### PR TITLE
fix(cli): cursor adapter 逐行输入，修复多行消息被折叠成 [Pasted text] 占位符

### DIFF
--- a/src/adapters/cli/cursor.ts
+++ b/src/adapters/cli/cursor.ts
@@ -6,6 +6,12 @@ function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+/** PTYs that have already received a writeInput. The first write lands while
+ *  cursor-agent's TUI is still doing its startup render, so it needs a longer
+ *  settle + throttle than later writes. Tracked by identity so the warmup state
+ *  is shared across adapter instances. Mirrors claude-code's first-write guard. */
+const cursorFirstWriteSeen = new WeakSet<PtyHandle>();
+
 export function createCursorAdapter(pathOverride?: string): CliAdapter {
   const bin = resolveCommand(pathOverride ?? 'cursor-agent');
   return {
@@ -34,19 +40,58 @@ export function createCursorAdapter(pathOverride?: string): CliAdapter {
     },
 
     async writeInput(pty: PtyHandle, content: string) {
-      // No on-disk submit verification yet — cursor stores transcripts as
-      // JSONL but the path isn't documented. Treat like aiden: paste the
-      // text, brief settle, send Enter. Worker still gets quiescence-based
-      // idle and the bridge fallback timer if the model never replies.
-      if (pty.sendText && pty.sendSpecialKeys) {
-        pty.sendText(content);
+      // Emit line-by-line instead of writing the whole message at once.
+      // cursor-agent's paste detector folds a multi-line chunk that arrives in
+      // one burst into a `[Pasted text +N lines]` placeholder the model can't
+      // read; typing each line with a throttle between keeps it under that
+      // threshold so the text lands verbatim. Covers both backends — tmux
+      // (send-keys) and raw PTY (write only). Never use bracketed-paste markers
+      // (\x1b[200~ … \x1b[201~): they trigger the fold.
+      //
+      // Soft-newline differs per backend because the detector counts LF (0x0a)
+      // bytes arriving densely:
+      //   - tmux: Ctrl+J, cursor's native soft-newline — renders cleanly and
+      //     send-keys spaces the bytes out enough to never fold.
+      //   - raw PTY: a fast write('\n') folds, so send `\` + CR; cursor eats the
+      //     backslash-before-CR as a soft-newline (not part of the submitted
+      //     text) and no LF byte hits the stream, making it fold-immune. Costs a
+      //     cosmetic trailing `\` in the local TUI render only.
+      // Submit is always a bare Enter (\r). No on-disk submit verification —
+      // cursor's transcript path isn't documented, so the worker relies on
+      // idle detection + the bridge fallback timer.
+      const useKeys = !!(pty.sendText && pty.sendSpecialKeys);
+      const emitText = (s: string) => (useKeys ? pty.sendText!(s) : pty.write(s));
+      const emitSoftNewline = () => {
+        if (useKeys) {
+          pty.sendSpecialKeys!('C-j');
+        } else {
+          pty.write('\\');
+          pty.write('\r');
+        }
+      };
+      const emitEnter = () => (useKeys ? pty.sendSpecialKeys!('Enter') : pty.write('\r'));
+
+      const isFirstWrite = !cursorFirstWriteSeen.has(pty);
+      if (isFirstWrite) {
+        cursorFirstWriteSeen.add(pty);
         await delay(200);
-        pty.sendSpecialKeys('Enter');
-      } else {
-        pty.write(content);
-        await delay(1000);
-        pty.write('\r');
       }
+      const throttleMs = isFirstWrite ? 80 : 30;
+      const tick = () => delay(throttleMs);
+
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i].length > 0) {
+          emitText(lines[i]);
+          await tick();
+        }
+        if (i < lines.length - 1) {
+          emitSoftNewline();
+          await tick();
+        }
+      }
+      await delay(200);
+      emitEnter();
     },
 
     completionPattern: undefined,


### PR DESCRIPTION
## 问题

cursor bot 收到飞书多行消息后，cursor-agent TUI 把整段内容折叠成 `[Pasted text +N lines]` 占位符，模型读不到原文（回复 "I don't actually see the pasted content"），飞书侧无任何回复，worker 日志一直 `Prompt detected (idle)`。

## 根因

旧 `writeInput` 一次性把整段多行内容写进 PTY（tmux 下 `sendText(整段)`，raw PTY 下 `write(整段)`）。cursor-agent 的 paste 检测在「一坨带换行的内容在很短时间内到达」时触发，折叠成占位符。实测：单次大写一定折叠；逐行写入则不会。

## 修复

改为**逐行 emit + 节流**，按 backend 选 soft-newline（因为 cursor 的检测是数密集到达的 LF 字节）：

- **tmux**：用 `Ctrl+J`（cursor 原生 soft-newline）——渲染干净无 `\` 残留，且 `send-keys` 逐键投递把字节拉开，不会触发折叠。
- **raw PTY**（无 tmux 的兜底）：用 `\` + CR——不带 LF 字节，天生免折叠；cursor 把行末 `\` 当 soft-newline 吃掉，不进入提交内容（模型收到干净原文），仅本地 TUI 渲染留一个 cosmetic `\`。
- 末尾单个 `Enter` 提交。首写多 settle + 加大 throttle（TUI 启动渲染未排空）。

不再使用 bracketed-paste 标记（`\x1b[200~ … \x1b[201~`），那正是触发折叠的东西。

## 验证

在 cursor-agent **2026.05.20** 直接复现并验证（tmux + Ctrl+J）：

| 检查项 | 结果 |
| --- | --- |
| `[Pasted text]` 折叠 | 0（40 / 60 行） |
| 行末字面 `\` 残留 | 0 |
| 模型完整收到原文 | ✓（回显首行+末行，含行内/路径反斜杠） |

读取 cursor 本地 transcript 交叉确认：模型收到的是完整 30 行原文，反斜杠、markdown 字面、中文/符号全部保留，无占位符。

🤖 Generated with [Claude Code](https://claude.com/claude-code)