### PR TITLE
fix(repo): track remote branch for wt selection

### DIFF
--- a/src/services/git-worktree.ts
+++ b/src/services/git-worktree.ts
@@ -47,6 +47,10 @@ async function localBranchExists(repo: string, branch: string): Promise<boolean>
   return (await tryGit(['rev-parse', '--verify', '--quiet', `refs/heads/${branch}`], repo)) !== null;
 }
 
+async function remoteBranchExists(repo: string, branch: string): Promise<boolean> {
+  return (await tryGit(['rev-parse', '--verify', '--quiet', `refs/remotes/origin/${branch}`], repo)) !== null;
+}
+
 /** The remote default branch (`origin/master` / `origin/main`), or `HEAD`
  *  for repos without a usable remote. `origin/HEAD` is only set on clone, so
  *  fall through to probing the usual names when it's missing. */
@@ -79,6 +83,7 @@ async function resolveMainWorktree(dir: string): Promise<string> {
  *
  * - No `branch` given → auto-pick `wt/N` (first free N), dir `<repo>-wt-N`.
  * - `branch` given and exists locally → check it out into the worktree.
+ * - `branch` given and exists remotely → create a local tracking branch from it.
  * - `branch` given and new → create it from the remote default branch.
  *
  * The base ref is fetched first so the worktree starts from the remote's
@@ -128,6 +133,21 @@ export async function createRepoWorktree(
     await git(['worktree', 'add', wtPath, branch], repo, 60_000);
     logger.info(`[git-worktree] created ${wtPath} on existing branch ${branch}`);
     return { path: wtPath, branch, baseRef: branch };
+  }
+
+  if (opts.branch?.trim()) {
+    try {
+      await git(['fetch', 'origin', branch], repo, 30_000);
+    } catch (e) {
+      logger.warn(`[git-worktree] fetch origin ${branch} failed, checking local remote ref: ${e instanceof Error ? e.message : e}`);
+    }
+
+    const remoteRef = `origin/${branch}`;
+    if (await remoteBranchExists(repo, branch)) {
+      await git(['worktree', 'add', '-b', branch, '--track', wtPath, remoteRef], repo, 60_000);
+      logger.info(`[git-worktree] created ${wtPath} tracking ${remoteRef}`);
+      return { path: wtPath, branch, baseRef: remoteRef };
+    }
   }
 
   await git(['worktree', 'add', '-b', branch, wtPath, baseRef], repo, 60_000);

--- a/test/git-worktree.test.ts
+++ b/test/git-worktree.test.ts
@@ -115,6 +115,24 @@ describe('createRepoWorktree', () => {
     expect(git(res.path, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('feat/existing');
   });
 
+  it('creates a local tracking branch when the explicit branch exists only on origin', async () => {
+    const upstream = makeUpstream('upstream');
+    git(upstream, 'switch', '-c', 'feat/remote-only');
+    git(upstream, 'commit', '--allow-empty', '-m', 'remote branch');
+    const remoteHead = git(upstream, 'rev-parse', 'HEAD');
+    git(upstream, 'switch', 'master');
+    const repo = makeClone(upstream, 'proj');
+
+    const res = await createRepoWorktree(repo, { branch: 'feat/remote-only' });
+
+    expect(res.branch).toBe('feat/remote-only');
+    expect(res.baseRef).toBe('origin/feat/remote-only');
+    expect(res.path).toBe(join(tempRoot, 'proj-feat-remote-only'));
+    expect(git(res.path, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('feat/remote-only');
+    expect(git(res.path, 'rev-parse', 'HEAD')).toBe(remoteHead);
+    expect(git(res.path, 'rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}')).toBe('origin/feat/remote-only');
+  });
+
   it('names the worktree after the MAIN repo when given a linked worktree path', async () => {
     const upstream = makeUpstream('upstream');
     const repo = makeClone(upstream, 'proj');


### PR DESCRIPTION
## Summary
- when `/repo wt <repo> <branch>` gets an explicit branch that is absent locally but present on `origin`, fetch it and create the worktree as a local tracking branch
- keep existing behavior for existing local branches and brand-new branches
- add a real-git regression test for the remote-only branch case

## Tests
- `pnpm vitest run --project unit test/git-worktree.test.ts`
- `pnpm tsc --noEmit`