### PR TITLE
feat(adopt): /adopt 支持 TRAE（traex）会话

### DIFF
--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -2,7 +2,7 @@
  * Session Discovery — scans tmux panes for running CLI processes that can be adopted.
  *
  * Discovers non-botmux tmux sessions running known CLI binaries (Claude Code,
- * Codex, Aiden, CoCo, Cursor, Gemini, OpenCode, MTR, Hermes, Pi) and collects metadata needed to adopt them.
+ * Codex, Aiden, CoCo, Cursor, Gemini, OpenCode, MTR, Hermes, TRAE, Pi) and collects metadata needed to adopt them.
  */
 import { execFileSync, execSync } from 'node:child_process';
 import { readdirSync, readFileSync, readlinkSync, realpathSync } from 'node:fs';
@@ -11,6 +11,7 @@ import { basename, join } from 'node:path';
 import type { CliId } from '../adapters/cli/types.js';
 import { findCodexRolloutByPid } from '../services/codex-transcript.js';
 import { findCocoSessionByPid } from '../services/coco-transcript.js';
+import { findTraexRolloutByPid } from '../services/traex-transcript.js';
 import { tmuxEnv } from '../setup/ensure-tmux.js';
 
 // macOS 没有 /proc，所以走 ps/lsof/pgrep 兜底。Linux 仍优先走 /proc 快路径。
@@ -49,6 +50,9 @@ const CLI_COMM_MAP: Record<string, CliId> = {
   // 改写过；macOS 下 `ps -o comm=` 拿到的是真实 argv[0]，因此这里需要
   // 把别名 traecli 也识别成 coco，否则 /adopt 扫不到这种会话。
   traecli: 'coco',
+  // TRAE（traex）是另一套 Codex 系 CLI，可执行就叫 `traex`，与上面 CoCo 的
+  // traecli 别名是两个不同的二进制（traecli 是 coco 的软链）。
+  traex: 'traex',
   gemini: 'gemini',
   opencode: 'opencode',
   mtr: 'mtr',
@@ -560,6 +564,12 @@ export function discoverAdoptableSessions(filterCliId?: CliId): AdoptableSession
         // re-probes too, so undefined here is acceptable.
         const cocoSession = findCocoSessionByPid(match.pid);
         if (cocoSession) sessionId = cocoSession.sessionId;
+      } else if (match.cliId === 'traex') {
+        // TRAE: same open-rollout-fd probe as Codex, with a TRAE-specific
+        // path matcher (~/.trae/cli/sessions/...). Worker-side re-probes by
+        // pid as a fallback, so undefined here is acceptable.
+        const rollout = findTraexRolloutByPid(match.pid);
+        if (rollout) sessionId = rollout.cliSessionId;
       }
 
       // 5b. Fall back to the CLI process's own start time for uptime. Without

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -2382,6 +2382,8 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
   //   - codex: worker resolves the rollout path either from cliSessionId
   //     (passed below when known) or by reading the Codex pid's open fds
   //     in /proc — so we always pass the pid for codex adopt.
+  //   - traex: same rollout strategy as codex (byte-identical JSONL format),
+  //     only the directory layout (~/.trae/cli/sessions) and finders differ.
   //   - coco: events.jsonl path is `~/.cache/coco/sessions/<sid>/events.jsonl`,
   //     deterministic from cliSessionId. PID is the fallback when discovery
   //     missed (events.jsonl isn't held open continuously, so worker may need
@@ -2413,7 +2415,7 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
   // open store.db fd (chatId), or from cliSessionId (= chatId) when discovery
   // captured it — so adopt must forward the pid + cwd like the other
   // transcript-backed CLIs.
-  const isStructuredBridge = adoptedCliId === 'codex' || adoptedCliId === 'coco' || adoptedCliId === 'mtr' || adoptedCliId === 'cursor';
+  const isStructuredBridge = adoptedCliId === 'codex' || adoptedCliId === 'traex' || adoptedCliId === 'coco' || adoptedCliId === 'mtr' || adoptedCliId === 'cursor';
   const adoptBackendType = adopted.source === 'herdr' ? 'herdr' : adopted.zellijPaneId ? 'zellij' : 'tmux';
 
   const initMsg: DaemonToWorker = {

--- a/src/core/zellij-adopt-discovery.ts
+++ b/src/core/zellij-adopt-discovery.ts
@@ -21,6 +21,7 @@ import {
 } from './session-discovery.js';
 import { findCodexRolloutByPid } from '../services/codex-transcript.js';
 import { findCocoSessionByPid } from '../services/coco-transcript.js';
+import { findTraexRolloutByPid } from '../services/traex-transcript.js';
 import { findServerPid } from '../adapters/backend/zellij-backend.js';
 import {
   listLiveSessions, parseListPanesJson,
@@ -166,6 +167,10 @@ function resolveSessionId(cliId: CliId, pid: number): { sessionId?: string; star
   if (cliId === 'coco') {
     const coco = findCocoSessionByPid(pid);
     return { sessionId: coco?.sessionId };
+  }
+  if (cliId === 'traex') {
+    const rollout = findTraexRolloutByPid(pid);
+    return { sessionId: rollout?.cliSessionId };
   }
   return {};
 }

--- a/test/session-discovery.test.ts
+++ b/test/session-discovery.test.ts
@@ -656,6 +656,68 @@ describe('discoverAdoptableSessions', () => {
     expect(results).toHaveLength(1);
     expect(results[0]!.sessionId).toBeUndefined();
   });
+
+  // ── TRAE (traex) /proc/<pid>/fd-based session discovery ─────────────────
+  // TRAE is a Codex-family CLI: it holds its rollout JSONL fd open for the
+  // session lifetime, so the pid → rollout probe mirrors Codex but matches
+  // the ~/.trae/cli/sessions layout.
+
+  it('detects a TRAE (traex) CLI process and captures sessionId from the open rollout fd', () => {
+    setupMocks({
+      paneLines: 'work:0.0 9000\n',
+      commMap: { 9000: 'bash', 9001: 'traex' },
+      childMap: { 9000: [9001] },
+      cwdMap: { 9001: '/workspace/proj' },
+      dimsMap: { 'work:0.0': '120 30' },
+      procFdMap: {
+        9001: [
+          '/dev/null',
+          '/home/testuser/.trae/cli/sessions/2026/06/11/rollout-2026-06-11T10-00-00-8db7d911-96f3-4764-a310-e42ae4cb626f.jsonl',
+        ],
+      },
+    });
+
+    const results = discoverAdoptableSessions();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.cliId).toBe('traex');
+    expect(results[0]!.cwd).toBe('/workspace/proj');
+    expect(results[0]!.sessionId).toBe('8db7d911-96f3-4764-a310-e42ae4cb626f');
+  });
+
+  it('returns traex discovery without sessionId when no rollout fd is open', () => {
+    setupMocks({
+      paneLines: 'work:0.0 9100\n',
+      commMap: { 9100: 'bash', 9101: 'traex' },
+      childMap: { 9100: [9101] },
+      cwdMap: { 9101: '/workspace/proj' },
+      dimsMap: { 'work:0.0': '120 30' },
+      procFdMap: {
+        9101: ['/dev/null', '/tmp/somefile.log'],
+      },
+    });
+
+    const results = discoverAdoptableSessions();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.cliId).toBe('traex');
+    expect(results[0]!.sessionId).toBeUndefined();
+  });
+
+  it('filters to traex sessions only when a TRAE bot adopts', () => {
+    setupMocks({
+      paneLines: 'work:0.0 9200\nwork:0.1 9300\n',
+      commMap: { 9200: 'traex', 9300: 'codex' },
+      cwdMap: { 9200: '/workspace/trae-proj', 9300: '/workspace/codex-proj' },
+      dimsMap: { 'work:0.0': '120 30', 'work:0.1': '120 30' },
+    });
+
+    const results = discoverAdoptableSessions('traex' as CliId);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.cliId).toBe('traex');
+    expect(results[0]!.cwd).toBe('/workspace/trae-proj');
+  });
 });
 
 describe('validateAdoptTarget', () => {


### PR DESCRIPTION
## 背景

TRAE bot 执行 `/adopt` 永远报「没有可接管的会话」。根因：`/adopt` 按 bot 自身 cliId 过滤 discovery，而 `session-discovery.ts` 的 `CLI_COMM_MAP` 没有 traex 条目，一个进程都扫不到。

有意思的是 **worker 侧的 traex adopt bridge 早已全部就位**（`setupAdoptTranscriptBridges` 的 traex 分支、`setupAdoptInputAdapter`、bridge tick 里的 `findTraexRolloutByPid` 轮询都在），缺的只是 daemon 侧三处接线。

## 改动

| 文件 | 改动 |
| --- | --- |
| `src/core/session-discovery.ts` | `CLI_COMM_MAP` 增加 `traex → 'traex'`；发现时用 `findTraexRolloutByPid` 经 `/proc/<pid>/fd` 探测 TRAE 原生 sessionId |
| `src/core/zellij-adopt-discovery.ts` | `resolveSessionId` 补 traex 分支 |
| `src/core/worker-pool.ts` | `forkAdoptWorker` 的 `isStructuredBridge` 纳入 traex，透传 `cliSessionId` / `adoptCliPid` / `adoptCwd`（不透传则 worker 的 bridge 永远接不上） |
| `test/session-discovery.test.ts` | 新增 3 例：识别 traex + fd 捕获 sessionId、无 rollout fd 时优雅降级、TRAE bot 过滤 |

## 注意点

- **与 CoCo 的 `traecli` 别名不冲突**：`traecli` 是 coco 的软链（映射 coco 不变），`traex` 是独立 ELF，comm 就是 `traex`。
- **TRAE rollout 懒落盘**：首轮消息后才创建 rollout JSONL，但创建后 fd 长持（与 Codex 同款，真机确认）。首轮前 adopt 时 sessionId 为空，由 worker 侧 1s tick 的 pid 探测兜底晚接——这正是既有 codex adopt 的同款路径。

## 验证

- tsc 0 错误；adopt/discovery 相关 4 个测试文件 68/68 过
- 全量 unit：4250 过 + 3 fail（已 checkout master 基线复核，同样 3 fail，确认既有非本 PR 引入）
- **真机**（traecli 0.200.7）：tmux 手起 traex → 编译后 discovery 认出 `cliId: traex` + cwd + startedAt，`validateAdoptTarget` 过；发首条消息触发 rollout 落盘后，重跑 discovery 成功捕获 `sessionId`