### PR TITLE
fix(reply-target): shared折叠话题内daemon侧消息不再漏到群顶层

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -317,7 +317,7 @@ function invalidConfiguredWorkingDirs(ds: DaemonSession | undefined, larkAppId: 
 
 export interface CommandHandlerDeps {
   activeSessions: Map<string, DaemonSession>;
-  sessionReply: (rootId: string, content: string, msgType?: string, larkAppId?: string) => Promise<string>;
+  sessionReply: (rootId: string, content: string, msgType?: string, larkAppId?: string, turnId?: string) => Promise<string>;
   getActiveCount: () => number;
   lastRepoScan: Map<string, import('../services/project-scanner.js').ProjectInfo[]>;
 }
@@ -877,8 +877,12 @@ export async function handleCommand(
   larkAppId?: string,
 ): Promise<void> {
   const { activeSessions, getActiveCount, lastRepoScan } = deps;
+  // Command replies carry the triggering messageId as the turnId so a shared
+  // (chat-scope) session triggered from inside a Lark thread anchors them into
+  // that thread (resolveSessionReplyTarget turnId gate) instead of leaking a
+  // plain top-level message.
   const sessionReply = (rid: string, content: string, msgType?: string) =>
-    deps.sessionReply(rid, content, msgType, larkAppId);
+    deps.sessionReply(rid, content, msgType, larkAppId, message.messageId);
   const ds = larkAppId ? activeSessions.get(sessionKey(rootId, larkAppId)) : undefined;
   const logTag = ds ? tag(ds) : rootId.substring(0, 12);
   const loc: Locale = localeForBot(ds?.larkAppId ?? larkAppId);

--- a/src/core/reply-target.ts
+++ b/src/core/reply-target.ts
@@ -63,6 +63,22 @@ export function beginReplyTargetTurn(
   ds.session.currentReplyTarget = undefined;
 }
 
+/**
+ * Effective turnId for a daemon-side message. Callers that know their turn
+ * (worker final_output, placeholder cards) pass it explicitly and the
+ * stale-turn gate in resolveSessionReplyTarget stays authoritative. Callers
+ * with NO turn context of their own (the worker's first streaming card,
+ * crash notices) fall back to the session's current reply-target turn — in a
+ * shared fold-back topic they then follow the conversation into the thread
+ * instead of leaking to the chat top level.
+ */
+export function fallbackTurnId(
+  ds: Pick<DaemonSession, 'session' | 'currentReplyTarget'>,
+  turnId: string | undefined,
+): string | undefined {
+  return turnId ?? (ds.currentReplyTarget ?? ds.session.currentReplyTarget)?.turnId;
+}
+
 export function syncReplyTargetState(ds: DaemonSession, s?: Session): void {
   const source = s ?? ds.session;
   ds.replyThreadAliases = source.replyThreadAliases;

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -14,6 +14,7 @@ import { randomBytes } from 'node:crypto';
 import { config } from '../config.js';
 import * as sessionStore from '../services/session-store.js';
 import { persistStreamCardState, rememberLastCliInput } from './session-manager.js';
+import { fallbackTurnId } from './reply-target.js';
 import { updateMessage, deleteMessage, sendEphemeralCard, sendUserMessage, addReaction, MessageWithdrawnError } from '../im/lark/client.js';
 import { buildStreamingCard, buildPrivateSnapshotCard, buildSessionCard, buildTuiPromptCard, buildTuiPromptResolvedCard, buildRelayedFrozenCard, getCliDisplayName } from '../im/lark/card-builder.js';
 import { loadFrozenCards, saveFrozenCards } from '../services/frozen-card-store.js';
@@ -1572,8 +1573,11 @@ export function forkWorker(ds: DaemonSession, prompt: string, resume = false): v
 function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
   const cb = requireCallbacks();
   const t = tag(ds);
+  // Worker messages without a turn of their own (first streaming card, crash
+  // notices) anchor to the session's current reply-target turn so a shared
+  // fold-back topic keeps them in-thread instead of leaking top-level.
   const scopedReply = (content: string, msgType?: string, turnId?: string) =>
-    cb.sessionReply(sessionAnchorId(ds), content, msgType, ds.larkAppId, turnId);
+    cb.sessionReply(sessionAnchorId(ds), content, msgType, ds.larkAppId, fallbackTurnId(ds, turnId));
   const bot = getBot(ds.larkAppId);
   const botCfg = bot.config;
   const loc = botLocale(botCfg);
@@ -2234,7 +2238,7 @@ function deliverFinalOutput(
   const cb = requireCallbacks();
   const effectiveCliId = ds.session.cliId ?? getBot(ds.larkAppId).config.cliId;
   const scopedReply = (content: string, msgType?: string, turnId?: string) =>
-    cb.sessionReply(sessionAnchorId(ds), content, msgType, ds.larkAppId, turnId);
+    cb.sessionReply(sessionAnchorId(ds), content, msgType, ds.larkAppId, fallbackTurnId(ds, turnId));
   setTimeout(async () => {
     let pendingCardId: string | undefined;
     let pendingQuoteTargetId: string | undefined;

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -30,6 +30,7 @@ import { loadFrozenCards, saveFrozenCards } from '../../services/frozen-card-sto
 import { forkWorker, killWorker, scheduleCardPatch, parkStreamCard, clearUsageLimitState, cardUsageLimit, writableTerminalLinkFor, resolvePrivateCardAudience, deliverWriteLinkCard, deliverEphemeralOrReply, CARD_POSTING_SENTINEL } from '../../core/worker-pool.js';
 import { getSessionWorkingDir, buildNewTopicPrompt, getAvailableBots, persistStreamCardState, resumeSession, rememberLastCliInput } from '../../core/session-manager.js';
 import { publishAttentionPatch } from '../../core/session-activity.js';
+import { fallbackTurnId } from '../../core/reply-target.js';
 import type { DaemonToWorker, DisplayMode, TermActionKey } from '../../types.js';
 import { sessionKey, sessionAnchorId, frozenDisplayMode } from '../../core/types.js';
 import type { DaemonSession } from '../../core/types.js';
@@ -42,7 +43,7 @@ import { t, localeForBot, isLocale, type Locale } from '../../i18n/index.js';
 
 export interface CardHandlerDeps {
   activeSessions: Map<string, DaemonSession>;
-  sessionReply: (rootId: string, content: string, msgType?: string, larkAppId?: string) => Promise<string>;
+  sessionReply: (rootId: string, content: string, msgType?: string, larkAppId?: string, turnId?: string) => Promise<string>;
   lastRepoScan: Map<string, ProjectInfo[]>;
   workflowApprovalDeps?: WorkflowApprovalHandlerDeps;
   workflowApprovalResolved?: (runId: string) => void | Promise<void>;
@@ -145,8 +146,12 @@ function validateCardCliBinding(ds: DaemonSession, value?: Record<string, string
 
 export async function handleCardAction(data: CardActionData, deps: CardHandlerDeps, larkAppId?: string): Promise<any> {
   const { activeSessions, lastRepoScan } = deps;
-  const sessionReply = (rid: string, content: string, msgType?: string) =>
-    deps.sessionReply(rid, content, msgType, larkAppId);
+  // turnId is forwarded only when the caller actually has a turn anchor
+  // (e.g. the pendingRepo confirmation) — most card actions have none.
+  const sessionReply = (rid: string, content: string, msgType?: string, turnId?: string) =>
+    turnId !== undefined
+      ? deps.sessionReply(rid, content, msgType, larkAppId, turnId)
+      : deps.sessionReply(rid, content, msgType, larkAppId);
   const action = data?.action;
   const value = action?.value;
   const cardMessageId = data?.context?.open_message_id ?? data?.open_message_id;
@@ -1564,7 +1569,10 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       targetDs.pendingSender = undefined;
       targetDs.pendingFollowUps = undefined;
       forkWorker(targetDs, prompt);
-      await sessionReply(rootId, t('cmd.repo.selected_in_pending', { name: dirLabel }, locTarget));
+      // A card click has no turn of its own — anchor the confirmation to the
+      // session's current reply-target turn so a shared fold-back topic keeps
+      // it in-thread (same leak as the /repo command path).
+      await sessionReply(rootId, t('cmd.repo.selected_in_pending', { name: dirLabel }, locTarget), undefined, fallbackTurnId(targetDs, undefined));
       logger.info(`[${tag(targetDs)}] Repo selected: ${dirPath}, spawning CLI`);
     } else {
       // Mid-session repo switch — close old session, start fresh.

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -721,6 +721,7 @@ describe('handleCommand', () => {
         expect.stringContaining('会话已关闭'),
         'interactive',
         LARK_APP_ID,
+        'msg_001',
       );
       const replyArgs = (deps.sessionReply as any).mock.calls[0];
       const cardJson = replyArgs[1] as string;
@@ -739,6 +740,7 @@ describe('handleCommand', () => {
         expect.stringContaining('没有活跃的会话'),
         undefined,
         LARK_APP_ID,
+        'msg_001',
       );
     });
   });
@@ -761,6 +763,7 @@ describe('handleCommand', () => {
         expect.stringContaining('正在重启'),
         undefined,
         LARK_APP_ID,
+        'msg_001',
       );
     });
 
@@ -778,6 +781,7 @@ describe('handleCommand', () => {
         expect.stringContaining('进程已终止'),
         undefined,
         LARK_APP_ID,
+        'msg_001',
       );
     });
 
@@ -793,6 +797,7 @@ describe('handleCommand', () => {
         expect.stringContaining('进程已终止'),
         undefined,
         LARK_APP_ID,
+        'msg_001',
       );
     });
 
@@ -806,6 +811,7 @@ describe('handleCommand', () => {
         expect.stringContaining('没有活跃的会话'),
         undefined,
         LARK_APP_ID,
+        'msg_001',
       );
     });
   });
@@ -990,6 +996,41 @@ describe('handleCommand', () => {
   // ─── /repo ──────────────────────────────────────────────────────────────
 
   describe('/repo', () => {
+    it('shared fold-back: every command reply carries the triggering messageId as turnId', async () => {
+      // A shared (chat-scope) session triggered from inside a Lark thread
+      // records currentReplyTarget={turnId: messageId}. Command replies must
+      // pass that same messageId through sessionReply so the turnId gate in
+      // resolveSessionReplyTarget anchors them into the topic instead of
+      // leaking a plain top-level message.
+      const ds = makeDaemonSession({ scope: 'chat' } as Partial<DaemonSession>);
+      const deps = makeDeps(ds);
+
+      await handleCommand('/repo', ROOT_ID, makeLarkMessage('/repo 1', { messageId: 'msg_turn' }), deps, LARK_APP_ID);
+
+      const call = vi.mocked(deps.sessionReply).mock.calls[0];
+      expect(call[4]).toBe('msg_turn');
+    });
+
+    it('pendingRepo first-spawn: the 已选择 confirmation carries the triggering messageId as turnId', async () => {
+      const ds = makeDaemonSession({
+        pendingRepo: true,
+        scope: 'chat',
+        currentReplyTarget: { rootMessageId: 'om_topic_root', turnId: 'msg_prime', updatedAt: new Date().toISOString() },
+      } as Partial<DaemonSession>);
+      const deps = makeDeps(ds);
+      deps.lastRepoScan.set(CHAT_ID, [
+        { name: 'project-a', path: '/home/testuser/project-a', branch: 'main' },
+      ]);
+
+      await handleCommand('/repo', ROOT_ID, makeLarkMessage('/repo 1', { messageId: 'msg_prime' }), deps, LARK_APP_ID);
+
+      const selected = vi.mocked(deps.sessionReply).mock.calls.find(
+        (c) => typeof c[1] === 'string' && (c[1] as string).includes('已选择'),
+      );
+      expect(selected, 'no 已选择 confirmation was sent').toBeDefined();
+      expect(selected![4]).toBe('msg_prime');
+    });
+
     it('should prompt to run /repo first when index given but no cached scan', async () => {
       const ds = makeDaemonSession();
       const deps = makeDeps(ds);
@@ -1075,6 +1116,7 @@ describe('handleCommand', () => {
         expect.any(String),
         'interactive',
         LARK_APP_ID,
+        'msg_001',
       );
     });
 

--- a/test/reply-target-fallback.test.ts
+++ b/test/reply-target-fallback.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for the shared fold-back turn anchoring helpers:
+ * fallbackTurnId + its composition with resolveSessionReplyTarget.
+ *
+ * Reproduces the dispatch-into-shared-bot leak: a shared (chat-scope) session
+ * triggered from inside a Lark thread anchors its USER-FACING replies into the
+ * thread (turnId gate matches), but daemon-side messages that carried no
+ * turnId — the worker's first streaming card, the /repo "已选择" confirmation —
+ * fell through to a plain top-level sendMessage. fallbackTurnId closes that
+ * gap for callers that have no turn context of their own, without weakening
+ * the stale-turn gate for callers that DO pass an explicit turnId.
+ *
+ * Run:  pnpm vitest run test/reply-target-fallback.test.ts
+ */
+import { describe, it, expect } from 'vitest';
+import { fallbackTurnId, resolveSessionReplyTarget } from '../src/core/reply-target.js';
+import type { DaemonSession } from '../src/core/types.js';
+
+const NOW = new Date().toISOString();
+
+function makeDs(overrides: Partial<DaemonSession> = {}): Pick<
+  DaemonSession,
+  'scope' | 'chatId' | 'session' | 'currentReplyTarget'
+> & Partial<DaemonSession> {
+  return {
+    scope: 'chat',
+    chatId: 'oc_chat',
+    session: {
+      sessionId: 'sess-1',
+      chatId: 'oc_chat',
+      rootMessageId: 'oc_chat',
+      title: 't',
+      status: 'active',
+      createdAt: NOW,
+    } as DaemonSession['session'],
+    currentReplyTarget: undefined,
+    ...overrides,
+  };
+}
+
+describe('fallbackTurnId', () => {
+  it('an explicit turnId always wins over the session anchor', () => {
+    const ds = makeDs({
+      currentReplyTarget: { rootMessageId: 'om_topic', turnId: 'turn-1', updatedAt: NOW },
+    });
+    expect(fallbackTurnId(ds as DaemonSession, 'turn-2')).toBe('turn-2');
+  });
+
+  it('no turn context → falls back to ds.currentReplyTarget.turnId', () => {
+    const ds = makeDs({
+      currentReplyTarget: { rootMessageId: 'om_topic', turnId: 'turn-1', updatedAt: NOW },
+    });
+    expect(fallbackTurnId(ds as DaemonSession, undefined)).toBe('turn-1');
+  });
+
+  it('falls back to the persisted session.currentReplyTarget when the in-memory one is absent (post-restart restore)', () => {
+    const ds = makeDs();
+    ds.session.currentReplyTarget = { rootMessageId: 'om_topic', turnId: 'turn-9', updatedAt: NOW };
+    expect(fallbackTurnId(ds as DaemonSession, undefined)).toBe('turn-9');
+  });
+
+  it('no anchor anywhere → undefined (plain chat reply, unchanged behavior)', () => {
+    expect(fallbackTurnId(makeDs() as DaemonSession, undefined)).toBeUndefined();
+  });
+});
+
+describe('fallbackTurnId × resolveSessionReplyTarget (the leak fix)', () => {
+  it('daemon-side message with NO turn context anchors into the shared fold-back topic instead of leaking top-level', () => {
+    const ds = makeDs({
+      currentReplyTarget: { rootMessageId: 'om_topic', turnId: 'turn-1', updatedAt: NOW },
+    });
+    // Pre-fix: resolveSessionReplyTarget(ds, undefined) → plain → top-level leak.
+    const target = resolveSessionReplyTarget(ds, fallbackTurnId(ds as DaemonSession, undefined));
+    expect(target).toEqual({ mode: 'thread', rootMessageId: 'om_topic' });
+  });
+
+  it('an explicit STALE turnId is still gated to plain — fallback must not weaken the cross-turn hijack guard', () => {
+    const ds = makeDs({
+      currentReplyTarget: { rootMessageId: 'om_topic', turnId: 'turn-1', updatedAt: NOW },
+    });
+    const target = resolveSessionReplyTarget(ds, fallbackTurnId(ds as DaemonSession, 'turn-2'));
+    expect(target).toEqual({ mode: 'plain', chatId: 'oc_chat' });
+  });
+
+  it('thread-scope sessions are unaffected: always reply into their own thread', () => {
+    const ds = makeDs({ scope: 'thread' });
+    ds.session.rootMessageId = 'om_root';
+    const target = resolveSessionReplyTarget(ds, fallbackTurnId(ds as DaemonSession, undefined));
+    expect(target).toEqual({ mode: 'thread', rootMessageId: 'om_root' });
+  });
+
+  it('plain chat session without any fold-back anchor keeps replying flat to the chat', () => {
+    const ds = makeDs();
+    const target = resolveSessionReplyTarget(ds, fallbackTurnId(ds as DaemonSession, undefined));
+    expect(target).toEqual({ mode: 'plain', chatId: 'oc_chat' });
+  });
+});


### PR DESCRIPTION
## 背景

多话题协作模式 dogfood（验证C，Nash shared 模式）真机实锤：dispatch 把 shared 模式 bot @ 进子话题后，正文回复正确锚进话题，但 **会话状态卡** 和 **「✅ 已选择 repo」确认** 漏到群顶层（飞书 API 拉取实锤这几条 thread_id=null）。

会话复用 chat-scope 是 shared 模式设计语义（申晗确认），**不动 scope**；要修的只是 daemon 侧消息的落点。

## 根因

`resolveSessionReplyTarget` 对 chat-scope 会话靠 turnId 闸决定「锚进折叠话题 vs plain 顶层」。两类调用没带 turnId：

1. **command-handler 的全部命令回复**（含 /repo「已选择」）——包装层从不传 turnId
2. **worker 无回合上下文的消息**（首张状态卡、崩溃通知）——msg.turnId=undefined

## 修复

- `handleCommand` 的 sessionReply 包装统一携带触发消息 messageId（= beginReplyTargetTurn 记录的 turnId，闸恰好匹配）
- 新增 `reply-target.fallbackTurnId`：**显式 turnId 始终优先**（跨回合防串闸不弱化，见测试），仅无回合上下文时回退会话当前回合锚；worker-pool 两处 scopedReply 接入
- card-handler 卡片选 repo 确认同样补锚（卡片包装仅在有 turnId 时传第5参，既有调用字节级不变）

## 测试

- 新增 `test/reply-target-fallback.test.ts` 8 例：fallback 语义、**stale turnId 仍被闸拦下**、thread-scope/plain chat 不受影响
- `command-handler.test.ts` 新增 2 例复现（修复前红：第5参 undefined）；7 处既有断言补第5参
- 全量 unit 4274/4277；3 fail 经 stash 对比为 master 基线既有（session-lifecycle-hooks + transfer-session，同 PR#186 审计结论）

## 遗留（不在本PR）

- handleRoleCommand/handleScheduleCommand 等子 handler 自带 4 参包装，shared 折叠话题内使用仍会漏顶层（低频，后续统一）
- shared 模式把子话题 @ 折进共享会话本身为设计行为；多 bot 编排若需要会话隔离，子 bot 应配 new-topic 模式