### PR TITLE
feat(card): support manual working directory selection

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -15,6 +15,7 @@ export const messages: Record<string, string> = {
   'card.btn.refresh': '🔃 Refresh',
   'card.btn.takeover': '🔄 Take Over',
   'card.btn.skip_repo': '▶️ Start Session Directly',
+  'card.btn.manual_repo': 'Use This Directory',
   'card.btn.half_page_up': '⇞ Page ½ Up',
   'card.btn.half_page_down': '⇟ Page ½ Down',
   'card.btn.send_custom': '📝 Send Custom Reply',
@@ -54,6 +55,7 @@ export const messages: Record<string, string> = {
   // ─── Repo select card ────────────────────────────────────────────────────
   'card.repo.title': '📁 Project Repository',
   'card.repo.placeholder_switch': 'Pick a repo to switch to',
+  'card.repo.manual_placeholder': 'Enter any working directory, e.g. /path/to/project or ~/projects/foo',
   'card.repo.current_active': 'Currently active project:',
   'card.repo.current_marker': ' ← current',
   'card.repo.note': 'You can also reply `/repo <N>` (e.g. `/repo 1`), or `/repo <path|name>` directly (e.g. `/repo botmux`, `/repo ~/projects/foo`) to skip this card.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -18,6 +18,7 @@ export const messages: Record<string, string> = {
   'card.btn.refresh': '🔃 刷新',
   'card.btn.takeover': '🔄 接管',
   'card.btn.skip_repo': '▶️ 直接开启会话',
+  'card.btn.manual_repo': '使用此目录',
   'card.btn.half_page_up': '⇞ 上半屏',
   'card.btn.half_page_down': '⇟ 下半屏',
   'card.btn.send_custom': '📝 发送自定义回复',
@@ -57,6 +58,7 @@ export const messages: Record<string, string> = {
   // ─── Repo select card ────────────────────────────────────────────────────
   'card.repo.title': '📁 项目仓库管理',
   'card.repo.placeholder_switch': '选择仓库并切换',
+  'card.repo.manual_placeholder': '输入任意工作目录，如 /path/to/project 或 ~/projects/foo',
   'card.repo.current_active': '当前活跃项目：',
   'card.repo.current_marker': ' ← 当前',
   'card.repo.note': '也可以回复 `/repo <编号>` 切换（如 `/repo 1`），或直接 `/repo <路径|项目名>`（如 `/repo botmux`、`/repo ~/projects/foo`）跳过本卡片',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -975,6 +975,25 @@ export function buildRepoSelectCard(projects: ProjectInfo[], currentPath?: strin
         ],
       },
       {
+        tag: 'form',
+        name: 'repo_manual_form',
+        elements: [
+          {
+            tag: 'input',
+            name: 'repo_manual_path',
+            placeholder: { tag: 'plain_text', content: t('card.repo.manual_placeholder', undefined, locale) },
+          },
+          {
+            tag: 'button',
+            name: 'repo_manual_submit',
+            text: { tag: 'plain_text', content: t('card.btn.manual_repo', undefined, locale) },
+            type: 'default',
+            action_type: 'form_submit',
+            value: { action: 'repo_manual_submit', root_id: rootMessageId ?? '' },
+          },
+        ],
+      },
+      {
         tag: 'note',
         elements: [
           {

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -4,6 +4,7 @@
  * Extracted from daemon.ts for modularity.
  */
 import { execSync } from 'node:child_process';
+import { basename } from 'node:path';
 import { config } from '../../config.js';
 import { getBot, getAllBots, getOwnerOpenId } from '../../bot-registry.js';
 import { canOperate, canTalk } from './event-dispatcher.js';
@@ -28,6 +29,7 @@ import { loadFrozenCards, saveFrozenCards } from '../../services/frozen-card-sto
 import { forkWorker, killWorker, scheduleCardPatch, parkStreamCard, clearUsageLimitState, cardUsageLimit, writableTerminalLinkFor, resolvePrivateCardAudience, deliverWriteLinkCard, deliverEphemeralOrReply, CARD_POSTING_SENTINEL } from '../../core/worker-pool.js';
 import { getSessionWorkingDir, buildNewTopicPrompt, getAvailableBots, persistStreamCardState, resumeSession, rememberLastCliInput } from '../../core/session-manager.js';
 import { publishAttentionPatch } from '../../core/session-activity.js';
+import { validateWorkingDir } from '../../core/working-dir.js';
 import type { DaemonToWorker, DisplayMode, TermActionKey } from '../../types.js';
 import { sessionKey, sessionAnchorId, frozenDisplayMode } from '../../core/types.js';
 import type { DaemonSession } from '../../core/types.js';
@@ -572,7 +574,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     return { toast: { type: 'success', content: t('card.relay.toast_success', undefined, loc) } };
   }
 
-  const isSensitive = value?.action && ['restart', 'close', 'resume', 'skip_repo', 'retry_last_task', 'get_write_link', 'toggle_stream', 'toggle_display', 'export_text', 'term_action', 'refresh_screenshot', 'takeover', 'disconnect', 'tui_keys', 'tui_text_input', 'wf_approve', 'wf_reject', 'wf_cancel'].includes(value.action);
+  const isSensitive = value?.action && ['restart', 'close', 'resume', 'skip_repo', 'repo_manual_submit', 'retry_last_task', 'get_write_link', 'toggle_stream', 'toggle_display', 'export_text', 'term_action', 'refresh_screenshot', 'takeover', 'disconnect', 'tui_keys', 'tui_text_input', 'wf_approve', 'wf_reject', 'wf_cancel'].includes(value.action);
   if (isSensitive) {
     const rootId = value?.root_id;
     // activeSessions is keyed by sessionKey(anchor, larkAppId) — `${anchor}::${larkAppId}`
@@ -596,7 +598,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     // pendingRepo 阶段，会话发起人（含 chat-granted 用户）可以 skip_repo 起会话——
     // 与 repo 下拉选择同款例外，否则被授权人连自己的首次会话都启动不了。
     const pendingRepoOwnerException =
-      value.action === 'skip_repo' && !!ds?.pendingRepo &&
+      (value.action === 'skip_repo' || value.action === 'repo_manual_submit') && !!ds?.pendingRepo &&
       !!operatorOpenId && operatorOpenId === ds.session.ownerOpenId;
     if (effectiveAppId) {
       if (!pendingRepoOwnerException && !canOperate(effectiveAppId, chatId, operatorOpenId)) {
@@ -1269,6 +1271,75 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       }
       if (cardMessageId && larkAppId) deleteMessage(larkAppId, cardMessageId);
       ds.repoCardMessageId = undefined;
+    }
+
+    if (actionType === 'repo_manual_submit' && ds) {
+      const locDs = localeForBot(ds.larkAppId);
+      const rawPath = String(action?.form_value?.repo_manual_path ?? '').trim();
+      if (!rawPath) {
+        return { toast: { type: 'error', content: t('cmd.cd.usage', undefined, locDs) } };
+      }
+
+      const validation = validateWorkingDir(rawPath, locDs);
+      if (!validation.ok) {
+        return { toast: { type: 'error', content: validation.error } };
+      }
+
+      const selectedPath = validation.resolvedPath;
+      const displayName = basename(selectedPath) || selectedPath;
+      ds.workingDir = selectedPath;
+      ds.session.workingDir = selectedPath;
+      sessionStore.updateSession(ds.session);
+
+      if (ds.pendingRepo) {
+        const selfBot = getBot(ds.larkAppId);
+        const botCfg = selfBot.config;
+        const effectiveCliId = sessionCliId(ds);
+        ds.pendingRepo = false;
+        publishAttentionPatch(ds);
+        const pendingPrompt = ds.pendingPrompt ?? '';
+        const prompt = buildNewTopicPrompt(
+          pendingPrompt,
+          ds.session.sessionId,
+          effectiveCliId,
+          botCfg.cliPathOverride,
+          ds.pendingAttachments,
+          ds.pendingMentions,
+          await getAvailableBots(ds.larkAppId, ds.chatId),
+          ds.pendingFollowUps,
+          { name: selfBot.botName, openId: selfBot.botOpenId },
+          locDs,
+          ds.pendingSender,
+          { larkAppId: ds.larkAppId, chatId: ds.chatId },
+        );
+        rememberLastCliInput(ds, pendingPrompt, prompt);
+        ds.pendingPrompt = undefined;
+        ds.pendingAttachments = undefined;
+        ds.pendingMentions = undefined;
+        ds.pendingSender = undefined;
+        ds.pendingFollowUps = undefined;
+        forkWorker(ds, prompt);
+        await sessionReply(rootId, t('cmd.repo.selected_in_pending', { name: displayName }, locDs));
+        logger.info(`[${tag(ds)}] Manual repo path selected, spawning CLI in ${selectedPath}`);
+      } else {
+        killWorker(ds);
+        sessionStore.closeSession(ds.session.sessionId);
+        const session = sessionStore.createSession(ds.chatId, rootId, displayName, ds.chatType);
+        ds.session = session;
+        ds.lastUserPrompt = undefined;
+        ds.lastCliInput = undefined;
+        ds.session.workingDir = selectedPath;
+        ds.session.larkAppId = ds.larkAppId;
+        sessionStore.updateSession(ds.session);
+        ds.hasHistory = false;
+        forkWorker(ds, '', false);
+        await sessionReply(rootId, t('cmd.repo.switched_to', { name: displayName }, locDs));
+        logger.info(`[${tag(ds)}] Manual repo path switched to ${selectedPath}`);
+      }
+
+      if (cardMessageId && larkAppId) deleteMessage(larkAppId, cardMessageId);
+      ds.repoCardMessageId = undefined;
+      return;
     }
     return;
   }

--- a/test/card-builder.test.ts
+++ b/test/card-builder.test.ts
@@ -701,6 +701,26 @@ describe('buildRepoSelectCard', () => {
     });
   });
 
+  // ── Manual directory form ──────────────────────────────────────────────
+
+  describe('manual directory form', () => {
+    it('should include an input and submit button for arbitrary working dirs', () => {
+      const card = parse(buildRepoSelectCard(projects, undefined, 'om_root'));
+      const formEl = card.elements.find((e: any) => e.tag === 'form' && e.name === 'repo_manual_form');
+      expect(formEl).toBeDefined();
+
+      const input = formEl.elements.find((e: any) => e.tag === 'input' && e.name === 'repo_manual_path');
+      expect(input).toBeDefined();
+      expect(input.placeholder.content).toContain('/path');
+
+      const submit = formEl.elements.find((e: any) => e.tag === 'button' && e.value?.action === 'repo_manual_submit');
+      expect(submit).toBeDefined();
+      expect(submit.name).toBe('repo_manual_submit');
+      expect(submit.action_type).toBe('form_submit');
+      expect(submit.value.root_id).toBe('om_root');
+    });
+  });
+
   // ── Note element ──────────────────────────────────────────────────────
 
   describe('note element', () => {
@@ -716,13 +736,14 @@ describe('buildRepoSelectCard', () => {
   // ── Element structure ─────────────────────────────────────────────────
 
   describe('element structure', () => {
-    it('should have 4 top-level elements: div, hr, action, note', () => {
+    it('should have 5 top-level elements: div, hr, action, form, note', () => {
       const card = parse(buildRepoSelectCard(projects));
-      expect(card.elements).toHaveLength(4);
+      expect(card.elements).toHaveLength(5);
       expect(card.elements[0].tag).toBe('div');
       expect(card.elements[1].tag).toBe('hr');
       expect(card.elements[2].tag).toBe('action');
-      expect(card.elements[3].tag).toBe('note');
+      expect(card.elements[3].tag).toBe('form');
+      expect(card.elements[4].tag).toBe('note');
     });
   });
 

--- a/test/repo-manual-card-action.test.ts
+++ b/test/repo-manual-card-action.test.ts
@@ -1,0 +1,156 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/im/lark/client.js', () => ({
+  deleteMessage: vi.fn(),
+  getChatInfo: vi.fn(),
+  MessageWithdrawnError: class MessageWithdrawnError extends Error {},
+}));
+
+vi.mock('../src/bot-registry.js', () => ({
+  getBot: vi.fn(() => ({
+    config: { larkAppId: 'app_test', larkAppSecret: 'secret', cliId: 'claude-code' },
+    resolvedAllowedUsers: ['ou_owner'],
+    botName: 'Test Bot',
+    botOpenId: 'ou_bot',
+  })),
+  getAllBots: vi.fn(() => []),
+  getBotClient: vi.fn(),
+  getOwnerOpenId: vi.fn(() => 'ou_owner'),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    web: { externalHost: 'localhost' },
+    session: { dataDir: '/tmp/test-sessions' },
+    daemon: { backendType: 'pty', cliId: 'claude-code' },
+  },
+}));
+
+vi.mock('../src/services/session-store.js', () => ({
+  updateSession: vi.fn(),
+  closeSession: vi.fn(),
+  createSession: vi.fn(),
+  getSession: vi.fn(),
+}));
+
+vi.mock('../src/core/worker-pool.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../src/core/worker-pool.js')>();
+  return {
+    ...orig,
+    forkWorker: vi.fn(),
+    killWorker: vi.fn(),
+  };
+});
+
+vi.mock('../src/core/session-manager.js', () => ({
+  buildNewTopicPrompt: vi.fn(() => 'mock-prompt'),
+  getAvailableBots: vi.fn(async () => []),
+  getSessionWorkingDir: vi.fn(() => '/tmp'),
+  persistStreamCardState: vi.fn(),
+  rememberLastCliInput: vi.fn((ds: any, userPrompt: string, cliInput: string) => {
+    ds.lastUserPrompt = userPrompt;
+    ds.lastCliInput = cliInput;
+  }),
+  resumeSession: vi.fn(),
+}));
+
+vi.mock('@larksuiteoapi/node-sdk', () => ({
+  Client: class { constructor() {} },
+  WSClient: class { start() {} },
+  EventDispatcher: class { register() {} },
+  LoggerLevel: { info: 2 },
+}));
+
+import { forkWorker } from '../src/core/worker-pool.js';
+import * as sessionManager from '../src/core/session-manager.js';
+import { sessionKey } from '../src/core/types.js';
+import type { DaemonSession } from '../src/core/types.js';
+import { handleCardAction, type CardHandlerDeps } from '../src/im/lark/card-handler.js';
+import * as sessionStore from '../src/services/session-store.js';
+
+const APP_ID = 'app_test';
+const ROOT_ID = 'om_root';
+
+function makePendingRepoSession(): DaemonSession {
+  return {
+    session: {
+      sessionId: 'sess-manual',
+      rootMessageId: ROOT_ID,
+      chatId: 'oc_chat',
+      chatType: 'group',
+      title: 'Manual Repo',
+      status: 'active' as any,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      pid: null,
+      ownerOpenId: 'ou_owner',
+      cliId: 'claude-code',
+    },
+    worker: null,
+    workerPort: null,
+    workerToken: null,
+    larkAppId: APP_ID,
+    chatId: 'oc_chat',
+    chatType: 'group',
+    spawnedAt: Date.now(),
+    cliVersion: '1.0',
+    lastMessageAt: Date.now(),
+    hasHistory: false,
+    pendingRepo: true,
+    pendingPrompt: 'run the queued task',
+  } as DaemonSession;
+}
+
+function repoManualSubmit(path: string) {
+  return {
+    action: {
+      value: { action: 'repo_manual_submit', root_id: ROOT_ID },
+      form_value: { repo_manual_path: path },
+    },
+    operator: { open_id: 'ou_owner' },
+  };
+}
+
+describe('repo manual card action', () => {
+  it('starts a pending session in the manually submitted existing directory', async () => {
+    const selectedPath = mkdtempSync(join(tmpdir(), 'botmux-manual-repo-'));
+    const ds = makePendingRepoSession();
+    const activeSessions = new Map<string, DaemonSession>([[sessionKey(ROOT_ID, APP_ID), ds]]);
+    const deps: CardHandlerDeps = {
+      activeSessions,
+      lastRepoScan: new Map(),
+      sessionReply: vi.fn(async () => 'om_reply'),
+    };
+
+    await handleCardAction(repoManualSubmit(selectedPath), deps, APP_ID);
+
+    expect(ds.pendingRepo).toBe(false);
+    expect(ds.workingDir).toBe(selectedPath);
+    expect(ds.session.workingDir).toBe(selectedPath);
+    expect(sessionStore.updateSession).toHaveBeenCalledWith(ds.session);
+    expect(sessionManager.buildNewTopicPrompt).toHaveBeenCalledWith(
+      'run the queued task',
+      'sess-manual',
+      'claude-code',
+      undefined,
+      undefined,
+      undefined,
+      [],
+      undefined,
+      { name: 'Test Bot', openId: 'ou_bot' },
+      'zh',
+      undefined,
+      { larkAppId: APP_ID, chatId: 'oc_chat' },
+    );
+    expect(forkWorker).toHaveBeenCalledWith(ds, 'mock-prompt');
+    expect(deps.sessionReply).toHaveBeenCalledWith(
+      ROOT_ID,
+      expect.stringContaining(basename(selectedPath)),
+      undefined,
+      APP_ID,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a manual working-directory input to the repository selection card
- allow the pending session owner to submit an existing local directory directly from the card
- start or switch the session in that selected directory
- add card-builder and card-action coverage for the manual submission flow

## Why

Project scanning may not list every useful working directory. Users can already type `/repo <path>` manually; this adds the same direct-path workflow to the interactive card.

## Validation

- `pnpm test -- test/card-builder.test.ts test/repo-manual-card-action.test.ts`
- `pnpm build`
