### PR TITLE
fix(card): 修复 CLI 限额时飞书卡片状态不明确的问题

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/root/iserver/botmux/node_modules

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -14,7 +14,7 @@ import { createCliAdapterSync } from '../adapters/cli/registry.js';
 import { deleteMessage } from '../im/lark/client.js';
 import { logger } from '../utils/logger.js';
 import { killWorker, forkWorker, forkAdoptWorker, getCurrentCliVersion } from './worker-pool.js';
-import { expandHome, getSessionWorkingDir, getProjectScanDir, getProjectScanDirs } from './session-manager.js';
+import { expandHome, getSessionWorkingDir, getProjectScanDir, getProjectScanDirs, rememberLastCliInput } from './session-manager.js';
 import { validateWorkingDir } from './working-dir.js';
 import { discoverAdoptableSessions, validateAdoptTarget, type AdoptableSession } from './session-discovery.js';
 import { generateAuthUrl, getTokenStatus } from '../utils/user-token.js';
@@ -389,8 +389,9 @@ export async function handleCommand(
             const botCfg = selfBot.config;
             ds.pendingRepo = false;
             const { buildNewTopicPrompt, getAvailableBots } = await import('./session-manager.js');
+            const pendingPrompt = ds.pendingPrompt ?? '';
             const prompt = buildNewTopicPrompt(
-              ds.pendingPrompt ?? '',
+              pendingPrompt,
               ds.session.sessionId,
               botCfg.cliId,
               botCfg.cliPathOverride,
@@ -402,6 +403,7 @@ export async function handleCommand(
               loc,
               ds.pendingSender,
             );
+            rememberLastCliInput(ds, pendingPrompt, prompt);
             ds.pendingPrompt = undefined;
             ds.pendingAttachments = undefined;
             ds.pendingMentions = undefined;
@@ -414,6 +416,8 @@ export async function handleCommand(
             sessionStore.closeSession(ds.session.sessionId);
             const session = sessionStore.createSession(ds.chatId, rootId, displayName, ds.chatType);
             ds.session = session;
+            ds.lastUserPrompt = undefined;
+            ds.lastCliInput = undefined;
             ds.session.workingDir = selectedPath;
             ds.session.larkAppId = ds.larkAppId;
             sessionStore.updateSession(ds.session);
@@ -464,8 +468,9 @@ export async function handleCommand(
           const botCfg = selfBot.config;
           ds.pendingRepo = false;
           const { buildNewTopicPrompt, getAvailableBots } = await import('./session-manager.js');
+          const pendingPrompt = ds.pendingPrompt ?? '';
           const prompt = buildNewTopicPrompt(
-            ds.pendingPrompt ?? '',
+            pendingPrompt,
             ds.session.sessionId,
             botCfg.cliId,
             botCfg.cliPathOverride,
@@ -477,6 +482,7 @@ export async function handleCommand(
             loc,
             ds.pendingSender,
           );
+          rememberLastCliInput(ds, pendingPrompt, prompt);
           ds.pendingPrompt = undefined;
           ds.pendingAttachments = undefined;
           ds.pendingMentions = undefined;

--- a/src/core/dashboard-rows.ts
+++ b/src/core/dashboard-rows.ts
@@ -14,7 +14,7 @@ export interface SessionRow {
   larkAppId: string;
   botName: string;
   cliId: CliId | 'unknown';
-  status: 'starting' | 'working' | 'idle' | 'analyzing' | 'closed';
+  status: 'starting' | 'working' | 'idle' | 'analyzing' | 'limited' | 'closed';
   adopt: boolean;
   spawnedAt: number;
   lastMessageAt: number;

--- a/src/core/dashboard-rows.ts
+++ b/src/core/dashboard-rows.ts
@@ -6,7 +6,7 @@
 // module so worker-pool can import the composer without pulling in the IPC
 // server (which itself imports worker-pool — that would be a cycle).
 import type { DaemonSession } from './types.js';
-import type { Session } from '../types.js';
+import type { Session, StreamStatus } from '../types.js';
 import type { CliId } from '../adapters/cli/types.js';
 
 export interface SessionRow {
@@ -14,7 +14,7 @@ export interface SessionRow {
   larkAppId: string;
   botName: string;
   cliId: CliId | 'unknown';
-  status: 'starting' | 'working' | 'idle' | 'analyzing' | 'limited' | 'closed';
+  status: StreamStatus | 'closed';
   adopt: boolean;
   spawnedAt: number;
   lastMessageAt: number;

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -24,6 +24,7 @@ import type { ResolvedSender } from '../im/lark/identity-cache.js';
 import { sessionKey, sessionAnchorId } from './types.js';
 import type { DaemonSession } from './types.js';
 import { markSessionActivity } from './session-activity.js';
+import { usageLimitStateKey } from '../utils/cli-usage-limit.js';
 import { t, localeForBot, type Locale } from '../i18n/index.js';
 import { parseWorkingDirList } from '../utils/working-dir.js';
 
@@ -33,6 +34,12 @@ function sessionCreatedAtMs(session: { createdAt?: string }): number {
 
 function sessionLastMessageAtMs(session: { createdAt?: string; lastMessageAt?: string }): number {
   return session.lastMessageAt ? (Date.parse(session.lastMessageAt) || sessionCreatedAtMs(session)) : sessionCreatedAtMs(session);
+}
+
+function sameUsageLimit(a: DaemonSession['usageLimit'], b: DaemonSession['usageLimit']): boolean {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  return usageLimitStateKey(a) === usageLimitStateKey(b) && a.retryReady === b.retryReady;
 }
 
 // ─── Path helpers ────────────────────────────────────────────────────────────
@@ -455,16 +462,30 @@ export function persistStreamCardState(ds: DaemonSession): void {
     s.streamCardNonce === ds.streamCardNonce &&
     s.displayMode === ds.displayMode &&
     s.currentImageKey === ds.currentImageKey &&
-    s.currentTurnTitle === ds.currentTurnTitle
+    s.currentTurnTitle === ds.currentTurnTitle &&
+    sameUsageLimit(s.usageLimit, ds.usageLimit) &&
+    s.lastUserPrompt === ds.lastUserPrompt &&
+    s.lastCliInput === ds.lastCliInput
   ) return;
   s.streamCardId = cardId;
   s.streamCardNonce = ds.streamCardNonce;
   s.displayMode = ds.displayMode;
   s.currentImageKey = ds.currentImageKey;
   s.currentTurnTitle = ds.currentTurnTitle;
+  s.usageLimit = ds.usageLimit;
+  s.lastUserPrompt = ds.lastUserPrompt;
+  s.lastCliInput = ds.lastCliInput;
   // Clear legacy field so it doesn't drift
   s.streamExpanded = undefined;
   sessionStore.updateSession(s);
+}
+
+export function rememberLastCliInput(ds: DaemonSession, userPrompt: string, cliInput: string): void {
+  ds.lastUserPrompt = userPrompt;
+  ds.lastCliInput = cliInput;
+  ds.session.lastUserPrompt = userPrompt;
+  ds.session.lastCliInput = cliInput;
+  sessionStore.updateSession(ds.session);
 }
 
 // ─── Session restore ─────────────────────────────────────────────────────────
@@ -520,6 +541,9 @@ export function restoreActiveSessions(activeSessions: Map<string, DaemonSession>
           : (session.streamExpanded ? 'screenshot' : 'hidden'),
         currentImageKey: session.currentImageKey,
         currentTurnTitle: session.currentTurnTitle,
+        usageLimit: session.usageLimit,
+        lastUserPrompt: session.lastUserPrompt,
+        lastCliInput: session.lastCliInput,
       };
       const anchor = sessionAnchorId(ds);
       messageQueue.ensureQueue(anchor);
@@ -560,6 +584,9 @@ export function restoreActiveSessions(activeSessions: Map<string, DaemonSession>
       displayMode: session.displayMode ?? (session.streamExpanded ? 'screenshot' : 'hidden'),
       currentImageKey: session.currentImageKey,
       currentTurnTitle: session.currentTurnTitle,
+      usageLimit: session.usageLimit,
+      lastUserPrompt: session.lastUserPrompt,
+      lastCliInput: session.lastCliInput,
     };
     const anchor = sessionAnchorId(ds);
     messageQueue.ensureQueue(anchor);
@@ -692,6 +719,9 @@ export function resumeSession(
     displayMode: session.displayMode ?? (session.streamExpanded ? 'screenshot' : 'hidden'),
     currentImageKey: session.currentImageKey,
     currentTurnTitle: session.currentTurnTitle,
+    usageLimit: session.usageLimit,
+    lastUserPrompt: session.lastUserPrompt,
+    lastCliInput: session.lastCliInput,
   };
 
   messageQueue.ensureQueue(anchor);
@@ -830,6 +860,7 @@ export async function executeScheduledTask(
   if (isContinuation && existing?.worker && !existing.worker.killed) {
     markSessionActivity(existing);
     try {
+      rememberLastCliInput(existing, task.prompt, task.prompt);
       existing.worker.send({ type: 'message', content: task.prompt });
       logger.info(`[scheduler] Task "${task.name}" injected into live session ${existing.session.sessionId}`);
       return;
@@ -870,6 +901,7 @@ export async function executeScheduledTask(
     workingDir: task.workingDir,
   };
   activeSessions.set(sessionKey(anchor, larkAppId), ds);
+  rememberLastCliInput(ds, task.prompt, prompt);
   forkWorker(ds, prompt);
 
   logger.info(`[scheduler] Task "${task.name}" spawned (session: ${session.sessionId}, scope: ${scope}, anchor: ${anchor}, continuation: ${isContinuation})`);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess } from 'node:child_process';
 import type { Session, DaemonToWorker, LarkAttachment, LarkMention, DisplayMode } from '../types.js';
+import type { CliUsageLimitState } from '../utils/cli-usage-limit.js';
 
 /** Frozen card state — cached content for historical streaming cards that can still be toggled. */
 export interface FrozenCard {
@@ -66,7 +67,11 @@ export interface DaemonSession {
   /** Latest uploaded screenshot image_key for the streaming card. */
   currentImageKey?: string;
   lastScreenContent?: string;    // last screen_update content — used to freeze card at idle
-  lastScreenStatus?: 'starting' | 'working' | 'idle' | 'analyzing';  // last screen_update status
+  lastScreenStatus?: 'starting' | 'working' | 'idle' | 'analyzing' | 'limited';  // last screen_update status
+  usageLimit?: CliUsageLimitState;
+  usageLimitRetryTimer?: NodeJS.Timeout;
+  lastUserPrompt?: string;
+  lastCliInput?: string;
   currentTurnTitle?: string;      // title for the current turn's streaming card
   cardPatchInFlight?: boolean;    // true while a card PATCH is in-flight
   pendingCardJson?: string;       // queued card JSON — flushed when in-flight PATCH completes (latest wins)

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,5 @@
 import type { ChildProcess } from 'node:child_process';
-import type { Session, DaemonToWorker, LarkAttachment, LarkMention, DisplayMode } from '../types.js';
+import type { Session, DaemonToWorker, LarkAttachment, LarkMention, DisplayMode, StreamStatus } from '../types.js';
 import type { CliUsageLimitState } from '../utils/cli-usage-limit.js';
 
 /** Frozen card state — cached content for historical streaming cards that can still be toggled. */
@@ -67,7 +67,7 @@ export interface DaemonSession {
   /** Latest uploaded screenshot image_key for the streaming card. */
   currentImageKey?: string;
   lastScreenContent?: string;    // last screen_update content — used to freeze card at idle
-  lastScreenStatus?: 'starting' | 'working' | 'idle' | 'analyzing' | 'limited';  // last screen_update status
+  lastScreenStatus?: StreamStatus;  // last screen_update status
   usageLimit?: CliUsageLimitState;
   usageLimitRetryTimer?: NodeJS.Timeout;
   lastUserPrompt?: string;

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -27,6 +27,7 @@ import { composeRowFromActive } from './dashboard-rows.js';
 import type { CliId } from '../adapters/cli/types.js';
 import type { DaemonToWorker, WorkerToDaemon, Session, DisplayMode } from '../types.js';
 import { sessionKey, sessionAnchorId, type DaemonSession } from './types.js';
+import { usageLimitStateKey, type CliUsageLimitState } from '../utils/cli-usage-limit.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -94,6 +95,82 @@ function tag(ds: DaemonSession): string {
 
 function sessionCliId(ds: DaemonSession, botCfg: { cliId: CliId }): CliId {
   return ds.session.cliId ?? botCfg.cliId;
+}
+
+function clearUsageLimitState(ds: DaemonSession): void {
+  if (ds.usageLimitRetryTimer) {
+    clearTimeout(ds.usageLimitRetryTimer);
+    ds.usageLimitRetryTimer = undefined;
+  }
+  ds.usageLimit = undefined;
+  persistStreamCardState(ds);
+}
+
+function cardUsageLimit(ds: DaemonSession, status: DaemonSession['lastScreenStatus']): CliUsageLimitState | undefined {
+  return status === 'limited' ? ds.usageLimit : undefined;
+}
+
+function scheduleUsageLimitCardPatch(ds: DaemonSession): void {
+  if (ds.lastScreenStatus !== 'limited') return;
+  if (!ds.streamCardId || ds.streamCardId === CARD_POSTING_SENTINEL || !ds.workerPort) return;
+
+  const bot = getBot(ds.larkAppId);
+  const effectiveCliId = sessionCliId(ds, bot.config);
+  const readUrl = `http://${config.web.externalHost}:${ds.workerPort}`;
+  const turnTitle = ds.currentTurnTitle || ds.session.title || getCliDisplayName(effectiveCliId);
+  const cardJson = buildStreamingCard(
+    ds.session.sessionId,
+    sessionAnchorId(ds),
+    readUrl,
+    turnTitle,
+    ds.lastScreenContent ?? '',
+    'limited',
+    effectiveCliId,
+    ds.displayMode ?? 'hidden',
+    ds.streamCardNonce,
+    ds.currentImageKey,
+    !!ds.adoptedFrom,
+    false,
+    localeForBot(ds.larkAppId),
+    ds.usageLimit,
+  );
+  scheduleCardPatch(ds, cardJson);
+}
+
+function armUsageLimitRetryTimer(ds: DaemonSession, previous?: CliUsageLimitState): void {
+  if (!ds.usageLimit) return;
+
+  if (ds.usageLimitRetryTimer) {
+    clearTimeout(ds.usageLimitRetryTimer);
+    ds.usageLimitRetryTimer = undefined;
+  }
+
+  if (ds.usageLimit.retryReady || ds.usageLimit.retryAtMs <= Date.now()) {
+    const wasReady = !!previous?.retryReady;
+    ds.usageLimit = { ...ds.usageLimit, retryReady: true };
+    persistStreamCardState(ds);
+    if (!wasReady) scheduleUsageLimitCardPatch(ds);
+    return;
+  }
+
+  const key = usageLimitStateKey(ds.usageLimit);
+  const delayMs = Math.max(0, ds.usageLimit.retryAtMs - Date.now());
+  ds.usageLimitRetryTimer = setTimeout(() => {
+    if (!ds.usageLimit || usageLimitStateKey(ds.usageLimit) !== key) return;
+    ds.usageLimit = { ...ds.usageLimit, retryReady: true };
+    persistStreamCardState(ds);
+    scheduleUsageLimitCardPatch(ds);
+  }, delayMs);
+}
+
+function updateUsageLimitState(ds: DaemonSession, usageLimit?: CliUsageLimitState): void {
+  if (!usageLimit) return;
+
+  const previous = ds.usageLimit;
+
+  ds.usageLimit = usageLimit;
+  persistStreamCardState(ds);
+  armUsageLimitRetryTimer(ds, previous);
 }
 
 const WORKER_ERROR_MARKER = '[botmux-worker-error]';
@@ -370,6 +447,7 @@ export function ensureCliEnv(cliId: CliId, cliPathOverride?: string): void {
 // ─── Kill worker ────────────────────────────────────────────────────────────
 
 export function killWorker(ds: DaemonSession): void {
+  clearUsageLimitState(ds);
   if (!ds.worker || ds.worker.killed) return;
   try {
     ds.worker.send({ type: 'close' } as DaemonToWorker);
@@ -571,6 +649,10 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
         const readOnlyUrl = `http://${config.web.externalHost}:${msg.port}`;
         const writeUrl = `${readOnlyUrl}?token=${msg.token}`;
         logger.info(`[${t}] Worker ready, terminal at ${readOnlyUrl}`);
+        if (ds.usageLimit) {
+          ds.lastScreenStatus = 'limited';
+          armUsageLimitRetryTimer(ds);
+        }
         // Dashboard: surface the new xterm port so the live terminal link works.
         dashboardEventBus.publish({
           type: 'session.update',
@@ -593,13 +675,14 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
             const initTitle = ds.currentTurnTitle || ds.session.title || getCliDisplayName(effectiveCliId);
             // Reuse persisted nonce so existing card buttons (toggle/etc) keep working.
             if (!ds.streamCardNonce) ds.streamCardNonce = randomBytes(4).toString('hex');
+            const initStatus = ds.usageLimit ? 'limited' : 'starting';
             const streamCardJson = buildStreamingCard(
               ds.session.sessionId,
               sessionAnchorId(ds),
               readOnlyUrl,
               initTitle,
               ds.lastScreenContent ?? '',
-              'starting',
+              initStatus,
               effectiveCliId,
               ds.displayMode ?? 'hidden',
               ds.streamCardNonce,
@@ -607,6 +690,7 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
               isAdopt,
               showTakeover,
               loc,
+              initStatus === 'limited' ? ds.usageLimit : undefined,
             );
             await updateMessage(ds.larkAppId, restoredCardId, streamCardJson);
             persistStreamCardState(ds);
@@ -635,13 +719,14 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
         try {
           ds.streamCardNonce = randomBytes(4).toString('hex');
           const initTitle = ds.currentTurnTitle || ds.session.title || getCliDisplayName(effectiveCliId);
+          const initStatus = ds.usageLimit ? 'limited' : 'starting';
           const streamCardJson = buildStreamingCard(
             ds.session.sessionId,
             sessionAnchorId(ds),
             readOnlyUrl,
             initTitle,
             '',
-            'starting',
+            initStatus,
             effectiveCliId,
             ds.displayMode ?? 'hidden',
             ds.streamCardNonce,
@@ -649,6 +734,7 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
             isAdopt,
             showTakeover,
             loc,
+            initStatus === 'limited' ? ds.usageLimit : undefined,
           );
           ds.streamCardId = await cb.sessionReply(sessionAnchorId(ds), streamCardJson, 'interactive', ds.larkAppId);
           persistStreamCardState(ds);
@@ -702,15 +788,16 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
       case 'screen_update': {
         if (!ds.workerPort) break;
         const prevStatus = ds.lastScreenStatus;
+        updateUsageLimitState(ds, msg.usageLimit);
         ds.lastScreenContent = msg.content;
-        ds.lastScreenStatus = msg.status;
+        ds.lastScreenStatus = (msg.usageLimit ?? ds.usageLimit) ? 'limited' : msg.status;
 
         // Dashboard: publish a patch only when status truly transitioned, so
         // SSE clients reflect real state changes (starting → working → idle)
         // without flooding on every PTY tick. The screen analyzer is the
         // upstream debouncer — by the time we get here, status flips are
         // already coarse-grained.
-        if (prevStatus !== msg.status) {
+        if (prevStatus !== ds.lastScreenStatus) {
           dashboardEventBus.publish({
             type: 'session.update',
             body: {
@@ -744,7 +831,7 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
             readUrl,
             turnTitle,
             isNewTurn ? '' : msg.content,
-            msg.status,
+            ds.lastScreenStatus,
             effectiveCliId,
             mode,
             ds.streamCardNonce,
@@ -752,6 +839,7 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
             isAdopt,
             showTakeover,
             loc,
+            cardUsageLimit(ds, ds.lastScreenStatus),
           );
           // Mark POST in-flight so subsequent screen_updates are dropped,
           // not POSTed as duplicate cards.
@@ -782,7 +870,7 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
         } else {
           // Same turn — PATCH only on status change. Image PATCHes go through
           // the screenshot_uploaded path; text is no longer a card body mode.
-          const statusChanged = prevStatus !== msg.status;
+          const statusChanged = prevStatus !== ds.lastScreenStatus;
           if (!statusChanged) break;
           const cardJson = buildStreamingCard(
             ds.session.sessionId,
@@ -790,7 +878,7 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
             readUrl,
             turnTitle,
             msg.content,
-            msg.status,
+            ds.lastScreenStatus,
             effectiveCliId,
             mode,
             ds.streamCardNonce,
@@ -798,6 +886,7 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
             isAdopt,
             showTakeover,
             loc,
+            cardUsageLimit(ds, ds.lastScreenStatus),
           );
           scheduleCardPatch(ds, cardJson);
         }
@@ -809,7 +898,8 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
         // reflect previous turn's content. Next 10s cycle picks up fresh content.
         if (ds.streamCardPending) break;
         ds.currentImageKey = msg.imageKey;
-        ds.lastScreenStatus = msg.status;
+        updateUsageLimitState(ds, msg.usageLimit);
+        ds.lastScreenStatus = (msg.usageLimit ?? ds.usageLimit) ? 'limited' : msg.status;
         persistStreamCardState(ds);
         if ((ds.displayMode ?? 'hidden') !== 'screenshot') break;
         if (!ds.streamCardId || ds.streamCardId === CARD_POSTING_SENTINEL || !ds.workerPort) break;
@@ -821,7 +911,7 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
           readUrl,
           turnTitle,
           ds.lastScreenContent ?? '',
-          msg.status,
+          ds.lastScreenStatus,
           effectiveCliId,
           'screenshot',
           ds.streamCardNonce,
@@ -829,6 +919,7 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
           isAdopt,
           showTakeover,
           loc,
+          cardUsageLimit(ds, ds.lastScreenStatus),
         );
         scheduleCardPatch(ds, cardJson);
         break;

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -97,7 +97,7 @@ function sessionCliId(ds: DaemonSession, botCfg: { cliId: CliId }): CliId {
   return ds.session.cliId ?? botCfg.cliId;
 }
 
-function clearUsageLimitState(ds: DaemonSession): void {
+export function clearUsageLimitState(ds: DaemonSession): void {
   if (ds.usageLimitRetryTimer) {
     clearTimeout(ds.usageLimitRetryTimer);
     ds.usageLimitRetryTimer = undefined;
@@ -106,8 +106,8 @@ function clearUsageLimitState(ds: DaemonSession): void {
   persistStreamCardState(ds);
 }
 
-function cardUsageLimit(ds: DaemonSession, status: DaemonSession['lastScreenStatus']): CliUsageLimitState | undefined {
-  return status === 'limited' ? ds.usageLimit : undefined;
+export function cardUsageLimit(ds: DaemonSession): CliUsageLimitState | undefined {
+  return ds.lastScreenStatus === 'limited' ? ds.usageLimit : undefined;
 }
 
 function scheduleUsageLimitCardPatch(ds: DaemonSession): void {
@@ -167,6 +167,13 @@ function updateUsageLimitState(ds: DaemonSession, usageLimit?: CliUsageLimitStat
   if (!usageLimit) return;
 
   const previous = ds.usageLimit;
+  // Screen updates repeat the same limit every tick while a session sits
+  // blocked. Skip the persist + timer re-arm churn unless the limit changed.
+  if (
+    previous &&
+    usageLimitStateKey(previous) === usageLimitStateKey(usageLimit) &&
+    previous.retryReady === usageLimit.retryReady
+  ) return;
 
   ds.usageLimit = usageLimit;
   persistStreamCardState(ds);
@@ -839,7 +846,7 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
             isAdopt,
             showTakeover,
             loc,
-            cardUsageLimit(ds, ds.lastScreenStatus),
+            cardUsageLimit(ds),
           );
           // Mark POST in-flight so subsequent screen_updates are dropped,
           // not POSTed as duplicate cards.
@@ -886,7 +893,7 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
             isAdopt,
             showTakeover,
             loc,
-            cardUsageLimit(ds, ds.lastScreenStatus),
+            cardUsageLimit(ds),
           );
           scheduleCardPatch(ds, cardJson);
         }
@@ -919,7 +926,7 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
           isAdopt,
           showTakeover,
           loc,
-          cardUsageLimit(ds, ds.lastScreenStatus),
+          cardUsageLimit(ds),
         );
         scheduleCardPatch(ds, cardJson);
         break;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -64,6 +64,7 @@ import {
   restoreActiveSessions,
   executeScheduledTask,
   persistStreamCardState,
+  rememberLastCliInput,
 } from './core/session-manager.js';
 import { handleCardAction } from './im/lark/card-handler.js';
 import type { CardHandlerDeps } from './im/lark/card-handler.js';
@@ -291,6 +292,8 @@ function getActiveCount(): number {
  * sees no visible response.
  */
 function beginNewTurn(ds: DaemonSession, title: string): void {
+  const previousUsageLimit = ds.usageLimit;
+  const previousStatus = ds.lastScreenStatus === 'limited' && previousUsageLimit ? 'limited' : 'idle';
   if (ds.streamCardId && ds.workerPort) {
     const readUrl = `http://${config.web.externalHost}:${ds.workerPort}`;
     const dsBotCfg = getBot(ds.larkAppId).config;
@@ -298,9 +301,9 @@ function beginNewTurn(ds: DaemonSession, title: string): void {
     const prevMode = ds.displayMode ?? 'hidden';
     const frozenCard = buildStreamingCard(
       ds.session.sessionId, sessionAnchorId(ds), readUrl, prevTitle,
-      ds.lastScreenContent ?? '', 'idle', dsBotCfg.cliId,
+      ds.lastScreenContent ?? '', previousStatus, dsBotCfg.cliId,
       prevMode, ds.streamCardNonce, ds.currentImageKey,
-      !!ds.adoptedFrom, false, localeForBot(ds.larkAppId),
+      !!ds.adoptedFrom, false, localeForBot(ds.larkAppId), previousUsageLimit,
     );
     scheduleCardPatch(ds, frozenCard);
 
@@ -316,6 +319,11 @@ function beginNewTurn(ds: DaemonSession, title: string): void {
       saveFrozenCards(ds.session.sessionId, ds.frozenCards);
     }
   }
+  if (ds.usageLimitRetryTimer) {
+    clearTimeout(ds.usageLimitRetryTimer);
+    ds.usageLimitRetryTimer = undefined;
+  }
+  ds.usageLimit = undefined;
   ds.streamCardPending = true;
   ds.currentTurnTitle = title.substring(0, 50);
   ds.currentImageKey = undefined;
@@ -619,6 +627,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
     if (await replyInvalidWorkingDirs(anchor, larkAppId, ds)) return;
     const selfBot = getBot(larkAppId);
     const prompt = buildNewTopicPrompt(promptContent, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, chatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId }, localeForBot(larkAppId), newTopicSender);
+    rememberLastCliInput(ds, promptContent, prompt);
     forkWorker(ds, prompt);
     const reason = oncallEntry
       ? `oncall-bound chat ${chatId}`
@@ -645,6 +654,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
     ds.pendingRepo = false;
     const selfBot = getBot(larkAppId);
     const prompt = buildNewTopicPrompt(promptContent, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, chatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId }, localeForBot(larkAppId), newTopicSender);
+    rememberLastCliInput(ds, promptContent, prompt);
     forkWorker(ds, prompt);
     logger.info(`Session ${session.sessionId} ready (no projects to select), total active: ${getActiveCount()}`);
   }
@@ -968,6 +978,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
       if (await replyInvalidWorkingDirs(anchor, larkAppId, newDs)) return;
       const selfBot = getBot(larkAppId);
       const prompt = buildNewTopicPrompt(promptContent, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, autoCreateChatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId }, localeForBot(larkAppId), autoCreateSender);
+      rememberLastCliInput(newDs, promptContent, prompt);
       forkWorker(newDs, prompt);
       const reason = oncallEntry
         ? `oncall-bound chat ${autoCreateChatId}`
@@ -994,6 +1005,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
       newDs.pendingRepo = false;
       const selfBot = getBot(larkAppId);
       const prompt = buildNewTopicPrompt(promptContent, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, autoCreateChatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId }, localeForBot(larkAppId), autoCreateSender);
+      rememberLastCliInput(newDs, promptContent, prompt);
       forkWorker(newDs, prompt);
     }
 
@@ -1028,12 +1040,18 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
           sender: await getThreadSender(),
         });
     beginNewTurn(ds, parsed.content);
+    rememberLastCliInput(ds, promptContent, msgContent);
     ds.worker.send({ type: 'message', content: msgContent } as DaemonToWorker);
   } else {
     // Worker not running — re-fork with resume. This is a NEW turn, so drop
     // any restored streaming-card reference; worker_ready will POST a fresh
     // card instead of PATCHing the previous turn's card in place.
     logger.info(`[${tag(ds)}] Worker not running, re-forking...`);
+    if (ds.usageLimitRetryTimer) {
+      clearTimeout(ds.usageLimitRetryTimer);
+      ds.usageLimitRetryTimer = undefined;
+    }
+    ds.usageLimit = undefined;
     ds.currentTurnTitle = parsed.content.substring(0, 50);
     // The cosmetic freeze step (above) is gated on a live worker. With no
     // worker we just park the current card in frozenCards — the upcoming
@@ -1069,6 +1087,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
       selfMention: { name: selfBot.botName, openId: selfBot.botOpenId },
       sender: await getThreadSender(),
     });
+    rememberLastCliInput(ds, promptContent, wrappedPrompt);
     forkWorker(ds, wrappedPrompt, ds.hasHistory);
   }
 }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -17,12 +17,15 @@ export const messages: Record<string, string> = {
   'card.btn.half_page_up': '⇞ Page ½ Up',
   'card.btn.half_page_down': '⇟ Page ½ Down',
   'card.btn.send_custom': '📝 Send Custom Reply',
+  'card.btn.retry_last_task': '🔁 Retry Last Task',
 
   // ─── Card status ─────────────────────────────────────────────────────────
   'card.status.starting': 'Starting…',
   'card.status.working': 'Working',
   'card.status.idle': 'Awaiting input',
   'card.status.analyzing': 'Analyzing…',
+  'card.status.limited': 'Limit reached',
+  'card.status.retry_ready': 'Ready to retry',
   'card.status.executing': 'Executing…',
   'card.status.session_closed': '🛑 Session Closed',
   'card.status.selected': 'Selected',
@@ -36,6 +39,8 @@ export const messages: Record<string, string> = {
   'card.body.cli_no_cli_resume': '_{cliName} cannot resume a specific session from the CLI; you can resume here in Lark._',
   'card.body.working_dir': '📁 Working dir:',
   'card.body.choose_label': 'Choice:',
+  'card.usage_limit.retry_at': '⚠️ {cliName} usage limit has been reached. Try again after {retryLabel}.',
+  'card.usage_limit.retry_ready': '✅ {cliName} usage limit should have reset. Retry the last task, or send a new message.',
 
   // ─── Repo select card ────────────────────────────────────────────────────
   'card.repo.title': '📁 Project Repository',
@@ -237,6 +242,9 @@ export const messages: Record<string, string> = {
   'card.action.tui_custom_input': 'Custom input',
   'card.action.tui_done': 'Done',
   'card.action.continue_using_current_repo': 'Keeping current repo: {cwd}',
+  'card.action.retry_last_task_missing': '⚠️ Cannot find the last task to retry. Send a new message instead.',
+  'card.action.retry_last_task_unavailable': '⚠️ This retry state is no longer active. Send a new message instead.',
+  'card.action.retry_last_task_not_ready': '⚠️ The limit is still active. Try again after {retryLabel}.',
 
   // ─── Worker → daemon notices ─────────────────────────────────────────────
   'worker.adopted_session_exited': '⏏ Adopted CLI session has exited.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -20,12 +20,15 @@ export const messages: Record<string, string> = {
   'card.btn.half_page_up': '⇞ 上半屏',
   'card.btn.half_page_down': '⇟ 下半屏',
   'card.btn.send_custom': '📝 发送自定义回复',
+  'card.btn.retry_last_task': '🔁 重发上一条任务',
 
   // ─── Card status ─────────────────────────────────────────────────────────
   'card.status.starting': '启动中…',
   'card.status.working': '工作中',
   'card.status.idle': '等待输入',
   'card.status.analyzing': '正在分析…',
+  'card.status.limited': '限额已达',
+  'card.status.retry_ready': '可重试',
   'card.status.executing': '正在执行…',
   'card.status.session_closed': '🛑 会话已关闭',
   'card.status.selected': '已选择',
@@ -39,6 +42,8 @@ export const messages: Record<string, string> = {
   'card.body.cli_no_cli_resume': '{cliName} 不支持从命令行精确恢复指定会话，可在飞书内 resume。',
   'card.body.working_dir': '📁 工作目录：',
   'card.body.choose_label': '选择:',
+  'card.usage_limit.retry_at': '⚠️ 当前已达到 {cliName} 使用限额。请在 {retryLabel} 后再试。',
+  'card.usage_limit.retry_ready': '✅ {cliName} 限额预计已刷新。你可以重发上一条任务，或直接发送新消息。',
 
   // ─── Repo select card ────────────────────────────────────────────────────
   'card.repo.title': '📁 项目仓库管理',
@@ -240,6 +245,9 @@ export const messages: Record<string, string> = {
   'card.action.tui_custom_input': 'Custom input',
   'card.action.tui_done': 'Done',
   'card.action.continue_using_current_repo': '继续使用当前仓库：{cwd}',
+  'card.action.retry_last_task_missing': '⚠️ 找不到上一条任务，无法重发。请直接发送新的消息。',
+  'card.action.retry_last_task_unavailable': '⚠️ 当前重试状态已失效。请直接发送新的消息。',
+  'card.action.retry_last_task_not_ready': '⚠️ 当前仍在限额中，请在 {retryLabel} 后再试。',
 
   // ─── Worker → daemon notices ─────────────────────────────────────────────
   'worker.adopted_session_exited': '⏏ 已采纳的 CLI 会话已退出',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -2,6 +2,7 @@ import type { ProjectInfo } from '../../services/project-scanner.js';
 import type { CliId } from '../../adapters/cli/types.js';
 import type { AdoptableSession } from '../../core/session-discovery.js';
 import type { DisplayMode } from '../../types.js';
+import type { CliUsageLimitState } from '../../utils/cli-usage-limit.js';
 import { t, type Locale } from '../../i18n/index.js';
 
 const cliDisplayNames: Record<CliId, string> = {
@@ -198,7 +199,7 @@ export function buildStreamingCard(
   terminalUrl: string,
   title: string,
   screenContent: string,
-  status: 'starting' | 'working' | 'idle' | 'analyzing',
+  status: 'starting' | 'working' | 'idle' | 'analyzing' | 'limited',
   cliId?: CliId,
   displayMode: DisplayMode = 'hidden',
   cardNonce?: string,
@@ -206,23 +207,38 @@ export function buildStreamingCard(
   adoptMode?: boolean,
   showTakeover?: boolean,
   locale?: Locale,
+  usageLimit?: CliUsageLimitState,
 ): string {
   const effectiveCliId = cliId ?? 'claude-code';
   const cliName = getCliDisplayName(effectiveCliId);
   const actionBase = { root_id: rootId, session_id: sessionId, cli_id: effectiveCliId, ...(cardNonce ? { card_nonce: cardNonce } : {}) };
-  const templateMap = { starting: 'yellow', working: 'blue', idle: 'green', analyzing: 'purple' } as const;
+  const displayStatus = status === 'limited' && usageLimit?.retryReady ? 'retry_ready' : status;
+  const templateMap = { starting: 'yellow', working: 'blue', idle: 'green', analyzing: 'purple', limited: 'red', retry_ready: 'green' } as const;
   const statusLabel = (s: typeof status): string => {
     switch (s) {
       case 'starting': return t('card.status.starting', undefined, locale);
       case 'working': return t('card.status.working', undefined, locale);
       case 'idle': return t('card.status.idle', undefined, locale);
       case 'analyzing': return t('card.status.analyzing', undefined, locale);
+      case 'limited': return usageLimit?.retryReady
+        ? t('card.status.retry_ready', undefined, locale)
+        : t('card.status.limited', undefined, locale);
     }
   };
 
   const elements: any[] = [];
 
   // ── Output body ─────────────────────────────────────────────────────────
+  if (status === 'limited' && usageLimit) {
+    elements.push({
+      tag: 'markdown',
+      content: usageLimit.retryReady
+        ? t('card.usage_limit.retry_ready', { cliName }, locale)
+        : t('card.usage_limit.retry_at', { cliName, retryLabel: usageLimit.retryLabel }, locale),
+    });
+    elements.push({ tag: 'hr' });
+  }
+
   if (displayMode === 'screenshot') {
     if (imageKey) {
       elements.push({
@@ -269,6 +285,14 @@ export function buildStreamingCard(
     type: 'primary',
     multi_url: { url: terminalUrl, pc_url: terminalUrl, android_url: terminalUrl, ios_url: terminalUrl },
   });
+  if (status === 'limited' && usageLimit?.retryReady) {
+    headerActions.push({
+      tag: 'button',
+      text: { tag: 'plain_text', content: t('card.btn.retry_last_task', undefined, locale) },
+      type: 'primary' as const,
+      value: { action: 'retry_last_task', ...actionBase },
+    });
+  }
   headerActions.push({
     tag: 'button',
     text: { tag: 'plain_text', content: t('card.btn.get_write_link', undefined, locale) },
@@ -336,7 +360,7 @@ export function buildStreamingCard(
     config: { wide_screen_mode: true },
     header: {
       title: { tag: 'plain_text', content: `🖥️ ${cliName} · ${escapeMd(title)} — ${statusLabel(status)}` },
-      template: templateMap[status],
+      template: templateMap[displayStatus],
     },
     elements,
   };

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -1,7 +1,7 @@
 import type { ProjectInfo } from '../../services/project-scanner.js';
 import type { CliId } from '../../adapters/cli/types.js';
 import type { AdoptableSession } from '../../core/session-discovery.js';
-import type { DisplayMode } from '../../types.js';
+import type { DisplayMode, StreamStatus } from '../../types.js';
 import type { CliUsageLimitState } from '../../utils/cli-usage-limit.js';
 import { t, type Locale } from '../../i18n/index.js';
 
@@ -199,7 +199,7 @@ export function buildStreamingCard(
   terminalUrl: string,
   title: string,
   screenContent: string,
-  status: 'starting' | 'working' | 'idle' | 'analyzing' | 'limited',
+  status: StreamStatus,
   cliId?: CliId,
   displayMode: DisplayMode = 'hidden',
   cardNonce?: string,

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -16,7 +16,7 @@ import { logger } from '../../utils/logger.js';
 import * as sessionStore from '../../services/session-store.js';
 import { loadFrozenCards, saveFrozenCards } from '../../services/frozen-card-store.js';
 import { forkWorker, killWorker, scheduleCardPatch, parkStreamCard } from '../../core/worker-pool.js';
-import { getSessionWorkingDir, buildNewTopicPrompt, getAvailableBots, persistStreamCardState, resumeSession } from '../../core/session-manager.js';
+import { getSessionWorkingDir, buildNewTopicPrompt, getAvailableBots, persistStreamCardState, resumeSession, rememberLastCliInput } from '../../core/session-manager.js';
 import type { DaemonToWorker, DisplayMode, TermActionKey } from '../../types.js';
 import { sessionKey, sessionAnchorId, frozenDisplayMode } from '../../core/types.js';
 import type { DaemonSession } from '../../core/types.js';
@@ -82,6 +82,18 @@ function sessionCliId(ds: DaemonSession) {
   return ds.session.cliId ?? getBot(ds.larkAppId).config.cliId;
 }
 
+function clearUsageLimitState(ds: DaemonSession): void {
+  if (ds.usageLimitRetryTimer) {
+    clearTimeout(ds.usageLimitRetryTimer);
+    ds.usageLimitRetryTimer = undefined;
+  }
+  ds.usageLimit = undefined;
+}
+
+function cardUsageLimit(ds: DaemonSession) {
+  return ds.lastScreenStatus === 'limited' ? ds.usageLimit : undefined;
+}
+
 function validateCardCliBinding(ds: DaemonSession, value?: Record<string, string>): boolean {
   const expected = value?.cli_id;
   if (!expected) return true;
@@ -129,7 +141,6 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
   // Use the receiving bot's allowedUsers — the operator open_id in card actions
   // is scoped to the app that received the callback.
   const operatorOpenId = data?.operator?.open_id;
-
   // ─── 群内授权卡片动作（grant_chat / grant_global / grant_deny）─────────────
   // 不绑定 session，必须在 session 解析之前处理。owner 强闸门 + nonce 校验。
   if (value?.action && (value.action === 'grant_chat' || value.action === 'grant_global' || value.action === 'grant_deny') && larkAppId) {
@@ -181,7 +192,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     return JSON.parse(buildGrantResultCard(kind, loc));
   }
 
-  const isSensitive = value?.action && ['restart', 'close', 'resume', 'skip_repo', 'get_write_link', 'toggle_stream', 'toggle_display', 'export_text', 'term_action', 'refresh_screenshot', 'takeover', 'disconnect', 'tui_keys', 'tui_text_input'].includes(value.action);
+  const isSensitive = value?.action && ['restart', 'close', 'resume', 'skip_repo', 'retry_last_task', 'get_write_link', 'toggle_stream', 'toggle_display', 'export_text', 'term_action', 'refresh_screenshot', 'takeover', 'disconnect', 'tui_keys', 'tui_text_input'].includes(value.action);
   if (isSensitive) {
     const rootId = value?.root_id;
     // activeSessions is keyed by sessionKey(anchor, larkAppId) — `${anchor}::${larkAppId}`
@@ -331,6 +342,62 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     if (actionType === 'takeover' && ds && ds.adoptedFrom) {
       await sessionReply(rootId, t('card.action.takeover_retired', undefined, localeForBot(ds.larkAppId)));
       logger.info(`[${tag(ds)}] Legacy takeover action ignored (bridge era; historical card)`);
+    }
+
+    if (actionType === 'retry_last_task' && ds) {
+      const locDs = localeForBot(ds.larkAppId);
+      const cliInput = ds.lastCliInput;
+      if (!cliInput) {
+        await sessionReply(rootId, t('card.action.retry_last_task_missing', undefined, locDs));
+        return;
+      }
+      if (!ds.usageLimit) {
+        await sessionReply(rootId, t('card.action.retry_last_task_unavailable', undefined, locDs));
+        return;
+      }
+      if (!ds.usageLimit.retryReady && ds.usageLimit.retryAtMs > Date.now()) {
+        await sessionReply(rootId, t('card.action.retry_last_task_not_ready', { retryLabel: ds.usageLimit.retryLabel }, locDs));
+        return;
+      }
+
+      clearUsageLimitState(ds);
+      ds.lastScreenStatus = 'working';
+      ds.streamCardPending = true;
+      ds.currentTurnTitle = (ds.lastUserPrompt || ds.currentTurnTitle || ds.session.title || getCliDisplayName(sessionCliId(ds))).substring(0, 50);
+      ds.currentImageKey = undefined;
+      persistStreamCardState(ds);
+
+      let cardJson: string | undefined;
+      if (ds.streamCardId && ds.streamCardId !== '__posting__' && ds.workerPort) {
+        const readUrl = `http://${config.web.externalHost}:${ds.workerPort}`;
+        cardJson = buildStreamingCard(
+          ds.session.sessionId,
+          sessionAnchorId(ds),
+          readUrl,
+          ds.currentTurnTitle,
+          '',
+          'working',
+          sessionCliId(ds),
+          ds.displayMode ?? 'hidden',
+          ds.streamCardNonce,
+          ds.currentImageKey,
+          !!ds.adoptedFrom,
+          false,
+          locDs,
+        );
+        scheduleCardPatch(ds, cardJson);
+      }
+
+      if (ds.worker && !ds.worker.killed) {
+        ds.worker.send({ type: 'message', content: cliInput } as DaemonToWorker);
+      } else {
+        forkWorker(ds, cliInput, ds.hasHistory);
+      }
+      logger.info(`[${tag(ds)}] Retrying last task after usage limit`);
+      if (cardJson) {
+        try { return JSON.parse(cardJson); } catch { /* fall through */ }
+      }
+      return;
     }
 
     if (actionType === 'tui_keys' && ds) {
@@ -502,6 +569,8 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
               ds.currentImageKey,
               !!ds.adoptedFrom,
               false,
+              localeForBot(ds.larkAppId),
+              cardUsageLimit(ds),
             );
             updateMessage(ds.larkAppId, cardMessageId, cardJson).catch(err =>
               logger.debug(`[${tag(ds)}] Failed to migrate unknown frozen card: ${err}`),
@@ -542,6 +611,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
           !!ds.adoptedFrom,
           false,
           localeForBot(ds.larkAppId),
+          cardUsageLimit(ds),
         );
         updateMessage(ds.larkAppId, frozen.messageId, cardJson).catch(err =>
           logger.debug(`[${tag(ds)}] Failed to migrate frozen card: ${err}`),
@@ -580,6 +650,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
           !!ds.adoptedFrom,
           false,
           localeForBot(ds.larkAppId),
+          cardUsageLimit(ds),
         );
         if (cardMessageId && cardMessageId !== ds.streamCardId) {
           updateMessage(ds.larkAppId, cardMessageId, cardJson).catch(err =>
@@ -643,6 +714,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
           !!ds.adoptedFrom,
           false,
           localeForBot(ds.larkAppId),
+          cardUsageLimit(ds),
         );
         if (cardMessageId && cardMessageId !== ds.streamCardId) {
           updateMessage(ds.larkAppId, cardMessageId, cardJson).catch(err =>
@@ -681,6 +753,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
           !!ds.adoptedFrom,
           false,
           localeForBot(ds.larkAppId),
+          cardUsageLimit(ds),
         );
         try { return JSON.parse(cardJson); } catch { /* fall through */ }
       }
@@ -695,8 +768,9 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
         const effectiveCliId = sessionCliId(ds);
         // Skip repo selection — spawn CLI with default working dir
         ds.pendingRepo = false;
+        const pendingPrompt = ds.pendingPrompt ?? '';
         const prompt = buildNewTopicPrompt(
-          ds.pendingPrompt ?? '',
+          pendingPrompt,
           ds.session.sessionId,
           effectiveCliId,
           botCfg.cliPathOverride,
@@ -708,6 +782,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
           locDs,
           ds.pendingSender,
         );
+        rememberLastCliInput(ds, pendingPrompt, prompt);
         ds.pendingPrompt = undefined;
         ds.pendingAttachments = undefined;
         ds.pendingMentions = undefined;
@@ -812,8 +887,9 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     const effectiveCliId = sessionCliId(targetDs);
     // First-time repo selection — now spawn CLI with the original prompt
     targetDs.pendingRepo = false;
+    const pendingPrompt = targetDs.pendingPrompt ?? '';
     const prompt = buildNewTopicPrompt(
-      targetDs.pendingPrompt ?? '',
+      pendingPrompt,
       targetDs.session.sessionId,
       effectiveCliId,
       botCfg.cliPathOverride,
@@ -825,6 +901,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       locTarget,
       targetDs.pendingSender,
     );
+    rememberLastCliInput(targetDs, pendingPrompt, prompt);
     targetDs.pendingPrompt = undefined;
     targetDs.pendingAttachments = undefined;
     targetDs.pendingMentions = undefined;
@@ -846,6 +923,8 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     sessionStore.closeSession(targetDs.session.sessionId);
     const session = sessionStore.createSession(targetDs.chatId, rootId, displayName, targetDs.chatType);
     targetDs.session = session;
+    targetDs.lastUserPrompt = undefined;
+    targetDs.lastCliInput = undefined;
     // Pin workingDir + larkAppId onto the new session before forkWorker.
     // Without this, a daemon restart restores the session with an empty
     // workingDir and the worker spawns in the bot's default cwd, so

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -15,7 +15,7 @@ import { createCliAdapterSync } from '../../adapters/cli/registry.js';
 import { logger } from '../../utils/logger.js';
 import * as sessionStore from '../../services/session-store.js';
 import { loadFrozenCards, saveFrozenCards } from '../../services/frozen-card-store.js';
-import { forkWorker, killWorker, scheduleCardPatch, parkStreamCard } from '../../core/worker-pool.js';
+import { forkWorker, killWorker, scheduleCardPatch, parkStreamCard, clearUsageLimitState, cardUsageLimit, CARD_POSTING_SENTINEL } from '../../core/worker-pool.js';
 import { getSessionWorkingDir, buildNewTopicPrompt, getAvailableBots, persistStreamCardState, resumeSession, rememberLastCliInput } from '../../core/session-manager.js';
 import type { DaemonToWorker, DisplayMode, TermActionKey } from '../../types.js';
 import { sessionKey, sessionAnchorId, frozenDisplayMode } from '../../core/types.js';
@@ -80,18 +80,6 @@ function getSessionByActionValue(
 
 function sessionCliId(ds: DaemonSession) {
   return ds.session.cliId ?? getBot(ds.larkAppId).config.cliId;
-}
-
-function clearUsageLimitState(ds: DaemonSession): void {
-  if (ds.usageLimitRetryTimer) {
-    clearTimeout(ds.usageLimitRetryTimer);
-    ds.usageLimitRetryTimer = undefined;
-  }
-  ds.usageLimit = undefined;
-}
-
-function cardUsageLimit(ds: DaemonSession) {
-  return ds.lastScreenStatus === 'limited' ? ds.usageLimit : undefined;
 }
 
 function validateCardCliBinding(ds: DaemonSession, value?: Record<string, string>): boolean {
@@ -368,7 +356,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       persistStreamCardState(ds);
 
       let cardJson: string | undefined;
-      if (ds.streamCardId && ds.streamCardId !== '__posting__' && ds.workerPort) {
+      if (ds.streamCardId && ds.streamCardId !== CARD_POSTING_SENTINEL && ds.workerPort) {
         const readUrl = `http://${config.web.externalHost}:${ds.workerPort}`;
         cardJson = buildStreamingCard(
           ds.session.sessionId,
@@ -695,7 +683,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       // Return the current card JSON so Feishu doesn't revert the displayed
       // image to the originally-POSTed initial frame while waiting for the
       // fresh screenshot PATCH (~1s).
-      if (ds.streamCardId && ds.streamCardId !== '__posting__' && ds.workerPort) {
+      if (ds.streamCardId && ds.streamCardId !== CARD_POSTING_SENTINEL && ds.workerPort) {
         const botCfg = getBot(ds.larkAppId).config;
         const effectiveCliId = sessionCliId(ds);
         const readUrl = `http://${config.web.externalHost}:${ds.workerPort}`;
@@ -734,7 +722,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
         ds.worker.send({ type: 'term_action', key } as DaemonToWorker);
         logger.info(`[${tag(ds)}] term_action: ${key}`);
       }
-      if (ds.streamCardId && ds.streamCardId !== '__posting__' && ds.workerPort) {
+      if (ds.streamCardId && ds.streamCardId !== CARD_POSTING_SENTINEL && ds.workerPort) {
         const botCfg = getBot(ds.larkAppId).config;
         const effectiveCliId = sessionCliId(ds);
         const readUrl = `http://${config.web.externalHost}:${ds.workerPort}`;

--- a/src/im/types.ts
+++ b/src/im/types.ts
@@ -51,7 +51,7 @@ export interface ImCardBuilder {
     terminalUrl: string;
     title: string;
     content: string;
-    status: 'starting' | 'working' | 'idle';
+    status: 'starting' | 'working' | 'idle' | 'limited';
   }): ImCard;
 
   buildRepoSelectCard(opts: {

--- a/src/im/types.ts
+++ b/src/im/types.ts
@@ -1,3 +1,5 @@
+import type { StreamStatus } from '../types.js';
+
 export interface ImMessage {
   id: string;
   threadId: string;
@@ -51,7 +53,7 @@ export interface ImCardBuilder {
     terminalUrl: string;
     title: string;
     content: string;
-    status: 'starting' | 'working' | 'idle' | 'limited';
+    status: StreamStatus;
   }): ImCard;
 
   buildRepoSelectCard(opts: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { CliUsageLimitState } from './utils/cli-usage-limit.js';
+
 export interface Session {
   sessionId: string;
   chatId: string;
@@ -38,6 +40,9 @@ export interface Session {
   /** Latest uploaded screenshot image_key, persisted so card can re-render after restart. */
   currentImageKey?: string;
   currentTurnTitle?: string;
+  usageLimit?: CliUsageLimitState;
+  lastUserPrompt?: string;
+  lastCliInput?: string;
   /** CLI-native resume id when it differs from botmux's sessionId (for example Codex thread id). */
   cliSessionId?: string;
   /** CLI used to spawn this session — stamped on every save so closed sessions retain it. */
@@ -168,11 +173,11 @@ export type WorkerToDaemon =
   | { type: 'ready'; port: number; token: string }
   | { type: 'claude_exit'; code: number | null; signal: string | null }
   | { type: 'prompt_ready' }
-  | { type: 'screen_update'; content: string; status: 'working' | 'idle' | 'analyzing' }
+  | { type: 'screen_update'; content: string; status: 'working' | 'idle' | 'analyzing' | 'limited'; usageLimit?: CliUsageLimitState }
   | { type: 'error'; message: string }
   | { type: 'tui_prompt'; description: string; options: Array<{ label?: string; text: string; selected: boolean; type?: string; keys?: string[] }>; multiSelect?: boolean }
   | { type: 'tui_prompt_resolved'; selectedText?: string }
-  | { type: 'screenshot_uploaded'; imageKey: string; status: 'working' | 'idle' | 'analyzing' }
+  | { type: 'screenshot_uploaded'; imageKey: string; status: 'working' | 'idle' | 'analyzing' | 'limited'; usageLimit?: CliUsageLimitState }
   | { type: 'user_notify'; message: string }
   | {
       type: 'final_output';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,10 @@
 import type { CliUsageLimitState } from './utils/cli-usage-limit.js';
 
+/** Runtime status the worker derives from screen content. */
+export type ScreenStatus = 'working' | 'idle' | 'analyzing' | 'limited';
+/** Status shown on a streaming card — adds the pre-spawn 'starting' phase. */
+export type StreamStatus = ScreenStatus | 'starting';
+
 export interface Session {
   sessionId: string;
   chatId: string;
@@ -173,11 +178,11 @@ export type WorkerToDaemon =
   | { type: 'ready'; port: number; token: string }
   | { type: 'claude_exit'; code: number | null; signal: string | null }
   | { type: 'prompt_ready' }
-  | { type: 'screen_update'; content: string; status: 'working' | 'idle' | 'analyzing' | 'limited'; usageLimit?: CliUsageLimitState }
+  | { type: 'screen_update'; content: string; status: ScreenStatus; usageLimit?: CliUsageLimitState }
   | { type: 'error'; message: string }
   | { type: 'tui_prompt'; description: string; options: Array<{ label?: string; text: string; selected: boolean; type?: string; keys?: string[] }>; multiSelect?: boolean }
   | { type: 'tui_prompt_resolved'; selectedText?: string }
-  | { type: 'screenshot_uploaded'; imageKey: string; status: 'working' | 'idle' | 'analyzing' | 'limited'; usageLimit?: CliUsageLimitState }
+  | { type: 'screenshot_uploaded'; imageKey: string; status: ScreenStatus; usageLimit?: CliUsageLimitState }
   | { type: 'user_notify'; message: string }
   | {
       type: 'final_output';

--- a/src/utils/cli-usage-limit.ts
+++ b/src/utils/cli-usage-limit.ts
@@ -1,0 +1,89 @@
+export type CliUsageLimitKind = 'usage' | 'rate';
+
+export interface CliUsageLimitState {
+  limited: true;
+  kind: CliUsageLimitKind;
+  retryAtMs: number;
+  retryLabel: string;
+  retryReady: boolean;
+}
+
+export interface CliUsageLimitNotDetected {
+  limited: false;
+}
+
+export type CliUsageLimitDetection = CliUsageLimitState | CliUsageLimitNotDetected;
+
+const USAGE_LIMIT_PATTERNS = [
+  /\bhit (?:your )?(?:usage )?limits?\b/i,
+  /\busage limits?.*(?:reached|exceeded|try again)\b/i,
+  /\b(?:quota|limit) (?:reached|exceeded)\b/i,
+  /\b(?:reached|exceeded) (?:your )?(?:usage )?(?:limit|quota)\b/i,
+];
+
+const RATE_LIMIT_PATTERNS = [
+  /\brate limits?.*(?:reached|exceeded)\b/i,
+  /\brate limited\b/i,
+];
+
+const RETRY_TIME_PATTERNS = [
+  /\btry\s+again\s+at\s+(\d{1,2})(?::(\d{2}))?\s*([ap]\.?m\.?)\b/i,
+  /\bresets?(?:\s+at)?\s+(\d{1,2})(?::(\d{2}))?\s*([ap]\.?m\.?)\b/i,
+];
+
+function hasPattern(text: string, patterns: RegExp[]): boolean {
+  return patterns.some(pattern => pattern.test(text));
+}
+
+function parseMeridiemTime(text: string, now: Date): { retryAtMs: number; retryLabel: string } | null {
+  for (const pattern of RETRY_TIME_PATTERNS) {
+    const match = pattern.exec(text);
+    if (!match) continue;
+
+    const rawHour = Number(match[1]);
+    const minute = match[2] === undefined ? 0 : Number(match[2]);
+    const meridiem = match[3].toLowerCase().replace(/\./g, '');
+    if (!Number.isInteger(rawHour) || rawHour < 1 || rawHour > 12) return null;
+    if (!Number.isInteger(minute) || minute < 0 || minute > 59) return null;
+
+    let hour = rawHour % 12;
+    if (meridiem === 'pm') hour += 12;
+
+    const retryAt = new Date(now);
+    retryAt.setHours(hour, minute, 0, 0);
+    if (retryAt.getTime() < now.getTime() && hour < 12) {
+      retryAt.setDate(retryAt.getDate() + 1);
+    }
+
+    return {
+      retryAtMs: retryAt.getTime(),
+      retryLabel: match[0].replace(/^(?:try\s+again\s+at|resets?(?:\s+at)?)\s+/i, '').trim(),
+    };
+  }
+  return null;
+}
+
+export function detectCliUsageLimit(text: string, now = new Date()): CliUsageLimitDetection {
+  const time = parseMeridiemTime(text, now);
+  if (!time) return { limited: false };
+
+  const kind: CliUsageLimitKind | null = hasPattern(text, RATE_LIMIT_PATTERNS)
+    ? 'rate'
+    : hasPattern(text, USAGE_LIMIT_PATTERNS)
+      ? 'usage'
+      : null;
+
+  if (!kind) return { limited: false };
+
+  return {
+    limited: true,
+    kind,
+    retryAtMs: time.retryAtMs,
+    retryLabel: time.retryLabel,
+    retryReady: now.getTime() >= time.retryAtMs,
+  };
+}
+
+export function usageLimitStateKey(state: CliUsageLimitState): string {
+  return `${state.kind}:${state.retryAtMs}:${state.retryLabel}`;
+}

--- a/src/utils/cli-usage-limit.ts
+++ b/src/utils/cli-usage-limit.ts
@@ -64,6 +64,11 @@ function parseMeridiemTime(text: string, now: Date): { retryAtMs: number; retryL
 }
 
 export function detectCliUsageLimit(text: string, now = new Date()): CliUsageLimitDetection {
+  // Hot path: runs on every screen tick for every active session. The retry
+  // patterns all require the literal "again" or "reset", so gate the heavier
+  // regex work behind one cheap scan to skip it for the >99% no-limit case.
+  if (!/again|reset/i.test(text)) return { limited: false };
+
   const time = parseMeridiemTime(text, now);
   if (!time) return { limited: false };
 

--- a/src/utils/transient-snapshot.ts
+++ b/src/utils/transient-snapshot.ts
@@ -73,7 +73,7 @@ export async function snapshotToPng(
   backend: unknown,
   fallbackCols: number,
   fallbackRows: number,
-): Promise<{ png: Buffer; ansi: string } | null> {
+): Promise<{ png: Buffer; ansi: string; content: string } | null> {
   const snap = tryCapturePipeSnapshot(backend, fallbackCols, fallbackRows);
   if (!snap) return null;
   const terminal = await buildTransientTerminal(snap);
@@ -84,7 +84,8 @@ export async function snapshotToPng(
     // stale scrollback after that scroll.
     const startY = terminal.buffer.active.baseY;
     const png = captureToPng(terminal, { cols: snap.cols, rows: snap.rows, startY });
-    return { png, ansi: snap.ansi };
+    const content = readViewportText(terminal, { filter: true, startY, rows: snap.rows });
+    return { png, ansi: snap.ansi, content };
   } finally {
     terminal.dispose();
   }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -57,6 +57,7 @@ import { IdleDetector } from './utils/idle-detector.js';
 import { ScreenAnalyzer } from './utils/screen-analyzer.js';
 import { captureToPng } from './utils/screenshot-renderer.js';
 import { snapshotToPng, snapshotToText } from './utils/transient-snapshot.js';
+import { detectCliUsageLimit, usageLimitStateKey, type CliUsageLimitState } from './utils/cli-usage-limit.js';
 import { uploadImageBuffer } from './utils/lark-upload.js';
 import { config } from './config.js';
 import * as sessionStore from './services/session-store.js';
@@ -90,6 +91,43 @@ let isPromptReady = false;
 /** Mutex for async flushPending — prevents concurrent flush loops. */
 let isFlushing = false;
 const pendingMessages: string[] = [];
+
+type RuntimeScreenStatus = 'working' | 'idle' | 'analyzing';
+
+let usageLimitTurnSeq = 0;
+let usageLimitDetectedTurnSeq: number | undefined;
+let suppressedRetryReadyUsageLimitKey: string | undefined;
+
+function currentUsageLimitSnapshot(): string {
+  return lastAnalyzerSnapshot || renderer?.rawSnapshot() || '';
+}
+
+function beginUsageLimitTurn(): number {
+  usageLimitTurnSeq++;
+  usageLimitDetectedTurnSeq = undefined;
+  const current = detectCliUsageLimit(currentUsageLimitSnapshot());
+  suppressedRetryReadyUsageLimitKey = current.limited && current.retryReady
+    ? usageLimitStateKey(current)
+    : undefined;
+  return usageLimitTurnSeq;
+}
+
+function screenStatusWithUsageLimit(
+  content: string,
+  status: RuntimeScreenStatus,
+): { status: RuntimeScreenStatus | 'limited'; usageLimit?: CliUsageLimitState } {
+  const detected = detectCliUsageLimit(content);
+  if (!detected.limited) return { status };
+
+  const key = usageLimitStateKey(detected);
+  if (detected.retryReady && key === suppressedRetryReadyUsageLimitKey) {
+    return { status };
+  }
+
+  suppressedRetryReadyUsageLimitKey = undefined;
+  usageLimitDetectedTurnSeq = usageLimitTurnSeq;
+  return { status: 'limited', usageLimit: detected };
+}
 
 // ─── Adopt-bridge state (Claude Code only) ─────────────────────────────────
 //
@@ -1714,6 +1752,7 @@ async function captureAndUpload(): Promise<void> {
   if (!larkAppIdForUpload || !larkAppSecretForUpload) { logScreenshotSkip('lark credentials missing'); return; }
 
   let png: Buffer;
+  let usageLimitContent = '';
   try {
     // Preferred path: pipe-pane backends ask tmux for a fresh viewport
     // snapshot and render it through a transient xterm-headless. This
@@ -1724,6 +1763,7 @@ async function captureAndUpload(): Promise<void> {
       if (pipeResult.ansi === lastShotHash) return;
       lastShotHash = pipeResult.ansi;
       png = pipeResult.png;
+      usageLimitContent = pipeResult.content;
     } else {
       // Fallback path: non-pipe backends (PtyBackend, legacy TmuxBackend)
       // still drive the long-lived renderer.
@@ -1734,6 +1774,7 @@ async function captureAndUpload(): Promise<void> {
       const hash = createHash('md5').update(snap).digest('hex');
       if (hash === lastShotHash) return;
       lastShotHash = hash;
+      usageLimitContent = snap;
       const shotCols = clamp(term.cols, MIN_RENDER_COLS, MAX_RENDER_COLS);
       const shotRows = clamp(term.rows, MIN_RENDER_ROWS, MAX_RENDER_ROWS);
       png = captureToPng(term, { cols: shotCols, rows: shotRows, startY });
@@ -1751,9 +1792,9 @@ async function captureAndUpload(): Promise<void> {
     return;
   }
 
-  let status: 'working' | 'idle' | 'analyzing' = isPromptReady ? 'idle' : 'working';
+  let status: RuntimeScreenStatus = isPromptReady ? 'idle' : 'working';
   if (screenAnalyzer?.isAnalyzing) status = 'analyzing';
-  send({ type: 'screenshot_uploaded', imageKey, status });
+  send({ type: 'screenshot_uploaded', imageKey, ...screenStatusWithUsageLimit(usageLimitContent, status) });
 }
 
 function applyDisplayMode(mode: DisplayMode): void {
@@ -2010,7 +2051,7 @@ function markPromptReady(): void {
   // (where the initial prompt is queued before the CLI becomes idle).
   if (renderer && pendingMessages.length === 0 && !isFlushing) {
     const { content } = renderer.snapshot();
-    send({ type: 'screen_update', content, status: 'idle' });
+    send({ type: 'screen_update', content, ...screenStatusWithUsageLimit(content, 'idle') });
   }
   flushPending();
 }
@@ -2054,6 +2095,7 @@ function scheduleSubmitFailureNotify(
   transcriptLabel: string,
   bridgeTurnId?: string,
   failureReason?: string,
+  turnSeq = usageLimitTurnSeq,
 ): void {
   const preview = msg.length > 60 ? msg.slice(0, 60) + '…' : msg;
   const dropBridgeMark = (): void => {
@@ -2084,6 +2126,11 @@ function scheduleSubmitFailureNotify(
       } catch (err: any) {
         log(`Deferred recheck threw (${err?.message ?? err}); falling through to warning.`);
       }
+    }
+    if (usageLimitDetectedTurnSeq === turnSeq) {
+      dropBridgeMark();
+      log(`Deferred recheck missing but usage limit was detected for this turn — suppressing submit warning. preview="${preview}"`);
+      return;
     }
     dropBridgeMark();
     log(`Deferred recheck still missing — notifying user. preview="${preview}"`);
@@ -2127,6 +2174,7 @@ async function flushPending(): Promise<void> {
   try {
     while (pendingMessages.length > 0 && backend && cliAdapter) {
       const msg = pendingMessages.shift()!;
+      const turnSeq = beginUsageLimitTurn();
       // Bridge fallback: mark immediately before writeInput. Doing it here
       // (instead of at enqueue time) means markTimeMs anchors to the
       // moment the message actually starts hitting the PTY — so any
@@ -2161,7 +2209,7 @@ async function flushPending(): Promise<void> {
         // nulled `backend` and told the user the CLI exited) — nothing more to
         // do. Otherwise surface it as a submit failure so the message isn't
         // silently lost.
-        if (backend) scheduleSubmitFailureNotify(msg, undefined, '会话 JSONL', bridgeTurnId);
+        if (backend) scheduleSubmitFailureNotify(msg, undefined, '会话 JSONL', bridgeTurnId, undefined, turnSeq);
         break;
       }
       // Persist any sessionId the adapter observed via authoritative sources
@@ -2179,7 +2227,7 @@ async function flushPending(): Promise<void> {
       // nulled backend) the user already got a "CLI exited" notice; don't also
       // nag that the submit wasn't confirmed.
       if (result && result.submitted === false && backend) {
-        scheduleSubmitFailureNotify(msg, result.recheck, '会话 JSONL', bridgeTurnId, result.failureReason);
+        scheduleSubmitFailureNotify(msg, result.recheck, '会话 JSONL', bridgeTurnId, result.failureReason, turnSeq);
       }
       // Codex bridge: stop after one writeInput per idle cycle. Codex's
       // bridge queue doesn't yet attribute queued_command-equivalents, so
@@ -2240,7 +2288,7 @@ function startScreenUpdates(): void {
   let lastTextSnapshotHash = '';
   screenUpdateTimer = setInterval(() => {
     if (awaitingFirstPrompt) return;
-    let status: 'working' | 'idle' | 'analyzing' = isPromptReady ? 'idle' : 'working';
+    let status: RuntimeScreenStatus = isPromptReady ? 'idle' : 'working';
     if (screenAnalyzer?.isAnalyzing) status = 'analyzing';
 
     void (async () => {
@@ -2270,9 +2318,10 @@ function startScreenUpdates(): void {
         return;
       }
 
-      if (changed || status !== lastSentStatus) {
-        lastSentStatus = status;
-        send({ type: 'screen_update', content, status });
+      const usageAware = screenStatusWithUsageLimit(content, status);
+      if (changed || usageAware.status !== lastSentStatus) {
+        lastSentStatus = usageAware.status;
+        send({ type: 'screen_update', content, ...usageAware });
       }
     })();
   }, SCREEN_UPDATE_INTERVAL_MS);
@@ -3090,6 +3139,7 @@ process.on('message', async (raw: unknown) => {
     case 'message': {
       // Mark new turn baseline so the streaming card only shows this turn's content
       renderer?.markNewTurn();
+      const turnSeq = beginUsageLimitTurn();
       // Cancel any active tmux copy-mode scroll so user input reaches the CLI.
       if (tmuxScrolledHalfPages > 0) exitTmuxScrollMode();
       const content = msg.content;
@@ -3133,7 +3183,7 @@ process.on('message', async (raw: unknown) => {
                 codexBridgeNotifyCliSessionId(result.cliSessionId);
               }
               if (result && result.submitted === false) {
-                scheduleSubmitFailureNotify(content, result.recheck, 'Codex history', undefined, result.failureReason);
+                scheduleSubmitFailureNotify(content, result.recheck, 'Codex history', undefined, result.failureReason, turnSeq);
               }
             } catch (err: any) {
               log(`Codex adopt writeInput error: ${err.message}`);
@@ -3174,6 +3224,7 @@ process.on('message', async (raw: unknown) => {
       // fires. Also skip adapter.writeInput() / pendingMessages queueing so
       // the prompt wrapping (Session ID, mention hints) is not prepended.
       renderer?.markNewTurn();
+      beginUsageLimitTurn();
       if (tmuxScrolledHalfPages > 0) exitTmuxScrollMode();
       if (backend) {
         if ('sendText' in backend && 'sendSpecialKeys' in backend) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -32,7 +32,7 @@ import { cocoEventsPathForSession, drainCocoEvents, findCocoSessionByPid } from 
 import { dirname } from 'node:path';
 import { createServer as createHttpServer, type IncomingMessage } from 'node:http';
 import { WebSocketServer, WebSocket } from 'ws';
-import type { DaemonToWorker, WorkerToDaemon, DisplayMode, TermActionKey } from './types.js';
+import type { DaemonToWorker, WorkerToDaemon, DisplayMode, TermActionKey, ScreenStatus } from './types.js';
 import { TerminalRenderer } from './utils/terminal-renderer.js';
 import {
   DEFAULT_RENDER_COLS,
@@ -92,7 +92,7 @@ let isPromptReady = false;
 let isFlushing = false;
 const pendingMessages: string[] = [];
 
-type RuntimeScreenStatus = 'working' | 'idle' | 'analyzing';
+type RuntimeScreenStatus = Exclude<ScreenStatus, 'limited'>;
 
 let usageLimitTurnSeq = 0;
 let usageLimitDetectedTurnSeq: number | undefined;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -94,39 +94,59 @@ const pendingMessages: string[] = [];
 
 type RuntimeScreenStatus = Exclude<ScreenStatus, 'limited'>;
 
-let usageLimitTurnSeq = 0;
-let usageLimitDetectedTurnSeq: number | undefined;
-let suppressedRetryReadyUsageLimitKey: string | undefined;
+// Per-turn usage-limit state machine. Owns the turn counter plus the
+// "did this turn hit a limit" / "suppress a stale retry-ready banner" flags, so
+// classify()'s state writes are explicit method calls rather than hidden
+// mutations of module globals from a function that otherwise reads as a pure
+// mapper.
+function createUsageLimitTracker() {
+  let turnSeq = 0;
+  let detectedTurn: number | undefined;
+  let suppressedRetryReadyKey: string | undefined;
+
+  return {
+    currentTurn(): number {
+      return turnSeq;
+    },
+    // Open a new turn; remember any stale retry-ready banner still on screen so
+    // classify() doesn't re-flag it as a fresh limit this turn.
+    beginTurn(snapshot: string): number {
+      turnSeq++;
+      detectedTurn = undefined;
+      const current = detectCliUsageLimit(snapshot);
+      suppressedRetryReadyKey = current.limited && current.retryReady
+        ? usageLimitStateKey(current)
+        : undefined;
+      return turnSeq;
+    },
+    // Map a runtime status to a usage-limit-aware status, recording whether this
+    // turn hit a limit (read back via detectedThisTurn).
+    classify(
+      content: string,
+      status: RuntimeScreenStatus,
+    ): { status: RuntimeScreenStatus | 'limited'; usageLimit?: CliUsageLimitState } {
+      const detected = detectCliUsageLimit(content);
+      if (!detected.limited) return { status };
+
+      const key = usageLimitStateKey(detected);
+      if (detected.retryReady && key === suppressedRetryReadyKey) {
+        return { status };
+      }
+
+      suppressedRetryReadyKey = undefined;
+      detectedTurn = turnSeq;
+      return { status: 'limited', usageLimit: detected };
+    },
+    detectedThisTurn(seq: number): boolean {
+      return detectedTurn === seq;
+    },
+  };
+}
+
+const usageLimitTracker = createUsageLimitTracker();
 
 function currentUsageLimitSnapshot(): string {
   return lastAnalyzerSnapshot || renderer?.rawSnapshot() || '';
-}
-
-function beginUsageLimitTurn(): number {
-  usageLimitTurnSeq++;
-  usageLimitDetectedTurnSeq = undefined;
-  const current = detectCliUsageLimit(currentUsageLimitSnapshot());
-  suppressedRetryReadyUsageLimitKey = current.limited && current.retryReady
-    ? usageLimitStateKey(current)
-    : undefined;
-  return usageLimitTurnSeq;
-}
-
-function screenStatusWithUsageLimit(
-  content: string,
-  status: RuntimeScreenStatus,
-): { status: RuntimeScreenStatus | 'limited'; usageLimit?: CliUsageLimitState } {
-  const detected = detectCliUsageLimit(content);
-  if (!detected.limited) return { status };
-
-  const key = usageLimitStateKey(detected);
-  if (detected.retryReady && key === suppressedRetryReadyUsageLimitKey) {
-    return { status };
-  }
-
-  suppressedRetryReadyUsageLimitKey = undefined;
-  usageLimitDetectedTurnSeq = usageLimitTurnSeq;
-  return { status: 'limited', usageLimit: detected };
 }
 
 // ─── Adopt-bridge state (Claude Code only) ─────────────────────────────────
@@ -1794,7 +1814,7 @@ async function captureAndUpload(): Promise<void> {
 
   let status: RuntimeScreenStatus = isPromptReady ? 'idle' : 'working';
   if (screenAnalyzer?.isAnalyzing) status = 'analyzing';
-  send({ type: 'screenshot_uploaded', imageKey, ...screenStatusWithUsageLimit(usageLimitContent, status) });
+  send({ type: 'screenshot_uploaded', imageKey, ...usageLimitTracker.classify(usageLimitContent, status) });
 }
 
 function applyDisplayMode(mode: DisplayMode): void {
@@ -2051,7 +2071,7 @@ function markPromptReady(): void {
   // (where the initial prompt is queued before the CLI becomes idle).
   if (renderer && pendingMessages.length === 0 && !isFlushing) {
     const { content } = renderer.snapshot();
-    send({ type: 'screen_update', content, ...screenStatusWithUsageLimit(content, 'idle') });
+    send({ type: 'screen_update', content, ...usageLimitTracker.classify(content, 'idle') });
   }
   flushPending();
 }
@@ -2095,7 +2115,7 @@ function scheduleSubmitFailureNotify(
   transcriptLabel: string,
   bridgeTurnId?: string,
   failureReason?: string,
-  turnSeq = usageLimitTurnSeq,
+  turnSeq = usageLimitTracker.currentTurn(),
 ): void {
   const preview = msg.length > 60 ? msg.slice(0, 60) + '…' : msg;
   const dropBridgeMark = (): void => {
@@ -2127,7 +2147,7 @@ function scheduleSubmitFailureNotify(
         log(`Deferred recheck threw (${err?.message ?? err}); falling through to warning.`);
       }
     }
-    if (usageLimitDetectedTurnSeq === turnSeq) {
+    if (usageLimitTracker.detectedThisTurn(turnSeq)) {
       dropBridgeMark();
       log(`Deferred recheck missing but usage limit was detected for this turn — suppressing submit warning. preview="${preview}"`);
       return;
@@ -2174,7 +2194,7 @@ async function flushPending(): Promise<void> {
   try {
     while (pendingMessages.length > 0 && backend && cliAdapter) {
       const msg = pendingMessages.shift()!;
-      const turnSeq = beginUsageLimitTurn();
+      const turnSeq = usageLimitTracker.beginTurn(currentUsageLimitSnapshot());
       // Bridge fallback: mark immediately before writeInput. Doing it here
       // (instead of at enqueue time) means markTimeMs anchors to the
       // moment the message actually starts hitting the PTY — so any
@@ -2318,7 +2338,7 @@ function startScreenUpdates(): void {
         return;
       }
 
-      const usageAware = screenStatusWithUsageLimit(content, status);
+      const usageAware = usageLimitTracker.classify(content, status);
       if (changed || usageAware.status !== lastSentStatus) {
         lastSentStatus = usageAware.status;
         send({ type: 'screen_update', content, ...usageAware });
@@ -3139,7 +3159,7 @@ process.on('message', async (raw: unknown) => {
     case 'message': {
       // Mark new turn baseline so the streaming card only shows this turn's content
       renderer?.markNewTurn();
-      const turnSeq = beginUsageLimitTurn();
+      const turnSeq = usageLimitTracker.beginTurn(currentUsageLimitSnapshot());
       // Cancel any active tmux copy-mode scroll so user input reaches the CLI.
       if (tmuxScrolledHalfPages > 0) exitTmuxScrollMode();
       const content = msg.content;
@@ -3224,7 +3244,7 @@ process.on('message', async (raw: unknown) => {
       // fires. Also skip adapter.writeInput() / pendingMessages queueing so
       // the prompt wrapping (Session ID, mention hints) is not prepended.
       renderer?.markNewTurn();
-      beginUsageLimitTurn();
+      usageLimitTracker.beginTurn(currentUsageLimitSnapshot());
       if (tmuxScrolledHalfPages > 0) exitTmuxScrollMode();
       if (backend) {
         if ('sendText' in backend && 'sendSpecialKeys' in backend) {

--- a/test/card-builder.test.ts
+++ b/test/card-builder.test.ts
@@ -294,6 +294,72 @@ describe('buildStreamingCard', () => {
       expect(card.header.title.content).toContain('Fix \\*bug\\*');
       expect(card.header.title.content).toContain('等待输入');
     });
+
+    it('should show red usage-limit status with retry time', () => {
+      const card = parse(buildStreamingCard(
+        SID,
+        ROOT,
+        URL,
+        TITLE,
+        '',
+        'limited',
+        'codex',
+        'hidden',
+        undefined,
+        undefined,
+        false,
+        false,
+        undefined,
+        {
+          limited: true,
+          kind: 'usage',
+          retryAtMs: new Date(2026, 4, 19, 22, 36).getTime(),
+          retryLabel: '10:36 PM',
+          retryReady: false,
+        },
+      ));
+
+      expect(card.header.template).toBe('red');
+      expect(card.header.title.content).toContain('限额已达');
+      expect(JSON.stringify(card)).toContain('10:36 PM');
+      const actions = findActions(card);
+      expect(actions.find((a: any) => a.value?.action === 'retry_last_task')).toBeUndefined();
+    });
+
+    it('should show retry-ready status and retry button after reset time', () => {
+      const card = parse(buildStreamingCard(
+        SID,
+        ROOT,
+        URL,
+        TITLE,
+        '',
+        'limited',
+        'codex',
+        'hidden',
+        'nonce_123',
+        undefined,
+        false,
+        false,
+        undefined,
+        {
+          limited: true,
+          kind: 'usage',
+          retryAtMs: new Date(2026, 4, 19, 22, 36).getTime(),
+          retryLabel: '10:36 PM',
+          retryReady: true,
+        },
+      ));
+
+      expect(card.header.template).toBe('green');
+      expect(card.header.title.content).toContain('可重试');
+      const actions = findActions(card);
+      const retryBtn = actions.find((a: any) => a.value?.action === 'retry_last_task');
+      expect(retryBtn).toBeDefined();
+      expect(retryBtn.text.content).toContain('重发上一条任务');
+      expect(retryBtn.value.root_id).toBe(ROOT);
+      expect(retryBtn.value.session_id).toBe(SID);
+      expect(retryBtn.value.card_nonce).toBe('nonce_123');
+    });
   });
 
   // ── Hidden display mode ────────────────────────────────────────────────

--- a/test/card-integration.test.ts
+++ b/test/card-integration.test.ts
@@ -26,6 +26,7 @@ import {
   makeCloseEvent,
   makeResumeEvent,
   makeGetWriteLinkEvent,
+  makeRetryLastTaskEvent,
 } from './fixtures/card-action-events.js';
 
 // ─── Shared state ─────────────────────────────────────────────────────────
@@ -138,6 +139,10 @@ vi.mock('../src/core/session-manager.js', () => ({
   persistStreamCardState: vi.fn(),
   buildBridgeInputContent: vi.fn((s: string) => s),
   buildFollowUpContent: vi.fn((s: string) => s),
+  rememberLastCliInput: vi.fn((ds: any, userPrompt: string, cliInput: string) => {
+    ds.lastUserPrompt = userPrompt;
+    ds.lastCliInput = cliInput;
+  }),
   // Resume action delegates to session-manager — tests stub per-scenario.
   resumeSession: vi.fn(),
 }));
@@ -832,6 +837,58 @@ describe('Card integration: full event flow', () => {
       expect((ds.worker as any).send).not.toHaveBeenCalledWith({ type: 'restart' });
       expect(forkWorker).not.toHaveBeenCalled();
       // sessionReply was used to surface the rejection message.
+      expect(deps.sessionReply).toHaveBeenCalled();
+    });
+  });
+
+  describe('Scenario 8: usage-limit retry action', () => {
+    it('resends the stored CLI input and clears the limit state when retry is ready', async () => {
+      const ds = makeDaemonSession({
+        streamCardId: 'om_stream_card_retry',
+        lastScreenStatus: 'limited',
+        usageLimit: {
+          limited: true,
+          kind: 'usage',
+          retryAtMs: Date.now() - 1000,
+          retryLabel: '10:36 PM',
+          retryReady: true,
+        },
+        lastUserPrompt: '继续',
+        lastCliInput: '<user_message>继续</user_message>',
+        currentImageKey: 'img_old',
+      });
+      const sessions = new Map<string, DaemonSession>();
+      sessions.set(sessionKey(ROOT_ID, APP_ID), ds);
+      const deps = makeDeps(sessions);
+
+      await handleCardAction(makeRetryLastTaskEvent(ROOT_ID), deps, APP_ID);
+
+      expect((ds.worker as any).send).toHaveBeenCalledWith({
+        type: 'message',
+        content: '<user_message>继续</user_message>',
+      });
+      expect(ds.usageLimit).toBeUndefined();
+      expect(ds.usageLimitRetryTimer).toBeUndefined();
+      expect(ds.lastScreenStatus).toBe('working');
+      expect(ds.streamCardPending).toBe(true);
+      expect(ds.currentImageKey).toBeUndefined();
+      expect(ds.currentTurnTitle).toBe('继续');
+    });
+
+    it('does not resend from a stale retry button after the limit state is cleared', async () => {
+      const ds = makeDaemonSession({
+        streamCardId: 'om_stream_card_stale_retry',
+        lastScreenStatus: 'working',
+        lastUserPrompt: '继续',
+        lastCliInput: '<user_message>继续</user_message>',
+      });
+      const sessions = new Map<string, DaemonSession>();
+      sessions.set(sessionKey(ROOT_ID, APP_ID), ds);
+      const deps = makeDeps(sessions);
+
+      await handleCardAction(makeRetryLastTaskEvent(ROOT_ID), deps, APP_ID);
+
+      expect((ds.worker as any).send).not.toHaveBeenCalled();
       expect(deps.sessionReply).toHaveBeenCalled();
     });
   });

--- a/test/card-toggle.e2e.ts
+++ b/test/card-toggle.e2e.ts
@@ -96,6 +96,10 @@ vi.mock('../src/core/session-manager.js', () => ({
   // displayMode — without a stub here the test crashes with "No export …"
   // before exercising the PATCH serialization we're actually testing.
   persistStreamCardState: vi.fn(),
+  rememberLastCliInput: vi.fn((ds: any, userPrompt: string, cliInput: string) => {
+    ds.lastUserPrompt = userPrompt;
+    ds.lastCliInput = cliInput;
+  }),
   resumeSession: vi.fn(),
 }));
 

--- a/test/cli-usage-limit.test.ts
+++ b/test/cli-usage-limit.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import { detectCliUsageLimit } from '../src/utils/cli-usage-limit.js';
+
+describe('detectCliUsageLimit', () => {
+  it('detects Codex usage limit output with a concrete retry time', () => {
+    const result = detectCliUsageLimit(
+      "You've hit your usage limit. Upgrade to Pro, visit https://chatgpt.com/codex/settings/usage or try again at 10:36 PM.",
+      new Date(2026, 4, 19, 22, 0),
+    );
+
+    expect(result.limited).toBe(true);
+    if (!result.limited) return;
+    expect(result.kind).toBe('usage');
+    expect(result.retryLabel).toBe('10:36 PM');
+    expect(new Date(result.retryAtMs).getHours()).toBe(22);
+    expect(new Date(result.retryAtMs).getMinutes()).toBe(36);
+    expect(result.retryReady).toBe(false);
+  });
+
+  it('detects Codex usage limit output when the TUI wraps the retry phrase', () => {
+    const result = detectCliUsageLimit(
+      "You've hit your usage limit. Upgrade to Pro, visit https://chatgpt.com/codex/settings/usage or try\nagain at 3:08 PM.",
+      new Date(2026, 4, 19, 14, 56),
+    );
+
+    expect(result.limited).toBe(true);
+    if (!result.limited) return;
+    expect(result.kind).toBe('usage');
+    expect(result.retryLabel).toBe('3:08 PM');
+    expect(new Date(result.retryAtMs).getHours()).toBe(15);
+    expect(new Date(result.retryAtMs).getMinutes()).toBe(8);
+    expect(result.retryReady).toBe(false);
+  });
+
+  it('detects Claude limit output with a reset time', () => {
+    const result = detectCliUsageLimit(
+      "You've hit your limit · resets 6:20pm (Asia/Calcutta)",
+      new Date(2026, 4, 19, 17, 30),
+    );
+
+    expect(result.limited).toBe(true);
+    if (!result.limited) return;
+    expect(result.kind).toBe('usage');
+    expect(result.retryLabel).toBe('6:20pm');
+    expect(new Date(result.retryAtMs).getHours()).toBe(18);
+    expect(new Date(result.retryAtMs).getMinutes()).toBe(20);
+    expect(result.retryReady).toBe(false);
+  });
+
+  it('detects blocking rate-limit output with a concrete retry time', () => {
+    const result = detectCliUsageLimit(
+      'Rate limit exceeded. Try again at 10:36 PM.',
+      new Date(2026, 4, 19, 17, 30),
+    );
+
+    expect(result.limited).toBe(true);
+    if (!result.limited) return;
+    expect(result.kind).toBe('rate');
+    expect(result.retryLabel).toBe('10:36 PM');
+  });
+
+  it('marks a detected limit as retry-ready once the retry time has passed', () => {
+    const result = detectCliUsageLimit(
+      "You've hit your usage limit. Try again at 10:36 PM.",
+      new Date(2026, 4, 19, 22, 40),
+    );
+
+    expect(result.limited).toBe(true);
+    if (!result.limited) return;
+    expect(result.retryReady).toBe(true);
+  });
+
+  it('rolls AM retry times to the next day when current time is already afternoon', () => {
+    const result = detectCliUsageLimit(
+      "You've hit your usage limit. Try again at 12:11 AM.",
+      new Date(2026, 4, 19, 23, 0),
+    );
+
+    expect(result.limited).toBe(true);
+    if (!result.limited) return;
+    const retryAt = new Date(result.retryAtMs);
+    expect(retryAt.getDate()).toBe(20);
+    expect(retryAt.getHours()).toBe(0);
+    expect(retryAt.getMinutes()).toBe(11);
+  });
+
+  it('does not treat low-quota warnings as a blocking usage limit', () => {
+    const result = detectCliUsageLimit(
+      'Heads up, you have less than 5% of your 5h limit left. Run /status for a breakdown.',
+      new Date(2026, 4, 19, 17, 30),
+    );
+
+    expect(result.limited).toBe(false);
+  });
+
+  it('does not treat approaching-rate-limit model suggestions as blocking', () => {
+    const result = detectCliUsageLimit(
+      'Approaching rate limits\nSwitch to gpt-5.4-mini for lower credit usage?',
+      new Date(2026, 4, 19, 17, 30),
+    );
+
+    expect(result.limited).toBe(false);
+  });
+
+  it('does not treat approaching-rate-limit text as blocking even when a time is present', () => {
+    const result = detectCliUsageLimit(
+      'Approaching rate limits. Try again at 10:36 PM if needed.',
+      new Date(2026, 4, 19, 17, 30),
+    );
+
+    expect(result.limited).toBe(false);
+  });
+
+  it('does not treat generic retry-later text as limited without a concrete time', () => {
+    const result = detectCliUsageLimit(
+      "You've hit your usage limit. Try again later.",
+      new Date(2026, 4, 19, 17, 30),
+    );
+
+    expect(result.limited).toBe(false);
+  });
+
+  it('does not treat documentation-like usage-limit text as blocking', () => {
+    const result = detectCliUsageLimit(
+      'Document that usage limits reset at midnight in the README.',
+      new Date(2026, 4, 19, 17, 30),
+    );
+
+    expect(result.limited).toBe(false);
+  });
+});

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -128,6 +128,10 @@ vi.mock('../src/core/session-manager.js', () => ({
   getSessionWorkingDir: vi.fn(() => '/home/testuser/projects'),
   getProjectScanDir: vi.fn(() => '/home/testuser'),
   getProjectScanDirs: vi.fn(() => ['/home/testuser']),
+  rememberLastCliInput: vi.fn((ds: any, userPrompt: string, cliInput: string) => {
+    ds.lastUserPrompt = userPrompt;
+    ds.lastCliInput = cliInput;
+  }),
 }));
 
 vi.mock('../src/core/session-discovery.js', () => ({

--- a/test/fixtures/card-action-events.ts
+++ b/test/fixtures/card-action-events.ts
@@ -38,6 +38,13 @@ export function makeGetWriteLinkEvent(rootId: string, operatorOpenId = 'ou_user'
   };
 }
 
+export function makeRetryLastTaskEvent(rootId: string, operatorOpenId = 'ou_user') {
+  return {
+    action: { value: { action: 'retry_last_task', root_id: rootId } },
+    operator: { open_id: operatorOpenId },
+  };
+}
+
 export function makeSkipRepoEvent(rootId: string, operatorOpenId = 'ou_user') {
   return {
     action: { value: { action: 'skip_repo', root_id: rootId } },

--- a/test/multi-bot-group-flow.e2e.ts
+++ b/test/multi-bot-group-flow.e2e.ts
@@ -38,6 +38,10 @@ vi.mock('../src/core/session-manager.js', () => ({
   getSessionWorkingDir: vi.fn(() => '/tmp'),
   buildNewTopicPrompt: vi.fn(() => 'mock-prompt'),
   getAvailableBots: vi.fn(async () => []),
+  rememberLastCliInput: vi.fn((ds: any, userPrompt: string, cliInput: string) => {
+    ds.lastUserPrompt = userPrompt;
+    ds.lastCliInput = cliInput;
+  }),
 }));
 
 vi.mock('../src/services/session-store.js', () => ({

--- a/test/multi-bot-session.e2e.ts
+++ b/test/multi-bot-session.e2e.ts
@@ -23,6 +23,10 @@ vi.mock('../src/core/session-manager.js', () => ({
   getSessionWorkingDir: vi.fn(() => '/tmp'),
   buildNewTopicPrompt: vi.fn(() => 'mock-prompt'),
   getAvailableBots: vi.fn(async () => []),
+  rememberLastCliInput: vi.fn((ds: any, userPrompt: string, cliInput: string) => {
+    ds.lastUserPrompt = userPrompt;
+    ds.lastCliInput = cliInput;
+  }),
 }));
 
 vi.mock('../src/services/session-store.js', () => ({

--- a/test/session-adopt.test.ts
+++ b/test/session-adopt.test.ts
@@ -79,6 +79,10 @@ vi.mock('../src/core/session-manager.js', () => ({
   getProjectScanDir: vi.fn(() => '/tmp'),
   getProjectScanDirs: vi.fn(() => ['/tmp']),
   getAvailableBots: vi.fn(async () => []),
+  rememberLastCliInput: vi.fn((ds: any, userPrompt: string, cliInput: string) => {
+    ds.lastUserPrompt = userPrompt;
+    ds.lastCliInput = cliInput;
+  }),
 }));
 
 vi.mock('../src/services/frozen-card-store.js', () => ({

--- a/test/session-resume.test.ts
+++ b/test/session-resume.test.ts
@@ -199,6 +199,10 @@ describe('resumeSession', () => {
   describe('success path', () => {
     it('flips status back to active, clears closedAt, and registers in the Map (thread-scope)', () => {
       const closed = makeClosedSession({ rootMessageId: 'om_threadA' });
+      (closed as any).lastUserPrompt = '继续修复限额后的任务';
+      (closed as any).lastCliInput = '<user_message>继续修复限额后的任务</user_message>';
+      sessionStore.updateSession(closed);
+      sessionStore.closeSession(closed.sessionId);
       const map = new Map<string, DaemonSession>();
 
       const r = resumeSession(closed.sessionId, map);
@@ -218,6 +222,8 @@ describe('resumeSession', () => {
       expect(ds.workingDir).toBe('/tmp/proj');
       expect(ds.worker).toBeNull();
       expect(ds.larkAppId).toBe('app_test');
+      expect(ds.lastUserPrompt).toBe('继续修复限额后的任务');
+      expect(ds.lastCliInput).toBe('<user_message>继续修复限额后的任务</user_message>');
     });
 
     it('uses chatId as the routing anchor for chat-scope sessions', () => {


### PR DESCRIPTION
### 背景
botmux 目前会把底层 CLI 的运行状态同步到飞书卡片中，例如启动中、工作中、等待输入等。

但当底层 CLI 进入使用限额或速率限制状态时，飞书卡片没有对应的状态表达。用户只能从终端截图或输出里看到限额提示，卡片本身仍可能显示为“等待输入”或普通工作状态。

我在实际使用 Codex 时遇到过这种情况：

You've hit your usage limit. Upgrade to Pro (...), visit ... or try
again at 3:08 PM.
这时 Codex 已经明确提示达到使用限额，并给出了可重试时间。但飞书卡片仍然没有进入一个明确的“限额中”状态。

### 问题
这个场景下有几个体验问题：

用户不知道当前任务是仍在执行、等待输入，还是已经被底层 CLI 限额阻塞
如果消息提交没有被 transcript/history 确认，还可能继续出现“20s 后未确认提交”的提示
到达可重试时间后，用户也没有明显提示知道现在可以继续尝试
如果用户想重发上一条任务，需要手动复制或重新输入

### 修改
这个 PR 新增了底层 CLI 限额状态的识别和飞书卡片展示：

新增 CLI usage/rate limit 输出检测逻辑
只有同时满足“明确阻塞型限额文案 + 明确重试时间”时，才进入限额状态
飞书卡片在限额中显示“限额已达”
到达重试时间后，卡片自动切换为“可重试”
到达可重试时间后，提供“重发上一条任务”按钮
用户发送新消息时，会清理旧限额状态，避免旧状态污染新任务
在已检测到限额的情况下，抑制“20s 后未确认提交”的误导提示
覆盖 Codex TUI 将 try again at 自动换行成 try\nagain at 的情况

### 识别策略
这里没有把所有包含 limit 或 rate limit 的文案都识别为限额状态。

原因是 Codex/Claude 也可能输出一些非阻塞提示，例如：

Heads up, you have less than 5% of your 5h limit left.
或者：

Approaching rate limits
这些只是预警或模型切换建议，不代表当前任务已经被限额阻塞。

所以这个 PR 保持保守判断：只有出现明确的阻塞型限额文案，并且包含明确的重试/恢复时间，才会更新飞书卡片为限额状态。

### 验证
本地已验证：

vitest run test/cli-usage-limit.test.ts test/card-builder.test.ts test/card-integration.test.ts
tsc --noEmit
pnpm run build
另外也用真实 Codex 限额场景做了手动验证：

终端显示 You've hit your usage limit ... try again at 3:08 PM
飞书卡片能切换到限额状态
到达 3:08 PM 后，卡片自动切换为“可重试”