### PR TITLE
fix(card): 修复 daemon 重启后限额卡片不会自动变为可重试的问题

### DIFF
--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -11,7 +11,7 @@ import * as sessionStore from '../services/session-store.js';
 import * as messageQueue from '../services/message-queue.js';
 import { downloadMessageResource, listChatBotMembers } from '../im/lark/client.js';
 import { logger } from '../utils/logger.js';
-import { forkWorker, forkAdoptWorker, killStalePids, getCurrentCliVersion } from './worker-pool.js';
+import { forkWorker, forkAdoptWorker, killStalePids, getCurrentCliVersion, restoreUsageLimitRuntimeState } from './worker-pool.js';
 import { createCliAdapterSync } from '../adapters/cli/registry.js';
 import { buildBotmuxShellHints } from '../adapters/cli/shared-hints.js';
 import { TmuxBackend } from '../adapters/backend/tmux-backend.js';
@@ -553,6 +553,7 @@ export function restoreActiveSessions(activeSessions: Map<string, DaemonSession>
       };
       const anchor = sessionAnchorId(ds);
       messageQueue.ensureQueue(anchor);
+      if (ds.usageLimit) restoreUsageLimitRuntimeState(ds);
       activeSessions.set(sessionKey(anchor, larkAppId), ds);
       forkAdoptWorker(ds, { restoredFromMetadata: true });
       logger.info(`[${session.sessionId.substring(0, 8)}] Restored adopt session (target: ${adopted.tmuxTarget}, scope: ${scope})`);
@@ -596,6 +597,7 @@ export function restoreActiveSessions(activeSessions: Map<string, DaemonSession>
     };
     const anchor = sessionAnchorId(ds);
     messageQueue.ensureQueue(anchor);
+    if (ds.usageLimit) restoreUsageLimitRuntimeState(ds);
     activeSessions.set(sessionKey(anchor, larkAppId), ds);
 
     logger.debug(`Registered session ${session.sessionId} (scope: ${scope}, anchor: ${anchor})`);

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -112,11 +112,12 @@ export function cardUsageLimit(ds: DaemonSession): CliUsageLimitState | undefine
 
 function scheduleUsageLimitCardPatch(ds: DaemonSession): void {
   if (ds.lastScreenStatus !== 'limited') return;
-  if (!ds.streamCardId || ds.streamCardId === CARD_POSTING_SENTINEL || !ds.workerPort) return;
+  const port = ds.workerPort ?? ds.session.webPort;
+  if (!ds.streamCardId || ds.streamCardId === CARD_POSTING_SENTINEL || !port) return;
 
   const bot = getBot(ds.larkAppId);
   const effectiveCliId = sessionCliId(ds, bot.config);
-  const readUrl = `http://${config.web.externalHost}:${ds.workerPort}`;
+  const readUrl = `http://${config.web.externalHost}:${port}`;
   const turnTitle = ds.currentTurnTitle || ds.session.title || getCliDisplayName(effectiveCliId);
   const cardJson = buildStreamingCard(
     ds.session.sessionId,
@@ -161,6 +162,12 @@ function armUsageLimitRetryTimer(ds: DaemonSession, previous?: CliUsageLimitStat
     persistStreamCardState(ds);
     scheduleUsageLimitCardPatch(ds);
   }, delayMs);
+}
+
+export function restoreUsageLimitRuntimeState(ds: DaemonSession): void {
+  if (!ds.usageLimit) return;
+  ds.lastScreenStatus = 'limited';
+  armUsageLimitRetryTimer(ds);
 }
 
 function updateUsageLimitState(ds: DaemonSession, usageLimit?: CliUsageLimitState): void {

--- a/src/utils/cli-usage-limit.ts
+++ b/src/utils/cli-usage-limit.ts
@@ -51,6 +51,10 @@ function parseMeridiemTime(text: string, now: Date): { retryAtMs: number; retryL
 
     const retryAt = new Date(now);
     retryAt.setHours(hour, minute, 0, 0);
+    // CLI output only includes a wall-clock time, not a date. Roll passed AM
+    // times into tomorrow because afternoon→midnight resets are common. Passed
+    // PM times stay on today: they might mean "just reset" or "tomorrow PM",
+    // and a wrong ready state self-heals when the CLI rejects the retry again.
     if (retryAt.getTime() < now.getTime() && hour < 12) {
       retryAt.setDate(retryAt.getDate() + 1);
     }

--- a/test/recall-frozen-cards.test.ts
+++ b/test/recall-frozen-cards.test.ts
@@ -7,7 +7,7 @@
  *
  * Run:  pnpm vitest run test/recall-frozen-cards.test.ts
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { DaemonSession, FrozenCard } from '../src/core/types.js';
 
 // ─── Mocks ─────────────────────────────────────────────────────────────────
@@ -47,7 +47,9 @@ vi.mock('../src/im/lark/card-builder.js', () => ({
 }));
 
 vi.mock('../src/bot-registry.js', () => ({
-  getBot: vi.fn(),
+  getBot: vi.fn(() => ({
+    config: { larkAppId: 'app_test', cliId: 'claude-code' },
+  })),
   getAllBots: vi.fn(() => []),
 }));
 
@@ -90,8 +92,9 @@ vi.mock('../src/adapters/backend/tmux-backend.js', () => ({
 
 // ─── Imports under test ────────────────────────────────────────────────────
 
-import { recallFrozenCards, parkStreamCard, scheduleCardPatch } from '../src/core/worker-pool.js';
+import { recallFrozenCards, parkStreamCard, restoreUsageLimitRuntimeState, scheduleCardPatch } from '../src/core/worker-pool.js';
 import { MessageWithdrawnError } from '../src/im/lark/client.js';
+import { buildStreamingCard } from '../src/im/lark/card-builder.js';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
@@ -143,6 +146,11 @@ beforeEach(() => {
   loadFrozenCardsMock.mockReset();
   loadFrozenCardsMock.mockReturnValue(new Map());
   persistStreamCardStateMock.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
 });
 
 function flush(): Promise<void> {
@@ -282,6 +290,76 @@ describe('recallFrozenCards', () => {
 
     expect(deleteMessageMock).toHaveBeenCalledTimes(1);
     expect(deleteMessageMock).toHaveBeenCalledWith(APP_ID, 'om_only');
+  });
+});
+
+describe('restoreUsageLimitRuntimeState', () => {
+  it('marks restored limit sessions limited and re-arms the retry timer', () => {
+    const now = new Date('2026-05-22T10:00:00Z').getTime();
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const ds = makeDs();
+    ds.streamCardId = 'om_live_limit';
+    ds.streamCardNonce = 'nonce_limit';
+    ds.session.webPort = 8080;
+    ds.workerPort = null;
+    ds.usageLimit = {
+      limited: true,
+      kind: 'usage',
+      retryAtMs: now + 1_000,
+      retryLabel: '10:01 AM',
+      retryReady: false,
+    };
+
+    restoreUsageLimitRuntimeState(ds);
+
+    expect(ds.lastScreenStatus).toBe('limited');
+    expect(ds.usageLimitRetryTimer).toBeDefined();
+    expect(ds.usageLimit.retryReady).toBe(false);
+    expect(persistStreamCardStateMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1_000);
+
+    expect(ds.usageLimit.retryReady).toBe(true);
+    expect(persistStreamCardStateMock).toHaveBeenCalledWith(ds);
+    expect(buildStreamingCard).toHaveBeenCalledWith(
+      SESSION_ID,
+      'om_root',
+      'http://localhost:8080',
+      't',
+      '',
+      'limited',
+      'claude-code',
+      'hidden',
+      'nonce_limit',
+      undefined,
+      false,
+      false,
+      'zh',
+      ds.usageLimit,
+    );
+    expect(updateMessageMock).toHaveBeenCalledWith(APP_ID, 'om_live_limit', '{}');
+  });
+
+  it('marks already-expired restored limits retry-ready immediately', () => {
+    const now = new Date('2026-05-22T10:00:00Z').getTime();
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const ds = makeDs();
+    ds.usageLimit = {
+      limited: true,
+      kind: 'usage',
+      retryAtMs: now - 1_000,
+      retryLabel: '9:59 AM',
+      retryReady: false,
+    };
+
+    restoreUsageLimitRuntimeState(ds);
+
+    expect(ds.lastScreenStatus).toBe('limited');
+    expect(ds.usageLimit.retryReady).toBe(true);
+    expect(ds.usageLimitRetryTimer).toBeUndefined();
+    expect(persistStreamCardStateMock).toHaveBeenCalledWith(ds);
   });
 });
 

--- a/test/session-resume.test.ts
+++ b/test/session-resume.test.ts
@@ -38,6 +38,7 @@ vi.mock('../src/core/worker-pool.js', () => ({
   forkAdoptWorker: vi.fn(),
   killStalePids: vi.fn(),
   getCurrentCliVersion: vi.fn(() => '1.0.0-test'),
+  restoreUsageLimitRuntimeState: vi.fn(),
 }));
 
 vi.mock('../src/bot-registry.js', () => ({
@@ -80,7 +81,8 @@ vi.mock('../src/core/session-activity.js', () => ({
   markSessionActivity: vi.fn(),
 }));
 
-import { resumeSession } from '../src/core/session-manager.js';
+import { restoreActiveSessions, resumeSession } from '../src/core/session-manager.js';
+import { restoreUsageLimitRuntimeState } from '../src/core/worker-pool.js';
 import * as sessionStore from '../src/services/session-store.js';
 import { sessionKey } from '../src/core/types.js';
 import type { DaemonSession } from '../src/core/types.js';
@@ -197,6 +199,27 @@ describe('resumeSession', () => {
   });
 
   describe('success path', () => {
+    it('restores usage-limit runtime state for active sessions after daemon restart', () => {
+      const s = sessionStore.createSession('oc_chat_limit', 'om_limit', 'Limited topic');
+      s.larkAppId = 'app_test';
+      s.scope = 'thread';
+      s.usageLimit = {
+        limited: true,
+        kind: 'usage',
+        retryAtMs: Date.now() + 60_000,
+        retryLabel: '10:36 PM',
+        retryReady: false,
+      };
+      sessionStore.updateSession(s);
+      const map = new Map<string, DaemonSession>();
+
+      restoreActiveSessions(map);
+
+      const ds = map.get(sessionKey('om_limit', 'app_test'));
+      expect(ds).toBeDefined();
+      expect(restoreUsageLimitRuntimeState).toHaveBeenCalledWith(ds);
+    });
+
     it('flips status back to active, clears closedAt, and registers in the Map (thread-scope)', () => {
       const closed = makeClosedSession({ rootMessageId: 'om_threadA' });
       (closed as any).lastUserPrompt = '继续修复限额后的任务';


### PR DESCRIPTION
### 背景

在 #32 里，botmux 新增了 CLI usage / rate limit 状态识别和飞书卡片展示：

- 检测到底层 CLI 进入限额状态时，卡片显示“限额已达”
- 到达 `try again at ...` / `resets ...` 对应时间后，卡片自动切换为“可重试”
- 用户可以点击“重发上一条任务”继续执行

非常感谢 @deepcoldy 在 review 里细致地帮忙收口实现细节，包括去重、类型统一、热路径优化和状态封装。也很感谢 review 里指出的两个后续取舍点，这两个点让限额状态的体验更完整了。

这个 PR 是 #32 的 follow-up，主要处理 daemon 重启后 retry timer 没有恢复的问题，并补充 PM 时间歧义的说明注释。

### 问题

`usageLimit` 状态本身已经会持久化到 session 里，例如：

```ts
{
  limited: true,
  kind: 'usage',
  retryAtMs,
  retryLabel,
  retryReady
}
```

但真正负责把卡片从“限额已达”切到“可重试”的 `setTimeout` 只存在于 daemon 进程内存里。

所以 daemon 重启后会出现一个小缺口：

- session 里还能读回 `usageLimit`
- 但原来的 retry timer 已经丢失
- 如果没有新的 worker/card 更新触发恢复，卡片可能停留在“限额已达”
- 到达 `retryAtMs` 后，也不会自动切换为“可重试”

另外，在 daemon 重启恢复期，普通 session 可能还没有 worker ready，此时 `ds.workerPort` 为空。如果 retry timer 到点时只依赖 `workerPort`，旧卡片也可能无法立即 PATCH。

### 修改

这个 PR 做了几件小修复：

- 新增 `restoreUsageLimitRuntimeState`
  - daemon 重启恢复 session 时，如果发现已有持久化的 `usageLimit`，会把运行态恢复为 `limited`
  - 根据 `usageLimit.retryAtMs` 重新 arm retry timer
- 在 `restoreActiveSessions` 中恢复 usage-limit 运行态
  - 覆盖普通 session
  - 覆盖 adopt session
- retry timer 到点后 PATCH 卡片时，端口选择改为：
  - 优先使用当前 live 的 `ds.workerPort`
  - 如果 worker 还没 ready，则 fallback 到持久化的 `ds.session.webPort`
- 在 `parseMeridiemTime` 里补充 PM 已过时间的注释
  - CLI 只给 wall-clock time，没有日期
  - 对已过 PM 时间不主动猜测“明天”
  - 误判成本较低，用户 retry 后 CLI 会再次拒绝并让卡片自愈回限额态

### 效果

现在 daemon 重启后的限额会话可以继续正常流转：

```text
daemon 重启
=> 从 session-store 读回 usageLimit
=> 恢复 limited 运行态
=> 根据 retryAtMs 重新创建 timer
=> 到点后 retryReady = true
=> PATCH 飞书卡片为“可重试”
```

即使 worker 还没有重新 ready，只要历史 session 里有 `session.webPort`，旧卡片也可以先完成状态更新。真正的写入能力仍然不受影响，写入终端链接依旧需要 live `workerPort + workerToken`。

### 识别策略 / 取舍

这个 PR 没有改变 usage / rate limit 的识别策略，也没有改变 `retryAtMs` 的核心解析逻辑。

关于 PM 已过时间的歧义，当前仍保持保守处理。例如：

```text
现在 23:50
CLI 说 try again at 10:36 PM
```

这种情况下，单靠文案无法判断它是“刚刚重置过”还是“明天 10:36 PM 才重置”。所以这里先保留现有启发式，只补充注释说明 tradeoff。最坏情况是用户多点一次重试，CLI 再次返回限额后卡片会回到限额态，可以自愈。

### 验证

本地已验证：

```bash
vitest run test/session-resume.test.ts test/recall-frozen-cards.test.ts test/cli-usage-limit.test.ts
tsc --noEmit
git diff --check
```

结果：

```text
42 tests passed
tsc --noEmit passed
git diff --check passed
```
