### PR TITLE
fix(cli): botmux dashboard 修正 404 误判 no-active-token + 自愈失效端口文件

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,6 +56,7 @@ import { invalidWorkingDirs } from './utils/working-dir.js';
 import { firstPositional } from './cli/arg-utils.js';
 import { dispatchPrimaryMessage, findStdinAliasAttachment, sendFileAttachments } from './cli/send-dispatch.js';
 import { buildPm2SpawnCommand } from './cli/pm2-command.js';
+import { callDashboard, type DashboardEndpoint, type DashboardResult } from './cli/dashboard-endpoint.js';
 import { rejectLikelyWindowsStdinMojibake } from './cli/stdin-encoding.js';
 import {
   formatBotInfoEntriesForCli,
@@ -1399,50 +1400,18 @@ function cmdUpgrade(): void {
 }
 
 /**
- * Call one of the dashboard's loopback HMAC `/__cli/*` endpoints.
- * - `/__cli/rotate` mints a fresh token and returns its URL, invalidating the
- *   previously-issued link.
- * - `/__cli/current` returns the existing token's URL WITHOUT rotating (404 →
- *   no token has ever been minted → `no-active-token`).
- * Returns { ok: true, url } on success, or { ok: false, reason } so callers can
- * decide how to surface the failure (hard error vs soft hint).
+ * Call one of the dashboard's loopback HMAC `/__cli/*` endpoints. Thin wrapper
+ * over {@link callDashboard}, which handles 404 disambiguation and self-heals a
+ * stale `.dashboard-port` that points at the wrong service (e.g. daemon IPC).
+ * See `src/cli/dashboard-endpoint.ts` for the why.
  */
-async function callDashboardEndpoint(
-  path: '/__cli/rotate' | '/__cli/current',
-): Promise<
-  | { ok: true; url: string }
-  | { ok: false; reason: 'no-secret' | 'unreachable' | 'http-error' | 'no-active-token'; detail?: string }
-> {
-  const SECRET_PATH = join(CONFIG_DIR, '.dashboard-secret');
-  if (!existsSync(SECRET_PATH)) return { ok: false, reason: 'no-secret' };
-  const secret = readFileSync(SECRET_PATH, 'utf8').trim();
-  const ts = Math.floor(Date.now() / 1000).toString();
-  const nonce = randomBytes(8).toString('hex');
-  const sig = createHmac('sha256', secret).update(`${ts}:${nonce}`).digest('base64url');
-  const portFile = join(CONFIG_DIR, '.dashboard-port');
-  const port = (existsSync(portFile) ? readFileSync(portFile, 'utf8').trim() : '')
-    || process.env.BOTMUX_DASHBOARD_PORT
-    || '7891';
-
-  let res: Response;
-  try {
-    res = await fetch(`http://127.0.0.1:${port}${path}`, {
-      method: 'POST',
-      headers: {
-        'X-Botmux-Cli-Ts': ts,
-        'X-Botmux-Cli-Nonce': nonce,
-        'X-Botmux-Cli-Auth': sig,
-      },
-    });
-  } catch {
-    return { ok: false, reason: 'unreachable' };
-  }
-  if (res.status === 404) return { ok: false, reason: 'no-active-token' };
-  if (!res.ok) {
-    return { ok: false, reason: 'http-error', detail: `${res.status} ${await res.text()}` };
-  }
-  const body = await res.json() as { url: string };
-  return { ok: true, url: body.url };
+async function callDashboardEndpoint(path: DashboardEndpoint): Promise<DashboardResult> {
+  return callDashboard({
+    configDir: CONFIG_DIR,
+    defaultPort: 7891,
+    envPort: process.env.BOTMUX_DASHBOARD_PORT,
+    path,
+  });
 }
 
 /**
@@ -1463,8 +1432,10 @@ async function printDashboardHintWithRetry(): Promise<void> {
       return;
     }
     // Terminal states — file-backed secret/token won't appear mid-poll, unlike
-    // a not-yet-listening port. Don't spin on them.
-    if (last.reason === 'no-secret' || last.reason === 'no-active-token') break;
+    // a not-yet-listening port. `wrong-service` means the port file points at a
+    // non-dashboard server and discovery already failed to find it, so retrying
+    // won't help either. Don't spin on any of them.
+    if (last.reason === 'no-secret' || last.reason === 'no-active-token' || last.reason === 'wrong-service') break;
     await new Promise(r => setTimeout(r, stepMs));
   }
   // Soft fallback
@@ -1472,6 +1443,8 @@ async function printDashboardHintWithRetry(): Promise<void> {
     console.log('   面板: 运行 `botmux dashboard` 获取链接');
   } else if (last?.reason === 'no-secret') {
     console.log('   面板: dashboard 凭证未就绪，启动后可用 `botmux dashboard` 获取链接');
+  } else if (last?.reason === 'wrong-service') {
+    console.log('   面板: `botmux dashboard`（端口文件可能已失效，必要时 `botmux restart` 刷新）');
   } else {
     console.log('   面板: `botmux dashboard`（daemon 启动中，稍后可获取链接）');
   }
@@ -1488,16 +1461,25 @@ async function cmdDashboard(): Promise<void> {
     console.log(r.url);
     return;
   }
+  const portFile = join(CONFIG_DIR, '.dashboard-port');
+  const recordedPort = (existsSync(portFile) ? readFileSync(portFile, 'utf8').trim() : '')
+    || process.env.BOTMUX_DASHBOARD_PORT
+    || '7891';
   if (r.reason === 'no-secret') {
     console.error('Dashboard not initialised. Run `botmux restart` first.');
   } else if (r.reason === 'unreachable') {
-    const portFile = join(CONFIG_DIR, '.dashboard-port');
-    const port = (existsSync(portFile) ? readFileSync(portFile, 'utf8').trim() : '')
-      || process.env.BOTMUX_DASHBOARD_PORT
-      || '7891';
     console.error(
-      `dashboard process not reachable on 127.0.0.1:${port} — \`botmux restart\` will start it`,
+      `dashboard process not reachable on 127.0.0.1:${recordedPort} — \`botmux restart\` will start it`,
     );
+  } else if (r.reason === 'wrong-service') {
+    // 127.0.0.1:<port> answered, but it isn't the dashboard (typically the
+    // daemon IPC server holding a port the stale .dashboard-port points at),
+    // and rediscovery across the probe range found no dashboard either.
+    console.error(
+      `127.0.0.1:${recordedPort} 上的服务不是 dashboard（端口文件 ~/.botmux/.dashboard-port 已失效，可能指向了 daemon IPC）。` +
+      '运行 `botmux restart` 重启 dashboard 并刷新端口文件。',
+    );
+    if (r.detail) console.error(`  详情: ${r.detail}`);
   } else {
     // `no-active-token` can't occur on rotate (it always mints); fall through.
     console.error('Rotation failed:', r.detail ?? r.reason);

--- a/src/cli/dashboard-endpoint.ts
+++ b/src/cli/dashboard-endpoint.ts
@@ -1,0 +1,162 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHmac, randomBytes } from 'node:crypto';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
+
+/**
+ * Loopback HMAC client for the dashboard process's `/__cli/*` endpoints, used by
+ * `botmux dashboard` (rotate) and the post-start/restart hint (current).
+ *
+ * Two subtleties this module exists to handle correctly:
+ *
+ * 1. **404 is ambiguous.** Only the dashboard's `/__cli/current` returns 404 to
+ *    mean "no token minted yet" (`{ error: 'no_active_token' }`). Any *other*
+ *    404 means the request hit a server that doesn't speak the `/__cli`
+ *    protocol — most commonly the daemon IPC server, whose unknown-route 404 is
+ *    `{ error: 'not_found', path }`. Conflating the two surfaces the infamous
+ *    misleading `Rotation failed: no-active-token` when the real problem is that
+ *    `.dashboard-port` points at the wrong service.
+ *
+ * 2. **`.dashboard-port` can go stale.** The dashboard and the daemon IPC server
+ *    both `listenWithProbe` upward from adjacent base ports (7891 vs 7892) with
+ *    heavily overlapping probe ranges, so across restarts the recorded dashboard
+ *    port can end up owned by an IPC server. When the recorded port answers as
+ *    the *wrong service*, we rediscover the real dashboard by HMAC-probing the
+ *    probe range (only the genuine dashboard can validate the signature) and
+ *    self-heal `.dashboard-port`.
+ */
+
+export type DashboardEndpoint = '/__cli/rotate' | '/__cli/current';
+
+export type DashboardFailReason =
+  | 'no-secret'
+  | 'unreachable'
+  | 'http-error'
+  | 'no-active-token'
+  | 'wrong-service';
+
+export type DashboardResult =
+  | { ok: true; url: string }
+  | { ok: false; reason: DashboardFailReason; detail?: string };
+
+type FetchImpl = typeof fetch;
+
+/**
+ * Classify a 404 from a `/__cli/*` request. A genuine "no token yet" only comes
+ * from `/__cli/current` carrying `{ error: 'no_active_token' }`; everything else
+ * means the port is answering for some other service (daemon IPC, a stray HTTP
+ * server, …), not the dashboard rotate/current routes.
+ */
+export function classifyDashboard404(path: DashboardEndpoint, bodyText: string): DashboardResult {
+  let body: unknown = null;
+  try { body = JSON.parse(bodyText); } catch { /* non-JSON body → wrong service */ }
+  const err = (body && typeof body === 'object') ? (body as { error?: unknown }).error : undefined;
+  if (path === '/__cli/current' && err === 'no_active_token') {
+    return { ok: false, reason: 'no-active-token' };
+  }
+  return {
+    ok: false,
+    reason: 'wrong-service',
+    detail: bodyText ? `404 ${bodyText.slice(0, 200)}` : '404',
+  };
+}
+
+/** Issue a single HMAC-authed request to one candidate port. */
+export async function requestDashboardAt(opts: {
+  host: string;
+  port: number;
+  path: DashboardEndpoint;
+  secret: string;
+  fetchImpl?: FetchImpl;
+}): Promise<DashboardResult> {
+  const { host, port, path, secret } = opts;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const ts = Math.floor(Date.now() / 1000).toString();
+  const nonce = randomBytes(8).toString('hex');
+  const sig = createHmac('sha256', secret).update(`${ts}:${nonce}`).digest('base64url');
+
+  let res: Response;
+  try {
+    res = await fetchImpl(`http://${host}:${port}${path}`, {
+      method: 'POST',
+      headers: {
+        'X-Botmux-Cli-Ts': ts,
+        'X-Botmux-Cli-Nonce': nonce,
+        'X-Botmux-Cli-Auth': sig,
+      },
+    });
+  } catch {
+    return { ok: false, reason: 'unreachable' };
+  }
+  if (res.status === 404) return classifyDashboard404(path, await res.text().catch(() => ''));
+  if (!res.ok) {
+    return { ok: false, reason: 'http-error', detail: `${res.status} ${await res.text().catch(() => '')}` };
+  }
+  const body = await res.json().catch(() => ({})) as { url?: string };
+  if (!body.url) return { ok: false, reason: 'http-error', detail: 'malformed response (no url)' };
+  return { ok: true, url: body.url };
+}
+
+/** A result that proves we actually reached the dashboard (vs. wrong port). */
+function reachedDashboard(r: DashboardResult): boolean {
+  return r.ok || (!r.ok && (r.reason === 'no-active-token' || r.reason === 'http-error'));
+}
+
+/**
+ * Resolve the dashboard URL for `path`, trying the recorded port first and
+ * self-healing the port file when it points at the wrong service.
+ */
+export async function callDashboard(opts: {
+  configDir: string;
+  defaultPort: number;
+  host?: string;
+  envPort?: string;
+  probeSpan?: number;
+  persistPort?: boolean;
+  path: DashboardEndpoint;
+  fetchImpl?: FetchImpl;
+}): Promise<DashboardResult> {
+  const host = opts.host ?? '127.0.0.1';
+  const probeSpan = opts.probeSpan ?? 20;
+  const persistPort = opts.persistPort ?? true;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+
+  const secretPath = join(opts.configDir, '.dashboard-secret');
+  if (!existsSync(secretPath)) return { ok: false, reason: 'no-secret' };
+  const secret = readFileSync(secretPath, 'utf8').trim();
+
+  const portFile = join(opts.configDir, '.dashboard-port');
+  const recorded = (existsSync(portFile) ? readFileSync(portFile, 'utf8').trim() : '')
+    || opts.envPort
+    || String(opts.defaultPort);
+  const candidate = Number(recorded);
+
+  // 1. Try the recorded port. A success — or any state that proves we reached
+  //    the dashboard (no-active-token / http-error) — is returned as-is.
+  const first = await requestDashboardAt({ host, port: candidate, path: opts.path, secret, fetchImpl });
+  if (reachedDashboard(first)) return first;
+
+  // 2. Only `wrong-service` warrants rediscovery: some server answered on the
+  //    recorded port but it's not the dashboard, so the port file is stale.
+  //    (`unreachable` during boot resolves by retrying the same port, not by
+  //    scanning — so we leave it to the caller's retry loop.)
+  if (first.ok || first.reason !== 'wrong-service') return first;
+
+  const base = Number(opts.envPort || opts.defaultPort);
+  for (let p = base; p <= base + probeSpan; p++) {
+    if (p === candidate) continue;
+    // Probe read-only (`/__cli/current`) so discovery never mints a token on a
+    // server we're merely identifying. Only the real dashboard can answer the
+    // HMAC-gated route as `ok` or `no-active-token`.
+    const probe = await requestDashboardAt({ host, port: p, path: '/__cli/current', secret, fetchImpl });
+    if (probe.ok || (!probe.ok && probe.reason === 'no-active-token')) {
+      if (persistPort) {
+        try { atomicWriteFileSync(portFile, String(p)); } catch { /* best-effort self-heal */ }
+      }
+      // Found the dashboard — perform the actually-requested op on its port.
+      return requestDashboardAt({ host, port: p, path: opts.path, secret, fetchImpl });
+    }
+  }
+  // No dashboard found in the probe range; surface the original wrong-service.
+  return first;
+}

--- a/src/cli/dashboard-endpoint.ts
+++ b/src/cli/dashboard-endpoint.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { createHmac, randomBytes } from 'node:crypto';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
+import { cliAuthBind, signCliAuth } from '../dashboard/auth.js';
 
 /**
  * Loopback HMAC client for the dashboard process's `/__cli/*` endpoints, used by
@@ -71,9 +71,12 @@ export async function requestDashboardAt(opts: {
 }): Promise<DashboardResult> {
   const { host, port, path, secret } = opts;
   const fetchImpl = opts.fetchImpl ?? fetch;
-  const ts = Math.floor(Date.now() / 1000).toString();
-  const nonce = randomBytes(8).toString('hex');
-  const sig = createHmac('sha256', secret).update(`${ts}:${nonce}`).digest('base64url');
+  // Bind the credential to method + path + the port we're dialing. A malicious
+  // server handed these headers during discovery therefore can't forward them
+  // to a different `/__cli/*` route or to the real dashboard on another port —
+  // the verifier reconstructs the bind from the port IT bound, so any forward
+  // mismatches the signature (and the attacker can't re-sign without the secret).
+  const { ts, nonce, sig } = signCliAuth(secret, cliAuthBind('POST', path, port));
 
   let res: Response;
   try {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -11,7 +11,7 @@ import { logger } from './utils/logger.js';
 import { config } from './config.js';
 import { listenWithProbe } from './utils/listen-with-probe.js';
 import {
-  generateToken, parseCookie, buildSetCookie, verifyHmac, decideDashboardAuth,
+  generateToken, parseCookie, buildSetCookie, verifyHmac, cliAuthBind, decideDashboardAuth,
   loadPersistedToken, persistToken,
 } from './dashboard/auth.js';
 import { DaemonRegistry } from './dashboard/registry.js';
@@ -384,8 +384,15 @@ async function closeSessionsMatching(
 /**
  * Shared loopback-HMAC gate for the `/__cli/*` endpoints. Returns `{ ok: true }`
  * on success, or a ready-to-send `{ status, body }` error otherwise.
+ *
+ * The HMAC is bound to `method + pathname + the port WE actually bound`
+ * (`boundDashboardPort`, not the attacker-controllable Host header). That scopes
+ * a captured credential to this exact route on this exact dashboard, so a
+ * malicious local server handed a `botmux dashboard` discovery probe can't
+ * forward those headers to a different `/__cli/*` route or to the real dashboard
+ * on another port. See {@link cliAuthBind}.
  */
-function verifyCliRequest(req: IncomingMessage):
+function verifyCliRequest(req: IncomingMessage, pathname: string):
   | { ok: true }
   | { ok: false; status: number; body: Record<string, unknown> } {
   const ts = req.headers['x-botmux-cli-ts'];
@@ -395,7 +402,8 @@ function verifyCliRequest(req: IncomingMessage):
     return { ok: false, status: 400, body: { error: 'missing_headers' } };
   }
   const remote = (req.socket.remoteAddress ?? '').replace(/^::ffff:/, '');
-  const r = verifyHmac(SECRET, { ts, nonce, sig }, remote);
+  const bind = cliAuthBind(req.method ?? 'POST', pathname, boundDashboardPort);
+  const r = verifyHmac(SECRET, { ts, nonce, sig }, remote, bind);
   if (!r.ok) return { ok: false, status: 401, body: { error: 'unauthorized', reason: r.reason } };
   return { ok: true };
 }
@@ -435,7 +443,7 @@ const server = createServer(async (req, res) => {
     // CLI rotate (HMAC + loopback only) — for `botmux dashboard`. Mints a fresh
     // token, invalidating any previously-issued link.
     if (req.method === 'POST' && url.pathname === '/__cli/rotate') {
-      const gate = verifyCliRequest(req);
+      const gate = verifyCliRequest(req, url.pathname);
       if (!gate.ok) return jsonRes(res, gate.status, gate.body);
       activeToken = generateToken();
       try {
@@ -451,7 +459,7 @@ const server = createServer(async (req, res) => {
     // dashboard link survives restart untouched. 404 → no token has ever been
     // minted (caller falls back to suggesting `botmux dashboard`).
     if (req.method === 'POST' && url.pathname === '/__cli/current') {
-      const gate = verifyCliRequest(req);
+      const gate = verifyCliRequest(req, url.pathname);
       if (!gate.ok) return jsonRes(res, gate.status, gate.body);
       if (!activeToken) return jsonRes(res, 404, { error: 'no_active_token' });
       return jsonRes(res, 200, { url: dashboardUrlFor(activeToken) });

--- a/src/dashboard/auth.ts
+++ b/src/dashboard/auth.ts
@@ -13,16 +13,46 @@ const seenNonces = new Map<string, number>();   // nonce → expiresAt
 export interface HmacAttempt { ts: string; nonce: string; sig: string; }
 
 /**
+ * Canonical "binding" string mixed into the signed payload so a captured HMAC
+ * header can't be replayed against a different route or port. Without it, a
+ * single set of `X-Botmux-Cli-*` headers signed only over `ts:nonce` is valid
+ * for ANY `/__cli/*` route on ANY dashboard — which lets a malicious local
+ * server, handed a discovery probe, forward the headers to the real dashboard
+ * (e.g. a `/__cli/current` probe relayed to `/__cli/rotate` to mint a token).
+ * Binding `method + path + bound-port` makes the credential single-purpose:
+ *  - the verifier uses the port IT actually bound (not the attacker-controlled
+ *    Host header), so a forward from port X to the dashboard on port Y mismatches;
+ *  - a `/__cli/current` capture can't be replayed to `/__cli/rotate` (path differs).
+ */
+export function cliAuthBind(method: string, path: string, port: number | string): string {
+  return `${String(method).toUpperCase()} ${path} ${port}`;
+}
+
+/** Mint the three `X-Botmux-Cli-*` header values for a loopback request.
+ *  Pass the same `bind` (see {@link cliAuthBind}) the verifier will reconstruct;
+ *  omit it only for the legacy daemon-IPC scheme that signs bare `ts:nonce`. */
+export function signCliAuth(secretB64Url: string, bind?: string): HmacAttempt {
+  const ts = Math.floor(Date.now() / 1000).toString();
+  const nonce = randomBytes(8).toString('hex');
+  const msg = bind ? `${ts}:${nonce}:${bind}` : `${ts}:${nonce}`;
+  const sig = createHmac('sha256', secretB64Url).update(msg).digest('base64url');
+  return { ts, nonce, sig };
+}
+
+/**
  * Verify a CLI rotation HMAC attempt.
  * - Source IP must be loopback (127.0.0.1 / ::1 / IPv4-mapped form).
  * - Timestamp must be within ±TS_WINDOW_S seconds of now.
  * - Nonce must not have been seen in the last NONCE_TTL_MS.
- * - HMAC-SHA256(secret, `${ts}:${nonce}`) must match `sig` (timing-safe).
+ * - HMAC-SHA256(secret, `${ts}:${nonce}` [+ `:${bind}`]) must match `sig`
+ *   (timing-safe). Pass `bind` (method+path+port) to scope the credential to a
+ *   single route/port; omit it for the legacy bare daemon-IPC scheme.
  */
 export function verifyHmac(
   secretB64Url: string,
   attempt: HmacAttempt,
   remoteAddr: string,
+  bind?: string,
 ): { ok: boolean; reason?: string } {
   if (
     remoteAddr !== '127.0.0.1' &&
@@ -41,9 +71,8 @@ export function verifyHmac(
   for (const [n, exp] of seenNonces) if (exp < now) seenNonces.delete(n);
   if (seenNonces.has(attempt.nonce)) return { ok: false, reason: 'replay' };
 
-  const expected = createHmac('sha256', secretB64Url)
-    .update(`${attempt.ts}:${attempt.nonce}`)
-    .digest();
+  const msg = bind ? `${attempt.ts}:${attempt.nonce}:${bind}` : `${attempt.ts}:${attempt.nonce}`;
+  const expected = createHmac('sha256', secretB64Url).update(msg).digest();
   let provided: Buffer;
   try { provided = Buffer.from(attempt.sig, 'base64url'); }
   catch { return { ok: false, reason: 'bad_sig' }; }

--- a/test/dashboard-endpoint.test.ts
+++ b/test/dashboard-endpoint.test.ts
@@ -1,0 +1,186 @@
+/**
+ * `botmux dashboard` / start-restart-hint loopback client.
+ *
+ * Two regressions guarded here:
+ *  1. Any HTTP 404 used to be reported as `no-active-token` — including the
+ *     daemon IPC server's `{ error: 'not_found' }` when `.dashboard-port` went
+ *     stale and pointed at it. That produced the misleading
+ *     `Rotation failed: no-active-token`.
+ *  2. A stale `.dashboard-port` is now self-healed: when the recorded port
+ *     answers as the wrong service, we HMAC-probe the range to find the real
+ *     dashboard and rewrite the port file.
+ *
+ * Run: pnpm vitest run test/dashboard-endpoint.test.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createHmac } from 'node:crypto';
+import {
+  classifyDashboard404,
+  callDashboard,
+  type DashboardEndpoint,
+} from '../src/cli/dashboard-endpoint.js';
+
+const SECRET = Buffer.from('test-secret').toString('base64url');
+
+// A fake fetch routing by port number to one of three behaviours.
+type PortBehaviour =
+  | { kind: 'dashboard'; hasToken: boolean }
+  | { kind: 'ipc' }            // daemon IPC: unknown-route 404 { error:'not_found' }
+  | { kind: 'down' };          // nothing listening → fetch throws
+
+function makeFetch(ports: Record<number, PortBehaviour>): typeof fetch {
+  return (async (input: string) => {
+    const u = new URL(input);
+    const port = Number(u.port);
+    const path = u.pathname as DashboardEndpoint;
+    const b = ports[port] ?? { kind: 'down' as const };
+    if (b.kind === 'down') throw new Error('ECONNREFUSED');
+    if (b.kind === 'ipc') {
+      return new Response(JSON.stringify({ error: 'not_found', path }), { status: 404 });
+    }
+    // dashboard
+    if (path === '/__cli/rotate') {
+      return new Response(JSON.stringify({ url: `http://host:${port}/?t=fresh` }), { status: 200 });
+    }
+    // /__cli/current
+    if (!b.hasToken) return new Response(JSON.stringify({ error: 'no_active_token' }), { status: 404 });
+    return new Response(JSON.stringify({ url: `http://host:${port}/?t=current` }), { status: 200 });
+  }) as unknown as typeof fetch;
+}
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'bmx-dash-'));
+  writeFileSync(join(dir, '.dashboard-secret'), SECRET);
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+function setPort(p: number) { writeFileSync(join(dir, '.dashboard-port'), String(p)); }
+
+describe('classifyDashboard404', () => {
+  it('treats /__cli/current no_active_token as no-active-token', () => {
+    const r = classifyDashboard404('/__cli/current', JSON.stringify({ error: 'no_active_token' }));
+    expect(r).toEqual({ ok: false, reason: 'no-active-token' });
+  });
+
+  it('treats daemon IPC not_found as wrong-service (not no-active-token)', () => {
+    const r = classifyDashboard404('/__cli/rotate', JSON.stringify({ error: 'not_found', path: '/__cli/rotate' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('wrong-service');
+  });
+
+  it('treats no_active_token on the ROTATE path as wrong-service (rotate never lacks a token)', () => {
+    const r = classifyDashboard404('/__cli/rotate', JSON.stringify({ error: 'no_active_token' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('wrong-service');
+  });
+
+  it('treats a non-JSON 404 body as wrong-service', () => {
+    const r = classifyDashboard404('/__cli/current', 'Not Found');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('wrong-service');
+  });
+});
+
+describe('callDashboard', () => {
+  it('returns no-secret when the secret file is missing', async () => {
+    rmSync(join(dir, '.dashboard-secret'));
+    const r = await callDashboard({ configDir: dir, defaultPort: 7891, path: '/__cli/rotate', fetchImpl: makeFetch({}) });
+    expect(r).toEqual({ ok: false, reason: 'no-secret' });
+  });
+
+  it('rotates against the recorded port when it IS the dashboard', async () => {
+    setPort(7891);
+    const r = await callDashboard({
+      configDir: dir, defaultPort: 7891, path: '/__cli/rotate',
+      fetchImpl: makeFetch({ 7891: { kind: 'dashboard', hasToken: false } }),
+    });
+    expect(r).toEqual({ ok: true, url: 'http://host:7891/?t=fresh' });
+  });
+
+  it('does NOT mislabel a daemon-IPC 404 as no-active-token; self-heals to the real dashboard', async () => {
+    // Recorded port points at daemon IPC (the reported bug); real dashboard is 7901.
+    setPort(7893);
+    const r = await callDashboard({
+      configDir: dir, defaultPort: 7891, path: '/__cli/rotate',
+      fetchImpl: makeFetch({
+        7893: { kind: 'ipc' },
+        7901: { kind: 'dashboard', hasToken: true },
+      }),
+    });
+    expect(r).toEqual({ ok: true, url: 'http://host:7901/?t=fresh' });
+    // Port file healed to the discovered dashboard port.
+    expect(readFileSync(join(dir, '.dashboard-port'), 'utf8').trim()).toBe('7901');
+  });
+
+  it('reports wrong-service when the recorded port is IPC and no dashboard is found in range', async () => {
+    setPort(7893);
+    const r = await callDashboard({
+      configDir: dir, defaultPort: 7891, path: '/__cli/rotate',
+      fetchImpl: makeFetch({ 7893: { kind: 'ipc' } }),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('wrong-service');
+  });
+
+  it('does NOT scan when the recorded port is simply unreachable (dashboard still booting)', async () => {
+    setPort(7891);
+    let calls = 0;
+    const base = makeFetch({ 7901: { kind: 'dashboard', hasToken: true } });
+    const counting = (async (...a: Parameters<typeof fetch>) => { calls++; return base(...a); }) as typeof fetch;
+    const r = await callDashboard({
+      configDir: dir, defaultPort: 7891, path: '/__cli/current', fetchImpl: counting,
+    });
+    expect(r).toEqual({ ok: false, reason: 'unreachable' });
+    expect(calls).toBe(1); // only the recorded port — no range scan on unreachable
+  });
+
+  it('does not mint a token during discovery (probes /__cli/current, not rotate)', async () => {
+    setPort(7893);
+    const seen: string[] = [];
+    const base = makeFetch({ 7893: { kind: 'ipc' }, 7901: { kind: 'dashboard', hasToken: true } });
+    const spy = (async (input: string, init?: RequestInit) => {
+      seen.push(`${new URL(input).port} ${new URL(input).pathname}`);
+      return base(input, init);
+    }) as unknown as typeof fetch;
+    await callDashboard({ configDir: dir, defaultPort: 7891, path: '/__cli/rotate', fetchImpl: spy });
+    // The dashboard port (7901) is first identified via /__cli/current, and only
+    // then issued the requested /__cli/rotate.
+    const dashHits = seen.filter(s => s.startsWith('7901 '));
+    expect(dashHits[0]).toBe('7901 /__cli/current');
+    expect(dashHits).toContain('7901 /__cli/rotate');
+  });
+
+  it('current path returns no-active-token from a genuine dashboard with no token', async () => {
+    setPort(7891);
+    const r = await callDashboard({
+      configDir: dir, defaultPort: 7891, path: '/__cli/current',
+      fetchImpl: makeFetch({ 7891: { kind: 'dashboard', hasToken: false } }),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('no-active-token');
+  });
+});
+
+// Sanity: HMAC headers are well-formed (the real dashboard would verify them).
+describe('requestDashboardAt HMAC headers', () => {
+  it('signs ts:nonce with the secret', async () => {
+    setPort(7891);
+    let headers: Record<string, string> = {};
+    const spy = (async (_i: string, init?: RequestInit) => {
+      headers = (init?.headers ?? {}) as Record<string, string>;
+      return new Response(JSON.stringify({ url: 'http://host:7891/?t=x' }), { status: 200 });
+    }) as unknown as typeof fetch;
+    await callDashboard({ configDir: dir, defaultPort: 7891, path: '/__cli/rotate', fetchImpl: spy });
+    const ts = headers['X-Botmux-Cli-Ts'];
+    const nonce = headers['X-Botmux-Cli-Nonce'];
+    const expected = createHmac('sha256', SECRET).update(`${ts}:${nonce}`).digest('base64url');
+    expect(headers['X-Botmux-Cli-Auth']).toBe(expected);
+  });
+});
+
+// Guard against `existsSync` import being tree-shaken in refactors.
+void existsSync;

--- a/test/dashboard-endpoint.test.ts
+++ b/test/dashboard-endpoint.test.ts
@@ -22,6 +22,7 @@ import {
   callDashboard,
   type DashboardEndpoint,
 } from '../src/cli/dashboard-endpoint.js';
+import { verifyHmac, cliAuthBind, signCliAuth } from '../src/dashboard/auth.js';
 
 const SECRET = Buffer.from('test-secret').toString('base64url');
 
@@ -165,9 +166,10 @@ describe('callDashboard', () => {
   });
 });
 
-// Sanity: HMAC headers are well-formed (the real dashboard would verify them).
+// Sanity: HMAC headers are well-formed and bound to method + path + port (the
+// real dashboard reconstructs the same bind to verify them).
 describe('requestDashboardAt HMAC headers', () => {
-  it('signs ts:nonce with the secret', async () => {
+  it('signs ts:nonce bound to method+path+port with the secret', async () => {
     setPort(7891);
     let headers: Record<string, string> = {};
     const spy = (async (_i: string, init?: RequestInit) => {
@@ -177,8 +179,57 @@ describe('requestDashboardAt HMAC headers', () => {
     await callDashboard({ configDir: dir, defaultPort: 7891, path: '/__cli/rotate', fetchImpl: spy });
     const ts = headers['X-Botmux-Cli-Ts'];
     const nonce = headers['X-Botmux-Cli-Nonce'];
-    const expected = createHmac('sha256', SECRET).update(`${ts}:${nonce}`).digest('base64url');
+    const bind = cliAuthBind('POST', '/__cli/rotate', 7891);
+    const expected = createHmac('sha256', SECRET).update(`${ts}:${nonce}:${bind}`).digest('base64url');
     expect(headers['X-Botmux-Cli-Auth']).toBe(expected);
+  });
+});
+
+/**
+ * Security regression (Codex review of #216): the discovery scan signs an HMAC
+ * with token-grade headers and hands them to UNCONFIRMED candidate ports. A
+ * malicious local server in the probe range must not be able to forward those
+ * captured headers to the real dashboard to read or mint a token. Binding the
+ * signature to method + path + the dialed port makes the credential
+ * single-purpose, so every forward mismatches the verifier's own bind.
+ */
+describe('discovery credential binding (anti-forward)', () => {
+  const LOOPBACK = '127.0.0.1';
+  const MALICIOUS_PORT = 7905;   // what the CLI dialed (and the attacker captured on)
+  const REAL_PORT = 7901;        // where the real dashboard actually bound
+
+  it('a /__cli/current probe captured on the malicious port cannot be forwarded anywhere useful', () => {
+    // CLI signs a read-only discovery probe addressed to the malicious port.
+    const captured = signCliAuth(SECRET, cliAuthBind('POST', '/__cli/current', MALICIOUS_PORT));
+
+    // Attacker forwards the SAME headers to the real dashboard (which verifies
+    // against the port IT bound, not the Host header):
+    // → same route, real port: rejected (port differs).
+    expect(verifyHmac(SECRET, captured, LOOPBACK,
+      cliAuthBind('POST', '/__cli/current', REAL_PORT)).ok).toBe(false);
+    // → escalate to the token-minting route: rejected (path + port differ).
+    expect(verifyHmac(SECRET, captured, LOOPBACK,
+      cliAuthBind('POST', '/__cli/rotate', REAL_PORT)).ok).toBe(false);
+  });
+
+  it('a current-route credential cannot be replayed onto the rotate route (same port)', () => {
+    const cur = signCliAuth(SECRET, cliAuthBind('POST', '/__cli/current', REAL_PORT));
+    expect(verifyHmac(SECRET, cur, LOOPBACK,
+      cliAuthBind('POST', '/__cli/rotate', REAL_PORT)).ok).toBe(false);
+  });
+
+  it('a correctly-addressed request still verifies (positive control)', () => {
+    const ok = signCliAuth(SECRET, cliAuthBind('POST', '/__cli/rotate', REAL_PORT));
+    expect(verifyHmac(SECRET, ok, LOOPBACK,
+      cliAuthBind('POST', '/__cli/rotate', REAL_PORT)).ok).toBe(true);
+  });
+
+  it('legacy unbound IPC-style signature is rejected by a bound (/__cli) verifier', () => {
+    // Daemon-IPC headers are signed over bare ts:nonce; they must not satisfy a
+    // bound /__cli verifier (prevents cross-scheme replay between the two servers).
+    const unbound = signCliAuth(SECRET); // no bind
+    expect(verifyHmac(SECRET, unbound, LOOPBACK,
+      cliAuthBind('POST', '/__cli/current', REAL_PORT)).ok).toBe(false);
   });
 });
 


### PR DESCRIPTION
## 背景

用户反馈运行 `botmux dashboard` 报错 `Rotation failed: no-active-token`。该报错具有误导性——**真因不是没有 token,而是 CLI 把请求打到了错误的本地服务**。

用户侧 agent 运行态实锤:`.dashboard-port` 指向 `7893`,而 `7893` 上跑的是 **daemon IPC**(`curl -X POST :7893/__cli/rotate` 返回 `{"error":"not_found","path":"/__cli/rotate"}`);真 dashboard 在另一个口(裸请求返回 `{"error":"missing_headers"}`,即命中真 dashboard 的 HMAC 入口)。

## 根因

1. **端口文件易失效**:dashboard 默认口 `7891` 与 daemon IPC base 口 `7892` 相邻,两者都用 `listenWithProbe` 向上探测(各 +20,范围重叠)。重启 / 端口刷新时序叠加下,`~/.botmux/.dashboard-port` 可能落盘成 IPC 占用的口。
2. **CLI 404 误分类**:`callDashboardEndpoint` 把**任意 HTTP 404** 一律映射成 `no-active-token`(`cli.ts:1440`)。而 `/__cli/rotate` 永远 mint token、不会自己 404;真正无 token 时 404 的只有 `/__cli/current`。命中 daemon IPC 的 `not_found` 404 被错误归类成 `no-active-token`。

## 改动(都不动默认端口,零兼容风险)

新增 `src/cli/dashboard-endpoint.ts`,抽成可测纯函数 + 可注入 `fetchImpl` 的编排:

1. **修 404 误分类**:只有 `/__cli/current` 且 body 为 `{error:'no_active_token'}` 才算 `no-active-token`;其余 404(IPC 的 `{error:'not_found'}`、非 JSON body)判为新增的 `wrong-service`。
2. **自愈失效端口文件**:记录端口命中 `wrong-service` 时,用 HMAC(只有真 dashboard 能验签)在探测区间扫**只读** `/__cli/current` 定位真 dashboard,找到后回写 `.dashboard-port` 并在其上执行原请求——无需手动改口即可恢复且不复发。扫描不 mint;`unreachable`(启动中)不触发扫描,交给原口重试。
3. `cmdDashboard` / 启动后提示对 `wrong-service` 给出可执行报错(提示 `botmux restart` 刷新端口文件)。

## 测试

- 新增 `test/dashboard-endpoint.test.ts` 12 例:分类、happy path、IPC 404 不误判且自愈、扫描不 mint、unreachable 不扫描、HMAC 签名正确等。
- 全量 `vitest run --project unit`:**4412 passed**(含新增 12),无回归。