### PR TITLE
fix(lark): 飞书事件先回执再后台处理，并去重防重复触发

### DIFF
--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -272,6 +272,52 @@ export async function checkRequiredScopes(larkAppId: string): Promise<void> {
 export const CHAT_CACHE_TTL = 5 * 60_000; // 5 minutes
 const chatStatsCache = new Map<string, { userCount: number; botCount: number; fetchedAt: number }>();
 
+// ─── Event callback ACK safety ──────────────────────────────────────────────
+//
+// Feishu/Lark expects event callbacks to return quickly. The message path below
+// can spend seconds doing OpenAPI lookups and spawning/dispatching a CLI
+// session; if the SDK waits for this async work before ACKing, Open Platform
+// retries the same event and may enqueue the same prompt twice. Claim a stable
+// event key, move heavy work behind setImmediate, and return from the callback
+// immediately so the transport can ACK promptly.
+
+const EVENT_CLAIM_TTL_MS = 60 * 60_000;
+const eventClaims = new Map<string, number>();
+
+function pruneEventClaims(now = Date.now()): void {
+  for (const [key, expiresAt] of eventClaims) {
+    if (expiresAt <= now) eventClaims.delete(key);
+  }
+}
+
+function claimEventOnce(key: string): boolean {
+  const now = Date.now();
+  if (eventClaims.size > 5000) pruneEventClaims(now);
+  const expiresAt = eventClaims.get(key);
+  if (expiresAt && expiresAt > now) return false;
+  eventClaims.set(key, now + EVENT_CLAIM_TTL_MS);
+  return true;
+}
+
+function scheduleAckSafeEvent(key: string, work: () => Promise<void>, label: string): void {
+  if (!claimEventOnce(key)) {
+    logger.info(`[event-dedupe] duplicate ${label} ignored: ${key}`);
+    return;
+  }
+  setImmediate(() => {
+    void work().catch(err => logger.error(`Error handling ${label}: ${err}`));
+  });
+}
+
+function eventIdForKey(data: any): string | undefined {
+  return data?.event_id ?? data?.uuid ?? data?.header?.event_id ?? data?.event?.event_id;
+}
+
+/** Test-only: clear callback dedupe claims between cases. */
+export function __resetEventClaimsForTest(): void {
+  eventClaims.clear();
+}
+
 export async function getGroupStats(larkAppId: string, chatId: string): Promise<{ userCount: number; botCount: number }> {
   const cacheKey = `${larkAppId}:${chatId}`;
   const cached = chatStatsCache.get(cacheKey);
@@ -849,7 +895,11 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
     // 主动开工 — 场景①: the bot was added to a chat. Hand off to the daemon,
     // which gates on the autoStartOnGroupJoin toggle + allowedUser membership.
     // Requires this event to be subscribed for the app in the Feishu console.
-    'im.chat.member.bot.added_v1': async (data: any) => {
+    'im.chat.member.bot.added_v1': (data: any) => {
+      const chatIdForKey: string | undefined = data?.chat_id;
+      const operatorForKey: string | undefined = data?.operator_id?.open_id;
+      const eventKey = `im.chat.member.bot.added_v1:${larkAppId}:${eventIdForKey(data) ?? `${chatIdForKey ?? 'unknown'}:${operatorForKey ?? 'unknown'}`}`;
+      scheduleAckSafeEvent(eventKey, async () => {
       try {
         const chatId: string | undefined = data?.chat_id;
         const operatorOpenId: string | undefined = data?.operator_id?.open_id;
@@ -859,6 +909,7 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
       } catch (err) {
         logger.error(`Error handling bot-added event: ${err}`);
       }
+      }, 'bot-added event');
     },
     'card.action.trigger': async (data: any) => {
       try {
@@ -875,7 +926,10 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
       }
       return undefined;
     },
-    'im.message.receive_v1': async (data: any) => {
+    'im.message.receive_v1': (data: any) => {
+      const messageIdForKey = data?.message?.message_id;
+      const eventKey = `im.message.receive_v1:${larkAppId}:${eventIdForKey(data) ?? messageIdForKey ?? JSON.stringify(data).slice(0, 200)}`;
+      scheduleAckSafeEvent(eventKey, async () => {
       try {
         const message = data.message;
         const sender = data.sender;
@@ -1141,6 +1195,7 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
       } catch (err) {
         logger.error(`Error handling message event: ${err}`);
       }
+      }, 'message event');
     },
   });
 

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -274,17 +274,31 @@ const chatStatsCache = new Map<string, { userCount: number; botCount: number; fe
 
 // ─── Event callback ACK safety ──────────────────────────────────────────────
 //
-// Feishu/Lark expects event callbacks to return quickly. The message path below
-// can spend seconds doing OpenAPI lookups and spawning/dispatching a CLI
-// session; if the SDK waits for this async work before ACKing, Open Platform
-// retries the same event and may enqueue the same prompt twice. Claim a stable
-// event key, move heavy work behind setImmediate, and return from the callback
-// immediately so the transport can ACK promptly.
-
-const EVENT_CLAIM_TTL_MS = 60 * 60_000;
+// The Lark WS SDK sends exactly one response frame per event and only AFTER the
+// registered handler's promise resolves (WSClient.handleEventData: it awaits
+// eventDispatcher.invoke, then sendMessage once). So that frame is the ACK: a
+// slow handler delays it past Feishu's 3s budget and triggers a timeout re-push.
+// The message path below can spend seconds on OpenAPI lookups + spawning a CLI,
+// so we return synchronously and run the heavy work behind setImmediate — the
+// handler resolves immediately, the ACK is prompt, and the work runs after.
+//
+// Dedupe: Feishu re-pushes an un-ACKed/non-200 event at 15s, 5min, 1h, 6h (max
+// 4 retries), and its pipeline is at-least-once, so a duplicate can arrive even
+// after a timely 200. Fast-ACK keeps us inside 3s so timeout-retries stop
+// firing — the realistic duplicate is then a near-simultaneous at-least-once
+// copy, which a short-lived claim per stable event key suppresses. The TTL
+// covers the 15s/5min/1h retry tiers with margin; the 6h tier is only reachable
+// after a sustained ACK failure that fast-ACK prevents, so we don't size for it.
+// (We claim-then-ack-success on purpose: a redelivery is always treated as a
+//  duplicate, never as recovery — matching the prior swallow-and-ACK behavior.)
+const EVENT_CLAIM_TTL_MS = 2 * 60 * 60_000; // 2h — covers the 15s/5min/1h retry tiers
+const EVENT_CLAIM_PRUNE_INTERVAL_MS = 5 * 60_000;
+const EVENT_CLAIM_PRUNE_SIZE = 5000;
 const eventClaims = new Map<string, number>();
+let eventClaimsLastPrunedAt = 0;
 
 function pruneEventClaims(now = Date.now()): void {
+  eventClaimsLastPrunedAt = now;
   for (const [key, expiresAt] of eventClaims) {
     if (expiresAt <= now) eventClaims.delete(key);
   }
@@ -292,7 +306,12 @@ function pruneEventClaims(now = Date.now()): void {
 
 function claimEventOnce(key: string): boolean {
   const now = Date.now();
-  if (eventClaims.size > 5000) pruneEventClaims(now);
+  // Prune under size pressure OR on a time interval, so a busy bot's map stays
+  // bounded regardless of call cadence (the size gate alone never fires below
+  // the threshold, leaving expired entries pinned for the full TTL).
+  if (eventClaims.size > EVENT_CLAIM_PRUNE_SIZE || now - eventClaimsLastPrunedAt > EVENT_CLAIM_PRUNE_INTERVAL_MS) {
+    pruneEventClaims(now);
+  }
   const expiresAt = eventClaims.get(key);
   if (expiresAt && expiresAt > now) return false;
   eventClaims.set(key, now + EVENT_CLAIM_TTL_MS);
@@ -304,16 +323,36 @@ function scheduleAckSafeEvent(key: string, work: () => Promise<void>, label: str
     logger.info(`[event-dedupe] duplicate ${label} ignored: ${key}`);
     return;
   }
+  // INVARIANT: claimEventOnce + this setImmediate scheduling must stay fully
+  // synchronous (no await before we get here). WS events arrive in order and
+  // setImmediate is FIFO, so same-anchor messages reach serializeByAnchor in
+  // arrival order ONLY while nothing awaits ahead of the schedule. An await here
+  // would reintroduce the kickoff-ordering bug serializeByAnchor guards against.
   setImmediate(() => {
     void work().catch(err => logger.error(`Error handling ${label}: ${err}`));
   });
+}
+
+// Fallback for an event that carries no stable id at all. Dedupe must never
+// silently DROP a real message, so we hand back a unique key (process it, accept
+// a rare duplicate) rather than a content-prefix key that could collide with a
+// distinct message and suppress it for the whole TTL.
+let unkeyableEventSeq = 0;
+function unkeyableEventKey(): string {
+  return `__unkeyable__:${++unkeyableEventSeq}`;
 }
 
 function eventIdForKey(data: any): string | undefined {
   return data?.event_id ?? data?.uuid ?? data?.header?.event_id ?? data?.event?.event_id;
 }
 
+// card.action.trigger is a synchronous callback with a 3s deadline and NO
+// re-push (unlike events). If a handler (e.g. restart, which spawns a worker)
+// might exceed the budget, we ACK before 3s with a toast and patch the card
+// afterwards — missing the deadline otherwise surfaces error 200341 to the user.
+// 2500ms leaves headroom for the WS frame round-trip inside the 3s window.
 const CARD_ACTION_ACK_TIMEOUT_MS = 2500;
+const CARD_ACTION_TIMEOUT = Symbol('card-action-timeout');
 const cardActionInFlight = new Set<string>();
 
 function cardActionMessageId(data: any): string | undefined {
@@ -362,7 +401,21 @@ async function patchTimedOutCardActionResult(larkAppId: string, data: any, shape
 }
 
 async function handleCardActionAckSafe(data: any, larkAppId: string, handlers: EventHandlers): Promise<any> {
+  const eventId = eventIdForKey(data);
   const key = cardActionKey(larkAppId, data);
+
+  // Durable dedupe ONLY when the platform gave a stable per-interaction id:
+  // suppresses a same-interaction redelivery over the long-connection so a
+  // non-idempotent action (restart/close) can't double-fire after the first
+  // copy already finished — the in-flight Set alone clears in finally() and
+  // would miss that. We deliberately do NOT durably claim the payload-based
+  // fallback key: distinct clicks of the same button (e.g. toggling stream
+  // on/off) legitimately repeat and must not be pinned for the whole TTL.
+  if (eventId && !claimEventOnce(key)) {
+    logger.info(`[event-dedupe] duplicate card action ignored (claimed): ${key}`);
+    return { toast: { type: 'info', content: '操作已收到，请勿重复点击' } };
+  }
+
   if (cardActionInFlight.has(key)) {
     logger.info(`[event-dedupe] duplicate card action ignored while in-flight: ${key}`);
     return { toast: { type: 'info', content: '操作正在处理中，请稍候' } };
@@ -379,15 +432,22 @@ async function handleCardActionAckSafe(data: any, larkAppId: string, handlers: E
 
   void work.then(result => {
     if (!timedOut || !result) return;
+    if (!result.card && result.toast) {
+      // A toast-only result can't be re-surfaced after we already ACKed with the
+      // generic "后台处理中" toast: toasts ride the synchronous callback response,
+      // and the message-update API only patches the card. Log rather than drop.
+      logger.warn(`[card-action] slow handler resolved to a toast-only result after ACK; not shown to user: ${JSON.stringify(result.toast)}`);
+      return;
+    }
     return patchTimedOutCardActionResult(larkAppId, data, result)
       .catch(err => logger.warn(`Failed to patch timed-out card action result: ${err}`));
   }).finally(() => {
     cardActionInFlight.delete(key);
   });
 
-  const timeout = new Promise(resolve => setTimeout(resolve, CARD_ACTION_ACK_TIMEOUT_MS, Symbol.for('card-action-timeout')));
+  const timeout = new Promise(resolve => setTimeout(resolve, CARD_ACTION_ACK_TIMEOUT_MS, CARD_ACTION_TIMEOUT));
   const result = await Promise.race([work, timeout]);
-  if (result === Symbol.for('card-action-timeout')) {
+  if (result === CARD_ACTION_TIMEOUT) {
     timedOut = true;
     logger.warn(`[card-action] handler exceeded ${CARD_ACTION_ACK_TIMEOUT_MS}ms; ACKing first and continuing in background: ${key}`);
     return { toast: { type: 'info', content: '操作已收到，后台处理中' } };
@@ -997,7 +1057,7 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
     'card.action.trigger': (data: any) => handleCardActionAckSafe(data, larkAppId, handlers),
     'im.message.receive_v1': (data: any) => {
       const messageIdForKey = data?.message?.message_id;
-      const eventKey = `im.message.receive_v1:${larkAppId}:${eventIdForKey(data) ?? messageIdForKey ?? JSON.stringify(data).slice(0, 200)}`;
+      const eventKey = `im.message.receive_v1:${larkAppId}:${eventIdForKey(data) ?? messageIdForKey ?? unkeyableEventKey()}`;
       scheduleAckSafeEvent(eventKey, async () => {
       try {
         const message = data.message;

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -8,7 +8,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { getBot, getAllBots, findOncallChat, getOwnerOpenId, type BotState } from '../../bot-registry.js';
 import { config } from '../../config.js';
-import { getChatInfo, getChatMode, listChatBotMembers, replyMessage, sendUserMessage, isHumanOpenId } from './client.js';
+import { getChatInfo, getChatMode, listChatBotMembers, replyMessage, sendUserMessage, isHumanOpenId, updateMessage } from './client.js';
 import { logger } from '../../utils/logger.js';
 import { serializeByAnchor } from '../../utils/anchor-serializer.js';
 import { parseForceTopicInvocation } from '../../core/command-handler.js';
@@ -313,9 +313,92 @@ function eventIdForKey(data: any): string | undefined {
   return data?.event_id ?? data?.uuid ?? data?.header?.event_id ?? data?.event?.event_id;
 }
 
+const CARD_ACTION_ACK_TIMEOUT_MS = 2500;
+const cardActionInFlight = new Set<string>();
+
+function cardActionMessageId(data: any): string | undefined {
+  return data?.context?.open_message_id ?? data?.open_message_id;
+}
+
+function cardActionKey(larkAppId: string, data: any): string {
+  const eventId = eventIdForKey(data);
+  if (eventId) return `card.action.trigger:${larkAppId}:${eventId}`;
+  const action = data?.action;
+  const value = action?.value ?? {};
+  return `card.action.trigger:${larkAppId}:${JSON.stringify({
+    messageId: cardActionMessageId(data),
+    operator: data?.operator?.open_id,
+    action: value?.action ?? action?.option ?? action?.tag,
+    rootId: value?.root_id,
+    sessionId: value?.session_id,
+    nonce: value?.card_nonce ?? value?.nonce,
+    option: action?.option,
+    key: value?.key,
+  })}`;
+}
+
+function shapeCardActionResult(result: any): any {
+  // The handler may return:
+  //   - an already-shaped Lark response ({toast} and/or {card}) -> pass through;
+  //   - a raw card body (e.g. toggle_stream) -> wrap as an in-place card patch.
+  if (result && (result.toast || result.card)) return result;
+  if (result) return { card: { type: 'raw', data: result } };
+  return undefined;
+}
+
+function serializeRawCardForPatch(cardData: any): string | undefined {
+  if (cardData === undefined || cardData === null) return undefined;
+  return typeof cardData === 'string' ? cardData : JSON.stringify(cardData);
+}
+
+async function patchTimedOutCardActionResult(larkAppId: string, data: any, shapedResult: any): Promise<void> {
+  const messageId = cardActionMessageId(data);
+  if (!messageId || !shapedResult?.card) return;
+  const card = shapedResult.card;
+  const raw = card.type === 'raw' ? card.data : card;
+  const body = serializeRawCardForPatch(raw);
+  if (!body) return;
+  await updateMessage(larkAppId, messageId, body);
+}
+
+async function handleCardActionAckSafe(data: any, larkAppId: string, handlers: EventHandlers): Promise<any> {
+  const key = cardActionKey(larkAppId, data);
+  if (cardActionInFlight.has(key)) {
+    logger.info(`[event-dedupe] duplicate card action ignored while in-flight: ${key}`);
+    return { toast: { type: 'info', content: '操作正在处理中，请稍候' } };
+  }
+
+  cardActionInFlight.add(key);
+  let timedOut = false;
+  const work = handlers.handleCardAction(data, larkAppId)
+    .then(shapeCardActionResult)
+    .catch(err => {
+      logger.error(`Error handling card action: ${err}`);
+      return undefined;
+    });
+
+  void work.then(result => {
+    if (!timedOut || !result) return;
+    return patchTimedOutCardActionResult(larkAppId, data, result)
+      .catch(err => logger.warn(`Failed to patch timed-out card action result: ${err}`));
+  }).finally(() => {
+    cardActionInFlight.delete(key);
+  });
+
+  const timeout = new Promise(resolve => setTimeout(resolve, CARD_ACTION_ACK_TIMEOUT_MS, Symbol.for('card-action-timeout')));
+  const result = await Promise.race([work, timeout]);
+  if (result === Symbol.for('card-action-timeout')) {
+    timedOut = true;
+    logger.warn(`[card-action] handler exceeded ${CARD_ACTION_ACK_TIMEOUT_MS}ms; ACKing first and continuing in background: ${key}`);
+    return { toast: { type: 'info', content: '操作已收到，后台处理中' } };
+  }
+  return result;
+}
+
 /** Test-only: clear callback dedupe claims between cases. */
 export function __resetEventClaimsForTest(): void {
   eventClaims.clear();
+  cardActionInFlight.clear();
 }
 
 export async function getGroupStats(larkAppId: string, chatId: string): Promise<{ userCount: number; botCount: number }> {
@@ -911,21 +994,7 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
       }
       }, 'bot-added event');
     },
-    'card.action.trigger': async (data: any) => {
-      try {
-        const result = await handlers.handleCardAction(data, larkAppId);
-        // The handler may return:
-        //   - an already-shaped Lark response ({toast} and/or {card}) → pass through
-        //     so toasts (e.g. "仅 owner 可操作") and explicit card payloads render;
-        //   - a raw card body (e.g. toggle_stream) → wrap as an in-place card patch
-        //     so Lark updates the clicked card without waiting for an API PATCH.
-        if (result && (result.toast || result.card)) return result;
-        if (result) return { card: { type: 'raw', data: result } };
-      } catch (err) {
-        logger.error(`Error handling card action: ${err}`);
-      }
-      return undefined;
-    },
+    'card.action.trigger': (data: any) => handleCardActionAckSafe(data, larkAppId, handlers),
     'im.message.receive_v1': (data: any) => {
       const messageIdForKey = data?.message?.message_id;
       const eventKey = `im.message.receive_v1:${larkAppId}:${eventIdForKey(data) ?? messageIdForKey ?? JSON.stringify(data).slice(0, 200)}`;

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -1911,6 +1911,43 @@ describe('card.action.trigger — ack-safe slow handlers', () => {
     release();
     await first;
   });
+
+  it('dedupes a same-event_id redelivery that arrives AFTER the first copy completed', async () => {
+    handlers.handleCardAction.mockResolvedValue({ type: 'done-card' });
+    const event = {
+      event_id: 'evt-card-claim',
+      action: { value: { action: 'restart', root_id: 'root-claim' } },
+      operator: { open_id: USER_OPEN_ID },
+      context: { open_message_id: 'om_claim_card' },
+    };
+
+    const first = await capturedHandlers['card.action.trigger'](event);
+    expect(first).toEqual({ card: { type: 'raw', data: { type: 'done-card' } } });
+
+    // In-flight Set has already cleared in finally(); only the durable claim can
+    // still stop a redelivery from re-firing a non-idempotent action (restart).
+    const redelivery = await capturedHandlers['card.action.trigger']({ ...event });
+    expect(redelivery).toEqual({ toast: { type: 'info', content: '操作已收到，请勿重复点击' } });
+    expect(handlers.handleCardAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT durably dedupe distinct clicks without an event_id (legitimate repeat)', async () => {
+    handlers.handleCardAction.mockResolvedValue({ type: 'toggled' });
+    const event = {
+      action: { value: { action: 'toggle_stream', root_id: 'root-toggle' } },
+      operator: { open_id: USER_OPEN_ID },
+      context: { open_message_id: 'om_toggle_card' },
+    };
+
+    const first = await capturedHandlers['card.action.trigger'](event);
+    const second = await capturedHandlers['card.action.trigger']({ ...event });
+
+    // No stable id to claim + in-flight guard cleared between clicks, so a repeat
+    // (e.g. toggling stream on then off) is NOT suppressed.
+    expect(first).toEqual({ card: { type: 'raw', data: { type: 'toggled' } } });
+    expect(second).toEqual({ card: { type: 'raw', data: { type: 'toggled' } } });
+    expect(handlers.handleCardAction).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('im.message.receive_v1 — ack-safe duplicate delivery', () => {
@@ -1969,6 +2006,27 @@ describe('im.message.receive_v1 — ack-safe duplicate delivery', () => {
     await flushEventWork();
 
     expect(handlers.handleNewTopic).toHaveBeenCalledTimes(1);
+  });
+
+  it('processes two id-less events instead of dropping one (fallback key never collides)', async () => {
+    const makeIdless = (text: string) => {
+      const e = makeUserMessageEvent({
+        senderOpenId: USER_OPEN_ID,
+        content: JSON.stringify({ text }),
+        chatId: 'chat-unkeyable',
+        chatType: 'group',
+        mentions: [{ key: '@_bot_a', name: 'BotA', id: { open_id: MY_OPEN_ID } }],
+      });
+      // Strip every id so both events take the unkeyable fallback path. A
+      // content-prefix fallback key would collide here and silently drop one.
+      return { ...e, uuid: undefined, event_id: undefined, message: { ...e.message, message_id: undefined } };
+    };
+
+    capturedHandlers['im.message.receive_v1'](makeIdless('@BotA first'));
+    capturedHandlers['im.message.receive_v1'](makeIdless('@BotA second'));
+    await flushEventWork();
+
+    expect(handlers.handleNewTopic).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -87,7 +87,8 @@ vi.mock('@larksuiteoapi/node-sdk', () => {
 
 // ─── Imports (must be after mocks) ──────────────────────────────────────────
 
-import { canOperate, canTalk, ensureBotOpenId, isBotMentioned, startLarkEventDispatcher, writeBotInfoFile, type EventHandlers } from '../src/im/lark/event-dispatcher.js';
+import { __resetAnchorQueues } from '../src/utils/anchor-serializer.js';
+import { __resetEventClaimsForTest, canOperate, canTalk, ensureBotOpenId, isBotMentioned, startLarkEventDispatcher, writeBotInfoFile, type EventHandlers } from '../src/im/lark/event-dispatcher.js';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -95,6 +96,11 @@ const MY_APP_ID = 'app-bot-a';
 const MY_OPEN_ID = 'ou_bot_a_open_id';
 const OTHER_BOT_OPEN_ID = 'ou_bot_b_open_id';
 const USER_OPEN_ID = 'ou_user_123';
+
+async function flushEventWork() {
+  await new Promise(resolve => setImmediate(resolve));
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
 
 function setupBotState(opts?: { botOpenId?: string | undefined; chatGrants?: Record<string, string[]>; globalGrants?: string[]; allowedUsers?: string[]; restrictGrantCommands?: boolean }) {
   mockGetBot.mockReturnValue({
@@ -249,6 +255,8 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
 
   beforeEach(() => {
     capturedHandlers = {};
+    __resetAnchorQueues();
+    __resetEventClaimsForTest();
     mockReplyMessage.mockClear();
     mockRecordObservedBots.mockClear();
     setupBotState();
@@ -274,7 +282,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(mockReplyMessage).toHaveBeenCalledWith(
       MY_APP_ID,
@@ -306,7 +314,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     const handler = capturedHandlers['im.message.receive_v1'];
     expect(handler).toBeDefined();
     await handler(event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
       anchor: 'root-thread-1',
@@ -324,7 +332,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
       anchor: 'root-thread-2',
@@ -341,7 +349,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
@@ -366,7 +374,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     handlers.isSessionOwner.mockReturnValue(false);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
@@ -389,7 +397,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     handlers.isSessionOwner.mockReturnValue(false);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
       scope: 'chat',
@@ -417,7 +425,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     handlers.isSessionOwner.mockReturnValue(false);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
       scope: 'chat',
@@ -448,7 +456,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     handlers.isSessionOwner.mockReturnValue(false);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
@@ -472,7 +480,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     handlers.isSessionOwner.mockReturnValue(false);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
       scope: 'chat',
@@ -498,7 +506,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     handlers.isSessionOwner.mockReturnValue(false);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
@@ -522,7 +530,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     handlers.isSessionOwner.mockReturnValue(false);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
       scope: 'chat',
@@ -554,7 +562,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     handlers.isSessionOwner.mockReturnValue(false);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
       scope: 'chat',
@@ -579,7 +587,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     event.message.root_id = undefined as any;
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
@@ -597,7 +605,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
       anchor: 'root-thread-oncall-close',
@@ -629,7 +637,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
@@ -695,7 +703,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleNewTopic).toHaveBeenCalledWith(event, expect.objectContaining({
       scope: 'chat',
@@ -713,7 +721,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
       anchor: 'root-thread-4',
@@ -730,7 +738,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
   });
@@ -747,7 +755,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     mockListChatBotMembers.mockResolvedValue([{ openId: MY_OPEN_ID, name: 'BotA' }]);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
       anchor: 'root-thread-6',
@@ -774,7 +782,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     ]);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     // No @mention → should NOT be routed even though bot owns session
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
@@ -797,7 +805,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     ]);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
       anchor: 'root-thread-8',
@@ -827,7 +835,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     mockListChatBotMembers.mockResolvedValue([{ openId: MY_OPEN_ID, name: 'BotA' }]);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
       scope: 'chat',
@@ -857,7 +865,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     mockListChatBotMembers.mockResolvedValue([{ openId: MY_OPEN_ID, name: 'BotA' }]);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleNewTopic).toHaveBeenCalledWith(event, expect.objectContaining({
       scope: 'thread',
@@ -881,7 +889,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     mockListChatBotMembers.mockResolvedValue([{ openId: MY_OPEN_ID, name: 'BotA' }]);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
       scope: 'thread',
@@ -906,7 +914,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     ]);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
   });
@@ -962,6 +970,8 @@ describe('im.message.receive_v1 — stale chat-scope detection (group → topic 
 
   beforeEach(() => {
     capturedHandlers = {};
+    __resetAnchorQueues();
+    __resetEventClaimsForTest();
     setupBotState();
     handlers = makeHandlers();
     mockIsChatOncallBoundForAnyBot.mockReturnValue(false);
@@ -986,7 +996,7 @@ describe('im.message.receive_v1 — stale chat-scope detection (group → topic 
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     // Reroutes: scope='thread', anchor=messageId → handleNewTopic seeds a new
     // thread session, NOT handleThreadReply on the stale chat-scope owner.
@@ -1014,7 +1024,7 @@ describe('im.message.receive_v1 — stale chat-scope detection (group → topic 
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
       scope: 'chat',
@@ -1042,7 +1052,7 @@ describe('im.message.receive_v1 — stale chat-scope detection (group → topic 
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     const forceRefreshCalls = mockGetChatMode.mock.calls.filter(
       ([, , options]) => (options as { forceRefresh?: boolean } | undefined)?.forceRefresh === true,
@@ -1066,6 +1076,8 @@ describe('im.message.receive_v1 — stale topic detection (topic → group conve
 
   beforeEach(() => {
     capturedHandlers = {};
+    __resetAnchorQueues();
+    __resetEventClaimsForTest();
     setupBotState();
     handlers = makeHandlers();
     mockIsChatOncallBoundForAnyBot.mockReturnValue(false);
@@ -1090,7 +1102,7 @@ describe('im.message.receive_v1 — stale topic detection (topic → group conve
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     // Reroutes: scope='chat', anchor=chatId → bot replies via sendMessage(chatId),
     // not replyMessage(messageId, reply_in_thread=true).
@@ -1119,7 +1131,7 @@ describe('im.message.receive_v1 — stale topic detection (topic → group conve
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleNewTopic).toHaveBeenCalledWith(event, expect.objectContaining({
       scope: 'thread',
@@ -1149,7 +1161,7 @@ describe('im.message.receive_v1 — stale topic detection (topic → group conve
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     const forceRefreshCalls = mockGetChatMode.mock.calls.filter(
       ([, , options]) => (options as { forceRefresh?: boolean } | undefined)?.forceRefresh === true,
@@ -1181,7 +1193,7 @@ describe('im.message.receive_v1 — stale topic detection (topic → group conve
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleNewTopic).toHaveBeenCalledWith(event, expect.objectContaining({
       scope: 'thread',
@@ -1196,6 +1208,8 @@ describe('im.message.receive_v1 — /t force-topic override', () => {
 
   beforeEach(() => {
     capturedHandlers = {};
+    __resetAnchorQueues();
+    __resetEventClaimsForTest();
     setupBotState();
     handlers = makeHandlers();
     mockGetChatMode.mockResolvedValue('group'); // 普通群
@@ -1215,7 +1229,7 @@ describe('im.message.receive_v1 — /t force-topic override', () => {
     mockListChatBotMembers.mockResolvedValue([{ openId: MY_OPEN_ID, name: 'BotA' }]);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleNewTopic).toHaveBeenCalledWith(event, expect.objectContaining({
       scope: 'thread',
@@ -1241,7 +1255,7 @@ describe('im.message.receive_v1 — /t force-topic override', () => {
     mockListChatBotMembers.mockResolvedValue([{ openId: MY_OPEN_ID, name: 'BotA' }]);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleNewTopic).toHaveBeenCalledWith(event, expect.objectContaining({
       scope: 'thread',
@@ -1274,7 +1288,7 @@ describe('im.message.receive_v1 — /t force-topic override', () => {
     mockListChatBotMembers.mockResolvedValue([{ openId: MY_OPEN_ID, name: 'BotA' }]);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleNewTopic).toHaveBeenCalledWith(event, expect.objectContaining({
       scope: 'thread',
@@ -1296,7 +1310,7 @@ describe('im.message.receive_v1 — /t force-topic override', () => {
     mockListChatBotMembers.mockResolvedValue([{ openId: MY_OPEN_ID, name: 'BotA' }]);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     // No /t → routing stays chat-scope (anchor = chatId)
     expect(handlers.handleNewTopic).toHaveBeenCalledWith(event, expect.objectContaining({
@@ -1320,7 +1334,7 @@ describe('im.message.receive_v1 — /t force-topic override', () => {
     mockListChatBotMembers.mockResolvedValue([{ openId: MY_OPEN_ID, name: 'BotA' }]);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     // Already thread-scope → keep anchor = root_id, do NOT change to messageId.
     expect(handlers.handleNewTopic).toHaveBeenCalledWith(event, expect.objectContaining({
@@ -1346,7 +1360,7 @@ describe('im.message.receive_v1 — /t force-topic override', () => {
     mockListChatBotMembers.mockResolvedValue([{ openId: MY_OPEN_ID, name: 'BotA' }]);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleNewTopic).toHaveBeenCalledWith(event, expect.objectContaining({
       scope: 'thread',
@@ -1375,7 +1389,7 @@ describe('im.message.receive_v1 — /t force-topic override', () => {
     ]);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleNewTopic).toHaveBeenCalledWith(event, expect.objectContaining({
       scope: 'thread',
@@ -1402,7 +1416,7 @@ describe('im.message.receive_v1 — /t force-topic override', () => {
     mockListChatBotMembers.mockResolvedValue([{ openId: MY_OPEN_ID, name: 'BotA' }]);
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
@@ -1427,6 +1441,8 @@ describe('im.message.receive_v1 — 主动开工 场景② (autoStartOnNewTopic)
 
   beforeEach(() => {
     capturedHandlers = {};
+    __resetAnchorQueues();
+    __resetEventClaimsForTest();
     setupBotState();
     handlers = makeHandlers();
     handlers.isSessionOwner.mockReturnValue(false);
@@ -1445,7 +1461,7 @@ describe('im.message.receive_v1 — 主动开工 场景② (autoStartOnNewTopic)
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleNewTopic).toHaveBeenCalledWith(event, expect.objectContaining({
       scope: 'thread',
@@ -1466,7 +1482,7 @@ describe('im.message.receive_v1 — 主动开工 场景② (autoStartOnNewTopic)
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
@@ -1484,7 +1500,7 @@ describe('im.message.receive_v1 — 主动开工 场景② (autoStartOnNewTopic)
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
   });
@@ -1503,7 +1519,7 @@ describe('im.message.receive_v1 — 主动开工 场景② (autoStartOnNewTopic)
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
@@ -1516,6 +1532,8 @@ describe('im.message.receive_v1 — /introduce command', () => {
 
   beforeEach(() => {
     capturedHandlers = {};
+    __resetAnchorQueues();
+    __resetEventClaimsForTest();
     setupBotState();
     handlers = makeHandlers();
     mockIsChatOncallBoundForAnyBot.mockReturnValue(false);
@@ -1552,7 +1570,7 @@ describe('im.message.receive_v1 — /introduce command', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(mockRecordObservedBots).toHaveBeenCalledTimes(1);
     const [, larkAppIdArg, chatIdArg, botsArg, sourceArg] = mockRecordObservedBots.mock.calls[0];
@@ -1577,7 +1595,7 @@ describe('im.message.receive_v1 — /introduce command', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(mockRecordObservedBots).toHaveBeenCalledTimes(1);
     const [, , , botsArg] = mockRecordObservedBots.mock.calls[0];
@@ -1597,7 +1615,7 @@ describe('im.message.receive_v1 — /introduce command', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(mockReplyMessage).toHaveBeenCalledTimes(1);
     const [larkAppIdArg, messageIdArg, contentArg] = mockReplyMessage.mock.calls[0];
@@ -1615,7 +1633,7 @@ describe('im.message.receive_v1 — /introduce command', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
@@ -1629,7 +1647,7 @@ describe('im.message.receive_v1 — /introduce command', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(mockRecordObservedBots).not.toHaveBeenCalled();
     expect(mockReplyMessage).not.toHaveBeenCalled();
@@ -1641,7 +1659,7 @@ describe('im.message.receive_v1 — /introduce command', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(mockRecordObservedBots).not.toHaveBeenCalled();
     expect(mockReplyMessage).not.toHaveBeenCalled();
@@ -1655,7 +1673,7 @@ describe('im.message.receive_v1 — /introduce command', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
@@ -1671,7 +1689,7 @@ describe('im.message.receive_v1 — /introduce command', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(mockRecordObservedBots).not.toHaveBeenCalled();
     expect(mockReplyMessage).not.toHaveBeenCalled();
@@ -1689,7 +1707,7 @@ describe('im.message.receive_v1 — /introduce command', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(mockRecordObservedBots).toHaveBeenCalledTimes(1);
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
@@ -1706,7 +1724,7 @@ describe('im.message.receive_v1 — /introduce command', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     const [, , , botsArg] = mockRecordObservedBots.mock.calls[0];
     expect((botsArg as Array<{ openId: string }>).map(b => b.openId).sort())
@@ -1727,7 +1745,7 @@ describe('im.message.receive_v1 — /introduce command', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(mockRecordObservedBots).toHaveBeenCalled();   // 任何人都能登记
     expect(mockReplyMessage).toHaveBeenCalled();          // 仍然回执 ack
@@ -1749,7 +1767,7 @@ describe('im.message.receive_v1 — /introduce command', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(mockRecordObservedBots).not.toHaveBeenCalled();
   });
@@ -1768,7 +1786,7 @@ describe('im.message.receive_v1 — /introduce command', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(mockRecordObservedBots).not.toHaveBeenCalled();
     expect(mockReplyMessage).not.toHaveBeenCalled();
@@ -1788,7 +1806,7 @@ describe('im.message.receive_v1 — /introduce command', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(mockRecordObservedBots).toHaveBeenCalledTimes(1);
   });
@@ -1819,11 +1837,70 @@ describe('im.message.receive_v1 — /introduce command', () => {
     });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
 
     expect(mockRecordObservedBots).toHaveBeenCalledTimes(1);
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+  });
+});
+
+describe('im.message.receive_v1 — ack-safe duplicate delivery', () => {
+  let handlers: ReturnType<typeof makeHandlers>;
+
+  beforeEach(() => {
+    capturedHandlers = {};
+    __resetAnchorQueues();
+    __resetEventClaimsForTest();
+    mockReplyMessage.mockClear();
+    mockRecordObservedBots.mockClear();
+    setupBotState({ allowedUsers: [USER_OPEN_ID] });
+    handlers = makeHandlers();
+    mockIsChatOncallBoundForAnyBot.mockReturnValue(false);
+    mockFindOncallChat.mockReturnValue(undefined);
+    mockGetChatMode.mockResolvedValue('group');
+    startLarkEventDispatcher(MY_APP_ID, 'secret', handlers);
+  });
+
+  it('returns before slow message processing settles so Lark can ACK promptly', async () => {
+    let release!: () => void;
+    const slowWork = new Promise<void>(resolve => { release = resolve; });
+    handlers.handleNewTopic.mockImplementation(async () => slowWork);
+
+    const event = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: '@BotA slow work' }),
+      messageId: 'msg-ack-fast',
+      chatId: 'chat-ack-fast',
+      chatType: 'group',
+      mentions: [{ key: '@_bot_a', name: 'BotA', id: { open_id: MY_OPEN_ID } }],
+    });
+
+    const call = capturedHandlers['im.message.receive_v1'](event);
+    await expect(Promise.resolve(call)).resolves.toBeUndefined();
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+
+    await new Promise(resolve => setImmediate(resolve));
+    expect(handlers.handleNewTopic).toHaveBeenCalledTimes(1);
+    release();
+    await flushEventWork();
+  });
+
+  it('dedupes timeout redelivery of the same message_id', async () => {
+    const event = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: '@BotA handle once' }),
+      messageId: 'msg-dedupe-once',
+      chatId: 'chat-dedupe-once',
+      chatType: 'group',
+      mentions: [{ key: '@_bot_a', name: 'BotA', id: { open_id: MY_OPEN_ID } }],
+    });
+
+    capturedHandlers['im.message.receive_v1'](event);
+    capturedHandlers['im.message.receive_v1']({ ...event, uuid: undefined, event_id: undefined });
+    await flushEventWork();
+
+    expect(handlers.handleNewTopic).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -1905,6 +1982,8 @@ describe('im.message.receive_v1 — botOpenId startup race', () => {
 
   beforeEach(() => {
     capturedHandlers = {};
+    __resetAnchorQueues();
+    __resetEventClaimsForTest();
     mockReplyMessage.mockClear();
     mockRecordObservedBots.mockClear();
     setupBotState();
@@ -1931,7 +2010,7 @@ describe('im.message.receive_v1 — botOpenId startup race', () => {
     const event = makeBotMessageEvent({ senderOpenId: OTHER_BOT_OPEN_ID, content: postContent, rootId: 'root-race-1' });
 
     await capturedHandlers['im.message.receive_v1'](event);
-    await new Promise(r => setTimeout(r, 0));
+    await flushEventWork();
     // Routing runs through serializeByAnchor (fire-and-forget); let its
     // microtask chain settle before asserting.
     await new Promise(resolve => setTimeout(resolve, 0));

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -43,6 +43,7 @@ const mockListChatBotMembers = vi.fn(async () => [] as Array<{ openId: string; n
 const mockGetChatMode = vi.fn(async () => 'topic' as 'group' | 'topic' | 'p2p');
 const mockGetChatInfo = vi.fn(async () => ({ userCount: 1, botCount: 1 }));
 const mockReplyMessage = vi.fn(async () => 'msg-id');
+const mockUpdateMessage = vi.fn(async () => true);
 // 默认所有 open_id 都判为「非真人」（bot）→ 保持既有用例「全部登记」的预期；
 // 需要模拟真人的用例用 mockResolvedValueOnce(true)。
 const mockIsHumanOpenId = vi.fn(async () => false);
@@ -51,6 +52,7 @@ vi.mock('../src/im/lark/client.js', () => ({
   getChatMode: (...args: any[]) => mockGetChatMode(...args),
   listChatBotMembers: (...args: any[]) => mockListChatBotMembers(...args),
   replyMessage: (...args: any[]) => mockReplyMessage(...args),
+  updateMessage: (...args: any[]) => mockUpdateMessage(...args),
   isHumanOpenId: (...args: any[]) => mockIsHumanOpenId(...args),
 }));
 
@@ -1842,6 +1844,72 @@ describe('im.message.receive_v1 — /introduce command', () => {
     expect(mockRecordObservedBots).toHaveBeenCalledTimes(1);
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
     expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+  });
+});
+
+describe('card.action.trigger — ack-safe slow handlers', () => {
+  let handlers: ReturnType<typeof makeHandlers>;
+
+  beforeEach(() => {
+    capturedHandlers = {};
+    __resetAnchorQueues();
+    __resetEventClaimsForTest();
+    mockUpdateMessage.mockClear();
+    setupBotState();
+    handlers = makeHandlers();
+    startLarkEventDispatcher(MY_APP_ID, 'secret', handlers);
+  });
+
+  it('preserves immediate card action responses when the handler is fast', async () => {
+    handlers.handleCardAction.mockResolvedValue({ type: 'updated-card' });
+
+    const result = await capturedHandlers['card.action.trigger']({
+      action: { value: { action: 'toggle_stream', root_id: 'root-fast' } },
+      operator: { open_id: USER_OPEN_ID },
+      context: { open_message_id: 'om_fast_card' },
+    });
+
+    expect(result).toEqual({ card: { type: 'raw', data: { type: 'updated-card' } } });
+    expect(mockUpdateMessage).not.toHaveBeenCalled();
+  });
+
+  it('returns a toast before a slow handler settles, then patches the card in background', async () => {
+    let release!: () => void;
+    const slow = new Promise(resolve => { release = () => resolve({ type: 'late-card' }); });
+    handlers.handleCardAction.mockReturnValue(slow as any);
+
+    vi.useFakeTimers();
+    const call = capturedHandlers['card.action.trigger']({
+      action: { value: { action: 'toggle_stream', root_id: 'root-slow' } },
+      operator: { open_id: USER_OPEN_ID },
+      context: { open_message_id: 'om_slow_card' },
+    });
+    await vi.advanceTimersByTimeAsync(2500);
+    await expect(call).resolves.toEqual({ toast: { type: 'info', content: '操作已收到，后台处理中' } });
+
+    release();
+    await vi.runAllTimersAsync();
+    vi.useRealTimers();
+
+    expect(mockUpdateMessage).toHaveBeenCalledWith(MY_APP_ID, 'om_slow_card', JSON.stringify({ type: 'late-card' }));
+  });
+
+  it('dedupes a repeated card action while the first copy is still running', async () => {
+    let release!: () => void;
+    handlers.handleCardAction.mockReturnValue(new Promise(resolve => { release = () => resolve(undefined); }) as any);
+    const event = {
+      action: { value: { action: 'restart', root_id: 'root-dup' } },
+      operator: { open_id: USER_OPEN_ID },
+      context: { open_message_id: 'om_dup_card' },
+    };
+
+    const first = capturedHandlers['card.action.trigger'](event);
+    const second = await capturedHandlers['card.action.trigger']({ ...event });
+
+    expect(second).toEqual({ toast: { type: 'info', content: '操作正在处理中，请稍候' } });
+    expect(handlers.handleCardAction).toHaveBeenCalledTimes(1);
+    release();
+    await first;
   });
 });
 


### PR DESCRIPTION
## 这个 PR 解决什么问题

飞书要求事件回调要「秒回」（快速 ACK）。但 botmux 收到消息后，会先做一串网络查询（查群信息、群模式、群成员、判断发消息的是不是真人……），再决定怎么开会话——这些加起来可能要好几秒。回调被这些慢活拖住，飞书以为我们没收到，就把同一条事件重发一遍，结果同一句话被处理两次、同一个会话被开两次。

卡片按钮也有同样的毛病：点一下「重启」这类按钮会去拉起 CLI 进程，处理慢了，飞书那边的卡片回调也会超时（client error 200341）。

> 调研确认：Lark WS SDK 是 **await 完 handler 才发唯一一帧 ACK**，3s 预算内必须返回；事件重推梯度 15s/5min/1h/6h（max 4）且 pipeline 是 at-least-once；**卡片回调同步、无补推**，超时只影响 UX。

## 改了什么

1. **消息事件、被拉群事件：先回执，再后台干活**
   收到事件后立刻返回（让飞书第一时间拿到 ACK），真正耗时的处理丢到后台 `setImmediate` 异步跑。

2. **加一道去重闸**
   用事件自带的 id（`event_id` / `uuid`，没有就退用 `message_id`）记一笔，短时间内同一个事件再来就直接丢掉，挡住「飞书超时重投 → 同一句话干两遍」。

3. **卡片按钮：处理慢了也先回个话**
   2.5 秒内处理完就正常返回、卡片照常更新；超时就先回一个 toast「操作已收到，后台处理中」让飞书别再等，等真正处理完再后台把卡片补刷成最终样子。

## 评审后补强（在上面基础上）

- **卡片动作改持久 claim（按 event_id）**：原本只在「处理中」去重，完成后被同一交互重投/重复触发会让 `restart`/`close` **二次执行**；无 event_id 的回退仍只做并发保护，不误伤合法重复点击（如 toggle 流式开/关）。
- **去重 TTL 60min→2h**：对齐飞书 15s/5min/1h 重推梯度，并加按时间间隔的剪枝，防 claim map 随调用频率无界增长。
- **超时分支不再静默吞「仅 toast」的慢结果**（ACK 后补不了 toast，改为告警日志）。
- **消息无 id 兜底键**由「内容前 200 字符」改为单调唯一键，杜绝前缀碰撞误丢真实消息。
- `Symbol.for`→模块级 Symbol 哨兵；补「claim+setImmediate 必须同步」的顺序不变量注释。

## 测试

- `pnpm vitest run test/event-dispatcher.test.ts` → 84/84
- `pnpm tsc --noEmit` 干净
- 全量 28 daemon 本地实跑验证通过
