### PR TITLE
fix(backend): 修复 tmux pipe 后端生命周期

### DIFF
--- a/src/adapters/backend/session-backend-selector.ts
+++ b/src/adapters/backend/session-backend-selector.ts
@@ -1,0 +1,35 @@
+import { PtyBackend } from './pty-backend.js';
+import { TmuxBackend } from './tmux-backend.js';
+import { TmuxPipeBackend } from './tmux-pipe-backend.js';
+import type { SessionBackend } from './types.js';
+
+export interface SelectedSessionBackend {
+  backend: SessionBackend;
+  isTmuxMode: boolean;
+  isPipeMode: boolean;
+}
+
+export function selectSessionBackend(opts: { sessionId: string; useTmux: boolean }): SelectedSessionBackend {
+  if (!opts.useTmux) {
+    return {
+      backend: new PtyBackend(),
+      isTmuxMode: false,
+      isPipeMode: false,
+    };
+  }
+
+  const sessionName = TmuxBackend.sessionName(opts.sessionId);
+  if (TmuxBackend.hasSession(sessionName)) {
+    return {
+      backend: new TmuxPipeBackend(sessionName, { ownsSession: true, isReattach: true }),
+      isTmuxMode: true,
+      isPipeMode: true,
+    };
+  }
+
+  return {
+    backend: new TmuxPipeBackend(sessionName, { createSession: true, ownsSession: true }),
+    isTmuxMode: true,
+    isPipeMode: true,
+  };
+}

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -59,13 +59,30 @@ export class TmuxPipeBackend implements SessionBackend {
   private pipeAttached = false;
   private readonly createSession: boolean;
   private readonly ownsSession: boolean;
-  private readonly isReattach: boolean;
+  private readonly _isReattach: boolean;
+
+  /** Claude Code session JSONL path — set by worker for claude-code sessions so
+   *  the claude-code adapter can verify paste+Enter submissions via file growth. */
+  claudeJsonlPath?: string;
+  /** PID of the spawned Claude Code child — used by the claude-code adapter to
+   *  follow Claude's authoritative session id via ~/.claude/sessions/<pid>.json. */
+  cliPid?: number;
+  /** Working directory the CLI was spawned in — cross-checked against the pid
+   *  file's cwd field so a recycled PID can't mislead the resolver. */
+  cliCwd?: string;
+
+  /** Whether this backend re-attached to an existing bmx-* tmux session
+   *  (rather than creating a new detached one). Mirrors TmuxBackend.isReattach
+   *  so the worker can branch on reattach behaviour without a private-cast. */
+  get isReattach(): boolean {
+    return this._isReattach;
+  }
 
   constructor(paneTarget: string, opts?: { createSession?: boolean; ownsSession?: boolean; isReattach?: boolean }) {
     this.paneTarget = paneTarget;
     this.createSession = opts?.createSession ?? false;
     this.ownsSession = opts?.ownsSession ?? false;
-    this.isReattach = opts?.isReattach ?? false;
+    this._isReattach = opts?.isReattach ?? false;
     // Per-instance fifo so concurrent adopt sessions don't collide.
     this.fifoPath = join(tmpdir(), `botmux-pipe-${randomBytes(8).toString('hex')}.fifo`);
   }
@@ -80,6 +97,11 @@ export class TmuxPipeBackend implements SessionBackend {
 
     if (this.createSession) {
       this.createDetachedSession(bin, args, opts);
+    } else if (this.ownsSession && this._isReattach) {
+      // Backfill tmux options on an existing bmx-* session — daemon may have
+      // been upgraded since the session was originally created, and options
+      // like set-clipboard / window-size largest are idempotent to re-apply.
+      this.applySessionOptions();
     }
 
     // Step 1: create the fifo. mkfifo is POSIX; linux/darwin both have it.

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -30,6 +30,7 @@ import { join } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import type { SessionBackend, SpawnOpts } from './types.js';
 import { tmuxEnv } from '../../setup/ensure-tmux.js';
+import { buildBotmuxEnvAssignments, resolveUserShell, SHELL_WRAPPER_SCRIPT, TmuxBackend } from './tmux-backend.js';
 
 function shellescape(s: string): string {
   // Single-quote-escape, replacing internal ' with '\''
@@ -44,32 +45,42 @@ export function normaliseCaptureLineEndings(s: string): string {
 }
 
 export class TmuxPipeBackend implements SessionBackend {
-  /** Real tmux pane address (e.g. "0:2.0"). */
+  /** Real tmux pane address (e.g. "0:2.0") or botmux session name (bmx-*). */
   private readonly paneTarget: string;
   private readonly fifoPath: string;
   private readStream: fs.ReadStream | null = null;
   private readonly dataCbs: Array<(d: string) => void> = [];
   private readonly exitCbs: Array<(code: number | null, signal: string | null) => void> = [];
+  private lifecycleTimer: NodeJS.Timeout | null = null;
   private cols = 200;
   private rows = 50;
   private exited = false;
   /** Set after pipe-pane subscription is active so kill() knows to cancel it. */
   private pipeAttached = false;
+  private readonly createSession: boolean;
+  private readonly ownsSession: boolean;
+  private readonly isReattach: boolean;
 
-  constructor(paneTarget: string) {
+  constructor(paneTarget: string, opts?: { createSession?: boolean; ownsSession?: boolean; isReattach?: boolean }) {
     this.paneTarget = paneTarget;
+    this.createSession = opts?.createSession ?? false;
+    this.ownsSession = opts?.ownsSession ?? false;
+    this.isReattach = opts?.isReattach ?? false;
     // Per-instance fifo so concurrent adopt sessions don't collide.
     this.fifoPath = join(tmpdir(), `botmux-pipe-${randomBytes(8).toString('hex')}.fifo`);
   }
 
   // ─── SessionBackend implementation ────────────────────────────────────────
 
-  /** spawn() in this backend doesn't actually spawn a process; it sets up
-   *  the pipe-pane subscription + fifo reader. The bin/args params are
-   *  ignored (the CLI is already running in the user's pane). */
-  spawn(_bin: string, _args: string[], opts: SpawnOpts): void {
+  /** spawn() sets up the pipe-pane subscription + fifo reader. In managed
+   *  mode it first creates a detached bmx-* tmux session that runs the CLI. */
+  spawn(bin: string, args: string[], opts: SpawnOpts): void {
     this.cols = opts.cols;
     this.rows = opts.rows;
+
+    if (this.createSession) {
+      this.createDetachedSession(bin, args, opts);
+    }
 
     // Step 1: create the fifo. mkfifo is POSIX; linux/darwin both have it.
     spawnSync('mkfifo', [this.fifoPath], { stdio: 'ignore' });
@@ -113,6 +124,7 @@ export class TmuxPipeBackend implements SessionBackend {
         { stdio: 'ignore', timeout: 5000, env: tmuxEnv() },
       );
       this.pipeAttached = true;
+      this.startLifecycleWatcher();
     } catch (err: any) {
       this.fireExit(1, null);
       throw err;
@@ -202,11 +214,15 @@ export class TmuxPipeBackend implements SessionBackend {
   }
 
   resize(cols: number, rows: number): void {
-    // Don't resize the user's tmux pane on every web client resize — that
-    // would visibly snap the user's own client around. We just remember the
-    // requested size for getAttachInfo / capture sizing.
     this.cols = cols;
     this.rows = rows;
+    if (this.ownsSession) {
+      execFileSync('tmux', ['resize-window', '-t', this.paneTarget, '-x', String(cols), '-y', String(rows)], {
+        stdio: 'ignore',
+        timeout: 5000,
+        env: tmuxEnv(),
+      });
+    }
   }
 
   onData(cb: (data: string) => void): void {
@@ -220,6 +236,7 @@ export class TmuxPipeBackend implements SessionBackend {
   kill(): void {
     if (this.exited) return;
     this.exited = true;
+    this.stopLifecycleWatcher();
     // Cancel tmux's pipe subscription. Calling pipe-pane without a command
     // turns it off for the target pane.
     if (this.pipeAttached) {
@@ -233,12 +250,13 @@ export class TmuxPipeBackend implements SessionBackend {
       this.readStream = null;
     }
     try { fs.unlinkSync(this.fifoPath); } catch { /* already gone */ }
-    this.fireExit(0, null);
   }
 
   destroySession(): void {
-    // Adopt mode never owns the source session — kill() is enough.
     this.kill();
+    if (this.ownsSession) {
+      TmuxBackend.killSession(this.paneTarget);
+    }
   }
 
   getChildPid(): number | null {
@@ -264,6 +282,76 @@ export class TmuxPipeBackend implements SessionBackend {
   }
 
   // ─── Pipe-specific helpers ────────────────────────────────────────────────
+
+  private startLifecycleWatcher(): void {
+    this.stopLifecycleWatcher();
+    this.lifecycleTimer = setInterval(() => {
+      if (this.exited) return;
+      try {
+        const paneId = execSync(
+          `tmux display-message -p -t ${shellescape(this.paneTarget)} '#{pane_id}'`,
+          { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 2000, env: tmuxEnv() },
+        ).trim();
+        if (!paneId) this.handlePaneExit();
+      } catch {
+        this.handlePaneExit();
+      }
+    }, 1000);
+  }
+
+  private stopLifecycleWatcher(): void {
+    if (this.lifecycleTimer) {
+      clearInterval(this.lifecycleTimer);
+      this.lifecycleTimer = null;
+    }
+  }
+
+  private handlePaneExit(): void {
+    if (this.exited) return;
+    this.exited = true;
+    this.stopLifecycleWatcher();
+    if (this.readStream) {
+      try { this.readStream.destroy(); } catch { /* already closed */ }
+      this.readStream = null;
+    }
+    try { fs.unlinkSync(this.fifoPath); } catch { /* already gone */ }
+    this.fireExit(1, null);
+  }
+
+  private createDetachedSession(bin: string, args: string[], opts: SpawnOpts): void {
+    const shellSpec = resolveUserShell();
+    const envAssignments = buildBotmuxEnvAssignments(opts.env);
+    execFileSync('tmux', [
+      'new-session',
+      '-d',
+      '-s', this.paneTarget,
+      '-x', String(opts.cols),
+      '-y', String(opts.rows),
+      '--',
+      shellSpec.shell, ...shellSpec.flags, '-c', SHELL_WRAPPER_SCRIPT, '_',
+      opts.cwd,
+      ...envAssignments,
+      bin, ...args,
+    ], {
+      cwd: opts.cwd,
+      stdio: 'ignore',
+      timeout: 5000,
+      env: tmuxEnv(opts.env),
+    });
+    this.applySessionOptions();
+  }
+
+  private applySessionOptions(): void {
+    const t = shellescape(this.paneTarget);
+    const env = tmuxEnv();
+    try {
+      execSync(`tmux set-option -t ${t} status off`, { stdio: 'ignore', env });
+      execSync(`tmux set-option -t ${t} mouse on`, { stdio: 'ignore', env });
+      execSync(`tmux set-option -s set-clipboard on`, { stdio: 'ignore', env });
+      execSync(`tmux set-option -t ${t} history-limit 50000`, { stdio: 'ignore', env });
+      execSync(`tmux set-option -t ${t} window-size largest`, { stdio: 'ignore', env });
+    } catch { /* session may not be ready yet — benign */ }
+  }
 
   /** Snapshot the current screen of the adopted pane WITH ANSI escapes,
    *  including history (-S - = start of scrollback). New web-terminal

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2450,7 +2450,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     send({ type: 'claude_exit', code, signal });
   });
 
-  if (isPipeMode && backend instanceof TmuxPipeBackend && (backend as any).isReattach) {
+  if (isPipeMode && backend instanceof TmuxPipeBackend && backend.isReattach) {
     log(`Re-attached to existing tmux session via pipe-pane: ${TmuxBackend.sessionName(cfg.sessionId)}`);
     try {
       const initial = backend.captureCurrentScreen();

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -50,6 +50,7 @@ import type { CliAdapter, PtyHandle } from './adapters/cli/types.js';
 import { PtyBackend } from './adapters/backend/pty-backend.js';
 import { TmuxBackend } from './adapters/backend/tmux-backend.js';
 import { TmuxPipeBackend } from './adapters/backend/tmux-pipe-backend.js';
+import { selectSessionBackend } from './adapters/backend/session-backend-selector.js';
 import type { SessionBackend } from './adapters/backend/types.js';
 import { tmuxEnv } from './setup/ensure-tmux.js';
 import { IdleDetector } from './utils/idle-detector.js';
@@ -2300,9 +2301,10 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     log('tmux backend requested but functional probe failed — falling back to PTY backend');
     useTmux = false;
   }
-  isTmuxMode = useTmux;
-  const tmuxBe = useTmux ? new TmuxBackend(TmuxBackend.sessionName(cfg.sessionId)) : null;
-  backend = tmuxBe ?? new PtyBackend();
+  const selectedBackend = selectSessionBackend({ sessionId: cfg.sessionId, useTmux });
+  isTmuxMode = selectedBackend.isTmuxMode;
+  isPipeMode = selectedBackend.isPipeMode;
+  backend = selectedBackend.backend;
 
   // Claude Code appends a line to ~/.claude/projects/<cwd-hash>/<sid>.jsonl each
   // time the user submits. The adapter uses this file to verify paste+Enter
@@ -2383,10 +2385,6 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   // On tmux re-attach, keep awaitingFirstPrompt = true so screen updates are
   // suppressed until the idle detector fires markNewTurn() — this prevents the
   // full tmux scrollback history from leaking into the streaming card.
-  if (tmuxBe?.isReattach) {
-    log('Re-attached to existing tmux session');
-  }
-
   // Bridge fallback: claude-code only. Tail Claude's transcript JSONL so a
   // turn the model finishes WITHOUT calling `botmux send` still gets its
   // assistant text forwarded to Lark (the gate in emitReadyTurns suppresses
@@ -2451,6 +2449,16 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     isPromptReady = false;
     send({ type: 'claude_exit', code, signal });
   });
+
+  if (isPipeMode && backend instanceof TmuxPipeBackend && (backend as any).isReattach) {
+    log(`Re-attached to existing tmux session via pipe-pane: ${TmuxBackend.sessionName(cfg.sessionId)}`);
+    try {
+      const initial = backend.captureCurrentScreen();
+      if (initial.length > 0) onPtyData(initial);
+    } catch (err: any) {
+      log(`captureCurrentScreen failed: ${err.message}`);
+    }
+  }
 
   // Fallback: if the CLI takes too long to show its prompt (e.g. slow
   // plugin init), unblock screen updates so the card doesn't stay at

--- a/test/session-backend-selector-shape.test.ts
+++ b/test/session-backend-selector-shape.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('session backend selector shape', () => {
+  it('does not expose dead tmuxBackend compatibility state', () => {
+    const source = readFileSync(join(process.cwd(), 'src/adapters/backend/session-backend-selector.ts'), 'utf8');
+    expect(source).not.toContain('tmuxBackend');
+  });
+});

--- a/test/tmux-pipe-backend.test.ts
+++ b/test/tmux-pipe-backend.test.ts
@@ -239,8 +239,93 @@ describe('normaliseCaptureLineEndings', () => {
   });
 });
 
+describe('TmuxPipeBackend managed session', () => {
+  it('creates detached session and applies botmux tmux options', () => {
+    const be = new TmuxPipeBackend('bmx-owned', { createSession: true, ownsSession: true });
+    be.spawn('/bin/echo', ['hello'], spawnOpts());
+
+    const newSessionCall = mockedExecFileSync.mock.calls.find(call => {
+      const args = call[1] as string[];
+      return args.includes('new-session');
+    });
+    expect(newSessionCall).toBeDefined();
+    expect(newSessionCall![1]).toContain('-d');
+    expect(newSessionCall![1]).toContain('bmx-owned');
+
+    const optionCalls = mockedExecSync.mock.calls.map(c => String(c[0]));
+    expect(optionCalls.some(c => c.includes('set-option') && c.includes('status off'))).toBe(true);
+    expect(optionCalls.some(c => c.includes('set-option') && c.includes('mouse on'))).toBe(true);
+    expect(optionCalls.some(c => c.includes('set-option') && c.includes('history-limit 50000'))).toBe(true);
+    expect(optionCalls.some(c => c.includes('set-option') && c.includes('window-size largest'))).toBe(true);
+    expect(optionCalls.some(c => c.includes('set-option -s set-clipboard on'))).toBe(true);
+  });
+
+  it('resizes owned tmux sessions and only records adopted pane resize', () => {
+    const owned = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
+    owned.resize(120, 40);
+    expect(mockedExecFileSync).toHaveBeenCalledWith('tmux', ['resize-window', '-t', 'bmx-owned', '-x', '120', '-y', '40'], expect.any(Object));
+
+    mockedExecFileSync.mockClear();
+    const adopted = new TmuxPipeBackend('0:2.0');
+    adopted.resize(100, 30);
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+});
+
+describe('TmuxPipeBackend lifecycle watcher', () => {
+  it('fires exit when the tmux pane disappears', () => {
+    vi.useFakeTimers();
+    try {
+      mockedExecSync.mockImplementation((cmd: any) => {
+        if (String(cmd).includes("display-message") && String(cmd).includes("#{pane_id}")) return '%1\n' as any;
+        return '' as any;
+      });
+      const be = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
+      const exits: Array<[number | null, string | null]> = [];
+      be.onExit((code, signal) => exits.push([code, signal]));
+      be.spawn('', [], spawnOpts());
+      mockedExecSync.mockImplementation((cmd: any) => {
+        if (String(cmd).includes("display-message") && String(cmd).includes("#{pane_id}")) {
+          throw new Error('no pane');
+        }
+        return '' as any;
+      });
+
+      vi.advanceTimersByTime(2_000);
+
+      expect(exits).toEqual([[1, null]]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('fires exit when tmux display-message succeeds with empty pane id', () => {
+    vi.useFakeTimers();
+    try {
+      mockedExecSync.mockImplementation((cmd: any) => {
+        if (String(cmd).includes("display-message") && String(cmd).includes("#{pane_id}")) return '%1\n' as any;
+        return '' as any;
+      });
+      const be = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
+      const exits: Array<[number | null, string | null]> = [];
+      be.onExit((code, signal) => exits.push([code, signal]));
+      be.spawn('', [], spawnOpts());
+      mockedExecSync.mockImplementation((cmd: any) => {
+        if (String(cmd).includes("display-message") && String(cmd).includes("#{pane_id}")) return '\n' as any;
+        return '' as any;
+      });
+
+      vi.advanceTimersByTime(2_000);
+
+      expect(exits).toEqual([[1, null]]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe('TmuxPipeBackend.kill', () => {
-  it('cancels pipe-pane subscription, unlinks the fifo, fires onExit', () => {
+  it('cancels pipe-pane subscription and unlinks the fifo without firing onExit', () => {
     const be = new TmuxPipeBackend('0:2.0');
     be.spawn('', [], spawnOpts());
     let exitFired = false;
@@ -258,7 +343,7 @@ describe('TmuxPipeBackend.kill', () => {
     expect(pipeCall).toContain("'0:2.0'");
 
     expect(mockedUnlinkSync).toHaveBeenCalledWith(expect.stringMatching(/botmux-pipe-.*\.fifo/));
-    expect(exitFired).toBe(true);
+    expect(exitFired).toBe(false);
   });
 
   it('is idempotent (second kill is a no-op)', () => {

--- a/test/tmux-reattach-backend.test.ts
+++ b/test/tmux-reattach-backend.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/adapters/backend/pty-backend.js', () => ({
+  PtyBackend: class MockPtyBackend {},
+}));
+
+vi.mock('../src/adapters/backend/tmux-backend.js', () => ({
+  TmuxBackend: class MockTmuxBackend {
+    static sessionName = vi.fn((id: string) => `bmx-${id.slice(0, 8)}`);
+    static hasSession = vi.fn();
+    constructor(public sessionName: string) {}
+  },
+}));
+
+vi.mock('../src/adapters/backend/tmux-pipe-backend.js', () => ({
+  TmuxPipeBackend: class MockTmuxPipeBackend {
+    constructor(public paneTarget: string, public opts?: unknown) {}
+  },
+}));
+
+import { TmuxBackend } from '../src/adapters/backend/tmux-backend.js';
+import { selectSessionBackend } from '../src/adapters/backend/session-backend-selector.js';
+
+describe('selectSessionBackend', () => {
+  beforeEach(() => {
+    vi.mocked(TmuxBackend.hasSession).mockReset();
+    vi.mocked(TmuxBackend.sessionName).mockClear();
+  });
+
+  it('uses owned pipe backend when reattaching to an existing tmux session', () => {
+    vi.mocked(TmuxBackend.hasSession).mockReturnValue(true);
+
+    const selected = selectSessionBackend({ sessionId: '9cfa0024-197d-4781-845b-c541dceb8980', useTmux: true });
+
+    expect(selected.isTmuxMode).toBe(true);
+    expect(selected.isPipeMode).toBe(true);
+    expect(selected.backend.constructor.name).toBe('MockTmuxPipeBackend');
+    expect((selected.backend as any).paneTarget).toBe('bmx-9cfa0024');
+    expect((selected.backend as any).opts).toEqual({ ownsSession: true, isReattach: true });
+  });
+
+  it('uses managed pipe backend for a new tmux session', () => {
+    vi.mocked(TmuxBackend.hasSession).mockReturnValue(false);
+
+    const selected = selectSessionBackend({ sessionId: '9cfa0024-197d-4781-845b-c541dceb8980', useTmux: true });
+
+    expect(selected.isTmuxMode).toBe(true);
+    expect(selected.isPipeMode).toBe(true);
+    expect(selected.backend.constructor.name).toBe('MockTmuxPipeBackend');
+    expect((selected.backend as any).paneTarget).toBe('bmx-9cfa0024');
+    expect((selected.backend as any).opts).toEqual({ createSession: true, ownsSession: true });
+  });
+
+  it('uses pty backend when tmux is disabled', () => {
+    const selected = selectSessionBackend({ sessionId: '9cfa0024-197d-4781-845b-c541dceb8980', useTmux: false });
+
+    expect(selected.isTmuxMode).toBe(false);
+    expect(selected.isPipeMode).toBe(false);
+    expect('tmuxBackend' in selected).toBe(false);
+  });
+});

--- a/test/worker-pipe-initial-screen-order.test.ts
+++ b/test/worker-pipe-initial-screen-order.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('worker pipe initial screen ordering', () => {
+  it('captures pipe initial screen after idle detector is registered', () => {
+    const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+    const captureIdx = source.indexOf('const initial = backend.captureCurrentScreen();');
+    const idleIdx = source.indexOf('// Set up idle detection');
+    expect(captureIdx).toBeGreaterThan(idleIdx);
+  });
+});


### PR DESCRIPTION
## 背景

安装 tmux 后，botmux 会从原来的 PTY backend 自动切到 tmux backend。旧实现用 `tmux attach-session` / attached `tmux new-session` 作为 worker 的观察层：

```text
worker -> node-pty -> tmux attach-session/new-session -> tmux pane -> Claude/Codex
```

这导致两个问题：

1. **viewer 退出被误判为 CLI 崩溃**
   - `tmux attach-session` 在 daemon/node-pty 环境中可能因为 `open terminal failed: not a terminal` / `lost tty` 退出。
   - 退出的是 tmux viewer/client，不是 pane 里的 Claude/Codex。
   - worker 统一把 backend exit 上报为 `claude_exit`，daemon 触发 auto-restart，连续多次后出现：
     `Claude crashed 4 times in 1 min, not auto-restarting`。

2. **真实 CLI 生命周期和观察层生命周期混在一起**
   - PTY 模式下 backend 进程就是 CLI，`onExit` 等价于 CLI 退出。
   - tmux 模式下 backend 进程只是 tmux client，真实 CLI 运行在 tmux pane 中。
   - 需要把“观察层退出”和“pane/CLI 真实退出”分开处理。

## 修改思路

把 botmux 自有 tmux session 也改成 `pipe-pane` 模型：

```text
worker -> tmux pipe-pane/capture-pane/send-keys -> tmux pane -> Claude/Codex
```

这样 worker 不再依赖 `tmux attach-session` 这个 viewer 进程：

- 新建 session：使用 detached `tmux new-session -d` 启动 CLI，再通过 `pipe-pane` 观察。
- 恢复已有 session：直接通过 `pipe-pane` 观察已有 `bmx-*` session。
- 写入：继续用 `tmux send-keys` / `paste-buffer`。
- 初始画面：reattach 时用 `capture-pane` 初始化 Web 终端/卡片，不再依赖 attach client 输出。

## 主要改动

- 新增 `session-backend-selector`，集中选择 backend：
  - tmux disabled / 探测失败：`PtyBackend`
  - tmux session 已存在：owned `TmuxPipeBackend` reattach
  - tmux session 不存在：managed `TmuxPipeBackend` 创建 detached session
- 扩展 `TmuxPipeBackend`：
  - 支持创建 botmux-owned detached `bmx-*` session
  - 主动 `kill()` / `destroySession()` 时只停止 observer，不向 daemon 上报 `claude_exit`
  - 真实 pane 消失时才触发 `onExit`
  - watcher 使用 `#{pane_id}`，把异常或空输出都视为 pane gone，覆盖 `display-message` status=0 但 stdout 为空的 tmux 行为
  - owned session 支持 `resize-window`
  - 新建 owned session 后应用原 tmux options：`status off`、`mouse on`、`set-clipboard on`、`history-limit 50000`、`window-size largest`
- 调整 `worker`：
  - 用 selector 初始化 backend
  - 只在 reattach pipe mode 下执行 `captureCurrentScreen()`
  - capture 放在 idle detector 注册之后，避免静止 prompt 绕过 idle detector 导致 pending 消息不 flush
- 补充回归测试覆盖：
  - existing tmux session 走 owned pipe backend
  - new tmux session 走 managed detached pipe backend
  - lifecycle watcher 对 pane missing / 空 pane id 触发 exit
  - 主动 kill 不触发 `onExit`
  - owned resize 与 adopt resize 行为区分
  - 初始 capture 顺序在 idle detector 注册之后
  - selector 不再暴露已无用的 `tmuxBackend` 兼容字段

## 为什么这样改

直接修补 `tmux attach-session` 的退出判断只能避免误报，但仍然让 botmux 依赖一个不稳定的 viewer 进程。`pipe-pane` 更符合 daemon 场景：botmux 后台观察/写入 tmux pane，而不是伪装成一个交互式终端用户 attach 进去。

这次改动把生命周期语义重新对齐：

- observer 主动停止：资源清理，不触发 restart
- tmux pane 真实消失：上报 `claude_exit`，daemon 可以按现有逻辑 restart / crash guard
- existing session：保留 `/close` kill `bmx-*` 的 ownership 语义
- new session：保留 tmux backend 的跨 daemon 重启能力

## Test plan

- [x] `vitest run test/tmux-reattach-backend.test.ts test/tmux-pipe-backend.test.ts test/worker-pipe-initial-screen-order.test.ts test/tmux-copy-mode.test.ts test/session-backend-selector-shape.test.ts`
- [x] `tsc --noEmit`
- [x] `tsc && esbuild src/dashboard/web/app.ts --bundle --outfile=dist/dashboard-web/app.js --platform=browser --format=iife --minify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)