### PR TITLE
fix: validate configured working dirs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,6 +41,7 @@ import {
 } from './setup/bot-config-editor.js';
 import type { CliId } from './adapters/cli/types.js';
 import { logger } from './utils/logger.js';
+import { invalidWorkingDirs } from './utils/working-dir.js';
 import { firstPositional } from './cli/arg-utils.js';
 import { isLocale, setDefaultLocale, SUPPORTED_LOCALES, type Locale } from './i18n/index.js';
 import { readGlobalConfig, setGlobalLocale, globalConfigPath } from './global-config.js';
@@ -178,6 +179,15 @@ function loadBotsJson(): any[] {
     }
   }
   return [];
+}
+
+function ensureBotWorkingDirsExist(bot: Record<string, any>, context = 'workingDir'): boolean {
+  const invalid = invalidWorkingDirs(bot);
+  if (invalid.length === 0) return true;
+  console.log(`\n❌ ${context} 指向的目录不存在或不是目录:`);
+  for (const dir of invalid) console.log(`   - ${dir}`);
+  console.log('   请先创建目录，或重新填写一个已存在的工作目录。');
+  return false;
 }
 
 function ensureUniqueBotProcessNames(bots: any[]): void {
@@ -477,6 +487,8 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
   // 字段即可. 手动 fallback 场景没 open_id, 字段直接不写 (== 不限制).
   if (creds.userOpenId) bot.allowedUsers = [creds.userOpenId];
 
+  if (!ensureBotWorkingDirsExist(bot, '默认工作目录')) return null;
+
   return normalizeBotConfig(bot);
 }
 
@@ -684,6 +696,11 @@ async function cmdSetup(): Promise<void> {
       } catch (err: any) {
         rl.close();
         console.log(`\n❌ 编辑失败: ${err?.message ?? String(err)}`);
+        return;
+      }
+      if (!ensureBotWorkingDirsExist(edited, '默认工作目录')) {
+        rl.close();
+        console.log('   配置未修改。');
         return;
       }
 

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -19,6 +19,7 @@ import { validateWorkingDir } from './working-dir.js';
 import { discoverAdoptableSessions, validateAdoptTarget, type AdoptableSession } from './session-discovery.js';
 import { generateAuthUrl, getTokenStatus } from '../utils/user-token.js';
 import { bindOncall, unbindOncall, getOncallStatus } from '../services/oncall-store.js';
+import { invalidWorkingDirs } from '../utils/working-dir.js';
 import type { LarkMessage, DaemonToWorker } from '../types.js';
 import { sessionKey, sessionAnchorId } from './types.js';
 import type { DaemonSession } from './types.js';
@@ -113,6 +114,21 @@ function formatUptime(ms: number): string {
   if (m < 60) return `${m}m${s % 60}s`;
   const h = Math.floor(m / 60);
   return `${h}h${m % 60}m`;
+}
+
+function invalidConfiguredWorkingDirs(ds: DaemonSession | undefined, larkAppId: string | undefined): string[] {
+  if (ds?.workingDir) return invalidWorkingDirs({ workingDir: ds.workingDir });
+  if (larkAppId) {
+    const bot = getBot(larkAppId);
+    return invalidWorkingDirs({
+      workingDir: bot.config.workingDir ?? '~',
+      workingDirs: bot.config.workingDirs,
+    });
+  }
+  return invalidWorkingDirs({
+    workingDir: config.daemon.workingDir ?? '~',
+    workingDirs: config.daemon.workingDirs,
+  });
 }
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -418,6 +434,11 @@ export async function handleCommand(
         }
 
         const scanDirs = getProjectScanDirs(ds);
+        const invalidDirs = invalidConfiguredWorkingDirs(ds, ds?.larkAppId ?? larkAppId);
+        if (invalidDirs.length > 0) {
+          await sessionReply(rootId, t('cmd.repo.working_dir_not_exist', { dirs: invalidDirs.map(d => `\`${d}\``).join(', ') }, loc));
+          break;
+        }
         const validDirs = scanDirs.filter(d => existsSync(d));
         if (validDirs.length === 0) {
           await sessionReply(rootId, t('cmd.repo.scan_dir_not_exist', { dirs: scanDirs.join(', ') }, loc));

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -25,6 +25,7 @@ import { sessionKey, sessionAnchorId } from './types.js';
 import type { DaemonSession } from './types.js';
 import { markSessionActivity } from './session-activity.js';
 import { t, localeForBot, type Locale } from '../i18n/index.js';
+import { parseWorkingDirList } from '../utils/working-dir.js';
 
 function sessionCreatedAtMs(session: { createdAt?: string }): number {
   return session.createdAt ? (Date.parse(session.createdAt) || Date.now()) : Date.now();
@@ -62,7 +63,10 @@ export function getProjectScanDirs(ds?: DaemonSession): string[] {
   if (ds?.larkAppId) {
     const bot = getBot(ds.larkAppId);
     const dirs = new Set<string>();
-    for (const wd of bot.config.workingDirs ?? [bot.config.workingDir ?? '~']) {
+    const workingDirs = bot.config.workingDirs?.length
+      ? bot.config.workingDirs
+      : parseWorkingDirList(bot.config.workingDir ?? '~');
+    for (const wd of workingDirs) {
       dirs.add(resolve(expandHome(wd), '..'));
     }
     if (ds.workingDir) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -20,6 +20,7 @@ import { expandMergeForward } from './im/lark/merge-forward.js';
 import { buildQuoteHint } from './im/lark/quote-hint.js';
 import { logger } from './utils/logger.js';
 import { ensureCjkFontsInstalled } from './utils/font-installer.js';
+import { invalidWorkingDirs } from './utils/working-dir.js';
 import type { DaemonToWorker, LarkMessage } from './types.js';
 export type { DaemonSession } from './core/types.js';
 import type { DaemonSession } from './core/types.js';
@@ -397,6 +398,29 @@ async function maybeAutoBindDefaultOncall(
   return r.entry;
 }
 
+async function replyInvalidWorkingDirs(
+  anchor: string,
+  larkAppId: string,
+  ds: DaemonSession,
+): Promise<boolean> {
+  const bot = getBot(larkAppId);
+  const invalid = invalidWorkingDirs({
+    workingDir: ds.workingDir ?? bot.config.workingDir ?? '~',
+    workingDirs: ds.workingDir ? undefined : bot.config.workingDirs,
+  });
+  if (invalid.length === 0) return false;
+
+  ds.pendingRepo = false;
+  activeSessions.delete(sessionKey(anchor, larkAppId));
+  sessionStore.closeSession(ds.session.sessionId);
+  const msg = tr('cmd.repo.working_dir_not_exist', {
+    dirs: invalid.map(d => `\`${d}\``).join(', '),
+  }, localeForBot(larkAppId));
+  await sessionReply(anchor, msg, 'text', larkAppId);
+  logger.warn(`[${tag(ds)}] configured workingDir missing: ${invalid.join(', ')}`);
+  return true;
+}
+
 async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
   const { chatId, messageId, chatType, larkAppId } = ctx;
   // scope/anchor are mutable here: `/t` / `/topic` may flip a 普通群 chat-scope
@@ -592,6 +616,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
 
   // Pinned (oncall binding or inherited from sibling bot): spawn CLI immediately.
   if (pinnedWorkingDir) {
+    if (await replyInvalidWorkingDirs(anchor, larkAppId, ds)) return;
     const selfBot = getBot(larkAppId);
     const prompt = buildNewTopicPrompt(promptContent, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, chatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId }, localeForBot(larkAppId), newTopicSender);
     forkWorker(ds, prompt);
@@ -603,6 +628,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
   }
 
   // Show repo selection card
+  if (await replyInvalidWorkingDirs(anchor, larkAppId, ds)) return;
   const scanDirs = getProjectScanDirs(ds).filter(d => existsSync(d));
   let projects: import('./services/project-scanner.js').ProjectInfo[] = [];
   if (scanDirs.length > 0) {
@@ -938,6 +964,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
     // Pinned (oncall binding or inherited from peer bot in same thread):
     // spawn CLI immediately, skip repo selection.
     if (pinnedWorkingDir) {
+      if (await replyInvalidWorkingDirs(anchor, larkAppId, newDs)) return;
       const selfBot = getBot(larkAppId);
       const prompt = buildNewTopicPrompt(promptContent, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, autoCreateChatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId }, localeForBot(larkAppId), autoCreateSender);
       forkWorker(newDs, prompt);
@@ -949,6 +976,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
     }
 
     // Show repo selection card (same as handleNewTopic)
+    if (await replyInvalidWorkingDirs(anchor, larkAppId, newDs)) return;
     const scanDirs2 = getProjectScanDirs(newDs).filter(d => existsSync(d));
     let projects: import('./services/project-scanner.js').ProjectInfo[] = [];
     if (scanDirs2.length > 0) {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -67,6 +67,7 @@ export const messages: Record<string, string> = {
   'cmd.repo.switched_to': '🔄 Switched to {name}',
   'cmd.repo.warning_running': '⚠️ A session is already running. Switching repos will close it and start a new one.\nIf that\'s what you want, pick the new repo from the card below.',
   'cmd.repo.scan_dir_not_exist': 'Scan dirs do not exist: {dirs}\nCheck that workingDir in bots.json points to a valid directory.',
+  'cmd.repo.working_dir_not_exist': '❌ Configured working directory does not exist or is not a directory: {dirs}\nCheck workingDir / workingDirs in ~/.botmux/bots.json, or run `botmux setup` and choose an existing directory.',
   'cmd.repo.no_git_repos': 'No git repositories found under {dirs}.',
   'cmd.skip.opened': '▶️ Session started (working dir: {cwd})',
   'cmd.skip.no_pending': 'No pending repo selection.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -70,6 +70,7 @@ export const messages: Record<string, string> = {
   'cmd.repo.switched_to': '🔄 已切换到 {name}',
   'cmd.repo.warning_running': '⚠️ 当前会话已在运行中，切换仓库将关闭当前会话并创建新会话。\n如需切换，请在下方卡片中选择新仓库。',
   'cmd.repo.scan_dir_not_exist': '扫描目录不存在：{dirs}\n请检查 bots.json 中的 workingDir 是否指向有效目录。',
+  'cmd.repo.working_dir_not_exist': '❌ 配置的工作目录不存在或不是目录：{dirs}\n请检查 ~/.botmux/bots.json 中的 workingDir / workingDirs，或重新运行 `botmux setup` 修改为已存在的目录。',
   'cmd.repo.no_git_repos': '在 {dirs} 下未找到 git 仓库。',
   'cmd.skip.opened': '▶️ 已直接开启会话（工作目录：{cwd}）',
   'cmd.skip.no_pending': '当前没有待选择的仓库。',

--- a/src/utils/working-dir.ts
+++ b/src/utils/working-dir.ts
@@ -1,0 +1,44 @@
+import { statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+export function expandHomePath(p: string): string {
+  return p.startsWith('~') ? join(homedir(), p.slice(1)) : p;
+}
+
+export function parseWorkingDirList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .flatMap(v => parseWorkingDirList(v))
+      .filter(Boolean);
+  }
+  if (typeof value !== 'string') return [];
+  return value.split(',').map(s => s.trim()).filter(Boolean);
+}
+
+export function configuredWorkingDirs(input: { workingDir?: unknown; workingDirs?: unknown }): string[] {
+  const dirs = [
+    ...parseWorkingDirList(input.workingDir),
+    ...parseWorkingDirList(input.workingDirs),
+  ];
+  const seen = new Set<string>();
+  return dirs.filter(dir => {
+    const resolved = resolve(expandHomePath(dir));
+    if (seen.has(resolved)) return false;
+    seen.add(resolved);
+    return true;
+  });
+}
+
+export function invalidWorkingDirs(input: { workingDir?: unknown; workingDirs?: unknown }): string[] {
+  const invalid: string[] = [];
+  for (const dir of configuredWorkingDirs(input)) {
+    const resolved = resolve(expandHomePath(dir));
+    try {
+      if (!statSync(resolved).isDirectory()) invalid.push(resolved);
+    } catch {
+      invalid.push(resolved);
+    }
+  }
+  return invalid;
+}

--- a/test/working-dir.test.ts
+++ b/test/working-dir.test.ts
@@ -1,0 +1,30 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { configuredWorkingDirs, invalidWorkingDirs, parseWorkingDirList } from '../src/utils/working-dir.js';
+
+describe('working-dir utils', () => {
+  it('parses comma-separated strings and arrays', () => {
+    expect(parseWorkingDirList('/a, /b,,/c')).toEqual(['/a', '/b', '/c']);
+    expect(parseWorkingDirList(['/a, /b', ' /c '])).toEqual(['/a', '/b', '/c']);
+    expect(parseWorkingDirList(undefined)).toEqual([]);
+  });
+
+  it('dedupes configured dirs by resolved path', () => {
+    const cwd = process.cwd();
+    expect(configuredWorkingDirs({ workingDir: '., ' + cwd })).toEqual(['.']);
+  });
+
+  it('reports missing paths and files as invalid dirs', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-working-dir-'));
+    const file = join(dir, 'not-a-dir');
+    const missing = join(dir, 'missing');
+    writeFileSync(file, 'x');
+
+    expect(invalidWorkingDirs({ workingDir: [dir, file, missing] })).toEqual([
+      resolve(file),
+      resolve(missing),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- validate configured workingDir / workingDirs during botmux setup and block invalid config writes
- check configured working dirs before sending repo selection cards or spawning pinned sessions, and reply with a Lark error when missing
- add shared working-dir parsing/validation utilities and cover comma-separated workingDir handling

## Test Plan
- pnpm vitest run test/working-dir.test.ts test/command-handler.test.ts
- pnpm build
