### PR TITLE
fix(tmux): exit copy-mode before forwarding input

### DIFF
--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -227,6 +227,7 @@ export class TmuxBackend implements SessionBackend {
    * For multiline text, use pasteText() instead (send-keys -l sends \n as Enter).
    */
   sendText(text: string): void {
+    this.exitCopyModeIfNeeded();
     execFileSync('tmux', ['send-keys', '-t', this.cmdTarget, '-l', '--', text], {
       stdio: 'ignore',
       timeout: 5000,
@@ -236,6 +237,7 @@ export class TmuxBackend implements SessionBackend {
 
   /** Send special keys (Enter, Escape, C-c, etc.) to the tmux pane. */
   sendSpecialKeys(...keys: string[]): void {
+    this.exitCopyModeIfNeeded();
     execFileSync('tmux', ['send-keys', '-t', this.cmdTarget, ...keys], {
       stdio: 'ignore',
       timeout: 5000,
@@ -271,6 +273,7 @@ export class TmuxBackend implements SessionBackend {
    * Safe for multiline content (unlike sendText where \n becomes Enter).
    */
   pasteText(text: string): void {
+    this.exitCopyModeIfNeeded();
     execFileSync('tmux', ['load-buffer', '-'], {
       input: text,
       stdio: ['pipe', 'ignore', 'ignore'],
@@ -282,6 +285,27 @@ export class TmuxBackend implements SessionBackend {
       timeout: 5000,
       env: tmuxEnv(),
     });
+  }
+
+  private exitCopyModeIfNeeded(): void {
+    try {
+      const inMode = execFileSync('tmux', ['display-message', '-p', '-t', this.cmdTarget, '#{pane_in_mode}'], {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 1000,
+        env: tmuxEnv(),
+      }).trim();
+
+      if (inMode === '1') {
+        execFileSync('tmux', ['send-keys', '-t', this.cmdTarget, '-X', 'cancel'], {
+          stdio: 'ignore',
+          timeout: 1000,
+          env: tmuxEnv(),
+        });
+      }
+    } catch {
+      // Pane may be gone or tmux may be restarting; keep the original write path best-effort.
+    }
   }
 
   resize(cols: number, rows: number): void {

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -126,6 +126,7 @@ export class TmuxPipeBackend implements SessionBackend {
 
   sendText(text: string): void {
     if (this.exited) return;
+    this.exitCopyModeIfNeeded();
     execFileSync('tmux', ['send-keys', '-t', this.paneTarget, '-l', '--', text], {
       stdio: 'ignore',
       timeout: 5000,
@@ -135,6 +136,7 @@ export class TmuxPipeBackend implements SessionBackend {
 
   sendSpecialKeys(...keys: string[]): void {
     if (this.exited) return;
+    this.exitCopyModeIfNeeded();
     execFileSync('tmux', ['send-keys', '-t', this.paneTarget, ...keys], {
       stdio: 'ignore',
       timeout: 5000,
@@ -144,6 +146,7 @@ export class TmuxPipeBackend implements SessionBackend {
 
   pasteText(text: string): void {
     if (this.exited) return;
+    this.exitCopyModeIfNeeded();
     execFileSync('tmux', ['load-buffer', '-'], {
       input: text,
       stdio: ['pipe', 'ignore', 'ignore'],
@@ -155,6 +158,29 @@ export class TmuxPipeBackend implements SessionBackend {
       timeout: 5000,
       env: tmuxEnv(),
     });
+  }
+
+  private exitCopyModeIfNeeded(): void {
+    if (this.exited) return;
+
+    try {
+      const inMode = execFileSync('tmux', ['display-message', '-p', '-t', this.paneTarget, '#{pane_in_mode}'], {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 1000,
+        env: tmuxEnv(),
+      }).trim();
+
+      if (inMode === '1') {
+        execFileSync('tmux', ['send-keys', '-t', this.paneTarget, '-X', 'cancel'], {
+          stdio: 'ignore',
+          timeout: 1000,
+          env: tmuxEnv(),
+        });
+      }
+    } catch {
+      // Pane may be gone or tmux may be restarting; keep the original write path best-effort.
+    }
   }
 
   enterCopyMode(): void {

--- a/test/tmux-backend-input.test.ts
+++ b/test/tmux-backend-input.test.ts
@@ -37,11 +37,13 @@ function createBackend(sessionName = 'bmx-test1234'): TmuxBackend {
 }
 
 function getCalls(): Array<{ cmd: string; args: string[]; opts?: any }> {
-  return mockedExecFileSync.mock.calls.map((call: any[]) => ({
-    cmd: call[0] as string,
-    args: call[1] as string[],
-    opts: call[2],
-  }));
+  return mockedExecFileSync.mock.calls
+    .map((call: any[]) => ({
+      cmd: call[0] as string,
+      args: call[1] as string[],
+      opts: call[2],
+    }))
+    .filter(call => !call.args.includes('display-message'));
 }
 
 // ---------------------------------------------------------------------------

--- a/test/tmux-copy-mode.test.ts
+++ b/test/tmux-copy-mode.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Regression tests for tmux copy-mode swallowing botmux input.
+ *
+ * When a pane is in copy-mode, `tmux send-keys` is handled by tmux itself
+ * instead of the CLI running in the pane. The tmux backends must cancel
+ * copy-mode before forwarding chat input.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+  execFileSync: vi.fn(),
+  spawnSync: vi.fn(),
+}));
+
+vi.mock('node-pty', () => ({
+  spawn: vi.fn(),
+}));
+
+import { execFileSync } from 'node:child_process';
+import { TmuxBackend } from '../src/adapters/backend/tmux-backend.js';
+import { TmuxPipeBackend } from '../src/adapters/backend/tmux-pipe-backend.js';
+
+const mockedExecFileSync = vi.mocked(execFileSync);
+
+function mockPaneMode(mode: '0' | '1') {
+  mockedExecFileSync.mockImplementation((cmd: any, args: any[]) => {
+    if (cmd === 'tmux' && args.includes('display-message')) {
+      return `${mode}\n` as any;
+    }
+    return Buffer.from('') as any;
+  });
+}
+
+function tmuxCalls() {
+  return mockedExecFileSync.mock.calls.map(call => call[1] as string[]);
+}
+
+function isCopyModeProbe(args: string[]) {
+  return args.includes('display-message') && args.includes('#{pane_in_mode}');
+}
+
+function isCopyModeCancel(args: string[]) {
+  return args.includes('send-keys') && args.includes('-X') && args.includes('cancel');
+}
+
+beforeEach(() => {
+  mockedExecFileSync.mockReset();
+  mockPaneMode('0');
+});
+
+describe('TmuxBackend copy-mode guard', () => {
+  it('cancels copy-mode before sendText forwards input', () => {
+    mockPaneMode('1');
+    const be = new TmuxBackend('bmx-copy');
+
+    be.sendText('hello');
+
+    const calls = tmuxCalls();
+    expect(calls[0]).toEqual(['display-message', '-p', '-t', 'bmx-copy', '#{pane_in_mode}']);
+    expect(calls[1]).toEqual(['send-keys', '-t', 'bmx-copy', '-X', 'cancel']);
+    expect(calls[2]).toEqual(['send-keys', '-t', 'bmx-copy', '-l', '--', 'hello']);
+  });
+
+  it('does not cancel copy-mode when the pane is already in normal mode', () => {
+    const be = new TmuxBackend('bmx-normal');
+
+    be.sendSpecialKeys('Enter');
+
+    const calls = tmuxCalls();
+    expect(calls.some(isCopyModeProbe)).toBe(true);
+    expect(calls.some(isCopyModeCancel)).toBe(false);
+    expect(calls.at(-1)).toEqual(['send-keys', '-t', 'bmx-normal', 'Enter']);
+  });
+
+  it('still pastes input if the copy-mode probe fails', () => {
+    mockedExecFileSync.mockImplementation((cmd: any, args: any[]) => {
+      if (cmd === 'tmux' && args.includes('display-message')) {
+        throw new Error('tmux server unavailable');
+      }
+      return Buffer.from('') as any;
+    });
+    const be = new TmuxBackend('bmx-probe-error');
+
+    be.pasteText('multi\nline');
+
+    const calls = tmuxCalls();
+    expect(calls.some(args => args.includes('load-buffer'))).toBe(true);
+    expect(calls.some(args => args.includes('paste-buffer'))).toBe(true);
+  });
+});
+
+describe('TmuxPipeBackend copy-mode guard', () => {
+  it('cancels copy-mode before sendSpecialKeys forwards input', () => {
+    mockPaneMode('1');
+    const be = new TmuxPipeBackend('0:2.0');
+
+    be.sendSpecialKeys('Enter');
+
+    const calls = tmuxCalls();
+    expect(calls[0]).toEqual(['display-message', '-p', '-t', '0:2.0', '#{pane_in_mode}']);
+    expect(calls[1]).toEqual(['send-keys', '-t', '0:2.0', '-X', 'cancel']);
+    expect(calls[2]).toEqual(['send-keys', '-t', '0:2.0', 'Enter']);
+  });
+
+  it('does not cancel copy-mode when the adopted pane is already in normal mode', () => {
+    const be = new TmuxPipeBackend('1:3.0');
+
+    be.sendText('hello');
+
+    const calls = tmuxCalls();
+    expect(calls.some(isCopyModeProbe)).toBe(true);
+    expect(calls.some(isCopyModeCancel)).toBe(false);
+    expect(calls.at(-1)).toEqual(['send-keys', '-t', '1:3.0', '-l', '--', 'hello']);
+  });
+
+  it('still pastes input if the copy-mode probe fails', () => {
+    mockedExecFileSync.mockImplementation((cmd: any, args: any[]) => {
+      if (cmd === 'tmux' && args.includes('display-message')) {
+        throw new Error('tmux server unavailable');
+      }
+      return Buffer.from('') as any;
+    });
+    const be = new TmuxPipeBackend('2:1.0');
+
+    be.pasteText('multi\nline');
+
+    const calls = tmuxCalls();
+    expect(calls.some(args => args.includes('load-buffer'))).toBe(true);
+    expect(calls.some(args => args.includes('paste-buffer'))).toBe(true);
+  });
+});

--- a/test/tmux-pipe-backend.test.ts
+++ b/test/tmux-pipe-backend.test.ts
@@ -46,6 +46,11 @@ const mockedExecFileSync = vi.mocked(execFileSync);
 const mockedSpawnSync = vi.mocked(spawnSync);
 const mockedUnlinkSync = vi.mocked(unlinkSync);
 
+function getExecFileCalls() {
+  return mockedExecFileSync.mock.calls
+    .filter(call => !(call[1] as string[]).includes('display-message'));
+}
+
 function spawnOpts() {
   return {
     cwd: '/tmp',
@@ -90,7 +95,7 @@ describe('TmuxPipeBackend input addressing', () => {
     mockedExecFileSync.mockClear();
     be.sendText('飞书消息');
 
-    const call = mockedExecFileSync.mock.calls[0];
+    const call = getExecFileCalls()[0];
     expect(call[0]).toBe('tmux');
     const args = call[1] as string[];
     const tIdx = args.indexOf('-t');
@@ -105,7 +110,7 @@ describe('TmuxPipeBackend input addressing', () => {
     mockedExecFileSync.mockClear();
     be.sendSpecialKeys('Enter');
 
-    const args = mockedExecFileSync.mock.calls[0][1] as string[];
+    const args = getExecFileCalls()[0][1] as string[];
     const tIdx = args.indexOf('-t');
     expect(args[tIdx + 1]).toBe('1:0.2');
     expect(args).toContain('Enter');
@@ -117,7 +122,7 @@ describe('TmuxPipeBackend input addressing', () => {
     mockedExecFileSync.mockClear();
     be.pasteText('multi\nline');
 
-    const calls = mockedExecFileSync.mock.calls;
+    const calls = getExecFileCalls();
     expect(calls[0][1]).toContain('load-buffer');
     expect((calls[0][2] as any).input).toBe('multi\nline');
 
@@ -132,7 +137,7 @@ describe('TmuxPipeBackend input addressing', () => {
     be.spawn('', [], spawnOpts());
     mockedExecFileSync.mockClear();
     be.write('hi');
-    const args = mockedExecFileSync.mock.calls[0][1] as string[];
+    const args = getExecFileCalls()[0][1] as string[];
     expect(args).toContain('-l');  // literal mode
     expect(args).toContain('hi');
   });


### PR DESCRIPTION
issue：当用户在 Web 终端/显示输出/滚动输出后，可能会让 tmux 进入一种“我现在在看历史/选择文本/滚动”的模式，tmux pane 可能停留在 copy-mode。此时 botmux 后续通过 tmux send-keys 写入用户消息时，按键不会进入 Codex/Claude/Gemini 等真实 CLI 输入框，而是被 tmux copy-mode 处理掉。表现为飞书卡片显示“等待输入”，随后提示“发给 Codex 后没能确认提交”。

fix：在发送文本、特殊按键或粘贴缓冲区内容之前，先检查 pane_in_mode 状态，并在必要时退出复制模式。这一保护机制同时适用于受管理的 tmux 会话和被接管（adopted）的 tmux 面板。