### PR TITLE
fix: guard Windows stdin encoding in send

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,6 +55,8 @@ import { logger } from './utils/logger.js';
 import { invalidWorkingDirs } from './utils/working-dir.js';
 import { firstPositional } from './cli/arg-utils.js';
 import { dispatchPrimaryMessage, findStdinAliasAttachment, sendFileAttachments } from './cli/send-dispatch.js';
+import { buildPm2SpawnCommand } from './cli/pm2-command.js';
+import { rejectLikelyWindowsStdinMojibake } from './cli/stdin-encoding.js';
 import {
   formatBotInfoEntriesForCli,
   formatChatBotsForCli,
@@ -1362,8 +1364,10 @@ function cmdLogs(): void {
     target = `/^${PM2_NAME}/`;
   }
 
-  // Use spawn for streaming output
-  const child = spawn(pm2Bin(), ['logs', target, '--lines', lines], {
+  // Use spawn for streaming output. Windows cannot spawn a .js CLI script
+  // directly, so run the bundled pm2 script through the current node.exe.
+  const pm2 = buildPm2SpawnCommand(pm2Bin(), ['logs', target, '--lines', lines]);
+  const child = spawn(pm2.command, pm2.args, {
     stdio: 'inherit',
     env: pm2Env(),
   });
@@ -3261,6 +3265,7 @@ async function cmdSend(rest: string[]): Promise<void> {
       content = await readStdin();
     }
   }
+  if (!contentFile) rejectLikelyWindowsStdinMojibake(content);
 
   if (!content.trim() && images.length === 0 && files.length === 0) {
     console.error('没有内容可发送。用法:\n  echo "消息" | botmux send\n  botmux send "消息"\n  botmux send --content-file /tmp/msg.md --images /tmp/chart.png');
@@ -4096,6 +4101,7 @@ async function cmdReport(rest: string[]): Promise<void> {
     const pos = positionals(rest);
     content = pos.length ? pos.join(' ') : await readStdin();
   }
+  if (!contentFile) rejectLikelyWindowsStdinMojibake(content);
   if (!content.trim()) {
     console.error('没有回报内容。用法: botmux report "子项目X 完成 + 产出位置"');
     process.exit(1);

--- a/src/cli/pm2-command.ts
+++ b/src/cli/pm2-command.ts
@@ -1,0 +1,16 @@
+export interface SpawnCommand {
+  command: string;
+  args: string[];
+}
+
+export function buildPm2SpawnCommand(
+  pm2Script: string,
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+  nodePath: string = process.execPath,
+): SpawnCommand {
+  if (platform === 'win32' && pm2Script !== 'pm2') {
+    return { command: nodePath, args: [pm2Script, ...args] };
+  }
+  return { command: pm2Script, args };
+}

--- a/src/cli/stdin-encoding.ts
+++ b/src/cli/stdin-encoding.ts
@@ -1,0 +1,21 @@
+export function looksLikeWindowsStdinMojibake(
+  content: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (platform !== 'win32') return false;
+
+  const trimmed = content.trim();
+  if (trimmed.length < 8) return false;
+  if (/[^\x00-\x7F]/.test(trimmed)) return false;
+
+  const questionCount = (trimmed.match(/\?/g) ?? []).length;
+  return questionCount >= 4 && questionCount / trimmed.length >= 0.18;
+}
+
+export function rejectLikelyWindowsStdinMojibake(content: string): void {
+  if (!looksLikeWindowsStdinMojibake(content)) return;
+
+  console.error('botmux send refused: Windows PowerShell appears to have converted non-ASCII stdin text to "?".');
+  console.error('Write the message to a UTF-8 file and use: botmux send --content-file <path>');
+  process.exit(2);
+}

--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -265,13 +265,13 @@ botmux send --attention=blocked --mention-back "缺 TOS 上传密钥，拿不到
 
 ### 纯文本（最常见）
 
-多行内容必须用 heredoc；不要写成 \`botmux send "第一行\\n第二行"\`，否则用户会在飞书里看到字面量 \`\\n\`。
+多行内容不要写成 \`botmux send "第一行\\n第二行"\`，否则用户会在飞书里看到字面量 \`\\n\`。在 Unix shell 里可用 heredoc；在 Windows/PowerShell 里发送包含中文或 emoji 的多行内容时，必须先写 UTF-8 文件，再用 \`--content-file\`，不要把中文直接通过 here-string、\`echo\` 或管道送进 stdin。
 
 \`\`\`bash
 # 直接传参
 botmux send "分析完成，核心问题是 X"
 
-# heredoc（多行内容推荐）
+# Unix shell: heredoc
 botmux send <<'EOF'
 ## 分析报告
 
@@ -285,9 +285,23 @@ EOF
 echo "构建成功 ✅" | botmux send
 \`\`\`
 
+\`\`\`powershell
+# Windows PowerShell: 中文/emoji 多行内容
+$msg = Join-Path $env:TEMP "botmux-message.md"
+@'
+## 分析报告
+
+1. 发现问题 A
+2. 建议方案 B
+
+需要你确认后我再动手。
+'@ | Set-Content -LiteralPath $msg -Encoding utf8
+botmux send --content-file $msg
+\`\`\`
+
 > ⚠️ **重要：single-quoted heredoc \`<<'EOF'\` 内反引号直接写真反引号，不要加反斜杠转义。**
 > 原因：单引号 heredoc 已经禁用所有特殊字符解释（\`$\`、反斜杠、反引号一律按字面量处理）。再加反斜杠反而会把"反斜杠+反引号"作为字面字符混进 markdown，让 markdown-it 按 CommonMark 的 backslash-escape 处理——结果卡片里三反引号变成可见字符、代码块整段废掉。
-> 自检：写完 bash 命令后扫一眼，如果 EOF 块内**任何反引号前面带反斜杠**，删掉那个反斜杠。
+> 自检：写完 bash 命令后扫一眼，如果 EOF 块内**任何反引号前面带反斜杠**，删掉那个反斜杠。Windows/PowerShell 需要中文或 emoji 时优先用上面的 \`--content-file\` 写法。
 
 ### 可用的 markdown 语法（自动走卡片）
 

--- a/test/builtin-skills.test.ts
+++ b/test/builtin-skills.test.ts
@@ -7,12 +7,14 @@ import { describe, it, expect } from 'vitest';
 import { BUILTIN_SKILLS, RETIRED_SKILL_NAMES } from '../src/skills/definitions.js';
 
 describe('built-in botmux-send skill', () => {
-  it('teaches heredoc usage for multiline sends', () => {
+  it('teaches safe multiline sends across Unix and Windows shells', () => {
     const skill = BUILTIN_SKILLS.find(s => s.name === 'botmux-send');
     expect(skill).toBeDefined();
     expect(skill!.content).toContain("botmux send <<'EOF'");
-    expect(skill!.content).toContain('botmux send "第一行\\n第二行"');
-    expect(skill!.content).toContain('字面量');
+    expect(skill!.content).toContain('Windows/PowerShell');
+    expect(skill!.content).toContain('--content-file');
+    expect(skill!.content).toContain('Set-Content -LiteralPath $msg -Encoding utf8');
+    expect(skill!.content).toContain('不要把中文直接通过 here-string');
   });
 
   it('warns that mention-back/no-mention are switches without values', () => {

--- a/test/pm2-command.test.ts
+++ b/test/pm2-command.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { buildPm2SpawnCommand } from '../src/cli/pm2-command.js';
+
+describe('buildPm2SpawnCommand', () => {
+  it('runs bundled pm2 script through node.exe on Windows', () => {
+    expect(buildPm2SpawnCommand(
+      'D:\\Application\\npm-global\\node_modules\\botmux\\node_modules\\pm2\\bin\\pm2',
+      ['logs', '/^botmux/', '--lines', '50'],
+      'win32',
+      'D:\\Application\\nodejs\\node.exe',
+    )).toEqual({
+      command: 'D:\\Application\\nodejs\\node.exe',
+      args: [
+        'D:\\Application\\npm-global\\node_modules\\botmux\\node_modules\\pm2\\bin\\pm2',
+        'logs',
+        '/^botmux/',
+        '--lines',
+        '50',
+      ],
+    });
+  });
+
+  it('keeps direct pm2 command unchanged on Windows', () => {
+    expect(buildPm2SpawnCommand('pm2', ['status'], 'win32', 'node.exe')).toEqual({
+      command: 'pm2',
+      args: ['status'],
+    });
+  });
+
+  it('keeps direct script execution on Unix platforms', () => {
+    expect(buildPm2SpawnCommand('/app/node_modules/pm2/bin/pm2', ['status'], 'linux', '/usr/bin/node')).toEqual({
+      command: '/app/node_modules/pm2/bin/pm2',
+      args: ['status'],
+    });
+  });
+});

--- a/test/windows-stdin-encoding.test.ts
+++ b/test/windows-stdin-encoding.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { looksLikeWindowsStdinMojibake } from '../src/cli/stdin-encoding.js';
+
+describe('looksLikeWindowsStdinMojibake', () => {
+  it('detects question-mark replacement on Windows stdin', () => {
+    expect(looksLikeWindowsStdinMojibake('????????? Wan-Animate', 'win32')).toBe(true);
+    expect(looksLikeWindowsStdinMojibake('??????\n??/?', 'win32')).toBe(true);
+  });
+
+  it('does not flag valid Unicode content', () => {
+    expect(looksLikeWindowsStdinMojibake('调研结论：中文正常 Wan-Animate', 'win32')).toBe(false);
+  });
+
+  it('does not flag non-Windows platforms', () => {
+    expect(looksLikeWindowsStdinMojibake('????????? Wan-Animate', 'linux')).toBe(false);
+  });
+
+  it('does not flag ordinary short or low-density question marks', () => {
+    expect(looksLikeWindowsStdinMojibake('OK?', 'win32')).toBe(false);
+    expect(looksLikeWindowsStdinMojibake('Did this work? Yes, it did.', 'win32')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- detect likely Windows PowerShell stdin mojibake before botmux send/report posts irreversible question-mark content
- run bundled pm2 through the current node executable for streaming logs on Windows
- update the botmux-send skill to recommend UTF-8 --content-file for Windows multiline Unicode content

## Tests
- npm exec -- pnpm vitest run test/windows-stdin-encoding.test.ts test/pm2-command.test.ts test/builtin-skills.test.ts
- npm exec -- pnpm exec tsc --noEmit

Note: npm exec -- pnpm test exceeded the 5 minute local tool timeout on Windows before producing a final result; no failing assertion was observed before timeout.