### PR TITLE
chore(release): 移除 changelog 里的 HD2D 资产脚注(每版重复、无必要)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,8 +147,6 @@ jobs:
               echo "$THANKS"
             fi
             echo ""
-            echo "> ℹ️ HD2D「办公室」游戏资产体积大且几乎不随版本变化，不随 npm 包/版本发布；dashboard 进入「办公室」后按需下载自 [hd2d-assets release](https://github.com/${GITHUB_REPOSITORY}/releases/tag/hd2d-assets-v2)。"
-            echo ""
             echo "**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/${PREV_TAG}...${GITHUB_REF_NAME}"
             echo 'CHANGELOG_EOF'
           } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
每个版本 release body 都被自动附上一行「HD2D 办公室游戏资产…按需下载自 hd2d-assets release」。办公室 tab 是全自动下载、没人手动去 release 翻文件,这行每版重复纯噪声(申晗在 v2.76.0 changelog 注意到)。撤回该脚注,恢复原 changelog 结尾。仅删 release.yml 里的两行 echo,无其它改动。