### PR TITLE
feat(cli): start/restart 后打印 dashboard 链接提示

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1198,6 +1198,7 @@ async function cmdStart(): Promise<void> {
   if (refreshAutostart({ pkgRoot: PKG_ROOT, configDir: CONFIG_DIR, logDir: LOG_DIR })) {
     console.log(`   autostart unit 已同步到当前 Node/cli.js 路径`);
   }
+  await printDashboardHintWithRetry();
 }
 
 /**
@@ -1318,6 +1319,7 @@ async function cmdRestart(): Promise<void> {
   if (refreshAutostart({ pkgRoot: PKG_ROOT, configDir: CONFIG_DIR, logDir: LOG_DIR })) {
     console.log(`autostart unit 已同步到当前 Node/cli.js 路径`);
   }
+  await printDashboardHintWithRetry();
 }
 
 /** Wraps `ensureDependencies()`. Neither tmux nor fonts are load-bearing —
@@ -1420,23 +1422,20 @@ function cmdUpgrade(): void {
 }
 
 /**
- * Print a fresh dashboard URL by HMAC-authing to the dashboard process's
- * loopback rotation endpoint. Each call invalidates the previously-issued
- * token, so sharing a URL is the same as sharing a one-shot session.
+ * Try to obtain a fresh dashboard URL via the loopback HMAC rotate endpoint.
+ * Returns { ok: true, url } on success, or { ok: false, reason } so callers
+ * can decide how to surface the failure (hard error vs soft hint).
  */
-async function cmdDashboard(): Promise<void> {
+async function fetchDashboardUrl(): Promise<
+  | { ok: true; url: string }
+  | { ok: false; reason: 'no-secret' | 'unreachable' | 'http-error'; detail?: string }
+> {
   const SECRET_PATH = join(CONFIG_DIR, '.dashboard-secret');
-  if (!existsSync(SECRET_PATH)) {
-    console.error('Dashboard not initialised. Run `botmux restart` first.');
-    process.exit(1);
-  }
+  if (!existsSync(SECRET_PATH)) return { ok: false, reason: 'no-secret' };
   const secret = readFileSync(SECRET_PATH, 'utf8').trim();
   const ts = Math.floor(Date.now() / 1000).toString();
   const nonce = randomBytes(8).toString('hex');
   const sig = createHmac('sha256', secret).update(`${ts}:${nonce}`).digest('base64url');
-  // Prefer the port the dashboard actually bound (it probes upward on
-  // EADDRINUSE, so the live port can differ from the configured default). The
-  // running dashboard refreshes this file on every successful bind.
   const portFile = join(CONFIG_DIR, '.dashboard-port');
   const port = (existsSync(portFile) ? readFileSync(portFile, 'utf8').trim() : '')
     || process.env.BOTMUX_DASHBOARD_PORT
@@ -1453,17 +1452,67 @@ async function cmdDashboard(): Promise<void> {
       },
     });
   } catch {
+    return { ok: false, reason: 'unreachable' };
+  }
+  if (!res.ok) {
+    return { ok: false, reason: 'http-error', detail: `${res.status} ${await res.text()}` };
+  }
+  const body = await res.json() as { url: string };
+  return { ok: true, url: body.url };
+}
+
+/**
+ * Best-effort dashboard hint printed after start/restart. Retries for a few
+ * seconds since the dashboard process boots after the daemon. If it still
+ * isn't ready, print a soft fallback so the user isn't blocked.
+ */
+async function printDashboardHintWithRetry(): Promise<void> {
+  const maxWaitMs = 6000;
+  const stepMs = 500;
+  const started = Date.now();
+  let last: Awaited<ReturnType<typeof fetchDashboardUrl>> | null = null;
+  while (Date.now() - started < maxWaitMs) {
+    last = await fetchDashboardUrl();
+    if (last.ok) {
+      console.log(`   面板: botmux dashboard (${last.url})`);
+      return;
+    }
+    if (last.reason === 'no-secret') break; // secret hasn't been generated — don't spin
+    await new Promise(r => setTimeout(r, stepMs));
+  }
+  // Soft fallback
+  if (last?.reason === 'no-secret') {
+    console.log('   面板: dashboard 凭证未就绪，启动后可用 `botmux dashboard` 获取链接');
+  } else {
+    console.log('   面板: `botmux dashboard`（daemon 启动中，稍后可获取链接）');
+  }
+}
+
+/**
+ * Print a fresh dashboard URL by HMAC-authing to the dashboard process's
+ * loopback rotation endpoint. Each call invalidates the previously-issued
+ * token, so sharing a URL is the same as sharing a one-shot session.
+ */
+async function cmdDashboard(): Promise<void> {
+  const r = await fetchDashboardUrl();
+  if (r.ok) {
+    console.log(r.url);
+    return;
+  }
+  if (r.reason === 'no-secret') {
+    console.error('Dashboard not initialised. Run `botmux restart` first.');
+  } else if (r.reason === 'unreachable') {
+    const portFile = join(CONFIG_DIR, '.dashboard-port');
+    const port = (existsSync(portFile) ? readFileSync(portFile, 'utf8').trim() : '')
+      || process.env.BOTMUX_DASHBOARD_PORT
+      || '7891';
     console.error(
       `dashboard process not reachable on 127.0.0.1:${port} — \`botmux restart\` will start it`,
     );
-    process.exit(1);
+  } else {
+    console.error('Rotation failed:', r.detail);
   }
-  if (!res.ok) {
-    console.error('Rotation failed:', res.status, await res.text());
-    process.exit(1);
-  }
-  const body = await res.json() as { url: string };
-  console.log(body.url);
+  process.exit(1);
 }
 
 // ─── Session helpers ──────────────────────────────────────────────────────────

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1422,13 +1422,19 @@ function cmdUpgrade(): void {
 }
 
 /**
- * Try to obtain a fresh dashboard URL via the loopback HMAC rotate endpoint.
- * Returns { ok: true, url } on success, or { ok: false, reason } so callers
- * can decide how to surface the failure (hard error vs soft hint).
+ * Call one of the dashboard's loopback HMAC `/__cli/*` endpoints.
+ * - `/__cli/rotate` mints a fresh token and returns its URL, invalidating the
+ *   previously-issued link.
+ * - `/__cli/current` returns the existing token's URL WITHOUT rotating (404 →
+ *   no token has ever been minted → `no-active-token`).
+ * Returns { ok: true, url } on success, or { ok: false, reason } so callers can
+ * decide how to surface the failure (hard error vs soft hint).
  */
-async function fetchDashboardUrl(): Promise<
+async function callDashboardEndpoint(
+  path: '/__cli/rotate' | '/__cli/current',
+): Promise<
   | { ok: true; url: string }
-  | { ok: false; reason: 'no-secret' | 'unreachable' | 'http-error'; detail?: string }
+  | { ok: false; reason: 'no-secret' | 'unreachable' | 'http-error' | 'no-active-token'; detail?: string }
 > {
   const SECRET_PATH = join(CONFIG_DIR, '.dashboard-secret');
   if (!existsSync(SECRET_PATH)) return { ok: false, reason: 'no-secret' };
@@ -1443,7 +1449,7 @@ async function fetchDashboardUrl(): Promise<
 
   let res: Response;
   try {
-    res = await fetch(`http://127.0.0.1:${port}/__cli/rotate`, {
+    res = await fetch(`http://127.0.0.1:${port}${path}`, {
       method: 'POST',
       headers: {
         'X-Botmux-Cli-Ts': ts,
@@ -1454,6 +1460,7 @@ async function fetchDashboardUrl(): Promise<
   } catch {
     return { ok: false, reason: 'unreachable' };
   }
+  if (res.status === 404) return { ok: false, reason: 'no-active-token' };
   if (!res.ok) {
     return { ok: false, reason: 'http-error', detail: `${res.status} ${await res.text()}` };
   }
@@ -1462,26 +1469,31 @@ async function fetchDashboardUrl(): Promise<
 }
 
 /**
- * Best-effort dashboard hint printed after start/restart. Retries for a few
- * seconds since the dashboard process boots after the daemon. If it still
- * isn't ready, print a soft fallback so the user isn't blocked.
+ * Best-effort dashboard hint printed after start/restart. Reads the LIVE link
+ * via /__cli/current (non-rotating) so an already-shared URL is preserved.
+ * Retries for a few seconds since the dashboard process boots after the daemon;
+ * if it still isn't ready, prints a soft fallback so the user isn't blocked.
  */
 async function printDashboardHintWithRetry(): Promise<void> {
   const maxWaitMs = 6000;
   const stepMs = 500;
   const started = Date.now();
-  let last: Awaited<ReturnType<typeof fetchDashboardUrl>> | null = null;
+  let last: Awaited<ReturnType<typeof callDashboardEndpoint>> | null = null;
   while (Date.now() - started < maxWaitMs) {
-    last = await fetchDashboardUrl();
+    last = await callDashboardEndpoint('/__cli/current');
     if (last.ok) {
       console.log(`   面板: botmux dashboard (${last.url})`);
       return;
     }
-    if (last.reason === 'no-secret') break; // secret hasn't been generated — don't spin
+    // Terminal states — file-backed secret/token won't appear mid-poll, unlike
+    // a not-yet-listening port. Don't spin on them.
+    if (last.reason === 'no-secret' || last.reason === 'no-active-token') break;
     await new Promise(r => setTimeout(r, stepMs));
   }
   // Soft fallback
-  if (last?.reason === 'no-secret') {
+  if (last?.reason === 'no-active-token') {
+    console.log('   面板: 运行 `botmux dashboard` 获取链接');
+  } else if (last?.reason === 'no-secret') {
     console.log('   面板: dashboard 凭证未就绪，启动后可用 `botmux dashboard` 获取链接');
   } else {
     console.log('   面板: `botmux dashboard`（daemon 启动中，稍后可获取链接）');
@@ -1494,7 +1506,7 @@ async function printDashboardHintWithRetry(): Promise<void> {
  * token, so sharing a URL is the same as sharing a one-shot session.
  */
 async function cmdDashboard(): Promise<void> {
-  const r = await fetchDashboardUrl();
+  const r = await callDashboardEndpoint('/__cli/rotate');
   if (r.ok) {
     console.log(r.url);
     return;
@@ -1510,7 +1522,8 @@ async function cmdDashboard(): Promise<void> {
       `dashboard process not reachable on 127.0.0.1:${port} — \`botmux restart\` will start it`,
     );
   } else {
-    console.error('Rotation failed:', r.detail);
+    // `no-active-token` can't occur on rotate (it always mints); fall through.
+    console.error('Rotation failed:', r.detail ?? r.reason);
   }
   process.exit(1);
 }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -56,6 +56,8 @@ function loadOrCreateSecret(): string {
 // The active dashboard token is persisted to disk so a previously-issued
 // dashboard URL survives `botmux restart`; only `botmux dashboard` (the
 // /__cli/rotate endpoint) rotates it and thereby invalidates the old link.
+// The start/restart hint reads it via the non-rotating /__cli/current endpoint
+// so it can show the live link without invalidating it.
 let activeToken: string | null = loadPersistedToken(TOKEN_PATH);
 
 // The port we actually bound (may differ from config.dashboard.port after an
@@ -348,6 +350,30 @@ async function closeSessionsMatching(
   }));
 }
 
+/**
+ * Shared loopback-HMAC gate for the `/__cli/*` endpoints. Returns `{ ok: true }`
+ * on success, or a ready-to-send `{ status, body }` error otherwise.
+ */
+function verifyCliRequest(req: IncomingMessage):
+  | { ok: true }
+  | { ok: false; status: number; body: Record<string, unknown> } {
+  const ts = req.headers['x-botmux-cli-ts'];
+  const nonce = req.headers['x-botmux-cli-nonce'];
+  const sig = req.headers['x-botmux-cli-auth'];
+  if (typeof ts !== 'string' || typeof nonce !== 'string' || typeof sig !== 'string') {
+    return { ok: false, status: 400, body: { error: 'missing_headers' } };
+  }
+  const remote = (req.socket.remoteAddress ?? '').replace(/^::ffff:/, '');
+  const r = verifyHmac(SECRET, { ts, nonce, sig }, remote);
+  if (!r.ok) return { ok: false, status: 401, body: { error: 'unauthorized', reason: r.reason } };
+  return { ok: true };
+}
+
+/** Build the dashboard URL for a token, using the actually-bound port. */
+function dashboardUrlFor(token: string): string {
+  return `http://${config.dashboard.externalHost}:${boundDashboardPort}/?t=${token}`;
+}
+
 const server = createServer(async (req, res) => {
   try {
     const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
@@ -375,25 +401,29 @@ const server = createServer(async (req, res) => {
       return;
     }
 
-    // CLI rotate (HMAC + loopback only) — for `botmux dashboard`
+    // CLI rotate (HMAC + loopback only) — for `botmux dashboard`. Mints a fresh
+    // token, invalidating any previously-issued link.
     if (req.method === 'POST' && url.pathname === '/__cli/rotate') {
-      const ts = req.headers['x-botmux-cli-ts'];
-      const nonce = req.headers['x-botmux-cli-nonce'];
-      const sig = req.headers['x-botmux-cli-auth'];
-      if (typeof ts !== 'string' || typeof nonce !== 'string' || typeof sig !== 'string') {
-        return jsonRes(res, 400, { error: 'missing_headers' });
-      }
-      const remote = (req.socket.remoteAddress ?? '').replace(/^::ffff:/, '');
-      const r = verifyHmac(SECRET, { ts, nonce, sig }, remote);
-      if (!r.ok) return jsonRes(res, 401, { error: 'unauthorized', reason: r.reason });
+      const gate = verifyCliRequest(req);
+      if (!gate.ok) return jsonRes(res, gate.status, gate.body);
       activeToken = generateToken();
       try {
         persistToken(TOKEN_PATH, activeToken);
       } catch (e) {
         logger.warn(`[dashboard] Failed to persist token to ${TOKEN_PATH}: ${(e as Error).message}`);
       }
-      const fullUrl = `http://${config.dashboard.externalHost}:${boundDashboardPort}/?t=${activeToken}`;
-      return jsonRes(res, 200, { url: fullUrl });
+      return jsonRes(res, 200, { url: dashboardUrlFor(activeToken) });
+    }
+
+    // CLI read current URL (HMAC + loopback only) — for the start/restart hint.
+    // Unlike /__cli/rotate this does NOT mint a token, so an already-issued
+    // dashboard link survives restart untouched. 404 → no token has ever been
+    // minted (caller falls back to suggesting `botmux dashboard`).
+    if (req.method === 'POST' && url.pathname === '/__cli/current') {
+      const gate = verifyCliRequest(req);
+      if (!gate.ok) return jsonRes(res, gate.status, gate.body);
+      if (!activeToken) return jsonRes(res, 404, { error: 'no_active_token' });
+      return jsonRes(res, 200, { url: dashboardUrlFor(activeToken) });
     }
 
     const presentedToken = authedToken(req, url);


### PR DESCRIPTION
## 需求
`botmux start` / `restart` 结束后，直接把 dashboard 链接贴出来（复用已有 dashboard，不新建）。

## 改动（`src/cli.ts`）
- 抽出 **`fetchDashboardUrl()`** 复用 helper：返回 `{ok,url}` | `{ok:false,reason}`，不再直接 `process.exit`，便于复用。
- 新增 **`printDashboardHintWithRetry()`**：start/restart 后最多轮询 6s（500ms/次）等 dashboard 端口就绪 —— 成功打印 `面板: botmux dashboard (URL)`；超时/无凭证给软提示、不阻塞。
- `cmdStart` / `cmdRestart` 末尾各调用一次；`cmdDashboard` 改为复用 `fetchDashboardUrl()`，保留原错误语义（no-secret / unreachable / http-error）。

## 作者 & 来源
由 **seed**（botmux 沙盒内 dogfood 实现）。本次也验证了文件沙盒：seed 改了 botmux 自己的 `src/cli.ts` + `pnpm build`，改动全隔离在 overlay 临时层，生产源码/dist 零改动。

## Reviewer 备注（@申晗 留意）
1. **每次 start/restart 都会 rotate dashboard token**（`fetchDashboardUrl` 走 rotate 端点，旧 token 失效）。restart 时 dashboard 进程本就重启、旧 token 反正失效，影响不大；但 `start` 或自动重启场景下，正在用的 dashboard 链接会被这次 rotate 失效。若需求本意是「展示当前链接但不 rotate」，需要 dashboard 侧加一个只读 current-url 端点（另开工）。
2. **restart 完成时间 +≤6s**（轮询等待）。交互式无感；自动重启/脚本场景多等几秒。

代码本身干净、tsc 通过、实现符合需求。以上两点为行为提醒，按需决定是否调整。