### PR TITLE
test(card,coco): 修复全量套件两个过时断言

### DIFF
--- a/test/card-toggle.e2e.ts
+++ b/test/card-toggle.e2e.ts
@@ -185,16 +185,18 @@ describe('Streaming card toggle_stream', () => {
   // ── Bug 1: Old card toggle should NOT affect latest card ──────────────────
 
   describe('Bug 1: clicking toggle on OLD frozen card', () => {
-    it('should NOT toggle when card_nonce differs from streamCardNonce (stale card)', async () => {
+    it('self-heals live displayMode on a stale-nonce click, but queues no PATCH without a clicked message id', async () => {
       const ds = makeDaemonSession({ displayMode: 'hidden' });
       const sessions = new Map<string, DaemonSession>();
       sessions.set(sessionKey(ROOT_ID, APP_ID), ds);
 
       await handleCardAction(makeToggleAction(NONCE_OLD), makeDeps(sessions), APP_ID);
 
-      // Stale-nonce click goes down the frozen-card branch which never touches
-      // ds.displayMode; the live card's PATCH queue stays empty.
-      expect(ds.displayMode).toBe('hidden');
+      // A stale-nonce click migrates the live session's displayMode and notifies
+      // the worker (the self-heal added in #19; see card-integration Scenario 3).
+      // The makeToggleAction event carries no clicked message id, so there is no
+      // card to PATCH — the live card's PATCH queue stays empty.
+      expect(ds.displayMode).toBe('screenshot');
       expect(patchCalls).toHaveLength(0);
     });
 

--- a/test/coco.e2e.ts
+++ b/test/coco.e2e.ts
@@ -236,9 +236,9 @@ describe('CoCo first-input submission (IdleDetector + readyPattern)', () => {
     detector.dispose();
   }, 30_000);
 
-  it('FIX: with readyPattern, idle waits for ⏵⏵ in TUI', async () => {
+  it('FIX: with readyPattern, idle does not fire until the ready prompt is rendered', async () => {
     const { IdleDetector } = await import('../src/utils/idle-detector.js');
-    const adapter = createCocoAdapter(); // has readyPattern: /⏵⏵/
+    const adapter = createCocoAdapter(); // has readyPattern: /⏵⏵|⬡/
     const sid = `e2e-fix-${Date.now()}`;
     const args = adapter.buildArgs({ sessionId: sid, resume: false });
 
@@ -248,8 +248,20 @@ describe('CoCo first-input submission (IdleDetector + readyPattern)', () => {
     let idleFiredAt = 0;
     detector.onIdle(() => { if (!idleFiredAt) idleFiredAt = Date.now(); });
 
+    // Track when CoCo's ready prompt first appears, so we assert the *contract*
+    // (idle gated on the prompt) rather than a wall-clock threshold — CoCo's
+    // boot speed varies by version (0.120.x renders the prompt in ~2.7s; older
+    // builds only after a ~5s xterm device-attribute query timeout).
+    const readyPattern = adapter.readyPattern!;
+    let acc = '';
+    let readySeenAt = 0;
+
     const spawnTs = Date.now();
-    session.proc.onData(data => detector.feed(data));
+    session.proc.onData(data => {
+      acc += data;
+      if (!readySeenAt && readyPattern.test(acc)) readySeenAt = Date.now();
+      detector.feed(data);
+    });
 
     await new Promise<void>(resolve => {
       const check = setInterval(() => {
@@ -260,12 +272,16 @@ describe('CoCo first-input submission (IdleDetector + readyPattern)', () => {
       }, 200);
     });
 
-    const elapsed = idleFiredAt ? idleFiredAt - spawnTs : -1;
-    console.log(`[fix] readyPattern ⏵⏵ → idle fired after ${elapsed}ms (TUI confirmed ready)`);
+    console.log(
+      `[fix] ready prompt seen at +${readySeenAt ? readySeenAt - spawnTs : -1}ms, ` +
+      `idle fired at +${idleFiredAt ? idleFiredAt - spawnTs : -1}ms`,
+    );
 
     expect(idleFiredAt, 'idle should eventually fire').toBeGreaterThan(0);
-    // Must fire AFTER TUI renders (⏵⏵ seen), which happens after xterm query timeout (~5s)
-    expect(elapsed, 'waits for TUI render before marking idle').toBeGreaterThanOrEqual(5000);
+    expect(readySeenAt, 'CoCo must emit a readyPattern glyph (⏵⏵/⬡) — guards against TUI glyph changes').toBeGreaterThan(0);
+    // The real contract: readyPattern suppresses quiescence until the input
+    // prompt renders, so idle must not fire before the glyph is seen.
+    expect(idleFiredAt, 'idle must not fire before the ready prompt is rendered').toBeGreaterThanOrEqual(readySeenAt);
 
     detector.dispose();
   }, 45_000);


### PR DESCRIPTION
## 背景

全量 `pnpm vitest run` 有两个稳定失败(非环境性,排除需要 live Feishu/浏览器的 `e2e-browser` 套件):

1. `test/card-toggle.e2e.ts` — `expected 'screenshot' to be 'hidden'`
2. `test/coco.e2e.ts` — `expected 2744 to be >= 5000`

两者根因都是**断言过时**,不是生产代码 bug。本 PR 仅改测试,无任何生产代码变更。

## 根因 & 修复

### 1. card-toggle:stale-nonce 自愈语义

`#19`(c4120f0)起,点击 stale-nonce 的旧卡片不再是 no-op,而是**自愈**:迁移 live session 的 `displayMode` 并通过 IPC 通知 worker —— 即便事件不带 message id 也会自愈(只是没有可 PATCH 的卡片)。这个契约由 `card-integration.test.ts` 的 Scenario 3 权威固定(其注释明确写了"NO clicked message id... State self-heals, worker is notified, but no card can be PATCHed")。

而 `card-toggle.e2e.ts` 这条断言写于 `#19` 之前,仍假设 stale 点击对 `displayMode` 是 no-op(`hidden`),与 Scenario 3 直接矛盾,是被 `#19` 改了行为却漏更新的旧断言。改为断言自愈到 `screenshot`、无 message id 时不发 PATCH。

> 过程记录:最初我尝试改生产代码去迎合这条旧断言,全量套件立刻测出它打破了 `card-integration` Scenario 3,遂回退生产代码、改这条过时测试。card-handler 现与 origin 字节一致。

### 2. coco:墙钟阈值 → 契约断言

原断言 `elapsed >= 5000ms` 依赖"CoCo 输入框要等 ~5s xterm 设备属性查询超时才渲染"的旧时序。CoCo 0.120.x 约 2.7s 就渲染出 ready glyph(`⏵⏵`/`⬡`),墙钟阈值与版本耦合而失效。

改为断言真正的契约:**idle 不会早于 ready glyph 出现**(`idleFiredAt >= readySeenAt`),并额外断言 CoCo 确实输出了匹配 `readyPattern` 的 glyph(守 glyph 变更回归)。版本无关,更稳。

## 验证

- 三个相关套件:`card-toggle` 6/6、`card-integration` 22/22、`coco` 10/10 全绿。
- 全量 `pnpm vitest run`:**1642 passed / 0 failed / 19 skipped**(基线为 2 failed)。剩余 15 个 "failed files" 是 `e2e-browser`(需 live Feishu+Midscene)在 hook 层失败的环境性噪音,无 test-level 失败。
- `pnpm test:agy` 单独跑 6/6(其 `finding(3)` 在全量并发负载下偶发超时,属 #19 真机 e2e 的固有 flakiness,不在本次范围)。
