### PR TITLE
fix(worker): daemon 启动清理上一代孤儿 worker，堵住硬退出导致的进程泄漏

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -5,7 +5,7 @@
 import { fork, execSync, type ChildProcess } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
-import { readFileSync, mkdirSync, existsSync, realpathSync } from 'node:fs';
+import { readFileSync, readdirSync, mkdirSync, existsSync, realpathSync } from 'node:fs';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { fileURLToPath } from 'node:url';
 import { ensureSkills, ensureAskSkill, ensurePluginSkills, removeGlobalBotmuxSkills } from '../skills/installer.js';
@@ -2539,6 +2539,106 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
   // Adopted CLIs come with pre-botmux history — anchor it out of the ledger.
   anchorUsageForDaemonSession(ds);
   recordOwnershipForDaemonSession(ds);
+}
+
+// ─── Reap orphan workers ────────────────────────────────────────────────────
+
+/** A live process, reduced to what orphan detection needs. */
+export interface ProcSnapshot {
+  pid: number;
+  ppid: number;
+  /** Full command line (argv joined by spaces). */
+  cmd: string;
+}
+
+/**
+ * Enumerate live processes as {pid, ppid, cmd}. Linux reads `/proc` directly
+ * (the rest of the worker code already relies on /proc); other POSIX shells out
+ * to `ps`. Returns `[]` on Windows or on any failure — callers then reap
+ * nothing, so "can't tell" can never escalate into a wrong kill.
+ */
+export function listProcesses(): ProcSnapshot[] {
+  if (process.platform === 'win32') return [];
+  try {
+    if (process.platform === 'linux') {
+      const procs: ProcSnapshot[] = [];
+      for (const entry of readdirSync('/proc')) {
+        if (!/^\d+$/.test(entry)) continue;
+        const pid = Number(entry);
+        try {
+          // /proc/<pid>/stat = "<pid> (comm) <state> <ppid> ...". `comm` can
+          // contain spaces and ')', so read ppid from after the LAST ')'.
+          const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
+          const after = stat.slice(stat.lastIndexOf(')') + 2).split(' ');
+          const ppid = Number(after[1]); // after = [state, ppid, ...]
+          const cmd = readFileSync(`/proc/${pid}/cmdline`, 'utf-8').replace(/\0/g, ' ').trim();
+          if (Number.isFinite(ppid)) procs.push({ pid, ppid, cmd });
+        } catch { /* exited mid-scan / unreadable — skip */ }
+      }
+      return procs;
+    }
+    // macOS / other POSIX. `-ww` defeats command-column truncation.
+    const raw = execSync('ps -axww -o pid=,ppid=,command=', { encoding: 'utf-8', maxBuffer: 32 * 1024 * 1024 });
+    const procs: ProcSnapshot[] = [];
+    for (const line of raw.split('\n')) {
+      const m = line.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/);
+      if (m) procs.push({ pid: Number(m[1]), ppid: Number(m[2]), cmd: m[3] });
+    }
+    return procs;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Reap worker processes orphaned by a previous daemon that died WITHOUT running
+ * its graceful shutdown — SIGKILL, OOM, or an uncaught crash. The shutdown()
+ * path in daemon.ts already SIGKILLs stragglers on SIGTERM, but a hard kill
+ * skips it entirely: the workers get re-parented to init (ppid==1), and because
+ * a fresh worker's pid overwrites `session.pid`, killStalePids can never reach
+ * them again. Each leaks ~0.5 GB and they pile up across restarts (observed:
+ * 22 orphans / 3.3 GB on a dev box; daemon.ts records a prior 841-orphan /
+ * ~65 GB incident).
+ *
+ * Identification is deliberately conservative — a process is reaped only if it
+ * BOTH:
+ *   1. has ppid==1 — its forking daemon is gone. A live daemon's workers are
+ *      parented to that daemon, so this never touches a running worker, even
+ *      under the one-daemon-per-bot layout or when several daemons start at
+ *      once; and
+ *   2. references THIS install's worker script in its command line — so we
+ *      never touch another botmux install or an unrelated `worker.js`.
+ *
+ * Process listing and the kill syscall are injectable for tests. Returns the
+ * number of orphans actually reaped.
+ */
+export function reapOrphanWorkers(opts: {
+  procs?: ProcSnapshot[];
+  kill?: (pid: number, signal: NodeJS.Signals) => void;
+  workerPath?: string;
+} = {}): number {
+  if (process.platform === 'win32') return 0;
+  const procs = opts.procs ?? listProcesses();
+  const kill = opts.kill ?? ((pid, signal) => { process.kill(pid, signal); });
+  const workerPath = opts.workerPath ?? join(__dirname, '..', 'worker.js');
+
+  let reaped = 0;
+  for (const p of procs) {
+    if (p.ppid !== 1) continue;                 // parent still alive → not an orphan
+    if (!p.cmd.includes(workerPath)) continue;  // not OUR worker script
+    try {
+      // SIGKILL, not SIGTERM: an orphan can be wedged in a sync code path (the
+      // very failure mode that produced it) where SIGTERM is lost. It holds no
+      // active session and no IPC channel, so there is nothing to flush.
+      kill(p.pid, 'SIGKILL');
+      reaped++;
+      logger.info(`Reaped orphan worker pid=${p.pid} (forking daemon gone)`);
+    } catch { /* already exited, or another daemon won the race — fine */ }
+  }
+  if (reaped > 0) {
+    logger.warn(`Reaped ${reaped} orphan worker(s) leaked by a previous daemon that didn't shut down cleanly.`);
+  }
+  return reaped;
 }
 
 // ─── Kill stale PIDs ────────────────────────────────────────────────────────

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -51,6 +51,7 @@ import {
   setActiveSessionsRegistry,
   forkWorker,
   killWorker,
+  reapOrphanWorkers,
   scheduleCardPatch,
   setCurrentCliVersion,
   getCurrentCliVersion,
@@ -3585,6 +3586,13 @@ export async function startDaemon(botIndex?: number): Promise<void> {
       },
     }, normalizeBrand(cfg.brand));
   }
+
+  // Reap workers orphaned by a previous daemon that was hard-killed (SIGKILL /
+  // OOM / crash) and so skipped graceful shutdown — they're re-parented to init
+  // (ppid==1) and untracked by any session.pid, so killStalePids can't reach
+  // them. Without this they leak ~0.5 GB each and accumulate across restarts.
+  // See reapOrphanWorkers() in worker-pool.ts.
+  reapOrphanWorkers();
 
   // Restore active sessions from previous run
   await restoreActiveSessions(activeSessions);

--- a/test/reap-orphan-workers.test.ts
+++ b/test/reap-orphan-workers.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { reapOrphanWorkers, type ProcSnapshot } from '../src/core/worker-pool.js';
+
+// Absolute path of THIS install's worker script, as it appears in a worker's
+// command line. reapOrphanWorkers() matches on this exact substring.
+const WP = '/opt/botmux/dist/worker.js';
+
+describe('reapOrphanWorkers', () => {
+  it('reaps only ppid==1 processes that reference this install’s worker script', () => {
+    const killed: number[] = [];
+    const procs: ProcSnapshot[] = [
+      { pid: 100, ppid: 1, cmd: `node --max-old-space-size=8192 ${WP}` }, // orphan ✓
+      { pid: 101, ppid: 1, cmd: `node ${WP}` },                            // orphan ✓
+      { pid: 102, ppid: 555, cmd: `node ${WP}` },                          // live worker (parented to daemon 555) ✗
+      { pid: 103, ppid: 1, cmd: 'node /other/botmux/dist/worker.js' },     // a DIFFERENT install's orphan ✗
+      { pid: 104, ppid: 1, cmd: '/usr/bin/claude --session-id abc' },      // CLI process, not a worker ✗
+      { pid: 105, ppid: 1, cmd: 'node /opt/botmux/dist/index-daemon.js' }, // daemon, not a worker ✗
+    ];
+
+    const n = reapOrphanWorkers({ procs, workerPath: WP, kill: (pid) => killed.push(pid) });
+
+    expect(n).toBe(2);
+    expect(killed.sort((a, b) => a - b)).toEqual([100, 101]);
+  });
+
+  it('never targets a live worker whose forking daemon is still alive', () => {
+    const killed: number[] = [];
+    const procs: ProcSnapshot[] = [
+      { pid: 200, ppid: 4242, cmd: `node ${WP}` },
+      { pid: 201, ppid: 4242, cmd: `node ${WP}` },
+    ];
+    expect(reapOrphanWorkers({ procs, workerPath: WP, kill: (p) => killed.push(p) })).toBe(0);
+    expect(killed).toEqual([]);
+  });
+
+  it('does not count a kill that throws (process already gone / lost the race)', () => {
+    const procs: ProcSnapshot[] = [{ pid: 300, ppid: 1, cmd: `node ${WP}` }];
+    const n = reapOrphanWorkers({
+      procs,
+      workerPath: WP,
+      kill: () => { throw Object.assign(new Error('No such process'), { code: 'ESRCH' }); },
+    });
+    expect(n).toBe(0);
+  });
+
+  it('reaps nothing when there are no matching orphans', () => {
+    const procs: ProcSnapshot[] = [
+      { pid: 1, ppid: 0, cmd: '/sbin/init' },
+      { pid: 400, ppid: 99, cmd: `node ${WP}` },
+    ];
+    const killed: number[] = [];
+    expect(reapOrphanWorkers({ procs, workerPath: WP, kill: (p) => killed.push(p) })).toBe(0);
+    expect(killed).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 问题

botmux 一个会话不关闭,稳定占用 ~0.5GB(worker 进程 ~140MB + CLI 进程 ~360MB)。但真正的资源黑洞不是单会话,而是 **daemon 重启后残留的孤儿 worker 进程**——它们不属于任何 active 会话,却永久常驻吃内存。

在一台真实运行的开发机上实测(daemon 14.2 小时前重启过):

```
worker 共 34 个:
  本次重启后的合法 worker : 12 个, 1621 MB   ← 精确等于 12 个 active 会话 ✅
  上次重启残留的孤儿 worker: 22 个, 3391 MB   ← 3.3 GB 泄漏,永不回收 ❌
```

这 22 个孤儿 worker 比当前 daemon 还老(2~5.7 天),`ppid==1`(已被 init 收养),不挂在任何活 daemon 下。`daemon.ts` 现有注释也记录过一次更严重的事故:**841 个孤儿 / ~65GB**。

## 根因

worker 是 daemon `fork()` 出来的非 detached 子进程。当 daemon **非优雅退出**时(`SIGKILL` / OOM / 未捕获崩溃——daemon 目前也没有 `uncaughtException` 处理器),它来不及杀掉 worker,这些 worker 被 init 收养成 `ppid==1` 孤儿。

而 botmux 靠 `session.pid` 记录追踪 worker。daemon 重启后:
1. 新 daemon 重新 attach 会话、`fork` 新 worker;
2. 新 worker 的 pid **覆盖** `session.pid`;
3. 旧孤儿 worker 的 pid 再也没有任何记录指向它 → `killStalePids` 永远找不到它 → **永久泄漏**,且每次重启单调累积。

## 现有防护的盲区

`shutdown()`(`daemon.ts`)已经在 **SIGTERM 优雅退出路径**加了防护:给每个 worker 发信号 → 等 `SHUTDOWN_GRACE_MS` → 对残留的 SIGKILL。这能防住"优雅退出时 worker 没退干净"。

但它**只在 daemon 自己能跑完 shutdown 时生效**。一旦 daemon 被硬杀(SIGKILL/OOM/崩溃),shutdown 根本不执行,worker 全部漏成孤儿——而**启动侧没有任何兜底清理**。这就是 22 个孤儿的来源。

## 修复

daemon 启动时(`restoreActiveSessions` 之前)新增 `reapOrphanWorkers()`:扫描所有进程,把同时满足以下两条的进程 `SIGKILL`:

1. **`ppid==1`** —— 其 forking daemon 已死。活 daemon 的 worker 都 parent 在各自 daemon 上(`ppid!=1`),所以**绝不会误杀正在运行的 worker**,在 one-daemon-per-bot 布局、多 daemon 并发启动下都安全;
2. **命令行匹配本 install 的 worker 脚本路径** —— 绝不碰另一份 botmux 安装或无关的 `worker.js`。

进程枚举走 Linux `/proc`(与现有代码一致)/ 其它 POSIX `ps`,Windows 直接跳过。判据刻意保守:"判断不了"时一个都不杀,不会把不确定升级成误杀。

## 安全性

- 不误杀活 worker:活 worker `ppid` 指向各自 daemon,不是 1。
- 不误杀别的安装:命令行必须含**本 install** 的 worker 绝对路径。
- 多 daemon 并发:都只杀 `ppid==1` 的孤儿,幂等;抢杀同一个孤儿时 `kill` 抛 `ESRCH` 被吞掉。
- SIGKILL 而非 SIGTERM:孤儿常卡在 sync code path(正是产生它的失败模式),SIGTERM 可能丢失;且孤儿无 active 会话、无 IPC,无需 flush。

## 测试与验证

- 新增 `test/reap-orphan-workers.test.ts`(4 例):只杀 `ppid==1` 且匹配本 install 的进程;不碰活 worker / 别的 install / CLI 进程 / daemon 进程;`kill` 抛错不计数;无孤儿时零动作。`procs` 与 `kill` 均依赖注入。
- `tsc --noEmit` 通过;`pnpm build` 通过;相关既有测试(session-manager / session-store / daemon-heartbeat / workflow-daemon-spawn 等)96 例全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
