### PR TITLE
兼容 Claude Code 自定义 Chat 快捷键

### DIFF
--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -243,13 +243,19 @@ function findJsonlAcrossProjectsRoot(
 
 const COMPLETION_RE = /\u2733\s*(?:Worked|Crunched|Cogitated|Cooked|Churned|Saut[eé]ed|Baked|Brewed) for \d+[smh]/;
 const CLAUDE_KEYBINDINGS_PATH = join(homedir(), '.claude', 'keybindings.json');
+/** Escape hatch: force a specific chat:submit key regardless of
+ *  keybindings.json. Accepts the same spellings as the config (e.g.
+ *  `meta+enter`, `alt+enter`, `enter`). A value that can't be sent through the
+ *  terminal makes writeInput fail fast with a clear reason. */
 const CLAUDE_SUBMIT_KEY_ENV = 'CLAUDE_CODE_SUBMIT_KEY';
 const CHAT_CONTEXT = 'Chat';
 const CHAT_SUBMIT_ACTION = 'chat:submit';
 const CHAT_NEWLINE_ACTION = 'chat:newline';
 const DEFAULT_SUBMIT_KEY = 'Enter';
 const UNSUPPORTED_SUBMIT_KEY_FAILURE =
-  'Claude Code Chat keybindings require a terminal-sendable chat:submit key such as meta+enter or alt+enter; cmd+enter cannot be sent through tmux/PTY.';
+  'Claude Code Chat keybindings have no terminal-sendable chat:submit key. ' +
+  'Only Enter, Meta+Enter (Alt+Enter) can be delivered through tmux/PTY; ' +
+  'keys such as Cmd+Enter, Ctrl+Enter or Shift+Enter cannot.';
 
 interface ClaudeChatKeybindings {
   submitKeys: string[] | null;
@@ -275,6 +281,13 @@ function readClaudeChatBindings(): Record<string, string> | null {
   return chat?.bindings ?? null;
 }
 
+// Only keys that a terminal can actually deliver to Claude Code's Ink input
+// are listed here. Plain Enter is `\r`; Meta/Alt+Enter is the widely-supported
+// ESC-prefix (`\x1b\r`). Ctrl+Enter and Shift+Enter are deliberately omitted:
+// terminals can't distinguish them from a bare Enter unless the Kitty keyboard
+// protocol / modifyOtherKeys is negotiated, so sending `C-Enter`/`S-Enter`
+// would silently fail to submit. Anything not listed falls through to a
+// fail-fast with a clear reason rather than a phantom submit.
 function toTmuxSubmitKey(key: string): string | null {
   const normalized = key.trim().toLowerCase();
   switch (normalized) {
@@ -284,13 +297,6 @@ function toTmuxSubmitKey(key: string): string | null {
     case 'alt+enter':
     case 'm-enter':
       return 'M-Enter';
-    case 'ctrl+enter':
-    case 'control+enter':
-    case 'c-enter':
-      return 'C-Enter';
-    case 'shift+enter':
-    case 's-enter':
-      return 'S-Enter';
     default:
       return null;
   }
@@ -318,14 +324,18 @@ function selectSubmitKey(bindings: Record<string, string> | null): string | null
   const submitKeys = Object.entries(bindings)
     .filter(([, action]) => action === CHAT_SUBMIT_ACTION)
     .map(([key]) => key);
-  if (submitKeys.length === 0) return DEFAULT_SUBMIT_KEY;
 
-  const terminalFriendlyOrder = ['meta+enter', 'alt+enter', 'enter', 'ctrl+enter', 'control+enter', 'shift+enter'];
+  const terminalFriendlyOrder = ['meta+enter', 'alt+enter', 'enter'];
   for (const candidate of terminalFriendlyOrder) {
     if (submitKeys.some(key => key.toLowerCase() === candidate)) return candidate;
   }
   const supportedSubmitKey = submitKeys.find(key => toTmuxSubmitKey(key));
   if (supportedSubmitKey) return supportedSubmitKey;
+  // No terminal-sendable submit binding (none configured, or only unsendable
+  // ones like cmd+enter). Fall back to plain Enter only when Enter is still
+  // unbound — i.e. Claude Code's built-in Enter=submit is intact. If Enter was
+  // remapped (e.g. to chat:newline), sending Enter would never submit, so we
+  // must fail fast instead.
   return bindingActionForKey(bindings, DEFAULT_SUBMIT_KEY) === undefined ? DEFAULT_SUBMIT_KEY : null;
 }
 

--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -242,6 +242,111 @@ function findJsonlAcrossProjectsRoot(
 }
 
 const COMPLETION_RE = /\u2733\s*(?:Worked|Crunched|Cogitated|Cooked|Churned|Saut[eé]ed|Baked|Brewed) for \d+[smh]/;
+const CLAUDE_KEYBINDINGS_PATH = join(homedir(), '.claude', 'keybindings.json');
+const CLAUDE_SUBMIT_KEY_ENV = 'CLAUDE_CODE_SUBMIT_KEY';
+const CHAT_CONTEXT = 'Chat';
+const CHAT_SUBMIT_ACTION = 'chat:submit';
+const CHAT_NEWLINE_ACTION = 'chat:newline';
+const DEFAULT_SUBMIT_KEY = 'Enter';
+const UNSUPPORTED_SUBMIT_KEY_FAILURE =
+  'Claude Code Chat keybindings require a terminal-sendable chat:submit key such as meta+enter or alt+enter; cmd+enter cannot be sent through tmux/PTY.';
+
+interface ClaudeChatKeybindings {
+  submitKeys: string[] | null;
+  rawSubmitSequence: string | null;
+  enterIsNewline: boolean;
+  failureReason?: string;
+}
+
+function readClaudeChatBindings(): Record<string, string> | null {
+  let parsed: any;
+  try {
+    parsed = JSON.parse(readFileSync(CLAUDE_KEYBINDINGS_PATH, 'utf8'));
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed?.bindings)) return null;
+  const chat = parsed.bindings.find((entry: any) => (
+    entry?.context === CHAT_CONTEXT &&
+    entry?.bindings &&
+    typeof entry.bindings === 'object' &&
+    !Array.isArray(entry.bindings)
+  ));
+  return chat?.bindings ?? null;
+}
+
+function toTmuxSubmitKey(key: string): string | null {
+  const normalized = key.trim().toLowerCase();
+  switch (normalized) {
+    case 'enter':
+      return 'Enter';
+    case 'meta+enter':
+    case 'alt+enter':
+    case 'm-enter':
+      return 'M-Enter';
+    case 'ctrl+enter':
+    case 'control+enter':
+    case 'c-enter':
+      return 'C-Enter';
+    case 'shift+enter':
+    case 's-enter':
+      return 'S-Enter';
+    default:
+      return null;
+  }
+}
+
+function toRawSubmitSequence(key: string): string | null {
+  const normalized = key.trim().toLowerCase();
+  switch (normalized) {
+    case 'enter':
+      return '\r';
+    case 'meta+enter':
+    case 'alt+enter':
+    case 'm-enter':
+      return '\x1b\r';
+    default:
+      return null;
+  }
+}
+
+function selectSubmitKey(bindings: Record<string, string> | null): string | null {
+  const override = process.env[CLAUDE_SUBMIT_KEY_ENV]?.trim();
+  if (override) return toTmuxSubmitKey(override) ? override : null;
+  if (!bindings) return DEFAULT_SUBMIT_KEY;
+
+  const submitKeys = Object.entries(bindings)
+    .filter(([, action]) => action === CHAT_SUBMIT_ACTION)
+    .map(([key]) => key);
+  if (submitKeys.length === 0) return DEFAULT_SUBMIT_KEY;
+
+  const terminalFriendlyOrder = ['meta+enter', 'alt+enter', 'enter', 'ctrl+enter', 'control+enter', 'shift+enter'];
+  for (const candidate of terminalFriendlyOrder) {
+    if (submitKeys.some(key => key.toLowerCase() === candidate)) return candidate;
+  }
+  const supportedSubmitKey = submitKeys.find(key => toTmuxSubmitKey(key));
+  if (supportedSubmitKey) return supportedSubmitKey;
+  return bindingActionForKey(bindings, DEFAULT_SUBMIT_KEY) === undefined ? DEFAULT_SUBMIT_KEY : null;
+}
+
+function bindingActionForKey(bindings: Record<string, string> | null, targetKey: string): string | undefined {
+  const normalizedTarget = targetKey.toLowerCase();
+  return Object.entries(bindings ?? {})
+    .find(([key]) => key.toLowerCase() === normalizedTarget)?.[1];
+}
+
+function resolveClaudeChatKeybindings(): ClaudeChatKeybindings {
+  const bindings = readClaudeChatBindings();
+  const submitKey = selectSubmitKey(bindings);
+  const tmuxSubmitKey = submitKey ? toTmuxSubmitKey(submitKey) : null;
+  const rawSubmitSequence = submitKey ? toRawSubmitSequence(submitKey) : null;
+  return {
+    submitKeys: tmuxSubmitKey ? [tmuxSubmitKey] : null,
+    rawSubmitSequence,
+    enterIsNewline: bindingActionForKey(bindings, DEFAULT_SUBMIT_KEY) === CHAT_NEWLINE_ACTION,
+    failureReason: submitKey === null ? UNSUPPORTED_SUBMIT_KEY_FAILURE : undefined,
+  };
+}
 
 /** PTYs that have already received at least one writeInput. The first write
  *  lands while Ink is still doing its startup render pass (banner, model
@@ -355,10 +460,18 @@ export function createClaudeCodeAdapter(pathOverride?: string): CliAdapter {
       const TYPING_THROTTLE_MS = isFirstWrite ? 80 : 30;
 
       const tick = () => new Promise<void>(r => setTimeout(r, TYPING_THROTTLE_MS));
+      const keybindings = resolveClaudeChatKeybindings();
 
-      const sendEnter = () => {
-        if (pty.sendSpecialKeys) pty.sendSpecialKeys('Enter');
-        else pty.write('\r');
+      const sendSubmit = (): boolean => {
+        if (pty.sendSpecialKeys && keybindings.submitKeys) {
+          pty.sendSpecialKeys(...keybindings.submitKeys);
+          return true;
+        }
+        if (!pty.sendSpecialKeys && keybindings.rawSubmitSequence) {
+          pty.write(keybindings.rawSubmitSequence);
+          return true;
+        }
+        return false;
       };
 
       // Pid-state path resolver: ~/.claude/sessions/<pid>.json carries
@@ -387,6 +500,18 @@ export function createClaudeCodeAdapter(pathOverride?: string): CliAdapter {
       let baseByte = pty.claudeJsonlPath ? currentFileSize(pty.claudeJsonlPath) : 0;
       const submitFingerprint = makeSubmitFingerprint(content);
       const submitSearchMinMtime = Date.now() - 60_000;
+      const buildResult = (submitted: boolean, failureReason?: string): { submitted: boolean; cliSessionId?: string; failureReason?: string } => {
+        const result = observedCliSessionId
+          ? { submitted, cliSessionId: observedCliSessionId }
+          : { submitted };
+        return failureReason ? { ...result, failureReason } : result;
+      };
+      const submitKeySupportedByBackend = pty.sendSpecialKeys
+        ? !!keybindings.submitKeys
+        : !!keybindings.rawSubmitSequence;
+      if (!submitKeySupportedByBackend) {
+        return buildResult(false, keybindings.failureReason ?? UNSUPPORTED_SUBMIT_KEY_FAILURE);
+      }
 
       if (pty.sendText && pty.sendSpecialKeys) {
         const lines = content.split('\n');
@@ -396,10 +521,12 @@ export function createClaudeCodeAdapter(pathOverride?: string): CliAdapter {
             await tick();
           }
           if (i < lines.length - 1) {
-            // Soft-newline: backslash + Enter inserts a newline in Claude
-            // Code's input box without submitting.
-            pty.sendText('\\');
-            await tick();
+            if (!keybindings.enterIsNewline) {
+              // Soft-newline: backslash + Enter inserts a newline in Claude
+              // Code's input box without submitting.
+              pty.sendText('\\');
+              await tick();
+            }
             pty.sendSpecialKeys('Enter');
             await tick();
           }
@@ -410,7 +537,9 @@ export function createClaudeCodeAdapter(pathOverride?: string): CliAdapter {
         pty.write('\x1b[200~' + content + '\x1b[201~');
       }
       await new Promise(r => setTimeout(r, submitDelay));
-      sendEnter();
+      if (!sendSubmit()) {
+        return buildResult(false, keybindings.failureReason ?? UNSUPPORTED_SUBMIT_KEY_FAILURE);
+      }
 
       // Without a JSONL path we can't verify — trust the fixed delay and return.
       // Still surface any sessionId we observed via the pid resolver so the
@@ -485,12 +614,6 @@ export function createClaudeCodeAdapter(pathOverride?: string): CliAdapter {
         return false;
       };
 
-      const buildResult = (submitted: boolean): { submitted: boolean; cliSessionId?: string } => {
-        return observedCliSessionId
-          ? { submitted, cliSessionId: observedCliSessionId }
-          : { submitted };
-      };
-
       // Retry budget: up to 2 extra Enters (3 sends total), each followed by
       // an 800ms wait for the JSONL to record either a direct user-submit line
       // or a type-ahead enqueue line. If the user is concurrently typing in the
@@ -501,7 +624,7 @@ export function createClaudeCodeAdapter(pathOverride?: string): CliAdapter {
         if (await confirmSubmit(800)) {
           return observedCliSessionId ? buildResult(true) : undefined;
         }
-        sendEnter();
+        if (!sendSubmit()) break;
       }
       // Final grace check.
       if (await confirmSubmit(800)) {

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -87,6 +87,10 @@ export interface CliAdapter {
   ): Promise<void | {
     submitted: boolean;
     cliSessionId?: string;
+    /** Non-transient reason when the adapter knows submission is impossible
+     *  without waiting for transcript confirmation (for example an unsupported
+     *  terminal keybinding). Worker surfaces this immediately. */
+    failureReason?: string;
     recheck?: () => boolean | Promise<boolean>;
   }>;
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2053,8 +2053,26 @@ function scheduleSubmitFailureNotify(
   recheck: (() => boolean | Promise<boolean>) | undefined,
   transcriptLabel: string,
   bridgeTurnId?: string,
+  failureReason?: string,
 ): void {
   const preview = msg.length > 60 ? msg.slice(0, 60) + '…' : msg;
+  const dropBridgeMark = (): void => {
+    if (!bridgeTurnId) return;
+    const dropped = bridgeQueue.dropPendingTurn(bridgeTurnId);
+    if (dropped) {
+      if (dropped.contentFingerprint) bridgeFingerprintScanLastMs.delete(dropped.contentFingerprint);
+      log(`Bridge mark dropped after submit failure (turnId=${bridgeTurnId}) — rotation-fallback scan will stop spinning on this fingerprint.`);
+    }
+  };
+  if (failureReason) {
+    dropBridgeMark();
+    log(`writeInput: submit impossible — notifying user immediately. reason="${failureReason}" preview="${preview}"`);
+    send({
+      type: 'user_notify',
+      message: `⚠️ 刚才那条消息没有写入 ${cliName()}，因为当前按键配置无法从终端自动提交。\n原因：${failureReason}\n请调整 Claude Code Chat keybinding 后重发。\n开头：${preview}`,
+    });
+    return;
+  }
   log(`writeInput: submit not confirmed after retries — deferred ${SUBMIT_DEFERRED_RECHECK_MS}ms recheck queued. preview="${preview}"`);
   setTimeout(async () => {
     if (recheck) {
@@ -2067,13 +2085,7 @@ function scheduleSubmitFailureNotify(
         log(`Deferred recheck threw (${err?.message ?? err}); falling through to warning.`);
       }
     }
-    if (bridgeTurnId) {
-      const dropped = bridgeQueue.dropPendingTurn(bridgeTurnId);
-      if (dropped) {
-        if (dropped.contentFingerprint) bridgeFingerprintScanLastMs.delete(dropped.contentFingerprint);
-        log(`Bridge mark dropped after submit failure (turnId=${bridgeTurnId}) — rotation-fallback scan will stop spinning on this fingerprint.`);
-      }
-    }
+    dropBridgeMark();
     log(`Deferred recheck still missing — notifying user. preview="${preview}"`);
     send({
       type: 'user_notify',
@@ -2147,7 +2159,7 @@ async function flushPending(): Promise<void> {
         if (codexBridgeActive) codexBridgeNotifyCliSessionId(result.cliSessionId);
       }
       if (result && result.submitted === false) {
-        scheduleSubmitFailureNotify(msg, result.recheck, '会话 JSONL', bridgeTurnId);
+        scheduleSubmitFailureNotify(msg, result.recheck, '会话 JSONL', bridgeTurnId, result.failureReason);
       }
       // Codex bridge: stop after one writeInput per idle cycle. Codex's
       // bridge queue doesn't yet attribute queued_command-equivalents, so
@@ -3100,7 +3112,7 @@ process.on('message', async (raw: unknown) => {
                 codexBridgeNotifyCliSessionId(result.cliSessionId);
               }
               if (result && result.submitted === false) {
-                scheduleSubmitFailureNotify(content, result.recheck, 'Codex history');
+                scheduleSubmitFailureNotify(content, result.recheck, 'Codex history', undefined, result.failureReason);
               }
             } catch (err: any) {
               log(`Codex adopt writeInput error: ${err.message}`);

--- a/test/write-input.test.ts
+++ b/test/write-input.test.ts
@@ -277,6 +277,65 @@ describe('writeInput: multiline, tmux mode', () => {
     }
   });
 
+  it('claude-code: fails before typing when only unsendable Ctrl+Enter can submit', async () => {
+    // Terminals cannot distinguish Ctrl+Enter from Enter, so it must NOT be
+    // treated as a sendable submit key — fail fast instead of phantom-submitting.
+    const adapter = createClaudeCodeAdapter('/bin/claude');
+    writeClaudeKeybindings({
+      'ctrl+enter': 'chat:submit',
+      enter: 'chat:newline',
+    });
+    try {
+      const pty = makeTmuxPty();
+      const result = await adapter.writeInput(pty, MULTILINE);
+
+      expect(pty.sendText).not.toHaveBeenCalled();
+      expect(pty.sendSpecialKeys).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        submitted: false,
+        failureReason: expect.stringContaining('terminal-sendable'),
+      });
+    } finally {
+      removeClaudeKeybindings();
+    }
+  });
+
+  it('claude-code: fails before typing when Enter is newline and no submit key is bound', async () => {
+    // A config that remaps Enter to newline without binding any chat:submit key
+    // would otherwise type the message and emit newlines forever — fail fast.
+    const adapter = createClaudeCodeAdapter('/bin/claude');
+    writeClaudeKeybindings({ enter: 'chat:newline' });
+    try {
+      const pty = makeTmuxPty();
+      const result = await adapter.writeInput(pty, MULTILINE);
+
+      expect(pty.sendText).not.toHaveBeenCalled();
+      expect(pty.sendSpecialKeys).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        submitted: false,
+        failureReason: expect.stringContaining('terminal-sendable'),
+      });
+    } finally {
+      removeClaudeKeybindings();
+    }
+  });
+
+  it('claude-code: CLAUDE_CODE_SUBMIT_KEY env overrides the submit key', async () => {
+    const adapter = createClaudeCodeAdapter('/bin/claude');
+    removeClaudeKeybindings();
+    process.env.CLAUDE_CODE_SUBMIT_KEY = 'meta+enter';
+    try {
+      const pty = makeTmuxPty();
+      await adapter.writeInput(pty, MULTILINE);
+
+      // Enter still submits by default here, so soft-newlines stay backslashed;
+      // only the final submit honours the override.
+      expect(pty.sendSpecialKeys.mock.calls.at(-1)).toEqual(['M-Enter']);
+    } finally {
+      delete process.env.CLAUDE_CODE_SUBMIT_KEY;
+    }
+  });
+
   it.each(PASTE_BUFFER_ADAPTERS)('%s: single pasteText(whole) + delayed Enter, no sendText', async (_name, adapter) => {
     // Coco's tmux path uses load-buffer + paste-buffer -d (PtyHandle.pasteText)
     // for the whole content, then a single delayed Enter. tmux wraps in

--- a/test/write-input.test.ts
+++ b/test/write-input.test.ts
@@ -43,7 +43,7 @@ import { createCodexAdapter } from '../src/adapters/cli/codex.js';
 import { createGeminiAdapter } from '../src/adapters/cli/gemini.js';
 import { createOpenCodeAdapter } from '../src/adapters/cli/opencode.js';
 import type { CliAdapter, PtyHandle } from '../src/adapters/cli/types.js';
-import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { appendFileSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -53,6 +53,7 @@ import { dirname, join } from 'node:path';
 
 const CODEX_HISTORY_PATH = join(homedir(), '.codex', 'history.jsonl');
 const COCO_HISTORY_PATH = join(homedir(), '.cache', 'coco', 'history.jsonl');
+const CLAUDE_KEYBINDINGS_PATH = join(homedir(), '.claude', 'keybindings.json');
 
 function appendCodexHistory(content: string, sessionId?: string): void {
   mkdirSync(dirname(CODEX_HISTORY_PATH), { recursive: true });
@@ -72,6 +73,17 @@ function appendCocoHistory(content: string): void {
 function resetCocoHistory(): void {
   mkdirSync(dirname(COCO_HISTORY_PATH), { recursive: true });
   writeFileSync(COCO_HISTORY_PATH, '');
+}
+
+function writeClaudeKeybindings(bindings: Record<string, string>): void {
+  mkdirSync(dirname(CLAUDE_KEYBINDINGS_PATH), { recursive: true });
+  writeFileSync(CLAUDE_KEYBINDINGS_PATH, JSON.stringify({
+    bindings: [{ context: 'Chat', bindings }],
+  }));
+}
+
+function removeClaudeKeybindings(): void {
+  try { rmSync(CLAUDE_KEYBINDINGS_PATH); } catch { /* absent */ }
 }
 
 function makeTmuxPty(opts?: { confirmCodexSubmit?: boolean; codexSessionId?: string }) {
@@ -216,6 +228,53 @@ describe('writeInput: multiline, tmux mode', () => {
     const backslashCalls = pty.sendText.mock.calls.filter(c => c[0] === '\\').length;
     expect(backslashCalls).toBe(2);
     expect(pty.sendSpecialKeys).toHaveBeenLastCalledWith('Enter');
+  });
+
+  it('claude-code: respects custom chat keybindings where Enter is newline and Meta+Enter submits', async () => {
+    const adapter = createClaudeCodeAdapter('/bin/claude');
+    writeClaudeKeybindings({
+      'cmd+enter': 'chat:submit',
+      'meta+enter': 'chat:submit',
+      enter: 'chat:newline',
+    });
+    try {
+      const pty = makeTmuxPty();
+      await adapter.writeInput(pty, MULTILINE);
+
+      expect(pty.pasteText).not.toHaveBeenCalled();
+      expect(pty.sendText).toHaveBeenCalledWith('first line');
+      expect(pty.sendText).toHaveBeenCalledWith('Session ID: abc-123');
+      expect(pty.sendText).not.toHaveBeenCalledWith('\\');
+      expect(pty.sendSpecialKeys.mock.calls).toEqual([
+        ['Enter'],
+        ['Enter'],
+        ['M-Enter'],
+      ]);
+    } finally {
+      removeClaudeKeybindings();
+    }
+  });
+
+  it('claude-code: fails before typing when only unsupported Cmd+Enter can submit', async () => {
+    const adapter = createClaudeCodeAdapter('/bin/claude');
+    writeClaudeKeybindings({
+      'cmd+enter': 'chat:submit',
+      enter: 'chat:newline',
+    });
+    try {
+      const pty = makeTmuxPty();
+      const result = await adapter.writeInput(pty, MULTILINE);
+
+      expect(pty.pasteText).not.toHaveBeenCalled();
+      expect(pty.sendText).not.toHaveBeenCalled();
+      expect(pty.sendSpecialKeys).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        submitted: false,
+        failureReason: expect.stringContaining('terminal-sendable'),
+      });
+    } finally {
+      removeClaudeKeybindings();
+    }
   });
 
   it.each(PASTE_BUFFER_ADAPTERS)('%s: single pasteText(whole) + delayed Enter, no sendText', async (_name, adapter) => {


### PR DESCRIPTION
## 变更摘要
- 在 `writeInput` 时动态读取 Claude Code Chat 快捷键配置 `~/.claude/keybindings.json`，不修改用户配置。
- 当 `enter` 配置为 `chat:newline` 时，嵌入换行使用普通 Enter，最终提交优先使用可通过终端发送的提交键，例如 `meta+enter` -> `M-Enter`。
- 当只有 `cmd+enter` 这类 tmux/PTY 无法合成的提交键可用时，在写入输入框前失败并返回明确原因，避免污染 Claude Code 输入框。
- 未配置自定义 Chat 快捷键的用户保持原有 Enter 提交行为。

Fixes #20

## 验证
- `pnpm vitest run test/write-input.test.ts`：通过，65 个测试全部通过。
- `pnpm build`：通过，`tsc` 和 dashboard bundle 均完成。
- 真实本地 keybinding 检查未修改 `~/.claude/keybindings.json`；当前配置下 adapter 发送 Enter、Enter，最后发送 M-Enter。
- 已按 handoff 记录完成 tarball 打包安装 smoke test：临时 HOME 下 `botmux start/status/stop` 路径可用。

## 说明
`cmd+enter` 通常无法通过 tmux/PTY 合成发送，因此 adapter 会优先选择 `meta+enter` 这类终端可发送的提交绑定。如果 `enter` 被配置为换行且没有可发送的提交键，botmux 现在会在写入前失败，并报告清晰的配置原因。