### PR TITLE
feat(daemon): 新增 defaultWorkingDir 跳过单仓 bot 的 repo 选择卡片

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -435,6 +435,7 @@ When `~/.botmux/bots.json` already exists, `botmux setup` can add a bot, reconfi
 | `cliPathOverride` | No | Absolute path to the CLI entry, for wrappers / routers; typical use: `ccr`, `claude-w`, `aiden-x-claude`, etc. |
 | `backendType` | No | Session backend: `pty` or `tmux` (auto-detected by default) |
 | `workingDir` | No | Default working directory, supports comma-separated |
+| `defaultWorkingDir` | No | Single-repo default: new topics with no oncall binding and no peer-session inheritance spawn directly here, skipping the repo-select card. `/cd <path>` still switches mid-session; the next new topic falls back to this default. **Difference from `defaultOncall`:** does NOT write `oncallChats` and does NOT change the `canTalk` / `canOperate` permission model |
 | `allowedUsers` | No | Allowed users (email prefixes or open_ids) |
 | `oncallChats` | No | Oncall bindings (written by `/oncall bind`), e.g. `[{ "chatId": "oc_xxx", "workingDir": "~/projects/foo" }]`; any group member can @ the bot |
 

--- a/README.md
+++ b/README.md
@@ -506,6 +506,7 @@ botmux setup
 | `cliPathOverride` | 否 | CLI 入口的绝对路径，用于套 wrapper / router；典型场景：ccr、claude-w、aiden-x-claude 等自定义入口 |
 | `backendType` | 否 | 会话后端：`pty` 或 `tmux`（默认自动检测） |
 | `workingDir` | 否 | 默认工作目录，支持逗号分隔多个目录 |
+| `defaultWorkingDir` | 否 | 单仓库默认目录：新话题在无 oncall 绑定 / 无同群兄弟 session 时直接进入该目录，跳过 repo 选择卡片。`/cd <path>` 仍可临时切换；下一个新话题回到该默认值。**与 `defaultOncall` 的区别**：不写 `oncallChats`、不修改 `canTalk`/`canOperate` 权限模型 |
 | `allowedUsers` | 否 | 允许的用户列表（邮箱前缀或 open_id） |
 | `oncallChats` | 否 | oncall 绑定（`/oncall bind` 写入），形如 `[{ "chatId": "oc_xxx", "workingDir": "~/projects/foo" }]`，群内任何成员可 @ 提问 |
 

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -45,6 +45,16 @@ export interface BotConfig {
   oncallChats?: OncallChat[];
   /** UI language for this bot: 'zh' or 'en'. Falls back to BOTMUX_LANG / LANG env when unset. */
   lang?: Locale;
+  /**
+   * Per-bot default working directory. When set, new topics that have no
+   * oncall binding and no sibling-session inheritance skip the repo-select
+   * card and spawn the CLI directly in this directory. `/cd <path>` still
+   * works to switch mid-session; the next new topic falls back to this default.
+   *
+   * Pure runtime fallback — does NOT write any state to bots.json and does
+   * NOT change the canTalk / canOperate permission model (unlike defaultOncall).
+   */
+  defaultWorkingDir?: string;
   /** Per-bot default: auto-bind every new group chat to oncall on first new-topic. */
   defaultOncall?: BotDefaultOncall;
   /**
@@ -326,6 +336,9 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
       oncallChats,
       defaultOncall,
       defaultOncallAutoboundChats,
+      defaultWorkingDir: typeof entry.defaultWorkingDir === 'string' && entry.defaultWorkingDir.trim()
+        ? entry.defaultWorkingDir.trim()
+        : undefined,
       chatGrants,
       lang: isLocale(entry.lang) ? entry.lang : undefined,
     });

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -398,6 +398,32 @@ async function maybeAutoBindDefaultOncall(
   return r.entry;
 }
 
+/**
+ * Resolve this bot's `defaultWorkingDir` for a new-topic spawn, if any.
+ * Unlike `defaultOncall`, this is a pure runtime fallback: no state is
+ * written to bots.json and the chat is NOT bound to oncall (so the
+ * permission model stays unchanged). `/cd <path>` can still switch the
+ * working dir mid-session; the next new topic falls back to this default.
+ *
+ * Returns the expanded path when the configured field points to a real
+ * directory; logs and returns undefined when the path is missing/invalid
+ * so the caller falls through to the repo-select card instead of
+ * spawning into a bad cwd.
+ */
+function resolveBotDefaultWorkingDir(larkAppId: string): string | undefined {
+  const raw = getBot(larkAppId).config.defaultWorkingDir;
+  if (!raw) return undefined;
+  const resolved = expandHome(raw);
+  try {
+    if (statSync(resolved).isDirectory()) return resolved;
+  } catch { /* not a dir */ }
+  logger.warn(
+    `[${larkAppId}] defaultWorkingDir invalid (${resolved}); ` +
+    `falling back to repo-select card`,
+  );
+  return undefined;
+}
+
 async function replyInvalidWorkingDirs(
   anchor: string,
   larkAppId: string,
@@ -585,7 +611,14 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
     ? findInheritablePeer({ scope, anchor, chatId, chatType, selfAppId: larkAppId })
     : null;
 
-  const pinnedWorkingDir = oncallEntry?.workingDir ?? inheritedFrom?.workingDir;
+  // Last-resort fallback: this bot's `defaultWorkingDir`. Pure runtime — no
+  // oncall binding written, no permission-model change. Lets a single-repo
+  // bot skip the repo-select card without committing to oncall semantics.
+  const botDefaultWorkingDir = (!oncallEntry && !inheritedFrom)
+    ? resolveBotDefaultWorkingDir(larkAppId)
+    : undefined;
+
+  const pinnedWorkingDir = oncallEntry?.workingDir ?? inheritedFrom?.workingDir ?? botDefaultWorkingDir;
   const ds: DaemonSession = {
     session,
     worker: null,
@@ -622,7 +655,9 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
     forkWorker(ds, prompt);
     const reason = oncallEntry
       ? `oncall-bound chat ${chatId}`
-      : `inherited from sibling session ${inheritedFrom!.sessionId.substring(0, 8)} (app=${inheritedFrom!.larkAppId ?? 'unknown'})`;
+      : inheritedFrom
+      ? `inherited from sibling session ${inheritedFrom.sessionId.substring(0, 8)} (app=${inheritedFrom.larkAppId ?? 'unknown'})`
+      : `bot defaultWorkingDir`;
     logger.info(`[${tag(ds)}] ${reason} → workingDir=${pinnedWorkingDir}, skipped repo select`);
     return;
   }
@@ -928,7 +963,13 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
         })
       : null;
 
-    const pinnedWorkingDir = oncallEntry?.workingDir ?? inheritedFrom?.workingDir;
+    // Last-resort fallback: this bot's `defaultWorkingDir`. See handleNewTopic
+    // for the symmetric block — both call sites must stay in sync.
+    const botDefaultWorkingDir = (!oncallEntry && !inheritedFrom)
+      ? resolveBotDefaultWorkingDir(larkAppId)
+      : undefined;
+
+    const pinnedWorkingDir = oncallEntry?.workingDir ?? inheritedFrom?.workingDir ?? botDefaultWorkingDir;
     // Now we know the message will spawn or pend a real session — resolve
     // sender (may await contact API budget) since every downstream branch
     // injects it either into the immediate prompt or stashes it on
@@ -971,7 +1012,9 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
       forkWorker(newDs, prompt);
       const reason = oncallEntry
         ? `oncall-bound chat ${autoCreateChatId}`
-        : `inherited from peer session ${inheritedFrom!.sessionId.substring(0, 8)} (app=${inheritedFrom!.larkAppId ?? 'unknown'})`;
+        : inheritedFrom
+        ? `inherited from peer session ${inheritedFrom.sessionId.substring(0, 8)} (app=${inheritedFrom.larkAppId ?? 'unknown'})`
+        : `bot defaultWorkingDir`;
       logger.info(`[${tag(newDs)}] ${reason} → workingDir=${pinnedWorkingDir}, skipped repo select`);
       return;
     }

--- a/test/bot-registry.test.ts
+++ b/test/bot-registry.test.ts
@@ -413,6 +413,27 @@ describe('loadBotConfigs', () => {
     expect(configs.map(c => c.cliId)).toEqual(['claude-code', 'aiden', 'coco']);
   });
 
+  it('should parse defaultWorkingDir as an optional string', () => {
+    process.env.BOTS_CONFIG = '/tmp/defwd.json';
+    fsMock.existsSync.mockReturnValue(true);
+    fsMock.readFileSync.mockReturnValue(JSON.stringify([
+      { larkAppId: 'a1', larkAppSecret: 's1', defaultWorkingDir: '~/projects/foo' },
+      { larkAppId: 'a2', larkAppSecret: 's2' },                      // unset → undefined
+      { larkAppId: 'a3', larkAppSecret: 's3', defaultWorkingDir: '' },  // empty → undefined
+      { larkAppId: 'a4', larkAppSecret: 's4', defaultWorkingDir: '   ' }, // whitespace → undefined
+      { larkAppId: 'a5', larkAppSecret: 's5', defaultWorkingDir: 42 }, // non-string → undefined
+      { larkAppId: 'a6', larkAppSecret: 's6', defaultWorkingDir: '  /repos/bar  ' }, // trimmed
+    ]));
+
+    const configs = mod.loadBotConfigs();
+    expect(configs[0].defaultWorkingDir).toBe('~/projects/foo');
+    expect(configs[1].defaultWorkingDir).toBeUndefined();
+    expect(configs[2].defaultWorkingDir).toBeUndefined();
+    expect(configs[3].defaultWorkingDir).toBeUndefined();
+    expect(configs[4].defaultWorkingDir).toBeUndefined();
+    expect(configs[5].defaultWorkingDir).toBe('/repos/bar');
+  });
+
   it('should handle empty workingDir string gracefully', () => {
     process.env.BOTS_CONFIG = '/tmp/empty_wd.json';
     fsMock.existsSync.mockReturnValue(true);


### PR DESCRIPTION
### Summary

添加一个 bot level 的配置，每个 bot 配置加可选 defaultWorkingDir 字段，新话题命中 oncall / 同群兄弟 session 之外的兜底分支时，直接在该目录 spawn CLI，跳过 repo 选择卡片。/cd <path> 仍可临时切换，下一个新话题回到该默认值。

与 defaultOncall 的区别：
- 不写 oncallChats / defaultOncallAutoboundChats，无持久化副作用
- 不影响 canTalk / canOperate 权限模型（defaultOncall 会把整个群开放为 oncall 工作区）
- 纯运行时 fallback，路径无效时 warn 并降级到 repo 选择卡片

适用场景：单仓库 bot，省掉每次新话题选 repo 的卡片，但又不想触发 oncall 的群级权限放开。

保持轻量级 pr，暂时没有加额外的控制能力，需要到配置文件中手动修改 defaultWorkingDir 

### Test

Local tested