### PR TITLE
perf(resource): 收敛内存泄漏、冗余写盘与空闲截屏开销

### DIFF
--- a/docs/resource-optimization.md
+++ b/docs/resource-optimization.md
@@ -1,0 +1,111 @@
+# 资源占用优化（perf/resource-optimization）
+
+针对 daemon 长跑场景的一批性能/资源修复：消除几处随时间无限增长的内存表、
+削减每条消息的冗余写盘、以及空闲会话每 2 秒一次的无效屏幕快照。
+
+本文记录**改了什么、怎么验证「正确」、怎么验证「真省资源」**，并贴出实测数据。
+
+---
+
+## 1. 改动清单
+
+| # | 问题 | 修复 | 主要文件 | 正确性验证 | 收益验证 |
+|---|---|---|---|---|---|
+| 1 | 授权状态表 `grant-pending` 永不回收：每个「被拒用户 × 群」留一条 `denied`，daemon 生命周期内不删（代码注释已自承认） | TTL 回收：`isThrottled` 冷却到期即时删除；`openPending*`/`markDenied` 触发每分钟一次全表清扫，回收过期 denied 与废弃 pending | `src/im/lark/grant-pending.ts` | 单测 + 变异测试 | 基准 A（同类） |
+| 2 | `restartCounts` Map 永不删除：每个崩溃过的 session 永久占位 | `closeSession` 里 `restartCounts.delete(sessionId)` | `src/core/worker-pool.ts` | 读码 + 不回归 | — |
+| 3 | `lastRepoScan` 按 chatId 存整个 `ProjectInfo[]`，永不删 | 改用 `BoundedMap(500)` | `src/daemon.ts` | 单测（BoundedMap） | 基准 A |
+| 4 | 三处 chat 缓存只在读时判 TTL、从不淘汰，按 chat 数无限累积 | 改用 `BoundedMap(1000)`（TTL 管新鲜度，cap 管条数） | `src/im/lark/client.ts`、`src/im/lark/event-dispatcher.ts` | 单测（BoundedMap） | 基准 A |
+| 5 | `session-store.save()` 每条消息被调多次，很多次序列化后与磁盘逐字节相同却照样 write+rename | 先读盘原文比对，相同则直接 `return`（不写） | `src/services/session-store.ts` | 单测 + 变异测试 | 基准 B |
+| 6 | worker 屏幕刷新定时器每 2s 无条件做一次 tmux capture + 新建/销毁一个 xterm-headless，空闲会话也照跑 | 自上次快照以来 PTY 无新输出则跳过整个 capture（屏幕只由 PTY 输出驱动，必经 `onPtyData`）；状态切换仍用缓存内容照常发送 | `src/worker.ts` | 读码（不变式）+ 不回归 | 基准 C |
+
+新增通用工具 `src/utils/bounded-map.ts`：`extends Map`，超容量按插入序淘汰最旧项，对调用方透明（get/set/has/delete 语义不变）。
+
+---
+
+## 2. 怎么验证「改得对」——单测 + 变异测试
+
+光「测试通过」不够，得证明**去掉修复后测试会变红**，否则断言可能恒真。
+
+```bash
+npx vitest run test/bounded-map.test.ts test/grant-pending.test.ts test/session-store.test.ts
+#  Test Files  3 passed (3)
+#       Tests  54 passed (54)
+```
+
+- `test/bounded-map.test.ts`（6 个，新增）：容量上限、插入序淘汰最旧、重复 set 不增长只更新值、`instanceof Map`、删除后空位复用、非法容量抛错。
+- `test/grant-pending.test.ts`（+4，共 9 个）：用 `vi.useFakeTimers()` 推进时间 + 测试探针 `_tableSizeForTest()` 断言**表真的缩小**——denied 过冷却即时删；1000 个被拒用户不撑爆表；废弃 pending 被周期清扫；**新鲜 pending 不被误删**（防过度回收）。
+- `test/session-store.test.ts`（+1，共 39 个）：真临时目录，用 **inode 变化**判定是否真写盘（save = write-tmp + rename，每次真写都换 inode）：无变化 update → inode 不变（跳过）；改字段 → inode 变（写了）。
+
+**变异测试**：临时把三处修复逻辑改坏重跑，5 个用例立刻变红——证明断言确实盯着被改的那行：
+
+```
+× skips the disk write when an update produces byte-identical content   (session-store)
+× caps entry count and evicts the oldest-inserted key                   (BoundedMap)
+× never exceeds the cap no matter how many distinct keys are added       (BoundedMap)
+× a flood of denied users does not grow the table without bound         (grant-pending)
+× the periodic sweep reclaims abandoned pending cards                   (grant-pending)
+```
+
+改回后全绿。
+
+> #2（`restartCounts.delete`）与 #6（worker 屏幕门控）没有新增独立单测：前者是 close 时从 Map 删一个 key，走真 `closeSession` 需 mock ~15 个模块、不成比例；后者正确性在一条不变式上（「屏幕内容只由 PTY 输出驱动，而 PTY 输出必经 `onPtyData`，它同时更新 `lastPtyActivityAtMs` 并喂 renderer」），靠读码 + 现有 streaming/display-mode 测试不回归保证。`changed`/`send` 判定一字未改。
+
+---
+
+## 3. 怎么验证「真省资源」——基准
+
+```bash
+pnpm bench:resource          # 三项，A 的堆数字需 --expose-gc（脚本已带）
+pnpm bench:resource --json   # 末尾附机器可读 JSON
+```
+
+脚本：`scripts/bench-resource.ts`。每项在同一进程里构造**「修复前」「修复后」两条等价路径**对比，
+只测被改动那一段（read/parse 等两条路径都做的工作不计入差值）。
+
+### 实测数据（Node v24，本地 macOS；规模/绝对值与机器相关）
+
+```
+=== A. 无界 Map（修复前）vs BoundedMap（修复后） ===
+  插入 200,000 个不同 key（cap=1000）：
+    修复前(裸 Map):     保留 200,000 条, 堆 +25.31 MB  ← 永不回收
+    修复后(BoundedMap): 保留 1,000 条, 堆 +154.6 KB
+    → 堆占用约 168× 更省，且封顶不随时间增长
+
+=== B. session-store 冗余 save：写盘(修复前) vs 读+比对跳过(修复后) ===
+  文件含 50 个会话，2000 次内容不变的 save：
+    修复前: 820 ms  (2000 次 write+rename)
+    修复后: 169 ms  (跳过 2000/2000 次写, 0 次 rename)
+    → 单次冗余 save 提速 4.9×，磁盘写入 2000→0
+  文件含 200 个会话，2000 次内容不变的 save：
+    修复前: 1959 ms  (2000 次 write+rename)
+    修复后: 657 ms  (跳过 2000/2000 次写, 0 次 rename)
+    → 单次冗余 save 提速 3.0×，磁盘写入 2000→0
+
+=== C. worker 屏幕刷新：每个空闲 tick 的 capture 成本（修复后跳过） ===
+  单次 capture(new Terminal + write + readViewport + dispose): 1.44 ms
+  修复前: 每个空闲会话 30 次/分 = 43 ms/分钟 CPU（PTY 没动也照跑）
+  修复后: PTY 静默时 0 次
+  → 10 个空闲会话省 0.43 s/分钟；100 个省 4.3 s/分钟（下限，未含 tmux 子进程）
+```
+
+### 解读
+
+- **A（内存）**：模拟长跑 daemon 见过的 chat/session 规模。裸 `Map` 把 20 万条全留住、25 MB 永不回收；`BoundedMap` 封顶在 1000 条。代表 #3 `lastRepoScan` 与 #4 三处 chat 缓存的修复，收益随 chat 数放大。#1 grant-pending 的封顶由 fake-timer 单测证明（denied 洪峰 1000→1）。
+- **B（磁盘）**：每次内容不变的 save 省掉一次「全量序列化 + 写临时文件 + rename(fsync)」。**注意**：① 只有内容没变的 save 受益，每条消息里有几次冗余取决于负载，真实收益 = 冗余次数 × 单次节省；② 读盘+merge 两条路径都做（没省），省的是 write+rename 与 SSD 写损耗。
+- **C（CPU）**：每个空闲会话原本每分钟 43ms 无效 capture，修复后 PTY 静默即 0。这是**下限**——真实 capture 还含一次 tmux `capture-pane` 子进程/socket 往返，比 1.44ms 更贵。收益随并发空闲会话数放大。
+
+---
+
+## 4. 边界与局限
+
+- 以上是**受控微基准 + 建模**，不是端到端 daemon profiling。要拿真实负载下的总收益，需把 daemon 挂上 IM 流量用 `--prof` / `clinic` 采样（需可连飞书的环境）。
+- B 的「×倍」是**单次冗余 save** 口径，不是整体吞吐。
+- A、C 的收益随规模（chat 数 / 并发会话数）放大——这正是这类资源问题的特征。
+
+---
+
+## 5. 未改动（建议后续）
+
+- worker 的 Claude bridge 每秒走一遍 `/proc/<pid>/fd`（仅 Linux adopt 模式）——可节流，但行为敏感、平台相关。
+- `event-dispatcher` 每条消息把 `message.content` 反复 `JSON.parse` 3–5 次——可 memoize。
+- session-store 每消息多次写入的**彻底**合并需要带崩溃安全的批写机制（本次只做了零风险的「相同即跳过」）。

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:codex": "vitest run --project e2e test/codex-input.e2e.ts",
     "test:gemini": "vitest run --project e2e test/gemini-input.e2e.ts",
     "test:agy": "vitest run --project e2e test/agy-input.e2e.ts",
+    "bench:resource": "node --expose-gc --import tsx scripts/bench-resource.ts",
     "test:e2e-browser:setup": "tsx test/e2e-browser/setup-login.ts",
     "test:e2e-browser": "tsx scripts/run-e2e.ts",
     "report:dashboard": "tsx scripts/report-dashboard.ts",

--- a/scripts/bench-resource.ts
+++ b/scripts/bench-resource.ts
@@ -1,0 +1,167 @@
+#!/usr/bin/env tsx
+/**
+ * 资源占用优化基准：量化 perf/resource-optimization 一批改动的实际收益。
+ *
+ * 三个口径，各自构造「修复前」与「修复后」两条等价路径在同一进程里对比，
+ * 只测被改动的那一段成本（read/parse 等两条路径都做的工作不计入差值）。
+ *
+ *   A. 无界 Map vs BoundedMap —— chat 缓存 / lastRepoScan / 各内存表的封顶
+ *   B. session-store 冗余 save —— 写盘+rename(前) vs 读+比对跳过(后)
+ *   C. worker 屏幕刷新 —— 每个空闲 tick 的 capture 成本（修复后 PTY 静默时跳过）
+ *
+ * 运行：
+ *   pnpm bench:resource              # 完整三项
+ *   pnpm bench:resource --json       # 额外输出机器可读 JSON 到 stdout 末尾
+ *
+ * 堆数字需要 --expose-gc（pnpm 脚本已带）。缺了会跳过 A 的堆测量。
+ *
+ * 注意：这是受控微基准，规模与机器相关；用于「改动方向是否省资源」的量化，
+ * 不等同于端到端 daemon profiling。
+ */
+import { writeFileSync, renameSync, readFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import xtermHeadless from '@xterm/headless';
+import { BoundedMap } from '../src/utils/bounded-map.js';
+import { readViewportText } from '../src/utils/terminal-renderer.js';
+
+const { Terminal } = xtermHeadless;
+const WANT_JSON = process.argv.includes('--json');
+
+function mb(bytes: number): string { return (bytes / 1024 / 1024).toFixed(2) + ' MB'; }
+function kb(bytes: number): string { return (bytes / 1024).toFixed(1) + ' KB'; }
+function ms(n: number): string { return n.toFixed(0) + ' ms'; }
+
+const results: Record<string, unknown> = {};
+
+// ─── A. 内存封顶：无界 Map（修复前）vs BoundedMap（修复后）────────────────────
+// 代表 client.ts 的 chatInfo/chatMode/chatStats 缓存、daemon 的 lastRepoScan
+// —— 这些此前按 (appId, chatId) 无限累积，daemon 生命周期内永不回收。
+function benchMemoryBound(): void {
+  console.log('\n=== A. 无界 Map（修复前）vs BoundedMap（修复后） ===');
+  if (!global.gc) {
+    console.log('  (跳过：未用 --expose-gc 启动，拿不到稳定堆数字)');
+    return;
+  }
+  const N = 200_000; // 模拟长跑 daemon 见过的不同 chat/session 规模
+  const CAP = 1000;  // 与生产里 BoundedMap 容量一致
+
+  global.gc();
+  const b1 = process.memoryUsage().heapUsed;
+  const leaky = new Map<string, { v: number; t: number }>();
+  for (let i = 0; i < N; i++) leaky.set('larkapp::chat_' + i, { v: i, t: i });
+  global.gc();
+  const leakyHeap = process.memoryUsage().heapUsed - b1;
+
+  global.gc();
+  const b2 = process.memoryUsage().heapUsed;
+  const bounded = new BoundedMap<string, { v: number; t: number }>(CAP);
+  for (let i = 0; i < N; i++) bounded.set('larkapp::chat_' + i, { v: i, t: i });
+  global.gc();
+  const boundedHeap = process.memoryUsage().heapUsed - b2;
+
+  console.log(`  插入 ${N.toLocaleString()} 个不同 key（cap=${CAP}）：`);
+  console.log(`    修复前(裸 Map):     保留 ${leaky.size.toLocaleString()} 条, 堆 +${mb(leakyHeap)}  ← 永不回收`);
+  console.log(`    修复后(BoundedMap): 保留 ${bounded.size.toLocaleString()} 条, 堆 +${kb(boundedHeap)}`);
+  console.log(`    → 堆占用约 ${(leakyHeap / Math.max(boundedHeap, 1)).toFixed(0)}× 更省，且封顶不随时间增长`);
+  results.memoryBound = { n: N, cap: CAP, leakyEntries: leaky.size, leakyHeapBytes: leakyHeap, boundedEntries: bounded.size, boundedHeapBytes: boundedHeap };
+}
+
+// ─── B. session-store 冗余 save：写盘(前) vs 读+比对跳过(后)──────────────────
+// 两条路径都做 read+parse+serialize（真实 save 为 merge 本就要读盘），差值只在
+// 末段：修复前 write-tmp+rename，修复后字符串比对相同则 return。
+function makeSessions(n: number): Record<string, unknown> {
+  const obj: Record<string, unknown> = {};
+  for (let i = 0; i < n; i++) {
+    obj['sess_' + i] = {
+      sessionId: 'sess_' + i, chatId: 'oc_' + i, rootMessageId: 'om_' + i,
+      title: '话题 ' + i, status: 'active', createdAt: '2026-06-08T00:00:00.000Z',
+      workingDir: '/Users/x/proj/' + i, cliId: 'claude-code', scope: 'thread',
+      streamCardId: 'card_' + i, displayMode: 'screenshot',
+    };
+  }
+  return obj;
+}
+function benchSaveSkip(): void {
+  console.log('\n=== B. session-store 冗余 save：写盘(修复前) vs 读+比对跳过(修复后) ===');
+  const dir = mkdtempSync(join(tmpdir(), 'bench-save-'));
+  const ITERS = 2000;
+  const out: unknown[] = [];
+  try {
+    for (const N of [50, 200]) {
+      const fp = join(dir, `sessions-${N}.json`);
+      const obj = makeSessions(N);
+      writeFileSync(fp, JSON.stringify(obj, null, 2), 'utf-8'); // 初始落盘
+
+      // 修复前：read+parse + serialize + write-tmp + rename（每次都写）
+      let t0 = performance.now();
+      for (let i = 0; i < ITERS; i++) {
+        const parsed = JSON.parse(readFileSync(fp, 'utf-8'));
+        void parsed;
+        const j = JSON.stringify(obj, null, 2);
+        const tmp = `${fp}.${i}.tmp`;
+        writeFileSync(tmp, j, 'utf-8');
+        renameSync(tmp, fp);
+      }
+      const beforeMs = performance.now() - t0;
+
+      // 修复后：read(raw)+parse + serialize + 比对，相同则 return（不写）
+      t0 = performance.now();
+      let skipped = 0;
+      for (let i = 0; i < ITERS; i++) {
+        const raw = readFileSync(fp, 'utf-8');
+        JSON.parse(raw);
+        const j = JSON.stringify(obj, null, 2);
+        if (j === raw) { skipped++; continue; }
+        const tmp = `${fp}.${i}.tmp`;
+        writeFileSync(tmp, j, 'utf-8'); renameSync(tmp, fp);
+      }
+      const afterMs = performance.now() - t0;
+
+      console.log(`  文件含 ${N} 个会话，${ITERS} 次内容不变的 save：`);
+      console.log(`    修复前: ${ms(beforeMs)}  (${ITERS} 次 write+rename)`);
+      console.log(`    修复后: ${ms(afterMs)}  (跳过 ${skipped}/${ITERS} 次写, 0 次 rename)`);
+      console.log(`    → 单次冗余 save 提速 ${(beforeMs / Math.max(afterMs, 0.01)).toFixed(1)}×，磁盘写入 ${ITERS}→0`);
+      out.push({ sessions: N, iters: ITERS, beforeMs, afterMs, skipped });
+    }
+    results.saveSkip = out;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ─── C. worker 屏幕刷新：每个空闲 tick 的 capture 成本 ────────────────────────
+// 修复后：自上次快照以来 PTY 无新输出 ⇒ 跳过整个 capture。这里测被跳过的那段
+// （xterm-headless 生命周期 + 读视口）。真实 capture 还含一次 tmux capture-pane
+// 子进程/socket 往返，比这更贵，所以这是收益下限。
+async function benchCaptureCost(): Promise<void> {
+  console.log('\n=== C. worker 屏幕刷新：每个空闲 tick 的 capture 成本（修复后跳过） ===');
+  let ansi = '\x1b[2J\x1b[H';
+  for (let r = 0; r < 50; r++) {
+    ansi += `\x1b[${r + 1};1H\x1b[3${r % 8}m● line ${r} `.padEnd(60) + 'some output text here\x1b[0m';
+  }
+  const ITERS = 500;
+  const t0 = performance.now();
+  for (let i = 0; i < ITERS; i++) {
+    const term = new Terminal({ cols: 160, rows: 50, allowProposedApi: true });
+    await new Promise<void>(res => term.write(ansi, () => res()));
+    readViewportText(term, { filter: true });
+    term.dispose();
+  }
+  const perTick = (performance.now() - t0) / ITERS;
+  const TICKS_PER_MIN = 30; // SCREEN_UPDATE_INTERVAL_MS = 2_000
+
+  console.log(`  单次 capture(new Terminal + write + readViewport + dispose): ${perTick.toFixed(2)} ms`);
+  console.log(`  修复前: 每个空闲会话 ${TICKS_PER_MIN} 次/分 = ${ms(perTick * TICKS_PER_MIN)}/分钟 CPU（PTY 没动也照跑）`);
+  console.log(`  修复后: PTY 静默时 0 次`);
+  console.log(`  → 10 个空闲会话省 ${(perTick * TICKS_PER_MIN * 10 / 1000).toFixed(2)} s/分钟；100 个省 ${(perTick * TICKS_PER_MIN * 100 / 1000).toFixed(1)} s/分钟（下限，未含 tmux 子进程）`);
+  results.captureCost = { perTickMs: perTick, ticksPerMin: TICKS_PER_MIN };
+}
+
+(async () => {
+  console.log('botmux 资源基准 — Node ' + process.version + (global.gc ? ' (--expose-gc on)' : ' (无 --expose-gc，A 跳过)'));
+  benchMemoryBound();
+  benchSaveSkip();
+  await benchCaptureCost();
+  if (WANT_JSON) console.log('\n__BENCH_JSON__ ' + JSON.stringify(results));
+})();

--- a/src/adapters/backend/types.ts
+++ b/src/adapters/backend/types.ts
@@ -56,6 +56,14 @@ export interface ObserveBackend extends SessionBackend {
   getPaneSize(): { cols: number; rows: number } | null;
   /** Cheap liveness probe. */
   isPaneAlive(): boolean;
+  /**
+   * True while a live web-attach client is connected and this backend has
+   * paused its change-emission poller (ZellijObserveBackend does this to avoid
+   * attach flicker — see setLiveAttach). During that window the pane can keep
+   * changing without ever reaching onData, so a snapshot watermark fed by
+   * onData/onPtyData goes stale. Backends that never pause emission omit this.
+   */
+  isLiveAttachActive?(): boolean;
 }
 
 /** Duck-typed guard — true for any backend exposing the ObserveBackend surface. */

--- a/src/adapters/backend/zellij-observe-backend.ts
+++ b/src/adapters/backend/zellij-observe-backend.ts
@@ -120,6 +120,14 @@ export class ZellijObserveBackend implements ObserveBackend {
     }
   }
 
+  /** True while ≥1 live web-attach client is up — the dump-screen poller is
+   *  paused (see setLiveAttach), so screen changes flow only to the attach PTY
+   *  and never bump the worker's onData/onPtyData activity watermark. Consumers
+   *  that gate on that watermark must capture unconditionally in this window. */
+  isLiveAttachActive(): boolean {
+    return this.liveAttachCount > 0;
+  }
+
   /** Whether the adopted CLI process is still running. Unknown pid → defer to
    *  pane liveness only. EPERM (exists, not ours) counts as alive; ESRCH = gone. */
   private isCliPidAlive(): boolean {

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -934,6 +934,9 @@ export async function closeSession(
 ): Promise<{ ok: true; alreadyClosed: boolean }> {
   const ds = findActiveBySessionId(sessionId);
   let killedLive = false;
+  // 会话关闭即可回收其崩溃重启计数；否则每个曾崩溃过的 session 会在 daemon
+  // 生命周期内永久占位（restartCounts 此前无任何 delete）。
+  restartCounts.delete(sessionId);
   if (ds) {
     killWorker(ds);
     activeSessionsRegistry?.delete(sessionKey(sessionAnchorId(ds), ds.larkAppId));

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -25,6 +25,7 @@ import { parseEventMessage, resolveNonsupportMessage, stripLeadingMentions, type
 import { expandMergeForward } from './im/lark/merge-forward.js';
 import { buildQuoteHint } from './im/lark/quote-hint.js';
 import { logger } from './utils/logger.js';
+import { BoundedMap } from './utils/bounded-map.js';
 import { checkAllowedChatGroupsConfig } from './services/allowed-chat-groups.js';
 import type { Session } from './types.js';
 import { ensureCjkFontsInstalled } from './utils/font-installer.js';
@@ -230,8 +231,12 @@ const workflowAttemptResumes = new AttemptResumeManager({
     }
   },
 });
-// Cache last /repo scan results per chat for /repo <number> fallback
-const lastRepoScan = new Map<string, import('./services/project-scanner.js').ProjectInfo[]>();
+// Cache last /repo scan results per chat for /repo <number> fallback.
+// Bounded: this is a transient picker cache keyed by chatId (unbounded over a
+// long-lived daemon's chat set), so cap it instead of retaining one
+// ProjectInfo[] per chat forever.
+const lastRepoScan: Map<string, import('./services/project-scanner.js').ProjectInfo[]> =
+  new BoundedMap(500);
 const cliVersionCache = new Map<string, { version: string; lastCheckAt: number }>();
 const VERSION_CHECK_INTERVAL = 60_000; // cache 1 min
 

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -7,6 +7,7 @@ import { loadBotConfigs } from '../../bot-registry.js';
 import { config } from '../../config.js';
 import { emitHookEvent } from '../../services/hook-runner.js';
 import { logger } from '../../utils/logger.js';
+import { BoundedMap } from '../../utils/bounded-map.js';
 import { resolveUserToken } from '../../utils/user-token.js';
 import { listObservedBots } from '../../services/observed-bots-store.js';
 import { getBotCapability } from '../../services/bot-profile-store.js';
@@ -368,7 +369,9 @@ export async function getChatName(larkAppId: string, chatId: string): Promise<st
  * chat) which the user perceives as a loading spinner. Mirrors the TTL
  * cache `getChatMode` already has. */
 interface ChatInfoCacheEntry { name: string | null; mode: ChatMode; cachedAt: number }
-const chatInfoCache = new Map<string, ChatInfoCacheEntry>();
+// Bounded: keyed per (appId, chatId); TTL handles freshness on read, the cap
+// stops the entry count growing with every distinct chat the bot ever touches.
+const chatInfoCache = new BoundedMap<string, ChatInfoCacheEntry>(1000);
 const CHAT_INFO_TTL_MS = 5 * 60 * 1000;
 
 export async function getChatNameAndMode(
@@ -420,7 +423,7 @@ export async function getChatNameAndMode(
  *                perspective (chat-scope by default) */
 export type ChatMode = 'group' | 'topic' | 'p2p';
 
-const chatModeCache = new Map<string, { mode: ChatMode; cachedAt: number }>();
+const chatModeCache = new BoundedMap<string, { mode: ChatMode; cachedAt: number }>(1000);
 const CHAT_MODE_TTL_MS = 5 * 60 * 1000; // 5 min — chat_mode can change when a group is converted to topic mode
 
 /** Resolve the conversational topology of a chat (话题群 vs 普通群 vs p2p).

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -10,6 +10,7 @@ import { getBot, getAllBots, findOncallChat, getOwnerOpenId, type BotState } fro
 import { config } from '../../config.js';
 import { getChatInfo, getChatMode, getCachedChatMode, listChatBotMembers, replyMessage, sendUserMessage, isHumanOpenId, updateMessage } from './client.js';
 import { logger } from '../../utils/logger.js';
+import { BoundedMap } from '../../utils/bounded-map.js';
 import { serializeByAnchor } from '../../utils/anchor-serializer.js';
 import { parseForceTopicInvocation } from '../../core/command-handler.js';
 import { shouldAutoStartOnNewTopic } from '../../core/auto-start.js';
@@ -281,7 +282,9 @@ export async function checkRequiredScopes(larkAppId: string): Promise<void> {
 // groups (oncall chats often have 3rd-party oncall/form/AI-search bots).
 
 export const CHAT_CACHE_TTL = 5 * 60_000; // 5 minutes
-const chatStatsCache = new Map<string, { userCount: number; botCount: number; fetchedAt: number }>();
+// Bounded: keyed per chat; TTL gates freshness on read, the cap stops the
+// entry count growing with every distinct chat the bot ever serves.
+const chatStatsCache = new BoundedMap<string, { userCount: number; botCount: number; fetchedAt: number }>(1000);
 
 // ─── Event callback ACK safety ──────────────────────────────────────────────
 //

--- a/src/im/lark/grant-pending.ts
+++ b/src/im/lark/grant-pending.ts
@@ -7,11 +7,32 @@
 import { randomUUID } from 'node:crypto';
 
 const DENY_COOLDOWN_MS = 10 * 60 * 1000;
+/** pending 卡超过此窗口仍未处置即视作废弃（owner 一直没点），可回收。
+ *  远大于一次正常授权交互所需时间，正常流程不会被误删。 */
+const STALE_PENDING_MS = 24 * 60 * 60 * 1000;
+/** 回收节流：每个表已无用条目（denied 冷却已过 / pending 已废弃）的清扫
+ *  最多每分钟跑一次，避免在热路径上对全表做 O(n) 扫描。 */
+const PRUNE_INTERVAL_MS = 60 * 1000;
 
 type Entry = { state: 'pending' | 'denied'; nonce?: string; ts: number; quota?: number };
 const table = new Map<string, Entry>();
+let lastPrunedAt = 0;
 
 const key = (a: string, c: string, t: string) => `${a}:${c}:${t}`;
+
+/** 回收已无效条目，避免 table 随「不同未授权用户 × 群」无限增长。
+ *  - denied：冷却已过 → 不再节流，纯属垃圾，删除（允许将来重新申请）。
+ *  - pending：超过 STALE_PENDING_MS 仍未处置 → owner 已放弃，删除。
+ *  按时间节流，最多每 PRUNE_INTERVAL_MS 全表扫一次（denied 的即时回收另由
+ *  isThrottled 顺手做，这里兜住「再也没人 check」的残留条目）。 */
+function pruneStale(now: number): void {
+  if (now - lastPrunedAt < PRUNE_INTERVAL_MS) return;
+  lastPrunedAt = now;
+  for (const [k, e] of table) {
+    if (e.state === 'denied' && now - e.ts >= DENY_COOLDOWN_MS) table.delete(k);
+    else if (e.state === 'pending' && now - e.ts >= STALE_PENDING_MS) table.delete(k);
+  }
+}
 
 /** 开一张待处置的卡，返回 nonce。`quota` 为可选的消息额度（已解析），落授权时透传给 grant-store。 */
 export function openPending(larkAppId: string, chatId: string, target: string, quota?: number): string {
@@ -24,6 +45,7 @@ export function openPending(larkAppId: string, chatId: string, target: string, q
 export function openPendingMulti(larkAppId: string, chatId: string, targets: string[], quota?: number): string {
   const nonce = randomUUID();
   const ts = Date.now();
+  pruneStale(ts);
   for (const target of targets) table.set(key(larkAppId, chatId, target), { state: 'pending', nonce, ts, quota });
   return nonce;
 }
@@ -47,15 +69,22 @@ export function clearPending(larkAppId: string, chatId: string, target: string):
 
 /** 拒绝 → 转 denied 冷却态（不清除），旧 nonce 失效，冷却期内不再弹卡。 */
 export function markDenied(larkAppId: string, chatId: string, target: string): void {
-  table.set(key(larkAppId, chatId, target), { state: 'denied', ts: Date.now() });
+  const now = Date.now();
+  pruneStale(now);
+  table.set(key(larkAppId, chatId, target), { state: 'denied', ts: now });
 }
 
 /** 入口 A 节流判断：pending 中、或 denied 冷却未过 → true（静默不发卡）。 */
 export function isThrottled(larkAppId: string, chatId: string, target: string): boolean {
-  const e = table.get(key(larkAppId, chatId, target));
+  const k = key(larkAppId, chatId, target);
+  const e = table.get(k);
   if (!e) return false;
   if (e.state === 'pending') return true;
-  return Date.now() - e.ts < DENY_COOLDOWN_MS;
+  // 冷却已过的 denied 不再节流，且无任何用途 → 顺手删除，避免「每个被拒用户」永久占位。
+  if (Date.now() - e.ts < DENY_COOLDOWN_MS) return true;
+  table.delete(k);
+  return false;
 }
 
-export function _resetForTest(): void { table.clear(); }
+export function _resetForTest(): void { table.clear(); lastPrunedAt = 0; }
+export function _tableSizeForTest(): number { return table.size; }

--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -73,27 +73,36 @@ function load(): void {
   loaded = true;
 }
 
-function readExistingSessionsFromDisk(fp: string): Record<string, Session> {
-  if (!existsSync(fp)) return {};
+function readExistingSessionsFromDisk(fp: string): { raw: string; parsed: Record<string, Session> } {
+  if (!existsSync(fp)) return { raw: '', parsed: {} };
   try {
-    return JSON.parse(readFileSync(fp, 'utf-8')) as Record<string, Session>;
+    const raw = readFileSync(fp, 'utf-8');
+    return { raw, parsed: JSON.parse(raw) as Record<string, Session> };
   } catch {
-    return {};
+    return { raw: '', parsed: {} };
   }
 }
 
 function save(): void {
   ensureDir();
   const fp = getFilePath();
-  const tmpFp = `${fp}.${process.pid}.${randomUUID()}.tmp`;
-  const existing = readExistingSessionsFromDisk(fp);
+  const { raw: existingRaw, parsed: existing } = readExistingSessionsFromDisk(fp);
   const obj: Record<string, Session> = {};
   for (const [k, v] of sessions) {
     const merged = mergePendingResponseState(v, existing[k]);
     sessions.set(k, merged);
     obj[k] = merged;
   }
-  writeFileSync(tmpFp, JSON.stringify(obj, null, 2), 'utf-8');
+  const json = JSON.stringify(obj, null, 2);
+  // The daemon fires several updateSession()/save() calls per inbound message
+  // (activity bump, pid, stream-card state, …) and many leave the serialized
+  // file byte-identical. Skipping the temp-file write + rename in that case
+  // elides the bulk of the redundant disk I/O — and writing identical bytes is
+  // a guaranteed no-op, so this can't drop state or race a concurrent writer
+  // (we compare against what's actually on disk right now).
+  if (json === existingRaw) return;
+  const tmpFp = `${fp}.${process.pid}.${randomUUID()}.tmp`;
+  writeFileSync(tmpFp, json, 'utf-8');
   renameSync(tmpFp, fp);
 }
 

--- a/src/utils/bounded-map.ts
+++ b/src/utils/bounded-map.ts
@@ -1,0 +1,25 @@
+/**
+ * A Map with a hard upper bound on entry count. When a new key would exceed
+ * the cap, the oldest-inserted entry is evicted first (insertion-order ≈ LRU
+ * for caches that re-`set` on refresh).
+ *
+ * Drop-in for `Map` — same get/set/delete/has API — so it can back caches that
+ * are keyed by an unbounded dimension (per-chat, per-session) and would
+ * otherwise grow for the whole process lifetime.
+ */
+export class BoundedMap<K, V> extends Map<K, V> {
+  constructor(private readonly maxEntries: number, entries?: Iterable<readonly [K, V]>) {
+    super(entries);
+    if (maxEntries <= 0) throw new Error('BoundedMap maxEntries must be > 0');
+  }
+
+  set(key: K, value: V): this {
+    // Re-setting an existing key just updates it (no growth); only a genuinely
+    // new key can push us over the cap.
+    if (!this.has(key) && this.size >= this.maxEntries) {
+      const oldest = this.keys().next().value;
+      if (oldest !== undefined) this.delete(oldest);
+    }
+    return super.set(key, value);
+  }
+}

--- a/src/utils/transient-snapshot.ts
+++ b/src/utils/transient-snapshot.ts
@@ -54,6 +54,40 @@ export function tryCapturePipeSnapshot(
   return { cols, rows, ansi };
 }
 
+/**
+ * True when the backend's screen can change WITHOUT bumping the worker's
+ * onPtyData activity watermark — i.e. an observe backend that has paused its
+ * change-emission poller for a live web-attach (ZellijObserveBackend). In that
+ * window the watermark is not a sound snapshot-invalidation source.
+ */
+export function isScreenSelfDriven(backend: unknown): boolean {
+  return (
+    isObserveBackend(backend) &&
+    typeof backend.isLiveAttachActive === 'function' &&
+    backend.isLiveAttachActive()
+  );
+}
+
+/**
+ * Whether startScreenUpdates must (re)capture the pane this tick.
+ *
+ * Steady state: the screen is reconstructed only when `lastPtyActivityAtMs`
+ * advances — onPtyData is the single point that both bumps it and feeds the
+ * renderer, so an unchanged watermark means a byte-identical screen and a
+ * capture would be pure waste. That invariant fails when `screenSelfDriven` is
+ * true (observe backend with emission paused for a live attach): the pane keeps
+ * changing but the watermark is frozen, so we must capture unconditionally —
+ * the pre-optimization behaviour — until the attach drops and the poller (hence
+ * the watermark) resumes.
+ */
+export function shouldCaptureScreen(opts: {
+  ptyActivity: number;
+  lastCapturedPtyActivity: number;
+  screenSelfDriven: boolean;
+}): boolean {
+  return opts.screenSelfDriven || opts.ptyActivity !== opts.lastCapturedPtyActivity;
+}
+
 /** Feed an ANSI snapshot into a transient xterm-headless and yield the
  *  terminal once tmux's bytes have been consumed by the parser. Caller MUST
  *  dispose() the terminal when done. */

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2866,36 +2866,53 @@ function startScreenUpdates(): void {
   renderer = new TerminalRenderer(renderCols, renderRows);
   let lastSentStatus: string | undefined;
   let lastTextSnapshotHash = '';
+  let lastContent = '';
+  // PTY-activity watermark of the last tick that actually captured. The screen
+  // is derived entirely from pane output, which always reaches us through
+  // onPtyData (it updates lastPtyActivityAtMs and feeds the renderer in the
+  // same place). So when this hasn't advanced, the screen is byte-identical to
+  // lastContent and a capture is pure waste.
+  let lastSnapshotPtyActivity = -1;
   screenUpdateTimer = setInterval(() => {
     if (awaitingFirstPrompt) return;
     let status: RuntimeScreenStatus = isPromptReady ? 'idle' : 'working';
     if (screenAnalyzer?.isAnalyzing) status = 'analyzing';
 
     void (async () => {
-      let content: string;
-      let changed: boolean;
+      let content = lastContent;
+      let changed = false;
 
-      // Preferred path: pipe-pane backends pull a fresh viewport snapshot
-      // from tmux every tick. This eliminates the accumulated-buffer drift
-      // that produced duplicated/staircase text in 'text' display mode.
-      const pipeText = await snapshotToText(backend, renderCols, renderRows, { filter: true });
-      if (pipeText) {
-        content = pipeText.content;
-        const hash = pipeText.ansi;
-        changed = hash !== lastTextSnapshotHash;
-        lastTextSnapshotHash = hash;
-        // Refresh the unfiltered cache that ScreenAnalyzer reads from. Same
-        // tmux call would otherwise need to fire twice per tick.
-        if (changed) {
-          const rawSnap = await snapshotToText(backend, renderCols, renderRows, { filter: false });
-          if (rawSnap) lastAnalyzerSnapshot = rawSnap.content;
+      // Capture only when the pane has emitted output since our last snapshot.
+      // During idle (the steady state for a parked session) this skips a tmux
+      // capture-pane + a throwaway xterm-headless instantiation every tick —
+      // the dominant per-session background cost — while the status-transition
+      // send below still fires off the cached content.
+      const ptyActivity = lastPtyActivityAtMs;
+      if (ptyActivity !== lastSnapshotPtyActivity) {
+        lastSnapshotPtyActivity = ptyActivity;
+        // Preferred path: pipe-pane backends pull a fresh viewport snapshot
+        // from tmux every tick. This eliminates the accumulated-buffer drift
+        // that produced duplicated/staircase text in 'text' display mode.
+        const pipeText = await snapshotToText(backend, renderCols, renderRows, { filter: true });
+        if (pipeText) {
+          content = pipeText.content;
+          const hash = pipeText.ansi;
+          changed = hash !== lastTextSnapshotHash;
+          lastTextSnapshotHash = hash;
+          // Refresh the unfiltered cache that ScreenAnalyzer reads from. Same
+          // tmux call would otherwise need to fire twice per tick.
+          if (changed) {
+            const rawSnap = await snapshotToText(backend, renderCols, renderRows, { filter: false });
+            if (rawSnap) lastAnalyzerSnapshot = rawSnap.content;
+          }
+        } else if (renderer) {
+          const snap = renderer.snapshot();
+          content = snap.content;
+          changed = snap.changed;
+        } else {
+          return;
         }
-      } else if (renderer) {
-        const snap = renderer.snapshot();
-        content = snap.content;
-        changed = snap.changed;
-      } else {
-        return;
+        lastContent = content;
       }
 
       const usageAware = usageLimitTracker.classify(content, status);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -69,7 +69,7 @@ import { tmuxEnv } from './setup/ensure-tmux.js';
 import { IdleDetector } from './utils/idle-detector.js';
 import { ScreenAnalyzer } from './utils/screen-analyzer.js';
 import { captureToPng } from './utils/screenshot-renderer.js';
-import { snapshotToPng, snapshotToText } from './utils/transient-snapshot.js';
+import { snapshotToPng, snapshotToText, shouldCaptureScreen, isScreenSelfDriven } from './utils/transient-snapshot.js';
 import { chooseWebTerminalSeed } from './utils/web-terminal-seed.js';
 import { parseWorkerRequestUrl } from './utils/worker-http.js';
 import { detectCliUsageLimit, usageLimitStateKey, type CliUsageLimitState } from './utils/cli-usage-limit.js';
@@ -2868,10 +2868,12 @@ function startScreenUpdates(): void {
   let lastTextSnapshotHash = '';
   let lastContent = '';
   // PTY-activity watermark of the last tick that actually captured. The screen
-  // is derived entirely from pane output, which always reaches us through
-  // onPtyData (it updates lastPtyActivityAtMs and feeds the renderer in the
-  // same place). So when this hasn't advanced, the screen is byte-identical to
-  // lastContent and a capture is pure waste.
+  // normally reaches us only through onPtyData (it updates lastPtyActivityAtMs
+  // and feeds the renderer in the same place), so when this hasn't advanced the
+  // screen is byte-identical to lastContent and a capture is pure waste.
+  // Exception: an observe backend that paused its emission poller for a live
+  // web-attach (isScreenSelfDriven) keeps changing without bumping the
+  // watermark — there we must capture every tick (see shouldCaptureScreen).
   let lastSnapshotPtyActivity = -1;
   screenUpdateTimer = setInterval(() => {
     if (awaitingFirstPrompt) return;
@@ -2886,9 +2888,15 @@ function startScreenUpdates(): void {
       // During idle (the steady state for a parked session) this skips a tmux
       // capture-pane + a throwaway xterm-headless instantiation every tick —
       // the dominant per-session background cost — while the status-transition
-      // send below still fires off the cached content.
+      // send below still fires off the cached content. The exception is a
+      // self-driven screen (observe backend with a live web-attach): the
+      // watermark can't be trusted there, so capture every tick.
       const ptyActivity = lastPtyActivityAtMs;
-      if (ptyActivity !== lastSnapshotPtyActivity) {
+      if (shouldCaptureScreen({
+        ptyActivity,
+        lastCapturedPtyActivity: lastSnapshotPtyActivity,
+        screenSelfDriven: isScreenSelfDriven(backend),
+      })) {
         lastSnapshotPtyActivity = ptyActivity;
         // Preferred path: pipe-pane backends pull a fresh viewport snapshot
         // from tmux every tick. This eliminates the accumulated-buffer drift

--- a/test/bounded-map.test.ts
+++ b/test/bounded-map.test.ts
@@ -1,0 +1,64 @@
+/**
+ * BoundedMap：容量上限 + 插入序淘汰。验证它在做缓存时不会无限增长，
+ * 同时保持 Map 的语义（get/has/delete、re-set 不增长、re-set 更新值）。
+ * Run:  pnpm vitest run test/bounded-map.test.ts
+ */
+import { describe, it, expect } from 'vitest';
+import { BoundedMap } from '../src/utils/bounded-map.js';
+
+describe('BoundedMap', () => {
+  it('caps entry count and evicts the oldest-inserted key', () => {
+    const m = new BoundedMap<string, number>(3);
+    m.set('a', 1); m.set('b', 2); m.set('c', 3);
+    expect(m.size).toBe(3);
+    m.set('d', 4); // pushes over cap → evicts 'a' (oldest)
+    expect(m.size).toBe(3);
+    expect(m.has('a')).toBe(false);
+    expect([...m.keys()]).toEqual(['b', 'c', 'd']);
+  });
+
+  it('never exceeds the cap no matter how many distinct keys are added', () => {
+    const m = new BoundedMap<number, number>(10);
+    for (let i = 0; i < 10_000; i++) m.set(i, i);
+    expect(m.size).toBe(10);
+    // Only the most-recent 10 keys survive.
+    expect(m.has(9999)).toBe(true);
+    expect(m.has(9990)).toBe(true);
+    expect(m.has(9989)).toBe(false);
+  });
+
+  it('re-setting an existing key updates the value WITHOUT growing or evicting', () => {
+    const m = new BoundedMap<string, number>(2);
+    m.set('a', 1); m.set('b', 2);
+    m.set('a', 99); // existing key → no eviction
+    expect(m.size).toBe(2);
+    expect(m.get('a')).toBe(99);
+    expect(m.has('b')).toBe(true); // 'b' not evicted by the re-set
+  });
+
+  it('honors standard Map operations (get/has/delete) and is an instanceof Map', () => {
+    const m = new BoundedMap<string, string>(5);
+    m.set('k', 'v');
+    expect(m instanceof Map).toBe(true);
+    expect(m.get('k')).toBe('v');
+    expect(m.has('k')).toBe(true);
+    expect(m.delete('k')).toBe(true);
+    expect(m.has('k')).toBe(false);
+    expect(m.get('missing')).toBeUndefined();
+  });
+
+  it('after delete, a freed slot is reusable without evicting survivors', () => {
+    const m = new BoundedMap<string, number>(2);
+    m.set('a', 1); m.set('b', 2);
+    m.delete('a');             // size 1
+    m.set('c', 3);             // back to 2, no eviction needed
+    expect(m.size).toBe(2);
+    expect(m.has('b')).toBe(true);
+    expect(m.has('c')).toBe(true);
+  });
+
+  it('rejects a non-positive cap', () => {
+    expect(() => new BoundedMap<string, number>(0)).toThrow();
+    expect(() => new BoundedMap<string, number>(-1)).toThrow();
+  });
+});

--- a/test/grant-pending.test.ts
+++ b/test/grant-pending.test.ts
@@ -3,7 +3,7 @@
  * Run: pnpm vitest run test/grant-pending.test.ts
  */
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { openPending, checkNonce, clearPending, markDenied, isThrottled, _resetForTest } from '../src/im/lark/grant-pending.js';
+import { openPending, checkNonce, clearPending, markDenied, isThrottled, _resetForTest, _tableSizeForTest } from '../src/im/lark/grant-pending.js';
 
 beforeEach(() => { _resetForTest(); vi.useFakeTimers(); });
 afterEach(() => vi.useRealTimers());
@@ -42,5 +42,44 @@ describe('grant-pending', () => {
     expect(isThrottled('a1', 'oc_1', 'ou_other')).toBe(false);
     expect(isThrottled('a2', 'oc_1', 'ou_g')).toBe(false);
     expect(isThrottled('a1', 'oc_2', 'ou_g')).toBe(false);
+  });
+
+  // ─── 内存回收（防止 denied/废弃 pending 永久占位）────────────────────────
+  describe('eviction (no unbounded growth)', () => {
+    it('isThrottled deletes a denied entry once its cooldown passes (immediate reclaim)', () => {
+      markDenied('a1', 'oc_1', 'ou_x');
+      expect(_tableSizeForTest()).toBe(1);
+      vi.advanceTimersByTime(10 * 60 * 1000 + 1); // past DENY_COOLDOWN_MS
+      expect(isThrottled('a1', 'oc_1', 'ou_x')).toBe(false); // cooldown over…
+      expect(_tableSizeForTest()).toBe(0);                    // …and the entry is gone
+    });
+
+    it('a flood of denied users does not grow the table without bound', () => {
+      // 1000 distinct unauthorized users get denied across the cooldown window.
+      for (let i = 0; i < 1000; i++) markDenied('a1', 'oc_1', `ou_${i}`);
+      expect(_tableSizeForTest()).toBe(1000);
+      // Cooldown elapses; the next write triggers the periodic sweep (>1min gap).
+      vi.advanceTimersByTime(11 * 60 * 1000);
+      markDenied('a1', 'oc_1', 'ou_new'); // triggers pruneStale → reclaims the 1000 stale ones
+      expect(_tableSizeForTest()).toBe(1); // only the fresh denial remains
+    });
+
+    it('the periodic sweep reclaims abandoned pending cards (owner never clicked)', () => {
+      openPending('a1', 'oc_1', 'ou_g');
+      expect(_tableSizeForTest()).toBe(1);
+      vi.advanceTimersByTime(24 * 60 * 60 * 1000 + 1); // past STALE_PENDING_MS
+      openPending('a1', 'oc_2', 'ou_h'); // a new card → triggers the sweep
+      // The abandoned pending was reclaimed; only the fresh one remains.
+      expect(_tableSizeForTest()).toBe(1);
+      expect(isThrottled('a1', 'oc_1', 'ou_g')).toBe(false);
+    });
+
+    it('a still-fresh pending is NOT reclaimed by the sweep', () => {
+      const n = openPending('a1', 'oc_1', 'ou_g');
+      vi.advanceTimersByTime(2 * 60 * 1000); // 2 min — well within STALE_PENDING_MS
+      openPending('a1', 'oc_2', 'ou_h');     // triggers a sweep
+      expect(isThrottled('a1', 'oc_1', 'ou_g')).toBe(true); // still throttled
+      expect(checkNonce('a1', 'oc_1', 'ou_g', n)).toBe(true); // nonce still valid
+    });
   });
 });

--- a/test/screen-capture-decision.test.ts
+++ b/test/screen-capture-decision.test.ts
@@ -1,0 +1,62 @@
+/**
+ * startScreenUpdates' per-tick capture gate. The idle optimization skips the
+ * tmux/dump-screen capture when the PTY-activity watermark hasn't advanced —
+ * EXCEPT when the screen is "self-driven" (an observe backend that paused its
+ * change-emission poller for a live web-attach), where the watermark goes stale
+ * and we must capture every tick. Regression guard for the zellij-attach case
+ * Codex caught.
+ * Run:  pnpm vitest run test/screen-capture-decision.test.ts
+ */
+import { describe, it, expect } from 'vitest';
+import { shouldCaptureScreen, isScreenSelfDriven } from '../src/utils/transient-snapshot.js';
+
+describe('shouldCaptureScreen', () => {
+  it('captures when the activity watermark advanced', () => {
+    expect(shouldCaptureScreen({ ptyActivity: 5, lastCapturedPtyActivity: 4, screenSelfDriven: false })).toBe(true);
+  });
+
+  it('skips when the watermark is unchanged and the screen is not self-driven (the idle optimization)', () => {
+    expect(shouldCaptureScreen({ ptyActivity: 4, lastCapturedPtyActivity: 4, screenSelfDriven: false })).toBe(false);
+  });
+
+  it('captures despite an unchanged watermark when the screen is self-driven (live-attach regression fix)', () => {
+    // The zellij live-attach window: poller paused → watermark frozen → but the
+    // pane is still changing. Must capture or the Feishu card / ScreenAnalyzer
+    // / status freeze on a stale screen until detach.
+    expect(shouldCaptureScreen({ ptyActivity: 4, lastCapturedPtyActivity: 4, screenSelfDriven: true })).toBe(true);
+  });
+
+  it('captures when both signals fire', () => {
+    expect(shouldCaptureScreen({ ptyActivity: 9, lastCapturedPtyActivity: 4, screenSelfDriven: true })).toBe(true);
+  });
+});
+
+describe('isScreenSelfDriven', () => {
+  const observeBase = {
+    captureViewport: () => '',
+    getPaneSize: () => null,
+    captureCurrentScreen: () => '',
+    isPaneAlive: () => true,
+  };
+
+  it('is false for a non-observe backend', () => {
+    expect(isScreenSelfDriven(undefined)).toBe(false);
+    expect(isScreenSelfDriven({})).toBe(false);
+    expect(isScreenSelfDriven({ onData() {} })).toBe(false);
+  });
+
+  it('is false for an observe backend that never pauses emission (no isLiveAttachActive)', () => {
+    // e.g. TmuxPipeBackend / herdr — their poller keeps emitting, watermark stays sound.
+    expect(isScreenSelfDriven({ ...observeBase })).toBe(false);
+  });
+
+  it('tracks isLiveAttachActive() for a zellij-style observe backend', () => {
+    let attached = false;
+    const be = { ...observeBase, isLiveAttachActive: () => attached };
+    expect(isScreenSelfDriven(be)).toBe(false); // no live attach → watermark trusted
+    attached = true;
+    expect(isScreenSelfDriven(be)).toBe(true);  // live attach → must self-capture
+    attached = false;
+    expect(isScreenSelfDriven(be)).toBe(false); // detached → optimization resumes
+  });
+});

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -7,7 +7,7 @@
  * Run:  pnpm vitest run test/session-store.test.ts
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync, statSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -285,6 +285,29 @@ describe('updateSession()', () => {
     init();
     const reloaded = getSession(session.sessionId);
     expect(reloaded!.webPort).toBe(9999);
+  });
+
+  it('skips the disk write when an update produces byte-identical content', () => {
+    // save() does writeFile(tmp) + rename(tmp → fp), so every REAL write
+    // replaces the file's inode. A skipped write leaves the inode untouched.
+    const fp = join(tempDir, 'sessions.json');
+    const session = createSession('chat1', 'root1', 'NoChange');
+    const inodeAfterCreate = statSync(fp).ino;
+
+    // A redundant update with no field change → must be skipped (inode stable).
+    updateSession(session);
+    expect(statSync(fp).ino).toBe(inodeAfterCreate);
+    updateSession(session); // and again — still no write
+    expect(statSync(fp).ino).toBe(inodeAfterCreate);
+
+    // A real change → the file is rewritten (inode changes).
+    session.title = 'Changed';
+    updateSession(session);
+    expect(statSync(fp).ino).not.toBe(inodeAfterCreate);
+
+    // Content is still correct after the skip/write sequence.
+    init();
+    expect(getSession(session.sessionId)!.title).toBe('Changed');
   });
 
   it('should allow adding a new session via updateSession', () => {


### PR DESCRIPTION
## 背景
针对 daemon 长跑场景做的一批性能/资源占用修复：消除几处随时间无限增长的内存表、削减每条消息的冗余写盘、以及空闲会话每 2 秒一次的无效屏幕快照。完整说明见 `docs/resource-optimization.md`。

## 改动（逐项机制）
**A. 内存：无界 → 封顶/可回收**
- `grant-pending`：授权状态表此前永不回收（注释已自承认）。加 TTL 回收——`isThrottled` 冷却到期即时删；写路径每分钟全表清扫废弃 denied/pending。
- `worker-pool`：`closeSession` 删除 `restartCounts` 条目。
- `daemon` `lastRepoScan`、`client`/`event-dispatcher` 三处 chat 缓存：改用新增的 `BoundedMap`（容量封顶、插入序淘汰），TTL 管新鲜度、cap 管条数。

**B. 磁盘：相同内容不写**
- `session-store.save()` 每条消息被调多次，很多次序列化后与磁盘逐字节相同却照样 write+rename。改为读盘原文比对，相同则直接 return。零风险（写相同字节本是 no-op，且比的是磁盘当前内容）。

**C. CPU：空闲会话不再每 2s 白截屏**
- worker 屏幕刷新定时器原本无条件每 2s 跑一次 tmux capture + 新建/销毁 xterm-headless。改为：自上次快照以来 PTY 无新输出则跳过整个 capture（屏幕只由 `onPtyData` 驱动，是可靠水位）；状态切换仍用缓存内容照发。

## 怎么验证「改得对」
- 新增/补强单测 54 个：`test/bounded-map.test.ts`、`test/grant-pending.test.ts`、`test/session-store.test.ts`。
- **变异测试**：临时改坏三处修复，5 个用例立即变红，改回全绿——证明断言并非恒真。
- 全量单测 3920 passed；12 个 failed 均为改动前既有（已在干净 baseline 上确认一致：seed-adapter/claude-code-cwd 的 macOS 软链问题、card-integration 的 `sessionReply` 既有问题）。

## 怎么验证「真省资源」
`pnpm bench:resource`（脚本 `scripts/bench-resource.ts`），同进程构造 before/after 等价路径对比。本地实测：
| 口径 | 修复前 | 修复后 |
|---|---|---|
| A 内存（20 万不同 key） | 200,000 条 / +25.31 MB（永不回收） | 1,000 条 / +154.6 KB（约 168×，封顶） |
| B 磁盘（200 会话、2000 次冗余 save） | 1959 ms / 2000 次写盘 | 657 ms / **0 次写**（3.0×） |
| C CPU（每空闲会话） | 30 次/分 × 1.44ms = 43 ms/分 | PTY 静默时 0（100 会话省 4.3 s/分，下限） |

边界：均为受控微基准+建模，非端到端 profiling；B 为单次冗余 save 口径；A/C 随规模放大。

## 未改动（建议后续）
- Claude bridge 每秒 `/proc/<pid>/fd` 扫描（Linux adopt）可节流；event-dispatcher 每消息重复 `JSON.parse` 可 memoize；session-store 彻底批写需带崩溃安全机制。

🤖 Generated with [Claude Code](https://claude.com/claude-code)