### PR TITLE
fix(lark): refresh stale observed bot open_ids

### DIFF
--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -1108,6 +1108,13 @@ export async function listChatBotMembers(larkAppId: string, chatId: string): Pro
   //   2) Otherwise (no/ambiguous match) → append as an external bot.
   try {
     const observedList = listObservedBots(config.session.dataDir, larkAppId, chatId);
+    const latestObservedByName = new Map<string, (typeof observedList)[number]>();
+    for (const o of observedList) {
+      const existing = latestObservedByName.get(o.name);
+      if (!existing || o.lastSeenAt > existing.lastSeenAt) {
+        latestObservedByName.set(o.name, o);
+      }
+    }
     const seenOpenIds = new Set(configured.map(b => b.openId));
     const norm = (s: string) => s.trim().toLowerCase();
     const byName = new Map<string, number[]>();
@@ -1117,7 +1124,7 @@ export async function listChatBotMembers(larkAppId: string, chatId: string): Pro
       if (arr) arr.push(i); else byName.set(k, [i]);
     });
 
-    for (const o of observedList) {
+    for (const o of latestObservedByName.values()) {
       if (seenOpenIds.has(o.openId)) continue;
       const matches = byName.get(norm(o.name)) ?? [];
       if (matches.length === 1) {

--- a/src/services/observed-bots-store.ts
+++ b/src/services/observed-bots-store.ts
@@ -90,6 +90,12 @@ export function recordObservedBots(
 
   const data = readFile(dataDir, larkAppId, chatId);
   for (const b of valid) {
+    for (const [existingOpenId, entry] of Object.entries(data)) {
+      if (entry.name === b.name && existingOpenId !== b.openId) {
+        delete data[existingOpenId];
+      }
+    }
+
     const prior = data[b.openId];
     if (prior) {
       data[b.openId] = { ...prior, name: b.name, lastSeenAt: now };

--- a/test/list-chat-bot-members.test.ts
+++ b/test/list-chat-bot-members.test.ts
@@ -246,4 +246,26 @@ describe('listChatBotMembers', () => {
     expect(fromPeer.find(b => b.openId === 'ou_B_as_seen_by_peer')).toBeDefined();
     expect(fromPeer.find(b => b.openId === 'ou_B_as_seen_by_self')).toBeUndefined();
   });
+
+  it('deduplicates same-name observed entries and keeps only the latest mentionable openId', async () => {
+    state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-list-chat-bots-'));
+    writeFileSync(join(state.dataDir, 'bots-info.json'), '[]');
+    const now = Date.now();
+    writeFileSync(join(state.dataDir, 'observed-bots-cli_self-oc_chat.json'), JSON.stringify({
+      'ou_stale': { name: 'NasCodex', source: 'introduce', firstSeenAt: now - 10_000, lastSeenAt: now - 10_000 },
+      'ou_current': { name: 'NasCodex', source: 'introduce', firstSeenAt: now, lastSeenAt: now },
+    }));
+
+    const { listChatBotMembers } = await import('../src/im/lark/client.js');
+    const bots = await listChatBotMembers('cli_self', 'oc_chat');
+
+    const nasEntries = bots.filter(b => b.displayName === 'NasCodex');
+    expect(nasEntries).toHaveLength(1);
+    expect(nasEntries[0]).toMatchObject({
+      openId: 'ou_current',
+      mentionable: true,
+      mentionSource: 'observed',
+    });
+    expect(bots.find(b => b.openId === 'ou_stale')).toBeUndefined();
+  });
 });

--- a/test/observed-bots-store.test.ts
+++ b/test/observed-bots-store.test.ts
@@ -179,4 +179,35 @@ describe('observed-bots-store', () => {
     recordObservedBots(dataDir, APP_A, 'oc_chat1', [], 'introduce', 1);
     expect(existsSync(join(dataDir, `observed-bots-${APP_A}-oc_chat1.json`))).toBe(false);
   });
+
+  it('replaces an old openId when the same name is observed with a new openId', () => {
+    recordObservedBots(dataDir, APP_A, 'oc_chat1', [{ openId: 'ou_old', name: 'BotB' }], 'introduce', 1_000);
+    recordObservedBots(dataDir, APP_A, 'oc_chat1', [{ openId: 'ou_new', name: 'BotB' }], 'introduce', 2_000);
+
+    const out = listObservedBots(dataDir, APP_A, 'oc_chat1', undefined, 2_000);
+    expect(out).toEqual<ObservedBot[]>([
+      { openId: 'ou_new', name: 'BotB', source: 'introduce', firstSeenAt: 2_000, lastSeenAt: 2_000 },
+    ]);
+
+    const fp = join(dataDir, `observed-bots-${APP_A}-oc_chat1.json`);
+    const json = JSON.parse(readFileSync(fp, 'utf-8'));
+    expect(json).not.toHaveProperty('ou_old');
+  });
+
+  it('uses the last same-name entry within a single observed batch', () => {
+    recordObservedBots(
+      dataDir,
+      APP_A,
+      'oc_chat1',
+      [
+        { openId: 'ou_first', name: 'BotB' },
+        { openId: 'ou_second', name: 'BotB' },
+      ],
+      'introduce',
+      1_000,
+    );
+
+    const out = listObservedBots(dataDir, APP_A, 'oc_chat1', undefined, 1_000);
+    expect(out.map(b => b.openId)).toEqual(['ou_second']);
+  });
 });


### PR DESCRIPTION
## Summary

Fix stale observed bot open_id handling for Lark cross-bot handoffs.

When `/introduce` records a bot name with a new open_id, `recordObservedBots()` now removes older same-name open_ids for the same observer and chat. `listChatBotMembers()` also defensively deduplicates observed entries by name and keeps the newest `lastSeenAt` record, so stale files created before this fix no longer expose old handles as mentionable.

Fixes #127.

## Validation

- `pnpm test -- observed-bots-store list-chat-bot-members`
- `pnpm build`
- `git diff --check`

Full `pnpm test` was also run locally. It still reports 43 failures unrelated to this change, concentrated in missing Feishu e2e env vars, node-pty/tmux/CLI e2e `posix_spawnp failed`, and macOS `/private/var` realpath expectations. The tests touched by this change pass both directly and during the full run.
