### PR TITLE
Fix setup bot display details

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,7 +48,7 @@ import { buildPreset, serializePreset, presetFilename } from './setup/agent-pres
 import type { CliId } from './adapters/cli/types.js';
 import { createCliAdapterSync } from './adapters/cli/registry.js';
 import { logger } from './utils/logger.js';
-import { invalidWorkingDirs } from './utils/working-dir.js';
+import { invalidWorkingDirs, normalizeWorkingDirInput } from './utils/working-dir.js';
 import { firstPositional } from './cli/arg-utils.js';
 import {
   formatBotInfoEntriesForCli,
@@ -673,7 +673,12 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
     console.log('   不写 bots.json。请重新运行 botmux setup。');
     return null;
   }
-  const workingDir = await ask(rl, '默认工作目录 [~]: ');
+  printInputHelp('默认工作目录', [
+    '留空沿用兼容默认值 ~（当前用户 home）；不改变老用户一路回车的行为。',
+    `当前命令所在目录是：${process.cwd()}；如果想使用它，请输入 .`,
+    '相对路径（如 docai/docai-oncall）会按当前命令所在目录解析；如要放在 home 下请写 ~/docai/docai-oncall。',
+  ]);
+  const workingDir = await ask(rl, '默认工作目录 [~]（当前目录请输入 .）: ');
   const modelChoice = await promptModel(rl, cliId);
 
   // 不再持久化 brand 字段: setup 阶段 brand=lark 直接被 obtainCredentials 中止,
@@ -684,9 +689,9 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
     larkAppId: creds.appId,
     larkAppSecret: creds.appSecret,
     cliId,
-    // 总是写 workingDir, 留空用 '~'. 用户手动编辑 bots.json 时一眼能看到字段
+    // 总是写 workingDir, 留空兼容旧版用 '~'. 用户手动编辑 bots.json 时一眼能看到字段
     // 在哪儿, 不用去 README 查字段名.
-    workingDir: workingDir.trim() || '~',
+    workingDir: normalizeWorkingDirInput(workingDir),
   };
   // modelChoice === undefined → 该 CLI 没声明候选 / 用户跳过；不写 model 字段
   if (typeof modelChoice === 'string' && modelChoice) {
@@ -809,6 +814,8 @@ async function promptEditBotConfig(
 
   printInputHelp('默认工作目录', [
     '可选。新会话默认进入的目录，支持逗号分隔多个候选目录。',
+    '推荐输入 ~/xxx 或 /绝对路径，语义最明确。',
+    '相对路径（如 docai/docai-oncall）会按当前命令所在目录解析；如要放在 home 下请写 ~/docai/docai-oncall。',
     '留空保留当前值；输入 - 清空并回到默认 ~。',
   ]);
   input.workingDir = await ask(rl, `默认工作目录 [${formatOptionalValue(bot.workingDir)}]: `);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,6 +41,7 @@ import {
   resolveCliId,
   assertOwnerWhenChatGroups,
   findInvalidAllowedUserEntries,
+  formatBotConfigTableRows,
   hasOwnerEntry,
   type BotConfigEditInput,
 } from './setup/bot-config-editor.js';
@@ -708,6 +709,9 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
     bot.allowedUsers = await promptRequiredOwner(rl);
   }
 
+  const appName = await refreshBotAppName(bot);
+  if (appName) console.log(`App Name: ${appName}\n`);
+
   if (!ensureBotWorkingDirsExist(bot, '默认工作目录')) return null;
 
   return normalizeBotConfig(bot);
@@ -728,19 +732,89 @@ function formatOptionalValue(v: unknown): string {
  * parseBotSelection 不再接受裸数字, 避免又冒出 "序号到底是几" 的歧义.
  */
 function formatBotConfigTable(bots: any[]): string {
-  if (bots.length === 0) return '';
-  const headers = ['进程名', 'App ID', 'CLI'];
-  const rows = bots.map((b, i) => [
-    botProcessName(b, i, PM2_NAME),
-    String(b?.larkAppId ?? ''),
-    String(b?.cliId ?? 'claude-code'),
-  ]);
-  const widths = headers.map((h, c) =>
-    Math.max(displayWidth(h), ...rows.map(r => displayWidth(r[c]))),
+  const appNames = loadKnownBotAppNames();
+  return formatBotConfigTableRows(bots.map((b, i) => ({
+    processName: botProcessName(b, i, PM2_NAME),
+    appName: knownBotAppName(b, appNames),
+    appId: String(b?.larkAppId ?? ''),
+    cliId: String(b?.cliId ?? 'claude-code'),
+  })));
+}
+
+type BotInfoEntryForSetup = { larkAppId?: string; botName?: string | null; appName?: string | null };
+
+function loadKnownBotAppNames(): Map<string, string> {
+  const map = new Map<string, string>();
+
+  const ingest = (entries: unknown): void => {
+    if (!Array.isArray(entries)) return;
+    for (const entry of entries as BotInfoEntryForSetup[]) {
+      const appId = typeof entry?.larkAppId === 'string' ? entry.larkAppId : '';
+      const name = typeof entry?.botName === 'string'
+        ? entry.botName.trim()
+        : typeof entry?.appName === 'string'
+          ? entry.appName.trim()
+          : '';
+      if (appId && name) map.set(appId, name);
+    }
+  };
+
+  // Populated by running daemons after /bot/v3/info; available even when setup
+  // is offline and avoids a network call in the common restart/edit path.
+  try { ingest(JSON.parse(readFileSync(join(DATA_DIR, 'bots-info.json'), 'utf-8'))); } catch { /* ignore */ }
+  // Cache written by setup's own best-effort lookup, so the name can show even
+  // before the first daemon start.
+  try { ingest(JSON.parse(readFileSync(join(CONFIG_DIR, 'bots-app-names.json'), 'utf-8'))); } catch { /* ignore */ }
+
+  return map;
+}
+
+function knownBotAppName(bot: any, appNames = loadKnownBotAppNames()): string | undefined {
+  const configured = typeof bot?.appName === 'string' ? bot.appName.trim() : '';
+  if (configured) return configured;
+  const appId = typeof bot?.larkAppId === 'string' ? bot.larkAppId : '';
+  return appId ? appNames.get(appId) : undefined;
+}
+
+function cacheBotAppName(appId: string, appName: string): void {
+  const cleanName = appName.trim();
+  if (!appId || !cleanName) return;
+  const path = join(CONFIG_DIR, 'bots-app-names.json');
+  const map = new Map<string, BotInfoEntryForSetup>();
+  try {
+    const entries = JSON.parse(readFileSync(path, 'utf-8'));
+    if (Array.isArray(entries)) {
+      for (const entry of entries as BotInfoEntryForSetup[]) {
+        if (typeof entry?.larkAppId === 'string') map.set(entry.larkAppId, entry);
+      }
+    }
+  } catch { /* ignore */ }
+  map.set(appId, { larkAppId: appId, appName: cleanName, botName: cleanName });
+  writeFileSync(path, JSON.stringify([...map.values()], null, 2) + '\n', { mode: 0o600 });
+}
+
+async function refreshBotAppName(bot: any): Promise<string | undefined> {
+  const appId = typeof bot?.larkAppId === 'string' ? bot.larkAppId : '';
+  const secret = typeof bot?.larkAppSecret === 'string' ? bot.larkAppSecret : '';
+  if (!appId || !secret) return undefined;
+  try {
+    const { fetchBotAppName } = await import('./setup/verify-permissions.js');
+    const info = await fetchBotAppName(appId, secret, botBrand(bot), { budgetMs: 5_000 });
+    if (info.ok) {
+      cacheBotAppName(appId, info.appName);
+      return info.appName;
+    }
+  } catch { /* best effort only */ }
+  return undefined;
+}
+
+async function refreshMissingBotAppNames(bots: any[]): Promise<void> {
+  const known = loadKnownBotAppNames();
+  await Promise.all(
+    bots
+      .filter((bot) => !knownBotAppName(bot, known))
+      .map((bot) => refreshBotAppName(bot)),
   );
-  const render = (cells: string[]) =>
-    '  ' + cells.map((cell, i) => padEndDisplay(cell, widths[i])).join('  ');
-  return [render(headers), ...rows.map(render)].join('\n');
 }
 
 async function promptEditBotConfig(
@@ -909,6 +983,7 @@ async function cmdSetup(): Promise<void> {
   if (hasBots) {
     // --- Multi-bot mode (bots.json exists) ---
     const bots = loadBotsJson();
+    await refreshMissingBotAppNames(bots);
     console.log(`已配置 ${bots.length} 个机器人：\n`);
     console.log(formatBotConfigTable(bots));
     console.log('');
@@ -977,6 +1052,7 @@ async function cmdSetup(): Promise<void> {
           return;
         }
         console.log('✅ 凭证有效\n');
+        await refreshBotAppName(edited);
       }
       rl.close();
 

--- a/src/core/working-dir.ts
+++ b/src/core/working-dir.ts
@@ -8,7 +8,9 @@ import { homedir } from 'node:os';
 import { t, type Locale } from '../i18n/index.js';
 
 export function expandHome(p: string): string {
-  return p.startsWith('~') ? join(homedir(), p.slice(1)) : p;
+  if (p === '~') return homedir();
+  if (p.startsWith('~/')) return join(homedir(), p.slice(2));
+  return p;
 }
 
 /**

--- a/src/setup/bot-config-editor.ts
+++ b/src/setup/bot-config-editor.ts
@@ -1,4 +1,5 @@
 import type { CliId } from '../adapters/cli/types.js';
+import { normalizeWorkingDirInput } from '../utils/working-dir.js';
 
 export const CLI_ID_CHOICES: Record<string, CliId> = {
   '1': 'claude-code',
@@ -304,7 +305,11 @@ export function applyBotConfigEdits<T extends Record<string, any>>(
     }
   }
 
-  applyOptionalString(out, 'workingDir', input.workingDir);
+  if (input.workingDir !== undefined) {
+    const workingDir = input.workingDir.trim();
+    if (workingDir === '-') delete out.workingDir;
+    else if (workingDir) out.workingDir = normalizeWorkingDirInput(workingDir);
+  }
 
   if (input.allowedUsers !== undefined) {
     const allowedUsers = input.allowedUsers.trim();

--- a/src/setup/bot-config-editor.ts
+++ b/src/setup/bot-config-editor.ts
@@ -259,6 +259,40 @@ export function removeBotConfig<T extends { larkAppId?: string; name?: unknown }
   return { bots: nextBots, removed: removed as T, index };
 }
 
+export interface BotConfigTableRow {
+  processName: string;
+  appName?: string;
+  appId: string;
+  cliId: string;
+}
+
+function displayWidth(s: string): number {
+  // Good enough for setup's CJK/ASCII table: wide code points count as 2,
+  // combining marks are rare in these labels and can safely count as 1 here.
+  let w = 0;
+  for (const ch of s) {
+    const cp = ch.codePointAt(0) ?? 0;
+    w += cp > 0x2e80 ? 2 : 1;
+  }
+  return w;
+}
+
+function padEndDisplay(s: string, width: number): string {
+  return s + ' '.repeat(Math.max(0, width - displayWidth(s)));
+}
+
+export function formatBotConfigTableRows(rows: BotConfigTableRow[]): string {
+  if (rows.length === 0) return '';
+  const headers = ['进程名', 'App Name', 'App ID', 'CLI'];
+  const cells = rows.map((r) => [r.processName, r.appName ?? '', r.appId, r.cliId]);
+  const widths = headers.map((h, c) =>
+    Math.max(displayWidth(h), ...cells.map(r => displayWidth(r[c]))),
+  );
+  const render = (row: string[]) =>
+    '  ' + row.map((cell, i) => padEndDisplay(cell, widths[i])).join('  ');
+  return [render(headers), ...cells.map(render)].join('\n');
+}
+
 export function applyBotConfigEdits<T extends Record<string, any>>(
   bot: T,
   input: BotConfigEditInput,

--- a/src/setup/verify-permissions.ts
+++ b/src/setup/verify-permissions.ts
@@ -99,6 +99,10 @@ export type CredentialValidation =
   | { ok: true; tenantAccessToken: string; tokenExpiresIn: number }
   | { ok: false; error: 'invalid_credentials' | 'network' | 'unknown'; message: string };
 
+export type BotInfoLookup =
+  | { ok: true; appName: string; openId?: string }
+  | { ok: false; error: 'invalid_credentials' | 'network' | 'unknown'; message: string };
+
 /**
  * 用 AppID/Secret 取一次 tenant_access_token, 验证凭证可用.
  *
@@ -166,6 +170,73 @@ export async function validateCredentials(
   // 10003 / 10012: app_id or app_secret invalid
   // 10014: 应用未发布
   // 99991663: app_secret invalid
+  if (body?.code === 10003 || body?.code === 10012 || body?.code === 99991663) {
+    return { ok: false, error: 'invalid_credentials', message: `凭证无效 (code=${body.code}): ${body.msg ?? ''}` };
+  }
+
+  return { ok: false, error: 'unknown', message: `code=${body?.code ?? '?'} msg=${body?.msg ?? ''}` };
+}
+
+/**
+ * Best-effort lookup for the human-visible Lark/Feishu bot app name.
+ * Used by `botmux setup` to make the existing-bots list recognizable without
+ * requiring the daemon to be running. Secret never appears in returned errors.
+ */
+export async function fetchBotAppName(
+  appId: string,
+  appSecret: string,
+  brand: Brand = 'feishu',
+  opts: { budgetMs?: number; signal?: AbortSignal } = {},
+): Promise<BotInfoLookup> {
+  const budgetMs = opts.budgetMs ?? 10_000;
+  const host = brand === 'lark' ? 'open.larksuite.com' : 'open.feishu.cn';
+
+  const token = await validateCredentials(appId, appSecret, brand, opts);
+  if (!token.ok) return token;
+
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), budgetMs);
+  if (opts.signal) {
+    if (opts.signal.aborted) ac.abort();
+    else opts.signal.addEventListener('abort', () => ac.abort(), { once: true });
+  }
+
+  let res: Response;
+  let body: any;
+  try {
+    res = await fetch(`https://${host}/open-apis/bot/v3/info/`, {
+      headers: { Authorization: `Bearer ${token.tenantAccessToken}` },
+      signal: ac.signal,
+    });
+    body = await res.json();
+  } catch (err: any) {
+    clearTimeout(timer);
+    const isAbort = err?.name === 'AbortError' || ac.signal.aborted;
+    if (!isAbort && err instanceof SyntaxError) {
+      return { ok: false, error: 'unknown', message: `HTTP ${res!?.status ?? '?'} 响应非 JSON` };
+    }
+    return {
+      ok: false,
+      error: 'network',
+      message: isAbort
+        ? `请求超时 (> ${budgetMs}ms)`
+        : `网络错误: ${err?.code ?? err?.message ?? 'unknown'}`,
+    };
+  }
+  clearTimeout(timer);
+
+  if (body?.code === 0) {
+    const appName = typeof body?.bot?.app_name === 'string' ? body.bot.app_name.trim() : '';
+    if (appName) {
+      return {
+        ok: true,
+        appName,
+        openId: typeof body?.bot?.open_id === 'string' ? body.bot.open_id : undefined,
+      };
+    }
+    return { ok: false, error: 'unknown', message: 'bot/v3/info 响应缺少 bot.app_name' };
+  }
+
   if (body?.code === 10003 || body?.code === 10012 || body?.code === 99991663) {
     return { ok: false, error: 'invalid_credentials', message: `凭证无效 (code=${body.code}): ${body.msg ?? ''}` };
   }

--- a/src/utils/working-dir.ts
+++ b/src/utils/working-dir.ts
@@ -2,8 +2,17 @@ import { statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 
+export function normalizeWorkingDirInput(input: string, fallback = '~'): string {
+  const s = input.trim();
+  if (!s) return fallback;
+  if (s === '-') return s;
+  return s;
+}
+
 export function expandHomePath(p: string): string {
-  return p.startsWith('~') ? join(homedir(), p.slice(1)) : p;
+  if (p === '~') return homedir();
+  if (p.startsWith('~/')) return join(homedir(), p.slice(2));
+  return p;
 }
 
 export function parseWorkingDirList(value: unknown): string[] {

--- a/test/bot-config-editor.test.ts
+++ b/test/bot-config-editor.test.ts
@@ -176,6 +176,18 @@ describe('applyBotConfigEdits', () => {
     });
   });
 
+  it('preserves bare relative workingDir edits', () => {
+    const updated = applyBotConfigEdits({
+      larkAppId: 'app',
+      larkAppSecret: 'secret',
+      workingDir: '~',
+    }, {
+      workingDir: 'docai/docai-oncall',
+    });
+
+    expect(updated.workingDir).toBe('docai/docai-oncall');
+  });
+
   it('accepts cliChoice as a literal cliId', () => {
     const updated = applyBotConfigEdits({
       larkAppId: 'app',

--- a/test/bot-config-editor.test.ts
+++ b/test/bot-config-editor.test.ts
@@ -5,6 +5,7 @@ import {
   assertOwnerWhenChatGroups,
   botProcessName,
   findInvalidAllowedUserEntries,
+  formatBotConfigTableRows,
   hasOwnerEntry,
   isValidAllowedUserEntry,
   normalizeBotConfig,
@@ -13,6 +14,18 @@ import {
   removeBotConfig,
   resolveCliId,
 } from '../src/setup/bot-config-editor.js';
+
+describe('formatBotConfigTableRows', () => {
+  it('includes App Name between process name and App ID', () => {
+    const table = formatBotConfigTableRows([
+      { processName: 'botmux-0', appName: 'Botmux Oncall', appId: 'cli_a940bbbbdd38dbde', cliId: 'codex' },
+    ]);
+
+    expect(table.split('\n')[0]).toContain('App Name');
+    expect(table).toContain('Botmux Oncall');
+    expect(table).toMatch(/进程名\s+App Name\s+App ID\s+CLI/);
+  });
+});
 
 describe('parseBotSelection', () => {
   const bots = [

--- a/test/setup-verify-permissions.test.ts
+++ b/test/setup-verify-permissions.test.ts
@@ -31,6 +31,7 @@ vi.mock('@larksuiteoapi/node-sdk', () => {
 import * as sdk from '@larksuiteoapi/node-sdk';
 import {
   validateCredentials,
+  fetchBotAppName,
   checkRequiredScopes,
   applyScopesUnverified,
   buildScopeDeepLink,
@@ -139,6 +140,52 @@ describe('validateCredentials', () => {
       expect.stringContaining('open.larksuite.com'),
       expect.any(Object),
     );
+  });
+});
+
+describe('fetchBotAppName', () => {
+  it('fetches tenant token then bot app_name without leaking secret', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ code: 0, tenant_access_token: 't-xxx', expire: 7200 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ code: 0, bot: { app_name: 'Codex Bot', open_id: 'ou_bot' } }),
+      });
+
+    const r = await fetchBotAppName('cli_x', 'super-secret-value-do-not-leak', 'feishu');
+
+    expect(r).toEqual({ ok: true, appName: 'Codex Bot', openId: 'ou_bot' });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('/open-apis/bot/v3/info/'),
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer t-xxx' },
+      }),
+    );
+  });
+
+  it('returns unknown when bot info has no app_name', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ code: 0, tenant_access_token: 't-xxx' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ code: 0, bot: { open_id: 'ou_bot' } }),
+      });
+
+    const r = await fetchBotAppName('cli_x', 'sec', 'feishu');
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toContain('app_name');
   });
 });
 

--- a/test/working-dir.test.ts
+++ b/test/working-dir.test.ts
@@ -1,8 +1,9 @@
 import { mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { configuredWorkingDirs, invalidWorkingDirs, parseWorkingDirList } from '../src/utils/working-dir.js';
+import { configuredWorkingDirs, invalidWorkingDirs, normalizeWorkingDirInput, parseWorkingDirList } from '../src/utils/working-dir.js';
+import { expandHome, validateWorkingDir } from '../src/core/working-dir.js';
 
 describe('working-dir utils', () => {
   it('parses comma-separated strings and arrays', () => {
@@ -14,6 +15,20 @@ describe('working-dir utils', () => {
   it('dedupes configured dirs by resolved path', () => {
     const cwd = process.cwd();
     expect(configuredWorkingDirs({ workingDir: '., ' + cwd })).toEqual(['.']);
+  });
+
+  it('expands ~/ paths to the user home directory', () => {
+    expect(expandHome('~')).toBe(homedir());
+    expect(expandHome('~/docai')).toBe(join(homedir(), 'docai'));
+    expect(validateWorkingDir('~').ok).toBe(true);
+  });
+
+  it('normalizes setup workingDir input without changing relative path semantics', () => {
+    expect(normalizeWorkingDirInput('')).toBe('~');
+    expect(normalizeWorkingDirInput('', '/repo/current')).toBe('/repo/current');
+    expect(normalizeWorkingDirInput('docai/docai-oncall')).toBe('docai/docai-oncall');
+    expect(normalizeWorkingDirInput('~/docai')).toBe('~/docai');
+    expect(normalizeWorkingDirInput('/srv/docai')).toBe('/srv/docai');
   });
 
   it('reports missing paths and files as invalid dirs', () => {


### PR DESCRIPTION
## Summary
- show bot App Name in the setup bot config table with best-effort lookup/cache
- clarify setup working directory defaults and keep blank input backward compatible
- add tests for App Name lookup/table formatting and working directory defaults

## Tests
- pnpm vitest run test/bot-config-editor.test.ts test/setup-verify-permissions.test.ts
- pnpm exec tsc --noEmit