### PR TITLE
feat: bind directory when creating groups

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,7 @@
  */
 import { execSync, spawnSync, spawn } from 'node:child_process';
 import { existsSync, mkdirSync, copyFileSync, readFileSync, writeFileSync, renameSync, readdirSync, readlinkSync, appendFileSync, statSync, unlinkSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { createInterface } from 'node:readline';
@@ -2761,6 +2761,7 @@ botmux create-group — 用一组机器人新建飞书群
 
 用法:
   botmux create-group --bot <name|larkAppId> [--bot ...] [--name "群名"]
+                      [--working-dir <path>]
 
 参数:
   --bot <ref>     至少一个，可多次。ref 推荐用 bot 显示名（同 botmux send 的 @<name>）或完整 larkAppId；
@@ -2768,12 +2769,16 @@ botmux create-group — 用一组机器人新建飞书群
                   bots.json 中第一个。重名 → 取 bots.json 中第一个匹配，stderr 打 warning。
                   重复 ref → 自动去重保留首次顺序。
   --name <群名>   可选；不传则用飞书默认无名群。
+  --working-dir <path>
+                 可选；创建成功后，把新群为所有成功入群的 bot 绑定到该目录（等价于逐个 /oncall bind），
+                 下次在群里开新话题时直接使用该目录，跳过仓库选择卡片。也可写作 --cwd / --dir。
 
 行为:
   - 第一个解析到的 bot 作为 creator（决定建群身份 + 初始群主 + open_id app scope）。
   - 邀请用户 / 转让群主 / @通知 对象都从 creator 的 resolvedAllowedUsers 取首个 open_id（email 自动转换；
     转不出来或为空则跳过对应步骤，stderr warning）。
   - 不依赖 botmux 会话，任何环境都能跑。
+  - --working-dir 会先校验路径存在且是目录；绑定失败不会重复建群，会在 stderr 给出逐 bot 结果。
 
 输出协议（skill 友好）:
   - 成功（即使 transfer/notify 部分失败）：stdout 单行 chatId，exit 0；stderr 打人类提示 + applink。
@@ -2786,6 +2791,37 @@ botmux create-group — 用一组机器人新建飞书群
 
   const botRefs = argValues(rest, '--bot');
   const name = argValue(rest, '--name');
+  const workingDirArg = argValue(rest, '--working-dir', '--cwd', '--dir');
+
+  let bindWorkingDir: string | undefined;
+  let bindWorkingDirResolved: string | undefined;
+  if (workingDirArg !== undefined) {
+    const trimmed = workingDirArg.trim();
+    if (!trimmed) {
+      console.error('--working-dir 不能为空。');
+      process.exit(1);
+    }
+    const expanded = trimmed.startsWith('~/') ? join(homedir(), trimmed.slice(2)) : trimmed;
+    const resolvedPath = resolve(expanded);
+    if (!existsSync(resolvedPath)) {
+      console.error(`--working-dir 路径不存在: ${resolvedPath}`);
+      process.exit(1);
+    }
+    let isDir = false;
+    try { isDir = statSync(resolvedPath).isDirectory(); }
+    catch (err: any) {
+      console.error(`--working-dir 无法读取: ${resolvedPath} (${err?.message ?? err})`);
+      process.exit(1);
+    }
+    if (!isDir) {
+      console.error(`--working-dir 不是目录: ${resolvedPath}`);
+      process.exit(1);
+    }
+    // Keep the user's spelling in bots.json, matching `/oncall bind`, while
+    // still showing the resolved path in CLI output for typo diagnostics.
+    bindWorkingDir = trimmed;
+    bindWorkingDirResolved = resolvedPath;
+  }
 
   if (botRefs.length === 0) {
     console.error('用法: botmux create-group --bot <name|larkAppId> [--bot ...] [--name "群名"]');
@@ -2868,6 +2904,7 @@ botmux create-group — 用一组机器人新建飞书群
       userOpenIds: targetOpenId ? [targetOpenId] : [],
       transferOwnerTo: targetOpenId,
       notifyOwnerOpenId: targetOpenId,
+      bindWorkingDir,
     });
   } catch (err: any) {
     console.error(`建群失败: ${err?.message ?? err}`);
@@ -2896,6 +2933,14 @@ botmux create-group — 用一组机器人新建飞书群
     console.error(`⚠️  @通知发送失败: ${result.notifyError}`);
   } else if (result.notifyMessageId) {
     console.error(`✅ @通知已发送 (msg ${result.notifyMessageId})`);
+  }
+  if (bindWorkingDir) {
+    const ok = result.oncallBindings.filter(b => b.ok).length;
+    const failed = result.oncallBindings.filter(b => !b.ok);
+    console.error(`✅ oncall 绑定目录：${bindWorkingDir} → ${bindWorkingDirResolved}（成功 ${ok}/${result.oncallBindings.length}）`);
+    for (const b of failed) {
+      console.error(`⚠️  ${b.larkAppId} 绑定失败: ${b.error ?? 'unknown'}`);
+    }
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,12 +18,13 @@
  */
 import { execSync, spawnSync, spawn } from 'node:child_process';
 import { existsSync, mkdirSync, copyFileSync, readFileSync, writeFileSync, renameSync, readdirSync, readlinkSync, appendFileSync, statSync, unlinkSync } from 'node:fs';
-import { join, dirname, resolve } from 'node:path';
+import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { createInterface } from 'node:readline';
 import { createRequire } from 'node:module';
 import { createHmac, randomBytes } from 'node:crypto';
+import { validateWorkingDir } from './core/working-dir.js';
 import { enableAutostart, disableAutostart, autostartStatus, refreshAutostart } from './autostart.js';
 import { tmuxEnv } from './setup/ensure-tmux.js';
 import { writeBotsJsonAtomic as writeBotsAtomic } from './setup/bots-store.js';
@@ -2801,26 +2802,15 @@ botmux create-group — 用一组机器人新建飞书群
       console.error('--working-dir 不能为空。');
       process.exit(1);
     }
-    const expanded = trimmed.startsWith('~/') ? join(homedir(), trimmed.slice(2)) : trimmed;
-    const resolvedPath = resolve(expanded);
-    if (!existsSync(resolvedPath)) {
-      console.error(`--working-dir 路径不存在: ${resolvedPath}`);
-      process.exit(1);
-    }
-    let isDir = false;
-    try { isDir = statSync(resolvedPath).isDirectory(); }
-    catch (err: any) {
-      console.error(`--working-dir 无法读取: ${resolvedPath} (${err?.message ?? err})`);
-      process.exit(1);
-    }
-    if (!isDir) {
-      console.error(`--working-dir 不是目录: ${resolvedPath}`);
+    const validation = validateWorkingDir(trimmed);
+    if (!validation.ok) {
+      console.error(`--working-dir ${validation.error}`);
       process.exit(1);
     }
     // Keep the user's spelling in bots.json, matching `/oncall bind`, while
     // still showing the resolved path in CLI output for typo diagnostics.
     bindWorkingDir = trimmed;
-    bindWorkingDirResolved = resolvedPath;
+    bindWorkingDirResolved = validation.resolvedPath;
   }
 
   if (botRefs.length === 0) {

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -2,8 +2,7 @@
  * Command handler — processes /slash commands from users.
  * Extracted from daemon.ts for modularity.
  */
-import { existsSync, statSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync } from 'node:fs';
 import { config } from '../config.js';
 import { getBot, getAllBots } from '../bot-registry.js';
 import * as sessionStore from '../services/session-store.js';
@@ -16,6 +15,7 @@ import { deleteMessage } from '../im/lark/client.js';
 import { logger } from '../utils/logger.js';
 import { killWorker, forkWorker, forkAdoptWorker, getCurrentCliVersion } from './worker-pool.js';
 import { expandHome, getSessionWorkingDir, getProjectScanDir, getProjectScanDirs } from './session-manager.js';
+import { validateWorkingDir } from './working-dir.js';
 import { discoverAdoptableSessions, validateAdoptTarget, type AdoptableSession } from './session-discovery.js';
 import { generateAuthUrl, getTokenStatus } from '../utils/user-token.js';
 import { bindOncall, unbindOncall, getOncallStatus } from '../services/oncall-store.js';
@@ -46,26 +46,9 @@ export interface SlashCommandInvocation {
 
 const MULTILINE_COMMANDS = new Set(['/schedule']);
 
-/**
- * Validate a user-supplied path for `/cd` and `/oncall bind`. Trust model is
- * "owner explicitly chose a directory" — the daemon already runs CLI prompts
- * with full filesystem access, so an allowlist would be theater. We only do
- * the typo guards: exists and is a directory.
- */
-export function validateWorkingDir(input: string, locale?: Locale): { ok: true; resolvedPath: string } | { ok: false; error: string } {
-  const resolvedPath = resolve(expandHome(input));
-  if (!existsSync(resolvedPath)) {
-    return { ok: false, error: t('cmd.cd.dir_not_exist', { path: resolvedPath }, locale) };
-  }
-  let isDir = false;
-  try { isDir = statSync(resolvedPath).isDirectory(); } catch (e: any) {
-    return { ok: false, error: t('cmd.cd.cannot_read', { path: resolvedPath, msg: e?.message ?? String(e) }, locale) };
-  }
-  if (!isDir) {
-    return { ok: false, error: t('cmd.cd.not_a_directory', { path: resolvedPath }, locale) };
-  }
-  return { ok: true, resolvedPath };
-}
+// `validateWorkingDir` now lives in ./working-dir.js (leaf module the CLI can
+// import without the daemon graph); re-exported here for existing callers.
+export { validateWorkingDir };
 
 /**
  * Parse a force-topic invocation: `/t [prompt]` or `/topic [prompt]`.

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -448,6 +448,7 @@ ipcRoute('POST', '/api/groups/create', async (req, res) => {
     userOpenIds?: unknown;
     transferOwnerTo?: unknown;
     notifyOwnerOpenId?: unknown;
+    bindWorkingDir?: unknown;
   };
   try {
     body = await readJsonBody<{
@@ -456,6 +457,7 @@ ipcRoute('POST', '/api/groups/create', async (req, res) => {
       userOpenIds?: string[];
       transferOwnerTo?: string;
       notifyOwnerOpenId?: string;
+      bindWorkingDir?: string;
     }>(req);
   } catch {
     return jsonRes(res, 400, { error: 'bad_json' });
@@ -477,6 +479,19 @@ ipcRoute('POST', '/api/groups/create', async (req, res) => {
   const notifyTo = typeof body.notifyOwnerOpenId === 'string' && body.notifyOwnerOpenId.trim()
     ? body.notifyOwnerOpenId.trim()
     : null;
+  const bindWorkingDir = typeof body.bindWorkingDir === 'string' ? body.bindWorkingDir.trim() : '';
+  let bindResolvedPath: string | undefined;
+  if (bindWorkingDir) {
+    const resolvedPath = resolve(expandHome(bindWorkingDir));
+    if (!existsSync(resolvedPath)) {
+      return jsonRes(res, 400, { ok: false, error: `目录不存在：${resolvedPath}` });
+    }
+    let isDir = false;
+    try { isDir = statSync(resolvedPath).isDirectory(); }
+    catch (e: any) { return jsonRes(res, 400, { ok: false, error: `无法读取路径：${resolvedPath}（${e?.message ?? e}）` }); }
+    if (!isDir) return jsonRes(res, 400, { ok: false, error: `路径不是目录：${resolvedPath}` });
+    bindResolvedPath = resolvedPath;
+  }
   try {
     const r = await createGroupWithBots({
       creatorLarkAppId: cachedLarkAppId,
@@ -485,8 +500,9 @@ ipcRoute('POST', '/api/groups/create', async (req, res) => {
       userOpenIds: userIds,
       transferOwnerTo: transferTo ?? undefined,
       notifyOwnerOpenId: notifyTo ?? undefined,
+      bindWorkingDir: bindWorkingDir || undefined,
     });
-    jsonRes(res, 200, r);
+    jsonRes(res, 200, bindResolvedPath ? { ...r, bindResolvedPath } : r);
   } catch (e) {
     jsonRes(res, 502, { ok: false, error: String((e as Error).message ?? e) });
   }

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -1,7 +1,5 @@
 // src/core/dashboard-ipc-server.ts
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
-import { existsSync, statSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { logger } from '../utils/logger.js';
 import * as sessionStore from '../services/session-store.js';
 import * as scheduleStore from '../services/schedule-store.js';
@@ -16,7 +14,7 @@ import { resumeSession } from './session-manager.js';
 import { getCliDisplayName } from '../im/lark/card-builder.js';
 import { locateLimiter } from './dashboard-locate.js';
 import { dashboardEventBus } from './dashboard-events.js';
-import { expandHome } from './session-manager.js';
+import { validateWorkingDir } from './working-dir.js';
 import {
   composeRowFromActive,
   composeRowFromClosed,
@@ -362,14 +360,9 @@ ipcRoute('PUT', '/api/oncall/:chatId', async (req, res, p) => {
   if (!workingDir) return jsonRes(res, 400, { ok: false, error: 'workingDir_required' });
 
   // Same validation as /oncall bind in Lark — exists + is a directory.
-  const resolvedPath = resolve(expandHome(workingDir));
-  if (!existsSync(resolvedPath)) {
-    return jsonRes(res, 400, { ok: false, error: `目录不存在：${resolvedPath}` });
-  }
-  let isDir = false;
-  try { isDir = statSync(resolvedPath).isDirectory(); }
-  catch (e: any) { return jsonRes(res, 400, { ok: false, error: `无法读取路径：${resolvedPath}（${e?.message ?? e}）` }); }
-  if (!isDir) return jsonRes(res, 400, { ok: false, error: `路径不是目录：${resolvedPath}` });
+  const v = validateWorkingDir(workingDir);
+  if (!v.ok) return jsonRes(res, 400, { ok: false, error: v.error });
+  const resolvedPath = v.resolvedPath;
 
   const r = await oncallStore.bindOncall(cachedLarkAppId, p.chatId, workingDir);
   if (!r.ok) return jsonRes(res, 400, r);
@@ -422,14 +415,9 @@ ipcRoute('PUT', '/api/bot-default-oncall', async (req, res) => {
   let resolvedPath = '';
   if (enabled) {
     if (!workingDir) return jsonRes(res, 400, { ok: false, error: 'workingDir_required' });
-    resolvedPath = resolve(expandHome(workingDir));
-    if (!existsSync(resolvedPath)) {
-      return jsonRes(res, 400, { ok: false, error: `目录不存在：${resolvedPath}` });
-    }
-    let isDir = false;
-    try { isDir = statSync(resolvedPath).isDirectory(); }
-    catch (e: any) { return jsonRes(res, 400, { ok: false, error: `无法读取路径：${resolvedPath}（${e?.message ?? e}）` }); }
-    if (!isDir) return jsonRes(res, 400, { ok: false, error: `路径不是目录：${resolvedPath}` });
+    const v = validateWorkingDir(workingDir);
+    if (!v.ok) return jsonRes(res, 400, { ok: false, error: v.error });
+    resolvedPath = v.resolvedPath;
   }
 
   const r = await oncallStore.updateBotDefaultOncall(cachedLarkAppId, { enabled, workingDir });
@@ -482,15 +470,9 @@ ipcRoute('POST', '/api/groups/create', async (req, res) => {
   const bindWorkingDir = typeof body.bindWorkingDir === 'string' ? body.bindWorkingDir.trim() : '';
   let bindResolvedPath: string | undefined;
   if (bindWorkingDir) {
-    const resolvedPath = resolve(expandHome(bindWorkingDir));
-    if (!existsSync(resolvedPath)) {
-      return jsonRes(res, 400, { ok: false, error: `目录不存在：${resolvedPath}` });
-    }
-    let isDir = false;
-    try { isDir = statSync(resolvedPath).isDirectory(); }
-    catch (e: any) { return jsonRes(res, 400, { ok: false, error: `无法读取路径：${resolvedPath}（${e?.message ?? e}）` }); }
-    if (!isDir) return jsonRes(res, 400, { ok: false, error: `路径不是目录：${resolvedPath}` });
-    bindResolvedPath = resolvedPath;
+    const v = validateWorkingDir(bindWorkingDir);
+    if (!v.ok) return jsonRes(res, 400, { ok: false, error: v.error });
+    bindResolvedPath = v.resolvedPath;
   }
   try {
     const r = await createGroupWithBots({

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -5,7 +5,7 @@
  */
 import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { homedir } from 'node:os';
+import { expandHome } from './working-dir.js';
 import { config } from '../config.js';
 import * as sessionStore from '../services/session-store.js';
 import * as messageQueue from '../services/message-queue.js';
@@ -36,9 +36,7 @@ function sessionLastMessageAtMs(session: { createdAt?: string; lastMessageAt?: s
 
 // ─── Path helpers ────────────────────────────────────────────────────────────
 
-export function expandHome(p: string): string {
-  return p.startsWith('~') ? join(homedir(), p.slice(1)) : p;
-}
+export { expandHome };
 
 export function getSessionWorkingDir(ds?: DaemonSession): string {
   if (ds?.workingDir) return expandHome(ds.workingDir);

--- a/src/core/working-dir.ts
+++ b/src/core/working-dir.ts
@@ -1,0 +1,33 @@
+/**
+ * Working-directory path helpers, kept dependency-light so the CLI entrypoint
+ * can import them without dragging in the daemon graph (worker-pool, PTY, …).
+ */
+import { existsSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { homedir } from 'node:os';
+import { t, type Locale } from '../i18n/index.js';
+
+export function expandHome(p: string): string {
+  return p.startsWith('~') ? join(homedir(), p.slice(1)) : p;
+}
+
+/**
+ * Validate a user-supplied path for `/cd` and `/oncall bind`. Trust model is
+ * "owner explicitly chose a directory" — the daemon already runs CLI prompts
+ * with full filesystem access, so an allowlist would be theater. We only do
+ * the typo guards: exists and is a directory.
+ */
+export function validateWorkingDir(input: string, locale?: Locale): { ok: true; resolvedPath: string } | { ok: false; error: string } {
+  const resolvedPath = resolve(expandHome(input));
+  if (!existsSync(resolvedPath)) {
+    return { ok: false, error: t('cmd.cd.dir_not_exist', { path: resolvedPath }, locale) };
+  }
+  let isDir = false;
+  try { isDir = statSync(resolvedPath).isDirectory(); } catch (e: any) {
+    return { ok: false, error: t('cmd.cd.cannot_read', { path: resolvedPath, msg: e?.message ?? String(e) }, locale) };
+  }
+  if (!isDir) {
+    return { ok: false, error: t('cmd.cd.not_a_directory', { path: resolvedPath }, locale) };
+  }
+  return { ok: true, resolvedPath };
+}

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -542,7 +542,7 @@ const server = createServer(async (req, res) => {
     // are app-scoped, so creator daemon and operator open_id come from the
     // SAME bot by construction. See dashboard/operator-selector.ts.
     if (req.method === 'POST' && url.pathname === '/api/groups/create') {
-      let parsed: { name?: unknown; larkAppIds?: unknown; userOpenIds?: unknown };
+      let parsed: { name?: unknown; larkAppIds?: unknown; userOpenIds?: unknown; bindWorkingDir?: unknown };
       try {
         const chunks: Buffer[] = [];
         for await (const c of req) chunks.push(c as Buffer);
@@ -587,6 +587,9 @@ const server = createServer(async (req, res) => {
         // Feishu push notification — being a chat member alone doesn't always
         // surface the chat in their sidebar (esp. mobile).
         notifyOwnerOpenId: autoInvited ?? undefined,
+        bindWorkingDir: typeof parsed.bindWorkingDir === 'string' && parsed.bindWorkingDir.trim()
+          ? parsed.bindWorkingDir.trim()
+          : undefined,
       };
       const upstream = await fetch(
         `http://127.0.0.1:${creator.ipcPort}/api/groups/create`,

--- a/src/dashboard/web/groups.ts
+++ b/src/dashboard/web/groups.ts
@@ -100,6 +100,11 @@ export async function renderGroupsPage(root: HTMLElement) {
             <span>Group name <small>(optional)</small></span>
             <input type="text" name="name" placeholder="e.g. AI ChangeLog" maxlength="60">
           </label>
+          <label class="form-row">
+            <span>Bind directory <small>(optional)</small></span>
+            <input type="text" name="bindWorkingDir" placeholder="e.g. ~/projects/botmux">
+            <small>Create the group and bind every invited bot to this directory, so new topics skip the repo picker.</small>
+          </label>
           <fieldset>
             <legend>Bots</legend>
             ${renderBotCheckboxes(allBots)}
@@ -118,6 +123,7 @@ export async function renderGroupsPage(root: HTMLElement) {
       ev.preventDefault();
       const fd = new FormData(ev.target as HTMLFormElement);
       const name = ((fd.get('name') as string) ?? '').trim();
+      const bindWorkingDir = ((fd.get('bindWorkingDir') as string) ?? '').trim();
       const ids = fd.getAll('bot') as string[];
       if (ids.length === 0) { alert('Pick at least one bot.'); return; }
       const submitBtn = (ev.target as HTMLFormElement).querySelector<HTMLButtonElement>('button[type=submit]');
@@ -126,7 +132,7 @@ export async function renderGroupsPage(root: HTMLElement) {
         const r = await fetch('/api/groups/create', {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ name: name || undefined, larkAppIds: ids }),
+          body: JSON.stringify({ name: name || undefined, larkAppIds: ids, bindWorkingDir: bindWorkingDir || undefined }),
         });
         const respBody = await r.json();
         if (respBody.ok && respBody.chatId) {
@@ -221,6 +227,14 @@ export async function renderGroupsPage(root: HTMLElement) {
     const transferErr = resp.transferError as string | null | undefined;
     const notifyMsgId = resp.notifyMessageId as string | null | undefined;
     const notifyErr = resp.notifyError as string | null | undefined;
+    const binds = Array.isArray(resp.oncallBindings) ? resp.oncallBindings as any[] : [];
+    const bindOk = binds.filter(b => b?.ok).length;
+    const bindFailed = binds.filter(b => !b?.ok);
+    const bindNote = binds.length > 0
+      ? bindFailed.length === 0
+        ? `<p class="hint-ok">已绑定目录：<code>${escapeHtml(resp.bindResolvedPath ?? '')}</code>（${bindOk}/${binds.length} bots）</p>`
+        : `<p class="hint-warn">目录绑定部分失败：成功 ${bindOk}/${binds.length}。${bindFailed.map(b => `<br><code>${escapeHtml(b.larkAppId ?? '?')}</code>: ${escapeHtml(b.error ?? 'unknown')}`).join('')}</p>`
+      : '';
     let inviteNote: string;
     if (auto) {
       const transferLine = ownerTo
@@ -250,6 +264,7 @@ export async function renderGroupsPage(root: HTMLElement) {
         <p><b>chatId:</b> <code>${escapeHtml(chatId)}</code> <button type="button" data-copy="${escapeHtml(chatId)}">copy</button></p>
         <p><b>创建者:</b> <code>${escapeHtml(resp.creator ?? '?')}</code></p>
         ${inviteNote}
+        ${bindNote}
         ${invalidNote ? `<ul>${invalidNote}</ul>` : ''}
         <div class="actions">
           <a class="btn-link primary" href="${appLink}" target="_blank" rel="noopener">↗ 打开新群</a>

--- a/src/services/group-creator.ts
+++ b/src/services/group-creator.ts
@@ -19,6 +19,7 @@
  */
 import { createChat, transferChatOwner } from './groups-store.js';
 import { sendMessage } from '../im/lark/client.js';
+import { bindOncall } from './oncall-store.js';
 
 export interface CreateGroupOpts {
   creatorLarkAppId: string;
@@ -29,6 +30,10 @@ export interface CreateGroupOpts {
   userOpenIds?: string[];
   transferOwnerTo?: string;
   notifyOwnerOpenId?: string;
+  /** Optional working directory to bind the newly created chat to oncall for
+   *  every invited bot. The path is validated by callers; this service only
+   *  persists the binding after chat.create succeeds. */
+  bindWorkingDir?: string;
 }
 
 export interface CreateGroupResult {
@@ -41,6 +46,7 @@ export interface CreateGroupResult {
   transferError: string | null;
   notifyMessageId: string | null;
   notifyError: string | null;
+  oncallBindings: { larkAppId: string; ok: boolean; created?: boolean; error?: string }[];
 }
 
 export async function createGroupWithBots(opts: CreateGroupOpts): Promise<CreateGroupResult> {
@@ -87,6 +93,28 @@ export async function createGroupWithBots(opts: CreateGroupOpts): Promise<Create
     }
   }
 
+  const oncallBindings: CreateGroupResult['oncallBindings'] = [];
+  const bindWorkingDir = opts.bindWorkingDir?.trim();
+  if (bindWorkingDir) {
+    // Bind the new chat for every bot that actually joined it. The creator is
+    // an implicit member; Lark reports rejected invitees in invalidBotIds.
+    const invalidBots = new Set(r.invalidBotIds);
+    const targetBotIds = Array.from(new Set([opts.creatorLarkAppId, ...opts.larkAppIds]))
+      .filter(id => !invalidBots.has(id));
+    for (const larkAppId of targetBotIds) {
+      try {
+        const br = await bindOncall(larkAppId, r.chatId, bindWorkingDir);
+        if (br.ok) {
+          oncallBindings.push({ larkAppId, ok: true, created: br.created });
+        } else {
+          oncallBindings.push({ larkAppId, ok: false, error: br.reason });
+        }
+      } catch (e: any) {
+        oncallBindings.push({ larkAppId, ok: false, error: e?.message ?? String(e) });
+      }
+    }
+  }
+
   return {
     ok: true,
     chatId: r.chatId,
@@ -97,5 +125,6 @@ export async function createGroupWithBots(opts: CreateGroupOpts): Promise<Create
     transferError,
     notifyMessageId,
     notifyError,
+    oncallBindings,
   };
 }

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -293,3 +293,55 @@ describe('POST /api/groups/:chatId/add-bots (Phase B)', () => {
     spy.mockRestore();
   });
 });
+
+describe('POST /api/groups/create', () => {
+  it('forwards bindWorkingDir after validating it is an existing directory', async () => {
+    setLarkAppId('test-app');
+    const spy = vi.spyOn(oncallStore, 'bindOncall').mockResolvedValue({
+      ok: true,
+      entry: { chatId: 'oc_new', workingDir: process.cwd() },
+      created: true,
+    });
+    const createSpy = vi.spyOn(groupsStore, 'createChat').mockResolvedValue({
+      chatId: 'oc_new',
+      invalidBotIds: [],
+      invalidUserIds: [],
+    });
+    handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/groups/create`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ larkAppIds: ['test-app', 'cli_X'], bindWorkingDir: process.cwd() }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.bindResolvedPath).toBe(process.cwd());
+    expect(body.oncallBindings).toEqual([
+      { larkAppId: 'test-app', ok: true, created: true },
+      { larkAppId: 'cli_X', ok: true, created: true },
+    ]);
+    expect(spy).toHaveBeenCalledWith('test-app', 'oc_new', process.cwd());
+    expect(spy).toHaveBeenCalledWith('cli_X', 'oc_new', process.cwd());
+    spy.mockRestore();
+    createSpy.mockRestore();
+  });
+
+  it('rejects missing bindWorkingDir before creating the group', async () => {
+    setLarkAppId('test-app');
+    const createSpy = vi.spyOn(groupsStore, 'createChat').mockResolvedValue({
+      chatId: 'oc_should_not_create',
+      invalidBotIds: [],
+      invalidUserIds: [],
+    });
+    handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/groups/create`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ larkAppIds: ['test-app'], bindWorkingDir: '/definitely/not/a/real/botmux/path' }),
+    });
+    expect(res.status).toBe(400);
+    expect(createSpy).not.toHaveBeenCalled();
+    createSpy.mockRestore();
+  });
+});

--- a/test/group-creator.test.ts
+++ b/test/group-creator.test.ts
@@ -25,6 +25,11 @@ vi.mock('../src/im/lark/client.js', () => ({
   sendMessage: (...args: any[]) => mockSendMessage(...args),
 }));
 
+const mockBindOncall = vi.fn();
+vi.mock('../src/services/oncall-store.js', () => ({
+  bindOncall: (...args: any[]) => mockBindOncall(...args),
+}));
+
 import { createGroupWithBots } from '../src/services/group-creator.js';
 
 const CREATOR = 'cli_creator_app';
@@ -36,6 +41,7 @@ describe('createGroupWithBots', () => {
     mockCreateChat.mockReset();
     mockTransferChatOwner.mockReset();
     mockSendMessage.mockReset();
+    mockBindOncall.mockReset();
   });
 
   it('returns chatId + all status fields on a clean happy path', async () => {
@@ -66,6 +72,7 @@ describe('createGroupWithBots', () => {
       transferError: null,
       notifyMessageId: 'om_notify_1',
       notifyError: null,
+      oncallBindings: [],
     });
   });
 
@@ -153,6 +160,48 @@ describe('createGroupWithBots', () => {
       creatorLarkAppId: CREATOR,
       larkAppIds: [CREATOR],
     })).rejects.toThrow('bad app secret');
+  });
+
+  it('binds the newly created chat for joined bots when bindWorkingDir is provided', async () => {
+    mockCreateChat.mockResolvedValue({
+      chatId: 'oc_bound',
+      invalidBotIds: ['cli_rejected_bot'],
+      invalidUserIds: [],
+    });
+    mockBindOncall.mockResolvedValue({ ok: true, created: true });
+
+    const result = await createGroupWithBots({
+      creatorLarkAppId: CREATOR,
+      larkAppIds: [CREATOR, OTHER_BOT, 'cli_rejected_bot'],
+      bindWorkingDir: '~/projects/botmux',
+    });
+
+    expect(mockBindOncall).toHaveBeenCalledTimes(2);
+    expect(mockBindOncall).toHaveBeenNthCalledWith(1, CREATOR, 'oc_bound', '~/projects/botmux');
+    expect(mockBindOncall).toHaveBeenNthCalledWith(2, OTHER_BOT, 'oc_bound', '~/projects/botmux');
+    expect(result.oncallBindings).toEqual([
+      { larkAppId: CREATOR, ok: true, created: true },
+      { larkAppId: OTHER_BOT, ok: true, created: true },
+    ]);
+  });
+
+  it('reports per-bot oncall bind failures without aborting group creation', async () => {
+    mockCreateChat.mockResolvedValue({ chatId: 'oc_bound', invalidBotIds: [], invalidUserIds: [] });
+    mockBindOncall
+      .mockResolvedValueOnce({ ok: true, created: false })
+      .mockResolvedValueOnce({ ok: false, reason: 'bot_not_in_config' });
+
+    const result = await createGroupWithBots({
+      creatorLarkAppId: CREATOR,
+      larkAppIds: [CREATOR, OTHER_BOT],
+      bindWorkingDir: '/repo',
+    });
+
+    expect(result.chatId).toBe('oc_bound');
+    expect(result.oncallBindings).toEqual([
+      { larkAppId: CREATOR, ok: true, created: false },
+      { larkAppId: OTHER_BOT, ok: false, error: 'bot_not_in_config' },
+    ]);
   });
 
   it('omits transfer/notify steps entirely when targets are not provided', async () => {


### PR DESCRIPTION
## Summary
- add `--working-dir` / `--cwd` / `--dir` to `botmux create-group` so new groups can be bound to an oncall directory during creation
- propagate the same bind option through the dashboard Create new group flow and show per-bot bind results
- validate bind directories before chat creation and return per-bot binding status without retrying chat creation on partial bind failures

## Tests
- `pnpm vitest run test/group-creator.test.ts test/dashboard-ipc.test.ts`
- `pnpm build`
