### PR TITLE
fix(repo): /repo 启动的会话不再提交空 prompt，等用户下一条消息

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -580,29 +580,43 @@ export async function handleCommand(
           const selfBot = getBot(ds!.larkAppId);
           const botCfg = selfBot.config;
           ds!.pendingRepo = false;
-          const { buildNewTopicPrompt, getAvailableBots } = await import('./session-manager.js');
           const pendingPrompt = ds!.pendingPrompt ?? '';
-          const prompt = buildNewTopicPrompt(
-            pendingPrompt,
-            ds!.session.sessionId,
-            botCfg.cliId,
-            botCfg.cliPathOverride,
-            ds!.pendingAttachments,
-            ds!.pendingMentions,
-            await getAvailableBots(ds!.larkAppId, ds!.chatId),
-            ds!.pendingFollowUps,
-            { name: selfBot.botName, openId: selfBot.botOpenId },
-            loc,
-            ds!.pendingSender,
-            { larkAppId, chatId: ds!.chatId },
-          );
-          rememberLastCliInput(ds!, pendingPrompt, prompt);
+          // Was there an actual buffered user message to deliver? A session
+          // launched *via* `/repo` (the command itself is the first message) has
+          // none — so boot the CLI idle and let the user's NEXT message be the
+          // first prompt, instead of submitting an empty/boilerplate user_message.
+          const hasBufferedInput =
+            pendingPrompt.trim().length > 0 ||
+            (ds!.pendingAttachments?.length ?? 0) > 0 ||
+            (ds!.pendingFollowUps?.length ?? 0) > 0;
+          if (hasBufferedInput) {
+            const { buildNewTopicPrompt, getAvailableBots } = await import('./session-manager.js');
+            const prompt = buildNewTopicPrompt(
+              pendingPrompt,
+              ds!.session.sessionId,
+              botCfg.cliId,
+              botCfg.cliPathOverride,
+              ds!.pendingAttachments,
+              ds!.pendingMentions,
+              await getAvailableBots(ds!.larkAppId, ds!.chatId),
+              ds!.pendingFollowUps,
+              { name: selfBot.botName, openId: selfBot.botOpenId },
+              loc,
+              ds!.pendingSender,
+              { larkAppId, chatId: ds!.chatId },
+            );
+            rememberLastCliInput(ds!, pendingPrompt, prompt);
+            forkWorker(ds!, prompt);
+          } else {
+            // Empty initial prompt → worker spawns the CLI without submitting
+            // anything (see worker.ts: the init prompt is only queued when truthy).
+            forkWorker(ds!, '', false);
+          }
           ds!.pendingPrompt = undefined;
           ds!.pendingAttachments = undefined;
           ds!.pendingMentions = undefined;
           ds!.pendingSender = undefined;
           ds!.pendingFollowUps = undefined;
-          forkWorker(ds!, prompt);
           await sessionReply(rootId, replyText);
         };
 

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -288,7 +288,7 @@ import { sessionKey } from '../src/core/types.js';
 import type { DaemonSession } from '../src/core/types.js';
 import type { LarkMessage, Session } from '../src/types.js';
 import { killWorker, forkWorker, getCurrentCliVersion } from '../src/core/worker-pool.js';
-import { getSessionWorkingDir } from '../src/core/session-manager.js';
+import { getSessionWorkingDir, buildNewTopicPrompt } from '../src/core/session-manager.js';
 import * as sessionStore from '../src/services/session-store.js';
 import * as scheduleStore from '../src/services/schedule-store.js';
 import * as scheduler from '../src/core/scheduler.js';
@@ -930,14 +930,16 @@ describe('handleCommand', () => {
   // ─── bare /repo while pending (replaces the old /skip command) ────────────
 
   describe('/repo (bare) while pending', () => {
-    it('should launch the CLI in the default workingDir without showing a card', async () => {
+    it('should boot the CLI idle (no prompt submitted) when launched via /repo itself', async () => {
       const ds = makeDaemonSession({ pendingRepo: true, pendingPrompt: '', repoCardMessageId: 'om_card' });
       const deps = makeDeps(ds);
 
       await handleCommand('/repo', ROOT_ID, makeLarkMessage('/repo'), deps, LARK_APP_ID);
 
-      // Forked the pending CLI (not the close+recreate switch path).
-      expect(forkWorker).toHaveBeenCalledWith(ds, expect.any(String));
+      // No buffered message → spawn idle with an empty prompt so the user's NEXT
+      // message becomes the first prompt (not an empty/boilerplate user_message).
+      expect(forkWorker).toHaveBeenCalledWith(ds, '', false);
+      expect(buildNewTopicPrompt).not.toHaveBeenCalled();
       expect(killWorker).not.toHaveBeenCalled();
       expect(sessionStore.createSession).not.toHaveBeenCalled();
       // Cleared pending state + withdrew the (already-sent) card.
@@ -949,6 +951,21 @@ describe('handleCommand', () => {
       expect(replyContent).toContain('已直接开启会话');
       // Did NOT fall through to the card-display scan path.
       expect(scanMultipleProjects).not.toHaveBeenCalled();
+    });
+
+    it('should still submit a buffered first message when bare /repo skips the card', async () => {
+      // Normal flow: real first message → card shown → user types bare /repo to
+      // skip. The buffered message must be delivered, not dropped.
+      const ds = makeDaemonSession({ pendingRepo: true, pendingPrompt: '帮我看看这个 bug' });
+      const deps = makeDeps(ds);
+
+      await handleCommand('/repo', ROOT_ID, makeLarkMessage('/repo'), deps, LARK_APP_ID);
+
+      // The buffered message is wrapped (mock → `WRAPPED:<prompt>`) and forked.
+      expect(buildNewTopicPrompt).toHaveBeenCalled();
+      expect((buildNewTopicPrompt as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe('帮我看看这个 bug');
+      expect(forkWorker).toHaveBeenCalledWith(ds, 'WRAPPED:帮我看看这个 bug');
+      expect(ds.pendingRepo).toBe(false);
     });
 
     it('should report an invalid workingDir and not spawn (keeps pending for recovery)', async () => {


### PR DESCRIPTION
通过 /repo 启动会话时（首条消息就是命令本身，无真实 prompt），forkPendingCli 之前总是 buildNewTopicPrompt('') 生成非空样板并提交，CLI 收到一条空 user_message 直接起跑。

修复：仅当有真实缓冲输入（pendingPrompt 非空 / 有附件 / 有 followup）才构建并提交 prompt；否则 forkWorker(ds, '', false) 空载启动 CLI（worker.ts 只在 prompt 为 truthy 时排队初始 prompt），用户下一条消息才是首个 prompt。正常卡片流程（真实首条消息→弹卡→裸 /repo 跳过）的缓冲消息仍照常提交。

测试：command-handler 拆两例——/repo 自启→空载(forkWorker(ds,'',false)、不调 buildNewTopicPrompt)；带缓冲消息裸 /repo→仍 WRAPPED 提交。build 通过，command-handler/event-dispatcher/oncall/inherit 等 231 例全绿。

承接 #64（首条 /repo 起 CLI），同样未发版，随后续测试一起发。