### PR TITLE
fix(lark): oncall talk 权限按接收 bot 隔离

### DIFF
--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -271,12 +271,12 @@ export function findOncallChat(larkAppId: string, chatId: string): OncallChat | 
   return bot?.config.oncallChats?.find(c => c.chatId === chatId);
 }
 
-// Cross-bot oncall chat check — cached by config-file mtime.
+// Cross-bot oncall chat discovery — cached by config-file mtime.
 //
-// /oncall bind is per-bot, but oncall is meant to be a chat-level property:
-// once any bot in a multi-bot deployment binds the chat, every sibling bot
-// should treat that chat as an oncall workspace too (otherwise unbound bots
-// fall back to allowedUsers and reply "⚠️ 无操作权限" when @-mentioned).
+// /oncall bind is per-bot for talk authorization: receiving-bot gates must use
+// findOncallChat(larkAppId, chatId). This cross-bot lookup remains for paths
+// that need deployment-wide discovery/inheritance, such as pinned working-dir
+// resolution and default-oncall checks.
 //
 // Multi-daemon deployments run one bot per process, so the in-memory `bots`
 // map only sees this daemon's own bot — sibling bots' bindings live only on

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -6,7 +6,7 @@
 import * as Lark from '@larksuiteoapi/node-sdk';
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { getBot, getAllBots, isChatOncallBoundForAnyBot, getOwnerOpenId, type BotState } from '../../bot-registry.js';
+import { getBot, getAllBots, findOncallChat, getOwnerOpenId, type BotState } from '../../bot-registry.js';
 import { config } from '../../config.js';
 import { getChatInfo, getChatMode, listChatBotMembers, replyMessage, sendUserMessage, isHumanOpenId } from './client.js';
 import { logger } from '../../utils/logger.js';
@@ -519,13 +519,13 @@ export function isBotMentioned(larkAppId: string, message: any, _senderOpenId: s
 //                slash commands like /cd /restart /close /oncall)
 //
 // Non-oncall chats: both fall back to the bot's allowedUsers.
-// Oncall-bound chats: talking is open to everyone in the group; operating
-// still requires allowedUsers (single source of truth — no per-chat owners).
+// Oncall-bound chats for the receiving bot: talking is open to everyone in the
+// group; operating still requires allowedUsers (single source of truth — no
+// per-chat owners).
 //
-// Oncall is a chat-level concept: `isChatOncallBoundForAnyBot` returns true
-// when ANY bot (this one or a sibling in another daemon) has the chat bound,
-// so an unbound sibling doesn't fall back to allowedUsers and reply
-// "⚠️ 无操作权限" when @-mentioned in a shared oncall workspace.
+// Oncall talk access is bot-scoped. Binding Bot A to a chat does not relax talk
+// access for sibling Bot B in the same deployment; Bot B must bind the same chat
+// itself, or continue using its own allowedUsers/chatGrants/globalGrants.
 
 export type TalkReason =
   | 'allowedUser'
@@ -579,7 +579,7 @@ export function evaluateTalk(larkAppId: string, chatId: string | undefined, send
   // 成员关系隐含在"能在该 chat 发言"里 —— 退群者发不了言自动失权，新人进群即生效，无需成员快照。
   const allowedUsers = bot.resolvedAllowedUsers;
   if (senderOpenId && allowedUsers.includes(senderOpenId)) return { allowed: true, reason: 'allowedUser' };
-  if (chatId && isChatOncallBoundForAnyBot(chatId)) return { allowed: true, reason: 'oncall' };
+  if (chatId && findOncallChat(larkAppId, chatId)) return { allowed: true, reason: 'oncall' };
   if (isKnownPeerBot(config.session.dataDir, larkAppId, senderOpenId)) return { allowed: true, reason: 'peer' };
   if (chatId && bot.config.allowedChatGroups?.includes(chatId)) return { allowed: true, reason: 'allowedChatGroup' };
 
@@ -946,15 +946,17 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
           // 对外部 bot 恒为 false——这跟 /introduce 是两套独立存储：/introduce 写的是
           // observed-bots-store，只负责让发送方"发现并能 @ 到"对方，过不了这道接收闸。
           //
-          // Oncall 群是显式部署的协作工作区，canTalk 已对任何成员（含真人）放行；这里
-          // 对 bot 同等放行，跳过 cross-ref vetting。否则 oncall 群里外部 bot 互相 @
-          // 会被静默丢弃、只有真人能拉起会话，与 oncall「全员可对话」语义不符。
+          // Oncall 群是当前接收 bot 显式部署的协作工作区，canTalk 已对任何成员
+          // （含真人）放行；这里对 bot 同等放行，跳过 cross-ref vetting。否则本
+          // bot 已绑定的 oncall 群里外部 bot 互相 @ 会被静默丢弃、只有真人能拉起会话。
+          // 注意 oncall talk access 是 bot-scoped：一个 bot 的 /oncall bind 不会放开
+          // sibling bot 的 talk 权限；如果 sibling bot 也要开放，需要自己绑定同一个 chat。
           //
           // owner 还可用 `/grant @bot` 把外部 bot 加进本群 chatGrants（与真人 /grant
           // 同一存储、同一 per-chat 语义）。命中 chatGrants 的 bot 即便不在 cross-ref，
           // 也与已注册 peer 同等放行——这是「授权外部 bot 在本群协作」的入口。
           // 全局授权（globalGrants）同理：命中即在任意群放行，是上面的全局版。
-          if (ctx.scope === 'chat' && !isChatOncallBoundForAnyBot(chatId)) {
+          if (ctx.scope === 'chat' && !findOncallChat(larkAppId, chatId)) {
             const ownsSession = handlers.isSessionOwner?.(ctx.anchor, larkAppId) ?? false;
             if (!ownsSession
                 && !isKnownPeerBot(config.session.dataDir, larkAppId, senderOpenId)

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -31,9 +31,11 @@ vi.mock('node:fs', async (importOriginal) => {
 const mockGetBot = vi.fn();
 const mockGetAllBots = vi.fn(() => []);
 const mockIsChatOncallBoundForAnyBot = vi.fn<(chatId: string) => boolean>(() => false);
+const mockFindOncallChat = vi.fn<(larkAppId: string, chatId: string) => { chatId: string; workingDir: string } | undefined>(() => undefined);
 vi.mock('../src/bot-registry.js', () => ({
   getBot: (...args: any[]) => mockGetBot(...args),
   getAllBots: () => mockGetAllBots(),
+  findOncallChat: (...args: any[]) => mockFindOncallChat(...(args as [string, string])),
   isChatOncallBoundForAnyBot: (...args: any[]) => mockIsChatOncallBoundForAnyBot(...(args as [string])),
 }));
 
@@ -252,6 +254,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     setupBotState();
     handlers = makeHandlers();
     mockIsChatOncallBoundForAnyBot.mockReturnValue(false);
+    mockFindOncallChat.mockReturnValue(undefined);
     startLarkEventDispatcher(MY_APP_ID, 'secret', handlers);
   });
 
@@ -529,14 +532,15 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
   });
 
   it('routes unknown-peer cross-bot @mention in oncall chat-scope (auto-create, no /introduce needed)', async () => {
-    // oncall 群是显式部署的协作工作区：canTalk 已对真人全员放行，bot→bot 接收侧
-    // 同等放行 —— 即使发送方不在 cross-ref（isKnownPeerBot=false），oncall 也跳过
-    // 这道 vetting，让外部 bot 直接拉起 chat-scope session。对照上面的非 oncall
-    // 用例：同样的 unknown peer 会被 drop。
+    // oncall 群是当前接收 bot 显式绑定的协作工作区：canTalk 已对真人全员放行，
+    // bot→bot 接收侧同等放行 —— 即使发送方不在 cross-ref（isKnownPeerBot=false），
+    // 也跳过这道 vetting，让外部 bot 直接拉起 chat-scope session。对照上面的非
+    // oncall 用例：同样的 unknown peer 会被 drop。
     // 注意 /introduce 写的是 observed-bots-store（发现/能 @ 到对方），跟这道接收侧
     // cross-ref vetting 是两套独立存储，不是这里放行的前提。
     mockGetChatMode.mockResolvedValueOnce('group');
     mockIsChatOncallBoundForAnyBot.mockReturnValue(true);
+    mockFindOncallChat.mockReturnValue({ chatId: 'chat-001', workingDir: '/repo' });
     mockReadFileSync.mockReturnValue('{}');  // empty cross-ref → unknown peer
     const event = makeBotMessageEvent({
       senderOpenId: OTHER_BOT_OPEN_ID,
@@ -566,6 +570,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     // 消息仍在 self 分支被 drop，不会因为 oncall 而被路由。
     // （self 非 /close 在 decideRouting 之前就 return，故无需 stub getChatMode。）
     mockIsChatOncallBoundForAnyBot.mockReturnValue(true);
+    mockFindOncallChat.mockReturnValue({ chatId: 'chat-001', workingDir: '/repo' });
     const event = makeBotMessageEvent({
       senderOpenId: MY_OPEN_ID,  // own message
       content: JSON.stringify({ text: 'I just finished the task' }),
@@ -584,6 +589,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     // 镜像上一条：oncall 不应改变 self /close 的既有行为 —— 精确 /close 仍进入
     // handleThreadReply 走关闭流程。
     mockIsChatOncallBoundForAnyBot.mockReturnValue(true);
+    mockFindOncallChat.mockReturnValue({ chatId: 'chat-001', workingDir: '/repo' });
     const event = makeBotMessageEvent({
       senderOpenId: MY_OPEN_ID,  // own message
       content: JSON.stringify({ text: '/close' }),
@@ -600,19 +606,18 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     }));
   });
 
-  it('treats oncall as chat-level: relaxes canTalk even when THIS bot is not the one bound', async () => {
-    // Regression: /oncall bind is per-bot, but oncall is meant to be a
-    // chat-level concept. In multi-bot deployments the user often only binds
-    // one bot — sibling bots used to fall back to allowedUsers and reply
-    // "⚠️ 无操作权限" when @-mentioned by anyone outside the allowlist.
-    // isChatOncallBoundForAnyBot now answers true if ANY bot has the chat
-    // bound, so unbound siblings join the relaxed talking gate too.
+  it('keeps sibling oncall bindings from relaxing this bot canTalk', async () => {
+    // /oncall bind is bot-scoped. If Bot A binds this chat, Bot B still uses
+    // Bot B's own allowedUsers/chatGrants/globalGrants until Bot B also binds
+    // the same chat. Cross-bot oncall discovery may still report the chat as
+    // bound somewhere, but that must not open talk access for this receiver.
     mockGetChatMode.mockResolvedValueOnce('topic');
     mockIsChatOncallBoundForAnyBot.mockReturnValue(true);
+    mockFindOncallChat.mockReturnValue(undefined);
     mockGetBot.mockReturnValue({
       config: { larkAppId: MY_APP_ID, larkAppSecret: 'secret', cliId: 'claude-code' },
       botOpenId: MY_OPEN_ID,
-      resolvedAllowedUsers: ['ou_some_other_human'],
+      resolvedAllowedUsers: ['ou_allowed_sibling'],
     });
     const event = makeUserMessageEvent({
       senderOpenId: USER_OPEN_ID, // NOT in allowedUsers
@@ -626,11 +631,9 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     await capturedHandlers['im.message.receive_v1'](event);
     await new Promise(r => setTimeout(r, 0));
 
-    expect(handlers.handleNewTopic).toHaveBeenCalledWith(event, expect.objectContaining({
-      anchor: 'msg-oncall-sibling',
-      scope: 'thread',
-      larkAppId: MY_APP_ID,
-    }));
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+    expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+    expect(canTalk(MY_APP_ID, 'chat-oncall-sibling', 'ou_allowed_sibling')).toBe(true);
   });
 
   it('allows ordinary talk for any sender when the current chat is in allowedChatGroups', () => {

--- a/test/grant-gates.test.ts
+++ b/test/grant-gates.test.ts
@@ -52,6 +52,29 @@ describe('grant gates', () => {
     expect(evaluateTalk('g1', 'oc_oncall_quota', 'ou_guest')).toEqual({ allowed: true, reason: 'oncall' });
   });
 
+  it('scopes oncall talk access to the bot that owns the binding', () => {
+    const botA = registerBot({
+      larkAppId: 'oncall_scope_a',
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: ['ou_owner_a'],
+      oncallChats: [{ chatId: 'oc_shared_oncall', workingDir: '/repo/a' }],
+    });
+    botA.resolvedAllowedUsers = ['ou_owner_a'];
+
+    const botB = registerBot({
+      larkAppId: 'oncall_scope_b',
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: ['ou_owner_b'],
+    });
+    botB.resolvedAllowedUsers = ['ou_owner_b'];
+
+    expect(canTalk('oncall_scope_a', 'oc_shared_oncall', 'ou_external')).toBe(true);
+    expect(canTalk('oncall_scope_b', 'oc_shared_oncall', 'ou_external')).toBe(false);
+    expect(canTalk('oncall_scope_b', 'oc_shared_oncall', 'ou_owner_b')).toBe(true);
+  });
+
   it('evaluateTalk prefers chat grant over global grant and emits a chat quota key', () => {
     expect(evaluateTalk('g1', 'oc_1', 'ou_both')).toEqual({
       allowed: true,


### PR DESCRIPTION
## 背景 / 现象

botmux 支持在同一部署里运行多个 Lark bot。每个 bot 都有自己的 `allowedUsers`、`chatGrants` / `globalGrants` 和 `oncallChats`，因此 `/oncall bind` 的 talk 放行也应该按 bot 隔离。

当前 `evaluateTalk()` 的 oncall 判断用了 `isChatOncallBoundForAnyBot(chatId)`：只要同部署里任意一个 bot 绑定了某个 oncall 群，当前接收消息的 bot 就会把这个群视为 oncall 并放开 talk。

这会导致多 bot 部署下的权限串扰：

- Bot A 绑定了 `oc_xxx` 作为 oncall 群
- Bot B 没有绑定 `oc_xxx`，并且有自己的 `allowedUsers` / grants 限制
- 外部用户在 `oc_xxx` 里 @ Bot B 时，Bot B 也会因为 Bot A 的 oncall 绑定而通过 `canTalk`

结果是 Bot A 的 oncall 配置放开了 sibling Bot B 的 talk 权限，绕过了 Bot B 自己的 `allowedUsers`、`chatGrants`、`globalGrants`。

## 根因

`isChatOncallBoundForAnyBot()` / `findOncallChatForAnyBot()` 是跨 bot discovery：它会查当前 bot，也会从共享 `bots.json` 里发现 sibling bot 的 oncall 绑定。

这个跨 bot lookup 适合用于部署级发现/继承场景，例如 pinned working dir、default-oncall 之类；但把它放进 talk 授权闸门后，就把 per-bot 的 `/oncall bind` 语义扩大成了 deployment-wide talk 放行。

同样的问题也存在于 foreign bot @mention 的 chat-scope fast path：外部 bot 只要命中任意 sibling 的 oncall 绑定，就能跳过接收侧的 peer / grant vetting。

## 修复

- `src/im/lark/event-dispatcher.ts` 改为 import `findOncallChat`
- `evaluateTalk(larkAppId, chatId, senderOpenId)` 中，oncall talk gate 改成 `findOncallChat(larkAppId, chatId)`
- foreign bot @mention 的 chat-scope gate 同步改成按接收 bot 查 `findOncallChat(larkAppId, chatId)`
- 更新相邻注释，明确 oncall talk access 是 bot-scoped：一个 bot 的 `/oncall bind` 不会放开 sibling bot；如果 sibling bot 也要开放，需要自己绑定同一个 chat
- 保留 `findOncallChatForAnyBot()` / `isChatOncallBoundForAnyBot()`，因为其他路径仍需要跨 bot oncall discovery

## 回归覆盖

新增/更新测试覆盖这个权限边界：

- 注册两个 bot，只有 Bot A 绑定 `oc_shared_oncall`
- 外部用户在该 chat 中 `canTalk(A) === true`
- 同一个外部用户对未绑定该 chat 的 Bot B：`canTalk(B) === false`
- Bot B 的 allowed user 仍然 `canTalk(B) === true`
- event dispatcher 的 sibling oncall 场景不再触发 Bot B 的 routing

## 验证

- [x] `pnpm vitest run test/grant-gates.test.ts test/event-dispatcher.test.ts`：87 tests 通过
- [x] `pnpm vitest run test/event-dispatcher.test.ts test/grant-gates.test.ts test/bot-registry.test.ts`：123 tests 通过
- [x] `pnpm build`：通过

## 影响范围

只收紧 oncall talk 授权和 foreign bot chat-scope gate 的接收侧判断。

跨 bot oncall discovery 函数仍保留，其他需要 deployment-wide discovery 的代码路径不受影响。
