### PR TITLE
fix(utils): 共享状态文件统一原子写(tmp+rename)

### DIFF
--- a/scripts/claim-botmux-bin.mjs
+++ b/scripts/claim-botmux-bin.mjs
@@ -6,16 +6,25 @@
 // 写入内容与 daemon 启动时写的 wrapper 完全一致（见 src/daemon.ts），所以两者幂等：
 // 「在哪 build+use，全局 botmux 就指哪；下次 daemon restart-from-dir 再覆盖」均自洽。
 import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { dirname, basename, join } from 'node:path';
 import { homedir } from 'node:os';
-import { mkdirSync, writeFileSync, readFileSync, existsSync, renameSync, unlinkSync } from 'node:fs';
+import { mkdirSync, writeFileSync, readFileSync, existsSync, renameSync, unlinkSync, realpathSync, chmodSync } from 'node:fs';
 
 // 原子写（与 src/utils/atomic-write.ts 同构，.mjs 不依赖 dist 故内联）：
 // 这个 wrapper 随时被并发会话 exec，裸写半截会让它们的 `botmux send` 全体失败。
+// 同构三要素缺一不可：①写前 realpath 穿透 symlink（否则把链接本体 rename 成
+// 普通文件）②唯一 tmp 名 ③写后显式 chmod（creation mode 被 umask 截断，
+// umask 077 下 0o755 会落成 0o700）。
 function atomicWriteFileSync(filePath, data, mode) {
+  try { filePath = realpathSync(filePath); }
+  catch {
+    try { filePath = join(realpathSync(dirname(filePath)), basename(filePath)); }
+    catch { /* 父目录也不存在，保持原路径 */ }
+  }
   const tmp = `${filePath}.${process.pid}.${Math.random().toString(16).slice(2, 10)}.tmp`;
   try {
     writeFileSync(tmp, data, { mode });
+    chmodSync(tmp, mode);
     renameSync(tmp, filePath);
   } catch (err) {
     try { unlinkSync(tmp); } catch { /* tmp 可能根本没写出来 */ }

--- a/scripts/claim-botmux-bin.mjs
+++ b/scripts/claim-botmux-bin.mjs
@@ -8,7 +8,20 @@
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
-import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { mkdirSync, writeFileSync, readFileSync, existsSync, renameSync, unlinkSync } from 'node:fs';
+
+// 原子写（与 src/utils/atomic-write.ts 同构，.mjs 不依赖 dist 故内联）：
+// 这个 wrapper 随时被并发会话 exec，裸写半截会让它们的 `botmux send` 全体失败。
+function atomicWriteFileSync(filePath, data, mode) {
+  const tmp = `${filePath}.${process.pid}.${Math.random().toString(16).slice(2, 10)}.tmp`;
+  try {
+    writeFileSync(tmp, data, { mode });
+    renameSync(tmp, filePath);
+  } catch (err) {
+    try { unlinkSync(tmp); } catch { /* tmp 可能根本没写出来 */ }
+    throw err;
+  }
+}
 
 // 逃生阀：偶尔只想 build 不想抢全局时 `BOTMUX_NO_CLAIM=1 pnpm use:here`
 if (process.env.BOTMUX_NO_CLAIM) {
@@ -33,7 +46,7 @@ try {
   if (existing === content) {
     console.log(`✓ 全局 botmux 已指向本 checkout（${cliScript}）`);
   } else {
-    writeFileSync(wrapper, content, { mode: 0o755 });
+    atomicWriteFileSync(wrapper, content, 0o755);
     console.log(`✅ 全局 botmux → 本 checkout（${cliScript}）`);
     console.log('   下一步 `botmux restart` 即从本 checkout 重启 daemon。');
   }

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -21,6 +21,7 @@
  */
 import { homedir } from 'node:os';
 import { mkdirSync, existsSync, writeFileSync, chmodSync, readdirSync, readFileSync, rmSync, statSync, openSync, fstatSync, readSync, writeSync, closeSync, constants as fsConstants } from 'node:fs';
+import { atomicWriteFileSync } from '../../utils/atomic-write.js';
 import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn, spawnSync } from 'node:child_process';
@@ -589,7 +590,8 @@ export function startOutboxWatcher(outbox: string, baseEnv: NodeJS.ProcessEnv, s
   const staging = join(dirname(outbox), 'relay-staging');
 
   const finish = (id: string, reqPath: string, name: string, staged: string[], code: number, stdout: string, stderr: string) => {
-    try { writeFileSync(join(outbox, `${id}.res.json`), JSON.stringify({ code, stdout, stderr })); } catch { /* */ }
+    // 原子写：沙盒侧 CLI 在 existsSync 轮询这个 res.json，rename 保证它读到完整 JSON。
+    try { atomicWriteFileSync(join(outbox, `${id}.res.json`), JSON.stringify({ code, stdout, stderr })); } catch { /* */ }
     try { rmSync(reqPath, { force: true }); } catch { /* */ }
     for (const p of staged) { try { rmSync(p, { force: true }); } catch { /* */ } }
     inFlight.delete(name);

--- a/src/adapters/coco-ask-plugin.ts
+++ b/src/adapters/coco-ask-plugin.ts
@@ -21,7 +21,8 @@
  * CoCo（与 Claude 写全局 settings.json 的安全模型一致）。
  */
 
-import { writeFileSync, mkdirSync } from 'node:fs';
+import { mkdirSync } from 'node:fs';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { execFileSync } from 'node:child_process';
@@ -59,15 +60,14 @@ export function installCocoAskPlugin(cocoBin: string): void {
     };
 
     mkdirSync(join(COCO_ASK_PLUGIN_DIR, '.codex-plugin'), { recursive: true });
-    writeFileSync(
+    // 原子写：多个 daemon（一 bot 一进程）启动时会并发刷同一份共享插件目录。
+    atomicWriteFileSync(
       join(COCO_ASK_PLUGIN_DIR, '.codex-plugin', 'plugin.json'),
       JSON.stringify(manifest, null, 2) + '\n',
-      'utf-8',
     );
-    writeFileSync(
+    atomicWriteFileSync(
       join(COCO_ASK_PLUGIN_DIR, 'hooks.json'),
       JSON.stringify(hooks, null, 2) + '\n',
-      'utf-8',
     );
 
     // 幂等安装（--yes 跳过确认）。stdio 忽略，避免污染 daemon 日志；超时兜底。

--- a/src/adapters/hook-installer.ts
+++ b/src/adapters/hook-installer.ts
@@ -4,7 +4,8 @@
  * 把 botmux 的 askUserQuestion hook 写入各 CLI 的配置文件。
  * 幂等：写前比对内容，相同则跳过；展开 ~ 路径；出错只 warn 不抛。
  */
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { readFileSync, mkdirSync, existsSync } from 'node:fs';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { logger } from '../utils/logger.js';
@@ -42,7 +43,9 @@ function writeIfChanged(filePath: string, content: string): boolean {
       if (existing === content) return false; // 内容相同，无需写入
     }
     mkdirSync(dirname(filePath), { recursive: true });
-    writeFileSync(filePath, content, 'utf-8');
+    // 原子写：目标是 ~/.claude/settings.json 这类被 CLI 并发读写的热配置，
+    // 裸写半截会让并发读者拿到坏 JSON 再整文件覆写回来（cjadk 事故同类）。
+    atomicWriteFileSync(filePath, content);
     return true;
   } catch (err: any) {
     throw new Error(`写入 ${filePath} 失败：${err.message}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@
  */
 import { execSync, spawnSync, spawn } from 'node:child_process';
 import { existsSync, mkdirSync, copyFileSync, readFileSync, writeFileSync, renameSync, readdirSync, readlinkSync, appendFileSync, statSync, unlinkSync } from 'node:fs';
+import { atomicWriteFileSync } from './utils/atomic-write.js';
 import { join, dirname, basename } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -181,7 +182,7 @@ function killDuplicatePm2GodDaemons(home: string = PM2_HOME): boolean {
   }
 
   try {
-    writeFileSync(pidFile, `${keepPid}\n`, 'utf-8');
+    atomicWriteFileSync(pidFile, `${keepPid}\n`);
   } catch { /* ignore */ }
 
   console.warn(`⚠️  检测到同一 PM2_HOME (${home}) 下存在多个 PM2 God Daemon，已清理重复实例；保留 pid ${keepPid}，移除: ${dupes.join(', ')}`);
@@ -3051,7 +3052,9 @@ async function relaySend(rest: string[], relayDir: string): Promise<void> {
     else if (FLAGS_VAL.has(tok) && i + 1 < rest.length) flags.push(tok, rest[++i]);
     // else dropped
   }
-  writeFileSync(join(relayDir, `${id}.req.json`), JSON.stringify({ contentFile: contentBase, attachments, flags }));
+  // 原子写：req.json 是 host watcher 的触发文件，rename 让它「完整出现」，
+  // watcher 永远不会读到半截 JSON（tmp 后缀不匹配 .req.json 过滤）。
+  atomicWriteFileSync(join(relayDir, `${id}.req.json`), JSON.stringify({ contentFile: contentBase, attachments, flags }));
 
   const resPath = join(relayDir, `${id}.res.json`);
   const deadlineMs = Date.now() + 120_000;
@@ -3916,7 +3919,8 @@ async function cmdDispatch(rest: string[]): Promise<void> {
         title: title.trim(),
         bots: built.mentionedOpenIds,
       };
-      writeFileSync(regPath, JSON.stringify(reg, null, 2));
+      // 原子写：共享 data dir，其它 bot 的 daemon 会并发读这个注册表。
+      atomicWriteFileSync(regPath, JSON.stringify(reg, null, 2));
     } catch { /* registry is best-effort */ }
 
     // 2. Optional repo prime — a plain TEXT message "@bot /repo <path>" (like a

--- a/src/core/role-resolver.ts
+++ b/src/core/role-resolver.ts
@@ -13,7 +13,8 @@
  * bot to adopt different personas in different Lark groups.
  */
 
-import { existsSync, readFileSync, statSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync, mkdirSync, unlinkSync } from 'node:fs';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { join, dirname } from 'node:path';
 import { config } from '../config.js';
 import { logger } from '../utils/logger.js';
@@ -126,7 +127,7 @@ export function writeRoleFile(larkAppId: string, chatId: string, content: string
   mkdirSync(dirname(filePath), { recursive: true });
   // Truncate by UTF-8 byte length, not JS string length
   const trimmed = truncateToByteLimit(content.trim());
-  writeFileSync(filePath, trimmed, 'utf-8');
+  atomicWriteFileSync(filePath, trimmed);
   cache.delete(cacheKey(larkAppId, chatId)); // invalidate so next read picks up the new content
   logger.info(`[role] wrote chat=${chatId} file=${filePath} (${Buffer.byteLength(trimmed, 'utf-8')} bytes)`);
 }
@@ -159,7 +160,7 @@ export function writeTeamRoleFile(larkAppId: string, content: string): void {
   const filePath = teamRoleFilePath(larkAppId);
   mkdirSync(dirname(filePath), { recursive: true });
   const trimmed = truncateToByteLimit(content.trim());
-  writeFileSync(filePath, trimmed, 'utf-8');
+  atomicWriteFileSync(filePath, trimmed);
   cache.delete(teamCacheKey(larkAppId));
   logger.info(`[role] wrote team app=${larkAppId} file=${filePath} (${Buffer.byteLength(trimmed, 'utf-8')} bytes)`);
 }

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -5,7 +5,8 @@
 import { fork, execSync, type ChildProcess } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
-import { readFileSync, writeFileSync, mkdirSync, existsSync, realpathSync } from 'node:fs';
+import { readFileSync, mkdirSync, existsSync, realpathSync } from 'node:fs';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { fileURLToPath } from 'node:url';
 import { ensureSkills, ensureAskSkill, ensurePluginSkills, removeGlobalBotmuxSkills } from '../skills/installer.js';
 import { installHook } from '../adapters/hook-installer.js';
@@ -828,7 +829,9 @@ function removeJsonKey(configPath: string, pathSegments: string[], keyToRemove: 
     }
     if (!node || typeof node !== 'object' || !(keyToRemove in node)) return false;
     delete node[keyToRemove];
-    writeFileSync(configPath, JSON.stringify(data, null, 2));
+    // 原子写：这里改的是外部 CLI 自己的热配置文件（如 ~/.claude.json），
+    // 裸写半截会弄坏 CLI 的状态。
+    atomicWriteFileSync(configPath, JSON.stringify(data, null, 2));
     return true;
   } catch {
     return false;
@@ -957,7 +960,9 @@ export function ensureClaudeFolderTrust(workingDir: string, stateJsonPath: strin
     if (entry.hasTrustDialogAccepted === true) return; // already trusted — skip write
 
     entry.hasTrustDialogAccepted = true;
-    writeFileSync(configPath, JSON.stringify(data, null, 2));
+    // 原子写：~/.claude.json 是 Claude Code 的热状态文件，所有并发 claude
+    // 实例都在读写，裸写半截会弄坏它们的状态。
+    atomicWriteFileSync(configPath, JSON.stringify(data, null, 2));
     logger.info(`[claude-trust] Pre-accepted folder trust for ${canonical}`);
   } catch (err) {
     logger.debug(`[claude-trust] seed failed (ignored): ${err}`);
@@ -2580,7 +2585,7 @@ function cleanupPersistentBackendSessions(backendType: 'tmux' | 'herdr', activeS
 
   try {
     mkdirSync(config.session.dataDir, { recursive: true });
-    writeFileSync(cliIdFile, currentCliId);
+    atomicWriteFileSync(cliIdFile, currentCliId);
   } catch (err) {
     logger.warn(`Failed to write ${cliIdFile}: ${err}`);
   }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,5 +1,6 @@
 import { execFileSync, type ChildProcess } from 'node:child_process';
-import { writeFileSync, readFileSync, existsSync, mkdirSync, unlinkSync, watch, readdirSync } from 'node:fs';
+import { readFileSync, existsSync, mkdirSync, unlinkSync, watch, readdirSync } from 'node:fs';
+import { atomicWriteFileSync } from './utils/atomic-write.js';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -579,12 +580,12 @@ function writePidFile(): void {
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
-  writeFileSync(getPidFile(), String(process.pid), 'utf-8');
+  atomicWriteFileSync(getPidFile(), String(process.pid));
   // Write breadcrumb so CLI tools (botmux list/delete) can find the active data dir
   const breadcrumb = join(homedir(), '.botmux', '.data-dir');
   try {
     mkdirSync(join(homedir(), '.botmux'), { recursive: true });
-    writeFileSync(breadcrumb, config.session.dataDir, 'utf-8');
+    atomicWriteFileSync(breadcrumb, config.session.dataDir);
   } catch { /* best effort */ }
 
   // Write a thin wrapper script so `botmux` is always in PATH for CLI sessions,
@@ -599,7 +600,9 @@ function writePidFile(): void {
     let existing = '';
     try { existing = readFileSync(wrapper, 'utf-8'); } catch { /* doesn't exist yet */ }
     if (existing !== content) {
-      writeFileSync(wrapper, content, { mode: 0o755 });
+      // 原子写：并发会话随时在 exec 这个 wrapper，半截脚本会让它们的
+      // `botmux send` 全体失败。
+      atomicWriteFileSync(wrapper, content, { mode: 0o755 });
       logger.info(`Wrapper script written: ${wrapper} → ${cliScript}`);
     }
   } catch (err: any) {
@@ -647,7 +650,8 @@ interface DaemonDescriptor {
 function writeDaemonDescriptor(d: DaemonDescriptor): void {
   mkdirSync(DAEMON_REGISTRY_DIR, { recursive: true });
   const fp = join(DAEMON_REGISTRY_DIR, `${d.larkAppId}.json`);
-  writeFileSync(fp, JSON.stringify(d), { mode: 0o600 });
+  // 原子写：dashboard 进程并发轮询读这些描述符（30s 心跳高频重写）。
+  atomicWriteFileSync(fp, JSON.stringify(d), { mode: 0o600 });
 }
 
 function removeDaemonDescriptor(larkAppId: string): void {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,8 +1,9 @@
 // src/dashboard.ts
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import {
-  readFileSync, writeFileSync, existsSync, chmodSync, mkdirSync, statSync,
+  readFileSync, existsSync, chmodSync, mkdirSync, statSync,
 } from 'node:fs';
+import { atomicWriteFileSync } from './utils/atomic-write.js';
 import { join, dirname, extname } from 'node:path';
 import { homedir } from 'node:os';
 import { randomBytes, createHmac } from 'node:crypto';
@@ -47,7 +48,7 @@ function loadOrCreateSecret(): string {
   if (existsSync(SECRET_PATH)) return readFileSync(SECRET_PATH, 'utf8').trim();
   const s = randomBytes(32).toString('base64url');
   mkdirSync(dirname(SECRET_PATH), { recursive: true });
-  writeFileSync(SECRET_PATH, s, { mode: 0o600 });
+  atomicWriteFileSync(SECRET_PATH, s, { mode: 0o600 });
   chmodSync(SECRET_PATH, 0o600);
   logger.info(`[dashboard] Generated dashboard secret at ${SECRET_PATH}`);
   return s;
@@ -1230,7 +1231,7 @@ listenWithProbe({
   log: (m) => logger.warn(`[dashboard] ${m}`),
 }).then((port) => {
   boundDashboardPort = port;
-  try { writeFileSync(PORT_PATH, String(port)); } catch (e) {
+  try { atomicWriteFileSync(PORT_PATH, String(port)); } catch (e) {
     logger.warn(`[dashboard] Failed to persist port to ${PORT_PATH}: ${(e as Error).message}`);
   }
   logger.info(`[dashboard] listening on ${config.dashboard.host}:${port}`);

--- a/src/dashboard/auth.ts
+++ b/src/dashboard/auth.ts
@@ -1,7 +1,8 @@
 import { randomBytes, createHmac, timingSafeEqual } from 'node:crypto';
 import {
-  readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync,
+  readFileSync, existsSync, mkdirSync, chmodSync,
 } from 'node:fs';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { dirname } from 'node:path';
 
 const NONCE_TTL_MS = 60_000;
@@ -78,7 +79,7 @@ export function loadPersistedToken(tokenPath: string): string | null {
 /** Persist the active dashboard token to `tokenPath` with 0600 perms. */
 export function persistToken(tokenPath: string, token: string): void {
   mkdirSync(dirname(tokenPath), { recursive: true });
-  writeFileSync(tokenPath, token, { mode: 0o600 });
+  atomicWriteFileSync(tokenPath, token, { mode: 0o600 });
   chmodSync(tokenPath, 0o600);
 }
 

--- a/src/dashboard/federation-spoke-api.ts
+++ b/src/dashboard/federation-spoke-api.ts
@@ -13,7 +13,8 @@
  */
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { randomBytes, randomUUID } from 'node:crypto';
-import { writeFileSync, readFileSync, mkdirSync, existsSync, unlinkSync } from 'node:fs';
+import { readFileSync, mkdirSync, existsSync, unlinkSync } from 'node:fs';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { join, dirname } from 'node:path';
 import { config } from '../config.js';
 import { jsonRes } from './workflow-api.js';
@@ -118,7 +119,7 @@ function writeTeamRole(dataDir: string, larkAppId: string, content: string): voi
   mkdirSync(dirname(fp), { recursive: true });
   let out = content.trim();
   while (Buffer.byteLength(out, 'utf-8') > MAX_ROLE_BYTES) out = out.slice(0, -1);
-  writeFileSync(fp, out, 'utf-8');
+  atomicWriteFileSync(fp, out);
 }
 
 async function readBody(req: IncomingMessage, maxBytes = 64 * 1024): Promise<any> {

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -4,7 +4,8 @@
  * Extracted from daemon.ts for modularity.
  */
 import * as Lark from '@larksuiteoapi/node-sdk';
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { readFileSync, mkdirSync, existsSync } from 'node:fs';
+import { atomicWriteFileSync } from '../../utils/atomic-write.js';
 import { join } from 'node:path';
 import { getBot, getAllBots, findOncallChat, getOwnerOpenId, type BotState } from '../../bot-registry.js';
 import { config } from '../../config.js';
@@ -67,7 +68,10 @@ export function writeBotInfoFile(dataDir: string): void {
     });
   }
 
-  writeFileSync(filePath, JSON.stringify([...map.values()], null, 2) + '\n');
+  // 原子写：一 bot 一 daemon，多个 daemon 进程并发 upsert 同一个 bots-info.json，
+  // 裸写会让并发读者看到半截 JSON。（read-merge-write 的 lost-update 仍存在，
+  // 但每个 daemon 周期性重写自己的条目，可自愈。）
+  atomicWriteFileSync(filePath, JSON.stringify([...map.values()], null, 2) + '\n');
 }
 
 /**
@@ -575,7 +579,7 @@ export function updateBotOpenIdCrossRef(
   if (changed) {
     try {
       if (!existsSync(dataDir)) mkdirSync(dataDir, { recursive: true });
-      writeFileSync(fp, JSON.stringify(existing, null, 2) + '\n');
+      atomicWriteFileSync(fp, JSON.stringify(existing, null, 2) + '\n');
       logger.debug(`Updated bot open_id cross-ref for ${larkAppId}: ${JSON.stringify(existing)}`);
     } catch (err) {
       logger.debug(`Failed to write bot open_id cross-ref: ${err}`);

--- a/src/services/message-queue.ts
+++ b/src/services/message-queue.ts
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync, appendFileSync, mkdirSync, existsSync } from 'node:fs';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { join } from 'node:path';
 import { config } from '../config.js';
 import { logger } from '../utils/logger.js';
@@ -45,7 +46,8 @@ function readOffset(rootMessageId: string): number {
 }
 
 function writeOffset(rootMessageId: string, offset: number): void {
-  writeFileSync(getOffsetFile(rootMessageId), String(offset), 'utf-8');
+  // 原子写：offset 半截（如 "12" 只写出 "1"）会导致重启后消息重读或跳读。
+  atomicWriteFileSync(getOffsetFile(rootMessageId), String(offset));
 }
 
 /** Reset offset to re-read all messages from a given byte position (0 = beginning). */

--- a/src/skills/installer.ts
+++ b/src/skills/installer.ts
@@ -1,4 +1,5 @@
-import { writeFileSync, mkdirSync, existsSync, readFileSync, rmSync, readdirSync, statSync } from 'node:fs';
+import { mkdirSync, existsSync, readFileSync, rmSync, readdirSync, statSync } from 'node:fs';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { logger } from '../utils/logger.js';
@@ -34,7 +35,7 @@ export function ensurePluginSkills(cliId: string, pluginDir: string | undefined)
   try {
     mkdirSync(manifestDir, { recursive: true });
     if (!(existsSync(manifestFile) && readFileSync(manifestFile, 'utf-8') === PLUGIN_MANIFEST)) {
-      writeFileSync(manifestFile, PLUGIN_MANIFEST, 'utf-8');
+      atomicWriteFileSync(manifestFile, PLUGIN_MANIFEST);
       logger.info(`[skills] Wrote plugin manifest for ${cliId} → ${manifestFile}`);
     }
   } catch (err: any) {
@@ -95,7 +96,7 @@ export function ensureAskSkill(cliId: string, skillsDir: string | undefined, ins
     if (install) {
       if (existsSync(skillFile) && readFileSync(skillFile, 'utf-8') === ASK_SKILL) return;
       mkdirSync(skillDir, { recursive: true });
-      writeFileSync(skillFile, ASK_SKILL, 'utf-8');
+      atomicWriteFileSync(skillFile, ASK_SKILL);
       logger.info(`[skills] Installed ${ASK_SKILL_NAME} (无 hook 接管，兜底) for ${cliId} → ${skillFile}`);
     } else {
       if (!existsSync(skillDir)) return;
@@ -130,7 +131,8 @@ export function ensureSkills(cliId: string, skillsDir: string | undefined): void
         if (current === skill.content) continue;
       }
       mkdirSync(skillDir, { recursive: true });
-      writeFileSync(skillFile, skill.content, 'utf-8');
+      // 原子写：多个 daemon 启动时并发刷同一份共享 skill 文件，CLI spawn 同时在读。
+      atomicWriteFileSync(skillFile, skill.content);
       logger.info(`[skills] Installed ${skill.name} for ${cliId} → ${skillFile}`);
     } catch (err: any) {
       logger.warn(`[skills] Failed to install ${skill.name} for ${cliId}: ${err.message}`);

--- a/src/utils/atomic-write.ts
+++ b/src/utils/atomic-write.ts
@@ -1,0 +1,74 @@
+/**
+ * atomic-write.ts — 原子写文件统一入口（tmp + rename）。
+ *
+ * 为什么需要它：裸 writeFileSync 在「写一半时被并发读 / 进程崩溃」下会让读者
+ * 看到半截内容（torn read），对跨进程共享的 JSON 状态文件、被 watcher 当触发
+ * 器消费的文件、被并发 exec 的脚本都是真实事故源（参考 cjadk settings.json
+ * 覆盖事故）。POSIX rename(2) 同文件系统内原子替换：读者要么看到旧文件、要么
+ * 看到完整新文件，永远不会看到中间态。
+ *
+ * tmp 命名带 pid + 随机后缀：多个进程并发写同一目标（如 30 个 daemon 齐写
+ * bots-info.json）时，固定 `.tmp` 名会互相撕对方的半成品再 rename 上去——
+ * 唯一名让每个写者各写各的，rename 收敛为 last-writer-wins。
+ *
+ * 约束：tmp 与目标同目录（同 fs 才保证 rename 原子且不跨设备失败）；失败时
+ * best-effort 清理 tmp，绝不破坏旧文件。
+ */
+import { writeFileSync, renameSync, unlinkSync } from 'node:fs';
+import { promises as fsp } from 'node:fs';
+import { randomBytes } from 'node:crypto';
+
+export interface AtomicWriteOptions {
+  /** 文件权限（如 0o600 密钥 / 0o755 可执行脚本）。设置在 tmp 上，rename 后保留。 */
+  mode?: number;
+  /** 文本编码，默认 utf-8（data 为 Buffer 时忽略）。 */
+  encoding?: BufferEncoding;
+}
+
+/** 生成与目标同目录的唯一 tmp 路径。 */
+function tmpPathFor(filePath: string): string {
+  return `${filePath}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
+}
+
+/**
+ * 原子写（同步）：写同目录唯一 tmp → rename 覆盖目标。
+ * 任何失败都不会影响目标文件的旧内容；tmp 残留会被 best-effort 清理。
+ */
+export function atomicWriteFileSync(
+  filePath: string,
+  data: string | Buffer,
+  options: AtomicWriteOptions = {},
+): void {
+  const tmp = tmpPathFor(filePath);
+  try {
+    writeFileSync(tmp, data, {
+      encoding: typeof data === 'string' ? (options.encoding ?? 'utf-8') : undefined,
+      ...(options.mode !== undefined ? { mode: options.mode } : {}),
+    });
+    renameSync(tmp, filePath);
+  } catch (err) {
+    try { unlinkSync(tmp); } catch { /* tmp 可能根本没写出来 */ }
+    throw err;
+  }
+}
+
+/**
+ * 原子写（异步）：语义同 atomicWriteFileSync，给 async 调用链（workflow 运行时等）。
+ */
+export async function atomicWriteFile(
+  filePath: string,
+  data: string | Buffer,
+  options: AtomicWriteOptions = {},
+): Promise<void> {
+  const tmp = tmpPathFor(filePath);
+  try {
+    await fsp.writeFile(tmp, data, {
+      encoding: typeof data === 'string' ? (options.encoding ?? 'utf-8') : undefined,
+      ...(options.mode !== undefined ? { mode: options.mode } : {}),
+    });
+    await fsp.rename(tmp, filePath);
+  } catch (err) {
+    try { await fsp.unlink(tmp); } catch { /* tmp 可能根本没写出来 */ }
+    throw err;
+  }
+}

--- a/src/utils/atomic-write.ts
+++ b/src/utils/atomic-write.ts
@@ -20,13 +20,18 @@
  * 是穿透链接写真实目标的。目标不存在时退而解析父目录（覆盖「软链目录里建新
  * 文件」），悬空 symlink 这种病态形态不特判。
  */
-import { writeFileSync, renameSync, unlinkSync, realpathSync } from 'node:fs';
+import { writeFileSync, renameSync, unlinkSync, realpathSync, chmodSync } from 'node:fs';
 import { promises as fsp } from 'node:fs';
 import { randomBytes } from 'node:crypto';
 import { dirname, basename, join } from 'node:path';
 
 export interface AtomicWriteOptions {
-  /** 文件权限（如 0o600 密钥 / 0o755 可执行脚本）。设置在 tmp 上，rename 后保留。 */
+  /**
+   * 文件权限（如 0o600 密钥 / 0o755 可执行脚本）。设置在 tmp 上，rename 后保留。
+   * 严格生效：creation mode 会被 umask 截断（umask 077 下 0o755 落成 0o700），
+   * 故写后再显式 chmod 到精确值——创建时仍传 mode 保证文件从不以比目标更宽的
+   * 权限存在过（截断只会更紧），chmod 再放宽到精确值。
+   */
   mode?: number;
   /** 文本编码，默认 utf-8（data 为 Buffer 时忽略）。 */
   encoding?: BufferEncoding;
@@ -64,6 +69,7 @@ export function atomicWriteFileSync(
       encoding: typeof data === 'string' ? (options.encoding ?? 'utf-8') : undefined,
       ...(options.mode !== undefined ? { mode: options.mode } : {}),
     });
+    if (options.mode !== undefined) chmodSync(tmp, options.mode);
     renameSync(tmp, filePath);
   } catch (err) {
     try { unlinkSync(tmp); } catch { /* tmp 可能根本没写出来 */ }
@@ -86,6 +92,7 @@ export async function atomicWriteFile(
       encoding: typeof data === 'string' ? (options.encoding ?? 'utf-8') : undefined,
       ...(options.mode !== undefined ? { mode: options.mode } : {}),
     });
+    if (options.mode !== undefined) await fsp.chmod(tmp, options.mode);
     await fsp.rename(tmp, filePath);
   } catch (err) {
     try { await fsp.unlink(tmp); } catch { /* tmp 可能根本没写出来 */ }

--- a/src/utils/atomic-write.ts
+++ b/src/utils/atomic-write.ts
@@ -13,10 +13,17 @@
  *
  * 约束：tmp 与目标同目录（同 fs 才保证 rename 原子且不跨设备失败）；失败时
  * best-effort 清理 tmp，绝不破坏旧文件。
+ *
+ * symlink：写前把目标解析到真实路径（realpath）再 rename。否则目标若是
+ * symlink（如 dotfiles 用户软链管理的 ~/.claude/settings.json），rename 会把
+ * 链接本体替换成普通文件——链接断掉、真实目标变孤儿；而被换掉的 in-place 写
+ * 是穿透链接写真实目标的。目标不存在时退而解析父目录（覆盖「软链目录里建新
+ * 文件」），悬空 symlink 这种病态形态不特判。
  */
-import { writeFileSync, renameSync, unlinkSync } from 'node:fs';
+import { writeFileSync, renameSync, unlinkSync, realpathSync } from 'node:fs';
 import { promises as fsp } from 'node:fs';
 import { randomBytes } from 'node:crypto';
+import { dirname, basename, join } from 'node:path';
 
 export interface AtomicWriteOptions {
   /** 文件权限（如 0o600 密钥 / 0o755 可执行脚本）。设置在 tmp 上，rename 后保留。 */
@@ -30,6 +37,17 @@ function tmpPathFor(filePath: string): string {
   return `${filePath}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
 }
 
+/** 解析 symlink 到真实路径；目标不存在时解析父目录，保持 in-place 写的穿透语义。 */
+function resolveRealPathSync(filePath: string): string {
+  try { return realpathSync(filePath); } catch { /* 目标尚不存在 */ }
+  try { return join(realpathSync(dirname(filePath)), basename(filePath)); } catch { return filePath; }
+}
+
+async function resolveRealPath(filePath: string): Promise<string> {
+  try { return await fsp.realpath(filePath); } catch { /* 目标尚不存在 */ }
+  try { return join(await fsp.realpath(dirname(filePath)), basename(filePath)); } catch { return filePath; }
+}
+
 /**
  * 原子写（同步）：写同目录唯一 tmp → rename 覆盖目标。
  * 任何失败都不会影响目标文件的旧内容；tmp 残留会被 best-effort 清理。
@@ -39,6 +57,7 @@ export function atomicWriteFileSync(
   data: string | Buffer,
   options: AtomicWriteOptions = {},
 ): void {
+  filePath = resolveRealPathSync(filePath);
   const tmp = tmpPathFor(filePath);
   try {
     writeFileSync(tmp, data, {
@@ -60,6 +79,7 @@ export async function atomicWriteFile(
   data: string | Buffer,
   options: AtomicWriteOptions = {},
 ): Promise<void> {
+  filePath = await resolveRealPath(filePath);
   const tmp = tmpPathFor(filePath);
   try {
     await fsp.writeFile(tmp, data, {

--- a/src/utils/user-token.ts
+++ b/src/utils/user-token.ts
@@ -8,7 +8,8 @@
  * OAuth login via /login command writes to botmux's own token file.
  * Auto-refreshes expired access_token using refresh_token.
  */
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { readFileSync, mkdirSync, existsSync } from 'node:fs';
+import { atomicWriteFileSync } from './atomic-write.js';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
@@ -86,7 +87,7 @@ function saveTokenForApp(token: TokenStore, appId: string): void {
   const path = tokenPathForApp(appId);
   const dir = dirname(path);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  writeFileSync(path, JSON.stringify(token, null, 2));
+  atomicWriteFileSync(path, JSON.stringify(token, null, 2));
 }
 
 function isValid(isoDate: string): boolean {

--- a/src/utils/user-token.ts
+++ b/src/utils/user-token.ts
@@ -87,7 +87,9 @@ function saveTokenForApp(token: TokenStore, appId: string): void {
   const path = tokenPathForApp(appId);
   const dir = dirname(path);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  atomicWriteFileSync(path, JSON.stringify(token, null, 2));
+  // 0600：OAuth token 是密钥，且原子写每次重建文件，不传 mode 会把用户
+  // 手动收紧过的权限在自动刷新时悄悄改回 0644。
+  atomicWriteFileSync(path, JSON.stringify(token, null, 2), { mode: 0o600 });
 }
 
 function isValid(isoDate: string): boolean {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -14,6 +14,7 @@
  */
 import { randomBytes } from 'node:crypto';
 import { mkdirSync, writeFileSync, unlinkSync, existsSync, statSync, readdirSync, readlinkSync, readFileSync, watch as fsWatch, createWriteStream, type FSWatcher, type WriteStream } from 'node:fs';
+import { atomicWriteFileSync } from './utils/atomic-write.js';
 import { isAbsolute, join } from 'node:path';
 import { drainTranscript, joinAssistantText, findJsonlContainingFingerprint, findJsonlsContainingExactContent, findLatestJsonl, extractLastAssistantTurn, stringifyUserContent, extractTurnStartText, splitTranscriptEventsByCutoff, type TranscriptEvent } from './services/claude-transcript.js';
 import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint } from './services/bridge-turn-queue.js';
@@ -119,7 +120,9 @@ let zellijAttachCfgPath: string | null = null;
 function ensureZellijAttachConfig(): string {
   if (zellijAttachCfgPath) return zellijAttachCfgPath;
   const p = join(process.env.SESSION_DATA_DIR ?? '/tmp', '.zellij-web-attach.kdl');
-  try { writeFileSync(p, ZELLIJ_CONFIG_KDL); } catch { /* best effort */ }
+  // 原子写：同一 data dir 下多个 worker 进程会写同一路径（内容相同），
+  // 裸写并发互踩会让 attach 客户端读到半截 kdl。
+  try { atomicWriteFileSync(p, ZELLIJ_CONFIG_KDL); } catch { /* best effort */ }
   zellijAttachCfgPath = p;
   return p;
 }
@@ -164,7 +167,8 @@ let currentBotmuxTurnId: string | undefined;
 function writeCliPidMarker(): void {
   if (!cliPidMarker || !sessionId) return;
   try {
-    writeFileSync(cliPidMarker, JSON.stringify({ sessionId, turnId: currentBotmuxTurnId ?? null }));
+    // 原子写：daemon 侧（killStalePids 等）随时读这个 marker JSON。
+    atomicWriteFileSync(cliPidMarker, JSON.stringify({ sessionId, turnId: currentBotmuxTurnId ?? null }));
   } catch (err: any) {
     log(`Failed to update CLI PID marker: ${err?.message ?? err}`);
   }

--- a/src/workflows/attempt-resume.ts
+++ b/src/workflows/attempt-resume.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'node:crypto';
-import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -457,7 +458,7 @@ export class AttemptResumeManager {
       ...(status === 'closed' ? { closedAt: now, closeReason: entry.closeReason } : {}),
     };
     mkdirSync(dirname(entry.sidecarPath), { recursive: true });
-    writeFileSync(entry.sidecarPath, JSON.stringify(sidecar, null, 2), 'utf-8');
+    atomicWriteFileSync(entry.sidecarPath, JSON.stringify(sidecar, null, 2));
   }
 
   private resumeUrl(webPort: number, writeToken: string): string {

--- a/src/workflows/blob.ts
+++ b/src/workflows/blob.ts
@@ -11,6 +11,7 @@ import { createHash } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 
+import { atomicWriteFile } from '../utils/atomic-write.js';
 import { canonicalJsonStringify } from './definition.js';
 import type { EventLog } from './events/append.js';
 import type { OutputRef } from './events/payloads.js';
@@ -32,7 +33,8 @@ export async function writeBlob(
 ): Promise<OutputRef> {
   const hash = createHash('sha256').update(buf).digest('hex');
   const path = join(log.blobDir, hash);
-  await fs.writeFile(path, buf);
+  // 原子写：路径即 sha256，裸写半截会留下「名字对、内容错」的 blob。
+  await atomicWriteFile(path, buf);
   return {
     outputHash: `sha256:${hash}`,
     outputPath: path,

--- a/src/workflows/daemon-spawn.ts
+++ b/src/workflows/daemon-spawn.ts
@@ -21,7 +21,8 @@
 
 import { fork, type ChildProcess } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { appendFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -568,10 +569,10 @@ function writeAttemptTerminalSidecar(
       updatedAt: now,
       ...(status === 'closed' ? { closedAt: now } : {}),
     };
-    writeFileSync(
+    // 原子写：daemon 重启后 attempt-resume 会读这个 sidecar 恢复会话。
+    atomicWriteFileSync(
       join(dir, ATTEMPT_TERMINAL_SIDECAR),
       JSON.stringify(sidecar, null, 2),
-      'utf-8',
     );
   } catch (err) {
     appendAttemptLog(

--- a/src/workflows/effect-input.ts
+++ b/src/workflows/effect-input.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 
+import { atomicWriteFile } from '../utils/atomic-write.js';
 import type { EventLog } from './events/append.js';
 
 export async function writeEffectInputSidecar(
@@ -11,7 +12,7 @@ export async function writeEffectInputSidecar(
 ): Promise<string> {
   const dir = await effectInputDir(log, activityId, attemptId);
   const path = join(dir, 'effect-input.json');
-  await fs.writeFile(path, JSON.stringify(input, null, 2), 'utf-8');
+  await atomicWriteFile(path, JSON.stringify(input, null, 2));
   return path;
 }
 

--- a/src/workflows/loader.ts
+++ b/src/workflows/loader.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
+import { atomicWriteFile } from '../utils/atomic-write.js';
 import {
   canonicalJsonStringify,
   parseWorkflowDefinition,
@@ -53,7 +54,7 @@ export async function snapshotWorkflowDefinition(
 ): Promise<string> {
   const dir = await getOrEnsureRunDir(runId, opts);
   const path = join(dir, 'workflow.json');
-  await fs.writeFile(path, canonicalJsonStringify(def), 'utf-8');
+  await atomicWriteFile(path, canonicalJsonStringify(def));
   return path;
 }
 
@@ -96,7 +97,7 @@ export async function writeRunChatBinding(
 ): Promise<string> {
   const dir = await getOrEnsureRunDir(runId, opts);
   const path = join(dir, 'chat-binding.json');
-  await fs.writeFile(path, JSON.stringify(binding, null, 2), 'utf-8');
+  await atomicWriteFile(path, JSON.stringify(binding, null, 2));
   return path;
 }
 

--- a/src/workflows/run-init.ts
+++ b/src/workflows/run-init.ts
@@ -17,6 +17,7 @@ import { createHash } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 
+import { atomicWriteFile } from '../utils/atomic-write.js';
 import { loadBotConfigs } from '../bot-registry.js';
 import { canonicalJsonStringify, computeRevisionId } from './definition.js';
 import type { WorkflowDefinition } from './definition.js';
@@ -108,7 +109,8 @@ async function writeRunInputBlob(
   const hash = createHash('sha256').update(buf).digest('hex');
   const path = join(log.blobDir, hash);
   // Content-addressed: same input ⇒ same path; re-writes are harmless.
-  await fs.writeFile(path, buf);
+  // 原子写：路径即 sha256，裸写半截会留下「名字对、内容错」的 blob。
+  await atomicWriteFile(path, buf);
   return {
     outputHash: `sha256:${hash}`,
     outputPath: path,

--- a/src/workflows/runtime.ts
+++ b/src/workflows/runtime.ts
@@ -19,6 +19,7 @@
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 
+import { atomicWriteFile } from '../utils/atomic-write.js';
 import { writeEffectInputSidecar } from './effect-input.js';
 import { writeBlob, writeJsonBlob } from './blob.js';
 import type { WorkflowDefinition } from './definition.js';
@@ -231,7 +232,7 @@ async function writeSessionSidecar(
 ): Promise<void> {
   const dir = await attemptSidecarDir(log, activityId, attemptId);
   const file = join(dir, 'session.json');
-  await fs.writeFile(file, JSON.stringify(session, null, 2), 'utf-8');
+  await atomicWriteFile(file, JSON.stringify(session, null, 2));
 }
 
 function withAttemptLogPath(

--- a/test/atomic-write.test.ts
+++ b/test/atomic-write.test.ts
@@ -1,0 +1,108 @@
+/**
+ * atomic-write.test.ts — utils/atomic-write 的单元测试。
+ *
+ * 覆盖：基本写入/覆盖、Buffer、mode 透传、写失败不破坏旧文件、tmp 清理、
+ * 并发写同一目标时读者永远看到完整内容（同进程并发近似模拟多进程场景）。
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, statSync, readdirSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { atomicWriteFileSync, atomicWriteFile } from '../src/utils/atomic-write.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'atomic-write-test-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('atomicWriteFileSync', () => {
+  it('写入新文件', () => {
+    const fp = join(dir, 'a.json');
+    atomicWriteFileSync(fp, '{"x":1}');
+    expect(readFileSync(fp, 'utf-8')).toBe('{"x":1}');
+  });
+
+  it('覆盖已有文件', () => {
+    const fp = join(dir, 'a.json');
+    writeFileSync(fp, 'old');
+    atomicWriteFileSync(fp, 'new');
+    expect(readFileSync(fp, 'utf-8')).toBe('new');
+  });
+
+  it('支持 Buffer', () => {
+    const fp = join(dir, 'b.bin');
+    const buf = Buffer.from([0, 1, 2, 255]);
+    atomicWriteFileSync(fp, buf);
+    expect(readFileSync(fp)).toEqual(buf);
+  });
+
+  it('mode 透传（0600 密钥 / 0755 可执行）', () => {
+    const secret = join(dir, 'secret');
+    atomicWriteFileSync(secret, 's3cret', { mode: 0o600 });
+    expect(statSync(secret).mode & 0o777).toBe(0o600);
+
+    const script = join(dir, 'wrapper');
+    atomicWriteFileSync(script, '#!/bin/sh\n', { mode: 0o755 });
+    expect(statSync(script).mode & 0o777).toBe(0o755);
+  });
+
+  it('不留 tmp 残骸', () => {
+    const fp = join(dir, 'a.json');
+    atomicWriteFileSync(fp, 'data');
+    atomicWriteFileSync(fp, 'data2');
+    expect(readdirSync(dir)).toEqual(['a.json']);
+  });
+
+  it('写失败（目录不存在）不破坏目标、抛错、不留 tmp', () => {
+    const fp = join(dir, 'no-such-dir', 'a.json');
+    expect(() => atomicWriteFileSync(fp, 'data')).toThrow();
+    expect(existsSync(join(dir, 'no-such-dir'))).toBe(false);
+    expect(readdirSync(dir)).toEqual([]);
+  });
+
+  it('并发写者各用唯一 tmp，互不相撕', () => {
+    // 同一目标连续/交错写多次后内容必须是某一次写入的完整值，
+    // 且目录里没有 tmp 残留（唯一名保证两次写不会共用 tmp）。
+    const fp = join(dir, 'shared.json');
+    const payloads = Array.from({ length: 20 }, (_, i) => JSON.stringify({ writer: i, data: 'x'.repeat(1000) }));
+    for (const p of payloads) atomicWriteFileSync(fp, p);
+    expect(payloads).toContain(readFileSync(fp, 'utf-8'));
+    expect(readdirSync(dir)).toEqual(['shared.json']);
+  });
+});
+
+describe('atomicWriteFile (async)', () => {
+  it('写入与覆盖', async () => {
+    const fp = join(dir, 'a.json');
+    await atomicWriteFile(fp, 'v1');
+    await atomicWriteFile(fp, 'v2');
+    expect(readFileSync(fp, 'utf-8')).toBe('v2');
+    expect(readdirSync(dir)).toEqual(['a.json']);
+  });
+
+  it('并发 async 写同一目标，结果是某一次的完整内容', async () => {
+    const fp = join(dir, 'c.json');
+    const payloads = Array.from({ length: 10 }, (_, i) => JSON.stringify({ writer: i, pad: 'y'.repeat(5000) }));
+    await Promise.all(payloads.map((p) => atomicWriteFile(fp, p)));
+    expect(payloads).toContain(readFileSync(fp, 'utf-8'));
+    expect(readdirSync(dir)).toEqual(['c.json']);
+  });
+
+  it('写失败不破坏旧文件', async () => {
+    const fp = join(dir, 'no-such-dir', 'a.json');
+    await expect(atomicWriteFile(fp, 'data')).rejects.toThrow();
+  });
+
+  it('Buffer 内容往返一致（content-addressed blob 场景）', async () => {
+    const fp = join(dir, 'blob');
+    const buf = Buffer.from('blob-content-'.repeat(100));
+    await atomicWriteFile(fp, buf);
+    expect(readFileSync(fp)).toEqual(buf);
+  });
+});

--- a/test/atomic-write.test.ts
+++ b/test/atomic-write.test.ts
@@ -53,6 +53,17 @@ describe('atomicWriteFileSync', () => {
     expect(statSync(script).mode & 0o777).toBe(0o755);
   });
 
+  it('mode 不被 umask 截断（umask 077 下 0755 仍精确生效）', () => {
+    const prev = process.umask(0o077);
+    try {
+      const fp = join(dir, 'wrapper-strict');
+      atomicWriteFileSync(fp, '#!/bin/sh\n', { mode: 0o755 });
+      expect(statSync(fp).mode & 0o777).toBe(0o755);
+    } finally {
+      process.umask(prev);
+    }
+  });
+
   it('不留 tmp 残骸', () => {
     const fp = join(dir, 'a.json');
     atomicWriteFileSync(fp, 'data');
@@ -143,5 +154,16 @@ describe('atomicWriteFile (async)', () => {
 
     expect(lstatSync(link).isSymbolicLink()).toBe(true);
     expect(readFileSync(real, 'utf-8')).toBe('new');
+  });
+
+  it('mode 不被 umask 截断（async 版）', async () => {
+    const prev = process.umask(0o077);
+    try {
+      const fp = join(dir, 'strict');
+      await atomicWriteFile(fp, 'x', { mode: 0o755 });
+      expect(statSync(fp).mode & 0o777).toBe(0o755);
+    } finally {
+      process.umask(prev);
+    }
   });
 });

--- a/test/atomic-write.test.ts
+++ b/test/atomic-write.test.ts
@@ -2,10 +2,11 @@
  * atomic-write.test.ts — utils/atomic-write 的单元测试。
  *
  * 覆盖：基本写入/覆盖、Buffer、mode 透传、写失败不破坏旧文件、tmp 清理、
- * 并发写同一目标时读者永远看到完整内容（同进程并发近似模拟多进程场景）。
+ * 并发写同一目标时读者永远看到完整内容（同进程并发近似模拟多进程场景）、
+ * symlink 目标穿透写真实文件不替换链接本体。
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, readFileSync, rmSync, statSync, readdirSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, statSync, readdirSync, writeFileSync, existsSync, symlinkSync, lstatSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -66,6 +67,32 @@ describe('atomicWriteFileSync', () => {
     expect(readdirSync(dir)).toEqual([]);
   });
 
+  it('目标是 symlink 时穿透写真实文件，不替换链接本体（dotfiles 场景）', () => {
+    // 模拟 dotfiles：~/.claude/settings.json -> ~/dotfiles/claude-settings.json
+    const real = join(dir, 'real-settings.json');
+    writeFileSync(real, '{"old":true}');
+    const link = join(dir, 'settings.json');
+    symlinkSync(real, link);
+
+    atomicWriteFileSync(link, '{"new":true}');
+
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);   // 链接本体还在
+    expect(readFileSync(real, 'utf-8')).toBe('{"new":true}'); // 真实目标被更新
+    expect(readFileSync(link, 'utf-8')).toBe('{"new":true}');
+  });
+
+  it('父目录是 symlink、目标尚不存在时，新文件落在真实目录', () => {
+    const realDir = join(dir, 'real-dir');
+    mkdirSync(realDir);
+    const linkDir = join(dir, 'link-dir');
+    symlinkSync(realDir, linkDir);
+
+    atomicWriteFileSync(join(linkDir, 'new.json'), '{"x":1}');
+
+    expect(readFileSync(join(realDir, 'new.json'), 'utf-8')).toBe('{"x":1}');
+    expect(lstatSync(linkDir).isSymbolicLink()).toBe(true);
+  });
+
   it('并发写者各用唯一 tmp，互不相撕', () => {
     // 同一目标连续/交错写多次后内容必须是某一次写入的完整值，
     // 且目录里没有 tmp 残留（唯一名保证两次写不会共用 tmp）。
@@ -104,5 +131,17 @@ describe('atomicWriteFile (async)', () => {
     const buf = Buffer.from('blob-content-'.repeat(100));
     await atomicWriteFile(fp, buf);
     expect(readFileSync(fp)).toEqual(buf);
+  });
+
+  it('目标是 symlink 时穿透写真实文件，不替换链接本体', async () => {
+    const real = join(dir, 'real.json');
+    writeFileSync(real, 'old');
+    const link = join(dir, 'link.json');
+    symlinkSync(real, link);
+
+    await atomicWriteFile(link, 'new');
+
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    expect(readFileSync(real, 'utf-8')).toBe('new');
   });
 });

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -27,6 +27,11 @@ vi.mock('node:fs', async (importOriginal) => {
     mkdirSync: vi.fn(),
   };
 });
+// bots-info.json 走原子写 helper；这里直接代理到 mockWriteFileSync，
+// 断言面（最终路径 + 完整内容）与裸 writeFileSync 时代保持一致。
+vi.mock('../src/utils/atomic-write.js', () => ({
+  atomicWriteFileSync: (...args: any[]) => mockWriteFileSync(...args),
+}));
 
 const mockGetBot = vi.fn();
 const mockGetAllBots = vi.fn(() => []);

--- a/test/message-queue.test.ts
+++ b/test/message-queue.test.ts
@@ -28,6 +28,17 @@ vi.mock('node:fs', () => ({
     if (!(p in files)) throw new Error(`ENOENT: ${p}`);
     return files[p];
   },
+  // atomic-write（tmp+rename）会经过这两个调用
+  renameSync: (from: string, to: string) => {
+    if (!(from in files)) throw new Error(`ENOENT: ${from}`);
+    files[to] = files[from];
+    delete files[from];
+  },
+  unlinkSync: (p: string) => {
+    if (!(p in files)) throw new Error(`ENOENT: ${p}`);
+    delete files[p];
+  },
+  promises: {},
 }));
 
 vi.mock('../src/config.js', () => ({


### PR DESCRIPTION
## 背景

申晗要求：梳理 botmux 中的非原子写操作，在不破坏逻辑的前提下改成原子写。直接动机是 cjadk 非原子写 + 并发 torn-read 把 ~/.claude/settings.json 砸到只剩 hooks 的事故——botmux 自己也有同类写法。

## 审计结论

全仓 155 个写文件点逐一分类：

- **已原子**（不动）：~25 个 services/*-store、bots.json（setup/bots-store）、sessions-*.json、global-config、maintenance、identity-cache、daemon-heartbeat 等，均已是 tmp+rename
- **不适用**（不动）：append-only（usage-ledger/trigger-log/queue jsonl/attempt log）、mkdtemp 私有目录、写完才交给下游的顺序流（ecosystem.config.json→pm2、patch→upload、plist→daemon-reload）、流式媒体下载
- **本 PR 改造**：真正裸写共享状态的 ~30 处

## 改动

新增 `src/utils/atomic-write.ts`：`atomicWriteFileSync` / `atomicWriteFile`（async）。同目录唯一 tmp（**pid+随机后缀**——多 daemon 并发写同一目标时固定 `.tmp` 名会互相撕半成品）→ rename 原子替换 → 失败 best-effort 清理 tmp、绝不破坏旧文件；mode 透传（0600 密钥 / 0755 脚本）。

按风险分类的转换点：

**A. 跨进程共享状态**
- daemon.ts：dashboard-daemons 心跳描述符（dashboard 30s 并发轮询读）、全局 botmux wrapper 脚本（重写时 ~35 会话在并发 exec，torn=全员 botmux 挂）、pid/breadcrumb
- event-dispatcher.ts：bots-info.json（30 daemon 并发 upsert）+ open_id cross-ref
- worker-pool.ts：removeJsonKey / ensureClaudeFolderTrust（写 ~/.claude.json 类外部热文件）+ cliIdFile
- hook-installer.ts：writeIfChanged（~/.claude/settings.json，cjadk 事故同类）
- message-queue.ts offset（半截=消息重读/跳读）、role-resolver 角色文件、user-token、dashboard secret/token/port（保 0600）、federation-spoke 角色、attempt-resume/daemon-spawn sidecar、cli.ts pm2 pid 去重 + orchestrate-dispatch.json、worker.ts cliPidMarker + zellij attach 配置

**B. 触发器文件**（rename 让它「完整出现」，watcher/轮询方永远读到完整 JSON）
- cli.ts 沙盒 relay req.json（host watcher 按 `.req.json` 后缀过滤，tmp 名不会误触发）
- sandbox.ts outbox res.json（CLI existsSync 轮询）

**C. 多 daemon 并发写的共享插件/skill**
- skills/installer.ts（SKILL.md/manifest，daemon 齐写 CLI 同读）、coco-ask-plugin.ts

**D. workflow run 状态**（崩溃后 resume 会读）
- loader/runtime/effect-input/run-init/blob（blob 是 content-addressed，裸写半截会留「名字对、内容错」的 blob）

## 测试

- 新增 test/atomic-write.test.ts 11 例：写入/覆盖/Buffer/mode 透传/失败不破坏旧文件/无 tmp 残留/并发完整性（sync+async）
- 适配 2 个既有测试的 node:fs mock（补 renameSync/unlinkSync；event-dispatcher 代理 atomic-write 保持断言面不变）
- tsc 0 错误；unit 全量 4258/4261，3 fail + 1 error 与 origin/master 基线逐一比对**完全一致**（session-lifecycle-hooks 1 + transfer-session 2 + tokenUsage unhandled rejection，均为既有问题，已用干净 master src 复跑实证）