### PR TITLE
fix(worker): 避免 Codex submit confirmation 活跃误报

### DIFF
--- a/src/services/submit-confirmation.ts
+++ b/src/services/submit-confirmation.ts
@@ -1,0 +1,23 @@
+export type SubmitActivityEvidence = 'pty-output' | 'structured-transcript' | 'botmux-send';
+
+export type SubmitConfirmationAction =
+  | { kind: 'notify-hard-failure'; reason: string }
+  | { kind: 'suppress-confirmed' }
+  | { kind: 'suppress-usage-limit' }
+  | { kind: 'suppress-active'; evidence: SubmitActivityEvidence }
+  | { kind: 'notify-stuck' };
+
+export interface SubmitConfirmationDecisionInput {
+  failureReason?: string;
+  recheckSubmitted: boolean;
+  usageLimitDetected: boolean;
+  activityEvidence?: SubmitActivityEvidence;
+}
+
+export function decideSubmitConfirmationAction(input: SubmitConfirmationDecisionInput): SubmitConfirmationAction {
+  if (input.failureReason) return { kind: 'notify-hard-failure', reason: input.failureReason };
+  if (input.recheckSubmitted) return { kind: 'suppress-confirmed' };
+  if (input.usageLimitDetected) return { kind: 'suppress-usage-limit' };
+  if (input.activityEvidence) return { kind: 'suppress-active', evidence: input.activityEvidence };
+  return { kind: 'notify-stuck' };
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -71,6 +71,7 @@ import { chooseWebTerminalSeed } from './utils/web-terminal-seed.js';
 import { detectCliUsageLimit, usageLimitStateKey, type CliUsageLimitState } from './utils/cli-usage-limit.js';
 import { uploadImageBuffer } from './utils/lark-upload.js';
 import { redactChildEnv } from './utils/child-env.js';
+import { decideSubmitConfirmationAction, type SubmitActivityEvidence } from './services/submit-confirmation.js';
 import { config } from './config.js';
 import * as sessionStore from './services/session-store.js';
 import * as pty from 'node-pty';
@@ -120,6 +121,10 @@ let isPromptReady = false;
 /** Mutex for async flushPending — prevents concurrent flush loops. */
 let isFlushing = false;
 const pendingMessages: string[] = [];
+/** Alternate submit-confirmation signals. Some CLIs can consume PTY input and
+ *  start work before their history/transcript submit marker is observable. */
+let lastPtyActivityAtMs = 0;
+let lastStructuredBridgeActivityAtMs = 0;
 
 type RuntimeScreenStatus = Exclude<ScreenStatus, 'limited'>;
 
@@ -369,6 +374,13 @@ function readSendMarkers(): BridgeSendMarker[] {
     log(`Bridge marker read failed: ${err.message}`);
     return [];
   }
+}
+
+function submitActivityEvidenceSince(sinceMs: number): SubmitActivityEvidence | undefined {
+  if (lastPtyActivityAtMs > sinceMs) return 'pty-output';
+  if (lastStructuredBridgeActivityAtMs > sinceMs) return 'structured-transcript';
+  if (readSendMarkers().some(m => m.sentAtMs >= sinceMs)) return 'botmux-send';
+  return undefined;
 }
 
 function clearSendMarkers(): void {
@@ -1099,6 +1111,7 @@ function bridgeIngest(): void {
   const result = drainTranscript(bridgeJsonlPath, bridgeOffset);
   bridgeOffset = result.newOffset;
   bridgePendingTail = result.pendingTail;
+  if (result.events.length > 0) lastStructuredBridgeActivityAtMs = Date.now();
   bridgeQueue.ingest(result.events, bridgeJsonlPath);
 }
 
@@ -1505,6 +1518,7 @@ function hermesBridgeIngest(): void {
   if (!hermesBridgeBaselineDone) return;
   const result = drainHermesStateDb(hermesBridgeOffset);
   hermesBridgeOffset = result.newOffset;
+  if (result.events.length > 0) lastStructuredBridgeActivityAtMs = Date.now();
   codexBridgeQueue.ingest(result.events);
   if (result.events.some(e => e.kind === 'assistant_final')) {
     idleDetector?.fireIdle();
@@ -1542,6 +1556,7 @@ function mtrBridgeIngest(): void {
   if (!mtrBridgeBaselineDone || !mtrBridgeSource) return;
   const result = drainMtrSession(mtrBridgeSource, mtrBridgeOffset);
   mtrBridgeOffset = result.newOffset;
+  if (result.events.length > 0) lastStructuredBridgeActivityAtMs = Date.now();
   codexBridgeQueue.ingest(result.events);
   if (result.events.some(e => e.kind === 'assistant_final')) {
     idleDetector?.fireIdle();
@@ -1655,6 +1670,7 @@ function codexBridgeIngest(): void {
   const result = structuredBridgeIngestPath(codexBridgeRolloutPath, codexBridgeOffset);
   codexBridgeOffset = result.newOffset;
   codexBridgePendingTail = result.pendingTail;
+  if (result.events.length > 0) lastStructuredBridgeActivityAtMs = Date.now();
   codexBridgeQueue.ingest(result.events);
   // Transcript-driven idle: an `assistant_final` event is the CLI declaring
   // end-of-turn, far more reliable than the screen-pattern heuristic
@@ -2360,6 +2376,7 @@ function splitCodexAppControl(data: string): string {
 function onPtyData(data: string): void {
   data = splitCodexAppControl(data);
   if (data.length === 0) return;
+  lastPtyActivityAtMs = Date.now();
   captureWorkflowTranscript(data);
   renderer?.write(data);
 
@@ -2490,42 +2507,67 @@ function scheduleSubmitFailureNotify(
     }
   };
   if (failureReason) {
+    const action = decideSubmitConfirmationAction({
+      failureReason,
+      recheckSubmitted: false,
+      usageLimitDetected: false,
+    });
     dropBridgeMark();
-    log(`writeInput: submit impossible — notifying user immediately. reason="${failureReason}" preview="${preview}"`);
+    const reason = action.kind === 'notify-hard-failure' ? action.reason : failureReason;
+    log(`writeInput: submit impossible — notifying user immediately. reason="${reason}" preview="${preview}"`);
     send({
       type: 'user_notify',
-      message: `⚠️ 刚才那条消息没有写入 ${cliName()}，因为当前按键配置无法从终端自动提交。\n原因：${failureReason}\n请调整 Claude Code Chat keybinding 后重发。\n开头：${preview}`,
+      message: `⚠️ 刚才那条消息没有写入 ${cliName()}，因为当前按键配置无法从终端自动提交。\n原因：${reason}\n请调整 Claude Code Chat keybinding 后重发。\n开头：${preview}`,
     });
     return;
   }
+  const activityBaselineMs = Date.now();
   log(`writeInput: submit not confirmed after retries — deferred ${SUBMIT_DEFERRED_RECHECK_MS}ms recheck queued. preview="${preview}"`);
   setTimeout(async () => {
+    let recheckSubmitted = false;
+    let cliSessionId: string | undefined;
     if (recheck) {
       try {
         const recheckResult = await recheck();
-        const recheckSubmitted = typeof recheckResult === 'boolean'
+        recheckSubmitted = typeof recheckResult === 'boolean'
           ? recheckResult
           : recheckResult.submitted === true;
-        if (recheckSubmitted) {
-          const cliSessionId = typeof recheckResult === 'object' && recheckResult && typeof recheckResult.cliSessionId === 'string'
-            ? recheckResult.cliSessionId
-            : undefined;
-          if (cliSessionId) {
-            persistCliSessionId(cliSessionId);
-            if (codexBridgeFallbackActive()) codexBridgeNotifyCliSessionId(cliSessionId);
-          }
-          log(`Deferred recheck found submit in ${transcriptLabel} — suppressing warning. preview="${preview}"`);
-          return;
-        }
+        cliSessionId = typeof recheckResult === 'object' && recheckResult && typeof recheckResult.cliSessionId === 'string'
+          ? recheckResult.cliSessionId
+          : undefined;
       } catch (err: any) {
         log(`Deferred recheck threw (${err?.message ?? err}); falling through to warning.`);
       }
     }
-    if (usageLimitTracker.detectedThisTurn(turnSeq)) {
-      dropBridgeMark();
-      log(`Deferred recheck missing but usage limit was detected for this turn — suppressing submit warning. preview="${preview}"`);
-      return;
+
+    const action = decideSubmitConfirmationAction({
+      recheckSubmitted,
+      usageLimitDetected: usageLimitTracker.detectedThisTurn(turnSeq),
+      activityEvidence: submitActivityEvidenceSince(activityBaselineMs),
+    });
+
+    switch (action.kind) {
+      case 'suppress-confirmed':
+        if (cliSessionId) {
+          persistCliSessionId(cliSessionId);
+          if (codexBridgeFallbackActive()) codexBridgeNotifyCliSessionId(cliSessionId);
+        }
+        log(`Deferred recheck found submit in ${transcriptLabel} — suppressing warning. preview="${preview}"`);
+        return;
+      case 'suppress-usage-limit':
+        dropBridgeMark();
+        log(`Deferred recheck missing but usage limit was detected for this turn — suppressing submit warning. preview="${preview}"`);
+        return;
+      case 'suppress-active':
+        log(`Deferred recheck missing but later ${action.evidence} shows ${cliName()} is active — suppressing submit warning. preview="${preview}"`);
+        return;
+      case 'notify-hard-failure':
+        // failureReason is handled synchronously above.
+        return;
+      case 'notify-stuck':
+        break;
     }
+
     dropBridgeMark();
     log(`Deferred recheck still missing — notifying user. preview="${preview}"`);
     send({

--- a/test/submit-confirmation.test.ts
+++ b/test/submit-confirmation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { decideSubmitConfirmationAction } from '../src/services/submit-confirmation.js';
+
+describe('decideSubmitConfirmationAction', () => {
+  it('notifies immediately when the adapter reports a hard failure reason', () => {
+    expect(decideSubmitConfirmationAction({
+      failureReason: 'unsupported submit key',
+      recheckSubmitted: false,
+      usageLimitDetected: false,
+      activityEvidence: undefined,
+    })).toEqual({ kind: 'notify-hard-failure', reason: 'unsupported submit key' });
+  });
+
+  it('suppresses the user warning when submit is unconfirmed but later activity proves the CLI consumed it', () => {
+    expect(decideSubmitConfirmationAction({
+      recheckSubmitted: false,
+      usageLimitDetected: false,
+      activityEvidence: 'pty-output',
+    })).toEqual({ kind: 'suppress-active', evidence: 'pty-output' });
+  });
+
+  it('suppresses the user warning when the deferred recheck eventually confirms the submit', () => {
+    expect(decideSubmitConfirmationAction({
+      recheckSubmitted: true,
+      usageLimitDetected: false,
+      activityEvidence: undefined,
+    })).toEqual({ kind: 'suppress-confirmed' });
+  });
+
+  it('suppresses the user warning when the turn hit a usage limit instead of a stuck input', () => {
+    expect(decideSubmitConfirmationAction({
+      recheckSubmitted: false,
+      usageLimitDetected: true,
+      activityEvidence: undefined,
+    })).toEqual({ kind: 'suppress-usage-limit' });
+  });
+
+  it('notifies when submit is unconfirmed and there is no later activity evidence', () => {
+    expect(decideSubmitConfirmationAction({
+      recheckSubmitted: false,
+      usageLimitDetected: false,
+      activityEvidence: undefined,
+    })).toEqual({ kind: 'notify-stuck' });
+  });
+});


### PR DESCRIPTION
## 背景 / 现象

botmux 的 submit confirmation 会在 `writeInput()` 没能从 Codex history / 会话 JSONL 中确认用户消息提交时，延迟 20s 再复查；如果还是没匹配到，就向用户发送“可能卡在输入框里”的 warning。

这个判断在真正提交失败时很有用，不能简单删除。但在 Codex 0.136 一类终端交互里，`history.jsonl` / transcript submit marker 不是唯一可靠信号：PTY 输入可能已经被 Codex 消费并开始执行，只是确认记录缺失、延迟或被 wrapper/history bridge 隔离影响。

实际观察到的误报形态是：

1. worker 已经 `Writing to PTY (flush)`
2. `writeInput` 的 history/transcript retry 没确认 submit，排 20s deferred recheck
3. deferred recheck 仍没匹配到 submit marker，于是发 user warning
4. 但同一个 Codex/tmux 会话已经显示完整 `<user_message>`，并继续执行工具调用，最后还通过 `botmux send` 发出了回复

也就是说，“未在 history/transcript 中确认 submit”被近似成了“消息没提交成功”，这个近似会产生 false positive。

## 根因

`submit-not-confirmed` 的 deferred path 目前只参考：

- adapter 的 `recheck()` 是否在 history/transcript 中找到 submit marker
- 本 turn 是否命中 usage limit

如果两者都没有，就直接 notify 用户。

它没有在发 warning 前检查其它“CLI 已消费这条输入”的信号，例如：

- deferred window 内 PTY 又输出了内容
- 结构化 transcript bridge 观察到后续事件
- 同 session 已出现 `botmux send` marker

所以在 Codex 已经开始工作、但 submit marker 缺失或延迟时，会误报“可能卡在输入框”。

## 修复

- 新增 `submit-confirmation` 判定服务，把 submit confirmation 后续动作分成：
  - `notify-hard-failure`：adapter 明确给出 `failureReason`，立即通知
  - `suppress-confirmed`：deferred recheck 确认 submit，抑制 warning
  - `suppress-usage-limit`：本 turn 命中 usage limit，抑制 warning
  - `suppress-active`：未确认 submit，但观察到 CLI 后续活跃，抑制 warning
  - `notify-stuck`：未确认且没有任何活跃证据，继续通知用户
- worker 在 submit retry 失败后记录一个 activity baseline。
- deferred recheck 失败时，在 notify 前检查 baseline 之后是否出现：
  - PTY output
  - structured transcript event
  - 当前 session 的 `botmux send` marker
- 观察到活跃证据时只记录日志，不向用户发送“卡输入框”warning。
- `failureReason` hard failure 分支保持立即告警，真正无法自动提交的情况不被屏蔽。

## 关于 wrapper

这类误报在使用定制 wrapper 的 Codex bot 上更容易暴露，例如 wrapper 使用专用 `CODEX_HOME` / history bridge 隔离运行环境时，botmux 的 history submit marker 可能更容易和真实 PTY 消费状态错开。

但只要 worker 已经观察到 CLI 在 deferred window 内继续输出、结构化 transcript 有事件、或 agent 已经 `botmux send`，就不应该再把“submit marker 未匹配”当作“输入卡住”。因此修复放在 botmux 的 submit warning gate，而不是要求每个 wrapper 自行规避。

## 回归覆盖

新增 `test/submit-confirmation.test.ts` 覆盖：

- `failureReason` hard failure 仍走立即 notify
- recheck false 但有 `pty-output` 活跃证据时 suppress warning
- recheck true 时 suppress warning
- usage limit 时 suppress warning
- recheck false 且无任何活跃证据时继续 notify stuck

相邻 `write-input.test.ts` 也继续覆盖 adapter 的 submit retry / deferred recheck 行为。

## 验证

- [x] `pnpm test -- test/submit-confirmation.test.ts`：5 tests 通过
- [x] `pnpm test -- test/submit-confirmation.test.ts test/write-input.test.ts`：98 tests 通过
- [x] `pnpm build`：通过
- [x] `git diff --check`：通过

## 影响范围

只收窄 deferred submit warning 的触发条件。

真正的 hard failure 和“未确认、无活跃证据、看起来仍可能卡住”的情况仍会通知用户；已观察到 CLI 后续处理迹象的情况不再误报。
