### PR TITLE
fix(setup): 移除 setup 交互中的 model 选择

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,7 +49,6 @@ import {
 } from './setup/bot-config-editor.js';
 import { buildPreset, serializePreset, presetFilename } from './setup/agent-preset.js';
 import type { CliId } from './adapters/cli/types.js';
-import { createCliAdapterSync } from './adapters/cli/registry.js';
 import { logger } from './utils/logger.js';
 import { invalidWorkingDirs } from './utils/working-dir.js';
 import { firstPositional } from './cli/arg-utils.js';
@@ -322,66 +321,6 @@ function printInputHelp(title: string, lines: string[]): void {
   for (const line of lines) {
     console.log(`  ${line}`);
   }
-}
-
-/**
- * 读取指定 CLI 适配器声明的候选 model 列表 —— 不支持 model 配置的 CLI（aiden/
- * antigravity/mtr 等没声明 modelChoices）返回 null，promptModel 据此整段
- * 跳过提问。适配器解析失败也按"不支持"处理，避免在 setup 中冒出陌生堆栈。
- */
-function cliModelChoices(cliId: CliId): readonly string[] | null {
-  try {
-    const adapter = createCliAdapterSync(cliId);
-    return adapter.modelChoices && adapter.modelChoices.length > 0
-      ? adapter.modelChoices
-      : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * 询问"指定 CLI 用哪个 model"。
- *   - cliId 对应的 adapter 没声明 modelChoices → return undefined（跳过提问）
- *   - 用户输入序号 → 取候选列表对应项
- *   - 输入空 + 提供 current → 保留当前值（current 透传出去）
- *   - 输入空 + 无 current → return undefined（用 CLI 默认）
- *   - 输入 `-` → return null（语义：清空，调用方据此 delete model 字段）
- *   - 输入自由文本 → 原样返回
- */
-async function promptModel(
-  rl: ReturnType<typeof createInterface>,
-  cliId: CliId,
-  current?: string,
-): Promise<string | null | undefined> {
-  const choices = cliModelChoices(cliId);
-  if (!choices) return undefined;
-
-  const numbered = choices.map((m, i) => `${i + 1}) ${m}`).join('  ');
-  printInputHelp(`CLI Model（${cliId}）`, [
-    '可选。在 spawn CLI 时注入 model 参数；同一 CLI 配多个 bot 可以跑不同 model。',
-    `候选: ${numbered}  ${choices.length + 1}) Other（自定义输入）`,
-    current
-      ? '留空保留当前值；输入 - 清空（回到 CLI 默认）。'
-      : '留空 = 不设置（用 CLI 默认）。',
-  ]);
-  const label = current ? formatOptionalValue(current) : '未设置';
-  const raw = (await ask(rl, `CLI Model [${label}]: `)).trim();
-  if (!raw) return current ?? undefined;
-  if (raw === '-') return null;
-
-  const numIdx = Number(raw);
-  if (Number.isInteger(numIdx) && numIdx >= 1 && numIdx <= choices.length) {
-    return choices[numIdx - 1];
-  }
-  if (Number.isInteger(numIdx) && numIdx === choices.length + 1) {
-    // 选了 Other，进一步要 free-form
-    const customRaw = (await ask(rl, '请输入 model 名: ')).trim();
-    if (!customRaw) return current ?? undefined;
-    return customRaw;
-  }
-  // 直接当成自由输入
-  return raw;
 }
 
 // Thin wrapper around setup/bots-store.writeBotsJsonAtomic so call-sites keep
@@ -672,7 +611,6 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
     return null;
   }
   const workingDir = await ask(rl, '默认工作目录 [~]: ');
-  const modelChoice = await promptModel(rl, cliId);
 
   const bot: Record<string, any> = {
     larkAppId: creds.appId,
@@ -688,10 +626,8 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
   if (creds.brand === 'lark') {
     bot.brand = 'lark';
   }
-  // modelChoice === undefined → 该 CLI 没声明候选 / 用户跳过；不写 model 字段
-  if (typeof modelChoice === 'string' && modelChoice) {
-    bot.model = modelChoice;
-  }
+  // setup 不再询问 model（用户常选到无权限的 model，setup 完一发消息就 spawn
+  // 报错，排查成本高）。需要指定 model 走 /config 卡片或手动编辑 bots.json。
   // 扫码场景默认填扫码人自己 (registerApp 返回里有 open_id), 天然就是 owner.
   // 优先解析成 union_id (on_，跨应用稳定)；失败则 fallback 到 open_id (ou_)。
   // 手动 fallback 场景没 open_id —— 必须显式指定 owner, 否则配置无 owner:
@@ -778,27 +714,13 @@ async function promptEditBotConfig(
   ]);
   input.cliPathOverride = await ask(rl, `CLI 可执行文件路径覆盖 [${formatOptionalValue(bot.cliPathOverride)}]: `);
 
-  // promptModel 返回 string | null | undefined，直接灌进 BotConfigEditInput.model:
-  //   undefined = 用户跳过 / adapter 不支持 → applyBotConfigEdits 不改 model
-  //   null      = 用户输 `-` 清空 → delete model
-  //   string    = 设值
-  // 用本轮编辑后的 cliId 而非 bot.cliId —— 用户可能刚换了 CLI。
-  const effectiveCliIdForModel = (resolveCliId(input.cliChoice) ?? bot.cliId ?? 'claude-code') as CliId;
+  // setup 不再询问 model（同 promptBotConfig 的理由）。但切换 CLI 时旧 model
+  // 是上一个 CLI 的值，套到新 CLI 上没意义甚至直接 spawn 报错，必须强制清空；
+  // 未换 CLI 时 input.model 留 undefined，applyBotConfigEdits 保持原值不动。
   const cliChanged = !!resolveCliId(input.cliChoice) && resolveCliId(input.cliChoice) !== bot.cliId;
-  if (cliChanged && !cliModelChoices(effectiveCliIdForModel)) {
-    // 切到一个不支持 model 的 adapter（例如 aiden / mtr / antigravity）：
-    // 即使原本配了 model 也要主动清空，避免 bots.json 里残留陈旧字段——
-    // 否则用户后面再换回支持 model 的 adapter 一路回车时，旧 model
-    // 会被当作"当前值"保留下来误套到新 CLI 上。
-    console.log('\n⚠️  新 CLI 不支持 --model 参数，已清空原 model 字段。');
+  if (cliChanged && bot.model) {
+    console.log('\n⚠️  已切换 CLI，原 model 字段已清空（如需指定 model 请用 /config 卡片或编辑 bots.json）。');
     input.model = null;
-  } else {
-    const promptCurrent = cliChanged ? undefined : (typeof bot.model === 'string' ? bot.model : undefined);
-    const result = await promptModel(rl, effectiveCliIdForModel, promptCurrent);
-    // 切换 CLI 时哪怕用户留空也要清掉旧 model —— 旧值是上一个 CLI 的 model，
-    // 套到新 CLI 上没意义。result === undefined 在"未变 CLI"分支等价于"保留旧值"，
-    // 但在 cliChanged 分支等价于"用户没指定，回到新 CLI 默认"，必须 force null。
-    input.model = cliChanged && result === undefined ? null : result;
   }
 
   printInputHelp('会话后端 backendType', [

--- a/src/setup/bot-config-editor.ts
+++ b/src/setup/bot-config-editor.ts
@@ -108,8 +108,9 @@ export interface BotConfigEditInput {
   cliChoice?: string;
   cliPathOverride?: string;
   /**
-   * Model 字段三态语义：
-   *   - undefined → 这次编辑没问过 model（adapter 没声明 modelChoices 自动跳过），保持原值
+   * Model 字段三态语义（setup 不再交互式询问 model，此字段仅由切换 CLI 时的
+   * 强制清空逻辑设 null；改 model 走 /config 卡片或手动编辑 bots.json）：
+   *   - undefined → 这次编辑不动 model，保持原值
    *   - string    → 设为这个 model
    *   - null      → 清空（删字段，回到 CLI 默认）
    */
@@ -289,8 +290,7 @@ export function applyBotConfigEdits<T extends Record<string, any>>(
 
   applyOptionalString(out, 'cliPathOverride', input.cliPathOverride);
 
-  // Model 字段：null = 清空，string = 设置，undefined = 不动。promptModel 已经
-  // 把"adapter 不支持 model"折叠成 undefined 直接跳过；这里不再去查 adapter。
+  // Model 字段：null = 清空，string = 设置，undefined = 不动。
   if (input.model === null) {
     delete out.model;
   } else if (typeof input.model === 'string') {

--- a/test/bot-config-editor.test.ts
+++ b/test/bot-config-editor.test.ts
@@ -198,10 +198,9 @@ describe('applyBotConfigEdits', () => {
     expect(cleared.model).toBeUndefined();
   });
 
-  // 防回归：cli.ts 的 promptEditBotConfig 在切到不支持 model 的 adapter
-  // （aiden/mtr/agy 等没声明 modelChoices）时会把 input.model 设成 null
-  // 强制清空旧 model — 这里只测 applyBotConfigEdits 把 null 解释为"删字段"
-  // 的契约，覆盖 Codex review 反馈的"切 CLI 后旧 model 残留"边界。
+  // 防回归：cli.ts 的 promptEditBotConfig 在切换 CLI 时会把 input.model 设成
+  // null 强制清空旧 model — 这里只测 applyBotConfigEdits 把 null 解释为
+  // "删字段"的契约，覆盖"切 CLI 后旧 model 残留"边界。
   it('input.model === null clears the field even when cliChoice also changes', () => {
     const updated = applyBotConfigEdits({
       larkAppId: 'app',


### PR DESCRIPTION
## 背景

setup 时让用户选 model 是高频踩坑点：选了无权限/拼错的 model，setup 本身能跑完，但配置完一发消息 CLI spawn 即报错，用户很难把报错和 setup 那一步关联起来。

## 改动

- **新建 bot**（`promptBotConfig`）：不再询问 CLI Model，不写 `model` 字段
- **编辑 bot**（`promptEditBotConfig`）：不再询问 model；但保留「切换 CLI 时强制清空旧 model」的防残留逻辑（旧 model 套到新 CLI 上没意义甚至直接 spawn 报错）
- 删除 `cli.ts` 中的 `promptModel` / `cliModelChoices`，编辑流不再为问 model 构造 adapter——顺带消掉 setup 中 shell 探测二进制的路径之一（此前调研过该探测会在部分用户 rc 配置下导致 setup 非自愿挂起）
- 同步更新 `bot-config-editor.ts` 注释与测试注释

## 不变的部分

- `bots.json` 的 `model` 字段仍然支持：/config 卡片的 model 下拉、手动编辑 bots.json 均不受影响
- 各 adapter 的 `modelChoices` 声明保留（/config 卡片仍在用）
- `applyBotConfigEdits` 的 model 三态契约不变（现仅由切 CLI 清空路径使用 null）

## 验证

- `pnpm build` tsc 0 错误
- 全量 unit：4295 passed，3 failed 为 master 既有基线（session-lifecycle-hooks + transfer-session，与本改动无关）