### PR TITLE
fix(coco): 修复 CoCo 消息无法自动提交

### DIFF
--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -269,7 +269,9 @@ export class TmuxBackend implements SessionBackend {
 
   /**
    * Paste text into the tmux pane via load-buffer + paste-buffer.
-   * Tmux automatically wraps in bracketed paste if the pane has it enabled.
+   * The -p flag asks tmux to insert bracketed-paste markers
+   * (\e[200~ … \e[201~) when the application has requested bracketed paste,
+   * so TUI apps (CoCo/Ink, etc.) can detect paste boundaries reliably.
    * Safe for multiline content (unlike sendText where \n becomes Enter).
    */
   pasteText(text: string): void {
@@ -280,7 +282,7 @@ export class TmuxBackend implements SessionBackend {
       timeout: 5000,
       env: tmuxEnv(),
     });
-    execFileSync('tmux', ['paste-buffer', '-t', this.cmdTarget, '-d'], {
+    execFileSync('tmux', ['paste-buffer', '-t', this.cmdTarget, '-d', '-p'], {
       stdio: 'ignore',
       timeout: 5000,
       env: tmuxEnv(),

--- a/src/adapters/cli/coco.ts
+++ b/src/adapters/cli/coco.ts
@@ -1,5 +1,5 @@
 import { existsSync, statSync, openSync, readSync, closeSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { homedir, platform } from 'node:os';
 import { join } from 'node:path';
 import { resolveCommand } from './registry.js';
 import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
@@ -11,7 +11,9 @@ import type { CliAdapter, PtyHandle } from './types.js';
  *  the Codex adapter uses ~/.codex/history.jsonl: write → poll for our
  *  marker → retry Enter if missing → return {submitted:false, recheck}
  *  on final failure so worker can surface a Lark warning. */
-const HISTORY_PATH = join(homedir(), '.cache', 'coco', 'history.jsonl');
+const HISTORY_PATH = platform() === 'darwin'
+  ? join(homedir(), 'Library', 'Caches', 'coco', 'history.jsonl')
+  : join(homedir(), '.cache', 'coco', 'history.jsonl');
 
 function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -128,7 +130,7 @@ export function createCocoAdapter(pathOverride?: string): CliAdapter {
       // OFF after slash commands; CoCo on a fresh-spawn message doesn't have
       // that concern.
       //
-      // Verification (unchanged): poll ~/.cache/coco/history.jsonl for the
+      // Verification (unchanged): poll CoCo's platform-specific history.jsonl for the
       // user-submit line whose decoded `content` starts with our prefix.
       // Retry Enter up to 3 times, then return {submitted:false, recheck}
       // for the worker's deferred recheck + Lark warning path.

--- a/test/write-input.test.ts
+++ b/test/write-input.test.ts
@@ -16,7 +16,8 @@
  *   off the per-line typing model that claude-code uses: Trae CLI 0.120.31
  *   fresh-spawn treated the rapid send-keys -l burst as an open-ended paste
  *   and swallowed the trailing Enter as a soft-newline, stranding the
- *   message in the input box. Submit is verified via ~/.cache/coco/history.jsonl.
+ *   message in the input box. Submit is verified via CoCo's platform-specific
+ *   history.jsonl.
  * - CoCo (raw PTY): same explicit \x1b[200~...\x1b[201~ wrap as claude-code.
  * - Other adapters (Aiden/Codex/Gemini/OpenCode): use plain sendText + Enter
  *   in tmux, or write(content) + \r in raw mode. The whole content (including
@@ -44,7 +45,7 @@ import { createGeminiAdapter } from '../src/adapters/cli/gemini.js';
 import { createOpenCodeAdapter } from '../src/adapters/cli/opencode.js';
 import type { CliAdapter, PtyHandle } from '../src/adapters/cli/types.js';
 import { appendFileSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { homedir, platform } from 'node:os';
 import { dirname, join } from 'node:path';
 
 // ---------------------------------------------------------------------------
@@ -52,7 +53,9 @@ import { dirname, join } from 'node:path';
 // ---------------------------------------------------------------------------
 
 const CODEX_HISTORY_PATH = join(homedir(), '.codex', 'history.jsonl');
-const COCO_HISTORY_PATH = join(homedir(), '.cache', 'coco', 'history.jsonl');
+const COCO_HISTORY_PATH = platform() === 'darwin'
+  ? join(homedir(), 'Library', 'Caches', 'coco', 'history.jsonl')
+  : join(homedir(), '.cache', 'coco', 'history.jsonl');
 const CLAUDE_KEYBINDINGS_PATH = join(homedir(), '.claude', 'keybindings.json');
 
 function appendCodexHistory(content: string, sessionId?: string): void {


### PR DESCRIPTION
## 背景

排查 CoCo / Trae CLI 在 botmux tmux 模式下的多行输入提交链路时，发现 CoCo 提交确认依赖两处行为：

1. CoCo 的全局 `history.jsonl` 路径是平台相关的：macOS 写入 `~/Library/Caches/coco/history.jsonl`，Linux 写入 `~/.cache/coco/history.jsonl`。此前 adapter 只按 Linux 路径读取，macOS 下会误读不到真实提交历史，影响提交确认、retry/failure 判断。
2. CoCo 在 tmux 模式下通过 `pasteText()` 注入多行内容。为了让 CoCo / Ink 更可靠地识别 paste 边界，tmux `paste-buffer` 需要带上 `-p`，在应用启用 bracketed paste 时插入 paste 边界控制码。

## 改动

- `src/adapters/cli/coco.ts`
  - CoCo history path 改为平台相关：macOS 使用 `~/Library/Caches/coco/history.jsonl`，其他平台保持 `~/.cache/coco/history.jsonl`。
  - 更新注释，避免继续写死 Linux 路径。
- `src/adapters/backend/tmux-backend.ts`
  - `pasteText()` 的 `tmux paste-buffer` 增加 `-p`，在应用启用 bracketed paste 时插入 paste 边界控制码。
- `test/write-input.test.ts`
  - 测试 helper 使用与 adapter 一致的平台相关 CoCo history path。
  - 保留 CoCo retry/failure 回归用例，避免 macOS 下误走 fresh-install shortcut 而掩盖提交失败。

## 验证

- `pnpm exec tsc --noEmit` ✅
- `pnpm vitest run test/write-input.test.ts` ✅ 68 tests
- `pnpm vitest run test/tmux-backend-input.test.ts` ✅ 12 tests
- `git diff --check` ✅

备注：本机 Node 为 `v20.20.2`，`pnpm` 会提示项目期望 `node >=22`，但上述验证命令均已通过。
