### PR TITLE
fix(ask): botmux ask 答复权限遵循 canTalk

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4267,8 +4267,7 @@ botmux create-group — 用一组机器人新建飞书群
 /**
  * postAsk: 找到 daemon → POST /api/asks → 返回 AskResult。
  * 连接失败 / HTTP 错误时抛出带 exitCode 属性的 Error：
- *   - exitCode=3：daemon 不可达或 HTTP 非 400
- *   - exitCode=2：400 + no_approvers
+ *   - exitCode=3：daemon 不可达或 HTTP 错误
  */
 async function postAsk(body: Record<string, unknown>): Promise<import('./core/ask-types.js').AskResult> {
   type AskResult = import('./core/ask-types.js').AskResult;
@@ -4304,13 +4303,6 @@ async function postAsk(body: Record<string, unknown>): Promise<import('./core/as
   if (!res.ok) {
     let errBody = '';
     try { errBody = (await res.text()).slice(0, 200); } catch { /* */ }
-    if (res.status === 400 && /no_approvers/.test(errBody)) {
-      const err = new Error(
-        'botmux ask: 当前会话没有可批准者（session.owner 不在 bot.allowedUsers 里，且 --approver 未指定）',
-      ) as Error & { exitCode: number };
-      err.exitCode = 2;
-      throw err;
-    }
     const err = new Error(`botmux ask: daemon HTTP ${res.status}: ${errBody}`) as Error & { exitCode: number };
     err.exitCode = 3;
     throw err;
@@ -4369,7 +4361,6 @@ async function cmdAsk(sub: string, rest: string[]): Promise<void> {
   const optionsRaw = argValue(rest, '--options');
   const timeoutRaw = argValue(rest, '--timeout');
   const useJson = rest.includes('--json');
-  const approverArgs = argValues(rest, '--approver');
   const positionalArgs = positionals(rest, ['--json']);
 
   let options;
@@ -4402,7 +4393,6 @@ async function cmdAsk(sub: string, rest: string[]): Promise<void> {
     options,
     prompt,
     timeoutMs,
-    approvers: approverArgs,
   };
 
   let result;
@@ -4546,7 +4536,6 @@ export async function runHook(
     rootMessageId: routeRoot,
     questions: parsed.questions,
     timeoutMs,
-    approvers: [],
   };
 
   let result: import('./core/ask-types.js').AskResult;

--- a/src/core/ask-api.ts
+++ b/src/core/ask-api.ts
@@ -1,9 +1,8 @@
 /**
  * Pure helpers for the daemon's `POST /api/asks` IPC route.
  *
- * Kept separate from daemon.ts so the body-validator and the approver
- * fallback chain (§6) are unit-testable without spinning up an HTTP server,
- * registering bots, or mounting a full session map.
+ * Kept separate from daemon.ts so the body-validator is unit-testable without
+ * spinning up an HTTP server, registering bots, or mounting a full session map.
  */
 
 import type { AskOption, AskQuestion } from './ask-types.js';
@@ -17,8 +16,6 @@ export interface AskApiBody {
   questions: AskQuestion[];
   /** Already in milliseconds. CLI side converts from `--timeout` seconds. */
   timeoutMs: number;
-  /** Empty array → use the §6 fallback chain. */
-  approvers: string[];
 }
 
 export type AskApiBodyError =
@@ -95,10 +92,6 @@ export function parseAskBody(raw: unknown): AskApiBody | { error: AskApiBodyErro
     return { error: 'bad_timeoutMs' };
   }
 
-  const approvers = Array.isArray(r.approvers)
-    ? r.approvers.filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
-    : [];
-
   let questions: AskQuestion[];
 
   if (Array.isArray(r.questions)) {
@@ -135,30 +128,5 @@ export function parseAskBody(raw: unknown): AskApiBody | { error: AskApiBodyErro
     rootMessageId: r.rootMessageId as string | null,
     questions,
     timeoutMs: r.timeoutMs,
-    approvers,
   };
-}
-
-/** Resolve the approver allowlist per §6 fallback chain:
- *   1. explicit `--approver` list from CLI args (non-empty wins outright)
- *   2. session.ownerOpenId ∩ bot.allowedUsers (single-owner topic chats)
- *   3. bot.allowedUsers (shared chats / no owner / owner not in allow)
- *
- *  Pure function: caller injects the lookups. The daemon wires
- *  `getBotAllowedUsers = (id) => getBot(id).resolvedAllowedUsers` and
- *  `getSessionOwner` = scan over activeSessions; tests pass stub funcs. */
-export function resolveAskApprovers(args: {
-  larkAppId: string;
-  sessionId: string;
-  explicit: ReadonlyArray<string>;
-  getBotAllowedUsers: (larkAppId: string) => ReadonlyArray<string>;
-  getSessionOwner: (sessionId: string) => string | undefined;
-}): Set<string> {
-  const explicit = args.explicit.filter((s) => s.trim().length > 0);
-  if (explicit.length > 0) return new Set(explicit);
-
-  const allow = args.getBotAllowedUsers(args.larkAppId);
-  const owner = args.getSessionOwner(args.sessionId);
-  if (owner && allow.includes(owner)) return new Set([owner]);
-  return new Set(allow);
 }

--- a/src/core/ask-args.ts
+++ b/src/core/ask-args.ts
@@ -1,9 +1,9 @@
 /**
  * Pure helpers for `botmux ask` argument parsing.
  *
- * Kept in its own file (no I/O, no env reads) so the CSV / timeout / approver
- * parsing can be unit-tested without spinning up a daemon. The actual CLI
- * dispatch (`cmdAsk`) lives in cli.ts and calls these helpers.
+ * Kept in its own file (no I/O, no env reads) so the CSV / timeout parsing can
+ * be unit-tested without spinning up a daemon. The actual CLI dispatch
+ * (`cmdAsk`) lives in cli.ts and calls these helpers.
  */
 
 import type { AskOption } from './ask-types.js';

--- a/src/core/ask-broker.ts
+++ b/src/core/ask-broker.ts
@@ -35,6 +35,26 @@ interface InternalPending extends Omit<PendingAsk, 'selections'> {
 const pending = new Map<string, InternalPending>();
 let dispatcher: AskCardDispatcher | null = null;
 
+/** IM-side canTalk predicate, wired by the daemon at bootstrap. Lets the broker
+ *  honour the bot's canTalk gate without importing Lark types: whoever may
+ *  address the bot in this chat may answer its `botmux ask`. Returns false until
+ *  wired, so an unwired broker authorizes no one (daemon always wires it). */
+let canTalkChecker: ((larkAppId: string, chatId: string, openId: string) => boolean) | null = null;
+
+/** Wire the canTalk predicate. Called once during daemon bootstrap. */
+export function setCanTalkChecker(
+  fn: (larkAppId: string, chatId: string, openId: string) => boolean,
+): void {
+  canTalkChecker = fn;
+}
+
+/** A click is authorized iff the clicker may `canTalk` to the bot in this chat.
+ *  `botmux ask` is a talk-level interaction (answering the agent's question),
+ *  so it follows the canTalk gate — not the stricter canOperate / allowedUsers. */
+function isAuthorizedToAnswer(ask: InternalPending, by: string): boolean {
+  return canTalkChecker?.(ask.larkAppId, ask.chatId, by) ?? false;
+}
+
 /** Window during which a settled ask is still queryable so race-losers get a
  *  precise `already_settled` outcome (and the card click handler can show
  *  "已被 X 答了" instead of a generic "已失效"). After this window expires,
@@ -97,7 +117,6 @@ export function registerAsk(input: CreateAskInput): Promise<AskResult> {
       chatId: input.chatId,
       rootMessageId: input.rootMessageId,
       sessionId: input.sessionId,
-      approvers: input.approvers,
       questions: input.questions,
       createdAt,
       deadlineAt,
@@ -153,7 +172,7 @@ export function toggleAsk(args: {
   if (!ask) return 'stale';
   if (ask.nonce !== args.nonce) return 'stale';
   if (ask.settled) return 'already_settled';
-  if (!ask.approvers.has(args.by)) return 'unauthorized';
+  if (!isAuthorizedToAnswer(ask, args.by)) return 'unauthorized';
 
   const question = ask.questions[args.questionIndex];
   if (!question) return 'stale';
@@ -197,7 +216,7 @@ export function submitAsk(args: {
   if (!ask) return 'stale';
   if (ask.nonce !== args.nonce) return 'stale';
   if (ask.settled) return 'already_settled';
-  if (!ask.approvers.has(args.by)) return 'unauthorized';
+  if (!isAuthorizedToAnswer(ask, args.by)) return 'unauthorized';
 
   // 构建最终答案数组（按问题顺序）
   let answers: ReadonlyArray<ReadonlyArray<string>>;
@@ -239,7 +258,7 @@ export function submitAsk(args: {
 /**
  * 提交一段自定义回复（用户在话题里直接打字作答，替代点按钮）并 settle。
  *
- * 校验：askId 存在 / 未 settle / `by` 在 approvers / text trim 后非空。
+ * 校验：askId 存在 / 未 settle / `by` 可 canTalk / text trim 后非空。
  * settle 为 `kind:'answered'`，各问 `answers` 为空数组、`comment` 携带 trim 后原文
  * （替代语义：没有任何选项被选中，CLI 侧 formatAnswer 用 comment 回落作答）。
  *
@@ -257,7 +276,7 @@ export function submitCustomReply(args: {
   const ask = pending.get(args.askId);
   if (!ask) return 'stale';
   if (ask.settled) return 'already_settled';
-  if (!ask.approvers.has(args.by)) return 'unauthorized';
+  if (!isAuthorizedToAnswer(ask, args.by)) return 'unauthorized';
   const text = args.text.trim();
   if (!text) return 'stale';
 
@@ -439,4 +458,5 @@ export function _resetForTest(): void {
   for (const ask of pending.values()) clearTimeout(ask.timeoutHandle);
   pending.clear();
   dispatcher = null;
+  canTalkChecker = null;
 }

--- a/src/core/ask-types.ts
+++ b/src/core/ask-types.ts
@@ -82,8 +82,8 @@ export interface AskJsonOutput {
 }
 
 /** Input accepted by broker.registerAsk. Caller (CLI subcommand → daemon IPC
- *  handler) is responsible for env validation, parameter parsing, and resolving
- *  the approver allowlist before reaching the broker.
+ *  handler) is responsible for env validation and parameter parsing. Click
+ *  authorization is the bot's canTalk gate, injected via `setCanTalkChecker`.
  *
  *  v0.1.8 变更：`options`/`prompt` 字段替换为 `questions: ReadonlyArray<AskQuestion>`。 */
 export interface CreateAskInput {
@@ -93,10 +93,6 @@ export interface CreateAskInput {
   rootMessageId: string | null;
   /** Session that issued the ask — used for audit + future replay scoping. */
   sessionId: string;
-  /** Pre-resolved open_id allowlist. Empty set means no one can answer; the
-   *  caller (not the broker) must enforce the §6 approver fallback chain so the
-   *  broker stays IM-agnostic. */
-  approvers: ReadonlySet<string>;
   /** 问题列表，调用方保证每问 `options.length ≥ 2` 且 key 唯一。 */
   questions: ReadonlyArray<AskQuestion>;
   /** Absolute deadline; computed by caller from `--timeout`. Broker won't
@@ -118,7 +114,6 @@ export interface PendingAsk {
   chatId: string;
   rootMessageId: string | null;
   sessionId: string;
-  approvers: ReadonlySet<string>;
   /** 问题列表，替代旧的 `options` + `prompt`。 */
   questions: ReadonlyArray<AskQuestion>;
   /** 当前已勾选答案快照。仅 daemon/card 内部使用；CLI IPC 边界不暴露。 */
@@ -137,7 +132,7 @@ export interface PendingAsk {
 export type AskClickOutcome =
   /** First valid click — caller's Promise resolves with `kind:'answered'`. */
   | 'accepted'
-  /** Clicker's open_id not in approvers — caller shows "你没有权限". */
+  /** Clicker can't canTalk to the bot in this chat — caller shows "你没有权限". */
   | 'unauthorized'
   /** No such askId, nonce mismatch, or unknown option — caller shows
    *  "此 ask 已失效（daemon 重启）". Covers the §8 stale-card case. */

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -139,11 +139,12 @@ import { isValidRunId, readRunSnapshot } from './workflows/ops-projection.js';
 import { AttemptResumeManager } from './workflows/attempt-resume.js';
 import {
   setCardDispatcher as setAskCardDispatcher,
+  setCanTalkChecker as setAskCanTalkChecker,
   registerAsk as registerAskBroker,
   findPendingAskByAnchor,
   submitCustomReply,
 } from './core/ask-broker.js';
-import { parseAskBody, resolveAskApprovers } from './core/ask-api.js';
+import { parseAskBody } from './core/ask-api.js';
 import { computeCocoPickerKeys } from './core/coco-picker-keys.js';
 import { createLarkAskCardDispatcher } from './im/lark/ask-card.js';
 
@@ -1748,32 +1749,13 @@ ipcRoute('POST', '/api/asks', async (req, res) => {
   const parsed = parseAskBody(raw);
   if ('error' in parsed) return jsonRes(res, 400, { ok: false, error: parsed.error });
 
-  const approvers = resolveAskApprovers({
-    larkAppId: parsed.larkAppId,
-    sessionId: parsed.sessionId,
-    explicit: parsed.approvers,
-    getBotAllowedUsers: (id) => {
-      try { return getBot(id).resolvedAllowedUsers; } catch { return []; }
-    },
-    getSessionOwner: (sid) => {
-      for (const ds of activeSessions.values()) {
-        if (ds.session.sessionId === sid) return ds.ownerOpenId;
-      }
-      return undefined;
-    },
-  });
-  if (approvers.size === 0) {
-    // Nobody can answer — fail loud rather than registering a
-    // guaranteed-timeout. CLI side maps this to exit 2.
-    return jsonRes(res, 400, { ok: false, error: 'no_approvers' });
-  }
-
+  // 谁能答复 = 谁能在该 chat 跟 bot 说话（canTalk）。鉴权在 broker 点击时按注入的
+  // canTalkChecker 判定（见下方 setAskCanTalkChecker），daemon 这里不再预解析 approver。
   const result = await registerAskBroker({
     larkAppId: parsed.larkAppId,
     chatId: parsed.chatId,
     rootMessageId: parsed.rootMessageId,
     sessionId: parsed.sessionId,
-    approvers,
     questions: parsed.questions,
     timeoutMs: parsed.timeoutMs,
   });
@@ -2981,17 +2963,17 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
     }
   }
 
-  // 自定义回复拦截：该话题有未结的 ask 且发送者有答复权限 → 把这条文字当答案，
-  // 走 submitCustomReply settle 掉 ask（替代选项语义），不再当作新一轮指令喂给 CLI。
-  // 此时发起 ask 的 CLI 正阻塞等结果，回什么都得先等 ask 结束，故无副作用。
-  // 仅拦截纯文字（slash 命令 / 回调 URL / workflow 已在上方各自 return，可用来中止）；
-  // 外部 bot 的 open_id 不在 approvers 里，天然不会命中。非授权人 / 空文字则落到正常
-  // 路由。卡片由 broker.onSettle 自动 PATCH 反映答案，无需额外回消息。
+  // 自定义回复拦截：该话题有未结的 ask 时，把这条文字当答案，走 submitCustomReply
+  // settle 掉 ask（替代选项语义），不再当作新一轮指令喂给 CLI。此时发起 ask 的 CLI
+  // 正阻塞等结果，回什么都得先等 ask 结束，故无副作用。仅拦截纯文字（slash 命令 /
+  // 回调 URL / workflow 已在上方各自 return，可用来中止）。答复权限 = canTalk，由
+  // broker 在 submitCustomReply 内按注入的 canTalkChecker 判定：非授权人返回
+  // 'unauthorized'，这里 fall through 到正常路由。卡片由 broker.onSettle 自动 PATCH。
   if (threadSenderOpenId && threadChatId) {
     const askReplyText = cmdContent.trim();
     if (askReplyText) {
       const pendingAsk = findPendingAskByAnchor({ larkAppId, chatId: threadChatId, anchor });
-      if (pendingAsk && pendingAsk.approvers.has(threadSenderOpenId)) {
+      if (pendingAsk) {
         const outcome = submitCustomReply({
           askId: pendingAsk.askId,
           by: threadSenderOpenId,
@@ -3381,6 +3363,9 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   scheduleStore.startExternalWriteWatcher();
   logger.info(`Bot ${idx}/${botConfigs.length}: ${cfg.larkAppId} (cli: ${cfg.cliId})`)
   setAskCardDispatcher(createLarkAskCardDispatcher());
+  // Honour the bot's canTalk gate for `botmux ask` answers: a clicker who may
+  // address the bot in this chat may answer an implicit-approver ask.
+  setAskCanTalkChecker((appId, chatId, openId) => evaluateTalk(appId, chatId, openId).allowed);
 
   writePidFile();
   const memoryDiagnostics = startMemoryDiagnostics();

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -665,6 +665,7 @@ export const messages: Record<string, string> = {
   'card.ask.timed_out': 'Timed out, no answer',
   'card.ask.invalidated': 'No longer valid',
   'card.ask.no_approver': 'No eligible responders',
+  'card.ask.answerable_talk_members': 'anyone who can talk to me in this chat',
 
   // Voice summary instruction (injected into the model session)
   'card.voice.summary_instruction': '🔊 [Voice summary request] Condense your last reply to the user into spoken prose of at most 5 sentences suitable for reading aloud: drop code, commands, file paths, URLs, English abbreviations and markdown; state only the conclusions, and get to the point in the first sentence. Then call `botmux send --voice "<the condensed spoken text>"` to send it as voice. Send only this one voice message — no extra text.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -668,6 +668,7 @@ export const messages: Record<string, string> = {
   'card.ask.timed_out': '超时未答',
   'card.ask.invalidated': '已失效',
   'card.ask.no_approver': '无可用答复人',
+  'card.ask.answerable_talk_members': '本群可对话成员',
 
   // Voice summary instruction (injected into the model session)
   'card.voice.summary_instruction': '🔊【语音总结请求】把你上一条发给用户的回复，精简成不超过 5 句、适合朗读的口语：去掉代码、命令、文件路径、URL、英文缩写和 markdown 标记，只讲结论，第一句直接进正题。然后调用 `botmux send --voice "<精简后的口语>"` 把它作为语音发出来。只发这一条语音，不要再额外发文字说明。',

--- a/src/im/lark/ask-card.ts
+++ b/src/im/lark/ask-card.ts
@@ -353,11 +353,10 @@ function templateForResult(result: AskResult): string {
   }
 }
 
-function approverSummary(ask: PendingAsk, locale?: Locale): string {
-  if (ask.approvers.size === 0) return t('card.ask.no_approver', undefined, locale);
-  const values = [...ask.approvers].map((id) => short(id, 18));
-  if (values.length <= 3) return values.join(', ');
-  return `${values.slice(0, 3).join(', ')} +${values.length - 3}`;
+function approverSummary(_ask: PendingAsk, locale?: Locale): string {
+  // 答复权限 = canTalk：谁能在该群跟 bot 说话谁就能答。卡片统一显示「本群可对话成员」，
+  // 不再按 open_id 列名单（鉴权在 broker 点击时按 canTalk 判定）。
+  return t('card.ask.answerable_talk_members', undefined, locale);
 }
 
 function asString(value: unknown): string | undefined {

--- a/test/ask-api.test.ts
+++ b/test/ask-api.test.ts
@@ -1,13 +1,12 @@
 /**
- * Unit tests for the daemon-side `POST /api/asks` helpers — parseAskBody and
- * the §6 approver-fallback chain. Pure-function tests, no HTTP server, no
- * bot-registry mocking.
+ * Unit tests for the daemon-side `POST /api/asks` body parser (parseAskBody).
+ * Pure-function tests, no HTTP server, no bot-registry mocking.
  *
  * Run:  pnpm vitest run test/ask-api.test.ts
  */
 import { describe, expect, it } from 'vitest';
 
-import { parseAskBody, resolveAskApprovers } from '../src/core/ask-api.js';
+import { parseAskBody } from '../src/core/ask-api.js';
 
 function validBody(over: Record<string, unknown> = {}) {
   return {
@@ -21,7 +20,6 @@ function validBody(over: Record<string, unknown> = {}) {
     ],
     prompt: '继续发版吗？',
     timeoutMs: 60_000,
-    approvers: [],
     ...over,
   };
 }
@@ -36,7 +34,6 @@ describe('parseAskBody — happy path', () => {
     expect(out.questions).toHaveLength(1);
     expect(out.questions[0].options).toHaveLength(2);
     expect(out.questions[0].options[0]).toEqual({ key: 'yes', label: '继续' });
-    expect(out.approvers).toEqual([]);
     expect(out.rootMessageId).toBe('om_root');
   });
 
@@ -45,14 +42,6 @@ describe('parseAskBody — happy path', () => {
     expect('error' in out).toBe(false);
     if ('error' in out) return;
     expect(out.rootMessageId).toBeNull();
-  });
-
-  it('filters blank entries from approvers array', () => {
-    const out = parseAskBody(
-      validBody({ approvers: ['ou_a', '', '   ', 'ou_b'] }),
-    );
-    if ('error' in out) throw new Error('expected ok');
-    expect(out.approvers).toEqual(['ou_a', 'ou_b']);
   });
 });
 
@@ -126,7 +115,7 @@ describe('parseAskBody — questions[] 多问多选', () => {
   it('接受 questions[]（多问多选）', () => {
     const body = parseAskBody({
       sessionId: 's', chatId: 'c', larkAppId: 'a', rootMessageId: null,
-      timeoutMs: 60000, approvers: [],
+      timeoutMs: 60000,
       questions: [
         { prompt: 'q1', multiSelect: false, options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }] },
         { prompt: 'q2', multiSelect: true, options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }] },
@@ -139,83 +128,13 @@ describe('parseAskBody — questions[] 多问多选', () => {
   it('兼容旧 options[]+prompt：归一成单问单选', () => {
     const body = parseAskBody({
       sessionId: 's', chatId: 'c', larkAppId: 'a', rootMessageId: null,
-      timeoutMs: 60000, approvers: [], prompt: 'go?', options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }],
+      timeoutMs: 60000, prompt: 'go?', options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }],
     });
     if (!('error' in body)) { expect(body.questions).toHaveLength(1); expect(body.questions[0].prompt).toBe('go?'); expect(body.questions[0].multiSelect).toBe(false); }
   });
 
   it('每问 options<2 报错', () => {
-    const body = parseAskBody({ sessionId: 's', chatId: 'c', larkAppId: 'a', rootMessageId: null, timeoutMs: 60000, approvers: [], questions: [{ prompt: 'q', multiSelect: false, options: [{ key: 'x', label: 'X' }] }] });
+    const body = parseAskBody({ sessionId: 's', chatId: 'c', larkAppId: 'a', rootMessageId: null, timeoutMs: 60000, questions: [{ prompt: 'q', multiSelect: false, options: [{ key: 'x', label: 'X' }] }] });
     expect('error' in body).toBe(true);
-  });
-});
-
-describe('resolveAskApprovers — §6 fallback chain', () => {
-  const allowDefault = ['ou_owner', 'ou_admin', 'ou_other'];
-
-  it('explicit --approver list wins outright (ignores fallback)', () => {
-    const got = resolveAskApprovers({
-      larkAppId: 'cli_app',
-      sessionId: 'sess-1',
-      explicit: ['ou_explicit_a', 'ou_explicit_b'],
-      getBotAllowedUsers: () => allowDefault,
-      getSessionOwner: () => 'ou_owner',
-    });
-    expect([...got].sort()).toEqual(['ou_explicit_a', 'ou_explicit_b']);
-  });
-
-  it('filters blank entries from explicit list', () => {
-    const got = resolveAskApprovers({
-      larkAppId: 'cli_app',
-      sessionId: 'sess-1',
-      explicit: ['ou_a', '   ', ''],
-      getBotAllowedUsers: () => allowDefault,
-      getSessionOwner: () => 'ou_owner',
-    });
-    expect([...got]).toEqual(['ou_a']);
-  });
-
-  it('owner ∩ allowedUsers when explicit is empty and owner exists in allowlist', () => {
-    const got = resolveAskApprovers({
-      larkAppId: 'cli_app',
-      sessionId: 'sess-1',
-      explicit: [],
-      getBotAllowedUsers: () => allowDefault,
-      getSessionOwner: () => 'ou_owner',
-    });
-    expect([...got]).toEqual(['ou_owner']);
-  });
-
-  it('falls back to full allowedUsers when owner is not in allowlist', () => {
-    const got = resolveAskApprovers({
-      larkAppId: 'cli_app',
-      sessionId: 'sess-1',
-      explicit: [],
-      getBotAllowedUsers: () => allowDefault,
-      getSessionOwner: () => 'ou_stranger',
-    });
-    expect([...got].sort()).toEqual([...allowDefault].sort());
-  });
-
-  it('falls back to full allowedUsers when owner is unknown', () => {
-    const got = resolveAskApprovers({
-      larkAppId: 'cli_app',
-      sessionId: 'sess-1',
-      explicit: [],
-      getBotAllowedUsers: () => allowDefault,
-      getSessionOwner: () => undefined,
-    });
-    expect([...got].sort()).toEqual([...allowDefault].sort());
-  });
-
-  it('returns empty set when neither explicit, owner, nor allowedUsers exist', () => {
-    const got = resolveAskApprovers({
-      larkAppId: 'cli_app',
-      sessionId: 'sess-1',
-      explicit: [],
-      getBotAllowedUsers: () => [],
-      getSessionOwner: () => undefined,
-    });
-    expect(got.size).toBe(0);
   });
 });

--- a/test/ask-broker.test.ts
+++ b/test/ask-broker.test.ts
@@ -1,6 +1,7 @@
 /**
- * Contract tests for the ask broker — covers §3 lifecycle, §6 approver, §7
- * timeout, §8 invalidation. Card dispatch is mocked via a fake AskCardDispatcher
+ * Contract tests for the ask broker — covers §3 lifecycle, canTalk-based click
+ * authorization, §7 timeout, §8 invalidation. Card dispatch is mocked via a fake
+ * AskCardDispatcher
  * so these tests stay IM-agnostic and run in pure node.
  *
  * Run:  pnpm vitest run test/ask-broker.test.ts
@@ -16,6 +17,7 @@ import {
   invalidateAll,
   registerAsk,
   setCardDispatcher,
+  setCanTalkChecker,
   submitAsk,
   submitCustomReply,
   toggleAsk,
@@ -40,7 +42,6 @@ function makeInput(over: Partial<CreateAskInput> = {}): CreateAskInput {
     chatId: 'oc_chat',
     rootMessageId: 'om_root',
     sessionId: 'sess-1',
-    approvers: new Set(['ou_owner']),
     questions: [{ prompt: '继续发版吗？', options: OPTIONS, multiSelect: false }],
     timeoutMs: 5_000,
     ...over,
@@ -73,9 +74,14 @@ function mockDispatcher(
   };
 }
 
+// 默认 canTalk 放行集：模拟「这些 open_id 能在该 chat 跟 bot 说话」。
+// 答复鉴权 = canTalk，故凡在此集合内者可作答，其余（ou_stranger / ou_other）拒绝。
+const DEFAULT_TALKERS = new Set(['ou_owner', 'ou_a', 'ou_b', 'ou_u', 'ou_talker']);
+
 beforeEach(() => {
   vi.useFakeTimers();
   _resetForTest();
+  setCanTalkChecker((_app, _chat, openId) => DEFAULT_TALKERS.has(openId));
 });
 
 afterEach(() => {
@@ -98,7 +104,6 @@ describe('registerAsk happy path', () => {
     expect(d.sendCalls).toHaveLength(1);
     const [dispatched] = d.sendCalls;
     expect(dispatched.questions).toEqual([{ prompt: '继续发版吗？', options: OPTIONS, multiSelect: false }]);
-    expect(dispatched.approvers.has('ou_owner')).toBe(true);
 
     const outcome = tryResolveAsk({
       askId: dispatched.askId,
@@ -170,13 +175,14 @@ describe('tryResolveAsk gating', () => {
     ).toBe('stale');
   });
 
-  it('returns "unauthorized" when clicker is not in approver allowlist', async () => {
+  it('returns "unauthorized" when clicker cannot canTalk in this chat', async () => {
     const d = mockDispatcher();
     setCardDispatcher(d);
-    registerAsk(makeInput({ approvers: new Set(['ou_owner']) }));
+    registerAsk(makeInput());
     await Promise.resolve();
     await Promise.resolve();
     const { askId, nonce } = d.sendCalls[0]!;
+    // ou_stranger 不在默认 canTalk 放行集 → unauthorized
     expect(
       tryResolveAsk({ askId, nonce, selected: 'yes', by: 'ou_stranger' }),
     ).toBe('unauthorized');
@@ -199,9 +205,7 @@ describe('tryResolveAsk gating', () => {
   it('returns "already_settled" for a second click after race winner', async () => {
     const d = mockDispatcher();
     setCardDispatcher(d);
-    registerAsk(
-      makeInput({ approvers: new Set(['ou_a', 'ou_b']) }),
-    );
+    registerAsk(makeInput());
     await Promise.resolve();
     await Promise.resolve();
     const { askId, nonce } = d.sendCalls[0]!;
@@ -212,6 +216,60 @@ describe('tryResolveAsk gating', () => {
     expect(
       tryResolveAsk({ askId, nonce, selected: 'no', by: 'ou_b' }),
     ).toBe('already_settled');
+  });
+});
+
+describe('canTalk authorization (遵循 canTalk 权限)', () => {
+  it('canTalk 命中 → 可作答（不依赖任何 approver 名单）', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    // 仅 ou_talker 能在该 chat 对话，其余拒绝（覆盖默认放行集）
+    setCanTalkChecker((_app, chatId, openId) => chatId === 'oc_chat' && openId === 'ou_talker');
+    registerAsk(makeInput());
+    await Promise.resolve();
+    await Promise.resolve();
+    const { askId, nonce } = d.sendCalls[0]!;
+    expect(tryResolveAsk({ askId, nonce, selected: 'yes', by: 'ou_talker' })).toBe('accepted');
+  });
+
+  it('canTalk 未命中 → unauthorized，ask 仍 pending', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    setCanTalkChecker(() => false);
+    registerAsk(makeInput());
+    await Promise.resolve();
+    await Promise.resolve();
+    const { askId, nonce } = d.sendCalls[0]!;
+    expect(tryResolveAsk({ askId, nonce, selected: 'yes', by: 'ou_stranger' })).toBe('unauthorized');
+    expect(_pendingCount()).toBe(1);
+  });
+
+  it('checker 未注入（degraded）→ 谁都不能答', async () => {
+    const d = mockDispatcher();
+    _resetForTest();        // 清空 beforeEach 注入的默认 checker
+    setCardDispatcher(d);
+    registerAsk(makeInput());
+    await Promise.resolve();
+    await Promise.resolve();
+    const { askId, nonce } = d.sendCalls[0]!;
+    expect(tryResolveAsk({ askId, nonce, selected: 'yes', by: 'ou_owner' })).toBe('unauthorized');
+  });
+
+  it('canTalk 放行覆盖 toggle / submitCustomReply 路径', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    setCanTalkChecker((_app, _chat, openId) => openId === 'ou_talker');
+    registerAsk(makeInput({
+      questions: [{ prompt: '多选？', options: OPTIONS, multiSelect: true }],
+    }));
+    await Promise.resolve();
+    await Promise.resolve();
+    const { askId, nonce } = d.sendCalls[0]!;
+    // 非 canTalk 用户被拒（先于 settle 验证）
+    expect(toggleAsk({ askId, nonce, questionIndex: 0, key: 'no', by: 'ou_stranger' })).toBe('unauthorized');
+    // canTalk 用户可 toggle + 自定义文字作答
+    expect(toggleAsk({ askId, nonce, questionIndex: 0, key: 'yes', by: 'ou_talker' })).toBe('toggled');
+    expect(submitCustomReply({ askId, by: 'ou_talker', text: '我直接打字答' })).toBe('accepted');
   });
 });
 
@@ -343,10 +401,10 @@ describe('onSettle hook is best-effort', () => {
 describe('toggleAsk + submitAsk', () => {
   it('多选：toggle 累积，submit 才 settle', async () => {
     _resetForTest();
+    setCanTalkChecker((_app, _chat, openId) => DEFAULT_TALKERS.has(openId));
     setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
     const p = registerAsk({
       larkAppId: 'a', chatId: 'c', rootMessageId: null, sessionId: 's',
-      approvers: new Set(['ou_u']),
       questions: [{ prompt: 'pick', options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }], multiSelect: true }],
       timeoutMs: 60_000,
     });
@@ -366,10 +424,10 @@ describe('toggleAsk + submitAsk', () => {
 
   it('toggle 取消选中（再次 toggle 同一 key 去除）', async () => {
     _resetForTest();
+    setCanTalkChecker((_app, _chat, openId) => DEFAULT_TALKERS.has(openId));
     setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
     const p = registerAsk({
       larkAppId: 'a', chatId: 'c', rootMessageId: null, sessionId: 's',
-      approvers: new Set(['ou_u']),
       questions: [{ prompt: 'pick', options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }], multiSelect: true }],
       timeoutMs: 60_000,
     });
@@ -386,10 +444,10 @@ describe('toggleAsk + submitAsk', () => {
 
   it('单选：toggle 后再 toggle 同一 key，set 内只保留该 key', async () => {
     _resetForTest();
+    setCanTalkChecker((_app, _chat, openId) => DEFAULT_TALKERS.has(openId));
     setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
     const p = registerAsk({
       larkAppId: 'a', chatId: 'c', rootMessageId: null, sessionId: 's',
-      approvers: new Set(['ou_u']),
       questions: [{ prompt: 'go', options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }], multiSelect: false }],
       timeoutMs: 60_000,
     });
@@ -405,10 +463,10 @@ describe('toggleAsk + submitAsk', () => {
 
   it('单问单选：submit 携带显式 selections', async () => {
     _resetForTest();
+    setCanTalkChecker((_app, _chat, openId) => DEFAULT_TALKERS.has(openId));
     setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
     const p = registerAsk({
       larkAppId: 'a', chatId: 'c', rootMessageId: null, sessionId: 's',
-      approvers: new Set(['ou_u']),
       questions: [{ prompt: 'go', options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }], multiSelect: false }],
       timeoutMs: 60_000,
     });
@@ -421,10 +479,10 @@ describe('toggleAsk + submitAsk', () => {
 
   it('未授权 toggle/submit 不改变状态', async () => {
     _resetForTest();
+    setCanTalkChecker((_app, _chat, openId) => DEFAULT_TALKERS.has(openId));
     setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
     registerAsk({
       larkAppId: 'a', chatId: 'c', rootMessageId: null, sessionId: 's',
-      approvers: new Set(['ou_u']),
       questions: [{ prompt: 'pick', options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }], multiSelect: true }],
       timeoutMs: 60_000,
     });
@@ -440,22 +498,24 @@ describe('toggleAsk + submitAsk', () => {
 
   it('toggleAsk 返回 stale（未知 askId）', () => {
     _resetForTest();
+    setCanTalkChecker((_app, _chat, openId) => DEFAULT_TALKERS.has(openId));
     setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
     expect(toggleAsk({ askId: 'no-such', nonce: 'x', questionIndex: 0, key: 'a', by: 'ou_u' })).toBe('stale');
   });
 
   it('submitAsk 返回 stale（未知 askId）', () => {
     _resetForTest();
+    setCanTalkChecker((_app, _chat, openId) => DEFAULT_TALKERS.has(openId));
     setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
     expect(submitAsk({ askId: 'no-such', nonce: 'x', by: 'ou_u' })).toBe('stale');
   });
 
   it('toggleAsk 返回 stale（options 中不存在的 key）', async () => {
     _resetForTest();
+    setCanTalkChecker((_app, _chat, openId) => DEFAULT_TALKERS.has(openId));
     setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
     registerAsk({
       larkAppId: 'a', chatId: 'c', rootMessageId: null, sessionId: 's',
-      approvers: new Set(['ou_u']),
       questions: [{ prompt: 'pick', options: [{ key: 'a', label: 'A' }], multiSelect: true }],
       timeoutMs: 60_000,
     });
@@ -466,10 +526,10 @@ describe('toggleAsk + submitAsk', () => {
 
   it('submitAsk 单选问题未选任何项时返回 stale', async () => {
     _resetForTest();
+    setCanTalkChecker((_app, _chat, openId) => DEFAULT_TALKERS.has(openId));
     setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
     registerAsk({
       larkAppId: 'a', chatId: 'c', rootMessageId: null, sessionId: 's',
-      approvers: new Set(['ou_u']),
       questions: [{ prompt: 'go', options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }], multiSelect: false }],
       timeoutMs: 60_000,
     });
@@ -482,6 +542,7 @@ describe('toggleAsk + submitAsk', () => {
 
   it('_allAskIds 返回所有未 settle 及已 settle(retention 内)的 askId', async () => {
     _resetForTest();
+    setCanTalkChecker((_app, _chat, openId) => DEFAULT_TALKERS.has(openId));
     setCardDispatcher({ send: async () => ({ messageId: 'm1' }) });
     registerAsk(makeInput({ sessionId: 'sx' }));
     registerAsk(makeInput({ sessionId: 'sy' }));

--- a/test/ask-card.test.ts
+++ b/test/ask-card.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { PendingAsk } from '../src/core/ask-types.js';
 
@@ -14,6 +14,7 @@ import {
   _resetForTest,
   registerAsk,
   setCardDispatcher,
+  setCanTalkChecker,
   submitAsk,
 } from '../src/core/ask-broker.js';
 import {
@@ -28,13 +29,18 @@ import {
 
 const mockedSubmitAsk = vi.mocked(submitAsk);
 
+// 答复鉴权 = canTalk。卡片点击测试里默认只放行 ou_owner，其余（如 ou_intruder）拒绝。
+beforeEach(() => {
+  setCanTalkChecker((_app, _chat, openId) => openId === 'ou_owner');
+});
+
 afterEach(() => {
   _resetForTest();
   // 只清计数/记录，不重置实现（spy 默认透传真实 submitAsk）
   mockedSubmitAsk.mockClear();
 });
 
-/** 构造一个带 questions/askId/nonce/deadlineAt/approvers 的 PendingAsk。 */
+/** 构造一个带 questions/askId/nonce/deadlineAt 的 PendingAsk。 */
 function makePending(overrides: Partial<PendingAsk> = {}): PendingAsk {
   return {
     askId: 'ask-1',
@@ -43,7 +49,6 @@ function makePending(overrides: Partial<PendingAsk> = {}): PendingAsk {
     chatId: 'oc_chat',
     rootMessageId: 'om_root',
     sessionId: 'sess-1',
-    approvers: new Set(['ou_owner']),
     questions: [
       {
         prompt: '线上 latency 涨了 30%，下一步怎么处理？',
@@ -88,15 +93,15 @@ describe('buildAskCard', () => {
     expect(blob).toContain('"key":"a"');
   });
 
-  it('单问卡片：渲染 prompt、approver、ask_id、nonce', () => {
+  it('单问卡片：渲染 prompt、可答复栏、ask_id、nonce', () => {
     const card = JSON.parse(buildAskCard(makePending()));
     const text = JSON.stringify(card);
 
     expect(card.header.title.content).toBe('botmux ask');
     expect(text).toContain('线上 latency');
-    // approver 应在卡片的 meta div fields 中（经 escapeMd 处理后 _ 被转义为 \_）
+    // 可答复栏 = canTalk 语义，统一显示「本群可对话成员」，不再按 open_id 列名单
     const metaDiv = card.elements[0];
-    expect(metaDiv.fields[1].text.content).toContain('ou\\_owner');
+    expect(metaDiv.fields[1].text.content).toContain('可对话成员');
     expect(text).toContain('"ask_id":"ask-1"');
     expect(text).toContain('"nonce":"nonce-1"');
     // 单问单选：稳定 action button，点击即答；不使用会被飞书 silent-drop 的 form/select_static
@@ -213,7 +218,6 @@ describe('handleAskCardAction', () => {
       chatId: 'oc_chat',
       rootMessageId: 'om_root',
       sessionId: 'sess-1',
-      approvers: new Set(['ou_owner']),
       questions: makePending().questions,
       timeoutMs: 10_000,
     });
@@ -264,7 +268,6 @@ describe('handleAskCardAction', () => {
       chatId: 'oc_chat',
       rootMessageId: 'om_root',
       sessionId: 'sess-1',
-      approvers: new Set(['ou_owner']),
       questions: makePending().questions,
       timeoutMs: 10_000,
     });
@@ -298,7 +301,6 @@ describe('handleAskCardAction', () => {
       chatId: 'oc_chat',
       rootMessageId: 'om_root',
       sessionId: 'sess-1',
-      approvers: new Set(['ou_owner']),
       questions: [
         { prompt: 'q', multiSelect: true, options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }] },
       ],
@@ -376,7 +378,6 @@ describe('handleAskCardAction: ask_submit 路径', () => {
       chatId: 'oc_chat',
       rootMessageId: 'om_root',
       sessionId: 'sess-1',
-      approvers: new Set(['ou_owner']),
       questions: [
         {
           prompt: '问题1',
@@ -406,7 +407,6 @@ describe('handleAskCardAction: ask_submit 路径', () => {
       chatId: 'oc_chat',
       rootMessageId: 'om_root',
       sessionId: 'sess-1',
-      approvers: new Set(['ou_owner']),
       questions: [
         { prompt: 'q', multiSelect: true, options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }] },
       ],
@@ -469,7 +469,6 @@ describe('handleAskCardAction: ask_submit 路径', () => {
       chatId: 'oc_chat',
       rootMessageId: 'om_root',
       sessionId: 'sess-1',
-      approvers: new Set(['ou_owner']),
       questions: [
         { prompt: 'q', multiSelect: true, options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }] },
       ],
@@ -508,7 +507,6 @@ describe('handleAskCardAction: ask_submit 路径', () => {
       chatId: 'oc_chat',
       rootMessageId: 'om_root',
       sessionId: 'sess-1',
-      approvers: new Set(['ou_owner']),
       questions: [
         { prompt: 'q1', multiSelect: false, options: [{ key: 'y', label: '是' }, { key: 'n', label: '否' }] },
         { prompt: 'q2', multiSelect: true, options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }] },


### PR DESCRIPTION
## 背景

原先 `botmux ask` 的"谁能答"由 allowedUsers（operate 级）回退链解析，导致 oncall 群 / allowedChatGroup / chatGrant / 开放模式里**真正在跟 bot 对话的人**（仅 canTalk、不在 allowedUsers）点不动 ask 卡片按钮，只能干等超时。

## 改动：答复权限改为纯 canTalk

谁能在该 chat 跟 bot 说话谁就能答。`botmux ask` 本就是 talk 级交互（回答 agent 的提问），理应走 canTalk 闸，而非更严的 canOperate。

- **broker**：新增 `setCanTalkChecker` 注入点，点击鉴权 = `canTalk(larkAppId, chatId, by)`；未注入时谁都不能答（daemon 启动必注入，防误放）。三条路径 `toggle / submit / submitCustomReply` 全覆盖。
- **删除** `--approver` 整套：`ask-api.resolveAskApprovers`、`CreateAskInput/PendingAsk.approvers/explicitApprovers`、daemon `no_approvers` 兜底、CLI `--approver` 解析与 exit2 分支、对应 i18n 键（hook 自动路径本就不传 approver）。
- **daemon 自定义文字回复拦截**：去掉 `approvers.has` 预检，统一交给 `submitCustomReply` 的 canTalk 闸；非 canTalk 自动 fall-through 到正常路由。
- **卡片"可答复"栏**：统一显示"本群可对话成员"。
- workflow humanGate 的 approvers 是另一套系统（src/workflows、daemon waitEventsByActivity），未受影响。

## 取舍

移除 `no_approvers` 快速失败后，完全锁死该 chat（无人 canTalk）时发起的 ask 会挂到超时而非立刻 exit2。此场景在正常使用中不会出现（会话本就是有人对话才起的），换来语义简化，可接受。

## 测试

净删 ~270 行。tsc 干净；ask-broker / ask-card / ask-api / event-dispatcher / card 等相关 **473 测试全绿**（含 canTalk 放行 / 拒绝 / 未注入降级、toggle / submitCustomReply 覆盖）。