### PR TITLE
fix(mira): notify dispatcher bot for fallback output

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -194,9 +194,17 @@ function loadKnownBotOpenIdsForApp(larkAppId: string): Set<string> {
   return knownBotOpenIdsFromCrossRef(crossRef, botEntries, larkAppId);
 }
 
-function daemonCardFooterRecipientOpenId(ds: DaemonSession): string | undefined {
+function daemonCardFooterRecipientOpenId(ds: DaemonSession, effectiveCliId?: string): string | undefined {
   const owner = ds.session.ownerOpenId;
-  if (!owner) return undefined;
+  if (!owner) {
+    // Mira runs through botmux's API runner and cannot execute `botmux send`
+    // itself. For bot-to-bot handoffs, address the daemon fallback card back
+    // to the original dispatcher so orchestration resumes.
+    if (effectiveCliId === 'mira' && ds.session.quoteTargetSenderIsBot && ds.session.creatorOpenId) {
+      return ds.session.creatorOpenId;
+    }
+    return undefined;
+  }
   try {
     return loadKnownBotOpenIdsForApp(ds.larkAppId).has(owner) ? undefined : owner;
   } catch {
@@ -1939,7 +1947,7 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
           break;
         }
         if (!msg.userText.trim() && !msg.assistantText.trim()) break;
-        const recipientOpenId = daemonCardFooterRecipientOpenId(ds);
+        const recipientOpenId = daemonCardFooterRecipientOpenId(ds, effectiveCliId);
         const cardJson = buildContextualReplyCard({
           title: '📜 /adopt 前最后一轮',
           userText: msg.userText,
@@ -2027,7 +2035,7 @@ function deliverFinalOutput(
       // they use the contextual card so the user prompt sits in a
       // blockquote and only the assistant body goes through full markdown
       // rendering.
-      const recipientOpenId = daemonCardFooterRecipientOpenId(ds);
+      const recipientOpenId = daemonCardFooterRecipientOpenId(ds, effectiveCliId);
       const cardJson = msg.kind === 'local-turn' || msg.kind === 'local-turn-headless'
         ? buildContextualReplyCard({
             title: msg.kind === 'local-turn-headless'

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -206,7 +206,14 @@ function daemonCardFooterRecipientOpenId(ds: DaemonSession, effectiveCliId?: str
     return undefined;
   }
   try {
-    return loadKnownBotOpenIdsForApp(ds.larkAppId).has(owner) ? undefined : owner;
+    if (loadKnownBotOpenIdsForApp(ds.larkAppId).has(owner)) {
+      // `/repo`-primed dispatch records the dispatching bot as owner (unlike
+      // the @-mention auto-create path, which nulls ownerOpenId for bot
+      // senders). Same Mira constraint applies: the daemon fallback is Mira's
+      // only reply channel, so address the dispatcher bot here too.
+      return effectiveCliId === 'mira' ? owner : undefined;
+    }
+    return owner;
   } catch {
     return owner;
   }

--- a/test/bridge-final-output-retry.test.ts
+++ b/test/bridge-final-output-retry.test.ts
@@ -217,6 +217,32 @@ describe('Bridge final_output delivery (P2 retry)', () => {
     expect(cardJson).not.toContain('<at id=ou_foreign_bot></at>');
   });
 
+  it('addresses Mira daemon fallback output back to the bot dispatcher', async () => {
+    const sessionReply = vi.fn(async () => 'om_reply');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+
+    const ds = makeDs();
+    ds.session.cliId = 'mira';
+    ds.session.ownerOpenId = undefined;
+    ds.ownerOpenId = undefined;
+    ds.session.creatorOpenId = 'ou_dispatcher_bot';
+    ds.session.quoteTargetSenderIsBot = true;
+
+    const { __testOnly_deliverFinalOutput } = await import('../src/core/worker-pool.js') as any;
+    __testOnly_deliverFinalOutput(ds, finalOutputMsg(), 'tag', 0);
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(sessionReply).toHaveBeenCalledTimes(1);
+    const cardJson = sessionReply.mock.calls[0][1] as string;
+    expect(cardJson).toContain('<at id=ou_dispatcher_bot></at>');
+  });
+
   it('keeps daemon final-output footer addressing for a human owner', async () => {
     const sessionReply = vi.fn(async () => 'om_reply');
     initWorkerPool({

--- a/test/bridge-final-output-retry.test.ts
+++ b/test/bridge-final-output-retry.test.ts
@@ -243,6 +243,40 @@ describe('Bridge final_output delivery (P2 retry)', () => {
     expect(cardJson).toContain('<at id=ou_dispatcher_bot></at>');
   });
 
+  it('addresses Mira fallback output to a known-bot owner (/repo-primed dispatch)', async () => {
+    // `botmux dispatch --repo` primes the thread with "@bot /repo <path>",
+    // which records the dispatching bot as ownerOpenId (daemon /repo
+    // session-create path) instead of nulling it like @-mention auto-create.
+    writeFileSync(
+      join('/tmp/test-sessions', 'bot-openids-app_test.json'),
+      JSON.stringify({ Orchestrator: 'ou_orch_bot' }),
+    );
+
+    const sessionReply = vi.fn(async () => 'om_reply');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+
+    const ds = makeDs();
+    ds.session.cliId = 'mira';
+    ds.session.ownerOpenId = 'ou_orch_bot';
+    ds.ownerOpenId = 'ou_orch_bot';
+    ds.session.creatorOpenId = 'ou_orch_bot';
+    ds.session.quoteTargetSenderIsBot = true;
+
+    const { __testOnly_deliverFinalOutput } = await import('../src/core/worker-pool.js') as any;
+    __testOnly_deliverFinalOutput(ds, finalOutputMsg(), 'tag', 0);
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(sessionReply).toHaveBeenCalledTimes(1);
+    const cardJson = sessionReply.mock.calls[0][1] as string;
+    expect(cardJson).toContain('<at id=ou_orch_bot></at>');
+  });
+
   it('keeps daemon final-output footer addressing for a human owner', async () => {
     const sessionReply = vi.fn(async () => 'om_reply');
     initWorkerPool({


### PR DESCRIPTION
## Summary

- route Mira daemon fallback output back to the original dispatcher bot in bot-to-bot handoff scenarios
- keep existing human-owner footer behavior unchanged
- add regression coverage for the Mira dispatcher notification case

## Why

Mira runs through botmux's API runner and cannot execute `botmux send` itself. When a bot dispatches work to Mira, daemon fallback output previously had no human owner to address and therefore did not mention the dispatcher bot. That left the orchestration bot unaware that Mira had responded.

## Validation

- `pnpm test -- test/bridge-final-output-retry.test.ts`
- `pnpm build`
