### PR TITLE
fix(card): 仓库选择卡文案补充 /repo <路径|项目名> 用法

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -48,7 +48,7 @@ export const messages: Record<string, string> = {
   'card.repo.placeholder_switch': 'Pick a repo to switch to',
   'card.repo.current_active': 'Currently active project:',
   'card.repo.current_marker': ' ← current',
-  'card.repo.note': 'You can also reply `/repo <N>` to switch — e.g. `/repo 1`.',
+  'card.repo.note': 'You can also reply `/repo <N>` (e.g. `/repo 1`), or `/repo <path|name>` directly (e.g. `/repo botmux`, `/repo ~/projects/foo`) to skip this card.',
 
   // In-group authorization card
   'card.grant.title': '🔑 Access Request',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -51,7 +51,7 @@ export const messages: Record<string, string> = {
   'card.repo.placeholder_switch': '选择仓库并切换',
   'card.repo.current_active': '当前活跃项目：',
   'card.repo.current_marker': ' ← 当前',
-  'card.repo.note': '也可以回复 `/repo <编号>` 切换，例如：`/repo 1`',
+  'card.repo.note': '也可以回复 `/repo <编号>` 切换（如 `/repo 1`），或直接 `/repo <路径|项目名>`（如 `/repo botmux`、`/repo ~/projects/foo`）跳过本卡片',
 
   // 群内授权卡片
   'card.grant.title': '🔑 使用授权',


### PR DESCRIPTION
v2.40.0 (#57) 给 /repo 加了直接传路径/项目名跳过仓库选择卡片的能力，但仓库选择卡片底部提示文案 card.repo.note 没跟上，仍只写了 /repo <编号>。本 PR 补上 /repo <路径|项目名> 的示例（/repo botmux、/repo ~/projects/foo）并说明可跳过本卡片，zh/en 同步。纯文案改动。测试：pnpm build 通过；card-builder(74) + dashboard-i18n(含 zh/en key 对齐) 76 例全绿。