### PR TITLE
fix(release): 修复 changelog 本次合并重复堆叠 + PR 重复两行

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,10 @@ jobs:
             PREV_TAG=$(git tag --sort=-v:refname | grep -Fxv "$GITHUB_REF_NAME" | grep -v -e '-' | head -1)
           fi
           TAG_MSG=$(git tag -l --format='%(contents)' "$GITHUB_REF_NAME")
-          # cliff.toml 渲染'本次合并' + '新贡献者'两段，GitHub PR 元数据由 GITHUB_TOKEN 拉取
-          CLIFF=$(npx --yes git-cliff --current)
+          # cliff.toml 渲染'本次合并' + '新贡献者'两段，GitHub PR 元数据由 GITHUB_TOKEN 拉取。
+          # 用显式区间 PREV_TAG..本 tag，别用 --current：--current 在 HEAD 落在 tag 上时
+          # 会把范围撑到好几个历史 release，导致'本次合并'重复堆叠多段。PREV_TAG 上面已算好。
+          CLIFF=$(npx --yes git-cliff "${PREV_TAG}..${GITHUB_REF_NAME}")
           {
             echo 'body<<CHANGELOG_EOF'
             [ -n "$TAG_MSG" ] && echo "$TAG_MSG"

--- a/cliff.toml
+++ b/cliff.toml
@@ -34,6 +34,12 @@ conventional_commits = false
 filter_unconventional = false
 split_commits = false
 filter_commits = false
+# 跳过 merge commit：用'Merge pull request'方式合 PR 时,git 历史里 PR 标题会同时挂在
+# 分支 commit 和 merge commit 上,不过滤会导致一个 PR 在'本次合并'里出现两次。
+# 兼容自定义 merge message:'Merge branch …'、'Merge: …'、'Merge fix/… '等。
+commit_parsers = [
+  { message = "^Merge[ :]", skip = true },
+]
 tag_pattern = "v[0-9].*"
 sort_commits = "oldest"
 


### PR DESCRIPTION
## 问题

GitHub Release 的 changelog 有两个由配置导致的毛病:

1. **多段「本次合并」重复堆叠** — `release.yml` 用 `git-cliff --current`,而 `--current` 在 HEAD 落在 tag 上时会把范围撑到多个历史 release(实测 v2.32.0 返回了 **6 个 release**),正文模板又没打印版本号标题,于是多段「本次合并」无标题地堆叠,把上个版本已发过的内容重复列出。
2. **一个 PR 显示两行** — `cliff.toml` 没过滤 merge commit。用「Merge pull request」方式合 PR 时,PR 标题同时挂在分支 commit 和 merge commit 上。

## 改动

- `release.yml`: `git-cliff --current` → 显式区间 `${PREV_TAG}..${GITHUB_REF_NAME}`(PREV_TAG 本就为 Full Changelog 链接算好了),只取本次区间。
- `cliff.toml`: 加 `commit_parsers` skip 掉 `^Merge[ :]`,每个改动只留一行 + 真实作者。

## 验证

本地对三个真实区间跑 `git-cliff`(带 GITHUB_TOKEN),均为 **1 段「本次合并」**、无重复行、作者署名正确(如 #31 显示 @SDGLBL)。

## 代价 / 已知

- inline 的 `(#PR)` 链接会消失(git-cliff 把 PR 号挂在被 skip 的 merge commit 上)。
- 「感谢贡献者」段此前就因同样的 merge-commit 归属问题从未真正触发(贡献者被记成点 merge 的人),本 PR 未处理,可另开。彻底解法是仓库改用 squash-merge。