### PR TITLE
feat(ask): askUserQuestion 飞书接管 —— botmux ask 子命令 + hook 拦截（多问/多选）

### DIFF
--- a/docs/TEST-GUIDE-ask-hooks.md
+++ b/docs/TEST-GUIDE-ask-hooks.md
@@ -1,0 +1,88 @@
+# 测试指南：botmux askUserQuestion hook 接管
+
+分支：`feat/botmux-ask-hooks`（已推送 origin）。本期支持 **Claude Code + OpenCode**；Codex 不适用（无结构化提问 hook）。
+
+## 1. 拉代码 + 构建（在另一台环境的 botmux 仓库里）
+
+```bash
+cd <你的 botmux 仓库目录>
+git fetch origin
+git checkout feat/botmux-ask-hooks      # 已在该分支则 git pull
+pnpm install
+pnpm build                              # tsc 干净，产出 dist/
+```
+
+确认 botmux 可执行指向这个仓库的 dist：
+```bash
+cat "$(which botmux)"                    # 应 exec node <本仓库>/dist/cli.js
+```
+
+## 2. 重启 daemon 让它跑新代码
+
+```bash
+botmux restart
+botmux status                            # 确认 online
+```
+
+## 3. 确认 hook 被装上（spawn 一个会话后）
+
+先在飞书话题里给 Claude bot 发条消息，拉起一个 Claude 会话，然后：
+
+```bash
+# Claude：应有指向 "hook claude-code" 的 PermissionRequest 钩子
+cat ~/.claude/settings.json | grep -A3 PermissionRequest
+
+# OpenCode：插件文件应存在
+ls -l ~/.config/opencode/plugin/botmux-ask.js
+```
+
+## 4. 触发 askUserQuestion（核心验证）
+
+**Claude 单选**：在 Claude 会话里让它问你一个选择题，例如发：
+> 用 AskUserQuestion 工具问我「今晚部署还是回滚」，给两个选项
+
+预期：飞书话题里弹出一张互动卡片（问题 + 选项下拉 + 「提交」按钮）。选一项 → 点提交 → Claude 收到答案继续往下。
+
+**Claude 多选**：让它问一个 `multiSelect` 的问题，例如：
+> 用 AskUserQuestion 多选问我「要跑哪些检查」，选项：单测/类型检查/lint，允许多选
+
+预期：卡片里是多选下拉，勾两项 → 提交 → 两个答案都正确回到 Claude。
+
+**OpenCode**：在 OpenCode 会话里同样触发一次提问，重复上面验证。
+
+## 5. 降级验证（重要）
+
+停掉 daemon（`botmux stop`）后，让 CLI 触发提问 → CLI 应**回退到它自己的终端原生提问**、不挂死。验证 hook 异常不卡 agent。
+
+## 6. 出问题时看哪里
+
+- daemon 日志：`botmux logs --bot <bot 名或序号>`，找 `[hook]`（安装）和 `[ask:...]`（提问生命周期）行。
+- 三个"线上没验过、各隔离在一处"的点，行为异常时按序查：
+  1. **飞书多选回调形状** → `src/im/lark/ask-card.ts` 的 `parseFormSelections`（已防御式兼容 数组/字符串/逗号串；若飞书回的格式更怪，这里加一种）。
+  2. **OpenCode 插件 question.asked API** → `src/adapters/hook-installer.ts`（有 `TODO(dogfood)` 标记；插件协议若对不上，改这一处）。
+  3. **Claude/OpenCode directive 形状** → `src/core/ask-hook/{claude-code,opencode}.ts` 的 `formatAnswer`（回填字段若 CLI 不认，改这一处）。
+
+## 7.（可选）不用 CLI 的快速冒烟：直接打 broker
+
+不想起 CLI，也可直接验"卡片 + 回调 + broker"整条（绕过 hook 客户端）：
+
+```bash
+# 找 daemon 的 ipc 端口（从 daemon 描述或日志）
+# 然后用多问多选 body 打 /api/asks，会在指定 chat 弹卡，点提交后本命令返回 answers
+curl -sS -X POST "http://127.0.0.1:<ipcPort>/api/asks" \
+  -H 'content-type: application/json' \
+  -d '{
+    "sessionId":"smoke","chatId":"<你所在话题的 chatId>","larkAppId":"<bot 的 appId>",
+    "rootMessageId":null,"timeoutMs":300000,"approvers":["<你的 open_id>"],
+    "questions":[
+      {"prompt":"部署还是回滚？","multiSelect":false,"options":[{"key":"deploy","label":"部署"},{"key":"rollback","label":"回滚"}]},
+      {"prompt":"跑哪些检查？","multiSelect":true,"options":[{"key":"unit","label":"单测"},{"key":"types","label":"类型检查"},{"key":"lint","label":"lint"}]}
+    ]
+  }'
+# 飞书点选 + 提交后，curl 返回 {"kind":"answered","answers":[["deploy"],["unit","types"]],...} 即全链路 OK
+```
+
+## 注意
+
+- Codex 别测 askUserQuestion——它没有结构化提问 hook，adapter 对它永远 passthrough（无害）。
+- 现有 `botmux ask buttons` 子命令仍可用（向后兼容，单选）。

--- a/docs/design/2026-05-25-botmux-ask-hooks-design.md
+++ b/docs/design/2026-05-25-botmux-ask-hooks-design.md
@@ -13,12 +13,15 @@
 
 **skill 触发的根本问题**：依赖 agent 肯读 skill、且肯放弃自己**原生的 AskUserQuestion 工具**改调 `botmux ask`。这不可靠——多数 agent 默认用自带的提问工具，skill 抢不过，于是问题根本到不了飞书。
 
-**目标**：把"触发/进料"从 skill 改为 **hook 拦截 agent 原生 askUserQuestion**，做到无需提示词配合、透明自动地把问题送到飞书并把答案送回 CLI。**broker / 卡片 / 答案路由 / 审批人链 / 超时 nonce 等基础设施全部复用，不重写。**
+**目标**：把"触发/进料"从 skill 改为 **hook 拦截 agent 原生 askUserQuestion**，做到无需提示词配合、透明自动地把问题送到飞书并把答案送回 CLI。**进料/回传两端新增，daemon 中段尽量复用**：审批人链、daemon route 骨架、env 注入零改动；broker / card / types 因要完整支持多选 + 多问而做向后兼容的扩展（见 §7），而非另起炉灶。
 
 ### 非目标（本期不做）
 
 - 终端原生 CLI（Kimi / Gemini / Coco / Aiden 等）的答案回传。这些 CLI 的 hook 只能"给出问题"、不能程序化回填，答案必须靠 PTY 键盘注入，可靠性是另一个等级（见 §8）。**本期只做 directive 回填三家，dogfood 通过后再做剩下的。**
-- 多问题（questions[] 长度 > 1）与多选（multiSelect）的完整保真（见 §7 取舍）。
+
+### 本期明确包含
+
+- **多选（multiSelect）与多问题（questions[] 长度 > 1）的完整保真。** 不降级。这要求把 ask 的问答模型从"单问单选、点按钮即答"升级为"N 个问题、每问单选或多选、一次提交"——会扩展 broker / card / types 三个模块（见 §7），但保持对现有 `botmux ask buttons` 单选子命令的向后兼容。
 
 ## 2. 设计原则
 
@@ -71,18 +74,22 @@ agent 调用原生 AskUserQuestion
 
 ### 5.2 per-CLI adapter 归一层（新增 `src/core/ask-hook/<cliId>.ts`）
 
-每个 CLI 一个纯模块，两个纯函数：
+每个 CLI 一个纯模块，两个纯函数（已按多问 + 多选建模）：
 
 ```ts
-// 入：原始 hook payload → 出：botmux 内部问题结构（或 null = 非 askUserQuestion，放行）
-parseQuestion(payload: unknown): { prompt: string; options: AskOption[]; raw: ParsedRaw } | null
+// 内部统一问题结构
+interface AskQuestion { prompt: string; options: AskOption[]; multiSelect: boolean }
 
-// 入：用户选的 key + 原始问题 → 出：该 CLI 的 directive 字符串
-formatAnswer(selectedKey: string, raw: ParsedRaw): string
+// 入：原始 hook payload → 出：问题数组（或 null = 非 askUserQuestion，放行）
+parseQuestions(payload: unknown): { questions: AskQuestion[]; raw: ParsedRaw } | null
+
+// 入：每问选中的 key（单选 1 个、多选 ≥0 个）+ 原始 payload → 出：该 CLI 的 directive 字符串
+// answersByQuestion[i] 对应 questions[i] 选中的 key 数组
+formatAnswer(answersByQuestion: string[][], raw: ParsedRaw): string
 ```
 
 - `claude-code.ts`、`codex.ts`、`opencode.ts` 三份。
-- 纯函数、无 IO，便于单测（对照各 CLI 真实 payload 样本）。
+- 纯函数、无 IO，便于单测（对照各 CLI 真实 payload 样本，含多问 / 多选样本）。
 - 通过 `src/core/ask-hook/registry.ts` 按 cliId 分发。
 
 ### 5.3 hook 安装：`ensureHooks(cliId, adapter)`（新增 `src/adapters/hook-installer.ts`）
@@ -92,9 +99,15 @@ formatAnswer(selectedKey: string, raw: ParsedRaw): string
 - 幂等：内容不变不写（对齐 `ensureSkills` 行为）。
 - 把对应 CLI 的 hook 配置写好，命令指向 `botmux hook <cliId>`。
 
-### 5.4 复用（零改动）
+### 5.4 复用与扩展
 
-`ask-broker.ts`、`ask-card.ts`、`ask-api.ts`、`card-handler.ts`、daemon `/api/asks` route、worker `BOTMUX_*` env 注入（worker.ts:2663）—— 全部保持原样。
+**零改动复用**：`ask-api.ts`（审批人链）、daemon `/api/asks` route 的鉴权/审批/广播骨架、worker `BOTMUX_*` env 注入（worker.ts:2663）。
+
+**需向后兼容地扩展**（因多选 + 多问，见 §7）：
+- `ask-types.ts`：问答模型从"单问 + 扁平 options + 单选"扩为"questions[]、每问 single/multi"；`AskResult.selected` 从 `string` 扩为按问题分组的 `string[][]`。保留旧单选形态的兼容映射，`botmux ask buttons` 子命令与其现有测试不破。
+- `ask-broker.ts`：`tryResolveAsk` 从"首次有效点击即 settle"改为"累积每问的勾选态、收到 Submit 才 settle"；单选问题仍可点击即记。
+- `ask-card.ts`：从"按钮即答"升级为"每问渲染选项（单选=单选钮语义、多选=可勾选）+ 一个 Submit 按钮"，settle 时 PATCH 成终态。
+- `card-handler.ts`：区分 toggle（记录勾选，不 settle）与 submit（收口 settle）两类动作。
 
 ### 5.5 退役 `ASK_SKILL`
 
@@ -105,14 +118,21 @@ formatAnswer(selectedKey: string, raw: ParsedRaw): string
 
 hook 客户端运行在 CLI 子进程里，自动继承 worker 注入的 `BOTMUX_SESSION_ID` / `BOTMUX_CHAT_ID` / `BOTMUX_LARK_APP_ID` / `BOTMUX_ROOT_MESSAGE_ID`（worker.ts:2663 现已注入），与 `botmux ask` 同源，无需新增注入。
 
-## 7. askUserQuestion 保真度取舍（需评审确认）
+## 7. 问答模型：完整支持多问 + 多选
 
-原生 askUserQuestion 是 `questions[]`（可能多问）、每问 `options[]`、可能 `multiSelect: true`；而现有 `ask-broker` / `ask-card` 模型是**单问 + 扁平 options + 单选按钮**。
+原生 askUserQuestion 是 `questions[]`（可能多问）、每问 `options[]`、可能 `multiSelect: true`；而现有 `ask-broker` / `ask-card` 模型是**单问 + 扁平 options + 单选按钮**。本期**不降级**，把模型升级为原生匹配的通用形态：
 
-**本期取舍（MVP）**：
-- 只处理 `questions[0]`，单选。覆盖绝大多数实际用法（典型为 1 问 ≤4 选、单选）。
-- `multiSelect: true` 或 `questions.length > 1`：MVP 先**降级为取首问、单选**，并在卡片上标注；adapter 的 `parseQuestion` 保留完整 raw 数据，为后续扩展留口。
-- 完整多问 / 多选支持列为 fast-follow（需扩 `ask-types` / `ask-card` / broker 的选择模型），不阻塞本期 dogfood。
+**统一模型：N 个问题 × 每问单选或多选 × 一次提交。**
+
+- 卡片渲染 `questions[]` 的每个问题为一个分区，分区内列出该问的选项：
+  - 单选问题：选项互斥，点一个即记为该问的答案。
+  - 多选问题：选项可勾选/取消，允许选多个（含 0 个，若该 CLI 语义允许）。
+- 卡片底部一个 **Submit** 按钮；用户调好所有问题的勾选后点 Submit，broker 才 settle，一次性收集全部答案。
+- 这一模型是 multiSelect 与多问的超集：单问单选是它的退化特例，因此**现有 `botmux ask buttons` 单选语义作为特例继续工作**（向后兼容）。
+
+**连带改动**（详见 §5.4）：`ask-types`（结果结构按问分组 `string[][]`）、`ask-broker`（累积勾选 + Submit 才 settle）、`ask-card`（勾选 + Submit 卡片）、`card-handler`（toggle / submit 两类动作）。`ask-api` 审批链、daemon route 骨架不变。
+
+**向后兼容要求**：扩展 `AskResult` / broker 行为时，保留旧单选形态的映射，`botmux ask` 子命令及其现有测试零回归。
 
 ## 8. 范围与分期
 
@@ -136,13 +156,15 @@ hook 客户端必须保证：**任何异常都不能让 agent 永久阻塞**。
 
 ## 11. 测试策略
 
-- adapter 纯函数单测：对照三家真实 hook payload 样本，测 `parseQuestion`（含非 askUserQuestion 放行、multiSelect 降级）与 `formatAnswer`（directive 形状）。
+- adapter 纯函数单测：对照三家真实 hook payload 样本，测 `parseQuestions`（含非 askUserQuestion 放行、单问单选、多选、多问多组）与 `formatAnswer`（含多选/多问的 directive 形状）。
+- broker 扩展单测：累积勾选、单选即记、Submit 才 settle、多问全收集、超时/失效路径；并补 toggle/submit 的抢答与 nonce 用例。
+- 向后兼容回归：现有 `ask-broker` / `ask-card` / `ask-api` 测试与 `botmux ask buttons` 单选语义零回归。
 - hook 客户端：mock daemon `/api/asks`，测正常回填、超时、daemon 不可达三条降级路径。
-- 复用既有 `ask-broker` / `ask-card` / `ask-api` 测试，确认零回归。
-- dogfood：三家真实 CLI 各跑一次原生提问，飞书点选，确认答案正确进 CLI。
+- dogfood：三家真实 CLI 各跑一次原生提问（含一个多选/多问场景），飞书点选 Submit，确认答案正确进 CLI。
 
 ## 12. 风险与未决
 
 - 各 CLI hook 配置格式 / directive 形状会随上游版本变动——需实测当前版本，并考虑版本门控（对齐桌面端经验）。
-- multiSelect / 多问降级的用户体验是否可接受，待评审。
+- broker 从"点击即 settle"改为"Submit 才 settle"是行为变更：需确保 `botmux ask` 子命令的旧单选语义与测试零回归（兼容映射）。
+- 多选/多问卡片的飞书交互形态（勾选组 + Submit）需确认在飞书互动卡片能力内可实现且体验可接受。
 - 去重策略（§10）的具体实现位置待落实现细节时确认。

--- a/docs/design/2026-05-25-botmux-ask-hooks-design.md
+++ b/docs/design/2026-05-25-botmux-ask-hooks-design.md
@@ -1,0 +1,148 @@
+# botmux askUserQuestion：从 skill 触发改为 hook 触发
+
+- 日期：2026-05-25
+- 分支：`feat/botmux-ask-hooks`（基于 `feat/botmux-ask`）
+- 状态：设计待评审
+
+## 1. 背景与目标
+
+`feat/botmux-ask` 分支已实现一套"向飞书用户发起阻塞式选择题"的能力，但**触发方式是 skill 驱动**：
+
+- `src/skills/definitions.ts` 里的 `ASK_SKILL`（名为 `botmux-ask` 的 SKILL.md）教 agent："要让用户选就 shell 调 `botmux ask buttons --options ...`"。
+- `botmux ask` 子命令 → `fetch http://127.0.0.1:<ipcPort>/api/asks` → daemon `ask-broker` → `ask-card` 发飞书互动卡片 → 用户点按钮 → broker settle → 答案沿长轮询回 CLI stdout。
+
+**skill 触发的根本问题**：依赖 agent 肯读 skill、且肯放弃自己**原生的 AskUserQuestion 工具**改调 `botmux ask`。这不可靠——多数 agent 默认用自带的提问工具，skill 抢不过，于是问题根本到不了飞书。
+
+**目标**：把"触发/进料"从 skill 改为 **hook 拦截 agent 原生 askUserQuestion**，做到无需提示词配合、透明自动地把问题送到飞书并把答案送回 CLI。**broker / 卡片 / 答案路由 / 审批人链 / 超时 nonce 等基础设施全部复用，不重写。**
+
+### 非目标（本期不做）
+
+- 终端原生 CLI（Kimi / Gemini / Coco / Aiden 等）的答案回传。这些 CLI 的 hook 只能"给出问题"、不能程序化回填，答案必须靠 PTY 键盘注入，可靠性是另一个等级（见 §8）。**本期只做 directive 回填三家，dogfood 通过后再做剩下的。**
+- 多问题（questions[] 长度 > 1）与多选（multiSelect）的完整保真（见 §7 取舍）。
+
+## 2. 设计原则
+
+1. **融会贯通，不盲抄。** 桌面端 x-desktop-app 有成熟实现，但它深度耦合 Electron / IPC / SessionState，与 botmux 的 daemon-worker + localhost HTTP + 飞书卡片骨架完全不同。我们**只借鉴其领域结论**（各 CLI 的事件名映射、payload 形状、directive 形状），代码按 botmux 风格原生重写。
+2. **最大化复用现有 ask 基础设施。** `ask-broker` / `ask-card` / `ask-api`（审批人链）/ `card-handler` / daemon `/api/asks` route 一律不动，hook 客户端打同一个 `/api/asks`。
+3. **hook 失败必须优雅降级**，绝不能让 agent 永久卡死等一个永不返回的答案（见 §9）。
+
+## 3. 要从桌面端"吃透"的领域知识（认知，非代码）
+
+| 知识点 | 内容 |
+| --- | --- |
+| askUserQuestion 入口事件 | Claude=`PermissionRequest`(tool=AskUserQuestion)；Codex=`PermissionRequest`(permission_request)；OpenCode=`QuestionAsked` |
+| payload 字段形状 | `tool_input.questions[]`，每项含 `question`、`options[]`、`multiSelect`；各家异名/嵌套差异 |
+| 阻塞式回填协议 | 这三家的 hook 是"发出后挂起等响应"，答案以 directive 形式写回 stdout 被 CLI 消费——**不碰键盘也能回答**的关键 |
+| hook 安装格式 | Claude=`~/.claude/settings.json` hooks；Codex=`~/.codex/hooks.json`+`config.toml`；OpenCode=JS 插件 |
+| directive 形状 | Claude=`hookSpecificOutput.decision.updatedInput.answers`；OpenCode=`{type:'answer', answers:string[][]}` |
+
+> 注：以上为设计输入，实现时需在 botmux 内对各 CLI 当前版本逐一**实测核验**，不照抄桌面端的具体字段常量。
+
+## 4. 架构与数据流（新）
+
+```
+agent 调用原生 AskUserQuestion
+  → CLI 触发 hook（Claude=PermissionRequest / Codex=permission_request / OpenCode=QuestionAsked）
+  → 执行 `botmux hook <cliId>`（新子命令；hook 客户端）
+      · 从 stdin 读 hook JSON
+      · 按 cliId 用 adapter 解析出 { prompt, options[] }
+      · 复用 §6 env（BOTMUX_SESSION_ID/CHAT_ID/LARK_APP_ID/ROOT_MESSAGE_ID）
+      · POST http://127.0.0.1:<ipcPort>/api/asks（与 `botmux ask` 完全同一路）
+      · 长轮询挂起，等 AskResult
+  → daemon: parseAskBody → resolveAskApprovers → registerAsk（broker，不变）
+  → ask-card 发飞书互动卡片（不变）
+  → 用户点按钮 → card-handler → tryResolveAsk → broker settle（不变）
+  → AskResult 回到 `botmux hook` 进程
+      · adapter 把 selected(key) + 原始 payload → 该 CLI 的 directive
+      · 写 directive 到 stdout
+  → CLI 消费 directive，agent 拿到答案，继续执行
+```
+
+**与现状的差异仅在两端**：进料端（skill 子命令调用 → hook 客户端）和回传端（stdout 打印 key → stdout 打印 directive）。中间 daemon 全链路零改动。
+
+## 5. 组件分解
+
+### 5.1 hook 客户端：`botmux hook <cliId>`（新增 `src/cli.ts` 子命令）
+
+- 职责：stdin→解析→POST `/api/asks`→等结果→stdout 输出 directive。
+- 与 `cmdAsk` 共享 daemon 发现（`findDaemon`）、`/api/asks` POST、长轮询逻辑——抽出公共 `postAsk()` 复用，避免两份。
+- 输入：`cliId`（claude-code / codex / opencode）作为参数；hook JSON 从 stdin。
+- 输出：directive JSON 到 stdout（成功）或安全的"放行/无操作"directive（降级，见 §9）。
+
+### 5.2 per-CLI adapter 归一层（新增 `src/core/ask-hook/<cliId>.ts`）
+
+每个 CLI 一个纯模块，两个纯函数：
+
+```ts
+// 入：原始 hook payload → 出：botmux 内部问题结构（或 null = 非 askUserQuestion，放行）
+parseQuestion(payload: unknown): { prompt: string; options: AskOption[]; raw: ParsedRaw } | null
+
+// 入：用户选的 key + 原始问题 → 出：该 CLI 的 directive 字符串
+formatAnswer(selectedKey: string, raw: ParsedRaw): string
+```
+
+- `claude-code.ts`、`codex.ts`、`opencode.ts` 三份。
+- 纯函数、无 IO，便于单测（对照各 CLI 真实 payload 样本）。
+- 通过 `src/core/ask-hook/registry.ts` 按 cliId 分发。
+
+### 5.3 hook 安装：`ensureHooks(cliId, adapter)`（新增 `src/adapters/hook-installer.ts`）
+
+- 紧贴 `src/core/worker-pool.ts:351` 现有 `ensureSkills(cliId, adapter.skillsDir)` 之后调用。
+- 在 `src/adapters/cli/types.ts` 的 adapter 接口上加可选元数据（hook 配置文件路径 + 写入格式），仅 claude-code / codex / opencode 三家填。
+- 幂等：内容不变不写（对齐 `ensureSkills` 行为）。
+- 把对应 CLI 的 hook 配置写好，命令指向 `botmux hook <cliId>`。
+
+### 5.4 复用（零改动）
+
+`ask-broker.ts`、`ask-card.ts`、`ask-api.ts`、`card-handler.ts`、daemon `/api/asks` route、worker `BOTMUX_*` env 注入（worker.ts:2663）—— 全部保持原样。
+
+### 5.5 退役 `ASK_SKILL`
+
+- 从 `BUILTIN_SKILLS` 移除 `botmux-ask`，加入 `RETIRED_SKILL_NAMES`，让 `ensureSkills` 自动清掉已装到各 CLI 的旧 SKILL.md。
+- **保留 `botmux ask` 子命令**：作为手动 / 脚本 / workflow 的显式入口仍有价值，只是不再靠 skill 推给 agent 自动用。
+
+## 6. 复用的会话上下文（env）
+
+hook 客户端运行在 CLI 子进程里，自动继承 worker 注入的 `BOTMUX_SESSION_ID` / `BOTMUX_CHAT_ID` / `BOTMUX_LARK_APP_ID` / `BOTMUX_ROOT_MESSAGE_ID`（worker.ts:2663 现已注入），与 `botmux ask` 同源，无需新增注入。
+
+## 7. askUserQuestion 保真度取舍（需评审确认）
+
+原生 askUserQuestion 是 `questions[]`（可能多问）、每问 `options[]`、可能 `multiSelect: true`；而现有 `ask-broker` / `ask-card` 模型是**单问 + 扁平 options + 单选按钮**。
+
+**本期取舍（MVP）**：
+- 只处理 `questions[0]`，单选。覆盖绝大多数实际用法（典型为 1 问 ≤4 选、单选）。
+- `multiSelect: true` 或 `questions.length > 1`：MVP 先**降级为取首问、单选**，并在卡片上标注；adapter 的 `parseQuestion` 保留完整 raw 数据，为后续扩展留口。
+- 完整多问 / 多选支持列为 fast-follow（需扩 `ask-types` / `ask-card` / broker 的选择模型），不阻塞本期 dogfood。
+
+## 8. 范围与分期
+
+| 阶段 | 内容 | 出口 |
+| --- | --- | --- |
+| 本期 | directive 三家（Claude / Codex / OpenCode）端到端 hook 接管 + 退役 ASK_SKILL | dogfood 验证：三家原生提问能自动到飞书、点选后答案正确回填、CLI 继续 |
+| 后续 | 终端原生那批：hook 取问题 + 复用现有 `tui_keys`/截屏链路回传，并与 ScreenAnalyzer 去重防双重弹卡 | 单独立项、单独验 |
+
+## 9. 错误处理与降级（关键）
+
+hook 客户端必须保证：**任何异常都不能让 agent 永久阻塞**。
+
+- daemon 不可达 / 无 approver / 超时 / 解析失败 → hook 客户端输出"放行/无操作"directive，让 CLI 回退到它**原生的**提问交互（即用户在终端自己答），而不是挂死。
+- 这等价于"hook 接管失败时，优雅退回到没有 botmux 接管的原状"。
+- 各 CLI 的"无操作 directive"形状需实测确认（通常是不带 decision 的空 `hookSpecificOutput` 或允许放行）。
+
+## 10. 与现有截屏路（ScreenAnalyzer）的关系
+
+- directive 三家：hook 接管后，这三家的 askUserQuestion 不应再被 ScreenAnalyzer 当 TUI prompt 二次弹卡。需确认/处理去重（hook 命中的会话对该工具的截屏弹卡做抑制）。
+- 终端原生那批本期不接 hook，截屏路维持现状。
+
+## 11. 测试策略
+
+- adapter 纯函数单测：对照三家真实 hook payload 样本，测 `parseQuestion`（含非 askUserQuestion 放行、multiSelect 降级）与 `formatAnswer`（directive 形状）。
+- hook 客户端：mock daemon `/api/asks`，测正常回填、超时、daemon 不可达三条降级路径。
+- 复用既有 `ask-broker` / `ask-card` / `ask-api` 测试，确认零回归。
+- dogfood：三家真实 CLI 各跑一次原生提问，飞书点选，确认答案正确进 CLI。
+
+## 12. 风险与未决
+
+- 各 CLI hook 配置格式 / directive 形状会随上游版本变动——需实测当前版本，并考虑版本门控（对齐桌面端经验）。
+- multiSelect / 多问降级的用户体验是否可接受，待评审。
+- 去重策略（§10）的具体实现位置待落实现细节时确认。

--- a/docs/plans/2026-05-25-botmux-ask-hooks.md
+++ b/docs/plans/2026-05-25-botmux-ask-hooks.md
@@ -1,0 +1,628 @@
+# botmux askUserQuestion hook 接管 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 botmux 的 askUserQuestion 能力从"skill 教 agent 调 `botmux ask`"改为"hook 拦截 agent 原生 askUserQuestion 自动接管"，并完整支持多选 + 多问。
+
+**Architecture:** CLI 触发 hook → `botmux hook <cliId>` 客户端（读 stdin、解析、POST `/api/asks`、等结果、回吐 directive）→ daemon 复用现有 `ask-broker`/审批链 → 飞书卡片（升级为多问+多选+Submit）→ 用户提交 → broker settle → 客户端把答案格式化成各 CLI 的 directive 写回 stdout。进料/回传两端新增，daemon 中段（审批链、route 骨架、env 注入）复用，broker/card/types 因多选向后兼容扩展。
+
+**Tech Stack:** TypeScript (ESM, `.js` import 后缀)、Node、vitest、飞书互动卡片 JSON。本期仅 Claude Code / Codex / OpenCode 三家（directive 回填）。
+
+**Spec:** `docs/design/2026-05-25-botmux-ask-hooks-design.md`
+
+**测试命令：** `cd /root/iserver/botmux/.claude/worktrees/botmux-ask-hooks && pnpm vitest run <file>`（全量：`pnpm vitest run`）。类型检查：`pnpm typecheck`（若有该 script，否则 `pnpm tsc --noEmit`）。
+
+---
+
+## File Structure
+
+**新增：**
+- `src/core/ask-hook/types.ts` — hook adapter 公共类型（`AskQuestion`、`HookAskAdapter`）
+- `src/core/ask-hook/claude-code.ts` — Claude `parseQuestions` + `formatAnswer`
+- `src/core/ask-hook/codex.ts` — Codex 同上
+- `src/core/ask-hook/opencode.ts` — OpenCode 同上
+- `src/core/ask-hook/registry.ts` — 按 cliId 取 adapter
+- `src/adapters/hook-installer.ts` — 把 hook 配置写入各 CLI 的 settings（幂等）
+- `test/ask-hook-claude.test.ts` / `test/ask-hook-codex.test.ts` / `test/ask-hook-opencode.test.ts`
+- `test/hook-installer.test.ts`
+
+**修改（向后兼容扩展）：**
+- `src/core/ask-types.ts` — 问答模型扩为 questions[]、结果按问分组
+- `src/core/ask-broker.ts` — 累积勾选、Submit 才 settle
+- `src/core/ask-api.ts` — `parseAskBody` 接受 questions[]（兼容旧 options[]）
+- `src/im/lark/ask-card.ts` — 卡片升级为多问+多选+Submit
+- `src/cli.ts` — 新增 `botmux hook <cliId>` 子命令 + 抽 `postAsk()` 公共函数
+- `src/core/worker-pool.ts` — `ensureCliSkills` 内追加 hook 安装
+- `src/adapters/cli/types.ts` — adapter 增加可选 `hookInstall` 元数据
+- `src/adapters/cli/{claude-code,codex,opencode}.ts` — 填 `hookInstall`
+- `src/skills/definitions.ts` — 退役 `botmux-ask` skill
+
+---
+
+## Task 0: Spike — 验证飞书多选卡片 + Submit 回调形状（非 TDD）
+
+**目的：** Task 4/5 的卡片 JSON 与回调解析依赖飞书互动卡片"多选组 + Submit"的真实 payload 形状。先用一次性脚本发卡并捕获回调，锁定字段，避免后续返工。
+
+**Files:** 临时脚本 `scripts/spike-ask-card.ts`（验证后删除，不提交）。
+
+- [ ] **Step 1：构造一张测试卡片**，含：1 个 `select_static`（单选下拉）、1 个 `multi_select_static`（多选下拉，各 option `value` 用 `q0::keyA` 形式编码"问题序号::选项key"），外层包 `form`（`tag:'form'`, `name:'ask_form'`），底部 1 个 `button`（`action_type:'form_submit'` 或飞书当前等价写法，`value:{action:'ask_submit', ask_id, nonce}`）。参考现有 `src/im/lark/ask-card.ts` 的 `sendMessage(..., 'interactive')` 发送方式。
+
+- [ ] **Step 2：发到一个测试 chat**（用一个真实 larkAppId + chatId，借 `src/im/lark/client.ts` 的 `sendMessage`）。
+
+- [ ] **Step 3：在 daemon webhook/card 回调处打印原始 action data**，点一次 Submit，记录：`data.action.value`、表单各字段名与值的真实结构（单选值形状、多选值是数组还是逗号串）。
+
+- [ ] **Step 4：把结论写进 spec 附录**（`docs/design/2026-05-25-botmux-ask-hooks-design.md` 末尾追加"附录A：飞书 form 回调形状实测"）。后续 Task 4/5 以此为准。
+
+- [ ] **Step 5：删除 spike 脚本，提交 spec 附录**
+
+```bash
+rm scripts/spike-ask-card.ts
+git add docs/design/2026-05-25-botmux-ask-hooks-design.md
+git commit -m "docs(ask): 附录A 飞书 form 多选回调形状实测结论"
+```
+
+> 若实测发现飞书不支持 `multi_select_static` + form 一次性提交，回退方案：多选用多个 `checker`（开关）组件 + 状态存 broker（toggle 动作累积），Submit 收口。该回退已在 Task 5 的 broker toggle 路径覆盖。
+
+---
+
+## Task 1: 扩展 `ask-types.ts` 为多问 + 多选模型（向后兼容）
+
+**Files:**
+- Modify: `src/core/ask-types.ts`
+- Test: `test/ask-types-shape.test.ts`（新增，纯类型/构造用例）
+
+- [ ] **Step 1: 写失败测试**（`test/ask-types-shape.test.ts`）
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { toLegacySelected, type AskQuestion, type AskResult } from '../src/core/ask-types.js';
+
+describe('ask-types 多问多选模型', () => {
+  it('toLegacySelected: 单问单选答案映射回旧 selected 字符串', () => {
+    const answered: AskResult = {
+      kind: 'answered',
+      answers: [['yes']],
+      by: 'ou_x',
+      comment: null,
+      timedOut: false,
+    };
+    expect(toLegacySelected(answered)).toBe('yes');
+  });
+
+  it('toLegacySelected: 多选或多问返回 null（旧单选语义不适用）', () => {
+    const multi: AskResult = {
+      kind: 'answered', answers: [['a', 'b']], by: 'ou_x', comment: null, timedOut: false,
+    };
+    expect(toLegacySelected(multi)).toBeNull();
+  });
+
+  it('AskQuestion 结构含 prompt/options/multiSelect', () => {
+    const q: AskQuestion = { prompt: 'go?', options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }], multiSelect: false };
+    expect(q.options).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `pnpm vitest run test/ask-types-shape.test.ts`
+Expected: FAIL（`toLegacySelected` / `AskQuestion` 未导出）
+
+- [ ] **Step 3: 修改 `ask-types.ts`**
+
+新增 `AskQuestion`；`CreateAskInput`/`PendingAsk` 的 `options` 改为 `questions: ReadonlyArray<AskQuestion>`；`AskResult.answered` 的 `selected: string` 改为 `answers: ReadonlyArray<ReadonlyArray<string>>`（`answers[i]` 对应 `questions[i]` 选中的 key 数组）；`AskClickOutcome` 增加 `'toggled'`（多选勾选累积，未 settle）。新增辅助：
+
+```ts
+/** 旧单选语义兼容：仅当"单问且恰好选 1 个"时返回该 key，否则 null。
+ *  `botmux ask buttons` 子命令与其测试据此保持单选行为不变。 */
+export function toLegacySelected(result: AskResult): string | null {
+  if (result.kind !== 'answered') return null;
+  if (result.answers.length === 1 && result.answers[0].length === 1) {
+    return result.answers[0][0];
+  }
+  return null;
+}
+```
+
+`AskResult` 的 `answered` 变体：
+```ts
+| { kind: 'answered'; answers: ReadonlyArray<ReadonlyArray<string>>; by: string; comment: null; timedOut: false }
+```
+`AskJsonOutput` 增加 `answers: string[][] | null`，保留 `selected: string | null`（= `toLegacySelected`）做向后兼容。
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `pnpm vitest run test/ask-types-shape.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/ask-types.ts test/ask-types-shape.test.ts
+git commit -m "feat(ask): types 扩为多问多选模型 + toLegacySelected 兼容"
+```
+
+> 注：本步会让 `ask-broker.ts`/`ask-card.ts`/`ask-api.ts` 暂时类型不通过——Task 2/3/4 依次修复。执行顺序勿跳。
+
+---
+
+## Task 2: 扩展 `ask-broker.ts`：累积勾选 + Submit 才 settle
+
+**Files:**
+- Modify: `src/core/ask-broker.ts`
+- Test: `test/ask-broker.test.ts`（在现有文件追加用例；现有用例按新模型调整）
+
+- [ ] **Step 1: 写失败测试**（追加到 `test/ask-broker.test.ts`）
+
+```ts
+it('多选：toggle 累积，submit 才 settle', async () => {
+  _resetForTest();
+  setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
+  const p = registerAsk({
+    larkAppId: 'a', chatId: 'c', rootMessageId: null, sessionId: 's',
+    approvers: new Set(['ou_u']),
+    questions: [{ prompt: 'pick', options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }], multiSelect: true }],
+    timeoutMs: 60_000,
+  });
+  const askId = [..._allAskIds()][0];
+  const nonce = _getPending(askId)!.nonce;
+  expect(toggleAsk({ askId, nonce, questionIndex: 0, key: 'a', by: 'ou_u' })).toBe('toggled');
+  expect(toggleAsk({ askId, nonce, questionIndex: 0, key: 'b', by: 'ou_u' })).toBe('toggled');
+  expect(submitAsk({ askId, nonce, by: 'ou_u' })).toBe('accepted');
+  const r = await p;
+  expect(r.kind).toBe('answered');
+  if (r.kind === 'answered') expect([...r.answers[0]].sort()).toEqual(['a', 'b']);
+});
+
+it('单问单选：submit 携带单选答案', async () => {
+  _resetForTest();
+  setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
+  const p = registerAsk({
+    larkAppId: 'a', chatId: 'c', rootMessageId: null, sessionId: 's',
+    approvers: new Set(['ou_u']),
+    questions: [{ prompt: 'go', options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }], multiSelect: false }],
+    timeoutMs: 60_000,
+  });
+  const askId = [..._allAskIds()][0];
+  const nonce = _getPending(askId)!.nonce;
+  expect(submitAsk({ askId, nonce, by: 'ou_u', selections: [['y']] })).toBe('accepted');
+  const r = await p;
+  if (r.kind === 'answered') expect(r.answers).toEqual([['y']]);
+});
+
+it('未授权 toggle/submit 不改变状态', () => {
+  /* 构造同上，toggleAsk/submitAsk 传 by:'ou_other' → 期望 'unauthorized'，_pendingCount() 不变 */
+});
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `pnpm vitest run test/ask-broker.test.ts`
+Expected: FAIL（`toggleAsk`/`submitAsk`/`_allAskIds` 未定义、`registerAsk` 仍要 `options`）
+
+- [ ] **Step 3: 改 `ask-broker.ts`**
+
+- `InternalPending` 增加 `selections: Map<number, Set<string>>`（按问题序号累积选中的 key）。
+- `registerAsk` 用 `input.questions` 初始化；为每个 `multiSelect:false` 的问题不预选。
+- 新增 `toggleAsk({askId, nonce, questionIndex, key, by})`：校验同 `tryResolveAsk`（存在/nonce/未 settle/授权/选项合法）；命中则在 `selections[questionIndex]` 翻转该 key（单选问题：set 内只保留该 key），返回 `'toggled'`；非法返回对应 outcome。
+- 新增 `submitAsk({askId, nonce, by, selections?})`：校验同上；`selections` 显式传入时（按钮单选/一次性 form 提交场景）直接用之，否则用累积的 `selections`；要求每个 `multiSelect:false` 的问题恰好 1 个选中、`multiSelect:true` 的问题按该 CLI 语义（≥0，由 adapter 决定是否允许空，broker 不强制）；校验通过则 `settle(kind:'answered', answers)` 并返回 `'accepted'`。
+- 保留 `tryResolveAsk` 作为"单问单选按钮即答"的便捷封装：内部等价 `submitAsk({..., selections:[[selected]]})`，使 `botmux ask buttons` 与其旧测试零回归。
+- 新增测试辅助 `export function _allAskIds(): string[]`。
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `pnpm vitest run test/ask-broker.test.ts`
+Expected: PASS（含原有用例）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/ask-broker.ts test/ask-broker.test.ts
+git commit -m "feat(ask): broker 支持 toggle 累积 + submit 收口，tryResolveAsk 退化为单选封装"
+```
+
+---
+
+## Task 3: `ask-api.ts` 接受 questions[]（兼容旧 options[]）
+
+**Files:**
+- Modify: `src/core/ask-api.ts`
+- Test: `test/ask-api.test.ts`（追加用例）
+
+- [ ] **Step 1: 写失败测试**（追加）
+
+```ts
+it('接受 questions[]（多问多选）', () => {
+  const body = parseAskBody({
+    sessionId: 's', chatId: 'c', larkAppId: 'a', rootMessageId: null,
+    timeoutMs: 60000, approvers: [],
+    questions: [
+      { prompt: 'q1', multiSelect: false, options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }] },
+      { prompt: 'q2', multiSelect: true, options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }] },
+    ],
+  });
+  expect('error' in body).toBe(false);
+  if (!('error' in body)) { expect(body.questions).toHaveLength(2); expect(body.questions[1].multiSelect).toBe(true); }
+});
+
+it('兼容旧 options[]+prompt：归一成单问单选', () => {
+  const body = parseAskBody({
+    sessionId: 's', chatId: 'c', larkAppId: 'a', rootMessageId: null,
+    timeoutMs: 60000, approvers: [], prompt: 'go?', options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }],
+  });
+  if (!('error' in body)) { expect(body.questions).toHaveLength(1); expect(body.questions[0].prompt).toBe('go?'); expect(body.questions[0].multiSelect).toBe(false); }
+});
+
+it('每问 options<2 报错', () => {
+  const body = parseAskBody({ sessionId:'s',chatId:'c',larkAppId:'a',rootMessageId:null,timeoutMs:60000,approvers:[], questions:[{prompt:'q',multiSelect:false,options:[{key:'x',label:'X'}]}] });
+  expect('error' in body).toBe(true);
+});
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `pnpm vitest run test/ask-api.test.ts`
+Expected: FAIL
+
+- [ ] **Step 3: 改 `parseAskBody`**
+
+`AskApiBody` 用 `questions: AskQuestion[]` 替代 `options/prompt`。解析逻辑：
+- 若 `r.questions` 是数组 → 逐问校验（`prompt` 非空 string、`multiSelect` boolean、`options` 数组且 ≥2、每 option `key` 非空且去重、`label` string）。
+- 否则若存在旧的 `r.options`+`r.prompt` → 归一成 `[{ prompt, multiSelect:false, options }]`（兼容 `botmux ask buttons`）。
+- 都没有 → `{ error:'bad_options' }`。
+- 新增错误码 `'bad_questions'`、`'bad_question_shape'`、`'bad_multiSelect'`。
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `pnpm vitest run test/ask-api.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: 同步 daemon route**
+
+`src/daemon.ts` 的 `/api/asks` 处理里把 `registerAskBroker({... options: parsed.options ...})` 改为 `questions: parsed.questions`。运行 `pnpm tsc --noEmit` 确认 daemon 类型通过。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/ask-api.ts src/daemon.ts test/ask-api.test.ts
+git commit -m "feat(ask): api 接受 questions[] 并兼容旧 options[]"
+```
+
+---
+
+## Task 4: `ask-card.ts` 升级为多问 + 多选 + Submit
+
+**Files:**
+- Modify: `src/im/lark/ask-card.ts`
+- Test: `test/ask-card.test.ts`（按新模型改写/追加）
+
+> 卡片 JSON 形状以 **Task 0 附录A 实测结论** 为准；下方为基线实现，字段名按附录调整。
+
+- [ ] **Step 1: 写失败测试**（`test/ask-card.test.ts`）
+
+```ts
+it('多问卡片：每问一个分区 + 选项组件 + 一个 submit', () => {
+  const ask = makePending({ questions: [
+    { prompt: 'q1', multiSelect: false, options: [{key:'y',label:'是'},{key:'n',label:'否'}] },
+    { prompt: 'q2', multiSelect: true,  options: [{key:'a',label:'A'},{key:'b',label:'B'}] },
+  ]});
+  const json = JSON.parse(buildAskCard(ask));
+  const blob = JSON.stringify(json);
+  expect(blob).toContain('q1'); expect(blob).toContain('q2');
+  expect(blob).toContain('ask_submit'); // submit 按钮 action
+  // 每问的选项 value 编码 questionIndex::key
+  expect(blob).toContain('0::y'); expect(blob).toContain('1::a');
+});
+
+it('settled 态：渲染答案摘要、无可点组件', () => {
+  const ask = makePending({ questions:[{prompt:'q',multiSelect:false,options:[{key:'y',label:'是'},{key:'n',label:'否'}]}] });
+  const json = JSON.parse(buildAskCard(ask, { kind:'answered', answers:[['y']], by:'ou_u', comment:null, timedOut:false }));
+  expect(JSON.stringify(json)).toContain('已选择');
+});
+```
+
+（`makePending` 为测试辅助：构造一个带 `questions`/`askId`/`nonce`/`deadlineAt`/`approvers` 的 `PendingAsk`。）
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `pnpm vitest run test/ask-card.test.ts`
+Expected: FAIL
+
+- [ ] **Step 3: 改 `buildAskCard`**
+
+- 未 settle：遍历 `ask.questions`，每问渲染：标题 `div`（`**问题 N**\n<prompt>`）+ 选项组件（单选用 `select_static`，多选用 `multi_select_static`，各 option `{ text:{tag:'plain_text',content:label}, value:'<i>::<key>' }`，组件 `name:'q<i>'`）。全部包进一个 `form`（`tag:'form', name:'ask_form'`），form 内末尾加 submit 按钮 `{ tag:'button', text:{...'提交'}, type:'primary', action_type:'<附录A 实测>', value:{ action:'ask_submit', ask_id, nonce } }`。
+- settled：保持现有"状态摘要"逻辑，但 `settleStatus` 改为遍历 `result.answers` 渲染每问选中的 label（用 `ask.questions[i].options` 映射 key→label）。
+- 删除/重写旧的 `chunk(options,4)` 按钮渲染（单问单选场景由"单选 select_static + submit"覆盖；如附录A 表明单选用按钮体验更好，可保留按钮但 value 编码 `0::key` 且复用 submit 即答路径）。
+- `dispatcher`（`createLarkAskCardDispatcher`）不变。
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `pnpm vitest run test/ask-card.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/im/lark/ask-card.ts test/ask-card.test.ts
+git commit -m "feat(ask): 卡片升级为多问+多选+Submit 渲染"
+```
+
+---
+
+## Task 5: 卡片回调解析 toggle/submit（`ask-card.ts` handler + `card-handler.ts`）
+
+**Files:**
+- Modify: `src/im/lark/ask-card.ts`（`handleAskCardAction`）
+- Modify: `src/im/lark/card-handler.ts`（动作分发，line ~190）
+- Test: `test/ask-card.test.ts`（追加 handler 用例）
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+it('handleAskCardAction: form submit 解析出每问答案并调 submitAsk', () => {
+  // 以 Task 0 附录A 的真实 form 回调形状构造 data：
+  //   data.action.value = { action:'ask_submit', ask_id, nonce }
+  //   data.action.form_value = { q0:'0::y', q1:['1::a','1::b'] }  // 形状按附录A
+  // 用 vi.mock('../../core/ask-broker.js') 断言 submitAsk 收到 selections=[['y'],['a','b']]
+});
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `pnpm vitest run test/ask-card.test.ts`
+Expected: FAIL
+
+- [ ] **Step 3: 改 handler**
+
+- 新增 `ASK_SUBMIT_ACTION = 'ask_submit'`、`ASK_TOGGLE_ACTION = 'ask_toggle'`（若附录A 表明多选靠 checker toggle 而非 form 一次提交，则启用 toggle 路径）。
+- `isAskCardAction` 覆盖 `ask_select`(旧单选即答) / `ask_submit` / `ask_toggle`。
+- `handleAskCardAction`：
+  - `ask_submit`：从 form 回调字段（附录A 形状）解出每问 `selections[i]`（拆 `'<i>::<key>'`），调 `submitAsk({askId,nonce,by,selections})`，按 outcome 出 toast。
+  - `ask_toggle`（回退方案）：解 `questionIndex`+`key`，调 `toggleAsk(...)`。
+  - `ask_select`（旧单选）：调 `tryResolveAsk(...)` 不变。
+- `card-handler.ts` line ~190：`if (isAskCardAction(value?.action)) return handleAskCardAction(data);` 已存在，无需改；确认新 action 名都进 `isAskCardAction`。
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `pnpm vitest run test/ask-card.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/im/lark/ask-card.ts src/im/lark/card-handler.ts test/ask-card.test.ts
+git commit -m "feat(ask): 卡片回调解析 submit/toggle，映射到 broker"
+```
+
+---
+
+## Task 6: per-CLI hook adapter（Claude / Codex / OpenCode）
+
+**Files:**
+- Create: `src/core/ask-hook/types.ts`, `src/core/ask-hook/claude-code.ts`, `codex.ts`, `opencode.ts`, `registry.ts`
+- Test: `test/ask-hook-claude.test.ts`, `test/ask-hook-codex.test.ts`, `test/ask-hook-opencode.test.ts`
+
+> payload/directive 形状借鉴桌面端结论（见 spec §3），**实现前用各 CLI 当前版本实测一个真实 payload 样本存入 `test/fixtures/`**，测试以真实样本为准。
+
+- [ ] **Step 1: 定义 `ask-hook/types.ts`**
+
+```ts
+import type { AskQuestion } from '../ask-types.js';
+
+export interface ParsedAsk {
+  questions: AskQuestion[];
+  /** adapter 私有的原始上下文，formatAnswer 用来重建 directive。 */
+  raw: unknown;
+}
+
+export interface HookAskAdapter {
+  /** 非 askUserQuestion 事件返回 null（hook 客户端据此输出"放行"directive）。 */
+  parseQuestions(payload: unknown): ParsedAsk | null;
+  /** answersByQuestion[i] = questions[i] 选中的 key 数组。返回写回 CLI 的 directive JSON 字符串。 */
+  formatAnswer(answersByQuestion: ReadonlyArray<ReadonlyArray<string>>, parsed: ParsedAsk): string;
+  /** hook 接管失败时的"放行/无操作"directive（让 CLI 回退原生终端提问）。 */
+  passthrough(payload: unknown): string;
+}
+```
+
+- [ ] **Step 2: 写 Claude 失败测试**（`test/ask-hook-claude.test.ts`，含 fixtures）
+
+```ts
+import claude from '../src/core/ask-hook/claude-code.js';
+it('parseQuestions: PermissionRequest + AskUserQuestion → questions', () => {
+  const payload = { hook_event_name:'PermissionRequest', tool_name:'AskUserQuestion',
+    tool_input:{ questions:[{ question:'部署?', multiSelect:false, options:[{label:'继续'},{label:'回滚'}] }] } };
+  const parsed = claude.parseQuestions(payload);
+  expect(parsed).not.toBeNull();
+  expect(parsed!.questions[0].prompt).toBe('部署?');
+  expect(parsed!.questions[0].options.map(o=>o.key)).toEqual(['继续','回滚']); // key=label（无独立 key 时）
+});
+it('parseQuestions: 非 AskUserQuestion → null', () => {
+  expect(claude.parseQuestions({ hook_event_name:'PreToolUse', tool_name:'Bash' })).toBeNull();
+});
+it('formatAnswer: 映射回 hookSpecificOutput.updatedInput.answers 形状', () => {
+  const payload = { hook_event_name:'PermissionRequest', tool_name:'AskUserQuestion',
+    tool_input:{ questions:[{ question:'部署?', multiSelect:false, options:[{label:'继续'},{label:'回滚'}] }] } };
+  const parsed = claude.parseQuestions(payload)!;
+  const directive = JSON.parse(claude.formatAnswer([['继续']], parsed));
+  // 断言形状按 spec §3 / 实测 fixture（updatedInput.answers）
+  expect(JSON.stringify(directive)).toContain('继续');
+});
+```
+
+- [ ] **Step 3: 运行确认失败** → `pnpm vitest run test/ask-hook-claude.test.ts`（FAIL）
+
+- [ ] **Step 4: 实现 `claude-code.ts`**（按 fixture 形状），导出 `default: HookAskAdapter`。`parseQuestions` 只在 `hook_event_name==='PermissionRequest' && tool_name==='AskUserQuestion'` 时解析 `tool_input.questions[]`（option 无独立 key 时 `key=label`，`multiSelect` 透传）；`formatAnswer` 把答案塞进 Claude directive；`passthrough` 返回放行 directive（按 §9 实测形状）。
+
+- [ ] **Step 5: 运行确认通过** → PASS
+
+- [ ] **Step 6: 重复 Step 2–5 实现 `codex.ts`** （事件 `permission_request`/PermissionRequest，directive 按 Codex 实测形状）与 **`opencode.ts`**（事件 `QuestionAsked`，directive `{type:'answer', answers:string[][]}`）。各自独立 fixture + 测试文件。
+
+- [ ] **Step 7: `registry.ts`**
+
+```ts
+import type { HookAskAdapter } from './types.js';
+import claude from './claude-code.js';
+import codex from './codex.js';
+import opencode from './opencode.js';
+const REGISTRY: Record<string, HookAskAdapter> = { 'claude-code': claude, codex, opencode };
+export function getHookAdapter(cliId: string): HookAskAdapter | undefined { return REGISTRY[cliId]; }
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/core/ask-hook test/ask-hook-*.test.ts test/fixtures
+git commit -m "feat(ask): 三家 hook adapter（parseQuestions/formatAnswer/passthrough）"
+```
+
+---
+
+## Task 7: `botmux hook <cliId>` 子命令 + 抽 `postAsk()`
+
+**Files:**
+- Modify: `src/cli.ts`（新增 `cmdHook`；抽 `postAsk`；在命令分发处注册 `hook`）
+- Test: `test/cmd-hook.test.ts`（对 `postAsk` + 答案→directive 流程做可注入测试）
+
+- [ ] **Step 1: 抽公共 `postAsk()`**：把 `cmdAsk` 里"findDaemon → fetch /api/asks → 解析 AskResult/错误码"抽成 `async function postAsk(body): Promise<AskResult>`（daemon 不可达/HTTP 错误时抛带 exitCode 的错误）。`cmdAsk` 改为调用它（行为不变，跑原有 ask 测试确认零回归）。
+
+- [ ] **Step 2: 写失败测试**（`test/cmd-hook.test.ts`）：mock `postAsk` 返回 `{kind:'answered', answers:[['继续']], ...}`，喂一个 Claude AskUserQuestion 的 stdin payload，断言 `cmdHook('claude-code')` 向 stdout 写出的 directive 含 `继续`；mock `postAsk` 抛 daemon-unreachable，断言输出 passthrough directive 且**退出码为 0**（不挂死、优雅放行）。
+
+- [ ] **Step 3: 运行确认失败** → FAIL
+
+- [ ] **Step 4: 实现 `cmdHook(cliId)`**
+
+流程：读 stdin 全文 → `JSON.parse` → `getHookAdapter(cliId)`（未知 cliId：输出 passthrough/空并 exit 0）→ `adapter.parseQuestions(payload)`；`null` 则 `console.log(adapter.passthrough(payload))` 并 return（放行）。否则构造 body：
+```ts
+const body = {
+  sessionId: process.env.BOTMUX_SESSION_ID!, chatId: process.env.BOTMUX_CHAT_ID!,
+  larkAppId: process.env.BOTMUX_LARK_APP_ID!, rootMessageId: process.env.BOTMUX_ROOT_MESSAGE_ID || null,
+  questions: parsed.questions, timeoutMs: <默认 e.g. 3600_000，可由 env BOTMUX_ASK_TIMEOUT_MS 覆盖>, approvers: [],
+};
+```
+`try { const r = await postAsk(body); ... } catch { console.log(adapter.passthrough(payload)); return; }`（任何失败都放行，绝不挂死）。`r.kind==='answered'` → `console.log(adapter.formatAnswer(r.answers, parsed))`；`timedOut`/`invalidated` → `console.log(adapter.passthrough(payload))`。缺 env（非 botmux 会话）→ 同样 passthrough 放行。复用 `cmdAsk` 的 `BOTMUX_WORKFLOW==='1'` gate（workflow subagent 内直接 passthrough）。
+
+- [ ] **Step 5: 注册命令**：在 `src/cli.ts` 主分发 switch 增加 `case 'hook': await cmdHook(args[0]); break;`（`args[0]`=cliId）。
+
+- [ ] **Step 6: 运行确认通过** → PASS；并 `pnpm vitest run test/ask-args.test.ts test/ask-api.test.ts`（ask 子命令零回归）。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cli.ts test/cmd-hook.test.ts
+git commit -m "feat(ask): botmux hook <cli> 客户端 + 抽 postAsk 公共流程"
+```
+
+---
+
+## Task 8: hook 安装器 + adapter 元数据 + spawn 接缝
+
+**Files:**
+- Create: `src/adapters/hook-installer.ts`
+- Modify: `src/adapters/cli/types.ts`（加 `hookInstall?`）、`src/adapters/cli/{claude-code,codex,opencode}.ts`（填）、`src/core/worker-pool.ts`（`ensureCliSkills` 内调用）
+- Test: `test/hook-installer.test.ts`
+
+- [ ] **Step 1: adapter 元数据类型**（`cli/types.ts`）
+
+```ts
+/** hook 安装描述：本期仅 directive 三家填。undefined = 不通过 hook 接管 askUserQuestion。 */
+readonly hookInstall?: {
+  /** 待写入的配置文件绝对路径（~ 由 installer 展开）。 */
+  configPath: string;
+  /** 写入格式：决定 installer 如何合并进既有配置。 */
+  format: 'claude-settings' | 'codex-hooks' | 'opencode-plugin';
+};
+```
+
+- [ ] **Step 2: 写失败测试**（`test/hook-installer.test.ts`）：用临时目录（`os.tmpdir()`）模拟各 configPath，调 `installHook(adapter, hookCommand)`，断言：(a) Claude settings.json 写入了指向 `botmux hook claude-code` 的 PermissionRequest hook；(b) 幂等——二次调用内容不变不重写（用 mtime 或内容比较）；(c) 既有无关配置不被破坏（合并而非覆盖）。
+
+- [ ] **Step 3: 运行确认失败** → FAIL
+
+- [ ] **Step 4: 实现 `hook-installer.ts`**
+
+`export function installHook(cliId, hookInstall, hookCommand)`：按 `format` 分派——`claude-settings`：读/建 JSON，向 `hooks.PermissionRequest` 合并一个指向 `hookCommand` 的 entry（matcher `*`、足够大的 timeout），保留其他事件/entry；`codex-hooks`：写 `~/.codex/hooks.json` 的 `PermissionRequest`；`opencode-plugin`：写插件文件（内容里 `QuestionAsked` 时连 daemon——本期可先写一个调 `botmux hook opencode` 的薄插件）。幂等：写前比对内容。`hookCommand` 形如 `<botmux 可执行路径> hook <cliId>`。
+
+- [ ] **Step 5: 填三家 adapter 的 `hookInstall`**（`claude-code.ts`/`codex.ts`/`opencode.ts` 各加常量）。
+
+- [ ] **Step 6: 接入 spawn**（`worker-pool.ts` 的 `ensureCliSkills`，line ~351 `ensureSkills(...)` 之后）
+
+```ts
+if (adapter.hookInstall) {
+  try { installHook(cliId, adapter.hookInstall, hookCommandFor(cliId)); }
+  catch (err) { logger.warn(`[hook] install failed for ${cliId}: ${err instanceof Error ? err.message : String(err)}`); }
+}
+```
+（`hookCommandFor` 解析 botmux 可执行路径 + `hook <cliId>`，参考仓库现有"botmux 自身路径"解析方式，如 `process.execPath`/`process.argv[1]` 或现有 helper。）
+
+- [ ] **Step 7: 运行确认通过** → `pnpm vitest run test/hook-installer.test.ts` PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/adapters/hook-installer.ts src/adapters/cli/types.ts src/adapters/cli/claude-code.ts src/adapters/cli/codex.ts src/adapters/cli/opencode.ts src/core/worker-pool.ts test/hook-installer.test.ts
+git commit -m "feat(ask): spawn 时安装各 CLI hook 指向 botmux hook 客户端"
+```
+
+---
+
+## Task 9: 退役 `ASK_SKILL`
+
+**Files:**
+- Modify: `src/skills/definitions.ts`
+- Test: `test/builtin-skills.test.ts`（调整）
+
+- [ ] **Step 1: 改测试**：断言 `BUILTIN_SKILLS` 不再含 `botmux-ask`，且 `RETIRED_SKILL_NAMES` 含 `botmux-ask`。
+
+- [ ] **Step 2: 运行确认失败** → FAIL
+
+- [ ] **Step 3: 改 `definitions.ts`**：从 `BUILTIN_SKILLS` 移除 `{ name:'botmux-ask', content: ASK_SKILL }`；把 `'botmux-ask'` 加入 `RETIRED_SKILL_NAMES`（使 `ensureSkills` 清掉已装的旧 SKILL.md）；删除 `ASK_SKILL` 常量。**保留 `botmux ask` 子命令本身**（`cmdAsk` 不动），仅去掉自动推给 agent 的 skill。
+
+- [ ] **Step 4: 运行确认通过** → PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/skills/definitions.ts test/builtin-skills.test.ts
+git commit -m "feat(ask): 退役 botmux-ask skill（改由 hook 接管，子命令保留）"
+```
+
+---
+
+## Task 10: 全量校验 + dogfood
+
+- [ ] **Step 1: 全量测试 + 类型检查**
+
+Run: `pnpm vitest run && pnpm tsc --noEmit`
+Expected: 全绿
+
+- [ ] **Step 2: 构建**：`pnpm build`（确认 `dist/cli.js` 含 `hook` 子命令）。
+
+- [ ] **Step 3: dogfood — Claude Code**：重启 daemon → 在飞书话题起一个 Claude 会话 → 让它触发原生 AskUserQuestion（单问单选）→ 确认飞书弹出问答卡片、点选 → 确认 CLI 收到答案继续。
+
+- [ ] **Step 4: dogfood — 多选/多问**：构造一个多选或多问的 AskUserQuestion，飞书勾选 + Submit，确认答案完整正确回填。
+
+- [ ] **Step 5: dogfood — Codex + OpenCode**：各重复 Step 3 一次。
+
+- [ ] **Step 6: dogfood — 降级**：停 daemon 后让 CLI 提问，确认 CLI 回退到原生终端提问、不挂死。
+
+- [ ] **Step 7: dogfood — 双重弹卡检查（spec §10）**：directive 三家提问时，观察是否同时被 ScreenAnalyzer 当 TUI prompt 又弹出一张截屏卡片（hook 卡 + 截屏卡）。
+  - 若**不双弹**（hook 经 directive 回填后 CLI 未渲染可截的菜单）：记录确认，无需额外处理。
+  - 若**双弹**：作为 fast-follow——在 ScreenAnalyzer 侧对"已装 hookInstall 的 CLI 的 AskUserQuestion 菜单"做抑制（按当前会话 cliId 是否 `hookInstall` 命中来 gate 截屏弹卡）。本期先记录现象，不阻塞合入。
+
+- [ ] **Step 8: 确认旧 skill 已清除**：检查各 CLI skills 目录下 `botmux-ask/SKILL.md` 已被 `ensureSkills` 删除。
+
+- [ ] **Step 9: 开 PR**
+
+```bash
+git push -u origin feat/botmux-ask-hooks
+# gh pr create --base feat/botmux-ask --head feat/botmux-ask-hooks --title "feat(ask): hook 接管 askUserQuestion（替换 skill 触发，支持多选多问）"
+```
+
+---
+
+## 风险与执行注意
+
+- **Task 0 是后续卡片任务的前置**，务必先做完并把附录A 落定，Task 4/5 的 form 字段名/回调形状以附录为准。
+- **Task 1 提交后中段类型暂不通过属预期**，Task 2/3/4 依序修复；勿跳序执行。
+- 各 CLI 的 hook payload / directive / passthrough 形状**必须用当前版本实测 fixture**，不照搬桌面端常量（spec §2 原则）。
+- 向后兼容红线：`botmux ask buttons` 单选语义与其现有测试**零回归**（`toLegacySelected` + `tryResolveAsk` 封装保障）。

--- a/src/adapters/adopt-route.ts
+++ b/src/adapters/adopt-route.ts
@@ -1,0 +1,192 @@
+/**
+ * adopt-route.ts
+ *
+ * 为没有 BOTMUX_* 环境变量的"孤立" Claude 进程（即通过 /adopt 接管的外部 CLI）
+ * 提供 askUserQuestion hook 的路由解析逻辑。
+ *
+ * 通过以下步骤确定目标 Lark 会话：
+ *   1. 收集 hook 进程的祖先 PID 链
+ *   2. 遍历在线 daemon，查询每个 daemon 是否有以某祖先 PID 启动的 adopt 会话
+ *   3. 首个命中即返回路由信息
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+// ── 类型 ───────────────────────────────────────────────────────────────────────
+
+/** 从 daemon 取回的 adopt 会话路由信息 */
+export interface AdoptRoute {
+  sessionId: string;
+  chatId: string;
+  larkAppId: string;
+  rootMessageId: string;
+}
+
+// ── 祖先 PID 收集 ──────────────────────────────────────────────────────────────
+
+/**
+ * 读取某进程的父 PID。
+ *
+ * 默认实现：
+ *   1. 优先从 /proc/<pid>/stat 读取（Linux），第 4 字段（0-based）是 ppid。
+ *      注意 stat 第 2 字段 comm 可以含括号和空格，所以从最后一个 `)` 之后的子串解析。
+ *   2. 失败时回退到 `ps -o ppid= -p <pid>`（macOS/Linux 通用）。
+ *
+ * 失败/进程不存在 → 返回 null。
+ */
+function defaultReadParent(pid: number): number | null {
+  // 先尝试 /proc（Linux 最快）
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
+    // stat 格式: "<pid> (<comm>) <state> <ppid> ..."
+    // comm 字段可能含空格和括号，取最后一个 ')' 之后的部分
+    const lastParen = stat.lastIndexOf(')');
+    if (lastParen === -1) throw new Error('unexpected /proc stat format');
+    const tail = stat.slice(lastParen + 1).trim();
+    // tail: "<state> <ppid> ..."
+    const parts = tail.split(' ');
+    // parts[0] = state, parts[1] = ppid
+    const ppid = parseInt(parts[1], 10);
+    if (Number.isInteger(ppid) && ppid > 0) return ppid;
+  } catch {
+    // /proc 不可用或解析失败，回退到 ps
+  }
+
+  // 回退到 ps（macOS / 无 /proc 的 Linux）
+  try {
+    const out = execFileSync('ps', ['-o', 'ppid=', '-p', String(pid)], {
+      encoding: 'utf-8',
+    });
+    const ppid = parseInt(out.trim(), 10);
+    if (Number.isInteger(ppid) && ppid > 0) return ppid;
+  } catch {
+    // 进程不存在或 ps 调用失败
+  }
+
+  return null;
+}
+
+/**
+ * 沿进程祖先链向上收集 PID（不含 startPid 自己）。
+ *
+ * @param startPid    起始进程 PID（自身不包含在结果中）
+ * @param readParent  注入式父 PID 读取函数（默认使用 /proc 或 ps）
+ * @param maxDepth    最大深度，防止意外无限循环（默认 40）
+ * @returns           祖先 PID 数组，从最近父进程到最远祖先
+ */
+export function getAncestorPids(
+  startPid: number,
+  readParent?: (pid: number) => number | null,
+  maxDepth?: number,
+): number[] {
+  const reader = readParent ?? defaultReadParent;
+  const depth = maxDepth ?? 40;
+  const ancestors: number[] = [];
+  const visited = new Set<number>([startPid]);
+
+  let current = startPid;
+  for (let i = 0; i < depth; i++) {
+    const parent = reader(current);
+    if (parent === null || parent <= 1) break;  // 到 init 或读不到，停止
+    if (visited.has(parent)) break;             // 防环
+    visited.add(parent);
+    ancestors.push(parent);
+    current = parent;
+  }
+
+  return ancestors;
+}
+
+// ── Daemon 查询辅助 ─────────────────────────────────────────────────────────────
+
+/**
+ * 查询某个 daemon 是否有以指定 PID 启动的活跃 adopt 会话。
+ *
+ * GET http://127.0.0.1:<ipcPort>/api/adopt-session/<pid>
+ *   200 → 解析 AdoptRoute；其它状态码或异常 → null（不抛）。
+ * 超时：2 秒（AbortController）。
+ */
+export async function queryAdoptSession(
+  ipcPort: number,
+  pid: number,
+): Promise<AdoptRoute | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 2000);
+  try {
+    const res = await fetch(
+      `http://127.0.0.1:${ipcPort}/api/adopt-session/${pid}`,
+      { signal: controller.signal },
+    );
+    if (!res.ok) return null;
+    const body = (await res.json()) as unknown;
+    if (!body || typeof body !== 'object') return null;
+    const b = body as Record<string, unknown>;
+    if (
+      typeof b.sessionId !== 'string' ||
+      typeof b.chatId !== 'string' ||
+      typeof b.larkAppId !== 'string' ||
+      typeof b.rootMessageId !== 'string'
+    ) {
+      return null;
+    }
+    return {
+      sessionId: b.sessionId,
+      chatId: b.chatId,
+      larkAppId: b.larkAppId,
+      rootMessageId: b.rootMessageId,
+    };
+  } catch {
+    // 超时、网络错误、JSON 解析失败等 → null
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ── 主逻辑 ─────────────────────────────────────────────────────────────────────
+
+/**
+ * 通过祖先 PID 匹配在线 adopt 会话。
+ *
+ * 遍历每个 daemon × 每个祖先 pid，首个命中即返回；都不中返回 null。
+ *
+ * @param deps.startPid      hook 进程自身的 PID
+ * @param deps.listDaemons   列出在线 daemon（ipcPort）
+ * @param deps.queryDaemon   查询某 daemon 是否有该 pid 的活跃 adopt 会话
+ * @param deps.getAncestors  取祖先 PID（默认使用 getAncestorPids）
+ */
+export async function resolveAdoptRoute(deps: {
+  startPid: number;
+  listDaemons: () => Array<{ ipcPort: number }>;
+  queryDaemon: (ipcPort: number, pid: number) => Promise<AdoptRoute | null>;
+  getAncestors?: (startPid: number) => number[];
+}): Promise<AdoptRoute | null> {
+  const { startPid, listDaemons, queryDaemon } = deps;
+  const getAncestors = deps.getAncestors ?? ((pid) => getAncestorPids(pid));
+  const ancestors = getAncestors(startPid);
+  if (ancestors.length === 0) return null;
+
+  const daemons = listDaemons();
+  if (daemons.length === 0) return null;
+
+  // 外层遍历 daemon，内层遍历祖先（减少对同一 daemon 的重复连接）。
+  // 命中顺序确定：daemon 列表序 × 祖先链序（由近及远），首个 active match 即返回。
+  // 同一个外部 Claude 理论上不会被多个 bot 同时 adopt，故首个命中即正解。
+  for (const daemon of daemons) {
+    for (const pid of ancestors) {
+      const route = await queryDaemon(daemon.ipcPort, pid);
+      if (route) {
+        // 排障用：默认静默，置 BOTMUX_HOOK_DEBUG=1 时打到 stderr（不污染 hook stdout）。
+        if (process.env.BOTMUX_HOOK_DEBUG === '1') {
+          process.stderr.write(
+            `[adopt-route] matched pid=${pid} daemon=${daemon.ipcPort} session=${route.sessionId}\n`,
+          );
+        }
+        return route;
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/adapters/adopt-route.ts
+++ b/src/adapters/adopt-route.ts
@@ -149,44 +149,72 @@ export async function queryAdoptSession(
 /**
  * 通过祖先 PID 匹配在线 adopt 会话。
  *
- * 遍历每个 daemon × 每个祖先 pid，首个命中即返回；都不中返回 null。
+ * **并发 + 全局 budget 封顶**：候选 = daemon 列表序 × 祖先链序（由近及远）逐个编号；
+ * 全部并发查询（每请求各自带 2s 超时），整体不超过 `budgetMs`。命中按候选 index 取
+ * 最小，保持确定性。
+ *
+ * 为何要全局 budget：runHook 在缺 BOTMUX_* 时同步 await 本函数，而全局 hook 会覆盖
+ * 非 botmux 的 Claude 会话；若某 daemon still-online 但 IPC 不响应，顺序 await 会
+ * `祖先数 × 2s × daemon 数` 线性叠加（可达几十秒），把真·非 botmux 的 ask 卡死。
+ * 并发让总耗时收敛到单请求量级，budget 再封顶，保证快速 passthrough。
  *
  * @param deps.startPid      hook 进程自身的 PID
  * @param deps.listDaemons   列出在线 daemon（ipcPort）
  * @param deps.queryDaemon   查询某 daemon 是否有该 pid 的活跃 adopt 会话
  * @param deps.getAncestors  取祖先 PID（默认使用 getAncestorPids）
+ * @param deps.budgetMs      整体耗时上限（默认 1500ms；可注入便于测试）
  */
 export async function resolveAdoptRoute(deps: {
   startPid: number;
   listDaemons: () => Array<{ ipcPort: number }>;
   queryDaemon: (ipcPort: number, pid: number) => Promise<AdoptRoute | null>;
   getAncestors?: (startPid: number) => number[];
+  budgetMs?: number;
 }): Promise<AdoptRoute | null> {
   const { startPid, listDaemons, queryDaemon } = deps;
   const getAncestors = deps.getAncestors ?? ((pid) => getAncestorPids(pid));
+  const budgetMs = deps.budgetMs ?? 1500;
   const ancestors = getAncestors(startPid);
   if (ancestors.length === 0) return null;
 
   const daemons = listDaemons();
   if (daemons.length === 0) return null;
 
-  // 外层遍历 daemon，内层遍历祖先（减少对同一 daemon 的重复连接）。
-  // 命中顺序确定：daemon 列表序 × 祖先链序（由近及远），首个 active match 即返回。
-  // 同一个外部 Claude 理论上不会被多个 bot 同时 adopt，故首个命中即正解。
+  // 候选编号：daemon 列表序 × 祖先链序（由近及远），index 决定确定性优先级。
+  const candidates: Array<{ index: number; ipcPort: number; pid: number }> = [];
+  let idx = 0;
   for (const daemon of daemons) {
     for (const pid of ancestors) {
-      const route = await queryDaemon(daemon.ipcPort, pid);
-      if (route) {
-        // 排障用：默认静默，置 BOTMUX_HOOK_DEBUG=1 时打到 stderr（不污染 hook stdout）。
-        if (process.env.BOTMUX_HOOK_DEBUG === '1') {
-          process.stderr.write(
-            `[adopt-route] matched pid=${pid} daemon=${daemon.ipcPort} session=${route.sessionId}\n`,
-          );
-        }
-        return route;
-      }
+      candidates.push({ index: idx++, ipcPort: daemon.ipcPort, pid });
     }
   }
 
-  return null;
+  // 并发发起全部查询，命中按 index 记入 hits；整体被 budget 封顶。
+  const hits = new Map<number, AdoptRoute>();
+  const queries = candidates.map(async (c) => {
+    const route = await queryDaemon(c.ipcPort, c.pid);
+    if (route) hits.set(c.index, route);
+  });
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const budget = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, budgetMs);
+    timer.unref?.();
+  });
+  try {
+    await Promise.race([Promise.allSettled(queries), budget]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+
+  // 在「budget 内已 settle 的命中」里按候选 index 升序取最早的一个（确定性）。
+  let best: AdoptRoute | null = null;
+  let bestIdx = Infinity;
+  for (const [i, route] of hits) {
+    if (i < bestIdx) { bestIdx = i; best = route; }
+  }
+  if (best && process.env.BOTMUX_HOOK_DEBUG === '1') {
+    process.stderr.write(`[adopt-route] matched candidate#${bestIdx} session=${best.sessionId}\n`);
+  }
+  return best;
 }

--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -446,6 +446,14 @@ const BOTMUX_INJECTED_ENV_KEYS = [
   'BOTMUX',
   'SESSION_DATA_DIR',
   'IS_SANDBOX',
+  // §5 of botmux ask v0.1.7: `botmux ask buttons` / `botmux hook <cli>` read
+  // these to locate the daemon, route the card back to this thread, and
+  // resolve approvers from session.owner. Without them, the hook client falls
+  // back to passthrough and the agent never reaches the Lark card.
+  'BOTMUX_SESSION_ID',
+  'BOTMUX_CHAT_ID',
+  'BOTMUX_LARK_APP_ID',
+  'BOTMUX_ROOT_MESSAGE_ID',
 ] as const;
 
 /**

--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -3,7 +3,6 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { resolveCommand } from './registry.js';
 import type { CliAdapter, PtyHandle } from './types.js';
-import { hookCommandFor } from '../hook-command.js';
 import { findJsonlContainingFingerprint, jsonlContainsFingerprint, normaliseForFingerprint } from '../../services/claude-transcript.js';
 import { t } from '../../i18n/index.js';
 
@@ -390,16 +389,12 @@ export function createClaudeCodeAdapter(pathOverride?: string): CliAdapter {
       }
       args.push('--dangerously-skip-permissions');
       // 内联 --settings JSON 作用域仅限本次 spawn，不会写入用户全局 ~/.claude/settings.json。
-      // 同时注入 PreToolUse hook（matcher='*'），使 AskUserQuestion 事件自动转发到
-      // `botmux hook claude-code`——进程级注入，不污染非 botmux 的 Claude 会话。
+      // 注意：askUserQuestion hook 不在这里注入——它要写全局 settings.json（见下方
+      // hookInstall），这样 adopt 模式（botmux 接管的是别处已启动、拿不到本 --settings
+      // 的 claude 会话）才能让那条会话读到 hook。
       args.push('--settings', JSON.stringify({
         skipDangerousModePermissionPrompt: true,
         permissions: { defaultMode: 'bypassPermissions' },
-        hooks: {
-          PreToolUse: [
-            { matcher: '*', hooks: [{ type: 'command', command: hookCommandFor('claude-code'), timeout: 86400 }] },
-          ],
-        },
       }));
       args.push('--disallowed-tools', 'EnterPlanMode,ExitPlanMode');
       const unknown = t('ai.identity.unknown', undefined, locale);
@@ -714,8 +709,15 @@ export function createClaudeCodeAdapter(pathOverride?: string): CliAdapter {
     systemHints: [],
     altScreen: false,
     skillsDir: '~/.claude/skills',
-    // hook 通过 buildArgs 的 --settings 内联 JSON 注入（进程级），不写全局 settings.json，
-    // 不污染非 botmux 的 Claude 会话。
+    // askUserQuestion hook 写全局 ~/.claude/settings.json（matcher='*' 的 PreToolUse），
+    // 把 AskUserQuestion 事件转发到 `botmux hook claude-code`。
+    // 选全局而非进程级 --settings：adopt 模式接管的是 botmux 没启动、拿不到 --settings
+    // 的已有 claude 会话，只有全局配置那条会话才读得到。代价是会作用于非 botmux 的
+    // claude 会话，但 hook 客户端在缺 BOTMUX_* env 时直接 passthrough 放行，不破坏它们。
+    hookInstall: {
+      configPath: '~/.claude/settings.json',
+      format: 'claude-settings',
+    },
     asksViaHook: true,
   };
 }

--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -709,7 +709,7 @@ export function createClaudeCodeAdapter(pathOverride?: string): CliAdapter {
     systemHints: [],
     altScreen: false,
     skillsDir: '~/.claude/skills',
-    // askUserQuestion hook 写全局 ~/.claude/settings.json（matcher='*' 的 PreToolUse），
+    // askUserQuestion hook 写全局 ~/.claude/settings.json（matcher='AskUserQuestion' 的 PreToolUse），
     // 把 AskUserQuestion 事件转发到 `botmux hook claude-code`。
     // 选全局而非进程级 --settings：adopt 模式接管的是 botmux 没启动、拿不到 --settings
     // 的已有 claude 会话，只有全局配置那条会话才读得到。代价是会作用于非 botmux 的

--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -3,6 +3,7 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { resolveCommand } from './registry.js';
 import type { CliAdapter, PtyHandle } from './types.js';
+import { hookCommandFor } from '../hook-command.js';
 import { findJsonlContainingFingerprint, jsonlContainsFingerprint, normaliseForFingerprint } from '../../services/claude-transcript.js';
 import { t } from '../../i18n/index.js';
 
@@ -388,16 +389,17 @@ export function createClaudeCodeAdapter(pathOverride?: string): CliAdapter {
         args.push('--session-id', sessionId);
       }
       args.push('--dangerously-skip-permissions');
-      // Suppress the first-run "--dangerously-skip-permissions" risk-acceptance
-      // screen for this spawn only. In a fresh $HOME that has never accepted it,
-      // Claude Code otherwise blocks on an interactive confirmation that botmux
-      // can't answer — it mistypes the user's message into the dialog and the
-      // session breaks (observed as `tmux send-keys … failed`). An inline
-      // --settings JSON is scoped to this process, so it never mutates the
-      // user's global ~/.claude/settings.json or their interactive claude.
+      // 内联 --settings JSON 作用域仅限本次 spawn，不会写入用户全局 ~/.claude/settings.json。
+      // 同时注入 PreToolUse hook（matcher='*'），使 AskUserQuestion 事件自动转发到
+      // `botmux hook claude-code`——进程级注入，不污染非 botmux 的 Claude 会话。
       args.push('--settings', JSON.stringify({
         skipDangerousModePermissionPrompt: true,
         permissions: { defaultMode: 'bypassPermissions' },
+        hooks: {
+          PreToolUse: [
+            { matcher: '*', hooks: [{ type: 'command', command: hookCommandFor('claude-code'), timeout: 86400 }] },
+          ],
+        },
       }));
       args.push('--disallowed-tools', 'EnterPlanMode,ExitPlanMode');
       const unknown = t('ai.identity.unknown', undefined, locale);
@@ -712,12 +714,9 @@ export function createClaudeCodeAdapter(pathOverride?: string): CliAdapter {
     systemHints: [],
     altScreen: false,
     skillsDir: '~/.claude/skills',
-    // botmux hook 安装：spawn 时把 PreToolUse/AskUserQuestion 钩子写入 Claude settings.json，
-    // 使 AskUserQuestion 事件自动转发到 `botmux hook claude-code`。
-    hookInstall: {
-      configPath: '~/.claude/settings.json',
-      format: 'claude-settings',
-    },
+    // hook 通过 buildArgs 的 --settings 内联 JSON 注入（进程级），不写全局 settings.json，
+    // 不污染非 botmux 的 Claude 会话。
+    asksViaHook: true,
   };
 }
 

--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -712,7 +712,7 @@ export function createClaudeCodeAdapter(pathOverride?: string): CliAdapter {
     systemHints: [],
     altScreen: false,
     skillsDir: '~/.claude/skills',
-    // botmux hook 安装：spawn 时把 PermissionRequest 钩子写入 Claude settings.json，
+    // botmux hook 安装：spawn 时把 PreToolUse/AskUserQuestion 钩子写入 Claude settings.json，
     // 使 AskUserQuestion 事件自动转发到 `botmux hook claude-code`。
     hookInstall: {
       configPath: '~/.claude/settings.json',

--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -712,6 +712,12 @@ export function createClaudeCodeAdapter(pathOverride?: string): CliAdapter {
     systemHints: [],
     altScreen: false,
     skillsDir: '~/.claude/skills',
+    // botmux hook 安装：spawn 时把 PermissionRequest 钩子写入 Claude settings.json，
+    // 使 AskUserQuestion 事件自动转发到 `botmux hook claude-code`。
+    hookInstall: {
+      configPath: '~/.claude/settings.json',
+      format: 'claude-settings',
+    },
   };
 }
 

--- a/src/adapters/cli/opencode.ts
+++ b/src/adapters/cli/opencode.ts
@@ -46,6 +46,12 @@ export function createOpenCodeAdapter(pathOverride?: string): CliAdapter {
     systemHints: BOTMUX_SHELL_HINTS,
     altScreen: true,                // Bubble Tea renders in alternate screen buffer
     skillsDir: '~/.config/opencode/skills',
+    // botmux hook 安装：spawn 时写入 OpenCode 插件文件，
+    // 使 question.asked 事件自动转发到 `botmux hook opencode`。
+    hookInstall: {
+      configPath: '~/.config/opencode/plugin/botmux-ask.js',
+      format: 'opencode-plugin',
+    },
   };
 }
 

--- a/src/adapters/cli/opencode.ts
+++ b/src/adapters/cli/opencode.ts
@@ -52,6 +52,7 @@ export function createOpenCodeAdapter(pathOverride?: string): CliAdapter {
       configPath: '~/.config/opencode/plugin/botmux-ask.js',
       format: 'opencode-plugin',
     },
+    asksViaHook: true,
   };
 }
 

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -102,6 +102,15 @@ export interface CliAdapter {
    *  support skills (or has a non-standard layout not yet integrated). */
   readonly skillsDir?: string;
 
+  /** hook 安装描述：spawn 时写入各 CLI 的 hook 配置，使 askUserQuestion 事件转发到
+   *  `botmux hook <cliId>`。undefined = 不通过 hook 接管 askUserQuestion。 */
+  readonly hookInstall?: {
+    /** 待写入的配置文件路径（~ 由 installer 展开）。 */
+    readonly configPath: string;
+    /** 写入格式：决定 installer 如何合并进既有配置。 */
+    readonly format: 'claude-settings' | 'opencode-plugin';
+  };
+
   /** Completion marker regex (beyond generic quiescence). undefined = quiescence only. */
   readonly completionPattern?: RegExp;
 

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -111,6 +111,10 @@ export interface CliAdapter {
     readonly format: 'claude-settings' | 'opencode-plugin';
   };
 
+  /** true = 该 CLI 通过 hook 接管 askUserQuestion（不再装 botmux-ask skill 兜底）。
+   *  注入机制由各 adapter 自行决定（Claude 走 --settings、OpenCode 走插件）。 */
+  readonly asksViaHook?: boolean;
+
   /** Completion marker regex (beyond generic quiescence). undefined = quiescence only. */
   readonly completionPattern?: RegExp;
 

--- a/src/adapters/hook-command.ts
+++ b/src/adapters/hook-command.ts
@@ -18,10 +18,23 @@ import { dirname, join } from 'node:path';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
- * 构造 `botmux hook <cliId>` 的完整调用字符串。
- * Node 路径和 cli 路径均加引号，防路径含空格时解析出错。
+ * 构造 `botmux hook <cliId>` 的 argv 形式 `{ cmd, args }`——规范形态。
+ * 调用方用 `spawn(cmd, args)` 直接执行：无需 shell 解析、不怕路径含空格。
+ * OpenCode 插件用它（spawnSync），避免「拼成带引号字符串再 split」把路径拆坏。
+ */
+export function hookCommandParts(cliId: string): { cmd: string; args: string[] } {
+  const cliEntry = join(__dirname, '..', 'cli.js');
+  return { cmd: process.execPath, args: [cliEntry, 'hook', cliId] };
+}
+
+/**
+ * 构造 `botmux hook <cliId>` 的 **shell 命令字符串**（仅可执行路径与 cli.js 路径加引号，
+ * 容忍空格；`hook` 子命令名与 cliId 不加引号）。
+ * 仅用于「按 shell 字符串执行」的场景，例如写进 Claude Code 的 `~/.claude/settings.json`
+ * （其 `command` 字段由 Claude 经 shell 执行）。需要 argv 的场景请用 `hookCommandParts`，
+ * 切勿对本字符串再 `.split(' ')`。
  */
 export function hookCommandFor(cliId: string): string {
-  const cliEntry = join(__dirname, '..', 'cli.js');
-  return `"${process.execPath}" "${cliEntry}" hook ${cliId}`;
+  const { cmd, args } = hookCommandParts(cliId);
+  return `"${cmd}" "${args[0]}" ${args.slice(1).join(' ')}`;
 }

--- a/src/adapters/hook-command.ts
+++ b/src/adapters/hook-command.ts
@@ -1,0 +1,27 @@
+/**
+ * hook-command.ts
+ *
+ * 独立模块：构造 `botmux hook <cliId>` 的完整调用字符串。
+ *
+ * 之所以从本模块自身位置回推 cli.js，而非使用 process.argv[1]：
+ *   - daemon 由 pm2 以 `dist/index-daemon.js` 启动，daemon 进程的 argv[1]
+ *     是 index-daemon.js——它只 startDaemon()，不处理 hook 子命令。
+ *   - 编译后本文件位于 `<pkgRoot>/dist/adapters/hook-command.js`，
+ *     CLI 入口固定在 `<pkgRoot>/dist/cli.js`（package.json `bin.botmux` 指向它），
+ *     即 `../cli.js`。源码 checkout 和 npm global 安装都如此——布局一致。
+ *
+ * 不从 worker-pool 导入，也不从 adapter 导入 worker-pool——避免循环依赖。
+ */
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * 构造 `botmux hook <cliId>` 的完整调用字符串。
+ * Node 路径和 cli 路径均加引号，防路径含空格时解析出错。
+ */
+export function hookCommandFor(cliId: string): string {
+  const cliEntry = join(__dirname, '..', 'cli.js');
+  return `"${process.execPath}" "${cliEntry}" hook ${cliId}`;
+}

--- a/src/adapters/hook-installer.ts
+++ b/src/adapters/hook-installer.ts
@@ -8,6 +8,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { logger } from '../utils/logger.js';
+import { hookCommandParts } from './hook-command.js';
 
 // ─── 类型 ────────────────────────────────────────────────────────────────────
 
@@ -127,10 +128,10 @@ function installClaudeSettings(configPath: string, hookCommand: string): void {
  * OpenCode 插件 API 目前处于 dogfood 阶段，`question.asked` 钩子形状和返回值约定
  * 需要在真实会话中实测确认（stdin/stdout 格式、同步/异步、返回值结构等）。
  */
-function buildOpenCodePlugin(hookCommand: string): string {
-  // 把 hookCommand 拆成 [execPath, ...args]，供 spawnSync 调用
-  // hookCommand 形如：/path/to/node /path/to/cli.js hook opencode
-  const escapedCommand = JSON.stringify(hookCommand);
+function buildOpenCodePlugin(parts: { cmd: string; args: string[] }): string {
+  // 用 argv 形式嵌入（不拼 shell 字符串、不 split）：含空格/引号的路径也不会被拆坏。
+  const cmdLit = JSON.stringify(parts.cmd);
+  const argsLit = JSON.stringify(parts.args);
   return `// botmux-ask opencode plugin
 // 将 OpenCode 的 question.asked 事件转发到 botmux hook opencode。
 // TODO(dogfood): 校验 OpenCode 插件 question.asked API
@@ -141,17 +142,17 @@ export default {
 
   // question.asked: OpenCode 向用户提问时触发。
   // payload 形状待实测（见 TODO 注释）。
-  // 返回值 { answer: string } 或 undefined（undefined = 由 OpenCode 自行处理）。
+  // 返回值 { type:'answer', answers } 或 undefined（undefined = 由 OpenCode 自行处理）。
   "question.asked"(payload) {
     try {
       const input = JSON.stringify(payload);
-      const parts = ${escapedCommand}.split(" ");
-      const result = spawnSync(parts[0], parts.slice(1), {
+      const result = spawnSync(${cmdLit}, ${argsLit}, {
         input,
         encoding: "utf-8",
         timeout: 86400000, // 24h，等待用户在飞书回答
       });
-      if (result.status === 0 && result.stdout) {
+      // stdout 为空 = hook 客户端 passthrough（放行）→ 返回 undefined，OpenCode 原生处理。
+      if (result.status === 0 && result.stdout && result.stdout.trim()) {
         return JSON.parse(result.stdout.trim());
       }
     } catch {
@@ -166,8 +167,8 @@ export default {
 /**
  * 写入 OpenCode 插件文件。幂等：内容相同则跳过。
  */
-function installOpenCodePlugin(configPath: string, hookCommand: string): void {
-  const content = buildOpenCodePlugin(hookCommand);
+function installOpenCodePlugin(configPath: string, parts: { cmd: string; args: string[] }): void {
+  const content = buildOpenCodePlugin(parts);
   const changed = writeIfChanged(configPath, content);
   if (changed) {
     logger.info(`[hook] 已写入 OpenCode 插件 → ${configPath}`);
@@ -198,7 +199,8 @@ export function installHook(
         installClaudeSettings(configPath, hookCommand);
         break;
       case 'opencode-plugin':
-        installOpenCodePlugin(configPath, hookCommand);
+        // OpenCode 插件走 argv parts（spawnSync），不复用 shell 字符串，避免被 split 拆坏。
+        installOpenCodePlugin(configPath, hookCommandParts(cliId));
         break;
       default: {
         // TypeScript exhaustiveness（编译时保障，运行时防御）

--- a/src/adapters/hook-installer.ts
+++ b/src/adapters/hook-installer.ts
@@ -1,0 +1,196 @@
+/**
+ * hook-installer.ts
+ *
+ * 把 botmux 的 askUserQuestion hook 写入各 CLI 的配置文件。
+ * 幂等：写前比对内容，相同则跳过；展开 ~ 路径；出错只 warn 不抛。
+ */
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+import { logger } from '../utils/logger.js';
+
+// ─── 类型 ────────────────────────────────────────────────────────────────────
+
+export interface HookInstallConfig {
+  readonly configPath: string;
+  readonly format: 'claude-settings' | 'opencode-plugin';
+}
+
+// ─── 工具函数 ─────────────────────────────────────────────────────────────────
+
+/** 展开路径中的 ~ 为当前用户 home 目录。 */
+function expandHome(p: string): string {
+  return p.startsWith('~') ? join(homedir(), p.slice(1)) : p;
+}
+
+/** 读 JSON 文件，失败返回 null。 */
+function readJsonFile<T>(filePath: string): T | null {
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+/** 幂等写文件：若内容与现有相同则跳过；自动创建目录。 */
+function writeIfChanged(filePath: string, content: string): boolean {
+  try {
+    if (existsSync(filePath)) {
+      const existing = readFileSync(filePath, 'utf-8');
+      if (existing === content) return false; // 内容相同，无需写入
+    }
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeFileSync(filePath, content, 'utf-8');
+    return true;
+  } catch (err: any) {
+    throw new Error(`写入 ${filePath} 失败：${err.message}`);
+  }
+}
+
+// ─── Claude settings.json 格式 ───────────────────────────────────────────────
+
+interface ClaudeHookEntry {
+  type: 'command';
+  command: string;
+  timeout?: number;
+}
+
+interface ClaudeHookGroup {
+  matcher?: string;
+  hooks: ClaudeHookEntry[];
+}
+
+interface ClaudeSettings {
+  hooks?: Record<string, ClaudeHookGroup[]>;
+  [key: string]: unknown;
+}
+
+/** 判断某个 hook group 是否是 botmux ask hook（用于幂等替换）。 */
+function isBotmuxAskHookGroup(group: ClaudeHookGroup, hookCommand: string): boolean {
+  return group.hooks.some(
+    (e) => e.type === 'command' && e.command === hookCommand,
+  );
+}
+
+/**
+ * 向 Claude settings.json 的 hooks.PermissionRequest 合并 botmux ask hook entry。
+ * 保留其他事件和 entry，不破坏无关配置。
+ */
+function installClaudeSettings(configPath: string, hookCommand: string): void {
+  const settings: ClaudeSettings = readJsonFile<ClaudeSettings>(configPath) ?? {};
+  const existingHooks = settings.hooks ?? {};
+
+  // 构造 botmux PermissionRequest hook group（matcher=* 拦截所有工具，含 AskUserQuestion）
+  const newEntry: ClaudeHookEntry = { type: 'command', command: hookCommand, timeout: 86400 };
+  const newGroup: ClaudeHookGroup = { matcher: '*', hooks: [newEntry] };
+
+  // 过滤掉旧的 botmux ask hook group（幂等：同 hookCommand 只保留一份）
+  const existing = existingHooks['PermissionRequest'] ?? [];
+  const filtered = existing.filter((g) => !isBotmuxAskHookGroup(g, hookCommand));
+  existingHooks['PermissionRequest'] = [...filtered, newGroup];
+
+  settings.hooks = existingHooks;
+  const content = JSON.stringify(settings, null, 2) + '\n';
+  const changed = writeIfChanged(configPath, content);
+  if (changed) {
+    logger.info(`[hook] 已写入 Claude hook → ${configPath}`);
+  } else {
+    logger.info(`[hook] Claude hook 已是最新，跳过写入 → ${configPath}`);
+  }
+}
+
+// ─── OpenCode plugin 格式 ─────────────────────────────────────────────────────
+
+/**
+ * 构造 botmux ask 的 OpenCode 插件内容。
+ * 插件监听 question.asked 事件，将 payload JSON 写入 botmux hook opencode 的 stdin，
+ * 读取 stdout 作为回答，返回给 OpenCode。
+ *
+ * TODO(dogfood): 校验 OpenCode 插件 question.asked API
+ * OpenCode 插件 API 目前处于 dogfood 阶段，`question.asked` 钩子形状和返回值约定
+ * 需要在真实会话中实测确认（stdin/stdout 格式、同步/异步、返回值结构等）。
+ */
+function buildOpenCodePlugin(hookCommand: string): string {
+  // 把 hookCommand 拆成 [execPath, ...args]，供 spawnSync 调用
+  // hookCommand 形如：/path/to/node /path/to/cli.js hook opencode
+  const escapedCommand = JSON.stringify(hookCommand);
+  return `// botmux-ask opencode plugin
+// 将 OpenCode 的 question.asked 事件转发到 botmux hook opencode。
+// TODO(dogfood): 校验 OpenCode 插件 question.asked API
+import { spawnSync } from "child_process";
+
+export default {
+  name: "botmux-ask",
+
+  // question.asked: OpenCode 向用户提问时触发。
+  // payload 形状待实测（见 TODO 注释）。
+  // 返回值 { answer: string } 或 undefined（undefined = 由 OpenCode 自行处理）。
+  "question.asked"(payload) {
+    try {
+      const input = JSON.stringify(payload);
+      const parts = ${escapedCommand}.split(" ");
+      const result = spawnSync(parts[0], parts.slice(1), {
+        input,
+        encoding: "utf-8",
+        timeout: 86400000, // 24h，等待用户在飞书回答
+      });
+      if (result.status === 0 && result.stdout) {
+        return JSON.parse(result.stdout.trim());
+      }
+    } catch {
+      // 任何失败都降级放行：返回 undefined 让 OpenCode 回退原生终端提问
+    }
+    return undefined;
+  },
+};
+`;
+}
+
+/**
+ * 写入 OpenCode 插件文件。幂等：内容相同则跳过。
+ */
+function installOpenCodePlugin(configPath: string, hookCommand: string): void {
+  const content = buildOpenCodePlugin(hookCommand);
+  const changed = writeIfChanged(configPath, content);
+  if (changed) {
+    logger.info(`[hook] 已写入 OpenCode 插件 → ${configPath}`);
+  } else {
+    logger.info(`[hook] OpenCode 插件已是最新，跳过写入 → ${configPath}`);
+  }
+}
+
+// ─── 主入口 ───────────────────────────────────────────────────────────────────
+
+/**
+ * 幂等地将 botmux ask hook 安装到指定 CLI 的配置文件。
+ *
+ * @param cliId - CLI 标识符（用于日志）
+ * @param hookInstall - adapter 提供的安装描述（configPath + format）
+ * @param hookCommand - botmux hook 子命令的完整调用字符串
+ *                      例如："/usr/bin/node /path/to/cli.js hook claude-code"
+ */
+export function installHook(
+  cliId: string,
+  hookInstall: HookInstallConfig,
+  hookCommand: string,
+): void {
+  try {
+    const configPath = expandHome(hookInstall.configPath);
+    switch (hookInstall.format) {
+      case 'claude-settings':
+        installClaudeSettings(configPath, hookCommand);
+        break;
+      case 'opencode-plugin':
+        installOpenCodePlugin(configPath, hookCommand);
+        break;
+      default: {
+        // TypeScript exhaustiveness（编译时保障，运行时防御）
+        const _exhaustive: never = hookInstall.format;
+        logger.warn(`[hook] 未知 format：${_exhaustive}，跳过 ${cliId}`);
+      }
+    }
+  } catch (err: any) {
+    logger.warn(`[hook] install failed for ${cliId}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}

--- a/src/adapters/hook-installer.ts
+++ b/src/adapters/hook-installer.ts
@@ -73,22 +73,38 @@ function isBotmuxAskHookGroup(group: ClaudeHookGroup, hookCommand: string): bool
   );
 }
 
+function removeBotmuxAskHookGroups(
+  hooks: Record<string, ClaudeHookGroup[]>,
+  eventName: string,
+  hookCommand: string,
+): void {
+  const existing = hooks[eventName] ?? [];
+  const filtered = existing.filter((g) => !isBotmuxAskHookGroup(g, hookCommand));
+  if (filtered.length === 0) {
+    delete hooks[eventName];
+  } else {
+    hooks[eventName] = filtered;
+  }
+}
+
 /**
- * 向 Claude settings.json 的 hooks.PermissionRequest 合并 botmux ask hook entry。
+ * 向 Claude settings.json 的 hooks.PreToolUse 合并 botmux ask hook entry。
+ * AskUserQuestion 在 bypassPermissions 模式下不会经过 PermissionRequest，
+ * 但 PreToolUse 仍会在工具执行前触发，因此这里必须挂 PreToolUse。
  * 保留其他事件和 entry，不破坏无关配置。
  */
 function installClaudeSettings(configPath: string, hookCommand: string): void {
   const settings: ClaudeSettings = readJsonFile<ClaudeSettings>(configPath) ?? {};
   const existingHooks = settings.hooks ?? {};
 
-  // 构造 botmux PermissionRequest hook group（matcher=* 拦截所有工具，含 AskUserQuestion）
+  // 构造 botmux PreToolUse hook group（只拦截 AskUserQuestion）
   const newEntry: ClaudeHookEntry = { type: 'command', command: hookCommand, timeout: 86400 };
-  const newGroup: ClaudeHookGroup = { matcher: '*', hooks: [newEntry] };
+  const newGroup: ClaudeHookGroup = { matcher: 'AskUserQuestion', hooks: [newEntry] };
 
-  // 过滤掉旧的 botmux ask hook group（幂等：同 hookCommand 只保留一份）
-  const existing = existingHooks['PermissionRequest'] ?? [];
-  const filtered = existing.filter((g) => !isBotmuxAskHookGroup(g, hookCommand));
-  existingHooks['PermissionRequest'] = [...filtered, newGroup];
+  // 过滤掉旧的 botmux ask hook group（幂等 + 从 PermissionRequest 迁移到 PreToolUse）
+  removeBotmuxAskHookGroups(existingHooks, 'PermissionRequest', hookCommand);
+  removeBotmuxAskHookGroups(existingHooks, 'PreToolUse', hookCommand);
+  existingHooks['PreToolUse'] = [...(existingHooks['PreToolUse'] ?? []), newGroup];
 
   settings.hooks = existingHooks;
   const content = JSON.stringify(settings, null, 2) + '\n';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3218,6 +3218,22 @@ botmux create-group — 用一组机器人新建飞书群
 // the daemon dies). See /tmp/botmux-ask.md (or design memory).
 
 async function cmdAsk(sub: string, rest: string[]): Promise<void> {
+  // Workflow-subagent safety gate (same posture as cmdSend): a CLI running
+  // inside a workflow subagent (Slice F) must not surface chat UI. Workflow
+  // approvals belong in humanGate / decision nodes so the choice is part of
+  // the run's event log; an ad-hoc `botmux ask` would bypass that audit
+  // trail entirely.
+  if (process.env.BOTMUX_WORKFLOW === '1') {
+    const runId = process.env.BOTMUX_WORKFLOW_RUN_ID ?? '?';
+    const nodeId = process.env.BOTMUX_WORKFLOW_NODE_ID ?? '?';
+    console.error(
+      `botmux ask refused inside workflow subagent (run=${runId} node=${nodeId}).\n` +
+        `Workflow subagents must surface approvals via humanGate / decision nodes\n` +
+        `so the resolution is recorded in the run's event log; ask would bypass it.`,
+    );
+    process.exit(2);
+  }
+
   // Only `buttons` shipped in v0.1.7. The bare alias (`botmux ask --options`)
   // routes here with sub='' — accept it and behave identically. `ask text` /
   // `ask confirm` are reserved for later versions.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3407,16 +3407,20 @@ async function cmdAsk(sub: string, rest: string[]): Promise<void> {
  * runHook: hook 命令的纯业务逻辑，接受已解析的 payload/env/postAskFn，
  * 返回应写到 stdout 的字符串。通过依赖注入使单元测试无需真实 daemon/env。
  *
- * @param payload   已经 JSON.parse 的 hook payload 对象
- * @param env       包含 BOTMUX_* 环境变量的字典
- * @param postAskFn 替代真实 postAsk 的可注入函数（测试用）
- * @returns         { stdout: string } 应写到 stdout 的内容
+ * @param payload              已经 JSON.parse 的 hook payload 对象
+ * @param env                  包含 BOTMUX_* 环境变量的字典
+ * @param postAskFn            替代真实 postAsk 的可注入函数（测试用）
+ * @param cliId                CLI 适配器 ID
+ * @param resolveAdoptRouteFn  可选：替代真实 adopt 路由解析的注入函数（测试用）；
+ *                             缺省时使用真实 resolveAdoptRoute（查祖先 PID → daemon）
+ * @returns                    { stdout: string } 应写到 stdout 的内容
  */
 export async function runHook(
   payload: unknown,
   env: Record<string, string | undefined>,
   postAskFn: (body: Record<string, unknown>) => Promise<import('./core/ask-types.js').AskResult>,
   cliId: string,
+  resolveAdoptRouteFn?: () => Promise<import('./adapters/adopt-route.js').AdoptRoute | null>,
 ): Promise<{ stdout: string }> {
   const { getHookAdapter } = await import('./core/ask-hook/registry.js');
 
@@ -3441,9 +3445,40 @@ export async function runHook(
   const sessionId = env.BOTMUX_SESSION_ID;
   const chatId = env.BOTMUX_CHAT_ID;
   const larkAppId = env.BOTMUX_LARK_APP_ID;
+
+  // 路由变量：优先用 env，env 缺失时尝试 adopt 路由
+  let routeSessionId = sessionId;
+  let routeChatId = chatId;
+  let routeLarkAppId = larkAppId;
+  let routeRoot: string | null = env.BOTMUX_ROOT_MESSAGE_ID || null;
+
   if (!sessionId || !chatId || !larkAppId) {
-    // 非 botmux 会话（env 缺失），passthrough 放行
-    return { stdout: adapter.passthrough(payload) };
+    // env 缺失 → 尝试通过祖先 PID 匹配在线 adopt 会话
+    const resolver = resolveAdoptRouteFn ?? (() => {
+      // 延迟 import 避免冷启动开销
+      return import('./adapters/adopt-route.js').then(({ resolveAdoptRoute, queryAdoptSession }) =>
+        resolveAdoptRoute({
+          startPid: process.pid,
+          listDaemons: listOnlineDaemons,
+          queryDaemon: queryAdoptSession,
+        }),
+      );
+    });
+    let adopt: import('./adapters/adopt-route.js').AdoptRoute | null = null;
+    try {
+      adopt = await resolver();
+    } catch {
+      // 解析失败 → 视作真非 botmux 会话，passthrough 放行
+    }
+    if (!adopt) {
+      // 真非 botmux 会话 → passthrough 放行
+      return { stdout: adapter.passthrough(payload) };
+    }
+    // adopt 命中 → 使用 adopt 路由信息
+    routeSessionId = adopt.sessionId;
+    routeChatId = adopt.chatId;
+    routeLarkAppId = adopt.larkAppId;
+    routeRoot = adopt.rootMessageId;
   }
 
   // 解析 timeoutMs：默认 1 小时，可由 BOTMUX_ASK_TIMEOUT_MS 覆盖
@@ -3458,10 +3493,10 @@ export async function runHook(
   }
 
   const body: Record<string, unknown> = {
-    sessionId,
-    chatId,
-    larkAppId,
-    rootMessageId: env.BOTMUX_ROOT_MESSAGE_ID || null,
+    sessionId: routeSessionId,
+    chatId: routeChatId,
+    larkAppId: routeLarkAppId,
+    rootMessageId: routeRoot,
     questions: parsed.questions,
     timeoutMs,
     approvers: [],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3217,6 +3217,67 @@ botmux create-group — 用一组机器人新建飞书群
 // process unblocks with the selected key (or exit 124 on timeout, exit 3 if
 // the daemon dies). See /tmp/botmux-ask.md (or design memory).
 
+/**
+ * postAsk: 找到 daemon → POST /api/asks → 返回 AskResult。
+ * 连接失败 / HTTP 错误时抛出带 exitCode 属性的 Error：
+ *   - exitCode=3：daemon 不可达或 HTTP 非 400
+ *   - exitCode=2：400 + no_approvers
+ */
+async function postAsk(body: Record<string, unknown>): Promise<import('./core/ask-types.js').AskResult> {
+  type AskResult = import('./core/ask-types.js').AskResult;
+
+  const larkAppId = body.larkAppId as string;
+  const daemon = findDaemon(larkAppId);
+  if (!daemon) {
+    const err = new Error(
+      `botmux ask: 找不到 daemon (larkAppId=${larkAppId})。daemon 已停？exit 3.`,
+    ) as Error & { exitCode: number };
+    err.exitCode = 3;
+    throw err;
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(`http://127.0.0.1:${daemon.ipcPort}/api/asks`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+      // No client-side timeout — broker enforces `timeoutMs` and will respond
+      // with `kind:'timedOut'` so this fetch always settles.
+    });
+  } catch (fetchErr) {
+    const msg = fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
+    const err = new Error(
+      `botmux ask: 无法连接 daemon (port=${daemon.ipcPort}): ${msg}`,
+    ) as Error & { exitCode: number };
+    err.exitCode = 3;
+    throw err;
+  }
+
+  if (!res.ok) {
+    let errBody = '';
+    try { errBody = (await res.text()).slice(0, 200); } catch { /* */ }
+    if (res.status === 400 && /no_approvers/.test(errBody)) {
+      const err = new Error(
+        'botmux ask: 当前会话没有可批准者（session.owner 不在 bot.allowedUsers 里，且 --approver 未指定）',
+      ) as Error & { exitCode: number };
+      err.exitCode = 2;
+      throw err;
+    }
+    const err = new Error(`botmux ask: daemon HTTP ${res.status}: ${errBody}`) as Error & { exitCode: number };
+    err.exitCode = 3;
+    throw err;
+  }
+
+  try {
+    return (await res.json()) as AskResult;
+  } catch (jsonErr) {
+    const err = new Error(`botmux ask: daemon 返回非 JSON: ${jsonErr}`) as Error & { exitCode: number };
+    err.exitCode = 3;
+    throw err;
+  }
+}
+
 async function cmdAsk(sub: string, rest: string[]): Promise<void> {
   // Workflow-subagent safety gate (same posture as cmdSend): a CLI running
   // inside a workflow subagent (Slice F) must not surface chat UI. Workflow
@@ -3246,8 +3307,8 @@ async function cmdAsk(sub: string, rest: string[]): Promise<void> {
 
   const { findMissingAskEnv, parseAskOptions, parseAskTimeoutSeconds, AskArgsError } =
     await import('./core/ask-args.js');
-  type AskResult = import('./core/ask-types.js').AskResult;
   type AskJsonOutput = import('./core/ask-types.js').AskJsonOutput;
+  const { toLegacySelected } = await import('./core/ask-types.js');
 
   const missing = findMissingAskEnv(process.env);
   if (missing) {
@@ -3286,14 +3347,6 @@ async function cmdAsk(sub: string, rest: string[]): Promise<void> {
   }
 
   const larkAppId = process.env.BOTMUX_LARK_APP_ID!;
-  const daemon = findDaemon(larkAppId);
-  if (!daemon) {
-    console.error(
-      `botmux ask: 找不到 daemon (larkAppId=${larkAppId})。daemon 已停？exit 3.`,
-    );
-    process.exit(3);
-  }
-
   const body = {
     sessionId: process.env.BOTMUX_SESSION_ID!,
     chatId: process.env.BOTMUX_CHAT_ID!,
@@ -3305,52 +3358,30 @@ async function cmdAsk(sub: string, rest: string[]): Promise<void> {
     approvers: approverArgs,
   };
 
-  let res: Response;
+  let result;
   try {
-    res = await fetch(`http://127.0.0.1:${daemon.ipcPort}/api/asks`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(body),
-      // No client-side timeout — broker enforces `timeoutMs` and will respond
-      // with `kind:'timedOut'` so this fetch always settles.
-    });
+    result = await postAsk(body);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error(`botmux ask: 无法连接 daemon (port=${daemon.ipcPort}): ${msg}`);
-    process.exit(3);
+    const code = (err as any).exitCode ?? 3;
+    console.error((err as Error).message);
+    process.exit(code);
   }
 
-  if (!res.ok) {
-    let errBody = '';
-    try { errBody = (await res.text()).slice(0, 200); } catch { /* */ }
-    if (res.status === 400 && /no_approvers/.test(errBody)) {
-      console.error(
-        'botmux ask: 当前会话没有可批准者（session.owner 不在 bot.allowedUsers 里，且 --approver 未指定）',
-      );
-      process.exit(2);
-    }
-    console.error(`botmux ask: daemon HTTP ${res.status}: ${errBody}`);
-    process.exit(3);
-  }
-
-  let result: AskResult;
-  try {
-    result = (await res.json()) as AskResult;
-  } catch (err) {
-    console.error(`botmux ask: daemon 返回非 JSON: ${err}`);
-    process.exit(3);
-  }
+  // result.kind==='answered' 时用 toLegacySelected 取回旧的 string（单问单选）
+  const selected = toLegacySelected(result);
 
   if (useJson) {
     const out: AskJsonOutput = {
-      selected: result.kind === 'answered' ? result.selected : null,
+      selected,
+      answers: result.kind === 'answered' ? (result.answers as string[][]) : null,
       by: result.kind === 'answered' ? result.by : null,
       comment: null,
       timedOut: result.kind === 'timedOut',
     };
     process.stdout.write(JSON.stringify(out) + '\n');
   } else if (result.kind === 'answered') {
-    process.stdout.write(result.selected + '\n');
+    // 非 JSON 模式：输出 selected key（单问单选），多选/多问输出空字符串
+    process.stdout.write((selected ?? '') + '\n');
   }
 
   switch (result.kind) {
@@ -3363,6 +3394,134 @@ async function cmdAsk(sub: string, rest: string[]): Promise<void> {
       console.error(`botmux ask: 已失效 (${result.reason})`);
       process.exit(3);
   }
+}
+
+// ─── botmux hook <cliId> ──────────────────────────────────────────────────────
+//
+// hook 模式：各 CLI hook 配置调用 `botmux hook <cliId>`，stdin 注入 hook payload，
+// 本命令解析问题 → POST /api/asks → 等结果 → 写 directive 到 stdout。
+// 任何失败（daemon 不可达、env 缺失、解析错误）均输出 passthrough directive 并 exit 0，
+// 绝不挂死，保证 CLI 可以继续原生终端提问。
+
+/**
+ * runHook: hook 命令的纯业务逻辑，接受已解析的 payload/env/postAskFn，
+ * 返回应写到 stdout 的字符串。通过依赖注入使单元测试无需真实 daemon/env。
+ *
+ * @param payload   已经 JSON.parse 的 hook payload 对象
+ * @param env       包含 BOTMUX_* 环境变量的字典
+ * @param postAskFn 替代真实 postAsk 的可注入函数（测试用）
+ * @returns         { stdout: string } 应写到 stdout 的内容
+ */
+export async function runHook(
+  payload: unknown,
+  env: Record<string, string | undefined>,
+  postAskFn: (body: Record<string, unknown>) => Promise<import('./core/ask-types.js').AskResult>,
+  cliId: string,
+): Promise<{ stdout: string }> {
+  const { getHookAdapter } = await import('./core/ask-hook/registry.js');
+
+  // 未知 cliId → 无 adapter，输出空字符串静默放行
+  const adapter = getHookAdapter(cliId);
+  if (!adapter) {
+    return { stdout: '' };
+  }
+
+  // Workflow-subagent 安全门：workflow 子 agent 内直接 passthrough
+  if (env.BOTMUX_WORKFLOW === '1') {
+    return { stdout: adapter.passthrough(payload) };
+  }
+
+  // 解析问题：非 askUserQuestion 类事件 → passthrough 放行
+  const parsed = adapter.parseQuestions(payload);
+  if (!parsed) {
+    return { stdout: adapter.passthrough(payload) };
+  }
+
+  // 检查必需的 BOTMUX_* env
+  const sessionId = env.BOTMUX_SESSION_ID;
+  const chatId = env.BOTMUX_CHAT_ID;
+  const larkAppId = env.BOTMUX_LARK_APP_ID;
+  if (!sessionId || !chatId || !larkAppId) {
+    // 非 botmux 会话（env 缺失），passthrough 放行
+    return { stdout: adapter.passthrough(payload) };
+  }
+
+  // 解析 timeoutMs：默认 1 小时，可由 BOTMUX_ASK_TIMEOUT_MS 覆盖
+  const DEFAULT_TIMEOUT_MS = 3_600_000;
+  let timeoutMs = DEFAULT_TIMEOUT_MS;
+  const timeoutEnv = env.BOTMUX_ASK_TIMEOUT_MS;
+  if (timeoutEnv) {
+    const parsed_timeout = parseInt(timeoutEnv, 10);
+    if (Number.isInteger(parsed_timeout) && parsed_timeout > 0) {
+      timeoutMs = parsed_timeout;
+    }
+  }
+
+  const body: Record<string, unknown> = {
+    sessionId,
+    chatId,
+    larkAppId,
+    rootMessageId: env.BOTMUX_ROOT_MESSAGE_ID || null,
+    questions: parsed.questions,
+    timeoutMs,
+    approvers: [],
+  };
+
+  let result: import('./core/ask-types.js').AskResult;
+  try {
+    result = await postAskFn(body);
+  } catch {
+    // 任何失败（daemon 不可达、HTTP 错误等）→ passthrough 放行
+    return { stdout: adapter.passthrough(payload) };
+  }
+
+  if (result.kind === 'answered') {
+    return { stdout: adapter.formatAnswer(result.answers, parsed) };
+  }
+
+  // timedOut / invalidated → passthrough 放行
+  return { stdout: adapter.passthrough(payload) };
+}
+
+/**
+ * cmdHook: `botmux hook <cliId>` 入口。
+ * 读取 stdin 全文 → JSON.parse → runHook → 写 stdout，exit 0。
+ */
+async function cmdHook(cliId: string): Promise<void> {
+  // 读取 stdin 全文
+  let stdinText = '';
+  try {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    stdinText = Buffer.concat(chunks).toString('utf-8');
+  } catch {
+    // stdin 读取失败 → 无法处理，静默退出
+    process.exit(0);
+  }
+
+  // JSON.parse 失败 → 输出空并退出（不挂死）
+  let payload: unknown;
+  try {
+    payload = JSON.parse(stdinText);
+  } catch {
+    process.exit(0);
+  }
+
+  const { getHookAdapter } = await import('./core/ask-hook/registry.js');
+  const adapter = getHookAdapter(cliId);
+  // 未知 cliId → 静默放行
+  if (!adapter) {
+    process.exit(0);
+  }
+
+  const env = process.env as Record<string, string | undefined>;
+  const result = await runHook(payload, env, postAsk, cliId);
+  if (result.stdout) {
+    console.log(result.stdout);
+  }
+  process.exit(0);
 }
 
 async function cmdBots(sub: string, rest: string[]): Promise<void> {
@@ -3575,6 +3734,12 @@ switch (command) {
     const { normalizeAskDispatch } = await import('./core/ask-args.js');
     const { sub, rest } = normalizeAskDispatch(process.argv.slice(3));
     await cmdAsk(sub, rest);
+    break;
+  }
+  case 'hook': {
+    // `botmux hook <cliId>` — hook 客户端，stdin 读 payload，stdout 写 directive
+    const cliId = process.argv[3] ?? '';
+    await cmdHook(cliId);
     break;
   }
   case 'workflow': {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3553,7 +3553,14 @@ switch (command) {
   case 'rm':      cmdDelete(); break;
   case 'resume':  await cmdResume(); break;
   case 'schedule': await cmdSchedule(process.argv[3] ?? '', process.argv.slice(4)); break;
-  case 'ask':      await cmdAsk(process.argv[3] ?? '', process.argv.slice(4)); break;
+  case 'ask': {
+    // `botmux ask buttons --options ...` → sub='buttons', rest=['--options', ...]
+    // `botmux ask --options ...`         → sub='',        rest=['--options', ...]  (bare alias)
+    const { normalizeAskDispatch } = await import('./core/ask-args.js');
+    const { sub, rest } = normalizeAskDispatch(process.argv.slice(3));
+    await cmdAsk(sub, rest);
+    break;
+  }
   case 'workflow': {
     const { cmdWorkflow } = await import('./cli/workflow.js');
     await cmdWorkflow(process.argv[3] ?? '', process.argv.slice(4));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3210,6 +3210,145 @@ botmux create-group — 用一组机器人新建飞书群
 
 // ─── Bots subcommand ─────────────────────────────────────────────────────────
 
+// ─── botmux ask v0.1.7 ───────────────────────────────────────────────────────
+//
+// CLI agent inside a botmux-spawned session calls `botmux ask buttons
+// --options "..." "<prompt>"`. Daemon sends a Lark card; user clicks; CLI
+// process unblocks with the selected key (or exit 124 on timeout, exit 3 if
+// the daemon dies). See /tmp/botmux-ask.md (or design memory).
+
+async function cmdAsk(sub: string, rest: string[]): Promise<void> {
+  // Only `buttons` shipped in v0.1.7. The bare alias (`botmux ask --options`)
+  // routes here with sub='' — accept it and behave identically. `ask text` /
+  // `ask confirm` are reserved for later versions.
+  if (sub && sub !== 'buttons') {
+    console.error(
+      `botmux ask: 未知 subcommand "${sub}"（v0.1.7 仅支持 \`buttons\` 或省略）`,
+    );
+    process.exit(2);
+  }
+
+  const { findMissingAskEnv, parseAskOptions, parseAskTimeoutSeconds, AskArgsError } =
+    await import('./core/ask-args.js');
+  type AskResult = import('./core/ask-types.js').AskResult;
+  type AskJsonOutput = import('./core/ask-types.js').AskJsonOutput;
+
+  const missing = findMissingAskEnv(process.env);
+  if (missing) {
+    console.error(
+      `botmux ask: 缺少必需环境变量 ${missing}。` +
+        ` 请在 botmux daemon spawn 的 CLI 会话内运行。`,
+    );
+    process.exit(2);
+  }
+
+  const optionsRaw = argValue(rest, '--options');
+  const timeoutRaw = argValue(rest, '--timeout');
+  const useJson = rest.includes('--json');
+  const approverArgs = argValues(rest, '--approver');
+  const positionalArgs = positionals(rest, ['--json']);
+
+  let options;
+  let timeoutMs;
+  try {
+    options = parseAskOptions(optionsRaw);
+    timeoutMs = parseAskTimeoutSeconds(timeoutRaw);
+  } catch (err) {
+    if (err instanceof AskArgsError) {
+      console.error(`botmux ask: ${err.message}`);
+      process.exit(2);
+    }
+    throw err;
+  }
+
+  const prompt = positionalArgs.join(' ').trim();
+  if (!prompt) {
+    console.error(
+      'botmux ask: 缺少 prompt。用法: botmux ask buttons --options "yes,no" "继续发版吗？"',
+    );
+    process.exit(2);
+  }
+
+  const larkAppId = process.env.BOTMUX_LARK_APP_ID!;
+  const daemon = findDaemon(larkAppId);
+  if (!daemon) {
+    console.error(
+      `botmux ask: 找不到 daemon (larkAppId=${larkAppId})。daemon 已停？exit 3.`,
+    );
+    process.exit(3);
+  }
+
+  const body = {
+    sessionId: process.env.BOTMUX_SESSION_ID!,
+    chatId: process.env.BOTMUX_CHAT_ID!,
+    larkAppId,
+    rootMessageId: process.env.BOTMUX_ROOT_MESSAGE_ID || null,
+    options,
+    prompt,
+    timeoutMs,
+    approvers: approverArgs,
+  };
+
+  let res: Response;
+  try {
+    res = await fetch(`http://127.0.0.1:${daemon.ipcPort}/api/asks`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+      // No client-side timeout — broker enforces `timeoutMs` and will respond
+      // with `kind:'timedOut'` so this fetch always settles.
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`botmux ask: 无法连接 daemon (port=${daemon.ipcPort}): ${msg}`);
+    process.exit(3);
+  }
+
+  if (!res.ok) {
+    let errBody = '';
+    try { errBody = (await res.text()).slice(0, 200); } catch { /* */ }
+    if (res.status === 400 && /no_approvers/.test(errBody)) {
+      console.error(
+        'botmux ask: 当前会话没有可批准者（session.owner 不在 bot.allowedUsers 里，且 --approver 未指定）',
+      );
+      process.exit(2);
+    }
+    console.error(`botmux ask: daemon HTTP ${res.status}: ${errBody}`);
+    process.exit(3);
+  }
+
+  let result: AskResult;
+  try {
+    result = (await res.json()) as AskResult;
+  } catch (err) {
+    console.error(`botmux ask: daemon 返回非 JSON: ${err}`);
+    process.exit(3);
+  }
+
+  if (useJson) {
+    const out: AskJsonOutput = {
+      selected: result.kind === 'answered' ? result.selected : null,
+      by: result.kind === 'answered' ? result.by : null,
+      comment: null,
+      timedOut: result.kind === 'timedOut',
+    };
+    process.stdout.write(JSON.stringify(out) + '\n');
+  } else if (result.kind === 'answered') {
+    process.stdout.write(result.selected + '\n');
+  }
+
+  switch (result.kind) {
+    case 'answered':
+      process.exit(0);
+    case 'timedOut':
+      console.error(`botmux ask: 超时（${timeoutMs / 1000}s），无回复`);
+      process.exit(124);
+    case 'invalidated':
+      console.error(`botmux ask: 已失效 (${result.reason})`);
+      process.exit(3);
+  }
+}
+
 async function cmdBots(sub: string, rest: string[]): Promise<void> {
   process.env.SESSION_DATA_DIR ??= resolveDataDir();
 
@@ -3414,6 +3553,7 @@ switch (command) {
   case 'rm':      cmdDelete(); break;
   case 'resume':  await cmdResume(); break;
   case 'schedule': await cmdSchedule(process.argv[3] ?? '', process.argv.slice(4)); break;
+  case 'ask':      await cmdAsk(process.argv[3] ?? '', process.argv.slice(4)); break;
   case 'workflow': {
     const { cmdWorkflow } = await import('./cli/workflow.js');
     await cmdWorkflow(process.argv[3] ?? '', process.argv.slice(4));

--- a/src/core/ask-api.ts
+++ b/src/core/ask-api.ts
@@ -6,15 +6,15 @@
  * registering bots, or mounting a full session map.
  */
 
-import type { AskOption } from './ask-types.js';
+import type { AskOption, AskQuestion } from './ask-types.js';
 
 export interface AskApiBody {
   sessionId: string;
   chatId: string;
   larkAppId: string;
   rootMessageId: string | null;
-  options: AskOption[];
-  prompt: string;
+  /** v0.1.8：替换旧的 options/prompt，支持多问多选。 */
+  questions: AskQuestion[];
   /** Already in milliseconds. CLI side converts from `--timeout` seconds. */
   timeoutMs: number;
   /** Empty array → use the §6 fallback chain. */
@@ -33,10 +33,50 @@ export type AskApiBodyError =
   | 'bad_option_shape'
   | 'bad_option_key'
   | 'bad_option_label'
-  | 'duplicate_option_key';
+  | 'duplicate_option_key'
+  | 'bad_questions'
+  | 'bad_question_shape'
+  | 'bad_multiSelect';
+
+/** 校验单个 option 对象，返回解析后的 AskOption 或错误码。 */
+function parseOption(o: unknown): AskOption | AskApiBodyError {
+  if (!o || typeof o !== 'object') return 'bad_option_shape';
+  const oo = o as Record<string, unknown>;
+  if (typeof oo.key !== 'string' || !oo.key.trim()) return 'bad_option_key';
+  if (typeof oo.label !== 'string') return 'bad_option_label';
+  return { key: oo.key, label: oo.label };
+}
+
+/** 校验 questions[] 数组，返回解析后的 AskQuestion[] 或错误码。 */
+function parseQuestions(arr: unknown[]): AskQuestion[] | AskApiBodyError {
+  const result: AskQuestion[] = [];
+  for (const q of arr) {
+    if (!q || typeof q !== 'object' || Array.isArray(q)) return 'bad_question_shape';
+    const qq = q as Record<string, unknown>;
+    if (typeof qq.prompt !== 'string' || !qq.prompt.trim()) return 'bad_question_shape';
+    if (typeof qq.multiSelect !== 'boolean') return 'bad_multiSelect';
+    if (!Array.isArray(qq.options) || qq.options.length < 2) return 'bad_options';
+    const opts: AskOption[] = [];
+    const seen = new Set<string>();
+    for (const o of qq.options) {
+      const parsed = parseOption(o);
+      if (typeof parsed === 'string') return parsed;
+      if (seen.has(parsed.key)) return 'duplicate_option_key';
+      seen.add(parsed.key);
+      opts.push(parsed);
+    }
+    result.push({ prompt: qq.prompt, multiSelect: qq.multiSelect, options: opts });
+  }
+  return result;
+}
 
 /** Validate the request body. Returns either the parsed body or an error code
- *  ready to be sent back as `{ ok: false, error }` with HTTP 400. */
+ *  ready to be sent back as `{ ok: false, error }` with HTTP 400.
+ *
+ *  v0.1.8：
+ *  - 优先识别 `questions[]` 新格式（多问多选）。
+ *  - 兼容旧的 `options[]` + `prompt` 格式，归一化为单问单选的 questions[]。
+ *  - 两者都没有则返回 `bad_options`。 */
 export function parseAskBody(raw: unknown): AskApiBody | { error: AskApiBodyError } {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { error: 'bad_body' };
   const r = raw as Record<string, unknown>;
@@ -47,7 +87,6 @@ export function parseAskBody(raw: unknown): AskApiBody | { error: AskApiBodyErro
   if (r.rootMessageId !== null && typeof r.rootMessageId !== 'string') {
     return { error: 'bad_rootMessageId' };
   }
-  if (typeof r.prompt !== 'string' || !r.prompt.trim()) return { error: 'bad_prompt' };
   if (
     typeof r.timeoutMs !== 'number' ||
     !Number.isFinite(r.timeoutMs) ||
@@ -55,31 +94,46 @@ export function parseAskBody(raw: unknown): AskApiBody | { error: AskApiBodyErro
   ) {
     return { error: 'bad_timeoutMs' };
   }
-  if (!Array.isArray(r.options) || r.options.length < 2) return { error: 'bad_options' };
-
-  const opts: AskOption[] = [];
-  const seen = new Set<string>();
-  for (const o of r.options) {
-    if (!o || typeof o !== 'object') return { error: 'bad_option_shape' };
-    const oo = o as Record<string, unknown>;
-    if (typeof oo.key !== 'string' || !oo.key.trim()) return { error: 'bad_option_key' };
-    if (typeof oo.label !== 'string') return { error: 'bad_option_label' };
-    if (seen.has(oo.key)) return { error: 'duplicate_option_key' };
-    seen.add(oo.key);
-    opts.push({ key: oo.key, label: oo.label });
-  }
 
   const approvers = Array.isArray(r.approvers)
     ? r.approvers.filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
     : [];
+
+  let questions: AskQuestion[];
+
+  if (Array.isArray(r.questions)) {
+    // 新格式：questions[] 多问多选
+    if (r.questions.length === 0) return { error: 'bad_questions' };
+    const parsed = parseQuestions(r.questions);
+    if (typeof parsed === 'string') return { error: parsed };
+    questions = parsed;
+  } else if (Array.isArray(r.options) && typeof r.prompt === 'string' && r.prompt.trim()) {
+    // 旧格式兼容：options[] + prompt → 归一化为单问单选
+    if (r.options.length < 2) return { error: 'bad_options' };
+    const opts: AskOption[] = [];
+    const seen = new Set<string>();
+    for (const o of r.options) {
+      const parsed = parseOption(o);
+      if (typeof parsed === 'string') return { error: parsed };
+      if (seen.has(parsed.key)) return { error: 'duplicate_option_key' };
+      seen.add(parsed.key);
+      opts.push(parsed);
+    }
+    questions = [{ prompt: r.prompt, multiSelect: false, options: opts }];
+  } else {
+    // 旧格式：仅有 prompt 校验（无 options 或 options 不合法）
+    if (typeof r.prompt !== 'string' || !r.prompt.trim()) return { error: 'bad_prompt' };
+    if (!Array.isArray(r.options) || r.options.length < 2) return { error: 'bad_options' };
+    // 走到这里说明 options 是数组但长度不足，上面已处理，此处不可达
+    return { error: 'bad_options' };
+  }
 
   return {
     sessionId: r.sessionId,
     chatId: r.chatId,
     larkAppId: r.larkAppId,
     rootMessageId: r.rootMessageId as string | null,
-    options: opts,
-    prompt: r.prompt,
+    questions,
     timeoutMs: r.timeoutMs,
     approvers,
   };

--- a/src/core/ask-api.ts
+++ b/src/core/ask-api.ts
@@ -1,0 +1,110 @@
+/**
+ * Pure helpers for the daemon's `POST /api/asks` IPC route.
+ *
+ * Kept separate from daemon.ts so the body-validator and the approver
+ * fallback chain (§6) are unit-testable without spinning up an HTTP server,
+ * registering bots, or mounting a full session map.
+ */
+
+import type { AskOption } from './ask-types.js';
+
+export interface AskApiBody {
+  sessionId: string;
+  chatId: string;
+  larkAppId: string;
+  rootMessageId: string | null;
+  options: AskOption[];
+  prompt: string;
+  /** Already in milliseconds. CLI side converts from `--timeout` seconds. */
+  timeoutMs: number;
+  /** Empty array → use the §6 fallback chain. */
+  approvers: string[];
+}
+
+export type AskApiBodyError =
+  | 'bad_body'
+  | 'bad_sessionId'
+  | 'bad_chatId'
+  | 'bad_larkAppId'
+  | 'bad_rootMessageId'
+  | 'bad_prompt'
+  | 'bad_timeoutMs'
+  | 'bad_options'
+  | 'bad_option_shape'
+  | 'bad_option_key'
+  | 'bad_option_label'
+  | 'duplicate_option_key';
+
+/** Validate the request body. Returns either the parsed body or an error code
+ *  ready to be sent back as `{ ok: false, error }` with HTTP 400. */
+export function parseAskBody(raw: unknown): AskApiBody | { error: AskApiBodyError } {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { error: 'bad_body' };
+  const r = raw as Record<string, unknown>;
+
+  if (typeof r.sessionId !== 'string' || !r.sessionId.trim()) return { error: 'bad_sessionId' };
+  if (typeof r.chatId !== 'string' || !r.chatId.trim()) return { error: 'bad_chatId' };
+  if (typeof r.larkAppId !== 'string' || !r.larkAppId.trim()) return { error: 'bad_larkAppId' };
+  if (r.rootMessageId !== null && typeof r.rootMessageId !== 'string') {
+    return { error: 'bad_rootMessageId' };
+  }
+  if (typeof r.prompt !== 'string' || !r.prompt.trim()) return { error: 'bad_prompt' };
+  if (
+    typeof r.timeoutMs !== 'number' ||
+    !Number.isFinite(r.timeoutMs) ||
+    r.timeoutMs < 1000
+  ) {
+    return { error: 'bad_timeoutMs' };
+  }
+  if (!Array.isArray(r.options) || r.options.length < 2) return { error: 'bad_options' };
+
+  const opts: AskOption[] = [];
+  const seen = new Set<string>();
+  for (const o of r.options) {
+    if (!o || typeof o !== 'object') return { error: 'bad_option_shape' };
+    const oo = o as Record<string, unknown>;
+    if (typeof oo.key !== 'string' || !oo.key.trim()) return { error: 'bad_option_key' };
+    if (typeof oo.label !== 'string') return { error: 'bad_option_label' };
+    if (seen.has(oo.key)) return { error: 'duplicate_option_key' };
+    seen.add(oo.key);
+    opts.push({ key: oo.key, label: oo.label });
+  }
+
+  const approvers = Array.isArray(r.approvers)
+    ? r.approvers.filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
+    : [];
+
+  return {
+    sessionId: r.sessionId,
+    chatId: r.chatId,
+    larkAppId: r.larkAppId,
+    rootMessageId: r.rootMessageId as string | null,
+    options: opts,
+    prompt: r.prompt,
+    timeoutMs: r.timeoutMs,
+    approvers,
+  };
+}
+
+/** Resolve the approver allowlist per §6 fallback chain:
+ *   1. explicit `--approver` list from CLI args (non-empty wins outright)
+ *   2. session.ownerOpenId ∩ bot.allowedUsers (single-owner topic chats)
+ *   3. bot.allowedUsers (shared chats / no owner / owner not in allow)
+ *
+ *  Pure function: caller injects the lookups. The daemon wires
+ *  `getBotAllowedUsers = (id) => getBot(id).resolvedAllowedUsers` and
+ *  `getSessionOwner` = scan over activeSessions; tests pass stub funcs. */
+export function resolveAskApprovers(args: {
+  larkAppId: string;
+  sessionId: string;
+  explicit: ReadonlyArray<string>;
+  getBotAllowedUsers: (larkAppId: string) => ReadonlyArray<string>;
+  getSessionOwner: (sessionId: string) => string | undefined;
+}): Set<string> {
+  const explicit = args.explicit.filter((s) => s.trim().length > 0);
+  if (explicit.length > 0) return new Set(explicit);
+
+  const allow = args.getBotAllowedUsers(args.larkAppId);
+  const owner = args.getSessionOwner(args.sessionId);
+  if (owner && allow.includes(owner)) return new Set([owner]);
+  return new Set(allow);
+}

--- a/src/core/ask-args.ts
+++ b/src/core/ask-args.ts
@@ -1,0 +1,132 @@
+/**
+ * Pure helpers for `botmux ask` argument parsing.
+ *
+ * Kept in its own file (no I/O, no env reads) so the CSV / timeout / approver
+ * parsing can be unit-tested without spinning up a daemon. The actual CLI
+ * dispatch (`cmdAsk`) lives in cli.ts and calls these helpers.
+ */
+
+import type { AskOption } from './ask-types.js';
+
+export class AskArgsError extends Error {
+  constructor(
+    public readonly code:
+      | 'options_missing'
+      | 'options_too_few'
+      | 'options_empty_key'
+      | 'options_duplicate_key'
+      | 'timeout_out_of_range'
+      | 'timeout_not_number',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'AskArgsError';
+  }
+}
+
+/** Parse `--options` CSV. Each item is either `key` (key==label) or `key=label`.
+ *
+ *  Rules:
+ *   - Trims whitespace around each item and around `key=label` halves.
+ *   - Drops empty items (trailing commas / `"a,,b"`); does not count them.
+ *   - Requires ≥ 2 distinct keys after parsing.
+ *   - Empty `key` (e.g. `"=label"`) is rejected.
+ *   - Duplicate keys are rejected — let the caller surface a clear error rather
+ *     than silently de-duping (which would change observable button count).
+ *   - The first `=` splits key/label; subsequent `=` are part of the label, so
+ *     `"go=继续=右"` → key=`go`, label=`继续=右`. */
+export function parseAskOptions(raw: string | undefined): AskOption[] {
+  if (raw === undefined || raw.trim() === '') {
+    throw new AskArgsError('options_missing', '缺少 --options（需要 ≥ 2 项，例如 --options "yes,no" 或 --options "yes=继续,no=回滚"）');
+  }
+  const items = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  const out: AskOption[] = [];
+  const seen = new Set<string>();
+  for (const item of items) {
+    const eq = item.indexOf('=');
+    let key: string;
+    let label: string;
+    if (eq < 0) {
+      key = item;
+      label = item;
+    } else {
+      key = item.slice(0, eq).trim();
+      label = item.slice(eq + 1).trim();
+      if (label === '') label = key; // `"yes="` → label falls back to key
+    }
+    if (key === '') {
+      throw new AskArgsError(
+        'options_empty_key',
+        `--options 项的 key 不能为空（"${item}"）`,
+      );
+    }
+    if (seen.has(key)) {
+      throw new AskArgsError(
+        'options_duplicate_key',
+        `--options 出现重复 key: ${key}`,
+      );
+    }
+    seen.add(key);
+    out.push({ key, label });
+  }
+
+  if (out.length < 2) {
+    throw new AskArgsError(
+      'options_too_few',
+      `--options 至少需要 2 项，收到 ${out.length}`,
+    );
+  }
+  return out;
+}
+
+/** Parse `--timeout <seconds>` → milliseconds. Bounds match §7:
+ *   - lower bound: 10s (sub-10s asks are almost always a bug)
+ *   - upper bound: 3600s (1h — past that, recovery should kick in v0.1.8)
+ *   - default: 300s (caller passes `undefined` to use it) */
+export function parseAskTimeoutSeconds(
+  raw: string | undefined,
+  defaults: { default: number; min: number; max: number } = {
+    default: 300,
+    min: 10,
+    max: 3600,
+  },
+): number {
+  if (raw === undefined) return defaults.default * 1000;
+  const trimmed = raw.trim();
+  if (trimmed === '') return defaults.default * 1000;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || !Number.isInteger(n)) {
+    throw new AskArgsError(
+      'timeout_not_number',
+      `--timeout 必须是整数秒数，收到 "${raw}"`,
+    );
+  }
+  if (n < defaults.min || n > defaults.max) {
+    throw new AskArgsError(
+      'timeout_out_of_range',
+      `--timeout 范围 [${defaults.min}, ${defaults.max}] 秒，收到 ${n}`,
+    );
+  }
+  return n * 1000;
+}
+
+/** Required env vars on the CLI side (§5). Returns the first missing one so
+ *  the caller can produce a single, specific error message. */
+export function findMissingAskEnv(
+  env: NodeJS.ProcessEnv,
+): string | null {
+  const required = [
+    'BOTMUX_SESSION_ID',
+    'BOTMUX_CHAT_ID',
+    'BOTMUX_LARK_APP_ID',
+    'BOTMUX_ROOT_MESSAGE_ID',
+  ];
+  for (const k of required) {
+    if (!env[k] || !env[k]!.trim()) return k;
+  }
+  return null;
+}

--- a/src/core/ask-args.ts
+++ b/src/core/ask-args.ts
@@ -114,6 +114,28 @@ export function parseAskTimeoutSeconds(
   return n * 1000;
 }
 
+/** Resolve the `(sub, rest)` pair for `botmux ask`'s top-level dispatch.
+ *
+ *  Input: positional args *after* the `ask` token. So for the user typing
+ *  `botmux ask buttons --options yes,no "prompt"` we get
+ *  `['buttons', '--options', 'yes,no', 'prompt']`; for the bare alias
+ *  `botmux ask --options yes,no "prompt"` we get
+ *  `['--options', 'yes,no', 'prompt']`.
+ *
+ *  The first positional starting with `--` means the user skipped the
+ *  subcommand and went straight to flags — that's the bare-alias path; we
+ *  return `sub=''` and let `cmdAsk` apply its v0.1.7 `buttons` default.
+ *  Otherwise the first positional is the subcommand. */
+export function normalizeAskDispatch(
+  tail: ReadonlyArray<string>,
+): { sub: string; rest: string[] } {
+  const next = tail[0] ?? '';
+  if (next.startsWith('--')) {
+    return { sub: '', rest: tail.slice(0) };
+  }
+  return { sub: next, rest: tail.slice(1) };
+}
+
 /** Required env vars on the CLI side (§5). Returns the first missing one so
  *  the caller can produce a single, specific error message. */
 export function findMissingAskEnv(

--- a/src/core/ask-broker.ts
+++ b/src/core/ask-broker.ts
@@ -1,0 +1,222 @@
+/**
+ * In-memory broker for `botmux ask` (v0.1.7).
+ *
+ * Holds the pending-ask registry, runs the deadline timers, and arbitrates
+ * click resolution. IM-agnostic: the im/lark side wires a dispatcher via
+ * `setCardDispatcher` so the broker doesn't import Lark types.
+ *
+ * §3 / §6 / §7 / §8 of /tmp/botmux-ask.md.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { logger } from '../utils/logger.js';
+import type {
+  AskCardDispatcher,
+  AskClickOutcome,
+  AskResult,
+  CreateAskInput,
+  PendingAsk,
+} from './ask-types.js';
+
+interface InternalPending extends PendingAsk {
+  resolve: (result: AskResult) => void;
+  timeoutHandle: NodeJS.Timeout;
+}
+
+const pending = new Map<string, InternalPending>();
+let dispatcher: AskCardDispatcher | null = null;
+
+/** Wire the IM-side dispatcher. Called once during daemon bootstrap from
+ *  daemon.ts after im/lark/ask-card.ts is constructed. */
+export function setCardDispatcher(d: AskCardDispatcher): void {
+  dispatcher = d;
+}
+
+/** Register a new pending ask. Returns a Promise that settles when:
+ *   - a valid click arrives (`kind:'answered'`)
+ *   - the deadline elapses (`kind:'timedOut'`)
+ *   - the broker invalidates the ask (`kind:'invalidated'`)
+ *
+ *  Side effects:
+ *   - generates askId + nonce
+ *   - starts the deadline timer
+ *   - dispatches the card; if the card send fails, the ask is immediately
+ *     invalidated and the Promise settles with `kind:'invalidated'`.
+ *
+ *  Throws synchronously only if no dispatcher has been wired — that's a
+ *  daemon-misconfiguration bug, not a runtime ask failure.
+ */
+export function registerAsk(input: CreateAskInput): Promise<AskResult> {
+  if (!dispatcher) {
+    throw new Error('ask-broker: cardDispatcher not wired — daemon bootstrap bug');
+  }
+
+  const askId = randomUUID();
+  const nonce = randomUUID().slice(0, 8);
+  const createdAt = Date.now();
+  const deadlineAt = createdAt + input.timeoutMs;
+
+  return new Promise<AskResult>((resolve) => {
+    const timeoutHandle = setTimeout(() => {
+      settle(askId, {
+        kind: 'timedOut',
+        selected: null,
+        by: null,
+        comment: null,
+        timedOut: true,
+      });
+    }, input.timeoutMs);
+    // Don't keep the event loop alive just because an ask is pending.
+    timeoutHandle.unref?.();
+
+    const ask: InternalPending = {
+      askId,
+      nonce,
+      larkAppId: input.larkAppId,
+      chatId: input.chatId,
+      rootMessageId: input.rootMessageId,
+      sessionId: input.sessionId,
+      approvers: input.approvers,
+      options: input.options,
+      prompt: input.prompt,
+      createdAt,
+      deadlineAt,
+      settled: false,
+      resolve,
+      timeoutHandle,
+    };
+    pending.set(askId, ask);
+
+    // Card dispatch is async — store the messageId once it lands.
+    void dispatcher!
+      .send(snapshot(ask))
+      .then(({ messageId }) => {
+        const cur = pending.get(askId);
+        if (cur && !cur.settled) cur.cardMessageId = messageId;
+      })
+      .catch((err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.warn?.(`ask-broker: ${askId} card dispatch failed: ${msg}`);
+        settle(askId, {
+          kind: 'invalidated',
+          reason: `card dispatch failed: ${msg}`,
+          selected: null,
+          by: null,
+          comment: null,
+          timedOut: false,
+        });
+      });
+  });
+}
+
+/** Resolve attempt from a card-button click. Returns one of the §10 outcomes;
+ *  caller (card click handler) maps to user-facing toast.
+ *
+ *  All four "no-op" outcomes (`unauthorized`/`stale`/`already_settled`) leave
+ *  the broker state unchanged so the original CLI Promise keeps waiting for
+ *  the real winner or the deadline. */
+export function tryResolveAsk(args: {
+  askId: string;
+  nonce: string;
+  selected: string;
+  by: string;
+}): AskClickOutcome {
+  const ask = pending.get(args.askId);
+  if (!ask) return 'stale';                       // unknown id (daemon restart, GC'd, etc.)
+  if (ask.nonce !== args.nonce) return 'stale';   // replayed click from a previous card
+  if (ask.settled) return 'already_settled';      // race loser
+  if (!ask.approvers.has(args.by)) return 'unauthorized';
+  if (!ask.options.some((o) => o.key === args.selected)) return 'stale';
+
+  settle(args.askId, {
+    kind: 'answered',
+    selected: args.selected,
+    by: args.by,
+    comment: null,
+    timedOut: false,
+  });
+  return 'accepted';
+}
+
+/** Invalidate every pending ask. Intended for daemon shutdown / restart paths
+ *  so CLI subprocesses unblock with `kind:'invalidated'` instead of waiting
+ *  forever on a dead daemon. */
+export function invalidateAll(reason: string): number {
+  const ids = [...pending.keys()];
+  for (const id of ids) {
+    settle(id, {
+      kind: 'invalidated',
+      reason,
+      selected: null,
+      by: null,
+      comment: null,
+      timedOut: false,
+    });
+  }
+  if (ids.length > 0) {
+    logger.info?.(`ask-broker: invalidated ${ids.length} pending ask(s): ${reason}`);
+  }
+  return ids.length;
+}
+
+/** Internal — settle an ask exactly once and notify the dispatcher's onSettle
+ *  hook (best-effort, never blocks broker state transitions). */
+function settle(askId: string, result: AskResult): void {
+  const ask = pending.get(askId);
+  if (!ask || ask.settled) return;
+  ask.settled = true;
+  clearTimeout(ask.timeoutHandle);
+  pending.delete(askId);
+
+  try {
+    ask.resolve(result);
+  } catch (err) {
+    logger.warn?.(
+      `ask-broker: ${askId} resolve threw: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (dispatcher?.onSettle) {
+    try {
+      void Promise.resolve(dispatcher.onSettle(snapshot(ask), result)).catch((err) => {
+        logger.warn?.(
+          `ask-broker: ${askId} onSettle failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    } catch (err) {
+      logger.warn?.(
+        `ask-broker: ${askId} onSettle threw: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}
+
+/** Strip broker-internal fields before handing a snapshot to the IM-side
+ *  dispatcher. Keeps the dispatcher contract narrow. */
+function snapshot(ask: InternalPending): PendingAsk {
+  const { resolve: _r, timeoutHandle: _t, ...rest } = ask;
+  return rest;
+}
+
+// ---- diagnostics for tests ---------------------------------------------------
+
+/** Pending ask count — for tests and metrics. Not part of the public API. */
+export function _pendingCount(): number {
+  return pending.size;
+}
+
+/** Read a pending ask by id — for tests only. Returns a snapshot; mutating it
+ *  has no effect on broker state. */
+export function _getPending(askId: string): PendingAsk | undefined {
+  const a = pending.get(askId);
+  return a ? snapshot(a) : undefined;
+}
+
+/** Reset broker state — for tests only. Does NOT resolve outstanding promises,
+ *  so tests must not call this while real CLI processes might be waiting. */
+export function _resetForTest(): void {
+  for (const ask of pending.values()) clearTimeout(ask.timeoutHandle);
+  pending.clear();
+  dispatcher = null;
+}

--- a/src/core/ask-broker.ts
+++ b/src/core/ask-broker.ts
@@ -19,7 +19,7 @@ import type {
   PendingAsk,
 } from './ask-types.js';
 
-interface InternalPending extends PendingAsk {
+interface InternalPending extends Omit<PendingAsk, 'selections'> {
   resolve: (result: AskResult) => void;
   timeoutHandle: NodeJS.Timeout;
   /** epoch ms when settle ran; undefined while still pending. */
@@ -325,7 +325,10 @@ function settle(askId: string, result: AskResult): void {
  *  dispatcher. Keeps the dispatcher contract narrow. */
 function snapshot(ask: InternalPending): PendingAsk {
   const { resolve: _r, timeoutHandle: _t, settledAt: _sat, selections: _sel, ...rest } = ask;
-  return rest;
+  return {
+    ...rest,
+    selections: ask.questions.map((_, i) => [...(ask.selections.get(i) ?? new Set<string>())]),
+  };
 }
 
 /** Drop settled entries that have aged past the retention window. Cheap O(n)
@@ -349,11 +352,17 @@ export function _pendingCount(): number {
   return n;
 }
 
+/** Read a pending ask by id. Returns a snapshot; mutating it has no effect on
+ *  broker state. Used by the card handler to PATCH toggle state. */
+export function getAskSnapshot(askId: string): PendingAsk | undefined {
+  const a = pending.get(askId);
+  return a ? snapshot(a) : undefined;
+}
+
 /** Read a pending ask by id — for tests only. Returns a snapshot; mutating it
  *  has no effect on broker state. */
 export function _getPending(askId: string): PendingAsk | undefined {
-  const a = pending.get(askId);
-  return a ? snapshot(a) : undefined;
+  return getAskSnapshot(askId);
 }
 
 /** 返回当前 pending map 中所有 askId 列表（含 settled 但仍在 retention 内的条目）。

--- a/src/core/ask-broker.ts
+++ b/src/core/ask-broker.ts
@@ -22,10 +22,18 @@ import type {
 interface InternalPending extends PendingAsk {
   resolve: (result: AskResult) => void;
   timeoutHandle: NodeJS.Timeout;
+  /** epoch ms when settle ran; undefined while still pending. */
+  settledAt?: number;
 }
 
 const pending = new Map<string, InternalPending>();
 let dispatcher: AskCardDispatcher | null = null;
+
+/** Window during which a settled ask is still queryable so race-losers get a
+ *  precise `already_settled` outcome (and the card click handler can show
+ *  "已被 X 答了" instead of a generic "已失效"). After this window expires,
+ *  late clicks fall through to `stale` like any forgotten id. */
+const SETTLED_RETENTION_MS = 60_000;
 
 /** Wire the IM-side dispatcher. Called once during daemon bootstrap from
  *  daemon.ts after im/lark/ask-card.ts is constructed. */
@@ -122,10 +130,11 @@ export function tryResolveAsk(args: {
   selected: string;
   by: string;
 }): AskClickOutcome {
+  gcSettled();
   const ask = pending.get(args.askId);
   if (!ask) return 'stale';                       // unknown id (daemon restart, GC'd, etc.)
   if (ask.nonce !== args.nonce) return 'stale';   // replayed click from a previous card
-  if (ask.settled) return 'already_settled';      // race loser
+  if (ask.settled) return 'already_settled';      // race loser, still within retention window
   if (!ask.approvers.has(args.by)) return 'unauthorized';
   if (!ask.options.some((o) => o.key === args.selected)) return 'stale';
 
@@ -141,9 +150,12 @@ export function tryResolveAsk(args: {
 
 /** Invalidate every pending ask. Intended for daemon shutdown / restart paths
  *  so CLI subprocesses unblock with `kind:'invalidated'` instead of waiting
- *  forever on a dead daemon. */
+ *  forever on a dead daemon. Returns the number of asks actually settled
+ *  (settled-but-retained entries from the race window are skipped). */
 export function invalidateAll(reason: string): number {
-  const ids = [...pending.keys()];
+  const ids = [...pending.entries()]
+    .filter(([, ask]) => !ask.settled)
+    .map(([id]) => id);
   for (const id of ids) {
     settle(id, {
       kind: 'invalidated',
@@ -161,13 +173,18 @@ export function invalidateAll(reason: string): number {
 }
 
 /** Internal — settle an ask exactly once and notify the dispatcher's onSettle
- *  hook (best-effort, never blocks broker state transitions). */
+ *  hook (best-effort, never blocks broker state transitions). The settled
+ *  entry stays in the map for `SETTLED_RETENTION_MS` so late race-losers get
+ *  a precise `already_settled` outcome; `gcSettled` reaps it afterward. */
 function settle(askId: string, result: AskResult): void {
   const ask = pending.get(askId);
   if (!ask || ask.settled) return;
   ask.settled = true;
+  ask.settledAt = Date.now();
   clearTimeout(ask.timeoutHandle);
-  pending.delete(askId);
+  // Reap older settled entries opportunistically — keeps the map bounded
+  // without paying for a dedicated GC timer.
+  gcSettled();
 
   try {
     ask.resolve(result);
@@ -195,15 +212,29 @@ function settle(askId: string, result: AskResult): void {
 /** Strip broker-internal fields before handing a snapshot to the IM-side
  *  dispatcher. Keeps the dispatcher contract narrow. */
 function snapshot(ask: InternalPending): PendingAsk {
-  const { resolve: _r, timeoutHandle: _t, ...rest } = ask;
+  const { resolve: _r, timeoutHandle: _t, settledAt: _sat, ...rest } = ask;
   return rest;
+}
+
+/** Drop settled entries that have aged past the retention window. Cheap O(n)
+ *  walk — n is tiny in practice (≤ a few dozen pending+recent asks). */
+function gcSettled(): void {
+  const cutoff = Date.now() - SETTLED_RETENTION_MS;
+  for (const [id, ask] of pending) {
+    if (ask.settled && ask.settledAt !== undefined && ask.settledAt < cutoff) {
+      pending.delete(id);
+    }
+  }
 }
 
 // ---- diagnostics for tests ---------------------------------------------------
 
-/** Pending ask count — for tests and metrics. Not part of the public API. */
+/** Count of asks still awaiting a click / timeout — excludes settled entries
+ *  retained within the race-loser feedback window. For tests and metrics only. */
 export function _pendingCount(): number {
-  return pending.size;
+  let n = 0;
+  for (const ask of pending.values()) if (!ask.settled) n++;
+  return n;
 }
 
 /** Read a pending ask by id — for tests only. Returns a snapshot; mutating it

--- a/src/core/ask-broker.ts
+++ b/src/core/ask-broker.ts
@@ -1,5 +1,5 @@
 /**
- * In-memory broker for `botmux ask` (v0.1.7).
+ * In-memory broker for `botmux ask` (v0.1.8).
  *
  * Holds the pending-ask registry, runs the deadline timers, and arbitrates
  * click resolution. IM-agnostic: the im/lark side wires a dispatcher via
@@ -24,6 +24,12 @@ interface InternalPending extends PendingAsk {
   timeoutHandle: NodeJS.Timeout;
   /** epoch ms when settle ran; undefined while still pending. */
   settledAt?: number;
+  /**
+   * 按问题序号（questionIndex）累积的勾选 key 集合。
+   * 单选问题（multiSelect:false）Set 内最多保留 1 个 key。
+   * 多选问题（multiSelect:true）Set 内可保留任意个 key。
+   */
+  selections: Map<number, Set<string>>;
 }
 
 const pending = new Map<string, InternalPending>();
@@ -78,6 +84,12 @@ export function registerAsk(input: CreateAskInput): Promise<AskResult> {
     // Don't keep the event loop alive just because an ask is pending.
     timeoutHandle.unref?.();
 
+    // 为每个问题初始化空的勾选集合
+    const selections = new Map<number, Set<string>>();
+    for (let i = 0; i < input.questions.length; i++) {
+      selections.set(i, new Set<string>());
+    }
+
     const ask: InternalPending = {
       askId,
       nonce,
@@ -86,13 +98,13 @@ export function registerAsk(input: CreateAskInput): Promise<AskResult> {
       rootMessageId: input.rootMessageId,
       sessionId: input.sessionId,
       approvers: input.approvers,
-      options: input.options,
-      prompt: input.prompt,
+      questions: input.questions,
       createdAt,
       deadlineAt,
       settled: false,
       resolve,
       timeoutHandle,
+      selections,
     };
     pending.set(askId, ask);
 
@@ -118,8 +130,118 @@ export function registerAsk(input: CreateAskInput): Promise<AskResult> {
   });
 }
 
+/**
+ * 勾选/取消勾选某问题的某个选项（累积模式，不 settle）。
+ *
+ * 校验同 `tryResolveAsk`：askId 存在 / nonce 匹配 / 未 settle / 已授权 /
+ * questionIndex 合法 / key 在该问题的 options 中。
+ *
+ * 对于单选问题（multiSelect:false），翻转时 Set 内只保留该 key（相当于"换选"）。
+ * 对于多选问题（multiSelect:true），翻转规则：已在 Set 中则移除，否则添加。
+ *
+ * 成功返回 `'toggled'`；非法返回对应 AskClickOutcome。
+ */
+export function toggleAsk(args: {
+  askId: string;
+  nonce: string;
+  questionIndex: number;
+  key: string;
+  by: string;
+}): AskClickOutcome {
+  gcSettled();
+  const ask = pending.get(args.askId);
+  if (!ask) return 'stale';
+  if (ask.nonce !== args.nonce) return 'stale';
+  if (ask.settled) return 'already_settled';
+  if (!ask.approvers.has(args.by)) return 'unauthorized';
+
+  const question = ask.questions[args.questionIndex];
+  if (!question) return 'stale';
+  if (!question.options.some((o) => o.key === args.key)) return 'stale';
+
+  const sel = ask.selections.get(args.questionIndex)!;
+
+  if (question.multiSelect) {
+    // 多选：有则删、无则加
+    if (sel.has(args.key)) {
+      sel.delete(args.key);
+    } else {
+      sel.add(args.key);
+    }
+  } else {
+    // 单选：清空后只保留该 key（等价于"换选"，再次 toggle 同一 key 也保留）
+    sel.clear();
+    sel.add(args.key);
+  }
+
+  return 'toggled';
+}
+
+/**
+ * 提交答案并 settle。
+ *
+ * `selections` 显式传入时直接使用（按钮单选 / 一次性表单提交场景）；
+ * 否则使用 `toggleAsk` 累积的勾选状态。
+ *
+ * 对于 `multiSelect:false` 的问题，要求恰好 1 个选中，否则返回 `'stale'`。
+ * 校验通过则 settle 并返回 `'accepted'`；非法返回对应 AskClickOutcome。
+ */
+export function submitAsk(args: {
+  askId: string;
+  nonce: string;
+  by: string;
+  selections?: ReadonlyArray<ReadonlyArray<string>>;
+}): AskClickOutcome {
+  gcSettled();
+  const ask = pending.get(args.askId);
+  if (!ask) return 'stale';
+  if (ask.nonce !== args.nonce) return 'stale';
+  if (ask.settled) return 'already_settled';
+  if (!ask.approvers.has(args.by)) return 'unauthorized';
+
+  // 构建最终答案数组（按问题顺序）
+  let answers: ReadonlyArray<ReadonlyArray<string>>;
+
+  if (args.selections !== undefined) {
+    // 显式传入：逐问校验单选约束 + key 合法性
+    answers = args.selections;
+    for (let i = 0; i < ask.questions.length; i++) {
+      const q = ask.questions[i]!;
+      const sel = answers[i] ?? [];
+      if (!q.multiSelect && sel.length !== 1) return 'stale';
+      // 校验每个选中的 key 必须在该问题的 options 中
+      for (const key of sel) {
+        if (!q.options.some((o) => o.key === key)) return 'stale';
+      }
+    }
+  } else {
+    // 使用累积的勾选状态
+    const built: string[][] = [];
+    for (let i = 0; i < ask.questions.length; i++) {
+      const q = ask.questions[i]!;
+      const sel = ask.selections.get(i)!;
+      if (!q.multiSelect && sel.size !== 1) return 'stale';
+      built.push([...sel]);
+    }
+    answers = built;
+  }
+
+  settle(args.askId, {
+    kind: 'answered',
+    answers,
+    by: args.by,
+    comment: null,
+    timedOut: false,
+  });
+  return 'accepted';
+}
+
 /** Resolve attempt from a card-button click. Returns one of the §10 outcomes;
  *  caller (card click handler) maps to user-facing toast.
+ *
+ *  v0.1.8 起退化为单问单选的便捷封装：等价于
+ *  `submitAsk({..., selections:[[selected]]})`.
+ *  使 `botmux ask buttons` 与其已有测试零回归。
  *
  *  All four "no-op" outcomes (`unauthorized`/`stale`/`already_settled`) leave
  *  the broker state unchanged so the original CLI Promise keeps waiting for
@@ -130,22 +252,12 @@ export function tryResolveAsk(args: {
   selected: string;
   by: string;
 }): AskClickOutcome {
-  gcSettled();
-  const ask = pending.get(args.askId);
-  if (!ask) return 'stale';                       // unknown id (daemon restart, GC'd, etc.)
-  if (ask.nonce !== args.nonce) return 'stale';   // replayed click from a previous card
-  if (ask.settled) return 'already_settled';      // race loser, still within retention window
-  if (!ask.approvers.has(args.by)) return 'unauthorized';
-  if (!ask.options.some((o) => o.key === args.selected)) return 'stale';
-
-  settle(args.askId, {
-    kind: 'answered',
-    selected: args.selected,
+  return submitAsk({
+    askId: args.askId,
+    nonce: args.nonce,
     by: args.by,
-    comment: null,
-    timedOut: false,
+    selections: [[args.selected]],
   });
-  return 'accepted';
 }
 
 /** Invalidate every pending ask. Intended for daemon shutdown / restart paths
@@ -212,7 +324,7 @@ function settle(askId: string, result: AskResult): void {
 /** Strip broker-internal fields before handing a snapshot to the IM-side
  *  dispatcher. Keeps the dispatcher contract narrow. */
 function snapshot(ask: InternalPending): PendingAsk {
-  const { resolve: _r, timeoutHandle: _t, settledAt: _sat, ...rest } = ask;
+  const { resolve: _r, timeoutHandle: _t, settledAt: _sat, selections: _sel, ...rest } = ask;
   return rest;
 }
 
@@ -242,6 +354,12 @@ export function _pendingCount(): number {
 export function _getPending(askId: string): PendingAsk | undefined {
   const a = pending.get(askId);
   return a ? snapshot(a) : undefined;
+}
+
+/** 返回当前 pending map 中所有 askId 列表（含 settled 但仍在 retention 内的条目）。
+ *  仅供测试使用。 */
+export function _allAskIds(): string[] {
+  return [...pending.keys()];
 }
 
 /** Reset broker state — for tests only. Does NOT resolve outstanding promises,

--- a/src/core/ask-hook/claude-code.ts
+++ b/src/core/ask-hook/claude-code.ts
@@ -1,0 +1,145 @@
+/**
+ * Claude Code hook adapter。
+ *
+ * Claude Code 通过 PermissionRequest hook 发起 AskUserQuestion，
+ * payload 形状：
+ *   {
+ *     hook_event_name: 'PermissionRequest',
+ *     tool_name: 'AskUserQuestion',
+ *     tool_input: {
+ *       questions: [
+ *         {
+ *           question: '问题文本',
+ *           multiSelect: boolean,
+ *           options: [{ label: '选项文本' }, ...]
+ *         }
+ *       ]
+ *     }
+ *   }
+ *
+ * Claude Code 期望的 answer directive（hookSpecificOutput）形状：
+ *   {
+ *     hookSpecificOutput: {
+ *       hookEventName: 'PermissionRequest',
+ *       decision: {
+ *         behavior: 'allow',
+ *         updatedInput: {
+ *           questions: <原始 questions 数组>,
+ *           answers: {
+ *             '问题文本': '选项label1, 选项label2',
+ *             ...
+ *           }
+ *         }
+ *       }
+ *     }
+ *   }
+ *
+ * passthrough（放行）directive 形状：
+ *   {
+ *     hookSpecificOutput: {
+ *       hookEventName: 'PermissionRequest',
+ *       decision: { behavior: 'allow', updatedInput: { questions: [...], answers: {} } }
+ *     }
+ *   }
+ *
+ * 参考来源：x-desktop-app/src/island/main/bridge/adapters/ClaudeAdapter.ts
+ *           x-desktop-app/src/island/main/bridge/BridgeServer.ts buildClaudeAnswerDirective
+ */
+
+import type { AskQuestion } from '../ask-types.js';
+import type { HookAskAdapter, ParsedAsk } from './types.js';
+
+/** 从 payload 中提取原始 questions 数组（用于写回 updatedInput.questions）。 */
+function extractRawQuestions(payload: unknown): Array<Record<string, unknown>> {
+  if (!payload || typeof payload !== 'object') return [];
+  const p = payload as Record<string, unknown>;
+  const toolInput = p.tool_input;
+  if (!toolInput || typeof toolInput !== 'object') return [];
+  const ti = toolInput as Record<string, unknown>;
+  const qs = ti.questions;
+  if (!Array.isArray(qs)) return [];
+  return qs as Array<Record<string, unknown>>;
+}
+
+const claudeCodeAdapter: HookAskAdapter = {
+  parseQuestions(payload: unknown): ParsedAsk | null {
+    if (!payload || typeof payload !== 'object') return null;
+    const p = payload as Record<string, unknown>;
+
+    // 只处理 PermissionRequest + AskUserQuestion 事件
+    if (p.hook_event_name !== 'PermissionRequest') return null;
+    if (p.tool_name !== 'AskUserQuestion') return null;
+
+    const rawQuestions = extractRawQuestions(payload);
+    if (rawQuestions.length === 0) return null;
+
+    const questions: AskQuestion[] = rawQuestions.map((q) => {
+      const qText = typeof q.question === 'string' ? q.question : String(q.question ?? '');
+      const multiSelect = !!q.multiSelect;
+      const rawOpts = Array.isArray(q.options) ? (q.options as Array<Record<string, unknown>>) : [];
+      const options = rawOpts.map((opt) => {
+        const label = typeof opt.label === 'string' ? opt.label : String(opt.label ?? '');
+        // option 无独立 key 时，用 label 作为 key
+        const key = typeof opt.key === 'string' && opt.key.length > 0 ? opt.key : label;
+        return { key, label };
+      });
+      return { prompt: qText, options, multiSelect };
+    });
+
+    return { questions, raw: payload };
+  },
+
+  formatAnswer(answersByQuestion: ReadonlyArray<ReadonlyArray<string>>, parsed: ParsedAsk): string {
+    const rawPayload = parsed.raw;
+    const rawQuestions = extractRawQuestions(rawPayload);
+
+    // Claude updatedInput.answers: { 问题文本: 'label1, label2' }；缺席的 question 不写 key。
+    const answers: Record<string, string> = {};
+    parsed.questions.forEach((q, i) => {
+      const selectedKeys = answersByQuestion[i];
+      if (!selectedKeys || selectedKeys.length === 0) return;
+
+      // 把 key 映射回 label（用于人类可读的 answers 值）
+      const labels = selectedKeys.map((k) => {
+        const opt = q.options.find((o) => o.key === k);
+        return opt ? opt.label : k;
+      });
+      answers[q.prompt] = labels.join(', ');
+    });
+
+    const directive = {
+      hookSpecificOutput: {
+        hookEventName: 'PermissionRequest',
+        decision: {
+          behavior: 'allow',
+          updatedInput: {
+            questions: rawQuestions,
+            answers,
+          },
+        },
+      },
+    };
+
+    return JSON.stringify(directive);
+  },
+
+  passthrough(payload: unknown): string {
+    // 放行：behavior='allow' + 空 answers，让 Claude Code 继续原生终端提问
+    const rawQuestions = extractRawQuestions(payload);
+    const directive = {
+      hookSpecificOutput: {
+        hookEventName: 'PermissionRequest',
+        decision: {
+          behavior: 'allow',
+          updatedInput: {
+            questions: rawQuestions,
+            answers: {},
+          },
+        },
+      },
+    };
+    return JSON.stringify(directive);
+  },
+};
+
+export default claudeCodeAdapter;

--- a/src/core/ask-hook/claude-code.ts
+++ b/src/core/ask-hook/claude-code.ts
@@ -112,11 +112,12 @@ const claudeCodeAdapter: HookAskAdapter = {
     return JSON.stringify(directive);
   },
 
-  passthrough(payload: unknown): string {
-    // 放行：allow + 空 answers，让 Claude Code 继续原生终端提问
-    const rawQuestions = extractRawQuestions(payload);
-    const directive = buildAllowDirective(hookEventName(payload), rawQuestions, {});
-    return JSON.stringify(directive);
+  passthrough(_payload: unknown): string {
+    // 真放行：空 stdout（+ exit 0）。Claude Code 无 hook decision 时工具照常执行，
+    // AskUserQuestion 在终端原生提问。
+    // 绝不能输出 allow + updatedInput：那会用空 answers 顶替 tool input，把这次提问
+    // 错误地"答空"掉（非 botmux 会话 / daemon 不可达时尤其有害）。
+    return '';
   },
 };
 

--- a/src/core/ask-hook/claude-code.ts
+++ b/src/core/ask-hook/claude-code.ts
@@ -1,10 +1,10 @@
 /**
  * Claude Code hook adapter。
  *
- * Claude Code 通过 PermissionRequest hook 发起 AskUserQuestion，
+ * Claude Code 通过 PreToolUse hook 发起 AskUserQuestion，
  * payload 形状：
  *   {
- *     hook_event_name: 'PermissionRequest',
+ *     hook_event_name: 'PreToolUse',
  *     tool_name: 'AskUserQuestion',
  *     tool_input: {
  *       questions: [
@@ -20,15 +20,13 @@
  * Claude Code 期望的 answer directive（hookSpecificOutput）形状：
  *   {
  *     hookSpecificOutput: {
- *       hookEventName: 'PermissionRequest',
- *       decision: {
- *         behavior: 'allow',
- *         updatedInput: {
- *           questions: <原始 questions 数组>,
- *           answers: {
- *             '问题文本': '选项label1, 选项label2',
- *             ...
- *           }
+ *       hookEventName: 'PreToolUse',
+ *       permissionDecision: 'allow',
+ *       updatedInput: {
+ *         questions: <原始 questions 数组>,
+ *         answers: {
+ *           '问题文本': '选项label1, 选项label2',
+ *           ...
  *         }
  *       }
  *     }
@@ -37,8 +35,9 @@
  * passthrough（放行）directive 形状：
  *   {
  *     hookSpecificOutput: {
- *       hookEventName: 'PermissionRequest',
- *       decision: { behavior: 'allow', updatedInput: { questions: [...], answers: {} } }
+ *       hookEventName: 'PreToolUse',
+ *       permissionDecision: 'allow',
+ *       updatedInput: { questions: [...], answers: {} }
  *     }
  *   }
  *
@@ -66,8 +65,8 @@ const claudeCodeAdapter: HookAskAdapter = {
     if (!payload || typeof payload !== 'object') return null;
     const p = payload as Record<string, unknown>;
 
-    // 只处理 PermissionRequest + AskUserQuestion 事件
-    if (p.hook_event_name !== 'PermissionRequest') return null;
+    // 处理 PreToolUse + AskUserQuestion。PermissionRequest 保留为迁移期兼容。
+    if (p.hook_event_name !== 'PreToolUse' && p.hook_event_name !== 'PermissionRequest') return null;
     if (p.tool_name !== 'AskUserQuestion') return null;
 
     const rawQuestions = extractRawQuestions(payload);
@@ -92,6 +91,7 @@ const claudeCodeAdapter: HookAskAdapter = {
   formatAnswer(answersByQuestion: ReadonlyArray<ReadonlyArray<string>>, parsed: ParsedAsk): string {
     const rawPayload = parsed.raw;
     const rawQuestions = extractRawQuestions(rawPayload);
+    const eventName = hookEventName(rawPayload);
 
     // Claude updatedInput.answers: { 问题文本: 'label1, label2' }；缺席的 question 不写 key。
     const answers: Record<string, string> = {};
@@ -107,39 +107,50 @@ const claudeCodeAdapter: HookAskAdapter = {
       answers[q.prompt] = labels.join(', ');
     });
 
-    const directive = {
-      hookSpecificOutput: {
-        hookEventName: 'PermissionRequest',
-        decision: {
-          behavior: 'allow',
-          updatedInput: {
-            questions: rawQuestions,
-            answers,
-          },
-        },
-      },
-    };
+    const directive = buildAllowDirective(eventName, rawQuestions, answers);
 
     return JSON.stringify(directive);
   },
 
   passthrough(payload: unknown): string {
-    // 放行：behavior='allow' + 空 answers，让 Claude Code 继续原生终端提问
+    // 放行：allow + 空 answers，让 Claude Code 继续原生终端提问
     const rawQuestions = extractRawQuestions(payload);
-    const directive = {
+    const directive = buildAllowDirective(hookEventName(payload), rawQuestions, {});
+    return JSON.stringify(directive);
+  },
+};
+
+function hookEventName(payload: unknown): 'PreToolUse' | 'PermissionRequest' {
+  if (payload && typeof payload === 'object') {
+    const eventName = (payload as Record<string, unknown>).hook_event_name;
+    if (eventName === 'PermissionRequest') return 'PermissionRequest';
+  }
+  return 'PreToolUse';
+}
+
+function buildAllowDirective(
+  eventName: 'PreToolUse' | 'PermissionRequest',
+  questions: Array<Record<string, unknown>>,
+  answers: Record<string, string>,
+): Record<string, unknown> {
+  if (eventName === 'PermissionRequest') {
+    return {
       hookSpecificOutput: {
         hookEventName: 'PermissionRequest',
         decision: {
           behavior: 'allow',
-          updatedInput: {
-            questions: rawQuestions,
-            answers: {},
-          },
+          updatedInput: { questions, answers },
         },
       },
     };
-    return JSON.stringify(directive);
-  },
-};
+  }
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'allow',
+      updatedInput: { questions, answers },
+    },
+  };
+}
 
 export default claudeCodeAdapter;

--- a/src/core/ask-hook/codex.ts
+++ b/src/core/ask-hook/codex.ts
@@ -64,14 +64,10 @@ const codexAdapter: HookAskAdapter = {
   },
 
   passthrough(_payload: unknown): string {
-    // 放行：behavior='allow'，让 Codex CLI 继续原生终端处理
-    const directive = {
-      hookSpecificOutput: {
-        hookEventName: 'PermissionRequest',
-        decision: { behavior: 'allow' },
-      },
-    };
-    return JSON.stringify(directive);
+    // 真放行：空 stdout（+ exit 0），不做任何 decision，让 Codex 走默认行为。
+    // 不输出 allow——那是替用户自动批准，并非"放行不干预"。
+    // （Codex 当前未接 hook，此分支仅为将来接入时的安全默认。）
+    return '';
   },
 };
 

--- a/src/core/ask-hook/codex.ts
+++ b/src/core/ask-hook/codex.ts
@@ -1,0 +1,78 @@
+/**
+ * Codex hook adapter。
+ *
+ * Codex 通过 PermissionRequest hook 发起权限请求，payload 形状：
+ *   {
+ *     hook_event_name: 'PermissionRequest',
+ *     tool_name: '<工具名>',
+ *     tool_input: { description?: string, command?: string, ... },
+ *     session_id: '<id>',
+ *     ...
+ *   }
+ *
+ * 与 Claude Code 不同，Codex **没有**结构化的 AskUserQuestion hook 事件——
+ * Codex 把问题藏在 Stop 事件的 last_assistant_message 文本里，
+ * 而非通过 PermissionRequest 以结构化方式发起。
+ * 因此 parseQuestions 对任意 Codex hook payload 均返回 null。
+ *
+ * Codex 期望的 permission directive（hookSpecificOutput）形状：
+ *   {
+ *     hookSpecificOutput: {
+ *       hookEventName: 'PermissionRequest',
+ *       decision: { behavior: 'allow' | 'deny', message?: string }
+ *     }
+ *   }
+ *
+ * passthrough（放行）directive 形状（behavior='allow'）：
+ *   {
+ *     hookSpecificOutput: {
+ *       hookEventName: 'PermissionRequest',
+ *       decision: { behavior: 'allow' }
+ *     }
+ *   }
+ *
+ * // TODO(dogfood): 验证 codex directive 形状（parseQuestions 总返回 null，
+ * //   formatAnswer 在当前版本不会被调用，但 passthrough 在 PermissionRequest 场景会被用到）
+ *
+ * 参考来源：x-desktop-app/src/island/main/bridge/adapters/CodexAdapter.ts
+ *           x-desktop-app/src/island/main/bridge/BridgeServer.ts codex 分支
+ */
+
+import type { HookAskAdapter, ParsedAsk } from './types.js';
+
+const codexAdapter: HookAskAdapter = {
+  parseQuestions(_payload: unknown): ParsedAsk | null {
+    // Codex 没有结构化 AskUserQuestion hook 事件，始终返回 null。
+    // Codex 的"提问"藏在 Stop 事件的 last_assistant_message 纯文本里，
+    // 不通过 PermissionRequest hook 以结构化方式触达 hooks-cli。
+    return null;
+  },
+
+  formatAnswer(answersByQuestion: ReadonlyArray<ReadonlyArray<string>>, parsed: ParsedAsk): string {
+    // 由于 parseQuestions 总返回 null，此方法在正常流程中不会被调用。
+    // 保留实现以满足接口约定：使用 allow + 空 decision 形状。
+    // TODO(dogfood): 验证 codex directive 形状
+    void answersByQuestion;
+    void parsed;
+    const directive = {
+      hookSpecificOutput: {
+        hookEventName: 'PermissionRequest',
+        decision: { behavior: 'allow' },
+      },
+    };
+    return JSON.stringify(directive);
+  },
+
+  passthrough(_payload: unknown): string {
+    // 放行：behavior='allow'，让 Codex CLI 继续原生终端处理
+    const directive = {
+      hookSpecificOutput: {
+        hookEventName: 'PermissionRequest',
+        decision: { behavior: 'allow' },
+      },
+    };
+    return JSON.stringify(directive);
+  },
+};
+
+export default codexAdapter;

--- a/src/core/ask-hook/opencode.ts
+++ b/src/core/ask-hook/opencode.ts
@@ -118,16 +118,10 @@ const openCodeAdapter: HookAskAdapter = {
     return JSON.stringify({ type: 'answer', text: flat });
   },
 
-  passthrough(payload: unknown): string {
-    // 放行：每条 question 填空哨兵 ['']，OpenCode plugin 约定"未答"
-    const p = payload as Record<string, unknown> | undefined;
-    const toolInput = (p?.tool_input as { questions?: unknown[] } | undefined);
-    const questionCount = Array.isArray(toolInput?.questions)
-      ? toolInput!.questions!.length
-      : 1;
-
-    const answers: string[][] = Array.from({ length: questionCount }, () => ['']);
-    return JSON.stringify({ type: 'answer', answers });
+  passthrough(_payload: unknown): string {
+    // 真放行：空 stdout。插件见 stdout 为空 → 返回 undefined → OpenCode 自行处理
+    // （原生终端提问）。不输出 {type:'answer',...}，避免用空答案顶替这次提问。
+    return '';
   },
 };
 

--- a/src/core/ask-hook/opencode.ts
+++ b/src/core/ask-hook/opencode.ts
@@ -1,0 +1,134 @@
+/**
+ * OpenCode hook adapter。
+ *
+ * OpenCode 通过 QuestionAsked 事件发起提问，payload 形状：
+ *   {
+ *     hook_event_name: 'QuestionAsked',
+ *     session_id: 'opencode-<id>',
+ *     question_id: '<id>',      // 同 _opencode_request_id
+ *     question_text: '问题文本（拍平版本）',
+ *     tool_input: {
+ *       questions: [
+ *         {
+ *           question: '问题文本',
+ *           header: '可选标题',
+ *           options: [{ label: '选项文本', description?: '描述' }, ...],
+ *           multiple: boolean,
+ *         }
+ *       ]
+ *     },
+ *     _opencode_request_id: '<id>',
+ *   }
+ *
+ * OpenCode 期望的 answer directive 形状（发往 /question/:id/reply）：
+ *   { type: 'answer', answers: string[][] }
+ *   其中 answers[i] = 第 i 个问题选中的 label 数组；跳过的 question 填 ['']。
+ *
+ * 若没有结构化 questions（旧版兼容路径），改用：
+ *   { type: 'answer', text: '自由文本' }
+ *
+ * passthrough（放行）directive 形状：
+ *   { type: 'answer', answers: [['']] }
+ *   （每条 question 填空哨兵 ['']，让 OpenCode plugin 视为"未答"并继续）
+ *
+ * 参考来源：x-desktop-app/src/island/main/bridge/adapters/OpenCodeAdapter.ts
+ *           x-desktop-app/src/island/main/bridge/BridgeServer.ts buildOpenCodeAnswerDirective
+ *           x-desktop-app/src/island/hooks-install/opencode.ts postQuestionReply
+ */
+
+import type { AskQuestion } from '../ask-types.js';
+import type { HookAskAdapter, ParsedAsk } from './types.js';
+
+const openCodeAdapter: HookAskAdapter = {
+  parseQuestions(payload: unknown): ParsedAsk | null {
+    if (!payload || typeof payload !== 'object') return null;
+    const p = payload as Record<string, unknown>;
+
+    // 只处理 QuestionAsked 事件
+    if (p.hook_event_name !== 'QuestionAsked') return null;
+
+    // 尝试从结构化 tool_input.questions 解析
+    const toolInput = p.tool_input as
+      | { questions?: Array<{
+          question?: string;
+          header?: string;
+          options?: Array<{ label?: string; description?: string }>;
+          multiple?: boolean;
+        }> }
+      | undefined;
+
+    const rawQuestions = toolInput?.questions;
+
+    if (rawQuestions && rawQuestions.length > 0) {
+      const questions: AskQuestion[] = rawQuestions.map((q, _qIdx) => {
+        const qText = q.question ?? '';
+        const multiSelect = !!q.multiple;
+        const rawOpts = q.options ?? [];
+        const options = rawOpts.map((opt) => {
+          const label = opt.label ?? '';
+          // option 无独立 key 时，用 label 作为 key
+          return { key: label, label };
+        });
+        return { prompt: qText, options, multiSelect };
+      });
+
+      return { questions, raw: payload };
+    }
+
+    // 旧版兼容：只有 question_text（无结构化 options）
+    const questionText = typeof p.question_text === 'string'
+      ? p.question_text
+      : 'OpenCode has a question';
+
+    const questions: AskQuestion[] = [
+      {
+        prompt: questionText,
+        options: [],
+        multiSelect: false,
+      },
+    ];
+
+    return { questions, raw: payload };
+  },
+
+  formatAnswer(answersByQuestion: ReadonlyArray<ReadonlyArray<string>>, parsed: ParsedAsk): string {
+    const p = parsed.raw as Record<string, unknown> | undefined;
+    const toolInput = (p?.tool_input as { questions?: unknown[] } | undefined);
+    const hasStructured = Array.isArray(toolInput?.questions) && (toolInput!.questions!.length > 0);
+
+    if (hasStructured) {
+      // 结构化路径：answers[i] = 第 i 个 question 选中的 label 数组；跳过填 ['']
+      const answers: string[][] = parsed.questions.map((q, i) => {
+        const selectedKeys = answersByQuestion[i];
+        if (!selectedKeys || selectedKeys.length === 0) return [''];
+        // OpenCode options 以 label 为 key，直接用 key（= label）
+        return selectedKeys.map((k) => {
+          const opt = q.options.find((o) => o.key === k);
+          return opt ? opt.label : k;
+        });
+      });
+      return JSON.stringify({ type: 'answer', answers });
+    }
+
+    // 旧版：拍平所有答案为 free-text
+    const flat = answersByQuestion
+      .flat()
+      .filter((s) => s.length > 0)
+      .join(', ');
+    return JSON.stringify({ type: 'answer', text: flat });
+  },
+
+  passthrough(payload: unknown): string {
+    // 放行：每条 question 填空哨兵 ['']，OpenCode plugin 约定"未答"
+    const p = payload as Record<string, unknown> | undefined;
+    const toolInput = (p?.tool_input as { questions?: unknown[] } | undefined);
+    const questionCount = Array.isArray(toolInput?.questions)
+      ? toolInput!.questions!.length
+      : 1;
+
+    const answers: string[][] = Array.from({ length: questionCount }, () => ['']);
+    return JSON.stringify({ type: 'answer', answers });
+  },
+};
+
+export default openCodeAdapter;

--- a/src/core/ask-hook/registry.ts
+++ b/src/core/ask-hook/registry.ts
@@ -1,0 +1,14 @@
+import type { HookAskAdapter } from './types.js';
+import claude from './claude-code.js';
+import codex from './codex.js';
+import opencode from './opencode.js';
+
+const REGISTRY: Record<string, HookAskAdapter> = {
+  'claude-code': claude,
+  codex,
+  opencode,
+};
+
+export function getHookAdapter(cliId: string): HookAskAdapter | undefined {
+  return REGISTRY[cliId];
+}

--- a/src/core/ask-hook/types.ts
+++ b/src/core/ask-hook/types.ts
@@ -1,0 +1,29 @@
+import type { AskQuestion } from '../ask-types.js';
+
+/** adapter 解析一个 hook payload 后得到的问题列表和原始上下文。 */
+export interface ParsedAsk {
+  questions: AskQuestion[];
+  /** adapter 私有的原始上下文，formatAnswer 用来重建 directive。 */
+  raw: unknown;
+}
+
+/**
+ * 每家 CLI 的 hook adapter 接口。
+ *
+ * - parseQuestions：非 askUserQuestion 事件返回 null（hook 客户端据此输出"放行"directive）。
+ * - formatAnswer：把用户答案映射回该 CLI 所期望的 directive JSON 字符串。
+ * - passthrough：hook 接管失败时的"放行/无操作" directive，让 CLI 回退原生终端提问。
+ */
+export interface HookAskAdapter {
+  /** 非 askUserQuestion 事件返回 null（hook 客户端据此输出"放行"directive）。 */
+  parseQuestions(payload: unknown): ParsedAsk | null;
+
+  /**
+   * answersByQuestion[i] = questions[i] 选中的 key 数组。
+   * 返回写回 CLI 的 directive JSON 字符串。
+   */
+  formatAnswer(answersByQuestion: ReadonlyArray<ReadonlyArray<string>>, parsed: ParsedAsk): string;
+
+  /** hook 接管失败时的"放行/无操作" directive（让 CLI 回退原生终端提问）。 */
+  passthrough(payload: unknown): string;
+}

--- a/src/core/ask-types.ts
+++ b/src/core/ask-types.ts
@@ -1,0 +1,124 @@
+/**
+ * Public types for `botmux ask` (v0.1.7).
+ *
+ * See `/tmp/botmux-ask.md` for the full design. This module is import-safe for
+ * both the daemon side (broker, card builder, click handler) and the CLI side
+ * (`botmux ask buttons` subcommand) — no runtime cross-imports.
+ */
+
+/** A single selectable option on an ask card. `key` is the stable identifier
+ *  returned via stdout; `label` is the human-facing button text. When the user
+ *  writes `--options "yes,no"`, `key === label`. With `--options "yes=继续"`,
+ *  `key="yes"` and `label="继续"`. */
+export interface AskOption {
+  key: string;
+  label: string;
+}
+
+/** Terminal result of an ask, returned to the CLI caller. Discriminated by
+ *  `kind` so the CLI can map straight to stdout shape + exit code. */
+export type AskResult =
+  | {
+      kind: 'answered';
+      selected: string;
+      by: string;
+      comment: null;
+      timedOut: false;
+    }
+  | {
+      kind: 'timedOut';
+      selected: null;
+      by: null;
+      comment: null;
+      timedOut: true;
+    }
+  | {
+      kind: 'invalidated';
+      reason: string;
+      selected: null;
+      by: null;
+      comment: null;
+      timedOut: false;
+    };
+
+/** JSON envelope emitted by `botmux ask buttons --json`. Keeps `comment` as a
+ *  forward-compat `null` slot — v0.1.8 may flip it to `string`. */
+export interface AskJsonOutput {
+  selected: string | null;
+  by: string | null;
+  comment: null;
+  timedOut: boolean;
+}
+
+/** Input accepted by broker.registerAsk. Caller (CLI subcommand → daemon IPC
+ *  handler) is responsible for env validation, parameter parsing, and resolving
+ *  the approver allowlist before reaching the broker. */
+export interface CreateAskInput {
+  larkAppId: string;
+  chatId: string;
+  /** thread-scope ask → root message_id; chat-scope ask → null. */
+  rootMessageId: string | null;
+  /** Session that issued the ask — used for audit + future replay scoping. */
+  sessionId: string;
+  /** Pre-resolved open_id allowlist. Empty set means no one can answer; the
+   *  caller (not the broker) must enforce the §6 approver fallback chain so the
+   *  broker stays IM-agnostic. */
+  approvers: ReadonlySet<string>;
+  /** Already deduplicated + validated. Caller guarantees `options.length ≥ 2`
+   *  and unique `key`s. */
+  options: ReadonlyArray<AskOption>;
+  prompt: string;
+  /** Absolute deadline; computed by caller from `--timeout`. Broker won't
+   *  re-compute. */
+  timeoutMs: number;
+}
+
+/** Daemon-internal state for a pending ask. Not exported on the IPC boundary —
+ *  the CLI side only sees `AskResult`. */
+export interface PendingAsk {
+  askId: string;
+  /** Anti-replay nonce embedded in each button's action value. Click events
+   *  whose nonce doesn't match → treated as stale (e.g. card from a previous
+   *  daemon process before restart). */
+  nonce: string;
+  larkAppId: string;
+  chatId: string;
+  rootMessageId: string | null;
+  sessionId: string;
+  approvers: ReadonlySet<string>;
+  options: ReadonlyArray<AskOption>;
+  prompt: string;
+  createdAt: number;
+  deadlineAt: number;
+  /** Set after the card dispatch succeeds. Until then, the ask is "registered
+   *  but not visible" — clicks can't physically arrive yet. */
+  cardMessageId?: string;
+  /** Once true, subsequent click attempts return `already_settled`. */
+  settled: boolean;
+}
+
+/** Outcome of a click-resolution attempt. Card click handler maps these to
+ *  user-visible toasts. */
+export type AskClickOutcome =
+  /** First valid click — caller's Promise resolves with `kind:'answered'`. */
+  | 'accepted'
+  /** Clicker's open_id not in approvers — caller shows "你没有权限". */
+  | 'unauthorized'
+  /** No such askId, nonce mismatch, or unknown option — caller shows
+   *  "此 ask 已失效（daemon 重启）". Covers the §8 stale-card case. */
+  | 'stale'
+  /** Ask already settled (race winner exists or timed out). */
+  | 'already_settled';
+
+/** Card dispatcher contract. The im/lark side registers a dispatcher via
+ *  `setCardDispatcher`; the broker is otherwise IM-agnostic. */
+export interface AskCardDispatcher {
+  send(ask: PendingAsk): Promise<{ messageId: string }>;
+  /** Called when an ask settles (answered / timedOut / invalidated). Card
+   *  builder uses this to PATCH the card into a terminal state. Best-effort —
+   *  the broker does not block on it. */
+  onSettle?(
+    ask: PendingAsk,
+    result: AskResult,
+  ): void | Promise<void>;
+}

--- a/src/core/ask-types.ts
+++ b/src/core/ask-types.ts
@@ -114,6 +114,8 @@ export interface PendingAsk {
   approvers: ReadonlySet<string>;
   /** 问题列表，替代旧的 `options` + `prompt`。 */
   questions: ReadonlyArray<AskQuestion>;
+  /** 当前已勾选答案快照。仅 daemon/card 内部使用；CLI IPC 边界不暴露。 */
+  selections?: ReadonlyArray<ReadonlyArray<string>>;
   createdAt: number;
   deadlineAt: number;
   /** Set after the card dispatch succeeds. Until then, the ask is "registered

--- a/src/core/ask-types.ts
+++ b/src/core/ask-types.ts
@@ -1,5 +1,5 @@
 /**
- * Public types for `botmux ask` (v0.1.7).
+ * Public types for `botmux ask` (v0.1.8).
  *
  * See `/tmp/botmux-ask.md` for the full design. This module is import-safe for
  * both the daemon side (broker, card builder, click handler) and the CLI side
@@ -15,12 +15,30 @@ export interface AskOption {
   label: string;
 }
 
+/** 多问多选模型中一个问题的描述。`key` 是问题的稳定标识符（可选，默认用序号），
+ *  `label` 是人类可读的标题（暂保留向后兼容），`prompt` 是问题正文，
+ *  `options` 是该问题的选项列表，`multiSelect` 表示是否允许多选。 */
+export interface AskQuestion {
+  /** 问题正文文本，展示给用户。 */
+  prompt: string;
+  /** 该问题的选项列表，调用方保证 `options.length ≥ 2` 且 `key` 唯一。 */
+  options: ReadonlyArray<AskOption>;
+  /** true = 多选（可选多个 key）；false = 单选（恰好 1 个 key）。 */
+  multiSelect: boolean;
+}
+
 /** Terminal result of an ask, returned to the CLI caller. Discriminated by
- *  `kind` so the CLI can map straight to stdout shape + exit code. */
+ *  `kind` so the CLI can map straight to stdout shape + exit code.
+ *
+ *  v0.1.8 变更：`answered` 变体的 `selected: string` 升级为
+ *  `answers: ReadonlyArray<ReadonlyArray<string>>`，其中 `answers[i]`
+ *  对应第 i 个问题（`questions[i]`）选中的 key 数组。
+ *  向后兼容：单问单选场景用 `toLegacySelected` 取回旧的 `string`。 */
 export type AskResult =
   | {
       kind: 'answered';
-      selected: string;
+      /** answers[i] = questions[i] 选中的 key 数组。 */
+      answers: ReadonlyArray<ReadonlyArray<string>>;
       by: string;
       comment: null;
       timedOut: false;
@@ -42,9 +60,15 @@ export type AskResult =
     };
 
 /** JSON envelope emitted by `botmux ask buttons --json`. Keeps `comment` as a
- *  forward-compat `null` slot — v0.1.8 may flip it to `string`. */
+ *  forward-compat `null` slot — v0.1.8 may flip it to `string`.
+ *
+ *  v0.1.8 新增 `answers: string[][] | null`（多问多选完整答案），
+ *  保留 `selected: string | null` 做向后兼容（等价于 `toLegacySelected`）。 */
 export interface AskJsonOutput {
+  /** 向后兼容：单问单选时等于 `answers[0][0]`，否则为 null。 */
   selected: string | null;
+  /** v0.1.8 新增：按问题分组的完整答案，answered 时非 null。 */
+  answers: string[][] | null;
   by: string | null;
   comment: null;
   timedOut: boolean;
@@ -52,7 +76,9 @@ export interface AskJsonOutput {
 
 /** Input accepted by broker.registerAsk. Caller (CLI subcommand → daemon IPC
  *  handler) is responsible for env validation, parameter parsing, and resolving
- *  the approver allowlist before reaching the broker. */
+ *  the approver allowlist before reaching the broker.
+ *
+ *  v0.1.8 变更：`options`/`prompt` 字段替换为 `questions: ReadonlyArray<AskQuestion>`。 */
 export interface CreateAskInput {
   larkAppId: string;
   chatId: string;
@@ -64,17 +90,17 @@ export interface CreateAskInput {
    *  caller (not the broker) must enforce the §6 approver fallback chain so the
    *  broker stays IM-agnostic. */
   approvers: ReadonlySet<string>;
-  /** Already deduplicated + validated. Caller guarantees `options.length ≥ 2`
-   *  and unique `key`s. */
-  options: ReadonlyArray<AskOption>;
-  prompt: string;
+  /** 问题列表，调用方保证每问 `options.length ≥ 2` 且 key 唯一。 */
+  questions: ReadonlyArray<AskQuestion>;
   /** Absolute deadline; computed by caller from `--timeout`. Broker won't
    *  re-compute. */
   timeoutMs: number;
 }
 
 /** Daemon-internal state for a pending ask. Not exported on the IPC boundary —
- *  the CLI side only sees `AskResult`. */
+ *  the CLI side only sees `AskResult`.
+ *
+ *  v0.1.8 变更：`options`/`prompt` 替换为 `questions`。 */
 export interface PendingAsk {
   askId: string;
   /** Anti-replay nonce embedded in each button's action value. Click events
@@ -86,8 +112,8 @@ export interface PendingAsk {
   rootMessageId: string | null;
   sessionId: string;
   approvers: ReadonlySet<string>;
-  options: ReadonlyArray<AskOption>;
-  prompt: string;
+  /** 问题列表，替代旧的 `options` + `prompt`。 */
+  questions: ReadonlyArray<AskQuestion>;
   createdAt: number;
   deadlineAt: number;
   /** Set after the card dispatch succeeds. Until then, the ask is "registered
@@ -108,7 +134,19 @@ export type AskClickOutcome =
    *  "此 ask 已失效（daemon 重启）". Covers the §8 stale-card case. */
   | 'stale'
   /** Ask already settled (race winner exists or timed out). */
-  | 'already_settled';
+  | 'already_settled'
+  /** 多选累积：用户勾选/取消某项，尚未 submit——不触发 settle。 */
+  | 'toggled';
+
+/** 旧单选语义兼容：仅当"单问且恰好选 1 个"时返回该 key，否则 null。
+ *  `botmux ask buttons` 子命令与其测试据此保持单选行为不变。 */
+export function toLegacySelected(result: AskResult): string | null {
+  if (result.kind !== 'answered') return null;
+  if (result.answers.length === 1 && result.answers[0].length === 1) {
+    return result.answers[0][0];
+  }
+  return null;
+}
 
 /** Card dispatcher contract. The im/lark side registers a dispatcher via
  *  `setCardDispatcher`; the broker is otherwise IM-agnostic. */

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -8,6 +8,7 @@ import { homedir } from 'node:os';
 import { readFileSync, writeFileSync, mkdirSync, existsSync, realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { ensureSkills } from '../skills/installer.js';
+import { installHook } from '../adapters/hook-installer.js';
 import { randomBytes } from 'node:crypto';
 import { config } from '../config.js';
 import * as sessionStore from '../services/session-store.js';
@@ -374,6 +375,17 @@ export const restartCounts = new Map<string, { count: number; lastAt: number }>(
 const skillsInstalledCliIds = new Set<string>();
 
 /**
+ * 构造 `botmux hook <cliId>` 的完整调用字符串。
+ * 使用与 autostart 一致的方案：process.execPath（当前 Node 可执行文件）+
+ * process.argv[1]（当前运行的 cli.js 入口文件）。
+ */
+function hookCommandFor(cliId: string): string {
+  // process.execPath = 运行 botmux daemon 的 Node 可执行文件绝对路径
+  // process.argv[1]  = 被 Node 执行的脚本（dist/cli.js）的绝对路径
+  return `${process.execPath} ${process.argv[1]} hook ${cliId}`;
+}
+
+/**
  * Ensure built-in skills are installed for a given CLI.
  * Synchronous and idempotent — runs once per CLI per daemon lifecycle.
  */
@@ -381,6 +393,11 @@ export function ensureCliSkills(cliId: CliId, cliPathOverride?: string): void {
   if (skillsInstalledCliIds.has(cliId)) return;
   const adapter = createCliAdapterSync(cliId, cliPathOverride);
   ensureSkills(cliId, adapter.skillsDir);
+  // 安装 askUserQuestion hook：把 botmux hook 子命令写入各 CLI 配置（幂等）
+  if (adapter.hookInstall) {
+    try { installHook(cliId, adapter.hookInstall, hookCommandFor(cliId)); }
+    catch (err) { logger.warn(`[hook] install failed for ${cliId}: ${err instanceof Error ? err.message : String(err)}`); }
+  }
   skillsInstalledCliIds.add(cliId);
 }
 

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -7,7 +7,7 @@ import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { readFileSync, writeFileSync, mkdirSync, existsSync, realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { ensureSkills } from '../skills/installer.js';
+import { ensureSkills, ensureAskSkill } from '../skills/installer.js';
 import { installHook } from '../adapters/hook-installer.js';
 import { randomBytes } from 'node:crypto';
 import { config } from '../config.js';
@@ -402,11 +402,16 @@ export function ensureCliSkills(cliId: CliId, cliPathOverride?: string): void {
   if (skillsInstalledCliIds.has(cliId)) return;
   const adapter = createCliAdapterSync(cliId, cliPathOverride);
   ensureSkills(cliId, adapter.skillsDir);
-  // 安装 askUserQuestion hook：把 botmux hook 子命令写入各 CLI 配置（幂等）
+  // askUserQuestion 接管策略：hook 优先 + 非 hook CLI 用 skill 兜底。
+  // - 有 hookInstall（Claude/OpenCode）：装 hook 拦截原生 AskUserQuestion，并删掉
+  //   botmux-ask skill，避免 skill 与 hook 双重弹卡。
+  // - 无 hookInstall（Codex/Cursor/尚未接 hook 的终端原生 CLI）：保留 botmux-ask
+  //   skill 作兜底，让 agent 仍可用 `botmux ask` 把选择题引到飞书。
   if (adapter.hookInstall) {
     try { installHook(cliId, adapter.hookInstall, hookCommandFor(cliId)); }
     catch (err) { logger.warn(`[hook] install failed for ${cliId}: ${err instanceof Error ? err.message : String(err)}`); }
   }
+  ensureAskSkill(cliId, adapter.skillsDir, !adapter.hookInstall);
   skillsInstalledCliIds.add(cliId);
 }
 

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -376,13 +376,22 @@ const skillsInstalledCliIds = new Set<string>();
 
 /**
  * 构造 `botmux hook <cliId>` 的完整调用字符串。
- * 使用与 autostart 一致的方案：process.execPath（当前 Node 可执行文件）+
- * process.argv[1]（当前运行的 cli.js 入口文件）。
+ *
+ * hook 命令由 CLI（Claude/OpenCode）作为子进程执行，必须指向 botmux 的 CLI 入口
+ * `dist/cli.js`——只有它分发 `hook` 子命令。
+ *
+ * 不能用 `process.argv[1]`：daemon 由 pm2 以 `dist/index-daemon.js` 启动，daemon 进程
+ * 的 argv[1] 是 index-daemon.js（只 `startDaemon()`、不处理 hook 子命令）。源码 checkout
+ * 和 npm global 安装都如此——用 argv[1] 会注入一条跑不通的命令。
+ *
+ * 改为从本模块自身位置回推：编译后本文件是 `<pkgRoot>/dist/core/worker-pool.js`，
+ * CLI 入口固定在 `<pkgRoot>/dist/cli.js`（package.json `bin.botmux` 指向它），即
+ * `../cli.js`。这对源码和 npm global 安装都成立（同一份 dist 布局）。
  */
-function hookCommandFor(cliId: string): string {
-  // process.execPath = 运行 botmux daemon 的 Node 可执行文件绝对路径
-  // process.argv[1]  = 被 Node 执行的脚本（dist/cli.js）的绝对路径
-  return `${process.execPath} ${process.argv[1]} hook ${cliId}`;
+export function hookCommandFor(cliId: string): string {
+  const cliEntry = join(__dirname, '..', 'cli.js');
+  // 加引号防 Node 路径 / 安装路径含空格。
+  return `"${process.execPath}" "${cliEntry}" hook ${cliId}`;
 }
 
 /**

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -9,6 +9,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync, realpathSync } from
 import { fileURLToPath } from 'node:url';
 import { ensureSkills, ensureAskSkill } from '../skills/installer.js';
 import { installHook } from '../adapters/hook-installer.js';
+import { hookCommandFor } from '../adapters/hook-command.js';
 import { randomBytes } from 'node:crypto';
 import { config } from '../config.js';
 import * as sessionStore from '../services/session-store.js';
@@ -375,26 +376,6 @@ export const restartCounts = new Map<string, { count: number; lastAt: number }>(
 const skillsInstalledCliIds = new Set<string>();
 
 /**
- * 构造 `botmux hook <cliId>` 的完整调用字符串。
- *
- * hook 命令由 CLI（Claude/OpenCode）作为子进程执行，必须指向 botmux 的 CLI 入口
- * `dist/cli.js`——只有它分发 `hook` 子命令。
- *
- * 不能用 `process.argv[1]`：daemon 由 pm2 以 `dist/index-daemon.js` 启动，daemon 进程
- * 的 argv[1] 是 index-daemon.js（只 `startDaemon()`、不处理 hook 子命令）。源码 checkout
- * 和 npm global 安装都如此——用 argv[1] 会注入一条跑不通的命令。
- *
- * 改为从本模块自身位置回推：编译后本文件是 `<pkgRoot>/dist/core/worker-pool.js`，
- * CLI 入口固定在 `<pkgRoot>/dist/cli.js`（package.json `bin.botmux` 指向它），即
- * `../cli.js`。这对源码和 npm global 安装都成立（同一份 dist 布局）。
- */
-export function hookCommandFor(cliId: string): string {
-  const cliEntry = join(__dirname, '..', 'cli.js');
-  // 加引号防 Node 路径 / 安装路径含空格。
-  return `"${process.execPath}" "${cliEntry}" hook ${cliId}`;
-}
-
-/**
  * Ensure built-in skills are installed for a given CLI.
  * Synchronous and idempotent — runs once per CLI per daemon lifecycle.
  */
@@ -403,15 +384,16 @@ export function ensureCliSkills(cliId: CliId, cliPathOverride?: string): void {
   const adapter = createCliAdapterSync(cliId, cliPathOverride);
   ensureSkills(cliId, adapter.skillsDir);
   // askUserQuestion 接管策略：hook 优先 + 非 hook CLI 用 skill 兜底。
-  // - 有 hookInstall（Claude/OpenCode）：装 hook 拦截原生 AskUserQuestion，并删掉
+  // - asksViaHook=true（Claude/OpenCode）：通过 hook 拦截原生 AskUserQuestion，删掉
   //   botmux-ask skill，避免 skill 与 hook 双重弹卡。
-  // - 无 hookInstall（Codex/Cursor/尚未接 hook 的终端原生 CLI）：保留 botmux-ask
+  //   Claude 走 --settings 进程级注入；OpenCode 走 hookInstall 插件写文件。
+  // - asksViaHook 未设（Codex/Cursor/尚未接 hook 的终端原生 CLI）：保留 botmux-ask
   //   skill 作兜底，让 agent 仍可用 `botmux ask` 把选择题引到飞书。
   if (adapter.hookInstall) {
     try { installHook(cliId, adapter.hookInstall, hookCommandFor(cliId)); }
     catch (err) { logger.warn(`[hook] install failed for ${cliId}: ${err instanceof Error ? err.message : String(err)}`); }
   }
-  ensureAskSkill(cliId, adapter.skillsDir, !adapter.hookInstall);
+  ensureAskSkill(cliId, adapter.skillsDir, !adapter.asksViaHook);
   skillsInstalledCliIds.add(cliId);
 }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -113,6 +113,8 @@ import { resolveWait } from './workflows/wait.js';
 import { replay } from './workflows/events/replay.js';
 import { isValidRunId, readRunSnapshot } from './workflows/ops-projection.js';
 import { AttemptResumeManager } from './workflows/attempt-resume.js';
+import { setCardDispatcher as setAskCardDispatcher } from './core/ask-broker.js';
+import { createLarkAskCardDispatcher } from './im/lark/ask-card.js';
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
@@ -2290,6 +2292,7 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   // running in a separate node process) so dashboard event bus stays in sync.
   scheduleStore.startExternalWriteWatcher();
   logger.info(`Bot ${idx}/${botConfigs.length}: ${cfg.larkAppId} (cli: ${cfg.cliId})`)
+  setAskCardDispatcher(createLarkAskCardDispatcher());
 
   writePidFile();
   const memoryDiagnostics = startMemoryDiagnostics();

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -113,7 +113,11 @@ import { resolveWait } from './workflows/wait.js';
 import { replay } from './workflows/events/replay.js';
 import { isValidRunId, readRunSnapshot } from './workflows/ops-projection.js';
 import { AttemptResumeManager } from './workflows/attempt-resume.js';
-import { setCardDispatcher as setAskCardDispatcher } from './core/ask-broker.js';
+import {
+  setCardDispatcher as setAskCardDispatcher,
+  registerAsk as registerAskBroker,
+} from './core/ask-broker.js';
+import { parseAskBody, resolveAskApprovers } from './core/ask-api.js';
 import { createLarkAskCardDispatcher } from './im/lark/ask-card.js';
 
 // ─── State ───────────────────────────────────────────────────────────────────
@@ -1427,6 +1431,56 @@ ipcRoute('POST', '/api/workflows/definitions/:id/run', async (req, res, params) 
           500;
     return jsonRes(res, status, result);
   }
+  return jsonRes(res, 200, result);
+});
+
+// ─── botmux ask v0.1.7 IPC route ─────────────────────────────────────────────
+//
+// CLI side: `botmux ask buttons --options "..."` POSTs here and keeps the
+// connection open until the broker settles the ask. Long keep-alive is OK —
+// the request's lifetime is bounded by `body.timeoutMs` which the broker
+// enforces. Default fetch on the CLI side has no read timeout.
+
+ipcRoute('POST', '/api/asks', async (req, res) => {
+  let raw: unknown;
+  try {
+    raw = await readJsonBody<unknown>(req);
+  } catch {
+    return jsonRes(res, 400, { ok: false, error: 'bad_json' });
+  }
+  const parsed = parseAskBody(raw);
+  if ('error' in parsed) return jsonRes(res, 400, { ok: false, error: parsed.error });
+
+  const approvers = resolveAskApprovers({
+    larkAppId: parsed.larkAppId,
+    sessionId: parsed.sessionId,
+    explicit: parsed.approvers,
+    getBotAllowedUsers: (id) => {
+      try { return getBot(id).resolvedAllowedUsers; } catch { return []; }
+    },
+    getSessionOwner: (sid) => {
+      for (const ds of activeSessions.values()) {
+        if (ds.session.sessionId === sid) return ds.ownerOpenId;
+      }
+      return undefined;
+    },
+  });
+  if (approvers.size === 0) {
+    // Nobody can answer — fail loud rather than registering a
+    // guaranteed-timeout. CLI side maps this to exit 2.
+    return jsonRes(res, 400, { ok: false, error: 'no_approvers' });
+  }
+
+  const result = await registerAskBroker({
+    larkAppId: parsed.larkAppId,
+    chatId: parsed.chatId,
+    rootMessageId: parsed.rootMessageId,
+    sessionId: parsed.sessionId,
+    approvers,
+    options: parsed.options,
+    prompt: parsed.prompt,
+    timeoutMs: parsed.timeoutMs,
+  });
   return jsonRes(res, 200, result);
 });
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1477,8 +1477,7 @@ ipcRoute('POST', '/api/asks', async (req, res) => {
     rootMessageId: parsed.rootMessageId,
     sessionId: parsed.sessionId,
     approvers,
-    options: parsed.options,
-    prompt: parsed.prompt,
+    questions: parsed.questions,
     timeoutMs: parsed.timeoutMs,
   });
   return jsonRes(res, 200, result);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -43,6 +43,7 @@ import {
   CARD_POSTING_SENTINEL,
   parkStreamCard,
   closeSession as closeSessionHelper,
+  ensureCliEnv,
 } from './core/worker-pool.js';
 import { ipcRoute, jsonRes, readJsonBody, setBotName, setLarkAppId, startIpcServer } from './core/dashboard-ipc-server.js';
 import { saveFrozenCards, deleteFrozenCards } from './services/frozen-card-store.js';
@@ -2339,6 +2340,12 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   }
   const cfg = botConfigs[idx];
   registerBot(cfg);
+  // 启动即为本 bot 的 CLI 预装环境（skills + askUserQuestion hook + 兜底 skill）。
+  // 关键：adopt 路径会跳过 ensureCliSkills，若重启后第一次就是 adopt 一个外部
+  // claude 会话，必须保证此时全局 ~/.claude/settings.json 已带 hook——否则"全局
+  // hook 适配 adopt"不成立。这里幂等、best-effort，不阻塞启动。
+  try { ensureCliEnv(cfg.cliId, cfg.cliPathOverride); }
+  catch (err) { logger.warn(`[hook] startup ensureCliEnv failed for ${cfg.cliId}: ${err instanceof Error ? err.message : String(err)}`); }
   sessionStore.init(cfg.larkAppId);
   chatFirstSeenStore.init(cfg.larkAppId);
   // Watch schedules.json for external writes (e.g. `botmux schedule add`

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1484,6 +1484,31 @@ ipcRoute('POST', '/api/asks', async (req, res) => {
   return jsonRes(res, 200, result);
 });
 
+// ─── adopt-session 查询端点 ───────────────────────────────────────────────────
+// CLI side（botmux hook）通过祖先 PID 匹配 adopt 会话，路由 askUserQuestion。
+// GET /api/adopt-session/:pid — 返回该 pid 对应的 adopt 会话路由信息。
+// 仅匹配**当前活跃**的 adopt 会话（按 originalCliPid）。残留风险：OS 的 PID 复用——
+// 若原 adopt 的 Claude 已退出、同号 PID 被别的进程复用，理论上可能误命中；但 hook
+// 进程是该 Claude 的子孙，只有 Claude 仍在跑时其祖先链里才会出现这个 PID，且 session
+// 必须仍在 activeSessions 里，复用窗口极小，可接受（不为此引入进程级鉴权）。
+ipcRoute('GET', '/api/adopt-session/:pid', (_req, res, params) => {
+  const pid = Number(params.pid);
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return jsonRes(res, 400, { ok: false, error: 'bad_pid' });
+  }
+  for (const ds of activeSessions.values()) {
+    if (ds.adoptedFrom?.originalCliPid === pid) {
+      return jsonRes(res, 200, {
+        sessionId: ds.session.sessionId,
+        chatId: ds.chatId,
+        larkAppId: ds.larkAppId,
+        rootMessageId: sessionAnchorId(ds),
+      });
+    }
+  }
+  return jsonRes(res, 404, { ok: false, error: 'no_adopt_session' });
+});
+
 function parseTriggerChatBinding(
   raw: unknown,
 ): { chatId: string; larkAppId: string } | undefined {

--- a/src/im/lark/ask-card.ts
+++ b/src/im/lark/ask-card.ts
@@ -41,8 +41,14 @@ export function createLarkAskCardDispatcher(
   return {
     async send(ask) {
       const cardJson = buildAskCard(ask);
-      const messageId = ask.rootMessageId
-        ? await reply(ask.larkAppId, ask.rootMessageId, cardJson, 'interactive', true)
+      // botmux 把 chat-scope session 的 routing anchor 也叫 rootMessageId,
+      // 但在 chat-scope 下它实际是 chat_id (oc_...) 而非 message_id (om_...).
+      // 飞书 /messages/{id}/reply 只接受 om_ — 用 oc_ 会 400 invalid message_id.
+      // 所以这里要按前缀判断是否真的能 reply.
+      const canReplyToRoot =
+        typeof ask.rootMessageId === 'string' && ask.rootMessageId.startsWith('om_');
+      const messageId = canReplyToRoot
+        ? await reply(ask.larkAppId, ask.rootMessageId!, cardJson, 'interactive', true)
         : await send(ask.larkAppId, ask.chatId, cardJson, 'interactive');
       return { messageId };
     },

--- a/src/im/lark/ask-card.ts
+++ b/src/im/lark/ask-card.ts
@@ -4,7 +4,7 @@ import type {
   AskResult,
   PendingAsk,
 } from '../../core/ask-types.js';
-import { tryResolveAsk } from '../../core/ask-broker.js';
+import { submitAsk, tryResolveAsk } from '../../core/ask-broker.js';
 import { logger } from '../../utils/logger.js';
 import { replyMessage, sendMessage, updateMessage } from './client.js';
 
@@ -84,7 +84,15 @@ export function handleAskCardAction(data: AskCardActionData): { toast: { type: s
     return toastForOutcome(tryResolveAsk({ askId, nonce, selected, by }));
   }
 
-  // 新 Submit 路径（Task 5 会完整实现）：暂返回 stale，避免未处理静默忽略
+  // 新 Submit 路径：从 form_value 中防御式解析各问答案，调 submitAsk
+  if (action === ASK_SUBMIT_ACTION) {
+    const formValue = data.action?.form_value ?? {};
+    // 推断问题数量：找最大 qN 的 N+1
+    const questionCount = guessQuestionCount(formValue);
+    const selections = parseFormSelections(formValue, questionCount);
+    return toastForOutcome(submitAsk({ askId, nonce, by, selections }));
+  }
+
   return staleToast();
 }
 
@@ -181,6 +189,58 @@ export function buildAskCard(ask: PendingAsk, result?: AskResult): string {
     },
     elements,
   });
+}
+
+/**
+ * 从 form_value 中推断问题数量（取最大 qN 索引 + 1，最少 1）。
+ */
+function guessQuestionCount(formValue: Record<string, unknown>): number {
+  let max = -1;
+  for (const key of Object.keys(formValue)) {
+    const m = key.match(/^q(\d+)$/);
+    if (m) {
+      const idx = parseInt(m[1]!, 10);
+      if (idx > max) max = idx;
+    }
+  }
+  return max >= 0 ? max + 1 : 1;
+}
+
+/**
+ * 防御式解析 Lark form_value，将每个 q<i> 字段的编码选项解析为选中 key 数组。
+ *
+ * 字段值可能为：
+ *  - string[]（multi_select_static 多选）
+ *  - string（select_static 单选，或 comma/semicolon 分隔的字符串）
+ *
+ * 每个编码值格式为 `<questionIndex>::<key>`，只收集 prefix 匹配的条目并剥去前缀。
+ * 导出供单元测试直接调用。
+ */
+export function parseFormSelections(
+  formValue: Record<string, unknown>,
+  questionCount: number,
+): string[][] {
+  const result: string[][] = [];
+  for (let i = 0; i < questionCount; i++) {
+    const raw = formValue[`q${i}`];
+    // 规范化为字符串数组
+    let tokens: string[];
+    if (Array.isArray(raw)) {
+      tokens = raw.filter((v): v is string => typeof v === 'string');
+    } else if (typeof raw === 'string') {
+      // 逗号或分号分隔的备用格式
+      tokens = raw.split(/[,;]/).map((s) => s.trim()).filter(Boolean);
+    } else {
+      tokens = [];
+    }
+    // 筛选出 prefix 匹配 `i::` 的 token，剥去前缀取 key
+    const prefix = `${i}::`;
+    const keys = tokens
+      .filter((t) => t.startsWith(prefix))
+      .map((t) => t.slice(prefix.length));
+    result.push(keys);
+  }
+  return result;
 }
 
 function toastForOutcome(outcome: AskClickOutcome): { toast: { type: string; content: string } } | undefined {

--- a/src/im/lark/ask-card.ts
+++ b/src/im/lark/ask-card.ts
@@ -4,7 +4,7 @@ import type {
   AskResult,
   PendingAsk,
 } from '../../core/ask-types.js';
-import { submitAsk, tryResolveAsk } from '../../core/ask-broker.js';
+import { getAskSnapshot, submitAsk, toggleAsk, tryResolveAsk } from '../../core/ask-broker.js';
 import { logger } from '../../utils/logger.js';
 import { replyMessage, sendMessage, updateMessage } from './client.js';
 
@@ -14,8 +14,10 @@ export const ASK_SELECT_ACTION = 'ask_select';
 /** 新多问 Submit 动作（form 内提交按钮携带此 action）。 */
 export const ASK_SUBMIT_ACTION = 'ask_submit';
 
-/** form 名称常量，与 workflow-cards.ts 形式对齐。 */
-const ASK_FORM_NAME = 'ask_form';
+/** 累积勾选动作。飞书会 silent-drop form + select_static，所以 v0.1.8 用按钮态。 */
+export const ASK_TOGGLE_ACTION = 'ask_toggle';
+
+const MAX_BUTTONS_PER_ACTION_ROW = 4;
 
 export interface AskCardActionData {
   operator?: { open_id?: string };
@@ -68,10 +70,12 @@ export function createLarkAskCardDispatcher(
 }
 
 export function isAskCardAction(action?: string): boolean {
-  return action === ASK_SELECT_ACTION || action === ASK_SUBMIT_ACTION;
+  return action === ASK_SELECT_ACTION || action === ASK_SUBMIT_ACTION || action === ASK_TOGGLE_ACTION;
 }
 
-export function handleAskCardAction(data: AskCardActionData): { toast: { type: string; content: string } } | undefined {
+export async function handleAskCardAction(
+  data: AskCardActionData,
+): Promise<{ toast: { type: string; content: string } } | Record<string, unknown> | undefined> {
   const value = data.action?.value;
   const action = asString(value?.action);
   if (!isAskCardAction(action)) return undefined;
@@ -90,13 +94,27 @@ export function handleAskCardAction(data: AskCardActionData): { toast: { type: s
     return toastForOutcome(tryResolveAsk({ askId, nonce, selected, by }));
   }
 
-  // 新 Submit 路径：从 form_value 中防御式解析各问答案，调 submitAsk
+  if (action === ASK_TOGGLE_ACTION) {
+    const questionIndex = asNumber(value?.question_index);
+    const key = asString(value?.key);
+    if (!Number.isInteger(questionIndex) || !key) return staleToast();
+    const outcome = toggleAsk({ askId, nonce, questionIndex, key, by });
+    if (outcome !== 'toggled') return toastForOutcome(outcome);
+    const updated = getAskSnapshot(askId);
+    if (!updated) return staleToast();
+    return JSON.parse(buildAskCard(updated)) as Record<string, unknown>;
+  }
+
+  // 新 Submit 路径：优先从按钮累积态提交；兼容旧 form_value 回调。
   if (action === ASK_SUBMIT_ACTION) {
     const formValue = data.action?.form_value ?? {};
-    // 推断问题数量：找最大 qN 的 N+1
-    const questionCount = guessQuestionCount(formValue);
-    const selections = parseFormSelections(formValue, questionCount);
-    return toastForOutcome(submitAsk({ askId, nonce, by, selections }));
+    if (Object.keys(formValue).length > 0) {
+      // 推断问题数量：找最大 qN 的 N+1
+      const questionCount = guessQuestionCount(formValue);
+      const selections = parseFormSelections(formValue, questionCount);
+      return toastForOutcome(submitAsk({ askId, nonce, by, selections }));
+    }
+    return toastForOutcome(submitAsk({ askId, nonce, by }));
   }
 
   return staleToast();
@@ -105,9 +123,12 @@ export function handleAskCardAction(data: AskCardActionData): { toast: { type: s
 /**
  * 构建 ask 卡片 JSON 字符串。
  *
- * 未 settle 时：将所有问题包在一个 form 内，每问渲染标题 div + 下拉选择组件，
- * 最后附一个 `action_type:'form_submit'` 的提交按钮。
- * 单选问题用 `select_static`，多选问题用 `multi_select_static`。
+ * 未 settle 时：
+ *   - 单问单选：每个选项一个按钮，点击即 settle（旧 ask_select 语义）
+ *   - 多问或多选：每个选项一个按钮用于累积勾选，最后用 Submit settle
+ *
+ * 注意：飞书服务端会 silent-drop `form` 内的 select_static / multi_select_static，
+ * 所以这里只使用稳定的 `action` + `button` 结构。
  *
  * 已 settle 时：渲染状态摘要，展示每问的选中标签（answered），或超时/失效信息。
  */
@@ -134,17 +155,17 @@ export function buildAskCard(ask: PendingAsk, result?: AskResult): string {
       text: { tag: 'lark_md', content: status },
     });
   } else {
-    // 未 settle：多问 form，每问一个标题 div + 选择组件，最后一个 Submit 按钮
+    // 未 settle：只用 action/buttons，避免 form+select 被飞书服务端静默丢弃。
     elements.push({ tag: 'hr' });
 
-    // form 内的元素列表
-    const formElements: Array<Record<string, unknown>> = [];
+    const requiresSubmit = ask.questions.length > 1 || ask.questions.some((q) => q.multiSelect);
+    const selections = ask.selections ?? ask.questions.map(() => []);
 
     for (let i = 0; i < ask.questions.length; i++) {
       const q = ask.questions[i]!;
 
       // 问题标题
-      formElements.push({
+      elements.push({
         tag: 'div',
         text: {
           tag: 'lark_md',
@@ -152,39 +173,50 @@ export function buildAskCard(ask: PendingAsk, result?: AskResult): string {
         },
       });
 
-      // 选项组件：单选 select_static / 多选 multi_select_static
-      const selectTag = q.multiSelect ? 'multi_select_static' : 'select_static';
-      const placeholder = q.multiSelect ? '可多选' : '请选择';
-      formElements.push({
-        tag: selectTag,
-        name: `q${i}`,
-        placeholder: { tag: 'plain_text', content: placeholder },
-        options: q.options.map((opt) => ({
-          text: { tag: 'plain_text', content: opt.label },
-          // value 编码 questionIndex::key，供 handler 解析
-          value: `${i}::${opt.key}`,
-        })),
-      });
+      const selected = new Set(selections[i] ?? []);
+      const optionButtons = q.options.map((opt) => ({
+        tag: 'button',
+        text: {
+          tag: 'plain_text',
+          content: requiresSubmit ? optionLabel(q.multiSelect, selected.has(opt.key), opt.label) : opt.label,
+        },
+        type: selected.has(opt.key) ? 'primary' : 'default',
+        value: requiresSubmit
+          ? {
+              action: ASK_TOGGLE_ACTION,
+              ask_id: ask.askId,
+              nonce: ask.nonce,
+              question_index: String(i),
+              key: opt.key,
+            }
+          : {
+              action: ASK_SELECT_ACTION,
+              ask_id: ask.askId,
+              nonce: ask.nonce,
+              key: opt.key,
+            },
+      }));
+      appendActionRows(elements, optionButtons);
     }
 
-    // Submit 按钮，放在 form 内，`action_type:'form_submit'` 与 workflow-cards.ts 完全一致
-    formElements.push({
-      tag: 'button',
-      text: { tag: 'plain_text', content: '提交' },
-      type: 'primary',
-      action_type: 'form_submit',
-      value: {
-        action: ASK_SUBMIT_ACTION,
-        ask_id: ask.askId,
-        nonce: ask.nonce,
-      },
-    });
-
-    elements.push({
-      tag: 'form',
-      name: ASK_FORM_NAME,
-      elements: formElements,
-    });
+    if (requiresSubmit) {
+      elements.push({ tag: 'hr' });
+      elements.push({
+        tag: 'action',
+        actions: [
+          {
+            tag: 'button',
+            text: { tag: 'plain_text', content: '提交' },
+            type: 'primary',
+            value: {
+              action: ASK_SUBMIT_ACTION,
+              ask_id: ask.askId,
+              nonce: ask.nonce,
+            },
+          },
+        ],
+      });
+    }
   }
 
   return JSON.stringify({
@@ -310,6 +342,26 @@ function approverSummary(ask: PendingAsk): string {
 
 function asString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
+}
+
+function asNumber(value: unknown): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string' && value.trim() !== '') return Number(value);
+  return Number.NaN;
+}
+
+function optionLabel(multiSelect: boolean, selected: boolean, label: string): string {
+  if (multiSelect) return `${selected ? '☑' : '☐'} ${label}`;
+  return `${selected ? '◉' : '○'} ${label}`;
+}
+
+function appendActionRows(elements: Array<Record<string, unknown>>, actions: Array<Record<string, unknown>>): void {
+  for (let i = 0; i < actions.length; i += MAX_BUTTONS_PER_ACTION_ROW) {
+    elements.push({
+      tag: 'action',
+      actions: actions.slice(i, i + MAX_BUTTONS_PER_ACTION_ROW),
+    });
+  }
 }
 
 function truncate(s: string, maxChars: number): string {

--- a/src/im/lark/ask-card.ts
+++ b/src/im/lark/ask-card.ts
@@ -8,12 +8,20 @@ import { tryResolveAsk } from '../../core/ask-broker.js';
 import { logger } from '../../utils/logger.js';
 import { replyMessage, sendMessage, updateMessage } from './client.js';
 
+/** 旧单选即答动作（保留兼容旧卡片回调；Task 5 新增 ask_submit 路径）。 */
 export const ASK_SELECT_ACTION = 'ask_select';
+
+/** 新多问 Submit 动作（form 内提交按钮携带此 action）。 */
+export const ASK_SUBMIT_ACTION = 'ask_submit';
+
+/** form 名称常量，与 workflow-cards.ts 形式对齐。 */
+const ASK_FORM_NAME = 'ask_form';
 
 export interface AskCardActionData {
   operator?: { open_id?: string };
   action?: {
     value?: Record<string, unknown>;
+    form_value?: Record<string, unknown>;
   };
 }
 
@@ -54,79 +62,115 @@ export function createLarkAskCardDispatcher(
 }
 
 export function isAskCardAction(action?: string): boolean {
-  return action === ASK_SELECT_ACTION;
+  return action === ASK_SELECT_ACTION || action === ASK_SUBMIT_ACTION;
 }
 
 export function handleAskCardAction(data: AskCardActionData): { toast: { type: string; content: string } } | undefined {
   const value = data.action?.value;
-  if (!isAskCardAction(asString(value?.action))) return undefined;
+  const action = asString(value?.action);
+  if (!isAskCardAction(action)) return undefined;
 
   const askId = asString(value?.ask_id);
   const nonce = asString(value?.nonce);
-  const selected = asString(value?.key);
   const by = data.operator?.open_id;
-  if (!askId || !nonce || !selected || !by) {
+  if (!askId || !nonce || !by) {
     return staleToast();
   }
 
-  return toastForOutcome(tryResolveAsk({ askId, nonce, selected, by }));
+  // 旧单选即答路径：按钮直接携带 key，调用 tryResolveAsk（单问单选便捷封装）
+  if (action === ASK_SELECT_ACTION) {
+    const selected = asString(value?.key);
+    if (!selected) return staleToast();
+    return toastForOutcome(tryResolveAsk({ askId, nonce, selected, by }));
+  }
+
+  // 新 Submit 路径（Task 5 会完整实现）：暂返回 stale，避免未处理静默忽略
+  return staleToast();
 }
 
+/**
+ * 构建 ask 卡片 JSON 字符串。
+ *
+ * 未 settle 时：将所有问题包在一个 form 内，每问渲染标题 div + 下拉选择组件，
+ * 最后附一个 `action_type:'form_submit'` 的提交按钮。
+ * 单选问题用 `select_static`，多选问题用 `multi_select_static`。
+ *
+ * 已 settle 时：渲染状态摘要，展示每问的选中标签（answered），或超时/失效信息。
+ */
 export function buildAskCard(ask: PendingAsk, result?: AskResult): string {
-  const prompt = truncate(ask.prompt, 512);
   const deadline = new Date(ask.deadlineAt).toLocaleString('zh-CN');
   const status = result ? settleStatus(result, ask) : undefined;
-  const elements: Array<Record<string, unknown>> = [
-    {
-      tag: 'div',
-      text: {
-        tag: 'lark_md',
-        content: `**问题**\n${escapeMd(prompt)}`,
-      },
-    },
-    {
-      tag: 'div',
-      fields: [
-        { is_short: true, text: { tag: 'lark_md', content: `**截止**\n${escapeMd(deadline)}` } },
-        { is_short: true, text: { tag: 'lark_md', content: `**可答复**\n${escapeMd(approverSummary(ask))}` } },
-      ],
-    },
-  ];
+
+  // 截止时间 + 可答复人 字段行（settled 与 unsettled 均展示）
+  const metaDiv = {
+    tag: 'div',
+    fields: [
+      { is_short: true, text: { tag: 'lark_md', content: `**截止**\n${escapeMd(deadline)}` } },
+      { is_short: true, text: { tag: 'lark_md', content: `**可答复**\n${escapeMd(approverSummary(ask))}` } },
+    ],
+  };
+
+  const elements: Array<Record<string, unknown>> = [metaDiv];
 
   if (status) {
+    // 已 settle：展示状态摘要，无可交互组件
     elements.push({ tag: 'hr' });
     elements.push({
       tag: 'div',
       text: { tag: 'lark_md', content: status },
     });
   } else {
+    // 未 settle：多问 form，每问一个标题 div + 选择组件，最后一个 Submit 按钮
     elements.push({ tag: 'hr' });
-    for (const row of chunk(ask.options, 4)) {
-      elements.push({
-        tag: 'column_set',
-        flex_mode: 'none',
-        horizontal_spacing: 'default',
-        columns: row.map((option) => ({
-          tag: 'column',
-          width: 'weighted',
-          weight: 1,
-          vertical_align: 'center',
-          elements: [
-            {
-              tag: 'button',
-              text: { tag: 'plain_text', content: option.label },
-              type: 'primary',
-              value: {
-                action: ASK_SELECT_ACTION,
-                ask_id: ask.askId,
-                nonce: ask.nonce,
-                key: option.key,
-              },
-            },
-          ],
+
+    // form 内的元素列表
+    const formElements: Array<Record<string, unknown>> = [];
+
+    for (let i = 0; i < ask.questions.length; i++) {
+      const q = ask.questions[i]!;
+
+      // 问题标题
+      formElements.push({
+        tag: 'div',
+        text: {
+          tag: 'lark_md',
+          content: `**问题 ${i + 1}**\n${escapeMd(truncate(q.prompt, 512))}`,
+        },
+      });
+
+      // 选项组件：单选 select_static / 多选 multi_select_static
+      const selectTag = q.multiSelect ? 'multi_select_static' : 'select_static';
+      const placeholder = q.multiSelect ? '可多选' : '请选择';
+      formElements.push({
+        tag: selectTag,
+        name: `q${i}`,
+        placeholder: { tag: 'plain_text', content: placeholder },
+        options: q.options.map((opt) => ({
+          text: { tag: 'plain_text', content: opt.label },
+          // value 编码 questionIndex::key，供 handler 解析
+          value: `${i}::${opt.key}`,
         })),
       });
     }
+
+    // Submit 按钮，放在 form 内，`action_type:'form_submit'` 与 workflow-cards.ts 完全一致
+    formElements.push({
+      tag: 'button',
+      text: { tag: 'plain_text', content: '提交' },
+      type: 'primary',
+      action_type: 'form_submit',
+      value: {
+        action: ASK_SUBMIT_ACTION,
+        ask_id: ask.askId,
+        nonce: ask.nonce,
+      },
+    });
+
+    elements.push({
+      tag: 'form',
+      name: ASK_FORM_NAME,
+      elements: formElements,
+    });
   }
 
   return JSON.stringify({
@@ -149,6 +193,9 @@ function toastForOutcome(outcome: AskClickOutcome): { toast: { type: string; con
       return { toast: { type: 'info', content: '这个 ask 已经被回答或结束' } };
     case 'stale':
       return staleToast();
+    case 'toggled':
+      // 累积勾选，不弹 toast
+      return undefined;
   }
 }
 
@@ -156,10 +203,23 @@ function staleToast(): { toast: { type: string; content: string } } {
   return { toast: { type: 'warning', content: '⚠️ 此 ask 已失效' } };
 }
 
+/**
+ * 生成已结束状态的摘要文本。
+ *
+ * answered：遍历每个问题，把选中的 key 映射为 label 并渲染。
+ * timedOut / invalidated：展示对应说明。
+ */
 function settleStatus(result: AskResult, ask: PendingAsk): string {
   if (result.kind === 'answered') {
-    const label = ask.options.find((o) => o.key === result.selected)?.label ?? result.selected;
-    return `**已选择：${escapeMd(label)}**\n操作人：${escapeMd(short(result.by, 28))}`;
+    // 每问一行：问题N：<选中标签>
+    const lines = result.answers.map((keys, i) => {
+      const q = ask.questions[i];
+      if (!q) return `问题${i + 1}：（无法解析）`;
+      const labels = keys.map((key) => q.options.find((o) => o.key === key)?.label ?? key);
+      return `问题${i + 1}：${labels.join(', ')}`;
+    });
+    const summary = lines.join('\n');
+    return `**已选择**\n${escapeMd(summary)}\n操作人：${escapeMd(short(result.by, 28))}`;
   }
   if (result.kind === 'timedOut') {
     return '**超时未答**';
@@ -180,12 +240,6 @@ function approverSummary(ask: PendingAsk): string {
   const values = [...ask.approvers].map((id) => short(id, 18));
   if (values.length <= 3) return values.join(', ');
   return `${values.slice(0, 3).join(', ')} +${values.length - 3}`;
-}
-
-function chunk<T>(values: ReadonlyArray<T>, size: number): T[][] {
-  const out: T[][] = [];
-  for (let i = 0; i < values.length; i += size) out.push(values.slice(i, i + size));
-  return out;
 }
 
 function asString(value: unknown): string | undefined {

--- a/src/im/lark/ask-card.ts
+++ b/src/im/lark/ask-card.ts
@@ -1,0 +1,206 @@
+import type {
+  AskCardDispatcher,
+  AskClickOutcome,
+  AskResult,
+  PendingAsk,
+} from '../../core/ask-types.js';
+import { tryResolveAsk } from '../../core/ask-broker.js';
+import { logger } from '../../utils/logger.js';
+import { replyMessage, sendMessage, updateMessage } from './client.js';
+
+export const ASK_SELECT_ACTION = 'ask_select';
+
+export interface AskCardActionData {
+  operator?: { open_id?: string };
+  action?: {
+    value?: Record<string, unknown>;
+  };
+}
+
+export interface AskCardDispatcherDeps {
+  sendMessage?: typeof sendMessage;
+  replyMessage?: typeof replyMessage;
+  updateMessage?: typeof updateMessage;
+}
+
+export function createLarkAskCardDispatcher(
+  deps: AskCardDispatcherDeps = {},
+): AskCardDispatcher {
+  const send = deps.sendMessage ?? sendMessage;
+  const reply = deps.replyMessage ?? replyMessage;
+  const update = deps.updateMessage ?? updateMessage;
+
+  return {
+    async send(ask) {
+      const cardJson = buildAskCard(ask);
+      const messageId = ask.rootMessageId
+        ? await reply(ask.larkAppId, ask.rootMessageId, cardJson, 'interactive', true)
+        : await send(ask.larkAppId, ask.chatId, cardJson, 'interactive');
+      return { messageId };
+    },
+    async onSettle(ask, result) {
+      if (!ask.cardMessageId) return;
+      try {
+        await update(ask.larkAppId, ask.cardMessageId, buildAskCard(ask, result));
+      } catch (err) {
+        logger.warn(
+          `[ask:${ask.askId}] failed to patch settled card: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    },
+  };
+}
+
+export function isAskCardAction(action?: string): boolean {
+  return action === ASK_SELECT_ACTION;
+}
+
+export function handleAskCardAction(data: AskCardActionData): { toast: { type: string; content: string } } | undefined {
+  const value = data.action?.value;
+  if (!isAskCardAction(asString(value?.action))) return undefined;
+
+  const askId = asString(value?.ask_id);
+  const nonce = asString(value?.nonce);
+  const selected = asString(value?.key);
+  const by = data.operator?.open_id;
+  if (!askId || !nonce || !selected || !by) {
+    return staleToast();
+  }
+
+  return toastForOutcome(tryResolveAsk({ askId, nonce, selected, by }));
+}
+
+export function buildAskCard(ask: PendingAsk, result?: AskResult): string {
+  const prompt = truncate(ask.prompt, 512);
+  const deadline = new Date(ask.deadlineAt).toLocaleString('zh-CN');
+  const status = result ? settleStatus(result, ask) : undefined;
+  const elements: Array<Record<string, unknown>> = [
+    {
+      tag: 'div',
+      text: {
+        tag: 'lark_md',
+        content: `**问题**\n${escapeMd(prompt)}`,
+      },
+    },
+    {
+      tag: 'div',
+      fields: [
+        { is_short: true, text: { tag: 'lark_md', content: `**截止**\n${escapeMd(deadline)}` } },
+        { is_short: true, text: { tag: 'lark_md', content: `**可答复**\n${escapeMd(approverSummary(ask))}` } },
+      ],
+    },
+  ];
+
+  if (status) {
+    elements.push({ tag: 'hr' });
+    elements.push({
+      tag: 'div',
+      text: { tag: 'lark_md', content: status },
+    });
+  } else {
+    elements.push({ tag: 'hr' });
+    for (const row of chunk(ask.options, 4)) {
+      elements.push({
+        tag: 'column_set',
+        flex_mode: 'none',
+        horizontal_spacing: 'default',
+        columns: row.map((option) => ({
+          tag: 'column',
+          width: 'weighted',
+          weight: 1,
+          vertical_align: 'center',
+          elements: [
+            {
+              tag: 'button',
+              text: { tag: 'plain_text', content: option.label },
+              type: 'primary',
+              value: {
+                action: ASK_SELECT_ACTION,
+                ask_id: ask.askId,
+                nonce: ask.nonce,
+                key: option.key,
+              },
+            },
+          ],
+        })),
+      });
+    }
+  }
+
+  return JSON.stringify({
+    config: { wide_screen_mode: true },
+    header: {
+      template: result ? templateForResult(result) : 'blue',
+      title: { tag: 'plain_text', content: result ? 'botmux ask 已结束' : 'botmux ask' },
+    },
+    elements,
+  });
+}
+
+function toastForOutcome(outcome: AskClickOutcome): { toast: { type: string; content: string } } | undefined {
+  switch (outcome) {
+    case 'accepted':
+      return undefined;
+    case 'unauthorized':
+      return { toast: { type: 'warning', content: '你没有权限回答这个 ask' } };
+    case 'already_settled':
+      return { toast: { type: 'info', content: '这个 ask 已经被回答或结束' } };
+    case 'stale':
+      return staleToast();
+  }
+}
+
+function staleToast(): { toast: { type: string; content: string } } {
+  return { toast: { type: 'warning', content: '⚠️ 此 ask 已失效' } };
+}
+
+function settleStatus(result: AskResult, ask: PendingAsk): string {
+  if (result.kind === 'answered') {
+    const label = ask.options.find((o) => o.key === result.selected)?.label ?? result.selected;
+    return `**已选择：${escapeMd(label)}**\n操作人：${escapeMd(short(result.by, 28))}`;
+  }
+  if (result.kind === 'timedOut') {
+    return '**超时未答**';
+  }
+  return `**已失效**\n${escapeMd(result.reason)}`;
+}
+
+function templateForResult(result: AskResult): string {
+  switch (result.kind) {
+    case 'answered': return 'green';
+    case 'timedOut': return 'orange';
+    case 'invalidated': return 'grey';
+  }
+}
+
+function approverSummary(ask: PendingAsk): string {
+  if (ask.approvers.size === 0) return '无可用答复人';
+  const values = [...ask.approvers].map((id) => short(id, 18));
+  if (values.length <= 3) return values.join(', ');
+  return `${values.slice(0, 3).join(', ')} +${values.length - 3}`;
+}
+
+function chunk<T>(values: ReadonlyArray<T>, size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < values.length; i += size) out.push(values.slice(i, i + size));
+  return out;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function truncate(s: string, maxChars: number): string {
+  if (s.length <= maxChars) return s || '（空）';
+  return `${s.slice(0, maxChars)}\n\n…（已截断）`;
+}
+
+function escapeMd(s: string): string {
+  return s.replace(/[*_~`\[\]\\]/g, (c) => `\\${c}`);
+}
+
+function short(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n)}…` : s;
+}

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -16,6 +16,7 @@ import {
   isWorkflowApprovalAction,
   type WorkflowApprovalHandlerDeps,
 } from './workflow-card-handler.js';
+import { handleAskCardAction, isAskCardAction } from './ask-card.js';
 import { createCliAdapterSync } from '../../adapters/cli/registry.js';
 import { logger } from '../../utils/logger.js';
 import * as sessionStore from '../../services/session-store.js';
@@ -184,6 +185,10 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     }
     // 兜底（无 card message_id，或撤回失败）：靠 callback 返回 patch 原地更新卡。
     return JSON.parse(buildGrantResultCard(kind, loc));
+  }
+
+  if (isAskCardAction(value?.action)) {
+    return handleAskCardAction(data);
   }
 
   const isSensitive = value?.action && ['restart', 'close', 'resume', 'skip_repo', 'retry_last_task', 'get_write_link', 'toggle_stream', 'toggle_display', 'export_text', 'term_action', 'refresh_screenshot', 'takeover', 'disconnect', 'tui_keys', 'tui_text_input', 'wf_approve', 'wf_reject', 'wf_cancel'].includes(value.action);

--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -448,6 +448,72 @@ botmux send --mention "ou_yyy:Aiden" "请 @Aiden 帮忙处理"
 \`\`\`
 `;
 
+const ASK_SKILL = `---
+name: botmux-ask
+description: 在当前飞书/Lark 话题里向用户发起阻塞式选择题并等待回答。触发场景：你需要用户在多个明确选项中做选择、确认风险动作、决定继续/回滚/中止，且后续命令需要拿到机器可解析的答案。使用 botmux ask buttons，stdout 只返回选中的 key，适合 shell 脚本和 CLI agent 继续执行。
+---
+
+# botmux-ask — 阻塞式向用户提问
+
+当你需要用户在明确选项里做选择，并且后续步骤必须等用户回答后才能继续时，使用 \`botmux ask buttons\`。
+
+## 什么时候用
+
+- 发布、回滚、删除、写文件、调用外部 API 等风险动作前，需要用户选择
+- 需求存在 2-6 个清晰分支，继续执行前必须拿到其中一个 key
+- 你正在 shell / CLI 里执行任务，需要把用户选择赋给变量继续跑
+
+## 不要用
+
+- 只是给用户汇报进展：用 \`botmux send\`
+- 需要自由文本长回答：v0.1.7 不支持，先用 \`botmux send\` 问用户
+- workflow 节点审批：workflow 已经有 humanGate / decision，不要套两层 ask
+
+## Canonical 用法
+
+\`\`\`bash
+choice=$(botmux ask buttons --options "deploy=继续发布,rollback=回滚,abort=中止" "线上 latency 涨了 30%，下一步怎么处理？")
+case "$choice" in
+  deploy) echo "继续发布" ;;
+  rollback) echo "执行回滚" ;;
+  abort) echo "中止" ;;
+esac
+\`\`\`
+
+\`key=label\` 里，**stdout 永远返回 key**，按钮上显示 label。只写 \`yes,no\` 时 key 和 label 相同。
+
+兼容 alias：\`botmux ask --options "yes,no" "继续吗？"\` 可以用，但文档和新脚本优先写 \`botmux ask buttons\`，给未来 \`ask text\` / \`ask confirm\` 留空间。
+
+## JSON 输出
+
+\`\`\`bash
+botmux ask buttons --json --options "yes=继续,no=停止" "继续执行吗？"
+\`\`\`
+
+stdout 为一行 JSON：
+
+\`\`\`json
+{"selected":"yes","by":"ou_xxx","timedOut":false,"comment":null}
+\`\`\`
+
+## 退出码和 stdout 契约
+
+- 成功：stdout 一行 \`<selected_key>\`，exit 0
+- \`--json\` 成功：stdout 一行 JSON，exit 0
+- 超时：stdout 为空，exit 124
+- 缺少 botmux 环境变量 / 参数错误：stdout 为空，exit 2
+- daemon 不可达或 ask 被 daemon restart 失效：stdout 为空，exit 3
+
+所有人类可读提示都在 stderr，调用方不要 parse stderr。
+
+## 选项规则
+
+- \`--options\` 必填，至少 2 项，逗号分隔
+- 推荐 \`key=label\`，key 用稳定英文短词，label 给用户看
+- 不支持 comment / multi-select / free-form text（v0.1.7 范围外）
+- 默认超时 300 秒，可用 \`--timeout <seconds>\` 调整
+`;
+
 const WORKFLOW_CREATE_SKILL = `---
 name: botmux-workflow-create
 description: 根据用户自然语言描述生成 botmux workflow JSON 定义文件。触发场景：用户说"我想做个流程"、"创建 workflow"、"把 X 拆成自动化"、"编排"、"orchestrate"、"自动化跑这几步"；或显式提到 botmux workflow create。必须先用 botmux bots list 查看可用 bot，先给用户确认设计，再写 $HOME/.botmux/workflows/<workflowId>.workflow.json，并用 botmux workflow validate 校验。
@@ -853,6 +919,7 @@ export const BUILTIN_SKILLS: SkillDef[] = [
   { name: 'botmux-quoted', content: QUOTED_SKILL },
   { name: 'botmux-send', content: SEND_SKILL },
   { name: 'botmux-bots', content: BOTS_SKILL },
+  { name: 'botmux-ask', content: ASK_SKILL },
   { name: 'botmux-workflow-create', content: WORKFLOW_CREATE_SKILL },
 ];
 

--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -847,6 +847,75 @@ humanGate：
 - executor 名不是默认三种之一且用户没确认：不要猜。
 `;
 
+export const ASK_SKILL = `---
+name: botmux-ask
+description: 在当前飞书/Lark 话题里向用户发起阻塞式选择题并等待回答。触发场景：你需要用户在多个明确选项中做选择、确认风险动作、决定继续/回滚/中止，且后续命令需要拿到机器可解析的答案。使用 botmux ask buttons，stdout 只返回选中的 key，适合 shell 脚本和 CLI agent 继续执行。
+---
+
+# botmux-ask — 阻塞式向用户提问
+
+当你需要用户在明确选项里做选择，并且后续步骤必须等用户回答后才能继续时，使用 \`botmux ask buttons\`。
+
+## 什么时候用
+
+- 发布、回滚、删除、写文件、调用外部 API 等风险动作前，需要用户选择
+- 需求存在 2-6 个清晰分支，继续执行前必须拿到其中一个 key
+- 你正在 shell / CLI 里执行任务，需要把用户选择赋给变量继续跑
+
+## 不要用
+
+- 只是给用户汇报进展：用 \`botmux send\`
+- 需要自由文本长回答：v0.1.7 不支持，先用 \`botmux send\` 问用户
+- workflow 节点审批：workflow 已经有 humanGate / decision，不要套两层 ask
+
+## Canonical 用法
+
+\`\`\`bash
+choice=$(botmux ask buttons --options "deploy=继续发布,rollback=回滚,abort=中止" "线上 latency 涨了 30%，下一步怎么处理？")
+case "$choice" in
+  deploy) echo "继续发布" ;;
+  rollback) echo "执行回滚" ;;
+  abort) echo "中止" ;;
+esac
+\`\`\`
+
+\`key=label\` 里，**stdout 永远返回 key**，按钮上显示 label。只写 \`yes,no\` 时 key 和 label 相同。
+
+兼容 alias：\`botmux ask --options "yes,no" "继续吗？"\` 可以用，但文档和新脚本优先写 \`botmux ask buttons\`，给未来 \`ask text\` / \`ask confirm\` 留空间。
+
+## JSON 输出
+
+\`\`\`bash
+botmux ask buttons --json --options "yes=继续,no=停止" "继续执行吗？"
+\`\`\`
+
+stdout 为一行 JSON。注意：\`--json\` 覆盖所有结果类型；超时 / 失效时也会输出 JSON，
+同时保留非 0 exit code。脚本判断超时必须看 exit code 或 \`timedOut\` 字段。
+
+\`\`\`json
+{"selected":"yes","by":"ou_xxx","timedOut":false,"comment":null}
+\`\`\`
+
+## 退出码和 stdout 契约
+
+- 成功：stdout 一行 \`<selected_key>\`，exit 0
+- \`--json\`：stdout 一行 JSON（包括超时 / 失效），exit code 仍按结果返回
+- 超时：默认模式 stdout 为空，exit 124；\`--json\` 时 \`{"selected":null,"timedOut":true,...}\`
+- 缺少 botmux 环境变量 / 参数错误：stdout 为空，exit 2
+- daemon 不可达或 ask 被 daemon restart 失效：默认模式 stdout 为空，exit 3；\`--json\` 时 \`selected:null\`
+
+所有人类可读提示都在 stderr，调用方不要 parse stderr。
+
+## 选项规则
+
+- \`--options\` 必填，至少 2 项，逗号分隔
+- 推荐 \`key=label\`，key 用稳定英文短词，label 给用户看
+- 不支持 comment / multi-select / free-form text（v0.1.7 范围外）
+- 默认超时 300 秒，可用 \`--timeout <seconds>\` 调整
+`;
+
+export const ASK_SKILL_NAME = 'botmux-ask';
+
 export const BUILTIN_SKILLS: SkillDef[] = [
   { name: 'botmux-schedule', content: SCHEDULE_SKILL },
   { name: 'botmux-history', content: HISTORY_SKILL },
@@ -861,6 +930,4 @@ export const BUILTIN_SKILLS: SkillDef[] = [
  *  in the CLI's skills directory. */
 export const RETIRED_SKILL_NAMES: string[] = [
   'botmux-thread-messages',
-  // botmux-ask skill 退役：askUserQuestion 能力改由 hook 自动接管，子命令 botmux ask 保留
-  'botmux-ask',
 ];

--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -490,7 +490,8 @@ esac
 botmux ask buttons --json --options "yes=继续,no=停止" "继续执行吗？"
 \`\`\`
 
-stdout 为一行 JSON：
+stdout 为一行 JSON。注意：\`--json\` 覆盖所有结果类型；超时 / 失效时也会输出 JSON，
+同时保留非 0 exit code。脚本判断超时必须看 exit code 或 \`timedOut\` 字段。
 
 \`\`\`json
 {"selected":"yes","by":"ou_xxx","timedOut":false,"comment":null}
@@ -499,10 +500,10 @@ stdout 为一行 JSON：
 ## 退出码和 stdout 契约
 
 - 成功：stdout 一行 \`<selected_key>\`，exit 0
-- \`--json\` 成功：stdout 一行 JSON，exit 0
-- 超时：stdout 为空，exit 124
+- \`--json\`：stdout 一行 JSON（包括超时 / 失效），exit code 仍按结果返回
+- 超时：默认模式 stdout 为空，exit 124；\`--json\` 时 \`{"selected":null,"timedOut":true,...}\`
 - 缺少 botmux 环境变量 / 参数错误：stdout 为空，exit 2
-- daemon 不可达或 ask 被 daemon restart 失效：stdout 为空，exit 3
+- daemon 不可达或 ask 被 daemon restart 失效：默认模式 stdout 为空，exit 3；\`--json\` 时 \`selected:null\`
 
 所有人类可读提示都在 stderr，调用方不要 parse stderr。
 

--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -448,73 +448,6 @@ botmux send --mention "ou_yyy:Aiden" "请 @Aiden 帮忙处理"
 \`\`\`
 `;
 
-const ASK_SKILL = `---
-name: botmux-ask
-description: 在当前飞书/Lark 话题里向用户发起阻塞式选择题并等待回答。触发场景：你需要用户在多个明确选项中做选择、确认风险动作、决定继续/回滚/中止，且后续命令需要拿到机器可解析的答案。使用 botmux ask buttons，stdout 只返回选中的 key，适合 shell 脚本和 CLI agent 继续执行。
----
-
-# botmux-ask — 阻塞式向用户提问
-
-当你需要用户在明确选项里做选择，并且后续步骤必须等用户回答后才能继续时，使用 \`botmux ask buttons\`。
-
-## 什么时候用
-
-- 发布、回滚、删除、写文件、调用外部 API 等风险动作前，需要用户选择
-- 需求存在 2-6 个清晰分支，继续执行前必须拿到其中一个 key
-- 你正在 shell / CLI 里执行任务，需要把用户选择赋给变量继续跑
-
-## 不要用
-
-- 只是给用户汇报进展：用 \`botmux send\`
-- 需要自由文本长回答：v0.1.7 不支持，先用 \`botmux send\` 问用户
-- workflow 节点审批：workflow 已经有 humanGate / decision，不要套两层 ask
-
-## Canonical 用法
-
-\`\`\`bash
-choice=$(botmux ask buttons --options "deploy=继续发布,rollback=回滚,abort=中止" "线上 latency 涨了 30%，下一步怎么处理？")
-case "$choice" in
-  deploy) echo "继续发布" ;;
-  rollback) echo "执行回滚" ;;
-  abort) echo "中止" ;;
-esac
-\`\`\`
-
-\`key=label\` 里，**stdout 永远返回 key**，按钮上显示 label。只写 \`yes,no\` 时 key 和 label 相同。
-
-兼容 alias：\`botmux ask --options "yes,no" "继续吗？"\` 可以用，但文档和新脚本优先写 \`botmux ask buttons\`，给未来 \`ask text\` / \`ask confirm\` 留空间。
-
-## JSON 输出
-
-\`\`\`bash
-botmux ask buttons --json --options "yes=继续,no=停止" "继续执行吗？"
-\`\`\`
-
-stdout 为一行 JSON。注意：\`--json\` 覆盖所有结果类型；超时 / 失效时也会输出 JSON，
-同时保留非 0 exit code。脚本判断超时必须看 exit code 或 \`timedOut\` 字段。
-
-\`\`\`json
-{"selected":"yes","by":"ou_xxx","timedOut":false,"comment":null}
-\`\`\`
-
-## 退出码和 stdout 契约
-
-- 成功：stdout 一行 \`<selected_key>\`，exit 0
-- \`--json\`：stdout 一行 JSON（包括超时 / 失效），exit code 仍按结果返回
-- 超时：默认模式 stdout 为空，exit 124；\`--json\` 时 \`{"selected":null,"timedOut":true,...}\`
-- 缺少 botmux 环境变量 / 参数错误：stdout 为空，exit 2
-- daemon 不可达或 ask 被 daemon restart 失效：默认模式 stdout 为空，exit 3；\`--json\` 时 \`selected:null\`
-
-所有人类可读提示都在 stderr，调用方不要 parse stderr。
-
-## 选项规则
-
-- \`--options\` 必填，至少 2 项，逗号分隔
-- 推荐 \`key=label\`，key 用稳定英文短词，label 给用户看
-- 不支持 comment / multi-select / free-form text（v0.1.7 范围外）
-- 默认超时 300 秒，可用 \`--timeout <seconds>\` 调整
-`;
-
 const WORKFLOW_CREATE_SKILL = `---
 name: botmux-workflow-create
 description: 根据用户自然语言描述生成 botmux workflow JSON 定义文件。触发场景：用户说"我想做个流程"、"创建 workflow"、"把 X 拆成自动化"、"编排"、"orchestrate"、"自动化跑这几步"；或显式提到 botmux workflow create。必须先用 botmux bots list 查看可用 bot，先给用户确认设计，再写 $HOME/.botmux/workflows/<workflowId>.workflow.json，并用 botmux workflow validate 校验。
@@ -920,7 +853,6 @@ export const BUILTIN_SKILLS: SkillDef[] = [
   { name: 'botmux-quoted', content: QUOTED_SKILL },
   { name: 'botmux-send', content: SEND_SKILL },
   { name: 'botmux-bots', content: BOTS_SKILL },
-  { name: 'botmux-ask', content: ASK_SKILL },
   { name: 'botmux-workflow-create', content: WORKFLOW_CREATE_SKILL },
 ];
 
@@ -929,4 +861,6 @@ export const BUILTIN_SKILLS: SkillDef[] = [
  *  in the CLI's skills directory. */
 export const RETIRED_SKILL_NAMES: string[] = [
   'botmux-thread-messages',
+  // botmux-ask skill 退役：askUserQuestion 能力改由 hook 自动接管，子命令 botmux ask 保留
+  'botmux-ask',
 ];

--- a/src/skills/installer.ts
+++ b/src/skills/installer.ts
@@ -2,10 +2,40 @@ import { writeFileSync, mkdirSync, existsSync, readFileSync, rmSync } from 'node
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { logger } from '../utils/logger.js';
-import { BUILTIN_SKILLS, RETIRED_SKILL_NAMES } from './definitions.js';
+import { BUILTIN_SKILLS, RETIRED_SKILL_NAMES, ASK_SKILL, ASK_SKILL_NAME } from './definitions.js';
 
 function expandHome(p: string): string {
   return p.startsWith('~') ? join(homedir(), p.slice(1)) : p;
+}
+
+/**
+ * 条件管理 `botmux-ask` skill —— hook 优先 + 非 hook CLI 兜底策略。
+ *
+ * - `install=false`（CLI 支持 hook 接管 askUserQuestion）：删除该 skill，避免
+ *   skill 与 hook 双重弹卡 / 抢工具。
+ * - `install=true`（CLI 无 hook 接管能力）：写入该 skill，让 agent 至少能用
+ *   `botmux ask buttons` 把选择题引到飞书（不如 hook 可靠，但有得用）。
+ *
+ * 幂等：install 时内容相同则跳过；remove 时不存在则跳过。
+ */
+export function ensureAskSkill(cliId: string, skillsDir: string | undefined, install: boolean): void {
+  if (!skillsDir) return;
+  const skillDir = join(expandHome(skillsDir), ASK_SKILL_NAME);
+  const skillFile = join(skillDir, 'SKILL.md');
+  try {
+    if (install) {
+      if (existsSync(skillFile) && readFileSync(skillFile, 'utf-8') === ASK_SKILL) return;
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(skillFile, ASK_SKILL, 'utf-8');
+      logger.info(`[skills] Installed ${ASK_SKILL_NAME} (无 hook 接管，兜底) for ${cliId} → ${skillFile}`);
+    } else {
+      if (!existsSync(skillDir)) return;
+      rmSync(skillDir, { recursive: true, force: true });
+      logger.info(`[skills] Removed ${ASK_SKILL_NAME} (hook 已接管) for ${cliId}`);
+    }
+  } catch (err: any) {
+    logger.warn(`[skills] ensureAskSkill(${install}) failed for ${cliId}: ${err.message}`);
+  }
 }
 
 /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2657,6 +2657,13 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     env: {
       ...process.env,
       CLAUDECODE: undefined,
+      // §5 of botmux ask v0.1.7 — `botmux ask buttons` reads these to find
+      // the daemon socket, route the card back to this thread, and resolve
+      // the approver allowlist against session.owner. Missing env → exit 2.
+      BOTMUX_SESSION_ID: cfg.sessionId,
+      BOTMUX_CHAT_ID: cfg.chatId,
+      BOTMUX_LARK_APP_ID: cfg.larkAppId,
+      BOTMUX_ROOT_MESSAGE_ID: cfg.rootMessageId,
       ...(injectClaudeSandbox ? { IS_SANDBOX: '1' } : {}),
     } as unknown as Record<string, string>,
   });

--- a/test/adopt-route.test.ts
+++ b/test/adopt-route.test.ts
@@ -1,0 +1,169 @@
+/**
+ * adopt-route.test.ts
+ *
+ * 测试 getAncestorPids 和 resolveAdoptRoute 的纯逻辑。
+ * 全部依赖注入，不访问真实 /proc / ps / 网络。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getAncestorPids, resolveAdoptRoute, type AdoptRoute } from '../src/adapters/adopt-route.js';
+
+// ── getAncestorPids ────────────────────────────────────────────────────────────
+
+describe('getAncestorPids', () => {
+  it('返回祖先链（不含 startPid 自己）', () => {
+    // 进程树：child(100) → p1(200) → p2(300) → p3(400)
+    const parentMap: Record<number, number> = {
+      100: 200,
+      200: 300,
+      300: 400,
+    };
+    const readParent = (pid: number): number | null => parentMap[pid] ?? null;
+    const result = getAncestorPids(100, readParent);
+    expect(result).toEqual([200, 300, 400]);
+  });
+
+  it('遇到 pid<=1 时停止', () => {
+    const parentMap: Record<number, number> = {
+      100: 50,
+      50: 1,   // 到 init
+    };
+    const readParent = (pid: number): number | null => parentMap[pid] ?? null;
+    const result = getAncestorPids(100, readParent);
+    // pid=1 不加入结果，在 50 处已停
+    expect(result).toEqual([50]);
+  });
+
+  it('readParent 返回 null 时停止', () => {
+    const parentMap: Record<number, number> = {
+      100: 200,
+    };
+    const readParent = (pid: number): number | null => parentMap[pid] ?? null;
+    const result = getAncestorPids(100, readParent);
+    expect(result).toEqual([200]);
+  });
+
+  it('防环：检测到循环时停止，结果有限', () => {
+    // 人为制造循环：100→200→300→100（不可能在真实进程树中，但代码要防范）
+    const parentMap: Record<number, number> = {
+      100: 200,
+      200: 300,
+      300: 100,  // 指回 startPid
+    };
+    const readParent = (pid: number): number | null => parentMap[pid] ?? null;
+    const result = getAncestorPids(100, readParent);
+    // 在遇到 100（startPid，已在 visited 里）时停止
+    expect(result).toEqual([200, 300]);
+    expect(result.length).toBeLessThan(10);
+  });
+
+  it('maxDepth 限制深度', () => {
+    // 构造深链：100→101→102→...→200（101 级）
+    const readParent = (pid: number): number | null => (pid < 200 ? pid + 1 : null);
+    const result = getAncestorPids(100, readParent, 5);
+    expect(result).toHaveLength(5);
+    expect(result[0]).toBe(101);
+    expect(result[4]).toBe(105);
+  });
+
+  it('startPid 无父（readParent 立刻返回 null）→ 空数组', () => {
+    const result = getAncestorPids(1, () => null);
+    expect(result).toEqual([]);
+  });
+});
+
+// ── resolveAdoptRoute ──────────────────────────────────────────────────────────
+
+const MOCK_ROUTE: AdoptRoute = {
+  sessionId: 's-adopt',
+  chatId: 'oc_chat1',
+  larkAppId: 'cli_apptest',
+  rootMessageId: 'om_root1',
+};
+
+describe('resolveAdoptRoute', () => {
+  it('遍历 daemon × 祖先，首个命中即返回', async () => {
+    // 祖先：[100, 200]；两个 daemon
+    const getAncestors = () => [100, 200];
+    const listDaemons = () => [{ ipcPort: 1 }, { ipcPort: 2 }];
+
+    // 只有 (port=2, pid=200) 命中
+    const queryDaemon = async (port: number, pid: number): Promise<AdoptRoute | null> => {
+      if (port === 2 && pid === 200) return MOCK_ROUTE;
+      return null;
+    };
+
+    const result = await resolveAdoptRoute({
+      startPid: 999,
+      listDaemons,
+      queryDaemon,
+      getAncestors,
+    });
+    expect(result).toEqual(MOCK_ROUTE);
+  });
+
+  it('首个命中后停止（不再查询后续 daemon/pid）', async () => {
+    const getAncestors = () => [100, 200];
+    const listDaemons = () => [{ ipcPort: 1 }, { ipcPort: 2 }];
+    const calls: Array<{ port: number; pid: number }> = [];
+
+    // (port=1, pid=100) 命中
+    const queryDaemon = async (port: number, pid: number): Promise<AdoptRoute | null> => {
+      calls.push({ port, pid });
+      if (port === 1 && pid === 100) return MOCK_ROUTE;
+      return null;
+    };
+
+    const result = await resolveAdoptRoute({
+      startPid: 999,
+      listDaemons,
+      queryDaemon,
+      getAncestors,
+    });
+    expect(result).toEqual(MOCK_ROUTE);
+    // 命中后不应再查询
+    expect(calls).toEqual([{ port: 1, pid: 100 }]);
+  });
+
+  it('全部 daemon × 祖先都未命中 → 返回 null', async () => {
+    const getAncestors = () => [100, 200];
+    const listDaemons = () => [{ ipcPort: 1 }, { ipcPort: 2 }];
+    const queryDaemon = async (): Promise<AdoptRoute | null> => null;
+
+    const result = await resolveAdoptRoute({
+      startPid: 999,
+      listDaemons,
+      queryDaemon,
+      getAncestors,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('无祖先（getAncestors 返回空数组）→ 返回 null', async () => {
+    const getAncestors = () => [];
+    const listDaemons = () => [{ ipcPort: 1 }];
+    const queryDaemon = async (): Promise<AdoptRoute | null> => MOCK_ROUTE;
+
+    const result = await resolveAdoptRoute({
+      startPid: 999,
+      listDaemons,
+      queryDaemon,
+      getAncestors,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('无在线 daemon（listDaemons 返回空数组）→ 返回 null', async () => {
+    const getAncestors = () => [100, 200];
+    const listDaemons = () => [] as Array<{ ipcPort: number }>;
+    const queryDaemon = async (): Promise<AdoptRoute | null> => MOCK_ROUTE;
+
+    const result = await resolveAdoptRoute({
+      startPid: 999,
+      listDaemons,
+      queryDaemon,
+      getAncestors,
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/test/adopt-route.test.ts
+++ b/test/adopt-route.test.ts
@@ -102,27 +102,38 @@ describe('resolveAdoptRoute', () => {
     expect(result).toEqual(MOCK_ROUTE);
   });
 
-  it('首个命中后停止（不再查询后续 daemon/pid）', async () => {
+  it('并发查询，多命中时按候选 index 取最小（确定性）', async () => {
+    // 候选编号：daemon 列表序 × 祖先链序 →
+    //   #0 (port1,100) #1 (port1,200) #2 (port2,100) #3 (port2,200)
     const getAncestors = () => [100, 200];
     const listDaemons = () => [{ ipcPort: 1 }, { ipcPort: 2 }];
-    const calls: Array<{ port: number; pid: number }> = [];
 
-    // (port=1, pid=100) 命中
+    // 让 #1(port1,200) 和 #3(port2,200) 都命中，但 #1 故意慢、#3 快返回；
+    // 并发下 #3 先 settle，但结果必须取 index 更小的 #1（确定性）。
+    const route1: AdoptRoute = { ...MOCK_ROUTE, sessionId: 's-idx1' };
+    const route3: AdoptRoute = { ...MOCK_ROUTE, sessionId: 's-idx3' };
     const queryDaemon = async (port: number, pid: number): Promise<AdoptRoute | null> => {
-      calls.push({ port, pid });
-      if (port === 1 && pid === 100) return MOCK_ROUTE;
+      if (port === 1 && pid === 200) { await new Promise((r) => setTimeout(r, 20)); return route1; }
+      if (port === 2 && pid === 200) return route3;
       return null;
     };
 
-    const result = await resolveAdoptRoute({
-      startPid: 999,
-      listDaemons,
-      queryDaemon,
-      getAncestors,
-    });
-    expect(result).toEqual(MOCK_ROUTE);
-    // 命中后不应再查询
-    expect(calls).toEqual([{ port: 1, pid: 100 }]);
+    const result = await resolveAdoptRoute({ startPid: 999, listDaemons, queryDaemon, getAncestors, budgetMs: 1000 });
+    expect(result?.sessionId).toBe('s-idx1');
+  });
+
+  it('全局 budget：所有 query 都挂起 → budget 内返回 null（不被无响应 daemon 卡住）', async () => {
+    const getAncestors = () => [100, 200, 300];
+    const listDaemons = () => [{ ipcPort: 1 }, { ipcPort: 2 }];
+    // 永不 resolve，模拟 still-online 但 IPC 不响应的 daemon
+    const queryDaemon = (): Promise<AdoptRoute | null> => new Promise<AdoptRoute | null>(() => {});
+
+    const t0 = Date.now();
+    const result = await resolveAdoptRoute({ startPid: 999, listDaemons, queryDaemon, getAncestors, budgetMs: 60 });
+    const elapsed = Date.now() - t0;
+    expect(result).toBeNull();
+    // 应在 budget 量级返回（给足余量），绝不线性叠加到 祖先×daemon×2s
+    expect(elapsed).toBeLessThan(1000);
   });
 
   it('全部 daemon × 祖先都未命中 → 返回 null', async () => {

--- a/test/ask-api.test.ts
+++ b/test/ask-api.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for the daemon-side `POST /api/asks` helpers — parseAskBody and
+ * the §6 approver-fallback chain. Pure-function tests, no HTTP server, no
+ * bot-registry mocking.
+ *
+ * Run:  pnpm vitest run test/ask-api.test.ts
+ */
+import { describe, expect, it } from 'vitest';
+
+import { parseAskBody, resolveAskApprovers } from '../src/core/ask-api.js';
+
+function validBody(over: Record<string, unknown> = {}) {
+  return {
+    sessionId: 'sess-1',
+    chatId: 'oc_chat',
+    larkAppId: 'cli_app',
+    rootMessageId: 'om_root',
+    options: [
+      { key: 'yes', label: '继续' },
+      { key: 'no', label: '回滚' },
+    ],
+    prompt: '继续发版吗？',
+    timeoutMs: 60_000,
+    approvers: [],
+    ...over,
+  };
+}
+
+describe('parseAskBody — happy path', () => {
+  it('accepts a fully populated body and returns the parsed shape', () => {
+    const out = parseAskBody(validBody());
+    expect('error' in out).toBe(false);
+    if ('error' in out) return;
+    expect(out.sessionId).toBe('sess-1');
+    expect(out.options).toHaveLength(2);
+    expect(out.options[0]).toEqual({ key: 'yes', label: '继续' });
+    expect(out.approvers).toEqual([]);
+    expect(out.rootMessageId).toBe('om_root');
+  });
+
+  it('accepts rootMessageId=null (chat-scope ask)', () => {
+    const out = parseAskBody(validBody({ rootMessageId: null }));
+    expect('error' in out).toBe(false);
+    if ('error' in out) return;
+    expect(out.rootMessageId).toBeNull();
+  });
+
+  it('filters blank entries from approvers array', () => {
+    const out = parseAskBody(
+      validBody({ approvers: ['ou_a', '', '   ', 'ou_b'] }),
+    );
+    if ('error' in out) throw new Error('expected ok');
+    expect(out.approvers).toEqual(['ou_a', 'ou_b']);
+  });
+});
+
+describe('parseAskBody — validation', () => {
+  it.each([
+    ['bad_body', null],
+    ['bad_body', undefined],
+    ['bad_body', []],
+    ['bad_body', 'not an object'],
+  ] as const)('returns %s for non-object raw=%j', (expected, raw) => {
+    const out = parseAskBody(raw);
+    expect(out).toEqual({ error: expected });
+  });
+
+  it.each([
+    ['bad_sessionId', { sessionId: '' }],
+    ['bad_sessionId', { sessionId: '   ' }],
+    ['bad_chatId', { chatId: '' }],
+    ['bad_larkAppId', { larkAppId: '' }],
+    ['bad_rootMessageId', { rootMessageId: 42 }],
+    ['bad_prompt', { prompt: '' }],
+    ['bad_prompt', { prompt: '   ' }],
+    ['bad_timeoutMs', { timeoutMs: 500 }],          // below minimum (1s)
+    ['bad_timeoutMs', { timeoutMs: NaN }],
+    ['bad_timeoutMs', { timeoutMs: 'forever' }],
+    ['bad_options', { options: [] }],
+    ['bad_options', { options: [{ key: 'only', label: 'only' }] }],
+    ['bad_options', { options: 'not-an-array' }],
+  ] as const)('returns %s when %s', (expected, override) => {
+    expect(parseAskBody(validBody(override))).toEqual({ error: expected });
+  });
+
+  it('rejects option with empty key', () => {
+    const out = parseAskBody(
+      validBody({
+        options: [
+          { key: '', label: 'bad' },
+          { key: 'yes', label: 'good' },
+        ],
+      }),
+    );
+    expect(out).toEqual({ error: 'bad_option_key' });
+  });
+
+  it('rejects option without a string label', () => {
+    const out = parseAskBody(
+      validBody({
+        options: [
+          { key: 'yes', label: 1 as unknown as string },
+          { key: 'no', label: 'no' },
+        ],
+      }),
+    );
+    expect(out).toEqual({ error: 'bad_option_label' });
+  });
+
+  it('rejects duplicate option keys', () => {
+    const out = parseAskBody(
+      validBody({
+        options: [
+          { key: 'yes', label: '继续' },
+          { key: 'yes', label: '再继续' },
+        ],
+      }),
+    );
+    expect(out).toEqual({ error: 'duplicate_option_key' });
+  });
+});
+
+describe('resolveAskApprovers — §6 fallback chain', () => {
+  const allowDefault = ['ou_owner', 'ou_admin', 'ou_other'];
+
+  it('explicit --approver list wins outright (ignores fallback)', () => {
+    const got = resolveAskApprovers({
+      larkAppId: 'cli_app',
+      sessionId: 'sess-1',
+      explicit: ['ou_explicit_a', 'ou_explicit_b'],
+      getBotAllowedUsers: () => allowDefault,
+      getSessionOwner: () => 'ou_owner',
+    });
+    expect([...got].sort()).toEqual(['ou_explicit_a', 'ou_explicit_b']);
+  });
+
+  it('filters blank entries from explicit list', () => {
+    const got = resolveAskApprovers({
+      larkAppId: 'cli_app',
+      sessionId: 'sess-1',
+      explicit: ['ou_a', '   ', ''],
+      getBotAllowedUsers: () => allowDefault,
+      getSessionOwner: () => 'ou_owner',
+    });
+    expect([...got]).toEqual(['ou_a']);
+  });
+
+  it('owner ∩ allowedUsers when explicit is empty and owner exists in allowlist', () => {
+    const got = resolveAskApprovers({
+      larkAppId: 'cli_app',
+      sessionId: 'sess-1',
+      explicit: [],
+      getBotAllowedUsers: () => allowDefault,
+      getSessionOwner: () => 'ou_owner',
+    });
+    expect([...got]).toEqual(['ou_owner']);
+  });
+
+  it('falls back to full allowedUsers when owner is not in allowlist', () => {
+    const got = resolveAskApprovers({
+      larkAppId: 'cli_app',
+      sessionId: 'sess-1',
+      explicit: [],
+      getBotAllowedUsers: () => allowDefault,
+      getSessionOwner: () => 'ou_stranger',
+    });
+    expect([...got].sort()).toEqual([...allowDefault].sort());
+  });
+
+  it('falls back to full allowedUsers when owner is unknown', () => {
+    const got = resolveAskApprovers({
+      larkAppId: 'cli_app',
+      sessionId: 'sess-1',
+      explicit: [],
+      getBotAllowedUsers: () => allowDefault,
+      getSessionOwner: () => undefined,
+    });
+    expect([...got].sort()).toEqual([...allowDefault].sort());
+  });
+
+  it('returns empty set when neither explicit, owner, nor allowedUsers exist', () => {
+    const got = resolveAskApprovers({
+      larkAppId: 'cli_app',
+      sessionId: 'sess-1',
+      explicit: [],
+      getBotAllowedUsers: () => [],
+      getSessionOwner: () => undefined,
+    });
+    expect(got.size).toBe(0);
+  });
+});

--- a/test/ask-api.test.ts
+++ b/test/ask-api.test.ts
@@ -32,8 +32,10 @@ describe('parseAskBody — happy path', () => {
     expect('error' in out).toBe(false);
     if ('error' in out) return;
     expect(out.sessionId).toBe('sess-1');
-    expect(out.options).toHaveLength(2);
-    expect(out.options[0]).toEqual({ key: 'yes', label: '继续' });
+    // 旧格式（options+prompt）归一化为 questions[0]
+    expect(out.questions).toHaveLength(1);
+    expect(out.questions[0].options).toHaveLength(2);
+    expect(out.questions[0].options[0]).toEqual({ key: 'yes', label: '继续' });
     expect(out.approvers).toEqual([]);
     expect(out.rootMessageId).toBe('om_root');
   });
@@ -117,6 +119,34 @@ describe('parseAskBody — validation', () => {
       }),
     );
     expect(out).toEqual({ error: 'duplicate_option_key' });
+  });
+});
+
+describe('parseAskBody — questions[] 多问多选', () => {
+  it('接受 questions[]（多问多选）', () => {
+    const body = parseAskBody({
+      sessionId: 's', chatId: 'c', larkAppId: 'a', rootMessageId: null,
+      timeoutMs: 60000, approvers: [],
+      questions: [
+        { prompt: 'q1', multiSelect: false, options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }] },
+        { prompt: 'q2', multiSelect: true, options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }] },
+      ],
+    });
+    expect('error' in body).toBe(false);
+    if (!('error' in body)) { expect(body.questions).toHaveLength(2); expect(body.questions[1].multiSelect).toBe(true); }
+  });
+
+  it('兼容旧 options[]+prompt：归一成单问单选', () => {
+    const body = parseAskBody({
+      sessionId: 's', chatId: 'c', larkAppId: 'a', rootMessageId: null,
+      timeoutMs: 60000, approvers: [], prompt: 'go?', options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }],
+    });
+    if (!('error' in body)) { expect(body.questions).toHaveLength(1); expect(body.questions[0].prompt).toBe('go?'); expect(body.questions[0].multiSelect).toBe(false); }
+  });
+
+  it('每问 options<2 报错', () => {
+    const body = parseAskBody({ sessionId: 's', chatId: 'c', larkAppId: 'a', rootMessageId: null, timeoutMs: 60000, approvers: [], questions: [{ prompt: 'q', multiSelect: false, options: [{ key: 'x', label: 'X' }] }] });
+    expect('error' in body).toBe(true);
   });
 });
 

--- a/test/ask-args.test.ts
+++ b/test/ask-args.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from 'vitest';
 import {
   AskArgsError,
   findMissingAskEnv,
+  normalizeAskDispatch,
   parseAskOptions,
   parseAskTimeoutSeconds,
 } from '../src/core/ask-args.js';
@@ -120,6 +121,48 @@ describe('parseAskTimeoutSeconds', () => {
     expect(() =>
       parseAskTimeoutSeconds('3', { default: 5, min: 1, max: 2 }),
     ).toThrowError(/范围/);
+  });
+});
+
+describe('normalizeAskDispatch', () => {
+  it('canonical form: `ask buttons --options ...` keeps sub=buttons', () => {
+    expect(normalizeAskDispatch(['buttons', '--options', 'yes,no', 'prompt'])).toEqual({
+      sub: 'buttons',
+      rest: ['--options', 'yes,no', 'prompt'],
+    });
+  });
+
+  it('bare alias: `ask --options ...` routes to sub="" with all flags in rest', () => {
+    expect(normalizeAskDispatch(['--options', 'yes,no', 'prompt'])).toEqual({
+      sub: '',
+      rest: ['--options', 'yes,no', 'prompt'],
+    });
+  });
+
+  it('bare alias: `ask --json --options ...` (any leading flag triggers alias)', () => {
+    expect(
+      normalizeAskDispatch(['--json', '--options', 'yes,no', 'prompt']),
+    ).toEqual({
+      sub: '',
+      rest: ['--json', '--options', 'yes,no', 'prompt'],
+    });
+  });
+
+  it('empty tail (just `botmux ask`) routes to sub="" with no rest', () => {
+    expect(normalizeAskDispatch([])).toEqual({ sub: '', rest: [] });
+  });
+
+  it('unknown subcommand passes through so cmdAsk can emit a useful error', () => {
+    expect(normalizeAskDispatch(['text', '--options', 'a,b'])).toEqual({
+      sub: 'text',
+      rest: ['--options', 'a,b'],
+    });
+  });
+
+  it('canonical form equivalence: bare alias and `buttons` produce same `rest`', () => {
+    const bare = normalizeAskDispatch(['--options', 'yes,no', 'p']);
+    const explicit = normalizeAskDispatch(['buttons', '--options', 'yes,no', 'p']);
+    expect(bare.rest).toEqual(explicit.rest);
   });
 });
 

--- a/test/ask-args.test.ts
+++ b/test/ask-args.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Pure-function tests for `botmux ask` argument parsing. Covers:
+ *  - --options CSV (key only / key=label / dedupe / empty key / count floor)
+ *  - --timeout bounds and integer-only enforcement
+ *  - missing env detection in §5 order
+ *
+ * Run:  pnpm vitest run test/ask-args.test.ts
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  AskArgsError,
+  findMissingAskEnv,
+  parseAskOptions,
+  parseAskTimeoutSeconds,
+} from '../src/core/ask-args.js';
+
+describe('parseAskOptions', () => {
+  it('parses bare keys with key==label', () => {
+    expect(parseAskOptions('yes,no')).toEqual([
+      { key: 'yes', label: 'yes' },
+      { key: 'no', label: 'no' },
+    ]);
+  });
+
+  it('parses key=label form, label can be CJK', () => {
+    expect(parseAskOptions('yes=继续,no=回滚')).toEqual([
+      { key: 'yes', label: '继续' },
+      { key: 'no', label: '回滚' },
+    ]);
+  });
+
+  it('mixes key-only and key=label entries', () => {
+    expect(parseAskOptions('go,abort=取消')).toEqual([
+      { key: 'go', label: 'go' },
+      { key: 'abort', label: '取消' },
+    ]);
+  });
+
+  it('treats further "=" as part of label (only first "=" splits)', () => {
+    expect(parseAskOptions('go=继续=右,no=不')).toEqual([
+      { key: 'go', label: '继续=右' },
+      { key: 'no', label: '不' },
+    ]);
+  });
+
+  it('trims whitespace around items and around key/label halves', () => {
+    expect(parseAskOptions('  yes  ,  no = 不要 ')).toEqual([
+      { key: 'yes', label: 'yes' },
+      { key: 'no', label: '不要' },
+    ]);
+  });
+
+  it('drops empty items between commas (trailing comma is forgiving)', () => {
+    expect(parseAskOptions('yes,,no,')).toEqual([
+      { key: 'yes', label: 'yes' },
+      { key: 'no', label: 'no' },
+    ]);
+  });
+
+  it('falls back label to key when "key=" has empty label half', () => {
+    expect(parseAskOptions('yes=,no')).toEqual([
+      { key: 'yes', label: 'yes' },
+      { key: 'no', label: 'no' },
+    ]);
+  });
+
+  it('rejects undefined / empty input', () => {
+    expect(() => parseAskOptions(undefined)).toThrowError(AskArgsError);
+    expect(() => parseAskOptions('')).toThrowError(/缺少 --options/);
+    expect(() => parseAskOptions('   ')).toThrowError(/缺少 --options/);
+  });
+
+  it('rejects fewer than 2 items', () => {
+    expect(() => parseAskOptions('onlyone')).toThrowError(/至少需要 2 项/);
+  });
+
+  it('rejects empty key like "=label"', () => {
+    expect(() => parseAskOptions('=label,yes')).toThrowError(/key 不能为空/);
+  });
+
+  it('rejects duplicate keys (no silent dedupe)', () => {
+    expect(() => parseAskOptions('yes,no,yes')).toThrowError(/重复 key: yes/);
+  });
+
+  it('tags errors with structured code for upstream mapping', () => {
+    try {
+      parseAskOptions('yes,yes');
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AskArgsError);
+      expect((err as AskArgsError).code).toBe('options_duplicate_key');
+    }
+  });
+});
+
+describe('parseAskTimeoutSeconds', () => {
+  it('defaults to 300s when unset', () => {
+    expect(parseAskTimeoutSeconds(undefined)).toBe(300_000);
+    expect(parseAskTimeoutSeconds('')).toBe(300_000);
+  });
+
+  it('parses integer seconds into ms', () => {
+    expect(parseAskTimeoutSeconds('600')).toBe(600_000);
+    expect(parseAskTimeoutSeconds('  10  ')).toBe(10_000);
+  });
+
+  it('rejects non-integer / non-numeric input', () => {
+    expect(() => parseAskTimeoutSeconds('abc')).toThrowError(/必须是整数秒数/);
+    expect(() => parseAskTimeoutSeconds('1.5')).toThrowError(/必须是整数秒数/);
+  });
+
+  it('rejects values outside [10, 3600]', () => {
+    expect(() => parseAskTimeoutSeconds('5')).toThrowError(/范围/);
+    expect(() => parseAskTimeoutSeconds('7200')).toThrowError(/范围/);
+  });
+
+  it('accepts custom bounds', () => {
+    expect(parseAskTimeoutSeconds('1', { default: 5, min: 1, max: 2 })).toBe(1000);
+    expect(() =>
+      parseAskTimeoutSeconds('3', { default: 5, min: 1, max: 2 }),
+    ).toThrowError(/范围/);
+  });
+});
+
+describe('findMissingAskEnv', () => {
+  it('returns null when all four env vars are present', () => {
+    expect(
+      findMissingAskEnv({
+        BOTMUX_SESSION_ID: 'sess-1',
+        BOTMUX_CHAT_ID: 'oc_1',
+        BOTMUX_LARK_APP_ID: 'cli_1',
+        BOTMUX_ROOT_MESSAGE_ID: 'om_1',
+      }),
+    ).toBeNull();
+  });
+
+  it('reports the first missing var in §5 order', () => {
+    expect(
+      findMissingAskEnv({
+        BOTMUX_CHAT_ID: 'oc_1',
+        BOTMUX_LARK_APP_ID: 'cli_1',
+        BOTMUX_ROOT_MESSAGE_ID: 'om_1',
+      }),
+    ).toBe('BOTMUX_SESSION_ID');
+    expect(
+      findMissingAskEnv({
+        BOTMUX_SESSION_ID: 'sess-1',
+        BOTMUX_LARK_APP_ID: 'cli_1',
+        BOTMUX_ROOT_MESSAGE_ID: 'om_1',
+      }),
+    ).toBe('BOTMUX_CHAT_ID');
+  });
+
+  it('treats blank/whitespace as missing', () => {
+    expect(
+      findMissingAskEnv({
+        BOTMUX_SESSION_ID: '   ',
+        BOTMUX_CHAT_ID: 'oc_1',
+        BOTMUX_LARK_APP_ID: 'cli_1',
+        BOTMUX_ROOT_MESSAGE_ID: 'om_1',
+      }),
+    ).toBe('BOTMUX_SESSION_ID');
+  });
+});

--- a/test/ask-broker.test.ts
+++ b/test/ask-broker.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Contract tests for the ask broker — covers §3 lifecycle, §6 approver, §7
+ * timeout, §8 invalidation. Card dispatch is mocked via a fake AskCardDispatcher
+ * so these tests stay IM-agnostic and run in pure node.
+ *
+ * Run:  pnpm vitest run test/ask-broker.test.ts
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  _getPending,
+  _pendingCount,
+  _resetForTest,
+  invalidateAll,
+  registerAsk,
+  setCardDispatcher,
+  tryResolveAsk,
+} from '../src/core/ask-broker.js';
+import type {
+  AskCardDispatcher,
+  AskOption,
+  AskResult,
+  CreateAskInput,
+  PendingAsk,
+} from '../src/core/ask-types.js';
+
+const OPTIONS: AskOption[] = [
+  { key: 'yes', label: '继续' },
+  { key: 'no', label: '回滚' },
+];
+
+function makeInput(over: Partial<CreateAskInput> = {}): CreateAskInput {
+  return {
+    larkAppId: 'cli_app',
+    chatId: 'oc_chat',
+    rootMessageId: 'om_root',
+    sessionId: 'sess-1',
+    approvers: new Set(['ou_owner']),
+    options: OPTIONS,
+    prompt: '继续发版吗？',
+    timeoutMs: 5_000,
+    ...over,
+  };
+}
+
+function mockDispatcher(
+  options: {
+    send?: AskCardDispatcher['send'];
+    onSettle?: AskCardDispatcher['onSettle'];
+  } = {},
+): AskCardDispatcher & {
+  sendCalls: PendingAsk[];
+  settleCalls: Array<{ ask: PendingAsk; result: AskResult }>;
+} {
+  const sendCalls: PendingAsk[] = [];
+  const settleCalls: Array<{ ask: PendingAsk; result: AskResult }> = [];
+  return {
+    async send(ask) {
+      sendCalls.push(ask);
+      if (options.send) return options.send(ask);
+      return { messageId: `om_card_${ask.askId}` };
+    },
+    onSettle(ask, result) {
+      settleCalls.push({ ask, result });
+      if (options.onSettle) return options.onSettle(ask, result);
+    },
+    sendCalls,
+    settleCalls,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  _resetForTest();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  _resetForTest();
+});
+
+describe('registerAsk happy path', () => {
+  it('register → tryResolveAsk("yes") resolves with kind:answered', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+
+    const p = registerAsk(makeInput());
+
+    // Card dispatch is async — flush the microtask queue so send() runs
+    // and cardMessageId is stored. Use a real-timers slip via Promise.resolve.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(_pendingCount()).toBe(1);
+    expect(d.sendCalls).toHaveLength(1);
+    const [dispatched] = d.sendCalls;
+    expect(dispatched.options).toEqual(OPTIONS);
+    expect(dispatched.approvers.has('ou_owner')).toBe(true);
+
+    const outcome = tryResolveAsk({
+      askId: dispatched.askId,
+      nonce: dispatched.nonce,
+      selected: 'yes',
+      by: 'ou_owner',
+    });
+    expect(outcome).toBe('accepted');
+
+    const result = await p;
+    expect(result).toEqual({
+      kind: 'answered',
+      selected: 'yes',
+      by: 'ou_owner',
+      comment: null,
+      timedOut: false,
+    });
+    expect(_pendingCount()).toBe(0);
+    expect(d.settleCalls).toHaveLength(1);
+    expect(d.settleCalls[0]!.result.kind).toBe('answered');
+  });
+
+  it('captures cardMessageId once dispatcher.send resolves', async () => {
+    const d = mockDispatcher({
+      send: async () => ({ messageId: 'om_specific_card' }),
+    });
+    setCardDispatcher(d);
+
+    registerAsk(makeInput());
+    // Flush enough microtasks so registerAsk's `dispatcher.send(...).then(...)`
+    // chain has run all three hops (caller microtask → send body resolve →
+    // .then callback). Four ticks is overkill but cheap.
+    for (let i = 0; i < 4; i++) await Promise.resolve();
+
+    const askId = d.sendCalls[0]!.askId;
+    const snap = _getPending(askId);
+    expect(snap?.cardMessageId).toBe('om_specific_card');
+  });
+});
+
+describe('tryResolveAsk gating', () => {
+  it('returns "stale" for unknown askId', () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    expect(
+      tryResolveAsk({
+        askId: 'no-such-id',
+        nonce: 'xxx',
+        selected: 'yes',
+        by: 'ou_owner',
+      }),
+    ).toBe('stale');
+  });
+
+  it('returns "stale" for nonce mismatch (covers daemon-restart stale card)', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    registerAsk(makeInput());
+    await Promise.resolve();
+    await Promise.resolve();
+    const { askId } = d.sendCalls[0]!;
+    expect(
+      tryResolveAsk({
+        askId,
+        nonce: 'wrong-nonce',
+        selected: 'yes',
+        by: 'ou_owner',
+      }),
+    ).toBe('stale');
+  });
+
+  it('returns "unauthorized" when clicker is not in approver allowlist', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    registerAsk(makeInput({ approvers: new Set(['ou_owner']) }));
+    await Promise.resolve();
+    await Promise.resolve();
+    const { askId, nonce } = d.sendCalls[0]!;
+    expect(
+      tryResolveAsk({ askId, nonce, selected: 'yes', by: 'ou_stranger' }),
+    ).toBe('unauthorized');
+    // Ask still pending — caller may have spoofed; broker must not settle.
+    expect(_pendingCount()).toBe(1);
+  });
+
+  it('returns "stale" when selected key is not in options (defensive)', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    registerAsk(makeInput());
+    await Promise.resolve();
+    await Promise.resolve();
+    const { askId, nonce } = d.sendCalls[0]!;
+    expect(
+      tryResolveAsk({ askId, nonce, selected: 'maybe', by: 'ou_owner' }),
+    ).toBe('stale');
+  });
+
+  it('returns "already_settled" for a second click after race winner', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    registerAsk(
+      makeInput({ approvers: new Set(['ou_a', 'ou_b']) }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    const { askId, nonce } = d.sendCalls[0]!;
+
+    expect(
+      tryResolveAsk({ askId, nonce, selected: 'yes', by: 'ou_a' }),
+    ).toBe('accepted');
+    expect(
+      tryResolveAsk({ askId, nonce, selected: 'no', by: 'ou_b' }),
+    ).toBe('already_settled');
+  });
+});
+
+describe('timeout', () => {
+  it('settles with kind:timedOut after deadlineMs elapses', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    const p = registerAsk(makeInput({ timeoutMs: 1_000 }));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(_pendingCount()).toBe(1);
+
+    vi.advanceTimersByTime(1_000);
+    const result = await p;
+    expect(result.kind).toBe('timedOut');
+    expect(result.timedOut).toBe(true);
+    expect(_pendingCount()).toBe(0);
+    expect(d.settleCalls[0]!.result.kind).toBe('timedOut');
+  });
+
+  it('clicks shortly after timeout return "already_settled" (within retention window)', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    const p = registerAsk(makeInput({ timeoutMs: 1_000 }));
+    await Promise.resolve();
+    await Promise.resolve();
+    const { askId, nonce } = d.sendCalls[0]!;
+    vi.advanceTimersByTime(1_000);
+    await p;
+
+    // Settled entry is retained for SETTLED_RETENTION_MS (60s) so race-losers
+    // get the precise "already_settled" outcome, not a generic "stale".
+    expect(
+      tryResolveAsk({ askId, nonce, selected: 'yes', by: 'ou_owner' }),
+    ).toBe('already_settled');
+  });
+
+  it('clicks well past retention window return "stale"', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    const p = registerAsk(makeInput({ timeoutMs: 1_000 }));
+    await Promise.resolve();
+    await Promise.resolve();
+    const { askId, nonce } = d.sendCalls[0]!;
+    vi.advanceTimersByTime(1_000);
+    await p;
+
+    // Push Date.now() past the 60s retention horizon — the settled entry
+    // should have been GC'd by the next click attempt.
+    vi.advanceTimersByTime(120_000);
+    expect(
+      tryResolveAsk({ askId, nonce, selected: 'yes', by: 'ou_owner' }),
+    ).toBe('stale');
+  });
+});
+
+describe('invalidateAll', () => {
+  it('settles every pending ask with kind:invalidated and clears registry', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    const p1 = registerAsk(makeInput({ sessionId: 'sess-a' }));
+    const p2 = registerAsk(makeInput({ sessionId: 'sess-b' }));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(_pendingCount()).toBe(2);
+
+    const count = invalidateAll('daemon shutdown');
+    expect(count).toBe(2);
+    expect(_pendingCount()).toBe(0);
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1.kind).toBe('invalidated');
+    expect(r2.kind).toBe('invalidated');
+    if (r1.kind === 'invalidated') {
+      expect(r1.reason).toBe('daemon shutdown');
+    }
+  });
+
+  it('returns 0 when no pending asks exist', () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    expect(invalidateAll('noop')).toBe(0);
+  });
+});
+
+describe('dispatcher failure', () => {
+  it('immediately settles the ask as invalidated if card dispatch throws', async () => {
+    const d = mockDispatcher({
+      send: async () => {
+        throw new Error('lark 5xx');
+      },
+    });
+    setCardDispatcher(d);
+
+    const result = await registerAsk(makeInput());
+    expect(result.kind).toBe('invalidated');
+    if (result.kind === 'invalidated') {
+      expect(result.reason).toMatch(/lark 5xx/);
+    }
+    expect(_pendingCount()).toBe(0);
+  });
+
+  it('throws synchronously if registerAsk is called before setCardDispatcher', () => {
+    // _resetForTest() unwired the dispatcher; do not wire one here.
+    expect(() => registerAsk(makeInput())).toThrowError(
+      /cardDispatcher not wired/,
+    );
+  });
+});
+
+describe('onSettle hook is best-effort', () => {
+  it('does not throw out of the broker even if onSettle throws', async () => {
+    const d = mockDispatcher({
+      onSettle: () => {
+        throw new Error('patch failed');
+      },
+    });
+    setCardDispatcher(d);
+    const p = registerAsk(makeInput({ timeoutMs: 500 }));
+    await Promise.resolve();
+    await Promise.resolve();
+    vi.advanceTimersByTime(500);
+    // Must still resolve cleanly despite onSettle blowing up.
+    const result = await p;
+    expect(result.kind).toBe('timedOut');
+  });
+});

--- a/test/ask-broker.test.ts
+++ b/test/ask-broker.test.ts
@@ -8,12 +8,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  _allAskIds,
   _getPending,
   _pendingCount,
   _resetForTest,
   invalidateAll,
   registerAsk,
   setCardDispatcher,
+  submitAsk,
+  toggleAsk,
   tryResolveAsk,
 } from '../src/core/ask-broker.js';
 import type {
@@ -36,8 +39,7 @@ function makeInput(over: Partial<CreateAskInput> = {}): CreateAskInput {
     rootMessageId: 'om_root',
     sessionId: 'sess-1',
     approvers: new Set(['ou_owner']),
-    options: OPTIONS,
-    prompt: '继续发版吗？',
+    questions: [{ prompt: '继续发版吗？', options: OPTIONS, multiSelect: false }],
     timeoutMs: 5_000,
     ...over,
   };
@@ -93,7 +95,7 @@ describe('registerAsk happy path', () => {
     expect(_pendingCount()).toBe(1);
     expect(d.sendCalls).toHaveLength(1);
     const [dispatched] = d.sendCalls;
-    expect(dispatched.options).toEqual(OPTIONS);
+    expect(dispatched.questions).toEqual([{ prompt: '继续发版吗？', options: OPTIONS, multiSelect: false }]);
     expect(dispatched.approvers.has('ou_owner')).toBe(true);
 
     const outcome = tryResolveAsk({
@@ -107,7 +109,7 @@ describe('registerAsk happy path', () => {
     const result = await p;
     expect(result).toEqual({
       kind: 'answered',
-      selected: 'yes',
+      answers: [['yes']],
       by: 'ou_owner',
       comment: null,
       timedOut: false,
@@ -333,5 +335,155 @@ describe('onSettle hook is best-effort', () => {
     // Must still resolve cleanly despite onSettle blowing up.
     const result = await p;
     expect(result.kind).toBe('timedOut');
+  });
+});
+
+describe('toggleAsk + submitAsk', () => {
+  it('多选：toggle 累积，submit 才 settle', async () => {
+    _resetForTest();
+    setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
+    const p = registerAsk({
+      larkAppId: 'a', chatId: 'c', rootMessageId: null, sessionId: 's',
+      approvers: new Set(['ou_u']),
+      questions: [{ prompt: 'pick', options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }], multiSelect: true }],
+      timeoutMs: 60_000,
+    });
+    const askId = _allAskIds()[0]!;
+    const nonce = _getPending(askId)!.nonce;
+    // toggle 两个选项 — 不 settle
+    expect(toggleAsk({ askId, nonce, questionIndex: 0, key: 'a', by: 'ou_u' })).toBe('toggled');
+    expect(_pendingCount()).toBe(1);
+    expect(toggleAsk({ askId, nonce, questionIndex: 0, key: 'b', by: 'ou_u' })).toBe('toggled');
+    expect(_pendingCount()).toBe(1);
+    // submit 用累积选中项 settle
+    expect(submitAsk({ askId, nonce, by: 'ou_u' })).toBe('accepted');
+    const r = await p;
+    expect(r.kind).toBe('answered');
+    if (r.kind === 'answered') expect([...r.answers[0]!].sort()).toEqual(['a', 'b']);
+  });
+
+  it('toggle 取消选中（再次 toggle 同一 key 去除）', async () => {
+    _resetForTest();
+    setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
+    const p = registerAsk({
+      larkAppId: 'a', chatId: 'c', rootMessageId: null, sessionId: 's',
+      approvers: new Set(['ou_u']),
+      questions: [{ prompt: 'pick', options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }], multiSelect: true }],
+      timeoutMs: 60_000,
+    });
+    const askId = _allAskIds()[0]!;
+    const nonce = _getPending(askId)!.nonce;
+    // 选 a 后取消 a，最终只有 b
+    expect(toggleAsk({ askId, nonce, questionIndex: 0, key: 'a', by: 'ou_u' })).toBe('toggled');
+    expect(toggleAsk({ askId, nonce, questionIndex: 0, key: 'a', by: 'ou_u' })).toBe('toggled');
+    expect(toggleAsk({ askId, nonce, questionIndex: 0, key: 'b', by: 'ou_u' })).toBe('toggled');
+    expect(submitAsk({ askId, nonce, by: 'ou_u' })).toBe('accepted');
+    const r = await p;
+    if (r.kind === 'answered') expect([...r.answers[0]!]).toEqual(['b']);
+  });
+
+  it('单选：toggle 后再 toggle 同一 key，set 内只保留该 key', async () => {
+    _resetForTest();
+    setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
+    const p = registerAsk({
+      larkAppId: 'a', chatId: 'c', rootMessageId: null, sessionId: 's',
+      approvers: new Set(['ou_u']),
+      questions: [{ prompt: 'go', options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }], multiSelect: false }],
+      timeoutMs: 60_000,
+    });
+    const askId = _allAskIds()[0]!;
+    const nonce = _getPending(askId)!.nonce;
+    // 单选 toggle：选 y → 选 n（不累积，只保留最后选的）
+    expect(toggleAsk({ askId, nonce, questionIndex: 0, key: 'y', by: 'ou_u' })).toBe('toggled');
+    expect(toggleAsk({ askId, nonce, questionIndex: 0, key: 'n', by: 'ou_u' })).toBe('toggled');
+    expect(submitAsk({ askId, nonce, by: 'ou_u' })).toBe('accepted');
+    const r = await p;
+    if (r.kind === 'answered') expect(r.answers).toEqual([['n']]);
+  });
+
+  it('单问单选：submit 携带显式 selections', async () => {
+    _resetForTest();
+    setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
+    const p = registerAsk({
+      larkAppId: 'a', chatId: 'c', rootMessageId: null, sessionId: 's',
+      approvers: new Set(['ou_u']),
+      questions: [{ prompt: 'go', options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }], multiSelect: false }],
+      timeoutMs: 60_000,
+    });
+    const askId = _allAskIds()[0]!;
+    const nonce = _getPending(askId)!.nonce;
+    expect(submitAsk({ askId, nonce, by: 'ou_u', selections: [['y']] })).toBe('accepted');
+    const r = await p;
+    if (r.kind === 'answered') expect(r.answers).toEqual([['y']]);
+  });
+
+  it('未授权 toggle/submit 不改变状态', async () => {
+    _resetForTest();
+    setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
+    registerAsk({
+      larkAppId: 'a', chatId: 'c', rootMessageId: null, sessionId: 's',
+      approvers: new Set(['ou_u']),
+      questions: [{ prompt: 'pick', options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }], multiSelect: true }],
+      timeoutMs: 60_000,
+    });
+    const askId = _allAskIds()[0]!;
+    const nonce = _getPending(askId)!.nonce;
+    // 未授权用户 toggle → unauthorized，状态不变
+    expect(toggleAsk({ askId, nonce, questionIndex: 0, key: 'a', by: 'ou_other' })).toBe('unauthorized');
+    expect(_pendingCount()).toBe(1);
+    // 未授权用户 submit → unauthorized，状态不变
+    expect(submitAsk({ askId, nonce, by: 'ou_other' })).toBe('unauthorized');
+    expect(_pendingCount()).toBe(1);
+  });
+
+  it('toggleAsk 返回 stale（未知 askId）', () => {
+    _resetForTest();
+    setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
+    expect(toggleAsk({ askId: 'no-such', nonce: 'x', questionIndex: 0, key: 'a', by: 'ou_u' })).toBe('stale');
+  });
+
+  it('submitAsk 返回 stale（未知 askId）', () => {
+    _resetForTest();
+    setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
+    expect(submitAsk({ askId: 'no-such', nonce: 'x', by: 'ou_u' })).toBe('stale');
+  });
+
+  it('toggleAsk 返回 stale（options 中不存在的 key）', async () => {
+    _resetForTest();
+    setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
+    registerAsk({
+      larkAppId: 'a', chatId: 'c', rootMessageId: null, sessionId: 's',
+      approvers: new Set(['ou_u']),
+      questions: [{ prompt: 'pick', options: [{ key: 'a', label: 'A' }], multiSelect: true }],
+      timeoutMs: 60_000,
+    });
+    const askId = _allAskIds()[0]!;
+    const nonce = _getPending(askId)!.nonce;
+    expect(toggleAsk({ askId, nonce, questionIndex: 0, key: 'z', by: 'ou_u' })).toBe('stale');
+  });
+
+  it('submitAsk 单选问题未选任何项时返回 stale', async () => {
+    _resetForTest();
+    setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
+    registerAsk({
+      larkAppId: 'a', chatId: 'c', rootMessageId: null, sessionId: 's',
+      approvers: new Set(['ou_u']),
+      questions: [{ prompt: 'go', options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }], multiSelect: false }],
+      timeoutMs: 60_000,
+    });
+    const askId = _allAskIds()[0]!;
+    const nonce = _getPending(askId)!.nonce;
+    // 未 toggle 任何项直接 submit，单选问题没选 → stale
+    expect(submitAsk({ askId, nonce, by: 'ou_u' })).toBe('stale');
+    expect(_pendingCount()).toBe(1);
+  });
+
+  it('_allAskIds 返回所有未 settle 及已 settle(retention 内)的 askId', async () => {
+    _resetForTest();
+    setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
+    registerAsk(makeInput({ sessionId: 'sx' }));
+    registerAsk(makeInput({ sessionId: 'sy' }));
+    const ids = _allAskIds();
+    expect(ids).toHaveLength(2);
   });
 });

--- a/test/ask-card.test.ts
+++ b/test/ask-card.test.ts
@@ -1,11 +1,20 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { PendingAsk } from '../src/core/ask-types.js';
+
+// vi.mock 被 vitest 提升到模块顶层，在 import 之前执行。
+// 用 importOriginal 保留所有真实导出，仅把 submitAsk 替换为可监测的 spy。
+vi.mock('../src/core/ask-broker.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/core/ask-broker.js')>();
+  return { ...actual, submitAsk: vi.fn(actual.submitAsk) };
+});
+
 import {
   _getPending,
   _resetForTest,
   registerAsk,
   setCardDispatcher,
+  submitAsk,
 } from '../src/core/ask-broker.js';
 import {
   ASK_SELECT_ACTION,
@@ -13,10 +22,15 @@ import {
   buildAskCard,
   createLarkAskCardDispatcher,
   handleAskCardAction,
+  parseFormSelections,
 } from '../src/im/lark/ask-card.js';
+
+const mockedSubmitAsk = vi.mocked(submitAsk);
 
 afterEach(() => {
   _resetForTest();
+  // 只清计数/记录，不重置实现（spy 默认透传真实 submitAsk）
+  mockedSubmitAsk.mockClear();
 });
 
 /** 构造一个带 questions/askId/nonce/deadlineAt/approvers 的 PendingAsk。 */
@@ -237,6 +251,242 @@ describe('handleAskCardAction', () => {
     });
     expect(result?.toast.type).toBe('warning');
     expect(result?.toast.content).toContain('没有权限');
+  });
+});
+
+// ─── parseFormSelections 单元测试 ─────────────────────────────────────────────
+
+describe('parseFormSelections', () => {
+  it('form_value 为数组：多选问题 → selections 收集所有 key', () => {
+    const result = parseFormSelections({ q0: ['0::a', '0::b'] }, 1);
+    expect(result).toEqual([['a', 'b']]);
+  });
+
+  it('form_value 为单字符串：单选问题 → selections=[["y"]]', () => {
+    const result = parseFormSelections({ q0: '0::y' }, 1);
+    expect(result).toEqual([['y']]);
+  });
+
+  it('form_value 为逗号分隔字符串：备用格式 → 拆分后收集 key', () => {
+    const result = parseFormSelections({ q0: '0::a,0::b' }, 1);
+    expect(result).toEqual([['a', 'b']]);
+  });
+
+  it('两问混合：第0问单选字符串 + 第1问数组多选', () => {
+    const result = parseFormSelections({ q0: '0::y', q1: ['1::a', '1::b'] }, 2);
+    expect(result).toEqual([['y'], ['a', 'b']]);
+  });
+
+  it('prefix 不匹配的 token 被过滤掉（防御乱序/跨问混入）', () => {
+    // q0 收到一个 1:: 前缀的混入值，应被忽略
+    const result = parseFormSelections({ q0: ['0::y', '1::x'] }, 1);
+    expect(result).toEqual([['y']]);
+  });
+
+  it('字段缺失时返回空数组', () => {
+    const result = parseFormSelections({}, 2);
+    expect(result).toEqual([[], []]);
+  });
+});
+
+// ─── handleAskCardAction: ask_submit 路径 ─────────────────────────────────────
+
+describe('handleAskCardAction: ask_submit 路径', () => {
+  /** 注册一个真实 pending ask，返回其 askId 和 nonce。 */
+  async function registerTestAsk(overrides: Partial<Parameters<typeof registerAsk>[0]> = {}) {
+    let captured: PendingAsk | undefined;
+    setCardDispatcher({
+      async send(ask) {
+        captured = ask;
+        return { messageId: 'om_ask' };
+      },
+    });
+    registerAsk({
+      larkAppId: 'cli_ask',
+      chatId: 'oc_chat',
+      rootMessageId: 'om_root',
+      sessionId: 'sess-1',
+      approvers: new Set(['ou_owner']),
+      questions: [
+        {
+          prompt: '问题1',
+          options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }],
+          multiSelect: false,
+        },
+      ],
+      timeoutMs: 10_000,
+      ...overrides,
+    });
+    await Promise.resolve();
+    return captured!;
+  }
+
+  it('form_value 为数组（multi_select_static）→ submitAsk 收到 selections=[["a","b"]]', async () => {
+    // 注册含 1 个多选问题的 ask
+    setCardDispatcher({ async send(ask) { return { messageId: 'om_ask' }; } });
+    let capturedAsk: PendingAsk | undefined;
+    setCardDispatcher({
+      async send(ask) {
+        capturedAsk = ask;
+        return { messageId: 'om_ask' };
+      },
+    });
+    registerAsk({
+      larkAppId: 'cli_ask',
+      chatId: 'oc_chat',
+      rootMessageId: 'om_root',
+      sessionId: 'sess-1',
+      approvers: new Set(['ou_owner']),
+      questions: [
+        { prompt: 'q', multiSelect: true, options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }] },
+      ],
+      timeoutMs: 10_000,
+    });
+    await Promise.resolve();
+
+    mockedSubmitAsk.mockReturnValueOnce('accepted');
+
+    handleAskCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: {
+        value: { action: ASK_SUBMIT_ACTION, ask_id: capturedAsk!.askId, nonce: capturedAsk!.nonce },
+        form_value: { q0: ['0::a', '0::b'] },
+      },
+    });
+
+    expect(mockedSubmitAsk).toHaveBeenCalledWith({
+      askId: capturedAsk!.askId,
+      nonce: capturedAsk!.nonce,
+      by: 'ou_owner',
+      selections: [['a', 'b']],
+    });
+  });
+
+  it('form_value 为单字符串（select_static）→ submitAsk 收到 selections=[["y"]]', async () => {
+    const captured = await registerTestAsk();
+
+    mockedSubmitAsk.mockReturnValueOnce('accepted');
+
+    handleAskCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: {
+        value: { action: ASK_SUBMIT_ACTION, ask_id: captured.askId, nonce: captured.nonce },
+        form_value: { q0: '0::y' },
+      },
+    });
+
+    expect(mockedSubmitAsk).toHaveBeenCalledWith({
+      askId: captured.askId,
+      nonce: captured.nonce,
+      by: 'ou_owner',
+      selections: [['y']],
+    });
+  });
+
+  it('form_value 为逗号分隔字符串（备用格式）→ submitAsk 收到 selections=[["a","b"]]', async () => {
+    setCardDispatcher({
+      async send(ask) { return { messageId: 'om_ask' }; },
+    });
+    let capturedAsk: PendingAsk | undefined;
+    setCardDispatcher({
+      async send(ask) {
+        capturedAsk = ask;
+        return { messageId: 'om_ask' };
+      },
+    });
+    registerAsk({
+      larkAppId: 'cli_ask',
+      chatId: 'oc_chat',
+      rootMessageId: 'om_root',
+      sessionId: 'sess-1',
+      approvers: new Set(['ou_owner']),
+      questions: [
+        { prompt: 'q', multiSelect: true, options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }] },
+      ],
+      timeoutMs: 10_000,
+    });
+    await Promise.resolve();
+
+    mockedSubmitAsk.mockReturnValueOnce('accepted');
+
+    handleAskCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: {
+        value: { action: ASK_SUBMIT_ACTION, ask_id: capturedAsk!.askId, nonce: capturedAsk!.nonce },
+        form_value: { q0: '0::a,0::b' },
+      },
+    });
+
+    expect(mockedSubmitAsk).toHaveBeenCalledWith({
+      askId: capturedAsk!.askId,
+      nonce: capturedAsk!.nonce,
+      by: 'ou_owner',
+      selections: [['a', 'b']],
+    });
+  });
+
+  it('两问混合：q0 单选字符串 + q1 数组多选 → selections=[["y"],["a","b"]]', async () => {
+    let capturedAsk: PendingAsk | undefined;
+    setCardDispatcher({
+      async send(ask) {
+        capturedAsk = ask;
+        return { messageId: 'om_ask' };
+      },
+    });
+    registerAsk({
+      larkAppId: 'cli_ask',
+      chatId: 'oc_chat',
+      rootMessageId: 'om_root',
+      sessionId: 'sess-1',
+      approvers: new Set(['ou_owner']),
+      questions: [
+        { prompt: 'q1', multiSelect: false, options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }] },
+        { prompt: 'q2', multiSelect: true, options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }] },
+      ],
+      timeoutMs: 10_000,
+    });
+    await Promise.resolve();
+
+    mockedSubmitAsk.mockReturnValueOnce('accepted');
+
+    handleAskCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: {
+        value: { action: ASK_SUBMIT_ACTION, ask_id: capturedAsk!.askId, nonce: capturedAsk!.nonce },
+        form_value: { q0: '0::y', q1: ['1::a', '1::b'] },
+      },
+    });
+
+    expect(mockedSubmitAsk).toHaveBeenCalledWith({
+      askId: capturedAsk!.askId,
+      nonce: capturedAsk!.nonce,
+      by: 'ou_owner',
+      selections: [['y'], ['a', 'b']],
+    });
+  });
+
+  it('缺少 askId/nonce → 返回 staleToast，submitAsk 不被调用', () => {
+    handleAskCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: {
+        value: { action: ASK_SUBMIT_ACTION },
+        form_value: { q0: '0::y' },
+      },
+    });
+
+    expect(mockedSubmitAsk).not.toHaveBeenCalled();
+  });
+
+  it('缺少 askId/nonce → 返回含"失效"字样的 warning toast', () => {
+    const result = handleAskCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: {
+        value: { action: ASK_SUBMIT_ACTION },
+        form_value: { q0: '0::y' },
+      },
+    });
+
+    expect(result?.toast.content).toContain('失效');
   });
 });
 

--- a/test/ask-card.test.ts
+++ b/test/ask-card.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { PendingAsk } from '../src/core/ask-types.js';
+import {
+  _getPending,
+  _resetForTest,
+  registerAsk,
+  setCardDispatcher,
+} from '../src/core/ask-broker.js';
+import {
+  ASK_SELECT_ACTION,
+  buildAskCard,
+  createLarkAskCardDispatcher,
+  handleAskCardAction,
+} from '../src/im/lark/ask-card.js';
+
+afterEach(() => {
+  _resetForTest();
+});
+
+function pendingAsk(overrides: Partial<PendingAsk> = {}): PendingAsk {
+  return {
+    askId: 'ask-1',
+    nonce: 'nonce-1',
+    larkAppId: 'cli_ask',
+    chatId: 'oc_chat',
+    rootMessageId: 'om_root',
+    sessionId: 'sess-1',
+    approvers: new Set(['ou_owner']),
+    options: [
+      { key: 'deploy', label: '继续发布' },
+      { key: 'rollback', label: '回滚' },
+      { key: 'abort', label: '中止' },
+    ],
+    prompt: '线上 latency 涨了 30%，下一步怎么处理？',
+    createdAt: 1_000,
+    deadlineAt: 1_000 + 300_000,
+    settled: false,
+    ...overrides,
+  };
+}
+
+describe('buildAskCard', () => {
+  it('renders prompt, approvers, and button action values', () => {
+    const card = JSON.parse(buildAskCard(pendingAsk()));
+    const text = JSON.stringify(card);
+
+    expect(card.header.title.content).toBe('botmux ask');
+    expect(text).toContain('线上 latency');
+    expect(card.elements[1].fields[1].text.content).toContain('ou\\_owner');
+    expect(text).toContain(ASK_SELECT_ACTION);
+    expect(text).toContain('"ask_id":"ask-1"');
+    expect(text).toContain('"nonce":"nonce-1"');
+    expect(text).toContain('"key":"deploy"');
+    expect(text).toContain('继续发布');
+  });
+
+  it('wraps options into column rows of at most four buttons', () => {
+    const card = JSON.parse(
+      buildAskCard(
+        pendingAsk({
+          options: [
+            { key: 'a', label: 'A' },
+            { key: 'b', label: 'B' },
+            { key: 'c', label: 'C' },
+            { key: 'd', label: 'D' },
+            { key: 'e', label: 'E' },
+          ],
+        }),
+      ),
+    );
+
+    const rows = card.elements.filter((e: any) => e.tag === 'column_set');
+    expect(rows).toHaveLength(2);
+    expect(rows[0].columns).toHaveLength(4);
+    expect(rows[1].columns).toHaveLength(1);
+  });
+
+  it('renders settled answered cards without live buttons', () => {
+    const card = JSON.parse(
+      buildAskCard(pendingAsk(), {
+        kind: 'answered',
+        selected: 'rollback',
+        by: 'ou_owner',
+        comment: null,
+        timedOut: false,
+      }),
+    );
+    const text = JSON.stringify(card);
+
+    expect(card.header.template).toBe('green');
+    expect(text).toContain('已选择');
+    expect(text).toContain('回滚');
+    expect(text).not.toContain(ASK_SELECT_ACTION);
+  });
+});
+
+describe('handleAskCardAction', () => {
+  it('resolves a pending ask and returns no toast for accepted clicks', async () => {
+    let askId = '';
+    setCardDispatcher({
+      async send(ask) {
+        askId = ask.askId;
+        return { messageId: 'om_ask' };
+      },
+    });
+    const promise = registerAsk({
+      larkAppId: 'cli_ask',
+      chatId: 'oc_chat',
+      rootMessageId: 'om_root',
+      sessionId: 'sess-1',
+      approvers: new Set(['ou_owner']),
+      options: pendingAsk().options,
+      prompt: 'choose',
+      timeoutMs: 10_000,
+    });
+    await Promise.resolve();
+    const pending = _getPending(askId);
+    expect(pending).toBeDefined();
+
+    const result = handleAskCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: {
+        value: {
+          action: ASK_SELECT_ACTION,
+          ask_id: askId,
+          nonce: 'should-not-match',
+          key: 'deploy',
+        },
+      },
+    });
+    expect(result?.toast.content).toContain('失效');
+
+    const accepted = handleAskCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: {
+        value: {
+          action: ASK_SELECT_ACTION,
+          ask_id: askId,
+          nonce: pending!.nonce,
+          key: 'deploy',
+        },
+      },
+    });
+    expect(accepted).toBeUndefined();
+    await expect(promise).resolves.toMatchObject({ kind: 'answered', selected: 'deploy', by: 'ou_owner' });
+  });
+
+  it('returns a warning toast for non-approvers', async () => {
+    let captured: PendingAsk | undefined;
+    setCardDispatcher({
+      async send(ask) {
+        captured = ask;
+        return { messageId: 'om_ask' };
+      },
+    });
+    registerAsk({
+      larkAppId: 'cli_ask',
+      chatId: 'oc_chat',
+      rootMessageId: 'om_root',
+      sessionId: 'sess-1',
+      approvers: new Set(['ou_owner']),
+      options: pendingAsk().options,
+      prompt: 'choose',
+      timeoutMs: 10_000,
+    });
+    await Promise.resolve();
+
+    const result = handleAskCardAction({
+      operator: { open_id: 'ou_intruder' },
+      action: {
+        value: {
+          action: ASK_SELECT_ACTION,
+          ask_id: captured!.askId,
+          nonce: captured!.nonce,
+          key: 'deploy',
+        },
+      },
+    });
+    expect(result?.toast.type).toBe('warning');
+    expect(result?.toast.content).toContain('没有权限');
+  });
+});
+
+describe('createLarkAskCardDispatcher', () => {
+  it('replies into the root thread when rootMessageId exists', async () => {
+    const reply = vi.fn(async () => 'om_reply');
+    const send = vi.fn(async () => 'om_send');
+    const dispatcher = createLarkAskCardDispatcher({ replyMessage: reply as any, sendMessage: send as any });
+
+    await expect(dispatcher.send(pendingAsk())).resolves.toEqual({ messageId: 'om_reply' });
+    expect(reply).toHaveBeenCalledWith('cli_ask', 'om_root', expect.any(String), 'interactive', true);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('sends to chat when rootMessageId is absent and patches on settle', async () => {
+    const update = vi.fn(async () => undefined);
+    const send = vi.fn(async () => 'om_send');
+    const dispatcher = createLarkAskCardDispatcher({ sendMessage: send as any, updateMessage: update as any });
+    const ask = pendingAsk({ rootMessageId: null, cardMessageId: 'om_card' });
+
+    await expect(dispatcher.send(ask)).resolves.toEqual({ messageId: 'om_send' });
+    expect(send).toHaveBeenCalledWith('cli_ask', 'oc_chat', expect.any(String), 'interactive');
+
+    await dispatcher.onSettle?.(ask, {
+      kind: 'timedOut',
+      selected: null,
+      by: null,
+      comment: null,
+      timedOut: true,
+    });
+    expect(update).toHaveBeenCalledWith('cli_ask', 'om_card', expect.stringContaining('超时'));
+  });
+});

--- a/test/ask-card.test.ts
+++ b/test/ask-card.test.ts
@@ -19,6 +19,7 @@ import {
 import {
   ASK_SELECT_ACTION,
   ASK_SUBMIT_ACTION,
+  ASK_TOGGLE_ACTION,
   buildAskCard,
   createLarkAskCardDispatcher,
   handleAskCardAction,
@@ -62,7 +63,7 @@ function makePending(overrides: Partial<PendingAsk> = {}): PendingAsk {
 }
 
 describe('buildAskCard', () => {
-  it('多问卡片：每问一个分区 + 选项组件 + 一个 submit', () => {
+  it('多问卡片：每问一个分区 + option buttons + 一个 submit', () => {
     const ask = makePending({
       questions: [
         { prompt: 'q1', multiSelect: false, options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }] },
@@ -79,9 +80,12 @@ describe('buildAskCard', () => {
     // submit 按钮 action 存在
     expect(blob).toContain(ASK_SUBMIT_ACTION);
 
-    // 每问的选项 value 编码 questionIndex::key
-    expect(blob).toContain('0::y');
-    expect(blob).toContain('1::a');
+    // 每问的选项通过 ask_toggle button 编码 question_index + key
+    expect(blob).toContain(ASK_TOGGLE_ACTION);
+    expect(blob).toContain('"question_index":"0"');
+    expect(blob).toContain('"key":"y"');
+    expect(blob).toContain('"question_index":"1"');
+    expect(blob).toContain('"key":"a"');
   });
 
   it('单问卡片：渲染 prompt、approver、ask_id、nonce', () => {
@@ -95,12 +99,14 @@ describe('buildAskCard', () => {
     expect(metaDiv.fields[1].text.content).toContain('ou\\_owner');
     expect(text).toContain('"ask_id":"ask-1"');
     expect(text).toContain('"nonce":"nonce-1"');
-    // 单选：select_static
-    expect(text).toContain('select_static');
+    // 单问单选：稳定 action button，点击即答；不使用会被飞书 silent-drop 的 form/select_static
+    expect(text).toContain(ASK_SELECT_ACTION);
+    expect(text).not.toContain('select_static');
+    expect(text).not.toContain('"tag":"form"');
     expect(text).toContain('继续发布');
   });
 
-  it('单问单选：使用 select_static，多问多选：使用 multi_select_static', () => {
+  it('多问/多选：使用 buttons + submit，不使用 form/select_static', () => {
     const ask = makePending({
       questions: [
         { prompt: 'single', multiSelect: false, options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }] },
@@ -108,8 +114,12 @@ describe('buildAskCard', () => {
       ],
     });
     const blob = buildAskCard(ask);
-    expect(blob).toContain('"select_static"');
-    expect(blob).toContain('"multi_select_static"');
+    expect(blob).toContain(ASK_TOGGLE_ACTION);
+    expect(blob).toContain(ASK_SUBMIT_ACTION);
+    expect(blob).toContain('☐ A');
+    expect(blob).not.toContain('"select_static"');
+    expect(blob).not.toContain('"multi_select_static"');
+    expect(blob).not.toContain('"tag":"form"');
   });
 
   it('settled 态（answered）：渲染答案摘要、无可点组件', () => {
@@ -190,7 +200,7 @@ describe('handleAskCardAction', () => {
     expect(pending).toBeDefined();
 
     // nonce 不匹配 → stale
-    const stale = handleAskCardAction({
+    const stale = await handleAskCardAction({
       operator: { open_id: 'ou_owner' },
       action: {
         value: {
@@ -204,7 +214,7 @@ describe('handleAskCardAction', () => {
     expect(stale?.toast.content).toContain('失效');
 
     // 正确 nonce + key → accepted
-    const accepted = handleAskCardAction({
+    const accepted = await handleAskCardAction({
       operator: { open_id: 'ou_owner' },
       action: {
         value: {
@@ -238,7 +248,7 @@ describe('handleAskCardAction', () => {
     });
     await Promise.resolve();
 
-    const result = handleAskCardAction({
+    const result = await handleAskCardAction({
       operator: { open_id: 'ou_intruder' },
       action: {
         value: {
@@ -251,6 +261,44 @@ describe('handleAskCardAction', () => {
     });
     expect(result?.toast.type).toBe('warning');
     expect(result?.toast.content).toContain('没有权限');
+  });
+
+  it('ask_toggle：累积勾选并返回原地 patch 卡片，展示已选状态', async () => {
+    let captured: PendingAsk | undefined;
+    setCardDispatcher({
+      async send(ask) {
+        captured = ask;
+        return { messageId: 'om_ask' };
+      },
+    });
+    registerAsk({
+      larkAppId: 'cli_ask',
+      chatId: 'oc_chat',
+      rootMessageId: 'om_root',
+      sessionId: 'sess-1',
+      approvers: new Set(['ou_owner']),
+      questions: [
+        { prompt: 'q', multiSelect: true, options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }] },
+      ],
+      timeoutMs: 10_000,
+    });
+    await Promise.resolve();
+
+    const patch = await handleAskCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: {
+        value: {
+          action: ASK_TOGGLE_ACTION,
+          ask_id: captured!.askId,
+          nonce: captured!.nonce,
+          question_index: '0',
+          key: 'a',
+        },
+      },
+    });
+
+    expect(JSON.stringify(patch)).toContain('☑ A');
+    expect(JSON.stringify(patch)).toContain('☐ B');
   });
 });
 
@@ -477,8 +525,8 @@ describe('handleAskCardAction: ask_submit 路径', () => {
     expect(mockedSubmitAsk).not.toHaveBeenCalled();
   });
 
-  it('缺少 askId/nonce → 返回含"失效"字样的 warning toast', () => {
-    const result = handleAskCardAction({
+  it('缺少 askId/nonce → 返回含"失效"字样的 warning toast', async () => {
+    const result = await handleAskCardAction({
       operator: { open_id: 'ou_owner' },
       action: {
         value: { action: ASK_SUBMIT_ACTION },

--- a/test/ask-card.test.ts
+++ b/test/ask-card.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../src/core/ask-broker.js';
 import {
   ASK_SELECT_ACTION,
+  ASK_SUBMIT_ACTION,
   buildAskCard,
   createLarkAskCardDispatcher,
   handleAskCardAction,
@@ -18,7 +19,8 @@ afterEach(() => {
   _resetForTest();
 });
 
-function pendingAsk(overrides: Partial<PendingAsk> = {}): PendingAsk {
+/** 构造一个带 questions/askId/nonce/deadlineAt/approvers 的 PendingAsk。 */
+function makePending(overrides: Partial<PendingAsk> = {}): PendingAsk {
   return {
     askId: 'ask-1',
     nonce: 'nonce-1',
@@ -27,12 +29,17 @@ function pendingAsk(overrides: Partial<PendingAsk> = {}): PendingAsk {
     rootMessageId: 'om_root',
     sessionId: 'sess-1',
     approvers: new Set(['ou_owner']),
-    options: [
-      { key: 'deploy', label: '继续发布' },
-      { key: 'rollback', label: '回滚' },
-      { key: 'abort', label: '中止' },
+    questions: [
+      {
+        prompt: '线上 latency 涨了 30%，下一步怎么处理？',
+        options: [
+          { key: 'deploy', label: '继续发布' },
+          { key: 'rollback', label: '回滚' },
+          { key: 'abort', label: '中止' },
+        ],
+        multiSelect: false,
+      },
     ],
-    prompt: '线上 latency 涨了 30%，下一步怎么处理？',
     createdAt: 1_000,
     deadlineAt: 1_000 + 300_000,
     settled: false,
@@ -41,62 +48,113 @@ function pendingAsk(overrides: Partial<PendingAsk> = {}): PendingAsk {
 }
 
 describe('buildAskCard', () => {
-  it('renders prompt, approvers, and button action values', () => {
-    const card = JSON.parse(buildAskCard(pendingAsk()));
+  it('多问卡片：每问一个分区 + 选项组件 + 一个 submit', () => {
+    const ask = makePending({
+      questions: [
+        { prompt: 'q1', multiSelect: false, options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }] },
+        { prompt: 'q2', multiSelect: true, options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }] },
+      ],
+    });
+    const json = JSON.parse(buildAskCard(ask));
+    const blob = JSON.stringify(json);
+
+    // 每问的 prompt 文本出现在卡片中
+    expect(blob).toContain('q1');
+    expect(blob).toContain('q2');
+
+    // submit 按钮 action 存在
+    expect(blob).toContain(ASK_SUBMIT_ACTION);
+
+    // 每问的选项 value 编码 questionIndex::key
+    expect(blob).toContain('0::y');
+    expect(blob).toContain('1::a');
+  });
+
+  it('单问卡片：渲染 prompt、approver、ask_id、nonce', () => {
+    const card = JSON.parse(buildAskCard(makePending()));
     const text = JSON.stringify(card);
 
     expect(card.header.title.content).toBe('botmux ask');
     expect(text).toContain('线上 latency');
-    expect(card.elements[1].fields[1].text.content).toContain('ou\\_owner');
-    expect(text).toContain(ASK_SELECT_ACTION);
+    // approver 应在卡片的 meta div fields 中（经 escapeMd 处理后 _ 被转义为 \_）
+    const metaDiv = card.elements[0];
+    expect(metaDiv.fields[1].text.content).toContain('ou\\_owner');
     expect(text).toContain('"ask_id":"ask-1"');
     expect(text).toContain('"nonce":"nonce-1"');
-    expect(text).toContain('"key":"deploy"');
+    // 单选：select_static
+    expect(text).toContain('select_static');
     expect(text).toContain('继续发布');
   });
 
-  it('wraps options into column rows of at most four buttons', () => {
-    const card = JSON.parse(
-      buildAskCard(
-        pendingAsk({
-          options: [
-            { key: 'a', label: 'A' },
-            { key: 'b', label: 'B' },
-            { key: 'c', label: 'C' },
-            { key: 'd', label: 'D' },
-            { key: 'e', label: 'E' },
-          ],
-        }),
-      ),
-    );
-
-    const rows = card.elements.filter((e: any) => e.tag === 'column_set');
-    expect(rows).toHaveLength(2);
-    expect(rows[0].columns).toHaveLength(4);
-    expect(rows[1].columns).toHaveLength(1);
+  it('单问单选：使用 select_static，多问多选：使用 multi_select_static', () => {
+    const ask = makePending({
+      questions: [
+        { prompt: 'single', multiSelect: false, options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }] },
+        { prompt: 'multi', multiSelect: true, options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }] },
+      ],
+    });
+    const blob = buildAskCard(ask);
+    expect(blob).toContain('"select_static"');
+    expect(blob).toContain('"multi_select_static"');
   });
 
-  it('renders settled answered cards without live buttons', () => {
-    const card = JSON.parse(
-      buildAskCard(pendingAsk(), {
-        kind: 'answered',
-        selected: 'rollback',
-        by: 'ou_owner',
-        comment: null,
-        timedOut: false,
-      }),
-    );
-    const text = JSON.stringify(card);
+  it('settled 态（answered）：渲染答案摘要、无可点组件', () => {
+    const ask = makePending({
+      questions: [{ prompt: 'q', multiSelect: false, options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }] }],
+    });
+    const json = JSON.parse(buildAskCard(ask, {
+      kind: 'answered',
+      answers: [['y']],
+      by: 'ou_u',
+      comment: null,
+      timedOut: false,
+    }));
+    const text = JSON.stringify(json);
 
-    expect(card.header.template).toBe('green');
+    expect(json.header.template).toBe('green');
+    // 答案摘要包含"已选择"文字
     expect(text).toContain('已选择');
-    expect(text).toContain('回滚');
+    // 选中标签"是"出现在卡片中
+    expect(text).toContain('是');
+    // 不含任何 action 动作（无可交互组件）
     expect(text).not.toContain(ASK_SELECT_ACTION);
+    expect(text).not.toContain(ASK_SUBMIT_ACTION);
+  });
+
+  it('settled 态（answered）：多问多选答案各问均渲染', () => {
+    const ask = makePending({
+      questions: [
+        { prompt: 'q1', multiSelect: false, options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }] },
+        { prompt: 'q2', multiSelect: true, options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }] },
+      ],
+    });
+    const text = buildAskCard(ask, {
+      kind: 'answered',
+      answers: [['y'], ['a', 'b']],
+      by: 'ou_u',
+      comment: null,
+      timedOut: false,
+    });
+    // 两问的标签均出现
+    expect(text).toContain('是');
+    expect(text).toContain('A');
+    expect(text).toContain('B');
+  });
+
+  it('settled 态（timedOut）：渲染超时文字', () => {
+    const text = buildAskCard(makePending(), {
+      kind: 'timedOut',
+      selected: null,
+      by: null,
+      comment: null,
+      timedOut: true,
+    });
+    expect(text).toContain('超时');
   });
 });
 
 describe('handleAskCardAction', () => {
-  it('resolves a pending ask and returns no toast for accepted clicks', async () => {
+  it('旧单选路径 ask_select：resolves pending ask，返回 undefined（无 toast）', async () => {
     let askId = '';
     setCardDispatcher({
       async send(ask) {
@@ -110,15 +168,15 @@ describe('handleAskCardAction', () => {
       rootMessageId: 'om_root',
       sessionId: 'sess-1',
       approvers: new Set(['ou_owner']),
-      options: pendingAsk().options,
-      prompt: 'choose',
+      questions: makePending().questions,
       timeoutMs: 10_000,
     });
     await Promise.resolve();
     const pending = _getPending(askId);
     expect(pending).toBeDefined();
 
-    const result = handleAskCardAction({
+    // nonce 不匹配 → stale
+    const stale = handleAskCardAction({
       operator: { open_id: 'ou_owner' },
       action: {
         value: {
@@ -129,8 +187,9 @@ describe('handleAskCardAction', () => {
         },
       },
     });
-    expect(result?.toast.content).toContain('失效');
+    expect(stale?.toast.content).toContain('失效');
 
+    // 正确 nonce + key → accepted
     const accepted = handleAskCardAction({
       operator: { open_id: 'ou_owner' },
       action: {
@@ -143,10 +202,10 @@ describe('handleAskCardAction', () => {
       },
     });
     expect(accepted).toBeUndefined();
-    await expect(promise).resolves.toMatchObject({ kind: 'answered', selected: 'deploy', by: 'ou_owner' });
+    await expect(promise).resolves.toMatchObject({ kind: 'answered', answers: [['deploy']], by: 'ou_owner' });
   });
 
-  it('returns a warning toast for non-approvers', async () => {
+  it('旧单选路径 ask_select：非授权人返回 warning toast', async () => {
     let captured: PendingAsk | undefined;
     setCardDispatcher({
       async send(ask) {
@@ -160,8 +219,7 @@ describe('handleAskCardAction', () => {
       rootMessageId: 'om_root',
       sessionId: 'sess-1',
       approvers: new Set(['ou_owner']),
-      options: pendingAsk().options,
-      prompt: 'choose',
+      questions: makePending().questions,
       timeoutMs: 10_000,
     });
     await Promise.resolve();
@@ -188,7 +246,7 @@ describe('createLarkAskCardDispatcher', () => {
     const send = vi.fn(async () => 'om_send');
     const dispatcher = createLarkAskCardDispatcher({ replyMessage: reply as any, sendMessage: send as any });
 
-    await expect(dispatcher.send(pendingAsk())).resolves.toEqual({ messageId: 'om_reply' });
+    await expect(dispatcher.send(makePending())).resolves.toEqual({ messageId: 'om_reply' });
     expect(reply).toHaveBeenCalledWith('cli_ask', 'om_root', expect.any(String), 'interactive', true);
     expect(send).not.toHaveBeenCalled();
   });
@@ -197,7 +255,7 @@ describe('createLarkAskCardDispatcher', () => {
     const update = vi.fn(async () => undefined);
     const send = vi.fn(async () => 'om_send');
     const dispatcher = createLarkAskCardDispatcher({ sendMessage: send as any, updateMessage: update as any });
-    const ask = pendingAsk({ rootMessageId: null, cardMessageId: 'om_card' });
+    const ask = makePending({ rootMessageId: null, cardMessageId: 'om_card' });
 
     await expect(dispatcher.send(ask)).resolves.toEqual({ messageId: 'om_send' });
     expect(send).toHaveBeenCalledWith('cli_ask', 'oc_chat', expect.any(String), 'interactive');

--- a/test/ask-hook-claude.test.ts
+++ b/test/ask-hook-claude.test.ts
@@ -153,28 +153,20 @@ describe('Claude Code hook adapter', () => {
     });
   });
 
-  describe('passthrough', () => {
-    it('返回 PreToolUse permissionDecision=allow + 空 answers 的 directive', () => {
+  describe('passthrough（真放行 = 空 stdout）', () => {
+    // 回归保护（Codex P1.1）：passthrough 必须是 no-op（空串），绝不能输出
+    // allow + updatedInput——否则会用空 answers 顶替 tool input，把提问"答空"掉。
+    it('非 askUserQuestion 事件 → 空字符串', () => {
       const payload = { ...(loadFixture('claude-ask-single.json') as any), hook_event_name: 'PreToolUse' };
-      const directive = JSON.parse(claude.passthrough(payload)) as Record<string, unknown>;
-      const hso = directive.hookSpecificOutput as Record<string, unknown>;
-      expect(hso.hookEventName).toBe('PreToolUse');
-      expect(hso.permissionDecision).toBe('allow');
-      const updatedInput = hso.updatedInput as Record<string, unknown>;
-      expect(updatedInput.answers).toEqual({});
+      expect(claude.passthrough(payload)).toBe('');
     });
 
-    it('passthrough 包含原始 questions（让 Claude 知道 context）', () => {
+    it('askUserQuestion 原始 payload → 仍是空字符串，不含 updatedInput/allow', () => {
       const payload = loadFixture('claude-ask-single.json') as any;
-      const directive = JSON.parse(claude.passthrough(payload)) as Record<string, unknown>;
-      const updatedInput = (directive.hookSpecificOutput as any).decision.updatedInput as Record<string, unknown>;
-      expect(Array.isArray(updatedInput.questions)).toBe(true);
-      expect((updatedInput.questions as unknown[]).length).toBeGreaterThan(0);
-    });
-
-    it('输出为合法 JSON 字符串', () => {
-      const payload = loadFixture('claude-ask-single.json');
-      expect(() => JSON.parse(claude.passthrough(payload))).not.toThrow();
+      const out = claude.passthrough(payload);
+      expect(out).toBe('');
+      expect(out).not.toContain('updatedInput');
+      expect(out).not.toContain('allow');
     });
   });
 });

--- a/test/ask-hook-claude.test.ts
+++ b/test/ask-hook-claude.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { join, dirname } from 'path';
+import { readFileSync } from 'fs';
+import claude from '../src/core/ask-hook/claude-code.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadFixture(name: string): unknown {
+  const p = join(__dirname, 'fixtures', name);
+  return JSON.parse(readFileSync(p, 'utf-8'));
+}
+
+describe('Claude Code hook adapter', () => {
+  describe('parseQuestions', () => {
+    it('PermissionRequest + AskUserQuestion → 解析出 questions', () => {
+      const payload = loadFixture('claude-ask-single.json');
+      const parsed = claude.parseQuestions(payload);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.questions).toHaveLength(1);
+      expect(parsed!.questions[0].prompt).toBe('继续部署还是回滚？');
+      expect(parsed!.questions[0].multiSelect).toBe(false);
+      expect(parsed!.questions[0].options).toHaveLength(2);
+      expect(parsed!.questions[0].options[0].key).toBe('继续部署');
+      expect(parsed!.questions[0].options[0].label).toBe('继续部署');
+      expect(parsed!.questions[0].options[1].key).toBe('回滚');
+    });
+
+    it('多问题 + multiSelect=true → 正确解析', () => {
+      const payload = loadFixture('claude-ask-multi.json');
+      const parsed = claude.parseQuestions(payload);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.questions).toHaveLength(2);
+      expect(parsed!.questions[0].prompt).toBe('选择测试环境？');
+      expect(parsed!.questions[0].multiSelect).toBe(true);
+      expect(parsed!.questions[0].options).toHaveLength(3);
+      expect(parsed!.questions[1].prompt).toBe('通知方式？');
+      expect(parsed!.questions[1].multiSelect).toBe(false);
+    });
+
+    it('option 无独立 key → key 等于 label', () => {
+      const payload = loadFixture('claude-ask-single.json');
+      const parsed = claude.parseQuestions(payload)!;
+      for (const opt of parsed.questions[0].options) {
+        expect(opt.key).toBe(opt.label);
+      }
+    });
+
+    it('非 AskUserQuestion → null', () => {
+      const payload = { hook_event_name: 'PreToolUse', tool_name: 'Bash' };
+      expect(claude.parseQuestions(payload)).toBeNull();
+    });
+
+    it('非 PermissionRequest → null', () => {
+      const payload = {
+        hook_event_name: 'PostToolUse',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions: [{ question: '?', multiSelect: false, options: [] }] },
+      };
+      expect(claude.parseQuestions(payload)).toBeNull();
+    });
+
+    it('tool_input.questions 为空数组 → null', () => {
+      const payload = {
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions: [] },
+      };
+      expect(claude.parseQuestions(payload)).toBeNull();
+    });
+
+    it('null / undefined → null', () => {
+      expect(claude.parseQuestions(null)).toBeNull();
+      expect(claude.parseQuestions(undefined)).toBeNull();
+    });
+
+    it('raw 保存原始 payload', () => {
+      const payload = loadFixture('claude-ask-single.json');
+      const parsed = claude.parseQuestions(payload)!;
+      expect(parsed.raw).toBe(payload);
+    });
+  });
+
+  describe('formatAnswer', () => {
+    it('单问单选 → hookSpecificOutput.decision.updatedInput.answers 含选中 label', () => {
+      const payload = loadFixture('claude-ask-single.json');
+      const parsed = claude.parseQuestions(payload)!;
+      const directiveStr = claude.formatAnswer([['继续部署']], parsed);
+      const directive = JSON.parse(directiveStr) as Record<string, unknown>;
+      const hso = directive.hookSpecificOutput as Record<string, unknown>;
+      expect(hso.hookEventName).toBe('PermissionRequest');
+      const decision = hso.decision as Record<string, unknown>;
+      expect(decision.behavior).toBe('allow');
+      const updatedInput = decision.updatedInput as Record<string, unknown>;
+      expect(updatedInput.answers).toMatchObject({ '继续部署还是回滚？': '继续部署' });
+    });
+
+    it('多选 → answers 值为逗号拼接', () => {
+      const payload = loadFixture('claude-ask-multi.json');
+      const parsed = claude.parseQuestions(payload)!;
+      const directiveStr = claude.formatAnswer([['staging', 'canary'], ['飞书']], parsed);
+      const directive = JSON.parse(directiveStr) as Record<string, unknown>;
+      const updatedInput = (directive.hookSpecificOutput as any).decision.updatedInput as Record<string, unknown>;
+      const answers = updatedInput.answers as Record<string, string>;
+      expect(answers['选择测试环境？']).toBe('staging, canary');
+      expect(answers['通知方式？']).toBe('飞书');
+    });
+
+    it('未答的 question → answers 不含该 key', () => {
+      const payload = loadFixture('claude-ask-multi.json');
+      const parsed = claude.parseQuestions(payload)!;
+      // 只答第一问，不答第二问
+      const directiveStr = claude.formatAnswer([['staging'], []], parsed);
+      const directive = JSON.parse(directiveStr) as Record<string, unknown>;
+      const answers = (directive.hookSpecificOutput as any).decision.updatedInput.answers as Record<string, string>;
+      expect('选择测试环境？' in answers).toBe(true);
+      expect('通知方式？' in answers).toBe(false);
+    });
+
+    it('updatedInput.questions 回传原始 questions 数组', () => {
+      const payload = loadFixture('claude-ask-single.json') as any;
+      const parsed = claude.parseQuestions(payload)!;
+      const directiveStr = claude.formatAnswer([['继续部署']], parsed);
+      const directive = JSON.parse(directiveStr) as Record<string, unknown>;
+      const updatedInput = (directive.hookSpecificOutput as any).decision.updatedInput as Record<string, unknown>;
+      expect(updatedInput.questions).toEqual(payload.tool_input.questions);
+    });
+
+    it('输出为合法 JSON 字符串', () => {
+      const payload = loadFixture('claude-ask-single.json');
+      const parsed = claude.parseQuestions(payload)!;
+      expect(() => JSON.parse(claude.formatAnswer([['继续部署']], parsed))).not.toThrow();
+    });
+  });
+
+  describe('passthrough', () => {
+    it('返回 behavior=allow + 空 answers 的 directive', () => {
+      const payload = loadFixture('claude-ask-single.json');
+      const directive = JSON.parse(claude.passthrough(payload)) as Record<string, unknown>;
+      const hso = directive.hookSpecificOutput as Record<string, unknown>;
+      expect(hso.hookEventName).toBe('PermissionRequest');
+      const decision = hso.decision as Record<string, unknown>;
+      expect(decision.behavior).toBe('allow');
+      const updatedInput = decision.updatedInput as Record<string, unknown>;
+      expect(updatedInput.answers).toEqual({});
+    });
+
+    it('passthrough 包含原始 questions（让 Claude 知道 context）', () => {
+      const payload = loadFixture('claude-ask-single.json') as any;
+      const directive = JSON.parse(claude.passthrough(payload)) as Record<string, unknown>;
+      const updatedInput = (directive.hookSpecificOutput as any).decision.updatedInput as Record<string, unknown>;
+      expect(Array.isArray(updatedInput.questions)).toBe(true);
+      expect((updatedInput.questions as unknown[]).length).toBeGreaterThan(0);
+    });
+
+    it('输出为合法 JSON 字符串', () => {
+      const payload = loadFixture('claude-ask-single.json');
+      expect(() => JSON.parse(claude.passthrough(payload))).not.toThrow();
+    });
+  });
+});

--- a/test/ask-hook-claude.test.ts
+++ b/test/ask-hook-claude.test.ts
@@ -14,8 +14,8 @@ function loadFixture(name: string): unknown {
 
 describe('Claude Code hook adapter', () => {
   describe('parseQuestions', () => {
-    it('PermissionRequest + AskUserQuestion → 解析出 questions', () => {
-      const payload = loadFixture('claude-ask-single.json');
+    it('PreToolUse + AskUserQuestion → 解析出 questions', () => {
+      const payload = { ...(loadFixture('claude-ask-single.json') as any), hook_event_name: 'PreToolUse' };
       const parsed = claude.parseQuestions(payload);
       expect(parsed).not.toBeNull();
       expect(parsed!.questions).toHaveLength(1);
@@ -25,6 +25,13 @@ describe('Claude Code hook adapter', () => {
       expect(parsed!.questions[0].options[0].key).toBe('继续部署');
       expect(parsed!.questions[0].options[0].label).toBe('继续部署');
       expect(parsed!.questions[0].options[1].key).toBe('回滚');
+    });
+
+    it('PermissionRequest + AskUserQuestion → 迁移期兼容解析', () => {
+      const payload = loadFixture('claude-ask-single.json');
+      const parsed = claude.parseQuestions(payload);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.questions[0].prompt).toBe('继续部署还是回滚？');
     });
 
     it('多问题 + multiSelect=true → 正确解析', () => {
@@ -52,7 +59,7 @@ describe('Claude Code hook adapter', () => {
       expect(claude.parseQuestions(payload)).toBeNull();
     });
 
-    it('非 PermissionRequest → null', () => {
+    it('非 PreToolUse/PermissionRequest → null', () => {
       const payload = {
         hook_event_name: 'PostToolUse',
         tool_name: 'AskUserQuestion',
@@ -83,7 +90,19 @@ describe('Claude Code hook adapter', () => {
   });
 
   describe('formatAnswer', () => {
-    it('单问单选 → hookSpecificOutput.decision.updatedInput.answers 含选中 label', () => {
+    it('单问单选 → PreToolUse hookSpecificOutput.updatedInput.answers 含选中 label', () => {
+      const payload = { ...(loadFixture('claude-ask-single.json') as any), hook_event_name: 'PreToolUse' };
+      const parsed = claude.parseQuestions(payload)!;
+      const directiveStr = claude.formatAnswer([['继续部署']], parsed);
+      const directive = JSON.parse(directiveStr) as Record<string, unknown>;
+      const hso = directive.hookSpecificOutput as Record<string, unknown>;
+      expect(hso.hookEventName).toBe('PreToolUse');
+      expect(hso.permissionDecision).toBe('allow');
+      const updatedInput = hso.updatedInput as Record<string, unknown>;
+      expect(updatedInput.answers).toMatchObject({ '继续部署还是回滚？': '继续部署' });
+    });
+
+    it('PermissionRequest payload → 保持旧 decision.behavior 输出', () => {
       const payload = loadFixture('claude-ask-single.json');
       const parsed = claude.parseQuestions(payload)!;
       const directiveStr = claude.formatAnswer([['继续部署']], parsed);
@@ -135,14 +154,13 @@ describe('Claude Code hook adapter', () => {
   });
 
   describe('passthrough', () => {
-    it('返回 behavior=allow + 空 answers 的 directive', () => {
-      const payload = loadFixture('claude-ask-single.json');
+    it('返回 PreToolUse permissionDecision=allow + 空 answers 的 directive', () => {
+      const payload = { ...(loadFixture('claude-ask-single.json') as any), hook_event_name: 'PreToolUse' };
       const directive = JSON.parse(claude.passthrough(payload)) as Record<string, unknown>;
       const hso = directive.hookSpecificOutput as Record<string, unknown>;
-      expect(hso.hookEventName).toBe('PermissionRequest');
-      const decision = hso.decision as Record<string, unknown>;
-      expect(decision.behavior).toBe('allow');
-      const updatedInput = decision.updatedInput as Record<string, unknown>;
+      expect(hso.hookEventName).toBe('PreToolUse');
+      expect(hso.permissionDecision).toBe('allow');
+      const updatedInput = hso.updatedInput as Record<string, unknown>;
       expect(updatedInput.answers).toEqual({});
     });
 

--- a/test/ask-hook-codex.test.ts
+++ b/test/ask-hook-codex.test.ts
@@ -53,26 +53,19 @@ describe('Codex hook adapter', () => {
     });
   });
 
-  describe('passthrough', () => {
-    it('PermissionRequest → hookSpecificOutput.decision.behavior=allow', () => {
-      const payload = loadFixture('codex-permission-single.json');
-      const directive = JSON.parse(codex.passthrough(payload)) as Record<string, unknown>;
-      const hso = directive.hookSpecificOutput as Record<string, unknown>;
-      expect(hso.hookEventName).toBe('PermissionRequest');
-      const decision = hso.decision as Record<string, unknown>;
-      // TODO(dogfood): 验证 codex directive 形状
-      expect(decision.behavior).toBe('allow');
+  describe('passthrough（真放行 = 空 stdout）', () => {
+    // 回归保护（Codex P1.1）：passthrough = 空串、不做任何 decision。
+    // 不输出 allow/deny——那是替用户自动决策，并非"放行不干预"。
+    it('PermissionRequest payload → 空字符串', () => {
+      expect(codex.passthrough(loadFixture('codex-permission-single.json'))).toBe('');
     });
 
-    it('输出为合法 JSON 字符串', () => {
-      const payload = loadFixture('codex-permission-single.json');
-      expect(() => JSON.parse(codex.passthrough(payload))).not.toThrow();
-    });
-
-    it('passthrough 不含 deny', () => {
-      const payload = loadFixture('codex-permission-single.json');
-      const directiveStr = codex.passthrough(payload);
-      expect(directiveStr).not.toContain('deny');
+    it('不含 allow / deny / decision', () => {
+      const out = codex.passthrough(loadFixture('codex-permission-single.json'));
+      expect(out).toBe('');
+      expect(out).not.toContain('allow');
+      expect(out).not.toContain('deny');
+      expect(out).not.toContain('decision');
     });
   });
 });

--- a/test/ask-hook-codex.test.ts
+++ b/test/ask-hook-codex.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'url';
+import { join, dirname } from 'path';
+import { readFileSync } from 'fs';
+import codex from '../src/core/ask-hook/codex.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadFixture(name: string): unknown {
+  const p = join(__dirname, 'fixtures', name);
+  return JSON.parse(readFileSync(p, 'utf-8'));
+}
+
+describe('Codex hook adapter', () => {
+  describe('parseQuestions', () => {
+    it('PermissionRequest (Bash) → null（Codex 无结构化 AskUserQuestion hook）', () => {
+      const payload = loadFixture('codex-permission-single.json');
+      expect(codex.parseQuestions(payload)).toBeNull();
+    });
+
+    it('任意 hook_event_name → null', () => {
+      expect(codex.parseQuestions({ hook_event_name: 'PermissionRequest', tool_name: 'Bash' })).toBeNull();
+      expect(codex.parseQuestions({ hook_event_name: 'SessionStart', session_id: 'x' })).toBeNull();
+      expect(codex.parseQuestions({ hook_event_name: 'Stop', session_id: 'x' })).toBeNull();
+    });
+
+    it('null / undefined → null', () => {
+      expect(codex.parseQuestions(null)).toBeNull();
+      expect(codex.parseQuestions(undefined)).toBeNull();
+    });
+  });
+
+  describe('formatAnswer', () => {
+    it('返回合法 JSON 字符串', () => {
+      // parseQuestions 总返回 null，formatAnswer 通常不被调用，
+      // 但接口约定仍需满足
+      const fakePayload = { hook_event_name: 'PermissionRequest', tool_name: 'Bash' };
+      const fakeParsed = {
+        questions: [],
+        raw: fakePayload,
+      };
+      const directiveStr = codex.formatAnswer([], fakeParsed);
+      expect(() => JSON.parse(directiveStr)).not.toThrow();
+    });
+
+    it('输出包含 hookSpecificOutput.decision.behavior=allow', () => {
+      const fakeParsed = { questions: [], raw: {} };
+      const directive = JSON.parse(codex.formatAnswer([], fakeParsed)) as Record<string, unknown>;
+      const hso = directive.hookSpecificOutput as Record<string, unknown>;
+      const decision = hso.decision as Record<string, unknown>;
+      // TODO(dogfood): 验证 codex directive 形状
+      expect(decision.behavior).toBe('allow');
+    });
+  });
+
+  describe('passthrough', () => {
+    it('PermissionRequest → hookSpecificOutput.decision.behavior=allow', () => {
+      const payload = loadFixture('codex-permission-single.json');
+      const directive = JSON.parse(codex.passthrough(payload)) as Record<string, unknown>;
+      const hso = directive.hookSpecificOutput as Record<string, unknown>;
+      expect(hso.hookEventName).toBe('PermissionRequest');
+      const decision = hso.decision as Record<string, unknown>;
+      // TODO(dogfood): 验证 codex directive 形状
+      expect(decision.behavior).toBe('allow');
+    });
+
+    it('输出为合法 JSON 字符串', () => {
+      const payload = loadFixture('codex-permission-single.json');
+      expect(() => JSON.parse(codex.passthrough(payload))).not.toThrow();
+    });
+
+    it('passthrough 不含 deny', () => {
+      const payload = loadFixture('codex-permission-single.json');
+      const directiveStr = codex.passthrough(payload);
+      expect(directiveStr).not.toContain('deny');
+    });
+  });
+});

--- a/test/ask-hook-opencode.test.ts
+++ b/test/ask-hook-opencode.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'url';
+import { join, dirname } from 'path';
+import { readFileSync } from 'fs';
+import opencode from '../src/core/ask-hook/opencode.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadFixture(name: string): unknown {
+  const p = join(__dirname, 'fixtures', name);
+  return JSON.parse(readFileSync(p, 'utf-8'));
+}
+
+describe('OpenCode hook adapter', () => {
+  describe('parseQuestions', () => {
+    it('QuestionAsked + 结构化 questions → 解析出 questions', () => {
+      const payload = loadFixture('opencode-ask-single.json');
+      const parsed = opencode.parseQuestions(payload);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.questions).toHaveLength(1);
+      expect(parsed!.questions[0].prompt).toBe('选择部署策略？');
+      expect(parsed!.questions[0].multiSelect).toBe(false);
+      expect(parsed!.questions[0].options).toHaveLength(2);
+      expect(parsed!.questions[0].options[0].key).toBe('蓝绿部署');
+      expect(parsed!.questions[0].options[0].label).toBe('蓝绿部署');
+      expect(parsed!.questions[0].options[1].key).toBe('滚动更新');
+    });
+
+    it('多问题 + multiple=true → 正确解析', () => {
+      const payload = loadFixture('opencode-ask-multi.json');
+      const parsed = opencode.parseQuestions(payload);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.questions).toHaveLength(2);
+      expect(parsed!.questions[0].prompt).toBe('选择测试范围？');
+      expect(parsed!.questions[0].multiSelect).toBe(true);
+      expect(parsed!.questions[0].options).toHaveLength(3);
+      expect(parsed!.questions[1].prompt).toBe('通知谁？');
+      expect(parsed!.questions[1].multiSelect).toBe(false);
+    });
+
+    it('option 无独立 key → key 等于 label', () => {
+      const payload = loadFixture('opencode-ask-single.json');
+      const parsed = opencode.parseQuestions(payload)!;
+      for (const opt of parsed.questions[0].options) {
+        expect(opt.key).toBe(opt.label);
+      }
+    });
+
+    it('旧版兼容：无 tool_input.questions → 使用 question_text', () => {
+      const payload = {
+        hook_event_name: 'QuestionAsked',
+        session_id: 'opencode-ses_x',
+        question_text: '你确定吗？',
+        _opencode_request_id: 'q_x',
+      };
+      const parsed = opencode.parseQuestions(payload);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.questions).toHaveLength(1);
+      expect(parsed!.questions[0].prompt).toBe('你确定吗？');
+      expect(parsed!.questions[0].options).toHaveLength(0);
+    });
+
+    it('非 QuestionAsked 事件 → null', () => {
+      const payload = {
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        session_id: 'opencode-x',
+      };
+      expect(opencode.parseQuestions(payload)).toBeNull();
+    });
+
+    it('PreToolUse → null', () => {
+      expect(opencode.parseQuestions({ hook_event_name: 'PreToolUse', session_id: 'opencode-x' })).toBeNull();
+    });
+
+    it('null / undefined → null', () => {
+      expect(opencode.parseQuestions(null)).toBeNull();
+      expect(opencode.parseQuestions(undefined)).toBeNull();
+    });
+
+    it('raw 保存原始 payload', () => {
+      const payload = loadFixture('opencode-ask-single.json');
+      const parsed = opencode.parseQuestions(payload)!;
+      expect(parsed.raw).toBe(payload);
+    });
+  });
+
+  describe('formatAnswer', () => {
+    it('单问单选 → { type: "answer", answers: [["蓝绿部署"]] }', () => {
+      const payload = loadFixture('opencode-ask-single.json');
+      const parsed = opencode.parseQuestions(payload)!;
+      const directiveStr = opencode.formatAnswer([['蓝绿部署']], parsed);
+      const directive = JSON.parse(directiveStr) as Record<string, unknown>;
+      expect(directive.type).toBe('answer');
+      expect(directive.answers).toEqual([['蓝绿部署']]);
+    });
+
+    it('多问多选 → answers[i] 含各问题选中的 label 数组', () => {
+      const payload = loadFixture('opencode-ask-multi.json');
+      const parsed = opencode.parseQuestions(payload)!;
+      const directiveStr = opencode.formatAnswer([['单元测试', 'E2E 测试'], ['研发团队']], parsed);
+      const directive = JSON.parse(directiveStr) as Record<string, unknown>;
+      expect(directive.type).toBe('answer');
+      expect(directive.answers).toEqual([['单元测试', 'E2E 测试'], ['研发团队']]);
+    });
+
+    it('跳过某问题 → 对应 question 填 [""]', () => {
+      const payload = loadFixture('opencode-ask-multi.json');
+      const parsed = opencode.parseQuestions(payload)!;
+      // 只答第二问，第一问留空
+      const directiveStr = opencode.formatAnswer([[], ['QA 团队']], parsed);
+      const directive = JSON.parse(directiveStr) as Record<string, unknown>;
+      expect(Array.isArray(directive.answers)).toBe(true);
+      const answers = directive.answers as string[][];
+      expect(answers[0]).toEqual(['']);
+      expect(answers[1]).toEqual(['QA 团队']);
+    });
+
+    it('旧版（无结构化 questions）→ { type: "answer", text: "..." }', () => {
+      const payload = {
+        hook_event_name: 'QuestionAsked',
+        session_id: 'opencode-ses_x',
+        question_text: '你确定吗？',
+        _opencode_request_id: 'q_x',
+      };
+      const parsed = opencode.parseQuestions(payload)!;
+      const directiveStr = opencode.formatAnswer([['确定']], parsed);
+      const directive = JSON.parse(directiveStr) as Record<string, unknown>;
+      expect(directive.type).toBe('answer');
+      expect(typeof directive.text).toBe('string');
+      expect(directive.text).toContain('确定');
+    });
+
+    it('输出为合法 JSON 字符串', () => {
+      const payload = loadFixture('opencode-ask-single.json');
+      const parsed = opencode.parseQuestions(payload)!;
+      expect(() => JSON.parse(opencode.formatAnswer([['蓝绿部署']], parsed))).not.toThrow();
+    });
+  });
+
+  describe('passthrough', () => {
+    it('单问 → { type: "answer", answers: [[""]] }', () => {
+      const payload = loadFixture('opencode-ask-single.json');
+      const directive = JSON.parse(opencode.passthrough(payload)) as Record<string, unknown>;
+      expect(directive.type).toBe('answer');
+      expect(directive.answers).toEqual([['']]);
+    });
+
+    it('多问 → answers 长度等于 question 数量，每项为 [""]', () => {
+      const payload = loadFixture('opencode-ask-multi.json');
+      const directive = JSON.parse(opencode.passthrough(payload)) as Record<string, unknown>;
+      expect(directive.type).toBe('answer');
+      const answers = directive.answers as string[][];
+      expect(answers).toHaveLength(2);
+      expect(answers[0]).toEqual(['']);
+      expect(answers[1]).toEqual(['']);
+    });
+
+    it('无 questions 结构 → [[""]]（兜底 1 个 question）', () => {
+      const payload = { hook_event_name: 'QuestionAsked', session_id: 'opencode-x', question_text: 'ok?' };
+      const directive = JSON.parse(opencode.passthrough(payload)) as Record<string, unknown>;
+      expect(directive.type).toBe('answer');
+      expect(directive.answers).toEqual([['']]);
+    });
+
+    it('输出为合法 JSON 字符串', () => {
+      const payload = loadFixture('opencode-ask-single.json');
+      expect(() => JSON.parse(opencode.passthrough(payload))).not.toThrow();
+    });
+  });
+});

--- a/test/ask-hook-opencode.test.ts
+++ b/test/ask-hook-opencode.test.ts
@@ -138,34 +138,22 @@ describe('OpenCode hook adapter', () => {
     });
   });
 
-  describe('passthrough', () => {
-    it('单问 → { type: "answer", answers: [[""]] }', () => {
-      const payload = loadFixture('opencode-ask-single.json');
-      const directive = JSON.parse(opencode.passthrough(payload)) as Record<string, unknown>;
-      expect(directive.type).toBe('answer');
-      expect(directive.answers).toEqual([['']]);
+  describe('passthrough（真放行 = 空 stdout）', () => {
+    // 回归保护（Codex P1.1）：passthrough = 空串。插件见空 stdout → 返回 undefined →
+    // OpenCode 原生处理；绝不输出 {type:'answer',...} 用空答案顶替提问。
+    it('单问 payload → 空字符串', () => {
+      expect(opencode.passthrough(loadFixture('opencode-ask-single.json'))).toBe('');
     });
 
-    it('多问 → answers 长度等于 question 数量，每项为 [""]', () => {
-      const payload = loadFixture('opencode-ask-multi.json');
-      const directive = JSON.parse(opencode.passthrough(payload)) as Record<string, unknown>;
-      expect(directive.type).toBe('answer');
-      const answers = directive.answers as string[][];
-      expect(answers).toHaveLength(2);
-      expect(answers[0]).toEqual(['']);
-      expect(answers[1]).toEqual(['']);
+    it('多问 payload → 空字符串', () => {
+      expect(opencode.passthrough(loadFixture('opencode-ask-multi.json'))).toBe('');
     });
 
-    it('无 questions 结构 → [[""]]（兜底 1 个 question）', () => {
+    it('无 questions 结构 → 空字符串，不含 answer', () => {
       const payload = { hook_event_name: 'QuestionAsked', session_id: 'opencode-x', question_text: 'ok?' };
-      const directive = JSON.parse(opencode.passthrough(payload)) as Record<string, unknown>;
-      expect(directive.type).toBe('answer');
-      expect(directive.answers).toEqual([['']]);
-    });
-
-    it('输出为合法 JSON 字符串', () => {
-      const payload = loadFixture('opencode-ask-single.json');
-      expect(() => JSON.parse(opencode.passthrough(payload))).not.toThrow();
+      const out = opencode.passthrough(payload);
+      expect(out).toBe('');
+      expect(out).not.toContain('answer');
     });
   });
 });

--- a/test/ask-types-shape.test.ts
+++ b/test/ask-types-shape.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { toLegacySelected, type AskQuestion, type AskResult } from '../src/core/ask-types.js';
+
+describe('ask-types 多问多选模型', () => {
+  it('toLegacySelected: 单问单选答案映射回旧 selected 字符串', () => {
+    const answered: AskResult = {
+      kind: 'answered',
+      answers: [['yes']],
+      by: 'ou_x',
+      comment: null,
+      timedOut: false,
+    };
+    expect(toLegacySelected(answered)).toBe('yes');
+  });
+
+  it('toLegacySelected: 多选或多问返回 null（旧单选语义不适用）', () => {
+    const multi: AskResult = {
+      kind: 'answered', answers: [['a', 'b']], by: 'ou_x', comment: null, timedOut: false,
+    };
+    expect(toLegacySelected(multi)).toBeNull();
+  });
+
+  it('AskQuestion 结构含 prompt/options/multiSelect', () => {
+    const q: AskQuestion = { prompt: 'go?', options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }], multiSelect: false };
+    expect(q.options).toHaveLength(2);
+  });
+});

--- a/test/builtin-skills.test.ts
+++ b/test/builtin-skills.test.ts
@@ -83,3 +83,17 @@ describe('built-in botmux-workflow-create skill', () => {
     expect(skill!.content).toContain('default');
   });
 });
+
+describe('built-in botmux-ask skill', () => {
+  it('documents canonical buttons usage and stdout contract', () => {
+    const skill = BUILTIN_SKILLS.find(s => s.name === 'botmux-ask');
+    expect(skill).toBeDefined();
+    expect(skill!.content).toContain('botmux ask buttons');
+    expect(skill!.content).toContain('--options');
+    expect(skill!.content).toContain('key=label');
+    expect(skill!.content).toContain('stdout');
+    expect(skill!.content).toContain('exit 124');
+    expect(skill!.content).toContain('--json');
+    expect(skill!.content).toContain('botmux send');
+  });
+});

--- a/test/builtin-skills.test.ts
+++ b/test/builtin-skills.test.ts
@@ -84,12 +84,12 @@ describe('built-in botmux-workflow-create skill', () => {
   });
 });
 
-describe('botmux-ask skill 退役', () => {
-  it('BUILTIN_SKILLS 不再包含 botmux-ask（改由 hook 接管）', () => {
+describe('botmux-ask skill 条件兜底（hook 优先 + 非 hook CLI 保留）', () => {
+  it('不在 BUILTIN_SKILLS（不再无条件装到所有 CLI）', () => {
     expect(BUILTIN_SKILLS.find(s => s.name === 'botmux-ask')).toBeUndefined();
   });
 
-  it('RETIRED_SKILL_NAMES 包含 botmux-ask（清理已安装的旧 SKILL.md）', () => {
-    expect(RETIRED_SKILL_NAMES).toContain('botmux-ask');
+  it('不在 RETIRED_SKILL_NAMES（改为按 CLI 条件管理，非全量退役）', () => {
+    expect(RETIRED_SKILL_NAMES).not.toContain('botmux-ask');
   });
 });

--- a/test/builtin-skills.test.ts
+++ b/test/builtin-skills.test.ts
@@ -94,6 +94,9 @@ describe('built-in botmux-ask skill', () => {
     expect(skill!.content).toContain('stdout');
     expect(skill!.content).toContain('exit 124');
     expect(skill!.content).toContain('--json');
+    expect(skill!.content).toContain('覆盖所有结果类型');
+    expect(skill!.content).toContain('timedOut');
+    expect(skill!.content).toContain('selected:null');
     expect(skill!.content).toContain('botmux send');
   });
 });

--- a/test/builtin-skills.test.ts
+++ b/test/builtin-skills.test.ts
@@ -84,19 +84,12 @@ describe('built-in botmux-workflow-create skill', () => {
   });
 });
 
-describe('built-in botmux-ask skill', () => {
-  it('documents canonical buttons usage and stdout contract', () => {
-    const skill = BUILTIN_SKILLS.find(s => s.name === 'botmux-ask');
-    expect(skill).toBeDefined();
-    expect(skill!.content).toContain('botmux ask buttons');
-    expect(skill!.content).toContain('--options');
-    expect(skill!.content).toContain('key=label');
-    expect(skill!.content).toContain('stdout');
-    expect(skill!.content).toContain('exit 124');
-    expect(skill!.content).toContain('--json');
-    expect(skill!.content).toContain('覆盖所有结果类型');
-    expect(skill!.content).toContain('timedOut');
-    expect(skill!.content).toContain('selected:null');
-    expect(skill!.content).toContain('botmux send');
+describe('botmux-ask skill 退役', () => {
+  it('BUILTIN_SKILLS 不再包含 botmux-ask（改由 hook 接管）', () => {
+    expect(BUILTIN_SKILLS.find(s => s.name === 'botmux-ask')).toBeUndefined();
+  });
+
+  it('RETIRED_SKILL_NAMES 包含 botmux-ask（清理已安装的旧 SKILL.md）', () => {
+    expect(RETIRED_SKILL_NAMES).toContain('botmux-ask');
   });
 });

--- a/test/claude-settings-hook.test.ts
+++ b/test/claude-settings-hook.test.ts
@@ -1,8 +1,11 @@
 /**
  * claude-settings-hook.test.ts
  *
- * 验证 Claude Code adapter 的 buildArgs 通过 --settings 内联 JSON 注入
- * PreToolUse hook，而非依赖全局 settings.json。
+ * 验证 Claude Code adapter：
+ * - askUserQuestion hook **不**注入进程级 --settings（避免只对 botmux spawn 的会话生效）；
+ * - 而是声明 hookInstall 写全局 ~/.claude/settings.json —— 这样 adopt 模式（botmux 接管
+ *   别处已启动、拿不到 --settings 的 claude 会话）也能让那条会话读到 hook。
+ * - 进程级 --settings 仅保留 bypassPermissions / skipDangerousMode，不被挤掉。
  */
 import { describe, it, expect, vi } from 'vitest';
 
@@ -13,39 +16,31 @@ vi.mock('node:child_process', () => ({
 
 import { createClaudeCodeAdapter } from '../src/adapters/cli/claude-code.js';
 
-describe('claude-code buildArgs —— --settings 内联 hook 注入', () => {
+describe('claude-code —— hook 走全局 settings、不进 --settings（适配 adopt 模式）', () => {
   const adapter = createClaudeCodeAdapter('/usr/bin/claude');
 
-  it('--settings 中包含 hooks.PreToolUse，hook command 指向 cli.js 并以 hook claude-code 结尾', () => {
+  it('--settings 内联 JSON 不含 hooks（hook 改由全局 settings.json 承载）', () => {
     const args = adapter.buildArgs({ sessionId: 's', resume: false, locale: 'zh' });
     const idx = args.indexOf('--settings');
     expect(idx).toBeGreaterThanOrEqual(0);
-
     const parsed = JSON.parse(args[idx + 1]);
-
-    // hook 配置存在
-    const preToolUse = parsed.hooks?.PreToolUse;
-    expect(Array.isArray(preToolUse)).toBe(true);
-    expect(preToolUse.length).toBeGreaterThanOrEqual(1);
-
-    // 第一个 group 的第一条 hook command
-    const hookEntry = preToolUse[0]?.hooks?.[0];
-    expect(hookEntry).toBeDefined();
-    expect(hookEntry.command).toContain('cli.js');
-    expect(hookEntry.command.endsWith('hook claude-code')).toBe(true);
+    expect(parsed.hooks).toBeUndefined();
   });
 
-  it('--settings 合并后 permissions.defaultMode 仍为 bypassPermissions', () => {
+  it('--settings 仍保留 bypassPermissions 与 skipDangerousModePermissionPrompt', () => {
     const args = adapter.buildArgs({ sessionId: 's', resume: false });
     const idx = args.indexOf('--settings');
     const parsed = JSON.parse(args[idx + 1]);
     expect(parsed.permissions?.defaultMode).toBe('bypassPermissions');
+    expect(parsed.skipDangerousModePermissionPrompt).toBe(true);
   });
 
-  it('--settings 合并后 skipDangerousModePermissionPrompt 仍为 true', () => {
-    const args = adapter.buildArgs({ sessionId: 's', resume: false });
-    const idx = args.indexOf('--settings');
-    const parsed = JSON.parse(args[idx + 1]);
-    expect(parsed.skipDangerousModePermissionPrompt).toBe(true);
+  it('adapter 声明 hookInstall 指向全局 ~/.claude/settings.json', () => {
+    expect(adapter.hookInstall).toEqual({
+      configPath: '~/.claude/settings.json',
+      format: 'claude-settings',
+    });
+    // 仍标记 asksViaHook（驱动「不装 botmux-ask skill 兜底」）
+    expect(adapter.asksViaHook).toBe(true);
   });
 });

--- a/test/claude-settings-hook.test.ts
+++ b/test/claude-settings-hook.test.ts
@@ -1,0 +1,51 @@
+/**
+ * claude-settings-hook.test.ts
+ *
+ * 验证 Claude Code adapter 的 buildArgs 通过 --settings 内联 JSON 注入
+ * PreToolUse hook，而非依赖全局 settings.json。
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock child_process.execSync 使 resolveCommand() 直接返回命令名。
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(() => ''),
+}));
+
+import { createClaudeCodeAdapter } from '../src/adapters/cli/claude-code.js';
+
+describe('claude-code buildArgs —— --settings 内联 hook 注入', () => {
+  const adapter = createClaudeCodeAdapter('/usr/bin/claude');
+
+  it('--settings 中包含 hooks.PreToolUse，hook command 指向 cli.js 并以 hook claude-code 结尾', () => {
+    const args = adapter.buildArgs({ sessionId: 's', resume: false, locale: 'zh' });
+    const idx = args.indexOf('--settings');
+    expect(idx).toBeGreaterThanOrEqual(0);
+
+    const parsed = JSON.parse(args[idx + 1]);
+
+    // hook 配置存在
+    const preToolUse = parsed.hooks?.PreToolUse;
+    expect(Array.isArray(preToolUse)).toBe(true);
+    expect(preToolUse.length).toBeGreaterThanOrEqual(1);
+
+    // 第一个 group 的第一条 hook command
+    const hookEntry = preToolUse[0]?.hooks?.[0];
+    expect(hookEntry).toBeDefined();
+    expect(hookEntry.command).toContain('cli.js');
+    expect(hookEntry.command.endsWith('hook claude-code')).toBe(true);
+  });
+
+  it('--settings 合并后 permissions.defaultMode 仍为 bypassPermissions', () => {
+    const args = adapter.buildArgs({ sessionId: 's', resume: false });
+    const idx = args.indexOf('--settings');
+    const parsed = JSON.parse(args[idx + 1]);
+    expect(parsed.permissions?.defaultMode).toBe('bypassPermissions');
+  });
+
+  it('--settings 合并后 skipDangerousModePermissionPrompt 仍为 true', () => {
+    const args = adapter.buildArgs({ sessionId: 's', resume: false });
+    const idx = args.indexOf('--settings');
+    const parsed = JSON.parse(args[idx + 1]);
+    expect(parsed.skipDangerousModePermissionPrompt).toBe(true);
+  });
+});

--- a/test/cmd-hook.test.ts
+++ b/test/cmd-hook.test.ts
@@ -1,0 +1,193 @@
+/**
+ * cmd-hook.test.ts
+ *
+ * 测试 runHook 核心逻辑（依赖注入方式，不依赖真实 daemon / env / stdin）。
+ * cmdHook 本身仅作薄包装（读 stdin + 调 runHook），不在本文件中直接测试。
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { runHook } from '../src/cli.js';
+import type { AskResult } from '../src/core/ask-types.js';
+import claudeAdapter from '../src/core/ask-hook/claude-code.js';
+
+// ── Claude AskUserQuestion payload fixture ─────────────────────────────────────
+
+const claudeAskPayload = {
+  hook_event_name: 'PermissionRequest',
+  tool_name: 'AskUserQuestion',
+  tool_input: {
+    questions: [
+      {
+        question: '继续还是取消？',
+        multiSelect: false,
+        options: [{ label: '继续' }, { label: '取消' }],
+      },
+    ],
+  },
+};
+
+// 非 askUserQuestion 的 Claude payload（PreToolUse）
+const claudePreToolPayload = {
+  hook_event_name: 'PreToolUse',
+  tool_name: 'Bash',
+  tool_input: { command: 'echo hi' },
+};
+
+// 完整的 botmux env
+const FULL_ENV: Record<string, string | undefined> = {
+  BOTMUX_SESSION_ID: 'sess_test_1',
+  BOTMUX_CHAT_ID: 'oc_chatxxx',
+  BOTMUX_LARK_APP_ID: 'cli_appxxx',
+  BOTMUX_ROOT_MESSAGE_ID: 'om_rootxxx',
+};
+
+// 构造一个正常返回 answered 的 postAskFn stub
+function makeAnsweredStub(answers: string[][]): () => Promise<AskResult> {
+  return async () => ({
+    kind: 'answered',
+    answers: answers as ReadonlyArray<ReadonlyArray<string>>,
+    by: 'ou_user1',
+    comment: null,
+    timedOut: false,
+  });
+}
+
+// 构造一个抛出错误的 postAskFn stub
+function makeThrowingStub(msg = 'daemon unreachable'): () => Promise<AskResult> {
+  return async () => {
+    throw Object.assign(new Error(msg), { exitCode: 3 });
+  };
+}
+
+// ── 测试 ───────────────────────────────────────────────────────────────────────
+
+describe('runHook', () => {
+  describe('(a) Claude AskUserQuestion + answered stub → stdout 含答案', () => {
+    it('formatAnswer 结果写入 stdout', async () => {
+      const stub = makeAnsweredStub([['继续']]);
+      const result = await runHook(claudeAskPayload, FULL_ENV, stub, 'claude-code');
+      expect(result.stdout).toBeTruthy();
+      // 输出应为合法 JSON
+      const directive = JSON.parse(result.stdout);
+      // Claude directive 应包含 hookSpecificOutput
+      expect(JSON.stringify(directive)).toContain('继续');
+    });
+  });
+
+  describe('(b) postAskFn 抛错 → 输出 passthrough，不抛出', () => {
+    it('任何 postAsk 错误均优雅放行', async () => {
+      const stub = makeThrowingStub('daemon unreachable');
+      // 不应抛出
+      let result: Awaited<ReturnType<typeof runHook>>;
+      expect(async () => {
+        result = await runHook(claudeAskPayload, FULL_ENV, stub, 'claude-code');
+      }).not.toThrow();
+
+      result = await runHook(claudeAskPayload, FULL_ENV, stub, 'claude-code');
+      // 输出应为 passthrough directive（behavior=allow + 空 answers）
+      const expected = claudeAdapter.passthrough(claudeAskPayload);
+      expect(result.stdout).toBe(expected);
+    });
+  });
+
+  describe('(c) 非 askUserQuestion payload → passthrough', () => {
+    it('PreToolUse payload → parseQuestions 返回 null → passthrough', async () => {
+      const stub = makeAnsweredStub([['继续']]);
+      const result = await runHook(claudePreToolPayload, FULL_ENV, stub, 'claude-code');
+      // 应为 passthrough（stub 不应被调用）
+      const expected = claudeAdapter.passthrough(claudePreToolPayload);
+      expect(result.stdout).toBe(expected);
+    });
+  });
+
+  describe('env 缺失 → passthrough 放行', () => {
+    it('BOTMUX_SESSION_ID 缺失 → passthrough', async () => {
+      const stub = makeAnsweredStub([['继续']]);
+      const env = { ...FULL_ENV, BOTMUX_SESSION_ID: undefined };
+      const result = await runHook(claudeAskPayload, env, stub, 'claude-code');
+      const expected = claudeAdapter.passthrough(claudeAskPayload);
+      expect(result.stdout).toBe(expected);
+    });
+
+    it('BOTMUX_CHAT_ID 缺失 → passthrough', async () => {
+      const stub = makeAnsweredStub([['继续']]);
+      const env = { ...FULL_ENV, BOTMUX_CHAT_ID: undefined };
+      const result = await runHook(claudeAskPayload, env, stub, 'claude-code');
+      const expected = claudeAdapter.passthrough(claudeAskPayload);
+      expect(result.stdout).toBe(expected);
+    });
+  });
+
+  describe('BOTMUX_WORKFLOW=1 → passthrough（不弹 UI）', () => {
+    it('workflow gate → passthrough', async () => {
+      const stub = vi.fn(makeAnsweredStub([['继续']]));
+      const env = { ...FULL_ENV, BOTMUX_WORKFLOW: '1' };
+      const result = await runHook(claudeAskPayload, env, stub, 'claude-code');
+      // stub 不应被调用
+      expect(stub).not.toHaveBeenCalled();
+      const expected = claudeAdapter.passthrough(claudeAskPayload);
+      expect(result.stdout).toBe(expected);
+    });
+  });
+
+  describe('未知 cliId → stdout 为空字符串', () => {
+    it('getHookAdapter 返回 undefined → stdout=""', async () => {
+      const stub = makeAnsweredStub([['继续']]);
+      const result = await runHook(claudeAskPayload, FULL_ENV, stub, 'unknown-cli-xyz');
+      expect(result.stdout).toBe('');
+    });
+  });
+
+  describe('timedOut / invalidated → passthrough', () => {
+    it('timedOut → passthrough', async () => {
+      const timedOutStub = async (): Promise<AskResult> => ({
+        kind: 'timedOut',
+        selected: null,
+        by: null,
+        comment: null,
+        timedOut: true,
+      });
+      const result = await runHook(claudeAskPayload, FULL_ENV, timedOutStub, 'claude-code');
+      const expected = claudeAdapter.passthrough(claudeAskPayload);
+      expect(result.stdout).toBe(expected);
+    });
+
+    it('invalidated → passthrough', async () => {
+      const invalidatedStub = async (): Promise<AskResult> => ({
+        kind: 'invalidated',
+        reason: 'test_invalidated',
+        selected: null,
+        by: null,
+        comment: null,
+        timedOut: false,
+      });
+      const result = await runHook(claudeAskPayload, FULL_ENV, invalidatedStub, 'claude-code');
+      const expected = claudeAdapter.passthrough(claudeAskPayload);
+      expect(result.stdout).toBe(expected);
+    });
+  });
+
+  describe('BOTMUX_ASK_TIMEOUT_MS env', () => {
+    it('有效正整数 → 覆盖默认 timeout 传给 postAskFn', async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      const captureStub = async (body: Record<string, unknown>): Promise<AskResult> => {
+        capturedBody = body;
+        return { kind: 'answered', answers: [['继续']], by: 'ou_u', comment: null, timedOut: false };
+      };
+      const env = { ...FULL_ENV, BOTMUX_ASK_TIMEOUT_MS: '7200000' };
+      await runHook(claudeAskPayload, env, captureStub, 'claude-code');
+      expect(capturedBody?.timeoutMs).toBe(7_200_000);
+    });
+
+    it('无效值 → 使用默认 3600000', async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      const captureStub = async (body: Record<string, unknown>): Promise<AskResult> => {
+        capturedBody = body;
+        return { kind: 'answered', answers: [['继续']], by: 'ou_u', comment: null, timedOut: false };
+      };
+      const env = { ...FULL_ENV, BOTMUX_ASK_TIMEOUT_MS: 'not_a_number' };
+      await runHook(claudeAskPayload, env, captureStub, 'claude-code');
+      expect(capturedBody?.timeoutMs).toBe(3_600_000);
+    });
+  });
+});

--- a/test/cmd-hook.test.ts
+++ b/test/cmd-hook.test.ts
@@ -6,9 +6,9 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
 import { runHook } from '../src/cli.js';
 import type { AskResult } from '../src/core/ask-types.js';
-import claudeAdapter from '../src/core/ask-hook/claude-code.js';
 
 // ── Claude AskUserQuestion payload fixture ─────────────────────────────────────
 
@@ -85,8 +85,9 @@ describe('runHook', () => {
 
       result = await runHook(claudeAskPayload, FULL_ENV, stub, 'claude-code');
       // 输出应为 passthrough directive（behavior=allow + 空 answers）
-      const expected = claudeAdapter.passthrough(claudeAskPayload);
-      expect(result.stdout).toBe(expected);
+      // 回归（Codex P1.1）：放行 = 空 stdout，绝不输出 directive。直接断言空串，
+      // 不与实现的 passthrough() 比较，避免实现回退时测试跟着移动。
+      expect(result.stdout).toBe('');
     });
   });
 
@@ -95,8 +96,7 @@ describe('runHook', () => {
       const stub = makeAnsweredStub([['继续']]);
       const result = await runHook(claudePreToolPayload, FULL_ENV, stub, 'claude-code');
       // 应为 passthrough（stub 不应被调用）
-      const expected = claudeAdapter.passthrough(claudePreToolPayload);
-      expect(result.stdout).toBe(expected);
+      expect(result.stdout).toBe('');
     });
   });
 
@@ -105,16 +105,18 @@ describe('runHook', () => {
       const stub = makeAnsweredStub([['继续']]);
       const env = { ...FULL_ENV, BOTMUX_SESSION_ID: undefined };
       const result = await runHook(claudeAskPayload, env, stub, 'claude-code');
-      const expected = claudeAdapter.passthrough(claudeAskPayload);
-      expect(result.stdout).toBe(expected);
+      // 回归（Codex P1.1）：放行 = 空 stdout，绝不输出 directive。直接断言空串，
+      // 不与实现的 passthrough() 比较，避免实现回退时测试跟着移动。
+      expect(result.stdout).toBe('');
     });
 
     it('BOTMUX_CHAT_ID 缺失 → passthrough', async () => {
       const stub = makeAnsweredStub([['继续']]);
       const env = { ...FULL_ENV, BOTMUX_CHAT_ID: undefined };
       const result = await runHook(claudeAskPayload, env, stub, 'claude-code');
-      const expected = claudeAdapter.passthrough(claudeAskPayload);
-      expect(result.stdout).toBe(expected);
+      // 回归（Codex P1.1）：放行 = 空 stdout，绝不输出 directive。直接断言空串，
+      // 不与实现的 passthrough() 比较，避免实现回退时测试跟着移动。
+      expect(result.stdout).toBe('');
     });
   });
 
@@ -125,8 +127,9 @@ describe('runHook', () => {
       const result = await runHook(claudeAskPayload, env, stub, 'claude-code');
       // stub 不应被调用
       expect(stub).not.toHaveBeenCalled();
-      const expected = claudeAdapter.passthrough(claudeAskPayload);
-      expect(result.stdout).toBe(expected);
+      // 回归（Codex P1.1）：放行 = 空 stdout，绝不输出 directive。直接断言空串，
+      // 不与实现的 passthrough() 比较，避免实现回退时测试跟着移动。
+      expect(result.stdout).toBe('');
     });
   });
 
@@ -148,8 +151,9 @@ describe('runHook', () => {
         timedOut: true,
       });
       const result = await runHook(claudeAskPayload, FULL_ENV, timedOutStub, 'claude-code');
-      const expected = claudeAdapter.passthrough(claudeAskPayload);
-      expect(result.stdout).toBe(expected);
+      // 回归（Codex P1.1）：放行 = 空 stdout，绝不输出 directive。直接断言空串，
+      // 不与实现的 passthrough() 比较，避免实现回退时测试跟着移动。
+      expect(result.stdout).toBe('');
     });
 
     it('invalidated → passthrough', async () => {
@@ -162,8 +166,9 @@ describe('runHook', () => {
         timedOut: false,
       });
       const result = await runHook(claudeAskPayload, FULL_ENV, invalidatedStub, 'claude-code');
-      const expected = claudeAdapter.passthrough(claudeAskPayload);
-      expect(result.stdout).toBe(expected);
+      // 回归（Codex P1.1）：放行 = 空 stdout，绝不输出 directive。直接断言空串，
+      // 不与实现的 passthrough() 比较，避免实现回退时测试跟着移动。
+      expect(result.stdout).toBe('');
     });
   });
 
@@ -188,6 +193,25 @@ describe('runHook', () => {
       const env = { ...FULL_ENV, BOTMUX_ASK_TIMEOUT_MS: 'not_a_number' };
       await runHook(claudeAskPayload, env, captureStub, 'claude-code');
       expect(capturedBody?.timeoutMs).toBe(3_600_000);
+    });
+  });
+
+  // 语义③（Codex 建议）：workflow subagent 里 `botmux ask` 必须被拒绝——审批走
+  // humanGate/decision 进 event log，不能用 ad-hoc ask 绕过。cmdAsk 用 process.exit(2)
+  // 拒绝，未导出、无法直接单测，这里用源码断言钉住该 gate，防被静默移除。
+  describe('语义③：workflow 里 botmux ask 拒绝（源码 gate 守卫）', () => {
+    it('cmdAsk 含 BOTMUX_WORKFLOW gate + exit 2 拒绝', () => {
+      const src = readFileSync(
+        new URL('../src/cli.ts', import.meta.url),
+        'utf-8',
+      );
+      const cmdAskIdx = src.indexOf('async function cmdAsk(');
+      expect(cmdAskIdx).toBeGreaterThanOrEqual(0);
+      // gate 在 cmdAsk 函数体起始处
+      const region = src.slice(cmdAskIdx, cmdAskIdx + 1500);
+      expect(region).toContain("process.env.BOTMUX_WORKFLOW === '1'");
+      expect(region).toContain('process.exit(2)');
+      expect(region.toLowerCase()).toContain('refused');
     });
   });
 });

--- a/test/cmd-hook.test.ts
+++ b/test/cmd-hook.test.ts
@@ -101,10 +101,15 @@ describe('runHook', () => {
   });
 
   describe('env 缺失 → passthrough 放行', () => {
+    // 注：runHook 第 5 参数是可选的 resolveAdoptRouteFn。
+    // 这里传 null-returning stub，确保测试不依赖真实 daemon 环境，
+    // 并且仍然覆盖 "adopt 也找不到 → passthrough" 的分支。
+    const nullAdoptResolver = async () => null;
+
     it('BOTMUX_SESSION_ID 缺失 → passthrough', async () => {
       const stub = makeAnsweredStub([['继续']]);
       const env = { ...FULL_ENV, BOTMUX_SESSION_ID: undefined };
-      const result = await runHook(claudeAskPayload, env, stub, 'claude-code');
+      const result = await runHook(claudeAskPayload, env, stub, 'claude-code', nullAdoptResolver);
       // 回归（Codex P1.1）：放行 = 空 stdout，绝不输出 directive。直接断言空串，
       // 不与实现的 passthrough() 比较，避免实现回退时测试跟着移动。
       expect(result.stdout).toBe('');
@@ -113,9 +118,63 @@ describe('runHook', () => {
     it('BOTMUX_CHAT_ID 缺失 → passthrough', async () => {
       const stub = makeAnsweredStub([['继续']]);
       const env = { ...FULL_ENV, BOTMUX_CHAT_ID: undefined };
-      const result = await runHook(claudeAskPayload, env, stub, 'claude-code');
+      const result = await runHook(claudeAskPayload, env, stub, 'claude-code', nullAdoptResolver);
       // 回归（Codex P1.1）：放行 = 空 stdout，绝不输出 directive。直接断言空串，
       // 不与实现的 passthrough() 比较，避免实现回退时测试跟着移动。
+      expect(result.stdout).toBe('');
+    });
+  });
+
+  describe('env 缺失 + adopt 路由命中 → 路由到 adopt 会话', () => {
+    const adoptRoute = {
+      sessionId: 's-adopt',
+      chatId: 'c-adopt',
+      larkAppId: 'a-adopt',
+      rootMessageId: 'om_x',
+    };
+
+    it('adopt 命中 → postAskFn 收到 adopt 会话的 body', async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      const captureStub = async (body: Record<string, unknown>) => {
+        capturedBody = body;
+        return { kind: 'answered' as const, answers: [['yes']], by: 'ou_u', comment: null, timedOut: false };
+      };
+      const adoptResolver = async () => adoptRoute;
+      // env 全缺失
+      const env: Record<string, string | undefined> = {};
+      const result = await runHook(claudeAskPayload, env, captureStub, 'claude-code', adoptResolver);
+      // body 应使用 adopt 路由信息
+      expect(capturedBody?.sessionId).toBe('s-adopt');
+      expect(capturedBody?.larkAppId).toBe('a-adopt');
+      expect(capturedBody?.chatId).toBe('c-adopt');
+      expect(capturedBody?.rootMessageId).toBe('om_x');
+      // 应输出答案 directive（非空）
+      expect(result.stdout).toBeTruthy();
+      const directive = JSON.parse(result.stdout);
+      expect(JSON.stringify(directive)).toContain('yes');
+    });
+
+    it('adopt 命中 → stdout 含 answer directive', async () => {
+      const captureStub = async (body: Record<string, unknown>) => {
+        void body;
+        return { kind: 'answered' as const, answers: [['yes']], by: 'ou_u', comment: null, timedOut: false };
+      };
+      const adoptResolver = async () => adoptRoute;
+      const env: Record<string, string | undefined> = {};
+      const result = await runHook(claudeAskPayload, env, captureStub, 'claude-code', adoptResolver);
+      expect(result.stdout).toBeTruthy();
+    });
+  });
+
+  describe('env 缺失 + adopt 路由返回 null → passthrough', () => {
+    // Codex 钉桩：祖先里有非 adopt PID、daemon 全 404（resolver 返回 null）时，
+    // 必须既不调用 postAsk、stdout 又为空——确保"真·非 botmux 会话"完全不受影响。
+    it('adopt 未命中 → postAsk 不被调用 且 stdout === ""', async () => {
+      const postAsk = vi.fn(makeAnsweredStub([['继续']]));
+      const nullAdoptResolver = async () => null;
+      const env: Record<string, string | undefined> = {};
+      const result = await runHook(claudeAskPayload, env, postAsk, 'claude-code', nullAdoptResolver);
+      expect(postAsk).not.toHaveBeenCalled();
       expect(result.stdout).toBe('');
     });
   });

--- a/test/ensure-ask-skill.test.ts
+++ b/test/ensure-ask-skill.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ensureAskSkill } from '../src/skills/installer.js';
+import { ASK_SKILL, ASK_SKILL_NAME } from '../src/skills/definitions.js';
+
+// hook 优先 + 非 hook CLI 兜底：
+//   install=true（无 hook 的 CLI）→ 写入 botmux-ask SKILL.md
+//   install=false（有 hook 的 CLI）→ 删除 botmux-ask（避免与 hook 双重弹卡）
+describe('ensureAskSkill', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'ask-skill-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  const skillFile = () => join(dir, ASK_SKILL_NAME, 'SKILL.md');
+
+  it('install=true：写入 botmux-ask/SKILL.md，内容为 ASK_SKILL', () => {
+    ensureAskSkill('codex', dir, true);
+    expect(existsSync(skillFile())).toBe(true);
+    expect(readFileSync(skillFile(), 'utf-8')).toBe(ASK_SKILL);
+  });
+
+  it('install=false：删除已存在的 botmux-ask（hook 接管的 CLI）', () => {
+    mkdirSync(join(dir, ASK_SKILL_NAME), { recursive: true });
+    writeFileSync(skillFile(), ASK_SKILL, 'utf-8');
+    ensureAskSkill('claude-code', dir, false);
+    expect(existsSync(join(dir, ASK_SKILL_NAME))).toBe(false);
+  });
+
+  it('install=false 且本就不存在：no-op，不报错', () => {
+    expect(() => ensureAskSkill('claude-code', dir, false)).not.toThrow();
+    expect(existsSync(join(dir, ASK_SKILL_NAME))).toBe(false);
+  });
+
+  it('skillsDir 为 undefined：直接跳过', () => {
+    expect(() => ensureAskSkill('cursor', undefined, true)).not.toThrow();
+  });
+});

--- a/test/fixtures/claude-ask-multi.json
+++ b/test/fixtures/claude-ask-multi.json
@@ -1,0 +1,26 @@
+{
+  "hook_event_name": "PermissionRequest",
+  "tool_name": "AskUserQuestion",
+  "session_id": "abc123",
+  "tool_input": {
+    "questions": [
+      {
+        "question": "选择测试环境？",
+        "multiSelect": true,
+        "options": [
+          { "label": "staging" },
+          { "label": "canary" },
+          { "label": "production" }
+        ]
+      },
+      {
+        "question": "通知方式？",
+        "multiSelect": false,
+        "options": [
+          { "label": "飞书" },
+          { "label": "邮件" }
+        ]
+      }
+    ]
+  }
+}

--- a/test/fixtures/claude-ask-single.json
+++ b/test/fixtures/claude-ask-single.json
@@ -1,0 +1,17 @@
+{
+  "hook_event_name": "PermissionRequest",
+  "tool_name": "AskUserQuestion",
+  "session_id": "abc123",
+  "tool_input": {
+    "questions": [
+      {
+        "question": "继续部署还是回滚？",
+        "multiSelect": false,
+        "options": [
+          { "label": "继续部署" },
+          { "label": "回滚" }
+        ]
+      }
+    ]
+  }
+}

--- a/test/fixtures/codex-permission-single.json
+++ b/test/fixtures/codex-permission-single.json
@@ -1,0 +1,10 @@
+{
+  "hook_event_name": "PermissionRequest",
+  "tool_name": "Bash",
+  "session_id": "codex-sess-001",
+  "tool_input": {
+    "description": "Run npm install",
+    "command": "npm install"
+  },
+  "permission_mode": "default"
+}

--- a/test/fixtures/opencode-ask-multi.json
+++ b/test/fixtures/opencode-ask-multi.json
@@ -1,0 +1,30 @@
+{
+  "hook_event_name": "QuestionAsked",
+  "session_id": "opencode-ses_abc123",
+  "question_id": "q_002",
+  "question_text": "选择测试范围？; 通知谁？",
+  "tool_input": {
+    "questions": [
+      {
+        "question": "选择测试范围？",
+        "header": "测试配置",
+        "options": [
+          { "label": "单元测试" },
+          { "label": "集成测试" },
+          { "label": "E2E 测试" }
+        ],
+        "multiple": true
+      },
+      {
+        "question": "通知谁？",
+        "header": "通知设置",
+        "options": [
+          { "label": "研发团队" },
+          { "label": "QA 团队" }
+        ],
+        "multiple": false
+      }
+    ]
+  },
+  "_opencode_request_id": "q_002"
+}

--- a/test/fixtures/opencode-ask-single.json
+++ b/test/fixtures/opencode-ask-single.json
@@ -1,0 +1,20 @@
+{
+  "hook_event_name": "QuestionAsked",
+  "session_id": "opencode-ses_abc123",
+  "question_id": "q_001",
+  "question_text": "选择部署策略？",
+  "tool_input": {
+    "questions": [
+      {
+        "question": "选择部署策略？",
+        "header": "部署配置",
+        "options": [
+          { "label": "蓝绿部署", "description": "零停机" },
+          { "label": "滚动更新", "description": "逐步切流" }
+        ],
+        "multiple": false
+      }
+    ]
+  },
+  "_opencode_request_id": "q_001"
+}

--- a/test/hook-command.test.ts
+++ b/test/hook-command.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { hookCommandFor } from '../src/core/worker-pool.js';
+
+// 回归保护：hook 命令必须指向 cli.js（有 `hook` 子命令分发），
+// 绝不能指向 index-daemon.js（只 startDaemon、不处理 hook）。
+// 该 bug 在 daemon 进程里用 process.argv[1] 时会出现——daemon 的 argv[1]
+// 是 index-daemon.js。源码与 npm global 安装都受影响。
+describe('hookCommandFor', () => {
+  it('指向 cli.js 而非 index-daemon.js，并以 hook 子命令结尾', () => {
+    const cmd = hookCommandFor('claude-code');
+    expect(cmd).toContain('cli.js');
+    expect(cmd).not.toContain('index-daemon');
+    expect(cmd.endsWith('hook claude-code')).toBe(true);
+  });
+
+  it('Node 路径与 cli 路径均加引号（容忍空格），cliId 透传', () => {
+    const cmd = hookCommandFor('opencode');
+    expect(cmd).toMatch(/^".+" ".+cli\.js" hook opencode$/);
+  });
+});

--- a/test/hook-command.test.ts
+++ b/test/hook-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { hookCommandFor } from '../src/core/worker-pool.js';
+import { hookCommandFor } from '../src/adapters/hook-command.js';
 
 // 回归保护：hook 命令必须指向 cli.js（有 `hook` 子命令分发），
 // 绝不能指向 index-daemon.js（只 startDaemon、不处理 hook）。

--- a/test/hook-installer.test.ts
+++ b/test/hook-installer.test.ts
@@ -152,6 +152,8 @@ describe('installHook — claude-settings', () => {
 describe('installHook — opencode-plugin', () => {
   let tmpDir: string;
   let configPath: string;
+  // 注意：opencode-plugin 路径下 installHook 会忽略传入的 hookCommand 字符串，
+  // 改用 hookCommandParts('opencode') 自行解析 argv（见 P1.2 修复）。这里传个占位即可。
   const hookCommand = '/usr/bin/node /path/to/cli.js hook opencode';
 
   beforeEach(() => {
@@ -159,12 +161,19 @@ describe('installHook — opencode-plugin', () => {
     configPath = join(tmpDir, '.config', 'opencode', 'plugin', 'botmux-ask.js');
   });
 
-  it('写入包含 hookCommand 的插件文件', () => {
+  it('插件用 argv 形式 spawnSync(cmd, args)，不拆 shell 字符串（Codex P1.2 回归）', () => {
     installHook('opencode', { configPath, format: 'opencode-plugin' }, hookCommand);
-
     const content = readFileSync(configPath, 'utf-8');
-    expect(content).toContain(hookCommand);
+
     expect(content).toContain('question.asked');
+    expect(content).toContain('spawnSync(');
+    // args 以 JSON 数组嵌入，包含 hook 子命令与 cliId
+    expect(content).toContain('"hook"');
+    expect(content).toContain('"opencode"');
+    expect(content).toContain('cli.js');
+    // 绝不能再出现「把带引号命令字符串 .split(" ")」的旧写法
+    expect(content).not.toContain('.split(');
+    expect(content).not.toContain('parts[0]');
   });
 
   it('幂等——二次调用后文件内容与第一次完全相同', () => {

--- a/test/hook-installer.test.ts
+++ b/test/hook-installer.test.ts
@@ -1,0 +1,151 @@
+/**
+ * hook-installer.test.ts
+ *
+ * 测试 installHook 对 claude-settings 格式的行为：
+ *   (a) 写入 PermissionRequest hook 指向给定 hookCommand
+ *   (b) 幂等——二次调用内容不变
+ *   (c) 既有无关配置保留（合并而非覆盖）
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { installHook } from '../src/adapters/hook-installer.js';
+
+// ─── 辅助：在临时目录创建独立的 configPath ─────────────────────────────────
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), 'botmux-hook-test-'));
+}
+
+// ─── claude-settings 格式 ─────────────────────────────────────────────────────
+
+describe('installHook — claude-settings', () => {
+  let tmpDir: string;
+  let configPath: string;
+  const hookCommand = '/usr/bin/node /path/to/cli.js hook claude-code';
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    configPath = join(tmpDir, '.claude', 'settings.json');
+  });
+
+  it('(a) 写入 PermissionRequest hook 指向给定 hookCommand', () => {
+    installHook('claude-code', { configPath, format: 'claude-settings' }, hookCommand);
+
+    const settings = JSON.parse(readFileSync(configPath, 'utf-8'));
+    const groups: any[] = settings.hooks?.PermissionRequest ?? [];
+    expect(groups.length).toBeGreaterThanOrEqual(1);
+
+    // 找到含有我们 hookCommand 的 group
+    const found = groups.find((g: any) =>
+      g.hooks?.some((e: any) => e.command === hookCommand),
+    );
+    expect(found).toBeDefined();
+    expect(found.matcher).toBe('*');
+
+    // 对应 entry 应有 timeout
+    const entry = found.hooks.find((e: any) => e.command === hookCommand);
+    expect(entry.type).toBe('command');
+    expect(typeof entry.timeout).toBe('number');
+    expect(entry.timeout).toBeGreaterThan(0);
+  });
+
+  it('(b) 幂等——二次调用后文件内容与第一次完全相同', () => {
+    installHook('claude-code', { configPath, format: 'claude-settings' }, hookCommand);
+    const contentAfterFirst = readFileSync(configPath, 'utf-8');
+
+    installHook('claude-code', { configPath, format: 'claude-settings' }, hookCommand);
+    const contentAfterSecond = readFileSync(configPath, 'utf-8');
+
+    expect(contentAfterSecond).toBe(contentAfterFirst);
+  });
+
+  it('(c) 既有无关配置（其他 key 和其他事件）在安装后保留', () => {
+    // 预先写入一个含无关 key 和另一事件 hook 的 settings.json
+    const existing = {
+      theme: 'dark',
+      someOtherSetting: 42,
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: 'Bash',
+            hooks: [{ type: 'command', command: '/usr/bin/some-other-hook' }],
+          },
+        ],
+      },
+    };
+    mkdirSync(join(tmpDir, '.claude'), { recursive: true });
+    writeFileSync(configPath, JSON.stringify(existing, null, 2) + '\n', 'utf-8');
+
+    installHook('claude-code', { configPath, format: 'claude-settings' }, hookCommand);
+
+    const settings = JSON.parse(readFileSync(configPath, 'utf-8'));
+
+    // 无关顶层 key 未被破坏
+    expect(settings.theme).toBe('dark');
+    expect(settings.someOtherSetting).toBe(42);
+
+    // 其他事件（PreToolUse）的 hook 仍在
+    const preToolGroups: any[] = settings.hooks?.PreToolUse ?? [];
+    expect(preToolGroups.length).toBe(1);
+    expect(preToolGroups[0].hooks[0].command).toBe('/usr/bin/some-other-hook');
+
+    // PermissionRequest 中有我们新写的 hook
+    const permGroups: any[] = settings.hooks?.PermissionRequest ?? [];
+    const found = permGroups.find((g: any) =>
+      g.hooks?.some((e: any) => e.command === hookCommand),
+    );
+    expect(found).toBeDefined();
+  });
+
+  it('(c2) 已有同 hookCommand 的 PermissionRequest entry 不会重复追加', () => {
+    // 第一次安装
+    installHook('claude-code', { configPath, format: 'claude-settings' }, hookCommand);
+    const afterFirst = JSON.parse(readFileSync(configPath, 'utf-8'));
+    const countFirst = (afterFirst.hooks?.PermissionRequest ?? []).filter((g: any) =>
+      g.hooks?.some((e: any) => e.command === hookCommand),
+    ).length;
+
+    // 第二次安装（幂等）
+    installHook('claude-code', { configPath, format: 'claude-settings' }, hookCommand);
+    const afterSecond = JSON.parse(readFileSync(configPath, 'utf-8'));
+    const countSecond = (afterSecond.hooks?.PermissionRequest ?? []).filter((g: any) =>
+      g.hooks?.some((e: any) => e.command === hookCommand),
+    ).length;
+
+    expect(countFirst).toBe(1);
+    expect(countSecond).toBe(1); // 不重复
+  });
+});
+
+// ─── opencode-plugin 格式 ─────────────────────────────────────────────────────
+
+describe('installHook — opencode-plugin', () => {
+  let tmpDir: string;
+  let configPath: string;
+  const hookCommand = '/usr/bin/node /path/to/cli.js hook opencode';
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    configPath = join(tmpDir, '.config', 'opencode', 'plugin', 'botmux-ask.js');
+  });
+
+  it('写入包含 hookCommand 的插件文件', () => {
+    installHook('opencode', { configPath, format: 'opencode-plugin' }, hookCommand);
+
+    const content = readFileSync(configPath, 'utf-8');
+    expect(content).toContain(hookCommand);
+    expect(content).toContain('question.asked');
+  });
+
+  it('幂等——二次调用后文件内容与第一次完全相同', () => {
+    installHook('opencode', { configPath, format: 'opencode-plugin' }, hookCommand);
+    const afterFirst = readFileSync(configPath, 'utf-8');
+
+    installHook('opencode', { configPath, format: 'opencode-plugin' }, hookCommand);
+    const afterSecond = readFileSync(configPath, 'utf-8');
+
+    expect(afterSecond).toBe(afterFirst);
+  });
+});

--- a/test/hook-installer.test.ts
+++ b/test/hook-installer.test.ts
@@ -2,7 +2,7 @@
  * hook-installer.test.ts
  *
  * 测试 installHook 对 claude-settings 格式的行为：
- *   (a) 写入 PermissionRequest hook 指向给定 hookCommand
+ *   (a) 写入 PreToolUse AskUserQuestion hook 指向给定 hookCommand
  *   (b) 幂等——二次调用内容不变
  *   (c) 既有无关配置保留（合并而非覆盖）
  */
@@ -30,11 +30,11 @@ describe('installHook — claude-settings', () => {
     configPath = join(tmpDir, '.claude', 'settings.json');
   });
 
-  it('(a) 写入 PermissionRequest hook 指向给定 hookCommand', () => {
+  it('(a) 写入 PreToolUse AskUserQuestion hook 指向给定 hookCommand', () => {
     installHook('claude-code', { configPath, format: 'claude-settings' }, hookCommand);
 
     const settings = JSON.parse(readFileSync(configPath, 'utf-8'));
-    const groups: any[] = settings.hooks?.PermissionRequest ?? [];
+    const groups: any[] = settings.hooks?.PreToolUse ?? [];
     expect(groups.length).toBeGreaterThanOrEqual(1);
 
     // 找到含有我们 hookCommand 的 group
@@ -42,7 +42,7 @@ describe('installHook — claude-settings', () => {
       g.hooks?.some((e: any) => e.command === hookCommand),
     );
     expect(found).toBeDefined();
-    expect(found.matcher).toBe('*');
+    expect(found.matcher).toBe('AskUserQuestion');
 
     // 对应 entry 应有 timeout
     const entry = found.hooks.find((e: any) => e.command === hookCommand);
@@ -88,34 +88,62 @@ describe('installHook — claude-settings', () => {
 
     // 其他事件（PreToolUse）的 hook 仍在
     const preToolGroups: any[] = settings.hooks?.PreToolUse ?? [];
-    expect(preToolGroups.length).toBe(1);
-    expect(preToolGroups[0].hooks[0].command).toBe('/usr/bin/some-other-hook');
+    expect(preToolGroups.some((g) => g.hooks?.some((e: any) => e.command === '/usr/bin/some-other-hook'))).toBe(true);
 
-    // PermissionRequest 中有我们新写的 hook
-    const permGroups: any[] = settings.hooks?.PermissionRequest ?? [];
-    const found = permGroups.find((g: any) =>
+    // PreToolUse 中有我们新写的 hook
+    const found = preToolGroups.find((g: any) =>
       g.hooks?.some((e: any) => e.command === hookCommand),
     );
     expect(found).toBeDefined();
+    expect(found.matcher).toBe('AskUserQuestion');
   });
 
-  it('(c2) 已有同 hookCommand 的 PermissionRequest entry 不会重复追加', () => {
+  it('(c2) 已有同 hookCommand 的 PreToolUse entry 不会重复追加', () => {
     // 第一次安装
     installHook('claude-code', { configPath, format: 'claude-settings' }, hookCommand);
     const afterFirst = JSON.parse(readFileSync(configPath, 'utf-8'));
-    const countFirst = (afterFirst.hooks?.PermissionRequest ?? []).filter((g: any) =>
+    const countFirst = (afterFirst.hooks?.PreToolUse ?? []).filter((g: any) =>
       g.hooks?.some((e: any) => e.command === hookCommand),
     ).length;
 
     // 第二次安装（幂等）
     installHook('claude-code', { configPath, format: 'claude-settings' }, hookCommand);
     const afterSecond = JSON.parse(readFileSync(configPath, 'utf-8'));
-    const countSecond = (afterSecond.hooks?.PermissionRequest ?? []).filter((g: any) =>
+    const countSecond = (afterSecond.hooks?.PreToolUse ?? []).filter((g: any) =>
       g.hooks?.some((e: any) => e.command === hookCommand),
     ).length;
 
     expect(countFirst).toBe(1);
     expect(countSecond).toBe(1); // 不重复
+  });
+
+  it('(d) 迁移旧 PermissionRequest botmux entry 到 PreToolUse', () => {
+    const existing = {
+      hooks: {
+        PermissionRequest: [
+          {
+            matcher: '*',
+            hooks: [{ type: 'command', command: hookCommand, timeout: 86400 }],
+          },
+          {
+            matcher: 'Bash',
+            hooks: [{ type: 'command', command: '/usr/bin/other-permission-hook' }],
+          },
+        ],
+      },
+    };
+    mkdirSync(join(tmpDir, '.claude'), { recursive: true });
+    writeFileSync(configPath, JSON.stringify(existing, null, 2) + '\n', 'utf-8');
+
+    installHook('claude-code', { configPath, format: 'claude-settings' }, hookCommand);
+
+    const settings = JSON.parse(readFileSync(configPath, 'utf-8'));
+    const permGroups: any[] = settings.hooks?.PermissionRequest ?? [];
+    expect(permGroups.some((g) => g.hooks?.some((e: any) => e.command === hookCommand))).toBe(false);
+    expect(permGroups.some((g) => g.hooks?.some((e: any) => e.command === '/usr/bin/other-permission-hook'))).toBe(true);
+
+    const preToolGroups: any[] = settings.hooks?.PreToolUse ?? [];
+    expect(preToolGroups.some((g) => g.matcher === 'AskUserQuestion' && g.hooks?.some((e: any) => e.command === hookCommand))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## 概述
为 botmux 增加 **askUserQuestion 的飞书接管能力**：AI CLI 需要让用户做选择时，问题以飞书互动卡片弹出，用户点选/提交，答案回流给 CLI。提供两条接入路径，并完整支持**多问 + 多选**。

## 两条接入路径
1. **`botmux ask` 子命令**（v0.1.7 已有）：脚本/手动显式发起阻塞式选择题 → daemon broker → 飞书卡片 → stdout 返回。
2. **hook 拦截（本轮新增，重点）**：拦截 AI CLI **原生的 AskUserQuestion**，无需 agent 配合调命令，透明接管。
   - `botmux hook <cli>` 客户端：读 hook stdin → 解析 questions → 复用同一条 `/api/asks` → 把答案格式化成各 CLI 的 directive 写回 stdout。
   - spawn 时把 hook 配置幂等注入各 CLI（Claude `settings.json`、OpenCode 插件），命令指向 `dist/cli.js`（按模块自身位置解析，源码 / npm global 均自洽）。

## 支持矩阵
- **Claude Code**：经 `PreToolUse` 拦截 `AskUserQuestion`（dogfood 实测确认走 PreToolUse），directive 回填。
- **OpenCode**：`QuestionAsked` 插件，directive 回填。
- **Codex**：无结构化提问 hook（问题是自由文本），adapter 恒 passthrough、不注入；不在本期范围。
- **Cursor**：无结构化 ask hook（仅 shell/MCP permission 二元授权），不在范围。

## 关键设计
- **中段复用**：`ask-broker` / 审批人链 / `/api/asks` route / env 注入零改动；hook 与子命令共用同一条链路。
- **多问 + 多选**：问答模型升级为「N 问 × 单/多选 × 一次提交」，单问单选为退化特例 —— `botmux ask buttons` 旧语义零回归（`toLegacySelected` 兼容）。
- **回调防御式解析**：选项 value 编码 `问题序号::key`，兼容飞书 form_value 的数组/字符串/逗号串。
- **异常必降级**：hook 任何失败（daemon 不可达 / 超时 / 解析失败 / workflow 子 agent）一律输出 passthrough，让 CLI 回退原生终端提问，绝不挂死。

## dogfood 修复（已含）
- Claude 改走 `PreToolUse`（实测 AskUserQuestion 不发 PermissionRequest）。
- 卡片选项以按钮渲染、cardDispatcher 按 `om_` 前缀决定 reply/send、TmuxBackend env 白名单补 BOTMUX_*。
- hook 命令指向 `cli.js` 而非 daemon 的 `index-daemon.js`（修复 npm global / 源码安装均失效，含回归测试）。

## 测试
- 全程 TDD；ask 全套单测 + 受影响单测 + master 改动区域（send-policy / message-parser / prompt-builder 等）共 400+ 全绿；`pnpm build` 干净。
- 已在独立环境 dogfood（Claude 单选/多选回填）。

## 文档
设计 spec / 实现计划 / 测试指南分别在 `docs/design/`、`docs/plans/`、`docs/TEST-GUIDE-ask-hooks.md`。
