### PR TITLE
fix(traex): readyPattern 兼容 ❯ 提示符与 % left 状态栏，修复首轮消息注入失效

### DIFF
--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -228,9 +228,9 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
     },
 
     completionPattern: undefined,
-    // TRAE's prompt indicator is identical to Codex's `›`. The status bar
-    // does not currently surface a "% left" counter, so only `›` is needed.
-    readyPattern: /›/,
+    // TRAE has shipped both the Codex-style `›` prompt and the Claude-style
+    // `❯` prompt; v0.200.7 also renders a "Context 100% left" status bar.
+    readyPattern: /[›❯]|\d+% left/,
     systemHints: BOTMUX_SHELL_HINTS,
     // TRAE 0.200+ shares Codex's type-ahead behaviour: input submitted while
     // a turn is running is parked and merged into the active turn.

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -30,6 +30,7 @@ import { createAntigravityAdapter } from '../src/adapters/cli/antigravity.js';
 import { createMtrAdapter, mtrSessionIdForBotmuxSession } from '../src/adapters/cli/mtr.js';
 import { createHermesAdapter } from '../src/adapters/cli/hermes.js';
 import { createMiraAdapter } from '../src/adapters/cli/mira.js';
+import { createTraexAdapter } from '../src/adapters/cli/traex.js';
 import { createPiAdapter } from '../src/adapters/cli/pi.js';
 import { createCopilotAdapter } from '../src/adapters/cli/copilot.js';
 import { createOhMyPiAdapter } from '../src/adapters/cli/oh-my-pi.js';
@@ -39,7 +40,7 @@ import type { CliAdapter, CliId } from '../src/adapters/cli/types.js';
 // Helpers
 // ---------------------------------------------------------------------------
 
-const ALL_CLI_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'codex-app', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes', 'mira', 'pi', 'copilot', 'oh-my-pi'];
+const ALL_CLI_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'codex-app', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes', 'mira', 'traex', 'pi', 'copilot', 'oh-my-pi'];
 
 // ---------------------------------------------------------------------------
 // 1. Factory: createCliAdapterSync
@@ -73,7 +74,7 @@ describe('createCliAdapterSync factory', () => {
 describe('lazy binary resolution', () => {
   // Adapters whose resolvedBin is the resolved CLI (codex-app/mira use
   // process.execPath and never probe, so they're excluded).
-  const PROBING_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'cursor', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes', 'copilot'];
+  const PROBING_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'cursor', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes', 'traex', 'copilot'];
 
   it.each(PROBING_IDS)('"%s": construction does not probe; first resolvedBin read does', async (id) => {
     const { spawnSync } = await import('node:child_process');
@@ -760,6 +761,14 @@ describe('readyPattern', () => {
     expect(adapter.readyPattern).toBeDefined();
     expect(adapter.readyPattern!.test('›')).toBe(true);
     expect(adapter.readyPattern!.test('97% left')).toBe(true);
+  });
+
+  it('traex matches prompt and context indicators', () => {
+    const adapter = createTraexAdapter('/bin/traex');
+    expect(adapter.readyPattern).toBeDefined();
+    expect(adapter.readyPattern!.test('›')).toBe(true);
+    expect(adapter.readyPattern!.test('❯ Run /review on my current changes')).toBe(true);
+    expect(adapter.readyPattern!.test('GPT-5.5 · Context 100% left')).toBe(true);
   });
 
   it('codex-app matches runner prompt indicator', () => {


### PR DESCRIPTION
## 问题

用户首次发起 traex 会话时，首轮 prompt 注入不进去；再发一条消息时，会把前一条一起 patch 进 CLI 提交。

## 根因（claude + codex 双重独立验证）

1. TRAE v0.200.7 的输入框提示符是 `❯`（U+276F，日志原始字节 `E2 9D AF`），而 traex 适配器的 `readyPattern: /›/` 写的是 Codex 的 `›`（U+203A）——字符错配，永远匹配不上。
2. `idle-detector.ts` 在「设了 readyPattern 但从未命中」时会压制 quiescence 检测，traex 又没有 completionPattern → 屏幕路径空闲检测整体失效。实证：daemon 日志中 traex worker（5ed62642）历史上 **0 条 "Prompt detected (idle)"**。
3. 于是首轮 prompt 只能等 15s 兜底超时 flush。TRAE 启动约 12s（MCP 握手失败时更久），一旦慢过 15s，兜底的 paste+Enter 打进尚未就绪的输入框 → 文本滞留不提交 → 第二条消息到达时两条一起提交，与现象完全吻合。

排查过程中曾怀疑 worker 初始化竞态（spawnCli 期间 ready 先到、flush 空队列），经核实不成立：`spawnCli()` 到首轮 prompt 入队之间是无 await 的同步代码，事件回调插不进来；且日志证明首轮 prompt 在队列层并未丢失。

## 修复

- `src/adapters/cli/traex.ts`：`readyPattern` 扩展为 `/[›❯]|\d+% left/`（TRAE 状态栏实际渲染 "Context 100% left"，原注释「没有 % left」已过时，一并修正）
- `test/cli-adapters.test.ts`：新增 traex readyPattern 用例（取自真实日志的三种串：`›`、`❯ Run /review...`、`Context 100% left`），并把 traex 补进 factory / lazy-resolution 覆盖列表

修复后 TRAE 启动完成约 2s 内即注入首轮 prompt，15s 超时回归纯兜底。

## 验证

- `pnpm vitest run --project unit test/cli-adapters.test.ts test/input-gate.test.ts test/worker-pipe-initial-screen-order.test.ts` → 206 passed
- `pnpm exec tsc --noEmit` → 无报错
- 已 rebase 至最新 origin/master（6309f3e）