### PR TITLE
feat: Web 终端 Cookie 鉴权 + 手机端体验优化 + 空闲休眠 + 卡片导出

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,10 @@ pnpm daemon:logs          # 查看日志
 ```
 
 - 每次修改后需要 `pnpm build` 然后 `pnpm daemon:restart`
+- 本项目通过 npm link 将全局 `botmux` 指向本地 dist/，build 后直接生效
+- **每次改动后必须在线上验证功能正常**，验证通过后再清理测试残留（测试话题、测试消息等）
+- 验证方式：查看 daemon 日志 `pnpm daemon:logs` | 在飞书测试群里发送消息触发功能 | 检查 pm2 进程状态
+- daemon 日志位于 `~/.botmux/logs/daemon-0-out.log`，也可通过 `./node_modules/.bin/pm2 logs botmux-0 --nostream --lines 50` 查看
 
 ## 模块结构
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -260,6 +260,7 @@ function ecosystemConfig(): string {
       // ad-hoc (e.g. `BOTMUX_MEMORY_DIAG_INTERVAL_MS=5000`) when chasing an
       // RSS regression — turned off in master so logs stay quiet.
       BOTMUX_MEMORY_DIAG_INTERVAL_MS: process.env.BOTMUX_MEMORY_DIAG_INTERVAL_MS ?? '0',
+      ...(process.env.WEB_TERMINAL_PASSWORD ? { WEB_TERMINAL_PASSWORD: process.env.WEB_TERMINAL_PASSWORD } : {}),
     },
   }));
 
@@ -2811,6 +2812,7 @@ function argValues(args: string[], ...flags: string[]): string[] {
 // keeps using `buildCardBodyElements` from there.
 import { buildMentionedPendingResponseCard } from './im/lark/card-builder.js';
 import { buildCardBodyElements, brandFooterSegment } from './im/lark/md-card.js';
+import { storeReplyContent } from './im/lark/reply-content-cache.js';
 import { COMPLETED_REACTION_EMOJI_TYPE, claimPendingResponseCard, isPendingResponseCardOpen, markPendingResponseCardPatchedIfCurrent, mergePendingResponseState, shouldMarkPendingAsMentionedSend, shouldPatchPendingOnExplicitSend } from './core/pending-response.js';
 import { resolveBrandLabel } from './bot-registry.js';
 import { config } from './config.js';
@@ -3397,6 +3399,30 @@ async function cmdSend(rest: string[]): Promise<void> {
           });
         }
       }
+
+      // Reply action buttons: export to Feishu doc + send raw markdown
+      const contentKey = storeReplyContent(text);
+      const actionRootId = (isChatScope ? s.chatId : s.rootMessageId) ?? s.chatId;
+      elements.push({ tag: 'hr' });
+      const rpcButton = (label: string, action: string) => ({
+        tag: 'button',
+        text: { tag: 'plain_text', content: label },
+        type: 'default',
+        width: 'fill',
+        behaviors: [{
+          type: 'callback',
+          value: { action, content_key: contentKey, root_id: actionRootId, session_id: sid },
+        }],
+      });
+      elements.push({
+        tag: 'column_set',
+        flex_mode: 'none',
+        horizontal_spacing: 'default',
+        columns: [
+          { tag: 'column', width: 'weighted', weight: 1, vertical_align: 'center', elements: [rpcButton('📄 导出飞书文档', 'export_to_doc')] },
+          { tag: 'column', width: 'weighted', weight: 1, vertical_align: 'center', elements: [rpcButton('📝 原始 Markdown', 'send_raw_md')] },
+        ],
+      });
 
       const cardJson = JSON.stringify({
         schema: '2.0',

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,7 @@ const configuredDashboardExternalHost =
   process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST ?? process.env.WEB_EXTERNAL_HOST;
 
 export function getWebExternalHost(): string {
-  return configuredWebExternalHost ?? getLocalIp();
+  return configuredWebExternalHost || getLocalIp();
 }
 
 export function getDashboardExternalHost(): string {

--- a/src/config.ts
+++ b/src/config.ts
@@ -97,6 +97,11 @@ export const config = {
     // shares this env and differs only by BOTMUX_BOT_INDEX. 0 = unset → links use
     // the local proxy port (relay must forward the same port number).
     externalPort: Number(process.env.WEB_EXTERNAL_PORT) || 0,
+    /** If set, all web terminal access requires this password. A browser
+     *  cookie (`bmx_auth`) is set on first successful login so the user
+     *  only enters it once per browser. Unset (default) = no auth — the
+     *  terminal URL alone grants access (legacy behaviour). */
+    terminalPassword: process.env.WEB_TERMINAL_PASSWORD,
   },
   dashboard: {
     host: process.env.BOTMUX_DASHBOARD_HOST ?? '0.0.0.0',

--- a/src/core/idle-suspender.ts
+++ b/src/core/idle-suspender.ts
@@ -36,8 +36,18 @@ export function startIdleSuspender(
   activeSessions: Map<string, DaemonSession>,
   sendNotification: (ds: DaemonSession, tier: 'light' | 'deep') => void,
 ): ReturnType<typeof setInterval> {
+  logger.info(
+    `[idle-suspender] started (light=${LIGHT_SLEEP_MS / 60000}m, ` +
+    `deep=${DEEP_SLEEP_MS / 3600000}h, scan=${SCAN_INTERVAL_MS / 1000}s)`,
+  );
+
+  let scanCount = 0;
   const timer = setInterval(() => {
     const now = Date.now();
+    scanCount++;
+
+    let totalWithWorker = 0;
+    let idleCandidates = 0;
 
     for (const ds of activeSessions.values()) {
       const sid = ds.session.sessionId;
@@ -60,6 +70,9 @@ export function startIdleSuspender(
       let targetTier: 'none' | 'light' | 'deep' = 'none';
       if (idleMs > DEEP_SLEEP_MS) targetTier = 'deep';
       else if (idleMs > LIGHT_SLEEP_MS) targetTier = 'light';
+
+      if (targetTier !== 'none') idleCandidates++;
+      if (ds.worker && !ds.worker.killed) totalWithWorker++;
 
       // Transition back to active — user came back
       if (targetTier === 'none') {
@@ -96,6 +109,15 @@ export function startIdleSuspender(
         // still mark tier so we notify if needed
         st.tier = targetTier;
       }
+    }
+    // Heartbeat every 10 scans (~10 min) so we can verify the loop is alive
+    // without spamming the log every minute.
+    if (scanCount % 10 === 0) {
+      logger.info(
+        `[idle-suspender] heartbeat #${scanCount}: ` +
+        `${activeSessions.size} total, ${totalWithWorker} with worker, ` +
+        `${idleCandidates} idle, ${stateMap.size} tracked`,
+      );
     }
   }, SCAN_INTERVAL_MS);
 

--- a/src/core/idle-suspender.ts
+++ b/src/core/idle-suspender.ts
@@ -1,0 +1,118 @@
+/**
+ * Idle session auto-suspender — scans active sessions and kills workers
+ * (and their tmux sessions) when the user hasn't sent a message for too long.
+ *
+ * Two tiers:
+ *   1. Light sleep (30 min) — kill worker + tmux, session can resume on next msg
+ *   2. Deep sleep (4 h)   — same action, different notification
+ *
+ * Both tiers use killWorker() which sends {type:'close'} to the worker;
+ * the worker's close handler destroys the tmux session before exiting.
+ * On the next user message, handleThreadReply sees ds.worker === null and
+ * re-forks with resume=true → new tmux + claude --resume from JSONL.
+ */
+
+import type { DaemonSession } from './types.js';
+import { killWorker } from './worker-pool.js';
+import { logger } from '../utils/logger.js';
+
+const LIGHT_SLEEP_MS = 30 * 60 * 1000;   // 30 minutes
+const DEEP_SLEEP_MS = 4 * 60 * 60 * 1000; // 4 hours
+const SCAN_INTERVAL_MS = 60 * 1000;        // scan every minute
+
+interface SuspendState {
+  tier: 'none' | 'light' | 'deep';
+  /** Avoid re-sending notifications every scan cycle. */
+  notified: boolean;
+}
+
+const stateMap = new Map<string, SuspendState>();
+
+function stateKey(sessionId: string): string {
+  return sessionId;
+}
+
+export function startIdleSuspender(
+  activeSessions: Map<string, DaemonSession>,
+  sendNotification: (ds: DaemonSession, tier: 'light' | 'deep') => void,
+): ReturnType<typeof setInterval> {
+  const timer = setInterval(() => {
+    const now = Date.now();
+
+    for (const ds of activeSessions.values()) {
+      const sid = ds.session.sessionId;
+      const lastMsg = ds.lastMessageAt;
+
+      // Skip sessions that can't be evaluated
+      if (!lastMsg) continue;
+      if (ds.pendingRepo) continue;
+
+      const idleMs = now - lastMsg;
+      const key = stateKey(sid);
+      let st = stateMap.get(key);
+
+      if (!st) {
+        st = { tier: 'none', notified: false };
+        stateMap.set(key, st);
+      }
+
+      // Determine target tier
+      let targetTier: 'none' | 'light' | 'deep' = 'none';
+      if (idleMs > DEEP_SLEEP_MS) targetTier = 'deep';
+      else if (idleMs > LIGHT_SLEEP_MS) targetTier = 'light';
+
+      // Transition back to active — user came back
+      if (targetTier === 'none') {
+        if (st.tier !== 'none') {
+          logger.info(`[idle-suspender] ${sid.substring(0, 8)} woke up (was ${st.tier})`);
+        }
+        st.tier = 'none';
+        st.notified = false;
+        continue;
+      }
+
+      // Already at or above this tier — skip
+      if (st.tier !== 'none' && st.tier !== targetTier) {
+        // Upgrading from light → deep, update state but don't re-kill
+        st.tier = targetTier;
+        st.notified = false; // allow deep notification
+      }
+      if (st.tier === targetTier && (st.notified || ds.worker === null || ds.worker?.killed)) {
+        continue;
+      }
+
+      // Execute suspend
+      if (ds.worker && !ds.worker.killed) {
+        killWorker(ds);
+        st.tier = targetTier;
+        st.notified = true;
+        logger.info(
+          `[idle-suspender] ${targetTier} sleep: ${sid.substring(0, 8)} ` +
+          `(idle ${Math.round(idleMs / 60000)}m, larkAppId=${ds.larkAppId})`,
+        );
+        sendNotification(ds, targetTier);
+      } else {
+        // Worker already dead (e.g. after daemon restart with quiet mode),
+        // still mark tier so we notify if needed
+        st.tier = targetTier;
+      }
+    }
+  }, SCAN_INTERVAL_MS);
+
+  timer.unref?.();
+  return timer;
+}
+
+/** Forget suspend state for a session (call when session is closed/removed). */
+export function forgetSuspendState(sessionId: string): void {
+  stateMap.delete(stateKey(sessionId));
+}
+
+/** Reset suspend state when user sends a new message (session is active again). */
+export function markSessionActive(sessionId: string): void {
+  const st = stateMap.get(stateKey(sessionId));
+  if (st) {
+    st.tier = 'none';
+    st.notified = false;
+  }
+}

--- a/src/core/session-activity.ts
+++ b/src/core/session-activity.ts
@@ -7,6 +7,7 @@ import * as sessionStore from '../services/session-store.js';
 import { dashboardEventBus } from './dashboard-events.js';
 import { composeRowFromActive } from './dashboard-rows.js';
 import type { DaemonSession } from './types.js';
+import { markSessionActive } from './idle-suspender.js';
 
 export function markSessionActivity(ds: DaemonSession, at: number = Date.now()): void {
   ds.lastMessageAt = at;
@@ -15,6 +16,8 @@ export function markSessionActivity(ds: DaemonSession, at: number = Date.now()):
     ds.session.lastMessageAt = iso;
     sessionStore.updateSession(ds.session);
   }
+  // Reset idle-suspender state — session just received a message
+  markSessionActive(ds.session.sessionId);
   dashboardEventBus.publish({
     type: 'session.update',
     body: { sessionId: ds.session.sessionId, patch: { lastMessageAt: at } },

--- a/src/core/terminal-url.ts
+++ b/src/core/terminal-url.ts
@@ -62,10 +62,29 @@ export function resetTerminalProxy(): void {
   externalPort = 0;
 }
 
+/**
+ * Returns true when the externalHost looks like an IP address (IPv4 or IPv6)
+ * that needs a port appended. Domain names behind reverse-proxies or tunnels
+ * (e.g. cpolar, nginx) serve on standard ports (80/443) so the port is omitted.
+ */
+function hostLooksLikeIp(host: string): boolean {
+  // IPv4: 1.2.3.4
+  if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)) return true;
+  // IPv6: [::1], [fe80::1], etc.
+  if (host.startsWith('[') && host.endsWith(']')) return true;
+  // Bare IPv6 (uncommon but valid in some contexts)
+  if (/^[0-9a-fA-F:]+$/.test(host) && host.includes(':')) return true;
+  return false;
+}
+
 export function buildTerminalUrl(ds: TerminalUrlSession, opts: { write?: boolean } = {}): string {
+  const host = config.web.externalHost;
+  const hostAndPort = hostLooksLikeIp(host)
+    ? `${host}:${getTerminalAdvertisedPort()}`
+    : host;
   const base = proxyReady
-    ? `http://${config.web.externalHost}:${getTerminalAdvertisedPort()}/s/${ds.session.sessionId}`
-    : `http://${config.web.externalHost}:${ds.workerPort ?? ds.session.webPort}`;
+    ? `http://${hostAndPort}/s/${ds.session.sessionId}`
+    : `http://${host}:${ds.workerPort ?? ds.session.webPort}`;
   if (opts.write && ds.workerToken) return `${base}?token=${ds.workerToken}`;
   return base;
 }

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -14,6 +14,7 @@ import { randomBytes } from 'node:crypto';
 import { config } from '../config.js';
 import * as sessionStore from '../services/session-store.js';
 import { persistStreamCardState } from './session-manager.js';
+import { forgetSuspendState } from './idle-suspender.js';
 import { updateMessage, deleteMessage, sendEphemeralCard, sendUserMessage, addReaction, MessageWithdrawnError } from '../im/lark/client.js';
 import { buildStreamingCard, buildPrivateSnapshotCard, buildSessionCard, buildTuiPromptCard, buildTuiPromptResolvedCard, buildRelayedFrozenCard, getCliDisplayName } from '../im/lark/card-builder.js';
 import { loadFrozenCards, saveFrozenCards } from '../services/frozen-card-store.js';
@@ -936,6 +937,7 @@ export async function closeSession(
   let killedLive = false;
   if (ds) {
     killWorker(ds);
+    forgetSuspendState(sessionId);
     activeSessionsRegistry?.delete(sessionKey(sessionAnchorId(ds), ds.larkAppId));
     killedLive = true;
     if (!ds.exitEventEmitted) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -105,6 +105,7 @@ import { learnFromMentions, resolveSender, flushIdentityCacheSync } from './im/l
 import { normalizeBrand } from './im/lark/lark-hosts.js';
 import { renderBufferedSenderBlock } from './core/session-manager.js';
 import { markSessionActivity, announcePendingRepoSession } from './core/session-activity.js';
+import { startIdleSuspender, forgetSuspendState } from './core/idle-suspender.js';
 import { WorkflowEventWatcher, handleWorkflowFanoutEvent } from './workflows/fanout.js';
 import type { WorkflowRuntimeContext, WorkerSpawnFn } from './workflows/runtime.js';
 import { runLoop } from './workflows/loop.js';
@@ -3352,6 +3353,17 @@ export async function startDaemon(botIndex?: number): Promise<void> {
       });
     }, 5_000).unref?.();
   }
+
+  // Start idle session auto-suspender — after 30 min of inactivity, kill the
+  // worker (which also destroys the tmux session via the close handler).
+  // After 4 h, the session is already in deep sleep — nothing extra to kill.
+  // Both tiers resume transparently on the next user message via
+  // handleThreadReply's ds.worker===null → forkWorker(resume:true) path.
+  const idleSuspender = startIdleSuspender(activeSessions, (ds, tier) => {
+    const anchor = ds.session.rootMessageId ?? ds.chatId;
+    const label = tier === 'deep' ? '深睡眠（超过 4 小时未活动）' : '休眠（超过 30 分钟未活动）';
+    sessionReply(anchor, `💤 会话已进入${label}。回复任意消息即可恢复对话。`, 'text', ds.larkAppId).catch(() => {});
+  });
 
   // Graceful shutdown. Sends SIGTERM (or `{type:'close'}` IPC via killWorker)
   // to every worker, then waits up to SHUTDOWN_GRACE_MS for them to exit

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -386,6 +386,10 @@ async function sessionReply(anchor: string, content: string, msgType: string = '
   // prefix fallback covers the close-button race: card-handler deletes ds
   // from activeSessions BEFORE sending the close-confirmation reply, so by
   // the time we run, ds is gone — but the anchor (chatId, oc_xxx) is enough
+  // Reset idle timer on every bot message so the suspend clock starts
+  // from the LAST bot output, not from the user's original message.
+  if (ds) ds.lastMessageAt = Date.now();
+
   // to know we should sendMessage, not reply_in_thread to a non-message-id.
   if (ds?.scope === 'chat' || anchor.startsWith('oc_')) {
     const chatId = ds?.chatId ?? anchor;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -489,6 +489,7 @@ export const messages: Record<string, string> = {
   'card.action.takeover_retired': '⚠️ The old "Take Over" button is retired. In bridge mode, botmux bridges the original CLI so replies still come back to Lark — no takeover needed. Full takeover (`/adopt --takeover`) is on the roadmap.',
   'card.action.terminal_not_ready': '⚠️ Terminal is not ready yet, please try again shortly.',
   'card.action.no_output': '(no output yet)',
+  'card.action.content_expired': 'Content expired, unable to retrieve original text.',
   'card.action.tui_select_title': 'Select options',
   'card.action.tui_custom_input': 'Custom input',
   'card.action.tui_done': 'Done',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -492,6 +492,7 @@ export const messages: Record<string, string> = {
   'card.action.takeover_retired': '⚠️ 旧版"接管"按钮已停用。bridge 模式下原 CLI 由 botmux 桥接，无需接管即可在飞书中收到回答。如需 /resume 完整接管能力，请等待 /adopt --takeover 命令上线。',
   'card.action.terminal_not_ready': '⚠️ 终端尚未就绪，请稍后再试。',
   'card.action.no_output': '(当前无输出内容)',
+  'card.action.content_expired': '内容已过期，无法获取原文。',
   'card.action.tui_select_title': 'Select options',
   'card.action.tui_custom_input': 'Custom input',
   'card.action.tui_done': 'Done',

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -572,7 +572,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     return { toast: { type: 'success', content: t('card.relay.toast_success', undefined, loc) } };
   }
 
-  const isSensitive = value?.action && ['restart', 'close', 'resume', 'skip_repo', 'retry_last_task', 'get_write_link', 'toggle_stream', 'toggle_display', 'export_text', 'term_action', 'refresh_screenshot', 'takeover', 'disconnect', 'tui_keys', 'tui_text_input', 'wf_approve', 'wf_reject', 'wf_cancel'].includes(value.action);
+  const isSensitive = value?.action && ['restart', 'close', 'resume', 'skip_repo', 'retry_last_task', 'get_write_link', 'toggle_stream', 'toggle_display', 'export_text', 'term_action', 'refresh_screenshot', 'takeover', 'disconnect', 'tui_keys', 'tui_text_input', 'wf_approve', 'wf_reject', 'wf_cancel', 'export_to_doc', 'send_raw_md'].includes(value.action);
   if (isSensitive) {
     const rootId = value?.root_id;
     // activeSessions is keyed by sessionKey(anchor, larkAppId) — `${anchor}::${larkAppId}`
@@ -1151,6 +1151,51 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       const body = content.trim() ? truncateContent(content, locDs) : t('card.action.no_output', undefined, locDs);
       await sessionReply(sessionAnchorId(ds), body);
       logger.info(`[${tag(ds)}] Exported terminal text (${body.length} chars)`);
+      return;
+    }
+
+    // Export AI reply as a Feishu Docx document. Runs async in background so
+    // the Feishu callback doesn't time out (lark-cli takes ~3-6s).
+    if (actionType === 'export_to_doc' && value?.content_key) {
+      const locDs = localeForBot(ds?.larkAppId ?? larkAppId);
+      const appId = larkAppId;
+      if (!appId) {
+        return { toast: { type: 'error', content: '无法确定 Lark 应用' } };
+      }
+      const { getReplyContent, deriveTitleFromMarkdown } = await import('../../im/lark/reply-content-cache.js');
+      const md = getReplyContent(value.content_key);
+      if (!md) {
+        return { toast: { type: 'error', content: t('card.action.content_expired', undefined, locDs) } };
+      }
+      const title = deriveTitleFromMarkdown(md);
+      // Fire-and-forget: return toast immediately so Feishu doesn't time out,
+      // then do the import asynchronously in the background.
+      const replyRootId = rootId;
+      Promise.resolve().then(async () => {
+        const { importMarkdownAsDoc } = await import('../../services/doc-import.js');
+        const result = await importMarkdownAsDoc(appId, md, title);
+        if (result.ok && result.docUrl) {
+          await sessionReply(replyRootId, `📄 已导出飞书文档：[${result.docTitle ?? title}](${result.docUrl})`);
+        } else {
+          await sessionReply(replyRootId, `❌ 导出失败：${result.error ?? '未知错误'}`);
+        }
+        logger.info(`[${tag(ds ?? { session: { sessionId: value.session_id } } as any)}] export_to_doc: ${result.ok ? 'ok' : 'failed'} (${md.length} chars)`);
+      }).catch((err: any) => {
+        logger.error(`[export_to_doc] background import failed: ${err?.message ?? err}`);
+      });
+      return { toast: { type: 'info', content: '正在导出飞书文档…' } };
+    }
+
+    // Send the raw markdown content as a plain text reply.
+    if (actionType === 'send_raw_md' && value?.content_key) {
+      const locDs = localeForBot(ds?.larkAppId ?? larkAppId);
+      const { getReplyContent } = await import('../../im/lark/reply-content-cache.js');
+      const md = getReplyContent(value.content_key);
+      if (!md) {
+        return { toast: { type: 'error', content: t('card.action.content_expired', undefined, locDs) } };
+      }
+      await sessionReply(rootId, md);
+      logger.info(`[${tag(ds ?? { session: { sessionId: value.session_id } } as any)}] send_raw_md: ${md.length} chars`);
       return;
     }
 

--- a/src/im/lark/reply-content-cache.ts
+++ b/src/im/lark/reply-content-cache.ts
@@ -1,0 +1,85 @@
+/**
+ * File-based cache for AI reply content, keyed by a short unique string.
+ * Card action buttons carry this key instead of the full content (which
+ * can be 10k+ chars and would exceed Feishu's value size limit).
+ *
+ * Uses the filesystem instead of an in-memory Map because `botmux send`
+ * runs as a short-lived CLI process while the card callback is handled by
+ * the long-lived daemon — they are different processes with separate
+ * memory spaces.
+ *
+ * TTL + max-count bounded so a leak doesn't grow unbounded across a
+ * long-running daemon.
+ */
+
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const TTL_MS = 60 * 60 * 1000; // 1 hour
+const MAX_FILES = 2000;
+
+// Use os.tmpdir() so botmux send (short-lived CLI) and the daemon
+// (long-lived pm2 process) share the same cache — an in-memory Map
+// would be per-process and invisible to the other side.
+function cacheDir(): string {
+  const dir = join(tmpdir(), 'botmux-reply-cache');
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/** Store reply content and return a lookup key for card buttons. */
+export function storeReplyContent(content: string): string {
+  const dir = cacheDir();
+
+  // Lazy eviction: if over max, delete expired files
+  let files: string[] = [];
+  try { files = readdirSync(dir); } catch { /* ignore */ }
+  if (files.length >= MAX_FILES) {
+    const now = Date.now();
+    for (const f of files) {
+      if (f === '.' || f === '..') continue;
+      try {
+        const st = statSync(join(dir, f));
+        if (now - st.mtimeMs > TTL_MS) unlinkSync(join(dir, f));
+      } catch { /* ignore */ }
+    }
+  }
+
+  const key = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  writeFileSync(join(dir, `${key}.txt`), content, 'utf-8');
+  return key;
+}
+
+/** Retrieve cached reply content. Returns undefined if expired or missing. */
+export function getReplyContent(key: string): string | undefined {
+  // Basic sanitisation: disallow path traversal
+  if (key.includes('/') || key.includes('\\') || key.includes('..')) return undefined;
+  const filePath = join(cacheDir(), `${key}.txt`);
+  try {
+    const st = statSync(filePath);
+    if (Date.now() - st.mtimeMs > TTL_MS) {
+      try { unlinkSync(filePath); } catch { /* ignore */ }
+      return undefined;
+    }
+    return readFileSync(filePath, 'utf-8');
+  } catch {
+    return undefined;
+  }
+}
+
+/** Derive a human-readable doc title from markdown: first non-empty,
+ *  non-code-fence line, truncated to 50 chars. */
+export function deriveTitleFromMarkdown(md: string): string {
+  const lines = md.split('\n');
+  let inFence = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (/^```/.test(trimmed)) { inFence = !inFence; continue; }
+    if (inFence) continue;
+    // Skip headings markers, blockquotes, list markers for the title
+    const cleaned = trimmed.replace(/^[#>*-]+ /, '').trim();
+    if (cleaned) return cleaned.length > 50 ? cleaned.slice(0, 47) + '...' : cleaned;
+  }
+  return 'AI 回复';
+}

--- a/src/services/doc-import.ts
+++ b/src/services/doc-import.ts
@@ -1,0 +1,86 @@
+/**
+ * Import a markdown string as a Feishu Docx document via lark-cli.
+ *
+ * Uses `lark-cli drive +import` which handles the multipart upload +
+ * import task + polling in a single CLI invocation. Much simpler than
+ * the SDK/curl approach.
+ */
+
+import { writeFileSync, unlinkSync, existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { exec } from 'node:child_process';
+import { logger } from '../utils/logger.js';
+import { config } from '../config.js';
+
+const MAX_FILE_BYTES = 20 * 1024 * 1024; // 20 MB limit for .md import
+
+interface ImportResult {
+  ok: boolean;
+  docUrl?: string;
+  docTitle?: string;
+  error?: string;
+}
+
+/** Run lark-cli asynchronously so the event loop stays unblocked. */
+function execLarkCli(cmd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    exec(cmd, { maxBuffer: 10 * 1024 * 1024, timeout: 120_000 }, (err, stdout, stderr) => {
+      if (err) {
+        reject(new Error(stderr?.trim() || err.message));
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
+}
+
+/**
+ * Import markdown content as a Feishu Docx document.
+ * Returns the document URL on success.
+ */
+export async function importMarkdownAsDoc(
+  _larkAppId: string,
+  markdown: string,
+  title: string,
+): Promise<ImportResult> {
+  const buf = Buffer.from(markdown, 'utf-8');
+  if (buf.length > MAX_FILE_BYTES) {
+    return { ok: false, error: '内容超过 20 MB，无法导入为飞书文档' };
+  }
+
+  const tmpName = `botmux-import-${randomBytes(6).toString('hex')}.md`;
+  const tmpPath = join(config.session.dataDir, 'tmp', tmpName);
+  const tmpDir = join(config.session.dataDir, 'tmp');
+  if (!existsSync(tmpDir)) mkdirSync(tmpDir, { recursive: true });
+
+  try {
+    writeFileSync(tmpPath, markdown, 'utf-8');
+
+    const result = await execLarkCli(
+      `cd '${tmpDir}' && lark-cli drive +import --file './${tmpName}' --type docx --name '${title.replace(/'/g, "'\\''")}' --json`,
+    );
+
+    const json: any = JSON.parse(result.trim());
+    if (!json?.ok) {
+      const msg = json?.error?.message ?? 'unknown error';
+      logger.error(`[doc-import] lark-cli import failed: ${msg}`);
+      return { ok: false, error: msg };
+    }
+
+    const docUrl: string | undefined = json?.data?.url;
+    const docTitle: string | undefined = json?.data?.job_error_msg === 'success' ? title : undefined;
+    if (!docUrl) {
+      logger.error(`[doc-import] lark-cli import returned no url: ${JSON.stringify(json?.data)}`);
+      return { ok: false, error: '导入成功但未返回文档链接' };
+    }
+
+    logger.info(`[doc-import] Imported markdown → ${docUrl} (title: ${docTitle ?? title})`);
+    return { ok: true, docUrl, docTitle: docTitle ?? title };
+  } catch (err: any) {
+    logger.error(`[doc-import] Import failed: ${err?.message ?? err}`);
+    return { ok: false, error: err?.message ?? '导入失败' };
+  } finally {
+    try { unlinkSync(tmpPath); } catch { /* ignore */ }
+  }
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3808,14 +3808,14 @@ body{display:flex;flex-direction:column}
    and momentum here (not just on body), and reserve gestures for pinch-zoom so
    single-finger drag is driven manually by the touch handler below. */
 #terminal .xterm-viewport{overscroll-behavior:none;-webkit-overflow-scrolling:auto;touch-action:pinch-zoom}
-/* On touch, glyph cells are selectable text — a finger-drag over text starts
-   native text selection (and the long-press callout) instead of scrolling,
-   which is why blank areas scroll fine but text areas stall/won't move.
-   Kill selection + callout on the rendered content so every drag is a clean
-   scroll.  Gated to .touch so desktop keeps mouse text-selection for copy. */
-body.touch #terminal .xterm-screen,
-body.touch #terminal .xterm-screen *{
-  -webkit-user-select:none;user-select:none;-webkit-touch-callout:none;touch-action:pinch-zoom}
+	/* On touch: kill text-selection (browser drag-to-select fights xterm.js
+	   scroll) so single-finger drag stays a clean scroll. Long-press callout
+	   is left at browser default — users can long-press for the native Copy /
+	   Select All menu. Pinch-zoom via browser (touch-action + preventDefault
+	   patch). */
+	body.touch #terminal .xterm-screen,
+	body.touch #terminal .xterm-screen *{
+	  -webkit-user-select:none;user-select:none;touch-action:pinch-zoom}
 #status{position:fixed;top:8px;right:12px;z-index:10;font:12px monospace;
   color:#565f89;background:#1a1b26cc;padding:2px 8px;border-radius:4px}
 #status.ok{color:#9ece6a}
@@ -3839,6 +3839,7 @@ body.touch #terminal .xterm-screen *{
   <button data-k="left">\u2190</button>
   <button data-k="right">\u2192</button>
   <button data-k="enter">\u21B5</button>
+	  <button data-k="copy" style="background:#33467c">\uD83D\uDCCB</button>
 </div>
 <div id="status" class="err">connecting...</div>
 <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5/lib/xterm.min.js"></script>
@@ -3849,7 +3850,12 @@ body.touch #terminal .xterm-screen *{
 <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-canvas@0/lib/addon-canvas.min.js"></script>
 <script>
 var isTouch='ontouchstart'in window||navigator.maxTouchPoints>0;
-if(isTouch){document.getElementById('vp').content='width=1100,viewport-fit=cover';document.body.classList.add('touch');}
+if(isTouch){var scrW=Math.max(screen.width||375,screen.height||667);var vpW=scrW<500?800:scrW<900?1000:1100;document.getElementById('vp').content='width='+vpW+',minimum-scale=0.3,maximum-scale=5,viewport-fit=cover';document.body.classList.add('touch');}
+// Allow browser native pinch-zoom. xterm.js calls preventDefault() on ALL touch
+// events (including multi-touch) for its own JS scroll handling, but this also
+// cancels the browser's pinch-zoom gesture. Skip preventDefault when >=2 fingers
+// are down so the browser can handle pinch-zoom natively.
+if(isTouch){(function(){var _pd=Event.prototype.preventDefault;Event.prototype.preventDefault=function(){if(this.type&&/^touch/.test(this.type)&&this.touches&&this.touches.length>=2)return;_pd.call(this)}})();}
 var hasToken=${hasWrite};
 if(!hasToken){var _rb=document.getElementById('readonly-banner');_rb.classList.add('show');_rb.addEventListener('click',function(){_rb.classList.remove('show')});}
 
@@ -3858,7 +3864,7 @@ var term=new Terminal({
     selectionBackground:'#33467c',black:'#15161e',red:'#f7768e',
     green:'#9ece6a',yellow:'#e0af68',blue:'#7aa2f7',magenta:'#bb9af7',
     cyan:'#7dcfff',white:'#a9b1d6'},
-  fontSize:14,fontFamily:"'JetBrains Mono','Fira Code',monospace",
+  fontSize:isTouch?15:14,fontFamily:"'JetBrains Mono','Fira Code',monospace",
   cursorBlink:!isTouch,scrollback:50000,allowProposedApi:true
 });
 var fit=new FitAddon.FitAddon();
@@ -4003,13 +4009,48 @@ if(isTouch&&hasToken){
     window.visualViewport.addEventListener('resize',posToolbar);
     window.visualViewport.addEventListener('scroll',posToolbar);
   }
+  // Copy button: copy visible terminal text to clipboard (self-contained,
+  // placed before OSC 52 helpers so cannot reference _doCopy / _showCopied).
+  var _copyBtn=document.querySelector('[data-k=copy]');
+  function _doCopyVis(){
+    var buf=term.buffer.active,text='';
+    var start=buf.viewportY,rows=term.rows;
+    var end=Math.min(start+rows,buf.length);
+    for(var i=start;i<end;i++){var ln=buf.getLine(i);if(ln)text+=ln.translateToString()+'\\n';}
+    var ta=document.createElement('textarea');ta.value=text;
+    ta.style.cssText='position:fixed;left:-9999px';document.body.appendChild(ta);ta.select();
+    try{document.execCommand('copy')}catch(ex){}
+    document.body.removeChild(ta);
+  }
+  function _copyToast(){
+    var d=document.createElement('div');
+    d.textContent='Copied!';d.style.cssText='position:fixed;top:8px;left:50%;transform:translateX(-50%);z-index:999;background:#9ece6a;color:#1a1b26;padding:4px 16px;border-radius:4px;font:13px monospace;pointer-events:none;opacity:1;transition:opacity .4s';
+    document.body.appendChild(d);
+    setTimeout(function(){d.style.opacity='0'},800);
+    setTimeout(function(){document.body.removeChild(d)},1200);
+  }
+  _copyBtn.addEventListener('touchend',function(e){e.preventDefault();e.stopPropagation();_doCopyVis();_copyToast();});
+  _copyBtn.addEventListener('click',function(e){e.preventDefault();e.stopPropagation();_doCopyVis();_copyToast();});
 }
 
-// Single-finger touch scrolling is handled natively by xterm's own Viewport
-// (handleTouchMove → scrollTop), so no custom handler here — a parallel one
-// would double-drive scrollTop and fight xterm.  overscroll-behavior:none on
-// .xterm-viewport (see <style>) kills the iOS rubber-band; the WebGL/Canvas
-// renderer above is what actually makes scrolling over text smooth.
+// Custom single-finger scroll — drives .xterm-viewport scrollTop directly
+// because xterm.js's built-in touch handler doesn't reliably receive events
+// when the WebGL canvas is active on some mobile browsers.
+if(isTouch){(function(){
+  var _sy=0,_ss=0,_on=false,_vp=null;
+  document.addEventListener('touchstart',function(e){
+    if(e.touches.length===1){
+      _sy=e.touches[0].clientY;
+      if(!_vp)_vp=document.querySelector('#terminal .xterm-viewport');
+      _ss=_vp?_vp.scrollTop:0;_on=true;
+    }else{_on=false;}
+  },{passive:true});
+  document.addEventListener('touchmove',function(e){
+    if(!_on||e.touches.length!==1)return;
+    if(_vp)_vp.scrollTop=_ss+(_sy-e.touches[0].clientY);
+  },{passive:true});
+  document.addEventListener('touchend',function(){_on=false},{passive:true});
+})();}
 </script>
 </body>
 </html>`;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3542,7 +3542,10 @@ function killCli(): void {
 
 function startWebServer(host: string, preferredPort?: number): Promise<number> {
   return new Promise((resolve, reject) => {
-    httpServer = createHttpServer((req, res) => {
+    const password = config.web.terminalPassword;
+    const authEnabled = !!password;
+
+    httpServer = createHttpServer(async (req, res) => {
       const url = parseWorkerRequestUrl(req);
       if (!url) {
         log(`Bad worker HTTP URL rejected: ${JSON.stringify(req.url ?? '')}`);
@@ -3550,6 +3553,33 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
         res.end('Bad Request');
         return;
       }
+
+      // ── Password gate ──
+      if (authEnabled) {
+        const cookies = parseCookies(req.headers.cookie);
+        if (cookies[AUTH_COOKIE] !== password) {
+          if (req.method === 'POST') {
+            const body = await readRequestBody(req);
+            const params = new URLSearchParams(body);
+            if (params.get('pwd') === password) {
+              res.writeHead(302, {
+                'Content-Type': 'text/html; charset=utf-8',
+                'Set-Cookie': `${AUTH_COOKIE}=${password}; Path=/s/; Max-Age=${AUTH_COOKIE_MAX_AGE}; HttpOnly; SameSite=Lax`,
+                Location: url.pathname + url.search,
+              });
+              res.end();
+              return;
+            }
+            res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+            res.end(getLoginPage(true));
+            return;
+          }
+          res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+          res.end(getLoginPage(false));
+          return;
+        }
+      }
+
       const hasWrite = url.searchParams.get('token') === writeToken;
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(getTerminalHtml(hasWrite));
@@ -3559,6 +3589,16 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
 
     wss.on('connection', (ws, req: IncomingMessage) => {
       wsClients.add(ws);
+
+      // Auth check for WebSocket (same cookie as the HTML page)
+      if (authEnabled) {
+        const cookies = parseCookies(req.headers.cookie);
+        if (cookies[AUTH_COOKIE] !== password) {
+          wsClients.delete(ws);
+          ws.close(4001, 'Authentication required');
+          return;
+        }
+      }
 
       // Check token from query string for write access
       const url = parseWorkerRequestUrl(req);
@@ -4052,6 +4092,64 @@ if(isTouch){(function(){
   document.addEventListener('touchend',function(){_on=false},{passive:true});
 })();}
 </script>
+</body>
+</html>`;
+}
+
+// ─── IPC Communication ───────────────────────────────────────────────────────
+
+/** Simple cookie parser: "k1=v1; k2=v2" → {k1:"v1", k2:"v2"} */
+function parseCookies(header?: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!header) return out;
+  for (const part of header.split(';')) {
+    const idx = part.indexOf('=');
+    if (idx < 0) continue;
+    out[part.slice(0, idx).trim()] = part.slice(idx + 1).trim();
+  }
+  return out;
+}
+
+/** Stream a small request body into a string. */
+function readRequestBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve) => {
+    let body = '';
+    req.on('data', (chunk: Buffer) => (body += chunk.toString()));
+    req.on('end', () => resolve(body));
+  });
+}
+
+const AUTH_COOKIE = 'bmx_auth';
+const AUTH_COOKIE_MAX_AGE = 2_592_000; // 30 days
+
+function getLoginPage(error: boolean): string {
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+<title>botmux · login</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+html,body{height:100%;background:#1a1b26;display:flex;align-items:center;justify-content:center;font-family:monospace}
+form{display:flex;flex-direction:column;gap:14px;padding:28px 24px;background:#24283b;border-radius:10px;border:1px solid #33467c;min-width:280px}
+h1{color:#a9b1d6;font-size:16px;text-align:center;margin-bottom:4px}
+label{color:#565f89;font-size:12px;text-align:center}
+input{background:#1a1b26;color:#a9b1d6;border:1px solid #33467c;border-radius:6px;padding:12px 14px;font-size:16px;font-family:monospace;outline:none}
+input:focus{border-color:#7aa2f7}
+button{background:#7aa2f7;color:#1a1b26;border:none;border-radius:6px;padding:12px;font-size:16px;font-family:monospace;cursor:pointer;font-weight:bold}
+button:active{opacity:0.85}
+.error{color:#f7768e;font-size:13px;text-align:center${error ? '' : ';display:none'}}
+</style>
+</head>
+<body>
+<form method="post">
+  <h1>terminal</h1>
+  <label>enter password to continue</label>
+  <input type="password" name="pwd" placeholder="password" autofocus>
+  <button type="submit">login</button>
+  <p class="error">wrong password, try again</p>
+</form>
 </body>
 </html>`;
 }


### PR DESCRIPTION
## 改动概览

基于 `deepcoldy/botmux` master，新增 4 个功能：

### 1. Web 终端 Cookie 登录鉴权
- 新增 `WEB_TERMINAL_PASSWORD` 配置项（不设 = 无鉴权，向下兼容）
- 首次访问显示 Tokyo Night 风格登录页，输入密码后设 Cookie（`bmx_auth`, Path=`/s/`, 30 天）
- Cookie 覆盖所有话题终端 + WebSocket 连接
- 终端链接自动识别 IP vs 域名：域名（cpolar/nginx）不拼端口，IP 才拼

### 2. 手机端 Web 终端体验优化
- **Viewport**: 不再写死 `width=1100`，按屏幕宽度自适应 800/1000/1100 + 显式缩放范围
- **双指缩放**: xterm.js 对所有触摸事件调 `preventDefault()` 阻止了浏览器原生缩放，加 monkey-patch 在 ≥2 指时跳过
- **单指滚动**: 补丁自定义 `touchstart→touchmove→touchend` 直接驱动 `.xterm-viewport.scrollTop`
- **长按复制**: 保留 `user-select:none`（保滚动），去掉 `-webkit-touch-callout:none`（恢复长按 Copy 菜单）
- **字号**: 触屏从 14px 调至 15px
- **快捷复制**: 工具栏加 📋 按钮，复制可见终端内容到剪贴板

### 3. 空闲 Session 自动休眠
- 30 分钟无活动 → 浅睡眠（kill worker + tmux）
- 4 小时 → 深睡眠
- 用户发新消息时自动 `forkWorker(resume:true)` 恢复
- 休眠计时从 bot 最后一条回复开始算（而非用户消息）

### 4. botmux send 卡片增加导出按钮
- 「📄 导出飞书文档」：异步导入为飞书 Docx
- 「📝 原始 Markdown」：直接回复 markdown 原文
- 基于文件系统的跨进程缓存（`botmux send` 是短命进程，daemon 是长命 PM2）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)