### PR TITLE
feat(setup): automate Feishu Open Platform setup

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@
  *
  * Usage:
  *   botmux setup          — interactive first-time configuration
+ *   botmux setup --no-open-platform-auto — skip Feishu Open Platform automation
  *   botmux start          — start daemon (pm2)
  *   botmux stop           — stop daemon
  *   botmux restart        — restart daemon (auto-restores sessions)
@@ -286,7 +287,22 @@ function hasConfig(): boolean {
 }
 
 function ask(rl: ReturnType<typeof createInterface>, question: string): Promise<string> {
-  return new Promise(resolve => rl.question(question, resolve));
+  return new Promise((resolve, reject) => {
+    const onError = (err: NodeJS.ErrnoException) => {
+      rl.off("error", onError);
+      if (err?.code === "EIO") {
+        console.warn("\nWarning: interactive input stream closed (EIO); continuing with empty input.");
+        resolve("");
+        return;
+      }
+      reject(err);
+    };
+    rl.once("error", onError);
+    rl.question(question, answer => {
+      rl.off("error", onError);
+      resolve(answer);
+    });
+  });
 }
 
 // ─── Setup helpers ──────────────────────────────────────────────────────────
@@ -457,6 +473,36 @@ function printRemainingSteps(appId: string, brand: 'feishu' | 'lark'): void {
 
   console.log('  完成后 `botmux start` (或 `botmux restart`)，启动检查不会卡住，');
   console.log('  缺权限只 WARN，去开放平台补齐后 daemon 自动恢复。\n');
+}
+
+async function finishOpenPlatformSetup(appId: string, brand: 'feishu' | 'lark', visibleMemberIds: string[] = []): Promise<void> {
+  const { parseSetupOpenPlatformAutoFlag, automateOpenPlatformSetup } = await import('./setup/open-platform-automation.js');
+  if (!parseSetupOpenPlatformAutoFlag(process.argv.slice(3))) {
+    console.log('\n已跳过开放平台自动配置 (--no-open-platform-auto)。');
+    printRemainingSteps(appId, brand);
+    return;
+  }
+
+  console.log('\n── 开放平台自动配置 ──\n');
+  console.log('将使用 botmux 内置 Feishu Web QR 登录获取/复用 Web session，自动导入权限、配置 redirect URL 并创建/发布版本。');
+  console.log('如失败会自动回退到手动步骤提示，不影响已写入的 botmux 配置。\n');
+
+  const result = await automateOpenPlatformSetup({ appId, brand, visibleMemberIds });
+  if (result.ok) {
+    console.log('✅ 开放平台自动配置完成');
+    console.log(`   Session 来源: ${result.sessionSource}`);
+    console.log(`   已导入权限数: ${result.scopeCount}`);
+    console.log(`   已配置 redirect URL: http://127.0.0.1:9768/callback`);
+    if (result.versionId) console.log(`   已提交发布版本: ${result.versionId}`);
+    else console.log('   已创建版本；未从响应中解析到 versionId，请到开放平台确认是否需要手动发布。');
+    console.log('');
+    return;
+  }
+
+  console.log(`⚠️  开放平台自动配置失败 (${result.reason}): ${result.message}`);
+  if (result.sessionFile) console.log(`   botmux session 文件: ${result.sessionFile}`);
+  console.log('   请按下面的手动步骤继续完成开放平台配置。');
+  printRemainingSteps(appId, brand);
 }
 
 /**
@@ -800,7 +846,7 @@ async function writeSingleBotConfig(): Promise<boolean> {
 
   writeBotsJsonAtomic([bot]);
   console.log(`\n✅ 配置已写入: ${BOTS_JSON_FILE}`);
-  printRemainingSteps(bot.larkAppId, botBrand(bot));
+  await finishOpenPlatformSetup(bot.larkAppId, botBrand(bot), bot.allowedUsers ?? []);
   console.log(`下一步:`);
   console.log(`  1. botmux start              启动 daemon`);
   console.log(`  2. botmux autostart enable   注册开机自启（推荐：${process.platform === 'darwin' ? 'mac launchd' : process.platform === 'linux' ? 'linux user systemd' : '当前平台暂不支持'}，无需 sudo）`);
@@ -844,7 +890,7 @@ async function cmdSetup(): Promise<void> {
       console.log(`旧配置已备份: ${BOTS_JSON_FILE}.bak`);
       writeBotsJsonAtomic([newBot]);
       console.log(`✅ 配置已写入: ${BOTS_JSON_FILE}`);
-      printRemainingSteps(newBot.larkAppId, botBrand(newBot));
+      await finishOpenPlatformSetup(newBot.larkAppId, botBrand(newBot), newBot.allowedUsers ?? []);
       console.log(`下一步: botmux restart\n`);
       return;
     }
@@ -902,7 +948,7 @@ async function cmdSetup(): Promise<void> {
       // appId 切换 = 换了一个飞书应用, 新 appId 大概率需要重新申请权限 + 配重定向 URL.
       // 把 printRemainingSteps 的深链端给用户, 比 README 警告里那句"历史数据不迁移"更可操作.
       if (appIdChanged) {
-        printRemainingSteps(edited.larkAppId, botBrand(edited));
+        await finishOpenPlatformSetup(edited.larkAppId, botBrand(edited), edited.allowedUsers ?? []);
       }
       console.log(`下一步: botmux restart\n`);
       return;
@@ -945,7 +991,7 @@ async function cmdSetup(): Promise<void> {
     writeBotsJsonAtomic([...bots, newBot]);
     console.log(`\n✅ 已添加机器人 ${newBot.larkAppId}，共 ${bots.length + 1} 个`);
     console.log(`   配置文件: ${BOTS_JSON_FILE}`);
-    printRemainingSteps(newBot.larkAppId, botBrand(newBot));
+    await finishOpenPlatformSetup(newBot.larkAppId, botBrand(newBot), newBot.allowedUsers ?? []);
     console.log(`下一步: botmux restart\n`);
 
   } else if (hasEnv) {
@@ -987,7 +1033,7 @@ async function cmdSetup(): Promise<void> {
     console.log(`\n✅ 已迁移到多机器人配置`);
     console.log(`   配置文件: ${BOTS_JSON_FILE}`);
     console.log(`   旧配置已备份: ${ENV_FILE}.bak`);
-    printRemainingSteps(newBot.larkAppId, botBrand(newBot));
+    await finishOpenPlatformSetup(newBot.larkAppId, botBrand(newBot), newBot.allowedUsers ?? []);
     console.log(`下一步: botmux restart\n`);
 
   } else {
@@ -2182,6 +2228,7 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
 
 命令:
   setup       交互式配置（首次使用 / 添加机器人）
+              默认使用 botmux 内置 Feishu Web QR 登录尝试自动导入权限/redirect/发布版本；可加 --no-open-platform-auto 跳过
   start       启动 daemon
   stop        停止 daemon
   restart     重启 daemon（自动恢复活跃会话）

--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -1,0 +1,954 @@
+/**
+ * Automates the Open Platform half of `botmux setup` after the PersonalAgent
+ * app has been created by the Feishu SDK registerApp flow.
+ *
+ * Follow-up for PR review: the current end-to-end setup can still ask for two
+ * QR scans: one for SDK app creation and one for this Web session. These can be
+ * collapsed in a later iteration by making the Feishu Web session the primary
+ * path for app creation as well: Web QR login -> create/find app -> read
+ * AppID/AppSecret -> write bots.json -> configure scopes/redirect/version.
+ * With a cached ~/.botmux/feishu-session.json, that path can create another bot
+ * with no QR scan at all. Keep the current SDK creation path as the stable
+ * fallback until that flow is fully verified.
+ */
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
+import { basename, join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import qrcode from 'qrcode-terminal';
+
+export const BOTMUX_REDIRECT_URL = 'http://127.0.0.1:9768/callback';
+const FEISHU_ACCOUNTS_ORIGIN = 'https://accounts.feishu.cn';
+const ASK_FEISHU_ORIGIN = 'https://ask.feishu.cn';
+const FEISHU_APP_ID = '12';
+const FEISHU_COMMON_HEADERS = {
+  'x-api-version': '1.0.28',
+  'x-device-info':
+    'device_id=0;device_name=Chrome;device_os=Mac;device_model=Chrome;lark_version=;channel=Release;package_name=feishu;tt_app_id=1658;is_dpop_support=true;is_iframe=false',
+  'x-locale': 'zh-CN',
+  'x-terminal-type': '2',
+};
+
+export interface StoredCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  secure: boolean;
+  httpOnly: boolean;
+  hostOnly: boolean;
+  expiresAt?: number;
+  sameSite?: string;
+}
+
+export interface ScopeManifest {
+  scopes?: {
+    tenant?: string[];
+    user?: string[];
+  };
+}
+
+export interface OpenPlatformScopeEntry {
+  id: string;
+  name: string;
+  bucket?: 'tenant' | 'user';
+}
+
+export interface MappedScopeIds {
+  tenantScopeIds: string[];
+  userScopeIds: string[];
+  missingTenantScopes: string[];
+  missingUserScopes: string[];
+}
+
+export type OpenPlatformAutomationResult =
+  | {
+      ok: true;
+      sessionFile: string;
+      sessionSource: FeishuWebSessionSource;
+      cookieCount: number;
+      scopeCount: number;
+      versionId?: string;
+    }
+  | {
+      ok: false;
+      reason:
+        | 'unsupported_brand'
+        | 'missing_session'
+        | 'invalid_session'
+        | 'login_failed'
+        | 'qr_expired'
+        | 'timeout'
+        | 'missing_csrf'
+        | 'scope_mapping_failed'
+        | 'network'
+        | 'api_error';
+      message: string;
+      sessionFile?: string;
+    };
+
+export interface OpenPlatformAutomationOptions {
+  appId: string;
+  brand?: 'feishu' | 'lark';
+  sessionFilePath?: string;
+  bytedcliFallbackSessionFilePath?: string;
+  disableBytedcliFallback?: boolean;
+  fetchImpl?: typeof fetch;
+  scopeManifest?: ScopeManifest;
+  pollIntervalMs?: number;
+  maxWaitMs?: number;
+  onQrCode?: (info: { qrText: string; qrPayload: string }) => void | Promise<void>;
+  onStatus?: (message: string) => void | Promise<void>;
+  visibleMemberIds?: string[];
+}
+
+
+export type FeishuWebSessionSource = 'botmux_cache' | 'qr_login' | 'bytedcli_fallback';
+export type FeishuWebSessionFailureReason = 'login_failed' | 'qr_expired' | 'timeout' | 'network' | 'invalid_session';
+
+export type FeishuWebSessionPrepareResult =
+  | {
+      ok: true;
+      sessionFile: string;
+      source: FeishuWebSessionSource;
+      cookies: StoredCookie[];
+      cookieCount: number;
+    }
+  | {
+      ok: false;
+      reason: FeishuWebSessionFailureReason;
+      message: string;
+      sessionFile: string;
+      fallbackSessionFile?: string;
+    };
+
+export interface FeishuWebSessionOptions {
+  sessionFilePath?: string;
+  bytedcliFallbackSessionFilePath?: string;
+  disableBytedcliFallback?: boolean;
+  fetchImpl?: typeof fetch;
+  pollIntervalMs?: number;
+  maxWaitMs?: number;
+  onQrCode?: (info: { qrText: string; qrPayload: string }) => void | Promise<void>;
+  onStatus?: (message: string) => void | Promise<void>;
+  visibleMemberIds?: string[];
+}
+
+
+export function parseSetupOpenPlatformAutoFlag(argv: string[]): boolean {
+  let enabled = true;
+  for (const arg of argv) {
+    if (arg === '--open-platform-auto') enabled = true;
+    if (arg === '--no-open-platform-auto') enabled = false;
+  }
+  return enabled;
+}
+
+export function botmuxFeishuSessionFilePath(configDir = join(homedir(), '.botmux')): string {
+  return join(configDir, 'feishu-session.json');
+}
+
+export function bytedcliFeishuSessionFilePath(homeDir = homedir()): string {
+  return join(homeDir, '.local', 'share', 'bytedcli', 'data', 'feishu_session.json');
+}
+
+export function readStoredCookiesFromSessionFile(filePath: string): StoredCookie[] | null {
+  if (!existsSync(filePath)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const cookies = (parsed as { cookies?: unknown }).cookies;
+  if (!Array.isArray(cookies)) return null;
+  return pruneExpiredCookies(cookies.filter(isStoredCookieRecord));
+}
+
+export function readStoredCookiesFromBytedcliSession(filePath: string): StoredCookie[] | null {
+  return readStoredCookiesFromSessionFile(filePath);
+}
+
+export function writeStoredCookiesToSessionFile(filePath: string, cookies: StoredCookie[]): void {
+  const dir = dirname(filePath);
+  mkdirSync(dir, { recursive: true });
+  try {
+    chmodSync(dir, 0o700);
+  } catch {
+    // Best-effort on non-POSIX filesystems.
+  }
+  const tmpPath = join(dir, `.${basename(filePath)}.${process.pid}.${Date.now()}.tmp`);
+  try {
+    writeFileSync(tmpPath, JSON.stringify({ cookies: pruneExpiredCookies(cookies) }, null, 2), {
+      encoding: 'utf-8',
+      mode: 0o600,
+    });
+    renameSync(tmpPath, filePath);
+  } finally {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // Ignore.
+    }
+  }
+  try {
+    chmodSync(filePath, 0o600);
+  } catch {
+    // Best-effort on non-POSIX filesystems.
+  }
+}
+
+export function getCookieHeader(cookies: StoredCookie[], requestUrl: string): string {
+  const url = new URL(requestUrl);
+  return pruneExpiredCookies(cookies)
+    .filter(cookie => {
+      if (cookie.secure && url.protocol !== 'https:') return false;
+      if (!domainMatches(url.hostname, cookie)) return false;
+      return pathMatches(url.pathname || '/', cookie.path || '/');
+    })
+    .sort((a, b) => b.path.length - a.path.length)
+    .map(cookie => `${cookie.name}=${cookie.value}`)
+    .join('; ');
+}
+
+export function extractOpenPlatformCsrfToken(html: string): string | null {
+  const match =
+    html.match(/\bwindow\.csrfToken\s*=\s*(['"])([^'"]+)\1/) ??
+    html.match(/\bcsrfToken\s*:\s*(['"])([^'"]+)\1/);
+  return match?.[2] ?? null;
+}
+
+export function extractOpenPlatformScopeEntries(payload: unknown): OpenPlatformScopeEntry[] {
+  const out: OpenPlatformScopeEntry[] = [];
+  collectScopeEntries(payload, undefined, out);
+  const seen = new Set<string>();
+  return out.filter(entry => {
+    const key = `${entry.bucket ?? 'any'}:${entry.name}:${entry.id}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function mapManifestScopesToOpenPlatformIds(
+  manifest: ScopeManifest,
+  catalog: OpenPlatformScopeEntry[],
+): MappedScopeIds {
+  const tenant = uniqueStrings(manifest.scopes?.tenant ?? []);
+  const user = uniqueStrings(manifest.scopes?.user ?? []);
+  return {
+    tenantScopeIds: mapScopeIds(tenant, catalog, 'tenant').ids,
+    userScopeIds: mapScopeIds(user, catalog, 'user').ids,
+    missingTenantScopes: mapScopeIds(tenant, catalog, 'tenant').missing,
+    missingUserScopes: mapScopeIds(user, catalog, 'user').missing,
+  };
+}
+
+export function buildScopeUpdatePayload(appId: string, mapped: Pick<MappedScopeIds, 'tenantScopeIds' | 'userScopeIds'>) {
+  return {
+    clientId: appId,
+    appScopeIDs: mapped.tenantScopeIds,
+    userScopeIDs: mapped.userScopeIds,
+    scopeIds: [],
+    operation: 'add',
+    isDeveloperPanel: true,
+  };
+}
+
+export function buildSafeSettingPayload(appId: string) {
+  return {
+    clientId: appId,
+    redirectURL: [BOTMUX_REDIRECT_URL],
+  };
+}
+
+export function buildAppVersionCreatePayload(appVersion: string, visibleMemberIds: string[] = []) {
+  return {
+    appVersion,
+    mobileDefaultAbility: 'bot',
+    pcDefaultAbility: 'bot',
+    changeLog: 'Init version',
+    visibleSuggest: {
+      departments: [],
+      members: visibleMemberIds,
+      groups: [],
+      isAll: 0,
+    },
+    applyReasonConfig: {
+      apiPrivilegeNeedReason: true,
+      contactPrivilegeNeedReason: true,
+      dataPrivilegeReasonMap: {},
+      visibleScopeNeedReason: true,
+      apiPrivilegeReasonMap: {},
+      contactPrivilegeReason: '',
+      isDataPrivilegeExpandMap: {},
+      visibleScopeReason: '',
+      dataPrivilegeNeedReason: true,
+      isAutoAudit: false,
+      isContactExpand: false,
+    },
+    b2cShareSuggest: false,
+    autoPublish: false,
+    remark: 'Personal AI assistant for self use',
+    blackVisibleSuggest: {
+      departments: [],
+      members: [],
+      groups: [],
+      isAll: 0,
+    },
+  };
+}
+
+export function buildFeishuQrPayload(token: string): string {
+  return JSON.stringify({ qrlogin: { token } });
+}
+
+export function mapFeishuQrPollingStatus(status: number | null): string {
+  if (status === 2) return '已经扫码，等待手机确认';
+  if (status === 5) return '二维码已过期';
+  return '等待飞书扫码';
+}
+
+export async function prepareFeishuWebSession(
+  options: FeishuWebSessionOptions = {},
+): Promise<FeishuWebSessionPrepareResult> {
+  const fetcher = options.fetchImpl ?? fetch;
+  const sessionFile = options.sessionFilePath ?? botmuxFeishuSessionFilePath();
+  const cached = readStoredCookiesFromSessionFile(sessionFile);
+  if (cached && cached.length > 0 && await validateFeishuWebSession(cached, fetcher)) {
+    return {
+      ok: true,
+      sessionFile,
+      source: 'botmux_cache',
+      cookies: cached,
+      cookieCount: cached.length,
+    };
+  }
+
+  let loginError: unknown;
+  try {
+    const loggedIn = await loginFeishuWebSession(fetcher, options);
+    writeStoredCookiesToSessionFile(sessionFile, loggedIn);
+    return {
+      ok: true,
+      sessionFile,
+      source: 'qr_login',
+      cookies: loggedIn,
+      cookieCount: loggedIn.length,
+    };
+  } catch (err) {
+    loginError = err;
+  }
+
+  const fallbackSessionFile = options.bytedcliFallbackSessionFilePath ?? bytedcliFeishuSessionFilePath();
+  if (!options.disableBytedcliFallback) {
+    const fallback = readStoredCookiesFromBytedcliSession(fallbackSessionFile);
+    if (fallback && fallback.length > 0 && await validateFeishuWebSession(fallback, fetcher)) {
+      writeStoredCookiesToSessionFile(sessionFile, fallback);
+      return {
+        ok: true,
+        sessionFile,
+        source: 'bytedcli_fallback',
+        cookies: fallback,
+        cookieCount: fallback.length,
+      };
+    }
+  }
+
+  return {
+    ok: false,
+    reason: classifyFeishuLoginError(loginError),
+    message: safeErrorMessage(loginError),
+    sessionFile,
+    fallbackSessionFile: options.disableBytedcliFallback ? undefined : fallbackSessionFile,
+  };
+}
+
+export async function automateOpenPlatformSetup(
+  options: OpenPlatformAutomationOptions,
+): Promise<OpenPlatformAutomationResult> {
+  const brand = options.brand ?? 'feishu';
+  if (brand !== 'feishu') {
+    return { ok: false, reason: 'unsupported_brand', message: '开放平台自动配置当前只支持 feishu.cn 租户' };
+  }
+
+  const fetcher = options.fetchImpl ?? fetch;
+  const preparedSession = await prepareFeishuWebSession({
+    sessionFilePath: options.sessionFilePath,
+    bytedcliFallbackSessionFilePath: options.bytedcliFallbackSessionFilePath,
+    disableBytedcliFallback: options.disableBytedcliFallback,
+    fetchImpl: fetcher,
+    pollIntervalMs: options.pollIntervalMs,
+    maxWaitMs: options.maxWaitMs,
+    onQrCode: options.onQrCode,
+    onStatus: options.onStatus,
+  });
+  if (!preparedSession.ok) {
+    return {
+      ok: false,
+      reason: preparedSession.reason,
+      message: `获取 Feishu Web session 失败: ${preparedSession.message}`,
+      sessionFile: preparedSession.sessionFile,
+    };
+  }
+
+  const sessionFile = preparedSession.sessionFile;
+  const session = new MutableCookieJar(preparedSession.cookies);
+  const defaultOrigin = 'https://open.feishu.cn';
+  const defaultAppHome = `${defaultOrigin}/app/${options.appId}`;
+  // The botmux-managed Feishu Web login yields reusable cookies, not Open
+  // Platform's page-scoped `window.csrfToken`. Load an Open Platform page with
+  // those cookies and extract CSRF from HTML before calling `/developers/v1/*`.
+  // Feishu tenants can redirect the console to open.larkoffice.com; API origin,
+  // referer, CSRF token and cookies must stay on that final origin.
+  let csrfToken: string | null = null;
+  let apiOrigin = defaultOrigin;
+  let appHome = defaultAppHome;
+  try {
+    const authPage = await session.fetchTextWithUrl(fetcher, `${defaultAppHome}/auth`);
+    apiOrigin = new URL(authPage.finalUrl).origin;
+    appHome = `${apiOrigin}/app/${options.appId}`;
+    csrfToken = extractOpenPlatformCsrfToken(authPage.text);
+    if (!csrfToken) {
+      const homePage = await session.fetchTextWithUrl(fetcher, appHome);
+      apiOrigin = new URL(homePage.finalUrl).origin;
+      appHome = `${apiOrigin}/app/${options.appId}`;
+      csrfToken = extractOpenPlatformCsrfToken(homePage.text);
+    }
+  } catch (err: any) {
+    return { ok: false, reason: 'network', message: `读取开放平台页面失败: ${safeErrorMessage(err)}`, sessionFile };
+  }
+  if (!csrfToken) {
+    return {
+      ok: false,
+      reason: 'missing_csrf',
+      message:
+        'Feishu session 可读取，但开放平台页面没有返回 window.csrfToken；可能需要在浏览器完成开放平台登录',
+      sessionFile,
+    };
+  }
+
+  const postJson = async (path: string, body?: unknown): Promise<unknown> => {
+    const url = `${apiOrigin}${path}`;
+    const response = await session.fetchRaw(fetcher, url, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json, text/plain, */*',
+        origin: apiOrigin,
+        referer: appHome,
+        'x-csrf-token': csrfToken!,
+        ...(body === undefined ? {} : { 'content-type': 'application/json' }),
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    let data: any;
+    try {
+      data = await response.json();
+    } catch {
+      data = null;
+    }
+    if (!response.ok) {
+      throw new OpenPlatformApiError(`HTTP ${response.status} ${path}: ${summarizeOpenPlatformPayload(data)}`, data);
+    }
+    if (data && typeof data === 'object' && typeof data.code === 'number' && data.code !== 0) {
+      throw new OpenPlatformApiError(`code=${data.code} msg=${data.msg ?? data.message ?? ''}`, data);
+    }
+    return data;
+  };
+
+  let allScopesPayload: unknown;
+  try {
+    allScopesPayload = await postJson(`/developers/v1/scope/all/${options.appId}`);
+  } catch (err: any) {
+    return { ok: false, reason: 'api_error', message: `读取开放平台 scope 列表失败: ${safeErrorMessage(err)}`, sessionFile };
+  }
+
+  const manifest = options.scopeManifest ?? readDefaultScopeManifest();
+  const catalog = extractOpenPlatformScopeEntries(allScopesPayload);
+  const mapped = mapManifestScopesToOpenPlatformIds(manifest, catalog);
+  const missing = [...mapped.missingTenantScopes, ...mapped.missingUserScopes];
+  if (missing.length > 0) {
+    console.warn(`Warning: ${missing.length} scopes are not present in the Open Platform catalog and will be skipped: ${missing.slice(0, 8).join(', ')}`);
+  }
+
+  try {
+    await postJson(`/developers/v1/scope/update/${options.appId}`, buildScopeUpdatePayload(options.appId, mapped));
+    await postJson(`/developers/v1/safe_setting/update/${options.appId}`, buildSafeSettingPayload(options.appId));
+    const contactRange = await postJson(`/developers/v1/contact_range/${options.appId}`, {});
+    const visibleMemberIds = extractContactRangeMemberIds(contactRange);
+    const versionList = await postJson(`/developers/v1/app_version/list/${options.appId}`, {});
+    const appVersion = nextAppVersion(versionList);
+    const created = await postJson(`/developers/v1/app_version/create/${options.appId}`, buildAppVersionCreatePayload(appVersion, visibleMemberIds));
+    const versionId = extractVersionId(created);
+    if (versionId) {
+      await postJson(`/developers/v1/publish/commit/${options.appId}/${versionId}`, { clientId: options.appId });
+    }
+    return {
+      ok: true,
+      sessionFile,
+      sessionSource: preparedSession.source,
+      cookieCount: preparedSession.cookieCount,
+      scopeCount: mapped.tenantScopeIds.length + mapped.userScopeIds.length,
+      versionId,
+    };
+  } catch (err: any) {
+    return { ok: false, reason: 'api_error', message: `开放平台自动配置失败: ${safeErrorMessage(err)}`, sessionFile };
+  }
+}
+
+async function validateFeishuWebSession(cookies: StoredCookie[], fetcher: typeof fetch): Promise<boolean> {
+  if (cookies.length === 0) return false;
+  const session = new MutableCookieJar(cookies);
+  try {
+    const response = await session.fetchRaw(fetcher, `${ASK_FEISHU_ORIGIN}/`, { method: 'GET' });
+    if (!response.ok) return false;
+    const text = await response.text();
+    return !isFeishuLoginLikeValue(text);
+  } catch {
+    return false;
+  }
+}
+
+async function loginFeishuWebSession(fetcher: typeof fetch, options: FeishuWebSessionOptions): Promise<StoredCookie[]> {
+  const session = new MutableCookieJar([]);
+  const redirectUrl = `${ASK_FEISHU_ORIGIN}/`;
+  // Implements Feishu Web QR session login directly: initialize
+  // `/accounts/qrlogin/init`, poll `/accounts/qrlogin/polling`, follow the
+  // returned cross-login URI, then persist the resulting cookie jar privately.
+  const qrInit = await initFeishuQrLogin(session, fetcher, redirectUrl);
+  const qrPayload = buildFeishuQrPayload(qrInit.token);
+  const qrText = await renderTerminalQr(qrPayload);
+  const onQrCode = options.onQrCode ?? defaultPrintFeishuQrCode;
+  await onQrCode({ qrText, qrPayload });
+
+  const pollIntervalMs = options.pollIntervalMs ?? 1500;
+  const maxWaitMs = options.maxWaitMs ?? 120_000;
+  const start = Date.now();
+  let lastStatusMessage = '';
+  for (;;) {
+    if (Date.now() - start > maxWaitMs) {
+      throw new FeishuWebSessionError('等待飞书扫码超时', 'timeout');
+    }
+
+    const poll = await pollFeishuQrLogin(session, fetcher, qrInit.flowKey);
+    if (poll.nextStep === 'enter_app') {
+      if (poll.crossLoginUri) {
+        await session.fetchRaw(fetcher, poll.crossLoginUri, { method: 'GET' });
+      }
+      await session.fetchRaw(fetcher, redirectUrl, { method: 'GET' });
+      const cookies = session.toJSON();
+      if (!await validateFeishuWebSession(cookies, fetcher)) {
+        throw new FeishuWebSessionError('飞书扫码已完成，但没有拿到可复用的 Web session', 'invalid_session');
+      }
+      return cookies;
+    }
+
+    const statusMessage = mapFeishuQrPollingStatus(poll.status);
+    if (options.onStatus && statusMessage !== lastStatusMessage) {
+      lastStatusMessage = statusMessage;
+      await options.onStatus(statusMessage);
+    }
+    if (poll.status === 5) {
+      throw new FeishuWebSessionError('二维码已过期', 'qr_expired');
+    }
+    await sleep(pollIntervalMs);
+  }
+}
+
+async function initFeishuQrLogin(
+  session: MutableCookieJar,
+  fetcher: typeof fetch,
+  authorizeUrl: string,
+): Promise<{ flowKey: string; token: string }> {
+  const endpoint = `${FEISHU_ACCOUNTS_ORIGIN}/accounts/qrlogin/init?_r${10000 + Math.floor(Math.random() * 80000)}=${Date.now()}`;
+  const response = await session.fetchRaw(fetcher, endpoint, {
+    method: 'POST',
+    headers: {
+      ...FEISHU_COMMON_HEADERS,
+      'x-app-id': FEISHU_APP_ID,
+      accept: 'application/json',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      biz_type: null,
+      redirect_uri: authorizeUrl,
+    }),
+  });
+  const data = await response.json();
+  assertFeishuApiOk(data, 'Feishu QR init failed');
+  const token = asRecord(asRecord(data).data).step_info
+    ? pickString(asRecord(asRecord(asRecord(data).data).step_info), ['token'])
+    : undefined;
+  const flowKey = response.headers.get('x-flow-key') ?? '';
+  if (!flowKey || !token) {
+    throw new FeishuWebSessionError('Feishu QR init missing flow key or token', 'login_failed');
+  }
+  return { flowKey, token };
+}
+
+async function pollFeishuQrLogin(
+  session: MutableCookieJar,
+  fetcher: typeof fetch,
+  flowKey: string,
+): Promise<{ nextStep: string | null; status: number | null; crossLoginUri: string | null }> {
+  const endpoint = `${FEISHU_ACCOUNTS_ORIGIN}/accounts/qrlogin/polling?_r${10000 + Math.floor(Math.random() * 80000)}=${Date.now()}`;
+  const response = await session.fetchRaw(fetcher, endpoint, {
+    method: 'POST',
+    headers: {
+      ...FEISHU_COMMON_HEADERS,
+      'x-app-id': FEISHU_APP_ID,
+      'x-flow-key': flowKey,
+      accept: 'application/json',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ biz_type: null }),
+  });
+  const data = await response.json();
+  assertFeishuApiOk(data, 'Feishu QR polling failed');
+  const payload = asRecord(asRecord(data).data);
+  const stepInfo = asRecord(payload.step_info);
+  return {
+    nextStep: pickString(payload, ['next_step']) ?? null,
+    status: typeof stepInfo.status === 'number' ? stepInfo.status : null,
+    crossLoginUri: pickString(stepInfo, ['cross_login_uri']) ?? null,
+  };
+}
+
+function readDefaultScopeManifest(): ScopeManifest {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(here, 'lark-scopes.json'),
+    join(here, 'setup', 'lark-scopes.json'),
+    join(here, '..', 'src', 'setup', 'lark-scopes.json'),
+  ];
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    return JSON.parse(readFileSync(candidate, 'utf-8')) as ScopeManifest;
+  }
+  throw new Error('找不到 botmux lark-scopes.json');
+}
+
+class MutableCookieJar {
+  private cookies: StoredCookie[];
+
+  constructor(cookies: StoredCookie[]) {
+    this.cookies = pruneExpiredCookies(cookies);
+  }
+
+  toJSON(): StoredCookie[] {
+    this.cookies = pruneExpiredCookies(this.cookies);
+    return this.cookies.map(cookie => ({ ...cookie }));
+  }
+
+  async fetchText(fetcher: typeof fetch, url: string): Promise<string> {
+    const response = await this.fetchRaw(fetcher, url, { method: 'GET' });
+    return await response.text();
+  }
+
+  async fetchTextWithUrl(fetcher: typeof fetch, url: string): Promise<{ text: string; finalUrl: string }> {
+    const response = await this.fetchRaw(fetcher, url, { method: 'GET' });
+    return {
+      text: await response.text(),
+      finalUrl: finalResponseUrl(response, url),
+    };
+  }
+
+  async fetchRaw(fetcher: typeof fetch, url: string, init: RequestInit = {}, maxHops = 10): Promise<Response> {
+    let current = url;
+    let referer: string | undefined;
+    for (let hop = 0; hop <= maxHops; hop += 1) {
+      const headers = new Headers(init.headers);
+      const cookieHeader = getCookieHeader(this.cookies, current);
+      if (cookieHeader) headers.set('cookie', cookieHeader);
+      headers.set('user-agent', headers.get('user-agent') ?? DEFAULT_BROWSER_USER_AGENT);
+      if (referer && !headers.has('referer')) headers.set('referer', referer);
+
+      const response = await fetcher(current, { ...init, headers, redirect: 'manual' });
+      this.loadFromResponse(current, response.headers);
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get('location');
+        if (!location) return response;
+        referer = current;
+        current = new URL(location, current).toString();
+        continue;
+      }
+      markFinalResponseUrl(response, current);
+      return response;
+    }
+    throw new Error('Too many redirects while accessing open platform');
+  }
+
+  private loadFromResponse(responseUrl: string, headers: Headers): void {
+    const rawSetCookies = typeof (headers as any).getSetCookie === 'function'
+      ? (headers as any).getSetCookie()
+      : splitSetCookieHeader(headers.get('set-cookie'));
+    for (const raw of rawSetCookies) {
+      const cookie = parseSetCookie(responseUrl, raw);
+      if (!cookie) continue;
+      const idx = this.cookies.findIndex(item => item.name === cookie.name && item.domain === cookie.domain && item.path === cookie.path);
+      if (cookie.expiresAt !== undefined && cookie.expiresAt <= Date.now()) {
+        if (idx >= 0) this.cookies.splice(idx, 1);
+        continue;
+      }
+      if (idx >= 0) this.cookies[idx] = cookie;
+      else this.cookies.push(cookie);
+    }
+    this.cookies = pruneExpiredCookies(this.cookies);
+  }
+}
+
+class OpenPlatformApiError extends Error {
+  constructor(message: string, readonly payload: unknown) {
+    super(message);
+  }
+}
+
+class FeishuWebSessionError extends Error {
+  constructor(message: string, readonly reason: FeishuWebSessionFailureReason) {
+    super(message);
+  }
+}
+
+const DEFAULT_BROWSER_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36';
+
+function defaultPrintFeishuQrCode(info: { qrText: string }): void {
+  process.stderr.write('\n请用飞书 App 扫码完成开放平台自动配置登录：\n\n');
+  process.stderr.write(`${info.qrText}\n`);
+  process.stderr.write('如果当前环境无法扫码，可重新运行 `botmux setup --no-open-platform-auto` 跳过自动配置。\n\n');
+}
+
+async function renderTerminalQr(payload: string): Promise<string> {
+  return await new Promise((resolve) => qrcode.generate(payload, { small: true }, qr => resolve(qr)));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function assertFeishuApiOk(payload: unknown, message: string): void {
+  const record = asRecord(payload);
+  if (record.code === 0) return;
+  const msg = pickString(record, ['message', 'msg']) ?? 'unknown error';
+  throw new FeishuWebSessionError(`${message}: ${msg}`, 'login_failed');
+}
+
+function isFeishuLoginLikeValue(value: string): boolean {
+  const normalized = value.toLowerCase();
+  return normalized.includes('/accounts/') || normalized.includes('/login') || normalized.includes('qrlogin');
+}
+
+function classifyFeishuLoginError(err: unknown): FeishuWebSessionFailureReason {
+  if (err instanceof FeishuWebSessionError) return err.reason;
+  const message = err instanceof Error ? err.message : String(err);
+  if (/timeout|timed out|超时/i.test(message)) return 'timeout';
+  if (/expired|过期/i.test(message)) return 'qr_expired';
+  if (/ETIMEDOUT|ECONNREFUSED|ENOTFOUND|ECONNRESET|fetch failed|network/i.test(message)) return 'network';
+  return 'login_failed';
+}
+
+function collectScopeEntries(value: unknown, bucket: 'tenant' | 'user' | undefined, out: OpenPlatformScopeEntry[]): void {
+  if (Array.isArray(value)) {
+    for (const item of value) collectScopeEntries(item, bucket, out);
+    return;
+  }
+  if (!value || typeof value !== 'object') return;
+  const record = value as Record<string, unknown>;
+  const name = pickString(record, ['scope_name', 'scopeName', 'name', 'key', 'scopeKey']);
+  const id = pickString(record, ['id', 'scope_id', 'scopeId', 'scopeID']);
+  if (name && id) out.push({ name, id, bucket });
+  for (const [key, child] of Object.entries(record)) {
+    const nextBucket = /user/i.test(key)
+      ? 'user'
+      : /app|client|tenant/i.test(key)
+        ? 'tenant'
+        : bucket;
+    if (child && typeof child === 'object') collectScopeEntries(child, nextBucket, out);
+  }
+}
+
+function mapScopeIds(scopeNames: string[], catalog: OpenPlatformScopeEntry[], bucket: 'tenant' | 'user') {
+  const ids: string[] = [];
+  const missing: string[] = [];
+  for (const scopeName of scopeNames) {
+    const matched =
+      catalog.find(entry => entry.name === scopeName && entry.bucket === bucket) ??
+      catalog.find(entry => entry.name === scopeName && entry.bucket === undefined) ??
+      catalog.find(entry => entry.name === scopeName);
+    if (matched) ids.push(matched.id);
+    else missing.push(scopeName);
+  }
+  return { ids: uniqueStrings(ids), missing };
+}
+
+function nextAppVersion(payload: unknown): string {
+  const data = asRecord(asRecord(payload).data);
+  const versions = Array.isArray(data.versions) ? data.versions : [];
+  const published = versions
+    .map(item => asRecord(item))
+    .filter(item => item.versionStatus === 2)
+    .map(item => pickString(item, ['appVersion']))
+    .filter((version): version is string => Boolean(version));
+  if (published.length === 0) return '0.0.1';
+  const latest = published[0];
+  const parts = latest.split('.').map(part => Number.parseInt(part, 10));
+  if (parts.length < 3 || parts.some(part => !Number.isFinite(part))) return '0.0.1';
+  parts[parts.length - 1] += 1;
+  return parts.join('.');
+}
+
+function extractContactRangeMemberIds(payload: unknown): string[] {
+  const data = asRecord(asRecord(payload).data);
+  const detail = asRecord(data.contactRangeDetail);
+  const members = Array.isArray(detail.members) ? detail.members : [];
+  return uniqueStrings(members
+    .map(item => pickString(asRecord(item), ['id']))
+    .filter((id): id is string => Boolean(id)));
+}
+
+function extractVersionId(payload: unknown): string | undefined {
+  const direct = pickString(asRecord(payload), ['versionId', 'version_id', 'id']);
+  if (direct) return direct;
+  const data = asRecord(asRecord(payload).data);
+  return pickString(data, ['versionId', 'version_id', 'id']) ?? pickString(asRecord(data.appVersion), ['versionId', 'version_id', 'id']);
+}
+
+function pickString(record: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value) return value;
+    if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  }
+  return undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function isStoredCookieRecord(value: unknown): value is StoredCookie {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const cookie = value as Partial<StoredCookie>;
+  return typeof cookie.name === 'string'
+    && typeof cookie.value === 'string'
+    && typeof cookie.domain === 'string'
+    && typeof cookie.path === 'string'
+    && typeof cookie.secure === 'boolean'
+    && typeof cookie.httpOnly === 'boolean'
+    && typeof cookie.hostOnly === 'boolean';
+}
+
+function pruneExpiredCookies(cookies: StoredCookie[]): StoredCookie[] {
+  const now = Date.now();
+  return cookies.filter(cookie => cookie.expiresAt === undefined || cookie.expiresAt > now);
+}
+
+function domainMatches(hostname: string, cookie: StoredCookie): boolean {
+  const host = hostname.toLowerCase();
+  const domain = cookie.domain.replace(/^\./, '').toLowerCase();
+  if (cookie.hostOnly) return host === domain;
+  return host === domain || host.endsWith(`.${domain}`);
+}
+
+function pathMatches(requestPath: string, cookiePath: string): boolean {
+  if (requestPath === cookiePath) return true;
+  if (!requestPath.startsWith(cookiePath)) return false;
+  return cookiePath.endsWith('/') || requestPath[cookiePath.length] === '/';
+}
+
+function splitSetCookieHeader(header: string | null): string[] {
+  if (!header) return [];
+  const parts: string[] = [];
+  let start = 0;
+  let inExpires = false;
+  for (let i = 0; i < header.length; i += 1) {
+    const slice = header.slice(Math.max(0, i - 8), i + 1).toLowerCase();
+    if (slice.endsWith('expires=')) inExpires = true;
+    if (inExpires && header[i] === ';') inExpires = false;
+    if (!inExpires && header[i] === ',') {
+      parts.push(header.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  parts.push(header.slice(start).trim());
+  return parts.filter(Boolean);
+}
+
+function parseSetCookie(responseUrl: string, header: string): StoredCookie | null {
+  const url = new URL(responseUrl);
+  const parts = header.split(';').map(part => part.trim()).filter(Boolean);
+  const first = parts.shift();
+  if (!first) return null;
+  const eq = first.indexOf('=');
+  if (eq <= 0) return null;
+  const cookie: StoredCookie = {
+    name: first.slice(0, eq),
+    value: first.slice(eq + 1),
+    domain: url.hostname,
+    path: '/',
+    secure: false,
+    httpOnly: false,
+    hostOnly: true,
+  };
+  for (const part of parts) {
+    const partEq = part.indexOf('=');
+    const key = (partEq >= 0 ? part.slice(0, partEq) : part).trim().toLowerCase();
+    const value = partEq >= 0 ? part.slice(partEq + 1).trim() : '';
+    if (key === 'domain' && value) {
+      cookie.domain = value.toLowerCase();
+      cookie.hostOnly = false;
+    } else if (key === 'path' && value) {
+      cookie.path = value;
+    } else if (key === 'secure') {
+      cookie.secure = true;
+    } else if (key === 'httponly') {
+      cookie.httpOnly = true;
+    } else if (key === 'expires' && value) {
+      const parsed = Date.parse(value);
+      if (Number.isFinite(parsed)) cookie.expiresAt = parsed;
+    } else if (key === 'max-age' && value) {
+      const seconds = Number(value);
+      if (Number.isFinite(seconds)) cookie.expiresAt = Date.now() + seconds * 1000;
+    } else if (key === 'samesite' && value) {
+      cookie.sameSite = value;
+    }
+  }
+  return cookie;
+}
+
+function summarizeOpenPlatformPayload(payload: unknown): string {
+  if (!payload || typeof payload !== 'object') return String(payload);
+  const record = payload as Record<string, unknown>;
+  const summary: Record<string, unknown> = {};
+  for (const key of ['code', 'msg', 'message', 'error', 'error_msg']) {
+    if (record[key] !== undefined) summary[key] = record[key];
+  }
+  return JSON.stringify(summary).slice(0, 500);
+}
+
+function safeErrorMessage(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.replace(/[A-Za-z0-9_=-]{24,}/g, '***');
+}
+
+function markFinalResponseUrl(response: Response, finalUrl: string): void {
+  try {
+    Object.defineProperty(response, 'botmuxFinalUrl', {
+      value: finalUrl,
+      configurable: true,
+    });
+  } catch {
+    // Response can be non-extensible in some runtimes; fall back to response.url.
+  }
+}
+
+function finalResponseUrl(response: Response, fallbackUrl: string): string {
+  return typeof (response as any).botmuxFinalUrl === 'string'
+    ? (response as any).botmuxFinalUrl
+    : response.url || fallbackUrl;
+}

--- a/test/setup-open-platform-automation.test.ts
+++ b/test/setup-open-platform-automation.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Unit tests for Open Platform setup automation helpers.
+ *
+ * Run: pnpm vitest run test/setup-open-platform-automation.test.ts
+ */
+import { mkdtempSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  automateOpenPlatformSetup,
+  botmuxFeishuSessionFilePath,
+  buildFeishuQrPayload,
+  buildSafeSettingPayload,
+  buildScopeUpdatePayload,
+  extractOpenPlatformCsrfToken,
+  extractOpenPlatformScopeEntries,
+  getCookieHeader,
+  mapFeishuQrPollingStatus,
+  mapManifestScopesToOpenPlatformIds,
+  parseSetupOpenPlatformAutoFlag,
+  prepareFeishuWebSession,
+  readStoredCookiesFromSessionFile,
+  type StoredCookie,
+  writeStoredCookiesToSessionFile,
+} from '../src/setup/open-platform-automation.js';
+
+function cookie(overrides: Partial<StoredCookie> = {}): StoredCookie {
+  return {
+    name: 'session',
+    value: 'secret-cookie-value',
+    domain: '.feishu.cn',
+    path: '/',
+    secure: true,
+    httpOnly: true,
+    hostOnly: false,
+    expiresAt: Date.now() + 60_000,
+    ...overrides,
+  };
+}
+
+describe('parseSetupOpenPlatformAutoFlag', () => {
+  it('is enabled by default, supports explicit skip, and keeps --open-platform-auto compatible', () => {
+    expect(parseSetupOpenPlatformAutoFlag([])).toBe(true);
+    expect(parseSetupOpenPlatformAutoFlag(['--open-platform-auto'])).toBe(true);
+    expect(parseSetupOpenPlatformAutoFlag(['--no-open-platform-auto'])).toBe(false);
+    expect(parseSetupOpenPlatformAutoFlag(['--open-platform-auto', '--no-open-platform-auto'])).toBe(false);
+    expect(parseSetupOpenPlatformAutoFlag(['--no-open-platform-auto', '--open-platform-auto'])).toBe(true);
+  });
+});
+
+describe('botmux Feishu session cookie adapter', () => {
+  it('writes private botmux cookie jar and builds scoped cookie headers without expired cookies', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-'));
+    const file = join(dir, 'feishu_session.json');
+    writeStoredCookiesToSessionFile(file, [
+      cookie(),
+      cookie({ name: 'expired', value: 'gone', expiresAt: Date.now() - 10 }),
+      cookie({ name: 'askOnly', value: 'nope', domain: 'ask.feishu.cn', hostOnly: true }),
+    ]);
+
+    const cookies = readStoredCookiesFromSessionFile(file);
+    expect(cookies?.map(c => c.name)).toEqual(['session', 'askOnly']);
+    expect(getCookieHeader(cookies ?? [], 'https://open.feishu.cn/app/cli_x/auth')).toBe('session=secret-cookie-value');
+    if (process.platform !== 'win32') {
+      expect(statSync(file).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it('resolves botmux session path under config dir', () => {
+    expect(botmuxFeishuSessionFilePath('/tmp/botmux-config')).toBe('/tmp/botmux-config/feishu-session.json');
+  });
+});
+
+describe('Open Platform payload helpers', () => {
+  it('builds Feishu QR payload and maps polling status', () => {
+    expect(buildFeishuQrPayload('qr-token')).toBe(JSON.stringify({ qrlogin: { token: 'qr-token' } }));
+    expect(mapFeishuQrPollingStatus(2)).toBe('已经扫码，等待手机确认');
+    expect(mapFeishuQrPollingStatus(5)).toBe('二维码已过期');
+    expect(mapFeishuQrPollingStatus(null)).toBe('等待飞书扫码');
+  });
+
+  it('extracts window.csrfToken from page HTML', () => {
+    expect(extractOpenPlatformCsrfToken('<script>window.csrfToken = "csrf_123"</script>')).toBe('csrf_123');
+  });
+
+  it('maps tenant/user scope names to Open Platform IDs and builds payloads', () => {
+    const entries = extractOpenPlatformScopeEntries({
+      data: {
+        appScopeList: [{ id: 101, name: 'im:message' }],
+        userScopeList: [{ scopeId: '202', scopeName: 'auth:user_access_token:read' }],
+      },
+    });
+    const mapped = mapManifestScopesToOpenPlatformIds(
+      { scopes: { tenant: ['im:message'], user: ['auth:user_access_token:read'] } },
+      entries,
+    );
+
+    expect(mapped).toEqual({
+      tenantScopeIds: ['101'],
+      userScopeIds: ['202'],
+      missingTenantScopes: [],
+      missingUserScopes: [],
+    });
+    expect(buildScopeUpdatePayload('cli_x', mapped)).toMatchObject({
+      clientId: 'cli_x',
+      appScopeIDs: ['101'],
+      userScopeIDs: ['202'],
+      operation: 'add',
+      isDeveloperPanel: true,
+    });
+    expect(buildSafeSettingPayload('cli_x').redirectURL).toEqual(['http://127.0.0.1:9768/callback']);
+  });
+});
+
+describe('prepareFeishuWebSession', () => {
+  it('gets a new botmux session via built-in Feishu QR login and saves it privately', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-'));
+    const sessionFile = join(dir, 'feishu-session.json');
+    const qrPayloads: string[] = [];
+    const fetchImpl = (async (url: string | URL | Request) => {
+      const href = String(url);
+      if (href.includes('/accounts/qrlogin/init')) {
+        return Response.json(
+          { code: 0, data: { step_info: { token: 'qr-token' } } },
+          { headers: { 'x-flow-key': 'flow-key' } },
+        );
+      }
+      if (href.includes('/accounts/qrlogin/polling')) {
+        return Response.json({
+          code: 0,
+          data: {
+            next_step: 'enter_app',
+            step_info: { status: 1, cross_login_uri: 'https://accounts.feishu.cn/cross-login' },
+          },
+        });
+      }
+      if (href === 'https://accounts.feishu.cn/cross-login') {
+        return new Response('', {
+          status: 302,
+          headers: {
+            location: 'https://ask.feishu.cn/',
+            'set-cookie': 'session=secret-cookie-value; Domain=.feishu.cn; Path=/; Secure; HttpOnly',
+          },
+        });
+      }
+      if (href === 'https://ask.feishu.cn/') return new Response('ask home', { status: 200 });
+      throw new Error(`unexpected url: ${href}`);
+    }) as typeof fetch;
+
+    const result = await prepareFeishuWebSession({
+      sessionFilePath: sessionFile,
+      fetchImpl,
+      pollIntervalMs: 0,
+      maxWaitMs: 1000,
+      onQrCode: ({ qrPayload }) => qrPayloads.push(qrPayload),
+    });
+
+    expect(result.ok && result.source).toBe('qr_login');
+    expect(qrPayloads).toEqual([JSON.stringify({ qrlogin: { token: 'qr-token' } })]);
+    expect(readStoredCookiesFromSessionFile(sessionFile)?.map(c => c.name)).toContain('session');
+    if (process.platform !== 'win32') {
+      expect(statSync(sessionFile).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it('uses old bytedcli session file only as fallback after built-in QR login fails', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-'));
+    const sessionFile = join(dir, 'feishu-session.json');
+    const fallbackSessionFile = join(dir, 'bytedcli-feishu-session.json');
+    writeFileSync(fallbackSessionFile, JSON.stringify({ cookies: [cookie()] }));
+    const fetchImpl = (async (url: string | URL | Request) => {
+      const href = String(url);
+      if (href.includes('/accounts/qrlogin/init')) throw new Error('login down');
+      if (href === 'https://ask.feishu.cn/') return new Response('ask home', { status: 200 });
+      throw new Error(`unexpected url: ${href}`);
+    }) as typeof fetch;
+
+    const result = await prepareFeishuWebSession({
+      sessionFilePath: sessionFile,
+      bytedcliFallbackSessionFilePath: fallbackSessionFile,
+      fetchImpl,
+      onQrCode: () => {},
+    });
+
+    expect(result.ok && result.source).toBe('bytedcli_fallback');
+    expect(readStoredCookiesFromSessionFile(sessionFile)?.map(c => c.name)).toContain('session');
+  });
+});
+
+describe('automateOpenPlatformSetup', () => {
+  it('returns login failure so setup can fall back to manual steps without aborting', async () => {
+    const fetchImpl = (async () => {
+      throw new Error('login down');
+    }) as typeof fetch;
+    const result = await automateOpenPlatformSetup({
+      appId: 'cli_x',
+      sessionFilePath: join(tmpdir(), `botmux-missing-${Date.now()}.json`),
+      disableBytedcliFallback: true,
+      fetchImpl,
+      scopeManifest: { scopes: { tenant: ['im:message'], user: [] } },
+      onQrCode: () => {},
+      maxWaitMs: 1,
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: 'login_failed' });
+  });
+
+  it('uses botmux session cookies, page csrf, and calls the expected Open Platform endpoints', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-'));
+    const sessionFile = join(dir, 'feishu-session.json');
+    writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      const href = String(url);
+      calls.push({ url: href, init: init ?? {} });
+      if (href === 'https://ask.feishu.cn/') return new Response('ask home', { status: 200 });
+      if (href.endsWith('/auth')) {
+        return new Response('<script>window.csrfToken="csrf_auto"</script>', { status: 200 });
+      }
+      if (href.includes('/scope/all/')) {
+        return Response.json({
+          code: 0,
+          data: {
+            appScopeList: [{ id: 'tenant-1', name: 'im:message' }],
+            userScopeList: [{ id: 'user-1', name: 'auth:user_access_token:read' }],
+          },
+        });
+      }
+      if (href.includes('/app_version/create/')) return Response.json({ code: 0, data: { versionId: 'v1' } });
+      return Response.json({ code: 0 });
+    }) as typeof fetch;
+
+    const result = await automateOpenPlatformSetup({
+      appId: 'cli_x',
+      sessionFilePath: sessionFile,
+      fetchImpl,
+      scopeManifest: { scopes: { tenant: ['im:message'], user: ['auth:user_access_token:read'] } },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.sessionSource).toBe('botmux_cache');
+    expect(calls.filter(call => new URL(call.url).host === 'open.feishu.cn').map(call => new URL(call.url).pathname)).toEqual([
+      '/app/cli_x/auth',
+      '/developers/v1/scope/all/cli_x',
+      '/developers/v1/scope/update/cli_x',
+      '/developers/v1/safe_setting/update/cli_x',
+      '/developers/v1/contact_range/cli_x',
+      '/developers/v1/app_version/list/cli_x',
+      '/developers/v1/app_version/create/cli_x',
+      '/developers/v1/publish/commit/cli_x/v1',
+    ]);
+    const updateCall = calls.find(call => call.url.includes('/scope/update/'));
+    expect(new Headers(updateCall?.init.headers).get('x-csrf-token')).toBe('csrf_auto');
+    expect(new Headers(updateCall?.init.headers).get('cookie')).toBe('session=secret-cookie-value');
+    expect(JSON.parse(String(updateCall?.init.body))).toMatchObject({
+      clientId: 'cli_x',
+      appScopeIDs: ['tenant-1'],
+      userScopeIDs: ['user-1'],
+    });
+  });
+
+  it('uses the redirected Open Platform origin for API calls and referer', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-'));
+    const sessionFile = join(dir, 'feishu-session.json');
+    writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      const href = String(url);
+      calls.push({ url: href, init: init ?? {} });
+      if (href === 'https://ask.feishu.cn/') return new Response('ask home', { status: 200 });
+      if (href === 'https://open.feishu.cn/app/cli_x/auth') {
+        return new Response('', {
+          status: 302,
+          headers: { location: 'https://open.larkoffice.com/app/cli_x/auth' },
+        });
+      }
+      if (href === 'https://open.larkoffice.com/app/cli_x/auth') {
+        return new Response('<script>window.csrfToken="csrf_larkoffice"</script>', {
+          status: 200,
+          headers: {
+            'set-cookie': 'lark_oapi_csrf_token=csrf_larkoffice_cookie; Domain=.larkoffice.com; Path=/; Secure',
+          },
+        });
+      }
+      if (href.includes('/scope/all/')) {
+        return Response.json({
+          code: 0,
+          data: {
+            appScopeList: [{ id: 'tenant-1', name: 'im:message' }],
+            userScopeList: [{ id: 'user-1', name: 'auth:user_access_token:read' }],
+          },
+        });
+      }
+      if (href.includes('/app_version/create/')) return Response.json({ code: 0, data: { versionId: 'v1' } });
+      return Response.json({ code: 0 });
+    }) as typeof fetch;
+
+    const result = await automateOpenPlatformSetup({
+      appId: 'cli_x',
+      sessionFilePath: sessionFile,
+      fetchImpl,
+      scopeManifest: { scopes: { tenant: ['im:message'], user: ['auth:user_access_token:read'] } },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(calls.filter(call => new URL(call.url).host === 'open.larkoffice.com').map(call => new URL(call.url).pathname)).toEqual([
+      '/app/cli_x/auth',
+      '/developers/v1/scope/all/cli_x',
+      '/developers/v1/scope/update/cli_x',
+      '/developers/v1/safe_setting/update/cli_x',
+      '/developers/v1/contact_range/cli_x',
+      '/developers/v1/app_version/list/cli_x',
+      '/developers/v1/app_version/create/cli_x',
+      '/developers/v1/publish/commit/cli_x/v1',
+    ]);
+    const updateCall = calls.find(call => call.url === 'https://open.larkoffice.com/developers/v1/scope/update/cli_x');
+    const updateHeaders = new Headers(updateCall?.init.headers);
+    expect(updateHeaders.get('origin')).toBe('https://open.larkoffice.com');
+    expect(updateHeaders.get('referer')).toBe('https://open.larkoffice.com/app/cli_x');
+    expect(updateHeaders.get('x-csrf-token')).toBe('csrf_larkoffice');
+    expect(updateHeaders.get('cookie')).toContain('lark_oapi_csrf_token=csrf_larkoffice_cookie');
+  });
+});


### PR DESCRIPTION
## Summary

- Make `botmux setup` run Feishu Open Platform auto configuration by default after writing `bots.json`.
- Add built-in Feishu Web QR session login for Open Platform APIs, with cached `~/.botmux/feishu-session.json` reuse and old bytedcli session file only as fallback.
- Automatically import available scopes, configure `http://127.0.0.1:9768/callback`, create and submit a publish version, and fallback to manual instructions on failure.
- Harden setup TTY input against `read EIO`, which can happen in SSH/tmux/kitty interactive flows.

## Flow

```mermaid
flowchart TD
  A[botmux setup] --> B[Create or enter Feishu app]
  B --> C[Validate AppID/AppSecret]
  C --> D[Prompt CLI adapter, working dir, model]
  D --> E[Write bots.json and lark-scopes.json]
  E --> F{--no-open-platform-auto?}

  F -- yes --> M[Print manual Open Platform steps]
  F -- no --> G[Prepare Feishu Web session]

  G --> G1{Cached botmux session valid?}
  G1 -- yes --> H[Load Open Platform page and extract CSRF]
  G1 -- no --> G2[Built-in Feishu Web QR login]
  G2 --> G3{QR login success?}
  G3 -- yes --> H
  G3 -- no --> G4{Old bytedcli session file valid?}
  G4 -- yes --> H
  G4 -- no --> M

  H --> I[Fetch Open Platform scope catalog]
  I --> J[Map manifest scopes to current tenant catalog]
  J --> J1{Missing scopes?}
  J1 -- yes --> J2[Warn and skip unavailable scopes]
  J1 -- no --> K[Update mapped scopes]
  J2 --> K

  K --> L[Update redirect URL]
  L --> N[Fetch contact range and version list]
  N --> O[Create next app version]
  O --> P[Commit publish]
  P --> Q[Setup auto config complete]

  K -. API/session failure .-> M
  L -. API/session failure .-> M
  O -. API/session failure .-> M
  P -. API/session failure .-> M
```

## Notes

- Scope catalogs are tenant-dependent. `lark-scopes.json` remains the desired full manifest, but setup only imports scopes that exist in the current Open Platform catalog. Missing scopes are reported as warnings and skipped instead of failing the whole auto setup.
- Version creation uses the Open Platform contact range and increments from the latest published version instead of always trying `0.0.1`.
- The current flow can still ask for two QR scans: SDK app creation and Web session login. A follow-up can collapse this by moving app creation into the Web session path.

## Test plan

- `pnpm build`
- `pnpm vitest run test/setup-open-platform-automation.test.ts`
- Fresh devbox e2e verified:
  - QR app creation succeeded
  - built-in Web QR login source: `qr_login`
  - imported 275 mapped scopes
  - configured redirect URL
  - submitted publish version successfully