### PR TITLE
fix(card): 话题内触发的卡片保留在话题内（ephemeral 仅限 chat-scope）

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -573,6 +573,15 @@ export async function deliverWriteLinkCard(
  * (topic groups reject with 18053) or in p2p, fall back to the normal visible
  * reply (`reply`). `content` is the card JSON when msgType==='interactive',
  * otherwise the plain text. Topic-group / p2p behavior is unchanged.
+ *
+ * IMPORTANT: ephemeral is only attempted for flat **chat-scope** sessions. The
+ * ephemeral API (`ephemeral/v1/send`) takes a `chat_id` only — it has no
+ * thread/root anchoring — so for a **thread-scope** session (a 话题 inside a
+ * 普通群, or a 话题群 topic) an ephemeral card would escape the topic and land at
+ * the group top-level. 话题群 happened to reject ephemeral with 18053 and fall
+ * back to the in-thread reply, but a 话题 inside a 普通群 succeeds and leaks the
+ * card out of the thread. So thread-scope sessions always take the visible
+ * `reply()` path, which routes back into the thread (`reply_in_thread`).
  */
 export async function deliverEphemeralOrReply(
   ds: DaemonSession,
@@ -581,7 +590,7 @@ export async function deliverEphemeralOrReply(
   msgType: 'text' | 'interactive',
   reply: () => Promise<unknown>,
 ): Promise<void> {
-  if (operatorOpenId && ds.chatType !== 'p2p') {
+  if (operatorOpenId && ds.chatType !== 'p2p' && ds.scope === 'chat') {
     try {
       // The ephemeral API is card-only (msg_type=text → 10003), so wrap a plain
       // confirmation line into a minimal markdown card.

--- a/test/card-integration.test.ts
+++ b/test/card-integration.test.ts
@@ -186,6 +186,7 @@ function makeDaemonSession(overrides?: Partial<DaemonSession>): DaemonSession {
       updatedAt: Date.now(),
       pid: null,
       chatType: 'group',
+      scope: 'chat',
     },
     worker: { killed: false, send: vi.fn() } as any,
     workerPort: 8080,
@@ -193,6 +194,10 @@ function makeDaemonSession(overrides?: Partial<DaemonSession>): DaemonSession {
     larkAppId: APP_ID,
     chatId: 'oc_chat',
     chatType: 'group',
+    // Flat 普通群 session: status confirmations (restart/close/resume/not-ready)
+    // go out as "visible-to-you" ephemeral cards. Thread-scope sessions take the
+    // visible in-thread reply instead — covered by the thread-scope cases below.
+    scope: 'chat',
     spawnedAt: Date.now(),
     cliVersion: '1.0',
     lastMessageAt: Date.now(),
@@ -597,7 +602,7 @@ describe('Card integration: full event flow', () => {
       vi.mocked(sessionStoreMod.getSession).mockReturnValue({
         sessionId, chatId: 'oc_chat', rootMessageId: ROOT_ID,
         title: 'closed', status: 'closed', createdAt: '2026-01-01T00:00:00.000Z',
-        larkAppId: APP_ID, scope: 'thread', cliId: 'claude-code',
+        larkAppId: APP_ID, scope: 'chat', cliId: 'claude-code',
       } as any);
 
       const sm = await import('../src/core/session-manager.js');
@@ -606,6 +611,7 @@ describe('Card integration: full event flow', () => {
         larkAppId: APP_ID,
         chatId: 'oc_chat',
         chatType: 'group',
+        scope: 'chat',  // flat 普通群 → resume notice goes out ephemeral
       };
       vi.mocked(sm.resumeSession).mockReturnValue({ ok: true, ds: fakeDs } as any);
 
@@ -727,6 +733,86 @@ describe('Card integration: full event flow', () => {
 
       expect(sm.resumeSession).not.toHaveBeenCalled();
       expect(deps.sessionReply).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Scenario 4b: thread-scope confirmations stay in-thread (no leak) ───
+  //
+  // Regression guard: the ephemeral API has no thread anchor, so a 话题 (a
+  // thread-scope session inside a 普通群) must NOT use ephemeral — the
+  // restart/close/resume confirmation has to stay in the topic via the visible
+  // in-thread reply (sessionReply → reply_in_thread). Flat 普通群 (scope:'chat',
+  // tested in Scenario 4) keeps the ephemeral "visible-to-you" behaviour.
+
+  describe('Scenario 4b: thread-scope status cards stay in the thread', () => {
+    it('restart confirmation in a thread-scope session is a visible in-thread reply, never ephemeral', async () => {
+      const clientMod = await import('../src/im/lark/client.js');
+      const workerSend = vi.fn();
+      const ds = makeDaemonSession({
+        scope: 'thread',
+        worker: { killed: false, send: workerSend } as any,
+      });
+      const sessions = new Map<string, DaemonSession>();
+      sessions.set(sessionKey(ROOT_ID, APP_ID), ds);
+      const deps = makeDeps(sessions);
+
+      await handleCardAction(makeRestartEvent(ROOT_ID), deps, APP_ID);
+
+      expect(workerSend).toHaveBeenCalledWith({ type: 'restart' });
+      expect(vi.mocked(clientMod.sendEphemeralCard)).not.toHaveBeenCalled();
+      expect(deps.sessionReply).toHaveBeenCalledWith(
+        ROOT_ID, expect.stringContaining('重启'), undefined, APP_ID,
+      );
+    });
+
+    it('close card in a thread-scope session is replied in-thread, never ephemeral', async () => {
+      const clientMod = await import('../src/im/lark/client.js');
+      const ds = makeDaemonSession({ scope: 'thread' });
+      const sessions = new Map<string, DaemonSession>();
+      const sKey = sessionKey(ROOT_ID, APP_ID);
+      sessions.set(sKey, ds);
+      const deps = makeDeps(sessions);
+
+      await handleCardAction(makeCloseEvent(ROOT_ID), deps, APP_ID);
+
+      expect(killWorker).toHaveBeenCalledWith(ds);
+      expect(sessions.has(sKey)).toBe(false);
+      expect(vi.mocked(clientMod.sendEphemeralCard)).not.toHaveBeenCalled();
+      expect(deps.sessionReply).toHaveBeenCalledWith(
+        ROOT_ID, expect.stringContaining('"type":"closed"'), 'interactive', APP_ID,
+      );
+    });
+
+    it('resume notice in a thread-scope session is replied in-thread, never ephemeral', async () => {
+      const clientMod = await import('../src/im/lark/client.js');
+      const sessionId = 'closed-uuid-thread';
+      const sessions = new Map<string, DaemonSession>();
+      const deps = makeDeps(sessions);
+
+      const sessionStoreMod = await import('../src/services/session-store.js');
+      vi.mocked(sessionStoreMod.getSession).mockReturnValue({
+        sessionId, chatId: 'oc_chat', rootMessageId: ROOT_ID,
+        title: 'closed', status: 'closed', createdAt: '2026-01-01T00:00:00.000Z',
+        larkAppId: APP_ID, scope: 'thread', cliId: 'claude-code',
+      } as any);
+
+      const sm = await import('../src/core/session-manager.js');
+      const fakeDs: any = {
+        session: { sessionId, cliId: 'claude-code' },
+        larkAppId: APP_ID,
+        chatId: 'oc_chat',
+        chatType: 'group',
+        scope: 'thread',  // 话题里恢复 → 确认留在话题内
+      };
+      vi.mocked(sm.resumeSession).mockReturnValue({ ok: true, ds: fakeDs } as any);
+
+      await handleCardAction(makeResumeEvent(ROOT_ID, sessionId), deps, APP_ID);
+
+      expect(sm.resumeSession).toHaveBeenCalledWith(sessionId, sessions);
+      expect(vi.mocked(clientMod.sendEphemeralCard)).not.toHaveBeenCalled();
+      expect(deps.sessionReply).toHaveBeenCalledWith(
+        ROOT_ID, expect.stringContaining('已恢复'), undefined, APP_ID,
+      );
     });
   });
 

--- a/test/ephemeral-or-reply.test.ts
+++ b/test/ephemeral-or-reply.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for deliverEphemeralOrReply (worker-pool.ts) — how restart /
+ * session-closed / resume status confirmations reach the operator.
+ *
+ * Regression guard (本次修复): the ephemeral API (`ephemeral/v1/send`) takes a
+ * `chat_id` only and has no thread/root anchoring. So an ephemeral confirmation
+ * for a **thread-scope** session (a 话题 inside a 普通群) escapes the topic and
+ * lands at the group top-level. The fix gates ephemeral to flat **chat-scope**
+ * sessions only; thread-scope sessions take the visible `reply()` path, which
+ * routes back into the thread via `reply_in_thread`.
+ *
+ * Run:  pnpm vitest run test/ephemeral-or-reply.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DaemonSession } from '../src/core/types.js';
+
+const { sendEphemeralCardMock } = vi.hoisted(() => ({
+  sendEphemeralCardMock: vi.fn(),
+}));
+
+vi.mock('../src/bot-registry.js', () => ({
+  getBot: vi.fn(() => ({ resolvedAllowedUsers: [], config: {} })),
+  getAllBots: vi.fn(() => []),
+  resolveBrandLabel: vi.fn(() => undefined),
+}));
+
+vi.mock('../src/im/lark/client.js', () => ({
+  updateMessage: vi.fn(),
+  deleteMessage: vi.fn(),
+  sendEphemeralCard: sendEphemeralCardMock,
+  sendUserMessage: vi.fn(),
+  addReaction: vi.fn(),
+  MessageWithdrawnError: class extends Error {},
+}));
+
+vi.mock('../src/services/frozen-card-store.js', () => ({
+  loadFrozenCards: vi.fn(() => new Map()),
+  saveFrozenCards: vi.fn(),
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+import { deliverEphemeralOrReply } from '../src/core/worker-pool.js';
+
+const OP = 'ou_operator';
+
+const ds = (over: Partial<DaemonSession> = {}) => ({
+  larkAppId: 'app',
+  chatId: 'oc_here',
+  chatType: 'group',
+  scope: 'chat',
+  session: { sessionId: 'sess1234abcd', rootMessageId: 'om_root' },
+  ...over,
+} as unknown as DaemonSession);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sendEphemeralCardMock.mockResolvedValue('eph_msg_id');
+});
+
+describe('deliverEphemeralOrReply', () => {
+  it('uses an ephemeral card (not the visible reply) for a flat chat-scope 普通群 session', async () => {
+    const reply = vi.fn().mockResolvedValue('reply_id');
+    await deliverEphemeralOrReply(ds({ scope: 'chat' }), OP, 'restarted', 'text', reply);
+    expect(sendEphemeralCardMock).toHaveBeenCalledTimes(1);
+    expect(sendEphemeralCardMock.mock.calls[0][0]).toBe('app');
+    expect(sendEphemeralCardMock.mock.calls[0][1]).toBe('oc_here');
+    expect(sendEphemeralCardMock.mock.calls[0][2]).toBe(OP);
+    expect(reply).not.toHaveBeenCalled();
+  });
+
+  it('wraps a plain text confirmation into a markdown card before sending ephemeral', async () => {
+    await deliverEphemeralOrReply(ds({ scope: 'chat' }), OP, 'restarted', 'text', vi.fn());
+    const cardJson = sendEphemeralCardMock.mock.calls[0][3];
+    const card = JSON.parse(cardJson);
+    expect(card.elements[0]).toMatchObject({ tag: 'markdown', content: 'restarted' });
+  });
+
+  it('passes an interactive card JSON through verbatim (no re-wrapping)', async () => {
+    const CARD = '{"card":"closed"}';
+    await deliverEphemeralOrReply(ds({ scope: 'chat' }), OP, CARD, 'interactive', vi.fn());
+    expect(sendEphemeralCardMock.mock.calls[0][3]).toBe(CARD);
+  });
+
+  it('REGRESSION: keeps the card in the thread for a thread-scope session — never ephemeral', async () => {
+    // A 话题 inside a 普通群: scope='thread'. Ephemeral has no thread anchor, so it
+    // must NOT be attempted — the card has to stay in the topic via reply().
+    const reply = vi.fn().mockResolvedValue('reply_id');
+    await deliverEphemeralOrReply(ds({ scope: 'thread' }), OP, 'restarted', 'text', reply);
+    expect(sendEphemeralCardMock).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledTimes(1);
+  });
+
+  it('REGRESSION: thread-scope close card stays in-thread too (interactive)', async () => {
+    const CARD = '{"card":"closed"}';
+    const reply = vi.fn().mockResolvedValue('reply_id');
+    await deliverEphemeralOrReply(ds({ scope: 'thread' }), OP, CARD, 'interactive', reply);
+    expect(sendEphemeralCardMock).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledTimes(1);
+  });
+
+  it('replies visibly (no ephemeral) for p2p chats', async () => {
+    const reply = vi.fn().mockResolvedValue('reply_id');
+    await deliverEphemeralOrReply(ds({ chatType: 'p2p', scope: 'chat' }), OP, 'restarted', 'text', reply);
+    expect(sendEphemeralCardMock).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledTimes(1);
+  });
+
+  it('replies visibly when there is no operator open_id', async () => {
+    const reply = vi.fn().mockResolvedValue('reply_id');
+    await deliverEphemeralOrReply(ds({ scope: 'chat' }), undefined, 'restarted', 'text', reply);
+    expect(sendEphemeralCardMock).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the visible reply when a chat-scope ephemeral send fails (e.g. 18053)', async () => {
+    sendEphemeralCardMock.mockRejectedValueOnce(new Error('chat can not be thread (code: 18053)'));
+    const reply = vi.fn().mockResolvedValue('reply_id');
+    await deliverEphemeralOrReply(ds({ scope: 'chat' }), OP, 'restarted', 'text', reply);
+    expect(sendEphemeralCardMock).toHaveBeenCalledTimes(1);
+    expect(reply).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 问题

话题内触发机器人的状态卡（重启/会话已关闭/会话已恢复确认）会发到话题外、落到普通群顶层。

## 根因

「私密话题 / 仅自己可见」ephemeral 特性（`be354449`）让 `deliverEphemeralOrReply` 对**任意非 p2p** 会话都走 `ephemeral/v1/send`。该 API 只接受 `chat_id`、**没有 thread/root 锚点**，所以对 **thread-scope** 会话（普通群里的话题）发出的确认卡会逃出话题、落到群顶层。

- 话题群：ephemeral 被 18053 拒绝 → 回退到 in-thread reply → 不暴露
- 普通群里的话题：ephemeral 成功 → 卡片外漏到顶层 ← 本 bug

## 修复

`deliverEphemeralOrReply` 的 ephemeral 路径加 `ds.scope === 'chat'` 守卫：

- **chat-scope（扁平普通群）**：可见回复本就落顶层，ephemeral 与之同位 → 保留「仅自己可见」体验
- **thread-scope（话题）**：一律走可见 `reply()`，经 `reply_in_thread` 回到话题内
- p2p / 无 operator：不变

顺带：话题群不再发出注定 18053 的徒劳 ephemeral 调用。

## 测试

新增 `test/ephemeral-or-reply.test.ts`（8 例），含两条 thread-scope 回归用例锁定「话题内卡片不外漏」。`pnpm build`（tsc）干净；相关套件（write-link / private-card / reply-mode / card-handler ×3 / command-handler）168 例全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)