### PR TITLE
feat(dashboard): 数字员工与群组显示真实飞书头像

### DIFF
--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -206,6 +206,7 @@ export interface BotState {
   client: Lark.Client;
   botOpenId?: string;
   botName?: string;       // Lark app display name (from /bot/v3/info)
+  botAvatarUrl?: string;  // Lark app avatar URL (from /bot/v3/info)
   resolvedAllowedUsers: string[];
   /** raw allowedUsers 条目 → 解析后的 open_id。供 /revoke 反查并删除 email 形式的 raw 条目。 */
   rawAllowedUserResolution: Map<string, string>;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -565,6 +565,8 @@ const DAEMON_REGISTRY_DIR = join(homedir(), '.botmux', 'data', 'dashboard-daemon
 interface DaemonDescriptor {
   larkAppId: string;
   botName: string;
+  /** Lark app avatar URL (from /bot/v3/info); absent until the open_id probe lands. */
+  botAvatarUrl?: string;
   botIndex: number;
   ipcPort: number;
   pid: number;
@@ -3065,8 +3067,17 @@ export async function startDaemon(botIndex?: number): Promise<void> {
     probeBotOpenId(cfg.larkAppId).then(() => {
       writeBotInfoFile(config.session.dataDir);
       const probedName = bot.botName;
+      const probedAvatar = bot.botAvatarUrl;
+      let descChanged = false;
       if (probedName && probedName !== desc.botName) {
         desc.botName = probedName;
+        descChanged = true;
+      }
+      if (probedAvatar && probedAvatar !== desc.botAvatarUrl) {
+        desc.botAvatarUrl = probedAvatar;
+        descChanged = true;
+      }
+      if (descChanged) {
         try { writeDaemonDescriptor(desc); } catch { /* best effort */ }
       }
       // SessionRow.botName 同步换成友好名——否则 dashboard 会话行一直显示

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -618,7 +618,7 @@ const server = createServer(async (req, res) => {
       // prompt strip + keeps /api/bots oncall removal honest).
       return jsonRes(res, 200, {
         chats: authed ? sorted : redactGroupsForPublic(sorted),
-        bots: onlineBots.map(b => ({ larkAppId: b.larkAppId, botName: b.botName })),
+        bots: onlineBots.map(b => ({ larkAppId: b.larkAppId, botName: b.botName, botAvatarUrl: b.botAvatarUrl })),
       });
     }
 

--- a/src/dashboard/public-redact.ts
+++ b/src/dashboard/public-redact.ts
@@ -20,7 +20,8 @@
  *  doesn't ride along. Dropped: `description`, `ownerId` (group config/PII),
  *  `hasRole` (leaks the role/persona existence matrix even though the roles
  *  page is token-gated), `oncallChat` (carries workingDir), `error`,
- *  `firstSeenAt`. Kept: chat `chatId/name/chatMode` (name-map) and
+ *  `firstSeenAt`. Kept: chat `chatId/name/chatMode/avatar` (name-map + group
+ *  头像，与公开看板已暴露的群名同等敏感度) and
  *  `memberBots[].larkAppId/botName/inChat` (roster). Returns a new array; never
  *  mutates the input. */
 export function redactGroupsForPublic(chats: unknown[]): unknown[] {
@@ -32,6 +33,7 @@ export function redactGroupsForPublic(chats: unknown[]): unknown[] {
       chatId: chat.chatId,
       name: chat.name,
       chatMode: chat.chatMode,
+      avatar: chat.avatar,
     };
     if (Array.isArray(chat.memberBots)) {
       out.memberBots = chat.memberBots.map((mb) => {

--- a/src/dashboard/registry.ts
+++ b/src/dashboard/registry.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path';
 export interface DaemonInfo {
   larkAppId: string;
   botName: string;
+  /** Lark app avatar URL (from /bot/v3/info); absent until the open_id probe lands. */
+  botAvatarUrl?: string;
   botIndex: number;
   ipcPort: number;
   pid: number;

--- a/src/dashboard/web/bot-defaults.ts
+++ b/src/dashboard/web/bot-defaults.ts
@@ -4,7 +4,7 @@
 // after the save; existing chats are left alone, and chats already auto-bound
 // once stay user-controlled.
 import { store } from './store.js';
-import { botOrbStyle, escapeHtml, t } from './ui.js';
+import { botAvatarHtml, escapeHtml, loadNameMaps, t } from './ui.js';
 
 let cache: { bots: any[] } = { bots: [] };
 let loadError: string | null = null;
@@ -141,7 +141,7 @@ export async function renderBotDefaultsPage(root: HTMLElement) {
       ? `<span class="bd-roster-flag">oncall</span>`
       : '';
     return `<div class="bd-roster-item${b.larkAppId === selectedAppId ? ' on' : ''}" data-appid="${escapeHtml(b.larkAppId)}" role="button" tabindex="0">
-      <span class="orb-avatar orb-avatar-sm" style="${botOrbStyle(name)}" aria-hidden="true"></span>
+      ${botAvatarHtml({ name, larkAppId: b.larkAppId, size: 'sm' })}
       <div class="bd-roster-tx">
         <b>${escapeHtml(name)}</b>
         <span>${escapeHtml(cli || b.larkAppId.slice(0, 14))}</span>
@@ -154,7 +154,7 @@ export async function renderBotDefaultsPage(root: HTMLElement) {
     if (b.error) {
       return `<article class="bd-card bd-profile" data-appid="${escapeHtml(b.larkAppId)}">
         <header class="bd-profile-head">
-          <span class="orb-avatar" style="${botOrbStyle(b.botName ?? b.larkAppId)}" aria-hidden="true"></span>
+          ${botAvatarHtml({ name: b.botName ?? b.larkAppId, larkAppId: b.larkAppId })}
           <div class="bd-profile-id"><strong>${escapeHtml(b.botName ?? b.larkAppId)}</strong>
           <code>${escapeHtml(b.larkAppId)}</code></div>
         </header>
@@ -167,7 +167,7 @@ export async function renderBotDefaultsPage(root: HTMLElement) {
     const cli = cliIdOf(b.larkAppId);
     return `<article class="bd-card bd-profile" data-appid="${escapeHtml(b.larkAppId)}">
       <header class="bd-profile-head">
-        <span class="orb-avatar" style="${botOrbStyle(name)}" aria-hidden="true"><i class="orb-dot orb-dot-ok"></i></span>
+        ${botAvatarHtml({ name, larkAppId: b.larkAppId, dot: 'ok' })}
         <div class="bd-profile-id">
           <strong>${escapeHtml(name)}</strong>
           ${cli ? `<span class="mate-role">${escapeHtml(cli)}</span>` : ''}
@@ -757,5 +757,6 @@ export async function renderBotDefaultsPage(root: HTMLElement) {
   }
 
   rerender();
+  void loadNameMaps().then(rerender); // 头像表就绪后重绘，让 /api/bots 这边也出真实头像
   form.addEventListener('input', rerender);
 }

--- a/src/dashboard/web/groups.ts
+++ b/src/dashboard/web/groups.ts
@@ -2,7 +2,7 @@
 // The aggregator at /api/groups fans out to all online daemons and merges chats
 // by chatId; the dashboard displays this as a matrix where each cell shows
 // whether a bot is a member of a given chat.
-import { escapeHtml, t } from './ui.js';
+import { chatAvatarHtml, escapeHtml, t } from './ui.js';
 
 let cache: { chats: any[]; bots: any[] } = { chats: [], bots: [] };
 
@@ -321,8 +321,13 @@ export async function renderGroupsPage(root: HTMLElement) {
     }
     body.innerHTML = filtered.map(c => `<tr data-chat="${escapeHtml(c.chatId)}">
       <td>
-        <strong>${escapeHtml(c.name ?? c.chatId)}</strong><br>
-        <small><code>${escapeHtml(c.chatId)}</code></small>
+        <div class="g-chat-cell">
+          ${chatAvatarHtml({ chatId: c.chatId, name: c.name, avatarUrl: c.avatar, size: 'sm' })}
+          <div class="g-chat-meta">
+            <strong>${escapeHtml(c.name ?? c.chatId)}</strong><br>
+            <small><code>${escapeHtml(c.chatId)}</code></small>
+          </div>
+        </div>
       </td>
       ${cache.bots.map(b => {
         const m = c.memberBots.find((m: any) => m.larkAppId === b.larkAppId);

--- a/src/dashboard/web/overview.ts
+++ b/src/dashboard/web/overview.ts
@@ -3,8 +3,8 @@
 import { store } from './store.js';
 import {
   attentionReason,
+  botAvatarHtml,
   botDisplayName,
-  botOrbStyle,
   chatDisplayTitle,
   escapeHtml,
   loadNameMaps,
@@ -28,6 +28,7 @@ async function loadGroupsSnapshot(): Promise<void> {
 type BotCard = {
   botName: string;
   larkAppId?: string;
+  botAvatarUrl?: string;
   cliId: string;
   online: boolean;
   sessions: any[];
@@ -60,6 +61,7 @@ function buildBotCards(sessions: any[]): BotCard[] {
     const card = ensure(b.larkAppId ?? b.botName ?? '-');
     card.online = true;
     if (b.botName) card.botName = b.botName;
+    if (b.botAvatarUrl) card.botAvatarUrl = b.botAvatarUrl;
   }
   // 两遍：先 active 建卡，再让 closed 会话只补充已有卡（不为其单独出卡）
   const ordered = [...sessions].sort((a, b) => Number(a.status === 'closed') - Number(b.status === 'closed'));
@@ -111,7 +113,7 @@ function mateCardHtml(card: BotCard): string {
         : `<span class="tag tag-ok">${escapeHtml(t('overview.botReady'))}</span>`;
   return `<article class="mate${needsYou ? ' mate-attn' : ''}${offline ? ' mate-off' : ''}">
     <div class="mate-top">
-      <span class="orb-avatar" style="${botOrbStyle(card.botName)}"><i class="orb-dot orb-dot-${dotClass}"></i></span>
+      ${botAvatarHtml({ name: card.botName, larkAppId: card.larkAppId, avatarUrl: card.botAvatarUrl, dot: dotClass })}
       <div class="mate-id">
         <b>${escapeHtml(card.botName)}</b>
         <span class="mate-role">${escapeHtml(card.cliId)}</span>
@@ -128,7 +130,7 @@ function mateCardHtml(card: BotCard): string {
 function attentionCardHtml(s: any): string {
   const botName = botDisplayName(s);
   return `<article class="qcard" data-id="${escapeHtml(s.sessionId)}">
-    <span class="orb-avatar orb-avatar-sm" style="${botOrbStyle(botName)}"></span>
+    ${botAvatarHtml({ name: botName, larkAppId: s.larkAppId, size: 'sm' })}
     <div class="qcard-tx">
       <b>${escapeHtml(botName)} · ${escapeHtml((stripMentionPrefix(s.title) || s.sessionId).slice(0, 56))}</b>
       <span>${escapeHtml(attentionReason(s) ?? '')} · ${relTime(s.lastMessageAt)}</span>
@@ -140,7 +142,7 @@ function attentionCardHtml(s: any): string {
 function activeSessionHtml(s: any): string {
   const botName = botDisplayName(s);
   return `<li class="sess-row">
-    <span class="orb-avatar orb-avatar-sm" style="${botOrbStyle(botName)}"></span>
+    ${botAvatarHtml({ name: botName, larkAppId: s.larkAppId, size: 'sm' })}
     <div class="sess-tx">
       <b>${escapeHtml((stripMentionPrefix(s.title) || s.sessionId).slice(0, 64))}</b>
       <span>${escapeHtml(botName)} · ${escapeHtml(chatDisplayTitle(s) ?? s.cliId ?? 'unknown')} · ${relTime(s.lastMessageAt)}</span>

--- a/src/dashboard/web/roles.ts
+++ b/src/dashboard/web/roles.ts
@@ -1,7 +1,7 @@
 // Roles page: hierarchical group → bot role editor.
 // Displays groups as collapsible sections with bots nested inside.
 // Each bot has its own per-group role definition selectable for editing.
-import { botOrbStyle, escapeHtml, t } from './ui.js';
+import { botAvatarHtml, escapeHtml, loadNameMaps, t } from './ui.js';
 
 interface BotInfo {
   larkAppId: string;
@@ -152,7 +152,7 @@ function renderTree(filter: string = ''): void {
                  data-group-id="${escapeHtml(g.chatId)}"
                  data-bot-id="${escapeHtml(b.larkAppId)}">
               <span class="roles-bot-indent"></span>
-              <span class="orb-avatar orb-avatar-sm" style="${botOrbStyle(b.botName)}" aria-hidden="true"></span>
+              ${botAvatarHtml({ name: b.botName, larkAppId: b.larkAppId, size: 'sm' })}
               <div class="roles-bot-info">
                 <div class="roles-bot-name">${escapeHtml(b.botName)}</div>
                 <div class="roles-bot-id">${escapeHtml(b.larkAppId)}</div>
@@ -291,6 +291,7 @@ export async function renderRolesPage(root: HTMLElement): Promise<void> {
   resetEditor();
 
   await loadGroups();
+  await loadNameMaps(); // 预热共享头像表，让角色树首屏就能出真实头像
   // Auto-expand groups that have at least one bot with a role
   for (const g of cache) {
     if (botRoleCount(g) > 0) expandedGroups.add(g.chatId);

--- a/src/dashboard/web/sessions.ts
+++ b/src/dashboard/web/sessions.ts
@@ -9,7 +9,7 @@ import {
 import { store } from './store.js';
 import {
   botDisplayName,
-  botOrbStyle,
+  botAvatarHtml,
   chatDisplayTitle,
   escapeHtml,
   loadNameMaps,
@@ -244,7 +244,7 @@ export function renderSessionsPage(root: HTMLElement) {
     const signal = boardSignalLabel(s);
     return `<article class="session-card${isSelected ? ' selected' : ''}" data-id="${escapeHtml(s.sessionId)}" aria-pressed="${isSelected}">
       <div class="session-card-top">
-        <span class="orb-avatar orb-avatar-sm" style="${botOrbStyle(botName)}" aria-hidden="true"></span>
+        ${botAvatarHtml({ name: botName, larkAppId: s.larkAppId, size: 'sm' })}
         <div class="session-card-title">
           <strong title="${escapeHtml(String(s.title ?? title))}">${escapeHtml(String(title).slice(0, 72))}</strong>
           <span>${escapeHtml(botName)} · ${escapeHtml(chatTitle ?? s.cliId ?? 'unknown')}</span>

--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -2149,6 +2149,31 @@ button.contrast:hover { background: var(--danger-soft); border-color: var(--dang
   height: 24px;
   box-shadow: inset 0 0 5px rgba(255, 255, 255, 0.28);
 }
+/* 有真实头像时，把渐变球底色换成中性占位，避免"先亮球后头像"的闪烁；
+   渐变球只在头像加载失败（onerror 移除 .orb-has-img）时作为兜底重新露出。 */
+.orb-avatar.orb-has-img {
+  background: var(--surface-muted);
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+/* 真实头像盖在数字生命球上；onerror 时移除自身，露出下面的渐变球兜底。
+   不加淡入动画——innerHTML 每次重绘都会重建 <img>，动画会跟着重放，看起来就是
+   头像在"刷新"。图本身有 HTTP 缓存 + URL 走 localStorage，重建即同步出图。 */
+.orb-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+}
+/* 飞书群头像：圆角方形，和圆形的 bot 头像一眼区分开。 */
+.orb-avatar.orb-square,
+.orb-avatar.orb-square .orb-img { border-radius: 9px; }
+.orb-avatar.orb-square.orb-avatar-sm,
+.orb-avatar.orb-square.orb-avatar-sm .orb-img { border-radius: 6px; }
+/* 群列表名称单元格：群头像 + 群名/ID 横向排列。 */
+.g-chat-cell { display: flex; align-items: center; gap: 8px; }
+.g-chat-meta { min-width: 0; }
 .orb-dot {
   position: absolute;
   right: -1px;

--- a/src/dashboard/web/ui.ts
+++ b/src/dashboard/web/ui.ts
@@ -174,6 +174,72 @@ export function botOrbStyle(name: string): string {
   return `--c1:${c1};--c2:${c2}`;
 }
 
+// 真实头像（飞书 /bot/v3/info 的 avatar_url）→ 渐变球。两套 key：larkAppId 优先，
+// 再退回 botName，方便只拿得到名字的渲染点（会话行 / 角色树）也能命中。
+const botAvatarByAppId = new Map<string, string>();
+const botAvatarByName = new Map<string, string>();
+
+/** 查 bot 头像 URL：larkAppId 命中优先，再按 botName 兜底；都没有返回 undefined。 */
+export function botAvatarUrlFor(name?: string, larkAppId?: string): string | undefined {
+  return (larkAppId ? botAvatarByAppId.get(larkAppId) : undefined)
+    ?? (name ? botAvatarByName.get(String(name)) : undefined);
+}
+
+export interface BotAvatarOpts {
+  /** 展示名 —— 决定回退渐变球的色相，也用于按名查头像。 */
+  name?: string;
+  /** 主查询键。 */
+  larkAppId?: string;
+  /** 显式头像 URL（调用方已拿到时传，省一次 map 查询、首屏即出图）。 */
+  avatarUrl?: string;
+  /** 尺寸：md=42px（默认），sm=24px。 */
+  size?: 'sm' | 'md';
+  /** 右下角状态点；不传则不渲染圆点。 */
+  dot?: 'ok' | 'busy' | 'warn' | 'off';
+}
+
+/** 全站统一的 bot 头像渲染：有头像出 <img>（盖在渐变球上、加载失败自动回退到
+ *  渐变球），没有就直接渲染渐变球。避免"先球后头像"闪烁靠 CSS 的 .orb-has-img。 */
+export function botAvatarHtml(opts: BotAvatarOpts): string {
+  const name = opts.name ?? '';
+  const url = opts.avatarUrl ?? botAvatarUrlFor(opts.name, opts.larkAppId);
+  const sizeCls = opts.size === 'sm' ? ' orb-avatar-sm' : '';
+  const hasImg = url ? ' orb-has-img' : '';
+  const dot = opts.dot ? `<i class="orb-dot orb-dot-${opts.dot}"></i>` : '';
+  const img = url
+    ? `<img class="orb-img" src="${escapeHtml(url)}" alt="" decoding="async" referrerpolicy="no-referrer" onerror="this.closest('.orb-avatar')?.classList.remove('orb-has-img');this.remove()"/>`
+    : '';
+  return `<span class="orb-avatar${sizeCls}${hasImg}" style="${botOrbStyle(name)}" aria-hidden="true">${img}${dot}</span>`;
+}
+
+/** 查飞书群头像 URL（按 chatId）。 */
+export function chatAvatarUrlFor(chatId?: string): string | undefined {
+  return chatId ? chatAvatarById.get(chatId) : undefined;
+}
+
+export interface ChatAvatarOpts {
+  chatId?: string;
+  /** 群名 —— 决定回退占位的色相。 */
+  name?: string;
+  /** 显式群头像 URL（调用方已有时传，省一次 map 查询）。 */
+  avatarUrl?: string;
+  /** 尺寸：md=42px（默认），sm=24px。 */
+  size?: 'sm' | 'md';
+}
+
+/** 飞书群头像渲染：圆角方形（.orb-square）以区别于圆形的 bot 头像；复用同一套
+ *  占位 / 淡入 / 加载失败回退机制（.orb-has-img / .orb-img）。 */
+export function chatAvatarHtml(opts: ChatAvatarOpts): string {
+  const name = opts.name ?? opts.chatId ?? '';
+  const url = opts.avatarUrl ?? chatAvatarUrlFor(opts.chatId);
+  const sizeCls = opts.size === 'sm' ? ' orb-avatar-sm' : '';
+  const hasImg = url ? ' orb-has-img' : '';
+  const img = url
+    ? `<img class="orb-img" src="${escapeHtml(url)}" alt="" decoding="async" referrerpolicy="no-referrer" onerror="this.closest('.orb-avatar')?.classList.remove('orb-has-img');this.remove()"/>`
+    : '';
+  return `<span class="orb-avatar orb-square${sizeCls}${hasImg}" style="${botOrbStyle(name)}" aria-hidden="true">${img}</span>`;
+}
+
 // ── 跨页共享的展示名解析（bot 友好名 / 群聊标题）────────────────────────────
 // daemon IPC 上报的 SessionRow.botName 历史上填的是 larkAppId（friendly name
 // probe 回来只回写了注册表 descriptor，没回填 IPC 的 cachedBotName），这里用
@@ -181,7 +247,42 @@ export function botOrbStyle(name: string): string {
 // 纯展示增强，不挡核心功能。
 const botNameByAppId = new Map<string, string>();
 const chatNameById = new Map<string, string>();
+const chatAvatarById = new Map<string, string>();
 let nameMapsPromise: Promise<void> | null = null;
+
+// 头像 URL 本地持久化：飞书 CDN 的图本身有 14 天 HTTP 缓存，但「先渲染渐变球、
+// 等 /api/groups 回来再换头像」这一刷会在每次冷加载/切页时出现。把 URL 存进
+// localStorage 并在模块加载时同步回灌，让任意页面首屏就拿得到头像 URL —— 配合
+// 浏览器图片缓存即时出图，彻底消除「球→头像」那一刷。
+const AVATAR_CACHE_KEY = 'botmux.avatarCache.v1';
+
+function hydrateAvatarCache(): void {
+  try {
+    const raw = typeof window !== 'undefined' ? window.localStorage.getItem(AVATAR_CACHE_KEY) : null;
+    if (!raw) return;
+    const c = JSON.parse(raw) as {
+      botByAppId?: Record<string, string>;
+      botByName?: Record<string, string>;
+      chatById?: Record<string, string>;
+    };
+    for (const [k, v] of Object.entries(c.botByAppId ?? {})) botAvatarByAppId.set(k, v);
+    for (const [k, v] of Object.entries(c.botByName ?? {})) botAvatarByName.set(k, v);
+    for (const [k, v] of Object.entries(c.chatById ?? {})) chatAvatarById.set(k, v);
+  } catch { /* 损坏/无 localStorage 时静默 */ }
+}
+
+function persistAvatarCache(): void {
+  try {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(AVATAR_CACHE_KEY, JSON.stringify({
+      botByAppId: Object.fromEntries(botAvatarByAppId),
+      botByName: Object.fromEntries(botAvatarByName),
+      chatById: Object.fromEntries(chatAvatarById),
+    }));
+  } catch { /* 配额/SSR 时静默 */ }
+}
+
+hydrateAvatarCache(); // 模块加载即回灌，先于任何页面渲染
 
 export function loadNameMaps(): Promise<void> {
   nameMapsPromise ??= (async () => {
@@ -193,10 +294,16 @@ export function loadNameMaps(): Promise<void> {
         if (b.larkAppId && b.botName && b.botName !== b.larkAppId) {
           botNameByAppId.set(b.larkAppId, String(b.botName));
         }
+        if (b.botAvatarUrl) {
+          if (b.larkAppId) botAvatarByAppId.set(b.larkAppId, String(b.botAvatarUrl));
+          if (b.botName) botAvatarByName.set(String(b.botName), String(b.botAvatarUrl));
+        }
       }
       for (const c of data.chats ?? []) {
         if (c.chatId && c.name) chatNameById.set(c.chatId, String(c.name));
+        if (c.chatId && c.avatar) chatAvatarById.set(c.chatId, String(c.avatar));
       }
+      persistAvatarCache(); // 刷新本地缓存，下次冷加载首屏即出头像
     } catch {
       // 失败不缓存（dashboard 刚启动 /api/groups 可能短暂 503）——
       // 清掉 memo，下一个页面 mount / strip 重绘再重试；期间显示原始 id。

--- a/src/dashboard/web/ui.ts
+++ b/src/dashboard/web/ui.ts
@@ -179,10 +179,12 @@ export function botOrbStyle(name: string): string {
 const botAvatarByAppId = new Map<string, string>();
 const botAvatarByName = new Map<string, string>();
 
-/** 查 bot 头像 URL：larkAppId 命中优先，再按 botName 兜底；都没有返回 undefined。 */
+/** 查 bot 头像 URL：larkAppId 是唯一稳定键，在场就只认它——绝不在 appId 落空时
+ *  串到 botName 兜底，否则两个同名 bot 会互相借用头像（按名查 last-writer-wins）。
+ *  只有完全没有 appId 的渲染点才退回按名查。 */
 export function botAvatarUrlFor(name?: string, larkAppId?: string): string | undefined {
-  return (larkAppId ? botAvatarByAppId.get(larkAppId) : undefined)
-    ?? (name ? botAvatarByName.get(String(name)) : undefined);
+  if (larkAppId) return botAvatarByAppId.get(larkAppId);
+  return name ? botAvatarByName.get(String(name)) : undefined;
 }
 
 export interface BotAvatarOpts {

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -39,7 +39,7 @@ export function writeBotInfoFile(dataDir: string): void {
   if (!existsSync(dataDir)) mkdirSync(dataDir, { recursive: true });
 
   // Read existing entries from other daemon processes
-  type BotInfoEntry = { larkAppId: string; botOpenId: string | null; botName: string | null; cliId: string };
+  type BotInfoEntry = { larkAppId: string; botOpenId: string | null; botName: string | null; botAvatarUrl: string | null; cliId: string };
   let existing: BotInfoEntry[] = [];
   try {
     if (existsSync(filePath)) {
@@ -59,6 +59,7 @@ export function writeBotInfoFile(dataDir: string): void {
       larkAppId: b.config.larkAppId,
       botOpenId: b.botOpenId ?? null,
       botName: b.botName ?? null,
+      botAvatarUrl: b.botAvatarUrl ?? null,
       cliId: b.config.cliId,
     });
   }
@@ -118,9 +119,11 @@ export async function probeBotOpenId(larkAppId: string): Promise<void> {
 
   const openId = botData.bot?.open_id;
   const appName = botData.bot?.app_name;
+  const avatarUrl = botData.bot?.avatar_url;
   if (openId) {
     bot.botOpenId = openId;
     if (appName) bot.botName = appName;
+    if (avatarUrl) bot.botAvatarUrl = avatarUrl;
     logger.info(`Bot open_id: ${bot.botOpenId}`);
   } else {
     throw new Error('No open_id in bot info response');

--- a/src/services/groups-store.ts
+++ b/src/services/groups-store.ts
@@ -19,6 +19,8 @@ export interface ChatBrief {
   description?: string;
   chatMode?: string;
   ownerId?: string;
+  /** 群头像 URL（/open-apis/im/v1/chats 的 avatar 字段）。 */
+  avatar?: string;
 }
 
 /**
@@ -45,6 +47,7 @@ export async function listChats(larkAppId: string): Promise<ChatBrief[]> {
         description: c.description,
         chatMode: c.chat_mode,
         ownerId: c.owner_id,
+        avatar: c.avatar,
       });
     }
     pageToken = res.data?.has_more ? res.data?.page_token : undefined;

--- a/test/dashboard-public-redact.test.ts
+++ b/test/dashboard-public-redact.test.ts
@@ -9,6 +9,7 @@ function sampleChats() {
       chatId: 'oc_chat1',
       name: '客户群 A',
       chatMode: 'group',
+      avatar: 'https://avatar.example/chat1.png',
       description: 'private description',
       ownerId: 'ou_owner',
       memberBots: [
@@ -70,6 +71,7 @@ describe('redactGroupsForPublic', () => {
         chatId: 'oc_chat1',
         name: '客户群 A',
         chatMode: 'group',
+        avatar: 'https://avatar.example/chat1.png',
         memberBots: [
           { larkAppId: 'cli_a', botName: 'Claude', inChat: true },
           { larkAppId: 'cli_b', botName: 'Codex', inChat: false },

--- a/test/groups-store.test.ts
+++ b/test/groups-store.test.ts
@@ -34,6 +34,7 @@ vi.mock('../src/bot-registry.js', () => ({
                 description: 'first chat',
                 chat_mode: 'group',
                 owner_id: 'ou_owner',
+                avatar: 'https://avatar.example/c1.png',
               },
             ],
             has_more: false,
@@ -77,6 +78,7 @@ describe('groups-store wrappers', () => {
     expect(out[0].description).toBe('first chat');
     expect(out[0].chatMode).toBe('group');
     expect(out[0].ownerId).toBe('ou_owner');
+    expect(out[0].avatar).toBe('https://avatar.example/c1.png');
   });
 
   it('isInChat returns boolean', async () => {


### PR DESCRIPTION
## 背景
dashboard 的「数字员工」卡此前用渐变「数字生命球」占位，群组列表只有文字。本次接入真实飞书头像，并解决头像刷新闪烁。

## 改动
### bot 头像
- `probeBotOpenId` 抓取 `/bot/v3/info` 的 `avatar_url`，经 `BotState` → daemon 描述符 → dashboard 注册表 → `/api/groups` 透出
- 抽出共享 `botAvatarHtml()`，全站 8 个渲染点统一接入（概览数字员工卡 / 需要你处理 / 活跃会话、会话列表、角色树、机器人默认页 roster/档案/错误卡）

### 群头像
- `listChats` 抓取 `im/v1/chats` 的 `avatar`（原本被丢弃），经 `/api/groups` 透出
- 群组页每行展示群头像，做成圆角方形（`orb-square`）以区别于圆形的 bot 头像，便于区分群
- 公开看板 redact 白名单放行群头像（与已公开的群名同敏感度）

### 防闪烁 / 缓存
- 头像 URL 存 localStorage 并在模块加载同步回灌 → 任意页面 / 刷新 / 切 tab 首屏即出图
- 移除淡入动画（概览每来一条 SSE 推送就整段重绘、重建 `<img>`，动画会跟着重放，看着像头像在"刷新"）
- `loading="lazy"` 改 `decoding="async"`
- 飞书 CDN 图片本身 `cache-control: max-age=1209600, public`（14 天），浏览器层已缓存
- 头像取不到 / 加载失败自动回退到原渐变球

## 测试
- `tsc --noEmit` 通过
- `groups-store` / `dashboard-public-redact` 单测通过（补了 `avatar` 字段断言）
- 已实测飞书 `/bot/v3/info` 返回 `avatar_url`、`im/v1/chats` 返回 `avatar`，URL 公开可加载（`HTTP 200 image/png`）

## 已知边界
dashboard 仍是「每次 SSE 推送整段 `innerHTML` 重建」，头像 `<img>` 节点每次重建。本 PR 靠「图有 HTTP 缓存 + URL 有 localStorage + 去动画」做到重建即同帧出图、视觉不闪；若要在高频抖动下彻底零残影，需改成 DOM diff / keyed 更新（更大重构，未包含）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
