### PR TITLE
fix(scanner): worktree 归属错乱 + 显示名重复 + tag/SHA 回退

### DIFF
--- a/src/services/project-scanner.ts
+++ b/src/services/project-scanner.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import { readdirSync, statSync, existsSync } from 'node:fs';
-import { join, basename } from 'node:path';
+import { join, basename, resolve } from 'node:path';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -28,45 +28,126 @@ export interface ProjectInfo {
   branch: string;     // current branch name
 }
 
-function getGitBranch(dir: string): string {
+/** zsh-prompt-style ref resolution: branch → tag → short SHA → 'unknown'.
+ *  `git rev-parse --abbrev-ref HEAD` returns the literal string `HEAD`
+ *  when detached, which is the signal to fall through to tag/SHA lookup. */
+function getGitRef(dir: string): string {
   try {
-    return execSync('git rev-parse --abbrev-ref HEAD', { cwd: dir, timeout: 5000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+      cwd: dir, timeout: 5000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    if (branch && branch !== 'HEAD') return branch;
+  } catch { /* fall through */ }
+  try {
+    const tag = execSync('git describe --tags --exact-match HEAD', {
+      cwd: dir, timeout: 5000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    if (tag) return tag;
+  } catch { /* not at a tag */ }
+  try {
+    const sha = execSync('git rev-parse --short HEAD', {
+      cwd: dir, timeout: 5000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    if (sha) return sha;
+  } catch { /* fall through */ }
+  return 'unknown';
+}
+
+/** Tag-or-short-SHA for a detached HEAD. The SHA is supplied by the
+ *  caller (parsed from `git worktree list --porcelain`'s `HEAD` line) so
+ *  we only need one extra exec per detached worktree. */
+function describeDetachedHead(worktreePath: string, headSha: string): string {
+  try {
+    const tag = execSync('git describe --tags --exact-match HEAD', {
+      cwd: worktreePath, timeout: 5000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    if (tag) return tag;
+  } catch { /* not at a tag */ }
+  return headSha ? headSha.slice(0, 7) : 'unknown';
+}
+
+/** Absolute path of the repo's shared `.git` directory. Sibling worktrees
+ *  of the same repo always resolve to the same value — we use it as the
+ *  dedup key so the scanner doesn't double-register a repo when both its
+ *  main and a linked worktree sit in the scan root. */
+function getGitCommonDir(dir: string): string {
+  try {
+    const out = execSync('git rev-parse --git-common-dir', {
+      cwd: dir, timeout: 5000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return resolve(dir, out);
   } catch {
-    return 'unknown';
+    return dir;
   }
 }
 
-function getWorktrees(repoPath: string): ProjectInfo[] {
+/** Discover all worktrees of the repo that `anyWorktreePath` belongs to.
+ *  Index 0 is the main worktree (`type:'repo'`), the rest are linked
+ *  worktrees (`type:'worktree'`).
+ *
+ *  All entries share the main worktree's basename as their `name` — that
+ *  way the display is stable regardless of which sibling worktree the
+ *  scanner happens to discover first via readdir, and the linked
+ *  worktree's directory basename (often a random checkout name) doesn't
+ *  leak into the UI. Renderers distinguish entries via the `branch` field
+ *  and the `type:'worktree'` flag. */
+function scanRepoFromAnyWorktree(anyWorktreePath: string): ProjectInfo[] {
+  const fallback: ProjectInfo[] = [{
+    name: basename(anyWorktreePath),
+    path: anyWorktreePath,
+    type: 'repo',
+    branch: getGitRef(anyWorktreePath),
+  }];
+
+  let output: string;
   try {
-    const output = execSync('git worktree list --porcelain', { cwd: repoPath, timeout: 5000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
-    const worktrees: ProjectInfo[] = [];
-    let currentPath = '';
-    let currentBranch = '';
-
-    for (const line of output.split('\n')) {
-      if (line.startsWith('worktree ')) {
-        currentPath = line.slice('worktree '.length);
-      } else if (line.startsWith('branch ')) {
-        currentBranch = line.slice('branch '.length).replace('refs/heads/', '');
-      } else if (line === '') {
-        // End of a worktree entry — skip the main worktree (same as repoPath)
-        if (currentPath && currentPath !== repoPath) {
-          worktrees.push({
-            name: `${basename(repoPath)}/${basename(currentPath)}`,
-            path: currentPath,
-            type: 'worktree',
-            branch: currentBranch || 'unknown',
-          });
-        }
-        currentPath = '';
-        currentBranch = '';
-      }
-    }
-
-    return worktrees;
+    output = execSync('git worktree list --porcelain', {
+      cwd: anyWorktreePath, timeout: 5000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'],
+    });
   } catch {
-    return [];
+    return fallback;
   }
+
+  const entries: { path: string; branch: string }[] = [];
+  let currentPath = '';
+  let currentHead = '';
+  let currentBranch = '';
+  for (const line of output.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      currentPath = line.slice('worktree '.length);
+    } else if (line.startsWith('HEAD ')) {
+      currentHead = line.slice('HEAD '.length);
+    } else if (line.startsWith('branch ')) {
+      currentBranch = line.slice('branch '.length).replace('refs/heads/', '');
+    } else if (line === '') {
+      if (currentPath) {
+        // Branch attached → use it. Otherwise (detached / bare) fall back
+        // to tag → short SHA, mirroring zsh git prompts.
+        const ref = currentBranch
+          || (currentHead ? describeDetachedHead(currentPath, currentHead) : 'unknown');
+        entries.push({ path: currentPath, branch: ref });
+      }
+      currentPath = '';
+      currentHead = '';
+      currentBranch = '';
+    }
+  }
+  if (entries.length === 0) return fallback;
+
+  const main = entries[0]!;
+  const repoName = basename(main.path);
+  const result: ProjectInfo[] = [
+    { name: repoName, path: main.path, type: 'repo', branch: main.branch },
+  ];
+  for (const wt of entries.slice(1)) {
+    result.push({
+      name: repoName,
+      path: wt.path,
+      type: 'worktree',
+      branch: wt.branch,
+    });
+  }
+  return result;
 }
 
 /**
@@ -75,7 +156,8 @@ function getWorktrees(repoPath: string): ProjectInfo[] {
  */
 export function scanProjects(baseDir: string, maxDepth: number = 3): ProjectInfo[] {
   const projects: ProjectInfo[] = [];
-  const seen = new Set<string>();
+  const seenRepos = new Set<string>();   // by git-common-dir, dedups sibling worktrees on disk
+  const seenPaths = new Set<string>();   // by absolute path
 
   function walk(dir: string, depth: number): void {
     if (depth > maxDepth) return;
@@ -91,22 +173,14 @@ export function scanProjects(baseDir: string, maxDepth: number = 3): ProjectInfo
     // an empty `.git/` (no HEAD inside) is rejected so the scanner keeps
     // recursing into the directory and finds the real repos below.
     if (entries.includes('.git') && isValidGitMarker(dir)) {
-      const realPath = dir;
-      if (!seen.has(realPath)) {
-        seen.add(realPath);
-        projects.push({
-          name: basename(realPath),
-          path: realPath,
-          type: 'repo',
-          branch: getGitBranch(realPath),
-        });
+      const commonDir = getGitCommonDir(dir);
+      if (seenRepos.has(commonDir)) return;
+      seenRepos.add(commonDir);
 
-        // Also scan for worktrees
-        for (const wt of getWorktrees(realPath)) {
-          if (!seen.has(wt.path)) {
-            seen.add(wt.path);
-            projects.push(wt);
-          }
+      for (const p of scanRepoFromAnyWorktree(dir)) {
+        if (!seenPaths.has(p.path)) {
+          seenPaths.add(p.path);
+          projects.push(p);
         }
       }
       return; // Don't recurse into git repos
@@ -131,7 +205,9 @@ export function scanProjects(baseDir: string, maxDepth: number = 3): ProjectInfo
   // Sort: repos first, then worktrees, alphabetically within each group
   projects.sort((a, b) => {
     if (a.type !== b.type) return a.type === 'repo' ? -1 : 1;
-    return a.name.localeCompare(b.name);
+    const byName = a.name.localeCompare(b.name);
+    if (byName !== 0) return byName;
+    return a.branch.localeCompare(b.branch);
   });
 
   logger.info(`Scanned ${baseDir}: found ${projects.length} project(s)`);
@@ -157,7 +233,9 @@ export function scanMultipleProjects(baseDirs: string[], maxDepth: number = 3): 
   // Sort: repos first, then worktrees, alphabetically within each group
   merged.sort((a, b) => {
     if (a.type !== b.type) return a.type === 'repo' ? -1 : 1;
-    return a.name.localeCompare(b.name);
+    const byName = a.name.localeCompare(b.name);
+    if (byName !== 0) return byName;
+    return a.branch.localeCompare(b.branch);
   });
 
   return merged;

--- a/test/project-scanner.test.ts
+++ b/test/project-scanner.test.ts
@@ -395,7 +395,11 @@ describe('scanProjects', () => {
     expect(repo.path).toBe(repoPath);
 
     const wt = results.find(r => r.type === 'worktree')!;
-    expect(wt.name).toBe('my-repo/my-repo-worktree-abc');
+    // The linked worktree's name is the MAIN worktree's basename — not its
+    // own directory basename (see issue #7). Renderers append `(branch)`
+    // and a `[worktree]` tag themselves, so the scanner only needs to keep
+    // `name` and `branch` separate.
+    expect(wt.name).toBe('my-repo');
     expect(wt.path).toBe(worktreePath);
     expect(wt.branch).toBe('feature-branch');
   });
@@ -419,6 +423,181 @@ describe('scanProjects', () => {
 
     expect(results).toHaveLength(1);
     expect(results[0]!.type).toBe('repo');
+  });
+
+  // ─── Main vs linked worktree attribution (issue #7) ─────────────────────
+
+  it('should attribute the repo to the main worktree even when a linked worktree is discovered first by readdir', () => {
+    // Reproduces issue #7: two sibling worktrees of the same underlying repo
+    // sit side-by-side in the scan root. Alphabetically the LINKED worktree
+    // ("aaa-feature", `.git` is a gitlink file) comes before the MAIN
+    // worktree ("zzz-main", `.git` is a real directory). The scanner walked
+    // into the linked one first and registered it as `type:'repo'`, then
+    // listed the main worktree under it with name `aaa-feature/zzz-main`.
+    // After the fix: the main worktree must be the `repo`, the linked one
+    // the `worktree`, regardless of readdir order.
+    const linkedPath = mkWorktreeGitlink('aaa-feature', '/some/.git/worktrees/aaa-feature');
+    const mainPath = mkRepo('zzz-main');
+
+    mockedExecSync.mockImplementation((cmd: string, opts?: any) => {
+      const cmdStr = String(cmd);
+      if (cmdStr.includes('rev-parse --git-common-dir')) {
+        // Both worktrees share the same common-dir — the main's .git/.
+        return `${mainPath}/.git\n`;
+      }
+      if (cmdStr.includes('rev-parse --abbrev-ref HEAD')) {
+        if (opts?.cwd === linkedPath) return 'feature/aaa\n';
+        return 'main\n';
+      }
+      if (cmdStr.includes('worktree list --porcelain')) {
+        // git convention: main worktree is always the first entry.
+        return [
+          `worktree ${mainPath}`,
+          'branch refs/heads/main',
+          '',
+          `worktree ${linkedPath}`,
+          'branch refs/heads/feature/aaa',
+          '',
+        ].join('\n');
+      }
+      return '';
+    });
+
+    const results = scanProjects(tempRoot);
+
+    // Exactly 2 entries: one repo + one worktree, no duplicates.
+    expect(results).toHaveLength(2);
+    expect(results.filter(r => r.type === 'repo')).toHaveLength(1);
+    expect(results.filter(r => r.type === 'worktree')).toHaveLength(1);
+
+    const repo = results.find(r => r.type === 'repo')!;
+    expect(repo.name).toBe('zzz-main');           // NOT 'aaa-feature'
+    expect(repo.path).toBe(mainPath);
+    expect(repo.branch).toBe('main');
+
+    const wt = results.find(r => r.type === 'worktree')!;
+    expect(wt.path).toBe(linkedPath);
+    expect(wt.branch).toBe('feature/aaa');
+    // Linked worktree's name is the MAIN worktree's basename — branch is
+    // surfaced via the `branch` field, not baked into `name` (renderers
+    // append it themselves).
+    expect(wt.name).toBe('zzz-main');
+  });
+
+  it('should NOT leak the linked-worktree directory basename into the display name', () => {
+    // Worktree directory basenames are often unrelated to branch names
+    // (random checkout dirs, timestamps, etc.). The scanner must use the
+    // MAIN worktree's basename — never the linked dir's — so the display
+    // is stable and meaningful.
+    const mainPath = mkRepo('repo');
+    const garbageBasename = 'tmp-checkout-7zKx';
+    const linkedPath = mkWorktreeGitlink(garbageBasename, '/some/.git/worktrees/x');
+
+    mockedExecSync.mockImplementation((cmd: string, opts?: any) => {
+      const cmdStr = String(cmd);
+      if (cmdStr.includes('rev-parse --git-common-dir')) {
+        return `${mainPath}/.git\n`;
+      }
+      if (cmdStr.includes('rev-parse --abbrev-ref HEAD')) {
+        if (opts?.cwd === linkedPath) return 'release/2026.05\n';
+        return 'main\n';
+      }
+      if (cmdStr.includes('worktree list --porcelain')) {
+        return [
+          `worktree ${mainPath}`,
+          'branch refs/heads/main',
+          '',
+          `worktree ${linkedPath}`,
+          'branch refs/heads/release/2026.05',
+          '',
+        ].join('\n');
+      }
+      return '';
+    });
+
+    const results = scanProjects(tempRoot);
+    const wt = results.find(r => r.type === 'worktree')!;
+
+    expect(wt.name).toBe('repo');
+    expect(wt.name).not.toContain(garbageBasename);
+    // Branch still available via the dedicated field for renderers.
+    expect(wt.branch).toBe('release/2026.05');
+  });
+
+  // ─── Detached HEAD: tag / short-sha fallback ─────────────────────────────
+
+  it('should report the tag name when a worktree has detached HEAD pointing at a tag', () => {
+    // zsh-style ref resolution: branch → tag → short sha. When `git
+    // worktree list --porcelain` emits `detached` (instead of `branch
+    // refs/heads/...`), look up the tag via `git describe --tags
+    // --exact-match HEAD` from inside that worktree.
+    const mainPath = mkRepo('repo');
+    const detachedPath = mkWorktreeGitlink('checkout-v1', '/some/.git/worktrees/x');
+
+    mockedExecSync.mockImplementation((cmd: string, opts?: any) => {
+      const cmdStr = String(cmd);
+      if (cmdStr.includes('rev-parse --git-common-dir')) {
+        return `${mainPath}/.git\n`;
+      }
+      if (cmdStr.includes('worktree list --porcelain')) {
+        return [
+          `worktree ${mainPath}`,
+          'HEAD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          'branch refs/heads/main',
+          '',
+          `worktree ${detachedPath}`,
+          'HEAD bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          'detached',
+          '',
+        ].join('\n');
+      }
+      if (cmdStr.includes('describe --tags --exact-match HEAD')) {
+        if (opts?.cwd === detachedPath) return 'v1.2.3\n';
+      }
+      return '';
+    });
+
+    const results = scanProjects(tempRoot);
+    const wt = results.find(r => r.type === 'worktree')!;
+
+    expect(wt.path).toBe(detachedPath);
+    expect(wt.branch).toBe('v1.2.3');
+  });
+
+  it('should fall back to the short SHA when a worktree has detached HEAD not pointing at any tag', () => {
+    const mainPath = mkRepo('repo');
+    const detachedPath = mkWorktreeGitlink('checkout-loose', '/some/.git/worktrees/y');
+
+    mockedExecSync.mockImplementation((cmd: string, opts?: any) => {
+      const cmdStr = String(cmd);
+      if (cmdStr.includes('rev-parse --git-common-dir')) {
+        return `${mainPath}/.git\n`;
+      }
+      if (cmdStr.includes('worktree list --porcelain')) {
+        return [
+          `worktree ${mainPath}`,
+          'HEAD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          'branch refs/heads/main',
+          '',
+          `worktree ${detachedPath}`,
+          'HEAD c0ffee1234567890abcdef0000000000deadbeef',
+          'detached',
+          '',
+        ].join('\n');
+      }
+      if (cmdStr.includes('describe --tags --exact-match HEAD')) {
+        // Not at any tag — git exits non-zero.
+        throw new Error('fatal: no tag exactly matches HEAD');
+      }
+      return '';
+    });
+
+    const results = scanProjects(tempRoot);
+    const wt = results.find(r => r.type === 'worktree')!;
+
+    expect(wt.path).toBe(detachedPath);
+    // First 7 chars of the HEAD SHA from the porcelain output.
+    expect(wt.branch).toBe('c0ffee1');
   });
 
   // ─── Deduplication ──────────────────────────────────────────────────────


### PR DESCRIPTION
## TL;DR

| | Before | After |
| --- | --- | --- |
| **同一仓库的 7 个 worktree(`flow-web-monorepo` + 6 个 linked)** | `doc-history-comment-popover (fix/doc-history-comment-popover)`<br>`doc-history-comment-popover/flow-web-monorepo (release/samantha) [worktree]`<br>`doc-history-comment-popover/docx-selection (feat/docx-share-0512) [worktree]`<br>… | `flow-web-monorepo (release/samantha)`<br>`flow-web-monorepo (fix/doc-history-comment-popover) [worktree]`<br>`flow-web-monorepo (feat/docx-share-0512) [worktree]`<br>… |
| **第一次修复后分支显示重复(中间态)** | `15. flow-web-monorepo (flow-agent) (flow-agent) [worktree]` | `15. flow-web-monorepo (flow-agent) [worktree]` |
| **worktree detached 到 tag 上** | `(unknown) [worktree]` | `(v1.2.3) [worktree]` |
| **worktree detached 到 commit 上** | `(unknown) [worktree]` | `(c0ffee1) [worktree]` |

## 问题

`src/services/project-scanner.ts` 有三个独立但相关的问题:

### 1. worktree 归属错乱(主修 / Closes #7)

`readdirSync` 按字典序遍历,先撞到的 `.git` 标记被注册为主仓库,然后跑 `git worktree list --porcelain` 把所有兄弟 worktree 挂在它名下。**主 worktree 反被当作 linked worktree**。

`isValidGitMarker` 对"`.git` 是文件(linked 的 gitlink)"和"`.git` 是目录(真主 worktree)"一视同仁,readdir 先撞到谁谁就当 repo,显示前缀完全不稳定。

### 2. 显示名重复

第一次修复时把 branch 直接 bake 进 `ProjectInfo.name`(`flow-web-monorepo (flow-agent)`),但 `card-builder.ts:343` 又拼了 `(${p.branch})`,导致显示成 `flow-web-monorepo (flow-agent) (flow-agent) [worktree]`。

### 3. detached HEAD 显示 `unknown`

porcelain 输出 detached 状态时只有 `HEAD <sha>` + `detached` 两行,旧代码只识别 `branch refs/heads/...`,detached 一律显示 `unknown` —— 没有信息量。

## 修复

### 用 `git rev-parse --git-common-dir` 做 repo 身份去重

同一仓库的所有 worktree(主 + linked)共享同一个 `common-dir`。扫描过程中遇到任何 `.git` 标记,先解析 common-dir → 在 `seenRepos` 里查重,**已处理过的兄弟 worktree 直接 skip**。这一下把 readdir 顺序的影响彻底切断。

### `git worktree list --porcelain` 的第一条永远是主 worktree

git 约定。直接拿它的 basename 当 repo 名,主 worktree 注册成 `type:'repo'`,其余 `type:'worktree'`。

### `ProjectInfo.name` 只放 repo basename

branch 单独走 `branch` 字段,渲染层(card-builder / command-handler / card-handler)已经在拼 `(branch)`,职责分清。

### detached HEAD 按 zsh 提示符顺序回退

```
branch (refs/heads/...)
  → tag (git describe --tags --exact-match HEAD)
    → 短 SHA (porcelain 的 HEAD 行,截前 7 位)
      → 'unknown'
```

`git describe --tags --exact-match` 只对真正 detached 的 worktree 调一次,attached 零额外开销。

## Test plan

- [x] **4 个新用例**:
  - `should attribute the repo to the main worktree even when a linked worktree is discovered first by readdir`
  - `should NOT leak the linked-worktree directory basename into the display name`
  - `should report the tag name when a worktree has detached HEAD pointing at a tag`
  - `should fall back to the short SHA when a worktree has detached HEAD not pointing at any tag`
- [x] scanner + 下游(`card-builder` / `command-handler`)**173/173 通过**
- [x] `tsc --noEmit` 通过
- [x] 真实目录(`/Users/bytedance/byte`,7 个 worktree)手工回测,飞书卡片显示符合预期
- [x] Codex review 通过

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)