### PR TITLE
fix(lark): 优化处理中卡片收尾体验

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2756,9 +2756,10 @@ function argValues(args: string[], ...flags: string[]): string[] {
 
 // Card v2 body builder helpers — extracted to im/lark/md-card.ts so the
 // daemon's bridge fallback path can produce identical cards. cmdSend
-// keeps using `buildCardBodyElements` and `hasMarkdown` from there.
+// keeps using `buildCardBodyElements` from there.
+import { buildMentionedPendingResponseCard } from './im/lark/card-builder.js';
 import { buildCardBodyElements, brandFooterSegment } from './im/lark/md-card.js';
-import { claimPendingResponseCard, isPendingResponseCardOpen, markPendingResponseCardPatchedIfCurrent, mergePendingResponseState } from './core/pending-response.js';
+import { COMPLETED_REACTION_EMOJI_TYPE, claimPendingResponseCard, isPendingResponseCardOpen, markPendingResponseCardPatchedIfCurrent, mergePendingResponseState, shouldMarkPendingAsMentionedSend, shouldPatchPendingOnExplicitSend } from './core/pending-response.js';
 import { resolveBrandLabel } from './bot-registry.js';
 import { config } from './config.js';
 import { resolveQuoteTarget, validateMentionDecision } from './services/send-policy.js';
@@ -2929,7 +2930,7 @@ async function cmdSend(rest: string[]): Promise<void> {
   const { registerBot, loadBotConfigs, findOncallChatForAnyBot } = await import('./bot-registry.js');
   try { for (const cfg of loadBotConfigs()) registerBot(cfg); } catch { /* */ }
 
-  const { sendMessage, replyMessage, uploadImage, uploadFile, deleteMessage, MessageWithdrawnError } = await import('./im/lark/client.js');
+  const { sendMessage, replyMessage, uploadImage, uploadFile, updateMessage, addReaction, MessageWithdrawnError } = await import('./im/lark/client.js');
   const appId = s.larkAppId!;
   // Effective target chat for top-level mode (defaults to session's chat)
   const targetChatId = overrideChatId ?? s.chatId;
@@ -3001,17 +3002,50 @@ async function cmdSend(rest: string[]): Promise<void> {
   };
 
   const shouldRecordBridgeMarker = !sendTopLevel && !overrideChatId && !sendInto;
+  let hasNotificationMentionsForPending = mentionArgs.length > 0;
 
   const dispatchOrPatchPending = async (content: string, msgType: string): Promise<string> => {
-    const pendingCardId = msgType === 'interactive' ? claimPendingResponseCard(s) : undefined;
-    const sentId = await dispatchPrimary(content, msgType);
-    const latest = pendingCardId ? loadSessionFresh(s) : undefined;
-    if (pendingCardId && latest?.pendingResponseCardId === pendingCardId) {
-      deleteMessage(appId, pendingCardId)
-        .then(() => { markPendingResponseCardPatchedIfCurrent(latest, pendingCardId); saveSession(latest); })
-        .catch((err: any) => logger.warn(`[send:${sid.substring(0, 8)}] failed to withdraw pending card after explicit send: ${err?.message ?? err}`));
+    const pendingCardId = shouldPatchPendingOnExplicitSend(s, { msgType, sendTopLevel, overrideChatId: !!overrideChatId, sendInto: !!sendInto, hasNotificationMentions: hasNotificationMentionsForPending })
+      ? claimPendingResponseCard(s)
+      : undefined;
+    if (!pendingCardId) {
+      const sentId = await dispatchPrimary(content, msgType);
+      if (shouldMarkPendingAsMentionedSend({ msgType, sendTopLevel, overrideChatId: !!overrideChatId, sendInto: !!sendInto, hasNotificationMentions: hasNotificationMentionsForPending })) {
+        const stalePendingCardId = claimPendingResponseCard(s);
+        const latest = stalePendingCardId ? loadSessionFresh(s) : undefined;
+        if (stalePendingCardId && latest?.pendingResponseCardId === stalePendingCardId) {
+          updateMessage(appId, stalePendingCardId, buildMentionedPendingResponseCard(localeForBot(appId)))
+            .then(() => {
+              if (markPendingResponseCardPatchedIfCurrent(latest, stalePendingCardId)) saveSession(latest);
+            })
+            .catch((err: any) => logger.warn(`[send:${sid.substring(0, 8)}] failed to mark pending card after mentioned send: ${err?.message ?? err}`));
+        }
+      }
+      return sentId;
     }
-    return sentId;
+
+    const latest = loadSessionFresh(s);
+    if (latest?.pendingResponseCardId !== pendingCardId) return dispatchPrimary(content, msgType);
+
+    try {
+      await updateMessage(appId, pendingCardId, content);
+      if (markPendingResponseCardPatchedIfCurrent(latest, pendingCardId)) {
+        saveSession(latest);
+        if (latest.quoteTargetId) {
+          addReaction(appId, latest.quoteTargetId, COMPLETED_REACTION_EMOJI_TYPE)
+            .catch((err: any) => logger.warn(`[send:${sid.substring(0, 8)}] failed to add completion reaction to ${latest.quoteTargetId}: ${err?.message ?? err}`));
+        }
+      }
+      return pendingCardId;
+    } catch (err: any) {
+      if (err instanceof MessageWithdrawnError) {
+        logger.warn(`[send:${sid.substring(0, 8)}] pending card withdrawn before explicit send patch; sending a new reply`);
+        markPendingResponseCardPatchedIfCurrent(latest, pendingCardId);
+        saveSession(latest);
+        return dispatchPrimary(content, msgType);
+      }
+      throw err;
+    }
   };
 
   // Quote chain (普通群): the primary message replies to the turn's target so
@@ -3154,6 +3188,7 @@ async function cmdSend(rest: string[]): Promise<void> {
     } catch { /* best-effort */ }
 
     const explicitKnownBotMention = hasKnownBotMention(text, mentions, botEntries, crossRef, appId);
+    hasNotificationMentionsForPending ||= explicitKnownBotMention;
     const knownBotOpenIds = knownBotOpenIdsFromCrossRef(crossRef, botEntries, appId);
     // --no-mention 显式不 @ 任何人 → 连 footer 的"发送给/cc"寻址 <at> 也清空，
     // 否则 footer 仍会 @ 人，与 --no-mention 语义和"未@任何人"输出自相矛盾

--- a/src/core/pending-response.ts
+++ b/src/core/pending-response.ts
@@ -1,6 +1,6 @@
 import type { Session } from '../types.js';
 
-export const COMPLETED_REACTION_EMOJI_TYPE = 'DONE';
+export const COMPLETED_REACTION_EMOJI_TYPE = 'GoGoGo';
 
 type PendingResponseSession = Pick<Session, 'pendingResponseCardId' | 'pendingResponseCardState' | 'lastPatchedResponseCardId'>;
 
@@ -41,6 +41,36 @@ export function mergePendingResponseState<T extends PendingResponseSession>(inco
     pendingResponseCardState: existing.pendingResponseCardState,
     lastPatchedResponseCardId: existing.lastPatchedResponseCardId,
   };
+}
+
+export function shouldPatchPendingOnExplicitSend(
+  session: Pick<Session, 'pendingResponseCardId' | 'pendingResponseCardState'>,
+  opts: { msgType: string; sendTopLevel: boolean; overrideChatId: boolean; sendInto: boolean; hasNotificationMentions: boolean },
+): boolean {
+  return opts.msgType === 'interactive'
+    && !opts.sendTopLevel
+    && !opts.overrideChatId
+    && !opts.sendInto
+    && !opts.hasNotificationMentions
+    && isPendingResponseCardOpen(session);
+}
+
+export function shouldReplyPendingInThread(scope: 'thread' | 'chat'): boolean {
+  return scope === 'thread';
+}
+
+export function shouldMarkPendingAsMentionedSend(opts: {
+  msgType: string;
+  sendTopLevel: boolean;
+  overrideChatId: boolean;
+  sendInto: boolean;
+  hasNotificationMentions: boolean;
+}): boolean {
+  return opts.msgType === 'interactive'
+    && !opts.sendTopLevel
+    && !opts.overrideChatId
+    && !opts.sendInto
+    && opts.hasNotificationMentions;
 }
 
 export function shouldWithdrawPreviousPendingOnNewTurn(_session: Pick<Session, 'pendingResponseCardId' | 'pendingResponseCardState'>): boolean {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -33,7 +33,7 @@ import type { CliId } from './adapters/cli/types.js';
 import * as scheduler from './core/scheduler.js';
 import { scanProjects, scanMultipleProjects } from './services/project-scanner.js';
 import { buildPendingResponseCard, buildQuotaExhaustedCard, buildRepoSelectCard, buildStreamingCard, getCliDisplayName } from './im/lark/card-builder.js';
-import { createPendingResponseQueue, markPendingResponseCardPatched, shouldTreatPendingCardAsPatchedByMarker, startPendingResponseTurn, syncPendingResponseState } from './core/pending-response.js';
+import { createPendingResponseQueue, markPendingResponseCardPatched, shouldReplyPendingInThread, shouldTreatPendingCardAsPatchedByMarker, startPendingResponseTurn, syncPendingResponseState } from './core/pending-response.js';
 import { readPendingResponsePatchMarker } from './services/pending-response-transaction-store.js';
 import { t as tr, botLocale, localeForBot } from './i18n/index.js';
 import { createCliAdapterSync } from './adapters/cli/registry.js';
@@ -315,7 +315,7 @@ async function postPendingResponseCard(ds: DaemonSession, replyToMessageId: stri
     syncPendingResponseState(ds.session, ds);
     const card = buildPendingResponseCard(localeForBot(ds.larkAppId));
     try {
-      const messageId = await replyMessage(ds.larkAppId, replyToMessageId, card, 'interactive', false);
+      const messageId = await replyMessage(ds.larkAppId, replyToMessageId, card, 'interactive', shouldReplyPendingInThread(ds.scope));
       startPendingResponseTurn(ds, messageId);
       startPendingResponseTurn(ds.session, messageId);
       sessionStore.updateSession(ds.session);

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -37,6 +37,7 @@ export const messages: Record<string, string> = {
   'card.pending.body': '🔄 Processing your request...',
   'card.pending.detoured_title': 'Sent',
   'card.pending.detoured_body': 'The final reply was sent to another target.',
+  'card.pending.mentioned_body': 'The final reply was sent as a new message.',
 
   // ─── Card body text ──────────────────────────────────────────────────────
   'card.body.cli_terminated': '{cliName} process has exited.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -40,6 +40,7 @@ export const messages: Record<string, string> = {
   'card.pending.body': '🔄 正在处理你的请求...',
   'card.pending.detoured_title': '已发送',
   'card.pending.detoured_body': '最终回复已发送到其他目标。',
+  'card.pending.mentioned_body': '最终回复已通过新消息发送。',
 
   // ─── Card body text ──────────────────────────────────────────────────────
   'card.body.cli_terminated': '{cliName} 进程已终止。',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -200,6 +200,23 @@ export function buildDetouredPendingResponseCard(locale?: Locale): string {
   });
 }
 
+export function buildMentionedPendingResponseCard(locale?: Locale): string {
+  return JSON.stringify({
+    schema: '2.0',
+    config: { update_multi: true },
+    header: {
+      template: 'grey',
+      title: { tag: 'plain_text', content: t('card.pending.detoured_title', undefined, locale) },
+    },
+    body: {
+      direction: 'vertical',
+      elements: [
+        { tag: 'markdown', content: t('card.pending.mentioned_body', undefined, locale) },
+      ],
+    },
+  });
+}
+
 /**
  * Build a frozen-snapshot card to PATCH onto the source-chat streaming card
  * after `/relay` moves the session elsewhere.

--- a/test/bridge-final-output-retry.test.ts
+++ b/test/bridge-final-output-retry.test.ts
@@ -262,7 +262,7 @@ describe('Bridge final_output delivery (P2 retry)', () => {
     expect(updateMessageMock).toHaveBeenCalledWith('app_test', 'om_pending', expect.any(String));
     expect(ds.session.pendingResponseCardId).toBeUndefined();
     expect(ds.session.pendingResponseCardState).toBe('patched');
-    expect(addReactionMock).toHaveBeenCalledWith('app_test', 'om_user', 'DONE');
+    expect(addReactionMock).toHaveBeenCalledWith('app_test', 'om_user', 'GoGoGo');
     expect(ds.lastBridgeEmittedUuid).toBe('uuid-1');
   });
 

--- a/test/pending-response-card.test.ts
+++ b/test/pending-response-card.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildDetouredPendingResponseCard, buildPendingResponseCard } from '../src/im/lark/card-builder.js';
+import { buildMentionedPendingResponseCard, buildDetouredPendingResponseCard, buildPendingResponseCard } from '../src/im/lark/card-builder.js';
 
 describe('pending response card', () => {
   it('builds a processing card without manual quote text', () => {
@@ -32,5 +32,19 @@ describe('pending response card', () => {
 
     expect(card.header.title.content).toBe('Sent');
     expect(JSON.stringify(card)).toContain('sent to another target');
+  });
+
+  it('builds a mentioned-send card for replies sent as a new mention message', () => {
+    const card = JSON.parse(buildMentionedPendingResponseCard());
+
+    expect(card.header.title.content).toBe('已发送');
+    expect(JSON.stringify(card)).toContain('最终回复已通过新消息发送');
+  });
+
+  it('builds English mentioned-send card text', () => {
+    const card = JSON.parse(buildMentionedPendingResponseCard('en'));
+
+    expect(card.header.title.content).toBe('Sent');
+    expect(JSON.stringify(card)).toContain('sent as a new message');
   });
 });

--- a/test/pending-response.test.ts
+++ b/test/pending-response.test.ts
@@ -7,14 +7,17 @@ import {
   isPendingResponseCardOpen,
   markPendingResponseCardPatched,
   markPendingResponseCardPatchedIfCurrent,
+  shouldMarkPendingAsMentionedSend,
+  shouldPatchPendingOnExplicitSend,
   shouldWithdrawPreviousPendingOnNewTurn,
+  shouldReplyPendingInThread,
   startPendingResponseTurn,
   syncPendingResponseState,
 } from '../src/core/pending-response.js';
 
 describe('pending response state', () => {
-  it('uses the Feishu completed emoji for completion notification', () => {
-    expect(COMPLETED_REACTION_EMOJI_TYPE).toBe('DONE');
+  it('uses the Feishu GoGoGo emoji for completion notification', () => {
+    expect(COMPLETED_REACTION_EMOJI_TYPE).toBe('GoGoGo');
   });
 
   it('starts and patches pending response state explicitly', () => {
@@ -30,6 +33,30 @@ describe('pending response state', () => {
     expect(session.lastPatchedResponseCardId).toBe('om_processing');
     expect(session.pendingResponseCardState).toBe('patched');
     expect(isPendingResponseCardOpen(session)).toBe(false);
+  });
+
+  it('patches an open pending card for explicit botmux send responses', () => {
+    const session = { pendingResponseCardId: 'om_processing', pendingResponseCardState: 'open' as const };
+
+    expect(shouldPatchPendingOnExplicitSend(session, { msgType: 'interactive', sendTopLevel: false, overrideChatId: false, sendInto: false, hasNotificationMentions: false })).toBe(true);
+    expect(shouldPatchPendingOnExplicitSend(session, { msgType: 'post', sendTopLevel: false, overrideChatId: false, sendInto: false, hasNotificationMentions: false })).toBe(false);
+    expect(shouldPatchPendingOnExplicitSend(session, { msgType: 'interactive', sendTopLevel: true, overrideChatId: false, sendInto: false, hasNotificationMentions: false })).toBe(false);
+    expect(shouldPatchPendingOnExplicitSend(session, { msgType: 'interactive', sendTopLevel: false, overrideChatId: true, sendInto: false, hasNotificationMentions: false })).toBe(false);
+    expect(shouldPatchPendingOnExplicitSend(session, { msgType: 'interactive', sendTopLevel: false, overrideChatId: false, sendInto: true, hasNotificationMentions: false })).toBe(false);
+    expect(shouldPatchPendingOnExplicitSend(session, { msgType: 'interactive', sendTopLevel: false, overrideChatId: false, sendInto: false, hasNotificationMentions: true })).toBe(false);
+  });
+
+  it('replies pending cards in thread-scope to seed private chat topics', () => {
+    expect(shouldReplyPendingInThread('thread')).toBe(true);
+    expect(shouldReplyPendingInThread('chat')).toBe(false);
+  });
+
+  it('marks mentioned sends only for same-thread replies, not detours', () => {
+    expect(shouldMarkPendingAsMentionedSend({ msgType: 'interactive', sendTopLevel: false, overrideChatId: false, sendInto: false, hasNotificationMentions: true })).toBe(true);
+    expect(shouldMarkPendingAsMentionedSend({ msgType: 'interactive', sendTopLevel: true, overrideChatId: false, sendInto: false, hasNotificationMentions: true })).toBe(false);
+    expect(shouldMarkPendingAsMentionedSend({ msgType: 'interactive', sendTopLevel: false, overrideChatId: true, sendInto: false, hasNotificationMentions: true })).toBe(false);
+    expect(shouldMarkPendingAsMentionedSend({ msgType: 'interactive', sendTopLevel: false, overrideChatId: false, sendInto: true, hasNotificationMentions: true })).toBe(false);
+    expect(shouldMarkPendingAsMentionedSend({ msgType: 'interactive', sendTopLevel: false, overrideChatId: false, sendInto: false, hasNotificationMentions: false })).toBe(false);
   });
 
   it('syncs daemon in-memory pending state from persisted patched state', () => {


### PR DESCRIPTION
## Summary
- 将处理中卡片完成提示表情从 DONE 调整为 GoGoGo，降低“任务完成”误解
- 关闭流式卡片时，显式 botmux send 优先 PATCH 处理中卡并补完成表情
- 修复私聊/话题中处理中卡片未开启话题回复的问题；显式 mention 场景保留新消息 @ 通知，并将原处理中卡标记为已通过新消息发送

## Test Plan
- [x] pnpm vitest run test/pending-response.test.ts test/pending-response-card.test.ts test/bridge-final-output-retry.test.ts
- [x] pnpm build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
