### PR TITLE
fix(card): slash 命令清单卡 note 标签改 markdown，适配飞书 schema 2.0

### DIFF
--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -456,9 +456,10 @@ export function buildSlashListCard(
       rows: shown.map((c) => ({ cmd: `\`${c.name}\``, desc: clipDesc(c.description) })),
     });
     if (discovered.length > MAX) {
+      // schema 2.0 卡片已不支持 note 标签（飞书 ErrCode 200861），改用 markdown 元素
       elements.push({
-        tag: 'note',
-        elements: [{ tag: 'lark_md', content: t('slashlist.more', { n: String(discovered.length - MAX) }, locale) }],
+        tag: 'markdown',
+        content: t('slashlist.more', { n: String(discovered.length - MAX) }, locale),
       });
     }
   }
@@ -466,9 +467,10 @@ export function buildSlashListCard(
   // MCP 提示（server 名，prompt 需运行时握手不在此列）
   if (mcpServers.length > 0) {
     elements.push({ tag: 'hr' });
+    // schema 2.0 卡片已不支持 note 标签（飞书 ErrCode 200861），改用 markdown 元素
     elements.push({
-      tag: 'note',
-      elements: [{ tag: 'lark_md', content: t('slashlist.mcp_note', { servers: mcpServers.join(', ') }, locale) }],
+      tag: 'markdown',
+      content: t('slashlist.mcp_note', { servers: mcpServers.join(', ') }, locale),
     });
   }
 


### PR DESCRIPTION
## 问题

`/list-slash-command`（`/slash`）的清单卡片使用 schema 2.0（表格组件需要），但卡片末尾的「另有 N 条未展示」与 MCP 提示两处用了 `note` 标签。飞书卡片 schema 2.0 已不再支持 `note`，整卡被 API 拒收：

```
code 230099: ErrPath: body -> elements -> [N](tag: note)
ErrMsg: cards of schema V2 no longer support this capability; unsupported tag note (ErrCode: 200861)
```

用户侧表现为发 `/slash` 后机器人无任何响应（daemon error log 里有 400）。

## 修复

两处 `note` 元素替换为 schema 2.0 支持的 `markdown` 元素，展示效果等价。其余旧版 schema 卡片中的 `note` 不受影响，未改动。

## 验证

- `pnpm build` 通过
- 本机 patch 后实测：`/slash` 卡片正常发出（364 条自定义命令分页表格 + 截断提示正常显示）