### PR TITLE
[codex] fix(daemon): 忽略无效继承工作目录

### DIFF
--- a/src/core/inherit-peer.ts
+++ b/src/core/inherit-peer.ts
@@ -17,7 +17,11 @@
  *   topic is "isolate the context", and silently inheriting overrides it.
  *   See docs/superpowers/specs/2026-05-10-force-topic-mode-design.md.
  */
+import { statSync } from 'node:fs';
+import { resolve } from 'node:path';
 import * as sessionStore from '../services/session-store.js';
+import { logger } from '../utils/logger.js';
+import { expandHomePath } from '../utils/working-dir.js';
 
 export interface InheritOptions {
   scope: 'thread' | 'chat';
@@ -33,14 +37,32 @@ export interface InheritedPeer {
   workingDir: string;
 }
 
+function resolvePeerWorkingDir(workingDir: string): string {
+  return resolve(expandHomePath(workingDir));
+}
+
+function isValidPeerWorkingDir(workingDir: string): boolean {
+  try {
+    return statSync(resolvePeerWorkingDir(workingDir)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 export function findInheritablePeer(opts: InheritOptions): InheritedPeer | null {
   const { scope, anchor, chatId, selfAppId } = opts;
   const sameAnchorPeers = scope === 'thread'
     ? sessionStore.findActiveSessionsByRoot(anchor)
     : sessionStore.findActiveChatScopeSessionsByChat(chatId);
-  const peer = sameAnchorPeers.find(p => p.larkAppId !== selfAppId && !!p.workingDir);
-  if (peer && peer.workingDir) {
-    return { sessionId: peer.sessionId, larkAppId: peer.larkAppId, workingDir: peer.workingDir };
+  for (const peer of sameAnchorPeers) {
+    if (peer.larkAppId === selfAppId || !peer.workingDir) continue;
+    if (isValidPeerWorkingDir(peer.workingDir)) {
+      return { sessionId: peer.sessionId, larkAppId: peer.larkAppId, workingDir: peer.workingDir };
+    }
+    logger.warn(
+      `[inherit-peer] ignored inherited peer workingDir from session ${peer.sessionId.substring(0, 8)} ` +
+      `(app=${peer.larkAppId ?? 'unknown'}): ${resolvePeerWorkingDir(peer.workingDir)} is missing or not a directory`,
+    );
   }
   return null;
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1982,6 +1982,8 @@ async function resolvePinnedWorkingDir(ctx: {
   return { pinnedWorkingDir, oncallEntry, inheritedFrom };
 }
 
+export const __testOnly_resolvePinnedWorkingDir = resolvePinnedWorkingDir;
+
 async function replyInvalidWorkingDirs(
   anchor: string,
   larkAppId: string,
@@ -2930,34 +2932,15 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
     session.scope = scope;
     sessionStore.updateSession(session);
 
-    // Oncall group: pin working dir from the chat-level binding, even if a
-    // sibling bot (running in another daemon) is the one that persisted it.
-    // Defaults auto-bind path mirrors handleNewTopic — keep both call sites
-    // in sync (this is the auto-create branch that fires when routing lands
-    // here without an active session, e.g. chat-scope first-reply paths).
-    let oncallEntry = findOncallChatForAnyBot(autoCreateChatId);
-    if (!oncallEntry) {
-      oncallEntry = await maybeAutoBindDefaultOncall(larkAppId, autoCreateChatId, autoCreateChatType);
-    }
-
-    // Cross-bot / chat-scope inheritance — see findInheritablePeer comments.
-    const inheritedFrom = !oncallEntry
-      ? findInheritablePeer({
-          scope,
-          anchor,
-          chatId: autoCreateChatId,
-          chatType: autoCreateChatType,
-          selfAppId: larkAppId,
-        })
-      : null;
-
-    // Last-resort fallback: this bot's `defaultWorkingDir`. See handleNewTopic
-    // for the symmetric block — both call sites must stay in sync.
-    const botDefaultWorkingDir = (!oncallEntry && !inheritedFrom)
-      ? resolveBotDefaultWorkingDir(larkAppId)
-      : undefined;
-
-    const pinnedWorkingDir = oncallEntry?.workingDir ?? inheritedFrom?.workingDir ?? botDefaultWorkingDir;
+    // Use the same layered oncall / inherit / default lookup as handleNewTopic
+    // so stale inherited peers are ignored consistently in both spawn paths.
+    const { pinnedWorkingDir, oncallEntry, inheritedFrom } = await resolvePinnedWorkingDir({
+      scope,
+      anchor,
+      chatId: autoCreateChatId,
+      chatType: autoCreateChatType,
+      larkAppId,
+    });
     // Now we know the message will spawn or pend a real session — resolve
     // sender (may await contact API budget) since every downstream branch
     // injects it either into the immediate prompt or stashes it on

--- a/test/daemon-pinned-working-dir.test.ts
+++ b/test/daemon-pinned-working-dir.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Regression coverage for new-session workingDir resolution.
+ *
+ * Run: pnpm vitest run test/daemon-pinned-working-dir.test.ts test/inherit-peer.test.ts
+ */
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@larksuiteoapi/node-sdk', () => {
+  class FakeClient { constructor(public opts: Record<string, unknown>) {} }
+  class FakeWSClient { start() {} }
+  class FakeEventDispatcher { register() {} }
+  return {
+    Client: FakeClient,
+    WSClient: FakeWSClient,
+    EventDispatcher: FakeEventDispatcher,
+    LoggerLevel: { info: 2 },
+  };
+});
+
+let tmpRoot = '';
+
+function tempDir(name: string): string {
+  const dir = join(tmpRoot, name);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+async function loadFreshModules() {
+  vi.resetModules();
+  process.env.SESSION_DATA_DIR = tempDir('sessions');
+  const botRegistry = await import('../src/bot-registry.js');
+  const sessionStore = await import('../src/services/session-store.js');
+  const daemon = await import('../src/daemon.js');
+  sessionStore.init();
+  return { botRegistry, sessionStore, daemon };
+}
+
+async function seedPeerSession(sessionStore: typeof import('../src/services/session-store.js'), workingDir: string) {
+  const peer = sessionStore.createSession('oc_chat', 'om_root', 'peer', 'group');
+  peer.larkAppId = 'app-peer';
+  peer.scope = 'thread';
+  peer.workingDir = workingDir;
+  sessionStore.updateSession(peer);
+  return peer;
+}
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'botmux-daemon-pinned-dir-'));
+});
+
+afterEach(() => {
+  delete process.env.SESSION_DATA_DIR;
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('resolvePinnedWorkingDir', () => {
+  it('inherits a same-anchor peer workingDir when the directory exists', async () => {
+    const { botRegistry, sessionStore, daemon } = await loadFreshModules();
+    const peerDir = tempDir('peer-repo');
+    const defaultDir = tempDir('default-repo');
+    botRegistry.registerBot({ larkAppId: 'app-peer', larkAppSecret: 's', cliId: 'claude-code' });
+    botRegistry.registerBot({
+      larkAppId: 'app-self',
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      defaultWorkingDir: defaultDir,
+    });
+    const peer = await seedPeerSession(sessionStore, peerDir);
+
+    const result = await daemon.__testOnly_resolvePinnedWorkingDir({
+      scope: 'thread',
+      anchor: 'om_root',
+      chatId: 'oc_chat',
+      chatType: 'group',
+      larkAppId: 'app-self',
+    });
+
+    expect(result.pinnedWorkingDir).toBe(peerDir);
+    expect(result.inheritedFrom).toEqual({ sessionId: peer.sessionId, larkAppId: 'app-peer', workingDir: peerDir });
+  });
+
+  it('ignores a stale inherited peer workingDir and falls back to this bot defaultWorkingDir', async () => {
+    const { botRegistry, sessionStore, daemon } = await loadFreshModules();
+    const stalePeerDir = join(tmpRoot, 'deleted-peer-repo');
+    const defaultDir = tempDir('default-repo');
+    botRegistry.registerBot({ larkAppId: 'app-peer', larkAppSecret: 's', cliId: 'claude-code' });
+    botRegistry.registerBot({
+      larkAppId: 'app-self',
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      defaultWorkingDir: defaultDir,
+    });
+    await seedPeerSession(sessionStore, stalePeerDir);
+
+    const result = await daemon.__testOnly_resolvePinnedWorkingDir({
+      scope: 'thread',
+      anchor: 'om_root',
+      chatId: 'oc_chat',
+      chatType: 'group',
+      larkAppId: 'app-self',
+    });
+
+    expect(result.pinnedWorkingDir).toBe(defaultDir);
+    expect(result.inheritedFrom).toBeNull();
+  });
+
+  it('returns no pinned workingDir when inherited peer and defaultWorkingDir are both invalid', async () => {
+    const { botRegistry, sessionStore, daemon } = await loadFreshModules();
+    const stalePeerDir = join(tmpRoot, 'deleted-peer-repo');
+    const staleDefaultDir = join(tmpRoot, 'deleted-default-repo');
+    botRegistry.registerBot({ larkAppId: 'app-peer', larkAppSecret: 's', cliId: 'claude-code' });
+    botRegistry.registerBot({
+      larkAppId: 'app-self',
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      defaultWorkingDir: staleDefaultDir,
+    });
+    await seedPeerSession(sessionStore, stalePeerDir);
+
+    const result = await daemon.__testOnly_resolvePinnedWorkingDir({
+      scope: 'thread',
+      anchor: 'om_root',
+      chatId: 'oc_chat',
+      chatType: 'group',
+      larkAppId: 'app-self',
+    });
+
+    expect(result.pinnedWorkingDir).toBeUndefined();
+    expect(result.inheritedFrom).toBeNull();
+  });
+});

--- a/test/inherit-peer.test.ts
+++ b/test/inherit-peer.test.ts
@@ -4,14 +4,22 @@
  *
  * Run:  pnpm vitest run test/inherit-peer.test.ts
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mockFindByRoot = vi.fn();
 const mockFindByChat = vi.fn();
+const mockLoggerWarn = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/services/session-store.js', () => ({
   findActiveSessionsByRoot: (...args: unknown[]) => mockFindByRoot(...args),
   findActiveChatScopeSessionsByChat: (...args: unknown[]) => mockFindByChat(...args),
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { warn: mockLoggerWarn },
 }));
 
 import { findInheritablePeer } from '../src/core/inherit-peer.js';
@@ -27,16 +35,30 @@ function makePeer(overrides: Partial<{ sessionId: string; rootMessageId: string;
   };
 }
 
+let tmpRoot = '';
+
+function tempDir(name: string): string {
+  const dir = join(tmpRoot, name);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  tmpRoot = mkdtempSync(join(tmpdir(), 'botmux-inherit-peer-'));
   mockFindByRoot.mockReturnValue([]);
   mockFindByChat.mockReturnValue([]);
 });
 
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
 describe('findInheritablePeer — layer 1 (cross-bot same-anchor)', () => {
   it('returns a thread-scope peer pinned at the same root by another bot', () => {
+    const workingDir = tempDir('repo-a');
     mockFindByRoot.mockReturnValue([
-      makePeer({ sessionId: 'peer-1', rootMessageId: 'om_root', workingDir: '/repo/a', larkAppId: 'app-other' }),
+      makePeer({ sessionId: 'peer-1', rootMessageId: 'om_root', workingDir, larkAppId: 'app-other' }),
     ]);
     const result = findInheritablePeer({
       scope: 'thread',
@@ -45,7 +67,7 @@ describe('findInheritablePeer — layer 1 (cross-bot same-anchor)', () => {
       chatType: 'group',
       selfAppId: 'app-self',
     });
-    expect(result).toEqual({ sessionId: 'peer-1', larkAppId: 'app-other', workingDir: '/repo/a' });
+    expect(result).toEqual({ sessionId: 'peer-1', larkAppId: 'app-other', workingDir });
   });
 
   it('skips peer that belongs to the same bot (would be self-inherit)', () => {
@@ -63,8 +85,9 @@ describe('findInheritablePeer — layer 1 (cross-bot same-anchor)', () => {
   });
 
   it('returns chat-scope peer pinned at the same chat by another bot', () => {
+    const workingDir = tempDir('repo-b');
     mockFindByChat.mockReturnValue([
-      makePeer({ sessionId: 'peer-2', chatId: 'oc_chat', scope: 'chat', workingDir: '/repo/b', larkAppId: 'app-other' }),
+      makePeer({ sessionId: 'peer-2', chatId: 'oc_chat', scope: 'chat', workingDir, larkAppId: 'app-other' }),
     ]);
     const result = findInheritablePeer({
       scope: 'chat',
@@ -73,7 +96,48 @@ describe('findInheritablePeer — layer 1 (cross-bot same-anchor)', () => {
       chatType: 'group',
       selfAppId: 'app-self',
     });
-    expect(result).toEqual({ sessionId: 'peer-2', larkAppId: 'app-other', workingDir: '/repo/b' });
+    expect(result).toEqual({ sessionId: 'peer-2', larkAppId: 'app-other', workingDir });
+  });
+
+  it('skips a stale same-anchor peer workingDir and inherits the next valid peer', () => {
+    const missingDir = join(tmpRoot, 'missing-repo');
+    const validDir = tempDir('repo-c');
+    mockFindByRoot.mockReturnValue([
+      makePeer({ sessionId: 'stale-peer', rootMessageId: 'om_root', workingDir: missingDir, larkAppId: 'app-other' }),
+      makePeer({ sessionId: 'valid-peer', rootMessageId: 'om_root', workingDir: validDir, larkAppId: 'app-third' }),
+    ]);
+
+    const result = findInheritablePeer({
+      scope: 'thread',
+      anchor: 'om_root',
+      chatId: 'oc_chat',
+      chatType: 'group',
+      selfAppId: 'app-self',
+    });
+
+    expect(result).toEqual({ sessionId: 'valid-peer', larkAppId: 'app-third', workingDir: validDir });
+    expect(mockLoggerWarn).toHaveBeenCalledWith(expect.stringContaining('ignored inherited peer workingDir'));
+    expect(mockLoggerWarn).toHaveBeenCalledWith(expect.stringContaining(missingDir));
+  });
+
+  it('returns null and logs when every same-anchor peer workingDir is invalid', () => {
+    const filePath = join(tmpRoot, 'not-a-directory');
+    writeFileSync(filePath, 'not a directory', 'utf-8');
+    mockFindByRoot.mockReturnValue([
+      makePeer({ sessionId: 'file-peer', rootMessageId: 'om_root', workingDir: filePath, larkAppId: 'app-other' }),
+    ]);
+
+    const result = findInheritablePeer({
+      scope: 'thread',
+      anchor: 'om_root',
+      chatId: 'oc_chat',
+      chatType: 'group',
+      selfAppId: 'app-self',
+    });
+
+    expect(result).toBeNull();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(expect.stringContaining('ignored inherited peer workingDir'));
+    expect(mockLoggerWarn).toHaveBeenCalledWith(expect.stringContaining(filePath));
   });
 });
 


### PR DESCRIPTION
## 背景 / 现象

新会话会在同一 thread / anchor 下尝试继承 sibling bot 的 `workingDir`。如果 peer session 是历史会话，目录可能已经不存在；旧逻辑会直接使用该目录，随后在工作目录校验阶段关闭新 session 并提示配置目录不存在，即使当前 bot 自己配置了可用的 `defaultWorkingDir`。

## 修复

- 在 `findInheritablePeer` 选择 peer 前校验 `workingDir` 存在且是目录。
- 对无效 inherited peer 记录 warning 并继续寻找下一个可继承 peer；没有有效 peer 时回退到当前 bot 的 `defaultWorkingDir`。
- auto-create follow-up 分支复用 `resolvePinnedWorkingDir`，与 `handleNewTopic` 保持同一套 oncall / inherited peer / defaultWorkingDir 优先级。

## 回归覆盖

- 同 anchor peer 的 `workingDir` 存在时仍然继承。
- 同 anchor peer 的 `workingDir` 无效时，使用当前 bot 的 `defaultWorkingDir`，并且不会把 inherited peer 当成 pinned dir。
- inherited peer 和 `defaultWorkingDir` 都无效时，不返回 pinned workingDir，保留原有 repo selection / invalid workingDir 后续流程。

## 验证

- `npm exec --yes pnpm@9.5.0 -- vitest run test/inherit-peer.test.ts test/daemon-pinned-working-dir.test.ts`
- `npm exec --yes pnpm@9.5.0 -- run build`
- `git diff --check`

## 影响范围

仅影响新会话创建时跨 bot / 同 anchor 继承工作目录的候选筛选。已有有效继承、oncall binding、`defaultWorkingDir` 和 repo selection 行为保持原优先级。