### PR TITLE
fix(backend/tmux-pipe): send-keys 失败不再崩 worker + CLI 退出诊断

### DIFF
--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -50,6 +50,15 @@ export class TmuxPipeBackend implements SessionBackend {
   private readonly fifoPath: string;
   private readStream: fs.ReadStream | null = null;
   private readonly dataCbs: Array<(d: string) => void> = [];
+  /** Bounded tail of the decoded output tmux most recently replicated from the
+   *  pane (kept to the last RECENT_OUTPUT_MAX UTF-16 code units, not an exact
+   *  byte count — fine for a diagnostic). Crash diagnostic: when a send fails
+   *  because the pane vanished, capture-pane can no longer read the (now-gone)
+   *  screen — but this text was already received over the pipe and is the
+   *  CLI's actual final stdout/stderr (e.g. a gateway/API error) right before
+   *  it exited. */
+  private recentOutput = '';
+  private static readonly RECENT_OUTPUT_MAX = 4096;
   private readonly exitCbs: Array<(code: number | null, signal: string | null) => void> = [];
   private lifecycleTimer: NodeJS.Timeout | null = null;
   private cols = 200;
@@ -126,6 +135,9 @@ export class TmuxPipeBackend implements SessionBackend {
 
     this.readStream.on('data', (chunk) => {
       const data = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      if (data) {
+        this.recentOutput = (this.recentOutput + data).slice(-TmuxPipeBackend.RECENT_OUTPUT_MAX);
+      }
       for (const cb of this.dataCbs) {
         try { cb(data); } catch { /* listener crash shouldn't kill the stream */ }
       }
@@ -161,37 +173,91 @@ export class TmuxPipeBackend implements SessionBackend {
   sendText(text: string): void {
     if (this.exited) return;
     this.exitCopyModeIfNeeded();
-    execFileSync('tmux', ['send-keys', '-t', this.paneTarget, '-l', '--', text], {
-      stdio: 'ignore',
-      timeout: 5000,
-      env: tmuxEnv(),
+    this.guardedSend('send-keys (text)', () => {
+      execFileSync('tmux', ['send-keys', '-t', this.paneTarget, '-l', '--', text], {
+        stdio: 'ignore',
+        timeout: 5000,
+        env: tmuxEnv(),
+      });
     });
   }
 
   sendSpecialKeys(...keys: string[]): void {
     if (this.exited) return;
     this.exitCopyModeIfNeeded();
-    execFileSync('tmux', ['send-keys', '-t', this.paneTarget, ...keys], {
-      stdio: 'ignore',
-      timeout: 5000,
-      env: tmuxEnv(),
+    this.guardedSend(`send-keys ${keys.join(' ')}`, () => {
+      execFileSync('tmux', ['send-keys', '-t', this.paneTarget, ...keys], {
+        stdio: 'ignore',
+        timeout: 5000,
+        env: tmuxEnv(),
+      });
     });
   }
 
   pasteText(text: string): void {
     if (this.exited) return;
     this.exitCopyModeIfNeeded();
-    execFileSync('tmux', ['load-buffer', '-'], {
-      input: text,
-      stdio: ['pipe', 'ignore', 'ignore'],
-      timeout: 5000,
-      env: tmuxEnv(),
+    this.guardedSend('paste-buffer', () => {
+      execFileSync('tmux', ['load-buffer', '-'], {
+        input: text,
+        stdio: ['pipe', 'ignore', 'ignore'],
+        timeout: 5000,
+        env: tmuxEnv(),
+      });
+      execFileSync('tmux', ['paste-buffer', '-t', this.paneTarget, '-d'], {
+        stdio: 'ignore',
+        timeout: 5000,
+        env: tmuxEnv(),
+      });
     });
-    execFileSync('tmux', ['paste-buffer', '-t', this.paneTarget, '-d'], {
-      stdio: 'ignore',
-      timeout: 5000,
-      env: tmuxEnv(),
-    });
+  }
+
+  /**
+   * Run a tmux write (send-keys / load-buffer / paste-buffer) that must never
+   * crash the worker on failure.
+   *
+   * Background: when the CLI process exits mid-write its tmux session/pane is
+   * destroyed, so the very next `tmux send-keys` returns exit 1. The 1s
+   * lifecycle watcher hasn't fired yet, so `this.exited` is still false and the
+   * guard above doesn't help. Previously execFileSync's synchronous throw
+   * propagated through writeInput → flushPending (a fire-and-forget async with
+   * no .catch) → unhandledRejection, which killed the entire worker process
+   * (and with it every Lark session it served).
+   *
+   * Classify the failure instead of letting it escape:
+   *   - pane GONE  → the CLI exited; convert to a normal onExit so the worker
+   *                  tears the session down and tells the user "CLI exited",
+   *                  exactly like the lifecycle watcher would have.
+   *   - pane ALIVE → a transient tmux hiccup; log and drop the keystroke. The
+   *                  claude-code adapter's JSONL retry/verify loop will catch a
+   *                  non-submission and surface a submit-failure notice.
+   *
+   * Either way this method never throws — every send-keys caller (web-terminal
+   * keys, TUI input, the typing loop) stays crash-safe without its own guard.
+   */
+  private guardedSend(op: string, run: () => void): void {
+    try {
+      run();
+    } catch (err: any) {
+      // A kill()/handlePaneExit() may have flipped exited between the guard
+      // and here; if so the teardown already happened.
+      if (this.exited) return;
+      const alive = this.isPaneAlive();
+      process.stderr.write(
+        `[tmux-pipe-backend] ${op} failed (pane ${alive ? 'ALIVE' : 'GONE'}): ${err?.message ?? err}\n`,
+      );
+      if (!alive) {
+        // Diagnostic: the pane is gone, so capture-pane can't read the final
+        // screen. Instead dump the tail tmux already replicated over the pipe
+        // — the CLI's real last stdout/stderr before it exited, which often
+        // explains WHY it exited (e.g. a gateway/API error line).
+        const tail = this.recentOutput.trim();
+        if (tail) {
+          process.stderr.write(`[tmux-pipe-backend] CLI last output before exit (tail):\n${tail}\n`);
+        }
+        this.handlePaneExit();
+      }
+    }
   }
 
   private exitCopyModeIfNeeded(): void {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2152,7 +2152,7 @@ async function flushPending(): Promise<void> {
       // backend regression). flushPending is invoked fire-and-forget, so an
       // escaping rejection would become an unhandledRejection and crash the
       // worker — exactly the failure mode this change is closing. Contain it.
-      let result: Awaited<ReturnType<typeof cliAdapter.writeInput>>;
+      let result: Awaited<ReturnType<typeof cliAdapter.writeInput>> | undefined;
       try {
         result = await cliAdapter.writeInput(backend, msg);
       } catch (err: any) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2146,7 +2146,24 @@ async function flushPending(): Promise<void> {
         codexBridgeMarkPendingTurn(msg);
       }
       log(`Writing to PTY (flush): "${msg.substring(0, 80)}"`);
-      const result = await cliAdapter.writeInput(backend, msg);
+      // Defense in depth: TmuxPipeBackend's send methods no longer throw on a
+      // dead pane (they fire onExit instead), but writeInput can still throw
+      // for other reasons (fs errors while resolving the JSONL, a future
+      // backend regression). flushPending is invoked fire-and-forget, so an
+      // escaping rejection would become an unhandledRejection and crash the
+      // worker — exactly the failure mode this change is closing. Contain it.
+      let result: Awaited<ReturnType<typeof cliAdapter.writeInput>>;
+      try {
+        result = await cliAdapter.writeInput(backend, msg);
+      } catch (err: any) {
+        log(`writeInput threw: ${err?.message ?? err}`);
+        // If the CLI exited mid-write the backend already fired onExit (which
+        // nulled `backend` and told the user the CLI exited) — nothing more to
+        // do. Otherwise surface it as a submit failure so the message isn't
+        // silently lost.
+        if (backend) scheduleSubmitFailureNotify(msg, undefined, '会话 JSONL', bridgeTurnId);
+        break;
+      }
       // Persist any sessionId the adapter observed via authoritative sources
       // (Claude's pid file, Codex's history). Done independently of submit
       // outcome — the rotation is real even when the current Enter didn't
@@ -2158,7 +2175,10 @@ async function flushPending(): Promise<void> {
         // attributed to this turn.
         if (codexBridgeActive) codexBridgeNotifyCliSessionId(result.cliSessionId);
       }
-      if (result && result.submitted === false) {
+      // `&& backend`: if the CLI exited during this write (pane gone → onExit
+      // nulled backend) the user already got a "CLI exited" notice; don't also
+      // nag that the submit wasn't confirmed.
+      if (result && result.submitted === false && backend) {
         scheduleSubmitFailureNotify(msg, result.recheck, '会话 JSONL', bridgeTurnId, result.failureReason);
       }
       // Codex bridge: stop after one writeInput per idle cycle. Codex's

--- a/test/tmux-pipe-backend.test.ts
+++ b/test/tmux-pipe-backend.test.ts
@@ -38,7 +38,7 @@ vi.mock('node:fs', async () => {
 });
 
 import { execSync, execFileSync, spawnSync } from 'node:child_process';
-import { unlinkSync } from 'node:fs';
+import { unlinkSync, createReadStream } from 'node:fs';
 import { TmuxPipeBackend, normaliseCaptureLineEndings } from '../src/adapters/backend/tmux-pipe-backend.js';
 
 const mockedExecSync = vi.mocked(execSync);
@@ -395,6 +395,92 @@ describe('TmuxPipeBackend lifecycle watcher', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe('TmuxPipeBackend send failure handling', () => {
+  // Regression: a CLI that exits mid-write destroys its tmux session, so the
+  // next `tmux send-keys` returns exit 1. Previously execFileSync's throw
+  // propagated through writeInput → flushPending (fire-and-forget async) →
+  // unhandledRejection and killed the whole worker. The send methods must
+  // never throw: pane-gone is converted to a normal onExit, a transient
+  // failure on a live pane is logged and dropped.
+  it('fires onExit (does NOT throw) when send-keys fails and the pane is gone', () => {
+    const be = new TmuxPipeBackend('bmx-dead', { ownsSession: true });
+    const exits: Array<[number | null, string | null]> = [];
+    be.onExit((c, s) => exits.push([c, s]));
+    be.spawn('', [], spawnOpts());
+
+    // The actual send-keys (execFileSync) fails…
+    mockedExecFileSync.mockImplementation((_bin: any, args: any) => {
+      if ((args as string[]).includes('send-keys')) throw new Error('no server running');
+      return '' as any;
+    });
+    // …and the liveness probe (execSync display-message) also fails ⇒ pane GONE.
+    mockedExecSync.mockImplementation(() => { throw new Error('no server running'); });
+
+    expect(() => be.sendSpecialKeys('Enter')).not.toThrow();
+    expect(exits).toEqual([[1, null]]);
+  });
+
+  it('drops the write (no throw, no exit) when send-keys fails but the pane is alive', () => {
+    const be = new TmuxPipeBackend('bmx-live', { ownsSession: true });
+    const exits: Array<[number | null, string | null]> = [];
+    be.onExit((c, s) => exits.push([c, s]));
+    be.spawn('', [], spawnOpts());
+
+    mockedExecFileSync.mockImplementation((_bin: any, args: any) => {
+      if ((args as string[]).includes('send-keys')) throw new Error('transient tmux error');
+      return '' as any;
+    });
+    // Liveness probe succeeds ⇒ pane ALIVE ⇒ transient error, just dropped.
+    mockedExecSync.mockReturnValue('' as any);
+
+    expect(() => be.sendText('hi')).not.toThrow();
+    expect(exits).toEqual([]);
+  });
+
+  it('dumps the piped output tail (CLI final stdout/stderr) when the pane is gone', () => {
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const be = new TmuxPipeBackend('bmx-dead3', { ownsSession: true });
+      be.spawn('', [], spawnOpts());
+      // Drive the fifo data handler so recentOutput holds the CLI's last bytes.
+      const stream: any = vi.mocked(createReadStream).mock.results.at(-1)!.value;
+      stream.emit('data', Buffer.from('Error: gateway 502 — model unavailable\n'));
+
+      mockedExecFileSync.mockImplementation((_bin: any, args: any) => {
+        if ((args as string[]).includes('send-keys')) throw new Error('no server running');
+        return '' as any;
+      });
+      mockedExecSync.mockImplementation(() => { throw new Error('no server running'); });
+
+      be.sendSpecialKeys('Enter');
+
+      const dumped = errSpy.mock.calls.map(c => String(c[0])).join('');
+      expect(dumped).toContain('CLI last output before exit');
+      expect(dumped).toContain('gateway 502 — model unavailable');
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('paste failure with a gone pane fires onExit instead of throwing', () => {
+    const be = new TmuxPipeBackend('bmx-dead2', { ownsSession: true });
+    const exits: Array<[number | null, string | null]> = [];
+    be.onExit((c, s) => exits.push([c, s]));
+    be.spawn('', [], spawnOpts());
+
+    mockedExecFileSync.mockImplementation((_bin: any, args: any) => {
+      if ((args as string[]).includes('load-buffer') || (args as string[]).includes('paste-buffer')) {
+        throw new Error('no server running');
+      }
+      return '' as any;
+    });
+    mockedExecSync.mockImplementation(() => { throw new Error('no server running'); });
+
+    expect(() => be.pasteText('hello')).not.toThrow();
+    expect(exits).toEqual([[1, null]]);
   });
 });
 


### PR DESCRIPTION
## 背景
排查「botmux 启动 CLI 异常、连带整个 worker 崩溃」时定位到:tmux 模式下向 CLI 逐行注入消息,若 CLI 中途退出、其 tmux 会话随之销毁,下一个 `tmux send-keys` 返回 exit 1;此前 execFileSync 同步抛错经 `writeInput → flushPending`(fire-and-forget async,无 .catch)冒泡成 unhandledRejection,**打死整个 worker**(连带它服务的其它会话)。

## 改动
- `TmuxPipeBackend` 的 sendText/sendSpecialKeys/pasteText 统一走 `guardedSend`:pane 已消失 → 当正常退出走 `handlePaneExit`,并 dump pipe 已转发的最近输出尾巴(`recentOutput`)作为「CLI 退出前最后输出」诊断;pane 仍存活 → 记日志丢弃。send 方法**不再抛错**,所有调用方无需各自加保护。
- `worker.flushPending` 对 writeInput 加 try/catch 兜底;CLI 已退出时不再重复发提交失败提示。
- 回归单测覆盖 pane GONE/ALIVE + 诊断 dump(test/tmux-pipe-backend.test.ts,30 tests)。

## 排查结论(供参考)
本次现场问题的**触发器是 macOS Homebrew tmux 3.6a 构建**(在 Linux 上编译 3.6a 做对照实验复现不出来,3.3a/3.6a/3.6a+extended-keys 全部正常),与 botmux 代码无关。但 worker 不该因单次 send-keys 失败而崩溃,故合入此健壮性修复 + 诊断。

之前 PR 里附带的「最低 tmux 版本校验」已按 review 意见**删除**(它基于「版本太老」的旧判断,挡不住「版本太新」的 3.6a)。

## 验证
- `pnpm exec tsc --noEmit` ✅
- `pnpm vitest run test/tmux-pipe-backend.test.ts` ✅ 30 tests