### PR TITLE
feat: /list-slash-command 命令清单 + 自定义透传命令配置

### DIFF
--- a/bots.json.example
+++ b/bots.json.example
@@ -8,7 +8,7 @@
     "allowedUsers": ["alice@company.com"],
     "allowedChatGroups": ["oc_xxx_team"],
     "workingDir": "~/projects",
-    "customPassthroughCommands": ["/status", "/export"]
+    "customPassthroughCommands": ["/goal", "/export"]
   },
   {
     "larkAppId": "cli_xxx_bot2",

--- a/bots.json.example
+++ b/bots.json.example
@@ -7,7 +7,8 @@
     "disableCliBypass": true,
     "allowedUsers": ["alice@company.com"],
     "allowedChatGroups": ["oc_xxx_team"],
-    "workingDir": "~/projects"
+    "workingDir": "~/projects",
+    "customPassthroughCommands": ["/status", "/export"]
   },
   {
     "larkAppId": "cli_xxx_bot2",

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -116,7 +116,7 @@ export interface BotConfig {
   restrictGrantCommands?: boolean;
   /**
    * 用户自定义、额外放行透传给 CLI 的 slash 命令 —— 在固定的 PASSTHROUGH_COMMANDS
-   * 之上扩展（例如把 CLI 内置但默认不放行的 `/status`、`/export` 加进来）。每项必须
+   * 之上扩展（例如把 CLI 支持但默认不放行的 `/goal`、`/export` 加进来）。每项必须
    * `/` 开头、小写、仅含 [a-z0-9:_-]；解析时归一化（缺失的 `/` 自动补、转小写、去重、
    * 丢弃非法项与会遮蔽 botmux daemon 命令的项）。与内置白名单合并后由
    * {@link resolvePassthroughCommands} 生效；`/list-slash-command` 可查看完整放行清单。

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -115,6 +115,15 @@ export interface BotConfig {
    */
   restrictGrantCommands?: boolean;
   /**
+   * 用户自定义、额外放行透传给 CLI 的 slash 命令 —— 在固定的 PASSTHROUGH_COMMANDS
+   * 之上扩展（例如把 CLI 内置但默认不放行的 `/status`、`/export` 加进来）。每项必须
+   * `/` 开头、小写、仅含 [a-z0-9:_-]；解析时归一化（缺失的 `/` 自动补、转小写、去重、
+   * 丢弃非法项与会遮蔽 botmux daemon 命令的项）。与内置白名单合并后由
+   * {@link resolvePassthroughCommands} 生效；`/list-slash-command` 可查看完整放行清单。
+   * 未配置（undefined）→ 仅用内置白名单（保持现状）。
+   */
+  customPassthroughCommands?: string[];
+  /**
    * Custom footer brand label for cards this bot sends. Three states:
    *   • `undefined` (unset)  → default `[botmux](github)` link
    *   • `''` (empty)         → brand suppressed (footer shows only 发送给 if any)
@@ -521,6 +530,21 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
       if (Object.keys(out).length > 0) quotaState = out;
     }
 
+    // customPassthroughCommands：用户额外放行透传的 slash 命令。归一化：转小写、
+    // 自动补前导 `/`、按 /^\/[a-z0-9][a-z0-9:_-]*$/ 过滤、去重。非法/缺省 → undefined。
+    // 注意：与 daemon 命令的冲突过滤放在 resolvePassthroughCommands（运行时合并）做，
+    // 这里只保证条目本身格式合法，避免在解析期耦合 command-handler 的命令清单。
+    let customPassthroughCommands: string[] | undefined;
+    if (Array.isArray(entry.customPassthroughCommands)) {
+      const normalized = entry.customPassthroughCommands
+        .filter((x: any): x is string => typeof x === 'string')
+        .map((x: string) => x.trim().toLowerCase())
+        .map((x: string) => (x.startsWith('/') ? x : `/${x}`))
+        .filter((x: string) => /^\/[a-z0-9][a-z0-9:_-]*$/.test(x));
+      const uniq = [...new Set<string>(normalized)];
+      if (uniq.length > 0) customPassthroughCommands = uniq;
+    }
+
     // voice：per-bot 语音引擎覆盖。结构化保留（engine ∈ sami|openai，sami/openai
     // 为对象，speaker/rate 透传）；非对象或 engine 非法 → undefined。深度校验
     // （凭证是否可用）在 resolveVoiceConfig 做，这里只挡明显垃圾。
@@ -567,6 +591,7 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
       messageQuota,
       quotaState,
       restrictGrantCommands: entry.restrictGrantCommands === true || undefined,
+      customPassthroughCommands,
       lang: isLocale(entry.lang) ? entry.lang : undefined,
       // Preserve '' distinctly from undefined: '' means "brand off", undefined
       // means "use default botmux brand". Don't trim-to-undefined here.

--- a/src/core/command-discovery.ts
+++ b/src/core/command-discovery.ts
@@ -1,0 +1,223 @@
+/**
+ * Slash-command discovery — enumerate the user-installed / project-local slash
+ * commands, skills and plugins that the underlying CLI (Claude Code family)
+ * would surface, purely by scanning the filesystem. Powers part ③ of the
+ * `/list-slash-command` daemon command.
+ *
+ * Scope (v1): the Claude `.claude/` layout —
+ *   • custom commands:  <root>/.claude/commands/**\/*.md  → /name (subdir → ns:name)
+ *   • skills:           <root>/.claude/skills/*\/SKILL.md  → /name
+ *   • plugins:          <claudeHome>/plugins/cache/<mp>/<plugin>/[<ver>/]{commands,skills}
+ * where <root> ∈ { workingDir (project), claudeHome (personal) } and
+ * <claudeHome> = $CLAUDE_CONFIG_DIR || ~/.claude.
+ *
+ * Intentionally dependency-free (no YAML / glob libs): a tiny frontmatter reader
+ * and a bounded recursive walker keep this importable from the leaf-ish command
+ * handler without pulling in the daemon graph.
+ *
+ * NOT covered: MCP-provided `/mcp__<server>__<prompt>` commands — enumerating
+ * those needs a live MCP handshake. {@link listMcpServerNames} cheaply surfaces
+ * the server *names* from `.mcp.json` so the caller can at least hint at them.
+ */
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import type { Dirent } from 'node:fs';
+import { join, basename, relative, sep } from 'node:path';
+import { homedir } from 'node:os';
+
+export type DiscoveredSource =
+  | 'project-command'
+  | 'user-command'
+  | 'project-skill'
+  | 'user-skill'
+  | 'plugin-command'
+  | 'plugin-skill';
+
+export interface DiscoveredCommand {
+  /** Invocation form, e.g. '/deploy' or '/myplugin:foo'. */
+  name: string;
+  /** First-line description pulled from frontmatter, when present. */
+  description?: string;
+  source: DiscoveredSource;
+  /** Human-friendly origin (relative-ish path or plugin id) for display. */
+  origin: string;
+}
+
+/** Resolve the Claude config/data root the CLI reads commands & skills from.
+ *  Honors CLAUDE_CONFIG_DIR (set by claude-family forks); defaults to ~/.claude. */
+function claudeHome(): string {
+  const env = process.env.CLAUDE_CONFIG_DIR?.trim();
+  return env && env.length > 0 ? env : join(homedir(), '.claude');
+}
+
+/** Minimal frontmatter reader: pull `name:` / `description:` from a leading
+ *  `---` … `---` block. No YAML dep — handles plain and quoted scalar values. */
+function readFrontmatter(file: string): { name?: string; description?: string } {
+  let text: string;
+  try {
+    text = readFileSync(file, 'utf-8');
+  } catch {
+    return {};
+  }
+  if (!text.startsWith('---')) return {};
+  const end = text.indexOf('\n---', 3);
+  if (end === -1) return {};
+  const block = text.slice(3, end);
+  const out: { name?: string; description?: string } = {};
+  for (const line of block.split(/\r?\n/)) {
+    const m = /^\s*(name|description)\s*:\s*(.+?)\s*$/.exec(line);
+    if (!m) continue;
+    let v = m[2].trim();
+    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+      v = v.slice(1, -1);
+    }
+    if (m[1] === 'name') out.name = v;
+    else out.description = v;
+  }
+  return out;
+}
+
+/** Recursively collect `*.md` files under `dir` (bounded depth, fail-soft). */
+function walkMd(dir: string, depth = 4): string[] {
+  if (depth < 0 || !existsSync(dir)) return [];
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const e of entries) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) out.push(...walkMd(p, depth - 1));
+    else if (e.isFile() && e.name.endsWith('.md')) out.push(p);
+  }
+  return out;
+}
+
+/** Immediate subdirectories of `dir` (fail-soft). */
+function listDirs(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => join(dir, e.name));
+  } catch {
+    return [];
+  }
+}
+
+/** `<commandsDir>/**\/*.md` → commands. Filename (minus .md) is the command;
+ *  nested subdirs become `ns:sub:name` namespaces (Claude convention). */
+function scanCommandsDir(
+  commandsDir: string,
+  source: DiscoveredSource,
+  originPrefix: string,
+): DiscoveredCommand[] {
+  return walkMd(commandsDir).map((file) => {
+    const rel = relative(commandsDir, file).replace(/\.md$/, '');
+    const name = '/' + rel.split(sep).join(':');
+    const fm = readFrontmatter(file);
+    return { name, description: fm.description, source, origin: `${originPrefix}/${rel}.md` };
+  });
+}
+
+/** `<skillsDir>/<name>/SKILL.md` → /name (optionally `ns:name` for plugins). */
+function scanSkillsDir(
+  skillsDir: string,
+  source: DiscoveredSource,
+  originPrefix: string,
+  namePrefix = '',
+): DiscoveredCommand[] {
+  const out: DiscoveredCommand[] = [];
+  for (const d of listDirs(skillsDir)) {
+    const skillMd = join(d, 'SKILL.md');
+    if (!existsSync(skillMd)) continue;
+    const base = basename(d);
+    const fm = readFrontmatter(skillMd);
+    out.push({
+      name: '/' + (namePrefix ? `${namePrefix}:${base}` : base),
+      description: fm.description,
+      source,
+      origin: `${originPrefix}/${base}/SKILL.md`,
+    });
+  }
+  return out;
+}
+
+/** Walk `<claudeRoot>/plugins/cache/<marketplace>/<plugin>/[<ver>/]{commands,skills}`.
+ *  commands/skills may sit directly under the plugin or under a version subdir —
+ *  we try both and let the caller's dedupe collapse any overlap. */
+function scanPlugins(claudeRoot: string): DiscoveredCommand[] {
+  const cacheRoot = join(claudeRoot, 'plugins', 'cache');
+  const out: DiscoveredCommand[] = [];
+  for (const mp of listDirs(cacheRoot)) {
+    for (const plugin of listDirs(mp)) {
+      const pluginId = basename(plugin);
+      const originPrefix = `plugins/${basename(mp)}/${pluginId}`;
+      const roots = [plugin, ...listDirs(plugin)];
+      for (const root of roots) {
+        for (const c of scanCommandsDir(join(root, 'commands'), 'plugin-command', originPrefix)) {
+          // Re-namespace `/foo` → `/pluginId:foo`.
+          out.push({ ...c, name: c.name.replace(/^\//, `/${pluginId}:`) });
+        }
+        out.push(...scanSkillsDir(join(root, 'skills'), 'plugin-skill', originPrefix, pluginId));
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Discover all filesystem-visible slash commands for a session's working dir.
+ * Personal (`~/.claude`) + project (`<workingDir>/.claude`) + plugins, deduped
+ * by (name, source) and sorted by name. Safe to call on any CLI: non-Claude
+ * layouts simply yield nothing.
+ */
+export function discoverSlashCommands(workingDir: string): DiscoveredCommand[] {
+  const home = claudeHome();
+  const found: DiscoveredCommand[] = [];
+
+  // Personal (global) layer.
+  found.push(...scanCommandsDir(join(home, 'commands'), 'user-command', '~/.claude/commands'));
+  found.push(...scanSkillsDir(join(home, 'skills'), 'user-skill', '~/.claude/skills'));
+  found.push(...scanPlugins(home));
+
+  // Project layer.
+  if (workingDir) {
+    const proj = join(workingDir, '.claude');
+    found.push(...scanCommandsDir(join(proj, 'commands'), 'project-command', '.claude/commands'));
+    found.push(...scanSkillsDir(join(proj, 'skills'), 'project-skill', '.claude/skills'));
+  }
+
+  const seen = new Set<string>();
+  const deduped: DiscoveredCommand[] = [];
+  for (const c of found) {
+    const key = c.name; // dedupe by name across sources (fixes duplicate cmds)
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(c);
+  }
+  deduped.sort((a, b) => a.name.localeCompare(b.name));
+  return deduped;
+}
+
+/**
+ * Cheaply surface MCP *server* names from `<workingDir>/.mcp.json` (the standard
+ * project-level MCP config). The actual `/mcp__<server>__<prompt>` commands need
+ * a live handshake to enumerate and are out of scope here — this is just a hint.
+ */
+export function listMcpServerNames(workingDir: string): string[] {
+  if (!workingDir) return [];
+  const file = join(workingDir, '.mcp.json');
+  if (!existsSync(file)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(file, 'utf-8'));
+    const servers = parsed?.mcpServers;
+    if (servers && typeof servers === 'object' && !Array.isArray(servers)) {
+      return Object.keys(servers);
+    }
+  } catch {
+    /* malformed .mcp.json — ignore */
+  }
+  return [];
+}

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -11,13 +11,14 @@ import * as sessionStore from '../services/session-store.js';
 import * as scheduleStore from '../services/schedule-store.js';
 import * as scheduler from './scheduler.js';
 import { scanProjects, scanMultipleProjects, describeProjectDir } from '../services/project-scanner.js';
-import { buildRepoSelectCard, buildAdoptSelectCard, buildCodexAppThreadSelectCard, buildSessionClosedCard, getCliDisplayName } from '../im/lark/card-builder.js';
+import { buildRepoSelectCard, buildAdoptSelectCard, buildCodexAppThreadSelectCard, buildSessionClosedCard, buildSlashListCard, getCliDisplayName } from '../im/lark/card-builder.js';
 import { createCliAdapterSync } from '../adapters/cli/registry.js';
 import { deleteMessage, sendMessage, listChatBotMembers, resolveUserUnionId, getChatModeStrict } from '../im/lark/client.js';
 import { claimPairing } from '../services/pairing-store.js';
 import { logger } from '../utils/logger.js';
 import { killWorker, forkWorker, forkAdoptWorker, getCurrentCliVersion, postFreshStreamingCard, postPrivateSnapshotCard, resolvePrivateCardAudience } from './worker-pool.js';
 import { expandHome, getSessionWorkingDir, getProjectScanDir, getProjectScanDirs, rememberLastCliInput } from './session-manager.js';
+import { discoverSlashCommands, listMcpServerNames } from './command-discovery.js';
 import { validateWorkingDir } from './working-dir.js';
 import { discoverAdoptableSessions, validateAdoptTarget, adoptTargetKey, adoptTargetLabel, type AdoptableSession } from './session-discovery.js';
 import { discoverAdoptableZellijSessions, validateZellijAdoptTarget, type ZellijAdoptableSession } from './zellij-adopt-discovery.js';
@@ -35,7 +36,7 @@ import { t, localeForBot, type Locale } from '../i18n/index.js';
 
 // ─── Exported constants ──────────────────────────────────────────────────────
 
-export const DAEMON_COMMANDS = new Set(['/close', '/restart', '/status', '/help', '/cd', '/repo', '/schedule', '/role', '/pair', '/login', '/adopt', '/detach', '/disconnect', '/oncall', '/group', '/g', '/relay', '/card']);
+export const DAEMON_COMMANDS = new Set(['/close', '/restart', '/status', '/help', '/cd', '/repo', '/schedule', '/role', '/pair', '/login', '/adopt', '/detach', '/disconnect', '/oncall', '/group', '/g', '/relay', '/card', '/list-slash-command', '/slash']);
 
 /**
  * Daemon commands that act on the chat itself rather than opening a
@@ -45,7 +46,7 @@ export const DAEMON_COMMANDS = new Set(['/close', '/restart', '/status', '/help'
  * card buttons routable, but for these that record is a phantom conversation
  * that pollutes the dashboard's session list. Handle them without a session.
  */
-export const SESSIONLESS_DAEMON_COMMANDS = new Set(['/group', '/g']);
+export const SESSIONLESS_DAEMON_COMMANDS = new Set(['/group', '/g', '/list-slash-command', '/slash']);
 
 /**
  * Slash commands that are forwarded verbatim to the underlying CLI (e.g.
@@ -62,6 +63,28 @@ export const PASSTHROUGH_COMMANDS = new Set([
   // Codex：/btw 向当前会话追加一条旁注/引导消息
   '/btw',
 ]);
+
+/**
+ * Effective passthrough set for a bot: the fixed {@link PASSTHROUGH_COMMANDS}
+ * plus the bot's `customPassthroughCommands` (bots.json). Entries that would
+ * shadow a botmux daemon command are dropped — daemon commands must keep their
+ * daemon semantics, and passthrough is checked BEFORE DAEMON_COMMANDS in the
+ * router, so an un-filtered custom `/status` would hijack the daemon's own.
+ * Unknown / no bot → falls back to the builtin set unchanged.
+ */
+export function resolvePassthroughCommands(larkAppId?: string): Set<string> {
+  const effective = new Set(PASSTHROUGH_COMMANDS);
+  if (!larkAppId) return effective;
+  try {
+    for (const c of getBot(larkAppId).config.customPassthroughCommands ?? []) {
+      if (DAEMON_COMMANDS.has(c)) continue; // never shadow a daemon command
+      effective.add(c);
+    }
+  } catch {
+    /* unknown bot — builtin set only */
+  }
+  return effective;
+}
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -1738,6 +1761,32 @@ export async function handleCommand(
         break;
       }
 
+      case '/list-slash-command':
+      case '/slash': {
+        // 列出本 bot 当前可用的 slash 命令，分三段：
+        //   ① botmux 固定放行的透传白名单（PASSTHROUGH_COMMANDS）
+        //   ② 用户在 bots.json 自定义配置的额外透传命令（customPassthroughCommands）
+        //   ③ 文件系统自动发现的 .claude 自定义命令 / skill / 插件（discoverSlashCommands）
+        // MCP 的 /mcp__<server>__<prompt> 需运行时握手才能枚举，这里仅按 .mcp.json 提示 server 名。
+        const botCfg = ds
+          ? getBot(ds.larkAppId).config
+          : (larkAppId ? getBot(larkAppId).config : getAllBots()[0]?.config);
+        const cliName = getCliDisplayName(botCfg?.cliId ?? 'claude-code');
+        const workingDir = getSessionWorkingDir(ds);
+        const builtin = [...PASSTHROUGH_COMMANDS];
+        const custom = botCfg?.customPassthroughCommands ?? [];
+        const discovered = discoverSlashCommands(workingDir);
+        const mcpServers = listMcpServerNames(workingDir);
+
+        const card = buildSlashListCard(
+          { cliName, builtin, custom, discovered, workingDir, mcpServers },
+          loc,
+        );
+        await sessionReply(rootId, card, 'interactive');
+        logger.info(`[${logTag}] /list-slash-command builtin=${builtin.length} custom=${custom.length} discovered=${discovered.length}`);
+        break;
+      }
+
       case '/help': {
         const botCfg = ds ? getBot(ds.larkAppId).config : getAllBots()[0]?.config;
         const cliName = getCliDisplayName(botCfg?.cliId ?? 'claude-code');
@@ -1786,6 +1835,7 @@ export async function handleCommand(
           t('help.heading_group', undefined, loc),
           t('help.group', undefined, loc),
           '',
+          t('help.list_slash', undefined, loc),
           t('help.help', undefined, loc),
         ];
         await sessionReply(rootId, help.join('\n'));

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -53,7 +53,7 @@ import {
 } from './core/worker-pool.js';
 import { ipcRoute, jsonRes, readJsonBody, setBotName, setLarkAppId, startIpcServer, setWorkflowRunner } from './core/dashboard-ipc-server.js';
 import { saveFrozenCards, deleteFrozenCards } from './services/frozen-card-store.js';
-import { DAEMON_COMMANDS, SESSIONLESS_DAEMON_COMMANDS, PASSTHROUGH_COMMANDS, handleCommand, handleCardCommand, parseSlashCommandInvocation, parseForceTopicInvocation } from './core/command-handler.js';
+import { DAEMON_COMMANDS, SESSIONLESS_DAEMON_COMMANDS, resolvePassthroughCommands, handleCommand, handleCardCommand, parseSlashCommandInvocation, parseForceTopicInvocation } from './core/command-handler.js';
 import type { CommandHandlerDeps } from './core/command-handler.js';
 import { findInheritablePeer } from './core/inherit-peer.js';
 import { isCallbackUrl, handleCallbackUrl } from './utils/user-token.js';
@@ -1966,7 +1966,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
       await handleCardCommand(anchor, larkAppId, chatId, senderOpenId, commandContent, commandDeps);
       return;
     }
-    if (PASSTHROUGH_COMMANDS.has(cmd)) {
+    if (resolvePassthroughCommands(larkAppId).has(cmd)) {
       await sessionReply(anchor, tr('daemon.cmd_requires_session', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
       return;
     }
@@ -2523,7 +2523,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
       await sessionReply(anchor, restrictedText, 'text', larkAppId);
       return;
     }
-    if (PASSTHROUGH_COMMANDS.has(cmd)) {
+    if (resolvePassthroughCommands(larkAppId).has(cmd)) {
       // 语义边界（刻意保留，非疏漏）：passthrough（/model /clear /compact 等）按
       // “发给 CLI 的对话输入”处理，因此不过下面 DAEMON_COMMANDS 的 oncall
       // canOperate 闸 —— oncall 放行的就是对话输入，canOperate 只管 botmux

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -309,7 +309,20 @@ export const messages: Record<string, string> = {
   'help.revoke': '@bot /revoke @someone  - Revoke their talk access (you can @ several at once); /revoke (no target) revokes the whole-chat grant',
   'help.heading_group': '🆕 One-shot session group:',
   'help.group': '/group <name>  (alias /g)  - Auto-create a group and invite you (the whole group = one CLI session)',
+  'help.list_slash': '/list-slash-command  (alias /slash)  - List the slash commands available now (fixed allowlist / custom config / auto-discovered)',
   'help.help': '/help       - Show this help',
+
+  // ─── /list-slash-command ─────────────────────────────────────────────────
+  'slashlist.heading': '🧩 Slash commands available now ({cliName})',
+  'slashlist.part_builtin': '① Fixed allowlist (builtin passthrough):',
+  'slashlist.part_custom': '② User-configured (bots.json · customPassthroughCommands):',
+  'slashlist.part_custom_empty': '(none configured — add customPassthroughCommands: ["/xxx"] to this bot in bots.json to allow more)',
+  'slashlist.part_discovered': '③ Auto-discovered ({cliName} .claude commands / skills / plugins):',
+  'slashlist.part_discovered_empty': '(none found — no commands/skills/plugins under {dir} or ~/.claude)',
+  'slashlist.more': '… {n} more not shown',
+  'slashlist.mcp_note': 'ℹ️ MCP /mcp__<server>__<prompt> commands need a live handshake to enumerate and are not listed here. Detected MCP servers: {servers}',
+  'slashlist.col_cmd': 'Command',
+  'slashlist.col_desc': 'Description',
 
   // ─── AI system prompt (Claude Code: --append-system-prompt) ──────────────
   'ai.routing.intro': 'You are connected to a Lark (Feishu) topic group. The user is reading on Lark and CANNOT see your terminal output.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -312,7 +312,20 @@ export const messages: Record<string, string> = {
   'help.revoke': '@机器人 /revoke @某人  - 撤销对方本群对话权（可一次 @ 多人/多 bot）；/revoke（不带人）撤销整群授权',
   'help.heading_group': '🆕 一键新建会话群：',
   'help.group': '/group <群名>  (别名 /g)  - 自动建群、邀请你进群（整群=一个 CLI 会话）',
+  'help.list_slash': '/list-slash-command  (别名 /slash)  - 列出当前可用的 slash 命令（固定放行 / 自定义配置 / 自动发现三段）',
   'help.help': '/help       - 显示此帮助',
+
+  // ─── /list-slash-command ─────────────────────────────────────────────────
+  'slashlist.heading': '🧩 当前可用的 Slash 命令（{cliName}）',
+  'slashlist.part_builtin': '① botmux 固定放行（内置透传白名单）：',
+  'slashlist.part_custom': '② 用户自定义配置（bots.json · customPassthroughCommands）：',
+  'slashlist.part_custom_empty': '（未配置 —— 在 bots.json 给本 bot 加 customPassthroughCommands: ["/xxx"] 即可额外放行）',
+  'slashlist.part_discovered': '③ 自动发现（{cliName} 的 .claude 自定义命令 / skill / 插件）：',
+  'slashlist.part_discovered_empty': '（未发现 —— {dir} 及 ~/.claude 下暂无 commands/skills/plugins）',
+  'slashlist.more': '… 另有 {n} 条未展示',
+  'slashlist.mcp_note': 'ℹ️ MCP 的 /mcp__<server>__<prompt> 需运行时握手才能枚举，此处不列。检测到 MCP server：{servers}',
+  'slashlist.col_cmd': '命令',
+  'slashlist.col_desc': '说明',
 
   // ─── AI system prompt (Claude Code: --append-system-prompt) ──────────────
   'ai.routing.intro': '你连接到了飞书（Lark）话题群。用户在飞书上阅读，看不到你的终端输出。',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -199,6 +199,107 @@ export function buildPendingResponseCard(locale?: Locale): string {
   });
 }
 
+/** Collapse whitespace and clip a discovered-command description for a table cell. */
+function clipDesc(desc?: string): string {
+  if (!desc) return '—';
+  const flat = desc.replace(/\s+/g, ' ').trim();
+  return flat.length > 70 ? flat.slice(0, 69) + '…' : flat;
+}
+
+/**
+ * Build the `/list-slash-command` card (schema 2.0): a coloured header and three
+ * sections — ① fixed passthrough allowlist, ② user-configured custom passthrough,
+ * ③ auto-discovered .claude commands/skills/plugins rendered as a paginated native
+ * table (command | description). An optional MCP-servers note is appended.
+ */
+export function buildSlashListCard(
+  params: {
+    cliName: string;
+    builtin: string[];
+    custom: string[];
+    discovered: { name: string; description?: string }[];
+    workingDir: string;
+    mcpServers: string[];
+  },
+  locale?: Locale,
+): string {
+  const { cliName, builtin, custom, discovered, workingDir, mcpServers } = params;
+  const asCode = (cmds: string[]) => cmds.map((c) => `\`${c}\``).join('  ');
+  const elements: any[] = [];
+
+  // ① 固定放行（内置透传白名单）
+  elements.push({
+    tag: 'markdown',
+    content: `**${t('slashlist.part_builtin', undefined, locale)}**\n${builtin.length ? asCode(builtin) : '—'}`,
+  });
+  elements.push({ tag: 'hr' });
+
+  // ② 用户自定义配置
+  elements.push({
+    tag: 'markdown',
+    content: `**${t('slashlist.part_custom', undefined, locale)}**\n${
+      custom.length ? asCode(custom) : t('slashlist.part_custom_empty', undefined, locale)
+    }`,
+  });
+  elements.push({ tag: 'hr' });
+
+  // ③ 自动发现（命令 / skill / 插件）
+  const discHeading = `**${t('slashlist.part_discovered', { cliName }, locale)}**`;
+  if (discovered.length === 0) {
+    elements.push({
+      tag: 'markdown',
+      content: `${discHeading}\n${t('slashlist.part_discovered_empty', { dir: workingDir }, locale)}`,
+    });
+  } else {
+    const MAX = 60;
+    const shown = discovered.slice(0, MAX);
+    elements.push({ tag: 'markdown', content: `${discHeading}　·　${discovered.length}` });
+    elements.push({
+      tag: 'table',
+      page_size: 10,
+      row_height: 'low',
+      header_style: {
+        text_align: 'left',
+        text_size: 'normal',
+        background_style: 'grey',
+        text_color: 'default',
+        bold: true,
+        lines: 1,
+      },
+      columns: [
+        { name: 'cmd', display_name: t('slashlist.col_cmd', undefined, locale), data_type: 'lark_md', width: '200px' },
+        { name: 'desc', display_name: t('slashlist.col_desc', undefined, locale), data_type: 'text', width: 'auto' },
+      ],
+      rows: shown.map((c) => ({ cmd: `\`${c.name}\``, desc: clipDesc(c.description) })),
+    });
+    if (discovered.length > MAX) {
+      elements.push({
+        tag: 'note',
+        elements: [{ tag: 'lark_md', content: t('slashlist.more', { n: String(discovered.length - MAX) }, locale) }],
+      });
+    }
+  }
+
+  // MCP 提示（server 名，prompt 需运行时握手不在此列）
+  if (mcpServers.length > 0) {
+    elements.push({ tag: 'hr' });
+    elements.push({
+      tag: 'note',
+      elements: [{ tag: 'lark_md', content: t('slashlist.mcp_note', { servers: mcpServers.join(', ') }, locale) }],
+    });
+  }
+
+  return JSON.stringify({
+    schema: '2.0',
+    config: { update_multi: true },
+    header: {
+      template: 'blue',
+      title: { tag: 'plain_text', content: t('slashlist.heading', { cliName }, locale) },
+    },
+    body: { direction: 'vertical', elements },
+  });
+}
+
 
 export function buildDetouredPendingResponseCard(locale?: Locale): string {
   return JSON.stringify({

--- a/test/command-discovery.test.ts
+++ b/test/command-discovery.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for command-discovery (filesystem slash-command discovery) and the
+ * customPassthroughCommands normalization in parseBotConfigsFromText.
+ *
+ * Run:  pnpm vitest run test/command-discovery.test.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { discoverSlashCommands, listMcpServerNames } from '../src/core/command-discovery.js';
+import { parseBotConfigsFromText } from '../src/bot-registry.js';
+
+function write(file: string, content: string): void {
+  mkdirSync(join(file, '..'), { recursive: true });
+  writeFileSync(file, content);
+}
+
+describe('discoverSlashCommands', () => {
+  let root: string;
+  let claudeHome: string;
+  const prevEnv = process.env.CLAUDE_CONFIG_DIR;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'botmux-disc-'));
+    claudeHome = join(root, 'home', '.claude');
+    // Point personal discovery at an isolated fake ~/.claude.
+    process.env.CLAUDE_CONFIG_DIR = claudeHome;
+  });
+
+  afterEach(() => {
+    if (prevEnv === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = prevEnv;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('finds project-level custom commands with frontmatter description', () => {
+    const proj = join(root, 'proj');
+    write(join(proj, '.claude', 'commands', 'deploy.md'), '---\ndescription: Ship it\n---\nbody');
+    const found = discoverSlashCommands(proj);
+    const deploy = found.find((c) => c.name === '/deploy');
+    expect(deploy).toBeDefined();
+    expect(deploy?.source).toBe('project-command');
+    expect(deploy?.description).toBe('Ship it');
+  });
+
+  it('namespaces nested command subdirs with ":"', () => {
+    const proj = join(root, 'proj');
+    write(join(proj, '.claude', 'commands', 'git', 'sync.md'), 'no frontmatter');
+    const found = discoverSlashCommands(proj);
+    expect(found.some((c) => c.name === '/git:sync')).toBe(true);
+  });
+
+  it('finds personal skills via SKILL.md', () => {
+    write(join(claudeHome, 'skills', 'lark-doc', 'SKILL.md'), '---\ndescription: Feishu docs\n---');
+    const found = discoverSlashCommands(join(root, 'proj'));
+    const skill = found.find((c) => c.name === '/lark-doc');
+    expect(skill).toBeDefined();
+    expect(skill?.source).toBe('user-skill');
+    expect(skill?.description).toBe('Feishu docs');
+  });
+
+  it('namespaces plugin skills as /pluginId:name', () => {
+    write(
+      join(claudeHome, 'plugins', 'cache', 'mp', 'figma', '1.0.0', 'skills', 'figma-use', 'SKILL.md'),
+      '---\ndescription: Use Figma\n---',
+    );
+    const found = discoverSlashCommands(join(root, 'proj'));
+    expect(found.some((c) => c.name === '/figma:figma-use')).toBe(true);
+  });
+
+  it('returns empty when nothing is installed', () => {
+    expect(discoverSlashCommands(join(root, 'empty'))).toEqual([]);
+  });
+});
+
+describe('listMcpServerNames', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'botmux-mcp-'));
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('reads mcpServers keys from .mcp.json', () => {
+    writeFileSync(join(root, '.mcp.json'), JSON.stringify({ mcpServers: { figma: {}, chrome: {} } }));
+    expect(listMcpServerNames(root).sort()).toEqual(['chrome', 'figma']);
+  });
+
+  it('returns [] when .mcp.json is absent or malformed', () => {
+    expect(listMcpServerNames(root)).toEqual([]);
+    writeFileSync(join(root, '.mcp.json'), '{ not json');
+    expect(listMcpServerNames(root)).toEqual([]);
+  });
+});
+
+describe('parseBotConfigsFromText · customPassthroughCommands', () => {
+  const base = { larkAppId: 'cli_x', larkAppSecret: 's' };
+
+  it('normalizes: lowercases, prepends "/", dedupes', () => {
+    const [cfg] = parseBotConfigsFromText(
+      JSON.stringify([{ ...base, customPassthroughCommands: ['Status', '/export', 'status'] }]),
+    );
+    expect(cfg.customPassthroughCommands).toEqual(['/status', '/export']);
+  });
+
+  it('drops malformed entries (spaces, bad chars, non-strings)', () => {
+    const [cfg] = parseBotConfigsFromText(
+      JSON.stringify([{ ...base, customPassthroughCommands: ['/ok-cmd', '/bad cmd', '/!nope', 42, '/UPPER:lower'] }]),
+    );
+    expect(cfg.customPassthroughCommands).toEqual(['/ok-cmd', '/upper:lower']);
+  });
+
+  it('is undefined when unset or all-invalid', () => {
+    const [a] = parseBotConfigsFromText(JSON.stringify([{ ...base }]));
+    expect(a.customPassthroughCommands).toBeUndefined();
+    const [b] = parseBotConfigsFromText(JSON.stringify([{ ...base, customPassthroughCommands: ['  ', '/!@#'] }]));
+    expect(b.customPassthroughCommands).toBeUndefined();
+  });
+});

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -428,7 +428,7 @@ function mockCodexAppBot(): void {
 
 describe('DAEMON_COMMANDS set', () => {
   it('should contain all expected commands', () => {
-    const expected = ['/close', '/restart', '/status', '/help', '/cd', '/repo', '/schedule', '/role', '/pair', '/login', '/adopt', '/detach', '/disconnect', '/oncall', '/group', '/g', '/relay', '/card'];
+    const expected = ['/close', '/restart', '/status', '/help', '/cd', '/repo', '/schedule', '/role', '/pair', '/login', '/adopt', '/detach', '/disconnect', '/oncall', '/group', '/g', '/relay', '/card', '/list-slash-command', '/slash'];
     for (const cmd of expected) {
       expect(DAEMON_COMMANDS.has(cmd), `Expected DAEMON_COMMANDS to contain ${cmd}`).toBe(true);
     }
@@ -449,7 +449,12 @@ describe('DAEMON_COMMANDS set', () => {
   });
 
   it('should have the correct size', () => {
-    expect(DAEMON_COMMANDS.size).toBe(18);
+    expect(DAEMON_COMMANDS.size).toBe(20);
+  });
+
+  it('contains the /list-slash-command lister and its /slash alias', () => {
+    expect(DAEMON_COMMANDS.has('/list-slash-command')).toBe(true);
+    expect(DAEMON_COMMANDS.has('/slash')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## 背景
botmux 原本只有一组硬编码透传白名单（`PASSTHROUGH_COMMANDS`），用户无法自助扩展，也没有地方查看「当前可用哪些 slash 命令」。

## 改动
### ① customPassthroughCommands（per-bot 自定义透传）
- bots.json 每个 bot 可配 `customPassthroughCommands: ["/xxx"]`，在固定白名单上额外放行
- 解析归一化（小写、补 `/`、按 `^/[a-z0-9][a-z0-9:_-]*$` 过滤、去重）
- 新增 `resolvePassthroughCommands()` 合并内置与自定义，并滤掉会遮蔽 daemon 命令的项；daemon 两处透传判断改为按 bot 动态解析

### ② /list-slash-command（别名 /slash）
- 只读 daemon 命令，飞书交互卡片三段展示：① 固定放行 / ② 自定义配置 / ③ 自动发现
- 权限同 `/help`，进 `SESSIONLESS_DAEMON_COMMANDS` 不造幻影会话
- 第三段用飞书原生分页表格（命令 ｜ 说明），长描述截断

### ③ 自动发现（command-discovery 模块）
- 零依赖扫描 `<cwd>/.claude` 与 `~/.claude` 的 commands/skills + 插件缓存
- 读 frontmatter description，**按命令名全局去重**（修掉同名命令被 commands/skills 各扫一次的重复）
- MCP 仅从 `.mcp.json` 提示 server 名（`/mcp__server__prompt` 需运行时握手，不在此列）

## 测试
- `tsc --noEmit` 干净
- 新增/更新单测：command-discovery（发现 / 归一化 / MCP / 卡片结构）、command-handler（命令集大小与成员）
- 卡片 JSON 用编译产物实跑校验

## 已知局限
- seed 等 Claude fork 的 per-CLI 配置目录（`CLAUDE_CONFIG_DIR`）daemon 进程未必带，claude-code 正确；后续可让 adapter 暴露 data root 补齐