### PR TITLE
fix(cli): 修复 claude-code 在 root 账户下启动失败

### DIFF
--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -314,6 +314,9 @@ const TMUX_PASSTHROUGH_VARS = [
   'LARK_APP_SECRET',
   '__OWNER_OPEN_ID',
   'SESSION_DATA_DIR',
+  // Claude Code 的 root/sudo 逃生舱：worker.ts 检测到 root 时会注入 IS_SANDBOX=1，
+  // tmux 不透传这个变量的话，--dangerously-skip-permissions 会被拦截立即退出。
+  'IS_SANDBOX',
 ];
 
 /** Minimal shell-escape for tmux session names (alphanumeric + dash). */

--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -5,9 +5,10 @@ import { resolveCommand } from './registry.js';
 import type { CliAdapter, PtyHandle } from './types.js';
 
 /** Resolve the JSONL transcript path Claude Code writes user/assistant turns to.
- *  Claude Code's project-hash scheme replaces both `/` and `.` with `-`. */
+ *  Claude Code's project-hash scheme replaces every non-[A-Za-z0-9-] char with `-`
+ *  (observed: `/foo/life_workspace` → `-foo-life-workspace`; `/`, `.`, `_` all become `-`). */
 export function claudeJsonlPathForSession(sessionId: string, cwd: string): string {
-  const projectHash = cwd.replace(/[/.]/g, '-');
+  const projectHash = cwd.replace(/[^A-Za-z0-9-]/g, '-');
   return join(homedir(), '.claude', 'projects', projectHash, `${sessionId}.jsonl`);
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -609,13 +609,30 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   const extra = (process.env.CLI_EXTRA_ARGS ?? '').trim();
   if (extra) args.push(...extra.split(/\s+/).filter(Boolean));
 
+  // Claude Code 在 root/sudo 下会拒绝 --dangerously-skip-permissions 并立即 exit。
+  // botmux 必须带这个 flag（话题里没法弹交互式审批），所以为 root 自动注入
+  // IS_SANDBOX=1 走 Claude Code 的受控环境逃生舱。用户显式设了就尊重不覆盖。
+  const claudeRootBypass =
+    cfg.cliId === 'claude-code' &&
+    process.getuid?.() === 0 &&
+    !process.env.IS_SANDBOX
+      ? { IS_SANDBOX: '1' }
+      : {};
+  if ((claudeRootBypass as { IS_SANDBOX?: string }).IS_SANDBOX) {
+    log('Detected root user — injecting IS_SANDBOX=1 for Claude Code');
+  }
+
   log(`Spawning: ${cliAdapter.resolvedBin} ${args.join(' ')} (cwd: ${cfg.workingDir})`);
 
   backend.spawn(cliAdapter.resolvedBin, args, {
     cwd: cfg.workingDir,
     cols: PTY_COLS,
     rows: PTY_ROWS,
-    env: { ...process.env, CLAUDECODE: undefined } as unknown as Record<string, string>,
+    env: {
+      ...process.env,
+      CLAUDECODE: undefined,
+      ...claudeRootBypass,
+    } as unknown as Record<string, string>,
   });
 
   // Write CLI PID marker so the MCP server can verify it was spawned by botmux.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -612,13 +612,11 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   // Claude Code 在 root/sudo 下会拒绝 --dangerously-skip-permissions 并立即 exit。
   // botmux 必须带这个 flag（话题里没法弹交互式审批），所以为 root 自动注入
   // IS_SANDBOX=1 走 Claude Code 的受控环境逃生舱。用户显式设了就尊重不覆盖。
-  const claudeRootBypass =
+  const injectClaudeSandbox =
     cfg.cliId === 'claude-code' &&
     process.getuid?.() === 0 &&
-    !process.env.IS_SANDBOX
-      ? { IS_SANDBOX: '1' }
-      : {};
-  if ((claudeRootBypass as { IS_SANDBOX?: string }).IS_SANDBOX) {
+    !process.env.IS_SANDBOX;
+  if (injectClaudeSandbox) {
     log('Detected root user — injecting IS_SANDBOX=1 for Claude Code');
   }
 
@@ -631,7 +629,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     env: {
       ...process.env,
       CLAUDECODE: undefined,
-      ...claudeRootBypass,
+      ...(injectClaudeSandbox ? { IS_SANDBOX: '1' } : {}),
     } as unknown as Record<string, string>,
   });
 


### PR DESCRIPTION
## 背景

Claude Code 在 root/sudo 下会拒绝 \`--dangerously-skip-permissions\` 并立即退出，而 botmux 在飞书话题里没法弹交互式审批，必须依赖这个 flag。docker / 服务器场景普遍以 root 跑，导致 claude-code 无法启动。

## 改动

- \`worker.ts\`：检测到 root 时为 claude-code 自动注入 \`IS_SANDBOX=1\`，走 Claude Code 的受控环境逃生舱；用户已显式设置则尊重不覆盖。
- \`tmux-backend.ts\`：把 \`IS_SANDBOX\` 加到 \`TMUX_PASSTHROUGH_VARS\`，否则 tmux backend 下变量被剥离，flag 仍然会被拦截。
- \`claude-code.ts\`：\`projectHash\` 正则从 \`/[/.]/g\` 改为 \`/[^A-Za-z0-9-]/g\`，匹配 Claude Code 实际行为（\`_\` 等字符也会被折叠成 \`-\`）。验证依据：\`/root/iserver/gcrm_overseas_monorepo\` 实际落在 \`~/.claude/projects/-root-iserver-gcrm-overseas-monorepo\`。

## 测试

- root 下启动 claude-code 不再立即退出
- 普通用户下行为不变（不注入 IS_SANDBOX）
- \`pnpm build\` 通过