### PR TITLE
fix(botmux): 优化 CoCo 粘贴和多 bot 线程路由

### DIFF
--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -269,7 +269,9 @@ export class TmuxBackend implements SessionBackend {
 
   /**
    * Paste text into the tmux pane via load-buffer + paste-buffer.
-   * Tmux automatically wraps in bracketed paste if the pane has it enabled.
+   * The -p flag asks tmux to insert bracketed-paste markers
+   * (\e[200~ … \e[201~) when the application has requested bracketed paste,
+   * so TUI apps (CoCo/Ink, etc.) can detect paste boundaries reliably.
    * Safe for multiline content (unlike sendText where \n becomes Enter).
    */
   pasteText(text: string): void {
@@ -280,7 +282,7 @@ export class TmuxBackend implements SessionBackend {
       timeout: 5000,
       env: tmuxEnv(),
     });
-    execFileSync('tmux', ['paste-buffer', '-t', this.cmdTarget, '-d'], {
+    execFileSync('tmux', ['paste-buffer', '-t', this.cmdTarget, '-d', '-p'], {
       stdio: 'ignore',
       timeout: 5000,
       env: tmuxEnv(),

--- a/src/adapters/cli/coco.ts
+++ b/src/adapters/cli/coco.ts
@@ -1,5 +1,5 @@
 import { existsSync, statSync, openSync, readSync, closeSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { homedir, platform } from 'node:os';
 import { join } from 'node:path';
 import { resolveCommand } from './registry.js';
 import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
@@ -11,7 +11,9 @@ import type { CliAdapter, PtyHandle } from './types.js';
  *  the Codex adapter uses ~/.codex/history.jsonl: write → poll for our
  *  marker → retry Enter if missing → return {submitted:false, recheck}
  *  on final failure so worker can surface a Lark warning. */
-const HISTORY_PATH = join(homedir(), '.cache', 'coco', 'history.jsonl');
+const HISTORY_PATH = platform() === 'darwin'
+  ? join(homedir(), 'Library', 'Caches', 'coco', 'history.jsonl')
+  : join(homedir(), '.cache', 'coco', 'history.jsonl');
 
 function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -128,7 +130,7 @@ export function createCocoAdapter(pathOverride?: string): CliAdapter {
       // OFF after slash commands; CoCo on a fresh-spawn message doesn't have
       // that concern.
       //
-      // Verification (unchanged): poll ~/.cache/coco/history.jsonl for the
+      // Verification (unchanged): poll CoCo's platform-specific history.jsonl for the
       // user-submit line whose decoded `content` starts with our prefix.
       // Retry Enter up to 3 times, then return {submitted:false, recheck}
       // for the worker's deferred recheck + Lark warning path.


### PR DESCRIPTION
## 背景

排查 CoCo / Trae CLI 在 botmux tmux 模式下的多行输入提交链路时，发现有几类问题需要一起修复：

1. CoCo 的全局 `history.jsonl` 路径是平台相关的：macOS 写入 `~/Library/Caches/coco/history.jsonl`，Linux 写入 `~/.cache/coco/history.jsonl`。此前 adapter 和测试都只按 Linux 路径处理，macOS 下会误读不到真实提交历史，影响提交确认、retry/failure 判断。
2. CoCo 依赖 tmux `paste-buffer` 传递多行内容。普通 botmux tmux 会话当前实际走 `TmuxPipeBackend`，不是 legacy `TmuxBackend`；只改 `TmuxBackend` 会漏掉主路径。两套 backend 的 paste 行为需要保持一致。
3. 多 bot 群聊中，已有线程后续回复是否允许免 `@mention`，不应该再由群内 bot 总数决定。真正需要 disambiguate 的场景是同一个 thread/chat conversation unit 已经有 peer bot active session；如果当前 bot 是唯一 session owner，用户在该线程内继续无 `@mention` 回复应能路由回当前 bot。
4. Copilot review 指出 `hasPeerSession` 在 group follow-up 热路径上同步扫描 session 文件。已补充 daemon 侧短 TTL 缓存，避免同一 conversation unit 的高频消息重复触发 `readFileSync + JSON.parse` 扫描。

## 改动

- `src/adapters/cli/coco.ts`
  - CoCo history path 改为平台相关：macOS 使用 `~/Library/Caches/coco/history.jsonl`，其他平台保持 `~/.cache/coco/history.jsonl`。
  - 更新注释，避免继续写死 Linux 路径。
- `src/adapters/backend/tmux-backend.ts`
  - `pasteText()` 的 `tmux paste-buffer` 增加 `-p`，在应用启用 bracketed paste 时插入 paste 边界控制码。
- `src/adapters/backend/tmux-pipe-backend.ts`
  - 同步 `pasteText()` 的 `paste-buffer -p`，覆盖当前普通 tmux 会话实际使用的 backend。
- `src/im/lark/event-dispatcher.ts` / `src/daemon.ts`
  - 新增 `hasPeerSession` handler。
  - group message permission gating 改为：当前 bot owns session 且发送人 allowed 且没有 peer session 时，允许免 `@mention`；存在 peer session 时仍要求 `@mention`。
  - `hasPeerSession` 通过 `PeerSessionCache` 做 1s TTL 缓存，按 `(scope, rootMessageId/chatId)` 缓存跨 bot session-store 查询结果。
- `src/core/peer-session-cache.ts`
  - 新增 daemon 侧 peer-session TTL cache，缓存 session-store 同步扫描结果，并按当前 app id 计算是否存在 peer。
- 测试
  - `test/write-input.test.ts` 使用与 adapter 一致的平台相关 CoCo history path，保留 retry/failure 回归用例。
  - `test/tmux-pipe-backend.test.ts` 覆盖 `paste-buffer -d -p`。
  - `test/event-dispatcher.test.ts` 覆盖 sole owner 免 `@mention` 与 peer owner 需要 `@mention` 两条路径。
  - `test/peer-session-cache.test.ts` 覆盖 TTL 内复用查询、TTL 过期刷新、chat-scope 按 chatId 查询且排除当前 app。

## 排查结论

本次改动中 review 发现的关键问题已修复：

- CoCo 测试 helper 如果仍写旧路径，会让 adapter 在 macOS 下误走 fresh-install shortcut，掩盖 retry/failure 回归。
- `paste-buffer -p` 必须同步到 `TmuxPipeBackend`，否则正常 botmux tmux 会话路径不会得到 bracketed paste 修复。
- `hasPeerSession` 不能每次 group follow-up 都同步扫 session 文件；现已在 daemon 侧增加 1s TTL 缓存，降低热路径阻塞风险。TTL 很短，跨 daemon session 变化最多短暂延迟；同一 conversation unit 高频消息不会重复扫盘。

## 验证

- `pnpm exec tsc --noEmit` ✅
- `pnpm vitest run test/peer-session-cache.test.ts test/event-dispatcher.test.ts` ✅ 60 tests
- `pnpm vitest run test/tmux-pipe-backend.test.ts` ✅ 26 tests
- `pnpm vitest run test/write-input.test.ts` ✅ 68 tests
- `git diff --check` ✅

备注：本机 Node 为 `v20.20.2`，`pnpm` 会提示项目期望 `node >=22`，但上述验证命令均已通过。
