### PR TITLE
fix(dashboard): 兜底轮询刷新 daemon 注册表

### DIFF
--- a/src/dashboard/registry.ts
+++ b/src/dashboard/registry.ts
@@ -21,8 +21,13 @@ export interface DaemonInfo {
 }
 
 const STALE_MS = 90_000;
+const DEFAULT_REFRESH_MS = 15_000;
 
 export type RegistryListener = (online: DaemonInfo[]) => void;
+
+export interface DaemonRegistryOptions {
+  refreshIntervalMs?: number;
+}
 
 /**
  * Watches the dashboard-daemons descriptor directory and exposes the
@@ -32,11 +37,19 @@ export class DaemonRegistry {
   private items = new Map<string, DaemonInfo>();
   private listeners = new Set<RegistryListener>();
   private watcher?: FSWatcher;
+  private poller?: ReturnType<typeof setInterval>;
+  private refreshIntervalMs: number;
 
-  constructor(private dir: string) {}
+  constructor(private dir: string, options: DaemonRegistryOptions = {}) {
+    this.refreshIntervalMs = options.refreshIntervalMs ?? DEFAULT_REFRESH_MS;
+  }
 
   async start(): Promise<void> {
     this.refresh();
+    if (!this.poller && this.refreshIntervalMs > 0) {
+      this.poller = setInterval(() => this.refresh(), this.refreshIntervalMs);
+      this.poller.unref?.();
+    }
     try {
       this.watcher = watch(this.dir, { persistent: true }, () => this.refresh());
     } catch {
@@ -48,6 +61,10 @@ export class DaemonRegistry {
   stop(): void {
     this.watcher?.close();
     this.watcher = undefined;
+    if (this.poller) {
+      clearInterval(this.poller);
+      this.poller = undefined;
+    }
   }
 
   list(): DaemonInfo[] {

--- a/test/dashboard-registry.test.ts
+++ b/test/dashboard-registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -9,7 +9,10 @@ beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'botmux-reg-'));
   mkdirSync(dir, { recursive: true });
 });
-afterEach(() => rmSync(dir, { recursive: true, force: true }));
+afterEach(() => {
+  vi.useRealTimers();
+  rmSync(dir, { recursive: true, force: true });
+});
 
 function writeDesc(larkAppId: string, port: number, hbAgo = 0) {
   writeFileSync(join(dir, `${larkAppId}.json`), JSON.stringify({
@@ -43,5 +46,29 @@ describe('DaemonRegistry', () => {
     expect(reg.list()).toEqual([]);
     reg.stop();
     rmSync(empty, { recursive: true, force: true });
+  });
+
+  it('polls descriptors so missed fs.watch heartbeat updates do not mark daemons stale', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    writeDesc('appA', 7892);
+
+    const reg = new DaemonRegistry(dir, { refreshIntervalMs: 1_000 });
+    await reg.start();
+
+    // Simulate a platform where fs.watch misses the daemon's atomic descriptor rewrite.
+    (reg as unknown as { watcher?: { close(): void } }).watcher?.close();
+
+    expect(reg.list().length).toBe(1);
+
+    vi.setSystemTime(95_000);
+    expect(reg.list()).toEqual([]);
+
+    writeDesc('appA', 7892);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(reg.list().length).toBe(1);
+    expect(reg.getByAppId('appA')?.ipcPort).toBe(7892);
+    reg.stop();
   });
 });


### PR DESCRIPTION
## 背景

触发场景是：`botmux-dashboard` 已经启动并读入过 daemon descriptor，daemon 也在正常运行、持续通过原子重写 `dashboard-daemons/*.json` 刷新 `lastHeartbeat`。如果这期间 dashboard 进程没有收到某次 descriptor 重写对应的 `fs.watch` 事件，内存里的 registry 就不会重新读取磁盘上的新 heartbeat。超过 90 秒 stale 阈值后，dashboard 会把仍在线的 daemon 过滤掉，表现为 `/api/bots` 返回空列表，群组矩阵等 dashboard 视图也看不到机器人；但直接访问 daemon IPC 仍能拿到 bot、sessions 和 groups。

根因是 `DaemonRegistry` 原先主要依赖 `fs.watch` 维护内存状态，而 descriptor heartbeat 是“当前状态”数据，不适合只靠边沿事件保持一致。`fs.watch` 可能因为原子 rename、事件合并/丢弃，或系统 watcher 限额等原因漏掉更新，导致 dashboard registry cache stale。

## 改动

- 为 `DaemonRegistry` 增加默认 15 秒一次的 polling refresh，保留原有 `fs.watch` 快速路径。
- 在 `stop()` 中清理 polling timer，避免测试和进程关闭时泄漏。
- 增加回归测试：模拟 `fs.watch` 未收到 descriptor 原子重写事件，确认 registry 能通过 polling 重新读取新 heartbeat，避免在线 daemon 被误判离线。

## 影响

- dashboard 不再因为文件监听漏事件而需要手动重启才能恢复机器人列表。
- polling 只读取 descriptor 目录和少量 JSON 文件；当前 dashboard 的订阅同步逻辑已有 `subs.has` / `attaching` 去重，不会重复打开 daemon SSE 订阅。

## 验证

- `pnpm test test/dashboard-registry.test.ts`：通过，4 tests passed。
- `pnpm build`：通过。
- `pnpm test`：已跑全量 unit，但存在非本次改动相关失败：`transfer-session` mock 缺 `getBotBrand`、`workflow-fanout` 遇到系统 file watcher `ENOSPC`、`session-lifecycle-hooks` 既有断言/未处理错误。