### PR TITLE
fix(bridge): 兜底 final 改取最后 tool_use 后的尾段，修 PR#174 误兜底回归

### DIFF
--- a/src/services/claude-transcript.ts
+++ b/src/services/claude-transcript.ts
@@ -194,6 +194,65 @@ export function joinAssistantText(events: TranscriptEvent[]): string {
     .join('\n\n');
 }
 
+function hasToolUseBlock(ev: TranscriptEvent): boolean {
+  const content = ev.message?.content;
+  return Array.isArray(content) && content.some(b => b && (b as any).type === 'tool_use');
+}
+
+/**
+ * The turn's FINAL answer: the contiguous run of this turn's assistant-text
+ * events after its last tool_use. A long agentic turn writes many interim
+ * narration blocks between tool calls; joining them all (joinAssistantText)
+ * makes the fallback both post a narration collage AND look "materially
+ * longer" than the model's own explicit `botmux send`, defeating the
+ * bridge-fallback gate. Walking back from the turn's last text event until a
+ * tool_use / tool_result boundary yields just the closing answer.
+ *
+ * Crossed (not boundaries): thinking-only assistant lines and non-message
+ * meta lines (`last-prompt`, `ai-title`, system, attachments) — Claude Code
+ * interleaves these freely inside a closing answer. Events from other turns
+ * never contribute: only uuids in `turnAssistantUuids` are collected.
+ * Returns '' for a turn with no text after its last tool_use (nothing worth
+ * falling back with — e.g. the turn ended in a `botmux send` call).
+ */
+export function trailingAssistantText(events: TranscriptEvent[], turnAssistantUuids: readonly string[]): string {
+  if (turnAssistantUuids.length === 0) return '';
+  const uuids = new Set(turnAssistantUuids);
+  const lastUuid = turnAssistantUuids[turnAssistantUuids.length - 1];
+  let end = -1;
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i]?.uuid === lastUuid) { end = i; break; }
+  }
+  if (end === -1) return '';
+  // The turn must actually END in text: if an assistant tool_use line follows
+  // the last text event (before any real next-turn user message), the turn
+  // closed mid-tooling — there is no final answer to fall back with.
+  for (let i = end + 1; i < events.length; i++) {
+    const ev = events[i];
+    if (!ev || typeof ev !== 'object') continue;
+    const role = ev.message?.role ?? ev.type;
+    if (role === 'assistant' && hasToolUseBlock(ev)) return '';
+    if (role === 'user' && isMeaningfulUserEvent(ev)) break;
+  }
+  const tail: TranscriptEvent[] = [];
+  for (let i = end; i >= 0; i--) {
+    const ev = events[i];
+    if (!ev || typeof ev !== 'object') continue;
+    const role = ev.message?.role ?? ev.type;
+    if (role === 'assistant') {
+      if (hasToolUseBlock(ev)) break;
+      if (ev.uuid && uuids.has(ev.uuid)) { tail.unshift(ev); continue; }
+      // Thinking-only / non-turn assistant lines: cross unless they belong to
+      // a DIFFERENT turn's visible text (then we've walked past our turn).
+      if (pickAssistantTextEvents([ev]).length > 0) break;
+      continue;
+    }
+    if (role === 'user') break;
+    // system / attachment / meta lines (last-prompt, ai-title, …): cross.
+  }
+  return joinAssistantText(tail);
+}
+
 /** XML wrappers Claude Code uses for synthetic user events that aren't real
  *  prompts (slash command invocation, local-command output caveat, etc.).
  *  These should usually carry `isMeta:true` and we'd filter on that — this

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -15,7 +15,7 @@
 import { randomBytes } from 'node:crypto';
 import { mkdirSync, writeFileSync, unlinkSync, existsSync, statSync, readdirSync, readlinkSync, readFileSync, watch as fsWatch, createWriteStream, type FSWatcher, type WriteStream } from 'node:fs';
 import { isAbsolute, join } from 'node:path';
-import { drainTranscript, joinAssistantText, findJsonlContainingFingerprint, findJsonlsContainingExactContent, findLatestJsonl, extractLastAssistantTurn, stringifyUserContent, extractTurnStartText, splitTranscriptEventsByCutoff, type TranscriptEvent } from './services/claude-transcript.js';
+import { drainTranscript, joinAssistantText, trailingAssistantText, findJsonlContainingFingerprint, findJsonlsContainingExactContent, findLatestJsonl, extractLastAssistantTurn, stringifyUserContent, extractTurnStartText, splitTranscriptEventsByCutoff, type TranscriptEvent } from './services/claude-transcript.js';
 import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint } from './services/bridge-turn-queue.js';
 import { shouldSuppressBridgeEmit, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
 import { shouldWriteNow } from './utils/input-gate.js';
@@ -1397,7 +1397,13 @@ function emitReadyTurns(): void {
     }
     const set = new Set(turn.assistantUuids);
     const matched = drained.events.filter(e => e.uuid && set.has(e.uuid));
-    const assistantText = joinAssistantText(matched);
+    // Non-adopt fallback posts the turn's FINAL answer (text after the last
+    // tool_use), not the whole-turn narration collage — joining every interim
+    // block both reads as noise in Lark and inflates finalText past the
+    // material-longer gate, re-posting turns the model already `botmux send`ed.
+    // Adopt keeps the full join: transcript drain is that mode's only channel,
+    // so interim narration is the user's only window into the turn.
+    const assistantText = adoptMode ? joinAssistantText(matched) : trailingAssistantText(drained.events, turn.assistantUuids);
     if (assistantText.length === 0) continue;
     const lastUuid = turn.assistantUuids[turn.assistantUuids.length - 1];
 

--- a/test/claude-transcript.test.ts
+++ b/test/claude-transcript.test.ts
@@ -10,11 +10,13 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync, appendFileSync, openSync, writeSync, closeSync, ftruncateSync, utimesSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, basename } from 'node:path';
+import { shouldSuppressBridgeEmit } from '../src/services/bridge-fallback-gate.js';
 import {
   drainTranscript,
   pickAssistantTextEvents,
   extractAssistantText,
   joinAssistantText,
+  trailingAssistantText,
   findLatestJsonl,
   findJsonlContainingFingerprint,
   jsonlContainsFingerprint,
@@ -1290,5 +1292,107 @@ describe('splitTranscriptEventsByCutoff', () => {
     );
     expect(history).toEqual([]);
     expect(live).toEqual([boundaryLarkEvent]);
+  });
+});
+
+// ─── trailingAssistantText：误兜底回归（PR#174 material-longer 闸 × 整轮拼接） ──
+//
+// 2026-06-11 现场：一个长工作轮（多次 tool_use、13 段过程旁白）结束时模型已
+// 显式 `botmux send`（窗口内最大 contentLength=749），但 joinAssistantText 把
+// 整轮旁白拼成 normalized 1530 当 finalText，material-longer 闸（≥2× 且 +120）
+// 判「未被覆盖」放行兜底，把整轮旁白拼贴发进了群。
+// 修复：非 adopt 的兜底 final 改取「最后一次 tool_use 之后的尾部 assistant
+// 文本」= 真正的收尾回答（该现场 normalized 903 < 749×2 → 正确抑制）。
+describe('trailingAssistantText', () => {
+  const aText = (uuid: string, text: string): TranscriptEvent => ({
+    type: 'assistant', uuid, message: { role: 'assistant', content: [{ type: 'text', text }] },
+  });
+  const aTool = (uuid: string): TranscriptEvent => ({
+    type: 'assistant', uuid, message: { role: 'assistant', content: [{ type: 'tool_use', id: `tu-${uuid}`, name: 'Bash', input: {} } as any] },
+  });
+  const aThinking = (uuid: string): TranscriptEvent => ({
+    type: 'assistant', uuid, message: { role: 'assistant', content: [{ type: 'thinking', thinking: 'hmm' } as any] },
+  });
+  const toolResult = (uuid: string): TranscriptEvent => ({
+    type: 'user', uuid, message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'x' } as any] },
+  });
+  const metaLine = (type: string): TranscriptEvent => ({ type } as TranscriptEvent);
+
+  it('pure-text turn (no tool_use): identical to joinAssistantText', () => {
+    const events = [aText('a1', 'first'), aText('a2', 'second')];
+    expect(trailingAssistantText(events, ['a1', 'a2'])).toBe('first\n\nsecond');
+    expect(trailingAssistantText(events, ['a1', 'a2'])).toBe(joinAssistantText(events));
+  });
+
+  it('narration + tool_use + final: returns ONLY the text after the last tool_use', () => {
+    const events = [
+      aText('a1', '旁白：我先看看代码。'),
+      aTool('t1'), toolResult('r1'),
+      aText('a2', '旁白：红了，10 个失败。'),
+      aTool('t2'), toolResult('r2'),
+      aText('a3', '修复完成，PR 已开。'),
+    ];
+    expect(trailingAssistantText(events, ['a1', 'a2', 'a3'])).toBe('修复完成，PR 已开。');
+  });
+
+  it('multi-segment final after the last tool_use is fully collected', () => {
+    const events = [
+      aTool('t1'), toolResult('r1'),
+      aText('a1', '结论第一段。'),
+      aText('a2', '结论第二段。'),
+    ];
+    expect(trailingAssistantText(events, ['a1', 'a2'])).toBe('结论第一段。\n\n结论第二段。');
+  });
+
+  it('thinking lines and non-message meta lines inside the tail are crossed, not boundaries', () => {
+    const events = [
+      aText('a1', '旁白'),
+      aTool('t1'), toolResult('r1'),
+      aText('a2', '收尾上半'),
+      aThinking('th1'),
+      metaLine('last-prompt'), metaLine('ai-title'),
+      aText('a3', '收尾下半'),
+    ];
+    expect(trailingAssistantText(events, ['a1', 'a2', 'a3'])).toBe('收尾上半\n\n收尾下半');
+  });
+
+  it('turn ending in a tool_use (no final text): returns empty — nothing to fall back with', () => {
+    const events = [aText('a1', '旁白'), aTool('t1'), toolResult('r1')];
+    expect(trailingAssistantText(events, ['a1'])).toBe('');
+  });
+
+  it('only collects uuids belonging to THIS turn (a previous turn final right before is not swept in)', () => {
+    const events = [
+      aText('prev', '上一轮的收尾。'),
+      aText('a1', '本轮收尾。'),
+    ];
+    expect(trailingAssistantText(events, ['a1'])).toBe('本轮收尾。');
+  });
+
+  it('field replay of the 2026-06-11 leak: gate passes the joined narration (bug) but suppresses the trailing final (fix)', () => {
+    // 形状还原：旁白若干段 + 多次工具调用 + 精炼收尾；窗口内已有
+    // contentLength=749 的显式 send marker。
+    const narration = Array.from({ length: 12 }, (_, i) => `过程旁白第 ${i} 段：`.padEnd(60, '细'));
+    const finalText = '最终收尾回答：'.padEnd(900, '答');
+    const events: TranscriptEvent[] = [];
+    const uuids: string[] = [];
+    narration.forEach((t, i) => {
+      events.push(aText(`n${i}`, t), aTool(`t${i}`), toolResult(`r${i}`));
+      uuids.push(`n${i}`);
+    });
+    events.push(aText('final', finalText));
+    uuids.push('final');
+
+    const markers = [{ sentAtMs: 5_000, contentLength: 749 }];
+    const turnBase = { markTimeMs: 1_000, isLocal: false };
+
+    const joined = joinAssistantText(events);
+    const trailing = trailingAssistantText(events, uuids);
+    expect(trailing).toBe(finalText);
+
+    // 旧行为：整轮拼接远超 749×2 → 闸放行 → 误兜底（这就是回归本体）
+    expect(shouldSuppressBridgeEmit({ ...turnBase, finalText: joined }, undefined, markers, false)).toBe(false);
+    // 新行为：尾段 900 < 749×2 → 抑制 ✓
+    expect(shouldSuppressBridgeEmit({ ...turnBase, finalText: trailing }, undefined, markers, false)).toBe(true);
   });
 });


### PR DESCRIPTION
## 现场（2026-06-11，真机数字级实锤）

长工作轮结束时模型已显式 `botmux send`（turn-sends marker 完好：窗口内 3 条，最大 contentLength=749，最后一条仅早兜底 26 秒），但兜底链路仍把**整轮 13 段过程旁白拼成一张 1729 chars 的卡片**重发进群。

## 根因

两个因素相乘：

1. `emitReadyTurns` 的 finalText = `joinAssistantText(matched)` = **turn 内全部 assistant 文本块拼接**（过程旁白 + 收尾），normalized 1530
2. PR#174 把抑制规则放宽为 material-longer 闸：final ≥ 窗口内最大 send×2 且差 ≥120 才放行兜底——本意是补发「只 send 过短进度、漏发长结论」的轮次

→ 1530 ≥ 749×2 → 闸判「未覆盖」→ 放行。**干活越久、旁白越多、收尾 send 越精炼的轮次越必中**。v2.67.0（首个含 #174 的线上版本，30 daemon 全量重启）之后误兜底高频化的根源。

## 修复

非 adopt 的兜底 final 改取「最后一个 tool_use 之后的尾部 assistant 文本」（新增 `claude-transcript.trailingAssistantText`）：

- **兜底内容**=真正的收尾回答，不再是整轮旁白拼贴（顺带修正兜底形态）
- **闸的长度参照**同步变为尾段——现场数字：尾段 903 < 749×2 → 正确抑制 ✓
- **#174 初衷保留**：短进度 send + 漏发长收尾 → 尾段仍显著长于 send → 照常补发
- turn 以 tool_use 结尾（如最后动作就是 `botmux send`）→ 尾段空 → 不兜底（语义上恰好正确）
- thinking 行 / meta 行（last-prompt、ai-title 等）只跨过不当边界；他轮 uuid 不卷入
- **adopt 模式不动**（保持整轮 join）：transcript drain 是该模式从模型到 Lark 的唯一通道，中间旁白是用户唯一的过程窗口
- codex 结构化路径不动：其 finalText 本来就是单条 agent_message

## 测试

- `claude-transcript.test.ts` 新增 `trailingAssistantText` 7 例（TDD：实现前全红），含 **2026-06-11 现场形状重放**——断言旧拼接会被闸放行（=回归本体）、新尾段被正确抑制
- 全量 unit 4271/4274；3 fail 为 master 基线既有（session-lifecycle-hooks + transfer-session，与 PR#186/#191 期间的基线一致）

## 关联

- 回归引入：#174；现场分析记录于会话 5d5a48b2 的 daemon 日志与 transcript
- 顺带发现的独立隐患（不在本 PR）：worker fs.watch 持续 EMFILE（fd 耗尽）退化轮询，30 daemon 机器疑 fd 泄漏，建议另查