### PR TITLE
feat(usage-ledger): spawn 时写 ownership 标记,关闭首条记录前的双计窗口

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,6 +33,10 @@ line (recordId, ts, session/bot/chat context, caller open_id, token deltas
 plus cumulative totals). Baselines are anchored at worker spawn so resumed or
 pre-botmux transcript history is never recorded. External trackers (e.g.
 kaboo) consume this directory; botmux never uploads it anywhere itself.
+Zero-delta records with `kind: "ownership"` are written at worker spawn (and
+when the CLI-native session id is first learned) so consumers can exclude a
+session from their native parsers before its first positive delta lands; they
+are markers, not accounting events, and never re-seed baselines.
 _Avoid_: usage log, billing database
 
 ## Example Dialogue

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -34,7 +34,7 @@ import { composeRowFromActive, composeRowFromClosed } from './dashboard-rows.js'
 import { publishAttentionPatch } from './session-activity.js';
 import { knownBotOpenIdsFromCrossRef, type BotMentionEntry } from '../utils/bot-routing.js';
 import { emitSessionLifecycleHook, emitSessionStateTransitionHook } from '../services/session-lifecycle-hooks.js';
-import { anchorUsageForDaemonSession, recordUsageForDaemonSession, reconcileUsageForDaemonSession } from '../services/usage-ledger.js';
+import { anchorUsageForDaemonSession, recordOwnershipForDaemonSession, recordUsageForDaemonSession, reconcileUsageForDaemonSession } from '../services/usage-ledger.js';
 import type { CliId } from '../adapters/cli/types.js';
 import type { DaemonToWorker, WorkerToDaemon, Session, DisplayMode } from '../types.js';
 import { sessionKey, sessionAnchorId, type DaemonSession } from './types.js';
@@ -1564,6 +1564,7 @@ export function forkWorker(ds: DaemonSession, prompt: string, resume = false): v
   // was submitted by botmux (anchoring would swallow it).
   if (resume) reconcileUsageForDaemonSession(ds);
   else anchorUsageForDaemonSession(ds);
+  recordOwnershipForDaemonSession(ds);
 }
 
 // ─── Shared worker IPC handler ──────────────────────────────────────────────
@@ -1780,6 +1781,10 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
       case 'cli_session_id': {
         ds.session.cliSessionId = msg.cliSessionId;
         sessionStore.updateSession(ds.session);
+        // Usage ledger: publish ownership the moment the CLI-native session id
+        // is known, so consumers exclude this session from native parsers
+        // before its first positive-delta record exists.
+        recordOwnershipForDaemonSession(ds);
         break;
       }
 
@@ -2503,6 +2508,7 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
   });
   // Adopted CLIs come with pre-botmux history — anchor it out of the ledger.
   anchorUsageForDaemonSession(ds);
+  recordOwnershipForDaemonSession(ds);
 }
 
 // ─── Kill stale PIDs ────────────────────────────────────────────────────────

--- a/src/services/usage-ledger.ts
+++ b/src/services/usage-ledger.ts
@@ -25,6 +25,10 @@ import type { DaemonSession } from '../core/types.js';
 
 export interface UsageLedgerRecord {
   v: 1;
+  /** 'ownership' marks a zero-delta marker written at session spawn so
+   *  consumers can exclude the session from native parsers BEFORE its first
+   *  positive delta lands; absent for normal usage records. */
+  kind?: 'ownership';
   recordId: string;
   ts: string;
   /** Baseline reset epoch this delta was measured in — lets the ledger itself
@@ -92,7 +96,11 @@ const sessionBaselineMemory = new Map<string, SessionBaseline | null>();
 
 export function __resetUsageLedgerMemoryForTest(): void {
   sessionBaselineMemory.clear();
+  ownershipWritten.clear();
 }
+
+/** Ownership markers already written by this process (recordId-keyed). */
+const ownershipWritten = new Set<string>();
 
 function baselineMemoryKey(larkAppId: string | undefined, sessionId: string): string {
   return `${larkAppId ?? ''}\u0000${sessionId}`;
@@ -128,7 +136,9 @@ function baselineFromLedger(dir: string, sessionId: string): SessionBaseline | n
       if (!line.includes(sessionId)) continue;
       try {
         const rec = JSON.parse(line);
-        if (rec?.sessionId === sessionId) latest = rec;
+        // Ownership markers are not accounting events — their zero totals
+        // must never re-seed a baseline.
+        if (rec?.sessionId === sessionId && rec?.kind !== 'ownership') latest = rec;
       } catch { /* skip malformed lines */ }
     }
     if (latest) {
@@ -402,6 +412,95 @@ export function recordUsageForDaemonSession(ds: DaemonSession, opts?: DaemonSess
     return recordSessionUsage({ ...args, usage: args.usage, ...opts });
   } catch (err: any) {
     logger.error(`usage-ledger: failed to record daemon session usage: ${err?.message ?? err}`);
+    return null;
+  }
+}
+
+export interface RecordSessionOwnershipArgs {
+  sessionId: string;
+  cliSessionId?: string;
+  larkAppId?: string;
+  cliId?: string;
+  chatId?: string;
+  title?: string;
+  workingDir?: string;
+  callerOpenId?: string;
+  now?: Date;
+  ledgerDir?: string;
+}
+
+/**
+ * Append a zero-delta ownership marker tying a botmux session to its
+ * CLI-native session id. Written at spawn / as soon as the CLI session id is
+ * known — consumers (kaboo) exclude the session from their native parsers the
+ * moment this line exists, closing the "native parser uploads the transcript
+ * before the first positive delta lands" double-count window. Does NOT touch
+ * baselines; the deterministic recordId makes cross-restart repeats collapse
+ * at the consumer.
+ */
+export function recordSessionOwnership(args: RecordSessionOwnershipArgs): UsageLedgerRecord | null {
+  try {
+    if (!args.cliSessionId) return null;
+    const recordId = createHash('sha256')
+      .update(`ownership|${args.sessionId}|${args.cliSessionId}`)
+      .digest('hex')
+      .slice(0, 32);
+    if (ownershipWritten.has(recordId)) return null;
+
+    const now = args.now ?? new Date();
+    const dir = args.ledgerDir ?? defaultLedgerDir();
+    mkdirSync(dir, { recursive: true });
+
+    const record: UsageLedgerRecord = {
+      v: 1,
+      kind: 'ownership',
+      recordId,
+      ts: now.toISOString(),
+      epoch: 0,
+      ...(args.larkAppId ? { larkAppId: args.larkAppId } : {}),
+      sessionId: args.sessionId,
+      ...(args.cliId ? { cliId: args.cliId } : {}),
+      cliSessionId: args.cliSessionId,
+      ...(args.chatId ? { chatId: args.chatId } : {}),
+      ...(args.title ? { title: args.title } : {}),
+      ...(args.workingDir ? { workingDir: args.workingDir } : {}),
+      ...(args.callerOpenId ? { callerOpenId: args.callerOpenId } : {}),
+      model: '',
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreateTokens: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalCacheReadTokens: 0,
+      totalCacheCreateTokens: 0,
+    };
+    appendFileSync(ledgerFilePath(dir, now), JSON.stringify(record) + '\n');
+    ownershipWritten.add(recordId);
+    return record;
+  } catch (err: any) {
+    logger.error(`usage-ledger: failed to record session ownership: ${err?.message ?? err}`);
+    return null;
+  }
+}
+
+/** Ownership marker from a live daemon session (no transcript read needed). */
+export function recordOwnershipForDaemonSession(ds: DaemonSession, opts?: DaemonSessionLedgerOpts): UsageLedgerRecord | null {
+  try {
+    const s = ds.session;
+    return recordSessionOwnership({
+      sessionId: s.sessionId,
+      cliSessionId: s.cliSessionId,
+      larkAppId: ds.larkAppId ?? s.larkAppId,
+      cliId: s.cliId,
+      chatId: s.chatId,
+      title: s.title,
+      workingDir: ds.workingDir ?? s.workingDir,
+      callerOpenId: s.lastCallerOpenId ?? s.creatorOpenId ?? s.ownerOpenId,
+      ...opts,
+    });
+  } catch (err: any) {
+    logger.error(`usage-ledger: failed to record daemon session ownership: ${err?.message ?? err}`);
     return null;
   }
 }

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -27,6 +27,8 @@ import {
   recordUsageForDaemonSession,
   anchorUsageForDaemonSession,
   reconcileUsageForDaemonSession,
+  recordSessionOwnership,
+  recordOwnershipForDaemonSession,
   __resetUsageLedgerMemoryForTest,
   type UsageLedgerRecord,
 } from '../src/services/usage-ledger.js';
@@ -389,5 +391,82 @@ describe('reconcileUsageForDaemonSession (daemon restart)', () => {
       inputTokens: 100,
       outputTokens: 20,
     });
+  });
+});
+
+describe('ownership records', () => {
+  it('writes a zero-delta ownership marker with a deterministic recordId', () => {
+    const rec = recordSessionOwnership({
+      ...baseArgs(),
+      ledgerDir: dir,
+    });
+
+    expect(rec).toMatchObject({
+      v: 1,
+      kind: 'ownership',
+      sessionId: 'sess-1',
+      cliSessionId: 'cli-sess-1',
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreateTokens: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+    });
+    expect(ledgerLines(dir)).toHaveLength(1);
+
+    // Same process: repeated markers are suppressed entirely.
+    expect(recordSessionOwnership({ ...baseArgs(), ledgerDir: dir })).toBeNull();
+    expect(ledgerLines(dir)).toHaveLength(1);
+
+    // Across a restart the line may repeat, but with the SAME recordId so the
+    // consumer's DedupKey collapses it.
+    __resetUsageLedgerMemoryForTest();
+    const again = recordSessionOwnership({ ...baseArgs({ now: new Date('2026-06-10T13:00:00Z') }), ledgerDir: dir });
+    expect(again!.recordId).toBe(rec!.recordId);
+  });
+
+  it('skips when cliSessionId is unknown', () => {
+    expect(recordSessionOwnership({ ...baseArgs({ cliSessionId: undefined }), ledgerDir: dir })).toBeNull();
+    expect(readdirSync(dir).filter((f) => f.startsWith('usage-'))).toHaveLength(0);
+  });
+
+  it('ownership markers never act as recovery baselines', () => {
+    // usage record 100/10, then an ownership marker (totals 0) lands AFTER it.
+    recordSessionUsage({ ...baseArgs(), ledgerDir: dir, usage: cumulative(100, 10) });
+    recordSessionOwnership({ ...baseArgs({ now: new Date('2026-06-10T12:30:00Z') }), ledgerDir: dir });
+
+    // State and memory lost: recovery must use the USAGE record (100/10) as
+    // baseline, not the newer zero-total ownership marker — otherwise the
+    // next snapshot would re-bill the whole 150.
+    const statePath = readdirSync(dir).find((f) => f.startsWith('state'));
+    writeFileSync(join(dir, statePath!), JSON.stringify({ v: 1, sessions: {} }));
+    __resetUsageLedgerMemoryForTest();
+
+    const rec = recordSessionUsage({
+      ...baseArgs({ now: new Date('2026-06-10T13:00:00Z') }),
+      ledgerDir: dir,
+      usage: cumulative(150, 15),
+    });
+    expect(rec).toMatchObject({ inputTokens: 50, outputTokens: 5 });
+  });
+
+  it('recordOwnershipForDaemonSession does not require a readable transcript', () => {
+    vi.mocked(getSessionTokenUsage).mockReturnValue(null);
+    const ds = {
+      larkAppId: 'cli_app',
+      workingDir: '/live-repo',
+      session: {
+        sessionId: 'sess-own',
+        cliId: 'claude-code',
+        cliSessionId: 'cli-sess-own',
+        chatId: 'oc_chat',
+        title: '新会话',
+        lastCallerOpenId: 'ou_last',
+      },
+    } as any;
+
+    const rec = recordOwnershipForDaemonSession(ds, { ledgerDir: dir });
+    expect(rec).toMatchObject({ kind: 'ownership', cliSessionId: 'cli-sess-own' });
   });
 });


### PR DESCRIPTION
kaboo MR seed/kaboo!292 复审(Codex)发现的可达窗口:owned 集只能看到已有正增量记录的会话,新 botmux 会话首轮期间 kaboo 的 native parser 仍会把同一 transcript 以原 source 上报;增量上报(GREATEST upsert)不撤销旧桶,双计在下次 full sync 前长期残留。

## 修复

- `recordSessionOwnership`:追加 `kind:"ownership"` 全零增量标记。确定性 recordId(`sha256("ownership|sessionId|cliSessionId")[:32]`),跨重启重复行同 id 由消费方 DedupKey 折叠;进程内 Set 去重避免重复落盘;**不触碰基线**。
- `baselineFromLedger` 跳过 ownership 标记——零 totals 永不充当崩溃恢复基线(否则 state 丢失时会把整段历史重新计费)。
- 接线:forkWorker(spawn/resume)、adopt、worker IPC `cli_session_id`(codex 等后发现原生 id 的 CLI 获知瞬间补写)。
- 对端 kaboo(seed/kaboo!292 @ 6816b7e):owned 集按目标 source 过滤 + 零增量记录不计费但计入 owned。

## 测试

usage-ledger 22 用例(新增 4:确定性 id 与跨重启同 id/进程内去重/缺 cliSessionId 跳过/ownership 不充当恢复基线);受影响 69 测试全绿;tsc 干净。