### PR TITLE
feat(traex): 新增 TRAE CLI (traex / traecli) 适配器

### DIFF
--- a/src/adapters/cli/registry.ts
+++ b/src/adapters/cli/registry.ts
@@ -16,6 +16,7 @@ import { createAntigravityAdapter } from './antigravity.js';
 import { createMtrAdapter } from './mtr.js';
 import { createHermesAdapter } from './hermes.js';
 import { createMiraAdapter } from './mira.js';
+import { createTraexAdapter } from './traex.js';
 
 /** Resolve a command name to its absolute path via shell `which`.
  *  Tries login shell first (-lc), then interactive shell (-ic) for tools
@@ -98,7 +99,7 @@ export async function createCliAdapter(id: CliId, pathOverride?: string): Promis
   return adapter;
 }
 
-export { createClaudeCodeAdapter, createSeedAdapter, createAidenAdapter, createCocoAdapter, createCodexAdapter, createCodexAppAdapter, createCursorAdapter, createGeminiAdapter, createOpenCodeAdapter, createAntigravityAdapter, createMtrAdapter, createHermesAdapter, createMiraAdapter };
+export { createClaudeCodeAdapter, createSeedAdapter, createAidenAdapter, createCocoAdapter, createCodexAdapter, createCodexAppAdapter, createCursorAdapter, createGeminiAdapter, createOpenCodeAdapter, createAntigravityAdapter, createMtrAdapter, createHermesAdapter, createMiraAdapter, createTraexAdapter };
 
 /** Synchronous version for use in worker process. */
 export function createCliAdapterSync(id: CliId, pathOverride?: string): CliAdapter {
@@ -116,6 +117,7 @@ export function createCliAdapterSync(id: CliId, pathOverride?: string): CliAdapt
     case 'mtr': return createMtrAdapter(pathOverride);
     case 'hermes': return createHermesAdapter(pathOverride);
     case 'mira': return createMiraAdapter(pathOverride);
+    case 'traex': return createTraexAdapter(pathOverride);
     default: throw new Error(`Unknown CLI adapter: ${id}`);
   }
 }

--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -1,0 +1,259 @@
+import { existsSync } from 'node:fs';
+import { resolveCommand } from './registry.js';
+import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
+import type { CliAdapter, PtyHandle } from './types.js';
+import { traeStateDbPath } from '../../services/traex-paths.js';
+
+/**
+ * TRAE CLI (a.k.a. traex / traecli) adapter.
+ *
+ * TRAE is a Codex-family CLI — it shares the same bracketed-paste input
+ * protocol, `--dangerously-bypass-approvals-and-sandbox` / `--no-alt-screen`
+ * flags, `resume <uuid>` subcommand, and `›` prompt marker.
+ *
+ * The important difference from the upstream Codex adapter:
+ *   - Data lives under ~/.trae (not ~/.codex), configurable via TRAE_HOME.
+ *   - There is no global history.jsonl. The per-session rollout JSONL format
+ *     is identical, but submit verification falls back to scanning the
+ *     threads SQLite table (state_5.sqlite) whose `first_user_message`
+ *     column is written synchronously when the CLI commits a user submit.
+ *   - Skills are installed into ~/.trae/skills.
+ */
+
+function delay(ms: number): Promise<void> {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+function normaliseHistoryText(text: string): string {
+  return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+function textMatches(actual: string, expected: string): boolean {
+  if (actual === expected) return true;
+  const na = normaliseHistoryText(actual);
+  const ne = normaliseHistoryText(expected);
+  if (na === ne) return true;
+  // first_user_message may be truncated by SQLite substr / UI. Accept a
+  // prefix match when expected is longer than what the DB recorded.
+  if (na.length > 0 && (ne.startsWith(na) || na.startsWith(ne.slice(0, na.length)))) return true;
+  return false;
+}
+
+// -- SQLite helpers (node:sqlite, Node 22+ experimental) -----------------
+
+type DatabaseSyncLike = {
+  prepare(sql: string): StatementSyncLike;
+  close(): void;
+};
+type StatementSyncLike = {
+  get(...params: unknown[]): any;
+  all(...params: unknown[]): any[];
+};
+
+let sqliteModule: { DatabaseSync: new (path: string) => DatabaseSyncLike } | null = null;
+let sqliteLoadAttempted = false;
+
+function loadSqlite(): typeof sqliteModule {
+  if (sqliteLoadAttempted) return sqliteModule;
+  sqliteLoadAttempted = true;
+  // node:sqlite is the built-in experimental SQLite binding available in
+  // Node 22+. It requires --experimental-sqlite at the time of writing
+  // (2026-06), but the import succeeds even without the flag; the first
+  // `new DatabaseSync(...)` throws if the runtime didn't opt in. We swallow
+  // that at query time and degrade gracefully.
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    sqliteModule = require('node:sqlite') as typeof sqliteModule;
+  } catch {
+    sqliteModule = null;
+  }
+  return sqliteModule;
+}
+
+function withDb<T>(fn: (db: DatabaseSyncLike) => T): T | null {
+  const mod = loadSqlite();
+  if (!mod) return null;
+  const dbPath = traeStateDbPath();
+  if (!existsSync(dbPath)) return null;
+  let db: DatabaseSyncLike | undefined;
+  try {
+    db = new mod.DatabaseSync(dbPath);
+    return fn(db);
+  } catch {
+    return null;
+  } finally {
+    try { db?.close(); } catch { /* ignore */ }
+  }
+}
+
+/** Snapshot of the newest thread's (id, updated_at_ms, first_user_message)
+ *  immediately before a submit. Used after the paste+Enter to detect a new
+ *  row (first turn) or a changed first_user_message (unlikely but cheap to
+ *  check alongside id+updated_at_ms). */
+interface ThreadSnapshot {
+  id?: string;
+  updatedAtMs?: number;
+  firstMessage?: string;
+}
+
+function snapLatestThread(): ThreadSnapshot {
+  return withDb((db) => {
+    const row = db.prepare(
+      'SELECT id, updated_at_ms AS updatedAtMs, first_user_message AS firstMessage ' +
+      'FROM threads ORDER BY updated_at_ms DESC LIMIT 1',
+    ).get() as ThreadSnapshot | undefined;
+    return row ?? { };
+  }) ?? { };
+}
+
+/** Return { found, cliSessionId } if, compared to `before`, a newer thread
+ *  now exists whose first_user_message matches `expectedText`. */
+function detectNewThread(before: ThreadSnapshot, expectedText: string): { found: boolean; cliSessionId?: string } {
+  return withDb((db) => {
+    const rows = db.prepare(
+      'SELECT id, updated_at_ms AS updatedAtMs, first_user_message AS firstMessage ' +
+      'FROM threads WHERE updated_at_ms >= COALESCE(?, 0) ORDER BY updated_at_ms DESC LIMIT 5',
+    ).all(before.updatedAtMs ?? 0) as ThreadSnapshot[];
+    for (const r of rows) {
+      // Skip the exact row we saw before (same id AND same timestamp).
+      if (r.id && before.id && r.id === before.id && r.updatedAtMs === before.updatedAtMs) continue;
+      if (r.firstMessage && textMatches(r.firstMessage, expectedText)) {
+        return { found: true, cliSessionId: r.id };
+      }
+      // A fresh thread whose first_message is empty so far (still being
+      // written) will be caught on a later poll.
+    }
+    return { found: false };
+  }) ?? { found: false };
+}
+
+/** Scan threads backwards for the most recent thread whose first_user_message
+ *  references the botmux session id. Used by buildArgs(resume) and
+ *  buildResumeCommand to recover a TRAE-native session UUID from a botmux
+ *  session id. */
+function latestTraeSessionForBotmuxSession(botmuxSessionId: string): string | undefined {
+  return withDb((db) => {
+    const rows = db.prepare(
+      'SELECT id, first_user_message AS firstMessage FROM threads ORDER BY created_at DESC LIMIT 200',
+    ).all() as { id: string; firstMessage?: string }[];
+    for (const r of rows) {
+      if (r.firstMessage && r.firstMessage.includes(botmuxSessionId)) return r.id;
+    }
+    return undefined;
+  }) ?? undefined;
+}
+
+// -------------------------------------------------------------------------
+
+export function createTraexAdapter(pathOverride?: string): CliAdapter {
+  const rawBin = pathOverride ?? 'traex';
+  let cachedBin: string | undefined;
+  return {
+    id: 'traex',
+    get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
+
+    buildArgs({ sessionId, resume, resumeSessionId, workingDir, model, disableCliBypass }) {
+      const baseArgs = [
+        ...(!disableCliBypass ? ['--dangerously-bypass-approvals-and-sandbox'] : []),
+        '--no-alt-screen',
+      ];
+      if (model && model.trim()) baseArgs.push('--model', model.trim());
+      if (workingDir) baseArgs.push('-C', workingDir);
+      if (!resume) return baseArgs;
+
+      const traeSessionId = resumeSessionId ?? latestTraeSessionForBotmuxSession(sessionId);
+      if (!traeSessionId) return baseArgs;
+      return ['resume', ...baseArgs, traeSessionId];
+    },
+
+    buildResumeCommand({ sessionId, cliSessionId }) {
+      const sid = cliSessionId ?? latestTraeSessionForBotmuxSession(sessionId);
+      if (!sid) return null;
+      return `traex resume ${sid}`;
+    },
+
+    async writeInput(pty: PtyHandle, content: string) {
+      // Same bracketed-paste strategy as the Codex adapter: multi-line user
+      // messages must not be split into separate turns by embedded \n.
+      const trySendEnter = (): boolean => {
+        try {
+          if (pty.sendSpecialKeys) pty.sendSpecialKeys('Enter');
+          else pty.write('\r');
+          return true;
+        } catch {
+          return false;
+        }
+      };
+
+      // Take the snapshot BEFORE the paste so we can tell a newly-appeared
+      // thread from pre-existing ones.
+      const beforeSnap = snapLatestThread();
+
+      try {
+        if (pty.pasteText) pty.pasteText(content);
+        else pty.write('\x1b[200~' + content + '\x1b[201~');
+      } catch {
+        return { submitted: false };
+      }
+      await delay(200);
+      if (!trySendEnter()) return { submitted: false };
+
+      // SQLite-backed submit verification. When node:sqlite is unavailable
+      // or the DB is missing (first run), we short-circuit and return
+      // undefined ("no verification performed, assume OK") — same behaviour
+      // as the Hermes / Aiden adapters.
+      const canVerify = loadSqlite() && existsSync(traeStateDbPath());
+      if (!canVerify) return undefined;
+
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const match = detectNewThread(beforeSnap, content);
+        if (match.found) {
+          return match.cliSessionId
+            ? { submitted: true, cliSessionId: match.cliSessionId }
+            : { submitted: true };
+        }
+        await delay(800);
+        if (!trySendEnter()) return { submitted: false };
+      }
+      const finalMatch = detectNewThread(beforeSnap, content);
+      if (finalMatch.found) {
+        return finalMatch.cliSessionId
+          ? { submitted: true, cliSessionId: finalMatch.cliSessionId }
+          : { submitted: true };
+      }
+      const recheck = () => {
+        const late = detectNewThread(beforeSnap, content);
+        return late.found
+          ? { submitted: true, cliSessionId: late.cliSessionId }
+          : false;
+      };
+      return { submitted: false, recheck };
+    },
+
+    completionPattern: undefined,
+    // TRAE's prompt indicator is identical to Codex's `›`. The status bar
+    // does not currently surface a "% left" counter, so only `›` is needed.
+    readyPattern: /›/,
+    systemHints: BOTMUX_SHELL_HINTS,
+    // TRAE 0.200+ shares Codex's type-ahead behaviour: input submitted while
+    // a turn is running is parked and merged into the active turn.
+    supportsTypeAhead: true,
+    altScreen: false,
+    skillsDir: '~/.trae/skills',
+    // Curated subset — the full catalogue has 27 models. `traex debug models`
+    // lists the rest; the setup flow always appends an "Other / custom"
+    // free-text option so users aren't locked out.
+    modelChoices: [
+      'Seed-Dogfooding-2.0',
+      'Doubao-Seed-2.0-Code',
+      'gpt-5.5',
+      'gpt-5',
+      'o3',
+      'Doubao_1_8',
+      'DeepSeek-V4-Pro',
+      'kimi-k2.6',
+    ],
+  };
+}
+
+export const create = createTraexAdapter;

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -197,4 +197,4 @@ export interface CliAdapter {
   readonly spawnEnv?: Readonly<Record<string, string>>;
 }
 
-export type CliId = 'claude-code' | 'seed' | 'aiden' | 'coco' | 'codex' | 'codex-app' | 'cursor' | 'gemini' | 'opencode' | 'antigravity' | 'mtr' | 'hermes' | 'mira';
+export type CliId = 'claude-code' | 'seed' | 'aiden' | 'coco' | 'codex' | 'codex-app' | 'cursor' | 'gemini' | 'opencode' | 'antigravity' | 'mtr' | 'hermes' | 'mira' | 'traex';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -664,7 +664,7 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
   }
   console.log('✅ 凭证有效（tenant_access_token 已成功获取）\n');
 
-  console.log('支持的 CLI: 1) claude-code  2) aiden  3) coco（别名 traecli）  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed');
+  console.log('支持的 CLI: 1) claude-code  2) aiden  3) coco（别名 traecli）  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed  14) traex');
   const cliChoice = await ask(rl, 'CLI 适配器 [1]: ');
   let cliId: CliId;
   try {
@@ -842,7 +842,7 @@ async function promptEditBotConfig(
   ]);
   input.larkAppSecret = await ask(rl, `LARK_APP_SECRET [保留当前值]: `);
 
-  console.log('\n支持的 CLI: 1) claude-code  2) aiden  3) coco（别名 traecli）  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed');
+  console.log('\n支持的 CLI: 1) claude-code  2) aiden  3) coco（别名 traecli）  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed  14) traex');
   printInputHelp('CLI 适配器', [
     '选择 botmux 需要套用哪一种 CLI 参数协议和会话恢复方式。',
     'coco 的别名 traecli 走同一适配器；二进制名是 traecli 也选 coco 即可。',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -21,6 +21,7 @@ const cliDisplayNames: Record<CliId, string> = {
   'mtr': 'MTR',
   'hermes': 'Hermes',
   'mira': 'Mira',
+  'traex': 'TRAE',
 };
 
 export function getCliDisplayName(cliId: CliId): string {

--- a/src/services/traex-paths.ts
+++ b/src/services/traex-paths.ts
@@ -1,0 +1,29 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+function expandHome(path: string): string {
+  return path.startsWith('~') ? join(homedir(), path.slice(1)) : path;
+}
+
+/** TRAE CLI (traex / traecli) stores config, state DB, sessions, and skills
+ *  under TRAE_HOME when set; otherwise it defaults to ~/.trae. Keep this
+ *  dynamic so tests and child processes that set TRAE_HOME after module load
+ *  still resolve correctly. */
+export function traeHome(): string {
+  const configured = process.env.TRAE_HOME?.trim();
+  return configured ? expandHome(configured) : join(homedir(), '.trae');
+}
+
+/** SQLite database holding the `threads` table (one row per interactive
+ *  session). Used as the submit-verification source of truth because traex
+ *  (unlike codex) does not write a flat history.jsonl. */
+export function traeStateDbPath(): string {
+  return join(traeHome(), 'cli', 'state_5.sqlite');
+}
+
+/** Per-session rollout JSONL files live under dates here, e.g.
+ *  sessions/2026/06/04/rollout-<timestamp>-<uuid>.jsonl. The threads table
+ *  stores the absolute path per session. */
+export function traeSessionsRoot(): string {
+  return join(traeHome(), 'cli', 'sessions');
+}

--- a/src/services/traex-transcript.ts
+++ b/src/services/traex-transcript.ts
@@ -1,0 +1,111 @@
+/**
+ * Reader for TRAE CLI (traex / traecli) per-session rollout JSONL.
+ *
+ * TRAE is a Codex-family CLI:
+ *   - Rollout content format is byte-identical to Codex (response_item with
+ *     role=user / role=assistant+phase=final_answer message blocks).
+ *   - Directory layout differs: sessions live under
+ *     ~/.trae/cli/sessions/<YYYY>/<MM>/<DD>/rollout-<ts>-<uuid>.jsonl
+ *     (note the extra `cli/` level vs Codex's ~/.codex/sessions/...).
+ *
+ * This module therefore re-exports drainCodexRollout and friends directly,
+ * and only provides TRAE-specific path finders (by pid / by session id).
+ */
+import { existsSync, statSync, readdirSync, readlinkSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { platform } from 'node:os';
+import { join } from 'node:path';
+import {
+  drainCodexRollout,
+  splitCodexEventsByCutoff,
+  extractLastCodexTurn,
+  type CodexBridgeEvent,
+  type CodexDrainResult,
+  codexSessionIdFromRolloutPath,
+} from './codex-transcript.js';
+import { traeSessionsRoot } from './traex-paths.js';
+
+export { drainCodexRollout as drainTraexRollout };
+export { splitCodexEventsByCutoff as splitTraexEventsByCutoff };
+export { extractLastCodexTurn as extractLastTraexTurn };
+export type { CodexBridgeEvent as TraexBridgeEvent, CodexDrainResult as TraexDrainResult };
+
+const IS_LINUX = platform() === 'linux';
+
+function matchTraexRolloutPath(target: string): { path: string; cliSessionId: string } | undefined {
+  if (!target.endsWith('.jsonl')) return undefined;
+  // Accept both the default layout (~/.trae/cli/sessions/...) and any
+  // TRAE_HOME override the user may have configured.
+  if (!target.includes('/sessions/') && !target.includes('.trae')) {
+    // Fast reject: the path has neither the sessions subdir nor the default
+    // TRAE home marker. Avoid false positives against Codex rollouts which
+    // share the same rollout-*.jsonl filename shape.
+    if (!target.includes('/cli/sessions/')) return undefined;
+  }
+  const sid = codexSessionIdFromRolloutPath(target);
+  if (!sid) return undefined;
+  return { path: target, cliSessionId: sid };
+}
+
+/** Find the rollout file an externally-running TRAE process has open.
+ *  Same /proc/<pid>/fd strategy as findCodexRolloutByPid, but with a
+ *  TRAE-specific path matcher so we never bind to a sibling Codex pane. */
+export function findTraexRolloutByPid(pid: number): { path: string; cliSessionId: string } | undefined {
+  if (!Number.isInteger(pid) || pid <= 0) return undefined;
+  if (IS_LINUX) {
+    const fdDir = `/proc/${pid}/fd`;
+    if (existsSync(fdDir)) {
+      let entries: string[];
+      try { entries = readdirSync(fdDir); } catch { return undefined; }
+      for (const fd of entries) {
+        let target: string;
+        try { target = readlinkSync(join(fdDir, fd)); } catch { continue; }
+        const hit = matchTraexRolloutPath(target);
+        if (hit) return hit;
+      }
+      return undefined;
+    }
+  }
+  let out: string;
+  try {
+    out = execSync(`lsof -p ${pid} -Fn`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch {
+    return undefined;
+  }
+  for (const line of out.split('\n')) {
+    if (!line.startsWith('n/')) continue;
+    const target = line.slice(1);
+    const hit = matchTraexRolloutPath(target);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+/** Locate the rollout file for a given TRAE session UUID. Filename shape is
+ *  identical to Codex: `rollout-<ts>-<sid>.jsonl`, so a suffix match over the
+ *  TRAE sessions tree is unambiguous. */
+export function findTraexRolloutBySessionId(cliSessionId: string): string | undefined {
+  const sessionsRoot = traeSessionsRoot();
+  if (!cliSessionId || !existsSync(sessionsRoot)) return undefined;
+  const suffix = `-${cliSessionId}.jsonl`;
+  const stack: string[] = [sessionsRoot];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries: string[];
+    try { entries = readdirSync(dir); } catch { continue; }
+    for (const name of entries) {
+      const full = join(dir, name);
+      let st: ReturnType<typeof statSync>;
+      try { st = statSync(full); } catch { continue; }
+      if (st.isDirectory()) {
+        stack.push(full);
+      } else if (st.isFile() && name.endsWith(suffix)) {
+        return full;
+      }
+    }
+  }
+  return undefined;
+}

--- a/src/setup/bot-config-editor.ts
+++ b/src/setup/bot-config-editor.ts
@@ -15,6 +15,7 @@ export const CLI_ID_CHOICES: Record<string, CliId> = {
   '11': 'codex-app',
   '12': 'mira',
   '13': 'seed',
+  '14': 'traex',
 };
 
 const VALID_CLI_IDS: ReadonlySet<string> = new Set(Object.values(CLI_ID_CHOICES));
@@ -38,11 +39,12 @@ const CLI_DISPLAY_LABELS: Record<CliId, string> = {
   'codex-app': 'Codex App',
   'mira': 'Mira',
   'seed': 'Seed',
+  'traex': 'TRAE',
 };
 
 /**
  * 有序 CLI 选项 (id + 展示名), 顺序与 setup 交互菜单 (CLI_ID_CHOICES 序号
- * 1..13) 一致. dashboard "添加机器人" 的 CLI 下拉直接读这里, 避免再抄一份
+ * 1..14) 一致. dashboard "添加机器人" 的 CLI 下拉直接读这里, 避免再抄一份
  * 列表. 单一事实源: CLI_ID_CHOICES 的值序.
  */
 export const CLI_OPTIONS: ReadonlyArray<{ id: CliId; label: string }> =
@@ -62,7 +64,7 @@ export function resolveCliId(input: string | undefined): CliId | undefined {
   if (mapped) return mapped;
   if (VALID_CLI_IDS.has(raw)) return raw as CliId;
   throw new Error(
-    `Unknown CLI 适配器 "${raw}"。请输入序号 1-13 或合法 ID 之一: ${[...VALID_CLI_IDS].join(', ')}`,
+    `Unknown CLI 适配器 "${raw}"。请输入序号 1-14 或合法 ID 之一: ${[...VALID_CLI_IDS].join(', ')}`,
   );
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -29,6 +29,7 @@ import {
 } from './services/bridge-rotation-policy.js';
 import { CodexBridgeQueue } from './services/codex-bridge-queue.js';
 import { drainCodexRollout, findCodexRolloutBySessionId, findCodexRolloutByPid, splitCodexEventsByCutoff, extractLastCodexTurn } from './services/codex-transcript.js';
+import { findTraexRolloutBySessionId, findTraexRolloutByPid } from './services/traex-transcript.js';
 import { cocoEventsPathForSession, drainCocoEvents, findCocoSessionByPid } from './services/coco-transcript.js';
 import { currentHermesStateOffset, drainHermesStateDb } from './services/hermes-transcript.js';
 import { currentMtrSessionOffset, drainMtrSession, findLatestMtrSessionByDirectory, findMtrSessionById, type MtrTranscriptSource } from './services/mtr-transcript.js';
@@ -115,7 +116,7 @@ function ensureZellijAttachConfig(): string {
 
 let sessionId = '';
 let lastInitConfig: Extract<DaemonToWorker, { type: 'init' }> | null = null;
-const CLI_DISPLAY_NAMES: Record<string, string> = { 'claude-code': 'Claude', seed: 'Seed', aiden: 'Aiden', coco: 'CoCo', codex: 'Codex', 'codex-app': 'Codex App', cursor: 'Cursor', gemini: 'Gemini', opencode: 'OpenCode', antigravity: 'Antigravity', mtr: 'MTR', hermes: 'Hermes', mira: 'Mira' };
+const CLI_DISPLAY_NAMES: Record<string, string> = { 'claude-code': 'Claude', seed: 'Seed', aiden: 'Aiden', coco: 'CoCo', codex: 'Codex', 'codex-app': 'Codex App', cursor: 'Cursor', gemini: 'Gemini', opencode: 'OpenCode', antigravity: 'Antigravity', mtr: 'MTR', hermes: 'Hermes', mira: 'Mira', traex: 'TRAE' };
 function cliName(): string { return CLI_DISPLAY_NAMES[lastInitConfig?.cliId ?? ''] ?? 'CLI'; }
 let isPromptReady = false;
 /** Mutex for async flushPending — prevents concurrent flush loops. */
@@ -1397,11 +1398,13 @@ function drainPathInto(path: string, fromOffset: number): { offset: number; tail
 function codexBridgeFallbackActive(): boolean {
   // True for transcript-backed CLIs whose final output can be harvested
   // when the model forgets to call `botmux send`.
-  return lastInitConfig?.cliId === 'codex' || lastInitConfig?.cliId === 'coco' || lastInitConfig?.cliId === 'hermes' || lastInitConfig?.cliId === 'mtr';
+  return lastInitConfig?.cliId === 'codex' || lastInitConfig?.cliId === 'traex' || lastInitConfig?.cliId === 'coco' || lastInitConfig?.cliId === 'hermes' || lastInitConfig?.cliId === 'mtr';
 }
 
+// Both Codex and TRAE share the same rollout JSONL layout (response_item
+// messages), so drainCodexRollout works for both.
 function structuredBridgeIsCodex(): boolean {
-  return lastInitConfig?.cliId === 'codex';
+  return lastInitConfig?.cliId === 'codex' || lastInitConfig?.cliId === 'traex';
 }
 
 function structuredBridgeIsHermes(): boolean {
@@ -1470,17 +1473,25 @@ function codexBridgeStartTimer(): void {
         // by sid suffix; CoCo's events.jsonl path is deterministic from
         // sid, so the lookup is just a path computation + existence check.
         const isCoco = lastInitConfig?.cliId === 'coco';
+        const isTraex = lastInitConfig?.cliId === 'traex';
         let path: string | undefined;
         if (codexBridgePendingSessionId) {
-          path = isCoco
-            ? cocoEventsPathForSession(codexBridgePendingSessionId)
-            : findCodexRolloutBySessionId(codexBridgePendingSessionId);
-          if (path && isCoco && !existsSync(path)) path = undefined;
+          if (isCoco) {
+            path = cocoEventsPathForSession(codexBridgePendingSessionId);
+            if (path && !existsSync(path)) path = undefined;
+          } else if (isTraex) {
+            path = findTraexRolloutBySessionId(codexBridgePendingSessionId);
+          } else {
+            path = findCodexRolloutBySessionId(codexBridgePendingSessionId);
+          }
         }
         if (!path && codexAdoptPendingPid) {
           if (isCoco) {
             const probed = findCocoSessionByPid(codexAdoptPendingPid);
             if (probed && existsSync(probed.eventsPath)) path = probed.eventsPath;
+          } else if (isTraex) {
+            const probed = findTraexRolloutByPid(codexAdoptPendingPid);
+            if (probed) path = probed.path;
           } else {
             const probed = findCodexRolloutByPid(codexAdoptPendingPid);
             if (probed) path = probed.path;
@@ -1647,7 +1658,9 @@ function codexBridgeNotifyCliSessionId(cliSessionId: string): void {
     }
     return;
   }
-  const path = findCodexRolloutBySessionId(cliSessionId);
+  const path = lastInitConfig?.cliId === 'traex'
+    ? findTraexRolloutBySessionId(cliSessionId)
+    : findCodexRolloutBySessionId(cliSessionId);
   if (path) {
     codexBridgePendingSessionId = undefined;
     codexBridgeAttach(path, 'fresh-empty');
@@ -2811,6 +2824,25 @@ function setupAdoptTranscriptBridges(cfg: Extract<DaemonToWorker, { type: 'init'
       codexAdoptPendingPid = cfg.adoptCliPid;
       codexBridgeStartTimer();
     }
+  } else if (cfg.cliId === 'traex') {
+    // TRAE rollout format is byte-identical to Codex; only the directory
+    // layout (and therefore the finder functions) differ.
+    const adoptStartMs = Date.now();
+    codexAdoptStartMs = adoptStartMs;
+    codexBridgeQueue.setLocalTurns(true, adoptStartMs);
+    let rolloutPath: string | undefined;
+    if (cfg.cliSessionId) rolloutPath = findTraexRolloutBySessionId(cfg.cliSessionId);
+    if (!rolloutPath && cfg.adoptCliPid) {
+      const probed = findTraexRolloutByPid(cfg.adoptCliPid);
+      if (probed) rolloutPath = probed.path;
+    }
+    if (rolloutPath) {
+      codexBridgeAttach(rolloutPath, 'split-live');
+    } else {
+      if (cfg.cliSessionId) codexBridgePendingSessionId = cfg.cliSessionId;
+      codexAdoptPendingPid = cfg.adoptCliPid;
+      codexBridgeStartTimer();
+    }
   } else if (cfg.cliId === 'coco') {
     const adoptStartMs = Date.now();
     codexAdoptStartMs = adoptStartMs;
@@ -2858,14 +2890,14 @@ function setupAdoptTranscriptBridges(cfg: Extract<DaemonToWorker, { type: 'init'
 function adoptIdleAdapter(cfg: Extract<DaemonToWorker, { type: 'init' }>): CliAdapter {
   return cfg.bridgeJsonlPath
     ? createCliAdapterSync('claude-code', undefined)
-    : cfg.cliId === 'codex' || cfg.cliId === 'coco' || cfg.cliId === 'mtr'
+    : cfg.cliId === 'codex' || cfg.cliId === 'traex' || cfg.cliId === 'coco' || cfg.cliId === 'mtr'
       ? createCliAdapterSync(cfg.cliId, undefined)
       : ({ completionPattern: undefined, readyPattern: undefined } as CliAdapter);
 }
 
 function setupAdoptInputAdapter(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
-  if (cfg.cliId === 'codex') {
-    cliAdapter = createCliAdapterSync('codex', cfg.cliPathOverride);
+  if (cfg.cliId === 'codex' || cfg.cliId === 'traex') {
+    cliAdapter = createCliAdapterSync(cfg.cliId, cfg.cliPathOverride);
   } else if (cfg.cliId === 'mtr') {
     cliAdapter = createCliAdapterSync('mtr', cfg.cliPathOverride);
   }
@@ -3256,6 +3288,22 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     } else {
       codexBridgeStartTimer();
     }
+  } else if (cfg.cliId === 'traex') {
+    // TRAE: same rollout shape as Codex, different finder path. For a fresh
+    // spawn (no cliSessionId yet) we just arm the poller; writeInput will
+    // surface the cliSessionId on the first successful submit and trigger
+    // codexBridgeNotifyCliSessionId → rollout attach.
+    if (cfg.cliSessionId) {
+      const rolloutPath = findTraexRolloutBySessionId(cfg.cliSessionId);
+      if (rolloutPath) {
+        codexBridgeAttach(rolloutPath, 'baseline-existing');
+      } else {
+        codexBridgePendingSessionId = cfg.cliSessionId;
+        codexBridgeStartTimer();
+      }
+    } else {
+      codexBridgeStartTimer();
+    }
   } else if (cfg.cliId === 'coco') {
     const eventsPath = cocoEventsPathForSession(cfg.sessionId);
     codexBridgeAttach(eventsPath, cfg.resume ? 'baseline-existing' : 'fresh-empty');
@@ -3302,15 +3350,22 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   }
 
   // Fallback: if the CLI takes too long to show its prompt (e.g. slow
-  // plugin init), unblock screen updates so the card doesn't stay at
-  // "启动中" forever.  markNewTurn() sets a clean baseline at the current
-  // cursor position so only content written *after* this point appears in
-  // the card.
+  // plugin init, or a spinner blocks the idle detector), unblock screen
+  // updates AND deliver any queued prompts so the first user message
+  // isn't stranded until the second message arrives. markNewTurn() sets a
+  // clean baseline at the current cursor position so only content written
+  // *after* this point appears in the card.
   setTimeout(() => {
     if (awaitingFirstPrompt) {
       awaitingFirstPrompt = false;
       renderer?.markNewTurn();
-      log('First prompt timeout — enabling screen updates');
+      log('First prompt timeout — enabling screen updates and flushing queued messages');
+      // For type-ahead adapters (Codex/CoCo/TRAE/Claude) the TUI is booted
+      // enough to park input even if the idle detector hasn't fired yet.
+      // Directly invoking markPromptReady() would claim the CLI is idle
+      // while it's still mid-boot, so flushPending() alone is safer — it
+      // respects typeAheadAllowed and drains pendingMessages now.
+      if (cliAdapter?.supportsTypeAhead) flushPending();
     }
   }, 15_000);
 }
@@ -3940,7 +3995,7 @@ process.on('message', async (raw: unknown) => {
         //     path, and the other CLIs' adopt flows haven't surfaced
         //     this submit-detection issue.
         if (backend) {
-          if (lastInitConfig?.cliId === 'codex' && cliAdapter) {
+          if ((lastInitConfig?.cliId === 'codex' || lastInitConfig?.cliId === 'traex') && cliAdapter) {
             // writeInput is async but we're already inside an async
             // message handler. Errors are best-effort logged; the bridge
             // ingest path is unaffected because mark already happened


### PR DESCRIPTION
## 概述

新增 TRAE CLI（二进制名 `traex` / `traecli`）的 botmux 适配器。

## 改动文件

**新增：**
- `src/services/traex-paths.ts` — `TRAE_HOME` / state DB / sessions 路径解析
- `src/services/traex-transcript.ts` — rollout finder（by pid / by session id）
- `src/adapters/cli/traex.ts` — CliAdapter 实现：
  - bracketed paste 输入协议
  - submit verification：通过 `node:sqlite` 查 `threads.first_user_message`，node:sqlite 不可用时优雅降级为无验证
  - resume：通过 SQLite 恢复 session UUID
  - `supportsTypeAhead: true`、精选常用模型

**修改（共 8 处注册点）：**
- `src/adapters/cli/types.ts` — `CliId` union 加 `'traex'`
- `src/adapters/cli/registry.ts` — import / switch / export
- `src/worker.ts` — transcript bridge 分支同步支持 traex；修复首 prompt 超时兜底
- `src/im/lark/card-builder.ts` — 显示名 `'TRAE'`
- `src/setup/bot-config-editor.ts` — `CLI_ID_CHOICES[14]` / `CLI_DISPLAY_LABELS` / 序号范围提示
- `src/cli.ts` — 两个 setup 交互菜单

## 重要修复

首 prompt 15s 超时兜底：原超时只开 screen updates，不 flush `pendingMessages`，导致第一条 Lark 消息卡在队列里直到第二条到达才（两条一起）写入 CLI。现在对 `supportsTypeAhead` 的适配器在超时后也 `flushPending()`。

## 验证

- `pnpm build` 通过，无 TS 错误
- `pnpm vitest run test/cli-adapters.test.ts` → 161 passed
- `pnpm vitest run test/bot-config-editor.test.ts` → 41 passed
- `pnpm daemon:restart` 后全部进程 online，无 error log

## 使用

`botmux setup` 编辑机器人，CLI 适配器选 `14`（或直接输入 `traex`）即可切到 TRAE。