### PR TITLE
feat(command): /card 与 /term 权限收敛为 canOperate

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -6,7 +6,7 @@ import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { join, resolve, basename } from 'node:path';
 import { config } from '../config.js';
 import { buildTerminalUrl } from './terminal-url.js';
-import { getBot, getAllBots, getBotOpenId, getOwnerOpenId } from '../bot-registry.js';
+import { getBot, getAllBots, getBotOpenId } from '../bot-registry.js';
 import * as sessionStore from '../services/session-store.js';
 import * as scheduleStore from '../services/schedule-store.js';
 import * as scheduler from './scheduler.js';
@@ -34,6 +34,7 @@ import {
 import { resolveCliId, findInvalidAllowedUserEntries } from '../setup/bot-config-editor.js';
 import { publishAttentionPatch, announcePendingRepoSession } from './session-activity.js';
 import { setCardMode } from '../services/card-mode-store.js';
+import { canOperate } from '../im/lark/event-dispatcher.js';
 import { invalidWorkingDirs } from '../utils/working-dir.js';
 import { writeRoleFile, deleteRoleFile, resolveRole, resolveTeamRoleFile, writeTeamRoleFile, deleteTeamRoleFile } from './role-resolver.js';
 import { getBotCapability, setBotCapability, clearBotCapability } from '../services/bot-profile-store.js';
@@ -711,7 +712,7 @@ async function handleConfigCommand(
 // ─── Main command handler ────────────────────────────────────────────────────
 
 /**
- * Handle `/card` (owner-only). Resolves the active session itself, so off/on
+ * Handle `/card` (operator-only). Resolves the active session itself, so off/on
  * work WITHOUT one -- they only toggle the per-chat `noCardChats` config. A
  * summon (show/bare) needs a live session.
  *
@@ -734,12 +735,12 @@ export async function handleCardCommand(
   const loc = localeForBot(larkAppId);
   const reply = (c: string) => deps.sessionReply(rootId, c, undefined, larkAppId);
 
-  const ownerOpenId = getOwnerOpenId(larkAppId);
-  // Open mode: when the bot has no configured owner/allowlist, botmux treats
-  // talk/operate as open to everyone. Keep /card consistent with that model:
-  // only enforce owner-only when an owner actually exists.
-  if (ownerOpenId && senderOpenId !== ownerOpenId) {
-    await reply(t('cmd.card.owner_only', undefined, loc));
+  // /card is an operator command — gate on canOperate, the same model every other
+  // daemon command uses. Open mode (no owner/allowlist) → canOperate passes for
+  // everyone; configured → any allowedUser (owner or co-owner); talk-only grantees
+  // (chatGrant/globalGrant/oncall members) are never operators.
+  if (!canOperate(larkAppId, chatId, senderOpenId)) {
+    await reply(t('cmd.card.operator_only', undefined, loc));
     return;
   }
 
@@ -794,18 +795,18 @@ export async function handleCardCommand(
 }
 
 /**
- * Handle `/term` (owner-only) — the slash-command twin of the "🔑 获取操作链接"
- * card button. Privately hands the owner a writable (token-bearing) terminal card:
- * an in-chat visible-to-you ephemeral card in plain groups, auto-falling back to a
- * DM in topic / p2p chats. The link rides only that private channel — never the
- * group. Gated identically to /card (`senderOpenId === owner`), and strictly
- * needs a live session whose terminal is up. Routed for both the new-topic path
- * (daemon.ts) and the existing-session switch below.
+ * Handle `/term` (operator-only) — the slash-command twin of the "🔑 获取操作链接"
+ * card button. Privately hands the operator a writable (token-bearing) terminal
+ * card: an in-chat visible-to-you ephemeral card in plain groups, auto-falling back
+ * to a DM in topic / p2p chats. The link rides only that private channel — never the
+ * group. Gated identically to /card (`canOperate`), and strictly needs a live
+ * session whose terminal is up. Routed for both the new-topic path (daemon.ts) and
+ * the existing-session switch below.
  */
 export async function handleTermLinkCommand(
   rootId: string,
   larkAppId: string,
-  _chatId: string,
+  chatId: string,
   senderOpenId: string | undefined,
   _content: string,
   deps: CommandHandlerDeps,
@@ -813,9 +814,12 @@ export async function handleTermLinkCommand(
   const loc = localeForBot(larkAppId);
   const reply = (c: string) => deps.sessionReply(rootId, c, undefined, larkAppId);
 
-  const ownerOpenId = getOwnerOpenId(larkAppId);
-  if (!ownerOpenId || !senderOpenId || senderOpenId !== ownerOpenId) {
-    await reply(t('cmd.term.owner_only', undefined, loc));
+  // /term is an operator command that hands out a *writable* terminal link — gate
+  // on canOperate (same model as other daemon commands). senderOpenId must be
+  // present: open-mode canOperate passes even an undefined sender, but the writable
+  // card is delivered privately to that exact open_id.
+  if (!senderOpenId || !canOperate(larkAppId, chatId, senderOpenId)) {
+    await reply(t('cmd.term.operator_only', undefined, loc));
     return;
   }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2751,7 +2751,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
       // /term only hands out a writable link for an ALREADY-live session — it must
       // never pre-create one. Special-case it before the canOperate gate + the
       // pre-create block below (mirrors the new-topic route + /card). Its own
-      // owner gate (stricter than canOperate) is the sole authority; without this,
+      // canOperate gate (inside the handler) is the sole authority; without this,
       // /term in a thread with no existingDs would spawn a worker:null phantom
       // session and pollute the dashboard before replying not_ready/owner_only.
       if (cmd === '/term') {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -180,8 +180,8 @@ export const messages: Record<string, string> = {
 
   // ─── Command responses ───────────────────────────────────────────────────
   'cmd.no_active_session': 'No active session in this topic.',
-  'cmd.card.owner_only': '⚠️ Only the bot owner can use /card.',
-  'cmd.term.owner_only': '⚠️ Only the bot owner can use /term to get the operable terminal link.',
+  'cmd.card.operator_only': '⚠️ Only authorized users (allowedUsers) can use /card.',
+  'cmd.term.operator_only': '⚠️ Only authorized users (allowedUsers) can use /term to get the operable terminal link.',
   'cmd.term.no_session': 'No active session in this topic — /term needs a running session.',
   'cmd.term.not_ready': '🔒 Terminal isn’t ready yet; send /term again once the session is up.',
   'cmd.term.failed': '⚠️ Failed to send the operable link (both the private card and DM failed); check the daemon logs.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -183,8 +183,8 @@ export const messages: Record<string, string> = {
 
   // ─── Command responses ───────────────────────────────────────────────────
   'cmd.no_active_session': '当前话题没有活跃的会话。',
-  'cmd.card.owner_only': '⚠️ 仅 bot 主人可以使用 /card。',
-  'cmd.term.owner_only': '⚠️ 仅 bot 主人可以用 /term 获取可操作终端链接。',
+  'cmd.card.operator_only': '⚠️ 仅授权用户（allowedUsers）可以使用 /card。',
+  'cmd.term.operator_only': '⚠️ 仅授权用户（allowedUsers）可以用 /term 获取可操作终端链接。',
   'cmd.term.no_session': '当前话题没有活跃会话，/term 需要一个跑着的会话。',
   'cmd.term.not_ready': '🔒 终端还没就绪，等会话起好后再发 /term。',
   'cmd.term.failed': '⚠️ 可操作链接发送失败（私密卡与 DM 均失败），看 daemon 日志。',

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -473,13 +473,14 @@ describe('opencode buildArgs', () => {
 describe('pi buildArgs', () => {
   const adapter = createPiAdapter('/usr/bin/pi');
 
-  it('launches Pi native TUI with session id and tools', () => {
+  it('launches Pi native TUI with session id, no --tools restriction (keeps MCP usable)', () => {
     const args = adapter.buildArgs({ sessionId: 'sess-pi', resume: false, initialPrompt: 'hello pi' });
     expect(adapter.resolvedBin).toBe('/usr/bin/pi');
     expect(args).toContain('--session-id');
     expect(args[args.indexOf('--session-id') + 1]).toBe('sess-pi');
-    expect(args).toContain('--tools');
-    expect(args[args.indexOf('--tools') + 1]).toBe('read,bash,edit,write,grep,find,ls');
+    // Pi must NOT receive a --tools allowlist: pinning the built-in tools shadows
+    // MCP tools. Let Pi use its default tool set so MCP servers stay usable.
+    expect(args).not.toContain('--tools');
     expect(args.at(-1)).toBe('hello pi');
     expect(adapter.passesInitialPromptViaArgs).toBe(true);
     expect(adapter.altScreen).toBe(true);

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -316,9 +316,21 @@ vi.mock('../src/services/oncall-store.js', () => ({
   getOncallStatus: vi.fn(() => undefined),
 }));
 
+// /card and /term gate on canOperate (the operator model). Default allow; tests
+// flip the return per-scenario to exercise the gate without re-testing canOperate's
+// own open-mode / allowlist / peer-bot logic (that lives in event-dispatcher).
+vi.mock('../src/im/lark/event-dispatcher.js', () => ({
+  canOperate: vi.fn(() => true),
+}));
+
+vi.mock('../src/services/card-mode-store.js', () => ({
+  setCardMode: vi.fn(async () => ({ ok: true })),
+}));
+
 // ─── Imports (after mocks) ──────────────────────────────────────────────────
 
-import { DAEMON_COMMANDS, SESSIONLESS_DAEMON_COMMANDS, PASSTHROUGH_COMMANDS, handleCommand, handleTermLinkCommand, parseSlashCommandInvocation, parseForceTopicInvocation } from '../src/core/command-handler.js';
+import { DAEMON_COMMANDS, SESSIONLESS_DAEMON_COMMANDS, PASSTHROUGH_COMMANDS, handleCommand, handleCardCommand, handleTermLinkCommand, parseSlashCommandInvocation, parseForceTopicInvocation } from '../src/core/command-handler.js';
+import { setCardMode } from '../src/services/card-mode-store.js';
 import { writeTeamRoleFile, deleteTeamRoleFile, resolveRole } from '../src/core/role-resolver.js';
 import { setBotCapability, clearBotCapability } from '../src/services/bot-profile-store.js';
 import type { CommandHandlerDeps } from '../src/core/command-handler.js';
@@ -328,6 +340,7 @@ import type { DaemonSession } from '../src/core/types.js';
 import type { LarkMessage, Session } from '../src/types.js';
 import { killWorker, forkWorker, getCurrentCliVersion, deliverEphemeralOrReply, deliverWritableTerminalCardTo } from '../src/core/worker-pool.js';
 import { getOwnerOpenId } from '../src/bot-registry.js';
+import { canOperate } from '../src/im/lark/event-dispatcher.js';
 import { getSessionWorkingDir, buildNewTopicPrompt } from '../src/core/session-manager.js';
 import * as sessionStore from '../src/services/session-store.js';
 import * as scheduleStore from '../src/services/schedule-store.js';
@@ -2572,19 +2585,74 @@ describe('/role subcommand routing', () => {
   });
 });
 
-describe('/term — operable terminal slash command (owner-only)', () => {
+describe('/card — operator / canOperate gate', () => {
+  const CHAT_ID = 'oc_chat_1';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(canOperate).mockReturnValue(true);
+    vi.mocked(setCardMode).mockResolvedValue({ ok: true } as any);
+  });
+
+  it('rejects a non-operator (canOperate=false): operator_only notice, no mode change', async () => {
+    vi.mocked(canOperate).mockReturnValue(false);
+    const deps = makeDeps();
+    await handleCardCommand(ROOT_ID, LARK_APP_ID, CHAT_ID, 'ou_random', '/card off', deps);
+    const reply = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(reply).toContain('仅授权用户');
+    expect(setCardMode).not.toHaveBeenCalled();
+  });
+
+  it('operator: /card off toggles the per-chat streaming card off', async () => {
+    const deps = makeDeps();
+    await handleCardCommand(ROOT_ID, LARK_APP_ID, CHAT_ID, 'ou_owner', '/card off', deps);
+    expect(setCardMode).toHaveBeenCalledWith(LARK_APP_ID, CHAT_ID, true);
+    const reply = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(reply).toContain('已关闭');
+  });
+
+  it('open mode: a non-owner sender passes canOperate and /card on works', async () => {
+    const deps = makeDeps();
+    await handleCardCommand(ROOT_ID, LARK_APP_ID, CHAT_ID, 'ou_random', '/card on', deps);
+    expect(setCardMode).toHaveBeenCalledWith(LARK_APP_ID, CHAT_ID, false);
+    const reply = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(reply).toContain('已恢复');
+  });
+});
+
+describe('/term — operable terminal slash command (operator / canOperate)', () => {
   const ownerMsg = (over: Partial<LarkMessage> = {}) => makeLarkMessage('/term', { senderId: 'ou_owner', ...over });
 
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.mocked(getOwnerOpenId).mockReturnValue('ou_owner');
+    vi.mocked(canOperate).mockReturnValue(true);
     vi.mocked(deliverWritableTerminalCardTo).mockResolvedValue('ephemeral');
   });
 
-  it('rejects a non-owner sender and never delivers a card', async () => {
+  it('rejects a non-operator (canOperate=false) and never delivers a card', async () => {
+    vi.mocked(canOperate).mockReturnValue(false);
     const deps = makeDeps(makeDaemonSession({ workerPort: 41000, workerToken: 't' }));
     await handleCommand('/term', ROOT_ID, makeLarkMessage('/term', { senderId: 'ou_random' }), deps, LARK_APP_ID);
     const reply = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
-    expect(reply).toContain('仅 bot 主人');
+    expect(reply).toContain('仅授权用户');
+    expect(deliverWritableTerminalCardTo).not.toHaveBeenCalled();
+  });
+
+  it('open mode / operator: a non-owner sender passes canOperate and gets the card', async () => {
+    // canOperate=true (open mode returns true for everyone) → delivery goes to the
+    // actual sender, not a fixed owner.
+    const ds = makeDaemonSession({ workerPort: 41000, workerToken: 'wtok' });
+    const deps = makeDeps(ds);
+    await handleCommand('/term', ROOT_ID, makeLarkMessage('/term', { senderId: 'ou_random' }), deps, LARK_APP_ID);
+    expect(deliverWritableTerminalCardTo).toHaveBeenCalledWith(ds, 'ou_random');
+  });
+
+  it('rejects when senderOpenId is missing even if canOperate passes (needs a recipient)', async () => {
+    const deps = makeDeps(makeDaemonSession({ workerPort: 41000, workerToken: 't' }));
+    await handleCommand('/term', ROOT_ID, makeLarkMessage('/term', { senderId: undefined as any }), deps, LARK_APP_ID);
+    const reply = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    expect(reply).toContain('仅授权用户');
     expect(deliverWritableTerminalCardTo).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## 背景
延续 #172 的讨论。`/card`、`/term` 原本走的是**比 canOperate 更严的 owner 专属闸**（`getOwnerOpenId`，只认第一个 allowedUser），与其它 daemon 命令的权限模型不一致。本 PR 按 owner（@申晗）拍板，把两者**收敛为纯 `canOperate`**。

> #172 已合入 master，本 PR 已 rebase 其上 → diff 仅本次改动。
> 注：#172 只合了 `pi.ts`（删 `--tools`）没合对应测试，导致 master 上 `cli-adapters.test.ts` 的 pi 用例当前是红的；本 PR 顺手修正它。

## 改动
**权限收敛（`src/core/command-handler.ts`）**
- `/card`、`/term` 闸门由 `senderOpenId === owner` 改为 `canOperate(...)`：
  - 开放模式（无 owner/白名单）→ canOperate 对所有人放行 → 两命令对所有人可用
  - 配置模式 → 任意 allowedUser（owner 或 co-owner）→ 修掉「co-owner 能跑 `/restart` 却跑不了 `/card`/`/term`」的既有不一致
  - talk-only 授权（chatGrant/globalGrant/oncall 成员）仍不是 operator，无法使用
- `/term` 额外保留 `!senderOpenId` 守卫：开放模式下 canOperate 会放行 undefined sender，但可写终端卡要私发给确切 open_id，缺 sender 时拒绝。

**文案（`src/i18n/{zh,en}.ts`）**
- key `cmd.{card,term}.owner_only` → `.operator_only`，措辞改为「仅授权用户（allowedUsers）」，与实际闸门语义一致。

**测试**
- 新增 `/card` canOperate 闸单测 3 例（非 operator 拒绝 / operator off 生效 / 开放模式非 owner 放行）。
- `/term` 测试块改写为 canOperate 模型，补「开放模式非 owner 放行」「缺 sender 拒绝」用例。
- 修正 #172 遗漏的 pi adapter stale 测试（删 `--tools` 后断言其不存在）。

## 安全考量
`/term` 发的是带 token 的可写终端链接。收敛后开放模式下任意群成员可获取——这与「开放模式 bot 本就接受任何人自然语言驱动终端」的姿态一致（owner 已确认采纳纯 canOperate，不加开放模式 fail-closed），且链接只私发请求者、不进群。

## 验证
- `tsc --noEmit` 干净；rebase 到最新 master 后 `command-handler.test.ts` + `cli-adapters.test.ts` 共 327 全过
- 全量 unit（rebase 前）：4115 通过 / 1 失败（`hook-runner` 计时断言 `Date.now()-started < 900`，在干净 master 上同样失败，纯环境负载 flake，与本改动无关）

🤖 Generated with [Claude Code](https://claude.com/claude-code)