### PR TITLE
feat(task): sync botmux tasks with Feishu tasks

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -8,11 +8,12 @@ import { config } from '../config.js';
 import { getBot, getAllBots, getBotOpenId } from '../bot-registry.js';
 import * as sessionStore from '../services/session-store.js';
 import * as scheduleStore from '../services/schedule-store.js';
+import * as taskStore from '../services/task-store.js';
 import * as scheduler from './scheduler.js';
 import { scanProjects, scanMultipleProjects } from '../services/project-scanner.js';
 import { buildRepoSelectCard, buildAdoptSelectCard, buildSessionClosedCard, getCliDisplayName } from '../im/lark/card-builder.js';
 import { createCliAdapterSync } from '../adapters/cli/registry.js';
-import { deleteMessage, sendMessage, listChatBotMembers } from '../im/lark/client.js';
+import { deleteMessage, sendMessage, replyMessage, listChatBotMembers } from '../im/lark/client.js';
 import { logger } from '../utils/logger.js';
 import { killWorker, forkWorker, forkAdoptWorker, getCurrentCliVersion } from './worker-pool.js';
 import { expandHome, getSessionWorkingDir, getProjectScanDir, getProjectScanDirs, rememberLastCliInput } from './session-manager.js';
@@ -22,6 +23,7 @@ import { generateAuthUrl, getTokenStatus } from '../utils/user-token.js';
 import { bindOncall, unbindOncall, getOncallStatus } from '../services/oncall-store.js';
 import { invalidWorkingDirs } from '../utils/working-dir.js';
 import { resolveRoleFile, writeRoleFile, deleteRoleFile } from './role-resolver.js';
+import { addFeishuTaskAssignee, completeFeishuTask, createFeishuTask, FeishuTaskUnavailableError } from '../services/feishu-task-client.js';
 import type { LarkMessage, DaemonToWorker } from '../types.js';
 import { sessionKey, sessionAnchorId } from './types.js';
 import type { DaemonSession } from './types.js';
@@ -29,7 +31,7 @@ import { t, localeForBot, type Locale } from '../i18n/index.js';
 
 // ─── Exported constants ──────────────────────────────────────────────────────
 
-export const DAEMON_COMMANDS = new Set(['/close', '/restart', '/status', '/help', '/cd', '/repo', '/skip', '/schedule', '/role', '/login', '/adopt', '/oncall', '/group', '/g']);
+export const DAEMON_COMMANDS = new Set(['/close', '/restart', '/status', '/help', '/cd', '/repo', '/skip', '/schedule', '/task', '/role', '/login', '/adopt', '/oncall', '/group', '/g']);
 
 /**
  * Slash commands that are forwarded verbatim to the underlying CLI (e.g.
@@ -354,6 +356,254 @@ async function handleScheduleCommand(
   await sessionReply(rootId, t('schedule.parse_failed', undefined, loc));
 }
 
+
+function taskUsage(): string {
+  return [
+    '用法:',
+    '/task new <name> - 登记当前 thread/chat 的任务（需要已有 session）',
+    '/task list - 列出当前群的任务',
+    '/task status <task-id> - 查看任务状态',
+    '/task close <task-id> - 关闭任务登记（不关闭 session）',
+    '/task assign <task-id> @Bot - 指派任务并显式 @目标 bot',
+  ].join('\n');
+}
+
+function formatTaskStatus(task: taskStore.ManagedTask): string {
+  return [
+    `Task: ${task.taskId}`,
+    `Feishu Task: ${task.externalTaskId ?? '-'}`,
+    `Name: ${task.name}`,
+    `Status: ${task.status}`,
+    `Session: ${task.sessionId}`,
+    `Chat: ${task.chatId}`,
+    `Anchor: ${task.anchor}`,
+    `Bot app: ${task.larkAppId}`,
+    `Owner: ${task.ownerOpenId ? `<at id=${task.ownerOpenId}></at>` : '-'}`,
+    `Assignee: ${task.assigneeOpenId ? `<at id=${task.assigneeOpenId}></at>` : '-'}`,
+    task.externalSyncError ? `Feishu sync: ${task.externalSyncError}` : undefined,
+    `Created: ${task.createdAt}`,
+    `Updated: ${task.updatedAt}`,
+  ].filter(Boolean).join('\n');
+}
+
+function buildTaskHandoffPost(task: taskStore.ManagedTask, assigneeOpenId: string): string {
+  const content: any[][] = [
+    [
+      { tag: 'at', user_id: assigneeOpenId },
+      { tag: 'text', text: ` 请接手任务 ${task.taskId}：${task.name}` },
+    ],
+    [{ tag: 'text', text: `Task: ${task.taskId}` }],
+    [{ tag: 'text', text: `Feishu Task: ${task.externalTaskId ?? '-'}` }],
+    [{ tag: 'text', text: `Session: ${task.sessionId}` }],
+    [{ tag: 'text', text: `Chat: ${task.chatId}` }],
+    [{ tag: 'text', text: `Thread/anchor: ${task.anchor}` }],
+    task.ownerOpenId
+      ? [{ tag: 'text', text: 'Owner: ' }, { tag: 'at', user_id: task.ownerOpenId }]
+      : [{ tag: 'text', text: 'Owner: -' }],
+    [{ tag: 'text', text: '请基于这个 task id 和对应 thread/session 上下文继续处理；这是显式 @ 指派，不依赖 lastCaller footer。' }],
+  ];
+  return JSON.stringify({ zh_cn: { title: '', content } });
+}
+
+function taskSyncError(err: unknown): string {
+  if (err instanceof FeishuTaskUnavailableError) return err.message;
+  return err instanceof Error ? err.message : String(err);
+}
+
+async function tryCreateExternalTask(task: taskStore.ManagedTask): Promise<taskStore.ManagedTask> {
+  try {
+    const external = await createFeishuTask({
+      larkAppId: task.larkAppId,
+      summary: task.name,
+      localTaskId: task.taskId,
+      sessionId: task.sessionId,
+      chatId: task.chatId,
+      anchor: task.anchor,
+      ownerOpenId: task.ownerOpenId,
+    });
+    return taskStore.updateTaskFields(task.taskId, {
+      externalTaskId: external.guid,
+      externalTaskUrl: external.url,
+      externalSyncError: undefined,
+    }) ?? task;
+  } catch (err) {
+    const message = taskSyncError(err);
+    logger.warn(`[task] Feishu task create failed for ${task.taskId}: ${message}`);
+    return taskStore.updateTaskFields(task.taskId, { externalSyncError: message }) ?? task;
+  }
+}
+
+async function tryCompleteExternalTask(task: taskStore.ManagedTask): Promise<taskStore.ManagedTask> {
+  if (!task.externalTaskId) return task;
+  try {
+    await completeFeishuTask(task.larkAppId, task.externalTaskId);
+    return taskStore.updateTaskFields(task.taskId, { externalSyncError: undefined }) ?? task;
+  } catch (err) {
+    const message = taskSyncError(err);
+    logger.warn(`[task] Feishu task complete failed for ${task.taskId}: ${message}`);
+    return taskStore.updateTaskFields(task.taskId, { externalSyncError: message }) ?? task;
+  }
+}
+
+async function tryAssignExternalTask(task: taskStore.ManagedTask, assigneeOpenId: string): Promise<taskStore.ManagedTask> {
+  if (!task.externalTaskId) return task;
+  try {
+    await addFeishuTaskAssignee(task.larkAppId, task.externalTaskId, assigneeOpenId);
+    return taskStore.updateTaskFields(task.taskId, { externalSyncError: undefined }) ?? task;
+  } catch (err) {
+    const message = taskSyncError(err);
+    logger.warn(`[task] Feishu task assign failed for ${task.taskId}: ${message}`);
+    return taskStore.updateTaskFields(task.taskId, { externalSyncError: message }) ?? task;
+  }
+}
+
+function mentionedOpenIds(message: LarkMessage): string[] {
+  return (message.mentions ?? [])
+    .map(m => m.openId)
+    .filter((id): id is string => !!id);
+}
+
+function isCurrentBotMention(openId: string, larkAppId?: string): boolean {
+  if (!larkAppId) return false;
+  const self = getBotOpenId(larkAppId);
+  return !!self && self === openId;
+}
+
+async function handleTaskCommand(
+  args: string,
+  rootId: string,
+  message: LarkMessage,
+  deps: CommandHandlerDeps,
+  larkAppId?: string,
+): Promise<void> {
+  const { activeSessions } = deps;
+  const sessionReply = (rid: string, content: string, msgType?: string) =>
+    deps.sessionReply(rid, content, msgType, larkAppId);
+  const rawDs = larkAppId ? activeSessions.get(sessionKey(rootId, larkAppId)) : undefined;
+  const isEphemeralTaskCommandSession = !!rawDs && !rawDs.hasHistory && !rawDs.worker && rawDs.session.title.trim().startsWith('/task');
+  const commandChatId = rawDs?.chatId;
+  if (isEphemeralTaskCommandSession && larkAppId) {
+    activeSessions.delete(sessionKey(rootId, larkAppId));
+    sessionStore.closeSession(rawDs.session.sessionId);
+  }
+  const ds = isEphemeralTaskCommandSession ? undefined : rawDs;
+  const [subRaw, ...rest] = args.trim().split(/\s+/).filter(Boolean);
+  const sub = subRaw?.toLowerCase();
+
+  if (!sub || sub === 'help' || sub === '帮助') {
+    await sessionReply(rootId, taskUsage());
+    return;
+  }
+
+  if (sub === 'new' || sub === '新建') {
+    const name = rest.join(' ').trim();
+    if (!name) {
+      await sessionReply(rootId, '请提供任务名称：/task new <name>');
+      return;
+    }
+    if (!ds) {
+      await sessionReply(rootId, '当前没有可绑定的 session。请先在独立话题里 @Bot 发起任务，或用 /t <任务内容> 开一个独立任务。');
+      return;
+    }
+    let task = taskStore.createTask({
+      name,
+      chatId: ds.chatId,
+      anchor: sessionAnchorId(ds),
+      sessionId: ds.session.sessionId,
+      larkAppId: ds.larkAppId,
+      ownerOpenId: message.senderId || ds.ownerOpenId || ds.session.ownerOpenId,
+    });
+    task = await tryCreateExternalTask(task);
+    const externalLine = task.externalTaskId
+      ? `Feishu Task: ${task.externalTaskId}`
+      : `Feishu Task: 未创建（${task.externalSyncError ?? 'unknown'}），已降级为本地 task`;
+    await sessionReply(rootId, `✅ 已登记任务 ${task.taskId}\n${externalLine}\nName: ${task.name}\nSession: ${task.sessionId}\nAnchor: ${task.anchor}`);
+    return;
+  }
+
+  if (sub === 'list' || sub === '列表') {
+    const chatId = ds?.chatId ?? commandChatId ?? (() => {
+      const all = taskStore.listTasks();
+      return all.find(t => t.anchor === rootId && t.larkAppId === larkAppId)?.chatId ?? all.find(t => t.anchor === rootId)?.chatId ?? rootId;
+    })();
+    const tasks = taskStore.listTasks({ chatId });
+    if (tasks.length === 0) {
+      await sessionReply(rootId, '当前群还没有登记 task。');
+      return;
+    }
+    const lines = tasks.map(t => `${t.taskId} [${t.status}] ${t.name}\n  feishu=${t.externalTaskId ?? '-'} session=${t.sessionId} anchor=${t.anchor} assignee=${t.assigneeOpenId ? `<at id=${t.assigneeOpenId}></at>` : '-'}`);
+    await sessionReply(rootId, `当前群任务：\n${lines.join('\n')}`);
+    return;
+  }
+
+  if (sub === 'status' || sub === '状态') {
+    const id = rest[0];
+    if (!id) {
+      await sessionReply(rootId, '请提供 task id：/task status <task-id>');
+      return;
+    }
+    const task = taskStore.getTask(id);
+    if (!task) {
+      await sessionReply(rootId, `未找到 task：${id}`);
+      return;
+    }
+    await sessionReply(rootId, formatTaskStatus(task));
+    return;
+  }
+
+  if (sub === 'close' || sub === '关闭') {
+    const id = rest[0];
+    if (!id) {
+      await sessionReply(rootId, '请提供 task id：/task close <task-id>');
+      return;
+    }
+    let task = taskStore.closeTask(id);
+    if (!task) {
+      await sessionReply(rootId, `未找到 task：${id}`);
+      return;
+    }
+    task = await tryCompleteExternalTask(task);
+    const syncLine = task.externalTaskId
+      ? (task.externalSyncError ? `\nFeishu Task 同步失败：${task.externalSyncError}` : '\nFeishu Task 已标记完成。')
+      : '';
+    await sessionReply(rootId, `✅ 已关闭任务 ${task.taskId}${syncLine}\n注意：关联 session 未关闭，如需关闭请在对应话题里使用 /close。`);
+    return;
+  }
+
+  if (sub === 'assign' || sub === '指派') {
+    const id = rest[0];
+    if (!id) {
+      await sessionReply(rootId, '请提供 task id：/task assign <task-id> @Bot');
+      return;
+    }
+    const candidates = mentionedOpenIds(message).filter(openId => !isCurrentBotMention(openId, larkAppId));
+    const assigneeOpenId = candidates[0];
+    if (!assigneeOpenId) {
+      await sessionReply(rootId, '请在 /task assign 命令里显式 @目标 Bot。');
+      return;
+    }
+    let task = taskStore.assignTask(id, assigneeOpenId);
+    if (!task) {
+      await sessionReply(rootId, `未找到 task：${id}`);
+      return;
+    }
+    task = await tryAssignExternalTask(task, assigneeOpenId);
+    const handoff = buildTaskHandoffPost(task, assigneeOpenId);
+    if (!larkAppId) {
+      await sessionReply(rootId, formatTaskStatus(task));
+      return;
+    }
+    if (ds?.scope === 'chat' || task.anchor.startsWith('oc_')) {
+      await sendMessage(larkAppId, task.chatId, handoff, 'post');
+    } else {
+      await replyMessage(larkAppId, task.anchor, handoff, 'post', true);
+    }
+    return;
+  }
+
+  await sessionReply(rootId, taskUsage());
+}
+
 // ─── Main command handler ────────────────────────────────────────────────────
 
 export async function handleCommand(
@@ -628,6 +878,13 @@ export async function handleCommand(
         const chatId = ds?.chatId!;
         await handleScheduleCommand(scheduleArgs, rootId, chatId, deps, larkAppId);
         logger.info(`[${logTag}] Schedule command handled`);
+        break;
+      }
+
+      case '/task': {
+        const taskArgs = message.content.replace(/^\/task\s*/i, '');
+        await handleTaskCommand(taskArgs, rootId, message, deps, larkAppId);
+        logger.info(`[${logTag}] Task command handled`);
         break;
       }
 
@@ -970,6 +1227,10 @@ export async function handleCommand(
           t('help.schedule_remove', undefined, loc),
           t('help.schedule_toggle', undefined, loc),
           t('help.schedule_run', undefined, loc),
+          '',
+          '任务管理:',
+          '/task new <name> — 登记当前任务',
+          '/task list | /task status <id> | /task assign <id> @Bot | /task close <id>',
           '',
           t('help.schedule_formats', undefined, loc),
           '',

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -8,6 +8,22 @@ import { logger } from '../../utils/logger.js';
 import { resolveUserToken } from '../../utils/user-token.js';
 import { listObservedBots } from '../../services/observed-bots-store.js';
 
+type LarkRequestParams = Record<string, string | number | boolean | undefined>;
+
+/**
+ * Call a Feishu GET endpoint without a request body.
+ *
+ * The official SDK currently lets axios attach `{}` as `data` for generated
+ * GET calls such as im.v1.message.list/get. Some gateway deployments reject
+ * GET-with-body and return HTTP 411 before the OpenAPI handler sees the
+ * request. `client.request()` contains an explicit GET empty-body guard, while
+ * still using the SDK's token/cache/auth plumbing, so use it for read-only
+ * message history/detail calls.
+ */
+async function larkGet(c: any, url: string, params: LarkRequestParams = {}): Promise<any> {
+  return c.request({ method: 'GET', url, params });
+}
+
 // Cached lightweight Lark clients for all configured bots (for isInChat checks)
 let allBotClients: Array<{ appId: string; cliId: string; client: InstanceType<typeof Client> }> | null = null;
 function getAllBotClients() {
@@ -314,10 +330,9 @@ export async function getMessageDetail(
   // Without the param, sub-messages still come back in the "Format A"
   // simplified card shape which extractCardContent handles.
   const userCardContent = options.userCardContent ?? true;
-  const res = await c.im.v1.message.get({
-    path: { message_id: messageId },
-    ...(userCardContent ? { params: { card_msg_content_type: 'user_card_content' } } : {}),
-  } as any);
+  const res = await larkGet(c, `/open-apis/im/v1/messages/${encodeURIComponent(messageId)}`, {
+    ...(userCardContent ? { card_msg_content_type: 'user_card_content' } : {}),
+  });
   if (res.code !== 0) {
     throw new Error(`Failed to get message: ${res.msg} (code: ${res.code})`);
   }
@@ -513,7 +528,7 @@ export async function listThreadMessages(larkAppId: string, chatId: string, root
 /** Get the thread_id (omt_xxx) from the root message via message.get. */
 async function resolveThreadId(c: any, rootMessageId: string): Promise<string | undefined> {
   try {
-    const res = await c.im.v1.message.get({ path: { message_id: rootMessageId } });
+    const res = await larkGet(c, `/open-apis/im/v1/messages/${encodeURIComponent(rootMessageId)}`);
     if (res.code === 0) {
       return res.data?.items?.[0]?.thread_id;
     }
@@ -533,14 +548,12 @@ async function listByThread(c: any, threadId: string, pageSize: number): Promise
   let pageToken: string | undefined;
 
   do {
-    const res = await c.im.v1.message.list({
-      params: {
-        container_id_type: 'thread' as any,
-        container_id: threadId,
-        page_size: Math.min(pageSize, LARK_MESSAGE_LIST_MAX_PAGE),
-        sort_type: 'ByCreateTimeAsc' as any,
-        ...(pageToken ? { page_token: pageToken } : {}),
-      },
+    const res = await larkGet(c, '/open-apis/im/v1/messages', {
+      container_id_type: 'thread',
+      container_id: threadId,
+      page_size: Math.min(pageSize, LARK_MESSAGE_LIST_MAX_PAGE),
+      sort_type: 'ByCreateTimeAsc',
+      ...(pageToken ? { page_token: pageToken } : {}),
     });
 
     if (res.code !== 0) {
@@ -572,14 +585,12 @@ export async function listChatMessages(
   let pageToken: string | undefined;
 
   do {
-    const res = await c.im.v1.message.list({
-      params: {
-        container_id_type: 'chat' as any,
-        container_id: chatId,
-        page_size: Math.min(pageSize, LARK_MESSAGE_LIST_MAX_PAGE),
-        sort_type: 'ByCreateTimeDesc' as any,
-        ...(pageToken ? { page_token: pageToken } : {}),
-      },
+    const res = await larkGet(c, '/open-apis/im/v1/messages', {
+      container_id_type: 'chat',
+      container_id: chatId,
+      page_size: Math.min(pageSize, LARK_MESSAGE_LIST_MAX_PAGE),
+      sort_type: 'ByCreateTimeDesc',
+      ...(pageToken ? { page_token: pageToken } : {}),
     });
 
     if (res.code !== 0) {
@@ -659,14 +670,12 @@ async function listByChatFilter(c: any, chatId: string, rootMessageId: string, p
   let pageToken: string | undefined;
 
   do {
-    const res = await c.im.v1.message.list({
-      params: {
-        container_id_type: 'chat' as any,
-        container_id: chatId,
-        page_size: Math.min(pageSize, LARK_MESSAGE_LIST_MAX_PAGE),
-        sort_type: 'ByCreateTimeDesc' as any,
-        ...(pageToken ? { page_token: pageToken } : {}),
-      },
+    const res = await larkGet(c, '/open-apis/im/v1/messages', {
+      container_id_type: 'chat',
+      container_id: chatId,
+      page_size: Math.min(pageSize, LARK_MESSAGE_LIST_MAX_PAGE),
+      sort_type: 'ByCreateTimeDesc',
+      ...(pageToken ? { page_token: pageToken } : {}),
     });
 
     if (res.code !== 0) {

--- a/src/services/feishu-task-client.ts
+++ b/src/services/feishu-task-client.ts
@@ -1,0 +1,159 @@
+import { getBot } from '../bot-registry.js';
+import { logger } from '../utils/logger.js';
+import { resolveUserToken } from '../utils/user-token.js';
+
+const FEISHU_TASK_API_BASE = 'https://open.feishu.cn/open-apis/task/v2';
+
+export interface FeishuTaskRef {
+  guid: string;
+  url?: string;
+}
+
+export class FeishuTaskUnavailableError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'FeishuTaskUnavailableError';
+  }
+}
+
+interface FeishuApiResponse<T = any> {
+  code?: number;
+  msg?: string;
+  data?: T;
+}
+
+async function resolveToken(larkAppId: string): Promise<string> {
+  const bot = getBot(larkAppId);
+  const token = await resolveUserToken(bot.config.larkAppId, bot.config.larkAppSecret);
+  if (!token) {
+    throw new FeishuTaskUnavailableError('missing_user_token');
+  }
+  return token;
+}
+
+async function requestFeishuTask<T>(larkAppId: string, path: string, init: RequestInit): Promise<T> {
+  const token = await resolveToken(larkAppId);
+  const res = await fetch(`${FEISHU_TASK_API_BASE}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json; charset=utf-8',
+      ...(init.headers ?? {}),
+    },
+  });
+
+  let body: FeishuApiResponse<T> | undefined;
+  const text = await res.text();
+  if (text) {
+    try {
+      body = JSON.parse(text) as FeishuApiResponse<T>;
+    } catch (err) {
+      throw new FeishuTaskUnavailableError(`invalid_response:${res.status}`, err);
+    }
+  }
+
+  if (!res.ok || (body?.code ?? 0) !== 0) {
+    const code = body?.code ?? res.status;
+    const msg = body?.msg ?? res.statusText;
+    throw new FeishuTaskUnavailableError(`feishu_task_api_error:${code}:${msg}`);
+  }
+
+  return (body?.data ?? {}) as T;
+}
+
+function trimDescription(description: string): string {
+  // Feishu task description supports up to 3000 UTF-8 chars. Keep a little
+  // room in case multi-byte chars are counted differently by the gateway.
+  return description.length <= 2800 ? description : `${description.slice(0, 2790)}...`;
+}
+
+export function buildBotmuxTaskDescription(input: {
+  localTaskId: string;
+  sessionId: string;
+  chatId: string;
+  anchor: string;
+  larkAppId: string;
+  ownerOpenId?: string;
+}): string {
+  return trimDescription([
+    'Created by botmux.',
+    '',
+    `botmux task id: ${input.localTaskId}`,
+    `session id: ${input.sessionId}`,
+    `chat id: ${input.chatId}`,
+    `thread/anchor: ${input.anchor}`,
+    `lark app id: ${input.larkAppId}`,
+    input.ownerOpenId ? `owner open_id: ${input.ownerOpenId}` : undefined,
+    '',
+    'Use the botmux /task commands in the original chat to inspect, assign, or close the linked CLI task.',
+  ].filter(Boolean).join('\n'));
+}
+
+function extractTaskGuid(data: any): string | undefined {
+  return data?.task?.guid ?? data?.task?.task_guid ?? data?.guid ?? data?.task_guid;
+}
+
+function extractTaskUrl(data: any): string | undefined {
+  return data?.task?.url ?? data?.task?.origin?.href?.url ?? data?.url;
+}
+
+export async function createFeishuTask(input: {
+  larkAppId: string;
+  summary: string;
+  localTaskId: string;
+  sessionId: string;
+  chatId: string;
+  anchor: string;
+  ownerOpenId?: string;
+}): Promise<FeishuTaskRef> {
+  const description = buildBotmuxTaskDescription(input);
+  const payload = {
+    summary: input.summary,
+    description,
+    origin: {
+      platform_i18n_name: { zh_cn: 'botmux', en_us: 'botmux' },
+      href: {
+        url: 'https://github.com/deepcoldy/botmux',
+        title: `botmux ${input.localTaskId}`,
+      },
+    },
+    extra: JSON.stringify({
+      source: 'botmux',
+      localTaskId: input.localTaskId,
+      sessionId: input.sessionId,
+      chatId: input.chatId,
+      anchor: input.anchor,
+      larkAppId: input.larkAppId,
+    }),
+  };
+
+  const data = await requestFeishuTask<any>(input.larkAppId, '/tasks', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const guid = extractTaskGuid(data);
+  if (!guid) throw new FeishuTaskUnavailableError('missing_task_guid');
+  logger.info(`[feishu-task] Created task ${guid} for local task ${input.localTaskId}`);
+  return { guid, url: extractTaskUrl(data) };
+}
+
+export async function completeFeishuTask(larkAppId: string, taskGuid: string): Promise<void> {
+  await requestFeishuTask(larkAppId, `/tasks/${encodeURIComponent(taskGuid)}`, {
+    method: 'PATCH',
+    body: JSON.stringify({
+      update_fields: ['completed_at'],
+      task: { completed_at: String(Date.now()) },
+    }),
+  });
+  logger.info(`[feishu-task] Completed task ${taskGuid}`);
+}
+
+export async function addFeishuTaskAssignee(larkAppId: string, taskGuid: string, openId: string): Promise<void> {
+  await requestFeishuTask(larkAppId, `/tasks/${encodeURIComponent(taskGuid)}/add_members`, {
+    method: 'POST',
+    body: JSON.stringify({
+      members: [{ id: openId, type: 'user', role: 'assignee' }],
+    }),
+  });
+  logger.info(`[feishu-task] Added assignee ${openId} to task ${taskGuid}`);
+}

--- a/src/services/task-store.ts
+++ b/src/services/task-store.ts
@@ -1,0 +1,146 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { config } from '../config.js';
+import { logger } from '../utils/logger.js';
+
+export type ManagedTaskStatus = 'active' | 'closed';
+
+export interface ManagedTask {
+  taskId: string;
+  externalTaskId?: string;
+  externalTaskUrl?: string;
+  externalSyncError?: string;
+  name: string;
+  status: ManagedTaskStatus;
+  chatId: string;
+  anchor: string;
+  sessionId: string;
+  larkAppId: string;
+  ownerOpenId?: string;
+  assigneeOpenId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+let tasks: Map<string, ManagedTask> = new Map();
+let loaded = false;
+
+function getFilePath(): string {
+  return join(config.session.dataDir, 'tasks.json');
+}
+
+function ensureDir(): void {
+  const dir = dirname(getFilePath());
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+function load(): void {
+  if (loaded) return;
+  ensureDir();
+  const fp = getFilePath();
+  if (existsSync(fp)) {
+    try {
+      const data = JSON.parse(readFileSync(fp, 'utf-8')) as Record<string, ManagedTask>;
+      tasks = new Map(Object.entries(data));
+      logger.info(`Loaded ${tasks.size} managed tasks from ${fp}`);
+    } catch (err) {
+      logger.error(`Failed to load managed tasks: ${err}`);
+      tasks = new Map();
+    }
+  }
+  loaded = true;
+}
+
+function save(): void {
+  ensureDir();
+  const fp = getFilePath();
+  const tmpFp = fp + '.tmp';
+  const obj: Record<string, ManagedTask> = {};
+  for (const [k, v] of tasks) obj[k] = v;
+  writeFileSync(tmpFp, JSON.stringify(obj, null, 2), 'utf-8');
+  renameSync(tmpFp, fp);
+}
+
+export function init(): void {
+  loaded = false;
+  tasks = new Map();
+}
+
+function shortId(): string {
+  return `task-${randomUUID().slice(0, 8)}`;
+}
+
+function nextTaskId(): string {
+  let id = shortId();
+  while (tasks.has(id)) id = shortId();
+  return id;
+}
+
+export function createTask(input: {
+  name: string;
+  chatId: string;
+  anchor: string;
+  sessionId: string;
+  larkAppId: string;
+  ownerOpenId?: string;
+  assigneeOpenId?: string;
+}): ManagedTask {
+  load();
+  const now = new Date().toISOString();
+  const task: ManagedTask = {
+    taskId: nextTaskId(),
+    name: input.name,
+    status: 'active',
+    chatId: input.chatId,
+    anchor: input.anchor,
+    sessionId: input.sessionId,
+    larkAppId: input.larkAppId,
+    ownerOpenId: input.ownerOpenId,
+    assigneeOpenId: input.assigneeOpenId,
+    createdAt: now,
+    updatedAt: now,
+  };
+  tasks.set(task.taskId, task);
+  save();
+  return task;
+}
+
+export function getTask(taskId: string): ManagedTask | undefined {
+  load();
+  return tasks.get(taskId);
+}
+
+export function listTasks(filter?: { chatId?: string; status?: ManagedTaskStatus }): ManagedTask[] {
+  load();
+  let out = [...tasks.values()];
+  if (filter?.chatId) out = out.filter(t => t.chatId === filter.chatId);
+  if (filter?.status) out = out.filter(t => t.status === filter.status);
+  return out.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+}
+
+export function updateTask(task: ManagedTask): ManagedTask {
+  load();
+  const next = { ...task, updatedAt: new Date().toISOString() };
+  tasks.set(next.taskId, next);
+  save();
+  return next;
+}
+
+export function updateTaskFields(taskId: string, patch: Partial<ManagedTask>): ManagedTask | undefined {
+  const task = getTask(taskId);
+  if (!task) return undefined;
+  return updateTask({ ...task, ...patch, taskId });
+}
+
+export function closeTask(taskId: string): ManagedTask | undefined {
+  const task = getTask(taskId);
+  if (!task) return undefined;
+  return updateTask({ ...task, status: 'closed' });
+}
+
+export function assignTask(taskId: string, assigneeOpenId: string): ManagedTask | undefined {
+  const task = getTask(taskId);
+  if (!task) return undefined;
+  return updateTask({ ...task, assigneeOpenId });
+}

--- a/src/utils/user-token.ts
+++ b/src/utils/user-token.ts
@@ -159,6 +159,8 @@ const DEFAULT_PORT = 9768;
 const DEFAULT_SCOPES = [
   'im:message:readonly',
   'im:resource',
+  'task:task:read',
+  'task:task:write',
   'offline_access',
 ].join(' ');
 

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -90,6 +90,45 @@ vi.mock('../src/services/schedule-store.js', () => ({
   listTasks: vi.fn(() => []),
 }));
 
+vi.mock('../src/services/task-store.js', () => ({
+  createTask: vi.fn((input: any) => ({
+    taskId: 'task-abc12345',
+    name: input.name,
+    status: 'active',
+    chatId: input.chatId,
+    anchor: input.anchor,
+    sessionId: input.sessionId,
+    larkAppId: input.larkAppId,
+    ownerOpenId: input.ownerOpenId,
+    createdAt: '2026-05-25T00:00:00.000Z',
+    updatedAt: '2026-05-25T00:00:00.000Z',
+  })),
+  listTasks: vi.fn(() => []),
+  getTask: vi.fn(),
+  closeTask: vi.fn(),
+  assignTask: vi.fn(),
+  updateTaskFields: vi.fn((id: string, patch: any) => ({
+    taskId: id,
+    name: 'Fix login',
+    status: 'active',
+    chatId: 'oc_chat_xyz',
+    anchor: 'om_root_abc123',
+    sessionId: 'sess-001',
+    larkAppId: 'app-1',
+    ownerOpenId: 'ou_sender',
+    createdAt: '2026-05-25T00:00:00.000Z',
+    updatedAt: '2026-05-25T00:00:00.000Z',
+    ...patch,
+  })),
+}));
+
+vi.mock('../src/services/feishu-task-client.js', () => ({
+  FeishuTaskUnavailableError: class FeishuTaskUnavailableError extends Error {},
+  createFeishuTask: vi.fn(async () => ({ guid: 'feishu-task-guid' })),
+  completeFeishuTask: vi.fn(async () => undefined),
+  addFeishuTaskAssignee: vi.fn(async () => undefined),
+}));
+
 vi.mock('../src/core/scheduler.js', () => ({
   removeTask: vi.fn(),
   enableTask: vi.fn(),
@@ -125,6 +164,7 @@ vi.mock('../src/im/lark/card-builder.js', () => ({
 vi.mock('../src/im/lark/client.js', () => ({
   deleteMessage: vi.fn(),
   sendMessage: vi.fn(async () => 'card-msg-id'),
+  replyMessage: vi.fn(async () => 'reply-msg-id'),
   listChatBotMembers: vi.fn(async () => []),
 }));
 
@@ -196,12 +236,14 @@ import { killWorker, forkWorker, getCurrentCliVersion } from '../src/core/worker
 import { getSessionWorkingDir } from '../src/core/session-manager.js';
 import * as sessionStore from '../src/services/session-store.js';
 import * as scheduleStore from '../src/services/schedule-store.js';
+import * as taskStore from '../src/services/task-store.js';
 import * as scheduler from '../src/core/scheduler.js';
-import { deleteMessage, sendMessage, listChatBotMembers } from '../src/im/lark/client.js';
+import { deleteMessage, sendMessage, replyMessage, listChatBotMembers } from '../src/im/lark/client.js';
 import { createGroupWithBots } from '../src/services/group-creator.js';
 import { getAllBots } from '../src/bot-registry.js';
 import { generateAuthUrl, getTokenStatus } from '../src/utils/user-token.js';
 import { bindOncall } from '../src/services/oncall-store.js';
+import { addFeishuTaskAssignee, completeFeishuTask, createFeishuTask } from '../src/services/feishu-task-client.js';
 import { existsSync, statSync, readFileSync } from 'node:fs';
 import { scanMultipleProjects } from '../src/services/project-scanner.js';
 import { discoverAdoptableSessions } from '../src/core/session-discovery.js';
@@ -271,7 +313,7 @@ function makeDeps(ds?: DaemonSession): CommandHandlerDeps {
 
 describe('DAEMON_COMMANDS set', () => {
   it('should contain all expected commands', () => {
-    const expected = ['/close', '/restart', '/status', '/help', '/cd', '/repo', '/skip', '/schedule', '/role', '/login', '/adopt', '/oncall', '/group', '/g'];
+    const expected = ['/close', '/restart', '/status', '/help', '/cd', '/repo', '/skip', '/schedule', '/task', '/role', '/login', '/adopt', '/oncall', '/group', '/g'];
     for (const cmd of expected) {
       expect(DAEMON_COMMANDS.has(cmd), `Expected DAEMON_COMMANDS to contain ${cmd}`).toBe(true);
     }
@@ -288,7 +330,7 @@ describe('DAEMON_COMMANDS set', () => {
   });
 
   it('should have the correct size', () => {
-    expect(DAEMON_COMMANDS.size).toBe(14);
+    expect(DAEMON_COMMANDS.size).toBe(15);
   });
 });
 
@@ -403,6 +445,177 @@ describe('parseForceTopicInvocation', () => {
 describe('handleCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+
+  // ─── /task ──────────────────────────────────────────────────────────────
+
+  describe('/task', () => {
+    it('registers the current session as a managed task', async () => {
+      const ds = makeDaemonSession();
+      const deps = makeDeps(ds);
+
+      await handleCommand('/task', ROOT_ID, makeLarkMessage('/task new Fix login'), deps, LARK_APP_ID);
+
+      expect(taskStore.createTask).toHaveBeenCalledWith(expect.objectContaining({
+        name: 'Fix login',
+        chatId: CHAT_ID,
+        anchor: ROOT_ID,
+        sessionId: 'sess-001',
+        larkAppId: LARK_APP_ID,
+        ownerOpenId: 'ou_sender',
+      }));
+      expect(deps.sessionReply).toHaveBeenCalledWith(
+        ROOT_ID,
+        expect.stringContaining('task-abc12345'),
+        undefined,
+        LARK_APP_ID,
+      );
+      expect(createFeishuTask).toHaveBeenCalledWith(expect.objectContaining({
+        localTaskId: 'task-abc12345',
+        summary: 'Fix login',
+        sessionId: 'sess-001',
+      }));
+      expect((deps.sessionReply as any).mock.calls[0][1]).toContain('feishu-task-guid');
+    });
+
+    it('falls back to local task when Feishu task creation is unavailable', async () => {
+      vi.mocked(createFeishuTask).mockRejectedValueOnce(new Error('missing_user_token'));
+      const ds = makeDaemonSession();
+      const deps = makeDeps(ds);
+
+      await handleCommand('/task', ROOT_ID, makeLarkMessage('/task new Fix login'), deps, LARK_APP_ID);
+
+      expect(taskStore.createTask).toHaveBeenCalled();
+      expect(taskStore.updateTaskFields).toHaveBeenCalledWith('task-abc12345', expect.objectContaining({
+        externalSyncError: 'missing_user_token',
+      }));
+      expect((deps.sessionReply as any).mock.calls[0][1]).toContain('已降级为本地 task');
+    });
+
+    it('refuses /task new when there is no active session to bind', async () => {
+      const deps = makeDeps();
+
+      await handleCommand('/task', ROOT_ID, makeLarkMessage('/task new Fix login'), deps, LARK_APP_ID);
+
+      expect(taskStore.createTask).not.toHaveBeenCalled();
+      expect(deps.sessionReply).toHaveBeenCalledWith(
+        ROOT_ID,
+        expect.stringContaining('当前没有可绑定的 session'),
+        undefined,
+        LARK_APP_ID,
+      );
+    });
+
+    it('lists tasks filtered by current chat without mixing sessions', async () => {
+      vi.mocked(taskStore.listTasks).mockReturnValueOnce([
+        {
+          taskId: 'task-a', name: 'A', status: 'active', chatId: CHAT_ID, anchor: 'om_a', sessionId: 'sess-a', larkAppId: LARK_APP_ID, createdAt: '1', updatedAt: '1',
+        } as any,
+        {
+          taskId: 'task-b', name: 'B', status: 'active', chatId: CHAT_ID, anchor: 'om_b', sessionId: 'sess-b', larkAppId: LARK_APP_ID, createdAt: '2', updatedAt: '2',
+        } as any,
+      ]);
+      const ds = makeDaemonSession();
+      const deps = makeDeps(ds);
+
+      await handleCommand('/task', ROOT_ID, makeLarkMessage('/task list'), deps, LARK_APP_ID);
+
+      expect(taskStore.listTasks).toHaveBeenCalledWith({ chatId: CHAT_ID });
+      const body = (deps.sessionReply as any).mock.calls[0][1] as string;
+      expect(body).toContain('task-a');
+      expect(body).toContain('sess-a');
+      expect(body).toContain('task-b');
+      expect(body).toContain('sess-b');
+    });
+
+    it('assigns a task by explicit mention and sends handoff without sessionReply footer', async () => {
+      vi.mocked(taskStore.updateTaskFields).mockImplementationOnce((_id: string, patch: any) => ({
+        taskId: 'task-a',
+        externalTaskId: 'feishu-a',
+        name: 'Fix A',
+        status: 'active',
+        chatId: CHAT_ID,
+        anchor: ROOT_ID,
+        sessionId: 'sess-a',
+        larkAppId: LARK_APP_ID,
+        ownerOpenId: 'ou_owner',
+        assigneeOpenId: 'ou_target_bot',
+        createdAt: '1',
+        updatedAt: '2',
+        ...patch,
+      } as any));
+      vi.mocked(taskStore.assignTask).mockReturnValueOnce({
+        taskId: 'task-a',
+        externalTaskId: 'feishu-a',
+        name: 'Fix A',
+        status: 'active',
+        chatId: CHAT_ID,
+        anchor: ROOT_ID,
+        sessionId: 'sess-a',
+        larkAppId: LARK_APP_ID,
+        ownerOpenId: 'ou_owner',
+        assigneeOpenId: 'ou_target_bot',
+        createdAt: '1',
+        updatedAt: '2',
+      } as any);
+      const ds = makeDaemonSession({ session: makeSession({ sessionId: 'sess-a' }), scope: 'thread' });
+      const deps = makeDeps(ds);
+      const msg = makeLarkMessage('/task assign task-a @Codex', {
+        mentions: [{ key: '@_user_1', name: 'Codex', openId: 'ou_target_bot' }],
+      });
+
+      await handleCommand('/task', ROOT_ID, msg, deps, LARK_APP_ID);
+
+      expect(taskStore.assignTask).toHaveBeenCalledWith('task-a', 'ou_target_bot');
+      expect(addFeishuTaskAssignee).toHaveBeenCalledWith(LARK_APP_ID, 'feishu-a', 'ou_target_bot');
+      expect(replyMessage).toHaveBeenCalledWith(
+        LARK_APP_ID,
+        ROOT_ID,
+        expect.stringContaining('"tag":"at","user_id":"ou_target_bot"'),
+        'post',
+        true,
+      );
+      const postJson = vi.mocked(replyMessage).mock.calls[0][2] as string;
+      const post = JSON.parse(postJson);
+      expect(post.zh_cn.content[0][0]).toEqual({ tag: 'at', user_id: 'ou_target_bot' });
+      expect(deps.sessionReply).not.toHaveBeenCalled();
+    });
+
+    it('completes the linked Feishu task when closing a managed task', async () => {
+      vi.mocked(taskStore.updateTaskFields).mockImplementationOnce((_id: string, patch: any) => ({
+        taskId: 'task-a',
+        externalTaskId: 'feishu-a',
+        name: 'Fix A',
+        status: 'closed',
+        chatId: CHAT_ID,
+        anchor: ROOT_ID,
+        sessionId: 'sess-a',
+        larkAppId: LARK_APP_ID,
+        createdAt: '1',
+        updatedAt: '2',
+        ...patch,
+      } as any));
+      vi.mocked(taskStore.closeTask).mockReturnValueOnce({
+        taskId: 'task-a',
+        externalTaskId: 'feishu-a',
+        name: 'Fix A',
+        status: 'closed',
+        chatId: CHAT_ID,
+        anchor: ROOT_ID,
+        sessionId: 'sess-a',
+        larkAppId: LARK_APP_ID,
+        createdAt: '1',
+        updatedAt: '2',
+      } as any);
+      const ds = makeDaemonSession({ session: makeSession({ sessionId: 'sess-a' }), scope: 'thread' });
+      const deps = makeDeps(ds);
+
+      await handleCommand('/task', ROOT_ID, makeLarkMessage('/task close task-a'), deps, LARK_APP_ID);
+
+      expect(completeFeishuTask).toHaveBeenCalledWith(LARK_APP_ID, 'feishu-a');
+      expect((deps.sessionReply as any).mock.calls[0][1]).toContain('Feishu Task 已标记完成');
+    });
   });
 
   // ─── /close ─────────────────────────────────────────────────────────────

--- a/test/task-store.test.ts
+++ b/test/task-store.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+let tempDir: string;
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    session: {
+      get dataDir() { return tempDir; },
+    },
+  },
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+import * as taskStore from '../src/services/task-store.js';
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'botmux-task-store-test-'));
+  taskStore.init();
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('task-store', () => {
+  it('creates, lists, assigns, closes, and reloads tasks', () => {
+    const task = taskStore.createTask({
+      name: 'Fix A',
+      chatId: 'oc_chat',
+      anchor: 'om_root_a',
+      sessionId: 'sess-a',
+      larkAppId: 'app-a',
+      ownerOpenId: 'ou_owner',
+    });
+
+    expect(task.taskId).toMatch(/^task-/);
+    expect(task.status).toBe('active');
+    expect(taskStore.getTask(task.taskId)?.name).toBe('Fix A');
+    expect(taskStore.listTasks({ chatId: 'oc_chat' })).toHaveLength(1);
+    expect(taskStore.listTasks({ chatId: 'oc_other' })).toHaveLength(0);
+
+    const assigned = taskStore.assignTask(task.taskId, 'ou_bot')!;
+    expect(assigned.assigneeOpenId).toBe('ou_bot');
+    expect(assigned.updatedAt >= task.updatedAt).toBe(true);
+
+    const linked = taskStore.updateTaskFields(task.taskId, {
+      externalTaskId: 'feishu-guid-1',
+      externalTaskUrl: 'https://example.com/task/1',
+    })!;
+    expect(linked.externalTaskId).toBe('feishu-guid-1');
+
+    const closed = taskStore.closeTask(task.taskId)!;
+    expect(closed.status).toBe('closed');
+    expect(taskStore.listTasks({ chatId: 'oc_chat', status: 'active' })).toHaveLength(0);
+
+    taskStore.init();
+    const reloaded = taskStore.getTask(task.taskId)!;
+    expect(reloaded.status).toBe('closed');
+    expect(reloaded.assigneeOpenId).toBe('ou_bot');
+    expect(reloaded.externalTaskId).toBe('feishu-guid-1');
+  });
+
+  it('keeps multiple tasks in the same chat bound to different sessions', () => {
+    const a = taskStore.createTask({ name: 'A', chatId: 'oc_chat', anchor: 'om_a', sessionId: 'sess-a', larkAppId: 'app-a' });
+    const b = taskStore.createTask({ name: 'B', chatId: 'oc_chat', anchor: 'om_b', sessionId: 'sess-b', larkAppId: 'app-a' });
+
+    const tasks = taskStore.listTasks({ chatId: 'oc_chat' });
+    expect(tasks.map(t => t.taskId)).toEqual([a.taskId, b.taskId]);
+    expect(tasks.map(t => t.sessionId)).toEqual(['sess-a', 'sess-b']);
+    expect(tasks.map(t => t.anchor)).toEqual(['om_a', 'om_b']);
+  });
+});


### PR DESCRIPTION
## Summary
- add local /task management store and daemon command handling
- sync created/assigned/closed botmux tasks to Feishu Task when user token permissions are available
- add task scopes and tests for the new task flow

## Tests
- pnpm vitest run test/task-store.test.ts test/command-handler.test.ts
- pnpm build

## Release
- v2.47.0 published to npm latest