### PR TITLE
fix(worker-pool): worker 重启走 POST 路径时补发 set_display_mode

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -645,6 +645,10 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
           );
           ds.streamCardId = await cb.sessionReply(sessionAnchorId(ds), streamCardJson, 'interactive', ds.larkAppId);
           persistStreamCardState(ds);
+          // Re-sync worker's display mode (it starts fresh in 'hidden')
+          if (ds.worker && ds.displayMode && ds.displayMode !== 'hidden') {
+            ds.worker.send({ type: 'set_display_mode', mode: ds.displayMode } as DaemonToWorker);
+          }
           // New card is live — recall any cards frozen by previous turns.
           // Done after `streamCardId` is committed so we never delete the old
           // card without a successor visible to the user.

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1114,6 +1114,7 @@ function deliverFinalOutput(
 /** Test-only alias so the retry pipeline can be exercised without a real
  *  fork. Intentionally underscored to discourage non-test callers. */
 export const __testOnly_deliverFinalOutput = deliverFinalOutput;
+export const __testOnly_setupWorkerHandlers = setupWorkerHandlers;
 
 // ─── Fork adopt worker ──────────────────────────────────────────────────────
 

--- a/test/worker-ready-display-mode.test.ts
+++ b/test/worker-ready-display-mode.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Verifies that the `case 'ready'` handler in worker-pool.ts sends
+ * `set_display_mode` to the worker after POSTing a new streaming card.
+ *
+ * Regression test for: worker 重启走 POST 路径时未补发 set_display_mode，
+ * 导致截图循环静默失效。
+ *
+ * Scenarios:
+ *   1. POST path + displayMode='screenshot' → worker.send called
+ *   2. POST path + displayMode='hidden' → worker.send NOT called
+ *   3. PATCH path + displayMode='screenshot' → worker.send called (symmetry)
+ *
+ * Run:  pnpm vitest run test/worker-ready-display-mode.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────
+
+const updateMessageMock = vi.fn(async () => {});
+
+vi.mock('../src/im/lark/client.js', () => {
+  class MessageWithdrawnError extends Error {
+    constructor(id: string) { super(`withdrawn: ${id}`); this.name = 'MessageWithdrawnError'; }
+  }
+  return {
+    updateMessage: (...args: any[]) => updateMessageMock(...args),
+    deleteMessage: vi.fn(async () => {}),
+    MessageWithdrawnError,
+  };
+});
+
+vi.mock('../src/im/lark/card-builder.js', () => ({
+  buildStreamingCard: vi.fn(() => '{"type":"streaming"}'),
+  buildSessionCard: vi.fn(() => '{"type":"session"}'),
+  buildTuiPromptCard: vi.fn(() => '{}'),
+  buildTuiPromptResolvedCard: vi.fn(() => '{}'),
+  getCliDisplayName: vi.fn(() => 'Claude'),
+}));
+
+vi.mock('../src/bot-registry.js', () => ({
+  getBot: vi.fn(() => ({
+    config: { larkAppId: 'app_test', larkAppSecret: 'secret', cliId: 'claude-code' },
+    resolvedAllowedUsers: [],
+    botOpenId: 'ou_bot',
+    botName: 'TestBot',
+  })),
+  getAllBots: vi.fn(() => []),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    web: { externalHost: 'localhost' },
+    session: { dataDir: '/tmp/test-sessions' },
+    daemon: { backendType: 'tmux', cliId: 'claude-code' },
+  },
+}));
+
+vi.mock('../src/services/session-store.js', () => ({
+  closeSession: vi.fn(),
+  updateSession: vi.fn(),
+}));
+
+vi.mock('../src/services/frozen-card-store.js', () => ({
+  loadFrozenCards: vi.fn(() => new Map()),
+  saveFrozenCards: vi.fn(),
+}));
+
+vi.mock('../src/core/session-manager.js', () => ({
+  persistStreamCardState: vi.fn(),
+}));
+
+vi.mock('../src/core/dashboard-events.js', () => ({
+  dashboardEventBus: { publish: vi.fn() },
+}));
+
+vi.mock('../src/core/dashboard-rows.js', () => ({
+  composeRowFromActive: vi.fn(),
+}));
+
+vi.mock('../src/skills/installer.js', () => ({
+  ensureSkills: vi.fn(),
+}));
+
+vi.mock('../src/adapters/cli/registry.js', () => ({
+  createCliAdapterSync: vi.fn(),
+}));
+
+vi.mock('../src/adapters/cli/claude-code.js', () => ({
+  claudeJsonlPathForSession: vi.fn(),
+}));
+
+vi.mock('../src/adapters/backend/tmux-backend.js', () => ({
+  TmuxBackend: class {},
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@larksuiteoapi/node-sdk', () => ({
+  Client: class { constructor() {} },
+  WSClient: class { start() {} },
+  EventDispatcher: class { register() {} },
+  LoggerLevel: { info: 2 },
+}));
+
+// ─── Imports under test ────────────────────────────────────────────────────
+
+import { initWorkerPool, __testOnly_setupWorkerHandlers } from '../src/core/worker-pool.js';
+import type { DaemonSession } from '../src/core/types.js';
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function makeFakeWorker() {
+  const w = new EventEmitter() as any;
+  w.killed = false;
+  w.send = vi.fn();
+  w.kill = vi.fn();
+  w.pid = 12345;
+  w.stdout = new EventEmitter();
+  w.stderr = new EventEmitter();
+  return w;
+}
+
+function makeDs(overrides?: Partial<DaemonSession>): DaemonSession {
+  return {
+    session: {
+      sessionId: 'sid-ready-test',
+      rootMessageId: 'om_root',
+      chatId: 'oc_chat',
+      title: 'Test Session',
+      status: 'active' as any,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      pid: null,
+      chatType: 'group',
+    },
+    worker: makeFakeWorker(),
+    workerPort: null,
+    workerToken: null,
+    larkAppId: 'app_test',
+    chatId: 'oc_chat',
+    chatType: 'group',
+    spawnedAt: Date.now(),
+    cliVersion: '1.0',
+    lastMessageAt: Date.now(),
+    hasHistory: false,
+    displayMode: 'hidden',
+    streamCardNonce: undefined,
+    lastScreenContent: '',
+    lastScreenStatus: 'working',
+    currentTurnTitle: 'Test task',
+    ...overrides,
+  } as DaemonSession;
+}
+
+function flush(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('Worker ready: set_display_mode re-sync', () => {
+  let sessionReplyMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionReplyMock = vi.fn(async () => 'om_new_card');
+    initWorkerPool({
+      sessionReply: sessionReplyMock,
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+  });
+
+  it('POST path sends set_display_mode when displayMode is screenshot', async () => {
+    const fakeWorker = makeFakeWorker();
+    // streamCardPending = true forces POST path (no existing card to PATCH)
+    const ds = makeDs({
+      displayMode: 'screenshot',
+      streamCardPending: true,
+      streamCardId: undefined,
+      worker: fakeWorker,
+    });
+
+    __testOnly_setupWorkerHandlers(ds, fakeWorker);
+    fakeWorker.emit('message', { type: 'ready', port: 9999, token: 'tok_abc' });
+    await flush();
+
+    // sessionReply should have been called (POST new card)
+    expect(sessionReplyMock).toHaveBeenCalledTimes(1);
+    // worker.send should be called with set_display_mode
+    expect(fakeWorker.send).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'set_display_mode', mode: 'screenshot' }),
+    );
+  });
+
+  it('POST path does NOT send set_display_mode when displayMode is hidden', async () => {
+    const fakeWorker = makeFakeWorker();
+    const ds = makeDs({
+      displayMode: 'hidden',
+      streamCardPending: true,
+      streamCardId: undefined,
+      worker: fakeWorker,
+    });
+
+    __testOnly_setupWorkerHandlers(ds, fakeWorker);
+    fakeWorker.emit('message', { type: 'ready', port: 9999, token: 'tok_abc' });
+    await flush();
+
+    expect(sessionReplyMock).toHaveBeenCalledTimes(1);
+    // worker.send should NOT be called with set_display_mode
+    const sendCalls = fakeWorker.send.mock.calls;
+    const displayModeCalls = sendCalls.filter(
+      (args: any[]) => args[0]?.type === 'set_display_mode',
+    );
+    expect(displayModeCalls).toHaveLength(0);
+  });
+
+  it('PATCH path sends set_display_mode when displayMode is screenshot', async () => {
+    const fakeWorker = makeFakeWorker();
+    // Existing card + streamCardPending=false → PATCH path
+    const ds = makeDs({
+      displayMode: 'screenshot',
+      streamCardPending: false,
+      streamCardId: 'om_existing_card',
+      worker: fakeWorker,
+    });
+
+    updateMessageMock.mockResolvedValueOnce(undefined);
+
+    __testOnly_setupWorkerHandlers(ds, fakeWorker);
+    fakeWorker.emit('message', { type: 'ready', port: 9999, token: 'tok_abc' });
+    await flush();
+
+    // updateMessage should have been called (PATCH existing card)
+    expect(updateMessageMock).toHaveBeenCalledTimes(1);
+    // sessionReply should NOT be called (didn't fall through to POST)
+    expect(sessionReplyMock).not.toHaveBeenCalled();
+    // worker.send should be called with set_display_mode
+    expect(fakeWorker.send).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'set_display_mode', mode: 'screenshot' }),
+    );
+  });
+});


### PR DESCRIPTION
### 背景

botmux 的截图循环由 worker 中的 `captureAndUpload()` 驱动，只有在 `displayMode === 'screenshot'` 时才拍照上传。daemon 在卡片就绪时通过 IPC 发送 `set_display_mode` 消息激活 worker 的截图循环。

### 问题

当 worker 崩溃/重启后，daemon 通过 `streamCardPending` 决定走 PATCH（复用旧卡片）还是 POST（新建卡片）两条路径恢复流式卡片。

- **PATCH 路径**（`worker-pool.ts` ~L614）：已正确在卡片恢复后向新 worker 发送 `set_display_mode`。
- **POST 路径**（`worker-pool.ts` ~L653）：**遗漏了这一步**。

后果：如果旧卡片 PATCH 失败（如消息被撤回）导致 fallback 到 POST 创建新卡片，新 worker 的 `displayMode` 一直停留在 `'hidden'`，截图循环静默失效，飞书端和网页端截图不再更新。

### 修改

在 POST 路径成功创建新卡片后，补发 `set_display_mode` 给 worker（与 PATCH 路径对齐）：

```typescript
// Re-sync worker's display mode (it starts fresh in 'hidden')
if (ds.worker && ds.displayMode && ds.displayMode !== 'hidden') {
  ds.worker.send({ type: 'set_display_mode', mode: ds.displayMode } as DaemonToWorker);
}
```

同时导出 `__testOnly_setupWorkerHandlers` 供单测直接触发 `case 'ready'` 处理逻辑。

### 验证

```bash
pnpm vitest run test/worker-ready-display-mode.test.ts
# → Test Files  1 passed
#    Tests      3 passed
```

| # | 场景 | 断言 |
|---|------|------|
| 1 | POST 路径 + `displayMode='screenshot'` | `worker.send` 被调用，参数含 `{ type: 'set_display_mode', mode: 'screenshot' }` |
| 2 | POST 路径 + `displayMode='hidden'` | `worker.send` 不被调用 |
| 3 | PATCH 路径 + `displayMode='screenshot'` | `worker.send` 被调用（对称性回归保护） |

注释掉修复代码后用例 1 失败（`worker.send` 调用次数为 0），证明测试有效覆盖该路径。