### PR TITLE
fix(cli): cursor 适配器修复 sender open_id 泄漏进回复正文

### DIFF
--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -188,6 +188,20 @@ export function renderSenderTag(sender?: ResolvedSender): string {
   return `<sender ${attrs.join(' ')} />`;
 }
 
+/**
+ * cursor-agent's model tends to copy the inlined `<sender open_id="ou_xxx"
+ * name="高鹏" />` verbatim into its reply — it reads `open_id:name` as the
+ * `--mention <open_id:name>` form and leaks `ou_xxx:高鹏` into the `botmux
+ * send` body / opening line. Other CLIs haven't shown this, so the guard is
+ * scoped to cursor only (claude-code et al. that set injectsSessionContext
+ * never see this inline tag anyway). Returns '' for every other CLI and when
+ * there is no sender tag to misread.
+ */
+export function renderCursorSenderNote(cliId: CliId | undefined, hasSender: boolean, locale?: Locale): string {
+  if (cliId !== 'cursor' || !hasSender) return '';
+  return `<sender_note>${t('ai.cursor.sender_note', undefined, locale)}</sender_note>`;
+}
+
 export function formatAttachmentsHint(attachments?: LarkAttachment[], locale?: Locale): string {
   if (!attachments || attachments.length === 0) return '';
   let imgN = 0, fileN = 0;
@@ -281,6 +295,9 @@ export function buildNewTopicPrompt(
   const senderBlock = renderSenderTag(sender);
   if (senderBlock) parts.push(senderBlock);
 
+  const senderNote = renderCursorSenderNote(cliId, !!senderBlock, locale);
+  if (senderNote) parts.push(senderNote);
+
   const attachHint = formatAttachmentsHint(attachments, locale);
   if (attachHint) parts.push(attachHint);
 
@@ -312,6 +329,9 @@ export function buildFollowUpContent(
 
   const senderBlock = renderSenderTag(opts?.sender);
   if (senderBlock) parts.push(senderBlock);
+
+  const senderNote = renderCursorSenderNote(opts?.cliId, !!senderBlock, opts?.locale);
+  if (senderNote) parts.push(senderNote);
 
   const attachHint = opts?.attachments && opts.attachments.length > 0
     ? formatAttachmentsHint(opts.attachments, opts.locale)

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -202,6 +202,24 @@ export function renderCursorSenderNote(cliId: CliId | undefined, hasSender: bool
   return `<sender_note>${t('ai.cursor.sender_note', undefined, locale)}</sender_note>`;
 }
 
+/**
+ * Render a buffered follow-up's sender attribution for daemon's pending-repo
+ * branch (handleThreadReply), where a cross-user follow-up's `<sender>` tag is
+ * prepended OUTSIDE the builder and later folds into the opening
+ * `<user_message>`. Pair the tag with the cursor anti-echo note so a folded-in
+ * foreign sender gets the same protection the builder gives its own top-level
+ * `<sender>`; otherwise an inline `ou_xxx:name` reaches cursor with no adjacent
+ * note (the builder's note only covers `ds.pendingSender`'s top-level tag, and
+ * may be absent entirely when pendingSender is undefined). Returns '' when
+ * there is no sender to attribute.
+ */
+export function renderBufferedSenderBlock(sender: ResolvedSender | undefined, cliId: CliId | undefined, locale?: Locale): string {
+  const tag = renderSenderTag(sender);
+  if (!tag) return '';
+  const note = renderCursorSenderNote(cliId, true, locale);
+  return note ? `${tag}\n${note}` : tag;
+}
+
 export function formatAttachmentsHint(attachments?: LarkAttachment[], locale?: Locale): string {
   if (!attachments || attachments.length === 0) return '';
   let imgN = 0, fileN = 0;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -94,7 +94,7 @@ import { EventLog as WorkflowEventLog } from './workflows/events/append.js';
 import { replay as replayWorkflow } from './workflows/events/replay.js';
 import { isBotMentioned, probeBotOpenId, startLarkEventDispatcher, writeBotInfoFile, canOperate, evaluateTalk, grantCommandRestriction, isKnownPeerBot, checkRequiredScopes, type RoutingContext, type TalkEvaluation } from './im/lark/event-dispatcher.js';
 import { learnFromMentions, resolveSender, flushIdentityCacheSync } from './im/lark/identity-cache.js';
-import { renderSenderTag } from './core/session-manager.js';
+import { renderBufferedSenderBlock } from './core/session-manager.js';
 import { markSessionActivity } from './core/session-activity.js';
 import { WorkflowEventWatcher, handleWorkflowFanoutEvent } from './workflows/fanout.js';
 import type { WorkflowRuntimeContext, WorkerSpawnFn } from './workflows/runtime.js';
@@ -2626,8 +2626,15 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
     // tell multi-user buffered messages apart after repo selection unlocks.
     const followUpSender = await getThreadSender();
     if (followUpSender?.openId && followUpSender.openId !== ds.pendingSender?.openId) {
-      const followUpSenderTag = renderSenderTag(followUpSender);
-      if (followUpSenderTag) enriched = `${followUpSenderTag}\n${enriched}`;
+      // This buffer folds into the opening <user_message> after repo selection,
+      // so pair the foreign sender tag with the cursor anti-echo note: without
+      // the adjacent note a cursor session sees an inline ou_xxx:name with no
+      // guard (the builder's own note only covers ds.pendingSender's top-level
+      // tag, and is absent entirely when pendingSender is undefined).
+      const followUpSenderBlock = renderBufferedSenderBlock(
+        followUpSender, getBot(larkAppId).config.cliId, localeForBot(larkAppId),
+      );
+      if (followUpSenderBlock) enriched = `${followUpSenderBlock}\n${enriched}`;
     }
     if (!ds.pendingFollowUps) ds.pendingFollowUps = [];
     ds.pendingFollowUps.push(enriched);

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -345,6 +345,7 @@ export const messages: Record<string, string> = {
   'ai.identity.short_routing': 'Reminder: handing work off to another bot REQUIRES `botmux send --mention <their open_id>` — without it, the other bot is not triggered.',
   'ai.available_bots.hint': 'To hand work off to a bot listed here you MUST --mention its open_id (botmux send --mention ou_xxx ...). Without --mention the other bot receives nothing.',
   'ai.followup.reminder': 'Replies must go via `botmux send` — terminal output does not reach the user.',
+  'ai.cursor.sender_note': 'The sender tag is metadata identifying the current speaker — never copy its open_id or name (e.g. ou_xxx:Alice) into your botmux send body or opening line; to @ the triggerer use botmux send --mention-back.',
   'ai.bridge.attachments_label': '[Attachments]',
   'ai.bridge.mentions_label': '[@Mentions]',
   'schedule.title_prefix': '[Scheduled]',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -348,6 +348,7 @@ export const messages: Record<string, string> = {
   'ai.identity.short_routing': '提醒：让别的 bot 接力干活必须 `botmux send --mention <对方 open_id>`，否则对方 bot 不会被触发。',
   'ai.available_bots.hint': '让这里的某个 bot 接力干活必须 --mention 它的 open_id（botmux send --mention ou_xxx ...），不 --mention 对方 bot 完全收不到消息',
   'ai.followup.reminder': '回复必须 botmux send，终端输出用户看不到',
+  'ai.cursor.sender_note': 'sender 标签只是元信息（标识当前发言人），不要把其中的 open_id 或名字（例如 ou_xxx:高鹏）抄进 botmux send 的正文或开头；要 @ 回触发者请用 botmux send --mention-back。',
   'ai.bridge.attachments_label': '[附件]',
   'ai.bridge.mentions_label': '[@提及]',
   'schedule.title_prefix': '[定时]',

--- a/test/prompt-builder.test.ts
+++ b/test/prompt-builder.test.ts
@@ -56,7 +56,7 @@ vi.mock('../src/core/worker-pool.js', () => ({
 
 // ─── Imports ──────────────────────────────────────────────────────────────
 
-import { buildNewTopicPrompt, buildFollowUpContent, buildReforkPrompt, renderSenderTag, renderCursorSenderNote } from '../src/core/session-manager.js';
+import { buildNewTopicPrompt, buildFollowUpContent, buildReforkPrompt, renderSenderTag, renderCursorSenderNote, renderBufferedSenderBlock } from '../src/core/session-manager.js';
 import type { DaemonSession } from '../src/core/types.js';
 
 // ─── Tests ────────────────────────────────────────────────────────────────
@@ -380,6 +380,83 @@ describe('renderCursorSenderNote', () => {
 
   it('returns empty when cliId is undefined', () => {
     expect(renderCursorSenderNote(undefined, true)).toBe('');
+  });
+});
+
+// ─── renderBufferedSenderBlock — daemon pending-repo cross-user buffer ──────
+//
+// daemon.ts (handleThreadReply) prepends a foreign sender's <sender> tag to a
+// buffered follow-up OUTSIDE the builder; it later folds into the opening
+// <user_message>. For cursor the tag MUST carry an adjacent anti-echo note,
+// else a folded-in ou_xxx:name reaches cursor unguarded.
+
+describe('renderBufferedSenderBlock', () => {
+  const SENDER = { openId: 'ou_bob', type: 'user', name: 'Bob' } as const;
+
+  it('pairs the <sender> tag with an adjacent <sender_note> for cursor', () => {
+    const out = renderBufferedSenderBlock(SENDER, 'cursor');
+    expect(out).toContain('<sender type="user" open_id="ou_bob" name="Bob" />');
+    expect(out).toContain('<sender_note>');
+    // Note sits right after the tag so cursor reads them together.
+    expect(out.indexOf('<sender_note>')).toBeGreaterThan(out.indexOf('<sender '));
+  });
+
+  it('renders the bare <sender> tag (no note) for non-cursor CLIs', () => {
+    for (const cli of ['claude-code', 'codex', 'gemini', 'opencode', 'coco', 'aiden'] as const) {
+      const out = renderBufferedSenderBlock(SENDER, cli);
+      expect(out).toContain('open_id="ou_bob"');
+      expect(out).not.toContain('<sender_note>');
+    }
+  });
+
+  it('renders the bare <sender> tag when cliId is undefined', () => {
+    const out = renderBufferedSenderBlock(SENDER, undefined);
+    expect(out).toContain('open_id="ou_bob"');
+    expect(out).not.toContain('<sender_note>');
+  });
+
+  it('returns empty when there is no resolvable sender', () => {
+    expect(renderBufferedSenderBlock(undefined, 'cursor')).toBe('');
+    expect(renderBufferedSenderBlock({ openId: '', type: 'user' }, 'cursor')).toBe('');
+  });
+});
+
+// ─── buildNewTopicPrompt: buffered cursor follow-up keeps note inside body ──
+//
+// End-to-end shape: daemon hands buildNewTopicPrompt the buffered string
+// produced by renderBufferedSenderBlock; folding into <user_message> must
+// preserve the foreign sender's adjacent note (so ou_bob:Bob is guarded even
+// though it lives inside the body, not at the top level).
+
+describe('buildNewTopicPrompt cursor buffered multi-user follow-up', () => {
+  it('keeps the foreign sender note adjacent inside the folded <user_message>', () => {
+    const buffered = `${renderBufferedSenderBlock({ openId: 'ou_bob', type: 'user', name: 'Bob' }, 'cursor')}\nBob 的补充`;
+    const prompt = buildNewTopicPrompt(
+      '主消息（Alice）', 'sid', 'cursor',
+      undefined, undefined, undefined, undefined,
+      [buffered],
+      undefined, undefined,
+      { openId: 'ou_alice', type: 'user', name: 'Alice' },
+    );
+    const body = prompt.match(/<user_message>\n([\s\S]*?)\n<\/user_message>/)![1];
+    expect(body).toContain('open_id="ou_bob"');
+    expect(body).toContain('<sender_note>');
+    // Bob's inline tag is immediately followed by the note inside the body.
+    expect(body.indexOf('<sender_note>')).toBeGreaterThan(body.indexOf('open_id="ou_bob"'));
+  });
+
+  it('omits the buffered note for a codex session (bare foreign tag only)', () => {
+    const buffered = `${renderBufferedSenderBlock({ openId: 'ou_bob', type: 'user', name: 'Bob' }, 'codex')}\nBob 的补充`;
+    const prompt = buildNewTopicPrompt(
+      '主消息（Alice）', 'sid', 'codex',
+      undefined, undefined, undefined, undefined,
+      [buffered],
+      undefined, undefined,
+      { openId: 'ou_alice', type: 'user', name: 'Alice' },
+    );
+    const body = prompt.match(/<user_message>\n([\s\S]*?)\n<\/user_message>/)![1];
+    expect(body).toContain('open_id="ou_bob"');
+    expect(body).not.toContain('<sender_note>');
   });
 });
 

--- a/test/prompt-builder.test.ts
+++ b/test/prompt-builder.test.ts
@@ -56,7 +56,7 @@ vi.mock('../src/core/worker-pool.js', () => ({
 
 // ─── Imports ──────────────────────────────────────────────────────────────
 
-import { buildNewTopicPrompt, buildFollowUpContent, buildReforkPrompt, renderSenderTag } from '../src/core/session-manager.js';
+import { buildNewTopicPrompt, buildFollowUpContent, buildReforkPrompt, renderSenderTag, renderCursorSenderNote } from '../src/core/session-manager.js';
 import type { DaemonSession } from '../src/core/types.js';
 
 // ─── Tests ────────────────────────────────────────────────────────────────
@@ -199,6 +199,32 @@ describe('buildFollowUpContent', () => {
     expect(content).not.toContain('<botmux_reminder>');
     expect(content).not.toContain('botmux send');
   });
+
+  it('injects <sender_note> for cursor follow-ups carrying a sender', () => {
+    const content = buildFollowUpContent('hi', SESSION_ID, {
+      cliId: 'cursor',
+      sender: { openId: 'ou_gp', type: 'user', name: '高鹏' },
+    });
+    // The note must sit right after the <sender> tag so the model reads them together.
+    expect(content).toContain('<sender type="user" open_id="ou_gp" name="高鹏" />');
+    expect(content).toContain('<sender_note>');
+    expect(content).toContain('--mention-back');
+    expect(content.indexOf('<sender_note>')).toBeGreaterThan(content.indexOf('<sender '));
+  });
+
+  it('does NOT inject <sender_note> for non-cursor CLIs even with a sender', () => {
+    const content = buildFollowUpContent('hi', SESSION_ID, {
+      cliId: 'codex',
+      sender: { openId: 'ou_gp', type: 'user', name: '高鹏' },
+    });
+    expect(content).toContain('<sender '); // sender tag still present
+    expect(content).not.toContain('<sender_note>');
+  });
+
+  it('does NOT inject <sender_note> for cursor when there is no sender', () => {
+    const content = buildFollowUpContent('hi', SESSION_ID, { cliId: 'cursor' });
+    expect(content).not.toContain('<sender_note>');
+  });
 });
 
 // ─── buildReforkPrompt — wraps re-fork branch (resume / daemon-restart) ─────
@@ -330,6 +356,54 @@ describe('renderSenderTag', () => {
     // And the tag's outer quotes are not eaten by inner ones.
     expect(out.startsWith('<sender ')).toBe(true);
     expect(out.endsWith(' />')).toBe(true);
+  });
+});
+
+// ─── renderCursorSenderNote — cursor-only anti-echo guard ──────────────────
+
+describe('renderCursorSenderNote', () => {
+  it('returns the note only for cursor with a sender present', () => {
+    const out = renderCursorSenderNote('cursor', true);
+    expect(out).toContain('<sender_note>');
+    expect(out).toContain('--mention-back');
+  });
+
+  it('returns empty for cursor when no sender tag is present', () => {
+    expect(renderCursorSenderNote('cursor', false)).toBe('');
+  });
+
+  it('returns empty for every non-cursor CLI', () => {
+    for (const cli of ['claude-code', 'codex', 'gemini', 'opencode', 'coco', 'aiden'] as const) {
+      expect(renderCursorSenderNote(cli, true)).toBe('');
+    }
+  });
+
+  it('returns empty when cliId is undefined', () => {
+    expect(renderCursorSenderNote(undefined, true)).toBe('');
+  });
+});
+
+// ─── buildNewTopicPrompt cursor sender-note injection ───────────────────────
+
+describe('buildNewTopicPrompt cursor <sender_note>', () => {
+  it('adds <sender_note> for cursor new topics with a sender', () => {
+    const prompt = buildNewTopicPrompt(
+      'hello', 'sid', 'cursor',
+      undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+      { openId: 'ou_gp', type: 'user', name: '高鹏' },
+    );
+    expect(prompt).toContain('<sender_note>');
+    expect(prompt.indexOf('<sender_note>')).toBeGreaterThan(prompt.indexOf('<sender '));
+  });
+
+  it('omits <sender_note> for codex new topics with the same sender', () => {
+    const prompt = buildNewTopicPrompt(
+      'hello', 'sid', 'codex',
+      undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+      { openId: 'ou_gp', type: 'user', name: '高鹏' },
+    );
+    expect(prompt).toContain('<sender ');
+    expect(prompt).not.toContain('<sender_note>');
   });
 });
 


### PR DESCRIPTION
## 问题

cursor (`cursor-agent`) 适配器没有设 `injectsSessionContext`，导致每条消息都把 `<sender type="user" open_id="ou_xxx" name="高鹏" />` 内联进 prompt。cursor 的模型把 `open_id` + `name` 误读成 mention 提示里教的 `--mention <open_id:名字>` 形式，于是把 `ou_xxx:高鹏` 抄进了 `botmux send` 的正文/开头，群里看到的回复变成：

```
ou_7a8de602dcf28ed0add6277e948b5fb1:高鹏 我是 Claude…
```

claude-code 那类走系统提示注入、不内联 `<sender>`，所以没这问题——本 bug 是 cursor 独有。

## 改动

- 新增 i18n key `ai.cursor.sender_note`（zh/en）。
- `session-manager.ts` 加 `renderCursorSenderNote(cliId, hasSender, locale)`：仅 `cliId === 'cursor'` 且有 sender 时返回 `<sender_note>…</sender_note>`，注入到 `buildNewTopicPrompt` 和 `buildFollowUpContent`（`buildReforkPrompt` 走后者自动覆盖），明确告诉模型 sender 只是元信息、不要抄进正文、要 @ 回触发者用 `--mention-back`。

## 向下兼容

- 用 `cliId === 'cursor'` 硬门，codex/coco/gemini/opencode/aiden 等同样吃 `<sender>` 的 CLI **零改动**。
- 纯增量标签 `<sender_note>`，无解析器依赖。
- `t()` 缺键回退，旧 locale 不崩。

## 测试

- `test/prompt-builder.test.ts` 新增 9 个用例（helper + 两个 builder × cursor 有/无 sender / 非 cursor）。
- `prompt-builder` 36 passed；相邻套件 command-handler / bridge-input / session-adopt 共 171 passed。
- `pnpm build`（tsc + bundle）全绿。

## Test plan

- [ ] `pnpm daemon:restart` 后在飞书话题群用 cursor bot 实测一轮，确认回复不再带 `ou_xxx:名字` 前缀
- [ ] 确认其它 CLI（claude-code/codex 等）回复行为无变化

Made with [Cursor](https://cursor.com)