### PR TITLE
fix(cli): 修复 bots list 的 isSelf 判定

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2648,15 +2648,11 @@ async function cmdBots(sub: string, rest: string[]): Promise<void> {
   let botEntries: BotInfoEntry[] = [];
   try { if (existsSync(botInfoPath)) botEntries = JSON.parse(readFileSync(botInfoPath, 'utf-8')); } catch { /* */ }
 
-  const botByCli = new Map<string, BotInfoEntry>();
-  for (const b of botEntries) botByCli.set(b.cliId, b);
-
   try {
     const { listChatBotMembers } = await import('./im/lark/client.js');
     const chatBots = await listChatBotMembers(appId, s.chatId);
     const result = chatBots.map(cb => {
-      const info = botByCli.get(cb.name);
-      return { name: cb.displayName, openId: cb.openId, isSelf: info?.larkAppId === appId };
+      return { name: cb.displayName, openId: cb.openId, isSelf: cb.larkAppId === appId };
     });
     console.log(JSON.stringify({ sessionId: sid, chatId: s.chatId, bots: result, total: result.length }, null, 2));
   } catch (err: any) {

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -586,7 +586,9 @@ async function listByChatFilter(c: any, chatId: string, rootMessageId: string, p
  * the one registered in this daemon process. This is critical for
  * multi-bot groups where each daemon only manages a single bot.
  */
-export async function listChatBotMembers(larkAppId: string, chatId: string): Promise<Array<{ larkAppId: string; openId: string; name: string; displayName: string }>> {
+export type ChatBotMember = { larkAppId: string; openId: string; name: string; displayName: string };
+
+export async function listChatBotMembers(larkAppId: string, chatId: string): Promise<ChatBotMember[]> {
   // Read per-bot cross-reference: other bots' open_ids as seen by larkAppId's app.
   // This is populated from @mention data in Lark events (the only reliable source,
   // since Lark open_id is per-app scoped — a bot's self-reported open_id is
@@ -635,5 +637,5 @@ export async function listChatBotMembers(larkAppId: string, chatId: string): Pro
       return null;
     }),
   );
-  return results.filter((r): r is { larkAppId: string; openId: string; name: string; displayName: string } => r !== null);
+  return results.filter((r): r is ChatBotMember => r !== null);
 }

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -586,7 +586,7 @@ async function listByChatFilter(c: any, chatId: string, rootMessageId: string, p
  * the one registered in this daemon process. This is critical for
  * multi-bot groups where each daemon only manages a single bot.
  */
-export async function listChatBotMembers(larkAppId: string, chatId: string): Promise<Array<{ openId: string; name: string; displayName: string }>> {
+export async function listChatBotMembers(larkAppId: string, chatId: string): Promise<Array<{ larkAppId: string; openId: string; name: string; displayName: string }>> {
   // Read per-bot cross-reference: other bots' open_ids as seen by larkAppId's app.
   // This is populated from @mention data in Lark events (the only reliable source,
   // since Lark open_id is per-app scoped — a bot's self-reported open_id is
@@ -627,7 +627,7 @@ export async function listChatBotMembers(larkAppId: string, chatId: string): Pro
           const openId = (info?.botName && crossRef.get(info.botName.toLowerCase()))
             ?? info?.botOpenId
             ?? appId;
-          return { openId, name: cliId, displayName: info?.botName ?? cliId };
+          return { larkAppId: appId, openId, name: cliId, displayName: info?.botName ?? cliId };
         }
       } catch (err) {
         logger.debug(`isInChat check failed for ${appId}: ${err}`);
@@ -635,5 +635,5 @@ export async function listChatBotMembers(larkAppId: string, chatId: string): Pro
       return null;
     }),
   );
-  return results.filter((r): r is { openId: string; name: string; displayName: string } => r !== null);
+  return results.filter((r): r is { larkAppId: string; openId: string; name: string; displayName: string } => r !== null);
 }

--- a/test/list-chat-bot-members.test.ts
+++ b/test/list-chat-bot-members.test.ts
@@ -1,7 +1,7 @@
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const state = vi.hoisted(() => ({ dataDir: '' }));
 
@@ -22,9 +22,6 @@ vi.mock('../src/utils/user-token.js', () => ({
 }));
 
 vi.mock('../src/bot-registry.js', () => ({
-  getBotClient: vi.fn(),
-  getBot: vi.fn(),
-  getAllBots: vi.fn(() => []),
   loadBotConfigs: vi.fn(() => [
     { larkAppId: 'cli_self', larkAppSecret: 's1', cliId: 'codex' },
     { larkAppId: 'cli_peer', larkAppSecret: 's2', cliId: 'codex' },
@@ -51,6 +48,13 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
 }));
 
 describe('listChatBotMembers', () => {
+  afterEach(() => {
+    if (state.dataDir) {
+      rmSync(state.dataDir, { recursive: true, force: true });
+      state.dataDir = '';
+    }
+  });
+
   it('returns larkAppId so callers can identify self when cliId is duplicated', async () => {
     state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-list-chat-bots-'));
     writeFileSync(join(state.dataDir, 'bots-info.json'), JSON.stringify([

--- a/test/list-chat-bot-members.test.ts
+++ b/test/list-chat-bot-members.test.ts
@@ -1,0 +1,74 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({ dataDir: '' }));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    session: {
+      get dataDir() { return state.dataDir; },
+    },
+  },
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../src/utils/user-token.js', () => ({
+  resolveUserToken: vi.fn(),
+}));
+
+vi.mock('../src/bot-registry.js', () => ({
+  getBotClient: vi.fn(),
+  getBot: vi.fn(),
+  getAllBots: vi.fn(() => []),
+  loadBotConfigs: vi.fn(() => [
+    { larkAppId: 'cli_self', larkAppSecret: 's1', cliId: 'codex' },
+    { larkAppId: 'cli_peer', larkAppSecret: 's2', cliId: 'codex' },
+  ]),
+}));
+
+vi.mock('@larksuiteoapi/node-sdk', () => ({
+  LoggerLevel: { error: 4 },
+  Client: class MockClient {
+    appId: string;
+    im: any;
+
+    constructor(opts: { appId: string }) {
+      this.appId = opts.appId;
+      this.im = {
+        v1: {
+          chatMembers: {
+            isInChat: vi.fn(async () => ({ code: 0, data: { is_in_chat: true } })),
+          },
+        },
+      };
+    }
+  },
+}));
+
+describe('listChatBotMembers', () => {
+  it('returns larkAppId so callers can identify self when cliId is duplicated', async () => {
+    state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-list-chat-bots-'));
+    writeFileSync(join(state.dataDir, 'bots-info.json'), JSON.stringify([
+      { larkAppId: 'cli_self', botOpenId: 'ou_self_seen_by_self', botName: 'Botmux Oncall(Codex)', cliId: 'codex' },
+      { larkAppId: 'cli_peer', botOpenId: 'ou_peer_seen_by_self', botName: 'Botmux Oncall(CoCo)', cliId: 'codex' },
+    ]));
+    writeFileSync(join(state.dataDir, 'bot-openids-cli_self.json'), JSON.stringify({
+      'Botmux Oncall(Codex)': 'ou_self_seen_by_self',
+      'Botmux Oncall(CoCo)': 'ou_peer_seen_by_self',
+    }));
+
+    const { listChatBotMembers } = await import('../src/im/lark/client.js');
+    const bots = await listChatBotMembers('cli_self', 'oc_chat');
+
+    expect(bots).toEqual([
+      { larkAppId: 'cli_self', name: 'codex', displayName: 'Botmux Oncall(Codex)', openId: 'ou_self_seen_by_self' },
+      { larkAppId: 'cli_peer', name: 'codex', displayName: 'Botmux Oncall(CoCo)', openId: 'ou_peer_seen_by_self' },
+    ]);
+    expect(bots.map(b => b.larkAppId === 'cli_self')).toEqual([true, false]);
+  });
+});


### PR DESCRIPTION
## 摘要
- `listChatBotMembers()` 返回群内每个 bot 对应的 `larkAppId`
- `botmux bots list` 用 `larkAppId === 当前 session.larkAppId` 判定 `isSelf`
- 增加重复 `cliId` 场景的回归测试，避免多个 Codex/同 CLI bot 时 self 判定全为 false

## 验证
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm vitest run test/list-chat-bot-members.test.ts test/prompt-builder.test.ts`
- [x] `pnpm run build`