### PR TITLE
fix(cli): CLI 二进制路径改惰性解析，根治 setup 被交互式 shell 探测挂起

### DIFF
--- a/src/adapters/cli/aiden.ts
+++ b/src/adapters/cli/aiden.ts
@@ -7,10 +7,14 @@ function delay(ms: number): Promise<void> {
 }
 
 export function createAidenAdapter(pathOverride?: string): CliAdapter {
-  const bin = resolveCommand(pathOverride ?? 'aiden');
+  // resolvedBin is lazy: setup constructs adapters only to read static
+  // modelChoices and must not shell out (see resolveCommand); the binary path
+  // is a spawn-time concern.
+  const rawBin = pathOverride ?? 'aiden';
+  let cachedBin: string | undefined;
   return {
     id: 'aiden',
-    resolvedBin: bin,
+    get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, disableCliBypass }) {
       const args: string[] = [];

--- a/src/adapters/cli/antigravity.ts
+++ b/src/adapters/cli/antigravity.ts
@@ -126,10 +126,14 @@ async function waitForHistoryAppend(
 }
 
 export function createAntigravityAdapter(pathOverride?: string): CliAdapter {
-  const bin = resolveCommand(pathOverride ?? 'agy');
+  // resolvedBin is lazy: setup constructs adapters only to read static
+  // modelChoices and must not shell out (see resolveCommand); the binary path
+  // is a spawn-time concern.
+  const rawBin = pathOverride ?? 'agy';
+  let cachedBin: string | undefined;
   return {
     id: 'antigravity',
-    resolvedBin: bin,
+    get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ resume, resumeSessionId, disableCliBypass }) {
       const args = disableCliBypass ? [] : ['--dangerously-skip-permissions'];

--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -412,7 +412,6 @@ export interface ClaudeFamilyVariant {
 }
 
 export function createClaudeCodeAdapter(pathOverride?: string): CliAdapter {
-  const bin = resolveCommand(pathOverride ?? 'claude');
   return createClaudeFamilyAdapter({
     id: 'claude-code',
     resumeBin: 'claude',
@@ -420,13 +419,18 @@ export function createClaudeCodeAdapter(pathOverride?: string): CliAdapter {
     stateJsonPath: join(homedir(), '.claude.json'),
     // alias（opus/sonnet/haiku）会被 Claude Code 解析成当前推荐的具体版本；具体 ID 锁版本。
     modelChoices: ['opus', 'sonnet', 'haiku', 'claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001'],
-  }, bin);
+  }, pathOverride ?? 'claude');
 }
 
-export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, bin: string): CliAdapter {
+export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, rawBin: string): CliAdapter {
+  // resolvedBin is resolved lazily on first read (memoised) so merely
+  // constructing the adapter — e.g. `botmux setup` reading modelChoices — never
+  // shells out via resolveCommand. The binary path is a spawn-time concern.
+  // (Seed passes an already-absolute bin here, so this getter is a no-op for it.)
+  let cachedBin: string | undefined;
   return {
     id: variant.id,
-    resolvedBin: bin,
+    get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
     supportsTypeAhead: true,
     claudeDataDir: variant.dataDir,
     claudeStateJsonPath: variant.stateJsonPath,

--- a/src/adapters/cli/coco.ts
+++ b/src/adapters/cli/coco.ts
@@ -114,10 +114,14 @@ function submitPrefix(content: string): string {
 }
 
 export function createCocoAdapter(pathOverride?: string): CliAdapter {
-  const bin = resolveCommand(pathOverride ?? 'coco');
+  // resolvedBin is lazy: setup constructs adapters only to read static
+  // modelChoices and must not shell out (see resolveCommand); the binary path
+  // is a spawn-time concern.
+  const rawBin = pathOverride ?? 'coco';
+  let cachedBin: string | undefined;
   return {
     id: 'coco',
-    resolvedBin: bin,
+    get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, model, disableCliBypass }) {
       const args: string[] = [];

--- a/src/adapters/cli/codex-app.ts
+++ b/src/adapters/cli/codex-app.ts
@@ -23,7 +23,11 @@ function encodeInput(content: string): string {
 }
 
 export function createCodexAppAdapter(pathOverride?: string): CliAdapter {
-  const codexBin = resolveCommand(pathOverride ?? 'codex');
+  // Resolve the wrapped `codex` binary lazily, on first buildArgs (spawn time),
+  // so constructing the adapter during `botmux setup` doesn't shell out via
+  // resolveCommand. resolvedBin is the node runner, not codex itself.
+  const rawCodexBin = pathOverride ?? 'codex';
+  let cachedCodexBin: string | undefined;
   return {
     id: 'codex-app',
     resolvedBin: process.execPath,
@@ -32,7 +36,7 @@ export function createCodexAppAdapter(pathOverride?: string): CliAdapter {
       const args = [
         runnerPath(),
         '--session-id', sessionId,
-        '--codex-bin', codexBin,
+        '--codex-bin', (cachedCodexBin ??= resolveCommand(rawCodexBin)),
       ];
       if (resume && resumeSessionId) args.push('--thread-id', resumeSessionId);
       pushOpt(args, '--cwd', workingDir);

--- a/src/adapters/cli/codex.ts
+++ b/src/adapters/cli/codex.ts
@@ -119,10 +119,14 @@ function latestCodexSessionForBotmuxSession(botmuxSessionId: string): string | u
 }
 
 export function createCodexAdapter(pathOverride?: string): CliAdapter {
-  const bin = resolveCommand(pathOverride ?? 'codex');
+  // resolvedBin is lazy: setup constructs adapters only to read static
+  // modelChoices and must not shell out (see resolveCommand); the binary path
+  // is a spawn-time concern.
+  const rawBin = pathOverride ?? 'codex';
+  let cachedBin: string | undefined;
   return {
     id: 'codex',
-    resolvedBin: bin,
+    get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, resumeSessionId, workingDir, model, disableCliBypass }) {
       const baseArgs = [

--- a/src/adapters/cli/cursor.ts
+++ b/src/adapters/cli/cursor.ts
@@ -13,10 +13,14 @@ function delay(ms: number): Promise<void> {
 const cursorFirstWriteSeen = new WeakSet<PtyHandle>();
 
 export function createCursorAdapter(pathOverride?: string): CliAdapter {
-  const bin = resolveCommand(pathOverride ?? 'cursor-agent');
+  // resolvedBin is lazy: setup constructs adapters only to read static
+  // modelChoices and must not shell out (see resolveCommand); the binary path
+  // is a spawn-time concern.
+  const rawBin = pathOverride ?? 'cursor-agent';
+  let cachedBin: string | undefined;
   return {
     id: 'cursor',
-    resolvedBin: bin,
+    get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ resume, resumeSessionId, model, disableCliBypass }) {
       // --force skips approvals so the model can act inside the topic without

--- a/src/adapters/cli/gemini.ts
+++ b/src/adapters/cli/gemini.ts
@@ -7,10 +7,14 @@ function delay(ms: number): Promise<void> {
 }
 
 export function createGeminiAdapter(pathOverride?: string): CliAdapter {
-  const bin = resolveCommand(pathOverride ?? 'gemini');
+  // resolvedBin is lazy: setup constructs adapters only to read static
+  // modelChoices and must not shell out (see resolveCommand); the binary path
+  // is a spawn-time concern.
+  const rawBin = pathOverride ?? 'gemini';
+  let cachedBin: string | undefined;
   return {
     id: 'gemini',
-    resolvedBin: bin,
+    get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ initialPrompt, model, disableCliBypass }) {
       // Gemini CLI manages sessions internally (--resume takes "latest" or

--- a/src/adapters/cli/hermes.ts
+++ b/src/adapters/cli/hermes.ts
@@ -7,10 +7,14 @@ function delay(ms: number): Promise<void> {
 }
 
 export function createHermesAdapter(pathOverride?: string): CliAdapter {
-  const bin = resolveCommand(pathOverride ?? 'hermes');
+  // resolvedBin is lazy: setup constructs adapters only to read static
+  // modelChoices and must not shell out (see resolveCommand); the binary path
+  // is a spawn-time concern.
+  const rawBin = pathOverride ?? 'hermes';
+  let cachedBin: string | undefined;
   return {
     id: 'hermes',
-    resolvedBin: bin,
+    get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, disableCliBypass }) {
       const args: string[] = [];

--- a/src/adapters/cli/mtr.ts
+++ b/src/adapters/cli/mtr.ts
@@ -28,10 +28,14 @@ function nativeSessionId(sessionId: string, cliSessionId?: string): string {
 }
 
 export function createMtrAdapter(pathOverride?: string): CliAdapter {
-  const bin = resolveCommand(pathOverride ?? 'mtr');
+  // resolvedBin is lazy: setup constructs adapters only to read static
+  // modelChoices and must not shell out (see resolveCommand); the binary path
+  // is a spawn-time concern.
+  const rawBin = pathOverride ?? 'mtr';
+  let cachedBin: string | undefined;
   return {
     id: 'mtr',
-    resolvedBin: bin,
+    get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, resumeSessionId, initialPrompt }) {
       const mtrSessionId = nativeSessionId(sessionId, resumeSessionId);

--- a/src/adapters/cli/opencode.ts
+++ b/src/adapters/cli/opencode.ts
@@ -7,10 +7,14 @@ function delay(ms: number): Promise<void> {
 }
 
 export function createOpenCodeAdapter(pathOverride?: string): CliAdapter {
-  const bin = resolveCommand(pathOverride ?? 'opencode');
+  // resolvedBin is lazy: setup constructs adapters only to read static
+  // modelChoices and must not shell out (see resolveCommand); the binary path
+  // is a spawn-time concern.
+  const rawBin = pathOverride ?? 'opencode';
+  let cachedBin: string | undefined;
   return {
     id: 'opencode',
-    resolvedBin: bin,
+    get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ initialPrompt, model }) {
       // OpenCode manages sessions internally (SQLite store).

--- a/src/adapters/cli/registry.ts
+++ b/src/adapters/cli/registry.ts
@@ -1,5 +1,5 @@
-import { execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { accessSync, constants, existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
 import type { CliAdapter, CliId } from './types.js';
@@ -24,17 +24,34 @@ export function resolveCommand(cmd: string): string {
   if (isAbsolute(cmd)) return cmd;
   const shell = process.env.SHELL || '/bin/zsh';
   const shells = [shell, '/bin/zsh', '/bin/bash'].filter((v, i, a) => a.indexOf(v) === i);
+  // `setsid` (util-linux) runs the probe in its own session with NO controlling
+  // terminal. Absent on macOS — there the tty-free stdio below is the safeguard.
+  const setsidBin = existsSync('/usr/bin/setsid') ? '/usr/bin/setsid' : null;
   // -lc: login shell (sources .profile/.zprofile) — covers npm/nvm/fnm installs
   // -ic: interactive shell (sources .bashrc/.zshrc) — covers installers like opencode
   for (const flags of ['-lc', '-ic']) {
     for (const sh of shells) {
-      try {
-        const result = execSync(`${sh} ${flags} 'which ${cmd}' 2>/dev/null`, {
-          encoding: 'utf-8',
-          timeout: 5_000,
-        }).trim();
-        if (result && isAbsolute(result)) return result;
-      } catch { /* try next */ }
+      // Harden the probe so it can't disturb the caller's terminal:
+      //  - stdio ['ignore','pipe','ignore'] → stdin & stderr are /dev/null, so a
+      //    `read` in the user's rc gets EOF instead of blocking, and the
+      //    interactive `-ic` shell sees no tty on its fds → it won't enable job
+      //    control or tcsetpgrp the controlling terminal;
+      //  - `setsid` (when present) gives it its own session with no controlling
+      //    tty, so even rc that pokes /dev/tty directly can't grab it or
+      //    SIGTTIN-suspend us.
+      // Without this, probing a CLI during `botmux setup` could silently
+      // suspend setup (the reported "[1]+ Stopped" with no error). `-ic` is
+      // kept so rc-only installs are still found.
+      const argv = setsidBin
+        ? [setsidBin, '-w', sh, flags, `which ${cmd}`]
+        : [sh, flags, `which ${cmd}`];
+      const result = spawnSync(argv[0]!, argv.slice(1), {
+        encoding: 'utf-8',
+        timeout: 5_000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      const found = (result.stdout ?? '').trim();
+      if (found && isAbsolute(found)) return found;
     }
   }
   if (process.platform === 'darwin' && cmd === 'codex') {
@@ -47,6 +64,26 @@ export function resolveCommand(cmd: string): string {
     }
   }
   return cmd;
+}
+
+/**
+ * Locate an executable the way `execvp` will at spawn time: an absolute path is
+ * checked directly, a bare name is searched across the current process's PATH.
+ * Returns the resolved absolute path, or null when nothing runnable is found.
+ *
+ * Used by the worker as a pre-flight before spawning the CLI, so a missing
+ * binary becomes one clear, reproducible message to the user instead of a
+ * silent crash-loop. Cheap and shell-free (no rc side effects).
+ */
+export function locateOnPath(cmd: string): string | null {
+  if (isAbsolute(cmd)) {
+    try { accessSync(cmd, constants.X_OK); return cmd; } catch { return null; }
+  }
+  for (const dir of (process.env.PATH ?? '').split(':').filter(Boolean)) {
+    const candidate = join(dir, cmd);
+    try { accessSync(candidate, constants.X_OK); return candidate; } catch { /* next dir */ }
+  }
+  return null;
 }
 
 const adapterCache = new Map<string, CliAdapter>();

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -14,7 +14,7 @@
  */
 import { randomBytes } from 'node:crypto';
 import { mkdirSync, writeFileSync, unlinkSync, existsSync, statSync, readdirSync, readlinkSync, readFileSync, watch as fsWatch, createWriteStream, type FSWatcher, type WriteStream } from 'node:fs';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import { drainTranscript, joinAssistantText, findJsonlContainingFingerprint, findJsonlsContainingExactContent, findLatestJsonl, extractLastAssistantTurn, stringifyUserContent, extractTurnStartText, splitTranscriptEventsByCutoff, type TranscriptEvent } from './services/claude-transcript.js';
 import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint } from './services/bridge-turn-queue.js';
 import { shouldSuppressBridgeEmit, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
@@ -48,7 +48,7 @@ import {
   clamp,
   resolveRenderDimensions,
 } from './utils/render-dimensions.js';
-import { createCliAdapterSync } from './adapters/cli/registry.js';
+import { createCliAdapterSync, locateOnPath } from './adapters/cli/registry.js';
 import { claudeJsonlPathForSession, resolveJsonlFromPid, findOpenClaudeSessionIds, DEFAULT_CLAUDE_DATA_DIR } from './adapters/cli/claude-code.js';
 import { mtrSessionIdForBotmuxSession } from './adapters/cli/mtr.js';
 import type { CliAdapter, PtyHandle, SubmitRecheckResult } from './adapters/cli/types.js';
@@ -3054,6 +3054,25 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     log(`Re-attaching to existing ${effectiveBackendType} session: ${persistentSessionName} (requested CLI: ${cliAdapter.resolvedBin})`);
   } else {
     log(`Spawning fresh CLI: ${cliAdapter.resolvedBin} ${args.join(' ')} (cwd: ${cfg.workingDir})`);
+
+    // Pre-flight: resolvedBin resolves here (lazy). If resolveCommand fell back
+    // to a bare name and it isn't on the worker's PATH either, the spawn would
+    // fail repeatedly and surface only as a generic crash-loop ("X crashed N
+    // times"), with no hint about WHY. Instead surface ONE clear, reproducible
+    // message and stop — the user can fix PATH / install the CLI and retry.
+    const wantBin = cliAdapter.resolvedBin;
+    if (!locateOnPath(wantBin)) {
+      log(`CLI binary not found: ${wantBin} (PATH=${process.env.PATH ?? ''})`);
+      const probe = isAbsolute(wantBin) ? `ls -l ${wantBin}` : `which ${wantBin}`;
+      send({
+        type: 'user_notify',
+        message:
+          `无法启动 ${cliName()}：找不到可执行文件「${wantBin}」。\n` +
+          `请在运行 botmux daemon 的这台机器上确认它已安装并在 PATH 中（自查：${probe}），然后重发消息重试。\n` +
+          `当前 daemon PATH=${process.env.PATH ?? '(空)'}`,
+      });
+      return;
+    }
   }
 
   // Build the child env. redactChildEnv() DELETES the keys that must not leak

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -10,9 +10,12 @@ import { randomUUID } from 'node:crypto';
 // Mock external dependencies BEFORE importing adapters
 // ---------------------------------------------------------------------------
 
-// Mock child_process.execSync so resolveCommand() returns the command as-is.
+// Mock child_process so resolveCommand()'s shell probe returns nothing (the
+// command falls through to the bare name). resolveCommand short-circuits
+// absolute paths before probing, so absolute pathOverrides never hit this.
 vi.mock('node:child_process', () => ({
   execSync: vi.fn(() => ''),
+  spawnSync: vi.fn(() => ({ stdout: '', status: 0 })),
 }));
 
 import { createCliAdapterSync } from '../src/adapters/cli/registry.js';
@@ -54,6 +57,42 @@ describe('createCliAdapterSync factory', () => {
     const adapter = createCliAdapterSync(id, `/opt/${id}`);
     if (id === 'codex-app' || id === 'mira') expect(adapter.resolvedBin).toBe(process.execPath);
     else expect(adapter.resolvedBin).toBe(`/opt/${id}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 1b. Lazy binary resolution — constructing an adapter must NOT shell out.
+// Regression for the setup hang: `botmux setup` builds an adapter just to read
+// `modelChoices`; if resolveCommand ran at construction it could suspend setup
+// via the interactive shell probe. The probe must defer to first resolvedBin read.
+// ---------------------------------------------------------------------------
+
+describe('lazy binary resolution', () => {
+  // Adapters whose resolvedBin is the resolved CLI (codex-app/mira use
+  // process.execPath and never probe, so they're excluded).
+  const PROBING_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'cursor', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes'];
+
+  it.each(PROBING_IDS)('"%s": construction does not probe; first resolvedBin read does', async (id) => {
+    const { spawnSync } = await import('node:child_process');
+    const probe = vi.mocked(spawnSync);
+    probe.mockClear();
+    const adapter = createCliAdapterSync(id); // bare command name → would probe if eager
+    // Seed eagerly resolves its bin to derive its data root; the others must not
+    // touch the shell until resolvedBin is read.
+    if (id !== 'seed') expect(probe).not.toHaveBeenCalled();
+    probe.mockClear();
+    void adapter.resolvedBin;
+    if (id !== 'seed') expect(probe).toHaveBeenCalled();
+  });
+
+  it('memoises: a second resolvedBin read does not probe again', async () => {
+    const { spawnSync } = await import('node:child_process');
+    const probe = vi.mocked(spawnSync);
+    const adapter = createCliAdapterSync('claude-code');
+    void adapter.resolvedBin; // resolve + cache
+    probe.mockClear();
+    void adapter.resolvedBin; // cached → no probe
+    expect(probe).not.toHaveBeenCalled();
   });
 });
 

--- a/test/seed-adapter.test.ts
+++ b/test/seed-adapter.test.ts
@@ -13,10 +13,12 @@ import { join, dirname } from 'node:path';
 import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
 
-// resolveCommand() shells out via execSync; mock it so an absolute pathOverride
-// is returned as-is (resolveCommand short-circuits absolute paths anyway).
+// resolveCommand() shells out to probe for the binary; mock it so an absolute
+// pathOverride is returned as-is (resolveCommand short-circuits absolute paths
+// before probing anyway).
 vi.mock('node:child_process', () => ({
   execSync: vi.fn(() => ''),
+  spawnSync: vi.fn(() => ({ stdout: '', status: 0 })),
 }));
 
 import { createSeedAdapter, deriveSeedDataDir } from '../src/adapters/cli/seed.js';


### PR DESCRIPTION
## 背景

用户反馈 `botmux setup` 总是「报错」、且无明确报错原因。截图是卡在「管理员 (owner):」提示、随后 `[1]+ Stopped botmux setup`。

## 根因

`Stopped` 是**非自愿**挂起（SIGTTIN），不是用户按 Ctrl+Z：

- setup 选完 CLI、问 model 那步会 `createCliAdapterSync(cliId)` 构造 adapter，只为读静态的 `modelChoices`。
- 但 adapter 工厂在构造时就**急着**调 `resolveCommand` 跑 `$SHELL -ic 'which <cli>'`（**交互式** shell）定位二进制。
- 交互式 `-ic` 会完整 source 用户 `.zshrc/.bashrc`，且与 setup 共用控制终端 `/dev/tty`；rc 里的 `stty`/`tmux`/任务控制会搅乱 setup 自己的终端 → 紧接着「管理员 (owner)」提示读终端时被动吃到 SIGTTIN（Stopped）。
- 取决于各人的 shell 配置，所以「该用户总中招、我们复现不出」。
- 而二进制路径只有**运行时**（worker spawn、daemon `--version`）才用得到，setup 根本不需要这次探测。

## 改动

1. **惰性解析（根治）**：adapter 的 `resolvedBin` 改为惰性 getter，构造不再 shell-out，首次读取时才解析并 memo。setup 读 `modelChoices` 全程零子进程。
2. **探测加固（护栏）**：`resolveCommand` 用 `stdio: ['ignore','pipe','ignore']`（stdin/stderr 接 `/dev/null`，rc 的 `read` 拿 EOF 不阻塞、交互式 shell 看不到 tty 不做任务控制）；Linux 下再套 `setsid` 起独立会话（无控制终端，rc 碰 `/dev/tty` 也碰不到 setup 终端、发不出 SIGTTIN）。保留 `-ic` 以兼容仅装在交互式 rc 里的 CLI。
3. **runtime 失败可见可复现**：worker spawn 前置 `locateOnPath` 自检，找不到可执行文件时发一条清晰提示（命令名 + 当前 PATH + 自查命令），而不是白白进 3 次崩溃重启循环、最后只丢通用的「X 崩溃 N 次」。

`seed` 仍在构造时解析（其 `.claude-runtime` 数据根需从二进制路径推导），但探测已加固，不再能挂起 setup。

## 测试

- 新增惰性解析回归：构造不探测、首读才探测、二读走缓存（11 个 probing 适配器 + memo 用例）。
- `test/cli-adapters.test.ts`、`test/seed-adapter.test.ts` 全套通过；`tsc --noEmit` 干净。
- 全量 `vitest run` 通过（除 master 既有的 e2e 慢测）。

## 发版

随本 PR 出 `v2.58.0-canary.0` 灰度验证。
