### PR TITLE
ci(release): 正式版必须从含最新 master 的 commit 发，拦截分叉分支发版

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,25 @@ jobs:
             exit 1
           fi
 
+      - name: Guard — stable release must contain the latest master
+        # 正式版（latest）只能从「包含最新 master 的 commit」上发：被打 tag 的 commit
+        # 必须把 origin/master 当作祖先——即直接在 master 上打 tag，或在已 rebase 到最新
+        # master 的子分支上打 tag。否则拒绝，防止从落后/分叉的个人分支打出正式版（曾发生
+        # v2.47.0 从落后 master 175 个 commit 的分支发到 latest，丢了一大批 master 改动）。
+        # canary/beta/rc/next 走旁路 dist-tag、用于分支灰度，不受此约束。
+        # 注意竞态：若打完 tag 后、本 job fetch 前 master 又前进了，这里会判定 tag 落后而
+        # fail（fail-closed，安全方向）——重新 fetch master 后在新 HEAD 上重打 tag 即可。
+        if: steps.dist_tag.outputs.tag == 'latest'
+        run: |
+          git fetch origin master --quiet
+          if ! git merge-base --is-ancestor origin/master HEAD; then
+            echo "REFUSING: tagged commit $(git rev-parse --short HEAD) does not contain the latest origin/master ($(git rev-parse --short origin/master))."
+            echo "Stable (latest) releases must be tagged on master, or on a branch rebased onto the latest master."
+            echo "Fix: rebase/merge onto origin/master then re-tag — or use a -canary/-beta/-rc suffix to publish off-master for testing."
+            exit 1
+          fi
+          echo "OK: tagged commit contains origin/master ($(git rev-parse --short origin/master))."
+
       - run: pnpm build
 
       - name: Publish to npm

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ pnpm daemon:logs          # 查看日志
 - **日常提交**：正常 `git commit` + `git push`，不会触发发版
 - **发版**：打 `v*` tag 并 push 即可，GitHub Action 自动从 tag 提取版本号写入 `package.json` 后发布 npm + 创建 GitHub Release
 - **不要**手动修改 `package.json` 的 `version` 字段来发版，CI 会自动处理
+- **正式版（latest）必须从 master 出**：CI 校验被打 tag 的 commit 含最新 `origin/master`（直接在 master 上打 tag，或在已 rebase 到最新 master 的子分支上打）。落后/分叉的分支打正式版会被拒绝。要从非 master 分支灰度，用 `-canary`/`-beta`/`-rc` 后缀走旁路 dist-tag
 - commit message 格式：`type(scope): 中文描述`。`type`（feat/fix/docs/chore 等）和 `scope`（模块名）保留英文，冒号后的描述用中文
 - 发版的 annotated tag message 用中文撰写，CI 会把 tag message 作为 GitHub Release body
 


### PR DESCRIPTION
release.yml 对发版分支零限制：任意 v* tag → checkout 该 commit → 纯净 vX.Y.Z 直发 npm latest，唯一闸是「禁止降级」。于是可从落后/分叉的个人分支打出正式版（v2.47.0 即从落后 master 175 commit 的 hotfix 分支发到 latest，丢了大批 master 改动）。

新增 latest-only 护栏：fetch origin/master 后 `git merge-base --is-ancestor origin/master HEAD`——被打 tag 的 commit 必须含最新 master（直接发 master，或发 rebase 到最新 master 的子分支），否则 fail。canary/beta/rc/next 走旁路 dist-tag 不受约束。

已校验 YAML 结构有效（12 steps）。CLAUDE.md 发版规范同步补一条。