### PR TITLE
fix(lark): /grant 通知按话题归属决定是否线程化回复

### DIFF
--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -7,7 +7,7 @@ import { execSync } from 'node:child_process';
 import { config } from '../../config.js';
 import { getBot, getAllBots, getOwnerOpenId } from '../../bot-registry.js';
 import { canOperate } from './event-dispatcher.js';
-import { sendUserMessage, updateMessage, deleteMessage, replyMessage, sendMessage, sendEphemeralCard } from './client.js';
+import { sendUserMessage, updateMessage, deleteMessage, replyMessage, sendMessage, sendEphemeralCard, getMessageDetail } from './client.js';
 import { buildSessionCard, buildStreamingCard, buildTuiPromptCard, buildTuiPromptProcessingCard, buildTuiPromptResolvedCard, buildSessionClosedCard, buildGrantResultCard, buildGrantNotifyCard, getCliDisplayName, truncateContent } from './card-builder.js';
 import { addChatGrant, addGlobalGrant } from '../../services/grant-store.js';
 import { checkNonce, clearPending, markDenied } from './grant-pending.js';
@@ -176,8 +176,22 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     // 这两步失败不回滚授权（已落库），仅记日志，并兜底用 in-place patch 让 owner 看到结果。
     if (cardMessageId) {
       // 通知是 best-effort（@被授权人）；失败不影响主流程，只记日志。
+      //
+      // reply_in_thread 只在「卡片本身已处于话题里」时才开：
+      //   - 话题群 / 普通群内话题 → 卡片有 thread_id → 线程化回复，落进原话题；
+      //   - 普通群顶层消息       → 卡片无 thread_id → reply_in_thread 会凭空开一个
+      //                            新话题（用户不想要），改为普通回复直接落到群里。
+      // thread_id 是「是否真的在话题里」的权威信号（见 event-dispatcher.decideRouting）。
+      // 探测失败时退回线程化回复，保持话题群下的原有行为。
+      let replyInThread = true;
       try {
-        await replyMessage(larkAppId, cardMessageId, buildGrantNotifyCard(kind, target, loc), 'interactive', true);
+        const detail = await getMessageDetail(larkAppId, cardMessageId);
+        replyInThread = Boolean(detail?.items?.[0]?.thread_id);
+      } catch (err) {
+        logger.debug(`grant notify thread-mode probe failed, defaulting to thread reply: ${err}`);
+      }
+      try {
+        await replyMessage(larkAppId, cardMessageId, buildGrantNotifyCard(kind, target, loc), 'interactive', replyInThread);
       } catch (err) {
         logger.warn(`grant notify failed (grant still applied): ${err}`);
       }

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -186,7 +186,11 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       let replyInThread = true;
       try {
         const detail = await getMessageDetail(larkAppId, cardMessageId);
-        replyInThread = Boolean(detail?.items?.[0]?.thread_id);
+        const item = detail?.items?.[0];
+        // 拿不到 message item 视为探测失败（走 catch 退回 true），而不是误判成
+        // 「无 thread_id → 普通回复」——后者会在话题群里破坏原有的线程化行为。
+        if (!item) throw new Error('no message item in getMessageDetail response');
+        replyInThread = Boolean(item.thread_id);
       } catch (err) {
         logger.debug(`grant notify thread-mode probe failed, defaulting to thread reply: ${err}`);
       }

--- a/test/card-handler-grant.test.ts
+++ b/test/card-handler-grant.test.ts
@@ -14,9 +14,16 @@ vi.mock('@larksuiteoapi/node-sdk', () => {
 
 const replyMock = vi.fn(async () => 'om_notify');
 const deleteMock = vi.fn(async () => true);  // deleteMessage now returns boolean (success)
+// 默认：卡片处于话题里（有 thread_id）→ 线程化回复。单测可 mockResolvedValueOnce 改写。
+const getMessageDetailMock = vi.fn(async () => ({ items: [{ thread_id: 'omt_thread' }] }));
 vi.mock('../src/im/lark/client.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../src/im/lark/client.js')>();
-  return { ...actual, replyMessage: (...a: any[]) => replyMock(...a), deleteMessage: (...a: any[]) => deleteMock(...a) };
+  return {
+    ...actual,
+    replyMessage: (...a: any[]) => replyMock(...a),
+    deleteMessage: (...a: any[]) => deleteMock(...a),
+    getMessageDetail: (...a: any[]) => getMessageDetailMock(...a),
+  };
 });
 
 let configPath: string;
@@ -39,6 +46,7 @@ function action(a: string, extra: Record<string, any> = {}, openMsgId?: string) 
 
 beforeEach(() => {
   replyMock.mockClear(); deleteMock.mockClear(); deleteMock.mockImplementation(async () => true);
+  getMessageDetailMock.mockClear(); getMessageDetailMock.mockImplementation(async () => ({ items: [{ thread_id: 'omt_thread' }] }));
   const dir = mkdtempSync(join(tmpdir(), 'botmux-cardgrant-'));
   configPath = join(dir, 'bots.json');
   writeFileSync(configPath, JSON.stringify([{ larkAppId: 'h1', larkAppSecret: 's', cliId: 'claude-code', allowedUsers: ['ou_owner'] }], null, 2));
@@ -71,6 +79,31 @@ describe('card-handler grant actions', () => {
     expect(deleteMock).toHaveBeenCalledWith('h1', 'om_card');
     expect(registry.getBot('h1').config.chatGrants).toEqual({ oc_1: ['ou_g'] });
     expect(pending.checkNonce('h1', 'oc_1', 'ou_g', nonce)).toBe(false);
+  });
+
+  it('卡片在话题里（有 thread_id）→ 线程化回复（reply_in_thread=true）', async () => {
+    const { pending, handler } = await fresh();
+    getMessageDetailMock.mockResolvedValueOnce({ items: [{ thread_id: 'omt_topic' }] });
+    const nonce = pending.openPending('h1', 'oc_1', 'ou_g');
+    await handler.handleCardAction(action('grant_chat', { nonce }, 'om_card'), deps, 'h1');
+    expect(getMessageDetailMock).toHaveBeenCalledWith('h1', 'om_card');
+    expect(replyMock).toHaveBeenCalledWith('h1', 'om_card', expect.stringContaining('ou_g'), 'interactive', true);
+  });
+
+  it('普通群顶层消息（无 thread_id）→ 普通回复落到群里（reply_in_thread=false，不开新话题）', async () => {
+    const { pending, handler } = await fresh();
+    getMessageDetailMock.mockResolvedValueOnce({ items: [{}] });  // 无 thread_id
+    const nonce = pending.openPending('h1', 'oc_1', 'ou_g');
+    await handler.handleCardAction(action('grant_chat', { nonce }, 'om_card'), deps, 'h1');
+    expect(replyMock).toHaveBeenCalledWith('h1', 'om_card', expect.stringContaining('ou_g'), 'interactive', false);
+  });
+
+  it('thread_id 探测失败 → 退回线程化回复（reply_in_thread=true）', async () => {
+    const { pending, handler } = await fresh();
+    getMessageDetailMock.mockRejectedValueOnce(new Error('lark 500'));
+    const nonce = pending.openPending('h1', 'oc_1', 'ou_g');
+    await handler.handleCardAction(action('grant_chat', { nonce }, 'om_card'), deps, 'h1');
+    expect(replyMock).toHaveBeenCalledWith('h1', 'om_card', expect.stringContaining('ou_g'), 'interactive', true);
   });
 
   it('owner grant_chat WITHOUT card id → fallback in-place card patch, persists', async () => {

--- a/test/card-handler-grant.test.ts
+++ b/test/card-handler-grant.test.ts
@@ -98,9 +98,17 @@ describe('card-handler grant actions', () => {
     expect(replyMock).toHaveBeenCalledWith('h1', 'om_card', expect.stringContaining('ou_g'), 'interactive', false);
   });
 
-  it('thread_id 探测失败 → 退回线程化回复（reply_in_thread=true）', async () => {
+  it('thread_id 探测失败（API 抛错）→ 退回线程化回复（reply_in_thread=true）', async () => {
     const { pending, handler } = await fresh();
     getMessageDetailMock.mockRejectedValueOnce(new Error('lark 500'));
+    const nonce = pending.openPending('h1', 'oc_1', 'ou_g');
+    await handler.handleCardAction(action('grant_chat', { nonce }, 'om_card'), deps, 'h1');
+    expect(replyMock).toHaveBeenCalledWith('h1', 'om_card', expect.stringContaining('ou_g'), 'interactive', true);
+  });
+
+  it('detail.items 为空 → 视为探测失败，退回线程化回复（不误判成普通回复）', async () => {
+    const { pending, handler } = await fresh();
+    getMessageDetailMock.mockResolvedValueOnce({ items: [] });
     const nonce = pending.openPending('h1', 'oc_1', 'ou_g');
     await handler.handleCardAction(action('grant_chat', { nonce }, 'om_card'), deps, 'h1');
     expect(replyMock).toHaveBeenCalledWith('h1', 'om_card', expect.stringContaining('ou_g'), 'interactive', true);


### PR DESCRIPTION
## 背景
`/grant` 授权成功后给被授权人发的通知（「已获授权在本群使用我，发消息 @ 我即可」）此前固定 `reply_in_thread=true`。在**普通群**对一条顶层消息授权时，这会凭空开一个新话题——非预期。

## 改动
`src/im/lark/card-handler.ts` 授权成功通知段：发通知前先 `getMessageDetail(cardMessageId)` 探测卡片消息的 `thread_id`：
- 卡片已在话题里（话题群 / 普通群内话题，有 `thread_id`）→ `reply_in_thread=true`，落进原话题；
- 普通群顶层消息（无 `thread_id`）→ `reply_in_thread=false`，普通回复直接落到群里，不开新话题；
- 拿不到 message item / API 抛错 → 视为探测失败，退回 `reply_in_thread=true`，保持话题群原行为。

判据与 `event-dispatcher.decideRouting`「`thread_id` 才是是否真的在话题里的权威信号」一致。

## 测试
`test/card-handler-grant.test.ts` 新增 4 个用例（有 thread_id / 无 thread_id / API 探测失败 / items 为空），`card-handler-grant`+`event-dispatcher`+`grant-command` 共 91 个测试通过，`tsc --noEmit` 通过。

## Review
Codex 已 review：无阻塞；hardening 建议（items 为空视为探测失败而非误判普通回复）已采纳。
p2p 留作未来注记——当前 grant card 仅 group 场景，DM 走这套卡时再按 `decideRouting` 补 `chat_type` 判据。

🤖 Generated with [Claude Code](https://claude.com/claude-code)