### PR TITLE
feat(lark): 群级不出卡 + reaction 表状态，/card off|on（叠加 master 的 disableStre…

### DIFF
--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -130,6 +130,8 @@ export interface BotConfig {
    * (undefined) keeps the streaming card. For users who find the live card noisy.
    */
   disableStreamingCard?: boolean;
+  /** chat_id list: chats where the live streaming card is suppressed (status falls back to master's pending-card morph). Written by `/card off|on`. */
+  noCardChats?: string[];
   /**
    * When true, the streaming card embeds a directly-usable WRITABLE terminal
    * link in its body (token included → anyone who can see the card can drive
@@ -570,6 +572,9 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
       // means "use default botmux brand". Don't trim-to-undefined here.
       brandLabel: typeof entry.brandLabel === 'string' ? entry.brandLabel : undefined,
       disableStreamingCard: entry.disableStreamingCard === true || undefined,
+      noCardChats: Array.isArray(entry.noCardChats)
+        ? entry.noCardChats.filter((x: any): x is string => typeof x === 'string' && x.trim().length > 0).map((x: string) => x.trim())
+        : undefined,
       writableTerminalLinkInCard: entry.writableTerminalLinkInCard === true || undefined,
       privateCard: entry.privateCard === true || undefined,
       autoStartOnGroupJoin: entry.autoStartOnGroupJoin === true || undefined,

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -6,7 +6,7 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { join, resolve, basename } from 'node:path';
 import { config } from '../config.js';
 import { buildTerminalUrl } from './terminal-url.js';
-import { getBot, getAllBots, getBotOpenId } from '../bot-registry.js';
+import { getBot, getAllBots, getBotOpenId, getOwnerOpenId } from '../bot-registry.js';
 import * as sessionStore from '../services/session-store.js';
 import * as scheduleStore from '../services/schedule-store.js';
 import * as scheduler from './scheduler.js';
@@ -24,6 +24,7 @@ import { discoverAdoptableZellijSessions, validateZellijAdoptTarget, type Zellij
 import { listCodexAppThreads, type CodexAppThreadSummary } from '../services/codex-app-threads.js';
 import { generateAuthUrl, getTokenStatus } from '../utils/user-token.js';
 import { bindOncall, unbindOncall, getOncallStatus } from '../services/oncall-store.js';
+import { setCardMode } from '../services/card-mode-store.js';
 import { invalidWorkingDirs } from '../utils/working-dir.js';
 import { writeRoleFile, deleteRoleFile, resolveRole, resolveTeamRoleFile, writeTeamRoleFile, deleteTeamRoleFile } from './role-resolver.js';
 import { getBotCapability, setBotCapability, clearBotCapability } from '../services/bot-profile-store.js';
@@ -487,6 +488,86 @@ async function handleScheduleCommand(
 }
 
 // ─── Main command handler ────────────────────────────────────────────────────
+
+/**
+ * Handle `/card` (owner-only). Resolves the active session itself, so off/on
+ * work WITHOUT one -- they only toggle the per-chat `noCardChats` config. A
+ * summon (show/bare) needs a live session.
+ *
+ * off  -> suppress the live streaming card for this chat (add to noCardChats);
+ *         status falls back to master's pending-card morph.
+ * on   -> restore cards for this chat (remove from noCardChats).
+ * ''/show -> summon a live card. privateCard -> private ephemeral snapshot
+ *         (fail closed on non-group); otherwise a group-visible live card.
+ * off/on also clear `streamingCardForced` so a prior summon does not
+ * short-circuit `streamingCardDisabled()`.
+ */
+export async function handleCardCommand(
+  rootId: string,
+  larkAppId: string,
+  chatId: string,
+  senderOpenId: string | undefined,
+  content: string,
+  deps: CommandHandlerDeps,
+): Promise<void> {
+  const loc = localeForBot(larkAppId);
+  const reply = (c: string) => deps.sessionReply(rootId, c, undefined, larkAppId);
+
+  const ownerOpenId = getOwnerOpenId(larkAppId);
+  if (!ownerOpenId || !senderOpenId || senderOpenId !== ownerOpenId) {
+    await reply(t('cmd.card.owner_only', undefined, loc));
+    return;
+  }
+
+  const ds = deps.activeSessions.get(sessionKey(rootId, larkAppId));
+  const sub = content.replace(/^\/card\s*/i, '').trim().toLowerCase();
+
+  if (sub === 'off') {
+    const r = await setCardMode(larkAppId, chatId, true);
+    if (ds) ds.streamingCardForced = undefined;
+    await reply(r.ok ? t('cmd.card.off_ok', undefined, loc) : t('cmd.card.fail', { reason: r.reason }, loc));
+    return;
+  }
+  if (sub === 'on') {
+    const r = await setCardMode(larkAppId, chatId, false);
+    if (ds) ds.streamingCardForced = undefined;
+    await reply(r.ok ? t('cmd.card.on_ok', undefined, loc) : t('cmd.card.fail', { reason: r.reason }, loc));
+    return;
+  }
+  if (sub === '' || sub === 'show') {
+    if (!ds) {
+      await reply(t('cmd.no_active_session', undefined, loc));
+      return;
+    }
+    if (getBot(ds.larkAppId).config.privateCard) {
+      const mode = await getChatModeStrict(ds.larkAppId, ds.chatId);
+      if (mode !== 'group') {
+        await reply(t('cmd.card.private_not_group', undefined, loc));
+        return;
+      }
+      const audience = resolvePrivateCardAudience(ds);
+      if (audience.length === 0) {
+        await reply(t('cmd.card.private_no_audience', undefined, loc));
+        return;
+      }
+      const r = await postPrivateSnapshotCard(ds, audience);
+      if (r.notReady) {
+        await reply(t('cmd.card.private_not_ready', undefined, loc));
+      } else if (r.sent === 0) {
+        await reply(t('cmd.card.private_failed', undefined, loc));
+      } else if (r.sent < r.total) {
+        await reply(t('cmd.card.private_partial', { sent: r.sent, total: r.total }, loc));
+      }
+      return;
+    }
+    ds.streamingCardForced = true;
+    const posted = await postFreshStreamingCard(ds, deps.sessionReply);
+    if (!posted) await reply(t('cmd.card.not_ready', undefined, loc));
+    return;
+  }
+
+  await reply(t('cmd.card.usage', undefined, loc));
+}
 
 export async function handleCommand(
   cmd: string,
@@ -1622,53 +1703,16 @@ export async function handleCommand(
       }
 
       case '/card': {
-        if (!ds) {
+        // Existing-session path. New topics route /card via handleCardCommand at
+        // the router (so no phantom session is created). off/on work without a
+        // live worker; show/bare summons a card.
+        const appId = ds?.larkAppId ?? larkAppId;
+        const cardChatId = ds?.chatId;
+        if (!appId || !cardChatId) {
           await sessionReply(rootId, t('cmd.no_active_session', undefined, loc));
           break;
         }
-        // Private mode (`privateCard`): send a one-shot snapshot only to the
-        // explicit talk-grant audience via the ephemeral API, instead of the
-        // group-visible live card. Ephemeral cards only work in plain `group`
-        // chats and can't be patched — so no live updates, and we fail closed
-        // (never fall back to a group-visible card) since not leaking is the
-        // entire point of this mode.
-        if (getBot(ds.larkAppId).config.privateCard) {
-          // Strict gate: only a *confirmed* plain group is safe — getChatModeStrict
-          // returns 'unknown' on API error instead of guessing 'group', so we fail
-          // closed (no leak) when we can't verify the chat type.
-          const mode = await getChatModeStrict(ds.larkAppId, ds.chatId);
-          if (mode !== 'group') {
-            await sessionReply(rootId, t('cmd.card.private_not_group', undefined, loc));
-            break;
-          }
-          const audience = resolvePrivateCardAudience(ds);
-          if (audience.length === 0) {
-            await sessionReply(rootId, t('cmd.card.private_no_audience', undefined, loc));
-            break;
-          }
-          const r = await postPrivateSnapshotCard(ds, audience);
-          if (r.notReady) {
-            await sessionReply(rootId, t('cmd.card.private_not_ready', undefined, loc));
-          } else if (r.sent === 0) {
-            // Total failure — surface a non-sensitive error (no terminal content,
-            // no open_id list). Most likely cause: missing send permission / bot
-            // not in chat / topic-thread chat.
-            await sessionReply(rootId, t('cmd.card.private_failed', undefined, loc));
-          } else if (r.sent < r.total) {
-            // Partial — report counts only, never the audience identities.
-            await sessionReply(rootId, t('cmd.card.private_partial', { sent: r.sent, total: r.total }, loc));
-          }
-          break;
-        }
-        // Manual summon. Force the live card on for the rest of this session —
-        // even when the bot has `disableStreamingCard` set — then post a fresh
-        // card. If the worker terminal isn't up yet, the force flag still sticks
-        // so the card appears (and live-updates) as soon as the worker is ready.
-        ds.streamingCardForced = true;
-        const posted = await postFreshStreamingCard(ds, deps.sessionReply);
-        if (!posted) {
-          await sessionReply(rootId, t('cmd.card.not_ready', undefined, loc));
-        }
+        await handleCardCommand(rootId, appId, cardChatId, message.senderId, message.content, deps);
         break;
       }
 

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -140,7 +140,11 @@ export function isRelayableRealSession(ds: DaemonSession): boolean {
 // per-session via `ds.streamingCardForced` (manually summon a live card).
 function streamingCardDisabled(ds: DaemonSession): boolean {
   if (ds.streamingCardForced) return false;
-  try { return getBot(ds.larkAppId).config.disableStreamingCard === true; } catch { return false; }
+  try {
+    const cfg = getBot(ds.larkAppId).config;
+    return cfg.disableStreamingCard === true
+      || (!!ds.chatId && !!cfg.noCardChats?.includes(ds.chatId));
+  } catch { return false; }
 }
 
 // Per-bot opt-in: the writable terminal link to embed directly in the streaming

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -53,7 +53,7 @@ import {
 } from './core/worker-pool.js';
 import { ipcRoute, jsonRes, readJsonBody, setBotName, setLarkAppId, startIpcServer, setWorkflowRunner } from './core/dashboard-ipc-server.js';
 import { saveFrozenCards, deleteFrozenCards } from './services/frozen-card-store.js';
-import { DAEMON_COMMANDS, SESSIONLESS_DAEMON_COMMANDS, PASSTHROUGH_COMMANDS, handleCommand, parseSlashCommandInvocation, parseForceTopicInvocation } from './core/command-handler.js';
+import { DAEMON_COMMANDS, SESSIONLESS_DAEMON_COMMANDS, PASSTHROUGH_COMMANDS, handleCommand, handleCardCommand, parseSlashCommandInvocation, parseForceTopicInvocation } from './core/command-handler.js';
 import type { CommandHandlerDeps } from './core/command-handler.js';
 import { findInheritablePeer } from './core/inherit-peer.js';
 import { isCallbackUrl, handleCallbackUrl } from './utils/user-token.js';
@@ -287,7 +287,11 @@ const pendingResponseQueue = createPendingResponseQueue();
 
 function streamingCardDisabledFor(ds: DaemonSession): boolean {
   if (ds.streamingCardForced) return false;
-  try { return getBot(ds.larkAppId).config.disableStreamingCard === true; } catch { return false; }
+  try {
+    const cfg = getBot(ds.larkAppId).config;
+    return cfg.disableStreamingCard === true
+      || (!!ds.chatId && !!cfg.noCardChats?.includes(ds.chatId));
+  } catch { return false; }
 }
 
 function readSessionFreshFromDisk(sessionId: string, larkAppId: string): import('./types.js').Session | undefined {
@@ -1372,6 +1376,10 @@ function getActiveCount(): number {
  * sees no visible response.
  */
 function beginNewTurn(ds: DaemonSession, title: string): void {
+  // `/card` summon is one-shot: it forces a live card only for the turn it ran
+  // in. A new turn returns to the config default (noCardChats / disableStreamingCard).
+  // Use `/card on` to persistently restore cards for the chat.
+  ds.streamingCardForced = undefined;
   const previousUsageLimit = ds.usageLimit;
   const previousStatus = ds.lastScreenStatus === 'limited' && previousUsageLimit ? 'limited' : 'idle';
   if (ds.streamCardId && ds.workerPort) {
@@ -1949,6 +1957,13 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
     const restrictedText = grantRestrictedSlashCommandText(larkAppId, chatId, senderOpenId, cmd);
     if (restrictedText) {
       await sessionReply(anchor, restrictedText, 'text', larkAppId);
+      return;
+    }
+    // /card needs no fresh session: off/on only toggle per-chat config, and a
+    // summon has nothing to show in a brand-new topic. Route here so the generic
+    // daemon-command block below does not pre-create a worker=null session.
+    if (cmd === '/card') {
+      await handleCardCommand(anchor, larkAppId, chatId, senderOpenId, commandContent, commandDeps);
       return;
     }
     if (PASSTHROUGH_COMMANDS.has(cmd)) {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -159,6 +159,11 @@ export const messages: Record<string, string> = {
 
   // ─── Command responses ───────────────────────────────────────────────────
   'cmd.no_active_session': 'No active session in this topic.',
+  'cmd.card.owner_only': '⚠️ Only the bot owner can use /card.',
+  'cmd.card.off_ok': '🔕 Streaming cards turned off for this chat; status now shows via the in-place pending card (no withdrawal). /card on to restore; /card summons a live card.',
+  'cmd.card.on_ok': '🔔 Streaming cards restored for this chat. The next status update posts a live card again.',
+  'cmd.card.fail': '⚠️ Operation failed: {reason}',
+  'cmd.card.usage': 'Usage: /card (summon) | /card off (suppress for this chat) | /card on (restore)',
   'cmd.card.not_ready': 'Terminal not ready yet — the streaming card will appear once the session is up.',
   'cmd.card.private_not_ready': '🔒 Terminal not ready yet — send /card again once the session is up.',
   'cmd.card.private_not_group': '🔒 Private cards only work in regular group chats — topic groups / DMs are unsupported (Feishu limitation).',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -162,6 +162,11 @@ export const messages: Record<string, string> = {
 
   // ─── Command responses ───────────────────────────────────────────────────
   'cmd.no_active_session': '当前话题没有活跃的会话。',
+  'cmd.card.owner_only': '⚠️ 仅 bot 主人可以使用 /card。',
+  'cmd.card.off_ok': '🔕 已关闭本群流式卡片，状态改用「处理中卡片」原地更新（不撤回）。/card on 恢复出卡；/card 可临时召唤一张实时卡。',
+  'cmd.card.on_ok': '🔔 已恢复本群流式卡片。下条状态起重新出实时卡。',
+  'cmd.card.fail': '⚠️ 操作失败：{reason}',
+  'cmd.card.usage': '用法：/card（召唤实时卡）| /card off（本群关流式卡）| /card on（恢复出卡）',
   'cmd.card.not_ready': '终端尚未就绪，等会话起好后流式卡片会自动出现。',
   'cmd.card.private_not_ready': '🔒 终端尚未就绪，等会话起好后再发一次 /card。',
   'cmd.card.private_not_group': '🔒 私密卡片仅支持普通群聊，话题群 / 单聊无法发送（飞书限制）。',

--- a/src/services/card-mode-store.ts
+++ b/src/services/card-mode-store.ts
@@ -1,0 +1,51 @@
+/**
+ * Card-mode bindings — persist the per-chat "no streaming card" switch into the
+ * bot config JSON (`noCardChats`) and keep the in-memory BotConfig in sync so
+ * events pick up the change without a daemon restart.
+ *
+ * Mirrors oncall-store: every write goes through `rmwBotEntry` (file lock +
+ * read-modify-write against the latest on-disk snapshot) so concurrent daemon
+ * processes sharing one bots.json don't lose updates.
+ *
+ * Permission is enforced at the call site (`/card` is owner-only); this layer
+ * only persists.
+ */
+import { getBot } from '../bot-registry.js';
+import { rmwBotEntry } from './config-store.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Toggle the streaming-card switch for a chat. `off=true` suppresses cards
+ * (emoji-reaction mode); `off=false` restores them. `changed` reports whether
+ * the set actually moved (idempotent re-toggles return false).
+ */
+export async function setCardMode(
+  larkAppId: string,
+  chatId: string,
+  off: boolean,
+): Promise<{ ok: true; changed: boolean } | { ok: false; reason: string }> {
+  let bot;
+  try { bot = getBot(larkAppId); } catch { return { ok: false, reason: 'bot_not_registered' }; }
+
+  const r = await rmwBotEntry<{ changed: boolean }>(larkAppId, (entry) => {
+    const cur: string[] = Array.isArray(entry.noCardChats) ? entry.noCardChats : [];
+    const has = cur.includes(chatId);
+    const changed = off ? !has : has;
+    entry.noCardChats = off
+      ? (has ? cur : [...cur, chatId])
+      : cur.filter((c: string) => c !== chatId);
+    return { write: changed, result: { changed } };
+  });
+  if (!r.ok) return { ok: false, reason: r.reason };
+
+  // Keep in-memory config in sync.
+  const mem = (bot.config.noCardChats ??= []);
+  if (off) {
+    if (!mem.includes(chatId)) mem.push(chatId);
+  } else {
+    bot.config.noCardChats = mem.filter(c => c !== chatId);
+  }
+
+  logger.info(`[card-mode:${larkAppId}] chat=${chatId} off=${off} changed=${r.result.changed}`);
+  return { ok: true, changed: r.result.changed };
+}


### PR DESCRIPTION
## 做了什么
  飞书话题里关掉流式卡时不再发「处理中」占位卡（会被撤回，刷出「撤回了一条消息」），改成在触发消息上贴 emoji reaction
  表运行状态（干活中/完成/限流），彻底消除关卡场景的「撤回了一条消息」。

  ## 关键点
  - 新增按群粒度关卡 `noCardChats`（`/card off|on` 写回 bots.json），叠加在 bot 级 `disableStreamingCard` 之上
  - 关卡时用 `updateStatusReaction` 在用户消息上贴 emoji（5 状态收敛 3 桶 + 去抖）
  - 禁用 master 的 pending 占位卡（`PENDING_PLACEHOLDER_CARD_ENABLED=false`）—— 关卡场景真正零撤回
  - `/card` 召唤改为一次性（`beginNewTurn` 清 `streamingCardForced`），不再「召唤一次就一直出卡」；`/card on` 持久恢复
  - `/card` 三方合并：保留 master 的 privateCard 私密快照逻辑

  ## 验证
  - `tsc` 零错误；本地 build + daemon 实测：关卡群发消息贴 emoji、零撤回；`/card` 召唤一次性
  - Codex review：修了首轮 reaction 失效、owner 校验 fail-closed、reaction 缓存时序 + 跨回合 guard