### PR TITLE
fix(worker): idle 会话超预算时暂停 worker

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@
  *   botmux delete <id>    — close a session by ID prefix
  *   botmux delete all     — close all active sessions
  *   botmux autostart enable|disable|status — manage boot-time autostart (launchd / user systemd)
+ *   botmux worker-budget status|set|unset — inspect/override idle worker suspension budget
  */
 import { execSync, spawnSync, spawn } from 'node:child_process';
 import { existsSync, mkdirSync, copyFileSync, readFileSync, writeFileSync, renameSync, readdirSync, readlinkSync, appendFileSync, statSync, unlinkSync } from 'node:fs';
@@ -63,7 +64,8 @@ import {
 } from './utils/bot-routing.js';
 import { isLocale, localeForBot, setDefaultLocale, SUPPORTED_LOCALES, type Locale } from './i18n/index.js';
 import { type Brand, chatAppLink, larkHosts, normalizeBrand, sdkDomain } from './im/lark/lark-hosts.js';
-import { readGlobalConfig, setGlobalLocale, globalConfigPath } from './global-config.js';
+import { mergeGlobalConfig, readGlobalConfig, setGlobalLocale, globalConfigPath, type WorkerConfig } from './global-config.js';
+import { detectWorkerResources, resolveWorkerBudget } from './core/worker-budget.js';
 import { buildBridgeSendMarkerContent } from './services/bridge-fallback-gate.js';
 
 // Resolve the CLI's UI locale once from the global config file, so subsequent
@@ -2309,6 +2311,10 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
   autostart enable     注册开机自启（macOS launchd / Linux user systemd，无需 sudo）
   autostart disable    注销开机自启
   autostart status     查看自启状态
+  worker-budget [status] 查看 idle worker 自动暂停预算
+       set --max-live-workers N [--idle-minutes N]
+                         覆盖全局 worker 预算，写入 ~/.botmux/config.json（agent 推荐用命令改，不手写 JSON）
+       unset             清除 worker 预算覆盖，恢复按机器 CPU/内存自动推导
   lang [zh|en]         切换 UI 语言（无参 = 查看当前设置）
        --bot N         仅改 bots.json 中第 N 个 bot 的 lang
        --unset         清除（global 或 --bot N 配合）
@@ -4397,6 +4403,88 @@ function cmdLang(args: string[]): void {
   console.log(`Run \`botmux restart\` for changes to take effect.`);
 }
 
+// ─── botmux worker-budget ───────────────────────────────────────────────────
+
+function parsePositiveInt(value: string | undefined, label: string): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    console.error(`${label} must be a positive integer.`);
+    process.exit(1);
+  }
+  return n;
+}
+
+function formatGib(bytes: number): string {
+  return `${(bytes / 1024 ** 3).toFixed(1)}GiB`;
+}
+
+function cmdWorkerBudget(args: string[]): void {
+  const sub = (args[0] ?? 'status').toLowerCase();
+  if (sub === '--help' || sub === '-h' || sub === 'help') {
+    console.log(`Usage:
+  botmux worker-budget [status]
+  botmux worker-budget set --max-live-workers <n> [--idle-minutes <n>|--idle-ms <n>]
+  botmux worker-budget unset`);
+    return;
+  }
+
+  if (sub === 'status') {
+    const cfg = readGlobalConfig();
+    const resources = detectWorkerResources();
+    const budget = resolveWorkerBudget(cfg.worker, resources);
+    console.log('Worker budget');
+    console.log(`  maxLiveWorkers: ${budget.maxLiveWorkers} (${budget.maxLiveWorkersSource})`);
+    console.log(`  idleSuspendMs:  ${budget.idleSuspendMs} (${budget.idleSuspendMsSource})`);
+    console.log(`  auto baseline:  ${budget.autoMaxLiveWorkers} from cpu=${resources.cpuCount}, memory=${formatGib(resources.memoryBytes)}`);
+    console.log(`  Config file:    ${globalConfigPath()}`);
+    console.log('');
+    console.log('Agent-safe edit commands:');
+    console.log('  botmux worker-budget set --max-live-workers 12 --idle-minutes 45');
+    console.log('  botmux worker-budget unset');
+    return;
+  }
+
+  if (sub === 'set') {
+    const rest = args.slice(1);
+    const maxLive = argValue(rest, '--max-live-workers', '--max-live');
+    const idleMs = argValue(rest, '--idle-ms', '--idle-suspend-ms');
+    const idleMinutes = argValue(rest, '--idle-minutes', '--idle-min');
+    if (maxLive === undefined && idleMs === undefined && idleMinutes === undefined) {
+      console.error('Usage: botmux worker-budget set --max-live-workers <n> [--idle-minutes <n>|--idle-ms <n>]');
+      process.exit(1);
+    }
+    if (idleMs !== undefined && idleMinutes !== undefined) {
+      console.error('Use only one of --idle-ms or --idle-minutes.');
+      process.exit(1);
+    }
+
+    const current = readGlobalConfig().worker ?? {};
+    const next: WorkerConfig = { ...current };
+    if (maxLive !== undefined) next.maxLiveWorkers = parsePositiveInt(maxLive, '--max-live-workers');
+    if (idleMs !== undefined) next.idleSuspendMs = parsePositiveInt(idleMs, '--idle-ms');
+    if (idleMinutes !== undefined) next.idleSuspendMs = parsePositiveInt(idleMinutes, '--idle-minutes') * 60_000;
+
+    mergeGlobalConfig({ worker: next });
+    const budget = resolveWorkerBudget(next);
+    console.log('✅ Updated worker budget.');
+    console.log(`  maxLiveWorkers: ${budget.maxLiveWorkers} (${budget.maxLiveWorkersSource})`);
+    console.log(`  idleSuspendMs:  ${budget.idleSuspendMs} (${budget.idleSuspendMsSource})`);
+    console.log(`  Config file:    ${globalConfigPath()}`);
+    console.log('Daemon reads this on the next idle-worker sweep; restart also picks it up.');
+    return;
+  }
+
+  if (sub === 'unset' || sub === 'clear') {
+    mergeGlobalConfig({ worker: null });
+    console.log('✅ Cleared worker budget override; daemon will use the auto-derived budget.');
+    console.log(`  Config file: ${globalConfigPath()}`);
+    return;
+  }
+
+  console.error('Usage: botmux worker-budget [status|set|unset]');
+  process.exit(1);
+}
+
 // ─── botmux preset ────────────────────────────────────────────────────────────
 
 /**
@@ -4758,6 +4846,7 @@ switch (command) {
   case 'quoted':   await cmdQuoted(process.argv.slice(3)); break;
   case 'lang':     cmdLang(process.argv.slice(3)); break;
   case 'voice':    await cmdVoiceSetup(process.argv.slice(3)); break;
+  case 'worker-budget': cmdWorkerBudget(process.argv.slice(3)); break;
   case 'thread':   {
     // Removed in favor of `botmux history` (普通群也兼容). Friendly stderr so
     // pre-rename scripts/skills surface the rename instead of "unknown command".

--- a/src/core/idle-worker-sweeper.ts
+++ b/src/core/idle-worker-sweeper.ts
@@ -1,0 +1,48 @@
+import type { DaemonSession } from './types.js';
+import { readGlobalConfig } from '../global-config.js';
+import { DEFAULT_IDLE_SUSPEND_MS, resolveWorkerBudget, type ResolvedWorkerBudget } from './worker-budget.js';
+import { isSuspendableBackendType, suspendWorker } from './worker-pool.js';
+
+export interface IdleWorkerSweepOptions {
+  now?: number;
+  workerBudget?: Pick<ResolvedWorkerBudget, 'maxLiveWorkers' | 'idleSuspendMs'>;
+}
+
+export interface IdleWorkerSweepResult {
+  sessionId: string;
+  reason: string;
+}
+
+export const DEFAULT_IDLE_WORKER_MS = DEFAULT_IDLE_SUSPEND_MS;
+
+function liveWorkers(activeSessions: Map<string, DaemonSession>): DaemonSession[] {
+  return [...activeSessions.values()].filter(ds => !!ds.worker && !ds.worker.killed);
+}
+
+export function sweepIdleWorkers(
+  activeSessions: Map<string, DaemonSession>,
+  opts: IdleWorkerSweepOptions = {},
+): IdleWorkerSweepResult[] {
+  const now = opts.now ?? Date.now();
+  const budget = opts.workerBudget ?? resolveWorkerBudget(readGlobalConfig().worker);
+  const maxLiveWorkers = budget.maxLiveWorkers;
+  const idleMs = budget.idleSuspendMs;
+  const running = liveWorkers(activeSessions);
+  if (running.length <= maxLiveWorkers) return [];
+
+  const candidates = running
+    .filter(ds => isSuspendableBackendType(ds.initConfig?.backendType))
+    .filter(ds => ds.lastScreenStatus === 'idle')
+    .filter(ds => now - (ds.lastMessageAt || 0) >= idleMs)
+    .sort((a, b) => (a.lastMessageAt || 0) - (b.lastMessageAt || 0));
+
+  const suspended: IdleWorkerSweepResult[] = [];
+  let liveCount = running.length;
+  for (const ds of candidates) {
+    if (liveCount <= maxLiveWorkers) break;
+    if (!suspendWorker(ds, 'idle_worker_budget')) continue;
+    suspended.push({ sessionId: ds.session.sessionId, reason: 'idle_worker_budget' });
+    liveCount--;
+  }
+  return suspended;
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -47,7 +47,7 @@ export interface DaemonSession {
   lastMessageAt: number;
   hasHistory: boolean;   // true after CLI has run at least once for this session
   workingDir?: string;
-  initConfig?: DaemonToWorker;   // stored for restart
+  initConfig?: Extract<DaemonToWorker, { type: 'init' }>;   // stored for restart
   pendingRepo?: boolean;         // waiting for repo selection before spawning CLI
   repoCardMessageId?: string;    // message_id of the repo selection card — for withdrawal
   pendingPrompt?: string;        // original user message to send after repo is selected

--- a/src/core/worker-budget.ts
+++ b/src/core/worker-budget.ts
@@ -1,0 +1,70 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { availableParallelism, totalmem } from 'node:os';
+import type { WorkerConfig } from '../global-config.js';
+
+export const MIN_AUTO_MAX_LIVE_WORKERS = 4;
+export const MAX_AUTO_MAX_LIVE_WORKERS = 32;
+export const DEFAULT_IDLE_SUSPEND_MS = 30 * 60_000;
+
+export interface WorkerResources {
+  cpuCount: number;
+  memoryBytes: number;
+}
+
+export interface ResolvedWorkerBudget {
+  maxLiveWorkers: number;
+  idleSuspendMs: number;
+  autoMaxLiveWorkers: number;
+  maxLiveWorkersSource: 'auto' | 'config';
+  idleSuspendMsSource: 'default' | 'config';
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function readMemoryLimitFile(path: string): number | undefined {
+  if (!existsSync(path)) return undefined;
+  const raw = readFileSync(path, 'utf-8').trim();
+  if (!raw || raw === 'max') return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+function cgroupMemoryLimitBytes(hostMemoryBytes: number): number | undefined {
+  const limits = [
+    readMemoryLimitFile('/sys/fs/cgroup/memory.max'),
+    readMemoryLimitFile('/sys/fs/cgroup/memory/memory.limit_in_bytes'),
+  ].filter((n): n is number => n !== undefined);
+  if (limits.length === 0) return undefined;
+  const limit = Math.min(...limits);
+  return limit < hostMemoryBytes ? limit : undefined;
+}
+
+export function detectWorkerResources(): WorkerResources {
+  const hostMemoryBytes = totalmem();
+  return {
+    cpuCount: Math.max(1, availableParallelism?.() ?? 1),
+    memoryBytes: cgroupMemoryLimitBytes(hostMemoryBytes) ?? hostMemoryBytes,
+  };
+}
+
+export function autoMaxLiveWorkers(resources: WorkerResources = detectWorkerResources()): number {
+  const cpuBudget = Math.max(1, resources.cpuCount) * 2;
+  const memoryBudget = Math.max(1, Math.round(resources.memoryBytes / 1024 ** 3));
+  return clamp(Math.min(cpuBudget, memoryBudget), MIN_AUTO_MAX_LIVE_WORKERS, MAX_AUTO_MAX_LIVE_WORKERS);
+}
+
+export function resolveWorkerBudget(
+  workerConfig?: WorkerConfig,
+  resources: WorkerResources = detectWorkerResources(),
+): ResolvedWorkerBudget {
+  const auto = autoMaxLiveWorkers(resources);
+  return {
+    maxLiveWorkers: workerConfig?.maxLiveWorkers ?? auto,
+    idleSuspendMs: workerConfig?.idleSuspendMs ?? DEFAULT_IDLE_SUSPEND_MS,
+    autoMaxLiveWorkers: auto,
+    maxLiveWorkersSource: workerConfig?.maxLiveWorkers === undefined ? 'auto' : 'config',
+    idleSuspendMsSource: workerConfig?.idleSuspendMs === undefined ? 'default' : 'config',
+  };
+}

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -33,6 +33,7 @@ import { composeRowFromActive } from './dashboard-rows.js';
 import { publishAttentionPatch } from './session-activity.js';
 import { knownBotOpenIdsFromCrossRef, type BotMentionEntry } from '../utils/bot-routing.js';
 import type { CliId } from '../adapters/cli/types.js';
+import type { BackendType } from '../adapters/backend/types.js';
 import type { DaemonToWorker, WorkerToDaemon, Session, DisplayMode } from '../types.js';
 import { sessionKey, sessionAnchorId, type DaemonSession } from './types.js';
 import { claimPendingResponseCard, COMPLETED_REACTION_EMOJI_TYPE, markPendingResponseCardPatchedIfCurrent, syncPendingResponseState } from './pending-response.js';
@@ -861,6 +862,40 @@ export function killWorker(ds: DaemonSession): void {
   ds.worker = null;
   ds.workerPort = null;
   ds.workerToken = null;
+}
+
+export function isSuspendableBackendType(backendType: BackendType | undefined): boolean {
+  return backendType === 'tmux' || backendType === 'herdr' || backendType === 'zellij';
+}
+
+export function suspendWorker(ds: DaemonSession, reason = 'suspended_idle'): boolean {
+  if (!ds.worker || ds.worker.killed) return false;
+  if (!isSuspendableBackendType(ds.initConfig?.backendType)) return false;
+
+  const w = ds.worker;
+  try {
+    w.send({ type: 'suspend' } as DaemonToWorker);
+  } catch {
+    try { w.kill('SIGTERM'); } catch { /* already gone */ }
+  }
+  armWorkerKillBackstop(w, tag(ds));
+
+  ds.worker = null;
+  ds.workerPort = null;
+  ds.workerToken = null;
+  ds.session.webPort = undefined;
+  sessionStore.updateSessionPid(ds.session.sessionId, null);
+  sessionStore.updateSession(ds.session);
+
+  if (!ds.exitEventEmitted) {
+    ds.exitEventEmitted = true;
+    dashboardEventBus.publish({
+      type: 'session.exited',
+      body: { sessionId: ds.session.sessionId, reason },
+    });
+  }
+  logger.info(`[${tag(ds)}] Worker suspended (${reason}); session remains active`);
+  return true;
 }
 
 function armWorkerKillBackstop(w: ChildProcess, label: string): void {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -77,6 +77,7 @@ import {
   rememberLastCliInput,
   ensureTerminalWorkerPort,
 } from './core/session-manager.js';
+import { sweepIdleWorkers } from './core/idle-worker-sweeper.js';
 import { handleCardAction } from './im/lark/card-handler.js';
 import type { CardHandlerDeps } from './im/lark/card-handler.js';
 import {
@@ -3122,6 +3123,14 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   // Restore active sessions from previous run
   await restoreActiveSessions(activeSessions);
 
+  const idleWorkerSweepTimer = setInterval(() => {
+    const suspended = sweepIdleWorkers(activeSessions);
+    if (suspended.length > 0) {
+      logger.info(`[idle-worker-sweeper] suspended ${suspended.length} idle worker(s)`);
+    }
+  }, 60_000);
+  idleWorkerSweepTimer.unref?.();
+
   await attachColdWorkflowRuns(cfg.larkAppId);
 
   // Start scheduler in every daemon.  Each daemon owns exactly one bot, so
@@ -3151,6 +3160,7 @@ export async function startDaemon(botIndex?: number): Promise<void> {
     workflowEventWatchers.clear();
     workflowRuns.clear();
     clearInterval(descriptorHeartbeat);
+    clearInterval(idleWorkerSweepTimer);
     if (memoryDiagnostics) clearInterval(memoryDiagnostics);
     removeDaemonDescriptor(cfg.larkAppId);
     ipcHandle.close().catch(() => { /* swallow */ });
@@ -3220,6 +3230,7 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   // the descriptor so the dashboard doesn't see a phantom daemon.
   process.on('exit', () => {
     clearInterval(descriptorHeartbeat);
+    clearInterval(idleWorkerSweepTimer);
     if (memoryDiagnostics) clearInterval(memoryDiagnostics);
     removeDaemonDescriptor(cfg.larkAppId);
     // Plain-exit path (uncaught fatal, manual process.exit) bypasses the

--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -18,6 +18,11 @@ import { homedir } from 'node:os';
 import { isLocale, type Locale } from './i18n/types.js';
 import type { VoiceConfig } from './services/voice/types.js';
 
+export interface WorkerConfig {
+  maxLiveWorkers?: number;
+  idleSuspendMs?: number;
+}
+
 export interface GlobalConfig {
   lang?: Locale;
   /** Machine-wide dashboard settings. These are intentionally global rather
@@ -28,6 +33,9 @@ export interface GlobalConfig {
    *  services/voice/types.ts. Presence (with usable creds) gates the
    *  "🔊 语音总结" button. */
   voice?: VoiceConfig;
+  /** Machine-wide worker resource policy. Daemon falls back to an
+   *  auto-derived live-worker budget when this block is absent. */
+  worker?: WorkerConfig;
 }
 
 export interface DashboardGlobalConfig {
@@ -58,6 +66,22 @@ function readDashboard(raw: unknown): DashboardGlobalConfig | undefined {
   if (typeof d.publicReadOnly === 'boolean') out.publicReadOnly = d.publicReadOnly;
   if (typeof d.openTerminalInFeishu === 'boolean') out.openTerminalInFeishu = d.openTerminalInFeishu;
   return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function readPositiveInteger(raw: unknown): number | undefined {
+  if (typeof raw !== 'number' || !Number.isInteger(raw) || raw <= 0) return undefined;
+  return raw;
+}
+
+function readWorker(raw: unknown): WorkerConfig | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const v = raw as Record<string, unknown>;
+  const worker: WorkerConfig = {};
+  const maxLiveWorkers = readPositiveInteger(v.maxLiveWorkers);
+  const idleSuspendMs = readPositiveInteger(v.idleSuspendMs);
+  if (maxLiveWorkers !== undefined) worker.maxLiveWorkers = maxLiveWorkers;
+  if (idleSuspendMs !== undefined) worker.idleSuspendMs = idleSuspendMs;
+  return Object.keys(worker).length > 0 ? worker : undefined;
 }
 
 export function globalConfigPath(): string {
@@ -108,6 +132,8 @@ export function readGlobalConfig(): GlobalConfig {
   if (dashboard) out.dashboard = dashboard;
   const voice = readVoice(raw.voice);
   if (voice) out.voice = voice;
+  const worker = readWorker(raw.worker);
+  if (worker) out.worker = worker;
   readCache = { path, value: out, at: Date.now() };
   return out;
 }

--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -969,6 +969,31 @@ stdout 为一行 JSON。注意：\`--json\` 覆盖所有结果类型；超时 / 
 - 默认超时 300 秒，可用 \`--timeout <seconds>\` 调整
 `;
 
+const WORKER_BUDGET_SKILL = `---
+name: botmux-worker-budget
+description: 查看或调整 botmux idle worker 自动暂停预算。触发场景：用户提到 OOM、内存占用、live worker 太多、闲置会话暂停、maxLiveWorkers、idleSuspendMs，或要求 agent 修改 worker 预算配置。必须使用 botmux worker-budget 命令，不要手写 ~/.botmux/config.json。
+---
+
+# botmux-worker-budget — worker 预算配置
+
+当用户要求查看或调整 botmux worker 资源预算时，使用 \`botmux worker-budget\`。不要直接编辑 \`~/.botmux/config.json\`；命令会校验正整数、保留未知配置，并写入 daemon 读取的全局配置。
+
+## 用法
+
+\`\`\`bash
+# 查看自动推导值、当前覆盖值、配置文件路径
+botmux worker-budget status
+
+# 覆盖 live worker 上限；idle 阈值可选
+botmux worker-budget set --max-live-workers 12 --idle-minutes 45
+
+# 清除覆盖，恢复按 CPU/内存自动推导
+botmux worker-budget unset
+\`\`\`
+
+\`maxLiveWorkers\` 控制多少个 live worker 以内保持常驻；超过预算时 daemon 会优先暂停最久未活跃的 worker。\`idleSuspendMs\` 控制 worker 需要闲置多久才允许被暂停。
+`;
+
 const ORCHESTRATE_SKILL = `---
 name: botmux-orchestrate
 description: 作为「主 bot/编排者」把一个大项目拆成多个子项目，在普通群里自动开多话题、把不同 bot（常 coder+reviewer 一组）派进各话题并行干活，用飞书任务清单当共享进度板，收齐结果再汇总。触发：用户提到「多话题协作模式」，或要「把大项目拆给多个机器人并行做」「协调多个 bot」「多话题并行推进」「你当总控/编排」「一个写一个 review 多组并行」，或显式提到 botmux orchestrate / botmux dispatch 派活。
@@ -1052,6 +1077,7 @@ export const BUILTIN_SKILLS: SkillDef[] = [
   { name: 'botmux-bots', content: BOTS_SKILL },
   { name: 'botmux-handoff', content: HANDOFF_SKILL },
   { name: 'botmux-workflow-create', content: WORKFLOW_CREATE_SKILL },
+  { name: 'botmux-worker-budget', content: WORKER_BUDGET_SKILL },
   { name: 'botmux-orchestrate', content: ORCHESTRATE_SKILL },
 ];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -218,6 +218,7 @@ export type DaemonToWorker =
   | { type: 'message'; content: string }
   | { type: 'raw_input'; content: string }
   | { type: 'close' }
+  | { type: 'suspend' }
   | { type: 'restart' }
   | { type: 'tui_keys'; keys: string[]; isFinal: boolean }
   | { type: 'tui_text_input'; keys: string[]; text: string }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4291,6 +4291,17 @@ process.on('message', async (raw: unknown) => {
       cleanup();
       process.exit(0);
     }
+
+    case 'suspend': {
+      log('Suspend requested');
+      stopScreenshotLoop();
+      stopBridgeWatcher();
+      try { backend?.kill(); } catch { /* detach best-effort */ }
+      backend = null;
+      isPromptReady = false;
+      cleanup();
+      process.exit(0);
+    }
   }
 });
 

--- a/test/builtin-skills.test.ts
+++ b/test/builtin-skills.test.ts
@@ -123,6 +123,19 @@ describe('built-in botmux-handoff skill', () => {
   });
 });
 
+describe('built-in botmux-worker-budget skill', () => {
+  it('teaches agents to use the CLI command instead of hand-editing JSON', () => {
+    const skill = BUILTIN_SKILLS.find(s => s.name === 'botmux-worker-budget');
+    expect(skill).toBeDefined();
+    expect(skill!.content).toContain('botmux worker-budget status');
+    expect(skill!.content).toContain('botmux worker-budget set --max-live-workers');
+    expect(skill!.content).toContain('botmux worker-budget unset');
+    expect(skill!.content).toContain('不要直接编辑 `~/.botmux/config.json`');
+    expect(skill!.content).toContain('maxLiveWorkers');
+    expect(skill!.content).toContain('idleSuspendMs');
+  });
+});
+
 describe('botmux-ask skill 条件兜底（hook 优先 + 非 hook CLI 保留）', () => {
   it('不在 BUILTIN_SKILLS（不再无条件装到所有 CLI）', () => {
     expect(BUILTIN_SKILLS.find(s => s.name === 'botmux-ask')).toBeUndefined();

--- a/test/global-config-worker.test.ts
+++ b/test/global-config-worker.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { globalConfigPath, mergeGlobalConfig, readGlobalConfig } from '../src/global-config.js';
+
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+
+function withHome(): string {
+  const home = mkdtempSync(join(tmpdir(), 'botmux-global-config-worker-'));
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  mkdirSync(join(home, '.botmux'), { recursive: true });
+  return home;
+}
+
+afterEach(() => {
+  process.env.HOME = originalHome;
+  process.env.USERPROFILE = originalUserProfile;
+});
+
+describe('global worker config', () => {
+  it('reads valid worker budget settings from the global config', () => {
+    const home = withHome();
+    writeFileSync(
+      join(home, '.botmux', 'config.json'),
+      JSON.stringify({
+        worker: {
+          maxLiveWorkers: 12,
+          idleSuspendMs: 45 * 60_000,
+        },
+      }),
+      { flag: 'w' },
+    );
+
+    expect(readGlobalConfig().worker).toEqual({
+      maxLiveWorkers: 12,
+      idleSuspendMs: 45 * 60_000,
+    });
+  });
+
+  it('drops invalid worker budget values while preserving unknown keys on write', () => {
+    const home = withHome();
+    writeFileSync(
+      join(home, '.botmux', 'config.json'),
+      JSON.stringify({
+        unknown: 'keep-me',
+        worker: {
+          maxLiveWorkers: -1,
+          idleSuspendMs: 'nope',
+        },
+      }),
+      { flag: 'w' },
+    );
+
+    expect(readGlobalConfig().worker).toBeUndefined();
+
+    mergeGlobalConfig({ worker: { maxLiveWorkers: 10 } as any });
+    const raw = JSON.parse(readFileSync(globalConfigPath(), 'utf-8'));
+    expect(raw.unknown).toBe('keep-me');
+    expect(raw.worker).toEqual({ maxLiveWorkers: 10 });
+  });
+});

--- a/test/idle-worker-sweeper.test.ts
+++ b/test/idle-worker-sweeper.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/services/session-store.js', () => ({
+  updateSessionPid: vi.fn(),
+  updateSession: vi.fn(),
+}));
+vi.mock('../src/core/dashboard-events.js', () => ({
+  dashboardEventBus: { publish: vi.fn() },
+}));
+vi.mock('../src/utils/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { sweepIdleWorkers } from '../src/core/idle-worker-sweeper.js';
+
+function ds(sessionId: string, backendType: string, lastMessageAt: number, worker = {}) {
+  return {
+    session: { sessionId, status: 'active' },
+    initConfig: { backendType },
+    worker: {
+      killed: false,
+      send: vi.fn(),
+      once: vi.fn(),
+      kill: vi.fn(),
+      exitCode: null,
+      signalCode: null,
+      ...worker,
+    },
+    workerPort: 1000,
+    workerToken: 'tok',
+    lastMessageAt,
+    lastScreenStatus: 'idle',
+    exitEventEmitted: false,
+  } as any;
+}
+
+describe('sweepIdleWorkers', () => {
+  it('does nothing while live workers are at or under the resolved budget', () => {
+    const now = 1_000_000;
+    const activeSessions = new Map<string, any>([
+      ['a', ds('a', 'tmux', now - 60 * 60_000)],
+      ['b', ds('b', 'herdr', now - 50 * 60_000)],
+      ['c', ds('c', 'zellij', now - 40 * 60_000)],
+      ['d', ds('d', 'tmux', now - 2 * 60_000)],
+    ]);
+
+    const suspended = sweepIdleWorkers(activeSessions, {
+      now,
+      workerBudget: { maxLiveWorkers: 8, idleSuspendMs: 30 * 60_000 },
+    });
+
+    expect(suspended).toEqual([]);
+    expect(activeSessions.get('a').worker).not.toBe(null);
+    expect(activeSessions.get('b').worker).not.toBe(null);
+    expect(activeSessions.get('c').worker).not.toBe(null);
+    expect(activeSessions.get('d').worker).not.toBe(null);
+  });
+
+  it('uses the resolved policy and suspends oldest idle workers over the live-worker budget', () => {
+    const now = 1_000_000;
+    const activeSessions = new Map<string, any>([
+      ['a', ds('a', 'tmux', now - 90 * 60_000)],
+      ['b', ds('b', 'herdr', now - 80 * 60_000)],
+      ['c', ds('c', 'zellij', now - 70 * 60_000)],
+      ['d', ds('d', 'tmux', now - 60 * 60_000)],
+      ['e', ds('e', 'herdr', now - 50 * 60_000)],
+      ['f', ds('f', 'zellij', now - 40 * 60_000)],
+      ['g', ds('g', 'tmux', now - 35 * 60_000)],
+      ['h', ds('h', 'herdr', now - 31 * 60_000)],
+      ['i', ds('i', 'zellij', now - 30 * 60_000)],
+      ['j', ds('j', 'tmux', now - 2 * 60_000)],
+    ]);
+
+    const suspended = sweepIdleWorkers(activeSessions, {
+      now,
+      workerBudget: { maxLiveWorkers: 8, idleSuspendMs: 30 * 60_000 },
+    });
+
+    expect(suspended.map(s => s.sessionId)).toEqual(['a', 'b']);
+    expect(activeSessions.get('a').session.status).toBe('active');
+    expect(activeSessions.get('b').session.status).toBe('active');
+    expect(activeSessions.get('c').worker).not.toBe(null);
+    expect(activeSessions.get('j').worker).not.toBe(null);
+  });
+
+  it('honors configured max live workers and idle suspend threshold', () => {
+    const now = 1_000_000;
+    const activeSessions = new Map<string, any>([
+      ['a', ds('a', 'tmux', now - 120 * 60_000)],
+      ['b', ds('b', 'herdr', now - 90 * 60_000)],
+      ['c', ds('c', 'zellij', now - 45 * 60_000)],
+      ['d', ds('d', 'tmux', now - 20 * 60_000)],
+      ['e', ds('e', 'herdr', now - 10 * 60_000)],
+      ['f', ds('f', 'zellij', now - 5 * 60_000)],
+    ]);
+
+    const suspended = sweepIdleWorkers(activeSessions, {
+      now,
+      workerBudget: { maxLiveWorkers: 4, idleSuspendMs: 30 * 60_000 },
+    });
+
+    expect(suspended.map(s => s.sessionId)).toEqual(['a', 'b']);
+    expect(activeSessions.get('a').worker).toBe(null);
+    expect(activeSessions.get('b').worker).toBe(null);
+    expect(activeSessions.get('c').worker).not.toBe(null);
+    expect(activeSessions.get('d').worker).not.toBe(null);
+  });
+
+  it('never suspends pty workers', () => {
+    const now = 1_000_000;
+    const activeSessions = new Map<string, any>([
+      ['a', ds('a', 'pty', now - 60 * 60_000)],
+      ['b', ds('b', 'pty', now - 60 * 60_000)],
+      ['c', ds('c', 'pty', now - 60 * 60_000)],
+      ['d', ds('d', 'pty', now - 60 * 60_000)],
+      ['e', ds('e', 'pty', now - 60 * 60_000)],
+      ['f', ds('f', 'pty', now - 60 * 60_000)],
+      ['g', ds('g', 'pty', now - 60 * 60_000)],
+      ['h', ds('h', 'pty', now - 60 * 60_000)],
+      ['i', ds('i', 'pty', now - 60 * 60_000)],
+      ['j', ds('j', 'tmux', now - 60 * 60_000)],
+    ]);
+
+    const suspended = sweepIdleWorkers(activeSessions, {
+      now,
+      workerBudget: { maxLiveWorkers: 8, idleSuspendMs: 30 * 60_000 },
+    });
+
+    expect(suspended.map(s => s.sessionId)).toEqual(['j']);
+    expect(activeSessions.get('a').worker).not.toBe(null);
+    expect(activeSessions.get('i').worker).not.toBe(null);
+  });
+
+  it('does not suspend workers that are not idle', () => {
+    const now = 1_000_000;
+    const activeSessions = new Map<string, any>([
+      ['a', { ...ds('a', 'tmux', now - 90 * 60_000), lastScreenStatus: 'working' }],
+      ['b', { ...ds('b', 'herdr', now - 80 * 60_000), lastScreenStatus: 'analyzing' }],
+      ['c', { ...ds('c', 'zellij', now - 70 * 60_000), lastScreenStatus: 'limited' }],
+      ['d', { ...ds('d', 'tmux', now - 60 * 60_000), lastScreenStatus: undefined }],
+      ['e', ds('e', 'herdr', now - 50 * 60_000)],
+      ['f', ds('f', 'zellij', now - 40 * 60_000)],
+      ['g', ds('g', 'tmux', now - 35 * 60_000)],
+      ['h', ds('h', 'herdr', now - 31 * 60_000)],
+      ['i', ds('i', 'zellij', now - 30 * 60_000)],
+      ['j', ds('j', 'tmux', now - 2 * 60_000)],
+    ]);
+
+    const suspended = sweepIdleWorkers(activeSessions, {
+      now,
+      workerBudget: { maxLiveWorkers: 8, idleSuspendMs: 30 * 60_000 },
+    });
+
+    expect(suspended.map(s => s.sessionId)).toEqual(['e', 'f']);
+    expect(activeSessions.get('a').worker).not.toBe(null);
+    expect(activeSessions.get('b').worker).not.toBe(null);
+    expect(activeSessions.get('c').worker).not.toBe(null);
+    expect(activeSessions.get('d').worker).not.toBe(null);
+  });
+});

--- a/test/worker-budget-cli.test.ts
+++ b/test/worker-budget-cli.test.ts
@@ -1,0 +1,59 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const CLI_PATH = join(__dirname, '..', 'dist', 'cli.js');
+
+let home: string;
+
+beforeAll(() => {
+  if (!existsSync(CLI_PATH)) {
+    throw new Error('dist/cli.js missing — run `pnpm build` first');
+  }
+  home = mkdtempSync(join(tmpdir(), 'botmux-worker-budget-cli-'));
+  mkdirSync(join(home, '.botmux'), { recursive: true });
+});
+
+afterAll(() => {
+  if (home) rmSync(home, { recursive: true, force: true });
+});
+
+function runCli(args: string[]): { status: number; stdout: string; stderr: string } {
+  const r = spawnSync('node', [CLI_PATH, ...args], {
+    cwd: home,
+    env: { ...process.env, HOME: home, USERPROFILE: home },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+  });
+  return { status: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+function readConfig(): any {
+  return JSON.parse(readFileSync(join(home, '.botmux', 'config.json'), 'utf-8'));
+}
+
+describe('botmux worker-budget CLI', () => {
+  it('shows the auto-derived budget and the agent-safe edit command', () => {
+    const out = runCli(['worker-budget', 'status']);
+
+    expect(out.status).toBe(0);
+    expect(out.stdout).toContain('Worker budget');
+    expect(out.stdout).toContain('maxLiveWorkers');
+    expect(out.stdout).toContain('botmux worker-budget set');
+  });
+
+  it('sets and unsets worker budget config without manual JSON editing', () => {
+    const set = runCli(['worker-budget', 'set', '--max-live-workers', '12', '--idle-minutes', '45']);
+    expect(set.status).toBe(0);
+    expect(readConfig().worker).toEqual({
+      maxLiveWorkers: 12,
+      idleSuspendMs: 45 * 60_000,
+    });
+
+    const unset = runCli(['worker-budget', 'unset']);
+    expect(unset.status).toBe(0);
+    expect(readConfig().worker).toBeUndefined();
+  });
+});

--- a/test/worker-budget.test.ts
+++ b/test/worker-budget.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveWorkerBudget } from '../src/core/worker-budget.js';
+
+const gib = (n: number) => n * 1024 ** 3;
+
+describe('resolveWorkerBudget', () => {
+  it('derives the default live-worker budget from CPU and memory', () => {
+    expect(resolveWorkerBudget(undefined, { cpuCount: 4, memoryBytes: gib(8) }).maxLiveWorkers).toBe(8);
+    expect(resolveWorkerBudget(undefined, { cpuCount: 8, memoryBytes: gib(16) }).maxLiveWorkers).toBe(16);
+    expect(resolveWorkerBudget(undefined, { cpuCount: 64, memoryBytes: gib(128) }).maxLiveWorkers).toBe(32);
+  });
+
+  it('lets global config override max live workers and idle threshold independently', () => {
+    const resolved = resolveWorkerBudget(
+      { maxLiveWorkers: 12, idleSuspendMs: 45 * 60_000 },
+      { cpuCount: 4, memoryBytes: gib(8) },
+    );
+
+    expect(resolved).toEqual({
+      maxLiveWorkers: 12,
+      idleSuspendMs: 45 * 60_000,
+      autoMaxLiveWorkers: 8,
+      maxLiveWorkersSource: 'config',
+      idleSuspendMsSource: 'config',
+    });
+  });
+});

--- a/test/worker-suspend.test.ts
+++ b/test/worker-suspend.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { BackendType } from '../src/adapters/backend/types.js';
+import type { CliId } from '../src/adapters/cli/types.js';
+
+vi.mock('../src/services/session-store.js', () => ({
+  updateSessionPid: vi.fn(),
+  updateSession: vi.fn(),
+}));
+vi.mock('../src/core/dashboard-events.js', () => ({
+  dashboardEventBus: { publish: vi.fn() },
+}));
+vi.mock('../src/utils/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { isSuspendableBackendType, suspendWorker } from '../src/core/worker-pool.js';
+
+const CLI_IDS: CliId[] = [
+  'claude-code',
+  'seed',
+  'aiden',
+  'coco',
+  'codex',
+  'codex-app',
+  'cursor',
+  'gemini',
+  'opencode',
+  'antigravity',
+  'mtr',
+  'hermes',
+  'mira',
+  'traex',
+  'pi',
+  'copilot',
+];
+
+const BACKENDS: BackendType[] = ['pty', 'tmux', 'herdr', 'zellij'];
+
+describe('worker suspend backend gating', () => {
+  it.each(BACKENDS)('classifies %s correctly', (backend) => {
+    expect(isSuspendableBackendType(backend)).toBe(backend !== 'pty');
+  });
+
+  it.each(CLI_IDS)('does not special-case CLI adapter %s', (_cliId) => {
+    expect(isSuspendableBackendType('tmux')).toBe(true);
+    expect(isSuspendableBackendType('herdr')).toBe(true);
+    expect(isSuspendableBackendType('zellij')).toBe(true);
+    expect(isSuspendableBackendType('pty')).toBe(false);
+  });
+});
+
+function fakeWorker() {
+  return {
+    killed: false,
+    pid: 12345,
+    send: vi.fn(),
+    once: vi.fn(),
+    kill: vi.fn(),
+    exitCode: null,
+    signalCode: null,
+  } as any;
+}
+
+describe('suspendWorker', () => {
+  it('suspends a persistent worker without closing the active session', () => {
+    const worker = fakeWorker();
+    const ds: any = {
+      session: { sessionId: 'sid-1', status: 'active' },
+      initConfig: { backendType: 'tmux' },
+      worker,
+      workerPort: 3456,
+      workerToken: 'token',
+      exitEventEmitted: false,
+    };
+
+    const didSuspend = suspendWorker(ds, 'idle_budget');
+
+    expect(didSuspend).toBe(true);
+    expect(worker.send).toHaveBeenCalledWith({ type: 'suspend' });
+    expect(ds.session.status).toBe('active');
+    expect(ds.worker).toBe(null);
+    expect(ds.workerPort).toBe(null);
+    expect(ds.workerToken).toBe(null);
+  });
+
+  it('does not suspend pty workers', () => {
+    const worker = fakeWorker();
+    const ds: any = {
+      session: { sessionId: 'sid-pty', status: 'active' },
+      initConfig: { backendType: 'pty' },
+      worker,
+      workerPort: 3456,
+      workerToken: 'token',
+    };
+
+    expect(suspendWorker(ds, 'idle_budget')).toBe(false);
+    expect(worker.send).not.toHaveBeenCalled();
+    expect(ds.worker).toBe(worker);
+  });
+});


### PR DESCRIPTION
## 背景 / 现象

在一台 4 核 Intel Celeron N5105、8GB 内存、约 6GB swap 的小型常驻 Docker 部署里，botmux 长期开较多会话后会积累大量 live worker。每个 live 会话不只是 session 记录，还会持有 botmux worker、CLI launcher，以及 Codex/Claude 等 backend 进程；会话长期 idle 时这些进程仍然占用内存，最终容易把机器推到 OOM 或重启。

即使部署方可以用 VM / Docker 做资源限制，框架层仍然需要主动回收 idle worker：资源限制只能控制故障边界，不能减少 botmux 自身随会话数增长而常驻的 backend 进程内存，也无法避免服务在限制内频繁触发 OOM。

## 修复

- 新增 idle worker sweeper：当 live worker 数量超过预算时，优先暂停最久未活跃、且 backend 支持恢复的 worker。
- 暂停只释放 worker 进程，不删除 session；用户再次进入会话时仍走原有 resume/restart 路径恢复。
- live worker 预算默认按机器可用 CPU / 内存自动推导，并限制在合理上下限内，避免把小机器的固定阈值套到大机器上。
- 支持全局配置覆盖 `maxLiveWorkers` 和 `idleSuspendMs`。
- 提供 `botmux worker-budget status|set|unset`，并新增 `botmux-worker-budget` 内置 skill；agent 调整该配置时应使用命令修改，不直接手写 `~/.botmux/config.json`。

## 默认值依据

live worker 默认预算按当前运行环境自动推导：

- CPU 预算：`availableParallelism() * 2`
- 内存预算：约 `1 worker / GiB`
- 最终取两者较小值，并限制在 `4..32`
- 在 Docker / cgroup 环境中，如果 cgroup memory limit 小于宿主机内存，会优先按 cgroup limit 计算

这个策略的目标是让瓶颈资源决定默认值：CPU 多但内存少时不保留过多 CLI 进程，内存多但 CPU 少时也不让可并发恢复的 live worker 无限增长。`4` 是避免小机器过早暂停最近会话的下限，`32` 是避免大机器默认值过大导致框架继续无界积累；需要更激进或更宽松的部署可以用 `botmux worker-budget set --max-live-workers N` 覆盖。

idle worker 默认 30 分钟后才允许暂停。这个默认值参考 Codex app-server 的 thread unload 策略：Codex 在 `thread/unsubscribe` 后，如果 thread 同时满足 no subscribers 且 no activity，会等待 30 分钟再 unload thread，并把状态转为 `notLoaded`。对应文档见 [codex-rs/app-server README](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md)，实现里也有 `THREAD_UNLOADING_DELAY = 30 * 60` 的常量，见 [thread_lifecycle.rs](https://raw.githubusercontent.com/openai/codex/main/codex-rs/app-server/src/request_processors/thread_lifecycle.rs)。

botmux 没有 Codex app-server 的 subscriber 模型，因此这里不照搬触发条件；只复用同一个保守时间窗口：半小时内的连续追问不频繁触发 suspend/resume，超过半小时且 live worker 超预算时，才释放 idle backend 进程。session 本身仍保留，后续消息继续走恢复路径。

## 回归覆盖

- worker budget 自动推导和配置覆盖
- 全局 config 读取、校验、保留未知 key
- `botmux worker-budget` CLI status / set / unset
- idle sweeper 的超预算暂停、idle 阈值、不可暂停 backend 保护
- session quiet restart / resume 既有行为
- built-in skill 内容，确保 agent 看到命令入口

## 验证

- `pnpm build`
- `pnpm vitest run test/worker-budget.test.ts test/global-config-worker.test.ts test/idle-worker-sweeper.test.ts test/worker-budget-cli.test.ts test/builtin-skills.test.ts test/worker-suspend.test.ts test/session-manager-quiet-restart.test.ts test/session-resume.test.ts`
- `git diff --check`

## 影响范围

主要影响 daemon 的 session worker 生命周期管理。不会删除 session，不会主动关闭不支持 suspend 的 backend worker；配置缺省时使用自动预算，已有部署无需新增配置即可生效。