### PR TITLE
feat(coco): CoCo AskUserQuestion 弹飞书选择卡（hook 检测 + 按键代答）

### DIFF
--- a/src/adapters/cli/coco.ts
+++ b/src/adapters/cli/coco.ts
@@ -4,6 +4,7 @@ import { resolveCommand } from './registry.js';
 import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
 import { cocoCacheRoot } from '../../services/coco-paths.js';
 import { delay, scaleMs } from '../../utils/timing.js';
+import { installCocoAskPlugin } from '../coco-ask-plugin.js';
 import type { CliAdapter, PtyHandle } from './types.js';
 
 /** Global submit log — CoCo appends one JSON line here on every successful
@@ -273,6 +274,13 @@ export function createCocoAdapter(pathOverride?: string): CliAdapter {
     // dequeue-deferral — see codex.ts and CodexBridgeQueue's HOL-block-drop.
     supportsTypeAhead: true,
     altScreen: false,
+    // AskUserQuestion 接管：装一个 CoCo 插件（hooks.json: PreToolUse/AskUserQuestion）
+    // 把事件转发到 `botmux hook coco`，弹成飞书选择卡。CoCo 的 hook 不能用 directive
+    // 代答，答案由 daemon 在结算后按键驱动原生 picker 回灌（见 coco-picker-keys.ts +
+    // daemon /api/asks coco 分支 + worker driveCocoPicker）。asksViaHook 置 true 以
+    // 关掉 botmux-ask skill 兜底，避免 skill 与 hook 双重弹卡。
+    asksViaHook: true,
+    ensureAskHook() { installCocoAskPlugin(this.resolvedBin); },
     // CoCo/Trae CLI reads the same skill root as the Trae-flavoured adapter.
     skillsDir: '~/.trae/skills',
     modelChoices: [

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -132,8 +132,15 @@ export interface CliAdapter {
   };
 
   /** true = 该 CLI 通过 hook 接管 askUserQuestion（不再装 botmux-ask skill 兜底）。
-   *  注入机制由各 adapter 自行决定（Claude 走 --settings、OpenCode 走插件）。 */
+   *  注入机制由各 adapter 自行决定（Claude 走 --settings、OpenCode 走插件、
+   *  CoCo 走 ensureAskHook 装插件）。 */
   readonly asksViaHook?: boolean;
+
+  /** 命令式 hook 安装钩子：适用于无法靠纯写文件完成、需要 spawn CLI 子命令的场景
+   *  （CoCo 需要 `coco plugin install`）。声明式写文件的 CLI 用 `hookInstall`；本方法
+   *  与 `hookInstall` 互斥。每个 daemon 生命周期由 ensureCliSkills 调用一次。
+   *  实现内部自行 try/catch，失败只 warn 不抛。 */
+  ensureAskHook?(): void;
 
   /** Completion marker regex (beyond generic quiescence). undefined = quiescence only. */
   readonly completionPattern?: RegExp;

--- a/src/adapters/coco-ask-plugin.ts
+++ b/src/adapters/coco-ask-plugin.ts
@@ -1,0 +1,84 @@
+/**
+ * coco-ask-plugin.ts
+ *
+ * 把 botmux 的 AskUserQuestion hook 以 **CoCo 插件** 形式安装到 CoCo (Trae CLI)。
+ *
+ * 为什么是插件而不是写配置文件：CoCo 0.120.x 把 hook 模型迁到了「插件 +
+ * marketplace」——老的 traecli.yaml 顶层 `hooks:` 在迁移时被丢弃，现在 hook 要么
+ * 内联进 traecli.toml（无 matcher，会对每个 tool 调用都触发，浪费），要么打包进
+ * 插件的 hooks.json（**支持 matcher**，可精确只拦 AskUserQuestion）。我们选后者。
+ *
+ * 插件目录结构（与 CoCo 官方插件一致）：
+ *   <pluginDir>/.codex-plugin/plugin.json   —— 清单，hooks 指向 ./hooks.json
+ *   <pluginDir>/hooks.json                  —— Claude settings.json 同构：
+ *     { hooks: { PreToolUse: [ { matcher:"AskUserQuestion",
+ *                                hooks:[ {type:"command", command:<botmux hook coco>, timeout} ] } ] } }
+ *
+ * 安装走 `coco plugin install <dir> --type local --yes`（幂等：同名插件覆盖；
+ * 每个 daemon 生命周期由 ensureCliSkills 调用一次）。这是全局安装（写
+ * ~/.trae 的 traecli.toml 信任哈希 + plugins 缓存），所有 CoCo 会话都会装上这条
+ * hook——但 hook 客户端在缺 BOTMUX_* env 时直接 passthrough，不影响用户自己跑的
+ * CoCo（与 Claude 写全局 settings.json 的安全模型一致）。
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { logger } from '../utils/logger.js';
+import { hookCommandFor } from './hook-command.js';
+
+/** botmux 生成的 CoCo ask 插件目录（不放进 ~/.trae，安装时由 coco 拷进 plugins 缓存）。 */
+const COCO_ASK_PLUGIN_DIR = join(homedir(), '.botmux', 'coco-ask-plugin');
+
+/** 幂等地构建插件目录并 `coco plugin install` 安装。失败只 warn 不抛。 */
+export function installCocoAskPlugin(cocoBin: string): void {
+  try {
+    const hookCommand = hookCommandFor('coco'); // 形如：'"<node>" "<cli.js>" hook coco'
+    const manifest = {
+      name: 'botmux-ask',
+      version: '1.0.0',
+      description: 'Route CoCo AskUserQuestion to a Lark selection card (botmux).',
+      hooks: './hooks.json',
+      interface: {
+        displayName: 'botmux ask',
+        shortDescription: 'Route AskUserQuestion to Lark',
+        category: 'Productivity',
+      },
+    };
+    // 只拦 AskUserQuestion；hook 客户端对其它事件/非 botmux 会话自行 passthrough。
+    const hooks = {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: 'AskUserQuestion',
+            hooks: [{ type: 'command', command: hookCommand, timeout: 86400 }],
+          },
+        ],
+      },
+    };
+
+    mkdirSync(join(COCO_ASK_PLUGIN_DIR, '.codex-plugin'), { recursive: true });
+    writeFileSync(
+      join(COCO_ASK_PLUGIN_DIR, '.codex-plugin', 'plugin.json'),
+      JSON.stringify(manifest, null, 2) + '\n',
+      'utf-8',
+    );
+    writeFileSync(
+      join(COCO_ASK_PLUGIN_DIR, 'hooks.json'),
+      JSON.stringify(hooks, null, 2) + '\n',
+      'utf-8',
+    );
+
+    // 幂等安装（--yes 跳过确认）。stdio 忽略，避免污染 daemon 日志；超时兜底。
+    execFileSync(cocoBin, ['plugin', 'install', COCO_ASK_PLUGIN_DIR, '--type', 'local', '--yes'], {
+      stdio: 'ignore',
+      timeout: 60_000,
+    });
+    logger.info(`[hook] CoCo ask 插件已安装 → ${COCO_ASK_PLUGIN_DIR}`);
+  } catch (err) {
+    logger.warn(
+      `[hook] CoCo ask 插件安装失败：${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/src/core/ask-hook/coco.ts
+++ b/src/core/ask-hook/coco.ts
@@ -1,0 +1,40 @@
+/**
+ * CoCo (Trae CLI) hook adapter。
+ *
+ * CoCo 的 AskUserQuestion PreToolUse payload 与 Claude Code **逐字段兼容**
+ * （hook_event_name='PreToolUse'、tool_name='AskUserQuestion'、
+ *   tool_input.questions[].{question, options[].label, multiSelect}），
+ * 所以 parseQuestions 直接复用 Claude 的解析。
+ *
+ * 但与 Claude 不同：CoCo 的 PreToolUse hook **不能用 directive 代答**——实测返回
+ * `permissionDecision:allow + updatedInput.answers` 后 CoCo 照样弹出原生 TUI
+ * 选择器。因此本 adapter 的 formatAnswer 故意返回空串（= passthrough），让 CoCo
+ * 渲染原生 picker；真正的「作答」由 daemon 在 ask 结算后，根据
+ * computeCocoPickerKeys 算出的按键序列驱动 worker 的 PTY 完成
+ * （见 daemon.ts /api/asks 的 coco 分支 + worker.ts driveCocoPicker）。
+ *
+ * 也就是说：hook 只负责「把结构化问题弹成飞书卡」，答案回灌走按键驱动，不走
+ * stdout directive。
+ */
+
+import claude from './claude-code.js';
+import type { HookAskAdapter, ParsedAsk } from './types.js';
+
+const cocoAdapter: HookAskAdapter = {
+  // payload 形状与 Claude 一致，直接复用其解析（不依赖 this）。
+  parseQuestions(payload: unknown): ParsedAsk | null {
+    return claude.parseQuestions(payload);
+  },
+
+  // CoCo 不能用 directive 代答 → 永远 passthrough（空 stdout）。答案由 daemon
+  // 通过按键驱动 picker 回灌，不经此处。
+  formatAnswer(): string {
+    return '';
+  },
+
+  passthrough(): string {
+    return '';
+  },
+};
+
+export default cocoAdapter;

--- a/src/core/ask-hook/registry.ts
+++ b/src/core/ask-hook/registry.ts
@@ -2,6 +2,7 @@ import type { HookAskAdapter } from './types.js';
 import claude from './claude-code.js';
 import codex from './codex.js';
 import opencode from './opencode.js';
+import coco from './coco.js';
 
 const REGISTRY: Record<string, HookAskAdapter> = {
   'claude-code': claude,
@@ -11,6 +12,11 @@ const REGISTRY: Record<string, HookAskAdapter> = {
   seed: claude,
   codex,
   opencode,
+  // CoCo (Trae CLI): AskUserQuestion payload is Claude-compatible (parseQuestions
+  // reuses claude), but it CANNOT be answered via a hook directive — the answer
+  // is delivered by keystroke-driving CoCo's native picker (see coco.ts +
+  // daemon /api/asks coco branch + worker driveCocoPicker).
+  coco,
 };
 
 export function getHookAdapter(cliId: string): HookAskAdapter | undefined {

--- a/src/core/coco-picker-keys.ts
+++ b/src/core/coco-picker-keys.ts
@@ -1,0 +1,71 @@
+/**
+ * coco-picker-keys.ts
+ *
+ * CoCo (Trae CLI) 的 AskUserQuestion 用一个原生 TUI 选择器作答，它的 PreToolUse
+ * hook **不能**像 Claude 那样用 directive 把答案塞回去（实测：返回
+ * updatedInput.answers 后 CoCo 照样弹原生 picker）。因此 botmux 改为：hook 把
+ * 结构化问题注册成飞书选择卡，用户答完后由 worker 用按键序列驱动这个原生
+ * picker 自动作答。本模块把「每题选中的 key」翻译成确定的按键序列。
+ *
+ * 实测的 picker 键位模型（CoCo 0.120.38）：
+ *   每题（光标从第 0 行起，Down/Up 移动）：
+ *     - 单选：Down×idx 到目标项 → Enter（选中并**自动跳下一题**）
+ *     - 多选：每个选中项 Down 到位 + Space 勾选；再 Down 到末尾的 "Next" 行 + Enter 进下一题
+ *       行布局：options 占 0..L-1，"Type something" 在 L，"Next" 在 L+1
+ *   全部答完进 "Review your answers"：光标默认在 "Submit answers"（第 0 行），Enter 提交
+ *
+ * navKeys 只负责「答完所有题、停在 Review 屏」；最后那记提交 Enter 由 worker 在
+ * 确认 Review 屏出现后单独补发（见 worker driveCocoPicker），避免屏幕切换还没渲染
+ * 完就把提交键打飞。
+ */
+
+import type { AskQuestion } from './ask-types.js';
+
+export interface CocoPickerPlan {
+  /** 导航 + 选择所有问题、最终停在 Review 屏的按键序列（不含提交 Enter）。 */
+  navKeys: string[];
+}
+
+/**
+ * 把 broker 的 answers（answers[i] = 第 i 题选中的 key 数组）翻译成驱动 CoCo
+ * 原生 picker 的按键序列。questions[i].options 的 key 与 answers[i] 里的 key 对应。
+ */
+export function computeCocoPickerKeys(
+  questions: ReadonlyArray<AskQuestion>,
+  answers: ReadonlyArray<ReadonlyArray<string>>,
+): CocoPickerPlan {
+  const navKeys: string[] = [];
+
+  questions.forEach((q, qi) => {
+    const opts = q.options;
+    const optionCount = opts.length;
+    const selected = answers[qi] ?? [];
+
+    if (!q.multiSelect) {
+      // 单选：broker 保证恰好 1 个选中；找不到时兜底选第 0 项（不应发生）。
+      const key = selected[0];
+      const found = opts.findIndex((o) => o.key === key);
+      const idx = found >= 0 ? found : 0;
+      for (let i = 0; i < idx; i++) navKeys.push('Down');
+      navKeys.push('Enter'); // 选中 + 自动跳下一题
+      return;
+    }
+
+    // 多选：按升序逐个 Down 到位 + Space 勾选，最后走到 "Next" 行 + Enter。
+    const indices = selected
+      .map((k) => opts.findIndex((o) => o.key === k))
+      .filter((i) => i >= 0)
+      .sort((a, b) => a - b);
+    let cursor = 0;
+    for (const idx of indices) {
+      for (let i = cursor; i < idx; i++) navKeys.push('Down');
+      navKeys.push('Space');
+      cursor = idx;
+    }
+    const nextRow = optionCount + 1; // options 0..L-1, "Type something"=L, "Next"=L+1
+    for (let i = cursor; i < nextRow; i++) navKeys.push('Down');
+    navKeys.push('Enter'); // "Next" 进下一题（或进 Review）
+  });
+
+  return { navKeys };
+}

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -681,6 +681,12 @@ export function ensureCliSkills(cliId: CliId, cliPathOverride?: string): void {
     try { installHook(cliId, adapter.hookInstall, hookCommandFor(cliId)); }
     catch (err) { logger.warn(`[hook] install failed for ${cliId}: ${err instanceof Error ? err.message : String(err)}`); }
   }
+  // 命令式 hook 安装（CoCo 走 `coco plugin install`，纯写文件搞不定）。内部自带
+  // try/catch，失败只 warn；与 hookInstall 互斥。
+  if (adapter.ensureAskHook) {
+    try { adapter.ensureAskHook(); }
+    catch (err) { logger.warn(`[hook] ensureAskHook failed for ${cliId}: ${err instanceof Error ? err.message : String(err)}`); }
+  }
   // botmux-ask 落在与其它 skill 同一目录：plugin 模式下是 {pluginDir}/skills。
   const askSkillsDir = adapter.pluginDir ? join(adapter.pluginDir, 'skills') : adapter.skillsDir;
   ensureAskSkill(cliId, askSkillsDir, !adapter.asksViaHook);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -141,6 +141,7 @@ import {
   submitCustomReply,
 } from './core/ask-broker.js';
 import { parseAskBody, resolveAskApprovers } from './core/ask-api.js';
+import { computeCocoPickerKeys } from './core/coco-picker-keys.js';
 import { createLarkAskCardDispatcher } from './im/lark/ask-card.js';
 
 // ─── State ───────────────────────────────────────────────────────────────────
@@ -1749,6 +1750,37 @@ ipcRoute('POST', '/api/asks', async (req, res) => {
     questions: parsed.questions,
     timeoutMs: parsed.timeoutMs,
   });
+
+  // CoCo 专属：它的 hook 不能用 directive 代答（hook 客户端永远 passthrough，CoCo 会
+  // 渲染原生 picker）。这里在 ask 结算为「已作答」时，把答案翻成按键序列下发给该会话
+  // 的 worker，由 worker 等 picker 渲染后驱动它自动作答。其它 CLI（claude/opencode）
+  // 仍走 hook directive，不进此分支。
+  if (result.kind === 'answered') {
+    let cocoDs: DaemonSession | undefined;
+    for (const ds of activeSessions.values()) {
+      if (ds.session.sessionId === parsed.sessionId) { cocoDs = ds; break; }
+    }
+    if (cocoDs?.session.cliId === 'coco' && cocoDs.worker) {
+      try {
+        // 单题：picker 选完直接提交（无 Review）；多题：最后一题之后才出 Review，需补提交。
+        const needsReviewSubmit = parsed.questions.length > 1;
+        const comment = result.comment;
+        let navKeys: string[];
+        if (comment && comment.trim()) {
+          // 自由文本：把光标移到第一题 "Type something" 行（= 选项数个 Down）。
+          const optionCount = parsed.questions[0]?.options.length ?? 0;
+          navKeys = Array<string>(optionCount).fill('Down');
+        } else {
+          navKeys = computeCocoPickerKeys(parsed.questions, result.answers).navKeys;
+        }
+        cocoDs.worker.send({ type: 'coco_drive_picker', navKeys, needsReviewSubmit, comment } as DaemonToWorker);
+        logger.info(`[${cocoDs.session.sessionId.slice(0, 8)}] CoCo picker drive: ${navKeys.length} keys, review=${needsReviewSubmit}, comment=${comment ? 'yes' : 'no'}`);
+      } catch (err) {
+        logger.warn(`CoCo picker drive failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  }
+
   return jsonRes(res, 200, result);
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -237,6 +237,12 @@ export type DaemonToWorker =
   | { type: 'restart' }
   | { type: 'tui_keys'; keys: string[]; isFinal: boolean }
   | { type: 'tui_text_input'; keys: string[]; text: string }
+  // CoCo AskUserQuestion 作答：daemon 在 ask 结算后下发，worker 等原生 picker 渲染后
+  // 用 navKeys 驱动它选择+导航。needsReviewSubmit=true（多题）时 navKeys 停在 Review
+  // 屏，worker 再补一记 Enter 提交；单题 navKeys 直接提交（无 Review）。comment 非空
+  // 表示用户用自由文本作答：navKeys 把光标移到第一题 "Type something"，worker 输入
+  // 文本后补一记 Enter 提交（多题自由文本不完整支持）。
+  | { type: 'coco_drive_picker'; navKeys: string[]; needsReviewSubmit: boolean; comment?: string | null }
   | { type: 'set_display_mode'; mode: DisplayMode }
   | { type: 'term_action'; key: TermActionKey }
   | { type: 'refresh_screen' };

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2400,6 +2400,74 @@ async function handleTuiTextInput(keys: string[], text: string): Promise<void> {
   }
 }
 
+/**
+ * Drive CoCo's native AskUserQuestion picker to enter the answer the user picked
+ * on the Lark card. CoCo's PreToolUse hook can't inject answers via a directive
+ * (verified), so the daemon sends this after the ask settles and the hook
+ * returned passthrough — meaning CoCo is about to (or just did) render the
+ * picker. We wait for the picker to appear, then play the key sequence.
+ *
+ * Verified behaviour (CoCo 0.120.38):
+ *   - Single question: the per-question final key (Enter / "Next"→Enter / typed
+ *     text→Enter) submits the whole ask DIRECTLY — there is no Review screen, so
+ *     NO extra Enter (sending one would hit the idle prompt).
+ *   - Multiple questions: after the last question advances, a "Review your
+ *     answers / Submit answers" screen appears; needsReviewSubmit drives the
+ *     extra Enter there.
+ *   - Free-text (comment): navKeys move the cursor to the first question's
+ *     "Type something" row; typing a char auto-switches that row to input mode,
+ *     then a single Enter submits. We type via the backend + one Enter (NOT the
+ *     adapter's writeInput, whose submit-verification retries would fire stray
+ *     Enters into the idle prompt). Multi-question free-text isn't fully
+ *     supported (one text can't answer several structured questions).
+ * Key names ('Down'/'Space'/'Enter') match what the manual probe confirmed.
+ */
+async function driveCocoPicker(navKeys: string[], needsReviewSubmit: boolean, comment?: string | null): Promise<void> {
+  if (!backend) return;
+  const snap = () => (lastAnalyzerSnapshot || renderer?.rawSnapshot() || '');
+  const waitFor = async (re: RegExp, timeoutMs: number): Promise<boolean> => {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (re.test(snap())) return true;
+      await new Promise(r => setTimeout(r, 200));
+    }
+    return false;
+  };
+
+  // The hook returns passthrough → CoCo renders the picker; only then send keys.
+  const appeared = await waitFor(/Enter to select|Tab\/Arrow keys|Review your answers/, 30_000);
+  if (!appeared) { log('coco_drive_picker: picker not detected within 30s — aborting drive'); return; }
+  tuiPromptBlocking = true;
+
+  if (comment && comment.trim()) {
+    // Free-text reply: navigate to the first question's "Type something" row,
+    // type the text, then a single Enter. Single-question submits directly; for
+    // multi-question this only fills the first question (logged limitation).
+    log(`coco_drive_picker: free-text answer (${navKeys.length} nav keys)${needsReviewSubmit ? ' [multi-question — partial]' : ''}`);
+    const b = backend as any;
+    if ('sendSpecialKeys' in backend) {
+      for (const key of navKeys) { b.sendSpecialKeys(key); await new Promise(r => setTimeout(r, 100)); }
+    } else {
+      for (const key of navKeys) { backend.write(KEY_TO_ANSI[key] ?? key); await new Promise(r => setTimeout(r, 100)); }
+    }
+    await new Promise(r => setTimeout(r, 150));
+    if ('sendText' in backend && b.sendText) b.sendText(comment); else backend.write(comment);
+    await new Promise(r => setTimeout(r, 200));
+    await handleTuiKeys(['Enter'], true); // single Enter submits + clears blocking state
+    return;
+  }
+
+  // Button selection. Single question: navKeys submit directly (isFinal=true).
+  // Multi question: navKeys land on Review, then one Enter on "Submit answers".
+  log(`coco_drive_picker: selection answer (${navKeys.length} keys, review=${needsReviewSubmit})`);
+  await handleTuiKeys(navKeys, !needsReviewSubmit);
+  if (needsReviewSubmit) {
+    const review = await waitFor(/Review your answers|Submit answers/, 8_000);
+    if (!review) log('coco_drive_picker: Review screen not detected — submitting anyway');
+    await handleTuiKeys(['Enter'], true); // cursor defaults to "Submit answers"
+  }
+}
+
 // ─── Trust Dialog Detection ──────────────────────────────────────────────────
 
 // Claude Code: "Yes, I trust this folder"
@@ -4333,6 +4401,11 @@ process.on('message', async (raw: unknown) => {
 
     case 'tui_text_input': {
       handleTuiTextInput(msg.keys, msg.text);
+      break;
+    }
+
+    case 'coco_drive_picker': {
+      void driveCocoPicker(msg.navKeys, msg.needsReviewSubmit, msg.comment);
       break;
     }
 

--- a/test/coco-picker-keys.test.ts
+++ b/test/coco-picker-keys.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { computeCocoPickerKeys } from '../src/core/coco-picker-keys.js';
+import type { AskQuestion } from '../src/core/ask-types.js';
+
+function q(prompt: string, labels: string[], multiSelect: boolean): AskQuestion {
+  return { prompt, multiSelect, options: labels.map((l) => ({ key: l, label: l })) };
+}
+
+describe('computeCocoPickerKeys', () => {
+  it('single question, single-select, first option → just Enter', () => {
+    const questions = [q('Pick', ['A', 'B', 'C'], false)];
+    const { navKeys } = computeCocoPickerKeys(questions, [['A']]);
+    expect(navKeys).toEqual(['Enter']);
+  });
+
+  it('single question, single-select, third option → Down Down Enter', () => {
+    const questions = [q('Pick', ['A', 'B', 'C'], false)];
+    const { navKeys } = computeCocoPickerKeys(questions, [['C']]);
+    expect(navKeys).toEqual(['Down', 'Down', 'Enter']);
+  });
+
+  it('single question, multi-select, options 0 and 2 → Space, nav to 2 + Space, nav to Next + Enter', () => {
+    // rows: 0 A, 1 B, 2 C, 3 "Type something", 4 Next
+    const questions = [q('Pick', ['A', 'B', 'C'], true)];
+    const { navKeys } = computeCocoPickerKeys(questions, [['A', 'C']]);
+    expect(navKeys).toEqual(['Space', 'Down', 'Down', 'Space', 'Down', 'Down', 'Enter']);
+  });
+
+  it('multi-select with single middle option → nav to it, Space, nav to Next, Enter', () => {
+    const questions = [q('Pick', ['A', 'B', 'C'], true)];
+    const { navKeys } = computeCocoPickerKeys(questions, [['B']]);
+    // to idx1: Down, Space; to Next(idx4): Down Down Down; Enter
+    expect(navKeys).toEqual(['Down', 'Space', 'Down', 'Down', 'Down', 'Enter']);
+  });
+
+  it('multi-select with nothing selected → straight to Next + Enter', () => {
+    const questions = [q('Pick', ['A', 'B', 'C'], true)];
+    const { navKeys } = computeCocoPickerKeys(questions, [[]]);
+    // to Next(idx4) from 0: Down x4, Enter
+    expect(navKeys).toEqual(['Down', 'Down', 'Down', 'Down', 'Enter']);
+  });
+
+  it('two questions: single-select(idx1) then multi-select(idx0)', () => {
+    const questions = [
+      q('Lang', ['Python', 'Go', 'Rust'], false),
+      q('Features', ['Auth', 'Logging', 'Cache'], true),
+    ];
+    const { navKeys } = computeCocoPickerKeys(questions, [['Go'], ['Auth']]);
+    // Q1 single idx1: Down, Enter (auto-advance)
+    // Q2 multi idx0: Space; Next(idx4) from 0: Down x4; Enter
+    expect(navKeys).toEqual(['Down', 'Enter', 'Space', 'Down', 'Down', 'Down', 'Down', 'Enter']);
+  });
+
+  it('unknown answer key falls back to first option (defensive)', () => {
+    const questions = [q('Pick', ['A', 'B'], false)];
+    const { navKeys } = computeCocoPickerKeys(questions, [['ZZZ']]);
+    expect(navKeys).toEqual(['Enter']);
+  });
+});


### PR DESCRIPTION
## 背景

Trae CLI（`coco`，亦名 `traecli`/`trae-agent`）的 AskUserQuestion 此前在 botmux 里只能靠 `botmux-ask` skill 软兜底（靠模型自觉调用）。本 PR 让它的原生 AskUserQuestion **自动弹成飞书选择卡**，用户在卡上点选后自动回灌——和 Claude 的体验对齐。

> 注：适配器 id 仍沿用 `coco`（bot 配置、会话持久化、`botmux hook coco` 插件命令都依赖它，改名是独立的破坏性变更）。命名收敛（traecli 为主、coco 为辅，并与现有 `traex` 适配器去重）建议另开 PR 处理。

## 为什么不直接照搬 Claude 的 hook

实机验证（Trae CLI 0.120.38）：它的 PreToolUse hook 与 Claude **逐字段同构**（`hook_event_name`/`tool_name`/`tool_input.questions[].{question,options[].label,multiSelect}`），但**不能用 directive 代答**——返回 Claude 那套 `permissionDecision:allow + updatedInput.answers` 后，仍照样弹出原生 TUI picker，不吃注入的答案。

所以采用**混合方案（hook 检测 + 按键代答）**：

1. 触发 AskUserQuestion → `botmux hook coco`（PreToolUse）把结构化多题问题注册成飞书选择卡（**复用现成的多问多选 `ask-broker`/`ask-card`，与 Claude 同一套 UI**），`formatAnswer` 走 passthrough 让 CLI 渲染原生 picker。
2. 用户在卡上答完 → daemon `/api/asks` 据「答案 + 题目」算出按键序列下发对应会话的 worker → worker 等 picker 渲染后用按键驱动它自动作答。
3. hook 经**插件**安装（`.codex-plugin/plugin.json` + `hooks.json`，matcher 仅 `AskUserQuestion`），`coco plugin install --type local`，由 `ensureAskHook` 在每个 daemon 生命周期装一次；`asksViaHook=true` 关掉 botmux-ask skill 兜底，避免双重弹卡。

## 实测键位铁律（Trae CLI 0.120.38，逐一真机验证）

- 单选：`Down×idx + Enter`（选中并自动跳下一题）
- 多选：逐项 `Down + Space` 勾选，再到末尾 `Next` 行 `Enter` 进下一题
- 自由文本：到 `Type something` 行直接打字（自动进输入模式）
- **单题 → 直接提交，无 Review 屏；多题 → 最后一题后才出 `Review your answers / Submit answers` 屏，需补一记 Enter**（`needsReviewSubmit = questions.length > 1`）

## 改动

新增：
- `core/coco-picker-keys.ts` — `computeCocoPickerKeys` 纯函数（答案→按键序列）+ 7 个单测
- `core/ask-hook/coco.ts` — hook adapter（`parseQuestions` 复用 claude，`formatAnswer`/`passthrough` 返回空串）
- `adapters/coco-ask-plugin.ts` — 构建插件 + `coco plugin install`

改动：
- `core/ask-hook/registry.ts`（注册 `coco`）
- `adapters/cli/types.ts`（新增可选 `ensureAskHook?()`）
- `adapters/cli/coco.ts`（`asksViaHook` + `ensureAskHook`）
- `core/worker-pool.ts`（调用 `ensureAskHook`）
- `types.ts`（新增 `coco_drive_picker` IPC）
- `daemon.ts`（`/api/asks` 结算后按 cliId=coco 算键下发 worker）
- `worker.ts`（`driveCocoPicker` + IPC case）

## 验证

- 已 rebase 到最新 master（解决 `coco.ts` 一处 import 冲突）；TSC 全过
- 新增 `computeCocoPickerKeys` 单测 7/7 过；`ask-hook` 套件 50/50 过；coco writeInput e2e 11/11 过
- 全量回归：失败均为既有问题（mira write-input e2e + 一个 session「尚未就绪」），与本改动无关——本改动均为「新增文件 + 按 cliId=coco 分流的新分支」，不动既有路径
- CLI 端所有行为（插件装 / hook 触发 / payload 形状 / 单选多选多题键位 / 单题直接提交 vs 多题 Review）均在真机逐一验证

## 已知限制 / 注意

- **整条飞书闭环（hook→弹卡→选→驱动 picker→收到答案）尚未在 live bot 上端到端 dogfood**，组件级已全验
- hook 插件是**全局**装进 `~/.trae`（同机多个 bot 共用 HOME）；hook 客户端在非 botmux/老 daemon 会安全 passthrough
- 多题 + 自由文本作答暂不完整支持（一段文本无法回答多个结构化问题）