### PR TITLE
feat(worker-budget): idleSuspendMode=always 闲置即挂起，支持 per-bot 覆盖

### DIFF
--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -6,6 +6,7 @@ import type { BackendType } from './adapters/backend/types.js';
 import type { CliId } from './adapters/cli/types.js';
 import { logger } from './utils/logger.js';
 import { isLocale, setBotLookup, type Locale } from './i18n/index.js';
+import type { WorkerConfig } from './global-config.js';
 import type { VoiceConfig } from './services/voice/types.js';
 import { type Brand, sdkDomain, normalizeBrand } from './im/lark/lark-hosts.js';
 
@@ -89,6 +90,16 @@ export interface BotConfig {
   oncallChats?: OncallChat[];
   /** UI language for this bot: 'zh' or 'en'. Falls back to BOTMUX_LANG / LANG env when unset. */
   lang?: Locale;
+  /**
+   * Per-bot worker 生命周期覆盖，逐字段 merge 在全局 `config.json#worker` 之上
+   * （multi-daemon 部署一 bot 一进程，本覆盖只影响该 bot 自己的 daemon）。
+   * 典型用法：报警归因这类"一次性"bot 配
+   * `{ "idleSuspendMode": "always", "idleSuspendMs": 600000 }` ——
+   * 出结论后闲置 10 分钟即挂起释放内存；话题里有人跟进时，active 会话的
+   * worker-null resume 路径会自动带上下文重新拉起 CLI，对用户透明。
+   * 常驻型 bot 不配则跟随全局预算策略。
+   */
+  worker?: WorkerConfig;
   /**
    * Per-bot default working directory. When set, new topics that have no
    * oncall binding and no sibling-session inheritance skip the repo-select

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -454,6 +454,32 @@ export function resolveBrandLabel(larkAppId: string): string | undefined {
   }
 }
 
+// Configured-bot count, mtime-cached like the other disk fallbacks above.
+let botCountCache: { mtimeMs: number; count: number } | null = null;
+
+/**
+ * How many bots the shared bots.json configures — i.e. how many daemons share
+ * this machine (multi-daemon deployments run one bot per process, so the
+ * in-memory registry only sees this daemon's own bot). Used to split the
+ * auto-derived worker budget across daemons. Falls back to the in-memory
+ * registry size (≥1) when no config file is readable, which also covers
+ * single-process/test setups.
+ */
+export function countConfiguredBots(): number {
+  const path = loadedConfigPath ?? botsConfigDiskPath();
+  if (path) {
+    try {
+      const stat = statSync(path);
+      if (!botCountCache || botCountCache.mtimeMs !== stat.mtimeMs) {
+        const raw = JSON.parse(readFileSync(path, 'utf-8'));
+        botCountCache = { mtimeMs: stat.mtimeMs, count: Array.isArray(raw) ? Math.max(1, raw.length) : 1 };
+      }
+      return botCountCache.count;
+    } catch { /* fall through to registry size */ }
+  }
+  return Math.max(1, bots.size);
+}
+
 /**
  * Load bot configurations from one of (in priority order):
  * 1. BOTS_CONFIG env var — path to a JSON file

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4836,8 +4836,14 @@ function cmdWorkerBudget(args: string[]): void {
   if (sub === '--help' || sub === '-h' || sub === 'help') {
     console.log(`Usage:
   botmux worker-budget [status]
-  botmux worker-budget set --max-live-workers <n> [--idle-minutes <n>|--idle-ms <n>]
-  botmux worker-budget unset`);
+  botmux worker-budget set --max-live-workers <n> [--idle-minutes <n>|--idle-ms <n>] [--idle-suspend-mode budget|always]
+  botmux worker-budget unset
+
+idle-suspend-mode:
+  budget (default)  suspend idle workers only while live workers exceed maxLiveWorkers
+  always            suspend any worker idle >= the threshold, regardless of count
+                    (sessions stay active; the next message transparently resumes them)
+Per-bot override: set a "worker" object on the bot entry in bots.json.`);
     return;
   }
 
@@ -4849,6 +4855,7 @@ function cmdWorkerBudget(args: string[]): void {
     console.log('Worker budget');
     console.log(`  maxLiveWorkers: ${budget.maxLiveWorkers} (${budget.maxLiveWorkersSource})`);
     console.log(`  idleSuspendMs:  ${budget.idleSuspendMs} (${budget.idleSuspendMsSource})`);
+    console.log(`  idleSuspendMode: ${budget.idleSuspendMode} (${budget.idleSuspendModeSource})`);
     console.log(`  auto baseline:  ${budget.autoMaxLiveWorkers} from cpu=${resources.cpuCount}, memory=${formatGib(resources.memoryBytes)}, daemons=${daemonCount} (per-daemon share)`);
     console.log(`  Config file:    ${globalConfigPath()}`);
     console.log('');
@@ -4863,12 +4870,17 @@ function cmdWorkerBudget(args: string[]): void {
     const maxLive = argValue(rest, '--max-live-workers', '--max-live');
     const idleMs = argValue(rest, '--idle-ms', '--idle-suspend-ms');
     const idleMinutes = argValue(rest, '--idle-minutes', '--idle-min');
-    if (maxLive === undefined && idleMs === undefined && idleMinutes === undefined) {
-      console.error('Usage: botmux worker-budget set --max-live-workers <n> [--idle-minutes <n>|--idle-ms <n>]');
+    const idleMode = argValue(rest, '--idle-suspend-mode', '--idle-mode');
+    if (maxLive === undefined && idleMs === undefined && idleMinutes === undefined && idleMode === undefined) {
+      console.error('Usage: botmux worker-budget set --max-live-workers <n> [--idle-minutes <n>|--idle-ms <n>] [--idle-suspend-mode budget|always]');
       process.exit(1);
     }
     if (idleMs !== undefined && idleMinutes !== undefined) {
       console.error('Use only one of --idle-ms or --idle-minutes.');
+      process.exit(1);
+    }
+    if (idleMode !== undefined && idleMode !== 'budget' && idleMode !== 'always') {
+      console.error('--idle-suspend-mode must be "budget" or "always".');
       process.exit(1);
     }
 
@@ -4877,12 +4889,14 @@ function cmdWorkerBudget(args: string[]): void {
     if (maxLive !== undefined) next.maxLiveWorkers = parsePositiveInt(maxLive, '--max-live-workers');
     if (idleMs !== undefined) next.idleSuspendMs = parsePositiveInt(idleMs, '--idle-ms');
     if (idleMinutes !== undefined) next.idleSuspendMs = parsePositiveInt(idleMinutes, '--idle-minutes') * 60_000;
+    if (idleMode !== undefined) next.idleSuspendMode = idleMode;
 
     mergeGlobalConfig({ worker: next });
     const budget = resolveWorkerBudget(next, undefined, countConfiguredBots());
     console.log('✅ Updated worker budget.');
     console.log(`  maxLiveWorkers: ${budget.maxLiveWorkers} (${budget.maxLiveWorkersSource})`);
     console.log(`  idleSuspendMs:  ${budget.idleSuspendMs} (${budget.idleSuspendMsSource})`);
+    console.log(`  idleSuspendMode: ${budget.idleSuspendMode} (${budget.idleSuspendModeSource})`);
     console.log(`  Config file:    ${globalConfigPath()}`);
     console.log('Daemon reads this on the next idle-worker sweep; restart also picks it up.');
     return;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2996,7 +2996,7 @@ function argValues(args: string[], ...flags: string[]): string[] {
 import { buildMentionedPendingResponseCard } from './im/lark/card-builder.js';
 import { buildCardBodyElements, brandFooterSegment } from './im/lark/md-card.js';
 import { COMPLETED_REACTION_EMOJI_TYPE, claimPendingResponseCard, isPendingResponseCardOpen, markPendingResponseCardPatchedIfCurrent, mergePendingResponseState, shouldMarkPendingAsMentionedSend, shouldPatchPendingOnExplicitSend } from './core/pending-response.js';
-import { resolveBrandLabel } from './bot-registry.js';
+import { countConfiguredBots, resolveBrandLabel } from './bot-registry.js';
 import { config } from './config.js';
 import { resolveQuoteTarget, validateMentionDecision, parseAttentionFlag, attentionUsageError } from './services/send-policy.js';
 
@@ -4844,11 +4844,12 @@ function cmdWorkerBudget(args: string[]): void {
   if (sub === 'status') {
     const cfg = readGlobalConfig();
     const resources = detectWorkerResources();
-    const budget = resolveWorkerBudget(cfg.worker, resources);
+    const daemonCount = countConfiguredBots();
+    const budget = resolveWorkerBudget(cfg.worker, resources, daemonCount);
     console.log('Worker budget');
     console.log(`  maxLiveWorkers: ${budget.maxLiveWorkers} (${budget.maxLiveWorkersSource})`);
     console.log(`  idleSuspendMs:  ${budget.idleSuspendMs} (${budget.idleSuspendMsSource})`);
-    console.log(`  auto baseline:  ${budget.autoMaxLiveWorkers} from cpu=${resources.cpuCount}, memory=${formatGib(resources.memoryBytes)}`);
+    console.log(`  auto baseline:  ${budget.autoMaxLiveWorkers} from cpu=${resources.cpuCount}, memory=${formatGib(resources.memoryBytes)}, daemons=${daemonCount} (per-daemon share)`);
     console.log(`  Config file:    ${globalConfigPath()}`);
     console.log('');
     console.log('Agent-safe edit commands:');
@@ -4878,7 +4879,7 @@ function cmdWorkerBudget(args: string[]): void {
     if (idleMinutes !== undefined) next.idleSuspendMs = parsePositiveInt(idleMinutes, '--idle-minutes') * 60_000;
 
     mergeGlobalConfig({ worker: next });
-    const budget = resolveWorkerBudget(next);
+    const budget = resolveWorkerBudget(next, undefined, countConfiguredBots());
     console.log('✅ Updated worker budget.');
     console.log(`  maxLiveWorkers: ${budget.maxLiveWorkers} (${budget.maxLiveWorkersSource})`);
     console.log(`  idleSuspendMs:  ${budget.idleSuspendMs} (${budget.idleSuspendMsSource})`);

--- a/src/core/idle-worker-sweeper.ts
+++ b/src/core/idle-worker-sweeper.ts
@@ -1,13 +1,19 @@
 import type { DaemonSession } from './types.js';
 import { countConfiguredBots } from '../bot-registry.js';
-import { readGlobalConfig } from '../global-config.js';
+import { readGlobalConfig, type IdleSuspendMode, type WorkerConfig } from '../global-config.js';
 import { DEFAULT_IDLE_SUSPEND_MS, resolveWorkerBudget, type ResolvedWorkerBudget } from './worker-budget.js';
 import { suspendWorker } from './worker-pool.js';
 import { isSuspendableBackendType } from './persistent-backend.js';
 
 export interface IdleWorkerSweepOptions {
   now?: number;
-  workerBudget?: Pick<ResolvedWorkerBudget, 'maxLiveWorkers' | 'idleSuspendMs'>;
+  workerBudget?: Pick<ResolvedWorkerBudget, 'maxLiveWorkers' | 'idleSuspendMs'> & { idleSuspendMode?: IdleSuspendMode };
+  /**
+   * This daemon's per-bot WorkerConfig (bots.json `worker` field), merged
+   * field-by-field over the global config — multi-daemon deployments run one
+   * bot per daemon, so the override scopes naturally to this process.
+   */
+  botWorkerOverride?: WorkerConfig;
 }
 
 export interface IdleWorkerSweepResult {
@@ -26,11 +32,18 @@ export function sweepIdleWorkers(
   opts: IdleWorkerSweepOptions = {},
 ): IdleWorkerSweepResult[] {
   const now = opts.now ?? Date.now();
-  const budget = opts.workerBudget ?? resolveWorkerBudget(readGlobalConfig().worker, undefined, countConfiguredBots());
+  const globalWorker = readGlobalConfig().worker;
+  const workerConfig = (globalWorker || opts.botWorkerOverride)
+    ? { ...globalWorker, ...opts.botWorkerOverride }
+    : undefined;
+  const budget = opts.workerBudget ?? resolveWorkerBudget(workerConfig, undefined, countConfiguredBots());
+  const mode: IdleSuspendMode = budget.idleSuspendMode ?? 'budget';
   const maxLiveWorkers = budget.maxLiveWorkers;
   const idleMs = budget.idleSuspendMs;
   const running = liveWorkers(activeSessions);
-  if (running.length <= maxLiveWorkers) return [];
+  // 'always' suspends every eligible idle worker; 'budget' (default) only
+  // trims the overflow above maxLiveWorkers, oldest-idle first.
+  if (mode !== 'always' && running.length <= maxLiveWorkers) return [];
 
   const candidates = running
     // Never suspend an adopted session. forkAdoptWorker stamps its
@@ -48,11 +61,12 @@ export function sweepIdleWorkers(
     .sort((a, b) => (a.lastMessageAt || 0) - (b.lastMessageAt || 0));
 
   const suspended: IdleWorkerSweepResult[] = [];
+  const reason = mode === 'always' ? 'idle_suspend_always' : 'idle_worker_budget';
   let liveCount = running.length;
   for (const ds of candidates) {
-    if (liveCount <= maxLiveWorkers) break;
-    if (!suspendWorker(ds, 'idle_worker_budget')) continue;
-    suspended.push({ sessionId: ds.session.sessionId, reason: 'idle_worker_budget' });
+    if (mode !== 'always' && liveCount <= maxLiveWorkers) break;
+    if (!suspendWorker(ds, reason)) continue;
+    suspended.push({ sessionId: ds.session.sessionId, reason });
     liveCount--;
   }
   return suspended;

--- a/src/core/idle-worker-sweeper.ts
+++ b/src/core/idle-worker-sweeper.ts
@@ -1,4 +1,5 @@
 import type { DaemonSession } from './types.js';
+import { countConfiguredBots } from '../bot-registry.js';
 import { readGlobalConfig } from '../global-config.js';
 import { DEFAULT_IDLE_SUSPEND_MS, resolveWorkerBudget, type ResolvedWorkerBudget } from './worker-budget.js';
 import { suspendWorker } from './worker-pool.js';
@@ -25,7 +26,7 @@ export function sweepIdleWorkers(
   opts: IdleWorkerSweepOptions = {},
 ): IdleWorkerSweepResult[] {
   const now = opts.now ?? Date.now();
-  const budget = opts.workerBudget ?? resolveWorkerBudget(readGlobalConfig().worker);
+  const budget = opts.workerBudget ?? resolveWorkerBudget(readGlobalConfig().worker, undefined, countConfiguredBots());
   const maxLiveWorkers = budget.maxLiveWorkers;
   const idleMs = budget.idleSuspendMs;
   const running = liveWorkers(activeSessions);

--- a/src/core/worker-budget.ts
+++ b/src/core/worker-budget.ts
@@ -49,17 +49,29 @@ export function detectWorkerResources(): WorkerResources {
   };
 }
 
-export function autoMaxLiveWorkers(resources: WorkerResources = detectWorkerResources()): number {
+/**
+ * Auto-derived per-daemon live-worker budget.
+ *
+ * `daemonCount` is the number of daemons sharing this machine (= bots in the
+ * shared bots.json; multi-daemon deployments run one bot per process). The
+ * machine-level budget min(cpu×2, memGiB) is split evenly across daemons —
+ * without this, N daemons each claim the whole box and the effective
+ * machine-wide cap silently becomes N × budget.
+ */
+export function autoMaxLiveWorkers(resources: WorkerResources = detectWorkerResources(), daemonCount = 1): number {
   const cpuBudget = Math.max(1, resources.cpuCount) * 2;
   const memoryBudget = Math.max(1, Math.round(resources.memoryBytes / 1024 ** 3));
-  return clamp(Math.min(cpuBudget, memoryBudget), MIN_AUTO_MAX_LIVE_WORKERS, MAX_AUTO_MAX_LIVE_WORKERS);
+  const machineBudget = Math.min(cpuBudget, memoryBudget);
+  const perDaemon = Math.floor(machineBudget / Math.max(1, daemonCount));
+  return clamp(perDaemon, MIN_AUTO_MAX_LIVE_WORKERS, MAX_AUTO_MAX_LIVE_WORKERS);
 }
 
 export function resolveWorkerBudget(
   workerConfig?: WorkerConfig,
   resources: WorkerResources = detectWorkerResources(),
+  daemonCount = 1,
 ): ResolvedWorkerBudget {
-  const auto = autoMaxLiveWorkers(resources);
+  const auto = autoMaxLiveWorkers(resources, daemonCount);
   return {
     maxLiveWorkers: workerConfig?.maxLiveWorkers ?? auto,
     idleSuspendMs: workerConfig?.idleSuspendMs ?? DEFAULT_IDLE_SUSPEND_MS,

--- a/src/core/worker-budget.ts
+++ b/src/core/worker-budget.ts
@@ -1,10 +1,11 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { availableParallelism, totalmem } from 'node:os';
-import type { WorkerConfig } from '../global-config.js';
+import type { IdleSuspendMode, WorkerConfig } from '../global-config.js';
 
 export const MIN_AUTO_MAX_LIVE_WORKERS = 4;
 export const MAX_AUTO_MAX_LIVE_WORKERS = 32;
 export const DEFAULT_IDLE_SUSPEND_MS = 30 * 60_000;
+export const DEFAULT_IDLE_SUSPEND_MODE: IdleSuspendMode = 'budget';
 
 export interface WorkerResources {
   cpuCount: number;
@@ -14,9 +15,11 @@ export interface WorkerResources {
 export interface ResolvedWorkerBudget {
   maxLiveWorkers: number;
   idleSuspendMs: number;
+  idleSuspendMode: IdleSuspendMode;
   autoMaxLiveWorkers: number;
   maxLiveWorkersSource: 'auto' | 'config';
   idleSuspendMsSource: 'default' | 'config';
+  idleSuspendModeSource: 'default' | 'config';
 }
 
 function clamp(n: number, min: number, max: number): number {
@@ -75,8 +78,10 @@ export function resolveWorkerBudget(
   return {
     maxLiveWorkers: workerConfig?.maxLiveWorkers ?? auto,
     idleSuspendMs: workerConfig?.idleSuspendMs ?? DEFAULT_IDLE_SUSPEND_MS,
+    idleSuspendMode: workerConfig?.idleSuspendMode ?? DEFAULT_IDLE_SUSPEND_MODE,
     autoMaxLiveWorkers: auto,
     maxLiveWorkersSource: workerConfig?.maxLiveWorkers === undefined ? 'auto' : 'config',
     idleSuspendMsSource: workerConfig?.idleSuspendMs === undefined ? 'default' : 'config',
+    idleSuspendModeSource: workerConfig?.idleSuspendMode === undefined ? 'default' : 'config',
   };
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -3457,7 +3457,14 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   }
 
   const idleWorkerSweepTimer = setInterval(() => {
-    const suspended = sweepIdleWorkers(activeSessions);
+    // Per-bot worker override (one bot per daemon): lets e.g. one-shot
+    // attribution bots opt into idleSuspendMode 'always' while resident bots
+    // keep the global budget policy. Read via getBot each tick so in-process
+    // config updates apply on the next sweep; hand-edits to bots.json still
+    // need a daemon restart (the file is only loaded at startup).
+    let botWorker;
+    try { botWorker = getBot(cfg.larkAppId).config.worker; } catch { /* bot deregistered */ }
+    const suspended = sweepIdleWorkers(activeSessions, { botWorkerOverride: botWorker });
     if (suspended.length > 0) {
       logger.info(`[idle-worker-sweeper] suspended ${suspended.length} idle worker(s)`);
     }

--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -18,9 +18,22 @@ import { homedir } from 'node:os';
 import { isLocale, type Locale } from './i18n/types.js';
 import type { VoiceConfig } from './services/voice/types.js';
 
+/**
+ * When idle workers get suspended:
+ *   - 'budget' (default): only while live workers exceed `maxLiveWorkers`,
+ *     oldest-idle first, down to the budget — the original behavior.
+ *   - 'always': any suspendable worker idle ≥ `idleSuspendMs` is suspended
+ *     regardless of the live count. Suspension keeps the session active, so
+ *     the next message in the topic transparently re-forks the CLI with its
+ *     context restored — suited to one-shot bots (e.g. alert attribution)
+ *     whose sessions are rarely followed up.
+ */
+export type IdleSuspendMode = 'budget' | 'always';
+
 export interface WorkerConfig {
   maxLiveWorkers?: number;
   idleSuspendMs?: number;
+  idleSuspendMode?: IdleSuspendMode;
 }
 
 export interface GlobalConfig {
@@ -178,6 +191,7 @@ function readWorker(raw: unknown): WorkerConfig | undefined {
   const idleSuspendMs = readPositiveInteger(v.idleSuspendMs);
   if (maxLiveWorkers !== undefined) worker.maxLiveWorkers = maxLiveWorkers;
   if (idleSuspendMs !== undefined) worker.idleSuspendMs = idleSuspendMs;
+  if (v.idleSuspendMode === 'budget' || v.idleSuspendMode === 'always') worker.idleSuspendMode = v.idleSuspendMode;
   return Object.keys(worker).length > 0 ? worker : undefined;
 }
 

--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -1005,11 +1005,16 @@ botmux worker-budget status
 # 覆盖 live worker 上限；idle 阈值可选
 botmux worker-budget set --max-live-workers 12 --idle-minutes 45
 
+# 切换挂起策略：always = 闲置即挂起（不看预算），budget = 仅超预算时挂起（默认）
+botmux worker-budget set --idle-suspend-mode always
+
 # 清除覆盖，恢复按 CPU/内存自动推导
 botmux worker-budget unset
 \`\`\`
 
 \`maxLiveWorkers\` 控制多少个 live worker 以内保持常驻；超过预算时 daemon 会优先暂停最久未活跃的 worker。\`idleSuspendMs\` 控制 worker 需要闲置多久才允许被暂停。
+
+\`idleSuspendMode\` 控制挂起时机：\`budget\`（默认）仅在 live worker 超过预算时挂起多余的；\`always\` 对任何闲置达到阈值的 worker 直接挂起、不看预算——挂起后会话仍是 active，话题里来新消息会自动带上下文重新拉起 CLI，适合报警归因这类「出结论即闲置」的一次性 bot。单个 bot 也可在 bots.json 对应条目加 \`"worker": { "idleSuspendMode": "always", "idleSuspendMs": 600000 }\` 做 per-bot 覆盖（改完需重启 daemon）。
 `;
 
 const ORCHESTRATE_SKILL = `---

--- a/test/idle-worker-sweeper.test.ts
+++ b/test/idle-worker-sweeper.test.ts
@@ -215,4 +215,50 @@ describe('sweepIdleWorkers', () => {
     expect(suspended).toEqual([]);
     expect(activeSessions.get('a').worker).not.toBe(null);
   });
+
+  it('always mode suspends every eligible idle worker even under the budget', () => {
+    const now = 1_000_000;
+    const activeSessions = new Map<string, any>([
+      ['a', ds('a', 'tmux', now - 90 * 60_000)],
+      ['b', ds('b', 'herdr', now - 80 * 60_000)],
+      ['c', ds('c', 'zellij', now - 31 * 60_000)],
+      ['d', ds('d', 'tmux', now - 2 * 60_000)], // under the idle threshold
+    ]);
+
+    // 4 live workers, budget 8 — budget mode would do nothing here.
+    const suspended = sweepIdleWorkers(activeSessions, {
+      now,
+      workerBudget: { maxLiveWorkers: 8, idleSuspendMs: 30 * 60_000, idleSuspendMode: 'always' },
+    });
+
+    expect(suspended.map(s => s.sessionId)).toEqual(['a', 'b', 'c']);
+    expect(suspended.every(s => s.reason === 'idle_suspend_always')).toBe(true);
+    expect(activeSessions.get('a').worker).toBe(null);
+    expect(activeSessions.get('b').worker).toBe(null);
+    expect(activeSessions.get('c').worker).toBe(null);
+    expect(activeSessions.get('d').worker).not.toBe(null);
+    // Suspension keeps sessions active (resumable on the next message).
+    expect(activeSessions.get('a').session.status).toBe('active');
+  });
+
+  it('always mode still skips non-idle, non-suspendable, and adopt sessions', () => {
+    const now = 1_000_000;
+    const adopt = { ...ds('a', 'tmux', now - 90 * 60_000), adoptedFrom: { tmuxTarget: 'user:0.1' } };
+    const activeSessions = new Map<string, any>([
+      ['a', adopt],
+      ['b', { ...ds('b', 'herdr', now - 80 * 60_000), lastScreenStatus: 'working' }],
+      ['c', ds('c', 'pty', now - 70 * 60_000)],
+      ['d', ds('d', 'tmux', now - 60 * 60_000)],
+    ]);
+
+    const suspended = sweepIdleWorkers(activeSessions, {
+      now,
+      workerBudget: { maxLiveWorkers: 8, idleSuspendMs: 30 * 60_000, idleSuspendMode: 'always' },
+    });
+
+    expect(suspended.map(s => s.sessionId)).toEqual(['d']);
+    expect(activeSessions.get('a').worker).not.toBe(null);
+    expect(activeSessions.get('b').worker).not.toBe(null);
+    expect(activeSessions.get('c').worker).not.toBe(null);
+  });
 });

--- a/test/worker-budget-cli.test.ts
+++ b/test/worker-budget-cli.test.ts
@@ -56,4 +56,23 @@ describe('botmux worker-budget CLI', () => {
     expect(unset.status).toBe(0);
     expect(readConfig().worker).toBeUndefined();
   });
+
+  it('sets and validates idle suspend mode', () => {
+    const set = runCli(['worker-budget', 'set', '--idle-suspend-mode', 'always']);
+    expect(set.status).toBe(0);
+    expect(readConfig().worker).toEqual({ idleSuspendMode: 'always' });
+    expect(set.stdout).toContain('idleSuspendMode: always (config)');
+
+    const status = runCli(['worker-budget', 'status']);
+    expect(status.status).toBe(0);
+    expect(status.stdout).toContain('idleSuspendMode: always (config)');
+
+    const bad = runCli(['worker-budget', 'set', '--idle-suspend-mode', 'sometimes']);
+    expect(bad.status).toBe(1);
+    expect(bad.stderr).toContain('--idle-suspend-mode must be "budget" or "always"');
+
+    const unset = runCli(['worker-budget', 'unset']);
+    expect(unset.status).toBe(0);
+    expect(readConfig().worker).toBeUndefined();
+  });
 });

--- a/test/worker-budget.test.ts
+++ b/test/worker-budget.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveWorkerBudget } from '../src/core/worker-budget.js';
+import { autoMaxLiveWorkers, resolveWorkerBudget } from '../src/core/worker-budget.js';
 
 const gib = (n: number) => n * 1024 ** 3;
 
@@ -9,6 +9,27 @@ describe('resolveWorkerBudget', () => {
     expect(resolveWorkerBudget(undefined, { cpuCount: 4, memoryBytes: gib(8) }).maxLiveWorkers).toBe(8);
     expect(resolveWorkerBudget(undefined, { cpuCount: 8, memoryBytes: gib(16) }).maxLiveWorkers).toBe(16);
     expect(resolveWorkerBudget(undefined, { cpuCount: 64, memoryBytes: gib(128) }).maxLiveWorkers).toBe(32);
+  });
+
+  it('splits the machine budget across daemons sharing the box', () => {
+    const box = { cpuCount: 56, memoryBytes: gib(110) };
+    // Single daemon: clamp(min(112, 110)) = 32 — unchanged legacy behavior.
+    expect(autoMaxLiveWorkers(box)).toBe(32);
+    expect(autoMaxLiveWorkers(box, 1)).toBe(32);
+    // Six daemons (one bot each): floor(110 / 6) = 18 per daemon.
+    expect(autoMaxLiveWorkers(box, 6)).toBe(18);
+    expect(resolveWorkerBudget(undefined, box, 6).maxLiveWorkers).toBe(18);
+    // The per-daemon share never drops below the MIN floor…
+    expect(autoMaxLiveWorkers(box, 100)).toBe(4);
+    // …and a bogus count is treated as a single daemon.
+    expect(autoMaxLiveWorkers(box, 0)).toBe(32);
+  });
+
+  it('keeps an explicit maxLiveWorkers override per-daemon (not split)', () => {
+    const resolved = resolveWorkerBudget({ maxLiveWorkers: 12 }, { cpuCount: 56, memoryBytes: gib(110) }, 6);
+    expect(resolved.maxLiveWorkers).toBe(12);
+    expect(resolved.maxLiveWorkersSource).toBe('config');
+    expect(resolved.autoMaxLiveWorkers).toBe(18);
   });
 
   it('lets global config override max live workers and idle threshold independently', () => {

--- a/test/worker-budget.test.ts
+++ b/test/worker-budget.test.ts
@@ -41,9 +41,25 @@ describe('resolveWorkerBudget', () => {
     expect(resolved).toEqual({
       maxLiveWorkers: 12,
       idleSuspendMs: 45 * 60_000,
+      idleSuspendMode: 'budget',
       autoMaxLiveWorkers: 8,
       maxLiveWorkersSource: 'config',
       idleSuspendMsSource: 'config',
+      idleSuspendModeSource: 'default',
     });
+  });
+
+  it('defaults idleSuspendMode to budget and honors a configured always', () => {
+    const box = { cpuCount: 4, memoryBytes: gib(8) };
+    const def = resolveWorkerBudget(undefined, box);
+    expect(def.idleSuspendMode).toBe('budget');
+    expect(def.idleSuspendModeSource).toBe('default');
+
+    const always = resolveWorkerBudget({ idleSuspendMode: 'always' }, box);
+    expect(always.idleSuspendMode).toBe('always');
+    expect(always.idleSuspendModeSource).toBe('config');
+    // Mode alone doesn't touch the numeric budget fields.
+    expect(always.maxLiveWorkers).toBe(8);
+    expect(always.maxLiveWorkersSource).toBe('auto');
   });
 });


### PR DESCRIPTION
预算模式（默认）只在 live worker 超过 maxLiveWorkers 时修剪超额部分，
一次性场景（如报警归因 bot：每条报警开一个话题/进程，出结论后基本
不再活跃）会让闲置进程在预算内无限驻留。新增 idleSuspendMode：

- 'budget'（默认）：维持原行为，仅超预算时挂起最久闲置的 worker
- 'always'：闲置 ≥ idleSuspendMs 即挂起、不看预算；会话保持 active， 话题里来新消息走 worker-null resume 路径自动带上下文复活

配置面：
- 全局：botmux worker-budget set --idle-suspend-mode always|budget， status 显示当前模式
- per-bot：bots.json 条目加 worker 字段逐项覆盖全局（一 bot 一 daemon， 天然只影响该 bot），如归因 bot 配 always + 短阈值，常驻 bot 不受影响
- sweeper 的挂起 reason 区分为 idle_suspend_always / idle_worker_budget