### PR TITLE
Stabilize Cursor Agent adopt transcript bridge

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -2079,6 +2079,9 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
   //     to re-probe via session.log / traces.jsonl fds).
   //   - mtr: worker tails MTR's sqlite transcript, resolving by native sid
   //     when discovery has one or by adopted cwd as a fallback.
+  //   - cursor: worker maps the adopt pid → its open store.db fd → chatId →
+  //     the append-only agent-transcript JSONL, then harvests final replies
+  //     from there (cursor-agent never calls `botmux send`).
   // Other CLIs fall back to legacy screen-capture only.
   const adoptedCliId = adopted.cliId ?? 'claude-code';
   if (adopted.source === 'herdr' && adoptedCliId === 'claude-code' && !adopted.sessionId) {
@@ -2097,7 +2100,11 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
     adoptedCliId === 'claude-code' && adopted.sessionId
       ? claudeJsonlPathForSession(adopted.sessionId, adopted.cwd)
       : undefined;
-  const isStructuredBridge = adoptedCliId === 'codex' || adoptedCliId === 'coco' || adoptedCliId === 'mtr';
+  // cursor: worker resolves the agent-transcript JSONL from the adopt pid's
+  // open store.db fd (chatId), or from cliSessionId (= chatId) when discovery
+  // captured it — so adopt must forward the pid + cwd like the other
+  // transcript-backed CLIs.
+  const isStructuredBridge = adoptedCliId === 'codex' || adoptedCliId === 'coco' || adoptedCliId === 'mtr' || adoptedCliId === 'cursor';
   const adoptBackendType = adopted.source === 'herdr' ? 'herdr' : adopted.zellijPaneId ? 'zellij' : 'tmux';
 
   const initMsg: DaemonToWorker = {

--- a/src/services/codex-bridge-queue.ts
+++ b/src/services/codex-bridge-queue.ts
@@ -140,39 +140,6 @@ export class CodexBridgeQueue {
     }
   }
 
-  debugSnapshot(): {
-    localTurnsEnabled: boolean;
-    queued: Array<{
-      turnId: string;
-      started: boolean;
-      hasFinalText: boolean;
-      isLocal: boolean;
-      markTimeMs?: number;
-      contentFingerprint?: string;
-    }>;
-    collectingTurnId?: string;
-    buffered: Array<{ kind: CodexBridgeEvent['kind']; uuid: string; timestampMs: number; textPreview: string }>;
-  } {
-    return {
-      localTurnsEnabled: this.localTurnsEnabled,
-      queued: this.queue.map(t => ({
-        turnId: t.turnId,
-        started: t.started,
-        hasFinalText: t.finalText !== undefined,
-        isLocal: t.isLocal === true,
-        markTimeMs: t.markTimeMs,
-        contentFingerprint: t.contentFingerprint,
-      })),
-      collectingTurnId: this.collecting?.turnId,
-      buffered: this.bufferedUnmatched.map(ev => ({
-        kind: ev.kind,
-        uuid: ev.uuid,
-        timestampMs: ev.timestampMs,
-        textPreview: ev.text.slice(0, 60),
-      })),
-    };
-  }
-
   private ingestOne(ev: CodexBridgeEvent, bufferUnmatched: boolean): void {
     if (ev.kind === 'user') {
       // First decide whether this user event is a REAL turn-start: either it

--- a/src/services/codex-bridge-queue.ts
+++ b/src/services/codex-bridge-queue.ts
@@ -41,6 +41,9 @@
 import { makeFingerprint, normaliseForFingerprint } from './bridge-turn-queue.js';
 import type { CodexBridgeEvent } from './codex-transcript.js';
 
+const UNMATCHED_REPLAY_WINDOW_MS = 5_000;
+const MAX_BUFFERED_UNMATCHED_EVENTS = 20;
+
 export interface CodexPendingTurn {
   turnId: string;
   started: boolean;
@@ -67,6 +70,7 @@ export class CodexBridgeQueue {
   private queue: CodexPendingTurn[] = [];
   private collecting: CodexPendingTurn | null = null;
   private localTurnsEnabled = false;
+  private bufferedUnmatched: CodexBridgeEvent[] = [];
   /** Lower bound (ms) for synthesising local turns — protects against a
    *  fresh-empty attach replaying historical iTerm conversation as
    *  "live" local input. Typically set to the moment adopt was wired up. */
@@ -85,6 +89,7 @@ export class CodexBridgeQueue {
   setLocalTurns(enabled: boolean, lowerBoundMs: number = Date.now()): void {
     this.localTurnsEnabled = enabled;
     this.localLowerBoundMs = lowerBoundMs;
+    if (enabled) this.bufferedUnmatched = [];
   }
 
   /** Push a pending Lark turn anchored to the message text. The fingerprint
@@ -99,6 +104,7 @@ export class CodexBridgeQueue {
       contentFingerprint: makeFingerprint(message),
       markTimeMs,
     });
+    this.replayBufferedUnmatched(markTimeMs);
   }
 
   /** Drop all pending turns. Used when the worker decides it can't reliably
@@ -106,6 +112,7 @@ export class CodexBridgeQueue {
   clearPending(): CodexPendingTurn[] {
     const dropped = this.queue.splice(0);
     if (this.collecting && dropped.includes(this.collecting)) this.collecting = null;
+    this.bufferedUnmatched = [];
     return dropped;
   }
 
@@ -115,85 +122,143 @@ export class CodexBridgeQueue {
     for (const ev of events) {
       if (!ev.uuid || this.seen.has(ev.uuid)) continue;
       this.seen.add(ev.uuid);
-      if (ev.kind === 'user') {
-        // First decide whether this user event is a REAL turn-start: either it
-        // matches the head pending Lark turn's fingerprint (and isn't tooOld),
-        // or — in adopt mode — it synthesises a local turn. Both the HOL-drop
-        // and the actual start key off this decision.
-        const next = this.queue.find(t => !t.started);
-        const tooOld = !!next && next.markTimeMs !== undefined && ev.timestampMs < next.markTimeMs - 5_000;
-        let fingerprintOk = true;
-        if (next?.contentFingerprint) {
-          fingerprintOk = normaliseForFingerprint(ev.text).includes(next.contentFingerprint);
-        }
-        const willStartNext = !!next && !tooOld && fingerprintOk;
-        const willSynthLocal = !willStartNext && this.localTurnsEnabled && ev.timestampMs >= this.localLowerBoundMs - 5_000;
+      this.ingestOne(ev, true);
+    }
+  }
 
-        // HOL-block drop (codex 0.134.0 active-turn steer): when a real new
-        // turn-start arrives while a turn is still collecting with no finalText,
-        // codex steered/merged this input into the active turn — it processes
-        // both as ONE turn and emits a single combined assistant_final, so the
-        // collecting turn will NEVER get its own final. Drop it now, otherwise
-        // it sits at the queue head forever and `drainEmittable()` wedges
-        // (started, no finalText → breaks the FIFO scan). Gating on "is a real
-        // turn-start" reuses the tooOld/fingerprint freshness already proven for
-        // turn-start, so the same 5s-skew invariant applies to both: a replayed
-        // historical user event is tooOld → won't start a turn → won't evict a
-        // live collecting turn; and a non-matching stray user event (non-adopt)
-        // is ignored rather than treated as a turn boundary. Mirrors Claude's
-        // BridgeTurnQueue.handleTurnStart HOL drop (which keys off "no assistant
-        // text yet" — the streaming-transcript equivalent of "no finalText").
-        if ((willStartNext || willSynthLocal) && this.collecting && this.collecting.finalText === undefined) {
-          const idx = this.queue.indexOf(this.collecting);
-          if (idx >= 0) this.queue.splice(idx, 1);
-          this.collecting = null;
-        }
+  private replayBufferedUnmatched(markTimeMs: number): void {
+    if (this.bufferedUnmatched.length === 0) return;
+    const replay = this.bufferedUnmatched.filter(ev => ev.timestampMs >= markTimeMs - UNMATCHED_REPLAY_WINDOW_MS);
+    this.bufferedUnmatched = [];
+    for (const ev of replay) this.ingestOne(ev, false);
+  }
 
-        if (willStartNext) {
-          next!.started = true;
-          next!.sourceSessionId = ev.sourceSessionId;
-          // Anchor the bridge-fallback suppression window to when the turn
-          // ACTUALLY started processing (the transcript user event's
-          // timestamp), not when the worker marked it. With type-ahead the
-          // worker marks turn N+1 immediately after turn N (both at flush
-          // time), but CoCo only writes turn N+1's user event when it
-          // dequeues it — i.e. after turn N's assistant_final. Without this
-          // override the [markTimeMs, nextTurn.markTimeMs) windows are all
-          // bunched at flush time, so turn N's own `botmux send` (which
-          // lands seconds later, after the model replies) falls OUTSIDE its
-          // own window and the fallback isn't suppressed → duplicate emit.
-          // `max` (not bare assignment) keeps the lower bound from ever
-          // moving backwards: a dequeue event can only be at or after the
-          // mark, and the -5s tooOld tolerance must not be able to widen the
-          // window into a previous turn's sends. Mirrors what Claude's
-          // BridgeTurnQueue.handleTurnStart does with eventTimeMs.
-          if (next!.markTimeMs === undefined) next!.markTimeMs = ev.timestampMs;
-          else next!.markTimeMs = Math.max(next!.markTimeMs, ev.timestampMs);
-          this.collecting = next!;
-        } else if (willSynthLocal) {
-          // Adopt mode local input: user typed in iTerm, no Lark
-          // fingerprint match. Synthesise a local turn so the assistant
-          // reply still reaches Lark. Insert AHEAD of any unstarted Lark
-          // turn so emit order matches when the event hit the transcript.
-          const localTurn: CodexPendingTurn = {
-            turnId: `codex-local-${ev.uuid}`,
-            started: true,
-            isLocal: true,
-            userText: ev.text,
-            markTimeMs: ev.timestampMs,
-            sourceSessionId: ev.sourceSessionId,
-          };
-          const insertAt = this.queue.findIndex(t => !t.started);
-          if (insertAt === -1) this.queue.push(localTurn);
-          else this.queue.splice(insertAt, 0, localTurn);
-          this.collecting = localTurn;
-        }
-      } else if (ev.kind === 'assistant_final') {
-        if (this.collecting) {
-          if (this.collecting.sourceSessionId && ev.sourceSessionId && this.collecting.sourceSessionId !== ev.sourceSessionId) continue;
-          this.collecting.finalText = ev.text;
-          this.collecting = null;
-        }
+  private rememberUnmatched(ev: CodexBridgeEvent): void {
+    this.bufferedUnmatched.push(ev);
+    if (this.bufferedUnmatched.length > MAX_BUFFERED_UNMATCHED_EVENTS) {
+      this.bufferedUnmatched.splice(0, this.bufferedUnmatched.length - MAX_BUFFERED_UNMATCHED_EVENTS);
+    }
+  }
+
+  debugSnapshot(): {
+    localTurnsEnabled: boolean;
+    queued: Array<{
+      turnId: string;
+      started: boolean;
+      hasFinalText: boolean;
+      isLocal: boolean;
+      markTimeMs?: number;
+      contentFingerprint?: string;
+    }>;
+    collectingTurnId?: string;
+    buffered: Array<{ kind: CodexBridgeEvent['kind']; uuid: string; timestampMs: number; textPreview: string }>;
+  } {
+    return {
+      localTurnsEnabled: this.localTurnsEnabled,
+      queued: this.queue.map(t => ({
+        turnId: t.turnId,
+        started: t.started,
+        hasFinalText: t.finalText !== undefined,
+        isLocal: t.isLocal === true,
+        markTimeMs: t.markTimeMs,
+        contentFingerprint: t.contentFingerprint,
+      })),
+      collectingTurnId: this.collecting?.turnId,
+      buffered: this.bufferedUnmatched.map(ev => ({
+        kind: ev.kind,
+        uuid: ev.uuid,
+        timestampMs: ev.timestampMs,
+        textPreview: ev.text.slice(0, 60),
+      })),
+    };
+  }
+
+  private ingestOne(ev: CodexBridgeEvent, bufferUnmatched: boolean): void {
+    if (ev.kind === 'user') {
+      // First decide whether this user event is a REAL turn-start: either it
+      // matches the head pending Lark turn's fingerprint (and isn't tooOld),
+      // or — in adopt mode — it synthesises a local turn. Both the HOL-drop
+      // and the actual start key off this decision.
+      const next = this.queue.find(t => !t.started);
+      const tooOld = !!next && next.markTimeMs !== undefined && ev.timestampMs < next.markTimeMs - UNMATCHED_REPLAY_WINDOW_MS;
+      let fingerprintOk = true;
+      if (next?.contentFingerprint) {
+        fingerprintOk = normaliseForFingerprint(ev.text).includes(next.contentFingerprint);
+      }
+      const willStartNext = !!next && !tooOld && fingerprintOk;
+      const willSynthLocal = !willStartNext && this.localTurnsEnabled && ev.timestampMs >= this.localLowerBoundMs - UNMATCHED_REPLAY_WINDOW_MS;
+
+      // HOL-block drop (codex 0.134.0 active-turn steer): when a real new
+      // turn-start arrives while a turn is still collecting with no finalText,
+      // codex steered/merged this input into the active turn — it processes
+      // both as ONE turn and emits a single combined assistant_final, so the
+      // collecting turn will NEVER get its own final. Drop it now, otherwise
+      // it sits at the queue head forever and `drainEmittable()` wedges
+      // (started, no finalText → breaks the FIFO scan). Gating on "is a real
+      // turn-start" reuses the tooOld/fingerprint freshness already proven for
+      // turn-start, so the same 5s-skew invariant applies to both: a replayed
+      // historical user event is tooOld → won't start a turn → won't evict a
+      // live collecting turn; and a non-matching stray user event (non-adopt)
+      // is ignored rather than treated as a turn boundary. Mirrors Claude's
+      // BridgeTurnQueue.handleTurnStart HOL drop (which keys off "no assistant
+      // text yet" — the streaming-transcript equivalent of "no finalText").
+      if ((willStartNext || willSynthLocal) && this.collecting && this.collecting.finalText === undefined) {
+        const idx = this.queue.indexOf(this.collecting);
+        if (idx >= 0) this.queue.splice(idx, 1);
+        this.collecting = null;
+      }
+
+      if (willStartNext) {
+        next!.started = true;
+        next!.sourceSessionId = ev.sourceSessionId;
+        // Anchor the bridge-fallback suppression window to when the turn
+        // ACTUALLY started processing (the transcript user event's
+        // timestamp), not when the worker marked it. With type-ahead the
+        // worker marks turn N+1 immediately after turn N (both at flush
+        // time), but CoCo only writes turn N+1's user event when it
+        // dequeues it — i.e. after turn N's assistant_final. Without this
+        // override the [markTimeMs, nextTurn.markTimeMs) windows are all
+        // bunched at flush time, so turn N's own `botmux send` (which
+        // lands seconds later, after the model replies) falls OUTSIDE its
+        // own window and the fallback isn't suppressed → duplicate emit.
+        // `max` (not bare assignment) keeps the lower bound from ever
+        // moving backwards: a dequeue event can only be at or after the
+        // mark, and the -5s tooOld tolerance must not be able to widen the
+        // window into a previous turn's sends. Mirrors what Claude's
+        // BridgeTurnQueue.handleTurnStart does with eventTimeMs.
+        if (next!.markTimeMs === undefined) next!.markTimeMs = ev.timestampMs;
+        else next!.markTimeMs = Math.max(next!.markTimeMs, ev.timestampMs);
+        this.collecting = next!;
+      } else if (willSynthLocal) {
+        // Adopt mode local input: user typed in iTerm, no Lark
+        // fingerprint match. Synthesise a local turn so the assistant
+        // reply still reaches Lark. Insert AHEAD of any unstarted Lark
+        // turn so emit order matches when the event hit the transcript.
+        const localTurn: CodexPendingTurn = {
+          turnId: `codex-local-${ev.uuid}`,
+          started: true,
+          isLocal: true,
+          userText: ev.text,
+          markTimeMs: ev.timestampMs,
+          sourceSessionId: ev.sourceSessionId,
+        };
+        const insertAt = this.queue.findIndex(t => !t.started);
+        if (insertAt === -1) this.queue.push(localTurn);
+        else this.queue.splice(insertAt, 0, localTurn);
+        this.collecting = localTurn;
+      } else if (bufferUnmatched && !this.localTurnsEnabled) {
+        // Cursor can write the Lark/user line to JSONL before the daemon IPC
+        // that marks the turn reaches this worker. Keep a tiny recent buffer
+        // so mark() can replay it instead of losing the line to `seen`.
+        this.rememberUnmatched(ev);
+      }
+    } else if (ev.kind === 'assistant_final') {
+      if (this.collecting) {
+        if (this.collecting.sourceSessionId && ev.sourceSessionId && this.collecting.sourceSessionId !== ev.sourceSessionId) return;
+        this.collecting.finalText = ev.text;
+        this.collecting = null;
+      } else if (bufferUnmatched && !this.localTurnsEnabled) {
+        this.rememberUnmatched(ev);
       }
     }
   }

--- a/src/services/cursor-transcript.ts
+++ b/src/services/cursor-transcript.ts
@@ -13,12 +13,34 @@
  * a content block is either `{ type: 'text', text }` or `{ type: 'tool_use',
  * name, input }`. Tool *results* are not recorded.
  *
- * Final-answer detection is simpler than Codex's `phase=final_answer`: the
- * model emits a `text + tool_use` line for every intermediate step and ends a
- * turn with a single `text`-only assistant line (no `tool_use`). So:
- *   - role=user                         → the user's prompt
+ * Where Cursor sits between the two existing bridge transcript shapes:
+ *   - Claude is a STREAMING event stream — one role:user event, then a run of
+ *     role:assistant events whose text grows incrementally; a turn has no
+ *     explicit terminator, so the bridge queue tracks the in-flight turn with
+ *     a `collecting` pointer.
+ *   - Codex is DISCRETE complete events — exactly one user_message and one
+ *     assistant_final per turn, each carrying the full text, with a definite
+ *     terminator (phase=final_answer).
+ * Cursor is a hybrid: each JSONL line is a DISCRETE, complete event (verified
+ * empirically — assistant lines are never growing prefixes of one another, so
+ * there is no Claude-style snapshot replay risk), but a turn is composed of
+ * MANY assistant lines (one per step). Crucially it still has a definite
+ * terminator: every intermediate step pairs its narration with a `tool_use`
+ * block, and the agent loop only stops when the model returns a message with
+ * NO tool_use. So a `text`-only assistant line is the end-of-turn final reply:
+ *   - role=user                          → the user's prompt
  *   - role=assistant, text & no tool_use → the model's final reply
- * Intermediate assistant lines (any with a tool_use block) are skipped.
+ * Every line carrying a tool_use block is an intermediate step and is dropped.
+ * This lets the reader distill Cursor's multi-event turn down to Codex's
+ * two-event (user, assistant_final) shape, so it can reuse the proven
+ * CodexBridgeQueue attribution as-is rather than a Claude-style streaming
+ * accumulator.
+ *
+ * Consequences of that distillation (intentional):
+ *   - Only the final wrap-up text is forwarded; the short per-step narrations
+ *     ("Let me read…", "Now I'll check…") are deliberately not relayed to Lark.
+ *   - An interrupted turn (process killed / Esc mid-tool, leaving no text-only
+ *     line) emits NOTHING rather than a half-answer — the safe failure mode.
  *
  * Cursor's JSONL carries no per-event timestamp, so the worker baselines this
  * transcript by byte offset at adopt time (history is behind the offset and

--- a/src/services/cursor-transcript.ts
+++ b/src/services/cursor-transcript.ts
@@ -1,0 +1,223 @@
+/**
+ * Reader for Cursor Agent's per-chat transcript JSONL.
+ *
+ * `cursor-agent` keeps each chat's authoritative store in a SQLite file
+ *   ~/.cursor/chats/<projectHash>/<chatId>/store.db
+ * (held open via fd for the whole session) and, in parallel, mirrors the
+ * conversation into an append-only JSONL transcript at
+ *   ~/.cursor/projects/<projectSlug>/agent-transcripts/<chatId>/<chatId>.jsonl
+ *
+ * The bridge reads the JSONL (not the SQLite store) because it's append-only
+ * plain text — the same integration surface the Codex/CoCo bridges use. Each
+ * line is `{ role: 'user' | 'assistant', message: { content: [...] } }` where
+ * a content block is either `{ type: 'text', text }` or `{ type: 'tool_use',
+ * name, input }`. Tool *results* are not recorded.
+ *
+ * Final-answer detection is simpler than Codex's `phase=final_answer`: the
+ * model emits a `text + tool_use` line for every intermediate step and ends a
+ * turn with a single `text`-only assistant line (no `tool_use`). So:
+ *   - role=user                         → the user's prompt
+ *   - role=assistant, text & no tool_use → the model's final reply
+ * Intermediate assistant lines (any with a tool_use block) are skipped.
+ *
+ * Cursor's JSONL carries no per-event timestamp, so the worker baselines this
+ * transcript by byte offset at adopt time (history is behind the offset and
+ * never re-ingested) and stamps live events with the drain wall-clock. That's
+ * why every emitted event uses `Date.now()` for `timestampMs` — enough for the
+ * shared CodexBridgeQueue's freshness gates given the offset baseline.
+ *
+ * Pure I/O. Attribution belongs in CodexBridgeQueue.
+ */
+import { existsSync, statSync, openSync, readSync, closeSync, readdirSync, readlinkSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { homedir, platform } from 'node:os';
+import { join } from 'node:path';
+import type { CodexBridgeEvent } from './codex-transcript.js';
+
+const IS_LINUX = platform() === 'linux';
+
+const CHAT_ID_RE = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+
+/** Default `~/.cursor/projects` root. Overridable by callers (tests) so the
+ *  scan doesn't depend on a real home directory. */
+export function cursorProjectsRoot(): string {
+  return join(homedir(), '.cursor', 'projects');
+}
+
+/** Extract the chatId encoded in a Cursor store.db path of the shape
+ *  `.../.cursor/chats/<projectHash>/<chatId>/store.db` (also matches the
+ *  `-wal` / `-shm` sidecar files SQLite keeps open). The chatId is the same
+ *  UUID used to name the agent-transcript JSONL, so it's the bridge between
+ *  the open fd and the transcript file. Returns undefined for non-matching
+ *  paths. */
+export function cursorChatIdFromStoreDbPath(path: string): string | undefined {
+  const re = new RegExp(`/\\.cursor/chats/[^/]+/(${CHAT_ID_RE})/store\\.db(?:-wal|-shm)?$`, 'i');
+  const m = re.exec(path);
+  return m ? m[1] : undefined;
+}
+
+/** Find the chatId of an externally-running cursor-agent process by reading
+ *  the store.db file it keeps open. cursor-agent holds an fd on its current
+ *  chat's SQLite store for the whole session lifetime, which makes this the
+ *  authoritative pid→chatId binding — far more reliable than scanning chat
+ *  dirs by mtime (which would race with sibling cursor-agent panes).
+ *
+ *  Linux: `/proc/<pid>/fd/*` fast path. macOS / BSD: `lsof -p <pid> -Fn`
+ *  fallback (same shape as codex-transcript.findCodexRolloutByPid). */
+export function findCursorChatIdByPid(pid: number): string | undefined {
+  if (!Number.isInteger(pid) || pid <= 0) return undefined;
+  if (IS_LINUX) {
+    const fdDir = `/proc/${pid}/fd`;
+    if (existsSync(fdDir)) {
+      let entries: string[];
+      try { entries = readdirSync(fdDir); } catch { return undefined; }
+      for (const fd of entries) {
+        let target: string;
+        try { target = readlinkSync(join(fdDir, fd)); } catch { continue; }
+        const chatId = cursorChatIdFromStoreDbPath(target);
+        if (chatId) return chatId;
+      }
+      return undefined;
+    }
+    // /proc unreadable — fall through to lsof.
+  }
+  let out: string;
+  try {
+    out = execSync(`lsof -p ${pid} -Fn`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch {
+    return undefined;
+  }
+  for (const line of out.split('\n')) {
+    if (!line.startsWith('n/')) continue;
+    const chatId = cursorChatIdFromStoreDbPath(line.slice(1));
+    if (chatId) return chatId;
+  }
+  return undefined;
+}
+
+/** Locate the agent-transcript JSONL for a given chatId. The chatId is a
+ *  globally-unique UUID, so a one-shot scan of the (small) projects root for
+ *  `<slug>/agent-transcripts/<chatId>/<chatId>.jsonl` is unambiguous and
+ *  avoids having to reproduce Cursor's opaque cwd→slug hashing. */
+export function findCursorTranscriptByChatId(
+  chatId: string,
+  projectsRoot: string = cursorProjectsRoot(),
+): string | undefined {
+  if (!chatId || !existsSync(projectsRoot)) return undefined;
+  let slugs: string[];
+  try { slugs = readdirSync(projectsRoot); } catch { return undefined; }
+  for (const slug of slugs) {
+    const candidate = join(projectsRoot, slug, 'agent-transcripts', chatId, `${chatId}.jsonl`);
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/** Resolve the transcript path for an externally-running cursor-agent pid:
+ *  pid → open store.db → chatId → agent-transcript JSONL. Returns both the
+ *  path and the chatId so the caller can remember the chatId for a later
+ *  retry if the JSONL isn't on disk yet. */
+export function findCursorTranscriptByPid(
+  pid: number,
+  projectsRoot: string = cursorProjectsRoot(),
+): { path: string; chatId: string } | undefined {
+  const chatId = findCursorChatIdByPid(pid);
+  if (!chatId) return undefined;
+  const path = findCursorTranscriptByChatId(chatId, projectsRoot);
+  return path ? { path, chatId } : undefined;
+}
+
+export interface CursorDrainResult {
+  events: CodexBridgeEvent[];
+  /** Byte offset of the last fully-parsed line + its trailing \n. The next
+   *  drain should pass this back as fromOffset. */
+  newOffset: number;
+  /** A line written without its terminating \n yet — informational; only
+   *  complete lines produce events. */
+  pendingTail: string;
+}
+
+/** Concatenate the text of all `type:'text'` blocks. Cursor uses the same
+ *  `{type:'text', text}` shape for both user prompts and assistant replies;
+ *  `tool_use` (and any other) blocks are ignored — the bridge only forwards
+ *  text. Tolerates a bare-string content for defensiveness. */
+function joinTextBlocks(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const block of content) {
+    if (block && typeof block === 'object' && (block as any).type === 'text') {
+      const text = (block as any).text;
+      if (typeof text === 'string') parts.push(text);
+    }
+  }
+  return parts.join('\n');
+}
+
+/** True when an assistant content array contains at least one tool_use block,
+ *  i.e. this is a mid-turn step rather than the final reply. */
+function hasToolUse(content: unknown): boolean {
+  if (!Array.isArray(content)) return false;
+  return content.some(b => b && typeof b === 'object' && (b as any).type === 'tool_use');
+}
+
+/** Increment-read the transcript from `fromOffset`. Mirrors the byte-offset
+ *  contract of codex-transcript.drainCodexRollout so the worker can reuse the
+ *  same fs.watch / poll wakeup machinery and the shared CodexBridgeQueue. */
+export function drainCursorTranscript(path: string, fromOffset: number): CursorDrainResult {
+  if (!existsSync(path)) return { events: [], newOffset: 0, pendingTail: '' };
+  let size: number;
+  try { size = statSync(path).size; } catch { return { events: [], newOffset: fromOffset, pendingTail: '' }; }
+  let start = fromOffset;
+  // Truncated / rotated jsonl — re-read from the top (mirrors Codex/Claude).
+  if (size < start) start = 0;
+  if (size === start) return { events: [], newOffset: start, pendingTail: '' };
+
+  const len = size - start;
+  const buf = Buffer.alloc(len);
+  const fd = openSync(path, 'r');
+  try { readSync(fd, buf, 0, len, start); } finally { closeSync(fd); }
+  const text = buf.toString('utf8');
+  const lastNl = text.lastIndexOf('\n');
+  const completeText = lastNl >= 0 ? text.slice(0, lastNl + 1) : '';
+  const pendingTail = lastNl >= 0 ? text.slice(lastNl + 1) : text;
+  const newOffset = start + Buffer.byteLength(completeText, 'utf8');
+
+  const events: CodexBridgeEvent[] = [];
+  // Track byte offset within the file so synthetic uuids are stable across
+  // re-drains (the transcript is append-only).
+  let cursor = start;
+  for (const line of completeText.split('\n')) {
+    if (line.length === 0) {
+      cursor += 1; // the \n after an empty line
+      continue;
+    }
+    const lineByteLen = Buffer.byteLength(line, 'utf8') + 1; // include \n
+    const lineStart = cursor;
+    cursor += lineByteLen;
+    let obj: any;
+    try { obj = JSON.parse(line); } catch { continue; }
+    const role = obj?.role ?? obj?.message?.role;
+    const content = obj?.message?.content;
+    // No per-event timestamp in Cursor's JSONL — stamp with the drain
+    // wall-clock. Combined with byte-offset baselining at attach, this keeps
+    // the CodexBridgeQueue freshness gates happy without a real timestamp.
+    const timestampMs = Date.now();
+    if (role === 'user') {
+      const t = joinTextBlocks(content);
+      if (!t) continue;
+      events.push({ uuid: `${path}:${lineStart}`, timestampMs, kind: 'user', text: t });
+    } else if (role === 'assistant') {
+      // A turn ends with a text-only assistant line; any line carrying a
+      // tool_use block is an intermediate step and must not be forwarded.
+      if (hasToolUse(content)) continue;
+      const t = joinTextBlocks(content);
+      if (!t) continue;
+      events.push({ uuid: `${path}:${lineStart}`, timestampMs, kind: 'assistant_final', text: t });
+    }
+  }
+  return { events, newOffset, pendingTail };
+}

--- a/src/services/cursor-transcript.ts
+++ b/src/services/cursor-transcript.ts
@@ -186,16 +186,71 @@ function hasToolUse(content: unknown): boolean {
   return content.some(b => b && typeof b === 'object' && (b as any).type === 'tool_use');
 }
 
+const CURSOR_REASONING_LEAK_HEADING_RE = new RegExp([
+  '\\n{2,}\\*\\*(?:',
+  [
+    'Considering',
+    'Thinking',
+    'Planning',
+    'Inspecting',
+    'Exploring',
+    'Reviewing',
+    'Troubleshooting',
+    'Diagnosing',
+    'Evaluating',
+    'Running',
+    'Checking',
+    'Reading',
+    'Understanding',
+    'Analyzing',
+    'Debugging',
+    'Responding',
+  ].join('|'),
+  ')\\b[^*\\n]{0,80}\\*\\*\\n{2,}',
+].join(''));
+
+function stripCursorReasoningLeak(text: string): string {
+  // Cursor's mirror can append the model's internal planning/debug summary to
+  // the same text-only assistant line that otherwise represents the final user
+  // reply. The leak starts with a bold English activity heading after a blank
+  // paragraph, e.g. "**Considering user response**".
+  const marker = CURSOR_REASONING_LEAK_HEADING_RE.exec(text);
+  if (!marker || marker.index <= 0) return text;
+  return text.slice(0, marker.index).trimEnd();
+}
+
+function eventFromLine(path: string, lineStart: number, obj: any, timestampMs: number): CodexBridgeEvent | undefined {
+  const role = obj?.role ?? obj?.message?.role;
+  const content = obj?.message?.content;
+  if (role === 'user') {
+    const t = joinTextBlocks(content);
+    if (!t) return undefined;
+    return { uuid: `${path}:${lineStart}`, timestampMs, kind: 'user', text: t };
+  }
+  if (role === 'assistant') {
+    // A turn ends with a text-only assistant line; any line carrying a
+    // tool_use block is an intermediate step and must not be forwarded.
+    if (hasToolUse(content)) return undefined;
+    const t = stripCursorReasoningLeak(joinTextBlocks(content));
+    if (!t) return undefined;
+    return { uuid: `${path}:${lineStart}`, timestampMs, kind: 'assistant_final', text: t };
+  }
+  return undefined;
+}
+
 /** Increment-read the transcript from `fromOffset`. Mirrors the byte-offset
  *  contract of codex-transcript.drainCodexRollout so the worker can reuse the
  *  same fs.watch / poll wakeup machinery and the shared CodexBridgeQueue. */
 export function drainCursorTranscript(path: string, fromOffset: number): CursorDrainResult {
-  if (!existsSync(path)) return { events: [], newOffset: 0, pendingTail: '' };
+  if (!existsSync(path)) return { events: [], newOffset: fromOffset, pendingTail: '' };
   let size: number;
   try { size = statSync(path).size; } catch { return { events: [], newOffset: fromOffset, pendingTail: '' }; }
   let start = fromOffset;
-  // Truncated / rotated jsonl — re-read from the top (mirrors Codex/Claude).
-  if (size < start) start = 0;
+  // Cursor's mirror can briefly disappear / shrink while it rewrites. Do not
+  // reset to 0 here: replaying the full history pollutes attribution state and
+  // can wedge a live turn behind old events. Wait for the mirror to grow past
+  // the last consumed byte instead.
+  if (size < start) return { events: [], newOffset: fromOffset, pendingTail: '' };
   if (size === start) return { events: [], newOffset: start, pendingTail: '' };
 
   const len = size - start;
@@ -205,8 +260,8 @@ export function drainCursorTranscript(path: string, fromOffset: number): CursorD
   const text = buf.toString('utf8');
   const lastNl = text.lastIndexOf('\n');
   const completeText = lastNl >= 0 ? text.slice(0, lastNl + 1) : '';
-  const pendingTail = lastNl >= 0 ? text.slice(lastNl + 1) : text;
-  const newOffset = start + Buffer.byteLength(completeText, 'utf8');
+  let pendingTail = lastNl >= 0 ? text.slice(lastNl + 1) : text;
+  let newOffset = start + Buffer.byteLength(completeText, 'utf8');
 
   const events: CodexBridgeEvent[] = [];
   // Track byte offset within the file so synthetic uuids are stable across
@@ -222,23 +277,27 @@ export function drainCursorTranscript(path: string, fromOffset: number): CursorD
     cursor += lineByteLen;
     let obj: any;
     try { obj = JSON.parse(line); } catch { continue; }
-    const role = obj?.role ?? obj?.message?.role;
-    const content = obj?.message?.content;
     // No per-event timestamp in Cursor's JSONL — stamp with the drain
     // wall-clock. Combined with byte-offset baselining at attach, this keeps
     // the CodexBridgeQueue freshness gates happy without a real timestamp.
     const timestampMs = Date.now();
-    if (role === 'user') {
-      const t = joinTextBlocks(content);
-      if (!t) continue;
-      events.push({ uuid: `${path}:${lineStart}`, timestampMs, kind: 'user', text: t });
-    } else if (role === 'assistant') {
-      // A turn ends with a text-only assistant line; any line carrying a
-      // tool_use block is an intermediate step and must not be forwarded.
-      if (hasToolUse(content)) continue;
-      const t = joinTextBlocks(content);
-      if (!t) continue;
-      events.push({ uuid: `${path}:${lineStart}`, timestampMs, kind: 'assistant_final', text: t });
+    const ev = eventFromLine(path, lineStart, obj, timestampMs);
+    if (ev) events.push(ev);
+  }
+
+  // Cursor frequently leaves the final JSON object at EOF without a trailing
+  // newline until the next turn mutates the mirror. If the tail is already a
+  // complete JSON object, consume it now; otherwise keep it pending.
+  if (pendingTail.length > 0) {
+    try {
+      const lineStart = newOffset;
+      const obj = JSON.parse(pendingTail);
+      const ev = eventFromLine(path, lineStart, obj, Date.now());
+      if (ev) events.push(ev);
+      newOffset = size;
+      pendingTail = '';
+    } catch {
+      // Still being written.
     }
   }
   return { events, newOffset, pendingTail };

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1440,41 +1440,6 @@ function structuredBridgeIngestPath(path: string, offset: number) {
   return drainCocoEvents(path, offset);
 }
 
-function codexBridgeProbeEnabled(): boolean {
-  // Cursor is the only current transcript bridge without per-event timestamps,
-  // so keep the high-cardinality attribution probe scoped there by default.
-  return codexBridgeIsCursor();
-}
-
-function codexBridgeEventPreview(events: CodexBridgeEvent[]): string {
-  return events.map(ev => {
-    const uuid = ev.uuid.length > 24 ? `...${ev.uuid.slice(-24)}` : ev.uuid;
-    return `${ev.kind}:${uuid}:${ev.text.replace(/\s+/g, ' ').slice(0, 60)}`;
-  }).join(' | ');
-}
-
-function codexBridgeQueueSnapshot(): string {
-  const snap = codexBridgeQueue.debugSnapshot();
-  return JSON.stringify({
-    localTurnsEnabled: snap.localTurnsEnabled,
-    collectingTurnId: snap.collectingTurnId,
-    queued: snap.queued.map(t => ({
-      turnId: t.turnId.slice(0, 8),
-      started: t.started,
-      hasFinalText: t.hasFinalText,
-      isLocal: t.isLocal,
-      markTimeMs: t.markTimeMs,
-      fp: t.contentFingerprint,
-    })),
-    buffered: snap.buffered.map(ev => ({
-      kind: ev.kind,
-      uuid: ev.uuid.length > 18 ? `...${ev.uuid.slice(-18)}` : ev.uuid,
-      timestampMs: ev.timestampMs,
-      text: ev.textPreview.replace(/\s+/g, ' '),
-    })),
-  });
-}
-
 function codexBridgeStartTimer(): void {
   if (codexBridgeTimer) return;
   // Single 1s ticker that handles three jobs: late-attach (poll for the
@@ -1808,16 +1773,11 @@ function codexBridgeIngest(): void {
     return;
   }
   if (!codexBridgeRolloutPath || !codexBridgeBaselineDone) return;
-  const oldOffset = codexBridgeOffset;
-  const before = codexBridgeProbeEnabled() ? codexBridgeQueueSnapshot() : '';
   const result = structuredBridgeIngestPath(codexBridgeRolloutPath, codexBridgeOffset);
   codexBridgeOffset = result.newOffset;
   codexBridgePendingTail = result.pendingTail;
   if (result.events.length > 0) lastStructuredBridgeActivityAtMs = Date.now();
   codexBridgeQueue.ingest(result.events);
-  if (codexBridgeProbeEnabled() && (result.events.length > 0 || oldOffset !== result.newOffset)) {
-    log(`Codex bridge probe ingest: offset=${oldOffset}->${result.newOffset}, events=${result.events.length}, tail=${result.pendingTail.length}, eventPreview="${codexBridgeEventPreview(result.events)}", before=${before}, after=${codexBridgeQueueSnapshot()}`);
-  }
   // Transcript-driven idle: an `assistant_final` event is the CLI declaring
   // end-of-turn, far more reliable than the screen-pattern heuristic
   // (CoCo's status bar varies by --yolo flag, version, theme; codex has
@@ -1835,13 +1795,7 @@ function codexBridgeIngest(): void {
 function codexBridgeMarkPendingTurn(messageText: string): boolean {
   if (!codexBridgeFallbackActive()) return false;
   const turnId = `codex-${randomBytes(8).toString('hex')}`;
-  if (codexBridgeProbeEnabled()) {
-    log(`Codex bridge probe mark: turn=${turnId.slice(0, 8)}, preview="${messageText.replace(/\s+/g, ' ').slice(0, 80)}", before=${codexBridgeQueueSnapshot()}`);
-  }
   codexBridgeQueue.mark(turnId, messageText);
-  if (codexBridgeProbeEnabled()) {
-    log(`Codex bridge probe mark done: turn=${turnId.slice(0, 8)}, after=${codexBridgeQueueSnapshot()}`);
-  }
   return true;
 }
 
@@ -1854,20 +1808,8 @@ function codexBridgeDrainAndMaybeEmit(): void {
 }
 
 function emitReadyCodexTurns(): void {
-  const probe = codexBridgeProbeEnabled();
-  const before = probe ? codexBridgeQueueSnapshot() : '';
   const ready = codexBridgeQueue.drainEmittable();
-  if (ready.length === 0) {
-    if (probe && before !== codexBridgeQueueSnapshot()) {
-      log(`Codex bridge probe drain: ready=0, before=${before}, after=${codexBridgeQueueSnapshot()}`);
-    } else if (probe && before.includes('"queued":[{')) {
-      log(`Codex bridge probe drain: ready=0, state=${before}`);
-    }
-    return;
-  }
-  if (probe) {
-    log(`Codex bridge probe drain: ready=${ready.length}, readyTurns=${JSON.stringify(ready.map(t => ({ turnId: t.turnId.slice(0, 8), isLocal: t.isLocal === true, finalLen: t.finalText?.length ?? 0, markTimeMs: t.markTimeMs })))}, before=${before}, after=${codexBridgeQueueSnapshot()}`);
-  }
+  if (ready.length === 0) return;
   const adoptMode = lastInitConfig?.adoptMode === true;
   // Adopt mode: model is the user's external Codex, no botmux send to
   // gate against — every assistant turn (Lark-driven OR locally typed)
@@ -1908,15 +1850,9 @@ function emitReadyCodexTurns(): void {
         kind: 'local-turn',
         userText: fields.userText,
       });
-      if (probe) {
-        log(`Codex bridge probe send local final_output: turn=${turn.turnId.slice(0, 8)}, len=${fields.content.length}`);
-      }
       continue;
     }
     send({ type: 'final_output', content: turn.finalText, lastUuid: turn.turnId, turnId: turn.turnId });
-    if (probe) {
-      log(`Codex bridge probe send final_output: turn=${turn.turnId.slice(0, 8)}, len=${turn.finalText.length}`);
-    }
   }
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1426,13 +1426,13 @@ function structuredBridgeIsMtr(): boolean {
   return lastInitConfig?.cliId === 'mtr';
 }
 
-function structuredBridgeIsCursor(): boolean {
+function codexBridgeIsCursor(): boolean {
   return lastInitConfig?.cliId === 'cursor';
 }
 
 function structuredBridgeIngestPath(path: string, offset: number) {
   if (structuredBridgeIsCodex()) return drainCodexRollout(path, offset);
-  if (structuredBridgeIsCursor()) return drainCursorTranscript(path, offset);
+  if (codexBridgeIsCursor()) return drainCursorTranscript(path, offset);
   if (structuredBridgeIsHermes()) {
     const result = drainHermesStateDb(offset);
     return { events: result.events, newOffset: result.newOffset, pendingTail: '' };
@@ -1440,20 +1440,20 @@ function structuredBridgeIngestPath(path: string, offset: number) {
   return drainCocoEvents(path, offset);
 }
 
-function structuredBridgeProbeEnabled(): boolean {
-  // Cursor is the only current structured bridge without per-event timestamps,
+function codexBridgeProbeEnabled(): boolean {
+  // Cursor is the only current transcript bridge without per-event timestamps,
   // so keep the high-cardinality attribution probe scoped there by default.
-  return structuredBridgeIsCursor();
+  return codexBridgeIsCursor();
 }
 
-function structuredBridgeEventPreview(events: CodexBridgeEvent[]): string {
+function codexBridgeEventPreview(events: CodexBridgeEvent[]): string {
   return events.map(ev => {
     const uuid = ev.uuid.length > 24 ? `...${ev.uuid.slice(-24)}` : ev.uuid;
     return `${ev.kind}:${uuid}:${ev.text.replace(/\s+/g, ' ').slice(0, 60)}`;
   }).join(' | ');
 }
 
-function structuredBridgeQueueSnapshot(): string {
+function codexBridgeQueueSnapshot(): string {
   const snap = codexBridgeQueue.debugSnapshot();
   return JSON.stringify({
     localTurnsEnabled: snap.localTurnsEnabled,
@@ -1513,7 +1513,7 @@ function codexBridgeStartTimer(): void {
         if (isPromptReady) emitReadyCodexTurns();
         return;
       }
-      if (structuredBridgeIsCursor()) {
+      if (codexBridgeIsCursor()) {
         // Late-attach: the transcript usually exists at adopt time (the
         // session is already running), so cursorBridgeAttach in setup wins.
         // This covers the rare race where pid→chatId resolved but the JSONL
@@ -1773,7 +1773,7 @@ function codexBridgeNotifyCliSessionId(cliSessionId: string): void {
     }
     return;
   }
-  if (structuredBridgeIsCursor()) {
+  if (codexBridgeIsCursor()) {
     // Cursor's cliSessionId is the chatId — the same UUID naming the
     // agent-transcript JSONL, so it resolves the path directly.
     const cursorPath = findCursorTranscriptByChatId(cliSessionId);
@@ -1809,14 +1809,14 @@ function codexBridgeIngest(): void {
   }
   if (!codexBridgeRolloutPath || !codexBridgeBaselineDone) return;
   const oldOffset = codexBridgeOffset;
-  const before = structuredBridgeProbeEnabled() ? structuredBridgeQueueSnapshot() : '';
+  const before = codexBridgeProbeEnabled() ? codexBridgeQueueSnapshot() : '';
   const result = structuredBridgeIngestPath(codexBridgeRolloutPath, codexBridgeOffset);
   codexBridgeOffset = result.newOffset;
   codexBridgePendingTail = result.pendingTail;
   if (result.events.length > 0) lastStructuredBridgeActivityAtMs = Date.now();
   codexBridgeQueue.ingest(result.events);
-  if (structuredBridgeProbeEnabled() && (result.events.length > 0 || oldOffset !== result.newOffset)) {
-    log(`Structured bridge probe ingest: offset=${oldOffset}->${result.newOffset}, events=${result.events.length}, tail=${result.pendingTail.length}, eventPreview="${structuredBridgeEventPreview(result.events)}", before=${before}, after=${structuredBridgeQueueSnapshot()}`);
+  if (codexBridgeProbeEnabled() && (result.events.length > 0 || oldOffset !== result.newOffset)) {
+    log(`Codex bridge probe ingest: offset=${oldOffset}->${result.newOffset}, events=${result.events.length}, tail=${result.pendingTail.length}, eventPreview="${codexBridgeEventPreview(result.events)}", before=${before}, after=${codexBridgeQueueSnapshot()}`);
   }
   // Transcript-driven idle: an `assistant_final` event is the CLI declaring
   // end-of-turn, far more reliable than the screen-pattern heuristic
@@ -1835,12 +1835,12 @@ function codexBridgeIngest(): void {
 function codexBridgeMarkPendingTurn(messageText: string): boolean {
   if (!codexBridgeFallbackActive()) return false;
   const turnId = `codex-${randomBytes(8).toString('hex')}`;
-  if (structuredBridgeProbeEnabled()) {
-    log(`Structured bridge probe mark: turn=${turnId.slice(0, 8)}, preview="${messageText.replace(/\s+/g, ' ').slice(0, 80)}", before=${structuredBridgeQueueSnapshot()}`);
+  if (codexBridgeProbeEnabled()) {
+    log(`Codex bridge probe mark: turn=${turnId.slice(0, 8)}, preview="${messageText.replace(/\s+/g, ' ').slice(0, 80)}", before=${codexBridgeQueueSnapshot()}`);
   }
   codexBridgeQueue.mark(turnId, messageText);
-  if (structuredBridgeProbeEnabled()) {
-    log(`Structured bridge probe mark done: turn=${turnId.slice(0, 8)}, after=${structuredBridgeQueueSnapshot()}`);
+  if (codexBridgeProbeEnabled()) {
+    log(`Codex bridge probe mark done: turn=${turnId.slice(0, 8)}, after=${codexBridgeQueueSnapshot()}`);
   }
   return true;
 }
@@ -1854,19 +1854,19 @@ function codexBridgeDrainAndMaybeEmit(): void {
 }
 
 function emitReadyCodexTurns(): void {
-  const probe = structuredBridgeProbeEnabled();
-  const before = probe ? structuredBridgeQueueSnapshot() : '';
+  const probe = codexBridgeProbeEnabled();
+  const before = probe ? codexBridgeQueueSnapshot() : '';
   const ready = codexBridgeQueue.drainEmittable();
   if (ready.length === 0) {
-    if (probe && before !== structuredBridgeQueueSnapshot()) {
-      log(`Structured bridge probe drain: ready=0, before=${before}, after=${structuredBridgeQueueSnapshot()}`);
+    if (probe && before !== codexBridgeQueueSnapshot()) {
+      log(`Codex bridge probe drain: ready=0, before=${before}, after=${codexBridgeQueueSnapshot()}`);
     } else if (probe && before.includes('"queued":[{')) {
-      log(`Structured bridge probe drain: ready=0, state=${before}`);
+      log(`Codex bridge probe drain: ready=0, state=${before}`);
     }
     return;
   }
   if (probe) {
-    log(`Structured bridge probe drain: ready=${ready.length}, readyTurns=${JSON.stringify(ready.map(t => ({ turnId: t.turnId.slice(0, 8), isLocal: t.isLocal === true, finalLen: t.finalText?.length ?? 0, markTimeMs: t.markTimeMs })))}, before=${before}, after=${structuredBridgeQueueSnapshot()}`);
+    log(`Codex bridge probe drain: ready=${ready.length}, readyTurns=${JSON.stringify(ready.map(t => ({ turnId: t.turnId.slice(0, 8), isLocal: t.isLocal === true, finalLen: t.finalText?.length ?? 0, markTimeMs: t.markTimeMs })))}, before=${before}, after=${codexBridgeQueueSnapshot()}`);
   }
   const adoptMode = lastInitConfig?.adoptMode === true;
   // Adopt mode: model is the user's external Codex, no botmux send to
@@ -1909,13 +1909,13 @@ function emitReadyCodexTurns(): void {
         userText: fields.userText,
       });
       if (probe) {
-        log(`Structured bridge probe send local final_output: turn=${turn.turnId.slice(0, 8)}, len=${fields.content.length}`);
+        log(`Codex bridge probe send local final_output: turn=${turn.turnId.slice(0, 8)}, len=${fields.content.length}`);
       }
       continue;
     }
     send({ type: 'final_output', content: turn.finalText, lastUuid: turn.turnId, turnId: turn.turnId });
     if (probe) {
-      log(`Structured bridge probe send final_output: turn=${turn.turnId.slice(0, 8)}, len=${turn.finalText.length}`);
+      log(`Codex bridge probe send final_output: turn=${turn.turnId.slice(0, 8)}, len=${turn.finalText.length}`);
     }
   }
 }
@@ -3045,7 +3045,7 @@ function setupAdoptTranscriptBridges(cfg: Extract<DaemonToWorker, { type: 'init'
     const adoptStartMs = Date.now();
     codexAdoptStartMs = adoptStartMs;
     // Cursor JSONL lacks per-event timestamps, but adopt still needs parity
-    // with other structured bridges: direct terminal input should be surfaced
+    // with other transcript bridges: direct terminal input should be surfaced
     // as a local-turn card in Lark. Baseline/offset handling above keeps
     // pre-adopt history out of the queue; worst-case mirror replay is a
     // duplicate local-turn message rather than lost local input.
@@ -4176,7 +4176,7 @@ process.on('message', async (raw: unknown) => {
           // in-flight events from a local-typed prior turn close before
           // this Lark turn's fingerprint window opens. Mark works even
           // pre-attach (queue is path-agnostic).
-          if (structuredBridgeIsCursor()) {
+          if (codexBridgeIsCursor()) {
             // Cursor may append the current Lark/user line to its transcript
             // before this IPC message is handled. Mark first so that preexisting
             // current-line can still fingerprint-match instead of being marked

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3044,11 +3044,12 @@ function setupAdoptTranscriptBridges(cfg: Extract<DaemonToWorker, { type: 'init'
   } else if (cfg.cliId === 'cursor') {
     const adoptStartMs = Date.now();
     codexAdoptStartMs = adoptStartMs;
-    // Cursor transcript events do not carry per-event timestamps. Lark
-    // fingerprint attribution is still safe, but unmatched user events cannot
-    // be reliably classified as fresh local terminal input after restore or
-    // late attach, so disable local-turn synthesis for Cursor.
-    codexBridgeQueue.setLocalTurns(false, adoptStartMs);
+    // Cursor JSONL lacks per-event timestamps, but adopt still needs parity
+    // with other structured bridges: direct terminal input should be surfaced
+    // as a local-turn card in Lark. Baseline/offset handling above keeps
+    // pre-adopt history out of the queue; worst-case mirror replay is a
+    // duplicate local-turn message rather than lost local input.
+    codexBridgeQueue.setLocalTurns(true, adoptStartMs);
     // Resolve the transcript: cliSessionId (= Cursor chatId) when discovery
     // captured it, else the adopt pid via its open store.db fd. Cursor lacks
     // per-event timestamps, so cursorBridgeAttach baselines by byte offset

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -33,6 +33,7 @@ import { findTraexRolloutBySessionId, findTraexRolloutByPid } from './services/t
 import { cocoEventsPathForSession, drainCocoEvents, findCocoSessionByPid } from './services/coco-transcript.js';
 import { currentHermesStateOffset, drainHermesStateDb } from './services/hermes-transcript.js';
 import { currentMtrSessionOffset, drainMtrSession, findLatestMtrSessionByDirectory, findMtrSessionById, type MtrTranscriptSource } from './services/mtr-transcript.js';
+import { drainCursorTranscript, findCursorTranscriptByChatId, findCursorTranscriptByPid } from './services/cursor-transcript.js';
 import { baselineJsonlCursor } from './services/jsonl-cursor.js';
 import { dirname } from 'node:path';
 import { createServer as createHttpServer, type IncomingMessage } from 'node:http';
@@ -1401,7 +1402,14 @@ function drainPathInto(path: string, fromOffset: number): { offset: number; tail
 function codexBridgeFallbackActive(): boolean {
   // True for transcript-backed CLIs whose final output can be harvested
   // when the model forgets to call `botmux send`.
-  return lastInitConfig?.cliId === 'codex' || lastInitConfig?.cliId === 'traex' || lastInitConfig?.cliId === 'coco' || lastInitConfig?.cliId === 'hermes' || lastInitConfig?.cliId === 'mtr';
+  const id = lastInitConfig?.cliId;
+  if (id === 'codex' || id === 'traex' || id === 'coco' || id === 'hermes' || id === 'mtr') return true;
+  // Cursor only harvests its transcript in adopt mode: a botmux-spawned
+  // cursor session carries the botmux skill and replies via `botmux send`,
+  // and we never resolve a transcript path for it — so leave that flow
+  // (screen capture + botmux send) untouched and scope the bridge to adopt.
+  if (id === 'cursor') return lastInitConfig?.adoptMode === true;
+  return false;
 }
 
 // Both Codex and TRAE share the same rollout JSONL layout (response_item
@@ -1418,8 +1426,13 @@ function structuredBridgeIsMtr(): boolean {
   return lastInitConfig?.cliId === 'mtr';
 }
 
+function structuredBridgeIsCursor(): boolean {
+  return lastInitConfig?.cliId === 'cursor';
+}
+
 function structuredBridgeIngestPath(path: string, offset: number) {
   if (structuredBridgeIsCodex()) return drainCodexRollout(path, offset);
+  if (structuredBridgeIsCursor()) return drainCursorTranscript(path, offset);
   if (structuredBridgeIsHermes()) {
     const result = drainHermesStateDb(offset);
     return { events: result.events, newOffset: result.newOffset, pendingTail: '' };
@@ -1462,6 +1475,29 @@ function codexBridgeStartTimer(): void {
           }
         }
         mtrBridgeIngest();
+        if (isPromptReady) emitReadyCodexTurns();
+        return;
+      }
+      if (structuredBridgeIsCursor()) {
+        // Late-attach: the transcript usually exists at adopt time (the
+        // session is already running), so cursorBridgeAttach in setup wins.
+        // This covers the rare race where pid→chatId resolved but the JSONL
+        // hadn't been created yet. Resolution order: chatId (cliSessionId) →
+        // path; then adopt pid → store.db fd → chatId → path.
+        if (!codexBridgeRolloutPath) {
+          let path = codexBridgePendingSessionId
+            ? findCursorTranscriptByChatId(codexBridgePendingSessionId)
+            : undefined;
+          if (!path && codexAdoptPendingPid) {
+            path = findCursorTranscriptByPid(codexAdoptPendingPid)?.path;
+          }
+          if (path) {
+            codexBridgePendingSessionId = undefined;
+            codexAdoptPendingPid = undefined;
+            cursorBridgeAttach(path);
+          }
+        }
+        codexBridgeIngest();
         if (isPromptReady) emitReadyCodexTurns();
         return;
       }
@@ -1645,6 +1681,24 @@ function codexBridgeAttach(rolloutPath: string, mode: 'baseline-existing' | 'fre
   codexBridgeStartTimer();
 }
 
+/** Attach the Cursor adopt bridge. Cursor's JSONL has no per-event
+ *  timestamp, so split-live's timestamp cutoff can't separate pre-adopt
+ *  history from live turns. Instead we baseline by byte offset (history is
+ *  behind the offset and never re-ingested) and surface the last completed
+ *  turn as the "📜 /adopt 前最后一轮" preamble from a one-shot full drain
+ *  before baselining past it. */
+function cursorBridgeAttach(path: string): void {
+  if (existsSync(path)) {
+    try {
+      const full = drainCursorTranscript(path, 0);
+      maybeEmitCodexAdoptPreamble(full.events);
+    } catch (err: any) {
+      log(`Cursor bridge preamble drain failed: ${err.message}`);
+    }
+  }
+  codexBridgeAttach(path, 'baseline-existing');
+}
+
 /** Called from flushPending after writeInput first returns a cliSessionId.
  *  Tries to locate the rollout file immediately; if it's not on disk yet,
  *  remembers the sid so the 1s poller can keep retrying. */
@@ -1655,6 +1709,19 @@ function codexBridgeNotifyCliSessionId(cliSessionId: string): void {
     if (source) {
       codexBridgePendingSessionId = undefined;
       mtrBridgeAttach(source, 'fresh-empty');
+    } else {
+      codexBridgePendingSessionId = cliSessionId;
+      codexBridgeStartTimer();
+    }
+    return;
+  }
+  if (structuredBridgeIsCursor()) {
+    // Cursor's cliSessionId is the chatId — the same UUID naming the
+    // agent-transcript JSONL, so it resolves the path directly.
+    const cursorPath = findCursorTranscriptByChatId(cliSessionId);
+    if (cursorPath) {
+      codexBridgePendingSessionId = undefined;
+      cursorBridgeAttach(cursorPath);
     } else {
       codexBridgePendingSessionId = cliSessionId;
       codexBridgeStartTimer();
@@ -2885,6 +2952,27 @@ function setupAdoptTranscriptBridges(cfg: Extract<DaemonToWorker, { type: 'init'
       codexBridgePendingSessionId = undefined;
       mtrBridgeAttach(source, 'split-live');
     } else {
+      codexBridgeStartTimer();
+    }
+  } else if (cfg.cliId === 'cursor') {
+    const adoptStartMs = Date.now();
+    codexAdoptStartMs = adoptStartMs;
+    codexBridgeQueue.setLocalTurns(true, adoptStartMs);
+    // Resolve the transcript: cliSessionId (= Cursor chatId) when discovery
+    // captured it, else the adopt pid via its open store.db fd. Cursor lacks
+    // per-event timestamps, so cursorBridgeAttach baselines by byte offset
+    // rather than the timestamp-cutoff split-live the other CLIs use.
+    let path: string | undefined;
+    if (cfg.cliSessionId) path = findCursorTranscriptByChatId(cfg.cliSessionId);
+    if (!path && cfg.adoptCliPid) {
+      const probed = findCursorTranscriptByPid(cfg.adoptCliPid);
+      if (probed) path = probed.path;
+    }
+    if (path) {
+      cursorBridgeAttach(path);
+    } else {
+      if (cfg.cliSessionId) codexBridgePendingSessionId = cfg.cliSessionId;
+      codexAdoptPendingPid = cfg.adoptCliPid;
       codexBridgeStartTimer();
     }
   }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -28,7 +28,7 @@ import {
   type PidFollowResult,
 } from './services/bridge-rotation-policy.js';
 import { CodexBridgeQueue } from './services/codex-bridge-queue.js';
-import { drainCodexRollout, findCodexRolloutBySessionId, findCodexRolloutByPid, splitCodexEventsByCutoff, extractLastCodexTurn } from './services/codex-transcript.js';
+import { drainCodexRollout, findCodexRolloutBySessionId, findCodexRolloutByPid, splitCodexEventsByCutoff, extractLastCodexTurn, type CodexBridgeEvent } from './services/codex-transcript.js';
 import { findTraexRolloutBySessionId, findTraexRolloutByPid } from './services/traex-transcript.js';
 import { cocoEventsPathForSession, drainCocoEvents, findCocoSessionByPid } from './services/coco-transcript.js';
 import { currentHermesStateOffset, drainHermesStateDb } from './services/hermes-transcript.js';
@@ -1440,6 +1440,41 @@ function structuredBridgeIngestPath(path: string, offset: number) {
   return drainCocoEvents(path, offset);
 }
 
+function structuredBridgeProbeEnabled(): boolean {
+  // Cursor is the only current structured bridge without per-event timestamps,
+  // so keep the high-cardinality attribution probe scoped there by default.
+  return structuredBridgeIsCursor();
+}
+
+function structuredBridgeEventPreview(events: CodexBridgeEvent[]): string {
+  return events.map(ev => {
+    const uuid = ev.uuid.length > 24 ? `...${ev.uuid.slice(-24)}` : ev.uuid;
+    return `${ev.kind}:${uuid}:${ev.text.replace(/\s+/g, ' ').slice(0, 60)}`;
+  }).join(' | ');
+}
+
+function structuredBridgeQueueSnapshot(): string {
+  const snap = codexBridgeQueue.debugSnapshot();
+  return JSON.stringify({
+    localTurnsEnabled: snap.localTurnsEnabled,
+    collectingTurnId: snap.collectingTurnId,
+    queued: snap.queued.map(t => ({
+      turnId: t.turnId.slice(0, 8),
+      started: t.started,
+      hasFinalText: t.hasFinalText,
+      isLocal: t.isLocal,
+      markTimeMs: t.markTimeMs,
+      fp: t.contentFingerprint,
+    })),
+    buffered: snap.buffered.map(ev => ({
+      kind: ev.kind,
+      uuid: ev.uuid.length > 18 ? `...${ev.uuid.slice(-18)}` : ev.uuid,
+      timestampMs: ev.timestampMs,
+      text: ev.textPreview.replace(/\s+/g, ' '),
+    })),
+  });
+}
+
 function codexBridgeStartTimer(): void {
   if (codexBridgeTimer) return;
   // Single 1s ticker that handles three jobs: late-attach (poll for the
@@ -1494,7 +1529,7 @@ function codexBridgeStartTimer(): void {
           if (path) {
             codexBridgePendingSessionId = undefined;
             codexAdoptPendingPid = undefined;
-            cursorBridgeAttach(path);
+            cursorBridgeAttach(path, cursorLateAttachMode(path));
           }
         }
         codexBridgeIngest();
@@ -1613,7 +1648,7 @@ function mtrBridgeIngest(): void {
   }
 }
 
-function codexBridgeAttach(rolloutPath: string, mode: 'baseline-existing' | 'fresh-empty' | 'split-live'): void {
+function codexBridgeAttach(rolloutPath: string, mode: 'baseline-existing' | 'baseline-existing-skip-tail' | 'fresh-empty' | 'split-live'): void {
   codexBridgeRolloutPath = rolloutPath;
   if (mode === 'fresh-empty') {
     // Brand-new session OR late-attach right after first submit. Either
@@ -1652,6 +1687,13 @@ function codexBridgeAttach(rolloutPath: string, mode: 'baseline-existing' | 'fre
     codexBridgePendingTail = '';
     codexBridgeBaselineDone = true;
     log(`Codex bridge split-live degraded to fresh (file missing): ${rolloutPath}`);
+  } else if (mode === 'baseline-existing-skip-tail' && existsSync(rolloutPath)) {
+    let size = 0;
+    try { size = statSync(rolloutPath).size; } catch { /* degrade below */ }
+    codexBridgeOffset = size;
+    codexBridgePendingTail = '';
+    codexBridgeBaselineDone = true;
+    log(`Codex bridge baselined: ${rolloutPath} (offset=${codexBridgeOffset}, skipTail=true)`);
   } else if (existsSync(rolloutPath)) {
     const cursor = baselineJsonlCursor(rolloutPath);
     codexBridgeOffset = cursor.newOffset;
@@ -1681,14 +1723,30 @@ function codexBridgeAttach(rolloutPath: string, mode: 'baseline-existing' | 'fre
   codexBridgeStartTimer();
 }
 
+type CursorAttachMode = 'baseline-existing' | 'fresh-empty';
+
+function cursorLateAttachMode(path: string): CursorAttachMode {
+  const start = codexAdoptStartMs;
+  if (start !== undefined) {
+    try {
+      const birthtimeMs = statSync(path).birthtimeMs;
+      // Cursor often creates the agent-transcript file lazily on the first
+      // post-adopt submit. In that case the first user line is live and must
+      // be ingested from byte 0 rather than swallowed as history.
+      if (Number.isFinite(birthtimeMs) && birthtimeMs >= start - 5_000) return 'fresh-empty';
+    } catch { /* fall back to history-safe baseline */ }
+  }
+  return 'baseline-existing';
+}
+
 /** Attach the Cursor adopt bridge. Cursor's JSONL has no per-event
- *  timestamp, so split-live's timestamp cutoff can't separate pre-adopt
- *  history from live turns. Instead we baseline by byte offset (history is
- *  behind the offset and never re-ingested) and surface the last completed
- *  turn as the "📜 /adopt 前最后一轮" preamble from a one-shot full drain
- *  before baselining past it. */
-function cursorBridgeAttach(path: string): void {
-  if (existsSync(path)) {
+ *  timestamp, so existing transcripts are baselined by byte offset. Cursor
+ *  restore intentionally skips any partial tail present at attach time: it is
+ *  old in-flight output and must not be attributed to the next Lark turn. If
+ *  the transcript is created after /adopt, attach fresh so the first
+ *  post-adopt Lark/user turn can still be attributed. */
+function cursorBridgeAttach(path: string, mode: CursorAttachMode = 'baseline-existing'): void {
+  if (mode === 'baseline-existing' && existsSync(path)) {
     try {
       const full = drainCursorTranscript(path, 0);
       maybeEmitCodexAdoptPreamble(full.events);
@@ -1696,7 +1754,7 @@ function cursorBridgeAttach(path: string): void {
       log(`Cursor bridge preamble drain failed: ${err.message}`);
     }
   }
-  codexBridgeAttach(path, 'baseline-existing');
+  codexBridgeAttach(path, mode === 'baseline-existing' ? 'baseline-existing-skip-tail' : mode);
 }
 
 /** Called from flushPending after writeInput first returns a cliSessionId.
@@ -1721,7 +1779,7 @@ function codexBridgeNotifyCliSessionId(cliSessionId: string): void {
     const cursorPath = findCursorTranscriptByChatId(cliSessionId);
     if (cursorPath) {
       codexBridgePendingSessionId = undefined;
-      cursorBridgeAttach(cursorPath);
+      cursorBridgeAttach(cursorPath, cursorLateAttachMode(cursorPath));
     } else {
       codexBridgePendingSessionId = cliSessionId;
       codexBridgeStartTimer();
@@ -1750,11 +1808,16 @@ function codexBridgeIngest(): void {
     return;
   }
   if (!codexBridgeRolloutPath || !codexBridgeBaselineDone) return;
+  const oldOffset = codexBridgeOffset;
+  const before = structuredBridgeProbeEnabled() ? structuredBridgeQueueSnapshot() : '';
   const result = structuredBridgeIngestPath(codexBridgeRolloutPath, codexBridgeOffset);
   codexBridgeOffset = result.newOffset;
   codexBridgePendingTail = result.pendingTail;
   if (result.events.length > 0) lastStructuredBridgeActivityAtMs = Date.now();
   codexBridgeQueue.ingest(result.events);
+  if (structuredBridgeProbeEnabled() && (result.events.length > 0 || oldOffset !== result.newOffset)) {
+    log(`Structured bridge probe ingest: offset=${oldOffset}->${result.newOffset}, events=${result.events.length}, tail=${result.pendingTail.length}, eventPreview="${structuredBridgeEventPreview(result.events)}", before=${before}, after=${structuredBridgeQueueSnapshot()}`);
+  }
   // Transcript-driven idle: an `assistant_final` event is the CLI declaring
   // end-of-turn, far more reliable than the screen-pattern heuristic
   // (CoCo's status bar varies by --yolo flag, version, theme; codex has
@@ -1772,7 +1835,13 @@ function codexBridgeIngest(): void {
 function codexBridgeMarkPendingTurn(messageText: string): boolean {
   if (!codexBridgeFallbackActive()) return false;
   const turnId = `codex-${randomBytes(8).toString('hex')}`;
+  if (structuredBridgeProbeEnabled()) {
+    log(`Structured bridge probe mark: turn=${turnId.slice(0, 8)}, preview="${messageText.replace(/\s+/g, ' ').slice(0, 80)}", before=${structuredBridgeQueueSnapshot()}`);
+  }
   codexBridgeQueue.mark(turnId, messageText);
+  if (structuredBridgeProbeEnabled()) {
+    log(`Structured bridge probe mark done: turn=${turnId.slice(0, 8)}, after=${structuredBridgeQueueSnapshot()}`);
+  }
   return true;
 }
 
@@ -1785,8 +1854,20 @@ function codexBridgeDrainAndMaybeEmit(): void {
 }
 
 function emitReadyCodexTurns(): void {
+  const probe = structuredBridgeProbeEnabled();
+  const before = probe ? structuredBridgeQueueSnapshot() : '';
   const ready = codexBridgeQueue.drainEmittable();
-  if (ready.length === 0) return;
+  if (ready.length === 0) {
+    if (probe && before !== structuredBridgeQueueSnapshot()) {
+      log(`Structured bridge probe drain: ready=0, before=${before}, after=${structuredBridgeQueueSnapshot()}`);
+    } else if (probe && before.includes('"queued":[{')) {
+      log(`Structured bridge probe drain: ready=0, state=${before}`);
+    }
+    return;
+  }
+  if (probe) {
+    log(`Structured bridge probe drain: ready=${ready.length}, readyTurns=${JSON.stringify(ready.map(t => ({ turnId: t.turnId.slice(0, 8), isLocal: t.isLocal === true, finalLen: t.finalText?.length ?? 0, markTimeMs: t.markTimeMs })))}, before=${before}, after=${structuredBridgeQueueSnapshot()}`);
+  }
   const adoptMode = lastInitConfig?.adoptMode === true;
   // Adopt mode: model is the user's external Codex, no botmux send to
   // gate against — every assistant turn (Lark-driven OR locally typed)
@@ -1827,9 +1908,15 @@ function emitReadyCodexTurns(): void {
         kind: 'local-turn',
         userText: fields.userText,
       });
+      if (probe) {
+        log(`Structured bridge probe send local final_output: turn=${turn.turnId.slice(0, 8)}, len=${fields.content.length}`);
+      }
       continue;
     }
     send({ type: 'final_output', content: turn.finalText, lastUuid: turn.turnId, turnId: turn.turnId });
+    if (probe) {
+      log(`Structured bridge probe send final_output: turn=${turn.turnId.slice(0, 8)}, len=${turn.finalText.length}`);
+    }
   }
 }
 
@@ -2957,7 +3044,11 @@ function setupAdoptTranscriptBridges(cfg: Extract<DaemonToWorker, { type: 'init'
   } else if (cfg.cliId === 'cursor') {
     const adoptStartMs = Date.now();
     codexAdoptStartMs = adoptStartMs;
-    codexBridgeQueue.setLocalTurns(true, adoptStartMs);
+    // Cursor transcript events do not carry per-event timestamps. Lark
+    // fingerprint attribution is still safe, but unmatched user events cannot
+    // be reliably classified as fresh local terminal input after restore or
+    // late attach, so disable local-turn synthesis for Cursor.
+    codexBridgeQueue.setLocalTurns(false, adoptStartMs);
     // Resolve the transcript: cliSessionId (= Cursor chatId) when discovery
     // captured it, else the adopt pid via its open store.db fd. Cursor lacks
     // per-event timestamps, so cursorBridgeAttach baselines by byte offset
@@ -4084,8 +4175,17 @@ process.on('message', async (raw: unknown) => {
           // in-flight events from a local-typed prior turn close before
           // this Lark turn's fingerprint window opens. Mark works even
           // pre-attach (queue is path-agnostic).
-          try { codexBridgeIngest(); } catch { /* best effort */ }
-          codexBridgeMarkPendingTurn(content);
+          if (structuredBridgeIsCursor()) {
+            // Cursor may append the current Lark/user line to its transcript
+            // before this IPC message is handled. Mark first so that preexisting
+            // current-line can still fingerprint-match instead of being marked
+            // seen as an unmatched event.
+            codexBridgeMarkPendingTurn(content);
+            try { codexBridgeIngest(); } catch { /* best effort */ }
+          } else {
+            try { codexBridgeIngest(); } catch { /* best effort */ }
+            codexBridgeMarkPendingTurn(content);
+          }
         }
         // Adopt mode write:
         //   - codex routes through cliAdapter.writeInput so the adapter's

--- a/test/codex-bridge-queue.test.ts
+++ b/test/codex-bridge-queue.test.ts
@@ -69,6 +69,30 @@ describe('CodexBridgeQueue', () => {
     expect(q.drainEmittable()).toEqual([]);
   });
 
+  it('replays recently buffered unmatched events when a matching mark arrives later', () => {
+    const q = new CodexBridgeQueue();
+    q.ingest([
+      userEv('say hi please', 'u-early', 1_000),
+      asstEv('Hi，收到。', 'a-early', 1_100),
+    ]);
+    q.mark('t1', 'say hi please', 4_000);
+    const ready = q.drainEmittable();
+    expect(ready).toHaveLength(1);
+    expect(ready[0].turnId).toBe('t1');
+    expect(ready[0].finalText).toBe('Hi，收到。');
+  });
+
+  it('does not replay buffered events older than the 5s skew window', () => {
+    const q = new CodexBridgeQueue();
+    q.ingest([
+      userEv('old prompt', 'u-old-buffered', 1_000),
+      asstEv('old answer', 'a-old-buffered', 1_100),
+    ]);
+    q.mark('t1', 'old prompt', 8_000);
+    expect(q.peek()[0].started).toBe(false);
+    expect(q.drainEmittable()).toEqual([]);
+  });
+
   it('absorb registers events as seen so they cannot start a turn later', () => {
     const q = new CodexBridgeQueue();
     const ev = userEv('historical message', 'u-hist');

--- a/test/cursor-transcript.test.ts
+++ b/test/cursor-transcript.test.ts
@@ -115,6 +115,33 @@ describe('drainCursorTranscript', () => {
     expect(r.events[1].text).toBe('done');
   });
 
+  it('distills a multi-turn conversation to discrete user/assistant_final pairs', () => {
+    // Two full turns, each: user → several tool steps → one text-only final.
+    // The bridge must see exactly the Codex-shaped 2-events-per-turn sequence.
+    writeFileSync(path,
+      line(userMsg('turn one')) +
+      line(assistantStep('looking', 'Grep')) +
+      line(assistantStep('reading', 'Read')) +
+      line(assistantFinal('answer one')) +
+      line(userMsg('turn two')) +
+      line(assistantStep('digging', 'Shell')) +
+      line(assistantFinal('answer two')));
+    const r = drainCursorTranscript(path, 0);
+    expect(r.events.map(e => ({ kind: e.kind, text: e.text }))).toEqual([
+      { kind: 'user', text: 'turn one' },
+      { kind: 'assistant_final', text: 'answer one' },
+      { kind: 'user', text: 'turn two' },
+      { kind: 'assistant_final', text: 'answer two' },
+    ]);
+  });
+
+  it('emits nothing for an interrupted turn that never reached a text-only final', () => {
+    // User asked, model ran a tool, then the process died — no terminator.
+    writeFileSync(path, line(userMsg('do it')) + line(assistantStep('working', 'Shell')));
+    const r = drainCursorTranscript(path, 0);
+    expect(r.events.map(e => e.kind)).toEqual(['user']);
+  });
+
   it('joins multiple text blocks of a final reply', () => {
     writeFileSync(path, line({
       role: 'assistant',

--- a/test/cursor-transcript.test.ts
+++ b/test/cursor-transcript.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, appendFileSync, rmSync, statSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  drainCursorTranscript,
+  cursorChatIdFromStoreDbPath,
+  findCursorTranscriptByChatId,
+} from '../src/services/cursor-transcript.js';
+
+let dir: string;
+let path: string;
+
+function line(obj: any): string {
+  return JSON.stringify(obj) + '\n';
+}
+
+function userMsg(text: string) {
+  return { role: 'user', message: { content: [{ type: 'text', text }] } };
+}
+
+/** An intermediate assistant step: narration text paired with a tool call. */
+function assistantStep(text: string, tool = 'Shell') {
+  return {
+    role: 'assistant',
+    message: { content: [{ type: 'text', text }, { type: 'tool_use', name: tool, input: {} }] },
+  };
+}
+
+/** A terminal assistant turn: text only, no tool_use. */
+function assistantFinal(text: string) {
+  return { role: 'assistant', message: { content: [{ type: 'text', text }] } };
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'cursor-transcript-'));
+  path = join(dir, 'chat.jsonl');
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('cursorChatIdFromStoreDbPath', () => {
+  const chatId = 'c8c78608-0eef-4930-8007-c41ba71ba05d';
+
+  it('extracts the chatId from a canonical store.db path', () => {
+    expect(cursorChatIdFromStoreDbPath(
+      `/home/u/.cursor/chats/410dba680c6b451fb276f0d01c358e81/${chatId}/store.db`,
+    )).toBe(chatId);
+  });
+
+  it('matches the -wal / -shm sidecar files SQLite keeps open', () => {
+    expect(cursorChatIdFromStoreDbPath(
+      `/home/u/.cursor/chats/hash/${chatId}/store.db-wal`,
+    )).toBe(chatId);
+    expect(cursorChatIdFromStoreDbPath(
+      `/home/u/.cursor/chats/hash/${chatId}/store.db-shm`,
+    )).toBe(chatId);
+  });
+
+  it('returns undefined for unrelated paths', () => {
+    expect(cursorChatIdFromStoreDbPath('/var/log/syslog')).toBeUndefined();
+    expect(cursorChatIdFromStoreDbPath('/home/u/.cursor/projects/foo/repo.json')).toBeUndefined();
+    // Right shape but not under .cursor/chats — reject to avoid false positives.
+    expect(cursorChatIdFromStoreDbPath(`/tmp/chats/h/${chatId}/store.db`)).toBeUndefined();
+  });
+});
+
+describe('findCursorTranscriptByChatId', () => {
+  it('locates <slug>/agent-transcripts/<chatId>/<chatId>.jsonl under projects root', () => {
+    const chatId = 'c8c78608-0eef-4930-8007-c41ba71ba05d';
+    const projectsRoot = join(dir, 'projects');
+    const slugDir = join(projectsRoot, 'data00-home-u-code-proj', 'agent-transcripts', chatId);
+    mkdirSync(slugDir, { recursive: true });
+    const jsonl = join(slugDir, `${chatId}.jsonl`);
+    writeFileSync(jsonl, '');
+    expect(findCursorTranscriptByChatId(chatId, projectsRoot)).toBe(jsonl);
+  });
+
+  it('returns undefined when the chatId has no transcript', () => {
+    const projectsRoot = join(dir, 'projects');
+    mkdirSync(projectsRoot, { recursive: true });
+    expect(findCursorTranscriptByChatId('00000000-0000-0000-0000-000000000000', projectsRoot)).toBeUndefined();
+  });
+
+  it('returns undefined when the projects root is missing', () => {
+    expect(findCursorTranscriptByChatId('x', join(dir, 'nope'))).toBeUndefined();
+  });
+});
+
+describe('drainCursorTranscript', () => {
+  it('returns empty for a missing file', () => {
+    const r = drainCursorTranscript(join(dir, 'missing.jsonl'), 0);
+    expect(r.events).toEqual([]);
+    expect(r.newOffset).toBe(0);
+  });
+
+  it('extracts user prompt + text-only assistant final', () => {
+    writeFileSync(path, line(userMsg('say hi')) + line(assistantFinal('Hi! 👋')));
+    const r = drainCursorTranscript(path, 0);
+    expect(r.events).toHaveLength(2);
+    expect(r.events[0]).toMatchObject({ kind: 'user', text: 'say hi' });
+    expect(r.events[1]).toMatchObject({ kind: 'assistant_final', text: 'Hi! 👋' });
+  });
+
+  it('skips intermediate assistant steps that carry a tool_use block', () => {
+    writeFileSync(path,
+      line(userMsg('do work')) +
+      line(assistantStep('let me look', 'Grep')) +
+      line(assistantStep('now read', 'Read')) +
+      line(assistantFinal('done')));
+    const r = drainCursorTranscript(path, 0);
+    expect(r.events.map(e => e.kind)).toEqual(['user', 'assistant_final']);
+    expect(r.events[1].text).toBe('done');
+  });
+
+  it('joins multiple text blocks of a final reply', () => {
+    writeFileSync(path, line({
+      role: 'assistant',
+      message: { content: [{ type: 'text', text: 'part one' }, { type: 'text', text: 'part two' }] },
+    }));
+    const r = drainCursorTranscript(path, 0);
+    expect(r.events).toHaveLength(1);
+    expect(r.events[0].text).toBe('part one\npart two');
+  });
+
+  it('skips assistant lines with no visible text (tool_use only)', () => {
+    writeFileSync(path, line({
+      role: 'assistant',
+      message: { content: [{ type: 'tool_use', name: 'Shell', input: {} }] },
+    }) + line(assistantFinal('reply')));
+    const r = drainCursorTranscript(path, 0);
+    expect(r.events).toHaveLength(1);
+    expect(r.events[0].text).toBe('reply');
+  });
+
+  it('ignores malformed JSON lines', () => {
+    writeFileSync(path, 'not json\n' + line(userMsg('after bad line')));
+    const r = drainCursorTranscript(path, 0);
+    expect(r.events).toHaveLength(1);
+    expect(r.events[0].text).toBe('after bad line');
+  });
+
+  it('byte-offset stable: re-drain from newOffset returns no events', () => {
+    writeFileSync(path, line(userMsg('first')) + line(assistantFinal('reply')));
+    const first = drainCursorTranscript(path, 0);
+    const second = drainCursorTranscript(path, first.newOffset);
+    expect(second.events).toEqual([]);
+    expect(second.newOffset).toBe(first.newOffset);
+  });
+
+  it('appended events drain incrementally', () => {
+    writeFileSync(path, line(userMsg('first')));
+    const r1 = drainCursorTranscript(path, 0);
+    expect(r1.events).toHaveLength(1);
+    appendFileSync(path, line(assistantFinal('reply')));
+    const r2 = drainCursorTranscript(path, r1.newOffset);
+    expect(r2.events).toHaveLength(1);
+    expect(r2.events[0].kind).toBe('assistant_final');
+  });
+
+  it('holds back a partial trailing line as pendingTail', () => {
+    writeFileSync(path, line(userMsg('complete')) + '{"role":"assistant","message":{"content"');
+    const r = drainCursorTranscript(path, 0);
+    expect(r.events).toHaveLength(1);
+    expect(r.pendingTail).toContain('content');
+    expect(r.newOffset).toBeLessThan(statSync(path).size);
+  });
+
+  it('uuid encodes path:byteStart and is stable across re-drains', () => {
+    writeFileSync(path, line(userMsg('uuid-one')) + line(userMsg('uuid-two')));
+    const r = drainCursorTranscript(path, 0);
+    expect(r.events).toHaveLength(2);
+    expect(r.events[0].uuid).toMatch(/\.jsonl:0$/);
+    expect(r.events[1].uuid).not.toBe(r.events[0].uuid);
+    const r2 = drainCursorTranscript(path, 0);
+    expect(r2.events.map(e => e.uuid)).toEqual(r.events.map(e => e.uuid));
+  });
+
+  it('truncated file (size < fromOffset) re-drains from the top', () => {
+    writeFileSync(path,
+      line(userMsg('original message long enough to advance the byte offset')) +
+      line(assistantFinal('a reasonably long original answer to take up bytes')));
+    const r1 = drainCursorTranscript(path, 0);
+    writeFileSync(path, line(userMsg('s')));
+    const r2 = drainCursorTranscript(path, r1.newOffset);
+    expect(r2.events).toHaveLength(1);
+    expect(r2.events[0].text).toBe('s');
+  });
+});

--- a/test/cursor-transcript.test.ts
+++ b/test/cursor-transcript.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, writeFileSync, appendFileSync, rmSync, statSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, appendFileSync, rmSync, statSync, mkdirSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -96,6 +96,15 @@ describe('drainCursorTranscript', () => {
     expect(r.newOffset).toBe(0);
   });
 
+  it('keeps the offset when an existing mirror briefly disappears', () => {
+    writeFileSync(path, line(userMsg('first')));
+    const r1 = drainCursorTranscript(path, 0);
+    unlinkSync(path);
+    const r2 = drainCursorTranscript(path, r1.newOffset);
+    expect(r2.events).toEqual([]);
+    expect(r2.newOffset).toBe(r1.newOffset);
+  });
+
   it('extracts user prompt + text-only assistant final', () => {
     writeFileSync(path, line(userMsg('say hi')) + line(assistantFinal('Hi! 👋')));
     const r = drainCursorTranscript(path, 0);
@@ -152,6 +161,19 @@ describe('drainCursorTranscript', () => {
     expect(r.events[0].text).toBe('part one\npart two');
   });
 
+  it('strips Cursor reasoning text appended to a text-only final reply', () => {
+    writeFileSync(path, line(assistantFinal([
+      'Hi, received.',
+      '',
+      '**Considering user response**',
+      '',
+      'This paragraph is internal reasoning from the Cursor transcript mirror.',
+    ].join('\n'))));
+    const r = drainCursorTranscript(path, 0);
+    expect(r.events).toHaveLength(1);
+    expect(r.events[0].text).toBe('Hi, received.');
+  });
+
   it('skips assistant lines with no visible text (tool_use only)', () => {
     writeFileSync(path, line({
       role: 'assistant',
@@ -195,6 +217,17 @@ describe('drainCursorTranscript', () => {
     expect(r.newOffset).toBeLessThan(statSync(path).size);
   });
 
+  it('parses a complete trailing JSON object without a newline', () => {
+    writeFileSync(path, line(userMsg('complete')) + JSON.stringify(assistantFinal('reply without newline')));
+    const r = drainCursorTranscript(path, 0);
+    expect(r.events.map(e => ({ kind: e.kind, text: e.text }))).toEqual([
+      { kind: 'user', text: 'complete' },
+      { kind: 'assistant_final', text: 'reply without newline' },
+    ]);
+    expect(r.pendingTail).toBe('');
+    expect(r.newOffset).toBe(statSync(path).size);
+  });
+
   it('uuid encodes path:byteStart and is stable across re-drains', () => {
     writeFileSync(path, line(userMsg('uuid-one')) + line(userMsg('uuid-two')));
     const r = drainCursorTranscript(path, 0);
@@ -205,14 +238,14 @@ describe('drainCursorTranscript', () => {
     expect(r2.events.map(e => e.uuid)).toEqual(r.events.map(e => e.uuid));
   });
 
-  it('truncated file (size < fromOffset) re-drains from the top', () => {
+  it('keeps the offset when Cursor temporarily rewrites the mirror smaller', () => {
     writeFileSync(path,
       line(userMsg('original message long enough to advance the byte offset')) +
       line(assistantFinal('a reasonably long original answer to take up bytes')));
     const r1 = drainCursorTranscript(path, 0);
     writeFileSync(path, line(userMsg('s')));
     const r2 = drainCursorTranscript(path, r1.newOffset);
-    expect(r2.events).toHaveLength(1);
-    expect(r2.events[0].text).toBe('s');
+    expect(r2.events).toEqual([]);
+    expect(r2.newOffset).toBe(r1.newOffset);
   });
 });


### PR DESCRIPTION
## Summary
- Add a Cursor Agent transcript reader that resolves adopted sessions through Cursor chat metadata and distills final replies into the existing Codex bridge queue.
- Wire Cursor adopt sessions into transcript fallback while keeping botmux-spawned Cursor sessions on the existing `botmux send` flow.
- Stabilize attribution for late transcript creation, partial tails, local terminal turns, and Cursor-only probe logging without broad bridge renames.

## Test plan
- `pnpm exec vitest run test/codex-bridge-queue.test.ts test/cursor-transcript.test.ts`
- `pnpm build`
- Replaced the local mise-installed botmux `dist` with this branch build and restarted via `~/repair-botmux-mise.sh`; `botmux status` reported all processes online.

## Notes
- The branch intentionally keeps the existing `codexBridge*` runtime naming and does not introduce the previous `structured-bridge-*` file rename.
