### PR TITLE
fix(adopt): 识别 traecli 进程名，CoCo trae 集成版可被 /adopt 扫到

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -662,7 +662,7 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
   }
   console.log('✅ 凭证有效（tenant_access_token 已成功获取）\n');
 
-  console.log('支持的 CLI: 1) claude-code  2) aiden  3) coco（含 trae 集成版 traecli）  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed');
+  console.log('支持的 CLI: 1) claude-code  2) aiden  3) coco（别名 traecli）  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed');
   const cliChoice = await ask(rl, 'CLI 适配器 [1]: ');
   let cliId: CliId;
   try {
@@ -762,10 +762,10 @@ async function promptEditBotConfig(
   ]);
   input.larkAppSecret = await ask(rl, `LARK_APP_SECRET [保留当前值]: `);
 
-  console.log('\n支持的 CLI: 1) claude-code  2) aiden  3) coco（含 trae 集成版 traecli）  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed');
+  console.log('\n支持的 CLI: 1) claude-code  2) aiden  3) coco（别名 traecli）  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed');
   printInputHelp('CLI 适配器', [
     '选择 botmux 需要套用哪一种 CLI 参数协议和会话恢复方式。',
-    'coco 同时覆盖 trae 集成版（二进制名 traecli）；用 trae 也选 coco 即可。',
+    'coco 的别名 traecli 走同一适配器；二进制名是 traecli 也选 coco 即可。',
     '留空保留当前值；可以输入序号，也可以直接输入适配器 ID。',
   ]);
   input.cliChoice = await ask(rl, `CLI 适配器 [${bot.cliId ?? 'claude-code'}]: `);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -662,7 +662,7 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
   }
   console.log('✅ 凭证有效（tenant_access_token 已成功获取）\n');
 
-  console.log('支持的 CLI: 1) claude-code  2) aiden  3) coco  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed');
+  console.log('支持的 CLI: 1) claude-code  2) aiden  3) coco（含 trae 集成版 traecli）  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed');
   const cliChoice = await ask(rl, 'CLI 适配器 [1]: ');
   let cliId: CliId;
   try {
@@ -762,9 +762,10 @@ async function promptEditBotConfig(
   ]);
   input.larkAppSecret = await ask(rl, `LARK_APP_SECRET [保留当前值]: `);
 
-  console.log('\n支持的 CLI: 1) claude-code  2) aiden  3) coco  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed');
+  console.log('\n支持的 CLI: 1) claude-code  2) aiden  3) coco（含 trae 集成版 traecli）  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed');
   printInputHelp('CLI 适配器', [
     '选择 botmux 需要套用哪一种 CLI 参数协议和会话恢复方式。',
+    'coco 同时覆盖 trae 集成版（二进制名 traecli）；用 trae 也选 coco 即可。',
     '留空保留当前值；可以输入序号，也可以直接输入适配器 ID。',
   ]);
   input.cliChoice = await ask(rl, `CLI 适配器 [${bot.cliId ?? 'claude-code'}]: `);

--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -37,10 +37,10 @@ const CLI_COMM_MAP: Record<string, CliId> = {
   codex: 'codex',
   aiden: 'aiden',
   coco: 'coco',
-  // CoCo 的某些发行版（如 trae 集成）安装的可执行实际叫 `traecli`，
-  // tmux pane_current_command 仍显示 "coco" 是因为进程标题被改写过；
-  // macOS 下 `ps -o comm=` 拿到的是真实 argv[0]，因此这里需要兜底把
-  // traecli 也识别成 coco，否则 /adopt 扫不到这种会话。
+  // CoCo 的别名 traecli：某些发行版（如 trae）安装的可执行实际叫
+  // `traecli`，tmux pane_current_command 仍显示 "coco" 是因为进程标题被
+  // 改写过；macOS 下 `ps -o comm=` 拿到的是真实 argv[0]，因此这里需要
+  // 把别名 traecli 也识别成 coco，否则 /adopt 扫不到这种会话。
   traecli: 'coco',
   gemini: 'gemini',
   opencode: 'opencode',

--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -37,6 +37,11 @@ const CLI_COMM_MAP: Record<string, CliId> = {
   codex: 'codex',
   aiden: 'aiden',
   coco: 'coco',
+  // CoCo 的某些发行版（如 trae 集成）安装的可执行实际叫 `traecli`，
+  // tmux pane_current_command 仍显示 "coco" 是因为进程标题被改写过；
+  // macOS 下 `ps -o comm=` 拿到的是真实 argv[0]，因此这里需要兜底把
+  // traecli 也识别成 coco，否则 /adopt 扫不到这种会话。
+  traecli: 'coco',
   gemini: 'gemini',
   opencode: 'opencode',
   mtr: 'mtr',


### PR DESCRIPTION
## 背景 / 现象

配置一个 `cliId: coco` 的 bot 后，在群里 `/adopt`，即使 tmux 里已经启动了 coco 会话，列表也是空的；其他 bot（claude-code 等）正常。

## 根因

CoCo 的 trae 集成版本安装的可执行实际叫 `traecli`，进程内部把标题改写成了 `coco`，所以：

- `tmux list-panes -F '#{pane_current_command}'` 看起来是 `coco`
- macOS `ps -o comm=` 返回的是真实 argv[0]，**`traecli`**

[`session-discovery.ts`](../blob/master/src/core/session-discovery.ts) 的 `readComm` 走的是 `ps -o comm=`，而 `CLI_COMM_MAP` 里只有 `coco -> coco`，没有 `traecli`，所以 `findCliProcess` 在 BFS 进程树时一路 miss，`discoverAdoptableSessions('coco')` 返回空。

复现（macOS，trae 集成的 coco）：

\`\`\`
$ ps -o comm= -p \$(pgrep -n traecli)
traecli
\`\`\`

## 修复

在 `CLI_COMM_MAP` 增加一条 `traecli: 'coco'` 兜底映射。

## 验证

修复前：

\`\`\`js
discoverAdoptableSessions('coco') => []
\`\`\`

修复后（同一台机器、同一个 tmux pane）：

\`\`\`json
[
  {
    "source": "tmux",
    "tmuxTarget": "trae:1.1",
    "panePid": 89104,
    "cliPid": 24118,
    "cliId": "coco",
    "sessionId": "95f8e745-9f10-45ca-8a26-e1bc0946d0f7",
    "cwd": "/Users/bytedance/Playground/botmux",
    "paneCols": 94,
    "paneRows": 39
  }
]
\`\`\`

## 影响范围

仅在 `comm` 名为 `traecli` 时新增一条映射，对其他 CLI 路径完全无影响。