### PR TITLE
fix(adopt): macOS 上 /adopt 也能扫到 CLI 会话

### DIFF
--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -6,12 +6,15 @@
  */
 import { execSync } from 'node:child_process';
 import { readFileSync, readlinkSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { homedir, platform } from 'node:os';
+import { basename, join } from 'node:path';
 import type { CliId } from '../adapters/cli/types.js';
 import { findCodexRolloutByPid } from '../services/codex-transcript.js';
 import { findCocoSessionByPid } from '../services/coco-transcript.js';
 import { tmuxEnv } from '../setup/ensure-tmux.js';
+
+// macOS 没有 /proc，所以走 ps/lsof/pgrep 兜底。Linux 仍优先走 /proc 快路径。
+const IS_LINUX = platform() === 'linux';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -46,39 +49,98 @@ function shellescape(s: string): string {
 }
 
 /**
- * Read the comm name for a PID from /proc.
- * Returns undefined if the process no longer exists.
+ * 读取进程的 comm 名（不含路径）。Linux 走 /proc/<pid>/comm 快路径；
+ * macOS / 其它 Unix 走 `ps -o comm=` 兜底。
+ *
+ * 注意 macOS 的 `ps -o comm=` 返回完整可执行路径（如 `/usr/local/bin/claude`），
+ * 所以这里统一做一次 basename，让上层匹配 CLI_COMM_MAP 的逻辑保持不变。
+ *
+ * 返回 undefined 表示进程不存在或读不到。
  */
 function readComm(pid: number): string | undefined {
+  if (IS_LINUX) {
+    try {
+      return readFileSync(`/proc/${pid}/comm`, 'utf-8').trim();
+    } catch {
+      // 落到下面的 ps 兜底
+    }
+  }
   try {
-    return readFileSync(`/proc/${pid}/comm`, 'utf-8').trim();
+    const out = execSync(`ps -o comm= -p ${pid}`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    if (!out) return undefined;
+    return out.includes('/') ? basename(out) : out;
   } catch {
     return undefined;
   }
 }
 
 /**
- * Read the cwd for a PID via /proc/<pid>/cwd symlink.
- * Returns undefined if unavailable.
+ * 读取进程的工作目录。Linux 走 /proc/<pid>/cwd 软链；
+ * macOS / 其它 Unix 走 `lsof -a -d cwd -p <pid> -Fn` 兜底。
+ *
+ * lsof -Fn 的输出格式：
+ *   p<pid>
+ *   fcwd
+ *   n<path>
+ * 这里只解析以 n 开头的那一行。
+ *
+ * 返回 undefined 表示读不到。
  */
 function readCwd(pid: number): string | undefined {
+  if (IS_LINUX) {
+    try {
+      return readlinkSync(`/proc/${pid}/cwd`);
+    } catch {
+      // 落到下面的 lsof 兜底
+    }
+  }
   try {
-    return readlinkSync(`/proc/${pid}/cwd`);
+    const out = execSync(`lsof -a -d cwd -p ${pid} -Fn`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    for (const line of out.split('\n')) {
+      if (line.startsWith('n')) return line.slice(1);
+    }
+    return undefined;
   } catch {
     return undefined;
   }
 }
 
-/** Get direct child PIDs of a process via `ps --ppid`. */
+/**
+ * 获取一个进程的直接子进程 PID。
+ *
+ * 既不能用 GNU `ps --ppid`（BSD ps 不支持长选项），也不能用 `pgrep -P`
+ * （macOS BSD pgrep 把 `-P` 当过滤器，要求**必须**搭配一个 pattern 位置参数，
+ * 不传 pattern 返回空）。
+ *
+ * 改成一次 `ps -A -o pid= -o ppid=` 把全表拿回来 JS 端过滤 —— 两个平台
+ * 的 ps 都接受这个写法。fork-exec 一次代价可接受，因为 discovery 本身是
+ * 低频操作（只在用户 /adopt 时跑一遍）。
+ */
 function getChildPids(pid: number): number[] {
   try {
-    const out = execSync(`ps --ppid ${pid} -o pid=`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
-    return out
-      .split('\n')
-      .map(s => s.trim())
-      .filter(Boolean)
-      .map(Number)
-      .filter(n => !isNaN(n));
+    const out = execSync('ps -A -o pid= -o ppid=', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const children: number[] = [];
+    for (const line of out.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const parts = trimmed.split(/\s+/);
+      if (parts.length < 2) continue;
+      const childPid = Number(parts[0]);
+      const parentPid = Number(parts[1]);
+      if (!isNaN(childPid) && !isNaN(parentPid) && parentPid === pid) {
+        children.push(childPid);
+      }
+    }
+    return children;
   } catch {
     return [];
   }
@@ -199,7 +261,7 @@ export function discoverAdoptableSessions(filterCliId?: CliId): AdoptableSession
     // 3b. Filter by CLI type if requested
     if (filterCliId && match.cliId !== filterCliId) continue;
 
-    // 4. Read CLI working directory from /proc
+    // 4. Read CLI working directory (Linux: /proc; macOS: lsof)
     const cwd = readCwd(match.pid);
     if (!cwd) continue;
 
@@ -270,3 +332,9 @@ export function validateAdoptTarget(tmuxTarget: string, expectedPid: number): bo
   const match = findCliProcess(panePid, 3);
   return match !== undefined && match.pid === expectedPid;
 }
+
+// 仅供单测使用 —— 暴露内部 helper，方便覆盖跨平台 (Linux /proc vs macOS ps/lsof/pgrep)
+// 的回归路径。生产代码不要直接消费这些导出。
+export const __testOnly_readComm = readComm;
+export const __testOnly_readCwd = readCwd;
+export const __testOnly_getChildPids = getChildPids;

--- a/test/session-discovery.smoke.test.ts
+++ b/test/session-discovery.smoke.test.ts
@@ -1,0 +1,90 @@
+/**
+ * 跨平台冒烟测试：`readComm` / `readCwd` / `getChildPids` 必须在 Linux 和
+ * macOS 上都能正确识别一个真实的子进程。
+ *
+ * 这里**不 mock**任何东西 —— 直接 spawn 一个 Node 子进程当 target，跑实际
+ * 命令验证返回值。和 session-discovery.test.ts 的 mock-based 单测互补：
+ * - mock-based 单测覆盖 discovery 的组合逻辑、tmux 输出解析、边界 case
+ * - smoke 测试切实抓平台命令兼容性（macOS BSD ps 不支持 GNU 长选项 `--ppid`
+ *   等历史回归，纯 mock 测不到）
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync, realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  __testOnly_readComm,
+  __testOnly_readCwd,
+  __testOnly_getChildPids,
+} from '../src/core/session-discovery.js';
+
+let child: ChildProcessWithoutNullStreams;
+let childCwd: string;
+
+beforeAll(async () => {
+  // macOS 的 tmpdir 通常是 /var/folders/.. 的软链，真实路径在 /private/var/...
+  // lsof 返回 resolve 后的路径，提前 realpath 一下让断言里两边形态一致。
+  childCwd = realpathSync(mkdtempSync(join(tmpdir(), 'bmx-sd-')));
+  // 用一个会保持运行 60s 的 Node 子进程当 target。stdout 输出 "ready" 后
+  // 才认为 cwd / pid 都已稳定。
+  child = spawn(
+    process.execPath,
+    ['-e', 'process.stdout.write("ready\\n"); setTimeout(() => {}, 60000);'],
+    { cwd: childCwd, stdio: ['ignore', 'pipe', 'pipe'] },
+  ) as ChildProcessWithoutNullStreams;
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('child not ready in 5s')), 5000);
+    child.stdout.once('data', (buf: Buffer) => {
+      if (buf.toString().includes('ready')) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    child.once('error', reject);
+  });
+});
+
+afterAll(() => {
+  if (child && !child.killed) child.kill('SIGKILL');
+  if (childCwd) rmSync(childCwd, { recursive: true, force: true });
+});
+
+describe('readComm', () => {
+  it('返回子进程的 comm 名 (basename, 不含路径)', () => {
+    const comm = __testOnly_readComm(child.pid!);
+    expect(comm).toBeDefined();
+    // Linux /proc/<pid>/comm 给短名 "node"；BSD ps 给完整路径，readComm
+    // 已统一 basename，所以这里都不应包含 "/"。
+    expect(comm).not.toContain('/');
+    expect(comm).toMatch(/^node/i);
+  });
+
+  it('对不存在的 PID 返回 undefined', () => {
+    // 取一个明显不存在的大 PID。ps / /proc 都读不到。
+    expect(__testOnly_readComm(2_000_000)).toBeUndefined();
+  });
+});
+
+describe('readCwd', () => {
+  it('返回子进程的工作目录', () => {
+    const cwd = __testOnly_readCwd(child.pid!);
+    expect(cwd).toBeDefined();
+    expect(cwd).toBe(childCwd);
+  });
+
+  it('对不存在的 PID 返回 undefined', () => {
+    expect(__testOnly_readCwd(2_000_000)).toBeUndefined();
+  });
+});
+
+describe('getChildPids', () => {
+  it('能在当前进程的子进程列表里找到 spawn 出来的 child', () => {
+    const children = __testOnly_getChildPids(process.pid);
+    expect(children).toContain(child.pid);
+  });
+
+  it('对不存在的 PID 返回空数组', () => {
+    expect(__testOnly_getChildPids(2_000_000)).toEqual([]);
+  });
+});

--- a/test/session-discovery.test.ts
+++ b/test/session-discovery.test.ts
@@ -23,6 +23,10 @@ vi.mock('node:fs', () => ({
 
 vi.mock('node:os', () => ({
   homedir: () => '/home/testuser',
+  // session-discovery 用 platform() 决定 Linux /proc 快路径 vs macOS ps/lsof 兜底。
+  // 既有 mock 数据全部按 Linux 形态准备，所以这里固定为 'linux'。
+  // macOS 兜底路径的覆盖见 test/session-discovery.smoke.test.ts。
+  platform: () => 'linux',
 }));
 
 import { execSync } from 'node:child_process';
@@ -87,15 +91,15 @@ function setupMocks(opts: {
       return paneLines;
     }
 
-    // ps --ppid
-    const psMatch = cmdStr.match(/ps --ppid (\d+)/);
-    if (psMatch) {
-      const ppid = Number(psMatch[1]);
-      const children = childMap[ppid];
-      if (!children || children.length === 0) {
-        throw new Error('no children');
+    // `ps -A -o pid= -o ppid=` —— 返回全表，由调用方过滤。我们这里把
+    // childMap 全展开成两列。
+    if (cmdStr.includes('ps -A -o pid= -o ppid=')) {
+      const rows: string[] = [];
+      for (const [ppidStr, kids] of Object.entries(childMap)) {
+        const ppid = Number(ppidStr);
+        for (const kid of kids) rows.push(`${kid} ${ppid}`);
       }
-      return children.map(p => `  ${p}`).join('\n') + '\n';
+      return rows.join('\n') + (rows.length ? '\n' : '');
     }
 
     // tmux display (pane dimensions)


### PR DESCRIPTION
## 问题

`/adopt` 在 macOS 上恒返回「未发现可接入的 CLI 会话」，即使本机确实有
一个在普通 tmux pane 里跑的 claude-code 进程。

根因：`src/core/session-discovery.ts` 三个 helper 全部只走 Linux `/proc`：

| 函数 | Linux 实现 | macOS 行为 |
|---|---|---|
| `readComm` | `readFileSync('/proc/<pid>/comm')` | `/proc` 不存在 → 抛 ENOENT 被吞 |
| `readCwd` | `readlinkSync('/proc/<pid>/cwd')` | 同上 |
| `getChildPids` | `ps --ppid <pid> -o pid=` | BSD ps 不支持 GNU 长选项 `--ppid` → 抛错被吞 |

三个 helper 全部静默返回 `undefined` / `[]`，`findCliProcess` 对每个
tmux pane 都返回 undefined，最终 `discoverAdoptableSessions` 返回空数组。

## 复现

macOS + tmux，一个普通 tmux pane 里跑 claude-code，然后在飞书话题里 `/adopt`：

```
未发现可接入的 CLI 会话
```

`tmux list-panes -a` 明明能看到那个 pane，pane 的子进程树里也确实有 claude。

## 修复方案

三个函数都改成 **Linux 走 /proc 快路径 + macOS 走 ps/lsof 兜底**：

```ts
const IS_LINUX = platform() === 'linux';

function readComm(pid) {
  if (IS_LINUX) {
    try { return readFileSync(`/proc/${pid}/comm`, 'utf-8').trim(); } catch {}
  }
  // macOS: `ps -o comm= -p <pid>` 返回完整路径，统一 basename
  const out = execSync(`ps -o comm= -p ${pid}`, ...).trim();
  return out.includes('/') ? basename(out) : out;
}

function readCwd(pid) {
  if (IS_LINUX) {
    try { return readlinkSync(`/proc/${pid}/cwd`); } catch {}
  }
  // macOS: lsof -Fn 输出 "p<pid>\nfcwd\nn<path>"，提取 n 行
  const out = execSync(`lsof -a -d cwd -p ${pid} -Fn`, ...);
  for (const line of out.split('\n')) {
    if (line.startsWith('n')) return line.slice(1);
  }
}

function getChildPids(pid) {
  // 一次 ps 全表 + JS 过滤。两个平台都支持。
  const out = execSync('ps -A -o pid= -o ppid=', ...);
  return out.split('\n')
    .map(s => s.trim().split(/\s+/))
    .filter(([_, ppid]) => Number(ppid) === pid)
    .map(([pid]) => Number(pid));
}
```

### 为什么不用 `pgrep -P`

最初想用 `pgrep -P <pid>` 替代 `ps --ppid`，因为它在 Linux procps-ng 上
和「列出 ppid 为 X 的所有子进程」语义一致。但是 macOS BSD pgrep 的 `-P`
是**过滤器**，必须搭配一个 pattern 位置参数：

```
$ pgrep -P 40617      # macOS：返回空，exit 1
$ pgrep -P 40617 .    # macOS：仍然只匹配 comm 含 "." 的子进程
```

所以最终改成一次 `ps -A` 拉全表 JS 过滤。fork-exec 一次，discovery 本身
是低频操作（仅 /adopt 时跑），代价可接受。

## 改动文件

```
src/core/session-discovery.ts | 102 ++++++++++++++++++++++++++++++++++-------
test/session-discovery.test.ts |  20 ++++----
test/session-discovery.smoke.test.ts (新增) | 90 +++++++++++++++++++++++++++++
```

## 测试

### 既有 mock-based 单测
更新 `test/session-discovery.test.ts` 让它继续过：
- `node:os` mock 加上 `platform: () => 'linux'`（既有 mock 数据全是 Linux 形态）
- `execSync` 的 ps 匹配从 `ps --ppid` 换成 `ps -A -o pid= -o ppid=`

### 新增 smoke 测试
纯 mock 测不到平台命令兼容性回归（比如 `pgrep -P` 在 macOS 上的坑就是
这样溜过去的）。新增 `test/session-discovery.smoke.test.ts` 不 mock 任何东西，
spawn 真子进程，在测试运行的平台上实测三个 helper：

```ts
beforeAll: spawn 一个 Node 子进程，等它 stdout 输出 "ready"
expect: readComm(child.pid) === "node"
expect: readCwd(child.pid) === childCwd
expect: getChildPids(process.pid).includes(child.pid)
```

跑 `pnpm vitest run test/session-discovery.{test,smoke.test}.ts`：

```
test/session-discovery.test.ts (21 tests | 1 failed)
test/session-discovery.smoke.test.ts (6 tests passed)

Test Files  1 failed | 1 passed (2)
     Tests  1 failed | 26 passed (27)
```

> **唯一 1 个 fail（`captures CoCo sessionId from a live session.log fd`）在
> 修改前的 master 上就已经失败**，与本 PR 无关。

### 端到端验证

在 macOS 14 (Darwin arm64) + Node 22.17，重新 build 后调用：

```js
import('./dist/core/session-discovery.js').then(({ discoverAdoptableSessions }) => {
  console.log(discoverAdoptableSessions('claude-code'));
});
```

成功扫到当前 tmux pane 的 claude 进程，返回的 sessionId 与
`~/.claude/projects/<cwd-hash>/<sid>.jsonl` 文件一致。`/adopt 6:0.0`
在飞书话题里也能正确接入这个 pane。

## 限制 / 未覆盖

- 仅修复 claude-code 的 adopt discovery 路径。**Codex/CoCo 仍依赖 `/proc/<pid>/fd`
  做 rollout/events 文件发现**（`services/codex-transcript.ts` /
  `coco-transcript.ts`），它们在 macOS 上仍走不通。Codex/CoCo 用户少，
  改起来牵涉 worker.ts 那边的 late-attach 轮询逻辑，留给后续 PR 单独跟进
- `readClaudeSessionMeta` 用的是 `~/.claude/sessions/<pid>.json`，这个文件
  Claude Code 在 macOS 上也会正常写，所以**没动**

## Checklist

- [x] `pnpm build` 通过
- [x] 既有单测全部通过（除 PR 前已 fail 的 CoCo case）
- [x] 新增 smoke 测试覆盖 Linux/macOS 双平台命令兼容性
- [x] 在 macOS 实机端到端验证 `/adopt` 流程
- [x] 不引入新依赖
