### PR TITLE
feat(preset): 新增 botmux preset export 导出Agent预设

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,7 +44,7 @@ import {
   hasOwnerEntry,
   type BotConfigEditInput,
 } from './setup/bot-config-editor.js';
-import { buildPreset, serializePreset } from './setup/agent-preset.js';
+import { buildPreset, serializePreset, presetFilename } from './setup/agent-preset.js';
 import type { CliId } from './adapters/cli/types.js';
 import { createCliAdapterSync } from './adapters/cli/registry.js';
 import { logger } from './utils/logger.js';
@@ -2409,6 +2409,23 @@ function argFlag(args: string[], flag: string): boolean {
   return args.includes(flag);
 }
 
+/**
+ * True when `flag` is present but lacks a usable value — i.e. it's the last
+ * token, is followed by another flag, or was given as `--flag=` (empty). Lets
+ * callers surface a friendly error instead of silently falling back to a
+ * default (e.g. treating a value-less `--from-chat` as "no chat"). `allowDash`
+ * permits a bare `-` value (used by `--out -` to mean stdout).
+ */
+function flagPresentButValueMissing(args: string[], flag: string, allowDash = false): boolean {
+  const i = args.findIndex(a => a === flag || a.startsWith(flag + '='));
+  if (i < 0) return false; // absent entirely — not "missing a value"
+  if (args[i].startsWith(flag + '=')) return args[i].slice(flag.length + 1) === '';
+  const next = args[i + 1];
+  if (next === undefined) return true;
+  if (next.startsWith('-')) return !(allowDash && next === '-');
+  return false;
+}
+
 /** Extract positional args, skipping --flag and the value that follows it
  *  (for --flag <value> style).  --flag=value style is self-contained.
  *  `booleanFlags` lists flags that take no value — without this hint the
@@ -4380,8 +4397,10 @@ async function cmdPreset(sub: string, rest: string[]): Promise<void> {
  *
  * Role source: team-level by default; `--from-chat <chatId>` exports that
  * group's role content instead (the chatId itself is dropped). Both role and
- * capability resolve under `config.session.dataDir`; inside an agent session the
- * daemon injects SESSION_DATA_DIR so that points at the live ~/.botmux data dir.
+ * capability resolve under the effective data dir: this fn sets
+ * `SESSION_DATA_DIR ??= resolveDataDir()` (SESSION_DATA_DIR → ~/.botmux
+ * breadcrumb → default), and reads it via config.session.dataDir's lazy getter —
+ * correct in agent sessions and bare-shell runs alike.
  */
 async function cmdPresetExport(rest: string[]): Promise<void> {
   process.env.SESSION_DATA_DIR ??= resolveDataDir();
@@ -4426,11 +4445,30 @@ async function cmdPresetExport(rest: string[]): Promise<void> {
     return;
   }
 
+  // Fail loudly when a flag was given without a value, instead of silently
+  // exporting as if it weren't passed (e.g. a value-less `--from-chat` would
+  // otherwise quietly fall back to the team role).
+  if (flagPresentButValueMissing(rest, '--from-chat')) {
+    console.error('❌ --from-chat 需要一个 chatId（如 oc_xxx）。');
+    console.error(USAGE);
+    process.exit(1);
+    return;
+  }
+  if (flagPresentButValueMissing(rest, '--out', true)) {
+    console.error('❌ --out 需要一个文件路径，或用 `--out -` 输出到 stdout。');
+    console.error(USAGE);
+    process.exit(1);
+    return;
+  }
+
   const fromChat = argValue(rest, '--from-chat');
   const out = argValue(rest, '--out');
   const skipConfirm = argFlag(rest, '--yes') || argFlag(rest, '-y');
 
-  // capability + role read the SAME data dir so they never diverge.
+  // capability + role read the SAME data dir. config.session.dataDir is a lazy
+  // getter, so the SESSION_DATA_DIR set at the top of this fn (= resolveDataDir())
+  // is honored — correct for both agent sessions AND bare-shell runs (no longer
+  // the frozen packaged default).
   const dataDir = config.session.dataDir;
   const { resolveTeamRoleFile, resolveRoleFile } = await import('./core/role-resolver.js');
   const { getBotCapability } = await import('./services/bot-profile-store.js');
@@ -4493,7 +4531,7 @@ async function cmdPresetExport(rest: string[]): Promise<void> {
     return;
   }
 
-  const outPath = out ?? `./${sourceName ?? appId}.botmux-preset.json`;
+  const outPath = out ?? `./${presetFilename(sourceName, appId)}`;
   try {
     writeFileSync(outPath, json, 'utf-8');
   } catch (err: any) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,7 @@ import {
   hasOwnerEntry,
   type BotConfigEditInput,
 } from './setup/bot-config-editor.js';
+import { buildPreset, serializePreset } from './setup/agent-preset.js';
 import type { CliId } from './adapters/cli/types.js';
 import { createCliAdapterSync } from './adapters/cli/registry.js';
 import { logger } from './utils/logger.js';
@@ -2325,6 +2326,12 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
   create-group --bot <name> [--bot ...] [--name "群名"]
                                        用指定 bot 起新群；详见 \`botmux create-group --help\`
 
+预设分享（导出某 bot 的可分享配置给同事，绝不含密钥）:
+  preset export <bot> [--from-chat <chatId>] [--out <file>] [--yes]
+                                       导出 cliId/model/角色/能力标签 + 接入指引；
+                                       默认 team 级角色，--from-chat 取某群角色内容；
+                                       缺省写 ./<name或appid>.botmux-preset.json，--out - 走 stdout
+
 配置目录: ~/.botmux/
 文档: https://github.com/deepcoldy/botmux
 `);
@@ -4347,6 +4354,157 @@ function cmdLang(args: string[]): void {
   console.log(`Run \`botmux restart\` for changes to take effect.`);
 }
 
+// ─── botmux preset ────────────────────────────────────────────────────────────
+
+/**
+ * `botmux preset <sub>` dispatcher. Currently only `export`.
+ */
+async function cmdPreset(sub: string, rest: string[]): Promise<void> {
+  switch (sub) {
+    case 'export':
+      await cmdPresetExport(rest);
+      break;
+    default:
+      console.error('用法: botmux preset export <bot> [--from-chat <chatId>] [--out <file>] [--yes]');
+      process.exit(1);
+  }
+}
+
+/**
+ * `botmux preset export <bot> [--from-chat <chatId>] [--out <file>] [--yes]`
+ *
+ * Export a bot's **shareable, secret-free** preset (cliId / model / team role /
+ * capability + an embedded guide) so a teammate's agent can self-configure a
+ * matching bot. Never emits credentials or deployment fields — see
+ * agent-preset.ts:buildPreset for the allow-list guarantee.
+ *
+ * Role source: team-level by default; `--from-chat <chatId>` exports that
+ * group's role content instead (the chatId itself is dropped). Both role and
+ * capability resolve under `config.session.dataDir`; inside an agent session the
+ * daemon injects SESSION_DATA_DIR so that points at the live ~/.botmux data dir.
+ */
+async function cmdPresetExport(rest: string[]): Promise<void> {
+  process.env.SESSION_DATA_DIR ??= resolveDataDir();
+
+  const USAGE = '用法: botmux preset export <bot> [--from-chat <chatId>] [--out <file>] [--yes]';
+  const selection = firstPositional(rest, ['--from-chat', '--out']);
+  if (!selection) {
+    console.error(USAGE);
+    console.error('  <bot>  进程名 (botmux-xxx) 或 larkAppId');
+    process.exit(1);
+    return;
+  }
+
+  const bots = loadBotsJson();
+  if (bots.length === 0) {
+    console.error('❌ 没有可用的 bot：未找到 bots.json 或其中为空。先跑 `botmux setup`。');
+    process.exit(1);
+    return;
+  }
+
+  const idx = parseBotSelection(selection, bots);
+  if (idx === undefined) {
+    console.error(`❌ 找不到 bot "${selection}"。可选：`);
+    bots.forEach((b: any, i: number) => {
+      const appId = typeof b.larkAppId === 'string' ? b.larkAppId : '(无 larkAppId)';
+      console.error(`   - ${botProcessName(b, i)}  (${appId})`);
+    });
+    process.exit(1);
+    return;
+  }
+
+  const bot: any = bots[idx];
+  const appId: string = typeof bot.larkAppId === 'string' ? bot.larkAppId : '';
+  if (!appId) {
+    console.error(`❌ bot "${selection}" 缺少 larkAppId，无法解析角色/能力。`);
+    process.exit(1);
+    return;
+  }
+  if (!bot.cliId || typeof bot.cliId !== 'string') {
+    console.error(`❌ bot "${selection}" 缺少 cliId，无法导出预设。`);
+    process.exit(1);
+    return;
+  }
+
+  const fromChat = argValue(rest, '--from-chat');
+  const out = argValue(rest, '--out');
+  const skipConfirm = argFlag(rest, '--yes') || argFlag(rest, '-y');
+
+  // capability + role read the SAME data dir so they never diverge.
+  const dataDir = config.session.dataDir;
+  const { resolveTeamRoleFile, resolveRoleFile } = await import('./core/role-resolver.js');
+  const { getBotCapability } = await import('./services/bot-profile-store.js');
+
+  let teamRole: string | null;
+  if (fromChat) {
+    teamRole = resolveRoleFile(appId, fromChat);
+    if (teamRole === null) {
+      console.error(`⚠️  群 ${fromChat} 下没有为该 bot 配置角色；导出将不含 teamRole（仍含 cliId/model/capability）。`);
+    }
+  } else {
+    teamRole = resolveTeamRoleFile(appId);
+    if (teamRole === null) {
+      console.error('⚠️  该 bot 没有 team 级角色；导出将不含 teamRole。可加 `--from-chat <chatId>` 导出某群的角色内容。');
+    }
+  }
+
+  const capability = getBotCapability(dataDir, appId);
+  const sourceName = typeof bot.name === 'string' && bot.name.trim() ? bot.name.trim() : undefined;
+
+  const preset = buildPreset({
+    cliId: bot.cliId,
+    model: typeof bot.model === 'string' ? bot.model : undefined,
+    teamRole,
+    capability,
+    sourceName,
+  });
+  const json = serializePreset(preset);
+
+  // Confirm before writing — the role may carry internal info. --yes skips.
+  if (!skipConfirm) {
+    if (!process.stdin.isTTY) {
+      console.error('❌ 角色内容可能含内部信息，导出前需确认；非交互环境（如 agent 调用）请加 `--yes` 跳过确认。');
+      process.exit(1);
+      return;
+    }
+    if (teamRole) {
+      console.error('\n即将导出以下角色内容，请确认不含敏感/内部信息：');
+      console.error('────────────────────────────────────────');
+      console.error(teamRole);
+      console.error('────────────────────────────────────────');
+    } else {
+      console.error('\n（无角色内容，仅导出 cliId/model/capability）');
+    }
+    // Prompt on stderr so a piped stdout (--out -) stays clean.
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    const answer = (await ask(rl, '确认导出？输入 y 继续，其它取消: ')).trim().toLowerCase();
+    rl.close();
+    if (answer !== 'y' && answer !== 'yes') {
+      console.error('已取消，未写入任何文件。');
+      process.exit(1);
+      return;
+    }
+  }
+
+  // stdout mode: the JSON must own stdout; all chatter goes to stderr.
+  if (out === '-') {
+    process.stdout.write(json);
+    console.error('✅ 已输出到 stdout。本文件不含任何密钥（larkAppId/secret/allowedUsers 等均未包含）。');
+    return;
+  }
+
+  const outPath = out ?? `./${sourceName ?? appId}.botmux-preset.json`;
+  try {
+    writeFileSync(outPath, json, 'utf-8');
+  } catch (err: any) {
+    console.error(`❌ 写入 ${outPath} 失败: ${err?.message ?? String(err)}`);
+    process.exit(1);
+    return;
+  }
+  console.error(`✅ 已导出预设到 ${outPath}`);
+  console.error('   本文件不含任何密钥（larkAppId/secret/allowedUsers/workingDir 等均未包含），可安全分享。');
+}
+
 // ─── Main ────────────────────────────────────────────────────────────────────
 
 function getVersion(): string {
@@ -4437,6 +4595,7 @@ switch (command) {
   case 'report': await cmdReport(process.argv.slice(3)); break;
   case 'create-group': await cmdCreateGroup(process.argv.slice(3)); break;
   case 'bots':     await cmdBots(process.argv[3] ?? 'list', process.argv.slice(4)); break;
+  case 'preset':   await cmdPreset(process.argv[3] ?? '', process.argv.slice(4)); break;
   case 'history':  await cmdHistory(process.argv.slice(3)); break;
   case 'quoted':   await cmdQuoted(process.argv.slice(3)); break;
   case 'lang':     cmdLang(process.argv.slice(3)); break;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4505,13 +4505,14 @@ async function cmdPresetExport(rest: string[]): Promise<void> {
       process.exit(1);
       return;
     }
-    if (teamRole) {
-      console.error('\n即将导出以下角色内容，请确认不含敏感/内部信息：');
+    if (teamRole || capability) {
+      console.error('\n即将导出以下内容，请确认不含敏感/内部信息：');
       console.error('────────────────────────────────────────');
-      console.error(teamRole);
+      if (teamRole) console.error(`[角色 teamRole]\n${teamRole}`);
+      if (capability) console.error(`[能力标签 capability] ${capability}`);
       console.error('────────────────────────────────────────');
     } else {
-      console.error('\n（无角色内容，仅导出 cliId/model/capability）');
+      console.error('\n（无角色 / 能力标签内容，仅导出 cliId/model）');
     }
     // Prompt on stderr so a piped stdout (--out -) stays clean.
     const rl = createInterface({ input: process.stdin, output: process.stderr });

--- a/src/config.ts
+++ b/src/config.ts
@@ -51,6 +51,10 @@ export const config = {
   },
   session: {
     get dataDir() { return process.env.SESSION_DATA_DIR ?? packagedDataDir; },
+    // Writable for back-compat: callers/tests historically assigned
+    // `config.session.dataDir = ...`. Map writes onto SESSION_DATA_DIR so the
+    // getter reflects them and the old assignable contract is preserved.
+    set dataDir(value: string) { process.env.SESSION_DATA_DIR = value; },
   },
   send: {
     /** @ hard-gate: every model-initiated `botmux send` reply must explicitly

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,13 +35,22 @@ function detectDefaultBackend(): 'pty' | 'tmux' {
   return probeTmuxFunctional().ok ? 'tmux' : 'pty';
 }
 
+// Computed once: the packaged fallback data dir. The effective dir is read
+// lazily (getter below) so that a SESSION_DATA_DIR set *after* this module is
+// first imported — e.g. cli.ts subcommands doing
+// `process.env.SESSION_DATA_DIR ??= resolveDataDir()` — is still honored. A
+// static value would freeze the packaged default at import time and make those
+// readers (resolveTeamRoleFile / getBotCapability / …) silently look in the
+// wrong directory. Mirrors the web/dashboard externalHost getters below.
+const packagedDataDir = new URL('../data', import.meta.url).pathname;
+
 export const config = {
   lark: {
     appId: process.env.LARK_APP_ID ?? '',
     appSecret: process.env.LARK_APP_SECRET ?? '',
   },
   session: {
-    dataDir: process.env.SESSION_DATA_DIR ?? new URL('../data', import.meta.url).pathname,
+    get dataDir() { return process.env.SESSION_DATA_DIR ?? packagedDataDir; },
   },
   send: {
     /** @ hard-gate: every model-initiated `botmux send` reply must explicitly

--- a/src/setup/agent-preset.ts
+++ b/src/setup/agent-preset.ts
@@ -109,6 +109,32 @@ export function serializePreset(preset: AgentPreset): string {
   return JSON.stringify(preset, null, 2) + '\n';
 }
 
+/**
+ * Slugify a string into a safe filename component: keep Unicode letters / digits
+ * / `_` / `.` / `-`, replace every other run with a single `-`, then trim
+ * leading/trailing separators. Returns '' if nothing usable remains (e.g. the
+ * input was only spaces or slashes). CJK names are preserved (they're \p{L}).
+ */
+export function slugifyForFilename(raw: string): string {
+  return raw
+    .trim()
+    .replace(/[^\p{L}\p{N}_.-]+/gu, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^[.\-]+|[.\-]+$/g, '');
+}
+
+/**
+ * Derive the default preset filename (no directory). Prefers the bot's human
+ * name, falls back to its larkAppId, and ALWAYS slugifies so the path stays
+ * valid/stable even when `name` carries spaces, slashes, etc. Never uses the
+ * `botmux-<n>` process name. Final 'bot' fallback guards the degenerate case
+ * where both name and appId slug to empty.
+ */
+export function presetFilename(sourceName: string | undefined, appId: string): string {
+  const base = slugifyForFilename(sourceName ?? '') || slugifyForFilename(appId) || 'bot';
+  return `${base}.botmux-preset.json`;
+}
+
 const presetSchema = z.object({
   botmuxPreset: z.literal(PRESET_VERSION),
   cliId: z.string().min(1),

--- a/src/setup/agent-preset.ts
+++ b/src/setup/agent-preset.ts
@@ -1,0 +1,144 @@
+/**
+ * Agent preset — a portable, **secret-free** snapshot of a bot's shareable
+ * configuration.
+ *
+ * `botmux preset export <bot>` writes one of these so a teammate's agent can
+ * self-configure a *matching* bot WITHOUT ever copying credentials. It carries
+ * only the parts that are safe to share — which CLI/model to use, the team-level
+ * role persona, and the one-line capability label — plus an embedded Chinese
+ * guide telling the receiving agent how to apply it.
+ *
+ * It deliberately omits everything identity- or deployment-specific:
+ * larkAppId / larkAppSecret / allowedUsers / allowedChatGroups / oncallChats /
+ * workingDir. Those must be supplied by each bot's own owner. The safety
+ * guarantee lives in `buildPreset`, which copies an explicit allow-list of
+ * fields and NEVER spreads its input, so a caller passing a full bot config
+ * (secrets and all) still produces a clean preset.
+ */
+import { z } from 'zod';
+
+/**
+ * On-disk preset format version. Doubles as a format discriminator: a file
+ * whose `botmuxPreset` !== PRESET_VERSION is rejected by `loadPreset`. Bump
+ * only on a breaking change to the shape below.
+ */
+export const PRESET_VERSION = 1;
+
+/**
+ * A secret-free, shareable bot preset. Field order here matches the serialized
+ * JSON (see `buildPreset`): marker first, identity-free config in the middle,
+ * human guide last.
+ */
+export interface AgentPreset {
+  /** Format marker + version. Always equal to {@link PRESET_VERSION}. */
+  botmuxPreset: number;
+  /** CLI adapter id the source bot uses (e.g. 'claude-code', 'aiden'). */
+  cliId: string;
+  /** Model override, if the source bot set one. */
+  model?: string;
+  /** Team-level role markdown (the persona injected into the CLI). */
+  teamRole?: string;
+  /** One-line capability label used in the collaboration roster. */
+  capability?: string;
+  /** Human-facing name of the source bot — for display / default filename. */
+  sourceName?: string;
+  /** Chinese guide telling the *receiving* agent how to apply this preset. */
+  guide: string;
+}
+
+/**
+ * Input accepted by {@link buildPreset}. The named fields are the allow-list;
+ * the index signature exists so callers can pass a full bot config (which also
+ * carries secrets like larkAppSecret) without a type error — those extra keys
+ * are simply never read.
+ */
+export interface BuildPresetInput {
+  cliId: string;
+  model?: string | null;
+  teamRole?: string | null;
+  capability?: string | null;
+  sourceName?: string | null;
+  /** Tolerate (and ignore) any extra fields, e.g. a full bot config's secrets. */
+  [extra: string]: unknown;
+}
+
+/**
+ * Guide embedded in every exported preset, addressed to the AI agent that will
+ * apply it on the receiving side. Kept in the file so it travels with the data.
+ */
+export const PRESET_GUIDE = [
+  '本文件是一个 botmux「Agent 预设」(agent preset)，由 `botmux preset export` 生成。',
+  '它携带某个机器人「可安全分享」的配置：使用的 CLI 适配器(cliId)、模型(model)、团队角色 persona(teamRole)、能力标签(capability)。',
+  '',
+  '它【不包含任何凭证或部署信息】——没有 larkAppId / larkAppSecret / allowedUsers / allowedChatGroups / workingDir。',
+  '因此单凭本文件无法登录、无法冒充原机器人，这是有意为之。',
+  '',
+  '如果你是一个 AI agent，请按下面的步骤帮用户用这份预设配置他自己的 botmux 机器人：',
+  '1. 让用户用【他自己】的飞书/Lark 应用凭证跑 `botmux setup`；larkAppId/larkAppSecret/allowedUsers 必须由他本人填写，',
+  '   绝不要从本文件或任何他人处复制粘贴密钥。',
+  '2. setup 时把 CLI 适配器设为本预设的 `cliId`，模型设为 `model`(如有)。',
+  '3. 把本预设的 `teamRole` 写为该 bot 的 team 级角色内容，把 `capability` 设为它的能力标签。',
+  '4. 完成后让用户 `botmux restart` 使配置生效。',
+  '',
+  '再次强调：凭证(AppID/Secret/token)必须每个机器人独立、由其所有者本人提供，切勿复制他人的密钥。',
+].join('\n');
+
+/**
+ * Build a preset by copying an explicit allow-list of fields. Never spreads
+ * `input`, so any secret-bearing extra keys on it are dropped by construction.
+ * Empty / null / undefined optional fields are omitted entirely.
+ */
+export function buildPreset(input: BuildPresetInput): AgentPreset {
+  const preset = {
+    botmuxPreset: PRESET_VERSION,
+    cliId: input.cliId,
+  } as AgentPreset;
+
+  if (input.model) preset.model = input.model;
+  if (input.teamRole) preset.teamRole = input.teamRole;
+  if (input.capability) preset.capability = input.capability;
+  if (input.sourceName) preset.sourceName = input.sourceName;
+
+  // Guide last so it reads naturally at the bottom of the JSON file.
+  preset.guide = PRESET_GUIDE;
+  return preset;
+}
+
+/** Serialize a preset to pretty JSON with a trailing newline (POSIX-friendly). */
+export function serializePreset(preset: AgentPreset): string {
+  return JSON.stringify(preset, null, 2) + '\n';
+}
+
+const presetSchema = z.object({
+  botmuxPreset: z.literal(PRESET_VERSION),
+  cliId: z.string().min(1),
+  model: z.string().optional(),
+  teamRole: z.string().optional(),
+  capability: z.string().optional(),
+  sourceName: z.string().optional(),
+  guide: z.string(),
+});
+
+/**
+ * Parse + validate a preset JSON string. Throws a friendly error on malformed
+ * JSON or on a wrong/missing version (kept for tests and future "preset apply"
+ * tooling). Unknown extra keys are stripped, so a future minor extension stays
+ * readable by older code as long as the version still matches.
+ */
+export function loadPreset(raw: string): AgentPreset {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err: any) {
+    throw new Error(`不是合法的 JSON: ${err?.message ?? String(err)}`);
+  }
+
+  const result = presetSchema.safeParse(parsed);
+  if (!result.success) {
+    const detail = result.error.issues
+      .map(i => `${i.path.join('.') || '(root)'}: ${i.message}`)
+      .join('; ');
+    throw new Error(`不是合法的 botmux 预设 (需要 botmuxPreset=${PRESET_VERSION}): ${detail}`);
+  }
+  return result.data;
+}

--- a/test/agent-preset.test.ts
+++ b/test/agent-preset.test.ts
@@ -15,6 +15,8 @@ import {
   buildPreset,
   serializePreset,
   loadPreset,
+  slugifyForFilename,
+  presetFilename,
 } from '../src/setup/agent-preset.js';
 
 describe('buildPreset — secret-free allow-list', () => {
@@ -98,6 +100,52 @@ describe('serialize ↔ load round-trip', () => {
   it('round-trips a minimal preset (no optional fields)', () => {
     const preset = buildPreset({ cliId: 'cursor' });
     expect(loadPreset(serializePreset(preset))).toEqual(preset);
+  });
+});
+
+describe('slugifyForFilename', () => {
+  it('replaces spaces / slashes / illegal chars with a single dash', () => {
+    expect(slugifyForFilename('Backend Bot/01')).toBe('Backend-Bot-01');
+    expect(slugifyForFilename('a  b\t/\\c')).toBe('a-b-c');
+    expect(slugifyForFilename('weird:*?<>|name')).toBe('weird-name');
+  });
+
+  it('keeps Unicode letters/digits and _ . -', () => {
+    expect(slugifyForFilename('后端_bot.v2-x')).toBe('后端_bot.v2-x');
+  });
+
+  it('trims leading/trailing separators and collapses repeats', () => {
+    expect(slugifyForFilename('  --foo--  ')).toBe('foo');
+    expect(slugifyForFilename('...name...')).toBe('name');
+  });
+
+  it('returns empty string when nothing usable remains', () => {
+    expect(slugifyForFilename('   ')).toBe('');
+    expect(slugifyForFilename('/// \\\\')).toBe('');
+  });
+});
+
+describe('presetFilename', () => {
+  it('prefers the (slugified) name', () => {
+    expect(presetFilename('Backend Bot', 'cli_app_1')).toBe('Backend-Bot.botmux-preset.json');
+  });
+
+  it('falls back to appId when name is absent', () => {
+    expect(presetFilename(undefined, 'cli_app_1')).toBe('cli_app_1.botmux-preset.json');
+  });
+
+  it('falls back to appId when name slugs to empty', () => {
+    expect(presetFilename('///', 'cli_app_1')).toBe('cli_app_1.botmux-preset.json');
+  });
+
+  it('falls back to "bot" when both slug to empty', () => {
+    expect(presetFilename('  ', '///')).toBe('bot.botmux-preset.json');
+  });
+
+  it('never contains path separators', () => {
+    const name = presetFilename('a/b/c', 'cli_x');
+    expect(name).not.toContain('/');
+    expect(name).not.toContain('\\');
   });
 });
 

--- a/test/agent-preset.test.ts
+++ b/test/agent-preset.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Agent preset model: build (secret-free allow-list), serialize, and load
+ * (zod-validated) round-trip.
+ *
+ * The headline guarantee is that buildPreset NEVER leaks a secret even when
+ * handed a full bot config, because it copies an explicit allow-list instead of
+ * spreading its input.
+ *
+ * Run: pnpm vitest run test/agent-preset.test.ts
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  PRESET_VERSION,
+  PRESET_GUIDE,
+  buildPreset,
+  serializePreset,
+  loadPreset,
+} from '../src/setup/agent-preset.js';
+
+describe('buildPreset — secret-free allow-list', () => {
+  it('drops every non-allow-listed field, even secrets, from a full bot config', () => {
+    const preset = buildPreset({
+      cliId: 'claude-code',
+      model: 'sonnet',
+      teamRole: '# 后端 bot\n擅长服务端排查。',
+      capability: '后端 bot，擅长服务端排查',
+      sourceName: 'backend',
+      // Everything below is identity/deployment/secret material and must NOT leak:
+      larkAppId: 'cli_xxx_secret_app',
+      larkAppSecret: 'super-secret-value',
+      allowedUsers: ['alice@example.com'],
+      allowedChatGroups: ['oc_team'],
+      oncallChats: ['oc_oncall'],
+      workingDir: '/Users/alice/projects',
+    });
+
+    // Structural guarantee: the object carries ONLY allow-listed keys — no
+    // larkAppId / larkAppSecret / allowedUsers / workingDir keys sneak in.
+    expect(Object.keys(preset).sort()).toEqual(
+      ['botmuxPreset', 'capability', 'cliId', 'guide', 'model', 'sourceName', 'teamRole'].sort(),
+    );
+    for (const leaked of ['larkAppId', 'larkAppSecret', 'allowedUsers', 'allowedChatGroups', 'oncallChats', 'workingDir']) {
+      expect(preset).not.toHaveProperty(leaked);
+    }
+
+    // Value guarantee: no secret VALUE leaks into the serialized JSON. (We check
+    // values, not key names — the guide text deliberately *names* the excluded
+    // fields to warn the recipient, so the field names themselves do appear.)
+    const serialized = serializePreset(preset);
+    for (const secretValue of [
+      'cli_xxx_secret_app',
+      'super-secret-value',
+      'alice@example.com',
+      'oc_team',
+      'oc_oncall',
+      '/Users/alice/projects',
+    ]) {
+      expect(serialized).not.toContain(secretValue);
+    }
+  });
+
+  it('omits optional fields that are empty / null / undefined', () => {
+    const preset = buildPreset({ cliId: 'aiden', model: null, teamRole: '', capability: undefined });
+    expect(preset).toEqual({
+      botmuxPreset: PRESET_VERSION,
+      cliId: 'aiden',
+      guide: PRESET_GUIDE,
+    });
+    expect(preset).not.toHaveProperty('model');
+    expect(preset).not.toHaveProperty('teamRole');
+    expect(preset).not.toHaveProperty('capability');
+    expect(preset).not.toHaveProperty('sourceName');
+  });
+});
+
+describe('buildPreset — version + guide stamping', () => {
+  it('always stamps the current version and the embedded guide', () => {
+    const preset = buildPreset({ cliId: 'codex' });
+    expect(preset.botmuxPreset).toBe(PRESET_VERSION);
+    expect(preset.guide).toBe(PRESET_GUIDE);
+    expect(preset.guide).toContain('不包含任何凭证');
+  });
+});
+
+describe('serialize ↔ load round-trip', () => {
+  it('loadPreset(serializePreset(x)) deep-equals x', () => {
+    const preset = buildPreset({
+      cliId: 'gemini',
+      model: 'gemini-2.5-pro',
+      teamRole: 'PERSONA',
+      capability: 'CAP',
+      sourceName: 'researcher',
+    });
+    const loaded = loadPreset(serializePreset(preset));
+    expect(loaded).toEqual(preset);
+  });
+
+  it('round-trips a minimal preset (no optional fields)', () => {
+    const preset = buildPreset({ cliId: 'cursor' });
+    expect(loadPreset(serializePreset(preset))).toEqual(preset);
+  });
+});
+
+describe('loadPreset — rejects bad input', () => {
+  it('throws on malformed JSON', () => {
+    expect(() => loadPreset('{ not json')).toThrow(/JSON/);
+  });
+
+  it('throws on a wrong version', () => {
+    const wrong = JSON.stringify({ botmuxPreset: PRESET_VERSION + 1, cliId: 'claude-code', guide: 'g' });
+    expect(() => loadPreset(wrong)).toThrow(/botmuxPreset/);
+  });
+
+  it('throws when the version marker is missing', () => {
+    const noMarker = JSON.stringify({ cliId: 'claude-code', guide: 'g' });
+    expect(() => loadPreset(noMarker)).toThrow();
+  });
+
+  it('throws when a required field is missing', () => {
+    const noCli = JSON.stringify({ botmuxPreset: PRESET_VERSION, guide: 'g' });
+    expect(() => loadPreset(noCli)).toThrow();
+  });
+
+  it('strips unknown extra keys but keeps the preset valid', () => {
+    const withExtra = JSON.stringify({
+      botmuxPreset: PRESET_VERSION,
+      cliId: 'claude-code',
+      guide: 'g',
+      somethingFuture: 'ignored',
+    });
+    const loaded = loadPreset(withExtra);
+    expect(loaded).not.toHaveProperty('somethingFuture');
+    expect(loaded.cliId).toBe('claude-code');
+  });
+});

--- a/test/config-data-dir.test.ts
+++ b/test/config-data-dir.test.ts
@@ -1,0 +1,39 @@
+/**
+ * config.session.dataDir must be a LAZY getter, not a value frozen at import.
+ *
+ * Several CLI subcommands set SESSION_DATA_DIR *after* config.js is first
+ * imported (e.g. `process.env.SESSION_DATA_DIR ??= resolveDataDir()`) and rely
+ * on later reads honoring it. If it were a static value, role/capability
+ * resolution (resolveTeamRoleFile / getBotCapability, which read
+ * config.session.dataDir) would silently read the packaged default dir.
+ *
+ * Run: pnpm vitest run test/config-data-dir.test.ts
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+afterEach(() => {
+  delete process.env.SESSION_DATA_DIR;
+  vi.resetModules();
+});
+
+describe('config.session.dataDir laziness', () => {
+  it('reflects SESSION_DATA_DIR set AFTER the module was imported', async () => {
+    delete process.env.SESSION_DATA_DIR;
+    vi.resetModules();
+    const { config } = await import('../src/config.js');
+
+    const before = config.session.dataDir; // packaged default
+    process.env.SESSION_DATA_DIR = '/tmp/botmux-late-dir';
+    const after = config.session.dataDir; // must pick up the value set just now
+
+    expect(after).toBe('/tmp/botmux-late-dir');
+    expect(after).not.toBe(before);
+  });
+
+  it('falls back to the packaged default when SESSION_DATA_DIR is unset', async () => {
+    delete process.env.SESSION_DATA_DIR;
+    vi.resetModules();
+    const { config } = await import('../src/config.js');
+    expect(config.session.dataDir).toContain('/data');
+  });
+});

--- a/test/preset-export-cli.test.ts
+++ b/test/preset-export-cli.test.ts
@@ -1,0 +1,141 @@
+/**
+ * End-to-end CLI boundary tests for `botmux preset export`, run against the
+ * built `dist/cli.js` as a subprocess (mirrors test/workflow-c0-isolation).
+ *
+ * Covers the review's CLI-boundary asks: default filename slugification,
+ * non-TTY without --yes fails (without blocking), `--out - --yes` emits ONLY
+ * JSON on stdout with logs on stderr, empty team role still exits 0, and
+ * value-less --from-chat / --out error out instead of silently defaulting.
+ *
+ * Requires a prior `pnpm build`. Run: pnpm vitest run test/preset-export-cli.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const CLI_PATH = join(__dirname, '..', 'dist', 'cli.js');
+
+let home: string;
+let dataDir: string;
+
+const SECRET = 'SECRET_SHOULD_NOT_LEAK_123';
+const APP_WITH_ROLE = 'cli_fake_app_001';
+const APP_NO_ROLE = 'cli_fake_app_002';
+
+beforeAll(() => {
+  if (!existsSync(CLI_PATH)) {
+    throw new Error('dist/cli.js missing — run `pnpm build` first');
+  }
+
+  home = mkdtempSync(join(tmpdir(), 'botmux-preset-cli-'));
+  dataDir = join(home, 'data');
+  mkdirSync(join(home, '.botmux'), { recursive: true });
+  mkdirSync(join(dataDir, 'team-roles'), { recursive: true });
+  mkdirSync(join(dataDir, 'bot-profiles'), { recursive: true });
+
+  writeFileSync(
+    join(home, '.botmux', 'bots.json'),
+    JSON.stringify([
+      {
+        name: 'Backend Bot/01', // intentionally illegal-for-filename chars
+        larkAppId: APP_WITH_ROLE,
+        larkAppSecret: SECRET,
+        cliId: 'claude-code',
+        model: 'sonnet',
+        allowedUsers: ['alice@example.com'],
+        workingDir: '/tmp/secret-workdir',
+      },
+      {
+        name: 'norole',
+        larkAppId: APP_NO_ROLE,
+        larkAppSecret: SECRET,
+        cliId: 'aiden',
+      },
+    ]),
+    'utf-8',
+  );
+
+  writeFileSync(join(dataDir, 'team-roles', `${APP_WITH_ROLE}.md`), '# 后端\nINTERNAL_NOTE_xyz', 'utf-8');
+  writeFileSync(
+    join(dataDir, 'bot-profiles', `${APP_WITH_ROLE}.json`),
+    JSON.stringify({ capability: '后端能力标签', updatedAt: 1 }),
+    'utf-8',
+  );
+});
+
+afterAll(() => {
+  if (home) rmSync(home, { recursive: true, force: true });
+});
+
+function runCli(args: string[]): { status: number; stdout: string; stderr: string } {
+  // spawnSync (not execFileSync) so we capture stderr on success too — several
+  // assertions check stderr while the command exits 0 (stdout stays JSON-clean).
+  const r = spawnSync('node', [CLI_PATH, ...args], {
+    cwd: home,
+    env: { ...process.env, HOME: home, SESSION_DATA_DIR: dataDir },
+    stdio: ['ignore', 'pipe', 'pipe'], // stdin ignored ⇒ not a TTY
+    encoding: 'utf-8',
+  });
+  return { status: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+describe('botmux preset export — CLI boundary', () => {
+  it('default filename is slugified from the bot name', () => {
+    const out = runCli(['preset', 'export', APP_WITH_ROLE, '--yes']);
+    expect(out.status).toBe(0);
+    const expected = join(home, 'Backend-Bot-01.botmux-preset.json');
+    expect(existsSync(expected)).toBe(true);
+    const body = readFileSync(expected, 'utf-8');
+    expect(body).not.toContain(SECRET);
+    expect(body).toContain('INTERNAL_NOTE_xyz'); // role resolved & included
+    expect(body).toContain('后端能力标签'); // capability resolved & included
+  });
+
+  it('--out - --yes emits ONLY JSON on stdout; logs go to stderr', () => {
+    const out = runCli(['preset', 'export', APP_WITH_ROLE, '--out', '-', '--yes']);
+    expect(out.status).toBe(0);
+    // stdout must parse as a single JSON object and carry no secret.
+    const parsed = JSON.parse(out.stdout);
+    expect(parsed.botmuxPreset).toBe(1);
+    expect(parsed.teamRole).toContain('INTERNAL_NOTE_xyz');
+    expect(out.stdout).not.toContain(SECRET);
+    // the human hint is on stderr, keeping stdout clean.
+    expect(out.stderr).toContain('不含任何密钥');
+  });
+
+  it('non-TTY without --yes fails fast (does not block on a prompt)', () => {
+    const out = runCli(['preset', 'export', APP_WITH_ROLE, '--out', '-']);
+    expect(out.status).toBe(1);
+    expect(out.stderr).toContain('--yes');
+    expect(out.stdout).toBe(''); // nothing written to stdout
+  });
+
+  it('empty team role still exits 0 (warns on stderr)', () => {
+    const out = runCli(['preset', 'export', APP_NO_ROLE, '--out', '-', '--yes']);
+    expect(out.status).toBe(0);
+    const parsed = JSON.parse(out.stdout);
+    expect(parsed.botmuxPreset).toBe(1);
+    expect(parsed.teamRole).toBeUndefined();
+    expect(out.stderr).toMatch(/没有 team 级角色|没有.*角色/);
+  });
+
+  it('value-less --from-chat errors instead of silently exporting team role', () => {
+    const out = runCli(['preset', 'export', APP_WITH_ROLE, '--from-chat', '--yes']);
+    expect(out.status).toBe(1);
+    expect(out.stderr).toContain('--from-chat');
+  });
+
+  it('value-less --out errors', () => {
+    const out = runCli(['preset', 'export', APP_WITH_ROLE, '--out']);
+    expect(out.status).toBe(1);
+    expect(out.stderr).toContain('--out');
+  });
+
+  it('unknown bot prints a friendly list and exits 1', () => {
+    const out = runCli(['preset', 'export', '__nope__', '--yes']);
+    expect(out.status).toBe(1);
+    expect(out.stderr).toContain('找不到 bot');
+  });
+});

--- a/test/preset-export-cli.test.ts
+++ b/test/preset-export-cli.test.ts
@@ -23,6 +23,7 @@ let dataDir: string;
 const SECRET = 'SECRET_SHOULD_NOT_LEAK_123';
 const APP_WITH_ROLE = 'cli_fake_app_001';
 const APP_NO_ROLE = 'cli_fake_app_002';
+const APP_BARE = 'cli_fake_app_003'; // role/capability live ONLY under the default data dir
 
 beforeAll(() => {
   if (!existsSync(CLI_PATH)) {
@@ -53,6 +54,12 @@ beforeAll(() => {
         larkAppSecret: SECRET,
         cliId: 'aiden',
       },
+      {
+        name: 'bareshell',
+        larkAppId: APP_BARE,
+        larkAppSecret: SECRET,
+        cliId: 'codex',
+      },
     ]),
     'utf-8',
   );
@@ -63,22 +70,52 @@ beforeAll(() => {
     JSON.stringify({ capability: '后端能力标签', updatedAt: 1 }),
     'utf-8',
   );
+
+  // Bare-shell fixture: APP_BARE's role/capability live ONLY under the DEFAULT
+  // data dir (~/.botmux/data → HOME/.botmux/data), with NO SESSION_DATA_DIR set.
+  // This is the actual bug scenario for Blocker 2: it only resolves correctly if
+  // resolveDataDir() falls back to the default AND config.session.dataDir reads
+  // it live (lazy getter) after the env is set inside cmdPresetExport.
+  const defaultDataDir = join(home, '.botmux', 'data');
+  mkdirSync(join(defaultDataDir, 'team-roles'), { recursive: true });
+  mkdirSync(join(defaultDataDir, 'bot-profiles'), { recursive: true });
+  writeFileSync(join(defaultDataDir, 'team-roles', `${APP_BARE}.md`), 'BARE_SHELL_ROLE_marker', 'utf-8');
+  writeFileSync(
+    join(defaultDataDir, 'bot-profiles', `${APP_BARE}.json`),
+    JSON.stringify({ capability: '裸终端能力', updatedAt: 1 }),
+    'utf-8',
+  );
 });
 
 afterAll(() => {
   if (home) rmSync(home, { recursive: true, force: true });
 });
 
-function runCli(args: string[]): { status: number; stdout: string; stderr: string } {
+function spawnCli(
+  args: string[],
+  env: Record<string, string | undefined>,
+): { status: number; stdout: string; stderr: string } {
   // spawnSync (not execFileSync) so we capture stderr on success too — several
   // assertions check stderr while the command exits 0 (stdout stays JSON-clean).
   const r = spawnSync('node', [CLI_PATH, ...args], {
     cwd: home,
-    env: { ...process.env, HOME: home, SESSION_DATA_DIR: dataDir },
+    env,
     stdio: ['ignore', 'pipe', 'pipe'], // stdin ignored ⇒ not a TTY
     encoding: 'utf-8',
   });
   return { status: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+/** Agent-session style: SESSION_DATA_DIR explicitly injected. */
+function runCli(args: string[]) {
+  return spawnCli(args, { ...process.env, HOME: home, SESSION_DATA_DIR: dataDir });
+}
+
+/** Bare-shell style: SESSION_DATA_DIR unset, resolved via default data dir. */
+function runCliBare(args: string[]) {
+  const env: Record<string, string | undefined> = { ...process.env, HOME: home };
+  delete env.SESSION_DATA_DIR;
+  return spawnCli(args, env);
 }
 
 describe('botmux preset export — CLI boundary', () => {
@@ -96,13 +133,26 @@ describe('botmux preset export — CLI boundary', () => {
   it('--out - --yes emits ONLY JSON on stdout; logs go to stderr', () => {
     const out = runCli(['preset', 'export', APP_WITH_ROLE, '--out', '-', '--yes']);
     expect(out.status).toBe(0);
-    // stdout must parse as a single JSON object and carry no secret.
+    // stdout must parse as a single JSON object and carry no secret…
     const parsed = JSON.parse(out.stdout);
     expect(parsed.botmuxPreset).toBe(1);
     expect(parsed.teamRole).toContain('INTERNAL_NOTE_xyz');
     expect(out.stdout).not.toContain(SECRET);
-    // the human hint is on stderr, keeping stdout clean.
+    // …and nothing but JSON: the human hint must be on stderr, not stdout.
+    expect(out.stdout.trimStart().startsWith('{')).toBe(true);
+    expect(out.stdout).not.toContain('不含任何密钥');
     expect(out.stderr).toContain('不含任何密钥');
+  });
+
+  it('bare shell (no SESSION_DATA_DIR) reads role/capability from the default data dir', () => {
+    const out = runCliBare(['preset', 'export', APP_BARE, '--out', '-', '--yes']);
+    expect(out.status).toBe(0);
+    const parsed = JSON.parse(out.stdout);
+    // Proves resolveDataDir() → default dir AND the lazy getter is read live:
+    // without the fix, config.session.dataDir would stay the packaged default
+    // and these would be silently absent.
+    expect(parsed.teamRole).toContain('BARE_SHELL_ROLE_marker');
+    expect(parsed.capability).toBe('裸终端能力');
   });
 
   it('non-TTY without --yes fails fast (does not block on a prompt)', () => {


### PR DESCRIPTION

## 背景 / 动机
有时想复用别人调好的 agent（CLI 选型 / 模型 / 角色人设 / 能力标签），但要跑在自己的飞书应用和模型上。`bots.json` 里大多是密钥和本地路径、不可分享，真正可分享的人设/能力又分散在 `team-roles/`、`bot-profiles/`。本 PR 把这些"可安全分享"的部分导出成一个**不含任何密钥**的预设 JSON。

本 PR **只做 `export`**：导出物交给接收方的 agent 去帮他配置自己的 bot（见预设内嵌的 `guide` 字段）。

## 改动
- 新增子命令 `botmux preset export <bot> [--from-chat <chatId>] [--out <file>] [--yes]`
- 新增 `src/setup/agent-preset.ts`：`buildPreset`（白名单组装，**绝不展开输入**，结构上不可能带出密钥）/ `serializePreset` / `loadPreset`（zod 校验，留给将来的 import 工具）+ 给接收方 agent 的内嵌中文 `guide`
- `src/config.ts`：`session.dataDir` 改为惰性 getter，使 CLI 子命令在导入后设置的 `SESSION_DATA_DIR` 能被 `resolveTeamRoleFile` / `getBotCapability` 正确读到

## 安全
- 白名单导出：预设只含 `cliId / model / teamRole / capability / sourceName / guide`，**永不含** `larkAppId / larkAppSecret / allowedUsers / allowedChatGroups / oncallChats / workingDir`
- 导出前打印角色内容供确认（`--yes` 跳过；非 TTY 缺 `--yes` 直接报错、不阻塞，保证可脚本化）
- `--out -` 时 stdout 只输出 JSON，提示一律走 stderr

## 用法
- `botmux preset export claude-main` — 交互确认后写 `./claude-main.botmux-preset.json`
- `botmux preset export claude-main --out -` — 打到 stdout（脚本用，配 `--yes`）
- `botmux preset export claude-main --from-chat oc_xxx` — 导出某群的角色内容

## Test plan
- [x] `pnpm build` 通过（无类型错误）
- [x] 新增测试全绿（29 例）：
  - `test/agent-preset.test.ts`：白名单 / 防密钥泄漏（喂完整含密钥配置仍不漏值）/ 版本+guide / serialize↔load round-trip / 坏 JSON 与错版本拒绝
  - `test/preset-export-cli.test.ts`：CLI 边界（默认文件名 slug 化、`--out -` 只输出 JSON、非 TTY 无 `--yes` 快速失败、空角色 exit 0、`--from-chat`/`--out` 缺值报错、裸终端读默认数据目录）
  - `test/config-data-dir.test.ts`：惰性 getter