### PR TITLE
docs(docs-site): 文档站源码入库 + 维护/发布说明（token 不入库）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ midscene_run/
 .antigravitycli/
 .cjadk/
 .trae/
+# magic / 妙笔发布 token 与 app 映射（含密钥，绝不提交）
+.magic-token
+.magic-apps.json
+docs-site/.magic-token

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -1,0 +1,60 @@
+# botmux 文档站
+
+botmux 的中文功能文档站，发布在**飞书妙笔（HTML Box）**上。
+
+- 线上地址：<https://magic.solutionsuite.cn/html-box/vkWHeJn1Fn2>
+- 源码：本目录的 [`index.html`](./index.html)
+
+## 形态
+
+一个**自包含的单文件 HTML 应用**（妙笔 HTML Box 是「一个 HTML = 一个应用」模型，扛不了多页静态站，所以做成单页富 SPA）：
+
+- 左侧导航树 + 站内搜索（`/` 唤起）+ 代码高亮 + 移动端自适应（汉堡菜单）
+- 依赖（Tailwind / marked / highlight.js）走 CDN
+- **文档内容**内嵌在 `<script type="text/markdown" data-doc="...">` 块里，写纯 Markdown 即可
+- **导航结构**由 JS 里的 `NAV` 数组定义（每项 `[data-doc, 标题]`，需与某个 markdown 块的 `data-doc` 对应）
+- 图片走 **TOS 外链**（不内联，保持 HTML 精简）
+
+> ⚠️ 妙笔把页面跑在 **无 `allow-same-origin` 的 sandbox iframe** 里：写 `location.hash` 会触发 iframe 重载、把视图打回首页，所以路由不依赖 hash、点击直接 `render()`（代码里有 `IN_IFRAME` 判断）。改路由相关逻辑时注意这点。
+
+## 维护（改内容）
+
+直接编辑 `index.html`：
+
+- 改/加某节内容 → 改对应的 `<script type="text/markdown" data-doc="xxx">` 块（纯 Markdown）。
+- 加新一节 → 新增一个 markdown 块 + 在 `NAV` 数组里加一项指向它的 `data-doc`。
+- 本地预览 → 浏览器直接打开 `index.html` 即可（本地非 iframe，hash 路由可用）。
+
+### 加图片
+
+截图 / GIF 先传 TOS 拿公开 URL，再在 Markdown 里 `![](url)` 外链（**不要内联 base64**，会撑大 HTML）：
+
+```bash
+# magic-builder 技能里的上传脚本
+node <magic-builder>/upload-file-to-tos/scripts/upload.js ./your-image.png -q
+```
+
+## 发布（到飞书妙笔）
+
+发布用妙笔官方的 **magic-builder** 技能，**token 只存在你本机、永不进仓库**：
+
+1. 安装 magic-builder 技能：下载并解压 <https://magic-builder.tos-cn-beijing.volces.com/skills/magic-builder.skill.zip>
+2. 拿**你自己的**妙笔开发 token：给妙笔机器人（<https://applink.larkoffice.com/T94fcr4NqQPz>）发 `dev`，复制返回的 token。
+3. 存 token（写到 `~/.magic-token`，已被 `.gitignore` 忽略，**绝不要提交**）：
+   ```bash
+   node <magic-builder>/publish-magic-page/scripts/publish.js token <你的token>
+   ```
+4. 发布：
+   ```bash
+   node <magic-builder>/publish-magic-page/scripts/publish.js publish docs-site/index.html --title "botmux 文档"
+   ```
+
+### 谁能发布？会暴露我的 token 吗？
+
+- **不会暴露**：token 只在各自本机的 `~/.magic-token` 里，从不进仓库。每个维护者用**自己的**妙笔账号 token。
+- **人人可维护源码**：`index.html` 在仓库里，任何人都能改、提 PR。
+- **关于官方线上 URL**：妙笔 app 绑定在「发布者的妙笔账号」下。
+  - 用你自己的 token 首次发布，会在**你账号下新建一个 app**（你自己的预览 URL）——适合自测 / 预览。
+  - 要更新**官方那个站**（`vkWHeJn1Fn2`），需由持有该 app 的妙笔账号 token 的人来发（magic-builder 按「相对路径 → remoteId」映射做原地更新，所以**在仓库根目录、用同一文件路径**发布即可命中原 app，不会产生重复）。
+
+> 简言之：**源码人人可改、可各自发预览；官方站的更新由 owner 跑一条命令完成**。

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -1014,54 +1014,11 @@ botmux 通过适配器桥接不同 CLI，`bots.json` 里用 `cliId` 选择。一
 3. **`chmod +x` 加可执行位（最容易漏！）**——botmux 用 node-pty 直接 exec 脚本，没有可执行位会 `EACCES`、CLI 起来即退、bot 崩溃重启。
 4. **直接执行脚本验证**（用 `~/.botmux/bin/xxx --version`，别用 `bash xxx` 测——走 bash 不需要可执行位会掩盖第 3 步问题）。然后在 `bots.json` 配 `cliPathOverride`（写**绝对路径**，别用 `~`），`botmux restart` 生效。
 
-**示例 · ttadk × claude**（`~/.botmux/bin/ttadk-claude`，记得 `chmod +x`）：
+各网关的**具体 wrapper 脚本**见对应配置文档（这些文档随上游更新，这里只放链接、不复制原文）：
 
-```bash
-#!/usr/bin/env bash
-if [ "$#" -eq 0 ]; then exec ttadk claude --model glm-5 --skip-check; fi
-argv=""; for arg in "$@"; do [ -n "$argv" ] && argv="$argv "; argv="$argv$(printf '%q' "$arg")"; done
-exec ttadk claude --model glm-5 --skip-check --args "$argv"
-```
-
-```json
-{ "cliId": "claude-code", "cliPathOverride": "/root/.botmux/bin/ttadk-claude" }
-```
-
-**示例 · aiden × claude**（剥掉 `--settings`，其余透传）：
-
-```bash
-#!/usr/bin/env bash
-args=(); skip=0
-for a in "$@"; do
-  [ $skip = 1 ] && { skip=0; continue; }
-  case "$a" in --settings) skip=1; continue;; --settings=*) continue;; esac
-  args+=("$a")
-done
-exec aiden x claude "${args[@]}"
-```
-
-```json
-{ "cliId": "claude-code", "cliPathOverride": "/root/.botmux/bin/aiden-x-claude" }
-```
-
-**示例 · aiden × codex**（codex 需要真 TTY 才能写 `history.jsonl`，用 `script` 强套 PTY 兜底）：
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-MODEL=gpt-5.5-paygo
-if script --version 2>/dev/null | grep -qi util-linux; then
-  exec script -qfe -c "exec aiden x codex --model $MODEL $(printf '%q ' "$@")" /dev/null
-else
-  exec script -q /dev/null aiden x codex --model "$MODEL" "$@"
-fi
-```
-
-```json
-{ "cliId": "codex", "cliPathOverride": "/root/.botmux/bin/aiden-x-codex" }
-```
-
-> **MTR**：社区贡献的接入方式，安装 `npm i -g @metamove-code/mtr-cli@latest`、`/login` 选 metamove 登录（开发机用 scan SSO）后按其文档接入。详见各自的飞书配置文档。
+- **aiden × claude / aiden × codex** — [配置文档](https://bytedance.larkoffice.com/docx/T63VdOsCxoLnlSxCjARcd6ocnNf)（aiden×codex 需用 `script` 强套 PTY）
+- **ttadk** — [配置指南](https://bytedance.larkoffice.com/docx/SkG3dVFLsoRnNgxzE6NcvdeCnws)（含各 CLI 的 wrapper 脚本一览）
+- **MTR** — [使用文档](https://bytedance.larkoffice.com/wiki/XjYKwXjlTivKoWksIVtcnmN6noH)（社区贡献，`npm i -g @metamove-code/mtr-cli@latest`）
 >
 > 排查 wrapper 问题的通用手法：`botmux logs` 找 `Spawning fresh CLI:` 那行，复制完整命令在本地手动跑一遍即可定位（权限 / 参数黑名单 / 登录态）。
 

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -1,0 +1,1496 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="use-iframe" content="true">
+  <meta name="html-box-height-mode" content="viewport">
+  <title>botmux 文档 · 飞书话题群 ↔ AI 编程 CLI</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/highlight.min.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github.min.css">
+  <style>
+    :root { --brand:#6d4aff; --brand-2:#8b6cff; --ink:#1f2330; --muted:#6b7280; --line:#e9eaf0; --bg:#ffffff; --sidebar:#fafafb; --code-bg:#f6f7f9; }
+    * { box-sizing:border-box; }
+    html,body { height:100%; margin:0; }
+    body { font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Hiragino Sans GB","Microsoft YaHei",Roboto,Helvetica,Arial,sans-serif; color:var(--ink); background:var(--bg); -webkit-font-smoothing:antialiased; }
+    .app { display:flex; flex-direction:column; height:100vh; overflow:hidden; }
+    /* top bar */
+    .topbar { height:56px; flex:0 0 56px; display:flex; align-items:center; gap:14px; padding:0 18px; border-bottom:1px solid var(--line); background:rgba(255,255,255,.9); backdrop-filter:blur(8px); z-index:30; }
+    .brand { display:flex; align-items:center; gap:10px; font-weight:700; font-size:16px; letter-spacing:.2px; cursor:pointer; }
+    .brand .logo { width:26px; height:26px; border-radius:7px; background:linear-gradient(135deg,var(--brand),var(--brand-2)); display:flex; align-items:center; justify-content:center; color:#fff; font-weight:800; font-size:14px; }
+    .ver { font-size:11px; color:var(--muted); border:1px solid var(--line); padding:1px 7px; border-radius:999px; }
+    .grow { flex:1; }
+    .search-btn { display:flex; align-items:center; gap:8px; height:34px; padding:0 12px; border:1px solid var(--line); border-radius:9px; background:#fff; color:var(--muted); font-size:13px; cursor:pointer; min-width:200px; }
+    .search-btn kbd { margin-left:auto; font-size:11px; background:var(--code-bg); border:1px solid var(--line); border-radius:5px; padding:1px 6px; }
+    .gh { color:var(--ink); opacity:.75; text-decoration:none; display:flex; align-items:center; }
+    .gh:hover { opacity:1; }
+    .hamb { display:none; border:none; background:none; cursor:pointer; padding:6px; }
+    /* layout */
+    .body { flex:1; display:flex; min-height:0; }
+    .sidebar { width:280px; flex:0 0 280px; border-right:1px solid var(--line); background:var(--sidebar); overflow-y:auto; padding:16px 10px 60px; }
+    .nav-group { margin:6px 0 14px; }
+    .nav-group > .gtitle { font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:.08em; color:var(--muted); padding:6px 12px; }
+    .nav-item { display:block; padding:7px 12px; margin:1px 4px; border-radius:8px; color:#3a3f4b; text-decoration:none; font-size:13.5px; line-height:1.3; cursor:pointer; }
+    .nav-item:hover { background:#f0eefb; color:var(--brand); }
+    .nav-item.active { background:linear-gradient(135deg,var(--brand),var(--brand-2)); color:#fff; font-weight:600; }
+    .content { flex:1; overflow-y:auto; padding:38px 48px 120px; scroll-behavior:smooth; }
+    .content-inner { max-width:820px; margin:0 auto; }
+    /* markdown typography */
+    .md h1 { font-size:30px; font-weight:800; margin:0 0 6px; letter-spacing:-.01em; }
+    .md h2 { font-size:22px; font-weight:700; margin:34px 0 12px; padding-top:10px; border-top:1px solid var(--line); }
+    .md h2:first-of-type { border-top:none; padding-top:0; margin-top:22px; }
+    .md h3 { font-size:17px; font-weight:700; margin:24px 0 8px; }
+    .md h4 { font-size:15px; font-weight:700; margin:18px 0 6px; color:#33384a; }
+    .md p { line-height:1.78; margin:12px 0; color:#33384a; }
+    .md a { color:var(--brand); text-decoration:none; border-bottom:1px solid rgba(109,74,255,.3); }
+    .md a:hover { border-bottom-color:var(--brand); }
+    .md ul,.md ol { padding-left:24px; line-height:1.8; color:#33384a; }
+    .md li { margin:5px 0; }
+    .md code { font-family:"SF Mono",ui-monospace,Menlo,Consolas,monospace; font-size:13px; background:var(--code-bg); border:1px solid var(--line); border-radius:5px; padding:1.5px 6px; color:#b3308b; }
+    .md pre { background:var(--code-bg); border:1px solid var(--line); border-radius:12px; padding:16px 18px; overflow-x:auto; margin:14px 0; }
+    .md pre code { background:none; border:none; padding:0; color:#1f2330; font-size:13px; line-height:1.65; }
+    .md blockquote { margin:14px 0; padding:10px 16px; border-left:3px solid var(--brand); background:#f7f5ff; border-radius:0 8px 8px 0; color:#4a4f5e; }
+    .md blockquote p { margin:4px 0; }
+    .md table { border-collapse:collapse; width:100%; margin:16px 0; font-size:13.5px; display:block; overflow-x:auto; }
+    .md th,.md td { border:1px solid var(--line); padding:9px 12px; text-align:left; vertical-align:top; }
+    .md th { background:#f4f2fd; font-weight:700; white-space:nowrap; }
+    .md tr:nth-child(even) td { background:#fafafb; }
+    .md hr { border:none; border-top:1px solid var(--line); margin:30px 0; }
+    .md img { max-width:100%; border-radius:10px; border:1px solid var(--line); margin:16px 0; display:block; box-shadow:0 1px 6px rgba(0,0,0,.05); }
+    .md .cap { font-size:12.5px; color:var(--muted); margin:-8px 0 16px; }
+    .md .lead { font-size:16px; color:var(--muted); line-height:1.7; margin:8px 0 20px; }
+    .pager { display:flex; justify-content:space-between; gap:14px; margin-top:50px; padding-top:24px; border-top:1px solid var(--line); }
+    .pager .pgl { flex:1; border:1px solid var(--line); border-radius:12px; padding:14px 18px; text-decoration:none; color:var(--ink); cursor:pointer; }
+    .pager .pgl:hover { border-color:var(--brand); background:#faf9ff; }
+    .pager .dir { font-size:11px; color:var(--muted); }
+    .pager .ttl { font-weight:600; color:var(--brand); margin-top:3px; }
+    .pager .next { text-align:right; }
+    .docfoot { margin-top:40px; font-size:12.5px; color:var(--muted); }
+    /* search modal */
+    .overlay { position:fixed; inset:0; background:rgba(20,20,30,.4); backdrop-filter:blur(2px); z-index:50; display:none; align-items:flex-start; justify-content:center; padding-top:12vh; }
+    .overlay.show { display:flex; }
+    .searchbox { width:90%; max-width:640px; background:#fff; border-radius:16px; box-shadow:0 24px 64px rgba(0,0,0,.28); overflow:hidden; }
+    .searchbox input { width:100%; border:none; outline:none; padding:18px 20px; font-size:16px; border-bottom:1px solid var(--line); }
+    .results { max-height:52vh; overflow-y:auto; }
+    .result { padding:12px 20px; border-bottom:1px solid #f2f2f5; cursor:pointer; }
+    .result:hover,.result.sel { background:#f4f2fd; }
+    .result .rt { font-weight:600; font-size:14px; color:var(--brand); }
+    .result .rg { font-size:11px; color:var(--muted); margin-left:8px; }
+    .result .rs { font-size:12.5px; color:var(--muted); margin-top:3px; line-height:1.5; }
+    .result .rs mark { background:#ffe9a8; color:inherit; border-radius:2px; padding:0 1px; }
+    .noresult { padding:24px 20px; color:var(--muted); text-align:center; font-size:14px; }
+    /* mobile */
+    .backdrop { display:none; }
+    @media (max-width:860px){
+      .content { padding:24px 18px 100px; }
+      .search-btn { min-width:0; width:38px; padding:0; justify-content:center; }
+      .search-btn .stxt,.search-btn kbd { display:none; }
+      .hamb { display:block; }
+      .sidebar { position:fixed; top:56px; left:0; bottom:0; z-index:40; transform:translateX(-100%); transition:transform .22s ease; box-shadow:6px 0 24px rgba(0,0,0,.12); }
+      .sidebar.open { transform:translateX(0); }
+      .backdrop.show { display:block; position:fixed; top:56px; inset:0 0 0 0; background:rgba(0,0,0,.32); z-index:35; }
+    }
+    .hl-anchor { color:var(--muted); text-decoration:none; opacity:0; margin-left:8px; font-weight:400; }
+    .md h2:hover .hl-anchor,.md h3:hover .hl-anchor { opacity:.6; }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <div class="topbar">
+      <button class="hamb" id="hamb" aria-label="菜单">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+      </button>
+      <div class="brand" id="brandHome">
+        <div class="logo">b</div>
+        <span>botmux 文档</span>
+        <span class="ver" id="ver">docs</span>
+      </div>
+      <div class="grow"></div>
+      <button class="search-btn" id="searchBtn">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <span class="stxt">搜索文档…</span>
+        <kbd>/</kbd>
+      </button>
+      <a class="gh" href="https://github.com/deepcoldy/botmux" target="_blank" rel="noopener" title="GitHub">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.2.8-.5v-2c-3.2.7-3.9-1.4-3.9-1.4-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.7.4-1.3.7-1.6-2.6-.3-5.3-1.3-5.3-5.7 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17.3 4.7 18.3 5 18.3 5c.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.4-2.7 5.4-5.3 5.7.4.4.8 1.1.8 2.2v3.3c0 .3.2.6.8.5 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5z"/></svg>
+      </a>
+    </div>
+    <div class="body">
+      <nav class="sidebar" id="sidebar"></nav>
+      <div class="backdrop" id="backdrop"></div>
+      <main class="content" id="content">
+        <div class="content-inner">
+          <article class="md" id="md"></article>
+          <div class="pager" id="pager"></div>
+          <div class="docfoot" id="docfoot"></div>
+        </div>
+      </main>
+    </div>
+  </div>
+
+  <div class="overlay" id="overlay">
+    <div class="searchbox">
+      <input id="searchInput" placeholder="搜索功能、命令、配置、FAQ…" autocomplete="off">
+      <div class="results" id="results"></div>
+    </div>
+  </div>
+
+  <!-- ===================== 文档内容（markdown） ===================== -->
+
+  <script type="text/markdown" data-doc="intro">
+# botmux
+
+<p class="lead">把飞书话题群变成 AI 编程 CLI 的遥控器。一条消息，启动一个独立的编程会话。</p>
+
+botmux 是一座桥：一个常驻 **daemon** 监听飞书消息，为每个新话题自动启动一个独立的 AI 编程 CLI 进程（Claude Code / Codex / Cursor / Gemini / OpenCode / Antigravity 等），把终端输出实时渲染成飞书**流式卡片**，并提供一个可交互的 **Web 终端**。手机、电脑、飞书三端同步——人在哪儿，编程会话就跟到哪儿。
+
+> 项目地址：<https://github.com/deepcoldy/botmux> ｜ npm：`npm install -g botmux`
+
+## 设计理念：不做 SDK wrapper，直接桥接 CLI
+
+botmux **不重新实现** Agent 能力，而是直接桥接已有的 AI 编程 CLI。记忆、上下文管理、工具调用、权限体系、plan mode、`/` 命令、MCP 生态——这些能力 CLI 本身都在飞速迭代，botmux 选择**站在这个进化之上**，而不是平行重造一套。CLI 每次升级，botmux 零适配自动受益。
+
+同时，botmux 在 daemon 里用 **结构化 prompt 注入**（XML 标签）把用户内容和系统指令隔开后再喂给 CLI——这是模型公认最稳的提示词格式，但日常用户无需也不该手写 XML，你照常发人话即可，封装由 botmux 替你完成。
+
+## 核心优势
+
+与 OpenClaw 等"基于 Agent SDK 重新构建"的方案相比：
+
+| 特性 | botmux | 基于 SDK 的方案 |
+|------|--------|----------------|
+| 底层架构 | 直接桥接**完整 CLI 进程** | 基于 Agent SDK 重新构建 |
+| CLI 能力 | 完整运行时（hooks / memory / plan mode / Skill / `/` 命令 / MCP） | SDK API 子集，缺失功能需手动补 |
+| CLI 升级 | 零适配自动受益 | 需跟进 SDK 版本变更 |
+| 记忆 / 上下文 | 直接复用 CLI 内建记忆，随 CLI 迭代增强 | 需自建，与 CLI 原生能力重复 |
+| 多 CLI | 6+ 种一键切换 | 绑定单一 SDK |
+| Web 终端 | 可交互完整终端，三端同步 | 通常仅只读输出 |
+| 多机器人协作 | 多 bot 同群 @mention 路由，进程隔离 | 通常单机器人 |
+| 终端直连 | `tmux attach` 进入进程，与本地一致 | 无法操作底层终端 |
+
+## 亮点功能
+
+- **实时流式卡片** — 每轮对话一张实时更新的飞书卡片，终端输出渲染为 Markdown
+- **可交互 Web 终端** — 不只是看，还能在浏览器里直接操作 CLI；移动端有悬浮快捷键工具栏
+- **多机器人协作** — 同群放多个不同 CLI 的机器人，@谁谁干活，让 Claude Code 和 Codex 一起 review 代码
+- **tmux 会话常驻** — daemon 重启不中断 CLI 进程
+- **会话接管（Adopt）** — 把本地 tmux 里跑着的 CLI 一键接进飞书，换设备继续
+- **定时任务** — 自然语言配置周期任务，到点在原话题续跑
+- **Oncall 模式** — 把群锚定到一个项目，值班群任何人 @ 即问即答
+
+➡️ 下一步：[5 分钟快速接入](#quickstart)
+  </script>
+
+  <script type="text/markdown" data-doc="quickstart">
+# 5 分钟快速接入
+
+> 💡 **TL;DR**：`npm i -g botmux` → `botmux setup` 扫码建应用、选 CLI、填工作目录 → `botmux start` → `botmux autostart enable` → 拉机器人进群开聊。
+
+## Step 1 · 安装
+
+```bash
+npm install -g botmux
+```
+
+要求 **Node.js ≥ 20**，且本地已安装并登录好至少一种 AI 编程 CLI（`claude` / `codex` / `cursor-agent` / `gemini` / `opencode` / `coco` / `agy` 等）。推荐安装 **tmux**（≥3.x），装了就自动启用会话常驻。
+
+## Step 2 · 配置（`botmux setup`）
+
+```bash
+botmux setup
+```
+
+交互式向导，跟着选即可：
+
+1. **新建配置**：输入 `1` 回车。（已有配置时输入 `2` 添加机器人）
+2. **创建机器人**：
+   - 输入 `1` → **扫码创建**（推荐）：飞书扫码，自动建出 PersonalAgent 应用并落盘 AppID/AppSecret，事件订阅 + bot 能力默认已配好。
+   - 输入 `2` → **手动创建**：去 [飞书开放平台](https://open.larkoffice.com/app) 建企业自建应用，粘 AppID/AppSecret。
+3. **选择 CLI**：选本次要接入的 CLI（如接 Claude Code 就选 `1`）。
+4. **默认工作目录**：通常填 git 项目的**父级目录**（如 `~/projects`），最多向下查找 3 层。尽量别填 `~`（要遍历太多文件夹）。
+
+> ⚠️ 目前仅支持**飞书 (feishu.cn) 租户**；扫码检测到 Lark 国际版会中止 setup。
+
+## Step 3 · 启动
+
+```bash
+botmux start            # 启动 daemon
+botmux autostart enable # 开机自启（推荐，重启机器不丢，无需 sudo）
+```
+
+## Step 4 · 申请权限
+
+setup 完成后会把完整权限 JSON 写到 `~/.botmux/lark-scopes.json` 并打印一键复制命令。把它复制到剪贴板，进开放平台「权限管理 → 批量导入/导出权限」粘贴提交。可用性范围选「仅自己可见」会自动通过。
+
+```bash
+# macOS
+cat ~/.botmux/lark-scopes.json | pbcopy
+# Linux 桌面
+cat ~/.botmux/lark-scopes.json | xclip -selection clipboard
+# SSH / 无 DISPLAY：直接 cat 后在本地终端鼠标选中
+cat ~/.botmux/lark-scopes.json
+```
+
+## Step 5 · 发版
+
+进开放平台「版本管理与发布 → 创建版本」并发布，可用性范围选「仅自己可见」自动通过审核。
+
+## Step 6 · 建群开聊
+
+1. 飞书里创建一个**话题群**（普通群也支持）。
+2. 群设置 → 群机器人 → 添加你刚建的机器人。
+3. 群里直接发消息，机器人自动响应——它会弹一张仓库选择卡片，选项目后 CLI 就在该目录启动。
+
+也可以**私聊机器人**直接开聊，或用 `botmux dashboard` 切到 Group Tab 一键拉群。
+
+## 收不到消息？自查
+
+PersonalAgent 默认配好订阅，正常不用动。如果 bot **完全收不到任何消息**：
+
+- **事件订阅**：开放平台 → 事件与回调 → 应订阅 `im.message.receive_v1` + `card.action.trigger`，方式为「长连接 (WebSocket)」，且 daemon 已在跑。
+- **机器人能力**：开放平台 → 应用功能 → 机器人 应已开通。
+
+确认后 `botmux restart`。更多见 [FAQ / 排错](#faq)。
+  </script>
+
+  <script type="text/markdown" data-doc="prerequisites">
+# 前置要求
+
+## 运行环境
+
+- **Node.js ≥ 20**
+- **AI 编程 CLI / 本地 Agent 应用**：至少一种已安装并完成认证，可执行文件在 `PATH` 中：
+  - `claude`（Claude Code）、`codex`、`cursor-agent`（Cursor）、`gemini`、`opencode`、`coco`（Trae / CoCo）、`agy`（Antigravity）、`hermes` 等
+  - **CoCo 最低版本 `0.120.32`**：type-ahead（会话忙时即可发新消息，由 CoCo 自己的队列接住）依赖该版本行为；更早版本忙时输入可能丢失，请升级。
+- **tmux ≥ 3.x**（可选）：安装后自动启用会话常驻——daemon 重启不中断 CLI。
+
+## CJK 字体（截图渲染中文/emoji 用）
+
+- **macOS**：自带 PingFang / Hiragino，无需配置。
+- **Debian / Ubuntu**：daemon 启动时若检测到缺字体，会后台 `apt-get install fonts-noto-cjk fonts-noto-color-emoji`（需免密 sudo 或以 root 运行；装完重启 daemon 生效）。
+- **其他 Linux**：手动安装 Noto CJK + Noto Color Emoji。
+
+## 推荐部署形态
+
+推荐部署在**常开的开发机**上（而非笔记本），这样 daemon 长期在线、tmux 会话常驻、随时手机遥控。配合 `botmux autostart enable` 实现重启自恢复。
+  </script>
+
+  <script type="text/markdown" data-doc="architecture">
+# 架构总览
+
+botmux 是一个薄编排层，把"飞书事件"翻译成"CLI 进程的输入/输出"。核心进程与模块：
+
+## 进程模型
+
+```
+飞书 (Lark) 长连接事件
+        │
+        ▼
+   ┌──────────┐   每个 bot 一个独立 daemon 进程
+   │  daemon  │   监听消息、路由、管理会话生命周期
+   └────┬─────┘
+        │ 每个话题 spawn 一个
+        ▼
+   ┌──────────┐   通过适配器拉起 CLI，挂在 PTY / tmux 后端上
+   │  worker  │   读终端输出 → 渲染卡片；收飞书消息 → 写入 CLI
+   └────┬─────┘
+        │
+        ▼
+   ┌──────────┐
+   │ CLI 进程  │   Claude Code / Codex / ...（完整运行时）
+   └──────────┘
+```
+
+> 生产形态是**一个 bot 一个 daemon 进程**。多机器人 = 多 daemon，进程完全隔离，互不干扰。
+
+## 模块结构
+
+| 模块 | 职责 |
+|------|------|
+| `daemon.ts` | 薄编排层，组装各模块并启动 |
+| `worker.ts` | Worker 子进程，通过适配器管理 CLI + PTY |
+| `server.ts` | Web 终端 HTTP 服务（xterm.js） |
+| `bot-registry.ts` | 多机器人配置加载 + 状态管理 |
+| `adapters/cli/` | CLI 适配器（参数构建、输入写入、Skill 目录），每种 CLI 一个文件 |
+| `adapters/backend/` | 会话后端：`PtyBackend`、`TmuxPipeBackend` |
+| `im/lark/` | 飞书：事件路由、卡片构建/处理、API client、消息解析 |
+| `core/` | `worker-pool`、`command-handler`、`session-manager`、`cost-calculator`、`scheduler` |
+| `skills/` | 开箱即用的 Skill（`botmux-send` / `botmux-schedule` / `botmux-bots` / `botmux-history` / `botmux-quoted`） |
+| `utils/` | `idle-detector`（CLI 空闲检测）、`terminal-renderer`（xterm.js 截屏）、`logger` |
+
+## 数据流
+
+1. 飞书推送 `im.message.receive_v1` → event-dispatcher 解析、判断归属（@mention / 话题 / 群权限）。
+2. command-handler 拦截 `/xxx` 斜杠命令；非命令消息交给会话。
+3. 新话题 → worker-pool spawn 一个 worker；已有会话 → 复用，把消息写进 CLI stdin。
+4. worker 持续读 PTY 输出，经 terminal-renderer 转成 Markdown，更新流式卡片。
+5. CLI 通过注入的 `botmux send` 等 Skill / 命令主动往话题发消息。
+
+关键点：**worker 与 CLI 通过后端（PTY 或 tmux）解耦**。tmux 后端下，daemon/worker 重启时 CLI 进程仍在 tmux 里活着，下次消息自动 re-attach，无需 `--resume` 重载上下文。详见 [tmux 会话常驻](#tmux)。
+  </script>
+
+  <script type="text/markdown" data-doc="session-model">
+# 会话与话题模型
+
+理解 botmux 的关键是搞清"一条消息落到哪个会话"。
+
+## 三种群形态
+
+| 形态 | 行为 |
+|------|------|
+| **话题群（THREAD）** | 每个新话题 = 一个独立 CLI 会话。同一话题内的消息进同一会话，不同话题互相隔离。最推荐。 |
+| **普通群（DEFAULT）** | 默认不自动开话题；用 `/t <prompt>` 主动开新话题（弹仓库选择卡片）。 |
+| **私聊** | 直接和机器人开聊，相当于一个长期会话。 |
+
+## Oncall 群 & chat-scope 群
+
+- **Oncall 群**：`/oncall bind <path>` 把整个群锚定到一个项目目录，跳过仓库选择，群内任何成员 @ 即问即答。见 [Oncall 模式](#oncall)。
+- **chat-scope 群**：`/group <群名>` 一键新建一个群，整个群作为一个独立会话。
+
+## 会话状态机
+
+流式卡片顶部的状态指示：
+
+- 🟡 **启动中** — worker 正在拉起 CLI 进程
+- 🔵 **工作中** — CLI 正在思考/执行，输出实时刷新
+- 🟢 **就绪** — CLI 空闲，等你的下一条消息
+
+每次回复创建**新的**流式卡片，上一轮卡片冻结在最后状态，便于回看历史。
+
+## 权限模型（三层）
+
+| 层级 | 能力 | 由谁控制 |
+|------|------|---------|
+| **对话权（canTalk）** | 提问、查日志、读代码 | `allowedChatGroups`（群内全员）/ `globalGrants`（全局名单）/ `/grant` |
+| **操作权（canOperate）** | 切目录 `/cd`、`/restart`、`/close`、点卡片按钮 | `allowedUsers`（owner 名单） |
+| **owner 专属** | `/grant` `/revoke` 授权他人 | owner |
+
+这套分层让你能放心把机器人拉进值班群：所有人能问，但只有 owner 能改会话状态，外部成员误点也不会把会话搞乱。
+  </script>
+
+  <script type="text/markdown" data-doc="cards">
+# 实时流式卡片
+
+每轮对话生成一张实时更新的飞书卡片，是你在手机/飞书上感知 CLI 的主窗口。
+
+![流式卡片折叠/展开](https://magic-builder.tos-cn-beijing.volces.com/uploads/1780033301464_fold&unfold.gif)
+
+- **终端输出实时渲染为 Markdown**，自动过滤 TUI 装饰（边框、光标、ANSI 转义），只展示实际工作输出。
+- **状态指示**：🟡 启动中 → 🔵 工作中 → 🟢 就绪。
+- **操作按钮**：
+  - 🖥 **打开终端** — 跳只读 Web 终端看完整进度
+  - 🔑 **获取操作链接** — 私聊给你一个可写终端链接
+  - 🔄 **重启 CLI** / ⏹ **关闭会话**
+- **每轮一张新卡片**：上一轮卡片冻结在最后状态，对话历史清晰可回溯。
+
+> 卡片正文是把终端帧渲染成 Markdown 的结果。CLI 主动发的消息（通过 `botmux send`）则是独立的富文本/图文消息，可带图片、文件、@mention。
+  </script>
+
+  <script type="text/markdown" data-doc="web-terminal">
+# Web 终端（可交互）
+
+每个会话都带一个基于 xterm.js 的 Web 终端，地址形如 `http://<WEB_EXTERNAL_HOST>:<端口>`。
+
+![Web 终端](https://magic-builder.tos-cn-beijing.volces.com/uploads/1780033301701_web_terminal.gif)
+
+## 两种链接
+
+| 链接 | 来源 | 能力 |
+|------|------|------|
+| **只读链接** | 自动展示在流式卡片上 | 随时查看进度，不能输入 |
+| **可操作链接** | 点卡片「🔑 获取操作链接」，经私聊发送 | 可直接在浏览器里操作 CLI |
+
+## 移动端
+
+平板/手机上提供**悬浮快捷键工具栏**：`Esc`、`Ctrl+C`、`Tab`、方向键等，手机上也能流畅操控 CLI（比如在 Claude Code 里选菜单、确认权限）。
+
+## 三端同步
+
+飞书话题、Web 终端、本地 tmux 三处看到的是**同一个** CLI 进程的实时状态。在电脑 tmux 里敲、在手机 Web 终端里敲、在飞书里发消息，效果一致。
+  </script>
+
+  <script type="text/markdown" data-doc="multi-bot">
+# 多机器人协作
+
+同一台机器上可运行多个飞书机器人，每个机器人可绑不同的 CLI。把它们拉进同一个群，就能让不同模型"赛博斗蛐蛐"。
+
+![多机器人协作](https://magic-builder.tos-cn-beijing.volces.com/uploads/1780033302192_multi-bot-collab.png)
+
+## 路由规则
+
+- **群里只有一个机器人**：无需 @，自动响应。
+- **群里有多个机器人**：用 `@mention` 指定接收方。
+- `@botA @botB /t <prompt>`：让**每个被 @ 的机器人**在同一条消息上各自独立开新话题，各跑各的。
+
+## 让机器人互相认识
+
+机器人之间默认**收不到**对方在群里发的普通消息。要让它们接力协作：
+
+1. 先发一次 `@botA @botB /introduce` —— 它们互相登记 open_id（@ 顺序任意，可带额外文本）。
+2. 之后各 bot 就能在自己的会话里用 `botmux send --mention <对方 open_id>` 显式 @ 对方，触发对方接力。
+
+> 跨 bot 协作的硬性事实：**不 `--mention` 对方 bot，对方完全不会被触发**。对方的 open_id 从 `botmux bots list` 或消息里的 `<available_bots>` 块拿。
+
+## 典型场景
+
+- **代码 review**：让 Claude Code 和 Codex 一起看同一个 MR，观点不同时互相挑刺。
+- **方案评审**：两个 AI 分别出方案，互相找漏洞。
+- **写审分离**：一个写，一个审，迭代收敛。
+
+配置极简：每个机器人一个飞书应用，拉进同一个群即可，进程完全隔离。
+
+> 相关：用 [角色与团队](#roles) 给每个 bot 设人设和能力标签；用 [一键建会话群](#group) 一句话拉多个 bot 进新群；用 [会话接力](#relay) 把会话搬到协作群。
+  </script>
+
+  <script type="text/markdown" data-doc="tmux">
+# Tmux 会话常驻
+
+安装 tmux 后自动启用。CLI 进程常驻在 tmux session 内，**daemon 重启不中断 CLI**。
+
+![tmux 会话管理](https://magic-builder.tos-cn-beijing.volces.com/uploads/1780033301974_tmux.gif)
+
+## 为什么重要
+
+`botmux restart` 时 worker 进程退出，但 tmux session（及其中的 CLI 进程）保持运行。下次收到消息时 worker 自动 re-attach，**无需 `--resume` 重载上下文**——上下文一直活着，省 token、省时间、不丢状态。
+
+| 事件 | tmux session | CLI 进程 |
+|------|-------------|---------|
+| `botmux restart` | 存活 | 存活（下次消息 re-attach） |
+| `/close` 或关闭按钮 | 销毁 | 终止（SIGHUP） |
+| CLI 自行退出 / 崩溃 | 随之关闭 | 已退出（自动用新 session 重启） |
+
+## 直接 attach
+
+```bash
+# 交互式会话列表，选择后直接 attach
+botmux list
+
+# 手动 attach（会话名 = bmx-<sessionId 前 8 位>）
+tmux attach -t bmx-<前8位>
+# Ctrl+B, D 退出 attach，不影响 CLI 继续运行
+
+# 强制降级到纯 pty 模式（不使用 tmux）
+BACKEND_TYPE=pty botmux start
+```
+
+attach 进去后你看到的就是和本地开发完全一致的终端——这也是 botmux 相比"只读输出"方案的关键区别。
+  </script>
+
+  <script type="text/markdown" data-doc="adopt">
+# 会话接入（Adopt）
+
+把**已经在本地 tmux 里跑着**的 CLI 进程无缝接入 botmux，在手机上通过飞书查看进度和交互。
+
+```
+/adopt              # 扫描本机 tmux，弹出选择卡片
+/adopt 0:2.0        # 直接接入指定 tmux pane
+```
+
+## 三种动作
+
+- **共享模式**：接入后，本地终端（如 iTerm2）和飞书双向同步——流式卡片实时显示终端输出，飞书聊天框输入直接透传到终端。本地的 tmux 全程保持连接。
+- **一键接管**：点流式卡片上的「🔄 接管」，botmux 以 `--resume` 重建会话，转为标准 botmux 会话。
+- **安全断开**：点「⏏ 断开」，botmux 退出观察，原 CLI 不受影响。
+
+## 典型用法
+
+在公司电脑 tmux 里跑 Claude Code，写到一半要走？手机飞书发 `/adopt` → 选会话 → 即刻同步。路上用手机继续，回到电脑点「断开」接着用。**不是远程控制，是真正的多设备共享。**
+  </script>
+
+  <script type="text/markdown" data-doc="schedule">
+# 定时任务
+
+支持三种调度类型 + 中文自然语言，到点在**创建任务的原话题**内续一条消息并执行（不另开 thread，工作目录与创建时一致）。
+
+## 两种创建方式
+
+- **斜杠命令**（快捷）：`/schedule 每日17:50 帮我看看AI圈有什么新闻`
+- **对话触发**（灵活）：直接跟 agent 说「帮我加个每天 18:00 检查部署的定时任务」，自动触发 `botmux-schedule` Skill。
+
+## 支持的格式
+
+```bash
+# 中文自然语言
+/schedule 每日17:50 帮我看看AI圈有什么新闻
+/schedule 工作日每天9:00 检查服务状态
+/schedule 每周一10:00 生成周报
+
+# 一次性任务
+/schedule 30分钟后 检查部署状态
+/schedule 明天9:00 发早会提醒
+
+# 英文 duration / interval / cron
+/schedule every 2h 巡检服务
+/schedule 30m 提醒我喝水
+/schedule 0 9 * * * 早安问候
+
+# ISO 时间戳
+/schedule 2026-05-01T10:00 ...
+```
+
+## 管理
+
+```bash
+/schedule list
+/schedule remove|enable|disable|run <id>
+```
+
+> 执行行为：到点若原话题的会话还活着，prompt 直接注入现有会话（不另起 worker）；否则新拉一个 worker 在原工作目录执行。
+  </script>
+
+  <script type="text/markdown" data-doc="oncall">
+# Oncall 模式
+
+把机器人拉进 oncall / 值班 / 报警群，一句 `/oncall bind ~/projects/your-service` 就能把这个群锚定到一个项目目录。从此群里**任何成员**都能 @ 机器人提问，无需选仓库、无需开新会话——直接进入这个项目目录开聊。
+
+## 命令
+
+| 命令 | 说明 |
+|------|------|
+| `/oncall bind <path>` | 绑定当前群到某项目目录，发起人自动成为 owner |
+| `/oncall unbind` | 解绑（仅 owner） |
+| `/oncall status` | 查看当前绑定 |
+
+## 权限分层
+
+- 群里**所有人**都能跟机器人对话（提问、查日志、读代码）
+- 只有 **owner** 能切换会话状态（`/cd`、`/restart`、`/close`、点流式卡片按钮）
+- 防止外部群成员误操作把会话搞乱
+
+## 配合定时任务起飞
+
+在 oncall 群里发 `/schedule 每天9:00 检查昨天的报警趋势并总结`，每天定点喂一份报告到群里——人不在岗，机器人替你看着。回复卡片会自动「发送给 @提问者 / cc @owner」，远程也能掌握群内动向。
+
+**典型场景**：值班群、报警群（Argos 报警分析）、跨团队咨询群、Oncall 答疑。
+  </script>
+
+  <script type="text/markdown" data-doc="dashboard">
+# Dashboard 管控面
+
+命令行 `botmux dashboard` 出一个一次性 token URL，浏览器里跨所有 daemon / 机器人统一管控。
+
+```bash
+botmux dashboard
+# 输出: http://<lan-ip>:7891/?t=<token>
+```
+
+> 每次跑都换一个 token，老 URL 立即失效——一次一密的取链方式。
+
+![Dashboard Groups 面板](https://magic-builder.tos-cn-beijing.volces.com/uploads/1780033300739_dash-groups.png)
+<p class="cap">Groups 面板：chat × bot 矩阵，一眼看清哪个群里有哪些机器人</p>
+
+## 功能
+
+- **Sessions**：跨所有 bot 列出活跃 + 已关闭会话，可按 CLI / 状态 / adopt / 文本过滤。点进 detail 可「定位到飞书话题」（机器人在原话题发 📍 标记 + 自动开 chat AppLink）、复制各种 ID、关闭会话；支持多选批量关闭。
+- **Schedules**：列出所有定时任务，可 Run now / Pause / Resume。
+- **Groups**：一键拉新群、拉 bot 入群、自动转让群主、@ 提醒；解散群聊、bot 退群（关联会话自动清理）。
+- **团队 / Roles / Bot Defaults**：团队面板做[跨部署协作](#roles)（邀请别人的部署进团队、跨部署拉群）；Roles 管理各 bot 人设；Bot Defaults 配默认行为。
+- **Workflows 管控面**：Run List 轮询；Run Detail 看 summary / dangling 红区 / node-activity / event timeline / 并发执行 timeline；可直接 cancel run、批准/拒绝 humanGate；Workflow Catalog 列出所有 workflow 并可带参触发。
+
+## 部署细节
+
+dashboard 走单独 pm2 进程 `botmux-dashboard`，跟 daemon 一起起停。每个 daemon 在 `127.0.0.1` 暴露内部 IPC（仅本机），dashboard 进程做反向代理 + HMAC 鉴权（`~/.botmux/.dashboard-secret`，mode 0600，不下发给浏览器）。
+  </script>
+
+  <script type="text/markdown" data-doc="workflow">
+# Workflow（实验性运维）
+
+`botmux workflow` 把工作流 run 的状态当一等公民暴露出来——查看哪些 run 在跑、读事件流、从崩溃 / awaiting 恢复或取消。所有命令读写 `BOTMUX_WORKFLOW_RUNS_DIR`（默认 `~/.botmux/workflow-runs`），**不需要 daemon 在线**。
+
+| 命令 | 说明 |
+|------|------|
+| `botmux workflow run <id> [--param k=v ...]` | 离线驱动 workflow；humanGate 节点跑到 awaiting-wait 退出 |
+| `botmux workflow resume <runId>` | 从磁盘 runDir 冷恢复一个已有 run |
+| `botmux workflow cancel <runId> [--reason <text>]` | 写 run-level cancelRequested 并驱动 cancel recovery |
+| `botmux workflow ls [--all] [--status ...] [--wide] [--json]` | 列所有 run；默认仅 non-terminal |
+| `botmux workflow tail <runId> [--from N] [--follow]` | 打印事件简表 |
+| `botmux workflow show <runId>` | replay 事件，打 Snapshot 摘要 |
+
+典型运维流程：
+
+```bash
+botmux workflow ls                         # 看哪些 run 在跑
+botmux workflow tail wf-abc-123            # 进一个 run 看事件
+botmux workflow resume wf-abc-123          # run 卡住/重启过 → 冷恢复
+botmux workflow cancel wf-abc-123 --reason '依赖外部超时'
+```
+
+> 这是实验性能力，主要给运维/调试 workflow 编排用。普通使用无需关心。
+  </script>
+
+  <script type="text/markdown" data-doc="skill-cli">
+# Skill + CLI 交互
+
+CLI 进入 botmux 会话时，自动获得 `~/.botmux/bin` 在 PATH 中，以及一组开箱即用的 Skill。这是 CLI agent **主动**与飞书话题交互的通道。
+
+## 开箱即用的能力
+
+| 命令 / Skill | 作用 |
+|------|------|
+| `botmux send` | 向当前话题发消息（文本 / 图片 / 文件 / @mention） |
+| `botmux history` | 读当前会话历史消息（话题群拉话题内，普通群拉整群） |
+| `botmux quoted <message_id>` | 读取被引用的那条消息（用户用引用 UI @ 机器人时） |
+| `botmux bots list` | 查当前群里的机器人及 open_id（供 `--mention`） |
+| `botmux schedule` | 增删改查定时任务 |
+
+这些能力通过 `--append-system-prompt` 注入 + Skill 描述自动引导 agent 使用。
+
+## 为什么是 Skill + CLI，而不是 MCP
+
+相比 Anthropic 官方那套基于 MCP 的方案，Skill + CLI 组合：
+
+- CLI 启动**不用做 MCP 握手**，不占用工具列表 token
+- 对 Claude Code / Codex / Cursor / Gemini / OpenCode / Antigravity **通用**——只要 CLI 能读 system prompt、能跑 shell 命令就行，不依赖任何 MCP 协议支持
+
+## wrapper 机制
+
+会话内命令依赖 `~/.botmux/bin/botmux` 这个 wrapper 脚本，daemon 启动时自动写入并加入 worker 的 PATH，**版本始终与 daemon 一致**（不需要单独 `npm i -g`）。session 信息通过祖先进程标记自动推断，agent 无需手动传 session id。
+  </script>
+
+  <script type="text/markdown" data-doc="roles">
+# 角色与团队
+
+给每个机器人按群设独立人设，并在多机器人协作时形成一份「团队花名册」。命令是 `/role`。
+
+## 两级 Role（人设）
+
+| 命令 | 作用 |
+|------|------|
+| `/role` | 查看当前**生效**的 Role（来源：本群覆盖 > 团队级 > 无） |
+| `/role set <Markdown>` | 设置**本群** Role（覆盖团队级） |
+| `/role delete` | 删除本群 Role |
+| `/role team set <Markdown>` | 设置**团队级** Role（该机器人**跨所有群**的默认人设） |
+| `/role team delete` | 删除团队级 Role |
+
+- **本群 Role** 优先级最高：同一个 bot 在不同群可以有不同性格 / 职责（如在 A 群当「严格的 reviewer」、在 B 群当「亲和的答疑助手」）。
+- **团队级 Role** 是该 bot 的跨群默认人设，没设本群 Role 时生效。
+- Role 内容是 Markdown，注入到 CLI 的 system prompt，最大约 4096 字节。
+
+## 能力标签（花名册）
+
+```bash
+/role cap set <一句话>   # 设置该 bot 的能力标签
+/role cap clear          # 清除
+```
+
+能力标签会显示在「花名册」里——`botmux bots list` 列出当前群的机器人时，每个 bot 带上它的 `cap` 一句话简介，方便你和其它 bot 知道「谁擅长干什么」，在多机器人协作 / 交接时挑对人。
+
+## 与多机器人协作的关系
+
+Role + 能力标签是[多机器人协作](#multi-bot)的基础设施：给每个 bot 清晰的身份和职责，群里 @ 时模型不易混淆、各司其职（如一个主控调度、一个做实现 / review）。
+
+## 团队协作（跨部署）
+
+在 `botmux dashboard` 的 **团队** 面板，可以把**别人的部署**（同事自己跑的 botmux）邀请进同一个团队，互相发现机器人、跨部署协作拉群。
+
+![Dashboard 团队 — 跨部署协作](https://magic-builder.tos-cn-beijing.volces.com/uploads/1780033301213_dash-team.png)
+
+- **绑定身份**：用机器人凭证自动识别你的飞书身份；绑定后拉群会把你拉进群、机器人也归到你名下。
+- **团队花名册**：聚合本部署 + 已加入团队的所有机器人（可跨部署），可按名称 / 能力 / CLI 搜索筛选，并标注谁有能力标签 / 团队角色。
+- **跨部署拉群**：在任一团队里勾选机器人即可一键建群，自动带上各自的负责人——一个群里凑齐不同同事部署的不同 CLI 协作。
+- **团队管理**：新建团队、生成邀请码、加入别人的团队，都在「团队管理」子页。
+
+> 适合多人 / 多机协作：每个人各自跑自己的 botmux 部署，通过团队联邦互相发现彼此的机器人，在同一个飞书群里协同。
+  </script>
+
+  <script type="text/markdown" data-doc="relay">
+# 会话接力（Relay）
+
+把一个**正在运行的 AI 会话**从一个群「接力」到另一个群继续——**飞书消息历史留在源群，但 AI 的记忆 / 上下文接续过去**，换个群无缝继续聊。命令是 `/relay`。
+
+> 与 [Adopt](#adopt) 的区别：Adopt 是把本机 tmux 里的进程接进飞书；Relay 是把一个已经在 botmux 里跑的会话从 A 群搬到 B 群。
+
+## 两种用法
+
+**1. `/relay`（picker 模式）—— 在目标群把会话「拉」过来**
+
+在你想接力**到**的那个群里发 `/relay`，弹出一张卡片，列出**你作为 owner、同一机器人在其它群里的活跃会话**，选一个拉过来即可。
+
+**2. `/relay --create`（建群模式）—— 把当前会话「搬」到新群**
+
+在当前会话里发 `@botA @botB /relay --create`：自动新建一个群、把被 @ 的机器人都拉进去，并把当前会话（以及被 @ 的协作伙伴在本话题的会话）一起接力过去。
+
+```bash
+/relay                      # 在目标群：拉一个你的远程会话过来
+@Claude @Codex /relay --create   # 把当前会话搬到一个新建的群，带上协作伙伴
+```
+
+## 接力后的提示
+
+接力成功后，新群里会收到类似：
+
+> 📋 已从「源群」接力会话过来。
+> ⚠️ 飞书消息历史留在源群，AI 记忆已接续。
+> @ 对应机器人继续对话即可。
+
+源群里那张流式卡片会冻结成存档（移除按钮，避免误操作影响新群里活着的会话）。
+
+## 限制
+
+- picker 模式只在**普通群**可用（单聊没有协作对象；话题群按话题路由、没有 thread 锚点）。
+- 只有**会话发起人（owner）**能接力自己的会话。
+- 会话**正在处理中（mid-turn）不能接力**，等本回合 idle 后再发。
+- `/adopt` 接入的外部 tmux 会话不能接力（CLI 在你电脑里、botmux 控不了其生命周期）。
+- 目标群若已有该 bot 的活跃会话，需先 `/close` 再接力。
+  </script>
+
+  <script type="text/markdown" data-doc="group">
+# 一键新建会话群
+
+`/group <群名>`（别名 `/g`）：自动**新建一个飞书群**、邀请你进群、转让群主，**整个群作为一个独立的 CLI 会话**（chat-scope）。适合给一个项目 / 任务单独开一个干净的协作空间。
+
+```bash
+/g 卡片竞态 bug
+```
+
+机器人回一张卡片：「✅ 已新建群「卡片竞态 bug」👉 <加群链接>」，点进去直接开聊即可——整个群就是一个独立会话。
+
+> 空群名时用时间戳兜底。建好后**不自动开会话**，进群找机器人开聊即可。
+
+## 多机器人一起建群
+
+命令里 @ 的机器人会被**一并拉进新群**（由第一个被 @ 的机器人负责建群）：
+
+```bash
+@Claude @Codex /g review 群授权
+```
+
+回复会列出「群内机器人：Claude、Codex」。这样新群天然就是一个多机器人协作空间，进去 @ 谁谁干活。
+
+## 在 Dashboard 里建群
+
+不想用命令的话，`botmux dashboard` 的 **Groups** 面板也能可视化建群、把指定 bot 拉进群、自动转让群主、@ 提醒，还能解散群 / 让 bot 退群（关联会话自动清理）。详见 [Dashboard 管控面](#dashboard)。
+
+![Dashboard 新建群](https://magic-builder.tos-cn-beijing.volces.com/uploads/1780033300986_dash-newgroup.png)
+<p class="cap">「New Group」：填群名、绑定目录、勾选要拉进群的机器人</p>
+  </script>
+
+  <script type="text/markdown" data-doc="slash-commands">
+# 斜杠命令
+
+在话题里直接发这些命令即可，由 daemon 拦截处理。botmux 不认识的 `/xxx` 会**原样透传**给底层 CLI（与 CLI 自身的 slash 命令互不冲突）。随时发 `/help` 查看完整清单。
+
+## 📌 会话管理
+
+| 命令 | 说明 |
+|------|------|
+| `/repo` | 仓库待选时用默认 workingDir 启动；会话进行中则弹项目选择卡片 |
+| `/repo <N>` | 切换到上次扫描的第 N 个项目 |
+| `/repo <路径\|项目名>` | 直接指定路径或 workingDir 下的一级项目名 |
+| `/cd <路径>` | 切换工作目录并重启 CLI 进程 |
+| `/status` | 查看会话信息（运行时间、终端地址等） |
+| `/restart` | 重启 CLI 进程（保留 session 上下文） |
+| `/close` | 关闭会话并发送可恢复卡片（含 CLI 自身 resume 命令） |
+| `/card` | 手动召唤当前会话的流式卡片（关流式时也能召唤并恢复实时刷新；私密卡片模式下改发仅授权人可见的静态快照） |
+| `/t <prompt>` `/topic <prompt>` | 普通群内强制开新话题 |
+
+## 🔀 透传给底层 CLI
+
+`/compact` `/model` `/clear` `/plugin` `/usage` `/context` `/cost` `/mcp` `/diff` `/code-review` `/security-review` `/review` `/btw` —— 字面送达底层 CLI，交给它的内置命令处理。
+
+## 📡 会话接入
+
+| 命令 | 说明 |
+|------|------|
+| `/adopt` | 扫描本机 tmux，弹卡片选择要接入的已运行会话 |
+| `/adopt <tmux_pane>` | 直接接入指定 pane（如 `/adopt 0:2.0`） |
+
+## 🔐 用户授权
+
+| 命令 | 说明 |
+|------|------|
+| `/login` | 飞书用户授权，授权后可下载第三方卡片图片、以你身份调云文档/日历等 API |
+| `/login status` | 查看授权状态 |
+| `/pair <配对码>` | 把 Web/Dashboard 端的会话与你的飞书身份配对（在网页端拿配对码，话题里发 `/pair <码>` 认领） |
+
+## 🎭 角色（人设）
+
+| 命令 | 说明 |
+|------|------|
+| `/role` | 查看当前生效的 Role（本群覆盖 > 团队级 > 无） |
+| `/role set <Markdown>` | 设置**本群** Role（覆盖团队级） |
+| `/role delete` | 删除本群 Role |
+| `/role team set <Markdown>` | 设置**团队级** Role（跨群默认人设） |
+| `/role cap set <一句话>` / `/role cap clear` | 设置/清除花名册里的能力标签 |
+
+详见 [角色与团队](#roles)。
+
+## 🔀 会话接力（普通群）
+
+| 命令 | 说明 |
+|------|------|
+| `/relay` | 在目标群弹卡片，把你在其它群的活跃会话**拉**过来继续 |
+| `@botA @botB /relay --create` | 把当前会话（带协作伙伴）**搬**到一个新建的群 |
+
+详见 [会话接力 Relay](#relay)。
+
+## 🛎️ Oncall（群聊）
+
+`/oncall bind <path>` · `/oncall unbind` · `/oncall status`
+
+## 🔑 使用授权（owner 专用）
+
+| 命令 | 说明 |
+|------|------|
+| `@机器人 /grant @某人` | 授权对方在本群对话；`/grant`（不带人）则授权**本群所有成员**对话 |
+| `@机器人 /revoke @某人` | 撤销对方本群对话权；`/revoke`（不带人）撤销整群授权 |
+
+## 🆕 一键新建会话群
+
+`/group <群名>`（别名 `/g`）：自动新建飞书群、邀请你进群、转让群主，整个群作为一个独立 CLI 会话。`@botA @botB /g <群名>` 可把多个机器人一并拉进新群。详见 [一键建会话群](#group)。
+
+## 👥 多机器人协作
+
+`@botA @botB /t <prompt>`（各自开新话题）· `@botA @botB /introduce`（互相登记 open_id）
+
+## ⏰ 定时 & ❓帮助
+
+`/schedule ...`（见 [定时任务](#schedule)）· `/help`（话题内显示完整清单）
+  </script>
+
+  <script type="text/markdown" data-doc="cli-commands">
+# CLI 命令
+
+在终端里管理 daemon 和会话。
+
+| 命令 | 说明 |
+|------|------|
+| `botmux setup` | 交互式配置（首次 / 添加 / 编辑 / 删除机器人） |
+| `botmux start` | 启动 daemon（PM2 管理） |
+| `botmux stop` | 停止 daemon |
+| `botmux restart` | 重启 daemon（自动恢复活跃会话） |
+| `botmux logs [--lines N]` | 查看日志 |
+| `botmux status` | 查看 daemon 状态 |
+| `botmux upgrade` | 升级到最新版本 |
+| `botmux list` (别名 `ls`) | 列出所有活跃会话 |
+| `botmux delete <id>` (别名 `del`/`rm`) | 关闭指定会话，支持 ID 前缀匹配 |
+| `botmux delete all` | 关闭所有活跃会话 |
+| `botmux delete stopped` | 清理进程已退出的僵尸会话 |
+| `botmux dashboard` | 输出一次 Web Dashboard URL（每次刷 token） |
+
+## 开机自启
+
+```bash
+botmux autostart enable   # 注册（macOS launchd / Linux user systemd，无需 sudo）
+botmux autostart disable  # 注销
+botmux autostart status   # 查看状态
+```
+
+- **macOS**：写 `~/Library/LaunchAgents/com.botmux.daemon.plist`，`launchctl bootstrap` 加载。
+- **Linux**：写 `~/.config/systemd/user/botmux.service`，`systemctl --user enable --now`。
+  - 服务器/无桌面环境登出会停服务，需跨登出常驻请 `sudo loginctl enable-linger <用户名>`。
+- 单元文件里的 `node`/`cli.js` 路径来自当前 `process.execPath`，nvm/fnm 切版本后跑一次 `enable` 重写即可（`start`/`restart` 也会自动检测路径变化原地刷新）。
+- `enable`/`disable` **只管自启钩子，不动正在跑的 daemon**——避免"只想关自启结果服务也被干掉"。
+
+## 会话内子命令（给 CLI agent 用）
+
+session 信息通过祖先进程标记自动推断，agent 直接调：
+
+| 命令 | 说明 |
+|------|------|
+| `botmux send [content]` | 向当前话题发消息（stdin / heredoc / `--content-file`；`--images`/`--files`/`--mention`） |
+| `botmux bots list` | 列出当前群里的机器人（含 open_id） |
+| `botmux history [--limit N]` | 拉会话历史（JSON） |
+| `botmux quoted <message_id>` | 拉被引用的单条消息（JSON） |
+| `botmux schedule add/list/remove/pause/resume/run` | 管理定时任务 |
+  </script>
+
+  <script type="text/markdown" data-doc="bots-json">
+# bots.json 配置
+
+通过 `~/.botmux/bots.json` 配置机器人。运行 `botmux setup` 交互式创建，或手动编辑。
+
+```json
+[
+  {
+    "larkAppId": "cli_xxx_bot1",
+    "larkAppSecret": "secret_1",
+    "name": "claude-main",
+    "cliId": "claude-code",
+    "model": "sonnet",
+    "workingDir": "~/projects",
+    "allowedUsers": ["alice@company.com"],
+    "allowedChatGroups": ["oc_xxx_team"]
+  },
+  {
+    "larkAppId": "cli_xxx_bot2",
+    "larkAppSecret": "secret_2",
+    "cliId": "codex",
+    "model": "gpt-5-codex",
+    "workingDir": "~/work"
+  }
+]
+```
+
+## 字段说明
+
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| `larkAppId` | 是 | 飞书应用 App ID |
+| `larkAppSecret` | 是 | 飞书应用 App Secret |
+| `name` | 否 | 进程名后缀，如 `claude-main` → `botmux-claude-main`；留空默认 `botmux-<序号>` |
+| `cliId` | 否 | CLI 适配器，默认 `claude-code`。见 [多 CLI 适配器](#adapters) |
+| `model` | 否 | 启动 CLI 用的模型名；留空走 CLI 默认 |
+| `cliPathOverride` | 否 | CLI 入口绝对路径，用于套 wrapper / router（ccr、claude-w、aiden-x-claude 等） |
+| `backendType` | 否 | 会话后端 `pty` / `tmux`（默认自动检测） |
+| `workingDir` | 否 | 默认工作目录，支持逗号分隔多个。从该目录**向下**递归找 git 仓库（最多 3 层），不向上扫 |
+| `defaultWorkingDir` | 否 | 单仓库默认目录：无 oncall / 无同群兄弟 session 时直接进入，跳过 repo 选择卡片 |
+| `allowedUsers` | 否 | 操作权名单（**完整邮箱**或 `ou_xxx`）。配了 `allowedChatGroups` 时至少要有一个作为 owner |
+| `allowedChatGroups` | 否 | 可对话群（`oc_xxx`）。群内任何成员可对话（仅 `canTalk`），敏感操作仍由 `allowedUsers` 控制 |
+| `globalGrants` | 否 | 全局可对话名单（`ou_xxx`，人或 bot）。任意群可对话，仅 `canTalk` |
+| `oncallChats` | 否 | oncall 绑定，`[{ "chatId": "oc_xxx", "workingDir": "~/projects/foo" }]` |
+
+> **配置优先级**：`BOTS_CONFIG` 环境变量 → `~/.botmux/bots.json`。改完跑 `botmux restart` 生效。
+  </script>
+
+  <script type="text/markdown" data-doc="env">
+# 环境变量与文件位置
+
+## 环境变量（写在 `~/.botmux/.env`）
+
+| 变量 | 默认 | 说明 |
+|------|------|------|
+| `BOTS_CONFIG` | _(未设置)_ | 指定 bots.json 路径（覆盖默认位置） |
+| `WEB_HOST` | `0.0.0.0` | HTTP 服务绑定地址 |
+| `WEB_EXTERNAL_HOST` | _(自动探测局域网 IP)_ | 终端链接中的外部主机名/IP |
+| `SESSION_DATA_DIR` | `~/.botmux/data` | 会话和队列存储目录 |
+| `BACKEND_TYPE` | _(自动检测)_ | `pty` 强制降级到纯 pty 模式 |
+| `DEBUG` | _(未设置)_ | 设为 `1` 启用调试日志 |
+
+### Dashboard 相关
+
+| 变量 | 默认 | 说明 |
+|------|------|------|
+| `BOTMUX_DASHBOARD_HOST` | `0.0.0.0` | dashboard HTTP 绑定地址 |
+| `BOTMUX_DASHBOARD_PORT` | `7891` | dashboard HTTP 端口 |
+| `BOTMUX_DASHBOARD_EXTERNAL_HOST` | `WEB_EXTERNAL_HOST` 或自动探测 | CLI 输出 URL 用的 host |
+| `BOTMUX_DAEMON_IPC_BASE_PORT` | `7892` | 每个 daemon 的 IPC 端口 = base + botIndex |
+| `BOTMUX_WORKFLOW_RUNS_DIR` | `~/.botmux/workflow-runs` | workflow run 存储目录 |
+
+## 文件位置
+
+| 路径 | 说明 |
+|------|------|
+| `~/.botmux/bots.json` | 机器人配置 |
+| `~/.botmux/.env` | 环境变量 |
+| `~/.botmux/data/` | 会话数据、消息队列 |
+| `~/.botmux/logs/` | Daemon 日志 |
+| `~/.botmux/bin/botmux` | 会话内 wrapper 脚本（自动写入） |
+| `~/.botmux/lark-scopes.json` | 完整权限申请 JSON |
+| `~/.botmux/.dashboard-secret` | dashboard HMAC 密钥（0600） |
+  </script>
+
+  <script type="text/markdown" data-doc="adapters">
+# 多 CLI 适配器
+
+botmux 通过适配器桥接不同 CLI，`bots.json` 里用 `cliId` 选择。一键切换，进程隔离。
+
+## 支持的 CLI
+
+| `cliId` | CLI | 支持 model 参数 |
+|---------|-----|:--:|
+| `claude-code` | Claude Code（默认） | ✅ |
+| `codex` | Codex | ✅ |
+| `codex-app` | Codex App | |
+| `cursor` | Cursor（cursor-agent） | ✅ |
+| `gemini` | Gemini | ✅ |
+| `opencode` | OpenCode | ✅ |
+| `coco` | CoCo / Trae（需 ≥ 0.120.32） | ✅ |
+| `aiden` | Aiden | |
+| `antigravity` | Antigravity（agy） | |
+| `hermes` | Hermes | |
+
+> 还有社区贡献的 MTR、ttadk、Mira 等接入方式。`model` 字段只对支持模型参数的适配器生效，其它会忽略。
+
+## 套 wrapper / 网关接入
+
+很多场景下你不是直接跑原生 CLI，而是套一层网关 / 路由（内网代理 + SSO、模型路由等），比如 `ccr`、`ttadk`、`aiden x claude`、`aiden x codex`。这时**不需要新适配器**：`cliId` 仍填底层真实 CLI（`claude-code` / `codex` …），只把启动入口换成一个 **wrapper 脚本**，用 `cliPathOverride` 指过去（`botmux setup` 编辑机器人时的「CLI 可执行文件路径覆盖」就是填它）。
+
+**通用四步：**
+
+1. **先登录网关**（一次性）：用跑 daemon 的**同一系统用户**完成 SSO 登录，token 缓存在该用户家目录。token 过期会弹交互登录卡住 PTY，注意保持登录态。
+2. **写 wrapper 脚本** 放 `~/.botmux/bin/`，把 botmux 传入的参数透传给真实 CLI（注意：有的网关拒收 botmux 注入的 `--settings`，要在脚本里剥掉）。
+3. **`chmod +x` 加可执行位（最容易漏！）**——botmux 用 node-pty 直接 exec 脚本，没有可执行位会 `EACCES`、CLI 起来即退、bot 崩溃重启。
+4. **直接执行脚本验证**（用 `~/.botmux/bin/xxx --version`，别用 `bash xxx` 测——走 bash 不需要可执行位会掩盖第 3 步问题）。然后在 `bots.json` 配 `cliPathOverride`（写**绝对路径**，别用 `~`），`botmux restart` 生效。
+
+**示例 · ttadk × claude**（`~/.botmux/bin/ttadk-claude`，记得 `chmod +x`）：
+
+```bash
+#!/usr/bin/env bash
+if [ "$#" -eq 0 ]; then exec ttadk claude --model glm-5 --skip-check; fi
+argv=""; for arg in "$@"; do [ -n "$argv" ] && argv="$argv "; argv="$argv$(printf '%q' "$arg")"; done
+exec ttadk claude --model glm-5 --skip-check --args "$argv"
+```
+
+```json
+{ "cliId": "claude-code", "cliPathOverride": "/root/.botmux/bin/ttadk-claude" }
+```
+
+**示例 · aiden × claude**（剥掉 `--settings`，其余透传）：
+
+```bash
+#!/usr/bin/env bash
+args=(); skip=0
+for a in "$@"; do
+  [ $skip = 1 ] && { skip=0; continue; }
+  case "$a" in --settings) skip=1; continue;; --settings=*) continue;; esac
+  args+=("$a")
+done
+exec aiden x claude "${args[@]}"
+```
+
+```json
+{ "cliId": "claude-code", "cliPathOverride": "/root/.botmux/bin/aiden-x-claude" }
+```
+
+**示例 · aiden × codex**（codex 需要真 TTY 才能写 `history.jsonl`，用 `script` 强套 PTY 兜底）：
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+MODEL=gpt-5.5-paygo
+if script --version 2>/dev/null | grep -qi util-linux; then
+  exec script -qfe -c "exec aiden x codex --model $MODEL $(printf '%q ' "$@")" /dev/null
+else
+  exec script -q /dev/null aiden x codex --model "$MODEL" "$@"
+fi
+```
+
+```json
+{ "cliId": "codex", "cliPathOverride": "/root/.botmux/bin/aiden-x-codex" }
+```
+
+> **MTR**：社区贡献的接入方式，安装 `npm i -g @metamove-code/mtr-cli@latest`、`/login` 选 metamove 登录（开发机用 scan SSO）后按其文档接入。详见各自的飞书配置文档。
+>
+> 排查 wrapper 问题的通用手法：`botmux logs` 找 `Spawning fresh CLI:` 那行，复制完整命令在本地手动跑一遍即可定位（权限 / 参数黑名单 / 登录态）。
+
+## 添加新适配器（贡献者）
+
+1. `src/adapters/cli/` 下新建文件，实现 `CliAdapter` 接口
+2. `src/adapters/cli/types.ts` 的 `CliId` 联合类型加新 ID
+3. `src/adapters/cli/registry.ts` 加 import / switch case / export
+4. `src/worker.ts` 的 `CLI_DISPLAY_NAMES`、`card-builder.ts` 的 `cliDisplayNames` 加显示名
+5. `src/cli.ts` setup 交互菜单加选项
+6. 更新 README
+
+详见 [CONTRIBUTING.md](https://github.com/deepcoldy/botmux/blob/master/CONTRIBUTING.md)。
+  </script>
+
+  <script type="text/markdown" data-doc="best-practices">
+# 最佳实践
+
+> 综合自 README、官方接入文档与社区交流群的实际使用反馈，持续补充中。踩坑细节单列在 [常见踩坑](#pitfalls)。
+
+## 部署
+
+- **Node.js 用 ≥ 22**。太老的 Node（如 v18）`botmux setup` 校验凭证时会报 `fetch is not defined` / `fetch failed`，导致不写 `bots.json`——根因是老 Node 没内置全局 `fetch`。
+- **部署在常开的开发机 / 服务器上**，而不是会合盖休眠的笔记本——daemon 要长期在线才能随时遥控。
+- **强烈推荐装 tmux**（CLI 需要在 tmux 里启动）。不能装时用 `BACKEND_TYPE=pty`（或 per-bot 配 `backendType: "pty"`）退路。
+- tmux **优先用系统包管理器自带的稳定版**（如 apt 的 3.3a），别盲目追新——Homebrew / 源码编译的高版本（如 3.6a）在部分机器上会让自动输入异常、CLI 中途退出。
+- 配完务必 `botmux autostart enable`，重启机器自恢复，无需 sudo。无桌面 Linux 想登出后常驻：`sudo loginctl enable-linger <用户名>`。
+- 用 nvm/fnm 切过 node 版本后，重跑一次 `botmux autostart enable` 刷新单元文件路径。
+- **重启 daemon 请在干净的非 tmux shell 里执行**。在 botmux/CLI 自己的 tmux pane 里 `botmux restart` 会把运行时变量（`TMUX`、`LARK_*`、`BOTMUX_*` 等）继承污染进 daemon，引发偶发的 token / 网关报错。
+- 一台机可跑**多个 botmux 实例**，每个绑不同飞书机器人即可（"左右手互搏"），安装流程与单实例一致。
+- 也支持绑定外部租户的飞书机器人；只要机器能连通飞书开放平台即可，不限办公网。
+
+## 会话管理
+
+- **会话/上下文复用规则**：普通群整群复用一个会话（群内开话题则话题内复用）；话题群每个话题各自一个会话；私聊自动开话题、话题内复用。
+- **每个话题会 fork 一个独立 CLI 进程，目前没有空闲自动回收**——不关就一直 active。及时清理：
+  - `/close`（会话级，kill 进程，关闭卡片可一键恢复）
+  - Dashboard 批量关闭（可按 N 小时 / N 天筛选）
+  - `botmux delete stopped`（清僵尸）/ `botmux delete all`（关全部）/ `botmux list`（先看有哪些）
+- **别直接 `tmux kill-session`**：daemon 仍认为会话 active，会按持久恢复逻辑重新拉起（直到 CLI 崩 4 次才停）。一律走 `botmux delete`，让会话状态同步标记 closed。
+- 想换目录用 `/cd`；想保上下文重启用 `/restart`；想留 resume 线索再关用 `/close`（卡片里给出 CLI 原生 resume 命令，可搬到本地继续）。
+- **一个独立任务一个独立话题**，上下文天然隔离。普通群里用 `/t` 强制开 thread-scope 会话。
+- **`/repo` 的仓库编号会随列表变化漂移**，自动化别写死编号——用 `/repo <项目名>` 或路径唯一指定。
+
+## 多机器人协作
+
+- 接力前先 `@botA @botB /introduce` 让它们互认 open_id，否则跨 bot `--mention` 拿不到对方。
+- 硬性事实：**不 `--mention` 对方 bot，对方完全不会被触发**。
+- **给不同 bot 不同名字 / 身份 / 职责**，别同名——否则群里 @ 时模型容易混淆、重复响应。常见分工：一个主控调度，一个做实现 / review。
+- 实测 8 个 bot 同群协作也不串台——关键是让每个 bot 用**独立的 git worktree**。
+- **赛马式协作**推荐"一方主导 + 执行、另一方 review + 必要时深度调研"，避免话痨模型导致轮次爆炸、烧 token。
+- 一个飞书 Bot 只能接一个长连接应用——别让别的抢 websocket 的应用共用同一 Bot，否则时好时坏。
+
+## 定时任务 / Oncall
+
+- 自然语言最省事：直接说「每天 9 点检查报警趋势并总结」。
+- 任务在**创建它的原话题**续跑，所以就在你想接收结果的那个话题里建。
+- Oncall 群 + 定时任务是绝配：定点把巡检 / 报警摘要喂进群。
+- **Oncall 机器人建议单独部署在专用机器上隔离**——oncall prompt 直达模型，用户使坏可能把机器搞坏，别跟重要环境混部。
+- 善用权限分层：放心拉成员进来问（`canTalk`），操作权（`/cd` `/restart` `/close`）仍锁在 `allowedUsers`。
+
+## Web 终端 / Dashboard 安全
+
+- 只读链接随时看；要动手再点「🔑 获取操作链接」拿可写链接（经私聊发，不暴露在群里）。
+- 手机上用悬浮快捷键工具栏处理 CLI 的交互菜单（选项、确认权限）。
+- **别把带 token 的 dashboard URL 发到群里**（等于公开临时访问凭证）。安全敏感场景把 host 绑到本机：`BOTMUX_DASHBOARD_HOST=127.0.0.1`。token 一次性，每次 `botmux dashboard` 重新生成、旧链接立即失效。
+- dashboard 打不开先 `curl http://<host>:<port>/__health`，返回 `{"ok":true}` 说明服务正常，问题多在浏览器代理 / host 不对 / 旧 token 链接。
+
+## 稳定与性能
+
+- `botmux send --images` 一次别传太多张图，建议**分批 ≤ 4 张**。
+- 多行消息用 heredoc，别在一行里写 `\n`（会被当字面量显示）。
+- 会话多了 CLI 进程会拉满负载，定期用 Dashboard 批量关闭，或换大规格机器。
+- 疑似卡死的通用三板斧：① `botmux logs` 找 `Spawning fresh CLI:` 那行、复制命令本地手动复现；② 进 Web 终端一眼看模型 / 网关报错；③ 把信息丢给本地 agent 自查（社区欢迎 PR）。
+  </script>
+
+  <script type="text/markdown" data-doc="pitfalls">
+# 常见踩坑与规避
+
+> 来自社区交流群的高频实战坑，按出现频率与影响排序。
+
+## 环境 / 安装
+
+- **Node 太老**：v18 等没内置全局 `fetch`，`botmux setup` 会报 `fetch is not defined` / `fetch failed` 且不写 `bots.json`。→ 升级到 **Node ≥ 22**。
+- **高版本 tmux 导致 CLI 中途退出**：Homebrew / 源码编译的 3.6a 等，症状是新建会话后输入到换行时 CLI 退出、`tmux send-keys ... Enter` 报错。→ 卸载 Homebrew tmux，改用系统自带稳定版（如 3.3a）。
+- **首次启动卡在人工确认**：CLI（如 Claude Code）首次会弹"信任目录 / bypass 权限"确认，没人工点过会卡住、报 `tmux send-keys` 错。→ 首次手动确认一次，之后不再出现。
+
+## 环境变量丢失（高频）
+
+- **bash 用户把变量写在 `.bash_profile` 拿不到**：新 worker 用 `bash -i` 启动，`bash -i` 只读 `.bashrc`。→ 在 `.bashrc` 里 `source ~/.bash_profile`，或直接把变量写进 `.bashrc`（zsh 用户写 `.zshrc`）。这是 `API Error 403` / 网关 token 报错的常见根因。
+- **root 下 Claude 拒绝 `--dangerously-skip-permissions`**：报 "cannot be used with root/sudo privileges"。→ `export IS_SANDBOX=1`（zsh 写 `.zshrc`、bash 写 `.bashrc`；PM2 / systemd / Docker 场景配在对应启动环境）。新版已自动对 root 场景注入。
+
+## 自定义 wrapper / 网关接入
+
+- **wrapper 没透传参数**：用网关脚本包装 CLI 启动时，若没把 `"$@"` 正确透传，CLI 拿不到 `--session-id` 等参数。→ `botmux logs` 找 `Spawning fresh CLI:` 那行，复制完整命令本地复现定位。
+- **wrapper 把 botmux 的参数加进黑名单**：例如屏蔽了 `--settings`、报 `unknown option '--images'`，会导致启动失败掉进 shell。→ 本地手动跑那条 spawn 命令定位，放行相关参数。
+
+## 输入 / 提交
+
+- **多行消息被拆成多条提交**：部分 TUI（Codex / CoCo）把多行 prompt 里的 `\n`、`\t` 当成 Enter / 补全键，逐行提交。→ 新版已把 Codex 输入改成 bracketed paste 规避（与 CoCo 一致）。自己写 `botmux send` 多行时也务必用 heredoc。
+- **上下文压缩后"忘记"往飞书发消息**：无持久 system prompt 的 CLI（CoCo / Codex / Gemini / OpenCode）只在话题首条注入路由说明，上下文被压缩后 routing 块丢失，模型会直接在终端答而不发飞书。→ 新版已对这类 CLI 每条 follow-up 重注入完整 routing 块；用更强的模型可缓解。
+- **弱模型 / 套壳模型不调 `botmux send`**：容易忘记调用、或一直重复调用停不下来。→ 用 SOTA 模型，或加更硬的 prompt 约束。
+
+## 进程 / 连接
+
+- **一个飞书 Bot 接了两个抢长连接的应用**：谁先抢到 websocket 就归谁，导致 botmux 时好时坏。→ 一个 Bot 只接一个长连接应用。
+- **`tmux kill-session` 后会话又被拉起**：daemon 仍认为 active。→ 走 `botmux delete`。
+- **`defaultWorkingDir` 配了之后每发一句就起新 session**：这是"跳过选仓库"的副作用。→ 不想要就删掉该配置。
+- **Codex 0.131+ headless 报 desktop attach socket 错**：`features.apps` 默认开启去连 desktop。→ botmux 已对其拉起的 Codex 加 `--disable apps` 规避。
+
+## 磁盘 / 日志
+
+- **`tmux-server-*.log` 撑爆磁盘**：只有用 `tmux -v`/`-vv` 启动才会产生，无自动轮转，长跑能涨到上百 GB。botmux 自身从不带 `-v`，这种文件可安全清理，不影响 botmux 日志。
+
+## 协作
+
+- **两个 bot 互相 @ 死循环**：每条消息底部都"发送给 @对方"会无限循环。→ 通常一方主动停就解；本质是模型多嘴行为，加约束。
+  </script>
+
+  <script type="text/markdown" data-doc="faq">
+# FAQ / 排错
+
+> 综合自 README 与社区交流群高频问题，持续补充中。更多坑见 [常见踩坑](#pitfalls)。
+
+## 机器人完全收不到消息怎么办？
+
+按顺序自查（PersonalAgent 默认配好，正常不用动）：
+
+1. **事件订阅**：开放平台 → 事件与回调 → 应订阅 `im.message.receive_v1` + `card.action.trigger`，方式为「长连接 (WebSocket)」，且 daemon 已在跑。
+2. **机器人能力**：开放平台 → 应用功能 → 机器人 应已开通。
+3. **发版**：应用要创建并发布过版本（可用性「仅自己可见」自动通过）。
+4. **长连接独占**：确认这个 Bot 没被别的应用同时抢长连接。
+5. 确认后 `botmux restart`（在干净 shell 里）。
+
+## 机器人在终端有输出，但没发到飞书？
+
+终端 stdout ≠ 已发飞书。必须显式执行 `botmux send`（并带 `--mention-back` / `--mention` / `--no-mention` 之一），群里才看得到。模型只 `echo`/`print` 或忘了调 `botmux send` 就不会发出。多行内容用 heredoc，别写成 `"第一行\n第二行"`。
+
+## `botmux history` 报 400 / 飞书网关 411？
+
+- **400**：通常是飞书机器人权限缺失（如缺 `im:message.group_msg`）→ 把权限 JSON 全开。
+- **411**：飞书网关对"带空 body 的 GET"更严格，旧版 SDK 给 GET 带 `{}` body 触发 → 升级到新版已修。
+
+## `Please run /login · API Error: 403` 怎么解？
+
+先分清是哪个 `/login`：
+
+- **飞书侧 App Token 调 API 被拒**：话题里发 `/login` → 点授权链接 → 把浏览器跳转的 callback URL（`http://127.0.0.1:9768/callback?...`，页面打不开是正常的）复制回话题。
+- **模型网关侧 403**：跟飞书授权无关，多为环境变量 / 网关 token 问题，常见根因是 bash 用户把变量写在 `.bash_profile` 没被 `bash -i` 读到（见 [常见踩坑](#pitfalls)）。
+
+## 支持 Lark 国际版（larksuite.com）吗？
+
+目前**仅支持飞书 (feishu.cn) 租户**。扫码检测到国际版会中止 setup，lark 域接入会在后续跟进。
+
+## 多个机器人怎么互相协作？
+
+先 `@botA @botB /introduce` 互相登记 open_id；之后用 `botmux send --mention <对方 open_id>` 显式触发对方。不 `--mention` 对方 bot 不会被触发。
+
+## daemon 重启会丢上下文吗？
+
+装了 **tmux** 就不会——CLI 进程常驻 tmux session，`botmux restart` 后下次消息自动 re-attach，无需 `--resume`。没装 tmux 则走 pty 模式，重启会重载。
+
+## 会话不关会一直跑吗？有自动回收吗？
+
+会一直跑，**目前无空闲 TTL 自动回收**。用 `/close`、Dashboard 批量关闭、或 `botmux delete stopped`/`all` 清理。
+
+## 工作目录 / 仓库选择不对？
+
+- `workingDir` 从该目录**向下**找 git 仓库（最多 3 层），不向上扫。指向集合根（如 `~/projects`）列出全部；指向单仓库只列该仓库（含 worktree）。
+- 临时切目录用 `/cd <path>`；想跳过选择卡片直连某仓库用 `defaultWorkingDir`（注意副作用见踩坑）。
+- 别把 `workingDir` 设成 `~`，会遍历太多文件夹。`/repo` 编号会漂移，用 `/repo <项目名>` 指定。
+
+## 权限怎么分？谁能操作？
+
+三层：`allowedChatGroups` / `globalGrants` 给**对话权**（群内全员可问）；`allowedUsers` 给**操作权**（owner 才能 `/cd` `/restart` `/close` 点按钮）。配了 `allowedChatGroups` 时 `allowedUsers` 至少要有一个 owner。
+
+## 运行中的会话能临时追问 / 打断吗？
+
+默认不打断当前轮，新消息排队（type-ahead），本轮结束再依次输入。想立即纠偏：先在卡片 / Web 终端点 `Esc` 打断，再提问。
+
+## 能用 ccr / 自定义网关 / 各种 wrapper 启动 CLI 吗？
+
+能。任何"原生 CLI + wrapper / 网关"的组合，写一个把 `"$@"` 透传的 wrapper 脚本，在 `botmux setup` 编辑机器人时把 `cliPathOverride` 配成该脚本路径即可。
+
+## 把机器人拉进新群能看之前的聊天记录吗？
+
+能。直接跟它说"看下历史聊天"，或引用某条消息。前提是飞书机器人权限开全（含群消息读取）。
+
+## 截图里中文 / emoji 是方块？
+
+缺 CJK 字体。Debian/Ubuntu daemon 会尝试自动装 `fonts-noto-cjk fonts-noto-color-emoji`（需免密 sudo 或 root）；其它 Linux 手动装 Noto CJK + Noto Color Emoji 后重启 daemon。
+
+## 普通群消息太多，能改成话题群吗？
+
+能，但需群主 / 管理员操作：群设置 → 群管理 → 群消息形式 → 选「话题消息」。机器人不能替群改设置。
+
+## Windows 能用吗？
+
+没在原生 Windows 上验证过，WSL2 应该问题不大。
+
+## 怎么升级？
+
+`botmux upgrade`。会话内的 `botmux` wrapper 版本始终跟 daemon 一致，无需单独升级。
+
+## CoCo 忙时发消息丢失？
+
+升级到 **CoCo ≥ 0.120.32**——type-ahead（忙时消息进 CoCo 自己的队列）依赖该版本行为。
+  </script>
+
+  <script type="text/markdown" data-doc="about">
+# 关于 & 资源
+
+botmux —— 飞书话题群 ↔ AI 编程 CLI 桥接。MIT 协议开源。
+
+## 链接
+
+- **GitHub**：<https://github.com/deepcoldy/botmux>
+- **npm**：`npm install -g botmux` · <https://www.npmjs.com/package/botmux>
+- **贡献指南**：[CONTRIBUTING.md](https://github.com/deepcoldy/botmux/blob/master/CONTRIBUTING.md)
+- **许可证**：[MIT](https://github.com/deepcoldy/botmux/blob/master/LICENSE)
+
+## 支持的 CLI
+
+Claude Code · Codex · Cursor · Gemini · OpenCode · CoCo(Trae) · Aiden · Antigravity · Hermes · MTR · ttadk · Mira
+
+## 加入交流群
+
+扫码加入 Botmux 飞书交流群（二维码永久有效）：
+
+<div style="display:flex;gap:24px;flex-wrap:wrap;align-items:flex-start;margin:14px 0;">
+  <div style="flex:1;min-width:200px;max-width:300px;">
+    <img src="https://magic-builder.tos-cn-beijing.volces.com/uploads/1780034556967_qr-internal.jpg" alt="内部交流群" style="width:100%;border-radius:10px;border:1px solid var(--line);">
+    <div class="cap">企业内部成员</div>
+  </div>
+  <div style="flex:1;min-width:200px;max-width:300px;">
+    <img src="https://magic-builder.tos-cn-beijing.volces.com/uploads/1780034557258_qr-external.jpg" alt="外部交流群" style="width:100%;border-radius:10px;border:1px solid var(--line);">
+    <div class="cap">外部 / 通用（话题群）</div>
+  </div>
+</div>
+
+## 反馈
+
+发现问题或想加功能，欢迎在 GitHub 提 Issue / PR，或来飞书 Botmux 交流群讨论。
+
+---
+
+<p class="lead">这份文档由 botmux 自己（在飞书话题里）生成并发布到飞书妙笔 🪄</p>
+  </script>
+
+  <!-- ===================== 应用逻辑 ===================== -->
+  <script>
+    // 环境兼容：mock window.magic / window.lark
+    (function ensureMagic(){
+      if(!window.magic) window.magic = {};
+      if(typeof window.magic.updateHeight!=='function') window.magic.updateHeight=async()=>{};
+      if(!window.lark) window.lark = {};
+    })();
+
+    // 导航结构
+    const NAV = [
+      { group:'开始', items:[
+        ['intro','介绍'],
+        ['quickstart','5 分钟快速接入'],
+        ['prerequisites','前置要求'],
+      ]},
+      { group:'核心概念', items:[
+        ['architecture','架构总览'],
+        ['session-model','会话与话题模型'],
+      ]},
+      { group:'功能详解', items:[
+        ['cards','实时流式卡片'],
+        ['web-terminal','Web 终端'],
+        ['multi-bot','多机器人协作'],
+        ['roles','角色与团队'],
+        ['tmux','tmux 会话常驻'],
+        ['adopt','会话接入 Adopt'],
+        ['relay','会话接力 Relay'],
+        ['group','一键建会话群'],
+        ['schedule','定时任务'],
+        ['oncall','Oncall 模式'],
+        ['dashboard','Dashboard 管控面'],
+        ['workflow','Workflow（实验性）'],
+        ['skill-cli','Skill + CLI 交互'],
+      ]},
+      { group:'命令参考', items:[
+        ['slash-commands','斜杠命令'],
+        ['cli-commands','CLI 命令'],
+      ]},
+      { group:'配置', items:[
+        ['bots-json','bots.json 配置'],
+        ['env','环境变量与文件位置'],
+        ['adapters','多 CLI 适配器'],
+      ]},
+      { group:'实践与排错', items:[
+        ['best-practices','最佳实践'],
+        ['pitfalls','常见踩坑'],
+        ['faq','FAQ / 排错'],
+        ['about','关于 & 资源'],
+      ]},
+    ];
+
+    // 读取所有 markdown 文档
+    const DOCS = {};
+    const FLAT = []; // [{id,title,group}]
+    document.querySelectorAll('script[type="text/markdown"]').forEach(s=>{
+      DOCS[s.dataset.doc] = s.textContent;
+    });
+    NAV.forEach(g=>g.items.forEach(([id,title])=>FLAT.push({id,title,group:g.group})));
+
+    // marked + highlight
+    marked.setOptions({
+      highlight:(code,lang)=>{
+        try{ if(lang && hljs.getLanguage(lang)) return hljs.highlight(code,{language:lang}).value; }catch(e){}
+        try{ return hljs.highlightAuto(code).value; }catch(e){ return code; }
+      },
+      breaks:false, gfm:true
+    });
+
+    // 渲染侧边栏
+    const sidebar = document.getElementById('sidebar');
+    function renderNav(active){
+      sidebar.innerHTML = NAV.map(g=>`
+        <div class="nav-group">
+          <div class="gtitle">${g.group}</div>
+          ${g.items.map(([id,title])=>`<div class="nav-item${id===active?' active':''}" data-id="${id}">${title}</div>`).join('')}
+        </div>`).join('');
+      // 直接绑定（与 searchBtn 一致；委托在沙箱里不可靠）
+      sidebar.querySelectorAll('.nav-item').forEach(a=> a.addEventListener('click',()=> go(a.dataset.id)));
+    }
+
+    function slug(text){ return text.trim().toLowerCase().replace(/[^\w一-龥]+/g,'-').replace(/^-+|-+$/g,''); }
+
+    // 渲染内容
+    const mdEl = document.getElementById('md');
+    const contentEl = document.getElementById('content');
+    function render(id){
+      if(!DOCS[id]) id='intro';
+      mdEl.innerHTML = marked.parse(DOCS[id]);
+      // 给 h2/h3 加锚点 id
+      mdEl.querySelectorAll('h2,h3').forEach(h=>{ if(!h.id) h.id=slug(h.textContent); });
+      // 内部链接 #xxx 改为 go()
+      mdEl.querySelectorAll('a[href^="#"]').forEach(a=>{
+        const t = a.getAttribute('href').slice(1);
+        if(DOCS[t]){ a.addEventListener('click',e=>{e.preventDefault(); go(t);}); }
+      });
+      // pager
+      const idx = FLAT.findIndex(f=>f.id===id);
+      const prev = FLAT[idx-1], next = FLAT[idx+1];
+      document.getElementById('pager').innerHTML =
+        (prev?`<div class="pgl" data-go="${prev.id}"><div class="dir">← 上一页</div><div class="ttl">${prev.title}</div></div>`:`<span></span>`)+
+        (next?`<div class="pgl next" data-go="${next.id}"><div class="dir">下一页 →</div><div class="ttl">${next.title}</div></div>`:`<span></span>`);
+      document.getElementById('pager').querySelectorAll('[data-go]').forEach(a=> a.addEventListener('click',()=> go(a.getAttribute('data-go'))));
+      document.getElementById('docfoot').innerHTML = `botmux 文档 · <a href="https://github.com/deepcoldy/botmux" target="_blank" style="color:var(--brand)">GitHub</a> · MIT`;
+      renderNav(id);
+      contentEl.scrollTop = 0;
+      window.magic.updateHeight && window.magic.updateHeight();
+    }
+
+    // 是否在 iframe 内（妙笔 HTML Box 把页面跑在 sandbox iframe 里，
+    // 此时写 location.hash 会触发 iframe 重新加载、把视图打回首页，所以禁用 hash）
+    const IN_IFRAME = (()=>{ try{ return window.self!==window.top; }catch(e){ return true; } })();
+    function go(id){
+      if(!IN_IFRAME){ try{ if(location.hash.slice(2)!==id) location.hash = '#/'+id; }catch(e){} }
+      render(id);
+      closeSidebar();
+    }
+    window.go = go;
+
+    document.getElementById('brandHome').addEventListener('click',()=>go('intro'));
+
+    window.addEventListener('hashchange',()=>{ const id=location.hash.replace(/^#\//,'')||'intro'; if(DOCS[id]) render(id); });
+
+    // 移动端侧边栏
+    const hamb=document.getElementById('hamb'), backdrop=document.getElementById('backdrop');
+    function openSidebar(){ sidebar.classList.add('open'); backdrop.classList.add('show'); }
+    function closeSidebar(){ sidebar.classList.remove('open'); backdrop.classList.remove('show'); }
+    hamb.addEventListener('click',()=> sidebar.classList.contains('open')?closeSidebar():openSidebar());
+    backdrop.addEventListener('click',closeSidebar);
+
+    // ============ 搜索 ============
+    const overlay=document.getElementById('overlay'), input=document.getElementById('searchInput'), results=document.getElementById('results');
+    // 预处理纯文本索引
+    const INDEX = FLAT.map(f=>{
+      const raw = (DOCS[f.id]||'').replace(/```[\s\S]*?```/g,' ').replace(/[#>*`|\-]/g,' ').replace(/\s+/g,' ');
+      return {...f, text:raw, lower:raw.toLowerCase()};
+    });
+    let selIdx = 0, curResults = [];
+    function openSearch(){ overlay.classList.add('show'); input.value=''; input.focus(); doSearch(''); }
+    function closeSearch(){ overlay.classList.remove('show'); }
+    document.getElementById('searchBtn').addEventListener('click',openSearch);
+    overlay.addEventListener('click',e=>{ if(e.target===overlay) closeSearch(); });
+    function esc(s){ return s.replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c])); }
+    function snippet(text,q){
+      if(!q) return text.slice(0,90);
+      const i = text.toLowerCase().indexOf(q.toLowerCase());
+      if(i<0) return text.slice(0,90);
+      const start=Math.max(0,i-30), s=text.slice(start,start+90);
+      return (start>0?'…':'')+esc(s).replace(new RegExp('('+q.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')+')','ig'),'<mark>$1</mark>');
+    }
+    function doSearch(q){
+      const ql=q.toLowerCase().trim();
+      curResults = !ql ? INDEX.slice() : INDEX.filter(f=> f.title.toLowerCase().includes(ql) || f.lower.includes(ql));
+      // 标题命中优先
+      if(ql) curResults.sort((a,b)=> (b.title.toLowerCase().includes(ql)?1:0)-(a.title.toLowerCase().includes(ql)?1:0));
+      selIdx=0;
+      results.innerHTML = curResults.length ? curResults.map((f,i)=>`
+        <div class="result${i===0?' sel':''}" data-id="${f.id}">
+          <div><span class="rt">${esc(f.title)}</span><span class="rg">${f.group}</span></div>
+          <div class="rs">${snippet(f.text,ql)}</div>
+        </div>`).join('') : `<div class="noresult">没有匹配的内容</div>`;
+      results.querySelectorAll('.result').forEach(r=> r.addEventListener('click',()=>{ go(r.dataset.id); closeSearch(); }));
+    }
+    input.addEventListener('input',e=>doSearch(e.target.value));
+    document.addEventListener('keydown',e=>{
+      if(e.key==='/' && !overlay.classList.contains('show') && !/INPUT|TEXTAREA/.test(document.activeElement.tagName)){ e.preventDefault(); openSearch(); }
+      else if(e.key==='Escape'){ closeSearch(); }
+      else if(overlay.classList.contains('show') && (e.key==='ArrowDown'||e.key==='ArrowUp')){
+        e.preventDefault();
+        const items=results.querySelectorAll('.result'); if(!items.length) return;
+        items[selIdx]?.classList.remove('sel');
+        selIdx = e.key==='ArrowDown' ? Math.min(selIdx+1,items.length-1) : Math.max(selIdx-1,0);
+        items[selIdx].classList.add('sel'); items[selIdx].scrollIntoView({block:'nearest'});
+      } else if(overlay.classList.contains('show') && e.key==='Enter'){
+        const item=results.querySelectorAll('.result')[selIdx]; if(item){ go(item.dataset.id); closeSearch(); }
+      }
+    });
+
+    // 初始渲染
+    render(location.hash.replace(/^#\//,'')||'intro');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
回答「文档站代码存哪、别人能否维护和发布、且不暴露隐私 token」。

## 加了什么
- `docs-site/index.html`：飞书妙笔上的 botmux 中文文档站**源码**（自包含单 HTML：左侧导航 + 站内搜索 + 代码高亮 + 移动自适应；内容内嵌在 `<script type="text/markdown">` 块里；图片走 TOS 外链）。
- `docs-site/README.md`：怎么改内容、怎么发布。
- `.gitignore`：补 `.magic-token` / `.magic-apps.json`，防止误提交妙笔密钥。

## 维护 & 发布模型（隐私安全）
- **源码人人可改**：改 `docs-site/index.html` 提 PR 即可。
- **token 永不入库**：发布用妙笔官方 magic-builder 技能，token 只存各自本机 `~/.magic-token`，每人用自己的妙笔账号 token。已扫描确认 index.html / 提交内容无任何 token。
- **官方线上站**（`vkWHeJn1Fn2`）绑定在发布者妙笔账号下：别人用自己 token 发的是自己账号下的预览副本；更新官方站由持该 app token 的 owner 跑一条命令（按相对路径→remoteId 原地更新）。

线上：https://magic.solutionsuite.cn/html-box/vkWHeJn1Fn2