### PR TITLE
feat: add ambient history scope

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,6 +41,7 @@ import {
 } from './setup/bot-config-editor.js';
 import type { CliId } from './adapters/cli/types.js';
 import { logger } from './utils/logger.js';
+import { invalidWorkingDirs } from './utils/working-dir.js';
 import { firstPositional } from './cli/arg-utils.js';
 import { isLocale, setDefaultLocale, SUPPORTED_LOCALES, type Locale } from './i18n/index.js';
 import { readGlobalConfig, setGlobalLocale, globalConfigPath } from './global-config.js';
@@ -178,6 +179,15 @@ function loadBotsJson(): any[] {
     }
   }
   return [];
+}
+
+function ensureBotWorkingDirsExist(bot: Record<string, any>, context = 'workingDir'): boolean {
+  const invalid = invalidWorkingDirs(bot);
+  if (invalid.length === 0) return true;
+  console.log(`\n❌ ${context} 指向的目录不存在或不是目录:`);
+  for (const dir of invalid) console.log(`   - ${dir}`);
+  console.log('   请先创建目录，或重新填写一个已存在的工作目录。');
+  return false;
 }
 
 function ensureUniqueBotProcessNames(bots: any[]): void {
@@ -477,6 +487,8 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
   // 字段即可. 手动 fallback 场景没 open_id, 字段直接不写 (== 不限制).
   if (creds.userOpenId) bot.allowedUsers = [creds.userOpenId];
 
+  if (!ensureBotWorkingDirsExist(bot, '默认工作目录')) return null;
+
   return normalizeBotConfig(bot);
 }
 
@@ -684,6 +696,11 @@ async function cmdSetup(): Promise<void> {
       } catch (err: any) {
         rl.close();
         console.log(`\n❌ 编辑失败: ${err?.message ?? String(err)}`);
+        return;
+      }
+      if (!ensureBotWorkingDirsExist(edited, '默认工作目录')) {
+        rl.close();
+        console.log('   配置未修改。');
         return;
       }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2044,7 +2044,9 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
        --top-level                     发顶层消息（不回复进当前话题）
        --chat-id <oc_xxx>              指定目标群（默认当前话题所在群）
   bots list                            列出当前群聊中的机器人（含 open_id）
-  history [--limit N]                  拉取当前会话的消息历史 (JSON)，话题群 → 话题内，普通群 → 整群
+  history [--limit N] [--scope session|thread|chat|ambient]
+                                       拉取当前会话的消息历史 (JSON)。默认按 session scope：话题/话题群 → 话题内，普通群 → 整群；
+                                       thread 会话里可用 --scope ambient 读取 thread 外的群聊上下文
   quoted <message_id>                  拉取被引用的单条消息 (JSON)，message_id 取自 daemon 注入的引用提示行
 
 新建飞书群:
@@ -2311,35 +2313,61 @@ async function resolveSessionAppId(sessionIdArg: string | undefined): Promise<{ 
 
 async function cmdHistory(rest: string[]): Promise<void> {
   const limit = parseInt(argValue(rest, '--limit') ?? '50', 10);
+  const scopeArg = argValue(rest, '--scope') ?? 'session';
   const sessionIdArg = argValue(rest, '--session-id');
   const { sid, larkAppId: appId, session: s } = await resolveSessionAppId(sessionIdArg);
 
-  const { listThreadMessages, listChatMessages } = await import('./im/lark/client.js');
-  const { parseApiMessage, cardContentHasUpgradeFallback, resolveMergedCardContent } = await import('./im/lark/message-parser.js');
+  const validScopes = new Set(['session', 'thread', 'chat', 'ambient']);
+  if (!validScopes.has(scopeArg)) {
+    console.error(`无效 --scope: ${scopeArg}。可用: session | thread | chat | ambient`);
+    process.exit(1);
+  }
+
+  const { getMessageDetail, listAmbientChatMessages, listThreadMessages, listChatMessages } = await import('./im/lark/client.js');
+  const { parseApiMessage } = await import('./im/lark/message-parser.js');
   const { expandMergeForward } = await import('./im/lark/merge-forward.js');
   try {
     // Chat-scope sessions (普通群整群一会话) have no thread to walk — list the
     // chat container directly and let the caller cap with --limit. Thread-scope
-    // sessions walk the thread container by root_id.
+    // sessions walk the thread container by root_id. `--scope chat|ambient`
+    // lets a thread-scope session intentionally read outside its thread when
+    // it needs the surrounding group conversation (for example `/t` spawned
+    // from an ongoing 普通群 discussion).
     const isChatScope = s.scope === 'chat';
-    const raw = isChatScope
+    const effectiveScope = scopeArg === 'session'
+      ? (isChatScope ? 'chat' : 'thread')
+      : scopeArg;
+
+    if (effectiveScope === 'thread' && isChatScope) {
+      console.error('当前 session 是 chat-scope，没有 thread 历史可读取。请使用 --scope chat。');
+      process.exit(1);
+    }
+
+    let ambientBeforeCreateTime: string | undefined;
+    if (effectiveScope === 'ambient') {
+      try {
+        const detail = await getMessageDetail(appId, s.rootMessageId, { userCardContent: false });
+        ambientBeforeCreateTime = detail?.items?.[0]?.create_time;
+      } catch {
+        // Best-effort only: ambient history should still work if the root
+        // message was withdrawn or is otherwise unavailable; it will then fall
+        // back to the chat tail with current-thread messages filtered out.
+      }
+    }
+
+    const raw = effectiveScope === 'chat'
       ? await listChatMessages(appId, s.chatId, limit)
-      : await listThreadMessages(appId, s.chatId, s.rootMessageId, limit);
+      : effectiveScope === 'ambient'
+        ? await listAmbientChatMessages(appId, s.chatId, limit, {
+            beforeCreateTime: ambientBeforeCreateTime,
+            excludeRootMessageId: s.rootMessageId,
+          })
+        : await listThreadMessages(appId, s.chatId, s.rootMessageId, limit);
     // Expand merge_forward to <forwarded_messages> XML, mirroring the live event
     // path in daemon.ts. Each merge_forward gets its own numberer (we don't
     // download resources here — only [图片 N] placeholders matter).
     const messages = await Promise.all(raw.map(async (m: any) => {
-      let parsed = parseApiMessage(m);
-      // `im.v1.message.list` returns Lark's simplified "请升级客户端" fallback for
-      // complex cards — the whole body (user-forwarded) or nested sub-cards
-      // buried mid-body (Argos alarms). Those are the cards where the list view
-      // alone is incomplete, so resolve them by unioning both `im.message.get`
-      // representations (server-rendered + full structured). Failures keep the
-      // list text. Simple cards (no fallback) already render fully here.
-      if (parsed.msgType === 'interactive' && cardContentHasUpgradeFallback(parsed.content)) {
-        const merged = await resolveMergedCardContent(appId, parsed.messageId).catch(() => null);
-        if (merged) parsed.content = merged.text;
-      }
+      const parsed = parseApiMessage(m);
       if (parsed.msgType === 'merge_forward') {
         await expandMergeForward(appId, parsed.messageId, parsed);
       }
@@ -2348,8 +2376,16 @@ async function cmdHistory(rest: string[]): Promise<void> {
     console.log(JSON.stringify({
       sessionId: sid,
       chatId: s.chatId,
-      scope: isChatScope ? 'chat' : 'thread',
+      scope: effectiveScope,
+      sessionScope: isChatScope ? 'chat' : 'thread',
       ...(isChatScope ? {} : { rootMessageId: s.rootMessageId }),
+      ...(effectiveScope === 'ambient' ? {
+        ambient: {
+          source: 'chat',
+          beforeCreateTime: ambientBeforeCreateTime,
+          excludeRootMessageId: s.rootMessageId,
+        },
+      } : {}),
       messages,
       total: messages.length,
     }, null, 2));
@@ -2378,7 +2414,6 @@ async function cmdQuoted(rest: string[]): Promise<void> {
   const { getMessageDetail } = await import('./im/lark/client.js');
   const { expandMergeForward } = await import('./im/lark/merge-forward.js');
   const { renderQuotedMessage } = await import('./cli/quoted-render.js');
-  const { resolveMergedCardContent } = await import('./im/lark/message-parser.js');
   try {
     const detail = await getMessageDetail(appId, messageId);
     const msg = detail?.items?.[0];
@@ -2387,15 +2422,6 @@ async function cmdQuoted(rest: string[]): Promise<void> {
       process.exit(1);
     }
     const rendered = await renderQuotedMessage(appId, msg, expandMergeForward);
-    // Interactive cards: union both im.message.get representations so the quoted
-    // view matches history/live (recovers names + sub-card content + options).
-    // This single-message path always merges — unlike history (which starts
-    // from the hole-bearing list view), the quoted base is the hole-free B view
-    // so there's no cheap local signal that a merge would add anything.
-    if (rendered.msgType === 'interactive') {
-      const merged = await resolveMergedCardContent(appId, messageId).catch(() => null);
-      if (merged) rendered.content = merged.text;
-    }
     console.log(JSON.stringify(rendered, null, 2));
   } catch (err: any) {
     console.error(`获取被引用消息失败: ${err.message}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2343,6 +2343,11 @@ async function cmdHistory(rest: string[]): Promise<void> {
       process.exit(1);
     }
 
+    if (effectiveScope === 'ambient' && isChatScope) {
+      console.error('当前 session 是 chat-scope，没有 thread root 可作为 ambient 边界。请使用 --scope chat。');
+      process.exit(1);
+    }
+
     let ambientBeforeCreateTime: string | undefined;
     if (effectiveScope === 'ambient') {
       try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2324,7 +2324,7 @@ async function cmdHistory(rest: string[]): Promise<void> {
   }
 
   const { getMessageDetail, listAmbientChatMessages, listThreadMessages, listChatMessages } = await import('./im/lark/client.js');
-  const { parseApiMessage } = await import('./im/lark/message-parser.js');
+  const { parseApiMessage, cardContentHasUpgradeFallback, resolveMergedCardContent } = await import('./im/lark/message-parser.js');
   const { expandMergeForward } = await import('./im/lark/merge-forward.js');
   try {
     // Chat-scope sessions (普通群整群一会话) have no thread to walk — list the
@@ -2372,7 +2372,17 @@ async function cmdHistory(rest: string[]): Promise<void> {
     // path in daemon.ts. Each merge_forward gets its own numberer (we don't
     // download resources here — only [图片 N] placeholders matter).
     const messages = await Promise.all(raw.map(async (m: any) => {
-      const parsed = parseApiMessage(m);
+      let parsed = parseApiMessage(m);
+      // `im.v1.message.list` returns Lark's simplified "请升级客户端" fallback for
+      // complex cards — the whole body (user-forwarded) or nested sub-cards
+      // buried mid-body (Argos alarms). Those are the cards where the list view
+      // alone is incomplete, so resolve them by unioning both `im.message.get`
+      // representations (server-rendered + full structured). Failures keep the
+      // list text. Simple cards (no fallback) already render fully here.
+      if (parsed.msgType === 'interactive' && cardContentHasUpgradeFallback(parsed.content)) {
+        const merged = await resolveMergedCardContent(appId, parsed.messageId).catch(() => null);
+        if (merged) parsed.content = merged.text;
+      }
       if (parsed.msgType === 'merge_forward') {
         await expandMergeForward(appId, parsed.messageId, parsed);
       }
@@ -2419,6 +2429,7 @@ async function cmdQuoted(rest: string[]): Promise<void> {
   const { getMessageDetail } = await import('./im/lark/client.js');
   const { expandMergeForward } = await import('./im/lark/merge-forward.js');
   const { renderQuotedMessage } = await import('./cli/quoted-render.js');
+  const { resolveMergedCardContent } = await import('./im/lark/message-parser.js');
   try {
     const detail = await getMessageDetail(appId, messageId);
     const msg = detail?.items?.[0];
@@ -2427,6 +2438,15 @@ async function cmdQuoted(rest: string[]): Promise<void> {
       process.exit(1);
     }
     const rendered = await renderQuotedMessage(appId, msg, expandMergeForward);
+    // Interactive cards: union both im.message.get representations so the quoted
+    // view matches history/live (recovers names + sub-card content + options).
+    // This single-message path always merges — unlike history (which starts
+    // from the hole-bearing list view), the quoted base is the hole-free B view
+    // so there's no cheap local signal that a merge would add anything.
+    if (rendered.msgType === 'interactive') {
+      const merged = await resolveMergedCardContent(appId, messageId).catch(() => null);
+      if (merged) rendered.content = merged.text;
+    }
     console.log(JSON.stringify(rendered, null, 2));
   } catch (err: any) {
     console.error(`获取被引用消息失败: ${err.message}`);

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -19,6 +19,7 @@ import { validateWorkingDir } from './working-dir.js';
 import { discoverAdoptableSessions, validateAdoptTarget, type AdoptableSession } from './session-discovery.js';
 import { generateAuthUrl, getTokenStatus } from '../utils/user-token.js';
 import { bindOncall, unbindOncall, getOncallStatus } from '../services/oncall-store.js';
+import { invalidWorkingDirs } from '../utils/working-dir.js';
 import type { LarkMessage, DaemonToWorker } from '../types.js';
 import { sessionKey, sessionAnchorId } from './types.js';
 import type { DaemonSession } from './types.js';
@@ -113,6 +114,21 @@ function formatUptime(ms: number): string {
   if (m < 60) return `${m}m${s % 60}s`;
   const h = Math.floor(m / 60);
   return `${h}h${m % 60}m`;
+}
+
+function invalidConfiguredWorkingDirs(ds: DaemonSession | undefined, larkAppId: string | undefined): string[] {
+  if (ds?.workingDir) return invalidWorkingDirs({ workingDir: ds.workingDir });
+  if (larkAppId) {
+    const bot = getBot(larkAppId);
+    return invalidWorkingDirs({
+      workingDir: bot.config.workingDir ?? '~',
+      workingDirs: bot.config.workingDirs,
+    });
+  }
+  return invalidWorkingDirs({
+    workingDir: config.daemon.workingDir ?? '~',
+    workingDirs: config.daemon.workingDirs,
+  });
 }
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -418,6 +434,11 @@ export async function handleCommand(
         }
 
         const scanDirs = getProjectScanDirs(ds);
+        const invalidDirs = invalidConfiguredWorkingDirs(ds, ds?.larkAppId ?? larkAppId);
+        if (invalidDirs.length > 0) {
+          await sessionReply(rootId, t('cmd.repo.working_dir_not_exist', { dirs: invalidDirs.map(d => `\`${d}\``).join(', ') }, loc));
+          break;
+        }
         const validDirs = scanDirs.filter(d => existsSync(d));
         if (validDirs.length === 0) {
           await sessionReply(rootId, t('cmd.repo.scan_dir_not_exist', { dirs: scanDirs.join(', ') }, loc));

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -25,6 +25,7 @@ import { sessionKey, sessionAnchorId } from './types.js';
 import type { DaemonSession } from './types.js';
 import { markSessionActivity } from './session-activity.js';
 import { t, localeForBot, type Locale } from '../i18n/index.js';
+import { parseWorkingDirList } from '../utils/working-dir.js';
 
 function sessionCreatedAtMs(session: { createdAt?: string }): number {
   return session.createdAt ? (Date.parse(session.createdAt) || Date.now()) : Date.now();
@@ -62,7 +63,10 @@ export function getProjectScanDirs(ds?: DaemonSession): string[] {
   if (ds?.larkAppId) {
     const bot = getBot(ds.larkAppId);
     const dirs = new Set<string>();
-    for (const wd of bot.config.workingDirs ?? [bot.config.workingDir ?? '~']) {
+    const workingDirs = bot.config.workingDirs?.length
+      ? bot.config.workingDirs
+      : parseWorkingDirList(bot.config.workingDir ?? '~');
+    for (const wd of workingDirs) {
       dirs.add(resolve(expandHome(wd), '..'));
     }
     if (ds.workingDir) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -20,6 +20,7 @@ import { expandMergeForward } from './im/lark/merge-forward.js';
 import { buildQuoteHint } from './im/lark/quote-hint.js';
 import { logger } from './utils/logger.js';
 import { ensureCjkFontsInstalled } from './utils/font-installer.js';
+import { invalidWorkingDirs } from './utils/working-dir.js';
 import type { DaemonToWorker, LarkMessage } from './types.js';
 export type { DaemonSession } from './core/types.js';
 import type { DaemonSession } from './core/types.js';
@@ -397,6 +398,29 @@ async function maybeAutoBindDefaultOncall(
   return r.entry;
 }
 
+async function replyInvalidWorkingDirs(
+  anchor: string,
+  larkAppId: string,
+  ds: DaemonSession,
+): Promise<boolean> {
+  const bot = getBot(larkAppId);
+  const invalid = invalidWorkingDirs({
+    workingDir: ds.workingDir ?? bot.config.workingDir ?? '~',
+    workingDirs: ds.workingDir ? undefined : bot.config.workingDirs,
+  });
+  if (invalid.length === 0) return false;
+
+  ds.pendingRepo = false;
+  activeSessions.delete(sessionKey(anchor, larkAppId));
+  sessionStore.closeSession(ds.session.sessionId);
+  const msg = tr('cmd.repo.working_dir_not_exist', {
+    dirs: invalid.map(d => `\`${d}\``).join(', '),
+  }, localeForBot(larkAppId));
+  await sessionReply(anchor, msg, 'text', larkAppId);
+  logger.warn(`[${tag(ds)}] configured workingDir missing: ${invalid.join(', ')}`);
+  return true;
+}
+
 async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
   const { chatId, messageId, chatType, larkAppId } = ctx;
   // scope/anchor are mutable here: `/t` / `/topic` may flip a 普通群 chat-scope
@@ -592,6 +616,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
 
   // Pinned (oncall binding or inherited from sibling bot): spawn CLI immediately.
   if (pinnedWorkingDir) {
+    if (await replyInvalidWorkingDirs(anchor, larkAppId, ds)) return;
     const selfBot = getBot(larkAppId);
     const prompt = buildNewTopicPrompt(promptContent, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, chatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId }, localeForBot(larkAppId), newTopicSender);
     forkWorker(ds, prompt);
@@ -603,6 +628,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
   }
 
   // Show repo selection card
+  if (await replyInvalidWorkingDirs(anchor, larkAppId, ds)) return;
   const scanDirs = getProjectScanDirs(ds).filter(d => existsSync(d));
   let projects: import('./services/project-scanner.js').ProjectInfo[] = [];
   if (scanDirs.length > 0) {
@@ -938,6 +964,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
     // Pinned (oncall binding or inherited from peer bot in same thread):
     // spawn CLI immediately, skip repo selection.
     if (pinnedWorkingDir) {
+      if (await replyInvalidWorkingDirs(anchor, larkAppId, newDs)) return;
       const selfBot = getBot(larkAppId);
       const prompt = buildNewTopicPrompt(promptContent, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, autoCreateChatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId }, localeForBot(larkAppId), autoCreateSender);
       forkWorker(newDs, prompt);
@@ -949,6 +976,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
     }
 
     // Show repo selection card (same as handleNewTopic)
+    if (await replyInvalidWorkingDirs(anchor, larkAppId, newDs)) return;
     const scanDirs2 = getProjectScanDirs(newDs).filter(d => existsSync(d));
     let projects: import('./services/project-scanner.js').ProjectInfo[] = [];
     if (scanDirs2.length > 0) {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -67,6 +67,7 @@ export const messages: Record<string, string> = {
   'cmd.repo.switched_to': '🔄 Switched to {name}',
   'cmd.repo.warning_running': '⚠️ A session is already running. Switching repos will close it and start a new one.\nIf that\'s what you want, pick the new repo from the card below.',
   'cmd.repo.scan_dir_not_exist': 'Scan dirs do not exist: {dirs}\nCheck that workingDir in bots.json points to a valid directory.',
+  'cmd.repo.working_dir_not_exist': '❌ Configured working directory does not exist or is not a directory: {dirs}\nCheck workingDir / workingDirs in ~/.botmux/bots.json, or run `botmux setup` and choose an existing directory.',
   'cmd.repo.no_git_repos': 'No git repositories found under {dirs}.',
   'cmd.skip.opened': '▶️ Session started (working dir: {cwd})',
   'cmd.skip.no_pending': 'No pending repo selection.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -70,6 +70,7 @@ export const messages: Record<string, string> = {
   'cmd.repo.switched_to': '🔄 已切换到 {name}',
   'cmd.repo.warning_running': '⚠️ 当前会话已在运行中，切换仓库将关闭当前会话并创建新会话。\n如需切换，请在下方卡片中选择新仓库。',
   'cmd.repo.scan_dir_not_exist': '扫描目录不存在：{dirs}\n请检查 bots.json 中的 workingDir 是否指向有效目录。',
+  'cmd.repo.working_dir_not_exist': '❌ 配置的工作目录不存在或不是目录：{dirs}\n请检查 ~/.botmux/bots.json 中的 workingDir / workingDirs，或重新运行 `botmux setup` 修改为已存在的目录。',
   'cmd.repo.no_git_repos': '在 {dirs} 下未找到 git 仓库。',
   'cmd.skip.opened': '▶️ 已直接开启会话（工作目录：{cwd}）',
   'cmd.skip.no_pending': '当前没有待选择的仓库。',

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -545,6 +545,61 @@ export async function listChatMessages(
   return allMessages.slice(0, pageSize).reverse();
 }
 
+export interface AmbientChatMessageOptions {
+  /**
+   * Exclude messages at/after this timestamp (Lark create_time, milliseconds as
+   * a string). Used by `/t` thread sessions to fetch the chat tail that existed
+   * before the thread was opened, avoiding bot cards/replies from the new
+   * thread polluting the context.
+   */
+  beforeCreateTime?: string;
+  /** Exclude the current thread root and its replies from the chat tail. */
+  excludeRootMessageId?: string;
+  /** How many chat-container messages to scan before filtering. */
+  scanLimit?: number;
+}
+
+export function filterAmbientChatMessages(
+  messages: any[],
+  pageSize: number,
+  options: Pick<AmbientChatMessageOptions, 'beforeCreateTime' | 'excludeRootMessageId'> = {},
+): any[] {
+  const beforeMs = options.beforeCreateTime ? Number(options.beforeCreateTime) : undefined;
+  const root = options.excludeRootMessageId;
+
+  const filtered = messages.filter((m: any) => {
+    if (root && (m.message_id === root || m.root_id === root)) return false;
+    if (Number.isFinite(beforeMs)) {
+      const createdMs = Number(m.create_time);
+      // If create_time is malformed, keep the message rather than silently
+      // dropping potentially useful context. Lark normally returns epoch ms.
+      if (Number.isFinite(createdMs) && createdMs >= (beforeMs as number)) return false;
+    }
+    return true;
+  });
+
+  return filtered.slice(Math.max(0, filtered.length - pageSize));
+}
+
+/**
+ * List recent chat-container messages as ambient context for a thread session.
+ *
+ * This intentionally differs from `listChatMessages`: callers want the newest
+ * `pageSize` messages AFTER filtering out the current thread and (optionally)
+ * messages created after the thread root. We therefore may scan more than
+ * `pageSize` items and cap only after filtering.
+ */
+export async function listAmbientChatMessages(
+  larkAppId: string,
+  chatId: string,
+  pageSize: number = 50,
+  options: AmbientChatMessageOptions = {},
+): Promise<any[]> {
+  const scanLimit = Math.max(pageSize, options.scanLimit ?? Math.min(Math.max(pageSize * 4, 50), 200));
+  const raw = await listChatMessages(larkAppId, chatId, scanLimit);
+  return filterAmbientChatMessages(raw, pageSize, options);
+}
+
 /** Fallback: scan chat messages and filter by root_id. */
 async function listByChatFilter(c: any, chatId: string, rootMessageId: string, pageSize: number): Promise<any[]> {
   const allMessages: any[] = [];

--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -117,7 +117,7 @@ description: 需要查看当前飞书会话历史消息时触发。话题群/话
 
 想回顾当前飞书会话里用户之前发过什么、别的机器人说了什么时使用。**话题群和普通群都支持**：默认按当前 session 范围读取；话题/thread 会话只返回当前话题内消息，普通群 chat-scope 会话返回整群最近 N 条（默认 50，按时间倒序取尾部、再按时间正序返回）。觉得历史太多就把 \`--limit\` 调小，需要更多上下文就调大。
 
-如果你在 thread 里需要读取 thread 外的群聊上下文（典型场景：用户在普通群讨论后用 \`/t\` 单开话题叫你处理），使用 \`botmux history --scope ambient --limit 20\`。它会读取当前 thread 所在群里、thread root 之前的最近消息，并排除当前 thread 本身，适合作为环境上下文。
+如果你在 thread 里需要读取 thread 外的群聊上下文（典型场景：用户在普通群讨论后用 \`/t\` 单开话题叫你处理），使用 \`botmux history --scope ambient --limit 20\`。它会读取当前 thread 所在群里、thread root 之前的最近消息，并排除当前 thread 本身，适合作为环境上下文。注意隐私边界：ambient 会读取 thread 外群聊消息，仅在用户明确需要群聊背景时使用，并优先使用较小的 limit。
 
 ## 用法
 
@@ -148,7 +148,7 @@ JSON 格式，字段：
   "chatId": "...",
   "scope": "thread" | "chat" | "ambient",
   "sessionScope": "thread" | "chat",
-  "rootMessageId": "...",     // 仅 scope=thread 时存在
+  "rootMessageId": "...",     // 仅 sessionScope=thread 时存在（包括 scope=ambient）
   "ambient": {                 // 仅 scope=ambient 时存在
     "source": "chat",
     "beforeCreateTime": "...",
@@ -165,7 +165,7 @@ JSON 格式，字段：
 
 - \`scope=thread\`：只返回属于当前话题的消息（按 rootMessageId 过滤）
 - \`scope=chat\`：返回当前群整群最近 N 条消息（不限于 session 创建之后，需要更老的就把 --limit 调大）
-- \`scope=ambient\`：返回当前 thread 外的群聊上下文，默认排除当前 thread，并优先限制在 thread root 创建前，适合 \`/t\` 后补充群内讨论背景
+- \`scope=ambient\`：返回当前 thread 外的群聊上下文，默认排除当前 thread，并优先限制在 thread root 创建前，适合 \`/t\` 后补充群内讨论背景；仅在用户明确需要群聊背景时使用，并优先小 \`--limit\`
 - \`senderType="app"\` 表示机器人发的消息（包括 Claude Code / Codex / 其它 bot），\`"user"\` 表示用户
 - **合并转发**消息会自动展开：\`msgType\` 变为 \`merge_forward_expanded\`，\`content\` 是 \`<forwarded_messages>...</forwarded_messages>\` XML（含 \`<participants>\` 别名表 + 嵌套 \`<msg from="A">\` 节点），与 daemon 实时事件路径一致
 - 需要先把 JSON 读进来再做总结，不要直接把 JSON 扔给用户

--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -110,12 +110,14 @@ botmux schedule add "每日11:00" "
 
 const HISTORY_SKILL = `---
 name: botmux-history
-description: 需要查看当前飞书会话历史消息时触发。话题群拉话题内消息，普通群拉整群最近 N 条（默认 50，用 --limit 调节，最多 50/页）。适合"看看之前聊了什么"、"最近的消息"、"上下文"类请求。在 CLI 会话内自动推断 session-id。
+description: 需要查看当前飞书会话历史消息时触发。话题群/话题会话默认拉话题内消息，普通群默认拉整群最近 N 条（默认 50，用 --limit 调节）。在 thread 内如果需要 thread 外的群聊上下文，用 --scope ambient。适合"看看之前聊了什么"、"最近的消息"、"上下文"类请求。在 CLI 会话内自动推断 session-id。
 ---
 
 # botmux-history — 读取会话消息历史
 
-想回顾当前飞书会话里用户之前发过什么、别的机器人说了什么时使用。**话题群和普通群都支持**：话题群里只返回当前话题内的消息，普通群里返回整群最近 N 条（默认 50，按时间倒序取尾部、再按时间正序返回）。觉得历史太多就把 \`--limit\` 调小，需要更多上下文就调大。
+想回顾当前飞书会话里用户之前发过什么、别的机器人说了什么时使用。**话题群和普通群都支持**：默认按当前 session 范围读取；话题/thread 会话只返回当前话题内消息，普通群 chat-scope 会话返回整群最近 N 条（默认 50，按时间倒序取尾部、再按时间正序返回）。觉得历史太多就把 \`--limit\` 调小，需要更多上下文就调大。
+
+如果你在 thread 里需要读取 thread 外的群聊上下文（典型场景：用户在普通群讨论后用 \`/t\` 单开话题叫你处理），使用 \`botmux history --scope ambient --limit 20\`。它会读取当前 thread 所在群里、thread root 之前的最近消息，并排除当前 thread 本身，适合作为环境上下文。
 
 ## 用法
 
@@ -128,6 +130,12 @@ botmux history --limit 100
 
 # 指定 session-id（不在 CLI 会话内时用）
 botmux history --session-id <uuid>
+
+# 在 thread 内读取 thread 外的群聊环境上下文（/t 场景优先用这个）
+botmux history --scope ambient --limit 20
+
+# 在 thread 内强制读取整个群聊最近消息（包含其他话题/卡片，噪音更大）
+botmux history --scope chat --limit 50
 \`\`\`
 
 ## 输出
@@ -138,8 +146,14 @@ JSON 格式，字段：
 {
   "sessionId": "...",
   "chatId": "...",
-  "scope": "thread" | "chat",
+  "scope": "thread" | "chat" | "ambient",
+  "sessionScope": "thread" | "chat",
   "rootMessageId": "...",     // 仅 scope=thread 时存在
+  "ambient": {                 // 仅 scope=ambient 时存在
+    "source": "chat",
+    "beforeCreateTime": "...",
+    "excludeRootMessageId": "..."
+  },
   "messages": [
     { "messageId": "...", "senderId": "...", "senderType": "user|app", "msgType": "text|post|interactive", "content": "...", "createTime": "..." }
   ],
@@ -151,6 +165,7 @@ JSON 格式，字段：
 
 - \`scope=thread\`：只返回属于当前话题的消息（按 rootMessageId 过滤）
 - \`scope=chat\`：返回当前群整群最近 N 条消息（不限于 session 创建之后，需要更老的就把 --limit 调大）
+- \`scope=ambient\`：返回当前 thread 外的群聊上下文，默认排除当前 thread，并优先限制在 thread root 创建前，适合 \`/t\` 后补充群内讨论背景
 - \`senderType="app"\` 表示机器人发的消息（包括 Claude Code / Codex / 其它 bot），\`"user"\` 表示用户
 - **合并转发**消息会自动展开：\`msgType\` 变为 \`merge_forward_expanded\`，\`content\` 是 \`<forwarded_messages>...</forwarded_messages>\` XML（含 \`<participants>\` 别名表 + 嵌套 \`<msg from="A">\` 节点），与 daemon 实时事件路径一致
 - 需要先把 JSON 读进来再做总结，不要直接把 JSON 扔给用户

--- a/src/utils/working-dir.ts
+++ b/src/utils/working-dir.ts
@@ -1,0 +1,44 @@
+import { statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+export function expandHomePath(p: string): string {
+  return p.startsWith('~') ? join(homedir(), p.slice(1)) : p;
+}
+
+export function parseWorkingDirList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .flatMap(v => parseWorkingDirList(v))
+      .filter(Boolean);
+  }
+  if (typeof value !== 'string') return [];
+  return value.split(',').map(s => s.trim()).filter(Boolean);
+}
+
+export function configuredWorkingDirs(input: { workingDir?: unknown; workingDirs?: unknown }): string[] {
+  const dirs = [
+    ...parseWorkingDirList(input.workingDir),
+    ...parseWorkingDirList(input.workingDirs),
+  ];
+  const seen = new Set<string>();
+  return dirs.filter(dir => {
+    const resolved = resolve(expandHomePath(dir));
+    if (seen.has(resolved)) return false;
+    seen.add(resolved);
+    return true;
+  });
+}
+
+export function invalidWorkingDirs(input: { workingDir?: unknown; workingDirs?: unknown }): string[] {
+  const invalid: string[] = [];
+  for (const dir of configuredWorkingDirs(input)) {
+    const resolved = resolve(expandHomePath(dir));
+    try {
+      if (!statSync(resolved).isDirectory()) invalid.push(resolved);
+    } catch {
+      invalid.push(resolved);
+    }
+  }
+  return invalid;
+}

--- a/test/ambient-history.test.ts
+++ b/test/ambient-history.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Unit tests for ambient chat history filtering.
+ *
+ * Run: pnpm vitest run test/ambient-history.test.ts
+ */
+import { describe, expect, it } from 'vitest';
+import { filterAmbientChatMessages } from '../src/im/lark/client.js';
+
+function msg(id: string, createTime: string, rootId?: string) {
+  return { message_id: id, create_time: createTime, ...(rootId ? { root_id: rootId } : {}) };
+}
+
+describe('filterAmbientChatMessages', () => {
+  it('excludes current thread root/replies and messages created at or after the root', () => {
+    const out = filterAmbientChatMessages([
+      msg('m1', '1000'),
+      msg('m2', '2000'),
+      msg('root', '3000'),
+      msg('reply', '3100', 'root'),
+      msg('later', '4000'),
+    ], 20, { beforeCreateTime: '3000', excludeRootMessageId: 'root' });
+
+    expect(out.map(m => m.message_id)).toEqual(['m1', 'm2']);
+  });
+
+  it('caps after filtering so callers get the newest ambient tail', () => {
+    const out = filterAmbientChatMessages([
+      msg('m1', '1000'),
+      msg('m2', '2000'),
+      msg('m3', '2500'),
+      msg('root', '3000'),
+      msg('reply', '3100', 'root'),
+    ], 2, { beforeCreateTime: '3000', excludeRootMessageId: 'root' });
+
+    expect(out.map(m => m.message_id)).toEqual(['m2', 'm3']);
+  });
+
+  it('keeps messages with malformed timestamps instead of dropping context', () => {
+    const out = filterAmbientChatMessages([
+      msg('m1', 'not-a-number'),
+      msg('root', '3000'),
+    ], 20, { beforeCreateTime: '3000', excludeRootMessageId: 'root' });
+
+    expect(out.map(m => m.message_id)).toEqual(['m1']);
+  });
+});

--- a/test/builtin-skills.test.ts
+++ b/test/builtin-skills.test.ts
@@ -24,6 +24,8 @@ describe('built-in botmux-history skill', () => {
     // Description must mention 普通群 so普通群 bots actually trigger the skill.
     expect(history!.content).toContain('普通群');
     expect(history!.content).toContain('scope=chat');
+    expect(history!.content).toContain('--scope ambient');
+    expect(history!.content).toContain('thread 外的群聊上下文');
   });
 
   it('retires the old botmux-thread-messages name', () => {

--- a/test/builtin-skills.test.ts
+++ b/test/builtin-skills.test.ts
@@ -26,6 +26,8 @@ describe('built-in botmux-history skill', () => {
     expect(history!.content).toContain('scope=chat');
     expect(history!.content).toContain('--scope ambient');
     expect(history!.content).toContain('thread 外的群聊上下文');
+    expect(history!.content).toContain('仅在用户明确需要群聊背景时使用');
+    expect(history!.content).toContain('sessionScope=thread');
   });
 
   it('retires the old botmux-thread-messages name', () => {

--- a/test/message-parser.test.ts
+++ b/test/message-parser.test.ts
@@ -21,6 +21,27 @@ function makeMsg(msgType: string, content: object | string) {
   };
 }
 
+// ─── API message metadata ─────────────────────────────────────────────────
+
+describe('parseApiMessage metadata', () => {
+  it('preserves root_id when present', () => {
+    const result = parseApiMessage({
+      ...makeMsg('text', { text: 'reply' }),
+      root_id: 'om_root',
+      thread_id: 'omt_thread',
+    });
+    expect(result.rootId).toBe('om_root');
+  });
+
+  it('falls back to thread_id for rootId when root_id is absent', () => {
+    const result = parseApiMessage({
+      ...makeMsg('text', { text: 'topic root' }),
+      thread_id: 'omt_thread',
+    });
+    expect(result.rootId).toBe('omt_thread');
+  });
+});
+
 // ─── Interactive card: Format A (Lark API simplified) ─────────────────────
 
 describe('Interactive card parsing: Format A (API simplified)', () => {

--- a/test/working-dir.test.ts
+++ b/test/working-dir.test.ts
@@ -1,0 +1,30 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { configuredWorkingDirs, invalidWorkingDirs, parseWorkingDirList } from '../src/utils/working-dir.js';
+
+describe('working-dir utils', () => {
+  it('parses comma-separated strings and arrays', () => {
+    expect(parseWorkingDirList('/a, /b,,/c')).toEqual(['/a', '/b', '/c']);
+    expect(parseWorkingDirList(['/a, /b', ' /c '])).toEqual(['/a', '/b', '/c']);
+    expect(parseWorkingDirList(undefined)).toEqual([]);
+  });
+
+  it('dedupes configured dirs by resolved path', () => {
+    const cwd = process.cwd();
+    expect(configuredWorkingDirs({ workingDir: '., ' + cwd })).toEqual(['.']);
+  });
+
+  it('reports missing paths and files as invalid dirs', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-working-dir-'));
+    const file = join(dir, 'not-a-dir');
+    const missing = join(dir, 'missing');
+    writeFileSync(file, 'x');
+
+    expect(invalidWorkingDirs({ workingDir: [dir, file, missing] })).toEqual([
+      resolve(file),
+      resolve(missing),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `botmux history --scope session|thread|chat|ambient`
- support ambient chat history for `/t` thread sessions by reading the parent chat tail before the thread root and filtering out the current thread
- document the new scope in the built-in `botmux-history` skill and add regression tests

## Validation
- `pnpm test -- test/ambient-history.test.ts test/builtin-skills.test.ts test/message-parser.test.ts` (59 passed)
- `pnpm build`

## Review
- Reviewed in Botmux thread by Botmux Oncall(CoCo): LGTM, no blocking issues found.
