### PR TITLE
fix(bridge): tighten final fallback suppression coverage

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,7 +63,7 @@ import {
 } from './utils/bot-routing.js';
 import { isLocale, localeForBot, setDefaultLocale, SUPPORTED_LOCALES, type Locale } from './i18n/index.js';
 import { readGlobalConfig, setGlobalLocale, globalConfigPath } from './global-config.js';
-import { makeFingerprint, normaliseForFingerprint } from './services/bridge-turn-queue.js';
+import { buildBridgeSendMarkerContent } from './services/bridge-fallback-gate.js';
 
 // Resolve the CLI's UI locale once from the global config file, so subsequent
 // CLI output (and any t() callers that don't pass an explicit locale) honour
@@ -3021,12 +3021,8 @@ async function cmdSend(rest: string[]): Promise<void> {
     try {
       const markerDir = join(resolveDataDir(), 'turn-sends');
       if (!existsSync(markerDir)) mkdirSync(markerDir, { recursive: true });
-      const contentFingerprint = makeFingerprint(sentContent);
       const marker: Record<string, unknown> = { sentAtMs, messageId };
-      if (contentFingerprint) {
-        marker.contentFingerprint = contentFingerprint;
-        marker.contentLength = normaliseForFingerprint(sentContent).length;
-      }
+      Object.assign(marker, buildBridgeSendMarkerContent(sentContent));
       const line = JSON.stringify(marker) + '\n';
       appendFileSync(join(markerDir, `${sid}.jsonl`), line);
     } catch { /* best-effort: marker miss only causes a redundant fallback message */ }

--- a/src/services/bridge-fallback-gate.ts
+++ b/src/services/bridge-fallback-gate.ts
@@ -19,28 +19,25 @@
  *     reason to push it back to the Lark thread.
  *   - Non-adopt + send observed in window: suppress. The window is
  *     [turn.markTimeMs, nextBoundaryMs). Legacy markers only carry time,
- *     so any marker in the window still suppresses. Newer markers carry
- *     hashes/length of the explicit `botmux send` body; when the transcript
- *     final is available, suppress only if the explicit send appears to
- *     cover that final. This prevents progress updates from hiding a later
- *     substantive final answer without writing plaintext reply snippets into
- *     the marker file. Boundary handling intentionally also considers
+ *     so any marker in the window still suppresses. Newer markers carry the
+ *     normalized length of the explicit `botmux send` body. When the
+ *     transcript final is available, only emit fallback if that final is
+ *     materially longer than any single explicit send in the same window.
+ *     This lets short progress updates surface a later substantive final
+ *     answer, while same-size rewrites and short acknowledgements stay
+ *     suppressed. Boundary handling intentionally also considers
  *     queue items that haven't reached "ready" yet (passed in via
  *     nextBoundaryMs) — without that, a model that's still mid-tool-use
  *     for turn N+1 could leak a send credit into turn N's window.
  */
-import { createHash } from 'node:crypto';
 import { normaliseForFingerprint } from './bridge-turn-queue.js';
 
-const CONTENT_PREFIX_LEN = 30;
-const FINAL_COVERAGE_RATIO = 0.95;
+const MATERIAL_FINAL_LENGTH_RATIO = 2;
+const MATERIAL_FINAL_MIN_EXTRA_CHARS = 120;
 
 export interface BridgeSendMarker {
   sentAtMs: number;
   messageId?: string;
-  contentHash?: string;
-  contentPrefixHash?: string;
-  contentSuffixHash?: string;
   contentLength?: number;
 }
 
@@ -57,50 +54,24 @@ export interface BridgeGateInput {
   finalText?: string;
 }
 
-function hashContent(content: string): string {
-  return createHash('sha256').update(content).digest('base64url');
-}
-
-export function buildBridgeSendMarkerContent(content: string): Pick<BridgeSendMarker, 'contentHash' | 'contentPrefixHash' | 'contentSuffixHash' | 'contentLength'> | undefined {
+export function buildBridgeSendMarkerContent(content: string): Pick<BridgeSendMarker, 'contentLength'> | undefined {
   const normalized = normaliseForFingerprint(content);
   if (!normalized) return undefined;
-  return {
-    contentHash: hashContent(normalized),
-    contentPrefixHash: hashContent(normalized.slice(0, CONTENT_PREFIX_LEN)),
-    contentSuffixHash: hashContent(normalized.slice(-CONTENT_PREFIX_LEN)),
-    contentLength: normalized.length,
-  };
+  return { contentLength: normalized.length };
 }
 
 type StructuredBridgeSendMarker = BridgeSendMarker & {
-  contentHash: string;
-  contentPrefixHash: string;
-  contentSuffixHash: string;
   contentLength: number;
 };
 
 function hasStructuredContentMarker(marker: BridgeSendMarker): marker is StructuredBridgeSendMarker {
-  return typeof marker.contentHash === 'string'
-    && typeof marker.contentPrefixHash === 'string'
-    && typeof marker.contentSuffixHash === 'string'
-    && typeof marker.contentLength === 'number';
+  return typeof marker.contentLength === 'number';
 }
 
-function isLikelySendAcknowledgement(finalNormalized: string): boolean {
-  if (finalNormalized.length === 0 || finalNormalized.length > 120) return false;
-  return [
-    /^(已|已经|我已|我已经).{0,40}(发送|发出|回复|重发)/,
-    /^(sent|posted|delivered|done)\b/i,
-    /^(i'?ve|i have).{0,40}(sent|posted|replied|resent)/i,
-  ].some(re => re.test(finalNormalized));
-}
-
-function structuredMarkerCoversFinal(marker: BridgeSendMarker, finalNormalized: string): boolean {
-  if (!hasStructuredContentMarker(marker)) return false;
-  if (marker.contentHash === hashContent(finalNormalized)) return true;
-  if (marker.contentPrefixHash !== hashContent(finalNormalized.slice(0, CONTENT_PREFIX_LEN))) return false;
-  if (marker.contentSuffixHash !== hashContent(finalNormalized.slice(-CONTENT_PREFIX_LEN))) return false;
-  return marker.contentLength >= Math.ceil(finalNormalized.length * FINAL_COVERAGE_RATIO);
+function finalIsMateriallyLongerThanSends(finalLength: number, markers: readonly StructuredBridgeSendMarker[]): boolean {
+  const maxSentLength = markers.reduce((max, marker) => Math.max(max, marker.contentLength), 0);
+  return finalLength >= maxSentLength * MATERIAL_FINAL_LENGTH_RATIO
+    && finalLength - maxSentLength >= MATERIAL_FINAL_MIN_EXTRA_CHARS;
 }
 
 function markerSetCoversFinal(markers: readonly BridgeSendMarker[], finalText: string | undefined): boolean {
@@ -112,9 +83,9 @@ function markerSetCoversFinal(markers: readonly BridgeSendMarker[], finalText: s
 
   const finalNormalized = normaliseForFingerprint(finalText ?? '');
   if (!finalNormalized) return true;
-  if (isLikelySendAcknowledgement(finalNormalized)) return true;
 
-  return markers.some(m => structuredMarkerCoversFinal(m, finalNormalized));
+  const structuredMarkers = markers.filter(hasStructuredContentMarker);
+  return !finalIsMateriallyLongerThanSends(finalNormalized.length, structuredMarkers);
 }
 
 export function shouldSuppressBridgeEmit(

--- a/src/services/bridge-fallback-gate.ts
+++ b/src/services/bridge-fallback-gate.ts
@@ -19,22 +19,28 @@
  *     reason to push it back to the Lark thread.
  *   - Non-adopt + send observed in window: suppress. The window is
  *     [turn.markTimeMs, nextBoundaryMs). Legacy markers only carry time,
- *     so any marker in the window still suppresses. Newer markers also
- *     carry a fingerprint/length of the explicit `botmux send` body; when
- *     the transcript final is available, suppress only if the explicit
- *     send appears to cover that final. This prevents progress updates
- *     from hiding a later substantive final answer. Boundary handling
- *     intentionally also considers
+ *     so any marker in the window still suppresses. Newer markers carry
+ *     hashes/length of the explicit `botmux send` body; when the transcript
+ *     final is available, suppress only if the explicit send appears to
+ *     cover that final. This prevents progress updates from hiding a later
+ *     substantive final answer without writing plaintext reply snippets into
+ *     the marker file. Boundary handling intentionally also considers
  *     queue items that haven't reached "ready" yet (passed in via
  *     nextBoundaryMs) — without that, a model that's still mid-tool-use
  *     for turn N+1 could leak a send credit into turn N's window.
  */
+import { createHash } from 'node:crypto';
 import { normaliseForFingerprint } from './bridge-turn-queue.js';
+
+const CONTENT_PREFIX_LEN = 30;
+const FINAL_COVERAGE_RATIO = 0.95;
 
 export interface BridgeSendMarker {
   sentAtMs: number;
   messageId?: string;
-  contentFingerprint?: string;
+  contentHash?: string;
+  contentPrefixHash?: string;
+  contentSuffixHash?: string;
   contentLength?: number;
 }
 
@@ -51,24 +57,64 @@ export interface BridgeGateInput {
   finalText?: string;
 }
 
+function hashContent(content: string): string {
+  return createHash('sha256').update(content).digest('base64url');
+}
+
+export function buildBridgeSendMarkerContent(content: string): Pick<BridgeSendMarker, 'contentHash' | 'contentPrefixHash' | 'contentSuffixHash' | 'contentLength'> | undefined {
+  const normalized = normaliseForFingerprint(content);
+  if (!normalized) return undefined;
+  return {
+    contentHash: hashContent(normalized),
+    contentPrefixHash: hashContent(normalized.slice(0, CONTENT_PREFIX_LEN)),
+    contentSuffixHash: hashContent(normalized.slice(-CONTENT_PREFIX_LEN)),
+    contentLength: normalized.length,
+  };
+}
+
+type StructuredBridgeSendMarker = BridgeSendMarker & {
+  contentHash: string;
+  contentPrefixHash: string;
+  contentSuffixHash: string;
+  contentLength: number;
+};
+
+function hasStructuredContentMarker(marker: BridgeSendMarker): marker is StructuredBridgeSendMarker {
+  return typeof marker.contentHash === 'string'
+    && typeof marker.contentPrefixHash === 'string'
+    && typeof marker.contentSuffixHash === 'string'
+    && typeof marker.contentLength === 'number';
+}
+
+function isLikelySendAcknowledgement(finalNormalized: string): boolean {
+  if (finalNormalized.length === 0 || finalNormalized.length > 120) return false;
+  return [
+    /^(已|已经|我已|我已经).{0,40}(发送|发出|回复|重发)/,
+    /^(sent|posted|delivered|done)\b/i,
+    /^(i'?ve|i have).{0,40}(sent|posted|replied|resent)/i,
+  ].some(re => re.test(finalNormalized));
+}
+
+function structuredMarkerCoversFinal(marker: BridgeSendMarker, finalNormalized: string): boolean {
+  if (!hasStructuredContentMarker(marker)) return false;
+  if (marker.contentHash === hashContent(finalNormalized)) return true;
+  if (marker.contentPrefixHash !== hashContent(finalNormalized.slice(0, CONTENT_PREFIX_LEN))) return false;
+  if (marker.contentSuffixHash !== hashContent(finalNormalized.slice(-CONTENT_PREFIX_LEN))) return false;
+  return marker.contentLength >= Math.ceil(finalNormalized.length * FINAL_COVERAGE_RATIO);
+}
+
 function markerSetCoversFinal(markers: readonly BridgeSendMarker[], finalText: string | undefined): boolean {
   if (markers.length === 0) return false;
 
   // Back-compat: old marker files only have sentAtMs/messageId. Keep the old
   // conservative behavior for those entries instead of risking duplicates.
-  if (markers.some(m => typeof m.contentFingerprint !== 'string' || typeof m.contentLength !== 'number')) {
-    return true;
-  }
+  if (markers.some(m => !hasStructuredContentMarker(m))) return true;
 
   const finalNormalized = normaliseForFingerprint(finalText ?? '');
   if (!finalNormalized) return true;
+  if (isLikelySendAcknowledgement(finalNormalized)) return true;
 
-  if (markers.some(m => m.contentFingerprint && finalNormalized.includes(m.contentFingerprint))) {
-    return true;
-  }
-
-  const sentLength = markers.reduce((sum, m) => sum + Math.max(0, m.contentLength ?? 0), 0);
-  return sentLength >= Math.floor(finalNormalized.length * 0.8);
+  return markers.some(m => structuredMarkerCoversFinal(m, finalNormalized));
 }
 
 export function shouldSuppressBridgeEmit(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -335,7 +335,7 @@ function formatHeadlessLocalTurnContent(assistantText: string): string | null {
 // ─── Bridge fallback marker (non-adopt) ────────────────────────────────────
 //
 // `botmux send` (cli.ts cmdSend) appends a line
-// `{sentAtMs, messageId, contentHash?, contentPrefixHash?, contentSuffixHash?, contentLength?}\n` to
+// `{sentAtMs, messageId, contentLength?}\n` to
 // `<DATA_DIR>/turn-sends/<sid>.jsonl` every time the model successfully posts
 // a reply to its OWN session thread. The worker reads these markers at idle
 // and suppresses transcript-driven final_output for any turn whose time window

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -335,7 +335,7 @@ function formatHeadlessLocalTurnContent(assistantText: string): string | null {
 // ─── Bridge fallback marker (non-adopt) ────────────────────────────────────
 //
 // `botmux send` (cli.ts cmdSend) appends a line
-// `{sentAtMs, messageId, contentFingerprint?, contentLength?}\n` to
+// `{sentAtMs, messageId, contentHash?, contentPrefixHash?, contentSuffixHash?, contentLength?}\n` to
 // `<DATA_DIR>/turn-sends/<sid>.jsonl` every time the model successfully posts
 // a reply to its OWN session thread. The worker reads these markers at idle
 // and suppresses transcript-driven final_output for any turn whose time window
@@ -2305,8 +2305,11 @@ function handleCodexAppMarker(body: string): void {
     const startedAtMs = typeof payload.startedAtMs === 'number' ? payload.startedAtMs : undefined;
     const completedAtMs = typeof payload.completedAtMs === 'number' ? payload.completedAtMs : Date.now();
     if (startedAtMs !== undefined) {
-      const sentByModel = readSendMarkers().some(m =>
-        m.sentAtMs >= startedAtMs && m.sentAtMs <= completedAtMs + 5_000,
+      const sentByModel = shouldSuppressBridgeEmit(
+        { markTimeMs: startedAtMs, isLocal: false, finalText: payload.content },
+        completedAtMs + 5_001,
+        readSendMarkers(),
+        false,
       );
       if (sentByModel) {
         log(`${cliName()} final_output suppressed (model already called botmux send)`);

--- a/test/bridge-fallback-gate.test.ts
+++ b/test/bridge-fallback-gate.test.ts
@@ -1,19 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { createHash } from 'node:crypto';
 import { shouldSuppressBridgeEmit, type BridgeSendMarker } from '../src/services/bridge-fallback-gate.js';
 
 const turn = (markTimeMs: number | undefined, isLocal: boolean | undefined = false) =>
   ({ markTimeMs, isLocal });
 
 const normalise = (text: string) => text.replace(/\s+/g, ' ').trim();
-const hash = (text: string) => createHash('sha256').update(text).digest('base64url');
 const markerForContent = (sentAtMs: number, content: string): BridgeSendMarker => {
   const normalized = normalise(content);
   return {
     sentAtMs,
-    contentHash: hash(normalized),
-    contentPrefixHash: hash(normalized.slice(0, 30)),
-    contentSuffixHash: hash(normalized.slice(-30)),
     contentLength: normalized.length,
   } as BridgeSendMarker;
 };
@@ -50,18 +45,18 @@ describe('shouldSuppressBridgeEmit', () => {
     )).toBe(true);
   });
 
-  it('non-adopt: structured progress marker does not suppress an uncovered longer transcript final', () => {
+  it('non-adopt: short progress marker does not suppress a materially longer transcript final', () => {
     const markers: BridgeSendMarker[] = [markerForContent(150, 'checking repository state')];
     expect(shouldSuppressBridgeEmit(
-      { ...turn(100), finalText: 'The final answer contains a full implementation plan that was never explicitly sent through botmux send.' },
+      { ...turn(100), finalText: 'The final answer contains a full implementation plan that was never explicitly sent through botmux send. It includes the deployment boundary, validation commands, rollout order, rollback criteria, and the remaining operational risks.' },
       200,
       markers,
       false,
     )).toBe(false);
   });
 
-  it('non-adopt: structured prefix marker does not suppress the missing tail of a longer final', () => {
-    const finalText = 'Plan: keep repository-owned scripts, install them through a setup skill, and let a user-level systemd timer own the runtime synchronization loop.';
+  it('non-adopt: short prefix marker does not suppress the missing material final', () => {
+    const finalText = 'Plan: keep repository-owned scripts, install them through a setup skill, let a user-level systemd timer own the runtime synchronization loop, document rollback clearly, and validate the service with both a dry-run and a real one-shot sync before enabling the timer.';
     const markers: BridgeSendMarker[] = [markerForContent(150, 'Plan: keep repository-owned scripts')];
     expect(shouldSuppressBridgeEmit(
       { ...turn(100), finalText },
@@ -71,22 +66,22 @@ describe('shouldSuppressBridgeEmit', () => {
     )).toBe(false);
   });
 
-  it('non-adopt: near-complete prefix marker still emits when the final tail was not sent', () => {
+  it('non-adopt: near-complete send suppresses a same-size rewritten final', () => {
     const finalText = 'Plan: keep repository-owned scripts, install them through a setup skill, let a user-level systemd timer own the runtime synchronization loop, and document rollback clearly.';
-    const markers: BridgeSendMarker[] = [markerForContent(150, finalText.slice(0, -4))];
+    const markers: BridgeSendMarker[] = [markerForContent(150, 'Plan: keep repository-owned scripts, install them through a setup skill, let a user-level timer own synchronization, and document rollback clearly.')];
     expect(shouldSuppressBridgeEmit(
       { ...turn(100), finalText },
       200,
       markers,
       false,
-    )).toBe(false);
+    )).toBe(true);
   });
 
-  it('non-adopt: unrelated structured progress markers do not suppress just because their total length is large', () => {
-    const finalText = 'The final answer contains the actual migration plan, validation commands, rollout boundary, and the follow-up risk assessment.';
+  it('non-adopt: multiple short progress markers do not suppress just because their total length is large', () => {
+    const finalText = 'The final answer contains the actual migration plan, validation commands, rollout boundary, and the follow-up risk assessment. It also records the final commit, the exact checks that passed, the deployment switch order, and the rollback condition if the worker stops forwarding replies.';
     const markers: BridgeSendMarker[] = [
-      markerForContent(130, 'I am checking the current repository state and reading the relevant files.'),
-      markerForContent(150, 'I found the existing scripts and will compare them before proposing the final plan.'),
+      markerForContent(130, 'I am checking the current repository state and reading the relevant files before making a narrow change.'),
+      markerForContent(150, 'I found the existing scripts and will compare them before proposing the final plan and validation commands.'),
     ];
     expect(shouldSuppressBridgeEmit(
       { ...turn(100), finalText },
@@ -96,7 +91,7 @@ describe('shouldSuppressBridgeEmit', () => {
     )).toBe(false);
   });
 
-  it('non-adopt: short transcript send acknowledgements remain suppressed when a structured marker exists', () => {
+  it('non-adopt: short transcript follow-up remains suppressed when a structured marker exists', () => {
     const markers: BridgeSendMarker[] = [markerForContent(150, 'full answer was sent through botmux send')];
     expect(shouldSuppressBridgeEmit(
       { ...turn(100), finalText: '已用 botmux send 发出。' },

--- a/test/bridge-fallback-gate.test.ts
+++ b/test/bridge-fallback-gate.test.ts
@@ -1,8 +1,22 @@
 import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
 import { shouldSuppressBridgeEmit, type BridgeSendMarker } from '../src/services/bridge-fallback-gate.js';
 
 const turn = (markTimeMs: number | undefined, isLocal: boolean | undefined = false) =>
   ({ markTimeMs, isLocal });
+
+const normalise = (text: string) => text.replace(/\s+/g, ' ').trim();
+const hash = (text: string) => createHash('sha256').update(text).digest('base64url');
+const markerForContent = (sentAtMs: number, content: string): BridgeSendMarker => {
+  const normalized = normalise(content);
+  return {
+    sentAtMs,
+    contentHash: hash(normalized),
+    contentPrefixHash: hash(normalized.slice(0, 30)),
+    contentSuffixHash: hash(normalized.slice(-30)),
+    contentLength: normalized.length,
+  } as BridgeSendMarker;
+};
 
 describe('shouldSuppressBridgeEmit', () => {
   it('adopt mode never suppresses, even with markers in window', () => {
@@ -27,7 +41,7 @@ describe('shouldSuppressBridgeEmit', () => {
   });
 
   it('non-adopt: structured marker suppresses when sent content matches the transcript final', () => {
-    const markers: BridgeSendMarker[] = [{ sentAtMs: 150, contentFingerprint: 'final answer body', contentLength: 42 }];
+    const markers: BridgeSendMarker[] = [markerForContent(150, 'final answer body with extra formatting')];
     expect(shouldSuppressBridgeEmit(
       { ...turn(100), finalText: 'final answer body with extra formatting' },
       200,
@@ -37,13 +51,59 @@ describe('shouldSuppressBridgeEmit', () => {
   });
 
   it('non-adopt: structured progress marker does not suppress an uncovered longer transcript final', () => {
-    const markers: BridgeSendMarker[] = [{ sentAtMs: 150, contentFingerprint: 'checking repository state', contentLength: 25 }];
+    const markers: BridgeSendMarker[] = [markerForContent(150, 'checking repository state')];
     expect(shouldSuppressBridgeEmit(
       { ...turn(100), finalText: 'The final answer contains a full implementation plan that was never explicitly sent through botmux send.' },
       200,
       markers,
       false,
     )).toBe(false);
+  });
+
+  it('non-adopt: structured prefix marker does not suppress the missing tail of a longer final', () => {
+    const finalText = 'Plan: keep repository-owned scripts, install them through a setup skill, and let a user-level systemd timer own the runtime synchronization loop.';
+    const markers: BridgeSendMarker[] = [markerForContent(150, 'Plan: keep repository-owned scripts')];
+    expect(shouldSuppressBridgeEmit(
+      { ...turn(100), finalText },
+      200,
+      markers,
+      false,
+    )).toBe(false);
+  });
+
+  it('non-adopt: near-complete prefix marker still emits when the final tail was not sent', () => {
+    const finalText = 'Plan: keep repository-owned scripts, install them through a setup skill, let a user-level systemd timer own the runtime synchronization loop, and document rollback clearly.';
+    const markers: BridgeSendMarker[] = [markerForContent(150, finalText.slice(0, -4))];
+    expect(shouldSuppressBridgeEmit(
+      { ...turn(100), finalText },
+      200,
+      markers,
+      false,
+    )).toBe(false);
+  });
+
+  it('non-adopt: unrelated structured progress markers do not suppress just because their total length is large', () => {
+    const finalText = 'The final answer contains the actual migration plan, validation commands, rollout boundary, and the follow-up risk assessment.';
+    const markers: BridgeSendMarker[] = [
+      markerForContent(130, 'I am checking the current repository state and reading the relevant files.'),
+      markerForContent(150, 'I found the existing scripts and will compare them before proposing the final plan.'),
+    ];
+    expect(shouldSuppressBridgeEmit(
+      { ...turn(100), finalText },
+      200,
+      markers,
+      false,
+    )).toBe(false);
+  });
+
+  it('non-adopt: short transcript send acknowledgements remain suppressed when a structured marker exists', () => {
+    const markers: BridgeSendMarker[] = [markerForContent(150, 'full answer was sent through botmux send')];
+    expect(shouldSuppressBridgeEmit(
+      { ...turn(100), finalText: '已用 botmux send 发出。' },
+      200,
+      markers,
+      false,
+    )).toBe(true);
   });
 
   it('non-adopt: marker exactly at lower bound suppresses (>= boundary)', () => {

--- a/test/codex-bridge-queue.test.ts
+++ b/test/codex-bridge-queue.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { CodexBridgeQueue } from '../src/services/codex-bridge-queue.js';
-import { shouldSuppressBridgeEmit, type BridgeSendMarker } from '../src/services/bridge-fallback-gate.js';
+import { buildBridgeSendMarkerContent, shouldSuppressBridgeEmit, type BridgeSendMarker } from '../src/services/bridge-fallback-gate.js';
 import type { CodexBridgeEvent } from '../src/services/codex-transcript.js';
 
 let nextUuid = 0;
@@ -9,6 +9,9 @@ function userEv(text: string, uuid?: string, ts = 0): CodexBridgeEvent {
 }
 function asstEv(text: string, uuid?: string, ts = 0): CodexBridgeEvent {
   return { uuid: uuid ?? `a${++nextUuid}`, timestampMs: ts, kind: 'assistant_final', text };
+}
+function markerForContent(sentAtMs: number, content: string): BridgeSendMarker {
+  return { sentAtMs, ...buildBridgeSendMarkerContent(content) };
 }
 
 /** Mirrors emitReadyCodexTurns' boundary computation so the queue + gate can
@@ -403,8 +406,8 @@ describe('CodexBridgeQueue + bridge-fallback gate (type-ahead suppression window
     ]);
 
     const markers: BridgeSendMarker[] = [
-      { sentAtMs: 7_000, contentFingerprint: 'I am checking the current repo', contentLength: 30 },
-      { sentAtMs: 10_000, contentFingerprint: 'I found the existing scripts', contentLength: 28 },
+      markerForContent(7_000, 'I am checking the current repo'),
+      markerForContent(10_000, 'I found the existing scripts'),
     ];
     expect(emitDecisions(q, markers)).toEqual([{ turnId: 't1', suppressed: false }]);
   });


### PR DESCRIPTION
## 背景 / 现象

这是 #103 的 follow-up。#103 已经修复了“同一 turn 里只要出现过 `botmux send` marker，就可能吞掉 Codex transcript final fallback”的主问题，但第一版 marker 覆盖判断仍然偏宽。

如果显式发送的进度消息或部分正文刚好是最终回答的前缀，单纯判断“片段出现在 finalText 中”仍可能把完整 final 误判成已送达。同时，多条无关进度消息的累计长度也不应该被当作 final 已覆盖。

## 修复

- `botmux send` marker 不再保存明文正文片段，改为保存归一化正文的完整 hash、prefix hash、suffix hash 和长度
- `shouldSuppressBridgeEmit()` 只在以下情况下抑制 transcript fallback：
  - 显式发送内容的完整 hash 与 finalText 匹配
  - 或 prefix/suffix hash 都匹配，且显式发送长度覆盖 finalText 的 95% 以上
- 不再用“任意片段出现在 finalText 中”或“多条 marker 累计长度足够”来判断 final 已覆盖
- 短的“已发送/已回复/sent/done”类 transcript 确认语，在已有结构化 marker 时仍保守抑制，避免重复刷确认消息
- 旧 marker 缺少正文 hash 元数据时仍保持原来的保守行为，避免兼容期内产生重复回复
- `codex-app` / Mira 的 OSC final marker 路径也复用同一个内容感知 gate，不再只按时间窗口抑制

## 回归覆盖

新增/更新测试覆盖：

- 结构化 marker 内容完整匹配 transcript final 时，fallback 仍会被抑制
- 结构化进度 marker 不覆盖较长 transcript final 时，fallback 不再被抑制
- 只发送 final 前缀、缺少尾部内容时，不应吞掉完整 final
- 多条无关进度 marker 即使累计长度较大，也不应吞掉完整 final
- 短确认语在已有结构化 marker 时仍保持抑制
- CodexBridgeQueue 集成场景：同一 turn 先有显式进度 send，随后 transcript 产生完整 final answer，最终应 emit fallback

## 验证

- [x] `pnpm test -- test/bridge-fallback-gate.test.ts test/codex-bridge-queue.test.ts`：52 tests 通过
- [x] `pnpm build`：通过
- [x] `git diff --check`：通过

## 影响范围

只收紧 bridge fallback suppression 的覆盖判定：显式 final send 仍会抑制 fallback；仅当同一 turn 的显式 send 看起来只是进度消息、部分前缀或无关中间消息、没有覆盖 transcript final 时，Codex final fallback 会继续发出。旧 marker 仍按原保守逻辑处理。