### PR TITLE
fix(bridge): resume 守的 transcript 缺失时自愈——放开 baseline gate 让指纹恢复接管

### DIFF
--- a/src/services/bridge-rotation-policy.ts
+++ b/src/services/bridge-rotation-policy.ts
@@ -184,3 +184,51 @@ export function decideFingerprintSwitch(
   }
   return { action: 'switch', path: exact[0], reason: 'unknown-sid-exact' };
 }
+
+// ─── Absent-baseline self-heal ─────────────────────────────────────────────
+
+export interface AbsentBaselineHealInput {
+  /** Whether the bridge has already completed baseline (gate already open). */
+  baselineDone: boolean;
+  /** Whether a `bridgeJsonlPath` is currently pinned. */
+  hasJsonlPath: boolean;
+  /** Whether that pinned path currently exists on disk. */
+  jsonlFileExists: boolean;
+}
+
+/**
+ * Decide whether a pending Lark turn arriving against a not-yet-baselined
+ * bridge should SELF-HEAL by arming fresh-empty readiness, instead of being
+ * dropped with "baseline not ready".
+ *
+ * Background: in `baseline-existing` (resume / restart-restore) mode the
+ * worker pins `bridgeJsonlPath` to `<sessionId>.jsonl` and waits for that
+ * file to appear before baselining. If Claude wrote its transcript under a
+ * DIFFERENT sessionId than the one we guessed — `--session-id` not honoured,
+ * a stale resume id, or an /adopt sid persisted as the botmux sid — the
+ * guessed file never appears, `baselineDone` stays false forever, and every
+ * turn is dropped ("baseline not ready"). The bridge is then permanently
+ * stuck on a path that does not exist (the user-reported "message went into
+ * the PTY but final_output was never attributed" symptom). The pid-state
+ * resolver that would normally correct this needs a live CLI pid, which is
+ * often missing on restart-restore — so the only recovery path that still
+ * works is the exact-content fingerprint scan, and IT is starved because no
+ * turn is ever marked.
+ *
+ * An ABSENT file has no prior history to absorb, so it is safe to declare
+ * fresh-empty readiness (offset 0, baseline done) here: the pending turn
+ * then gets marked, which arms the per-tick exact-content fingerprint
+ * recovery (`decideFingerprintSwitch`) to discover the jsonl Claude actually
+ * appended this message to and switch the bridge onto it — no dependence on
+ * Claude's internal pid-state / tasks files, so it is Claude-version-robust.
+ *
+ * Returns true ONLY when baseline isn't done, a path is pinned, and that
+ * path is absent. When the file EXISTS (the genuine slow-resume-with-history
+ * case), this returns false so normal lazy-baseline runs instead and prior
+ * turns are absorbed rather than re-emitted.
+ */
+export function shouldHealAbsentBaseline(input: AbsentBaselineHealInput): boolean {
+  if (input.baselineDone) return false;
+  if (!input.hasJsonlPath) return false;
+  return !input.jsonlFileExists;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -26,6 +26,7 @@ import {
   shouldRunQuietRotation,
   evaluatePidResolverPullback,
   decideFingerprintSwitch,
+  shouldHealAbsentBaseline,
   sessionIdFromJsonlPath,
   SESSION_ID_FILENAME_RE,
   type PidFollowResult,
@@ -1376,8 +1377,27 @@ function stopBridgeWatcher(): void {
 function bridgeMarkPendingTurn(messageText: string, preferredTurnId?: string): string | undefined {
   if (!bridgeJsonlPath) return undefined;
   if (!bridgeBaselineDone) {
-    log('Bridge baseline not ready — this turn will not have transcript-driven final_output');
-    return undefined;
+    // Self-heal a stuck baseline: the guessed transcript path never
+    // materialised (Claude wrote under a different sessionId, a stale resume
+    // id, or an /adopt sid persisted as the botmux sid). An absent file has
+    // no history to absorb, so arm fresh-empty readiness so THIS turn gets
+    // marked — the mark arms the per-tick exact-content fingerprint recovery,
+    // which finds the jsonl Claude actually wrote this message to and switches
+    // the bridge onto it (no dependence on Claude-internal pid files, so
+    // version-robust). See shouldHealAbsentBaseline for the full rationale.
+    if (shouldHealAbsentBaseline({
+      baselineDone: bridgeBaselineDone,
+      hasJsonlPath: !!bridgeJsonlPath,
+      jsonlFileExists: existsSyncSafe(bridgeJsonlPath),
+    })) {
+      bridgeOffset = 0;
+      bridgePendingTail = '';
+      bridgeBaselineDone = true;
+      log(`Bridge baseline self-healed: guessed transcript ${bridgeJsonlPath} absent; fresh-empty readiness armed for fingerprint recovery`);
+    } else {
+      log('Bridge baseline not ready — this turn will not have transcript-driven final_output');
+      return undefined;
+    }
   }
   const fingerprint = makeFingerprint(messageText);
   // Full normalised content powers the unknown-sid recovery path. When a

--- a/test/bridge-rotation-policy.test.ts
+++ b/test/bridge-rotation-policy.test.ts
@@ -3,6 +3,7 @@ import {
   shouldRunQuietRotation,
   evaluatePidResolverPullback,
   decideFingerprintSwitch,
+  shouldHealAbsentBaseline,
   sessionIdFromJsonlPath,
 } from '../src/services/bridge-rotation-policy.js';
 
@@ -244,5 +245,52 @@ describe('decideFingerprintSwitch', () => {
     });
     const r = decideFingerprintSwitch(input);
     expect(r).toEqual({ action: 'no-match' });
+  });
+});
+
+describe('shouldHealAbsentBaseline', () => {
+  it('heals when baseline not done, a path is pinned, and the file is absent', () => {
+    // The user-reported stuck case: resume/restore guessed <botmux-sid>.jsonl,
+    // Claude wrote under a different sessionId, so the guessed file never
+    // appears. An absent file has no history to absorb → safe to arm
+    // fresh-empty readiness so the turn gets marked and fingerprint recovery
+    // can find the real transcript.
+    expect(shouldHealAbsentBaseline({
+      baselineDone: false,
+      hasJsonlPath: true,
+      jsonlFileExists: false,
+    })).toBe(true);
+  });
+
+  it('does NOT heal when the pinned file exists (slow-resume-with-history)', () => {
+    // The genuine resume case: the file exists with prior turns. Healing here
+    // (offset 0) would re-emit history as live turns. Defer to normal
+    // lazy-baseline instead.
+    expect(shouldHealAbsentBaseline({
+      baselineDone: false,
+      hasJsonlPath: true,
+      jsonlFileExists: true,
+    })).toBe(false);
+  });
+
+  it('does NOT heal once baseline is already done', () => {
+    expect(shouldHealAbsentBaseline({
+      baselineDone: true,
+      hasJsonlPath: true,
+      jsonlFileExists: false,
+    })).toBe(false);
+    expect(shouldHealAbsentBaseline({
+      baselineDone: true,
+      hasJsonlPath: true,
+      jsonlFileExists: true,
+    })).toBe(false);
+  });
+
+  it('does NOT heal when no path is pinned (nothing to recover onto)', () => {
+    expect(shouldHealAbsentBaseline({
+      baselineDone: false,
+      hasJsonlPath: false,
+      jsonlFileExists: false,
+    })).toBe(false);
   });
 });


### PR DESCRIPTION
## 问题

用户反馈「消息进了 PTY 但没有回复 / final_output 归因失败」，日志三连：
`Bridge transcript not yet present` → `Bridge baseline not ready` → `writeInput: submit not confirmed after retries`。

## 根因

恢复/重启会话走 `baseline-existing` 模式时，worker 把 `bridgeJsonlPath` 钉在 `<sid>.jsonl` 上，等文件出现再 baseline。若 Claude 把 transcript 写到了**和我们猜测不同的 sessionId** 下（`--session-id` 未被认、stale resume id、或 adopt 持久化的 sid 误存成 botmux sid），该文件**永不出现**，`bridgeBaselineDone` 永远翻不了 true：

1. `bridgeMarkPendingTurn` 因 `!bridgeBaselineDone` 直接 return → 本轮从不入队
2. 没有 pending turn → **不依赖 pid** 的指纹精确正文恢复 `maybeSwitchBridgeJsonl` 拿不到锚点，空转
3. 纠偏用的 pid-state resolver 在重启恢复时常因 pid 缺失而 `'unavailable'`
4. 直接靠 mtime 的 `maybeFollowQuietRotation` 需要当前文件存在才能比对 → 文件缺失时早退

→ bridge 永久卡在不存在的路径上。

**为什么本地不复现**：本地 resume 目标文件一定存在（首次 spawn 时 Claude 认了 `--session-id <botmux-sid>`，`--resume` 又往同一文件追加），「文件缺失」分支从没走到过。

## 修复（方案A）

缺失文件**没有历史可吸收**，故在「baseline 未完成 + 路径已钉 + 文件缺失」时安全地武装 fresh-empty 就绪（offset 0），让本轮被标记 → 指纹精确正文恢复接管，扫到 Claude 真正写入的 jsonl 并切换。**不依赖 Claude 内部 pid 文件，版本无关。**

关键安全边界：文件**存在**的慢 resume 场景（有历史）**不触发**，仍走正常 lazy-baseline，避免历史重发。

- 新增纯函数 `shouldHealAbsentBaseline`（`bridge-rotation-policy.ts`）+ 4 单测
- worker 侧在 `bridgeMarkPendingTurn` 的 baseline gate 接线
- 全量 **4404/4404** 通过，tsc 0 error

## 测试

`npx vitest run --project unit` → 292 files / 4404 tests 全绿。
