### PR TITLE
fix(worker): CLI 提交途中崩溃不再丢消息——在途输入跨重启重投

### DIFF
--- a/src/core/inflight-input-tracker.ts
+++ b/src/core/inflight-input-tracker.ts
@@ -1,0 +1,59 @@
+/**
+ * Tracks user inputs that have been written to the CLI's PTY but whose turn
+ * hasn't completed yet (the CLI hasn't returned to its idle prompt since the
+ * write). If the CLI process dies first, those inputs would otherwise vanish:
+ * codex crashing mid-submit never records them in history.jsonl, the
+ * auto-restarted CLI comes up idle and empty, and nothing re-delivers — the
+ * user-visible symptom is a session stuck at 「等待输入」 that "never received"
+ * the message (2026-06-10 incident, codex 0.137.0 exit 1 ~3s after paste).
+ *
+ * The worker wires it up as:
+ *   - flushPending dequeues an item and writes it  → onWrite(item)
+ *   - CLI returns to idle prompt (markPromptReady) → onTurnComplete()
+ *   - CLI process exits (backend.onExit)           → onCliExit()
+ *   - fresh CLI spawning (spawnCli, non-adopt)     → takeCarryOver() and
+ *     unshift the result back into pendingMessages
+ *
+ * Trade-off: if the CLI accepted the input and died mid-turn, re-delivery
+ * makes the restarted CLI see the prompt twice — a duplicate ask beats a
+ * silently lost message. A false-idle blip mid-turn clears the in-flight set
+ * early and degrades to the old lose-on-crash behavior for that turn only.
+ */
+
+export type InflightItem = { content: string; turnId?: string };
+
+export class InflightInputTracker {
+  private unacked: InflightItem[] = [];
+  private carryOver: InflightItem[] = [];
+
+  /** An input just went onto the CLI's PTY. */
+  onWrite(item: InflightItem): void {
+    this.unacked.push(item);
+  }
+
+  /** CLI is back at its idle prompt — everything written has been consumed
+   *  (answered, steered into the active turn, or drained from the TUI's own
+   *  type-ahead queue). Nothing is in flight anymore. */
+  onTurnComplete(): void {
+    this.unacked.length = 0;
+  }
+
+  /** CLI process died. Stash whatever was in flight for the next spawn.
+   *  Appends (rather than replaces) so a double exit before the respawn
+   *  consumes the stash can't drop the earlier batch. Returns how many
+   *  items were newly stashed by THIS exit. */
+  onCliExit(): number {
+    const n = this.unacked.length;
+    if (n > 0) this.carryOver.push(...this.unacked.splice(0));
+    return n;
+  }
+
+  /** A fresh CLI is spawning: hand back everything that must be re-queued,
+   *  and reset the in-flight set (a brand-new process can't have anything
+   *  in flight — covers a previous life whose exit event never fired, e.g.
+   *  a detach-style kill). */
+  takeCarryOver(): InflightItem[] {
+    this.unacked.length = 0;
+    return this.carryOver.splice(0);
+  }
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -19,6 +19,7 @@ import { drainTranscript, joinAssistantText, findJsonlContainingFingerprint, fin
 import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint } from './services/bridge-turn-queue.js';
 import { shouldSuppressBridgeEmit, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
 import { shouldWriteNow } from './utils/input-gate.js';
+import { InflightInputTracker } from './core/inflight-input-tracker.js';
 import {
   shouldRunQuietRotation,
   evaluatePidResolverPullback,
@@ -127,6 +128,9 @@ let isPromptReady = false;
 /** Mutex for async flushPending — prevents concurrent flush loops. */
 let isFlushing = false;
 const pendingMessages: Array<{ content: string; turnId?: string }> = [];
+/** Inputs written to the CLI whose turn hasn't completed — re-queued across a
+ *  CLI crash so a submit-time death can't silently eat user messages. */
+const inflightInputs = new InflightInputTracker();
 /** Alternate submit-confirmation signals. Some CLIs can consume PTY input and
  *  start work before their history/transcript submit marker is observable. */
 let lastPtyActivityAtMs = 0;
@@ -2561,6 +2565,10 @@ function onPtyData(data: string): void {
 function markPromptReady(): void {
   if (isPromptReady) return;  // guard against duplicate calls
   isPromptReady = true;
+  // CLI is back at its prompt — every previously written input has been
+  // consumed, so nothing is in flight anymore. A later crash must not
+  // replay these.
+  inflightInputs.onTurnComplete();
   maybeEmitWorkflowTranscriptOutput();
   if (awaitingFirstPrompt) {
     awaitingFirstPrompt = false;
@@ -2751,6 +2759,9 @@ async function flushPending(): Promise<void> {
   try {
     while (pendingMessages.length > 0 && backend && cliAdapter) {
       const item = pendingMessages.shift()!;
+      // Track as in-flight until the CLI returns to idle (markPromptReady).
+      // If the CLI exits first, onExit stashes these for re-queue on respawn.
+      inflightInputs.onWrite(item);
       const msg = item.content;
       currentBotmuxTurnId = item.turnId;
       writeCliPidMarker();
@@ -3090,6 +3101,18 @@ function seedBackendScreen(source: string, be: Pick<SessionBackend, 'captureCurr
 }
 
 function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
+  // Re-deliver inputs that were in-flight when the previous CLI died (see
+  // backend.onExit). killCli() already wiped pendingMessages, so these go to
+  // the front; the normal flush paths (prompt detect / first-prompt timeout)
+  // deliver them once the fresh CLI is ready. Adopt mode observes a CLI we
+  // don't own — never replay into it.
+  if (!cfg.adoptMode) {
+    const carry = inflightInputs.takeCarryOver();
+    if (carry.length > 0) {
+      pendingMessages.unshift(...carry);
+      log(`Re-queued ${carry.length} in-flight message(s) lost to CLI exit`);
+    }
+  }
   // ── Adopt mode: observe the user's existing terminal backend (no attach) ──
   if (cfg.adoptMode && cfg.adoptSource === 'herdr' && cfg.adoptHerdrSessionName && (cfg.adoptHerdrPaneId || cfg.adoptHerdrTarget)) {
     isTmuxMode = false;
@@ -3546,6 +3569,14 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   backend.onData(onPtyData);
   backend.onExit((code, signal) => {
     log(`${cliName()} exited (code: ${code}, signal: ${signal})`);
+    // Inputs written but not yet consumed (no idle since the write) die with
+    // the CLI — codex crashing mid-submit never records them, and the fresh
+    // respawn comes up empty. Stash them so the next spawnCli re-queues and
+    // re-delivers.
+    const stashed = inflightInputs.onCliExit();
+    if (stashed > 0) {
+      log(`CLI exited with ${stashed} in-flight message(s); will re-queue after restart`);
+    }
     backend = null;
     isPromptReady = false;
     send({ type: 'claude_exit', code, signal });

--- a/test/inflight-input-tracker.test.ts
+++ b/test/inflight-input-tracker.test.ts
@@ -1,0 +1,95 @@
+/**
+ * InflightInputTracker — the state machine that re-queues user inputs across
+ * a CLI crash.
+ *
+ * Regression for the 2026-06-10 incident: a bot-to-bot @mention spawned a
+ * fresh codex session, the worker wrote the prompt to the PTY, codex exited
+ * code 1 ~3s later WITHOUT recording the submit (history.jsonl has no entry),
+ * the auto-restart brought up an idle CLI, and nothing re-delivered — the
+ * session sat at 「等待输入」 forever and the message was silently lost
+ * (killCli wipes pendingMessages; the item had already been dequeued).
+ *
+ * Run:  pnpm vitest run test/inflight-input-tracker.test.ts
+ */
+import { describe, it, expect } from 'vitest';
+
+import { InflightInputTracker } from '../src/core/inflight-input-tracker.js';
+
+const item = (content: string, turnId?: string) => ({ content, turnId });
+
+describe('InflightInputTracker', () => {
+  it('incident shape: write → CLI crash → respawn re-queues the lost input', () => {
+    const t = new InflightInputTracker();
+    t.onWrite(item('review PR #159', 'turn-1'));
+
+    expect(t.onCliExit()).toBe(1);
+
+    const carry = t.takeCarryOver();
+    expect(carry).toEqual([{ content: 'review PR #159', turnId: 'turn-1' }]);
+    // Consumed exactly once — a second spawn gets nothing.
+    expect(t.takeCarryOver()).toEqual([]);
+  });
+
+  it('completed turn: idle clears in-flight, a later crash re-queues nothing', () => {
+    const t = new InflightInputTracker();
+    t.onWrite(item('hello'));
+    t.onTurnComplete();
+
+    expect(t.onCliExit()).toBe(0);
+    expect(t.takeCarryOver()).toEqual([]);
+  });
+
+  it('type-ahead: multiple writes before idle are all carried over in order', () => {
+    const t = new InflightInputTracker();
+    t.onWrite(item('msg-1', 'a'));
+    t.onWrite(item('msg-2', 'b'));
+
+    expect(t.onCliExit()).toBe(2);
+    expect(t.takeCarryOver().map(i => i.content)).toEqual(['msg-1', 'msg-2']);
+  });
+
+  it('double exit before respawn keeps the earlier stash (appends, not replaces)', () => {
+    const t = new InflightInputTracker();
+    t.onWrite(item('first'));
+    expect(t.onCliExit()).toBe(1);
+
+    // Second exit with nothing newly in flight must not drop the stash.
+    expect(t.onCliExit()).toBe(0);
+    expect(t.takeCarryOver().map(i => i.content)).toEqual(['first']);
+  });
+
+  it('exit → stash → new write before consume → second exit appends both batches', () => {
+    const t = new InflightInputTracker();
+    t.onWrite(item('first'));
+    t.onCliExit();
+    t.onWrite(item('second'));
+    t.onCliExit();
+
+    expect(t.takeCarryOver().map(i => i.content)).toEqual(['first', 'second']);
+  });
+
+  it('takeCarryOver on a fresh spawn drops stale in-flight entries from a previous life', () => {
+    const t = new InflightInputTracker();
+    // A detach-style kill never fires onExit, so unacked could go stale.
+    t.onWrite(item('stale'));
+    expect(t.takeCarryOver()).toEqual([]);   // nothing stashed — nothing replayed
+    // The stale entry must be gone: a later exit has nothing to stash.
+    expect(t.onCliExit()).toBe(0);
+  });
+
+  it('full lifecycle: turns complete normally, only the crashed turn replays', () => {
+    const t = new InflightInputTracker();
+    // Turn 1 — normal.
+    t.onWrite(item('turn-1'));
+    t.onTurnComplete();
+    // Turn 2 — crash mid-turn.
+    t.onWrite(item('turn-2'));
+    expect(t.onCliExit()).toBe(1);
+    expect(t.takeCarryOver().map(i => i.content)).toEqual(['turn-2']);
+    // Turn 3 on the fresh CLI — normal again, nothing lingers.
+    t.onWrite(item('turn-3'));
+    t.onTurnComplete();
+    expect(t.onCliExit()).toBe(0);
+    expect(t.takeCarryOver()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 线上事故（2026-06-10，daemon-3 / Codex bot）

bot-to-bot @ 消息触发新建 codex 会话后，消息静默丢失，会话永远停在「等待输入」。daemon 日志证据链：

```
02:56:32.377 Prompt detected (idle)          ← codex 显示 prompt
02:56:32.379 Writing to PTY (flush): "..."   ← 同一毫秒写入消息
02:56:35.825 Codex exited (code: 1)          ← 提交途中崩溃（history.jsonl 无该条记录）
02:56:36     Auto-restarting Codex...        ← 自动重启
02:56:44.826 First prompt timeout — flushing queued messages   ← 但队列是空的
02:56:45.813 Prompt detected (idle)          ← 新 CLI 空转，消息再无人投递
```

根因：消息在崩溃前已从 `pendingMessages` 出队，`killCli()` 又会清空队列——CLI 崩溃后**没有任何机制重投在途消息**。

复现实验：关掉卡死会话后用同样的多行消息重新触发，fresh spawn 这次 boot 慢了 10 秒、写入后 400ms 提交确认成功。崩溃是 codex「刚就绪立即吃多行粘贴」的**偶发竞态，非确定性**——所以兜底必须做在 botmux 侧，而不是指望上游修。

## 修法

新增 `core/inflight-input-tracker.ts` 状态机（独立模块，可单测），worker 四点接线：

| 时机 | 调用 |
| --- | --- |
| flushPending 出队写入 PTY | `onWrite(item)` — 登记在途 |
| CLI 回到 idle prompt（markPromptReady） | `onTurnComplete()` — 回合完成，清空在途 |
| CLI 进程死亡（backend.onExit） | `onCliExit()` — 暂存在途输入（append 语义，double-exit 不丢批） |
| spawnCli 重启（非 adopt） | `takeCarryOver()` — 重投到 pendingMessages 队头，由既有 flush 路径送达；同时清掉上一世残留 |

**取舍**：若 CLI 实际吃到输入后才崩，重启后会重复问一次——重复一次好过静默丢失。false-idle 提前清空仅使该回合退化回旧行为（丢失），不会更差。adopt 模式观察的是用户自己的 CLI，绝不重投。

## 测试

- 状态机 7 例：事发场景走查 / 正常回合不重投 / type-ahead 多消息按序保全 / double-exit 保留先前批次 / 暂存后新写再崩两批合并 / fresh-spawn 丢弃残留 / 完整生命周期只重投崩溃回合
- `tsc --noEmit` + `pnpm build` 干净
- 全量 4227 过，失败画像与干净 origin/master 完全一致（15 浏览器 e2e 缺 storageState 夹具、mira 多行 3 例、DAEMON_COMMANDS size 漂移、hook-runner 1 例——均为既有，已逐一在干净 HEAD 上核实）

## 关联

- 对应 memory「codex 兜底失效真因」中的修法 A（崩溃丢消息）
- `DAEMON_COMMANDS` size 漂移已在 PR #159 顺手修复，本分支不重复修