### PR TITLE
fix(sandbox): 文件沙盒 --tmpfs /run 抹掉 fnm/nvm bin 致 CLI 秒退崩溃循环

### DIFF
--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -170,6 +170,35 @@ export function buildSandboxArgs(plan: SandboxPlan): string[] {
   return a;
 }
 
+/**
+ * After `buildSandboxArgs` masks `/run` with a fresh tmpfs, any executable whose
+ * resolved path lives UNDER `/run` (the common case: fnm/nvm/volta expose the
+ * active toolchain's bin dir as a per-session symlink farm under
+ * `/run/user/<uid>/fnm_multishells/<hash>/bin`, and `which codex` / the daemon's
+ * own `process.execPath` for node land there) would VANISH inside the sandbox →
+ * bwrap `execvp` fails → the CLI exits instantly → Botmux's crash-loop guard
+ * trips after 4 retries. This re-exposes each such bin dir read-only at its real
+ * path so the binary (and the node interpreter its `#!/usr/bin/env node` shebang
+ * needs, which lives in the same fnm bin dir) survive the tmpfs.
+ *
+ * Pure: returns the `--ro-bind-try <dir> <dir>` args (deduped, `/run/`-subpaths
+ * only — NEVER `/run` itself, which would clobber the tmpfs and the relay shim
+ * mounted at /run/sbxbin). `-try` so a stale/racing path can't fail the spawn.
+ * Returns [] for binaries already outside /run (system node, npm/pnpm globals) —
+ * non-fnm users are unaffected.
+ */
+export function reexposeRunBinArgs(binPaths: (string | undefined)[]): string[] {
+  const dirs = new Set<string>();
+  for (const p of binPaths) {
+    if (!p || typeof p !== 'string') continue;
+    const d = dirname(p);
+    if (d.startsWith('/run/')) dirs.add(d); // startsWith('/run/') excludes '/run' itself
+  }
+  const out: string[] = [];
+  for (const d of dirs) out.push('--ro-bind-try', d, d);
+  return out;
+}
+
 // ───────────────────────────── orchestration ─────────────────────────────────
 
 /** Absolute path to this build's compiled cli.js (dist/cli.js), derived from
@@ -350,6 +379,11 @@ export function prepareSandbox(opts: {
   // botmux-send etc. skills, no secrets). Re-exposed read-only at its real path.
   const pluginDir = join(home, '.botmux', 'claude-plugin');
   args.push('--ro-bind-try', pluginDir, pluginDir);
+  // Re-expose any CLI/node bin dir living under /run (fnm/nvm/volta symlink farms)
+  // that the `--tmpfs /run` above just masked — else the resolved cliBin / the
+  // node its shebang needs vanish in-sandbox and the CLI crash-loops on spawn.
+  // process.execPath = the daemon's own node (under /run too when fnm-managed).
+  args.push(...reexposeRunBinArgs([opts.cliBin, process.execPath]));
 
   // Authoritative child env via bwrap --setenv (works on pty AND tmux — the tmux
   // backend only forwards a fixed whitelist, which excludes HOME/PATH/relay).

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -183,12 +183,14 @@ export function buildSandboxArgs(plan: SandboxPlan): string[] {
  *
  * The caller feeds in EVERY path that will be exec'd inside the sandbox, not just
  * the direct bwrap target: the cliBin, the daemon's own node (process.execPath),
- * AND the raw cliArgs — the last covers SECOND-STAGE binaries a runner spawns
- * later, e.g. the codex-app adapter's `--codex-bin /run/.../codex` (its
- * resolvedBin is the daemon node running the runner, so without this the real
- * codex path would still be masked). Non-path argv tokens (`--session-id`, ids,
- * `app-server`, …) have a dirname of `.` and are silently ignored, so passing the
- * whole cliArgs through is safe.
+ * AND each adapter-declared SECOND-STAGE executable (CliAdapter.sandboxExtraExecPaths)
+ * — e.g. the codex-app adapter's resolved `codex` (its resolvedBin is the daemon
+ * node running the runner, which spawns the real codex later for the app-server,
+ * so without this the codex path would still be masked). We deliberately do NOT
+ * scan raw cliArgs: a path arg like `--cwd /run/user/<uid>/proj` would re-bind its
+ * PARENT `/run/user/<uid>`, shadowing the project overlay mounted there and
+ * exposing sibling files / IPC sockets — re-exposing must be limited to declared
+ * executables.
  *
  * Pure: returns the `--ro-bind-try <dir> <dir>` args (deduped, `/run/`-subpaths
  * only — NEVER `/run` itself, which would clobber the tmpfs and the relay shim
@@ -282,6 +284,10 @@ export function prepareSandbox(opts: {
   /** This CLI's auth/login paths (CliAdapter.authPaths) to keep real+writable so
    *  token refresh / login persists. `~` expanded; missing paths skipped. */
   authPaths?: readonly string[];
+  /** Adapter-declared SECOND-STAGE executables (CliAdapter.sandboxExtraExecPaths)
+   *  spawned inside the sandbox beyond cliBin — re-exposed if under /run. ONLY
+   *  executable paths (never cwd/path args). undefined → none. */
+  extraExecPaths?: readonly string[];
 }): SandboxSpawn | null {
   if (!opts.enabled) return null;
   if (process.platform !== 'linux') return null; // overlayfs + bwrap are Linux-only
@@ -390,14 +396,13 @@ export function prepareSandbox(opts: {
   args.push('--ro-bind-try', pluginDir, pluginDir);
   // Re-expose any bin dir living under /run (fnm/nvm/volta symlink farms) that the
   // `--tmpfs /run` above just masked — else the resolved cliBin / the node its
-  // shebang needs / a second-stage binary the runner spawns vanish in-sandbox and
-  // the CLI crash-loops on spawn. We feed in every in-sandbox executable path:
+  // shebang needs / an adapter's declared second-stage binary vanish in-sandbox
+  // and the CLI crash-loops on spawn. ONLY executable paths (never cwd/path args):
   //  - opts.cliBin: the direct bwrap target
   //  - process.execPath: the daemon's own node (under /run too when fnm-managed)
-  //  - opts.cliArgs: covers second-stage binaries, e.g. codex-app's --codex-bin
-  //    (resolvedBin there is the daemon node, so cliBin alone misses the real
-  //    codex path). Non-path tokens are ignored by reexposeRunBinArgs.
-  args.push(...reexposeRunBinArgs([opts.cliBin, process.execPath, ...opts.cliArgs]));
+  //  - opts.extraExecPaths: adapter-declared second-stage execs, e.g. codex-app's
+  //    real codex (its resolvedBin is the daemon node, so cliBin alone misses it).
+  args.push(...reexposeRunBinArgs([opts.cliBin, process.execPath, ...(opts.extraExecPaths ?? [])]));
 
   // Authoritative child env via bwrap --setenv (works on pty AND tmux — the tmux
   // backend only forwards a fixed whitelist, which excludes HOME/PATH/relay).

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -181,6 +181,15 @@ export function buildSandboxArgs(plan: SandboxPlan): string[] {
  * path so the binary (and the node interpreter its `#!/usr/bin/env node` shebang
  * needs, which lives in the same fnm bin dir) survive the tmpfs.
  *
+ * The caller feeds in EVERY path that will be exec'd inside the sandbox, not just
+ * the direct bwrap target: the cliBin, the daemon's own node (process.execPath),
+ * AND the raw cliArgs — the last covers SECOND-STAGE binaries a runner spawns
+ * later, e.g. the codex-app adapter's `--codex-bin /run/.../codex` (its
+ * resolvedBin is the daemon node running the runner, so without this the real
+ * codex path would still be masked). Non-path argv tokens (`--session-id`, ids,
+ * `app-server`, …) have a dirname of `.` and are silently ignored, so passing the
+ * whole cliArgs through is safe.
+ *
  * Pure: returns the `--ro-bind-try <dir> <dir>` args (deduped, `/run/`-subpaths
  * only — NEVER `/run` itself, which would clobber the tmpfs and the relay shim
  * mounted at /run/sbxbin). `-try` so a stale/racing path can't fail the spawn.
@@ -379,11 +388,16 @@ export function prepareSandbox(opts: {
   // botmux-send etc. skills, no secrets). Re-exposed read-only at its real path.
   const pluginDir = join(home, '.botmux', 'claude-plugin');
   args.push('--ro-bind-try', pluginDir, pluginDir);
-  // Re-expose any CLI/node bin dir living under /run (fnm/nvm/volta symlink farms)
-  // that the `--tmpfs /run` above just masked — else the resolved cliBin / the
-  // node its shebang needs vanish in-sandbox and the CLI crash-loops on spawn.
-  // process.execPath = the daemon's own node (under /run too when fnm-managed).
-  args.push(...reexposeRunBinArgs([opts.cliBin, process.execPath]));
+  // Re-expose any bin dir living under /run (fnm/nvm/volta symlink farms) that the
+  // `--tmpfs /run` above just masked — else the resolved cliBin / the node its
+  // shebang needs / a second-stage binary the runner spawns vanish in-sandbox and
+  // the CLI crash-loops on spawn. We feed in every in-sandbox executable path:
+  //  - opts.cliBin: the direct bwrap target
+  //  - process.execPath: the daemon's own node (under /run too when fnm-managed)
+  //  - opts.cliArgs: covers second-stage binaries, e.g. codex-app's --codex-bin
+  //    (resolvedBin there is the daemon node, so cliBin alone misses the real
+  //    codex path). Non-path tokens are ignored by reexposeRunBinArgs.
+  args.push(...reexposeRunBinArgs([opts.cliBin, process.execPath, ...opts.cliArgs]));
 
   // Authoritative child env via bwrap --setenv (works on pty AND tmux — the tmux
   // backend only forwards a fixed whitelist, which excludes HOME/PATH/relay).

--- a/src/adapters/cli/codex-app.ts
+++ b/src/adapters/cli/codex-app.ts
@@ -30,6 +30,15 @@ export function createCodexAppAdapter(pathOverride?: string): CliAdapter {
     authPaths: ['~/.codex/auth.json'],
     resolvedBin: process.execPath,
 
+    // resolvedBin is node-running-the-runner; the REAL codex is spawned later for
+    // the app-server (codex-app-runner.ts). Declare it so the file sandbox can
+    // re-expose its bin dir when it lives under /run (fnm/nvm) — else --tmpfs /run
+    // masks it and the in-sandbox app-server spawn ENOENTs into a crash-loop. Same
+    // lazy resolve+cache as buildArgs; only an executable path, never the cwd.
+    sandboxExtraExecPaths() {
+      return [(cachedCodexBin ??= resolveCommand(rawCodexBin))];
+    },
+
     buildArgs({ sessionId, resume, resumeSessionId, workingDir, botName, botOpenId, locale }) {
       const args = [
         runnerPath(),

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -243,6 +243,23 @@ export interface CliAdapter {
    *  undefined / empty → no carve-out. */
   readonly authPaths?: readonly string[];
 
+  /** Absolute paths of ADDITIONAL executables this adapter spawns as a SECOND
+   *  stage INSIDE the file sandbox, beyond `resolvedBin` (the bwrap target). The
+   *  sandbox masks `/run` with a fresh tmpfs; any such binary living under
+   *  `/run/...` (fnm/nvm/volta bin symlink farms) would then vanish and crash-loop
+   *  the CLI, so the sandbox re-exposes their containing dirs read-only.
+   *
+   *  Most adapters omit this — their `resolvedBin` IS the binary that runs. It is
+   *  for adapters whose `resolvedBin` is a launcher: codex-app's `resolvedBin` is
+   *  node running the runner, while the REAL `codex` (spawned later for the
+   *  app-server) is the one that must survive `--tmpfs /run`.
+   *
+   *  Return ONLY executable paths — never plain path args like the working dir,
+   *  whose parent dir re-bind would shadow the project overlay and widen exposure.
+   *  Resolved lazily / read AFTER buildArgs() (so a lazily-resolved bin is cached).
+   *  Missing/empty → no extra re-expose. */
+  sandboxExtraExecPaths?(): readonly string[];
+
   /** Extra env merged into the spawned child's environment. Used by Claude-family
    *  forks to point the CLI at its data root (e.g. Seed's `CLAUDE_CONFIG_DIR`).
    *  Keys placed here are also forwarded through the tmux backend (see

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3741,6 +3741,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
           cliArgs: args,
           hidePaths: cfg.sandboxHidePaths ?? [],
           authPaths: cliAdapter.authPaths,
+          extraExecPaths: cliAdapter.sandboxExtraExecPaths?.(),
         });
         if (sbx) {
           spawnBin = sbx.bin;

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect } from 'vitest';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { mkdtempSync, existsSync, writeFileSync, readFileSync, symlinkSync, rmSync, mkdirSync } from 'node:fs';
-import { buildSandboxArgs, validateRelayRequest, materializeOutboxFile, prepareSandbox, type SandboxPlan } from '../src/adapters/backend/sandbox.js';
+import { buildSandboxArgs, reexposeRunBinArgs, validateRelayRequest, materializeOutboxFile, prepareSandbox, type SandboxPlan } from '../src/adapters/backend/sandbox.js';
 import { computeSandboxDiff, applySandboxDiff, upperDir } from '../src/services/sandbox-land.js';
 
 const tmp = () => mkdtempSync(join(tmpdir(), 'sbx-'));
@@ -109,6 +109,42 @@ describe('buildSandboxArgs (overlay model)', () => {
     for (const flag of ['--unshare-user', '--unshare-pid', '--unshare-ipc']) {
       expect(a).toContain(flag);
     }
+  });
+});
+
+// ── reexposeRunBinArgs: restore fnm/nvm bin dirs masked by --tmpfs /run ──
+// Regression for "file sandbox can't start" on fnm/nvm/volta machines: the
+// resolved CLI binary (and the daemon's own node) live under /run/user/.../bin,
+// which --tmpfs /run masks → bwrap execvp fails → crash-loop.
+describe('reexposeRunBinArgs (fnm/nvm /run bin dirs)', () => {
+  it('re-binds the containing dir of a /run-resident binary read-only at its real path', () => {
+    const a = reexposeRunBinArgs(['/run/user/1001/fnm_multishells/abc_123/bin/codex']);
+    expect(tripleIdx(a, '--ro-bind-try', '/run/user/1001/fnm_multishells/abc_123/bin', '/run/user/1001/fnm_multishells/abc_123/bin')).toBe(0);
+  });
+
+  it('dedupes when the binary and node share one /run bin dir', () => {
+    const dir = '/run/user/1001/fnm_multishells/abc_123/bin';
+    const a = reexposeRunBinArgs([`${dir}/codex`, `${dir}/node`]);
+    expect(a).toEqual(['--ro-bind-try', dir, dir]);
+  });
+
+  it('handles distinct /run dirs for the binary and node', () => {
+    const a = reexposeRunBinArgs(['/run/a/bin/codex', '/run/b/bin/node']);
+    expect(tripleIdx(a, '--ro-bind-try', '/run/a/bin', '/run/a/bin')).toBeGreaterThanOrEqual(0);
+    expect(tripleIdx(a, '--ro-bind-try', '/run/b/bin', '/run/b/bin')).toBeGreaterThanOrEqual(0);
+  });
+
+  it('ignores binaries outside /run (system node, npm/pnpm globals) — non-fnm users unaffected', () => {
+    expect(reexposeRunBinArgs(['/usr/bin/node', '/usr/local/bin/codex', undefined])).toEqual([]);
+  });
+
+  it('NEVER re-binds /run itself (would clobber the tmpfs + the /run/sbxbin relay shim)', () => {
+    // A binary directly at /run/node has dirname '/run' — must be skipped.
+    expect(reexposeRunBinArgs(['/run/node'])).toEqual([]);
+  });
+
+  it('skips empty/non-string entries', () => {
+    expect(reexposeRunBinArgs([undefined, '', '/run/user/1/bin/x'])).toEqual(['--ro-bind-try', '/run/user/1/bin', '/run/user/1/bin']);
   });
 });
 

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { mkdtempSync, existsSync, writeFileSync, readFileSync, symlinkSync, rmSync, mkdirSync } from 'node:fs';
 import { buildSandboxArgs, reexposeRunBinArgs, validateRelayRequest, materializeOutboxFile, prepareSandbox, type SandboxPlan } from '../src/adapters/backend/sandbox.js';
+import { createCodexAppAdapter } from '../src/adapters/cli/codex-app.js';
 import { computeSandboxDiff, applySandboxDiff, upperDir } from '../src/services/sandbox-land.js';
 
 const tmp = () => mkdtempSync(join(tmpdir(), 'sbx-'));
@@ -147,18 +148,43 @@ describe('reexposeRunBinArgs (fnm/nvm /run bin dirs)', () => {
     expect(reexposeRunBinArgs([undefined, '', '/run/user/1/bin/x'])).toEqual(['--ro-bind-try', '/run/user/1/bin', '/run/user/1/bin']);
   });
 
-  it('covers a SECOND-STAGE /run binary in cliArgs when cliBin+node are OUTSIDE /run (codex-app --codex-bin)', () => {
-    // codex-app: resolvedBin = daemon node (stable fnm install, NOT /run); the
-    // real codex is passed as `--codex-bin /run/.../codex` and spawned inside the
-    // sandbox by the runner. Without folding cliArgs in, the re-bind list is empty
-    // and --tmpfs /run still masks the second-stage binary → crash-loop.
+  it('covers a SECOND-STAGE /run binary (codex-app real codex) when cliBin+node are OUTSIDE /run', () => {
+    // codex-app: resolvedBin = daemon node (stable fnm install, NOT /run); the real
+    // codex (spawned inside the sandbox for app-server) is declared via
+    // sandboxExtraExecPaths. prepareSandbox feeds [cliBin, process.execPath, ...extra].
     const stableNode = '/root/.local/share/fnm/node-versions/v24.16.0/installation/bin/node';
     const runCodex = '/run/user/1001/fnm_multishells/abc_123/bin/codex';
-    const cliArgs = ['/path/to/runner.js', '--session-id', 's1', '--codex-bin', runCodex, '--cwd', '/home/u/proj'];
-    const a = reexposeRunBinArgs([stableNode, stableNode, ...cliArgs]);
-    expect(tripleIdx(a, '--ro-bind-try', '/run/user/1001/fnm_multishells/abc_123/bin', '/run/user/1001/fnm_multishells/abc_123/bin')).toBeGreaterThanOrEqual(0);
-    // and nothing else got re-bound (the stable node + non-path tokens are ignored)
+    const a = reexposeRunBinArgs([stableNode, stableNode, runCodex]);
+    // only the fnm bin dir is re-bound (stable node ignored, never the cwd)
     expect(a).toEqual(['--ro-bind-try', '/run/user/1001/fnm_multishells/abc_123/bin', '/run/user/1001/fnm_multishells/abc_123/bin']);
+  });
+
+  it('DANGER it guards against: a /run working-dir path would re-bind its parent (so the wiring must NOT feed cwd/cliArgs in)', () => {
+    // This documents WHY prepareSandbox passes ONLY declared exec paths, never raw
+    // cliArgs: a `--cwd /run/user/1001/proj` would re-bind PARENT /run/user/1001,
+    // shadowing the project overlay mounted there + exposing siblings/IPC sockets.
+    expect(reexposeRunBinArgs(['/run/user/1001/proj'])).toEqual(['--ro-bind-try', '/run/user/1001', '/run/user/1001']);
+  });
+});
+
+// ── codex-app adapter declares ONLY the second-stage executable, never the cwd ──
+// Negative regression for Codex's blocker: sandboxExtraExecPaths must return the
+// resolved codex binary and NOTHING path-like (the working dir), so the sandbox
+// never re-binds a /run cwd's parent.
+describe('codex-app sandboxExtraExecPaths', () => {
+  it('returns exactly the resolved codex bin and never the working dir', () => {
+    // pathOverride is absolute → resolveCommand short-circuits (no shell-out / flake).
+    const runCodex = '/run/user/1001/fnm_multishells/abc_123/bin/codex';
+    const adapter = createCodexAppAdapter(runCodex);
+    // build args with a /run working dir — must NOT leak into the exec-path list.
+    adapter.buildArgs({ sessionId: 's1', resume: false, workingDir: '/run/user/1001/proj' });
+    const extra = adapter.sandboxExtraExecPaths?.();
+    expect(extra).toEqual([runCodex]);
+    expect(extra).not.toContain('/run/user/1001/proj');
+    // and the resulting re-expose hits only the codex bin dir, not the cwd parent.
+    const a = reexposeRunBinArgs([adapter.resolvedBin, process.execPath, ...(extra ?? [])]);
+    expect(a).toContain('/run/user/1001/fnm_multishells/abc_123/bin');
+    expect(a).not.toContain('/run/user/1001');
   });
 });
 

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -146,6 +146,20 @@ describe('reexposeRunBinArgs (fnm/nvm /run bin dirs)', () => {
   it('skips empty/non-string entries', () => {
     expect(reexposeRunBinArgs([undefined, '', '/run/user/1/bin/x'])).toEqual(['--ro-bind-try', '/run/user/1/bin', '/run/user/1/bin']);
   });
+
+  it('covers a SECOND-STAGE /run binary in cliArgs when cliBin+node are OUTSIDE /run (codex-app --codex-bin)', () => {
+    // codex-app: resolvedBin = daemon node (stable fnm install, NOT /run); the
+    // real codex is passed as `--codex-bin /run/.../codex` and spawned inside the
+    // sandbox by the runner. Without folding cliArgs in, the re-bind list is empty
+    // and --tmpfs /run still masks the second-stage binary → crash-loop.
+    const stableNode = '/root/.local/share/fnm/node-versions/v24.16.0/installation/bin/node';
+    const runCodex = '/run/user/1001/fnm_multishells/abc_123/bin/codex';
+    const cliArgs = ['/path/to/runner.js', '--session-id', 's1', '--codex-bin', runCodex, '--cwd', '/home/u/proj'];
+    const a = reexposeRunBinArgs([stableNode, stableNode, ...cliArgs]);
+    expect(tripleIdx(a, '--ro-bind-try', '/run/user/1001/fnm_multishells/abc_123/bin', '/run/user/1001/fnm_multishells/abc_123/bin')).toBeGreaterThanOrEqual(0);
+    // and nothing else got re-bound (the stable node + non-path tokens are ignored)
+    expect(a).toEqual(['--ro-bind-try', '/run/user/1001/fnm_multishells/abc_123/bin', '/run/user/1001/fnm_multishells/abc_123/bin']);
+  });
 });
 
 // ── validateRelayRequest: pure schema + flag-allowlist boundary (UNCHANGED) ──


### PR DESCRIPTION
## 问题
飞书群用户反馈「开启文件沙盒后会话无法启动」，表现为 `⚠️ <CLI> 在 1 分钟内崩溃 4 次，已停止自动重启`。

## 根因（代码层确认）
1. `resolveCommand()` 用登录/交互 shell 跑 `which <cli>` 拿绝对路径。用 fnm/nvm/volta 的机器上，活动 node 版本的 bin 目录被暴露成 `/run/user/<uid>/fnm_multishells/<hash>/bin` 这种 per-session symlink farm，`which codex` 必然返回该 `/run` 下路径。
2. `worker.ts` 把这个 `resolvedBin` 原样当 `cliBin` 传给 `prepareSandbox`。
3. `buildSandboxArgs()` 里 `--tmpfs /run` 把整个 `/run` 换成空 tmpfs。
4. 进沙盒后 `bwrap … -- /run/user/.../codex` 这个可执行路径不存在 → `execvp` 失败 → CLI 秒退 → 攒够 4 次触发 Botmux 崩溃保护。
5. 连 `#!/usr/bin/env node` 的 node 解释器也中招（fnm 的 node 同在该 `/run` bin 目录 / daemon 自身 `process.execPath` 也在 `/run` 下）。

**影响面**：所有用 fnm/nvm/volta 的用户一开文件沙盒就必崩，是通病不是个例。

## 修法
新增纯函数 `reexposeRunBinArgs(binPaths)`：在 `--tmpfs /run` 之后，对落在 `/run/` 子路径下的二进制所在目录用 `--ro-bind-try <dir> <dir>` 只读暴露回来，让 CLI 二进制与 node 解释器熬过 tmpfs。

- 只处理 `/run/` 子路径，**绝不** re-bind `/run` 本身（否则会覆盖 tmpfs 和 `/run/sbxbin` relay shim）
- 用 `--ro-bind-try` 容错（路径竞态/失效不致整个 spawn 失败）
- 非 `/run` 安装（系统 node、npm/pnpm 全局）返回空 → 非 fnm 用户零影响
- `prepareSandbox` 对 `cliBin` + `process.execPath`(daemon node) 各查一次

## 测试
- 新增 6 个 `reexposeRunBinArgs` 单测（re-bind/去重/多目录/非 /run 跳过/绝不动 /run 本身/空值）
- `test/sandbox.test.ts` 35 全过
- 全量 unit 4406/4406 全过

## 临时绕过（不打此 patch 时）
给该 bot 配 `cliPathOverride` 指向一个不在 `/run` 下的稳定 wrapper（实际 node + cli.js 绝对路径）。