### PR TITLE
feat(grant/oncall): 自助授权卡继承默认额度 / 修复授权卡 300000 / oncall 默认额度与首条消息不再弹申请卡

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -13,7 +13,7 @@ import { chatHasAllowedUser, resolveGroupJoinPrompt } from './core/auto-start.js
 import { loadBotConfigs, registerBot, getBot, getAllBots, findOncallChatForAnyBot, type BotState, type OncallChat } from './bot-registry.js';
 import * as sessionStore from './services/session-store.js';
 import * as chatFirstSeenStore from './services/chat-first-seen-store.js';
-import { autoBindOncallFromDefault } from './services/oncall-store.js';
+import { ensureDefaultOncallBound } from './services/oncall-store.js';
 import * as scheduleStore from './services/schedule-store.js';
 import * as messageQueue from './services/message-queue.js';
 import { parseEventMessage, resolveNonsupportMessage, stripLeadingMentions, type MessageResource } from './im/lark/message-parser.js';
@@ -429,7 +429,8 @@ export async function enforceMessageQuotaForCliInput(
 
   let quota;
   try {
-    quota = await consumeQuota(larkAppId, ev.quotaKey);
+    const def = getBot(larkAppId).config.messageQuota?.defaultLimit;
+    quota = await consumeQuota(larkAppId, ev.quotaKey, def);
   } catch (err) {
     logger.warn(`[quota:${larkAppId}] consume failed; dropping message ${messageId.substring(0, 12)}: ${err}`);
     abortCharge(larkAppId, messageId);
@@ -452,10 +453,10 @@ export async function enforceMessageQuotaForCliInput(
   }
   // 扣费成功才定论为 done。
   commitCharge(larkAppId, messageId);
-  if (quota.exhausted) {
-    await revokeQuotaGrant(larkAppId, chatId, senderOpenId, ev);
-    await notifyQuotaExhausted(larkAppId, anchor, senderOpenId, quota.limit);
-  }
+  // exhausted=当前这条刚好用完额度（但依然放行给 AI 处理）。
+  // 不在此时发通知，避免给用户"本条已被拒绝"的错觉；
+  // 也不提前 revoke —— 把 quotaState 的 {limit, used>=limit} 记录保留下来，
+  // 等用户下一条消息进来被 allow=false 拦截时，再发"额度已用完"通知 + 执行 revoke。
   return true;
 }
 
@@ -1751,56 +1752,16 @@ function parseTriggerChatBinding(
  * unless it's already bound (`findOncallChatForAnyBot` upstream) or the user
  * has opted out via tombstone.
  *
- * Returns the binding entry on success, undefined when any precondition
- * fails or the lock-internal authoritative check (in `autoBindOncallFromDefault`)
- * sees a concurrent tombstone / existing binding.
+ * Thin wrapper around the shared `ensureDefaultOncallBound` in oncall-store,
+ * which dispatcher also calls before canTalk to avoid the oncall-first-message
+ * "无权限 → 弹授权卡" bug. Idempotent: repeated calls safe.
  */
 async function maybeAutoBindDefaultOncall(
   larkAppId: string,
   chatId: string,
   chatType: 'group' | 'p2p',
 ): Promise<OncallChat | undefined> {
-  if (chatType !== 'group') return undefined; // oncall is group-only by design
-  const bot = getBot(larkAppId);
-  const def = bot.config.defaultOncall;
-  if (!def?.enabled || !def.workingDir) return undefined;
-
-  // Fast-path tombstone check against the in-memory snapshot — avoids taking
-  // the lock when we already know we'd skip. The AUTHORITATIVE re-check lives
-  // inside autoBindOncallFromDefault under the file lock, so a race with a
-  // concurrent unbind (which writes the tombstone) is still safe.
-  const autobound = bot.config.defaultOncallAutoboundChats ?? [];
-  if (autobound.includes(chatId)) return undefined;
-
-  // Validate workingDir at fire time too — directory might have been
-  // deleted/moved since the dashboard save validated it. Skipping (vs.
-  // crashing) lets the user fix the path without losing other bot config.
-  const resolved = expandHome(def.workingDir);
-  let isDir = false;
-  try { isDir = statSync(resolved).isDirectory(); } catch { /* not a dir */ }
-  if (!isDir) {
-    logger.warn(
-      `[${larkAppId}] defaultOncall workingDir invalid (${resolved}); ` +
-      `skipping auto-bind for chat=${chatId}`,
-    );
-    return undefined;
-  }
-
-  const r = await autoBindOncallFromDefault(larkAppId, chatId, def.workingDir);
-  if (!r.ok) {
-    logger.warn(`[${larkAppId}] defaultOncall auto-bind failed: chat=${chatId} reason=${r.reason}`);
-    return undefined;
-  }
-  if (r.skipped) {
-    // Lock-internal authoritative check disagreed with our fast-path —
-    // tombstone or binding raced in. Fine, just don't surface a binding.
-    logger.info(`[${larkAppId}] defaultOncall auto-bind skipped chat=${chatId} reason=${r.skipped}`);
-    return undefined;
-  }
-  logger.info(
-    `[${larkAppId}] defaultOncall auto-bound chat=${chatId} → ${def.workingDir}`,
-  );
-  return r.entry;
+  return ensureDefaultOncallBound(larkAppId, chatId, chatType);
 }
 
 /**

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -231,48 +231,46 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     } catch (err) {
       logger.warn(`grant auto-introduce (observed) failed (grant still applied): ${err}`);
     }
-    // 授权成功后：在原线程 @ 被授权人发通知 + 撤回授权卡（用户要求）。
-    // 这两步失败不回滚授权（已落库），仅记日志，并兜底用 in-place patch 让 owner 看到结果。
+    // 授权成功后：
+    //   1. 先同步返回 callback 响应（in-place patch 成「已授权」终态卡），避免飞书等待
+    //      太久或 deleteMessage 与 callback 响应竞态导致客户端 300000 报错；
+    //   2. 通知卡 + 部分失败告知 + 撤回原卡 走后台 fire-and-forget（不阻塞 callback）。
+    const resultCardBody = JSON.parse(buildGrantResultCard(kind, loc));
     if (cardMessageId) {
-      // 通知是 best-effort（@被授权人）；失败不影响主流程，只记日志。
-      //
-      // reply_in_thread 只在「卡片本身已处于话题里」时才开：
-      //   - 话题群 / 普通群内话题 → 卡片有 thread_id → 线程化回复，落进原话题；
-      //   - 普通群顶层消息       → 卡片无 thread_id → reply_in_thread 会凭空开一个
-      //                            新话题（用户不想要），改为普通回复直接落到群里。
-      // thread_id 是「是否真的在话题里」的权威信号（见 event-dispatcher.decideRouting）。
-      // 探测失败时退回线程化回复，保持话题群下的原有行为。
       let replyInThread = true;
       try {
         const detail = await getMessageDetail(larkAppId, cardMessageId);
         const item = detail?.items?.[0];
-        // 拿不到 message item 视为探测失败（走 catch 退回 true），而不是误判成
-        // 「无 thread_id → 普通回复」——后者会在话题群里破坏原有的线程化行为。
         if (!item) throw new Error('no message item in getMessageDetail response');
         replyInThread = Boolean(item.thread_id);
       } catch (err) {
         logger.debug(`grant notify thread-mode probe failed, defaulting to thread reply: ${err}`);
       }
-      try {
-        await replyMessage(larkAppId, cardMessageId, buildGrantNotifyCard(kind, target, loc, quota), 'interactive', replyInThread);
-      } catch (err) {
-        logger.warn(`grant notify failed (grant still applied): ${err}`);
-      }
-      // 部分授权失败：在原线程明确告知 owner（绝不静默撤卡）。失败 target 的 pending 已清，
-      // owner 据此可重新 /grant 重试。
-      if (failed.length > 0) {
-        const failNames = failed.map(f => idToName.get(f.openId) || f.openId).join('、');
-        await replyMessage(larkAppId, cardMessageId, t('card.grant.partial_failed', { names: failNames }, loc), 'text', replyInThread)
-          .catch(err => logger.warn(`grant partial-failure notice failed: ${err}`));
-      }
-      // 撤回授权卡。deleteMessage 返回 boolean——只有确认撤回成功才不返回 patch；
-      // 否则（SDK 吞错/非 0 code）落到 in-place patch，避免卡片留在原地无终态。
-      const withdrawn = await deleteMessage(larkAppId, cardMessageId);
-      if (withdrawn) return;
-      logger.warn(`grant card withdraw failed (grant still applied); falling back to in-place patch`);
+      // fire-and-forget: 通知卡 + 部分失败文字 + 撤回原卡
+      Promise.resolve()
+        .then(async () => {
+          try {
+            await replyMessage(larkAppId, cardMessageId, buildGrantNotifyCard(kind, target, loc, quota), 'interactive', replyInThread);
+          } catch (err) {
+            logger.warn(`grant notify failed (grant still applied): ${err}`);
+          }
+          if (failed.length > 0) {
+            const failNames = failed.map(f => idToName.get(f.openId) || f.openId).join('、');
+            try {
+              await replyMessage(larkAppId, cardMessageId, t('card.grant.partial_failed', { names: failNames }, loc), 'text', replyInThread);
+            } catch (err) {
+              logger.warn(`grant partial-failure notice failed: ${err}`);
+            }
+          }
+          try {
+            await deleteMessage(larkAppId, cardMessageId);
+          } catch (err) {
+            logger.debug(`grant card withdraw (post-callback) failed: ${err}`);
+          }
+        })
+        .catch(err => logger.error(`grant post-callback background tasks failed: ${err}`));
     }
-    // 兜底（无 card message_id，或撤回失败）：靠 callback 返回 patch 原地更新卡。
-    return JSON.parse(buildGrantResultCard(kind, loc));
+    return resultCardBody;
   }
 
   if (isAskCardAction(value?.action)) {

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -21,6 +21,7 @@ import { buildGrantCard } from './card-builder.js';
 import { openPending, isThrottled } from './grant-pending.js';
 import { localeForBot, t } from '../../i18n/index.js';
 import { chatQuotaKey, globalQuotaKey } from '../../services/grant-store.js';
+import { ensureDefaultOncallBound } from '../../services/oncall-store.js';
 
 // ─── Bot identity ─────────────────────────────────────────────────────────
 
@@ -768,7 +769,16 @@ export function evaluateTalk(larkAppId: string, chatId: string | undefined, send
   // 成员关系隐含在"能在该 chat 发言"里 —— 退群者发不了言自动失权，新人进群即生效，无需成员快照。
   const allowedUsers = bot.resolvedAllowedUsers;
   if (senderOpenId && allowedUsers.includes(senderOpenId)) return { allowed: true, reason: 'allowedUser' };
-  if (chatId && findOncallChat(larkAppId, chatId)) return { allowed: true, reason: 'oncall' };
+  // Oncall 群命中：默认不限额；仅当 bot 配了 messageQuota.defaultLimit 时，
+  // 才挂 chat:<chatId>:<openId> 这一 quotaKey（与 chatGrant 同键、同计数器，
+  // 便于 owner 后续 /grant @x N 续杯/重置）。
+  if (chatId && findOncallChat(larkAppId, chatId)) {
+    const def = bot.config.messageQuota?.defaultLimit;
+    if (typeof def === 'number' && Number.isInteger(def) && def > 0 && senderOpenId) {
+      return { allowed: true, reason: 'oncall', quotaKey: chatQuotaKey(chatId, senderOpenId) };
+    }
+    return { allowed: true, reason: 'oncall' };
+  }
   if (isKnownPeerBot(config.session.dataDir, larkAppId, senderOpenId)) return { allowed: true, reason: 'peer' };
   if (chatId && bot.config.allowedChatGroups?.includes(chatId)) return { allowed: true, reason: 'allowedChatGroup' };
 
@@ -820,7 +830,7 @@ async function maybeSendGrantRequestCard(
   if (isThrottled(larkAppId, chatId, requesterOpenId)) return;
   const name = (message?.mentions ?? []).find((m: any) => m?.id?.open_id === requesterOpenId)?.name
     ?? requesterOpenId;
-  const nonce = openPending(larkAppId, chatId, requesterOpenId);
+  const nonce = openPending(larkAppId, chatId, requesterOpenId, getBot(larkAppId).config.messageQuota?.defaultLimit);
   const card = buildGrantCard(
     { ownerOpenId: owner, targets: [{ openId: requesterOpenId, name: String(name) }], chatId, nonce, mode: 'request' },
     localeForBot(larkAppId),
@@ -1158,6 +1168,12 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
         }
 
         const senderOpenId = sender?.sender_id?.open_id as string | undefined;
+        // defaultOncall 自动绑定必须在 canTalk 权限判断前完成，否则已开 defaultOncall
+        // 的群首次 @bot 时 oncallChats 中还没有该 chat → evaluateTalk 判无权限 → 误弹
+        // 自助授权申请卡。ensureDefaultOncallBound 本身带 fast-path 短路且 idempotent。
+        await ensureDefaultOncallBound(larkAppId, chatId, chatType).catch(err =>
+          logger.warn(`[oncall:${larkAppId}] pre-permission auto-bind failed for ${chatId.substring(0, 12)}: ${err}`),
+        );
         const isAllowed = canTalk(larkAppId, chatId, senderOpenId);
 
         // /introduce — collaboration handshake. Intercept before any routing

--- a/src/services/grant-store.ts
+++ b/src/services/grant-store.ts
@@ -173,16 +173,25 @@ export async function removeGlobalGrant(
  * 已达/超上限 → allow:false（应拦本条 + 自愈 revoke）。
  * 正常递增 → allow:true，exhausted=（used 恰好达 limit），调用方放行本条、若 exhausted 则处理后 revoke。
  * 基础设施失败（getBot / RMW）会 throw —— 调用方 catch 后 fail-closed（拒发以保硬上限）。
+ *
+ * defaultLimit>0 且 quotaKey 对应记录不存在时：懒初始化 {limit:defaultLimit, used:1}
+ * （oncall 群默认额度场景，避免每条消息都要显式 /grant 才落记录）。
  */
 export async function consumeQuota(
-  larkAppId: string, quotaKey: string,
+  larkAppId: string, quotaKey: string, defaultLimit?: number,
 ): Promise<{ tracked: boolean; allow: boolean; exhausted: boolean; used: number; limit: number }> {
   const bot = getBot(larkAppId); // throw → 调用方 fail-closed
   type Res = { tracked: boolean; allow: boolean; exhausted: boolean; used: number; limit: number };
+  const initLimit = typeof defaultLimit === 'number' && Number.isInteger(defaultLimit) && defaultLimit > 0 ? defaultLimit : 0;
   const r = await rmwBotEntry<Res>(larkAppId, (entry) => {
     const qs = getQuotaMap(entry);
     const rec = qs?.[quotaKey];
-    if (!rec) return { write: false, result: { tracked: false, allow: true, exhausted: false, used: 0, limit: 0 } };
+    if (!rec) {
+      if (!initLimit) return { write: false, result: { tracked: false, allow: true, exhausted: false, used: 0, limit: 0 } };
+      // 懒初始化：defaultLimit 生效，首次命中即 used=1
+      entry.quotaState = { ...(qs ?? {}), [quotaKey]: { limit: initLimit, used: 1 } };
+      return { write: true, result: { tracked: true, allow: true, exhausted: 1 >= initLimit, used: 1, limit: initLimit } };
+    }
     if (rec.used >= rec.limit) {
       return { write: false, result: { tracked: true, allow: false, exhausted: true, used: rec.used, limit: rec.limit } };
     }

--- a/src/services/oncall-store.ts
+++ b/src/services/oncall-store.ts
@@ -14,10 +14,11 @@
  * write race. The lock is also re-acquired around the read so the modify
  * step always works against the latest on-disk snapshot.
  */
-import { readFileSync } from 'node:fs';
+import { readFileSync, statSync } from 'node:fs';
 import { getBot, type BotDefaultOncall, type OncallChat } from '../bot-registry.js';
 import { rmwBotEntry } from './config-store.js';
 import { logger } from '../utils/logger.js';
+import { expandHomePath } from '../utils/working-dir.js';
 
 // ─── Manual binding ───────────────────────────────────────────────────────
 
@@ -248,6 +249,39 @@ export async function autoBindOncallFromDefault(
 
   logger.info(`[oncall:${larkAppId}] auto-bind (default) chat=${chatId} dir=${workingDir}`);
   return { ok: true, entry: next, created: r.result.created };
+}
+
+/**
+ * 前置 auto-bind：dispatcher 在权限判断前调用，保证 oncall 群的首条 @bot 消息
+ * 不被误判为"无权限"弹授权申请卡。
+ *
+ * 做了与 daemon 侧一致的快速短路：非群聊 / defaultOncall 未开 / 已在 tombstone 列表
+ * / chat 已有显式 oncall 绑定 → 立刻 return；否则调 autoBindOncallFromDefault
+ * （内部会在锁内做权威二次校验）。idempotent，daemon spawn 路径二次调用安全。
+ */
+export async function ensureDefaultOncallBound(
+  larkAppId: string,
+  chatId: string,
+  chatType: 'group' | 'p2p',
+): Promise<OncallChat | undefined> {
+  if (chatType !== 'group') return undefined;
+  let bot;
+  try { bot = getBot(larkAppId); } catch { return undefined; }
+  const def = bot.config.defaultOncall;
+  if (!def?.enabled || !def.workingDir) return undefined;
+  // fast-path: tombstone 或已显式绑定 —— 跳过磁盘写
+  if ((bot.config.defaultOncallAutoboundChats ?? []).includes(chatId)) return undefined;
+  if (bot.config.oncallChats?.some(c => c.chatId === chatId)) return undefined;
+  const resolved = expandHomePath(def.workingDir);
+  let isDir = false;
+  try { isDir = statSync(resolved).isDirectory(); } catch { /* not a dir */ }
+  if (!isDir) {
+    logger.warn(`[oncall:${larkAppId}] defaultOncall workingDir invalid (${resolved}); skipping auto-bind chat=${chatId}`);
+    return undefined;
+  }
+  const r = await autoBindOncallFromDefault(larkAppId, chatId, def.workingDir);
+  if (!r.ok || r.skipped) return undefined;
+  return r.entry;
 }
 
 // Test helper — read raw bots.json synchronously. Not for production use.

--- a/test/card-handler-grant-partial.test.ts
+++ b/test/card-handler-grant-partial.test.ts
@@ -43,6 +43,10 @@ vi.mock('../src/services/observed-bots-store.js', async (importOriginal) => {
 
 const deps = { activeSessions: new Map(), sessionReply: vi.fn(async () => 'mid'), lastRepoScan: new Map() } as any;
 
+// 通知卡 / 部分失败文字 / 撤回原卡现在走 fire-and-forget 后台（handleCardAction 先同步返回
+// 终态卡避免 callback 超时 → 300000）。一次宏任务把整条后台微任务链排空再断言后台副作用。
+const flushBackground = () => new Promise(resolve => setTimeout(resolve, 0));
+
 async function fresh() {
   vi.resetModules();
   const registry = await import('../src/bot-registry.js');
@@ -77,11 +81,13 @@ describe('card-handler 部分授权失败', () => {
     const nonce = pending.openPendingMulti('h1', 'oc_1', ['ou_ok', 'ou_fail']);
     await handler.handleCardAction(multiAction(['ou_ok', 'ou_fail'], ['好机器人', '坏目标'], nonce), deps, 'h1');
 
-    // 失败 target 的 pending 必须清掉：checkNonce/isThrottled 都不再挡它
+    // 失败 target 的 pending 必须清掉：checkNonce/isThrottled 都不再挡它（同步发生，扣 pending 在落库阶段）
     expect(pending.checkNonce('h1', 'oc_1', 'ou_fail', nonce)).toBe(false);
     expect(pending.isThrottled('h1', 'oc_1', 'ou_fail')).toBe(false);
     // 成功 target 也清了
     expect(pending.checkNonce('h1', 'oc_1', 'ou_ok', nonce)).toBe(false);
+
+    await flushBackground();   // 通知 + 失败清单文字 + 撤卡走后台 fire-and-forget
 
     // owner 收到失败清单（含失败目标名），且不是静默
     const partialReply = replyMock.mock.calls.find(c => typeof c[2] === 'string' && String(c[2]).includes('坏目标'));

--- a/test/card-handler-grant.test.ts
+++ b/test/card-handler-grant.test.ts
@@ -39,6 +39,11 @@ vi.mock('../src/services/observed-bots-store.js', async (importOriginal) => {
 let configPath: string;
 const deps = { activeSessions: new Map(), sessionReply: vi.fn(async () => 'mid'), lastRepoScan: new Map() } as any;
 
+// 授权成功后，通知卡 / 撤回原卡现在走 fire-and-forget 后台：handleCardAction 先同步返回
+// 「已授权」终态卡（in-place patch），避免 callback 等太久或 deleteMessage 竞态 → 飞书 300000。
+// 一次宏任务（setTimeout 0）会等整条后台微任务链排空，再断言后台副作用（reply/delete）。
+const flushBackground = () => new Promise(resolve => setTimeout(resolve, 0));
+
 async function fresh() {
   vi.resetModules();
   const registry = await import('../src/bot-registry.js');
@@ -82,11 +87,12 @@ describe('card-handler grant actions', () => {
     expect(registry.getBot('h1').config.chatGrants).toBeUndefined();
   });
 
-  it('owner grant_chat WITH card id → @notify + withdraw + persists, returns nothing', async () => {
+  it('owner grant_chat WITH card id → 同步返回终态卡 patch + 后台 @notify + withdraw + persists', async () => {
     const { registry, pending, handler } = await fresh();
     const nonce = pending.openPending('h1', 'oc_1', 'ou_g');
     const res = await handler.handleCardAction(action('grant_chat', { nonce }, 'om_card'), deps, 'h1');
-    expect(res).toBeUndefined();
+    expect(res?.elements).toBeTruthy();           // 同步先回「已授权」终态卡（避免 callback 超时/竞态 → 300000）
+    await flushBackground();                       // 通知 + 撤卡走后台 fire-and-forget
     expect(replyMock).toHaveBeenCalledWith('h1', 'om_card', expect.stringContaining('ou_g'), 'interactive', true);
     expect(deleteMock).toHaveBeenCalledWith('h1', 'om_card');
     expect(registry.getBot('h1').config.chatGrants).toEqual({ oc_1: ['ou_g'] });
@@ -154,11 +160,12 @@ describe('card-handler grant actions', () => {
     expect(registry.getBot('h1').config.chatGrants).toBeUndefined();
   });
 
-  it('owner grant_global → writes globalGrants (not chatGrants/allowedUsers), notifies + withdraws', async () => {
+  it('owner grant_global → writes globalGrants (not chatGrants/allowedUsers), 终态卡 patch + 后台 notify + withdraw', async () => {
     const { registry, pending, handler } = await fresh();
     const nonce = pending.openPending('h1', 'oc_1', 'ou_g');
     const res = await handler.handleCardAction(action('grant_global', { nonce }, 'om_card'), deps, 'h1');
-    expect(res).toBeUndefined();
+    expect(res?.elements).toBeTruthy();
+    await flushBackground();
     expect(replyMock).toHaveBeenCalledWith('h1', 'om_card', expect.stringContaining('ou_g'), 'interactive', true);
     expect(deleteMock).toHaveBeenCalledWith('h1', 'om_card');
     const cfg = registry.getBot('h1').config;
@@ -182,11 +189,12 @@ describe('card-handler grant actions', () => {
     return data;
   }
 
-  it('multi grant_chat: 一次授权全部目标 + @通知全部 + 撤卡 + 清 pending', async () => {
+  it('multi grant_chat: 一次授权全部目标 + 终态卡 patch + 后台 @通知全部 + 撤卡 + 清 pending', async () => {
     const { registry, pending, handler } = await fresh();
     const nonce = pending.openPendingMulti('h1', 'oc_1', ['ou_a', 'ou_b', 'ou_c']);
     const res = await handler.handleCardAction(multiAction('grant_chat', ['ou_a', 'ou_b', 'ou_c'], nonce, 'om_card'), deps, 'h1');
-    expect(res).toBeUndefined();
+    expect(res?.elements).toBeTruthy();
+    await flushBackground();
     // 通知 @ 了全部三人
     const notify = replyMock.mock.calls.at(-1)![2] as string;
     expect(notify).toContain('ou_a'); expect(notify).toContain('ou_b'); expect(notify).toContain('ou_c');

--- a/test/message-quota-enforcement.test.ts
+++ b/test/message-quota-enforcement.test.ts
@@ -148,23 +148,26 @@ describe('message quota enforcement', () => {
     expect(mocks.consumeQuota).not.toHaveBeenCalled();
   });
 
-  it('allows the exhausting chat-grant message, then removes chat grant and notifies', async () => {
+  it('allows the exhausting chat-grant message but defers revoke/notify to the next message', async () => {
+    // exhausted=true 表示「本条刚好用完额度」——依旧放行给 AI 处理，但不在此时 revoke/notify
+    // （避免给用户「本条已被拒绝」的错觉）；revoke + 通知推迟到下一条被 allow=false 拦截时再做。
     mocks.consumeQuota.mockResolvedValue({ tracked: true, allow: true, exhausted: true, used: 5, limit: 5 });
     await expect(enforceMessageQuotaForCliInput('quota_app', 'oc_1', 'ou_chat', 'om_2', 'om_anchor'))
       .resolves.toBe(true);
-    expect(mocks.consumeQuota).toHaveBeenCalledWith('quota_app', 'chat:oc_1:ou_chat');
+    expect(mocks.consumeQuota).toHaveBeenCalledWith('quota_app', 'chat:oc_1:ou_chat', undefined);
     expect(mocks.commitCharge).toHaveBeenCalledWith('quota_app', 'om_2');
-    expect(mocks.removeChatGrant).toHaveBeenCalledWith('quota_app', 'oc_1', 'ou_chat');
+    // 延迟通知：耗尽这一条不再立即 revoke / 发卡 / 通知
+    expect(mocks.removeChatGrant).not.toHaveBeenCalled();
     expect(mocks.removeGlobalGrant).not.toHaveBeenCalled();
-    expect(mocks.buildQuotaExhaustedCard).toHaveBeenCalledWith('ou_chat', 5, expect.any(String));
-    expect(mocks.replyMessage).toHaveBeenCalledWith('quota_app', 'om_anchor', 'quota-card', 'interactive', true);
+    expect(mocks.buildQuotaExhaustedCard).not.toHaveBeenCalled();
+    expect(mocks.replyMessage).not.toHaveBeenCalled();
   });
 
   it('drops already-exhausted global-grant messages and self-heals the grant', async () => {
     mocks.consumeQuota.mockResolvedValue({ tracked: true, allow: false, used: 5, limit: 5 });
     await expect(enforceMessageQuotaForCliInput('quota_app', 'oc_9', 'ou_global', 'om_3', 'om_anchor'))
       .resolves.toBe(false);
-    expect(mocks.consumeQuota).toHaveBeenCalledWith('quota_app', 'global:ou_global');
+    expect(mocks.consumeQuota).toHaveBeenCalledWith('quota_app', 'global:ou_global', undefined);
     expect(mocks.removeGlobalGrant).toHaveBeenCalledWith('quota_app', 'ou_global');
     expect(mocks.replyMessage).toHaveBeenCalled();
   });


### PR DESCRIPTION
## 改动

### 1. 自助授权申请卡继承默认额度 (`fix(grant)`)
`maybeSendGrantRequestCard` 在 openPending 时透传 `messageQuota.defaultLimit`，使普通用户 @bot 触发的自助授权卡不再是无限，与 owner 主动 `/grant @x` 的行为一致。未配 defaultLimit 保持无限。

### 2. 修复点击授权按钮后飞书报 `code: 300000` (`fix(grant)`)
根因：`card.action.trigger` callback 同步等待 getMessageDetail + replyMessage + deleteMessage 三个 API 串行完成才返回，要么触发飞书超时，要么 deleteMessage 先把卡片删掉导致 callback 返回响应时找不到目标卡片。
修复：callback 同步先返回「已授权」终态卡（in-place patch），通知卡/撤回原卡移到后台 fire-and-forget，不阻塞回调；dispatcher 回调也永远返回合法 JSON，不再返回 undefined。

### 3. defaultOncall 群首条消息不再弹"申请授权"卡 (`feat(oncall)`)
根因：canTalk 判断跑在 defaultOncall 自动绑定之前，首条消息 oncallChats 还没有该 chat，被判无权限。
修复：在 dispatcher 的 canTalk 判断前调用共享 helper `ensureDefaultOncallBound` 先落绑定；daemon 侧 `maybeAutoBindDefaultOncall` 改为调用同一 helper 消除重复。

### 4. Oncall 群默认额度 (`feat(oncall)`)
配了 `messageQuota.defaultLimit` 后，oncall 群里的非白名单成员也会按该默认值计数（与 chatGrant 共用 `chat:<chatId>:<openId>` 同键、同计数器，owner `/grant @x N` 天然续杯/重置）；owner / allowedUsers 不受影响；未配 defaultLimit 保持无限。
配套：`consumeQuota` 新增可选 `defaultLimit` 参数，记录不存在时懒初始化；额度用尽不再立刻发通知，改为下一条被拒时再提示（最后一条正常被处理，避免用户"本条明明成功了却提示额度用完"的错觉）。

## 验证
- `pnpm build` 通过
- 已 `pnpm daemon:restart` 部署到开发环境