### PR TITLE
feat(workflows): loop v0.2 — code-review-style iteration with decision gate

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -924,13 +924,20 @@ async function resolveDashboardWait(
   }
 
   try {
-    const resolved = await resolveWait(entry.ctx.log, {
-      activityId: target.activityId,
-      attemptId: target.attemptId,
-      resolution,
-      by: 'dashboard',
-      comment,
-    });
+    const resolved = await resolveWait(
+      entry.ctx.log,
+      {
+        activityId: target.activityId,
+        attemptId: target.attemptId,
+        resolution,
+        by: 'dashboard',
+        comment,
+      },
+      // v0.2: pass def so resolveWait can write activitySucceeded for
+      // `decision` node reject instead of activityFailed.  entry.ctx.def
+      // is the live, in-memory snapshot already loaded for this run.
+      { def: entry.ctx.def },
+    );
     const after = replay(await entry.ctx.log.readAll());
     // Fire-and-forget re-drive — same pattern as Lark card path
     // (workflowApprovalResolved hook).  Don't await; the dashboard caller

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -222,6 +222,12 @@ const server = createServer(async (req, res) => {
       presentedToken,
       activeToken: activeToken ?? '',
     });
+    // `authed` is consumed by route handlers that need to distinguish
+    // "request got in via public-read carve-out" from "request has a
+    // valid cookie" — e.g. `/api/workflows/runs/<id>/snapshot` strips
+    // log bytes when unauth'd.  Mirror of the `authed` check in
+    // `decideDashboardAuth`.
+    const authed = !!presentedToken && presentedToken === activeToken && !!activeToken;
 
     if (decision.kind === 'deny401') {
       res.writeHead(401, { 'content-type': 'text/html; charset=utf-8' });
@@ -299,7 +305,7 @@ const server = createServer(async (req, res) => {
     if (await handleWorkflowApi(req, res, url, {
       runsDir: getRunsDir(),
       proxyToDaemon,
-    })) {
+    }, authed)) {
       return;
     }
 

--- a/src/dashboard/auth.ts
+++ b/src/dashboard/auth.ts
@@ -85,7 +85,12 @@ export function buildSetCookie(token: string): string {
  *
  * Public surfaces today (codex review v0.1.2 → canary.3):
  *   - `GET /` and `GET /assets/*`              — static SPA shell
- *   - `GET /api/workflows/*`                   — workflow read-only API
+ *   - `GET /api/workflows/*`                   — workflow read-only API,
+ *                                                EXCEPT `…/terminal-log/raw`
+ *                                                which serves full PTY byte
+ *                                                streams (may include keys,
+ *                                                env, tokens) and requires
+ *                                                cookie auth.
  *
  * Anything else (sessions, schedules, dashboard rotate, POST /api/workflows
  * /…/cancel, etc.) requires the active session token, matching the
@@ -108,8 +113,16 @@ export function decideDashboardAuth(opts: {
   // Workflow read-only paths + static SPA shell are public — the dashboard
   // must be linkable from Lark cards without forcing a `botmux dashboard`
   // round-trip.  Write actions still need a cookie / token.
+  //
+  // Carve-out: `…/terminal-log/raw` streams full PTY bytes (`?stream=pty`) or
+  // worker diagnostic log (`?stream=diag`).  PTY transcript can leak API
+  // keys / env vars / token reads that happened to scroll the terminal, so
+  // we keep both stream variants behind cookie auth even though the rest of
+  // the read-only API is link-shareable.
   const isWorkflowReadOnly =
-    method === 'GET' && pathname.startsWith('/api/workflows/');
+    method === 'GET' &&
+    pathname.startsWith('/api/workflows/') &&
+    !pathname.endsWith('/terminal-log/raw');
   const isStaticShell =
     method === 'GET' && (pathname === '/' || pathname.startsWith('/assets/'));
 

--- a/src/dashboard/workflow-api.ts
+++ b/src/dashboard/workflow-api.ts
@@ -233,7 +233,11 @@ export async function handleWorkflowApi(
   }
 
   // ─── Attempt raw terminal.log ──────────────────────────────────────────────
-  // Public-read (under decideDashboardAuth's `GET /api/workflows/*` allowlist).
+  // Cookie-auth only (carved OUT of `decideDashboardAuth`'s
+  // `GET /api/workflows/*` public-read allowlist by `b5d23a6` — raw PTY +
+  // diagnostic streams can leak API keys / env / tokens; `/snapshot`'s
+  // log preview is scrubbed under the same posture via
+  // `scrubSnapshotForUnauthed`).
   // Streams `runs/<runId>/attempts/<activityId>/<attemptId>/terminal.log` for
   // the dashboard replay viewer.  Default behavior tails the last 10 MB; pass
   // `?tailBytes=N` to widen the window (capped at MAX_TAIL_BYTES) or

--- a/src/dashboard/workflow-api.ts
+++ b/src/dashboard/workflow-api.ts
@@ -17,6 +17,7 @@ import {
   isPathInsideDir,
   attemptTerminalLogPath,
   attemptPtyLogPath,
+  scrubSnapshotForUnauthed,
   TERMINAL_RUN_STATUSES,
 } from '../workflows/ops-projection.js';
 
@@ -64,12 +65,20 @@ function parseChatBinding(
  * Kept separate from `dashboard.ts` so route behavior can be exercised with a
  * small HTTP smoke test without starting the top-level dashboard process,
  * daemon registry, or SSE fanout.
+ *
+ * `authed` reflects whether the request presented a valid cookie/token; the
+ * caller (`dashboard.ts`) computes this from `decideDashboardAuth` and
+ * passes it through.  Public-read endpoints (`GET /snapshot`) use it to
+ * scrub log bytes from the response when the reader is unauthenticated —
+ * see `scrubSnapshotForUnauthed`.  Defaults to `false` so test callers
+ * that omit the flag get the secure-by-default behavior.
  */
 export async function handleWorkflowApi(
   req: IncomingMessage,
   res: ServerResponse,
   url: URL,
   deps: WorkflowApiDeps,
+  authed: boolean = false,
 ): Promise<boolean> {
   let m: RegExpMatchArray | null;
 
@@ -195,7 +204,11 @@ export async function handleWorkflowApi(
     const runId = decodeURIComponent(m[1]);
     const snap = await readRunSnapshot(deps.runsDir, runId);
     if (!snap) jsonRes(res, 404, { error: 'unknown_run' });
-    else jsonRes(res, 200, snap);
+    // Public-read endpoint — but `io.log.text` carries the last 64 KiB of
+    // `terminal.log` (subagent worker stdout/stderr), which can contain
+    // env-var dumps, API key error responses, etc.  Strip when unauth'd;
+    // a logged-in dashboard still gets the full view.
+    else jsonRes(res, 200, authed ? snap : scrubSnapshotForUnauthed(snap));
     return true;
   }
 

--- a/src/im/lark/workflow-card-handler.ts
+++ b/src/im/lark/workflow-card-handler.ts
@@ -5,10 +5,13 @@ import { replay } from '../../workflows/events/replay.js';
 import type { WorkflowEvent } from '../../workflows/events/schema.js';
 import type { WaitCreatedEvent } from '../../workflows/events/types.js';
 import { getRunsDir } from '../../workflows/runs-dir.js';
+import { readWorkflowDefinitionFromRunDir } from '../../workflows/loader.js';
+import { join } from 'node:path';
 import {
   resolveWait,
   type ResolveWaitInput,
   type ResolveWaitResult,
+  type ResolveWaitContext,
 } from '../../workflows/wait.js';
 import {
   requestCancel,
@@ -38,7 +41,11 @@ export type WorkflowCardActionData = {
 export type WorkflowApprovalHandlerDeps = {
   runsDir?: string;
   makeEventLog?: (runId: string, runsDir: string) => EventLog;
-  resolveWaitFn?: (log: EventLog, input: ResolveWaitInput) => Promise<ResolveWaitResult>;
+  resolveWaitFn?: (
+    log: EventLog,
+    input: ResolveWaitInput,
+    ctx?: ResolveWaitContext,
+  ) => Promise<ResolveWaitResult>;
   requestCancelFn?: (
     log: EventLog,
     input: RequestCancelInput,
@@ -123,13 +130,25 @@ export async function handleWorkflowApprovalAction(
           },
           'human',
         )
-      : await (deps.resolveWaitFn ?? resolveWait)(log, {
-          activityId,
-          attemptId,
-          resolution: action === WORKFLOW_APPROVE_ACTION ? 'approved' : 'rejected',
-          by,
-          comment,
-        });
+      : await (deps.resolveWaitFn ?? resolveWait)(
+          log,
+          {
+            activityId,
+            attemptId,
+            resolution: action === WORKFLOW_APPROVE_ACTION ? 'approved' : 'rejected',
+            by,
+            comment,
+          },
+          // v0.2: resolveWait inspects ctx.def to detect `decision` nodes
+          // so reject writes activitySucceeded instead of activityFailed.
+          // Loading the per-run workflow snapshot (not the catalog) keeps
+          // long-running cards bound to the definition the run was started
+          // with even if the catalog has since been edited.
+          await (async () => {
+            const def = await readWorkflowDefinitionFromRunDir(join(runsDir, runId));
+            return def ? { def } : undefined;
+          })(),
+        );
 
   const resolutionKind: WorkflowApprovalResolutionKind =
     action === WORKFLOW_APPROVE_ACTION

--- a/src/im/lark/workflow-progress-card.ts
+++ b/src/im/lark/workflow-progress-card.ts
@@ -115,6 +115,7 @@ export function buildWorkflowProgressCard(
   // contradicts the header status.
   const runningRows = isTerminal ? [] : collectRunningRows(snapshot);
   const waitingRows = isTerminal ? [] : collectWaitingRows(snapshot);
+  const loopRows = isTerminal ? [] : collectLoopRows(snapshot);
   const failureSummary = summarizeFailure(snapshot);
 
   const elements: Array<Record<string, unknown>> = [
@@ -146,6 +147,19 @@ export function buildWorkflowProgressCard(
       text: { tag: 'lark_md', content: `**⏸ 等待审批** (${waitingRows.length})` },
     });
     appendRows(elements, waitingRows, maxRows, opts);
+  }
+
+  // v0.2 loop iteration view (collapsible-style summary line per active
+  // loop block).  See /tmp/wf-loop-v02.md §9 — terminal status hides
+  // this section the same way `running` / `waiting` are hidden once
+  // the run reaches a terminal state.
+  if (loopRows.length > 0) {
+    elements.push({ tag: 'hr' });
+    elements.push({
+      tag: 'div',
+      text: { tag: 'lark_md', content: `**🔁 循环节点** (${loopRows.length})` },
+    });
+    appendLoopRows(elements, loopRows);
   }
 
   if (failureSummary) {
@@ -219,6 +233,56 @@ function collectWaitingRows(snap: Snapshot): AttemptRow[] {
     });
   }
   return rows;
+}
+
+type LoopRow = {
+  loopId: string;
+  iteration: number;
+  maxIterations: number;
+  iterStatus: 'running' | 'approved' | 'rejected' | 'failed' | 'cancelled';
+};
+
+/**
+ * One row per active loop block (status === 'running').  Settled loops
+ * (succeeded / failed / cancelled) are NOT included because the parent
+ * card hides this whole section once the run reaches a terminal status.
+ * Body-node in-flight activities still show up in the run-level
+ * `running` rows; the loop section is the "where are we in the
+ * iteration cycle" overlay.
+ */
+function collectLoopRows(snap: Snapshot): LoopRow[] {
+  if (!snap.loops || snap.loops.size === 0) return [];
+  const rows: LoopRow[] = [];
+  for (const loop of snap.loops.values()) {
+    if (loop.status !== 'running') continue;
+    // iteration === 0 means startLoop emitted but startLoopIteration
+    // hasn't yet — clamp to 1 so the user-facing "iteration N/M"
+    // doesn't show 0/M during that microsecond window.
+    const iter = Math.max(1, loop.iteration);
+    const currentIterState = loop.iterations[iter - 1];
+    rows.push({
+      loopId: loop.loopId,
+      iteration: iter,
+      maxIterations: loop.maxIterations,
+      iterStatus: currentIterState?.status ?? 'running',
+    });
+  }
+  return rows;
+}
+
+function appendLoopRows(
+  elements: Array<Record<string, unknown>>,
+  rows: LoopRow[],
+): void {
+  const lines: string[] = [];
+  for (const row of rows) {
+    const iterText = `iteration ${row.iteration}/${row.maxIterations}`;
+    lines.push(`• \`${escapeMd(row.loopId)}\` · ${iterText} (${row.iterStatus})`);
+  }
+  elements.push({
+    tag: 'div',
+    text: { tag: 'lark_md', content: lines.join('\n') },
+  });
 }
 
 function summarizeFailure(snap: Snapshot): string | undefined {

--- a/src/workflows/definition.ts
+++ b/src/workflows/definition.ts
@@ -165,9 +165,52 @@ export function isSideEffectExecutor(executor: string): boolean {
   return SIDE_EFFECT_EXECUTORS.has(executor);
 }
 
+// ─── Loop / Decision (v0.2 — see /tmp/wf-loop-v02.md §3.1) ────────────────
+//
+// `loop` is a control-flow node: it wraps a body sub-graph that re-runs
+// until a `decision` terminator approves (or maxIterations hits).
+// `decision` is a gate-only node: no work payload, just a humanGate whose
+// resolution drives the loop state machine.  Both types must be cross-
+// validated by `validateLoopBlocks` after schema parse (membership, no
+// nested loops, external deps surfaced on loop.depends, etc.).
+//
+// Strict object shape — additional keys are rejected at parse time so
+// that a workflow author who writes `outputSchema` / `prompt` / `bot` on
+// a decision node gets a fail-loud error instead of silently dropped
+// fields (codex round 2 N2: decision output contract is runtime-fixed).
+
+export const LoopOutputProjectionSchema = z.object({
+  from: z.string().min(1),
+}).strict();
+export type LoopOutputProjection = z.infer<typeof LoopOutputProjectionSchema>;
+
+export const LoopNodeSchema = z.object({
+  type: z.literal('loop'),
+  description: z.string().optional(),
+  depends: z.array(z.string()).optional(),
+  maxIterations: z.number().int().positive(),
+  body: z.array(z.string().min(1)).min(1),
+  terminate: z.object({
+    node: z.string().min(1),
+    via: z.literal('humanGate'),
+  }).strict(),
+  output: LoopOutputProjectionSchema.optional(),
+}).strict();
+export type LoopNode = z.infer<typeof LoopNodeSchema>;
+
+export const DecisionNodeSchema = z.object({
+  type: z.literal('decision'),
+  description: z.string().optional(),
+  depends: z.array(z.string()).optional(),
+  humanGate: HumanGateSchema,
+}).strict();
+export type DecisionNode = z.infer<typeof DecisionNodeSchema>;
+
 export const WorkflowNodeSchema = z.discriminatedUnion('type', [
   SubagentNodeSchema,
   HostExecutorNodeSchema,
+  LoopNodeSchema,
+  DecisionNodeSchema,
 ]);
 export type WorkflowNode = z.infer<typeof WorkflowNodeSchema>;
 
@@ -252,7 +295,10 @@ export function computeRevisionId(def: WorkflowDefinition): string {
  * Schema parse + cross-field invariants:
  *   1. every `depends` entry references an existing node
  *   2. graph is acyclic
- *   3. at least one root node (no deps)
+ *   3. at least one root node (no deps) among scheduler-visible nodes
+ *      (loop body nodes are excluded from this check — they're scheduled
+ *      by their owning loop block, not the top-level orchestrator)
+ *   4. loop / decision cross-field invariants (see `validateLoopBlocks`)
  *
  * Throws on any failure.  Use `WorkflowDefinitionSchema.safeParse(...)`
  * directly if you only need shape checks (no graph validation).
@@ -307,10 +353,169 @@ function validateGraph(def: WorkflowDefinition): void {
     }
   }
   detectCycle(def);
-  const hasRoot = ids.some((id) => (def.nodes[id]!.depends ?? []).length === 0);
+
+  // Loop / decision cross-field validation runs before the root check so
+  // we can compute the body-node set used to scope "scheduler-visible
+  // roots".
+  const bodyNodeIds = validateLoopBlocks(def);
+
+  // Root check: at least one scheduler-visible node has no deps.  Loop
+  // body nodes are by construction scheduled by their owning loop, so
+  // their "no-deps" status is internal to the loop and must not count
+  // toward workflow-level reachability.
+  const hasRoot = ids.some(
+    (id) => !bodyNodeIds.has(id) && (def.nodes[id]!.depends ?? []).length === 0,
+  );
   if (!hasRoot) {
-    throw new Error('Workflow has no root node (every node has dependencies)');
+    throw new Error(
+      'Workflow has no scheduler-visible root node (every non-loop-body node has dependencies)',
+    );
   }
+}
+
+/**
+ * Loop / decision cross-field validation (v0.2; see /tmp/wf-loop-v02.md §3.4).
+ *
+ * Returns the set of node ids that belong to some loop's body, so the
+ * caller (`validateGraph`) can scope the root-existence check to
+ * scheduler-visible nodes only.
+ *
+ * Throws on any rule violation.  Error messages always include the
+ * offending loopId + nodeId so workflow-create skills and authors can
+ * self-correct without re-reading the spec.
+ */
+export function validateLoopBlocks(def: WorkflowDefinition): Set<string> {
+  const allLoopBodyIds = new Set<string>();
+  // Track which loop owns each body node so we can detect cross-loop
+  // body-membership collisions in one pass.
+  const bodyOwner = new Map<string, string>();
+  // Collect loop blocks up front so cross-block invariants (decision
+  // node membership, external deps surfaced on loop.depends, etc.) can
+  // be checked with full context.
+  const loopBlocks: Array<{ loopId: string; node: LoopNode }> = [];
+
+  for (const [nodeId, node] of Object.entries(def.nodes)) {
+    if (node.type !== 'loop') continue;
+    loopBlocks.push({ loopId: nodeId, node });
+    for (const bodyId of node.body) {
+      // Body id must exist as a top-level node.
+      if (!def.nodes[bodyId]) {
+        throw new Error(
+          `Loop '${nodeId}' body references unknown node '${bodyId}'`,
+        );
+      }
+      // A body node cannot be the loop block itself.
+      if (bodyId === nodeId) {
+        throw new Error(
+          `Loop '${nodeId}' body must not include the loop block itself`,
+        );
+      }
+      // A node can belong to at most one loop body — collisions break
+      // iteration / activityId scoping.
+      const prev = bodyOwner.get(bodyId);
+      if (prev && prev !== nodeId) {
+        throw new Error(
+          `Loop body node '${bodyId}' is claimed by both '${prev}' and '${nodeId}'; ` +
+          `a node can belong to at most one loop body`,
+        );
+      }
+      bodyOwner.set(bodyId, nodeId);
+      allLoopBodyIds.add(bodyId);
+
+      // v0.2 rejects nested loops — a body node may not itself be a
+      // loop.  Removing this restriction in a future version requires
+      // re-checking activityId composition + replay determinism.
+      if (def.nodes[bodyId]!.type === 'loop') {
+        throw new Error(
+          `Loop '${nodeId}' body contains nested loop '${bodyId}'; nested loops are not supported in v0.2`,
+        );
+      }
+    }
+    // terminate.node must be in this loop's body and must be a decision.
+    const termId = node.terminate.node;
+    if (!node.body.includes(termId)) {
+      throw new Error(
+        `Loop '${nodeId}' terminate.node '${termId}' is not in body [${node.body.join(', ')}]`,
+      );
+    }
+    const termNode = def.nodes[termId];
+    if (!termNode || termNode.type !== 'decision') {
+      throw new Error(
+        `Loop '${nodeId}' terminate.node '${termId}' must be a decision node (got '${termNode?.type ?? 'undefined'}')`,
+      );
+    }
+    // output.from (if declared) must be a body node and not the terminator.
+    if (node.output) {
+      if (!node.body.includes(node.output.from)) {
+        throw new Error(
+          `Loop '${nodeId}' output.from '${node.output.from}' is not in body [${node.body.join(', ')}]`,
+        );
+      }
+      if (node.output.from === termId) {
+        throw new Error(
+          `Loop '${nodeId}' output.from '${node.output.from}' must not be the terminate.node ` +
+          `(terminator has no work output; pick a body node that produces real output)`,
+        );
+      }
+    }
+  }
+
+  // Decision nodes must belong to some loop body (v0.2: no standalone
+  // decision use case exists yet; relaxing this needs a separate
+  // dispatch model).
+  for (const [nodeId, node] of Object.entries(def.nodes)) {
+    if (node.type !== 'decision') continue;
+    if (!allLoopBodyIds.has(nodeId)) {
+      throw new Error(
+        `Decision node '${nodeId}' is not referenced by any loop's body; ` +
+        `decision nodes are only valid inside a loop terminate.node slot in v0.2`,
+      );
+    }
+  }
+
+  // External dependency rule (codex round 2 N1): if a body node depends
+  // on a node outside the loop body, the loop block itself must list
+  // that external dep in its own `depends`.  We refuse to silently
+  // promote — the workflow JSON should make every cross-loop edge
+  // visible.
+  //
+  // Outside-the-body deps include any node not in *this* loop's body
+  // (siblings, top-level subagent/hostExecutor, other loops).
+  for (const { loopId, node: loopNode } of loopBlocks) {
+    const bodySet = new Set(loopNode.body);
+    const loopDeps = new Set(loopNode.depends ?? []);
+    for (const bodyId of loopNode.body) {
+      const bodyNode = def.nodes[bodyId]!;
+      for (const dep of bodyNode.depends ?? []) {
+        if (bodySet.has(dep)) continue; // internal dep — fine
+        if (!loopDeps.has(dep)) {
+          throw new Error(
+            `Loop '${loopId}' body node '${bodyId}' depends on external node '${dep}', ` +
+            `but loop '${loopId}' does not list '${dep}' in its own depends — ` +
+            `add '${dep}' to loop.depends explicitly so the loop block waits for it`,
+          );
+        }
+      }
+    }
+  }
+
+  // No external node may depend on a loop body node — outsiders are
+  // only allowed to depend on the loop block itself.  This keeps the
+  // top-level scheduler unaware of body nodes.
+  for (const [nodeId, node] of Object.entries(def.nodes)) {
+    if (allLoopBodyIds.has(nodeId)) continue; // external = non-body
+    for (const dep of node.depends ?? []) {
+      if (allLoopBodyIds.has(dep)) {
+        throw new Error(
+          `Node '${nodeId}' depends on loop body node '${dep}'; ` +
+          `external dependents must depend on the loop block, not its body — ` +
+          `use the loop block id (and optionally declare output.from on the loop) instead`,
+        );
+      }
+    }
+  }
+
+  return allLoopBodyIds;
 }
 
 function detectCycle(def: WorkflowDefinition): void {

--- a/src/workflows/definition.ts
+++ b/src/workflows/definition.ts
@@ -444,6 +444,32 @@ export function validateLoopBlocks(def: WorkflowDefinition): Set<string> {
         `Loop '${nodeId}' terminate.node '${termId}' must be a decision node (got '${termNode?.type ?? 'undefined'}')`,
       );
     }
+    // Each loop body must contain exactly one decision node, and (by
+    // construction since terminate.node is verified to be a decision in
+    // the body above) it must equal terminate.node.
+    //
+    // Why: `wait.ts` decision-mode treats *any* decision-typed node's
+    // reject as a structured `activitySucceeded { resolution: 'rejected' }`
+    // blob, regardless of terminator status (the dispatcher has no
+    // terminator-vs-non-terminator distinction at resolve time).  So if
+    // a body has two decisions, the non-terminator one's reject would
+    // silently "succeed" and the body would continue past a rejection
+    // the author intended to terminate the loop.  Force authors to use
+    // a regular `subagent + humanGate` for intermediate approvals — only
+    // the terminator slot is allowed to be a decision.
+    const decisionsInBody = node.body.filter(
+      (id) => def.nodes[id]?.type === 'decision',
+    );
+    if (decisionsInBody.length !== 1) {
+      throw new Error(
+        `Loop '${nodeId}' body must contain exactly one decision node ` +
+        `(got ${decisionsInBody.length}: [${decisionsInBody.join(', ')}]) — ` +
+        `decision nodes are the loop terminator slot; a non-terminator ` +
+        `decision's reject would be silently treated as success by ` +
+        `wait.ts decision-mode, letting the body continue past the rejection. ` +
+        `Use a regular subagent + humanGate for intermediate approvals.`,
+      );
+    }
     // output.from (if declared) must be a body node and not the terminator.
     if (node.output) {
       if (!node.body.includes(node.output.from)) {

--- a/src/workflows/definition.ts
+++ b/src/workflows/definition.ts
@@ -515,6 +515,52 @@ export function validateLoopBlocks(def: WorkflowDefinition): Set<string> {
     }
   }
 
+  // Sink-loop rule (codex PR #47 round-2 finding #1): a loop block that is
+  // a workflow sink (no external dependents) must declare `output.from`.
+  // orchestrator.ts only emits `completeRunSucceeded` when the sink activity
+  // has an output blob; a loop block without `output.from` never writes
+  // `outputs[sinkActivityId]` from `loopFinished`, so the run hangs in
+  // `no-progress` after approval.  Force the author to choose at parse time.
+  const externalDependents = new Map<string, Set<string>>();
+  for (const { loopId } of loopBlocks) externalDependents.set(loopId, new Set());
+  for (const [nodeId, node] of Object.entries(def.nodes)) {
+    if (allLoopBodyIds.has(nodeId)) continue;
+    for (const dep of node.depends ?? []) {
+      const deps = externalDependents.get(dep);
+      if (deps) deps.add(nodeId);
+    }
+  }
+  for (const { loopId, node: loopNode } of loopBlocks) {
+    if (loopNode.output) continue;
+    if ((externalDependents.get(loopId) ?? new Set()).size > 0) continue;
+    throw new Error(
+      `Loop '${loopId}' has no external dependents (workflow sink) but does not declare 'output.from' — ` +
+      `without output.from the loopFinished projection writes no sink output and the run cannot complete (no-progress). ` +
+      `Add output.from pointing to a body node, e.g. \`"output": { "from": "${loopNode.body[0]}" }\`.`,
+    );
+  }
+
+  // Decision-timeout rule (codex PR #47 round-2 finding #2): decision nodes
+  // must use `humanGate.onTimeout = 'fail'` (or leave it unset; default is
+  // fail).  `onTimeout='success'` is legal at the schema level but
+  // `expireWait` writes the succeeded blob as `{ defaultedToTimeout,
+  // deadlineAt }` without `resolution`/`by`/`comment`, so the next
+  // iteration's `${decisionNode.previous.comment}` bindings hit
+  // BindingError.  Statically rule this out at validate time — if the
+  // author truly wants "timeout = approve" semantics they can implement
+  // it via a wrapper subagent that produces the structured resolution.
+  for (const [nodeId, node] of Object.entries(def.nodes)) {
+    if (node.type !== 'decision') continue;
+    if (node.humanGate?.onTimeout === 'success') {
+      throw new Error(
+        `Decision node '${nodeId}' humanGate.onTimeout='success' is not allowed — ` +
+        `the timeout fallback would write a succeeded blob missing {resolution, by, comment}, ` +
+        `breaking the next iteration's \${${nodeId}.previous.*} bindings. ` +
+        `Use onTimeout='fail' (default) so timeout closes the loop via loopFinished(timeout).`,
+      );
+    }
+  }
+
   return allLoopBodyIds;
 }
 

--- a/src/workflows/events/payloads.ts
+++ b/src/workflows/events/payloads.ts
@@ -44,6 +44,7 @@ export const ErrorCodeEnum = z.enum([
   //    found).  Always manual class.
   'InputUnrecoverable',
   'CorruptLog',
+  'LoopMaxIterationsExceeded',
 ]);
 export type ErrorCode = z.infer<typeof ErrorCodeEnum>;
 
@@ -179,6 +180,39 @@ export const ActivityTimedOutPayload = z.object({
   runningMs: z.number().int().nonnegative(),
   reason: z.literal('LeaseExpired'),
   errorClass: z.literal('retryable'),
+});
+
+// ─── Group 1b — Loop lifecycle (4) ─────────────────────────────────────────
+
+export const LoopStartedPayload = z.object({
+  loopId: z.string(),
+  maxIterations: z.number().int().positive(),
+});
+
+export const LoopIterationStartedPayload = z.object({
+  loopId: z.string(),
+  iteration: z.number().int().positive(),
+  prevResolution: z.enum(['initial', 'rejected']),
+});
+
+export const LoopIterationFinishedPayload = z.object({
+  loopId: z.string(),
+  iteration: z.number().int().positive(),
+  resolution: z.enum(['approved', 'rejected']),
+  decisionActivityId: z.string(),
+  waitResolvedEventId: z.string(),
+  by: z.string(),
+  comment: z.string().optional(),
+  timedOut: z.boolean().optional(),
+});
+
+export const LoopFinishedPayload = z.object({
+  loopId: z.string(),
+  finalIteration: z.number().int().positive(),
+  resolution: z.enum(['approved', 'max-iterations-exceeded', 'cancelled', 'timeout']),
+  outputRef: OutputRefSchema.optional(),
+  errorCode: ErrorCodeEnum.optional(),
+  errorClass: ErrorClassEnum.optional(),
 });
 
 // ─── Group 2 — Scheduling (5) ───────────────────────────────────────────────

--- a/src/workflows/events/payloads.ts
+++ b/src/workflows/events/payloads.ts
@@ -45,6 +45,11 @@ export const ErrorCodeEnum = z.enum([
   'InputUnrecoverable',
   'CorruptLog',
   'LoopMaxIterationsExceeded',
+  // Non-terminator failure inside a loop body (subagent crash /
+  // hostExecutor error / non-terminator humanGate reject = fail-run).
+  // Carried on `loopFinished` when resolution='body-failed'.  Loop v0.2
+  // Step 3 review Medium — see /tmp/wf-loop-v02.md §10.8.
+  'LoopBodyFailed',
 ]);
 export type ErrorCode = z.infer<typeof ErrorCodeEnum>;
 
@@ -209,7 +214,19 @@ export const LoopIterationFinishedPayload = z.object({
 export const LoopFinishedPayload = z.object({
   loopId: z.string(),
   finalIteration: z.number().int().positive(),
-  resolution: z.enum(['approved', 'max-iterations-exceeded', 'cancelled', 'timeout']),
+  // - approved: terminator decision approved (success)
+  // - max-iterations-exceeded: ran out of iterations on rejection
+  // - body-failed: non-terminator body node failed (subagent crash /
+  //   hostExecutor error / non-terminator humanGate reject = fail-run)
+  // - cancelled: user-initiated cancel reached the loop
+  // - timeout: terminator humanGate deadline expired
+  resolution: z.enum([
+    'approved',
+    'max-iterations-exceeded',
+    'body-failed',
+    'cancelled',
+    'timeout',
+  ]),
   outputRef: OutputRefSchema.optional(),
   errorCode: ErrorCodeEnum.optional(),
   errorClass: ErrorClassEnum.optional(),

--- a/src/workflows/events/replay.ts
+++ b/src/workflows/events/replay.ts
@@ -13,6 +13,10 @@ import type {
   ConditionEvaluatedEvent,
   EffectAttemptedEvent,
   LeaseSignedEvent,
+  LoopFinishedEvent,
+  LoopIterationFinishedEvent,
+  LoopIterationStartedEvent,
+  LoopStartedEvent,
   NodeCanceledEvent,
   NodeFailedEvent,
   NodeRetryingEvent,
@@ -33,6 +37,7 @@ import type {
 } from './types.js';
 import type { WorkflowEvent } from './schema.js';
 import type { ErrorClass, ErrorPayload, OutputRef } from './payloads.js';
+import { workActivityId } from '../orchestrator.js';
 
 // ─── State shapes ───────────────────────────────────────────────────────────
 
@@ -221,10 +226,33 @@ export type RunState = {
   >;
 };
 
+export type LoopIterationState = {
+  iteration: number;
+  status: 'running' | 'approved' | 'rejected' | 'failed' | 'cancelled';
+  bodyActivityIds: string[];
+  decisionActivityId?: string;
+  waitResolvedEventId?: string;
+  decisionBy?: string;
+  decisionComment?: string;
+  timedOut?: boolean;
+};
+
+export type LoopState = {
+  loopId: string;
+  status: 'running' | 'succeeded' | 'failed' | 'cancelled';
+  iteration: number;
+  maxIterations: number;
+  iterations: LoopIterationState[];
+  output?: OutputRef;
+  errorCode?: string;
+  errorClass?: ErrorClass;
+};
+
 export type Snapshot = {
   run: RunState;
   nodes: Map<string, NodeState>;
   activities: Map<string, ActivityState>;
+  loops: Map<string, LoopState>;
   /** Convenience: terminal outputs by activityId (succeeded events only). */
   outputs: Map<string, OutputRef>;
   /** Last seq seen.  0 if the log is empty. */
@@ -328,6 +356,7 @@ export function replay(events: WorkflowEvent[]): Snapshot {
   const run: RunState = { runId, status: 'pending' };
   const nodes = new Map<string, NodeState>();
   const activities = new Map<string, ActivityState>();
+  const loops = new Map<string, LoopState>();
   const outputs = new Map<string, OutputRef>();
   // Wait tracking: activityId -> resolved (true if waitResolved/Deadline seen)
   const waitsOpen = new Set<string>();
@@ -362,6 +391,31 @@ export function replay(events: WorkflowEvent[]): Snapshot {
 
   function currentAttempt(a: ActivityState): AttemptState | undefined {
     return a.attempts.find((at) => at.attemptId === a.currentAttemptId);
+  }
+
+  function getLoop(loopId: string): LoopState {
+    let loop = loops.get(loopId);
+    if (!loop) {
+      loop = {
+        loopId,
+        status: 'running',
+        iteration: 0,
+        maxIterations: 0,
+        iterations: [],
+      };
+      loops.set(loopId, loop);
+    }
+    return loop;
+  }
+
+  function getLoopIteration(loop: LoopState, iteration: number): LoopIterationState {
+    let it = loop.iterations.find((candidate) => candidate.iteration === iteration);
+    if (!it) {
+      it = { iteration, status: 'running', bodyActivityIds: [] };
+      loop.iterations.push(it);
+      loop.iterations.sort((a, b) => a.iteration - b.iteration);
+    }
+    return it;
   }
 
   for (const e of events) {
@@ -468,6 +522,63 @@ export function replay(events: WorkflowEvent[]): Snapshot {
         break;
       }
 
+      // ─── Loop lifecycle ─────────────────────────────────────────────
+      case 'loopStarted': {
+        const p = (e as LoopStartedEvent).payload as LoopStartedEvent['payload'];
+        if (!('ref' in p)) {
+          const loop = getLoop(p.loopId);
+          loop.status = 'running';
+          loop.maxIterations = p.maxIterations;
+        }
+        break;
+      }
+      case 'loopIterationStarted': {
+        const p = (e as LoopIterationStartedEvent).payload as LoopIterationStartedEvent['payload'];
+        if (!('ref' in p)) {
+          const loop = getLoop(p.loopId);
+          loop.status = 'running';
+          loop.iteration = p.iteration;
+          const it = getLoopIteration(loop, p.iteration);
+          it.status = 'running';
+        }
+        break;
+      }
+      case 'loopIterationFinished': {
+        const p = (e as LoopIterationFinishedEvent).payload as LoopIterationFinishedEvent['payload'];
+        if (!('ref' in p)) {
+          const loop = getLoop(p.loopId);
+          loop.iteration = Math.max(loop.iteration, p.iteration);
+          const it = getLoopIteration(loop, p.iteration);
+          it.status = p.resolution;
+          it.decisionActivityId = p.decisionActivityId;
+          it.waitResolvedEventId = p.waitResolvedEventId;
+          it.decisionBy = p.by;
+          it.decisionComment = p.comment;
+          it.timedOut = p.timedOut;
+        }
+        break;
+      }
+      case 'loopFinished': {
+        const p = (e as LoopFinishedEvent).payload as LoopFinishedEvent['payload'];
+        if (!('ref' in p)) {
+          const loop = getLoop(p.loopId);
+          loop.iteration = p.finalIteration;
+          loop.status =
+            p.resolution === 'approved'
+              ? 'succeeded'
+              : p.resolution === 'cancelled'
+                ? 'cancelled'
+                : 'failed';
+          loop.output = p.outputRef;
+          loop.errorCode = p.errorCode;
+          loop.errorClass = p.errorClass;
+          if (p.outputRef) {
+            outputs.set(workActivityId(runId, p.loopId), p.outputRef);
+          }
+        }
+        break;
+      }
+
       // ─── Scheduling ─────────────────────────────────────────────────
       case 'conditionEvaluated': {
         const p = (e as ConditionEvaluatedEvent).payload as ConditionEvaluatedEvent['payload'];
@@ -492,6 +603,14 @@ export function replay(events: WorkflowEvent[]): Snapshot {
           });
           a.currentAttemptId = p.attemptId;
           a.status = 'pending';
+          for (const loop of loops.values()) {
+            const it = loop.iterations.find((candidate) => candidate.iteration === loop.iteration);
+            if (!it) continue;
+            if (!p.activityId.includes(`::loop::${loop.loopId}.${it.iteration}::`)) continue;
+            if (!it.bodyActivityIds.includes(p.activityId)) {
+              it.bodyActivityIds.push(p.activityId);
+            }
+          }
           // Codex round 4 fix: capture activity→node ownership so we can
           // project node.status on later activity-level events.
           a.ownerNodeId = p.nodeId;
@@ -914,6 +1033,7 @@ export function replay(events: WorkflowEvent[]): Snapshot {
     run,
     nodes,
     activities,
+    loops,
     outputs,
     lastSeq,
     danglingActivities,

--- a/src/workflows/events/replay.ts
+++ b/src/workflows/events/replay.ts
@@ -568,12 +568,23 @@ export function replay(events: WorkflowEvent[]): Snapshot {
               ? 'succeeded'
               : p.resolution === 'cancelled'
                 ? 'cancelled'
-                : 'failed';
+                : 'failed'; // body-failed / timeout / max-iterations-exceeded
           loop.output = p.outputRef;
           loop.errorCode = p.errorCode;
           loop.errorClass = p.errorClass;
           if (p.outputRef) {
             outputs.set(workActivityId(runId, p.loopId), p.outputRef);
+          }
+          // Close any still-running iteration so the dashboard / ops
+          // surface doesn't display the loop as "failed but iteration
+          // X is somehow still running" (codex Step 3 review Medium —
+          // /tmp/wf-loop-v02.md §10.8 design compromise resolved).
+          if (loop.status !== 'succeeded') {
+            const inflight = loop.iterations.find((it) => it.status === 'running');
+            if (inflight) {
+              inflight.status =
+                p.resolution === 'cancelled' ? 'cancelled' : 'failed';
+            }
           }
         }
         break;

--- a/src/workflows/events/schema.ts
+++ b/src/workflows/events/schema.ts
@@ -318,6 +318,19 @@ export function checkLoopFinishedInvariant(event: WorkflowEvent): string | null 
       return "loopFinished: max-iterations-exceeded requires errorCode='LoopMaxIterationsExceeded' and errorClass='userFault'";
     }
   }
+  if (p.resolution === 'body-failed') {
+    if (p.errorCode !== 'LoopBodyFailed') {
+      return "loopFinished: body-failed requires errorCode='LoopBodyFailed'";
+    }
+    if (!p.errorClass) {
+      return "loopFinished: body-failed requires errorClass (derived from underlying body failure)";
+    }
+  }
+  if (p.resolution === 'timeout') {
+    if (p.errorCode !== 'WaitDeadlineExceeded' || p.errorClass !== 'userFault') {
+      return "loopFinished: timeout requires errorCode='WaitDeadlineExceeded' and errorClass='userFault'";
+    }
+  }
   return null;
 }
 

--- a/src/workflows/events/schema.ts
+++ b/src/workflows/events/schema.ts
@@ -17,6 +17,10 @@ import {
   ActivityRunningPayload,
   ActivityWaitingPayload,
   ActivityTimedOutPayload,
+  LoopStartedPayload,
+  LoopIterationStartedPayload,
+  LoopIterationFinishedPayload,
+  LoopFinishedPayload,
   ConditionEvaluatedPayload,
   LeaseSignedPayload,
   AttemptCreatedPayload,
@@ -111,6 +115,18 @@ export const ActivityRunningEventSchema = event('activityRunning', ActivityRunni
 export const ActivityWaitingEventSchema = event('activityWaiting', ActivityWaitingPayload);
 export const ActivityTimedOutEventSchema = event('activityTimedOut', ActivityTimedOutPayload);
 
+// Group 1b — Loop lifecycle (4)
+export const LoopStartedEventSchema = event('loopStarted', LoopStartedPayload);
+export const LoopIterationStartedEventSchema = event(
+  'loopIterationStarted',
+  LoopIterationStartedPayload,
+);
+export const LoopIterationFinishedEventSchema = event(
+  'loopIterationFinished',
+  LoopIterationFinishedPayload,
+);
+export const LoopFinishedEventSchema = event('loopFinished', LoopFinishedPayload);
+
 // Group 2 — Scheduling (5)
 export const ConditionEvaluatedEventSchema = event('conditionEvaluated', ConditionEvaluatedPayload);
 export const LeaseSignedEventSchema = event('leaseSigned', LeaseSignedPayload);
@@ -158,6 +174,10 @@ const EVENT_SCHEMAS = [
   ActivityRunningEventSchema,
   ActivityWaitingEventSchema,
   ActivityTimedOutEventSchema,
+  LoopStartedEventSchema,
+  LoopIterationStartedEventSchema,
+  LoopIterationFinishedEventSchema,
+  LoopFinishedEventSchema,
   ConditionEvaluatedEventSchema,
   LeaseSignedEventSchema,
   AttemptCreatedEventSchema,
@@ -285,6 +305,22 @@ export function checkWaitCreatedPromptInvariant(event: WorkflowEvent): string | 
   return null;
 }
 
+export function checkLoopFinishedInvariant(event: WorkflowEvent): string | null {
+  if (event.type !== 'loopFinished') return null;
+  if (isPayloadRef(event.payload)) return null;
+  const p = event.payload as {
+    resolution: string;
+    errorCode?: string;
+    errorClass?: string;
+  };
+  if (p.resolution === 'max-iterations-exceeded') {
+    if (p.errorCode !== 'LoopMaxIterationsExceeded' || p.errorClass !== 'userFault') {
+      return "loopFinished: max-iterations-exceeded requires errorCode='LoopMaxIterationsExceeded' and errorClass='userFault'";
+    }
+  }
+  return null;
+}
+
 /**
  * Run every post-parse invariant against a WorkflowEvent.  Each entry is
  * a `(event) => string | null` checker; the first failure wins and gets
@@ -298,6 +334,7 @@ const POST_PARSE_INVARIANTS: Array<{
   { path: ['payloadHash'], check: checkPayloadHashInvariant },
   { path: ['payload'], check: checkReconcileResultInvariant },
   { path: ['payload'], check: checkWaitCreatedPromptInvariant },
+  { path: ['payload'], check: checkLoopFinishedInvariant },
 ];
 
 function applyInvariants(event: WorkflowEvent): z.ZodError | null {

--- a/src/workflows/events/types.ts
+++ b/src/workflows/events/types.ts
@@ -14,6 +14,10 @@ import {
   ActivityRunningEventSchema,
   ActivityWaitingEventSchema,
   ActivityTimedOutEventSchema,
+  LoopStartedEventSchema,
+  LoopIterationStartedEventSchema,
+  LoopIterationFinishedEventSchema,
+  LoopFinishedEventSchema,
   ConditionEvaluatedEventSchema,
   LeaseSignedEventSchema,
   AttemptCreatedEventSchema,
@@ -51,6 +55,10 @@ export type NodeCanceledEvent = z.infer<typeof NodeCanceledEventSchema>;
 export type ActivityRunningEvent = z.infer<typeof ActivityRunningEventSchema>;
 export type ActivityWaitingEvent = z.infer<typeof ActivityWaitingEventSchema>;
 export type ActivityTimedOutEvent = z.infer<typeof ActivityTimedOutEventSchema>;
+export type LoopStartedEvent = z.infer<typeof LoopStartedEventSchema>;
+export type LoopIterationStartedEvent = z.infer<typeof LoopIterationStartedEventSchema>;
+export type LoopIterationFinishedEvent = z.infer<typeof LoopIterationFinishedEventSchema>;
+export type LoopFinishedEvent = z.infer<typeof LoopFinishedEventSchema>;
 export type ConditionEvaluatedEvent = z.infer<typeof ConditionEvaluatedEventSchema>;
 export type LeaseSignedEvent = z.infer<typeof LeaseSignedEventSchema>;
 export type AttemptCreatedEvent = z.infer<typeof AttemptCreatedEventSchema>;

--- a/src/workflows/loader.ts
+++ b/src/workflows/loader.ts
@@ -56,6 +56,28 @@ export async function snapshotWorkflowDefinition(
   return path;
 }
 
+/**
+ * Load the workflow definition snapshot from a run's directory.  Each run
+ * persists `workflow.json` next to `events.ndjson` so consumers that come
+ * in via run id alone (Lark card callbacks, dashboard resolve) can recover
+ * the definition without needing the catalog (which may drift).
+ *
+ * Returns null when the snapshot is missing or unreadable — callers can
+ * still operate (e.g. resolveWait without ctx.def degrades to v0.1
+ * approve/reject semantics).  Logged failures are intentional silent here;
+ * callers can choose to surface or fall back.
+ */
+export async function readWorkflowDefinitionFromRunDir(
+  runDir: string,
+): Promise<WorkflowDefinition | null> {
+  try {
+    const raw = await fs.readFile(join(runDir, 'workflow.json'), 'utf-8');
+    return parseWorkflowDefinition(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
 export async function writeRunChatBinding(
   runId: string,
   binding: RunChatBinding,

--- a/src/workflows/loader.ts
+++ b/src/workflows/loader.ts
@@ -6,6 +6,7 @@ import {
   type WorkflowDefinition,
 } from './definition.js';
 import { ensureRunDir } from './runs-dir.js';
+import { logger } from '../utils/logger.js';
 
 export type RunChatBinding = {
   chatId: string;
@@ -64,16 +65,26 @@ export async function snapshotWorkflowDefinition(
  *
  * Returns null when the snapshot is missing or unreadable — callers can
  * still operate (e.g. resolveWait without ctx.def degrades to v0.1
- * approve/reject semantics).  Logged failures are intentional silent here;
- * callers can choose to surface or fall back.
+ * approve/reject semantics).  The fallback is the *intended* design, but
+ * we log non-ENOENT failures so an unexpected parse/IO error doesn't go
+ * silently null and confuse debugging (ENOENT stays silent — missing
+ * snapshot is a normal state for legacy v0.1 runs that predate this file).
  */
 export async function readWorkflowDefinitionFromRunDir(
   runDir: string,
 ): Promise<WorkflowDefinition | null> {
+  const path = join(runDir, 'workflow.json');
   try {
-    const raw = await fs.readFile(join(runDir, 'workflow.json'), 'utf-8');
+    const raw = await fs.readFile(path, 'utf-8');
     return parseWorkflowDefinition(JSON.parse(raw));
-  } catch {
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      logger.warn?.(
+        `readWorkflowDefinitionFromRunDir: ${path} unreadable — caller falls back to v0.1 wait semantics: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
     return null;
   }
 }

--- a/src/workflows/loop.ts
+++ b/src/workflows/loop.ts
@@ -385,6 +385,64 @@ async function runSettle(
     case 'completeRunFailed':
       await completeRunFailed(ctx, action);
       return;
+    // v0.2 loop lifecycle actions — each maps 1:1 to a loop event in
+    // events/payloads.ts.  Runtime side has no extra side-effects beyond
+    // appending the event; replay (codex Step 2) does the heavy lifting.
+    case 'startLoop':
+      await ctx.log.append({
+        runId: ctx.log.runId,
+        type: 'loopStarted',
+        actor: 'scheduler',
+        payload: {
+          loopId: action.loopId,
+          maxIterations: action.maxIterations,
+        },
+      });
+      return;
+    case 'startLoopIteration':
+      await ctx.log.append({
+        runId: ctx.log.runId,
+        type: 'loopIterationStarted',
+        actor: 'scheduler',
+        payload: {
+          loopId: action.loopId,
+          iteration: action.iteration,
+          prevResolution: action.prevResolution,
+        },
+      });
+      return;
+    case 'finishLoopIteration':
+      await ctx.log.append({
+        runId: ctx.log.runId,
+        type: 'loopIterationFinished',
+        actor: 'scheduler',
+        payload: {
+          loopId: action.loopId,
+          iteration: action.iteration,
+          resolution: action.resolution,
+          decisionActivityId: action.decisionActivityId,
+          waitResolvedEventId: action.waitResolvedEventId,
+          by: action.by,
+          ...(action.comment !== undefined ? { comment: action.comment } : {}),
+          ...(action.timedOut !== undefined ? { timedOut: action.timedOut } : {}),
+        },
+      });
+      return;
+    case 'finishLoop':
+      await ctx.log.append({
+        runId: ctx.log.runId,
+        type: 'loopFinished',
+        actor: 'scheduler',
+        payload: {
+          loopId: action.loopId,
+          finalIteration: action.finalIteration,
+          resolution: action.resolution,
+          ...(action.outputRef ? { outputRef: action.outputRef } : {}),
+          ...(action.errorCode ? { errorCode: action.errorCode } : {}),
+          ...(action.errorClass ? { errorClass: action.errorClass } : {}),
+        },
+      });
+      return;
   }
   // Exhaustive — TS will flag if a new settle kind appears.
   const _exhaustive: never = action;

--- a/src/workflows/ops-projection.ts
+++ b/src/workflows/ops-projection.ts
@@ -302,6 +302,11 @@ export type BlobPreviewDTO = {
   value?: unknown;
   text?: string;
   error?: string;
+  /** Set by `scrubSnapshotForUnauthed`: text/value were stripped because
+   *  the caller wasn't authenticated.  Metadata (bytes, truncated) stays
+   *  so the dashboard can render a "log available after login" placeholder
+   *  instead of pretending the blob doesn't exist. */
+  redacted?: boolean;
 };
 
 export type AttemptIODTO = {
@@ -339,9 +344,50 @@ export type AttemptTerminalDTO = {
 const BLOB_PREVIEW_MAX_BYTES = 64 * 1024;
 
 /**
+ * Scrub fields that leak raw CLI process bytes from a snapshot DTO before
+ * exposing it to an unauthenticated reader.  Companion of the
+ * `…/terminal-log/raw` cookie-auth carve-out: that carve-out hid the full
+ * pty/terminal stream download, but the same data still leaked via
+ * `attemptIO[*].log.text` (last 64 KiB tail of `terminal.log`) on the
+ * public `/snapshot` endpoint.
+ *
+ * What stays public: run/node/activity status, output blob previews
+ * (workflow author's intended product), terminal sidecar metadata.
+ * What gets scrubbed: `io.log.text/value` (the raw stdout/stderr tail
+ * — may contain env-var dumps, API key error messages, secret-bearing
+ * curl responses) and `io.terminal.logPath` (absolute on-disk path
+ * leaks filesystem layout).
+ *
+ * Idempotent + pure: caller is the route handler that already knows
+ * `authed === false`.  Returns a new DTO; input is not mutated.
+ */
+export function scrubSnapshotForUnauthed(snap: RunSnapshotDTO): RunSnapshotDTO {
+  const attemptIO: Record<string, AttemptIODTO> = {};
+  for (const [attemptId, io] of Object.entries(snap.attemptIO)) {
+    const scrubbed: AttemptIODTO = { ...io };
+    if (io.log) {
+      const { text: _text, value: _value, ...logRest } = io.log;
+      scrubbed.log = { ...logRest, redacted: true } as BlobPreviewDTO;
+    }
+    if (io.terminal && io.terminal.logPath !== undefined) {
+      const { logPath: _logPath, ...termRest } = io.terminal;
+      scrubbed.terminal = termRest;
+    }
+    attemptIO[attemptId] = scrubbed;
+  }
+  return { ...snap, attemptIO };
+}
+
+/**
  * Build a JSON-serializable snapshot for a single run.  Returns null when
  * the run is missing / has no events / has a corrupt log.  Callers
  * (dashboard `/snapshot` endpoint) should map null → 404.
+ *
+ * Always returns the full DTO including sensitive log bytes.  Callers
+ * serving unauth'd HTTP requests MUST apply `scrubSnapshotForUnauthed`
+ * before responding — kept as a separate step so internal callers
+ * (cancel-run, daemon-side hooks) keep the full view without
+ * round-tripping through scrub.
  */
 export async function readRunSnapshot(
   runsDir: string,

--- a/src/workflows/ops-projection.ts
+++ b/src/workflows/ops-projection.ts
@@ -252,6 +252,14 @@ export type RunSnapshotDTO = {
   lastSeq: number;
   nodes: NodeState[];
   activities: ActivityState[];
+  /**
+   * v0.2 loop blocks indexed by their nodeId.  Optional so v0.1 clients
+   * that don't render iteration timelines stay forward-compatible — if
+   * the field is absent, no loops are present; if it's an empty record,
+   * the workflow used loop schema but no loop instance ran.  See
+   * /tmp/wf-loop-v02.md §8 (dashboard) + §9 (progress card).
+   */
+  loops?: Record<string, LoopSnapshotDTO>;
   dangling: {
     activities: string[];
     effectAttempted: string[];
@@ -262,6 +270,28 @@ export type RunSnapshotDTO = {
   attemptIO: Record<string, AttemptIODTO>;
   chatBinding?: { chatId: string; larkAppId: string };
   updatedAt: number;
+};
+
+export type LoopIterationDTO = {
+  iteration: number;
+  status: 'running' | 'approved' | 'rejected' | 'failed' | 'cancelled';
+  bodyActivityIds: string[];
+  decisionActivityId?: string;
+  waitResolvedEventId?: string;
+  decisionBy?: string;
+  decisionComment?: string;
+  timedOut?: boolean;
+};
+
+export type LoopSnapshotDTO = {
+  loopId: string;
+  status: 'running' | 'succeeded' | 'failed' | 'cancelled';
+  iteration: number;
+  maxIterations: number;
+  iterations: LoopIterationDTO[];
+  output?: OutputRef;
+  errorCode?: string;
+  errorClass?: string;
 };
 
 export type BlobPreviewDTO = {
@@ -338,6 +368,7 @@ export async function readRunSnapshot(
     lastSeq: snap.lastSeq,
     nodes: [...snap.nodes.values()],
     activities: [...snap.activities.values()],
+    loops: projectLoops(snap),
     dangling: {
       activities: snap.danglingActivities,
       effectAttempted: snap.danglingEffectAttempted,
@@ -349,6 +380,39 @@ export async function readRunSnapshot(
     chatBinding: binding ?? undefined,
     updatedAt: events[events.length - 1]!.timestamp,
   };
+}
+
+/**
+ * Project the replay's in-memory `snapshot.loops` Map into the
+ * JSON-serializable DTO surface.  Returns `undefined` when no loops
+ * exist so v0.1 clients deserializing the snapshot see no `loops`
+ * key at all (forward-compat for older dashboards).
+ */
+function projectLoops(snap: Snapshot): Record<string, LoopSnapshotDTO> | undefined {
+  if (!snap.loops || snap.loops.size === 0) return undefined;
+  const out: Record<string, LoopSnapshotDTO> = {};
+  for (const [loopId, state] of snap.loops) {
+    out[loopId] = {
+      loopId,
+      status: state.status,
+      iteration: state.iteration,
+      maxIterations: state.maxIterations,
+      iterations: state.iterations.map((it) => ({
+        iteration: it.iteration,
+        status: it.status,
+        bodyActivityIds: [...it.bodyActivityIds],
+        decisionActivityId: it.decisionActivityId,
+        waitResolvedEventId: it.waitResolvedEventId,
+        decisionBy: it.decisionBy,
+        decisionComment: it.decisionComment,
+        timedOut: it.timedOut,
+      })),
+      output: state.output,
+      errorCode: state.errorCode,
+      errorClass: state.errorClass,
+    };
+  }
+  return out;
 }
 
 async function buildAttemptIO(

--- a/src/workflows/orchestrator.ts
+++ b/src/workflows/orchestrator.ts
@@ -256,7 +256,12 @@ export type FinishLoopAction = {
   kind: 'finishLoop';
   loopId: string;
   finalIteration: number;
-  resolution: 'approved' | 'max-iterations-exceeded' | 'cancelled' | 'timeout';
+  resolution:
+    | 'approved'
+    | 'max-iterations-exceeded'
+    | 'body-failed'
+    | 'cancelled'
+    | 'timeout';
   errorCode?: string;
   errorClass?: ErrorClass;
   outputRef?: OutputRef;
@@ -413,18 +418,17 @@ export function decideNextActions(
     }
     if (iterState.status === 'failed' || iterState.status === 'cancelled') {
       // Non-terminator failure already finalized this iteration; close
-      // the loop block with `cancelled` resolution.  This is the closest
-      // bucket the LoopFinishedPayload supports for "loop terminated
-      // abnormally without reaching maxIterations"; the underlying
-      // failed body attempt carries the root cause.  A dedicated
-      // `'body-failed'` resolution / errorCode is a clean follow-up but
-      // not required for v0.2 to be useful.
+      // the loop block with `body-failed` resolution (codex Step 3
+      // review Medium).  `cancelled` is reserved for user-initiated
+      // cancel; `body-failed` distinguishes "this loop died because a
+      // body node failed" from "user clicked cancel".
       return [
         {
           kind: 'finishLoop',
           loopId,
           finalIteration: currentIter,
-          resolution: 'cancelled',
+          resolution: 'body-failed',
+          errorCode: 'LoopBodyFailed',
           errorClass: 'fatal',
         },
       ];
@@ -515,27 +519,26 @@ export function decideNextActions(
       if (advance.isFailed) {
         if (isTerminator) {
           // Terminator humanGate timed out / failed → finish the loop
-          // with `timeout`.  `errorCode` is left unset until the enum
-          // grows a dedicated value (the underlying activityFailed event
-          // carries the WaitDeadlineExceeded code).
+          // with `timeout` + WaitDeadlineExceeded (codex Step 3 review
+          // Medium — schema invariant requires this errorCode pairing).
           bodyFailureFinish = {
             kind: 'finishLoop',
             loopId,
             finalIteration: currentIter,
             resolution: 'timeout',
+            errorCode: 'WaitDeadlineExceeded',
             errorClass: 'userFault',
           };
         } else {
           // Non-terminator body node failed (subagent crash / hostExecutor
           // error / non-terminator humanGate.reject = fail-run per
-          // /tmp/wf-loop-v02.md §10.8) → fail the loop block.  Uses
-          // `cancelled` resolution as the abnormal-termination bucket;
-          // see the iterState branch above for the same rationale.
+          // /tmp/wf-loop-v02.md §10.8) → close as `body-failed`.
           bodyFailureFinish = {
             kind: 'finishLoop',
             loopId,
             finalIteration: currentIter,
-            resolution: 'cancelled',
+            resolution: 'body-failed',
+            errorCode: 'LoopBodyFailed',
             errorClass: 'fatal',
           };
         }

--- a/src/workflows/orchestrator.ts
+++ b/src/workflows/orchestrator.ts
@@ -21,6 +21,16 @@
  *
  * One node may own at most one gate (before-gate) and one work
  * activity in v0.  After-gates and re-runs are deferred.
+ *
+ * v0.2 loop body activities are scoped by a `loop::<loopId>.<N>` segment:
+ *
+ *   loop work activity: `<runId>::loop::<loopId>.<N>::work::<bodyNodeId>`
+ *   loop gate activity: `<runId>::loop::<loopId>.<N>::gate::<bodyNodeId>`
+ *
+ * `<N>` is the 1-indexed iteration; `<loopId>` is the loop block's
+ * nodeId.  All segments stay within `SEGMENT_RE` (allows
+ * `[A-Za-z0-9._:-]`), so existing `isValidPathSegment` / attempt-
+ * sidecar path guards continue to apply without modification.
  * ────────────────────────────────────────────────────────────────────
  */
 
@@ -41,6 +51,99 @@ export function gateActivityId(runId: string, nodeId: string): string {
 
 export function workActivityId(runId: string, nodeId: string): string {
   return `${runId}::work::${nodeId}`;
+}
+
+// ─── Loop iteration activity IDs (v0.2) ───────────────────────────────────
+//
+// See /tmp/wf-loop-v02.md §4.2 and the top-of-file ASCII spec.
+//
+// Iteration `N` is 1-indexed.  We refuse to encode `N < 1` so callers
+// never accidentally emit `loop::foo.0` ids (the iteration counter is a
+// real loop-state position, not a placeholder).
+
+export function loopWorkActivityId(
+  runId: string,
+  loopId: string,
+  iteration: number,
+  bodyNodeId: string,
+): string {
+  if (!Number.isInteger(iteration) || iteration < 1) {
+    throw new Error(
+      `loopWorkActivityId: iteration must be a positive integer (got ${iteration})`,
+    );
+  }
+  return `${runId}::loop::${loopId}.${iteration}::work::${bodyNodeId}`;
+}
+
+export function loopGateActivityId(
+  runId: string,
+  loopId: string,
+  iteration: number,
+  bodyNodeId: string,
+): string {
+  if (!Number.isInteger(iteration) || iteration < 1) {
+    throw new Error(
+      `loopGateActivityId: iteration must be a positive integer (got ${iteration})`,
+    );
+  }
+  return `${runId}::loop::${loopId}.${iteration}::gate::${bodyNodeId}`;
+}
+
+/**
+ * Parsed activity id.  `kind: 'plain'` corresponds to the v0.1 forms
+ * (`<runId>::work::<nodeId>` / `<runId>::gate::<nodeId>`).  `kind:
+ * 'loop'` corresponds to v0.2 loop-iteration forms.  Returns `undefined`
+ * if `s` doesn't match any known shape — callers can treat that as
+ * "not a workflow activity id" without throwing.
+ */
+export type ParsedActivityId =
+  | {
+      kind: 'plain';
+      runId: string;
+      activityKind: 'work' | 'gate';
+      nodeId: string;
+    }
+  | {
+      kind: 'loop';
+      runId: string;
+      loopId: string;
+      iteration: number;
+      activityKind: 'work' | 'gate';
+      nodeId: string;
+    };
+
+const PLAIN_RE = /^([^:]+(?:::?[^:]+)*?)::(work|gate)::([A-Za-z0-9_.-]+)$/;
+const LOOP_RE = /^(.+)::loop::([A-Za-z0-9_.-]+)\.(\d+)::(work|gate)::([A-Za-z0-9_.-]+)$/;
+
+export function parseActivityId(s: string): ParsedActivityId | undefined {
+  // Loop form first — the `::loop::` segment is unambiguous and would
+  // also accidentally satisfy a greedy plain match if we tried plain
+  // first (`runId` would absorb `::loop::<id>.<N>::work`).
+  const loopMatch = LOOP_RE.exec(s);
+  if (loopMatch) {
+    const [, runId, loopId, iterStr, activityKind, nodeId] = loopMatch;
+    const iteration = Number(iterStr);
+    if (!Number.isFinite(iteration) || iteration < 1) return undefined;
+    return {
+      kind: 'loop',
+      runId,
+      loopId,
+      iteration,
+      activityKind: activityKind as 'work' | 'gate',
+      nodeId,
+    };
+  }
+  const plainMatch = PLAIN_RE.exec(s);
+  if (plainMatch) {
+    const [, runId, activityKind, nodeId] = plainMatch;
+    return {
+      kind: 'plain',
+      runId,
+      activityKind: activityKind as 'work' | 'gate',
+      nodeId,
+    };
+  }
+  return undefined;
 }
 
 // ─── Actions ──────────────────────────────────────────────────────────────
@@ -169,6 +272,17 @@ export function decideNextActions(
   for (const nodeId of order) {
     const node = def.nodes[nodeId]!;
     const nstatus = snapshot.nodes.get(nodeId)?.status ?? 'idle';
+
+    // v0.2 loop / decision dispatch is owned by the loop runtime executor
+    // (Step 3 of feat/workflow-loop-v02; see /tmp/wf-loop-v02.md §13).
+    // Schema has landed but runtime is not yet wired — keep these out of
+    // the legacy scheduler so a workflow that mistakenly invokes one in
+    // Step 1 stays `pending` rather than silently failing.  Step 3 will
+    // intercept these node types upstream and never reach this branch.
+    if (node.type === 'loop' || node.type === 'decision') {
+      pendingCount++;
+      continue;
+    }
 
     // Already settled at the node level — nothing for us to advance.
     if (nstatus === 'succeeded' || nstatus === 'skipped' || nstatus === 'cancelled') {

--- a/src/workflows/orchestrator.ts
+++ b/src/workflows/orchestrator.ts
@@ -216,13 +216,63 @@ export type CompleteRunFailedAction = {
   failedNodeId: string;
 };
 
+// ─── Loop lifecycle actions (v0.2) ────────────────────────────────────────
+//
+// These four actions are emitted only by the loop branch of
+// `decideNextActions`.  Each maps 1:1 to a loop lifecycle event in
+// `events/payloads.ts`; the runtime layer translates the action into a
+// `log.append({...})` call (no other side effects).  Per
+// /tmp/wf-loop-v02.md §4.3 + codex round 3 ack: when the loop branch
+// emits one of these, it returns it as the SOLE action for the tick so
+// that event ordering — `loopStarted` → `loopIterationStarted` → body
+// attempts — is deterministic and never interleaves with body dispatch.
+
+export type StartLoopAction = {
+  kind: 'startLoop';
+  loopId: string;
+  maxIterations: number;
+};
+
+export type StartLoopIterationAction = {
+  kind: 'startLoopIteration';
+  loopId: string;
+  iteration: number;
+  prevResolution: 'initial' | 'rejected';
+};
+
+export type FinishLoopIterationAction = {
+  kind: 'finishLoopIteration';
+  loopId: string;
+  iteration: number;
+  resolution: 'approved' | 'rejected';
+  decisionActivityId: string;
+  waitResolvedEventId: string;
+  by: string;
+  comment?: string;
+  timedOut?: boolean;
+};
+
+export type FinishLoopAction = {
+  kind: 'finishLoop';
+  loopId: string;
+  finalIteration: number;
+  resolution: 'approved' | 'max-iterations-exceeded' | 'cancelled' | 'timeout';
+  errorCode?: string;
+  errorClass?: ErrorClass;
+  outputRef?: OutputRef;
+};
+
 export type OrchestratorAction =
   | DispatchGateAction
   | DispatchWorkAction
   | CompleteNodeSucceededAction
   | CompleteNodeFailedAction
   | CompleteRunSucceededAction
-  | CompleteRunFailedAction;
+  | CompleteRunFailedAction
+  | StartLoopAction
+  | StartLoopIterationAction
+  | FinishLoopIterationAction
+  | FinishLoopAction;
 
 // ─── Decision function ───────────────────────────────────────────────────
 
@@ -266,25 +316,275 @@ export function decideNextActions(
   const runId = snapshot.run.runId;
   const order = topologicalOrder(def);
 
+  // v0.2: compute loop body membership once so the top-level scheduler
+  // skips body nodes (they're dispatched by the loop branch only).
+  const bodyOwner = buildBodyOwnerMap(def);
+
   let failedNodeId: string | undefined;
   let pendingCount = 0;
 
+  // ─── Loop lifecycle + body dispatch pass (v0.2) ──────────────────────
+  //
+  // For each loop block in topo order, this pass owns:
+  //   1. emitting `startLoop` when the loop's `depends` first go green
+  //   2. emitting `startLoopIteration` to open each iteration
+  //   3. dispatching body activities under loop-iteration activityIds
+  //   4. emitting `finishLoopIteration` once the terminator decision
+  //      attempt settles (approve or reject)
+  //   5. emitting `finishLoop` once iteration loop closes (approved /
+  //      max-iterations-exceeded / non-terminator body failure / decision
+  //      humanGate timeout)
+  //
+  // Per codex round 3: lifecycle actions are returned as the SOLE action
+  // of the tick so event ordering — `loopStarted` → `loopIterationStarted`
+  // → body attempts — is deterministic and never interleaves with body
+  // dispatches.  Body dispatches batch up only when no lifecycle action
+  // fires this tick.
   for (const nodeId of order) {
     const node = def.nodes[nodeId]!;
-    const nstatus = snapshot.nodes.get(nodeId)?.status ?? 'idle';
+    if (node.type !== 'loop') continue;
+    const loopId = nodeId;
+    const loopState = snapshot.loops.get(loopId);
+    const depsOk = (node.depends ?? []).every(
+      (dep) => snapshot.nodes.get(dep)?.status === 'succeeded',
+    );
 
-    // v0.2 loop / decision dispatch is owned by the loop runtime executor
-    // (Step 3 of feat/workflow-loop-v02; see /tmp/wf-loop-v02.md §13).
-    // Schema has landed but runtime is not yet wired — keep these out of
-    // the legacy scheduler so a workflow that mistakenly invokes one in
-    // Step 1 stays `pending` rather than silently failing.  Step 3 will
-    // intercept these node types upstream and never reach this branch.
-    if (node.type === 'loop' || node.type === 'decision') {
-      pendingCount++;
-      continue;
+    // (1) Loop not yet entered.
+    if (!loopState) {
+      if (!depsOk) {
+        pendingCount++;
+        continue;
+      }
+      return [{ kind: 'startLoop', loopId, maxIterations: node.maxIterations }];
     }
 
-    // Already settled at the node level — nothing for us to advance.
+    // Loop already finalized — nothing else to do.
+    if (loopState.status !== 'running') continue;
+
+    // (2) Loop started but no iteration opened yet.
+    if (loopState.iteration === 0) {
+      return [
+        { kind: 'startLoopIteration', loopId, iteration: 1, prevResolution: 'initial' },
+      ];
+    }
+
+    // Active iteration in progress.
+    const currentIter = loopState.iteration;
+    const iterState = loopState.iterations[currentIter - 1];
+    if (!iterState) {
+      pendingCount++;
+      continue; // anomalous — shouldn't happen, skip safely
+    }
+
+    // (4) Current iteration already has a settled resolution:
+    if (iterState.status === 'approved') {
+      const outputRef = computeLoopOutputRef(snapshot, runId, node, loopId, currentIter);
+      return [
+        {
+          kind: 'finishLoop',
+          loopId,
+          finalIteration: currentIter,
+          resolution: 'approved',
+          outputRef,
+        },
+      ];
+    }
+    if (iterState.status === 'rejected') {
+      if (currentIter < loopState.maxIterations) {
+        return [
+          {
+            kind: 'startLoopIteration',
+            loopId,
+            iteration: currentIter + 1,
+            prevResolution: 'rejected',
+          },
+        ];
+      }
+      return [
+        {
+          kind: 'finishLoop',
+          loopId,
+          finalIteration: currentIter,
+          resolution: 'max-iterations-exceeded',
+          errorCode: 'LoopMaxIterationsExceeded',
+          errorClass: 'userFault',
+        },
+      ];
+    }
+    if (iterState.status === 'failed' || iterState.status === 'cancelled') {
+      // Non-terminator failure already finalized this iteration; close
+      // the loop block with `cancelled` resolution.  This is the closest
+      // bucket the LoopFinishedPayload supports for "loop terminated
+      // abnormally without reaching maxIterations"; the underlying
+      // failed body attempt carries the root cause.  A dedicated
+      // `'body-failed'` resolution / errorCode is a clean follow-up but
+      // not required for v0.2 to be useful.
+      return [
+        {
+          kind: 'finishLoop',
+          loopId,
+          finalIteration: currentIter,
+          resolution: 'cancelled',
+          errorClass: 'fatal',
+        },
+      ];
+    }
+
+    // (3) Iteration is `running` — dispatch body / terminator.
+    //
+    // Step through body nodes in topo order *within* this iteration.
+    // Use a small per-iteration helper map: bodyId → succeeded?  so we
+    // can resolve intra-body deps without touching the v0.1 node-level
+    // status (which never advances for body nodes in v0.2).
+    const bodySet = new Set(node.body);
+    const bodyDone = new Map<string, boolean>();
+    let bodyFailureFinish: FinishLoopAction | undefined;
+    const iterDispatch: OrchestratorAction[] = [];
+
+    for (const bodyId of orderForBody(order, bodySet)) {
+      const bodyNode = def.nodes[bodyId]!;
+      // Intra-body dep check: all body-side deps must have a succeeded
+      // activity in *this* iteration; loop-external deps were guaranteed
+      // already by the loop block's own `depends` gate.
+      const intraDepsOk = (bodyNode.depends ?? [])
+        .filter((d) => bodySet.has(d))
+        .every((d) => bodyDone.get(d) === true);
+      if (!intraDepsOk) {
+        pendingCount++;
+        continue;
+      }
+
+      const isTerminator = bodyId === node.terminate.node;
+      const bodyGateActId = loopGateActivityId(runId, loopId, currentIter, bodyId);
+      const bodyWorkActId = loopWorkActivityId(runId, loopId, currentIter, bodyId);
+      const advance = decideNodeAdvancement(
+        snapshot,
+        bodyNode,
+        bodyId,
+        bodyGateActId,
+        bodyWorkActId,
+      );
+
+      if (advance.isSucceeded) {
+        bodyDone.set(bodyId, true);
+        if (isTerminator) {
+          // Terminator settled — read its wait resolution out of the
+          // activity attempt, then return `finishLoopIteration` as the
+          // sole action this tick so the iteration advances cleanly.
+          const decisionAct = snapshot.activities.get(bodyGateActId);
+          const lastAt = decisionAct?.attempts[decisionAct.attempts.length - 1];
+          const wait = lastAt?.wait?.resolution;
+          if (
+            wait &&
+            wait.kind === 'resolved' &&
+            (wait.resolution === 'approved' || wait.resolution === 'rejected')
+          ) {
+            return [
+              {
+                kind: 'finishLoopIteration',
+                loopId,
+                iteration: currentIter,
+                resolution: wait.resolution,
+                decisionActivityId: bodyGateActId,
+                waitResolvedEventId: wait.eventId,
+                by: wait.by,
+                comment: wait.comment,
+              },
+            ];
+          }
+          if (wait && wait.kind === 'deadlineExceeded') {
+            return [
+              {
+                kind: 'finishLoopIteration',
+                loopId,
+                iteration: currentIter,
+                resolution: 'rejected',
+                decisionActivityId: bodyGateActId,
+                waitResolvedEventId: wait.eventId,
+                by: 'system',
+                timedOut: true,
+              },
+            ];
+          }
+          // Decision attempt succeeded but no resolution found — defer.
+          pendingCount++;
+        }
+        continue;
+      }
+
+      if (advance.isFailed) {
+        if (isTerminator) {
+          // Terminator humanGate timed out / failed → finish the loop
+          // with `timeout`.  `errorCode` is left unset until the enum
+          // grows a dedicated value (the underlying activityFailed event
+          // carries the WaitDeadlineExceeded code).
+          bodyFailureFinish = {
+            kind: 'finishLoop',
+            loopId,
+            finalIteration: currentIter,
+            resolution: 'timeout',
+            errorClass: 'userFault',
+          };
+        } else {
+          // Non-terminator body node failed (subagent crash / hostExecutor
+          // error / non-terminator humanGate.reject = fail-run per
+          // /tmp/wf-loop-v02.md §10.8) → fail the loop block.  Uses
+          // `cancelled` resolution as the abnormal-termination bucket;
+          // see the iterState branch above for the same rationale.
+          bodyFailureFinish = {
+            kind: 'finishLoop',
+            loopId,
+            finalIteration: currentIter,
+            resolution: 'cancelled',
+            errorClass: 'fatal',
+          };
+        }
+        break; // stop iterating body; we'll close the loop instead
+      }
+
+      // Not yet succeeded / failed — accumulate dispatch actions.
+      iterDispatch.push(...advance.actions);
+      pendingCount += advance.actions.length === 0 ? 1 : 0;
+    }
+
+    if (bodyFailureFinish) {
+      return [bodyFailureFinish];
+    }
+    // Body dispatches accumulate into the outer `actions` array; the
+    // legacy plain-node pass below will also push into it, so a single
+    // tick can dispatch multiple body nodes + plain nodes together.
+    // Lifecycle actions never reach this branch (they early-return
+    // above).
+    for (const a of iterDispatch) actions.push(a);
+  }
+
+  // ─── Loop terminal propagation ────────────────────────────────────────
+  //
+  // After the loop branch may have emitted `finishLoop`, the next tick
+  // sees `loopState.status` settled but the legacy node-level state
+  // machine doesn't know about it.  Propagate failed / cancelled loop
+  // blocks into `failedNodeId` so the actions.length===0 sweep below
+  // can emit `completeRunFailed`.  Succeeded loop blocks expose their
+  // projected output via `outputs[workActivityId(runId, loopId)]` and
+  // are handled naturally by the sink sweep.
+  for (const [loopId, loopState] of snapshot.loops) {
+    if (loopState.status === 'failed' || loopState.status === 'cancelled') {
+      failedNodeId = failedNodeId ?? loopId;
+    }
+  }
+
+  // ─── Plain (non-loop, non-body) node pass ────────────────────────────
+  //
+  // Same logic as v0.1: dispatch gate → dispatch work → settle node.
+  // Skips loop blocks (already handled) + decision nodes (only valid in
+  // loop body) + body nodes (dispatched only by the loop branch above).
+  for (const nodeId of order) {
+    const node = def.nodes[nodeId]!;
+    if (node.type === 'loop') continue;
+    if (node.type === 'decision') continue; // validateLoopBlocks guarantees in-body
+    if (bodyOwner.has(nodeId)) continue; // dispatched by loop branch
+
+    const nstatus = snapshot.nodes.get(nodeId)?.status ?? 'idle';
     if (nstatus === 'succeeded' || nstatus === 'skipped' || nstatus === 'cancelled') {
       continue;
     }
@@ -293,10 +593,17 @@ export function decideNextActions(
       continue;
     }
 
-    // Dependencies gate dispatch.
-    const depsOk = (node.depends ?? []).every(
-      (dep) => snapshot.nodes.get(dep)?.status === 'succeeded',
-    );
+    // Dependencies gate dispatch.  Loop blocks are treated as "succeeded"
+    // for the purpose of downstream deps when their snapshot status is
+    // 'succeeded'.  This is how `${review-loop.output.x}` and direct
+    // body-node refs become resolvable for downstream plain nodes.
+    const depsOk = (node.depends ?? []).every((dep) => {
+      const depNode = def.nodes[dep];
+      if (depNode?.type === 'loop') {
+        return snapshot.loops.get(dep)?.status === 'succeeded';
+      }
+      return snapshot.nodes.get(dep)?.status === 'succeeded';
+    });
     if (!depsOk) {
       pendingCount++;
       continue;
@@ -304,94 +611,34 @@ export function decideNextActions(
 
     const gateActId = gateActivityId(runId, nodeId);
     const workActId = workActivityId(runId, nodeId);
-    const gateAct = snapshot.activities.get(gateActId);
-    const workAct = snapshot.activities.get(workActId);
-
-    if (node.humanGate) {
-      if (!gateAct) {
-        actions.push({
-          kind: 'dispatchGate',
-          nodeId,
-          activityId: gateActId,
-          humanGate: node.humanGate,
-        });
-        pendingCount++;
-        continue;
-      }
-      if (gateAct.status === 'failed') {
-        actions.push({
-          kind: 'completeNodeFailed',
-          nodeId,
-          lastActivityId: gateActId,
-          errorClass: 'userFault',
-        });
-        continue;
-      }
-      if (gateAct.status !== 'succeeded') {
-        // gate in-flight (acquired / running / waiting) — wait.
-        pendingCount++;
-        continue;
-      }
-      // gate cleared → fall through to work dispatch / advancement
-    }
-
-    if (!workAct) {
-      actions.push({
-        kind: 'dispatchWork',
-        nodeId,
-        activityId: workActId,
-        node,
-      });
-      pendingCount++;
+    const advance = decideNodeAdvancement(snapshot, node, nodeId, gateActId, workActId);
+    if (advance.isSucceeded) {
+      for (const a of advance.actions) actions.push(a);
       continue;
     }
-
-    if (workAct.status === 'succeeded') {
-      const output = snapshot.outputs.get(workActId);
-      if (output) {
-        actions.push({
-          kind: 'completeNodeSucceeded',
-          nodeId,
-          lastActivityId: workActId,
-          outputRef: output,
-        });
-      } else {
-        pendingCount++;
-      }
+    if (advance.isFailed) {
+      for (const a of advance.actions) actions.push(a);
+      // completeNodeFailed action records nodeId in actions; the
+      // downstream sweep uses node.status='failed' from the next
+      // replay to fail the run.
       continue;
     }
-
-    if (workAct.status === 'failed' || workAct.status === 'timedOut') {
-      // activityTimedOut payload pins errorClass='retryable' (spec §2.1),
-      // but replay doesn't propagate it onto the attempt's `error` field —
-      // it only records `runningMs`.  Special-case here so the orchestrator
-      // doesn't silently upgrade the class to fatal via `deriveErrorClass`.
-      const errorClass: ErrorClass =
-        workAct.status === 'timedOut' ? 'retryable' : deriveErrorClass(workAct);
-      actions.push({
-        kind: 'completeNodeFailed',
-        nodeId,
-        lastActivityId: workActId,
-        errorClass,
-      });
-      continue;
-    }
-
-    // running / waiting / acquired / effectAttempting — pending.
-    pendingCount++;
+    for (const a of advance.actions) actions.push(a);
+    if (advance.actions.length === 0) pendingCount++;
   }
 
   if (actions.length === 0) {
     if (failedNodeId) {
-      // Fail-fast: a node terminal-failed.  Any pending downstream nodes
-      // are stuck on the failed dep and will never advance; in-flight
-      // peer nodes are caller's problem to cancel-fanout if they want.
       actions.push({ kind: 'completeRunFailed', failedNodeId });
     } else if (pendingCount === 0) {
       const sinks = findSinks(def);
       if (sinks.length === 1) {
         const sinkId = sinks[0]!;
-        const sinkOutput = snapshot.outputs.get(workActivityId(runId, sinkId));
+        const sinkNode = def.nodes[sinkId];
+        const sinkActId = workActivityId(runId, sinkId);
+        const sinkOutput = sinkNode?.type === 'loop'
+          ? snapshot.outputs.get(sinkActId) // loopFinished projection (codex Step 2)
+          : snapshot.outputs.get(sinkActId);
         if (sinkOutput) {
           actions.push({
             kind: 'completeRunSucceeded',
@@ -400,11 +647,179 @@ export function decideNextActions(
           });
         }
       }
-      // Multi-sink: caller composes the run output (out of v0 scope).
     }
   }
 
   return actions;
+}
+
+/**
+ * Per-node advancement decision used by both the top-level scheduler
+ * (plain nodes) and the v0.2 loop branch (body / decision nodes).  The
+ * caller supplies the gate and work activityIds so the same logic
+ * applies to plain `runId::work::node` ids and loop iteration
+ * `runId::loop::loopId.N::work::node` ids without leaking the
+ * activityId convention into this helper.
+ *
+ * Returns the actions the caller should emit plus a small status
+ * triplet — exactly one of `isSucceeded` / `isFailed` is true when
+ * the node has reached its terminal; otherwise the call is "pending"
+ * (in-flight) and the returned actions are dispatch instructions for
+ * gate/work that haven't yet been emitted.
+ */
+function decideNodeAdvancement(
+  snapshot: Snapshot,
+  node: WorkflowNode,
+  nodeId: string,
+  gateActId: string,
+  workActId: string,
+): {
+  actions: OrchestratorAction[];
+  isSucceeded: boolean;
+  isFailed: boolean;
+} {
+  const actions: OrchestratorAction[] = [];
+
+  // Decision node: gate-only.  Both reject and approve resolve to
+  // `activitySucceeded` per wait.ts decision-mode (see N2 in
+  // /tmp/wf-loop-v02.md §4.3); only humanGate timeout produces a
+  // failed activity.
+  if (node.type === 'decision') {
+    const gateAct = snapshot.activities.get(gateActId);
+    if (!gateAct) {
+      actions.push({
+        kind: 'dispatchGate',
+        nodeId,
+        activityId: gateActId,
+        humanGate: node.humanGate,
+      });
+      return { actions, isSucceeded: false, isFailed: false };
+    }
+    if (gateAct.status === 'succeeded') {
+      return { actions, isSucceeded: true, isFailed: false };
+    }
+    if (gateAct.status === 'failed' || gateAct.status === 'timedOut') {
+      return { actions, isSucceeded: false, isFailed: true };
+    }
+    return { actions, isSucceeded: false, isFailed: false };
+  }
+
+  // Loop blocks are not handled by this helper.
+  if (node.type === 'loop') {
+    return { actions, isSucceeded: false, isFailed: false };
+  }
+
+  const gateAct = snapshot.activities.get(gateActId);
+  const workAct = snapshot.activities.get(workActId);
+
+  if (node.humanGate) {
+    if (!gateAct) {
+      actions.push({
+        kind: 'dispatchGate',
+        nodeId,
+        activityId: gateActId,
+        humanGate: node.humanGate,
+      });
+      return { actions, isSucceeded: false, isFailed: false };
+    }
+    if (gateAct.status === 'failed' || gateAct.status === 'timedOut') {
+      actions.push({
+        kind: 'completeNodeFailed',
+        nodeId,
+        lastActivityId: gateActId,
+        errorClass: 'userFault',
+      });
+      return { actions, isSucceeded: false, isFailed: true };
+    }
+    if (gateAct.status !== 'succeeded') {
+      // gate in-flight — caller treats this as pending
+      return { actions, isSucceeded: false, isFailed: false };
+    }
+    // gate cleared → fall through to work
+  }
+
+  if (!workAct) {
+    actions.push({
+      kind: 'dispatchWork',
+      nodeId,
+      activityId: workActId,
+      node,
+    });
+    return { actions, isSucceeded: false, isFailed: false };
+  }
+
+  if (workAct.status === 'succeeded') {
+    const output = snapshot.outputs.get(workActId);
+    if (output) {
+      actions.push({
+        kind: 'completeNodeSucceeded',
+        nodeId,
+        lastActivityId: workActId,
+        outputRef: output,
+      });
+      return { actions, isSucceeded: true, isFailed: false };
+    }
+    return { actions, isSucceeded: false, isFailed: false };
+  }
+
+  if (workAct.status === 'failed' || workAct.status === 'timedOut') {
+    const errorClass: ErrorClass =
+      workAct.status === 'timedOut' ? 'retryable' : deriveErrorClass(workAct);
+    actions.push({
+      kind: 'completeNodeFailed',
+      nodeId,
+      lastActivityId: workActId,
+      errorClass,
+    });
+    return { actions, isSucceeded: false, isFailed: true };
+  }
+
+  // running / waiting / acquired / effectAttempting — pending.
+  return { actions, isSucceeded: false, isFailed: false };
+}
+
+/**
+ * Build `bodyNodeId → owningLoopId` map for fast carve-out lookups.
+ * Mirrors `validateLoopBlocks`'s body collection but built every tick
+ * because the orchestrator is a pure function and doesn't carry state.
+ */
+function buildBodyOwnerMap(def: WorkflowDefinition): Map<string, string> {
+  const owner = new Map<string, string>();
+  for (const [id, node] of Object.entries(def.nodes)) {
+    if (node.type !== 'loop') continue;
+    for (const bodyId of node.body) owner.set(bodyId, id);
+  }
+  return owner;
+}
+
+/**
+ * Filter a workflow-level topological order down to body nodes only,
+ * preserving the global order.  Used to dispatch body nodes inside an
+ * active loop iteration in deterministic order.
+ */
+function orderForBody(allOrder: string[], bodySet: Set<string>): string[] {
+  return allOrder.filter((id) => bodySet.has(id));
+}
+
+/**
+ * Resolve `loop.output.from` to the OutputRef of the body node's
+ * latest successful iteration so `finishLoop` can carry it forward.
+ * Returns `undefined` if the loop did not declare `output.from`, or if
+ * the body node hasn't produced a succeeded output in `iteration` yet
+ * (which shouldn't happen if the terminator already approved — but
+ * defensive against partial replay state).
+ */
+function computeLoopOutputRef(
+  snapshot: Snapshot,
+  runId: string,
+  loopNode: { output?: { from: string } },
+  loopId: string,
+  iteration: number,
+): OutputRef | undefined {
+  const from = loopNode.output?.from;
+  if (!from) return undefined;
+  const bodyWorkActId = loopWorkActivityId(runId, loopId, iteration, from);
+  return snapshot.outputs.get(bodyWorkActId);
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
@@ -417,9 +832,19 @@ function deriveErrorClass(activity: {
 }
 
 function findSinks(def: WorkflowDefinition): string[] {
+  const bodyOwner = buildBodyOwnerMap(def);
+  // Only consider top-level (non-body) nodes when computing sinks.  Body
+  // nodes are dispatched by their owning loop block; the outside view of
+  // a loop is "the loop block itself produces output" so body nodes must
+  // never count as workflow-level sinks even if no peer depends on them
+  // directly.  (`reviewDecision` is the canonical example — nothing
+  // outside the loop depends on it, but it's structurally internal.)
   const referenced = new Set<string>();
-  for (const node of Object.values(def.nodes)) {
+  for (const [id, node] of Object.entries(def.nodes)) {
+    if (bodyOwner.has(id)) continue;
     for (const dep of node.depends ?? []) referenced.add(dep);
   }
-  return Object.keys(def.nodes).filter((id) => !referenced.has(id));
+  return Object.keys(def.nodes).filter(
+    (id) => !bodyOwner.has(id) && !referenced.has(id),
+  );
 }

--- a/src/workflows/output-binding.ts
+++ b/src/workflows/output-binding.ts
@@ -38,8 +38,9 @@ import { promises as fs } from 'node:fs';
 
 import type { WorkflowDefinition } from './definition.js';
 import type { EventLog } from './events/append.js';
+import type { OutputRef } from './events/payloads.js';
 import type { Snapshot } from './events/replay.js';
-import { workActivityId } from './orchestrator.js';
+import { parseActivityId, workActivityId } from './orchestrator.js';
 
 export class BindingError extends Error {
   constructor(message: string) {
@@ -49,11 +50,13 @@ export class BindingError extends Error {
 }
 
 export type ParsedRef = {
+  kind: 'output' | 'params' | 'previous';
   nodeId: string;
   pathSegments: string[];
 };
 
 const REF_MARKER = '.output.';
+const PREVIOUS_MARKER = '.previous.';
 const PARAMS_PREFIX = 'params.';
 const SEGMENT_PATTERN = /^[A-Za-z0-9_-]+$/;
 const FORBIDDEN_SEGMENTS = new Set(['__proto__', 'prototype', 'constructor']);
@@ -62,11 +65,23 @@ export function parseRef(ref: string): ParsedRef {
   const idx = ref.indexOf(REF_MARKER);
   if (idx < 0 && ref.startsWith(PARAMS_PREFIX)) {
     const rawPath = ref.slice(PARAMS_PREFIX.length);
-    return { nodeId: 'params', pathSegments: parsePathSegments(rawPath, ref) };
+    return { kind: 'params', nodeId: 'params', pathSegments: parsePathSegments(rawPath, ref) };
+  }
+  const previousIdx = ref.indexOf(PREVIOUS_MARKER);
+  if (idx < 0 && previousIdx >= 0) {
+    const nodeId = ref.slice(0, previousIdx);
+    if (!nodeId) {
+      throw new BindingError(`$ref '${ref}' has empty nodeId before '.previous.'`);
+    }
+    const rawPath = ref.slice(previousIdx + PREVIOUS_MARKER.length);
+    if (!rawPath) {
+      throw new BindingError(`$ref '${ref}' has empty path after '.previous.'`);
+    }
+    return { kind: 'previous', nodeId, pathSegments: parsePathSegments(rawPath, ref) };
   }
   if (idx < 0) {
     throw new BindingError(
-      `$ref '${ref}' missing '.output.' separator (expected '<nodeId>.output.<path>' or 'params.<path>')`,
+      `$ref '${ref}' missing '.output.' separator (expected '<nodeId>.output.<path>', '<nodeId>.previous.<path>', or 'params.<path>')`,
     );
   }
   const nodeId = ref.slice(0, idx);
@@ -78,7 +93,7 @@ export function parseRef(ref: string): ParsedRef {
     throw new BindingError(`$ref '${ref}' has empty path after '.output.'`);
   }
   const segments = parsePathSegments(rawPath, ref);
-  return { nodeId, pathSegments: segments };
+  return { kind: 'output', nodeId, pathSegments: segments };
 }
 
 function parsePathSegments(rawPath: string, ref: string): string[] {
@@ -115,15 +130,21 @@ export type BindingContext = {
   def: WorkflowDefinition;
   log: EventLog;
   loadParams?: () => Promise<Record<string, unknown>>;
+  loopContext?: {
+    loopId: string;
+    iteration: number;
+  };
 };
 
 export async function resolveOutputRef(
   ref: string,
   ctx: BindingContext,
+  options?: { allowMissingPrevious?: boolean },
 ): Promise<unknown> {
-  const { nodeId, pathSegments } = parseRef(ref);
+  const parsed = parseRef(ref);
+  const { kind, nodeId, pathSegments } = parsed;
 
-  if (nodeId === 'params' && !ref.includes(REF_MARKER)) {
+  if (kind === 'params') {
     const params = await loadRunParams(ref, ctx);
     return walkPath(params, pathSegments, ref);
   }
@@ -135,8 +156,9 @@ export async function resolveOutputRef(
     );
   }
 
-  const actId = workActivityId(ctx.snapshot.run.runId, nodeId);
-  const outputRef = ctx.snapshot.outputs.get(actId);
+  const outputRef = kind === 'previous'
+    ? findPreviousLoopOutputRef(ref, nodeId, ctx, options)
+    : findLatestOutputRef(nodeId, ctx);
   if (!outputRef) {
     throw new BindingError(
       `$ref '${ref}' references node '${nodeId}' which has not produced a successful output yet`,
@@ -168,11 +190,61 @@ export async function resolveOutputRef(
   // bare `output` payload.  The `.output.` prefix in `$ref` syntax means
   // "the logical output side" — for hostExecutor we go through the
   // wrapping `output` key, for subagent we walk directly.
-  const root = nodeDef.type === 'hostExecutor'
+  const logicalNodeDef = nodeDef.type === 'loop' && nodeDef.output
+    ? ctx.def.nodes[nodeDef.output.from] ?? nodeDef
+    : nodeDef;
+  const root = logicalNodeDef.type === 'hostExecutor'
     ? (blob as { output?: unknown })?.output
     : blob;
 
   return walkPath(root, pathSegments, ref);
+}
+
+function findLatestOutputRef(nodeId: string, ctx: BindingContext): OutputRef | undefined {
+  const plain = ctx.snapshot.outputs.get(workActivityId(ctx.snapshot.run.runId, nodeId));
+  if (plain) return plain;
+  return findLoopOutputRef(nodeId, ctx);
+}
+
+function findPreviousLoopOutputRef(
+  ref: string,
+  nodeId: string,
+  ctx: BindingContext,
+  options?: { allowMissingPrevious?: boolean },
+): OutputRef | undefined {
+  if (!ctx.loopContext) {
+    throw new BindingError(
+      `$ref '${ref}' uses '.previous.' outside a loop iteration context`,
+    );
+  }
+  if (ctx.loopContext.iteration <= 1) {
+    if (options?.allowMissingPrevious) return undefined;
+    throw new BindingError(`$ref '${ref}' has no previous iteration for iteration 1`);
+  }
+  return findLoopOutputRef(nodeId, ctx, ctx.loopContext.loopId, ctx.loopContext.iteration - 1);
+}
+
+function findLoopOutputRef(
+  nodeId: string,
+  ctx: BindingContext,
+  loopId?: string,
+  iteration?: number,
+): OutputRef | undefined {
+  let best: { iteration: number; outputRef: OutputRef } | undefined;
+  for (const [activityId, outputRef] of ctx.snapshot.outputs.entries()) {
+    const parsed = parseActivityId(activityId);
+    if (!parsed || parsed.kind !== 'loop') continue;
+    if (parsed.nodeId !== nodeId) continue;
+    const nodeDef = ctx.def.nodes[nodeId];
+    const expectedKind = nodeDef?.type === 'decision' ? 'gate' : 'work';
+    if (parsed.activityKind !== expectedKind) continue;
+    if (loopId !== undefined && parsed.loopId !== loopId) continue;
+    if (iteration !== undefined && parsed.iteration !== iteration) continue;
+    if (!best || parsed.iteration > best.iteration) {
+      best = { iteration: parsed.iteration, outputRef };
+    }
+  }
+  return best?.outputRef;
 }
 
 async function loadRunParams(ref: string, ctx: BindingContext): Promise<Record<string, unknown>> {
@@ -296,7 +368,14 @@ async function interpolateStringRefs(value: string, ctx: BindingContext): Promis
     if (!ref) {
       throw new BindingError(`empty string ref interpolation in '${value}'`);
     }
-    const resolved = await resolveOutputRef(ref, ctx);
+    const parsed = parseRef(ref);
+    const resolved = parsed.kind === 'previous' && ctx.loopContext?.iteration === 1
+      ? undefined
+      : await resolveOutputRef(ref, ctx, { allowMissingPrevious: true });
+    if (resolved === undefined && parsed.kind === 'previous') {
+      cursor = end + 1;
+      continue;
+    }
     out += stringifyInterpolatedValue(ref, resolved);
     cursor = end + 1;
   }

--- a/src/workflows/runtime.ts
+++ b/src/workflows/runtime.ts
@@ -42,13 +42,14 @@ import type {
   RunSucceededEvent,
   WaitCreatedEvent,
 } from './events/types.js';
-import type {
-  CompleteNodeFailedAction,
-  CompleteNodeSucceededAction,
-  CompleteRunFailedAction,
-  CompleteRunSucceededAction,
-  DispatchGateAction,
-  DispatchWorkAction,
+import {
+  parseActivityId,
+  type CompleteNodeFailedAction,
+  type CompleteNodeSucceededAction,
+  type CompleteRunFailedAction,
+  type CompleteRunSucceededAction,
+  type DispatchGateAction,
+  type DispatchWorkAction,
 } from './orchestrator.js';
 import { createWait } from './wait.js';
 import { executeSideEffect } from './hostExecutors/protocol.js';
@@ -254,8 +255,19 @@ async function resolveWorkflowIdentity(
 function bindingContext(
   ctx: WorkflowRuntimeContext,
   snapshot: Snapshot,
+  activityId?: string,
 ): BindingContext {
   let paramsPromise: Promise<Record<string, unknown>> | undefined;
+  // Loop body nodes need their iteration coordinates surfaced to the
+  // binder so `${node.previous.x}` resolves against the prior iteration.
+  // Caller dispatch sites (dispatchWork / dispatchHumanGate / hostExecutor
+  // path) pass `action.activityId`; parseActivityId picks loop kind and
+  // we forward { loopId, iteration }.  Plain activityIds leave
+  // loopContext undefined and `.previous.` still fails-loud as designed.
+  const parsed = activityId ? parseActivityId(activityId) : undefined;
+  const loopContext = parsed?.kind === 'loop'
+    ? { loopId: parsed.loopId, iteration: parsed.iteration }
+    : undefined;
   return {
     snapshot,
     def: ctx.def,
@@ -264,6 +276,7 @@ function bindingContext(
       paramsPromise ??= loadRunParamsFromSnapshot(snapshot);
       return paramsPromise;
     },
+    loopContext,
   };
 }
 
@@ -372,7 +385,7 @@ export async function dispatchGate(
   try {
     resolvedPrompt = await resolveBoundString(
       action.humanGate.prompt,
-      bindingContext(ctx, options.snapshot ?? replay(await ctx.log.readAll())),
+      bindingContext(ctx, options.snapshot ?? replay(await ctx.log.readAll()), action.activityId),
     );
   } catch (err) {
     if (err instanceof BindingError) {
@@ -546,6 +559,7 @@ export async function dispatchWork(
   const bindingCtx = bindingContext(
     ctx,
     options.snapshot ?? replay(await ctx.log.readAll()),
+    action.activityId,
   );
 
   if (node.type === 'loop' || node.type === 'decision') {

--- a/src/workflows/runtime.ts
+++ b/src/workflows/runtime.ts
@@ -34,6 +34,7 @@ import { replay, type Snapshot } from './events/replay.js';
 import type {
   ActivityFailedEvent,
   AttemptCreatedEvent,
+  LoopFinishedEvent,
   NodeFailedEvent,
   NodeSucceededEvent,
   RunCanceledEvent,
@@ -885,8 +886,12 @@ async function findRootCauseEventId(
   const events = await ctx.log.readAll();
   // Prefer the activityFailed under the failed node's last activity.
   // Fall back to the nodeFailed event itself (always exists by now).
+  // For loop block failures (v0.2): loop blocks have no own attempts /
+  // nodeFailed; the `loopFinished` event is the authoritative root
+  // cause of a loop-level failure (codex Step 3 review Blocker 2).
   let nodeFailedEventId: string | undefined;
   let activityFailedEventId: string | undefined;
+  let loopFinishedEventId: string | undefined;
   const nodeActivities = new Set<string>();
   for (const e of events) {
     if (e.type === 'attemptCreated') {
@@ -902,9 +907,19 @@ async function findRootCauseEventId(
       if (!('ref' in p) && p.nodeId === nodeId) {
         nodeFailedEventId = e.eventId;
       }
+    } else if (e.type === 'loopFinished') {
+      const p = (e as LoopFinishedEvent).payload;
+      if (!('ref' in p) && p.loopId === nodeId && p.resolution !== 'approved') {
+        loopFinishedEventId = e.eventId;
+      }
     }
   }
-  return activityFailedEventId ?? nodeFailedEventId ?? events[0]!.eventId;
+  return (
+    activityFailedEventId ??
+    nodeFailedEventId ??
+    loopFinishedEventId ??
+    events[0]!.eventId
+  );
 }
 
 export async function completeRunFailed(

--- a/src/workflows/runtime.ts
+++ b/src/workflows/runtime.ts
@@ -547,6 +547,19 @@ export async function dispatchWork(
     options.snapshot ?? replay(await ctx.log.readAll()),
   );
 
+  if (node.type === 'loop' || node.type === 'decision') {
+    // v0.2 schema introduced these node types but their dispatch is
+    // owned by the loop runtime executor (Step 3 of
+    // feat/workflow-loop-v02; see /tmp/wf-loop-v02.md §13).  The
+    // orchestrator (`decideNextActions`) skips them so we should never
+    // get here in Step 1; throw fail-loud rather than silently no-op so
+    // any regression is caught immediately in tests.
+    throw new Error(
+      `dispatchWork received unexpected node type '${node.type}' for node '${action.nodeId}' ` +
+      `(loop runtime not yet wired in Step 1; orchestrator should intercept upstream)`,
+    );
+  }
+
   if (node.type === 'hostExecutor') {
     // attemptCreated carries the RAW (pre-binding) input.  Operator-side
     // debug can see the literal `$ref` the author wrote, while the

--- a/src/workflows/wait.ts
+++ b/src/workflows/wait.ts
@@ -221,7 +221,11 @@ export async function resolveWait(
             externalRefs: {
               resolution: input.resolution,
               by: input.by,
-              ...(input.comment ? { comment: input.comment } : {}),
+              // Always materialize `comment` (empty string when missing) so
+              // downstream `${node.output.comment}` / `${node.previous.comment}`
+              // bindings don't hit BindingError on the natural "approve/reject
+              // without note" interaction. input.output may override.
+              comment: input.comment ?? '',
               ...(input.output ?? {}),
             },
           },

--- a/src/workflows/wait.ts
+++ b/src/workflows/wait.ts
@@ -40,6 +40,7 @@ import type {
 } from './events/types.js';
 import type { WorkflowDefinition } from './definition.js';
 import { parseActivityId } from './orchestrator.js';
+import { writeJsonBlob } from './blob.js';
 
 // ─── Public types ───────────────────────────────────────────────────────────
 
@@ -304,8 +305,14 @@ async function writeWaitTerminal(
 ): Promise<ActivitySucceededEvent | ActivityFailedEvent> {
   if (spec.kind.tag === 'succeeded') {
     const externalRefs = spec.kind.externalRefs;
-    const outputBuf = Buffer.from(JSON.stringify(externalRefs), 'utf-8');
-    const outputHash = await sha256Hex(outputBuf);
+    // Persist externalRefs as a real blob so `${node.output.x}` /
+    // `${node.previous.x}` binding can read the resolution payload.
+    // Plain wait approve also benefits — downstream nodes can now read
+    // `${gate.output.resolution}` without falling back to externalRefs.
+    // (Previously we hand-rolled an OutputRef without `outputPath`,
+    // which made the binding layer fail-loud on decision `previous`
+    // references — codex Step 3 review Blocker 1.)
+    const outputRef = await writeJsonBlob(log, externalRefs);
     return (await log.append({
       runId: log.runId,
       type: 'activitySucceeded',
@@ -313,12 +320,7 @@ async function writeWaitTerminal(
       payload: {
         activityId: spec.activityId,
         attemptId: spec.attemptId,
-        outputRef: {
-          outputHash: `sha256:${outputHash}`,
-          outputBytes: outputBuf.length,
-          outputSchemaVersion: 1,
-          contentType: 'application/json',
-        },
+        outputRef,
         externalRefs,
       },
     })) as ActivitySucceededEvent;
@@ -337,9 +339,4 @@ async function writeWaitTerminal(
       },
     },
   })) as ActivityFailedEvent;
-}
-
-async function sha256Hex(buf: Buffer): Promise<string> {
-  const { createHash } = await import('node:crypto');
-  return createHash('sha256').update(buf).digest('hex');
 }

--- a/src/workflows/wait.ts
+++ b/src/workflows/wait.ts
@@ -38,6 +38,8 @@ import type {
   WaitDeadlineExceededEvent,
   WaitResolvedEvent,
 } from './events/types.js';
+import type { WorkflowDefinition } from './definition.js';
+import { parseActivityId } from './orchestrator.js';
 
 // ─── Public types ───────────────────────────────────────────────────────────
 
@@ -103,6 +105,21 @@ export type ExpireWaitInput = {
 export type ResolveWaitResult = {
   resolutionEvent: WaitResolvedEvent;
   terminalEvent: ActivitySucceededEvent | ActivityFailedEvent;
+  /** Convenience surface of the resolution event's eventId — useful as
+   *  the loop runtime's `waitResolvedEventId` audit anchor without
+   *  reaching into `.resolutionEvent.eventId`. */
+  waitResolvedEventId: string;
+};
+
+/**
+ * Optional context for resolveWait.  When `def` is supplied, resolveWait
+ * recognises `decision` nodes (v0.2 loop terminators) and writes their
+ * terminal as `activitySucceeded` with a fixed `{resolution, by, comment?}`
+ * output blob — including the `rejected` case, which for plain nodes
+ * still maps to `activityFailed`.  See /tmp/wf-loop-v02.md §4.3 N2.
+ */
+export type ResolveWaitContext = {
+  def?: WorkflowDefinition;
 };
 
 export type ExpireWaitResult = {
@@ -149,14 +166,21 @@ export async function createWait(
 /**
  * Close a wait via external decision.  Writes `waitResolved` followed
  * by the activity terminal.  The terminal mapping is fixed by spec
- * §2.4:
+ * §2.4 for plain nodes:
  *   - approved → activitySucceeded
  *   - rejected → activityFailed { InputValidationFailed, userFault }
  *   - external → activitySucceeded { externalRefs.resolution='external' }
+ *
+ * For v0.2 `decision` nodes (loop terminators), the mapping is different:
+ * BOTH approve and reject resolve to `activitySucceeded` with a fixed
+ * `{resolution, by, comment?}` output blob — rejection is a legal
+ * decision output, not a failure.  Pass `ctx.def` so resolveWait can
+ * look up the node type via `parseActivityId(activityId).nodeId`.
  */
 export async function resolveWait(
   log: EventLog,
   input: ResolveWaitInput,
+  ctx?: ResolveWaitContext,
 ): Promise<ResolveWaitResult> {
   const resolutionEvent = (await log.append({
     runId: log.runId,
@@ -170,11 +194,19 @@ export async function resolveWait(
     },
   })) as WaitResolvedEvent;
 
+  // v0.2: detect decision node so reject doesn't go through activityFailed.
+  const isDecisionNode = (() => {
+    if (!ctx?.def) return false;
+    const parsed = parseActivityId(input.activityId);
+    if (!parsed) return false;
+    return ctx.def.nodes[parsed.nodeId]?.type === 'decision';
+  })();
+
   const terminalEvent = await writeWaitTerminal(log, {
     activityId: input.activityId,
     attemptId: input.attemptId,
     kind:
-      input.resolution === 'rejected'
+      input.resolution === 'rejected' && !isDecisionNode
         ? {
             tag: 'failed',
             errorCode: 'InputValidationFailed',
@@ -194,7 +226,11 @@ export async function resolveWait(
           },
   });
 
-  return { resolutionEvent, terminalEvent };
+  return {
+    resolutionEvent,
+    terminalEvent,
+    waitResolvedEventId: resolutionEvent.eventId,
+  };
 }
 
 // ─── expireWait ────────────────────────────────────────────────────────────

--- a/test/dashboard-auth.test.ts
+++ b/test/dashboard-auth.test.ts
@@ -88,6 +88,33 @@ describe('decideDashboardAuth — public surface', () => {
     expect(d.kind).toBe('allow');
   });
 
+  it('GET /api/workflows/runs/.../terminal-log/raw — NOT public (PTY bytes)', () => {
+    // PTY transcript may have logged API keys / env / token reads that
+    // happened to scroll the terminal — keep it behind cookie auth even
+    // though sibling workflow read paths are link-shareable.
+    const d = decideDashboardAuth({
+      method: 'GET',
+      pathname:
+        '/api/workflows/runs/run-1/attempts/att-1/node-a/terminal-log/raw',
+      hasTokenParam: false,
+      presentedToken: undefined,
+      activeToken: TOK,
+    });
+    expect(d.kind).toBe('deny401');
+  });
+
+  it('GET /api/workflows/...terminal-log/raw with valid cookie → allow', () => {
+    const d = decideDashboardAuth({
+      method: 'GET',
+      pathname:
+        '/api/workflows/runs/run-1/attempts/att-1/node-a/terminal-log/raw',
+      hasTokenParam: false,
+      presentedToken: TOK,
+      activeToken: TOK,
+    });
+    expect(d.kind).toBe('allow');
+  });
+
   it('GET / — static SPA shell allow without any token', () => {
     const d = decideDashboardAuth({
       method: 'GET',

--- a/test/dashboard-workflow-api.test.ts
+++ b/test/dashboard-workflow-api.test.ts
@@ -123,6 +123,87 @@ describe('dashboard workflow API routes', () => {
     ]);
   });
 
+  it('GET /snapshot strips io.log.text for unauth\'d callers but keeps it for auth\'d', async () => {
+    // Seed a succeeded run with a terminal.log carrying a fake secret.
+    await seedSucceededRun('api-secret-01', DONE_DEF);
+    // The runtime helpers in this test seed the events but don't actually
+    // write per-attempt terminal.log files — synthesize one so the
+    // projection has bytes to scrub.
+    const snapPeek = await fetch(`${baseUrl}/api/workflows/runs/api-secret-01/snapshot`, {
+      headers: { 'x-test-authed': '1' },
+    });
+    const snapPeekBody = await snapPeek.json() as {
+      attemptIO: Record<string, { input?: unknown }>;
+    };
+    const attemptId = Object.keys(snapPeekBody.attemptIO)[0];
+    expect(attemptId).toBeTruthy();
+    // attemptId format: <runId>::work::<node>::att-N → strip the att-N suffix
+    // to recover the parent activityId for the on-disk attempts directory.
+    const activityId = attemptId.split('::att-')[0];
+    const attemptDir = join(
+      runsDir,
+      'api-secret-01',
+      'attempts',
+      activityId,
+      attemptId,
+    );
+    await mkdir(attemptDir, { recursive: true });
+    await writeFile(
+      join(attemptDir, 'terminal.log'),
+      '[ts] stderr LEAKED_TOKEN=sk-fake-must-not-leak\n',
+    );
+    await writeFile(
+      join(attemptDir, 'terminal.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        sessionId: 'wf-api-secret',
+        webPort: 32999,
+        status: 'closed',
+        cliId: 'claude-code',
+        logPath: join(attemptDir, 'terminal.log'),
+        startedAt: 1,
+        updatedAt: 2,
+      }),
+    );
+
+    // Unauthenticated public read — log bytes must be stripped, metadata kept.
+    const unauthRes = await fetch(
+      `${baseUrl}/api/workflows/runs/api-secret-01/snapshot`,
+    );
+    expect(unauthRes.status).toBe(200);
+    const unauth = await unauthRes.json() as {
+      attemptIO: Record<string, {
+        log?: { text?: string; redacted?: boolean; outputBytes?: number };
+        terminal?: { logPath?: string; sessionId?: string; webPort?: number };
+      }>;
+    };
+    const unauthIO = unauth.attemptIO[attemptId];
+    expect(unauthIO?.log?.text).toBeUndefined();
+    expect(unauthIO?.log?.redacted).toBe(true);
+    expect(unauthIO?.log?.outputBytes).toBeGreaterThan(0);
+    expect(unauthIO?.terminal?.logPath).toBeUndefined();
+    expect(unauthIO?.terminal?.sessionId).toBe('wf-api-secret');
+    expect(unauthIO?.terminal?.webPort).toBe(32999);
+
+    // Authenticated read still sees the full log + logPath — same data
+    // a logged-in `botmux dashboard` user has always seen.
+    const authRes = await fetch(
+      `${baseUrl}/api/workflows/runs/api-secret-01/snapshot`,
+      { headers: { 'x-test-authed': '1' } },
+    );
+    expect(authRes.status).toBe(200);
+    const authed = await authRes.json() as {
+      attemptIO: Record<string, {
+        log?: { text?: string; redacted?: boolean };
+        terminal?: { logPath?: string };
+      }>;
+    };
+    const authedIO = authed.attemptIO[attemptId];
+    expect(authedIO?.log?.text).toContain('LEAKED_TOKEN=sk-fake-must-not-leak');
+    expect(authedIO?.log?.redacted).toBeUndefined();
+    expect(authedIO?.terminal?.logPath).toBe(join(attemptDir, 'terminal.log'));
+  });
+
   it('short-circuits cancel for terminal runs without proxying to daemon', async () => {
     await seedSucceededRun('api-done-01', DONE_DEF);
 
@@ -641,7 +722,13 @@ async function startWorkflowApiServer(deps: WorkflowApiDeps): Promise<{
   const server = createServer(async (req, res) => {
     try {
       const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
-      if (await handleWorkflowApi(req, res, url, deps)) return;
+      // Test seam: `x-test-authed: 1` request header simulates a logged-in
+      // dashboard session for tests that want to verify the auth-gated
+      // branch (e.g. snapshot scrub).  Default (no header) mirrors a
+      // public-read request that came in via the `decideDashboardAuth`
+      // carve-out — same auth posture as a Lark card recipient.
+      const isAuthed = req.headers['x-test-authed'] === '1';
+      if (await handleWorkflowApi(req, res, url, deps, isAuthed)) return;
       jsonRes(res, 404, { error: 'not_found' });
     } catch (err) {
       jsonRes(res, 500, { error: String(err) });

--- a/test/workflow-approval-card.test.ts
+++ b/test/workflow-approval-card.test.ts
@@ -20,6 +20,9 @@ import {
   handleWorkflowApprovalAction,
   workflowFrozenStoreId,
 } from '../src/im/lark/workflow-card-handler.js';
+import { parseWorkflowDefinition } from '../src/workflows/definition.js';
+import { snapshotWorkflowDefinition } from '../src/workflows/loader.js';
+import { loopGateActivityId } from '../src/workflows/orchestrator.js';
 
 const RUN_ID = 'run-approval-card-01';
 const ACTIVITY_ID = 'act-approval';
@@ -435,5 +438,105 @@ describe('handleWorkflowApprovalAction', () => {
     expect(second).toMatchObject({ ok: true, duplicate: true });
     expect(requestCancelFn).toHaveBeenCalledTimes(1);
     expect(resolveWaitFn).not.toHaveBeenCalled();
+  });
+
+  // v0.2: reject on a `decision` node must write activitySucceeded so the
+  // loop body continues into iteration N+1 (rejection is a legal decision
+  // output, not a wait failure).  Regression for the dogfood crash where
+  // card-handler.ts called resolveWait WITHOUT ctx.def, so isDecisionNode
+  // stayed false → reject wrote activityFailed → orchestrator closed the
+  // loop with `body-failed`.  This pins card-handler to load the run's
+  // workflow.json snapshot and pass it through.
+  it('decision-node reject writes activitySucceeded (loop body proceeds to iter N+1)', async () => {
+    const LOOP_ID = 'review-loop';
+    const ITER = 1;
+    const NODE = 'reviewDecision';
+    const decisionActivityId = loopGateActivityId(RUN_ID, LOOP_ID, ITER, NODE);
+    const decisionAttemptId = `${decisionActivityId}::att-1`;
+
+    // Snapshot a minimal loop def into the run dir so card-handler can load it.
+    const def = parseWorkflowDefinition({
+      workflowId: 'trip-planner',
+      version: 1,
+      nodes: {
+        implement: { type: 'subagent', bot: 'cli_a', prompt: 'impl' },
+        review: { type: 'subagent', bot: 'cli_b', depends: ['implement'], prompt: 'rev' },
+        reviewDecision: {
+          type: 'decision',
+          depends: ['review'],
+          humanGate: { stage: 'before', prompt: 'approve?' },
+        },
+        [LOOP_ID]: {
+          type: 'loop',
+          maxIterations: 3,
+          body: ['implement', 'review', 'reviewDecision'],
+          terminate: { node: 'reviewDecision', via: 'humanGate' },
+          output: { from: 'implement' },
+        },
+      },
+    });
+    await snapshotWorkflowDefinition(RUN_ID, def, { runsDir: baseDir });
+
+    // Bootstrap a waitCreated on the loop gate activity id.
+    await log.append(runCreated);
+    await log.append({
+      runId: RUN_ID,
+      type: 'attemptCreated',
+      actor: 'scheduler',
+      payload: {
+        nodeId: NODE,
+        activityId: decisionActivityId,
+        attemptId: decisionAttemptId,
+        attemptNumber: 1,
+        inputRef: sampleOutputRef,
+      },
+    });
+    await createWait(log, {
+      activityId: decisionActivityId,
+      attemptId: decisionAttemptId,
+      nodeId: NODE,
+      waitKind: 'human-gate',
+      deadlineAt: 2_000_000_000_000,
+      prompt: 'approve?',
+    });
+
+    const cardNonce = workflowApprovalCardNonce(RUN_ID, decisionActivityId, decisionAttemptId);
+    await handleWorkflowApprovalAction(
+      {
+        operator: { open_id: 'ou_approver' },
+        action: {
+          value: {
+            action: WORKFLOW_REJECT_ACTION,
+            run_id: RUN_ID,
+            activity_id: decisionActivityId,
+            attempt_id: decisionAttemptId,
+            card_nonce: cardNonce,
+          },
+          form_value: { [WORKFLOW_COMMENT_FIELD]: 'add error handling' },
+        },
+        context: { open_message_id: 'om_card_reject' },
+      },
+      {
+        runsDir: baseDir,
+        loadFrozenCardsFn: () => new Map(),
+        saveFrozenCardsFn: () => undefined,
+      },
+    );
+
+    const events = await log.readAll();
+    const terminal = events.find(
+      (e) =>
+        (e.type === 'activitySucceeded' || e.type === 'activityFailed') &&
+        (e.payload as any).activityId === decisionActivityId,
+    );
+    expect(terminal?.type).toBe('activitySucceeded');
+    // The reject comment is captured in externalRefs.comment so the next
+    // iteration's `${reviewDecision.previous.comment}` binding can read it.
+    const externalRefs = (terminal?.payload as any)?.externalRefs;
+    expect(externalRefs).toMatchObject({
+      resolution: 'rejected',
+      by: 'ou_approver',
+      comment: 'add error handling',
+    });
   });
 });

--- a/test/workflow-definition.test.ts
+++ b/test/workflow-definition.test.ts
@@ -4,6 +4,7 @@ import {
   computeRevisionId,
   parseWorkflowDefinition,
   topologicalOrder,
+  validateLoopBlocks,
   WorkflowDefinitionSchema,
   type WorkflowDefinition,
 } from '../src/workflows/definition.js';
@@ -396,5 +397,332 @@ describe('topologicalOrder', () => {
     expect(order[order.length - 1]).toBe('sink');
     expect(order.indexOf('left')).toBeLessThan(order.indexOf('sink'));
     expect(order.indexOf('right')).toBeLessThan(order.indexOf('sink'));
+  });
+});
+
+// ─── loop / decision schema + validateLoopBlocks (v0.2) ────────────────────
+//
+// Step 1 of feat/workflow-loop-v02 — see /tmp/wf-loop-v02.md §3 + §13.
+// Locks the cross-field invariants so Step 2/3 implementers can rely on
+// any def that survives `parseWorkflowDefinition` being well-formed.
+
+function loopFixture(extra: Record<string, unknown> = {}): any {
+  return {
+    workflowId: 'code-review-loop',
+    version: 1,
+    nodes: {
+      implement: {
+        type: 'subagent',
+        bot: 'b',
+        prompt: 'implement task',
+      },
+      review: {
+        type: 'subagent',
+        bot: 'b',
+        depends: ['implement'],
+        prompt: 'review ${implement.output.code}',
+      },
+      reviewDecision: {
+        type: 'decision',
+        depends: ['review'],
+        humanGate: {
+          stage: 'before',
+          prompt: { $ref: 'review.output.preview' },
+        },
+      },
+      'review-loop': {
+        type: 'loop',
+        maxIterations: 3,
+        body: ['implement', 'review', 'reviewDecision'],
+        terminate: { node: 'reviewDecision', via: 'humanGate' },
+        output: { from: 'implement' },
+      },
+      publish: {
+        type: 'subagent',
+        bot: 'b',
+        depends: ['review-loop'],
+        prompt: 'announce ${review-loop.output.code}',
+      },
+      ...extra,
+    },
+  };
+}
+
+describe('loop / decision schema (parse-time strict)', () => {
+  it('accepts a valid loop + decision + body fixture', () => {
+    const def = parseWorkflowDefinition(loopFixture());
+    expect(def.nodes['review-loop']!.type).toBe('loop');
+    expect(def.nodes.reviewDecision!.type).toBe('decision');
+  });
+
+  it('rejects unknown extra fields on a loop node (strict)', () => {
+    const raw = loopFixture();
+    raw.nodes['review-loop'].weird = 1;
+    expect(() => parseWorkflowDefinition(raw)).toThrow();
+  });
+
+  it('rejects unknown extra fields on a decision node (strict)', () => {
+    const raw = loopFixture();
+    raw.nodes.reviewDecision.outputSchema = { type: 'object' };
+    // codex round 2 N2: decision output is runtime-fixed; author writing
+    // `outputSchema` / `prompt` / `bot` / `executor` must fail-loud, not
+    // silently drop.
+    expect(() => parseWorkflowDefinition(raw)).toThrow();
+  });
+
+  it('rejects decision node with prompt / bot / executor fields', () => {
+    for (const field of ['prompt', 'bot', 'executor', 'input']) {
+      const raw = loopFixture();
+      raw.nodes.reviewDecision[field] = 'x';
+      expect(
+        () => parseWorkflowDefinition(raw),
+        `decision with .${field} should be rejected`,
+      ).toThrow();
+    }
+  });
+
+  it('rejects decision node without humanGate', () => {
+    const raw = loopFixture();
+    delete raw.nodes.reviewDecision.humanGate;
+    expect(() => parseWorkflowDefinition(raw)).toThrow();
+  });
+
+  it('rejects loop.maxIterations <= 0', () => {
+    const raw = loopFixture();
+    raw.nodes['review-loop'].maxIterations = 0;
+    expect(() => parseWorkflowDefinition(raw)).toThrow();
+  });
+
+  it('rejects loop.body referencing unknown node', () => {
+    const raw = loopFixture();
+    raw.nodes['review-loop'].body = ['implement', 'review', 'no-such-node'];
+    expect(() => parseWorkflowDefinition(raw)).toThrow(
+      /Loop 'review-loop'.*'no-such-node'/,
+    );
+  });
+
+  it('rejects empty body', () => {
+    const raw = loopFixture();
+    raw.nodes['review-loop'].body = [];
+    expect(() => parseWorkflowDefinition(raw)).toThrow();
+  });
+
+  it('rejects terminate.node not in body', () => {
+    const raw = loopFixture();
+    raw.nodes['review-loop'].terminate.node = 'implement';
+    raw.nodes['review-loop'].body = ['implement', 'review'];
+    // Now implement is not a decision; expect explicit error.
+    expect(() => parseWorkflowDefinition(raw)).toThrow(
+      /terminate\.node.*must be a decision/,
+    );
+  });
+
+  it('rejects terminate.node that is a subagent (not decision)', () => {
+    const raw = loopFixture();
+    raw.nodes['review-loop'].terminate.node = 'review';
+    expect(() => parseWorkflowDefinition(raw)).toThrow(
+      /terminate\.node 'review' must be a decision node/,
+    );
+  });
+
+  it('rejects loop block including itself in body', () => {
+    const raw = loopFixture();
+    raw.nodes['review-loop'].body = ['implement', 'review', 'reviewDecision', 'review-loop'];
+    expect(() => parseWorkflowDefinition(raw)).toThrow(
+      /body must not include the loop block itself/,
+    );
+  });
+
+  it('rejects a node owned by two loops', () => {
+    const raw = loopFixture();
+    raw.nodes['review-loop-2'] = {
+      type: 'loop',
+      maxIterations: 2,
+      body: ['implement', 'reviewDecision2'],
+      terminate: { node: 'reviewDecision2', via: 'humanGate' },
+    };
+    raw.nodes.reviewDecision2 = {
+      type: 'decision',
+      depends: ['implement'],
+      humanGate: { stage: 'before', prompt: 'ok?' },
+    };
+    expect(() => parseWorkflowDefinition(raw)).toThrow(
+      /'implement' is claimed by both/,
+    );
+  });
+
+  it('rejects nested loop in body (v0.2 not supported)', () => {
+    const raw = loopFixture();
+    raw.nodes.innerLoop = {
+      type: 'loop',
+      maxIterations: 2,
+      body: ['innerDecision'],
+      terminate: { node: 'innerDecision', via: 'humanGate' },
+    };
+    raw.nodes.innerDecision = {
+      type: 'decision',
+      humanGate: { stage: 'before', prompt: 'ok?' },
+    };
+    raw.nodes['review-loop'].body = ['implement', 'review', 'reviewDecision', 'innerLoop'];
+    expect(() => parseWorkflowDefinition(raw)).toThrow(
+      /nested loop 'innerLoop'.*not supported in v0\.2/,
+    );
+  });
+
+  it('rejects decision node not referenced by any loop', () => {
+    const raw = loopFixture();
+    raw.nodes.danglingDecision = {
+      type: 'decision',
+      humanGate: { stage: 'before', prompt: 'ok?' },
+    };
+    expect(() => parseWorkflowDefinition(raw)).toThrow(
+      /Decision node 'danglingDecision' is not referenced by any loop's body/,
+    );
+  });
+
+  it('rejects external dep not surfaced on loop.depends (codex N1)', () => {
+    // implement depends on `setup`, which is OUTSIDE the loop; but
+    // `review-loop` itself does not list `setup` in its own depends.
+    // Validator must demand explicit surfacing.
+    const raw = loopFixture();
+    raw.nodes.setup = { type: 'subagent', bot: 'b', prompt: 'setup' };
+    raw.nodes.implement.depends = ['setup'];
+    expect(() => parseWorkflowDefinition(raw)).toThrow(
+      /body node 'implement' depends on external node 'setup'.*add 'setup' to loop\.depends/,
+    );
+  });
+
+  it('accepts external dep when loop.depends surfaces it (codex N1 happy path)', () => {
+    const raw = loopFixture();
+    raw.nodes.setup = { type: 'subagent', bot: 'b', prompt: 'setup' };
+    raw.nodes.implement.depends = ['setup'];
+    raw.nodes['review-loop'].depends = ['setup'];
+    expect(() => parseWorkflowDefinition(raw)).not.toThrow();
+  });
+
+  it('rejects external node depending on a loop body node', () => {
+    // publish currently depends on the loop block — fine.  Change it to
+    // depend directly on `implement` (a body node) to trigger the
+    // external-depends-on-body guard.
+    const raw = loopFixture();
+    raw.nodes.publish.depends = ['implement'];
+    expect(() => parseWorkflowDefinition(raw)).toThrow(
+      /Node 'publish' depends on loop body node 'implement'/,
+    );
+  });
+
+  it('rejects loop.output.from referencing the terminator', () => {
+    const raw = loopFixture();
+    raw.nodes['review-loop'].output = { from: 'reviewDecision' };
+    expect(() => parseWorkflowDefinition(raw)).toThrow(
+      /output\.from 'reviewDecision' must not be the terminate\.node/,
+    );
+  });
+
+  it('rejects loop.output.from referencing a non-body node', () => {
+    const raw = loopFixture();
+    raw.nodes['review-loop'].output = { from: 'publish' };
+    expect(() => parseWorkflowDefinition(raw)).toThrow(
+      /output\.from 'publish' is not in body/,
+    );
+  });
+
+  it('root check ignores body-internal "no-deps" nodes', () => {
+    // `implement` has no deps but lives inside a loop body — it must
+    // not satisfy workflow-level root presence on its own.  Pull
+    // `publish` out so the only non-body candidate is the loop block,
+    // which DOES count as a valid scheduler-visible root (no deps).
+    const raw = loopFixture();
+    delete raw.nodes.publish;
+    expect(() => parseWorkflowDefinition(raw)).not.toThrow();
+  });
+
+  it('reports root failure when every non-body node has deps', () => {
+    // Construct a minimal case: just a loop block + an outer node that
+    // depends on the loop block (no roots outside the body).  This
+    // would have passed in v0.1 because `implement`-style body nodes
+    // counted as roots.
+    const raw: any = {
+      workflowId: 'wf-no-root',
+      version: 1,
+      nodes: {
+        implement: { type: 'subagent', bot: 'b', prompt: 'x' },
+        dec: {
+          type: 'decision',
+          depends: ['implement'],
+          humanGate: { stage: 'before', prompt: 'ok?' },
+        },
+        loop1: {
+          type: 'loop',
+          maxIterations: 2,
+          body: ['implement', 'dec'],
+          terminate: { node: 'dec', via: 'humanGate' },
+          depends: ['outerOnly'],
+        },
+        outerOnly: {
+          type: 'subagent',
+          bot: 'b',
+          prompt: 'x',
+          depends: ['loop1'],
+        },
+      },
+    };
+    // outerOnly depends on loop1, loop1 depends on outerOnly → cycle
+    // at top level (loop1 ↔ outerOnly).  We want the root-check error,
+    // not cycle — relax outerOnly to depend only on loop1 and add a
+    // sentinel non-root.  Simpler: construct purely root-less.
+    raw.nodes.loop1.depends = [];
+    raw.nodes.outerOnly.depends = ['loop1'];
+    // Now scheduler-visible roots: { loop1 }.  Loop block has no deps —
+    // so root check PASSES.  We've actually just covered the happy
+    // path; the body-only-root failure scenario already triggers via
+    // `loopFixture` minus all outer nodes (no outer node = body
+    // roots ignored = no-root error).
+    const onlyBody: any = {
+      workflowId: 'wf-only-body',
+      version: 1,
+      nodes: {
+        implement: { type: 'subagent', bot: 'b', prompt: 'x' },
+        dec: {
+          type: 'decision',
+          depends: ['implement'],
+          humanGate: { stage: 'before', prompt: 'ok?' },
+        },
+        loop1: {
+          type: 'loop',
+          maxIterations: 2,
+          body: ['implement', 'dec'],
+          terminate: { node: 'dec', via: 'humanGate' },
+          depends: ['absent-non-body'],
+        },
+      },
+    };
+    // depends on a non-existent node → caught earlier ("unknown node");
+    // adjust to depend on a real outer node that itself has deps.
+    onlyBody.nodes['absent-non-body'] = {
+      type: 'subagent', bot: 'b', prompt: 'x', depends: ['loop1'],
+    };
+    // Now there's a cycle (loop1 ↔ absent-non-body).  This is an
+    // intentional accumulator-style test; root-check failure is hard
+    // to reach without other guards firing first.  Validate that *some*
+    // error fires.
+    expect(() => parseWorkflowDefinition(onlyBody)).toThrow();
+  });
+});
+
+describe('validateLoopBlocks direct (returns body set)', () => {
+  it('returns body-node set for downstream use', () => {
+    const def = parseWorkflowDefinition(loopFixture());
+    const bodySet = validateLoopBlocks(def);
+    expect(bodySet.has('implement')).toBe(true);
+    expect(bodySet.has('review')).toBe(true);
+    expect(bodySet.has('reviewDecision')).toBe(true);
+    expect(bodySet.has('publish')).toBe(false);
+    expect(bodySet.has('review-loop')).toBe(false);
+  });
+
+  it('returns empty set when no loops', () => {
+    const def = parseWorkflowDefinition(tripPlannerFixture());
+    expect(validateLoopBlocks(def).size).toBe(0);
   });
 });

--- a/test/workflow-definition.test.ts
+++ b/test/workflow-definition.test.ts
@@ -760,6 +760,48 @@ describe('loop sink + decision-timeout validation (PR #47 round 2)', () => {
   });
 });
 
+// External-reviewer PR #47 round-3 finding: non-terminator decisions in
+// the body would be schema-legal but `wait.ts` decision-mode treats *any*
+// decision-typed node's reject as `activitySucceeded`, so the body would
+// silently continue past a "reject" the author intended to terminate the
+// loop.  validateLoopBlocks now enforces "exactly one decision per body,
+// which must equal terminate.node".
+describe('loop body single-decision enforcement (PR #47 round 3)', () => {
+  it('rejects body with two decision nodes (non-terminator silently swallows reject)', () => {
+    const raw = loopFixture();
+    // Inject a second decision node BEFORE the terminator.
+    raw.nodes.preDecision = {
+      type: 'decision',
+      depends: ['implement'],
+      humanGate: { stage: 'before', prompt: 'gate before review?' },
+    };
+    raw.nodes.review.depends = ['preDecision'];
+    raw.nodes['review-loop'].body = ['implement', 'preDecision', 'review', 'reviewDecision'];
+    expect(() => parseWorkflowDefinition(raw)).toThrow(
+      /Loop 'review-loop' body must contain exactly one decision node.*preDecision.*reviewDecision/s,
+    );
+  });
+
+  it('accepts body with exactly one decision == terminate.node (baseline)', () => {
+    const raw = loopFixture();
+    expect(() => parseWorkflowDefinition(raw)).not.toThrow();
+  });
+
+  it('error message points authors at subagent + humanGate for intermediate approvals', () => {
+    const raw = loopFixture();
+    raw.nodes.preDecision = {
+      type: 'decision',
+      depends: ['implement'],
+      humanGate: { stage: 'before', prompt: 'gate?' },
+    };
+    raw.nodes.review.depends = ['preDecision'];
+    raw.nodes['review-loop'].body = ['implement', 'preDecision', 'review', 'reviewDecision'];
+    expect(() => parseWorkflowDefinition(raw)).toThrow(
+      /subagent \+ humanGate for intermediate approvals/,
+    );
+  });
+});
+
 describe('validateLoopBlocks direct (returns body set)', () => {
   it('returns body-node set for downstream use', () => {
     const def = parseWorkflowDefinition(loopFixture());

--- a/test/workflow-definition.test.ts
+++ b/test/workflow-definition.test.ts
@@ -710,6 +710,56 @@ describe('loop / decision schema (parse-time strict)', () => {
   });
 });
 
+// Codex PR #47 round-2 finding #1 + #2 — schema-legal but runtime-broken
+// configurations that validateLoopBlocks now rejects at parse time.
+describe('loop sink + decision-timeout validation (PR #47 round 2)', () => {
+  it('rejects sink loop without output.from (no-progress hang)', () => {
+    const raw = loopFixture();
+    delete raw.nodes.publish; // remove the external dependent
+    delete raw.nodes['review-loop'].output; // and the output.from
+    expect(() => parseWorkflowDefinition(raw)).toThrow(
+      /Loop 'review-loop' has no external dependents.*output\.from/,
+    );
+  });
+
+  it('accepts non-sink loop without output.from (downstream exists)', () => {
+    // When `publish` depends on the loop, the loop is not a sink so
+    // `output.from` becomes optional.  This pins that the sink rule
+    // only fires for actual workflow sinks.
+    const raw = loopFixture();
+    delete raw.nodes['review-loop'].output;
+    raw.nodes.publish.prompt = 'announce'; // no longer references loop output
+    expect(() => parseWorkflowDefinition(raw)).not.toThrow();
+  });
+
+  it('accepts sink loop WITH output.from', () => {
+    const raw = loopFixture();
+    delete raw.nodes.publish;
+    // output.from already declared in loopFixture → loop is sink + declares output
+    expect(() => parseWorkflowDefinition(raw)).not.toThrow();
+  });
+
+  it("rejects decision node with humanGate.onTimeout='success'", () => {
+    const raw = loopFixture();
+    raw.nodes.reviewDecision.humanGate.onTimeout = 'success';
+    expect(() => parseWorkflowDefinition(raw)).toThrow(
+      /Decision node 'reviewDecision'.*onTimeout='success'.*not allowed/,
+    );
+  });
+
+  it("accepts decision node with humanGate.onTimeout='fail'", () => {
+    const raw = loopFixture();
+    raw.nodes.reviewDecision.humanGate.onTimeout = 'fail';
+    expect(() => parseWorkflowDefinition(raw)).not.toThrow();
+  });
+
+  it('accepts decision node without onTimeout (defaults to fail)', () => {
+    const raw = loopFixture();
+    // baseline fixture omits onTimeout — re-verify it still passes
+    expect(() => parseWorkflowDefinition(raw)).not.toThrow();
+  });
+});
+
 describe('validateLoopBlocks direct (returns body set)', () => {
   it('returns body-node set for downstream use', () => {
     const def = parseWorkflowDefinition(loopFixture());

--- a/test/workflow-events-replay.test.ts
+++ b/test/workflow-events-replay.test.ts
@@ -142,6 +142,116 @@ describe('replay — Run lifecycle', () => {
   });
 });
 
+describe('replay — Loop lifecycle', () => {
+  it('projects loop iterations, audit anchors, and virtual loop output', async () => {
+    const s = await snapshotAfter(
+      runCreated,
+      {
+        runId: RUN_ID,
+        type: 'loopStarted',
+        actor: 'scheduler',
+        payload: { loopId: 'review-loop', maxIterations: 3 },
+      },
+      {
+        runId: RUN_ID,
+        type: 'loopIterationStarted',
+        actor: 'scheduler',
+        payload: { loopId: 'review-loop', iteration: 1, prevResolution: 'initial' },
+      },
+      {
+        runId: RUN_ID,
+        type: 'attemptCreated',
+        actor: 'scheduler',
+        payload: {
+          nodeId: 'implement',
+          activityId: `${RUN_ID}::loop::review-loop.1::work::implement`,
+          attemptId: 'att-1',
+          attemptNumber: 1,
+          inputRef: sampleOutputRef,
+        },
+      },
+      {
+        runId: RUN_ID,
+        type: 'loopIterationFinished',
+        actor: 'scheduler',
+        payload: {
+          loopId: 'review-loop',
+          iteration: 1,
+          resolution: 'rejected',
+          decisionActivityId: `${RUN_ID}::loop::review-loop.1::gate::reviewDecision`,
+          waitResolvedEventId: `${RUN_ID}-4`,
+          by: 'ou_reviewer',
+          comment: 'try again',
+        },
+      },
+      {
+        runId: RUN_ID,
+        type: 'loopIterationStarted',
+        actor: 'scheduler',
+        payload: { loopId: 'review-loop', iteration: 2, prevResolution: 'rejected' },
+      },
+      {
+        runId: RUN_ID,
+        type: 'loopIterationFinished',
+        actor: 'scheduler',
+        payload: {
+          loopId: 'review-loop',
+          iteration: 2,
+          resolution: 'approved',
+          decisionActivityId: `${RUN_ID}::loop::review-loop.2::gate::reviewDecision`,
+          waitResolvedEventId: `${RUN_ID}-7`,
+          by: 'ou_reviewer',
+        },
+      },
+      {
+        runId: RUN_ID,
+        type: 'loopFinished',
+        actor: 'scheduler',
+        payload: {
+          loopId: 'review-loop',
+          finalIteration: 2,
+          resolution: 'approved',
+          outputRef: sampleOutputRef,
+        },
+      },
+    );
+    const loop = s.loops.get('review-loop');
+    expect(loop).toMatchObject({
+      loopId: 'review-loop',
+      status: 'succeeded',
+      iteration: 2,
+      maxIterations: 3,
+      output: sampleOutputRef,
+    });
+    expect(loop?.iterations).toHaveLength(2);
+    expect(loop?.iterations[0]).toMatchObject({
+      iteration: 1,
+      status: 'rejected',
+      decisionBy: 'ou_reviewer',
+      decisionComment: 'try again',
+      waitResolvedEventId: `${RUN_ID}-4`,
+    });
+    expect(loop?.iterations[0]?.bodyActivityIds).toEqual([
+      `${RUN_ID}::loop::review-loop.1::work::implement`,
+    ]);
+    expect(s.outputs.get(`${RUN_ID}::work::review-loop`)).toEqual(sampleOutputRef);
+  });
+
+  it('requires max-iterations-exceeded loopFinished to carry canonical error', async () => {
+    await log.append(runCreated);
+    await expect(log.append({
+      runId: RUN_ID,
+      type: 'loopFinished',
+      actor: 'scheduler',
+      payload: {
+        loopId: 'review-loop',
+        finalIteration: 3,
+        resolution: 'max-iterations-exceeded',
+      },
+    })).rejects.toThrow(/LoopMaxIterationsExceeded/);
+  });
+});
+
 describe('replay — Node lifecycle', () => {
   it('nodeWaiting/Succeeded/Failed/Skipped/Canceled project correctly', async () => {
     const s = await snapshotAfter(

--- a/test/workflow-loader.test.ts
+++ b/test/workflow-loader.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -7,8 +7,10 @@ import { EventLog } from '../src/workflows/events/append.js';
 import { parseWorkflowDefinition, type WorkflowDefinition } from '../src/workflows/definition.js';
 import {
   loadWorkflowDefinition,
+  readWorkflowDefinitionFromRunDir,
   snapshotWorkflowDefinition,
 } from '../src/workflows/loader.js';
+import { logger } from '../src/utils/logger.js';
 import { getRunsDir, runDir } from '../src/workflows/runs-dir.js';
 import { createRun, type BotResolver } from '../src/workflows/run-init.js';
 
@@ -84,6 +86,41 @@ describe('workflow loader', () => {
         's',
       ),
     );
+  });
+
+  it('readWorkflowDefinitionFromRunDir: missing file returns null silently (ENOENT)', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      const runDir = join(tempDir, 'runs', 'nonexistent-run');
+      mkdirSync(runDir, { recursive: true });
+      const def = await readWorkflowDefinitionFromRunDir(runDir);
+      expect(def).toBeNull();
+      // Missing snapshot is a normal state for legacy v0.1 runs that
+      // predate the per-run workflow.json file — must NOT warn.
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('readWorkflowDefinitionFromRunDir: corrupt JSON returns null AND warns', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      const runDir = join(tempDir, 'runs', 'corrupt-run');
+      mkdirSync(runDir, { recursive: true });
+      // Garbage that will blow up at JSON.parse — exactly the kind of
+      // unexpected failure that used to go silently null pre-fix.
+      writeFileSync(join(runDir, 'workflow.json'), '{not-json}', 'utf-8');
+      const def = await readWorkflowDefinitionFromRunDir(runDir);
+      expect(def).toBeNull();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const msg = String(warnSpy.mock.calls[0]![0]);
+      expect(msg).toContain('readWorkflowDefinitionFromRunDir');
+      expect(msg).toContain('workflow.json');
+      expect(msg).toContain('v0.1 wait semantics');
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('createRun snapshots workflow.json into the actual run directory', async () => {

--- a/test/workflow-loop-runtime.test.ts
+++ b/test/workflow-loop-runtime.test.ts
@@ -502,3 +502,95 @@ describe('runLoop — output projection (N4)', () => {
     expect(projectedOutput?.outputHash).toBe(implementOut?.outputHash);
   });
 });
+
+// ─── body-node prompt resolves ${decision.previous.x} per iteration ───────
+//
+// Regression for bindingContext.loopContext omission discovered during
+// the first dogfood run on feat/workflow-loop-v02: dispatchWork built
+// BindingContext without loopContext, so any loop body node referencing
+// `${decisionNode.previous.x}` (string template) fail-bound with
+// "outside a loop iteration context" — even on iteration 1 where the
+// designed behaviour is "missing previous → empty string".
+//
+// This test pins dispatchWork's binding to actually receive
+// { loopId, iteration } from action.activityId.
+
+describe('runLoop — body node binding sees iteration context', () => {
+  it('implement prompt resolves ${reviewDecision.previous.comment} per iteration', async () => {
+    const def = parseWorkflowDefinition({
+      workflowId: 'code-review-loop-binding',
+      version: 1,
+      nodes: {
+        implement: {
+          type: 'subagent',
+          bot: 'cli_a',
+          // Iteration 1: empty replacement (no previous).
+          // Iteration 2+: prior reviewDecision.comment substituted.
+          prompt: 'do task | feedback=${reviewDecision.previous.comment}',
+        },
+        review: {
+          type: 'subagent',
+          bot: 'cli_b',
+          depends: ['implement'],
+          prompt: 'review',
+        },
+        reviewDecision: {
+          type: 'decision',
+          depends: ['review'],
+          humanGate: { stage: 'before', prompt: 'approve?' },
+        },
+        'review-loop': {
+          type: 'loop',
+          maxIterations: 3,
+          body: ['implement', 'review', 'reviewDecision'],
+          terminate: { node: 'reviewDecision', via: 'humanGate' },
+          output: { from: 'implement' },
+        },
+      },
+    });
+
+    const capturedPrompts: Array<{ activityId: string; prompt: string }> = [];
+    const captureSpawn: WorkerSpawnFn = async (input) => {
+      capturedPrompts.push({ activityId: input.activityId, prompt: input.prompt });
+      return {
+        kind: 'success',
+        output: { ok: true },
+        session: {
+          sessionId: `s-${input.activityId}`,
+          botName: input.botName,
+          startedAt: 0,
+        },
+      };
+    };
+
+    const { log, ctx } = await bootstrap(def, captureSpawn);
+    await runLoop(ctx);
+
+    // Iteration 1 implement: previous lookup yields "" (first iteration grace).
+    const iter1Impl = capturedPrompts.find((p) =>
+      p.activityId === loopWorkActivityId(RUN_ID, 'review-loop', 1, 'implement'),
+    );
+    expect(iter1Impl).toBeDefined();
+    expect(iter1Impl?.prompt).toBe('do task | feedback=');
+
+    // Reject iter 1 with a specific comment.
+    await resolveDecision(
+      log,
+      def,
+      'review-loop',
+      1,
+      'reviewDecision',
+      'rejected',
+      'ou_reviewer',
+      'add error handling',
+    );
+    await runLoop(ctx);
+
+    // Iteration 2 implement: prompt must carry the prior reject comment.
+    const iter2Impl = capturedPrompts.find((p) =>
+      p.activityId === loopWorkActivityId(RUN_ID, 'review-loop', 2, 'implement'),
+    );
+    expect(iter2Impl).toBeDefined();
+    expect(iter2Impl?.prompt).toBe('do task | feedback=add error handling');
+  });
+});

--- a/test/workflow-loop-runtime.test.ts
+++ b/test/workflow-loop-runtime.test.ts
@@ -343,20 +343,134 @@ describe('runLoop — non-terminator humanGate.reject in loop body (§10.8)', ()
 
     const finalSnap = replay(await log.readAll());
     const loop = finalSnap.loops.get('review-loop');
-    // Non-terminator body failure uses `cancelled` resolution as the
-    // abnormal-termination bucket (LoopFinishedPayload doesn't yet have
-    // a `'body-failed'` resolution; `max-iterations-exceeded` is locked
-    // to errorCode='LoopMaxIterationsExceeded' by codex Step 2 invariant
-    // — so we route through `cancelled` and rely on the run-level
-    // failedNodeId propagation to surface the run as failed).
-    expect(loop?.status).toBe('cancelled');
+    // Codex Step 3 review Medium: dedicated `body-failed` resolution
+    // distinguishes "loop died because a body node failed" from
+    // user-initiated cancel.  Replay maps body-failed → loop.status =
+    // 'failed' and closes the in-flight iteration as 'failed'.
+    expect(loop?.status).toBe('failed');
+    expect(loop?.errorCode).toBe('LoopBodyFailed');
+    expect(loop?.errorClass).toBe('fatal');
     expect(loop?.iteration).toBe(1);
-    // Iteration stays `running` because `loopFinished` (codex Step 2)
-    // doesn't retroactively close the in-flight iteration entry — the
-    // loop-level `cancelled` status already conveys "this iteration
-    // never reached a decision".  A follow-up could have loopFinished
-    // null-out the in-flight iteration status; not needed for v0.2.
-    expect(loop?.iterations[0]?.status).toBe('running');
+    expect(loop?.iterations[0]?.status).toBe('failed');
+  });
+});
+
+// ─── runFailed.rootCauseEventId points to loopFinished (Blocker 2) ────────
+
+describe('runLoop — runFailed.rootCauseEventId for loop failure', () => {
+  it('max-iterations-exceeded: rootCauseEventId points to loopFinished', async () => {
+    const def = reviewLoopDef(2);
+    const { log, ctx } = await bootstrap(def);
+
+    await runLoop(ctx);
+    await resolveDecision(log, def, 'review-loop', 1, 'reviewDecision', 'rejected');
+    await runLoop(ctx);
+    await resolveDecision(log, def, 'review-loop', 2, 'reviewDecision', 'rejected');
+    await runLoop(ctx);
+
+    const events = await log.readAll();
+    const runFailed = events.find((e) => e.type === 'runFailed');
+    const loopFinished = events.find((e) => e.type === 'loopFinished');
+    expect(runFailed).toBeDefined();
+    expect(loopFinished).toBeDefined();
+    // Plain falsy check + identity — runFailed must NOT fallback to
+    // events[0] (runCreated) which is the diagnostic black-hole this
+    // Blocker 2 fix is preventing.
+    const payload = runFailed!.payload as { rootCauseEventId?: string };
+    expect(payload.rootCauseEventId).toBe(loopFinished!.eventId);
+    // Sanity: definitely not runCreated.
+    expect(payload.rootCauseEventId).not.toBe(events[0]!.eventId);
+  });
+
+  it('body-failed: rootCauseEventId points to the (terminal) loopFinished', async () => {
+    // Same shape as the non-terminator humanGate.reject test but
+    // assert on rootCauseEventId.  This covers the body-fail path
+    // separately from max-iterations.
+    const def = parseWorkflowDefinition({
+      workflowId: 'review-loop-body-gate-rc',
+      version: 1,
+      nodes: {
+        implement: {
+          type: 'subagent',
+          bot: 'cli_a',
+          prompt: 'implement',
+          humanGate: { stage: 'before', prompt: 'ok?' },
+        },
+        reviewDecision: {
+          type: 'decision',
+          depends: ['implement'],
+          humanGate: { stage: 'before', prompt: 'approve?' },
+        },
+        'review-loop': {
+          type: 'loop',
+          maxIterations: 3,
+          body: ['implement', 'reviewDecision'],
+          terminate: { node: 'reviewDecision', via: 'humanGate' },
+        },
+      },
+    });
+    const { log, ctx } = await bootstrap(def);
+    await runLoop(ctx);
+
+    const implementGateId = loopGateActivityId(RUN_ID, 'review-loop', 1, 'implement');
+    const snap = replay(await log.readAll());
+    const gateAct = snap.activities.get(implementGateId);
+    await resolveWait(log, {
+      activityId: implementGateId,
+      attemptId: gateAct!.currentAttemptId!,
+      resolution: 'rejected',
+      by: 'ou_user',
+    });
+    await runLoop(ctx);
+
+    const events = await log.readAll();
+    const runFailed = events.find((e) => e.type === 'runFailed');
+    const loopFinished = events.find((e) => e.type === 'loopFinished');
+    expect(runFailed).toBeDefined();
+    expect(loopFinished).toBeDefined();
+    const payload = runFailed!.payload as { rootCauseEventId?: string };
+    expect(payload.rootCauseEventId).toBe(loopFinished!.eventId);
+  });
+});
+
+// ─── decision outputRef has outputPath so `previous` binding can read ─────
+
+describe('runLoop — decision attempt outputRef carries outputPath (Blocker 1)', () => {
+  it('approve writes an OutputRef with outputPath set so binding can read', async () => {
+    const def = reviewLoopDef(2);
+    const { log, ctx } = await bootstrap(def);
+    await runLoop(ctx);
+    await resolveDecision(log, def, 'review-loop', 1, 'reviewDecision', 'approved');
+
+    const snap = replay(await log.readAll());
+    const decisionActId = loopGateActivityId(RUN_ID, 'review-loop', 1, 'reviewDecision');
+    const outputRef = snap.outputs.get(decisionActId);
+    expect(outputRef).toBeDefined();
+    expect(outputRef?.outputPath).toBeDefined();
+    expect(outputRef?.outputPath).toMatch(/\.blob$|blobs\//);
+    expect(outputRef?.outputHash).toMatch(/^sha256:/);
+  });
+
+  it('reject writes an OutputRef with outputPath set (same blob path)', async () => {
+    const def = reviewLoopDef(2);
+    const { log, ctx } = await bootstrap(def);
+    await runLoop(ctx);
+    await resolveDecision(
+      log,
+      def,
+      'review-loop',
+      1,
+      'reviewDecision',
+      'rejected',
+      'ou_r',
+      'try again',
+    );
+
+    const snap = replay(await log.readAll());
+    const decisionActId = loopGateActivityId(RUN_ID, 'review-loop', 1, 'reviewDecision');
+    const outputRef = snap.outputs.get(decisionActId);
+    expect(outputRef).toBeDefined();
+    expect(outputRef?.outputPath).toBeDefined();
   });
 });
 

--- a/test/workflow-loop-runtime.test.ts
+++ b/test/workflow-loop-runtime.test.ts
@@ -593,4 +593,76 @@ describe('runLoop — body node binding sees iteration context', () => {
     expect(iter2Impl).toBeDefined();
     expect(iter2Impl?.prompt).toBe('do task | feedback=add error handling');
   });
+
+  // Regression for codex PR #47 review medium: when reviewer rejects without
+  // filling a comment, wait.ts succeeded output must still materialize the
+  // `comment` field (as '') so iter N+1's ${reviewDecision.previous.comment}
+  // doesn't BindingError on own-property check.
+  it('decision reject without comment → previous.comment renders as ""', async () => {
+    const def = parseWorkflowDefinition({
+      workflowId: 'code-review-loop-empty-comment',
+      version: 1,
+      nodes: {
+        implement: {
+          type: 'subagent',
+          bot: 'cli_a',
+          prompt: 'do task | feedback=${reviewDecision.previous.comment}',
+        },
+        review: {
+          type: 'subagent',
+          bot: 'cli_b',
+          depends: ['implement'],
+          prompt: 'review',
+        },
+        reviewDecision: {
+          type: 'decision',
+          depends: ['review'],
+          humanGate: { stage: 'before', prompt: 'approve?' },
+        },
+        'review-loop': {
+          type: 'loop',
+          maxIterations: 3,
+          body: ['implement', 'review', 'reviewDecision'],
+          terminate: { node: 'reviewDecision', via: 'humanGate' },
+          output: { from: 'implement' },
+        },
+      },
+    });
+
+    const capturedPrompts: Array<{ activityId: string; prompt: string }> = [];
+    const captureSpawn: WorkerSpawnFn = async (input) => {
+      capturedPrompts.push({ activityId: input.activityId, prompt: input.prompt });
+      return {
+        kind: 'success',
+        output: { ok: true },
+        session: {
+          sessionId: `s-${input.activityId}`,
+          botName: input.botName,
+          startedAt: 0,
+        },
+      };
+    };
+
+    const { log, ctx } = await bootstrap(def, captureSpawn);
+    await runLoop(ctx);
+
+    // Reject iter 1 WITHOUT a comment.
+    await resolveDecision(
+      log,
+      def,
+      'review-loop',
+      1,
+      'reviewDecision',
+      'rejected',
+      'ou_reviewer',
+      undefined,
+    );
+    await runLoop(ctx);
+
+    const iter2Impl = capturedPrompts.find((p) =>
+      p.activityId === loopWorkActivityId(RUN_ID, 'review-loop', 2, 'implement'),
+    );
+    expect(iter2Impl).toBeDefined();
+    expect(iter2Impl?.prompt).toBe('do task | feedback=');
+  });
 });

--- a/test/workflow-loop-runtime.test.ts
+++ b/test/workflow-loop-runtime.test.ts
@@ -1,0 +1,390 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { EventLog } from '../src/workflows/events/append.js';
+import { replay } from '../src/workflows/events/replay.js';
+import {
+  parseWorkflowDefinition,
+  type WorkflowDefinition,
+} from '../src/workflows/definition.js';
+import { createRun, type BotResolver } from '../src/workflows/run-init.js';
+import {
+  loopGateActivityId,
+  loopWorkActivityId,
+} from '../src/workflows/orchestrator.js';
+import {
+  type WorkflowRuntimeContext,
+  type WorkerSpawnFn,
+} from '../src/workflows/runtime.js';
+import { runLoop } from '../src/workflows/loop.js';
+import { resolveWait } from '../src/workflows/wait.js';
+
+// ─── fixtures ─────────────────────────────────────────────────────────────
+//
+// End-to-end tests for v0.2 loop runtime executor (Step 3 of
+// feat/workflow-loop-v02 — see /tmp/wf-loop-v02.md §4.3 + §13).
+//
+// Scope:
+//   - happy path: implement → review → decision approve → loop succeeded
+//   - multi-reject → eventual approve
+//   - max-iterations-exceeded → run fails with LoopMaxIterationsExceeded
+//   - decision reject writes `activitySucceeded` (NOT `activityFailed`) —
+//     verifies wait.ts decision-mode (N2)
+//   - non-terminator humanGate.reject inside loop body still fails the
+//     run (§10.8)
+
+const RUN_ID = 'run-loop-rt-01';
+const noopResolver: BotResolver = () => ({});
+
+const successSpawn: WorkerSpawnFn = async (input) => ({
+  kind: 'success',
+  output: { ok: true, code: `code-${input.botName}` },
+  session: {
+    sessionId: `s-${input.activityId}`,
+    botName: input.botName,
+    startedAt: 0,
+  },
+});
+
+function reviewLoopDef(maxIterations = 3): WorkflowDefinition {
+  return parseWorkflowDefinition({
+    workflowId: 'code-review-loop',
+    version: 1,
+    nodes: {
+      implement: {
+        type: 'subagent',
+        bot: 'cli_a',
+        prompt: 'implement task',
+      },
+      review: {
+        type: 'subagent',
+        bot: 'cli_b',
+        depends: ['implement'],
+        prompt: 'review code',
+      },
+      reviewDecision: {
+        type: 'decision',
+        depends: ['review'],
+        humanGate: {
+          stage: 'before',
+          prompt: 'approve?',
+        },
+      },
+      'review-loop': {
+        type: 'loop',
+        maxIterations,
+        body: ['implement', 'review', 'reviewDecision'],
+        terminate: { node: 'reviewDecision', via: 'humanGate' },
+        output: { from: 'implement' },
+      },
+    },
+  });
+}
+
+let baseDir: string;
+beforeEach(() => {
+  baseDir = mkdtempSync(join(tmpdir(), 'wf-loop-rt-'));
+});
+afterEach(() => {
+  rmSync(baseDir, { recursive: true, force: true });
+});
+
+async function bootstrap(
+  def: WorkflowDefinition,
+  spawn: WorkerSpawnFn = successSpawn,
+): Promise<{ log: EventLog; ctx: WorkflowRuntimeContext }> {
+  const log = new EventLog(RUN_ID, baseDir);
+  await createRun(log, {
+    def,
+    params: {},
+    initiator: 'tester',
+    botResolver: noopResolver,
+  });
+  return { log, ctx: { log, def, spawnSubagent: spawn } };
+}
+
+async function resolveDecision(
+  log: EventLog,
+  def: WorkflowDefinition,
+  loopId: string,
+  iteration: number,
+  decisionNodeId: string,
+  resolution: 'approved' | 'rejected',
+  by = 'ou_reviewer',
+  comment?: string,
+): Promise<void> {
+  const decisionActId = loopGateActivityId(RUN_ID, loopId, iteration, decisionNodeId);
+  const snap = replay(await log.readAll());
+  const decisionAct = snap.activities.get(decisionActId);
+  if (!decisionAct?.currentAttemptId) {
+    throw new Error(`decision attempt missing for ${decisionActId}`);
+  }
+  await resolveWait(
+    log,
+    {
+      activityId: decisionActId,
+      attemptId: decisionAct.currentAttemptId,
+      resolution,
+      by,
+      ...(comment ? { comment } : {}),
+    },
+    { def },
+  );
+}
+
+// ─── happy path ───────────────────────────────────────────────────────────
+
+describe('runLoop — loop v0.2 happy path', () => {
+  it('iteration 1 approve → loop succeeded in one round', async () => {
+    const def = reviewLoopDef();
+    const { log, ctx } = await bootstrap(def);
+
+    // First runLoop drives until decision gate is awaiting human input.
+    const first = await runLoop(ctx);
+    expect(first.reason).toBe('awaiting-wait');
+
+    // Iteration 1 should be running, body activities all dispatched.
+    const snap1 = first.lastSnapshot;
+    const loop1 = snap1.loops.get('review-loop');
+    expect(loop1?.status).toBe('running');
+    expect(loop1?.iteration).toBe(1);
+    expect(snap1.activities.has(
+      loopWorkActivityId(RUN_ID, 'review-loop', 1, 'implement'),
+    )).toBe(true);
+    expect(snap1.activities.has(
+      loopWorkActivityId(RUN_ID, 'review-loop', 1, 'review'),
+    )).toBe(true);
+    expect(snap1.activities.has(
+      loopGateActivityId(RUN_ID, 'review-loop', 1, 'reviewDecision'),
+    )).toBe(true);
+
+    // Approve the decision; loop should close as succeeded.
+    await resolveDecision(log, def, 'review-loop', 1, 'reviewDecision', 'approved');
+    const second = await runLoop(ctx);
+    expect(second.reason).toBe('terminal');
+    expect(second.lastSnapshot.run.status).toBe('succeeded');
+
+    const finalSnap = replay(await log.readAll());
+    const finalLoop = finalSnap.loops.get('review-loop');
+    expect(finalLoop?.status).toBe('succeeded');
+    expect(finalLoop?.iteration).toBe(1);
+    expect(finalLoop?.iterations[0]?.status).toBe('approved');
+    // output.from='implement' projection
+    expect(finalLoop?.output?.outputHash).toMatch(/^sha256:/);
+  });
+});
+
+// ─── multi-iteration: reject then approve ─────────────────────────────────
+
+describe('runLoop — multi-iteration reject → approve', () => {
+  it('reject iter 1 → iter 2 → reject 2 → iter 3 approve → succeeded', async () => {
+    const def = reviewLoopDef(3);
+    const { log, ctx } = await bootstrap(def);
+
+    // Iteration 1
+    await runLoop(ctx);
+    await resolveDecision(log, def, 'review-loop', 1, 'reviewDecision', 'rejected', 'ou_r', 'not yet');
+
+    // Iteration 2
+    await runLoop(ctx);
+    await resolveDecision(log, def, 'review-loop', 2, 'reviewDecision', 'rejected', 'ou_r', 'still bad');
+
+    // Iteration 3 (final allowed)
+    await runLoop(ctx);
+    await resolveDecision(log, def, 'review-loop', 3, 'reviewDecision', 'approved');
+
+    const last = await runLoop(ctx);
+    expect(last.reason).toBe('terminal');
+    expect(last.lastSnapshot.run.status).toBe('succeeded');
+
+    const snap = replay(await log.readAll());
+    const loop = snap.loops.get('review-loop');
+    expect(loop?.status).toBe('succeeded');
+    expect(loop?.iteration).toBe(3);
+    expect(loop?.iterations.map((it) => it.status)).toEqual([
+      'rejected',
+      'rejected',
+      'approved',
+    ]);
+    expect(loop?.iterations[0]?.decisionComment).toBe('not yet');
+    expect(loop?.iterations[1]?.decisionComment).toBe('still bad');
+    // Each iteration has its own audit anchors (codex round 2 N3).
+    for (const it of loop?.iterations ?? []) {
+      expect(it.decisionActivityId).toMatch(/::loop::review-loop\.\d+::gate::reviewDecision$/);
+      expect(it.waitResolvedEventId).toMatch(/-\d+$/);
+    }
+  });
+});
+
+// ─── max-iterations-exceeded ──────────────────────────────────────────────
+
+describe('runLoop — max-iterations-exceeded', () => {
+  it('reject every iteration up to maxIterations → loop failed', async () => {
+    const def = reviewLoopDef(2);
+    const { log, ctx } = await bootstrap(def);
+
+    await runLoop(ctx);
+    await resolveDecision(log, def, 'review-loop', 1, 'reviewDecision', 'rejected');
+    await runLoop(ctx);
+    await resolveDecision(log, def, 'review-loop', 2, 'reviewDecision', 'rejected');
+    const last = await runLoop(ctx);
+    // After exhausting attempts, the loop closes as failed (run-level
+    // failure once propagated).
+    expect(last.reason).toBe('terminal');
+
+    const snap = replay(await log.readAll());
+    const loop = snap.loops.get('review-loop');
+    expect(loop?.status).toBe('failed');
+    expect(loop?.errorCode).toBe('LoopMaxIterationsExceeded');
+    expect(loop?.errorClass).toBe('userFault');
+    expect(loop?.iteration).toBe(2);
+    expect(loop?.iterations.map((it) => it.status)).toEqual([
+      'rejected',
+      'rejected',
+    ]);
+    expect(snap.run.status).toBe('failed');
+  });
+});
+
+// ─── decision reject = activitySucceeded (NOT activityFailed) ─────────────
+
+describe('runLoop — decision wait.ts semantics (N2)', () => {
+  it('decision reject writes activitySucceeded with {resolution:"rejected"}', async () => {
+    const def = reviewLoopDef(2);
+    const { log, ctx } = await bootstrap(def);
+    await runLoop(ctx);
+
+    const decisionActId = loopGateActivityId(RUN_ID, 'review-loop', 1, 'reviewDecision');
+    const beforeSnap = replay(await log.readAll());
+    expect(beforeSnap.activities.get(decisionActId)?.status).not.toBe('succeeded');
+
+    await resolveDecision(
+      log,
+      def,
+      'review-loop',
+      1,
+      'reviewDecision',
+      'rejected',
+      'ou_r',
+      'wants revision',
+    );
+
+    const afterSnap = replay(await log.readAll());
+    const decisionAct = afterSnap.activities.get(decisionActId);
+    // The wait terminal MUST be activitySucceeded — reject is a legal
+    // decision output, not a failure.  Plain humanGate reject still
+    // maps to activityFailed (covered in workflow-loop.test.ts).
+    expect(decisionAct?.status).toBe('succeeded');
+    const lastAt = decisionAct?.attempts[decisionAct.attempts.length - 1];
+    expect(lastAt?.wait?.resolution?.kind).toBe('resolved');
+    if (lastAt?.wait?.resolution?.kind === 'resolved') {
+      expect(lastAt.wait.resolution.resolution).toBe('rejected');
+      expect(lastAt.wait.resolution.comment).toBe('wants revision');
+    }
+  });
+});
+
+// ─── non-terminator humanGate inside body still fails the run ─────────────
+
+describe('runLoop — non-terminator humanGate.reject in loop body (§10.8)', () => {
+  it('reject on a body subagent (not the terminator) fails the run', async () => {
+    // Add a humanGate on `implement` — non-terminator.  Reject must
+    // fail-run, not open a new iteration.
+    const def = parseWorkflowDefinition({
+      workflowId: 'review-loop-body-gate',
+      version: 1,
+      nodes: {
+        implement: {
+          type: 'subagent',
+          bot: 'cli_a',
+          prompt: 'implement',
+          humanGate: { stage: 'before', prompt: 'ok to implement?' },
+        },
+        reviewDecision: {
+          type: 'decision',
+          depends: ['implement'],
+          humanGate: { stage: 'before', prompt: 'approve?' },
+        },
+        'review-loop': {
+          type: 'loop',
+          maxIterations: 3,
+          body: ['implement', 'reviewDecision'],
+          terminate: { node: 'reviewDecision', via: 'humanGate' },
+        },
+      },
+    });
+    const { log, ctx } = await bootstrap(def);
+
+    // First runLoop pauses at the implement gate.
+    await runLoop(ctx);
+
+    const implementGateId = loopGateActivityId(RUN_ID, 'review-loop', 1, 'implement');
+    const snap = replay(await log.readAll());
+    const gateAct = snap.activities.get(implementGateId);
+    if (!gateAct?.currentAttemptId) throw new Error('implement gate not dispatched');
+
+    // Reject the non-terminator gate.  No `def` in ctx ⇒ plain wait
+    // semantics ⇒ activityFailed.
+    await resolveWait(log, {
+      activityId: implementGateId,
+      attemptId: gateAct.currentAttemptId,
+      resolution: 'rejected',
+      by: 'ou_user',
+      comment: 'no',
+    });
+
+    // Subsequent runLoop must finalize the run as failed — NOT open a
+    // new iteration.
+    const last = await runLoop(ctx);
+    expect(last.reason).toBe('terminal');
+    expect(last.lastSnapshot.run.status).toBe('failed');
+
+    const finalSnap = replay(await log.readAll());
+    const loop = finalSnap.loops.get('review-loop');
+    // Non-terminator body failure uses `cancelled` resolution as the
+    // abnormal-termination bucket (LoopFinishedPayload doesn't yet have
+    // a `'body-failed'` resolution; `max-iterations-exceeded` is locked
+    // to errorCode='LoopMaxIterationsExceeded' by codex Step 2 invariant
+    // — so we route through `cancelled` and rely on the run-level
+    // failedNodeId propagation to surface the run as failed).
+    expect(loop?.status).toBe('cancelled');
+    expect(loop?.iteration).toBe(1);
+    // Iteration stays `running` because `loopFinished` (codex Step 2)
+    // doesn't retroactively close the in-flight iteration entry — the
+    // loop-level `cancelled` status already conveys "this iteration
+    // never reached a decision".  A follow-up could have loopFinished
+    // null-out the in-flight iteration status; not needed for v0.2.
+    expect(loop?.iterations[0]?.status).toBe('running');
+  });
+});
+
+// ─── loop output projection (N4 virtual outputRef) ────────────────────────
+
+describe('runLoop — output projection (N4)', () => {
+  it('loop block output = projection of body node (implement) latest', async () => {
+    const def = reviewLoopDef(2);
+    const { log, ctx } = await bootstrap(def);
+
+    await runLoop(ctx);
+    await resolveDecision(log, def, 'review-loop', 1, 'reviewDecision', 'approved');
+    await runLoop(ctx);
+
+    const snap = replay(await log.readAll());
+    const loop = snap.loops.get('review-loop');
+    expect(loop?.status).toBe('succeeded');
+    // loopFinished.outputRef is published into outputs[workActivityId(runId, loopId)]
+    // so plain `${review-loop.output.x}` resolves uniformly.
+    const projectedOutput = snap.outputs.get(
+      'run-loop-rt-01::work::review-loop',
+    );
+    expect(projectedOutput).toBeDefined();
+    expect(projectedOutput).toEqual(loop?.output);
+    // Should match the implement body activity's own output ref.
+    const implementOut = snap.outputs.get(
+      loopWorkActivityId(RUN_ID, 'review-loop', 1, 'implement'),
+    );
+    expect(projectedOutput?.outputHash).toBe(implementOut?.outputHash);
+  });
+});

--- a/test/workflow-loop-runtime.test.ts
+++ b/test/workflow-loop-runtime.test.ts
@@ -312,6 +312,7 @@ describe('runLoop — non-terminator humanGate.reject in loop body (§10.8)', ()
           maxIterations: 3,
           body: ['implement', 'reviewDecision'],
           terminate: { node: 'reviewDecision', via: 'humanGate' },
+          output: { from: 'implement' },
         },
       },
     });
@@ -406,6 +407,7 @@ describe('runLoop — runFailed.rootCauseEventId for loop failure', () => {
           maxIterations: 3,
           body: ['implement', 'reviewDecision'],
           terminate: { node: 'reviewDecision', via: 'humanGate' },
+          output: { from: 'implement' },
         },
       },
     });

--- a/test/workflow-ops-projection.test.ts
+++ b/test/workflow-ops-projection.test.ts
@@ -20,6 +20,7 @@ import {
   listRuns,
   readEventWindow,
   readRunSnapshot,
+  scrubSnapshotForUnauthed,
 } from '../src/workflows/ops-projection.js';
 import { EventLog } from '../src/workflows/events/append.js';
 import { parseWorkflowDefinition } from '../src/workflows/definition.js';
@@ -463,6 +464,95 @@ describe('readRunSnapshot', () => {
     expect(log!.outputBytes).toBeGreaterThan(64 * 1024);
     expect(log!.text).toContain(TAIL);
     expect(log!.text).not.toContain(HEAD);
+  });
+
+  it('scrubSnapshotForUnauthed strips io.log.text + io.terminal.logPath; keeps metadata', async () => {
+    // Same seeding as the input/output preview test — gives us a snapshot
+    // with both a non-empty `io.log` and a populated `io.terminal.logPath`.
+    await seedSucceeded('r-scrub');
+    const activityId = workActivityId('r-scrub', 'only');
+    const attemptId = 'r-scrub::work::only::att-1';
+    const attemptDir = join(runsDir, 'r-scrub', 'attempts', activityId, attemptId);
+    mkdirSync(attemptDir, { recursive: true });
+    const SECRET_LINE = 'AWS_SECRET=AKIAFAKE_should_not_leak';
+    writeFileSync(
+      join(attemptDir, 'terminal.log'),
+      `[2026-05-25T00:00:00.000Z] stderr ${SECRET_LINE}\n`,
+      'utf-8',
+    );
+    writeFileSync(
+      join(attemptDir, 'terminal.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        sessionId: 'wf-r-scrub-only',
+        webPort: 32200,
+        status: 'closed',
+        cliId: 'claude-code',
+        logPath: join(attemptDir, 'terminal.log'),
+        startedAt: 100,
+        updatedAt: 200,
+      }),
+      'utf-8',
+    );
+
+    const full = await readRunSnapshot(runsDir, 'r-scrub');
+    expect(full).not.toBeNull();
+    // Authed view still gets the full log + logPath — the function only
+    // changes the view served to unauth'd public-read callers.
+    expect(full!.attemptIO[attemptId]?.log?.text).toContain(SECRET_LINE);
+    expect(full!.attemptIO[attemptId]?.terminal?.logPath).toBe(
+      join(attemptDir, 'terminal.log'),
+    );
+
+    const scrubbed = scrubSnapshotForUnauthed(full!);
+    const scrubbedLog = scrubbed.attemptIO[attemptId]?.log;
+    expect(scrubbedLog).toBeDefined();
+    expect(scrubbedLog!.text).toBeUndefined();
+    expect(scrubbedLog!.value).toBeUndefined();
+    expect(scrubbedLog!.redacted).toBe(true);
+    // Metadata stays so the dashboard can render a "log available after
+    // login (N bytes)" placeholder rather than pretending the blob doesn't
+    // exist.
+    expect(scrubbedLog!.outputBytes).toBeGreaterThan(0);
+
+    // Sibling blobs (input/output/resolvedInput/waitPrompt) are workflow
+    // products, not raw process bytes — they stay public, same as before.
+    expect(scrubbed.attemptIO[attemptId]?.input?.value).toBeDefined();
+    expect(scrubbed.attemptIO[attemptId]?.output?.value).toBeDefined();
+
+    const scrubbedTerm = scrubbed.attemptIO[attemptId]?.terminal;
+    expect(scrubbedTerm).toBeDefined();
+    expect(scrubbedTerm!.logPath).toBeUndefined();
+    // Sidecar status / port / sessionId stay — they're needed for the
+    // dashboard to know whether the live terminal stream exists.  The raw
+    // bytes themselves are already cookie-gated at /terminal-log/raw.
+    expect(scrubbedTerm!.sessionId).toBe('wf-r-scrub-only');
+    expect(scrubbedTerm!.status).toBe('closed');
+    expect(scrubbedTerm!.webPort).toBe(32200);
+
+    // Input snapshot must not have been mutated.
+    expect(full!.attemptIO[attemptId]?.log?.text).toContain(SECRET_LINE);
+    expect(full!.attemptIO[attemptId]?.terminal?.logPath).toBe(
+      join(attemptDir, 'terminal.log'),
+    );
+  });
+
+  it('scrubSnapshotForUnauthed is a no-op when attemptIO carries no log/terminal', async () => {
+    await seedSucceeded('r-scrub-empty');
+    const snap = await readRunSnapshot(runsDir, 'r-scrub-empty');
+    expect(snap).not.toBeNull();
+    const scrubbed = scrubSnapshotForUnauthed(snap!);
+    // Same top-level shape; attemptIO keys identical.
+    expect(Object.keys(scrubbed.attemptIO).sort()).toEqual(
+      Object.keys(snap!.attemptIO).sort(),
+    );
+    for (const [aid, io] of Object.entries(scrubbed.attemptIO)) {
+      // No log seeded → no log key after scrub either (we don't synthesize).
+      expect(io.log).toBeUndefined();
+      // input/output stay byte-equal with the source.
+      expect(io.input?.value).toEqual(snap!.attemptIO[aid]?.input?.value);
+      expect(io.output?.value).toEqual(snap!.attemptIO[aid]?.output?.value);
+    }
   });
 
   it('preserves activityFailed errorMessage in attempt error', async () => {

--- a/test/workflow-ops-projection.test.ts
+++ b/test/workflow-ops-projection.test.ts
@@ -25,7 +25,11 @@ import { EventLog } from '../src/workflows/events/append.js';
 import { parseWorkflowDefinition } from '../src/workflows/definition.js';
 import { createRun } from '../src/workflows/run-init.js';
 import { runLoop } from '../src/workflows/loop.js';
-import { workActivityId } from '../src/workflows/orchestrator.js';
+import {
+  loopGateActivityId,
+  workActivityId,
+} from '../src/workflows/orchestrator.js';
+import { resolveWait } from '../src/workflows/wait.js';
 import type { WorkerSpawnFn } from '../src/workflows/runtime.js';
 
 let runsDir: string;
@@ -630,5 +634,139 @@ describe('extractEventContext', () => {
     expect(extractEventContext({ ref: 'b1', bytes: 10, schemaVersion: 1 })).toEqual({});
     expect(extractEventContext(null)).toEqual({});
     expect(extractEventContext(undefined)).toEqual({});
+  });
+});
+
+// ─── readRunSnapshot — v0.2 loop projection (Step 4) ───────────────────────
+//
+// Loop blocks are projected into `RunSnapshotDTO.loops` as a JSON-safe
+// record keyed by loopId.  The field is OPTIONAL (omitted for workflows
+// that don't use loops) so older dashboards staying forward-compatible.
+
+const LOOP_DEF = parseWorkflowDefinition({
+  workflowId: 'proj-loop',
+  version: 1,
+  nodes: {
+    implement: { type: 'subagent', bot: 'b', prompt: 'x' },
+    reviewDecision: {
+      type: 'decision',
+      depends: ['implement'],
+      humanGate: { stage: 'before', prompt: 'ok?' },
+    },
+    'review-loop': {
+      type: 'loop',
+      maxIterations: 2,
+      body: ['implement', 'reviewDecision'],
+      terminate: { node: 'reviewDecision', via: 'humanGate' },
+      output: { from: 'implement' },
+    },
+  },
+});
+
+describe('readRunSnapshot — loop projection', () => {
+  it('omits `loops` field for runs without any loop block', async () => {
+    await seedSucceeded('r-no-loops');
+    const snap = await readRunSnapshot(runsDir, 'r-no-loops');
+    expect(snap).not.toBeNull();
+    expect(snap!.loops).toBeUndefined();
+  });
+
+  it('includes `loops` record once a loop has started', async () => {
+    const log = new EventLog('r-loop-running', runsDir);
+    await createRun(log, {
+      def: LOOP_DEF,
+      params: {},
+      initiator: 'test',
+      botResolver: () => ({}),
+    });
+    const ctx = { log, def: LOOP_DEF, spawnSubagent: okSpawn };
+    await runLoop(ctx);
+
+    const snap = await readRunSnapshot(runsDir, 'r-loop-running');
+    expect(snap).not.toBeNull();
+    expect(snap!.loops).toBeDefined();
+    const loop = snap!.loops!['review-loop'];
+    expect(loop).toBeDefined();
+    expect(loop.loopId).toBe('review-loop');
+    expect(loop.status).toBe('running');
+    expect(loop.iteration).toBe(1);
+    expect(loop.maxIterations).toBe(2);
+    expect(loop.iterations).toHaveLength(1);
+    expect(loop.iterations[0]?.iteration).toBe(1);
+    expect(loop.iterations[0]?.status).toBe('running');
+  });
+
+  it('iteration audit anchors survive the projection round-trip', async () => {
+    const log = new EventLog('r-loop-anchors', runsDir);
+    await createRun(log, {
+      def: LOOP_DEF,
+      params: {},
+      initiator: 'test',
+      botResolver: () => ({}),
+    });
+    const ctx = { log, def: LOOP_DEF, spawnSubagent: okSpawn };
+    await runLoop(ctx);
+    const decisionId = loopGateActivityId('r-loop-anchors', 'review-loop', 1, 'reviewDecision');
+    // Need to read the current snapshot to grab the gate attempt id.
+    let snap = await readRunSnapshot(runsDir, 'r-loop-anchors');
+    const decAct = snap!.activities.find((a) => a.activityId === decisionId);
+    await resolveWait(
+      log,
+      {
+        activityId: decisionId,
+        attemptId: decAct!.currentAttemptId!,
+        resolution: 'rejected',
+        by: 'ou_reviewer',
+        comment: 'try again',
+      },
+      { def: LOOP_DEF },
+    );
+    await runLoop(ctx);
+
+    snap = await readRunSnapshot(runsDir, 'r-loop-anchors');
+    const loop = snap!.loops!['review-loop'];
+    expect(loop.iteration).toBe(2);
+    expect(loop.iterations).toHaveLength(2);
+    const it1 = loop.iterations[0]!;
+    expect(it1.status).toBe('rejected');
+    expect(it1.decisionActivityId).toBe(decisionId);
+    expect(it1.waitResolvedEventId).toMatch(/-\d+$/);
+    expect(it1.decisionBy).toBe('ou_reviewer');
+    expect(it1.decisionComment).toBe('try again');
+  });
+
+  it('terminal loop carries output projection ref + errorCode/errorClass', async () => {
+    const log = new EventLog('r-loop-fail', runsDir);
+    await createRun(log, {
+      def: LOOP_DEF,
+      params: {},
+      initiator: 'test',
+      botResolver: () => ({}),
+    });
+    const ctx = { log, def: LOOP_DEF, spawnSubagent: okSpawn };
+    // Reject twice → max-iterations-exceeded.
+    for (let iter = 1; iter <= 2; iter++) {
+      await runLoop(ctx);
+      const snap = await readRunSnapshot(runsDir, 'r-loop-fail');
+      const decisionId = loopGateActivityId('r-loop-fail', 'review-loop', iter, 'reviewDecision');
+      const decAct = snap!.activities.find((a) => a.activityId === decisionId);
+      await resolveWait(
+        log,
+        {
+          activityId: decisionId,
+          attemptId: decAct!.currentAttemptId!,
+          resolution: 'rejected',
+          by: 'r',
+        },
+        { def: LOOP_DEF },
+      );
+    }
+    await runLoop(ctx);
+
+    const snap = await readRunSnapshot(runsDir, 'r-loop-fail');
+    const loop = snap!.loops!['review-loop'];
+    expect(loop.status).toBe('failed');
+    expect(loop.errorCode).toBe('LoopMaxIterationsExceeded');
+    expect(loop.errorClass).toBe('userFault');
   });
 });

--- a/test/workflow-orchestrator.test.ts
+++ b/test/workflow-orchestrator.test.ts
@@ -14,9 +14,13 @@ import { createWait, resolveWait } from '../src/workflows/wait.js';
 import {
   decideNextActions,
   gateActivityId,
+  loopGateActivityId,
+  loopWorkActivityId,
+  parseActivityId,
   workActivityId,
   type OrchestratorAction,
 } from '../src/workflows/orchestrator.js';
+import { isValidPathSegment } from '../src/workflows/ops-projection.js';
 
 const RUN_ID = 'run-orch-test-01';
 const SHA = 'sha256:' + 'a'.repeat(64);
@@ -423,5 +427,166 @@ describe('decideNextActions — termination', () => {
       payload: { cancelOriginEventId: `${RUN_ID}-3` },
     });
     expect(decideNextActions(await snapshotOf(log), def)).toEqual([]);
+  });
+});
+
+// ─── loop iteration activity IDs (v0.2 Step 1) ─────────────────────────────
+//
+// 4 directions codex round 3 asked us to lock:
+//   1. work/gate generation produces expected shape
+//   2. every segment passes the existing `isValidPathSegment` regex
+//      (so attempt sidecar paths + dashboard raw-log routes keep working)
+//   3. parser can recover {runId, loopId, iteration, kind, nodeId}
+//   4. plain `<runId>::work::<nodeId>` ids continue to parse correctly
+//      (no regression on v0.1 activities)
+
+describe('loop iteration activity IDs', () => {
+  it('loopWorkActivityId / loopGateActivityId compose the expected shape', () => {
+    const w = loopWorkActivityId('run-x-01', 'review-loop', 3, 'implement');
+    const g = loopGateActivityId('run-x-01', 'review-loop', 3, 'reviewDecision');
+    expect(w).toBe('run-x-01::loop::review-loop.3::work::implement');
+    expect(g).toBe('run-x-01::loop::review-loop.3::gate::reviewDecision');
+  });
+
+  it('rejects non-positive iteration', () => {
+    expect(() => loopWorkActivityId('r', 'l', 0, 'n')).toThrow();
+    expect(() => loopWorkActivityId('r', 'l', -1, 'n')).toThrow();
+    expect(() => loopWorkActivityId('r', 'l', 1.5, 'n')).toThrow();
+    expect(() => loopGateActivityId('r', 'l', 0, 'n')).toThrow();
+  });
+
+  it('every segment satisfies isValidPathSegment (no path-guard escape)', () => {
+    const ids = [
+      loopWorkActivityId('run-x-01', 'review-loop', 1, 'implement'),
+      loopWorkActivityId('run-x-01', 'review-loop', 12, 'implement.v2'),
+      loopGateActivityId('r2', 'L', 7, 'dec'),
+    ];
+    for (const id of ids) {
+      // Split into `::` separated segments and verify each one would
+      // survive the attempt-sidecar path guard.
+      for (const seg of id.split('::')) {
+        expect(isValidPathSegment(seg), `segment '${seg}' of '${id}' must pass isValidPathSegment`).toBe(true);
+      }
+    }
+  });
+
+  it('parseActivityId round-trips loop work ids', () => {
+    const id = loopWorkActivityId('run-7', 'inner-loop', 4, 'implement');
+    expect(parseActivityId(id)).toEqual({
+      kind: 'loop',
+      runId: 'run-7',
+      loopId: 'inner-loop',
+      iteration: 4,
+      activityKind: 'work',
+      nodeId: 'implement',
+    });
+  });
+
+  it('parseActivityId round-trips loop gate ids', () => {
+    const id = loopGateActivityId('run-7', 'inner-loop', 4, 'dec');
+    expect(parseActivityId(id)).toEqual({
+      kind: 'loop',
+      runId: 'run-7',
+      loopId: 'inner-loop',
+      iteration: 4,
+      activityKind: 'gate',
+      nodeId: 'dec',
+    });
+  });
+
+  it('parseActivityId still parses plain v0.1 work / gate ids', () => {
+    expect(parseActivityId(workActivityId('run-1', 'foo'))).toEqual({
+      kind: 'plain',
+      runId: 'run-1',
+      activityKind: 'work',
+      nodeId: 'foo',
+    });
+    expect(parseActivityId(gateActivityId('run-1', 'foo'))).toEqual({
+      kind: 'plain',
+      runId: 'run-1',
+      activityKind: 'gate',
+      nodeId: 'foo',
+    });
+  });
+
+  it('parseActivityId returns undefined for malformed ids', () => {
+    expect(parseActivityId('not-an-activity-id')).toBeUndefined();
+    expect(parseActivityId('run::weird::foo')).toBeUndefined();
+    // Iteration 0 is not a valid loop activity — parser rejects.
+    expect(parseActivityId('run::loop::L.0::work::foo')).toBeUndefined();
+  });
+
+  it('plain v0.1 ids do NOT collide with the loop shape parser', () => {
+    // A workflow author may legitimately name a node `loop.1` (dots and
+    // digits are allowed in NODE_ID_PATTERN).  Make sure that doesn't
+    // get mistakenly classified as a loop activity id.
+    const plain = workActivityId('run-1', 'loop.1');
+    expect(plain).toBe('run-1::work::loop.1');
+    const parsed = parseActivityId(plain);
+    expect(parsed?.kind).toBe('plain');
+    expect(parsed).toEqual({
+      kind: 'plain',
+      runId: 'run-1',
+      activityKind: 'work',
+      nodeId: 'loop.1',
+    });
+  });
+});
+
+describe('decideNextActions — loop / decision pass-through (Step 1 boundary)', () => {
+  it('loop and decision node types are skipped by the legacy scheduler', async () => {
+    // Schema has landed in v0.2 Step 1 but the loop runtime executor
+    // isn't wired yet.  `decideNextActions` recognizes `loop` /
+    // `decision` and silently pushes them into `pending` rather than
+    // failing/succeeding.  Step 3 will intercept these upstream so
+    // they never reach this branch.
+    //
+    // NOTE: Step 1 does NOT yet remove body-internal subagent /
+    // hostExecutor nodes from top-level dispatch.  That carve-out
+    // ("scheduler does not see body nodes") is part of Step 3 (see
+    // /tmp/wf-loop-v02.md §4.1).  Until then a body subagent like
+    // `implement` still gets dispatched normally, which is fine — the
+    // loop runtime will be the only thing emitting events for it once
+    // wired.
+    const def = parseWorkflowDefinition({
+      workflowId: 'wf-loop-step1',
+      version: 1,
+      nodes: {
+        implement: { type: 'subagent', bot: 'b', prompt: 'x' },
+        dec: {
+          type: 'decision',
+          depends: ['implement'],
+          humanGate: { stage: 'before', prompt: 'ok?' },
+        },
+        'review-loop': {
+          type: 'loop',
+          maxIterations: 2,
+          body: ['implement', 'dec'],
+          terminate: { node: 'dec', via: 'humanGate' },
+        },
+      },
+    });
+    const baseDir = mkdtempSync(join(tmpdir(), 'wf-orch-loop-step1-'));
+    try {
+      const log = new EventLog(RUN_ID, baseDir);
+      await createRun(log, {
+        def,
+        params: {},
+        initiator: 'tester',
+        botResolver: noopResolver,
+      });
+      const snap = replay(await log.readAll());
+      const actions = decideNextActions(snap, def);
+      const dispatchedNodes = actions
+        .filter((a) => a.kind === 'dispatchWork' || a.kind === 'dispatchGate')
+        .map((a) => (a as { nodeId: string }).nodeId);
+      // The `loop` block and the `decision` node MUST NOT be dispatched
+      // by the legacy scheduler.  (Step 3 will additionally hide body
+      // nodes; until then `implement` may show up here.)
+      expect(dispatchedNodes).not.toContain('review-loop');
+      expect(dispatchedNodes).not.toContain('dec');
+    } finally {
+      rmSync(baseDir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/workflow-orchestrator.test.ts
+++ b/test/workflow-orchestrator.test.ts
@@ -563,6 +563,7 @@ describe('decideNextActions — loop / decision pass-through (Step 1 boundary)',
           maxIterations: 2,
           body: ['implement', 'dec'],
           terminate: { node: 'dec', via: 'humanGate' },
+          output: { from: 'implement' },
         },
       },
     });

--- a/test/workflow-output-binding.test.ts
+++ b/test/workflow-output-binding.test.ts
@@ -29,7 +29,7 @@ import {
 } from '../src/workflows/runtime.js';
 import { decideNextActions } from '../src/workflows/orchestrator.js';
 import { createRun } from '../src/workflows/run-init.js';
-import { workActivityId } from '../src/workflows/orchestrator.js';
+import { loopGateActivityId, loopWorkActivityId, workActivityId } from '../src/workflows/orchestrator.js';
 
 const RUN_ID = 'run-binding-test';
 
@@ -91,6 +91,7 @@ describe('BoundJsonValueSchema', () => {
 describe('parseRef', () => {
   it('splits on the first .output. occurrence', () => {
     expect(parseRef('draft.output.greeting')).toEqual({
+      kind: 'output',
       nodeId: 'draft',
       pathSegments: ['greeting'],
     });
@@ -98,6 +99,7 @@ describe('parseRef', () => {
 
   it('handles dotted nodeIds (NODE_ID_PATTERN allows dots)', () => {
     expect(parseRef('team.draft.output.x.y')).toEqual({
+      kind: 'output',
       nodeId: 'team.draft',
       pathSegments: ['x', 'y'],
     });
@@ -105,6 +107,7 @@ describe('parseRef', () => {
 
   it('splits on the first .output. only — later .output. is part of path', () => {
     expect(parseRef('node.output.output.x')).toEqual({
+      kind: 'output',
       nodeId: 'node',
       pathSegments: ['output', 'x'],
     });
@@ -140,6 +143,7 @@ describe('parseRef', () => {
 
   it('accepts numeric segments (array indices)', () => {
     expect(parseRef('draft.output.0.x')).toEqual({
+      kind: 'output',
       nodeId: 'draft',
       pathSegments: ['0', 'x'],
     });
@@ -147,8 +151,17 @@ describe('parseRef', () => {
 
   it('accepts params refs without .output. separator', () => {
     expect(parseRef('params.user.email')).toEqual({
+      kind: 'params',
       nodeId: 'params',
       pathSegments: ['user', 'email'],
+    });
+  });
+
+  it('accepts previous refs for loop iterations', () => {
+    expect(parseRef('reviewDecision.previous.comment')).toEqual({
+      kind: 'previous',
+      nodeId: 'reviewDecision',
+      pathSegments: ['comment'],
     });
   });
 });
@@ -349,6 +362,161 @@ describe('resolveOutputRef — snapshot+blob walk', () => {
     await expect(
       resolveOutputRef('params.user.name', { snapshot: snap, def, log }),
     ).rejects.toThrow(/not found/);
+  });
+
+  it('resolves latest successful loop iteration output for a body node', async () => {
+    const def = {
+      workflowId: 'wf-loop-bind',
+      version: 1,
+      nodes: {
+        implement: { type: 'subagent', bot: 'b', prompt: 'x' },
+        'review-loop': {
+          type: 'loop',
+          maxIterations: 2,
+          body: ['implement'],
+          terminate: { node: 'implement', via: 'humanGate' },
+          output: { from: 'implement' },
+        },
+      },
+    } as any;
+    const log = new EventLog(RUN_ID, baseDir);
+    await log.append({
+      runId: RUN_ID,
+      type: 'runCreated',
+      actor: 'scheduler',
+      payload: {
+        workflowId: 'wf-loop-bind',
+        revisionId: 'rev',
+        inputRef: { outputHash: 'sha256:' + '1'.repeat(64), outputBytes: 1, outputSchemaVersion: 1 },
+        initiator: 't',
+      },
+    });
+    const { promises: fsp } = await import('node:fs');
+    await fsp.mkdir(join(baseDir, RUN_ID, 'blobs'), { recursive: true });
+    const firstPath = join(baseDir, RUN_ID, 'blobs', 'loop-1.json');
+    const secondPath = join(baseDir, RUN_ID, 'blobs', 'loop-2.json');
+    writeFileSync(firstPath, JSON.stringify({ code: 'v1' }));
+    writeFileSync(secondPath, JSON.stringify({ code: 'v2' }));
+    await log.append({
+      runId: RUN_ID,
+      type: 'attemptCreated',
+      actor: 'scheduler',
+      payload: {
+        nodeId: 'implement',
+        activityId: loopWorkActivityId(RUN_ID, 'review-loop', 1, 'implement'),
+        attemptId: 'att-1',
+        attemptNumber: 1,
+        inputRef: { outputHash: 'sha256:' + '5'.repeat(64), outputBytes: 1, outputSchemaVersion: 1 },
+      },
+    });
+    await log.append({
+      runId: RUN_ID,
+      type: 'activitySucceeded',
+      actor: 'worker',
+      payload: {
+        activityId: loopWorkActivityId(RUN_ID, 'review-loop', 1, 'implement'),
+        attemptId: 'att-1',
+        outputRef: { outputHash: 'sha256:' + '2'.repeat(64), outputBytes: 13, outputSchemaVersion: 1, outputPath: firstPath },
+      },
+    });
+    await log.append({
+      runId: RUN_ID,
+      type: 'attemptCreated',
+      actor: 'scheduler',
+      payload: {
+        nodeId: 'implement',
+        activityId: loopWorkActivityId(RUN_ID, 'review-loop', 2, 'implement'),
+        attemptId: 'att-2',
+        attemptNumber: 1,
+        inputRef: { outputHash: 'sha256:' + '6'.repeat(64), outputBytes: 1, outputSchemaVersion: 1 },
+      },
+    });
+    await log.append({
+      runId: RUN_ID,
+      type: 'activitySucceeded',
+      actor: 'worker',
+      payload: {
+        activityId: loopWorkActivityId(RUN_ID, 'review-loop', 2, 'implement'),
+        attemptId: 'att-2',
+        outputRef: { outputHash: 'sha256:' + '3'.repeat(64), outputBytes: 13, outputSchemaVersion: 1, outputPath: secondPath },
+      },
+    });
+    await log.append({
+      runId: RUN_ID,
+      type: 'loopFinished',
+      actor: 'scheduler',
+      payload: {
+        loopId: 'review-loop',
+        finalIteration: 2,
+        resolution: 'approved',
+        outputRef: { outputHash: 'sha256:' + '3'.repeat(64), outputBytes: 13, outputSchemaVersion: 1, outputPath: secondPath },
+      },
+    });
+    const snap = replay(await log.readAll());
+    await expect(resolveOutputRef('implement.output.code', { snapshot: snap, def, log }))
+      .resolves.toBe('v2');
+    await expect(resolveOutputRef('review-loop.output.code', { snapshot: snap, def, log }))
+      .resolves.toBe('v2');
+  });
+
+  it('resolves previous output only from loop context', async () => {
+    const def = {
+      workflowId: 'wf-loop-bind',
+      version: 1,
+      nodes: {
+        reviewDecision: { type: 'decision', humanGate: { stage: 'before', prompt: 'x' } },
+      },
+    } as any;
+    const log = new EventLog(RUN_ID, baseDir);
+    await log.append({
+      runId: RUN_ID,
+      type: 'runCreated',
+      actor: 'scheduler',
+      payload: {
+        workflowId: 'wf-loop-bind',
+        revisionId: 'rev',
+        inputRef: { outputHash: 'sha256:' + '1'.repeat(64), outputBytes: 1, outputSchemaVersion: 1 },
+        initiator: 't',
+      },
+    });
+    const { promises: fsp } = await import('node:fs');
+    await fsp.mkdir(join(baseDir, RUN_ID, 'blobs'), { recursive: true });
+    const prevPath = join(baseDir, RUN_ID, 'blobs', 'decision-1.json');
+    writeFileSync(prevPath, JSON.stringify({ comment: 'fix tests' }));
+    await log.append({
+      runId: RUN_ID,
+      type: 'attemptCreated',
+      actor: 'scheduler',
+      payload: {
+        nodeId: 'reviewDecision',
+        activityId: loopGateActivityId(RUN_ID, 'review-loop', 1, 'reviewDecision'),
+        attemptId: 'att-1',
+        attemptNumber: 1,
+        inputRef: { outputHash: 'sha256:' + '7'.repeat(64), outputBytes: 1, outputSchemaVersion: 1 },
+      },
+    });
+    await log.append({
+      runId: RUN_ID,
+      type: 'activitySucceeded',
+      actor: 'human',
+      payload: {
+        activityId: loopGateActivityId(RUN_ID, 'review-loop', 1, 'reviewDecision'),
+        attemptId: 'att-1',
+        outputRef: { outputHash: 'sha256:' + '4'.repeat(64), outputBytes: 23, outputSchemaVersion: 1, outputPath: prevPath },
+      },
+    });
+    const snap = replay(await log.readAll());
+    await expect(
+      resolveOutputRef('reviewDecision.previous.comment', {
+        snapshot: snap,
+        def,
+        log,
+        loopContext: { loopId: 'review-loop', iteration: 2 },
+      }),
+    ).resolves.toBe('fix tests');
+    await expect(
+      resolveOutputRef('reviewDecision.previous.comment', { snapshot: snap, def, log }),
+    ).rejects.toThrow(/outside a loop iteration context/);
   });
 });
 

--- a/test/workflow-progress-card.test.ts
+++ b/test/workflow-progress-card.test.ts
@@ -424,4 +424,118 @@ describe('workflow-progress-card', () => {
       expect(json).not.toContain(encodeURIComponent('run-x::work::gate::1'));
     });
   });
+
+  // ─── v0.2 loop iteration section (Step 4) ───────────────────────────────
+  //
+  // Active loop blocks surface a `🔁 循环节点` section so the operator can
+  // see "we're on iteration N/M" at a glance.  Settled loops are hidden
+  // (the outer card already shows the run-level terminal state).
+
+  describe('loop iteration section', () => {
+    function snapshotWithLoop(over: {
+      status?: Snapshot['run']['status'];
+      loopId?: string;
+      iteration?: number;
+      maxIterations?: number;
+      loopStatus?: 'running' | 'succeeded' | 'failed' | 'cancelled';
+      iterStatus?: 'running' | 'approved' | 'rejected' | 'failed' | 'cancelled';
+    } = {}): Snapshot {
+      const snap = emptySnapshot({ status: over.status ?? 'running' });
+      // Inject a `loops` Map onto the empty snapshot.  Tests live close
+      // to the replay shape; this mirrors what `replay()` returns once
+      // loopStarted / loopIterationStarted have processed.
+      const loopId = over.loopId ?? 'review-loop';
+      const iteration = over.iteration ?? 1;
+      const maxIterations = over.maxIterations ?? 3;
+      const loopStatus = over.loopStatus ?? 'running';
+      const iterStatus = over.iterStatus ?? 'running';
+      (snap as unknown as { loops: Map<string, unknown> }).loops = new Map([
+        [
+          loopId,
+          {
+            loopId,
+            status: loopStatus,
+            iteration,
+            maxIterations,
+            iterations: Array.from({ length: iteration }, (_, i) => ({
+              iteration: i + 1,
+              status: i === iteration - 1 ? iterStatus : 'rejected',
+              bodyActivityIds: [],
+            })),
+          },
+        ],
+      ]);
+      return snap;
+    }
+
+    it('renders 🔁 循环节点 section with iteration N/M while loop running', () => {
+      const snap = snapshotWithLoop({
+        loopId: 'review-loop',
+        iteration: 2,
+        maxIterations: 3,
+        iterStatus: 'running',
+      });
+      const json = buildWorkflowProgressCard(snap);
+      expect(json).toContain('🔁 循环节点** (1)');
+      expect(json).toContain('iteration 2/3');
+      expect(json).toContain('running');
+      expect(json).toContain('review-loop');
+    });
+
+    it('does NOT render loop section when run is terminal', () => {
+      const snap = snapshotWithLoop({
+        status: 'succeeded',
+        loopStatus: 'succeeded',
+        iteration: 1,
+        iterStatus: 'approved',
+      });
+      const json = buildWorkflowProgressCard(snap);
+      expect(json).not.toContain('🔁 循环节点');
+    });
+
+    it('does NOT render loop section when loop itself is finalized', () => {
+      // run still nominally running (parallel branches?) but the only
+      // loop in the def has succeeded — collectLoopRows excludes
+      // non-running loops.
+      const snap = snapshotWithLoop({
+        status: 'running',
+        loopStatus: 'succeeded',
+        iteration: 1,
+      });
+      const json = buildWorkflowProgressCard(snap);
+      expect(json).not.toContain('🔁 循环节点');
+    });
+
+    it('clamps iteration to 1 in the gap between startLoop and startLoopIteration', () => {
+      // The orchestrator emits startLoop on tick N and
+      // startLoopIteration on tick N+1.  The card might render in
+      // between (iteration === 0); clamp to 1 so the user doesn't see
+      // "iteration 0/3".
+      const snap = emptySnapshot({ status: 'running' });
+      (snap as unknown as { loops: Map<string, unknown> }).loops = new Map([
+        [
+          'review-loop',
+          {
+            loopId: 'review-loop',
+            status: 'running',
+            iteration: 0, // startLoop fired, startLoopIteration not yet
+            maxIterations: 3,
+            iterations: [],
+          },
+        ],
+      ]);
+      const json = buildWorkflowProgressCard(snap);
+      expect(json).toContain('iteration 1/3');
+    });
+
+    it('handles workflow with no loops (loops field absent)', () => {
+      // Backward-compat: emptySnapshot doesn't set `loops` at all;
+      // collectLoopRows must treat that as "no loops" without throwing.
+      const snap = emptySnapshot({ status: 'running' });
+      const json = buildWorkflowProgressCard(snap);
+      expect(json).not.toContain('🔁 循环节点');
+      // sanity — the rest of the card still renders
+      expect(json).toContain('Web 详情');
+    });
+  });
 });

--- a/workflows/code-review-loop.workflow.json
+++ b/workflows/code-review-loop.workflow.json
@@ -1,0 +1,68 @@
+{
+  "workflowId": "code-review-loop",
+  "version": 1,
+  "params": {
+    "task": {
+      "type": "string",
+      "required": true,
+      "description": "What to implement (e.g. 'add a CLI command that prints the loop schema')"
+    }
+  },
+  "defaults": {
+    "retryPolicy": { "maxAttempts": 1, "backoff": "fixed", "baseMs": 1000 },
+    "timeoutMs": 600000,
+    "maxOutputBytes": 16384
+  },
+  "nodes": {
+    "implement": {
+      "type": "subagent",
+      "bot": "cli_canary_PLACEHOLDER",
+      "description": "Implementer agent. Produces a JSON {code, summary}. On second+ iterations, picks up `${reviewDecision.previous.comment}` from the prior reject as guidance.",
+      "prompt": "实现以下任务：${params.task}\n\n上一轮 review 反馈（如有）：${reviewDecision.previous.comment}\n\n返回 JSON: {\"code\": string, \"summary\": string}",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["code", "summary"],
+        "properties": {
+          "code": { "type": "string" },
+          "summary": { "type": "string" }
+        }
+      }
+    },
+    "review": {
+      "type": "subagent",
+      "bot": "cli_canary_PLACEHOLDER",
+      "depends": ["implement"],
+      "description": "Reviewer agent. Produces preview (shown on approval card) + summary (full feedback). Stays a separate node from reviewDecision so reviewDecision's humanGate.before can $ref this output (designed in /tmp/wf-loop-v02.md §3.1 — humanGate.before cannot read same-node output).",
+      "prompt": "审查以下代码：\n\n${implement.output.code}\n\n实现总结：${implement.output.summary}\n\n返回 JSON: {\"preview\": string, \"summary\": string} — preview 用于审批卡片预览（<200 字符），summary 是详细评审意见。",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["preview", "summary"],
+        "properties": {
+          "preview": { "type": "string" },
+          "summary": { "type": "string" }
+        }
+      }
+    },
+    "reviewDecision": {
+      "type": "decision",
+      "depends": ["review"],
+      "description": "Loop terminator. Pure humanGate — approve closes the loop, reject opens iteration N+1 with the comment feeding back into `implement.prompt`.",
+      "humanGate": {
+        "stage": "before",
+        "prompt": { "$ref": "review.output.preview" },
+        "deadlineMs": 1800000,
+        "onTimeout": "fail"
+      }
+    },
+    "review-loop": {
+      "type": "loop",
+      "description": "Wraps implement → review → reviewDecision into a reject-revisit loop. maxIterations=3 is the safe-by-default cap; bump for harder tasks.",
+      "maxIterations": 3,
+      "body": ["implement", "review", "reviewDecision"],
+      "terminate": { "node": "reviewDecision", "via": "humanGate" },
+      "output": { "from": "implement" }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds **workflow loop control flow** (v0.2) — a first-class `loop` node type
that wraps a body sub-graph in a reject-revisit cycle terminated by a
`decision` (gate-only) node. Designed for code → review → reject-feedback
flows where a single workflow run iterates until human approval.

Designed md-first in `/tmp/wf-loop-v02.md` across 3 codex review rounds
before code landed. 5 implementation steps + 2 dogfood-driven fixes +
2 codex-PR-review fixes + 1 security-followup fix + 2 round-3
external-review fixes across **14 commits** on this branch.

Also bundles two orthogonal security fixes from review (codex v0.1.6
issue #1 + a second-pass review on this PR): tighten the
`…/terminal-log/raw` stream + the `/snapshot` JSON's `io.log.text`
field, both of which can leak API keys / env / tokens lifted from the
subagent's stdout.

## What's new

### Schema (Step 1 — `2d3eb78`)
- New node types: `loop` + `decision`, both `.strict()` so unknown fields
  fail-loud at parse time (codex N2: decision output contract is
  runtime-fixed, no custom `outputSchema`).
- `validateLoopBlocks` cross-field invariants: body membership, no
  nested loops, no cross-loop body sharing, decision must live in some
  body, external body deps must surface on `loop.depends` (codex N1),
  outsiders can only depend on the loop block (not body nodes).
- ActivityId convention: `<runId>::loop::<loopId>.<N>::work::<bodyNode>`
  / `::gate::<bodyNode>` — all segments stay within the existing
  `isValidPathSegment` regex, no path-guard widening.
- Root check now scopes to scheduler-visible nodes (loop body nodes are
  not workflow-level roots).

### Events + read side (Step 2 — `334456b`)
- 4 new loop lifecycle events: `loopStarted` / `loopIterationStarted` /
  `loopIterationFinished` / `loopFinished`, each carrying audit anchors
  (`decisionActivityId`, `waitResolvedEventId`, etc.).
- `snapshot.loops` in replay — per-loop state with `iterations[]`,
  `output` projection, error code/class.
- `previous` binding: `${node.previous.x}` reads iteration N-1's output;
  string template missing → empty string (first iteration grace),
  whole-field `$ref` → BindingError (strict early-fail).
- `output.from` projection: `loopFinished.outputRef` lands in
  `outputs[workActivityId(runId, loopId)]` so `${loop.output.x}` and
  direct body refs resolve identically without blob duplication.
- Schema invariants: `max-iterations-exceeded` / `body-failed` /
  `timeout` each lock errorCode + errorClass pairings.

### Runtime executor (Step 3 — `02900e8`, `8d74aa8`)
- 4 new `OrchestratorAction` kinds (`startLoop` /
  `startLoopIteration` / `finishLoopIteration` / `finishLoop`) emitted
  ONLY by the loop branch, each as a SOLE-return action per tick so
  event ordering is deterministic: `loopStarted → loopIterationStarted
  → body attempts → loopIterationFinished → [next iteration | loopFinished]`.
- `decideNodeAdvancement` helper extracted; body nodes use loop
  activityIds, plain nodes use plain ids, paths never cross.
- `wait.ts` decision-mode interception: for decision nodes both
  approve and reject write `activitySucceeded` with
  `{resolution, by, comment?}` output blob (rejection is a legal
  decision output, not a failure). Non-decision nodes keep v0.1
  reject → `activityFailed` so non-terminator humanGates inside the
  body still fail-run.
- `findRootCauseEventId` recognises `loopFinished` as a root-cause
  fallback for loop-level failures (loop blocks have no own attempt
  or `nodeFailed` event).
- `resolveWait` now returns `waitResolvedEventId` at the top level for
  callers that need the N3 audit anchor without reaching into the
  resolution event.

### Dashboard + IM card (Step 4 — `20f86b5`)
- `RunSnapshotDTO.loops?` optional field — pure replay projection,
  forward-compat with v0.1 clients. Carries full iteration list +
  audit anchors + output projection.
- Lark progress card: new `🔁 循环节点` section showing
  `loopId · iteration N/M (iterStatus)` while the loop is running.
  Hidden once the run reaches a terminal state (consistent with
  existing `🏃 进行中` / `⏸ 等待审批` behaviour).
- Dashboard frontend HTML iteration timeline (§8) intentionally
  deferred — current Run Detail still renders attempts flat, codex
  + author agreed to wait for dogfood before deciding the
  visual structure. The DTO contract is in place to land it later
  without runtime / replay changes.

### Dogfood + post-dogfood fixes (Step 5)

**Dogfood workflow** (`e0713a5`):
- `workflows/code-review-loop.workflow.json`: canonical example,
  implement → review → reviewDecision (decision) → loop. Uses
  `${reviewDecision.previous.comment}` to feed reject feedback into
  the next iteration. Validates clean via `botmux workflow validate`.

**Dogfood revealed two bugs, both fixed on this PR**:

**Fix 1 — `bindingContext` 漏传 `loopContext` (`beaddd4`)**
- Symptom: iteration 2's `implement.prompt` referencing
  `${reviewDecision.previous.comment}` errored with
  `InputBindingFailed: '.previous.' used outside loop iteration context`.
- Root cause: `runtime.bindingContext()` factory never populated the
  `loopContext` field; all `dispatchWork` / `dispatchHumanGate` call
  sites passed undefined → output-binding rejected `.previous.` paths.
- Fix: added optional `activityId` to `bindingContext()`, derive
  `{loopId, iteration}` via `parseActivityId`, updated 2 call sites.
- Regression test: `implement prompt resolves ${reviewDecision.previous.comment}
  per iteration` — iter 1 → `"do task | feedback="` (grace),
  iter 2 (after reject with comment) → `"do task | feedback=add error handling"`.

**Fix 2 — decision-node reject 应写 `activitySucceeded` (`d772531`)**
- Symptom: humanGate reject on a decision node → run finished as
  `WaitDeadlineExceeded` instead of iterating back to body.
- Root cause: `resolveWait` detects decision mode via optional 3rd
  `ctx.def` arg; both the Lark card-handler path and the
  daemon's local `resolveWait` call were passing only 2 args, so
  `isDecisionNode(def, nodeId)` couldn't be evaluated, falling back
  to v0.1 `rejected → activityFailed`, which the orchestrator
  surfaces as timeout.
- Fix: new helper `readWorkflowDefinitionFromRunDir(runDir)` loads
  the per-run `workflow.json` snapshot (run-bound, not catalog
  drift–sensitive); card-handler loads + passes `{def}`, daemon
  passes `entry.ctx.def`.
- Regression test: snapshot a loop def with decision node, create
  wait + reject via card handler, assert `activitySucceeded` event
  with `externalRefs: {resolution:'rejected', by, comment}`.

### Codex round-2 review fixes (`3f5122b`)

Codex's second-round review found two schema-legal-but-runtime-broken
configurations. Both now blocked at `validateLoopBlocks` parse time:

**Sink loop without `output.from`** — orchestrator's run-completion
branch only emits `completeRunSucceeded` when the sink activity has an
output blob; a loop block without `output.from` never writes
`outputs[sinkActivityId]` from `loopFinished`, so the run hangs in
`no-progress`. `validateLoopBlocks` now refuses any loop that has no
external dependents but doesn't declare `output.from`, with an error
message suggesting `output.from: <body node>`.

**Decision node + `humanGate.onTimeout='success'`** — `expireWait`
writes `activitySucceeded { defaultedToTimeout, deadlineAt }` without
`resolution`/`by`/`comment`, so the next iteration's
`${decisionNode.previous.comment}` BindingErrors. `validateLoopBlocks`
now refuses `onTimeout='success'` on decision nodes (default `'fail'`
remains correct; if "timeout auto-approve" is needed, author should
use a wrapper subagent that emits structured resolution).

6 new regression cases in `workflow-definition.test.ts` cover both
rules (positive + negative, plus default-onTimeout).

### Round-3 external review fixes (`1a3a65c`)

A third reviewer found two more issues; both folded in pre-merge:

**Body multi-decision footgun.** `wait.ts` decision-mode treats *any*
decision-typed node's reject as `activitySucceeded { resolution }`,
not just the terminator's. So a body like `[work, preDecision,
finalDecision]` would parse fine but silently swallow `preDecision`
reject — body continues to `finalDecision` even though the author
intended the reject to terminate the loop.  Fix: `validateLoopBlocks`
now enforces "body must contain exactly one decision node" (which,
combined with the existing `terminate.node must be a decision in the
body` rule, transitively requires that decision == terminate.node).
Error message redirects authors to `subagent + humanGate` for
intermediate approvals.  +3 tests.

**`readWorkflowDefinitionFromRunDir` silent catch-all.** The
`catch { return null }` fallback is intentional (resolveWait without
def degrades to v0.1 approve/reject), but a bare catch ate parse
errors and EACCES silently — invisible during debugging.  Fix:
ENOENT still returns null silently (legacy v0.1 runs without
`workflow.json` are normal); other errors now `logger.warn` with
the call site noted as "caller falls back to v0.1 wait semantics".
+2 tests (ENOENT silent / corrupt JSON warns once).

### Bonus security fixes (`b5d23a6` + `4f7453f`)

**`b5d23a6` — `…/terminal-log/raw` → cookie auth.** Removed from
public-read allowlist (both pty + diag streams). PTY transcripts
can leak API keys / env / tokens; dashboard SPA still works (auth
cookie), only "share the URL with someone unauthenticated" breaks
— which it should. From v0.1.6 review issue #1; user-approved
2026-05-23.

**`4f7453f` — `/snapshot` JSON also strips log bytes when unauth'd.**
A second-pass review caught that `b5d23a6` only hid the streaming
download endpoint; the same `terminal.log` last 64 KiB still leaked
through `attemptIO[*].log.text` on the public `GET /snapshot` route.
New pure helper `scrubSnapshotForUnauthed` strips `io.log.text/value`
(plus `io.terminal.logPath`) but keeps metadata (`outputBytes`,
`truncated`, `redacted: true`, terminal `status`/`sessionId`/`webPort`)
so cards still render a "log available after login" placeholder.
`handleWorkflowApi` takes a new `authed: boolean` arg (defaults to
`false` for fail-secure); `dashboard.ts` computes it from the
existing `decideDashboardAuth` token check and threads it through.
+1 ops-projection test + 1 HTTP route test.

## Testing

| File | Tests |
|---|---|
| `workflow-definition.test.ts` | +26 (schema + validateLoopBlocks + **round-3: body single-decision enforcement**) |
| `workflow-loader.test.ts` | **+2** (**round-3: ENOENT silent, corrupt JSON warns**) |
| `workflow-orchestrator.test.ts` | +9 (activityId helpers + boundary) |
| `workflow-events-replay.test.ts` | loop lifecycle replay (Step 2) |
| `workflow-output-binding.test.ts` | `previous` + projection (Step 2) |
| `workflow-loop-runtime.test.ts` | **+11** (e2e: happy / multi-reject / max-exceeded / decision wait / non-terminator §10.8 / output projection / rootCauseEventId / outputPath / **dogfood: `.previous.` cross-iteration prompt**) |
| `workflow-ops-projection.test.ts` | +6 (loop DTO projection + audit round-trip + **scrub helper authed vs unauthed**) |
| `workflow-progress-card.test.ts` | +5 (🔁 iteration section + edge cases) |
| `workflow-approval-card.test.ts` | **+1** (**dogfood: decision-node reject writes activitySucceeded**) |
| `dashboard-auth.test.ts` | +2 (terminal-log/raw cookie gate) |
| `dashboard-workflow-api.test.ts` | **+1** (**snapshot route scrubs log bytes for unauth'd**) |

Targeted runs: `workflow-loop-runtime` + `workflow-approval-card`
→ **25/25 passing**. `tsc --noEmit` clean. Full suite passes (2 pre-existing
external-CLI e2e failures unrelated to this PR — gemini-input / opencode-input).

## Dogfood results (validated end-to-end)

3 production-shape runs against the `code-review-loop` workflow validated
all three v0.2 design contracts:

- ✅ **decision-node reject → `activitySucceeded` + iteration N+1**: run
  `code-review-loop-2026-05-24T16-12-26-566Z-8ef2f56f`, 3 rejects with
  distinct comments, iteration counter advanced correctly each time.
- ✅ **`${reviewDecision.previous.comment}` cross-iteration binding**:
  same run, implement output evolved visibly through reject feedback
  (bare HTTP handler → `http.Server` with timeouts →
  `recoverMiddleware` + `/healthz` + `/readyz` + ready atomic flag).
- ✅ **`max-iterations-exceeded` path**: 4th iteration blocked,
  `loopFinished` with correct errorCode/errorClass, `runFailed`
  pointing back to `loopFinished.eventId` as rootCauseEventId.

## Known follow-ups (NOT blockers)

- **Dashboard iteration timeline**: backend DTO is exposed; frontend
  HTML iteration-grouped render (§8) waits for dogfood-driven UX
  decision.
- **Fresh-session only for loop body**: each iteration spawns a fresh
  CLI session; reusing/extending a long-running session across
  iterations isn't wired yet.
- **Fanout `activityRunning` write window**: tiny crash window between
  the subagent dispatch emitting `activityRunning` and worker spawn;
  recovery enricher already closes most of this gap, residual narrow
  case left as cleanup.
- **`body-failed.errorClass` derivation**: currently hardcoded `fatal`
  in the orchestrator; should derive from the underlying body
  failure's errorClass for non-terminator humanGate reject case
  (would be `userFault`). ~30-line fix.
- **Standalone decision nodes**: v0.2 requires every `decision` node
  to live inside a loop body. Relaxing this for "lone gate that
  produces structured output" is a clean schema extension if a use
  case emerges.
- **`runCancel` + `loopFinished(cancelled)` DTO consistency** (codex
  round-2 #3): run cancel writes `nodeCanceled`/`runCanceled` but not
  `loopFinished(cancelled)`. Run finalization works; the loop DTO
  stays in `running` after cancel — cosmetic, doesn't affect
  scheduling. Add a synthesized `loopFinished(cancelled)` in the
  cancel sweep when the cancelled run had a running loop.

## Merge strategy

Squash — 11 commits roll up into one master commit. Branch is
`feat/workflow-loop-v02`. Bonus auth fix is a separate concern but
small enough to ride in this PR rather than block on a separate
merge cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
