### PR TITLE
fix(session): close zombie active session when tmux backing session i…

### DIFF
--- a/src/adapters/backend/herdr-backend.ts
+++ b/src/adapters/backend/herdr-backend.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
-import type { BackendType, SessionBackend, SpawnOpts } from './types.js';
+import type { BackendType, SessionBackend, SpawnOpts, SessionProbe } from './types.js';
 
 export type PersistentBackendType = Exclude<BackendType, 'pty'>;
 
@@ -149,8 +149,21 @@ export class HerdrBackend implements SessionBackend {
   }
 
   static hasSession(name: string): boolean {
-    const raw = jsonCommand(['session', 'list', '--json']);
-    return extractSessions(raw).some((s: any) => s?.name === name && s?.running === true);
+    return HerdrBackend.probeSession(name) === 'exists';
+  }
+
+  /**
+   * Tri-state existence probe. A failed/timed-out `session list` (tryJsonCommand
+   * → {ok:false}) yields 'unknown' rather than collapsing into 'missing', so a
+   * transient herdr-server hiccup on restore can't be mistaken for a gone
+   * session. A present-but-not-running row is a genuine zombie → 'missing'.
+   */
+  static probeSession(name: string): SessionProbe {
+    const result = tryJsonCommand(['session', 'list', '--json']);
+    if (!result.ok) return 'unknown';
+    return extractSessions(result.value).some((s: any) => s?.name === name && s?.running === true)
+      ? 'exists'
+      : 'missing';
   }
 
   static killSession(name: string): void {

--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -2,7 +2,7 @@ import * as pty from 'node-pty';
 import { execSync, execFileSync } from 'node:child_process';
 import { accessSync, constants as fsConstants } from 'node:fs';
 import { basename } from 'node:path';
-import type { SessionBackend, SpawnOpts } from './types.js';
+import type { SessionBackend, SpawnOpts, SessionProbe } from './types.js';
 import { probeTmuxFunctional, tmuxEnv } from '../../setup/ensure-tmux.js';
 import { REDACTED_CHILD_ENV_KEYS } from '../../utils/child-env.js';
 import { logger } from '../../utils/logger.js';
@@ -71,11 +71,25 @@ export class TmuxBackend implements SessionBackend {
 
   /** Check if a named tmux session exists. */
   static hasSession(name: string): boolean {
+    return TmuxBackend.probeSession(name) === 'exists';
+  }
+
+  /**
+   * Tri-state existence probe. `tmux has-session` exits 0 when the session
+   * exists and exits non-zero (clean status, no signal) when the server
+   * answered but the session is absent — including "no server running", which
+   * means every pane is genuinely gone. Either of those is an authoritative
+   * 'missing'. A timeout (signal/killed) or a spawn failure (e.g. ENOENT, no
+   * numeric exit status) means we never got an answer → 'unknown', so a hung
+   * server can't be mistaken for a gone session.
+   */
+  static probeSession(name: string): SessionProbe {
     try {
-      execSync(`tmux has-session -t ${shellescape(name)}`, { stdio: 'ignore', env: tmuxEnv() });
-      return true;
-    } catch {
-      return false;
+      execSync(`tmux has-session -t ${shellescape(name)}`, { stdio: 'ignore', env: tmuxEnv(), timeout: 3000 });
+      return 'exists';
+    } catch (e: any) {
+      if (e && typeof e.status === 'number' && !e.signal) return 'missing';
+      return 'unknown';
     }
   }
 

--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -76,16 +76,22 @@ export class TmuxBackend implements SessionBackend {
 
   /**
    * Tri-state existence probe. `tmux has-session` exits 0 when the session
-   * exists and exits non-zero (clean status, no signal) when the server
-   * answered but the session is absent — including "no server running", which
-   * means every pane is genuinely gone. Either of those is an authoritative
-   * 'missing'. A timeout (signal/killed) or a spawn failure (e.g. ENOENT, no
-   * numeric exit status) means we never got an answer → 'unknown', so a hung
-   * server can't be mistaken for a gone session.
+   * exists and exits 1 (clean status, no signal) when the server answered but
+   * the session is absent — including "no server running", which means every
+   * pane is genuinely gone. That is an authoritative 'missing'. Anything else —
+   * a timeout (signal/killed) or a spawn failure (binary not on PATH → ENOENT,
+   * not executable → EACCES; neither carries a numeric exit status) — means we
+   * never got an answer → 'unknown', so a flaky/unavailable tmux can't be
+   * mistaken for a gone session.
+   *
+   * Uses execFileSync (NOT a shell string): running tmux directly keeps a
+   * missing/unrunnable binary as ENOENT/EACCES. A shell would instead surface
+   * those as its own clean exits 127/126, which this classifier would wrongly
+   * read as 'missing' and then drive a destructive restore-time close.
    */
   static probeSession(name: string): SessionProbe {
     try {
-      execSync(`tmux has-session -t ${shellescape(name)}`, { stdio: 'ignore', env: tmuxEnv(), timeout: 3000 });
+      execFileSync('tmux', ['has-session', '-t', name], { stdio: 'ignore', env: tmuxEnv(), timeout: 3000 });
       return 'exists';
     } catch (e: any) {
       if (e && typeof e.status === 'number' && !e.signal) return 'missing';

--- a/src/adapters/backend/types.ts
+++ b/src/adapters/backend/types.ts
@@ -1,5 +1,20 @@
 export type BackendType = 'pty' | 'tmux' | 'herdr' | 'zellij';
 
+/**
+ * Tri-state result of probing whether a named backing session exists.
+ *
+ *   - 'exists'  — the probe command succeeded and confirmed a live session.
+ *   - 'missing' — the probe command succeeded and confirmed no such live session.
+ *   - 'unknown' — the probe command FAILED (error / timeout / unparseable output),
+ *                 so we could not determine existence either way.
+ *
+ * The distinction matters wherever a `false`/`missing` answer drives a
+ * destructive action (e.g. closing an active session on restore): a transient
+ * 'unknown' must never be treated as 'missing', or one flaky probe could
+ * permanently tear down a still-alive session.
+ */
+export type SessionProbe = 'exists' | 'missing' | 'unknown';
+
 export interface SpawnOpts {
   cwd: string;
   cols: number;

--- a/src/adapters/backend/zellij-backend.ts
+++ b/src/adapters/backend/zellij-backend.ts
@@ -3,7 +3,7 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { SessionBackend, SpawnOpts } from './types.js';
+import type { SessionBackend, SpawnOpts, SessionProbe } from './types.js';
 import { zellijEnv, probeZellijFunctional } from '../../setup/ensure-zellij.js';
 import { resolveUserShell, buildBotmuxEnvAssignments, SHELL_WRAPPER_SCRIPT } from './tmux-backend.js';
 import { logger } from '../../utils/logger.js';
@@ -79,6 +79,15 @@ export class ZellijBackend implements SessionBackend {
    *  session lingers in `list-sessions` as "(EXITED - attach to resurrect)";
    *  we must not treat those as reattachable, so filter them out. */
   static liveSessions(): string[] {
+    const probe = ZellijBackend.probeLiveSessions();
+    return probe.ok ? probe.sessions : [];
+  }
+
+  /** Like liveSessions(), but distinguishes "command failed/timed out" ({ok:false})
+   *  from "command succeeded, zero live sessions" ({ok:true, sessions:[]}). The
+   *  tri-state probe builds on this so a transient `list-sessions` failure isn't
+   *  read as "session gone". */
+  static probeLiveSessions(): { ok: true; sessions: string[] } | { ok: false } {
     try {
       const out = execFileSync('zellij', ['list-sessions', '--no-formatting'], {
         encoding: 'utf-8',
@@ -86,19 +95,28 @@ export class ZellijBackend implements SessionBackend {
         timeout: 3000,
         env: zellijEnv(),
       });
-      return out
-        .split('\n')
-        .map(l => l.trim())
-        .filter(l => l.length > 0 && !/EXITED/i.test(l))
-        .map(l => l.split(/\s+/)[0]!)
-        .filter(Boolean);
+      return {
+        ok: true,
+        sessions: out
+          .split('\n')
+          .map(l => l.trim())
+          .filter(l => l.length > 0 && !/EXITED/i.test(l))
+          .map(l => l.split(/\s+/)[0]!)
+          .filter(Boolean),
+      };
     } catch {
-      return [];
+      return { ok: false };
     }
   }
 
   static hasSession(name: string): boolean {
-    return ZellijBackend.liveSessions().includes(name);
+    return ZellijBackend.probeSession(name) === 'exists';
+  }
+
+  static probeSession(name: string): SessionProbe {
+    const probe = ZellijBackend.probeLiveSessions();
+    if (!probe.ok) return 'unknown';
+    return probe.sessions.includes(name) ? 'exists' : 'missing';
   }
 
   /** Kill + purge a session (so no resurrectable corpse accumulates). */

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -21,7 +21,7 @@ import { ZellijBackend } from '../adapters/backend/zellij-backend.js';
 import { getBot, getAllBots } from '../bot-registry.js';
 import type { CliId } from '../adapters/cli/types.js';
 import { validateZellijAdoptTarget } from './zellij-adopt-discovery.js';
-import type { BackendType } from '../adapters/backend/types.js';
+import type { BackendType, SessionProbe } from '../adapters/backend/types.js';
 import type { LarkAttachment, LarkMention, ScheduledTask } from '../types.js';
 import type { MessageResource } from '../im/lark/message-parser.js';
 import type { ResolvedSender } from '../im/lark/identity-cache.js';
@@ -728,10 +728,25 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
     if (!shouldAutoForkOnRestore(backendType, config.daemon.quietRestart)) continue;
 
     const backendName = persistentSessionName(backendType, ds.session.sessionId);
-    if (!persistentSessionExists(backendType, backendName)) {
+    const probe = probePersistentSession(backendType, backendName);
+    if (probe === 'missing') {
+      // Probe succeeded and authoritatively says the backing pane/agent is gone
+      // — this is a true zombie. Close it (evicts the active record + marks the
+      // store row closed) so the next message starts a clean session.
       const tag = ds.session.sessionId.substring(0, 8);
       logger.warn(`[${tag}] ${backendType} backing session "${backendName}" is gone — closing zombie active session`);
       await closeSession(ds.session.sessionId);
+      continue;
+    }
+    if (probe === 'unknown') {
+      // Probe FAILED (CLI error / timeout / unparseable output) — e.g. a herdr
+      // server still warming up on restart. We can't tell whether the session
+      // survived, so we must NOT close it: a transient failure would otherwise
+      // permanently tear down a still-alive session (context lost, pane leaked,
+      // store closed → no lazy recovery). Keep the worker-less active record and
+      // let it re-attach on the next message, exactly like the old behaviour.
+      const tag = ds.session.sessionId.substring(0, 8);
+      logger.warn(`[${tag}] ${backendType} backing session "${backendName}" probe inconclusive — keeping active session for lazy recovery`);
       continue;
     }
 
@@ -776,10 +791,10 @@ function persistentSessionName(backendType: Exclude<BackendType, 'pty'>, session
   return HerdrBackend.sessionName(sessionId);
 }
 
-function persistentSessionExists(backendType: Exclude<BackendType, 'pty'>, name: string): boolean {
-  if (backendType === 'tmux') return TmuxBackend.hasSession(name);
-  if (backendType === 'zellij') return ZellijBackend.hasSession(name);
-  return HerdrBackend.hasSession(name);
+function probePersistentSession(backendType: Exclude<BackendType, 'pty'>, name: string): SessionProbe {
+  if (backendType === 'tmux') return TmuxBackend.probeSession(name);
+  if (backendType === 'zellij') return ZellijBackend.probeSession(name);
+  return HerdrBackend.probeSession(name);
 }
 
 function killPersistentSession(backendType: Exclude<BackendType, 'pty'>, name: string): void {
@@ -813,7 +828,11 @@ export async function ensureTerminalWorkerPort(ds: DaemonSession): Promise<numbe
 
   const backendType = getSessionPersistentBackendType(ds);
   if (!backendType) return undefined;
-  if (!persistentSessionExists(backendType, persistentSessionName(backendType, ds.session.sessionId))) {
+  // Non-destructive read path: only wake a worker when the backing pane is
+  // CONFIRMED alive. 'missing' or 'unknown' both bail (a 502 the terminal
+  // retries) — same conservative stance as the old boolean check, with no risk
+  // of closing anything.
+  if (probePersistentSession(backendType, persistentSessionName(backendType, ds.session.sessionId)) !== 'exists') {
     return undefined;
   }
 

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -728,7 +728,12 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
     if (!shouldAutoForkOnRestore(backendType, config.daemon.quietRestart)) continue;
 
     const backendName = persistentSessionName(backendType, ds.session.sessionId);
-    if (!persistentSessionExists(backendType, backendName)) continue;
+    if (!persistentSessionExists(backendType, backendName)) {
+      const tag = ds.session.sessionId.substring(0, 8);
+      logger.warn(`[${tag}] ${backendType} backing session "${backendName}" is gone — closing zombie active session`);
+      await closeSession(ds.session.sessionId);
+      continue;
+    }
 
     // Guard against re-attaching to a persistent session that was started with a
     // different CLI than the bot is currently configured for. Persistent backend

--- a/test/herdr-backend.test.ts
+++ b/test/herdr-backend.test.ts
@@ -118,6 +118,36 @@ describe('HerdrBackend connection surface', () => {
     expect(HerdrBackend.hasSession('missing')).toBe(false);
   });
 
+  // ── Tri-state probe (exists | missing | unknown) ────────────────────────────
+  // The restore-time zombie-close decision MUST NOT collapse "list command
+  // failed/timed out" into "session is gone" — a transient probe failure would
+  // otherwise permanently close a still-alive session. probeSession() keeps the
+  // two apart; hasSession() stays the conservative boolean wrapper.
+  it('probeSession() reports "exists" for a running session and "missing" for an absent one', () => {
+    setHerdrResponses([{
+      match: a => a[0] === 'session' && a[1] === 'list',
+      reply: () => JSON.stringify({ sessions: [{ name: SESSION, running: true }] }),
+    }]);
+    expect(HerdrBackend.probeSession(SESSION)).toBe('exists');
+    expect(HerdrBackend.probeSession('bmx-absent')).toBe('missing');
+  });
+
+  it('probeSession() reports "missing" for a present-but-not-running row (a genuine zombie)', () => {
+    setHerdrResponses([{
+      match: a => a[0] === 'session' && a[1] === 'list',
+      reply: () => JSON.stringify({ sessions: [{ name: SESSION, running: false }] }),
+    }]);
+    expect(HerdrBackend.probeSession(SESSION)).toBe('missing');
+  });
+
+  it('probeSession() reports "unknown" when `session list` fails/times out — NOT "missing"', () => {
+    mockedExecFileSync.mockImplementation((() => { throw new Error('ETIMEDOUT'); }) as any);
+    expect(HerdrBackend.probeSession(SESSION)).toBe('unknown');
+    // hasSession() must stay conservative (false) on unknown so existing
+    // boolean callers are unaffected by the new tri-state.
+    expect(HerdrBackend.hasSession(SESSION)).toBe(false);
+  });
+
   it('ensureServer skips boot poll when session already exists (no spawn, no sleep)', () => {
     setHerdrResponses([
       { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },

--- a/test/restore-zombie-close.test.ts
+++ b/test/restore-zombie-close.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Restore-time zombie-close decision for persistent backends (tmux/zellij/herdr).
+ *
+ * On daemon restart, restoreActiveSessions() re-registers every persisted active
+ * session and then, for persistent backends, probes whether the backing
+ * pane/agent survived. PR #98 made a *missing* backing session trigger a
+ * permanent closeSession(). The hazard the gate caught: a transient probe
+ * failure (herdr server slow-start / list timeout / CLI hiccup) used to fold
+ * into the same `false` as "genuinely gone", so one flaky probe could close a
+ * still-alive session for good (context lost, pane leaked, store row closed →
+ * no lazy recovery).
+ *
+ * The fix upgrades the probe to tri-state (exists | missing | unknown). These
+ * tests pin the decision boundary:
+ *   - missing  → closeSession (Map eviction + store closed), no fork
+ *   - unknown  → keep the active record (no close, no fork) for lazy recovery
+ *   - exists   → auto-fork to re-attach, no close
+ *
+ * Heavy collaborators are mocked at the module boundary; the session-store runs
+ * for real against a temp dir, and the worker-pool mock faithfully reproduces
+ * closeSession's eviction-from-the-live-Map + store-close mechanism (mirrors
+ * session-resume.test.ts) so we assert the real eviction, not just end state.
+ *
+ * Run:  pnpm vitest run test/restore-zombie-close.test.ts
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+let tempDir: string;
+
+// Mutable probe verdict the mocked TmuxBackend returns this test run.
+const probe = vi.hoisted(() => ({ result: 'exists' as 'exists' | 'missing' | 'unknown' }));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    session: {
+      get dataDir() { return tempDir; },
+    },
+    // Persistent backend + eager restore (quietRestart off) ⇒ the close/fork
+    // decision path under test runs.
+    daemon: { backendType: 'tmux', quietRestart: false, workingDir: '~', workingDirs: ['~'] },
+  },
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('../src/services/frozen-card-store.js', () => ({
+  deleteFrozenCards: vi.fn(),
+}));
+
+// Shared holder so the mocked worker-pool's closeSession evicts from the SAME
+// Map the test passes into restoreActiveSessions — production's closeSession
+// evicts from activeSessionsRegistry, which IS that Map.
+const wp = vi.hoisted(() => ({ registry: null as Map<string, any> | null }));
+
+vi.mock('../src/core/worker-pool.js', () => ({
+  forkWorker: vi.fn(),
+  forkAdoptWorker: vi.fn(),
+  killStalePids: vi.fn(),
+  getCurrentCliVersion: vi.fn(() => '1.0.0-test'),
+  restoreUsageLimitRuntimeState: vi.fn(),
+  setActiveSessionSafe: vi.fn(async (map: Map<string, any>, key: string, ds: any) => {
+    const prev = map.get(key);
+    if (prev && prev !== ds) {
+      for (const [k, v] of map) { if (v === prev) { map.delete(k); break; } }
+    }
+    map.set(key, ds);
+  }),
+  isRelayableRealSession: (ds: any) =>
+    !!ds?.worker || !!ds?.session?.cliId || !!ds?.session?.lastCliInput,
+  // Faithful: evict the matching entry from the live Map (as production does via
+  // activeSessionsRegistry) AND mark the persisted row closed.
+  closeSession: vi.fn(async (sid: string) => {
+    const reg = wp.registry;
+    if (reg) {
+      for (const [k, v] of reg) {
+        if (v?.session?.sessionId === sid) { reg.delete(k); break; }
+      }
+    }
+    const store = await import('../src/services/session-store.js');
+    const s = store.getSession(sid);
+    if (s && s.status !== 'closed') store.closeSession(sid);
+    return { ok: true, alreadyClosed: false };
+  }),
+}));
+
+vi.mock('../src/bot-registry.js', () => ({
+  getBot: vi.fn(() => ({
+    config: { larkAppId: 'app_test', cliId: 'claude-code', workingDir: '~', workingDirs: ['~'] },
+    botName: 'TestBot',
+    botOpenId: 'ou_test',
+    resolvedAllowedUsers: [],
+  })),
+  getAllBots: vi.fn(() => [{
+    config: { larkAppId: 'app_test', cliId: 'claude-code' },
+    botName: 'TestBot',
+    botOpenId: 'ou_test',
+    resolvedAllowedUsers: [],
+  }]),
+}));
+
+vi.mock('../src/services/message-queue.js', () => ({
+  ensureQueue: vi.fn(),
+}));
+
+vi.mock('../src/im/lark/client.js', () => ({
+  downloadMessageResource: vi.fn(),
+  listChatBotMembers: vi.fn(),
+}));
+
+vi.mock('../src/adapters/cli/registry.js', () => ({
+  createCliAdapterSync: vi.fn(),
+}));
+
+// TmuxBackend mock: probeSession returns the per-test verdict; hasSession mirrors
+// production's delegation (probeSession === 'exists'). Keeping the old boolean
+// behaviour here is what makes the "unknown" case a true RED before the fix:
+// pre-fix restore calls hasSession() → false on unknown → wrongly closes.
+vi.mock('../src/adapters/backend/tmux-backend.js', () => ({
+  TmuxBackend: {
+    sessionName: vi.fn((id: string) => `bmx-${id.slice(0, 8)}`),
+    probeSession: vi.fn(() => probe.result),
+    hasSession: vi.fn(() => probe.result === 'exists'),
+    killSession: vi.fn(),
+  },
+}));
+
+vi.mock('../src/core/session-discovery.js', () => ({
+  validateAdoptTarget: vi.fn(() => true),
+  validateAdoptTargetState: vi.fn(() => 'alive'),
+  adoptTargetLabel: vi.fn(() => 'target'),
+}));
+
+vi.mock('../src/core/session-activity.js', () => ({
+  markSessionActivity: vi.fn(),
+}));
+
+import { restoreActiveSessions } from '../src/core/session-manager.js';
+import { forkWorker, closeSession } from '../src/core/worker-pool.js';
+import * as sessionStore from '../src/services/session-store.js';
+import { sessionKey } from '../src/core/types.js';
+import type { DaemonSession } from '../src/core/types.js';
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'restore-zombie-test-'));
+  sessionStore.init();
+  wp.registry = null;
+  probe.result = 'exists';
+  vi.mocked(closeSession).mockClear();
+  vi.mocked(forkWorker).mockClear();
+});
+
+afterEach(() => {
+  try { rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+function makeActivePersistentSession(rootMessageId: string) {
+  const s = sessionStore.createSession('oc_chat1', rootMessageId, 'Topic', 'group');
+  s.larkAppId = 'app_test';
+  s.workingDir = '/tmp/proj';
+  s.cliId = 'claude-code';
+  s.scope = 'thread';
+  sessionStore.updateSession(s);
+  return s; // left active
+}
+
+describe('restoreActiveSessions — persistent-backend zombie-close decision', () => {
+  it('"missing" → closes the zombie (Map eviction + store closed), does not fork', async () => {
+    probe.result = 'missing';
+    const s = makeActivePersistentSession('om_missing');
+    const map = new Map<string, DaemonSession>();
+    wp.registry = map;
+
+    await restoreActiveSessions(map);
+
+    expect(closeSession).toHaveBeenCalledWith(s.sessionId);
+    expect([...map.values()].some(v => v.session.sessionId === s.sessionId)).toBe(false);
+    expect(sessionStore.getSession(s.sessionId)!.status).toBe('closed');
+    expect(forkWorker).not.toHaveBeenCalled();
+  });
+
+  it('"unknown" → keeps the active record (no close, no fork) for lazy recovery', async () => {
+    probe.result = 'unknown';
+    const s = makeActivePersistentSession('om_unknown');
+    const map = new Map<string, DaemonSession>();
+    wp.registry = map;
+
+    await restoreActiveSessions(map);
+
+    expect(closeSession).not.toHaveBeenCalled();
+    const ds = map.get(sessionKey('om_unknown', 'app_test'));
+    expect(ds).toBeDefined();              // active record retained…
+    expect(ds!.worker).toBeNull();         // …worker-less, resumes on next message
+    expect(sessionStore.getSession(s.sessionId)!.status).toBe('active'); // NOT closed
+    expect(forkWorker).not.toHaveBeenCalled();
+  });
+
+  it('"exists" → auto-forks to re-attach, does not close', async () => {
+    probe.result = 'exists';
+    const s = makeActivePersistentSession('om_exists');
+    const map = new Map<string, DaemonSession>();
+    wp.registry = map;
+
+    await restoreActiveSessions(map);
+
+    expect(closeSession).not.toHaveBeenCalled();
+    expect(forkWorker).toHaveBeenCalled();
+    expect(vi.mocked(forkWorker).mock.calls[0]![0].session.sessionId).toBe(s.sessionId);
+    expect(map.get(sessionKey('om_exists', 'app_test'))).toBeDefined();
+  });
+});

--- a/test/tmux-probe.test.ts
+++ b/test/tmux-probe.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for TmuxBackend.probeSession() — the tri-state existence probe
+ * used by restore's zombie-close decision.
+ *
+ * The hazard these pin: a probe FAILURE (tmux not on PATH, not executable,
+ * hung) must classify as 'unknown', never 'missing' — because restore turns
+ * 'missing' into a destructive closeSession(). A shell-string `execSync` leaks
+ * the shell's own command-not-found / not-executable exit codes (127 / 126) as
+ * clean numeric statuses, which a naive "non-zero status ⇒ missing" rule would
+ * misread as "session gone". Running the binary directly via execFileSync keeps
+ * those failures as ENOENT/EACCES (no numeric status) ⇒ 'unknown'.
+ *
+ * Both execSync and execFileSync are mocked per scenario so the test pins the
+ * intended CLASSIFICATION regardless of which child_process API the impl uses.
+ *
+ * Run:  pnpm vitest run test/tmux-probe.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return { ...actual, execSync: vi.fn(), execFileSync: vi.fn() };
+});
+
+import { execSync, execFileSync } from 'node:child_process';
+import { TmuxBackend } from '../src/adapters/backend/tmux-backend.js';
+
+const mockedExecSync = vi.mocked(execSync);
+const mockedExecFileSync = vi.mocked(execFileSync);
+
+const NAME = 'bmx-deadbeef';
+
+function err(props: Record<string, unknown>): Error {
+  return Object.assign(new Error('cmd failed'), props);
+}
+
+/** Drive BOTH child_process entry points with the same logical outcome, so the
+ *  asserted classification holds whether the impl shells out (execSync) or runs
+ *  the binary directly (execFileSync). */
+function bothThrow(syncProps: Record<string, unknown>, fileProps: Record<string, unknown>) {
+  mockedExecSync.mockImplementation((() => { throw err(syncProps); }) as any);
+  mockedExecFileSync.mockImplementation((() => { throw err(fileProps); }) as any);
+}
+
+beforeEach(() => {
+  mockedExecSync.mockReset();
+  mockedExecFileSync.mockReset();
+});
+
+describe('TmuxBackend.probeSession', () => {
+  it('returns "exists" when has-session succeeds (exit 0)', () => {
+    mockedExecSync.mockImplementation((() => '') as any);
+    mockedExecFileSync.mockImplementation((() => '') as any);
+    expect(TmuxBackend.probeSession(NAME)).toBe('exists');
+  });
+
+  it('returns "missing" when the server answers and the session is absent (clean exit 1)', () => {
+    bothThrow({ status: 1, signal: null }, { status: 1, signal: null });
+    expect(TmuxBackend.probeSession(NAME)).toBe('missing');
+  });
+
+  it('returns "unknown" when tmux is not found (command-not-found / ENOENT), NOT "missing"', () => {
+    // Shell path surfaces command-not-found as a *clean* exit 127; the direct
+    // execFileSync path surfaces it as ENOENT (no numeric status).
+    bothThrow({ status: 127, signal: null }, { code: 'ENOENT', status: null, signal: null });
+    expect(TmuxBackend.probeSession(NAME)).toBe('unknown');
+  });
+
+  it('returns "unknown" when tmux is not executable (permission / EACCES), NOT "missing"', () => {
+    bothThrow({ status: 126, signal: null }, { code: 'EACCES', status: null, signal: null });
+    expect(TmuxBackend.probeSession(NAME)).toBe('unknown');
+  });
+
+  it('returns "unknown" on timeout (killed by signal)', () => {
+    bothThrow({ signal: 'SIGTERM', status: null, killed: true }, { signal: 'SIGTERM', status: null, killed: true });
+    expect(TmuxBackend.probeSession(NAME)).toBe('unknown');
+  });
+
+  it('hasSession() stays a conservative boolean wrapper (false on unknown)', () => {
+    bothThrow({ status: 127, signal: null }, { code: 'ENOENT', status: null, signal: null });
+    expect(TmuxBackend.hasSession(NAME)).toBe(false);
+  });
+});


### PR DESCRIPTION
…s missing on restore

When restoreActiveSessions() iterates persistent-backend sessions and finds the backing tmux/zellij/herdr session is gone, it previously just `continue`d, leaving the DaemonSession registered as active forever. Any incoming message for that chat would match the orphaned entry and be silently dropped (no worker to handle it, no error surfaced to the user).

Fix: call closeSession(sessionId) before continuing so the session is removed from both the runtime activeSessions Map and the sessionStore (status → closed), and a warn log is emitted to make the cleanup visible.