### PR TITLE
chore(prompt): 调整 botmux 稳定上下文顺序

### DIFF
--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -235,6 +235,16 @@ export function formatAttachmentsHint(attachments?: LarkAttachment[], locale?: L
   return `<attachments hint="${xmlEscape(t('ai.attach.hint', undefined, locale))}">\n${items.join('\n')}\n</attachments>`;
 }
 
+function renderRoleContextBlock(larkAppId: string | undefined, chatId: string | undefined): string {
+  if (!larkAppId || !chatId) return '';
+
+  const { content: roleContent, source: roleSource } = resolveRole(larkAppId, chatId);
+  if (!roleContent) return '';
+
+  const ctx = roleSource === 'team' ? 'team' : 'group';
+  return `<role context="${ctx}" chat_id="${xmlEscape(chatId)}">\n${roleContent}\n</role>`;
+}
+
 export function buildNewTopicPrompt(
   userMessage: string,
   sessionId: string,
@@ -272,14 +282,7 @@ export function buildNewTopicPrompt(
     ].join('\n');
   }
 
-  let roleBlock = '';
-  if (opts?.larkAppId && opts?.chatId) {
-    const { content: roleContent, source: roleSource } = resolveRole(opts.larkAppId, opts.chatId);
-    if (roleContent) {
-      const ctx = roleSource === 'team' ? 'team' : 'group';
-      roleBlock = `<role context="${ctx}" chat_id="${xmlEscape(opts.chatId)}">\n${roleContent}\n</role>`;
-    }
-  }
+  const roleBlock = renderRoleContextBlock(opts?.larkAppId, opts?.chatId);
 
   let mentionBlock = '';
   if (mentions && mentions.length > 0) {
@@ -312,7 +315,19 @@ export function buildNewTopicPrompt(
     ? [userMessage, ...followUps].join('\n\n')
     : userMessage;
   const userBlock = `<user_message>\n${mergedMessage}\n</user_message>`;
-  const parts: string[] = [userBlock];
+  const parts: string[] = [];
+
+  // Put stable, instruction-like context before the user's first turn. This
+  // improves salience without moving per-turn attribution (sender/mentions)
+  // into the prompt-cache prefix.
+  if (!adapter.injectsSessionContext) {
+    if (routingBlock) parts.push(routingBlock);
+    if (identityBlock) parts.push(identityBlock);
+    parts.push(`<session_id>${xmlEscape(sessionId)}</session_id>`);
+  }
+  if (roleBlock) parts.push(roleBlock);
+
+  parts.push(userBlock);
 
   const senderBlock = renderSenderTag(sender);
   if (senderBlock) parts.push(senderBlock);
@@ -325,12 +340,6 @@ export function buildNewTopicPrompt(
 
   // CLIs with injectsSessionContext (Claude Code) get Lark routing/identity
   // and session ID via system prompt, so skip those blocks here.
-  if (!adapter.injectsSessionContext) {
-    parts.push(`<session_id>${xmlEscape(sessionId)}</session_id>`);
-    if (routingBlock) parts.push(routingBlock);
-    if (identityBlock) parts.push(identityBlock);
-  }
-  if (roleBlock) parts.push(roleBlock);
   if (mentionBlock) parts.push(mentionBlock);
   if (botBlock) parts.push(botBlock);
 
@@ -347,7 +356,22 @@ export function buildFollowUpContent(
   sessionId: string,
   opts?: { attachments?: LarkAttachment[]; mentions?: LarkMention[]; isAdoptMode?: boolean; cliId?: CliId; cliPathOverride?: string; locale?: Locale; sender?: ResolvedSender; larkAppId?: string; chatId?: string },
 ): string {
-  const parts: string[] = [`<user_message>\n${content}\n</user_message>`];
+  const parts: string[] = [];
+  const roleBlock = renderRoleContextBlock(opts?.larkAppId, opts?.chatId);
+  const skipSessionId = opts?.isAdoptMode || (opts?.cliId
+    ? createCliAdapterSync(opts.cliId, opts.cliPathOverride).injectsSessionContext
+    : false);
+
+  // Put stable context before the user's turn. Follow the new-topic order for
+  // shared blocks: session id first, then role. Keep per-turn attribution and
+  // attachments after <user_message>.
+  if (!skipSessionId) parts.push(`<session_id>${xmlEscape(sessionId)}</session_id>`);
+  if (roleBlock) parts.push(roleBlock);
+  if (opts?.cliId !== 'mira') {
+    parts.push(`<botmux_reminder>${t('ai.followup.reminder', undefined, opts?.locale)}</botmux_reminder>`);
+  }
+
+  parts.push(`<user_message>\n${content}\n</user_message>`);
 
   const senderBlock = renderSenderTag(opts?.sender);
   if (senderBlock) parts.push(senderBlock);
@@ -360,34 +384,12 @@ export function buildFollowUpContent(
     : '';
   if (attachHint) parts.push(attachHint);
 
-  // Inject role for follow-up messages: per-chat override ＞ team default (same as buildNewTopicPrompt)
-  if (opts?.larkAppId && opts?.chatId) {
-    const { content: roleContent, source: roleSource } = resolveRole(opts.larkAppId, opts.chatId);
-    if (roleContent) {
-      const ctx = roleSource === 'team' ? 'team' : 'group';
-      parts.push(`<role context="${ctx}" chat_id="${xmlEscape(opts.chatId)}">\n${roleContent}\n</role>`);
-    }
-  }
-
-  if (!opts?.isAdoptMode) {
-    const skipSessionId = opts?.cliId
-      ? createCliAdapterSync(opts.cliId, opts.cliPathOverride).injectsSessionContext
-      : false;
-    if (!skipSessionId) {
-      parts.push(`<session_id>${xmlEscape(sessionId)}</session_id>`);
-    }
-  }
-
   if (opts?.mentions && opts.mentions.length > 0) {
     const items = opts.mentions.map(m => {
       const oid = m.openId ? ` open_id="${xmlEscape(m.openId)}"` : '';
       return `  <mention name="${xmlEscape(m.name)}"${oid} />`;
     });
     parts.push(`<mentions>\n${items.join('\n')}\n</mentions>`);
-  }
-
-  if (opts?.cliId !== 'mira') {
-    parts.push(`<botmux_reminder>${t('ai.followup.reminder', undefined, opts?.locale)}</botmux_reminder>`);
   }
 
   return parts.join('\n\n');

--- a/src/services/resumable-session-discovery.ts
+++ b/src/services/resumable-session-discovery.ts
@@ -97,11 +97,15 @@ function truncateTitle(text: string): string {
 //  (common in this repo: "explain <botmux_routing>", "why does <sender type=
 //  appear") is NOT mis-flagged.
 const BOTMUX_INJECTION_PATTERNS: readonly RegExp[] = [
-  // The whole prompt IS a botmux envelope — it STARTS with the opening wrapper.
-  // botmux wraps every forwarded AND scheduled message this way; an external
-  // prompt that merely discusses the tags has them mid-text, not leading. This
-  // also catches scheduled-task sessions that carry no trailing <sender> block.
+  // The whole prompt IS a botmux envelope. Older prompts START with the opening
+  // wrapper; newer non-injecting CLIs place stable routing/identity/session
+  // blocks first, then the wrapper. External prompts may discuss these tags
+  // mid-text, but they don't start with this structural envelope.
   /^<user_message>[\s\S]*?<\/user_message>/,
+  /^<botmux_routing>[\s\S]*?<\/botmux_routing>\s*(?:<identity>[\s\S]*?<\/identity>\s*)?<session_id>[^<]+<\/session_id>\s*(?:<role\b[\s\S]*?<\/role>\s*)?(?:<botmux_reminder>[\s\S]*?<\/botmux_reminder>\s*)?<user_message>[\s\S]*?<\/user_message>/,
+  /^<role\s+context="(?:team|group)"\s+chat_id="[^"]+">[\s\S]*?<\/role>\s*(?:<session_id>[^<]+<\/session_id>\s*)?(?:<botmux_reminder>[\s\S]*?<\/botmux_reminder>\s*)?<user_message>[\s\S]*?<\/user_message>/,
+  /^<session_id>[^<]+<\/session_id>\s*(?:<role\b[\s\S]*?<\/role>\s*)?(?:<botmux_reminder>[\s\S]*?<\/botmux_reminder>\s*)?<user_message>[\s\S]*?<\/user_message>/,
+  /^<botmux_reminder>[\s\S]*?<\/botmux_reminder>\s*<user_message>[\s\S]*?<\/user_message>/,
   /^用户发送了：\s*\n-{3,}/,
   // Modern envelope: the `</user_message>` close butted up against one of
   // botmux's trailing blocks (claude → <sender>, codex/traex → <session_id>,

--- a/test/prompt-builder.test.ts
+++ b/test/prompt-builder.test.ts
@@ -125,6 +125,43 @@ describe('buildNewTopicPrompt', () => {
     expect(prompt).toContain('name="Alice"');
     expect(prompt).toContain('open_id="ou_alice"');
   });
+
+  it('puts stable routing and bot identity before the first user message for non-injecting CLIs', () => {
+    const prompt = buildNewTopicPrompt(
+      'hello',
+      SESSION_ID,
+      'codex',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { name: 'Codex Bot', openId: 'ou_bot' },
+    );
+
+    expect(prompt.indexOf('<botmux_routing>')).toBeLessThan(prompt.indexOf('<identity>'));
+    expect(prompt.indexOf('<identity>')).toBeLessThan(prompt.indexOf('<user_message>'));
+    expect(prompt.indexOf(`<session_id>${SESSION_ID}</session_id>`)).toBeLessThan(prompt.indexOf('<user_message>'));
+  });
+
+  it('keeps per-turn sender and mentions after the first user message', () => {
+    const prompt = buildNewTopicPrompt(
+      'hello',
+      SESSION_ID,
+      'codex',
+      undefined,
+      undefined,
+      [{ name: 'Alice', openId: 'ou_alice' }],
+      undefined,
+      undefined,
+      { name: 'Codex Bot', openId: 'ou_bot' },
+      undefined,
+      { openId: 'ou_sender', type: 'user', name: 'Sender' },
+    );
+
+    expect(prompt.indexOf('<sender ')).toBeGreaterThan(prompt.indexOf('<user_message>'));
+    expect(prompt.indexOf('<mentions>')).toBeGreaterThan(prompt.indexOf('<user_message>'));
+  });
 });
 
 describe('buildFollowUpContent', () => {
@@ -167,6 +204,19 @@ describe('buildFollowUpContent', () => {
     expect(content).toContain('<mentions>');
     expect(content).toContain('name="Bob"');
     expect(content).toContain('open_id="ou_bob"');
+  });
+
+  it('places stable reminder before follow-up user content', () => {
+    const content = buildFollowUpContent('hello', SESSION_ID, {
+      cliId: 'codex',
+      sender: { openId: 'ou_sender', type: 'user', name: 'Sender' },
+      mentions: [{ name: 'Bob', openId: 'ou_bob' }],
+    });
+
+    expect(content.indexOf('<session_id>')).toBeLessThan(content.indexOf('<botmux_reminder>'));
+    expect(content.indexOf('<botmux_reminder>')).toBeLessThan(content.indexOf('<user_message>'));
+    expect(content.indexOf('<sender ')).toBeGreaterThan(content.indexOf('</user_message>'));
+    expect(content.indexOf('<mentions>')).toBeGreaterThan(content.indexOf('</user_message>'));
   });
 
   it('should omit <session_id> but keep mentions in adopt mode', () => {
@@ -265,6 +315,7 @@ describe('buildReforkPrompt', () => {
     expect(out).toContain('</user_message>');
     expect(out).toContain('<botmux_reminder>');
     expect(out).toContain('botmux send');
+    expect(out.indexOf('<botmux_reminder>')).toBeLessThan(out.indexOf('<user_message>'));
   });
 
   it('embeds <session_id> for CLIs without injectsSessionContext (codex)', () => {

--- a/test/resumable-session-discovery.test.ts
+++ b/test/resumable-session-discovery.test.ts
@@ -174,6 +174,44 @@ describe('discoverRolloutSessions (codex / traex)', () => {
     expect(out.map((s) => s.cliSessionId)).toEqual(['sid-ext']);
   });
 
+  it('drops botmux-origin rollouts with stable metadata before user_message', async () => {
+    writeRollout('2026/06/14', 'rollout-bmx-prefix.jsonl', [
+      { type: 'session_meta', payload: { id: 'sid-bmx-prefix', cwd: '/root/x' } },
+      {
+        type: 'event_msg',
+        payload: {
+          type: 'user_message',
+          message: '<botmux_routing>\nuse botmux send\n</botmux_routing>\n\n<identity>\n  <name>Codex Bot</name>\n  <open_id>ou_bot</open_id>\n</identity>\n\n<session_id>sess-123</session_id>\n\n<role context="team" chat_id="oc_team">\nreviewer\n</role>\n\n<user_message>\nactual prompt\n</user_message>',
+        },
+      },
+    ]);
+    writeRollout('2026/06/15', 'rollout-ext-prefix-discuss.jsonl', [
+      { type: 'session_meta', payload: { id: 'sid-ext-prefix-discuss', cwd: '/root/y' } },
+      { type: 'event_msg', payload: { type: 'user_message', message: 'Please explain why botmux may place <botmux_routing> before <user_message>.' } },
+    ]);
+    const out = await discoverRolloutSessions(sessionsRoot, 10);
+    expect(out.map((s) => s.cliSessionId)).toEqual(['sid-ext-prefix-discuss']);
+  });
+
+  it('drops botmux-origin rollouts with reminder before user_message', async () => {
+    writeRollout('2026/06/14', 'rollout-bmx-reminder-prefix.jsonl', [
+      { type: 'session_meta', payload: { id: 'sid-bmx-reminder-prefix', cwd: '/root/x' } },
+      {
+        type: 'event_msg',
+        payload: {
+          type: 'user_message',
+          message: '<session_id>sess-123</session_id>\n\n<role context="team" chat_id="oc_team">\nreviewer\n</role>\n\n<botmux_reminder>reply via botmux send</botmux_reminder>\n\n<user_message>\nactual prompt\n</user_message>',
+        },
+      },
+    ]);
+    writeRollout('2026/06/15', 'rollout-ext-reminder-discuss.jsonl', [
+      { type: 'session_meta', payload: { id: 'sid-ext-reminder-discuss', cwd: '/root/y' } },
+      { type: 'event_msg', payload: { type: 'user_message', message: 'Please explain what <botmux_reminder> means.' } },
+    ]);
+    const out = await discoverRolloutSessions(sessionsRoot, 10);
+    expect(out.map((s) => s.cliSessionId)).toEqual(['sid-ext-reminder-discuss']);
+  });
+
   // Regression (Codex blocker 2): legacy botmux rollouts may carry a
   // "你已连接到飞书话题，" preamble before "用户发送了：", which an anchored ^ match
   // missed. The envelope-paired-with-"Session ID:" combo catches it regardless.

--- a/test/role-resolver.test.ts
+++ b/test/role-resolver.test.ts
@@ -137,3 +137,26 @@ describe('buildNewTopicPrompt team-role injection', () => {
     expect(prompt).toContain('TEAM_PERSONA');
   });
 });
+
+describe('buildFollowUpContent role injection', () => {
+  it('places stable role context before the follow-up user message', async () => {
+    await fresh();
+    const { writeRoleFile } = await import('../src/core/role-resolver.js');
+    writeRoleFile('app1', 'oc_follow', 'FOLLOWUP_PERSONA');
+    const { buildFollowUpContent } = await import('../src/core/session-manager.js');
+    const prompt = buildFollowUpContent('follow up', 'sess-follow', {
+      larkAppId: 'app1',
+      chatId: 'oc_follow',
+      sender: { openId: 'ou_sender', type: 'user', name: 'Sender' },
+      mentions: [{ name: 'Reviewer', openId: 'ou_reviewer' }],
+    });
+
+    expect(prompt).toContain('<role context="group" chat_id="oc_follow">');
+    expect(prompt).toContain('FOLLOWUP_PERSONA');
+    expect(prompt.indexOf('<session_id>')).toBeLessThan(prompt.indexOf('<role '));
+    expect(prompt.indexOf('<role ')).toBeLessThan(prompt.indexOf('<botmux_reminder>'));
+    expect(prompt.indexOf('<botmux_reminder>')).toBeLessThan(prompt.indexOf('<user_message>'));
+    expect(prompt.indexOf('<sender ')).toBeGreaterThan(prompt.indexOf('</user_message>'));
+    expect(prompt.indexOf('<mentions>')).toBeGreaterThan(prompt.indexOf('</user_message>'));
+  });
+});


### PR DESCRIPTION
核心Idea：
1. Prompt越靠前效果越好，特别是管控类的
2. 不变的信息靠前，Token缓存命中效果越好，变化的信息尽可能往后

## Summary
- 调整 botmux prompt 标签顺序，把稳定指令/会话上下文前置到 `<user_message>` 前。
- 保持本轮归因和输入附属信息在 `<user_message>` 后，避免 sender/mentions/attachments 进入稳定前缀。
- 更新 `/adopt` 的 resumable-session discovery 过滤规则，避免新 envelope 被误判成外部会话。
- 补充 prompt 顺序、role/reminder 前置、discovery 过滤的回归测试。

## Final Tag Ordering
- New topic, non-injecting CLI: `<botmux_routing>` -> `<identity>` -> `<session_id>` -> `<role>` -> `<user_message>` -> `<sender>` -> `<sender_note>` -> `<attachments>` -> `<mentions>` -> `<available_bots>`.
- New topic, injectsSessionContext CLI: `<role>` -> `<user_message>` -> `<sender>` -> `<attachments>` -> `<mentions>` -> `<available_bots>`.
- Follow-up/refork, ordinary mode: `<session_id>` -> `<role>` -> `<botmux_reminder>` -> `<user_message>` -> `<sender>` -> `<sender_note>` -> `<attachments>` -> `<mentions>`.
- Follow-up/refork, injectsSessionContext CLI: `<role>` -> `<botmux_reminder>` -> `<user_message>` -> `<sender>` -> `<attachments>` -> `<mentions>`.
- Follow-up/refork, adopt mode: `<role>` -> `<botmux_reminder>` -> `<user_message>` -> `<sender>` -> `<sender_note>` -> `<attachments>` -> `<mentions>`.

`mira` follow-up/refork 仍不注入 `<botmux_reminder>`。Bridge/adopt raw input 仍不注入 `<session_id>` 和 `<botmux_reminder>`。

## Verification
- `pnpm test -- test/prompt-builder.test.ts test/role-resolver.test.ts test/resumable-session-discovery.test.ts test/bridge-input.test.ts` passed: 92 tests.
- `pnpm build` passed.
- 本地安装验证通过：`pnpm switch:here` + `~/.botmux/bin/botmux restart` 后，4 个 daemon 和 dashboard 均从当前 checkout 的 `dist` 产物启动并 online。

## Full Test Note
- 全量 `pnpm test` 仍有 15 个失败，已确认与本次改动无直接关系：
  - 14 个失败来自当前环境 git 2.20.1 不支持测试 helper 里的 `git init -b`。
  - 1 个失败来自 `test/tmux-backend-env.test.ts` 的 shell wrapper syntax check。