### PR TITLE
Add Lark sender metadata to CLI prompts

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -393,10 +393,12 @@ export async function handleCommand(
               await getAvailableBots(ds.larkAppId, ds.chatId),
               ds.pendingFollowUps,
               { name: selfBot.botName, openId: selfBot.botOpenId },
+              ds.pendingSender,
             );
             ds.pendingPrompt = undefined;
             ds.pendingAttachments = undefined;
             ds.pendingMentions = undefined;
+            ds.pendingSender = undefined;
             ds.pendingFollowUps = undefined;
             forkWorker(ds, prompt);
             await sessionReply(rootId, `✅ 已选择 ${displayName}`);
@@ -466,10 +468,12 @@ export async function handleCommand(
             await getAvailableBots(ds.larkAppId, ds.chatId),
             ds.pendingFollowUps,
             { name: selfBot.botName, openId: selfBot.botOpenId },
+            ds.pendingSender,
           );
           ds.pendingPrompt = undefined;
           ds.pendingAttachments = undefined;
           ds.pendingMentions = undefined;
+          ds.pendingSender = undefined;
           ds.pendingFollowUps = undefined;
           forkWorker(ds, prompt);
           const cwd = getSessionWorkingDir(ds);

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -17,7 +17,7 @@ import { TmuxBackend } from '../adapters/backend/tmux-backend.js';
 import { getBot, getAllBots } from '../bot-registry.js';
 import type { CliId } from '../adapters/cli/types.js';
 import { validateAdoptTarget } from './session-discovery.js';
-import type { LarkAttachment, LarkMention, ScheduledTask } from '../types.js';
+import type { LarkAttachment, LarkMention, LarkSender, ScheduledTask } from '../types.js';
 import type { MessageResource } from '../im/lark/message-parser.js';
 import { sessionKey, sessionAnchorId } from './types.js';
 import type { DaemonSession } from './types.js';
@@ -157,6 +157,16 @@ function xmlEscape(s: string): string {
     .replace(/'/g, '&apos;');
 }
 
+function formatSenderTag(sender?: LarkSender): string {
+  if (!sender) return '';
+  const attrs = [
+    `type="${xmlEscape(sender.type)}"`,
+    `open_id="${xmlEscape(sender.openId)}"`,
+    sender.name ? `name="${xmlEscape(sender.name)}"` : '',
+  ].filter(Boolean).join(' ');
+  return `<sender ${attrs} />`;
+}
+
 export function formatAttachmentsHint(attachments?: LarkAttachment[]): string {
   if (!attachments || attachments.length === 0) return '';
   let imgN = 0, fileN = 0;
@@ -178,6 +188,7 @@ export function buildNewTopicPrompt(
   availableBots?: Array<{ name: string; displayName: string; openId: string }>,
   followUps?: string[],
   botIdentity?: { name?: string; openId?: string },
+  sender?: LarkSender,
 ): string {
   const adapter = createCliAdapterSync(cliId, cliPathOverride);
   const hints = adapter.systemHints;
@@ -220,6 +231,8 @@ export function buildNewTopicPrompt(
 
   const userBlock = `<user_message>\n${userMessage}\n</user_message>`;
   const parts: string[] = [userBlock];
+  const senderTag = formatSenderTag(sender);
+  if (senderTag) parts.push(senderTag);
 
   if (followUps && followUps.length > 0) {
     for (const fu of followUps) {
@@ -251,9 +264,11 @@ export function buildNewTopicPrompt(
 export function buildFollowUpContent(
   content: string,
   sessionId: string,
-  opts?: { attachments?: LarkAttachment[]; mentions?: LarkMention[]; isAdoptMode?: boolean; cliId?: CliId; cliPathOverride?: string },
+  opts?: { attachments?: LarkAttachment[]; mentions?: LarkMention[]; sender?: LarkSender; isAdoptMode?: boolean; cliId?: CliId; cliPathOverride?: string },
 ): string {
   const parts: string[] = [`<user_message>\n${content}\n</user_message>`];
+  const senderTag = formatSenderTag(opts?.sender);
+  if (senderTag) parts.push(senderTag);
 
   const attachHint = opts?.attachments && opts.attachments.length > 0
     ? formatAttachmentsHint(opts.attachments)
@@ -392,6 +407,7 @@ export function buildReforkPrompt(
   opts?: {
     attachments?: LarkAttachment[];
     mentions?: LarkMention[];
+    sender?: LarkSender;
     cliId?: CliId;
     cliPathOverride?: string;
     selfMention?: { name?: string | null; openId?: string | null };
@@ -410,6 +426,7 @@ export function buildReforkPrompt(
     isAdoptMode: false,
     cliId: opts?.cliId,
     cliPathOverride: opts?.cliPathOverride,
+    sender: opts?.sender,
   });
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,5 @@
 import type { ChildProcess } from 'node:child_process';
-import type { Session, DaemonToWorker, LarkAttachment, LarkMention, DisplayMode } from '../types.js';
+import type { Session, DaemonToWorker, LarkAttachment, LarkMention, LarkSender, DisplayMode } from '../types.js';
 
 /** Frozen card state — cached content for historical streaming cards that can still be toggled. */
 export interface FrozenCard {
@@ -52,6 +52,7 @@ export interface DaemonSession {
   pendingPrompt?: string;        // original user message to send after repo is selected
   pendingAttachments?: LarkAttachment[];
   pendingMentions?: LarkMention[];    // @mentions from initial message, used when building prompt after repo selection
+  pendingSender?: LarkSender;          // sender metadata from the initial message
   pendingFollowUps?: string[];         // buffered follow-up messages (enriched) sent while waiting for repo selection
   ownerOpenId?: string;          // topic creator's open_id — receives write-enabled terminal link via DM
   streamCardId?: string;         // message_id of the streaming card in group (PATCHed with live output)

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -19,7 +19,7 @@ import { parseEventMessage, resolveNonsupportMessage, stripLeadingMentions, type
 import { expandMergeForward } from './im/lark/merge-forward.js';
 import { logger } from './utils/logger.js';
 import { ensureCjkFontsInstalled } from './utils/font-installer.js';
-import type { DaemonToWorker, LarkMessage } from './types.js';
+import type { DaemonToWorker, LarkMessage, LarkSender } from './types.js';
 export type { DaemonSession } from './core/types.js';
 import type { DaemonSession } from './core/types.js';
 import { sessionKey, sessionAnchorId } from './core/types.js';
@@ -333,6 +333,12 @@ const cardDeps: CardHandlerDeps = {
 
 // ─── Event handling ──────────────────────────────────────────────────────────
 
+function messageSender(parsed: LarkMessage, name?: string): LarkSender {
+  return name
+    ? { openId: parsed.senderId, type: parsed.senderType, name }
+    : { openId: parsed.senderId, type: parsed.senderType };
+}
+
 /**
  * Default-oncall is a uniform forward-only policy: whenever the toggle is
  * on, ANY chat the bot is currently in — old or newly added, doesn't matter —
@@ -555,6 +561,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
     pendingPrompt: content,
     pendingAttachments: attachments.length > 0 ? attachments : undefined,
     pendingMentions: parsed.mentions,
+    pendingSender: messageSender(parsed),
     ownerOpenId: senderOpenId,
     currentTurnTitle: content.substring(0, 50),
     workingDir: pinnedWorkingDir,
@@ -568,7 +575,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
   // Pinned (oncall binding or inherited from sibling bot): spawn CLI immediately.
   if (pinnedWorkingDir) {
     const selfBot = getBot(larkAppId);
-    const prompt = buildNewTopicPrompt(content, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, chatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId });
+    const prompt = buildNewTopicPrompt(content, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, chatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId }, messageSender(parsed));
     forkWorker(ds, prompt);
     const reason = oncallEntry
       ? `oncall-bound chat ${chatId}`
@@ -593,7 +600,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
     // No projects found — skip repo selection, spawn directly
     ds.pendingRepo = false;
     const selfBot = getBot(larkAppId);
-    const prompt = buildNewTopicPrompt(content, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, chatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId });
+    const prompt = buildNewTopicPrompt(content, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, chatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId }, messageSender(parsed));
     forkWorker(ds, prompt);
     logger.info(`Session ${session.sessionId} ready (no projects to select), total active: ${getActiveCount()}`);
   }
@@ -663,9 +670,9 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
     senderOpenIdForPrefix !== selfBotOpenId &&
     (isBotSenderType ||
       isKnownPeerBot(config.session.dataDir, larkAppId, senderOpenIdForPrefix));
-  const botSenderPrefix = isForeignBot
-    ? `[来自 ${lookupForeignBotName(senderOpenIdForPrefix!, larkAppId)} 的 @mention]\n`
-    : '';
+  const senderName = isForeignBot ? lookupForeignBotName(senderOpenIdForPrefix!, larkAppId) : undefined;
+  const botSenderPrefix = senderName ? `[来自 ${senderName} 的 @mention]\n` : '';
+  const sender = messageSender(parsed, senderName);
   const promptContent = botSenderPrefix + parsed.content;
   if (isForeignBot) {
     logger.info(
@@ -858,6 +865,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
       pendingPrompt: promptContent,
       pendingAttachments: attachments.length > 0 ? attachments : undefined,
       pendingMentions: parsed.mentions,
+      pendingSender: sender,
       ownerOpenId: senderOId,
       currentTurnTitle: parsed.content.substring(0, 50),
       workingDir: pinnedWorkingDir,
@@ -872,7 +880,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
     // spawn CLI immediately, skip repo selection.
     if (pinnedWorkingDir) {
       const selfBot = getBot(larkAppId);
-      const prompt = buildNewTopicPrompt(promptContent, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, autoCreateChatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId });
+      const prompt = buildNewTopicPrompt(promptContent, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, autoCreateChatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId }, sender);
       forkWorker(newDs, prompt);
       const reason = oncallEntry
         ? `oncall-bound chat ${autoCreateChatId}`
@@ -897,7 +905,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
       // No projects found — skip repo selection, spawn directly
       newDs.pendingRepo = false;
       const selfBot = getBot(larkAppId);
-      const prompt = buildNewTopicPrompt(promptContent, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, autoCreateChatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId });
+      const prompt = buildNewTopicPrompt(promptContent, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, autoCreateChatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId }, sender);
       forkWorker(newDs, prompt);
     }
 
@@ -929,6 +937,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
           isAdoptMode: false,
           cliId: dsBotCfgForMsg.cliId,
           cliPathOverride: dsBotCfgForMsg.cliPathOverride,
+          sender,
         });
     beginNewTurn(ds, parsed.content);
     ds.worker.send({ type: 'message', content: msgContent } as DaemonToWorker);
@@ -962,6 +971,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
       cliId: dsBotCfgForFork.cliId,
       cliPathOverride: dsBotCfgForFork.cliPathOverride,
       selfMention: { name: selfBot.botName, openId: selfBot.botOpenId },
+      sender,
     });
     forkWorker(ds, wrappedPrompt, ds.hasHistory);
   }

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -519,10 +519,12 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
           await getAvailableBots(ds.larkAppId, ds.chatId),
           ds.pendingFollowUps,
           { name: selfBot.botName, openId: selfBot.botOpenId },
+          ds.pendingSender,
         );
         ds.pendingPrompt = undefined;
         ds.pendingAttachments = undefined;
         ds.pendingMentions = undefined;
+        ds.pendingSender = undefined;
         ds.pendingFollowUps = undefined;
         forkWorker(ds, prompt);
         const cwd = getSessionWorkingDir(ds);
@@ -615,10 +617,12 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       await getAvailableBots(targetDs.larkAppId, targetDs.chatId),
       targetDs.pendingFollowUps,
       { name: selfBot.botName, openId: selfBot.botOpenId },
+      targetDs.pendingSender,
     );
     targetDs.pendingPrompt = undefined;
     targetDs.pendingAttachments = undefined;
     targetDs.pendingMentions = undefined;
+    targetDs.pendingSender = undefined;
     targetDs.pendingFollowUps = undefined;
     forkWorker(targetDs, prompt);
     await sessionReply(rootId, `✅ 已选择 ${displayName}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,12 @@ export interface LarkMention {
   openId?: string;    // open_id of the mentioned user/bot
 }
 
+export interface LarkSender {
+  openId: string;
+  type: string;
+  name?: string;
+}
+
 export interface LarkMessage {
   messageId: string;
   rootId: string;

--- a/test/prompt-builder.test.ts
+++ b/test/prompt-builder.test.ts
@@ -114,6 +114,22 @@ describe('buildNewTopicPrompt', () => {
     expect(prompt).toContain('name="Alice"');
     expect(prompt).toContain('open_id="ou_alice"');
   });
+
+  it('should include sender metadata when provided', () => {
+    const prompt = buildNewTopicPrompt(
+      'hello',
+      SESSION_ID,
+      'claude-code',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { type: 'user', openId: 'ou_sender', name: 'Alice' },
+    );
+    expect(prompt).toContain('<sender type="user" open_id="ou_sender" name="Alice" />');
+  });
 });
 
 describe('buildFollowUpContent', () => {
@@ -156,6 +172,13 @@ describe('buildFollowUpContent', () => {
     expect(content).toContain('<mentions>');
     expect(content).toContain('name="Bob"');
     expect(content).toContain('open_id="ou_bob"');
+  });
+
+  it('should include sender metadata without requiring a name', () => {
+    const content = buildFollowUpContent('hello', SESSION_ID, {
+      sender: { type: 'user', openId: 'ou_sender' },
+    });
+    expect(content).toContain('<sender type="user" open_id="ou_sender" />');
   });
 
   it('should omit <session_id> but keep mentions in adopt mode', () => {
@@ -244,6 +267,15 @@ describe('buildReforkPrompt', () => {
     expect(out).toContain('path="/tmp/x.jpg"');
     expect(out).toContain('name="Alice"');
     expect(out).toContain('open_id="ou_alice"');
+  });
+
+  it('forwards sender metadata to the wrapper', () => {
+    const ds = makeDs();
+    const out = buildReforkPrompt(ds, 'hello', {
+      cliId: 'codex',
+      sender: { type: 'user', openId: 'ou_sender' },
+    });
+    expect(out).toContain('<sender type="user" open_id="ou_sender" />');
   });
 
   it('uses bridge content (no botmux tags) when ds.adoptedFrom is set', () => {


### PR DESCRIPTION
## Summary
- add optional Lark sender metadata and render `<sender ... />` in botmux-managed CLI prompts
- pass sender metadata through new-topic, follow-up, refork, and pending repo-selection paths
- keep scope minimal: no user cache or contact API lookup; user names remain optional, foreign bot names reuse existing lookup

Closes #13

## Tests
- npx --yes pnpm@10.21.0 vitest run test/prompt-builder.test.ts test/command-handler.test.ts test/card-integration.test.ts
- npx --yes pnpm@10.21.0 exec tsc --noEmit
- git diff --check