### PR TITLE
feat: add oh-my-pi (omp) CLI adapter

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -64,7 +64,7 @@ Compared to OpenClaw-style approaches built on Agent SDKs:
 ## Prerequisites
 
 - **Node.js** >= 20
-- **AI coding CLI / local agent app** installed and authenticated (`claude`, `codex`, `coco`, `cursor-agent`, `gemini`, `opencode`, `hermes`, `seed` (Seed CLI, a Claude Code fork), `pi`, `copilot` (GitHub Copilot CLI), `traex` (TRAE CLI), or `agy` (Antigravity) in PATH)
+- **AI coding CLI / local agent app** installed and authenticated (`claude`, `codex`, `coco`, `cursor-agent`, `gemini`, `opencode`, `hermes`, `seed` (Seed CLI, a Claude Code fork), `pi`, `omp` (oh-my-pi, a Pi fork), `copilot` (GitHub Copilot CLI), `traex` (TRAE CLI), or `agy` (Antigravity) in PATH)
   - **CoCo requires `0.120.32+`**: type-ahead (sending a new message while a turn is still running, parked in CoCo's own message queue) relies on 0.120.32+ behavior; earlier versions may drop or serialize input while busy — upgrade before use
 - **tmux** >= 3.x (optional — auto-enabled when installed for persistent CLI sessions)
 - **CJK fonts** (only needed for screenshot rendering of Chinese text / emoji):

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ CLI 进入 botmux 会话时自动获得 `~/.botmux/bin` 在 PATH 中，以及一
 ## 前置要求
 
 - **Node.js** >= 20
-- **AI 编程 CLI / 本地 Agent 应用** 已安装并完成认证（`claude`、`codex`、`coco`、`cursor-agent`、`gemini`、`opencode`、`hermes`、`seed`（Seed CLI，Claude Code 衍生）、`pi`、`copilot`（GitHub Copilot CLI）、`traex`（TRAE CLI）或 `agy`（Antigravity）在 PATH 中）
+- **AI 编程 CLI / 本地 Agent 应用** 已安装并完成认证（`claude`、`codex`、`coco`、`cursor-agent`、`gemini`、`opencode`、`hermes`、`seed`（Seed CLI，Claude Code 衍生）、`pi`、`omp`（oh-my-pi，Pi 衍生）、`copilot`（GitHub Copilot CLI）、`traex`（TRAE CLI）或 `agy`（Antigravity）在 PATH 中）
   - **CoCo 最低版本 `0.120.32`**：type-ahead（会话忙时即可发新消息，由 CoCo 自己的消息队列接住）依赖 0.120.32+ 的行为；更早版本忙时输入可能丢失或串行，请升级后再用
 - **tmux** >= 3.x（可选，安装后自动启用会话常驻）
 - **CJK 字体**（用于截图渲染中文/emoji）：

--- a/src/adapters/cli/oh-my-pi.ts
+++ b/src/adapters/cli/oh-my-pi.ts
@@ -1,0 +1,61 @@
+import { resolveCommand } from './registry.js';
+import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
+import type { CliAdapter, PtyHandle } from './types.js';
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/** Adapter for oh-my-pi coding agent's native TUI (`omp`). */
+export function createOhMyPiAdapter(pathOverride?: string): CliAdapter {
+  const bin = resolveCommand(pathOverride ?? 'omp');
+  return {
+    id: 'oh-my-pi',
+    resolvedBin: bin,
+
+    // oh-my-pi has no --session-id; sessions are managed internally.
+    // buildResumeCommand handles resume separately.
+    buildArgs({ initialPrompt, model, workingDir, disableCliBypass }) {
+      const args = [
+        '--tools', 'read,bash,edit,write,browser,web_search,ast_grep,ast_edit,lsp,debug,find,eval,search,task,ask',
+        '--no-title',
+      ];
+      if (!disableCliBypass) {
+        args.push('--approval-mode', 'yolo');
+      }
+      if (model?.trim()) args.push('--model', model.trim());
+      if (workingDir) args.push('--cwd', workingDir);
+      if (initialPrompt) args.push(initialPrompt);
+      return args;
+    },
+
+    // --continue resumes the latest local session.  No precise session-id
+    // mapping exists (gemini/opencode share this limitation), so this is
+    // best-effort convenience rather than guaranteed per-session resume.
+    buildResumeCommand() {
+      return 'omp --continue';
+    },
+
+    passesInitialPromptViaArgs: true,
+
+    async writeInput(pty: PtyHandle, content: string) {
+      if (pty.pasteText && pty.sendSpecialKeys) {
+        pty.pasteText(content);
+        await delay(200);
+        pty.sendSpecialKeys('Enter');
+      } else {
+        pty.write(`\x1b[200~${content}\x1b[201~`);
+        await delay(1000);
+        pty.write('\r');
+      }
+    },
+
+    completionPattern: undefined,
+    readyPattern: undefined,
+    systemHints: BOTMUX_SHELL_HINTS,
+    altScreen: true,
+    skillsDir: '~/.omp/agent/skills',
+  };
+}
+
+export const create = createOhMyPiAdapter;

--- a/src/adapters/cli/oh-my-pi.ts
+++ b/src/adapters/cli/oh-my-pi.ts
@@ -2,9 +2,7 @@ import { resolveCommand } from './registry.js';
 import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
 import type { CliAdapter, PtyHandle } from './types.js';
 
-function delay(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
+import { delay } from '../../utils/timing.js';
 
 /** Adapter for oh-my-pi coding agent's native TUI (`omp`). */
 export function createOhMyPiAdapter(pathOverride?: string): CliAdapter {

--- a/src/adapters/cli/registry.ts
+++ b/src/adapters/cli/registry.ts
@@ -19,6 +19,7 @@ import { createMiraAdapter } from './mira.js';
 import { createTraexAdapter } from './traex.js';
 import { createPiAdapter } from './pi.js';
 import { createCopilotAdapter } from './copilot.js';
+import { createOhMyPiAdapter } from './oh-my-pi.js';
 
 /** Resolve a command name to its absolute path via shell `which`.
  *  Tries login shell first (-lc), then interactive shell (-ic) for tools
@@ -101,7 +102,7 @@ export async function createCliAdapter(id: CliId, pathOverride?: string): Promis
   return adapter;
 }
 
-export { createClaudeCodeAdapter, createSeedAdapter, createAidenAdapter, createCocoAdapter, createCodexAdapter, createCodexAppAdapter, createCursorAdapter, createGeminiAdapter, createOpenCodeAdapter, createAntigravityAdapter, createMtrAdapter, createHermesAdapter, createMiraAdapter, createTraexAdapter, createPiAdapter, createCopilotAdapter };
+export { createClaudeCodeAdapter, createSeedAdapter, createAidenAdapter, createCocoAdapter, createCodexAdapter, createCodexAppAdapter, createCursorAdapter, createGeminiAdapter, createOpenCodeAdapter, createAntigravityAdapter, createMtrAdapter, createHermesAdapter, createMiraAdapter, createTraexAdapter, createPiAdapter, createCopilotAdapter, createOhMyPiAdapter };
 
 /** Synchronous version for use in worker process. */
 export function createCliAdapterSync(id: CliId, pathOverride?: string): CliAdapter {
@@ -122,6 +123,7 @@ export function createCliAdapterSync(id: CliId, pathOverride?: string): CliAdapt
     case 'traex': return createTraexAdapter(pathOverride);
     case 'pi': return createPiAdapter(pathOverride);
     case 'copilot': return createCopilotAdapter(pathOverride);
+    case 'oh-my-pi': return createOhMyPiAdapter(pathOverride);
     default: throw new Error(`Unknown CLI adapter: ${id}`);
   }
 }

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -200,4 +200,4 @@ export interface CliAdapter {
   versionCommand?(): { bin: string; args: string[] };
 }
 
-export type CliId = 'claude-code' | 'seed' | 'aiden' | 'coco' | 'codex' | 'codex-app' | 'cursor' | 'gemini' | 'opencode' | 'antigravity' | 'mtr' | 'hermes' | 'mira' | 'traex' | 'pi' | 'copilot';
+export type CliId = 'claude-code' | 'seed' | 'aiden' | 'coco' | 'codex' | 'codex-app' | 'cursor' | 'gemini' | 'opencode' | 'antigravity' | 'mtr' | 'hermes' | 'mira' | 'traex' | 'pi' | 'copilot' | 'oh-my-pi';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -660,7 +660,7 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
   }
   console.log('✅ 凭证有效（tenant_access_token 已成功获取）\n');
 
-  console.log('支持的 CLI: 1) claude-code  2) aiden  3) coco（别名 traecli）  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed  14) traex  15) pi  16) copilot');
+  console.log('支持的 CLI: 1) claude-code  2) aiden  3) coco（别名 traecli）  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed  14) traex  15) pi  16) copilot  17) oh-my-pi');
   const cliChoice = await ask(rl, 'CLI 适配器 [1]: ');
   let cliId: CliId;
   try {
@@ -762,7 +762,7 @@ async function promptEditBotConfig(
   ]);
   input.larkAppSecret = await ask(rl, `LARK_APP_SECRET [保留当前值]: `);
 
-  console.log('\n支持的 CLI: 1) claude-code  2) aiden  3) coco（别名 traecli）  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed  14) traex  15) pi  16) copilot');
+  console.log('\n支持的 CLI: 1) claude-code  2) aiden  3) coco（别名 traecli）  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed  14) traex  15) pi  16) copilot  17) oh-my-pi');
   printInputHelp('CLI 适配器', [
     '选择 botmux 需要套用哪一种 CLI 参数协议和会话恢复方式。',
     'coco 的别名 traecli 走同一适配器；二进制名是 traecli 也选 coco 即可。',

--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -54,6 +54,7 @@ const CLI_COMM_MAP: Record<string, CliId> = {
   mtr: 'mtr',
   hermes: 'hermes',
   pi: 'pi',
+  omp: 'oh-my-pi',
 };
 
 /** Interpreters and native launchers that may hide the CLI identity in argv.

--- a/src/dashboard/web/sessions.ts
+++ b/src/dashboard/web/sessions.ts
@@ -38,6 +38,7 @@ const CLI_FILTER_OPTIONS = [
   'copilot',
   'aiden',
   'coco',
+  'oh-my-pi',
   'unknown',
 ];
 

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -189,6 +189,7 @@ const cliDisplayNames: Record<CliId, string> = {
   'traex': 'TRAE',
   'pi': 'Pi',
   'copilot': 'Copilot',
+  'oh-my-pi': 'OMP',
 };
 
 export function getCliDisplayName(cliId: CliId): string {

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -189,7 +189,7 @@ const cliDisplayNames: Record<CliId, string> = {
   'traex': 'TRAE',
   'pi': 'Pi',
   'copilot': 'Copilot',
-  'oh-my-pi': 'OMP',
+  'oh-my-pi': 'Oh My Pi',
 };
 
 export function getCliDisplayName(cliId: CliId): string {

--- a/src/setup/bot-config-editor.ts
+++ b/src/setup/bot-config-editor.ts
@@ -43,6 +43,7 @@ const CLI_DISPLAY_LABELS: Record<CliId, string> = {
   'traex': 'TRAE',
   'pi': 'Pi',
   'copilot': 'Copilot',
+  'oh-my-pi': 'OMP',
 };
 
 /**

--- a/src/setup/bot-config-editor.ts
+++ b/src/setup/bot-config-editor.ts
@@ -17,6 +17,7 @@ export const CLI_ID_CHOICES: Record<string, CliId> = {
   '14': 'traex',
   '15': 'pi',
   '16': 'copilot',
+  '17': 'oh-my-pi',
 };
 
 const VALID_CLI_IDS: ReadonlySet<string> = new Set(Object.values(CLI_ID_CHOICES));
@@ -68,7 +69,7 @@ export function resolveCliId(input: string | undefined): CliId | undefined {
   if (mapped) return mapped;
   if (VALID_CLI_IDS.has(raw)) return raw as CliId;
   throw new Error(
-    `Unknown CLI 适配器 "${raw}"。请输入序号 1-16 或合法 ID 之一: ${[...VALID_CLI_IDS].join(', ')}`,
+    `Unknown CLI 适配器 "${raw}"。请输入序号 1-17 或合法 ID 之一: ${[...VALID_CLI_IDS].join(', ')}`,
   );
 }
 

--- a/src/setup/bot-config-editor.ts
+++ b/src/setup/bot-config-editor.ts
@@ -44,7 +44,7 @@ const CLI_DISPLAY_LABELS: Record<CliId, string> = {
   'traex': 'TRAE',
   'pi': 'Pi',
   'copilot': 'Copilot',
-  'oh-my-pi': 'OMP',
+  'oh-my-pi': 'Oh My Pi',
 };
 
 /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -119,7 +119,7 @@ function ensureZellijAttachConfig(): string {
 
 let sessionId = '';
 let lastInitConfig: Extract<DaemonToWorker, { type: 'init' }> | null = null;
-const CLI_DISPLAY_NAMES: Record<string, string> = { 'claude-code': 'Claude', seed: 'Seed', aiden: 'Aiden', coco: 'CoCo', codex: 'Codex', 'codex-app': 'Codex App', cursor: 'Cursor', gemini: 'Gemini', opencode: 'OpenCode', antigravity: 'Antigravity', mtr: 'MTR', hermes: 'Hermes', mira: 'Mira', traex: 'TRAE', pi: 'Pi', copilot: 'Copilot' };
+const CLI_DISPLAY_NAMES: Record<string, string> = { 'claude-code': 'Claude', seed: 'Seed', aiden: 'Aiden', coco: 'CoCo', codex: 'Codex', 'codex-app': 'Codex App', cursor: 'Cursor', gemini: 'Gemini', opencode: 'OpenCode', antigravity: 'Antigravity', mtr: 'MTR', hermes: 'Hermes', mira: 'Mira', traex: 'TRAE', pi: 'Pi', copilot: 'Copilot', 'oh-my-pi': 'Oh My Pi' };
 function cliName(): string { return CLI_DISPLAY_NAMES[lastInitConfig?.cliId ?? ''] ?? 'CLI'; }
 let isPromptReady = false;
 /** Mutex for async flushPending — prevents concurrent flush loops. */

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -30,15 +30,16 @@ import { createAntigravityAdapter } from '../src/adapters/cli/antigravity.js';
 import { createMtrAdapter, mtrSessionIdForBotmuxSession } from '../src/adapters/cli/mtr.js';
 import { createHermesAdapter } from '../src/adapters/cli/hermes.js';
 import { createMiraAdapter } from '../src/adapters/cli/mira.js';
-import { createCopilotAdapter } from '../src/adapters/cli/copilot.js';
 import { createPiAdapter } from '../src/adapters/cli/pi.js';
+import { createCopilotAdapter } from '../src/adapters/cli/copilot.js';
+import { createOhMyPiAdapter } from '../src/adapters/cli/oh-my-pi.js';
 import type { CliAdapter, CliId } from '../src/adapters/cli/types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-const ALL_CLI_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'codex-app', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes', 'mira', 'pi', 'copilot'];
+const ALL_CLI_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'codex-app', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes', 'mira', 'pi', 'copilot', 'oh-my-pi'];
 
 // ---------------------------------------------------------------------------
 // 1. Factory: createCliAdapterSync
@@ -473,6 +474,58 @@ describe('pi buildArgs', () => {
     expect(args.at(-1)).toBe('hello pi');
     expect(adapter.passesInitialPromptViaArgs).toBe(true);
     expect(adapter.altScreen).toBe(true);
+  });
+});
+
+describe('oh-my-pi buildArgs', () => {
+  const adapter = createOhMyPiAdapter('/usr/bin/omp');
+
+  it('launches omp TUI with tools, approval-mode, and no-title', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-omp', resume: false, initialPrompt: 'hello omp' });
+    expect(adapter.resolvedBin).toBe('/usr/bin/omp');
+    expect(args).toContain('--tools');
+    expect(args).toContain('read,bash,edit,write,browser,web_search,ast_grep,ast_edit,lsp,debug,find,eval,search,task,ask');
+    expect(args).toContain('--approval-mode');
+    expect(args[args.indexOf('--approval-mode') + 1]).toBe('yolo');
+    expect(args).toContain('--no-title');
+    expect(args.at(-1)).toBe('hello omp');
+    expect(adapter.passesInitialPromptViaArgs).toBe(true);
+    expect(adapter.altScreen).toBe(true);
+  });
+
+  it('does not include --session-id (oh-my-pi has none)', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-omp', resume: false });
+    expect(args).not.toContain('--session-id');
+    expect(args).not.toContain('sess-omp');
+  });
+
+  it('omits --approval-mode yolo when disableCliBypass is true', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-omp', resume: false, disableCliBypass: true });
+    expect(args).not.toContain('--approval-mode');
+    expect(args).not.toContain('yolo');
+    expect(args).toContain('--no-title');
+  });
+
+  it('passes configured model with --model', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-omp', resume: false, model: 'opus' });
+    const idx = args.indexOf('--model');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(args[idx + 1]).toBe('opus');
+  });
+
+  it('passes working directory with --cwd', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-omp', resume: false, workingDir: '/repo/root' });
+    const idx = args.indexOf('--cwd');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(args[idx + 1]).toBe('/repo/root');
+  });
+
+  it('skillsDir points to ~/.omp/agent/skills', () => {
+    expect(adapter.skillsDir).toBe('~/.omp/agent/skills');
+  });
+
+  it('has no modelChoices (setup skips model prompt)', () => {
+    expect(adapter.modelChoices).toBeUndefined();
   });
 });
 
@@ -963,6 +1016,12 @@ describe('buildResumeCommand', () => {
     const a = createPiAdapter('/bin/pi');
     expect(a.buildResumeCommand?.({ sessionId: 'bm-pi', cliSessionId: 'ignored' }))
       .toBe('pi --session-id bm-pi');
+  });
+
+  it('oh-my-pi emits `omp --continue` (best-effort, ignores sessionId)', () => {
+    const a = createOhMyPiAdapter('/bin/omp');
+    expect(a.buildResumeCommand?.({ sessionId: 'bm-omp', cliSessionId: 'ignored' }))
+      .toBe('omp --continue');
   });
 
   it('copilot emits `copilot --resume <cliSessionId>` when known, null otherwise', () => {

--- a/test/write-input-all-cli.e2e.ts
+++ b/test/write-input-all-cli.e2e.ts
@@ -26,6 +26,7 @@ import { createMtrAdapter } from '../src/adapters/cli/mtr.js';
 import { createHermesAdapter } from '../src/adapters/cli/hermes.js';
 import { createMiraAdapter } from '../src/adapters/cli/mira.js';
 import { createCopilotAdapter } from '../src/adapters/cli/copilot.js';
+import { createOhMyPiAdapter } from '../src/adapters/cli/oh-my-pi.js';
 
 // ─── Mock PTY recorder ──────────────────────────────────────────────────────
 
@@ -119,6 +120,7 @@ const ADAPTERS = [
   { name: 'hermes', create: () => safeCreate(() => createHermesAdapter()) },
   { name: 'mira', create: () => safeCreate(() => createMiraAdapter()) },
   { name: 'copilot', create: () => safeCreate(() => createCopilotAdapter()) },
+  { name: 'oh-my-pi', create: () => safeCreate(() => createOhMyPiAdapter()) },
 ];
 
 // ─── Tests ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Add [oh-my-pi](https://github.com/can1357/oh-my-pi) CLI adapter support. oh-my-pi is an actively-maintained fork of Pi (`@mariozechner/pi-coding-agent`), installed as the `omp` binary.

The new adapter coexists with the existing `pi` adapter — users can choose either in setup.

## Changes

**11 files**, +137 / -8

| File | Change |
|---|---|
| `src/adapters/cli/oh-my-pi.ts` | New: 61-line adapter (eager bin resolution, 15 tools, `--approval-mode yolo`, `omp --continue` resume) |
| `src/adapters/cli/types.ts` | CliId union + `'oh-my-pi'` |
| `src/adapters/cli/registry.ts` | Import, re-export, factory case |
| `src/im/lark/card-builder.ts` | Display name entry |
| `src/setup/bot-config-editor.ts` | CLI_ID_CHOICES(17), display label, error message update |
| `src/cli.ts` | Setup menu strings ×2 |
| `src/worker.ts` | CLI_DISPLAY_NAMES entry |
| `src/core/session-discovery.ts` | `omp` → `oh-my-pi` COMM_MAP |
| `src/dashboard/web/sessions.ts` | Filter option |
| `test/cli-adapters.test.ts` | 8 unit test cases |
| `test/write-input-all-cli.e2e.ts` | writeInput integration |

## Design decisions

- **Coexists with pi**: pi is kept for backward compatibility
- **No `--session-id`**: oh-my-pi manages sessions internally (no external session naming). Resume uses `omp --continue` (best-effort convenience, not auto-resume)
- **No modelChoices**: setup skips model prompt (same as pi)
- **15 tools**: expanded from pi's 7 to cover all botmux agent capabilities
- **No hook integration**: oh-my-pi has no `askUserQuestion` hook event; falls back to `botmux-ask` skill

## Verification

- TypeScript: zero errors
- Unit tests: 195/195 passing (8 new oh-my-pi cases)
- E2E tests: 118/121 passing (3 pre-existing mira failures)
- Live smoke test: `omp --tools ... --approval-mode yolo --no-title` parsed correctly (v15.10.2)
- Deployed and tested locally: daemon starts, skills install, CLI version detected
