### PR TITLE
fix(grant): 多 bot 同时授权两 bug——前导@误当目标 + 通知卡唤醒对方 bot

### DIFF
--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -1067,10 +1067,26 @@ export function buildGrantCard(o: GrantCardOpts, locale?: Locale): string {
   return JSON.stringify(card);
 }
 
-/** 授权成功后给被授权人的通知卡（@ 对方，独立消息）。支持一次 @ 多个被授权人；带额度时追加"（额度 N 条）"。 */
-export function buildGrantNotifyCard(kind: 'chat' | 'global', targetOpenId: string | string[], locale?: Locale, quota?: number): string {
-  const ids = Array.isArray(targetOpenId) ? targetOpenId : [targetOpenId];
-  const at = ids.map(id => `<at id=${id}></at>`).join(' ');
+/** 授权成功后给被授权人的通知卡（独立消息）。支持一次通知多个被授权人；带额度时追加"（额度 N 条）"。
+ *
+ *  **真人 grantee 用 `<at>` 点名，bot grantee 只用纯文本名字**：卡片里的 `<at id=botOpenId>` 会被
+ *  对方 bot 的 daemon 当成一次「被 @」消息，从而凭新授权/同伴 peer 关系在本群误拉起一个空会话
+ *  （申晗实测 bug：手动 /grant 后面没有 prompt，不该触发自动会话）。纯文本名字不产生 mention 事件，
+ *  既保留「谁被授权」的可读信息，又不会唤醒对方 bot。传 string/string[]（无 isBot 信息）时按真人
+ *  处理（@ 全部），保持旧调用方/单测兼容。 */
+export function buildGrantNotifyCard(
+  kind: 'chat' | 'global',
+  target: string | string[] | Array<{ openId: string; name?: string; isBot?: boolean }>,
+  locale?: Locale,
+  quota?: number,
+): string {
+  const entries = (Array.isArray(target) ? target : [target]).map(tt =>
+    typeof tt === 'string' ? { openId: tt, name: undefined as string | undefined, isBot: false } : tt);
+  const at = entries.map(e =>
+    e.isBot
+      ? (e.name && e.name.length > 0 ? e.name : e.openId)   // bot：纯文本名字，绝不 <at>（否则唤醒对方 bot）
+      : `<at id=${e.openId}></at>`,                          // 真人：@ 点名（真人被 @ 不会自动开会话）
+  ).join(' ');
   let content = t(kind === 'chat' ? 'card.grant.notify_chat' : 'card.grant.notify_global', { at }, locale);
   if (quota !== undefined && quota > 0) content += t('card.grant.notify_quota_suffix', { n: quota }, locale);
   const card = {

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -244,16 +244,17 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     // 清掉后失败 target 可重新走 /grant 或自助申请；失败清单下面在原线程明确告知 owner，
     // 不做「撤卡 + 静默失败 + pending 永久卡住」。
     for (const f of failed) clearPending(larkAppId, grantChatId, f.openId);
-    const target = granted;
+    // 一次查通讯录判定哪些 grantee 是真人（vs bot），结果同时供下面两处复用：
+    //   1. observed 花名册自动登记（只收 bot，剔真人）；
+    //   2. 通知卡 @ 渲染（只 @ 真人，bot 用纯文本名字 —— 见下方注释）。
+    // 缺 contact 读权限/查询瞬时失败 → 一律按 bot 处理（false）：登记侧沿用历史「全部登记」回退，
+    // 通知侧则把对方当 bot 不 @（宁可少 @ 一次真人，也不误唤醒 bot 拉空会话）。
+    const humanFlags = await Promise.all(granted.map(id => isHumanOpenId(larkAppId, id).catch(() => false)));
     // /grant @bot 成功后顺带把「bot」目标登记进 observed 花名册（等价内部跑一次 /introduce），
     // 授权 + 可点名一步到位。写的是 observed-bots-store（让本 daemon 能 @ 回对方），不影响
     // isKnownPeerBot 接收闸（那查的是 cross-ref，两套独立存储），零额外路由权。best-effort。
     // 真人**不**登记：查通讯录确认是真人就剔除，避免污染 <available_bots> 误导模型。
-    // 注意：grant 自动登记是新增路径，缺 contact 读权限/查询瞬时失败时真人会被当 bot 误登记
-    // （/introduce 同款过滤但本就登记全部，对它无回退损失）。该 scope 已是 critical 且启动自检
-    // 缺失即 DM 管理员，把这条污染面收敛到「管理员未按提示开权限」的窗口（见 isHumanOpenId）。
     try {
-      const humanFlags = await Promise.all(granted.map(id => isHumanOpenId(larkAppId, id).catch(() => false)));
       const botEntries = granted
         .map((id, i) => ({ id, human: humanFlags[i] }))
         .filter(x => !x.human)
@@ -266,6 +267,8 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     } catch (err) {
       logger.warn(`grant auto-introduce (observed) failed (grant still applied): ${err}`);
     }
+    // 通知卡的 grantee 渲染参数：bot 只用纯文本名字（不 <at>，否则唤醒对方 bot 误拉空会话），真人 @ 点名。
+    const notifyTargets = granted.map((id, i) => ({ openId: id, name: idToName.get(id) || undefined, isBot: !humanFlags[i] }));
     // 授权成功后：
     //   1. 先同步返回 callback 响应（in-place patch 成「已授权」终态卡），避免飞书等待
     //      太久或 deleteMessage 与 callback 响应竞态导致客户端 300000 报错；
@@ -285,7 +288,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       Promise.resolve()
         .then(async () => {
           try {
-            await replyMessage(larkAppId, cardMessageId, buildGrantNotifyCard(kind, target, loc, quota), 'interactive', replyInThread);
+            await replyMessage(larkAppId, cardMessageId, buildGrantNotifyCard(kind, notifyTargets, loc, quota), 'interactive', replyInThread);
           } catch (err) {
             logger.warn(`grant notify failed (grant still applied): ${err}`);
           }

--- a/src/im/lark/grant-command.ts
+++ b/src/im/lark/grant-command.ts
@@ -14,10 +14,31 @@ import { replyMessage } from './client.js';
 import { localeForBot, t } from '../../i18n/index.js';
 import { logger } from '../../utils/logger.js';
 
-/** 从 mention 列表取所有非本 bot 的对象（可以是真人，也可以是另一个 bot——
+/** 从 mention 列表取所有非本 bot 的【授权目标】（可以是真人，也可以是另一个 bot——
  *  授权 bot 走同一条路，命中后写本群 chatGrants，放行其在本群拉起 chat-scope 会话）。
- *  按 open_id 去重、保持 @ 顺序，支持一次 /grant @a @b、/revoke @a @b 批量处置。 */
+ *  按 open_id 去重、保持 @ 顺序，支持一次 /grant @a @b、/revoke @a @b 批量处置。
+ *
+ *  **只取「命令词 /grant|/revoke 之后」出现的 @**：命令词之前的 @ 是「点名让哪个 bot 执行」
+ *  （`@OperatorBot /grant @Grantee`），不是 grantee。否则 owner 一条 `@Claude @Codex /grant`
+ *  把两个操作 bot 都前导 @ 了，每个 daemon 会把「另一个 bot」当成目标 → 两 bot 互相授权
+ *  （申晗实测 bug）。位置过滤仅在能拿到位置信息（text 形态的 key / post 的节点序）时生效；
+ *  纯 mentions 的合成消息（无 content.text）退回历史「全部非本 bot」行为。 */
 export function parseGrantTargets(message: any, botOpenId: string | undefined): Array<{ openId: string; name: string }> {
+  let content: any;
+  try { content = JSON.parse(message?.content ?? '{}'); } catch { content = undefined; }
+
+  // text 形态：@ 落在 content.text 里，每个 mention 带 key 占位符可定位其位置 → 按命令词位置过滤。
+  if (content && typeof content.text === 'string') {
+    return parseTextTargetsAfterCommand(content.text, message?.mentions ?? [], botOpenId);
+  }
+  // post（富文本）形态：@ 落在 inline `at` 节点（message.mentions 常为空、偶有填充，统一走节点序）→
+  // 按命令词节点位置过滤，不被「message.mentions 是否填充」左右。
+  const inner = content?.zh_cn ?? content?.en_us ?? content;
+  if (Array.isArray(inner?.content)) {
+    return parsePostAtMentions(message, botOpenId);
+  }
+
+  // 合成消息（仅 mentions、无 content 结构，多见于单测/旧调用）：无位置信息，退回全部非本 bot。
   const seen = new Set<string>();
   const out: Array<{ openId: string; name: string }> = [];
   for (const x of (message?.mentions ?? [])) {
@@ -26,13 +47,34 @@ export function parseGrantTargets(message: any, botOpenId: string | undefined): 
     seen.add(oid);
     out.push({ openId: oid, name: x.name ?? oid });
   }
-  // post（富文本）消息的 message.mentions 常为空，@ 落在 inline `at` 节点里。不回退的话
-  // `@Operator /grant @Target` 的富文本会解析出 0 目标 → 落进裸 /grant 分支误开整群授权。
-  if (out.length === 0) return parsePostAtMentions(message, botOpenId);
   return out;
 }
 
-/** 从 post inline `at` 节点取非本 bot 的目标（user_name 兜 name），按 user_id 去重、保持顺序。 */
+/** text 形态：只取「命令词之后」的非本 bot mention。用 mention 的 key 占位符定位其在 text 里的
+ *  位置；`key(?!\d)` 边界规避 @_user_1 / @_user_10 前缀歧义（与 isGrantTargetOnly 同款）。
+ *  定位不到 key（异常形态）时保守退回「视为目标」，与历史行为一致，不漏真实 grantee。 */
+function parseTextTargetsAfterCommand(
+  text: string, mentions: any[], botOpenId: string | undefined,
+): Array<{ openId: string; name: string }> {
+  const cmdIdx = text.search(/\/(?:grant|revoke)\b/i);
+  const seen = new Set<string>();
+  const out: Array<{ openId: string; name: string }> = [];
+  for (const m of mentions) {
+    const oid = m?.id?.open_id;
+    if (!oid || oid === botOpenId || seen.has(oid)) continue;
+    const key = m?.key;
+    if (cmdIdx >= 0 && typeof key === 'string' && key.length > 0) {
+      const km = new RegExp(`${escapeRe(key)}(?!\\d)`).exec(text);
+      if (km && km.index <= cmdIdx) continue;   // 命令词之前 = 操作 bot 点名，剔除
+    }
+    seen.add(oid);
+    out.push({ openId: oid, name: m.name ?? oid });
+  }
+  return out;
+}
+
+/** 从 post inline `at` 节点取非本 bot 的目标（user_name 兜 name），按 user_id 去重、保持顺序。
+ *  同 text 形态：只收「命令词文本节点之后」的 `at` 节点（前导 @ 是操作 bot 点名，剔除）。 */
 function parsePostAtMentions(message: any, botOpenId: string | undefined): Array<{ openId: string; name: string }> {
   const seen = new Set<string>();
   const out: Array<{ openId: string; name: string }> = [];
@@ -40,15 +82,22 @@ function parsePostAtMentions(message: any, botOpenId: string | undefined): Array
   try { content = JSON.parse(message?.content ?? '{}'); } catch { return out; }
   const inner = content?.zh_cn ?? content?.en_us ?? content;
   if (!Array.isArray(inner?.content)) return out;
+  // 先定位命令词文本节点的序号，再只收其后的 at 节点。
+  let seq = 0, cmdSeq = -1;
+  const ats: Array<{ oid: string; name: string; seq: number }> = [];
   for (const para of inner.content) {
     if (!Array.isArray(para)) continue;
     for (const node of para) {
-      if (node?.tag !== 'at') continue;
-      const oid = node.user_id;
-      if (!oid || oid === botOpenId || seen.has(oid)) continue;
-      seen.add(oid);
-      out.push({ openId: oid, name: node.user_name ?? oid });
+      if (cmdSeq < 0 && node?.tag === 'text' && /\/(?:grant|revoke)\b/i.test(node.text ?? '')) cmdSeq = seq;
+      if (node?.tag === 'at' && node.user_id) ats.push({ oid: node.user_id, name: node.user_name ?? node.user_id, seq });
+      seq++;
     }
+  }
+  for (const a of ats) {
+    if (a.oid === botOpenId || seen.has(a.oid)) continue;
+    if (cmdSeq >= 0 && a.seq <= cmdSeq) continue;   // 命令词之前 = 操作 bot 点名，剔除
+    seen.add(a.oid);
+    out.push({ openId: a.oid, name: a.name });
   }
   return out;
 }

--- a/test/card-handler-grant.test.ts
+++ b/test/card-handler-grant.test.ts
@@ -237,6 +237,39 @@ describe('card-handler grant actions', () => {
     expect(entries).toEqual([{ openId: 'ou_a', name: '张三' }, { openId: 'ou_bot2', name: 'Codex' }]);
   });
 
+  // 申晗实测 bug：手动 /grant 一个 bot 后，通知卡若 <at> 对方 bot 会唤醒其 daemon 误拉空会话。
+  // 修复后通知卡对 bot grantee 只用纯文本名字（无 <at>），对真人仍 @。
+  it('通知卡：bot grantee 用纯文本名字（无 <at>），不唤醒对方 bot', async () => {
+    const { pending, handler } = await fresh();
+    // 默认 isHumanMock=false → ou_bot2 判为 bot。
+    const nonce = pending.openPendingMulti('h1', 'oc_1', ['ou_bot2']);
+    const data: any = {
+      operator: { open_id: 'ou_owner' }, context: { open_message_id: 'om_card' },
+      action: { value: { action: 'grant_chat', target_open_ids: ['ou_bot2'], target_names: ['Codex'], chat_id: 'oc_1', nonce } },
+    };
+    await handler.handleCardAction(data, deps, 'h1');
+    await flushBackground();
+    const notify = replyMock.mock.calls.at(-1)![2] as string;
+    expect(notify).not.toContain('<at id=ou_bot2');   // bot 绝不被 <at>
+    expect(notify).toContain('Codex');                 // 纯文本名字保留可读信息
+  });
+
+  it('通知卡：真人 grantee 仍 @ 点名（真人被 @ 不会自动开会话）', async () => {
+    const { pending, handler } = await fresh();
+    isHumanMock.mockImplementation(async (_app: string, openId: string) => openId === 'ou_human');
+    const nonce = pending.openPendingMulti('h1', 'oc_1', ['ou_human', 'ou_bot2']);
+    const data: any = {
+      operator: { open_id: 'ou_owner' }, context: { open_message_id: 'om_card' },
+      action: { value: { action: 'grant_chat', target_open_ids: ['ou_human', 'ou_bot2'], target_names: ['真人', 'Codex'], chat_id: 'oc_1', nonce } },
+    };
+    await handler.handleCardAction(data, deps, 'h1');
+    await flushBackground();
+    const notify = replyMock.mock.calls.at(-1)![2] as string;
+    expect(notify).toContain('<at id=ou_human></at>');  // 真人 → @
+    expect(notify).not.toContain('<at id=ou_bot2');      // bot → 纯文本
+    expect(notify).toContain('Codex');
+  });
+
   it('grant 成功 → 查通讯录确认是真人的目标不登记花名册（避免污染 bot 列表）', async () => {
     const { registry, pending, handler } = await fresh();
     isHumanMock.mockImplementation(async (_app: string, openId: string) => openId === 'ou_human');

--- a/test/grant-card.test.ts
+++ b/test/grant-card.test.ts
@@ -51,11 +51,31 @@ describe('buildGrantCard', () => {
     expect(byAction.grant_global).toMatchObject({ target_open_ids: ['ou_a', 'ou_b', 'ou_bot'], chat_id: 'oc_3', nonce: 'n3' });
   });
 
-  it('buildGrantNotifyCard @-mentions every granted target', () => {
+  it('buildGrantNotifyCard @-mentions every granted target (legacy string[] = humans)', () => {
     const card = JSON.parse(buildGrantNotifyCard('chat', ['ou_a', 'ou_b'], 'zh'));
     const flat = JSON.stringify(card);
     expect(flat).toContain('<at id=ou_a></at>');
     expect(flat).toContain('<at id=ou_b></at>');
+  });
+
+  // 申晗实测 bug 修复：bot grantee 绝不能用 <at>（会唤醒对方 bot 的 daemon 误拉空会话），
+  // 改用纯文本名字；真人 grantee 仍 @ 点名（真人被 @ 不会自动开会话）。
+  it('buildGrantNotifyCard renders bot grantees as PLAIN name (no <at>), humans as @', () => {
+    const card = JSON.parse(buildGrantNotifyCard('chat', [
+      { openId: 'ou_human', name: '张三', isBot: false },
+      { openId: 'ou_codex', name: 'Codex', isBot: true },
+    ], 'zh'));
+    const flat = JSON.stringify(card);
+    expect(flat).toContain('<at id=ou_human></at>');   // 真人 → @
+    expect(flat).not.toContain('<at id=ou_codex');     // bot → 绝无 <at>
+    expect(flat).toContain('Codex');                   // bot → 纯文本名字
+  });
+
+  it('buildGrantNotifyCard bot grantee without name falls back to open_id (still no <at>)', () => {
+    const card = JSON.parse(buildGrantNotifyCard('chat', [{ openId: 'ou_codex', isBot: true }], 'zh'));
+    const flat = JSON.stringify(card);
+    expect(flat).not.toContain('<at id=ou_codex');
+    expect(flat).toContain('ou_codex');
   });
 
   it('buildGrantResultCard has no buttons', () => {

--- a/test/grant-command.test.ts
+++ b/test/grant-command.test.ts
@@ -108,6 +108,59 @@ describe('parseGrantTargets (multi)', () => {
     };
     expect(parseGrantTargets(barePost, 'ou_bot')).toEqual([]);
   });
+
+  // ── 位置过滤：命令词之前的 @ 是「点名操作 bot」，不是 grantee（申晗实测 bug 回归）─────────
+  // `@Claude @Codex /grant`（两 bot 都前导 @、命令后无目标）：每个 daemon 都不该把「另一个 bot」
+  // 当成 grantee，否则两 bot 互相授权。
+  it('text: co-addressed operator bot BEFORE /grant is NOT a target (no mutual grant)', () => {
+    // 从 Claude(ou_bot) 这个 daemon 看：自己 + Codex 都在命令词之前 → 0 个目标。
+    const msg = {
+      content: JSON.stringify({ text: '@_user_1 @_user_2 /grant' }),
+      mentions: [
+        { key: '@_user_1', id: { open_id: 'ou_bot' }, name: 'Claude' },   // 本 bot（前导）
+        { key: '@_user_2', id: { open_id: 'ou_codex' }, name: 'Codex' },  // 另一操作 bot（前导）
+      ],
+    };
+    expect(parseGrantTargets(msg, 'ou_bot')).toEqual([]);
+  });
+
+  it('text: only mentions AFTER /grant count as targets; leading operator dropped', () => {
+    const msg = {
+      content: JSON.stringify({ text: '@_user_1 /grant @_user_2 @_user_3' }),
+      mentions: [
+        { key: '@_user_1', id: { open_id: 'ou_op' }, name: 'OperatorBot' },  // 前导操作 bot → 剔除
+        { key: '@_user_2', id: { open_id: 'ou_a' }, name: '张三' },
+        { key: '@_user_3', id: { open_id: 'ou_b' }, name: '李四' },
+      ],
+    };
+    expect(parseGrantTargets(msg, 'ou_bot')).toEqual([
+      { openId: 'ou_a', name: '张三' },
+      { openId: 'ou_b', name: '李四' },
+    ]);
+  });
+
+  it('text: key-prefix collision (@_user_1 leading vs @_user_10 trailing) resolved by position', () => {
+    const msg = {
+      content: JSON.stringify({ text: '@_user_10 /grant @_user_1' }),
+      mentions: [
+        { key: '@_user_10', id: { open_id: 'ou_op' }, name: 'OperatorBot' },  // 前导 → 剔除
+        { key: '@_user_1', id: { open_id: 'ou_a' }, name: '张三' },           // 命令后 → 目标
+      ],
+    };
+    expect(parseGrantTargets(msg, 'ou_bot')).toEqual([{ openId: 'ou_a', name: '张三' }]);
+  });
+
+  it('post: co-addressed operator bot BEFORE /grant node is NOT a target', () => {
+    const postMsg = {
+      content: JSON.stringify({ zh_cn: { content: [[
+        { tag: 'at', user_id: 'ou_bot', user_name: 'Claude' },    // 本 bot（前导）
+        { tag: 'at', user_id: 'ou_codex', user_name: 'Codex' },   // 另一操作 bot（前导）
+        { tag: 'text', text: ' /grant' },
+      ]] } }),
+      mentions: [],
+    };
+    expect(parseGrantTargets(postMsg, 'ou_bot')).toEqual([]);
+  });
 });
 
 describe('tryHandleGrantCommand (@bot /grant @user)', () => {
@@ -361,6 +414,51 @@ describe('tryHandleGrantCommand bot-as-target (@operator /grant @thisBot)', () =
     expect(handled).toBe(true);
     const [, , , msgType] = replyMock.mock.calls.at(-1)!;
     expect(msgType).toBe('interactive');                         // card still pops for the operator
+  });
+});
+
+describe('tryHandleGrantCommand two bots co-addressed (@Claude @Codex /grant)', () => {
+  // 申晗实测 bug：`@Claude @Codex /grant`（两 bot 都在命令词之前、命令后无目标）。从本 bot=ou_bot
+  // 的 daemon 看，另一个 bot 在命令词之前 = 操作 bot 点名，不是 grantee → 绝不能弹「授权对方 bot」
+  // 的卡（那会导致两 bot 互相授权 + 唤醒对方拉空会话）。命令后无目标 → 落进裸 /grant 整群分支。
+  function coAddressedMsg() {
+    return {
+      message_id: 'om_co', chat_id: 'oc_room',
+      content: JSON.stringify({ text: '@_user_1 @_user_2 /grant' }),
+      mentions: [
+        { key: '@_user_1', id: { open_id: 'ou_bot' }, name: 'Claude' },    // 本 bot（前导）
+        { key: '@_user_2', id: { open_id: 'ou_codex' }, name: 'Codex' },   // 另一操作 bot（前导）
+      ],
+    };
+  }
+
+  let configPath: string;
+  beforeEach(() => {
+    replyMock.mockClear();
+    pending._resetForTest();
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-grant-co-'));
+    configPath = join(dir, 'bots.json');
+    process.env.BOTS_CONFIG = configPath;
+    writeFileSync(configPath, JSON.stringify([
+      { larkAppId: 'bco', larkAppSecret: 's', cliId: 'claude-code', allowedUsers: ['ou_owner'] },
+    ], null, 2), 'utf-8');
+    loadBotConfigs().forEach(c => registerBot(c));
+    const bot = getBot('bco');
+    bot.botOpenId = 'ou_bot';
+    bot.resolvedAllowedUsers = ['ou_owner'];
+  });
+  afterEach(() => { delete process.env.BOTS_CONFIG; vi.restoreAllMocks(); });
+
+  it('owner: does NOT grant the other bot — no per-target card, no chatGrants entry', async () => {
+    const handled = await tryHandleGrantCommand('bco', coAddressedMsg(), 'ou_owner');
+    expect(handled).toBe(true);
+    // 没有针对「另一个 bot」开 pending（互相授权的核心症状）→ pending 表为空。
+    expect(pending._tableSizeForTest()).toBe(0);
+    // 对方 bot 绝不被写进 chatGrants（互相授权的落库症状）。
+    expect(getBot('bco').config.chatGrants?.['oc_room'] ?? []).not.toContain('ou_codex');
+    // 落进裸 /grant 整群分支：纯文本回执，不是「授权对方 bot」的授权卡。
+    const [, , , msgType] = replyMock.mock.calls.at(-1)!;
+    expect(msgType ?? 'text').not.toBe('interactive');
   });
 });
 


### PR DESCRIPTION
## 背景
申晗实测 `@Claude @Codex /grant`（两 bot 都被前导 @、命令后无目标）暴露两个 bug：
1. 两 bot 互相授权；
2. 授权后自动拉起一个空会话（「等待输入」），而手动 /grant 后面没 prompt。

## Bug 1：前导 @ 被误当授权目标
`parseGrantTargets` 把所有「非自己」的 @ 都当 grantee，不看位置。命令词之前的 @ 是「点名让哪个 bot 执行」（`@OperatorBot /grant @Grantee`），不是被授权人。于是 Claude 把前导 @ 的 Codex 当目标、Codex 把 Claude 当目标 → 互授。

**修复**：只取 `/grant|/revoke` 命令词**之后**出现的 @。
- text 形态：用 mention 的 key 占位符定位其在 text 里的位置，`key(?!\d)` 边界规避 `@_user_1`/`@_user_10` 前缀歧义（与 `isGrantTargetOnly` 同款）。
- post 富文本：按节点序定位命令词文本节点，只收其后的 `at` 节点（不再被 `message.mentions` 是否填充左右）。
- 纯 mentions 的合成消息（无 content 结构）退回历史「全部非本 bot」行为，向后兼容。

→ `@Claude @Codex /grant` 命令后无目标，每个 bot 都不把对方当目标；落进裸 /grant 整群分支（与单 bot `@Claude /grant` 语义一致）。

## Bug 2：通知卡唤醒对方 bot 拉空会话
授权成功通知卡「✅ @对方 已获授权」对 bot grantee 也打真实 `<at id=botOpenId>`。这个 @ 被对方 bot 的 daemon 当成一次「被 @」消息，凭新授权/同伴 peer 关系（isKnownPeerBot/chatGrant）在本群 auto-create 一个会话；手动 /grant 没 prompt → 空会话。

**修复**：通知卡**真人 grantee 仍 @ 点名**（真人被 @ 不会自动开会话），**bot grantee 只用纯文本名字**（不产生 mention 事件，不唤醒对方 bot），可读信息保留。复用授权流程里已算好的 `isHumanOpenId` 结果，无新增通讯录调用。

## 测试
- `parseGrantTargets` 位置过滤：text/post 两形态、前缀歧义、co-addressed 两 bot 不互授；
- `tryHandleGrantCommand` 端到端：`@Claude @Codex /grant` 不弹「授权对方 bot」的卡、不写 chatGrants；
- `buildGrantNotifyCard` + card-handler 集成：bot grantee 无 `<at>`、真人 grantee 有 `<at>`。
- 全量单测 4333/4333 过，tsc clean。

## 改动文件
- `src/im/lark/grant-command.ts`（位置过滤）
- `src/im/lark/card-builder.ts` + `src/im/lark/card-handler.ts`（通知卡 @ 渲染）
- 3 个测试文件