### PR TITLE
docs(docs-site): /list-slash-command 与 customPassthroughCommands 配置说明

### DIFF
--- a/docs-site/docs/bots-json.md
+++ b/docs-site/docs/bots-json.md
@@ -47,6 +47,7 @@
 | `disableCliBypass` | `true` 时不自动追加 CLI 的免审批 / 沙箱绕过参数（`--yolo`、`--dangerously-*`）；缺省 / `false` 保持原行为 |
 | `backendType` | 会话后端，可选 `pty` / `tmux` / `herdr` / `zellij`。留空**自动检测**：tmux 可用选 `tmux`，否则 `pty`（`herdr`、`zellij` 不会被自动选中，需显式指定）。`tmux` / `herdr` / `zellij` 都是持久会话，对应二进制探测失败时自动回落 `pty`（`zellij` 需 ≥ 0.44）；`pty` 直连进程、不跨重启持久。见 [tmux 后端](/tmux) |
 | `lang` | 该 bot 的界面语言 `zh` / `en`；留空回落 `BOTMUX_LANG` / `LANG` 环境变量 |
+| `customPassthroughCommands` | 在固定透传白名单之上，额外放行透传给底层 CLI 的 slash 命令，如 `["/goal", "/export"]`。自动归一化（缺失的 `/` 自动补、转小写、仅留 `[a-z0-9:_-]`、去重）；会遮蔽 botmux daemon 命令（如 `/status`）的项会被丢弃，配了也不生效。用 `/list-slash-command` 查看完整放行清单。见 [斜杠命令](/slash-commands) |
 
 ## 工作目录
 

--- a/docs-site/docs/slash-commands.md
+++ b/docs-site/docs/slash-commands.md
@@ -20,6 +20,18 @@
 
 `/compact` `/model` `/clear` `/plugin` `/usage` `/context` `/cost` `/mcp` `/diff` `/code-review` `/security-review` `/review` `/btw` —— 字面送达底层 CLI，交给它的内置命令处理。
 
+想放行更多命令，给该 bot 配 [`customPassthroughCommands`](/bots-json)（如 `["/goal", "/export"]`）即可在上面白名单之外按需扩展。会遮蔽 botmux daemon 命令的项（如 `/status`、`/help`、`/cd`）会被自动丢弃——daemon 命令始终保留自身语义，无法被透传覆盖。
+
+## 🧩 查看可用命令
+
+`/list-slash-command`（别名 `/slash`）：在卡片里分三段列出当前可用的 slash 命令——
+
+1. botmux 固定放行的透传白名单；
+2. 本 bot 在 bots.json 用 `customPassthroughCommands` 自定义放行的命令；
+3. 从 `.claude` 目录（项目级 + `~/.claude` + 插件缓存）自动发现的自定义命令 / skill / 插件，以「命令 ｜ 说明」分页表格展示，并提示检测到的 MCP server 名。
+
+权限同 `/help`，不占用会话槽位。
+
 ## 📡 会话接入
 
 | 命令 | 说明 |


### PR DESCRIPTION
随 v2.61.0 (PR #118) 补充文档站说明：

- `slash-commands.md`：新增「🧩 查看可用命令」段（/list-slash-command 别名 /slash 的三段清单），并在透传段说明 customPassthroughCommands 扩展白名单 + daemon 命令不可被覆盖
- `bots-json.md`：CLI 与模型 表新增 `customPassthroughCommands` 字段说明

本地 rspress build 通过，两页正常渲染。