### PR TITLE
fix(adopt): detect Cursor agent sessions and fix adopt-session uptime/liveness reporting

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1480,6 +1480,13 @@ interface SessionData {
   pendingResponseCardId?: string;
   pendingResponseCardState?: 'open' | 'patched';
   lastPatchedResponseCardId?: string;
+  // Markers that a real CLI ever ran in this session (vs a daemon-command
+  // scratch placeholder). Persisted by the daemon; only presence is checked
+  // here, so they're typed loosely. Used by cmdList to avoid reporting an
+  // unconfirmed /adopt scratch as a crashed CLI session.
+  cliId?: string;
+  lastCliInput?: string;
+  adoptedFrom?: unknown;
 }
 
 /**
@@ -2032,24 +2039,38 @@ async function cmdList(): Promise<void> {
   const sessions = loadSessions();
   const active = [...sessions.values()].filter(s => s.status === 'active');
 
-  // Auto-prune unrecoverable sessions: process dead and no tmux session
+  // Auto-prune unrecoverable sessions: process dead and no tmux session.
+  // Split into two buckets so a never-activated daemon-command scratch (e.g. an
+  // unconfirmed /adopt that only posted a picker card, /help, an abandoned
+  // /relay picker) isn't reported as a crashed CLI. Such a scratch never forked
+  // a worker, so it has no cliId / lastCliInput / adoptedFrom — the same "was it
+  // ever a real CLI session" markers isRelayableRealSession uses. Closing it is
+  // fine, but the "进程已死且无 tmux session" notice wrongly implies a CLI ran
+  // and crashed, which is exactly the confusing output users hit after /adopt.
   const pruned: SessionData[] = [];
+  const prunedScratch: SessionData[] = [];
   const live: SessionData[] = [];
   for (const s of active) {
     const hasPid = !!(s.pid && isProcessAlive(s.pid));
     const hasTmux = tmuxSessionExists(`bmx-${s.sessionId.substring(0, 8)}`);
     if (!hasPid && !hasTmux) {
-      pruned.push(s);
+      const everReal = !!(s.cliId || s.lastCliInput || s.adoptedFrom);
+      (everReal ? pruned : prunedScratch).push(s);
     } else {
       live.push(s);
     }
   }
-  if (pruned.length > 0) {
-    for (const s of pruned) {
+  const closeNow = (arr: SessionData[]) => {
+    for (const s of arr) {
       s.status = 'closed';
       s.closedAt = new Date().toISOString();
       saveSession(s);
     }
+  };
+  // Scratches: close silently — they were placeholders, not dead sessions.
+  closeNow(prunedScratch);
+  if (pruned.length > 0) {
+    closeNow(pruned);
     console.log(`已自动清理 ${pruned.length} 个不可恢复的会话（进程已死且无 tmux session）`);
   }
 

--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -2,7 +2,7 @@
  * Session Discovery — scans tmux panes for running CLI processes that can be adopted.
  *
  * Discovers non-botmux tmux sessions running known CLI binaries (Claude Code,
- * Codex, Aiden, CoCo, Gemini, OpenCode, MTR, Hermes) and collects metadata needed to adopt them.
+ * Codex, Aiden, CoCo, Cursor, Gemini, OpenCode, MTR, Hermes) and collects metadata needed to adopt them.
  */
 import { execFileSync, execSync } from 'node:child_process';
 import { readdirSync, readFileSync, readlinkSync, realpathSync } from 'node:fs';
@@ -43,6 +43,7 @@ const CLI_COMM_MAP: Record<string, CliId> = {
   codex: 'codex',
   aiden: 'aiden',
   coco: 'coco',
+  'cursor-agent': 'cursor',
   // CoCo 的别名 traecli：某些发行版（如 trae）安装的可执行实际叫
   // `traecli`，tmux pane_current_command 仍显示 "coco" 是因为进程标题被
   // 改写过；macOS 下 `ps -o comm=` 拿到的是真实 argv[0]，因此这里需要
@@ -57,6 +58,10 @@ const CLI_COMM_MAP: Record<string, CliId> = {
 export function cliIdForComm(comm: string, filterCliId?: CliId): CliId | undefined {
   const normalizedComm = comm.startsWith('.') ? comm.slice(1) : comm;
   const direct = CLI_COMM_MAP[comm] ?? CLI_COMM_MAP[normalizedComm];
+  // Cursor's agent binary may be installed as the generic name `agent`. Only
+  // accept that alias when a Cursor bot is explicitly asking, otherwise a broad
+  // /adopt scan could mistake unrelated agent processes for Cursor sessions.
+  if (filterCliId === 'cursor' && normalizedComm === 'agent') return 'cursor';
   // MTR is an OpenCode fork and some installs still expose the underlying
   // native process as "opencode". When an MTR bot asks to adopt, treat that
   // process as MTR so the bot's filter does not hide its own sessions.
@@ -305,9 +310,9 @@ function extractHerdrAgents(raw: any): any[] {
   return Array.isArray(agents) ? agents : [];
 }
 
-function herdrAgentCliId(agent: any): CliId | undefined {
+function herdrAgentCliId(agent: any, filterCliId?: CliId): CliId | undefined {
   const name = typeof agent?.agent === 'string' ? basename(agent.agent) : '';
-  return name in CLI_COMM_MAP ? CLI_COMM_MAP[name]! : undefined;
+  return name ? cliIdForComm(name, filterCliId) : undefined;
 }
 
 function discoverHerdrAdoptableSessions(filterCliId?: CliId): AdoptableSession[] {
@@ -321,7 +326,7 @@ function discoverHerdrAdoptableSessions(filterCliId?: CliId): AdoptableSession[]
     const sessionName = session.name as string;
     const rawAgents = herdrJson(['--session', sessionName, 'agent', 'list']);
     for (const agent of extractHerdrAgents(rawAgents)) {
-      const cliId = herdrAgentCliId(agent);
+      const cliId = herdrAgentCliId(agent, filterCliId);
       if (!cliId) continue;
       if (filterCliId && cliId !== filterCliId) continue;
       const cwd = typeof agent?.cwd === 'string' ? agent.cwd : undefined;

--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -55,6 +55,14 @@ const CLI_COMM_MAP: Record<string, CliId> = {
   hermes: 'hermes',
 };
 
+/** Interpreters and native launchers that may hide the CLI identity in argv.
+ *  Cursor Agent is one example on Linux: /proc/<pid>/comm can be `MainThread`
+ *  while argv[0] is `/.../cursor-agent` or `/.../agent`. */
+const COMM_ARGV_LAUNCHERS = new Set([
+  'node', 'nodejs', 'bun', 'deno', 'python', 'python2', 'python3', 'ruby', 'npx', 'tsx',
+  'MainThread',
+]);
+
 export function cliIdForComm(comm: string, filterCliId?: CliId): CliId | undefined {
   const normalizedComm = comm.startsWith('.') ? comm.slice(1) : comm;
   const direct = CLI_COMM_MAP[comm] ?? CLI_COMM_MAP[normalizedComm];
@@ -67,6 +75,37 @@ export function cliIdForComm(comm: string, filterCliId?: CliId): CliId | undefin
   // process as MTR so the bot's filter does not hide its own sessions.
   if (filterCliId === 'mtr' && direct === 'opencode') return 'mtr';
   return direct;
+}
+
+/** /proc/<pid>/cmdline → argv (Linux fast path; ps fallback for macOS). */
+export function readCmdline(pid: number): string[] {
+  try {
+    return readFileSync(`/proc/${pid}/cmdline`, 'utf-8').split('\0').filter(Boolean);
+  } catch {
+    try {
+      const out = execFileSync('ps', ['-o', 'args=', '-p', String(pid)], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
+      return out.trim().split(/\s+/).filter(Boolean);
+    } catch { return []; }
+  }
+}
+
+/**
+ * Resolve a CliId from a process's comm + argv. Checks comm first; if the comm
+ * belongs to a generic launcher, scan argv for the CLI executable basename.
+ */
+export function cliIdFromCommArgv(comm: string | undefined, argv: string[], filterCliId?: CliId): CliId | undefined {
+  if (!comm) return undefined;
+  let detected = cliIdForComm(comm, filterCliId);
+  if (!detected && COMM_ARGV_LAUNCHERS.has(comm)) {
+    for (const arg of argv) {
+      if (arg.startsWith('-')) continue;
+      const id = cliIdForComm(basename(arg), filterCliId);
+      if (id) { detected = id; break; }
+    }
+  }
+  if (!detected) return undefined;
+  if (filterCliId && detected !== filterCliId) return undefined;
+  return detected;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -192,7 +231,7 @@ function findCliProcess(
     for (const pid of current) {
       const comm = readComm(pid);
       if (comm) {
-        const cliId = cliIdForComm(comm, filterCliId);
+        const cliId = cliIdFromCommArgv(comm, readCmdline(pid), filterCliId);
         if (cliId) return { pid, cliId };
       }
       next.push(...getChildPids(pid));

--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -178,6 +178,77 @@ export function readCwd(pid: number): string | undefined {
   }
 }
 
+// /proc/stat btime 与 CLK_TCK 在一次 daemon 生命周期内不变，缓存避免每个候选都
+// 重复 fork-exec / 读盘。
+let cachedBtimeSeconds: number | undefined;
+let cachedBtimeRead = false;
+function readBootTimeSeconds(): number | undefined {
+  if (cachedBtimeRead) return cachedBtimeSeconds;
+  cachedBtimeRead = true;
+  try {
+    const m = readFileSync('/proc/stat', 'utf-8').match(/^btime\s+(\d+)/m);
+    cachedBtimeSeconds = m ? Number(m[1]) : undefined;
+  } catch {
+    cachedBtimeSeconds = undefined;
+  }
+  return cachedBtimeSeconds;
+}
+
+let cachedClkTck: number | undefined;
+function clockTicksPerSecond(): number {
+  if (cachedClkTck !== undefined) return cachedClkTck;
+  try {
+    const n = Number(execFileSync('getconf', ['CLK_TCK'], {
+      encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim());
+    cachedClkTck = Number.isFinite(n) && n > 0 ? n : 100;
+  } catch {
+    // 100 是 Linux 上几乎通用的默认值，拿不到 getconf 时用它兜底。
+    cachedClkTck = 100;
+  }
+  return cachedClkTck;
+}
+
+/**
+ * 进程启动时间（epoch ms），best-effort。让 /adopt 选择卡片能为**任意** CLI 显示
+ * 真实运行时长，而不是只有 Claude（Claude 另有 ~/.claude/sessions/<pid>.json 带
+ * startedAt）。其它 CLI（cursor/codex/coco/gemini…）之前一律落 "未知" 就是因为
+ * 这里没有兜底。
+ *
+ * Linux 走 /proc/<pid>/stat（字段 22 = starttime，单位时钟滴答，自开机起算）+
+ * /proc/stat 的 btime；其它 Unix 走 `ps -o lstart=` 解析。读不到返回 undefined。
+ */
+export function readProcessStartTime(pid: number): number | undefined {
+  if (IS_LINUX) {
+    try {
+      const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
+      // comm（字段 2）用括号包裹且可能含空格/括号，slice 到最后一个 ')' 之后，
+      // 让后续字段偏移稳定。')' 之后第一个字段是 state（字段 3），所以 starttime
+      // （字段 22）对应这里的下标 19。
+      const afterComm = stat.slice(stat.lastIndexOf(')') + 1).trim().split(/\s+/);
+      const starttimeTicks = Number(afterComm[19]);
+      const btime = readBootTimeSeconds();
+      if (Number.isFinite(starttimeTicks) && btime !== undefined) {
+        return Math.round((btime + starttimeTicks / clockTicksPerSecond()) * 1000);
+      }
+    } catch {
+      // 落到下面的 ps 兜底
+    }
+  }
+  try {
+    const out = execFileSync('ps', ['-o', 'lstart=', '-p', String(pid)], {
+      encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (out) {
+      const ms = Date.parse(out);
+      if (Number.isFinite(ms)) return ms;
+    }
+  } catch {
+    // 进程不存在 / ps 不可用
+  }
+  return undefined;
+}
+
 /**
  * 获取一个进程的直接子进程 PID。
  *
@@ -487,6 +558,13 @@ export function discoverAdoptableSessions(filterCliId?: CliId): AdoptableSession
         // re-probes too, so undefined here is acceptable.
         const cocoSession = findCocoSessionByPid(match.pid);
         if (cocoSession) sessionId = cocoSession.sessionId;
+      }
+
+      // 5b. Fall back to the CLI process's own start time for uptime. Without
+      // this only Claude (which has a session JSON with startedAt) shows a real
+      // uptime; every other CLI — cursor/codex/coco/gemini… — rendered "未知".
+      if (startedAt === undefined) {
+        startedAt = readProcessStartTime(match.pid);
       }
 
       // 6. Get pane dimensions

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -2165,6 +2165,14 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
   ds.worker = worker;
   ds.spawnedAt = Date.now();
   ds.cliVersion = '';
+  // Persist the bridge worker's pid, exactly like forkWorker. Without it the
+  // session row keeps pid=null, so `botmux list` (and killStalePids) judge an
+  // adopt session by "process dead AND no bmx-<id> tmux" — but adopt attaches to
+  // the user's OWN tmux/zellij pane, never a bmx-* session, so the heuristic
+  // always reported it unrecoverable and auto-pruned it to "closed" right after
+  // /adopt. Storing the worker pid (botmux's bridge, NOT the user's CLI) makes
+  // liveness consistent with normal sessions and leaves the user's CLI alone.
+  sessionStore.updateSessionPid(ds.session.sessionId, worker.pid ?? null);
   logger.info(`[${t}] Adopt worker forked (pid: ${worker.pid}, target: ${adopted.tmuxTarget ?? `${adopted.zellijSession}/${adopted.zellijPaneId}`})`);
 
   ds.exitEventEmitted = false;

--- a/src/core/zellij-adopt-discovery.ts
+++ b/src/core/zellij-adopt-discovery.ts
@@ -13,11 +13,10 @@
  * project dir). If a pane matches zero or >1 process, we REFUSE it (skip) —
  * better no-adopt than adopting the wrong pane (Codex's guidance).
  */
-import { realpathSync, readFileSync } from 'node:fs';
-import { basename } from 'node:path';
+import { realpathSync } from 'node:fs';
 import type { CliId } from '../adapters/cli/types.js';
 import {
-  cliIdForComm, readComm, readCwd, getChildPids, readClaudeSessionMeta,
+  readComm, readCwd, getChildPids, readClaudeSessionMeta, cliIdFromCommArgv, readCmdline,
 } from './session-discovery.js';
 import { findCodexRolloutByPid } from '../services/codex-transcript.js';
 import { findCocoSessionByPid } from '../services/coco-transcript.js';
@@ -28,6 +27,8 @@ import {
 import { zellijEnv } from '../setup/ensure-zellij.js';
 import { logger } from '../utils/logger.js';
 import { execFileSync } from 'node:child_process';
+
+export { cliIdFromCommArgv } from './session-discovery.js';
 
 export interface ZellijAdoptableSession {
   zellijSession: string;   // e.g. "mywork"
@@ -47,46 +48,6 @@ function canonPath(p: string | undefined): string | undefined {
   let out = p;
   try { out = realpathSync(p); } catch { /* keep raw */ }
   return out.length > 1 && out.endsWith('/') ? out.slice(0, -1) : out;
-}
-
-/** Interpreters that launch a CLI as a script argument (fnm/npx shims, etc.),
- *  so the CLI identity lives in argv, not in comm. */
-const INTERPRETERS = new Set(['node', 'nodejs', 'bun', 'deno', 'python', 'python2', 'python3', 'ruby', 'npx', 'tsx']);
-
-/** /proc/<pid>/cmdline → argv (Linux fast path; ps fallback for macOS). */
-function readCmdline(pid: number): string[] {
-  try {
-    return readFileSync(`/proc/${pid}/cmdline`, 'utf-8').split('\0').filter(Boolean);
-  } catch {
-    try {
-      const out = execFileSync('ps', ['-o', 'args=', '-p', String(pid)], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
-      return out.trim().split(/\s+/).filter(Boolean);
-    } catch { return []; }
-  }
-}
-
-/**
- * Resolve a CliId from a process's comm + argv (pure — unit testable). Checks
- * comm first (renamed binary, e.g. `codex`/`claude`); if comm is a bare
- * interpreter (e.g. an fnm shim launches `node …/bin/codex`, so /proc/comm is
- * "node"), scan argv for the CLI script basename. Without this, node-wrapped
- * CLIs are invisible to discovery.
- */
-export function cliIdFromCommArgv(comm: string | undefined, argv: string[], filterCliId?: CliId): CliId | undefined {
-  if (!comm) return undefined;
-  // cliIdForComm only special-cases mtr/opencode for filterCliId; it does NOT
-  // otherwise filter — so apply the filter explicitly at the end.
-  let detected = cliIdForComm(comm, filterCliId);
-  if (!detected && INTERPRETERS.has(comm)) {
-    for (const arg of argv.slice(1)) {
-      if (arg.startsWith('-')) continue; // skip flags
-      const id = cliIdForComm(basename(arg), filterCliId);
-      if (id) { detected = id; break; }
-    }
-  }
-  if (!detected) return undefined;
-  if (filterCliId && detected !== filterCliId) return undefined;
-  return detected;
 }
 
 function cliIdForProc(pid: number, filterCliId?: CliId): CliId | undefined {

--- a/src/core/zellij-adopt-discovery.ts
+++ b/src/core/zellij-adopt-discovery.ts
@@ -17,6 +17,7 @@ import { realpathSync } from 'node:fs';
 import type { CliId } from '../adapters/cli/types.js';
 import {
   readComm, readCwd, getChildPids, readClaudeSessionMeta, cliIdFromCommArgv, readCmdline,
+  readProcessStartTime,
 } from './session-discovery.js';
 import { findCodexRolloutByPid } from '../services/codex-transcript.js';
 import { findCocoSessionByPid } from '../services/coco-transcript.js';
@@ -224,7 +225,9 @@ export function discoverAdoptableZellijSessions(filterCliId?: CliId): ZellijAdop
         cliId: cli.cliId,
         sessionId,
         cwd: cli.cwd ?? '',
-        startedAt,
+        // Same uptime fallback as the tmux path: only Claude carries startedAt
+        // from its session JSON, so derive it from the process for everyone else.
+        startedAt: startedAt ?? readProcessStartTime(cli.pid),
         paneCols: dims.cols,
         paneRows: dims.rows,
       });

--- a/test/herdr-session-discovery.test.ts
+++ b/test/herdr-session-discovery.test.ts
@@ -145,6 +145,24 @@ describe('discoverAdoptableSessions (herdr branch)', () => {
     expect(onlyCodex[0]!.cliId).toBe('codex');
   });
 
+  it('treats generic agent as Cursor only when Cursor is requested', () => {
+    installHerdrFixture({
+      sessions: [{ name: 'work', running: true }],
+      agentsBySession: {
+        work: [
+          { agent: 'agent', pane_id: '1-1', cwd: '/cursor' },
+        ],
+      },
+    });
+
+    expect(discoverAdoptableSessions()).toHaveLength(0);
+
+    const onlyCursor = discoverAdoptableSessions('cursor');
+    expect(onlyCursor).toHaveLength(1);
+    expect(onlyCursor[0]!.cliId).toBe('cursor');
+    expect(onlyCursor[0]!.cwd).toBe('/cursor');
+  });
+
   it('returns an empty list when herdr is unavailable', () => {
     mockedExecFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
     expect(discoverAdoptableSessions()).toEqual([]);

--- a/test/session-discovery.test.ts
+++ b/test/session-discovery.test.ts
@@ -226,6 +226,41 @@ describe('discoverAdoptableSessions', () => {
     expect(results[1]!.paneRows).toBe(50);
   });
 
+  it('should discover cursor-agent processes as Cursor sessions', () => {
+    setupMocks({
+      paneLines: 'cursor:0.0 1000\n',
+      commMap: { 1000: 'zsh', 1001: 'cursor-agent' },
+      childMap: { 1000: [1001] },
+      cwdMap: { 1001: '/workspace/cursor' },
+      dimsMap: { 'cursor:0.0': '160 50' },
+    });
+
+    const results = discoverAdoptableSessions();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.cliId).toBe('cursor');
+    expect(results[0]!.cliPid).toBe(1001);
+    expect(results[0]!.cwd).toBe('/workspace/cursor');
+  });
+
+  it('should treat generic agent as Cursor only for Cursor-filtered adoption', () => {
+    setupMocks({
+      paneLines: 'cursor:0.0 1000\n',
+      commMap: { 1000: 'zsh', 1001: 'agent' },
+      childMap: { 1000: [1001] },
+      cwdMap: { 1001: '/workspace/cursor' },
+      dimsMap: { 'cursor:0.0': '160 50' },
+    });
+
+    expect(discoverAdoptableSessions()).toHaveLength(0);
+
+    const results = discoverAdoptableSessions('cursor');
+    expect(results).toHaveLength(1);
+    expect(results[0]!.cliId).toBe('cursor');
+    expect(results[0]!.cliPid).toBe(1001);
+    expect(results[0]!.cwd).toBe('/workspace/cursor');
+  });
+
   it('should skip bmx-* prefixed sessions', () => {
     setupMocks({
       paneLines: 'bmx-abc12345:0.0 1000\nmysession:0.0 2000\n',

--- a/test/session-discovery.test.ts
+++ b/test/session-discovery.test.ts
@@ -60,12 +60,19 @@ function setupMocks(opts: {
   cmdlineMap?: Record<number, string[]>;
   dimsMap?: Record<string, string>;
   claudeMeta?: Record<number, string>;
+  /** pid → starttime (clock ticks since boot) for /proc/<pid>/stat field 22.
+   *  Drives readProcessStartTime's Linux fast path. Pids absent here yield a
+   *  thrown ENOENT → readProcessStartTime returns undefined (no ps fallback in
+   *  the mocked child_process), matching the "uptime unknown" legacy behavior. */
+  statMap?: Record<number, number>;
+  /** /proc/stat btime (seconds since epoch). Defaults to 1_700_000_000. */
+  bootTimeSeconds?: number;
   /** pid → ordered list of /proc/<pid>/fd/<n> symlink target strings.
    *  Used to test CoCo session discovery (and any future fd-walking logic).
    *  Pass `'<path> (deleted)'` suffix to simulate procfs's deleted-inode marker. */
   procFdMap?: Record<number, string[]>;
 }) {
-  const { paneLines, commMap = {}, cwdMap = {}, childMap = {}, cmdlineMap = {}, dimsMap = {}, claudeMeta = {}, procFdMap = {} } = opts;
+  const { paneLines, commMap = {}, cwdMap = {}, childMap = {}, cmdlineMap = {}, dimsMap = {}, claudeMeta = {}, statMap = {}, bootTimeSeconds = 1_700_000_000, procFdMap = {} } = opts;
 
   // Replace blanket existsSync / readdirSync mocks with procFdMap-aware ones.
   mockExistsSync.mockImplementation((path: unknown) => {
@@ -145,6 +152,25 @@ function setupMocks(opts: {
     if (cmdlineMatch) {
       const pid = Number(cmdlineMatch[1]);
       if (pid in cmdlineMap) return cmdlineMap[pid]!.join('\0') + '\0';
+      throw new Error('ENOENT');
+    }
+
+    // /proc/stat (system boot time)
+    if (pathStr === '/proc/stat') {
+      return `cpu 0 0 0 0\nbtime ${bootTimeSeconds}\nprocesses 1\n`;
+    }
+
+    // /proc/<pid>/stat — only field 22 (starttime, index 19 after the comm
+    // paren) matters to readProcessStartTime; pad the leading fields with 0s.
+    const statMatch = pathStr.match(/\/proc\/(\d+)\/stat$/);
+    if (statMatch) {
+      const pid = Number(statMatch[1]);
+      if (pid in statMap) {
+        const after = Array(19).fill('0');
+        after[0] = 'S';
+        after.push(String(statMap[pid]));
+        return `${pid} (proc) ${after.join(' ')}`;
+      }
       throw new Error('ENOENT');
     }
 
@@ -251,6 +277,25 @@ describe('discoverAdoptableSessions', () => {
     expect(results[0]!.cliId).toBe('cursor');
     expect(results[0]!.cliPid).toBe(1001);
     expect(results[0]!.cwd).toBe('/workspace/cursor');
+  });
+
+  it('should derive startedAt from process start time for non-Claude CLIs', () => {
+    setupMocks({
+      paneLines: 'cursor:0.0 1000\n',
+      commMap: { 1000: 'zsh', 1001: 'cursor-agent' },
+      childMap: { 1000: [1001] },
+      cwdMap: { 1001: '/workspace/cursor' },
+      dimsMap: { 'cursor:0.0': '160 50' },
+      // btime 1_700_000_000s + 50000 ticks / 100 Hz = 1_700_000_500s
+      statMap: { 1001: 50_000 },
+      bootTimeSeconds: 1_700_000_000,
+    });
+
+    const results = discoverAdoptableSessions();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.cliId).toBe('cursor');
+    expect(results[0]!.startedAt).toBe(1_700_000_500_000);
   });
 
   it('should treat generic agent as Cursor only for Cursor-filtered adoption', () => {

--- a/test/session-discovery.test.ts
+++ b/test/session-discovery.test.ts
@@ -48,6 +48,7 @@ const mockReaddirSync = vi.mocked(readdirSync);
  * commMap: pid → comm name
  * cwdMap: pid → cwd path
  * childMap: pid → child pids
+ * cmdlineMap: pid → argv list for /proc/<pid>/cmdline
  * dimsMap: tmuxTarget → "cols rows"
  * claudeMeta: pid → JSON string of session metadata
  */
@@ -56,6 +57,7 @@ function setupMocks(opts: {
   commMap?: Record<number, string>;
   cwdMap?: Record<number, string>;
   childMap?: Record<number, number[]>;
+  cmdlineMap?: Record<number, string[]>;
   dimsMap?: Record<string, string>;
   claudeMeta?: Record<number, string>;
   /** pid → ordered list of /proc/<pid>/fd/<n> symlink target strings.
@@ -63,7 +65,7 @@ function setupMocks(opts: {
    *  Pass `'<path> (deleted)'` suffix to simulate procfs's deleted-inode marker. */
   procFdMap?: Record<number, string[]>;
 }) {
-  const { paneLines, commMap = {}, cwdMap = {}, childMap = {}, dimsMap = {}, claudeMeta = {}, procFdMap = {} } = opts;
+  const { paneLines, commMap = {}, cwdMap = {}, childMap = {}, cmdlineMap = {}, dimsMap = {}, claudeMeta = {}, procFdMap = {} } = opts;
 
   // Replace blanket existsSync / readdirSync mocks with procFdMap-aware ones.
   mockExistsSync.mockImplementation((path: unknown) => {
@@ -135,6 +137,14 @@ function setupMocks(opts: {
     if (commMatch) {
       const pid = Number(commMatch[1]);
       if (pid in commMap) return commMap[pid] + '\n';
+      throw new Error('ENOENT');
+    }
+
+    // /proc/<pid>/cmdline
+    const cmdlineMatch = pathStr.match(/\/proc\/(\d+)\/cmdline/);
+    if (cmdlineMatch) {
+      const pid = Number(cmdlineMatch[1]);
+      if (pid in cmdlineMap) return cmdlineMap[pid]!.join('\0') + '\0';
       throw new Error('ENOENT');
     }
 
@@ -246,8 +256,9 @@ describe('discoverAdoptableSessions', () => {
   it('should treat generic agent as Cursor only for Cursor-filtered adoption', () => {
     setupMocks({
       paneLines: 'cursor:0.0 1000\n',
-      commMap: { 1000: 'zsh', 1001: 'agent' },
+      commMap: { 1000: 'zsh', 1001: 'MainThread' },
       childMap: { 1000: [1001] },
+      cmdlineMap: { 1001: ['/home/user/.local/bin/agent', '--model', 'gpt-5.5-extra-high'] },
       cwdMap: { 1001: '/workspace/cursor' },
       dimsMap: { 'cursor:0.0': '160 50' },
     });

--- a/test/zellij-cli-detection.test.ts
+++ b/test/zellij-cli-detection.test.ts
@@ -5,12 +5,21 @@ describe('cliIdFromCommArgv', () => {
   it('detects a renamed-binary CLI by comm', () => {
     expect(cliIdFromCommArgv('codex', ['/usr/local/bin/codex'])).toBe('codex');
     expect(cliIdFromCommArgv('claude', ['claude'])).toBe('claude-code');
+    expect(cliIdFromCommArgv('cursor-agent', ['cursor-agent'])).toBe('cursor');
   });
 
   it('detects a node-wrapped CLI by argv (fnm shim: comm is "node")', () => {
     // The real-world case: `node /run/user/0/fnm_multishells/…/bin/codex`
     expect(cliIdFromCommArgv('node', ['node', '/run/user/0/fnm_multishells/x/bin/codex'])).toBe('codex');
     expect(cliIdFromCommArgv('node', ['node', '/home/u/.local/bin/claude'])).toBe('claude-code');
+    expect(cliIdFromCommArgv('node', ['node', '/home/u/.local/bin/cursor-agent'])).toBe('cursor');
+  });
+
+  it('only treats generic agent as Cursor when the Cursor bot filters adopt sessions', () => {
+    expect(cliIdFromCommArgv('agent', ['agent'])).toBeUndefined();
+    expect(cliIdFromCommArgv('agent', ['agent'], 'cursor')).toBe('cursor');
+    expect(cliIdFromCommArgv('node', ['node', '/home/u/.local/bin/agent'])).toBeUndefined();
+    expect(cliIdFromCommArgv('node', ['node', '/home/u/.local/bin/agent'], 'cursor')).toBe('cursor');
   });
 
   it('skips flags when scanning argv', () => {
@@ -27,5 +36,7 @@ describe('cliIdFromCommArgv', () => {
     // node-wrapped codex, but the bot is claude → no match
     expect(cliIdFromCommArgv('node', ['node', '/x/bin/codex'], 'claude-code')).toBeUndefined();
     expect(cliIdFromCommArgv('node', ['node', '/x/bin/codex'], 'codex')).toBe('codex');
+    expect(cliIdFromCommArgv('cursor-agent', ['cursor-agent'], 'codex')).toBeUndefined();
+    expect(cliIdFromCommArgv('cursor-agent', ['cursor-agent'], 'cursor')).toBe('cursor');
   });
 });

--- a/test/zellij-cli-detection.test.ts
+++ b/test/zellij-cli-detection.test.ts
@@ -20,6 +20,8 @@ describe('cliIdFromCommArgv', () => {
     expect(cliIdFromCommArgv('agent', ['agent'], 'cursor')).toBe('cursor');
     expect(cliIdFromCommArgv('node', ['node', '/home/u/.local/bin/agent'])).toBeUndefined();
     expect(cliIdFromCommArgv('node', ['node', '/home/u/.local/bin/agent'], 'cursor')).toBe('cursor');
+    expect(cliIdFromCommArgv('MainThread', ['/home/u/.local/bin/agent'], 'cursor')).toBe('cursor');
+    expect(cliIdFromCommArgv('MainThread', ['/home/u/.local/bin/agent'])).toBeUndefined();
   });
 
   it('skips flags when scanning argv', () => {


### PR DESCRIPTION
## Summary
Make `/adopt` work end-to-end for Cursor Agent sessions, and fix two adopt-session bugs surfaced along the way.

**Cursor detection**
- Recognize `cursor-agent` processes as Cursor sessions during `/adopt` discovery.
- Treat the generic `agent` binary as Cursor only when a Cursor bot is filtering candidates, so broad scans don't adopt unrelated agent processes.
- Inspect argv (not just `/proc/<pid>/comm`) when walking a pane's process tree — Cursor Agent can report comm as `MainThread` while the real executable lives in argv[0]. Detection now lives in the shared session-discovery module and is reused by the tmux, zellij, and Herdr discovery paths.

**Adopt-session uptime & liveness**
- Populate `startedAt` for every CLI, not just Claude: add `readProcessStartTime` (Linux `/proc/<pid>/stat` starttime + `/proc/stat` btime, `ps -o lstart=` fallback) so the adopt picker stops rendering "unknown" uptime for cursor/codex/coco/gemini.
- Persist the bridge worker pid in `forkAdoptWorker`, mirroring `forkWorker`. Adopt sessions kept `pid=null`, so `botmux list`/`killStalePids` judged them by "process dead AND no `bmx-*` tmux" and pruned them right after `/adopt`. The stored pid is botmux's bridge worker, never the user's CLI.

**`botmux list` output**
- Don't report an unconfirmed `/adopt` scratch placeholder as a crashed session. `cmdList` now distinguishes sessions that ever ran a real CLI (`cliId` / `lastCliInput` / `adoptedFrom`, matching `isRelayableRealSession`) from never-activated scratches: scratches are closed silently, genuinely dead sessions keep the original warning.

## Validation
- `pnpm vitest run test/session-discovery.test.ts test/zellij-cli-detection.test.ts test/herdr-session-discovery.test.ts test/session-store.test.ts`
- `pnpm build`

## Notes
- No lockfile changes.
