### PR TITLE
fix(bridge): 过滤 Claude 任务通知避免兜底错发

### DIFF
--- a/src/services/claude-transcript.ts
+++ b/src/services/claude-transcript.ts
@@ -205,6 +205,7 @@ const SYNTHETIC_USER_PREFIXES = [
   '<local-command-caveat>',
   '<local-command-stdout>',
   '<local-command-stderr>',
+  '<task-notification>',
 ];
 
 /** True when a `type:'user'` (or `message.role:'user'`) event represents a
@@ -240,6 +241,7 @@ export function isMeaningfulQueuedCommand(ev: TranscriptEvent | null | undefined
   if (!ev || typeof ev !== 'object') return false;
   if (ev.type !== 'attachment') return false;
   if (ev.attachment?.type !== 'queued_command') return false;
+  if (ev.attachment.commandMode === 'task-notification') return false;
   if ((ev as any).isSidechain === true) return false;
   const text = normaliseForFingerprint(extractTurnStartText(ev));
   if (text.length === 0) return false;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1339,7 +1339,7 @@ function emitReadyTurns(): void {
   for (let i = 0; i < ready.length; i++) {
     const turn = ready[i];
     const nextBoundaryMs = (i + 1 < ready.length ? ready[i + 1].markTimeMs : nextPendingMarkTimeMs);
-    if (shouldSuppressBridgeEmit({ markTimeMs: turn.markTimeMs, isLocal: turn.isLocal }, nextBoundaryMs, markers, adoptMode)) {
+    if (turn.isLocal && shouldSuppressBridgeEmit({ markTimeMs: turn.markTimeMs, isLocal: turn.isLocal }, nextBoundaryMs, markers, adoptMode)) {
       const reason = turn.isLocal ? 'local-typed' : 'model called botmux send within window';
       log(`Bridge fallback suppressed for turn ${turn.turnId.substring(0, 8)} (${reason})`);
       continue;
@@ -1357,6 +1357,12 @@ function emitReadyTurns(): void {
     const assistantText = joinAssistantText(matched);
     if (assistantText.length === 0) continue;
     const lastUuid = turn.assistantUuids[turn.assistantUuids.length - 1];
+
+    if (shouldSuppressBridgeEmit({ markTimeMs: turn.markTimeMs, isLocal: turn.isLocal, finalText: assistantText }, nextBoundaryMs, markers, adoptMode)) {
+      const reason = turn.isLocal ? 'local-typed' : 'model called botmux send within window';
+      log(`Bridge fallback suppressed for turn ${turn.turnId.substring(0, 8)} (${reason})`);
+      continue;
+    }
 
     if (turn.isLocal) {
       if (turn.userUuid) {

--- a/test/bridge-turn-queue.test.ts
+++ b/test/bridge-turn-queue.test.ts
@@ -14,11 +14,11 @@
  */
 import { describe, it, expect } from 'vitest';
 import { BridgeTurnQueue, makeFingerprint } from '../src/services/bridge-turn-queue.js';
-import { shouldSuppressBridgeEmit } from '../src/services/bridge-fallback-gate.js';
+import { shouldSuppressBridgeEmit, type BridgeSendMarker } from '../src/services/bridge-fallback-gate.js';
 import type { TranscriptEvent } from '../src/services/claude-transcript.js';
 
-function user(uuid: string, content: string = `<input ${uuid}>`): TranscriptEvent {
-  return { type: 'user', uuid, message: { role: 'user', content } };
+function user(uuid: string, content: string = `<input ${uuid}>`, timestamp?: string): TranscriptEvent {
+  return { type: 'user', uuid, timestamp, message: { role: 'user', content } };
 }
 function assistant(uuid: string, text: string, sidechain = false): TranscriptEvent {
   const ev: TranscriptEvent = {
@@ -592,12 +592,12 @@ describe('BridgeTurnQueue', () => {
   // anchors on "Claude actually started processing this turn" — not on the
   // earlier moment the worker wrote to PTY.
   describe('attachment(queued_command) attribution', () => {
-    function queuedCommand(uuid: string, prompt: string, timestamp?: string): TranscriptEvent {
+    function queuedCommand(uuid: string, prompt: string, timestamp?: string, commandMode?: string): TranscriptEvent {
       return {
         type: 'attachment',
         uuid,
         timestamp,
-        attachment: { type: 'queued_command', prompt },
+        attachment: { type: 'queued_command', prompt, commandMode },
       };
     }
 
@@ -745,6 +745,87 @@ describe('BridgeTurnQueue', () => {
       expect(peek).toHaveLength(1);
       expect(peek[0].turnId).toBe('t1');
       expect(peek[0].assistantUuids).toEqual(['a1']);
+    });
+
+    it('task-notification queued_command is filtered: does not split the active Lark turn', () => {
+      const q = new BridgeTurnQueue();
+      q.mark('t1', makeFingerprint('run the research task'), Date.parse('2026-06-10T13:05:58.982Z'));
+      q.ingest([
+        user('u1', 'run the research task', '2026-06-10T13:06:06.637Z'),
+        assistant('a-start', 'I will inspect the repo first.'),
+        queuedCommand(
+          'q-task',
+          '<task-notification>\n<task-id>agent-1</task-id>\n<status>completed</status>\n</task-notification>',
+          '2026-06-10T13:09:30.130Z',
+          'task-notification',
+        ),
+        queuedCommand(
+          'q-task-no-mode',
+          '<task-notification>\n<task-id>agent-2</task-id>\n<status>completed</status>\n</task-notification>',
+          '2026-06-10T13:10:00.000Z',
+        ),
+        assistant('a-final', 'Final answer after the task notification.'),
+      ]);
+
+      const ready = q.drainEmittable();
+      expect(ready).toHaveLength(1);
+      expect(ready[0].turnId).toBe('t1');
+      expect(ready[0].isLocal).toBeFalsy();
+      expect(ready[0].assistantUuids).toEqual(['a-start', 'a-final']);
+    });
+
+    it('task notifications do not cap the send-marker window before the final botmux send', () => {
+      const q = new BridgeTurnQueue();
+      const firstPrompt = '<user_message>research startup hooks</user_message>';
+      q.mark('turn-1', makeFingerprint(firstPrompt), Date.parse('2026-06-10T13:05:58.982Z'));
+      q.ingest([
+        {
+          type: 'user',
+          uuid: 'u-lark',
+          timestamp: '2026-06-10T13:06:06.637Z',
+          message: { role: 'user', content: firstPrompt },
+        },
+        assistant('a-start', '我来先看图片和现有的启动检测逻辑，然后调研 Claude/Codex 的 hooks 能力。'),
+        queuedCommand(
+          'q-agent-a',
+          '<task-notification>\n<task-id>a777</task-id>\n<status>completed</status>\n</task-notification>',
+          '2026-06-10T13:09:30.130Z',
+          'task-notification',
+        ),
+        assistant('a-progress', 'Claude 侧完整闭环验证通过。清理现场，等 Codex 调研结果：'),
+        queuedCommand(
+          'q-agent-b',
+          '<task-notification>\n<task-id>a586</task-id>\n<status>completed</status>\n</task-notification>',
+          '2026-06-10T13:15:07.250Z',
+          'task-notification',
+        ),
+        assistant('a-final', '调研完成，结论已发飞书。简要总结：最终收尾文本。'),
+      ]);
+
+      const ready = q.drainEmittable();
+      expect(ready).toHaveLength(1);
+      expect(ready[0].turnId).toBe('turn-1');
+      expect(ready[0].isLocal).toBeFalsy();
+      expect(ready[0].assistantUuids).toEqual(['a-start', 'a-progress', 'a-final']);
+
+      const assistantText = [
+        '我来先看图片和现有的启动检测逻辑，然后调研 Claude/Codex 的 hooks 能力。',
+        'Claude 侧完整闭环验证通过。清理现场，等 Codex 调研结果：',
+        '调研完成，结论已发飞书。简要总结：最终收尾文本。',
+      ].join('\n\n');
+      const markers: BridgeSendMarker[] = [{
+        sentAtMs: Date.parse('2026-06-10T13:15:50.924Z'),
+        messageId: 'om_final',
+        contentLength: 1646,
+      }];
+      expect(
+        shouldSuppressBridgeEmit(
+          { markTimeMs: ready[0].markTimeMs, isLocal: ready[0].isLocal, finalText: assistantText },
+          undefined,
+          markers,
+          false,
+        ),
+      ).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## 根因

2026-06-10 现场的 Claude transcript 里，同一轮 Lark turn 中间出现了 Claude Code 写入的 `attachment.type=queued_command` / `commandMode=task-notification` 事件，prompt 形如 `<task-notification>...`。

现有 `isMeaningfulQueuedCommand()` 会把所有非空 queued_command 都当作真实用户 turn 起点，导致 bridge 队列把同一个 Lark turn 错切成：

- 原始 turn：只包含开头 assistant 过程性文本（46 chars）
- local task-notification turn：包含后续过程文本和最终 assistant 收尾文本

idle 后 local turn 被非 adopt 逻辑抑制，但原始 turn 的 send-marker 对账窗口被 local turn 边界提前截断，看不到最后一次 `botmux send` marker，于是兜底链路把 turn 开头那段过程性文本补发到了群里。

补充：现场 marker 文件里确实有最终 `botmux send` 记录（contentLength=1646），所以这不是 marker 写入失败，而是 task notification 误切 turn 后导致 marker window 选错。

## 修复

- 过滤 Claude task-notification queued_command：
  - `commandMode === 'task-notification'` 直接视为非真实用户输入
  - prompt 以 `<task-notification>` 开头也进入 synthetic 前缀过滤
- Claude bridge fallback 抑制逻辑拿到真实 `assistantText` 后再对非 local turn 做 marker 对账，和 Codex 路径一样使用 final text 长度判断是否已被显式 `botmux send` 覆盖。

## 行为说明

本次现场形状下，最终终端收尾文本会被视为已被最后一次显式 `botmux send` 覆盖，不再 fallback 补发；如果未来某轮确实存在未被显式发送覆盖的更长最终 assistant 文本，兜底链路仍会按 final text + marker gate 发出正确段落。

## 回归测试

新增/扩展 `test/bridge-turn-queue.test.ts`：

- task-notification queued_command 不再切分当前 Lark turn
- 重放“开头 assistant 文本 + 多个 task notification + 多次 botmux send marker + 末尾 assistant 文本”的结构，断言 marker window 不会被 task notification 截断，fallback 会被最终 send marker 正确抑制

## 验证

- `npx vitest run --project unit test/bridge-turn-queue.test.ts test/bridge-fallback-gate.test.ts`
- `pnpm build`
- `npx vitest run --project unit`
- `git diff --check`
