### PR TITLE
docs(docs-site): 关于页加入群链接

### DIFF
--- a/docs-site/docs/about.mdx
+++ b/docs-site/docs/about.mdx
@@ -16,11 +16,11 @@ botmux —— 飞书话题群 ↔ AI 编程 CLI 桥接。MIT 协议开源。
 <div style={{ display: 'flex', gap: '24px', flexWrap: 'wrap', alignItems: 'flex-start', margin: '16px 0' }}>
   <figure style={{ margin: 0, maxWidth: '260px' }}>
     <img src="https://magic-builder.tos-cn-beijing.volces.com/uploads/1780034556967_qr-internal.jpg" alt="内部交流群" style={{ width: '100%', borderRadius: '10px' }} />
-    <figcaption style={{ textAlign: 'center', marginTop: '8px', opacity: 0.7 }}>企业内部成员</figcaption>
+    <figcaption style={{ textAlign: 'center', marginTop: '8px', opacity: 0.7 }}>企业内部成员 · <a href="https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=dfft5c3e-fbff-4b80-b153-2b30794d5f9c">点此入群 →</a></figcaption>
   </figure>
   <figure style={{ margin: 0, maxWidth: '260px' }}>
     <img src="https://magic-builder.tos-cn-beijing.volces.com/uploads/1780034557258_qr-external.jpg" alt="外部交流群" style={{ width: '100%', borderRadius: '10px' }} />
-    <figcaption style={{ textAlign: 'center', marginTop: '8px', opacity: 0.7 }}>外部 / 通用（话题群）</figcaption>
+    <figcaption style={{ textAlign: 'center', marginTop: '8px', opacity: 0.7 }}>外部 / 通用（话题群） · <a href="https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=43eq98bb-78fb-41fc-a543-24ab9c07cce9">点此入群 →</a></figcaption>
   </figure>
 </div>
 

--- a/docs-site/rspress.config.ts
+++ b/docs-site/rspress.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   title: 'botmux 文档',
   description: '飞书话题群 ↔ AI 编程 CLI 桥接',
   builderConfig: {
-    output: { assetPrefix: "https://cdn.jsdelivr.net/gh/deepcoldy/botmux@docs-assets-v4/" },
+    output: { assetPrefix: "https://cdn.jsdelivr.net/gh/deepcoldy/botmux@docs-assets-v5/" },
   },
   themeConfig: {
     socialLinks: [


### PR DESCRIPTION
在 /about 的两个交流群二维码下加上「点此入群」链接（内部/外部）；资源版本升到 docs-assets-v5。已部署上线。