### PR TITLE
fix: MTR transcript bridge

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1930,13 +1930,15 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
   //     deterministic from cliSessionId. PID is the fallback when discovery
   //     missed (events.jsonl isn't held open continuously, so worker may need
   //     to re-probe via session.log / traces.jsonl fds).
+  //   - mtr: worker tails MTR's sqlite transcript, resolving by native sid
+  //     when discovery has one or by adopted cwd as a fallback.
   // Other CLIs fall back to legacy screen-capture only.
   const adoptedCliId = adopted.cliId ?? 'claude-code';
   const bridgeJsonlPath =
     adoptedCliId === 'claude-code' && adopted.sessionId
       ? claudeJsonlPathForSession(adopted.sessionId, adopted.cwd)
       : undefined;
-  const isStructuredBridge = adoptedCliId === 'codex' || adoptedCliId === 'coco';
+  const isStructuredBridge = adoptedCliId === 'codex' || adoptedCliId === 'coco' || adoptedCliId === 'mtr';
 
   const initMsg: DaemonToWorker = {
     type: 'init',

--- a/src/services/mtr-transcript.ts
+++ b/src/services/mtr-transcript.ts
@@ -14,6 +14,7 @@ import type { CodexBridgeEvent } from './codex-transcript.js';
 
 const MTR_DATA_DIR = join(homedir(), '.local', 'share', 'opencode');
 const MTR_DB_RE = /^mtr(?:-[A-Za-z0-9._-]+)?\.db$/;
+const MTR_CURSOR_LOOKBACK_MS = 5_000;
 
 export interface MtrTranscriptSource {
   dbPath: string;
@@ -120,6 +121,10 @@ function groupRows(rows: MtrJoinedRow[]): GroupedMessage[] {
 }
 
 function queryChangedRows(source: MtrTranscriptSource, offset: number): MtrJoinedRow[] {
+  // MTR only gives us timestamp cursors. Re-read a small overlap so rows that
+  // share the previous max timestamp but commit after the last poll are not
+  // skipped by the exclusive SQL predicate. The bridge queue de-dupes by uuid.
+  const lowerBound = Math.max(0, offset - MTR_CURSOR_LOOKBACK_MS);
   const script = `
 import json
 import sqlite3
@@ -150,7 +155,7 @@ rows = conn.execute(
     WHERE m.id IN (SELECT id FROM changed)
     ORDER BY m.time_created, m.id, p.time_created, p.id
     """,
-    (${JSON.stringify(source.sessionId)}, ${JSON.stringify(offset)}, ${JSON.stringify(offset)}),
+    (${JSON.stringify(source.sessionId)}, ${JSON.stringify(lowerBound)}, ${JSON.stringify(lowerBound)}),
 ).fetchall()
 print(json.dumps([dict(r) for r in rows], ensure_ascii=False))
 `;

--- a/src/services/mtr-transcript.ts
+++ b/src/services/mtr-transcript.ts
@@ -1,0 +1,302 @@
+/**
+ * Reader for MTR's OpenCode-compatible SQLite session store.
+ *
+ * MTR persists conversations under ~/.local/share/opencode/mtr*.db. The schema
+ * stores message role/finish metadata in message.data and visible text in the
+ * part table. This reader maps completed user/assistant turns into the same
+ * bridge event shape used by Codex/CoCo/Hermes.
+ */
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import type { CodexBridgeEvent } from './codex-transcript.js';
+
+const MTR_DATA_DIR = join(homedir(), '.local', 'share', 'opencode');
+const MTR_DB_RE = /^mtr(?:-[A-Za-z0-9._-]+)?\.db$/;
+
+export interface MtrTranscriptSource {
+  dbPath: string;
+  sessionId: string;
+}
+
+interface MtrSessionRow {
+  id: string;
+  time_updated?: number;
+}
+
+interface MtrJoinedRow {
+  message_id: string;
+  session_id: string;
+  message_time_created?: number;
+  message_time_updated?: number;
+  message_data: string;
+  part_id?: string | null;
+  part_time_created?: number | null;
+  part_time_updated?: number | null;
+  part_data?: string | null;
+}
+
+interface GroupedMessage {
+  id: string;
+  sessionId: string;
+  timeCreated: number;
+  timeUpdated: number;
+  data: Record<string, unknown>;
+  parts: Array<{ id: string; timeUpdated: number; data: Record<string, unknown> }>;
+}
+
+function runPythonJson<T>(script: string): T {
+  const proc = spawnSync('python3', ['-c', script], { encoding: 'utf8', maxBuffer: 20 * 1024 * 1024 });
+  if (proc.status !== 0) throw new Error((proc.stderr || proc.error?.message || 'python3 sqlite query failed').trim());
+  const stdout = proc.stdout.trim();
+  return (stdout ? JSON.parse(stdout) : []) as T;
+}
+
+function jsonParseObject(raw: string | null | undefined): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function messageTimestampMs(message: GroupedMessage, assistantFinal: boolean): number {
+  const time = message.data.time;
+  if (time && typeof time === 'object') {
+    const t = time as Record<string, unknown>;
+    const completed = numberValue(t.completed);
+    if (assistantFinal && completed !== undefined) return completed;
+    const created = numberValue(t.created);
+    if (created !== undefined) return created;
+  }
+  return message.timeUpdated || message.timeCreated || Date.now();
+}
+
+function textFromParts(parts: GroupedMessage['parts']): string {
+  const out: string[] = [];
+  for (const part of parts) {
+    if (part.data.type !== 'text') continue;
+    if (part.data.ignored === true) continue;
+    const text = part.data.text;
+    if (typeof text === 'string' && text.trim()) out.push(text);
+  }
+  return out.join('');
+}
+
+function groupRows(rows: MtrJoinedRow[]): GroupedMessage[] {
+  const map = new Map<string, GroupedMessage>();
+  for (const row of rows) {
+    let msg = map.get(row.message_id);
+    if (!msg) {
+      msg = {
+        id: row.message_id,
+        sessionId: row.session_id,
+        timeCreated: row.message_time_created ?? 0,
+        timeUpdated: row.message_time_updated ?? 0,
+        data: jsonParseObject(row.message_data),
+        parts: [],
+      };
+      map.set(row.message_id, msg);
+    }
+    if (typeof row.message_time_updated === 'number' && row.message_time_updated > msg.timeUpdated) {
+      msg.timeUpdated = row.message_time_updated;
+    }
+    if (row.part_id && row.part_data) {
+      msg.parts.push({
+        id: row.part_id,
+        timeUpdated: row.part_time_updated ?? 0,
+        data: jsonParseObject(row.part_data),
+      });
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => (a.timeCreated - b.timeCreated) || a.id.localeCompare(b.id));
+}
+
+function queryChangedRows(source: MtrTranscriptSource, offset: number): MtrJoinedRow[] {
+  const script = `
+import json
+import sqlite3
+conn = sqlite3.connect(${JSON.stringify(source.dbPath)})
+conn.row_factory = sqlite3.Row
+rows = conn.execute(
+    """
+    WITH changed AS (
+      SELECT m.id
+      FROM message m
+      LEFT JOIN part p ON p.message_id = m.id
+      WHERE m.session_id = ?
+        AND (m.time_updated > ? OR COALESCE(p.time_updated, 0) > ?)
+      GROUP BY m.id
+    )
+    SELECT
+      m.id AS message_id,
+      m.session_id AS session_id,
+      m.time_created AS message_time_created,
+      m.time_updated AS message_time_updated,
+      m.data AS message_data,
+      p.id AS part_id,
+      p.time_created AS part_time_created,
+      p.time_updated AS part_time_updated,
+      p.data AS part_data
+    FROM message m
+    LEFT JOIN part p ON p.message_id = m.id
+    WHERE m.id IN (SELECT id FROM changed)
+    ORDER BY m.time_created, m.id, p.time_created, p.id
+    """,
+    (${JSON.stringify(source.sessionId)}, ${JSON.stringify(offset)}, ${JSON.stringify(offset)}),
+).fetchall()
+print(json.dumps([dict(r) for r in rows], ensure_ascii=False))
+`;
+  return runPythonJson<MtrJoinedRow[]>(script);
+}
+
+function currentOffset(source: MtrTranscriptSource): number {
+  const script = `
+import sqlite3
+conn = sqlite3.connect(${JSON.stringify(source.dbPath)})
+row = conn.execute(
+    """
+    SELECT COALESCE(MAX(value), 0) FROM (
+      SELECT time_updated AS value FROM message WHERE session_id = ?
+      UNION ALL
+      SELECT time_updated AS value FROM part WHERE session_id = ?
+    )
+    """,
+    (${JSON.stringify(source.sessionId)}, ${JSON.stringify(source.sessionId)}),
+).fetchone()
+print(row[0] or 0)
+`;
+  const proc = spawnSync('python3', ['-c', script], { encoding: 'utf8' });
+  if (proc.status !== 0) return 0;
+  return Number.parseInt(proc.stdout.trim(), 10) || 0;
+}
+
+function querySessionById(dbPath: string, sessionId: string): MtrSessionRow | undefined {
+  const script = `
+import json
+import sqlite3
+conn = sqlite3.connect(${JSON.stringify(dbPath)})
+conn.row_factory = sqlite3.Row
+row = conn.execute(
+    "SELECT id, time_updated FROM session WHERE id = ? LIMIT 1",
+    (${JSON.stringify(sessionId)},),
+).fetchone()
+print(json.dumps(dict(row), ensure_ascii=False) if row else "null")
+`;
+  const row = runPythonJson<MtrSessionRow | null>(script);
+  return row || undefined;
+}
+
+function queryLatestSessionByDirectory(dbPath: string, directory: string): MtrSessionRow | undefined {
+  const script = `
+import json
+import sqlite3
+conn = sqlite3.connect(${JSON.stringify(dbPath)})
+conn.row_factory = sqlite3.Row
+row = conn.execute(
+    """
+    SELECT id, time_updated
+    FROM session
+    WHERE directory = ?
+    ORDER BY time_updated DESC
+    LIMIT 1
+    """,
+    (${JSON.stringify(directory)},),
+).fetchone()
+print(json.dumps(dict(row), ensure_ascii=False) if row else "null")
+`;
+  const row = runPythonJson<MtrSessionRow | null>(script);
+  return row || undefined;
+}
+
+export function mtrDbCandidates(dataDir = MTR_DATA_DIR): string[] {
+  if (!existsSync(dataDir)) return [];
+  let names: string[];
+  try { names = readdirSync(dataDir); } catch { return []; }
+  return names
+    .filter(name => MTR_DB_RE.test(name))
+    .map(name => join(dataDir, name))
+    .filter(path => {
+      try { return statSync(path).isFile(); } catch { return false; }
+    });
+}
+
+export function findMtrSessionById(sessionId: string | undefined, dbPaths = mtrDbCandidates()): MtrTranscriptSource | undefined {
+  if (!sessionId) return undefined;
+  for (const dbPath of dbPaths) {
+    if (!existsSync(dbPath)) continue;
+    try {
+      const row = querySessionById(dbPath, sessionId);
+      if (row) return { dbPath, sessionId: row.id };
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+export function findLatestMtrSessionByDirectory(directory: string | undefined, dbPaths = mtrDbCandidates()): MtrTranscriptSource | undefined {
+  if (!directory) return undefined;
+  let best: { dbPath: string; row: MtrSessionRow } | undefined;
+  for (const dbPath of dbPaths) {
+    if (!existsSync(dbPath)) continue;
+    try {
+      const row = queryLatestSessionByDirectory(dbPath, directory);
+      if (!row) continue;
+      if (!best || (row.time_updated ?? 0) > (best.row.time_updated ?? 0)) best = { dbPath, row };
+    } catch {
+      continue;
+    }
+  }
+  return best ? { dbPath: best.dbPath, sessionId: best.row.id } : undefined;
+}
+
+export function drainMtrSession(source: MtrTranscriptSource | undefined, fromOffset: number): { events: CodexBridgeEvent[]; newOffset: number } {
+  if (!source || !existsSync(source.dbPath)) return { events: [], newOffset: fromOffset };
+  const rows = queryChangedRows(source, fromOffset);
+  let newOffset = fromOffset;
+  const events: CodexBridgeEvent[] = [];
+  for (const msg of groupRows(rows)) {
+    newOffset = Math.max(
+      newOffset,
+      msg.timeUpdated,
+      ...msg.parts.map(part => part.timeUpdated),
+    );
+    const role = msg.data.role;
+    if (role === 'user') {
+      const text = textFromParts(msg.parts);
+      if (!text) continue;
+      events.push({
+        uuid: `mtr:${source.dbPath}:${msg.id}`,
+        timestampMs: messageTimestampMs(msg, false),
+        kind: 'user',
+        text,
+        sourceSessionId: msg.sessionId,
+      });
+    } else if (role === 'assistant') {
+      if (msg.data.finish !== 'stop') continue;
+      const text = textFromParts(msg.parts);
+      if (!text) continue;
+      events.push({
+        uuid: `mtr:${source.dbPath}:${msg.id}`,
+        timestampMs: messageTimestampMs(msg, true),
+        kind: 'assistant_final',
+        text,
+        sourceSessionId: msg.sessionId,
+      });
+    }
+  }
+  return { events, newOffset };
+}
+
+export function currentMtrSessionOffset(source: MtrTranscriptSource | undefined): number {
+  if (!source || !existsSync(source.dbPath)) return 0;
+  return currentOffset(source);
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1451,9 +1451,12 @@ function mtrBridgeAttach(source: MtrTranscriptSource, mode: 'baseline-existing' 
     log(`MTR bridge split-live: ${source.dbPath}#${source.sessionId} (history=${history.length}, live=${live.length}, cutoff=${cutoff}, offset=${mtrBridgeOffset})`);
     maybeEmitCodexAdoptPreamble(history);
   } else if (mode === 'baseline-existing') {
-    mtrBridgeOffset = currentMtrSessionOffset(source);
+    const baseline = currentMtrSessionOffset(source);
+    const result = drainMtrSession(source, baseline);
+    codexBridgeQueue.absorb(result.events);
+    mtrBridgeOffset = Math.max(baseline, result.newOffset);
     mtrBridgeBaselineDone = true;
-    log(`MTR bridge baselined: ${source.dbPath}#${source.sessionId} (offset=${mtrBridgeOffset})`);
+    log(`MTR bridge baselined: ${source.dbPath}#${source.sessionId} (offset=${mtrBridgeOffset}, absorbed=${result.events.length})`);
   } else {
     mtrBridgeOffset = 0;
     mtrBridgeBaselineDone = true;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -30,6 +30,7 @@ import { CodexBridgeQueue } from './services/codex-bridge-queue.js';
 import { drainCodexRollout, findCodexRolloutBySessionId, findCodexRolloutByPid, splitCodexEventsByCutoff, extractLastCodexTurn } from './services/codex-transcript.js';
 import { cocoEventsPathForSession, drainCocoEvents, findCocoSessionByPid } from './services/coco-transcript.js';
 import { currentHermesStateOffset, drainHermesStateDb } from './services/hermes-transcript.js';
+import { currentMtrSessionOffset, drainMtrSession, findLatestMtrSessionByDirectory, findMtrSessionById, type MtrTranscriptSource } from './services/mtr-transcript.js';
 import { baselineJsonlCursor } from './services/jsonl-cursor.js';
 import { dirname } from 'node:path';
 import { createServer as createHttpServer, type IncomingMessage } from 'node:http';
@@ -48,6 +49,7 @@ import {
 } from './utils/render-dimensions.js';
 import { createCliAdapterSync } from './adapters/cli/registry.js';
 import { claudeJsonlPathForSession, resolveJsonlFromPid, findOpenClaudeSessionIds } from './adapters/cli/claude-code.js';
+import { mtrSessionIdForBotmuxSession } from './adapters/cli/mtr.js';
 import type { CliAdapter, PtyHandle } from './adapters/cli/types.js';
 import { PtyBackend } from './adapters/backend/pty-backend.js';
 import { TmuxBackend } from './adapters/backend/tmux-backend.js';
@@ -237,6 +239,9 @@ let codexBridgeWatcher: FSWatcher | null = null;
 let codexBridgeTimer: NodeJS.Timeout | null = null;
 let hermesBridgeOffset = 0;
 let hermesBridgeBaselineDone = false;
+let mtrBridgeSource: MtrTranscriptSource | undefined;
+let mtrBridgeOffset = 0;
+let mtrBridgeBaselineDone = false;
 /** Codex sessionId we received via writeInput but haven't yet resolved a
  *  rollout file for. The poller keeps retrying — the file appears on
  *  Codex's first user submit, but with some race delay after our submit
@@ -1306,7 +1311,7 @@ function drainPathInto(path: string, fromOffset: number): { offset: number; tail
 function codexBridgeFallbackActive(): boolean {
   // True for transcript-backed CLIs whose final output can be harvested
   // when the model forgets to call `botmux send`.
-  return lastInitConfig?.cliId === 'codex' || lastInitConfig?.cliId === 'coco' || lastInitConfig?.cliId === 'hermes';
+  return lastInitConfig?.cliId === 'codex' || lastInitConfig?.cliId === 'coco' || lastInitConfig?.cliId === 'hermes' || lastInitConfig?.cliId === 'mtr';
 }
 
 function structuredBridgeIsCodex(): boolean {
@@ -1315,6 +1320,10 @@ function structuredBridgeIsCodex(): boolean {
 
 function structuredBridgeIsHermes(): boolean {
   return lastInitConfig?.cliId === 'hermes';
+}
+
+function structuredBridgeIsMtr(): boolean {
+  return lastInitConfig?.cliId === 'mtr';
 }
 
 function structuredBridgeIngestPath(path: string, offset: number) {
@@ -1344,6 +1353,23 @@ function codexBridgeStartTimer(): void {
       if (structuredBridgeIsHermes()) {
         if (!hermesBridgeBaselineDone) hermesBridgeAttach(lastInitConfig?.resume ? 'baseline-existing' : 'fresh-empty');
         hermesBridgeIngest();
+        if (isPromptReady) emitReadyCodexTurns();
+        return;
+      }
+      if (structuredBridgeIsMtr()) {
+        if (!mtrBridgeSource) {
+          const source =
+            findMtrSessionById(codexBridgePendingSessionId)
+            ?? (lastInitConfig?.adoptMode
+              ? findLatestMtrSessionByDirectory(lastInitConfig.adoptCwd ?? lastInitConfig.workingDir)
+              : undefined);
+          if (source) {
+            codexBridgePendingSessionId = undefined;
+            codexAdoptPendingPid = undefined;
+            mtrBridgeAttach(source, lastInitConfig?.adoptMode ? 'split-live' : 'fresh-empty');
+          }
+        }
+        mtrBridgeIngest();
         if (isPromptReady) emitReadyCodexTurns();
         return;
       }
@@ -1406,6 +1432,40 @@ function hermesBridgeIngest(): void {
   if (!hermesBridgeBaselineDone) return;
   const result = drainHermesStateDb(hermesBridgeOffset);
   hermesBridgeOffset = result.newOffset;
+  codexBridgeQueue.ingest(result.events);
+  if (result.events.some(e => e.kind === 'assistant_final')) {
+    idleDetector?.fireIdle();
+  }
+}
+
+function mtrBridgeAttach(source: MtrTranscriptSource, mode: 'baseline-existing' | 'fresh-empty' | 'split-live'): void {
+  mtrBridgeSource = source;
+  if (mode === 'split-live') {
+    const result = drainMtrSession(source, 0);
+    const cutoff = (codexAdoptStartMs ?? Date.now()) - 5_000;
+    const { history, live } = splitCodexEventsByCutoff(result.events, cutoff);
+    codexBridgeQueue.absorb(history);
+    codexBridgeQueue.ingest(live);
+    mtrBridgeOffset = result.newOffset;
+    mtrBridgeBaselineDone = true;
+    log(`MTR bridge split-live: ${source.dbPath}#${source.sessionId} (history=${history.length}, live=${live.length}, cutoff=${cutoff}, offset=${mtrBridgeOffset})`);
+    maybeEmitCodexAdoptPreamble(history);
+  } else if (mode === 'baseline-existing') {
+    mtrBridgeOffset = currentMtrSessionOffset(source);
+    mtrBridgeBaselineDone = true;
+    log(`MTR bridge baselined: ${source.dbPath}#${source.sessionId} (offset=${mtrBridgeOffset})`);
+  } else {
+    mtrBridgeOffset = 0;
+    mtrBridgeBaselineDone = true;
+    log(`MTR bridge fresh-empty: ${source.dbPath}#${source.sessionId}`);
+  }
+  codexBridgeStartTimer();
+}
+
+function mtrBridgeIngest(): void {
+  if (!mtrBridgeBaselineDone || !mtrBridgeSource) return;
+  const result = drainMtrSession(mtrBridgeSource, mtrBridgeOffset);
+  mtrBridgeOffset = result.newOffset;
   codexBridgeQueue.ingest(result.events);
   if (result.events.some(e => e.kind === 'assistant_final')) {
     idleDetector?.fireIdle();
@@ -1485,6 +1545,17 @@ function codexBridgeAttach(rolloutPath: string, mode: 'baseline-existing' | 'fre
  *  remembers the sid so the 1s poller can keep retrying. */
 function codexBridgeNotifyCliSessionId(cliSessionId: string): void {
   if (!codexBridgeFallbackActive() || codexBridgeRolloutPath) return;
+  if (structuredBridgeIsMtr()) {
+    const source = findMtrSessionById(cliSessionId);
+    if (source) {
+      codexBridgePendingSessionId = undefined;
+      mtrBridgeAttach(source, 'fresh-empty');
+    } else {
+      codexBridgePendingSessionId = cliSessionId;
+      codexBridgeStartTimer();
+    }
+    return;
+  }
   const path = findCodexRolloutBySessionId(cliSessionId);
   if (path) {
     codexBridgePendingSessionId = undefined;
@@ -1498,6 +1569,10 @@ function codexBridgeNotifyCliSessionId(cliSessionId: string): void {
 function codexBridgeIngest(): void {
   if (structuredBridgeIsHermes()) {
     hermesBridgeIngest();
+    return;
+  }
+  if (structuredBridgeIsMtr()) {
+    mtrBridgeIngest();
     return;
   }
   if (!codexBridgeRolloutPath || !codexBridgeBaselineDone) return;
@@ -1528,7 +1603,7 @@ function codexBridgeMarkPendingTurn(messageText: string): boolean {
 
 function codexBridgeDrainAndMaybeEmit(): void {
   if (!codexBridgeFallbackActive()) return;
-  if (structuredBridgeIsHermes() || (codexBridgeRolloutPath && codexBridgeBaselineDone)) {
+  if (structuredBridgeIsHermes() || structuredBridgeIsMtr() || (codexBridgeRolloutPath && codexBridgeBaselineDone)) {
     try { codexBridgeIngest(); } catch (err: any) { log(`Codex bridge ingest error: ${err.message}`); }
   }
   emitReadyCodexTurns();
@@ -1598,6 +1673,9 @@ function stopCodexBridge(): void {
   codexBridgeBaselineDone = false;
   hermesBridgeOffset = 0;
   hermesBridgeBaselineDone = false;
+  mtrBridgeSource = undefined;
+  mtrBridgeOffset = 0;
+  mtrBridgeBaselineDone = false;
   codexBridgeQueue.clearPending();
   codexBridgeQueue.setLocalTurns(false);
   codexBridgePendingSessionId = undefined;
@@ -2687,6 +2765,20 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
       // The 1s timer covers ingest + emit even when the watcher never armed,
       // and is idempotent (no-op if already started).
       codexBridgeStartTimer();
+    } else if (cfg.cliId === 'mtr') {
+      const adoptStartMs = Date.now();
+      codexAdoptStartMs = adoptStartMs;
+      codexBridgeQueue.setLocalTurns(true, adoptStartMs);
+      if (cfg.cliSessionId) codexBridgePendingSessionId = cfg.cliSessionId;
+      const source =
+        findMtrSessionById(cfg.cliSessionId)
+        ?? findLatestMtrSessionByDirectory(cfg.adoptCwd ?? cfg.workingDir);
+      if (source) {
+        codexBridgePendingSessionId = undefined;
+        mtrBridgeAttach(source, 'split-live');
+      } else {
+        codexBridgeStartTimer();
+      }
     }
 
     // Idle detection. In bridge mode we use the adopted CLI's real
@@ -2695,7 +2787,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     // minimal output-quiescence-only detector.
     const idleAdapter = cfg.bridgeJsonlPath
       ? createCliAdapterSync('claude-code', undefined)
-      : cfg.cliId === 'codex' || cfg.cliId === 'coco'
+      : cfg.cliId === 'codex' || cfg.cliId === 'coco' || cfg.cliId === 'mtr'
         ? createCliAdapterSync(cfg.cliId, undefined)
         : ({ completionPattern: undefined, readyPattern: undefined } as any);
     idleDetector = new IdleDetector(idleAdapter);
@@ -2710,6 +2802,8 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     // this failure mode and we don't want to risk regressing them.
     if (cfg.cliId === 'codex') {
       cliAdapter = createCliAdapterSync('codex', cfg.cliPathOverride);
+    } else if (cfg.cliId === 'mtr') {
+      cliAdapter = createCliAdapterSync('mtr', cfg.cliPathOverride);
     }
     idleDetector.onIdle(() => {
       log('Prompt detected (idle) — adopt mode');
@@ -2885,8 +2979,8 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   // calling `botmux send`, harvest the final answer from the CLI transcript
   // and post it to Lark. Codex needs late attach because its rollout id is
   // discovered after the first submit; CoCo's events path is deterministic
-  // from botmux sessionId. Hermes uses a global SQLite store, so baseline its
-  // row id at spawn and poll for rows after each queued prompt is flushed.
+  // from botmux sessionId. Hermes and MTR use SQLite stores, so baseline the
+  // relevant cursor at spawn and poll for rows after each queued prompt flushes.
   if (cfg.cliId === 'hermes') {
     hermesBridgeAttach(cfg.resume ? 'baseline-existing' : 'fresh-empty');
   } else if (cfg.cliId === 'codex') {
@@ -2905,6 +2999,15 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     const eventsPath = cocoEventsPathForSession(cfg.sessionId);
     codexBridgeAttach(eventsPath, cfg.resume ? 'baseline-existing' : 'fresh-empty');
     codexBridgeStartTimer();
+  } else if (cfg.cliId === 'mtr') {
+    const mtrSessionId = cfg.cliSessionId ?? mtrSessionIdForBotmuxSession(cfg.sessionId);
+    codexBridgePendingSessionId = mtrSessionId;
+    const source = findMtrSessionById(mtrSessionId);
+    if (source) {
+      mtrBridgeAttach(source, cfg.resume ? 'baseline-existing' : 'fresh-empty');
+    } else {
+      codexBridgeStartTimer();
+    }
   }
 
   // Set up idle detection

--- a/test/mtr-transcript.test.ts
+++ b/test/mtr-transcript.test.ts
@@ -1,0 +1,132 @@
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    readdirSync: vi.fn(),
+    statSync: vi.fn(),
+  };
+});
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return {
+    ...actual,
+    spawnSync: vi.fn(),
+  };
+});
+
+const existsSyncMock = vi.mocked(existsSync);
+const readdirSyncMock = vi.mocked(readdirSync);
+const statSyncMock = vi.mocked(statSync);
+const spawnSyncMock = vi.mocked(spawnSync);
+
+describe('mtr transcript reader', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    existsSyncMock.mockReset();
+    readdirSyncMock.mockReset();
+    statSyncMock.mockReset();
+    spawnSyncMock.mockReset();
+  });
+
+  it('returns empty events when the db is missing', async () => {
+    existsSyncMock.mockReturnValue(false);
+    const { drainMtrSession, currentMtrSessionOffset } = await import('../src/services/mtr-transcript.js');
+    const source = { dbPath: '/tmp/mtr-alpha.db', sessionId: 'ses_abc' };
+
+    expect(drainMtrSession(source, 9)).toEqual({ events: [], newOffset: 9 });
+    expect(currentMtrSessionOffset(source)).toBe(0);
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('converts completed MTR messages into bridge events', async () => {
+    existsSyncMock.mockReturnValue(true);
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      stderr: '',
+      stdout: JSON.stringify([
+        {
+          message_id: 'msg_user',
+          session_id: 'ses_1',
+          message_time_created: 1000,
+          message_time_updated: 1001,
+          message_data: JSON.stringify({ role: 'user', time: { created: 1000 } }),
+          part_id: 'part_user',
+          part_time_updated: 1002,
+          part_data: JSON.stringify({ type: 'text', text: 'hello' }),
+        },
+        {
+          message_id: 'msg_tool',
+          session_id: 'ses_1',
+          message_time_created: 1100,
+          message_time_updated: 1200,
+          message_data: JSON.stringify({ role: 'assistant', finish: 'tool-calls', time: { created: 1100, completed: 1200 } }),
+          part_id: 'part_tool_text',
+          part_time_updated: 1190,
+          part_data: JSON.stringify({ type: 'text', text: 'thinking' }),
+        },
+        {
+          message_id: 'msg_assistant',
+          session_id: 'ses_1',
+          message_time_created: 1300,
+          message_time_updated: 1500,
+          message_data: JSON.stringify({ role: 'assistant', finish: 'stop', time: { created: 1300, completed: 1500 } }),
+          part_id: 'part_step',
+          part_time_updated: 1400,
+          part_data: JSON.stringify({ type: 'step-start' }),
+        },
+        {
+          message_id: 'msg_assistant',
+          session_id: 'ses_1',
+          message_time_created: 1300,
+          message_time_updated: 1500,
+          message_data: JSON.stringify({ role: 'assistant', finish: 'stop', time: { created: 1300, completed: 1500 } }),
+          part_id: 'part_text',
+          part_time_updated: 1490,
+          part_data: JSON.stringify({ type: 'text', text: 'hi there' }),
+        },
+      ]),
+    } as any);
+    const { drainMtrSession } = await import('../src/services/mtr-transcript.js');
+
+    expect(drainMtrSession({ dbPath: '/tmp/mtr-alpha.db', sessionId: 'ses_1' }, 999)).toEqual({
+      newOffset: 1500,
+      events: [
+        {
+          uuid: 'mtr:/tmp/mtr-alpha.db:msg_user',
+          timestampMs: 1000,
+          kind: 'user',
+          text: 'hello',
+          sourceSessionId: 'ses_1',
+        },
+        {
+          uuid: 'mtr:/tmp/mtr-alpha.db:msg_assistant',
+          timestampMs: 1500,
+          kind: 'assistant_final',
+          text: 'hi there',
+          sourceSessionId: 'ses_1',
+        },
+      ],
+    });
+  });
+
+  it('finds the newest MTR db session for a directory', async () => {
+    existsSyncMock.mockReturnValue(true);
+    readdirSyncMock.mockReturnValue(['mtr.db', 'mtr-alpha.db', 'mtr-alpha.db-wal'] as any);
+    statSyncMock.mockReturnValue({ isFile: () => true } as any);
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, stdout: JSON.stringify({ id: 'ses_old', time_updated: 10 }), stderr: '' } as any)
+      .mockReturnValueOnce({ status: 0, stdout: JSON.stringify({ id: 'ses_new', time_updated: 20 }), stderr: '' } as any);
+    const { findLatestMtrSessionByDirectory } = await import('../src/services/mtr-transcript.js');
+
+    expect(findLatestMtrSessionByDirectory('/repo', ['/tmp/mtr.db', '/tmp/mtr-alpha.db'])).toEqual({
+      dbPath: '/tmp/mtr-alpha.db',
+      sessionId: 'ses_new',
+    });
+  });
+});

--- a/test/mtr-transcript.test.ts
+++ b/test/mtr-transcript.test.ts
@@ -115,6 +115,20 @@ describe('mtr transcript reader', () => {
     });
   });
 
+  it('re-reads a small timestamp overlap to avoid same-ms cursor misses', async () => {
+    existsSyncMock.mockReturnValue(true);
+    spawnSyncMock.mockReturnValue({ status: 0, stderr: '', stdout: '[]' } as any);
+    const { drainMtrSession } = await import('../src/services/mtr-transcript.js');
+
+    expect(drainMtrSession({ dbPath: '/tmp/mtr-alpha.db', sessionId: 'ses_1' }, 10_000)).toEqual({
+      events: [],
+      newOffset: 10_000,
+    });
+
+    const script = spawnSyncMock.mock.calls[0]![1]![1] as string;
+    expect(script).toContain('("ses_1", 5000, 5000)');
+  });
+
   it('finds the newest MTR db session for a directory', async () => {
     existsSyncMock.mockReturnValue(true);
     readdirSyncMock.mockReturnValue(['mtr.db', 'mtr-alpha.db', 'mtr-alpha.db-wal'] as any);


### PR DESCRIPTION
## Summary
- restore a basic MTR SQLite transcript reader for bridge fallback replies
- enable MTR adopted workers to tail the transcript and forward final output to Lark
- add focused transcript reader coverage

## Validation
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/vitest run test/mtr-transcript.test.ts test/session-discovery.test.ts test/cli-adapters.test.ts