### PR TITLE
feat(cli): add Copilot adapter

### DIFF
--- a/src/adapters/cli/copilot.ts
+++ b/src/adapters/cli/copilot.ts
@@ -1,0 +1,78 @@
+import { resolveCommand } from './registry.js';
+import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
+import type { CliAdapter, PtyHandle } from './types.js';
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/** GitHub Copilot CLI adapter (`@github/copilot`).
+ *
+ *  Copilot CLI is an Ink-based interactive agent shipped as the `copilot`
+ *  binary (npm `@github/copilot`). It manages sessions internally — botmux's
+ *  `sessionId` cannot be forced as the CLI session id, so we always start
+ *  fresh and rely on `--resume <id>` (or `--continue`) for resume. */
+export function createCopilotAdapter(pathOverride?: string): CliAdapter {
+  // resolvedBin is lazy: setup constructs adapters only to read static
+  // modelChoices and must not shell out (see resolveCommand); the binary path
+  // is a spawn-time concern.
+  const rawBin = pathOverride ?? 'copilot';
+  let cachedBin: string | undefined;
+  return {
+    id: 'copilot',
+    get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
+
+    buildArgs({ resume, resumeSessionId, model, disableCliBypass }) {
+      // --allow-all-tools puts Copilot in the same "act without per-tool
+      // approval" posture as cursor's --force / claude-code's
+      // --dangerously-skip-permissions. Without it every shell/edit bounces
+      // back to the TUI for confirmation, which the user can't see in Lark.
+      const args: string[] = disableCliBypass ? [] : ['--allow-all-tools'];
+      if (model && model.trim()) {
+        args.push('--model', model.trim());
+      }
+      if (!resume) return args;
+      if (resumeSessionId) return [...args, '--resume', resumeSessionId];
+      // No id on hand — fall back to "most recent session" so the user's
+      // context isn't lost. --continue is Copilot's shorthand for
+      // resume-latest.
+      return [...args, '--continue'];
+    },
+
+    buildResumeCommand({ cliSessionId }) {
+      // Copilot session ids are opaque and not derivable from botmux's
+      // sessionId; without one we can't print a precise one-liner — let the
+      // closed-session card fall back to its generic note.
+      if (!cliSessionId) return null;
+      return `copilot --resume ${cliSessionId}`;
+    },
+
+    async writeInput(pty: PtyHandle, content: string) {
+      // Copilot's Ink TUI behaves like Gemini/OpenCode: the TextInput
+      // component has an async startup phase; writing during that window can
+      // be silently lost. Once the prompt is rendered, sendText + Enter is
+      // reliable. No documented bracketed-paste fold (unlike cursor), so the
+      // simple write+Enter path mirrors the gemini adapter.
+      if (pty.sendText && pty.sendSpecialKeys) {
+        pty.sendText(content);
+        await delay(200);
+        pty.sendSpecialKeys('Enter');
+      } else {
+        pty.write(content);
+        await delay(1000);
+        pty.write('\r');
+      }
+    },
+
+    completionPattern: undefined,   // quiescence only — no explicit completion marker
+    readyPattern: undefined,        // Ink TUI prompt is too generic to match reliably
+    systemHints: BOTMUX_SHELL_HINTS,
+    altScreen: true,                // Ink renders in the alternate screen buffer
+    // Curated model list per Copilot CLI docs: default is Claude Sonnet 4;
+    // Sonnet 4.5 / GPT-5 available via /model. Setup always appends a free-form
+    // "Other" option, so this is curation only.
+    modelChoices: ['claude-sonnet-4', 'claude-sonnet-4.5', 'gpt-5'],
+  };
+}
+
+export const create = createCopilotAdapter;

--- a/src/adapters/cli/registry.ts
+++ b/src/adapters/cli/registry.ts
@@ -16,6 +16,7 @@ import { createAntigravityAdapter } from './antigravity.js';
 import { createMtrAdapter } from './mtr.js';
 import { createHermesAdapter } from './hermes.js';
 import { createMiraAdapter } from './mira.js';
+import { createCopilotAdapter } from './copilot.js';
 
 /** Resolve a command name to its absolute path via shell `which`.
  *  Tries login shell first (-lc), then interactive shell (-ic) for tools
@@ -98,7 +99,7 @@ export async function createCliAdapter(id: CliId, pathOverride?: string): Promis
   return adapter;
 }
 
-export { createClaudeCodeAdapter, createSeedAdapter, createAidenAdapter, createCocoAdapter, createCodexAdapter, createCodexAppAdapter, createCursorAdapter, createGeminiAdapter, createOpenCodeAdapter, createAntigravityAdapter, createMtrAdapter, createHermesAdapter, createMiraAdapter };
+export { createClaudeCodeAdapter, createSeedAdapter, createAidenAdapter, createCocoAdapter, createCodexAdapter, createCodexAppAdapter, createCursorAdapter, createGeminiAdapter, createOpenCodeAdapter, createAntigravityAdapter, createMtrAdapter, createHermesAdapter, createMiraAdapter, createCopilotAdapter };
 
 /** Synchronous version for use in worker process. */
 export function createCliAdapterSync(id: CliId, pathOverride?: string): CliAdapter {
@@ -116,6 +117,7 @@ export function createCliAdapterSync(id: CliId, pathOverride?: string): CliAdapt
     case 'mtr': return createMtrAdapter(pathOverride);
     case 'hermes': return createHermesAdapter(pathOverride);
     case 'mira': return createMiraAdapter(pathOverride);
+    case 'copilot': return createCopilotAdapter(pathOverride);
     default: throw new Error(`Unknown CLI adapter: ${id}`);
   }
 }

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -197,4 +197,4 @@ export interface CliAdapter {
   readonly spawnEnv?: Readonly<Record<string, string>>;
 }
 
-export type CliId = 'claude-code' | 'seed' | 'aiden' | 'coco' | 'codex' | 'codex-app' | 'cursor' | 'gemini' | 'opencode' | 'antigravity' | 'mtr' | 'hermes' | 'mira';
+export type CliId = 'claude-code' | 'seed' | 'aiden' | 'coco' | 'codex' | 'codex-app' | 'cursor' | 'gemini' | 'opencode' | 'antigravity' | 'mtr' | 'hermes' | 'mira' | 'copilot';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -623,7 +623,7 @@ async function promptRequiredOwner(rl: ReturnType<typeof createInterface>): Prom
     '推荐格式（优先级高到低）：完整邮箱（alice@example.com）> union_id（on_xxx，跨应用稳定）> open_id（ou_xxx，仅限同一应用）。',
     '注意：必须是完整邮箱，邮箱前缀（如 alice）无法解析、不接受。',
   ]);
-  for (;;) {
+  for (; ;) {
     const raw = (await ask(rl, '管理员 (owner): ')).trim();
     const entries = raw.split(',').map(s => s.trim()).filter(Boolean);
     if (entries.length === 0) {
@@ -664,7 +664,7 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
   }
   console.log('✅ 凭证有效（tenant_access_token 已成功获取）\n');
 
-  console.log('支持的 CLI: 1) claude-code  2) aiden  3) coco（别名 traecli）  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed');
+  console.log('支持的 CLI: 1) claude-code  2) aiden  3) coco（别名 traecli）  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed  14) copilot');
   const cliChoice = await ask(rl, 'CLI 适配器 [1]: ');
   let cliId: CliId;
   try {
@@ -842,7 +842,7 @@ async function promptEditBotConfig(
   ]);
   input.larkAppSecret = await ask(rl, `LARK_APP_SECRET [保留当前值]: `);
 
-  console.log('\n支持的 CLI: 1) claude-code  2) aiden  3) coco（别名 traecli）  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed');
+  console.log('\n支持的 CLI: 1) claude-code  2) aiden  3) coco（别名 traecli）  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed  14) copilot');
   printInputHelp('CLI 适配器', [
     '选择 botmux 需要套用哪一种 CLI 参数协议和会话恢复方式。',
     'coco 的别名 traecli 走同一适配器；二进制名是 traecli 也选 coco 即可。',
@@ -2792,9 +2792,9 @@ async function cmdHistory(rest: string[]): Promise<void> {
       ? await listChatMessages(appId, s.chatId, limit)
       : effectiveScope === 'ambient'
         ? await listAmbientChatMessages(appId, s.chatId, limit, {
-            beforeCreateTime: ambientBeforeCreateTime,
-            excludeRootMessageId: s.rootMessageId,
-          })
+          beforeCreateTime: ambientBeforeCreateTime,
+          excludeRootMessageId: s.rootMessageId,
+        })
         : await listThreadMessages(appId, s.chatId, s.rootMessageId, limit);
     // Expand merge_forward to <forwarded_messages> XML, mirroring the live event
     // path in daemon.ts. Each merge_forward gets its own numberer (we don't
@@ -3070,7 +3070,7 @@ async function cmdSend(rest: string[]): Promise<void> {
   // (open_id from the session — model needn't know it). Bare-name form so it
   // renders as a trailing <at>.
   if (mentionBack && s.quoteTargetSenderOpenId
-      && !mentions.some(m => m.open_id === s.quoteTargetSenderOpenId)) {
+    && !mentions.some(m => m.open_id === s.quoteTargetSenderOpenId)) {
     mentions.push({ open_id: s.quoteTargetSenderOpenId, name: '' });
   }
 
@@ -3274,69 +3274,69 @@ async function cmdSend(rest: string[]): Promise<void> {
       // 出现的 @名字 仍会被注入成 <at>，破坏 --no-mention 语义、还可能误触发对方
       // bot（正是要避免的循环 @）。botEntries/crossRef 仍需加载供 footer 寻址用。
       if (!noMention) {
-      const alreadyMentioned = new Set(mentions.map(m => m.open_id));
-      // Sort by name length desc so longer names ("Claude分身") win over their
-      // prefix ("Claude") when both could match — break-on-first-hit otherwise
-      // routes "@Claude分身" to Claude.
-      const sortedEntries = [...botEntries].sort(
-        (a, b) => (b.botName?.length ?? 0) - (a.botName?.length ?? 0),
-      );
-      const selfAliases = new Set(
-        botEntries
-          .filter(entry => entry.larkAppId === appId)
-          .flatMap(entry => [entry.botName, entry.cliId])
-          .filter((name): name is string => !!name)
-          .map(name => name.toLowerCase()),
-      );
-      // Bots actively in THIS conversation (thread root for thread-scope, chat for
-      // chat-scope). Used to gate the type-generic `cliId` alias so prose "@codex"
-      // resolves to the codex bot collaborating HERE, not every same-type bot
-      // (the fan-out that pulled all Codex-named bots into a topic). See
-      // eligibleAutoMentionAliases.
-      const convoBotAppIds = new Set<string>();
-      for (const sess of loadSessions().values()) {
-        if (sess.status !== 'active' || !sess.larkAppId) continue;
-        const here = isChatScope
-          ? sess.chatId === s.chatId
-          : (!!s.rootMessageId && sess.rootMessageId === s.rootMessageId);
-        if (here) convoBotAppIds.add(sess.larkAppId);
-      }
-      for (const entry of sortedEntries) {
-        if (!entry.botName || entry.larkAppId === appId) continue;
-        const names = eligibleAutoMentionAliases({
-          botName: entry.botName,
-          cliId: entry.cliId ?? undefined,
-          larkAppId: entry.larkAppId ?? undefined,
-          selfAliases,
-          convoBotAppIds,
-        });
-        for (const name of names) {
-          const escName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-          // Boundary: lookbehind blocks only ASCII word chars (so `user@Claude`
-          // is rejected but `看看@CoCo` is accepted — CJK prefix is normal in
-          // Chinese text). Lookahead blocks any Unicode letter/digit so
-          // `@Claude2` doesn't match name "Claude" and `@Claude分身好的` doesn't
-          // either-half-match.
-          const re = new RegExp(`(?<![A-Za-z0-9_])@${escName}(?![\\p{L}\\p{N}_])`, 'iu');
-          if (!re.test(text)) continue;
-          // Lark open_id is per-app scoped. Use sender-scoped id from cross-ref
-          // only — falling back to entry.botOpenId would feed Lark a wrong-scope
-          // id (target's self-scoped) and the API would reject it. Skip + warn
-          // so the missing cross-ref is observable instead of silently dropped.
-          const senderScopedId = crossRef[entry.botName];
-          if (!senderScopedId) {
-            console.error(`[botmux send] no cross-ref entry for "${entry.botName}" in app ${appId}, skipping auto-mention (cross-ref populates after the sender app first sees the target bot)`);
+        const alreadyMentioned = new Set(mentions.map(m => m.open_id));
+        // Sort by name length desc so longer names ("Claude分身") win over their
+        // prefix ("Claude") when both could match — break-on-first-hit otherwise
+        // routes "@Claude分身" to Claude.
+        const sortedEntries = [...botEntries].sort(
+          (a, b) => (b.botName?.length ?? 0) - (a.botName?.length ?? 0),
+        );
+        const selfAliases = new Set(
+          botEntries
+            .filter(entry => entry.larkAppId === appId)
+            .flatMap(entry => [entry.botName, entry.cliId])
+            .filter((name): name is string => !!name)
+            .map(name => name.toLowerCase()),
+        );
+        // Bots actively in THIS conversation (thread root for thread-scope, chat for
+        // chat-scope). Used to gate the type-generic `cliId` alias so prose "@codex"
+        // resolves to the codex bot collaborating HERE, not every same-type bot
+        // (the fan-out that pulled all Codex-named bots into a topic). See
+        // eligibleAutoMentionAliases.
+        const convoBotAppIds = new Set<string>();
+        for (const sess of loadSessions().values()) {
+          if (sess.status !== 'active' || !sess.larkAppId) continue;
+          const here = isChatScope
+            ? sess.chatId === s.chatId
+            : (!!s.rootMessageId && sess.rootMessageId === s.rootMessageId);
+          if (here) convoBotAppIds.add(sess.larkAppId);
+        }
+        for (const entry of sortedEntries) {
+          if (!entry.botName || entry.larkAppId === appId) continue;
+          const names = eligibleAutoMentionAliases({
+            botName: entry.botName,
+            cliId: entry.cliId ?? undefined,
+            larkAppId: entry.larkAppId ?? undefined,
+            selfAliases,
+            convoBotAppIds,
+          });
+          for (const name of names) {
+            const escName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            // Boundary: lookbehind blocks only ASCII word chars (so `user@Claude`
+            // is rejected but `看看@CoCo` is accepted — CJK prefix is normal in
+            // Chinese text). Lookahead blocks any Unicode letter/digit so
+            // `@Claude2` doesn't match name "Claude" and `@Claude分身好的` doesn't
+            // either-half-match.
+            const re = new RegExp(`(?<![A-Za-z0-9_])@${escName}(?![\\p{L}\\p{N}_])`, 'iu');
+            if (!re.test(text)) continue;
+            // Lark open_id is per-app scoped. Use sender-scoped id from cross-ref
+            // only — falling back to entry.botOpenId would feed Lark a wrong-scope
+            // id (target's self-scoped) and the API would reject it. Skip + warn
+            // so the missing cross-ref is observable instead of silently dropped.
+            const senderScopedId = crossRef[entry.botName];
+            if (!senderScopedId) {
+              console.error(`[botmux send] no cross-ref entry for "${entry.botName}" in app ${appId}, skipping auto-mention (cross-ref populates after the sender app first sees the target bot)`);
+              break;
+            }
+            if (alreadyMentioned.has(senderScopedId)) break;
+            // Prose `@OtherBot` auto-injection: inject normally. (The off-topic
+            // sub-bot guard used to DROP this; we now let the model @ freely and
+            // pick the destination with --into instead of being silently dropped.)
+            mentions.push({ open_id: senderScopedId, name: entry.botName });
+            alreadyMentioned.add(senderScopedId);
             break;
           }
-          if (alreadyMentioned.has(senderScopedId)) break;
-          // Prose `@OtherBot` auto-injection: inject normally. (The off-topic
-          // sub-bot guard used to DROP this; we now let the model @ freely and
-          // pick the destination with --into instead of being silently dropped.)
-          mentions.push({ open_id: senderScopedId, name: entry.botName });
-          alreadyMentioned.add(senderScopedId);
-          break;
         }
-      }
       }
     } catch { /* best-effort */ }
 
@@ -3349,10 +3349,10 @@ async function cmdSend(rest: string[]): Promise<void> {
     const footerAddressing = (sendTopLevel || noMention)
       ? { sendTo: undefined as string | undefined, cc: [] as string[] }
       : buildFooterAddressing(s, {
-          isOncall: !!oncallEntry,
-          hasExplicitBotMention: explicitKnownBotMention,
-          knownBotOpenIds,
-        });
+        isOncall: !!oncallEntry,
+        hasExplicitBotMention: explicitKnownBotMention,
+        knownBotOpenIds,
+      });
 
     const mentionMap = new Map<string, string>();
     for (const m of mentions) if (m.name) mentionMap.set(m.name.toLowerCase(), m.open_id);
@@ -4094,8 +4094,8 @@ async function cmdAsk(sub: string, rest: string[]): Promise<void> {
     const nodeId = process.env.BOTMUX_WORKFLOW_NODE_ID ?? '?';
     console.error(
       `botmux ask refused inside workflow subagent (run=${runId} node=${nodeId}).\n` +
-        `Workflow subagents must surface approvals via humanGate / decision nodes\n` +
-        `so the resolution is recorded in the run's event log; ask would bypass it.`,
+      `Workflow subagents must surface approvals via humanGate / decision nodes\n` +
+      `so the resolution is recorded in the run's event log; ask would bypass it.`,
     );
     process.exit(2);
   }
@@ -4119,7 +4119,7 @@ async function cmdAsk(sub: string, rest: string[]): Promise<void> {
   if (missing) {
     console.error(
       `botmux ask: 缺少必需环境变量 ${missing}。` +
-        ` 请在 botmux daemon spawn 的 CLI 会话内运行。`,
+      ` 请在 botmux daemon spawn 的 CLI 会话内运行。`,
     );
     process.exit(2);
   }
@@ -4818,21 +4818,21 @@ async function cmdVoiceSetup(args: string[]): Promise<void> {
 
 switch (command) {
   case '--version':
-  case '-v':      console.log(getVersion()); break;
-  case 'setup':   await cmdSetup(); break;
-  case 'start':   await cmdStart(); break;
-  case 'stop':    cmdStop(); break;
+  case '-v': console.log(getVersion()); break;
+  case 'setup': await cmdSetup(); break;
+  case 'start': await cmdStart(); break;
+  case 'stop': cmdStop(); break;
   case 'restart': await cmdRestart(); break;
-  case 'logs':    cmdLogs(); break;
-  case 'status':  cmdStatus(); break;
+  case 'logs': cmdLogs(); break;
+  case 'status': cmdStatus(); break;
   case 'upgrade': cmdUpgrade(); break;
   case 'dashboard': await cmdDashboard(); break;
   case 'list':
-  case 'ls':      await cmdList(); break;
+  case 'ls': await cmdList(); break;
   case 'delete':
   case 'del':
-  case 'rm':      cmdDelete(); break;
-  case 'resume':  await cmdResume(); break;
+  case 'rm': cmdDelete(); break;
+  case 'resume': await cmdResume(); break;
   case 'schedule': await cmdSchedule(process.argv[3] ?? '', process.argv.slice(4)); break;
   case 'ask': {
     // `botmux ask buttons --options ...` → sub='buttons', rest=['--options', ...]
@@ -4885,5 +4885,5 @@ switch (command) {
     else { console.error(`用法: botmux autostart <enable|disable|status>`); process.exit(1); }
     break;
   }
-  default:        showHelp(); break;
+  default: showHelp(); break;
 }

--- a/src/dashboard/web/sessions.ts
+++ b/src/dashboard/web/sessions.ts
@@ -17,6 +17,7 @@ const CLI_FILTER_OPTIONS = [
   'mtr',
   'hermes',
   'mira',
+  'copilot',
   'aiden',
   'coco',
   'unknown',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -426,7 +426,7 @@ export const messages: Record<string, string> = {
   'setup.lark_perm_chat': '  - im:chat (group info)',
   'setup.lark_perm_user_base': '  - contact:user.base:readonly (user info)',
   'setup.lark_enable_events': 'Enable Event Subscription (WebSocket mode):',
-  'setup.supported_clis': 'Supported CLIs: 1) claude-code  2) aiden  3) coco  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira',
+  'setup.supported_clis': 'Supported CLIs: 1) claude-code  2) aiden  3) coco  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed  14) copilot',
   'setup.prompt_cli_choice': 'CLI adapter [1]: ',
   'setup.prompt_working_dir': 'Default working directory [~]: ',
   'setup.prompt_allowed_users': 'Allowed users (emails or open_ids, comma-separated; empty = no restriction): ',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -429,7 +429,7 @@ export const messages: Record<string, string> = {
   'setup.lark_perm_chat': '  - im:chat (群信息)',
   'setup.lark_perm_user_base': '  - contact:user.base:readonly (用户信息)',
   'setup.lark_enable_events': '启用事件订阅 (WebSocket 模式):',
-  'setup.supported_clis': '支持的 CLI: 1) claude-code  2) aiden  3) coco  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira',
+  'setup.supported_clis': '支持的 CLI: 1) claude-code  2) aiden  3) coco  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed  14) copilot',
   'setup.prompt_cli_choice': 'CLI 适配器 [1]: ',
   'setup.prompt_working_dir': '默认工作目录 [~]: ',
   'setup.prompt_allowed_users': '允许的用户 (邮箱或 open_id，逗号分隔，留空=不限制): ',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -21,6 +21,7 @@ const cliDisplayNames: Record<CliId, string> = {
   'mtr': 'MTR',
   'hermes': 'Hermes',
   'mira': 'Mira',
+  'copilot': 'Copilot',
 };
 
 export function getCliDisplayName(cliId: CliId): string {

--- a/src/setup/bot-config-editor.ts
+++ b/src/setup/bot-config-editor.ts
@@ -15,6 +15,7 @@ export const CLI_ID_CHOICES: Record<string, CliId> = {
   '11': 'codex-app',
   '12': 'mira',
   '13': 'seed',
+  '14': 'copilot',
 };
 
 const VALID_CLI_IDS: ReadonlySet<string> = new Set(Object.values(CLI_ID_CHOICES));
@@ -38,11 +39,12 @@ const CLI_DISPLAY_LABELS: Record<CliId, string> = {
   'codex-app': 'Codex App',
   'mira': 'Mira',
   'seed': 'Seed',
+  'copilot': 'Copilot',
 };
 
 /**
  * 有序 CLI 选项 (id + 展示名), 顺序与 setup 交互菜单 (CLI_ID_CHOICES 序号
- * 1..13) 一致. dashboard "添加机器人" 的 CLI 下拉直接读这里, 避免再抄一份
+ * 1..14) 一致. dashboard "添加机器人" 的 CLI 下拉直接读这里, 避免再抄一份
  * 列表. 单一事实源: CLI_ID_CHOICES 的值序.
  */
 export const CLI_OPTIONS: ReadonlyArray<{ id: CliId; label: string }> =
@@ -51,7 +53,7 @@ export const CLI_OPTIONS: ReadonlyArray<{ id: CliId; label: string }> =
 /**
  * 把 setup 里"CLI 适配器"那一格的原始输入解析成合法的 CliId.
  *   - 空 → undefined (调用方决定 "preserve current" 还是套默认 'claude-code')
- *   - "1".."13" → CLI_ID_CHOICES 映射
+ *   - "1".."14" → CLI_ID_CHOICES 映射
  *   - 已是合法 cliId 字面值 → 原样返回
  *   - 其它 → throw (typo 不该静默落盘成 cliId)
  */
@@ -62,7 +64,7 @@ export function resolveCliId(input: string | undefined): CliId | undefined {
   if (mapped) return mapped;
   if (VALID_CLI_IDS.has(raw)) return raw as CliId;
   throw new Error(
-    `Unknown CLI 适配器 "${raw}"。请输入序号 1-13 或合法 ID 之一: ${[...VALID_CLI_IDS].join(', ')}`,
+    `Unknown CLI 适配器 "${raw}"。请输入序号 1-14 或合法 ID 之一: ${[...VALID_CLI_IDS].join(', ')}`,
   );
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -115,7 +115,7 @@ function ensureZellijAttachConfig(): string {
 
 let sessionId = '';
 let lastInitConfig: Extract<DaemonToWorker, { type: 'init' }> | null = null;
-const CLI_DISPLAY_NAMES: Record<string, string> = { 'claude-code': 'Claude', seed: 'Seed', aiden: 'Aiden', coco: 'CoCo', codex: 'Codex', 'codex-app': 'Codex App', cursor: 'Cursor', gemini: 'Gemini', opencode: 'OpenCode', antigravity: 'Antigravity', mtr: 'MTR', hermes: 'Hermes', mira: 'Mira' };
+const CLI_DISPLAY_NAMES: Record<string, string> = { 'claude-code': 'Claude', seed: 'Seed', aiden: 'Aiden', coco: 'CoCo', codex: 'Codex', 'codex-app': 'Codex App', cursor: 'Cursor', gemini: 'Gemini', opencode: 'OpenCode', antigravity: 'Antigravity', mtr: 'MTR', hermes: 'Hermes', mira: 'Mira', copilot: 'Copilot' };
 function cliName(): string { return CLI_DISPLAY_NAMES[lastInitConfig?.cliId ?? ''] ?? 'CLI'; }
 let isPromptReady = false;
 /** Mutex for async flushPending — prevents concurrent flush loops. */
@@ -678,9 +678,9 @@ function maybeSwitchBridgeJsonl(): boolean {
     findExact: (acceptCandidate) =>
       candidate.contentNormalized
         ? findJsonlsContainingExactContent(bridgeJsonlDir!, candidate.contentNormalized, {
-            ...fingerprintScanOptions,
-            acceptCandidate,
-          })
+          ...fingerprintScanOptions,
+          acceptCandidate,
+        })
         : [],
   });
   if (decision.action === 'switch') {
@@ -2059,7 +2059,7 @@ async function captureAndUpload(): Promise<void> {
   // gate on it). Logging here exists to surface the unexpected case — e.g. a
   // stray scheduleOneShotAfterAction firing after user toggled back to hidden.
   if (displayMode !== 'screenshot') { logScreenshotSkip(`displayMode=${displayMode}`); return; }
-  if (awaitingFirstPrompt)          { logScreenshotSkip('awaitingFirstPrompt'); return; }
+  if (awaitingFirstPrompt) { logScreenshotSkip('awaitingFirstPrompt'); return; }
   if (!larkAppIdForUpload || !larkAppSecretForUpload) { logScreenshotSkip('lark credentials missing'); return; }
 
   let png: Buffer;
@@ -2344,7 +2344,7 @@ function splitCodexAppControl(data: string): string {
 
   let out = '';
   let cursor = 0;
-  for (;;) {
+  for (; ;) {
     const start = input.indexOf(CODEX_APP_OSC_PREFIX, cursor);
     if (start < 0) {
       let tailStart = input.length;
@@ -2391,10 +2391,10 @@ function onPtyData(data: string): void {
     let lastToggleActive = altBufferActive;
     ALT_ENTER_RE.lastIndex = 0;
     ALT_EXIT_RE.lastIndex = 0;
-    for (let m: RegExpExecArray | null; (m = ALT_ENTER_RE.exec(data)); ) {
+    for (let m: RegExpExecArray | null; (m = ALT_ENTER_RE.exec(data));) {
       if (m.index > lastToggleIdx) { lastToggleIdx = m.index; lastToggleActive = true; }
     }
-    for (let m: RegExpExecArray | null; (m = ALT_EXIT_RE.exec(data)); ) {
+    for (let m: RegExpExecArray | null; (m = ALT_EXIT_RE.exec(data));) {
       if (m.index > lastToggleIdx) { lastToggleIdx = m.index; lastToggleActive = false; }
     }
     altBufferActive = lastToggleActive;

--- a/test/bot-config-editor.test.ts
+++ b/test/bot-config-editor.test.ts
@@ -262,6 +262,8 @@ describe('resolveCliId', () => {
     expect(resolveCliId('10')).toBe('hermes');
     expect(resolveCliId('11')).toBe('codex-app');
     expect(resolveCliId('12')).toBe('mira');
+    expect(resolveCliId('13')).toBe('seed');
+    expect(resolveCliId('14')).toBe('copilot');
   });
 
   it('passes through literal cliIds unchanged', () => {
@@ -271,6 +273,8 @@ describe('resolveCliId', () => {
     expect(resolveCliId('mtr')).toBe('mtr');
     expect(resolveCliId('hermes')).toBe('hermes');
     expect(resolveCliId('mira')).toBe('mira');
+    expect(resolveCliId('seed')).toBe('seed');
+    expect(resolveCliId('copilot')).toBe('copilot');
   });
 
   it('throws on typos so they do not leak into bots.json', () => {

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -30,13 +30,14 @@ import { createAntigravityAdapter } from '../src/adapters/cli/antigravity.js';
 import { createMtrAdapter, mtrSessionIdForBotmuxSession } from '../src/adapters/cli/mtr.js';
 import { createHermesAdapter } from '../src/adapters/cli/hermes.js';
 import { createMiraAdapter } from '../src/adapters/cli/mira.js';
+import { createCopilotAdapter } from '../src/adapters/cli/copilot.js';
 import type { CliAdapter, CliId } from '../src/adapters/cli/types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-const ALL_CLI_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'codex-app', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes', 'mira'];
+const ALL_CLI_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'codex-app', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes', 'mira', 'copilot'];
 
 // ---------------------------------------------------------------------------
 // 1. Factory: createCliAdapterSync
@@ -70,7 +71,7 @@ describe('createCliAdapterSync factory', () => {
 describe('lazy binary resolution', () => {
   // Adapters whose resolvedBin is the resolved CLI (codex-app/mira use
   // process.execPath and never probe, so they're excluded).
-  const PROBING_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'cursor', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes'];
+  const PROBING_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'cursor', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes', 'copilot'];
 
   it.each(PROBING_IDS)('"%s": construction does not probe; first resolvedBin read does', async (id) => {
     const { spawnSync } = await import('node:child_process');
@@ -331,6 +332,53 @@ describe('mira buildArgs', () => {
     });
     expect(args).toContain('--mira-session-id');
     expect(args).toContain('mira-session-123');
+  });
+});
+
+describe('copilot buildArgs', () => {
+  const adapter = createCopilotAdapter('/usr/bin/copilot');
+
+  it('fresh session passes --allow-all-tools without resume flags', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-cp', resume: false });
+    expect(args).toContain('--allow-all-tools');
+    expect(args).not.toContain('--resume');
+    expect(args).not.toContain('--continue');
+    expect(args).not.toContain('sess-cp');
+  });
+
+  it('resume with cliSessionId passes --resume <id>', () => {
+    const args = adapter.buildArgs({
+      sessionId: 'sess-cp',
+      resume: true,
+      resumeSessionId: 'copilot-sess-abc',
+    });
+    expect(args).toContain('--resume');
+    const idx = args.indexOf('--resume');
+    expect(args[idx + 1]).toBe('copilot-sess-abc');
+  });
+
+  it('resume without cliSessionId falls back to --continue', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-cp', resume: true });
+    expect(args).toContain('--continue');
+    expect(args).not.toContain('--resume');
+  });
+
+  it('passes configured model with --model', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-cp', resume: false, model: 'gpt-5' });
+    const idx = args.indexOf('--model');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(args[idx + 1]).toBe('gpt-5');
+  });
+
+  it('does not bake initialPrompt into args', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-cp', resume: false, initialPrompt: 'hello copilot' });
+    expect(args).not.toContain('hello copilot');
+    expect(adapter.passesInitialPromptViaArgs).toBeFalsy();
+  });
+
+  it('surfaces curated model choices for setup', () => {
+    expect(adapter.modelChoices).toContain('claude-sonnet-4');
+    expect(adapter.modelChoices).toContain('gpt-5');
   });
 });
 
@@ -607,6 +655,10 @@ describe('completionPattern', () => {
   it('hermes has no completionPattern', () => {
     expect(createHermesAdapter('/bin/hermes').completionPattern).toBeUndefined();
   });
+
+  it('copilot has no completionPattern', () => {
+    expect(createCopilotAdapter('/bin/copilot').completionPattern).toBeUndefined();
+  });
 });
 
 describe('readyPattern', () => {
@@ -666,6 +718,10 @@ describe('readyPattern', () => {
   it('hermes has no readyPattern', () => {
     expect(createHermesAdapter('/bin/hermes').readyPattern).toBeUndefined();
   });
+
+  it('copilot has no readyPattern', () => {
+    expect(createCopilotAdapter('/bin/copilot').readyPattern).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -697,6 +753,7 @@ describe('systemHints', () => {
     ['antigravity', () => createAntigravityAdapter('/bin/agy')],
     ['mtr', () => createMtrAdapter('/bin/mtr')],
     ['hermes', () => createHermesAdapter('/bin/hermes')],
+    ['copilot', () => createCopilotAdapter('/bin/copilot')],
   ];
 
   it.each(nonClaudeAdapters)('%s systemHints include botmux send routing guidance', (_name, factory) => {
@@ -723,6 +780,7 @@ describe('id property', () => {
     ['mtr', () => createMtrAdapter('/bin/mtr')],
     ['hermes', () => createHermesAdapter('/bin/hermes')],
     ['mira', () => createMiraAdapter()],
+    ['copilot', () => createCopilotAdapter('/bin/copilot')],
   ];
 
   it.each(expected)('adapter id is "%s"', (expectedId, factory) => {
@@ -777,6 +835,10 @@ describe('altScreen property', () => {
 
   it('mira does not use alt screen', () => {
     expect(createMiraAdapter().altScreen).toBe(false);
+  });
+
+  it('copilot uses alt screen (Ink TUI)', () => {
+    expect(createCopilotAdapter('/bin/copilot').altScreen).toBe(true);
   });
 });
 
@@ -859,5 +921,12 @@ describe('buildResumeCommand', () => {
     expect(a.buildResumeCommand?.({ sessionId: 'bm-ag', cliSessionId: 'cid-uuid' }))
       .toBe('agy --conversation cid-uuid');
     expect(a.buildResumeCommand?.({ sessionId: 'bm-ag' })).toBeNull();
+  });
+
+  it('copilot emits `copilot --resume <cliSessionId>` when known, null otherwise', () => {
+    const a = createCopilotAdapter('/bin/copilot');
+    expect(a.buildResumeCommand?.({ sessionId: 'bm-cp', cliSessionId: 'copilot-sess-1' }))
+      .toBe('copilot --resume copilot-sess-1');
+    expect(a.buildResumeCommand?.({ sessionId: 'bm-cp' })).toBeNull();
   });
 });

--- a/test/write-input-all-cli.e2e.ts
+++ b/test/write-input-all-cli.e2e.ts
@@ -25,6 +25,7 @@ import { createOpenCodeAdapter } from '../src/adapters/cli/opencode.js';
 import { createMtrAdapter } from '../src/adapters/cli/mtr.js';
 import { createHermesAdapter } from '../src/adapters/cli/hermes.js';
 import { createMiraAdapter } from '../src/adapters/cli/mira.js';
+import { createCopilotAdapter } from '../src/adapters/cli/copilot.js';
 
 // ─── Mock PTY recorder ──────────────────────────────────────────────────────
 
@@ -117,6 +118,7 @@ const ADAPTERS = [
   { name: 'mtr', create: () => safeCreate(() => createMtrAdapter()) },
   { name: 'hermes', create: () => safeCreate(() => createHermesAdapter()) },
   { name: 'mira', create: () => safeCreate(() => createMiraAdapter()) },
+  { name: 'copilot', create: () => safeCreate(() => createCopilotAdapter()) },
 ];
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -126,7 +128,7 @@ describe('writeInput: write sequence verification (all CLIs × all scenarios)', 
     describe(adapterDef.name, () => {
       const adapter = adapterDef.create();
       if (!adapter) {
-        it.skip(`${adapterDef.name} not installed`, () => {});
+        it.skip(`${adapterDef.name} not installed`, () => { });
         return;
       }
 
@@ -256,7 +258,7 @@ describe('writeInput: timing analysis', () => {
 
         const strategy = hasBracketedPaste(pty.writes) ? 'bracketed-paste'
           : pty.writes.length === 1 ? 'single-write'
-          : 'split-write+delay';
+            : 'split-write+delay';
 
         results.push({
           scenario: scenario.name,


### PR DESCRIPTION
## Summary
- add a GitHub Copilot CLI adapter
- register Copilot in setup, CLI display names, dashboard filtering, and Lark cards
- add focused adapter/setup tests

## Verification
- pnpm exec tsc --noEmit
- pnpm exec vitest run test/cli-adapters.test.ts test/bot-config-editor.test.ts