### PR TITLE
fix(worker): /close 杀掉无 worker 时残留的 tmux/herdr/zellij 后台会话

### DIFF
--- a/src/core/idle-worker-sweeper.ts
+++ b/src/core/idle-worker-sweeper.ts
@@ -1,7 +1,8 @@
 import type { DaemonSession } from './types.js';
 import { readGlobalConfig } from '../global-config.js';
 import { DEFAULT_IDLE_SUSPEND_MS, resolveWorkerBudget, type ResolvedWorkerBudget } from './worker-budget.js';
-import { isSuspendableBackendType, suspendWorker } from './worker-pool.js';
+import { suspendWorker } from './worker-pool.js';
+import { isSuspendableBackendType } from './persistent-backend.js';
 
 export interface IdleWorkerSweepOptions {
   now?: number;

--- a/src/core/persistent-backend.ts
+++ b/src/core/persistent-backend.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared helpers for sessions backed by a persistent multiplexer
+ * (tmux / herdr / zellij). These backends keep the CLI alive across worker
+ * exits BY DESIGN (idle-suspend, lazy restore), so several daemon paths must
+ * resolve / name / probe / kill the backing session WITHOUT a live worker:
+ * the restore-time zombie sweep and terminal wake (session-manager.ts), and
+ * the /close teardown of orphaned sessions (worker-pool.ts killWorker).
+ *
+ * This module owns the backend dispatch so those paths can't drift apart.
+ * It must stay dependency-light (backends + registry + config only) — both
+ * worker-pool and session-manager import it, and those two already form an
+ * import cycle with each other.
+ */
+import { config } from '../config.js';
+import { getBot } from '../bot-registry.js';
+import { TmuxBackend } from '../adapters/backend/tmux-backend.js';
+import { HerdrBackend } from '../adapters/backend/herdr-backend.js';
+import { ZellijBackend } from '../adapters/backend/zellij-backend.js';
+import type { BackendType, SessionProbe } from '../adapters/backend/types.js';
+import type { DaemonSession } from './types.js';
+
+export type PersistentBackendType = Exclude<BackendType, 'pty'>;
+
+export function isSuspendableBackendType(
+  backendType: BackendType | undefined,
+): backendType is PersistentBackendType {
+  return backendType === 'tmux' || backendType === 'herdr' || backendType === 'zellij';
+}
+
+/**
+ * Resolve which persistent backend (if any) backs a session: prefer the
+ * worker's stored init config — the per-session truth captured at spawn time,
+ * which survives idle-suspend and tracks bot-config drift — then the bot
+ * config, then the daemon default (covers lazy-restored sessions that never
+ * forked a worker, where initConfig is unset).
+ */
+export function getSessionPersistentBackendType(ds: DaemonSession): PersistentBackendType | undefined {
+  let backendType: BackendType | undefined = ds.initConfig?.backendType;
+  if (!backendType) {
+    backendType = config.daemon.backendType;
+    try {
+      backendType = getBot(ds.larkAppId).config.backendType ?? backendType;
+    } catch { /* bot deregistered — keep daemon default */ }
+  }
+  return isSuspendableBackendType(backendType) ? backendType : undefined;
+}
+
+/** Deterministic backing-session name (`bmx-<sid8>`, same rule across backends). */
+export function persistentSessionName(backendType: PersistentBackendType, sessionId: string): string {
+  if (backendType === 'tmux') return TmuxBackend.sessionName(sessionId);
+  if (backendType === 'zellij') return ZellijBackend.sessionName(sessionId);
+  return HerdrBackend.sessionName(sessionId);
+}
+
+export function probePersistentSession(backendType: PersistentBackendType, name: string): SessionProbe {
+  if (backendType === 'tmux') return TmuxBackend.probeSession(name);
+  if (backendType === 'zellij') return ZellijBackend.probeSession(name);
+  return HerdrBackend.probeSession(name);
+}
+
+/** Kill a backing session (each backend's killSession is a no-op when absent). */
+export function killPersistentSession(backendType: PersistentBackendType, name: string): void {
+  if (backendType === 'tmux') TmuxBackend.killSession(name);
+  else if (backendType === 'zellij') ZellijBackend.killSession(name);
+  else HerdrBackend.killSession(name);
+}

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -14,14 +14,12 @@ import { logger } from '../utils/logger.js';
 import { forkWorker, forkAdoptWorker, killStalePids, getCurrentCliVersion, restoreUsageLimitRuntimeState, setActiveSessionSafe, isRelayableRealSession, closeSession } from './worker-pool.js';
 import { createCliAdapterSync } from '../adapters/cli/registry.js';
 import { buildBotmuxShellHints } from '../adapters/cli/shared-hints.js';
-import { TmuxBackend } from '../adapters/backend/tmux-backend.js';
-import { HerdrBackend } from '../adapters/backend/herdr-backend.js';
+import { getSessionPersistentBackendType, persistentSessionName, probePersistentSession, killPersistentSession } from './persistent-backend.js';
 import { adoptTargetLabel, validateAdoptTargetState } from './session-discovery.js';
-import { ZellijBackend } from '../adapters/backend/zellij-backend.js';
 import { getBot, getAllBots } from '../bot-registry.js';
 import type { CliId } from '../adapters/cli/types.js';
 import { validateZellijAdoptTarget } from './zellij-adopt-discovery.js';
-import type { BackendType, SessionProbe } from '../adapters/backend/types.js';
+import type { BackendType } from '../adapters/backend/types.js';
 import type { LarkAttachment, LarkMention, ScheduledTask } from '../types.js';
 import type { MessageResource } from '../im/lark/message-parser.js';
 import type { ResolvedSender } from '../im/lark/identity-cache.js';
@@ -830,32 +828,6 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
 
   const hasPersistentBackend = [...activeSessions.values()].some(ds => !!getSessionPersistentBackendType(ds));
   logger.info(`Restored ${active.length} session(s)${hasPersistentBackend ? '' : ', waiting for messages to resume'}`);
-}
-
-function getSessionPersistentBackendType(ds: DaemonSession): Exclude<BackendType, 'pty'> | undefined {
-  let backendType = config.daemon.backendType;
-  try {
-    backendType = getBot(ds.larkAppId).config.backendType ?? backendType;
-  } catch { /* bot deregistered */ }
-  return backendType === 'tmux' || backendType === 'herdr' || backendType === 'zellij' ? backendType : undefined;
-}
-
-function persistentSessionName(backendType: Exclude<BackendType, 'pty'>, sessionId: string): string {
-  if (backendType === 'tmux') return TmuxBackend.sessionName(sessionId);
-  if (backendType === 'zellij') return ZellijBackend.sessionName(sessionId);
-  return HerdrBackend.sessionName(sessionId);
-}
-
-function probePersistentSession(backendType: Exclude<BackendType, 'pty'>, name: string): SessionProbe {
-  if (backendType === 'tmux') return TmuxBackend.probeSession(name);
-  if (backendType === 'zellij') return ZellijBackend.probeSession(name);
-  return HerdrBackend.probeSession(name);
-}
-
-function killPersistentSession(backendType: Exclude<BackendType, 'pty'>, name: string): void {
-  if (backendType === 'tmux') TmuxBackend.killSession(name);
-  else if (backendType === 'zellij') ZellijBackend.killSession(name);
-  else HerdrBackend.killSession(name);
 }
 
 /**

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -26,6 +26,7 @@ import { findUniqueClaudeSessionByCwd } from './session-discovery.js';
 import { buildMarkdownCard, buildContextualReplyCard } from '../im/lark/md-card.js';
 import { TmuxBackend } from '../adapters/backend/tmux-backend.js';
 import { HerdrBackend } from '../adapters/backend/herdr-backend.js';
+import { ZellijBackend } from '../adapters/backend/zellij-backend.js';
 import { getBot, getAllBots, resolveBrandLabel } from '../bot-registry.js';
 import { normalizeBrand } from '../im/lark/lark-hosts.js';
 import { dashboardEventBus } from './dashboard-events.js';
@@ -967,7 +968,16 @@ export function ensureClaudeFolderTrust(workingDir: string, stateJsonPath: strin
 
 export function killWorker(ds: DaemonSession): void {
   clearUsageLimitState(ds);
-  if (!ds.worker || ds.worker.killed) return;
+  if (!ds.worker || ds.worker.killed) {
+    // No live worker to receive {type:'close'}, so its destroySession() — which
+    // tears down the persistent backing session (tmux/herdr/zellij) — never
+    // fires. Those sessions survive a worker exit BY DESIGN (idle-suspend /
+    // lazy-restore keep the CLI alive for later resume), so /close on such a
+    // session would leave an orphaned CLI running in tmux that still replies.
+    // Destroy the backing session directly here so /close always terminates it.
+    destroyOrphanedBackingSession(ds);
+    return;
+  }
   try {
     ds.worker.send({ type: 'close' } as DaemonToWorker);
   } catch { /* IPC already closed */ }
@@ -980,6 +990,44 @@ export function killWorker(ds: DaemonSession): void {
 
 export function isSuspendableBackendType(backendType: BackendType | undefined): boolean {
   return backendType === 'tmux' || backendType === 'herdr' || backendType === 'zellij';
+}
+
+/** Resolve a session's backend type when killing it without a live worker:
+ *  prefer the worker's stored init config, then the bot/daemon config. */
+function resolveBackendTypeForKill(ds: DaemonSession): BackendType | undefined {
+  if (ds.initConfig?.backendType) return ds.initConfig.backendType;
+  try {
+    const cfg = getBot(ds.larkAppId).config.backendType;
+    if (cfg) return cfg;
+  } catch { /* bot not registered — fall through to daemon default */ }
+  return config.daemon.backendType;
+}
+
+/**
+ * Tear down a persistent backing session (tmux/herdr/zellij) directly from the
+ * daemon when there is no live worker to do it via the 'close' IPC. The session
+ * name is deterministic from the session UUID, and each killSession() is a no-op
+ * if the session is already gone.
+ *
+ * Adopt sessions are skipped: botmux never owned the user's pane (ownsSession is
+ * false worker-side too), so killing it would violate the bridge invariant of
+ * leaving the user's own CLI untouched.
+ */
+function destroyOrphanedBackingSession(ds: DaemonSession): void {
+  if (ds.initConfig?.adoptMode || ds.adoptedFrom) return;
+  const backendType = resolveBackendTypeForKill(ds);
+  if (!isSuspendableBackendType(backendType)) return;
+  const sessionId = ds.session.sessionId;
+  try {
+    switch (backendType) {
+      case 'tmux': TmuxBackend.killSession(TmuxBackend.sessionName(sessionId)); break;
+      case 'herdr': HerdrBackend.killSession(HerdrBackend.sessionName(sessionId)); break;
+      case 'zellij': ZellijBackend.killSession(ZellijBackend.sessionName(sessionId)); break;
+    }
+    logger.info(`[${tag(ds)}] killWorker: no live worker — destroyed orphaned ${backendType} backing session`);
+  } catch (err) {
+    logger.warn(`[${tag(ds)}] killWorker: failed to destroy orphaned ${backendType} backing session: ${err}`);
+  }
 }
 
 export function suspendWorker(ds: DaemonSession, reason = 'suspended_idle'): boolean {

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -26,7 +26,7 @@ import { findUniqueClaudeSessionByCwd } from './session-discovery.js';
 import { buildMarkdownCard, buildContextualReplyCard } from '../im/lark/md-card.js';
 import { TmuxBackend } from '../adapters/backend/tmux-backend.js';
 import { HerdrBackend } from '../adapters/backend/herdr-backend.js';
-import { ZellijBackend } from '../adapters/backend/zellij-backend.js';
+import { isSuspendableBackendType, getSessionPersistentBackendType, persistentSessionName, killPersistentSession } from './persistent-backend.js';
 import { getBot, getAllBots, resolveBrandLabel } from '../bot-registry.js';
 import { normalizeBrand } from '../im/lark/lark-hosts.js';
 import { dashboardEventBus } from './dashboard-events.js';
@@ -35,7 +35,6 @@ import { publishAttentionPatch } from './session-activity.js';
 import { knownBotOpenIdsFromCrossRef, type BotMentionEntry } from '../utils/bot-routing.js';
 import { emitSessionLifecycleHook, emitSessionStateTransitionHook } from '../services/session-lifecycle-hooks.js';
 import type { CliId } from '../adapters/cli/types.js';
-import type { BackendType } from '../adapters/backend/types.js';
 import type { DaemonToWorker, WorkerToDaemon, Session, DisplayMode } from '../types.js';
 import { sessionKey, sessionAnchorId, type DaemonSession } from './types.js';
 import { claimPendingResponseCard, COMPLETED_REACTION_EMOJI_TYPE, markPendingResponseCardPatchedIfCurrent, syncPendingResponseState } from './pending-response.js';
@@ -988,21 +987,6 @@ export function killWorker(ds: DaemonSession): void {
   ds.workerToken = null;
 }
 
-export function isSuspendableBackendType(backendType: BackendType | undefined): boolean {
-  return backendType === 'tmux' || backendType === 'herdr' || backendType === 'zellij';
-}
-
-/** Resolve a session's backend type when killing it without a live worker:
- *  prefer the worker's stored init config, then the bot/daemon config. */
-function resolveBackendTypeForKill(ds: DaemonSession): BackendType | undefined {
-  if (ds.initConfig?.backendType) return ds.initConfig.backendType;
-  try {
-    const cfg = getBot(ds.larkAppId).config.backendType;
-    if (cfg) return cfg;
-  } catch { /* bot not registered — fall through to daemon default */ }
-  return config.daemon.backendType;
-}
-
 /**
  * Tear down a persistent backing session (tmux/herdr/zellij) directly from the
  * daemon when there is no live worker to do it via the 'close' IPC. The session
@@ -1015,15 +999,10 @@ function resolveBackendTypeForKill(ds: DaemonSession): BackendType | undefined {
  */
 function destroyOrphanedBackingSession(ds: DaemonSession): void {
   if (ds.initConfig?.adoptMode || ds.adoptedFrom) return;
-  const backendType = resolveBackendTypeForKill(ds);
-  if (!isSuspendableBackendType(backendType)) return;
-  const sessionId = ds.session.sessionId;
+  const backendType = getSessionPersistentBackendType(ds);
+  if (!backendType) return;
   try {
-    switch (backendType) {
-      case 'tmux': TmuxBackend.killSession(TmuxBackend.sessionName(sessionId)); break;
-      case 'herdr': HerdrBackend.killSession(HerdrBackend.sessionName(sessionId)); break;
-      case 'zellij': ZellijBackend.killSession(ZellijBackend.sessionName(sessionId)); break;
-    }
+    killPersistentSession(backendType, persistentSessionName(backendType, ds.session.sessionId));
     logger.info(`[${tag(ds)}] killWorker: no live worker — destroyed orphaned ${backendType} backing session`);
   } catch (err) {
     logger.warn(`[${tag(ds)}] killWorker: failed to destroy orphaned ${backendType} backing session: ${err}`);

--- a/test/kill-worker-orphaned-backend.test.ts
+++ b/test/kill-worker-orphaned-backend.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for killWorker's orphaned-backing-session teardown (worker-pool.ts).
+ *
+ * Bug: clicking 「关闭会话」/close does not kill the CLI running in tmux when the
+ * session has no live worker. A persistent backend (tmux/herdr/zellij) keeps its
+ * backing session + CLI alive across a worker exit BY DESIGN (idle-suspend and
+ * lazy-restore resume into it later). killWorker used to early-return when
+ * `ds.worker` was null, so the 'close' IPC — and the worker-side destroySession()
+ * that tears the backing session down — never ran. The orphaned CLI kept living
+ * in tmux and still replied after /close.
+ *
+ * Fix: when there is no live worker, killWorker destroys the backing session
+ * directly via the deterministic session name. Adopt sessions are skipped (the
+ * user's own pane must never be killed).
+ *
+ * Run:  pnpm vitest run test/kill-worker-orphaned-backend.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { DaemonSession } from '../src/core/types.js';
+
+const { tmuxKill, herdrKill, zellijKill, getBotMock } = vi.hoisted(() => ({
+  tmuxKill: vi.fn(),
+  herdrKill: vi.fn(),
+  zellijKill: vi.fn(),
+  getBotMock: vi.fn(() => ({ resolvedAllowedUsers: [], config: {} })),
+}));
+
+vi.mock('../src/adapters/backend/tmux-backend.js', () => ({
+  TmuxBackend: { sessionName: (id: string) => `bmx-${id.slice(0, 8)}`, killSession: tmuxKill },
+}));
+vi.mock('../src/adapters/backend/herdr-backend.js', () => ({
+  HerdrBackend: { sessionName: (id: string) => `bmx-${id.slice(0, 8)}`, killSession: herdrKill },
+}));
+vi.mock('../src/adapters/backend/zellij-backend.js', () => ({
+  ZellijBackend: { sessionName: (id: string) => `bmx-${id.slice(0, 8)}`, killSession: zellijKill },
+}));
+
+vi.mock('../src/bot-registry.js', () => ({
+  getBot: getBotMock,
+  getAllBots: vi.fn(() => []),
+  resolveBrandLabel: vi.fn(() => undefined),
+}));
+
+vi.mock('../src/im/lark/client.js', () => ({
+  updateMessage: vi.fn(),
+  deleteMessage: vi.fn(),
+  sendEphemeralCard: vi.fn(),
+  sendUserMessage: vi.fn(),
+  addReaction: vi.fn(),
+  MessageWithdrawnError: class extends Error {},
+}));
+
+vi.mock('../src/services/frozen-card-store.js', () => ({
+  loadFrozenCards: vi.fn(() => new Map()),
+  saveFrozenCards: vi.fn(),
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+import { killWorker } from '../src/core/worker-pool.js';
+
+const SID = 'abcd1234-0000-0000-0000-000000000000';
+const EXPECTED_NAME = 'bmx-abcd1234';
+
+// All stream-card fields left unset on both ds and ds.session so
+// persistStreamCardState() early-returns (no disk write) during clearUsageLimitState.
+const ds = (over: Partial<DaemonSession> = {}, initOver: any = {}): DaemonSession => ({
+  larkAppId: 'app',
+  chatId: 'oc_here',
+  chatType: 'group',
+  scope: 'chat',
+  worker: null,
+  session: { sessionId: SID },
+  initConfig: { backendType: 'tmux', ...initOver },
+  ...over,
+} as unknown as DaemonSession);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getBotMock.mockReturnValue({ resolvedAllowedUsers: [], config: {} } as any);
+});
+
+describe('killWorker — orphaned backing session teardown (no live worker)', () => {
+  it('destroys the tmux backing session by deterministic name', () => {
+    killWorker(ds({}, { backendType: 'tmux' }));
+    expect(tmuxKill).toHaveBeenCalledWith(EXPECTED_NAME);
+    expect(herdrKill).not.toHaveBeenCalled();
+    expect(zellijKill).not.toHaveBeenCalled();
+  });
+
+  it('destroys the herdr backing session', () => {
+    killWorker(ds({}, { backendType: 'herdr' }));
+    expect(herdrKill).toHaveBeenCalledWith(EXPECTED_NAME);
+    expect(tmuxKill).not.toHaveBeenCalled();
+  });
+
+  it('destroys the zellij backing session', () => {
+    killWorker(ds({}, { backendType: 'zellij' }));
+    expect(zellijKill).toHaveBeenCalledWith(EXPECTED_NAME);
+    expect(tmuxKill).not.toHaveBeenCalled();
+  });
+
+  it('does nothing for a non-persistent pty backend', () => {
+    killWorker(ds({}, { backendType: 'pty' }));
+    expect(tmuxKill).not.toHaveBeenCalled();
+    expect(herdrKill).not.toHaveBeenCalled();
+    expect(zellijKill).not.toHaveBeenCalled();
+  });
+
+  it('SKIPS adopt sessions (initConfig.adoptMode) — never kills the user\'s own pane', () => {
+    killWorker(ds({}, { backendType: 'tmux', adoptMode: true }));
+    expect(tmuxKill).not.toHaveBeenCalled();
+  });
+
+  it('SKIPS adopt sessions (ds.adoptedFrom set)', () => {
+    killWorker(ds({ adoptedFrom: { source: 'tmux' } as any }, { backendType: 'tmux' }));
+    expect(tmuxKill).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the bot config backendType when initConfig is absent (lazy-restored session)', () => {
+    getBotMock.mockReturnValue({ resolvedAllowedUsers: [], config: { backendType: 'herdr' } } as any);
+    killWorker(ds({ initConfig: undefined } as any, {}));
+    expect(herdrKill).toHaveBeenCalledWith(EXPECTED_NAME);
+    expect(tmuxKill).not.toHaveBeenCalled();
+  });
+});
+
+describe('killWorker — with a live worker (unchanged path)', () => {
+  it('sends the close IPC to the worker and does NOT kill the backing session directly', () => {
+    const send = vi.fn();
+    const d = ds({ worker: { killed: false, send, once: vi.fn() } as any }, { backendType: 'tmux' });
+    killWorker(d);
+    expect(send).toHaveBeenCalledWith({ type: 'close' });
+    // The live worker's own destroySession() handles teardown — daemon must not
+    // double-kill here.
+    expect(tmuxKill).not.toHaveBeenCalled();
+    expect(d.worker).toBeNull();
+  });
+});

--- a/test/worker-suspend.test.ts
+++ b/test/worker-suspend.test.ts
@@ -18,7 +18,8 @@ vi.mock('../src/utils/logger.js', () => ({
   },
 }));
 
-import { isSuspendableBackendType, suspendWorker } from '../src/core/worker-pool.js';
+import { suspendWorker } from '../src/core/worker-pool.js';
+import { isSuspendableBackendType } from '../src/core/persistent-backend.js';
 
 const CLI_IDS: CliId[] = [
   'claude-code',


### PR DESCRIPTION
## 问题

点击「关闭会话」（/close）后，tmux 里的 CLI 进程没被杀掉，CLI 还会继续回复。

## 根因

`killWorker`（worker-pool.ts）在 `ds.worker` 为空时直接 `early-return`，从不发 `{type:'close'}` IPC，worker 侧负责拆掉持久后台会话的 `destroySession()` 也就不会跑。

而持久后端（tmux/herdr/zellij）的后台会话 + CLI 进程**本就会跨 worker 退出而存活**——idle-suspend 与懒恢复都靠它留着以便后续 resume。于是对一个已被挂起（worker 已回收）的会话点「关闭会话」，tmux 里的 CLI 仍在运行、还会继续回复。截图即此场景：关闭卡已发出，CLI 仍回了一条。

## 修复

`killWorker` 在无 live worker 时，按确定性会话名 `bmx-<sid8>` 直接销毁后台会话：

- 后端类型优先取 worker 的 `initConfig.backendType`（覆盖 idle-suspend 主场景），其次回退 bot/daemon 配置（覆盖懒恢复后从未 fork 的会话）。
- **adopt 会话跳过**：那是用户自己的 pane（worker 侧 `ownsSession=false`），杀掉会破坏「不碰用户 CLI」的桥接约束。`initConfig.adoptMode` 或 `ds.adoptedFrom` 任一命中即跳过。
- worker 存活时路径完全不变（仍走 close IPC → destroySession，幂等，不重复杀）。

## 测试

新增 `test/kill-worker-orphaned-backend.test.ts`（8 例）：tmux/herdr/zellij 三种销毁、pty 跳过、adopt 两种跳过、initConfig 缺失时配置回退、live worker 不被直接杀。全量 unit **4091/4091** 通过，tsc 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)