### PR TITLE
fix(cli): codex-app/mira 大消息分块注入 + 写失败如实上报

### DIFF
--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -222,10 +222,10 @@ export class TmuxPipeBackend implements SessionBackend {
     this.sendText(data);
   }
 
-  sendText(text: string): void {
-    if (this.exited) return;
+  sendText(text: string): boolean {
+    if (this.exited) return false;
     this.exitCopyModeIfNeeded();
-    this.guardedSend('send-keys (text)', () => {
+    return this.guardedSend('send-keys (text)', () => {
       execFileSync('tmux', ['send-keys', '-t', this.paneTarget, '-l', '--', text], {
         stdio: 'ignore',
         timeout: 5000,
@@ -234,10 +234,10 @@ export class TmuxPipeBackend implements SessionBackend {
     });
   }
 
-  sendSpecialKeys(...keys: string[]): void {
-    if (this.exited) return;
+  sendSpecialKeys(...keys: string[]): boolean {
+    if (this.exited) return false;
     this.exitCopyModeIfNeeded();
-    this.guardedSend(`send-keys ${keys.join(' ')}`, () => {
+    return this.guardedSend(`send-keys ${keys.join(' ')}`, () => {
       execFileSync('tmux', ['send-keys', '-t', this.paneTarget, ...keys], {
         stdio: 'ignore',
         timeout: 5000,
@@ -297,14 +297,20 @@ export class TmuxPipeBackend implements SessionBackend {
    *
    * Either way this method never throws — every send-keys caller (web-terminal
    * keys, TUI input, the typing loop) stays crash-safe without its own guard.
+   *
+   * Returns true when the write succeeded, false when it was dropped (pane gone
+   * or a pane-alive hiccup). Callers that verify submission (runner adapters)
+   * read this to report a non-submission; the many fire-and-forget callers
+   * (web-terminal keys, copy-mode) just ignore it.
    */
-  private guardedSend(op: string, run: () => void): void {
+  private guardedSend(op: string, run: () => void): boolean {
     try {
       run();
+      return true;
     } catch (err: any) {
       // A kill()/handlePaneExit() may have flipped exited between the guard
       // and here; if so the teardown already happened.
-      if (this.exited) return;
+      if (this.exited) return false;
       const alive = this.isPaneAlive();
       process.stderr.write(
         `[tmux-pipe-backend] ${op} failed (pane ${alive ? 'ALIVE' : 'GONE'}): ${err?.message ?? err}\n`,
@@ -320,6 +326,7 @@ export class TmuxPipeBackend implements SessionBackend {
         }
         this.handlePaneExit();
       }
+      return false;
     }
   }
 

--- a/src/adapters/cli/codex-app.ts
+++ b/src/adapters/cli/codex-app.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { resolveCommand } from './registry.js';
 import type { CliAdapter, PtyHandle } from './types.js';
+import { writeRunnerInput } from './runner-input.js';
 
 function runnerPath(): string {
   const here = dirname(fileURLToPath(import.meta.url));
@@ -16,10 +17,6 @@ function runnerPath(): string {
 function pushOpt(args: string[], key: string, value: string | undefined): void {
   if (value === undefined || value.length === 0) return;
   args.push(key, value);
-}
-
-function encodeInput(content: string): string {
-  return Buffer.from(JSON.stringify({ type: 'message', content }), 'utf8').toString('base64');
 }
 
 export function createCodexAppAdapter(pathOverride?: string): CliAdapter {
@@ -54,18 +51,10 @@ export function createCodexAppAdapter(pathOverride?: string): CliAdapter {
     },
 
     async writeInput(pty: PtyHandle, content: string) {
-      const line = `::botmux-codex-app:${encodeInput(content)}`;
-      try {
-        if (pty.sendText && pty.sendSpecialKeys) {
-          pty.sendText(line);
-          pty.sendSpecialKeys('Enter');
-        } else {
-          pty.write(line + '\r');
-        }
-      } catch {
-        return { submitted: false };
-      }
-      return { submitted: true };
+      // Chunked + throttled stdin injection — a single send-keys of the whole
+      // (potentially ~20KB) control line overruns the pane pty input buffer and
+      // gets dropped. See runner-input.ts.
+      return writeRunnerInput(pty, '::botmux-codex-app:', content);
     },
 
     completionPattern: undefined,

--- a/src/adapters/cli/mira.ts
+++ b/src/adapters/cli/mira.ts
@@ -2,6 +2,7 @@ import { fileURLToPath } from 'node:url';
 import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import type { CliAdapter, PtyHandle } from './types.js';
+import { writeRunnerInput } from './runner-input.js';
 
 function runnerPath(): string {
   const here = dirname(fileURLToPath(import.meta.url));
@@ -15,10 +16,6 @@ function runnerPath(): string {
 function pushOpt(args: string[], key: string, value: string | undefined): void {
   if (value === undefined || value.length === 0) return;
   args.push(key, value);
-}
-
-function encodeInput(content: string): string {
-  return Buffer.from(JSON.stringify({ type: 'message', content }), 'utf8').toString('base64');
 }
 
 export function createMiraAdapter(_pathOverride?: string): CliAdapter {
@@ -45,18 +42,9 @@ export function createMiraAdapter(_pathOverride?: string): CliAdapter {
     },
 
     async writeInput(pty: PtyHandle, content: string) {
-      const line = `::botmux-mira:${encodeInput(content)}`;
-      try {
-        if (pty.sendText && pty.sendSpecialKeys) {
-          pty.sendText(line);
-          pty.sendSpecialKeys('Enter');
-        } else {
-          pty.write(line + '\r');
-        }
-      } catch {
-        return { submitted: false };
-      }
-      return { submitted: true };
+      // Chunked + throttled stdin injection (see runner-input.ts) — avoids the
+      // single-giant-send-keys drop that wedged sessions on large messages.
+      return writeRunnerInput(pty, '::botmux-mira:', content);
     },
 
     completionPattern: undefined,

--- a/src/adapters/cli/runner-input.ts
+++ b/src/adapters/cli/runner-input.ts
@@ -93,31 +93,41 @@ export async function writeRunnerInput(
   }
 
   const sendText = pty.sendText.bind(pty);
-  const sendEnter = (): boolean => pty.sendSpecialKeys!('Enter') !== false;
+  const sendEnterWithRetry = (attempts = 3): boolean => {
+    for (let i = 0; i < attempts; i++) {
+      if (pty.sendSpecialKeys!('Enter') !== false) return true;
+    }
+    return false;
+  };
 
-  // Pre-flush any leftover partial control line (see buffer-hygiene contract).
-  // Cheap and idempotent on the happy path: the previous message's submit Enter
-  // already emptied the buffer, so this just enqueues a blank line the runner
-  // ignores.
-  sendEnter();
+  // Pre-flush MUST land before we write a new control line. It terminates any
+  // partial line a prior failed write left in the runner's buffer (runner
+  // discards the fragment as bad input; an empty buffer just ignores the blank
+  // line). If it can't land, the buffer may still hold an old partial — writing
+  // our new line NOW would merge "old partial + new line" into one bad line the
+  // runner drops, while our submit Enter would still report success (a silent
+  // message loss — exactly the failure mode this whole change closes). So bail
+  // with submitted:false and let the worker re-queue; we never touch the buffer
+  // with a half write. (Idempotent on the happy path: the previous message's
+  // submit Enter already emptied the buffer, so this enqueues an ignored blank.)
+  if (!sendEnterWithRetry()) return { submitted: false };
 
   const chunks = chunkAscii(line, RUNNER_INPUT_CHUNK_BYTES);
   for (let i = 0; i < chunks.length; i++) {
     if (sendText(chunks[i]) === false) {
-      // The chunks already written are sitting in the runner's buffer as a
-      // partial control line with no terminating newline. Flush it (best-effort)
-      // so the discarded fragment can't merge with the next message.
-      sendEnter();
+      // The chunks already written are a partial control line with no
+      // terminating newline. Flush it (with retry) so it's less likely to
+      // linger; even if every retry drops, the NEXT call's pre-flush gate above
+      // refuses to write onto the dirty buffer, so no corruption-as-success can
+      // slip through.
+      sendEnterWithRetry();
       return { submitted: false };
     }
     if (i < chunks.length - 1) await delay(RUNNER_INPUT_THROTTLE_MS);
   }
 
-  // Submit, retrying the Enter — a single dropped Enter leaves a complete but
-  // unsubmitted line in the buffer (the next call's pre-flush would belatedly
-  // submit it; retrying here makes that vanishingly rare).
-  for (let attempt = 0; attempt < 3; attempt++) {
-    if (sendEnter()) return { submitted: true };
-  }
-  return { submitted: false };
+  // Submit (with retry — a single dropped Enter would leave a complete but
+  // unsubmitted line in the buffer).
+  if (!sendEnterWithRetry()) return { submitted: false };
+  return { submitted: true };
 }

--- a/src/adapters/cli/runner-input.ts
+++ b/src/adapters/cli/runner-input.ts
@@ -61,6 +61,18 @@ export function chunkAscii(line: string, maxBytes: number): string[] {
  * write — the tmux backend's send methods return `false` on a dropped-but-pane-
  * alive keystroke, so a genuine drop is now surfaced to the worker (which warns
  * / re-queues) instead of being swallowed as a false success.
+ *
+ * Buffer-hygiene contract (the runner only clears its stdin buffer on a newline,
+ * see handleInput in codex-app-runner.ts / mira-runner.ts — a half-written
+ * control line with no trailing Enter lingers and would PREPEND to the next
+ * message, corrupting both into one un-parseable blob):
+ *   - Pre-flush: emit one Enter before writing, terminating any partial line a
+ *     prior failed write may have left behind (runner discards the fragment as
+ *     bad input; an empty buffer just ignores the blank line).
+ *   - On a dropped chunk: emit a flush Enter so the partial we just wrote can't
+ *     merge with the next message, then report non-submission for re-queue.
+ *   - Submit Enter is retried — a single dropped Enter would otherwise leave a
+ *     COMPLETE but unsubmitted line in the buffer.
  */
 export async function writeRunnerInput(
   pty: PtyHandle,
@@ -81,13 +93,31 @@ export async function writeRunnerInput(
   }
 
   const sendText = pty.sendText.bind(pty);
-  const sendEnter = pty.sendSpecialKeys.bind(pty);
-  const chunks = chunkAscii(line, RUNNER_INPUT_CHUNK_BYTES);
+  const sendEnter = (): boolean => pty.sendSpecialKeys!('Enter') !== false;
 
+  // Pre-flush any leftover partial control line (see buffer-hygiene contract).
+  // Cheap and idempotent on the happy path: the previous message's submit Enter
+  // already emptied the buffer, so this just enqueues a blank line the runner
+  // ignores.
+  sendEnter();
+
+  const chunks = chunkAscii(line, RUNNER_INPUT_CHUNK_BYTES);
   for (let i = 0; i < chunks.length; i++) {
-    if (sendText(chunks[i]) === false) return { submitted: false };
+    if (sendText(chunks[i]) === false) {
+      // The chunks already written are sitting in the runner's buffer as a
+      // partial control line with no terminating newline. Flush it (best-effort)
+      // so the discarded fragment can't merge with the next message.
+      sendEnter();
+      return { submitted: false };
+    }
     if (i < chunks.length - 1) await delay(RUNNER_INPUT_THROTTLE_MS);
   }
-  if (sendEnter('Enter') === false) return { submitted: false };
-  return { submitted: true };
+
+  // Submit, retrying the Enter — a single dropped Enter leaves a complete but
+  // unsubmitted line in the buffer (the next call's pre-flush would belatedly
+  // submit it; retrying here makes that vanishingly rare).
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (sendEnter()) return { submitted: true };
+  }
+  return { submitted: false };
 }

--- a/src/adapters/cli/runner-input.ts
+++ b/src/adapters/cli/runner-input.ts
@@ -1,0 +1,93 @@
+import type { PtyHandle } from './types.js';
+import { delay } from '../../utils/timing.js';
+
+/**
+ * Shared stdin-injection path for the "runner" CLI adapters (codex-app, mira).
+ *
+ * These adapters don't drive a TUI — they spawn a small Node runner that reads
+ * its stdin raw, byte-by-byte, and enqueues a message only when it sees a
+ * trailing newline (see codex-app-runner.ts / mira-runner.ts). botmux hands the
+ * runner one control line per message:
+ *
+ *     ::botmux-<id>:<base64(JSON)>\n
+ *
+ * The naive implementation wrote the WHOLE line in a single
+ * `tmux send-keys -l -- <line>`. For a large message (e.g. a Code Review
+ * webhook whose full MR JSON is embedded — ~16-21KB after base64) that single
+ * injection overruns the pane pty's input buffer (N_TTY's ~4KB read buffer):
+ * tmux's write blocks until the reader drains, which takes longer than
+ * execFileSync's 5s timeout, so the send-keys is killed and the keystroke is
+ * silently dropped — yet the old writeInput still reported `submitted: true`,
+ * wedging the session "busy" forever. (Compare claude-code, which throttles
+ * its send-keys for exactly this reason; codex-app/mira were the only naive
+ * single-shot writers.)
+ *
+ * Fix: split the line into small chunks and inject them with a short throttle
+ * between writes, so no single send-keys overruns the buffer and the reader
+ * keeps draining. Crucially we never inject a newline between chunks — the
+ * runner accumulates the partial line in its own buffer and only acts on the
+ * final Enter — so splitting mid-line is safe. The control line is pure ASCII
+ * (marker + base64 alphabet), so 1 char == 1 byte and slicing by code unit is
+ * a clean byte split.
+ */
+
+/** Max bytes per send-keys chunk. Well under the ~4KB N_TTY input buffer so a
+ *  single chunk always drains before the next, even if the reader is briefly
+ *  busy. */
+export const RUNNER_INPUT_CHUNK_BYTES = 1024;
+
+/** Throttle between chunks — gives the runner's event loop time to drain the
+ *  pane pty between writes. */
+export const RUNNER_INPUT_THROTTLE_MS = 20;
+
+export function encodeRunnerInput(content: string): string {
+  return Buffer.from(JSON.stringify({ type: 'message', content }), 'utf8').toString('base64');
+}
+
+/** Split an ASCII string into <=maxBytes pieces. Safe because the caller only
+ *  ever passes `marker + base64`, which is single-byte throughout. */
+export function chunkAscii(line: string, maxBytes: number): string[] {
+  const chunks: string[] = [];
+  for (let i = 0; i < line.length; i += maxBytes) {
+    chunks.push(line.slice(i, i + maxBytes));
+  }
+  return chunks;
+}
+
+/**
+ * Write one control line to a runner adapter's stdin, chunked + throttled.
+ *
+ * Returns `{ submitted: false }` when any chunk (or the final Enter) fails to
+ * write — the tmux backend's send methods return `false` on a dropped-but-pane-
+ * alive keystroke, so a genuine drop is now surfaced to the worker (which warns
+ * / re-queues) instead of being swallowed as a false success.
+ */
+export async function writeRunnerInput(
+  pty: PtyHandle,
+  markerPrefix: string,
+  content: string,
+): Promise<{ submitted: boolean }> {
+  const line = `${markerPrefix}${encodeRunnerInput(content)}`;
+
+  // Non-tmux fallback (raw PTY): a single write is fine — there's no send-keys
+  // process to time out, and the PTY write isn't bounded the same way.
+  if (!pty.sendText || !pty.sendSpecialKeys) {
+    try {
+      pty.write(line + '\r');
+    } catch {
+      return { submitted: false };
+    }
+    return { submitted: true };
+  }
+
+  const sendText = pty.sendText.bind(pty);
+  const sendEnter = pty.sendSpecialKeys.bind(pty);
+  const chunks = chunkAscii(line, RUNNER_INPUT_CHUNK_BYTES);
+
+  for (let i = 0; i < chunks.length; i++) {
+    if (sendText(chunks[i]) === false) return { submitted: false };
+    if (i < chunks.length - 1) await delay(RUNNER_INPUT_THROTTLE_MS);
+  }
+  if (sendEnter('Enter') === false) return { submitted: false };
+  return { submitted: true };
+}

--- a/src/adapters/cli/runner-input.ts
+++ b/src/adapters/cli/runner-input.ts
@@ -59,8 +59,9 @@ export function chunkAscii(line: string, maxBytes: number): string[] {
  *
  * Returns `{ submitted: false }` when any chunk (or the final Enter) fails to
  * write — the tmux backend's send methods return `false` on a dropped-but-pane-
- * alive keystroke, so a genuine drop is now surfaced to the worker (which warns
- * / re-queues) instead of being swallowed as a false success.
+ * alive keystroke, so a genuine drop is now surfaced to the worker (which raises
+ * a submit-failure notice + recheck so the user can retry) instead of being
+ * swallowed as a false success.
  *
  * Buffer-hygiene contract (the runner only clears its stdin buffer on a newline,
  * see handleInput in codex-app-runner.ts / mira-runner.ts — a half-written
@@ -70,7 +71,7 @@ export function chunkAscii(line: string, maxBytes: number): string[] {
  *     prior failed write may have left behind (runner discards the fragment as
  *     bad input; an empty buffer just ignores the blank line).
  *   - On a dropped chunk: emit a flush Enter so the partial we just wrote can't
- *     merge with the next message, then report non-submission for re-queue.
+ *     merge with the next message, then report non-submission (submit-failure).
  *   - Submit Enter is retried — a single dropped Enter would otherwise leave a
  *     COMPLETE but unsubmitted line in the buffer.
  */
@@ -107,8 +108,9 @@ export async function writeRunnerInput(
   // our new line NOW would merge "old partial + new line" into one bad line the
   // runner drops, while our submit Enter would still report success (a silent
   // message loss — exactly the failure mode this whole change closes). So bail
-  // with submitted:false and let the worker re-queue; we never touch the buffer
-  // with a half write. (Idempotent on the happy path: the previous message's
+  // with submitted:false (the worker raises a submit-failure notice + recheck so
+  // the user can retry); we never touch the buffer with a half write. (Idempotent
+  // on the happy path: the previous message's
   // submit Enter already emptied the buffer, so this enqueues an ignored blank.)
   if (!sendEnterWithRetry()) return { submitted: false };
 

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -1,9 +1,13 @@
 export interface PtyHandle {
   write(data: string): void;
-  /** Send text literally via tmux send-keys -l (tmux mode only). */
-  sendText?(text: string): void;
-  /** Send special keys via tmux send-keys, e.g. 'Enter', 'Escape', 'C-c' (tmux mode only). */
-  sendSpecialKeys?(...keys: string[]): void;
+  /** Send text literally via tmux send-keys -l (tmux mode only).
+   *  Returns `false` when the write was dropped (e.g. send-keys failed while the
+   *  pane is still alive) so callers can surface a non-submission; `void`/`true`
+   *  means the write was issued. Backends that can't tell return void. */
+  sendText?(text: string): void | boolean;
+  /** Send special keys via tmux send-keys, e.g. 'Enter', 'Escape', 'C-c' (tmux mode only).
+   *  Returns `false` on a dropped write (see sendText). */
+  sendSpecialKeys?(...keys: string[]): void | boolean;
   /** Paste text via tmux load-buffer + paste-buffer (auto-brackets if terminal supports it). */
   pasteText?(text: string): void;
   /** Absolute path to Claude Code's session JSONL; set by worker for claude-code adapter.

--- a/test/runner-input.test.ts
+++ b/test/runner-input.test.ts
@@ -164,10 +164,13 @@ describe('writeRunnerInput — tmux mode', () => {
     expect(enterCount()).toBe(2);
   });
 
-  it('reports submitted:false when every Enter is dropped (after retries)', async () => {
-    const { pty } = fakeTmuxPty({ failEnter: true });
+  it('pre-flush gate: when every Enter is dropped, bail submitted:false WITHOUT writing any chunk', async () => {
+    const { pty, textChunks } = fakeTmuxPty({ failEnter: true });
     const res = await writeRunnerInput(pty, MARKER, 'short message');
     expect(res).toEqual({ submitted: false });
+    // The pre-flush Enter never lands, so we must not write the control line
+    // onto a possibly-dirty buffer.
+    expect(textChunks).toHaveLength(0);
   });
 });
 
@@ -214,5 +217,54 @@ describe('writeRunnerInput — runner buffer hygiene (no cross-message contamina
     expect(runner.enqueued).toEqual(['first', 'second']);
     expect(runner.bad).toEqual([]);
     expect(runner.buf).toBe('');
+  });
+
+  // Codex re-review 🔴: failure-flush Enter ALSO drops, then the next message's
+  // pre-flush Enter ALSO drops. The old code would write the next line onto the
+  // dirty buffer and (if its submit Enter landed) falsely report submitted:true
+  // while the runner only saw a parse error — a silent message loss. The
+  // pre-flush gate must prevent that.
+  it('pre-flush gate blocks a write onto a dirty buffer — no false submitted:true, no corruption', async () => {
+    const runner = makeRunnerSim();
+    // Stateful driver spanning both calls; script global text/enter drop indices.
+    let textIdx = 0;
+    let enterIdx = 0;
+    const dropText = new Set<number>();
+    const dropEnter = new Set<number>();
+    const pty: PtyHandle = {
+      write() { throw new Error('unused'); },
+      sendText(t: string) { const i = textIdx++; if (dropText.has(i)) return false; runner.feed(t); return true; },
+      sendSpecialKeys() { const i = enterIdx++; if (dropEnter.has(i)) return false; runner.feed('\r'); return true; },
+    };
+
+    // Message A: a >=3-chunk payload; drop the last chunk so a partial lingers,
+    // and drop ALL of A's failure-flush Enter retries so the partial is NOT
+    // flushed. (A pre-flush = enter 0 lands; failure-flush = enters 1,2,3 drop.)
+    const aContent = 'A'.repeat(2000);
+    const aChunks = chunkAscii(MARKER + encodeRunnerInput(aContent), RUNNER_INPUT_CHUNK_BYTES);
+    expect(aChunks.length).toBeGreaterThanOrEqual(3);
+    dropText.add(aChunks.length - 1);
+    dropEnter.add(1); dropEnter.add(2); dropEnter.add(3);
+    const a = await writeRunnerInput(pty, MARKER, aContent);
+    expect(a).toEqual({ submitted: false });
+    expect(runner.buf).not.toBe('');            // A's partial is stuck in the buffer
+
+    // Message B: drop ALL of B's pre-flush Enter retries (enters 4,5,6). The gate
+    // must refuse to write B's chunks and report submitted:false.
+    dropEnter.add(4); dropEnter.add(5); dropEnter.add(6);
+    const textBefore = textIdx;
+    const b = await writeRunnerInput(pty, MARKER, 'message B');
+    expect(b).toEqual({ submitted: false });    // NOT a false success
+    expect(textIdx).toBe(textBefore);           // zero chunks written for B
+    expect(runner.enqueued).not.toContain('message B');
+    expect(runner.bad).not.toContain('shape');  // no merged bad line attributed as submitted
+
+    // Recovery: a clean B' (all Enters land) pre-flushes A's stuck partial
+    // (discarded as bad), then enqueues intact.
+    const cleanRunnerPty = fakeRunnerPty(runner); // fresh counters, no drops
+    const bb = await writeRunnerInput(cleanRunnerPty, MARKER, 'message B prime');
+    expect(bb).toEqual({ submitted: true });
+    expect(runner.enqueued).toContain('message B prime');
+    expect(runner.enqueued).not.toContain('message B');
   });
 });

--- a/test/runner-input.test.ts
+++ b/test/runner-input.test.ts
@@ -7,13 +7,16 @@ import {
 } from '../src/adapters/cli/runner-input.js';
 import type { PtyHandle } from '../src/adapters/cli/types.js';
 
+const MARKER = '::botmux-codex-app:';
+
 /** Fake tmux-mode PtyHandle that records sendText/sendSpecialKeys calls.
- *  `failTextAt` / `failEnter` make a specific write report a dropped keystroke
- *  (mirrors TmuxPipeBackend returning false on a pane-alive send-keys failure). */
+ *  `failTextAt` drops a specific chunk; `failEnter` makes every Enter report a
+ *  dropped keystroke (mirrors TmuxPipeBackend returning false on a pane-alive
+ *  send-keys failure). */
 function fakeTmuxPty(opts: { failTextAt?: number; failEnter?: boolean } = {}) {
   const textChunks: string[] = [];
-  const enters: string[][] = [];
   let textCalls = 0;
+  let enterCalls = 0;
   const pty: PtyHandle = {
     write() {
       throw new Error('tmux-mode pty should not use write()');
@@ -24,13 +27,12 @@ function fakeTmuxPty(opts: { failTextAt?: number; failEnter?: boolean } = {}) {
       textChunks.push(text);
       return true;
     },
-    sendSpecialKeys(...keys: string[]) {
-      if (opts.failEnter) return false;
-      enters.push(keys);
-      return true;
+    sendSpecialKeys() {
+      enterCalls++;
+      return opts.failEnter ? false : true;
     },
   };
-  return { pty, textChunks, enters };
+  return { pty, textChunks, enterCount: () => enterCalls };
 }
 
 /** Fake raw-PTY handle (no tmux send methods): exercises the write() fallback. */
@@ -45,7 +47,59 @@ function fakeRawPty(opts: { throwOnWrite?: boolean } = {}) {
   return { pty, writes };
 }
 
-const MARKER = '::botmux-codex-app:';
+/** Faithful mirror of codex-app-runner.ts / mira-runner.ts handleInput buffer
+ *  logic: accumulate stdin bytes, enqueue (and base64-decode the control line)
+ *  only on a newline. Used to prove no cross-message buffer contamination. */
+function makeRunnerSim() {
+  let buf = '';
+  const enqueued: string[] = [];
+  const bad: string[] = [];
+  return {
+    feed(s: string) {
+      for (const ch of s) {
+        if (ch === '\r' || ch === '\n') {
+          const t = buf.trim();
+          buf = '';
+          if (!t) continue; // blank line ignored (enqueueLine early-return)
+          if (t.startsWith(MARKER)) {
+            try {
+              const d = JSON.parse(Buffer.from(t.slice(MARKER.length), 'base64').toString('utf8'));
+              if (d?.type === 'message' && typeof d.content === 'string') enqueued.push(d.content);
+              else bad.push('shape');
+            } catch { bad.push('decode'); }
+          } else {
+            bad.push('raw:' + t.slice(0, 20));
+          }
+        } else {
+          buf += ch;
+        }
+      }
+    },
+    enqueued,
+    bad,
+    get buf() { return buf; },
+  };
+}
+
+/** Fake pty that drives a runner sim: text chunks feed the runner unless dropped;
+ *  Enter feeds a newline. */
+function fakeRunnerPty(runner: ReturnType<typeof makeRunnerSim>, opts: { dropTextAt?: number } = {}) {
+  let textCalls = 0;
+  const pty: PtyHandle = {
+    write() { throw new Error('unused'); },
+    sendText(text: string) {
+      const idx = textCalls++;
+      if (opts.dropTextAt === idx) return false; // dropped: runner never sees these bytes
+      runner.feed(text);
+      return true;
+    },
+    sendSpecialKeys() {
+      runner.feed('\r');
+      return true;
+    },
+  };
+  return pty;
+}
 
 describe('chunkAscii', () => {
   it('splits into <=maxBytes pieces and rejoins losslessly', () => {
@@ -53,7 +107,6 @@ describe('chunkAscii', () => {
     const chunks = chunkAscii(s, 1024);
     expect(chunks).toHaveLength(3);
     expect(chunks[0].length).toBe(1024);
-    expect(chunks[1].length).toBe(1024);
     expect(chunks[2].length).toBe(452);
     expect(chunks.join('')).toBe(s);
   });
@@ -64,17 +117,17 @@ describe('chunkAscii', () => {
 });
 
 describe('writeRunnerInput — tmux mode', () => {
-  it('chunks a large (>4KB) payload, every chunk within the byte cap, then one Enter', async () => {
-    const big = 'A'.repeat(15_000); // base64 inflates this well past the N_TTY buffer
-    const { pty, textChunks, enters } = fakeTmuxPty();
+  it('chunks a large (>4KB) payload, every chunk within the byte cap, then submits', async () => {
+    const big = 'A'.repeat(15_000);
+    const { pty, textChunks, enterCount } = fakeTmuxPty();
 
     const res = await writeRunnerInput(pty, MARKER, big);
 
     expect(res).toEqual({ submitted: true });
     expect(textChunks.length).toBeGreaterThan(1);
     for (const c of textChunks) expect(c.length).toBeLessThanOrEqual(RUNNER_INPUT_CHUNK_BYTES);
-    // Exactly one trailing submit.
-    expect(enters).toEqual([['Enter']]);
+    // pre-flush Enter + submit Enter on the happy path.
+    expect(enterCount()).toBe(2);
   });
 
   it('reassembled chunks decode back to the original content (no corruption, no stray newline)', async () => {
@@ -87,36 +140,34 @@ describe('writeRunnerInput — tmux mode', () => {
     expect(line.startsWith(MARKER)).toBe(true);
     expect(line).not.toContain('\n');
     expect(line).not.toContain('\r');
-    const decoded = JSON.parse(
-      Buffer.from(line.slice(MARKER.length), 'base64').toString('utf8'),
-    );
+    const decoded = JSON.parse(Buffer.from(line.slice(MARKER.length), 'base64').toString('utf8'));
     expect(decoded).toEqual({ type: 'message', content: original });
   });
 
-  it('the joined line equals marker + encodeRunnerInput(content)', async () => {
+  it('the joined text chunks equal marker + encodeRunnerInput(content)', async () => {
     const content = 'hello world';
     const { pty, textChunks } = fakeTmuxPty();
     await writeRunnerInput(pty, MARKER, content);
     expect(textChunks.join('')).toBe(MARKER + encodeRunnerInput(content));
   });
 
-  it('reports submitted:false and stops sending when a chunk is dropped', async () => {
+  it('reports submitted:false and flushes the partial when a chunk is dropped', async () => {
     const big = 'B'.repeat(15_000);
-    const { pty, textChunks, enters } = fakeTmuxPty({ failTextAt: 2 });
+    const { pty, textChunks, enterCount } = fakeTmuxPty({ failTextAt: 2 });
 
     const res = await writeRunnerInput(pty, MARKER, big);
 
     expect(res).toEqual({ submitted: false });
-    // Chunks 0 and 1 landed; chunk 2 failed and we bailed — no Enter.
+    // Chunks 0 and 1 landed; chunk 2 failed and we bailed.
     expect(textChunks).toHaveLength(2);
-    expect(enters).toHaveLength(0);
+    // pre-flush Enter + flush-on-failure Enter — the partial line gets terminated.
+    expect(enterCount()).toBe(2);
   });
 
-  it('reports submitted:false when the trailing Enter is dropped', async () => {
-    const { pty, enters } = fakeTmuxPty({ failEnter: true });
+  it('reports submitted:false when every Enter is dropped (after retries)', async () => {
+    const { pty } = fakeTmuxPty({ failEnter: true });
     const res = await writeRunnerInput(pty, MARKER, 'short message');
     expect(res).toEqual({ submitted: false });
-    expect(enters).toHaveLength(0);
   });
 });
 
@@ -133,5 +184,35 @@ describe('writeRunnerInput — raw PTY fallback', () => {
     const { pty } = fakeRawPty({ throwOnWrite: true });
     const res = await writeRunnerInput(pty, MARKER, 'x');
     expect(res).toEqual({ submitted: false });
+  });
+});
+
+// Codex review 🔴 regression: a partial write must NOT corrupt the next message.
+describe('writeRunnerInput — runner buffer hygiene (no cross-message contamination)', () => {
+  it('a dropped chunk leaves the runner buffer clean so the NEXT message decodes intact', async () => {
+    const runner = makeRunnerSim();
+
+    // Message A: drop chunk 2 mid-stream.
+    const big = 'A'.repeat(15_000);
+    const resA = await writeRunnerInput(fakeRunnerPty(runner, { dropTextAt: 2 }), MARKER, big);
+    expect(resA).toEqual({ submitted: false });
+    // A never enqueues intact; its partial got flushed (discarded as bad input),
+    // so the runner buffer is empty — nothing left to prepend to the next line.
+    expect(runner.enqueued).not.toContain(big);
+    expect(runner.buf).toBe('');
+
+    // Message B through the SAME runner: must arrive intact, not merged with A.
+    const resB = await writeRunnerInput(fakeRunnerPty(runner), MARKER, 'clean message B');
+    expect(resB).toEqual({ submitted: true });
+    expect(runner.enqueued).toContain('clean message B');
+  });
+
+  it('back-to-back successful messages each enqueue exactly once, in order', async () => {
+    const runner = makeRunnerSim();
+    await writeRunnerInput(fakeRunnerPty(runner), MARKER, 'first');
+    await writeRunnerInput(fakeRunnerPty(runner), MARKER, 'second');
+    expect(runner.enqueued).toEqual(['first', 'second']);
+    expect(runner.bad).toEqual([]);
+    expect(runner.buf).toBe('');
   });
 });

--- a/test/runner-input.test.ts
+++ b/test/runner-input.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import {
+  writeRunnerInput,
+  chunkAscii,
+  encodeRunnerInput,
+  RUNNER_INPUT_CHUNK_BYTES,
+} from '../src/adapters/cli/runner-input.js';
+import type { PtyHandle } from '../src/adapters/cli/types.js';
+
+/** Fake tmux-mode PtyHandle that records sendText/sendSpecialKeys calls.
+ *  `failTextAt` / `failEnter` make a specific write report a dropped keystroke
+ *  (mirrors TmuxPipeBackend returning false on a pane-alive send-keys failure). */
+function fakeTmuxPty(opts: { failTextAt?: number; failEnter?: boolean } = {}) {
+  const textChunks: string[] = [];
+  const enters: string[][] = [];
+  let textCalls = 0;
+  const pty: PtyHandle = {
+    write() {
+      throw new Error('tmux-mode pty should not use write()');
+    },
+    sendText(text: string) {
+      const idx = textCalls++;
+      if (opts.failTextAt === idx) return false;
+      textChunks.push(text);
+      return true;
+    },
+    sendSpecialKeys(...keys: string[]) {
+      if (opts.failEnter) return false;
+      enters.push(keys);
+      return true;
+    },
+  };
+  return { pty, textChunks, enters };
+}
+
+/** Fake raw-PTY handle (no tmux send methods): exercises the write() fallback. */
+function fakeRawPty(opts: { throwOnWrite?: boolean } = {}) {
+  const writes: string[] = [];
+  const pty: PtyHandle = {
+    write(data: string) {
+      if (opts.throwOnWrite) throw new Error('pty gone');
+      writes.push(data);
+    },
+  };
+  return { pty, writes };
+}
+
+const MARKER = '::botmux-codex-app:';
+
+describe('chunkAscii', () => {
+  it('splits into <=maxBytes pieces and rejoins losslessly', () => {
+    const s = 'x'.repeat(2500);
+    const chunks = chunkAscii(s, 1024);
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0].length).toBe(1024);
+    expect(chunks[1].length).toBe(1024);
+    expect(chunks[2].length).toBe(452);
+    expect(chunks.join('')).toBe(s);
+  });
+
+  it('returns a single chunk when under the limit', () => {
+    expect(chunkAscii('abc', 1024)).toEqual(['abc']);
+  });
+});
+
+describe('writeRunnerInput — tmux mode', () => {
+  it('chunks a large (>4KB) payload, every chunk within the byte cap, then one Enter', async () => {
+    const big = 'A'.repeat(15_000); // base64 inflates this well past the N_TTY buffer
+    const { pty, textChunks, enters } = fakeTmuxPty();
+
+    const res = await writeRunnerInput(pty, MARKER, big);
+
+    expect(res).toEqual({ submitted: true });
+    expect(textChunks.length).toBeGreaterThan(1);
+    for (const c of textChunks) expect(c.length).toBeLessThanOrEqual(RUNNER_INPUT_CHUNK_BYTES);
+    // Exactly one trailing submit.
+    expect(enters).toEqual([['Enter']]);
+  });
+
+  it('reassembled chunks decode back to the original content (no corruption, no stray newline)', async () => {
+    const original = 'multi\nline\tmessage with 💥 unicode ' + 'z'.repeat(5000);
+    const { pty, textChunks } = fakeTmuxPty();
+
+    await writeRunnerInput(pty, MARKER, original);
+
+    const line = textChunks.join('');
+    expect(line.startsWith(MARKER)).toBe(true);
+    expect(line).not.toContain('\n');
+    expect(line).not.toContain('\r');
+    const decoded = JSON.parse(
+      Buffer.from(line.slice(MARKER.length), 'base64').toString('utf8'),
+    );
+    expect(decoded).toEqual({ type: 'message', content: original });
+  });
+
+  it('the joined line equals marker + encodeRunnerInput(content)', async () => {
+    const content = 'hello world';
+    const { pty, textChunks } = fakeTmuxPty();
+    await writeRunnerInput(pty, MARKER, content);
+    expect(textChunks.join('')).toBe(MARKER + encodeRunnerInput(content));
+  });
+
+  it('reports submitted:false and stops sending when a chunk is dropped', async () => {
+    const big = 'B'.repeat(15_000);
+    const { pty, textChunks, enters } = fakeTmuxPty({ failTextAt: 2 });
+
+    const res = await writeRunnerInput(pty, MARKER, big);
+
+    expect(res).toEqual({ submitted: false });
+    // Chunks 0 and 1 landed; chunk 2 failed and we bailed — no Enter.
+    expect(textChunks).toHaveLength(2);
+    expect(enters).toHaveLength(0);
+  });
+
+  it('reports submitted:false when the trailing Enter is dropped', async () => {
+    const { pty, enters } = fakeTmuxPty({ failEnter: true });
+    const res = await writeRunnerInput(pty, MARKER, 'short message');
+    expect(res).toEqual({ submitted: false });
+    expect(enters).toHaveLength(0);
+  });
+});
+
+describe('writeRunnerInput — raw PTY fallback', () => {
+  it('writes the whole line + CR in one shot and reports submitted:true', async () => {
+    const content = 'fallback path';
+    const { pty, writes } = fakeRawPty();
+    const res = await writeRunnerInput(pty, MARKER, content);
+    expect(res).toEqual({ submitted: true });
+    expect(writes).toEqual([MARKER + encodeRunnerInput(content) + '\r']);
+  });
+
+  it('reports submitted:false when the raw write throws (pane gone)', async () => {
+    const { pty } = fakeRawPty({ throwOnWrite: true });
+    const res = await writeRunnerInput(pty, MARKER, 'x');
+    expect(res).toEqual({ submitted: false });
+  });
+});

--- a/test/write-input-all-cli.e2e.ts
+++ b/test/write-input-all-cli.e2e.ts
@@ -80,6 +80,14 @@ function hasDelayBetween(writes: WriteRecord[], minMs: number): boolean {
   return false;
 }
 
+/** True when nothing the adapter wrote contains a raw newline. Runner adapters
+ *  (mira / codex-app) base64-encode the whole message into a single control
+ *  line, so the content's own newlines never reach the TUI as Enter keystrokes
+ *  — a stronger multi-line-safety strategy than bracketed paste or delay. */
+function hasNoRawNewline(writes: WriteRecord[]): boolean {
+  return !writes.map(w => w.data).join('').includes('\n');
+}
+
 // ─── Test fixtures ──────────────────────────────────────────────────────────
 
 const SINGLE_LINE = 'hello world';
@@ -154,16 +162,19 @@ describe('writeInput: write sequence verification (all CLIs × all scenarios)', 
 
             const usesBracket = hasBracketedPaste(pty.writes);
             const usesDelay = hasDelayBetween(pty.writes, 100);
+            const usesEncoding = hasNoRawNewline(pty.writes);
 
             console.log(`\n[${adapterDef.name}] ${scenario.name} multi-line strategy:`);
             console.log(`  bracketed paste: ${usesBracket}`);
             console.log(`  has delay (>=100ms): ${usesDelay}`);
+            console.log(`  no raw newline (encoded): ${usesEncoding}`);
             console.log(pty.dump());
 
-            // Multi-line MUST use some strategy to avoid \n being treated as Enter
+            // Multi-line MUST use some strategy to avoid \n being treated as Enter:
+            // bracketed paste, a delay before CR, or encoding it away (runner adapters).
             expect(
-              usesBracket || usesDelay,
-              `${adapterDef.name}: multi-line needs bracketed paste or delay before CR`,
+              usesBracket || usesDelay || usesEncoding,
+              `${adapterDef.name}: multi-line needs bracketed paste, delay, or newline-free encoding`,
             ).toBe(true);
           });
         }


### PR DESCRIPTION
## 问题

Code Review webhook 的全量 MR JSON（~12-16KB）被原样塞进一条消息发给 codex-app，base64 编码后膨胀到 ~16-21KB。codex-app/mira 适配器把整条控制行一次性 `tmux send-keys -l` 灌进 pane，超大 payload 撑爆 pane pty 的输入缓冲（~4KB N_TTY），tmux 的写阻塞命中 `execFileSync` 5s 超时被杀，`guardedSend` 捕获后判 pane ALIVE → **静默丢键**；而旧 `writeInput` 仍返回 `submitted:true`，worker 误判已发出 → 不触发提交失败补救 → turn 永远 working、等不到 `final` marker → **会话被钉死在 busy**，后续所有 @ 排队成 "Codex App is busy"。

对照：codex CLI 走 `pasteText`（load-buffer + paste-buffer，tmux 异步分块写）天然规避；claude-code 走分块节流 send-keys。codex-app / mira 是仅有的「裸单发」runner 适配器。

## 改动

- **新增 `src/adapters/cli/runner-input.ts`**：`writeRunnerInput` 把控制行分块（≤1KB）+ 节流（20ms）注入，块间不夹换行（runner 靠尾部 Enter 才入队，分块安全），末尾单发 Enter。codex-app / mira 共用。
- **`TmuxPipeBackend.sendText/sendSpecialKeys` 改为返回 boolean**（`guardedSend` 返回成功与否）：任一块或 Enter 写失败 → `writeRunnerInput` 返回 `submitted:false`，让 worker 既有的提交失败补救/重投生效，不再误报成功钉死会话。`PtyHandle` 对应方法返回类型 `void → void | boolean`（其它 backend 返 void，兼容）。
- `codex-app.ts` / `mira.ts` 的 `writeInput` 收敛成一行调用。

> 为什么 codex-app/mira 不能照搬 codex 的 paste：它们的 runner raw 模式逐字节读 stdin、不认 bracketed-paste 标记 `\e[200~…\e[201~`，会污染 base64 串。所以只能走分块 send-keys（对齐 claude-code 思路）。

webhook 全量 payload **保留不截断**（产品决策）。

## 验证

- **单测**：新增 9 例（`test/runner-input.test.ts`，覆盖分块/重组无损/失败短路/raw-pty 兜底），全量 unit **4092 passed, 0 fail**。
- **真机复现**（真 tmux 3.3a + 真 pty 线路，1:1 复刻 codex-app-runner stdin 处理的 stub，喂 15.6KB content / 20.8KB base64）：

```
OLD 单发 send-keys: TIMED OUT (killed) → runner RECEIVED=[]  （消息彻底丢失）
NEW 分块 + 节流:    all chunks sent OK  → runner RECEIVED 15600  （字节一致，无损）
```
