### PR TITLE
test(group): 修复 #38 引入的 /group 命令单测回归

### DIFF
--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -234,7 +234,7 @@ function makeDeps(ds?: DaemonSession): CommandHandlerDeps {
 
 describe('DAEMON_COMMANDS set', () => {
   it('should contain all expected commands', () => {
-    const expected = ['/close', '/restart', '/status', '/help', '/cd', '/repo', '/skip', '/schedule', '/login', '/adopt', '/oncall'];
+    const expected = ['/close', '/restart', '/status', '/help', '/cd', '/repo', '/skip', '/schedule', '/login', '/adopt', '/oncall', '/group', '/g'];
     for (const cmd of expected) {
       expect(DAEMON_COMMANDS.has(cmd), `Expected DAEMON_COMMANDS to contain ${cmd}`).toBe(true);
     }
@@ -251,7 +251,7 @@ describe('DAEMON_COMMANDS set', () => {
   });
 
   it('should have the correct size', () => {
-    expect(DAEMON_COMMANDS.size).toBe(11);
+    expect(DAEMON_COMMANDS.size).toBe(13);
   });
 });
 

--- a/test/group-creator.test.ts
+++ b/test/group-creator.test.ts
@@ -8,6 +8,8 @@
  *  - invalidUserIds includes transferTo → skip transfer with 'invitee_rejected'
  *  - invalidUserIds includes notifyTo → skip notify with 'invitee_rejected'
  *  - transferChatOwner failure surfaces as `transferError`, chatId still returned
+ *  - transferChatOwner error but getChatOwner confirms target → treated as success
+ *    (Lark slow-ACK / 504 false-negative recovery)
  *  - sendMessage throw surfaces as `notifyError`, chatId still returned
  *  - createChat throw bubbles up (caller decides exit code)
  */
@@ -15,9 +17,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 const mockCreateChat = vi.fn();
 const mockTransferChatOwner = vi.fn();
+const mockGetChatOwner = vi.fn();
 vi.mock('../src/services/groups-store.js', () => ({
   createChat: (...args: any[]) => mockCreateChat(...args),
   transferChatOwner: (...args: any[]) => mockTransferChatOwner(...args),
+  getChatOwner: (...args: any[]) => mockGetChatOwner(...args),
 }));
 
 const mockSendMessage = vi.fn();
@@ -40,6 +44,7 @@ describe('createGroupWithBots', () => {
   beforeEach(() => {
     mockCreateChat.mockReset();
     mockTransferChatOwner.mockReset();
+    mockGetChatOwner.mockReset();
     mockSendMessage.mockReset();
     mockBindOncall.mockReset();
   });
@@ -123,6 +128,9 @@ describe('createGroupWithBots', () => {
   it('surfaces transferChatOwner failure as transferError without aborting', async () => {
     mockCreateChat.mockResolvedValue({ chatId: 'oc_x', invalidBotIds: [], invalidUserIds: [] });
     mockTransferChatOwner.mockResolvedValue({ ok: false, error: 'permission_denied' });
+    // Readback confirms the transfer really did NOT happen (owner is still
+    // someone other than the target), so the error must surface.
+    mockGetChatOwner.mockResolvedValue('ou_still_the_bot');
     mockSendMessage.mockResolvedValue('om_notify');
     const result = await createGroupWithBots({
       creatorLarkAppId: CREATOR,
@@ -136,6 +144,25 @@ describe('createGroupWithBots', () => {
     // notify still ran
     expect(result.notifyMessageId).toBe('om_notify');
     expect(result.notifyError).toBeNull();
+  });
+
+  it('treats a transfer error as success when getChatOwner confirms the target', async () => {
+    // Lark sometimes returns 504/transient errors on owner transfer even though
+    // the write committed. group-creator reads back the owner; if it already
+    // matches the target, the transfer really succeeded and no error surfaces.
+    mockCreateChat.mockResolvedValue({ chatId: 'oc_x', invalidBotIds: [], invalidUserIds: [] });
+    mockTransferChatOwner.mockResolvedValue({ ok: false, error: 'gateway_timeout' });
+    mockGetChatOwner.mockResolvedValue(USER_OPEN_ID);
+    mockSendMessage.mockResolvedValue('om_notify');
+    const result = await createGroupWithBots({
+      creatorLarkAppId: CREATOR,
+      larkAppIds: [CREATOR],
+      transferOwnerTo: USER_OPEN_ID,
+      notifyOwnerOpenId: USER_OPEN_ID,
+    });
+    expect(mockGetChatOwner).toHaveBeenCalledWith(CREATOR, 'oc_x');
+    expect(result.ownerTransferredTo).toBe(USER_OPEN_ID);
+    expect(result.transferError).toBeNull();
   });
 
   it('surfaces sendMessage throw as notifyError without aborting', async () => {


### PR DESCRIPTION
### 背景

PR #38（`feat(daemon): 新增 /group(=/g) 命令一键建群`）已合入 master，但引入两处单测回归，在 master 上仍直接失败。本 PR 作为 follow-up 修复。

### 修复

1. **`test/command-handler.test.ts`** — `DAEMON_COMMANDS` 新增 `/group`、`/g` 后实际为 13 项，但断言仍写 `size === 11` → 失败。同步 `expected` 列表（补 `/group`、`/g`）与 size 断言（→13）。
2. **`test/group-creator.test.ts`** — `src/services/group-creator.ts` 在转让群主失败路径会回读 `getChatOwner` 做慢-ACK 校验，但 `groups-store` 的 `vi.mock` 工厂未导出该函数 → 调用 `undefined` 抛 `No "getChatOwner" export is defined`。
   - 补 `getChatOwner` mock 桩 + `beforeEach` reset；
   - 既有「transfer 失败」用例显式让回读返回非目标 owner，意图更清晰；
   - 新增正向用例：transfer 报错（504/慢 ACK）但回读确认目标已是群主 → 视为成功、不报错。

### 验证

```
pnpm vitest run test/command-handler.test.ts test/group-creator.test.ts
→ Test Files 2 passed | Tests 78 passed (command-handler 66 / group-creator 12)
```

> 说明：仅改测试文件，不动运行时逻辑。本地全量 `pnpm test` 的其它失败（缺 `markdown-it`/`qrcode-terminal` 依赖、飞书/CLI e2e env）与本改动及 #38 无关。
