### PR TITLE
fix(maintenance): 自动更新重启用 setsid 脱离 daemon 进程树 + 失败可见

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1180,10 +1180,17 @@ function deleteAllBotmuxProcesses(home: string = PM2_HOME): void {
             env: pm2Env(home),
             timeout: 10_000,
           });
-        } catch { /* */ }
+        } catch (e) {
+          // Don't swallow silently — a failed delete here used to leave the
+          // restart half-done with no trace. Surface it (the auto-restart
+          // driver captures stderr to ~/.botmux/logs/maintenance-restart.log).
+          console.error(`[restart] pm2 delete ${app.name} failed: ${e instanceof Error ? e.message : e}`);
+        }
       }
     }
-  } catch { /* pm2 not running or no apps */ }
+  } catch (e) {
+    console.error(`[restart] pm2 jlist failed (pm2 not running or no apps?): ${e instanceof Error ? e.message : e}`);
+  }
 }
 
 function killPm2GodDaemon(home: string = PM2_HOME): void {

--- a/src/core/maintenance.ts
+++ b/src/core/maintenance.ts
@@ -16,8 +16,9 @@
  * production wiring.
  */
 import { execSync, spawn } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, renameSync, writeFileSync, writeSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { config } from '../config.js';
 import { logger } from '../utils/logger.js';
 import { readGlobalConfig, type MaintenanceConfig } from '../global-config.js';
@@ -136,6 +137,41 @@ export function writeMaintenanceStateTo(dir: string, s: MaintenanceState): void 
  *  within the same minute it's reached. */
 export const MAINTENANCE_TICK_MS = 60_000;
 
+/** Where the auto-restart driver's stdout/stderr is captured, so a failed
+ *  restart-to-apply is diagnosable (previously stdio was 'ignore'). */
+export function maintenanceRestartLogPath(): string {
+  return join(homedir(), '.botmux', 'logs', 'maintenance-restart.log');
+}
+
+/**
+ * Build the command to launch `botmux restart` for applying an auto-update.
+ *
+ * The restart driver must NOT remain a descendant of the daemon it's about to
+ * tear down: `botmux restart` deletes botmux-0 (the very daemon that spawned
+ * this), and when PM2 kills botmux-0 a child in its process tree gets
+ * interrupted — so the restart aborts after deleting botmux-0 and never
+ * restarts the rest (the 2026-06-11 incident). `setsid` starts it in a brand
+ * new session, reparented to init, immune to botmux-0's teardown. Without
+ * setsid we fall back to a plain spawn (still detached by the caller).
+ */
+export function buildRestartLauncher(
+  node: string,
+  cliEntry: string,
+  hasSetsid: boolean,
+): { cmd: string; args: string[] } {
+  if (hasSetsid) return { cmd: 'setsid', args: [node, cliEntry, 'restart'] };
+  return { cmd: node, args: [cliEntry, 'restart'] };
+}
+
+function setsidAvailable(): boolean {
+  try {
+    execSync('command -v setsid', { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function productionDeps(): MaintenanceDeps {
   return {
     now: () => Date.now(),
@@ -150,12 +186,29 @@ function productionDeps(): MaintenanceDeps {
     },
     writeIntent: (intent) => writeRestartIntent(intent),
     triggerRestart: () => {
-      const child = spawn(process.execPath, [botmuxCliEntry(), 'restart'], {
+      // Capture the restart's output to a log so a failure is visible.
+      const logFile = maintenanceRestartLogPath();
+      let fd: number | undefined;
+      try {
+        mkdirSync(dirname(logFile), { recursive: true });
+        fd = openSync(logFile, 'a');
+        writeSync(fd, `\n[${new Date().toISOString()}] auto-update: launching restart to apply\n`);
+      } catch {
+        fd = undefined; // fall back to discarding output rather than failing the restart
+      }
+      const { cmd, args } = buildRestartLauncher(process.execPath, botmuxCliEntry(), setsidAvailable());
+      const child = spawn(cmd, args, {
         detached: true,
-        stdio: 'ignore',
+        stdio: fd !== undefined ? ['ignore', fd, fd] : 'ignore',
         env: process.env,
       });
+      // A detached child's 'error' (e.g. spawn ENOENT) would otherwise throw
+      // unhandled and crash the daemon — log it instead.
+      child.on('error', (e) => logger.error(`[maintenance] restart launch failed: ${e instanceof Error ? e.message : e}`));
       child.unref();
+      if (fd !== undefined) {
+        try { closeSync(fd); } catch { /* the detached child holds its own dup */ }
+      }
     },
     log: (msg) => logger.info(`[maintenance] ${msg}`),
   };

--- a/test/maintenance.test.ts
+++ b/test/maintenance.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -6,6 +6,8 @@ import {
   runMaintenanceTick,
   readMaintenanceStateTo,
   writeMaintenanceStateTo,
+  buildRestartLauncher,
+  maintenanceRestartLogPath,
   type MaintenanceDeps,
   type MaintenanceState,
 } from '../src/core/maintenance.js';
@@ -142,6 +144,29 @@ describe('runMaintenanceTick', () => {
     expect(calls.restart).toBe(0);
     expect(calls.intents).toEqual([]);
     expect(state.autoUpdate?.lastDate).toBe(TODAY);
+  });
+});
+
+describe('buildRestartLauncher', () => {
+  const NODE = '/usr/bin/node';
+  const CLI = '/opt/botmux/dist/cli.js';
+
+  it('uses setsid to start the restart in a new session when available', () => {
+    // The auto-restart driver must NOT be a descendant of the daemon it kills,
+    // or PM2 tearing down botmux-0 interrupts the restart. setsid → new session.
+    expect(buildRestartLauncher(NODE, CLI, true)).toEqual({ cmd: 'setsid', args: [NODE, CLI, 'restart'] });
+  });
+
+  it('falls back to a plain detached node spawn when setsid is unavailable', () => {
+    expect(buildRestartLauncher(NODE, CLI, false)).toEqual({ cmd: NODE, args: [CLI, 'restart'] });
+  });
+});
+
+describe('maintenanceRestartLogPath', () => {
+  afterEach(() => vi.unstubAllEnvs());
+  it('points at ~/.botmux/logs/maintenance-restart.log', () => {
+    vi.stubEnv('HOME', '/home/bot');
+    expect(maintenanceRestartLogPath()).toBe('/home/bot/.botmux/logs/maintenance-restart.log');
   });
 });
 


### PR DESCRIPTION
## 问题
自动更新装到新版本后会触发 `botmux restart` 来应用。当前实现里，这个 restart 是 daemon(botmux-0) 直接 `spawn(node, [cli, 'restart'], {detached, stdio:'ignore'})` 出来的子进程；而 `botmux restart` → `deleteAllBotmuxProcesses()` 会**先删掉 botmux-0 自己**。该 restart 子进程是 botmux-0 的后代，PM2 拆 botmux-0 时把这条 restart 链路一并打断——结果只删了 botmux-0，没删其余 botmux-1..N、也没 `pm2 start`，整组卡死在「装了新版本但没应用」。

雪上加霜：
- `deleteAllBotmuxProcesses` 的 per-delete 异常被 `catch {}` 静默吞，`stdio:'ignore'` 又丢掉所有输出 → 现场没有任何报错痕迹。
- 维护定时器只在 bot-0(`idx===0`) 启动，botmux-0 被删后维护任务也随之消失 → 后续自动更新彻底停摆。

（手动 `botmux restart` 不受影响：它的父进程是用户 shell，与 botmux-0 无关。）

## 修复
- **`setsid` 脱离进程树**：把 restart 起在一个全新 session（reparent 到 init），不再随 botmux-0 的 PM2 teardown 一起死。`setsid` 不可用时回退到原 detached spawn。
- **可观测**：restart 的 stdout/stderr 写入 `~/.botmux/logs/maintenance-restart.log`（原为 `'ignore'`），失败可诊断。
- **不再崩 daemon**：给 detached child 加 `'error'` 监听，避免 spawn 失败抛未处理事件。
- **不再吞错**：`deleteAllBotmuxProcesses` 的 `pm2 delete` / `jlist` 失败打到 stderr（随上面的 restart 日志落盘）。

## 测试
- 新增 `buildRestartLauncher` / `maintenanceRestartLogPath` 单测。
- `tsc` + `build` 通过；全量单测 **4393/4393** 全绿。
- ⚠️ 完整端到端需在真实 npm 全局安装上跑一次「自动更新 → 重启应用」周期验证；PM2 自重启无法在本机安全复现。

## Follow-up（不含本 PR）
维护定时器只在 bot-0 跑是单点——bot-0 一旦消失维护即停。后续可加健康检查 / 其它 daemon 接管兜底。