### PR TITLE
feat(sandbox): 各 CLI 鉴权目录沙盒内真实 rw 绑定（修登录态丢失）

### DIFF
--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -128,6 +128,10 @@ export interface SandboxPlan {
   hideDirs: string[];
   /** Per-bot privacy masks: files blanked with a read-only empty placeholder. */
   hideFiles: { path: string; empty: string }[];
+  /** CLI auth/login paths kept REAL + writable (bound rw over the isolated home so
+   *  the CLI's token refresh / login persists — unlike project edits which are
+   *  isolated). Resolved + existence-filtered by prepareSandbox. */
+  authReal?: string[];
   /** Keep network egress. File-only scope ⇒ default true (npm/pip/git work). */
   net?: boolean;
 }
@@ -150,6 +154,9 @@ export function buildSandboxArgs(plan: SandboxPlan): string[] {
   // Write-isolated home + project (overlay merged: reads=real lower, writes=upper).
   a.push('--bind', plan.homeMerged, plan.home);
   a.push('--bind', plan.projectMerged, plan.projectMount);
+  // CLI auth/login dirs kept REAL + writable (bind over the isolated home) so token
+  // refresh / login persists. Narrow (auth only) → session history stays isolated.
+  for (const p of plan.authReal ?? []) a.push('--bind', p, p);
   // Per-bot privacy masks (opt-in, no defaults).
   for (const dir of plan.hideDirs) a.push('--tmpfs', dir);
   for (const f of plan.hideFiles) a.push('--ro-bind', f.empty, f.path);
@@ -233,6 +240,9 @@ export function prepareSandbox(opts: {
   /** Per-bot privacy masks (opt-in, no defaults). Paths existing as dirs are
    *  blanked with a tmpfs; files with an empty read-only placeholder. */
   hidePaths?: string[];
+  /** This CLI's auth/login paths (CliAdapter.authPaths) to keep real+writable so
+   *  token refresh / login persists. `~` expanded; missing paths skipped. */
+  authPaths?: readonly string[];
 }): SandboxSpawn | null {
   if (!opts.enabled) return null;
   if (process.platform !== 'linux') return null; // overlayfs + bwrap are Linux-only
@@ -308,6 +318,17 @@ export function prepareSandbox(opts: {
     }
   }
 
+  // CLI auth/login paths kept real+writable (token refresh / login must persist,
+  // unlike isolated project edits). Resolve `~` and bind only existing paths — a
+  // missing auth file isn't a valid mountpoint (the CLI must be logged in on the
+  // host; login-from-scratch inside the sandbox isn't supported).
+  const authReal: string[] = [];
+  for (const raw of opts.authPaths ?? []) {
+    if (!raw || typeof raw !== 'string') continue;
+    const p = raw.replace(/^~(?=\/|$)/, home);
+    try { if (existsSync(p)) authReal.push(p); } catch { /* */ }
+  }
+
   const plan: SandboxPlan = {
     projectMount,
     projectMerged: projMerged,
@@ -316,6 +337,7 @@ export function prepareSandbox(opts: {
     outbox,
     hideDirs,
     hideFiles,
+    authReal,
     net: true,
   };
   const args = buildSandboxArgs(plan);

--- a/src/adapters/cli/antigravity.ts
+++ b/src/adapters/cli/antigravity.ts
@@ -130,6 +130,7 @@ export function createAntigravityAdapter(pathOverride?: string): CliAdapter {
   let cachedBin: string | undefined;
   return {
     id: 'antigravity',
+    authPaths: ['~/.gemini/oauth_creds.json', '~/.gemini/antigravity-cli/antigravity-oauth-token'],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ resume, resumeSessionId, disableCliBypass }) {

--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -411,11 +411,14 @@ export interface ClaudeFamilyVariant {
    *  aliases; forks whose model set is gateway-defined
    *  pass undefined so setup skips the prompt. */
   readonly modelChoices?: readonly string[];
+  /** Auth/login paths kept real+writable in the file sandbox (see CliAdapter.authPaths). */
+  readonly authPaths?: readonly string[];
 }
 
 export function createClaudeCodeAdapter(pathOverride?: string): CliAdapter {
   return createClaudeFamilyAdapter({
     id: 'claude-code',
+    authPaths: ['~/.claude/.credentials.json'],
     resumeBin: 'claude',
     dataDir: DEFAULT_CLAUDE_DATA_DIR,
     stateJsonPath: join(homedir(), '.claude.json'),
@@ -437,6 +440,7 @@ export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, rawBin: 
     claudeDataDir: variant.dataDir,
     claudeStateJsonPath: variant.stateJsonPath,
     spawnEnv: variant.spawnEnv,
+    authPaths: variant.authPaths,
 
     buildResumeCommand({ sessionId, cliSessionId }) {
       // Claude resumes by reading <id>.jsonl, so we need the most recently

--- a/src/adapters/cli/coco.ts
+++ b/src/adapters/cli/coco.ts
@@ -119,6 +119,7 @@ export function createCocoAdapter(pathOverride?: string): CliAdapter {
   let cachedBin: string | undefined;
   return {
     id: 'coco',
+    authPaths: ['~/.trae/cli/auth.json'],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, model, disableCliBypass }) {

--- a/src/adapters/cli/codex-app.ts
+++ b/src/adapters/cli/codex-app.ts
@@ -27,6 +27,7 @@ export function createCodexAppAdapter(pathOverride?: string): CliAdapter {
   let cachedCodexBin: string | undefined;
   return {
     id: 'codex-app',
+    authPaths: ['~/.codex/auth.json'],
     resolvedBin: process.execPath,
 
     buildArgs({ sessionId, resume, resumeSessionId, workingDir, botName, botOpenId, locale }) {

--- a/src/adapters/cli/codex.ts
+++ b/src/adapters/cli/codex.ts
@@ -123,6 +123,7 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
   let cachedBin: string | undefined;
   return {
     id: 'codex',
+    authPaths: ['~/.codex/auth.json'],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, resumeSessionId, workingDir, model, disableCliBypass }) {

--- a/src/adapters/cli/gemini.ts
+++ b/src/adapters/cli/gemini.ts
@@ -12,6 +12,7 @@ export function createGeminiAdapter(pathOverride?: string): CliAdapter {
   let cachedBin: string | undefined;
   return {
     id: 'gemini',
+    authPaths: ['~/.gemini/oauth_creds.json'],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ initialPrompt, model, disableCliBypass }) {

--- a/src/adapters/cli/mtr.ts
+++ b/src/adapters/cli/mtr.ts
@@ -33,6 +33,7 @@ export function createMtrAdapter(pathOverride?: string): CliAdapter {
   let cachedBin: string | undefined;
   return {
     id: 'mtr',
+    authPaths: ['~/.local/share/opencode/auth.json'],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, resumeSessionId, initialPrompt }) {

--- a/src/adapters/cli/oh-my-pi.ts
+++ b/src/adapters/cli/oh-my-pi.ts
@@ -9,6 +9,7 @@ export function createOhMyPiAdapter(pathOverride?: string): CliAdapter {
   const bin = resolveCommand(pathOverride ?? 'omp');
   return {
     id: 'oh-my-pi',
+    authPaths: ['~/.omp/agent/auth.json'],
     resolvedBin: bin,
 
     // oh-my-pi has no --session-id; sessions are managed internally.

--- a/src/adapters/cli/opencode.ts
+++ b/src/adapters/cli/opencode.ts
@@ -12,6 +12,7 @@ export function createOpenCodeAdapter(pathOverride?: string): CliAdapter {
   let cachedBin: string | undefined;
   return {
     id: 'opencode',
+    authPaths: ['~/.local/share/opencode/auth.json'],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ initialPrompt, model }) {

--- a/src/adapters/cli/pi.ts
+++ b/src/adapters/cli/pi.ts
@@ -9,6 +9,7 @@ export function createPiAdapter(pathOverride?: string): CliAdapter {
   const bin = resolveCommand(pathOverride ?? 'pi');
   return {
     id: 'pi',
+    authPaths: ['~/.pi/agent/auth.json'],
     resolvedBin: bin,
 
     buildArgs({ sessionId, initialPrompt }) {

--- a/src/adapters/cli/seed.ts
+++ b/src/adapters/cli/seed.ts
@@ -48,6 +48,7 @@ export function createSeedAdapter(pathOverride?: string): CliAdapter {
   const dataDir = deriveSeedDataDir(bin);
   return createClaudeFamilyAdapter({
     id: 'seed',
+    authPaths: ['~/.local/share/bytedcli'],
     resumeBin: 'seed',
     dataDir,
     // Seed keeps `.claude.json` inside its data root (CLAUDE_CONFIG_DIR layout),

--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -147,6 +147,7 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
   let cachedBin: string | undefined;
   return {
     id: 'traex',
+    authPaths: ['~/.trae/cli/auth.json'],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, resumeSessionId, workingDir, model, disableCliBypass }) {

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -210,6 +210,16 @@ export interface CliAdapter {
    *  data root for forks that set CLAUDE_CONFIG_DIR. */
   readonly claudeStateJsonPath?: string;
 
+  /** Paths (files or dirs) holding THIS CLI's auth / login state that must stay
+   *  REAL + writable inside the file sandbox. The sandbox isolates writes (so the
+   *  agent's project edits are reviewable), but a CLI's token refresh / login
+   *  must PERSIST to the real auth — otherwise the sandboxed CLI loses its login
+   *  (see seed's `bytecloud-auth`). The sandbox binds each existing path rw over
+   *  the isolated overlay so auth reads/refreshes/logins hit the real files.
+   *  `~` is expanded. Keep NARROW (auth only) so session history stays isolated.
+   *  undefined / empty → no carve-out. */
+  readonly authPaths?: readonly string[];
+
   /** Extra env merged into the spawned child's environment. Used by Claude-family
    *  forks to point the CLI at its data root (e.g. Seed's `CLAUDE_CONFIG_DIR`).
    *  Keys placed here are also forwarded through the tmux backend (see

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3561,6 +3561,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
           cliBin: cliAdapter.resolvedBin,
           cliArgs: args,
           hidePaths: cfg.sandboxHidePaths ?? [],
+          authPaths: cliAdapter.authPaths,
         });
         if (sbx) {
           spawnBin = sbx.bin;


### PR DESCRIPTION
沙盒隔离写导致 CLI 的 token 刷新/登录写不持久→登录态丢失（seed 实测）。给 CliAdapter 加 authPaths，每个 CLI 声明鉴权目录，沙盒里真实 rw 绑定（窄绑，会话历史仍隔离）。各 CLI 鉴权位置见 commit。实测各 CLI auth 真实绑定 + seed 持久验证 + 29 sandbox 测试过。claude 按申晗不验证。