### PR TITLE
fix(daemon): /group、/g 不再被记录为 dashboard 会话

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -34,6 +34,16 @@ import { t, localeForBot, type Locale } from '../i18n/index.js';
 export const DAEMON_COMMANDS = new Set(['/close', '/restart', '/status', '/help', '/cd', '/repo', '/schedule', '/role', '/pair', '/login', '/adopt', '/oncall', '/group', '/g', '/relay', '/card']);
 
 /**
+ * Daemon commands that act on the chat itself rather than opening a
+ * conversation. `/group` (`/g`) just creates a Lark group and replies once —
+ * no follow-up turns, no CLI worker. The new-topic spawn path normally
+ * pre-creates a sessionStore record so a command can attach state and keep
+ * card buttons routable, but for these that record is a phantom conversation
+ * that pollutes the dashboard's session list. Handle them without a session.
+ */
+export const SESSIONLESS_DAEMON_COMMANDS = new Set(['/group', '/g']);
+
+/**
  * Slash commands that are forwarded verbatim to the underlying CLI (e.g.
  * Claude Code's `/compact`, `/model`, `/usage`). The daemon does NOT handle
  * these — it just relays them to the worker via a raw_input IPC message,
@@ -962,7 +972,10 @@ export async function handleCommand(
         //   • RESOLUTION (bot → larkAppId for the invite) uses the live roster
         //     listChatBotMembers(), failing CLOSED on any miss.
         const mentions = message.mentions ?? [];
-        const sourceChatId = ds?.chatId;
+        // `/group` runs without a pre-created session (see
+        // SESSIONLESS_DAEMON_COMMANDS), so the source chat comes from the
+        // message; fall back to the active session when invoked mid-session.
+        const sourceChatId = message.chatId ?? ds?.chatId;
         const knownBotNames = globalKnownBotNames();
 
         // Degraded-state guard: if the user @-mentioned someone but the global bot

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -48,7 +48,7 @@ import {
 } from './core/worker-pool.js';
 import { ipcRoute, jsonRes, readJsonBody, setBotName, setLarkAppId, startIpcServer, setWorkflowRunner } from './core/dashboard-ipc-server.js';
 import { saveFrozenCards, deleteFrozenCards } from './services/frozen-card-store.js';
-import { DAEMON_COMMANDS, PASSTHROUGH_COMMANDS, handleCommand, parseSlashCommandInvocation, parseForceTopicInvocation } from './core/command-handler.js';
+import { DAEMON_COMMANDS, SESSIONLESS_DAEMON_COMMANDS, PASSTHROUGH_COMMANDS, handleCommand, parseSlashCommandInvocation, parseForceTopicInvocation } from './core/command-handler.js';
 import type { CommandHandlerDeps } from './core/command-handler.js';
 import { findInheritablePeer } from './core/inherit-peer.js';
 import { isCallbackUrl, handleCallbackUrl } from './utils/user-token.js';
@@ -1737,6 +1737,14 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
         await sessionReply(anchor, tr('daemon.cmd_allowed_users_only', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
         return;
       }
+      // `/group` (`/g`) doesn't open a conversation — creating a sessionStore
+      // record for it would surface a phantom session in the dashboard. Run it
+      // without a session; pass chatId on the message so the handler can reach
+      // the chat roster (it normally reads it from the active session's ds).
+      if (SESSIONLESS_DAEMON_COMMANDS.has(cmd)) {
+        await handleCommand(cmd, anchor, { ...parsed, content: commandContent, chatId }, commandDeps, larkAppId);
+        return;
+      }
       // Same rootMessageId reasoning as below in the main spawn path:
       // thread-scope MUST anchor on the thread root or sessionAnchorId() will
       // disagree with activeSessions's key and downstream card buttons silently
@@ -2076,7 +2084,8 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
         return;
       }
       // Pass mention-stripped content so /command argument parsing works.
-      handleCommand(cmd, anchor, { ...parsed, content: commandContent }, commandDeps, larkAppId);
+      // chatId lets session-less handlers (e.g. /group) reach the chat roster.
+      handleCommand(cmd, anchor, { ...parsed, content: commandContent, chatId: threadChatId }, commandDeps, larkAppId);
       return;
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,10 @@ export interface LarkMention {
 export interface LarkMessage {
   messageId: string;
   rootId: string;
+  /** Source chat the message came from. Populated for commands that run
+   *  without a session (e.g. `/group`) so the handler can reach the chat
+   *  roster without an active session to read `ds.chatId` from. */
+  chatId?: string;
   /** Immediate parent — set when the user used the Lark "quote/reply"
    *  UI to reference a specific earlier message. Empty otherwise. */
   parentId?: string;

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -280,7 +280,7 @@ vi.mock('../src/services/oncall-store.js', () => ({
 
 // ─── Imports (after mocks) ──────────────────────────────────────────────────
 
-import { DAEMON_COMMANDS, PASSTHROUGH_COMMANDS, handleCommand, parseSlashCommandInvocation, parseForceTopicInvocation } from '../src/core/command-handler.js';
+import { DAEMON_COMMANDS, SESSIONLESS_DAEMON_COMMANDS, PASSTHROUGH_COMMANDS, handleCommand, parseSlashCommandInvocation, parseForceTopicInvocation } from '../src/core/command-handler.js';
 import { writeTeamRoleFile, deleteTeamRoleFile, resolveRole } from '../src/core/role-resolver.js';
 import { setBotCapability, clearBotCapability } from '../src/services/bot-profile-store.js';
 import type { CommandHandlerDeps } from '../src/core/command-handler.js';
@@ -395,6 +395,28 @@ describe('DAEMON_COMMANDS set', () => {
 
   it('should have the correct size', () => {
     expect(DAEMON_COMMANDS.size).toBe(16);
+  });
+});
+
+describe('SESSIONLESS_DAEMON_COMMANDS set', () => {
+  it('contains /group and its /g alias', () => {
+    expect(SESSIONLESS_DAEMON_COMMANDS.has('/group')).toBe(true);
+    expect(SESSIONLESS_DAEMON_COMMANDS.has('/g')).toBe(true);
+  });
+
+  it('is a subset of DAEMON_COMMANDS (they are still daemon-handled)', () => {
+    for (const cmd of SESSIONLESS_DAEMON_COMMANDS) {
+      expect(DAEMON_COMMANDS.has(cmd), `${cmd} must also be a daemon command`).toBe(true);
+    }
+  });
+
+  it('excludes conversation/state commands that need a session', () => {
+    // These attach state to or operate on an active session, so they must
+    // keep going through the session-creating path.
+    expect(SESSIONLESS_DAEMON_COMMANDS.has('/repo')).toBe(false);
+    expect(SESSIONLESS_DAEMON_COMMANDS.has('/cd')).toBe(false);
+    expect(SESSIONLESS_DAEMON_COMMANDS.has('/close')).toBe(false);
+    expect(SESSIONLESS_DAEMON_COMMANDS.has('/card')).toBe(false);
   });
 });
 
@@ -1392,6 +1414,49 @@ describe('handleCommand', () => {
       expect(mockedSend).not.toHaveBeenCalled();
       // No chat-scope session registered for the new group.
       expect(deps.activeSessions.has(sessionKey('oc_new_group', LARK_APP_ID))).toBe(false);
+    });
+
+    it('runs with NO active session, reading the source chat from message.chatId', async () => {
+      // The daemon runs /group through SESSIONLESS_DAEMON_COMMANDS — no
+      // sessionStore record, so handleCommand sees no ds. Resolving the
+      // @-mentioned bots needs the source chatId, which now rides on the
+      // message instead of ds.chatId.
+      mockedListBots.mockResolvedValueOnce([
+        { larkAppId: 'app-1', openId: 'ou_claude', name: 'claude-code', displayName: 'Claude', source: 'configured' },
+        { larkAppId: 'app-2', openId: 'ou_codex', name: 'codex', displayName: 'Codex', source: 'configured' },
+      ]);
+      const deps = makeDeps(); // no ds — the sessionless path
+      const msg = makeLarkMessage('/group @Codex 项目', {
+        chatId: CHAT_ID,
+        mentions: [
+          { key: '@_user_1', name: 'Claude', openId: 'ou_claude' },
+          { key: '@_user_2', name: 'Codex', openId: 'ou_codex' },
+        ],
+      });
+
+      await handleCommand('/group', ROOT_ID, msg, deps, LARK_APP_ID);
+
+      // Roster lookup used the chatId from the message, and the group was created.
+      expect(mockedListBots).toHaveBeenCalledWith(LARK_APP_ID, CHAT_ID);
+      expect(mockedCreate).toHaveBeenCalledTimes(1);
+      expect(mockedCreate.mock.calls[0][0].larkAppIds).toEqual(['app-1', 'app-2']);
+    });
+
+    it('fails closed (no group) with bots mentioned but no chatId on message and no ds', async () => {
+      const deps = makeDeps(); // no ds
+      const msg = makeLarkMessage('/group @Codex 项目', {
+        // chatId intentionally omitted
+        mentions: [
+          { key: '@_user_1', name: 'Claude', openId: 'ou_claude' },
+          { key: '@_user_2', name: 'Codex', openId: 'ou_codex' },
+        ],
+      });
+
+      await handleCommand('/group', ROOT_ID, msg, deps, LARK_APP_ID);
+
+      expect(mockedCreate).not.toHaveBeenCalled();
+      const reply = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+      expect(reply).toContain('无法解析');
     });
 
     it('invites every @-mentioned bot when the first mentioned bot is us', async () => {


### PR DESCRIPTION
## 问题

`/g`、`/group` 拉群命令在 dashboard 的会话列表里留下一条幽灵会话。

## 根因

`daemon.ts` 的新话题路径对*所有* daemon 命令统一 `sessionStore.createSession(...)`——这是为 `/repo`、`/cd` 等需要挂会话状态、且回复卡片按钮要能按 `sessionKey` 路由的命令服务的。但 `/group`、`/g` 只是建一个飞书群、回一条消息，没有后续轮次也没有 CLI worker，本不该建会话，于是污染了 dashboard。

## 改动

- **`command-handler.ts`**：新增 `SESSIONLESS_DAEMON_COMMANDS = {/group, /g}` 命令分类；`/group` 解析群成员所需的来源 chatId 从 `message.chatId ?? ds?.chatId` 取（不再仅依赖会话）
- **`daemon.ts`**：新话题路径里这两个命令短路，直接 `handleCommand` 而不建会话；两处 daemon 命令分发把 `chatId` 透传进 message
- **`types.ts`**：`LarkMessage` 新增可选 `chatId`
- **`command-handler.test.ts`**：新增回归测试

## 测试

- `pnpm build` 通过
- `command-handler.test.ts` 84 个测试全绿（含新增：无会话 + message.chatId 也能拉群、缺 chatId 时 fail-closed、SESSIONLESS 集合成员校验）
- 全量套件的既有失败（`bridge-final-output-retry` 缺 `resolveBrandLabel` mock、`write-input` 的 mira 适配器）在 master 上同样失败，与本次改动无关