### PR TITLE
fix(hooks): 避免 daemon 把 hook 事件无限转发给自己（pm2 restart 注入会话环境所致）

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -20,7 +20,7 @@ import * as chatFirstSeenStore from './services/chat-first-seen-store.js';
 import { ensureDefaultOncallBound } from './services/oncall-store.js';
 import * as scheduleStore from './services/schedule-store.js';
 import * as messageQueue from './services/message-queue.js';
-import { emitHookEvent, HOOK_EVENTS, type HookEvent } from './services/hook-runner.js';
+import { emitHookEvent, emitHookEventLocal, HOOK_EVENTS, type HookEvent } from './services/hook-runner.js';
 import { setSessionLifecycleShutdown } from './services/session-lifecycle-hooks.js';
 import { parseEventMessage, resolveNonsupportMessage, stripLeadingMentions, type MessageResource } from './im/lark/message-parser.js';
 import { expandMergeForward } from './im/lark/merge-forward.js';
@@ -1864,8 +1864,10 @@ ipcRoute('POST', '/api/session-ready', async (req, res) => {
 // CLI side（botmux send 等）调用 emitHookEvent 时，把事件转发到 daemon 这条
 // 接口；daemon 在自己的长寿命事件循环里负责 spawn hook、跑 timeout、超时杀
 // 整个进程组。短命 CLI 进程的 timer.unref 会让超时承诺失效、跑飞的 hook 留
-// 孤儿，让 daemon 接管根治这一缺口。daemon 进程自身不带 BOTMUX_SESSION_ID
-// 环境变量，所以这里调 emitHookEvent 不会再触发转发回退（无递归）。
+// 孤儿，让 daemon 接管根治这一缺口。这里必须调 emitHookEventLocal（只跑本地、
+// 永不转发）：若调 emitHookEvent，一旦会话级环境变量泄进 daemon（如在 botmux
+// 会话内执行 `botmux restart`，pm2 会把调用方环境注入新 daemon），事件会被
+// 无限自转发回本端口，烧满一核且日志静默。
 ipcRoute('POST', '/api/hooks/emit', async (req, res) => {
   let raw: unknown;
   try {
@@ -1883,7 +1885,7 @@ ipcRoute('POST', '/api/hooks/emit', async (req, res) => {
   if (!payload || typeof payload !== 'object') {
     return jsonRes(res, 400, { ok: false, error: 'bad_payload' });
   }
-  emitHookEvent(event as HookEvent, payload as Record<string, unknown>);
+  emitHookEventLocal(event as HookEvent, payload as Record<string, unknown>);
   return jsonRes(res, 202, { ok: true });
 });
 

--- a/src/index-daemon.ts
+++ b/src/index-daemon.ts
@@ -9,6 +9,16 @@ import { existsSync } from 'node:fs';
 const globalEnv = join(homedir(), '.botmux', '.env');
 dotenvConfig({ path: existsSync(globalEnv) ? globalEnv : '.env' });
 
+// A daemon is never a session. pm2 startOrRestart injects the caller's
+// environment into restarted apps, so a `botmux restart` issued from inside a
+// botmux session leaks session-scoped vars into this long-lived process —
+// hook-runner's CLI gate would then mistake the daemon for CLI context and
+// forward every hook event to the daemon itself (/api/hooks/emit) in an
+// infinite self-loop. Scrub unconditionally at boot.
+for (const k of ['BOTMUX_SESSION_ID', 'BOTMUX_LARK_APP_ID', 'BOTMUX_CHAT_ID', 'BOTMUX_ROOT_MESSAGE_ID']) {
+  delete process.env[k];
+}
+
 async function main() {
   // Resolve global UI locale from ~/.botmux/config.json BEFORE loading
   // daemon code — `bot-registry`, `card-builder`, etc. read `t()` against

--- a/src/services/hook-runner.ts
+++ b/src/services/hook-runner.ts
@@ -346,6 +346,12 @@ async function runHookCommand(
       });
     });
 
+    // Hooks that don't drain stdin and exit fast (touch/echo/notify-send,
+    // `botmux send`, …) close their read end before this write flushes →
+    // EPIPE on the stdin socket. Without a listener that 'error' is unhandled;
+    // in the long-lived daemon (no global uncaughtException handler) it would
+    // crash the whole process. The hook already spawned, so swallow it.
+    child.stdin?.on('error', () => { /* EPIPE: fast-exiting hook closed stdin */ });
     child.stdin?.end(JSON.stringify(payload), () => {
       if (options.fireAndForget) (child.stdin as any)?.unref?.();
     });

--- a/src/services/hook-runner.ts
+++ b/src/services/hook-runner.ts
@@ -365,31 +365,60 @@ export function emitHookEvent(event: HookEvent, body: Record<string, unknown> = 
     // can't enforce timeouts itself — fireAndForget unrefs the timer, so a
     // runaway hook would survive as an orphan. The daemon stays alive, its
     // timer fires reliably, and `process.kill(-pid)` cleans the whole group.
-    // Daemon process doesn't have BOTMUX_SESSION_ID set, so this gate
-    // naturally avoids recursive forward when emitHookEvent runs daemon-side.
+    // The daemon itself must never take this branch — it boots with
+    // session-scoped env scrubbed (index-daemon.ts) and its /api/hooks/emit
+    // handler calls emitHookEventLocal, so the gate can't self-forward even
+    // if leaked env survives somewhere.
     if (process.env.BOTMUX_SESSION_ID && process.env.BOTMUX_LARK_APP_ID) {
       void forwardEmitToDaemon(event, payload, process.env.BOTMUX_LARK_APP_ID);
       return;
     }
 
-    const hooks = loadHookConfigs().filter(hook => hook.event === event && filterMatches(hook.filter, payload));
-    if (hooks.length === 0) return;
-
-    for (const [i, hook] of hooks.entries()) {
-      const hookPayload = prepareHookPayload(hook, payload);
-      const tag = `${event}[${i}] (${hook.command.slice(0, 60)})`;
-      void runHookCommand(hook, hookPayload, { fireAndForget: true }).then(result => {
-        if (!result.ok) {
-          logger.warn(`[hooks] ${tag} failed: ${result.error ?? `code=${result.code} signal=${result.signal ?? 'none'}`}`);
-        } else {
-          logger.debug(`[hooks] ${tag} completed`);
-        }
-      }).catch((err: any) => {
-        logger.warn(`[hooks] ${tag} crashed: ${err?.message ?? String(err)}`);
-      });
-    }
+    runHooksLocally(payload);
   } catch (err: any) {
     logger.warn(`[hooks] Failed to emit ${event}: ${err?.message ?? String(err)}`);
+  }
+}
+
+/**
+ * Daemon-side emit: always run hooks in-process, never forward. The
+ * /api/hooks/emit handler MUST use this instead of emitHookEvent — re-entering
+ * the CLI gate there means a daemon that accidentally carries session-scoped
+ * env (e.g. `botmux restart` issued from inside a botmux session: pm2
+ * startOrRestart injects the caller's environment into the restarted daemon)
+ * would POST every event back to itself in an infinite loop — one core pegged
+ * and hundreds of self-connections on the IPC port, with nothing in the logs.
+ */
+export function emitHookEventLocal(event: HookEvent, body: Record<string, unknown> = {}): void {
+  try {
+    const payload: HookPayload = {
+      ...body,
+      event,
+      emittedAt: new Date().toISOString(),
+    };
+    runHooksLocally(payload);
+  } catch (err: any) {
+    logger.warn(`[hooks] Failed to emit ${event}: ${err?.message ?? String(err)}`);
+  }
+}
+
+function runHooksLocally(payload: HookPayload): void {
+  const event = payload.event;
+  const hooks = loadHookConfigs().filter(hook => hook.event === event && filterMatches(hook.filter, payload));
+  if (hooks.length === 0) return;
+
+  for (const [i, hook] of hooks.entries()) {
+    const hookPayload = prepareHookPayload(hook, payload);
+    const tag = `${event}[${i}] (${hook.command.slice(0, 60)})`;
+    void runHookCommand(hook, hookPayload, { fireAndForget: true }).then(result => {
+      if (!result.ok) {
+        logger.warn(`[hooks] ${tag} failed: ${result.error ?? `code=${result.code} signal=${result.signal ?? 'none'}`}`);
+      } else {
+        logger.debug(`[hooks] ${tag} completed`);
+      }
+    }).catch((err: any) => {
+      logger.warn(`[hooks] ${tag} crashed: ${err?.message ?? String(err)}`);
+    });
   }
 }
 

--- a/test/hook-runner.test.ts
+++ b/test/hook-runner.test.ts
@@ -310,6 +310,51 @@ describe('runHookCommandForTest', () => {
     expect(Date.now() - started).toBeLessThan(900);
   });
 
+  it('emitHookEventLocal spawns locally even when session env leaked into the process', async () => {
+    // Regression guard for the daemon self-forward storm: the daemon's
+    // /api/hooks/emit handler runs hooks via emitHookEventLocal, which must
+    // execute locally and never re-enter the CLI forward gate — even when
+    // session-scoped env leaked into the process (e.g. pm2 startOrRestart
+    // injecting the caller's environment after an in-session `botmux restart`).
+    const marker = join(tmpDir, 'daemon-local-spawn-touched');
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--import',
+        'tsx',
+        '--input-type=module',
+        '-e',
+        [
+          "const { emitHookEventLocal } = await import('./src/services/hook-runner.ts');",
+          "emitHookEventLocal('outbound.send', { content: 'hi' });",
+        ].join('\n'),
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          BOTMUX_SESSION_ID: 'sid-leaked-into-daemon',
+          BOTMUX_LARK_APP_ID: 'cli_leaked_into_daemon',
+          BOTMUX_HOOKS_JSON: JSON.stringify([
+            { event: 'outbound.send', command: `/usr/bin/touch ${marker}`, timeoutMs: 5000 },
+          ]),
+        },
+        timeout: 5000,
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    // fireAndForget lets the emitting process exit before the hook child
+    // finishes — poll briefly for the marker instead of asserting instantly.
+    const deadline = Date.now() + 3000;
+    while (!existsSync(marker) && Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+    expect(existsSync(marker)).toBe(true);
+  });
+
   it('CLI context forwards to daemon instead of spawning locally', () => {
     // Behavioural proof of the daemon-supervised path: when BOTMUX_SESSION_ID
     // and BOTMUX_LARK_APP_ID are set (CLI session), emitHookEvent forwards to


### PR DESCRIPTION
## 问题

生产环境排查「机器变慢」时发现：有个 daemon 进程持续占满一个 CPU 核好几个小时，它的 IPC 端口（`7892+botIndex`）上堆了 1100+ 条 TCP 连接，其中约 99% 是**自己连自己**（正常只有 4 条），而且日志里什么都没有。macOS、4 个 bot，2.67.1 和 2.71.5 都能复现。

根因是一个自我转发的死循环：

1. `emitHookEvent` 靠「进程有没有 `BOTMUX_SESSION_ID` + `BOTMUX_LARK_APP_ID`」来判断自己是 CLI 还是 daemon（原注释也写了"daemon 不会有这些变量，所以不会递归转发"）。
2. 但 `pm2 startOrRestart` 会把**调用方的环境**注入到被重启的进程。在 botmux 会话里执行 `botmux restart`（agent 替用户做运维时很常见，会话 shell 天然带着这些变量）就会把会话环境泄进 daemon。
3. 这样的 daemon 发出的每个 hook 事件都走进 CLI 分支 → POST 回自己的 `/api/hooks/emit` → 处理器再调 `emitHookEvent` → 再转发……无限循环。事件越积越多，连接堆到上千、CPU 占满一核；因为每一步都"成功"，日志是 debug 级，所以全程安静。

5 次重启对照：在会话里 `botmux restart` 3 次全部复现；从干净终端、或用 `env -u BOTMUX_*` 剥掉环境变量重启 2 次都正常。

## 改动（两层，各自都能单独断开循环）

- **`/api/hooks/emit` 改调新增的 `emitHookEventLocal`**（只在本地执行、从不转发）：接收端从结构上不再递归，环境里有没有泄漏的变量都一样。`emitHookEvent` 原来的本地执行逻辑抽成 `runHooksLocally` 复用，CLI 侧的转发行为不变。
- **`index-daemon.ts` 启动时清掉会话级环境变量**（`BOTMUX_SESSION_ID` / `BOTMUX_LARK_APP_ID` / `BOTMUX_CHAT_ID` / `BOTMUX_ROOT_MESSAGE_ID`）：daemon 本就不该是会话；顺带挡住其他依赖这些变量做判断的逻辑被误导。

## 验证

- 新增回归测试：进程带着泄漏的会话环境变量时，`emitHookEventLocal` 仍在本地执行 hook（复用仓库现成的 spawnSync + tsx + marker 文件写法）；原有「CLI 转发给 daemon」用例保证转发路径不回归。
- `pnpm vitest run test/hook-runner.test.ts test/hook-runner-cache.test.ts`：21/21 通过；全量 `pnpm test` 只剩本机存量的环境相关失败（git-worktree / node-pty 等，已在干净 master 上对照确认与本改动无关）。
- 等价修复（daemon 入口清环境）已在我的生产机以补丁形式跑了验证：打上之后用之前 100% 复现的「会话内重启」方式重启，daemon 全部正常（CPU≈0、连接数 4）。
