### PR TITLE
fix: port local pi adapter and card patches

### DIFF
--- a/src/adapters/cli/pi.ts
+++ b/src/adapters/cli/pi.ts
@@ -14,7 +14,6 @@ export function createPiAdapter(pathOverride?: string): CliAdapter {
     buildArgs({ sessionId, initialPrompt }) {
       const args = [
         '--session-id', sessionId,
-        '--tools', 'read,bash,edit,write,grep,find,ls',
       ];
       // Pi's interactive mode processes positional initial messages after TUI
       // startup, avoiding stdin races while keeping the native TUI visible.

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -735,7 +735,10 @@ export async function handleCardCommand(
   const reply = (c: string) => deps.sessionReply(rootId, c, undefined, larkAppId);
 
   const ownerOpenId = getOwnerOpenId(larkAppId);
-  if (!ownerOpenId || !senderOpenId || senderOpenId !== ownerOpenId) {
+  // Open mode: when the bot has no configured owner/allowlist, botmux treats
+  // talk/operate as open to everyone. Keep /card consistent with that model:
+  // only enforce owner-only when an owner actually exists.
+  if (ownerOpenId && senderOpenId !== ownerOpenId) {
     await reply(t('cmd.card.owner_only', undefined, loc));
     return;
   }


### PR DESCRIPTION
1. pi adapter不需要传入工具列表，会影响mcp使用
2. /card 命令 - 当放开外部用户使用时，不限制是否是owner

-- jiadingkun@bytedance.com
