### PR TITLE
fix(pi): allow typeahead input

### DIFF
--- a/src/adapters/cli/pi.ts
+++ b/src/adapters/cli/pi.ts
@@ -42,6 +42,7 @@ export function createPiAdapter(pathOverride?: string): CliAdapter {
 
     completionPattern: undefined,
     readyPattern: undefined,
+    supportsTypeAhead: true,
     systemHints: BOTMUX_SHELL_HINTS,
     altScreen: true,
     skillsDir: '~/.pi/agent/skills',

--- a/src/utils/pending-input-queue.ts
+++ b/src/utils/pending-input-queue.ts
@@ -1,0 +1,15 @@
+export interface PendingCliInput {
+  content: string;
+  turnId?: string;
+}
+
+export function mergeQueuedCliInput(
+  pending: PendingCliInput[],
+  next: PendingCliInput,
+): boolean {
+  const tail = pending[pending.length - 1];
+  if (!tail) return false;
+  tail.content = `${tail.content}\n\n${next.content}`;
+  tail.turnId = next.turnId ?? tail.turnId;
+  return true;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -20,6 +20,7 @@ import { drainTranscript, joinAssistantText, trailingAssistantText, findJsonlCon
 import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint } from './services/bridge-turn-queue.js';
 import { shouldSuppressBridgeEmit, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
 import { shouldWriteNow } from './utils/input-gate.js';
+import { mergeQueuedCliInput, type PendingCliInput } from './utils/pending-input-queue.js';
 import { ReadyGate, shouldArmReadyGate } from './utils/ready-gate.js';
 import { InflightInputTracker } from './core/inflight-input-tracker.js';
 import {
@@ -216,7 +217,7 @@ function releaseReadyGate(reason: string): void {
     settleThenFlush(Date.now());
   }
 }
-const pendingMessages: Array<{ content: string; turnId?: string }> = [];
+const pendingMessages: PendingCliInput[] = [];
 /** Inputs written to the CLI whose turn hasn't completed — re-queued across a
  *  CLI crash so a submit-time death can't silently eat user messages. */
 const inflightInputs = new InflightInputTracker();
@@ -3043,7 +3044,19 @@ async function flushPending(): Promise<void> {
 
 function sendToPty(content: string, turnId?: string): void {
   if (!backend || !cliAdapter) return;
-  pendingMessages.push({ content, turnId });
+  const next = { content, turnId };
+  const shouldMergeQueued = !isFlushing && !shouldWriteNow({
+    isPromptReady,
+    isFlushing,
+    supportsTypeAhead: cliAdapter.supportsTypeAhead === true,
+    awaitingFirstPrompt,
+  });
+  const mergedQueued = shouldMergeQueued && mergeQueuedCliInput(pendingMessages, next);
+  if (mergedQueued) {
+    log(`Merged queued message (${pendingMessages.length} pending): "${content.substring(0, 80)}" — ${cliName()} ${awaitingFirstPrompt ? 'still booting' : 'is busy'}`);
+  } else {
+    pendingMessages.push(next);
+  }
   // User-override semantics: a fresh Lark message while a TUI prompt is "active"
   // takes precedence over the AI-detected prompt. The screen analyzer can be
   // wrong (false positive on a question that has no rendered options) and a
@@ -3068,10 +3081,10 @@ function sendToPty(content: string, turnId?: string): void {
   // delivers queued messages instead. See input-gate.ts; this fixes dispatch's
   // brief reaching Codex before its first idle and never landing.
   if (shouldWriteNow({ isPromptReady, isFlushing, supportsTypeAhead: cliAdapter.supportsTypeAhead === true, awaitingFirstPrompt })) {
-    log(`Writing to PTY: "${content.substring(0, 80)}"`);
+    if (!mergedQueued) log(`Writing to PTY: "${content.substring(0, 80)}"`);
     flushPending();  // fire-and-forget async; no-op if already flushing
   } else {
-    log(`Queued message (${pendingMessages.length} pending): "${content.substring(0, 80)}" — ${cliName()} ${awaitingFirstPrompt ? 'still booting' : 'is busy'}`);
+    if (!mergedQueued) log(`Queued message (${pendingMessages.length} pending): "${content.substring(0, 80)}" — ${cliName()} ${awaitingFirstPrompt ? 'still booting' : 'is busy'}`);
   }
 }
 

--- a/test/worker-queue-merge.test.ts
+++ b/test/worker-queue-merge.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { mergeQueuedCliInput } from '../src/utils/pending-input-queue.js';
+
+describe('mergeQueuedCliInput', () => {
+  it('returns false when there is no queued message to merge into', () => {
+    const pending: Array<{ content: string; turnId?: string }> = [];
+
+    expect(mergeQueuedCliInput(pending, { content: 'next', turnId: 't2' })).toBe(false);
+    expect(pending).toEqual([]);
+  });
+
+  it('merges incremental queued messages into the pending tail', () => {
+    const pending = [{ content: 'first', turnId: 't1' }];
+
+    expect(mergeQueuedCliInput(pending, { content: 'second', turnId: 't2' })).toBe(true);
+
+    expect(pending).toEqual([{ content: 'first\n\nsecond', turnId: 't2' }]);
+  });
+});

--- a/test/write-input.test.ts
+++ b/test/write-input.test.ts
@@ -46,6 +46,7 @@ import { createOpenCodeAdapter } from '../src/adapters/cli/opencode.js';
 import { createMtrAdapter } from '../src/adapters/cli/mtr.js';
 import { createHermesAdapter } from '../src/adapters/cli/hermes.js';
 import { createMiraAdapter } from '../src/adapters/cli/mira.js';
+import { createPiAdapter } from '../src/adapters/cli/pi.js';
 import type { CliAdapter, PtyHandle } from '../src/adapters/cli/types.js';
 import { appendFileSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir, platform } from 'node:os';
@@ -171,13 +172,14 @@ const HUMAN_TYPING_ADAPTERS: AdapterEntry[] = [
 ];
 
 /** Adapters that use tmux pasteText (load-buffer + paste-buffer -d) with
- *  delayed Enter — CoCo / Trae CLI and Codex. See coco.ts for the Trae 0.120.31
+ *  delayed Enter — CoCo / Trae CLI, Codex, and Pi. See coco.ts for the Trae 0.120.31
  *  burst bug, and codex.ts for the per-line-submit bug bracketed paste fixes
  *  (Codex 0.134+ handles bracketed paste correctly — the old "Codex exits on
  *  bracketed paste" note was true only for a much earlier build). */
 const PASTE_BUFFER_ADAPTERS: AdapterEntry[] = [
   ['coco', createCocoAdapter('/bin/coco')],
   ['codex', createCodexAdapter('/bin/codex')],
+  ['pi', createPiAdapter('/bin/pi')],
 ];
 
 /** Adapters that wrap content in bracketed-paste markers (\x1b[200~ ... \x1b[201~)
@@ -489,6 +491,10 @@ describe('supportsTypeAhead flag', () => {
 
   it('codex: true (0.134.0+ parks submit-while-busy, writes rollout user event at dequeue time)', () => {
     expect(createCodexAdapter('/bin/codex').supportsTypeAhead).toBe(true);
+  });
+
+  it('pi: true (parks submit-while-busy in its TUI queue, avoiding missed idle detection)', () => {
+    expect(createPiAdapter('/bin/pi').supportsTypeAhead).toBe(true);
   });
 
   it.each(PLAIN_ADAPTERS.filter(([name]) => name !== 'codex'))('%s: undefined (default behavior)', (_name, adapter) => {


### PR DESCRIPTION
◆ 修复描述

  修复新版 Pi 在 botmux 中偶发卡在 Pi is busy 的问题。

  新版 Pi 在完成一轮回复后，botmux 的 idle/prompt 检测可能没有识别到它已经回到可输入状态，导致后续飞书消息虽然已经被 botmux 收到并路由到同一个 session，但一直停留在 pending queue
  中，日志表现为：

  Queued message (...) — Pi is busy

  本次将 Pi adapter 标记为支持 type-ahead：

  supportsTypeAhead: true

  这样当 botmux 没有及时识别到 Pi idle 时，仍可把后续消息写入 Pi TUI，由 Pi 自己排队处理，避免消息长期卡住。

  同时补充了 write-input 单测：

  - 将 Pi 纳入 paste-buffer 输入路径覆盖
  - 断言 Pi adapter 的 supportsTypeAhead 为 true

  验证：

  - pnpm vitest run test/write-input.test.ts 通过
  - pnpm build 通过
  - 本地安装并重启 botmux 后，运行态日志确认后续 PI 消息已进入 Writing to PTY / Writing to PTY (flush)，不再卡在 Pi is busy 队列中。



  新增优化逻辑：

  - 如果消息还没有被 flush 到 PTY，且此时 CLI 仍 busy / still booting，新来的增量消息会合并到 pending queue 尾部。
  - 等后续 flush 时，只写一次 PTY，内容用空行拼接。
  - 正在 flush 或可以立即写入 PTY 的场景保持原行为，不合并，避免影响正在发送中的输入。

  验证已通过：

  - pnpm vitest run test/worker-queue-merge.test.ts test/input-gate.test.ts test/write-input.test.ts
  - pnpm build