### PR TITLE
feat(card): 仓库选择卡支持手动输入工作目录（重写 #150）

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -15,6 +15,7 @@ export const messages: Record<string, string> = {
   'card.btn.refresh': '🔃 Refresh',
   'card.btn.takeover': '🔄 Take Over',
   'card.btn.skip_repo': '▶️ Start Session Directly',
+  'card.btn.manual_repo': 'Use This Directory',
   'card.btn.half_page_up': '⇞ Page ½ Up',
   'card.btn.half_page_down': '⇟ Page ½ Down',
   'card.btn.send_custom': '📝 Send Custom Reply',
@@ -54,6 +55,8 @@ export const messages: Record<string, string> = {
   // ─── Repo select card ────────────────────────────────────────────────────
   'card.repo.title': '📁 Project Repository',
   'card.repo.placeholder_switch': 'Pick a repo to switch to',
+  'card.repo.manual_placeholder': 'Enter any working directory, e.g. /path/to/project or ~/projects/foo',
+  'card.repo.manual_empty': 'Please enter a working directory path',
   'card.repo.current_active': 'Currently active project:',
   'card.repo.current_marker': ' ← current',
   'card.repo.note': 'You can also reply `/repo <N>` (e.g. `/repo 1`), or `/repo <path|name>` directly (e.g. `/repo botmux`, `/repo ~/projects/foo`) to skip this card. `/repo wt <N|name> [branch]` opens a fresh worktree off the remote default branch.',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -57,7 +57,7 @@ export const messages: Record<string, string> = {
   'card.repo.placeholder_switch': 'Pick a repo to switch to',
   'card.repo.manual_placeholder': 'Enter any working directory, e.g. /path/to/project or ~/projects/foo',
   'card.repo.manual_empty': 'Please enter a working directory path',
-  'card.repo.current_active': 'Currently active project:',
+  'card.repo.current_active': 'Current working directory:',
   'card.repo.current_marker': ' ← current',
   'card.repo.note': 'You can also reply `/repo <N>` (e.g. `/repo 1`), or `/repo <path|name>` directly (e.g. `/repo botmux`, `/repo ~/projects/foo`) to skip this card. `/repo wt <N|name> [branch]` opens a fresh worktree off the remote default branch.',
   'card.repo.placeholder_worktree': '🌿 Open a repo as a new worktree',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -18,6 +18,7 @@ export const messages: Record<string, string> = {
   'card.btn.refresh': '🔃 刷新',
   'card.btn.takeover': '🔄 接管',
   'card.btn.skip_repo': '▶️ 直接开启会话',
+  'card.btn.manual_repo': '使用此目录',
   'card.btn.half_page_up': '⇞ 上半屏',
   'card.btn.half_page_down': '⇟ 下半屏',
   'card.btn.send_custom': '📝 发送自定义回复',
@@ -57,6 +58,8 @@ export const messages: Record<string, string> = {
   // ─── Repo select card ────────────────────────────────────────────────────
   'card.repo.title': '📁 项目仓库管理',
   'card.repo.placeholder_switch': '选择仓库并切换',
+  'card.repo.manual_placeholder': '输入任意工作目录，如 /path/to/project 或 ~/projects/foo',
+  'card.repo.manual_empty': '请输入工作目录路径',
   'card.repo.current_active': '当前活跃项目：',
   'card.repo.current_marker': ' ← 当前',
   'card.repo.note': '也可以回复 `/repo <编号>` 切换（如 `/repo 1`），或直接 `/repo <路径|项目名>`（如 `/repo botmux`、`/repo ~/projects/foo`）跳过本卡片；`/repo wt <编号|项目名> [分支名]` 基于远端默认分支新建 worktree 打开',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -60,7 +60,7 @@ export const messages: Record<string, string> = {
   'card.repo.placeholder_switch': '选择仓库并切换',
   'card.repo.manual_placeholder': '输入任意工作目录，如 /path/to/project 或 ~/projects/foo',
   'card.repo.manual_empty': '请输入工作目录路径',
-  'card.repo.current_active': '当前活跃项目：',
+  'card.repo.current_active': '当前工作目录：',
   'card.repo.current_marker': ' ← 当前',
   'card.repo.note': '也可以回复 `/repo <编号>` 切换（如 `/repo 1`），或直接 `/repo <路径|项目名>`（如 `/repo botmux`、`/repo ~/projects/foo`）跳过本卡片；`/repo wt <编号|项目名> [分支名]` 基于远端默认分支新建 worktree 打开',
   'card.repo.placeholder_worktree': '🌿 选仓库新建 worktree 打开',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -1005,6 +1005,28 @@ export function buildRepoSelectCard(projects: ProjectInfo[], currentPath?: strin
           },
         ],
       }] : []),
+      // Manual entry: type any existing local directory the scan didn't surface
+      // (mirrors `/repo <path>`). form_submit hands the input back under
+      // value.action='repo_manual_submit' with form_value.repo_manual_path.
+      {
+        tag: 'form',
+        name: 'repo_manual_form',
+        elements: [
+          {
+            tag: 'input',
+            name: 'repo_manual_path',
+            placeholder: { tag: 'plain_text', content: t('card.repo.manual_placeholder', undefined, locale) },
+          },
+          {
+            tag: 'button',
+            name: 'repo_manual_submit',
+            text: { tag: 'plain_text', content: t('card.btn.manual_repo', undefined, locale) },
+            type: 'default',
+            action_type: 'form_submit',
+            value: { action: 'repo_manual_submit', root_id: rootMessageId ?? '' },
+          },
+        ],
+      },
       {
         tag: 'note',
         elements: [

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -967,12 +967,47 @@ export function buildRepoSelectCard(projects: ProjectInfo[], currentPath?: strin
       title: { tag: 'plain_text', content: t('card.repo.title', undefined, locale) },
     },
     elements: [
+      // Current working directory + 「直接开启会话」on the same row: the skip
+      // button means "use this directory as-is, don't pick a repo", so it pairs
+      // with the current-dir line rather than the switch dropdown below.
       {
-        tag: 'div',
-        text: {
-          tag: 'lark_md',
-          content: `${t('card.repo.current_active', undefined, locale)}**${escapeMd(currentPath ?? 'N/A')}**`,
-        },
+        tag: 'column_set',
+        // flow: columns sit side-by-side on desktop and reflow (button wraps
+        // below) on narrow mobile instead of squeezing the button until its
+        // label truncates. auto-width columns size to content, so the text and
+        // button hug each other (no wide desktop gap) and the button always
+        // shows its full label.
+        flex_mode: 'flow',
+        horizontal_spacing: 'default',
+        columns: [
+          {
+            tag: 'column',
+            width: 'auto',
+            vertical_align: 'center',
+            elements: [
+              {
+                tag: 'div',
+                text: {
+                  tag: 'lark_md',
+                  content: `${t('card.repo.current_active', undefined, locale)}**${escapeMd(currentPath ?? 'N/A')}**`,
+                },
+              },
+            ],
+          },
+          {
+            tag: 'column',
+            width: 'auto',
+            vertical_align: 'center',
+            elements: [
+              {
+                tag: 'button',
+                text: { tag: 'plain_text', content: t('card.btn.skip_repo', undefined, locale) },
+                type: 'primary',
+                value: { action: 'skip_repo', root_id: rootMessageId ?? '' },
+              },
+            ],
+          },
+        ],
       },
       {
         tag: 'hr',
@@ -985,12 +1020,6 @@ export function buildRepoSelectCard(projects: ProjectInfo[], currentPath?: strin
             placeholder: { tag: 'plain_text', content: t('card.repo.placeholder_switch', undefined, locale) },
             options,
             value: { key: 'repo_switch', root_id: rootMessageId ?? '' },
-          },
-          {
-            tag: 'button',
-            text: { tag: 'plain_text', content: t('card.btn.skip_repo', undefined, locale) },
-            type: 'primary',
-            value: { action: 'skip_repo', root_id: rootMessageId ?? '' },
           },
         ],
       },
@@ -1012,18 +1041,47 @@ export function buildRepoSelectCard(projects: ProjectInfo[], currentPath?: strin
         tag: 'form',
         name: 'repo_manual_form',
         elements: [
+          // Input + 「使用此目录」on one row (column_set), mirroring the
+          // dropdown+button rhythm above. form_submit still collects
+          // form_value.repo_manual_path from the enclosing form.
           {
-            tag: 'input',
-            name: 'repo_manual_path',
-            placeholder: { tag: 'plain_text', content: t('card.repo.manual_placeholder', undefined, locale) },
-          },
-          {
-            tag: 'button',
-            name: 'repo_manual_submit',
-            text: { tag: 'plain_text', content: t('card.btn.manual_repo', undefined, locale) },
-            type: 'default',
-            action_type: 'form_submit',
-            value: { action: 'repo_manual_submit', root_id: rootMessageId ?? '' },
+            tag: 'column_set',
+            // flex_mode 'none' keeps the weighted input filling the row while
+            // the auto-width button hugs its label — input stays usable on
+            // mobile (not squeezed by a flow reflow) and the button never
+            // truncates. (flow mode collapsed the input on narrow screens.)
+            flex_mode: 'none',
+            horizontal_spacing: 'default',
+            columns: [
+              {
+                tag: 'column',
+                width: 'weighted',
+                weight: 1,
+                vertical_align: 'center',
+                elements: [
+                  {
+                    tag: 'input',
+                    name: 'repo_manual_path',
+                    placeholder: { tag: 'plain_text', content: t('card.repo.manual_placeholder', undefined, locale) },
+                  },
+                ],
+              },
+              {
+                tag: 'column',
+                width: 'auto',
+                vertical_align: 'center',
+                elements: [
+                  {
+                    tag: 'button',
+                    name: 'repo_manual_submit',
+                    text: { tag: 'plain_text', content: t('card.btn.manual_repo', undefined, locale) },
+                    type: 'default',
+                    action_type: 'form_submit',
+                    value: { action: 'repo_manual_submit', root_id: rootMessageId ?? '' },
+                  },
+                ],
+              },
+            ],
           },
         ],
       },

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -32,6 +32,7 @@ import { forkWorker, killWorker, scheduleCardPatch, parkStreamCard, clearUsageLi
 import { getSessionWorkingDir, buildNewTopicPrompt, getAvailableBots, persistStreamCardState, resumeSession, rememberLastCliInput } from '../../core/session-manager.js';
 import { publishAttentionPatch } from '../../core/session-activity.js';
 import { fallbackTurnId } from '../../core/reply-target.js';
+import { validateWorkingDir } from '../../core/working-dir.js';
 import type { DaemonToWorker, DisplayMode, TermActionKey } from '../../types.js';
 import { sessionKey, sessionAnchorId, frozenDisplayMode } from '../../core/types.js';
 import type { DaemonSession } from '../../core/types.js';
@@ -141,6 +142,143 @@ function validateCardCliBinding(ds: DaemonSession, value?: Record<string, string
     `action=${value?.action ?? '?'} expected=${expected} actual=${actual}`,
   );
   return false;
+}
+
+/**
+ * Commit a resolved working directory onto a repo-select session: pin it, then
+ * either fork the pending CLI (first selection) or close + recreate the session
+ * (mid-session switch). Shared by the dropdown flow, the worktree flow (which
+ * funnels back in with the freshly created worktree path) and the manual
+ * directory-entry form. Extracted to module scope so the form-submit branch can
+ * reuse the exact same spawn/switch path instead of duplicating it.
+ */
+async function commitRepoSelection(
+  ctx: {
+    ds: DaemonSession;
+    rootId: string;
+    cardMessageId?: string;
+    larkAppId?: string;
+    activeSessions: Map<string, DaemonSession>;
+    sessionReply: (rid: string, content: string, msgType?: string, turnId?: string) => Promise<string>;
+  },
+  dirPath: string,
+  dirLabel: string,
+): Promise<void> {
+  const { ds, rootId, cardMessageId, larkAppId, activeSessions, sessionReply } = ctx;
+  const locTarget = localeForBot(ds.larkAppId);
+  // `/close` deletes the active-map entry without touching sessionId or
+  // pendingRepo — identity against the map is the only tell that the session
+  // this flow captured is gone. Checked alongside the generation snapshots.
+  const repoSessionKey = larkAppId ? sessionKey(rootId, larkAppId) : rootId;
+  const sessionStillActive = () => activeSessions.get(repoSessionKey) === ds;
+  const commitGenSessionId = ds.session.sessionId;
+  ds.workingDir = dirPath;
+  ds.session.workingDir = dirPath;
+  sessionStore.updateSession(ds.session);
+
+  if (ds.pendingRepo) {
+    const selfBot = getBot(ds.larkAppId);
+    const botCfg = selfBot.config;
+    const effectiveCliId = sessionCliId(ds);
+    // First-time repo selection — now spawn CLI with the original prompt
+    ds.pendingRepo = false;
+    publishAttentionPatch(ds);
+    const pendingPrompt = ds.pendingPrompt ?? '';
+    const pendingRawInput = ds.pendingRawInput;
+    // Raw-input cold start still wraps any input buffered while the repo card
+    // was pending — see the skip_repo branch for the rationale.
+    const hasBufferedInput =
+      pendingPrompt.trim().length > 0 ||
+      (ds.pendingAttachments?.length ?? 0) > 0 ||
+      (ds.pendingFollowUps?.length ?? 0) > 0;
+    const wrappedPrompt = (!pendingRawInput || hasBufferedInput)
+      ? buildNewTopicPrompt(
+          pendingPrompt,
+          ds.session.sessionId,
+          effectiveCliId,
+          botCfg.cliPathOverride,
+          ds.pendingAttachments,
+          ds.pendingMentions,
+          await getAvailableBots(ds.larkAppId, ds.chatId),
+          ds.pendingFollowUps,
+          { name: selfBot.botName, openId: selfBot.botOpenId },
+          locTarget,
+          ds.pendingSender,
+          { larkAppId: ds.larkAppId, chatId: ds.chatId },
+        )
+      : '';
+    const prompt = pendingRawInput ? '' : wrappedPrompt;
+    // Last-line defence: prompt prep awaited above — if anything replaced
+    // OR closed the session in that window, forking now would clobber it
+    // (or resurrect a /close'd session).
+    if (!sessionStillActive() || ds.session.sessionId !== commitGenSessionId) {
+      logger.warn(`[${tag(ds)}] Session replaced or closed while preparing the pending-CLI prompt (${commitGenSessionId} → ${ds.session.sessionId}, active=${sessionStillActive()}) — aborting this fork`);
+      return;
+    }
+    if (pendingRawInput && hasBufferedInput) {
+      ds.pendingFollowUpInput = {
+        userPrompt: pendingPrompt || (ds.pendingFollowUps?.join('\n\n') ?? ''),
+        cliInput: wrappedPrompt,
+      };
+    }
+    rememberLastCliInput(ds, pendingRawInput ?? pendingPrompt, pendingRawInput ?? prompt);
+    ds.pendingPrompt = undefined;
+    ds.pendingAttachments = undefined;
+    ds.pendingMentions = undefined;
+    ds.pendingSender = undefined;
+    ds.pendingFollowUps = undefined;
+    forkWorker(ds, prompt);
+    // A card click has no turn of its own — anchor the confirmation to the
+    // session's current reply-target turn so a shared fold-back topic keeps
+    // it in-thread (same leak as the /repo command path).
+    await sessionReply(rootId, t('cmd.repo.selected_in_pending', { name: dirLabel }, locTarget), undefined, fallbackTurnId(ds, undefined));
+    logger.info(`[${tag(ds)}] Repo selected: ${dirPath}, spawning CLI`);
+  } else {
+    // Mid-session repo switch — close old session, start fresh.
+    killWorker(ds);
+    // Park the current card in `frozenCards` so the next POST under the new
+    // session sweeps it via recall. closeSession() wipes the on-disk
+    // frozen-cards file under the OLD sessionId, but the in-memory Map
+    // travels with `ds` into the new session and still carries the
+    // old messageId for deletion. If fork or POST fails, the parked card
+    // stays in the thread instead of vanishing prematurely.
+    parkStreamCard(ds);
+    sessionStore.closeSession(ds.session.sessionId);
+    const session = sessionStore.createSession(ds.chatId, rootId, dirLabel, ds.chatType);
+    ds.session = session;
+    ds.lastUserPrompt = undefined;
+    ds.lastCliInput = undefined;
+    // Pin workingDir + larkAppId onto the new session before forkWorker.
+    // Without this, a daemon restart restores the session with an empty
+    // workingDir and the worker spawns in the bot's default cwd, so
+    // `claude --resume` looks in the wrong .claude/projects/<hash>/ dir and
+    // exits code 0 immediately, crash-looping until the rate-limiter trips.
+    ds.session.workingDir = dirPath;
+    ds.session.larkAppId = ds.larkAppId;
+    sessionStore.updateSession(ds.session);
+    ds.hasHistory = false;
+    // Re-persist the parked card under the NEW sessionId so a daemon crash
+    // before the next POST doesn't strand it. closeSession() above wiped
+    // the on-disk file under the OLD sessionId; without this re-save, the
+    // in-memory Map only survives in process memory.
+    if (ds.frozenCards && ds.frozenCards.size > 0) {
+      saveFrozenCards(ds.session.sessionId, ds.frozenCards);
+    }
+    // Drop the old turn's streaming-card reference so worker_ready POSTs a
+    // fresh card for the new session instead of PATCHing the previous one.
+    ds.streamCardId = undefined;
+    ds.streamCardNonce = undefined;
+    ds.streamCardPending = undefined;
+    ds.lastScreenContent = undefined;
+    ds.lastScreenStatus = undefined;
+    forkWorker(ds, '', false);
+    await sessionReply(rootId, t('cmd.repo.switched_to', { name: dirLabel }, locTarget));
+    logger.info(`[${tag(ds)}] Repo switched to ${dirPath}, new session created`);
+  }
+
+  // Withdraw the repo selection card
+  if (cardMessageId && larkAppId) deleteMessage(larkAppId, cardMessageId);
+  ds.repoCardMessageId = undefined;
 }
 
 // ─── Main handler ─────────────────────────────────────────────────────────
@@ -637,7 +775,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     return { toast: { type: 'success', content: t('card.relay.toast_success', undefined, loc) } };
   }
 
-  const isSensitive = value?.action && ['restart', 'close', 'resume', 'skip_repo', 'retry_last_task', 'get_write_link', 'toggle_stream', 'toggle_display', 'export_text', 'term_action', 'refresh_screenshot', 'takeover', 'disconnect', 'tui_keys', 'tui_text_input', 'wf_approve', 'wf_reject', 'wf_cancel'].includes(value.action);
+  const isSensitive = value?.action && ['restart', 'close', 'resume', 'skip_repo', 'repo_manual_submit', 'retry_last_task', 'get_write_link', 'toggle_stream', 'toggle_display', 'export_text', 'term_action', 'refresh_screenshot', 'takeover', 'disconnect', 'tui_keys', 'tui_text_input', 'wf_approve', 'wf_reject', 'wf_cancel'].includes(value.action);
   if (isSensitive) {
     const rootId = value?.root_id;
     // activeSessions is keyed by sessionKey(anchor, larkAppId) — `${anchor}::${larkAppId}`
@@ -658,10 +796,10 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       : undefined;
     const effectiveAppId = larkAppId ?? ds?.larkAppId ?? closedForCtx?.larkAppId;
     const chatId = ds?.chatId ?? closedForCtx?.chatId;
-    // pendingRepo 阶段，会话发起人（含 chat-granted 用户）可以 skip_repo 起会话——
-    // 与 repo 下拉选择同款例外，否则被授权人连自己的首次会话都启动不了。
+    // pendingRepo 阶段，会话发起人（含 chat-granted 用户）可以 skip_repo / 手动填目录
+    // 起会话——与 repo 下拉选择同款例外，否则被授权人连自己的首次会话都启动不了。
     const pendingRepoOwnerException =
-      value.action === 'skip_repo' && !!ds?.pendingRepo &&
+      (value.action === 'skip_repo' || value.action === 'repo_manual_submit') && !!ds?.pendingRepo &&
       !!operatorOpenId && operatorOpenId === ds.session.ownerOpenId;
     if (effectiveAppId) {
       if (!pendingRepoOwnerException && !canOperate(effectiveAppId, chatId, operatorOpenId)) {
@@ -1354,6 +1492,35 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       if (cardMessageId && larkAppId) deleteMessage(larkAppId, cardMessageId);
       ds.repoCardMessageId = undefined;
     }
+
+    // Manual working-directory entry from the repo card form. The project scan
+    // may not surface every useful directory; this mirrors `/repo <path>` from
+    // the card. Permission is gated at the top (isSensitive + pendingRepoOwner
+    // exception), same as skip_repo. Always a plain commit — worktree creation
+    // needs a scanned git repo root, not an arbitrary path.
+    if (actionType === 'repo_manual_submit' && ds) {
+      const locDs = localeForBot(ds.larkAppId);
+      const rawPath = String(action?.form_value?.repo_manual_path ?? '').trim();
+      if (!rawPath) {
+        return { toast: { type: 'error', content: t('card.repo.manual_empty', undefined, locDs) } };
+      }
+      const validation = validateWorkingDir(rawPath, locDs);
+      if (!validation.ok) {
+        return { toast: { type: 'error', content: validation.error } };
+      }
+      // A worktree creation in flight holds the commit lock — a manual switch
+      // interleaving there would double-fork (same guard as the plain switch).
+      if (ds.worktreeCreating) {
+        return { toast: { type: 'info', content: t('cmd.repo.worktree_in_progress', undefined, locDs) } };
+      }
+      const selectedPath = validation.resolvedPath;
+      const displayName = pathBasename(selectedPath) || selectedPath;
+      await commitRepoSelection(
+        { ds, rootId, cardMessageId, larkAppId, activeSessions, sessionReply },
+        selectedPath,
+        displayName,
+      );
+    }
     return;
   }
 
@@ -1548,120 +1715,10 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
   const repoSessionKey = sessionKey(rootId, larkAppId!);
   const sessionStillActive = () => activeSessions.get(repoSessionKey) === targetDs;
 
-  // Shared commit path for a resolved directory: pin it on the session, then
-  // either fork the pending CLI (first selection) or close + recreate the
-  // session (mid-session switch). The worktree flow funnels back in here with
-  // the freshly created worktree path.
-  const commitSelection = async (dirPath: string, dirLabel: string) => {
-    const commitGenSessionId = targetDs.session.sessionId;
-    targetDs.workingDir = dirPath;
-    targetDs.session.workingDir = dirPath;
-    sessionStore.updateSession(targetDs.session);
-
-    if (targetDs.pendingRepo) {
-      const selfBot = getBot(targetDs.larkAppId);
-      const botCfg = selfBot.config;
-      const effectiveCliId = sessionCliId(targetDs);
-      // First-time repo selection — now spawn CLI with the original prompt
-      targetDs.pendingRepo = false;
-      publishAttentionPatch(targetDs);
-      const pendingPrompt = targetDs.pendingPrompt ?? '';
-      const pendingRawInput = targetDs.pendingRawInput;
-      // Raw-input cold start still wraps any input buffered while the repo card
-      // was pending — see the skip_repo branch above for the rationale.
-      const hasBufferedInput =
-        pendingPrompt.trim().length > 0 ||
-        (targetDs.pendingAttachments?.length ?? 0) > 0 ||
-        (targetDs.pendingFollowUps?.length ?? 0) > 0;
-      const wrappedPrompt = (!pendingRawInput || hasBufferedInput)
-        ? buildNewTopicPrompt(
-            pendingPrompt,
-            targetDs.session.sessionId,
-            effectiveCliId,
-            botCfg.cliPathOverride,
-            targetDs.pendingAttachments,
-            targetDs.pendingMentions,
-            await getAvailableBots(targetDs.larkAppId, targetDs.chatId),
-            targetDs.pendingFollowUps,
-            { name: selfBot.botName, openId: selfBot.botOpenId },
-            locTarget,
-            targetDs.pendingSender,
-            { larkAppId: targetDs.larkAppId, chatId: targetDs.chatId },
-          )
-        : '';
-      const prompt = pendingRawInput ? '' : wrappedPrompt;
-      // Last-line defence: prompt prep awaited above — if anything replaced
-      // OR closed the session in that window, forking now would clobber it
-      // (or resurrect a /close'd session).
-      if (!sessionStillActive() || targetDs.session.sessionId !== commitGenSessionId) {
-        logger.warn(`[${tag(targetDs)}] Session replaced or closed while preparing the pending-CLI prompt (${commitGenSessionId} → ${targetDs.session.sessionId}, active=${sessionStillActive()}) — aborting this fork`);
-        return;
-      }
-      if (pendingRawInput && hasBufferedInput) {
-        targetDs.pendingFollowUpInput = {
-          userPrompt: pendingPrompt || (targetDs.pendingFollowUps?.join('\n\n') ?? ''),
-          cliInput: wrappedPrompt,
-        };
-      }
-      rememberLastCliInput(targetDs, pendingRawInput ?? pendingPrompt, pendingRawInput ?? prompt);
-      targetDs.pendingPrompt = undefined;
-      targetDs.pendingAttachments = undefined;
-      targetDs.pendingMentions = undefined;
-      targetDs.pendingSender = undefined;
-      targetDs.pendingFollowUps = undefined;
-      forkWorker(targetDs, prompt);
-      // A card click has no turn of its own — anchor the confirmation to the
-      // session's current reply-target turn so a shared fold-back topic keeps
-      // it in-thread (same leak as the /repo command path).
-      await sessionReply(rootId, t('cmd.repo.selected_in_pending', { name: dirLabel }, locTarget), undefined, fallbackTurnId(targetDs, undefined));
-      logger.info(`[${tag(targetDs)}] Repo selected: ${dirPath}, spawning CLI`);
-    } else {
-      // Mid-session repo switch — close old session, start fresh.
-      killWorker(targetDs);
-      // Park the current card in `frozenCards` so the next POST under the new
-      // session sweeps it via recall. closeSession() wipes the on-disk
-      // frozen-cards file under the OLD sessionId, but the in-memory Map
-      // travels with `targetDs` into the new session and still carries the
-      // old messageId for deletion. If fork or POST fails, the parked card
-      // stays in the thread instead of vanishing prematurely.
-      parkStreamCard(targetDs);
-      sessionStore.closeSession(targetDs.session.sessionId);
-      const session = sessionStore.createSession(targetDs.chatId, rootId, dirLabel, targetDs.chatType);
-      targetDs.session = session;
-      targetDs.lastUserPrompt = undefined;
-      targetDs.lastCliInput = undefined;
-      // Pin workingDir + larkAppId onto the new session before forkWorker.
-      // Without this, a daemon restart restores the session with an empty
-      // workingDir and the worker spawns in the bot's default cwd, so
-      // `claude --resume` looks in the wrong .claude/projects/<hash>/ dir and
-      // exits code 0 immediately, crash-looping until the rate-limiter trips.
-      targetDs.session.workingDir = dirPath;
-      targetDs.session.larkAppId = targetDs.larkAppId;
-      sessionStore.updateSession(targetDs.session);
-      targetDs.hasHistory = false;
-      // Re-persist the parked card under the NEW sessionId so a daemon crash
-      // before the next POST doesn't strand it. closeSession() above wiped
-      // the on-disk file under the OLD sessionId; without this re-save, the
-      // in-memory Map only survives in process memory.
-      if (targetDs.frozenCards && targetDs.frozenCards.size > 0) {
-        saveFrozenCards(targetDs.session.sessionId, targetDs.frozenCards);
-      }
-      // Drop the old turn's streaming-card reference so worker_ready POSTs a
-      // fresh card for the new session instead of PATCHing the previous one.
-      targetDs.streamCardId = undefined;
-      targetDs.streamCardNonce = undefined;
-      targetDs.streamCardPending = undefined;
-      targetDs.lastScreenContent = undefined;
-      targetDs.lastScreenStatus = undefined;
-      forkWorker(targetDs, '', false);
-      await sessionReply(rootId, t('cmd.repo.switched_to', { name: dirLabel }, locTarget));
-      logger.info(`[${tag(targetDs)}] Repo switched to ${dirPath}, new session created`);
-    }
-
-    // Withdraw the repo selection card
-    if (cardMessageId && larkAppId) deleteMessage(larkAppId, cardMessageId);
-    targetDs.repoCardMessageId = undefined;
-  };
+  // Shared commit context for a resolved directory — funnels the dropdown,
+  // worktree and manual-entry flows through the same module-level
+  // commitRepoSelection (pin dir, then fork pending CLI or close+recreate).
+  const commitCtx = { ds: targetDs, rootId, cardMessageId, larkAppId, activeSessions, sessionReply };
 
   if (isWorktreeOpen) {
     // Worktree creation involves a `git fetch` that can take many seconds —
@@ -1707,7 +1764,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
         // right before committing, or we'd kill the session it just spawned.
         if (sessionChanged()) return notSwitched(creation, 'during reply');
         try {
-          await commitSelection(creation.path, `${pathBasename(creation.path)} (${creation.branch})`);
+          await commitRepoSelection(commitCtx, creation.path, `${pathBasename(creation.path)} (${creation.branch})`);
         } catch (e) {
           // The worktree DOES exist at this point — only the switch failed.
           // Don't report it as a creation failure, or the user retries and
@@ -1729,5 +1786,5 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
   if (targetDs.worktreeCreating) {
     return { toast: { type: 'info', content: t('cmd.repo.worktree_in_progress', undefined, locTarget) } };
   }
-  await commitSelection(selectedPath, displayName);
+  await commitRepoSelection(commitCtx, selectedPath, displayName);
 }

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -163,6 +163,10 @@ async function commitRepoSelection(
   },
   dirPath: string,
   dirLabel: string,
+  // The worktree flow already posted a precise "worktree 已创建：path 分支 …"
+  // line before funnelling in here — suppress the redundant "已选择/已切换"
+  // confirmation so the user sees a single message, not two.
+  opts?: { suppressConfirmReply?: boolean },
 ): Promise<void> {
   const { ds, rootId, cardMessageId, larkAppId, activeSessions, sessionReply } = ctx;
   const locTarget = localeForBot(ds.larkAppId);
@@ -231,7 +235,9 @@ async function commitRepoSelection(
     // A card click has no turn of its own — anchor the confirmation to the
     // session's current reply-target turn so a shared fold-back topic keeps
     // it in-thread (same leak as the /repo command path).
-    await sessionReply(rootId, t('cmd.repo.selected_in_pending', { name: dirLabel }, locTarget), undefined, fallbackTurnId(ds, undefined));
+    if (!opts?.suppressConfirmReply) {
+      await sessionReply(rootId, t('cmd.repo.selected_in_pending', { name: dirLabel }, locTarget), undefined, fallbackTurnId(ds, undefined));
+    }
     logger.info(`[${tag(ds)}] Repo selected: ${dirPath}, spawning CLI`);
   } else {
     // Mid-session repo switch — close old session, start fresh.
@@ -272,7 +278,9 @@ async function commitRepoSelection(
     ds.lastScreenContent = undefined;
     ds.lastScreenStatus = undefined;
     forkWorker(ds, '', false);
-    await sessionReply(rootId, t('cmd.repo.switched_to', { name: dirLabel }, locTarget));
+    if (!opts?.suppressConfirmReply) {
+      await sessionReply(rootId, t('cmd.repo.switched_to', { name: dirLabel }, locTarget));
+    }
     logger.info(`[${tag(ds)}] Repo switched to ${dirPath}, new session created`);
   }
 
@@ -1764,7 +1772,9 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
         // right before committing, or we'd kill the session it just spawned.
         if (sessionChanged()) return notSwitched(creation, 'during reply');
         try {
-          await commitRepoSelection(commitCtx, creation.path, `${pathBasename(creation.path)} (${creation.branch})`);
+          // The "worktree 已创建：…" notice above already confirms the switch —
+          // suppress commitRepoSelection's own "已选择/已切换" to avoid a dup.
+          await commitRepoSelection(commitCtx, creation.path, `${pathBasename(creation.path)} (${creation.branch})`, { suppressConfirmReply: true });
         } catch (e) {
           // The worktree DOES exist at this point — only the switch failed.
           // Don't report it as a creation failure, or the user retries and

--- a/test/card-builder.test.ts
+++ b/test/card-builder.test.ts
@@ -716,14 +716,36 @@ describe('buildRepoSelectCard', () => {
   // ── Element structure ─────────────────────────────────────────────────
 
   describe('element structure', () => {
-    it('should have 5 top-level elements: div, hr, action, worktree action, note', () => {
+    it('should have 6 top-level elements: div, hr, action, worktree action, manual form, note', () => {
       const card = parse(buildRepoSelectCard(projects));
-      expect(card.elements).toHaveLength(5);
+      expect(card.elements).toHaveLength(6);
       expect(card.elements[0].tag).toBe('div');
       expect(card.elements[1].tag).toBe('hr');
       expect(card.elements[2].tag).toBe('action');
       expect(card.elements[3].tag).toBe('action');
-      expect(card.elements[4].tag).toBe('note');
+      expect(card.elements[4].tag).toBe('form');
+      expect(card.elements[5].tag).toBe('note');
+    });
+
+    it('manual-entry form carries an input + form_submit button under repo_manual_submit', () => {
+      const card = parse(buildRepoSelectCard(projects, undefined, 'om_root'));
+      const form = card.elements.find((e: any) => e.tag === 'form' && e.name === 'repo_manual_form');
+      expect(form).toBeDefined();
+      const input = form.elements.find((e: any) => e.tag === 'input');
+      expect(input.name).toBe('repo_manual_path');
+      const btn = form.elements.find((e: any) => e.tag === 'button');
+      expect(btn.action_type).toBe('form_submit');
+      expect(btn.value.action).toBe('repo_manual_submit');
+      expect(btn.value.root_id).toBe('om_root');
+    });
+
+    it('keeps the manual-entry form even when no main repos exist (worktree action omitted)', () => {
+      const onlyWorktrees: ProjectInfo[] = [
+        { name: 'beta', path: '/home/user/beta', type: 'worktree', branch: 'feat-x' },
+      ];
+      const card = parse(buildRepoSelectCard(onlyWorktrees));
+      // div, hr, action, form, note — worktree action dropped, form stays
+      expect(card.elements.map((e: any) => e.tag)).toEqual(['div', 'hr', 'action', 'form', 'note']);
     });
   });
 

--- a/test/card-builder.test.ts
+++ b/test/card-builder.test.ts
@@ -576,6 +576,24 @@ describe('buildRepoSelectCard', () => {
     { name: 'gamma', path: '/home/user/gamma', type: 'repo', branch: 'develop' },
   ];
 
+  // The current-dir text + 「直接开启会话」and the manual input + button are
+  // each wrapped in a column_set for same-row layout, so a plain top-level
+  // .find() no longer reaches the div / input / button. Walk into column_set
+  // columns and form elements to collect every node by tag.
+  function deepFind(card: any, tag: string): any[] {
+    const out: any[] = [];
+    const walk = (els: any[]) => {
+      for (const el of els ?? []) {
+        if (el?.tag === tag) out.push(el);
+        if (Array.isArray(el?.columns)) el.columns.forEach((c: any) => walk(c.elements));
+        if (Array.isArray(el?.elements)) walk(el.elements);
+        if (Array.isArray(el?.actions)) walk(el.actions);
+      }
+    };
+    walk(card.elements);
+    return out;
+  }
+
   it('should return valid JSON', () => {
     const json = buildRepoSelectCard(projects);
     expect(() => JSON.parse(json)).not.toThrow();
@@ -597,20 +615,27 @@ describe('buildRepoSelectCard', () => {
   describe('current path display', () => {
     it('should show currentPath when provided', () => {
       const card = parse(buildRepoSelectCard(projects, '/home/user/alpha'));
-      const divEl = card.elements.find((e: any) => e.tag === 'div');
+      const divEl = deepFind(card, 'div')[0];
       expect(divEl.text.content).toContain('/home/user/alpha');
     });
 
     it('should show "N/A" when currentPath is undefined', () => {
       const card = parse(buildRepoSelectCard(projects));
-      const divEl = card.elements.find((e: any) => e.tag === 'div');
+      const divEl = deepFind(card, 'div')[0];
       expect(divEl.text.content).toContain('N/A');
     });
 
     it('should escape markdown special chars in currentPath', () => {
       const card = parse(buildRepoSelectCard(projects, '/home/user/[special]'));
-      const divEl = card.elements.find((e: any) => e.tag === 'div');
+      const divEl = deepFind(card, 'div')[0];
       expect(divEl.text.content).toContain('\\[special\\]');
+    });
+
+    it('uses the "当前工作目录" label (not "项目")', () => {
+      const card = parse(buildRepoSelectCard(projects, '/home/user/alpha'));
+      const divEl = deepFind(card, 'div')[0];
+      expect(divEl.text.content).toContain('当前工作目录');
+      expect(divEl.text.content).not.toContain('当前活跃项目');
     });
   });
 
@@ -690,14 +715,20 @@ describe('buildRepoSelectCard', () => {
   // ── Skip repo button ──────────────────────────────────────────────────
 
   describe('skip repo button', () => {
-    it('should include "直接开启会话" button with primary type', () => {
+    it('should include "直接开启会话" button with primary type, paired with the current-dir row', () => {
       const card = parse(buildRepoSelectCard(projects, undefined, 'om_root'));
-      const actionEl = card.elements.find((e: any) => e.tag === 'action');
-      const skipBtn = actionEl.actions.find((a: any) => a.value?.action === 'skip_repo');
+      const skipBtn = deepFind(card, 'button').find((b: any) => b.value?.action === 'skip_repo');
       expect(skipBtn).toBeDefined();
       expect(skipBtn.type).toBe('primary');
       expect(skipBtn.text.content).toContain('直接开启会话');
       expect(skipBtn.value.root_id).toBe('om_root');
+      // It now lives in the top column_set (next to 当前工作目录), NOT in the
+      // switch-dropdown action row.
+      const switchRow = card.elements.find((e: any) => e.tag === 'action');
+      expect(switchRow.actions.some((a: any) => a.value?.action === 'skip_repo')).toBe(false);
+      expect(card.elements[0].tag).toBe('column_set');
+      const topButtons = deepFind({ elements: [card.elements[0]] }, 'button');
+      expect(topButtons.some((b: any) => b.value?.action === 'skip_repo')).toBe(true);
     });
   });
 
@@ -716,24 +747,26 @@ describe('buildRepoSelectCard', () => {
   // ── Element structure ─────────────────────────────────────────────────
 
   describe('element structure', () => {
-    it('should have 6 top-level elements: div, hr, action, worktree action, manual form, note', () => {
+    it('should have 6 top-level elements: dir+skip column_set, hr, switch action, worktree action, manual form, note', () => {
       const card = parse(buildRepoSelectCard(projects));
       expect(card.elements).toHaveLength(6);
-      expect(card.elements[0].tag).toBe('div');
+      expect(card.elements[0].tag).toBe('column_set'); // 当前工作目录 + 直接开启会话
       expect(card.elements[1].tag).toBe('hr');
-      expect(card.elements[2].tag).toBe('action');
-      expect(card.elements[3].tag).toBe('action');
-      expect(card.elements[4].tag).toBe('form');
+      expect(card.elements[2].tag).toBe('action');     // 选择仓库并切换 dropdown
+      expect(card.elements[3].tag).toBe('action');     // worktree dropdown
+      expect(card.elements[4].tag).toBe('form');       // manual entry
       expect(card.elements[5].tag).toBe('note');
     });
 
-    it('manual-entry form carries an input + form_submit button under repo_manual_submit', () => {
+    it('manual-entry form carries an input + form_submit button (same row via column_set)', () => {
       const card = parse(buildRepoSelectCard(projects, undefined, 'om_root'));
       const form = card.elements.find((e: any) => e.tag === 'form' && e.name === 'repo_manual_form');
       expect(form).toBeDefined();
-      const input = form.elements.find((e: any) => e.tag === 'input');
+      // input + button now share a row inside a column_set under the form
+      expect(form.elements[0].tag).toBe('column_set');
+      const input = deepFind({ elements: [form] }, 'input')[0];
       expect(input.name).toBe('repo_manual_path');
-      const btn = form.elements.find((e: any) => e.tag === 'button');
+      const btn = deepFind({ elements: [form] }, 'button').find((b: any) => b.name === 'repo_manual_submit');
       expect(btn.action_type).toBe('form_submit');
       expect(btn.value.action).toBe('repo_manual_submit');
       expect(btn.value.root_id).toBe('om_root');
@@ -744,8 +777,8 @@ describe('buildRepoSelectCard', () => {
         { name: 'beta', path: '/home/user/beta', type: 'worktree', branch: 'feat-x' },
       ];
       const card = parse(buildRepoSelectCard(onlyWorktrees));
-      // div, hr, action, form, note — worktree action dropped, form stays
-      expect(card.elements.map((e: any) => e.tag)).toEqual(['div', 'hr', 'action', 'form', 'note']);
+      // column_set(dir+skip), hr, switch action, form, note — worktree action dropped, form stays
+      expect(card.elements.map((e: any) => e.tag)).toEqual(['column_set', 'hr', 'action', 'form', 'note']);
     });
   });
 

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -9,7 +9,7 @@
  *
  * Run:  pnpm vitest run test/card-handler-repo-select.test.ts
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // ─── Mocks (before importing the module under test) ───────────────────────
 
@@ -110,6 +110,9 @@ import { createRepoWorktree } from '../src/services/git-worktree.js';
 import { sessionKey } from '../src/core/types.js';
 import type { DaemonSession } from '../src/core/types.js';
 import type { ProjectInfo } from '../src/services/project-scanner.js';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
@@ -159,6 +162,17 @@ function makeSelectEvent(key: 'repo_switch' | 'repo_worktree', path: string) {
   return {
     operator: { open_id: OWNER },
     action: { option: path, value: { key, root_id: ROOT_ID } },
+    context: { open_message_id: 'om_card' },
+  };
+}
+
+function makeManualEvent(path: string, operator = OWNER) {
+  return {
+    operator: { open_id: operator },
+    action: {
+      value: { action: 'repo_manual_submit', root_id: ROOT_ID },
+      form_value: { repo_manual_path: path },
+    },
     context: { open_message_id: 'om_card' },
   };
 }
@@ -396,5 +410,75 @@ describe('repo select card — worktree open', () => {
     expect(forkWorker).not.toHaveBeenCalled();
     expect(ds.pendingRepo).toBe(true); // still recoverable — card stays
     expect(sessionReply.mock.calls.map(c => c[1]).join()).toContain('fetch blew up');
+  });
+});
+
+describe('repo select card — manual directory entry', () => {
+  let tmpDir: string;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'botmux-manual-repo-')); });
+  afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('pendingRepo manual submit forks the CLI in the typed directory', async () => {
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'queued task', worker: null });
+    const { deps, sessionReply } = makeDeps(ds);
+
+    await handleCardAction(makeManualEvent(tmpDir), deps, APP_ID);
+
+    expect(ds.pendingRepo).toBe(false);
+    expect(ds.workingDir).toBe(tmpDir);
+    expect(ds.session.workingDir).toBe(tmpDir);
+    expect(forkWorker).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(forkWorker).mock.calls[0]![1]).toBe('mock-prompt');
+    const reply = sessionReply.mock.calls.map(c => c[1]).join();
+    expect(reply).toContain('已选择');
+    expect(reply).toContain(basename(tmpDir));
+    expect(killWorker).not.toHaveBeenCalled();
+  });
+
+  it('mid-session manual submit closes the old session and forks a fresh one', async () => {
+    const ds = makeDs(); // no pendingRepo
+    const { deps, sessionReply } = makeDeps(ds);
+
+    await handleCardAction(makeManualEvent(tmpDir), deps, APP_ID);
+
+    expect(killWorker).toHaveBeenCalledTimes(1);
+    expect(closeSession).toHaveBeenCalledWith('uuid-old');
+    expect(ds.session.sessionId).toMatch(/^uuid-new-/);
+    expect(ds.session.workingDir).toBe(tmpDir);
+    expect(forkWorker).toHaveBeenCalledTimes(1);
+    expect(sessionReply.mock.calls.map(c => c[1]).join()).toContain('已切换');
+  });
+
+  it('rejects a non-existent path with an error toast and does not fork', async () => {
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null });
+    const { deps } = makeDeps(ds);
+
+    const res = await handleCardAction(makeManualEvent(join(tmpDir, 'nope-does-not-exist')), deps, APP_ID);
+
+    expect(res?.toast?.type).toBe('error');
+    expect(forkWorker).not.toHaveBeenCalled();
+    expect(ds.pendingRepo).toBe(true); // recoverable — card stays
+  });
+
+  it('rejects an empty path with an error toast and does not fork', async () => {
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null });
+    const { deps } = makeDeps(ds);
+
+    const res = await handleCardAction(makeManualEvent('   '), deps, APP_ID);
+
+    expect(res?.toast?.type).toBe('error');
+    expect(forkWorker).not.toHaveBeenCalled();
+    expect(ds.pendingRepo).toBe(true);
+  });
+
+  it('blocks a manual submit while a worktree creation holds the commit lock', async () => {
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null, worktreeCreating: true });
+    const { deps } = makeDeps(ds);
+
+    const res = await handleCardAction(makeManualEvent(tmpDir), deps, APP_ID);
+
+    expect(res?.toast?.content).toContain('已有一个 worktree 正在创建');
+    expect(forkWorker).not.toHaveBeenCalled();
+    expect(ds.pendingRepo).toBe(true);
   });
 });

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -254,7 +254,11 @@ describe('repo select card — worktree open', () => {
     expect(ds.workingDir).toBe('/repos/alpha-wt-1');
     expect(ds.session.workingDir).toBe('/repos/alpha-wt-1');
     expect(ds.pendingRepo).toBe(false);
-    expect(sessionReply.mock.calls.map(c => c[1]).join()).toContain('worktree 已创建');
+    const replies = sessionReply.mock.calls.map(c => c[1]).join();
+    expect(replies).toContain('worktree 已创建');
+    // The redundant "已选择" confirmation is suppressed in the worktree flow —
+    // the "worktree 已创建：…" line above is the single message the user sees.
+    expect(replies).not.toContain('已选择');
   });
 
   it('blocks a plain switch while git runs — and does NOT commit when the session moved on out-of-band', async () => {


### PR DESCRIPTION
## 背景

重写停滞的 #150。原 PR 的功能诉求仍有效——仓库选择卡至今没有手动路径输入框，唯一等价物是 \`/repo <path>\` 文字命令——但旧实现在 #180 把 pendingRepo 起会话/切换收敛进 \`commitSelection()\` 之前，内联复制了约 70 行 spawn 逻辑，已与 master 冲突且无法干净 rebase。作者长期未响应，遂按申晗指示在最新 master 上重写。

## 改动

- **card-builder**：仓库选择卡新增 \`repo_manual_form\` 手动输入框（input + \`form_submit\` 按钮），始终展示（即使无可建 worktree 的主仓库）。
- **card-handler**：
  - 把原本内联在选卡流程里的 \`commitSelection\` 提取为**模块级 \`commitRepoSelection\`**，下拉切换 / worktree 打开 / 手动输入三条路径共用同一套 pendingRepo 起会话 + mid-session 切换 + 各代际/identity 竞态护栏（#180 的竞态修复原样保留）。
  - 新增 \`repo_manual_submit\` 分支：\`validateWorkingDir\` 校验（存在性 + 是否目录）→ 空/非法路径回 error toast 且不 fork → worktree 创建在途时按同款锁拒绝（避免双 fork）→ 走 \`commitRepoSelection\`。
  - 权限接线：\`repo_manual_submit\` 加入 \`isSensitive\` 列表 + 扩展 \`pendingRepoOwnerException\`（与 \`skip_repo\` 同款，让 pending 阶段会话发起人能起自己的首次会话）。
- **i18n**：新增 \`card.btn.manual_repo\` / \`card.repo.manual_placeholder\` / \`card.repo.manual_empty\`（zh + en）。

## 验证

- \`tsc\` 0 error
- \`test/card-handler-repo-select.test.ts\`：新增 5 例（pending 起会话 / mid-session 切换 / 非法路径 / 空路径 / worktree 锁拒绝）；**11 条既有竞态用例全部仍绿**——印证 commitSelection 提取为 commitRepoSelection 后行为不变。
- \`test/card-builder.test.ts\`：更新结构断言 + 新增 3 例（表单存在/字段/无主仓库时仍保留表单）。
- 全量 unit：**289 文件 / 4385 测试全过**。

未发版未部署。

Closes #150