### PR TITLE
fix(workflow): propagate cliPathOverride to daemon spawn init

### DIFF
--- a/src/im/lark/workflow-slash-command.ts
+++ b/src/im/lark/workflow-slash-command.ts
@@ -272,6 +272,7 @@ function snapshotFromConfig(
     cliId: string;
     name?: string;
     workingDir?: string;
+    cliPathOverride?: string;
   },
 ): BotSnapshot {
   return {
@@ -279,6 +280,7 @@ function snapshotFromConfig(
     cliId: cfg.cliId,
     displayName: cfg.name ?? requestedName,
     ...(cfg.workingDir ? { workingDir: cfg.workingDir } : {}),
+    ...(cfg.cliPathOverride ? { cliPathOverride: cfg.cliPathOverride } : {}),
   };
 }
 

--- a/src/workflows/daemon-spawn.ts
+++ b/src/workflows/daemon-spawn.ts
@@ -252,6 +252,9 @@ async function runOneShotImpl(
     larkAppSecret: creds.larkAppSecret,
     botName: input.botName,
     locale: 'zh' as const,
+    ...(input.botSnapshot?.cliPathOverride
+      ? { cliPathOverride: input.botSnapshot.cliPathOverride }
+      : {}),
   };
   logOneShotMemory(input, 'after-init-object');
 

--- a/src/workflows/events/payloads.ts
+++ b/src/workflows/events/payloads.ts
@@ -107,6 +107,7 @@ export const BotSnapshotSchema = z.object({
   cliId: z.string().optional(),
   displayName: z.string().optional(),
   workingDir: z.string().optional(),
+  cliPathOverride: z.string().optional(),
 });
 export type BotSnapshot = z.infer<typeof BotSnapshotSchema>;
 

--- a/src/workflows/events/replay.ts
+++ b/src/workflows/events/replay.ts
@@ -222,6 +222,7 @@ export type RunState = {
       cliId?: string;
       displayName?: string;
       workingDir?: string;
+      cliPathOverride?: string;
     }
   >;
 };

--- a/test/workflow-run-init.test.ts
+++ b/test/workflow-run-init.test.ts
@@ -69,6 +69,7 @@ describe('createRun', () => {
         cliId: 'codex',
         displayName: 'Codex Loopy',
         workingDir: '/tmp/codex',
+        cliPathOverride: '/opt/botmux-mc-codex',
       },
     });
 
@@ -99,6 +100,7 @@ describe('createRun', () => {
         cliId: 'codex',
         displayName: 'Codex Loopy',
         workingDir: '/tmp/codex',
+        cliPathOverride: '/opt/botmux-mc-codex',
       },
     });
 

--- a/test/workflow-runtime.test.ts
+++ b/test/workflow-runtime.test.ts
@@ -687,6 +687,7 @@ describe('botSnapshots reach the spawner', () => {
               cliId: 'codex',
               displayName: 'Pinned',
               workingDir: '/runs/pinned-cwd',
+              cliPathOverride: '/opt/botmux-mc-codex',
             }
           : undefined,
     });
@@ -714,6 +715,7 @@ describe('botSnapshots reach the spawner', () => {
       cliId: 'codex',
       displayName: 'Pinned',
       workingDir: '/runs/pinned-cwd',
+      cliPathOverride: '/opt/botmux-mc-codex',
     });
     expect(captured[0]!.workingDir).toBe('/runs/pinned-cwd');
   });


### PR DESCRIPTION
背景

workflow 模式下，子 agent 启动时会走到 daemon-spawn 链路。该链路中 cliPathOverride 没有从 bot snapshot 透传到 worker init，导致 workflow 子进程可能回退到裸 codex 可执行文件（而不是封装器路径，如 botmux-mc-codex），进而出现登录页/超时问题。

根因
cliPathOverride 在 workflow 的 snapshot/init 数据链路中丢失：
BotSnapshot schema 未包含 cliPathOverride
slash-command 构造 snapshot 时未写入该字段
daemon-spawn 构造 worker init payload 时未透传该字段
replay state 类型未同步字段

修复内容
在 workflow BotSnapshot schema 增加 cliPathOverride?: string
在 snapshot 构造处透传 cfg.cliPathOverride
在 daemon-spawn worker init payload 中透传 input.botSnapshot.cliPathOverride
replay state 类型补齐该字段

影响范围

仅影响 workflow 路径下 worker 启动时 CLI 可执行路径的选择逻辑；非 workflow 常规会话行为不变。

验证
单测：
corepack pnpm test test/workflow-run-init.test.ts test/workflow-runtime.test.ts test/workflow-im-skill.test.ts
结果：36/36 通过
