### PR TITLE
fix(worker): worker 监听地址不再继承 WEB_HOST，避免反代失联(#107 跟进)

### DIFF
--- a/src/utils/worker-http.ts
+++ b/src/utils/worker-http.ts
@@ -9,8 +9,14 @@ export function getConfiguredWorkerHttpHost(env: EnvLike = process.env): string 
 }
 
 export function resolveWorkerHttpHost(env: EnvLike = process.env): string {
-  const webHost = env.WEB_HOST?.trim();
-  return (getConfiguredWorkerHttpHost(env) ?? webHost) || '0.0.0.0';
+  // Default to all-interfaces (matches the historical hardcoded worker bind)
+  // and only narrow when an explicit worker-host knob is set. Deliberately does
+  // NOT inherit WEB_HOST: the daemon terminal reverse proxy always dials the
+  // worker at 127.0.0.1, so binding the worker to a specific non-loopback
+  // WEB_HOST IP would make every `/s/{sessionId}` terminal (and the direct
+  // workflow terminal) unreachable. To confine the worker, set an explicit
+  // BOTMUX_WORKER_HTTP_HOST instead.
+  return getConfiguredWorkerHttpHost(env) ?? '0.0.0.0';
 }
 
 export function parseWorkerRequestUrl(req: Pick<IncomingMessage, 'url' | 'headers'>): URL | null {

--- a/test/worker-http.test.ts
+++ b/test/worker-http.test.ts
@@ -36,8 +36,11 @@ describe('resolveWorkerHttpHost', () => {
     expect(resolveWorkerHttpHost({})).toBe('0.0.0.0');
   });
 
-  it('follows WEB_HOST when worker HTTP host is not configured', () => {
-    expect(resolveWorkerHttpHost({ WEB_HOST: '192.0.2.10' })).toBe('192.0.2.10');
+  it('ignores WEB_HOST — the worker bind is decoupled from the daemon HTTP host', () => {
+    // The daemon terminal proxy always dials the worker at 127.0.0.1, so the
+    // worker must stay reachable on loopback regardless of WEB_HOST. Binding to
+    // a specific WEB_HOST IP would break `/s/{sessionId}` terminals.
+    expect(resolveWorkerHttpHost({ WEB_HOST: '192.0.2.10' })).toBe('0.0.0.0');
   });
 
   it('allows explicit worker HTTP host override', () => {
@@ -48,7 +51,19 @@ describe('resolveWorkerHttpHost', () => {
     expect(resolveWorkerHttpHost({ BOTMUX_WORKER_HOST: '::1' })).toBe('::1');
   });
 
+  it('explicit worker HTTP host wins over WEB_HOST', () => {
+    expect(resolveWorkerHttpHost({ BOTMUX_WORKER_HTTP_HOST: '127.0.0.1', WEB_HOST: '192.0.2.10' })).toBe('127.0.0.1');
+  });
+
+  it('BOTMUX_WORKER_HTTP_HOST wins over the BOTMUX_WORKER_HOST alias', () => {
+    expect(resolveWorkerHttpHost({ BOTMUX_WORKER_HTTP_HOST: '1.1.1.1', BOTMUX_WORKER_HOST: '2.2.2.2' })).toBe('1.1.1.1');
+  });
+
   it('ignores blank overrides', () => {
     expect(resolveWorkerHttpHost({ BOTMUX_WORKER_HTTP_HOST: '  ' })).toBe('0.0.0.0');
+  });
+
+  it('a blank override does not let WEB_HOST shadow the all-interfaces default', () => {
+    expect(resolveWorkerHttpHost({ BOTMUX_WORKER_HTTP_HOST: '  ', WEB_HOST: '192.0.2.10' })).toBe('0.0.0.0');
   });
 });


### PR DESCRIPTION
## 背景
跟进已合并的 #107（@xiongz-c 的 worker web server 硬化）。#107 的崩溃修复（`parseWorkerRequestUrl` try/catch）是对的，但它顺带把 worker 监听地址从硬编码 `'0.0.0.0'` 改成继承 `WEB_HOST`，引入了一个隐蔽回归。

## 问题
daemon 的单端口终端反代恒定拨号 worker 的 `127.0.0.1`（`terminal-proxy.ts:85/:109`），workflow/subagent 终端则直连 `externalHost:webPort`。当部署设置 `WEB_HOST=<具体 LAN IP>` 时，旧逻辑让 worker 只绑该网卡，反代经 `127.0.0.1` 连不上 → 每个 `/s/{sessionId}` 终端 502。master 上原本不会发生（worker 一直硬绑 `0.0.0.0`）。

## 修复
`resolveWorkerHttpHost` 去掉对 `WEB_HOST` 的兜底继承：默认严格回到 `'0.0.0.0'`（与 master 历史硬编码逐字节一致，零行为变化），只有显式的 `BOTMUX_WORKER_HTTP_HOST` / `BOTMUX_WORKER_HOST` 才能收紧。崩溃修复本身不动。

## 验证
- `tsc --noEmit` exit 0
- `worker-http.test.ts` 11/11（改 follows-WEB_HOST → ignores-WEB_HOST，补优先级用例）
- `terminal-proxy.test.ts` + `terminal-url.test.ts` 28/28