### PR TITLE
fix(daemon): 恢复 /card off 的「处理中」占位卡与完成 emoji

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -39,8 +39,9 @@ import { startTerminalProxy, type TerminalProxyHandle } from './core/terminal-pr
 import type { CliId } from './adapters/cli/types.js';
 import * as scheduler from './core/scheduler.js';
 import { scanProjects, scanMultipleProjects } from './services/project-scanner.js';
-import { buildQuotaExhaustedCard, buildRepoSelectCard, buildStreamingCard, getCliDisplayName } from './im/lark/card-builder.js';
-import { createPendingResponseQueue, markPendingResponseCardPatched, syncPendingResponseState } from './core/pending-response.js';
+import { buildPendingResponseCard, buildQuotaExhaustedCard, buildRepoSelectCard, buildStreamingCard, getCliDisplayName } from './im/lark/card-builder.js';
+import { createPendingResponseQueue, markPendingResponseCardPatched, shouldTreatPendingCardAsPatchedByMarker, startPendingResponseTurn, syncPendingResponseState } from './core/pending-response.js';
+import { readPendingResponsePatchMarker } from './services/pending-response-transaction-store.js';
 import { t as tr, botLocale, localeForBot } from './i18n/index.js';
 import { createCliAdapterSync } from './adapters/cli/registry.js';
 import {
@@ -345,19 +346,38 @@ function readSessionFreshFromDisk(sessionId: string, larkAppId: string): import(
   return undefined;
 }
 
-async function postPendingResponseCard(ds: DaemonSession, replyToMessageId: string, prompt: string, sender?: { name?: string }, turnId?: string): Promise<void> {
-  // Card-off means no visible botmux cards at all. If a prior build left an
-  // open pending-response placeholder on this session, clear its state so a
-  // later `botmux send --mention...` cannot patch it to “final reply sent via
-  // new message”. Do not call any Lark send/update API here.
+export async function postPendingResponseCard(ds: DaemonSession, replyToMessageId: string, prompt: string, sender?: { name?: string }, turnId?: string): Promise<void> {
+  // Card-off path (streaming card disabled for this session): post a lightweight
+  // 「处理中」 placeholder. The final reply / `botmux send` patches this card in
+  // place — and that patch is also what lets the 完成 emoji land on the user's
+  // original message. When streaming cards are ON the streaming card itself is
+  // the placeholder, so this is a no-op for those sessions.
+  if (!streamingCardDisabledFor(ds)) return;
   await pendingResponseQueue.run(ds.session.sessionId, async () => {
     const fresh = readSessionFreshFromDisk(ds.session.sessionId, ds.larkAppId);
     syncPendingResponseState(ds, fresh);
     if (fresh) syncReplyTargetState(ds, fresh);
-    if (ds.pendingResponseCardId || ds.session.pendingResponseCardId) {
+    // Reconcile a PATCH that committed at Feishu but whose session save lost the
+    // race, so a stale prior card isn't left dangling as "open".
+    const marker = readPendingResponsePatchMarker(ds.session.sessionId);
+    if (shouldTreatPendingCardAsPatchedByMarker(ds.pendingResponseCardId, marker)) {
       markPendingResponseCardPatched(ds);
-      markPendingResponseCardPatched(ds.session);
+    }
+    syncPendingResponseState(ds.session, ds);
+    const card = buildPendingResponseCard(localeForBot(ds.larkAppId));
+    try {
+      // Route the placeholder to the same target the final reply will use: a
+      // topic-alias turn (chat-scope + matching turnId) lands in the topic
+      // thread; otherwise it's a plain chat message / thread-scope reply.
+      const target = resolveSessionReplyTarget(ds, turnId);
+      const messageId = target.mode === 'thread'
+        ? await replyMessage(ds.larkAppId, target.rootMessageId, card, 'interactive', true)
+        : await sendMessage(ds.larkAppId, target.chatId, card, 'interactive');
+      startPendingResponseTurn(ds, messageId);
+      startPendingResponseTurn(ds.session, messageId);
       sessionStore.updateSession(ds.session);
+    } catch (err) {
+      logger.warn(`[${tag(ds)}] failed to post pending response card: ${err instanceof Error ? err.message : String(err)}`);
     }
   });
 }

--- a/test/pending-response-card-post.test.ts
+++ b/test/pending-response-card-post.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Regression: `/card off` (disableStreamingCard) must still post a 「处理中」
+ * placeholder card and record it as the open pending-response card — that card
+ * is what the final reply / `botmux send` patches in place, and its patch is
+ * what lets the 完成 emoji land on the user's message.
+ *
+ * Commit 8b48871 (topic reply mode) silently neutered `postPendingResponseCard`
+ * into a no-op ("card-off = no visible botmux cards at all"), which made both
+ * the placeholder and the emoji disappear. There was no test covering the
+ * placeholder-post path, so the regression slipped in. This locks the
+ * creation side; the patch + GoGoGo-emoji side is covered by
+ * test/bridge-final-output-retry.test.ts.
+ *
+ * Run:  pnpm vitest run test/pending-response-card-post.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const mocks = vi.hoisted(() => ({
+  replyMessage: vi.fn(),
+  sendMessage: vi.fn(),
+}));
+
+vi.mock('@larksuiteoapi/node-sdk', () => {
+  class FakeClient { constructor(public opts: Record<string, unknown>) {} }
+  return { Client: FakeClient };
+});
+
+vi.mock('../src/im/lark/client.js', async () => {
+  const actual = await vi.importActual<any>('../src/im/lark/client.js');
+  return { ...actual, replyMessage: mocks.replyMessage, sendMessage: mocks.sendMessage };
+});
+
+import { registerBot } from '../src/bot-registry.js';
+import { postPendingResponseCard } from '../src/daemon.js';
+import {
+  markPendingResponsePatchMarkerPatched,
+  writePendingResponsePatchMarker,
+} from '../src/services/pending-response-transaction-store.js';
+import type { DaemonSession } from '../src/core/types.js';
+
+const APP = 'pending_card_app';
+const APP_NOCARD = 'pending_card_nocard_app';
+
+function makeDs(scope: 'chat' | 'thread', over: Partial<DaemonSession> = {}): DaemonSession {
+  const session: any = {
+    sessionId: 'sess-' + Math.random().toString(36).slice(2),
+    chatId: 'oc_pending',
+    rootMessageId: 'om_root',
+    createdAt: new Date().toISOString(),
+  };
+  return {
+    session,
+    larkAppId: APP,
+    chatId: 'oc_pending',
+    scope,
+    ...over,
+  } as unknown as DaemonSession;
+}
+
+function placeholderTitle(content: string): string {
+  return JSON.parse(content).header.title.content;
+}
+const PLACEHOLDER_TITLES = ['处理中', 'Processing'];
+
+describe('postPendingResponseCard — card-off placeholder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.SESSION_DATA_DIR = mkdtempSync(join(tmpdir(), 'botmux-pending-'));
+    mocks.replyMessage.mockResolvedValue('om_placeholder');
+    mocks.sendMessage.mockResolvedValue('om_placeholder');
+    registerBot({
+      larkAppId: APP,
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: ['ou_owner'],
+      disableStreamingCard: true,
+    });
+    registerBot({
+      larkAppId: APP_NOCARD,
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: ['ou_owner'],
+      // streaming card NOT globally disabled — only suppressed for this one chat.
+      noCardChats: ['oc_pending'],
+    });
+  });
+
+  it('chat-scope plain: posts a 处理中 placeholder as a top-level chat message and records it open', async () => {
+    const ds = makeDs('chat');
+    await postPendingResponseCard(ds, 'om_trigger', 'hello', undefined, 'turn-1');
+
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.replyMessage).not.toHaveBeenCalled();
+    const [appId, chatId, content, msgType] = mocks.sendMessage.mock.calls[0];
+    expect(appId).toBe(APP);
+    expect(chatId).toBe('oc_pending');
+    expect(msgType).toBe('interactive');
+    expect(PLACEHOLDER_TITLES).toContain(placeholderTitle(content));
+
+    expect(ds.session.pendingResponseCardId).toBe('om_placeholder');
+    expect(ds.session.pendingResponseCardState).toBe('open');
+  });
+
+  it('thread-scope: replies the placeholder inside the thread', async () => {
+    const ds = makeDs('thread');
+    await postPendingResponseCard(ds, 'om_trigger', 'hello', undefined, 'turn-1');
+
+    expect(mocks.replyMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+    const [appId, target, content, msgType, replyInThread] = mocks.replyMessage.mock.calls[0];
+    expect(appId).toBe(APP);
+    expect(target).toBe('om_root');
+    expect(msgType).toBe('interactive');
+    expect(replyInThread).toBe(true);
+    expect(PLACEHOLDER_TITLES).toContain(placeholderTitle(content));
+    expect(ds.session.pendingResponseCardId).toBe('om_placeholder');
+  });
+
+  it('chat-scope topic-alias: routes the placeholder into the aliased topic thread on a matching turn', async () => {
+    const ds = makeDs('chat', {
+      currentReplyTarget: { rootMessageId: 'om_topic', turnId: 'turn-1', updatedAt: new Date().toISOString() },
+    });
+    await postPendingResponseCard(ds, 'om_trigger', 'hello', undefined, 'turn-1');
+
+    expect(mocks.replyMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+    const [, target, , , replyInThread] = mocks.replyMessage.mock.calls[0];
+    expect(target).toBe('om_topic');
+    expect(replyInThread).toBe(true);
+  });
+
+  it('chat-scope topic-alias: a non-matching turnId does NOT hijack into the stale topic — falls back to plain chat', async () => {
+    // The alias was set for turn-1; a later top-level turn-2 must not be
+    // routed into turn-1's topic thread (resolveSessionReplyTarget turnId gate).
+    const ds = makeDs('chat', {
+      currentReplyTarget: { rootMessageId: 'om_topic', turnId: 'turn-1', updatedAt: new Date().toISOString() },
+    });
+    await postPendingResponseCard(ds, 'om_trigger', 'hello', undefined, 'turn-2');
+
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.replyMessage).not.toHaveBeenCalled();
+    expect(mocks.sendMessage.mock.calls[0][1]).toBe('oc_pending');
+  });
+
+  it('noCardChats: posts the placeholder even when disableStreamingCard is not globally set', async () => {
+    const ds = makeDs('chat', { larkAppId: APP_NOCARD } as Partial<DaemonSession>);
+    await postPendingResponseCard(ds, 'om_trigger', 'hello', undefined, 'turn-1');
+
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.sendMessage.mock.calls[0][0]).toBe(APP_NOCARD);
+    expect(ds.session.pendingResponseCardId).toBe('om_placeholder');
+    expect(ds.session.pendingResponseCardState).toBe('open');
+  });
+
+  it('streaming card enabled (forced): no placeholder posted, no pending card recorded', async () => {
+    const ds = makeDs('chat', { streamingCardForced: true } as Partial<DaemonSession>);
+    await postPendingResponseCard(ds, 'om_trigger', 'hello', undefined, 'turn-1');
+
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+    expect(mocks.replyMessage).not.toHaveBeenCalled();
+    expect(ds.session.pendingResponseCardId).toBeUndefined();
+  });
+
+  it('Lark API failure: swallows the error and records no open card (no dangling pending state)', async () => {
+    mocks.sendMessage.mockRejectedValueOnce(new Error('lark 500'));
+    const ds = makeDs('chat');
+
+    await expect(postPendingResponseCard(ds, 'om_trigger', 'hello', undefined, 'turn-1')).resolves.toBeUndefined();
+    expect(ds.session.pendingResponseCardId).toBeUndefined();
+    expect(ds.session.pendingResponseCardState).toBeUndefined();
+  });
+
+  it('marker reconciliation: a prior open card whose PATCH committed (marker=patched) is settled before a fresh placeholder is posted', async () => {
+    const ds = makeDs('chat');
+    // Simulate a previous turn whose card was PATCHed at Feishu (marker promoted)
+    // but whose session save lost the race, so the in-memory card still looks open.
+    (ds as any).pendingResponseCardId = 'om_stale';
+    (ds as any).pendingResponseCardState = 'open';
+    ds.session.pendingResponseCardId = 'om_stale';
+    ds.session.pendingResponseCardState = 'open';
+    writePendingResponsePatchMarker(ds.session.sessionId, 'om_stale');
+    markPendingResponsePatchMarkerPatched(ds.session.sessionId);
+
+    mocks.sendMessage.mockResolvedValueOnce('om_fresh');
+    await postPendingResponseCard(ds, 'om_trigger', 'hello', undefined, 'turn-1');
+
+    // Stale card reconciled to patched, then a brand-new open card recorded.
+    expect(ds.session.lastPatchedResponseCardId).toBe('om_stale');
+    expect(ds.session.pendingResponseCardId).toBe('om_fresh');
+    expect(ds.session.pendingResponseCardState).toBe('open');
+  });
+
+  it('sequential turns: each turn posts a fresh placeholder and the latest card id wins', async () => {
+    const ds = makeDs('chat');
+    mocks.sendMessage.mockResolvedValueOnce('om_first').mockResolvedValueOnce('om_second');
+
+    await postPendingResponseCard(ds, 'om_trigger', 'hello', undefined, 'turn-1');
+    expect(ds.session.pendingResponseCardId).toBe('om_first');
+
+    await postPendingResponseCard(ds, 'om_trigger2', 'hello again', undefined, 'turn-2');
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(2);
+    expect(ds.session.pendingResponseCardId).toBe('om_second');
+    expect(ds.session.pendingResponseCardState).toBe('open');
+  });
+});

--- a/test/pending-response.test.ts
+++ b/test/pending-response.test.ts
@@ -7,6 +7,7 @@ import {
   isPendingResponseCardOpen,
   markPendingResponseCardPatched,
   markPendingResponseCardPatchedIfCurrent,
+  mergePendingResponseState,
   shouldMarkPendingAsMentionedSend,
   shouldPatchPendingOnExplicitSend,
   shouldWithdrawPreviousPendingOnNewTurn,
@@ -136,5 +137,71 @@ describe('pending response state', () => {
     await Promise.all([first, second]);
     expect(events).toEqual(['first:start', 'first:end', 'second:start']);
     expect(queue.size()).toBe(0);
+  });
+});
+
+// mergePendingResponseState reconciles a worker's incoming Session save against
+// the daemon's freshly-persisted pending-card state. It is the race guard that
+// keeps a placeholder card (and therefore the 完成 emoji) from being lost or
+// double-opened when worker and daemon write the same session out of order.
+// Used by services/session-store.ts on every persist; previously untested.
+type PR = {
+  marker?: string;
+  pendingResponseCardId?: string;
+  pendingResponseCardState?: 'open' | 'patched';
+  lastPatchedResponseCardId?: string;
+};
+
+describe('mergePendingResponseState', () => {
+  it('returns incoming verbatim when there is no existing persisted record', () => {
+    const incoming: PR = { marker: 'in', pendingResponseCardId: 'om_x', pendingResponseCardState: 'open' };
+    expect(mergePendingResponseState(incoming, undefined)).toBe(incoming);
+  });
+
+  it('returns incoming when the existing record carries no pending-card fields', () => {
+    const incoming: PR = { marker: 'in', pendingResponseCardId: 'om_x', pendingResponseCardState: 'open' };
+    const existing: PR = { marker: 'old' };
+    expect(mergePendingResponseState(incoming, existing)).toBe(incoming);
+  });
+
+  it('lets a worker that opened a brand-new card win over stale persisted state', () => {
+    const incoming: PR = { pendingResponseCardId: 'om_new', pendingResponseCardState: 'open' };
+    const existing: PR = { pendingResponseCardState: 'patched', lastPatchedResponseCardId: 'om_old' };
+    expect(mergePendingResponseState(incoming, existing)).toBe(incoming);
+  });
+
+  it('does NOT re-open a card the persisted state already patched (incoming.open id === existing.lastPatched)', () => {
+    const incoming: PR = { pendingResponseCardId: 'om_dup', pendingResponseCardState: 'open' };
+    const existing: PR = { pendingResponseCardState: 'patched', lastPatchedResponseCardId: 'om_dup' };
+    const merged = mergePendingResponseState(incoming, existing);
+    expect(merged.pendingResponseCardId).toBeUndefined();
+    expect(merged.pendingResponseCardState).toBe('patched');
+    expect(merged.lastPatchedResponseCardId).toBe('om_dup');
+  });
+
+  it('accepts an incoming patch when the existing record has no newer open card', () => {
+    const incoming: PR = { pendingResponseCardState: 'patched', lastPatchedResponseCardId: 'om_a' };
+    const existing: PR = { pendingResponseCardState: 'patched', lastPatchedResponseCardId: 'om_a' };
+    expect(mergePendingResponseState(incoming, existing)).toBe(incoming);
+  });
+
+  it('protects a newer open card from being clobbered by an older finalizer marking patched', () => {
+    const incoming: PR = { pendingResponseCardState: 'patched', lastPatchedResponseCardId: 'om_a' };
+    const existing: PR = { pendingResponseCardId: 'om_b', pendingResponseCardState: 'open' };
+    const merged = mergePendingResponseState(incoming, existing);
+    expect(merged.pendingResponseCardId).toBe('om_b');
+    expect(merged.pendingResponseCardState).toBe('open');
+    expect(merged.lastPatchedResponseCardId).toBeUndefined();
+  });
+
+  it('preserves a persisted open card when the incoming save has no pending intent, keeping incoming\'s other fields', () => {
+    const incoming: PR = { marker: 'keep' };
+    const existing: PR = { pendingResponseCardId: 'om_b', pendingResponseCardState: 'open' };
+    const merged = mergePendingResponseState(incoming, existing);
+    expect(merged.marker).toBe('keep');
+    expect(merged.pendingResponseCardId).toBe('om_b');
+    expect(merged.pendingResponseCardState).toBe('open');
+    expect(merged).not.toBe(incoming);
+    expect(merged).not.toBe(existing);
   });
 });


### PR DESCRIPTION
## 背景

用户反馈：关闭流式卡片后，最新版本不再显示「处理中」占位卡，完成 emoji（GoGoGo）也消失了。

排查（本话题前文 Codex oncall 会话已定位）：`8b48871`（topic reply mode）顺手把 `postPendingResponseCard()` 改成了「card-off 不发任何 botmux 卡、只同步/清理 pending 状态」的空操作。完成 emoji 依赖最终回复 **patch 一张 open 的占位卡**（worker-pool final_output 路径成功 patch 后才给用户原消息加 reaction）——不创建占位卡，emoji 链路也就一起断了。`/card off` 文案仍写着「状态改用处理中卡片原地更新（不撤回）」，实现已悄悄变成全静默，文案与行为不一致。

## 修复

按「保留轻量占位卡 + 完成 emoji」方向恢复（产品语义、用户提示、既有状态机设计都指向该方案）：

- 恢复占位卡发送，仍由 `streamingCardDisabledFor` 把关（流式卡开启时流式卡本身就是占位，不重复发）
- **topic-reply-mode 兼容**：占位卡走 `8b48871` 自己引入的 `resolveSessionReplyTarget(ds, turnId)` 路由——topic 别名回合落到话题内、普通群平铺、话题群线程内回复，与最终回复落点一致（回归前的旧代码反而做不到这点）
- 重新用 `startPendingResponseTurn` 记录 open 卡 → final_output patch → GoGoGo emoji 链路恢复
- 恢复 PATCH-marker 对账：Feishu PATCH 已提交但 session 存盘输了竞争时，先把旧卡结清为 patched 再发新占位卡，不留悬挂 open 态

## 测试（修复 + 补盲区）

`8b48871` 能悄悄溜进来正是因为**占位卡创建侧此前零测试覆盖**，本 PR 一并补齐：

- 新增 `test/pending-response-card-post.test.ts` 9 例：chat 平铺 / 话题内 / topic 别名命中 / turnId 不匹配回落（不劫持旧话题）/ noCardChats 分支 / Lark API 失败不留悬挂态 / marker 对账 / 连续回合最新卡胜出 / 流式卡开启不发
- `test/pending-response.test.ts` 补 `mergePendingResponseState` 7 例（session-store 每次持久化都走的竞态护栏，此前同样零覆盖）
- patch+emoji 侧已有 `bridge-final-output-retry.test.ts` 覆盖，不重复
- 相关簇 8 文件 104 测全绿；`tsc --noEmit` + `pnpm build` 干净——均在含 i18n 二阶段 + #159 + #160 的最新 master（7c70199d）上重验

## 备注

本修复最初做在共享主 checkout（未提交），期间被同步 master 的会话 auto-stash；本 PR 从 stash 恢复后在干净分支上重建，stash@{0} 暂保留作备份，合并后可丢弃。