### PR TITLE
fix(codex): 新会话显式传入工作目录

### DIFF
--- a/src/adapters/cli/codex.ts
+++ b/src/adapters/cli/codex.ts
@@ -110,15 +110,19 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
     id: 'codex',
     resolvedBin: bin,
 
-    buildArgs({ sessionId, resume, resumeSessionId }) {
+    buildArgs({ sessionId, resume, resumeSessionId, workingDir }) {
       const baseArgs = [
         '--dangerously-bypass-approvals-and-sandbox',
         '--no-alt-screen',
       ];
-      if (!resume) return baseArgs;
+      // Codex app-server can keep its own cwd at $HOME; -C pins fresh agent roots.
+      const freshArgs = workingDir
+        ? [...baseArgs, '-C', workingDir]
+        : baseArgs;
+      if (!resume) return freshArgs;
 
       const codexSessionId = resumeSessionId ?? latestCodexSessionForBotmuxSession(sessionId);
-      if (!codexSessionId) return baseArgs;
+      if (!codexSessionId) return freshArgs;
       return ['resume', ...baseArgs, codexSessionId];
     },
 

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -27,13 +27,15 @@ export interface CliAdapter {
   readonly resolvedBin: string;
 
   /** Build spawn arguments (bin comes from resolvedBin).
-   *  Note: workingDir is NOT passed here — it's the backend's cwd, not a CLI arg.
+   *  The backend also spawns the process in `workingDir`; adapters may use the
+   *  same value when a CLI needs an explicit workspace-root flag.
    *  When initialPrompt is provided and the adapter supports it, the prompt
    *  is baked into CLI args (e.g. Gemini's -i flag) instead of being written
    *  to stdin after idle detection. */
   buildArgs(opts: {
     sessionId: string;
     resume: boolean;
+    workingDir?: string;
     /** CLI-native session id used for resume when it differs from botmux's session id. */
     resumeSessionId?: string;
     initialPrompt?: string;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2471,6 +2471,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   const args = cliAdapter.buildArgs({
     sessionId: cfg.sessionId,
     resume: cfg.resume ?? false,
+    workingDir: cfg.workingDir,
     resumeSessionId: cfg.cliSessionId,
     initialPrompt: cfg.prompt || undefined,
     botName: cfg.botName,

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -161,6 +161,16 @@ describe('codex buildArgs', () => {
     const args = adapter.buildArgs({ sessionId: 'sess-4', resume: false });
     expect(args).not.toContain('sess-4');
   });
+
+  it('passes the effective working directory as Codex agent root', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-4', resume: false, workingDir: '/repo/root' });
+    expect(args).toEqual([
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--no-alt-screen',
+      '-C',
+      '/repo/root',
+    ]);
+  });
 });
 
 describe('gemini buildArgs', () => {

--- a/test/write-input.test.ts
+++ b/test/write-input.test.ts
@@ -830,6 +830,23 @@ describe('codex writeInput submission confirmation', () => {
     ]);
   });
 
+  it('buildArgs does not override Codex resume cwd with -C', () => {
+    resetCodexHistory();
+    const adapter = createCodexAdapter('/bin/codex');
+
+    expect(adapter.buildArgs({
+      sessionId: 'botmux-session',
+      resume: true,
+      resumeSessionId: '019dd3e2-f2da-7592-86b5-a43d4cd0772f',
+      workingDir: '/repo/root',
+    })).toEqual([
+      'resume',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--no-alt-screen',
+      '019dd3e2-f2da-7592-86b5-a43d4cd0772f',
+    ]);
+  });
+
   it('buildArgs falls back to the latest history entry containing the botmux session id', () => {
     resetCodexHistory();
     appendCodexHistory('<session_id>botmux-session</session_id>', 'old-codex-session');
@@ -852,6 +869,22 @@ describe('codex writeInput submission confirmation', () => {
     expect(adapter.buildArgs({ sessionId: 'botmux-session', resume: true })).toEqual([
       '--dangerously-bypass-approvals-and-sandbox',
       '--no-alt-screen',
+    ]);
+  });
+
+  it('buildArgs pins cwd when resume falls back to a fresh Codex session', () => {
+    resetCodexHistory();
+    const adapter = createCodexAdapter('/bin/codex');
+
+    expect(adapter.buildArgs({
+      sessionId: 'botmux-session',
+      resume: true,
+      workingDir: '/repo/root',
+    })).toEqual([
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--no-alt-screen',
+      '-C',
+      '/repo/root',
     ]);
   });
 


### PR DESCRIPTION
## 背景

Fixes #30

Codex app-server / Desktop 连接已存在时，app-server 进程 cwd 可能停在 HOME。botmux 虽然用 backend cwd 在目标项目目录启动 Codex TUI，但 Codex 新会话写入 rollout 的 agent cwd 仍可能落到 HOME。

## 改动

- 将 worker 的有效 `workingDir` 传给 CLI adapter 的 `buildArgs`。
- Codex 新建会话时追加 `-C <workingDir>`，让 agent root 由 botmux 选择的目录显式决定。
- 如果 botmux 请求 resume 但找不到 Codex session id、实际退化为新建会话，也追加 `-C <workingDir>`。
- 真正的 `codex resume <sessionId>` 不传 `-C`，保留 Codex 已记录的历史会话 cwd。
- 补充 fresh / resume / resume-fallback 三条参数构造测试。

## 验证

- `./node_modules/.bin/vitest run test/cli-adapters.test.ts test/write-input.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `npm exec --yes pnpm -- build`