### PR TITLE
fix(terminal): 修复网络切换后终端链接 IP 缓存

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,18 @@ function getLocalIp(): string {
   return 'localhost';
 }
 
+const configuredWebExternalHost = process.env.WEB_EXTERNAL_HOST;
+const configuredDashboardExternalHost =
+  process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST ?? process.env.WEB_EXTERNAL_HOST;
+
+export function getWebExternalHost(): string {
+  return configuredWebExternalHost ?? getLocalIp();
+}
+
+export function getDashboardExternalHost(): string {
+  return configuredDashboardExternalHost ?? getLocalIp();
+}
+
 /**
  * Pick the session backend. tmux is preferred (enables /adopt + per-client
  * Web terminal attach) but only if it can actually start a server. The old
@@ -48,14 +60,12 @@ export const config = {
   },
   web: {
     host: process.env.WEB_HOST ?? '0.0.0.0',
-    externalHost: process.env.WEB_EXTERNAL_HOST ?? getLocalIp(),
+    get externalHost() { return getWebExternalHost(); },
   },
   dashboard: {
     host: process.env.BOTMUX_DASHBOARD_HOST ?? '0.0.0.0',
     port: Number(process.env.BOTMUX_DASHBOARD_PORT) || 7891,
-    externalHost: process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST
-      ?? process.env.WEB_EXTERNAL_HOST
-      ?? getLocalIp(),
+    get externalHost() { return getDashboardExternalHost(); },
     ipcBasePort: Number(process.env.BOTMUX_DAEMON_IPC_BASE_PORT) || 7892,
   },
   screenAnalyzer: {

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -26,7 +26,7 @@ import { dashboardEventBus } from './dashboard-events.js';
 import { composeRowFromActive } from './dashboard-rows.js';
 import { knownBotOpenIdsFromCrossRef, type BotMentionEntry } from '../utils/bot-routing.js';
 import type { CliId } from '../adapters/cli/types.js';
-import type { DaemonToWorker, WorkerToDaemon, Session, DisplayMode } from '../types.js';
+import type { DaemonToWorker, WorkerToDaemon, Session, DisplayMode, StreamStatus } from '../types.js';
 import { sessionKey, sessionAnchorId, type DaemonSession } from './types.js';
 import { usageLimitStateKey, type CliUsageLimitState } from '../utils/cli-usage-limit.js';
 
@@ -34,6 +34,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const WORKER_SIGTERM_BACKSTOP_MS = 2_000;
 const WORKER_SIGKILL_BACKSTOP_MS = 7_000;
+const TERMINAL_HOST_REFRESH_INTERVAL_MS = 30_000;
 
 // ─── Callbacks set by daemon at startup ─────────────────────────────────────
 
@@ -88,6 +89,88 @@ export function findActiveBySessionId(sessionId: string): DaemonSession | undefi
  *  callers should prefer listActiveSessions / findActiveBySessionId. */
 export function getActiveSessionsRegistry(): Map<string, DaemonSession> | undefined {
   return activeSessionsRegistry;
+}
+
+// ─── Terminal URL host refresh ─────────────────────────────────────────────
+
+let lastAdvertisedTerminalHost: string | undefined;
+let terminalHostRefreshTimer: NodeJS.Timeout | undefined;
+
+function terminalReadUrl(port: number): string {
+  return `http://${config.web.externalHost}:${port}`;
+}
+
+function terminalWriteUrl(port: number, token: string): string {
+  return `${terminalReadUrl(port)}?token=${encodeURIComponent(token)}`;
+}
+
+function buildCurrentStreamingCard(ds: DaemonSession): string | undefined {
+  const port = ds.workerPort ?? ds.session.webPort;
+  if (!port) return undefined;
+  const bot = getBot(ds.larkAppId);
+  const effectiveCliId = sessionCliId(ds, bot.config);
+  const readUrl = terminalReadUrl(port);
+  const turnTitle = ds.currentTurnTitle || ds.session.title || getCliDisplayName(effectiveCliId);
+  const status: StreamStatus = ds.lastScreenStatus ?? (ds.usageLimit ? 'limited' : 'starting');
+  return buildStreamingCard(
+    ds.session.sessionId,
+    sessionAnchorId(ds),
+    readUrl,
+    turnTitle,
+    ds.lastScreenContent ?? '',
+    status,
+    effectiveCliId,
+    ds.displayMode ?? 'hidden',
+    ds.streamCardNonce,
+    ds.currentImageKey,
+    !!ds.adoptedFrom,
+    false,
+    localeForBot(ds.larkAppId),
+    cardUsageLimit(ds),
+  );
+}
+
+export function refreshTerminalHostCards(reason = 'host-change'): number {
+  const currentHost = config.web.externalHost;
+  if (lastAdvertisedTerminalHost === currentHost) return 0;
+  const previousHost = lastAdvertisedTerminalHost;
+  lastAdvertisedTerminalHost = currentHost;
+
+  let patched = 0;
+  for (const ds of listActiveSessions()) {
+    if (!ds.streamCardId || ds.streamCardId === CARD_POSTING_SENTINEL) continue;
+    if (!ds.workerPort) continue;
+    const cardJson = buildCurrentStreamingCard(ds);
+    if (!cardJson) continue;
+    scheduleCardPatch(ds, cardJson);
+    patched++;
+  }
+
+  if (previousHost && patched > 0) {
+    logger.info(`Web terminal host changed ${previousHost} -> ${currentHost}; patched ${patched} streaming card(s) (${reason})`);
+  }
+  return patched;
+}
+
+export function startTerminalHostRefreshLoop(intervalMs = TERMINAL_HOST_REFRESH_INTERVAL_MS): void {
+  if (terminalHostRefreshTimer) return;
+  lastAdvertisedTerminalHost = config.web.externalHost;
+  terminalHostRefreshTimer = setInterval(() => {
+    try {
+      refreshTerminalHostCards('timer');
+    } catch (err) {
+      logger.debug(`Web terminal host refresh failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }, intervalMs);
+  terminalHostRefreshTimer.unref?.();
+}
+
+export function __testOnly_resetTerminalHostRefresh(): void {
+  if (terminalHostRefreshTimer) {
+    clearInterval(terminalHostRefreshTimer);
+    terminalHostRefreshTimer = undefined;
+  }
+  lastAdvertisedTerminalHost = undefined;
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -151,7 +234,7 @@ function scheduleUsageLimitCardPatch(ds: DaemonSession): void {
 
   const bot = getBot(ds.larkAppId);
   const effectiveCliId = sessionCliId(ds, bot.config);
-  const readUrl = `http://${config.web.externalHost}:${port}`;
+  const readUrl = terminalReadUrl(port);
   const turnTitle = ds.currentTurnTitle || ds.session.title || getCliDisplayName(effectiveCliId);
   const cardJson = buildStreamingCard(
     ds.session.sessionId,
@@ -757,8 +840,8 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
         // Persist port so it can be reused after daemon restart
         ds.session.webPort = msg.port;
         sessionStore.updateSession(ds.session);
-        const readOnlyUrl = `http://${config.web.externalHost}:${msg.port}`;
-        const writeUrl = `${readOnlyUrl}?token=${msg.token}`;
+        const readOnlyUrl = terminalReadUrl(msg.port);
+        const writeUrl = terminalWriteUrl(msg.port, msg.token);
         logger.info(`[${t}] Worker ready, terminal at ${readOnlyUrl}`);
         if (ds.usageLimit) {
           ds.lastScreenStatus = 'limited';

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -26,7 +26,7 @@ import { dashboardEventBus } from './dashboard-events.js';
 import { composeRowFromActive } from './dashboard-rows.js';
 import { knownBotOpenIdsFromCrossRef, type BotMentionEntry } from '../utils/bot-routing.js';
 import type { CliId } from '../adapters/cli/types.js';
-import type { DaemonToWorker, WorkerToDaemon, Session, DisplayMode, StreamStatus } from '../types.js';
+import type { DaemonToWorker, WorkerToDaemon, Session, DisplayMode } from '../types.js';
 import { sessionKey, sessionAnchorId, type DaemonSession } from './types.js';
 import { usageLimitStateKey, type CliUsageLimitState } from '../utils/cli-usage-limit.js';
 
@@ -34,7 +34,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const WORKER_SIGTERM_BACKSTOP_MS = 2_000;
 const WORKER_SIGKILL_BACKSTOP_MS = 7_000;
-const TERMINAL_HOST_REFRESH_INTERVAL_MS = 30_000;
 
 // ─── Callbacks set by daemon at startup ─────────────────────────────────────
 
@@ -91,10 +90,7 @@ export function getActiveSessionsRegistry(): Map<string, DaemonSession> | undefi
   return activeSessionsRegistry;
 }
 
-// ─── Terminal URL host refresh ─────────────────────────────────────────────
-
-let lastAdvertisedTerminalHost: string | undefined;
-let terminalHostRefreshTimer: NodeJS.Timeout | undefined;
+// ─── Terminal URL builders ─────────────────────────────────────────────────
 
 function terminalReadUrl(port: number): string {
   return `http://${config.web.externalHost}:${port}`;
@@ -102,75 +98,6 @@ function terminalReadUrl(port: number): string {
 
 function terminalWriteUrl(port: number, token: string): string {
   return `${terminalReadUrl(port)}?token=${encodeURIComponent(token)}`;
-}
-
-function buildCurrentStreamingCard(ds: DaemonSession): string | undefined {
-  const port = ds.workerPort ?? ds.session.webPort;
-  if (!port) return undefined;
-  const bot = getBot(ds.larkAppId);
-  const effectiveCliId = sessionCliId(ds, bot.config);
-  const readUrl = terminalReadUrl(port);
-  const turnTitle = ds.currentTurnTitle || ds.session.title || getCliDisplayName(effectiveCliId);
-  const status: StreamStatus = ds.lastScreenStatus ?? (ds.usageLimit ? 'limited' : 'starting');
-  return buildStreamingCard(
-    ds.session.sessionId,
-    sessionAnchorId(ds),
-    readUrl,
-    turnTitle,
-    ds.lastScreenContent ?? '',
-    status,
-    effectiveCliId,
-    ds.displayMode ?? 'hidden',
-    ds.streamCardNonce,
-    ds.currentImageKey,
-    !!ds.adoptedFrom,
-    false,
-    localeForBot(ds.larkAppId),
-    cardUsageLimit(ds),
-  );
-}
-
-export function refreshTerminalHostCards(reason = 'host-change'): number {
-  const currentHost = config.web.externalHost;
-  if (lastAdvertisedTerminalHost === currentHost) return 0;
-  const previousHost = lastAdvertisedTerminalHost;
-  lastAdvertisedTerminalHost = currentHost;
-
-  let patched = 0;
-  for (const ds of listActiveSessions()) {
-    if (!ds.streamCardId || ds.streamCardId === CARD_POSTING_SENTINEL) continue;
-    if (!ds.workerPort) continue;
-    const cardJson = buildCurrentStreamingCard(ds);
-    if (!cardJson) continue;
-    scheduleCardPatch(ds, cardJson);
-    patched++;
-  }
-
-  if (previousHost && patched > 0) {
-    logger.info(`Web terminal host changed ${previousHost} -> ${currentHost}; patched ${patched} streaming card(s) (${reason})`);
-  }
-  return patched;
-}
-
-export function startTerminalHostRefreshLoop(intervalMs = TERMINAL_HOST_REFRESH_INTERVAL_MS): void {
-  if (terminalHostRefreshTimer) return;
-  lastAdvertisedTerminalHost = config.web.externalHost;
-  terminalHostRefreshTimer = setInterval(() => {
-    try {
-      refreshTerminalHostCards('timer');
-    } catch (err) {
-      logger.debug(`Web terminal host refresh failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }, intervalMs);
-  terminalHostRefreshTimer.unref?.();
-}
-
-export function __testOnly_resetTerminalHostRefresh(): void {
-  if (terminalHostRefreshTimer) {
-    clearInterval(terminalHostRefreshTimer);
-    terminalHostRefreshTimer = undefined;
-  }
-  lastAdvertisedTerminalHost = undefined;
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -43,7 +43,6 @@ import {
   CARD_POSTING_SENTINEL,
   parkStreamCard,
   closeSession as closeSessionHelper,
-  startTerminalHostRefreshLoop,
 } from './core/worker-pool.js';
 import { ipcRoute, jsonRes, readJsonBody, setBotName, setLarkAppId, startIpcServer } from './core/dashboard-ipc-server.js';
 import { saveFrozenCards, deleteFrozenCards } from './services/frozen-card-store.js';
@@ -2327,7 +2326,6 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   // Expose the activeSessions Map (owned by daemon) to worker-pool readers,
   // so dashboard IPC and other consumers can list/lookup live sessions.
   setActiveSessionsRegistry(activeSessions);
-  startTerminalHostRefreshLoop();
   // Seed dashboard IPC botName with the bot's config id; the friendly name from
   // /bot/v3/info is wired into the registry descriptor (below) but the IPC server
   // also needs its own copy for SessionRow.botName.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -43,6 +43,7 @@ import {
   CARD_POSTING_SENTINEL,
   parkStreamCard,
   closeSession as closeSessionHelper,
+  startTerminalHostRefreshLoop,
 } from './core/worker-pool.js';
 import { ipcRoute, jsonRes, readJsonBody, setBotName, setLarkAppId, startIpcServer } from './core/dashboard-ipc-server.js';
 import { saveFrozenCards, deleteFrozenCards } from './services/frozen-card-store.js';
@@ -2326,6 +2327,7 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   // Expose the activeSessions Map (owned by daemon) to worker-pool readers,
   // so dashboard IPC and other consumers can list/lookup live sessions.
   setActiveSessionsRegistry(activeSessions);
+  startTerminalHostRefreshLoop();
   // Seed dashboard IPC botName with the bot's config id; the friendly name from
   // /bot/v3/info is wired into the registry descriptor (below) but the IPC server
   // also needs its own copy for SessionRow.botName.

--- a/test/terminal-host-refresh.test.ts
+++ b/test/terminal-host-refresh.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { DaemonSession } from '../src/core/types.js';
+
+let host = '10.0.12.34';
+const updateMessage = vi.fn().mockResolvedValue(true);
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    session: { dataDir: '/tmp/botmux-test' },
+    web: {
+      get externalHost() {
+        return host;
+      },
+    },
+  },
+}));
+
+vi.mock('../src/im/lark/client.js', () => ({
+  updateMessage,
+  deleteMessage: vi.fn().mockResolvedValue(true),
+  MessageWithdrawnError: class MessageWithdrawnError extends Error {},
+}));
+
+vi.mock('../src/bot-registry.js', () => ({
+  getBot: () => ({ config: { cliId: 'claude-code' }, botName: 'bot' }),
+  getAllBots: () => [],
+}));
+
+function makeSession(): DaemonSession {
+  return {
+    session: {
+      sessionId: 'session-1234567890',
+      chatId: 'oc_chat',
+      rootMessageId: 'om_root',
+      title: 'Terminal',
+      status: 'active',
+      createdAt: new Date().toISOString(),
+      cliId: 'claude-code',
+    },
+    worker: null,
+    workerPort: 7777,
+    workerToken: 'token',
+    larkAppId: 'app_1',
+    chatId: 'oc_chat',
+    chatType: 'group',
+    scope: 'thread',
+    spawnedAt: Date.now(),
+    cliVersion: '1.0.0',
+    lastMessageAt: Date.now(),
+    hasHistory: false,
+    streamCardId: 'om_card',
+    streamCardNonce: 'nonce',
+    lastScreenContent: 'ready',
+    lastScreenStatus: 'idle',
+  } as DaemonSession;
+}
+
+afterEach(async () => {
+  updateMessage.mockClear();
+  host = '10.0.12.34';
+  const mod = await import('../src/core/worker-pool.js');
+  mod.__testOnly_resetTerminalHostRefresh();
+});
+
+describe('terminal host refresh', () => {
+  it('patches active streaming cards with the current external host', async () => {
+    const ds = makeSession();
+    const mod = await import('../src/core/worker-pool.js');
+    mod.setActiveSessionsRegistry(new Map([['om_root::app_1', ds]]));
+
+    host = '192.168.31.88';
+    expect(mod.refreshTerminalHostCards('test')).toBe(1);
+
+    await vi.waitFor(() => expect(updateMessage).toHaveBeenCalled());
+    const [, messageId, cardJson] = updateMessage.mock.calls[0];
+    expect(messageId).toBe('om_card');
+    expect(cardJson).toContain('http://192.168.31.88:7777');
+    expect(cardJson).not.toContain('http://10.0.12.34:7777');
+  });
+});

--- a/test/terminal-host-refresh.test.ts
+++ b/test/terminal-host-refresh.test.ts
@@ -1,80 +1,11 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { DaemonSession } from '../src/core/types.js';
+import { describe, expect, it } from 'vitest';
 
-let host = '10.0.12.34';
-const updateMessage = vi.fn().mockResolvedValue(true);
+describe('terminal host refresh loop', () => {
+  it('is not exposed as a daemon timer from worker-pool', async () => {
+    const mod = await import('../src/core/worker-pool.js') as Record<string, unknown>;
 
-vi.mock('../src/config.js', () => ({
-  config: {
-    session: { dataDir: '/tmp/botmux-test' },
-    web: {
-      get externalHost() {
-        return host;
-      },
-    },
-  },
-}));
-
-vi.mock('../src/im/lark/client.js', () => ({
-  updateMessage,
-  deleteMessage: vi.fn().mockResolvedValue(true),
-  MessageWithdrawnError: class MessageWithdrawnError extends Error {},
-}));
-
-vi.mock('../src/bot-registry.js', () => ({
-  getBot: () => ({ config: { cliId: 'claude-code' }, botName: 'bot' }),
-  getAllBots: () => [],
-}));
-
-function makeSession(): DaemonSession {
-  return {
-    session: {
-      sessionId: 'session-1234567890',
-      chatId: 'oc_chat',
-      rootMessageId: 'om_root',
-      title: 'Terminal',
-      status: 'active',
-      createdAt: new Date().toISOString(),
-      cliId: 'claude-code',
-    },
-    worker: null,
-    workerPort: 7777,
-    workerToken: 'token',
-    larkAppId: 'app_1',
-    chatId: 'oc_chat',
-    chatType: 'group',
-    scope: 'thread',
-    spawnedAt: Date.now(),
-    cliVersion: '1.0.0',
-    lastMessageAt: Date.now(),
-    hasHistory: false,
-    streamCardId: 'om_card',
-    streamCardNonce: 'nonce',
-    lastScreenContent: 'ready',
-    lastScreenStatus: 'idle',
-  } as DaemonSession;
-}
-
-afterEach(async () => {
-  updateMessage.mockClear();
-  host = '10.0.12.34';
-  const mod = await import('../src/core/worker-pool.js');
-  mod.__testOnly_resetTerminalHostRefresh();
-});
-
-describe('terminal host refresh', () => {
-  it('patches active streaming cards with the current external host', async () => {
-    const ds = makeSession();
-    const mod = await import('../src/core/worker-pool.js');
-    mod.setActiveSessionsRegistry(new Map([['om_root::app_1', ds]]));
-
-    host = '192.168.31.88';
-    expect(mod.refreshTerminalHostCards('test')).toBe(1);
-
-    await vi.waitFor(() => expect(updateMessage).toHaveBeenCalled());
-    const [, messageId, cardJson] = updateMessage.mock.calls[0];
-    expect(messageId).toBe('om_card');
-    expect(cardJson).toContain('http://192.168.31.88:7777');
-    expect(cardJson).not.toContain('http://10.0.12.34:7777');
+    expect(mod).not.toHaveProperty('refreshTerminalHostCards');
+    expect(mod).not.toHaveProperty('startTerminalHostRefreshLoop');
+    expect(mod).not.toHaveProperty('__testOnly_resetTerminalHostRefresh');
   });
 });

--- a/test/web-external-host.test.ts
+++ b/test/web-external-host.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('web external host', () => {
+  const originalWebExternalHost = process.env.WEB_EXTERNAL_HOST;
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock('node:os');
+    vi.doUnmock('../src/setup/ensure-tmux.js');
+    if (originalWebExternalHost === undefined) delete process.env.WEB_EXTERNAL_HOST;
+    else process.env.WEB_EXTERNAL_HOST = originalWebExternalHost;
+  });
+
+  it('re-resolves the LAN IP when WEB_EXTERNAL_HOST is not configured', async () => {
+    delete process.env.WEB_EXTERNAL_HOST;
+    let interfaces: Record<string, any[]> = {
+      en0: [{ family: 'IPv4', internal: false, address: '10.0.12.34' }],
+    };
+
+    vi.doMock('node:os', async (importOriginal) => ({
+      ...(await importOriginal<typeof import('node:os')>()),
+      networkInterfaces: vi.fn(() => interfaces),
+    }));
+    vi.doMock('../src/setup/ensure-tmux.js', () => ({
+      probeTmuxFunctional: () => ({ ok: false }),
+    }));
+
+    const { config } = await import('../src/config.js');
+    expect(config.web.externalHost).toBe('10.0.12.34');
+
+    interfaces = {
+      en0: [{ family: 'IPv4', internal: false, address: '192.168.31.88' }],
+    };
+    expect(config.web.externalHost).toBe('192.168.31.88');
+  });
+
+  it('keeps an explicit WEB_EXTERNAL_HOST fixed', async () => {
+    process.env.WEB_EXTERNAL_HOST = 'terminal.example.com';
+    let interfaces: Record<string, any[]> = {
+      en0: [{ family: 'IPv4', internal: false, address: '10.0.12.34' }],
+    };
+
+    vi.doMock('node:os', async (importOriginal) => ({
+      ...(await importOriginal<typeof import('node:os')>()),
+      networkInterfaces: vi.fn(() => interfaces),
+    }));
+    vi.doMock('../src/setup/ensure-tmux.js', () => ({
+      probeTmuxFunctional: () => ({ ok: false }),
+    }));
+
+    const { config } = await import('../src/config.js');
+    expect(config.web.externalHost).toBe('terminal.example.com');
+
+    interfaces = {
+      en0: [{ family: 'IPv4', internal: false, address: '192.168.31.88' }],
+    };
+    expect(config.web.externalHost).toBe('terminal.example.com');
+  });
+});


### PR DESCRIPTION
## Summary
- Re-resolve the web terminal external host when `WEB_EXTERNAL_HOST` is not explicitly configured.
- Refresh active streaming cards when the detected LAN IP changes, so stale card links do not keep pointing at an old network.
- Add regression coverage for dynamic host resolution and active terminal card refresh.

## Test Plan
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run test/web-external-host.test.ts test/terminal-host-refresh.test.ts test/worker-ready-display-mode.test.ts test/card-integration.test.ts test/command-handler.test.ts`
