### PR TITLE
fix(ask): hook 去重按结构识别，避免 dev/npm 双安装重复触发发双卡

### DIFF
--- a/src/adapters/hook-installer.ts
+++ b/src/adapters/hook-installer.ts
@@ -67,10 +67,32 @@ interface ClaudeSettings {
   [key: string]: unknown;
 }
 
-/** 判断某个 hook group 是否是 botmux ask hook（用于幂等替换）。 */
+/**
+ * 从完整 hookCommand 中提取 `hook <cliId>` 尾签名。
+ * hookCommand 形如：`"<node>" "<...dist/cli.js>" hook claude-code`，
+ * 尾部 `hook <cliId>` 不随 node / cli.js 安装路径变化。
+ */
+function botmuxHookSuffix(hookCommand: string): string {
+  const idx = hookCommand.lastIndexOf(' hook ');
+  return idx === -1 ? hookCommand : hookCommand.slice(idx + 1); // "hook <cliId>"
+}
+
+/**
+ * 判断某个 hook group 是否是 botmux ask hook（用于幂等替换）。
+ *
+ * 不能只按命令字符串完全相等比对：同一台机器上 dev 源码 checkout 与 npm global
+ * 安装的 cli.js 绝对路径不同，命令字符串就不同，会导致两条 botmux hook 同时残留、
+ * 同一次 AskUserQuestion 触发两次 → 飞书发出两张卡。
+ * 因此结构化识别：命令引用了 botmux 的 `cli.js` 且尾部是相同的 `hook <cliId>` 签名，
+ * 即视为 botmux hook，无论它指向哪个安装路径。
+ */
 function isBotmuxAskHookGroup(group: ClaudeHookGroup, hookCommand: string): boolean {
+  const suffix = botmuxHookSuffix(hookCommand); // e.g. "hook claude-code"
   return group.hooks.some(
-    (e) => e.type === 'command' && e.command === hookCommand,
+    (e) =>
+      e.type === 'command' &&
+      (e.command === hookCommand ||
+        (e.command.includes('cli.js') && e.command.trimEnd().endsWith(suffix))),
   );
 }
 

--- a/test/hook-installer.test.ts
+++ b/test/hook-installer.test.ts
@@ -117,6 +117,35 @@ describe('installHook — claude-settings', () => {
     expect(countSecond).toBe(1); // 不重复
   });
 
+  it('(c3) 不同安装路径的旧 botmux hook 在重装时被去重（避免双卡）', () => {
+    // 模拟 dev 源码安装残留的 hook，命令路径与本次 npm-global 安装不同
+    const devCommand =
+      '"/root/.local/share/fnm/.../bin/node" "/root/claude-code-workspace/botmux/dist/cli.js" hook claude-code';
+    const existing = {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: 'AskUserQuestion',
+            hooks: [{ type: 'command', command: devCommand, timeout: 86400 }],
+          },
+        ],
+      },
+    };
+    mkdirSync(join(tmpDir, '.claude'), { recursive: true });
+    writeFileSync(configPath, JSON.stringify(existing, null, 2) + '\n', 'utf-8');
+
+    // 用另一安装路径的 hookCommand 重装
+    installHook('claude-code', { configPath, format: 'claude-settings' }, hookCommand);
+
+    const settings = JSON.parse(readFileSync(configPath, 'utf-8'));
+    const groups: any[] = settings.hooks?.PreToolUse ?? [];
+    // 旧 dev 路径 hook 应被结构化识别并移除，只留下本次安装的一条
+    const askGroups = groups.filter((g) => g.matcher === 'AskUserQuestion');
+    expect(askGroups.length).toBe(1);
+    expect(askGroups[0].hooks.some((e: any) => e.command === devCommand)).toBe(false);
+    expect(askGroups[0].hooks.some((e: any) => e.command === hookCommand)).toBe(true);
+  });
+
   it('(d) 迁移旧 PermissionRequest botmux entry 到 PreToolUse', () => {
     const existing = {
       hooks: {


### PR DESCRIPTION
## 问题
`~/.claude/settings.json` 的 PreToolUse 里同时残留两条 botmux AskUserQuestion hook，分别指向 dev 源码 checkout 与 npm global 安装的 `cli.js`。Claude 对一次 AskUserQuestion 把两条都触发 → 各跑一遍 `botmux ask` → 飞书发出**两张卡**。

## 根因
`isBotmuxAskHookGroup` 只按命令字符串「完全相等」去重。两个安装路径的命令串不同，重装时各自只删自己那条，留下对方那条。

## 修复
去重改为**结构化识别**：命令引用了 botmux 的 `cli.js` 且尾部为相同的 `hook <cliId>` 签名，即视为 botmux hook，无论它指向哪个安装路径。

## 测试
新增回归用例 (c3)：不同安装路径的旧 botmux hook 在重装时被去重。`test/hook-installer.test.ts` 8 个用例全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)