### PR TITLE
fix(lark): prefer cross-ref over stale observed bots

### DIFF
--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -1118,6 +1118,12 @@ export type ChatBotMember = {
 };
 
 export async function listChatBotMembers(larkAppId: string, chatId: string): Promise<ChatBotMember[]> {
+  // Single name-key normalizer used for EVERY cross-source name match below
+  // (cross-ref ⇄ bots-info ⇄ observed). Trim-only: strips incidental leading/
+  // trailing whitespace but stays case-sensitive, so two genuinely distinct bots
+  // whose names differ only in case ("Claude" vs "claude") never collide.
+  const norm = (s: string) => s.trim();
+
   // Read per-bot cross-reference: other bots' open_ids as seen by larkAppId's app.
   // This is populated from @mention data in Lark events (the only reliable source,
   // since Lark open_id is per-app scoped — a bot's self-reported open_id is
@@ -1128,7 +1134,7 @@ export async function listChatBotMembers(larkAppId: string, chatId: string): Pro
     if (existsSync(crossRefPath)) {
       const data: Record<string, string> = JSON.parse(readFileSync(crossRefPath, 'utf-8'));
       for (const [name, openId] of Object.entries(data)) {
-        crossRef.set(name.toLowerCase(), openId);
+        crossRef.set(norm(name), openId);
       }
     }
   } catch { /* ignore */ }
@@ -1153,7 +1159,7 @@ export async function listChatBotMembers(larkAppId: string, chatId: string): Pro
         if (res.code === 0 && res.data?.is_in_chat) {
           const info = appIdToInfo.get(appId);
           // Prefer cross-reference (correct per-app open_id), fall back to self-seen
-          const crossHit = info?.botName ? crossRef.get(info.botName.toLowerCase()) : undefined;
+          const crossHit = info?.botName ? crossRef.get(norm(info.botName)) : undefined;
           const openId = crossHit ?? info?.botOpenId ?? appId;
           const isSelf = appId === larkAppId;
           // Reliable @-mention only when the per-app open_id was learned via
@@ -1196,12 +1202,12 @@ export async function listChatBotMembers(larkAppId: string, chatId: string): Pro
     const observedList = listObservedBots(config.session.dataDir, larkAppId, chatId);
     const latestObservedByName = new Map<string, (typeof observedList)[number]>();
     for (const o of observedList) {
-      const existing = latestObservedByName.get(o.name);
+      const k = norm(o.name);
+      const existing = latestObservedByName.get(k);
       if (!existing || o.lastSeenAt > existing.lastSeenAt) {
-        latestObservedByName.set(o.name, o);
+        latestObservedByName.set(k, o);
       }
     }
-    const norm = (s: string) => s.trim().toLowerCase();
     const seenOpenIds = new Set(configured.map(b => b.openId));
     const byName = new Map<string, number[]>();
     configured.forEach((b, i) => {

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -1201,8 +1201,8 @@ export async function listChatBotMembers(larkAppId: string, chatId: string): Pro
         latestObservedByName.set(o.name, o);
       }
     }
-    const seenOpenIds = new Set(configured.map(b => b.openId));
     const norm = (s: string) => s.trim().toLowerCase();
+    const seenOpenIds = new Set(configured.map(b => b.openId));
     const byName = new Map<string, number[]>();
     configured.forEach((b, i) => {
       const k = norm(b.displayName);
@@ -1211,28 +1211,31 @@ export async function listChatBotMembers(larkAppId: string, chatId: string): Pro
     });
 
     for (const o of latestObservedByName.values()) {
-      if (seenOpenIds.has(o.openId)) continue;
+      const crossHit = crossRef.get(norm(o.name));
+      const openId = crossHit ?? o.openId;
+      const mentionSource: ChatBotMember['mentionSource'] = crossHit ? 'cross-ref' : 'observed';
+      if (seenOpenIds.has(openId)) continue;
       const matches = byName.get(norm(o.name)) ?? [];
       if (matches.length === 1) {
         const row = configured[matches[0]];
         // Upgrade only if not already a reliable cross-ref handle.
         if (row.mentionSource !== 'cross-ref') {
-          configured[matches[0]] = { ...row, openId: o.openId, mentionable: true, mentionSource: 'observed' };
-          seenOpenIds.add(o.openId);
+          configured[matches[0]] = { ...row, openId, mentionable: true, mentionSource };
+          seenOpenIds.add(openId);
         }
         continue; // matched → never also append as an external duplicate
       }
       configured.push({
         larkAppId: '',
-        openId: o.openId,
+        openId,
         name: o.name,
         displayName: o.name,
         source: 'introduce',
         hasTeamRole: false,
         mentionable: true,
-        mentionSource: 'observed',
+        mentionSource,
       });
-      seenOpenIds.add(o.openId);
+      seenOpenIds.add(openId);
     }
   } catch (err) {
     logger.debug(`Failed to load observed bots for ${chatId}: ${err}`);

--- a/test/list-chat-bot-members.test.ts
+++ b/test/list-chat-bot-members.test.ts
@@ -268,4 +268,30 @@ describe('listChatBotMembers', () => {
     });
     expect(bots.find(b => b.openId === 'ou_stale')).toBeUndefined();
   });
+
+  it('prefers a same-name bot-openids cross-ref over a stale observed external handle', async () => {
+    state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-list-chat-bots-'));
+    writeFileSync(join(state.dataDir, 'bots-info.json'), '[]');
+    writeFileSync(join(state.dataDir, 'bot-openids-cli_self.json'), JSON.stringify({
+      NasCodex: 'ou_current_cross_ref',
+    }));
+    const now = Date.now();
+    writeFileSync(join(state.dataDir, 'observed-bots-cli_self-oc_chat.json'), JSON.stringify({
+      'ou_stale_observed': { name: 'NasCodex', source: 'introduce', firstSeenAt: now, lastSeenAt: now },
+    }));
+
+    const { listChatBotMembers } = await import('../src/im/lark/client.js');
+    const bots = await listChatBotMembers('cli_self', 'oc_chat');
+
+    const nasEntries = bots.filter(b => b.displayName === 'NasCodex');
+    expect(nasEntries).toHaveLength(1);
+    expect(nasEntries[0]).toMatchObject({
+      larkAppId: '',
+      openId: 'ou_current_cross_ref',
+      source: 'introduce',
+      mentionable: true,
+      mentionSource: 'cross-ref',
+    });
+    expect(bots.find(b => b.openId === 'ou_stale_observed')).toBeUndefined();
+  });
 });

--- a/test/list-chat-bot-members.test.ts
+++ b/test/list-chat-bot-members.test.ts
@@ -294,4 +294,33 @@ describe('listChatBotMembers', () => {
     });
     expect(bots.find(b => b.openId === 'ou_stale_observed')).toBeUndefined();
   });
+
+  it('cross-ref name matching trims whitespace but stays case-sensitive', async () => {
+    // The unified name-key normalizer is trim-only. A cross-ref key with stray
+    // surrounding whitespace still matches an observed name (trim), but a
+    // case-only difference does NOT — "Claude" and "claude" stay distinct bots.
+    state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-list-chat-bots-'));
+    writeFileSync(join(state.dataDir, 'bots-info.json'), '[]');
+    writeFileSync(join(state.dataDir, 'bot-openids-cli_self.json'), JSON.stringify({
+      '  NasCodex  ': 'ou_cross_ref_padded', // whitespace-padded → must still match
+      'Claude': 'ou_cross_ref_claude',       // capital C → must NOT match observed "claude"
+    }));
+    const now = Date.now();
+    writeFileSync(join(state.dataDir, 'observed-bots-cli_self-oc_chat.json'), JSON.stringify({
+      'ou_obs_nas': { name: 'NasCodex', source: 'introduce', firstSeenAt: now, lastSeenAt: now },
+      'ou_obs_claude': { name: 'claude', source: 'introduce', firstSeenAt: now, lastSeenAt: now },
+    }));
+
+    const { listChatBotMembers } = await import('../src/im/lark/client.js');
+    const bots = await listChatBotMembers('cli_self', 'oc_chat');
+
+    // Trim: padded cross-ref key matched the observed "NasCodex" → cross-ref openId wins.
+    const nas = bots.find(b => b.displayName === 'NasCodex')!;
+    expect(nas).toMatchObject({ openId: 'ou_cross_ref_padded', mentionSource: 'cross-ref' });
+
+    // Case-sensitive: observed "claude" must NOT pick up the "Claude" cross-ref id;
+    // it stays an observed external row with its own observed open_id.
+    const claude = bots.find(b => b.displayName === 'claude')!;
+    expect(claude).toMatchObject({ openId: 'ou_obs_claude', mentionSource: 'observed' });
+  });
 });


### PR DESCRIPTION
## Summary
- Prefer same-name `bot-openids-*` cross-ref entries when merging observed external bots in `botmux bots list`
- Prevent stale observed open_ids from shadowing a current cross-ref for federated/external bots
- Add a regression test for the NasCodex-style case where `bots-info.json` has no local configured row

Fixes #207

## Verification
- `pnpm vitest run --project unit test/list-chat-bot-members.test.ts`
- `pnpm build`

## Notes
- `pnpm test` still has pre-existing environment/main-branch failures unrelated to this change:
  - `test/child-env.test.ts`: node-pty `posix_spawnp failed`
  - `test/git-worktree.test.ts`: `/private/var/...` vs `/var/...` temp path expectations
  - `test/sandbox.test.ts`: mkdir-only opaque dir assertion
  - `test/worker-budget-cli.test.ts`: worker-budget CLI output/config-file failures
