### PR TITLE
fix(lark): 所有只读 GET 避免发空 body（规避网关 411）

### DIFF
--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -14,13 +14,18 @@ type LarkRequestParams = Record<string, string | number | boolean | undefined>;
  * Call a Feishu GET endpoint without a request body.
  *
  * The official SDK currently lets axios attach `{}` as `data` for generated
- * GET calls such as im.v1.message.list/get. Some gateway deployments reject
- * GET-with-body and return HTTP 411 before the OpenAPI handler sees the
- * request. `client.request()` contains an explicit GET empty-body guard, while
- * still using the SDK's token/cache/auth plumbing, so use it for read-only
- * message history/detail calls.
+ * GET calls such as im.v1.message.list/get, im.v1.chat.get/list,
+ * im.v1.chatMembers.isInChat and contact.v3.user.get. Some gateway
+ * deployments reject GET-with-body and return HTTP 411 before the OpenAPI
+ * handler sees the request. The SDK's generic `client.request()` contains an
+ * explicit GET empty-body guard (`fix: #153`) while still using the SDK's
+ * token/cache/auth plumbing, so route every read-only GET through it.
+ *
+ * `url` is the API path (e.g. `/open-apis/im/v1/chats/<id>`); path params must
+ * already be interpolated by the caller. Returns the parsed JSON body
+ * (`{ code, msg, data }`), identical to the generated method's resolved value.
  */
-async function larkGet(c: any, url: string, params: LarkRequestParams = {}): Promise<any> {
+export async function larkGet(c: any, url: string, params: LarkRequestParams = {}): Promise<any> {
   return c.request({ method: 'GET', url, params });
 }
 
@@ -187,9 +192,7 @@ export async function sendUserMessage(larkAppId: string, openId: string, content
 
 export async function getChatInfo(larkAppId: string, chatId: string): Promise<{ userCount: number; botCount: number }> {
   const c = getBotClient(larkAppId);
-  const res = await (c as any).im.v1.chat.get({
-    path: { chat_id: chatId },
-  });
+  const res = await larkGet(c, `/open-apis/im/v1/chats/${encodeURIComponent(chatId)}`);
   if (res.code !== 0) {
     throw new Error(`Failed to get chat info: ${res.msg} (code: ${res.code})`);
   }
@@ -243,9 +246,7 @@ export async function getChatMode(
   let mode: ChatMode = 'group';
   try {
     const c = getBotClient(larkAppId);
-    const res = await (c as any).im.v1.chat.get({
-      path: { chat_id: chatId },
-    });
+    const res = await larkGet(c, `/open-apis/im/v1/chats/${encodeURIComponent(chatId)}`);
     if (res.code === 0) {
       const rawMode = String(res.data?.chat_mode ?? '').toLowerCase();
       const rawType = String(res.data?.chat_type ?? '').toLowerCase();
@@ -375,9 +376,15 @@ export async function downloadMessageResource(larkAppId: string, messageId: stri
 
 async function downloadWithAppToken(larkAppId: string, messageId: string, fileKey: string, type: 'image' | 'file', savePath: string): Promise<void> {
   const c = getBotClient(larkAppId);
-  const res = await (c as any).im.v1.messageResource.get({
-    path: { message_id: messageId, file_key: fileKey },
+  // Route through client.request() (empty-GET-body guard) instead of the
+  // generated messageResource.get, which sends `{}` as a GET body and trips
+  // gateway 411s. responseType:'stream' makes the interceptor resolve to the
+  // raw readable stream; writeResourceToDisk drains it chunk-by-chunk.
+  const res = await (c as any).request({
+    method: 'GET',
+    url: `/open-apis/im/v1/messages/${encodeURIComponent(messageId)}/resources/${encodeURIComponent(fileKey)}`,
     params: { type },
+    responseType: 'stream',
   });
   await writeResourceToDisk(res, savePath);
 }
@@ -756,9 +763,7 @@ export async function listChatBotMembers(larkAppId: string, chatId: string): Pro
   const configuredResults = await Promise.all(
     clients.map(async ({ appId, cliId, client }): Promise<ChatBotMember | null> => {
       try {
-        const res = await (client as any).im.v1.chatMembers.isInChat({
-          path: { chat_id: chatId },
-        });
+        const res = await larkGet(client, `/open-apis/im/v1/chats/${encodeURIComponent(chatId)}/members/is_in_chat`);
         if (res.code === 0 && res.data?.is_in_chat) {
           const info = appIdToInfo.get(appId);
           // Prefer cross-reference (correct per-app open_id), fall back to self-seen

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -8,6 +8,22 @@ import { logger } from '../../utils/logger.js';
 import { resolveUserToken } from '../../utils/user-token.js';
 import { listObservedBots } from '../../services/observed-bots-store.js';
 
+type LarkRequestParams = Record<string, string | number | boolean | undefined>;
+
+/**
+ * Call a Feishu GET endpoint without a request body.
+ *
+ * The official SDK currently lets axios attach `{}` as `data` for generated
+ * GET calls such as im.v1.message.list/get. Some gateway deployments reject
+ * GET-with-body and return HTTP 411 before the OpenAPI handler sees the
+ * request. `client.request()` contains an explicit GET empty-body guard, while
+ * still using the SDK's token/cache/auth plumbing, so use it for read-only
+ * message history/detail calls.
+ */
+async function larkGet(c: any, url: string, params: LarkRequestParams = {}): Promise<any> {
+  return c.request({ method: 'GET', url, params });
+}
+
 // Cached lightweight Lark clients for all configured bots (for isInChat checks)
 let allBotClients: Array<{ appId: string; cliId: string; client: InstanceType<typeof Client> }> | null = null;
 function getAllBotClients() {
@@ -314,10 +330,9 @@ export async function getMessageDetail(
   // Without the param, sub-messages still come back in the "Format A"
   // simplified card shape which extractCardContent handles.
   const userCardContent = options.userCardContent ?? true;
-  const res = await c.im.v1.message.get({
-    path: { message_id: messageId },
-    ...(userCardContent ? { params: { card_msg_content_type: 'user_card_content' } } : {}),
-  } as any);
+  const res = await larkGet(c, `/open-apis/im/v1/messages/${encodeURIComponent(messageId)}`, {
+    ...(userCardContent ? { card_msg_content_type: 'user_card_content' } : {}),
+  });
   if (res.code !== 0) {
     throw new Error(`Failed to get message: ${res.msg} (code: ${res.code})`);
   }
@@ -513,7 +528,7 @@ export async function listThreadMessages(larkAppId: string, chatId: string, root
 /** Get the thread_id (omt_xxx) from the root message via message.get. */
 async function resolveThreadId(c: any, rootMessageId: string): Promise<string | undefined> {
   try {
-    const res = await c.im.v1.message.get({ path: { message_id: rootMessageId } });
+    const res = await larkGet(c, `/open-apis/im/v1/messages/${encodeURIComponent(rootMessageId)}`);
     if (res.code === 0) {
       return res.data?.items?.[0]?.thread_id;
     }
@@ -533,14 +548,12 @@ async function listByThread(c: any, threadId: string, pageSize: number): Promise
   let pageToken: string | undefined;
 
   do {
-    const res = await c.im.v1.message.list({
-      params: {
-        container_id_type: 'thread' as any,
-        container_id: threadId,
-        page_size: Math.min(pageSize, LARK_MESSAGE_LIST_MAX_PAGE),
-        sort_type: 'ByCreateTimeAsc' as any,
-        ...(pageToken ? { page_token: pageToken } : {}),
-      },
+    const res = await larkGet(c, '/open-apis/im/v1/messages', {
+      container_id_type: 'thread',
+      container_id: threadId,
+      page_size: Math.min(pageSize, LARK_MESSAGE_LIST_MAX_PAGE),
+      sort_type: 'ByCreateTimeAsc',
+      ...(pageToken ? { page_token: pageToken } : {}),
     });
 
     if (res.code !== 0) {
@@ -572,14 +585,12 @@ export async function listChatMessages(
   let pageToken: string | undefined;
 
   do {
-    const res = await c.im.v1.message.list({
-      params: {
-        container_id_type: 'chat' as any,
-        container_id: chatId,
-        page_size: Math.min(pageSize, LARK_MESSAGE_LIST_MAX_PAGE),
-        sort_type: 'ByCreateTimeDesc' as any,
-        ...(pageToken ? { page_token: pageToken } : {}),
-      },
+    const res = await larkGet(c, '/open-apis/im/v1/messages', {
+      container_id_type: 'chat',
+      container_id: chatId,
+      page_size: Math.min(pageSize, LARK_MESSAGE_LIST_MAX_PAGE),
+      sort_type: 'ByCreateTimeDesc',
+      ...(pageToken ? { page_token: pageToken } : {}),
     });
 
     if (res.code !== 0) {
@@ -659,14 +670,12 @@ async function listByChatFilter(c: any, chatId: string, rootMessageId: string, p
   let pageToken: string | undefined;
 
   do {
-    const res = await c.im.v1.message.list({
-      params: {
-        container_id_type: 'chat' as any,
-        container_id: chatId,
-        page_size: Math.min(pageSize, LARK_MESSAGE_LIST_MAX_PAGE),
-        sort_type: 'ByCreateTimeDesc' as any,
-        ...(pageToken ? { page_token: pageToken } : {}),
-      },
+    const res = await larkGet(c, '/open-apis/im/v1/messages', {
+      container_id_type: 'chat',
+      container_id: chatId,
+      page_size: Math.min(pageSize, LARK_MESSAGE_LIST_MAX_PAGE),
+      sort_type: 'ByCreateTimeDesc',
+      ...(pageToken ? { page_token: pageToken } : {}),
     });
 
     if (res.code !== 0) {

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -1,5 +1,6 @@
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync, createWriteStream, mkdirSync, existsSync } from 'node:fs';
 import { dirname, extname, basename, join } from 'node:path';
+import { pipeline } from 'node:stream/promises';
 import { Client, LoggerLevel } from '@larksuiteoapi/node-sdk';
 import { getBotClient, getAllBots, getBot } from '../../bot-registry.js';
 import { loadBotConfigs } from '../../bot-registry.js';
@@ -408,11 +409,12 @@ async function writeResourceToDisk(res: any, savePath: string): Promise<void> {
   } else if (res && typeof res === 'object' && 'writeFile' in res) {
     await res.writeFile(savePath);
   } else {
-    const chunks: Buffer[] = [];
-    for await (const chunk of res as AsyncIterable<Buffer>) {
-      chunks.push(Buffer.from(chunk));
-    }
-    writeFileSync(savePath, Buffer.concat(chunks));
+    // Raw Readable (client.request with responseType:'stream'). Pipe straight
+    // to disk instead of buffering — this resource API serves files up to
+    // 100MB, so Buffer.concat + writeFileSync would spike memory and block the
+    // event loop under concurrent downloads. pipeline handles backpressure and
+    // closes/cleans up both streams on error.
+    await pipeline(res as NodeJS.ReadableStream, createWriteStream(savePath));
   }
 }
 

--- a/src/im/lark/identity-cache.ts
+++ b/src/im/lark/identity-cache.ts
@@ -23,6 +23,7 @@ import { join, dirname } from 'node:path';
 import { getBotClient } from '../../bot-registry.js';
 import { config } from '../../config.js';
 import { logger } from '../../utils/logger.js';
+import { larkGet } from './client.js';
 
 export type IdentityType = 'user' | 'bot' | 'app' | 'unknown';
 
@@ -214,9 +215,8 @@ export async function resolveName(larkAppId: string, openId: string): Promise<st
 async function fetchUserName(larkAppId: string, openId: string): Promise<void> {
   try {
     const c = getBotClient(larkAppId);
-    const res = await (c as any).contact.v3.user.get({
-      path: { user_id: openId },
-      params: { user_id_type: 'open_id' },
+    const res = await larkGet(c, `/open-apis/contact/v3/users/${encodeURIComponent(openId)}`, {
+      user_id_type: 'open_id',
     });
     if (res?.code === 0) {
       const name: string | undefined = res.data?.user?.name;

--- a/src/services/groups-store.ts
+++ b/src/services/groups-store.ts
@@ -10,6 +10,7 @@
  * proxy selection happens at the route layer.
  */
 import { getBotClient } from '../bot-registry.js';
+import { larkGet } from '../im/lark/client.js';
 
 export interface ChatBrief {
   chatId: string;
@@ -28,12 +29,10 @@ export async function listChats(larkAppId: string): Promise<ChatBrief[]> {
   const out: ChatBrief[] = [];
   let pageToken: string | undefined;
   do {
-    const res: any = await (client as any).im.v1.chat.list({
-      params: {
-        page_size: 100,
-        user_id_type: 'open_id',
-        ...(pageToken ? { page_token: pageToken } : {}),
-      },
+    const res: any = await larkGet(client, '/open-apis/im/v1/chats', {
+      page_size: 100,
+      user_id_type: 'open_id',
+      ...(pageToken ? { page_token: pageToken } : {}),
     });
     if (res.code !== 0 && res.code !== undefined) {
       throw new Error(`Failed to list chats: ${res.msg} (code: ${res.code})`);
@@ -63,9 +62,7 @@ export async function listChats(larkAppId: string): Promise<ChatBrief[]> {
 export async function isInChat(larkAppId: string, chatId: string): Promise<boolean> {
   const client = getBotClient(larkAppId);
   try {
-    const res: any = await (client as any).im.v1.chatMembers.isInChat({
-      path: { chat_id: chatId },
-    });
+    const res: any = await larkGet(client, `/open-apis/im/v1/chats/${encodeURIComponent(chatId)}/members/is_in_chat`);
     if (res.code !== 0 && res.code !== undefined) return false;
     return !!res.data?.is_in_chat;
   } catch {
@@ -160,9 +157,8 @@ export async function getChatOwner(
 ): Promise<string | undefined> {
   const client = getBotClient(larkAppId);
   try {
-    const res: any = await (client as any).im.v1.chat.get({
-      path: { chat_id: chatId },
-      params: { user_id_type: 'open_id' },
+    const res: any = await larkGet(client, `/open-apis/im/v1/chats/${encodeURIComponent(chatId)}`, {
+      user_id_type: 'open_id',
     });
     if (res.code !== 0 && res.code !== undefined) return undefined;
     const owner = res.data?.owner_id;

--- a/src/setup/verify-permissions.ts
+++ b/src/setup/verify-permissions.ts
@@ -202,7 +202,12 @@ export async function checkRequiredScopes(
 
   let resp: any;
   try {
-    resp = await client.application.scope.list();
+    // Route through client.request() (GET empty-body guard) instead of the
+    // generated application.scope.list, which sends `{}` as a GET body and
+    // trips gateway 411s — same root cause as the IM read fixes. Inlined here
+    // (rather than importing larkGet) to keep setup code decoupled from the
+    // runtime IM client module. Resolves to { code, msg, data }, unchanged.
+    resp = await (client as any).request({ method: 'GET', url: '/open-apis/application/v6/scopes' });
   } catch (err: any) {
     return { ok: false, error: 'network', message: `scope.list 调用失败: ${err?.code ?? err?.message ?? 'unknown'}` };
   }

--- a/test/groups-store.test.ts
+++ b/test/groups-store.test.ts
@@ -12,31 +12,45 @@ const chatCreateStub = vi.fn();
 const chatUpdateStub = vi.fn();
 
 // Mock bot-registry's getBotClient — that's where groups-store imports from.
+// Read-only GETs (listChats / isInChat / getChatOwner) now go through
+// `client.request()` to avoid the empty-GET-body 411; mutating calls
+// (chat.create / chat.update / chatMembers.create) stay on generated methods.
 vi.mock('../src/bot-registry.js', () => ({
   getBotClient: vi.fn().mockImplementation(() => ({
+    request: vi.fn().mockImplementation(async ({ url }: { url: string }) => {
+      if (url.includes('/members/is_in_chat')) {
+        return { code: 0, data: { is_in_chat: true } };
+      }
+      if (/\/open-apis\/im\/v1\/chats$/.test(url)) {
+        return {
+          code: 0,
+          data: {
+            items: [
+              {
+                chat_id: 'c1',
+                name: 'one',
+                description: 'first chat',
+                chat_mode: 'group',
+                owner_id: 'ou_owner',
+              },
+            ],
+            has_more: false,
+          },
+        };
+      }
+      // getChatOwner: GET /open-apis/im/v1/chats/<id>
+      if (/\/open-apis\/im\/v1\/chats\/[^/]+$/.test(url)) {
+        return { code: 0, data: { owner_id: 'ou_owner' } };
+      }
+      throw new Error(`unexpected GET url in mock: ${url}`);
+    }),
     im: {
       v1: {
         chat: {
-          list: vi.fn().mockResolvedValue({
-            code: 0,
-            data: {
-              items: [
-                {
-                  chat_id: 'c1',
-                  name: 'one',
-                  description: 'first chat',
-                  chat_mode: 'group',
-                  owner_id: 'ou_owner',
-                },
-              ],
-              has_more: false,
-            },
-          }),
           create: chatCreateStub,
           update: chatUpdateStub,
         },
         chatMembers: {
-          isInChat: vi.fn().mockResolvedValue({ code: 0, data: { is_in_chat: true } }),
           create: vi.fn().mockResolvedValue({
             code: 0,
             data: { invalid_id_list: ['cli_X'] },

--- a/test/list-chat-bot-members.test.ts
+++ b/test/list-chat-bot-members.test.ts
@@ -36,13 +36,15 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
 
     constructor(opts: { appId: string }) {
       this.appId = opts.appId;
-      this.im = {
-        v1: {
-          chatMembers: {
-            isInChat: vi.fn(async () => ({ code: 0, data: { is_in_chat: true } })),
-          },
-        },
-      };
+      this.im = { v1: {} };
+    }
+
+    // isInChat now routes through client.request() (empty-GET-body 411 guard).
+    async request({ url }: { url: string }) {
+      if (url.includes('/members/is_in_chat')) {
+        return { code: 0, data: { is_in_chat: true } };
+      }
+      throw new Error(`unexpected GET url in mock: ${url}`);
     }
   },
 }));

--- a/test/setup-verify-permissions.test.ts
+++ b/test/setup-verify-permissions.test.ts
@@ -12,6 +12,10 @@ vi.mock('@larksuiteoapi/node-sdk', () => {
   const scopeApplyMock = vi.fn();
   class FakeClient {
     application = { scope: { list: scopeListMock, apply: scopeApplyMock } };
+    // checkRequiredScopes now reads scopes via client.request() (GET empty-body
+    // 411 guard) instead of the generated scope.list; delegate to the same
+    // scopeListMock so existing mockResolved/mockRejected setups still apply.
+    request = (...args: unknown[]) => scopeListMock(...args);
     constructor(_: unknown) {}
   }
   return {


### PR DESCRIPTION
## Summary
飞书部分网关会在 OpenAPI 业务层之前拒绝"带 body 的 GET"，返回 HTTP 411。`@larksuiteoapi/node-sdk` 生成的 GET 方法（message/chat/contact/resource）会把空 `{}` 经 axios 当作 GET body 发出去，从而被这类网关拦截；而 SDK 的通用 `client.request()` 自带 GET 空 body 保护（`fix: #153`）。本 PR 把所有受影响的只读 GET 统一改走 `client.request()`。

## 改动范围
**消息读取（初版）：**
- `getMessageDetail`、`resolveThreadId`、`listThreadMessages`、`listChatMessages`、`listByChatFilter`

**扩展到其余只读 GET（同一根因）：**
- `im.v1.chat.get` — `getChatInfo` / `getChatMode` / `getChatOwner`
- `im.v1.chat.list` — `listChats`
- `im.v1.chatMembers.isInChat` — `getChatBotMembers` / `groups-store.isInChat`（⚠️ `/group` 建群与 `/grant` chatId-based 授权依赖此接口）
- `contact.v3.user.get` — `identity-cache` 姓名解析
- `im.v1.messageResource.get` — 图片/文件下载（经 `client.request` 传 `responseType:'stream'` 拿原始流，由 `writeResourceToDisk` 落盘）

实现：导出复用 `larkGet(c, url, params)`，内部走 `client.request({ method:'GET', ... })`，保留 SDK token/cache/auth，返回结构与生成方法一致。

## Verification
- `pnpm exec tsc --noEmit`
- `pnpm build`
- 受影响用例全绿：groups-store / list-chat-bot-members / message-parser / merge-forward / forwarded-renderer / ambient-history / quoted-render / create-group-resolver / chat-first-seen-store + event-dispatcher / card-integration / session-adopt / group-creator / bridge-final-output-retry（共 220+ 用例）
- mock 更新：`groups-store` / `list-chat-bot-members` 测试改打 `client.request`