### PR TITLE
fix(bridge): 进度 send 不再吞掉 Codex final fallback

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,6 +63,7 @@ import {
 } from './utils/bot-routing.js';
 import { isLocale, localeForBot, setDefaultLocale, SUPPORTED_LOCALES, type Locale } from './i18n/index.js';
 import { readGlobalConfig, setGlobalLocale, globalConfigPath } from './global-config.js';
+import { makeFingerprint, normaliseForFingerprint } from './services/bridge-turn-queue.js';
 
 // Resolve the CLI's UI locale once from the global config file, so subsequent
 // CLI output (and any t() callers that don't pass an explicit locale) honour
@@ -3016,11 +3017,17 @@ async function cmdSend(rest: string[]): Promise<void> {
     sendTarget.mode === 'plain'
       ? sendMessage(appId, sendTarget.chatId, content, msgType)
       : replyMessage(appId, sendTarget.root, content, msgType, true);
-  const recordBridgeSendMarker = (sentAtMs: number, messageId: string): void => {
+  const recordBridgeSendMarker = (sentAtMs: number, messageId: string, sentContent: string): void => {
     try {
       const markerDir = join(resolveDataDir(), 'turn-sends');
       if (!existsSync(markerDir)) mkdirSync(markerDir, { recursive: true });
-      const line = JSON.stringify({ sentAtMs, messageId }) + '\n';
+      const contentFingerprint = makeFingerprint(sentContent);
+      const marker: Record<string, unknown> = { sentAtMs, messageId };
+      if (contentFingerprint) {
+        marker.contentFingerprint = contentFingerprint;
+        marker.contentLength = normaliseForFingerprint(sentContent).length;
+      }
+      const line = JSON.stringify(marker) + '\n';
       appendFileSync(join(markerDir, `${sid}.jsonl`), line);
     } catch { /* best-effort: marker miss only causes a redundant fallback message */ }
   };
@@ -3364,9 +3371,10 @@ async function cmdSend(rest: string[]): Promise<void> {
     }
 
     // Bridge fallback marker — append-only jsonl per session. Same-thread
-    // sends always suppress transcript fallback; detoured sends suppress only
-    // when they closed a pending response card for this turn.
-    if (shouldRecordBridgeMarker) recordBridgeSendMarker(sentAtMs, messageId);
+    // sends can suppress transcript fallback when their content appears to
+    // cover the same final answer; detoured sends suppress only when they
+    // closed a pending response card for this turn.
+    if (shouldRecordBridgeMarker) recordBridgeSendMarker(sentAtMs, messageId, text);
 
     // Send file attachments as separate messages
     const fileIds: string[] = [];

--- a/src/services/bridge-fallback-gate.ts
+++ b/src/services/bridge-fallback-gate.ts
@@ -18,16 +18,24 @@
  *     terminal hand-typed input — the user is already looking at it, no
  *     reason to push it back to the Lark thread.
  *   - Non-adopt + send observed in window: suppress. The window is
- *     [turn.markTimeMs, nextBoundaryMs); any `botmux send` whose
- *     sentAtMs falls inside means the model already delivered this turn
- *     to Lark itself. Boundary handling intentionally also considers
+ *     [turn.markTimeMs, nextBoundaryMs). Legacy markers only carry time,
+ *     so any marker in the window still suppresses. Newer markers also
+ *     carry a fingerprint/length of the explicit `botmux send` body; when
+ *     the transcript final is available, suppress only if the explicit
+ *     send appears to cover that final. This prevents progress updates
+ *     from hiding a later substantive final answer. Boundary handling
+ *     intentionally also considers
  *     queue items that haven't reached "ready" yet (passed in via
  *     nextBoundaryMs) — without that, a model that's still mid-tool-use
  *     for turn N+1 could leak a send credit into turn N's window.
  */
+import { normaliseForFingerprint } from './bridge-turn-queue.js';
+
 export interface BridgeSendMarker {
   sentAtMs: number;
   messageId?: string;
+  contentFingerprint?: string;
+  contentLength?: number;
 }
 
 export interface BridgeGateInput {
@@ -38,6 +46,29 @@ export interface BridgeGateInput {
   /** Whether the queue synthesised this turn from a local-terminal event
    *  (no fingerprint match for a Lark message). */
   isLocal: boolean | undefined;
+  /** Transcript final text for this turn, when available. Lets structured
+   *  send markers distinguish final-answer sends from earlier progress sends. */
+  finalText?: string;
+}
+
+function markerSetCoversFinal(markers: readonly BridgeSendMarker[], finalText: string | undefined): boolean {
+  if (markers.length === 0) return false;
+
+  // Back-compat: old marker files only have sentAtMs/messageId. Keep the old
+  // conservative behavior for those entries instead of risking duplicates.
+  if (markers.some(m => typeof m.contentFingerprint !== 'string' || typeof m.contentLength !== 'number')) {
+    return true;
+  }
+
+  const finalNormalized = normaliseForFingerprint(finalText ?? '');
+  if (!finalNormalized) return true;
+
+  if (markers.some(m => m.contentFingerprint && finalNormalized.includes(m.contentFingerprint))) {
+    return true;
+  }
+
+  const sentLength = markers.reduce((sum, m) => sum + Math.max(0, m.contentLength ?? 0), 0);
+  return sentLength >= Math.floor(finalNormalized.length * 0.8);
 }
 
 export function shouldSuppressBridgeEmit(
@@ -51,5 +82,6 @@ export function shouldSuppressBridgeEmit(
   if (turn.markTimeMs === undefined) return false;
   const lower = turn.markTimeMs;
   const upper = nextBoundaryMs ?? Number.POSITIVE_INFINITY;
-  return markers.some(m => m.sentAtMs >= lower && m.sentAtMs < upper);
+  const markersInWindow = markers.filter(m => m.sentAtMs >= lower && m.sentAtMs < upper);
+  return markerSetCoversFinal(markersInWindow, turn.finalText);
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -334,12 +334,14 @@ function formatHeadlessLocalTurnContent(assistantText: string): string | null {
 
 // ─── Bridge fallback marker (non-adopt) ────────────────────────────────────
 //
-// `botmux send` (cli.ts cmdSend) appends a line `{sentAtMs, messageId}\n` to
+// `botmux send` (cli.ts cmdSend) appends a line
+// `{sentAtMs, messageId, contentFingerprint?, contentLength?}\n` to
 // `<DATA_DIR>/turn-sends/<sid>.jsonl` every time the model successfully posts
 // a reply to its OWN session thread. The worker reads these markers at idle
-// and suppresses transcript-driven final_output for any turn whose time
-// window already contains a send — i.e. the model didn't forget, no fallback
-// needed. Append-only over a shared file (instead of a per-turn marker) is
+// and suppresses transcript-driven final_output for any turn whose time window
+// already contains a send that appears to cover the same final answer — i.e.
+// the model didn't forget, no fallback needed. Append-only over a shared file
+// (instead of a per-turn marker) is
 // type-ahead safe: type-ahead'd turns each have their own [markTimeMs,
 // nextTurn.markTimeMs) window, and a stray send only fills its own bucket.
 // This relies on each turn's markTimeMs reflecting when it ACTUALLY started
@@ -1709,7 +1711,7 @@ function emitReadyCodexTurns(): void {
     const turn = ready[i];
     if (!turn.finalText) continue;
     const nextBoundaryMs = (i + 1 < ready.length ? ready[i + 1].markTimeMs : nextPendingMarkTimeMs);
-    if (shouldSuppressBridgeEmit({ markTimeMs: turn.markTimeMs, isLocal: turn.isLocal }, nextBoundaryMs, markers, adoptMode)) {
+    if (shouldSuppressBridgeEmit({ markTimeMs: turn.markTimeMs, isLocal: turn.isLocal, finalText: turn.finalText }, nextBoundaryMs, markers, adoptMode)) {
       log(`Codex bridge fallback suppressed for turn ${turn.turnId.substring(0, 8)} (gate)`);
       continue;
     }

--- a/test/bridge-fallback-gate.test.ts
+++ b/test/bridge-fallback-gate.test.ts
@@ -26,6 +26,26 @@ describe('shouldSuppressBridgeEmit', () => {
     expect(shouldSuppressBridgeEmit(turn(100), 200, markers, false)).toBe(true);
   });
 
+  it('non-adopt: structured marker suppresses when sent content matches the transcript final', () => {
+    const markers: BridgeSendMarker[] = [{ sentAtMs: 150, contentFingerprint: 'final answer body', contentLength: 42 }];
+    expect(shouldSuppressBridgeEmit(
+      { ...turn(100), finalText: 'final answer body with extra formatting' },
+      200,
+      markers,
+      false,
+    )).toBe(true);
+  });
+
+  it('non-adopt: structured progress marker does not suppress an uncovered longer transcript final', () => {
+    const markers: BridgeSendMarker[] = [{ sentAtMs: 150, contentFingerprint: 'checking repository state', contentLength: 25 }];
+    expect(shouldSuppressBridgeEmit(
+      { ...turn(100), finalText: 'The final answer contains a full implementation plan that was never explicitly sent through botmux send.' },
+      200,
+      markers,
+      false,
+    )).toBe(false);
+  });
+
   it('non-adopt: marker exactly at lower bound suppresses (>= boundary)', () => {
     const markers: BridgeSendMarker[] = [{ sentAtMs: 100 }];
     expect(shouldSuppressBridgeEmit(turn(100), 200, markers, false)).toBe(true);

--- a/test/codex-bridge-queue.test.ts
+++ b/test/codex-bridge-queue.test.ts
@@ -34,7 +34,7 @@ function emitDecisions(
     out.push({
       turnId: turn.turnId,
       suppressed: shouldSuppressBridgeEmit(
-        { markTimeMs: turn.markTimeMs, isLocal: turn.isLocal }, nextBoundaryMs, markers, adoptMode,
+        { markTimeMs: turn.markTimeMs, isLocal: turn.isLocal, finalText: turn.finalText }, nextBoundaryMs, markers, adoptMode,
       ),
     });
   }
@@ -390,6 +390,25 @@ describe('CodexBridgeQueue', () => {
 });
 
 describe('CodexBridgeQueue + bridge-fallback gate (type-ahead suppression windows)', () => {
+  it('does not let explicit progress sends suppress a later transcript final answer', () => {
+    const q = new CodexBridgeQueue();
+    q.mark('t1', 'please design the sync plan', 1_000);
+    q.ingest([
+      userEv('please design the sync plan', 'u1', 5_000),
+      asstEv(
+        'I recommend a three-layer design: keep the repository-owned scripts, install them through a setup skill, and let a user-level systemd timer own the runtime synchronization loop.',
+        'a1',
+        15_000,
+      ),
+    ]);
+
+    const markers: BridgeSendMarker[] = [
+      { sentAtMs: 7_000, contentFingerprint: 'I am checking the current repo', contentLength: 30 },
+      { sentAtMs: 10_000, contentFingerprint: 'I found the existing scripts', contentLength: 28 },
+    ];
+    expect(emitDecisions(q, markers)).toEqual([{ turnId: 't1', suppressed: false }]);
+  });
+
   it('turn1 send no longer escapes its window when turn2 was type-ahead-marked early', () => {
     // The exact P1 regression: without the dequeue-time markTimeMs override +
     // started-only boundary, turn1's window would be the bunched [1000, 1001)


### PR DESCRIPTION
## 背景 / 现象

Codex bridge fallback 会在模型没有显式调用 `botmux send` 时，从 Codex transcript 里把 `assistant_final` 转成 Lark 回复。

此前 suppression gate 只看同一 turn 时间窗口内是否出现过 `botmux send` marker。只要模型在处理中先用 `botmux send` 发过一条进度消息，后续 transcript 里的正式 final answer 就可能被认为“已经发过”，从而被 fallback 抑制。

这会导致用户在飞书里只看到中间进度，看不到最终方案或最终结论。典型顺序是：

1. 用户发起一轮请求
2. 模型先 `botmux send` 一条“我在看/我先检查”的进度
3. 模型最终把完整方案写在 Codex `assistant_final`
4. botmux 看到本轮已有 send marker，误判为最终回答已送达
5. 飞书里缺失第 3 步的完整 final answer

## 根因

`turn-sends/<session>.jsonl` 原本只有 `{ sentAtMs, messageId }`，gate 只能判断“这一轮有没有显式 send”，不能区分这条 send 是进度消息，还是已经覆盖了最终回答。

第一版修复把 marker 扩展为正文片段和长度，但单纯判断“片段是否出现在 finalText 中”仍然不够安全：如果进度消息或部分正文正好是最终回答的前缀，仍可能吞掉后续完整 final。同时累计多条无关进度消息的长度也不应该被当成 final 已覆盖。

## 修复

- `botmux send` 写入 bridge marker 时，不再保存明文正文片段，改为保存归一化正文的 hash、prefix hash、suffix hash 和长度
- `shouldSuppressBridgeEmit()` 在有结构化 marker 和 transcript finalText 时，只在以下情况下抑制 fallback：
  - 显式发送内容的完整 hash 与 finalText 匹配
  - 或 prefix/suffix hash 都匹配，且显式发送长度覆盖 finalText 的 95% 以上
- 不再用“任意片段出现在 finalText 中”或“多条 marker 累计长度足够”来抑制 final fallback
- 对很短的“已发送/已回复/sent/done”类 transcript 确认语，仍在已有结构化 marker 时保守抑制，避免重复刷一条无意义确认
- 旧 marker 缺少正文 hash 元数据时仍保持旧的保守行为，避免兼容期内产生重复回复
- `codex-app` / Mira 的 OSC final marker 路径也复用同一个内容感知 gate，不再只按时间窗口抑制

## 回归覆盖

新增/更新测试覆盖：

- 结构化 marker 内容完整匹配 transcript final 时，fallback 仍会被抑制，避免重复回复
- 结构化进度 marker 不覆盖较长 transcript final 时，fallback 不再被抑制
- 只发送 final 前缀、缺少尾部内容时，不应吞掉完整 final
- 多条无关进度 marker 即使累计长度较大，也不应吞掉完整 final
- 短确认语在已有结构化 marker 时仍保持抑制
- CodexBridgeQueue 集成场景：同一 turn 先有显式进度 send，随后 transcript 产生完整 final answer，最终应 emit fallback

## 验证

- [x] `pnpm test -- test/bridge-fallback-gate.test.ts test/codex-bridge-queue.test.ts`：52 tests 通过
- [x] `pnpm build`：通过
- [x] `git diff --check`：通过

## 影响范围

只改变 bridge fallback suppression 的判定精度：显式 final send 仍会抑制 fallback；仅当同一 turn 的显式 send 看起来只是进度消息、部分前缀或无关中间消息、没有覆盖 transcript final 时，Codex final fallback 会继续发出。旧 marker 仍按原保守逻辑处理。