### PR TITLE
fix(resume): 接口化 Tier1 预检 + Tier2 重启计数，取代 #189 简版

### DIFF
--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -442,6 +442,37 @@ export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, rawBin: 
     spawnEnv: variant.spawnEnv,
     authPaths: variant.authPaths,
 
+    /** Prove the resume JSONL exists (or at least the project dir does, so the
+     *  sessionId lookup will find it). Conservative: only returns true when we
+     *  can stat the exact file; false when the file is provably absent;
+     *  undefined on any weirdness (caller will still try the spawn and rely on
+     *  the secondary guard).
+     *
+     *  The `dataDir` parameter carries the EFFECTIVE data root, i.e. after any
+     *  sandbox overlay redirection — the worker mirrors the same calculation
+     *  into `(backend).claudeJsonlPath = claudeJsonlPathForSession(...)` so
+     *  this probe sees the same filesystem the spawned CLI will write to. */
+    checkResumeTargetExists({ sessionId, cliSessionId, workingDir, dataDir }) {
+      if (!workingDir) return undefined;
+      const effectiveDataDir = dataDir ?? variant.dataDir;
+      const sid = cliSessionId ?? sessionId;
+      if (!sid) return undefined;
+      try {
+        const p = claudeJsonlPathForSession(sid, workingDir, effectiveDataDir);
+        if (existsSync(p)) return true;
+        // Also try the project directory (allows partial matches): absent
+        // projectDir means no resume target could possibly exist — Claude
+        // writes `<sid>.jsonl` there on first submit and never moves it.
+        if (!existsSync(dirname(p))) return false;
+        // Project dir exists but this specific sid doesn't. Could be a
+        // mid-session rotation the adapter's pid resolver would catch — don't
+        // block, let spawn try; the secondary guard still covers it.
+        return undefined;
+      } catch {
+        return undefined;
+      }
+    },
+
     buildResumeCommand({ sessionId, cliSessionId }) {
       // Claude resumes by reading <id>.jsonl, so we need the most recently
       // observed CLI-native id (rotation can happen mid-run); fall back to the

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -226,6 +226,35 @@ export interface CliAdapter {
    *  BOTMUX_INJECTED_ENV_KEYS). undefined → inherit the worker env unchanged. */
   readonly spawnEnv?: Readonly<Record<string, string>>;
 
+  /** Optional: pre-flight check for resume targets.
+   *
+   *  Called with `resume=true` before spawn so a missing conversation JSONL /
+   *  rollout / DB entry does not produce a CLI-level "No conversation found"
+   *  exit code 1 — which would otherwise be amplified into an auto-restart
+   *  crash loop by the daemon's claude_exit handler.
+   *
+   *  Return `true` = resume target looks present (spawn normally with --resume).
+   *  Return `false` = target is provably missing → worker will fall back to a
+   *  FRESH session (resume=false, drop cliSessionId, log + user_notify once).
+   *  Return `undefined` / omit = adapter cannot tell cheaply → rely on the
+   *  worker's SECONDARY guard (2nd restart forces fresh) so unknown-shape CLIs
+   *  still degrade without crash-looping.
+   *
+   *  Must be synchronous, cheap, and conservative. An adapter that can verify
+   *  the resume target without spawning a subprocess implements this; others
+   *  simply leave it undefined (the secondary guard is always active). */
+  checkResumeTargetExists?(opts: {
+    sessionId: string;
+    /** CLI-native session id from session.cliSessionId, when available. */
+    cliSessionId?: string;
+    /** Working directory the CLI will spawn in. Used by Claude-family to
+     *  locate <projects>/<cwdHash>/<id>.jsonl. */
+    workingDir?: string;
+    /** Claude-family data dir (~/.claude, ~/.claude-runtime, …) so the probe
+     *  targets the SAME root the adapter will actually write into. */
+    dataDir?: string;
+  }): boolean | undefined;
+
   /** Optional CLI version command override. Defaults to `[resolvedBin, '--version']`. */
   versionCommand?(): { bin: string; args: string[] };
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -105,6 +105,14 @@ let consecutiveInWorkerRestarts = 0;
  *  lifecycle so a 4× crash loop does not spam the Lark thread with 4 copies
  *  of the same warning. */
 let resumeFallbackNotified = false;
+/** The effectiveResume flag used by the most recent spawnCli call. Written
+ *  immediately after the two-tier fallback check so late-attach timers
+ *  (hermes, cursor, etc.) can read THE SAME semantics the spawn used,
+ *  instead of re-deriving from lastInitConfig.resume (which never reflects
+ *  Tier-1/Tier-2 fresh demotion). Updated in spawnCli BEFORE any bridge
+ *  setup so even the tick that fires between spawnCli-start and the
+ *  adapter's hermesBridgeAttach reads the correct mode. */
+let lastSpawnEffectiveResume = false;
 let idleDetector: IdleDetector | null = null;
 let isTmuxMode = false;
 /** Adopt-bridge mode using TmuxPipeBackend: not a tmux attach client, all
@@ -1518,7 +1526,11 @@ function codexBridgeStartTimer(): void {
   codexBridgeTimer = setInterval(() => {
     try {
       if (structuredBridgeIsHermes()) {
-        if (!hermesBridgeBaselineDone) hermesBridgeAttach(lastInitConfig?.resume ? 'baseline-existing' : 'fresh-empty');
+        // Use lastSpawnEffectiveResume (written by spawnCli AFTER the
+        // two-tier fallback), NOT lastInitConfig.resume. Otherwise a
+        // Tier-1/Tier-2 demotion to fresh would still baseline the empty
+        // hermes store as "existing" and swallow the first turn.
+        if (!hermesBridgeBaselineDone) hermesBridgeAttach(lastSpawnEffectiveResume ? 'baseline-existing' : 'fresh-empty');
         hermesBridgeIngest();
         if (isPromptReady) emitReadyCodexTurns();
         return;
@@ -3468,6 +3480,12 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     (backend as TmuxBackend | PtyBackend | ZellijBackend).claudeJsonlPath =
       claudeJsonlPathForSession(bridgeWatchId, cfg.workingDir, claudeDataDir);
   }
+  // Publish the resolved resume semantics so any late-attach timer (hermes,
+  // cursor, …) driven by codexBridgeStartTimer sees the SAME mode the spawn
+  // used. Without this, Tier-1/Tier-2 fresh demotion would still use
+  // `lastInitConfig.resume` (= true) and baseline an empty store, swallowing
+  // the fresh session's first turn.
+  lastSpawnEffectiveResume = effectiveResume;
 
   const args = cliAdapter.buildArgs({
     sessionId: effectiveAdapterSessionId,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -93,6 +93,18 @@ let cliPidMarker: string | null = null;  // path to .botmux-cli-pids/<pid>
 let sandboxStopWatcher: (() => void) | null = null;  // stop fn for the sandbox outbox watcher
 let sandboxCleanup: (() => void) | null = null;      // unmount overlays + rm the per-session sandbox tree
 let sandboxTeardownDone = false;                     // guards the exit-time best-effort teardown from double-running / running on suspend-for-resume
+/** Counts consecutive in-worker restart cycles (see case 'restart'). Used by
+ *  the SECONDARY guard so an adapter whose checkResumeTargetExists misses
+ *  (returns undefined) or whose resume target vanishes between the check and
+ *  spawn never crash-loops: 2nd consecutive restart → drop resume semantics,
+ *  spawn fresh. Reset to 0 whenever spawnCli proceeds with a successful
+ *  (non-forced) config, so healthy restarts (e.g. user `/restart`) are
+ *  unaffected. */
+let consecutiveInWorkerRestarts = 0;
+/** Guard: user_notify for "resume → fresh fallback" is sent once per worker
+ *  lifecycle so a 4× crash loop does not spam the Lark thread with 4 copies
+ *  of the same warning. */
+let resumeFallbackNotified = false;
 let idleDetector: IdleDetector | null = null;
 let isTmuxMode = false;
 /** Adopt-bridge mode using TmuxPipeBackend: not a tmux attach client, all
@@ -2675,6 +2687,13 @@ function markPromptReady(): void {
     return;
   }
   isPromptReady = true;
+  // CLI 实际启动成功（回到 prompt）：复位连续重启计数。
+  // 任何能到这一步的 spawn 都算"成功"——后续即便再崩溃（不是 resume 目标不存在
+  // 的问题），下一轮也该有新的 2 次重试预算，而不是被历史重启计数卡住。
+  if (consecutiveInWorkerRestarts > 0) {
+    log(`CLI reached prompt successfully — resetting consecutive restart count (was ${consecutiveInWorkerRestarts})`);
+    consecutiveInWorkerRestarts = 0;
+  }
   // CLI is back at its prompt — every previously written input has been
   // consumed, so nothing is in flight anymore. A later crash must not
   // replay these.
@@ -3381,34 +3400,80 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     log(`[sandbox] redirecting Claude bridge dataDir → overlay upper: ${redirected}`);
     claudeDataDir = redirected;
   }
-  // Resume-fresh fallback: if we'd `--resume` a Claude-family session but its
-  // conversation jsonl is GONE, the CLI exits 1 ("No conversation found") and the
-  // auto-restarter keeps re-resuming → a single transient crash amplifies into a
-  // crash-loop. This bites sandboxed sessions especially: their jsonl lives in the
-  // ephemeral overlay upper, which crash-cleanup reclaims. Detect the missing
-  // conversation and spawn FRESH instead — loses prior context but never loops.
+  // ── Resume pre-flight check + two-tier fallback ──────────────────────────
+  // Tier 1 (adapter probe): adapter.checkResumeTargetExists returns false
+  // → skip --resume, spawn FRESH.
+  // Tier 2 (restart count): 2nd consecutive in-worker restart → force FRESH,
+  // regardless of probe result. This covers adapters without a probe AND
+  // probe/spawn races (target vanishes between the check and spawn).
+  //
+  // Supersedes the claude-family-only inline probe (PR #189) with a
+  // general adapter-owned check (cleaner boundary) + a numeric safety net.
+  //
+  // User impact: losing context is better than a 4× daemon-side crash loop
+  // that leaves the bot stuck in "crashed N times" state until the human
+  // re-closes the session.
   let effectiveResume = cfg.resume ?? false;
-  if (effectiveResume && claudeDataDir && cfg.cliSessionId) {
-    const resumeJsonl = claudeJsonlPathForSession(cfg.cliSessionId, cfg.workingDir, claudeDataDir);
-    if (!existsSync(resumeJsonl)) {
-      log(`[resume] conversation gone (${resumeJsonl}) — spawning FRESH instead of --resume (avoids "No conversation found" crash-loop)`);
-      effectiveResume = false;
-    }
+  let effectiveCliSessionId = cfg.cliSessionId;
+  let effectiveAdapterSessionId = adapterSessionId;
+  const tier2ForceFresh = effectiveResume && consecutiveInWorkerRestarts >= 2;
+  let tier1ProbeFalse = false;
+  if (effectiveResume && !tier2ForceFresh) {
+    const probe = cliAdapter.checkResumeTargetExists?.({
+      sessionId: effectiveAdapterSessionId,
+      cliSessionId: effectiveCliSessionId,
+      workingDir: cfg.workingDir,
+      dataDir: claudeDataDir,
+    });
+    if (probe === false) tier1ProbeFalse = true;
   }
-  if (claudeDataDir) {
+  const fallBackToFresh = effectiveResume && (tier1ProbeFalse || tier2ForceFresh);
+  if (fallBackToFresh) {
+    const reason = tier2ForceFresh
+      ? `consecutive restart x${consecutiveInWorkerRestarts} — 2nd failed resume attempt`
+      : 'adapter confirmed resume target does not exist on disk';
+    log(`Resume fallback: dropping --resume (${reason}) → fresh session ${cfg.sessionId}`);
+    effectiveResume = false;
+    effectiveCliSessionId = undefined;
+    effectiveAdapterSessionId = cfg.sessionId;
+    // Recompute the claude-family JSONL path: it now targets the FRESH
+    // sessionId (fresh spawn creates <newSid>.jsonl, not the old one).
+    if (claudeDataDir) {
+      (backend as TmuxBackend | PtyBackend | ZellijBackend).claudeJsonlPath =
+        claudeJsonlPathForSession(effectiveAdapterSessionId, cfg.workingDir, claudeDataDir);
+    }
+    // Single human-visible warning. Spam guard: at most once per worker
+    // lifecycle (a 4× crash loop otherwise duplicates the notice).
+    if (!resumeFallbackNotified) {
+      resumeFallbackNotified = true;
+      send({
+        type: 'user_notify',
+        turnId: currentBotmuxTurnId,
+        message:
+          `⚠️  历史会话（${(cfg.cliSessionId ?? cfg.originalSessionId ?? cfg.sessionId).substring(0, 16)}…）` +
+          `无法恢复，已为你**新起一个干净会话**（原因：${reason}）。\n` +
+          `之前的上下文不会带到本轮，需要的话请简述背景。`,
+      });
+    }
+    // Reset the counter so the fresh spawn gets a clean 2-attempt budget in
+    // case IT crashes later for an unrelated reason.
+    consecutiveInWorkerRestarts = 0;
+  } else if (claudeDataDir) {
     // Watch where the spawned CLI will actually write: the resumed conversation
     // when resuming, else the fresh session id (a stale cliSessionId would point
     // the bridge at the gone jsonl).
-    const bridgeWatchId = effectiveResume ? (cfg.cliSessionId ?? adapterSessionId) : adapterSessionId;
+    const bridgeWatchId = effectiveResume
+      ? (effectiveCliSessionId ?? effectiveAdapterSessionId)
+      : effectiveAdapterSessionId;
     (backend as TmuxBackend | PtyBackend | ZellijBackend).claudeJsonlPath =
       claudeJsonlPathForSession(bridgeWatchId, cfg.workingDir, claudeDataDir);
   }
 
   const args = cliAdapter.buildArgs({
-    sessionId: adapterSessionId,
+    sessionId: effectiveAdapterSessionId,
     resume: effectiveResume,
     workingDir: cfg.workingDir,
-    resumeSessionId: cfg.cliSessionId,
+    resumeSessionId: effectiveCliSessionId,
     initialPrompt: cfg.prompt || undefined,
     botName: cfg.botName,
     botOpenId: cfg.botOpenId,
@@ -3679,9 +3744,6 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     setTimeout(resolveCliPidLate, 120);
   }
 
-  // On tmux re-attach, keep awaitingFirstPrompt = true so screen updates are
-  // suppressed until the idle detector fires markNewTurn() — this prevents the
-  // full tmux scrollback history from leaking into the streaming card.
   // Bridge fallback: claude-code only. Tail Claude's transcript JSONL so a
   // turn the model finishes WITHOUT calling `botmux send` still gets its
   // assistant text forwarded to Lark (the gate in emitReadyTurns suppresses
@@ -3690,11 +3752,14 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   // the file Claude creates on first submit isn't absorbed as history,
   // and baseline-existing on resume so prior-run turns ARE absorbed (we
   // don't want to re-emit yesterday's conversation as fresh turns).
-  if (claudeDataDir && adapterSessionId) {
-    // Use effectiveResume (not cfg.resume): the resume-fresh fallback above may
-    // have demoted a resume to fresh because the conversation jsonl was gone, so
-    // the bridge must watch the FRESH session's jsonl in fresh-empty mode.
-    const claudeBridgeSessionId = effectiveResume ? (cfg.cliSessionId ?? adapterSessionId) : adapterSessionId;
+  //
+  // NOTE: use effectiveResume / effectiveAdapterSessionId / effectiveCliSessionId
+  // here, NOT cfg.* — the two-tier fallback above may have flipped
+  // resume → FRESH, in which case the baseline mode and session id MUST
+  // follow the flip. The same variables also cover Tier-2 (count-based)
+  // fallbacks that fire for non-Claude CLIs (below).
+  if (claudeDataDir && effectiveAdapterSessionId) {
+    const claudeBridgeSessionId = effectiveCliSessionId ?? effectiveAdapterSessionId;
     const claudeJsonl = claudeJsonlPathForSession(claudeBridgeSessionId, cfg.workingDir, claudeDataDir);
     startBridgeWatcher(claudeJsonl, {
       cliPid: cliPid ?? undefined,
@@ -3710,15 +3775,19 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   // discovered after the first submit; CoCo's events path is deterministic
   // from botmux sessionId. Hermes and MTR use SQLite stores, so baseline the
   // relevant cursor at spawn and poll for rows after each queued prompt flushes.
+  //
+  // Mode uses effectiveResume: when the resume probe flipped us to FRESH, we
+  // must NOT baseline the "restored" cursor against an empty / absent store
+  // (would otherwise swallow the fresh session's first turn).
   if (cfg.cliId === 'hermes') {
-    hermesBridgeAttach(cfg.resume ? 'baseline-existing' : 'fresh-empty');
+    hermesBridgeAttach(effectiveResume ? 'baseline-existing' : 'fresh-empty');
   } else if (cfg.cliId === 'codex') {
-    if (cfg.cliSessionId) {
-      const rolloutPath = findCodexRolloutBySessionId(cfg.cliSessionId);
+    if (effectiveCliSessionId) {
+      const rolloutPath = findCodexRolloutBySessionId(effectiveCliSessionId);
       if (rolloutPath) {
         codexBridgeAttach(rolloutPath, 'baseline-existing');
       } else {
-        codexBridgePendingSessionId = cfg.cliSessionId;
+        codexBridgePendingSessionId = effectiveCliSessionId;
         codexBridgeStartTimer();
       }
     } else {
@@ -3729,27 +3798,27 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     // spawn (no cliSessionId yet) we just arm the poller; writeInput will
     // surface the cliSessionId on the first successful submit and trigger
     // codexBridgeNotifyCliSessionId → rollout attach.
-    if (cfg.cliSessionId) {
-      const rolloutPath = findTraexRolloutBySessionId(cfg.cliSessionId);
+    if (effectiveCliSessionId) {
+      const rolloutPath = findTraexRolloutBySessionId(effectiveCliSessionId);
       if (rolloutPath) {
         codexBridgeAttach(rolloutPath, 'baseline-existing');
       } else {
-        codexBridgePendingSessionId = cfg.cliSessionId;
+        codexBridgePendingSessionId = effectiveCliSessionId;
         codexBridgeStartTimer();
       }
     } else {
       codexBridgeStartTimer();
     }
   } else if (cfg.cliId === 'coco') {
-    const eventsPath = cocoEventsPathForSession(cfg.sessionId);
-    codexBridgeAttach(eventsPath, cfg.resume ? 'baseline-existing' : 'fresh-empty');
+    const eventsPath = cocoEventsPathForSession(effectiveAdapterSessionId);
+    codexBridgeAttach(eventsPath, effectiveResume ? 'baseline-existing' : 'fresh-empty');
     codexBridgeStartTimer();
   } else if (cfg.cliId === 'mtr') {
-    const mtrSessionId = cfg.cliSessionId ?? mtrSessionIdForBotmuxSession(cfg.sessionId);
+    const mtrSessionId = effectiveCliSessionId ?? mtrSessionIdForBotmuxSession(effectiveAdapterSessionId);
     codexBridgePendingSessionId = mtrSessionId;
     const source = findMtrSessionById(mtrSessionId);
     if (source) {
-      mtrBridgeAttach(source, cfg.resume ? 'baseline-existing' : 'fresh-empty');
+      mtrBridgeAttach(source, effectiveResume ? 'baseline-existing' : 'fresh-empty');
     } else {
       codexBridgeStartTimer();
     }
@@ -4575,6 +4644,17 @@ process.on('message', async (raw: unknown) => {
         break;
       }
       log('Restart requested');
+      // Tier-2 guard: 2nd consecutive in-worker restart forces FRESH.
+      // Increment BEFORE spawnCli so the guard trips at count==2 (i.e. the
+      // third attempted spawn in a 1-success → 2-failure sequence):
+      //   initial spawn (count=0) → fail → claude_exit → daemon sends restart
+      //   1st restart (count=1) → resume still fails → restart
+      //   2nd restart (count=2) → tier-2 kicks in → FRESH
+      // Tier 1 probe (adapter.checkResumeTargetExists) is re-run on each
+      // spawn, so even count=1 often short-circuits; tier-2 only catches
+      // silent/race failures and adapters that don't implement the probe.
+      consecutiveInWorkerRestarts++;
+      log(`Restart count: ${consecutiveInWorkerRestarts} (>=2 forces FRESH)`);
       // Must destroySession(), not kill(): for persistent backends (tmux/herdr)
       // kill() only detaches — the backing session + CLI process keep running,
       // so the resume:true spawnCli below would re-attach to the SAME live CLI


### PR DESCRIPTION
## 背景

#189 做了 Claude-family inline `existsSync` 的 Tier1 预检，解决 seed/claude 沙盒 jsonl 丢失后 crash loop 的 p0 问题，**已全量部署顶着线上**。

本 PR 把它升级成覆盖**全 CLI** 的两层防御超集版，取代 #189 的内联实现：

- Tier 1 由 adapter 自行实现 `checkResumeTargetExists()`（比 worker 里硬编码更干净的边界），**非 claude-family adapter 以后也可以加**
- 新增 **Tier 2 重启计数兜底**（`consecutiveInWorkerRestarts >= 2`）：即使 probe miss 或 probe/spawn 之间 race（检查完文件立刻被删），第二回重启也强制 fresh，保证不会循环崩溃

## 变更

| 文件 | 改动 |
|---|---|
| `src/adapters/cli/types.ts` | 新增可选接口 `checkResumeTargetExists({sessionId, cliSessionId, workingDir, dataDir}): boolean \| undefined` |
| `src/adapters/cli/claude-code.ts` | Claude-family 实现：基于 `claudeJsonlPathForSession()`，只有「确定不存在」才返回 false（保守，避免误伤 mid-session 旋转 id 场景）；project dir 不存在也直接判 false（加速沙盒 overlay 被回收场景） |
| `src/worker.ts` | 见下 |

## worker 内逻辑

1. **State**：加 `consecutiveInWorkerRestarts`（计数器）+ `resumeFallbackNotified`（警告 spam guard）
2. **spawnCli Tier 1 预检**：`resume=true` 且未触发 Tier 2 时调用 adapter probe
3. **spawnCli Tier 2 强制**：`consecutiveInWorkerRestarts >= 2` 直接 effectiveResume=false
4. **fallback 落地**：当任一层触发 → `effectiveResume=false`，同时
   - 清 `cliSessionId`、重算 `claudeJsonlPath` 指向 FRESH sid
   - **所有 bridge watcher**（claude-jsonl / codex / traex / coco / hermes / mtr）都用 `effectiveResume` / `effectiveCliSessionId` / `effectiveAdapterSessionId`（之前 #189 只改了 claude-family 那一段，为 Tier 2 触达非 claude CLI 必须全部跟上）
   - 单次 `user_notify` 警告丢上下文
   - 计数器清零（fresh spawn 有新预算）
5. **`case 'restart'`**：bump 计数器 + 打日志（`>=2 forces FRESH`）
6. **`markPromptReady`**：CLI 真回到 prompt → 清零计数器（真正跑起来过的会话，后续无关原因崩溃不该被历史计数卡）

## 对 #189 的相对增益

- ✅ 非 claude-family CLI（codex / traex / coco / hermes / mtr / cursor / mira / antigravity 等）也受 Tier 2 保护——之前完全裸奔
- ✅ probe/spawn race 有兜底（沙盒目录被并发回收、或 user 在检查瞬间 `/clear`）
- ✅ adapter 各自判断更可维护：新增 CLI 只要自家实现 probe 就自动接入 Tier 1
- ✅ fallback 后 bridge baseline 全链路一致（避免 fallback 到 fresh 但 codex 仍按 baseline-existing 启动吞首条消息）

## 验证

- `pnpm build` tsc 通过
- 与 #189 行为对 claude-family 等价 → 当前线上被 #189 覆盖的场景不会回退
- Tier 2 触发序列：初始 resume 失败 → 1st restart count=1 → 仍失败 → 2nd restart count=2 → Tier 2 强制 fresh ✅