### PR TITLE
fix(lark): 长连接重连耗尽后自愈，免去长断网/睡眠后手动重启

### DIFF
--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -1502,10 +1502,40 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
     // heartbeats, etc.) and floods pm2 error.log when stderr is the only sink.
     // DEBUG=1 widens the level back to info for troubleshooting.
     loggerLevel: process.env.DEBUG ? Lark.LoggerLevel.info : Lark.LoggerLevel.warn,
+    // 主机长断网（夜间合盖睡眠、Wi-Fi 切换、VPN 重连）后，SDK 重连要先用 HTTPS 去
+    // 飞书换 ws 接入点，这步会 ENOTFOUND / 15s 超时；重连次数由服务端下发且有限，
+    // 耗尽后 SDK 置 terminalError 永久放弃，但进程仍 online、PM2 不会兜底 —— 表现为
+    // 「必须手动 botmux restart 才能恢复收消息」。下面两道防线让长连接死后自愈。
+    //
+    // ① pingTimeout：发 ping 后 30s 内无任何 inbound 帧即掐断 socket，触发 close →
+    //    SDK 自身重连。专治 TCP 半开连接（没收到 FIN/RST、close 事件不触发）的静默卡死。
+    wsConfig: { pingTimeout: 30 },
+    // 重连握手卡死（DNS/代理/NAT）兜底，避免单次握手永久 pending。
+    handshakeTimeoutMs: 15_000,
+    // 重连过程打日志，便于事后从 `pnpm daemon:logs` 复盘（warn 默认看不到这些）。
+    onReconnecting: () => logger.warn(`[ws] ${larkAppId} reconnecting…`),
+    onReconnected: () => logger.info(`[ws] ${larkAppId} reconnected`),
+    onError: (err) => logger.error(`[ws] ${larkAppId} terminal error: ${err.message}`),
   });
 
   wsClient.start({ eventDispatcher });
   logger.info('Daemon WSClient started');
+
+  // ② SDK 重连耗尽后停在 terminalError（getConnectionStatus().state === 'failed'）并
+  //    永久放弃。每分钟探测一次，发现已放弃就 start() 重新发起一轮全新握手 —— start()
+  //    会清掉 terminalError 并重新 pullConnectConfig + connect，无需手动重启 daemon。
+  //    只在 'failed' 时介入，不打断 SDK 正在进行的 'reconnecting' / 'connecting'。
+  let reviving = false;
+  const reviveTimer = setInterval(() => {
+    if (reviving) return;
+    if (wsClient.getConnectionStatus().state !== 'failed') return;
+    reviving = true;
+    logger.warn(`[ws] ${larkAppId} connection failed (reconnect exhausted), restarting WSClient`);
+    wsClient.start({ eventDispatcher })
+      .catch(err => logger.error(`[ws] ${larkAppId} WSClient restart failed: ${err?.message ?? err}`))
+      .finally(() => { reviving = false; });
+  }, 60_000);
+  reviveTimer.unref();
 
   return wsClient;
 }

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -80,7 +80,8 @@ vi.mock('@larksuiteoapi/node-sdk', () => {
     }
   }
   class MockWSClient {
-    start() {}
+    start = vi.fn(async () => {});
+    getConnectionStatus = vi.fn(() => ({ state: 'connected', reconnectAttempts: 0 }));
   }
   return {
     EventDispatcher: MockEventDispatcher,
@@ -2761,5 +2762,35 @@ describe('ensureBotOpenId — dedup', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(botState.botOpenId).toBe(MY_OPEN_ID);
     vi.unstubAllGlobals();
+  });
+});
+
+describe('startLarkEventDispatcher — 长连接死后自愈 (reconnect-exhausted recovery)', () => {
+  it('SDK 重连耗尽 (state=failed) 时，定时探测并重新 start() 重建长连接', async () => {
+    vi.useFakeTimers();
+    const ws = startLarkEventDispatcher(MY_APP_ID, 'secret', makeHandlers()) as any;
+    // 启动时的首次握手
+    expect(ws.start).toHaveBeenCalledTimes(1);
+
+    // 模拟主机长断网：SDK 重连预算耗尽、永久放弃，但进程仍 online（PM2 不会兜底）
+    ws.getConnectionStatus.mockReturnValue({ state: 'failed', reconnectAttempts: 9 });
+
+    // 健康检查每 60s 一次：发现 failed → 重新 start() 重建
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(ws.start).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  it('连接健康 (state=connected) 时不重建，不打断 SDK 自身的重连', async () => {
+    vi.useFakeTimers();
+    const ws = startLarkEventDispatcher(MY_APP_ID, 'secret', makeHandlers()) as any;
+    expect(ws.start).toHaveBeenCalledTimes(1);
+
+    // getConnectionStatus 默认返回 connected；推进多个周期都不应触发重建
+    await vi.advanceTimersByTimeAsync(180_000);
+    expect(ws.start).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## 问题

主机长断网后，botmux 偶尔需要手动 `botmux restart` 才能恢复接收飞书消息。

规律（与线上日志吻合）：
- **短抖动能自愈**：网络短暂中断（如十几分钟）后，之后收发恢复正常，无需重启。
- **长断网 / 笔记本睡一夜则不能**：长时间 `ENOTFOUND open.feishu.cn`（数小时）后，必须手动 restart。

## 根因

每个 bot 的 daemon 维持一条到飞书的 WebSocket 长连接（`@larksuiteoapi/node-sdk` 的 `WSClient`，由 `startLarkEventDispatcher` 里的 `wsClient.start()` 起）。SDK 自带有限次自动重连，但重连**不是「连上 socket 就行」**——它要先用 HTTPS 调 `pullConnectConfig` 去飞书换 ws 接入点，这步依赖 DNS + 网络：

1. **短断网**：网络在重连预算耗尽前恢复 → 某次重连成功 → 自愈 ✅
2. **长断网**：每次重连的 `pullConnectConfig` 都 `ENOTFOUND` / 15s 超时（日志里的 `[ws] timeout of 15000ms exceeded` 正是这步 HTTPS 请求的超时）→ 重试预算耗尽后 SDK 置 `terminalError` 永久放弃（`getConnectionStatus().state === 'failed'`）→ 进程仍 `online`、长连接已死 ❌

**笔记本睡眠会放大**：睡眠时 Node 进程被冻结、重连定时器不跑，醒来瞬间 Wi-Fi/VPN 还没就绪，补跑的几次重连全打空 → 直接判死。

**PM2 / autostart 不兜底**：PM2 只在进程退出/崩溃时拉起。这里进程一直 `online`、只是长连接 `terminalError`，PM2 看它活着不会重启；而 `startLarkEventDispatcher` 创建的 `wsClient` 返回值此前也未被任何代码持有 / 监控。

## 修复

全部收在 `startLarkEventDispatcher` 内部，daemon 侧零改动：

| 失败模式 | 现象 | 修复 |
|---|---|---|
| 长断网重连耗尽（主因） | `state==='failed'`、进程 online 却收不到消息 | **① 健康检查**：每 60s 探测 `getConnectionStatus()`，发现 `'failed'` 就 `start()` 重建一轮全新握手（`start()` 会清掉 `terminalError` 并重新 `pullConnectConfig + connect`） |
| TCP 半开连接（休眠 / NAT，`close` 不触发） | 假 `connected`、收不到消息 | **② `wsConfig.pingTimeout: 30`**：发 ping 后 30s 内无任何 inbound 帧即掐断 socket，触发 `close` → SDK 自身重连 |
| 重连握手卡死（DNS / 代理 / NAT） | 单次握手永久 pending | **`handshakeTimeoutMs: 15000`** 兜底 |

另挂 `onReconnecting / onReconnected / onError` 打日志，便于事后从 `pnpm daemon:logs` 复盘（`warn` 级别下原本看不到重连过程）。

关键设计：**不依赖服务端下发的 `reconnectCount` 具体值**——耗尽放弃由 ① 救、半开连接由 ② 救、睡眠判死由 ① 救，三种失败模式各有兜底。

## 验证

- `pnpm build`（含 `tsc`）通过：SDK 1.64.0 的 `wsConfig.pingTimeout`、`handshakeTimeoutMs`、`getConnectionStatus`、`onReconnecting/onReconnected/onError` 均为 public 且类型匹配。
- `test/event-dispatcher.test.ts`：110 passed，新增 2 例覆盖 `failed → 重建` / `connected → 不重建`（`MockWSClient` 增量加 `getConnectionStatus`，现有用例零破坏）。
- 说明：真实「长断网数小时后自愈」无法在本地端到端复现，本 PR 依据为 SDK 源码行为分析 + 单测 + 类型核对；建议合入后观察一次夜间睡眠场景的日志（`[ws] ... reconnecting…` / `connection failed ... restarting WSClient`）确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
