### PR TITLE
fix(worker): harden web terminal request handling

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { networkInterfaces } from 'node:os';
 import type { BackendType } from './adapters/backend/types.js';
 import { probeTmuxFunctional } from './setup/ensure-tmux.js';
+import { resolveWorkerHttpHost } from './utils/worker-http.js';
 
 /** Get the first non-loopback IPv4 address, fallback to localhost. */
 function getLocalIp(): string {
@@ -80,6 +81,7 @@ export const config = {
   },
   web: {
     host: process.env.WEB_HOST ?? '0.0.0.0',
+    workerHost: resolveWorkerHttpHost(),
     get externalHost() { return getWebExternalHost(); },
     // Single reverse-proxy port per daemon that fronts every session's web
     // terminal under `/s/{sessionId}`. Lets dev-machine users forward one port

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -34,9 +34,8 @@ import type { CliId } from '../adapters/cli/types.js';
 import type { DaemonToWorker, WorkerToDaemon, Session, DisplayMode } from '../types.js';
 import { sessionKey, sessionAnchorId, type DaemonSession } from './types.js';
 import { claimPendingResponseCard, COMPLETED_REACTION_EMOJI_TYPE, markPendingResponseCardPatchedIfCurrent, syncPendingResponseState } from './pending-response.js';
-import { buildTerminalUrl, getTerminalProxyPort } from './terminal-url.js';
+import { buildTerminalUrl } from './terminal-url.js';
 import { usageLimitStateKey, type CliUsageLimitState } from '../utils/cli-usage-limit.js';
-import { resolveWorkerHttpHostForFork } from '../utils/worker-http.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -54,14 +53,6 @@ export interface WorkerPoolCallbacks {
 }
 
 let callbacks: WorkerPoolCallbacks | undefined;
-
-function workerHttpHostForFork(): string {
-  return resolveWorkerHttpHostForFork({
-    env: process.env,
-    terminalProxyPort: getTerminalProxyPort(),
-    webHost: config.web.host,
-  });
-}
 
 /**
  * Initialise worker-pool callbacks. Must be called once before forkWorker().
@@ -1247,7 +1238,6 @@ export function forkWorker(ds: DaemonSession, prompt: string, resume = false): v
       CLAUDECODE: undefined,
       BOTMUX: '1',  // Marker so user scripts/skills can detect a botmux-spawned CLI
       SESSION_DATA_DIR: config.session.dataDir,
-      BOTMUX_WORKER_HTTP_HOST: workerHttpHostForFork(),
       LARK_APP_ID: botCfg.larkAppId,
       LARK_APP_SECRET: botCfg.larkAppSecret,
     },
@@ -2053,7 +2043,6 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
       ...process.env,
       CLAUDECODE: undefined,
       BOTMUX: '1',
-      BOTMUX_WORKER_HTTP_HOST: workerHttpHostForFork(),
       LARK_APP_ID: botCfg.larkAppId,
       LARK_APP_SECRET: botCfg.larkAppSecret,
     },

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -34,8 +34,9 @@ import type { CliId } from '../adapters/cli/types.js';
 import type { DaemonToWorker, WorkerToDaemon, Session, DisplayMode } from '../types.js';
 import { sessionKey, sessionAnchorId, type DaemonSession } from './types.js';
 import { claimPendingResponseCard, COMPLETED_REACTION_EMOJI_TYPE, markPendingResponseCardPatchedIfCurrent, syncPendingResponseState } from './pending-response.js';
-import { buildTerminalUrl } from './terminal-url.js';
+import { buildTerminalUrl, getTerminalProxyPort } from './terminal-url.js';
 import { usageLimitStateKey, type CliUsageLimitState } from '../utils/cli-usage-limit.js';
+import { resolveWorkerHttpHostForFork } from '../utils/worker-http.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -53,6 +54,14 @@ export interface WorkerPoolCallbacks {
 }
 
 let callbacks: WorkerPoolCallbacks | undefined;
+
+function workerHttpHostForFork(): string {
+  return resolveWorkerHttpHostForFork({
+    env: process.env,
+    terminalProxyPort: getTerminalProxyPort(),
+    webHost: config.web.host,
+  });
+}
 
 /**
  * Initialise worker-pool callbacks. Must be called once before forkWorker().
@@ -1238,6 +1247,7 @@ export function forkWorker(ds: DaemonSession, prompt: string, resume = false): v
       CLAUDECODE: undefined,
       BOTMUX: '1',  // Marker so user scripts/skills can detect a botmux-spawned CLI
       SESSION_DATA_DIR: config.session.dataDir,
+      BOTMUX_WORKER_HTTP_HOST: workerHttpHostForFork(),
       LARK_APP_ID: botCfg.larkAppId,
       LARK_APP_SECRET: botCfg.larkAppSecret,
     },
@@ -2043,6 +2053,7 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
       ...process.env,
       CLAUDECODE: undefined,
       BOTMUX: '1',
+      BOTMUX_WORKER_HTTP_HOST: workerHttpHostForFork(),
       LARK_APP_ID: botCfg.larkAppId,
       LARK_APP_SECRET: botCfg.larkAppSecret,
     },

--- a/src/utils/worker-http.ts
+++ b/src/utils/worker-http.ts
@@ -9,16 +9,8 @@ export function getConfiguredWorkerHttpHost(env: EnvLike = process.env): string 
 }
 
 export function resolveWorkerHttpHost(env: EnvLike = process.env): string {
-  return getConfiguredWorkerHttpHost(env) ?? '127.0.0.1';
-}
-
-export function resolveWorkerHttpHostForFork(opts: {
-  env?: EnvLike;
-  terminalProxyPort: number;
-  webHost: string;
-}): string {
-  return getConfiguredWorkerHttpHost(opts.env ?? process.env)
-    ?? (opts.terminalProxyPort > 0 ? '127.0.0.1' : opts.webHost);
+  const webHost = env.WEB_HOST?.trim();
+  return (getConfiguredWorkerHttpHost(env) ?? webHost) || '0.0.0.0';
 }
 
 export function parseWorkerRequestUrl(req: Pick<IncomingMessage, 'url' | 'headers'>): URL | null {

--- a/src/utils/worker-http.ts
+++ b/src/utils/worker-http.ts
@@ -1,0 +1,20 @@
+import type { IncomingMessage } from 'node:http';
+
+type EnvLike = Partial<Record<string, string | undefined>>;
+
+export function resolveWorkerHttpHost(env: EnvLike = process.env): string {
+  const raw = env.BOTMUX_WORKER_HTTP_HOST ?? env.BOTMUX_WORKER_HOST;
+  const host = raw?.trim();
+  return host || '127.0.0.1';
+}
+
+export function parseWorkerRequestUrl(req: Pick<IncomingMessage, 'url' | 'headers'>): URL | null {
+  const host = typeof req.headers.host === 'string' && req.headers.host.trim()
+    ? req.headers.host.trim()
+    : 'localhost';
+  try {
+    return new URL(req.url ?? '/', `http://${host}`);
+  } catch {
+    return null;
+  }
+}

--- a/src/utils/worker-http.ts
+++ b/src/utils/worker-http.ts
@@ -2,10 +2,23 @@ import type { IncomingMessage } from 'node:http';
 
 type EnvLike = Partial<Record<string, string | undefined>>;
 
-export function resolveWorkerHttpHost(env: EnvLike = process.env): string {
+export function getConfiguredWorkerHttpHost(env: EnvLike = process.env): string | undefined {
   const raw = env.BOTMUX_WORKER_HTTP_HOST ?? env.BOTMUX_WORKER_HOST;
   const host = raw?.trim();
-  return host || '127.0.0.1';
+  return host || undefined;
+}
+
+export function resolveWorkerHttpHost(env: EnvLike = process.env): string {
+  return getConfiguredWorkerHttpHost(env) ?? '127.0.0.1';
+}
+
+export function resolveWorkerHttpHostForFork(opts: {
+  env?: EnvLike;
+  terminalProxyPort: number;
+  webHost: string;
+}): string {
+  return getConfiguredWorkerHttpHost(opts.env ?? process.env)
+    ?? (opts.terminalProxyPort > 0 ? '127.0.0.1' : opts.webHost);
 }
 
 export function parseWorkerRequestUrl(req: Pick<IncomingMessage, 'url' | 'headers'>): URL | null {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -68,6 +68,7 @@ import { ScreenAnalyzer } from './utils/screen-analyzer.js';
 import { captureToPng } from './utils/screenshot-renderer.js';
 import { snapshotToPng, snapshotToText } from './utils/transient-snapshot.js';
 import { chooseWebTerminalSeed } from './utils/web-terminal-seed.js';
+import { parseWorkerRequestUrl } from './utils/worker-http.js';
 import { detectCliUsageLimit, usageLimitStateKey, type CliUsageLimitState } from './utils/cli-usage-limit.js';
 import { uploadImageBuffer } from './utils/lark-upload.js';
 import { redactChildEnv } from './utils/child-env.js';
@@ -3345,7 +3346,13 @@ function killCli(): void {
 function startWebServer(host: string, preferredPort?: number): Promise<number> {
   return new Promise((resolve, reject) => {
     httpServer = createHttpServer((req, res) => {
-      const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+      const url = parseWorkerRequestUrl(req);
+      if (!url) {
+        log(`Bad worker HTTP URL rejected: ${JSON.stringify(req.url ?? '')}`);
+        res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('Bad Request');
+        return;
+      }
       const hasWrite = url.searchParams.get('token') === writeToken;
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(getTerminalHtml(hasWrite));
@@ -3357,7 +3364,13 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
       wsClients.add(ws);
 
       // Check token from query string for write access
-      const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+      const url = parseWorkerRequestUrl(req);
+      if (!url) {
+        log(`Bad worker WS URL rejected: ${JSON.stringify(req.url ?? '')}`);
+        wsClients.delete(ws);
+        ws.close(1008, 'Bad Request');
+        return;
+      }
       const hasWrite = url.searchParams.get('token') === writeToken;
       if (hasWrite) authedClients.add(ws);
       log(`WS client connected (total: ${wsClients.size}, write: ${hasWrite})`);
@@ -3875,7 +3888,7 @@ process.on('message', async (raw: unknown) => {
       try {
         let port = 0;
         if (!isWorkflowWorker()) {
-          port = await startWebServer('0.0.0.0', msg.webPort);
+          port = await startWebServer(config.web.workerHost, msg.webPort);
           startScreenUpdates();
           startScreenAnalyzer();
         } else {
@@ -3883,7 +3896,7 @@ process.on('message', async (raw: unknown) => {
           // workflow dashboard can observe in-flight subagents.  Keep the
           // chat-side features disabled: no screen cards, no analyzer, no
           // sessionStore writes.
-          port = await startWebServer('0.0.0.0', msg.webPort);
+          port = await startWebServer(config.web.workerHost, msg.webPort);
           log('Workflow worker mode: web terminal enabled; skipping screen updates and screen analyzer');
         }
         spawnCli(msg);

--- a/test/worker-http.test.ts
+++ b/test/worker-http.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { IncomingMessage } from 'node:http';
-import { parseWorkerRequestUrl, resolveWorkerHttpHost, resolveWorkerHttpHostForFork } from '../src/utils/worker-http.js';
+import { parseWorkerRequestUrl, resolveWorkerHttpHost } from '../src/utils/worker-http.js';
 
 function req(url: string | undefined, host?: string): Pick<IncomingMessage, 'url' | 'headers'> {
   return {
@@ -32,12 +32,16 @@ describe('parseWorkerRequestUrl', () => {
 });
 
 describe('resolveWorkerHttpHost', () => {
-  it('defaults worker HTTP to loopback', () => {
-    expect(resolveWorkerHttpHost({})).toBe('127.0.0.1');
+  it('keeps the historical default of listening on all interfaces', () => {
+    expect(resolveWorkerHttpHost({})).toBe('0.0.0.0');
+  });
+
+  it('follows WEB_HOST when worker HTTP host is not configured', () => {
+    expect(resolveWorkerHttpHost({ WEB_HOST: '192.0.2.10' })).toBe('192.0.2.10');
   });
 
   it('allows explicit worker HTTP host override', () => {
-    expect(resolveWorkerHttpHost({ BOTMUX_WORKER_HTTP_HOST: '0.0.0.0' })).toBe('0.0.0.0');
+    expect(resolveWorkerHttpHost({ BOTMUX_WORKER_HTTP_HOST: '127.0.0.1' })).toBe('127.0.0.1');
   });
 
   it('falls back to BOTMUX_WORKER_HOST for shorter deployments', () => {
@@ -45,32 +49,6 @@ describe('resolveWorkerHttpHost', () => {
   });
 
   it('ignores blank overrides', () => {
-    expect(resolveWorkerHttpHost({ BOTMUX_WORKER_HTTP_HOST: '  ' })).toBe('127.0.0.1');
-  });
-});
-
-describe('resolveWorkerHttpHostForFork', () => {
-  it('uses loopback by default when the terminal proxy is available', () => {
-    expect(resolveWorkerHttpHostForFork({
-      env: {},
-      terminalProxyPort: 8801,
-      webHost: '0.0.0.0',
-    })).toBe('127.0.0.1');
-  });
-
-  it('preserves direct worker-port fallback when the terminal proxy is unavailable', () => {
-    expect(resolveWorkerHttpHostForFork({
-      env: {},
-      terminalProxyPort: 0,
-      webHost: '0.0.0.0',
-    })).toBe('0.0.0.0');
-  });
-
-  it('lets explicit worker host override proxy-aware defaults', () => {
-    expect(resolveWorkerHttpHostForFork({
-      env: { BOTMUX_WORKER_HTTP_HOST: '::1' },
-      terminalProxyPort: 0,
-      webHost: '0.0.0.0',
-    })).toBe('::1');
+    expect(resolveWorkerHttpHost({ BOTMUX_WORKER_HTTP_HOST: '  ' })).toBe('0.0.0.0');
   });
 });

--- a/test/worker-http.test.ts
+++ b/test/worker-http.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import type { IncomingMessage } from 'node:http';
+import { parseWorkerRequestUrl, resolveWorkerHttpHost } from '../src/utils/worker-http.js';
+
+function req(url: string | undefined, host?: string): Pick<IncomingMessage, 'url' | 'headers'> {
+  return {
+    url,
+    headers: host === undefined ? {} : { host },
+  } as Pick<IncomingMessage, 'url' | 'headers'>;
+}
+
+describe('parseWorkerRequestUrl', () => {
+  it('parses normal worker HTTP paths and query params', () => {
+    const url = parseWorkerRequestUrl(req('/?token=secret', '127.0.0.1:1234'));
+
+    expect(url?.pathname).toBe('/');
+    expect(url?.searchParams.get('token')).toBe('secret');
+  });
+
+  it('returns null instead of throwing for invalid protocol-relative URLs', () => {
+    const url = parseWorkerRequestUrl(req('//..%252f..%252fetc%252fpasswd', '10.0.0.1:1234'));
+
+    expect(url).toBeNull();
+  });
+
+  it('uses localhost as a safe base when Host is missing', () => {
+    const url = parseWorkerRequestUrl(req('/terminal'));
+
+    expect(url?.host).toBe('localhost');
+    expect(url?.pathname).toBe('/terminal');
+  });
+});
+
+describe('resolveWorkerHttpHost', () => {
+  it('defaults worker HTTP to loopback', () => {
+    expect(resolveWorkerHttpHost({})).toBe('127.0.0.1');
+  });
+
+  it('allows explicit worker HTTP host override', () => {
+    expect(resolveWorkerHttpHost({ BOTMUX_WORKER_HTTP_HOST: '0.0.0.0' })).toBe('0.0.0.0');
+  });
+
+  it('falls back to BOTMUX_WORKER_HOST for shorter deployments', () => {
+    expect(resolveWorkerHttpHost({ BOTMUX_WORKER_HOST: '::1' })).toBe('::1');
+  });
+
+  it('ignores blank overrides', () => {
+    expect(resolveWorkerHttpHost({ BOTMUX_WORKER_HTTP_HOST: '  ' })).toBe('127.0.0.1');
+  });
+});

--- a/test/worker-http.test.ts
+++ b/test/worker-http.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { IncomingMessage } from 'node:http';
-import { parseWorkerRequestUrl, resolveWorkerHttpHost } from '../src/utils/worker-http.js';
+import { parseWorkerRequestUrl, resolveWorkerHttpHost, resolveWorkerHttpHostForFork } from '../src/utils/worker-http.js';
 
 function req(url: string | undefined, host?: string): Pick<IncomingMessage, 'url' | 'headers'> {
   return {
@@ -46,5 +46,31 @@ describe('resolveWorkerHttpHost', () => {
 
   it('ignores blank overrides', () => {
     expect(resolveWorkerHttpHost({ BOTMUX_WORKER_HTTP_HOST: '  ' })).toBe('127.0.0.1');
+  });
+});
+
+describe('resolveWorkerHttpHostForFork', () => {
+  it('uses loopback by default when the terminal proxy is available', () => {
+    expect(resolveWorkerHttpHostForFork({
+      env: {},
+      terminalProxyPort: 8801,
+      webHost: '0.0.0.0',
+    })).toBe('127.0.0.1');
+  });
+
+  it('preserves direct worker-port fallback when the terminal proxy is unavailable', () => {
+    expect(resolveWorkerHttpHostForFork({
+      env: {},
+      terminalProxyPort: 0,
+      webHost: '0.0.0.0',
+    })).toBe('0.0.0.0');
+  });
+
+  it('lets explicit worker host override proxy-aware defaults', () => {
+    expect(resolveWorkerHttpHostForFork({
+      env: { BOTMUX_WORKER_HTTP_HOST: '::1' },
+      terminalProxyPort: 0,
+      webHost: '0.0.0.0',
+    })).toBe('::1');
   });
 });


### PR DESCRIPTION
## Summary

- worker HTTP handler 改用安全 URL 解析；遇到非法 URL 时返回 400，而不是让 `new URL(...)` 的未捕获异常打崩 worker。
- worker WebSocket 连接同样复用安全解析；非法 URL 会关闭连接，不再让 worker 进程退出。
- 保持默认监听行为兼容：worker HTTP host 默认仍跟随 `WEB_HOST`，未配置时仍是历史默认 `0.0.0.0`。
- 支持显式收紧 worker HTTP host：有安全/隐私需求的部署可以设置 `BOTMUX_WORKER_HTTP_HOST=127.0.0.1`（也支持较短的 `BOTMUX_WORKER_HOST`）。
- 补充 `worker-http` 单测覆盖非法 protocol-relative URL、缺失 Host 的安全 fallback、默认 host、`WEB_HOST` fallback 和显式 worker host override。

## 背景 / 风险

每个 session worker 会启动一个 HTTP/WebSocket server，用于提供 web terminal。默认部署会把 worker web terminal 端口按 `WEB_HOST` 暴露；这些端口本身有 token 鉴权，但仍可能收到可疑的扫描或攻击流量。

其中一种风险是畸形的 protocol-relative URL。当前 handler 直接执行 `new URL(req.url, base)`，这类输入会让 Node 抛出 `TypeError: Invalid URL`。如果异常没有被捕获，整个 session worker 会退出，造成当前 CLI 会话中断；在 worker 端口可达的部署里，这等价于一个无需通过业务鉴权即可触发的 worker-level DoS 风险。

## 修复方式

本次修复不改变默认对外可用性，只修补请求处理和提供可选收紧项：

1. worker HTTP/WS handler 对请求 URL 做安全解析，解析失败时 HTTP 返回 400，WS 关闭连接，不再让异常逃出 handler。
2. 默认 worker listen host 保持原有语义：`BOTMUX_WORKER_HTTP_HOST` / `BOTMUX_WORKER_HOST` > `WEB_HOST` > `0.0.0.0`。
3. 有安全/隐私需求的部署可以显式设置 `BOTMUX_WORKER_HTTP_HOST=127.0.0.1`，让 worker 随机端口只接受本机 terminal proxy / 本机访问。

## Compatibility

默认行为保持兼容：未设置新环境变量时，worker 仍按 `WEB_HOST` 或历史默认 `0.0.0.0` 监听，依赖直接访问 worker 随机端口的部署不需要改配置。

如需收紧为仅本机访问：

```bash
BOTMUX_WORKER_HTTP_HOST=127.0.0.1
```

## Validation

- `pnpm test -- test/worker-http.test.ts test/terminal-proxy.test.ts test/terminal-url.test.ts`
- `pnpm build`
- `git diff --check`