### PR TITLE
feat(usage-ledger): usage 账本——每轮 turn 的 token 增量落盘 JSONL

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,6 +26,15 @@ cache read/create tokens when the CLI reports them; Token Out is the native
 output-side total. Botmux does not estimate token counts from message text.
 _Avoid_: token estimate, cost estimate
 
+**Usage Ledger**:
+Append-only daily JSONL files under `~/.botmux/usage/` recording per-turn
+**Token Usage** deltas per **Session**. Each record is a self-describing JSON
+line (recordId, ts, session/bot/chat context, caller open_id, token deltas
+plus cumulative totals). Baselines are anchored at worker spawn so resumed or
+pre-botmux transcript history is never recorded. External trackers (e.g.
+kaboo) consume this directory; botmux never uploads it anywhere itself.
+_Avoid_: usage log, billing database
+
 ## Example Dialogue
 
 Dev: "This Bot uses Codex as its Agent CLI."

--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -320,14 +320,20 @@ export function __resetSessionUsageCachesForTest(): void {
 
 /** Memoize a transcript-path lookup. `hitTtlMs === null` means a found path
  *  is trusted forever (rollout/transcript files never move); misses are
- *  always retried after PATH_MISS_RETRY_MS. */
-function cachedPathLookup(key: string, hitTtlMs: number | null, lookup: () => string | null): string | null {
+ *  retried after PATH_MISS_RETRY_MS — or immediately when `retryMiss` is set
+ *  (ledger reads must see lazily created transcripts at turn boundaries). */
+function cachedPathLookup(
+  key: string,
+  hitTtlMs: number | null,
+  lookup: () => string | null,
+  opts?: { retryMiss?: boolean },
+): string | null {
   const now = Date.now();
   const cached = sessionPathCache.get(key);
   if (cached) {
     if (cached.path !== null) {
       if (hitTtlMs === null || now - cached.atMs < hitTtlMs) return cached.path;
-    } else if (now - cached.atMs < PATH_MISS_RETRY_MS) {
+    } else if (!opts?.retryMiss && now - cached.atMs < PATH_MISS_RETRY_MS) {
       return null;
     }
   }
@@ -547,13 +553,13 @@ function tokenUsagePathForSession(q: SessionTokenUsageQuery): string | null {
       return cachedPathLookup(`codex:${q.sessionId}:${q.cliSessionId ?? ''}`, null, () => {
         const codexSid = q.cliSessionId || findCodexSessionIdByBotmuxSessionId(q.sessionId) || q.sessionId;
         return findCodexRolloutBySessionId(codexSid) ?? null;
-      });
+      }, { retryMiss: q.fresh });
     case 'coco':
       return cocoEventsPathForSession(sid);
     case 'cursor':
-      return cachedPathLookup(`cursor:${sid}`, null, () => findCursorTranscriptByChatId(sid) ?? null);
+      return cachedPathLookup(`cursor:${sid}`, null, () => findCursorTranscriptByChatId(sid) ?? null, { retryMiss: q.fresh });
     case 'traex':
-      return cachedPathLookup(`traex:${sid}`, null, () => findTraexRolloutBySessionId(sid) ?? null);
+      return cachedPathLookup(`traex:${sid}`, null, () => findTraexRolloutBySessionId(sid) ?? null, { retryMiss: q.fresh });
     case 'antigravity':
       return q.cliSessionId
         ? join(homedir(), '.gemini', 'antigravity-cli', 'brain', q.cliSessionId, '.system_generated', 'logs', 'transcript.jsonl')
@@ -573,6 +579,7 @@ export function getSessionTokenUsage(q: SessionTokenUsageQuery): SessionTokenUsa
         findAidenLatestCheckpointBySessionId(sid, undefined, q.cwd) ??
         findAidenLatestCheckpointByBotmuxSessionId(q.sessionId, undefined, q.cwd) ??
         null,
+      { retryMiss: q.fresh },
     );
     if (!checkpointPath || !existsSync(checkpointPath)) return null;
     return readSessionTokenUsageFile(checkpointPath, 'aiden', { fresh: q.fresh });

--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -34,6 +34,9 @@ export interface SessionTokenUsageQuery {
   sessionId: string;
   cliSessionId?: string;
   cwd?: string;
+  /** Bypass the reparse throttle (stat short-circuit and incremental folding
+   *  still apply). Use at low-frequency exact points like ledger snapshots. */
+  fresh?: boolean;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -376,7 +379,7 @@ interface UsageReadResult {
   result: SessionTokenUsage | null;
 }
 
-function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind): UsageReadResult | null {
+function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, opts?: { fresh?: boolean }): UsageReadResult | null {
   const key = `${kind}:${path}`;
   let st: Stats | null = null;
   try {
@@ -400,7 +403,8 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind): U
   const cached = usageFileCache.get(key);
   if (cached) {
     const unchanged = cached.mtimeMs === st.mtimeMs && cached.size === st.size;
-    if (unchanged || now - cached.parsedAtMs < USAGE_REPARSE_MIN_INTERVAL_MS) {
+    const throttled = !opts?.fresh && now - cached.parsedAtMs < USAGE_REPARSE_MIN_INTERVAL_MS;
+    if (unchanged || throttled) {
       return { agg: cached.previewAgg, result: cached.result };
     }
   }
@@ -479,8 +483,8 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind): U
 /** Read a transcript's token usage through the stat/incremental cache.
  *  This is the reusable entry point for dashboard rows and, later, the
  *  persistent usage ledger. */
-export function readSessionTokenUsageFile(path: string, kind: CachedUsageKind): SessionTokenUsage | null {
-  return readSessionTokenAggregateCached(path, kind)?.result ?? null;
+export function readSessionTokenUsageFile(path: string, kind: CachedUsageKind, opts?: { fresh?: boolean }): SessionTokenUsage | null {
+  return readSessionTokenAggregateCached(path, kind, opts)?.result ?? null;
 }
 
 function readTokenUsageFromAidenCheckpoint(path: string): SessionTokenUsage | null {
@@ -571,11 +575,11 @@ export function getSessionTokenUsage(q: SessionTokenUsageQuery): SessionTokenUsa
         null,
     );
     if (!checkpointPath || !existsSync(checkpointPath)) return null;
-    return readSessionTokenUsageFile(checkpointPath, 'aiden');
+    return readSessionTokenUsageFile(checkpointPath, 'aiden', { fresh: q.fresh });
   }
   const path = tokenUsagePathForSession(q);
   if (!path || !existsSync(path)) return null;
-  return readSessionTokenUsageFile(path, usageKindForCli(q.cliId));
+  return readSessionTokenUsageFile(path, usageKindForCli(q.cliId), { fresh: q.fresh });
 }
 
 export function formatNumber(n: number): string {

--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -321,18 +321,21 @@ export function __resetSessionUsageCachesForTest(): void {
 /** Memoize a transcript-path lookup. `hitTtlMs === null` means a found path
  *  is trusted forever (rollout/transcript files never move); misses are
  *  retried after PATH_MISS_RETRY_MS — or immediately when `retryMiss` is set
- *  (ledger reads must see lazily created transcripts at turn boundaries). */
+ *  (ledger reads must see lazily created transcripts at turn boundaries).
+ *  `refreshHit` additionally re-resolves a cached positive hit — for sources
+ *  whose path MOVES between turns (aiden checkpoints), a fresh ledger read
+ *  must not settle for a stale path inside the hit TTL. */
 function cachedPathLookup(
   key: string,
   hitTtlMs: number | null,
   lookup: () => string | null,
-  opts?: { retryMiss?: boolean },
+  opts?: { retryMiss?: boolean; refreshHit?: boolean },
 ): string | null {
   const now = Date.now();
   const cached = sessionPathCache.get(key);
   if (cached) {
     if (cached.path !== null) {
-      if (hitTtlMs === null || now - cached.atMs < hitTtlMs) return cached.path;
+      if (!opts?.refreshHit && (hitTtlMs === null || now - cached.atMs < hitTtlMs)) return cached.path;
     } else if (!opts?.retryMiss && now - cached.atMs < PATH_MISS_RETRY_MS) {
       return null;
     }
@@ -579,7 +582,7 @@ export function getSessionTokenUsage(q: SessionTokenUsageQuery): SessionTokenUsa
         findAidenLatestCheckpointBySessionId(sid, undefined, q.cwd) ??
         findAidenLatestCheckpointByBotmuxSessionId(q.sessionId, undefined, q.cwd) ??
         null,
-      { retryMiss: q.fresh },
+      { retryMiss: q.fresh, refreshHit: q.fresh },
     );
     if (!checkpointPath || !existsSync(checkpointPath)) return null;
     return readSessionTokenUsageFile(checkpointPath, 'aiden', { fresh: q.fresh });

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -34,7 +34,7 @@ import { composeRowFromActive, composeRowFromClosed } from './dashboard-rows.js'
 import { publishAttentionPatch } from './session-activity.js';
 import { knownBotOpenIdsFromCrossRef, type BotMentionEntry } from '../utils/bot-routing.js';
 import { emitSessionLifecycleHook, emitSessionStateTransitionHook } from '../services/session-lifecycle-hooks.js';
-import { anchorUsageForDaemonSession, recordUsageForDaemonSession } from '../services/usage-ledger.js';
+import { anchorUsageForDaemonSession, recordUsageForDaemonSession, reconcileUsageForDaemonSession } from '../services/usage-ledger.js';
 import type { CliId } from '../adapters/cli/types.js';
 import type { DaemonToWorker, WorkerToDaemon, Session, DisplayMode } from '../types.js';
 import { sessionKey, sessionAnchorId, type DaemonSession } from './types.js';
@@ -1558,10 +1558,12 @@ export function forkWorker(ds: DaemonSession, prompt: string, resume = false): v
     reason: resume ? 'resume' : 'worker_spawn',
     pid: worker.pid ?? null,
   });
-  // Usage ledger: anchor the baseline at spawn so resumed history (or growth
-  // while the daemon was down) is never billed; only turns driven from here
-  // on produce records.
-  anchorUsageForDaemonSession(ds);
+  // Usage ledger: fresh spawns anchor the baseline so pre-existing transcript
+  // history is never billed. Restores reconcile instead — an in-flight turn
+  // may have completed inside tmux while the daemon was down, and that work
+  // was submitted by botmux (anchoring would swallow it).
+  if (resume) reconcileUsageForDaemonSession(ds);
+  else anchorUsageForDaemonSession(ds);
 }
 
 // ─── Shared worker IPC handler ──────────────────────────────────────────────

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -34,6 +34,7 @@ import { composeRowFromActive, composeRowFromClosed } from './dashboard-rows.js'
 import { publishAttentionPatch } from './session-activity.js';
 import { knownBotOpenIdsFromCrossRef, type BotMentionEntry } from '../utils/bot-routing.js';
 import { emitSessionLifecycleHook, emitSessionStateTransitionHook } from '../services/session-lifecycle-hooks.js';
+import { anchorUsageForDaemonSession, recordUsageForDaemonSession } from '../services/usage-ledger.js';
 import type { CliId } from '../adapters/cli/types.js';
 import type { DaemonToWorker, WorkerToDaemon, Session, DisplayMode } from '../types.js';
 import { sessionKey, sessionAnchorId, type DaemonSession } from './types.js';
@@ -1078,6 +1079,9 @@ export async function closeSession(
   // 生命周期内永久占位（restartCounts 此前无任何 delete）。
   restartCounts.delete(sessionId);
   if (ds) {
+    // Usage ledger: flush the final delta before the worker goes away (a
+    // crash/limited turn may never have reached an idle edge).
+    recordUsageForDaemonSession(ds);
     killWorker(ds);
     activeSessionsRegistry?.delete(sessionKey(sessionAnchorId(ds), ds.larkAppId));
     killedLive = true;
@@ -1554,6 +1558,10 @@ export function forkWorker(ds: DaemonSession, prompt: string, resume = false): v
     reason: resume ? 'resume' : 'worker_spawn',
     pid: worker.pid ?? null,
   });
+  // Usage ledger: anchor the baseline at spawn so resumed history (or growth
+  // while the daemon was down) is never billed; only turns driven from here
+  // on produce records.
+  anchorUsageForDaemonSession(ds);
 }
 
 // ─── Shared worker IPC handler ──────────────────────────────────────────────
@@ -1801,6 +1809,11 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
             source: 'screen_update',
             content: msg.content,
           });
+          // Usage ledger: idle/limited edges are turn boundaries — append the
+          // token delta accrued during the turn that just finished.
+          if (ds.lastScreenStatus === 'idle' || ds.lastScreenStatus === 'limited') {
+            recordUsageForDaemonSession(ds);
+          }
         }
 
         // Bot opted out of the streaming card — dashboard SSE above already got
@@ -2486,6 +2499,8 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
     pid: worker.pid ?? null,
     adoptedFrom: adopted.tmuxTarget,
   });
+  // Adopted CLIs come with pre-botmux history — anchor it out of the ledger.
+  anchorUsageForDaemonSession(ds);
 }
 
 // ─── Kill stale PIDs ────────────────────────────────────────────────────────

--- a/src/services/usage-ledger.ts
+++ b/src/services/usage-ledger.ts
@@ -18,7 +18,7 @@
 import { appendFileSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { randomUUID } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import { logger } from '../utils/logger.js';
 import { getSessionTokenUsage, type SessionTokenUsage } from '../core/cost-calculator.js';
 import type { DaemonSession } from '../core/types.js';
@@ -72,6 +72,9 @@ interface SessionBaseline {
   cacheReadTokens: number;
   cacheCreateTokens: number;
   recordedAt: string;
+  /** Bumped on every baseline reset (shrink, explicit anchor) so identical
+   *  totals transitions in different epochs get distinct recordIds. */
+  epoch?: number;
 }
 
 interface LedgerState {
@@ -86,13 +89,17 @@ export function defaultLedgerDir(): string {
   return process.env.BOTMUX_USAGE_DIR || join(homedir(), '.botmux', 'usage');
 }
 
-function statePath(dir: string): string {
-  return join(dir, 'state.json');
+// Baselines are partitioned per bot (larkAppId): botmux can run one daemon
+// per bot, and a shared read-modify-write state file would let one daemon's
+// rename clobber another's freshly advanced baselines.
+function statePath(dir: string, larkAppId?: string): string {
+  const id = (larkAppId ?? '').replace(/[^A-Za-z0-9_-]/g, '') || 'default';
+  return join(dir, `state-${id}.json`);
 }
 
-function loadState(dir: string): LedgerState {
+function loadState(dir: string, larkAppId?: string): LedgerState {
   try {
-    const parsed = JSON.parse(readFileSync(statePath(dir), 'utf8'));
+    const parsed = JSON.parse(readFileSync(statePath(dir, larkAppId), 'utf8'));
     if (parsed && typeof parsed === 'object' && parsed.sessions && typeof parsed.sessions === 'object') {
       return { v: 1, sessions: parsed.sessions };
     }
@@ -100,17 +107,44 @@ function loadState(dir: string): LedgerState {
   return { v: 1, sessions: {} };
 }
 
-function saveState(dir: string, state: LedgerState, now: Date): void {
+function saveState(dir: string, larkAppId: string | undefined, state: LedgerState, now: Date): void {
   for (const [sessionId, baseline] of Object.entries(state.sessions)) {
     const recordedAt = Date.parse(baseline.recordedAt);
     if (Number.isFinite(recordedAt) && now.getTime() - recordedAt > BASELINE_RETENTION_MS) {
       delete state.sessions[sessionId];
     }
   }
-  // Single-daemon writer; temp+rename keeps a crash from truncating state.
-  const tmp = statePath(dir) + '.tmp';
+  // temp+rename keeps a crash from truncating state; the pid suffix keeps
+  // concurrent daemons from stomping each other's tmp file.
+  const target = statePath(dir, larkAppId);
+  const tmp = `${target}.${process.pid}.tmp`;
   writeFileSync(tmp, JSON.stringify(state));
-  renameSync(tmp, statePath(dir));
+  renameSync(tmp, target);
+}
+
+/** Deterministic id for one baseline→snapshot transition: a crash-replay of
+ *  the same transition regenerates the SAME id, so the consumer's DedupKey
+ *  collapses the duplicated ledger line instead of double counting it. */
+function deterministicRecordId(
+  sessionId: string,
+  epoch: number,
+  prev: SessionBaseline | undefined,
+  cur: SessionTokenUsage,
+): string {
+  const h = createHash('sha256');
+  h.update([
+    sessionId,
+    epoch,
+    prev?.inputTokens ?? 0,
+    prev?.outputTokens ?? 0,
+    prev?.cacheReadTokens ?? 0,
+    prev?.cacheCreateTokens ?? 0,
+    cur.inputTokens,
+    cur.outputTokens,
+    cur.cacheReadTokens,
+    cur.cacheCreateTokens,
+  ].join('|'));
+  return h.digest('hex').slice(0, 32);
 }
 
 function ledgerFilePath(dir: string, now: Date): string {
@@ -130,9 +164,10 @@ export function recordSessionUsage(args: RecordSessionUsageArgs): UsageLedgerRec
     const dir = args.ledgerDir ?? defaultLedgerDir();
     mkdirSync(dir, { recursive: true });
 
-    const state = loadState(dir);
+    const state = loadState(dir, args.larkAppId);
     const prev = state.sessions[args.sessionId];
     const cur = args.usage;
+    const prevEpoch = prev?.epoch ?? 0;
 
     const deltaInput = cur.inputTokens - (prev?.inputTokens ?? 0);
     const deltaOutput = cur.outputTokens - (prev?.outputTokens ?? 0);
@@ -145,12 +180,16 @@ export function recordSessionUsage(args: RecordSessionUsageArgs): UsageLedgerRec
       cacheReadTokens: cur.cacheReadTokens,
       cacheCreateTokens: cur.cacheCreateTokens,
       recordedAt: now.toISOString(),
+      epoch: prevEpoch,
     };
 
     if (deltaInput < 0 || deltaOutput < 0 || deltaCacheRead < 0 || deltaCacheCreate < 0) {
       // Cumulative shrank (/clear, rotation): re-anchor, never write negatives.
+      // The epoch bump keeps a later identical totals transition from reusing
+      // a pre-reset recordId.
+      baseline.epoch = prevEpoch + 1;
       state.sessions[args.sessionId] = baseline;
-      saveState(dir, state, now);
+      saveState(dir, args.larkAppId, state, now);
       return null;
     }
     if (deltaInput === 0 && deltaOutput === 0 && deltaCacheRead === 0 && deltaCacheCreate === 0) {
@@ -159,7 +198,7 @@ export function recordSessionUsage(args: RecordSessionUsageArgs): UsageLedgerRec
 
     const record: UsageLedgerRecord = {
       v: 1,
-      recordId: randomUUID(),
+      recordId: deterministicRecordId(args.sessionId, prevEpoch, prev, cur),
       ts: now.toISOString(),
       ...(args.larkAppId ? { larkAppId: args.larkAppId } : {}),
       sessionId: args.sessionId,
@@ -180,9 +219,11 @@ export function recordSessionUsage(args: RecordSessionUsageArgs): UsageLedgerRec
       totalCacheCreateTokens: cur.cacheCreateTokens,
     };
 
+    // Append first, then advance the baseline: a crash in between replays the
+    // same transition with the SAME recordId, which the consumer dedupes.
     appendFileSync(ledgerFilePath(dir, now), JSON.stringify(record) + '\n');
     state.sessions[args.sessionId] = baseline;
-    saveState(dir, state, now);
+    saveState(dir, args.larkAppId, state, now);
     return record;
   } catch (err: any) {
     // The ledger must never take the daemon down with it.
@@ -204,15 +245,18 @@ export function anchorSessionUsage(args: RecordSessionUsageArgs): void {
     const dir = args.ledgerDir ?? defaultLedgerDir();
     mkdirSync(dir, { recursive: true });
 
-    const state = loadState(dir);
+    const state = loadState(dir, args.larkAppId);
     state.sessions[args.sessionId] = {
       inputTokens: args.usage.inputTokens,
       outputTokens: args.usage.outputTokens,
       cacheReadTokens: args.usage.cacheReadTokens,
       cacheCreateTokens: args.usage.cacheCreateTokens,
       recordedAt: now.toISOString(),
+      // Anchors start a new epoch: transitions after a re-anchor must never
+      // collide with recordIds from before it.
+      epoch: (state.sessions[args.sessionId]?.epoch ?? 0) + 1,
     };
-    saveState(dir, state, now);
+    saveState(dir, args.larkAppId, state, now);
   } catch (err: any) {
     logger.error(`usage-ledger: failed to anchor session baseline: ${err?.message ?? err}`);
   }
@@ -258,6 +302,30 @@ export function recordUsageForDaemonSession(ds: DaemonSession, opts?: DaemonSess
     return recordSessionUsage({ ...args, usage: args.usage, ...opts });
   } catch (err: any) {
     logger.error(`usage-ledger: failed to record daemon session usage: ${err?.message ?? err}`);
+    return null;
+  }
+}
+
+/**
+ * Daemon-restart restore: a turn that was in flight when the daemon died may
+ * have finished inside tmux while we were away — that work was submitted by
+ * botmux and belongs in the ledger. If the session already has a baseline,
+ * record the catch-up delta; only sessions the ledger has never seen are
+ * anchored (their transcript history predates botmux bookkeeping).
+ */
+export function reconcileUsageForDaemonSession(ds: DaemonSession, opts?: DaemonSessionLedgerOpts): UsageLedgerRecord | null {
+  try {
+    const args = ledgerArgsForDaemonSession(ds);
+    if (!args.usage) return null;
+    const dir = opts?.ledgerDir ?? defaultLedgerDir();
+    const state = loadState(dir, args.larkAppId);
+    if (state.sessions[args.sessionId]) {
+      return recordSessionUsage({ ...args, usage: args.usage, ...opts });
+    }
+    anchorSessionUsage({ ...args, usage: args.usage, ...opts });
+    return null;
+  } catch (err: any) {
+    logger.error(`usage-ledger: failed to reconcile daemon session usage: ${err?.message ?? err}`);
     return null;
   }
 }

--- a/src/services/usage-ledger.ts
+++ b/src/services/usage-ledger.ts
@@ -280,9 +280,9 @@ export function recordSessionUsage(args: RecordSessionUsageArgs): UsageLedgerRec
       // The epoch bump keeps a later identical totals transition from reusing
       // a pre-reset recordId.
       baseline.epoch = prevEpoch + 1;
+      sessionBaselineMemory.set(baselineMemoryKey(args.larkAppId, args.sessionId), baseline);
       state.sessions[args.sessionId] = baseline;
       saveState(dir, args.larkAppId, state, now);
-      sessionBaselineMemory.set(baselineMemoryKey(args.larkAppId, args.sessionId), baseline);
       return null;
     }
     if (deltaInput === 0 && deltaOutput === 0 && deltaCacheRead === 0 && deltaCacheCreate === 0) {
@@ -316,9 +316,11 @@ export function recordSessionUsage(args: RecordSessionUsageArgs): UsageLedgerRec
     // Append first, then advance the baseline: a crash in between replays the
     // same transition with the SAME recordId, which the consumer dedupes.
     appendFileSync(ledgerFilePath(dir, now), JSON.stringify(record) + '\n');
+    // Memory advances immediately after the append: even if saveState throws
+    // without killing the process, this process will not re-bill the interval.
+    sessionBaselineMemory.set(baselineMemoryKey(args.larkAppId, args.sessionId), baseline);
     state.sessions[args.sessionId] = baseline;
     saveState(dir, args.larkAppId, state, now);
-    sessionBaselineMemory.set(baselineMemoryKey(args.larkAppId, args.sessionId), baseline);
     return record;
   } catch (err: any) {
     // The ledger must never take the daemon down with it.
@@ -352,9 +354,9 @@ export function anchorSessionUsage(args: RecordSessionUsageArgs): void {
       // collide with recordIds from before it.
       epoch: (prev?.epoch ?? 0) + 1,
     };
+    sessionBaselineMemory.set(baselineMemoryKey(args.larkAppId, args.sessionId), baseline);
     state.sessions[args.sessionId] = baseline;
     saveState(dir, args.larkAppId, state, now);
-    sessionBaselineMemory.set(baselineMemoryKey(args.larkAppId, args.sessionId), baseline);
   } catch (err: any) {
     logger.error(`usage-ledger: failed to anchor session baseline: ${err?.message ?? err}`);
   }

--- a/src/services/usage-ledger.ts
+++ b/src/services/usage-ledger.ts
@@ -1,0 +1,274 @@
+/**
+ * Usage ledger — durable per-turn token usage records.
+ *
+ * On every turn boundary (working→idle edge, session close) the daemon takes
+ * a cumulative token snapshot of the session's transcript (via the cached
+ * reader in cost-calculator) and appends the positive delta as one
+ * self-describing JSON line to a daily ledger file.
+ *
+ * The ledger is the stable contract for external usage trackers (kaboo-cli
+ * reads it the same way it reads HappyClaw's usage_records table):
+ *   ~/.botmux/usage/usage-YYYY-MM-DD.jsonl   (UTC date, append-only)
+ *   ~/.botmux/usage/state.json               (per-session baselines)
+ *
+ * Records intentionally carry redundant context (larkAppId, chatId, title,
+ * callerOpenId, cumulative totals) so a single excerpted line self-validates
+ * without joining back to sessions.json.
+ */
+import { appendFileSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { logger } from '../utils/logger.js';
+import { getSessionTokenUsage, type SessionTokenUsage } from '../core/cost-calculator.js';
+import type { DaemonSession } from '../core/types.js';
+
+export interface UsageLedgerRecord {
+  v: 1;
+  recordId: string;
+  ts: string;
+  larkAppId?: string;
+  sessionId: string;
+  cliId?: string;
+  cliSessionId?: string;
+  chatId?: string;
+  title?: string;
+  workingDir?: string;
+  /** open_id of the user whose message triggered this turn — attribution
+   *  metadata only; usage is billed to the machine owner. */
+  callerOpenId?: string;
+  model: string;
+  /** Positive deltas since the previous record of this session. */
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+  /** Cumulative transcript totals at record time, for self-validation. */
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCacheReadTokens: number;
+  totalCacheCreateTokens: number;
+}
+
+export interface RecordSessionUsageArgs {
+  sessionId: string;
+  usage: SessionTokenUsage;
+  larkAppId?: string;
+  cliId?: string;
+  cliSessionId?: string;
+  chatId?: string;
+  title?: string;
+  workingDir?: string;
+  callerOpenId?: string;
+  /** Injectable for tests; defaults to wall clock. */
+  now?: Date;
+  /** Injectable for tests; defaults to ~/.botmux/usage (BOTMUX_USAGE_DIR overrides). */
+  ledgerDir?: string;
+}
+
+interface SessionBaseline {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+  recordedAt: string;
+}
+
+interface LedgerState {
+  v: 1;
+  sessions: { [sessionId: string]: SessionBaseline };
+}
+
+/** Baselines for sessions idle longer than this are pruned from state.json. */
+const BASELINE_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+export function defaultLedgerDir(): string {
+  return process.env.BOTMUX_USAGE_DIR || join(homedir(), '.botmux', 'usage');
+}
+
+function statePath(dir: string): string {
+  return join(dir, 'state.json');
+}
+
+function loadState(dir: string): LedgerState {
+  try {
+    const parsed = JSON.parse(readFileSync(statePath(dir), 'utf8'));
+    if (parsed && typeof parsed === 'object' && parsed.sessions && typeof parsed.sessions === 'object') {
+      return { v: 1, sessions: parsed.sessions };
+    }
+  } catch { /* first run or corrupt state — start fresh */ }
+  return { v: 1, sessions: {} };
+}
+
+function saveState(dir: string, state: LedgerState, now: Date): void {
+  for (const [sessionId, baseline] of Object.entries(state.sessions)) {
+    const recordedAt = Date.parse(baseline.recordedAt);
+    if (Number.isFinite(recordedAt) && now.getTime() - recordedAt > BASELINE_RETENTION_MS) {
+      delete state.sessions[sessionId];
+    }
+  }
+  // Single-daemon writer; temp+rename keeps a crash from truncating state.
+  const tmp = statePath(dir) + '.tmp';
+  writeFileSync(tmp, JSON.stringify(state));
+  renameSync(tmp, statePath(dir));
+}
+
+function ledgerFilePath(dir: string, now: Date): string {
+  const date = now.toISOString().slice(0, 10);
+  return join(dir, `usage-${date}.jsonl`);
+}
+
+/**
+ * Diff the cumulative usage snapshot against the session's stored baseline
+ * and append a record when the delta is positive. Returns the record, or
+ * null when there is nothing to write (no growth, or a shrink — transcript
+ * rotation / clear — which just resets the baseline).
+ */
+export function recordSessionUsage(args: RecordSessionUsageArgs): UsageLedgerRecord | null {
+  try {
+    const now = args.now ?? new Date();
+    const dir = args.ledgerDir ?? defaultLedgerDir();
+    mkdirSync(dir, { recursive: true });
+
+    const state = loadState(dir);
+    const prev = state.sessions[args.sessionId];
+    const cur = args.usage;
+
+    const deltaInput = cur.inputTokens - (prev?.inputTokens ?? 0);
+    const deltaOutput = cur.outputTokens - (prev?.outputTokens ?? 0);
+    const deltaCacheRead = cur.cacheReadTokens - (prev?.cacheReadTokens ?? 0);
+    const deltaCacheCreate = cur.cacheCreateTokens - (prev?.cacheCreateTokens ?? 0);
+
+    const baseline: SessionBaseline = {
+      inputTokens: cur.inputTokens,
+      outputTokens: cur.outputTokens,
+      cacheReadTokens: cur.cacheReadTokens,
+      cacheCreateTokens: cur.cacheCreateTokens,
+      recordedAt: now.toISOString(),
+    };
+
+    if (deltaInput < 0 || deltaOutput < 0 || deltaCacheRead < 0 || deltaCacheCreate < 0) {
+      // Cumulative shrank (/clear, rotation): re-anchor, never write negatives.
+      state.sessions[args.sessionId] = baseline;
+      saveState(dir, state, now);
+      return null;
+    }
+    if (deltaInput === 0 && deltaOutput === 0 && deltaCacheRead === 0 && deltaCacheCreate === 0) {
+      return null;
+    }
+
+    const record: UsageLedgerRecord = {
+      v: 1,
+      recordId: randomUUID(),
+      ts: now.toISOString(),
+      ...(args.larkAppId ? { larkAppId: args.larkAppId } : {}),
+      sessionId: args.sessionId,
+      ...(args.cliId ? { cliId: args.cliId } : {}),
+      ...(args.cliSessionId ? { cliSessionId: args.cliSessionId } : {}),
+      ...(args.chatId ? { chatId: args.chatId } : {}),
+      ...(args.title ? { title: args.title } : {}),
+      ...(args.workingDir ? { workingDir: args.workingDir } : {}),
+      ...(args.callerOpenId ? { callerOpenId: args.callerOpenId } : {}),
+      model: cur.model,
+      inputTokens: deltaInput,
+      outputTokens: deltaOutput,
+      cacheReadTokens: deltaCacheRead,
+      cacheCreateTokens: deltaCacheCreate,
+      totalInputTokens: cur.inputTokens,
+      totalOutputTokens: cur.outputTokens,
+      totalCacheReadTokens: cur.cacheReadTokens,
+      totalCacheCreateTokens: cur.cacheCreateTokens,
+    };
+
+    appendFileSync(ledgerFilePath(dir, now), JSON.stringify(record) + '\n');
+    state.sessions[args.sessionId] = baseline;
+    saveState(dir, state, now);
+    return record;
+  } catch (err: any) {
+    // The ledger must never take the daemon down with it.
+    logger.error(`usage-ledger: failed to record session usage: ${err?.message ?? err}`);
+    return null;
+  }
+}
+
+/**
+ * Re-anchor a session's baseline to the current cumulative snapshot WITHOUT
+ * writing a record. Called at worker spawn: anything already in the
+ * transcript at that point (resumed history, direct-tmux use while the
+ * daemon was down) stays out of the ledger — only growth that happens while
+ * botmux drives the session is recorded.
+ */
+export function anchorSessionUsage(args: RecordSessionUsageArgs): void {
+  try {
+    const now = args.now ?? new Date();
+    const dir = args.ledgerDir ?? defaultLedgerDir();
+    mkdirSync(dir, { recursive: true });
+
+    const state = loadState(dir);
+    state.sessions[args.sessionId] = {
+      inputTokens: args.usage.inputTokens,
+      outputTokens: args.usage.outputTokens,
+      cacheReadTokens: args.usage.cacheReadTokens,
+      cacheCreateTokens: args.usage.cacheCreateTokens,
+      recordedAt: now.toISOString(),
+    };
+    saveState(dir, state, now);
+  } catch (err: any) {
+    logger.error(`usage-ledger: failed to anchor session baseline: ${err?.message ?? err}`);
+  }
+}
+
+// ─── Daemon-session wrappers ─────────────────────────────────────────────────
+
+interface DaemonSessionLedgerOpts {
+  now?: Date;
+  ledgerDir?: string;
+}
+
+function ledgerArgsForDaemonSession(ds: DaemonSession): Omit<RecordSessionUsageArgs, 'usage'> & { usage: SessionTokenUsage | null } {
+  const s = ds.session;
+  const workingDir = ds.workingDir ?? s.workingDir;
+  // fresh: ledger snapshots are turn-boundary exact — bypass the dashboard
+  // read throttle (incremental folding keeps this cheap).
+  const usage = getSessionTokenUsage({
+    cliId: s.cliId ?? 'unknown',
+    sessionId: s.sessionId,
+    cliSessionId: s.cliSessionId,
+    cwd: workingDir,
+    fresh: true,
+  });
+  return {
+    sessionId: s.sessionId,
+    usage,
+    larkAppId: ds.larkAppId ?? s.larkAppId,
+    cliId: s.cliId,
+    cliSessionId: s.cliSessionId,
+    chatId: s.chatId,
+    title: s.title,
+    workingDir,
+    callerOpenId: s.lastCallerOpenId ?? s.creatorOpenId ?? s.ownerOpenId,
+  };
+}
+
+/** Turn boundary (idle/limited edge, session close): append the delta. */
+export function recordUsageForDaemonSession(ds: DaemonSession, opts?: DaemonSessionLedgerOpts): UsageLedgerRecord | null {
+  try {
+    const args = ledgerArgsForDaemonSession(ds);
+    if (!args.usage) return null;
+    return recordSessionUsage({ ...args, usage: args.usage, ...opts });
+  } catch (err: any) {
+    logger.error(`usage-ledger: failed to record daemon session usage: ${err?.message ?? err}`);
+    return null;
+  }
+}
+
+/** Worker spawn: re-anchor so pre-existing transcript history is not billed. */
+export function anchorUsageForDaemonSession(ds: DaemonSession, opts?: DaemonSessionLedgerOpts): void {
+  try {
+    const args = ledgerArgsForDaemonSession(ds);
+    if (!args.usage) return;
+    anchorSessionUsage({ ...args, usage: args.usage, ...opts });
+  } catch (err: any) {
+    logger.error(`usage-ledger: failed to anchor daemon session usage: ${err?.message ?? err}`);
+  }
+}

--- a/src/services/usage-ledger.ts
+++ b/src/services/usage-ledger.ts
@@ -15,7 +15,7 @@
  * callerOpenId, cumulative totals) so a single excerpted line self-validates
  * without joining back to sessions.json.
  */
-import { appendFileSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { appendFileSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
@@ -27,6 +27,9 @@ export interface UsageLedgerRecord {
   v: 1;
   recordId: string;
   ts: string;
+  /** Baseline reset epoch this delta was measured in — lets the ledger itself
+   *  re-seed a lost baseline (crash recovery) without ambiguity. */
+  epoch: number;
   larkAppId?: string;
   sessionId: string;
   cliId?: string;
@@ -80,6 +83,95 @@ interface SessionBaseline {
 interface LedgerState {
   v: 1;
   sessions: { [sessionId: string]: SessionBaseline };
+}
+
+/** Last authoritative baseline per session, kept in memory: the hot path
+ *  never rescans the ledger, and a lost/stale state file inside one process
+ *  lifetime cannot regress the baseline. */
+const sessionBaselineMemory = new Map<string, SessionBaseline | null>();
+
+export function __resetUsageLedgerMemoryForTest(): void {
+  sessionBaselineMemory.clear();
+}
+
+function baselineMemoryKey(larkAppId: string | undefined, sessionId: string): string {
+  return `${larkAppId ?? ''}\u0000${sessionId}`;
+}
+
+function finiteNum(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : 0;
+}
+
+/** Reconstruct the newest baseline for a session from the ledger files
+ *  themselves (newest file first; last matching line in a file is newest).
+ *  This is the crash-recovery source of truth: a record that reached the
+ *  ledger but whose state advance was lost is still binding. */
+function baselineFromLedger(dir: string, sessionId: string): SessionBaseline | null {
+  let files: string[];
+  try {
+    files = readdirSync(dir)
+      .filter((f) => /^usage-\d{4}-\d{2}-\d{2}\.jsonl$/.test(f))
+      .sort()
+      .reverse();
+  } catch {
+    return null;
+  }
+  for (const name of files) {
+    let content: string;
+    try {
+      content = readFileSync(join(dir, name), 'utf8');
+    } catch {
+      continue;
+    }
+    let latest: any = null;
+    for (const line of content.split('\n')) {
+      if (!line.includes(sessionId)) continue;
+      try {
+        const rec = JSON.parse(line);
+        if (rec?.sessionId === sessionId) latest = rec;
+      } catch { /* skip malformed lines */ }
+    }
+    if (latest) {
+      return {
+        inputTokens: finiteNum(latest.totalInputTokens),
+        outputTokens: finiteNum(latest.totalOutputTokens),
+        cacheReadTokens: finiteNum(latest.totalCacheReadTokens),
+        cacheCreateTokens: finiteNum(latest.totalCacheCreateTokens),
+        recordedAt: typeof latest.ts === 'string' ? latest.ts : new Date(0).toISOString(),
+        epoch: finiteNum(latest.epoch),
+      };
+    }
+  }
+  return null;
+}
+
+/** Of two baseline candidates, pick the newer: higher epoch wins; within an
+ *  epoch totals are monotonic, so the larger sum wins. */
+function newerBaseline(a: SessionBaseline | undefined | null, b: SessionBaseline | undefined | null): SessionBaseline | undefined {
+  if (!a) return b ?? undefined;
+  if (!b) return a;
+  const ea = a.epoch ?? 0;
+  const eb = b.epoch ?? 0;
+  if (ea !== eb) return ea > eb ? a : b;
+  const sum = (x: SessionBaseline) => x.inputTokens + x.outputTokens + x.cacheReadTokens + x.cacheCreateTokens;
+  return sum(a) >= sum(b) ? a : b;
+}
+
+/** Effective baseline = newest of (state file, in-memory latest, ledger scan).
+ *  The ledger scan runs at most once per session per process lifetime. */
+function resolveBaseline(
+  dir: string,
+  larkAppId: string | undefined,
+  sessionId: string,
+  stateBaseline: SessionBaseline | undefined,
+): SessionBaseline | undefined {
+  const key = baselineMemoryKey(larkAppId, sessionId);
+  let remembered = sessionBaselineMemory.get(key);
+  if (remembered === undefined) {
+    remembered = baselineFromLedger(dir, sessionId);
+    sessionBaselineMemory.set(key, remembered);
+  }
+  return newerBaseline(stateBaseline, remembered);
 }
 
 /** Baselines for sessions idle longer than this are pruned from state.json. */
@@ -165,7 +257,7 @@ export function recordSessionUsage(args: RecordSessionUsageArgs): UsageLedgerRec
     mkdirSync(dir, { recursive: true });
 
     const state = loadState(dir, args.larkAppId);
-    const prev = state.sessions[args.sessionId];
+    const prev = resolveBaseline(dir, args.larkAppId, args.sessionId, state.sessions[args.sessionId]);
     const cur = args.usage;
     const prevEpoch = prev?.epoch ?? 0;
 
@@ -190,6 +282,7 @@ export function recordSessionUsage(args: RecordSessionUsageArgs): UsageLedgerRec
       baseline.epoch = prevEpoch + 1;
       state.sessions[args.sessionId] = baseline;
       saveState(dir, args.larkAppId, state, now);
+      sessionBaselineMemory.set(baselineMemoryKey(args.larkAppId, args.sessionId), baseline);
       return null;
     }
     if (deltaInput === 0 && deltaOutput === 0 && deltaCacheRead === 0 && deltaCacheCreate === 0) {
@@ -200,6 +293,7 @@ export function recordSessionUsage(args: RecordSessionUsageArgs): UsageLedgerRec
       v: 1,
       recordId: deterministicRecordId(args.sessionId, prevEpoch, prev, cur),
       ts: now.toISOString(),
+      epoch: prevEpoch,
       ...(args.larkAppId ? { larkAppId: args.larkAppId } : {}),
       sessionId: args.sessionId,
       ...(args.cliId ? { cliId: args.cliId } : {}),
@@ -224,6 +318,7 @@ export function recordSessionUsage(args: RecordSessionUsageArgs): UsageLedgerRec
     appendFileSync(ledgerFilePath(dir, now), JSON.stringify(record) + '\n');
     state.sessions[args.sessionId] = baseline;
     saveState(dir, args.larkAppId, state, now);
+    sessionBaselineMemory.set(baselineMemoryKey(args.larkAppId, args.sessionId), baseline);
     return record;
   } catch (err: any) {
     // The ledger must never take the daemon down with it.
@@ -246,7 +341,8 @@ export function anchorSessionUsage(args: RecordSessionUsageArgs): void {
     mkdirSync(dir, { recursive: true });
 
     const state = loadState(dir, args.larkAppId);
-    state.sessions[args.sessionId] = {
+    const prev = resolveBaseline(dir, args.larkAppId, args.sessionId, state.sessions[args.sessionId]);
+    const baseline: SessionBaseline = {
       inputTokens: args.usage.inputTokens,
       outputTokens: args.usage.outputTokens,
       cacheReadTokens: args.usage.cacheReadTokens,
@@ -254,9 +350,11 @@ export function anchorSessionUsage(args: RecordSessionUsageArgs): void {
       recordedAt: now.toISOString(),
       // Anchors start a new epoch: transitions after a re-anchor must never
       // collide with recordIds from before it.
-      epoch: (state.sessions[args.sessionId]?.epoch ?? 0) + 1,
+      epoch: (prev?.epoch ?? 0) + 1,
     };
+    state.sessions[args.sessionId] = baseline;
     saveState(dir, args.larkAppId, state, now);
+    sessionBaselineMemory.set(baselineMemoryKey(args.larkAppId, args.sessionId), baseline);
   } catch (err: any) {
     logger.error(`usage-ledger: failed to anchor session baseline: ${err?.message ?? err}`);
   }
@@ -319,7 +417,7 @@ export function reconcileUsageForDaemonSession(ds: DaemonSession, opts?: DaemonS
     if (!args.usage) return null;
     const dir = opts?.ledgerDir ?? defaultLedgerDir();
     const state = loadState(dir, args.larkAppId);
-    if (state.sessions[args.sessionId]) {
+    if (resolveBaseline(dir, args.larkAppId, args.sessionId, state.sessions[args.sessionId])) {
       return recordSessionUsage({ ...args, usage: args.usage, ...opts });
     }
     anchorSessionUsage({ ...args, usage: args.usage, ...opts });

--- a/test/cost-calculator-cache.test.ts
+++ b/test/cost-calculator-cache.test.ts
@@ -122,6 +122,22 @@ describe('readSessionTokenUsageFile caching', () => {
     expect(second).toMatchObject({ turns: 3, inputTokens: 301, outputTokens: 31 });
   });
 
+  it('fresh:true bypasses the reparse throttle but keeps incremental folding', () => {
+    const p = join(dir, 's.jsonl');
+    writeFileSync(p, `${claudeLine('msg_a', 100, 10)}\n`);
+    const first = readSessionTokenUsageFile(p, 'claude');
+    expect(first).toMatchObject({ turns: 1 });
+
+    appendFileSync(p, `${claudeLine('msg_b', 200, 20)}\n`);
+    now += 5_000; // inside the throttle window
+    // Default read serves the stale cache; a fresh read must not.
+    expect(readSessionTokenUsageFile(p, 'claude')).toBe(first);
+    expect(readSessionTokenUsageFile(p, 'claude', { fresh: true })).toMatchObject({
+      turns: 2,
+      inputTokens: 300,
+    });
+  });
+
   it('keeps codex cumulative semantics across incremental reads', () => {
     const p = join(dir, 'rollout.jsonl');
     writeFileSync(p, `${codexCountLine(100, 20)}\n`);

--- a/test/cost-calculator.test.ts
+++ b/test/cost-calculator.test.ts
@@ -706,6 +706,28 @@ describe('getSessionTokenUsage', () => {
     }
   });
 
+  it('fresh lookups bypass a cached codex path miss', () => {
+    vi.mocked(findCodexSessionIdByBotmuxSessionId).mockReturnValue(undefined);
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(undefined);
+    expect(getSessionTokenUsage({ cliId: 'codex', sessionId: 'botmux-sid' })).toBeNull(); // miss now cached
+
+    // The rollout appears moments later (transcripts are created lazily).
+    vi.mocked(findCodexSessionIdByBotmuxSessionId).mockReturnValue('codex-sid');
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue('/home/testuser/.codex/sessions/rollout-codex-sid.jsonl');
+    setupJsonl(JSON.stringify({
+      type: 'event_msg',
+      payload: { type: 'token_count', info: { total_token_usage: { input_tokens: 42, output_tokens: 7 } } },
+    }));
+
+    // The dashboard path keeps the negative cache…
+    expect(getSessionTokenUsage({ cliId: 'codex', sessionId: 'botmux-sid' })).toBeNull();
+    // …but a fresh (ledger) read must see the newly created transcript.
+    expect(getSessionTokenUsage({ cliId: 'codex', sessionId: 'botmux-sid', fresh: true })).toMatchObject({
+      in: 42,
+      out: 7,
+    });
+  });
+
   it('caches the aiden checkpoint lookup briefly', () => {
     vi.mocked(findAidenLatestCheckpointBySessionId).mockReturnValue('/home/testuser/.aiden/checkpoints/ws/aiden-sid/checkpoint.json');
     setupJsonl(JSON.stringify({

--- a/test/cost-calculator.test.ts
+++ b/test/cost-calculator.test.ts
@@ -740,6 +740,25 @@ describe('getSessionTokenUsage', () => {
     expect(findAidenLatestCheckpointBySessionId).toHaveBeenCalledTimes(1);
   });
 
+  it('fresh aiden lookups bypass the positive hit TTL (checkpoints move per turn)', () => {
+    vi.mocked(findAidenLatestCheckpointBySessionId).mockReturnValue('/home/testuser/.aiden/checkpoints/ws/aiden-sid/cp-1.json');
+    setupJsonl(JSON.stringify({
+      checkpoint: { channel_values: { messages: [{ type: 'ai', usage_metadata: { input_tokens: 1, output_tokens: 1 } }] } },
+    }));
+
+    getSessionTokenUsage({ cliId: 'aiden', sessionId: 'aiden-sid' });
+    expect(findAidenLatestCheckpointBySessionId).toHaveBeenCalledTimes(1);
+
+    // Ledger (fresh) reads must re-resolve: latest.json points at a NEW
+    // checkpoint file every turn, and a 15s-stale path misses the last turn.
+    getSessionTokenUsage({ cliId: 'aiden', sessionId: 'aiden-sid', fresh: true });
+    expect(findAidenLatestCheckpointBySessionId).toHaveBeenCalledTimes(2);
+
+    // The dashboard (non-fresh) path keeps the TTL cache.
+    getSessionTokenUsage({ cliId: 'aiden', sessionId: 'aiden-sid' });
+    expect(findAidenLatestCheckpointBySessionId).toHaveBeenCalledTimes(2);
+  });
+
   it('counts a multi-block Claude turn (same message.id) once', () => {
     const block = (id: string, input: number, output: number, cacheRead = 0, cacheCreate = 0) =>
       JSON.stringify({

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -8,7 +8,7 @@
  * Run:  pnpm vitest run test/usage-ledger.test.ts
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -26,6 +26,7 @@ import {
   anchorSessionUsage,
   recordUsageForDaemonSession,
   anchorUsageForDaemonSession,
+  reconcileUsageForDaemonSession,
   type UsageLedgerRecord,
 } from '../src/services/usage-ledger.js';
 import type { SessionTokenUsage } from '../src/core/cost-calculator.js';
@@ -102,7 +103,7 @@ describe('recordSessionUsage', () => {
       totalCacheReadTokens: 5,
       totalCacheCreateTokens: 2,
     });
-    expect(rec!.recordId).toMatch(/[0-9a-f-]{36}/);
+    expect(rec!.recordId).toMatch(/^[0-9a-f]{32}$/);
 
     const lines = ledgerLines(dir);
     expect(lines).toHaveLength(1);
@@ -178,6 +179,55 @@ describe('recordSessionUsage', () => {
     const a = recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(100, 10) });
     const b = recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(200, 20) });
     expect(a!.recordId).not.toBe(b!.recordId);
+  });
+
+  it('replays of the same baseline→snapshot transition reuse the recordId (crash idempotence)', () => {
+    // Crash window: ledger line appended but state.json never advanced. The
+    // replay recomputes the same delta from the same baseline — it must carry
+    // the SAME recordId so the consumer's DedupKey collapses the duplicate.
+    const a = recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(100, 10) });
+
+    // Simulate the lost state advance: restore the pre-record state file.
+    const statePath = readdirSync(dir).find((f) => f.startsWith('state'));
+    writeFileSync(join(dir, statePath!), JSON.stringify({ v: 1, sessions: {} }));
+
+    const b = recordSessionUsage({
+      ...baseArgs({ now: new Date('2026-06-10T12:01:00Z') }),
+      ledgerDir: dir,
+      usage: cumulative(100, 10),
+    });
+
+    expect(b!.recordId).toBe(a!.recordId);
+  });
+
+  it('does not reuse recordIds across reset epochs for identical transitions', () => {
+    // 0→(100,10), then shrink-reset, then 0→(100,10) again: same totals pair
+    // but a REAL second delta — the reset epoch must keep the ids distinct.
+    const a = recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(100, 10) });
+    recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(0, 0) }); // shrink → re-anchor
+    const b = recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(100, 10) });
+
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(b!.recordId).not.toBe(a!.recordId);
+  });
+
+  it('keeps per-bot baselines in separate state files', () => {
+    recordSessionUsage({ ...baseArgs({ larkAppId: 'cli_a' }), ledgerDir: dir, usage: cumulative(100, 10) });
+    recordSessionUsage({
+      ...baseArgs({ larkAppId: 'cli_b', sessionId: 'sess-other' }),
+      ledgerDir: dir,
+      usage: cumulative(7, 3),
+    });
+
+    const stateFiles = readdirSync(dir).filter((f) => f.startsWith('state')).sort();
+    expect(stateFiles.some((f) => f.includes('cli_a'))).toBe(true);
+    expect(stateFiles.some((f) => f.includes('cli_b'))).toBe(true);
+
+    // cli_b's write must not clobber cli_a's baseline: the next cli_a record
+    // is still a delta, not a fresh full-cumulative dump.
+    const rec = recordSessionUsage({ ...baseArgs({ larkAppId: 'cli_a' }), ledgerDir: dir, usage: cumulative(150, 12) });
+    expect(rec).toMatchObject({ inputTokens: 50, outputTokens: 2 });
   });
 });
 
@@ -265,5 +315,49 @@ describe('daemon-session wrappers', () => {
     vi.mocked(getSessionTokenUsage).mockReturnValue(cumulative(620, 80));
     const rec = recordUsageForDaemonSession(ds, { ledgerDir: dir });
     expect(rec).toMatchObject({ inputTokens: 120, outputTokens: 30 });
+  });
+});
+
+describe('reconcileUsageForDaemonSession (daemon restart)', () => {
+  const ds = {
+    larkAppId: 'cli_app',
+    workingDir: '/live-repo',
+    session: {
+      sessionId: 'sess-r',
+      cliId: 'claude-code',
+      cliSessionId: 'cli-sess-r',
+      chatId: 'oc_chat',
+      title: '重启恢复',
+      lastCallerOpenId: 'ou_last',
+    },
+  } as any;
+
+  beforeEach(() => {
+    vi.mocked(getSessionTokenUsage).mockReset();
+    vi.mocked(getSessionTokenUsage).mockReturnValue(null);
+  });
+
+  it('records the catch-up delta when a baseline exists (turn finished while daemon was down)', () => {
+    vi.mocked(getSessionTokenUsage).mockReturnValue(cumulative(100, 10));
+    recordUsageForDaemonSession(ds, { ledgerDir: dir });
+
+    // The in-flight turn completed inside tmux during the crash window.
+    vi.mocked(getSessionTokenUsage).mockReturnValue(cumulative(200, 20));
+    const rec = reconcileUsageForDaemonSession(ds, { ledgerDir: dir });
+
+    expect(rec).toMatchObject({ inputTokens: 100, outputTokens: 10 });
+  });
+
+  it('anchors without recording when the session is new to the ledger', () => {
+    vi.mocked(getSessionTokenUsage).mockReturnValue(cumulative(500, 50));
+    expect(reconcileUsageForDaemonSession(ds, { ledgerDir: dir })).toBeNull();
+    expect(readdirSync(dir).filter((f) => f.startsWith('usage-'))).toHaveLength(0);
+
+    // Growth after the anchor is measured from it, not from zero.
+    vi.mocked(getSessionTokenUsage).mockReturnValue(cumulative(600, 70));
+    expect(recordUsageForDaemonSession(ds, { ledgerDir: dir })).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 20,
+    });
   });
 });

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Usage ledger tests — per-turn token usage deltas appended to daily JSONL.
+ *
+ * The ledger is the durable contract consumed by external trackers (kaboo):
+ * each record is a self-describing JSON line with positive token deltas and
+ * cumulative snapshots for self-validation.
+ *
+ * Run:  pnpm vitest run test/usage-ledger.test.ts
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../src/core/cost-calculator.js', () => ({
+  getSessionTokenUsage: vi.fn(() => null),
+}));
+
+import { getSessionTokenUsage } from '../src/core/cost-calculator.js';
+import {
+  recordSessionUsage,
+  anchorSessionUsage,
+  recordUsageForDaemonSession,
+  anchorUsageForDaemonSession,
+  type UsageLedgerRecord,
+} from '../src/services/usage-ledger.js';
+import type { SessionTokenUsage } from '../src/core/cost-calculator.js';
+
+function cumulative(input: number, output: number, cacheRead = 0, cacheCreate = 0, model = 'claude-opus-4-7'): SessionTokenUsage {
+  return {
+    in: input + cacheRead + cacheCreate,
+    out: output,
+    inputTokens: input,
+    outputTokens: output,
+    cacheReadTokens: cacheRead,
+    cacheCreateTokens: cacheCreate,
+    model,
+    turns: 1,
+  };
+}
+
+function baseArgs(overrides: Record<string, unknown> = {}) {
+  return {
+    larkAppId: 'cli_app',
+    sessionId: 'sess-1',
+    cliId: 'claude-code',
+    cliSessionId: 'cli-sess-1',
+    chatId: 'oc_chat',
+    title: '修复支付回调',
+    workingDir: '/repo',
+    callerOpenId: 'ou_caller',
+    now: new Date('2026-06-10T12:00:00Z'),
+    ...overrides,
+  };
+}
+
+function ledgerLines(dir: string, date = '2026-06-10'): UsageLedgerRecord[] {
+  const content = readFileSync(join(dir, `usage-${date}.jsonl`), 'utf8');
+  return content.trim().split('\n').map((l) => JSON.parse(l));
+}
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'usage-ledger-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('recordSessionUsage', () => {
+  it('writes the first record with the full cumulative usage as delta', () => {
+    const rec = recordSessionUsage({
+      ...baseArgs(),
+      ledgerDir: dir,
+      usage: cumulative(100, 10, 5, 2),
+    });
+
+    expect(rec).toMatchObject({
+      v: 1,
+      larkAppId: 'cli_app',
+      sessionId: 'sess-1',
+      cliId: 'claude-code',
+      cliSessionId: 'cli-sess-1',
+      chatId: 'oc_chat',
+      title: '修复支付回调',
+      workingDir: '/repo',
+      callerOpenId: 'ou_caller',
+      model: 'claude-opus-4-7',
+      ts: '2026-06-10T12:00:00.000Z',
+      inputTokens: 100,
+      outputTokens: 10,
+      cacheReadTokens: 5,
+      cacheCreateTokens: 2,
+      totalInputTokens: 100,
+      totalOutputTokens: 10,
+      totalCacheReadTokens: 5,
+      totalCacheCreateTokens: 2,
+    });
+    expect(rec!.recordId).toMatch(/[0-9a-f-]{36}/);
+
+    const lines = ledgerLines(dir);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toEqual(rec);
+  });
+
+  it('emits only the positive delta on subsequent records', () => {
+    recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(100, 10) });
+    const rec = recordSessionUsage({
+      ...baseArgs({ now: new Date('2026-06-10T12:05:00Z'), callerOpenId: 'ou_other' }),
+      ledgerDir: dir,
+      usage: cumulative(250, 30),
+    });
+
+    expect(rec).toMatchObject({
+      inputTokens: 150,
+      outputTokens: 20,
+      totalInputTokens: 250,
+      totalOutputTokens: 30,
+      callerOpenId: 'ou_other',
+    });
+    expect(ledgerLines(dir)).toHaveLength(2);
+  });
+
+  it('returns null and appends nothing when usage is unchanged', () => {
+    recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(100, 10) });
+    const rec = recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(100, 10) });
+
+    expect(rec).toBeNull();
+    expect(ledgerLines(dir)).toHaveLength(1);
+  });
+
+  it('resets the baseline without a record when cumulative usage shrinks', () => {
+    recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(100, 10) });
+    // /clear or transcript rotation: cumulative drops — no negative record.
+    const shrunk = recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(40, 5) });
+    expect(shrunk).toBeNull();
+
+    // Growth from the new baseline is measured against 40/5, not 100/10.
+    const rec = recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(90, 15) });
+    expect(rec).toMatchObject({ inputTokens: 50, outputTokens: 10 });
+    expect(ledgerLines(dir)).toHaveLength(2);
+  });
+
+  it('tracks sessions independently', () => {
+    recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(100, 10) });
+    const rec = recordSessionUsage({
+      ...baseArgs({ sessionId: 'sess-2', cliSessionId: 'cli-sess-2' }),
+      ledgerDir: dir,
+      usage: cumulative(7, 3),
+    });
+
+    expect(rec).toMatchObject({ sessionId: 'sess-2', inputTokens: 7, outputTokens: 3 });
+  });
+
+  it('rotates ledger files by UTC date', () => {
+    recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(100, 10) });
+    recordSessionUsage({
+      ...baseArgs({ now: new Date('2026-06-11T01:00:00Z') }),
+      ledgerDir: dir,
+      usage: cumulative(250, 30),
+    });
+
+    expect(ledgerLines(dir, '2026-06-10')).toHaveLength(1);
+    expect(ledgerLines(dir, '2026-06-11')).toHaveLength(1);
+    expect(readdirSync(dir).filter((f) => f.startsWith('usage-')).sort()).toEqual([
+      'usage-2026-06-10.jsonl',
+      'usage-2026-06-11.jsonl',
+    ]);
+  });
+
+  it('assigns a unique recordId per record', () => {
+    const a = recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(100, 10) });
+    const b = recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(200, 20) });
+    expect(a!.recordId).not.toBe(b!.recordId);
+  });
+});
+
+describe('anchorSessionUsage', () => {
+  it('sets the baseline without writing a record', () => {
+    anchorSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(100, 10) });
+
+    expect(readdirSync(dir).filter((f) => f.startsWith('usage-'))).toHaveLength(0);
+
+    // Growth is measured from the anchored baseline, not from zero.
+    const rec = recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(250, 30) });
+    expect(rec).toMatchObject({ inputTokens: 150, outputTokens: 20 });
+  });
+
+  it('overwrites an existing baseline (resume re-anchor)', () => {
+    recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(100, 10) });
+    // Transcript grew outside botmux (e.g. direct tmux use while daemon was
+    // down) — re-anchoring on spawn keeps that growth out of the ledger.
+    anchorSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(180, 25) });
+
+    const rec = recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(200, 30) });
+    expect(rec).toMatchObject({ inputTokens: 20, outputTokens: 5 });
+    expect(ledgerLines(dir)).toHaveLength(2);
+  });
+});
+
+describe('daemon-session wrappers', () => {
+  const ds = {
+    larkAppId: 'cli_app',
+    workingDir: '/live-repo',
+    session: {
+      sessionId: 'sess-1',
+      cliId: 'claude-code',
+      cliSessionId: 'cli-sess-1',
+      chatId: 'oc_chat',
+      title: '修复支付回调',
+      workingDir: '/stored-repo',
+      lastCallerOpenId: 'ou_last',
+      creatorOpenId: 'ou_creator',
+    },
+  } as any;
+
+  beforeEach(() => {
+    vi.mocked(getSessionTokenUsage).mockReset();
+    vi.mocked(getSessionTokenUsage).mockReturnValue(null);
+  });
+
+  it('snapshots the transcript and appends the delta record', () => {
+    vi.mocked(getSessionTokenUsage).mockReturnValue(cumulative(100, 10));
+
+    const rec = recordUsageForDaemonSession(ds, { ledgerDir: dir, now: new Date('2026-06-10T12:00:00Z') });
+
+    expect(getSessionTokenUsage).toHaveBeenCalledWith({
+      cliId: 'claude-code',
+      sessionId: 'sess-1',
+      cliSessionId: 'cli-sess-1',
+      cwd: '/live-repo',
+      fresh: true,
+    });
+    expect(rec).toMatchObject({
+      sessionId: 'sess-1',
+      larkAppId: 'cli_app',
+      cliId: 'claude-code',
+      chatId: 'oc_chat',
+      title: '修复支付回调',
+      workingDir: '/live-repo',
+      callerOpenId: 'ou_last',
+      inputTokens: 100,
+      outputTokens: 10,
+    });
+  });
+
+  it('does nothing when the transcript has no usage', () => {
+    vi.mocked(getSessionTokenUsage).mockReturnValue(null);
+
+    expect(recordUsageForDaemonSession(ds, { ledgerDir: dir })).toBeNull();
+    expect(readdirSync(dir).filter((f) => f.startsWith('usage-'))).toHaveLength(0);
+  });
+
+  it('anchorUsageForDaemonSession anchors without recording', () => {
+    vi.mocked(getSessionTokenUsage).mockReturnValue(cumulative(500, 50));
+    anchorUsageForDaemonSession(ds, { ledgerDir: dir });
+    expect(readdirSync(dir).filter((f) => f.startsWith('usage-'))).toHaveLength(0);
+
+    vi.mocked(getSessionTokenUsage).mockReturnValue(cumulative(620, 80));
+    const rec = recordUsageForDaemonSession(ds, { ledgerDir: dir });
+    expect(rec).toMatchObject({ inputTokens: 120, outputTokens: 30 });
+  });
+});

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -27,6 +27,7 @@ import {
   recordUsageForDaemonSession,
   anchorUsageForDaemonSession,
   reconcileUsageForDaemonSession,
+  __resetUsageLedgerMemoryForTest,
   type UsageLedgerRecord,
 } from '../src/services/usage-ledger.js';
 import type { SessionTokenUsage } from '../src/core/cost-calculator.js';
@@ -68,6 +69,7 @@ let dir: string;
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'usage-ledger-'));
+  __resetUsageLedgerMemoryForTest();
 });
 
 afterEach(() => {
@@ -181,23 +183,51 @@ describe('recordSessionUsage', () => {
     expect(a!.recordId).not.toBe(b!.recordId);
   });
 
-  it('replays of the same baseline→snapshot transition reuse the recordId (crash idempotence)', () => {
-    // Crash window: ledger line appended but state.json never advanced. The
-    // replay recomputes the same delta from the same baseline — it must carry
-    // the SAME recordId so the consumer's DedupKey collapses the duplicate.
-    const a = recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(100, 10) });
+  it('recovers the baseline from the ledger when state never advanced (crash replay)', () => {
+    // Crash window: ledger line appended but state never advanced, then the
+    // daemon restarted (in-memory latest lost too). The ledger itself is the
+    // source of truth: its newest record's cumulative totals re-seed the
+    // baseline, so neither a same-snapshot replay nor a grown snapshot can
+    // double count the already-recorded interval.
+    recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(100, 10) });
 
-    // Simulate the lost state advance: restore the pre-record state file.
     const statePath = readdirSync(dir).find((f) => f.startsWith('state'));
     writeFileSync(join(dir, statePath!), JSON.stringify({ v: 1, sessions: {} }));
+    __resetUsageLedgerMemoryForTest(); // simulate process restart
 
-    const b = recordSessionUsage({
+    // Same snapshot replay → nothing new to record.
+    expect(recordSessionUsage({
       ...baseArgs({ now: new Date('2026-06-10T12:01:00Z') }),
       ledgerDir: dir,
       usage: cumulative(100, 10),
-    });
+    })).toBeNull();
 
-    expect(b!.recordId).toBe(a!.recordId);
+    // Grown snapshot → only the残余 delta beyond the ledger's latest totals.
+    const b = recordSessionUsage({
+      ...baseArgs({ now: new Date('2026-06-10T12:02:00Z') }),
+      ledgerDir: dir,
+      usage: cumulative(150, 15),
+    });
+    expect(b).toMatchObject({ inputTokens: 50, outputTokens: 5 });
+    expect(ledgerLines(dir)).toHaveLength(2);
+  });
+
+  it('recovers a stale (not just missing) baseline from the ledger', () => {
+    // Crash after appending 100→150 with the state save lost: state still says
+    // 100 while the ledger's newest record says 150. The newer one must win.
+    recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(100, 10) });
+    const statePath = join(dir, readdirSync(dir).find((f) => f.startsWith('state'))!);
+    const stateAt100 = readFileSync(statePath, 'utf8');
+    recordSessionUsage({ ...baseArgs({ now: new Date('2026-06-10T12:01:00Z') }), ledgerDir: dir, usage: cumulative(150, 15) });
+    writeFileSync(statePath, stateAt100); // roll the state back to 100/10
+    __resetUsageLedgerMemoryForTest();
+
+    const rec = recordSessionUsage({
+      ...baseArgs({ now: new Date('2026-06-10T12:02:00Z') }),
+      ledgerDir: dir,
+      usage: cumulative(180, 18),
+    });
+    expect(rec).toMatchObject({ inputTokens: 30, outputTokens: 3 });
   });
 
   it('does not reuse recordIds across reset epochs for identical transitions', () => {


### PR DESCRIPTION
为外部用量统计(kaboo)提供稳定数据契约,类比 HappyClaw 的 usage_records 表。建立在 #170 的读数层之上。

## 设计

- **存储**:`~/.botmux/usage/usage-YYYY-MM-DD.jsonl`(UTC 按天滚动,append-only,`BOTMUX_USAGE_DIR` 可覆盖)。每条记录自描述:recordId / ts / larkAppId / sessionId / cliId / cliSessionId / chatId / 话题标题 / workingDir / callerOpenId / model / 四类 token 增量 + 累计快照(自校验)。
- **基线锚定**：全新 spawn / adopt 时把基线锚到当前累计值——resume 的历史、adopt 接管前的历史不入账；只有 botmux 驱动期间的增量才落账。新会话 transcript 从零生长，首轮完整入账。**daemon 重启恢复（resume）走 reconcile**：已有基线的会话记 catch-up 增量（宕机期间在 tmux 里完成的、由 botmux 提交的 turn 不丢），账本没见过的会话才锚定。
- **崩溃恢复（exactly-once）**：账本记录携带 epoch；基线解析取 state 文件 / 进程内存 / 账本最新记录三者中最新者（epoch 高者胜，同 epoch 取累计和大者）。append 与基线前进之间崩溃后：同快照重放 → delta 0 不落账；快照已增长 → 只记账本最新累计之后的残余增量。账本扫描每会话每进程至多一次。
- **重放幂等**：recordId 是确定性指纹 sha256(sessionId|epoch|基线→快照四元组)，append 与基线前进之间崩溃后的重放产生同一 recordId，消费方按 DedupKey 去重即 exactly-once；epoch 在每次基线重置时递增。
- **多 daemon 隔离**：基线 state 按 larkAppId 拆文件，one-daemon-per-bot 部署无共享读改写；tmp 带 pid 后缀。
- **已知取舍**：daemon 重启 reconcile 会把停机期间用户直接在同一 tmux 会话里产生的本地用量也记入账本（无法与 botmux 已提交的 in-flight turn 区分）；按"crash 中的 botmux turn 不丢"优先级接受此取舍。
- **记账时机**:screen_update 状态边沿进入 idle / limited(turn 结束)+ closeSession 杀 worker 前。负增量(/clear、transcript 轮转)只重置基线,不写负数。
- **fresh 读数**:`SessionTokenUsageQuery` 新增 `fresh` 选项——账本快照绕过 15s 重解析节流(stat 短路与增量折叠保留),保证 turn 边界精确;dashboard 渲染路径不受影响。
- **隔离性**:账本全程 try/catch,任何故障不影响 daemon;state.json temp+rename 原子写,30 天闲置基线自动剪枝。
- CONTEXT.md 增补 Usage Ledger 术语。

## 消费方

kaboo-cli 的 botmux parser(kaboo 仓库 feat/botmux-source)读取该目录:recordId 作 DedupKey,并用 ledger 中的 cliSessionId 在 claude-code/seed/codex parser 中排除 botmux 会话防双计。归因模型:**botmux 会话的用量全部记机器主人**,callerOpenId 仅为元数据。

## 测试

`test/usage-ledger.test.ts` 13 个用例:首记/增量差分/无变化不写/负增量重置基线/多会话隔离/按天滚动/recordId 唯一/锚定语义(含 resume 重锚)/DaemonSession 包装/fresh 旁路。受影响 86 测试全绿,`tsc --noEmit` 干净。
