### PR TITLE
v3 workflow: 跨节点 revisit + instance 重建

### DIFF
--- a/docs/design/2026-06-08-v3-human-ask-freetext-and-revisit.md
+++ b/docs/design/2026-06-08-v3-human-ask-freetext-and-revisit.md
@@ -1,0 +1,163 @@
+# v3 HITL 自由文本 human-ask + 跨节点 revisit feedback 设计
+
+- 日期：2026-06-08
+- 状态：设计稿（claude × 菲菲公主 收敛，王皓已拍板转增量），待实现
+- 关联：
+  - `67742d8 feat(workflow): v3 goal-mode 运行时 human-ask（骑 blocked+retry 轨）` —— 本设计的**实现基线**
+  - `docs/design/2026-06-03-v3-blocked-resultschema-design.md`（blocked/retry 轨）
+  - `docs/design/2026-06-06-v3-structured-loop-design.md`（loop / feedback / 有界回溯）
+
+## 0. 一句话
+
+`67742d8` 已经把 HITL 的 MVP 实现了（goal worker 写 `ask.json`+`ASK_HUMAN` fail manifest → blocked → 飞书选项卡 → `answer.json` + `nodeRetryRequested.answer` → `buildInputs` 注入 `human/answer` → 重跑）。本设计**不重造**，只做两个增量：
+
+- **增量 1**：human-ask 从「2–6 选项按钮」扩到**自由文本答案**（补 PRD/计费规则这类填空场景）。
+- **增量 2**：**跨节点 revisit feedback** —— 下游回溯上游时，把「为什么回 + 哪里错 + 你上次写了啥」注入给上游目标节点；加 revisit 预算安全闸。
+
+两者复用同一根 rail：**事件钉指针路径 → `buildInputs` 读事件注入 → 目标节点 goal.txt 强制消费**。
+
+---
+
+## 1. 实现基线（`67742d8` 现状，代码事实）
+
+| 关注点 | 现状 | 文件 |
+|---|---|---|
+| ask 协议 | `GoalAsk{question, options[2..6]}` / `GoalAnswer{selected, by}` | `contract.ts` |
+| 触发 | worker 写 `ask.json`(`GOAL_ASK_FILE`) + `error.code=ASK_HUMAN`(`ASK_HUMAN_ERROR_CODE`) fail manifest，正常退出 | `contract.ts` / goal 侧 |
+| 判定 | `classifyTerminal` 自报 fail+retryable → **blocked** | `runtime.ts` |
+| 事件 | `nodeBlocked.ask = {question, options}` | `journal.ts` |
+| 答案 | daemon 写 `answer.json`(`GOAL_ANSWER_FILE`) 于受阻 attempt 旁；`nodeRetryRequested.answer = {path, preview, by}` 指针 | `daemon-run.ts` `requestV3Retry` |
+| 注入 | `buildInputs` 读 `answer.path` → 注入 `from:"human"`、`name:"answer"` | `runtime.ts` |
+| 卡片 | `v3-blocked-card` 三态（受阻/拍板/已答）+ handler | `im/lark/v3-blocked-card*.ts` |
+| adapter | goal-mode(`BOTMUX_V3_GOAL=1`) 禁原生 `AskUserQuestion`；`botmux-goal-ask` skill 教 agent 怎么问 | `adapters/cli/claude-code.ts` / `skills/definitions.ts` |
+| 写序 | `writeFileSync(answer.json)` **在** `appendEvent(nodeRetryRequested)` **之前**（崩溃安全）；但是 **plain 写，非原子** | `daemon-run.ts` |
+
+**局限（commit 自陈）**：单问题 + 选项按钮，未上多选 / 自由文本；revisit 完全未碰。
+
+---
+
+## 2. 增量 1：自由文本 human-ask
+
+### 2.1 协议扩展（`contract.ts`）
+`GoalAsk` 支持两种形态（二选一）：
+```jsonc
+// 选择题（现状，保留）
+{ "question": "...", "options": ["A", "B"] }
+// 填空题（新增）
+{ "question": "...", "freeText": true }
+```
+`GoalAnswer` 对应二选一：
+```jsonc
+{ "selected": "A", "by": "ou_xxx" }      // 选择题
+{ "text": "用户填写的内容", "by": "ou_xxx" } // 填空题
+```
+- 校验：`options` 与 `freeText` **互斥且必居其一**；`freeText:true` 时不得带 `options`。
+- `readGoalAsk()`：识别 `freeText`，不再把「无 options」降级成普通 blocked 卡。
+
+### 2.2 卡片（`v3-blocked-card` + handler）
+- ask 卡新增**输入框形态**（`freeText` 时渲染文本输入 + 「提交」按钮；`options` 时维持按钮）。
+- handler：`freeText` 提交 → `GoalAnswer.text`；选项点击 → `GoalAnswer.selected`。
+- 三态不变（受阻/拍板/已答），「已答」冻结卡展示用户填的文本预览（限长）。
+
+### 2.3 答案落盘（`daemon-run.ts` `requestV3Retry`）
+- `input.answer` 扩成 `{ selected?: string; text?: string; by: string }`。
+- **`answer.json` 改原子写（tmp + rename）**——硬要求，非优化。自由文本更长更易写到一半崩；对齐 `human-gate.ts` 既有的 `atomicWriteJson`。
+- 写序不变：**先原子写 `answer.json`，再 append `nodeRetryRequested.answer`**。
+
+### 2.4 注入 + 消费
+- `buildInputs` 注入逻辑不变（读 `answer.path` → `from:"human"`/`name:"answer"`），文本/选项都走同一路径。
+- `renderGoalFile` 的「Asking a human」段不变；agent 读 `human/answer` 拿决策续跑。
+
+### 2.5 skill 文案（`botmux-goal-ask`）
+- **必须同步改**：不能再写「只能 2–6 个选项」。新增：当答案无法用有限选项穷举（要用户补一段内容/规则/细节）时，用 `freeText:true`。给出选择题 vs 填空题的判据与示例。
+
+### 2.6 不变量
+- 写序：answer 先落盘、event 后写。
+- 自由文本预览限长（卡片 + 投影），不外泄绝对路径/token。
+
+---
+
+## 3. 增量 2：跨节点 revisit feedback
+
+### 3.1 现状缺口（代码事实）
+现在 revisit 链路：节点 `result.json` 写 `status:revisit + revisitTo + reason` → `nodeRevisitRequested{toNodeId, reason}` → `affectedNodesFrom(toNodeId)` 把目标及下游标 `nodeInstanceSuperseded` → 目标新 instance 重跑。
+**缺口**：`reason` 只进事件、从不注入；触发回溯的下游产出、目标自己旧产出都没带给目标的新 instance —— **上游瞎重跑**。
+
+### 3.2 事件扩展（`journal.ts` `nodeRevisitRequested`）
+在触发回溯那一刻钉死三个**快照路径（runDir 相对）**：
+```jsonc
+{
+  "type": "nodeRevisitRequested",
+  "nodeId": "review", "instanceId": "review#001", "attemptId": "review#001/attempts/001",
+  "toNodeId": "prd",
+  "reason": "PRD 缺少计费边界规则",
+  "reasonPath": "revisits/review#001-attempt-001/reason.md",
+  "sourceManifestPath": "review#001/attempts/001/manifest.json",
+  "targetPreviousManifestPath": "prd#001/attempts/001/manifest.json"
+}
+```
+- `reasonPath`：runtime 把 reason 落成 `reason.md`（reason 可能长，统一文件化）。
+- `sourceManifestPath`：触发回溯节点（C）当时的 manifest 快照。
+- `targetPreviousManifestPath`：回溯目标（A）当前 effective instance 的上一份**成功** manifest。
+- v1 用 **manifest 快照模型**（不在事件里 stamp 选中的 file entries）；attempts 不可变 → manifestPath 是冻结指针，replay 确定。选择性 feedback 留后续（届时需 stamp「选择」决策）。
+
+### 3.3 注入分两档（`runtime.ts` `buildInputs`）
+调度**回溯目标 A 的新 instance** 时，新增 `from:"revisit"` 输入，注入**三件套**：
+1. `revisit-reason` ← `reasonPath`
+2. C 的产出 ← `sourceManifestPath` 的 manifest files
+3. A 自己旧产出 ← `targetPreviousManifestPath` 的 manifest files
+
+调度**中间被刷新节点**（target 与 C 之间）时：**只注入 `revisit-reason`**（它们要的是修正后的上游输入，不是完整反馈）。reason 全 cone 是低成本「指错靶」保险。
+
+> 缺 A 旧产出，A 只会**重写**而非**在旧版上改** —— 三件套缺一不可。
+
+### 3.4 强制消费（`runtime.ts` `renderGoalFile`）
+target 的 goal.txt 追加硬指令：
+> 这是一次由下游节点请求的回溯重跑。继续前必须先读 `from=revisit` 的 reason、source output、previous target output，并基于反馈修正当前节点产物。
+
+非 target 的刷新节点：轻量说明「因上游回溯被刷新，可读 `revisit-reason` 了解背景，主要依据最新上游输入继续」。
+
+### 3.5 安全闸：revisit 预算（两级）
+1. **per `source→target` pair，默认 1 次**：主信号，blocked 时精确定位哪条边 ping-pong。`C→A` 与 `C→B` 是**独立计数器**。
+2. **per-run 全局上限，默认 8**：总闸，防多目标横跳 / 多节点齐回溯把成本拖垮。
+- 任一耗尽 → **run blocked**（不是某 attempt） → 发**预算耗尽卡**，人工 grant：补某条 pair +1，或抬全局上限。
+- grant 卡复用 `loopIterationGranted` / blocked-retry 的 **expected 守卫**（带 expected pair + 当前计数 / 全局计数 + nonce），防过期卡 / 重复点击多放预算。
+- 计数从 journal 的 `nodeRevisitRequested` 事件算（确定、可重放），不靠内存。
+
+### 3.6 不变量
+- `supersede` 只写 `nodeInstanceSuperseded` 标记，**永不删**旧 instance / 旧 attempt 文件（否则钉住的快照悬空）。
+- 事件路径一律 runDir 相对；注入 `inputs.json` 时才转绝对；投影 / 卡片不泄露绝对路径 / token。
+- revisit 仍是 DAG 外的运行时回跳，定义图永不成环。
+
+### 3.7 和 loop 的边界
+loop = 预先已知的局部反复（implement→test→fix），有 `maxIterations`，可视化好；revisit = 运行中才发现的不规则跨层回跳。**预期多轮打磨的固定链路用 loop，不要用 revisit。** 两者共享「feedback 注入 + 有界预算」的思路，不平行造轮子。
+
+---
+
+## 4. 改动文件清单 + 分工
+
+| 文件 | 增量 1（自由文本 ask） | 增量 2（revisit feedback） |
+|---|---|---|
+| `contract.ts` | GoalAsk.freeText / GoalAnswer.text + 互斥校验 | （revisit 输入 label 常量，如需） |
+| `journal.ts` | — | nodeRevisitRequested +reasonPath/sourceManifestPath/targetPreviousManifestPath |
+| `runtime.ts` | readGoalAsk 识别 freeText；buildInputs 注入不变 | appendRevisitEvents 钉三路径 + 落 reason.md；buildInputs 加 `from:"revisit"` 注入；renderGoalFile revisit 段；预算计数 |
+| `daemon-run.ts` | requestV3Retry 收 text + **answer.json 原子写** | 预算耗尽 → 发 grant 卡；requestRevisitGrant 入口 |
+| `im/lark/v3-blocked-card*.ts` | ask 卡输入框形态 + handler text | revisit 预算 grant 卡 + handler（复用 expected 守卫） |
+| `skills/definitions.ts` | botmux-goal-ask 文案改（允许 freeText） | — |
+| `dag.ts` | — | revisit 预算默认值常量 / 校验（如需） |
+
+**建议分工**（待与菲菲公主敲定）：
+- **增量 1（自由文本 human-ask）** —— 内聚在「ask 协议 + 卡片 + skill + answer 落盘」，contract/card/handler/skill/daemon-run.requestV3Retry。
+- **增量 2（revisit feedback + 预算）** —— 内聚在「journal 事件 + buildInputs 注入 + supersede 快照 + 预算/grant」，journal/runtime/daemon-run grant/grant 卡。
+- **共享文件防冲突**：两者都动 `runtime.ts`(buildInputs) 和 `v3-blocked-card`——各自加**独立的 `from:` 分支 / 独立卡类型**，函数级隔离，不改对方分支。接口若要改先群里吱一声。
+
+## 5. 测试计划
+- 增量 1：freeText ask → blocked 卡渲染输入框；提交 text → answer.json 原子落盘 + 事件指针；buildInputs 注入 `human/answer` 文本；skill 文案回归；options 形态不回归。
+- 增量 2：`nodeRevisitRequested` 三路径 stamp；target 新 instance 注入三件套、中间节点只拿 reason；renderGoalFile revisit 段；per-pair 耗尽 → blocked + grant 卡；per-run 全局耗尽 → blocked；grant expected 守卫挡过期卡；supersede 不删文件（快照可读）；路径 runDir 相对、投影不漏绝对路径。
+
+## 6. 明确不做（防 scope 蔓延）
+- 批量多问题 / 一次 blocked 问多个。
+- 多轮滚动 block-context（自由文本 ask 的多轮累积语义，先按现有单 answer 注入）。
+- confirm_required（产出候选→求确认→候选回灌）。
+- revisit 选择性 feedback（下游点名带哪几个文件）。
+- 路径约定收敛（human-ask 的 answer.path 绝对 vs revisit 相对）—— 记 tech-debt，本轮不回改 human-ask。

--- a/docs/runbook-v3-revisit-real-cli-smoke.md
+++ b/docs/runbook-v3-revisit-real-cli-smoke.md
@@ -1,0 +1,32 @@
+# Runbook — v3 跨节点 revisit 真机 (真 daemon + 真 CLI) smoke
+
+自动化测试覆盖到哪、为什么真 CLI 这步是手动的，以及怎么手动跑一次。
+
+## 自动化已覆盖（CI 安全、确定性）
+
+| 层 | 测试 | 覆盖 |
+|---|---|---|
+| 引擎/编排 | `v3-runtime` | revisit 识别 → supersede cone → 重生 #002 → A→B→C 端到端 → feedback 三件套 → buildInputs 抗旧实例迟到 → 两级预算 |
+| daemon | `v3-revisit-e2e` | **真 `driveV3Run`** + 真 manifest 校验 (`readAndValidateManifest`) + grill 出生/bots 解析 + revisit→预算耗尽→`postRevisitGrantCard`→`requestRevisitGrant` 原子 grant+retry→收敛成功 |
+| daemon | `v3-daemon-run` | requestRevisitGrant 守卫 (partial-pair / pair-source-mismatch / stale-attempt / 幂等)、gate stale-card、recovery |
+| 飞书卡 | `v3-revisit-grant-card` | grant 卡构建 + handler 点击 grant+retry/stale/权限 |
+
+**注入的是脚本化 worker（不 spawn 真 CLI）**：真 CLI 是否回溯取决于模型决策，不可作确定性断言；且本机无 swap，长 Claude Code 会话有 OOM 史（见 ai-workspace 记忆），不宜在 CI 里 spawn。
+
+## 真 CLI smoke（手动，跑一次确认 worker→goal.txt→result.json→runtime 链路）
+
+前置：`claude` 已登录（`claude --version` 能跑）；开发机内存够（`free -g` 看 available，长跑前先 `atop` 备查）。
+
+1. 起一个带 `revisitTo` 的最小 dag（A→C，C 可回溯 A），通过正常 grill 流程出生 run（或直接喂 dag.json + grill state）。
+2. C 的 goal 里明确写“如果上游 A 的产出缺少 X，请用 revisit 退回 A”——让模型有明确触发条件，再把 A 的产出做成缺 X。
+3. 起 daemon，`driveV3Run`（或走飞书话题触发）。观察 journal：
+   - `nodeRevisitRequested{nodeId:C, toNodeId:A}`
+   - `nodeInstanceSuperseded`（A/C 的 #001）
+   - A#002/C#002 重新 dispatch
+   - C#002 的 `inputs.json` 含 `from:"revisit"` 三件套（reason/source/previous）
+4. 连续回溯到 per-pair=1 耗尽 → 飞书应弹 **revisit grant 卡**（橙，标 `C → A` / per-pair）。点「准许回溯 +1」→ 卡转绿冻结 + C 重跑。
+5. 让 C 这次满足 → run `succeeded`。
+
+排查：
+- 没弹卡 → 看 daemon 日志 `postRevisitGrantCard`；确认 run 真的 `blocked` 且 `nodeBlocked.errorCode=REVISIT_BUDGET_EXHAUSTED`。
+- 点卡无反应 → 看 card-handler 是否注册 `v3RevisitGrantDeps`（daemon.ts）+ nonce 是否过期（回溯后旧卡按 attemptId 失效，看最新那张）。

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -101,6 +101,7 @@ import { createV3GateRunner, requestV3Retry, requestV3LoopGrant } from './workfl
 import { buildV3GateCard } from './im/lark/v3-gate-card.js';
 import { buildV3BlockedCard } from './im/lark/v3-blocked-card.js';
 import { buildV3LoopGrantCard } from './im/lark/v3-loop-grant-card.js';
+import { buildV3RevisitGrantCard } from './im/lark/v3-revisit-grant-card.js';
 import { isValidRunId as isValidV3RunId } from './workflows/v3/ops-projection.js';
 import { readRunChatBinding as readV3RunChatBinding, defaultBaseDir as v3DefaultBaseDir } from './workflows/v3/grill-state.js';
 
@@ -1576,6 +1577,21 @@ const v3GateRunner = createV3GateRunner({
       await sendMessage(binding.larkAppId, binding.chatId, card, 'interactive');
     }
   },
+  postRevisitGrantCard: async (binding, info, runId) => {
+    const card = buildV3RevisitGrantCard({
+      runId,
+      sourceNodeId: info.sourceNodeId,
+      toNodeId: info.toNodeId,
+      tier: info.tier,
+      attemptId: info.attemptId,
+      detail: info.detail,
+    });
+    if (binding.rootMessageId) {
+      await sessionReply(binding.rootMessageId, card, 'interactive', binding.larkAppId);
+    } else {
+      await sendMessage(binding.larkAppId, binding.chatId, card, 'interactive');
+    }
+  },
   notifyTerminal: async (binding, runId, outcome) => {
     if (!binding?.rootMessageId) return;
     const msg = outcome.runStatus === 'succeeded'
@@ -1613,6 +1629,11 @@ const cardDeps: CardHandlerDeps = {
       binding ? canOperate(binding.larkAppId, binding.chatId, operatorOpenId) : false,
   },
   v3LoopGrantDeps: {
+    driveRun: (runId) => v3GateRunner.driveDetached(runId),
+    canResolve: (binding, operatorOpenId) =>
+      binding ? canOperate(binding.larkAppId, binding.chatId, operatorOpenId) : false,
+  },
+  v3RevisitGrantDeps: {
     driveRun: (runId) => v3GateRunner.driveDetached(runId),
     canResolve: (binding, operatorOpenId) =>
       binding ? canOperate(binding.larkAppId, binding.chatId, operatorOpenId) : false,

--- a/src/dashboard/web/v3.ts
+++ b/src/dashboard/web/v3.ts
@@ -30,6 +30,7 @@ const NODE_LABEL: Record<RunNodeView['status'], string> = {
   skipped: '已跳过', // edge-activation: 分支未选中的中性终态（非失败）
   cancelled: '已取消', // early-release loser：已无关并被收尸的中性终态
   blocked: '受阻',
+  superseded: '已刷新', // 跨节点回溯把该 instance 刷新了，节点会重跑出新 instance
   failed: '失败',
 };
 const DECISION_LABEL: Record<string, string> = {

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -606,7 +606,12 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
   }
   if (isV3BlockedAction(value?.action)) {
     if (!deps.v3BlockedDeps) return;
-    return await handleV3BlockedAction(value as unknown as V3BlockedActionValue | V3AskAnswerActionValue, operatorOpenId, deps.v3BlockedDeps);
+    return await handleV3BlockedAction(
+      value as unknown as V3BlockedActionValue | V3AskAnswerActionValue,
+      operatorOpenId,
+      deps.v3BlockedDeps,
+      action?.form_value,
+    );
   }
   if (isV3LoopGrantAction(value?.action)) {
     if (!deps.v3LoopGrantDeps) return;

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -38,6 +38,12 @@ import {
   type V3LoopGrantCardHandlerDeps,
 } from './v3-loop-grant-card-handler.js';
 import type { V3LoopGrantActionValue } from './v3-loop-grant-card.js';
+import {
+  handleV3RevisitGrantAction,
+  isV3RevisitGrantAction,
+  type V3RevisitGrantCardHandlerDeps,
+} from './v3-revisit-grant-card-handler.js';
+import type { V3RevisitGrantActionValue } from './v3-revisit-grant-card.js';
 import { handleAskCardAction, isAskCardAction } from './ask-card.js';
 import { createCliAdapterSync } from '../../adapters/cli/registry.js';
 import { logger } from '../../utils/logger.js';
@@ -67,6 +73,8 @@ export interface CardHandlerDeps {
   v3BlockedDeps?: V3BlockedCardHandlerDeps;
   /** v3 loop 追加一轮卡点击处理（同一个 runner 的 driveRun）. */
   v3LoopGrantDeps?: V3LoopGrantCardHandlerDeps;
+  /** v3 回溯预算准许卡点击处理（同一个 runner 的 driveRun）. */
+  v3RevisitGrantDeps?: V3RevisitGrantCardHandlerDeps;
 }
 
 interface CardActionData {
@@ -612,6 +620,10 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       deps.v3BlockedDeps,
       action?.form_value,
     );
+  }
+  if (isV3RevisitGrantAction(value?.action)) {
+    if (!deps.v3RevisitGrantDeps) return;
+    return await handleV3RevisitGrantAction(value as unknown as V3RevisitGrantActionValue, operatorOpenId, deps.v3RevisitGrantDeps);
   }
   if (isV3LoopGrantAction(value?.action)) {
     if (!deps.v3LoopGrantDeps) return;

--- a/src/im/lark/v3-blocked-card-handler.ts
+++ b/src/im/lark/v3-blocked-card-handler.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path';
 import {
   V3_BLOCKED_RETRY_ACTION,
   V3_BLOCKED_ASK_ANSWER_ACTION,
+  V3_BLOCKED_ASK_TEXT_FIELD,
   buildV3BlockedCard,
   v3BlockedCardNonce,
   type V3BlockedActionValue,
@@ -27,6 +28,12 @@ import { isValidRunId } from '../../workflows/v3/ops-projection.js';
 
 export function isV3BlockedAction(action: unknown): boolean {
   return action === V3_BLOCKED_RETRY_ACTION || action === V3_BLOCKED_ASK_ANSWER_ACTION;
+}
+
+function isV3AskAnswerValue(
+  value: V3BlockedActionValue | V3AskAnswerActionValue,
+): value is V3AskAnswerActionValue {
+  return value.action === V3_BLOCKED_ASK_ANSWER_ACTION;
 }
 
 export interface V3BlockedCardHandlerDeps {
@@ -48,10 +55,11 @@ export async function handleV3BlockedAction(
   value: V3BlockedActionValue | V3AskAnswerActionValue,
   operatorOpenId: string | undefined,
   deps: V3BlockedCardHandlerDeps,
+  formValue?: Record<string, string>,
 ): Promise<unknown> {
   // 同一张卡两条 action：普通重试 / human-ask 选项答题。后者额外带 selected，
   // 走同一条 requestV3Retry 通道（带 answer），只是冻结卡渲染不同。
-  const isAsk = value.action === V3_BLOCKED_ASK_ANSWER_ACTION;
+  const isAsk = isV3AskAnswerValue(value);
   const verb = isAsk ? '回答' : '重试';
   const baseDir = deps.baseDir ?? defaultBaseDir();
   if (!isValidRunId(value.runId)) {
@@ -71,16 +79,34 @@ export async function handleV3BlockedAction(
 
   const requestRetry = deps.requestRetry ?? requestV3Retry;
   let outcome;
+  let answer:
+    | { selected: string; by: string }
+    | { text: string; by: string }
+    | undefined;
   try {
+    const textAnswer =
+      isAsk && 'answerKind' in value && value.answerKind === 'text'
+        ? (formValue?.[V3_BLOCKED_ASK_TEXT_FIELD] ?? '').trim()
+        : undefined;
+    if (isAsk && 'answerKind' in value && value.answerKind === 'text' && !textAnswer) {
+      return { toast: { type: 'warning', content: '请先填写答案' } };
+    }
+    if (isAsk) {
+      if (textAnswer !== undefined) {
+        answer = { text: textAnswer, by: operatorOpenId ?? 'unknown' };
+      } else if ('selected' in value) {
+        answer = { selected: value.selected, by: operatorOpenId ?? 'unknown' };
+      } else {
+        return { toast: { type: 'warning', content: '这张卡已失效（答案类型不匹配）' } };
+      }
+    }
     // expectedAttemptId（codex blocker）：nonce 只证明这张卡自身没被改，证不了
     // 它指向的 attempt 还是"当前 blocked 的那个"——core 必须再比一次，否则
     // 001 的旧卡能把 002 的 blocked 推进到 003。
     outcome = requestRetry(baseDir, value.runId, {
       nodeId: value.nodeId,
       expectedAttemptId: value.attemptId,
-      ...(isAsk
-        ? { answer: { selected: value.selected, by: operatorOpenId ?? 'unknown' } }
-        : {}),
+      ...(answer ? { answer } : {}),
     });
   } catch (err) {
     return {
@@ -122,7 +148,9 @@ export async function handleV3BlockedAction(
         // 带上 ask 仅为在冻结卡里复现问题文案（answered 优先于 options 渲染）。
         ask: info.ask,
         answered: {
-          selected: (value as V3AskAnswerActionValue).selected,
+          ...(answer && 'text' in answer
+            ? { text: answer.text }
+            : { selected: answer?.selected ?? '' }),
           nextAttemptId: outcome.nextAttemptId,
           by: operatorOpenId,
         },

--- a/src/im/lark/v3-blocked-card.ts
+++ b/src/im/lark/v3-blocked-card.ts
@@ -13,6 +13,7 @@ import { config } from '../../config.js';
 export const V3_BLOCKED_RETRY_ACTION = 'v3_blocked_retry';
 /** 运行时 human-ask 选项按钮的 action（与「重试」同卡不同 namespace）。 */
 export const V3_BLOCKED_ASK_ANSWER_ACTION = 'v3_blocked_ask_answer';
+export const V3_BLOCKED_ASK_TEXT_FIELD = 'v3_blocked_ask_text';
 
 /** card 按钮回传的 value 形态——v3-blocked-card-handler 据此解析。 */
 export interface V3BlockedActionValue {
@@ -24,16 +25,26 @@ export interface V3BlockedActionValue {
   nonce: string;
 }
 
-/** ask 选项按钮回传的 value —— 人选的选项 + 受阻 attempt（freshness）。 */
-export interface V3AskAnswerActionValue {
-  action: typeof V3_BLOCKED_ASK_ANSWER_ACTION;
-  runId: string;
-  nodeId: string;
-  attemptId: string;
-  /** 选中的选项文本（= GoalAsk.options 之一），落库为 answer.selected。 */
-  selected: string;
-  nonce: string;
-}
+/** ask 回传的 value —— 人的答案 + 受阻 attempt（freshness）。 */
+export type V3AskAnswerActionValue =
+  | {
+      action: typeof V3_BLOCKED_ASK_ANSWER_ACTION;
+      runId: string;
+      nodeId: string;
+      attemptId: string;
+      /** 选中的选项文本（= GoalAsk.options 之一），落库为 answer.selected。 */
+      selected: string;
+      nonce: string;
+    }
+  | {
+      action: typeof V3_BLOCKED_ASK_ANSWER_ACTION;
+      runId: string;
+      nodeId: string;
+      attemptId: string;
+      /** 自由文本答案走 form_value[V3_BLOCKED_ASK_TEXT_FIELD]，不塞进 button value。 */
+      answerKind: 'text';
+      nonce: string;
+    };
 
 export interface V3BlockedCardInput {
   runId: string;
@@ -48,10 +59,10 @@ export interface V3BlockedCardInput {
   messageMaxChars?: number;
   /** 有值 → 渲染冻结的「已重试」卡（无按钮，防 stale UI 重复提交）。 */
   retried?: { nextAttemptId: string; by?: string };
-  /** 运行时 human-ask：agent 的问题 + 选项 → 渲染选项按钮卡（替代重试按钮）。 */
-  ask?: { question: string; options: string[] };
+  /** 运行时 human-ask：agent 的问题 → 渲染选项按钮或自由文本输入卡。 */
+  ask?: { question: string; options?: string[]; freeText?: boolean };
   /** 有值 → 渲染冻结的「已回答」卡（ask 专用，无按钮）。 */
-  answered?: { selected: string; nextAttemptId: string; by?: string };
+  answered?: { selected?: string; text?: string; nextAttemptId: string; by?: string };
 }
 
 const DEFAULT_MESSAGE_MAX_CHARS = 500;
@@ -102,22 +113,50 @@ export function buildV3BlockedCard(input: V3BlockedCardInput): string {
       });
     }
     if (answered) {
+      const answerPreview = answered.text ?? answered.selected ?? '';
       elements.push({ tag: 'hr' });
       elements.push({
         tag: 'div',
         text: {
           tag: 'lark_md',
           content:
-            `✅ 已选择 → **${escapeMd(answered.selected)}**` +
+            `✅ 已回答 → **${escapeMd(truncate(answerPreview, msgMax))}**` +
             (answered.by ? ` · by ${escapeMd(short(answered.by, 20))}` : '') +
             ` · 重跑 ${escapeMd(answered.nextAttemptId.slice(answered.nextAttemptId.lastIndexOf('/') + 1))}`,
         },
+      });
+    } else if (ask?.freeText) {
+      elements.push({
+        tag: 'form',
+        name: 'v3_blocked_ask_text_form',
+        elements: [
+          {
+            tag: 'input',
+            name: V3_BLOCKED_ASK_TEXT_FIELD,
+            placeholder: { tag: 'plain_text', content: '填写答案' },
+          },
+          {
+            tag: 'button',
+            text: { tag: 'plain_text', content: '提交并重跑' },
+            type: 'primary',
+            name: 'v3_blocked_ask_text_submit',
+            action_type: 'form_submit',
+            value: {
+              action: V3_BLOCKED_ASK_ANSWER_ACTION,
+              runId: input.runId,
+              nodeId: input.nodeId,
+              attemptId: input.attemptId,
+              answerKind: 'text',
+              nonce,
+            } satisfies V3AskAnswerActionValue,
+          },
+        ],
       });
     } else if (ask) {
       // 一个选项一个按钮，选中文本回传为 answer.selected（按 attempt 入 nonce 防 stale）。
       elements.push({
         tag: 'action',
-        actions: ask.options.map((opt) => ({
+        actions: (ask.options ?? []).map((opt) => ({
           tag: 'button',
           text: { tag: 'plain_text', content: short(opt, 80) },
           type: 'primary',

--- a/src/im/lark/v3-revisit-grant-card-handler.ts
+++ b/src/im/lark/v3-revisit-grant-card-handler.ts
@@ -1,0 +1,118 @@
+/**
+ * v3 回溯预算准许卡点击处理 —— card-handler 的 v3 分支(与
+ * `v3-loop-grant-card-handler` 同骨架)。把一次「➕ 准许回溯 +1」点击翻译成:
+ * 权限校验 → `requestRevisitGrant`(原子 grant + retry;幂等:已恢复 →
+ * not-budget-blocked) → 冻结卡 / toast + 触发 `driveV3Run` 重跑被卡节点。
+ *
+ * scope 正确性:按钮 value 带 tier —— pair grant 带 source/target,run grant
+ * 都不带,交给 core 的 partial-pair / pair-source-mismatch 守卫兜底。
+ */
+
+import { join } from 'node:path';
+import {
+  V3_REVISIT_GRANT_ACTION,
+  buildV3RevisitGrantCard,
+  v3RevisitGrantCardNonce,
+  type V3RevisitGrantActionValue,
+} from './v3-revisit-grant-card.js';
+import { requestRevisitGrant, revisitBudgetBlockedInfoFor } from '../../workflows/v3/daemon-run.js';
+import { readJournal } from '../../workflows/v3/journal.js';
+import {
+  readGrillState,
+  defaultBaseDir,
+  type RunChatBinding,
+} from '../../workflows/v3/grill-state.js';
+import { isValidRunId } from '../../workflows/v3/ops-projection.js';
+
+export function isV3RevisitGrantAction(action: unknown): boolean {
+  return action === V3_REVISIT_GRANT_ACTION;
+}
+
+export interface V3RevisitGrantCardHandlerDeps {
+  baseDir?: string;
+  /** Re-enter the run after grant + retry.  Fire-and-forget (daemon logs errors). */
+  driveRun: (runId: string) => void;
+  /** Permission: may this operator grant revisits of this run?  Same semantics
+   *  as the gate/blocked/loop-grant handlers' canResolve. */
+  canResolve?: (binding: RunChatBinding | undefined, operatorOpenId: string | undefined) => boolean;
+  /** Injectable for tests. Default = real requestRevisitGrant. */
+  requestGrant?: typeof requestRevisitGrant;
+}
+
+/**
+ * Handle a v3 revisit-grant card click.  Returns the Lark card-action response:
+ * a frozen「已准许」card, or a `{ toast }`.  Triggers `driveRun` on success.
+ */
+export async function handleV3RevisitGrantAction(
+  value: V3RevisitGrantActionValue,
+  operatorOpenId: string | undefined,
+  deps: V3RevisitGrantCardHandlerDeps,
+): Promise<unknown> {
+  const baseDir = deps.baseDir ?? defaultBaseDir();
+  if (!isValidRunId(value.runId)) {
+    return { toast: { type: 'warning', content: '准许已失效（非法 run）' } };
+  }
+  // attemptId 入 nonce:grant+retry 消费后节点进入新 attempt,旧卡 nonce 对不上 → stale。
+  if (value.nonce !== v3RevisitGrantCardNonce(value.runId, value.sourceNodeId, value.attemptId)) {
+    return { toast: { type: 'warning', content: '准许卡已失效（nonce 不匹配，看最新那张卡）' } };
+  }
+  const tier = value.tier === 'run' ? 'run' : 'pair';
+  const runDir = join(baseDir, value.runId);
+  const grill = readGrillState(runDir);
+  const binding = grill?.chatBinding;
+
+  if (deps.canResolve && !deps.canResolve(binding, operatorOpenId)) {
+    return { toast: { type: 'warning', content: '你没有权限准许这个 run 的回溯' } };
+  }
+
+  const requestGrant = deps.requestGrant ?? requestRevisitGrant;
+  let outcome;
+  try {
+    // pair grant 带 source/target;run grant 都不带。expectedAttemptId(同
+    // expectedAttemptId 教训):nonce 只证卡自身没改,证不了它指向的耗尽 attempt
+    // 还是"当前这次"——core 必须再比一次。
+    outcome = requestGrant(baseDir, value.runId, {
+      ...(tier === 'pair' ? { sourceNodeId: value.sourceNodeId, toNodeId: value.toNodeId } : {}),
+      by: operatorOpenId ?? 'system',
+      expectedAttemptId: value.attemptId,
+    });
+  } catch (err) {
+    return {
+      toast: { type: 'error', content: `准许失败，请再试：${err instanceof Error ? err.message : String(err)}` },
+    };
+  }
+
+  if (outcome.kind === 'invalid') {
+    return {
+      toast: {
+        type: 'warning',
+        content: outcome.reason === 'partial-pair' ? '准许卡参数不完整（pair 信息缺失）' : '准许卡与当前受阻节点不匹配',
+      },
+    };
+  }
+  if (outcome.kind === 'stale-run') {
+    return {
+      toast: {
+        type: 'warning',
+        content:
+          outcome.reason === 'missing' ? '该 run 不存在或已清理'
+          : outcome.reason === 'stale-attempt' ? '该节点已进入新一次尝试，这张旧卡失效（看最新那张卡）'
+          : '该 run 已不在回溯预算受阻状态，准许卡失效',
+      },
+    };
+  }
+
+  // granted → drive the run (blocked node retries within extended budget) + freeze card.
+  deps.driveRun(value.runId);
+  const info = revisitBudgetBlockedInfoFor(readJournal(join(runDir, 'journal.ndjson')), value.sourceNodeId);
+  const frozen = buildV3RevisitGrantCard({
+    runId: value.runId,
+    sourceNodeId: value.sourceNodeId,
+    toNodeId: value.toNodeId,
+    tier,
+    attemptId: value.attemptId,
+    detail: info?.detail,
+    grantedNow: { by: operatorOpenId },
+  });
+  return JSON.parse(frozen);
+}

--- a/src/im/lark/v3-revisit-grant-card.ts
+++ b/src/im/lark/v3-revisit-grant-card.ts
@@ -1,0 +1,165 @@
+/**
+ * v3 回溯预算耗尽卡 —— 一个节点想回溯某祖先,但 per-pair / per-run 预算用尽
+ * (nodeBlocked errorCode=REVISIT_BUDGET_EXHAUSTED → run blocked)时的飞书入口。
+ * 和 blocked 重试卡是两张卡:这里没有"失败",只是回溯次数到顶——按钮语义是
+ * 「准许再回溯 1 次」(append revisitBudgetGranted + 原子 retry blocked 节点),
+ * 不是「重跑某 attempt」。
+ *
+ * stale 防护与 loop grant 卡同构:nonce 以 blocked `attemptId` 为 freshness key
+ * —— grant+retry 后 blocked 节点进入新 attempt,旧卡 attemptId 对不上 core 的
+ * expectedAttemptId 比对,天然失效。
+ *
+ * scope 正确性(菲菲 review):卡片明确标出耗尽的是 pair 还是 run-wide,并据此
+ * 让按钮带对应 scope —— pair grant 带 source/target,run grant 都不带。给错
+ * scope 会出现"grant 了但 retry 后又因另一层预算继续 blocked"。
+ */
+
+import { config } from '../../config.js';
+
+export const V3_REVISIT_GRANT_ACTION = 'v3_revisit_grant';
+
+/** card 按钮回传的 value 形态——v3-revisit-grant-card-handler 据此解析。 */
+export interface V3RevisitGrantActionValue {
+  action: typeof V3_REVISIT_GRANT_ACTION;
+  runId: string;
+  /** 发起回溯(被 blocked)的节点。 */
+  sourceNodeId: string;
+  /** 回溯目标祖先。 */
+  toNodeId: string;
+  /** 耗尽的层级 —— 决定 grant scope:'pair' 带 source/target,'run' 都不带。 */
+  tier: 'pair' | 'run';
+  /** blocked attemptId —— nonce + core expectedAttemptId 的 freshness key。 */
+  attemptId: string;
+  nonce: string;
+}
+
+export interface V3RevisitGrantCardInput {
+  runId: string;
+  sourceNodeId: string;
+  toNodeId: string;
+  tier: 'pair' | 'run';
+  attemptId: string;
+  /** 预算耗尽 detail(如 `... (1/1) — grant +1 ...`)。 */
+  detail?: string;
+  /** 省略则按 runId/sourceNodeId/attemptId 推导。 */
+  nonce?: string;
+  webDetailUrl?: string;
+  detailMaxChars?: number;
+  /** 有值 → 渲染冻结的「已准许」卡(无按钮,防 stale UI 重复提交)。 */
+  grantedNow?: { by?: string };
+}
+
+const DEFAULT_DETAIL_MAX_CHARS = 500;
+
+/** 稳定 nonce:同一 run 同一节点同一 blocked attempt 的卡 nonce 固定(重发一致);
+ *  attemptId 入 nonce —— grant+retry 消费后 blocked 节点进入新 attempt,旧卡失效。 */
+export function v3RevisitGrantCardNonce(runId: string, sourceNodeId: string, attemptId: string): string {
+  return `v3revisitgrant:${runId}:${sourceNodeId}:${attemptId}`;
+}
+
+function v3RunDetailUrl(runId: string): string {
+  return `http://${config.dashboard.externalHost}:${config.dashboard.port}/#/v3/${encodeURIComponent(runId)}`;
+}
+
+export function buildV3RevisitGrantCard(input: V3RevisitGrantCardInput): string {
+  const nonce = input.nonce ?? v3RevisitGrantCardNonce(input.runId, input.sourceNodeId, input.attemptId);
+  const webDetailUrl = input.webDetailUrl ?? v3RunDetailUrl(input.runId);
+  const detailMax = input.detailMaxChars ?? DEFAULT_DETAIL_MAX_CHARS;
+  const granted = input.grantedNow;
+
+  const scopeLabel = input.tier === 'pair' ? `${input.sourceNodeId} → ${input.toNodeId}` : '整个 run';
+  const title = granted ? `已准许回溯：${scopeLabel}` : `回溯预算耗尽：${scopeLabel}`;
+  // 与 loop grant 卡同款语义色:耗尽=橙(可恢复),准许后转绿。
+  const template = granted ? 'green' : 'orange';
+
+  const elements: Array<Record<string, unknown>> = [
+    {
+      tag: 'div',
+      fields: [
+        { is_short: true, text: { tag: 'lark_md', content: `**Run**\n${escapeMd(short(input.runId, 24))}` } },
+        { is_short: true, text: { tag: 'lark_md', content: `**回溯**\n${escapeMd(input.sourceNodeId)} → ${escapeMd(input.toNodeId)}` } },
+        { is_short: true, text: { tag: 'lark_md', content: `**耗尽层级**\n${input.tier === 'pair' ? 'per-pair（这条边）' : 'per-run（全局）'}` } },
+      ],
+    },
+    { tag: 'hr' },
+    {
+      tag: 'div',
+      text: {
+        tag: 'lark_md',
+        content: `**情况**\n节点 ${escapeMd(input.sourceNodeId)} 想回溯到 ${escapeMd(input.toNodeId)},但回溯次数已到上限` +
+          (input.detail ? `\n${escapeMd(truncate(input.detail, detailMax))}` : ''),
+      },
+    },
+  ];
+
+  if (granted) {
+    elements.push({ tag: 'hr' });
+    elements.push({
+      tag: 'div',
+      text: {
+        tag: 'lark_md',
+        content: `➕ 已准许再回溯 1 次（${input.tier === 'pair' ? '本边' : '全局'}）` +
+          (granted.by ? ` · by ${escapeMd(short(granted.by, 20))}` : ''),
+      },
+    });
+  } else {
+    elements.push({
+      tag: 'div',
+      text: {
+        tag: 'lark_md',
+        content: '点「准许回溯 +1」会放行这次回溯并自动重跑该节点；若觉得不该再回溯,留着不点即可（run 保持受阻）。',
+      },
+    });
+    elements.push({
+      tag: 'action',
+      actions: [
+        {
+          tag: 'button',
+          text: { tag: 'plain_text', content: '➕ 准许回溯 +1' },
+          type: 'primary',
+          value: {
+            action: V3_REVISIT_GRANT_ACTION,
+            runId: input.runId,
+            sourceNodeId: input.sourceNodeId,
+            toNodeId: input.toNodeId,
+            tier: input.tier,
+            attemptId: input.attemptId,
+            nonce,
+          } satisfies V3RevisitGrantActionValue,
+        },
+      ],
+    });
+  }
+
+  elements.push({
+    tag: 'action',
+    actions: [
+      {
+        tag: 'button',
+        text: { tag: 'plain_text', content: 'Web 详情' },
+        type: 'default',
+        multi_url: { url: webDetailUrl, pc_url: webDetailUrl, android_url: webDetailUrl, ios_url: webDetailUrl },
+      },
+    ],
+  });
+
+  return JSON.stringify({
+    config: { wide_screen_mode: true },
+    header: { template, title: { tag: 'plain_text', content: title } },
+    elements,
+  });
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max)}…（截断，完整见 Web 详情）`;
+}
+
+function short(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max)}…`;
+}
+
+/** 转义 lark_md 里会被解析的字符,防 detail 注入破坏卡片结构。 */
+function escapeMd(s: string): string {
+  return s.replace(/[\\*_~`\[\]]/g, (c) => `\\${c}`);
+}

--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -973,17 +973,18 @@ stdout 为一行 JSON。注意：\`--json\` 覆盖所有结果类型；超时 / 
 
 const GOAL_ASK_SKILL = `---
 name: botmux-goal-ask
-description: v3 goal-mode 节点在真正需要人类判断时使用的文件式 ask 协议。触发场景：你运行在 botmux v3 goal-mode，必须让人从 2-6 个明确选项中做一个判断，且无法自行研究或推断。不要调用原生 AskUserQuestion，也不要调用 botmux ask；写 ask.json + ASK_HUMAN failure manifest 后停止。
+description: v3 goal-mode 节点在真正需要人类判断时使用的文件式 ask 协议。触发场景：你运行在 botmux v3 goal-mode，必须让人做选择或补充自由文本，且无法自行研究或推断。不要调用原生 AskUserQuestion，也不要调用 botmux ask；写 ask.json + ASK_HUMAN failure manifest 后停止。
 ---
 
 # botmux-goal-ask — v3 goal-mode 人类判断
 
-你运行在 botmux v3 goal-mode 时，不能打开原生交互问答，也不能调用 \`botmux ask\`。如果且仅如果你遇到**必须由人做判断**的选择题，使用本文件协议暂停节点。
+你运行在 botmux v3 goal-mode 时，不能打开原生交互问答，也不能调用 \`botmux ask\`。如果且仅如果你遇到**必须由人做判断或补充信息**的问题，使用本文件协议暂停节点。
 
 ## 什么时候用
 
 - 需要产品 / 业务 / 风险决策，不能通过读取文件、运行命令、搜索资料自行判断
 - 选项已经清楚，可以给出 2-6 个具体选择
+- 需要人补充一段规则、细节、边界说明，不能改写成有限选项
 - 没有人回答前继续执行会改变方向或造成风险
 
 ## 什么时候不要用
@@ -991,16 +992,27 @@ description: v3 goal-mode 节点在真正需要人类判断时使用的文件式
 - 登录、鉴权、权限、外部确认弹窗：写普通 retryable failure manifest（如 \`AUTH_REQUIRED\`），不要 ask
 - 你可以自行推断、测试或查证的问题：直接处理，不要打断人
 - workflow 节点审批：外层 humanGate 已经处理，不要套 ask
-- 自由文本长回答：v3 MVP 只支持选项按钮；把问题改写成清晰选项
+- 可以通过有限选项表达的问题：优先用 options，不要滥用自由文本
 
 ## 协议
 
-1. 写 ask 文件到当前 attempt 目录：
+1. 写 ask 文件到当前 attempt 目录。
+
+选择题：
 
 \`\`\`json
 {
   "question": "一个清晰的问题",
   "options": ["选项 A", "选项 B"]
+}
+\`\`\`
+
+填空题：
+
+\`\`\`json
+{
+  "question": "请补充计费规则的边界说明",
+  "freeText": true
 }
 \`\`\`
 
@@ -1040,7 +1052,7 @@ manifest 的要求：
 $${GOAL_ENV.INPUTS_PATH}
 \`\`\`
 
-输入里会有一个 \`from: "human/answer"\` 的条目，指向 answer.json。读取它，里面的 \`selected\` 就是人类选项，然后继续完成原目标。
+输入里会有一个 \`from: "human/answer"\` 的条目，指向 answer.json。读取它：选择题看 \`selected\`，填空题看 \`text\`，然后继续完成原目标。
 `;
 
 const WORKER_BUDGET_SKILL = `---

--- a/src/workflows/v3/contract.ts
+++ b/src/workflows/v3/contract.ts
@@ -130,7 +130,7 @@ export const GOAL_ENV = {
 
 /**
  * A goal worker that needs a human decision mid-run does NOT block in-process.
- * Instead it writes its question + options to `GOAL_ASK_FILE` under the attempt
+ * Instead it writes its question to `GOAL_ASK_FILE` under the attempt
  * dir, then exits with a fail manifest carrying `error.code = ASK_HUMAN_ERROR_CODE`
  * and `error.retryable: true`.  classifyTerminal routes that to `blocked` (the
  * retryable half), and the daemon posts an ask card instead of a plain retry
@@ -150,19 +150,35 @@ export const GOAL_ASK_FILE = 'ask.json';
  *  human's {@link GoalAnswer} to; the retry's GoalInputs points at this path. */
 export const GOAL_ANSWER_FILE = 'answer.json';
 
-export interface GoalAsk {
-  /** The single question to put to the human. */
-  question: string;
-  /** 2–6 concrete options the human picks from; each becomes a card button. */
-  options: string[];
-}
+export type GoalAsk =
+  | {
+      /** The single question to put to the human. */
+      question: string;
+      /** 2–6 concrete options the human picks from; each becomes a card button. */
+      options: string[];
+      freeText?: false;
+    }
+  | {
+      /** The single question to put to the human. */
+      question: string;
+      /** Ask the human to provide free-form text instead of picking an option. */
+      freeText: true;
+      options?: never;
+    };
 
-export interface GoalAnswer {
-  /** The option the human selected (one of {@link GoalAsk.options}). */
-  selected: string;
-  /** open_id of the human who answered. */
-  by: string;
-}
+export type GoalAnswer =
+  | {
+      /** The option the human selected (one of {@link GoalAsk.options}). */
+      selected: string;
+      /** open_id of the human who answered. */
+      by: string;
+    }
+  | {
+      /** Free-form text the human provided. */
+      text: string;
+      /** open_id of the human who answered. */
+      by: string;
+    };
 
 // ─── Supported CLIs ─────────────────────────────────────────────────────────
 

--- a/src/workflows/v3/daemon-run.ts
+++ b/src/workflows/v3/daemon-run.ts
@@ -16,8 +16,8 @@
  * concurrent clicks / start can't double-spawn.
  */
 
-import { join } from 'node:path';
-import { existsSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { existsSync, mkdirSync, readdirSync, renameSync, statSync, writeFileSync } from 'node:fs';
 
 import { loadBotConfigs, type BotConfig } from '../../bot-registry.js';
 import { isLoopNode, loadDag } from './dag.js';
@@ -50,7 +50,7 @@ import {
 import { readJournal, appendEvent, type StoredEvent, type V3ErrorClass } from './journal.js';
 import { materialize } from './state.js';
 import { isValidRunId } from './ops-projection.js';
-import { GOAL_ANSWER_FILE, type GoalAnswer, type ValidateManifest } from './contract.js';
+import { GOAL_ANSWER_FILE, type GoalAnswer, type GoalAsk, type ValidateManifest } from './contract.js';
 
 /**
  * runId → runDir with a path-traversal guard (codex review #2).  runIds reach
@@ -72,9 +72,9 @@ export interface V3BlockedInfo {
   errorCode?: string;
   message?: string;
   /** Present when the block is a runtime human-ask (errorCode === ASK_HUMAN):
-   *  the agent's question + options → the daemon posts an ask card (option
-   *  buttons) instead of a plain retry card. */
-  ask?: { question: string; options: string[] };
+   *  the agent's question → the daemon posts an ask card instead of a plain
+   *  retry card. */
+  ask?: GoalAsk;
 }
 
 /** Latest `nodeBlocked` details for a node (card content).  Falls back to a
@@ -293,6 +293,25 @@ export type V3RetryOutcome =
   | { kind: 'already-requested'; nodeId: string }
   | { kind: 'stale-run'; reason: 'missing' | 'not-blocked' | 'stale-attempt' | 'loop-node' };
 
+type V3RetryAnswerInput =
+  | { selected: string; by: string }
+  | { text: string; by: string };
+
+function atomicWriteJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(value, null, 2));
+  renameSync(tmp, path);
+}
+
+const HUMAN_ANSWER_PREVIEW_MAX_CHARS = 200;
+
+function answerPreview(s: string): string {
+  return s.length <= HUMAN_ANSWER_PREVIEW_MAX_CHARS
+    ? s
+    : `${s.slice(0, HUMAN_ANSWER_PREVIEW_MAX_CHARS)}...`;
+}
+
 /**
  * Append a retry intent for a blocked node (the resume entrypoint — daemon
  * card click and `botmux workflow retry` both land here).  Recovery-first +
@@ -315,7 +334,7 @@ export type V3RetryOutcome =
 export function requestV3Retry(
   baseDir: string,
   runId: string,
-  input: { nodeId?: string; expectedAttemptId?: string; answer?: { selected: string; by: string } } = {},
+  input: { nodeId?: string; expectedAttemptId?: string; answer?: V3RetryAnswerInput } = {},
 ): V3RetryOutcome {
   const runDir = safeRunDir(baseDir, runId);
   const journalPath = join(runDir, 'journal.ndjson');
@@ -369,9 +388,16 @@ export function requestV3Retry(
   let answer: { path: string; preview: string; by: string } | undefined;
   if (input.answer) {
     const answerPath = join(runDir, previousAttemptId, GOAL_ANSWER_FILE);
-    const payload: GoalAnswer = { selected: input.answer.selected, by: input.answer.by };
-    writeFileSync(answerPath, JSON.stringify(payload, null, 2));
-    answer = { path: answerPath, preview: input.answer.selected, by: input.answer.by };
+    const payload: GoalAnswer =
+      'text' in input.answer
+        ? { text: input.answer.text, by: input.answer.by }
+        : { selected: input.answer.selected, by: input.answer.by };
+    atomicWriteJson(answerPath, payload);
+    answer = {
+      path: answerPath,
+      preview: answerPreview('text' in payload ? payload.text : payload.selected),
+      by: payload.by,
+    };
   }
 
   appendEvent(journalPath, {

--- a/src/workflows/v3/daemon-run.ts
+++ b/src/workflows/v3/daemon-run.ts
@@ -274,12 +274,14 @@ export function resolveV3GateClick(
   if (!resolution) return { kind: 'stale-run', reason: 'no-wait' };
 
   resolveWait(runDir, input.waitId, resolution, input.by, input.selected);
+  const instanceId = snap.nodes.get(wait.nodeId)?.effectiveInstanceId;
   appendEvent(journalPath, {
     type: 'gateResolved',
     // nodeId from the WAIT FILE, not caller input (codex review #1): the wait is
     // the authoritative state — a wrong/stale caller nodeId must not let us write
     // gateResolved for a different node.
     nodeId: wait.nodeId,
+    ...(instanceId ? { instanceId } : {}),
     waitId: input.waitId,
     resolution,
     by: input.by,
@@ -345,10 +347,11 @@ export function requestV3Retry(
   // Target resolution: explicit nodeId > the run's blocked pointer > a node
   // with an unconsumed retry reservation (a prior retry already cleared the
   // blocked pointer — the idempotent repeat-call path).
+  const retryKeyFor = (id: string): string => snap.nodes.get(id)?.effectiveInstanceId ?? id;
   const nodeId =
     input.nodeId ??
     snap.blockedNodeId ??
-    [...snap.nodes.keys()].find((id) => unconsumedRetryEvent(events, id) !== undefined);
+    [...snap.nodes.keys()].find((id) => unconsumedRetryEvent(events, retryKeyFor(id)) !== undefined);
   if (!nodeId) return { kind: 'stale-run', reason: 'not-blocked' };
   // An exhausted LOOP blocks the run too, but "retry an attempt" is the wrong
   // verb for it — the recovery is a grant (+1 iteration).  Route loudly.
@@ -358,7 +361,7 @@ export function requestV3Retry(
   if (status === 'pending') {
     // An unconsumed retry reservation already reset this node — idempotent
     // no-op (a second click / a CLI retry racing the card must not double-append).
-    const pendingRetry = unconsumedRetryEvent(events, nodeId);
+    const pendingRetry = unconsumedRetryEvent(events, retryKeyFor(nodeId));
     if (pendingRetry) {
       // The repeat-call is only "the same retry" when it references the attempt
       // that retry was FOR — a stale older card is not an idempotent repeat.
@@ -475,16 +478,19 @@ export function requestV3LoopGrant(
   return { kind: 'granted', loopId, fromIteration: ls.iteration, nextIteration: ls.iteration + 1 };
 }
 
-/** The node's `nodeRetryRequested` whose reserved attempt has not yet been
- *  consumed by a matching `nodeDispatched` (undefined when none pending). */
+/** The `nodeRetryRequested` for `key` whose reserved attempt has not yet been
+ *  consumed by a matching `nodeDispatched` (undefined when none pending).  `key`
+ *  matches by `(instanceId ?? nodeId)` so a stale retry on an OLD instance isn't
+ *  mistaken for the current instance's pending retry (constraint 5 / 菲菲 #3). */
 function unconsumedRetryEvent(
   events: StoredEvent[],
-  nodeId: string,
+  key: string,
 ): Extract<StoredEvent, { type: 'nodeRetryRequested' }> | undefined {
+  const matches = (e: { nodeId: string; instanceId?: string }): boolean => (e.instanceId ?? e.nodeId) === key;
   let pending: Extract<StoredEvent, { type: 'nodeRetryRequested' }> | undefined;
   for (const e of events) {
-    if (e.type === 'nodeRetryRequested' && e.nodeId === nodeId) pending = e;
-    else if (e.type === 'nodeDispatched' && e.nodeId === nodeId && e.attemptId === pending?.nextAttemptId) {
+    if (e.type === 'nodeRetryRequested' && matches(e)) pending = e;
+    else if (e.type === 'nodeDispatched' && matches(e) && e.attemptId === pending?.nextAttemptId) {
       pending = undefined;
     }
   }
@@ -768,6 +774,7 @@ function reconcileOneRun(
       appendEvent(journalPath, {
         type: 'gateResolved',
         nodeId: wait.nodeId,
+        ...(snap.nodes.get(wait.nodeId)?.effectiveInstanceId ? { instanceId: snap.nodes.get(wait.nodeId)!.effectiveInstanceId } : {}),
         waitId,
         resolution: wait.status,
         by: wait.by ?? 'system',

--- a/src/workflows/v3/daemon-run.ts
+++ b/src/workflows/v3/daemon-run.ts
@@ -423,6 +423,33 @@ export function requestV3Retry(
   return { kind: 'requested', nodeId, previousAttemptId, nextAttemptId };
 }
 
+export type V3RevisitGrantOutcome =
+  | { kind: 'granted'; scope: 'pair' | 'run' }
+  | { kind: 'stale-run'; reason: 'missing' };
+
+/** Grant +1 revisit budget after a run blocked on exhaustion (the revisit
+ *  analogue of a loop-iteration grant).  A PAIR grant (both sourceNodeId +
+ *  toNodeId) bumps one source→target edge; a RUN grant (neither) bumps the
+ *  run-wide allowance.  The granted budget is consumed when the blocked node is
+ *  retried and re-attempts its revisit. */
+export function requestRevisitGrant(
+  baseDir: string,
+  runId: string,
+  input: { sourceNodeId?: string; toNodeId?: string; by: string; reason?: string },
+): V3RevisitGrantOutcome {
+  const runDir = safeRunDir(baseDir, runId);
+  const journalPath = join(runDir, 'journal.ndjson');
+  if (!existsSync(journalPath)) return { kind: 'stale-run', reason: 'missing' };
+  const pair = !!(input.sourceNodeId && input.toNodeId);
+  appendEvent(journalPath, {
+    type: 'revisitBudgetGranted',
+    ...(pair ? { sourceNodeId: input.sourceNodeId, toNodeId: input.toNodeId } : {}),
+    by: input.by,
+    ...(input.reason ? { reason: input.reason } : {}),
+  });
+  return { kind: 'granted', scope: pair ? 'pair' : 'run' };
+}
+
 export type V3LoopGrantOutcome =
   | { kind: 'granted'; loopId: string; fromIteration: number; nextIteration: number }
   | { kind: 'already-granted'; loopId: string }

--- a/src/workflows/v3/daemon-run.ts
+++ b/src/workflows/v3/daemon-run.ts
@@ -424,30 +424,60 @@ export function requestV3Retry(
 }
 
 export type V3RevisitGrantOutcome =
-  | { kind: 'granted'; scope: 'pair' | 'run' }
-  | { kind: 'stale-run'; reason: 'missing' };
+  | { kind: 'granted'; scope: 'pair' | 'run'; retry: V3RetryOutcome }
+  | { kind: 'invalid'; reason: 'partial-pair' | 'pair-source-mismatch' }
+  | { kind: 'stale-run'; reason: 'missing' | 'not-budget-blocked' | 'stale-attempt' };
 
-/** Grant +1 revisit budget after a run blocked on exhaustion (the revisit
- *  analogue of a loop-iteration grant).  A PAIR grant (both sourceNodeId +
- *  toNodeId) bumps one source→target edge; a RUN grant (neither) bumps the
- *  run-wide allowance.  The granted budget is consumed when the blocked node is
- *  retried and re-attempts its revisit. */
+/** Grant +1 revisit budget after a run blocked on `REVISIT_BUDGET_EXHAUSTED`,
+ *  then resume (the revisit analogue of a loop-iteration grant).  Atomic
+ *  "continue": append `revisitBudgetGranted` AND retry the blocked node so it
+ *  re-attempts its revisit within the extended budget — one entry, like the
+ *  card's one-click.  Guards (菲菲 review):
+ *   - the run MUST currently be blocked on a `REVISIT_BUDGET_EXHAUSTED` node
+ *     (freshness + idempotency: after grant+retry the node is pending, so a
+ *     repeat call is `not-budget-blocked` and adds NO further budget);
+ *   - PAIR grant ⇒ both sourceNodeId+toNodeId, and sourceNodeId MUST be the
+ *     blocked node; RUN grant ⇒ neither; a half-filled pair is rejected (never
+ *     silently widened to a run grant);
+ *   - `expectedAttemptId` (card passes it) must match the blocked attempt. */
 export function requestRevisitGrant(
   baseDir: string,
   runId: string,
-  input: { sourceNodeId?: string; toNodeId?: string; by: string; reason?: string },
+  input: { sourceNodeId?: string; toNodeId?: string; by: string; reason?: string; expectedAttemptId?: string },
 ): V3RevisitGrantOutcome {
   const runDir = safeRunDir(baseDir, runId);
   const journalPath = join(runDir, 'journal.ndjson');
   if (!existsSync(journalPath)) return { kind: 'stale-run', reason: 'missing' };
-  const pair = !!(input.sourceNodeId && input.toNodeId);
+
+  // Reject a half-filled pair before touching state (never widen to run grant).
+  const hasSource = input.sourceNodeId !== undefined;
+  const hasTo = input.toNodeId !== undefined;
+  if (hasSource !== hasTo) return { kind: 'invalid', reason: 'partial-pair' };
+  const pair = hasSource && hasTo;
+
+  // Freshness: must currently be blocked on a budget-exhausted node.
+  const events = readJournal(journalPath);
+  const snap = materialize(events);
+  const blockedNodeId = snap.blockedNodeId;
+  if (!blockedNodeId) return { kind: 'stale-run', reason: 'not-budget-blocked' };
+  const info = blockedInfoFor(events, blockedNodeId);
+  if (info.errorCode !== 'REVISIT_BUDGET_EXHAUSTED') return { kind: 'stale-run', reason: 'not-budget-blocked' };
+  if (input.expectedAttemptId && input.expectedAttemptId !== info.attemptId) {
+    return { kind: 'stale-run', reason: 'stale-attempt' };
+  }
+  // A pair grant must target the blocked node as its source.
+  if (pair && input.sourceNodeId !== blockedNodeId) return { kind: 'invalid', reason: 'pair-source-mismatch' };
+
   appendEvent(journalPath, {
     type: 'revisitBudgetGranted',
     ...(pair ? { sourceNodeId: input.sourceNodeId, toNodeId: input.toNodeId } : {}),
     by: input.by,
     ...(input.reason ? { reason: input.reason } : {}),
   });
-  return { kind: 'granted', scope: pair ? 'pair' : 'run' };
+  // Resume: retry the blocked node so it re-runs and re-requests its revisit
+  // within the now-extended budget (reuses requestV3Retry's idempotency/guards).
+  const retry = requestV3Retry(baseDir, runId, { nodeId: blockedNodeId, expectedAttemptId: info.attemptId });
+  return { kind: 'granted', scope: pair ? 'pair' : 'run', retry };
 }
 
 export type V3LoopGrantOutcome =

--- a/src/workflows/v3/daemon-run.ts
+++ b/src/workflows/v3/daemon-run.ts
@@ -311,6 +311,12 @@ export function resolveV3GateClick(
   if (snap.nodes.get(wait.nodeId)?.status !== 'gateWaiting') {
     return { kind: 'stale-run', reason: 'stale-node' };
   }
+  // Stale-card guard: the wait must belong to the node's CURRENT effective
+  // instance.  A revisit makes a fresh instance + gate (`A#002-gate`); an old
+  // `A#001-gate` card must NOT resolve the new instance's gate.
+  if (wait.instanceId && wait.instanceId !== snap.nodes.get(wait.nodeId)?.effectiveInstanceId) {
+    return { kind: 'stale-run', reason: 'stale-node' };
+  }
   if (!canResolveGateWait(wait, input.by)) return { kind: 'unauthorized' };
   const resolution = selectedResolution(wait, input.selected);
   if (!resolution) return { kind: 'stale-run', reason: 'no-wait' };
@@ -871,11 +877,14 @@ function reconcileOneRun(
   const repost: V3PendingGate[] = [];
   let resume = false;
   for (const nodeId of gateWaitingNodes) {
-    const waitId = `${nodeId}-gate`;
+    // Instance-level waitId mirrors startGate so recovery reads the SAME wait
+    // file the dispatch wrote (stale-card protection).
+    const instanceId = snap.nodes.get(nodeId)?.effectiveInstanceId;
+    const waitId = `${instanceId ?? nodeId}-gate`;
     let wait = readWait(runDir, waitId);
     if (!wait) {
       const gate = dagNodeGate.get(nodeId) ?? normalizeGateWaitInput({ prompt: '(humanGate — 等待人工审批)' });
-      wait = writePendingWait(runDir, { waitId, nodeId, ...gate });
+      wait = writePendingWait(runDir, { waitId, nodeId, ...(instanceId ? { instanceId } : {}), ...gate });
     }
     if (wait.status === 'pending') {
       repost.push({

--- a/src/workflows/v3/daemon-run.ts
+++ b/src/workflows/v3/daemon-run.ts
@@ -516,12 +516,24 @@ export function requestRevisitGrant(
   // A pair grant must target the blocked node as its source.
   if (pair && input.sourceNodeId !== blockedNodeId) return { kind: 'invalid', reason: 'pair-source-mismatch' };
 
-  appendEvent(journalPath, {
-    type: 'revisitBudgetGranted',
-    ...(pair ? { sourceNodeId: input.sourceNodeId, toNodeId: input.toNodeId } : {}),
-    by: input.by,
-    ...(input.reason ? { reason: input.reason } : {}),
-  });
+  // Recovery-safe grant (code review): the node can be blocked on
+  // REVISIT_BUDGET_EXHAUSTED yet have budget ALREADY ok — that's the crash
+  // window where a prior call appended `revisitBudgetGranted` but died before the
+  // retry.  Re-granting there would double the budget for one approval.  So only
+  // append the grant while the budget is STILL exhausted; otherwise just resume
+  // (retry) the half-applied grant.  Both paths are idempotent: after the retry
+  // the node is pending, so a further click is `not-budget-blocked`.
+  const stillExhausted = info.revisitTo
+    ? !revisitBudgetStatus(events, blockedNodeId, info.revisitTo).ok
+    : true; // no recorded target → can't re-check; treat as exhausted (append once)
+  if (stillExhausted) {
+    appendEvent(journalPath, {
+      type: 'revisitBudgetGranted',
+      ...(pair ? { sourceNodeId: input.sourceNodeId, toNodeId: input.toNodeId } : {}),
+      by: input.by,
+      ...(input.reason ? { reason: input.reason } : {}),
+    });
+  }
   // Resume: retry the blocked node so it re-runs and re-requests its revisit
   // within the now-extended budget (reuses requestV3Retry's idempotency/guards).
   const retry = requestV3Retry(baseDir, runId, { nodeId: blockedNodeId, expectedAttemptId: info.attemptId });

--- a/src/workflows/v3/daemon-run.ts
+++ b/src/workflows/v3/daemon-run.ts
@@ -25,6 +25,7 @@ import {
   runWorkflow,
   nextAttemptIdFor,
   latestAttemptIdFor,
+  revisitBudgetStatus,
   type V3RuntimeDeps,
   type V3RuntimeOptions,
   type V3RunOutcome,
@@ -75,6 +76,9 @@ export interface V3BlockedInfo {
    *  the agent's question → the daemon posts an ask card instead of a plain
    *  retry card. */
   ask?: GoalAsk;
+  /** Present when errorCode === 'REVISIT_BUDGET_EXHAUSTED': the ancestor this
+   *  node tried to revisit → the daemon posts a revisit-grant card. */
+  revisitTo?: string;
 }
 
 /** Latest `nodeBlocked` details for a node (card content).  Falls back to a
@@ -91,10 +95,40 @@ export function blockedInfoFor(events: StoredEvent[], nodeId: string): V3Blocked
         errorCode: e.errorCode,
         message: e.message,
         ...(e.ask ? { ask: e.ask } : {}),
+        ...(e.revisitTo ? { revisitTo: e.revisitTo } : {}),
       };
     }
   }
   return found ?? { nodeId, attemptId: latestAttemptIdFor(events, nodeId) ?? `${nodeId}/attempts/001` };
+}
+
+/** What the daemon needs to render a revisit-budget grant card.  Derived from
+ *  the blocked event (source/target/attempt) + a re-run budget check (which tier
+ *  is exhausted — the card must grant the RIGHT scope, 菲菲 review).  Returns
+ *  undefined when `nodeId` isn't actually blocked on REVISIT_BUDGET_EXHAUSTED. */
+export interface V3RevisitBudgetBlockedInfo {
+  sourceNodeId: string;
+  toNodeId: string;
+  attemptId: string;
+  tier: 'pair' | 'run';
+  detail: string;
+}
+export function revisitBudgetBlockedInfoFor(
+  events: StoredEvent[],
+  nodeId: string,
+): V3RevisitBudgetBlockedInfo | undefined {
+  const info = blockedInfoFor(events, nodeId);
+  if (info.errorCode !== 'REVISIT_BUDGET_EXHAUSTED' || !info.revisitTo) return undefined;
+  const status = revisitBudgetStatus(events, nodeId, info.revisitTo);
+  // Exhausted at block time; if a grant already lifted it the card is stale —
+  // fall back to 'pair' tier + the recorded message for a still-renderable card.
+  return {
+    sourceNodeId: nodeId,
+    toNodeId: info.revisitTo,
+    attemptId: info.attemptId,
+    tier: status.ok ? 'pair' : status.tier,
+    detail: status.ok ? (info.message ?? 'revisit budget') : status.detail,
+  };
 }
 
 /** What the daemon needs to render an exhausted-loop grant card. */
@@ -137,6 +171,10 @@ export interface V3DaemonRunDeps {
   /** Post an exhausted-loop grant card (+1 iteration).  Optional — same
    *  fallthrough semantics as postBlockedCard. */
   postLoopGrantCard?: (binding: RunChatBinding, info: V3LoopExhaustedInfo, runId: string) => Promise<void>;
+  /** Post a revisit-budget grant card (+1 revisit).  Optional — same fallthrough
+   *  semantics as postBlockedCard.  Chosen over the plain blocked card when the
+   *  block is a `REVISIT_BUDGET_EXHAUSTED`. */
+  postRevisitGrantCard?: (binding: RunChatBinding, info: V3RevisitBudgetBlockedInfo, runId: string) => Promise<void>;
   /** Report a terminal run (final card / message).  Optional. */
   onTerminal?: (runId: string, outcome: V3TerminalOutcome, binding?: RunChatBinding) => Promise<void>;
   maxParallel?: number;
@@ -206,11 +244,15 @@ export async function driveV3Run(runId: string, deps: V3DaemonRunDeps): Promise<
     //   - blocked node/instance (contract failure) → retry card (new attempt).
     const events = readJournal(join(runDir, 'journal.ndjson'));
     const isLoop = materialize(events).loops.has(outcome.blockedNodeId);
+    const revisitBudget = revisitBudgetBlockedInfoFor(events, outcome.blockedNodeId);
     if (isLoop && deps.postLoopGrantCard) {
       const info = loopExhaustedInfoFor(events, outcome.blockedNodeId);
       const loopNode = dag.nodes.find((n) => n.id === outcome.blockedNodeId);
       if (loopNode && isLoopNode(loopNode)) info.maxIterations = loopNode.maxIterations;
       await deps.postLoopGrantCard(binding, info, runId);
+    } else if (revisitBudget && deps.postRevisitGrantCard) {
+      // Revisit budget exhausted → grant card (+1 revisit), not a plain retry.
+      await deps.postRevisitGrantCard(binding, revisitBudget, runId);
     } else if (!isLoop && deps.postBlockedCard) {
       await deps.postBlockedCard(binding, blockedInfoFor(events, outcome.blockedNodeId), runId);
     } else {
@@ -566,6 +608,9 @@ export interface V3GateRecovery {
   /** exhausted loop whose grant card the daemon should (re)post — the loop
    *  flavor of the same crash window. */
   repostLoopGrant?: V3LoopExhaustedInfo;
+  /** revisit-budget-exhausted node whose grant card the daemon should (re)post —
+   *  the revisit flavor of the same crash window. */
+  repostRevisitGrant?: V3RevisitBudgetBlockedInfo;
   /** true when a resolved-but-unjournaled gate was healed → daemon should driveV3Run. */
   resume: boolean;
 }
@@ -579,6 +624,8 @@ export interface V3GateRunnerDeps {
   postBlockedCard?: (binding: RunChatBinding, info: V3BlockedInfo, runId: string) => Promise<void>;
   /** Post (or re-post) an exhausted loop's grant card. */
   postLoopGrantCard?: (binding: RunChatBinding, info: V3LoopExhaustedInfo, runId: string) => Promise<void>;
+  /** Post (or re-post) a revisit-budget-exhausted node's grant card. */
+  postRevisitGrantCard?: (binding: RunChatBinding, info: V3RevisitBudgetBlockedInfo, runId: string) => Promise<void>;
   /** Notify a terminal run (optional, daemon-supplied). */
   notifyTerminal?: (binding: RunChatBinding | undefined, runId: string, outcome: V3TerminalOutcome) => Promise<void>;
   /** runtime deps passthrough (tests inject; daemon uses real pool). */
@@ -623,6 +670,7 @@ export function createV3GateRunner(deps: V3GateRunnerDeps) {
           postGateCard: (binding, gate, rid) => deps.postCard(binding, gate, rid),
           postBlockedCard: deps.postBlockedCard,
           postLoopGrantCard: deps.postLoopGrantCard,
+          postRevisitGrantCard: deps.postRevisitGrantCard,
           onTerminal: (rid, outcome, binding) =>
             deps.notifyTerminal ? deps.notifyTerminal(binding, rid, outcome) : Promise.resolve(),
         });
@@ -667,6 +715,13 @@ export function createV3GateRunner(deps: V3GateRunnerDeps) {
         if (rec.repostLoopGrant && deps.postLoopGrantCard) {
           try {
             await deps.postLoopGrantCard(rec.binding, rec.repostLoopGrant, rec.runId);
+          } catch (err) {
+            deps.onError?.(rec.runId, err);
+          }
+        }
+        if (rec.repostRevisitGrant && deps.postRevisitGrantCard) {
+          try {
+            await deps.postRevisitGrantCard(rec.binding, rec.repostRevisitGrant, rec.runId);
           } catch (err) {
             deps.onError?.(rec.runId, err);
           }
@@ -726,12 +781,18 @@ export function reconcileV3PendingGates(baseDir: string = defaultBaseDir(), owne
           }
           out.push({ runId, runDir, binding, repost: [], repostLoopGrant: info, resume: false });
         } else {
-          out.push({
-            runId, runDir, binding,
-            repost: [],
-            repostBlocked: blockedInfoFor(events, snap.blockedNodeId),
-            resume: false,
-          });
+          // Revisit-budget block → grant card; otherwise the plain retry card.
+          const revisitBudget = revisitBudgetBlockedInfoFor(events, snap.blockedNodeId);
+          if (revisitBudget) {
+            out.push({ runId, runDir, binding, repost: [], repostRevisitGrant: revisitBudget, resume: false });
+          } else {
+            out.push({
+              runId, runDir, binding,
+              repost: [],
+              repostBlocked: blockedInfoFor(events, snap.blockedNodeId),
+              resume: false,
+            });
+          }
         }
         continue;
       }

--- a/src/workflows/v3/daemon-run.ts
+++ b/src/workflows/v3/daemon-run.ts
@@ -371,7 +371,13 @@ export function requestV3Retry(
   }
   if (status !== 'blocked') return { kind: 'stale-run', reason: 'not-blocked' };
 
-  const previousAttemptId = latestAttemptIdFor(events, nodeId);
+  // Constraint 5: a retry stays in the SAME instance — key attempt numbering by
+  // the blocked node's effective instance (`A#001`), not the bare nodeId, so the
+  // new attempt is `A#001/attempts/002` (NOT a new instance).  Legacy runs with
+  // no instance fall back to nodeId.
+  const instanceId = snap.nodes.get(nodeId)?.effectiveInstanceId;
+  const attemptKey = instanceId ?? nodeId;
+  const previousAttemptId = latestAttemptIdFor(events, attemptKey);
   if (!previousAttemptId) return { kind: 'stale-run', reason: 'not-blocked' };
   const info = blockedInfoFor(events, nodeId);
   // Freshness gate (codex blocker): the click must target the CURRENTLY
@@ -379,7 +385,7 @@ export function requestV3Retry(
   if (input.expectedAttemptId && input.expectedAttemptId !== info.attemptId) {
     return { kind: 'stale-run', reason: 'stale-attempt' };
   }
-  const nextAttemptId = nextAttemptIdFor(events, nodeId);
+  const nextAttemptId = nextAttemptIdFor(events, attemptKey);
 
   // Runtime human-ask answer: persist the chosen option next to the asked
   // attempt (answer.json) and carry its path on the retry event — buildInputs
@@ -403,6 +409,7 @@ export function requestV3Retry(
   appendEvent(journalPath, {
     type: 'nodeRetryRequested',
     nodeId,
+    ...(instanceId ? { instanceId } : {}),
     previousAttemptId,
     nextAttemptId,
     reason: 'blockedRetry',

--- a/src/workflows/v3/daemon-run.ts
+++ b/src/workflows/v3/daemon-run.ts
@@ -481,7 +481,7 @@ export function requestV3LoopGrant(
 /** The `nodeRetryRequested` for `key` whose reserved attempt has not yet been
  *  consumed by a matching `nodeDispatched` (undefined when none pending).  `key`
  *  matches by `(instanceId ?? nodeId)` so a stale retry on an OLD instance isn't
- *  mistaken for the current instance's pending retry (constraint 5 / 菲菲 #3). */
+ *  mistaken for the current instance's pending retry (constraint 5 / review #3). */
 function unconsumedRetryEvent(
   events: StoredEvent[],
   key: string,

--- a/src/workflows/v3/dag.ts
+++ b/src/workflows/v3/dag.ts
@@ -244,6 +244,13 @@ export interface V3Node {
    *  `result.json` (listed in its manifest files) matching this schema; a
    *  violation blocks (not fails) the node.  Absent → zero behavior change. */
   resultSchema?: V3ResultSchema;
+  /** Definition-level revisit exits (cross-node回溯).  When this node's
+   *  `result.json` returns `{ "status": "revisit", "revisitTo": "<A>" }`, the
+   *  runtime may revisit ancestor node `<A>` — but ONLY if `<A>` is listed
+   *  here.  Default (absent / empty) = the node cannot revisit anything.
+   *  validateDag enforces every entry is an ANCESTOR (transitive `depends`),
+   *  so a revisit can never create a forward jump or a cycle in the run. */
+  revisitTo?: string[];
 
   // ── loop-only fields (type === 'loop'; see V3LoopNode) ──
   /** Hard iteration bound; the loop blocks (recoverable, human can grant +1)
@@ -429,6 +436,8 @@ export function validateDag(raw: unknown): V3Dag {
 
     const override = normOverride(n.override, `node "${id}"`, problems);
 
+    const revisitTo = normRevisitTo(n.revisitTo, id, problems);
+
     nodes.push({
       id,
       type,
@@ -441,6 +450,7 @@ export function validateDag(raw: unknown): V3Dag {
       timeoutSec,
       humanGate,
       resultSchema,
+      ...(revisitTo ? { revisitTo } : {}),
     });
   }
 
@@ -454,6 +464,23 @@ export function validateDag(raw: unknown): V3Dag {
         problems.push(`node "${node.id}".inputs references unknown node "${inp.from}"`);
       } else if (!node.depends.some((d) => d.from === inp.from)) {
         problems.push(`node "${node.id}".inputs.from "${inp.from}" must also be in depends`);
+      }
+    }
+    // revisitTo: each target must exist AND be a (transitive) ANCESTOR of this
+    // node — a revisit only ever jumps BACKWARD, so the definition graph stays
+    // acyclic and the supersede cone is well-defined (cross-node回溯 design).
+    if (node.revisitTo && node.revisitTo.length > 0) {
+      const ancestors = ancestorsOf(node.id, nodes);
+      for (const target of node.revisitTo) {
+        if (!ids.has(target)) {
+          problems.push(`node "${node.id}".revisitTo references unknown node "${target}"`);
+        } else if (target === node.id) {
+          problems.push(`node "${node.id}".revisitTo cannot point at itself`);
+        } else if (!ancestors.has(target)) {
+          problems.push(
+            `node "${node.id}".revisitTo "${target}" must be an ancestor (reachable via depends) — revisit only jumps backward`,
+          );
+        }
       }
     }
   }
@@ -782,6 +809,44 @@ function normTimeoutSec(v: unknown, where: string, problems: string[]): number |
     return undefined;
   }
   return v;
+}
+
+/** Normalize `revisitTo`: an optional array of non-empty path-safe node ids.
+ *  Shape only here; the ancestor / existence cross-checks run once all ids are
+ *  collected (validateDag's cross-node pass). */
+function normRevisitTo(v: unknown, id: string, problems: string[]): string[] | undefined {
+  if (v === undefined) return undefined;
+  if (!Array.isArray(v)) {
+    problems.push(`node "${id}".revisitTo must be an array of node ids`);
+    return undefined;
+  }
+  const out: string[] = [];
+  for (const entry of v) {
+    if (typeof entry !== 'string' || entry.trim() === '') {
+      problems.push(`node "${id}".revisitTo entries must be non-empty node-id strings`);
+      continue;
+    }
+    out.push(entry);
+  }
+  if (new Set(out).size !== out.length) problems.push(`node "${id}".revisitTo has duplicates`);
+  return out.length > 0 ? out : undefined;
+}
+
+/** Transitive ancestors of `nodeId` over `depends` edges (the set of nodes
+ *  from which `nodeId` is reachable downstream).  Used to constrain
+ *  `revisitTo` to backward-only jumps.  Pure BFS over the (acyclic-by-design)
+ *  definition graph. */
+function ancestorsOf(nodeId: string, nodes: V3Node[]): Set<string> {
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  const seen = new Set<string>();
+  const queue = [...(byId.get(nodeId)?.depends.map((d) => d.from) ?? [])];
+  while (queue.length > 0) {
+    const cur = queue.shift()!;
+    if (seen.has(cur)) continue;
+    seen.add(cur);
+    for (const dep of byId.get(cur)?.depends ?? []) queue.push(dep.from);
+  }
+  return seen;
 }
 
 /**

--- a/src/workflows/v3/dag.ts
+++ b/src/workflows/v3/dag.ts
@@ -171,6 +171,17 @@ export const RESULT_ENUM_MAX_VALUE_LENGTH = 64;
  *  extra iterations one at a time once the loop blocks. */
 export const MAX_LOOP_ITERATIONS = 20;
 
+/** Cross-node revisit budgets (anti-infinite-loop).  Two tiers:
+ *  - PER-PAIR (source→target): how many times one node may revisit one ancestor
+ *    before the run blocks — default 1 (a node sends each ancestor back once;
+ *    expected multi-round rework belongs in a structured loop, not ad-hoc
+ *    revisit).  Pinpoints which edge is ping-ponging.
+ *  - PER-RUN: total revisits across the whole run — a generous backstop so many
+ *    distinct pairs (or many nodes revisiting) can't run away.
+ *  Exhaustion blocks the run; a human grants +1 (revisitBudgetGranted). */
+export const DEFAULT_REVISIT_BUDGET_PER_PAIR = 1;
+export const DEFAULT_REVISIT_BUDGET_PER_RUN = 8;
+
 // ─── Loop schema ─────────────────────────────────────────────────────────
 
 /**

--- a/src/workflows/v3/human-gate.ts
+++ b/src/workflows/v3/human-gate.ts
@@ -32,6 +32,10 @@ export type GateWaitStatus = 'pending' | 'approved' | 'rejected';
 export interface GateWait {
   waitId: string;
   nodeId: string;
+  /** The runtime instance this gate belongs to (`A#001`).  A revisit makes a
+   *  fresh instance + fresh gate; resolve-time validation rejects a stale card
+   *  whose instance is no longer the node's effective one (菲菲 review). */
+  instanceId?: string;
   prompt: string;
   options: string[];
   approveOptions: string[];
@@ -72,13 +76,14 @@ function atomicWriteJson(path: string, value: unknown): void {
 export function writePendingWait(
   runDir: string,
   input: { waitId: string; nodeId: string; prompt: string } &
-    Partial<Pick<GateWait, 'options' | 'approveOptions' | 'approvers'>>,
+    Partial<Pick<GateWait, 'options' | 'approveOptions' | 'approvers' | 'instanceId'>>,
 ): GateWait {
   const options = input.options ?? [...DEFAULT_HUMAN_GATE_OPTIONS];
   const approveOptions = input.approveOptions ?? (options.includes('approve') ? ['approve'] : [options[0]!]);
   const wait: GateWait = {
     waitId: input.waitId,
     nodeId: input.nodeId,
+    ...(input.instanceId ? { instanceId: input.instanceId } : {}),
     prompt: input.prompt,
     options,
     approveOptions,
@@ -158,6 +163,7 @@ function normalizeWaitFile(raw: Partial<GateWait>): GateWait {
   return {
     waitId: raw.waitId ?? '',
     nodeId: raw.nodeId ?? '',
+    ...(raw.instanceId ? { instanceId: raw.instanceId } : {}),
     prompt: raw.prompt ?? '',
     options,
     approveOptions: raw.approveOptions ?? (options.includes('approve') ? ['approve'] : [options[0]!]),

--- a/src/workflows/v3/human-gate.ts
+++ b/src/workflows/v3/human-gate.ts
@@ -34,7 +34,7 @@ export interface GateWait {
   nodeId: string;
   /** The runtime instance this gate belongs to (`A#001`).  A revisit makes a
    *  fresh instance + fresh gate; resolve-time validation rejects a stale card
-   *  whose instance is no longer the node's effective one (菲菲 review). */
+   *  whose instance is no longer the node's effective one (code review). */
   instanceId?: string;
   prompt: string;
   options: string[];

--- a/src/workflows/v3/journal.ts
+++ b/src/workflows/v3/journal.ts
@@ -16,6 +16,7 @@
 
 import { appendFileSync, readFileSync, existsSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
+import type { GoalAsk } from './contract.js';
 
 // ─── Event taxonomy ─────────────────────────────────────────────────────────
 
@@ -68,11 +69,10 @@ export type V3Event =
   // retryable) decides blocked-vs-failed; blocked halts the run like failed
   // but is retryable via `nodeRetryRequested` (journal event, NOT in-memory).
   // `ask` is present ONLY when the block is a runtime human-ask (errorCode ===
-  // ASK_HUMAN_ERROR_CODE): the goal worker's question + options, read from the
-  // attempt's ask.json.  The daemon renders an ask card (question + option
-  // buttons) instead of a plain retry card; everything else is identical to a
-  // contract-failure block.
-  | { type: 'nodeBlocked'; nodeId: string; attemptId: string; errorClass: V3ErrorClass; errorCode?: string; message?: string; ask?: { question: string; options: string[] } }
+  // ASK_HUMAN_ERROR_CODE): the goal worker's question, read from the attempt's
+  // ask.json.  The daemon renders an ask card instead of a plain retry card;
+  // everything else is identical to a contract-failure block.
+  | { type: 'nodeBlocked'; nodeId: string; attemptId: string; errorClass: V3ErrorClass; errorCode?: string; message?: string; ask?: GoalAsk }
   // Retry intent for a blocked node.  Appended by the retry entrypoint (CLI /
   // daemon card click).  materialize() resets the node to pending and records
   // `nextAttemptId` as the attempt reservation; the orchestrator then re-
@@ -88,7 +88,7 @@ export type V3Event =
       previousErrorClass?: V3ErrorClass;
       previousErrorCode?: string;
       // Present ONLY when the retry answers a runtime human-ask: the human's
-      // selected option, persisted to `answer.path` (an absolute path, next to
+      // selected option or free-text answer, persisted to `answer.path` (an absolute path, next to
       // the asked attempt).  buildInputs injects it into the retry attempt's
       // GoalInputs as a `human/answer` input so the agent reads the decision and
       // continues.  Absent for an ordinary blocked retry.

--- a/src/workflows/v3/journal.ts
+++ b/src/workflows/v3/journal.ts
@@ -53,18 +53,25 @@ export interface V3LoopRef {
 
 export type V3Event =
   | { type: 'runStarted'; runId: string }
-  | { type: 'nodeDispatched'; nodeId: string; attemptId: string; loop?: V3LoopRef }
+  // `instanceId` (`A#001`) identifies the RUNTIME instance of definition node
+  // `nodeId`.  A cross-node revisit supersedes an instance and the node gets a
+  // fresh one (`A#002`); `attemptId` is a try WITHIN an instance
+  // (`A#001/attempts/002`, from a blocked / human-ask retry).  Optional for
+  // back-compat: pre-instance-layer events and loop body expansions (which
+  // carry their own expanded nodeId) omit it, and consumers fall back to
+  // nodeId-keyed behavior (instance restoration design 2026-06-08).
+  | { type: 'nodeDispatched'; nodeId: string; instanceId?: string; attemptId: string; loop?: V3LoopRef }
   // Written when the node's worker web terminal is ready (mid-run) so the
   // dashboard can attach to an in-flight node's LIVE terminal instead of waiting
   // for completion.  Kept even if the node later fails (terminal info survives).
   // NOTE: deliberately NO web-terminal `token` here — it's a WRITE token, and
   // read-only "watch the subagent" doesn't need it; persisting it would turn
   // write access into a durable artifact (codex security review 2026-06-02).
-  | { type: 'nodeSessionReady'; nodeId: string; attemptId: string; sessionInfo: { sessionId: string; webPort?: number }; ptyLogPath?: string }
-  | { type: 'nodeSucceeded'; nodeId: string; attemptId: string; manifestPath: string }
+  | { type: 'nodeSessionReady'; nodeId: string; instanceId?: string; attemptId: string; sessionInfo: { sessionId: string; webPort?: number }; ptyLogPath?: string }
+  | { type: 'nodeSucceeded'; nodeId: string; instanceId?: string; attemptId: string; manifestPath: string }
   // `errorCode` carries the node's self-reported `manifest.error.code` (e.g.
   // AUTH_REQUIRED) so dashboards see the real cause, not just the coarse class.
-  | { type: 'nodeFailed'; nodeId: string; attemptId: string; errorClass: V3ErrorClass; errorCode?: string; message?: string }
+  | { type: 'nodeFailed'; nodeId: string; instanceId?: string; attemptId: string; errorClass: V3ErrorClass; errorCode?: string; message?: string }
   // Semantic/contract failure — recoverable.  classifyTerminal(errorClass,
   // retryable) decides blocked-vs-failed; blocked halts the run like failed
   // but is retryable via `nodeRetryRequested` (journal event, NOT in-memory).
@@ -72,7 +79,7 @@ export type V3Event =
   // ASK_HUMAN_ERROR_CODE): the goal worker's question, read from the attempt's
   // ask.json.  The daemon renders an ask card instead of a plain retry card;
   // everything else is identical to a contract-failure block.
-  | { type: 'nodeBlocked'; nodeId: string; attemptId: string; errorClass: V3ErrorClass; errorCode?: string; message?: string; ask?: GoalAsk }
+  | { type: 'nodeBlocked'; nodeId: string; instanceId?: string; attemptId: string; errorClass: V3ErrorClass; errorCode?: string; message?: string; ask?: GoalAsk }
   // Retry intent for a blocked node.  Appended by the retry entrypoint (CLI /
   // daemon card click).  materialize() resets the node to pending and records
   // `nextAttemptId` as the attempt reservation; the orchestrator then re-
@@ -82,6 +89,11 @@ export type V3Event =
   | {
       type: 'nodeRetryRequested';
       nodeId: string;
+      // The instance being retried.  A blocked / human-ask retry stays in the
+      // SAME instance — `previousAttemptId`/`nextAttemptId` are attempts under
+      // this `instanceId` (`A#001/attempts/002`).  This is NOT a revisit: a
+      // revisit makes a NEW instance via nodeInstanceSuperseded + re-dispatch.
+      instanceId?: string;
       previousAttemptId: string;
       nextAttemptId: string;
       reason: 'blockedRetry';
@@ -94,16 +106,24 @@ export type V3Event =
       // continues.  Absent for an ordinary blocked retry.
       answer?: { path: string; preview: string; by: string };
     }
-  | { type: 'gateDispatched'; nodeId: string; waitId: string }
-  | { type: 'gateResolved'; nodeId: string; waitId: string; resolution: 'approved' | 'rejected'; by: string; selected?: string }
+  // Gate is per-INSTANCE: `A#001`'s approval must not clear `A#002` after a
+  // revisit (constraint 6).  `instanceId` optional for back-compat.
+  | { type: 'gateDispatched'; nodeId: string; instanceId?: string; waitId: string }
+  | { type: 'gateResolved'; nodeId: string; instanceId?: string; waitId: string; resolution: 'approved' | 'rejected'; by: string; selected?: string }
   // ── edge activation lifecycle ──
   // Conditional edge predicates read a source node's validated result.json
   // exactly once, then persist the verdict here.  Replay / dashboards /
   // decideNext consume this event and never re-read result.json.
+  // `fromInstanceId`/`toInstanceId` scope the verdict to a concrete instance
+  // pair so a revisit's `A#001->B#001` verdict never bleeds onto the fresh
+  // `A#002->B#002` edge (constraint 1).  `from`/`to` stay as definition-layer
+  // labels for the dashboard; both optional for back-compat.
   | {
       type: 'edgeResolved';
       from: string;
       to: string;
+      fromInstanceId?: string;
+      toInstanceId?: string;
       sourceAttemptId: string;
       active: boolean;
       detail?: string;
@@ -118,10 +138,38 @@ export type V3Event =
   | {
       type: 'nodeCancelled';
       nodeId: string;
+      instanceId?: string;
       attemptId?: string;
       reason: 'earlyReleaseLoser';
       byNodeId: string;
       detail?: string;
+    }
+  // ── cross-node revisit / instance lifecycle (instance restoration 2026-06-08) ──
+  // A node's worker emitted result.json `status:"revisit"` requesting a jump
+  // back to ancestor `toNodeId` (must be in the node's `revisitTo`).  Audit +
+  // the trigger for the supersede sweep the runtime appends next.  `reason` is
+  // the worker's free-text "why" (the cross-node analogue of a block reason).
+  | {
+      type: 'nodeRevisitRequested';
+      nodeId: string;
+      instanceId: string;
+      attemptId: string;
+      toNodeId: string;
+      reason?: string;
+    }
+  // The revisit invalidates a runtime instance: the target's current effective
+  // instance AND every already-materialized instance in its downstream cone are
+  // superseded (marked, never deleted — files stay for audit + as the
+  // `targetPreviousManifestPath` snapshot).  `byNodeId` = the revisit target
+  // that triggered the refresh.  materialize sets the instance `superseded` and
+  // recomputes the node's `effectiveInstanceId`, so decideNext re-dispatches a
+  // fresh `#NNN`.  This is the "refresh" the dashboard shows on those nodes.
+  | {
+      type: 'nodeInstanceSuperseded';
+      nodeId: string;
+      instanceId: string;
+      byNodeId: string;
+      reason: 'refresh';
     }
   // ── structured loop lifecycle ──
   // A loop is a composite node: its body expands into REAL journal-level nodes

--- a/src/workflows/v3/journal.ts
+++ b/src/workflows/v3/journal.ts
@@ -181,6 +181,18 @@ export type V3Event =
       byNodeId: string;
       reason: 'refresh';
     }
+  // A human granted extra revisit budget after the run blocked on exhaustion
+  // (the revisit analogue of loopIterationGranted).  A PAIR grant (both
+  // sourceNodeId + toNodeId set) bumps one source→target edge's allowance by 1;
+  // a RUN grant (neither set) bumps the run-wide allowance by 1.  Consumed by
+  // the next budget check in the runtime's revisit recognition.
+  | {
+      type: 'revisitBudgetGranted';
+      sourceNodeId?: string;
+      toNodeId?: string;
+      by: string;
+      reason?: string;
+    }
   // ── structured loop lifecycle ──
   // A loop is a composite node: its body expands into REAL journal-level nodes
   // per iteration (instance ids via loopInstanceId), so dispatch/settle/retry

--- a/src/workflows/v3/journal.ts
+++ b/src/workflows/v3/journal.ts
@@ -79,7 +79,12 @@ export type V3Event =
   // ASK_HUMAN_ERROR_CODE): the goal worker's question, read from the attempt's
   // ask.json.  The daemon renders an ask card instead of a plain retry card;
   // everything else is identical to a contract-failure block.
-  | { type: 'nodeBlocked'; nodeId: string; instanceId?: string; attemptId: string; errorClass: V3ErrorClass; errorCode?: string; message?: string; ask?: GoalAsk }
+  | { type: 'nodeBlocked'; nodeId: string; instanceId?: string; attemptId: string; errorClass: V3ErrorClass; errorCode?: string; message?: string; ask?: GoalAsk;
+      // Set only when errorCode === 'REVISIT_BUDGET_EXHAUSTED': the ancestor this
+      // node tried to revisit.  The grant card reads it to label the source→target
+      // pair + pick the grant scope (the revisit was budget-blocked before any
+      // nodeRevisitRequested was journaled, so the target isn't recorded elsewhere).
+      revisitTo?: string }
   // Retry intent for a blocked node.  Appended by the retry entrypoint (CLI /
   // daemon card click).  materialize() resets the node to pending and records
   // `nextAttemptId` as the attempt reservation; the orchestrator then re-

--- a/src/workflows/v3/journal.ts
+++ b/src/workflows/v3/journal.ts
@@ -156,6 +156,16 @@ export type V3Event =
       attemptId: string;
       toNodeId: string;
       reason?: string;
+      // Feedback paths (runDir-relative) the target's fresh instance reads via
+      // `from:"revisit"` inputs — so it knows WHY it was sent back, WHAT the
+      // downstream found, and WHAT it itself produced last time, instead of
+      // re-running blind.  reasonPath: the reason text file (runtime-written);
+      // sourceManifestPath: the requesting node's manifest (its products are the
+      // "where it went wrong" evidence); targetPreviousManifestPath: the target's
+      // own prior (now-superseded) manifest (so it edits, not rewrites).
+      reasonPath?: string;
+      sourceManifestPath?: string;
+      targetPreviousManifestPath?: string;
     }
   // The revisit invalidates a runtime instance: the target's current effective
   // instance AND every already-materialized instance in its downstream cone are

--- a/src/workflows/v3/orchestrator.ts
+++ b/src/workflows/v3/orchestrator.ts
@@ -400,14 +400,15 @@ function firstUnresolved(activities: EdgeActivity[]): Extract<EdgeActivity, { ki
   return activities.find((a): a is Extract<EdgeActivity, { kind: 'unresolved' }> => a.kind === 'unresolved');
 }
 
-/** The edge key for the CURRENT effective instances of source/target — must
- *  mirror the key materialize stores edgeResolved under (constraint 1), so a
- *  revisit's `A#002->B#002` reads its OWN verdict, not `A#001->B#001`'s.
- *  Falls back to the nodeId pair when a node has no runtime instance. */
+/** The edge key for the source's CURRENT effective instance — mirrors the key
+ *  materialize stores edgeResolved under (verdict bound to SOURCE instance, 菲菲
+ *  review).  A source revisit (`A#001`→`A#002`) reads a fresh `A#002->B`, never
+ *  the superseded `A#001->B`.  Target is keyed by nodeId (it has no instance at
+ *  edge-resolve time); a target-only revisit reusing the verdict is a known,
+ *  documented limitation. */
 function currentEdgeKey(from: string, to: string, state: V3RunState): string {
   const fromInst = st(state, from).effectiveInstanceId ?? from;
-  const toInst = st(state, to).effectiveInstanceId ?? to;
-  return `${fromInst}->${toInst}`;
+  return `${fromInst}->${to}`;
 }
 
 /** The CURRENT iteration's expanded instance ids of a loop node (empty for

--- a/src/workflows/v3/orchestrator.ts
+++ b/src/workflows/v3/orchestrator.ts
@@ -99,7 +99,7 @@ export type V3Action =
   /** Abort an early-release loser whose remaining products are no longer used. */
   | { kind: 'cancelNode'; nodeId: string; byNodeId: string; detail?: string }
   /** Post the humanGate approval card + persist a `waits/<id>.json` (Q10). */
-  | { kind: 'dispatchGate'; nodeId: string }
+  | { kind: 'dispatchGate'; nodeId: string; instanceId?: string }
   /** Spawn an ephemeral worker via `runNode` for this node's goal.  `loop` is
    *  set for body-instance dispatches (the runtime synthesizes the instance
    *  node from the loop's body definition).  `instanceId` is set when this is a
@@ -275,7 +275,9 @@ export function decideNext(
     }
 
     if (node.humanGate && !s.gateCleared) {
-      actions.push({ kind: 'dispatchGate', nodeId: id });
+      // The gate belongs to the instance that will run on approval — same
+      // id resolution as dispatchWork (constraint 6), so gate + work share it.
+      actions.push({ kind: 'dispatchGate', nodeId: id, instanceId: s.effectiveInstanceId ?? nextInstanceId(id, instances) });
       continue;
     }
     // Every plain-node dispatch runs under a runtime instance (constraint 4 +
@@ -337,7 +339,7 @@ function readinessFor(node: V3Node, state: V3RunState, edges: V3EdgeRunState): N
     const source = st(state, dep.from);
     if (source.status === 'done') {
       if (!dep.when) return { kind: 'active', from: dep.from };
-      const edge = edges.get(edgeKey(dep.from, node.id));
+      const edge = edges.get(currentEdgeKey(dep.from, node.id, state));
       if (!edge) return { kind: 'unresolved', from: dep.from };
       return edge.active
         ? { kind: 'active', from: dep.from }
@@ -398,8 +400,14 @@ function firstUnresolved(activities: EdgeActivity[]): Extract<EdgeActivity, { ki
   return activities.find((a): a is Extract<EdgeActivity, { kind: 'unresolved' }> => a.kind === 'unresolved');
 }
 
-function edgeKey(from: string, to: string): string {
-  return `${from}->${to}`;
+/** The edge key for the CURRENT effective instances of source/target — must
+ *  mirror the key materialize stores edgeResolved under (constraint 1), so a
+ *  revisit's `A#002->B#002` reads its OWN verdict, not `A#001->B#001`'s.
+ *  Falls back to the nodeId pair when a node has no runtime instance. */
+function currentEdgeKey(from: string, to: string, state: V3RunState): string {
+  const fromInst = st(state, from).effectiveInstanceId ?? from;
+  const toInst = st(state, to).effectiveInstanceId ?? to;
+  return `${fromInst}->${toInst}`;
 }
 
 /** The CURRENT iteration's expanded instance ids of a loop node (empty for
@@ -493,7 +501,7 @@ function edgeActivityFor(
   const source = st(state, from);
   if (source.status === 'done') {
     if (!conditional) return { kind: 'active', from };
-    const edge = edges.get(edgeKey(from, to));
+    const edge = edges.get(currentEdgeKey(from, to, state));
     if (!edge) return { kind: 'unresolved', from };
     return edge.active
       ? { kind: 'active', from }

--- a/src/workflows/v3/orchestrator.ts
+++ b/src/workflows/v3/orchestrator.ts
@@ -102,8 +102,13 @@ export type V3Action =
   | { kind: 'dispatchGate'; nodeId: string }
   /** Spawn an ephemeral worker via `runNode` for this node's goal.  `loop` is
    *  set for body-instance dispatches (the runtime synthesizes the instance
-   *  node from the loop's body definition). */
-  | { kind: 'dispatchWork'; nodeId: string; loop?: V3LoopRef; omitted?: V3OmittedInput[] }
+   *  node from the loop's body definition).  `instanceId` is set when this is a
+   *  cross-node-revisit RE-DISPATCH (`A#002`): the prior instance was
+   *  superseded, so decideNext computes the next instance number deterministically
+   *  from `state.instances` (constraint 4 — the action carries it, the runtime
+   *  does not guess).  Absent on a first dispatch / loop body (those keep the
+   *  pre-instance-layer path until the runtime brick threads instances through). */
+  | { kind: 'dispatchWork'; nodeId: string; instanceId?: string; loop?: V3LoopRef; omitted?: V3OmittedInput[] }
   // ── loop control (the runtime translates each into ONE journal append) ──
   /** Outer deps of a loop are done → append loopStarted. */
   | { kind: 'startLoop'; loopId: string }
@@ -142,6 +147,7 @@ export function decideNext(
   state: V3RunState,
   loops: V3LoopRunState = new Map(),
   edges: V3EdgeRunState = new Map(),
+  instances: V3RunState = new Map(),
 ): V3Action[] {
   const order = topologicalOrder(dag);
   const nodes = new Map(dag.nodes.map((n) => [n.id, n]));
@@ -272,11 +278,17 @@ export function decideNext(
       actions.push({ kind: 'dispatchGate', nodeId: id });
       continue;
     }
-    actions.push(
-      readiness.omitted
-        ? { kind: 'dispatchWork', nodeId: id, omitted: readiness.omitted }
-        : { kind: 'dispatchWork', nodeId: id },
-    );
+    // A node with prior runtime instances (all superseded by a revisit) is a
+    // RE-DISPATCH: compute the next instance id (`A#002`) so the action — not
+    // the runtime — owns it (constraint 4).  A first dispatch (no instances)
+    // keeps the pre-instance-layer path (instanceId undefined).
+    const reInstanceId = nextInstanceId(id, instances);
+    actions.push({
+      kind: 'dispatchWork',
+      nodeId: id,
+      ...(reInstanceId ? { instanceId: reInstanceId } : {}),
+      ...(readiness.omitted ? { omitted: readiness.omitted } : {}),
+    });
     for (const loser of readiness.earlyLosers ?? []) {
       if (canCancelLoser(loser, id, dag, state, edges)) {
         actions.push({
@@ -532,4 +544,24 @@ export function findSinks(dag: V3Dag): string[] {
 
 function st(state: V3RunState, id: string): V3NodeState {
   return state.get(id) ?? { status: 'pending' };
+}
+
+/** The next runtime instance id for a definition node, computed from every
+ *  instance that has EVER appeared for it (`running/done/blocked/superseded`,
+ *  per 菲菲's review — not just the effective/terminal ones, else a re-dispatch
+ *  could collide with an existing `A#002`).  Returns `undefined` when the node
+ *  has no instances yet (a first dispatch keeps the pre-instance path).
+ *  Instance ids are `<nodeId>#NNN`, zero-padded to mirror attempt `001`. */
+function nextInstanceId(nodeId: string, instances: V3RunState): string | undefined {
+  const prefix = `${nodeId}#`;
+  let max = 0;
+  let seen = false;
+  for (const instanceId of instances.keys()) {
+    if (!instanceId.startsWith(prefix)) continue;
+    const n = Number.parseInt(instanceId.slice(prefix.length), 10);
+    if (!Number.isFinite(n)) continue;
+    seen = true;
+    if (n > max) max = n;
+  }
+  return seen ? `${prefix}${String(max + 1).padStart(3, '0')}` : undefined;
 }

--- a/src/workflows/v3/orchestrator.ts
+++ b/src/workflows/v3/orchestrator.ts
@@ -281,7 +281,7 @@ export function decideNext(
       continue;
     }
     // Every plain-node dispatch runs under a runtime instance (constraint 4 +
-    // 菲菲: 首派也要 #001).  decideNext — not the runtime — owns the id:
+    // design rule: 首派也要 #001).  decideNext — not the runtime — owns the id:
     //   - blocked / human-ask RETRY stays in the SAME instance (constraint 5):
     //     the node still carries `effectiveInstanceId`, so reuse it (the retry
     //     is a new attempt INSIDE it, e.g. A#001/attempts/002).
@@ -401,7 +401,7 @@ function firstUnresolved(activities: EdgeActivity[]): Extract<EdgeActivity, { ki
 }
 
 /** The edge key for the source's CURRENT effective instance — mirrors the key
- *  materialize stores edgeResolved under (verdict bound to SOURCE instance, 菲菲
+ *  materialize stores edgeResolved under (verdict bound to SOURCE instance, per code
  *  review).  A source revisit (`A#001`→`A#002`) reads a fresh `A#002->B`, never
  *  the superseded `A#001->B`.  Target is keyed by nodeId (it has no instance at
  *  edge-resolve time); a target-only revisit reusing the verdict is a known,
@@ -561,10 +561,10 @@ function st(state: V3RunState, id: string): V3NodeState {
 
 /** The next runtime instance id for a definition node, computed from every
  *  instance that has EVER appeared for it (`running/done/blocked/superseded`,
- *  per 菲菲's review — not just the effective/terminal ones, else a re-dispatch
+ *  per code review — not just the effective/terminal ones, else a re-dispatch
  *  could collide with an existing `A#002`).  First dispatch (no instances) →
  *  `#001`; a revisit re-dispatch → `#002`, … — instance is the real runtime
- *  node, so EVERY plain-node dispatch gets one (菲菲: 首派也要 #001).  Instance
+ *  node, so EVERY plain-node dispatch gets one (design rule: 首派也要 #001).  Instance
  *  ids are `<nodeId>#NNN`, zero-padded to mirror attempt `001`. */
 function nextInstanceId(nodeId: string, instances: V3RunState): string {
   const prefix = `${nodeId}#`;

--- a/src/workflows/v3/orchestrator.ts
+++ b/src/workflows/v3/orchestrator.ts
@@ -278,15 +278,19 @@ export function decideNext(
       actions.push({ kind: 'dispatchGate', nodeId: id });
       continue;
     }
-    // A node with prior runtime instances (all superseded by a revisit) is a
-    // RE-DISPATCH: compute the next instance id (`A#002`) so the action — not
-    // the runtime — owns it (constraint 4).  A first dispatch (no instances)
-    // keeps the pre-instance-layer path (instanceId undefined).
-    const reInstanceId = nextInstanceId(id, instances);
+    // Every plain-node dispatch runs under a runtime instance (constraint 4 +
+    // 菲菲: 首派也要 #001).  decideNext — not the runtime — owns the id:
+    //   - blocked / human-ask RETRY stays in the SAME instance (constraint 5):
+    //     the node still carries `effectiveInstanceId`, so reuse it (the retry
+    //     is a new attempt INSIDE it, e.g. A#001/attempts/002).
+    //   - first dispatch (no effective) → #001; a revisit re-dispatch (supersede
+    //     cleared the effective) → next #NNN from state.instances.
+    // (loop body dispatches use loopInstanceId, handled above.)
+    const instanceId = s.effectiveInstanceId ?? nextInstanceId(id, instances);
     actions.push({
       kind: 'dispatchWork',
       nodeId: id,
-      ...(reInstanceId ? { instanceId: reInstanceId } : {}),
+      instanceId,
       ...(readiness.omitted ? { omitted: readiness.omitted } : {}),
     });
     for (const loser of readiness.earlyLosers ?? []) {
@@ -549,19 +553,17 @@ function st(state: V3RunState, id: string): V3NodeState {
 /** The next runtime instance id for a definition node, computed from every
  *  instance that has EVER appeared for it (`running/done/blocked/superseded`,
  *  per 菲菲's review — not just the effective/terminal ones, else a re-dispatch
- *  could collide with an existing `A#002`).  Returns `undefined` when the node
- *  has no instances yet (a first dispatch keeps the pre-instance path).
- *  Instance ids are `<nodeId>#NNN`, zero-padded to mirror attempt `001`. */
-function nextInstanceId(nodeId: string, instances: V3RunState): string | undefined {
+ *  could collide with an existing `A#002`).  First dispatch (no instances) →
+ *  `#001`; a revisit re-dispatch → `#002`, … — instance is the real runtime
+ *  node, so EVERY plain-node dispatch gets one (菲菲: 首派也要 #001).  Instance
+ *  ids are `<nodeId>#NNN`, zero-padded to mirror attempt `001`. */
+function nextInstanceId(nodeId: string, instances: V3RunState): string {
   const prefix = `${nodeId}#`;
   let max = 0;
-  let seen = false;
   for (const instanceId of instances.keys()) {
     if (!instanceId.startsWith(prefix)) continue;
     const n = Number.parseInt(instanceId.slice(prefix.length), 10);
-    if (!Number.isFinite(n)) continue;
-    seen = true;
-    if (n > max) max = n;
+    if (Number.isFinite(n) && n > max) max = n;
   }
-  return seen ? `${prefix}${String(max + 1).padStart(3, '0')}` : undefined;
+  return `${prefix}${String(max + 1).padStart(3, '0')}`;
 }

--- a/src/workflows/v3/orchestrator.ts
+++ b/src/workflows/v3/orchestrator.ts
@@ -27,6 +27,9 @@ export type V3NodeStatus =
   | 'skipped'      // triggerRule unsatisfied; acceptable terminal if a sink still reaches done
   | 'cancelled'    // early-release loser; neutral terminal, not fail-fast
   | 'blocked'      // semantic/contract failure — recoverable via retry (new attempt)
+  | 'superseded'   // an INSTANCE refreshed by a cross-node revisit; the node gets
+                   //   a fresh instance and re-dispatches.  A settled-terminal for
+                   //   that instance, NOT a failure (instance restoration 2026-06-08)
   | 'failed';      // infrastructure failure / gate rejected / timed out — needs intervention
 
 export interface V3NodeState {
@@ -36,6 +39,11 @@ export interface V3NodeState {
    *  gate transitions the node straight to `failed` (set by the runtime), so
    *  this flag only ever records the approved case. */
   gateCleared?: boolean;
+  /** The current live runtime instance of this DEFINITION node (`A#002`).
+   *  Set on dispatch; cleared when a revisit supersedes it (the node then
+   *  re-dispatches a fresh instance).  Absent on the pre-instance-layer path
+   *  (plain nodeId-keyed events) and loop body expansions. */
+  effectiveInstanceId?: string;
 }
 
 /** nodeId → state.  A node absent from the map is treated as `pending`. */
@@ -496,7 +504,11 @@ function terminalStatus(status: V3NodeStatus): boolean {
     status === 'skipped' ||
     status === 'cancelled' ||
     status === 'failed' ||
-    status === 'blocked';
+    status === 'blocked' ||
+    // A superseded INSTANCE is settled (it won't change); the DEFINITION node
+    // re-dispatches under a fresh instance, but that is tracked at the node
+    // level (effectiveInstanceId), not by this per-instance status.
+    status === 'superseded';
 }
 
 function sinkOmissionDetail(sinks: string[], state: V3RunState): string {

--- a/src/workflows/v3/runtime.ts
+++ b/src/workflows/v3/runtime.ts
@@ -123,7 +123,7 @@ export function renderGoalFile(
     'You are an autonomous agent completing exactly ONE botmux v3 workflow node.',
     'Work toward the goal above until it is done, then stop. Do NOT ask the user with interactive tools (they are disabled in this mode). If you genuinely need a human DECISION to proceed, use the human-ask escape hatch described below (also available as the `botmux-goal-ask` skill).',
     '',
-    `- Upstream inputs: the file at $${E.INPUTS_PATH} is a JSON object \`{ "inputs": [...] }\` listing upstream products, each with an absolute \`path\`. Read only the ones the goal needs (it may be empty). If an \`omitted\` array is present, those declared inputs were intentionally not produced (their workflow branch was not taken) — treat their absence as by-design, do NOT invent their content.`,
+    `- Upstream inputs: the file at $${E.INPUTS_PATH} is a JSON object \`{ "inputs": [...] }\` listing upstream products, each with an absolute \`path\`. Read only the ones the goal needs (it may be empty). If it includes a \`human/answer\` input, read it before continuing. If an \`omitted\` array is present, those declared inputs were intentionally not produced (their workflow branch was not taken) — treat their absence as by-design, do NOT invent their content.`,
     `- Output: write ALL products under the directory at $${E.OUTPUT_DIR}. Do NOT write anything outside that directory.`,
     `- Manifest (required): before you finish, write a JSON manifest to $${E.MANIFEST_PATH} with exactly this shape:`,
     '',
@@ -148,9 +148,9 @@ export function renderGoalFile(
     '',
     '## Asking a human (only when a DECISION truly needs a person)',
     `If — and ONLY if — you cannot proceed without a human's judgement call (a choice only a person can make; NOT something you can research, infer, or decide yourself), use the runtime human-ask:`,
-    `  1. Write a JSON file to $${E.ATTEMPT_DIR}/${GOAL_ASK_FILE} of the shape \`{ "question": "<one clear question>", "options": ["<2-6 concrete choices>"] }\`.`,
+    `  1. Write a JSON file to $${E.ATTEMPT_DIR}/${GOAL_ASK_FILE}. Use \`{ "question": "<one clear question>", "options": ["<2-6 concrete choices>"] }\` for a choice, or \`{ "question": "<one clear question>", "freeText": true }\` when the human must provide details in their own words.`,
     `  2. Write a failure manifest with \`error.code: "${ASK_HUMAN_ERROR_CODE}"\`, \`error.retryable: true\`, and \`summary\` = your question, then STOP.`,
-    `A human picks one option; this node then RE-RUNS with their choice injected into $${E.INPUTS_PATH} as the \`human/answer\` input (read it and continue from there). Prefer deciding yourself — every ask pauses the whole workflow on a person.`,
+    `A human answers; this node then RE-RUNS with their answer injected into $${E.INPUTS_PATH} as the \`human/answer\` input. Read its \`selected\` or \`text\` field and continue from there. Prefer deciding yourself — every ask pauses the whole workflow on a person.`,
     '',
   ].join('\n');
 }
@@ -189,7 +189,7 @@ export function classifyTerminal(
  * Defensive: a missing / malformed / out-of-bounds file yields `undefined`, so a
  * broken ask degrades to a plain blocked card rather than crashing the drive —
  * the manifest's `error.message` still carries the question text for the human.
- * Needs ≥2 options (a choice) and caps at 6 (card sanity).  Exported for tests.
+ * Accepts either 2–6 concrete options or `freeText:true`.  Exported for tests.
  */
 export function readGoalAsk(askPath: string): GoalAsk | undefined {
   if (!existsSync(askPath)) return undefined;
@@ -203,6 +203,11 @@ export function readGoalAsk(askPath: string): GoalAsk | undefined {
   const o = parsed as Record<string, unknown>;
   const question = typeof o.question === 'string' ? o.question.trim() : '';
   if (!question) return undefined;
+  const hasOptions = Object.prototype.hasOwnProperty.call(o, 'options');
+  if (o.freeText === true) {
+    if (hasOptions) return undefined;
+    return { question, freeText: true };
+  }
   const options = Array.isArray(o.options)
     ? o.options.filter((x): x is string => typeof x === 'string' && x.trim() !== '').map((x) => x.trim())
     : [];

--- a/src/workflows/v3/runtime.ts
+++ b/src/workflows/v3/runtime.ts
@@ -242,6 +242,45 @@ export interface ResultValidation {
   problems?: string[];
 }
 
+/** Read a worker's cross-node revisit request from `result.json` (if any).  A
+ *  revisit is `{ "status": "revisit", "revisitTo": "<ancestor>", "reason"? }`.
+ *  Absent result.json / non-revisit status → `{ ok:true }` (no request).  A
+ *  malformed revisit (missing/blank revisitTo, non-string reason) → `ok:false`
+ *  so the runtime blocks it as resultInvalid.  The ancestor membership check
+ *  (toNodeId ∈ node.revisitTo) is the caller's (it has the node). */
+export function readRevisitRequest(
+  manifest: Manifest,
+  outputDir: string,
+): { ok: true; request?: { toNodeId: string; reason?: string } } | { ok: false; problems: string[] } {
+  const entry = manifest.files.find((f) => f.path === 'result.json');
+  if (!entry) return { ok: true };
+  let value: unknown;
+  try {
+    value = JSON.parse(readFileSync(join(outputDir, entry.path), 'utf-8'));
+  } catch {
+    return { ok: true }; // unreadable result.json: not a revisit (resultSchema path reports it)
+  }
+  if (!value || typeof value !== 'object' || (value as Record<string, unknown>).status !== 'revisit') {
+    return { ok: true };
+  }
+  const v = value as Record<string, unknown>;
+  const problems: string[] = [];
+  if (typeof v.revisitTo !== 'string' || v.revisitTo.trim() === '') {
+    problems.push('result.json status "revisit" requires a non-empty string "revisitTo"');
+  }
+  if (v.reason !== undefined && typeof v.reason !== 'string') {
+    problems.push('result.json "reason" must be a string when present');
+  }
+  if (problems.length > 0) return { ok: false, problems };
+  return {
+    ok: true,
+    request: {
+      toNodeId: v.revisitTo as string,
+      ...(typeof v.reason === 'string' && v.reason ? { reason: v.reason } : {}),
+    },
+  };
+}
+
 /**
  * Validate a `result.json` against the node's (already dag-validated) result
  * schema subset.  Top-level types only — see `V3ResultSchema`.  Undeclared
@@ -739,6 +778,31 @@ export async function runWorkflow(
         const manifestSaysOk = verdict.ok && verdict.manifest?.status === 'ok';
 
         if (result.status === 'ok' && manifestSaysOk) {
+          // Cross-node revisit: the worker's result.json may request a jump back
+          // to an ancestor (`status:"revisit", revisitTo, reason`).  Recognized
+          // BEFORE success/resultSchema — a revisit is not a node success.
+          const revisit = readRevisitRequest(verdict.manifest!, outputDir);
+          if (!revisit.ok) {
+            appendEvent(journalPath, {
+              type: 'nodeBlocked', nodeId: node.id, ...(instanceId ? { instanceId } : {}), attemptId,
+              errorClass: 'resultInvalid', message: revisit.problems.join('; '),
+            });
+            return;
+          }
+          if (revisit.request) {
+            if (!node.revisitTo?.includes(revisit.request.toNodeId)) {
+              appendEvent(journalPath, {
+                type: 'nodeBlocked', nodeId: node.id, ...(instanceId ? { instanceId } : {}), attemptId,
+                errorClass: 'resultInvalid',
+                message: `result.json requests revisit to "${revisit.request.toNodeId}", not in node "${node.id}".revisitTo`,
+              });
+              return;
+            }
+            // goal-node dispatches always carry instanceId (首派 #001); the
+            // fallback keeps the type total for the legacy/no-instance path.
+            appendRevisitEvents(node.id, instanceId ?? node.id, attemptId, revisit.request);
+            return;
+          }
           // Opt-in structured-result contract: the manifest MUST list a
           // `result.json` entry (so it went through the manifest validator's
           // path/hash checks like every other product), and the file must
@@ -839,6 +903,51 @@ export async function runWorkflow(
         releaseSlots(botKey, botSnap.cliId);
       });
     inFlight.set(node.id, p);
+  }
+
+  /** A node's transitive downstream cone (the node itself + every node reachable
+   *  via `depends` edges).  The set a revisit to `root` must refresh: `root`'s
+   *  product changed, so every result derived from it is stale. */
+  function affectedNodesFrom(root: string): string[] {
+    const reachable = new Set<string>([root]);
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const n of dag.nodes) {
+        if (reachable.has(n.id)) continue;
+        if (n.depends.some((d) => reachable.has(d.from))) {
+          reachable.add(n.id);
+          changed = true;
+        }
+      }
+    }
+    return [...reachable];
+  }
+
+  /** A worker requested a cross-node revisit to ancestor `toNodeId`: journal the
+   *  request, then supersede the CURRENT effective instance of the target AND its
+   *  whole downstream cone (mark-only, files kept).  materialize then drops their
+   *  effectiveInstanceId → decideNext re-dispatches fresh `#NNN` instances. */
+  function appendRevisitEvents(
+    nodeId: string,
+    instanceId: string,
+    attemptId: string,
+    request: { toNodeId: string; reason?: string },
+  ): void {
+    appendEvent(journalPath, {
+      type: 'nodeRevisitRequested',
+      nodeId, instanceId, attemptId, toNodeId: request.toNodeId,
+      ...(request.reason ? { reason: request.reason } : {}),
+    });
+    const snap = materialize(readJournal(journalPath));
+    for (const affectedNodeId of affectedNodesFrom(request.toNodeId)) {
+      const eff = snap.nodes.get(affectedNodeId)?.effectiveInstanceId;
+      if (!eff) continue; // never-dispatched downstream node has nothing to supersede
+      appendEvent(journalPath, {
+        type: 'nodeInstanceSuperseded',
+        nodeId: affectedNodeId, instanceId: eff, byNodeId: request.toNodeId, reason: 'refresh',
+      });
+    }
   }
 
   function startGate(node: V3Node, instanceId?: string): void {

--- a/src/workflows/v3/runtime.ts
+++ b/src/workflows/v3/runtime.ts
@@ -844,6 +844,9 @@ export async function runWorkflow(
   function startGate(node: V3Node, instanceId?: string): void {
     const waitId = `${node.id}-gate`; // MVP: one gate per node
     const gate = normalizeGateWaitInput(node.humanGate!);
+    // gateDispatched carries instanceId (journal layer, accepted in 3239cf8);
+    // DEFERRED: instance-level waitId + stale-card guard (菲菲 review) — needs a
+    // waitId migration / card-action change, off the A→B→C critical path.
     appendEvent(journalPath, { type: 'gateDispatched', nodeId: node.id, ...(instanceId ? { instanceId } : {}), waitId });
 
     if (gateMode === 'suspend') {

--- a/src/workflows/v3/runtime.ts
+++ b/src/workflows/v3/runtime.ts
@@ -575,7 +575,7 @@ export async function runWorkflow(
           startWork(node, botSnap, botKey, events, a.loop, a.omitted, a.instanceId);
           startedThisTick++;
         } else if (a.kind === 'dispatchGate') {
-          startGate(nodesById.get(a.nodeId)!);
+          startGate(nodesById.get(a.nodeId)!, a.instanceId);
           startedThisTick++;
         }
       }
@@ -841,10 +841,10 @@ export async function runWorkflow(
     inFlight.set(node.id, p);
   }
 
-  function startGate(node: V3Node): void {
+  function startGate(node: V3Node, instanceId?: string): void {
     const waitId = `${node.id}-gate`; // MVP: one gate per node
     const gate = normalizeGateWaitInput(node.humanGate!);
-    appendEvent(journalPath, { type: 'gateDispatched', nodeId: node.id, waitId });
+    appendEvent(journalPath, { type: 'gateDispatched', nodeId: node.id, ...(instanceId ? { instanceId } : {}), waitId });
 
     if (gateMode === 'suspend') {
       writePendingWait(runDir, { waitId, nodeId: node.id, ...gate });
@@ -974,6 +974,14 @@ export async function runWorkflow(
     a: Extract<V3Action, { kind: 'resolveEdge' }>,
     events: StoredEvent[],
   ): void {
+    // Scope the verdict to the CURRENT effective instances of source/target so a
+    // revisit's `A#001->B#001` verdict never bleeds onto `A#002->B#002`
+    // (constraint 1).  Legacy/no-instance falls back to the bare nodeId.
+    const snap = materialize(events);
+    const fromInstanceId = snap.nodes.get(a.from)?.effectiveInstanceId;
+    const toInstanceId = snap.nodes.get(a.to)?.effectiveInstanceId;
+    const fromKey = fromInstanceId ?? a.from;
+    const instPair = { ...(fromInstanceId ? { fromInstanceId } : {}), ...(toInstanceId ? { toInstanceId } : {}) };
     const target = nodesById.get(a.to);
     const dep = target?.depends.find((d) => d.from === a.from);
     if (!target || !dep?.when) {
@@ -981,7 +989,8 @@ export async function runWorkflow(
         type: 'edgeResolved',
         from: a.from,
         to: a.to,
-        sourceAttemptId: latestAttemptIdFor(events, a.from) ?? `${a.from}/attempts/unknown`,
+        ...instPair,
+        sourceAttemptId: latestAttemptIdFor(events, fromKey) ?? `${fromKey}/attempts/unknown`,
         active: false,
         detail: 'edge predicate missing at resolution time',
       });
@@ -991,8 +1000,8 @@ export async function runWorkflow(
     const succ = [...events]
       .reverse()
       .find((e): e is StoredEvent & { type: 'nodeSucceeded' } =>
-        e.type === 'nodeSucceeded' && e.nodeId === a.from);
-    const sourceAttemptId = succ?.attemptId ?? `${a.from}/attempts/unknown`;
+        e.type === 'nodeSucceeded' && (e.instanceId ?? e.nodeId) === fromKey);
+    const sourceAttemptId = succ?.attemptId ?? `${fromKey}/attempts/unknown`;
     const key = dep.when.path.slice('result.'.length);
     let active = false;
     let detail = `${dep.when.path}=<unreadable>`;
@@ -1016,6 +1025,7 @@ export async function runWorkflow(
       type: 'edgeResolved',
       from: a.from,
       to: a.to,
+      ...instPair,
       sourceAttemptId,
       active,
       detail,

--- a/src/workflows/v3/runtime.ts
+++ b/src/workflows/v3/runtime.ts
@@ -22,6 +22,8 @@ import { join, dirname, relative, isAbsolute } from 'node:path';
 
 import {
   DEFAULT_NODE_TIMEOUT_SEC,
+  DEFAULT_REVISIT_BUDGET_PER_PAIR,
+  DEFAULT_REVISIT_BUDGET_PER_RUN,
   isGoalNode,
   isLoopNode,
   loopInstanceId,
@@ -249,6 +251,40 @@ export interface ResultValidation {
  *  malformed revisit (missing/blank revisitTo, non-string reason) → `ok:false`
  *  so the runtime blocks it as resultInvalid.  The ancestor membership check
  *  (toNodeId ∈ node.revisitTo) is the caller's (it has the node). */
+/** Two-tier revisit budget check (anti-infinite-loop): a source→target pair may
+ *  revisit `DEFAULT_REVISIT_BUDGET_PER_PAIR` times, and the whole run
+ *  `DEFAULT_REVISIT_BUDGET_PER_RUN` times, each extendable by a
+ *  `revisitBudgetGranted` event.  Counts revisits ALREADY made; returns
+ *  `{ok:false, detail}` when this next revisit would exceed either tier. */
+export function revisitBudgetStatus(
+  events: StoredEvent[],
+  sourceNodeId: string,
+  toNodeId: string,
+): { ok: true } | { ok: false; detail: string } {
+  let pairUsed = 0;
+  let runUsed = 0;
+  let pairGranted = 0;
+  let runGranted = 0;
+  for (const e of events) {
+    if (e.type === 'nodeRevisitRequested') {
+      runUsed++;
+      if (e.nodeId === sourceNodeId && e.toNodeId === toNodeId) pairUsed++;
+    } else if (e.type === 'revisitBudgetGranted') {
+      if (e.sourceNodeId === sourceNodeId && e.toNodeId === toNodeId) pairGranted++;
+      else if (e.sourceNodeId === undefined && e.toNodeId === undefined) runGranted++;
+    }
+  }
+  const pairLimit = DEFAULT_REVISIT_BUDGET_PER_PAIR + pairGranted;
+  const runLimit = DEFAULT_REVISIT_BUDGET_PER_RUN + runGranted;
+  if (pairUsed >= pairLimit) {
+    return { ok: false, detail: `revisit budget exhausted for ${sourceNodeId}->${toNodeId} (${pairUsed}/${pairLimit}) — grant +1 (this pair) to continue` };
+  }
+  if (runUsed >= runLimit) {
+    return { ok: false, detail: `run-wide revisit budget exhausted (${runUsed}/${runLimit}) — grant +1 (run) to continue` };
+  }
+  return { ok: true };
+}
+
 export function readRevisitRequest(
   manifest: Manifest,
   outputDir: string,
@@ -796,6 +832,17 @@ export async function runWorkflow(
                 type: 'nodeBlocked', nodeId: node.id, ...(instanceId ? { instanceId } : {}), attemptId,
                 errorClass: 'resultInvalid',
                 message: `result.json requests revisit to "${revisit.request.toNodeId}", not in node "${node.id}".revisitTo`,
+              });
+              return;
+            }
+            // Anti-infinite-loop: a revisit consumes per-pair + per-run budget.
+            // Exhausted → block this node (recoverable) instead of superseding;
+            // a human grants +1 (revisitBudgetGranted) then retries.
+            const budget = revisitBudgetStatus(readJournal(journalPath), node.id, revisit.request.toNodeId);
+            if (!budget.ok) {
+              appendEvent(journalPath, {
+                type: 'nodeBlocked', nodeId: node.id, ...(instanceId ? { instanceId } : {}), attemptId,
+                errorClass: 'resultInvalid', errorCode: 'REVISIT_BUDGET_EXHAUSTED', message: budget.detail,
               });
               return;
             }

--- a/src/workflows/v3/runtime.ts
+++ b/src/workflows/v3/runtime.ts
@@ -1024,15 +1024,15 @@ export async function runWorkflow(
   }
 
   function startGate(node: V3Node, instanceId?: string): void {
-    const waitId = `${node.id}-gate`; // MVP: one gate per node
+    // Instance-level waitId so a revisit's fresh gate (`A#002-gate`) gets its own
+    // wait file + card nonce, never overwriting the superseded `A#001-gate`
+    // (stale-card protection).  Legacy/no-instance → `<nodeId>-gate`.
+    const waitId = `${instanceId ?? node.id}-gate`;
     const gate = normalizeGateWaitInput(node.humanGate!);
-    // gateDispatched carries instanceId (journal layer, accepted in 3239cf8);
-    // DEFERRED: instance-level waitId + stale-card guard (code review) — needs a
-    // waitId migration / card-action change, off the A→B→C critical path.
     appendEvent(journalPath, { type: 'gateDispatched', nodeId: node.id, ...(instanceId ? { instanceId } : {}), waitId });
 
     if (gateMode === 'suspend') {
-      writePendingWait(runDir, { waitId, nodeId: node.id, ...gate });
+      writePendingWait(runDir, { waitId, nodeId: node.id, ...(instanceId ? { instanceId } : {}), ...gate });
       return;
     }
 
@@ -1243,14 +1243,16 @@ export async function runWorkflow(
     return true;
   }
 
-  function pendingGateWaits(state: Map<string, { status: string }>): V3PendingGate[] {
+  function pendingGateWaits(state: Map<string, { status: string; effectiveInstanceId?: string }>): V3PendingGate[] {
     const waits: V3PendingGate[] = [];
     for (const node of dag.nodes) {
       if (state.get(node.id)?.status !== 'gateWaiting') continue;
       const prompt = node.humanGate?.prompt;
       if (!prompt) continue;
       const gate = normalizeGateWaitInput(node.humanGate!);
-      waits.push({ nodeId: node.id, waitId: `${node.id}-gate`, ...gate });
+      // Instance-level waitId mirrors startGate (stale-card protection).
+      const instanceId = state.get(node.id)?.effectiveInstanceId;
+      waits.push({ nodeId: node.id, waitId: `${instanceId ?? node.id}-gate`, ...gate });
     }
     return waits;
   }

--- a/src/workflows/v3/runtime.ts
+++ b/src/workflows/v3/runtime.ts
@@ -492,7 +492,7 @@ export async function runWorkflow(
     writeState(statePath, snap);
     if (snap.runStatus !== 'running') break;
 
-    const actions = decideNext(dag, snap.nodes, snap.loops, snap.edges);
+    const actions = decideNext(dag, snap.nodes, snap.loops, snap.edges, snap.instances);
 
     // Terminal sweep: write the run terminal event, then re-tick so the top of
     // the loop observes it and breaks (single exit path).

--- a/src/workflows/v3/runtime.ts
+++ b/src/workflows/v3/runtime.ts
@@ -1208,6 +1208,11 @@ export async function runWorkflow(
   ): GoalInputs {
     const inputs: GoalInputs['inputs'] = [];
     const omittedFrom = new Set((omitted ?? []).map((o) => o.from));
+    // Resolve upstream products by the source's CURRENT effective instance, NOT
+    // by nodeId-latest (菲菲 blocker): after a revisit, a stale `A#001` worker
+    // can settle LATE; nodeId-latest would then hand `A#001`'s old product to
+    // `B#002`.  Keying by effectiveInstanceId pins it to `A#002`.
+    const snap = materialize(events);
 
     // Runtime human-ask answer: when THIS dispatch is the retry a human-ask was
     // answered into, inject the persisted answer as a `human/answer` input so the
@@ -1227,18 +1232,23 @@ export async function runWorkflow(
       });
     }
 
-    const latestSuccess = (nodeId: string) =>
+    // Latest success for a dispatch `key` (an effective instance `A#002`, a loop
+    // body expansion, or a legacy nodeId), matched by `(instanceId ?? nodeId)`.
+    const latestSuccess = (key: string) =>
       [...events]
         .reverse()
         .find((e): e is StoredEvent & { type: 'nodeSucceeded' } =>
-          e.type === 'nodeSucceeded' && e.nodeId === nodeId);
+          e.type === 'nodeSucceeded' && (e.instanceId ?? e.nodeId) === key);
 
     const pushFrom = (
       label: string,
       nodeId: string,
       filter?: (f: Manifest['files'][number]) => boolean,
     ): void => {
-      const succ = latestSuccess(nodeId);
+      // Pin to the source's current effective instance (falls back to nodeId for
+      // loop bodies / legacy with no instance).
+      const key = snap.nodes.get(nodeId)?.effectiveInstanceId ?? nodeId;
+      const succ = latestSuccess(key);
       if (!succ) return; // deps are gated upstream — defensive skip
       const upstreamOutputDir = join(dirname(succ.manifestPath), 'work');
       const manifest = JSON.parse(readFileSync(succ.manifestPath, 'utf-8')) as Manifest;
@@ -1246,6 +1256,7 @@ export async function runWorkflow(
         if (filter && !filter(f)) continue;
         inputs.push({
           from: label,
+          ...(succ.instanceId ? { instanceId: succ.instanceId } : {}),
           name: f.name,
           path: join(upstreamOutputDir, f.path),
           kind: f.kind,

--- a/src/workflows/v3/runtime.ts
+++ b/src/workflows/v3/runtime.ts
@@ -18,7 +18,7 @@
  */
 
 import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, relative, isAbsolute } from 'node:path';
 
 import {
   DEFAULT_NODE_TIMEOUT_SEC,
@@ -945,21 +945,24 @@ export async function runWorkflow(
       ? [...events0].reverse().find((e): e is StoredEvent & { type: 'nodeSucceeded' } =>
           e.type === 'nodeSucceeded' && (e.instanceId ?? e.nodeId) === targetEff)
       : undefined;
-    // Persist the reason as a file the target's fresh instance can Read.
-    let reasonPath: string | undefined;
+    // Persist the reason as a file the target's fresh instance can Read.  The
+    // journal stores runDir-RELATIVE paths (run-dir portability + no abs-path
+    // leakage into projections/cards); buildInputs resolves to absolute on read.
+    let reasonPathRel: string | undefined;
     if (request.reason) {
       const dir = join(runDir, 'revisits');
       mkdirSync(dir, { recursive: true });
-      reasonPath = join(dir, `${instanceId.replace(/[#/]/g, '-')}-reason.md`);
-      writeFileSync(reasonPath, `# Revisit reason (from ${nodeId} / ${instanceId})\n\n${request.reason}\n`);
+      const abs = join(dir, `${instanceId.replace(/[#/]/g, '-')}-reason.md`);
+      writeFileSync(abs, `# Revisit reason (from ${nodeId} / ${instanceId})\n\n${request.reason}\n`);
+      reasonPathRel = relative(runDir, abs);
     }
     appendEvent(journalPath, {
       type: 'nodeRevisitRequested',
       nodeId, instanceId, attemptId, toNodeId: request.toNodeId,
       ...(request.reason ? { reason: request.reason } : {}),
-      ...(reasonPath ? { reasonPath } : {}),
-      sourceManifestPath,
-      ...(targetSucc ? { targetPreviousManifestPath: targetSucc.manifestPath } : {}),
+      ...(reasonPathRel ? { reasonPath: reasonPathRel } : {}),
+      sourceManifestPath: relative(runDir, sourceManifestPath),
+      ...(targetSucc ? { targetPreviousManifestPath: relative(runDir, targetSucc.manifestPath) } : {}),
     });
     for (const affectedNodeId of affectedNodesFrom(request.toNodeId)) {
       const eff = snap.nodes.get(affectedNodeId)?.effectiveInstanceId;
@@ -1291,15 +1294,19 @@ export async function runWorkflow(
     // nodeRevisitRequested event (requester / target-prior), not via a
     // nodeSucceeded lookup.  Names are prefixed so the agent can tell the
     // feedback pieces apart (`revisit/source:…`, `revisit/previous:…`).
+    // Journal stores runDir-relative revisit paths; resolve to absolute for read.
+    const resolveRunPath = (p: string): string => (isAbsolute(p) ? p : join(runDir, p));
     const pushManifestByPath = (label: string, manifestPath: string | undefined, namePrefix: string): void => {
-      if (!manifestPath || !existsSync(manifestPath)) return;
+      if (!manifestPath) return;
+      const abs = resolveRunPath(manifestPath);
+      if (!existsSync(abs)) return;
       let manifest: Manifest;
       try {
-        manifest = JSON.parse(readFileSync(manifestPath, 'utf-8')) as Manifest;
+        manifest = JSON.parse(readFileSync(abs, 'utf-8')) as Manifest;
       } catch {
         return;
       }
-      const outDir = join(dirname(manifestPath), 'work');
+      const outDir = join(dirname(abs), 'work');
       for (const f of manifest.files) {
         inputs.push({
           from: label,
@@ -1342,7 +1349,7 @@ export async function runWorkflow(
         e.type === 'nodeRevisitRequested' && e.toNodeId === node.id);
     if (revisitReq) {
       if (revisitReq.reasonPath) {
-        inputs.push({ from: 'revisit', name: 'reason', path: revisitReq.reasonPath, kind: 'markdown', preview: revisitReq.reason });
+        inputs.push({ from: 'revisit', name: 'reason', path: resolveRunPath(revisitReq.reasonPath), kind: 'markdown', preview: revisitReq.reason });
       }
       pushManifestByPath('revisit', revisitReq.sourceManifestPath, 'source');
       pushManifestByPath('revisit', revisitReq.targetPreviousManifestPath, 'previous');

--- a/src/workflows/v3/runtime.ts
+++ b/src/workflows/v3/runtime.ts
@@ -1223,10 +1223,14 @@ export async function runWorkflow(
     const status = snap.nodes.get(a.nodeId)?.status ?? 'pending';
     if (status !== 'pending' && status !== 'gateWaiting' && status !== 'running') return false;
 
-    const attemptId = latestAttemptIdFor(events, a.nodeId);
+    // Stamp the cancelled INSTANCE so a later instance (`A#002` after a revisit)
+    // settles freely — the cancel suppression in materialize keys by instance.
+    const instanceId = snap.nodes.get(a.nodeId)?.effectiveInstanceId;
+    const attemptId = latestAttemptIdFor(events, instanceId ?? a.nodeId);
     appendEvent(journalPath, {
       type: 'nodeCancelled',
       nodeId: a.nodeId,
+      ...(instanceId ? { instanceId } : {}),
       attemptId,
       reason: 'earlyReleaseLoser',
       byNodeId: a.byNodeId,

--- a/src/workflows/v3/runtime.ts
+++ b/src/workflows/v3/runtime.ts
@@ -255,12 +255,13 @@ export interface ResultValidation {
  *  revisit `DEFAULT_REVISIT_BUDGET_PER_PAIR` times, and the whole run
  *  `DEFAULT_REVISIT_BUDGET_PER_RUN` times, each extendable by a
  *  `revisitBudgetGranted` event.  Counts revisits ALREADY made; returns
- *  `{ok:false, detail}` when this next revisit would exceed either tier. */
+ *  `{ok:false, tier, detail}` when this next revisit would exceed a tier —
+ *  `tier` tells the grant card which scope to extend (菲菲 review). */
 export function revisitBudgetStatus(
   events: StoredEvent[],
   sourceNodeId: string,
   toNodeId: string,
-): { ok: true } | { ok: false; detail: string } {
+): { ok: true } | { ok: false; tier: 'pair' | 'run'; detail: string } {
   let pairUsed = 0;
   let runUsed = 0;
   let pairGranted = 0;
@@ -277,10 +278,10 @@ export function revisitBudgetStatus(
   const pairLimit = DEFAULT_REVISIT_BUDGET_PER_PAIR + pairGranted;
   const runLimit = DEFAULT_REVISIT_BUDGET_PER_RUN + runGranted;
   if (pairUsed >= pairLimit) {
-    return { ok: false, detail: `revisit budget exhausted for ${sourceNodeId}->${toNodeId} (${pairUsed}/${pairLimit}) — grant +1 (this pair) to continue` };
+    return { ok: false, tier: 'pair', detail: `revisit budget exhausted for ${sourceNodeId}->${toNodeId} (${pairUsed}/${pairLimit}) — grant +1 (this pair) to continue` };
   }
   if (runUsed >= runLimit) {
-    return { ok: false, detail: `run-wide revisit budget exhausted (${runUsed}/${runLimit}) — grant +1 (run) to continue` };
+    return { ok: false, tier: 'run', detail: `run-wide revisit budget exhausted (${runUsed}/${runLimit}) — grant +1 (run) to continue` };
   }
   return { ok: true };
 }
@@ -843,6 +844,7 @@ export async function runWorkflow(
               appendEvent(journalPath, {
                 type: 'nodeBlocked', nodeId: node.id, ...(instanceId ? { instanceId } : {}), attemptId,
                 errorClass: 'resultInvalid', errorCode: 'REVISIT_BUDGET_EXHAUSTED', message: budget.detail,
+                revisitTo: revisit.request.toNodeId,
               });
               return;
             }

--- a/src/workflows/v3/runtime.ts
+++ b/src/workflows/v3/runtime.ts
@@ -124,6 +124,7 @@ export function renderGoalFile(
     'Work toward the goal above until it is done, then stop. Do NOT ask the user with interactive tools (they are disabled in this mode). If you genuinely need a human DECISION to proceed, use the human-ask escape hatch described below (also available as the `botmux-goal-ask` skill).',
     '',
     `- Upstream inputs: the file at $${E.INPUTS_PATH} is a JSON object \`{ "inputs": [...] }\` listing upstream products, each with an absolute \`path\`. Read only the ones the goal needs (it may be empty). If it includes a \`human/answer\` input, read it before continuing. If an \`omitted\` array is present, those declared inputs were intentionally not produced (their workflow branch was not taken) — treat their absence as by-design, do NOT invent their content.`,
+    `- Revisit feedback: if any input has \`"from": "revisit"\`, a DOWNSTREAM node sent this node back because its product was inadequate. You MUST read these before doing anything else: \`reason\` (why you were sent back), \`source:*\` (the downstream node's output — the evidence of what was wrong), and \`previous:*\` (YOUR OWN previous output — edit/fix it, do not rewrite from scratch). Address the reason; do not just reproduce the prior output.`,
     `- Output: write ALL products under the directory at $${E.OUTPUT_DIR}. Do NOT write anything outside that directory.`,
     `- Manifest (required): before you finish, write a JSON manifest to $${E.MANIFEST_PATH} with exactly this shape:`,
     '',
@@ -800,7 +801,7 @@ export async function runWorkflow(
             }
             // goal-node dispatches always carry instanceId (首派 #001); the
             // fallback keeps the type total for the legacy/no-instance path.
-            appendRevisitEvents(node.id, instanceId ?? node.id, attemptId, revisit.request);
+            appendRevisitEvents(node.id, instanceId ?? node.id, attemptId, revisit.request, result.manifestPath);
             return;
           }
           // Opt-in structured-result contract: the manifest MUST list a
@@ -933,13 +934,33 @@ export async function runWorkflow(
     instanceId: string,
     attemptId: string,
     request: { toNodeId: string; reason?: string },
+    sourceManifestPath: string,
   ): void {
+    // Capture feedback paths BEFORE the supersede sweep, while the target's
+    // current effective instance + its successful manifest are still resolvable.
+    const events0 = readJournal(journalPath);
+    const snap = materialize(events0);
+    const targetEff = snap.nodes.get(request.toNodeId)?.effectiveInstanceId;
+    const targetSucc = targetEff
+      ? [...events0].reverse().find((e): e is StoredEvent & { type: 'nodeSucceeded' } =>
+          e.type === 'nodeSucceeded' && (e.instanceId ?? e.nodeId) === targetEff)
+      : undefined;
+    // Persist the reason as a file the target's fresh instance can Read.
+    let reasonPath: string | undefined;
+    if (request.reason) {
+      const dir = join(runDir, 'revisits');
+      mkdirSync(dir, { recursive: true });
+      reasonPath = join(dir, `${instanceId.replace(/[#/]/g, '-')}-reason.md`);
+      writeFileSync(reasonPath, `# Revisit reason (from ${nodeId} / ${instanceId})\n\n${request.reason}\n`);
+    }
     appendEvent(journalPath, {
       type: 'nodeRevisitRequested',
       nodeId, instanceId, attemptId, toNodeId: request.toNodeId,
       ...(request.reason ? { reason: request.reason } : {}),
+      ...(reasonPath ? { reasonPath } : {}),
+      sourceManifestPath,
+      ...(targetSucc ? { targetPreviousManifestPath: targetSucc.manifestPath } : {}),
     });
-    const snap = materialize(readJournal(journalPath));
     for (const affectedNodeId of affectedNodesFrom(request.toNodeId)) {
       const eff = snap.nodes.get(affectedNodeId)?.effectiveInstanceId;
       if (!eff) continue; // never-dispatched downstream node has nothing to supersede
@@ -1265,6 +1286,31 @@ export async function runWorkflow(
       }
     };
 
+    // Push every file of a manifest at a known (absolute) path — used for
+    // revisit feedback where the manifest is referenced directly off the
+    // nodeRevisitRequested event (requester / target-prior), not via a
+    // nodeSucceeded lookup.  Names are prefixed so the agent can tell the
+    // feedback pieces apart (`revisit/source:…`, `revisit/previous:…`).
+    const pushManifestByPath = (label: string, manifestPath: string | undefined, namePrefix: string): void => {
+      if (!manifestPath || !existsSync(manifestPath)) return;
+      let manifest: Manifest;
+      try {
+        manifest = JSON.parse(readFileSync(manifestPath, 'utf-8')) as Manifest;
+      } catch {
+        return;
+      }
+      const outDir = join(dirname(manifestPath), 'work');
+      for (const f of manifest.files) {
+        inputs.push({
+          from: label,
+          name: `${namePrefix}:${f.name}`,
+          path: join(outDir, f.path),
+          kind: f.kind,
+          preview: f.preview,
+        });
+      }
+    };
+
     // P3 selector misses collected during resolution — merged into `omitted`
     // so the agent reads the gap as a known contract issue, not silence.
     const selectorMisses: Array<{ from: string; reason: 'selectorMiss' }> = [];
@@ -1283,6 +1329,23 @@ export async function runWorkflow(
     for (const ref of node.inputs) {
       if (omittedFrom.has(ref.from)) continue; // branch not taken — surfaced via `omitted`
       pushRef(ref);
+    }
+
+    // Cross-node revisit feedback: when THIS node is a revisit target, its fresh
+    // instance is sent back blind unless we hand it (1) WHY it was sent back,
+    // (2) the requester's output (where it went wrong), (3) its OWN prior output
+    // (so it edits rather than rewrites).  All as `from:"revisit"` inputs; the
+    // goal.txt instructs the agent to read them first.  A plain first run / a
+    // cone node that wasn't the target has no such event → nothing injected.
+    const revisitReq = [...events].reverse().find(
+      (e): e is StoredEvent & { type: 'nodeRevisitRequested' } =>
+        e.type === 'nodeRevisitRequested' && e.toNodeId === node.id);
+    if (revisitReq) {
+      if (revisitReq.reasonPath) {
+        inputs.push({ from: 'revisit', name: 'reason', path: revisitReq.reasonPath, kind: 'markdown', preview: revisitReq.reason });
+      }
+      pushManifestByPath('revisit', revisitReq.sourceManifestPath, 'source');
+      pushManifestByPath('revisit', revisitReq.targetPreviousManifestPath, 'previous');
     }
 
     if (loopRef) {

--- a/src/workflows/v3/runtime.ts
+++ b/src/workflows/v3/runtime.ts
@@ -320,16 +320,21 @@ function attemptNumber(attemptId: string): number | undefined {
  * a first dispatch.  Dispatch events are the authority for "seen"; a
  * reservation is consumed by a later `nodeDispatched` with the same number.
  */
-export function nextAttemptIdFor(events: StoredEvent[], nodeId: string): string {
+export function nextAttemptIdFor(events: StoredEvent[], key: string): string {
+  // `key` is the dispatch namespace: a runtime instance (`A#001`), a loop body
+  // expansion (`loopId.i001.code`), or a legacy nodeId.  Match events by their
+  // instance when they carry one, else by nodeId — so `A#002`'s attempts are
+  // counted separately from `A#001`'s (constraint 3/5).
+  const matches = (e: { nodeId: string; instanceId?: string }): boolean => (e.instanceId ?? e.nodeId) === key;
   let maxSeen = 0;
   let reserved: number | undefined;
   for (const e of events) {
-    if (e.type === 'nodeDispatched' && e.nodeId === nodeId) {
+    if (e.type === 'nodeDispatched' && matches(e)) {
       const n = attemptNumber(e.attemptId);
       if (n === undefined) continue;
       maxSeen = Math.max(maxSeen, n);
       if (reserved === n) reserved = undefined; // reservation consumed
-    } else if (e.type === 'nodeRetryRequested' && e.nodeId === nodeId) {
+    } else if (e.type === 'nodeRetryRequested' && matches(e)) {
       const n = attemptNumber(e.nextAttemptId);
       if (n === undefined) continue;
       reserved = n;
@@ -337,15 +342,17 @@ export function nextAttemptIdFor(events: StoredEvent[], nodeId: string): string 
     }
   }
   const n = reserved ?? maxSeen + 1;
-  return `${nodeId}/attempts/${String(n).padStart(3, '0')}`;
+  return `${key}/attempts/${String(n).padStart(3, '0')}`;
 }
 
-/** Latest dispatched attemptId for a node (the `previousAttemptId` a retry
- *  entrypoint must reference).  Undefined when the node never dispatched. */
-export function latestAttemptIdFor(events: StoredEvent[], nodeId: string): string | undefined {
+/** Latest dispatched attemptId for a dispatch `key` (the `previousAttemptId` a
+ *  retry entrypoint must reference).  `key` is an instance (`A#001`), a loop
+ *  body expansion, or a legacy nodeId — matched by `(instanceId ?? nodeId)` so
+ *  a retry stays inside the same instance.  Undefined when never dispatched. */
+export function latestAttemptIdFor(events: StoredEvent[], key: string): string | undefined {
   let latest: string | undefined;
   for (const e of events) {
-    if (e.type === 'nodeDispatched' && e.nodeId === nodeId) latest = e.attemptId;
+    if (e.type === 'nodeDispatched' && (e.instanceId ?? e.nodeId) === key) latest = e.attemptId;
   }
   return latest;
 }
@@ -565,7 +572,7 @@ export async function runWorkflow(
           const botSnap = botSnapshots.get(botKey)!;
           if ((botInFlight.get(botKey) ?? 0) >= perBotCap) continue;
           if ((cliInFlight.get(botSnap.cliId) ?? 0) >= perCliCap) continue;
-          startWork(node, botSnap, botKey, events, a.loop, a.omitted);
+          startWork(node, botSnap, botKey, events, a.loop, a.omitted, a.instanceId);
           startedThisTick++;
         } else if (a.kind === 'dispatchGate') {
           startGate(nodesById.get(a.nodeId)!);
@@ -625,13 +632,19 @@ export async function runWorkflow(
     events: StoredEvent[],
     loopRef?: V3LoopRef,
     omitted?: GoalInputs['omitted'],
+    instanceId?: string,
   ): void {
+    // The dispatch key namespaces the attempt dir + journal events.  For a
+    // plain node it's the runtime instance (`A#001`); for a loop body it's the
+    // expanded node.id (`loopId.i001.code`); legacy/no-instance falls back to
+    // node.id.  attempt dir = `<runDir>/<key>/attempts/NNN`.
+    const dispatchKey = instanceId ?? node.id;
     // Attempt number derived from the journal: 001 on first dispatch, the
     // reserved nextAttemptId after a blocked retry (no hardcoded 001 — a retry
     // must not overwrite the previous attempt's logs/manifest/pty).
-    const attemptId = nextAttemptIdFor(events, node.id);
+    const attemptId = nextAttemptIdFor(events, dispatchKey);
     const attemptNNN = attemptId.slice(attemptId.lastIndexOf('/') + 1);
-    const attemptDir = join(runDir, node.id, 'attempts', attemptNNN);
+    const attemptDir = join(runDir, dispatchKey, 'attempts', attemptNNN);
     const outputDir = join(attemptDir, 'work');
     mkdirSync(outputDir, { recursive: true });
 
@@ -664,7 +677,7 @@ export async function runWorkflow(
       [GOAL_ENV.V3_MARKER]: '1',
     };
 
-    appendEvent(journalPath, { type: 'nodeDispatched', nodeId: node.id, attemptId, loop: loopRef });
+    appendEvent(journalPath, { type: 'nodeDispatched', nodeId: node.id, ...(instanceId ? { instanceId } : {}), attemptId, loop: loopRef });
     botInFlight.set(botKey, (botInFlight.get(botKey) ?? 0) + 1);
     cliInFlight.set(botSnap.cliId, (cliInFlight.get(botSnap.cliId) ?? 0) + 1);
 
@@ -672,7 +685,7 @@ export async function runWorkflow(
     // contract types `runNode` to V3GoalNode, so narrow explicitly.
     if (!isGoalNode(node)) {
       appendEvent(journalPath, {
-        type: 'nodeFailed', nodeId: node.id, attemptId,
+        type: 'nodeFailed', nodeId: node.id, ...(instanceId ? { instanceId } : {}), attemptId,
         errorClass: 'workerError', message: `node "${node.id}" is not a goal node`,
       });
       releaseSlots(botKey, botSnap.cliId);
@@ -707,6 +720,7 @@ export async function runWorkflow(
         appendEvent(journalPath, {
           type: 'nodeSessionReady',
           nodeId: node.id,
+          ...(instanceId ? { instanceId } : {}),
           attemptId,
           sessionInfo: { sessionId: info.sessionId, webPort: info.webPort },
           ptyLogPath: info.ptyLogPath,
@@ -734,7 +748,7 @@ export async function runWorkflow(
             const entry = verdict.manifest!.files.find((f) => f.path === 'result.json');
             if (!entry) {
               appendEvent(journalPath, {
-                type: 'nodeBlocked', nodeId: node.id, attemptId,
+                type: 'nodeBlocked', nodeId: node.id, ...(instanceId ? { instanceId } : {}), attemptId,
                 errorClass: 'resultInvalid',
                 message: 'node declares resultSchema but its manifest lists no "result.json" file',
               });
@@ -743,7 +757,7 @@ export async function runWorkflow(
             const res = validateResult(join(outputDir, entry.path), node.resultSchema);
             if (!res.ok) {
               appendEvent(journalPath, {
-                type: 'nodeBlocked', nodeId: node.id, attemptId,
+                type: 'nodeBlocked', nodeId: node.id, ...(instanceId ? { instanceId } : {}), attemptId,
                 errorClass: 'resultInvalid',
                 message: (res.problems ?? ['result.json failed schema validation']).join('; '),
               });
@@ -751,7 +765,7 @@ export async function runWorkflow(
             }
           }
           appendEvent(journalPath, {
-            type: 'nodeSucceeded', nodeId: node.id, attemptId, manifestPath: result.manifestPath,
+            type: 'nodeSucceeded', nodeId: node.id, ...(instanceId ? { instanceId } : {}), attemptId, manifestPath: result.manifestPath,
           });
           return;
         }
@@ -799,19 +813,19 @@ export async function runWorkflow(
               : undefined;
           appendEvent(journalPath, {
             type: 'nodeBlocked',
-            nodeId: node.id, attemptId, errorClass, errorCode, message,
+            nodeId: node.id, ...(instanceId ? { instanceId } : {}), attemptId, errorClass, errorCode, message,
             ...(ask ? { ask } : {}),
           });
         } else {
           appendEvent(journalPath, {
             type: 'nodeFailed',
-            nodeId: node.id, attemptId, errorClass, errorCode, message,
+            nodeId: node.id, ...(instanceId ? { instanceId } : {}), attemptId, errorClass, errorCode, message,
           });
         }
       })
       .catch((err: unknown) => {
         appendEvent(journalPath, {
-          type: 'nodeFailed', nodeId: node.id, attemptId,
+          type: 'nodeFailed', nodeId: node.id, ...(instanceId ? { instanceId } : {}), attemptId,
           errorClass: 'workerError', message: err instanceof Error ? err.message : String(err),
         });
       })

--- a/src/workflows/v3/runtime.ts
+++ b/src/workflows/v3/runtime.ts
@@ -954,7 +954,7 @@ export async function runWorkflow(
     const waitId = `${node.id}-gate`; // MVP: one gate per node
     const gate = normalizeGateWaitInput(node.humanGate!);
     // gateDispatched carries instanceId (journal layer, accepted in 3239cf8);
-    // DEFERRED: instance-level waitId + stale-card guard (菲菲 review) — needs a
+    // DEFERRED: instance-level waitId + stale-card guard (code review) — needs a
     // waitId migration / card-action change, off the A→B→C critical path.
     appendEvent(journalPath, { type: 'gateDispatched', nodeId: node.id, ...(instanceId ? { instanceId } : {}), waitId });
 
@@ -1209,7 +1209,7 @@ export async function runWorkflow(
     const inputs: GoalInputs['inputs'] = [];
     const omittedFrom = new Set((omitted ?? []).map((o) => o.from));
     // Resolve upstream products by the source's CURRENT effective instance, NOT
-    // by nodeId-latest (菲菲 blocker): after a revisit, a stale `A#001` worker
+    // by nodeId-latest (stale-instance blocker): after a revisit, a stale `A#001` worker
     // can settle LATE; nodeId-latest would then hand `A#001`'s old product to
     // `B#002`.  Keying by effectiveInstanceId pins it to `A#002`.
     const snap = materialize(events);

--- a/src/workflows/v3/state.ts
+++ b/src/workflows/v3/state.ts
@@ -232,11 +232,15 @@ export function materialize(events: StoredEvent[]): V3RunSnapshot {
         break;
       }
       case 'edgeResolved': {
-        // Key by instance pair (constraint 1): `A#001->B#001` and `A#002->B#002`
-        // are distinct verdicts — a revisit's fresh edge is never first-wins-
-        // shadowed by the superseded instance's old verdict.  Legacy/no-instance
-        // events fall back to the nodeId pair.
-        const key = `${e.fromInstanceId ?? e.from}->${e.toInstanceId ?? e.to}`;
+        // Verdict is bound to the SOURCE effective instance only (菲菲 review):
+        // the edge resolves BEFORE the target dispatches, so the target has no
+        // instance yet — key is `<sourceInstance>-><targetNodeId>`.  This makes
+        // `A#001->B` and `A#002->B` distinct, so a SOURCE revisit's fresh verdict
+        // is never first-wins-shadowed by the superseded one.  KNOWN LIMITATION:
+        // a TARGET-only revisit (B refreshed, A unchanged) reuses `A#001->B` — to
+        // be upgraded when target-specific edge semantics actually arise.
+        // `toInstanceId` stays on the event as record-only, NOT part of the key.
+        const key = `${e.fromInstanceId ?? e.from}->${e.to}`;
         if (!edges.has(key)) {
           edges.set(key, { active: e.active, sourceAttemptId: e.sourceAttemptId });
         }

--- a/src/workflows/v3/state.ts
+++ b/src/workflows/v3/state.ts
@@ -232,7 +232,11 @@ export function materialize(events: StoredEvent[]): V3RunSnapshot {
         break;
       }
       case 'edgeResolved': {
-        const key = `${e.from}->${e.to}`;
+        // Key by instance pair (constraint 1): `A#001->B#001` and `A#002->B#002`
+        // are distinct verdicts — a revisit's fresh edge is never first-wins-
+        // shadowed by the superseded instance's old verdict.  Legacy/no-instance
+        // events fall back to the nodeId pair.
+        const key = `${e.fromInstanceId ?? e.from}->${e.toInstanceId ?? e.to}`;
         if (!edges.has(key)) {
           edges.set(key, { active: e.active, sourceAttemptId: e.sourceAttemptId });
         }

--- a/src/workflows/v3/state.ts
+++ b/src/workflows/v3/state.ts
@@ -137,9 +137,11 @@ export function materialize(events: StoredEvent[]): V3RunSnapshot {
       status === 'blocked';
   };
 
-  const cancelledCovers = (nodeId: string, attemptId?: string): boolean => {
-    if (!cancelledAttempts.has(nodeId)) return false;
-    const cancelledAttemptId = cancelledAttempts.get(nodeId);
+  // Keyed by `(instanceId ?? nodeId)` so cancelling `A#001` (an early-release
+  // loser) never suppresses `A#002`'s settle after a revisit re-dispatch.
+  const cancelledCovers = (key: string, attemptId?: string): boolean => {
+    if (!cancelledAttempts.has(key)) return false;
+    const cancelledAttemptId = cancelledAttempts.get(key);
     return cancelledAttemptId === undefined || cancelledAttemptId === attemptId;
   };
 
@@ -149,24 +151,30 @@ export function materialize(events: StoredEvent[]): V3RunSnapshot {
         runStatus = 'running';
         break;
       case 'nodeDispatched':
-        if (nodes.get(e.nodeId)?.status === 'cancelled') break;
+        // Don't resurrect a cancelled early-release loser via a late dispatch.
+        // Instance-aware: only the SAME cancelled instance is blocked — a fresh
+        // instance (`A#002` after a revisit) dispatches even though `A#001` was
+        // cancelled.  Legacy (no instance) keeps the node-view guard.
+        if (e.instanceId) {
+          if (instances.get(e.instanceId)?.status === 'cancelled') break;
+        } else if (nodes.get(e.nodeId)?.status === 'cancelled') break;
         // Dispatch makes this instance the node's effective one.
         if (e.instanceId) recordInstance(e.nodeId, e.instanceId, 'running', true);
         else set(e.nodeId, 'running');
         attempts.set(e.instanceId ?? e.nodeId, e.attemptId); // constraint 3: key by instance when present
         break;
       case 'nodeSucceeded':
-        if (cancelledCovers(e.nodeId, e.attemptId)) break;
+        if (cancelledCovers(e.instanceId ?? e.nodeId, e.attemptId)) break;
         if (e.instanceId) recordInstance(e.nodeId, e.instanceId, 'done', false);
         else set(e.nodeId, 'done');
         break;
       case 'nodeFailed':
-        if (cancelledCovers(e.nodeId, e.attemptId)) break;
+        if (cancelledCovers(e.instanceId ?? e.nodeId, e.attemptId)) break;
         if (e.instanceId) recordInstance(e.nodeId, e.instanceId, 'failed', false);
         else set(e.nodeId, 'failed');
         break;
       case 'nodeBlocked':
-        if (cancelledCovers(e.nodeId, e.attemptId)) break;
+        if (cancelledCovers(e.instanceId ?? e.nodeId, e.attemptId)) break;
         if (e.instanceId) recordInstance(e.nodeId, e.instanceId, 'blocked', false);
         else set(e.nodeId, 'blocked');
         break;
@@ -252,8 +260,10 @@ export function materialize(events: StoredEvent[]): V3RunSnapshot {
         break;
       case 'nodeCancelled':
         if (terminal(e.nodeId)) break;
-        cancelledAttempts.set(e.nodeId, e.attemptId);
-        set(e.nodeId, 'cancelled');
+        // Suppress by instance (or nodeId fallback) so a later instance settles freely.
+        cancelledAttempts.set(e.instanceId ?? e.nodeId, e.attemptId);
+        if (e.instanceId) recordInstance(e.nodeId, e.instanceId, 'cancelled', false);
+        else set(e.nodeId, 'cancelled');
         break;
       case 'runSucceeded':
         runStatus = 'succeeded';

--- a/src/workflows/v3/state.ts
+++ b/src/workflows/v3/state.ts
@@ -104,6 +104,10 @@ export function materialize(events: StoredEvent[]): V3RunSnapshot {
   // (loop body expansions, pre-instance-layer) skip this entirely and keep the
   // plain nodeId-keyed behavior above.
   const recordInstance = (nodeId: string, instanceId: string, status: V3NodeStatus, makeEffective: boolean): void => {
+    // A superseded instance is FROZEN: a stale late settle from its old worker
+    // (nodeSucceeded/Failed/Blocked) must NOT revive it to done/failed — the
+    // refresh state is what the dashboard shows (菲菲 review blocker 1).
+    if (instances.get(instanceId)?.status === 'superseded') return;
     instances.set(instanceId, { status });
     if (makeEffective) {
       const prev = nodes.get(nodeId);
@@ -205,13 +209,28 @@ export function materialize(events: StoredEvent[]): V3RunSnapshot {
       }
       case 'gateDispatched':
         if (nodes.get(e.nodeId)?.status === 'cancelled') break;
-        set(e.nodeId, 'gateWaiting');
+        // Gate is per-INSTANCE (constraint 6): A#001's approval must not clear
+        // A#002.  When the event carries instanceId, the gate state lives on
+        // the instance + (when effective) mirrors to the node.
+        if (e.instanceId) {
+          instances.set(e.instanceId, { status: 'gateWaiting' });
+          nodes.set(e.nodeId, { ...(nodes.get(e.nodeId) ?? {}), status: 'gateWaiting', effectiveInstanceId: e.instanceId });
+        } else set(e.nodeId, 'gateWaiting');
         break;
-      case 'gateResolved':
+      case 'gateResolved': {
         if (nodes.get(e.nodeId)?.status === 'cancelled') break;
-        if (e.resolution === 'approved') set(e.nodeId, 'pending', true);
+        const approved = e.resolution === 'approved';
+        if (e.instanceId) {
+          instances.set(e.instanceId, approved ? { status: 'pending', gateCleared: true } : { status: 'failed' });
+          // Only mirror to the node view if this instance is the live one.
+          if (nodes.get(e.nodeId)?.effectiveInstanceId === e.instanceId) {
+            const prev = nodes.get(e.nodeId)!;
+            nodes.set(e.nodeId, approved ? { ...prev, status: 'pending', gateCleared: true } : { ...prev, status: 'failed' });
+          }
+        } else if (approved) set(e.nodeId, 'pending', true);
         else set(e.nodeId, 'failed');
         break;
+      }
       case 'edgeResolved': {
         const key = `${e.from}->${e.to}`;
         if (!edges.has(key)) {

--- a/src/workflows/v3/state.ts
+++ b/src/workflows/v3/state.ts
@@ -106,7 +106,7 @@ export function materialize(events: StoredEvent[]): V3RunSnapshot {
   const recordInstance = (nodeId: string, instanceId: string, status: V3NodeStatus, makeEffective: boolean): void => {
     // A superseded instance is FROZEN: a stale late settle from its old worker
     // (nodeSucceeded/Failed/Blocked) must NOT revive it to done/failed — the
-    // refresh state is what the dashboard shows (菲菲 review blocker 1).
+    // refresh state is what the dashboard shows (review blocker 1).
     if (instances.get(instanceId)?.status === 'superseded') return;
     instances.set(instanceId, { status });
     if (makeEffective) {
@@ -232,7 +232,7 @@ export function materialize(events: StoredEvent[]): V3RunSnapshot {
         break;
       }
       case 'edgeResolved': {
-        // Verdict is bound to the SOURCE effective instance only (菲菲 review):
+        // Verdict is bound to the SOURCE effective instance only (code review):
         // the edge resolves BEFORE the target dispatches, so the target has no
         // instance yet — key is `<sourceInstance>-><targetNodeId>`.  This makes
         // `A#001->B` and `A#002->B` distinct, so a SOURCE revisit's fresh verdict

--- a/src/workflows/v3/state.ts
+++ b/src/workflows/v3/state.ts
@@ -39,8 +39,13 @@ export interface V3RunSnapshot {
   /** Set once `runBlocked` is observed — the blocked node (cleared back to
    *  running by a subsequent `nodeRetryRequested` on replay). */
   blockedNodeId?: string;
-  /** nodeId → current node state (the input `decideNext` consumes). */
+  /** nodeId → current node state (the input `decideNext` consumes).  For a
+   *  node with runtime instances, `.effectiveInstanceId` points at its live
+   *  instance. */
   nodes: V3RunState;
+  /** instanceId (`A#001`) → that runtime instance's state (incl. `superseded`).
+   *  Empty for runs that never used the instance layer (plain nodeId events). */
+  instances: V3RunState;
   /** nodeId → the attemptId of its latest dispatch — or, after a
    *  `nodeRetryRequested`, the reserved `nextAttemptId` the retry will use. */
   attempts: Map<string, string>;
@@ -71,6 +76,7 @@ export interface V3RunSnapshot {
  */
 export function materialize(events: StoredEvent[]): V3RunSnapshot {
   const nodes: V3RunState = new Map();
+  const instances: V3RunState = new Map();
   const attempts = new Map<string, string>();
   const loops: V3LoopRunState = new Map();
   const edges: V3EdgeRunState = new Map();
@@ -87,7 +93,26 @@ export function materialize(events: StoredEvent[]): V3RunSnapshot {
     // Carry an approved-gate flag forward unless this transition sets it.
     const carried = gateCleared ?? prev?.gateCleared;
     if (carried) next.gateCleared = true;
+    // Preserve the node's effective instance pointer across status changes.
+    if (prev?.effectiveInstanceId) next.effectiveInstanceId = prev.effectiveInstanceId;
     nodes.set(id, next);
+  };
+
+  // Instance-layer mirror (instance restoration 2026-06-08): when a lifecycle
+  // event carries `instanceId`, record that instance's status AND point the
+  // definition node's `effectiveInstanceId` at it.  Events without instanceId
+  // (loop body expansions, pre-instance-layer) skip this entirely and keep the
+  // plain nodeId-keyed behavior above.
+  const recordInstance = (nodeId: string, instanceId: string, status: V3NodeStatus, makeEffective: boolean): void => {
+    instances.set(instanceId, { status });
+    if (makeEffective) {
+      const prev = nodes.get(nodeId);
+      nodes.set(nodeId, { ...(prev ?? { status }), status, effectiveInstanceId: instanceId });
+    } else if (nodes.get(nodeId)?.effectiveInstanceId === instanceId) {
+      // settle of the CURRENT effective instance → reflect on the node view.
+      const prev = nodes.get(nodeId)!;
+      nodes.set(nodeId, { ...prev, status });
+    }
   };
 
   const loop = (id: string): V3LoopState => {
@@ -121,32 +146,63 @@ export function materialize(events: StoredEvent[]): V3RunSnapshot {
         break;
       case 'nodeDispatched':
         if (nodes.get(e.nodeId)?.status === 'cancelled') break;
-        set(e.nodeId, 'running');
-        attempts.set(e.nodeId, e.attemptId);
+        // Dispatch makes this instance the node's effective one.
+        if (e.instanceId) recordInstance(e.nodeId, e.instanceId, 'running', true);
+        else set(e.nodeId, 'running');
+        attempts.set(e.instanceId ?? e.nodeId, e.attemptId); // constraint 3: key by instance when present
         break;
       case 'nodeSucceeded':
         if (cancelledCovers(e.nodeId, e.attemptId)) break;
-        set(e.nodeId, 'done');
+        if (e.instanceId) recordInstance(e.nodeId, e.instanceId, 'done', false);
+        else set(e.nodeId, 'done');
         break;
       case 'nodeFailed':
         if (cancelledCovers(e.nodeId, e.attemptId)) break;
-        set(e.nodeId, 'failed');
+        if (e.instanceId) recordInstance(e.nodeId, e.instanceId, 'failed', false);
+        else set(e.nodeId, 'failed');
         break;
       case 'nodeBlocked':
         if (cancelledCovers(e.nodeId, e.attemptId)) break;
-        set(e.nodeId, 'blocked');
+        if (e.instanceId) recordInstance(e.nodeId, e.instanceId, 'blocked', false);
+        else set(e.nodeId, 'blocked');
         break;
       case 'nodeRetryRequested':
         // Replay-correct unblock (codex blocker #1 of the blocked design):
         // the retry is a journal event, so a fresh materialize() yields
         // pending — NOT a memory-only patch that evaporates on next replay.
+        // Constraint 5: retry is a new ATTEMPT inside the SAME instance — the
+        // node keeps its effectiveInstanceId; only its status goes pending.
         set(e.nodeId, 'pending');
-        attempts.set(e.nodeId, e.nextAttemptId);
+        if (e.instanceId) instances.set(e.instanceId, { status: 'pending' });
+        attempts.set(e.instanceId ?? e.nodeId, e.nextAttemptId); // constraint 3
         if (runStatus === 'blocked') {
           runStatus = 'running';
           blockedNodeId = undefined;
         }
         break;
+      // ── cross-node revisit / instance refresh ──
+      case 'nodeRevisitRequested':
+        // Audit only: the nodeInstanceSuperseded events the runtime appends
+        // right after do the actual state change.  Recorded for replay /
+        // dashboard "why did this node refresh".
+        break;
+      case 'nodeInstanceSuperseded': {
+        instances.set(e.instanceId, { status: 'superseded' });
+        // If the superseded instance was the node's live one, the node re-
+        // dispatches a fresh instance: drop effectiveInstanceId + gateCleared
+        // (constraint 6: the fresh instance must re-approve its gate) and go
+        // pending so decideNext re-dispatches.
+        if (nodes.get(e.nodeId)?.effectiveInstanceId === e.instanceId) {
+          nodes.set(e.nodeId, { status: 'pending' });
+        }
+        // A refresh during a blocked run re-opens scheduling (analogue of
+        // nodeRetryRequested / loopIterationGranted).
+        if (runStatus === 'blocked' && blockedNodeId === e.nodeId) {
+          runStatus = 'running';
+          blockedNodeId = undefined;
+        }
+        break;
+      }
       case 'gateDispatched':
         if (nodes.get(e.nodeId)?.status === 'cancelled') break;
         set(e.nodeId, 'gateWaiting');
@@ -225,7 +281,7 @@ export function materialize(events: StoredEvent[]): V3RunSnapshot {
     }
   }
 
-  return { runStatus, failedNodeId, failureReason, failureDetail, blockedNodeId, nodes, attempts, loops, edges };
+  return { runStatus, failedNodeId, failureReason, failureDetail, blockedNodeId, nodes, instances, attempts, loops, edges };
 }
 
 // ─── STATE checkpoint (atomic write / read) ────────────────────────────────
@@ -239,6 +295,7 @@ interface StateFile {
   failureDetail?: string;
   blockedNodeId?: string;
   nodes: Record<string, V3NodeState>;
+  instances?: Record<string, V3NodeState>;
   attempts: Record<string, string>;
   loops?: Record<string, V3LoopState>;
   edges?: Record<string, { active: boolean; sourceAttemptId: string }>;
@@ -261,6 +318,7 @@ export function writeState(statePath: string, snap: V3RunSnapshot): void {
     failureDetail: snap.failureDetail,
     blockedNodeId: snap.blockedNodeId,
     nodes: Object.fromEntries(snap.nodes),
+    instances: snap.instances.size > 0 ? Object.fromEntries(snap.instances) : undefined,
     attempts: Object.fromEntries(snap.attempts),
     loops: snap.loops.size > 0 ? Object.fromEntries(snap.loops) : undefined,
     edges: snap.edges.size > 0 ? Object.fromEntries(snap.edges) : undefined,
@@ -284,6 +342,7 @@ export function readState(statePath: string): V3RunSnapshot | undefined {
     failureDetail: file.failureDetail,
     blockedNodeId: file.blockedNodeId,
     nodes: new Map(Object.entries(file.nodes)),
+    instances: new Map(Object.entries(file.instances ?? {})),
     attempts: new Map(Object.entries(file.attempts)),
     loops: new Map(Object.entries(file.loops ?? {})),
     edges: new Map(Object.entries(file.edges ?? {})),

--- a/test/v3-blocked-card.test.ts
+++ b/test/v3-blocked-card.test.ts
@@ -13,6 +13,7 @@ import {
   v3BlockedCardNonce,
   V3_BLOCKED_RETRY_ACTION,
   V3_BLOCKED_ASK_ANSWER_ACTION,
+  V3_BLOCKED_ASK_TEXT_FIELD,
   type V3BlockedActionValue,
   type V3AskAnswerActionValue,
 } from '../src/im/lark/v3-blocked-card.js';
@@ -92,6 +93,29 @@ describe('buildV3BlockedCard', () => {
     expect(JSON.stringify(card)).not.toContain(V3_BLOCKED_RETRY_ACTION);
   });
 
+  it('ask 自由文本卡：blue header + 输入框 + 提交按钮（value 不携带文本）', () => {
+    const card = JSON.parse(buildV3BlockedCard({
+      ...INPUT,
+      ask: { question: '请补充计费规则', freeText: true },
+    }));
+    expect(card.header.template).toBe('blue');
+    expect(JSON.stringify(card)).toContain('请补充计费规则');
+    const formEl = card.elements.find((e: any) => e.tag === 'form');
+    expect(formEl.elements.find((e: any) => e.tag === 'input').name).toBe(V3_BLOCKED_ASK_TEXT_FIELD);
+    const submit = formEl.elements.find((e: any) => e.tag === 'button');
+    const value = submit.value as V3AskAnswerActionValue;
+    expect(value).toMatchObject({
+      action: V3_BLOCKED_ASK_ANSWER_ACTION,
+      runId: INPUT.runId,
+      nodeId: 'deploy',
+      attemptId: 'deploy/attempts/001',
+      answerKind: 'text',
+      nonce: v3BlockedCardNonce(INPUT.runId, 'deploy', 'deploy/attempts/001'),
+    });
+    expect(JSON.stringify(value)).not.toContain('计费');
+    expect(JSON.stringify(card)).not.toContain(V3_BLOCKED_RETRY_ACTION);
+  });
+
   it('answered 冻结卡：green + 无选项按钮 + 显示选中项与新 attempt', () => {
     const card = JSON.parse(buildV3BlockedCard({
       ...INPUT,
@@ -101,6 +125,19 @@ describe('buildV3BlockedCard', () => {
     expect(card.header.template).toBe('green');
     const json = JSON.stringify(card);
     expect(json).toContain('prod');
+    expect(json).toContain('002');
+    expect(json).not.toContain(V3_BLOCKED_ASK_ANSWER_ACTION);
+  });
+
+  it('answered 自由文本冻结卡：green + 显示文本预览与新 attempt', () => {
+    const card = JSON.parse(buildV3BlockedCard({
+      ...INPUT,
+      ask: { question: '请补充计费规则', freeText: true },
+      answered: { text: '超过 30 天按自然月计费', nextAttemptId: 'deploy/attempts/002', by: 'ou_x' },
+    }));
+    expect(card.header.template).toBe('green');
+    const json = JSON.stringify(card);
+    expect(json).toContain('超过 30 天');
     expect(json).toContain('002');
     expect(json).not.toContain(V3_BLOCKED_ASK_ANSWER_ACTION);
   });
@@ -215,6 +252,55 @@ describe('handleV3BlockedAction', () => {
     // 重试事件带 answer 指针
     const retryEvt: any = readJournal(journalPath).find((e) => e.type === 'nodeRetryRequested');
     expect(retryEvt.answer).toMatchObject({ preview: 'prod', by: 'ou_op' });
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it('ask 自由文本提交 → 原子写 answer.json + nodeRetryRequested.answer + 冻结「已回答」卡 + driveRun', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'v3-blocked-card-'));
+    const runId = 'ask-260606-0002';
+    const { runDir } = birthRun({
+      goal: 'g', baseDir: base, runId,
+      chatBinding: { larkAppId: 'cli_test', chatId: 'oc_chat', rootMessageId: 'om_root' },
+    });
+    const journalPath = join(runDir, 'journal.ndjson');
+    mkdirSync(join(runDir, 'deploy', 'attempts', '001'), { recursive: true });
+    appendEvent(journalPath, { type: 'runStarted', runId });
+    appendEvent(journalPath, { type: 'nodeDispatched', nodeId: 'deploy', attemptId: 'deploy/attempts/001' });
+    appendEvent(journalPath, {
+      type: 'nodeBlocked', nodeId: 'deploy', attemptId: 'deploy/attempts/001',
+      errorClass: 'manifestInvalid', errorCode: ASK_HUMAN_ERROR_CODE, message: '请补充计费规则',
+      ask: { question: '请补充计费规则', freeText: true },
+    });
+    appendEvent(journalPath, { type: 'runBlocked', blockedNodeId: 'deploy' });
+
+    const askValue: V3AskAnswerActionValue = {
+      action: V3_BLOCKED_ASK_ANSWER_ACTION,
+      runId, nodeId: 'deploy', attemptId: 'deploy/attempts/001',
+      answerKind: 'text',
+      nonce: v3BlockedCardNonce(runId, 'deploy', 'deploy/attempts/001'),
+    };
+    const longAnswer = `超过 30 天按自然月计费。${'计费边界说明'.repeat(40)}`;
+    const driveRun = vi.fn();
+    const res: any = await handleV3BlockedAction(
+      askValue,
+      'ou_op',
+      { baseDir: base, driveRun },
+      { [V3_BLOCKED_ASK_TEXT_FIELD]: longAnswer },
+    );
+
+    expect(driveRun).toHaveBeenCalledWith(runId);
+    expect(res.header.template).toBe('green');
+    expect(JSON.stringify(res)).toContain('超过 30 天');
+
+    const answerPath = join(runDir, 'deploy', 'attempts', '001', GOAL_ANSWER_FILE);
+    const answer = JSON.parse(readFileSync(answerPath, 'utf-8'));
+    expect(answer).toMatchObject({ text: longAnswer, by: 'ou_op' });
+
+    const retryEvt: any = readJournal(journalPath).find((e) => e.type === 'nodeRetryRequested');
+    expect(retryEvt.answer.by).toBe('ou_op');
+    expect(retryEvt.answer.preview).toContain('超过 30 天');
+    expect(retryEvt.answer.preview.length).toBeLessThan(longAnswer.length);
+    expect(retryEvt.answer.preview.length).toBeLessThanOrEqual(203);
     rmSync(base, { recursive: true, force: true });
   });
 

--- a/test/v3-blocked.test.ts
+++ b/test/v3-blocked.test.ts
@@ -23,6 +23,7 @@ import {
   nextAttemptIdFor,
   latestAttemptIdFor,
   renderGoalFile,
+  readGoalAsk,
   type V3RuntimeDeps,
 } from '../src/workflows/v3/runtime.js';
 import { requestV3Retry, reconcileV3PendingGates, blockedInfoFor } from '../src/workflows/v3/daemon-run.js';
@@ -95,6 +96,34 @@ describe('classifyTerminal', () => {
     expect(classifyTerminal('workerError', { selfReportedFail: true, retryable: false })).toBe('failed');
     expect(classifyTerminal('workerError', { selfReportedFail: true, retryable: true })).toBe('blocked');
     expect(classifyTerminal('workerError', { selfReportedFail: true })).toBe('blocked');
+  });
+});
+
+describe('readGoalAsk', () => {
+  it('accepts option asks and free-text asks', () => {
+    const base = freshBase();
+    try {
+      const optionPath = join(base, 'option-ask.json');
+      writeFileSync(optionPath, JSON.stringify({ question: '部署到哪里？', options: ['staging', 'prod'] }));
+      expect(readGoalAsk(optionPath)).toEqual({ question: '部署到哪里？', options: ['staging', 'prod'] });
+
+      const textPath = join(base, 'text-ask.json');
+      writeFileSync(textPath, JSON.stringify({ question: '补充计费规则', freeText: true }));
+      expect(readGoalAsk(textPath)).toEqual({ question: '补充计费规则', freeText: true });
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects ambiguous asks', () => {
+    const base = freshBase();
+    try {
+      const badPath = join(base, 'bad-ask.json');
+      writeFileSync(badPath, JSON.stringify({ question: '补充计费规则', freeText: true, options: ['A', 'B'] }));
+      expect(readGoalAsk(badPath)).toBeUndefined();
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/v3-blocked.test.ts
+++ b/test/v3-blocked.test.ts
@@ -293,9 +293,9 @@ describe('requestV3Retry + 重驱动全链路', () => {
     writeGrillState(runDir, { ...state, status: 'dag_approved', dagPath });
     const journalPath = join(runDir, 'journal.ndjson');
     appendEvent(journalPath, { type: 'runStarted', runId });
-    appendEvent(journalPath, { type: 'nodeDispatched', nodeId: 'work', attemptId: 'work/attempts/001' });
+    appendEvent(journalPath, { type: 'nodeDispatched', nodeId: 'work', instanceId: 'work#001', attemptId: 'work#001/attempts/001' });
     appendEvent(journalPath, {
-      type: 'nodeBlocked', nodeId: 'work', attemptId: 'work/attempts/001',
+      type: 'nodeBlocked', nodeId: 'work', instanceId: 'work#001', attemptId: 'work#001/attempts/001',
       errorClass: 'workerError', errorCode: 'AUTH_REQUIRED', message: '需要登录',
     });
     appendEvent(journalPath, { type: 'runBlocked', blockedNodeId: 'work' });
@@ -307,7 +307,7 @@ describe('requestV3Retry + 重驱动全链路', () => {
     const { journalPath } = seedBlockedRun(base, 'retry-001');
 
     const out = requestV3Retry(base, 'retry-001');
-    expect(out).toMatchObject({ kind: 'requested', nodeId: 'work', nextAttemptId: 'work/attempts/002' });
+    expect(out).toMatchObject({ kind: 'requested', nodeId: 'work', nextAttemptId: 'work#001/attempts/002' });
 
     // 防 Blocker1 回归：fresh replay 必须得出 pending（解锁在 journal 里）。
     const snap = materialize(readJournal(journalPath));
@@ -323,7 +323,7 @@ describe('requestV3Retry + 重驱动全链路', () => {
       (await import('node:fs')).readFileSync(join(base, 'retry-001', 'dag.json'), 'utf-8'),
     ));
     const runNode: RunNode = async (req) => {
-      expect(req.attemptId).toBe('work/attempts/002');
+      expect(req.attemptId).toBe('work#001/attempts/002');
       const m: Manifest = {
         schemaVersion: 1, status: 'ok', summary: 'done',
         files: [product(req.outputDir, 'out.md', 'ok')],
@@ -356,29 +356,29 @@ describe('requestV3Retry + 重驱动全链路', () => {
   it('stale 旧卡（codex blocker）：001 的卡不能把 002 的 blocked 推进到 003', () => {
     const base = freshBase();
     const { journalPath } = seedBlockedRun(base, 'retry-005');
-    // 001 blocked → 点卡 retry → 002 跑 → 002 又 blocked
-    expect(requestV3Retry(base, 'retry-005', { expectedAttemptId: 'work/attempts/001' }).kind).toBe('requested');
-    appendEvent(journalPath, { type: 'nodeDispatched', nodeId: 'work', attemptId: 'work/attempts/002' });
+    // 001 blocked → 点卡 retry → 002 跑 → 002 又 blocked（全在同一 instance work#001 内）
+    expect(requestV3Retry(base, 'retry-005', { expectedAttemptId: 'work#001/attempts/001' }).kind).toBe('requested');
+    appendEvent(journalPath, { type: 'nodeDispatched', nodeId: 'work', instanceId: 'work#001', attemptId: 'work#001/attempts/002' });
     appendEvent(journalPath, {
-      type: 'nodeBlocked', nodeId: 'work', attemptId: 'work/attempts/002',
+      type: 'nodeBlocked', nodeId: 'work', instanceId: 'work#001', attemptId: 'work#001/attempts/002',
       errorClass: 'workerError', errorCode: 'AUTH_REQUIRED', message: '还是要登录',
     });
     appendEvent(journalPath, { type: 'runBlocked', blockedNodeId: 'work' });
 
     // 用 001 的旧卡点击 → stale-attempt，绝不 append 003
-    const stale = requestV3Retry(base, 'retry-005', { nodeId: 'work', expectedAttemptId: 'work/attempts/001' });
+    const stale = requestV3Retry(base, 'retry-005', { nodeId: 'work', expectedAttemptId: 'work#001/attempts/001' });
     expect(stale).toMatchObject({ kind: 'stale-run', reason: 'stale-attempt' });
     expect(readJournal(journalPath).filter((e) => e.type === 'nodeRetryRequested')).toHaveLength(1);
 
     // 当前卡（002）/ CLI（不带 expectedAttemptId）仍可重试
-    const fresh = requestV3Retry(base, 'retry-005', { nodeId: 'work', expectedAttemptId: 'work/attempts/002' });
-    expect(fresh).toMatchObject({ kind: 'requested', nextAttemptId: 'work/attempts/003' });
+    const fresh = requestV3Retry(base, 'retry-005', { nodeId: 'work', expectedAttemptId: 'work#001/attempts/002' });
+    expect(fresh).toMatchObject({ kind: 'requested', nextAttemptId: 'work#001/attempts/003' });
 
     // 预留未消费期间，001 旧卡点进 pending 分支也必须 stale（不是 already-requested）
-    const staleOnPending = requestV3Retry(base, 'retry-005', { nodeId: 'work', expectedAttemptId: 'work/attempts/001' });
+    const staleOnPending = requestV3Retry(base, 'retry-005', { nodeId: 'work', expectedAttemptId: 'work#001/attempts/001' });
     expect(staleOnPending).toMatchObject({ kind: 'stale-run', reason: 'stale-attempt' });
     // 002 的卡在预留未消费期间重复点 → already-requested（幂等）
-    expect(requestV3Retry(base, 'retry-005', { nodeId: 'work', expectedAttemptId: 'work/attempts/002' }).kind).toBe('already-requested');
+    expect(requestV3Retry(base, 'retry-005', { nodeId: 'work', expectedAttemptId: 'work#001/attempts/002' }).kind).toBe('already-requested');
     rmSync(base, { recursive: true, force: true });
   });
 
@@ -405,7 +405,7 @@ describe('requestV3Retry + 重驱动全链路', () => {
     const base = freshBase();
     const { journalPath } = seedBlockedRun(base, 'retry-004');
     const info = blockedInfoFor(readJournal(journalPath), 'work');
-    expect(info).toMatchObject({ nodeId: 'work', attemptId: 'work/attempts/001', errorCode: 'AUTH_REQUIRED' });
+    expect(info).toMatchObject({ nodeId: 'work', attemptId: 'work#001/attempts/001', errorCode: 'AUTH_REQUIRED' });
     rmSync(base, { recursive: true, force: true });
   });
 });

--- a/test/v3-daemon-run.test.ts
+++ b/test/v3-daemon-run.test.ts
@@ -75,12 +75,12 @@ describe('driveV3Run — suspend gate → 发卡 → 点击 redrive', () => {
       expect(postGateCard).toHaveBeenCalledTimes(1);
       const [binding, gate, runId] = postGateCard.mock.calls[0]!;
       expect(binding).toEqual(BINDING);
-      expect(gate).toMatchObject({ nodeId: 'deploy', waitId: 'deploy-gate', prompt: '批准部署？' });
+      expect(gate).toMatchObject({ nodeId: 'deploy', waitId: 'deploy#001-gate', prompt: '批准部署？' });
       expect(runId).toBe('gate-run');
       expect(onTerminal).not.toHaveBeenCalled();
       expect(runNodeCalls()).toBe(0);
       // wait file 已被 runtime 写出（pending）
-      expect(readWait(runDir, 'deploy-gate')?.status).toBe('pending');
+      expect(readWait(runDir, 'deploy#001-gate')?.status).toBe('pending');
     } finally {
       rmSync(base, { recursive: true, force: true });
     }
@@ -95,9 +95,9 @@ describe('driveV3Run — suspend gate → 发卡 → 点击 redrive', () => {
       await driveV3Run('gate-run', shared.deps); // → awaitingGate
 
       // 模拟 card handler 点击批准：先 resolveWait，再 append gateResolved
-      resolveWait(runDir, 'deploy-gate', 'approved', 'ou_user');
+      resolveWait(runDir, 'deploy#001-gate', 'approved', 'ou_user');
       appendEvent(join(runDir, 'journal.ndjson'), {
-        type: 'gateResolved', nodeId: 'deploy', waitId: 'deploy-gate', resolution: 'approved', by: 'ou_user',
+        type: 'gateResolved', nodeId: 'deploy', waitId: 'deploy#001-gate', resolution: 'approved', by: 'ou_user',
       } as any);
 
       const outcome = await driveV3Run('gate-run', shared.deps); // redrive
@@ -157,9 +157,9 @@ describe('resolveV3GateClick — 幂等 + terminal-safe（codex #5/#1/#2）', ()
       const runDir = toAwaitingGate(base);
       await driveV3Run('gate-run', stubDeps(base).deps); // 写出 pending wait + running journal
 
-      const out = resolveV3GateClick(base, 'gate-run', { waitId: 'deploy-gate', selected: 'approve', by: 'ou_user' });
+      const out = resolveV3GateClick(base, 'gate-run', { waitId: 'deploy#001-gate', selected: 'approve', by: 'ou_user' });
       expect(out).toEqual({ kind: 'resolved', resolution: 'approved' });
-      expect(readWait(runDir, 'deploy-gate')?.status).toBe('approved');
+      expect(readWait(runDir, 'deploy#001-gate')?.status).toBe('approved');
       const gr = readJournal(join(runDir, 'journal.ndjson')).find((e) => e.type === 'gateResolved') as any;
       expect(gr).toBeTruthy();
       expect(gr.resolution).toBe('approved');
@@ -175,14 +175,14 @@ describe('resolveV3GateClick — 幂等 + terminal-safe（codex #5/#1/#2）', ()
     try {
       const runDir = toAwaitingGate(base);
       await driveV3Run('gate-run', stubDeps(base).deps);
-      resolveV3GateClick(base, 'gate-run', { waitId: 'deploy-gate', selected: 'approve', by: 'ou_user' });
+      resolveV3GateClick(base, 'gate-run', { waitId: 'deploy#001-gate', selected: 'approve', by: 'ou_user' });
       const before = readJournal(join(runDir, 'journal.ndjson')).filter((e) => e.type === 'gateResolved').length;
 
-      const out = resolveV3GateClick(base, 'gate-run', { waitId: 'deploy-gate', selected: 'reject', by: 'ou_other' });
+      const out = resolveV3GateClick(base, 'gate-run', { waitId: 'deploy#001-gate', selected: 'reject', by: 'ou_other' });
       expect(out).toEqual({ kind: 'already-settled', status: 'approved' });
       const after = readJournal(join(runDir, 'journal.ndjson')).filter((e) => e.type === 'gateResolved').length;
       expect(after).toBe(before);
-      expect(readWait(runDir, 'deploy-gate')?.status).toBe('approved');
+      expect(readWait(runDir, 'deploy#001-gate')?.status).toBe('approved');
     } finally {
       rmSync(base, { recursive: true, force: true });
     }
@@ -193,7 +193,7 @@ describe('resolveV3GateClick — 幂等 + terminal-safe（codex #5/#1/#2）', ()
     try {
       const runDir = toAwaitingGate(base);
       await driveV3Run('gate-run', stubDeps(base).deps);
-      const wait = readWait(runDir, 'deploy-gate')!;
+      const wait = readWait(runDir, 'deploy#001-gate')!;
       writePendingWait(runDir, {
         waitId: wait.waitId,
         nodeId: wait.nodeId,
@@ -203,10 +203,10 @@ describe('resolveV3GateClick — 幂等 + terminal-safe（codex #5/#1/#2）', ()
         approvers: ['ou_owner'],
       });
 
-      const out = resolveV3GateClick(base, 'gate-run', { waitId: 'deploy-gate', selected: 'approve', by: 'ou_intruder' });
+      const out = resolveV3GateClick(base, 'gate-run', { waitId: 'deploy#001-gate', selected: 'approve', by: 'ou_intruder' });
 
       expect(out).toEqual({ kind: 'unauthorized' });
-      expect(readWait(runDir, 'deploy-gate')?.status).toBe('pending');
+      expect(readWait(runDir, 'deploy#001-gate')?.status).toBe('pending');
       expect(readJournal(join(runDir, 'journal.ndjson')).some((e) => e.type === 'gateResolved')).toBe(false);
     } finally {
       rmSync(base, { recursive: true, force: true });
@@ -220,9 +220,9 @@ describe('resolveV3GateClick — 幂等 + terminal-safe（codex #5/#1/#2）', ()
       await driveV3Run('gate-run', stubDeps(base).deps);
       appendEvent(join(runDir, 'journal.ndjson'), { type: 'runSucceeded' } as any);
 
-      const out = resolveV3GateClick(base, 'gate-run', { waitId: 'deploy-gate', selected: 'approve', by: 'ou_user' });
+      const out = resolveV3GateClick(base, 'gate-run', { waitId: 'deploy#001-gate', selected: 'approve', by: 'ou_user' });
       expect(out).toEqual({ kind: 'stale-run', reason: 'terminal' });
-      expect(readWait(runDir, 'deploy-gate')?.status).toBe('pending');
+      expect(readWait(runDir, 'deploy#001-gate')?.status).toBe('pending');
     } finally {
       rmSync(base, { recursive: true, force: true });
     }
@@ -244,7 +244,7 @@ describe('resolveV3GateClick — 幂等 + terminal-safe（codex #5/#1/#2）', ()
     const base = freshBase();
     try {
       seedApprovedRun(base, 'gate-run', { binding: BINDING });
-      const out = resolveV3GateClick(base, 'gate-run', { waitId: 'deploy-gate', selected: 'approve', by: 'u' });
+      const out = resolveV3GateClick(base, 'gate-run', { waitId: 'deploy#001-gate', selected: 'approve', by: 'u' });
       expect(out).toEqual({ kind: 'stale-run', reason: 'missing' });
     } finally {
       rmSync(base, { recursive: true, force: true });
@@ -256,6 +256,32 @@ describe('resolveV3GateClick — 幂等 + terminal-safe（codex #5/#1/#2）', ()
     try {
       expect(() => resolveV3GateClick(base, '../escape', { waitId: 'w', selected: 'approve', by: 'u' })).toThrow(/invalid runId/);
       await expect(driveV3Run('a/b', stubDeps(base).deps)).rejects.toThrow(/invalid runId/);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it('stale-card 防护:回溯后旧 A#001-gate 卡点击失效,A#002-gate 才有效', () => {
+    const base = freshBase();
+    try {
+      const runId = 'gate-revisit';
+      const { runDir } = birthRun({ goal: 'g', baseDir: base, runId, chatBinding: BINDING });
+      const jp = join(runDir, 'journal.ndjson');
+      appendEvent(jp, { type: 'runStarted', runId });
+      // A#001 派 gate → 被回溯 supersede → A#002 重新派 gate（两张独立 wait 文件）
+      appendEvent(jp, { type: 'gateDispatched', nodeId: 'A', instanceId: 'A#001', waitId: 'A#001-gate' });
+      writePendingWait(runDir, { waitId: 'A#001-gate', nodeId: 'A', instanceId: 'A#001', prompt: '批?' });
+      appendEvent(jp, { type: 'nodeInstanceSuperseded', nodeId: 'A', instanceId: 'A#001', byNodeId: 'A', reason: 'refresh' });
+      appendEvent(jp, { type: 'gateDispatched', nodeId: 'A', instanceId: 'A#002', waitId: 'A#002-gate' });
+      writePendingWait(runDir, { waitId: 'A#002-gate', nodeId: 'A', instanceId: 'A#002', prompt: '批?' });
+
+      // 旧 A#001 卡点击 → stale-node（wait.instanceId A#001 ≠ 当前 effective A#002）
+      expect(resolveV3GateClick(base, runId, { waitId: 'A#001-gate', selected: 'approve', by: 'ou_user' }))
+        .toEqual({ kind: 'stale-run', reason: 'stale-node' });
+      expect(readWait(runDir, 'A#001-gate')?.status).toBe('pending'); // 没被消费
+      // 当前 A#002 卡点击 → 正常 resolved
+      expect(resolveV3GateClick(base, runId, { waitId: 'A#002-gate', selected: 'approve', by: 'ou_user' }))
+        .toEqual({ kind: 'resolved', resolution: 'approved' });
     } finally {
       rmSync(base, { recursive: true, force: true });
     }
@@ -496,9 +522,9 @@ describe('createV3GateRunner — coalescing：drive 期间 click 不丢（codex 
       expect(postCalled).toBe(true);
 
       // 模拟用户点卡（gate resolve）+ 在 drive 仍 in-flight 时再 driveDetached
-      resolveWait(runDir, 'deploy-gate', 'approved', 'ou_user');
+      resolveWait(runDir, 'deploy#001-gate', 'approved', 'ou_user');
       appendEvent(join(runDir, 'journal.ndjson'), {
-        type: 'gateResolved', nodeId: 'deploy', waitId: 'deploy-gate', resolution: 'approved', by: 'ou_user',
+        type: 'gateResolved', nodeId: 'deploy', waitId: 'deploy#001-gate', resolution: 'approved', by: 'ou_user',
       } as any);
       runner.driveDetached('gate-run'); // in-flight → coalesce 成 rerun（不能丢）
 

--- a/test/v3-early-release.test.ts
+++ b/test/v3-early-release.test.ts
@@ -81,6 +81,7 @@ describe('v3 early-release / loser cancellation', () => {
       {
         kind: 'dispatchWork',
         nodeId: 'merge',
+        instanceId: 'merge#001',
         omitted: [{ from: 'b', reason: 'earlyRelease' }, { from: 'c', reason: 'earlyRelease' }],
       },
       { kind: 'cancelNode', nodeId: 'b', byNodeId: 'merge', detail: 'early-release loser for "merge"' },
@@ -101,7 +102,7 @@ describe('v3 early-release / loser cancellation', () => {
     });
 
     const actions = decideNext(dag, st({ a: 'done', b: 'running', c: 'running' }));
-    expect(actions).toContainEqual({ kind: 'dispatchWork', nodeId: 'merge', omitted: [{ from: 'b', reason: 'earlyRelease' }] });
+    expect(actions).toContainEqual({ kind: 'dispatchWork', nodeId: 'merge', instanceId: 'merge#001', omitted: [{ from: 'b', reason: 'earlyRelease' }] });
     expect(actions.some((a) => a.kind === 'cancelNode' && a.nodeId === 'b')).toBe(false);
   });
 

--- a/test/v3-early-release.test.ts
+++ b/test/v3-early-release.test.ts
@@ -139,6 +139,21 @@ describe('v3 early-release / loser cancellation', () => {
     expect(materialize(events).nodes.get('b')?.status).toBe('cancelled');
   });
 
+  it('materialize: 取消 A#001 不压制 A#002 的成功(instance 化 cancel)', () => {
+    const events: StoredEvent[] = [
+      { ts: 1, type: 'runStarted', runId: 'cancel-instance' },
+      { ts: 2, type: 'nodeDispatched', nodeId: 'A', instanceId: 'A#001', attemptId: 'A#001/attempts/001' },
+      { ts: 3, type: 'nodeCancelled', nodeId: 'A', instanceId: 'A#001', attemptId: 'A#001/attempts/001', reason: 'earlyReleaseLoser', byNodeId: 'm' },
+      // 回溯后重生的 A#002 正常成功 —— 旧 A#001 的 cancel 不能把它压成 cancelled。
+      { ts: 4, type: 'nodeDispatched', nodeId: 'A', instanceId: 'A#002', attemptId: 'A#002/attempts/001' },
+      { ts: 5, type: 'nodeSucceeded', nodeId: 'A', instanceId: 'A#002', attemptId: 'A#002/attempts/001', manifestPath: '/tmp/m.json' },
+    ];
+    const snap = materialize(events);
+    expect(snap.instances.get('A#001')?.status).toBe('cancelled');
+    expect(snap.instances.get('A#002')?.status).toBe('done');
+    expect(snap.nodes.get('A')?.status).toBe('done'); // 节点视图 = 当前 effective A#002
+  });
+
   it('runtime: 三路赛马 one_success，赢家发车，败者 abort 后失败不污染终态', async () => {
     const base = mkdtempSync(join(tmpdir(), 'v3-early-runtime-'));
     try {

--- a/test/v3-edge-schema.test.ts
+++ b/test/v3-edge-schema.test.ts
@@ -470,3 +470,57 @@ describe('renderGoalFile: enum 说明行', () => {
     expect(noEnum).not.toContain('MUST use one of the listed values');
   });
 });
+
+// ─── revisitTo 校验（跨节点回溯，只能指向祖先）────────────────────────────────
+
+describe('validateDag: revisitTo 校验', () => {
+  // A -> B -> C 链；C 想回溯到祖先 A。
+  const chain = (cExtra: Record<string, unknown>) =>
+    dag([
+      goal('A'),
+      goal('B', { depends: ['A'] }),
+      goal('C', { depends: ['B'], ...cExtra }),
+    ]);
+
+  it('指向(传递)祖先 → 合法', () => {
+    const d = validateDag(chain({ revisitTo: ['A'] }));
+    expect(d.nodes.find((n) => n.id === 'C')?.revisitTo).toEqual(['A']);
+  });
+
+  it('指向直接父节点 → 合法', () => {
+    expect(problemsOf(() => validateDag(chain({ revisitTo: ['B'] })))).toEqual([]);
+  });
+
+  it('未声明 revisitTo → 字段缺省、零问题', () => {
+    const d = validateDag(chain({}));
+    expect(d.nodes.find((n) => n.id === 'C')?.revisitTo).toBeUndefined();
+  });
+
+  it('指向未知节点 → 报 unknown', () => {
+    const p = problemsOf(() => validateDag(chain({ revisitTo: ['X'] })));
+    expect(p.some((m) => m.includes('revisitTo references unknown node "X"'))).toBe(true);
+  });
+
+  it('指向自身 → 拒', () => {
+    const p = problemsOf(() => validateDag(chain({ revisitTo: ['C'] })));
+    expect(p.some((m) => m.includes('cannot point at itself'))).toBe(true);
+  });
+
+  it('指向非祖先(下游/兄弟) → 拒(只能向后跳)', () => {
+    // A 想 revisitTo B,但 B 是 A 的下游 → 非法。
+    const p = problemsOf(() =>
+      validateDag(dag([goal('A', { revisitTo: ['B'] }), goal('B', { depends: ['A'] })])),
+    );
+    expect(p.some((m) => m.includes('must be an ancestor'))).toBe(true);
+  });
+
+  it('revisitTo 不是数组 → 拒', () => {
+    const p = problemsOf(() => validateDag(chain({ revisitTo: 'A' })));
+    expect(p.some((m) => m.includes('must be an array'))).toBe(true);
+  });
+
+  it('revisitTo 有重复 → 报 duplicates', () => {
+    const p = problemsOf(() => validateDag(chain({ revisitTo: ['A', 'A'] })));
+    expect(p.some((m) => m.includes('has duplicates'))).toBe(true);
+  });
+});

--- a/test/v3-engine.test.ts
+++ b/test/v3-engine.test.ts
@@ -19,7 +19,7 @@ import {
   DagValidationError,
   type V3Dag,
 } from '../src/workflows/v3/dag.js';
-import { decideNext, findSinks, type V3RunState } from '../src/workflows/v3/orchestrator.js';
+import { decideNext, findSinks, type V3RunState, type V3EdgeRunState } from '../src/workflows/v3/orchestrator.js';
 import { appendEvent, readJournal } from '../src/workflows/v3/journal.js';
 import { materialize, writeState, readState } from '../src/workflows/v3/state.js';
 
@@ -174,6 +174,24 @@ describe('decideNext', () => {
 
   it('findSinks 找到末端节点', () => {
     expect(findSinks(dag)).toEqual(['summarize']);
+  });
+
+  it('回溯不复用旧条件边 verdict（verdict 绑 source effective instance）', () => {
+    const branch = validateDag({
+      runId: 'b',
+      nodes: [
+        { id: 'judge', type: 'goal', goal: 'j', depends: [], inputs: [],
+          resultSchema: { type: 'object', properties: { decision: { type: 'string', enum: ['pass', 'fail'] } }, required: ['decision'] } },
+        { id: 'pass', type: 'goal', goal: 'p', depends: [{ from: 'judge', when: { path: 'result.decision', equals: 'pass' } }], inputs: [] },
+      ],
+    });
+    // judge 旧实例 #001 的条件边 verdict=active 仍在 edges 里。
+    const edges: V3EdgeRunState = new Map([['judge#001->pass', { active: true, sourceAttemptId: 'judge#001/attempts/001' }]]);
+    // judge 被回溯刷新：effective 现在是 #002（新实例已成功）。
+    const state: V3RunState = new Map([['judge', { status: 'done', effectiveInstanceId: 'judge#002' }]]);
+    // pass 的 readiness 必须查 `judge#002->pass`（未解析）→ 重新 resolveEdge，
+    // 绝不复用 `judge#001->pass` 的 active verdict（菲菲 review #2）。
+    expect(decideNext(branch, state, new Map(), edges)).toEqual([{ kind: 'resolveEdge', from: 'judge', to: 'pass' }]);
   });
 
   it('条件边 unresolved → 先 resolveEdge，不派下游', () => {

--- a/test/v3-engine.test.ts
+++ b/test/v3-engine.test.ts
@@ -166,7 +166,7 @@ describe('decideNext', () => {
       runId: 'g',
       nodes: [{ id: 'a', type: 'goal', goal: 'g', depends: [], inputs: [], humanGate: { prompt: '批？' } }],
     });
-    expect(decideNext(gated, new Map())).toEqual([{ kind: 'dispatchGate', nodeId: 'a' }]);
+    expect(decideNext(gated, new Map())).toEqual([{ kind: 'dispatchGate', nodeId: 'a', instanceId: 'a#001' }]);
     // gate 已批准（gateCleared）→ 派 work
     const cleared: V3RunState = new Map([['a', { status: 'pending', gateCleared: true }]]);
     expect(decideNext(gated, cleared)).toEqual([{ kind: 'dispatchWork', nodeId: 'a', instanceId: 'a#001' }]);

--- a/test/v3-engine.test.ts
+++ b/test/v3-engine.test.ts
@@ -146,6 +146,21 @@ describe('decideNext', () => {
     expect(decideNext(dag, state)).toEqual([{ kind: 'completeRunFailed', failedNodeId: 'research' }]);
   });
 
+  it('回溯重派：节点 pending + 有 superseded 实例 → dispatchWork 带 next instanceId', () => {
+    // 回溯把 research#001 刷新后,节点回 pending;重派应得 research#002（约束4）。
+    const state: V3RunState = new Map([['research', { status: 'pending' }]]);
+    const instances: V3RunState = new Map([['research#001', { status: 'superseded' }]]);
+    expect(decideNext(dag, state, new Map(), new Map(), instances)).toEqual([
+      { kind: 'dispatchWork', nodeId: 'research', instanceId: 'research#002' },
+    ]);
+  });
+
+  it('首次派发(instances 为空)不带 instanceId（向后兼容首轮路径）', () => {
+    expect(decideNext(dag, new Map(), new Map(), new Map(), new Map())).toEqual([
+      { kind: 'dispatchWork', nodeId: 'research' },
+    ]);
+  });
+
   it('humanGate：先派 gate，approved 后派 work', () => {
     const gated = validateDag({
       runId: 'g',

--- a/test/v3-engine.test.ts
+++ b/test/v3-engine.test.ts
@@ -118,14 +118,14 @@ describe('topologicalOrder', () => {
 describe('decideNext', () => {
   const dag: V3Dag = validateDag(TWO_NODE);
 
-  it('空状态：只派根节点，依赖未就绪的不派', () => {
+  it('空状态：只派根节点，依赖未就绪的不派（首派带 #001 实例）', () => {
     const actions = decideNext(dag, new Map());
-    expect(actions).toEqual([{ kind: 'dispatchWork', nodeId: 'research' }]);
+    expect(actions).toEqual([{ kind: 'dispatchWork', nodeId: 'research', instanceId: 'research#001' }]);
   });
 
   it('根节点 done 后派下游', () => {
     const state: V3RunState = new Map([['research', { status: 'done' }]]);
-    expect(decideNext(dag, state)).toEqual([{ kind: 'dispatchWork', nodeId: 'summarize' }]);
+    expect(decideNext(dag, state)).toEqual([{ kind: 'dispatchWork', nodeId: 'summarize', instanceId: 'summarize#001' }]);
   });
 
   it('运行中节点不重复派', () => {
@@ -155,9 +155,9 @@ describe('decideNext', () => {
     ]);
   });
 
-  it('首次派发(instances 为空)不带 instanceId（向后兼容首轮路径）', () => {
+  it('首次派发(instances 为空) → 带 #001（instance 是真正运行节点,首派也是实例）', () => {
     expect(decideNext(dag, new Map(), new Map(), new Map(), new Map())).toEqual([
-      { kind: 'dispatchWork', nodeId: 'research' },
+      { kind: 'dispatchWork', nodeId: 'research', instanceId: 'research#001' },
     ]);
   });
 
@@ -169,7 +169,7 @@ describe('decideNext', () => {
     expect(decideNext(gated, new Map())).toEqual([{ kind: 'dispatchGate', nodeId: 'a' }]);
     // gate 已批准（gateCleared）→ 派 work
     const cleared: V3RunState = new Map([['a', { status: 'pending', gateCleared: true }]]);
-    expect(decideNext(gated, cleared)).toEqual([{ kind: 'dispatchWork', nodeId: 'a' }]);
+    expect(decideNext(gated, cleared)).toEqual([{ kind: 'dispatchWork', nodeId: 'a', instanceId: 'a#001' }]);
   });
 
   it('findSinks 找到末端节点', () => {
@@ -246,7 +246,7 @@ describe('decideNext', () => {
     ]);
     expect(decideNext(branch, state, new Map(), edges)).toEqual([
       { kind: 'skipNode', nodeId: 'fail', detail: expect.stringContaining('edgeInactive') },
-      { kind: 'dispatchWork', nodeId: 'pass' },
+      { kind: 'dispatchWork', nodeId: 'pass', instanceId: 'pass#001' },
     ]);
 
     const afterSkip: V3RunState = new Map([
@@ -293,6 +293,7 @@ describe('decideNext', () => {
       {
         kind: 'dispatchWork',
         nodeId: 'any',
+        instanceId: 'any#001',
         omitted: [
           { from: 'b', reason: 'sourceSkipped' },
           { from: 'c', reason: 'sourceSkipped' },

--- a/test/v3-engine.test.ts
+++ b/test/v3-engine.test.ts
@@ -449,6 +449,55 @@ describe('journal + state', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it('instance 层: dispatch 带 instanceId → instances + effectiveInstanceId', () => {
+    const snap = materialize([
+      { ts: 1, type: 'nodeDispatched', nodeId: 'A', instanceId: 'A#001', attemptId: 'A#001/attempts/001' },
+      { ts: 2, type: 'nodeSucceeded', nodeId: 'A', instanceId: 'A#001', attemptId: 'A#001/attempts/001', manifestPath: '/x' },
+    ]);
+    expect(snap.nodes.get('A')).toEqual({ status: 'done', effectiveInstanceId: 'A#001' });
+    expect(snap.instances.get('A#001')!.status).toBe('done');
+    // attempts keyed by instanceId (constraint 3)
+    expect(snap.attempts.get('A#001')).toBe('A#001/attempts/001');
+  });
+
+  it('instance 层: revisit supersede 把目标+下游 instance 刷新, 节点回 pending', () => {
+    // A -> B -> C 首轮全成功, C#001 回溯 A → A/B/C #001 全 superseded.
+    const snap = materialize([
+      { ts: 1, type: 'nodeDispatched', nodeId: 'A', instanceId: 'A#001', attemptId: 'A#001/attempts/001' },
+      { ts: 2, type: 'nodeSucceeded', nodeId: 'A', instanceId: 'A#001', attemptId: 'A#001/attempts/001', manifestPath: '/a' },
+      { ts: 3, type: 'nodeDispatched', nodeId: 'B', instanceId: 'B#001', attemptId: 'B#001/attempts/001' },
+      { ts: 4, type: 'nodeSucceeded', nodeId: 'B', instanceId: 'B#001', attemptId: 'B#001/attempts/001', manifestPath: '/b' },
+      { ts: 5, type: 'nodeDispatched', nodeId: 'C', instanceId: 'C#001', attemptId: 'C#001/attempts/001' },
+      { ts: 6, type: 'nodeSucceeded', nodeId: 'C', instanceId: 'C#001', attemptId: 'C#001/attempts/001', manifestPath: '/c' },
+      { ts: 7, type: 'nodeRevisitRequested', nodeId: 'C', instanceId: 'C#001', attemptId: 'C#001/attempts/001', toNodeId: 'A', reason: '缺信息' },
+      { ts: 8, type: 'nodeInstanceSuperseded', nodeId: 'A', instanceId: 'A#001', byNodeId: 'A', reason: 'refresh' },
+      { ts: 9, type: 'nodeInstanceSuperseded', nodeId: 'B', instanceId: 'B#001', byNodeId: 'A', reason: 'refresh' },
+      { ts: 10, type: 'nodeInstanceSuperseded', nodeId: 'C', instanceId: 'C#001', byNodeId: 'A', reason: 'refresh' },
+    ]);
+    // 旧 instance 全 superseded
+    expect(snap.instances.get('A#001')!.status).toBe('superseded');
+    expect(snap.instances.get('B#001')!.status).toBe('superseded');
+    expect(snap.instances.get('C#001')!.status).toBe('superseded');
+    // 节点回 pending、effective 清空 → decideNext 会重派 #002
+    expect(snap.nodes.get('A')).toEqual({ status: 'pending' });
+    expect(snap.nodes.get('B')).toEqual({ status: 'pending' });
+    expect(snap.nodes.get('C')).toEqual({ status: 'pending' });
+  });
+
+  it('instance 层: 重派 A#002 后 effective 指向新实例; 旧实例迟到 settle 不复活节点', () => {
+    const snap = materialize([
+      { ts: 1, type: 'nodeDispatched', nodeId: 'A', instanceId: 'A#001', attemptId: 'A#001/attempts/001' },
+      { ts: 2, type: 'nodeInstanceSuperseded', nodeId: 'A', instanceId: 'A#001', byNodeId: 'A', reason: 'refresh' },
+      { ts: 3, type: 'nodeDispatched', nodeId: 'A', instanceId: 'A#002', attemptId: 'A#002/attempts/001' },
+      // 旧实例 A#001 的迟到成功（不该把节点拉回 done — 它已被 supersede）
+      { ts: 4, type: 'nodeSucceeded', nodeId: 'A', instanceId: 'A#001', attemptId: 'A#001/attempts/001', manifestPath: '/stale' },
+    ]);
+    expect(snap.nodes.get('A')).toEqual({ status: 'running', effectiveInstanceId: 'A#002' });
+    expect(snap.instances.get('A#002')!.status).toBe('running');
+    // 迟到 settle 记到旧 instance, 但不动节点 effective 视图
+    expect(snap.instances.get('A#001')!.status).toBe('done');
+  });
 });
 
 // ── loadDag（文件 IO）─────────────────────────────────────────────────────────

--- a/test/v3-engine.test.ts
+++ b/test/v3-engine.test.ts
@@ -485,18 +485,37 @@ describe('journal + state', () => {
     expect(snap.nodes.get('C')).toEqual({ status: 'pending' });
   });
 
-  it('instance 层: 重派 A#002 后 effective 指向新实例; 旧实例迟到 settle 不复活节点', () => {
+  it('instance 层: 重派 A#002 后 effective 指向新实例; 旧实例迟到 settle 不复活、不解冻刷新态', () => {
     const snap = materialize([
       { ts: 1, type: 'nodeDispatched', nodeId: 'A', instanceId: 'A#001', attemptId: 'A#001/attempts/001' },
       { ts: 2, type: 'nodeInstanceSuperseded', nodeId: 'A', instanceId: 'A#001', byNodeId: 'A', reason: 'refresh' },
       { ts: 3, type: 'nodeDispatched', nodeId: 'A', instanceId: 'A#002', attemptId: 'A#002/attempts/001' },
-      // 旧实例 A#001 的迟到成功（不该把节点拉回 done — 它已被 supersede）
+      // 旧实例 A#001 的迟到成功（不该把节点拉回 done，也不该把 A#001 从 superseded 变 done）
       { ts: 4, type: 'nodeSucceeded', nodeId: 'A', instanceId: 'A#001', attemptId: 'A#001/attempts/001', manifestPath: '/stale' },
     ]);
     expect(snap.nodes.get('A')).toEqual({ status: 'running', effectiveInstanceId: 'A#002' });
     expect(snap.instances.get('A#002')!.status).toBe('running');
-    // 迟到 settle 记到旧 instance, 但不动节点 effective 视图
-    expect(snap.instances.get('A#001')!.status).toBe('done');
+    // 迟到 settle 不能解冻刷新态：A#001 仍是 superseded（菲菲 review blocker 1）
+    expect(snap.instances.get('A#001')!.status).toBe('superseded');
+  });
+
+  it('instance 层: gate 挂 instance — A#001 批准不污染 A#002（约束6）', () => {
+    const snap = materialize([
+      // A#001 的 gate 批准 → A#001 instance gateCleared
+      { ts: 1, type: 'gateDispatched', nodeId: 'A', instanceId: 'A#001', waitId: 'w1' },
+      { ts: 2, type: 'gateResolved', nodeId: 'A', instanceId: 'A#001', waitId: 'w1', resolution: 'approved', by: 'u' },
+      // A#001 被回溯刷新
+      { ts: 3, type: 'nodeInstanceSuperseded', nodeId: 'A', instanceId: 'A#001', byNodeId: 'A', reason: 'refresh' },
+      // 新实例 A#002 的 gate 重新派发（尚未批准）
+      { ts: 4, type: 'gateDispatched', nodeId: 'A', instanceId: 'A#002', waitId: 'w2' },
+    ]);
+    // A#001 先被批准(pending+gateCleared)再被回溯刷新 → 终态 superseded（刷新态冻结）
+    expect(snap.instances.get('A#001')!.status).toBe('superseded');
+    expect(snap.instances.get('A#002')!.status).toBe('gateWaiting');
+    // 节点视图跟最新 effective 实例 A#002：在等审批，gateCleared 没被 A#001 的批准污染
+    expect(snap.nodes.get('A')!.status).toBe('gateWaiting');
+    expect(snap.nodes.get('A')!.effectiveInstanceId).toBe('A#002');
+    expect(snap.nodes.get('A')!.gateCleared).toBeUndefined();
   });
 });
 

--- a/test/v3-loop.test.ts
+++ b/test/v3-loop.test.ts
@@ -341,7 +341,7 @@ describe('decideNext loop scheduling', () => {
     new Map(Object.entries(entries).map(([k, v]) => [k, { status: v as never }]));
 
   it('gates startLoop on outer deps', () => {
-    expect(decideNext(dag, st({}))).toEqual([{ kind: 'dispatchWork', nodeId: 'prepare' }]);
+    expect(decideNext(dag, st({}))).toEqual([{ kind: 'dispatchWork', nodeId: 'prepare', instanceId: 'prepare#001' }]);
     const actions = decideNext(dag, st({ prepare: 'done' }));
     expect(actions).toEqual([{ kind: 'startLoop', loopId: 'fix' }]);
   });
@@ -399,7 +399,7 @@ describe('decideNext loop scheduling', () => {
       st({ prepare: 'done', fix: 'done' }),
       ls({ iteration: 2, decided: true, lastDecision: 'exit' }),
     );
-    expect(actions).toEqual([{ kind: 'dispatchWork', nodeId: 'report' }]);
+    expect(actions).toEqual([{ kind: 'dispatchWork', nodeId: 'report', instanceId: 'report#001' }]);
   });
 });
 

--- a/test/v3-revisit-e2e.test.ts
+++ b/test/v3-revisit-e2e.test.ts
@@ -1,0 +1,117 @@
+/**
+ * v3-revisit-e2e.test.ts — 跨节点 revisit 的 DAEMON 级端到端：走真正的
+ * `driveV3Run`(grill 出生 + dag.json + bots 解析 + 真 manifest 校验
+ * readAndValidateManifest)+ 注入一个脚本化 worker(不 spawn 真 CLI —— 真 CLI
+ * 是否回溯取决于模型,不可作确定性测试;真机 smoke 见 docs 的 runbook)。
+ *
+ * 覆盖 unit/集成测试够不到的 daemon 编排:revisit → supersede → 预算耗尽 →
+ * postRevisitGrantCard 真被调 → requestRevisitGrant 原子 grant+retry → redrive →
+ * 成功。证明卡片那一砖确实接到了 daemon 受阻分发上。
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+
+import { driveV3Run, requestRevisitGrant, type V3DaemonRunDeps } from '../src/workflows/v3/daemon-run.js';
+import { birthRun, writeGrillState, readGrillState } from '../src/workflows/v3/grill-state.js';
+import { readAndValidateManifest, ManifestValidationError } from '../src/workflows/v3/manifest.js';
+import { readJournal } from '../src/workflows/v3/journal.js';
+import { GOAL_ENV, type Manifest, type RunNode, type ValidateManifest } from '../src/workflows/v3/contract.js';
+
+const BINDING = { larkAppId: 'cli_test', chatId: 'oc_chat', rootMessageId: 'om_root' };
+
+const realValidate: ValidateManifest = async (manifestPath, outputDir) => {
+  try {
+    return { ok: true, manifest: await readAndValidateManifest(manifestPath, outputDir) };
+  } catch (e) {
+    return { ok: false, problems: e instanceof ManifestValidationError ? e.problems : [String(e)] };
+  }
+};
+
+function file(outputDir: string, name: string, content: string, kind: 'markdown' | 'json'): Manifest['files'][number] {
+  writeFileSync(join(outputDir, name), content);
+  return { name, path: name, kind, bytes: Buffer.byteLength(content), sha256: createHash('sha256').update(content).digest('hex'), mime: kind === 'json' ? 'application/json' : 'text/markdown' };
+}
+function writeManifest(req: Parameters<RunNode>[0], m: Manifest): string {
+  const p = req.env[GOAL_ENV.MANIFEST_PATH]!;
+  writeFileSync(p, JSON.stringify(m));
+  return p;
+}
+
+/** A→C, C 声明可回溯 A,且 C 永远请求回溯(逼出预算耗尽)。 */
+function seedRevisitRun(base: string, runId: string): string {
+  const { runDir } = birthRun({ goal: 'g', baseDir: base, runId, chatBinding: BINDING });
+  const dagPath = join(runDir, 'dag.json');
+  writeFileSync(dagPath, JSON.stringify({
+    runId,
+    nodes: [
+      { id: 'A', type: 'goal', goal: 'a', depends: [], inputs: [] },
+      { id: 'C', type: 'goal', goal: 'c', depends: ['A'], inputs: [{ from: 'A' }], revisitTo: ['A'] },
+    ],
+  }));
+  const state = readGrillState(runDir)!;
+  writeGrillState(runDir, { ...state, status: 'dag_approved', dagPath });
+  return runDir;
+}
+
+describe('v3 revisit — daemon 级 e2e (driveV3Run + 真 manifest 校验 + 脚本化 worker)', () => {
+  it('revisit → 预算耗尽 → postRevisitGrantCard 被调 → grant+retry → 收敛成功', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'v3-revisit-e2e-'));
+    try {
+      const runId = 'revisit-e2e';
+      seedRevisitRun(base, runId);
+
+      // C 在 #001/#002 请求回溯(逼出 per-pair=1 耗尽),#003 起成功收敛。
+      const cRevisitInstances = new Set(['C#001', 'C#002']);
+      const runNode: RunNode = async (req) => {
+        if (req.node.id === 'A') {
+          return { status: 'ok', manifestPath: writeManifest(req, { schemaVersion: 1, status: 'ok', summary: 'a', files: [file(req.outputDir, 'a.md', 'A', 'markdown')] }) };
+        }
+        const inst = req.attemptId.split('/')[0]!; // e.g. C#002
+        if (cRevisitInstances.has(inst)) {
+          return { status: 'ok', manifestPath: writeManifest(req, { schemaVersion: 1, status: 'ok', summary: 'revisit', files: [file(req.outputDir, 'result.json', JSON.stringify({ status: 'revisit', revisitTo: 'A', reason: '还要改' }), 'json')] }) };
+        }
+        return { status: 'ok', manifestPath: writeManifest(req, { schemaVersion: 1, status: 'ok', summary: 'c done', files: [file(req.outputDir, 'c.md', 'C-final', 'markdown')] }) };
+      };
+
+      const postRevisitGrantCard = vi.fn(async () => {});
+      const deps: V3DaemonRunDeps = {
+        baseDir: base,
+        loadBots: () => [{ larkAppId: 'cli_test', larkAppSecret: 's', cliId: 'claude-code' } as any],
+        makeRunNode: () => runNode,
+        validateManifest: realValidate,
+        postRevisitGrantCard,
+        onTerminal: async () => {},
+      };
+
+      // drive 1:C#001 回溯 → A#002,C#002 → C#002 回溯 → per-pair 1/1 耗尽 → 受阻。
+      const first = await driveV3Run(runId, deps);
+      expect(first.reason).toBe('terminal');
+      if (first.reason === 'terminal') expect(first.runStatus).toBe('blocked');
+      // daemon 选了 revisit grant 卡(不是普通 retry 卡),且 scope=pair。
+      expect(postRevisitGrantCard).toHaveBeenCalledTimes(1);
+      const info = postRevisitGrantCard.mock.calls[0]![1];
+      expect(info).toMatchObject({ sourceNodeId: 'C', toNodeId: 'A', tier: 'pair' });
+
+      // 人工准许(pair)+ 原子 retry。
+      const grant = requestRevisitGrant(base, runId, { sourceNodeId: 'C', toNodeId: 'A', by: 'ou_user', expectedAttemptId: info.attemptId });
+      expect(grant.kind).toBe('granted');
+
+      // drive 2:C#002 回溯放行(预算 2)→ A#003,C#003 → C#003 成功 → run 成功。
+      const second = await driveV3Run(runId, deps);
+      expect(second.reason).toBe('terminal');
+      if (second.reason === 'terminal') expect(second.runStatus).toBe('succeeded');
+
+      const events = readJournal(join(base, runId, 'journal.ndjson'));
+      // 共放行 2 次回溯(C#001、C#002),C#003 成功收敛。
+      expect(events.filter((e) => e.type === 'nodeRevisitRequested').length).toBe(2);
+      expect(events.some((e) => e.type === 'nodeSucceeded' && (e as any).instanceId === 'C#003')).toBe(true);
+      expect(events.filter((e) => e.type === 'revisitBudgetGranted').length).toBe(1);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/v3-revisit-grant-card.test.ts
+++ b/test/v3-revisit-grant-card.test.ts
@@ -1,0 +1,152 @@
+/**
+ * v3-revisit-grant-card(.handler).test.ts — 回溯预算耗尽卡构建 + 点击处理。
+ * 镜像 v3-loop-grant-card 系测试:卡片纯函数断言 + handler 注入 seam,含 stale
+ * 防护(attemptId nonce —— expectedAttemptId 的同款教训)+ scope 正确性(pair/run)。
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  buildV3RevisitGrantCard,
+  v3RevisitGrantCardNonce,
+  V3_REVISIT_GRANT_ACTION,
+  type V3RevisitGrantActionValue,
+} from '../src/im/lark/v3-revisit-grant-card.js';
+import { handleV3RevisitGrantAction } from '../src/im/lark/v3-revisit-grant-card-handler.js';
+import { birthRun } from '../src/workflows/v3/grill-state.js';
+import { appendEvent, readJournal } from '../src/workflows/v3/journal.js';
+
+const INPUT = {
+  runId: 'demo-run-260608-1300',
+  sourceNodeId: 'C',
+  toNodeId: 'A',
+  tier: 'pair' as const,
+  attemptId: 'C#002/attempts/001',
+  detail: 'revisit budget exhausted for C->A (1/1) — grant +1 (this pair) to continue',
+};
+
+describe('buildV3RevisitGrantCard', () => {
+  it('pending 卡:orange header + 准许按钮 value 带 action/runId/source/to/tier/attemptId/nonce', () => {
+    const card = JSON.parse(buildV3RevisitGrantCard(INPUT));
+    expect(card.header.template).toBe('orange');
+    expect(card.header.title.content).toContain('C → A');
+    const actionEl = card.elements.find((e: any) => e.tag === 'action' && e.actions[0]?.value);
+    const value = actionEl.actions[0].value as V3RevisitGrantActionValue;
+    expect(value).toMatchObject({
+      action: V3_REVISIT_GRANT_ACTION,
+      runId: INPUT.runId,
+      sourceNodeId: 'C',
+      toNodeId: 'A',
+      tier: 'pair',
+      attemptId: 'C#002/attempts/001',
+      nonce: v3RevisitGrantCardNonce(INPUT.runId, 'C', 'C#002/attempts/001'),
+    });
+  });
+
+  it('run-wide 耗尽:标题/层级显示整个 run', () => {
+    const card = JSON.parse(buildV3RevisitGrantCard({ ...INPUT, tier: 'run' }));
+    expect(card.header.title.content).toContain('整个 run');
+    expect(JSON.stringify(card)).toContain('per-run');
+  });
+
+  it('granted 冻结卡:green + 无准许按钮', () => {
+    const card = JSON.parse(buildV3RevisitGrantCard({ ...INPUT, grantedNow: { by: 'ou_x' } }));
+    expect(card.header.template).toBe('green');
+    expect(JSON.stringify(card)).not.toContain(V3_REVISIT_GRANT_ACTION);
+  });
+
+  it('detail 注入安全:lark_md 特殊字符被转义', () => {
+    const card = JSON.parse(buildV3RevisitGrantCard({ ...INPUT, detail: '*bold* [x](y)' }));
+    const el = card.elements.find((e: any) => e.tag === 'div' && e.text?.content?.includes('情况'));
+    expect(el.text.content).toContain('\\*bold\\*');
+  });
+});
+
+describe('handleV3RevisitGrantAction', () => {
+  /** 种一个 C→A 回溯预算耗尽的 blocked run(per-pair 1/1)。 */
+  function seed(base: string, runId: string): string {
+    const { runDir } = birthRun({
+      goal: 'g', baseDir: base, runId,
+      chatBinding: { larkAppId: 'cli_test', chatId: 'oc_chat', rootMessageId: 'om_root' },
+    });
+    const journalPath = join(runDir, 'journal.ndjson');
+    appendEvent(journalPath, { type: 'runStarted', runId });
+    appendEvent(journalPath, { type: 'nodeDispatched', nodeId: 'C', instanceId: 'C#002', attemptId: 'C#002/attempts/001' });
+    // 已回溯过 1 次(pair 1/1 耗尽)
+    appendEvent(journalPath, { type: 'nodeRevisitRequested', nodeId: 'C', instanceId: 'C#001', attemptId: 'C#001/attempts/001', toNodeId: 'A' });
+    appendEvent(journalPath, {
+      type: 'nodeBlocked', nodeId: 'C', instanceId: 'C#002', attemptId: 'C#002/attempts/001',
+      errorClass: 'resultInvalid', errorCode: 'REVISIT_BUDGET_EXHAUSTED', message: 'exhausted', revisitTo: 'A',
+    });
+    appendEvent(journalPath, { type: 'runBlocked', blockedNodeId: 'C' });
+    return runDir;
+  }
+
+  const value = (runId: string, attemptId = 'C#002/attempts/001'): V3RevisitGrantActionValue => ({
+    action: V3_REVISIT_GRANT_ACTION,
+    runId, sourceNodeId: 'C', toNodeId: 'A', tier: 'pair', attemptId,
+    nonce: v3RevisitGrantCardNonce(runId, 'C', attemptId),
+  });
+
+  it('点击 → grant append + 原子 retry + driveRun + 冻结 green 卡', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'v3-revisit-grant-'));
+    const runId = 'rg-260608-0001';
+    const runDir = seed(base, runId);
+    const driveRun = vi.fn();
+    const res: any = await handleV3RevisitGrantAction(value(runId), 'ou_op', { baseDir: base, driveRun });
+    expect(driveRun).toHaveBeenCalledWith(runId);
+    expect(res.header.template).toBe('green');
+    const events = readJournal(join(runDir, 'journal.ndjson'));
+    expect(events.find((e) => e.type === 'revisitBudgetGranted')).toMatchObject({ sourceNodeId: 'C', toNodeId: 'A', by: 'ou_op' });
+    // 原子 retry:C 进入 attempts/002
+    expect(events.find((e) => e.type === 'nodeRetryRequested')).toMatchObject({ nodeId: 'C', nextAttemptId: 'C#002/attempts/002' });
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it('二次点击(retry 后已 pending)→ stale toast,不重复加预算', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'v3-revisit-grant-'));
+    const runId = 'rg-260608-0002';
+    const runDir = seed(base, runId);
+    const driveRun = vi.fn();
+    await handleV3RevisitGrantAction(value(runId), 'ou_op', { baseDir: base, driveRun });
+    const res: any = await handleV3RevisitGrantAction(value(runId), 'ou_op', { baseDir: base, driveRun });
+    expect(res.toast.type).toBe('warning');
+    expect(readJournal(join(runDir, 'journal.ndjson')).filter((e) => e.type === 'revisitBudgetGranted')).toHaveLength(1);
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it('nonce 不匹配 / 非法 runId / 无权限 → toast 不动 journal', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'v3-revisit-grant-'));
+    const runId = 'rg-260608-0003';
+    const runDir = seed(base, runId);
+    const driveRun = vi.fn();
+
+    const badNonce: any = await handleV3RevisitGrantAction({ ...value(runId), nonce: 'wrong' }, 'ou_op', { baseDir: base, driveRun });
+    expect(badNonce.toast.type).toBe('warning');
+
+    const badId: any = await handleV3RevisitGrantAction({ ...value(runId), runId: '../escape' }, 'ou_op', { baseDir: base, driveRun });
+    expect(badId.toast.type).toBe('warning');
+
+    const denied: any = await handleV3RevisitGrantAction(value(runId), 'ou_op', { baseDir: base, driveRun, canResolve: () => false });
+    expect(denied.toast.content).toContain('权限');
+    expect(driveRun).not.toHaveBeenCalled();
+    expect(readJournal(join(runDir, 'journal.ndjson')).some((e) => e.type === 'revisitBudgetGranted')).toBe(false);
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it('stale attempt:旧卡 attemptId 对不上当前 blocked attempt → 失效', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'v3-revisit-grant-'));
+    const runId = 'rg-260608-0004';
+    const runDir = seed(base, runId);
+    const driveRun = vi.fn();
+    // 旧卡指向 attempts/000(对不上当前 blocked 的 attempts/001)
+    const res: any = await handleV3RevisitGrantAction(value(runId, 'C#002/attempts/000'), 'ou_op', { baseDir: base, driveRun });
+    expect(res.toast.type).toBe('warning');
+    expect(driveRun).not.toHaveBeenCalled();
+    expect(readJournal(join(runDir, 'journal.ndjson')).some((e) => e.type === 'revisitBudgetGranted')).toBe(false);
+    rmSync(base, { recursive: true, force: true });
+  });
+});

--- a/test/v3-runtime.test.ts
+++ b/test/v3-runtime.test.ts
@@ -638,3 +638,75 @@ describe('runtime CLI 白名单守卫', () => {
     }
   });
 });
+
+// ─── 跨节点回溯 A→B→C 端到端（菲菲的精确验收）────────────────────────────────
+describe('runWorkflow — 跨节点 revisit A→B→C', () => {
+  it('C#001 回溯 A → A/B/C#001 全 superseded → 重生 #002 → 仅 C#002 done run 才成功; B#002 读 A#002', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'v3-rt-revisit-'));
+    try {
+      const dag = validateDag({
+        runId: 'revisit-abc',
+        nodes: [
+          { id: 'A', type: 'goal', goal: 'a', depends: [], inputs: [] },
+          { id: 'B', type: 'goal', goal: 'b', depends: ['A'], inputs: [{ from: 'A' }] },
+          // C 声明可回溯到祖先 A
+          { id: 'C', type: 'goal', goal: 'c', depends: ['B'], inputs: [{ from: 'B' }], revisitTo: ['A'] },
+        ],
+      });
+      let cRuns = 0;
+      let bSawAContent = '';
+      const runNode: RunNode = async (req) => {
+        if (req.node.id === 'A') {
+          // 第二次跑(A#002)产出不同内容,用来验证 B#002 读到的是新版
+          const content = req.attemptId.startsWith('A#002') ? 'A-v2' : 'A-v1';
+          return { status: 'ok', manifestPath: writeManifest(req, {
+            schemaVersion: 1, status: 'ok', summary: 'a', files: [product(req.outputDir, 'a.md', content)],
+          }) };
+        }
+        if (req.node.id === 'B') {
+          const inputs = JSON.parse(readFileSync(req.inputsPath, 'utf-8')) as GoalInputs;
+          const fromA = inputs.inputs.find((i) => i.from === 'A');
+          if (fromA && req.attemptId.startsWith('B#002')) bSawAContent = readFileSync(fromA.path, 'utf-8');
+          return { status: 'ok', manifestPath: writeManifest(req, {
+            schemaVersion: 1, status: 'ok', summary: 'b', files: [product(req.outputDir, 'b.md', 'B-out')],
+          }) };
+        }
+        // C: 首个 instance(C#001)写 result.json 请求回溯到 A；第二个(C#002)正常成功。
+        cRuns++;
+        if (req.attemptId.startsWith('C#001')) {
+          const rj = jsonProduct(req.outputDir, 'result.json', { status: 'revisit', revisitTo: 'A', reason: '缺计费规则' });
+          return { status: 'ok', manifestPath: writeManifest(req, {
+            schemaVersion: 1, status: 'ok', summary: 'revisit', files: [rj],
+          }) };
+        }
+        return { status: 'ok', manifestPath: writeManifest(req, {
+          schemaVersion: 1, status: 'ok', summary: 'c done', files: [product(req.outputDir, 'c.md', 'C-out')],
+        }) };
+      };
+
+      const deps: V3RuntimeDeps = { runNode, validateManifest, resolveBotSnapshot };
+      const outcome = await runWorkflow(dag, deps, { baseDir: base });
+
+      expect(outcome).toMatchObject({ reason: 'terminal', runStatus: 'succeeded' });
+      const events = readJournal(join(outcome.runDir, 'journal.ndjson'));
+
+      // C 请求了回溯到 A
+      expect(events.some((e) => e.type === 'nodeRevisitRequested' && (e as any).toNodeId === 'A')).toBe(true);
+      // A/B/C 的 #001 实例全部被 supersede（刷新）
+      expect(events.filter((e) => e.type === 'nodeInstanceSuperseded').map((e) => (e as any).instanceId).sort())
+        .toEqual(['A#001', 'B#001', 'C#001']);
+      // 重新生成 #002 三个实例
+      expect(events.filter((e) => e.type === 'nodeDispatched' && (e as any).instanceId?.endsWith('#002'))
+        .map((e) => (e as any).instanceId).sort()).toEqual(['A#002', 'B#002', 'C#002']);
+      // 只有 C#002 成功（C#001 是 revisit,不算成功终态）
+      expect(events.some((e) => e.type === 'nodeSucceeded' && (e as any).instanceId === 'C#002')).toBe(true);
+      expect(events.some((e) => e.type === 'nodeSucceeded' && (e as any).instanceId === 'C#001')).toBe(false);
+      // B#002 的 inputs 来自 A#002（新版产物），不是 A#001
+      expect(bSawAContent).toBe('A-v2');
+      // C 一共跑了 2 次（#001 回溯 + #002 成功）
+      expect(cRuns).toBe(2);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/v3-runtime.test.ts
+++ b/test/v3-runtime.test.ts
@@ -819,23 +819,57 @@ describe('runWorkflow — 跨节点 revisit A→B→C', () => {
     }
   });
 
-  it('回溯预算:grant +1 后预算解锁(revisitBudgetStatus + requestRevisitGrant)', () => {
-    const base = mkdtempSync(join(tmpdir(), 'v3-rt-grant-'));
+  it('回溯预算:revisitBudgetStatus 计数 + grant 事件解锁(纯函数,不泄漏别的 pair)', () => {
+    const base = mkdtempSync(join(tmpdir(), 'v3-rt-budgetstatus-'));
     try {
-      const runDir = join(base, 'g');
-      const jp = join(runDir, 'journal.ndjson');
-      // 模拟 C→A 已回溯 1 次(达到 per-pair 默认 1)
+      const jp = join(base, 'journal.ndjson');
       appendEvent(jp, { type: 'runStarted', runId: 'g' });
       appendEvent(jp, { type: 'nodeRevisitRequested', nodeId: 'C', instanceId: 'C#001', attemptId: 'C#001/attempts/001', toNodeId: 'A' });
-      // 此时 C→A 已耗尽
-      expect(revisitBudgetStatus(readJournal(jp), 'C', 'A').ok).toBe(false);
-      // 人工 grant +1（pair 维度）
-      const out = requestRevisitGrant(base, 'g', { sourceNodeId: 'C', toNodeId: 'A', by: 'ou_user' });
-      expect(out).toEqual({ kind: 'granted', scope: 'pair' });
-      // grant 后预算解锁
-      expect(revisitBudgetStatus(readJournal(jp), 'C', 'A').ok).toBe(true);
-      // 但别的 pair / run 维度不受这条 pair grant 影响（D→A 仍按默认）
-      expect(revisitBudgetStatus(readJournal(jp), 'D', 'A').ok).toBe(true); // D 还没回溯过
+      expect(revisitBudgetStatus(readJournal(jp), 'C', 'A').ok).toBe(false); // pair 1/1 耗尽
+      // pair grant +1（直接 append 事件,测计数,不经 requestRevisitGrant 的恢复语义）
+      appendEvent(jp, { type: 'revisitBudgetGranted', sourceNodeId: 'C', toNodeId: 'A', by: 'ou_user' });
+      expect(revisitBudgetStatus(readJournal(jp), 'C', 'A').ok).toBe(true);  // 1 < 1+1
+      expect(revisitBudgetStatus(readJournal(jp), 'D', 'A').ok).toBe(true);  // pair grant 不泄漏到 D→A
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it('回溯预算:requestRevisitGrant 守卫 + 原子 grant+retry 恢复', () => {
+    const base = mkdtempSync(join(tmpdir(), 'v3-rt-grant-'));
+    try {
+      const runId = 'g';
+      const jp = join(base, runId, 'journal.ndjson');
+      // 造一个"卡在 REVISIT_BUDGET_EXHAUSTED"的 run:C#002 想回溯 A 但预算耗尽。
+      appendEvent(jp, { type: 'runStarted', runId });
+      appendEvent(jp, { type: 'nodeDispatched', nodeId: 'C', instanceId: 'C#002', attemptId: 'C#002/attempts/001' });
+      appendEvent(jp, { type: 'nodeRevisitRequested', nodeId: 'C', instanceId: 'C#001', attemptId: 'C#001/attempts/001', toNodeId: 'A' });
+      appendEvent(jp, {
+        type: 'nodeBlocked', nodeId: 'C', instanceId: 'C#002', attemptId: 'C#002/attempts/001',
+        errorClass: 'resultInvalid', errorCode: 'REVISIT_BUDGET_EXHAUSTED', message: 'exhausted',
+      });
+      appendEvent(jp, { type: 'runBlocked', blockedNodeId: 'C' });
+
+      // 守卫:半个 pair → invalid;pair source 不是 blocked 节点 → invalid。
+      expect(requestRevisitGrant(base, runId, { sourceNodeId: 'C', by: 'u' })).toEqual({ kind: 'invalid', reason: 'partial-pair' });
+      expect(requestRevisitGrant(base, runId, { sourceNodeId: 'X', toNodeId: 'A', by: 'u' })).toEqual({ kind: 'invalid', reason: 'pair-source-mismatch' });
+      // stale attempt → 拒绝
+      expect(requestRevisitGrant(base, runId, { sourceNodeId: 'C', toNodeId: 'A', by: 'u', expectedAttemptId: 'C#002/attempts/999' }))
+        .toEqual({ kind: 'stale-run', reason: 'stale-attempt' });
+
+      // 合法 pair grant → granted + 原子 retry(C 重新派 attempts/002)
+      const out = requestRevisitGrant(base, runId, { sourceNodeId: 'C', toNodeId: 'A', by: 'ou_user', expectedAttemptId: 'C#002/attempts/001' });
+      expect(out.kind).toBe('granted');
+      if (out.kind !== 'granted') throw new Error('expected granted');
+      expect(out.scope).toBe('pair');
+      expect(out.retry).toMatchObject({ kind: 'requested', nodeId: 'C', nextAttemptId: 'C#002/attempts/002' });
+      // 预算确实加了
+      const events = readJournal(jp);
+      expect(events.filter((e) => e.type === 'revisitBudgetGranted').length).toBe(1);
+      // 幂等/新鲜度:retry 后 C 已 pending,再点 grant → not-budget-blocked,不再加预算
+      expect(requestRevisitGrant(base, runId, { sourceNodeId: 'C', toNodeId: 'A', by: 'ou_user' }))
+        .toEqual({ kind: 'stale-run', reason: 'not-budget-blocked' });
+      expect(readJournal(jp).filter((e) => e.type === 'revisitBudgetGranted').length).toBe(1); // 没多加
     } finally {
       rmSync(base, { recursive: true, force: true });
     }

--- a/test/v3-runtime.test.ts
+++ b/test/v3-runtime.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, isAbsolute } from 'node:path';
 import { createHash } from 'node:crypto';
@@ -705,6 +705,58 @@ describe('runWorkflow — 跨节点 revisit A→B→C', () => {
       expect(bSawAContent).toBe('A-v2');
       // C 一共跑了 2 次（#001 回溯 + #002 成功）
       expect(cRuns).toBe(2);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it('buildInputs 抗旧实例迟到成功：journal 里 A 最后一条 success 是迟到的 A#001,B 仍读 A#002', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'v3-rt-latestale-'));
+    try {
+      const dag = validateDag({
+        runId: 'late',
+        nodes: [
+          { id: 'A', type: 'goal', goal: 'a', depends: [], inputs: [] },
+          { id: 'B', type: 'goal', goal: 'b', depends: ['A'], inputs: [{ from: 'A' }] },
+        ],
+      });
+      const runDir = join(base, 'late');
+      const writeA = (inst: string, content: string): string => {
+        const work = join(runDir, inst, 'attempts', '001', 'work');
+        mkdirSync(work, { recursive: true });
+        const file = product(work, 'a.md', content);
+        const mp = join(runDir, inst, 'attempts', '001', 'manifest.json');
+        writeFileSync(mp, JSON.stringify({ schemaVersion: 1, status: 'ok', summary: 'a', files: [file] }));
+        return mp;
+      };
+      const m1 = writeA('A#001', 'A-v1');
+      const m2 = writeA('A#002', 'A-v2');
+      const jp = join(runDir, 'journal.ndjson');
+      appendEvent(jp, { type: 'runStarted', runId: 'late' });
+      appendEvent(jp, { type: 'nodeDispatched', nodeId: 'A', instanceId: 'A#001', attemptId: 'A#001/attempts/001' });
+      appendEvent(jp, { type: 'nodeSucceeded', nodeId: 'A', instanceId: 'A#001', attemptId: 'A#001/attempts/001', manifestPath: m1 });
+      appendEvent(jp, { type: 'nodeInstanceSuperseded', nodeId: 'A', instanceId: 'A#001', byNodeId: 'A', reason: 'refresh' });
+      appendEvent(jp, { type: 'nodeDispatched', nodeId: 'A', instanceId: 'A#002', attemptId: 'A#002/attempts/001' });
+      appendEvent(jp, { type: 'nodeSucceeded', nodeId: 'A', instanceId: 'A#002', attemptId: 'A#002/attempts/001', manifestPath: m2 });
+      // 旧 A#001 worker 迟到再写一次 success → journal 里 A 的“最后一条” success 是 A#001（nodeId-latest 会被它骗到）
+      appendEvent(jp, { type: 'nodeSucceeded', nodeId: 'A', instanceId: 'A#001', attemptId: 'A#001/attempts/001', manifestPath: m1 });
+
+      let bSawA = '';
+      const runNode: RunNode = async (req) => {
+        if (req.node.id === 'B') {
+          const inputs = JSON.parse(readFileSync(req.inputsPath, 'utf-8')) as GoalInputs;
+          const fromA = inputs.inputs.find((i) => i.from === 'A');
+          bSawA = fromA ? readFileSync(fromA.path, 'utf-8') : '(none)';
+        }
+        return { status: 'ok', manifestPath: writeManifest(req, {
+          schemaVersion: 1, status: 'ok', summary: 'b', files: [product(req.outputDir, 'b.md', 'B-out')],
+        }) };
+      };
+      const deps: V3RuntimeDeps = { runNode, validateManifest, resolveBotSnapshot };
+      const outcome = await runWorkflow(dag, deps, { baseDir: base });
+      expect(outcome).toMatchObject({ reason: 'terminal', runStatus: 'succeeded' });
+      // 关键:按 effective instance(A#002)取产物,不被迟到的 A#001 success 污染。
+      expect(bSawA).toBe('A-v2');
     } finally {
       rmSync(base, { recursive: true, force: true });
     }

--- a/test/v3-runtime.test.ts
+++ b/test/v3-runtime.test.ts
@@ -16,7 +16,8 @@ import { createHash } from 'node:crypto';
 
 import { validateDag } from '../src/workflows/v3/dag.js';
 import { appendEvent, readJournal } from '../src/workflows/v3/journal.js';
-import { runWorkflow, type V3RuntimeDeps } from '../src/workflows/v3/runtime.js';
+import { runWorkflow, revisitBudgetStatus, type V3RuntimeDeps } from '../src/workflows/v3/runtime.js';
+import { requestRevisitGrant } from '../src/workflows/v3/daemon-run.js';
 import { readAndValidateManifest, ManifestValidationError } from '../src/workflows/v3/manifest.js';
 import {
   createFileGate,
@@ -775,6 +776,66 @@ describe('runWorkflow — 跨节点 revisit A→B→C', () => {
       expect(outcome).toMatchObject({ reason: 'terminal', runStatus: 'succeeded' });
       // 关键:按 effective instance(A#002)取产物,不被迟到的 A#001 success 污染。
       expect(bSawA).toBe('A-v2');
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it('回溯预算:per-pair 默认 1,第二次 C→A 回溯耗尽 → run blocked(防无限回溯)', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'v3-rt-budget-'));
+    try {
+      const dag = validateDag({
+        runId: 'budget-abc',
+        nodes: [
+          { id: 'A', type: 'goal', goal: 'a', depends: [], inputs: [] },
+          { id: 'C', type: 'goal', goal: 'c', depends: ['A'], inputs: [{ from: 'A' }], revisitTo: ['A'] },
+        ],
+      });
+      let cRuns = 0;
+      const runNode: RunNode = async (req) => {
+        if (req.node.id === 'A') {
+          return { status: 'ok', manifestPath: writeManifest(req, {
+            schemaVersion: 1, status: 'ok', summary: 'a', files: [product(req.outputDir, 'a.md', 'A')],
+          }) };
+        }
+        // C 每次都请求回溯到 A（永不满意）。
+        cRuns++;
+        const rj = jsonProduct(req.outputDir, 'result.json', { status: 'revisit', revisitTo: 'A', reason: '还是不行' });
+        return { status: 'ok', manifestPath: writeManifest(req, {
+          schemaVersion: 1, status: 'ok', summary: 'revisit', files: [rj],
+        }) };
+      };
+      const deps: V3RuntimeDeps = { runNode, validateManifest, resolveBotSnapshot };
+      const outcome = await runWorkflow(dag, deps, { baseDir: base });
+
+      // C#001 回溯(允许)→ A#002 + C#002 → C#002 再回溯(pair 1/1 耗尽)→ C#002 blocked → run blocked
+      expect(outcome).toMatchObject({ reason: 'terminal', runStatus: 'blocked' });
+      const events = readJournal(join(outcome.runDir, 'journal.ndjson'));
+      expect(events.filter((e) => e.type === 'nodeRevisitRequested').length).toBe(1); // 只放行了 1 次
+      expect(events.some((e) => e.type === 'nodeBlocked' && (e as any).errorCode === 'REVISIT_BUDGET_EXHAUSTED')).toBe(true);
+      expect(cRuns).toBe(2); // C#001(放行) + C#002(被预算挡下)
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it('回溯预算:grant +1 后预算解锁(revisitBudgetStatus + requestRevisitGrant)', () => {
+    const base = mkdtempSync(join(tmpdir(), 'v3-rt-grant-'));
+    try {
+      const runDir = join(base, 'g');
+      const jp = join(runDir, 'journal.ndjson');
+      // 模拟 C→A 已回溯 1 次(达到 per-pair 默认 1)
+      appendEvent(jp, { type: 'runStarted', runId: 'g' });
+      appendEvent(jp, { type: 'nodeRevisitRequested', nodeId: 'C', instanceId: 'C#001', attemptId: 'C#001/attempts/001', toNodeId: 'A' });
+      // 此时 C→A 已耗尽
+      expect(revisitBudgetStatus(readJournal(jp), 'C', 'A').ok).toBe(false);
+      // 人工 grant +1（pair 维度）
+      const out = requestRevisitGrant(base, 'g', { sourceNodeId: 'C', toNodeId: 'A', by: 'ou_user' });
+      expect(out).toEqual({ kind: 'granted', scope: 'pair' });
+      // grant 后预算解锁
+      expect(revisitBudgetStatus(readJournal(jp), 'C', 'A').ok).toBe(true);
+      // 但别的 pair / run 维度不受这条 pair grant 影响（D→A 仍按默认）
+      expect(revisitBudgetStatus(readJournal(jp), 'D', 'A').ok).toBe(true); // D 还没回溯过
     } finally {
       rmSync(base, { recursive: true, force: true });
     }

--- a/test/v3-runtime.test.ts
+++ b/test/v3-runtime.test.ts
@@ -415,7 +415,7 @@ describe('runWorkflow — humanGate suspend mode', () => {
         runDir: join(base, 'gate-run'),
         pendingWaits: [{
           nodeId: 'deploy',
-          waitId: 'deploy-gate',
+          waitId: 'deploy#001-gate',
           prompt: '批准部署？',
           options: ['approve', 'reject'],
           approveOptions: ['approve'],
@@ -423,7 +423,7 @@ describe('runWorkflow — humanGate suspend mode', () => {
         }],
       });
       expect(runNodeCalls).toBe(0);
-      expect(readWait(first.runDir, 'deploy-gate')).toMatchObject({
+      expect(readWait(first.runDir, 'deploy#001-gate')).toMatchObject({
         status: 'pending',
         nodeId: 'deploy',
         prompt: '批准部署？',
@@ -432,11 +432,11 @@ describe('runWorkflow — humanGate suspend mode', () => {
       expect(events.some((e) => e.type === 'gateDispatched' && e.nodeId === 'deploy')).toBe(true);
       expect(events.some((e) => e.type === 'nodeDispatched' && e.nodeId === 'deploy')).toBe(false);
 
-      resolveWait(first.runDir, 'deploy-gate', 'approved', 'ou_reviewer');
+      resolveWait(first.runDir, 'deploy#001-gate', 'approved', 'ou_reviewer');
       appendEvent(join(first.runDir, 'journal.ndjson'), {
         type: 'gateResolved',
         nodeId: 'deploy',
-        waitId: 'deploy-gate',
+        waitId: 'deploy#001-gate',
         resolution: 'approved',
         by: 'ou_reviewer',
       });
@@ -484,7 +484,7 @@ describe('runWorkflow — humanGate suspend mode', () => {
       if (outcome.reason !== 'awaitingGate') throw new Error('expected awaitingGate outcome');
       expect(outcome.pendingWaits).toEqual([{
         nodeId: 'approval',
-        waitId: 'approval-gate',
+        waitId: 'approval#001-gate',
         prompt: '批准？',
         options: ['approve', 'reject'],
         approveOptions: ['approve'],
@@ -492,7 +492,7 @@ describe('runWorkflow — humanGate suspend mode', () => {
       }]);
       const events = readJournal(join(outcome.runDir, 'journal.ndjson'));
       expect(events.some((e) => e.type === 'nodeSucceeded' && e.nodeId === 'research')).toBe(true);
-      expect(readWait(outcome.runDir, 'approval-gate')?.status).toBe('pending');
+      expect(readWait(outcome.runDir, 'approval#001-gate')?.status).toBe('pending');
     } finally {
       rmSync(base, { recursive: true, force: true });
     }
@@ -527,7 +527,7 @@ describe('runWorkflow — humanGate suspend mode', () => {
       const outcome = await runWorkflow(dag, deps, { baseDir: base });
 
       expect(outcome).toMatchObject({ reason: 'terminal', runStatus: 'succeeded' });
-      expect(readWait(outcome.runDir, 'deploy-gate')).toMatchObject({ status: 'approved', by: 'ou_cli' });
+      expect(readWait(outcome.runDir, 'deploy#001-gate')).toMatchObject({ status: 'approved', by: 'ou_cli' });
     } finally {
       rmSync(base, { recursive: true, force: true });
     }

--- a/test/v3-runtime.test.ts
+++ b/test/v3-runtime.test.ts
@@ -874,4 +874,31 @@ describe('runWorkflow — 跨节点 revisit A→B→C', () => {
       rmSync(base, { recursive: true, force: true });
     }
   });
+
+  it('回溯预算:grant 已写但 retry 未写的崩溃窗口 → 不重复加预算,只补 retry(recovery-safe)', () => {
+    const base = mkdtempSync(join(tmpdir(), 'v3-rt-grant-crash-'));
+    try {
+      const runId = 'g';
+      const jp = join(base, runId, 'journal.ndjson');
+      appendEvent(jp, { type: 'runStarted', runId });
+      appendEvent(jp, { type: 'nodeDispatched', nodeId: 'C', instanceId: 'C#002', attemptId: 'C#002/attempts/001' });
+      appendEvent(jp, { type: 'nodeRevisitRequested', nodeId: 'C', instanceId: 'C#001', attemptId: 'C#001/attempts/001', toNodeId: 'A' });
+      appendEvent(jp, {
+        type: 'nodeBlocked', nodeId: 'C', instanceId: 'C#002', attemptId: 'C#002/attempts/001',
+        errorClass: 'resultInvalid', errorCode: 'REVISIT_BUDGET_EXHAUSTED', message: 'exhausted', revisitTo: 'A',
+      });
+      appendEvent(jp, { type: 'runBlocked', blockedNodeId: 'C' });
+      // 崩溃窗口:grant 已写(预算已 ok),但 retry 还没写 —— 节点仍 blocked。
+      appendEvent(jp, { type: 'revisitBudgetGranted', sourceNodeId: 'C', toNodeId: 'A', by: 'ou_user' });
+
+      // 恢复点击:绝不能再 append 第二条 grant(否则一次准许变 +2),只补 retry。
+      const out = requestRevisitGrant(base, runId, { sourceNodeId: 'C', toNodeId: 'A', by: 'ou_user', expectedAttemptId: 'C#002/attempts/001' });
+      expect(out.kind).toBe('granted');
+      const events = readJournal(jp);
+      expect(events.filter((e) => e.type === 'revisitBudgetGranted').length).toBe(1); // 仍是 1,没翻倍
+      expect(events.find((e) => e.type === 'nodeRetryRequested')).toMatchObject({ nodeId: 'C', nextAttemptId: 'C#002/attempts/002' });
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/v3-runtime.test.ts
+++ b/test/v3-runtime.test.ts
@@ -697,7 +697,12 @@ describe('runWorkflow — 跨节点 revisit A→B→C', () => {
       const events = readJournal(join(outcome.runDir, 'journal.ndjson'));
 
       // C 请求了回溯到 A
-      expect(events.some((e) => e.type === 'nodeRevisitRequested' && (e as any).toNodeId === 'A')).toBe(true);
+      const rr = events.find((e) => e.type === 'nodeRevisitRequested' && (e as any).toNodeId === 'A') as any;
+      expect(rr).toBeDefined();
+      // 协议:journal 里三个 feedback 路径都是 runDir 相对(可搬迁 + 不泄漏本机绝对路径)
+      expect(isAbsolute(rr.reasonPath)).toBe(false);
+      expect(isAbsolute(rr.sourceManifestPath)).toBe(false);
+      expect(isAbsolute(rr.targetPreviousManifestPath)).toBe(false);
       // A/B/C 的 #001 实例全部被 supersede（刷新）
       expect(events.filter((e) => e.type === 'nodeInstanceSuperseded').map((e) => (e as any).instanceId).sort())
         .toEqual(['A#001', 'B#001', 'C#001']);

--- a/test/v3-runtime.test.ts
+++ b/test/v3-runtime.test.ts
@@ -124,16 +124,16 @@ describe('runWorkflow — research→summarize 最小闭环', () => {
       expect(events.some((e) => e.type === 'runSucceeded')).toBe(true);
 
       const inputs = JSON.parse(
-        readFileSync(join(outcome.runDir, 'summarize', 'attempts', '001', 'inputs.json'), 'utf-8'),
+        readFileSync(join(outcome.runDir, 'summarize#001', 'attempts', '001', 'inputs.json'), 'utf-8'),
       ) as GoalInputs;
       expect(inputs.inputs).toHaveLength(1);
       expect(isAbsolute(inputs.inputs[0]!.path)).toBe(true);
-      expect(inputs.inputs[0]!.path).toContain(join('research', 'attempts', '001', 'work', 'out.md'));
+      expect(inputs.inputs[0]!.path).toContain(join('research#001', 'attempts', '001', 'work', 'out.md'));
 
       // goal.txt carries the user goal + the full execution/manifest contract
       // (it is NOT the bare goal string) so the short `/goal` command can just
       // point the agent here without tripping TUI paste-detection.
-      const goalFile = readFileSync(join(outcome.runDir, 'research', 'attempts', '001', 'goal.txt'), 'utf-8');
+      const goalFile = readFileSync(join(outcome.runDir, 'research#001', 'attempts', '001', 'goal.txt'), 'utf-8');
       expect(goalFile).toContain('调研 X');                         // the user goal
       expect(goalFile).toContain(GOAL_ENV.MANIFEST_PATH);           // contract references the manifest env
       expect(goalFile).toContain('"schemaVersion": 1');             // rendered manifest shape
@@ -271,15 +271,15 @@ describe('runWorkflow — edge activation', () => {
         from: e.from, to: e.to, active: e.active, sourceAttemptId: e.sourceAttemptId,
       })).sort((a, b) => a.to.localeCompare(b.to));
       expect(resolved).toEqual([
-        { from: 'judge', to: 'fail', active: false, sourceAttemptId: 'judge/attempts/001' },
-        { from: 'judge', to: 'pass', active: true, sourceAttemptId: 'judge/attempts/001' },
+        { from: 'judge', to: 'fail', active: false, sourceAttemptId: 'judge#001/attempts/001' },
+        { from: 'judge', to: 'pass', active: true, sourceAttemptId: 'judge#001/attempts/001' },
       ]);
       expect(events.some((e) => e.type === 'nodeSkipped' && e.nodeId === 'fail')).toBe(true);
       expect(events.some((e) => e.type === 'nodeDispatched' && e.nodeId === 'fail')).toBe(false);
       expect(events.some((e) => e.type === 'nodeSucceeded' && e.nodeId === 'merge')).toBe(true);
       expect(mergeInputs?.inputs.map((i) => i.from)).toEqual(['pass']);
       expect(mergeInputs?.omitted).toEqual([{ from: 'fail', reason: 'sourceSkipped' }]);
-      const mergeGoal = readFileSync(join(outcome.runDir, 'merge', 'attempts', '001', 'goal.txt'), 'utf-8');
+      const mergeGoal = readFileSync(join(outcome.runDir, 'merge#001', 'attempts', '001', 'goal.txt'), 'utf-8');
       expect(mergeGoal).toContain('omitted');
     } finally {
       rmSync(base, { recursive: true, force: true });

--- a/test/v3-runtime.test.ts
+++ b/test/v3-runtime.test.ts
@@ -655,8 +655,14 @@ describe('runWorkflow — 跨节点 revisit A→B→C', () => {
       });
       let cRuns = 0;
       let bSawAContent = '';
+      let aRevisitFeedback: GoalInputs['inputs'] = [];
       const runNode: RunNode = async (req) => {
         if (req.node.id === 'A') {
+          // A#002 是回溯目标的重跑：捕获注入的 from:revisit 反馈。
+          if (req.attemptId.startsWith('A#002')) {
+            const inputs = JSON.parse(readFileSync(req.inputsPath, 'utf-8')) as GoalInputs;
+            aRevisitFeedback = inputs.inputs.filter((i) => i.from === 'revisit');
+          }
           // 第二次跑(A#002)产出不同内容,用来验证 B#002 读到的是新版
           const content = req.attemptId.startsWith('A#002') ? 'A-v2' : 'A-v1';
           return { status: 'ok', manifestPath: writeManifest(req, {
@@ -703,6 +709,13 @@ describe('runWorkflow — 跨节点 revisit A→B→C', () => {
       expect(events.some((e) => e.type === 'nodeSucceeded' && (e as any).instanceId === 'C#001')).toBe(false);
       // B#002 的 inputs 来自 A#002（新版产物），不是 A#001
       expect(bSawAContent).toBe('A-v2');
+      // A#002(回溯目标重跑)拿到三件套 feedback:reason + 下游(C)产出 + A 自己旧产出。
+      expect(aRevisitFeedback.some((i) => i.name === 'reason' && (i.preview ?? '').includes('缺计费规则'))).toBe(true);
+      expect(aRevisitFeedback.some((i) => i.name.startsWith('source:'))).toBe(true); // C 的 result.json
+      // previous: A#001 的旧产物 a.md(内容 'A-v1')
+      const prev = aRevisitFeedback.find((i) => i.name.startsWith('previous:'));
+      expect(prev).toBeDefined();
+      expect(readFileSync(prev!.path, 'utf-8')).toBe('A-v1');
       // C 一共跑了 2 次（#001 回溯 + #002 成功）
       expect(cRuns).toBe(2);
     } finally {


### PR DESCRIPTION
## 概要
为 v3 workflow 引擎加 **跨节点回溯 (cross-node revisit)**,并为此重建 **instance 模型**。一个节点可声明 `revisitTo: [<祖先>]`,其 worker 写 `result.json {status:"revisit", revisitTo, reason}` 即可把流程退回上游祖先重做,并带着反馈过去。

22 commit,**tsc clean,v3 全量 307 测试全绿**,逐砖经 @菲菲公主 review,终审 LGTM。

## 做了什么
- **instance 三层模型**:nodeId → instanceId(`A#001`)→ attempt;`effectiveInstanceId` + `superseded` 状态。全链路 instance 化(dispatch/settle/edge/gate/retry/attempt/buildInputs)。
- **revisit 执行**:`status:revisit` 识别 → `nodeRevisitRequested` + supersede cone(目标 + 下游全刷新)→ decideNext 重派 `#002`。
- **buildInputs 按 effective instance** 取上游产物 —— 抗"旧实例迟到 settle"污染(B#002 只读 A#002)。
- **feedback 三件套**:回溯目标的新 instance 拿到 `from:revisit` 输入(reason + 下游产出 + 自己旧产出)+ goal.txt 强制先读再改。
- **两级预算 + grant**:per-pair(默认1)/ per-run(默认8)防无限回溯;耗尽 → blocked → 飞书 **revisit grant 卡**(标 pair/run 层级)→ 一键准许 + 原子 grant+retry,recovery-safe(崩溃窗口不重复加预算)。
- **instance 化收尾**:nodeCancelled(取消 A#001 不影响 A#002)、gate stale-card 防护(instance 级 waitId + resolve 校验)。

## 测试
- 单元 + 集成:instance materialize / decideNext / runtime / blocked / 预算 / 卡片 / handler。
- **A→B→C 集成**:C 回溯 A → #001 全 superseded → 重生 #002 → 仅 C#002 成功 → B#002 读 A#002。
- **daemon 级 e2e**(`v3-revisit-e2e`):真 `driveV3Run` + 真 manifest 校验,端到端验 revisit→预算耗尽→grant 卡→grant+retry→收敛。

## 不在本 PR
- 真 CLI 手动 smoke:见 `docs/runbook-v3-revisit-real-cli-smoke.md`(模型决策不确定 + 本机无 swap 有 OOM 史 → 走手动,不进 CI)。