### PR TITLE
Open terminal links in Lark sidebar

### DIFF
--- a/src/adapters/backend/session-backend-selector.ts
+++ b/src/adapters/backend/session-backend-selector.ts
@@ -56,9 +56,11 @@ export function selectSessionBackend(opts: { sessionId: string; backendType: Bac
   }
 
   const sessionName = TmuxBackend.sessionName(opts.sessionId);
-  if (TmuxBackend.hasSession(sessionName)) {
+  const groupSessionName = TmuxBackend.groupSessionName();
+  const paneTarget = groupSessionName ? `${groupSessionName}:${sessionName}` : sessionName;
+  if (groupSessionName ? TmuxBackend.hasWindow(paneTarget) : TmuxBackend.hasSession(sessionName)) {
     return {
-      backend: new TmuxPipeBackend(sessionName, { ownsSession: true, isReattach: true }),
+      backend: new TmuxPipeBackend(paneTarget, { ownsSession: true, isReattach: true, groupSessionName }),
       isTmuxMode: true,
       isPipeMode: true,
       isZellijMode: false,
@@ -66,7 +68,7 @@ export function selectSessionBackend(opts: { sessionId: string; backendType: Bac
   }
 
   return {
-    backend: new TmuxPipeBackend(sessionName, { createSession: true, ownsSession: true }),
+    backend: new TmuxPipeBackend(paneTarget, { createSession: true, ownsSession: true, groupSessionName }),
     isTmuxMode: true,
     isPipeMode: true,
     isZellijMode: false,

--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -28,6 +28,10 @@ const REDACTED_ENV_UNSET_CLAUSE = `unset ${REDACTED_CHILD_ENV_KEYS.join(' ')}`;
  *   - destroySession() kills the tmux session (for explicit /close)
  *
  * Naming: tmux sessions are named `bmx-<sessionId.slice(0,8)>`.
+ *
+ * Optional shared-session mode: when BOTMUX_TMUX_GROUP_SESSION is set, botmux
+ * keeps all managed tmux windows inside that single tmux session. Each agent
+ * session still gets an isolated window named `bmx-<sessionId.slice(0,8)>`.
  */
 export class TmuxBackend implements SessionBackend {
   private process: pty.IPty | null = null;
@@ -69,6 +73,24 @@ export class TmuxBackend implements SessionBackend {
     return `bmx-${sessionId.slice(0, 8)}`;
   }
 
+  /** Optional shared tmux session name. Empty / unset keeps legacy per-session mode. */
+  static groupSessionName(): string | undefined {
+    const name = process.env.BOTMUX_TMUX_GROUP_SESSION?.trim();
+    return name || undefined;
+  }
+
+  /** Window name used inside BOTMUX_TMUX_GROUP_SESSION shared-session mode. */
+  static groupWindowName(sessionId: string): string {
+    return TmuxBackend.sessionName(sessionId);
+  }
+
+  /** tmux target for a managed Botmux pane/session. */
+  static managedTarget(sessionId: string): string {
+    const group = TmuxBackend.groupSessionName();
+    const name = TmuxBackend.sessionName(sessionId);
+    return group ? `${group}:${name}` : name;
+  }
+
   /** Check if a named tmux session exists. */
   static hasSession(name: string): boolean {
     try {
@@ -79,6 +101,11 @@ export class TmuxBackend implements SessionBackend {
     }
   }
 
+  /** Check if a shared-session window target exists. */
+  static hasWindow(target: string): boolean {
+    return TmuxBackend.hasSession(target);
+  }
+
   /** Kill a named tmux session (no-op if it doesn't exist). */
   static killSession(name: string): void {
     try {
@@ -86,9 +113,24 @@ export class TmuxBackend implements SessionBackend {
     } catch { /* session doesn't exist */ }
   }
 
+  /** Kill a specific tmux window (used by shared-session mode). */
+  static killWindow(target: string): void {
+    try {
+      execSync(`tmux kill-window -t ${shellescape(target)}`, { stdio: 'ignore', env: tmuxEnv() });
+    } catch { /* window doesn't exist */ }
+  }
+
   /** List all botmux tmux sessions (bmx-* prefix). */
   static listBotmuxSessions(): string[] {
     try {
+      const group = TmuxBackend.groupSessionName();
+      if (group) {
+        const out = execSync(`tmux list-windows -t ${shellescape(group)} -F '#{window_name}' 2>/dev/null`, {
+          encoding: 'utf-8',
+          env: tmuxEnv(),
+        });
+        return out.split('\n').filter(s => s.startsWith('bmx-')).map(s => `${group}:${s}`);
+      }
       const out = execSync("tmux list-sessions -F '#{session_name}' 2>/dev/null", {
         encoding: 'utf-8',
         env: tmuxEnv(),

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -84,6 +84,8 @@ export function composeSeedBody(
 export class TmuxPipeBackend implements SessionBackend {
   /** Real tmux pane address (e.g. "0:2.0") or botmux session name (bmx-*). */
   private readonly paneTarget: string;
+  /** Optional shared tmux session that owns this backend's botmux window. */
+  private readonly groupSessionName?: string;
   private readonly fifoPath: string;
   private readStream: fs.ReadStream | null = null;
   /** Streaming UTF-8 decoder. The fifo read emits raw Buffer chunks at libuv's
@@ -128,18 +130,19 @@ export class TmuxPipeBackend implements SessionBackend {
    *  file's cwd field so a recycled PID can't mislead the resolver. */
   cliCwd?: string;
 
-  /** Whether this backend re-attached to an existing bmx-* tmux session
+  /** Whether this backend re-attached to an existing bmx-* tmux session/window
    *  (rather than creating a new detached one). Mirrors TmuxBackend.isReattach
    *  so the worker can branch on reattach behaviour without a private-cast. */
   get isReattach(): boolean {
     return this._isReattach;
   }
 
-  constructor(paneTarget: string, opts?: { createSession?: boolean; ownsSession?: boolean; isReattach?: boolean }) {
+  constructor(paneTarget: string, opts?: { createSession?: boolean; ownsSession?: boolean; isReattach?: boolean; groupSessionName?: string }) {
     this.paneTarget = paneTarget;
     this.createSession = opts?.createSession ?? false;
     this.ownsSession = opts?.ownsSession ?? false;
     this._isReattach = opts?.isReattach ?? false;
+    this.groupSessionName = opts?.groupSessionName;
     // Per-instance fifo so concurrent adopt sessions don't collide.
     this.fifoPath = join(tmpdir(), `botmux-pipe-${randomBytes(8).toString('hex')}.fifo`);
   }
@@ -147,7 +150,7 @@ export class TmuxPipeBackend implements SessionBackend {
   // ─── SessionBackend implementation ────────────────────────────────────────
 
   /** spawn() sets up the pipe-pane subscription + fifo reader. In managed
-   *  mode it first creates a detached bmx-* tmux session that runs the CLI. */
+   *  mode it first creates a detached bmx-* tmux session/window that runs the CLI. */
   spawn(bin: string, args: string[], opts: SpawnOpts): void {
     this.cols = opts.cols;
     this.rows = opts.rows;
@@ -155,7 +158,7 @@ export class TmuxPipeBackend implements SessionBackend {
     if (this.createSession) {
       this.createDetachedSession(bin, args, opts);
     } else if (this.ownsSession && this._isReattach) {
-      // Backfill tmux options on an existing bmx-* session — daemon may have
+      // Backfill tmux options on an existing bmx-* session/window — daemon may have
       // been upgraded since the session was originally created, and options
       // like set-clipboard / window-size largest are idempotent to re-apply.
       this.applySessionOptions();
@@ -406,7 +409,8 @@ export class TmuxPipeBackend implements SessionBackend {
   destroySession(): void {
     this.kill();
     if (this.ownsSession) {
-      TmuxBackend.killSession(this.paneTarget);
+      if (this.groupSessionName) TmuxBackend.killWindow(this.paneTarget);
+      else TmuxBackend.killSession(this.paneTarget);
     }
   }
 
@@ -472,24 +476,74 @@ export class TmuxPipeBackend implements SessionBackend {
   private createDetachedSession(bin: string, args: string[], opts: SpawnOpts): void {
     const shellSpec = resolveUserShell();
     const envAssignments = buildBotmuxEnvAssignments(opts.env);
-    execFileSync('tmux', [
-      'new-session',
-      '-d',
-      '-s', this.paneTarget,
-      '-x', String(opts.cols),
-      '-y', String(opts.rows),
-      '--',
+    const command = [
       shellSpec.shell, ...shellSpec.flags, '-c', SHELL_WRAPPER_SCRIPT, '_',
       opts.cwd,
       ...envAssignments,
       bin, ...args,
+    ];
+    if (this.groupSessionName) {
+      this.createGroupedWindow(command, opts);
+    } else {
+      execFileSync('tmux', [
+        'new-session',
+        '-d',
+        '-s', this.paneTarget,
+        '-x', String(opts.cols),
+        '-y', String(opts.rows),
+        '--',
+        ...command,
+      ], {
+        cwd: opts.cwd,
+        stdio: 'ignore',
+        timeout: 5000,
+        env: tmuxEnv(opts.env),
+      });
+    }
+    this.applySessionOptions();
+  }
+
+  private createGroupedWindow(command: string[], opts: SpawnOpts): void {
+    const group = this.groupSessionName!;
+    const windowName = this.paneTarget.slice(group.length + 1);
+    const env = tmuxEnv(opts.env);
+    if (!TmuxBackend.hasSession(group)) {
+      execFileSync('tmux', [
+        'new-session',
+        '-d',
+        '-s', group,
+        '-n', windowName,
+        '-x', String(opts.cols),
+        '-y', String(opts.rows),
+        '--',
+        ...command,
+      ], {
+        cwd: opts.cwd,
+        stdio: 'ignore',
+        timeout: 5000,
+        env,
+      });
+      return;
+    }
+
+    execFileSync('tmux', [
+      'new-window',
+      '-d',
+      '-t', group,
+      '-n', windowName,
+      '--',
+      ...command,
     ], {
       cwd: opts.cwd,
       stdio: 'ignore',
       timeout: 5000,
-      env: tmuxEnv(opts.env),
+      env,
     });
-    this.applySessionOptions();
+    execFileSync('tmux', ['resize-window', '-t', this.paneTarget, '-x', String(opts.cols), '-y', String(opts.rows)], {
+      stdio: 'ignore',
+      timeout: 5000,
+      env,
+    });
   }
 
   private applySessionOptions(): void {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,7 +48,7 @@ import { buildPreset, serializePreset, presetFilename } from './setup/agent-pres
 import type { CliId } from './adapters/cli/types.js';
 import { createCliAdapterSync } from './adapters/cli/registry.js';
 import { logger } from './utils/logger.js';
-import { invalidWorkingDirs } from './utils/working-dir.js';
+import { invalidWorkingDirs, normalizeWorkingDirInput } from './utils/working-dir.js';
 import { firstPositional } from './cli/arg-utils.js';
 import {
   formatBotInfoEntriesForCli,
@@ -673,7 +673,12 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
     console.log('   不写 bots.json。请重新运行 botmux setup。');
     return null;
   }
-  const workingDir = await ask(rl, '默认工作目录 [~]: ');
+  printInputHelp('默认工作目录', [
+    '留空沿用兼容默认值 ~（当前用户 home）；不改变老用户一路回车的行为。',
+    `当前命令所在目录是：${process.cwd()}；如果想使用它，请输入 .`,
+    '相对路径（如 docai/docai-oncall）会按当前命令所在目录解析；如要放在 home 下请写 ~/docai/docai-oncall。',
+  ]);
+  const workingDir = await ask(rl, '默认工作目录 [~]（当前目录请输入 .）: ');
   const modelChoice = await promptModel(rl, cliId);
 
   // 不再持久化 brand 字段: setup 阶段 brand=lark 直接被 obtainCredentials 中止,
@@ -684,9 +689,9 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
     larkAppId: creds.appId,
     larkAppSecret: creds.appSecret,
     cliId,
-    // 总是写 workingDir, 留空用 '~'. 用户手动编辑 bots.json 时一眼能看到字段
+    // 总是写 workingDir, 留空兼容旧版用 '~'. 用户手动编辑 bots.json 时一眼能看到字段
     // 在哪儿, 不用去 README 查字段名.
-    workingDir: workingDir.trim() || '~',
+    workingDir: normalizeWorkingDirInput(workingDir),
   };
   // modelChoice === undefined → 该 CLI 没声明候选 / 用户跳过；不写 model 字段
   if (typeof modelChoice === 'string' && modelChoice) {
@@ -809,6 +814,8 @@ async function promptEditBotConfig(
 
   printInputHelp('默认工作目录', [
     '可选。新会话默认进入的目录，支持逗号分隔多个候选目录。',
+    '推荐输入 ~/xxx 或 /绝对路径，语义最明确。',
+    '相对路径（如 docai/docai-oncall）会按当前命令所在目录解析；如要放在 home 下请写 ~/docai/docai-oncall。',
     '留空保留当前值；输入 - 清空并回到默认 ~。',
   ]);
   input.workingDir = await ask(rl, `默认工作目录 [${formatOptionalValue(bot.workingDir)}]: `);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@
  *   botmux delete all     — close all active sessions
  *   botmux autostart enable|disable|status — manage boot-time autostart (launchd / user systemd)
  */
-import { execSync, spawnSync, spawn } from 'node:child_process';
+import { execSync, execFileSync, spawnSync, spawn } from 'node:child_process';
 import { existsSync, mkdirSync, copyFileSync, readFileSync, writeFileSync, renameSync, readdirSync, readlinkSync, appendFileSync, statSync, unlinkSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
@@ -1862,6 +1862,34 @@ function tmuxSessionExists(name: string): boolean {
   }
 }
 
+function botmuxTmuxTarget(sessionId: string): string {
+  const name = `bmx-${sessionId.substring(0, 8)}`;
+  const group = process.env.BOTMUX_TMUX_GROUP_SESSION?.trim();
+  return group ? `${group}:${name}` : name;
+}
+
+function botmuxTmuxTargetExists(sessionId: string): boolean {
+  return tmuxSessionExists(botmuxTmuxTarget(sessionId));
+}
+
+function killBotmuxTmuxTarget(sessionId: string): string | undefined {
+  const target = botmuxTmuxTarget(sessionId);
+  const group = process.env.BOTMUX_TMUX_GROUP_SESSION?.trim();
+  try {
+    const args = group ? ['kill-window', '-t', target] : ['kill-session', '-t', target];
+    execFileSync('tmux', args, { stdio: 'ignore', env: tmuxEnv() });
+    return target;
+  } catch {
+    return undefined;
+  }
+}
+
+function tmuxAttachArgsForTarget(target: string): string[] {
+  // tmux accepts `session:window` directly for attach-session and selects that
+  // window inside the shared group session.
+  return ['attach-session', '-t', target];
+}
+
 /** Shorten path for display: replace $HOME with ~. */
 function shortenPath(p: string): string {
   const home = homedir();
@@ -1918,8 +1946,8 @@ function interactiveSessionPicker(active: SessionData[]): Promise<void> {
       const status = (alive ? 'online' : s.pid ? 'stopped' : 'idle').padEnd(cols.status);
       parts.push(title, dir, pid, uptime, status);
 
-      const tmuxName = `bmx-${s.sessionId.substring(0, 8)}`;
-      const hasTmux = tmuxSessionExists(tmuxName);
+      const tmuxName = botmuxTmuxTarget(s.sessionId);
+      const hasTmux = botmuxTmuxTargetExists(s.sessionId);
       return { session: s, text: parts.join(' │ '), alive, tmuxName, hasTmux };
     });
   }
@@ -2025,7 +2053,7 @@ function interactiveSessionPicker(active: SessionData[]): Promise<void> {
 
       // Kill tmux session
       if (r.hasTmux) {
-        try { execSync(`tmux kill-session -t '${r.tmuxName}' 2>/dev/null`, { stdio: 'ignore', env: tmuxEnv() }); } catch { /* */ }
+        killBotmuxTmuxTarget(s.sessionId);
       }
 
       // Mark closed & persist
@@ -2100,7 +2128,7 @@ function interactiveSessionPicker(active: SessionData[]): Promise<void> {
           return;
         }
         cleanup();
-        spawnSync('tmux', ['attach-session', '-t', selected.tmuxName], {
+        spawnSync('tmux', tmuxAttachArgsForTarget(selected.tmuxName), {
           stdio: 'inherit',
           env: tmuxEnv(),
         });
@@ -2120,7 +2148,7 @@ async function cmdList(): Promise<void> {
   const live: SessionData[] = [];
   for (const s of active) {
     const hasPid = !!(s.pid && isProcessAlive(s.pid));
-    const hasTmux = tmuxSessionExists(`bmx-${s.sessionId.substring(0, 8)}`);
+    const hasTmux = botmuxTmuxTargetExists(s.sessionId);
     if (!hasPid && !hasTmux) {
       pruned.push(s);
     } else {
@@ -2176,7 +2204,7 @@ function cmdDelete(): void {
   } else if (target === 'stopped') {
     toDelete = active.filter(s => {
       const hasPid = !!(s.pid && isProcessAlive(s.pid));
-      const hasTmux = tmuxSessionExists(`bmx-${s.sessionId.substring(0, 8)}`);
+      const hasTmux = botmuxTmuxTargetExists(s.sessionId);
       return !hasPid && !hasTmux;
     });
     if (toDelete.length === 0) {
@@ -2208,11 +2236,8 @@ function cmdDelete(): void {
     }
 
     // Kill associated tmux session if it exists
-    const tmuxName = `bmx-${s.sessionId.substring(0, 8)}`;
-    try {
-      execSync(`tmux kill-session -t '${tmuxName}' 2>/dev/null`, { stdio: 'ignore', env: tmuxEnv() });
-      console.log(`  killed tmux ${tmuxName}`);
-    } catch { /* no tmux session */ }
+    const killedTmux = killBotmuxTmuxTarget(s.sessionId);
+    if (killedTmux) console.log(`  killed tmux ${killedTmux}`);
 
     // Mark session as closed
     s.status = 'closed';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,6 +41,7 @@ import {
   resolveCliId,
   assertOwnerWhenChatGroups,
   findInvalidAllowedUserEntries,
+  formatBotConfigTableRows,
   hasOwnerEntry,
   type BotConfigEditInput,
 } from './setup/bot-config-editor.js';
@@ -708,6 +709,9 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
     bot.allowedUsers = await promptRequiredOwner(rl);
   }
 
+  const appName = await refreshBotAppName(bot);
+  if (appName) console.log(`App Name: ${appName}\n`);
+
   if (!ensureBotWorkingDirsExist(bot, '默认工作目录')) return null;
 
   return normalizeBotConfig(bot);
@@ -728,19 +732,89 @@ function formatOptionalValue(v: unknown): string {
  * parseBotSelection 不再接受裸数字, 避免又冒出 "序号到底是几" 的歧义.
  */
 function formatBotConfigTable(bots: any[]): string {
-  if (bots.length === 0) return '';
-  const headers = ['进程名', 'App ID', 'CLI'];
-  const rows = bots.map((b, i) => [
-    botProcessName(b, i, PM2_NAME),
-    String(b?.larkAppId ?? ''),
-    String(b?.cliId ?? 'claude-code'),
-  ]);
-  const widths = headers.map((h, c) =>
-    Math.max(displayWidth(h), ...rows.map(r => displayWidth(r[c]))),
+  const appNames = loadKnownBotAppNames();
+  return formatBotConfigTableRows(bots.map((b, i) => ({
+    processName: botProcessName(b, i, PM2_NAME),
+    appName: knownBotAppName(b, appNames),
+    appId: String(b?.larkAppId ?? ''),
+    cliId: String(b?.cliId ?? 'claude-code'),
+  })));
+}
+
+type BotInfoEntryForSetup = { larkAppId?: string; botName?: string | null; appName?: string | null };
+
+function loadKnownBotAppNames(): Map<string, string> {
+  const map = new Map<string, string>();
+
+  const ingest = (entries: unknown): void => {
+    if (!Array.isArray(entries)) return;
+    for (const entry of entries as BotInfoEntryForSetup[]) {
+      const appId = typeof entry?.larkAppId === 'string' ? entry.larkAppId : '';
+      const name = typeof entry?.botName === 'string'
+        ? entry.botName.trim()
+        : typeof entry?.appName === 'string'
+          ? entry.appName.trim()
+          : '';
+      if (appId && name) map.set(appId, name);
+    }
+  };
+
+  // Populated by running daemons after /bot/v3/info; available even when setup
+  // is offline and avoids a network call in the common restart/edit path.
+  try { ingest(JSON.parse(readFileSync(join(DATA_DIR, 'bots-info.json'), 'utf-8'))); } catch { /* ignore */ }
+  // Cache written by setup's own best-effort lookup, so the name can show even
+  // before the first daemon start.
+  try { ingest(JSON.parse(readFileSync(join(CONFIG_DIR, 'bots-app-names.json'), 'utf-8'))); } catch { /* ignore */ }
+
+  return map;
+}
+
+function knownBotAppName(bot: any, appNames = loadKnownBotAppNames()): string | undefined {
+  const configured = typeof bot?.appName === 'string' ? bot.appName.trim() : '';
+  if (configured) return configured;
+  const appId = typeof bot?.larkAppId === 'string' ? bot.larkAppId : '';
+  return appId ? appNames.get(appId) : undefined;
+}
+
+function cacheBotAppName(appId: string, appName: string): void {
+  const cleanName = appName.trim();
+  if (!appId || !cleanName) return;
+  const path = join(CONFIG_DIR, 'bots-app-names.json');
+  const map = new Map<string, BotInfoEntryForSetup>();
+  try {
+    const entries = JSON.parse(readFileSync(path, 'utf-8'));
+    if (Array.isArray(entries)) {
+      for (const entry of entries as BotInfoEntryForSetup[]) {
+        if (typeof entry?.larkAppId === 'string') map.set(entry.larkAppId, entry);
+      }
+    }
+  } catch { /* ignore */ }
+  map.set(appId, { larkAppId: appId, appName: cleanName, botName: cleanName });
+  writeFileSync(path, JSON.stringify([...map.values()], null, 2) + '\n', { mode: 0o600 });
+}
+
+async function refreshBotAppName(bot: any): Promise<string | undefined> {
+  const appId = typeof bot?.larkAppId === 'string' ? bot.larkAppId : '';
+  const secret = typeof bot?.larkAppSecret === 'string' ? bot.larkAppSecret : '';
+  if (!appId || !secret) return undefined;
+  try {
+    const { fetchBotAppName } = await import('./setup/verify-permissions.js');
+    const info = await fetchBotAppName(appId, secret, botBrand(bot), { budgetMs: 5_000 });
+    if (info.ok) {
+      cacheBotAppName(appId, info.appName);
+      return info.appName;
+    }
+  } catch { /* best effort only */ }
+  return undefined;
+}
+
+async function refreshMissingBotAppNames(bots: any[]): Promise<void> {
+  const known = loadKnownBotAppNames();
+  await Promise.all(
+    bots
+      .filter((bot) => !knownBotAppName(bot, known))
+      .map((bot) => refreshBotAppName(bot)),
   );
-  const render = (cells: string[]) =>
-    '  ' + cells.map((cell, i) => padEndDisplay(cell, widths[i])).join('  ');
-  return [render(headers), ...rows.map(render)].join('\n');
 }
 
 async function promptEditBotConfig(
@@ -909,6 +983,7 @@ async function cmdSetup(): Promise<void> {
   if (hasBots) {
     // --- Multi-bot mode (bots.json exists) ---
     const bots = loadBotsJson();
+    await refreshMissingBotAppNames(bots);
     console.log(`已配置 ${bots.length} 个机器人：\n`);
     console.log(formatBotConfigTable(bots));
     console.log('');
@@ -977,6 +1052,7 @@ async function cmdSetup(): Promise<void> {
           return;
         }
         console.log('✅ 凭证有效\n');
+        await refreshBotAppName(edited);
       }
       rl.close();
 

--- a/src/codex-app-runner.ts
+++ b/src/codex-app-runner.ts
@@ -111,8 +111,11 @@ class AppServerClient {
   private lastStderr = '';
   private fatalError?: Error;
 
-  constructor(private readonly codexBin: string, private readonly cwd: string) {
-    this.child = spawn(codexBin, ['app-server', '--listen', 'stdio://'], {
+  constructor(private readonly codexBin: string, private readonly cwd: string, private readonly mode: 'proxy' | 'standalone') {
+    const appServerArgs = mode === 'proxy'
+      ? ['app-server', 'proxy']
+      : ['app-server', '--listen', 'stdio://'];
+    this.child = spawn(codexBin, appServerArgs, {
       cwd,
       env: process.env,
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -129,10 +132,10 @@ class AppServerClient {
       const hint = (err as NodeJS.ErrnoException).code === 'ENOENT'
         ? '\nHint: install the Codex CLI, or set cliPathOverride to the Codex App bundled binary, for example /Applications/Codex.app/Contents/Resources/codex.'
         : '';
-      this.failAll(new Error(`Failed to start Codex app-server with "${codexBin}": ${err.message}${hint}`));
+      this.failAll(new Error(`Failed to start Codex app-server ${mode} with "${codexBin}": ${err.message}${hint}`));
     });
     this.child.on('exit', (code, signal) => {
-      const err = this.fatalError ?? new Error(`Codex app-server exited (code=${code}, signal=${signal})${this.lastStderr ? `\n${this.lastStderr}` : ''}`);
+      const err = this.fatalError ?? new Error(`Codex app-server ${mode} exited (code=${code}, signal=${signal})${this.lastStderr ? `\n${this.lastStderr}` : ''}`);
       this.failAll(err);
     });
   }
@@ -242,7 +245,7 @@ try {
   process.exit(2);
 }
 
-const client = new AppServerClient(args.codexBin, args.cwd);
+let client: AppServerClient;
 let threadId = args.threadId;
 let threadReady = false;
 let activeTurn: ActiveTurn | null = null;
@@ -363,10 +366,6 @@ async function ensureThread(): Promise<string> {
         sandbox: 'danger-full-access',
         config: { shell_environment_policy: { inherit: 'all' } },
         developerInstructions: appDeveloperInstructions(args),
-        excludeTurns: true,
-        // Keep Codex App's rich history in sync with turns created by this
-        // external runner so the desktop UI can render follow-up messages.
-        persistExtendedHistory: true,
       });
       const resumedThreadId = String(resumed.thread.id);
       threadId = resumedThreadId;
@@ -388,10 +387,6 @@ async function ensureThread(): Promise<string> {
     serviceName: 'botmux',
     developerInstructions: appDeveloperInstructions(args),
     ephemeral: false,
-    experimentalRawEvents: false,
-    // Keep Codex App's rich history in sync with turns created by this
-    // external runner so the desktop UI can render follow-up messages.
-    persistExtendedHistory: true,
   });
   const startedThreadId = String(started.thread.id);
   threadId = startedThreadId;
@@ -502,9 +497,28 @@ function handleInput(data: Buffer): void {
 }
 
 async function main(): Promise<void> {
-  client.onRequest(handleServerRequest);
-  client.onNotification(handleNotification);
-  await client.initialize();
+  const preferStandalone = process.env.BOTMUX_CODEX_APP_STANDALONE === '1';
+  const modes: Array<'proxy' | 'standalone'> = preferStandalone ? ['standalone'] : ['proxy', 'standalone'];
+  let lastErr: unknown;
+  for (const mode of modes) {
+    client = new AppServerClient(args.codexBin, args.cwd, mode);
+    client.onRequest(handleServerRequest);
+    client.onNotification(handleNotification);
+    try {
+      await client.initialize();
+      if (mode === 'proxy') writeLine('[codex-app] connected through running app-server daemon.');
+      break;
+    } catch (err) {
+      lastErr = err;
+      client.close();
+      if (mode === 'proxy') {
+        writeLine(`[codex-app] app-server proxy unavailable; falling back to standalone app-server: ${asError(err).message}`);
+        continue;
+      }
+      throw err;
+    }
+  }
+  if (!client) throw asError(lastErr ?? new Error('failed to start Codex app-server'));
   await ensureThread();
   writeLine('Codex App connected.');
   if (process.stdin.isTTY) process.stdin.setRawMode(true);

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -762,19 +762,22 @@ function getSessionPersistentBackendType(ds: DaemonSession): Exclude<BackendType
 }
 
 function persistentSessionName(backendType: Exclude<BackendType, 'pty'>, sessionId: string): string {
-  if (backendType === 'tmux') return TmuxBackend.sessionName(sessionId);
+  if (backendType === 'tmux') return TmuxBackend.managedTarget(sessionId);
   if (backendType === 'zellij') return ZellijBackend.sessionName(sessionId);
   return HerdrBackend.sessionName(sessionId);
 }
 
 function persistentSessionExists(backendType: Exclude<BackendType, 'pty'>, name: string): boolean {
-  if (backendType === 'tmux') return TmuxBackend.hasSession(name);
+  if (backendType === 'tmux') return TmuxBackend.groupSessionName() ? TmuxBackend.hasWindow(name) : TmuxBackend.hasSession(name);
   if (backendType === 'zellij') return ZellijBackend.hasSession(name);
   return HerdrBackend.hasSession(name);
 }
 
 function killPersistentSession(backendType: Exclude<BackendType, 'pty'>, name: string): void {
-  if (backendType === 'tmux') TmuxBackend.killSession(name);
+  if (backendType === 'tmux') {
+    if (TmuxBackend.groupSessionName()) TmuxBackend.killWindow(name);
+    else TmuxBackend.killSession(name);
+  }
   else if (backendType === 'zellij') ZellijBackend.killSession(name);
   else HerdrBackend.killSession(name);
 }

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -971,7 +971,7 @@ export async function setActiveSessionSafe(
  * process keeps running inside its tmux session — only the routing fields
  * (chatId, rootMessageId, scope) and activeSessions key are rewritten. After
  * the rewrite, forkWorker spawns a new worker that re-attaches to the same
- * `bmx-<sessionId>` tmux, so the AI's transcript continues without break.
+ * managed botmux tmux target, so the AI's transcript continues without break.
  *
  * Visible side effects:
  *   - Lark messages in the *source* chat remain where they were — we have no
@@ -1175,7 +1175,7 @@ export async function transferSession(
   });
 
   // forkWorker with resume=true — TmuxBackend.spawn detects the surviving
-  // `bmx-<sessionId>` session and re-attaches instead of creating a new one.
+  // managed botmux tmux target and re-attaches instead of creating a new one.
   fkw(ds, '', /*resume*/true);
 
   logger.info(
@@ -2213,19 +2213,21 @@ function cleanupPersistentBackendSessions(backendType: 'tmux' | 'herdr', activeS
   if (!multiBot && lastCliId && lastCliId !== currentCliId) {
     logger.info(`CLI_ID changed (${lastCliId} → ${currentCliId}), killing all ${backendType} sessions`);
     for (const name of backend.listBotmuxSessions()) {
-      backend.killSession(name);
+      if (backendType === 'tmux' && TmuxBackend.groupSessionName()) TmuxBackend.killWindow(name);
+      else backend.killSession(name);
     }
   } else {
     const activeNames = new Set(
-      activeSessions_.map(s => backend.sessionName(s.sessionId)),
+      activeSessions_.map(s => backendType === 'tmux' ? TmuxBackend.managedTarget(s.sessionId) : backend.sessionName(s.sessionId)),
     );
     const ownedNames = new Set(
-      sessionStore.listSessions().map(s => backend.sessionName(s.sessionId)),
+      sessionStore.listSessions().map(s => backendType === 'tmux' ? TmuxBackend.managedTarget(s.sessionId) : backend.sessionName(s.sessionId)),
     );
     for (const name of backend.listBotmuxSessions()) {
       if (ownedNames.has(name) && !activeNames.has(name)) {
         logger.info(`Killing orphaned ${backendType} session: ${name}`);
-        backend.killSession(name);
+        if (backendType === 'tmux' && TmuxBackend.groupSessionName()) TmuxBackend.killWindow(name);
+        else backend.killSession(name);
       }
     }
     for (const session of activeSessions_) {
@@ -2234,9 +2236,10 @@ function cleanupPersistentBackendSessions(backendType: 'tmux' | 'herdr', activeS
       let botCliId: CliId | undefined;
       try { botCliId = getBot(session.larkAppId).config.cliId; } catch { continue; }
       if (botCliId && sessionCliId !== botCliId) {
-        const name = backend.sessionName(session.sessionId);
+        const name = backendType === 'tmux' ? TmuxBackend.managedTarget(session.sessionId) : backend.sessionName(session.sessionId);
         logger.info(`CLI mismatch for ${session.sessionId.substring(0, 8)} (session=${sessionCliId}, bot=${botCliId}), killing ${backendType} ${name}`);
-        backend.killSession(name);
+        if (backendType === 'tmux' && TmuxBackend.groupSessionName()) TmuxBackend.killWindow(name);
+        else backend.killSession(name);
       }
     }
   }

--- a/src/core/working-dir.ts
+++ b/src/core/working-dir.ts
@@ -8,7 +8,9 @@ import { homedir } from 'node:os';
 import { t, type Locale } from '../i18n/index.js';
 
 export function expandHome(p: string): string {
-  return p.startsWith('~') ? join(homedir(), p.slice(1)) : p;
+  if (p === '~') return homedir();
+  if (p.startsWith('~/')) return join(homedir(), p.slice(2));
+  return p;
 }
 
 /**

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -32,6 +32,28 @@ function escapeMd(s: string): string {
   return s.replace(/[*_~`\[\]\\]/g, c => `\\${c}`);
 }
 
+function sidebarUrl(url: string): string {
+  const qs = new URLSearchParams({
+    mode: 'sidebar-semi',
+    min_width: '350',
+    width: '800',
+    max_width: '1200',
+    reload: 'false',
+    url,
+  });
+  return `https://applink.feishu.cn/client/web_url/open?${qs.toString()}`;
+}
+
+function sidebarMultiUrl(url: string): Record<string, string> {
+  const pcUrl = sidebarUrl(url);
+  return {
+    url: pcUrl,
+    pc_url: pcUrl,
+    android_url: url,
+    ios_url: url,
+  };
+}
+
 /**
  * Build a Feishu interactive card with terminal button + action buttons.
  * @param showManageButtons - When true, include restart & close buttons (used in the private write-link card — delivered as a "visible-to-you" ephemeral card in plain groups, or DM'd as fallback).
@@ -54,12 +76,7 @@ export function buildSessionCard(
       tag: 'button',
       text: { tag: 'plain_text', content: t(showManageButtons ? 'card.btn.open_writable_terminal' : 'card.btn.open_terminal', undefined, locale) },
       type: 'primary',
-      multi_url: {
-        url: terminalUrl,
-        pc_url: terminalUrl,
-        android_url: terminalUrl,
-        ios_url: terminalUrl,
-      },
+      multi_url: sidebarMultiUrl(terminalUrl),
     },
   ];
   if (!showManageButtons) {
@@ -420,7 +437,7 @@ export function buildStreamingCard(
     tag: 'button',
     text: { tag: 'plain_text', content: t('card.btn.open_terminal', undefined, locale) },
     type: 'primary',
-    multi_url: { url: terminalUrl, pc_url: terminalUrl, android_url: terminalUrl, ios_url: terminalUrl },
+    multi_url: sidebarMultiUrl(terminalUrl),
   });
   if (status === 'limited' && usageLimit?.retryReady) {
     headerActions.push({
@@ -584,7 +601,7 @@ export function buildPrivateSnapshotCard(
         tag: 'button',
         text: { tag: 'plain_text', content: t('card.btn.open_terminal', undefined, locale) },
         type: 'primary',
-        multi_url: { url: terminalUrl, pc_url: terminalUrl, android_url: terminalUrl, ios_url: terminalUrl },
+        multi_url: sidebarMultiUrl(terminalUrl),
       },
       {
         tag: 'button',

--- a/src/setup/bot-config-editor.ts
+++ b/src/setup/bot-config-editor.ts
@@ -1,4 +1,5 @@
 import type { CliId } from '../adapters/cli/types.js';
+import { normalizeWorkingDirInput } from '../utils/working-dir.js';
 
 export const CLI_ID_CHOICES: Record<string, CliId> = {
   '1': 'claude-code',
@@ -304,7 +305,11 @@ export function applyBotConfigEdits<T extends Record<string, any>>(
     }
   }
 
-  applyOptionalString(out, 'workingDir', input.workingDir);
+  if (input.workingDir !== undefined) {
+    const workingDir = input.workingDir.trim();
+    if (workingDir === '-') delete out.workingDir;
+    else if (workingDir) out.workingDir = normalizeWorkingDirInput(workingDir);
+  }
 
   if (input.allowedUsers !== undefined) {
     const allowedUsers = input.allowedUsers.trim();

--- a/src/setup/bot-config-editor.ts
+++ b/src/setup/bot-config-editor.ts
@@ -259,6 +259,40 @@ export function removeBotConfig<T extends { larkAppId?: string; name?: unknown }
   return { bots: nextBots, removed: removed as T, index };
 }
 
+export interface BotConfigTableRow {
+  processName: string;
+  appName?: string;
+  appId: string;
+  cliId: string;
+}
+
+function displayWidth(s: string): number {
+  // Good enough for setup's CJK/ASCII table: wide code points count as 2,
+  // combining marks are rare in these labels and can safely count as 1 here.
+  let w = 0;
+  for (const ch of s) {
+    const cp = ch.codePointAt(0) ?? 0;
+    w += cp > 0x2e80 ? 2 : 1;
+  }
+  return w;
+}
+
+function padEndDisplay(s: string, width: number): string {
+  return s + ' '.repeat(Math.max(0, width - displayWidth(s)));
+}
+
+export function formatBotConfigTableRows(rows: BotConfigTableRow[]): string {
+  if (rows.length === 0) return '';
+  const headers = ['进程名', 'App Name', 'App ID', 'CLI'];
+  const cells = rows.map((r) => [r.processName, r.appName ?? '', r.appId, r.cliId]);
+  const widths = headers.map((h, c) =>
+    Math.max(displayWidth(h), ...cells.map(r => displayWidth(r[c]))),
+  );
+  const render = (row: string[]) =>
+    '  ' + row.map((cell, i) => padEndDisplay(cell, widths[i])).join('  ');
+  return [render(headers), ...cells.map(render)].join('\n');
+}
+
 export function applyBotConfigEdits<T extends Record<string, any>>(
   bot: T,
   input: BotConfigEditInput,

--- a/src/setup/verify-permissions.ts
+++ b/src/setup/verify-permissions.ts
@@ -99,6 +99,10 @@ export type CredentialValidation =
   | { ok: true; tenantAccessToken: string; tokenExpiresIn: number }
   | { ok: false; error: 'invalid_credentials' | 'network' | 'unknown'; message: string };
 
+export type BotInfoLookup =
+  | { ok: true; appName: string; openId?: string }
+  | { ok: false; error: 'invalid_credentials' | 'network' | 'unknown'; message: string };
+
 /**
  * 用 AppID/Secret 取一次 tenant_access_token, 验证凭证可用.
  *
@@ -166,6 +170,73 @@ export async function validateCredentials(
   // 10003 / 10012: app_id or app_secret invalid
   // 10014: 应用未发布
   // 99991663: app_secret invalid
+  if (body?.code === 10003 || body?.code === 10012 || body?.code === 99991663) {
+    return { ok: false, error: 'invalid_credentials', message: `凭证无效 (code=${body.code}): ${body.msg ?? ''}` };
+  }
+
+  return { ok: false, error: 'unknown', message: `code=${body?.code ?? '?'} msg=${body?.msg ?? ''}` };
+}
+
+/**
+ * Best-effort lookup for the human-visible Lark/Feishu bot app name.
+ * Used by `botmux setup` to make the existing-bots list recognizable without
+ * requiring the daemon to be running. Secret never appears in returned errors.
+ */
+export async function fetchBotAppName(
+  appId: string,
+  appSecret: string,
+  brand: Brand = 'feishu',
+  opts: { budgetMs?: number; signal?: AbortSignal } = {},
+): Promise<BotInfoLookup> {
+  const budgetMs = opts.budgetMs ?? 10_000;
+  const host = brand === 'lark' ? 'open.larksuite.com' : 'open.feishu.cn';
+
+  const token = await validateCredentials(appId, appSecret, brand, opts);
+  if (!token.ok) return token;
+
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), budgetMs);
+  if (opts.signal) {
+    if (opts.signal.aborted) ac.abort();
+    else opts.signal.addEventListener('abort', () => ac.abort(), { once: true });
+  }
+
+  let res: Response;
+  let body: any;
+  try {
+    res = await fetch(`https://${host}/open-apis/bot/v3/info/`, {
+      headers: { Authorization: `Bearer ${token.tenantAccessToken}` },
+      signal: ac.signal,
+    });
+    body = await res.json();
+  } catch (err: any) {
+    clearTimeout(timer);
+    const isAbort = err?.name === 'AbortError' || ac.signal.aborted;
+    if (!isAbort && err instanceof SyntaxError) {
+      return { ok: false, error: 'unknown', message: `HTTP ${res!?.status ?? '?'} 响应非 JSON` };
+    }
+    return {
+      ok: false,
+      error: 'network',
+      message: isAbort
+        ? `请求超时 (> ${budgetMs}ms)`
+        : `网络错误: ${err?.code ?? err?.message ?? 'unknown'}`,
+    };
+  }
+  clearTimeout(timer);
+
+  if (body?.code === 0) {
+    const appName = typeof body?.bot?.app_name === 'string' ? body.bot.app_name.trim() : '';
+    if (appName) {
+      return {
+        ok: true,
+        appName,
+        openId: typeof body?.bot?.open_id === 'string' ? body.bot.open_id : undefined,
+      };
+    }
+    return { ok: false, error: 'unknown', message: 'bot/v3/info 响应缺少 bot.app_name' };
+  }
+
   if (body?.code === 10003 || body?.code === 10012 || body?.code === 99991663) {
     return { ok: false, error: 'invalid_credentials', message: `凭证无效 (code=${body.code}): ${body.msg ?? ''}` };
   }

--- a/src/utils/working-dir.ts
+++ b/src/utils/working-dir.ts
@@ -2,8 +2,17 @@ import { statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 
+export function normalizeWorkingDirInput(input: string, fallback = '~'): string {
+  const s = input.trim();
+  if (!s) return fallback;
+  if (s === '-') return s;
+  return s;
+}
+
 export function expandHomePath(p: string): string {
-  return p.startsWith('~') ? join(homedir(), p.slice(1)) : p;
+  if (p === '~') return homedir();
+  if (p.startsWith('~/')) return join(homedir(), p.slice(2));
+  return p;
 }
 
 export function parseWorkingDirList(value: unknown): string[] {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3037,7 +3037,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   // is misleading and has cost real debugging time. (CliId-mismatch reattach
   // is now blocked upstream in restoreActiveSessions / killStalePids.)
   const persistentSessionName = effectiveBackendType === 'tmux'
-    ? TmuxBackend.sessionName(cfg.sessionId)
+    ? TmuxBackend.managedTarget(cfg.sessionId)
     : effectiveBackendType === 'herdr'
       ? HerdrBackend.sessionName(cfg.sessionId)
       : effectiveBackendType === 'zellij'
@@ -3045,7 +3045,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
       : undefined;
   const willReattachPersistent = persistentSessionName
     ? effectiveBackendType === 'tmux'
-      ? TmuxBackend.hasSession(persistentSessionName)
+      ? (TmuxBackend.groupSessionName() ? TmuxBackend.hasWindow(persistentSessionName) : TmuxBackend.hasSession(persistentSessionName))
       : effectiveBackendType === 'zellij'
         ? ZellijBackend.hasSession(persistentSessionName)
         : HerdrBackend.hasSession(persistentSessionName)
@@ -3305,7 +3305,7 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
         // ── Tmux-attach mode: per-client attach ──
         // Each WS client gets its own `tmux attach-session` PTY.
         // Scrollback is handled natively by tmux (history-limit).
-        // In adopt mode, attach to the user's original pane; otherwise use bmx-* session.
+        // In adopt mode, attach to the user's original pane; otherwise use the managed botmux tmux target.
         //
         // Spawn is DEFERRED until the client sends its first 'resize'.  If we
         // spawned at a default size (e.g. 80×24) first and then resized, tmux
@@ -3314,7 +3314,7 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
         // byte-for-byte (empty, separators, etc.) are not retransmitted, so
         // the earlier frame "bleeds through" — visible as a second
         // banner/prompt stacked above the new layout when scrolling up.
-        const tmuxTarget = lastInitConfig?.adoptTmuxTarget ?? TmuxBackend.sessionName(sessionId);
+        const tmuxTarget = lastInitConfig?.adoptTmuxTarget ?? TmuxBackend.managedTarget(sessionId);
         let cp: pty.IPty | null = null;
         const pendingInput: string[] = [];
 

--- a/test/bot-config-editor.test.ts
+++ b/test/bot-config-editor.test.ts
@@ -176,6 +176,18 @@ describe('applyBotConfigEdits', () => {
     });
   });
 
+  it('preserves bare relative workingDir edits', () => {
+    const updated = applyBotConfigEdits({
+      larkAppId: 'app',
+      larkAppSecret: 'secret',
+      workingDir: '~',
+    }, {
+      workingDir: 'docai/docai-oncall',
+    });
+
+    expect(updated.workingDir).toBe('docai/docai-oncall');
+  });
+
   it('accepts cliChoice as a literal cliId', () => {
     const updated = applyBotConfigEdits({
       larkAppId: 'app',

--- a/test/bot-config-editor.test.ts
+++ b/test/bot-config-editor.test.ts
@@ -5,6 +5,7 @@ import {
   assertOwnerWhenChatGroups,
   botProcessName,
   findInvalidAllowedUserEntries,
+  formatBotConfigTableRows,
   hasOwnerEntry,
   isValidAllowedUserEntry,
   normalizeBotConfig,
@@ -13,6 +14,18 @@ import {
   removeBotConfig,
   resolveCliId,
 } from '../src/setup/bot-config-editor.js';
+
+describe('formatBotConfigTableRows', () => {
+  it('includes App Name between process name and App ID', () => {
+    const table = formatBotConfigTableRows([
+      { processName: 'botmux-0', appName: 'Botmux Oncall', appId: 'cli_a940bbbbdd38dbde', cliId: 'codex' },
+    ]);
+
+    expect(table.split('\n')[0]).toContain('App Name');
+    expect(table).toContain('Botmux Oncall');
+    expect(table).toMatch(/进程名\s+App Name\s+App ID\s+CLI/);
+  });
+});
 
 describe('parseBotSelection', () => {
   const bots = [

--- a/test/card-builder.test.ts
+++ b/test/card-builder.test.ts
@@ -36,6 +36,17 @@ function buttonTexts(actions: any[]): string[] {
     .map((a: any) => a.text.content);
 }
 
+function expectSidebarUrl(actual: string, targetUrl: string): void {
+  const u = new URL(actual);
+  expect(`${u.origin}${u.pathname}`).toBe('https://applink.feishu.cn/client/web_url/open');
+  expect(u.searchParams.get('mode')).toBe('sidebar-semi');
+  expect(u.searchParams.get('min_width')).toBe('350');
+  expect(u.searchParams.get('width')).toBe('800');
+  expect(u.searchParams.get('max_width')).toBe('1200');
+  expect(u.searchParams.get('reload')).toBe('false');
+  expect(u.searchParams.get('url')).toBe(targetUrl);
+}
+
 // ─── getCliDisplayName ────────────────────────────────────────────────────
 
 describe('getCliDisplayName', () => {
@@ -125,8 +136,8 @@ describe('buildSessionCard', () => {
       const terminalBtn = actions[0];
       expect(terminalBtn.type).toBe('primary');
       expect(terminalBtn.text.content).toContain('打开终端');
-      expect(terminalBtn.multi_url.url).toBe(URL);
-      expect(terminalBtn.multi_url.pc_url).toBe(URL);
+      expectSidebarUrl(terminalBtn.multi_url.url, URL);
+      expectSidebarUrl(terminalBtn.multi_url.pc_url, URL);
       expect(terminalBtn.multi_url.android_url).toBe(URL);
       expect(terminalBtn.multi_url.ios_url).toBe(URL);
     });
@@ -470,7 +481,10 @@ describe('buildStreamingCard', () => {
       const actions = findActions(card);
       const termBtn = actions.find((a: any) => a.multi_url);
       expect(termBtn).toBeDefined();
-      expect(termBtn.multi_url.url).toBe(URL);
+      expectSidebarUrl(termBtn.multi_url.url, URL);
+      expectSidebarUrl(termBtn.multi_url.pc_url, URL);
+      expect(termBtn.multi_url.android_url).toBe(URL);
+      expect(termBtn.multi_url.ios_url).toBe(URL);
       expect(termBtn.type).toBe('primary');
     });
 
@@ -987,7 +1001,10 @@ describe('buildPrivateSnapshotCard', () => {
     expect(actions.sort()).toEqual(['close', 'get_write_link']);
     // open-terminal is a URL button (no callback action)
     const link = btns.find((b: any) => b.multi_url);
-    expect(link.multi_url.url).toBe('https://t.example/ro');
+    expectSidebarUrl(link.multi_url.url, 'https://t.example/ro');
+    expectSidebarUrl(link.multi_url.pc_url, 'https://t.example/ro');
+    expect(link.multi_url.android_url).toBe('https://t.example/ro');
+    expect(link.multi_url.ios_url).toBe('https://t.example/ro');
     // none of the patch-driven / quick-key controls leak in
     for (const bad of ['toggle_display', 'export_text', 'refresh_screenshot', 'term_action']) {
       expect(actions).not.toContain(bad);

--- a/test/setup-verify-permissions.test.ts
+++ b/test/setup-verify-permissions.test.ts
@@ -31,6 +31,7 @@ vi.mock('@larksuiteoapi/node-sdk', () => {
 import * as sdk from '@larksuiteoapi/node-sdk';
 import {
   validateCredentials,
+  fetchBotAppName,
   checkRequiredScopes,
   applyScopesUnverified,
   buildScopeDeepLink,
@@ -139,6 +140,52 @@ describe('validateCredentials', () => {
       expect.stringContaining('open.larksuite.com'),
       expect.any(Object),
     );
+  });
+});
+
+describe('fetchBotAppName', () => {
+  it('fetches tenant token then bot app_name without leaking secret', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ code: 0, tenant_access_token: 't-xxx', expire: 7200 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ code: 0, bot: { app_name: 'Codex Bot', open_id: 'ou_bot' } }),
+      });
+
+    const r = await fetchBotAppName('cli_x', 'super-secret-value-do-not-leak', 'feishu');
+
+    expect(r).toEqual({ ok: true, appName: 'Codex Bot', openId: 'ou_bot' });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('/open-apis/bot/v3/info/'),
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer t-xxx' },
+      }),
+    );
+  });
+
+  it('returns unknown when bot info has no app_name', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ code: 0, tenant_access_token: 't-xxx' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ code: 0, bot: { open_id: 'ou_bot' } }),
+      });
+
+    const r = await fetchBotAppName('cli_x', 'sec', 'feishu');
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toContain('app_name');
   });
 });
 

--- a/test/tmux-pipe-backend.test.ts
+++ b/test/tmux-pipe-backend.test.ts
@@ -359,6 +359,30 @@ describe('TmuxPipeBackend managed session', () => {
     expect(optionCalls.some(c => c.includes('set-option -s set-clipboard on'))).toBe(true);
   });
 
+  it('creates a shared-session window when groupSessionName is set', () => {
+    const be = new TmuxPipeBackend('botmux:bmx-owned', { createSession: true, ownsSession: true, groupSessionName: 'botmux' });
+    mockedExecSync.mockImplementation((cmd: any) => {
+      if (String(cmd).includes('has-session')) throw new Error('missing');
+      return Buffer.from('') as any;
+    });
+    be.spawn('/bin/echo', ['hello'], spawnOpts());
+
+    const calls = mockedExecFileSync.mock.calls.map(call => call[1] as string[]);
+    expect(calls.some(args =>
+      args.includes('new-session') &&
+      args.includes('-s') && args.includes('botmux') &&
+      args.includes('-n') && args.includes('bmx-owned'),
+    )).toBe(true);
+  });
+
+  it('kills only the shared-session window on destroySession', () => {
+    const be = new TmuxPipeBackend('botmux:bmx-owned', { ownsSession: true, groupSessionName: 'botmux' });
+    be.destroySession();
+
+    expect(mockedExecSync).toHaveBeenCalledWith("tmux kill-window -t 'botmux:bmx-owned'", expect.any(Object));
+    expect(mockedExecSync).not.toHaveBeenCalledWith("tmux kill-session -t 'botmux:bmx-owned'", expect.any(Object));
+  });
+
   it('resizes owned tmux sessions and only records adopted pane resize', () => {
     const owned = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
     owned.resize(120, 40);

--- a/test/tmux-reattach-backend.test.ts
+++ b/test/tmux-reattach-backend.test.ts
@@ -7,6 +7,8 @@ vi.mock('../src/adapters/backend/pty-backend.js', () => ({
 vi.mock('../src/adapters/backend/tmux-backend.js', () => ({
   TmuxBackend: class MockTmuxBackend {
     static sessionName = vi.fn((id: string) => `bmx-${id.slice(0, 8)}`);
+    static groupSessionName = vi.fn(() => undefined as string | undefined);
+    static hasWindow = vi.fn();
     static hasSession = vi.fn();
     constructor(public sessionName: string) {}
   },
@@ -41,6 +43,8 @@ import { selectSessionBackend } from '../src/adapters/backend/session-backend-se
 describe('selectSessionBackend', () => {
   beforeEach(() => {
     vi.mocked(TmuxBackend.hasSession).mockReset();
+    vi.mocked(TmuxBackend.hasWindow).mockReset();
+    vi.mocked(TmuxBackend.groupSessionName).mockReset().mockReturnValue(undefined);
     vi.mocked(TmuxBackend.sessionName).mockClear();
   });
 
@@ -54,6 +58,19 @@ describe('selectSessionBackend', () => {
     expect(selected.backend.constructor.name).toBe('MockTmuxPipeBackend');
     expect((selected.backend as any).paneTarget).toBe('bmx-9cfa0024');
     expect((selected.backend as any).opts).toEqual({ ownsSession: true, isReattach: true });
+  });
+
+  it('uses a shared tmux session window when BOTMUX_TMUX_GROUP_SESSION is set', () => {
+    vi.mocked(TmuxBackend.groupSessionName).mockReturnValue('botmux');
+    vi.mocked(TmuxBackend.hasWindow).mockReturnValue(false);
+
+    const selected = selectSessionBackend({ sessionId: '9cfa0024-197d-4781-845b-c541dceb8980', backendType: 'tmux' });
+
+    expect(selected.backend.constructor.name).toBe('MockTmuxPipeBackend');
+    expect((selected.backend as any).paneTarget).toBe('botmux:bmx-9cfa0024');
+    expect((selected.backend as any).opts).toEqual({ createSession: true, ownsSession: true, groupSessionName: 'botmux' });
+    expect(TmuxBackend.hasSession).not.toHaveBeenCalled();
+    expect(TmuxBackend.hasWindow).toHaveBeenCalledWith('botmux:bmx-9cfa0024');
   });
 
   it('uses managed pipe backend for a new tmux session', () => {

--- a/test/working-dir.test.ts
+++ b/test/working-dir.test.ts
@@ -1,8 +1,9 @@
 import { mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { configuredWorkingDirs, invalidWorkingDirs, parseWorkingDirList } from '../src/utils/working-dir.js';
+import { configuredWorkingDirs, invalidWorkingDirs, normalizeWorkingDirInput, parseWorkingDirList } from '../src/utils/working-dir.js';
+import { expandHome, validateWorkingDir } from '../src/core/working-dir.js';
 
 describe('working-dir utils', () => {
   it('parses comma-separated strings and arrays', () => {
@@ -14,6 +15,20 @@ describe('working-dir utils', () => {
   it('dedupes configured dirs by resolved path', () => {
     const cwd = process.cwd();
     expect(configuredWorkingDirs({ workingDir: '., ' + cwd })).toEqual(['.']);
+  });
+
+  it('expands ~/ paths to the user home directory', () => {
+    expect(expandHome('~')).toBe(homedir());
+    expect(expandHome('~/docai')).toBe(join(homedir(), 'docai'));
+    expect(validateWorkingDir('~').ok).toBe(true);
+  });
+
+  it('normalizes setup workingDir input without changing relative path semantics', () => {
+    expect(normalizeWorkingDirInput('')).toBe('~');
+    expect(normalizeWorkingDirInput('', '/repo/current')).toBe('/repo/current');
+    expect(normalizeWorkingDirInput('docai/docai-oncall')).toBe('docai/docai-oncall');
+    expect(normalizeWorkingDirInput('~/docai')).toBe('~/docai');
+    expect(normalizeWorkingDirInput('/srv/docai')).toBe('/srv/docai');
   });
 
   it('reports missing paths and files as invalid dirs', () => {


### PR DESCRIPTION
## Summary

- open Botmux terminal card links in Lark PC sidebar mode via `client/web_url/open`
- set sidebar bounds to `min_width=350`, `width=800`, `max_width=1200`
- keep mobile links pointing directly at the original terminal URL

## Test plan

- `pnpm vitest run test/card-builder.test.ts`
- `pnpm build`
