### PR TITLE
feat(cli): Claude/Seed SessionStart hook「真就绪」信号门控首条 prompt

### DIFF
--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -2,6 +2,7 @@ import { existsSync, statSync, openSync, readSync, closeSync, readFileSync, read
 import { homedir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 import { resolveCommand } from './registry.js';
+import { sessionReadyHookCommand } from '../hook-command.js';
 import type { CliAdapter, CliId, PtyHandle } from './types.js';
 import { findJsonlContainingFingerprint, jsonlContainsFingerprint, normaliseForFingerprint } from '../../services/claude-transcript.js';
 import { t } from '../../i18n/index.js';
@@ -456,15 +457,30 @@ export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, rawBin: 
       }
       if (!disableCliBypass) {
         args.push('--dangerously-skip-permissions');
-        // 内联 --settings JSON 作用域仅限本次 spawn，不会写入用户全局 ~/.claude/settings.json。
-        // 注意：askUserQuestion hook 不在这里注入——它要写全局 settings.json（见下方
-        // hookInstall），这样 adopt 模式（botmux 接管的是别处已启动、拿不到本 --settings
-        // 的 claude 会话）才能让那条会话读到 hook。
-        args.push('--settings', JSON.stringify({
-          skipDangerousModePermissionPrompt: true,
-          permissions: { defaultMode: 'bypassPermissions' },
-        }));
       }
+      // 进程级 --settings JSON：作用域仅限本次 spawn，不写入用户全局 ~/.claude/settings.json，
+      // 并与用户自有 settings.json 合并（Claude 把多个 settings 源按事件 **合并** hooks 数组，
+      // 不互相覆盖——所以用户自己的 SessionStart hook 不会失效）。承载两件事：
+      //   1. SessionStart hook → `botmux session-ready`：CLI「真就绪」信号。cjadk 之类自定义
+      //      launcher 的启动选择器光标 ❯ 会误命中 readyPattern → IdleDetector 误判就绪 → 首条
+      //      prompt 被选择器整条吞掉。SessionStart 在真输入框渲染时才触发（卡在选择器期间不
+      //      触发），是无歧义的就绪信号；worker 收到前不投首条 prompt（见 worker ready-gate）。
+      //      无条件注入（即便 disableCliBypass）：否则 worker 的就绪门控会空等到超时兜底。
+      //   2. bypass 权限相关键（仅 !disableCliBypass）。
+      // 注意：askUserQuestion hook 不在这里——它要写全局 settings.json（见下方 hookInstall），
+      // 这样 adopt 模式（接管的别处 claude 会话拿不到本 --settings）才能读到那条 hook。
+      // SessionStart 就绪信号无需兼容 adopt（adopt 会话不走 botmux 投首条的门控），故只走
+      // 进程级注入足矣。
+      const inlineSettings: Record<string, unknown> = {
+        hooks: {
+          SessionStart: [{ hooks: [{ type: 'command', command: sessionReadyHookCommand() }] }],
+        },
+      };
+      if (!disableCliBypass) {
+        inlineSettings.skipDangerousModePermissionPrompt = true;
+        inlineSettings.permissions = { defaultMode: 'bypassPermissions' };
+      }
+      args.push('--settings', JSON.stringify(inlineSettings));
       args.push('--disallowed-tools', 'EnterPlanMode,ExitPlanMode');
       // Inject botmux's built-in skills as a plugin scoped to THIS session only.
       // Keeps them out of the user's global ~/.claude/skills so a standalone
@@ -779,6 +795,10 @@ export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, rawBin: 
 
     completionPattern: COMPLETION_RE,
     readyPattern: /❯/,
+    // Claude 家族在 spawn 时注入 SessionStart hook（见 buildArgs），回调
+    // `botmux session-ready` 给出「真就绪」信号。worker 据此武装 ready-gate：
+    // 收到信号前不投首条 prompt，绕开 cjadk 启动选择器吞首条消息的 bug。
+    injectsReadyHook: true,
     systemHints: [],
     altScreen: false,
     // Skills are injected per-session via --plugin-dir (see buildArgs), NOT

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -153,6 +153,15 @@ export interface CliAdapter {
    *  Examples: CoCo `⏵⏵` status bar, Codex `›` prompt indicator. */
   readonly readyPattern?: RegExp;
 
+  /** Claude-family CLIs only. When true, the adapter injects a `SessionStart`
+   *  hook at spawn (process-level `--settings`) that calls `botmux session-ready`
+   *  once the CLI's input box is genuinely rendered. The worker arms a ready-gate
+   *  on this flag and holds the FIRST prompt until the signal arrives (or a
+   *  fallback timeout), so a startup launcher's selector `❯` — which falsely
+   *  matches `readyPattern` — can't trip an early flush that the selector eats.
+   *  undefined/false → no gate (every other CLI behaves exactly as before). */
+  readonly injectsReadyHook?: boolean;
+
   /** CLI-specific system hints injected into the initial prompt.
    *  e.g. "use Read tool for attachments", "don't use PlanMode" */
   readonly systemHints: string[];

--- a/src/adapters/hook-command.ts
+++ b/src/adapters/hook-command.ts
@@ -38,3 +38,16 @@ export function hookCommandFor(cliId: string): string {
   const { cmd, args } = hookCommandParts(cliId);
   return `"${cmd}" "${args[0]}" ${args.slice(1).join(' ')}`;
 }
+
+/**
+ * 构造 Claude 家族 `SessionStart` hook 的 **shell 命令字符串** → `botmux session-ready`。
+ * 与 `hookCommandFor` 同源的路径解析与加引号策略（仅可执行路径与 cli.js 路径加引号），
+ * 因为它被写进 Claude 进程级 `--settings` 的 `command` 字段、由 Claude 经 shell 执行。
+ *
+ * 无 cliId 参数：session-ready 只靠 hook 子进程继承的 `BOTMUX_SESSION_ID` /
+ * `BOTMUX_LARK_APP_ID` env 定位会话与 daemon，不需要 CLI 类型。
+ */
+export function sessionReadyHookCommand(): string {
+  const cliEntry = join(__dirname, '..', 'cli.js');
+  return `"${process.execPath}" "${cliEntry}" session-ready`;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4540,6 +4540,49 @@ async function cmdHook(cliId: string): Promise<void> {
   process.exit(0);
 }
 
+// ─── botmux session-ready ─────────────────────────────────────────────────────
+//
+// Claude 家族（claude/seed）的 SessionStart hook 客户端。Claude 在 TUI 输入框
+// 真正渲染就绪时（startup / resume / clear / compact）触发本命令；它通知 daemon
+// 「CLI 真就绪」，放行 worker 端被 ready-gate 门控的首条 prompt——绕开 cjadk 之类
+// 自定义 launcher 启动选择器的 ❯ 误命中 readyPattern、把首条消息整条吞掉的 bug。
+//
+// 会话归属只靠 hook 子进程继承的 env（worker spawn 时设的 BOTMUX_SESSION_ID /
+// BOTMUX_LARK_APP_ID）。任何失败（env 缺失=adopt/非 botmux 会话、daemon 不可达）
+// 都静默 exit 0：绝不挂死 CLI 启动；信号丢了 worker 有超时兜底。
+async function cmdSessionReady(): Promise<void> {
+  // 排空 stdin：Claude 把 SessionStart payload 写到这里。我们只取 source 字段
+  // （诊断用），但务必消费掉，避免 CLI 端写满管道阻塞。best-effort。
+  let payloadText = '';
+  try {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    payloadText = Buffer.concat(chunks).toString('utf-8');
+  } catch { /* stdin 读不到也无所谓 */ }
+  let source: string | undefined;
+  try {
+    const p = JSON.parse(payloadText);
+    if (p && typeof p.source === 'string') source = p.source;
+  } catch { /* 非 JSON / 空 → 不带 source */ }
+
+  const sessionId = process.env.BOTMUX_SESSION_ID;
+  const larkAppId = process.env.BOTMUX_LARK_APP_ID;
+  // env 缺失 → adopt / 非 botmux 会话；就绪门控对它们不适用，静默放行。
+  if (!sessionId || !larkAppId) process.exit(0);
+
+  const daemon = findDaemon(larkAppId);
+  if (daemon) {
+    try {
+      await fetch(`http://127.0.0.1:${daemon.ipcPort}/api/session-ready`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ sessionId, source }),
+      });
+    } catch { /* daemon 不可达 → 放弃，worker 走超时兜底 */ }
+  }
+  process.exit(0);
+}
+
 async function cmdBots(sub: string, rest: string[]): Promise<void> {
   process.env.SESSION_DATA_DIR ??= resolveDataDir();
 
@@ -5138,6 +5181,12 @@ switch (command) {
     // `botmux hook <cliId>` — hook 客户端，stdin 读 payload，stdout 写 directive
     const cliId = process.argv[3] ?? '';
     await cmdHook(cliId);
+    break;
+  }
+  case 'session-ready': {
+    // `botmux session-ready` — Claude 家族 SessionStart hook 客户端，通知 daemon
+    // 「CLI 真就绪」，放行被门控的首条 prompt。
+    await cmdSessionReady();
     break;
   }
   case 'workflow': {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1841,6 +1841,39 @@ ipcRoute('POST', '/api/attention', async (req, res) => {
   return jsonRes(res, 200, { ok: true });
 });
 
+// ─── session-ready IPC route (internal: Claude-family 真就绪信号) ─────────────
+//
+// NOT an agent-facing command. Claude/Seed 的 SessionStart hook 经
+// `botmux session-ready`（cli.ts cmdSessionReady）调到这里，daemon 把信号转发给
+// 该会话的 worker；worker 放行被 ready-gate 门控的首条 prompt（绕开 cjadk 启动
+// 选择器吞首条消息）。找不到会话 / worker 仍返回 200（best-effort）：worker 侧
+// 有超时兜底，信号丢失不致命，没必要让 hook 客户端报错。
+ipcRoute('POST', '/api/session-ready', async (req, res) => {
+  let raw: { sessionId?: unknown; source?: unknown };
+  try {
+    raw = await readJsonBody(req);
+  } catch {
+    return jsonRes(res, 400, { ok: false, error: 'bad_json' });
+  }
+  const sessionId = typeof raw.sessionId === 'string' ? raw.sessionId : '';
+  if (!sessionId) return jsonRes(res, 400, { ok: false, error: 'missing_sessionId' });
+  const source = typeof raw.source === 'string' ? raw.source : undefined;
+
+  let ds: DaemonSession | undefined;
+  for (const s of activeSessions.values()) {
+    if (s.session.sessionId === sessionId) { ds = s; break; }
+  }
+  if (ds?.worker) {
+    try {
+      ds.worker.send({ type: 'session_ready', source } as DaemonToWorker);
+      logger.info(`[${sessionId.slice(0, 8)}] session-ready signal forwarded to worker (source=${source ?? '?'})`);
+    } catch (err) {
+      logger.warn(`session-ready forward failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  return jsonRes(res, 200, { ok: true });
+});
+
 // ─── hooks emit 转发端点 ────────────────────────────────────────────────────
 // CLI side（botmux send 等）调用 emitHookEvent 时，把事件转发到 daemon 这条
 // 接口；daemon 在自己的长寿命事件循环里负责 spawn hook、跑 timeout、超时杀

--- a/src/types.ts
+++ b/src/types.ts
@@ -256,7 +256,11 @@ export type DaemonToWorker =
   | { type: 'set_display_mode'; mode: DisplayMode }
   | { type: 'set_locale'; locale: 'zh' | 'en' }
   | { type: 'term_action'; key: TermActionKey }
-  | { type: 'refresh_screen' };
+  | { type: 'refresh_screen' }
+  // Claude-family「真就绪」信号：CLI 的 SessionStart hook 经 `botmux session-ready`
+  // 调到 daemon，daemon 转发给本会话 worker，放行被 ready-gate 门控的首条 prompt
+  // （绕开 cjadk 启动选择器吞首条消息）。source = SessionStart 的 startup/resume/… 。
+  | { type: 'session_ready'; source?: string };
 
 /** Messages sent from Worker to Daemon */
 export type WorkerToDaemon =

--- a/src/utils/ready-gate.ts
+++ b/src/utils/ready-gate.ts
@@ -31,6 +31,33 @@
  * Pure and self-contained (no timers, no IO) so the worker owns the fallback
  * timer and IPC wiring while the transition logic stays unit-testable.
  */
+/**
+ * Decide whether the worker should ARM the ready-gate for a given spawn. The
+ * gate is only valid when a SessionStart hook will actually fire — i.e. a FRESH
+ * Claude-family spawn that re-runs the CLI binary with our `--settings`:
+ *
+ *   - `injectsReadyHook`        — the adapter injects the hook (claude / seed).
+ *   - NOT `adoptMode`           — adopt panes are pre-existing, never spawned with
+ *                                 our `--settings`, so they can't get the hook.
+ *   - NOT `willReattachPersistent` — on daemon restart / worker recovery the
+ *                                 worker re-attaches to an existing tmux/zellij/
+ *                                 herdr session and does NOT re-run the CLI's
+ *                                 bin/args, so NO new SessionStart hook fires. An
+ *                                 already-idle Claude would otherwise have its
+ *                                 first post-recovery message held until the
+ *                                 fallback timeout — a user-visible regression.
+ *
+ * Any of the negatives → don't arm; the gate stays open and the spawn behaves
+ * exactly as before (readyPattern + quiescence).
+ */
+export function shouldArmReadyGate(state: {
+  injectsReadyHook: boolean;
+  adoptMode: boolean;
+  willReattachPersistent: boolean;
+}): boolean {
+  return state.injectsReadyHook && !state.adoptMode && !state.willReattachPersistent;
+}
+
 export class ReadyGate {
   private armed = false;
   private received = false;

--- a/src/utils/ready-gate.ts
+++ b/src/utils/ready-gate.ts
@@ -1,0 +1,71 @@
+/**
+ * Ready-gate state machine — holds the FIRST prompt for Claude-family CLIs until
+ * a SessionStart hook fires a "真就绪" (true-ready) signal.
+ *
+ * Why this exists: a custom launcher (e.g. `cjadk claude`) shows an interactive
+ * model/session selector at startup whose cursor is `❯` (U+276F). That glyph
+ * precisely matches the claude adapter's `readyPattern: /❯/`, and the selector
+ * sits silent → the IdleDetector declares the CLI idle far too early → the worker
+ * types the first prompt straight INTO the selector, which eats the text (and the
+ * trailing Enter mis-selects a menu item). The selector clears before Claude's
+ * real input box renders, so the message is silently lost.
+ *
+ * Claude Code's `SessionStart` hook fires within ~3ms of the real input box
+ * rendering, and crucially does NOT fire while the launcher is still on its
+ * selector — so it's an unambiguous "the CLI is genuinely ready" signal. This
+ * gate suspends the first flush until that signal (or a fallback timeout) so the
+ * selector can never eat the first message.
+ *
+ * Lifecycle (recreated per CLI spawn in the worker):
+ *   - `arm()`        — call at spawn when the adapter injects the SessionStart
+ *                      hook and we're NOT in adopt mode. Left disarmed otherwise,
+ *                      so every other CLI / adopt pane behaves exactly as before.
+ *   - `shouldHold()` — true while armed and the signal hasn't arrived; the worker
+ *                      checks this in markPromptReady() and flushPending() and
+ *                      defers the first prompt while it holds.
+ *   - `receive()`    — the hook fired, OR the fallback timeout elapsed. Opens the
+ *                      gate permanently for this spawn. Returns true only on the
+ *                      transition that actually releases held input, so the caller
+ *                      knows whether a flush is warranted.
+ *
+ * Pure and self-contained (no timers, no IO) so the worker owns the fallback
+ * timer and IPC wiring while the transition logic stays unit-testable.
+ */
+export class ReadyGate {
+  private armed = false;
+  private received = false;
+
+  /** Arm the gate so it holds the first prompt until the ready signal. Idempotent. */
+  arm(): void {
+    this.armed = true;
+  }
+
+  /** True while the worker must hold pending input (armed and signal not yet seen). */
+  shouldHold(): boolean {
+    return this.armed && !this.received;
+  }
+
+  /**
+   * Record the ready signal (real SessionStart hook) or the fallback timeout.
+   * Returns `true` only on the first call that releases a holding gate (armed +
+   * not previously received) — i.e. when the caller should now flush. Returns
+   * `false` when the gate was never armed (nothing was held) or the signal was
+   * already received (idempotent — late duplicate hook fires are no-ops).
+   */
+  receive(): boolean {
+    if (this.received) return false;
+    const wasHolding = this.armed;
+    this.received = true;
+    return wasHolding;
+  }
+
+  /** Whether the gate is currently armed (for diagnostics / tests). */
+  get isArmed(): boolean {
+    return this.armed;
+  }
+
+  /** Whether the ready signal (or fallback) has been recorded. */
+  get isReceived(): boolean {
+    return this.received;
+  }
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -19,6 +19,7 @@ import { drainTranscript, joinAssistantText, findJsonlContainingFingerprint, fin
 import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint } from './services/bridge-turn-queue.js';
 import { shouldSuppressBridgeEmit, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
 import { shouldWriteNow } from './utils/input-gate.js';
+import { ReadyGate } from './utils/ready-gate.js';
 import { InflightInputTracker } from './core/inflight-input-tracker.js';
 import {
   shouldRunQuietRotation,
@@ -130,6 +131,28 @@ function cliName(): string { return CLI_DISPLAY_NAMES[lastInitConfig?.cliId ?? '
 let isPromptReady = false;
 /** Mutex for async flushPending — prevents concurrent flush loops. */
 let isFlushing = false;
+/** Ready-gate (Claude-family): holds the first prompt until the SessionStart
+ *  hook fires a true-ready signal, so a cjadk-style startup selector's ❯ (which
+ *  falsely matches readyPattern) can't eat the first message. Recreated + armed
+ *  per spawn in spawnCli; disarmed on signal or fallback timeout. */
+let readyGate = new ReadyGate();
+/** Fallback timer: if the SessionStart signal never arrives (hook injection
+ *  failed / old CLI / launcher didn't pass --settings / adopt) release the gate
+ *  and fall back to readyPattern + quiescence. */
+let readySignalTimer: ReturnType<typeof setTimeout> | null = null;
+/** How long the ready-gate waits for the SessionStart signal before falling
+ *  back. The real signal lands within ~ms of the input box rendering, so this is
+ *  pure insurance against a missing/failed hook — generous but bounded. */
+const READY_SIGNAL_TIMEOUT_MS = 45_000;
+/** Release the ready-gate and flush anything it held. No-op when the gate was
+ *  never armed (other CLIs / adopt) or already released (idempotent). */
+function releaseReadyGate(reason: string): void {
+  if (readySignalTimer) { clearTimeout(readySignalTimer); readySignalTimer = null; }
+  if (readyGate.receive()) {
+    log(`Ready gate released (${reason}); delivering held first prompt`);
+    flushPending();
+  }
+}
 const pendingMessages: Array<{ content: string; turnId?: string }> = [];
 /** Inputs written to the CLI whose turn hasn't completed — re-queued across a
  *  CLI crash so a submit-time death can't silently eat user messages. */
@@ -2641,6 +2664,16 @@ function onPtyData(data: string): void {
 
 function markPromptReady(): void {
   if (isPromptReady) return;  // guard against duplicate calls
+  // Ready-gate: a startup selector's ❯ (cjadk et al.) falsely matches
+  // readyPattern → the IdleDetector fires idle while the CLI is NOT actually at
+  // its input box. Hold off declaring ready until the SessionStart hook signal
+  // (or the fallback timeout) so the first prompt isn't typed into the selector.
+  // releaseReadyGate() drives flushPending() once the real signal lands, and a
+  // later genuine idle then runs this fully. No-op for non-armed gates.
+  if (readyGate.shouldHold()) {
+    log('Idle detected but holding for SessionStart ready signal (startup selector guard)');
+    return;
+  }
   isPromptReady = true;
   // CLI is back at its prompt — every previously written input has been
   // consumed, so nothing is in flight anymore. A later crash must not
@@ -2798,6 +2831,14 @@ async function flushPending(): Promise<void> {
   if (isFlushing) return;  // while loop in active flush will pick up new messages
   if (!backend || !cliAdapter) return;
   if (pendingMessages.length === 0) return;  // nothing to flush — keep isPromptReady
+  // Ready-gate: hold the FIRST prompt until the SessionStart hook fires a true-
+  // ready signal. A cjadk-style startup selector's ❯ falsely matches readyPattern
+  // and would otherwise eat this message. releaseReadyGate() re-invokes us once
+  // the signal (or fallback timeout) lands. No-op for non-armed gates / other CLIs.
+  if (readyGate.shouldHold()) {
+    log(`Holding ${pendingMessages.length} pending message(s) until SessionStart ready signal`);
+    return;
+  }
   // Type-ahead adapters flush even while the CLI is busy; others wait for
   // idle. Claude bridge fallback used to also disable type-ahead because
   // BridgeTurnQueue.ingest didn't recognise the `attachment(queued_command)`
@@ -3692,6 +3733,25 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     }
   }
 
+  // Arm the ready-gate for Claude-family CLIs (which inject the SessionStart
+  // hook via --settings; see claude-code.ts buildArgs). Until `botmux
+  // session-ready` fires (daemon → 'session_ready' IPC → releaseReadyGate) we
+  // hold the first prompt so a cjadk-style startup selector's ❯ can't eat it.
+  // Adopt panes aren't spawned with our --settings (can't get the hook), so we
+  // don't arm them — they'd only wait out the timeout. Fallback: release after
+  // READY_SIGNAL_TIMEOUT_MS and fall back to readyPattern + quiescence.
+  readyGate = new ReadyGate();
+  if (readySignalTimer) { clearTimeout(readySignalTimer); readySignalTimer = null; }
+  if (cliAdapter.injectsReadyHook && !cfg.adoptMode) {
+    readyGate.arm();
+    log('Ready gate armed — holding first prompt until SessionStart ready signal');
+    readySignalTimer = setTimeout(() => {
+      readySignalTimer = null;
+      releaseReadyGate('signal timeout fallback');
+    }, READY_SIGNAL_TIMEOUT_MS);
+    readySignalTimer.unref?.();
+  }
+
   // Set up idle detection
   idleDetector = new IdleDetector(cliAdapter);
   idleDetector.onIdle(() => {
@@ -3754,6 +3814,8 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
 function killCli(): void {
   idleDetector?.dispose();
   idleDetector = null;
+  // Cancel any pending ready-gate fallback timer; spawnCli re-arms on respawn.
+  if (readySignalTimer) { clearTimeout(readySignalTimer); readySignalTimer = null; }
   stopScreenAnalyzer();
   stopScreenUpdates();
   backend?.kill();
@@ -4517,6 +4579,16 @@ process.on('message', async (raw: unknown) => {
 
     case 'coco_drive_picker': {
       void driveCocoPicker(msg.navKeys, msg.needsReviewSubmit, msg.comment);
+      break;
+    }
+
+    case 'session_ready': {
+      // Claude-family SessionStart hook fired (via `botmux session-ready` →
+      // daemon). The CLI's input box is genuinely rendered — release the
+      // ready-gate and deliver any held first prompt. Idempotent: a later
+      // duplicate (clear/compact source) or a post-timeout fire is a no-op.
+      log(`SessionStart ready signal received (source=${msg.source ?? '?'})`);
+      releaseReadyGate('SessionStart hook');
       break;
     }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -19,7 +19,7 @@ import { drainTranscript, joinAssistantText, findJsonlContainingFingerprint, fin
 import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint } from './services/bridge-turn-queue.js';
 import { shouldSuppressBridgeEmit, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
 import { shouldWriteNow } from './utils/input-gate.js';
-import { ReadyGate } from './utils/ready-gate.js';
+import { ReadyGate, shouldArmReadyGate } from './utils/ready-gate.js';
 import { InflightInputTracker } from './core/inflight-input-tracker.js';
 import {
   shouldRunQuietRotation,
@@ -3733,16 +3733,22 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     }
   }
 
-  // Arm the ready-gate for Claude-family CLIs (which inject the SessionStart
-  // hook via --settings; see claude-code.ts buildArgs). Until `botmux
-  // session-ready` fires (daemon → 'session_ready' IPC → releaseReadyGate) we
-  // hold the first prompt so a cjadk-style startup selector's ❯ can't eat it.
-  // Adopt panes aren't spawned with our --settings (can't get the hook), so we
-  // don't arm them — they'd only wait out the timeout. Fallback: release after
-  // READY_SIGNAL_TIMEOUT_MS and fall back to readyPattern + quiescence.
+  // Arm the ready-gate for FRESH Claude-family spawns (which inject the
+  // SessionStart hook via --settings; see claude-code.ts buildArgs). Until
+  // `botmux session-ready` fires (daemon → 'session_ready' IPC → releaseReadyGate)
+  // we hold the first prompt so a cjadk-style startup selector's ❯ can't eat it.
+  // shouldArmReadyGate() excludes adopt (pre-existing pane, no --settings) AND
+  // persistent-backend reattach (daemon restart re-attaches an already-running
+  // tmux/zellij/herdr Claude WITHOUT re-running its bin/args → no new
+  // SessionStart hook → arming would hold the first post-recovery message until
+  // the timeout). Fallback: release after READY_SIGNAL_TIMEOUT_MS → readyPattern.
   readyGate = new ReadyGate();
   if (readySignalTimer) { clearTimeout(readySignalTimer); readySignalTimer = null; }
-  if (cliAdapter.injectsReadyHook && !cfg.adoptMode) {
+  if (shouldArmReadyGate({
+    injectsReadyHook: cliAdapter.injectsReadyHook === true,
+    adoptMode: cfg.adoptMode === true,
+    willReattachPersistent,
+  })) {
     readyGate.arm();
     log('Ready gate armed — holding first prompt until SessionStart ready signal');
     readySignalTimer = setTimeout(() => {

--- a/test/claude-settings-hook.test.ts
+++ b/test/claude-settings-hook.test.ts
@@ -1,11 +1,15 @@
 /**
  * claude-settings-hook.test.ts
  *
- * 验证 Claude Code adapter：
+ * 验证 Claude Code adapter 的 --settings hook 注入策略：
  * - askUserQuestion hook **不**注入进程级 --settings（避免只对 botmux spawn 的会话生效）；
- * - 而是声明 hookInstall 写全局 ~/.claude/settings.json —— 这样 adopt 模式（botmux 接管
- *   别处已启动、拿不到 --settings 的 claude 会话）也能让那条会话读到 hook。
+ *   而是声明 hookInstall 写全局 ~/.claude/settings.json —— 这样 adopt 模式（botmux 接管
+ *   别处已启动、拿不到 --settings 的 claude 会话）也能让那条会话读到 hook（即 --settings
+ *   里 **不含** PreToolUse / AskUserQuestion）。
  * - 进程级 --settings 仅保留 bypassPermissions / skipDangerousMode，不被挤掉。
+ * - SessionStart hook（真就绪信号 → `botmux session-ready`）**走**进程级 --settings：
+ *   它无需兼容 adopt（adopt 会话不走 botmux 投首条的门控），故只进程级注入；且无条件
+ *   注入（即便 disableCliBypass）否则 worker 就绪门控会空等到超时兜底。
  */
 import { describe, it, expect, vi } from 'vitest';
 import { homedir } from 'node:os';
@@ -18,23 +22,52 @@ vi.mock('node:child_process', () => ({
 
 import { createClaudeCodeAdapter } from '../src/adapters/cli/claude-code.js';
 
-describe('claude-code —— hook 走全局 settings、不进 --settings（适配 adopt 模式）', () => {
+function settingsOf(args: string[]): any {
+  const idx = args.indexOf('--settings');
+  expect(idx).toBeGreaterThanOrEqual(0);
+  return JSON.parse(args[idx + 1]);
+}
+
+describe('claude-code —— hook 注入策略（adopt 兼容 + SessionStart 真就绪信号）', () => {
   const adapter = createClaudeCodeAdapter('/usr/bin/claude');
 
-  it('--settings 内联 JSON 不含 hooks（hook 改由全局 settings.json 承载）', () => {
+  it('--settings 含 SessionStart hook → botmux session-ready', () => {
     const args = adapter.buildArgs({ sessionId: 's', resume: false, locale: 'zh' });
-    const idx = args.indexOf('--settings');
-    expect(idx).toBeGreaterThanOrEqual(0);
-    const parsed = JSON.parse(args[idx + 1]);
-    expect(parsed.hooks).toBeUndefined();
+    const parsed = settingsOf(args);
+    const cmd = parsed.hooks?.SessionStart?.[0]?.hooks?.[0]?.command as string;
+    expect(typeof cmd).toBe('string');
+    expect(cmd).toContain('cli.js');
+    expect(cmd).not.toContain('index-daemon');
+    expect(cmd.endsWith('session-ready')).toBe(true);
+  });
+
+  it('--settings 内联 JSON **不含** askUserQuestion（PreToolUse 仍走全局 settings，适配 adopt）', () => {
+    const args = adapter.buildArgs({ sessionId: 's', resume: false });
+    const parsed = settingsOf(args);
+    expect(parsed.hooks?.PreToolUse).toBeUndefined();
   });
 
   it('--settings 仍保留 bypassPermissions 与 skipDangerousModePermissionPrompt', () => {
     const args = adapter.buildArgs({ sessionId: 's', resume: false });
-    const idx = args.indexOf('--settings');
-    const parsed = JSON.parse(args[idx + 1]);
+    const parsed = settingsOf(args);
     expect(parsed.permissions?.defaultMode).toBe('bypassPermissions');
     expect(parsed.skipDangerousModePermissionPrompt).toBe(true);
+  });
+
+  it('disableCliBypass=true 时仍注入 SessionStart hook，但不带 bypass 键', () => {
+    const args = adapter.buildArgs({ sessionId: 's', resume: false, disableCliBypass: true });
+    // bypass 关闭 → 不加 --dangerously-skip-permissions
+    expect(args).not.toContain('--dangerously-skip-permissions');
+    const parsed = settingsOf(args);
+    // SessionStart hook 仍在（否则 worker 就绪门控空等超时）
+    expect(parsed.hooks?.SessionStart?.[0]?.hooks?.[0]?.command).toContain('session-ready');
+    // 但 bypass 相关键缺席
+    expect(parsed.skipDangerousModePermissionPrompt).toBeUndefined();
+    expect(parsed.permissions).toBeUndefined();
+  });
+
+  it('adapter 标记 injectsReadyHook（驱动 worker 武装 ready-gate）', () => {
+    expect(adapter.injectsReadyHook).toBe(true);
   });
 
   it('adapter 声明 hookInstall 指向全局 ~/.claude/settings.json', () => {

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -140,11 +140,19 @@ describe('claude-code buildArgs', () => {
     expect(parsed.permissions.defaultMode).toBe('bypassPermissions');
   });
 
-  it('omits dangerous permission flags/settings when disableCliBypass is true', () => {
+  it('omits dangerous permission flags/keys when disableCliBypass is true (but keeps the SessionStart ready hook)', () => {
     const args = adapter.buildArgs({ sessionId: 's', resume: false, disableCliBypass: true });
     expect(args).not.toContain('--dangerously-skip-permissions');
-    expect(args).not.toContain('--settings');
     expect(args).toContain('--disallowed-tools');
+    // --settings is still emitted — it now also carries the SessionStart真就绪
+    // hook, which must be injected unconditionally (else the worker ready-gate
+    // would wait out its fallback timeout). But the bypass keys are gone.
+    const idx = args.indexOf('--settings');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    const parsed = JSON.parse(args[idx + 1]);
+    expect(parsed.skipDangerousModePermissionPrompt).toBeUndefined();
+    expect(parsed.permissions).toBeUndefined();
+    expect(parsed.hooks?.SessionStart?.[0]?.hooks?.[0]?.command).toContain('session-ready');
   });
 
   it('ignores initialPrompt (not passed via args)', () => {

--- a/test/hook-command.test.ts
+++ b/test/hook-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { hookCommandFor } from '../src/adapters/hook-command.js';
+import { hookCommandFor, sessionReadyHookCommand } from '../src/adapters/hook-command.js';
 
 // 回归保护：hook 命令必须指向 cli.js（有 `hook` 子命令分发），
 // 绝不能指向 index-daemon.js（只 startDaemon、不处理 hook）。
@@ -16,5 +16,19 @@ describe('hookCommandFor', () => {
   it('Node 路径与 cli 路径均加引号（容忍空格），cliId 透传', () => {
     const cmd = hookCommandFor('opencode');
     expect(cmd).toMatch(/^".+" ".+cli\.js" hook opencode$/);
+  });
+});
+
+describe('sessionReadyHookCommand', () => {
+  it('指向 cli.js 而非 index-daemon.js，并以 session-ready 子命令结尾', () => {
+    const cmd = sessionReadyHookCommand();
+    expect(cmd).toContain('cli.js');
+    expect(cmd).not.toContain('index-daemon');
+    expect(cmd.endsWith('session-ready')).toBe(true);
+  });
+
+  it('Node 路径与 cli 路径均加引号（容忍空格），无 cliId 参数', () => {
+    const cmd = sessionReadyHookCommand();
+    expect(cmd).toMatch(/^".+" ".+cli\.js" session-ready$/);
   });
 });

--- a/test/ready-gate.test.ts
+++ b/test/ready-gate.test.ts
@@ -13,7 +13,34 @@
  * Run: pnpm vitest run test/ready-gate.test.ts
  */
 import { describe, it, expect } from 'vitest';
-import { ReadyGate } from '../src/utils/ready-gate.js';
+import { ReadyGate, shouldArmReadyGate } from '../src/utils/ready-gate.js';
+
+describe('shouldArmReadyGate', () => {
+  const base = { injectsReadyHook: true, adoptMode: false, willReattachPersistent: false };
+
+  it('arms a fresh Claude-family spawn (hook will fire)', () => {
+    expect(shouldArmReadyGate(base)).toBe(true);
+  });
+
+  it('does NOT arm a non-Claude CLI (no SessionStart hook injected)', () => {
+    expect(shouldArmReadyGate({ ...base, injectsReadyHook: false })).toBe(false);
+  });
+
+  it('does NOT arm adopt panes (pre-existing, never got our --settings)', () => {
+    expect(shouldArmReadyGate({ ...base, adoptMode: true })).toBe(false);
+  });
+
+  it('THE REATTACH REGRESSION: does NOT arm a persistent-backend reattach', () => {
+    // daemon restart re-attaches an already-running tmux/zellij/herdr Claude
+    // WITHOUT re-running its bin/args → no new SessionStart hook fires. Arming
+    // would hold the first post-recovery message until the fallback timeout.
+    expect(shouldArmReadyGate({ ...base, willReattachPersistent: true })).toBe(false);
+  });
+
+  it('reattach exclusion wins even for an otherwise-eligible fresh-looking spawn', () => {
+    expect(shouldArmReadyGate({ injectsReadyHook: true, adoptMode: false, willReattachPersistent: true })).toBe(false);
+  });
+});
 
 describe('ReadyGate', () => {
   it('not armed → never holds, receive() reports no flush needed (other CLIs / adopt)', () => {

--- a/test/ready-gate.test.ts
+++ b/test/ready-gate.test.ts
@@ -1,0 +1,87 @@
+/**
+ * ready-gate.test.ts
+ *
+ * Ready-gate state machine — holds the FIRST prompt for Claude-family CLIs until
+ * a SessionStart hook fires a "真就绪" signal (or a fallback timeout elapses), so
+ * a cjadk-style startup selector's ❯ (which falsely matches readyPattern) can't
+ * trip an early flush that the selector eats.
+ *
+ * Scenarios pinned (per the task brief): signal-first, signal-after, timeout
+ * fallback, resume (re-arm), and the not-armed passthrough that guarantees every
+ * other CLI / adopt pane behaves exactly as before.
+ *
+ * Run: pnpm vitest run test/ready-gate.test.ts
+ */
+import { describe, it, expect } from 'vitest';
+import { ReadyGate } from '../src/utils/ready-gate.js';
+
+describe('ReadyGate', () => {
+  it('not armed → never holds, receive() reports no flush needed (other CLIs / adopt)', () => {
+    const g = new ReadyGate();
+    expect(g.isArmed).toBe(false);
+    expect(g.shouldHold()).toBe(false);
+    // A stray signal on an un-armed gate releases nothing (nothing was held).
+    expect(g.receive()).toBe(false);
+    expect(g.shouldHold()).toBe(false);
+  });
+
+  it('armed → holds until the signal arrives', () => {
+    const g = new ReadyGate();
+    g.arm();
+    expect(g.isArmed).toBe(true);
+    expect(g.shouldHold()).toBe(true);
+  });
+
+  it('signal arrives (hook) → release returns true once, then gate stays open', () => {
+    const g = new ReadyGate();
+    g.arm();
+    expect(g.shouldHold()).toBe(true);
+    expect(g.receive()).toBe(true);     // transition: holding → open ⇒ caller flushes
+    expect(g.isReceived).toBe(true);
+    expect(g.shouldHold()).toBe(false); // permanently open for this spawn
+  });
+
+  it('duplicate / late signal is idempotent (clear/compact source, or post-timeout fire)', () => {
+    const g = new ReadyGate();
+    g.arm();
+    expect(g.receive()).toBe(true);
+    // A second fire (e.g. SessionStart source=clear later in the session, or the
+    // timeout firing after the real hook) must NOT trigger another flush.
+    expect(g.receive()).toBe(false);
+    expect(g.receive()).toBe(false);
+    expect(g.shouldHold()).toBe(false);
+  });
+
+  it('timeout fallback before any signal → release returns true (flush held prompt)', () => {
+    const g = new ReadyGate();
+    g.arm();
+    expect(g.shouldHold()).toBe(true);
+    // Worker fallback timer calls receive() — same transition as the real hook.
+    expect(g.receive()).toBe(true);
+    expect(g.shouldHold()).toBe(false);
+    // The real hook firing afterwards is then a no-op.
+    expect(g.receive()).toBe(false);
+  });
+
+  it('resume re-arms via a fresh instance (worker recreates per spawn)', () => {
+    // First spawn.
+    let g = new ReadyGate();
+    g.arm();
+    expect(g.receive()).toBe(true);
+    expect(g.shouldHold()).toBe(false);
+    // Respawn / resume: worker assigns a brand-new gate, so the previous
+    // received state can't leak and accidentally pass the next first prompt.
+    g = new ReadyGate();
+    g.arm();
+    expect(g.shouldHold()).toBe(true);
+    expect(g.isReceived).toBe(false);
+  });
+
+  it('arm() is idempotent and order-independent with receive()', () => {
+    const g = new ReadyGate();
+    g.arm();
+    g.arm();
+    expect(g.shouldHold()).toBe(true);
+    expect(g.receive()).toBe(true);
+  });
+});


### PR DESCRIPTION
## 背景（bug 已复现实锤）

自定义 launcher（`cjadk claude`）启动时带交互选择器（模型/会话选择），选择器光标恰是 `❯`(U+276F)，**精确命中** claude adapter 的 `readyPattern: /❯/`（`claude-code.ts`），且选择器静默 → `IdleDetector` 误判 CLI 就绪 → worker 投首条 prompt → **文本被选择器整条吞掉**（文字丢弃、Enter 误选「新建会话」、claude 起来后输入框是空的）。

## 方案

Claude 家族（claude + seed）spawn 时经**进程级 `--settings`** 注入 `SessionStart` hook，回调 `botmux session-ready` 作为 CLI「**真就绪**」信号——它仅在 claude 真输入框渲染时触发、**卡在选择器期间不触发**。worker 武装 ready-gate：

1. **收到信号前不投首条 prompt**（门控 `markPromptReady` + `flushPending`）；
2. 信号到了（`botmux session-ready` → daemon `POST /api/session-ready` → worker `session_ready` IPC）**立即放行**；
3. **超时兜底**（45s）回退现有 `readyPattern + quiescence`，兼容 adopt 模式（拿不到 `--settings`）、hook 注入失败、旧版 CLI；
4. `readyPattern` 机制保留不动（其它 CLI 仍靠它）。

## 改动

| 文件 | 改动 |
|---|---|
| `src/utils/ready-gate.ts`（新） | 纯状态机 `ReadyGate`（`arm`/`shouldHold`/`receive`），无 timer/IO，可单测 |
| `adapters/cli/claude-code.ts` | `buildArgs`：SessionStart hook 进 `--settings`（与用户自有 hooks **合并不覆盖**；askUserQuestion 仍走全局 settings 适配 adopt）；**无条件注入**（即便 `disableCliBypass`，否则门控空等超时）。新增 `injectsReadyHook: true` |
| `adapters/hook-command.ts` | `sessionReadyHookCommand()`（同源路径解析 + 加引号，指向 `cli.js session-ready`） |
| `worker.ts` | `spawnCli` 武装 gate + 兜底 timer；`markPromptReady`/`flushPending` 门控；`session_ready` IPC 放行；`killCli` 清 timer |
| `daemon.ts` | `POST /api/session-ready` 转发信号给会话 worker（best-effort，找不到也 200） |
| `cli.ts` | `botmux session-ready` 子命令（env 缺失=adopt/非botmux、daemon 不可达 → 静默 `exit 0`） |
| `types.ts` / `cli/types.ts` | `DaemonToWorker.session_ready`、`CliAdapter.injectsReadyHook` |

合并语义：Claude 把多个 settings 源（用户全局 + 进程级 `--settings`）的 hooks **按事件合并**，不互相覆盖——用户自己的 SessionStart hook 不会失效。

## 验证

**全量 unit：4095/4095 通过**（`npx vitest run --project unit`）。新增/更新单测：
- `ready-gate.test.ts` 7 例：信号先到 / 后到 / 超时兜底 / resume 重武装 / **未武装透传**（保证其它 CLI 零回归）/ 幂等。
- `hook-command.test.ts` +2 例（session-ready 指向 cli.js）。
- `claude-settings-hook.test.ts` 6 例：`--settings` 含 SessionStart、**不含** PreToolUse（adopt 仍走全局）、`disableCliBypass` 仍注入 hook 但去掉 bypass 键、`injectsReadyHook`。
- `cli-adapters.test.ts`：`disableCliBypass` 断言更新（`--settings` 现在恒在、只是不带 bypass 键）。

**真机（tmux + `cjadk claude` v2026.6.4-4）**——用探针 hook 替换 `session-ready` 记录触发时刻：

1. 无 `--session-id`（复现原 bug）：4s 时屏幕显示 `❯ 新建会话` 选择器（命中 readyPattern）但**探针 log 空**（SessionStart 未触发）→ 门控会正确 hold。按 Enter 过掉选择器、claude 真输入框渲染后，SessionStart 才触发，payload：
   ```
   {"session_id":"…","hook_event_name":"SessionStart","source":"startup","model":"gpt-5.5[1m]"}
   ```
2. 带 `--session-id`（真实 botmux 调用形态）：会话选择器被跳过、模型选择器**自动前进**（无需按键），`❯` 真输入框出现的同一时刻 SessionStart 自动触发（采样：t≤4.5s `❯count=0`+未触发；t=5.0s `❯count=1`+已触发）→ 信号自动到达、无死锁、无需人工。

证明：SessionStart 是无歧义的「真就绪」信号（选择器期间不触发，真输入框渲染时才触发），门控据此放行首条 prompt 即不再被选择器吞。

🤖 Generated with [Claude Code](https://claude.com/claude-code)