### PR TITLE
fix(cli): botmux send 杜绝「已发却报失败」导致的重复消息

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,7 +52,7 @@ import { createCliAdapterSync } from './adapters/cli/registry.js';
 import { logger } from './utils/logger.js';
 import { invalidWorkingDirs } from './utils/working-dir.js';
 import { firstPositional } from './cli/arg-utils.js';
-import { dispatchPrimaryMessage } from './cli/send-dispatch.js';
+import { dispatchPrimaryMessage, findStdinAliasAttachment, sendFileAttachments } from './cli/send-dispatch.js';
 import {
   formatBotInfoEntriesForCli,
   formatChatBotsForCli,
@@ -2842,6 +2842,19 @@ async function cmdSend(rest: string[]): Promise<void> {
   const sessionIdArg = argValue(rest, '--session-id');
   const images = argValues(rest, '--image', '--images');
   const files = argValues(rest, '--file', '--files');
+  // stdin can't be both the message body (which `botmux send` reads from it) and
+  // a `--file`/`--image` attachment — the second read sees EOF and the upload
+  // fails *after* the message is already sent, leaving the caller to resend.
+  // Reject up front so exit≠0 reliably means "nothing was sent".
+  const stdinAlias = findStdinAliasAttachment([...images, ...files]);
+  if (stdinAlias) {
+    console.error(
+      `不能把 stdin（${stdinAlias}）当作 --file/--image 附件：botmux send 已从 stdin 读取消息正文，\n` +
+      `同一个 stdin 没法既当正文又当附件（第二次读到的是 EOF）。\n` +
+      `要发送管道内容，先落到临时文件：  数据来源 > /tmp/x && botmux send --files /tmp/x …`,
+    );
+    process.exit(1);
+  }
   const mentionArgs = argValues(rest, '--mention');  // "open_id:Display Name"
   const contentFile = argValue(rest, '--content-file');
   // 回复一律走交互卡片。`--card` / `--text` 是隐藏的旧脚本兼容 no-op：纯文本
@@ -3434,12 +3447,16 @@ async function cmdSend(rest: string[]): Promise<void> {
     // closed a pending response card for this turn.
     if (shouldRecordBridgeMarker) recordBridgeSendMarker(sentAtMs, messageId, text);
 
-    // Send file attachments as separate messages
-    const fileIds: string[] = [];
-    for (const fp of files) {
-      const fileKey = await uploadFile(appId, fp);
-      const fid = await dispatch(JSON.stringify({ file_key: fileKey }), 'file');
-      fileIds.push(fid);
+    // Send file attachments as separate messages — best-effort. The primary
+    // message is already delivered above; a failing attachment must not throw
+    // out to the catch below (which would report total failure / exit 1 for an
+    // already-sent message and make the caller resend). Warn instead, and list
+    // the failures in the success JSON.
+    const { failed: failedAttachments } = await sendFileAttachments(
+      { uploadFile, dispatch }, appId, files,
+    );
+    for (const f of failedAttachments) {
+      console.error(`⚠️ 附件未发送（主消息已送达 ${messageId}，请勿重发）: ${f.path} — ${f.error}`);
     }
 
     // Bot-to-bot 转发依赖飞书"获取群组中其他机器人和用户@当前机器人的消息"权限：
@@ -3485,6 +3502,9 @@ async function cmdSend(rest: string[]): Promise<void> {
       quotedMessageId: primaryQuotedId,
       mentioned: mentions.map(m => ({ open_id: m.open_id, name: m.name })),
       ...(attention.requested ? { attentionRaised, attentionError } : {}),
+      ...(failedAttachments.length > 0
+        ? { failedAttachments: failedAttachments.map(f => f.path) }
+        : {}),
     }));
   } catch (err: any) {
     console.error(`发送失败: ${err.message}`);

--- a/src/cli/send-dispatch.ts
+++ b/src/cli/send-dispatch.ts
@@ -22,6 +22,61 @@ export type DispatchPrimaryDeps = {
   replyMessage: ReplyMessageFn;
 };
 
+/**
+ * Paths that resolve to the process's own stdin. `botmux send` reads stdin for
+ * the message body (the documented `echo "msg" | botmux send` form), so passing
+ * one of these to `--file`/`--image` makes a single stdin serve two consumers:
+ * the body is read first, then the attachment read sees EOF. The attachment
+ * upload then fails *after* the primary message was already delivered, so the
+ * command exits non-zero for an already-sent message and the caller resends —
+ * producing duplicate messages. Reject these up front instead.
+ */
+const STDIN_ALIAS_PATHS = new Set(['-', '/dev/stdin', '/dev/fd/0', '/proc/self/fd/0']);
+
+/** First attachment path that aliases stdin, or null if none do. */
+export function findStdinAliasAttachment(paths: readonly string[]): string | null {
+  for (const p of paths) {
+    if (STDIN_ALIAS_PATHS.has(p.trim())) return p;
+  }
+  return null;
+}
+
+export type SendFileAttachmentsDeps = {
+  uploadFile: (appId: string, path: string) => Promise<string>;
+  dispatch: (content: string, msgType: string) => Promise<string>;
+};
+
+export type SendFileAttachmentsResult = {
+  sent: string[];                              // message ids of delivered attachments
+  failed: { path: string; error: string }[];  // attachments that failed to upload/send
+};
+
+/**
+ * Upload + post each file as its own message, best-effort. By the time this
+ * runs the primary message has already been delivered, so a failure on one
+ * attachment must NOT throw: letting it bubble would make the caller report
+ * total failure (exit 1) for an already-sent message, which drives resends and
+ * duplicates. Collect failures so the caller can surface them as a warning
+ * while still reporting the primary send as the success it was.
+ */
+export async function sendFileAttachments(
+  deps: SendFileAttachmentsDeps,
+  appId: string,
+  files: readonly string[],
+): Promise<SendFileAttachmentsResult> {
+  const sent: string[] = [];
+  const failed: { path: string; error: string }[] = [];
+  for (const fp of files) {
+    try {
+      const fileKey = await deps.uploadFile(appId, fp);
+      sent.push(await deps.dispatch(JSON.stringify({ file_key: fileKey }), 'file'));
+    } catch (err: any) {
+      failed.push({ path: fp, error: err?.message ?? String(err) });
+    }
+  }
+  return { sent, failed };
+}
+
 export type DispatchPrimaryOptions = {
   appId: string;
   targetChatId: string;

--- a/test/cli-send-dispatch.test.ts
+++ b/test/cli-send-dispatch.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { dispatchPrimaryMessage } from '../src/cli/send-dispatch.js';
+import { dispatchPrimaryMessage, findStdinAliasAttachment, sendFileAttachments } from '../src/cli/send-dispatch.js';
 
 class MessageWithdrawnError extends Error {}
 
@@ -71,5 +71,68 @@ describe('dispatchPrimaryMessage hook context wiring', () => {
       undefined,
       baseOptions.hookContext,
     );
+  });
+});
+
+describe('findStdinAliasAttachment (reject stdin-as-attachment up front)', () => {
+  it('flags every known stdin alias', () => {
+    for (const p of ['-', '/dev/stdin', '/dev/fd/0', '/proc/self/fd/0']) {
+      expect(findStdinAliasAttachment([p])).toBe(p);
+    }
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(findStdinAliasAttachment([' /dev/stdin '])).toBe(' /dev/stdin ');
+  });
+
+  it('returns null for ordinary file paths', () => {
+    expect(findStdinAliasAttachment(['/tmp/report.md', './chart.png'])).toBeNull();
+    expect(findStdinAliasAttachment([])).toBeNull();
+  });
+
+  it('returns the first aliasing path when mixed with real ones', () => {
+    expect(findStdinAliasAttachment(['/tmp/ok.png', '/dev/stdin', '/tmp/also.md'])).toBe('/dev/stdin');
+  });
+});
+
+describe('sendFileAttachments (best-effort, never throws after primary send)', () => {
+  it('uploads + dispatches each file and returns their message ids', async () => {
+    const uploadFile = vi.fn(async (_app: string, p: string) => `key:${p}`);
+    const dispatch = vi.fn(async (content: string) => `om:${content}`);
+
+    const res = await sendFileAttachments({ uploadFile, dispatch }, 'cli_app', ['/a', '/b']);
+
+    expect(res.failed).toEqual([]);
+    expect(res.sent).toEqual([
+      'om:{"file_key":"key:/a"}',
+      'om:{"file_key":"key:/b"}',
+    ]);
+    expect(uploadFile).toHaveBeenCalledTimes(2);
+  });
+
+  it('captures a failing attachment without throwing and still sends the others', async () => {
+    const uploadFile = vi.fn(async (_app: string, p: string) => {
+      if (p === '/bad') throw new Error('upload boom');
+      return `key:${p}`;
+    });
+    const dispatch = vi.fn(async (content: string) => `om:${content}`);
+
+    const res = await sendFileAttachments({ uploadFile, dispatch }, 'cli_app', ['/good', '/bad', '/good2']);
+
+    expect(res.sent).toEqual(['om:{"file_key":"key:/good"}', 'om:{"file_key":"key:/good2"}']);
+    expect(res.failed).toEqual([{ path: '/bad', error: 'upload boom' }]);
+  });
+
+  it('captures a dispatch failure too, and never rejects even if all fail', async () => {
+    const uploadFile = vi.fn(async (_app: string, p: string) => `key:${p}`);
+    const dispatch = vi.fn(async () => { throw new Error('dispatch down'); });
+
+    const res = await sendFileAttachments({ uploadFile, dispatch }, 'cli_app', ['/x', '/y']);
+
+    expect(res.sent).toEqual([]);
+    expect(res.failed).toEqual([
+      { path: '/x', error: 'dispatch down' },
+      { path: '/y', error: 'dispatch down' },
+    ]);
   });
 });


### PR DESCRIPTION
## 背景

排查"飞书里出现两条一模一样的消息"时定位到 `botmux send` 的一个**非原子失败**：命令会在主消息已经发出去之后才失败并 `exit 1`，让调用方误判"没发成功"而重发，于是出现重复消息。

触发我的具体写法是 `cat … | botmux send --files /dev/stdin`：`send` 先把 stdin 读成消息正文，主卡片发出（`dispatchOrPatchPending`），**随后**附件循环再 `uploadFile('/dev/stdin')`——stdin 已被读光 → 抛错 → 外层 `catch` 打"发送失败" `exit 1`。可消息明明已经送达了。

## 改动（两处，消灭"已发却 exit 1"中间态）

**D1 · 发送前拒绝 stdin 当附件**（`src/cli.ts` cmdSend 入口）
`--file`/`--image` 指向 stdin 别名（`/dev/stdin`、`/dev/fd/0`、`/proc/self/fd/0`、`-`）时直接报错退出。`botmux send` 已从 stdin 读正文，同一个 stdin 没法既当正文又当附件。趁早拒绝保证 `exit≠0 ⟺ 什么都没发`，并提示用户改用临时文件。

**D2 · 发送后附件失败改 best-effort**（`src/cli.ts` + `sendFileAttachments`）
主消息送达后才上传的附件，单个失败不再抛进外层 catch；改为收集失败、逐条打警告（标注「主消息已送达 <messageId>，请勿重发」），主消息照报 `success`（exit 0），并在成功 JSON 里加可选 `failedAttachments: [path…]`。这对**所有**附件失败（不止 stdin）都生效。

> 设计原则（按失败时机分流）：能在发送前判出来的（D1）→ 报错拒绝；主消息已发出后才失败的（D2）→ 报成功 + 警告，绝不 exit 1 装作整体失败。要消灭的是中间态。

**语义变更提示**：附件上传失败现在 `exit 0`（之前 `exit 1`）。判据从 stderr 警告 + JSON 的 `failedAttachments` 字段获取。这是为了不再诱导调用方重发主消息——本 issue 的根因。

## 实现

抽出两个纯函数到 `src/cli/send-dispatch.ts`：`findStdinAliasAttachment(paths)`、`sendFileAttachments(deps, appId, files)`，便于单测。

## 验证

- `tsc --noEmit` 0 错；`pnpm build` 0
- 新增 6 个单测（`test/cli-send-dispatch.test.ts`）：stdin 别名识别 4 例 + best-effort 上传 3 例（含单附件失败仍发其余、dispatch 失败、全失败不抛）
- 端到端冒烟：`echo hi | botmux send --files /dev/stdin` 现在 exit 1 + 清晰提示，**发送前**就拒绝，不再发任何消息
- 全量 unit project **3939/3939 全绿**，无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)
