### PR TITLE
fix(lark): honor /t override for bot senders

### DIFF
--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -1196,15 +1196,35 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
           if (!isBotMentioned(larkAppId, message, undefined)) return;
           const decision = await decideRoutingWithSource(larkAppId, message);
           const ctx = { scope: decision.scope, anchor: decision.anchor };
+          // Honor `/t` / `/topic` from bot senders too, aligning with the human
+          // path so an explicit `@bot /t …` handoff seeds a fresh topic instead of
+          // sticking to chat-scope. Applied BEFORE the gate (and the topic_alias
+          // fold) so vetting keys on the FINAL routing: `/t` rewrites ctx to a
+          // brand-new {thread, messageId} anchor. forceTopicApplied also suppresses
+          // the topic_alias fold below — a `/t` seed wins over alias, same
+          // precedence as the human path.
+          const forcedTopic = maybeApplyForceTopicOverride(ctx, message, messageId);
+          if (forcedTopic) {
+            logger.info(`[/t] Force-topic override (bot sender): msg=${messageId.substring(0, 12)} → thread-scope, anchor=msg`);
+          }
           const replyRootId = await maybeApplyTopicAliasSeed({
-            larkAppId, chatId, chatType, message, senderOpenId, messageId, routing: ctx,
+            larkAppId, chatId, chatType, message, senderOpenId, messageId, routing: ctx, forceTopicApplied: forcedTopic,
           });
-          // Regular-group foreign-bot @mention without an existing session:
-          // gate to vetted botmux peers (registered in our bot-openids cross-ref).
-          // This applies both to legacy chat-scope routing and to the
-          // regularGroupReplyInThread send-shape, so random Lark bots cannot
-          // silently spawn sessions in 普通群 just because this bot replies in
-          // threads. Known Bot A → Bot B handoffs in 普通群 still work.
+          // Regular-group foreign-bot @mention: gate to vetted botmux peers
+          // (registered in our bot-openids cross-ref). Fires for legacy chat-scope
+          // routing, the regularGroupReplyInThread/new-topic send-shape
+          // (decision.source === 'regular-group-thread'), AND a `/t` force-topic
+          // seed (forcedTopic) — so random Lark bots cannot silently spawn sessions
+          // in 普通群, whether this bot replies in threads or a stranger bot @s us
+          // with `/t`. Known Bot A → Bot B handoffs in 普通群 still work.
+          //
+          // ownsSession is read on ctx.anchor AFTER the `/t` override above. That
+          // exemption means "a foreign bot following up into a session we already
+          // own" (e.g. a chat-scope session at chatId). A `/t` rewrites the anchor
+          // to a fresh messageId where we own nothing, so an unvetted bot can NOT
+          // ride the existing chat-scope session's ownership to skip vetting — it
+          // must independently hit isKnownPeerBot / chatGrants / globalGrants (or
+          // this bot's own oncall chat).
           //
           // 注意 isKnownPeerBot 查的是 cross-ref（bot-openids-<appId>.json），它只
           // 收录 bots-info.json 里有名字的 bot，即本机 daemon 自己配置的 bot
@@ -1222,7 +1242,7 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
           // 同一存储、同一 per-chat 语义）。命中 chatGrants 的 bot 即便不在 cross-ref，
           // 也与已注册 peer 同等放行——这是「授权外部 bot 在本群协作」的入口。
           // 全局授权（globalGrants）同理：命中即在任意群放行，是上面的全局版。
-          if ((ctx.scope === 'chat' || decision.source === 'regular-group-thread') && !findOncallChat(larkAppId, chatId)) {
+          if ((ctx.scope === 'chat' || decision.source === 'regular-group-thread' || forcedTopic) && !findOncallChat(larkAppId, chatId)) {
             const ownsSession = handlers.isSessionOwner?.(ctx.anchor, larkAppId) ?? false;
             if (!ownsSession
                 && !isKnownPeerBot(config.session.dataDir, larkAppId, senderOpenId)

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -482,6 +482,206 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
   });
 
+  it('still drops an unknown-peer bot even when it sends /t (no force-topic gate bypass)', async () => {
+    // 关键回归：bot-sender 的 `/t` override 把 chat-scope 翻成 thread-scope，但
+    // 它必须排在 vetting gate 之后。否则随机第三方 bot 发 `@bot /t …` 会让闸门
+    // 的 `ctx.scope === 'chat' || source === 'regular-group-thread'` 两条件全 false
+    // → 绕过 vetting → 静默 spawn 一个 thread-scope 会话。这条用例锁死「不能绕」。
+    mockGetChatMode.mockResolvedValueOnce('group');  // 普通群, regularGroupReplyInThread off → source=regular-group-chat
+    mockReadFileSync.mockReturnValue('{}');  // empty cross-ref → unknown peer
+    const event = makeBotMessageEvent({
+      senderOpenId: OTHER_BOT_OPEN_ID,
+      senderType: 'bot',
+      content: JSON.stringify({
+        zh_cn: { content: [[
+          { tag: 'at', user_id: MY_OPEN_ID },
+          { tag: 'text', text: ' /t spawn me' },
+        ]] },
+      }),
+      rootId: undefined,
+    });
+    event.message.root_id = undefined as any;
+    handlers.isSessionOwner.mockReturnValue(false);
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+  });
+
+  it('lets a KNOWN-peer bot use /t to seed a fresh topic in 普通群', async () => {
+    // 合法用例：已登记 peer bot（cross-ref 命中）发 `@bot /t …` 交接，过 vetting
+    // gate 后 override 生效，把 chat-scope 翻成 thread-scope 开新话题。与上面的
+    // 「unknown peer + /t 被 drop」对照，证明修复只挡未授权 bot、不误伤交接。
+    mockGetChatMode.mockResolvedValueOnce('group');
+    mockReadFileSync.mockReturnValue(JSON.stringify({ 'BotB': OTHER_BOT_OPEN_ID }));  // known peer
+    const event = makeBotMessageEvent({
+      senderOpenId: OTHER_BOT_OPEN_ID,
+      senderType: 'bot',
+      content: JSON.stringify({
+        zh_cn: { content: [[
+          { tag: 'at', user_id: MY_OPEN_ID },
+          { tag: 'text', text: ' /t spawn me' },
+        ]] },
+      }),
+      rootId: undefined,
+    });
+    event.message.root_id = undefined as any;
+    handlers.isSessionOwner.mockReturnValue(false);
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
+      scope: 'thread',
+      anchor: 'msg-001',
+      larkAppId: MY_APP_ID,
+    }));
+  });
+
+  it('still drops an unknown-peer bot /t when this bot owns a chat-scope session (stale-anchor ownsSession must not exempt)', async () => {
+    // 关键回归（Codex gate 抓到）：vetting gate 的 ownsSession 放行口是「外部 bot
+    // 跟进我们已拥有的会话」。但 /t 会把 anchor 从 chatId 改成新的 messageId——
+    // 我们在新 anchor 上不拥有任何会话。所以 gate 必须按 override 之后的 anchor 算
+    // ownsSession，否则未授权 bot 借旧 chat-scope session 的归属绕过 vetting，再被
+    // /t 翻成 thread 后在新 anchor 上 auto-create 出一个会话。
+    mockGetChatMode.mockResolvedValueOnce('group');
+    mockReadFileSync.mockReturnValue('{}');  // empty cross-ref → unknown peer
+    const event = makeBotMessageEvent({
+      senderOpenId: OTHER_BOT_OPEN_ID,
+      senderType: 'bot',
+      content: JSON.stringify({
+        zh_cn: { content: [[
+          { tag: 'at', user_id: MY_OPEN_ID },
+          { tag: 'text', text: ' /t spawn me' },
+        ]] },
+      }),
+      rootId: undefined,
+    });
+    event.message.root_id = undefined as any;
+    // bot already owns the chat-scope session at chat-001 (the OLD anchor)
+    handlers.isSessionOwner.mockImplementation((anchor: string) => anchor === 'chat-001');
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+  });
+
+  it('still drops an unknown-peer bot on the /topic alias too (alias must not bypass either)', async () => {
+    // /t 和 /topic 走同一条 parseForceTopicInvocation，别让别名成为绕过 vetting 的后门。
+    mockGetChatMode.mockResolvedValueOnce('group');
+    mockReadFileSync.mockReturnValue('{}');  // empty cross-ref → unknown peer
+    const event = makeBotMessageEvent({
+      senderOpenId: OTHER_BOT_OPEN_ID,
+      senderType: 'bot',
+      content: JSON.stringify({
+        zh_cn: { content: [[
+          { tag: 'at', user_id: MY_OPEN_ID },
+          { tag: 'text', text: ' /topic spawn me' },
+        ]] },
+      }),
+      rootId: undefined,
+    });
+    event.message.root_id = undefined as any;
+    handlers.isSessionOwner.mockReturnValue(false);
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+  });
+
+  it('lets a chat-granted bot use /t to seed a topic (override reachable past the grant exemption)', async () => {
+    // 闸门的另一条放行口：chatGrants。override 排在闸门之后，仍须能被这条放行路径到达。
+    setupBotState({ chatGrants: { 'chat-001': [OTHER_BOT_OPEN_ID] } });
+    mockGetChatMode.mockResolvedValueOnce('group');
+    mockReadFileSync.mockReturnValue('{}');  // empty cross-ref → unknown peer，唯一放行靠 grant
+    const event = makeBotMessageEvent({
+      senderOpenId: OTHER_BOT_OPEN_ID,
+      senderType: 'bot',
+      content: JSON.stringify({
+        zh_cn: { content: [[
+          { tag: 'at', user_id: MY_OPEN_ID },
+          { tag: 'text', text: ' /t spawn me' },
+        ]] },
+      }),
+      rootId: undefined,
+    });
+    event.message.root_id = undefined as any;
+    handlers.isSessionOwner.mockReturnValue(false);
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
+      scope: 'thread',
+      anchor: 'msg-001',
+      larkAppId: MY_APP_ID,
+    }));
+  });
+
+  it('lets a globally-granted bot use /t to seed a topic (override reachable past the global grant)', async () => {
+    setupBotState({ globalGrants: [OTHER_BOT_OPEN_ID] });
+    mockGetChatMode.mockResolvedValueOnce('group');
+    mockReadFileSync.mockReturnValue('{}');  // empty cross-ref → unknown peer
+    const event = makeBotMessageEvent({
+      senderOpenId: OTHER_BOT_OPEN_ID,
+      senderType: 'bot',
+      content: JSON.stringify({
+        zh_cn: { content: [[
+          { tag: 'at', user_id: MY_OPEN_ID },
+          { tag: 'text', text: ' /t spawn me' },
+        ]] },
+      }),
+      rootId: undefined,
+    });
+    event.message.root_id = undefined as any;
+    handlers.isSessionOwner.mockReturnValue(false);
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
+      scope: 'thread',
+      anchor: 'msg-001',
+      larkAppId: MY_APP_ID,
+    }));
+  });
+
+  it('lets a bot use /t to seed a topic in an oncall chat (override reachable past the oncall exemption)', async () => {
+    // oncall 短路整段 gate（!findOncallChat），override 仍须落在它后面照常翻 thread。
+    mockGetChatMode.mockResolvedValueOnce('group');
+    mockIsChatOncallBoundForAnyBot.mockReturnValue(true);
+    mockFindOncallChat.mockReturnValue({ chatId: 'chat-001', workingDir: '/repo' });
+    mockReadFileSync.mockReturnValue('{}');  // empty cross-ref → unknown peer，靠 oncall 放行
+    const event = makeBotMessageEvent({
+      senderOpenId: OTHER_BOT_OPEN_ID,
+      senderType: 'bot',
+      content: JSON.stringify({
+        zh_cn: { content: [[
+          { tag: 'at', user_id: MY_OPEN_ID },
+          { tag: 'text', text: ' /t spawn me' },
+        ]] },
+      }),
+      rootId: undefined,
+    });
+    event.message.root_id = undefined as any;
+    handlers.isSessionOwner.mockReturnValue(false);
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
+      scope: 'thread',
+      anchor: 'msg-001',
+      larkAppId: MY_APP_ID,
+    }));
+  });
+
   it('routes unknown-peer cross-bot @mention in chat-scope when the bot is chat-granted via /grant', async () => {
     // owner 用 `/grant @bot` 把外部 bot 加进本群 chatGrants：即便它不在 peer
     // cross-ref（isKnownPeerBot=false），命中 chatGrants 也应与已注册 peer 同等


### PR DESCRIPTION
## Background
In Lark group chats, `/t` / `/topic` should force routing to thread-scope and create a new topic.
This behavior already works for human senders, but bot-originated messages (foreign bot @mention path) did not apply the same override.

As a result, bot messages like `@BotB /t ...` could stay on chat-scope and fail to seed a new topic.

## What changed
- File: `src/im/lark/event-dispatcher.ts`
- In the bot-sender branch (`sender_type = app/bot`), after `decideRouting(...)`, apply:
  - `maybeApplyForceTopicOverride(ctx, message, messageId)`
- Add an info log for bot sender `/t` override hits.

## Why
This aligns bot-sender behavior with human-sender behavior for `/t` / `/topic`, ensuring explicit topic creation works consistently in normal group chats.

## Scope / Risk
- Minimal, localized change in routing for bot-originated messages only.
- No change to permission gating / mention checks / existing session ownership logic.

## Validation
- `test/event-dispatcher.test.ts` passed
- `test/bot-routing.test.ts` passed
- Total: 108/108 tests passed
