### PR TITLE
feat(sandbox): overlayfs 读全/写隔离模型（替掉 clone+脱敏，解决磁盘/鉴权/历史会话）

### DIFF
--- a/scripts/sandbox-cli-functional-probe.mjs
+++ b/scripts/sandbox-cli-functional-probe.mjs
@@ -1,0 +1,194 @@
+// FUNCTIONAL probe: actually RUN the real CLIs (codex, claude-code, seed) inside
+// the overlay bwrap sandbox built by the compiled prepareSandbox.
+//
+// For each CLI it does TWO bwrap runs sharing one sandbox plan:
+//   (1) RECON via /bin/sh: verify config/auth readability, project edit lands in
+//       proj-upper, the `botmux` relay shim loads (node <cli.js> prints help, no
+//       "Cannot find module"), and the proxy env is present in the sandbox env.
+//   (2) REAL CLI start: run the actual CLI binary non-interactively (`--version`)
+//       to confirm the process STARTS and does not crash / Cannot-find-module.
+//
+// Mirrors worker.ts wiring: resolved binary + real adapter args + adapter spawnEnv
+// (seed's CLAUDE_CONFIG_DIR) + sbx.env merged into the child env.
+//
+// Run: node scripts/sandbox-cli-functional-probe.mjs
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, rmSync, mkdtempSync, statSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+import { prepareSandbox } from '../dist/adapters/backend/sandbox.js';
+import { createCliAdapterSync } from '../dist/adapters/cli/registry.js';
+
+const SRC = '/root/sandbox-demo';
+const HOME = homedir();
+const CLAUDE_CRED = join(HOME, '.claude', '.credentials.json');
+const CLAUDE_SETTINGS = join(HOME, '.claude', 'settings.json');
+const CODEX_AUTH = join(HOME, '.codex', 'auth.json');
+
+function line() { console.log('─'.repeat(72)); }
+
+// Build the per-CLI sandbox using the SAME inputs worker.ts feeds prepareSandbox.
+function buildSbx(cliId, sessionId, dataDir, cliBin, cliArgs) {
+  return prepareSandbox({
+    enabled: true,
+    cliId,
+    sessionId,
+    sourceWorkingDir: SRC,
+    dataDir,
+    cliBin,
+    cliArgs,
+    hidePaths: [],
+  });
+}
+
+// Mirror worker.ts childEnv assembly: process.env + adapter.spawnEnv + sbx.env.
+function childEnv(adapter, sbx) {
+  const e = { ...process.env };
+  if (adapter.spawnEnv) Object.assign(e, adapter.spawnEnv);
+  Object.assign(e, sbx.env);
+  return e;
+}
+
+const reconScript = (authCheck, configCheck) => `
+  set +e
+  echo "RECON: whoami=$(id -un) uid=$(id -u)"
+  echo "RECON: cwd=$(pwd)"
+  echo "RECON: project README line1=$(head -1 README.md 2>&1)"
+  echo "RECON: ${authCheck}"
+  echo "RECON: ${configCheck}"
+  echo "RECON: proxy_in_env https_proxy=\${https_proxy:-MISSING} HTTPS_PROXY=\${HTTPS_PROXY:-MISSING}"
+  echo "RECON: PATH_head=$(echo \$PATH | cut -d: -f1)"
+  echo "RECON: HOME=\$HOME"
+  echo "RECON: BOTMUX_SEND_RELAY=\${BOTMUX_SEND_RELAY:-MISSING}"
+  # EDIT a project file (must land in proj-upper, NOT in real /root/sandbox-demo)
+  echo "edit-by-$(id -un)-$$" > sandbox_edit_marker.txt
+  echo "# appended in sandbox" >> app.py
+  echo "RECON: wrote project files"
+  # relay shim: 'botmux' on PATH must exec node <cli.js>; help must print w/o module error
+  BOUT=$(botmux --help 2>&1)
+  if echo "\$BOUT" | grep -qi "Cannot find module"; then
+    echo "RECON: relay_shim=CANNOT_FIND_MODULE"
+  elif echo "\$BOUT" | grep -qiE "botmux|usage|command|send|daemon|schedule"; then
+    echo "RECON: relay_shim=OK (botmux help loaded)"
+  else
+    echo "RECON: relay_shim=UNKNOWN_OUTPUT"
+  fi
+  echo "RECON: relay_shim_first_line=$(echo \"\$BOUT\" | head -1)"
+`;
+
+const cases = [
+  {
+    cliId: 'codex',
+    binPath: '/root/.local/share/fnm/node-versions/v22.21.1/installation/bin/codex',
+    label: 'codex (codex-cli)',
+    authCheck: 'codex_auth_readable=$( [ -r "$HOME/.codex/auth.json" ] && echo YES || echo NO )',
+    configCheck: 'codex_config_readable=$( [ -r "$HOME/.codex/config.toml" ] && echo YES || echo NO )',
+    versionArgs: ['--version'],
+  },
+  {
+    cliId: 'claude-code',
+    binPath: '/root/.local/bin/claude',
+    label: 'claude-code (claude)',
+    authCheck: 'claude_creds_readable=$( [ -r "$HOME/.claude/.credentials.json" ] && echo YES || echo NO )',
+    configCheck: 'claude_settings_readable=$( [ -r "$HOME/.claude/settings.json" ] && echo YES || echo NO )',
+    versionArgs: ['--version'],
+  },
+  {
+    cliId: 'seed',
+    binPath: '/root/.local/share/fnm/node-versions/v22.21.1/installation/bin/seed',
+    label: 'seed (Seed fork; CLAUDE_CONFIG_DIR=.claude-runtime)',
+    // Seed reads CLAUDE_CONFIG_DIR (set via adapter.spawnEnv) — assert that dir's settings.
+    authCheck: 'seed_config_dir=${CLAUDE_CONFIG_DIR:-UNSET}',
+    configCheck: 'seed_settings_readable=$( [ -r "$CLAUDE_CONFIG_DIR/settings.json" ] && echo YES || echo NO )',
+    versionArgs: ['--version'],
+  },
+];
+
+const results = [];
+
+for (const c of cases) {
+  line();
+  console.log(`### ${c.label}`);
+  const adapter = createCliAdapterSync(c.cliId, c.binPath);
+  const bin = adapter.resolvedBin;
+  console.log(`resolvedBin = ${bin}`);
+  console.log(`spawnEnv    = ${JSON.stringify(adapter.spawnEnv ?? {})}`);
+
+  const res = { cliId: c.cliId, started: false, auth: '?', config: '?', edit: false, relay: '?', proxy: false, versionExit: null, notes: [] };
+
+  // ── (1) RECON run (sh inside the sandbox) ──────────────────────────────────
+  const reconData = mkdtempSync(join(tmpdir(), `sbx-recon-${c.cliId}-`));
+  const reconSid = `recon-${c.cliId}-${Date.now()}`;
+  const sbxRecon = buildSbx(c.cliId, reconSid, reconData, '/bin/sh', ['-c', reconScript(c.authCheck, c.configCheck)]);
+  if (!sbxRecon) {
+    console.log('RECON: prepareSandbox returned null — FAIL (mount failed/unsupported)');
+    res.notes.push('prepareSandbox null on recon');
+    results.push(res);
+    try { rmSync(reconData, { recursive: true, force: true }); } catch {}
+    continue;
+  }
+  const reconEnv = childEnv(adapter, sbxRecon);
+  const rr = spawnSync(sbxRecon.bin, sbxRecon.args, { env: reconEnv, encoding: 'utf8' });
+  console.log('--- recon stdout ---');
+  console.log((rr.stdout || '(none)').trimEnd());
+  if (rr.stderr && rr.stderr.trim()) { console.log('--- recon stderr ---'); console.log(rr.stderr.trimEnd()); }
+
+  const out = rr.stdout || '';
+  res.auth = (out.match(/(?:credentials_readable|auth_readable|config_dir)=(\S+)/) || [])[1] ?? '?';
+  res.config = (out.match(/settings_readable=(\S+)/) || [])[1] ?? '?';
+  res.relay = /relay_shim=OK/.test(out) ? 'OK' : /CANNOT_FIND_MODULE/.test(out) ? 'CANNOT_FIND_MODULE' : 'UNKNOWN';
+  res.proxy = /HTTPS_PROXY=http/.test(out);
+
+  // EDIT landed in proj-upper, real project untouched
+  const upperMarker = join(sbxRecon.workDir, 'sandbox_edit_marker.txt');
+  const upperApp = join(sbxRecon.workDir, 'app.py');
+  const realMarker = join(SRC, 'sandbox_edit_marker.txt');
+  const editLanded = existsSync(upperMarker) && existsSync(upperApp);
+  const realUntouched = !existsSync(realMarker) && !readFileSync(join(SRC, 'app.py'), 'utf8').includes('# appended in sandbox');
+  res.edit = editLanded && realUntouched;
+  console.log(`VERIFY: edit landed in proj-upper=${editLanded} realUntouched=${realUntouched}`);
+  if (editLanded) console.log(`VERIFY: upper marker content=${JSON.stringify(readFileSync(upperMarker, 'utf8').trim())}`);
+
+  sbxRecon.cleanup();
+  try { rmSync(reconData, { recursive: true, force: true }); } catch {}
+
+  // ── (2) REAL CLI start (run the actual binary, non-interactive) ────────────
+  const verData = mkdtempSync(join(tmpdir(), `sbx-ver-${c.cliId}-`));
+  const verSid = `ver-${c.cliId}-${Date.now()}`;
+  const sbxVer = buildSbx(c.cliId, verSid, verData, bin, c.versionArgs);
+  if (!sbxVer) {
+    console.log('VERSION: prepareSandbox returned null — FAIL');
+    res.notes.push('prepareSandbox null on version run');
+  } else {
+    const verEnv = childEnv(adapter, sbxVer);
+    const vr = spawnSync(sbxVer.bin, sbxVer.args, { env: verEnv, encoding: 'utf8', timeout: 60000 });
+    res.versionExit = vr.status;
+    const vout = (vr.stdout || '').trim();
+    const verr = (vr.stderr || '').trim();
+    console.log(`--- real \`${c.cliId} ${c.versionArgs.join(' ')}\` inside sandbox ---`);
+    console.log(`exit=${vr.status} signal=${vr.signal ?? ''}`);
+    if (vout) console.log(`stdout: ${vout.split('\n')[0]}`);
+    if (verr) console.log(`stderr: ${verr.split('\n').slice(0, 5).join(' | ')}`);
+    const moduleErr = /Cannot find module/i.test(vout + verr);
+    res.started = vr.status === 0 && !moduleErr;
+    if (moduleErr) res.notes.push('Cannot find module');
+    sbxVer.cleanup();
+  }
+  try { rmSync(verData, { recursive: true, force: true }); } catch {}
+
+  results.push(res);
+}
+
+line();
+console.log('=== SUMMARY ===');
+for (const r of results) {
+  console.log(
+    `${r.cliId.padEnd(12)} | started=${r.started} | versionExit=${r.versionExit} | ` +
+    `auth/configDir=${r.auth} | settings=${r.config} | editLands=${r.edit} | ` +
+    `relayShim=${r.relay} | proxyEnv=${r.proxy}` +
+    (r.notes.length ? ` | notes=${r.notes.join(',')}` : '')
+  );
+}
+const allGood = results.every(r => r.started && r.edit && r.relay === 'OK' && r.proxy);
+console.log('RESULT:', allGood ? 'ALL PASS' : 'SEE SUMMARY (some checks failed)');
+process.exit(allGood ? 0 : 1);

--- a/scripts/sandbox-cli-live-turn-probe.mjs
+++ b/scripts/sandbox-cli-live-turn-probe.mjs
@@ -1,0 +1,66 @@
+// LIVE-TURN probe: run a real non-interactive AI turn for each CLI INSIDE the
+// overlay bwrap sandbox. This exercises the full path: process start → read real
+// config/auth → use proxy env → reach the API → produce output. Bounded timeouts.
+//
+// Run: node scripts/sandbox-cli-live-turn-probe.mjs
+import { spawnSync } from 'node:child_process';
+import { rmSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { prepareSandbox } from '../dist/adapters/backend/sandbox.js';
+import { createCliAdapterSync } from '../dist/adapters/cli/registry.js';
+
+const SRC = '/root/sandbox-demo';
+const PROMPT = 'Reply with exactly the single word: PONG';
+
+function childEnv(adapter, sbx) {
+  const e = { ...process.env };
+  if (adapter.spawnEnv) Object.assign(e, adapter.spawnEnv);
+  Object.assign(e, sbx.env);
+  return e;
+}
+
+const cases = [
+  {
+    cliId: 'claude-code',
+    binPath: '/root/.local/bin/claude',
+    args: ['--print', '--dangerously-skip-permissions', PROMPT],
+    needle: /PONG/i,
+  },
+  {
+    cliId: 'seed',
+    binPath: '/root/.local/share/fnm/node-versions/v22.21.1/installation/bin/seed',
+    args: ['--print', '--dangerously-skip-permissions', PROMPT],
+    needle: /PONG/i,
+  },
+  {
+    cliId: 'codex',
+    binPath: '/root/.local/share/fnm/node-versions/v22.21.1/installation/bin/codex',
+    args: ['exec', '--dangerously-bypass-approvals-and-sandbox', PROMPT],
+    needle: /PONG/i,
+  },
+];
+
+for (const c of cases) {
+  console.log('─'.repeat(72));
+  console.log(`### ${c.cliId} live turn: \`${c.cliId} ${c.args.join(' ')}\``);
+  const adapter = createCliAdapterSync(c.cliId, c.binPath);
+  const data = mkdtempSync(join(tmpdir(), `sbx-live-${c.cliId}-`));
+  const sid = `live-${c.cliId}-${Date.now()}`;
+  const sbx = prepareSandbox({
+    enabled: true, cliId: c.cliId, sessionId: sid, sourceWorkingDir: SRC,
+    dataDir: data, cliBin: adapter.resolvedBin, cliArgs: c.args, hidePaths: [],
+  });
+  if (!sbx) { console.log('prepareSandbox null — FAIL'); try { rmSync(data, { recursive: true, force: true }); } catch {} continue; }
+  const env = childEnv(adapter, sbx);
+  const r = spawnSync(sbx.bin, sbx.args, { env, encoding: 'utf8', timeout: 120000 });
+  const out = (r.stdout || '').trim();
+  const err = (r.stderr || '').trim();
+  console.log(`exit=${r.status} signal=${r.signal ?? ''} timedOut=${r.error?.code === 'ETIMEDOUT' || r.signal === 'SIGTERM'}`);
+  if (out) console.log('--- stdout (last 800 chars) ---\n' + out.slice(-800));
+  if (err) console.log('--- stderr (last 800 chars) ---\n' + err.slice(-800));
+  const got = c.needle.test(out);
+  console.log(`VERDICT ${c.cliId}: live turn ${got ? 'PRODUCED EXPECTED OUTPUT (auth+proxy+API all worked)' : 'did NOT produce expected output'}`);
+  sbx.cleanup();
+  try { rmSync(data, { recursive: true, force: true }); } catch {}
+}

--- a/scripts/sandbox-fixes-probe.mjs
+++ b/scripts/sandbox-fixes-probe.mjs
@@ -1,0 +1,72 @@
+// Real-mechanics probe for the overlay sandbox AFTER the issue fixes.
+// Verifies: reads pass through to real fs, writes outside project are ephemeral,
+// project edits show in proj-upper, ~/.claude/.credentials.json readable, and
+// the FIFO-in-outbox DoS no longer hangs the relay materialize path.
+import { prepareSandbox, materializeOutboxFile } from '../dist/adapters/backend/sandbox.js';
+import { spawnSync, execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+
+const out = (k, v) => console.log(`${k}=${v}`);
+const SRC = '/root/sandbox-demo';
+const dataDir = mkdtempSync(join(tmpdir(), 'sbx-probe-'));
+const sid = 'probe-' + Math.random().toString(36).slice(2);
+const leak = '/root/iserver/botmux/SBXLEAK.txt';
+
+const sbx = prepareSandbox({
+  enabled: true, cliId: 'codex', sessionId: sid, sourceWorkingDir: SRC,
+  dataDir, cliBin: '/bin/sh', cliArgs: [], hidePaths: [],
+});
+if (!sbx) { out('PREPARE', 'NULL (overlay mount failed?)'); process.exit(1); }
+out('PREPARE', 'OK');
+out('UPPER', sbx.workDir);
+out('OUTBOX', sbx.outbox);
+
+// The script run inside bwrap: read a real file, attempt an out-of-project write,
+// edit a project file, read a credential file.
+const inner = [
+  'echo "--- read real /etc/hostname ---"',
+  'cat /etc/hostname',
+  'echo "--- attempt out-of-project write (should be ephemeral, NOT hit real host) ---"',
+  `echo SBXLEAK_FROM_AGENT > ${leak} && echo "wrote-inside-sandbox=$(cat ${leak})"`,
+  'echo "--- edit a project file ---"',
+  `echo "EDITED BY AGENT" > ${SRC}/greeting.txt && echo "in-sandbox greeting=$(cat ${SRC}/greeting.txt)"`,
+  `echo "NEW FILE" > ${SRC}/added-by-agent.txt`,
+  'echo "--- read ~/.claude credentials ---"',
+  `test -r ${join(homedir(), '.claude/.credentials.json')} && echo "creds-readable=YES" || echo "creds-readable=NO"`,
+  'echo "--- env relay/home ---"',
+  'echo "HOME=$HOME"; echo "BOTMUX_SEND_RELAY=$BOTMUX_SEND_RELAY"; echo "PATH=$PATH"',
+].join('\n');
+
+// sbx.args ends with: -- /bin/sh ; replace cliArgs by appending -c <inner>.
+const args = [...sbx.args, '-c', inner];
+const r = spawnSync(sbx.bin, args, { encoding: 'utf8', env: { ...process.env, ...sbx.env } });
+console.log('=== INNER STDOUT ===');
+console.log(r.stdout ?? '');
+if (r.stderr) { console.log('=== INNER STDERR ==='); console.log(r.stderr.slice(0, 2000)); }
+out('INNER_EXIT', r.status);
+
+// Host-side checks after the run.
+out('HOST_LEAK_FILE_EXISTS', existsSync(leak));               // MUST be false (write was ephemeral)
+out('HOST_PROJECT_GREETING', JSON.stringify(readFileSync(join(SRC, 'greeting.txt'), 'utf8'))); // MUST be unchanged real
+out('UPPER_HAS_GREETING', existsSync(join(sbx.workDir, 'greeting.txt')));   // edit copied-up here
+out('UPPER_HAS_ADDED', existsSync(join(sbx.workDir, 'added-by-agent.txt')));
+try { out('UPPER_LISTING', JSON.stringify(readdirSync(sbx.workDir))); } catch (e) { out('UPPER_LISTING', 'ERR ' + e.message); }
+
+// FIFO-in-outbox DoS: drop a FIFO and confirm materialize returns immediately false.
+try {
+  execFileSync('mkfifo', [join(sbx.outbox, 'evil')], { stdio: 'ignore' });
+  const t0 = Date.now();
+  const fr = materializeOutboxFile(sbx.outbox, 'evil', join(dataDir, 'fifo-dest'));
+  out('FIFO_MATERIALIZE_RESULT', fr);                          // MUST be false
+  out('FIFO_MATERIALIZE_MS', Date.now() - t0);                 // MUST be small (no hang)
+  out('FIFO_DEST_CREATED', existsSync(join(dataDir, 'fifo-dest')));
+} catch (e) { out('FIFO_TEST', 'skip ' + e.message); }
+
+sbx.cleanup();
+out('CLEANUP', 'done');
+out('MOUNT_AFTER_CLEANUP_PROJ', spawnSync('mountpoint', ['-q', join(dataDir, 'sandboxes', sid, 'proj-merged')]).status === 0);
+out('MOUNT_AFTER_CLEANUP_HOME', spawnSync('mountpoint', ['-q', join(dataDir, 'sandboxes', sid, 'home-merged')]).status === 0);
+out('SESSIONROOT_AFTER_CLEANUP', existsSync(join(dataDir, 'sandboxes', sid)));
+out('VARTMP_AFTER_CLEANUP', existsSync(join('/var/tmp/botmux-sbx', sid)));

--- a/scripts/sandbox-opaque-land-probe.mjs
+++ b/scripts/sandbox-opaque-land-probe.mjs
@@ -1,0 +1,61 @@
+// Validates opaque-dir landing (#8 + #10) with a REAL overlay opaque dir.
+//   - a REPLACED dir (exists in lower) → stale lower files dropped on land
+//   - a NEW dir (not in lower)         → mkdir only, never rm -rf unrelated files
+import { applySandboxDiff, computeSandboxDiff } from '../dist/services/sandbox-land.js';
+import { mountOverlay, unmountOverlay } from '../dist/adapters/backend/sandbox.js';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, cpSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const out = (k, v) => console.log(`${k}=${v}`);
+const base = mkdtempSync(join(tmpdir(), 'opq-'));
+const lower = join(base, 'lower');     // the REAL project (overlay lower)
+const dataDir = join(base, 'data');
+const sid = 'opq';
+const sessionRoot = join(dataDir, 'sandboxes', sid);
+const upper = join(sessionRoot, 'proj-upper');
+const work = join(sessionRoot, 'proj-work');
+const merged = join(sessionRoot, 'proj-merged');
+
+// Lower (real project): an existing dir with stale files + a top file.
+mkdirSync(join(lower, 'replaceme', 'sub'), { recursive: true });
+writeFileSync(join(lower, 'replaceme', 'stale-top.txt'), 'STALE TOP\n');
+writeFileSync(join(lower, 'replaceme', 'sub', 'stale-deep.txt'), 'STALE DEEP\n');
+writeFileSync(join(lower, 'keep.txt'), 'keep me\n');
+
+const ok = mountOverlay({ lower, upper, work, merged });
+out('MOUNT', ok);
+if (!ok) process.exit(1);
+// prepareSandbox records this; the probe mounts directly so write it ourselves.
+writeFileSync(join(sessionRoot, 'meta.json'), JSON.stringify({ projectLower: lower }));
+
+// Agent in the merged view: wholesale-replace `replaceme/` and create a NEW dir.
+rmSync(join(merged, 'replaceme'), { recursive: true, force: true });
+mkdirSync(join(merged, 'replaceme'), { recursive: true });
+writeFileSync(join(merged, 'replaceme', 'fresh.txt'), 'FRESH\n');
+mkdirSync(join(merged, 'brandnew'), { recursive: true });
+writeFileSync(join(merged, 'brandnew', 'n.txt'), 'NEW\n');
+
+// Build a landing TARGET = a copy of the real lower (the actual repo to land into),
+// drifted: it ALSO has a concurrent file under the brand-new dir path.
+const target = join(base, 'target');
+cpSync(lower, target, { recursive: true });
+mkdirSync(join(target, 'brandnew'), { recursive: true });
+writeFileSync(join(target, 'brandnew', 'concurrent.txt'), 'DO NOT DELETE\n');
+
+const d = computeSandboxDiff(dataDir, sid);
+out('DIFF_OK', d.ok); out('DIFF_FILES', d.ok ? d.files : 'n/a');
+
+const a = applySandboxDiff(target, dataDir, sid);
+out('APPLY_OK', a.ok); if (!a.ok) out('APPLY_ERR', a.error);
+
+// Assertions:
+out('REPLACED_STALE_TOP_GONE', !existsSync(join(target, 'replaceme', 'stale-top.txt')));   // want true
+out('REPLACED_STALE_DEEP_GONE', !existsSync(join(target, 'replaceme', 'sub', 'stale-deep.txt'))); // want true
+out('REPLACED_FRESH_PRESENT', existsSync(join(target, 'replaceme', 'fresh.txt')));         // want true
+out('NEWDIR_CONCURRENT_SURVIVES', existsSync(join(target, 'brandnew', 'concurrent.txt'))); // want true (no clobber)
+out('NEWDIR_FILE_PRESENT', existsSync(join(target, 'brandnew', 'n.txt')));                 // want true
+out('UNRELATED_KEEP_SURVIVES', existsSync(join(target, 'keep.txt')));                      // want true
+
+unmountOverlay(merged);
+out('DONE', 'ok');

--- a/scripts/sandbox-overlay-probe.mjs
+++ b/scripts/sandbox-overlay-probe.mjs
@@ -1,0 +1,92 @@
+// Self-probe for the overlay sandbox: build prepareSandbox for codex against
+// /root/sandbox-demo, run bwrap with a sh -c that exercises read/write isolation,
+// then clean up. Run with: node scripts/sandbox-overlay-probe.mjs
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, rmSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { prepareSandbox } from '../dist/adapters/backend/sandbox.js';
+
+const SRC = '/root/sandbox-demo';
+const LEAK = '/root/iserver/botmux/SBXLEAK.txt';
+const dataDir = mkdtempSync(join(tmpdir(), 'sbx-probe-'));
+const sid = 'probe-' + Date.now();
+
+// pre-clean leak target so a stale file from a prior run doesn't false-positive
+try { rmSync(LEAK, { force: true }); } catch {}
+
+const inSandboxScript = `
+  set +e
+  echo "PROBE: hostname read = $(cat /etc/hostname 2>&1)"
+  echo "PROBE: project README first line = $(head -1 README.md 2>&1)"
+  echo "PROBE: credentials readable = $( [ -r "$HOME/.claude/.credentials.json" ] && echo YES || echo NO )"
+  # write a NEW file inside the project (should land in proj-upper, real untouched)
+  echo "edited-by-sandbox" > sandbox_probe_new.txt
+  echo "appended-by-sandbox" >> app.py
+  echo "PROBE: wrote project files"
+  # try to write a real file OUTSIDE the project (must be ephemeral, not landed)
+  echo "LEAKED" > ${LEAK} 2>&1 && echo "PROBE: wrote leak file (will check host)" || echo "PROBE: leak write FAILED (good)"
+  echo "PROBE: leak file visible inside sandbox = $( [ -f ${LEAK} ] && echo YES || echo NO )"
+`;
+
+const sbx = prepareSandbox({
+  enabled: true,
+  cliId: 'codex',
+  sessionId: sid,
+  sourceWorkingDir: SRC,
+  dataDir,
+  cliBin: '/bin/sh',
+  cliArgs: ['-c', inSandboxScript],
+  hidePaths: [],
+});
+
+if (!sbx) {
+  console.log('RESULT: prepareSandbox returned null (mount failed / unsupported) — FAIL');
+  try { rmSync(dataDir, { recursive: true, force: true }); } catch {}
+  process.exit(2);
+}
+
+console.log('PROBE: bwrap bin =', sbx.bin);
+console.log('PROBE: upper (changeset) dir =', sbx.workDir);
+
+const env = { ...process.env, ...sbx.env };
+const r = spawnSync(sbx.bin, sbx.args, { env, encoding: 'utf8' });
+console.log('--- sandbox stdout ---');
+console.log(r.stdout || '(none)');
+if (r.stderr && r.stderr.trim()) {
+  console.log('--- sandbox stderr ---');
+  console.log(r.stderr);
+}
+console.log('PROBE: bwrap exit status =', r.status);
+
+// HOST-side verification
+const leakOnHost = existsSync(LEAK);
+console.log('VERIFY: leak file present on REAL host =', leakOnHost, leakOnHost ? '(BAD — escape!)' : '(good — isolated)');
+
+const upperNew = join(sbx.workDir, 'sandbox_probe_new.txt');
+const upperHasNew = existsSync(upperNew);
+console.log('VERIFY: new project file present in proj-upper =', upperHasNew, upperHasNew ? '(good)' : '(BAD)');
+if (upperHasNew) console.log('VERIFY: upper new file content =', JSON.stringify(readFileSync(upperNew, 'utf8').trim()));
+
+const upperApp = join(sbx.workDir, 'app.py');
+const upperHasApp = existsSync(upperApp);
+console.log('VERIFY: modified app.py copied-up into proj-upper =', upperHasApp, upperHasApp ? '(good)' : '(BAD)');
+
+// real project must be UNTOUCHED
+const realNew = existsSync(join(SRC, 'sandbox_probe_new.txt'));
+const realApp = readFileSync(join(SRC, 'app.py'), 'utf8');
+console.log('VERIFY: real project got the NEW file (should be false until /land) =', realNew);
+console.log('VERIFY: real app.py contains sandbox append (should be false) =', realApp.includes('appended-by-sandbox'));
+
+// cleanup (unmount overlays + rm trees)
+sbx.cleanup();
+try { rmSync(dataDir, { recursive: true, force: true }); } catch {}
+try { rmSync(LEAK, { force: true }); } catch {}
+
+// final mountpoint sanity
+const mp1 = spawnSync('mountpoint', ['-q', join(dataDir, 'sandboxes', sid, 'proj-merged')], { stdio: 'ignore' });
+console.log('VERIFY: proj-merged still mounted after cleanup =', mp1.status === 0, '(should be false)');
+
+const pass = !leakOnHost && upperHasNew && upperHasApp && !realNew && !realApp.includes('appended-by-sandbox');
+console.log('RESULT:', pass ? 'PASS' : 'FAIL');
+process.exit(pass ? 0 : 1);

--- a/scripts/sandbox-relay-roundtrip-probe.mjs
+++ b/scripts/sandbox-relay-roundtrip-probe.mjs
@@ -1,0 +1,89 @@
+// RELAY round-trip probe: inside the sandbox, run the `botmux` relay shim
+// (`botmux send ...`) and confirm it drops a valid request into the outbox.
+// Then validate that request with the exported validateRelayRequest (the host
+// security boundary). We deliberately do NOT run the real host watcher re-exec
+// (that would post to a real Lark chat). A background "fake watcher" writes a
+// .res.json so the in-sandbox shim returns instead of hanging 120s.
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync, readdirSync, rmSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { prepareSandbox, validateRelayRequest } from '../dist/adapters/backend/sandbox.js';
+import { createCliAdapterSync } from '../dist/adapters/cli/registry.js';
+
+const SRC = '/root/sandbox-demo';
+const adapter = createCliAdapterSync('codex', '/root/.local/share/fnm/node-versions/v22.21.1/installation/bin/codex');
+const data = mkdtempSync(join(tmpdir(), 'sbx-relay-'));
+const sid = `relay-${Date.now()}`;
+
+// The in-sandbox shim runs `botmux send`, which resolves session-id from
+// BOTMUX_SESSION_ID — inject it like the worker does.
+const script = `
+  set +e
+  export BOTMUX_SESSION_ID=${sid}
+  echo "RELAY: BOTMUX_SEND_RELAY=$BOTMUX_SEND_RELAY"
+  botmux send "hello from sandbox via relay shim" --no-quote
+  echo "RELAY: botmux send exit=$?"
+`;
+
+const sbx = prepareSandbox({
+  enabled: true, cliId: 'codex', sessionId: sid, sourceWorkingDir: SRC,
+  dataDir: data, cliBin: '/bin/sh', cliArgs: ['-c', script], hidePaths: [],
+});
+if (!sbx) { console.log('prepareSandbox null — FAIL'); process.exit(2); }
+
+const outbox = sbx.outbox;
+let capturedReq = null;
+
+// Fake watcher: as soon as a *.req.json appears, capture+validate it and write a
+// .res.json so the in-sandbox shim's 120s wait returns immediately.
+const fake = setInterval(() => {
+  let entries = [];
+  try { entries = readdirSync(outbox); } catch { return; }
+  for (const name of entries) {
+    if (!name.endsWith('.req.json')) continue;
+    const id = name.slice(0, -'.req.json'.length);
+    try {
+      const req = JSON.parse(readFileSync(join(outbox, name), 'utf8'));
+      capturedReq = req;
+      // validate content file actually exists in outbox
+      const contentPath = join(outbox, req.contentFile);
+      capturedReq.__contentExists = existsSync(contentPath);
+      capturedReq.__contentText = capturedReq.__contentExists ? readFileSync(contentPath, 'utf8') : null;
+    } catch (e) { capturedReq = { __parseError: String(e) }; }
+    writeFileSync(join(outbox, `${id}.res.json`), JSON.stringify({ code: 0, stdout: 'fake-watcher-ok', stderr: '' }));
+  }
+}, 100);
+
+// IMPORTANT: run the shim with async spawn (NOT spawnSync) so the fake-watcher
+// setInterval can fire concurrently — spawnSync would block the event loop and
+// the in-sandbox shim would hang 120s waiting for a .res.json that never lands.
+const env = { ...process.env, ...sbx.env };
+const r = await new Promise((resolve) => {
+  const child = spawn(sbx.bin, sbx.args, { env });
+  let out = '', err = '';
+  child.stdout.on('data', d => { out += d; });
+  child.stderr.on('data', d => { err += d; });
+  child.on('close', (code) => resolve({ status: code, stdout: out, stderr: err }));
+  child.on('error', (e) => resolve({ status: -1, stdout: out, stderr: String(e) }));
+});
+clearInterval(fake);
+console.log('--- shim stdout ---'); console.log((r.stdout || '(none)').trimEnd());
+if (r.stderr && r.stderr.trim()) { console.log('--- shim stderr ---'); console.log(r.stderr.trimEnd()); }
+console.log('shim exit =', r.status);
+
+console.log('captured outbox request =', JSON.stringify(capturedReq));
+let validOk = false;
+if (capturedReq && !capturedReq.__parseError) {
+  const v = validateRelayRequest({ contentFile: capturedReq.contentFile, attachments: capturedReq.attachments, flags: capturedReq.flags });
+  validOk = v.ok;
+  console.log('validateRelayRequest =', JSON.stringify(v));
+  console.log('content materialized & readable on host =', capturedReq.__contentExists, JSON.stringify(capturedReq.__contentText));
+}
+
+sbx.cleanup();
+try { rmSync(data, { recursive: true, force: true }); } catch {}
+
+const pass = !!capturedReq && !capturedReq.__parseError && validOk && capturedReq.__contentExists;
+console.log('RESULT:', pass ? 'RELAY ROUND-TRIP OK (shim → outbox req → host-side validate passes)' : 'RELAY FAIL');
+process.exit(pass ? 0 : 1);

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -1,72 +1,111 @@
 /**
- * File-isolation sandbox (bubblewrap) for oncall bots.
+ * File-isolation sandbox (bubblewrap + overlayfs) for oncall bots.
  *
- * Wraps a CLI invocation so the agent can only read/write a per-session project
- * copy + a scoped, de-identified config dir — never the host's home, secrets
- * (~/.ssh, ~/.aws, bots.json), or other sessions'/projects' data.
+ * Model (OVERLAYFS read-all / write-isolated, per product decision 2026-06-10):
+ * the sandboxed agent READS the entire real filesystem natively — the real CLI
+ * config/auth/env/project, NO scrub, the CLI just works. WRITES are isolated via
+ * an overlayfs mount: the real lower layer is NEVER modified, only changed files
+ * copy-up into a per-session UPPER layer (zero-copy reads, only the delta uses
+ * disk, NO git clone). Landing copies that UPPER changeset back to the real
+ * project. Privacy masking is per-bot opt-in with NO defaults.
  *
- * Scope = FILE ISOLATION ONLY (per product decision 2026-06-05): host files
- * can't be touched; network is intentionally NOT isolated (npm/pip/git keep
- * working). This is bwrap's "default-deny + allowlist" model, NOT a defence
- * against a determined kernel-level escape — see
- * docs/sandbox-oncall-research-20260605.md.
+ * Mechanism (empirically verified — runs as root on this 5.15 kernel):
+ *   mount -t overlay overlay -o lowerdir=REAL,upperdir=UPPER,workdir=WORK MERGED
+ * bwrap 0.8.0 has NO --overlay, so we mount the overlay ON THE HOST then bind the
+ * merged dir into bwrap. overlayfs forbids upper/work INSIDE lower, so the HOME
+ * overlay (lower=/root) puts upper/work OUTSIDE /root (under /var/tmp/...). The
+ * PROJECT overlay upper/work under <dataDir>/sandboxes/<sessionId>/ is fine.
  *
- * Linux-only (bwrap depends on Linux user/mount namespaces). macOS reuses
- * Anthropic's sandbox-exec approach and is handled elsewhere.
+ * Linux-only (overlayfs + bwrap depend on Linux). macOS reuses Anthropic's
+ * sandbox-exec approach and is handled elsewhere.
  */
 import { homedir } from 'node:os';
-import { cpSync, mkdirSync, existsSync, writeFileSync, chmodSync, readdirSync, readFileSync, rmSync, realpathSync, openSync, fstatSync, readSync, writeSync, closeSync, constants as fsConstants } from 'node:fs';
+import { mkdirSync, existsSync, writeFileSync, chmodSync, readdirSync, readFileSync, rmSync, statSync, openSync, fstatSync, readSync, writeSync, closeSync, constants as fsConstants } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn, spawnSync } from 'node:child_process';
 
+/** Host root for the HOME overlay's upper/work — MUST be OUTSIDE the home lower
+ *  (overlayfs forbids upper/work inside lower). */
+const VARTMP_ROOT = '/var/tmp/botmux-sbx';
+
+// ───────────────────────────── overlay primitives ────────────────────────────
+
+/**
+ * Mount an overlayfs: reads fall through to `lower` (real, zero copy); writes
+ * copy-up into `upper` (the landable changeset). `work` is overlayfs scratch on
+ * the same fs as `upper`. Returns true iff `mount` exited 0.
+ */
+export function mountOverlay(opts: { lower: string; upper: string; work: string; merged: string }): boolean {
+  for (const d of [opts.upper, opts.work, opts.merged]) {
+    try { mkdirSync(d, { recursive: true }); } catch { /* */ }
+  }
+  const r = spawnSync('mount', [
+    '-t', 'overlay', 'overlay',
+    '-o', `lowerdir=${opts.lower},upperdir=${opts.upper},workdir=${opts.work}`,
+    opts.merged,
+  ], { stdio: 'pipe' });
+  return r.status === 0;
+}
+
+/** True iff `path` is currently a mountpoint (host-side overlay still mounted). */
+export function isMounted(path: string): boolean {
+  return spawnSync('mountpoint', ['-q', path], { stdio: 'ignore' }).status === 0;
+}
+
+/** Unmount an overlay merged dir. Best-effort: lazy-umount (`-l`) if a normal
+ *  umount fails (busy fd from a still-draining child). No-op if not a mount. */
+export function unmountOverlay(merged: string): void {
+  if (!isMounted(merged)) return; // not a mountpoint
+  const r = spawnSync('umount', [merged], { stdio: 'ignore' });
+  if (r.status !== 0) spawnSync('umount', ['-l', merged], { stdio: 'ignore' });
+}
+
+// ───────────────────────────── argv builder ──────────────────────────────────
+
 export interface SandboxPlan {
-  /** Host path of the per-session writable project copy (a `git clone` of the
-   *  source). Mounted INSIDE the sandbox at `projectMount`, not at this path. */
-  workDir: string;
-  /** In-sandbox path the clone is mounted at — MUST equal the original
-   *  workingDir the CLI was given (e.g. codex `-C <dir>`), so the CLI's existing
-   *  args resolve to the clone. Also the child's chdir. */
+  /** In-sandbox path the project is bound at — equals the original workingDir the
+   *  CLI was given, so the CLI's existing path args resolve. Also the child's chdir. */
   projectMount: string;
-  /** Per-session scoped HOME — bound over the real home path so every CLI's
-   *  hardcoded `~/.<cli>` resolves into this de-identified area. */
-  scopedHome: string;
-  /** Daemon-mediated `botmux send` outbox — the ONLY IPC surface bound in, so
-   *  bots.json / Lark creds never enter the sandbox. */
+  /** Host path of the merged project overlay (reads=real lower, writes=upper). */
+  projectMerged: string;
+  /** In-sandbox path the home overlay is bound at — equals the real home path so
+   *  every CLI's hardcoded `~/.<cli>` resolves there. */
+  home: string;
+  /** Host path of the merged home overlay. */
+  homeMerged: string;
+  /** Daemon-mediated `botmux send` outbox — bound LAST so it wins over any mask. */
   outbox: string;
-  /** Extra read-only paths the toolchain lives under (node/CLI binaries via
-   *  fnm, the botmux dist) — re-exposed AFTER the scoped-home mask because on
-   *  this host they sit under $HOME (e.g. ~/.local/share/fnm, ~/iserver/botmux). */
-  toolchainRo: string[];
+  /** Per-bot privacy masks: directories blanked with an empty tmpfs. */
+  hideDirs: string[];
+  /** Per-bot privacy masks: files blanked with a read-only empty placeholder. */
+  hideFiles: { path: string; empty: string }[];
   /** Keep network egress. File-only scope ⇒ default true (npm/pip/git work). */
   net?: boolean;
 }
-
-/** System dirs the toolchain needs, mounted read-only. `-try` so a missing
- *  path (e.g. /lib64 on some arches) is skipped rather than aborting. */
-const SYS_RO = ['/usr', '/bin', '/sbin', '/lib', '/lib64', '/etc', '/opt'] as const;
 
 /**
  * Build the bwrap argv prefix. Final spawn becomes:
  *   bwrap <these args> -- <cliBin> <cliArgs...>
  *
- * Mount order matters: the scoped HOME is bound over the real home FIRST, then
- * toolchain/work/outbox paths (some under home) are re-bound on top — bwrap
- * applies binds in order, so the later, more specific mounts win.
+ * Mount order matters (later mounts win): the whole real fs read-only first, then
+ * the home + project merged overlays bind over it (so writes there are isolated),
+ * then privacy masks blank specific paths, then the outbox binds LAST so it stays
+ * writable even if a mask covers a parent dir.
  */
 export function buildSandboxArgs(plan: SandboxPlan): string[] {
-  const home = homedir();
   const a: string[] = [];
-  for (const p of SYS_RO) a.push('--ro-bind-try', p, p);
-  a.push('--proc', '/proc', '--dev', '/dev', '--tmpfs', '/tmp', '--tmpfs', '/run');
-  // Mask the real home with the de-identified scoped home (same path → no env
-  // translation; ~/.codex, ~/.claude, ~/.config/* all resolve into scopedHome).
-  a.push('--bind', plan.scopedHome, home);
-  // Re-expose toolchain that lives under $HOME (node/CLI/botmux dist).
-  for (const p of plan.toolchainRo) a.push('--ro-bind-try', p, p);
-  // Writable: the project copy (mounted AT the original workingDir so the CLI's
-  // existing path args resolve) and the send-outbox (its own host path).
-  a.push('--bind', plan.workDir, plan.projectMount);
+  // Read the entire real fs (zero scrub — the CLI's config/auth/env just work).
+  a.push('--ro-bind', '/', '/');
+  // Fresh kernel/runtime dirs (the ro-bind of / would otherwise carry host /tmp etc.).
+  a.push('--proc', '/proc', '--dev', '/dev', '--tmpfs', '/tmp', '--tmpfs', '/run', '--tmpfs', '/dev/shm');
+  // Write-isolated home + project (overlay merged: reads=real lower, writes=upper).
+  a.push('--bind', plan.homeMerged, plan.home);
+  a.push('--bind', plan.projectMerged, plan.projectMount);
+  // Per-bot privacy masks (opt-in, no defaults).
+  for (const dir of plan.hideDirs) a.push('--tmpfs', dir);
+  for (const f of plan.hideFiles) a.push('--ro-bind', f.empty, f.path);
+  // Outbox LAST so it wins even if a mask covers a parent dir.
   a.push('--bind', plan.outbox, plan.outbox);
   // Isolate namespaces (keep net unless explicitly disabled).
   a.push('--unshare-user', '--unshare-pid', '--unshare-ipc', '--unshare-uts', '--unshare-cgroup-try');
@@ -75,150 +114,7 @@ export function buildSandboxArgs(plan: SandboxPlan): string[] {
   return a;
 }
 
-/** Per-CLI config-dir scoping for `~/<subdir>`. Two modes:
- *   - `seed`  (allowlist): copy ONLY these entries — safest, for CLIs whose
- *     minimal auth set is known (codex).
- *   - `scrub` (blocklist): copy the WHOLE dir EXCEPT these entries — robust for
- *     CLIs that need their full config to run (claude needs settings.json's env
- *     proxy block, settings.local.json, MCP config, …; coco needs its plugins).
- *     Only the cross-session-history items are excluded.
- *  `claudeTrust` additionally writes a minimal `~/.claude.json` trusting only the
- *  current project (the host's 69-project list is dropped). */
-interface ConfigScope { subdir: string; seed?: readonly string[]; scrub?: readonly string[]; claudeTrust?: boolean; }
-
-const CONFIG_SCOPE: Record<string, ConfigScope> = {
-  // codex: seed auth + config only. history.jsonl / sessions / logs_2.sqlite /
-  // goals_*.sqlite / cache are deliberately dropped (cross-session privacy AND
-  // the multi-GB logs_2.sqlite WAL bloat — see project_codex_logs_wal_bloat).
-  codex: {
-    subdir: '.codex',
-    seed: ['auth.json', 'config.toml', 'config.toml.old', 'config.toml.current', 'hooks.json', 'installation_id'],
-  },
-  'codex-app': {
-    subdir: '.codex',
-    seed: ['auth.json', 'config.toml', 'config.toml.old', 'config.toml.current', 'hooks.json', 'installation_id'],
-  },
-  // claude: ALLOWLIST (default-deny) — ~/.claude has many session/privacy dirs
-  // (history.jsonl, projects/, file-history/, paste-cache/, plans/, tasks/,
-  // downloads/, debug/ …) that must NOT enter the sandbox, so we copy only the
-  // config/auth files. settings.json is critical: its `env` block carries
-  // http_proxy/https_proxy — without it claude can't reach the API. + folder-trust.
-  'claude-code': {
-    subdir: '.claude',
-    seed: ['.credentials.json', 'settings.json', 'settings.local.json', 'mcp-needs-auth-cache.json'],
-    claudeTrust: true,
-  },
-  // coco (Rust): copy ~/.cache/coco EXCEPT history/sessions/logs; keep plugins/
-  // (its API config). coco recreates history/sessions fresh inside the sandbox.
-  coco: {
-    subdir: '.cache/coco',
-    scrub: ['history.jsonl', 'sessions', 'log', 'crashmarks', 'event-queue'],
-  },
-};
-
-/**
- * Materialise a de-identified config dir inside `scopedHome`: copy ONLY the
- * auth/config files from the host's real config, never history/sessions.
- * `dereference` resolves symlinks (codex's config.toml → config.toml.old) into
- * real files, since the symlink target won't exist inside the masked home.
- *
- * Returns false if this CLI has no persistent config to scope (hermes/aiden/…).
- */
-export function seedScopedConfig(cliId: string, scopedHome: string, projectMount?: string): boolean {
-  const scope = CONFIG_SCOPE[cliId];
-  if (!scope) return false;
-  const hostRoot = join(homedir(), scope.subdir);
-  const dstRoot = join(scopedHome, scope.subdir);
-  mkdirSync(dstRoot, { recursive: true });
-
-  const copy = (name: string) => {
-    const src = join(hostRoot, name);
-    if (!existsSync(src)) return;
-    try { cpSync(src, join(dstRoot, name), { recursive: true, dereference: true }); }
-    catch { /* best-effort: a missing/locked entry shouldn't block the sandbox */ }
-  };
-
-  if (scope.seed) {
-    for (const f of scope.seed) copy(f);
-  } else if (scope.scrub) {
-    const skip = new Set<string>(scope.scrub);
-    let entries: string[] = [];
-    try { entries = readdirSync(hostRoot); } catch { /* host config absent */ }
-    for (const name of entries) if (!skip.has(name)) copy(name);
-  }
-
-  if (scope.claudeTrust && projectMount) seedClaudeTrust(scopedHome, projectMount);
-  scrubSeededHooks(dstRoot);
-  return true;
-}
-
-/** Fix the hooks in the seeded config (claude settings.json, codex hooks.json …)
- *  so they don't fail inside the sandbox:
- *   - botmux's OWN hook (`<node> <host>/dist/cli.js hook <cli>`, e.g. claude's
- *     AskUserQuestion → Lark card) → KEEP, but rewrite its paths to the
- *     in-sandbox relocated runtime: `…/dist/cli.js` → /botmux-runtime/dist/cli.js,
- *     absolute `…/bin/node` → `node` (resolved on the sandbox PATH).
- *   - every OTHER hook (the owner's host tooling, e.g. `/root/.flux/bin/...`) →
- *     STRIP. Those binaries aren't bound in the sandbox, so they'd exit 127
- *     ("command not found") and spam the CLI's hook UI; the owner's personal
- *     host hooks also shouldn't run inside an isolated oncall sandbox. */
-function scrubSeededHooks(dstRoot: string): void {
-  const isBotmuxHook = (cmd: unknown): cmd is string =>
-    typeof cmd === 'string' && /\/cli\.js\b/.test(cmd) && /\bhook\b/.test(cmd);
-  const rewrite = (cmd: string): string =>
-    cmd.replace(/"[^"]*\/dist\/cli\.js"/g, '"/botmux-runtime/dist/cli.js"')
-       .replace(/"[^"]*\/bin\/node"/g, '"node"');
-  let names: string[] = [];
-  try { names = readdirSync(dstRoot); } catch { return; }
-  for (const name of names) {
-    if (!name.endsWith('.json')) continue;
-    const p = join(dstRoot, name);
-    let data: any;
-    try { data = JSON.parse(readFileSync(p, 'utf8')); } catch { continue; }
-    if (!data?.hooks || typeof data.hooks !== 'object') continue;
-    let changed = false;
-    for (const event of Object.keys(data.hooks)) {
-      const entries = data.hooks[event];
-      if (!Array.isArray(entries)) continue;
-      const keptEntries: any[] = [];
-      for (const entry of entries) {
-        const hooks = Array.isArray(entry?.hooks) ? entry.hooks : [];
-        const keptHooks = hooks.filter((h: any) => {
-          if (!isBotmuxHook(h?.command)) { changed = true; return false; }   // strip host hook
-          const nc = rewrite(h.command); if (nc !== h.command) { h.command = nc; changed = true; }
-          return true;
-        });
-        if (keptHooks.length) { entry.hooks = keptHooks; keptEntries.push(entry); }
-        else changed = true;
-      }
-      if (keptEntries.length) data.hooks[event] = keptEntries;
-      else { delete data.hooks[event]; changed = true; }
-    }
-    if (changed) { try { writeFileSync(p, JSON.stringify(data, null, 2)); } catch { /* */ } }
-  }
-}
-
-/** Write a minimal `<scopedHome>/.claude.json` that pre-accepts folder-trust for
- *  ONLY `projectMount`. We start from the host file (to keep claude's onboarding/
- *  account state so it doesn't re-run first-run) but REPLACE its `projects` map
- *  so the host's full project list never enters the sandbox. */
-function seedClaudeTrust(scopedHome: string, projectMount: string): void {
-  const hostJson = join(homedir(), '.claude.json');
-  let data: any = {};
-  if (existsSync(hostJson)) {
-    try { data = JSON.parse(readFileSync(hostJson, 'utf8')); } catch { data = {}; }
-  }
-  if (!data || typeof data !== 'object') data = {};
-  data.projects = { [projectMount]: { hasTrustDialogAccepted: true } };  // drop host's project list
-  try { writeFileSync(join(scopedHome, '.claude.json'), JSON.stringify(data)); } catch { /* */ }
-}
-
-// ───────────────────────────── orchestration ─────────────────────────────
-//
-// Everything below wires the primitives above into the worker's spawn path:
-// per-session dirs, a project clone, a PATH-injected `botmux` shim that runs
-// THIS build (so `botmux send` hits relay mode), and the daemon-side outbox
-// watcher that delivers relayed sends with the worker's creds.
+// ───────────────────────────── orchestration ─────────────────────────────────
 
 /** Absolute path to this build's compiled cli.js (dist/cli.js), derived from
  *  this module's own location (dist/adapters/backend/sandbox.js → ../../cli.js). */
@@ -227,7 +123,7 @@ function distCliJs(): string {
 }
 
 /** Is file-sandbox enabled for this session? Spike gate = env; the real
- *  per-bot BotConfig.sandbox flag is a follow-up. */
+ *  per-bot BotConfig.sandbox flag is decided by the caller. */
 export function sandboxEnabled(): boolean {
   return process.env.BOTMUX_SANDBOX === '1';
 }
@@ -237,71 +133,29 @@ export interface SandboxSpawn {
   bin: string;
   /** bwrap args + '--' + original (bin, ...args). */
   args: string[];
-  /** Env overrides to merge into childEnv (HOME, PATH, BOTMUX_SEND_RELAY). */
+  /** Env overrides to merge into childEnv (HOME, PATH, BOTMUX_SEND_RELAY, proxies). */
   env: Record<string, string>;
   /** Outbox dir the daemon watcher must service. */
   outbox: string;
-  /** Per-session project copy (for logging / landing). */
+  /** Project overlay UPPER dir — THE LANDABLE CHANGESET (used by sandbox-land). */
   workDir: string;
-  /** Remove the per-session sandbox tree. */
+  /** Unmount the overlays + remove the per-session sandbox tree. */
   cleanup: () => void;
 }
 
-function cloneProject(src: string, dst: string): void {
-  if (existsSync(join(src, '.git'))) {
-    // --no-hardlinks → fully independent object store; the sandbox can never
-    // corrupt the source repo, even with the shared-checkout setup.
-    const r = spawnSync('git', ['clone', '--local', '--no-hardlinks', '--quiet', src, dst], { stdio: 'ignore' });
-    if (r.status === 0) {
-      try {
-        // `git clone` only carries committed content. Overlay the source's
-        // WORKING TREE (uncommitted edits + untracked files) so the agent sees
-        // exactly what the owner sees — otherwise an owner's untracked file
-        // looks "new" to the agent and `/land` fails with "already exists".
-        overlayWorkingTree(src, dst);
-        // Baseline-commit the overlaid working tree. `/land` then diffs the
-        // agent's changes against THIS baseline (not the source's last commit),
-        // so landing applies only the agent's delta — not the owner's
-        // pre-existing uncommitted work (which the real repo already has).
-        spawnSync('git', ['-C', dst, 'add', '-A'], { stdio: 'ignore' });
-        spawnSync('git', ['-C', dst, '-c', 'user.email=sandbox@botmux.local', '-c', 'user.name=botmux-sandbox', 'commit', '-q', '--no-verify', '-m', 'botmux sandbox baseline (working tree)'], { stdio: 'ignore' });
-        const head = spawnSync('git', ['-C', dst, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).stdout?.trim();
-        if (head) writeFileSync(join(dirname(dst), 'clone-base'), head);
-      } catch { /* non-fatal: land falls back to HEAD */ }
-      return;
-    }
-    // fall through to cp on any git failure (non-repo edge, detached, etc.)
-  }
-  cpSync(src, dst, { recursive: true });
-}
-
-/** Make dst's working tree match src's: apply tracked edits + copy untracked. */
-function overlayWorkingTree(src: string, dst: string): void {
-  // Tracked modifications/deletions vs HEAD → apply onto the fresh checkout.
-  const diff = spawnSync('git', ['-C', src, 'diff', 'HEAD', '--binary'], { encoding: 'utf8', maxBuffer: 256 * 1024 * 1024 });
-  if (diff.status === 0 && diff.stdout && diff.stdout.trim()) {
-    const tmp = join(dirname(dst), 'wt-overlay.patch');
-    writeFileSync(tmp, diff.stdout);
-    spawnSync('git', ['-C', dst, 'apply', '--whitespace=nowarn', tmp], { stdio: 'ignore' });
-    try { rmSync(tmp); } catch { /* */ }
-  }
-  // Untracked, non-ignored files (skips node_modules/.gitignore'd cruft).
-  const others = spawnSync('git', ['-C', src, 'ls-files', '--others', '--exclude-standard', '-z'], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
-  if (others.status === 0 && others.stdout) {
-    for (const rel of others.stdout.split('\0').filter(Boolean)) {
-      try {
-        mkdirSync(dirname(join(dst, rel)), { recursive: true });
-        cpSync(join(src, rel), join(dst, rel));
-      } catch { /* skip unreadable/vanished */ }
-    }
-  }
-}
+/** Proxy env vars forwarded into the sandbox so the CLI reaches the API even on
+ *  the tmux backend (which otherwise only forwards a fixed whitelist). */
+const PROXY_ENV_KEYS = ['http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY', 'no_proxy', 'NO_PROXY', 'all_proxy', 'ALL_PROXY'] as const;
 
 /**
  * Build the sandboxed spawn for a CLI session, or return null when sandboxing
- * is off / unsupported. Creates per-session dirs under
- * <dataDir>/sandboxes/<sessionId>/, clones the source project, seeds a
- * de-identified config dir, and installs a `botmux` shim on PATH.
+ * is off / unsupported / a required overlay mount fails (fail-safe = the worker
+ * treats null as a hard error and does NOT silently run unsandboxed).
+ *
+ * Layout under <dataDir>/sandboxes/<sessionId>/: outbox, shimbin, proj-upper
+ * (the landable changeset), proj-work, proj-merged, home-merged. The HOME
+ * overlay's upper/work live under /var/tmp/botmux-sbx/<sessionId>/ because
+ * overlayfs forbids upper/work inside the lower (= the real home).
  */
 export function prepareSandbox(opts: {
   /** Whether the sandbox is on for THIS session (per-bot BotConfig.sandbox OR
@@ -314,86 +168,111 @@ export function prepareSandbox(opts: {
   dataDir: string;
   cliBin: string;
   cliArgs: string[];
+  /** Per-bot privacy masks (opt-in, no defaults). Paths existing as dirs are
+   *  blanked with a tmpfs; files with an empty read-only placeholder. */
+  hidePaths?: string[];
 }): SandboxSpawn | null {
   if (!opts.enabled) return null;
-  if (process.platform !== 'linux') return null; // bwrap is Linux-only
+  if (process.platform !== 'linux') return null; // overlayfs + bwrap are Linux-only
 
-  const root = join(opts.dataDir, 'sandboxes', opts.sessionId);
-  const scopedHome = join(root, 'home');
-  const workDir = join(root, 'work');
-  const outbox = join(root, 'outbox');
-  const shimBin = join(root, 'shimbin');
-  for (const d of [scopedHome, outbox, shimBin]) mkdirSync(d, { recursive: true });
+  const sessionRoot = join(opts.dataDir, 'sandboxes', opts.sessionId);
+  const outbox = join(sessionRoot, 'outbox');
+  const shimBin = join(sessionRoot, 'shimbin');
+  const empties = join(sessionRoot, 'empties');
+  const projUpper = join(sessionRoot, 'proj-upper');   // THE LANDABLE CHANGESET
+  const projWork = join(sessionRoot, 'proj-work');
+  const projMerged = join(sessionRoot, 'proj-merged');
+  const homeMerged = join(sessionRoot, 'home-merged');  // merged may live under sessionRoot
+  // HOME overlay upper/work MUST be OUTSIDE the home lower (overlayfs constraint).
+  const vartmp = join(VARTMP_ROOT, opts.sessionId);
+  const homeUpper = join(vartmp, 'home-upper');
+  const homeWork = join(vartmp, 'home-work');
+  for (const d of [outbox, shimBin, empties]) mkdirSync(d, { recursive: true });
 
-  // Project copy (BOTMUX_SANDBOX_SRC overrides for spike testing — the bot's
-  // configured workingDir may be huge/unsuitable).
-  const src = process.env.BOTMUX_SANDBOX_SRC || opts.sourceWorkingDir;
-  if (!existsSync(workDir)) cloneProject(src, workDir);
+  const home = homedir();
+  // BOTMUX_SANDBOX_SRC overrides the LOWER project source for spike testing only.
+  const projectSource = process.env.BOTMUX_SANDBOX_SRC || opts.sourceWorkingDir;
+  const projectMount = opts.sourceWorkingDir;
 
-  // De-identified CLI config (auth + settings/proxy-env; cross-session history
-  // scrubbed). projectMount lets claude-family pre-accept folder-trust for it.
-  seedScopedConfig(opts.cliId, scopedHome, opts.sourceWorkingDir);
+  // A same-session re-spawn (e.g. in-pane /clear) re-enters here; unmount any
+  // stale merged overlays first so we don't stack a second mount on the same dir.
+  unmountOverlay(projMerged);
+  unmountOverlay(homeMerged);
 
-  // `botmux` shim → THIS build's cli.js, so in-sandbox `botmux send` hits relay
-  // mode (and never the host's shared dist / bots.json).
+  // Mount the HOME overlay (lower=real home → reads pass through, writes isolate).
+  const homeOk = mountOverlay({ lower: home, upper: homeUpper, work: homeWork, merged: homeMerged });
+  if (!homeOk) {
+    return null; // fail-safe: no silent unsandboxed run
+  }
+  // Mount the PROJECT overlay. proj-upper = the landable changeset.
+  const projOk = mountOverlay({ lower: projectSource, upper: projUpper, work: projWork, merged: projMerged });
+  if (!projOk) {
+    unmountOverlay(homeMerged);
+    return null; // fail-safe
+  }
+
+  // Record the project LOWER source so landing can tell a wholesale-REPLACED dir
+  // (existed in the lower at create time) from a purely-NEW dir (overlayfs marks
+  // BOTH opaque, so the lower is the only reliable discriminator — and the live
+  // landing target may have drifted, so we must check the lower-at-create, not it).
+  try { writeFileSync(join(sessionRoot, 'meta.json'), JSON.stringify({ projectLower: projectSource })); } catch { /* */ }
+
+  // `botmux` shim → THIS build's cli.js (readable natively via --ro-bind / /), so
+  // in-sandbox `botmux send` hits relay mode (and never the host bots.json).
   const shim = join(shimBin, 'botmux');
-  // Run the relocated runtime (see /botmux-runtime binds below), NOT the cli.js
-  // at its host path — that path can be shadowed by the project clone.
-  writeFileSync(shim, `#!/bin/sh\nexec node /botmux-runtime/dist/cli.js "$@"\n`);
+  writeFileSync(shim, `#!/bin/sh\nexec node ${JSON.stringify(distCliJs())} "$@"\n`);
   chmodSync(shim, 0o755);
 
-  // Toolchain that lives under $HOME and must survive the scoped-home mask:
-  // the fnm node/CLI install + this build's dist (for the shim's cli.js).
-  const home = homedir();
-  const toolchainRo: string[] = [];
-  const nodeDir = dirname(process.execPath);                 // .../installation/bin
-  toolchainRo.push(dirname(nodeDir));                         // .../installation (node + npm-global CLIs)
-  const pkgRoot = dirname(dirname(distCliJs()));             // <build>/dist's parent (the package root)
-  // NOTE: the botmux runtime (dist / node_modules / package.json) is deliberately
-  // NOT bound here at its real pkgRoot path. It's relocated to /botmux-runtime
-  // below. Binding it at pkgRoot lets the project clone shadow it whenever a bot
-  // dogfoods botmux (workingDir == the botmux dir), which broke the `botmux send`
-  // shim (clone has no dist/node_modules — they're .gitignore'd). [B3]
-  // The CLI binary's own dir + its symlink-resolved dir. Critical: claude/coco
-  // live in ~/.local/bin (under the masked home), so without this they're not
-  // found inside the sandbox and exec fails. (codex happened to be under the
-  // fnm install above; not all CLIs are.)
-  toolchainRo.push(dirname(opts.cliBin));
-  try { toolchainRo.push(dirname(realpathSync(opts.cliBin))); } catch { /* */ }
+  // Per-bot privacy masks: existing dirs → tmpfs blank; everything else → empty
+  // read-only placeholder file. No defaults (caller passes hidePaths explicitly).
+  const hideDirs: string[] = [];
+  const hideFiles: { path: string; empty: string }[] = [];
+  let emptyIdx = 0;
+  for (const p of opts.hidePaths ?? []) {
+    if (!p || typeof p !== 'string') continue;
+    let isDir = false;
+    try { isDir = existsSync(p) && statSync(p).isDirectory(); } catch { /* */ }
+    if (isDir) {
+      hideDirs.push(p);
+    } else {
+      const empty = join(empties, `mask-${emptyIdx++}`);
+      try { writeFileSync(empty, ''); } catch { /* */ }
+      hideFiles.push({ path: p, empty });
+    }
+  }
 
-  // Mount target = the original workingDir the CLI was told about (NOT the
-  // clone source, which BOTMUX_SANDBOX_SRC may override). codex's `-C <dir>` etc.
-  // then resolve to the clone.
-  const plan: SandboxPlan = { workDir, projectMount: opts.sourceWorkingDir, scopedHome, outbox, toolchainRo, net: true };
-  const args = buildSandboxArgs(plan);
-  // Mount the shim bin at a fixed, host-absent path and prepend it to PATH.
-  args.push('--ro-bind', shimBin, '/sbxbin');
-  // Botmux runtime at a FIXED sandbox-private path (/botmux-runtime), bound LAST
-  // and at a path no user projectMount can equal — so the project clone can
-  // never shadow it (B3), and we never drop a read-only package.json onto the
-  // user's clone. The shim runs /botmux-runtime/dist/cli.js; node resolves deps
-  // from /botmux-runtime/node_modules (walk-up from dist/), and package.json
-  // gives cli.js its "type":"module". node_modules may be a symlink → the bind
-  // follows it to the real deps.
-  args.push('--ro-bind', join(pkgRoot, 'dist'), '/botmux-runtime/dist');
-  args.push('--ro-bind-try', join(pkgRoot, 'package.json'), '/botmux-runtime/package.json');
-  args.push('--ro-bind', join(pkgRoot, 'node_modules'), '/botmux-runtime/node_modules');
-  // botmux skill/plugin dir (claude `--plugin-dir` points here; carries the
-  // botmux-send etc. skills, no secrets). Re-exposed read-only on top of the
-  // masked ~/.botmux so the agent's skills load (but bots.json stays hidden).
-  const pluginDir = join(home, '.botmux', 'claude-plugin');
-  if (existsSync(pluginDir)) args.push('--ro-bind-try', pluginDir, pluginDir);
-
-  // Set the sandbox env via bwrap --setenv (authoritative for the child) rather
-  // than relying on the spawn env. The tmux backend only forwards a fixed
-  // whitelist (BOTMUX_INJECTED_ENV_KEYS) to its pane, which does NOT include
-  // HOME / PATH / BOTMUX_SEND_RELAY — so without --setenv the sandbox would only
-  // work under the pty backend. --setenv makes pty AND tmux both work.
-  const env: Record<string, string> = {
-    HOME: home,                          // scoped home is mounted AT the real home path
-    BOTMUX_SEND_RELAY: outbox,           // routes `botmux send` to the daemon outbox watcher
-    PATH: `/sbxbin:${process.env.PATH ?? ''}`,  // /sbxbin first so `botmux` = the relay shim
+  const plan: SandboxPlan = {
+    projectMount,
+    projectMerged: projMerged,
+    home,
+    homeMerged,
+    outbox,
+    hideDirs,
+    hideFiles,
+    net: true,
   };
+  const args = buildSandboxArgs(plan);
+  // Shim bin at a fixed path UNDER the /run tmpfs — the whole real fs is bound
+  // read-only (`--ro-bind / /`), so bwrap can't mkdir a new mountpoint at the
+  // root (/sbxbin) → it must live under a writable tmpfs (/run). PATH points here.
+  args.push('--ro-bind', shimBin, '/run/sbxbin');
+  // botmux skill/plugin dir (claude `--plugin-dir` points here; carries the
+  // botmux-send etc. skills, no secrets). Re-exposed read-only at its real path.
+  const pluginDir = join(home, '.botmux', 'claude-plugin');
+  args.push('--ro-bind-try', pluginDir, pluginDir);
+
+  // Authoritative child env via bwrap --setenv (works on pty AND tmux — the tmux
+  // backend only forwards a fixed whitelist, which excludes HOME/PATH/relay).
+  const env: Record<string, string> = {
+    HOME: home,                                      // home overlay is bound AT the real home path
+    BOTMUX_SEND_RELAY: outbox,                       // routes `botmux send` to the daemon outbox watcher
+    PATH: `/run/sbxbin:${process.env.PATH ?? ''}`,   // /run/sbxbin first so `botmux` = the relay shim
+  };
+  // Forward proxy vars so the CLI reaches the API on the tmux backend too.
+  for (const k of PROXY_ENV_KEYS) {
+    const v = process.env[k];
+    if (typeof v === 'string' && v) env[k] = v;
+  }
   for (const [k, v] of Object.entries(env)) args.push('--setenv', k, v);
   args.push('--', opts.cliBin, ...opts.cliArgs);
 
@@ -402,9 +281,107 @@ export function prepareSandbox(opts: {
     args,
     env,
     outbox,
-    workDir,
-    cleanup: () => { try { rmSync(root, { recursive: true, force: true }); } catch { /* */ } },
+    workDir: projUpper,
+    cleanup: () => {
+      unmountOverlay(projMerged);
+      unmountOverlay(homeMerged);
+      try { rmSync(sessionRoot, { recursive: true, force: true }); } catch { /* */ }
+      try { rmSync(vartmp, { recursive: true, force: true }); } catch { /* */ }
+    },
   };
+}
+
+/**
+ * Re-attach the daemon/worker side to an ALREADY-spawned sandbox session WITHOUT
+ * touching the overlays. Used on daemon-restart reattach to a persistent
+ * (tmux/herdr/zellij) pane whose bwrap'd CLI is still alive: the CLI is bound to
+ * its own namespace-pinned overlay, so we must NOT unmount/remount (that would
+ * leave a duplicate host-side mount the CLI isn't using). We only need the outbox
+ * path back so the watcher can keep servicing the live CLI's `botmux send`, plus
+ * the workDir (upper changeset for landing) and a cleanup that tears the residue
+ * down at close/exit. Returns null if the session has no sandbox tree on disk
+ * (never sandboxed). Linux-only, mirrors prepareSandbox's layout.
+ */
+export function attachSandboxOutbox(opts: { sessionId: string; dataDir: string }): { outbox: string; workDir: string; cleanup: () => void } | null {
+  if (process.platform !== 'linux') return null;
+  const sessionRoot = join(opts.dataDir, 'sandboxes', opts.sessionId);
+  const outbox = join(sessionRoot, 'outbox');
+  const projUpper = join(sessionRoot, 'proj-upper');
+  if (!existsSync(outbox) && !existsSync(projUpper)) return null; // never sandboxed
+  // Ensure the outbox exists (the watcher reads it); never (re)mount here.
+  try { mkdirSync(outbox, { recursive: true }); } catch { /* */ }
+  const projMerged = join(sessionRoot, 'proj-merged');
+  const homeMerged = join(sessionRoot, 'home-merged');
+  const vartmp = join(VARTMP_ROOT, opts.sessionId);
+  return {
+    outbox,
+    workDir: projUpper,
+    cleanup: () => {
+      unmountOverlay(projMerged);
+      unmountOverlay(homeMerged);
+      try { rmSync(sessionRoot, { recursive: true, force: true }); } catch { /* */ }
+      try { rmSync(vartmp, { recursive: true, force: true }); } catch { /* */ }
+    },
+  };
+}
+
+/** Reclaim one session's overlay residue: unmount both merged overlays + rm the
+ *  per-session tree (incl. the /var/tmp home scratch). Idempotent / best-effort. */
+function reclaimSandbox(dataDir: string, sid: string): void {
+  const sessionRoot = join(dataDir, 'sandboxes', sid);
+  unmountOverlay(join(sessionRoot, 'proj-merged'));
+  unmountOverlay(join(sessionRoot, 'home-merged'));
+  try { rmSync(sessionRoot, { recursive: true, force: true }); } catch { /* */ }
+  try { rmSync(join(VARTMP_ROOT, sid), { recursive: true, force: true }); } catch { /* */ }
+}
+
+/**
+ * Reclaim leaked sandbox residue.
+ *
+ * Two classes of leak are reclaimed:
+ *  1. NON-ACTIVE orphans — sid not in `activeSessionIds`: the session is gone, so
+ *     any leftover mount/dir is pure residue (the original startup-sweep case,
+ *     guarding against a daemon crash/kill that skipped killCli()).
+ *  2. ACTIVE-but-DEAD — sid IS in `activeSessionIds`, yet NEITHER of its merged
+ *     overlays is still mounted. This closes the blind spot where a sandboxed
+ *     worker was SIGKILL'd (straggler reaper) or crashed: the session stays
+ *     status='active' on disk, so the old "skip if active" rule would let the
+ *     leaked upper/work dirs survive across restarts indefinitely. We only GC an
+ *     active sid when its mounts are ALREADY gone — we NEVER tear down a live
+ *     mount (a CLI persisting in a tmux/herdr/zellij pane is still bound to it),
+ *     so a genuinely-live persistent session keeps its changeset.
+ *
+ * Safe to call repeatedly: wire once at daemon bootstrap AND on a periodic timer
+ * (the SIGKILL/straggler path can't run worker-side killCli(), so a startup-only
+ * sweep would let a crashed-active session's mount survive for the whole next
+ * daemon lifetime — one daemon per bot can run for days).
+ */
+export function sweepOrphanSandboxes(dataDir: string, activeSessionIds: Set<string>): void {
+  const root = join(dataDir, 'sandboxes');
+  let sids: string[] = [];
+  try { sids = readdirSync(root); } catch { return; } // no sandboxes dir yet
+  // Grace before reclaiming an ACTIVE-but-unmounted sandbox: a worker that just
+  // (re)spawned creates the outbox/shimbin dirs a few syscalls BEFORE it mounts
+  // the overlay. Without this, a sweep firing in that tiny window would nuke an
+  // in-progress session's outbox. Non-active orphans are reclaimed immediately
+  // (no live worker can be mid-spawn for a session that isn't active).
+  const ACTIVE_DEAD_GRACE_MS = 60_000;
+  const now = Date.now();
+  for (const sid of sids) {
+    const sessionRoot = join(root, sid);
+    if (activeSessionIds.has(sid)) {
+      // Active session: keep it while a host-side overlay is still mounted (= a
+      // live CLI may be bound to the changeset). If BOTH merged overlays are gone
+      // AND the tree is older than the spawn grace, the worker/CLI is dead →
+      // reclaim the dead residue. We NEVER tear down a live mount, so a genuinely
+      // live persistent (tmux/herdr/zellij) session keeps its changeset.
+      if (isMounted(join(sessionRoot, 'proj-merged')) || isMounted(join(sessionRoot, 'home-merged'))) continue;
+      let ageOk = false;
+      try { ageOk = now - statSync(sessionRoot).mtimeMs > ACTIVE_DEAD_GRACE_MS; } catch { ageOk = false; }
+      if (!ageOk) continue; // too fresh — could be a worker mid-spawn
+    }
+    reclaimSandbox(dataDir, sid);
+  }
 }
 
 // Relay request schema (written by cli.ts relaySend, validated here). The
@@ -454,6 +431,10 @@ export function validateRelayRequest(req: RelayRequest): { ok: true; value: Vali
     if (RELAY_FLAGS_VAL.has(f)) {
       const v = rawFlags[i + 1];
       if (typeof v !== 'string') return { ok: false, error: `flag ${f} needs a string value` };
+      // The value must NOT itself be a flag — else a sandbox could pass
+      // ['--mention','--session-id'] and have --session-id swallowed as the
+      // value, corrupting the worker-forced session-id (self-DoS).
+      if (v.startsWith('--')) return { ok: false, error: `flag ${f} value must not be a flag` };
       flags.push(f, v); i++; continue;
     }
     return { ok: false, error: `flag not allowed: ${f}` };
@@ -464,14 +445,19 @@ export function validateRelayRequest(req: RelayRequest): { ok: true; value: Vali
 /**
  * TOCTOU-safe copy of an outbox file (`outbox/<name>`, name already validated as
  * a plain basename) into a host-private `dest`. Opens with O_NOFOLLOW so a
- * symlink swapped in by the sandbox AFTER validation is rejected at open time;
- * reads from the fd (not the path), so the inode can't be swapped under us.
- * Returns false (reject) on symlink / non-regular / any error.
+ * symlink swapped in by the sandbox AFTER validation is rejected at open time,
+ * and O_NONBLOCK so opening a FIFO/special the sandbox dropped into the (rw-bound)
+ * outbox returns IMMEDIATELY instead of blocking the synchronous watcher tick
+ * forever (a FIFO with no writer would otherwise hang the whole worker event
+ * loop — an agent-triggerable DoS). After open we fstat-reject anything that
+ * isn't a regular file (a FIFO opened O_NONBLOCK|O_RDONLY succeeds but isFile()
+ * is false → rejected here). Reads from the fd (not the path), so the inode can't
+ * be swapped under us. Returns false (reject) on symlink / non-regular / any error.
  */
 export function materializeOutboxFile(outbox: string, name: string, dest: string): boolean {
   let fd: number;
-  try { fd = openSync(join(outbox, name), fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW); }
-  catch { return false; }  // symlink (ELOOP) or missing
+  try { fd = openSync(join(outbox, name), fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK); }
+  catch { return false; }  // symlink (ELOOP), FIFO w/o writer is non-blocking now, or missing
   let outFd: number | null = null;
   try {
     if (!fstatSync(fd).isFile()) return false;  // reject dir/fifo/device/etc.

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -73,6 +73,13 @@ export interface BotConfig {
    * forces it on regardless (testing).
    */
   sandbox?: boolean;
+  /**
+   * Per-bot privacy masks for the sandbox: absolute paths blanked inside the
+   * overlay sandbox (dirs → empty tmpfs; files → empty placeholder). OPT-IN with
+   * NO defaults — the agent reads the entire real fs natively unless a path is
+   * listed here. Only meaningful when `sandbox` is true. Linux-only.
+   */
+  sandboxHidePaths?: string[];
   backendType?: BackendType;
   workingDir?: string;
   workingDirs?: string[];
@@ -660,6 +667,9 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
         : undefined,
       disableCliBypass: entry.disableCliBypass === true,
       sandbox: entry.sandbox === true,
+      sandboxHidePaths: Array.isArray(entry.sandboxHidePaths)
+        ? entry.sandboxHidePaths.filter((p: unknown): p is string => typeof p === 'string' && !!p.trim())
+        : [],
       backendType: entry.backendType,
       workingDir: workingDirs?.[0] ?? entry.workingDir,
       workingDirs,

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -2,7 +2,7 @@
  * Command handler — processes /slash commands from users.
  * Extracted from daemon.ts for modularity.
  */
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { join, resolve, basename } from 'node:path';
 import { config } from '../config.js';
 import { buildTerminalUrl } from './terminal-url.js';
@@ -14,7 +14,7 @@ import { scanProjects, scanMultipleProjects, describeProjectDir } from '../servi
 import { buildRepoSelectCard, buildAdoptSelectCard, buildCodexAppThreadSelectCard, buildSessionClosedCard, buildSlashListCard, getCliDisplayName, buildConfigCard, buildLandCard } from '../im/lark/card-builder.js';
 import { computeSandboxDiff } from '../services/sandbox-land.js';
 import { createCliAdapterSync } from '../adapters/cli/registry.js';
-import { deleteMessage, sendMessage, sendUserMessage, listChatBotMembers, resolveUserUnionId, getChatModeStrict } from '../im/lark/client.js';
+import { deleteMessage, sendMessage, sendUserMessage, listChatBotMembers, resolveUserUnionId, getChatModeStrict, uploadFile } from '../im/lark/client.js';
 import { chatAppLink, normalizeBrand } from '../im/lark/lark-hosts.js';
 import { claimPairing } from '../services/pairing-store.js';
 import { logger } from '../utils/logger.js';
@@ -865,11 +865,29 @@ export async function handleCommand(
         const d = computeSandboxDiff(config.session.dataDir, sid, loc);
         if (!d.ok) { await sessionReply(rootId, t('cmd.land.cannot', { error: d.error }, loc)); break; }
         if (d.empty) { await sessionReply(rootId, t('cmd.land.empty', undefined, loc)); break; }
-        const lines = d.patch.split('\n');
-        const preview = lines.slice(0, 40).join('\n') + (lines.length > 40 ? '\n…' : '');
-        const card = buildLandCard({ sessionId: sid, workingDir: wd, statText: d.statText, files: d.files, insertions: d.insertions, deletions: d.deletions, preview }, loc);
+        // In-card preview: cap by lines AND chars (Lark card size limit); the FULL
+        // diff goes to an attached .patch file (better for large changesets).
+        const MAX_LINES = 60, MAX_CHARS = 4000;
+        const allLines = d.patch.split('\n');
+        let preview = allLines.slice(0, MAX_LINES).join('\n');
+        let truncated = allLines.length > MAX_LINES;
+        if (preview.length > MAX_CHARS) { preview = preview.slice(0, MAX_CHARS); truncated = true; }
+        // Attach the full .patch (git apply-able) — sent as a file message first,
+        // then the review card below it.
+        let patchAttached = false;
+        if (larkAppId) {
+          try {
+            const patchName = `botmux-land-${sid.slice(0, 8)}.patch`;
+            const patchPath = join(config.session.dataDir, 'sandboxes', sid, patchName);
+            writeFileSync(patchPath, d.patch);
+            const fileKey = await uploadFile(larkAppId, patchPath);
+            await sendMessage(larkAppId, ds.session.chatId, JSON.stringify({ file_key: fileKey }), 'file');
+            patchAttached = true;
+          } catch (e) { logger.warn(`[${logTag}] /land patch attach failed: ${(e as Error).message}`); }
+        }
+        const card = buildLandCard({ sessionId: sid, workingDir: wd, statText: d.statText, files: d.files, insertions: d.insertions, deletions: d.deletions, preview, truncated, patchAttached }, loc);
         await sessionReply(rootId, card, 'interactive');
-        logger.info(`[${logTag}] /land: ${d.files} files (+${d.insertions}/-${d.deletions}) → review card`);
+        logger.info(`[${logTag}] /land: ${d.files} files (+${d.insertions}/-${d.deletions}) → card${patchAttached ? ' + .patch' : ''}`);
         break;
       }
 

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -164,7 +164,7 @@ ipcRoute('POST', '/api/sessions/:sessionId/sandbox-land/:action', (_req, res, pa
   const d = computeSandboxDiff(config.session.dataDir, params.sessionId, locLand);
   if (!d.ok) return jsonRes(res, 200, { ok: false, error: d.error });
   if (d.empty) return jsonRes(res, 200, { ok: false, error: t('sandbox.no_changes_left', undefined, locLand) });
-  const a = applySandboxDiff(wd, d.patch, locLand);
+  const a = applySandboxDiff(wd, config.session.dataDir, params.sessionId, locLand);
   jsonRes(res, 200, a.ok ? { ok: true, files: d.files, insertions: d.insertions, deletions: d.deletions, workingDir: wd } : { ok: false, error: a.error });
 });
 

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1279,6 +1279,22 @@ export function forkWorker(ds: DaemonSession, prompt: string, resume = false): v
   const cwd = rawCwd && existsSync(rawCwd) ? rawCwd : homedir();
   if (cwd !== rawCwd) logger.warn(`[${t}] workingDir "${rawCwd}" does not exist — falling back to ${cwd}`);
 
+  // Sandbox decision is RECORDED ON THE SESSION at creation and reused on
+  // restore — so toggling the live bot flag never retroactively (un)sandboxes a
+  // historical session. A brand-new session (resume=false) with no recorded
+  // decision adopts the live bot flag; a restore (resume=true) with no recorded
+  // decision predates the sandbox feature → stays NOT sandboxed.
+  if (ds.session.sandbox === undefined) {
+    if (!resume) {
+      ds.session.sandbox = botCfg.sandbox === true;
+      ds.session.sandboxHidePaths = botCfg.sandboxHidePaths ?? [];
+    } else {
+      ds.session.sandbox = false;
+      ds.session.sandboxHidePaths = [];
+    }
+    sessionStore.updateSession(ds.session);
+  }
+
   // Guard against double-fork: if a worker is already running, kill it first
   if (ds.worker && !ds.worker.killed) {
     logger.warn(`[${t}] Worker already running (pid: ${ds.worker.pid}), killing before re-fork`);
@@ -1352,7 +1368,10 @@ export function forkWorker(ds: DaemonSession, prompt: string, resume = false): v
     cliPathOverride: botCfg.cliPathOverride,
     model: botCfg.model,
     disableCliBypass: botCfg.disableCliBypass === true,
-    sandbox: botCfg.sandbox === true,
+    // Use the decision recorded on the session (above), NOT the live bot flag, so
+    // historical sessions never get retroactively sandboxed on restart.
+    sandbox: ds.session.sandbox === true,
+    sandboxHidePaths: ds.session.sandboxHidePaths ?? [],
     backendType: botCfg.backendType ?? config.daemon.backendType,
     prompt,
     resume,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -84,6 +84,7 @@ import {
   ensureTerminalWorkerPort,
 } from './core/session-manager.js';
 import { beginReplyTargetTurn, resolveSessionReplyTarget, syncReplyTargetState } from './core/reply-target.js';
+import { sweepOrphanSandboxes } from './adapters/backend/sandbox.js';
 import { sweepIdleWorkers } from './core/idle-worker-sweeper.js';
 import { handleCardAction } from './im/lark/card-handler.js';
 import type { CardHandlerDeps } from './im/lark/card-handler.js';
@@ -3382,6 +3383,16 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   // Restore active sessions from previous run
   await restoreActiveSessions(activeSessions);
 
+  // Sweep orphan sandbox overlays left by a previous run's crash/kill: any
+  // <dataDir>/sandboxes/<sid> whose session is no longer active gets its
+  // overlays unmounted and its dirs removed (plus the /var/tmp home scratch).
+  // Active sessions keep theirs — a same-topic worker reuses the upper changeset.
+  try {
+    sweepOrphanSandboxes(config.session.dataDir, new Set([...activeSessions.values()].map(ds => ds.session.sessionId)));
+  } catch (err: any) {
+    logger.warn(`[sandbox-sweep] failed: ${err?.message ?? err}`);
+  }
+
   const idleWorkerSweepTimer = setInterval(() => {
     const suspended = sweepIdleWorkers(activeSessions);
     if (suspended.length > 0) {
@@ -3389,6 +3400,22 @@ export async function startDaemon(botIndex?: number): Promise<void> {
     }
   }, 60_000);
   idleWorkerSweepTimer.unref?.();
+
+  // Periodic sandbox reconciler: the daemon's SIGKILL straggler-reaper (and any
+  // worker SIGKILL) bypasses worker-side killCli(), so the overlay mounts +
+  // upper/work dirs of a killed-but-still-active sandboxed session would leak for
+  // the rest of this daemon's lifetime (one daemon per bot can run for days). The
+  // startup sweep alone can't catch a session that dies AFTER boot. This re-runs
+  // the sweep on a timer: it reclaims active sessions whose overlays are already
+  // unmounted (= worker/CLI dead) without ever tearing down a live mount.
+  const sandboxReconcileTimer = setInterval(() => {
+    try {
+      sweepOrphanSandboxes(config.session.dataDir, new Set([...activeSessions.values()].map(ds => ds.session.sessionId)));
+    } catch (err: any) {
+      logger.warn(`[sandbox-reconcile] failed: ${err?.message ?? err}`);
+    }
+  }, 120_000);
+  sandboxReconcileTimer.unref?.();
 
   await attachColdWorkflowRuns(cfg.larkAppId);
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -696,12 +696,12 @@ export const messages: Record<string, string> = {
   'daemon.auto_start_member_read_failed': '⚠️ botmux “auto-start when added to a new chat” is on, but reading the chat members failed, so it can’t tell whether any authorized user is present — auto-start was skipped.\n\nMost likely cause: missing permission to read chat members (im:chat / chat info), or the “bot added to chat” event `im.chat.member.bot.added_v1` isn’t subscribed.\n\nGo to the Lark Open Platform → your app → Permissions / Event subscriptions to add them, then `botmux restart`.\n\nDetails: {detail}',
 
   // Sandbox landing (/land) errors
-  'sandbox.no_clone': 'This session has no sandbox copy (sandbox off, or the copy was cleaned up).',
-  'sandbox.clone_not_git': 'The sandbox copy isn’t a git repo; diff landing isn’t supported yet.',
+  'sandbox.no_clone': 'This session has no sandbox change layer (sandbox off, or the layer was cleaned up).',
+  'sandbox.clone_not_git': 'The sandbox change layer is unavailable; landing isn’t supported.',
   'sandbox.nothing_to_land': 'No changes to land.',
-  'sandbox.target_not_git': 'Landing target isn’t a git repo: {dir}',
-  'sandbox.apply_failed': 'git apply failed (may conflict with the current repo state; manual merge needed): {detail}',
-  'sandbox.diff_failed': 'git diff failed: {detail}',
+  'sandbox.target_not_git': 'Landing target directory does not exist: {dir}',
+  'sandbox.apply_failed': 'Landing failed: {detail}',
+  'sandbox.diff_failed': 'Reading sandbox changes failed: {detail}',
   'sandbox.workingdir_not_found': 'Session workingDir not found',
-  'sandbox.no_changes_left': 'The sandbox copy has no changes left',
+  'sandbox.no_changes_left': 'The sandbox change layer has no changes left',
 };

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -75,6 +75,8 @@ export const messages: Record<string, string> = {
   'card.land.body': 'The sandbox session produced **{files}** changed file(s) (**+{ins} / -{del}**).\nTarget: `{dir}`\n\nReview the diff below; "Apply to disk" will `git apply` these changes back to the real repo.',
   'card.land.files_header': 'Changed files',
   'card.land.preview_header': 'Diff preview',
+  'card.land.truncated': 'Preview truncated — full diff in the attached .patch file',
+  'card.land.patch_note': 'Full .patch attached (git apply-able)',
   'card.land.btn_apply': 'Apply to disk',
   'card.land.btn_discard': 'Discard',
   'card.land.note': 'Owner-only; changes come from an isolated clone — the real repo is untouched until you apply.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -699,12 +699,12 @@ export const messages: Record<string, string> = {
   'daemon.auto_start_member_read_failed': '⚠️ botmux「被拉进新群自动开工」已开启，但读取群成员失败，无法判断群里是否有授权用户，自动开工被跳过。\n\n最可能原因：缺少读取群成员的权限（im:chat / 群信息读取），或没有订阅「机器人进群」事件 `im.chat.member.bot.added_v1`。\n\n请到飞书开放平台 → 应用 → 权限管理 / 事件订阅 里补齐，然后 `botmux restart`。\n\n错误详情：{detail}',
 
   // Sandbox landing (/land) errors
-  'sandbox.no_clone': '该会话没有沙盒副本（未开沙盒，或副本已清理）',
-  'sandbox.clone_not_git': '沙盒副本不是 git 仓库，暂不支持 diff 落盘',
+  'sandbox.no_clone': '该会话没有沙盒改动层（未开沙盒，或改动层已清理）',
+  'sandbox.clone_not_git': '沙盒改动层不可用，暂不支持落盘',
   'sandbox.nothing_to_land': '没有改动可落盘',
-  'sandbox.target_not_git': '落盘目标不是 git 仓库：{dir}',
-  'sandbox.apply_failed': 'git apply 失败（可能与当前仓库状态冲突，需手动合并）：{detail}',
-  'sandbox.diff_failed': 'git diff 失败：{detail}',
+  'sandbox.target_not_git': '落盘目标目录不存在：{dir}',
+  'sandbox.apply_failed': '落盘失败：{detail}',
+  'sandbox.diff_failed': '读取沙盒改动失败：{detail}',
   'sandbox.workingdir_not_found': '找不到会话 workingDir',
-  'sandbox.no_changes_left': '沙盒副本已无改动',
+  'sandbox.no_changes_left': '沙盒改动层已无改动',
 };

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -78,6 +78,8 @@ export const messages: Record<string, string> = {
   'card.land.body': '沙盒会话产生了 **{files}** 个文件改动（**+{ins} / -{del}**）。\n落盘目标：`{dir}`\n\n审阅下方 diff，确认后「应用到磁盘」会把这些改动 `git apply` 回真实仓库。',
   'card.land.files_header': '改动文件',
   'card.land.preview_header': 'diff 预览',
+  'card.land.truncated': '预览已截断，完整改动见下方 .patch 文件',
+  'card.land.patch_note': '已附完整 .patch 文件（可 git apply）',
   'card.land.btn_apply': '应用到磁盘',
   'card.land.btn_discard': '丢弃',
   'card.land.note': '仅 owner 可应用；改动来自隔离副本，应用前真实仓库不受影响。',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -1707,15 +1707,24 @@ export interface LandCardOpts {
   files: number;
   insertions: number;
   deletions: number;
-  preview: string;   // truncated patch text
+  preview: string;        // patch text for the in-card preview (already truncated)
+  truncated?: boolean;    // preview was cut → full diff is in the attached .patch
+  patchAttached?: boolean; // a .patch file message accompanies this card
 }
 
 export function buildLandCard(o: LandCardOpts, locale?: Locale): string {
   const v = { sessionId: o.sessionId, workingDir: o.workingDir };
   const body = t('card.land.body', { files: o.files, ins: o.insertions, del: o.deletions, dir: escapeMd(o.workingDir) }, locale);
   const elements: any[] = [{ tag: 'div', text: { tag: 'lark_md', content: body } }];
-  if (o.statText) elements.push({ tag: 'div', text: { tag: 'lark_md', content: `**${t('card.land.files_header', undefined, locale)}**\n` + '```\n' + o.statText.slice(0, 1500) + '\n```' } });
-  if (o.preview) elements.push({ tag: 'div', text: { tag: 'lark_md', content: `**${t('card.land.preview_header', undefined, locale)}**\n` + '```diff\n' + o.preview + '\n```' } });
+  // Use the card v2 `markdown` element (NOT a lark_md div) for the stat + diff —
+  // it renders ``` fenced code blocks as real monospace blocks, which lark_md
+  // divs do not. Paths are already project-relative (computeSandboxDiff).
+  if (o.statText) elements.push({ tag: 'markdown', content: `**${t('card.land.files_header', undefined, locale)}**\n` + '```text\n' + o.statText.slice(0, 2000) + '\n```' });
+  if (o.preview) {
+    const note = o.truncated ? `\n\n_${t('card.land.truncated', undefined, locale)}_` : '';
+    elements.push({ tag: 'markdown', content: `**${t('card.land.preview_header', undefined, locale)}**\n` + '```diff\n' + o.preview + '\n```' + note });
+  }
+  if (o.patchAttached) elements.push({ tag: 'note', elements: [{ tag: 'lark_md', content: t('card.land.patch_note', undefined, locale) }] });
   elements.push(
     { tag: 'hr' },
     { tag: 'action', actions: [

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -179,7 +179,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     const d = computeSandboxDiff(config.session.dataDir, sid, loc);
     if (!d.ok) return JSON.parse(buildLandResultCard('failed', d.error, loc));
     if (d.empty) return JSON.parse(buildLandResultCard('discarded', '', loc));
-    const a = applySandboxDiff(wd, d.patch, loc);
+    const a = applySandboxDiff(wd, config.session.dataDir, sid, loc);
     if (!a.ok) return JSON.parse(buildLandResultCard('failed', a.error, loc));
     logger.info(`Land applied: ${d.files} files (+${d.insertions}/-${d.deletions}) → ${wd}`);
     return JSON.parse(buildLandResultCard('applied', t('card.land.applied_body', { files: d.files, ins: d.insertions, del: d.deletions, dir: wd }, loc), loc));

--- a/src/services/sandbox-land.ts
+++ b/src/services/sandbox-land.ts
@@ -1,81 +1,334 @@
 /**
- * Sandbox landing: compute the diff the (oblivious) sandboxed agent produced in
- * its per-session clone, and apply it back to the real source repo on the
- * owner's confirmation. Owner-triggered only (via the `/land` command or the
- * dashboard button) — the agent in the sandbox can't see that it's a clone.
+ * Sandbox landing (overlayfs model): the project overlay UPPER dir IS the
+ * changeset the sandboxed agent produced. We compute a human-readable diff from
+ * it (preview/patch via `git diff --no-index` against the real project), and on
+ * the owner's confirmation copy the changed files back into the real project.
  *
- * The clone is a `git clone` of the source; cloneProject records its base
- * commit in <sandboxRoot>/clone-base. The diff = everything (committed + staged
- * + untracked) in the clone vs that base. Apply = `git apply --3way` onto the
- * real repo (so it tolerates the source having moved on since the clone).
+ * The agent in the sandbox is oblivious it's overlaid — it thinks it edits the
+ * real files. So landing is owner-triggered only (the `/land` command or the
+ * dashboard button), never by the agent.
+ *
+ * Upper-layer semantics (overlayfs):
+ *   - a regular file in upper           → a new-or-modified file
+ *   - a symlink in upper                → a symlink the agent created/changed
+ *   - a character device with rdev 0    → a WHITEOUT (the agent deleted the file)
+ *   - a dir with xattr trusted.overlay.opaque=y → the dir's lower contents are
+ *     hidden. NOTE: overlayfs sets this xattr on BOTH a freshly-created dir AND a
+ *     wholesale-replaced dir, so opacity ALONE cannot tell "new" from "replaced".
+ *     The real discriminator is whether the dir also exists in the lower (= the
+ *     target). We therefore only treat an opaque dir as a wholesale REPLACE (drop
+ *     the lower's stale contents) when it ALSO exists in the target; a purely-new
+ *     opaque dir is just mkdir'd — never rm -rf'd over unrelated real files.
  */
-import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync, readdirSync, lstatSync, copyFileSync, mkdirSync, rmSync, readFileSync,
+  readlinkSync, symlinkSync, unlinkSync,
+} from 'node:fs';
+import { join, dirname, relative } from 'node:path';
 import { t, type Locale } from '../i18n/index.js';
 
 export interface LandDiff {
   ok: true;
   empty: boolean;
   patch: string;
-  statText: string;   // `git diff --stat` (file list + per-file +/-)
+  statText: string;   // file list + per-file change kind
   files: number;
   insertions: number;
   deletions: number;
 }
 export interface LandError { ok: false; error: string }
 
-function cloneDir(dataDir: string, sessionId: string): string {
-  return join(dataDir, 'sandboxes', sessionId, 'work');
+/** One change the agent made, derived from the overlay upper layer. */
+interface UpperChange {
+  /** Path relative to the project root. */
+  rel: string;
+  /** file = regular file; symlink = a link (target in `linkTarget`); delete = a
+   *  whiteout; opaque = an opaque dir (REPLACE iff it also exists in the target). */
+  kind: 'file' | 'symlink' | 'delete' | 'opaque';
+  /** Symlink target string (only for kind:'symlink'). */
+  linkTarget?: string;
 }
 
-/** Compute the agent's changes in the session's sandbox clone vs the clone base. */
-export function computeSandboxDiff(dataDir: string, sessionId: string, locale?: Locale): LandDiff | LandError {
-  const clone = cloneDir(dataDir, sessionId);
-  if (!existsSync(clone)) return { ok: false, error: t('sandbox.no_clone', undefined, locale) };
-  if (!existsSync(join(clone, '.git'))) return { ok: false, error: t('sandbox.clone_not_git', undefined, locale) };
-  const baseFile = join(dirname(clone), 'clone-base');
-  const base = existsSync(baseFile) ? readFileSync(baseFile, 'utf8').trim() : 'HEAD';
+/** Locate the project overlay UPPER dir (= SandboxSpawn.workDir) for a session. */
+export function upperDir(dataDir: string, sessionId: string): string {
+  return join(dataDir, 'sandboxes', sessionId, 'proj-upper');
+}
+
+/**
+ * The project LOWER source recorded by prepareSandbox at create time (meta.json).
+ * Used to tell a wholesale-REPLACED opaque dir (existed in the lower) from a
+ * purely-NEW opaque dir (didn't) — overlayfs marks BOTH opaque, so the lower is
+ * the only reliable discriminator, and the LIVE landing target may have drifted
+ * (concurrent work) so we must NOT use it for this. Returns '' when unknown
+ * (older session / meta missing) → callers fall back to the target.
+ */
+function projectLower(dataDir: string, sessionId: string): string {
   try {
-    // Stage everything (incl. untracked/deleted) so the diff captures it all.
-    execFileSync('git', ['-C', clone, 'add', '-A'], { stdio: 'ignore' });
-    const patch = execFileSync('git', ['-C', clone, 'diff', '--cached', '--binary', base], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
-    const statText = execFileSync('git', ['-C', clone, 'diff', '--cached', '--stat', base], { encoding: 'utf8', maxBuffer: 4 * 1024 * 1024 }).trim();
-    const shortstat = execFileSync('git', ['-C', clone, 'diff', '--cached', '--shortstat', base], { encoding: 'utf8' }).trim();
-    return {
-      ok: true,
-      empty: patch.trim() === '',
-      patch,
-      statText,
-      files: Number(shortstat.match(/(\d+) files? changed/)?.[1] ?? 0),
-      insertions: Number(shortstat.match(/(\d+) insertion/)?.[1] ?? 0),
-      deletions: Number(shortstat.match(/(\d+) deletion/)?.[1] ?? 0),
-    };
-  } catch (e: any) {
-    return { ok: false, error: t('sandbox.diff_failed', { detail: (e?.stderr ?? e?.message ?? e).toString().slice(0, 300) }, locale) };
+    const meta = JSON.parse(readFileSync(join(dataDir, 'sandboxes', sessionId, 'meta.json'), 'utf8'));
+    return typeof meta?.projectLower === 'string' ? meta.projectLower : '';
+  } catch { return ''; }
+}
+
+/** True if a path is an overlayfs whiteout (char device, rdev 0). */
+function isWhiteout(p: string): boolean {
+  try {
+    const st = lstatSync(p);
+    return st.isCharacterDevice() && st.rdev === 0;
+  } catch { return false; }
+}
+
+/**
+ * Read the overlay opaque xattr for a dir.
+ *   - 'y'   → the dir is opaque
+ *   - ''    → the dir is present and NOT opaque (xattr absent)
+ *   - null  → could NOT determine (no xattr tooling available / read failed)
+ *
+ * `getfattr` is provided by the `attr` package and is frequently NOT installed;
+ * `trusted.overlay.*` also requires CAP_SYS_ADMIN to read (we run as root). We
+ * try getfattr first, then python3's os.getxattr (commonly present), and return
+ * null when neither can answer — callers must NOT silently treat null as "not
+ * opaque" (that would leak stale lower files); they fail-closed where it matters.
+ */
+function readOpaqueXattr(p: string): 'y' | '' | null {
+  // getfattr (attr package). --only-values prints just the value; ENOATTR → exit≠0.
+  const gf = spawnSync('getfattr', ['-n', 'trusted.overlay.opaque', '--only-values', '-h', p], { encoding: 'utf8' });
+  if (gf.error == null && typeof gf.status === 'number') {
+    if (gf.status === 0) return (gf.stdout ?? '').trim() === 'y' ? 'y' : '';
+    // exit≠0 with stderr mentioning "No such attribute"/ENOATTR → present, not opaque.
+    const se = (gf.stderr ?? '').toLowerCase();
+    if (se.includes('no such attribute') || se.includes('enoattr') || se.includes('not found')) return '';
+    // other failure (e.g. permission) → fall through to python.
   }
+  // python3's os.getxattr — exit 0 + 'y' on stdout when opaque; exit 0 + '' when
+  // the attr is absent; exit 2 only if python itself is unavailable.
+  const py = spawnSync('python3', [
+    '-c',
+    "import os,sys\n" +
+    "try:\n" +
+    " v=os.getxattr(sys.argv[1],'trusted.overlay.opaque')\n" +
+    " sys.stdout.write(v.decode('latin1','replace'))\n" +
+    "except OSError as e:\n" +
+    " import errno\n" +
+    " sys.exit(0) if e.errno in (errno.ENODATA,errno.ENOATTR if hasattr(errno,'ENOATTR') else errno.ENODATA) else sys.exit(3)\n",
+    p,
+  ], { encoding: 'utf8' });
+  if (py.error == null && py.status === 0) return (py.stdout ?? '').trim() === 'y' ? 'y' : '';
+  return null; // undeterminable
 }
 
-/** Apply a sandbox patch onto the real target repo (the session's workingDir). */
-export function applySandboxDiff(targetDir: string, patch: string, locale?: Locale): { ok: true } | LandError {
-  if (!patch.trim()) return { ok: false, error: t('sandbox.nothing_to_land', undefined, locale) };
-  if (!existsSync(join(targetDir, '.git'))) return { ok: false, error: t('sandbox.target_not_git', { dir: targetDir }, locale) };
-  const dir = mkdtempSync(join(tmpdir(), 'sbx-land-'));
-  const patchFile = join(dir, 'changes.patch');
-  writeFileSync(patchFile, patch);
-  try {
-    // --3way tolerates the source repo having advanced since the clone.
-    execFileSync('git', ['-C', targetDir, 'apply', '--3way', '--whitespace=nowarn', patchFile], { stdio: 'pipe' });
-    return { ok: true };
-  } catch {
-    try {
-      execFileSync('git', ['-C', targetDir, 'apply', '--whitespace=nowarn', patchFile], { stdio: 'pipe' });
-      return { ok: true };
-    } catch (e2: any) {
-      return { ok: false, error: t('sandbox.apply_failed', { detail: (e2?.stderr ?? e2?.message ?? e2).toString().slice(0, 400) }, locale) };
+/** Walk the upper layer, classifying every entry into an UpperChange. */
+function walkUpper(upper: string): UpperChange[] {
+  const changes: UpperChange[] = [];
+  const recurse = (dir: string) => {
+    let entries: string[] = [];
+    try { entries = readdirSync(dir); } catch { return; }
+    for (const name of entries) {
+      const full = join(dir, name);
+      const rel = relative(upper, full);
+      if (isWhiteout(full)) { changes.push({ rel, kind: 'delete' }); continue; }
+      let st;
+      try { st = lstatSync(full); } catch { continue; }
+      if (st.isSymbolicLink()) {
+        // A symlink is landed as a symlink (NOT dereferenced into a content copy,
+        // which would destroy the link and could snapshot out-of-tree host data).
+        let linkTarget = '';
+        try { linkTarget = readlinkSync(full); } catch { /* */ }
+        changes.push({ rel, kind: 'symlink', linkTarget });
+      } else if (st.isDirectory()) {
+        // Opacity is recorded; the new-vs-replace decision is deferred to apply
+        // (where the target — the lower — is known). Either way we recurse so the
+        // dir's surviving children land as their own 'file'/'symlink' changes.
+        const opaque = readOpaqueXattr(full);
+        if (opaque === 'y' || opaque === null) changes.push({ rel, kind: 'opaque' });
+        recurse(full);
+      } else if (st.isFile()) {
+        changes.push({ rel, kind: 'file' });
+      }
+      // other special files (fifos/sockets/non-whiteout devices) are skipped.
     }
-  } finally {
-    try { rmSync(dir, { recursive: true, force: true }); } catch { /* */ }
+  };
+  recurse(upper);
+  return changes;
+}
+
+/**
+ * Compute the agent's changeset from the session's overlay upper layer, with a
+ * human-readable preview (per-file `git diff --no-index` vs the real project).
+ */
+export function computeSandboxDiff(dataDir: string, sessionId: string, locale?: Locale): LandDiff | LandError {
+  const upper = upperDir(dataDir, sessionId);
+  if (!existsSync(upper)) return { ok: false, error: t('sandbox.no_clone', undefined, locale) };
+
+  let changes: UpperChange[];
+  try { changes = walkUpper(upper); }
+  catch (e: any) { return { ok: false, error: t('sandbox.diff_failed', { detail: (e?.message ?? e).toString().slice(0, 300) }, locale) }; }
+
+  if (changes.length === 0) {
+    return { ok: true, empty: true, patch: '', statText: '', files: 0, insertions: 0, deletions: 0 };
+  }
+
+  // The real project root is recorded as the overlay's lower; for the preview we
+  // diff the upper file against the same-named real file. We don't know the real
+  // root from the upper alone, so the preview diffs upper-vs-(real sibling) only
+  // when the caller's apply target is known — here we render a kind+path summary
+  // plus a `git diff --no-index /dev/null <upperfile>` so the content is visible.
+  const statLines: string[] = [];
+  const patchParts: string[] = [];
+  let insertions = 0;
+  let deletions = 0;
+  for (const c of changes) {
+    if (c.kind === 'delete') {
+      statLines.push(`  D  ${c.rel}`);
+      patchParts.push(`--- a/${c.rel}\n+++ /dev/null\n(deleted by sandboxed agent)\n`);
+      deletions++;
+      continue;
+    }
+    if (c.kind === 'symlink') {
+      statLines.push(`  L  ${c.rel} -> ${c.linkTarget ?? ''}`);
+      patchParts.push(`(symlink ${c.rel} -> ${c.linkTarget ?? ''})\n`);
+      continue;
+    }
+    if (c.kind === 'opaque') {
+      // We can't know here whether it's a fresh dir or a wholesale replace (that
+      // depends on the target's lower, resolved at apply time) — label it neutrally.
+      statLines.push(`  R  ${c.rel}/ (directory contents replaced, if it pre-existed)`);
+      patchParts.push(`(directory contents replaced: ${c.rel}/)\n`);
+      continue;
+    }
+    statLines.push(`  M  ${c.rel}`);
+    // Show the new content as a diff against an empty file (no-index, always
+    // available; the upper file is the post-edit content the agent produced).
+    const upPath = join(upper, c.rel);
+    let body = '';
+    try {
+      const r = spawnSync('git', ['diff', '--no-index', '--', '/dev/null', upPath], { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 });
+      body = r.stdout ?? '';
+    } catch { /* */ }
+    if (!body) {
+      try { body = `+++ b/${c.rel}\n${readFileSync(upPath, 'utf8').split('\n').map(l => `+${l}`).join('\n')}\n`; } catch { body = `(binary or unreadable: ${c.rel})\n`; }
+    }
+    insertions += body.split('\n').filter(l => l.startsWith('+') && !l.startsWith('+++')).length;
+    patchParts.push(body);
+  }
+
+  return {
+    ok: true,
+    empty: false,
+    patch: patchParts.join('\n'),
+    statText: statLines.join('\n'),
+    files: changes.length,
+    insertions,
+    deletions,
+  };
+}
+
+/**
+ * Apply the session's overlay upper changeset onto the real target project:
+ *   - regular file in upper → mkdir -p parent, copy over the real file
+ *   - symlink in upper      → recreate the link (NOT a dereferenced copy)
+ *   - whiteout              → remove the corresponding real file/dir
+ *   - opaque dir            → only when the dir ALSO exists in the target (= a
+ *                             wholesale replace): drop the stale lower contents,
+ *                             then re-create it (its surviving files arrive as
+ *                             separate 'file'/'symlink' changes). A purely-new
+ *                             opaque dir is just mkdir'd (never rm -rf'd).
+ *
+ * Two-phase for safety:
+ *   1) PRE-VALIDATE every source is landable (dangling symlink, unreadable regular
+ *      file, undeterminable opacity on a dir that exists in the target) BEFORE we
+ *      mutate anything — so the common mid-loop failure (a dangling relative
+ *      symlink) is caught up front and the real project is left untouched.
+ *   2) APPLY; if a per-file op still throws (race / permission / ENOSPC), we
+ *      report which files were already applied so the owner isn't told "failed"
+ *      with the repo silently half-landed and no clue about its state.
+ */
+export function applySandboxDiff(targetDir: string, dataDir: string, sessionId: string, locale?: Locale): { ok: true } | LandError {
+  const upper = upperDir(dataDir, sessionId);
+  if (!existsSync(upper)) return { ok: false, error: t('sandbox.no_clone', undefined, locale) };
+  if (!existsSync(targetDir)) return { ok: false, error: t('sandbox.target_not_git', { dir: targetDir }, locale) };
+
+  let changes: UpperChange[];
+  try { changes = walkUpper(upper); }
+  catch (e: any) { return { ok: false, error: t('sandbox.apply_failed', { detail: (e?.message ?? e).toString().slice(0, 300) }, locale) }; }
+  if (changes.length === 0) return { ok: false, error: t('sandbox.nothing_to_land', undefined, locale) };
+
+  // Project LOWER (create-time) — the reliable new-vs-replace discriminator for
+  // opaque dirs; '' when unknown → fall back to the live target.
+  const lower = projectLower(dataDir, sessionId);
+  // Does dir `rel` count as a REPLACE (existed in the lower) vs a fresh NEW dir?
+  const existedInLower = (rel: string): boolean =>
+    lower ? existsSync(join(lower, rel)) : existsSync(join(targetDir, rel));
+
+  // ── Phase 1: pre-validate — fail-closed BEFORE any mutation ────────────────
+  const preErrors: string[] = [];
+  for (const c of changes) {
+    if (c.kind === 'file') {
+      const src = join(upper, c.rel);
+      // Resolve via lstat: a regular file must be readable; a broken/special src
+      // would make the in-loop copyFileSync throw mid-land. Catch it now.
+      try { lstatSync(src); } catch (e: any) { preErrors.push(`${c.rel}: source missing (${e?.code ?? e})`); }
+    } else if (c.kind === 'symlink') {
+      if (!c.linkTarget) preErrors.push(`${c.rel}: unreadable symlink target`);
+    } else if (c.kind === 'opaque') {
+      // Only an opaque dir that existed in the LOWER triggers a destructive
+      // rm -rf (a wholesale replace). For such a dir, if we could NOT determine
+      // opacity (readOpaqueXattr → null, no xattr tooling) we MUST NOT guess
+      // "not opaque" (that leaks stale lower files); fail-closed with a clear
+      // message. A purely-NEW opaque dir needs no opacity read at all.
+      if (existedInLower(c.rel)) {
+        const opaque = readOpaqueXattr(join(upper, c.rel));
+        if (opaque === null) {
+          preErrors.push(`${c.rel}/: cannot determine overlay opacity (install the "attr" package, i.e. getfattr) — refusing to land a possibly-replaced directory without knowing whether to drop its stale contents`);
+        }
+      }
+    }
+  }
+  if (preErrors.length > 0) {
+    return { ok: false, error: t('sandbox.apply_failed', { detail: `pre-flight (no changes applied): ${preErrors.slice(0, 8).join('; ').slice(0, 380)}` }, locale) };
+  }
+
+  // ── Phase 2: apply ─────────────────────────────────────────────────────────
+  const applied: string[] = [];
+  try {
+    for (const c of changes) {
+      const real = join(targetDir, c.rel);
+      if (c.kind === 'delete') {
+        try { rmSync(real, { recursive: true, force: true }); } catch { /* already gone */ }
+        applied.push(`-${c.rel}`);
+        continue;
+      }
+      if (c.kind === 'opaque') {
+        // Wholesale REPLACE only when the dir existed in the LOWER (create-time)
+        // — drop its stale contents. A purely-NEW opaque dir is just mkdir'd, so
+        // we never rm -rf unrelated real files that drifted into the live target
+        // under a path the agent merely created fresh (the new-dir clobber).
+        if (existedInLower(c.rel) && existsSync(real)) {
+          try { rmSync(real, { recursive: true, force: true }); } catch { /* */ }
+        }
+        mkdirSync(real, { recursive: true });
+        applied.push(`R ${c.rel}/`);
+        continue;
+      }
+      if (c.kind === 'symlink') {
+        // Recreate the link verbatim (preserve symlink-ness; do NOT dereference).
+        mkdirSync(dirname(real), { recursive: true });
+        try { unlinkSync(real); } catch { /* not present */ }
+        try { rmSync(real, { recursive: true, force: true }); } catch { /* was a dir */ }
+        symlinkSync(c.linkTarget ?? '', real);
+        applied.push(`L ${c.rel}`);
+        continue;
+      }
+      // regular file: copy the upper content over the real file.
+      mkdirSync(dirname(real), { recursive: true });
+      // If a symlink/dir is squatting the target path, clear it first so copy lands a file.
+      try { const st = lstatSync(real); if (st.isSymbolicLink() || st.isDirectory()) rmSync(real, { recursive: true, force: true }); } catch { /* */ }
+      copyFileSync(join(upper, c.rel), real);
+      applied.push(c.rel);
+    }
+    return { ok: true };
+  } catch (e: any) {
+    const detail = `${(e?.message ?? e).toString().slice(0, 240)} — already applied (${applied.length}): ${applied.slice(0, 12).join(', ').slice(0, 200)}`;
+    return { ok: false, error: t('sandbox.apply_failed', { detail }, locale) };
   }
 }

--- a/src/services/sandbox-land.ts
+++ b/src/services/sandbox-land.ts
@@ -168,48 +168,62 @@ export function computeSandboxDiff(dataDir: string, sessionId: string, locale?: 
     return { ok: true, empty: true, patch: '', statText: '', files: 0, insertions: 0, deletions: 0 };
   }
 
-  // The real project root is recorded as the overlay's lower; for the preview we
-  // diff the upper file against the same-named real file. We don't know the real
-  // root from the upper alone, so the preview diffs upper-vs-(real sibling) only
-  // when the caller's apply target is known — here we render a kind+path summary
-  // plus a `git diff --no-index /dev/null <upperfile>` so the content is visible.
+  // Diff each upper file against the SAME-NAMED real file in the overlay lower
+  // (the recorded project root) so modified files show a true unified diff (not
+  // the whole file as "added"), then rewrite git's --no-index headers to
+  // project-relative a/<rel> b/<rel> — clean for the card AND `git apply`-able as
+  // the .patch file. New files diff vs /dev/null; deletions diff lower vs /dev/null.
+  const lower = projectLower(dataDir, sessionId);   // real project root ('' if unknown)
+  const relDiff = (oldPath: string, newPath: string, rel: string): string => {
+    let out = '';
+    try { out = spawnSync('git', ['diff', '--no-index', '--', oldPath, newPath], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }).stdout ?? ''; }
+    catch { /* */ }
+    if (!out) return '';
+    return out.split('\n').map(line => {
+      if (line.startsWith('diff --git ')) return `diff --git a/${rel} b/${rel}`;
+      if (line.startsWith('--- ')) return line.includes('/dev/null') ? '--- /dev/null' : `--- a/${rel}`;
+      if (line.startsWith('+++ ')) return line.includes('/dev/null') ? '+++ /dev/null' : `+++ b/${rel}`;
+      return line;
+    }).join('\n');
+  };
+  const countPlus = (b: string) => b.split('\n').filter(l => l.startsWith('+') && !l.startsWith('+++')).length;
+  const countMinus = (b: string) => b.split('\n').filter(l => l.startsWith('-') && !l.startsWith('---')).length;
+
   const statLines: string[] = [];
   const patchParts: string[] = [];
-  let insertions = 0;
-  let deletions = 0;
+  let insertions = 0, deletions = 0, fileCount = 0;
   for (const c of changes) {
     if (c.kind === 'delete') {
-      statLines.push(`  D  ${c.rel}`);
-      patchParts.push(`--- a/${c.rel}\n+++ /dev/null\n(deleted by sandboxed agent)\n`);
-      deletions++;
+      const lowFile = lower ? join(lower, c.rel) : '';
+      const body = (lowFile && existsSync(lowFile))
+        ? relDiff(lowFile, '/dev/null', c.rel)
+        : `diff --git a/${c.rel} b/${c.rel}\ndeleted file\n--- a/${c.rel}\n+++ /dev/null\n`;
+      statLines.push(`D  ${c.rel}`);
+      deletions += countMinus(body) || 1;
+      patchParts.push(body); fileCount++;
       continue;
     }
     if (c.kind === 'symlink') {
-      statLines.push(`  L  ${c.rel} -> ${c.linkTarget ?? ''}`);
-      patchParts.push(`(symlink ${c.rel} -> ${c.linkTarget ?? ''})\n`);
-      continue;
+      statLines.push(`L  ${c.rel} -> ${c.linkTarget ?? ''}`);
+      patchParts.push(`# symlink ${c.rel} -> ${c.linkTarget ?? ''} (recreated on land; not in this text patch)`);
+      fileCount++; continue;
     }
     if (c.kind === 'opaque') {
-      // We can't know here whether it's a fresh dir or a wholesale replace (that
-      // depends on the target's lower, resolved at apply time) — label it neutrally.
-      statLines.push(`  R  ${c.rel}/ (directory contents replaced, if it pre-existed)`);
-      patchParts.push(`(directory contents replaced: ${c.rel}/)\n`);
+      // Replaced directory; its surviving children land as their own 'file'
+      // changes (walkUpper recursed), so no diff body here — just note it.
+      statLines.push(`R  ${c.rel}/ (directory replaced)`);
       continue;
     }
-    statLines.push(`  M  ${c.rel}`);
-    // Show the new content as a diff against an empty file (no-index, always
-    // available; the upper file is the post-edit content the agent produced).
+    // regular file: modified (exists in lower) vs new
     const upPath = join(upper, c.rel);
-    let body = '';
-    try {
-      const r = spawnSync('git', ['diff', '--no-index', '--', '/dev/null', upPath], { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 });
-      body = r.stdout ?? '';
-    } catch { /* */ }
-    if (!body) {
-      try { body = `+++ b/${c.rel}\n${readFileSync(upPath, 'utf8').split('\n').map(l => `+${l}`).join('\n')}\n`; } catch { body = `(binary or unreadable: ${c.rel})\n`; }
-    }
-    insertions += body.split('\n').filter(l => l.startsWith('+') && !l.startsWith('+++')).length;
-    patchParts.push(body);
+    const lowFile = lower ? join(lower, c.rel) : '';
+    const isMod = !!(lowFile && existsSync(lowFile));
+    const body = relDiff(isMod ? lowFile : '/dev/null', upPath, c.rel)
+      || `diff --git a/${c.rel} b/${c.rel}\n(binary or unreadable: ${c.rel})\n`;
+    statLines.push(`${isMod ? 'M' : 'A'}  ${c.rel}`);
+    insertions += countPlus(body);
+    deletions += countMinus(body);
+    patchParts.push(body); fileCount++;
   }
 
   return {
@@ -217,7 +231,7 @@ export function computeSandboxDiff(dataDir: string, sessionId: string, locale?: 
     empty: false,
     patch: patchParts.join('\n'),
     statText: statLines.join('\n'),
-    files: changes.length,
+    files: fileCount,
     insertions,
     deletions,
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,16 @@ export interface Session {
   cliSessionId?: string;
   /** CLI used to spawn this session — stamped on every save so closed sessions retain it. */
   cliId?: import('./adapters/cli/types.js').CliId;
+  /**
+   * Sandbox decision RECORDED AT SESSION CREATION (overlay file-isolation). The
+   * live bot flag (BotConfig.sandbox) can be toggled later, but a session's
+   * sandbox status is frozen here at creation so a restore/restart never
+   * retroactively sandboxes (or un-sandboxes) a historical session. Undefined on
+   * sessions created before this field existed → treated as not sandboxed.
+   */
+  sandbox?: boolean;
+  /** Per-bot privacy masks recorded alongside `sandbox` at session creation. */
+  sandboxHidePaths?: string[];
   /** Persisted adopt metadata — allows adopt sessions to survive daemon restarts.
    *  Either tmuxTarget (tmux backend) OR zellijSession+zellijPaneId (zellij). */
   adoptedFrom?: {
@@ -229,7 +239,7 @@ export type TermActionKey =
 
 /** Messages sent from Daemon to Worker */
 export type DaemonToWorker =
-  | { type: 'init'; sessionId: string; chatId: string; rootMessageId: string; workingDir: string; cliId: string; cliPathOverride?: string; model?: string; disableCliBypass?: boolean; sandbox?: boolean; backendType: BackendType; prompt: string; resume?: boolean; cliSessionId?: string; originalSessionId?: string; ownerOpenId?: string; webPort?: number; larkAppId: string; larkAppSecret: string; brand?: 'feishu' | 'lark'; botName?: string; botOpenId?: string; locale?: 'zh' | 'en'; turnId?: string; adoptMode?: boolean; adoptSource?: 'tmux' | 'herdr' | 'zellij'; adoptTmuxTarget?: string; adoptZellijSession?: string; adoptZellijPaneId?: string; adoptHerdrSessionName?: string; adoptHerdrTarget?: string; adoptHerdrPaneId?: string; adoptPaneCols?: number; adoptPaneRows?: number; bridgeJsonlPath?: string; adoptCliPid?: number; adoptCwd?: string; adoptRestoredFromMetadata?: boolean }
+  | { type: 'init'; sessionId: string; chatId: string; rootMessageId: string; workingDir: string; cliId: string; cliPathOverride?: string; model?: string; disableCliBypass?: boolean; sandbox?: boolean; sandboxHidePaths?: string[]; backendType: BackendType; prompt: string; resume?: boolean; cliSessionId?: string; originalSessionId?: string; ownerOpenId?: string; webPort?: number; larkAppId: string; larkAppSecret: string; brand?: 'feishu' | 'lark'; botName?: string; botOpenId?: string; locale?: 'zh' | 'en'; turnId?: string; adoptMode?: boolean; adoptSource?: 'tmux' | 'herdr' | 'zellij'; adoptTmuxTarget?: string; adoptZellijSession?: string; adoptZellijPaneId?: string; adoptHerdrSessionName?: string; adoptHerdrTarget?: string; adoptHerdrPaneId?: string; adoptPaneCols?: number; adoptPaneRows?: number; bridgeJsonlPath?: string; adoptCliPid?: number; adoptCwd?: string; adoptRestoredFromMetadata?: boolean }
   | { type: 'message'; content: string; turnId?: string }
   | { type: 'raw_input'; content: string }
   | { type: 'close' }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -66,7 +66,7 @@ import { ZellijObserveBackend } from './adapters/backend/zellij-observe-backend.
 import { zellijEnv } from './setup/ensure-zellij.js';
 import { isObserveBackend, type ObserveBackend } from './adapters/backend/types.js';
 import { selectSessionBackend } from './adapters/backend/session-backend-selector.js';
-import { prepareSandbox, startOutboxWatcher, sandboxEnabled } from './adapters/backend/sandbox.js';
+import { prepareSandbox, attachSandboxOutbox, startOutboxWatcher, sandboxEnabled } from './adapters/backend/sandbox.js';
 import type { BackendType, SessionBackend } from './adapters/backend/types.js';
 import { tmuxEnv } from './setup/ensure-tmux.js';
 import { IdleDetector } from './utils/idle-detector.js';
@@ -90,6 +90,8 @@ let cliAdapter: CliAdapter | null = null;
 let backend: SessionBackend | null = null;
 let cliPidMarker: string | null = null;  // path to .botmux-cli-pids/<pid>
 let sandboxStopWatcher: (() => void) | null = null;  // stop fn for the sandbox outbox watcher
+let sandboxCleanup: (() => void) | null = null;      // unmount overlays + rm the per-session sandbox tree
+let sandboxTeardownDone = false;                     // guards the exit-time best-effort teardown from double-running / running on suspend-for-resume
 let idleDetector: IdleDetector | null = null;
 let isTmuxMode = false;
 /** Adopt-bridge mode using TmuxPipeBackend: not a tmux attach client, all
@@ -3448,29 +3450,81 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   // bwrap directly) and tmux (the tmux pane's command becomes `bwrap … -- cli`);
   // env is carried via bwrap --setenv (see prepareSandbox), not the backend.
   const sandboxOn = cfg.sandbox === true || sandboxEnabled();
-  if (sandboxOn && (effectiveBackendType === 'pty' || effectiveBackendType === 'tmux') && process.env.SESSION_DATA_DIR) {
+  if (sandboxOn) {
+    // FAIL-SAFE (not fail-open): when the sandbox is requested, a missing
+    // precondition (no SESSION_DATA_DIR, or a backend we can't wrap) must be a
+    // HARD ERROR, never a silent skip — otherwise the CLI would spawn UNSANDBOXED
+    // with full host write access and no log, the exact opposite of the
+    // oncall-untrusted-agent invariant. In normal operation worker-pool sets
+    // SESSION_DATA_DIR and the backend is pty/tmux, so this never trips.
+    const dataDir = process.env.SESSION_DATA_DIR;
+    if (effectiveBackendType !== 'pty' && effectiveBackendType !== 'tmux') {
+      const msg = `Sandbox ENABLED but backend "${effectiveBackendType}" is not sandboxable (only pty/tmux) — aborting spawn to avoid an unsandboxed run`;
+      log(msg);
+      throw new Error(msg);
+    }
+    if (!dataDir) {
+      const msg = 'Sandbox ENABLED but SESSION_DATA_DIR is unset — aborting spawn to avoid an unsandboxed run';
+      log(msg);
+      throw new Error(msg);
+    }
     try {
-      const sbx = prepareSandbox({
-        enabled: sandboxOn,
-        cliId: cfg.cliId,
-        sessionId: cfg.sessionId,
-        sourceWorkingDir: cfg.workingDir,
-        dataDir: process.env.SESSION_DATA_DIR,
-        cliBin: cliAdapter.resolvedBin,
-        cliArgs: args,
-      });
-      if (sbx) {
-        spawnBin = sbx.bin;
-        spawnArgs = sbx.args;
-        spawnCwd = sbx.workDir;
-        Object.assign(childEnv, sbx.env);
-        if (sandboxStopWatcher) { try { sandboxStopWatcher(); } catch { /* */ } }
-        // session-id is FORCED here so a relayed send can't target another session.
-        sandboxStopWatcher = startOutboxWatcher(sbx.outbox, childEnv, cfg.sessionId);
-        log(`Sandbox ON (${cfg.cliId}): work=${sbx.workDir} outbox=${sbx.outbox}`);
+      if (willReattachPersistent) {
+        // Daemon-restart reattach to a persistent (tmux/herdr/zellij) pane whose
+        // bwrap'd CLI is STILL ALIVE. backend.spawn() ignores bin/args here and
+        // just re-attaches, and the live CLI is bound to its own namespace-pinned
+        // overlay — so we must NOT unmount/remount (prepareSandbox would leave a
+        // duplicate host-side overlay the CLI isn't using). We only re-wire the
+        // outbox watcher (so the live CLI's `botmux send` keeps being serviced)
+        // and the cleanup ref (so close/exit reclaims the residue). No re-prep.
+        const att = attachSandboxOutbox({ sessionId: cfg.sessionId, dataDir });
+        if (att) {
+          if (sandboxStopWatcher) { try { sandboxStopWatcher(); } catch { /* */ } }
+          if (sandboxCleanup) { try { sandboxCleanup(); } catch { /* */ } }
+          sandboxCleanup = att.cleanup;
+          sandboxStopWatcher = startOutboxWatcher(att.outbox, childEnv, cfg.sessionId);
+          log(`Sandbox REATTACH (${cfg.cliId}): live pane CLI kept, re-wired outbox=${att.outbox} (no remount)`);
+        } else {
+          // No sandbox tree on disk for a session we're reattaching to: the
+          // pane's CLI may be unsandboxed (sandbox enabled after it spawned). Do
+          // NOT remount under a live CLI; just continue the reattach as-is.
+          log(`Sandbox REATTACH (${cfg.cliId}): no on-disk sandbox tree — reattaching live pane without re-prep`);
+        }
+      } else {
+        const sbx = prepareSandbox({
+          enabled: sandboxOn,
+          cliId: cfg.cliId,
+          sessionId: cfg.sessionId,
+          sourceWorkingDir: cfg.workingDir,
+          dataDir,
+          cliBin: cliAdapter.resolvedBin,
+          cliArgs: args,
+          hidePaths: cfg.sandboxHidePaths ?? [],
+        });
+        if (sbx) {
+          spawnBin = sbx.bin;
+          spawnArgs = sbx.args;
+          // In the overlay model the child still chdirs to projectMount (via bwrap
+          // --chdir), so spawnCwd stays the real workingDir; the overlay merged dir
+          // is bound there. sbx.workDir is the UPPER changeset (for landing), NOT a cwd.
+          Object.assign(childEnv, sbx.env);
+          if (sandboxStopWatcher) { try { sandboxStopWatcher(); } catch { /* */ } }
+          if (sandboxCleanup) { try { sandboxCleanup(); } catch { /* */ } }
+          sandboxCleanup = sbx.cleanup;
+          // session-id is FORCED here so a relayed send can't target another session.
+          sandboxStopWatcher = startOutboxWatcher(sbx.outbox, childEnv, cfg.sessionId);
+          log(`Sandbox ON (${cfg.cliId}): upper=${sbx.workDir} outbox=${sbx.outbox}`);
+        } else {
+          // Sandbox was requested but prepareSandbox returned null (a required
+          // overlay mount failed, or non-Linux). Fail safe: do NOT silently run
+          // unsandboxed — surface a hard error so the session doesn't leak.
+          log(`Sandbox ENABLED but prepare returned null (mount failed / unsupported) — aborting spawn to avoid an unsandboxed run`);
+          throw new Error('sandbox requested but could not be established');
+        }
       }
     } catch (err: any) {
-      log(`Sandbox prepare failed (${err.message}) — falling back to direct spawn`);
+      log(`Sandbox prepare failed (${err.message}) — aborting (sandbox is a hard requirement when enabled)`);
+      throw err;
     }
   }
 
@@ -3694,11 +3748,17 @@ function killCli(): void {
     try { unlinkSync(cliPidMarker); } catch { /* already gone */ }
     cliPidMarker = null;
   }
-  // Stop the sandbox outbox watcher (the per-session sandbox tree is left in
-  // place so a same-topic resume reuses the same clone + scoped config).
+  // Stop the sandbox outbox watcher, then unmount the overlays + remove the
+  // per-session sandbox tree. In the overlay model the upper layer (the
+  // changeset) must be landed BEFORE close — `/land` runs while the session is
+  // still active, so by cleanup time anything worth keeping is already applied.
   if (sandboxStopWatcher) {
     try { sandboxStopWatcher(); } catch { /* */ }
     sandboxStopWatcher = null;
+  }
+  if (sandboxCleanup) {
+    try { sandboxCleanup(); } catch { /* */ }
+    sandboxCleanup = null;
   }
   isPromptReady = false;
   pendingMessages.length = 0;
@@ -4494,6 +4554,16 @@ process.on('message', async (raw: unknown) => {
       try { backend?.kill(); } catch { /* detach best-effort */ }
       backend = null;
       isPromptReady = false;
+      // Suspend INTENDS to resume later: preserve the sandbox overlay mount + the
+      // upper changeset across the suspension (on resume, prepareSandbox re-mounts
+      // over the SAME upper). So we stop the outbox watcher (no live CLI to serve)
+      // but DO NOT run sandboxCleanup (which would unmount + rm the changeset). We
+      // also disarm the exit-time teardown so process.exit(0) below can't reclaim
+      // it. (Crash/SIGKILL of a suspended-but-active session is still backstopped
+      // by the daemon's periodic sandbox reconciler.)
+      if (sandboxStopWatcher) { try { sandboxStopWatcher(); } catch { /* */ } sandboxStopWatcher = null; }
+      sandboxCleanup = null;           // drop the ref WITHOUT calling it (keep the mount)
+      sandboxTeardownDone = true;      // make the process.on('exit') hook a no-op
       cleanup();
       process.exit(0);
     }
@@ -4544,5 +4614,37 @@ setInterval(() => {
     process.exit(0);
   }
 }, 30_000).unref();
+
+// ─── Sandbox crash-time teardown ─────────────────────────────────────────────
+// killCli() (which unmounts the overlays + rm's the per-session tree) only runs
+// from the SIGTERM/SIGINT/disconnect/watchdog handlers and the close/suspend IPC
+// cases. An UNCAUGHT exception or unhandled rejection kills the process WITHOUT
+// any of those firing, so without this hook a crashed sandboxed worker would
+// leak BOTH overlay mounts (mount-table growth) + its upper/work dirs (disk leak)
+// per crash. We run a minimal, synchronous, best-effort sandbox teardown here so
+// the overlay/dir residue is reclaimed even on an abnormal exit. (SIGKILL still
+// can't be trapped — the daemon-side sweep + the periodic reconciler below are
+// the backstop for that.)
+function teardownSandboxBestEffort(): void {
+  if (sandboxTeardownDone) return;
+  sandboxTeardownDone = true;
+  try { sandboxStopWatcher?.(); } catch { /* */ }
+  sandboxStopWatcher = null;
+  try { sandboxCleanup?.(); } catch { /* */ }
+  sandboxCleanup = null;
+}
+process.on('exit', () => { teardownSandboxBestEffort(); });
+process.on('uncaughtException', (err) => {
+  try { log(`Uncaught exception — tearing down sandbox before exit: ${err?.stack ?? err}`); } catch { /* */ }
+  teardownSandboxBestEffort();
+  try { cleanup(); } catch { /* */ }
+  process.exit(1);
+});
+process.on('unhandledRejection', (reason: any) => {
+  try { log(`Unhandled rejection — tearing down sandbox before exit: ${reason?.stack ?? reason}`); } catch { /* */ }
+  teardownSandboxBestEffort();
+  try { cleanup(); } catch { /* */ }
+  process.exit(1);
+});
 
 log('Worker started, waiting for init...');

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -1,25 +1,30 @@
 /**
  * sandbox.test.ts
  *
- * Pure-logic tests for the file-isolation sandbox (bubblewrap) arg builder and
- * the per-CLI config-scoping helper. No bwrap/network — just the argv shape and
- * the scrub contract.
+ * Pure-logic tests for the overlayfs file-isolation sandbox: the bwrap arg
+ * builder (overlay binds + privacy masks + outbox-last), the relay security
+ * boundary (validateRelayRequest / materializeOutboxFile, unchanged), and the
+ * upper-layer landing (computeSandboxDiff / applySandboxDiff). No real mount —
+ * just the argv shape and the upper-walk/apply contract.
  */
 import { describe, it, expect } from 'vitest';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { mkdtempSync, existsSync, writeFileSync, readFileSync, symlinkSync, rmSync } from 'node:fs';
-import { buildSandboxArgs, seedScopedConfig, validateRelayRequest, materializeOutboxFile, prepareSandbox, type SandboxPlan } from '../src/adapters/backend/sandbox.js';
+import { mkdtempSync, existsSync, writeFileSync, readFileSync, symlinkSync, rmSync, mkdirSync } from 'node:fs';
+import { buildSandboxArgs, validateRelayRequest, materializeOutboxFile, prepareSandbox, type SandboxPlan } from '../src/adapters/backend/sandbox.js';
+import { computeSandboxDiff, applySandboxDiff, upperDir } from '../src/services/sandbox-land.js';
 
 const tmp = () => mkdtempSync(join(tmpdir(), 'sbx-'));
 
 function plan(over: Partial<SandboxPlan> = {}): SandboxPlan {
   return {
-    workDir: '/data/sandboxes/s1/work',
     projectMount: '/home/u/proj',
-    scopedHome: '/data/sandboxes/s1/home',
+    projectMerged: '/data/sandboxes/s1/proj-merged',
+    home: '/root',
+    homeMerged: '/data/sandboxes/s1/home-merged',
     outbox: '/data/sandboxes/s1/outbox',
-    toolchainRo: ['/opt/node'],
+    hideDirs: [],
+    hideFiles: [],
     net: true,
     ...over,
   };
@@ -33,25 +38,65 @@ function bindDest(args: string[], flag: string, src: string): string | undefined
   return undefined;
 }
 
-describe('buildSandboxArgs', () => {
-  it('masks the real home with the scoped home', () => {
+/** Index of the (flag, a, b) triple in args, or -1. */
+function tripleIdx(args: string[], flag: string, a: string, b: string): number {
+  for (let i = 0; i < args.length - 2; i++) {
+    if (args[i] === flag && args[i + 1] === a && args[i + 2] === b) return i;
+  }
+  return -1;
+}
+
+describe('buildSandboxArgs (overlay model)', () => {
+  it('reads the entire real fs read-only (--ro-bind / /)', () => {
     const a = buildSandboxArgs(plan());
-    expect(bindDest(a, '--bind', '/data/sandboxes/s1/home')).toBe(homedir());
+    expect(tripleIdx(a, '--ro-bind', '/', '/')).toBeGreaterThanOrEqual(0);
   });
 
-  it('mounts the clone AT projectMount (not at its own host path)', () => {
+  it('binds the merged home overlay AT the real home path', () => {
     const a = buildSandboxArgs(plan());
-    // clone host path → projectMount
-    expect(bindDest(a, '--bind', '/data/sandboxes/s1/work')).toBe('/home/u/proj');
-    // and chdir is the mount target, so the CLI's -C/cwd args resolve
+    expect(bindDest(a, '--bind', '/data/sandboxes/s1/home-merged')).toBe('/root');
+  });
+
+  it('binds the merged project overlay AT projectMount and chdirs there', () => {
+    const a = buildSandboxArgs(plan());
+    expect(bindDest(a, '--bind', '/data/sandboxes/s1/proj-merged')).toBe('/home/u/proj');
     const ci = a.indexOf('--chdir');
     expect(a[ci + 1]).toBe('/home/u/proj');
   });
 
-  it('binds the outbox at its own path and re-exposes toolchain read-only', () => {
+  it('masks hideDirs with a tmpfs and hideFiles with a read-only empty placeholder', () => {
+    const a = buildSandboxArgs(plan({
+      hideDirs: ['/root/.ssh'],
+      hideFiles: [{ path: '/root/.botmux/bots.json', empty: '/data/sandboxes/s1/empties/mask-0' }],
+    }));
+    // dir → tmpfs
+    const di = a.indexOf('--tmpfs');
+    expect(a).toContain('--tmpfs');
+    expect(a.includes('/root/.ssh')).toBe(true);
+    expect(tripleIdx(a, '--tmpfs', '/root/.ssh', '/root/.ssh')).toBe(-1); // tmpfs takes a single arg
+    expect(di).toBeGreaterThanOrEqual(0);
+    // file → ro-bind empty placeholder over the real path
+    expect(bindDest(a, '--ro-bind', '/data/sandboxes/s1/empties/mask-0')).toBe('/root/.botmux/bots.json');
+  });
+
+  it('binds the outbox LAST so a mask covering a parent dir cannot shadow it', () => {
+    const a = buildSandboxArgs(plan({
+      hideDirs: ['/data/sandboxes/s1'],  // covers the outbox's parent
+    }));
+    const maskIdx = a.indexOf('/data/sandboxes/s1');
+    const outboxIdx = tripleIdx(a, '--bind', '/data/sandboxes/s1/outbox', '/data/sandboxes/s1/outbox');
+    expect(outboxIdx).toBeGreaterThanOrEqual(0);
+    expect(outboxIdx).toBeGreaterThan(maskIdx); // outbox bind comes after the mask
+  });
+
+  it('no clone/scrub artefacts: never binds a per-session clone "work" dir', () => {
     const a = buildSandboxArgs(plan());
-    expect(bindDest(a, '--bind', '/data/sandboxes/s1/outbox')).toBe('/data/sandboxes/s1/outbox');
-    expect(bindDest(a, '--ro-bind-try', '/opt/node')).toBe('/opt/node');
+    // The old model bound a `git clone` "work" dir; the overlay model never does
+    // — the project is a merged overlay bound at projectMount, nothing else.
+    expect(a.some(x => x.includes('/work'))).toBe(false);
+    // The only binds are: ro / /, the two overlay merged dirs, and the outbox.
+    const binds = a.filter((x, i) => x === '--bind').length;
+    expect(binds).toBe(3); // home-merged, proj-merged, outbox
   });
 
   it('keeps the network by default and drops it when net=false', () => {
@@ -67,21 +112,7 @@ describe('buildSandboxArgs', () => {
   });
 });
 
-describe('seedScopedConfig', () => {
-  it('returns false for a CLI with no persistent config', () => {
-    const home = mkdtempSync(join(tmpdir(), 'sbx-'));
-    expect(seedScopedConfig('hermes', home)).toBe(false);
-  });
-
-  it('creates the scoped config dir for a known CLI (codex)', () => {
-    const home = mkdtempSync(join(tmpdir(), 'sbx-'));
-    expect(seedScopedConfig('codex', home)).toBe(true);
-    // The de-identified ~/.codex is materialised even if the host has nothing to copy.
-    expect(existsSync(join(home, '.codex'))).toBe(true);
-  });
-});
-
-// ── validateRelayRequest: pure schema + flag-allowlist boundary ─────────────
+// ── validateRelayRequest: pure schema + flag-allowlist boundary (UNCHANGED) ──
 // Regression for the "sandbox makes host read an arbitrary path" confused-deputy
 // blocker: only plain outbox basenames + allowlisted flags pass; raw argv /
 // path flags / sandbox-chosen session-id are rejected.
@@ -104,6 +135,11 @@ describe('validateRelayRequest', () => {
     expect(validateRelayRequest({ contentFile: 'c.content', flags: ['--session-id', 'other'] }).ok).toBe(false);
   });
 
+  it('rejects a value-taking flag whose value is itself a flag (--mention --session-id desync)', () => {
+    expect(validateRelayRequest({ contentFile: 'c.content', flags: ['--mention', '--session-id'] }).ok).toBe(false);
+    expect(validateRelayRequest({ contentFile: 'c.content', flags: ['--quote', '--mention'] }).ok).toBe(false);
+  });
+
   it('rejects non-basename content / attachment names (../ traversal)', () => {
     expect(validateRelayRequest({ contentFile: '../../etc/passwd' }).ok).toBe(false);
     expect(validateRelayRequest({ contentFile: 'c.content', attachments: ['../secret'] }).ok).toBe(false);
@@ -112,10 +148,7 @@ describe('validateRelayRequest', () => {
   });
 });
 
-// ── materializeOutboxFile: TOCTOU-safe read of an outbox file ───────────────
-// Regression for the post-validation symlink-swap (TOCTOU): the read itself
-// refuses symlinks (O_NOFOLLOW) and reads from the fd, so a swap can't redirect
-// it to a host file. There is no separate check-then-use window any more.
+// ── materializeOutboxFile: TOCTOU-safe read of an outbox file (UNCHANGED) ────
 describe('materializeOutboxFile (TOCTOU)', () => {
   it('copies a regular outbox file into the private dest', () => {
     const outbox = tmp(); const stage = tmp();
@@ -129,7 +162,6 @@ describe('materializeOutboxFile (TOCTOU)', () => {
     const outbox = tmp(); const stage = tmp(); const secretDir = tmp();
     const secret = join(secretDir, 'bots.json');
     writeFileSync(secret, 'SECRET_FROM_HOST');
-    // simulate the sandbox swapping the validated name for a symlink-to-secret
     symlinkSync(secret, join(outbox, 'c.content'));
     const dest = join(stage, 'out');
     expect(materializeOutboxFile(outbox, 'c.content', dest)).toBe(false);  // O_NOFOLLOW rejects
@@ -139,13 +171,28 @@ describe('materializeOutboxFile (TOCTOU)', () => {
   it('refuses a missing or non-regular file', () => {
     const outbox = tmp(); const stage = tmp();
     expect(materializeOutboxFile(outbox, 'nope', join(stage, 'o'))).toBe(false);
-    rmSync(join(stage, 'sub'), { recursive: true, force: true });
+  });
+
+  it('does NOT hang on a FIFO and rejects it (O_NONBLOCK + fstat-reject)', () => {
+    // Regression: a malicious agent drops a FIFO into the rw-bound outbox; without
+    // O_NONBLOCK the synchronous openSync blocks forever (no writer), freezing the
+    // worker event loop. With O_NONBLOCK the open returns immediately and the
+    // fstat reject (isFile() false) refuses it — no hang, no materialization.
+    const { execFileSync } = require('node:child_process') as typeof import('node:child_process');
+    const outbox = tmp(); const stage = tmp();
+    try { execFileSync('mkfifo', [join(outbox, 'evil')], { stdio: 'ignore' }); }
+    catch { return; } // mkfifo unavailable in this env — skip
+    const dest = join(stage, 'o');
+    const start = Date.now();
+    const r = materializeOutboxFile(outbox, 'evil', dest);
+    const elapsed = Date.now() - start;
+    expect(r).toBe(false);            // rejected (not a regular file)
+    expect(existsSync(dest)).toBe(false);
+    expect(elapsed).toBeLessThan(2000); // returned immediately, did NOT block
   });
 });
 
 // ── prepareSandbox: the per-bot toggle must actually engage bwrap ────────────
-// Regression for the "dashboard sandbox:true never triggers bwrap" blocker:
-// prepareSandbox must honor the explicit `enabled` flag, NOT the env var.
 describe('prepareSandbox enabled gate', () => {
   it('returns null when not enabled (regardless of env)', () => {
     const r = prepareSandbox({
@@ -154,21 +201,213 @@ describe('prepareSandbox enabled gate', () => {
     });
     expect(r).toBeNull();
   });
+});
 
-  it.skipIf(process.platform !== 'linux')('engages bwrap when enabled=true without BOTMUX_SANDBOX env', () => {
+// ── Landing from the overlay UPPER layer ─────────────────────────────────────
+// The project overlay UPPER dir IS the changeset. computeSandboxDiff walks it
+// (regular file = add/modify, char-dev rdev0 = whiteout/delete); applySandboxDiff
+// copies the changes onto a real target. We simulate the upper layer on disk.
+describe('sandbox landing from upper layer', () => {
+  function makeUpper(dataDir: string, sid: string): string {
+    const up = upperDir(dataDir, sid);
+    mkdirSync(up, { recursive: true });
+    return up;
+  }
+
+  it('computeSandboxDiff classifies a new + a modified file under the upper', () => {
+    const dataDir = tmp(); const sid = 's-diff';
+    const up = makeUpper(dataDir, sid);
+    writeFileSync(join(up, 'added.txt'), 'brand new\n');
+    mkdirSync(join(up, 'sub'), { recursive: true });
+    writeFileSync(join(up, 'sub', 'edited.txt'), 'changed content\n');
+
+    const d = computeSandboxDiff(dataDir, sid);
+    expect(d.ok).toBe(true);
+    if (!d.ok) return;
+    expect(d.empty).toBe(false);
+    expect(d.files).toBe(2);
+    // both files visible in the stat summary
+    expect(d.statText).toContain('added.txt');
+    expect(d.statText).toContain('sub/edited.txt');
+  });
+
+  it('computeSandboxDiff reports empty when the upper has no changes', () => {
+    const dataDir = tmp(); const sid = 's-empty';
+    makeUpper(dataDir, sid);
+    const d = computeSandboxDiff(dataDir, sid);
+    expect(d.ok).toBe(true);
+    if (!d.ok) return;
+    expect(d.empty).toBe(true);
+    expect(d.files).toBe(0);
+  });
+
+  it('computeSandboxDiff errors when the session has no upper layer', () => {
+    const dataDir = tmp();
+    const d = computeSandboxDiff(dataDir, 'nope');
+    expect(d.ok).toBe(false);
+  });
+
+  it('applySandboxDiff copies new + modified files onto the real target', () => {
+    const dataDir = tmp(); const sid = 's-apply';
+    const up = makeUpper(dataDir, sid);
+    const target = tmp();
+    // target already has the file the agent "modified"
+    writeFileSync(join(target, 'edited.txt'), 'old content\n');
+    // upper = the agent's changeset
+    writeFileSync(join(up, 'added.txt'), 'NEW FILE\n');
+    writeFileSync(join(up, 'edited.txt'), 'NEW CONTENT\n');
+    mkdirSync(join(up, 'deep'), { recursive: true });
+    writeFileSync(join(up, 'deep', 'nested.txt'), 'nested\n');
+
+    const a = applySandboxDiff(target, dataDir, sid);
+    expect(a.ok).toBe(true);
+    expect(readFileSync(join(target, 'added.txt'), 'utf8')).toBe('NEW FILE\n');
+    expect(readFileSync(join(target, 'edited.txt'), 'utf8')).toBe('NEW CONTENT\n');         // overwrote old
+    expect(readFileSync(join(target, 'deep', 'nested.txt'), 'utf8')).toBe('nested\n');      // mkdir -p parent
+  });
+
+  it('applySandboxDiff honors an overlay whiteout (char-dev rdev 0) as a deletion when mknod is available', () => {
+    const dataDir = tmp(); const sid = 's-del';
+    const up = makeUpper(dataDir, sid);
+    const target = tmp();
+    writeFileSync(join(target, 'gone.txt'), 'to be deleted\n');
+    // Try to create a real overlay whiteout (char device, 0/0). Needs CAP_MKNOD;
+    // root in this env has it, but skip gracefully if mknod is unavailable.
+    const { spawnSync } = require('node:child_process') as typeof import('node:child_process');
+    const r = spawnSync('mknod', [join(up, 'gone.txt'), 'c', '0', '0'], { stdio: 'ignore' });
+    if (r.status !== 0) {
+      // Environment can't make a whiteout — assert the detector at least doesn't
+      // misclassify, and skip the deletion assertion.
+      expect(existsSync(join(target, 'gone.txt'))).toBe(true);
+      return;
+    }
+    const a = applySandboxDiff(target, dataDir, sid);
+    expect(a.ok).toBe(true);
+    expect(existsSync(join(target, 'gone.txt'))).toBe(false); // whiteout → removed from target
+  });
+
+  it('applySandboxDiff errors when nothing changed', () => {
+    const dataDir = tmp(); const sid = 's-noop';
+    makeUpper(dataDir, sid);
+    const target = tmp();
+    const a = applySandboxDiff(target, dataDir, sid);
+    expect(a.ok).toBe(false);
+  });
+
+  it('lands a symlink AS a symlink (does not dereference into a content copy)', () => {
+    const dataDir = tmp(); const sid = 's-link';
+    const up = makeUpper(dataDir, sid);
+    const target = tmp();
+    // a project-relative symlink the agent created in the upper layer
+    writeFileSync(join(up, 'real.txt'), 'payload\n');
+    symlinkSync('real.txt', join(up, 'alias.txt'));
+
+    const a = applySandboxDiff(target, dataDir, sid);
+    expect(a.ok).toBe(true);
+    const { lstatSync, readlinkSync } = require('node:fs') as typeof import('node:fs');
+    expect(lstatSync(join(target, 'alias.txt')).isSymbolicLink()).toBe(true); // still a link
+    expect(readlinkSync(join(target, 'alias.txt'))).toBe('real.txt');         // target preserved
+  });
+
+  it('a dangling symlink no longer throws mid-loop — it lands as a link, edits land too', () => {
+    const dataDir = tmp(); const sid = 's-dangling';
+    const up = makeUpper(dataDir, sid);
+    const target = tmp();
+    writeFileSync(join(target, 'keep.txt'), 'original\n');
+    // upper changeset: a normal edit + a NEW file + a DANGLING symlink. The old
+    // code dereferenced the link via copyFileSync → ENOENT mid-loop → the project
+    // was left half-landed. Now a symlink (even dangling) is recreated as a link,
+    // so apply SUCCEEDS and all changes land.
+    writeFileSync(join(up, 'keep.txt'), 'EDITED\n');
+    writeFileSync(join(up, 'added.txt'), 'NEW\n');
+    symlinkSync('/nonexistent/dangling/target', join(up, 'dangling.lnk'));
+
+    const a = applySandboxDiff(target, dataDir, sid);
+    expect(a.ok).toBe(true);
+    const { lstatSync } = require('node:fs') as typeof import('node:fs');
+    expect(lstatSync(join(target, 'dangling.lnk')).isSymbolicLink()).toBe(true);
+    expect(readFileSync(join(target, 'keep.txt'), 'utf8')).toBe('EDITED\n');
+    expect(readFileSync(join(target, 'added.txt'), 'utf8')).toBe('NEW\n');
+  });
+
+  it('multi-file apply lands every change (two-phase apply, happy path)', () => {
+    // The two-phase apply pre-validates all sources, then applies. Confirm a
+    // multi-file changeset lands fully. (The fail-closed NO-mutation path — when
+    // overlay opacity is undeterminable on a lower-existing dir — is verified by
+    // the crippled-PATH opaque-land probe, which can't run as a unit test here
+    // because it needs a real opaque overlay dir + no xattr tooling.)
+    const dataDir = tmp(); const sid = 's-multi';
+    const up = makeUpper(dataDir, sid);
+    const target = tmp();
+    writeFileSync(join(target, 'a.txt'), 'old\n');
+    writeFileSync(join(up, 'a.txt'), 'new\n');
+    writeFileSync(join(up, 'b.txt'), 'new b\n');
+    const a = applySandboxDiff(target, dataDir, sid);
+    expect(a.ok).toBe(true);
+    expect(readFileSync(join(target, 'a.txt'), 'utf8')).toBe('new\n');
+    expect(readFileSync(join(target, 'b.txt'), 'utf8')).toBe('new b\n');
+  });
+
+  it('a BRAND-NEW opaque dir is mkdir-only (does NOT rm -rf unrelated real files)', () => {
+    // Regression #10: overlay marks BOTH new and replaced dirs opaque. apply must
+    // only rm -rf an opaque dir that ALSO exists in the target; a purely-new dir
+    // must not clobber concurrent real files that drifted under that path.
+    const dataDir = tmp(); const sid = 's-newdir';
+    const up = makeUpper(dataDir, sid);
+    const target = tmp();
+    // The target real project has drifted: a sibling appeared under a path the
+    // agent will also create. Simulate "agent created src/new-feature/ fresh".
+    mkdirSync(join(target, 'src', 'new-feature'), { recursive: true });
+    writeFileSync(join(target, 'src', 'new-feature', 'concurrent.txt'), 'do not delete me\n');
+    // Upper: the agent's brand-new dir + its file. We cannot set a real opaque
+    // xattr without root/CAP_SYS_ADMIN here, so this asserts the NON-opaque path
+    // (plain new dir) never clobbers; the opaque-but-new path shares the same
+    // exists-in-target guard in apply.
+    mkdirSync(join(up, 'src', 'new-feature'), { recursive: true });
+    writeFileSync(join(up, 'src', 'new-feature', 'feature.txt'), 'brand new feature\n');
+
+    const a = applySandboxDiff(target, dataDir, sid);
+    expect(a.ok).toBe(true);
+    expect(readFileSync(join(target, 'src', 'new-feature', 'feature.txt'), 'utf8')).toBe('brand new feature\n');
+    // the concurrent file the agent never touched MUST survive
+    expect(existsSync(join(target, 'src', 'new-feature', 'concurrent.txt'))).toBe(true);
+  });
+});
+
+// ── prepareSandbox: hidePaths produce the right masks ────────────────────────
+// On Linux with root we can actually mount the overlays; verify the resulting
+// argv masks an existing dir via tmpfs and a file via an empty ro-bind.
+describe.skipIf(process.platform !== 'linux')('prepareSandbox hidePaths masks', () => {
+  it('turns an existing dir hidePath into a tmpfs mask and a file into a ro-bind empty', () => {
     const src = tmp();
-    writeFileSync(join(src, 'file.txt'), 'x');  // a non-git project copied via cp
+    writeFileSync(join(src, 'file.txt'), 'x');
+    // a dir + a file to hide (both under a tmp tree so they exist)
+    const secretDir = tmp();
+    mkdirSync(join(secretDir, 'sekret'), { recursive: true });
+    const secretFile = join(secretDir, 'creds.json');
+    writeFileSync(secretFile, 'TOKEN');
+
     const prev = process.env.BOTMUX_SANDBOX;
-    delete process.env.BOTMUX_SANDBOX;  // prove env is NOT what enables it
+    delete process.env.BOTMUX_SANDBOX;
+    const dataDir = tmp();
+    const sid = 'hp-' + Math.random().toString(36).slice(2);
+    let r: ReturnType<typeof prepareSandbox> = null;
     try {
-      const r = prepareSandbox({
-        enabled: true, cliId: 'codex', sessionId: 'pb', sourceWorkingDir: src,
-        dataDir: tmp(), cliBin: '/bin/true', cliArgs: [],
+      r = prepareSandbox({
+        enabled: true, cliId: 'codex', sessionId: sid, sourceWorkingDir: src,
+        dataDir, cliBin: '/bin/true', cliArgs: [],
+        hidePaths: [join(secretDir, 'sekret'), secretFile],
       });
-      expect(r).not.toBeNull();
-      expect(r!.bin).toBe('bwrap');
-      expect(r!.args).toContain('--');
+      if (r === null) return; // overlay mount unavailable in this env — skip assertions
+      // dir → tmpfs mask
+      expect(r.args).toContain(join(secretDir, 'sekret'));
+      const ti = r.args.indexOf('--tmpfs');
+      expect(ti).toBeGreaterThanOrEqual(0);
+      // file → ro-bind of an empty placeholder over the real file path
+      const idx = r.args.findIndex((x, i) => x === '--ro-bind' && r!.args[i + 2] === secretFile);
+      expect(idx).toBeGreaterThanOrEqual(0);
     } finally {
+      if (r) r.cleanup();
       if (prev !== undefined) process.env.BOTMUX_SANDBOX = prev;
     }
   });


### PR DESCRIPTION
把 oncall 文件沙盒从 clone+脱敏重写为 overlayfs 读全/写隔离模型。

**模型**：bwrap --ro-bind / / 读整个真实 fs（CLI 原生读真实 config/auth/env，不脱敏→鉴权天然好使）；HOME overlay（写临时不落真盘，upper 放 /var/tmp 满足 overlayfs 约束）；PROJECT overlay（改动 copy-up 到 upper=可落盘改动集，**零 git clone**，只占改动文件磁盘）；per-bot sandboxHidePaths（默认读全，可配屏蔽）；--setenv 整套 proxy。

**解决**：磁盘（不 clone）、鉴权（原生读真实配置）、历史会话重启不再无脑沙盒（按会话固化）。落盘保留（拷 upper 改动集回真实仓库）。

**质量**：workflow 实现 + 5 维对抗复核（安全/生命周期/落盘/CLI实跑/回归）发现 22 问、修 10 高中危（FIFO DoS、fail-open、crash mount 泄漏、SIGKILL 残留、opaque-dir fail-closed、非原子 apply、symlink 保留等），2 个故意不修（read-all 是产品决定、seed 未登录是宿主问题）。tsc/build/29 sandbox + 140 相关测试过；独立实测写隔离（真盘零改动）+ codex/claude 真机 turn。已 rebase 干净到当前 master。