### PR TITLE
fix(quoted): 支持引用卡片消息解析

### DIFF
--- a/src/cli/quoted-render.ts
+++ b/src/cli/quoted-render.ts
@@ -8,6 +8,7 @@ import {
   parseApiMessage,
   extractResources,
   createImgNumberer,
+  normalizeApiMessageContent,
   type MessageResource,
 } from '../im/lark/message-parser.js';
 
@@ -48,7 +49,9 @@ export async function renderQuotedMessage(
   // the other order leaves resources unnumbered when extractTextContent runs
   // first (it only consults the cache, doesn't create entries for resources
   // that haven't been declared yet via extractResources).
-  const resources = extractResources(rawMessage.msg_type ?? '', rawMessage.body?.content ?? '', numberer);
+  const msgType = rawMessage.msg_type ?? '';
+  const content = normalizeApiMessageContent(msgType, rawMessage.body?.content ?? '');
+  const resources = extractResources(msgType, content, numberer);
   const parsed = parseApiMessage(rawMessage, numberer);
   if (parsed.msgType === 'merge_forward') {
     const { extraResources } = await expandMergeForward(larkAppId, parsed.messageId, parsed, numberer);

--- a/src/cli/quoted-render.ts
+++ b/src/cli/quoted-render.ts
@@ -8,7 +8,6 @@ import {
   parseApiMessage,
   extractResources,
   createImgNumberer,
-  normalizeApiMessageContent,
   type MessageResource,
 } from '../im/lark/message-parser.js';
 
@@ -49,9 +48,7 @@ export async function renderQuotedMessage(
   // the other order leaves resources unnumbered when extractTextContent runs
   // first (it only consults the cache, doesn't create entries for resources
   // that haven't been declared yet via extractResources).
-  const msgType = rawMessage.msg_type ?? '';
-  const content = normalizeApiMessageContent(msgType, rawMessage.body?.content ?? '');
-  const resources = extractResources(msgType, content, numberer);
+  const resources = extractResources(rawMessage.msg_type ?? '', rawMessage.body?.content ?? '', numberer);
   const parsed = parseApiMessage(rawMessage, numberer);
   if (parsed.msgType === 'merge_forward') {
     const { extraResources } = await expandMergeForward(larkAppId, parsed.messageId, parsed, numberer);

--- a/src/im/lark/message-parser.ts
+++ b/src/im/lark/message-parser.ts
@@ -155,6 +155,7 @@ export function createImgNumberer(): ImgNumberer {
 }
 
 export function extractResources(msgType: string, rawContent: string, numberer?: ImgNumberer): MessageResource[] {
+  rawContent = normalizeApiMessageContent(msgType, rawContent);
   const nb = numberer ?? createImgNumberer();
   const pushIfNew = (resources: MessageResource[], r: MessageResource) => {
     if (nb.assign(`${r.type}:${r.key}`).isNew) resources.push(r);
@@ -269,15 +270,22 @@ export function parseEventMessage(data: RawEventData): { parsed: LarkMessage; re
 }
 
 export function parseApiMessage(msg: any, numberer?: ImgNumberer): LarkMessage {
+  const msgType = msg.msg_type ?? 'text';
+  const rawContent = msg.body?.content ?? '';
   return {
     messageId: msg.message_id ?? '',
     rootId: msg.root_id ?? msg.thread_id ?? '',
     senderId: msg.sender?.id ?? '',
     senderType: msg.sender?.sender_type ?? 'unknown',
-    msgType: msg.msg_type ?? 'text',
-    content: extractTextContent(msg.msg_type ?? 'text', msg.body?.content ?? '', undefined, numberer),
+    msgType,
+    content: extractTextContent(msgType, normalizeApiMessageContent(msgType, rawContent), undefined, numberer),
     createTime: msg.create_time ?? '',
   };
+}
+
+export function normalizeApiMessageContent(msgType: string, rawContent: string): string {
+  if (msgType !== 'interactive') return rawContent;
+  return unwrapUserDslContent(rawContent) ?? rawContent;
 }
 
 /** Resolve post body from either wrapped {"zh_cn":{title,content}} or unwrapped {title,content} format */

--- a/src/im/lark/message-parser.ts
+++ b/src/im/lark/message-parser.ts
@@ -155,13 +155,13 @@ export function createImgNumberer(): ImgNumberer {
 }
 
 export function extractResources(msgType: string, rawContent: string, numberer?: ImgNumberer): MessageResource[] {
-  rawContent = normalizeApiMessageContent(msgType, rawContent);
+  const content = normalizeApiMessageContent(msgType, rawContent);
   const nb = numberer ?? createImgNumberer();
   const pushIfNew = (resources: MessageResource[], r: MessageResource) => {
     if (nb.assign(`${r.type}:${r.key}`).isNew) resources.push(r);
   };
   try {
-    const parsed = JSON.parse(rawContent);
+    const parsed = JSON.parse(content);
 
     if (msgType === 'image') {
       const resources: MessageResource[] = [];
@@ -283,7 +283,7 @@ export function parseApiMessage(msg: any, numberer?: ImgNumberer): LarkMessage {
   };
 }
 
-export function normalizeApiMessageContent(msgType: string, rawContent: string): string {
+function normalizeApiMessageContent(msgType: string, rawContent: string): string {
   if (msgType !== 'interactive') return rawContent;
   return unwrapUserDslContent(rawContent) ?? rawContent;
 }

--- a/test/message-parser.test.ts
+++ b/test/message-parser.test.ts
@@ -119,6 +119,27 @@ describe('Interactive card parsing: Format A (API simplified)', () => {
 // ─── Interactive card: Format B (original card JSON) ──────────────────────
 
 describe('Interactive card parsing: Format B (original card JSON)', () => {
+  it('unwraps user_dsl before parsing API interactive messages', () => {
+    const card = {
+      user_dsl: JSON.stringify({
+        header: { title: { tag: 'plain_text', content: '引用卡片' } },
+        body: {
+          elements: [
+            { tag: 'markdown', content: '卡片正文' },
+            { tag: 'img', img_key: 'img_card' },
+          ],
+        },
+      }),
+    };
+    const numberer = createImgNumberer();
+    const resources = extractResources('interactive', JSON.stringify(card), numberer);
+    const result = parseApiMessage(makeMsg('interactive', card), numberer);
+    expect(result.content).toContain('[卡片: 引用卡片]');
+    expect(result.content).toContain('卡片正文');
+    expect(result.content).toContain('[图片 1]');
+    expect(resources).toEqual([{ type: 'image', key: 'img_card', name: 'img_card.jpg' }]);
+  });
+
   it('should extract header title and div text', () => {
     const card = {
       config: { wide_screen_mode: true },

--- a/test/quoted-render.test.ts
+++ b/test/quoted-render.test.ts
@@ -65,6 +65,28 @@ describe('renderQuotedMessage: post', () => {
   });
 });
 
+describe('renderQuotedMessage: interactive', () => {
+  it('parses user_dsl card content and keeps image placeholders aligned with resources', async () => {
+    const out = await renderQuotedMessage('app_x', rawMessage('interactive', {
+      user_dsl: JSON.stringify({
+        header: { title: { tag: 'plain_text', content: 'Quoted Card' } },
+        body: {
+          elements: [
+            { tag: 'markdown', content: 'card body' },
+            { tag: 'img', img_key: 'img_card' },
+          ],
+        },
+      }),
+    }), noExpand);
+
+    expect(out.msgType).toBe('interactive');
+    expect(out.content).toContain('[卡片: Quoted Card]');
+    expect(out.content).toContain('card body');
+    expect(out.content).toContain('[图片 1]');
+    expect(out.resources).toEqual([{ type: 'image', key: 'img_card', name: 'img_card.jpg' }]);
+  });
+});
+
 describe('renderQuotedMessage: merge_forward', () => {
   it('appends sub-message extraResources after top-level resources and stamps msgType to merge_forward_expanded', async () => {
     // Stub expandMergeForward to mimic a forwarded subtree with one image


### PR DESCRIPTION
## Summary
- normalize interactive API message content by unwrapping `user_dsl` before parsing
- make `botmux quoted` reuse the same card parsing path as live received messages
- keep quoted card image resources and `[图片 N]` placeholders aligned

## Test Plan
- `pnpm vitest run test/message-parser.test.ts test/quoted-render.test.ts`
- `pnpm exec tsc --noEmit`
