### PR TITLE
fix(auto-start): 入群 D7 成员检查加退避重试，修复报警平台先拉 bot 后拉人的竞态漏判

### DIFF
--- a/src/core/auto-start.ts
+++ b/src/core/auto-start.ts
@@ -82,3 +82,38 @@ export function chatHasAllowedUser(
 export function resolveGroupJoinPrompt(configured: string | undefined): string {
   return (configured ?? '').trim();
 }
+
+/**
+ * 场景①: D7 gate with retry — wait for an allowedUser to appear in the chat.
+ *
+ * Alarm/oncall platforms that auto-create incident chats (e.g. ByteDance
+ * Nexus) add the bot FIRST and the human members moments later. A one-shot
+ * membership snapshot taken at bot.added time races against that and loses:
+ * the chat looks like it has no allowedUser and auto-start is silently
+ * skipped even though the owner lands in the chat a second later. Re-check
+ * membership a few times with backoff before giving up.
+ *
+ * Attempts = retryDelaysMs.length + 1 (default 4 attempts over ~25s). Errors
+ * from `listMembers` propagate to the caller on ANY attempt — same handling
+ * as the previous one-shot check (warn + scope hint). Empty allowedUsers
+ * short-circuits to false without calling `listMembers` (FR-2).
+ */
+export async function waitForAllowedUserInChat(opts: {
+  listMembers: () => Promise<string[]>;
+  allowedUsers: Iterable<string>;
+  /** Waits BETWEEN attempts (ms). Default [3000, 7000, 15000]. */
+  retryDelaysMs?: number[];
+  sleep?: (ms: number) => Promise<void>;
+  onRetry?: (attempt: number, delayMs: number) => void;
+}): Promise<boolean> {
+  const allowed = [...opts.allowedUsers];
+  if (allowed.length === 0) return false;
+  const delays = opts.retryDelaysMs ?? [3000, 7000, 15000];
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>(r => setTimeout(r, ms)));
+  for (let attempt = 0; ; attempt++) {
+    if (chatHasAllowedUser(await opts.listMembers(), allowed)) return true;
+    if (attempt >= delays.length) return false;
+    opts.onRetry?.(attempt + 1, delays[attempt]);
+    await sleep(delays[attempt]);
+  }
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -12,7 +12,7 @@ import { startMaintenance, stopMaintenance } from './core/maintenance.js';
 import { sendRestartReportIfPending } from './core/restart-report.js';
 import { statSync } from 'node:fs';
 import { getChatMode, listChatMemberOpenIds, replyMessage, resolveAllowedUsersWithMap, sendMessage, sendUserMessage, updateMessage } from './im/lark/client.js';
-import { chatHasAllowedUser, resolveGroupJoinPrompt } from './core/auto-start.js';
+import { resolveGroupJoinPrompt, waitForAllowedUserInChat } from './core/auto-start.js';
 import { loadBotConfigs, registerBot, getBot, getAllBots, findOncallChatForAnyBot, type BotState, type OncallChat } from './bot-registry.js';
 import * as sessionStore from './services/session-store.js';
 import * as chatFirstSeenStore from './services/chat-first-seen-store.js';
@@ -2382,16 +2382,26 @@ async function handleBotAdded(chatId: string, operatorOpenId: string | undefined
   if (priorAnchorKey) groupJoinAnchorByChat.delete(chatLiveKey); // stale entry, will re-register below
   autoStartJoinInFlight.add(lockKey);
   try {
-    // D7 gate: an allowedUser must be a member of the chat.
-    let memberOpenIds: string[];
+    // D7 gate: an allowedUser must be a member of the chat. Alarm/oncall
+    // platforms (e.g. Nexus) create the chat, add bots first and the human
+    // members moments later — a one-shot membership snapshot here races
+    // against that and loses, so re-check with backoff before giving up
+    // (the in-flight lock above keeps duplicate bot.added events deduped
+    // while we wait).
+    let hasAllowedUser: boolean;
     try {
-      memberOpenIds = await listChatMemberOpenIds(larkAppId, chatId);
+      hasAllowedUser = await waitForAllowedUserInChat({
+        listMembers: () => listChatMemberOpenIds(larkAppId, chatId),
+        allowedUsers: bot.resolvedAllowedUsers,
+        onRetry: (attempt, delayMs) =>
+          logger.info(`[auto-start:入群] ${chatId.substring(0, 12)} 暂无 allowedUser 成员，${delayMs}ms 后重查（第 ${attempt} 次）`),
+      });
     } catch (err: any) {
       logger.warn(`[auto-start:入群] ${chatId.substring(0, 12)} 拉群成员失败：${err?.message ?? err}`);
       await warnGroupJoinScopeOnce(larkAppId, String(err?.message ?? err));
       return;
     }
-    if (!chatHasAllowedUser(memberOpenIds, bot.resolvedAllowedUsers)) {
+    if (!hasAllowedUser) {
       logger.info(`[auto-start:入群] ${chatId.substring(0, 12)} 群内无 allowedUser 成员，忽略`);
       return;
     }

--- a/test/auto-start.test.ts
+++ b/test/auto-start.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   chatHasAllowedUser,
   resolveGroupJoinPrompt,
   shouldAutoStartOnNewTopic,
+  waitForAllowedUserInChat,
 } from '../src/core/auto-start.js';
 
 describe('shouldAutoStartOnNewTopic (场景②)', () => {
@@ -74,5 +75,88 @@ describe('resolveGroupJoinPrompt (场景① D8)', () => {
 
   it('returns empty string for a blank prompt', () => {
     expect(resolveGroupJoinPrompt('   ')).toBe('');
+  });
+});
+
+describe('waitForAllowedUserInChat (场景① D7 入群竞态)', () => {
+  /** sleep stub: records requested delays, resolves immediately. */
+  function makeSleep() {
+    const slept: number[] = [];
+    return { slept, sleep: async (ms: number) => { slept.push(ms); } };
+  }
+
+  it('returns true without retrying when an allowedUser is already a member', async () => {
+    const { slept, sleep } = makeSleep();
+    const listMembers = vi.fn(async () => ['ou_bot', 'ou_owner']);
+    await expect(
+      waitForAllowedUserInChat({ listMembers, allowedUsers: ['ou_owner'], sleep }),
+    ).resolves.toBe(true);
+    expect(listMembers).toHaveBeenCalledTimes(1);
+    expect(slept).toEqual([]);
+  });
+
+  it('retries until the allowedUser shows up (platform adds bot before humans)', async () => {
+    const { slept, sleep } = makeSleep();
+    // Nexus-style sequence: at bot.added time the chat only contains bots;
+    // the humans (incl. the owner) land a moment later.
+    const listMembers = vi
+      .fn<() => Promise<string[]>>()
+      .mockResolvedValueOnce(['ou_bot'])
+      .mockResolvedValueOnce(['ou_bot', 'ou_other'])
+      .mockResolvedValue(['ou_bot', 'ou_other', 'ou_owner']);
+    const retries: Array<[number, number]> = [];
+    await expect(
+      waitForAllowedUserInChat({
+        listMembers,
+        allowedUsers: ['ou_owner'],
+        sleep,
+        onRetry: (attempt, delayMs) => retries.push([attempt, delayMs]),
+      }),
+    ).resolves.toBe(true);
+    expect(listMembers).toHaveBeenCalledTimes(3);
+    expect(slept).toEqual([3000, 7000]);
+    expect(retries).toEqual([[1, 3000], [2, 7000]]);
+  });
+
+  it('gives up after exhausting all retries', async () => {
+    const { slept, sleep } = makeSleep();
+    const listMembers = vi.fn(async () => ['ou_bot']);
+    await expect(
+      waitForAllowedUserInChat({ listMembers, allowedUsers: ['ou_owner'], sleep }),
+    ).resolves.toBe(false);
+    expect(listMembers).toHaveBeenCalledTimes(4); // 1 + default 3 retries
+    expect(slept).toEqual([3000, 7000, 15000]);
+  });
+
+  it('honours custom retryDelaysMs', async () => {
+    const { slept, sleep } = makeSleep();
+    const listMembers = vi.fn(async () => ['ou_bot']);
+    await expect(
+      waitForAllowedUserInChat({
+        listMembers,
+        allowedUsers: ['ou_owner'],
+        retryDelaysMs: [10],
+        sleep,
+      }),
+    ).resolves.toBe(false);
+    expect(listMembers).toHaveBeenCalledTimes(2);
+    expect(slept).toEqual([10]);
+  });
+
+  it('FR-2: short-circuits false for empty allowedUsers without listing members', async () => {
+    const listMembers = vi.fn(async () => ['ou_x']);
+    await expect(waitForAllowedUserInChat({ listMembers, allowedUsers: [] })).resolves.toBe(false);
+    expect(listMembers).not.toHaveBeenCalled();
+  });
+
+  it('propagates listMembers errors to the caller (any attempt)', async () => {
+    const { sleep } = makeSleep();
+    const listMembers = vi
+      .fn<() => Promise<string[]>>()
+      .mockResolvedValueOnce(['ou_bot'])
+      .mockRejectedValueOnce(new Error('no scope'));
+    await expect(
+      waitForAllowedUserInChat({ listMembers, allowedUsers: ['ou_owner'], sleep }),
+    ).rejects.toThrow('no scope');
   });
 });


### PR DESCRIPTION
报警/值班平台（如 Nexus）自动建群时先把 bot 拉进群、人晚几秒才进。
bot.added 瞬间一次性查成员必然查不到 allowedUser，自动开工被静默跳过
（实测连续 14 次平台拉群全部命中此竞态）。改为 waitForAllowedUserInChat 带退避重查（默认 3s/7s/15s 共 4 次尝试），in-flight 锁在等待期间继续
对重复事件去重；listMembers 报错仍按原行为透传（warn + scope 提示）。