### PR TITLE
Clarify botmux send mention switches in built-in skill

### DIFF
--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -341,6 +341,8 @@ botmux send --mention ou_xxx "帮忙看下这段代码"
 | \`--mention-back\` | @ 回**本轮触发消息的发送者**（open_id 自动从会话取，你不用记） |
 | \`--no-mention\` | 明确声明本条不 @ 任何人 |
 
+> ⚠️ \`--mention-back\` / \`--no-mention\` 是开关，后面不跟任何参数；要 @ 具体的人用 \`--mention <open_id:名字>\`。正文来源按 \`--content-file > 位置参数 > stdin\` 选择，多行正文推荐只放在 heredoc/stdin 中。
+
 决策规则（**按内容价值判断，不是按"人还是 bot"**）：
 - **有实质结论、需要对方继续看 / 确认 / 决策** → \`--mention-back\`（@回触发者）或 \`--mention\` 点名，确保对方看到。
 - **纯记录 / 低优先级进度 / 简短确认（"收到""在看"）** → \`--no-mention\`，别打扰。

--- a/test/builtin-skills.test.ts
+++ b/test/builtin-skills.test.ts
@@ -14,6 +14,17 @@ describe('built-in botmux-send skill', () => {
     expect(skill!.content).toContain('botmux send "第一行\\n第二行"');
     expect(skill!.content).toContain('字面量');
   });
+
+  it('warns that mention-back/no-mention are switches without values', () => {
+    const skill = BUILTIN_SKILLS.find(s => s.name === 'botmux-send');
+    expect(skill).toBeDefined();
+    expect(skill!.content).toContain('--mention-back');
+    expect(skill!.content).toContain('--no-mention');
+    expect(skill!.content).toContain('是开关，后面不跟任何参数');
+    expect(skill!.content).toContain('--mention <open_id:名字>');
+    expect(skill!.content).toContain('--content-file > 位置参数 > stdin');
+    expect(skill!.content).toContain('多行正文推荐只放在 heredoc/stdin 中');
+  });
 });
 
 describe('built-in botmux-history skill', () => {


### PR DESCRIPTION
Bot send msg like this sometimes
<img width="514" height="204" alt="image" src="https://github.com/user-attachments/assets/3e1cf2bb-86a3-4db8-83e1-c74df3002156" />
And the analysis result listed below
<img width="1032" height="230" alt="image" src="https://github.com/user-attachments/assets/7ca79fc9-e7f3-4f86-94bc-5cb0fa60432a" />

strengthen the internal botmux send skill a little bit. 

## Summary
- Clarify in the built-in `botmux-send` skill that `--mention-back` and `--no-mention` are value-less switches.
- Point agents to `--mention <open_id:name>` for explicit recipients, and document the existing content-source precedence for multiline bodies.
- Add regression coverage for the built-in skill guidance.

## Test plan
- `pnpm vitest run test/builtin-skills.test.ts test/send-policy.test.ts`
- `pnpm build`
