### PR TITLE
fix(lark): 收敛 SDK 错误日志为单行+脱敏 token，静默 reaction/memdiag 噪声

### DIFF
--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -312,13 +312,64 @@ export function getLoadedConfigPath(): string | undefined {
 // traces, etc.); without DEBUG=1 those become no-ops in the CLI path and
 // stay in daemon.log on the daemon path — pm2's error.log no longer sees
 // "[lark:info] client ready" floods.
+// Cap raw dumps so an unrecognized error shape can never flood the log the way
+// the SDK's full AxiosError blob (stack + config + headers) did — that bloated
+// pm2's error.log past 1GB and, worse, leaked the `Authorization: Bearer t-…`
+// access token on every request failure.
+const MAX_FALLBACK_LEN = 300;
 function safeStringify(v: unknown): string {
   if (typeof v === 'string') return v;
-  try { return JSON.stringify(v); } catch { return String(v); }
+  let s: string;
+  try { s = JSON.stringify(v) ?? String(v); } catch { s = String(v); }
+  return s.length > MAX_FALLBACK_LEN ? `${s.slice(0, MAX_FALLBACK_LEN)}…(+${s.length - MAX_FALLBACK_LEN})` : s;
 }
-const fmtLark = (msg: any[]) => msg.map(safeStringify).join(' ');
+
+// Drop the protocol+host (and `/open-apis/` prefix) so the line shows just the
+// API path that matters for triage, never the bearer token in the URL/headers.
+function shortLarkPath(url: unknown): string {
+  if (typeof url !== 'string' || !url) return '';
+  const path = url.replace(/^https?:\/\/[^/]+/, '').replace(/^\/open-apis\//, '');
+  return path || url;
+}
+
+/**
+ * Condense a Lark SDK error into one readable line, preserving just the fields
+ * needed to triage (HTTP status + business `code`/`msg`/`log_id`). Returns null
+ * when the value isn't an axios-shaped error, so callers fall back to
+ * length-capped stringify. Never serializes `config`/`headers`/`stack`, so the
+ * access token can't leak.
+ */
+export function formatLarkError(v: any): string | null {
+  if (!v || typeof v !== 'object') return null;
+  const isAxios = v.isAxiosError === true || v.name === 'AxiosError' || (v.config && (v.response || v.status != null));
+  if (!isAxios) return null;
+  const method = String(v.config?.method ?? '').toUpperCase();
+  const path = shortLarkPath(v.config?.url);
+  const httpStatus = v.response?.status ?? v.status;
+  // Lark business error lives in the response body; some shapes surface it on
+  // the error object directly.
+  const data = v.response?.data ?? {};
+  const code = data.code ?? v.code;
+  const msg = data.msg ?? v.msg;
+  const logId = data.log_id ?? data.logId;
+  const parts: string[] = [];
+  if (method) parts.push(method);
+  if (path) parts.push(path);
+  if (httpStatus != null || method || path) parts.push(`→ ${httpStatus ?? '?'}`);
+  if (typeof code === 'number') parts.push(`code=${code}`);
+  if (typeof msg === 'string' && msg) parts.push(`"${msg}"`);
+  if (logId) parts.push(`log_id=${logId}`);
+  if (!parts.length) return null;
+  return parts.join(' ');
+}
+
+const fmtLark = (msg: any[]) => msg.map((m) => formatLarkError(m) ?? safeStringify(m)).join(' ');
 const larkLogger = {
-  error: (...msg: any[]) => logger.error(`[lark] ${fmtLark(msg)}`),
+  // SDK request failures arrive here as raw AxiosError objects — condense to a
+  // single triage line (status + lark code/msg/log_id) instead of dumping the
+  // stack/config blob. Demoted to warn: nearly all are environmental and already
+  // handled at the call site (rate limits, bot-not-in-chat, stale threads).
+  error: (...msg: any[]) => logger.warn(`[lark] ${fmtLark(msg)}`),
   warn:  (...msg: any[]) => logger.warn(`[lark] ${fmtLark(msg)}`),
   info:  (...msg: any[]) => logger.info(`[lark] ${fmtLark(msg)}`),
   debug: (...msg: any[]) => logger.debug(`[lark] ${fmtLark(msg)}`),

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -253,7 +253,10 @@ function parsePositiveIntEnv(name: string): number {
   const raw = process.env[name];
   if (!raw) return 0;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  // `0` is the documented "off" sentinel that the daemon spawn always passes
+  // (`BOTMUX_MEMORY_DIAG_INTERVAL_MS ?? '0'`) — treat it as a silent no-op, only
+  // warn on genuinely malformed values (non-numeric / negative).
+  if (!Number.isFinite(parsed) || parsed < 0) {
     logger.warn(`[memdiag] ignoring invalid ${name}=${JSON.stringify(raw)}`);
     return 0;
   }

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -1348,6 +1348,11 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
     'drive.file.comment_add_v1': (data: any) => handleCommentEventAckSafe(data, larkAppId, handlers),
     'drive.notice.comment_add_v1': (data: any) => handleCommentEventAckSafe(data, larkAppId, handlers),
     'card.action.trigger': (data: any) => handleCardActionAckSafe(data, larkAppId, handlers),
+    // 表情回复事件——一旦在开发者后台订阅了 reaction，SDK 每收到一次都会因
+    // 没有 handler 打 "no im.message.reaction.created_v1 handle" 警告刷屏。
+    // botmux 不消费表情事件，注册显式 no-op 把这条噪声静默掉。
+    'im.message.reaction.created_v1': () => {},
+    'im.message.reaction.deleted_v1': () => {},
     'im.message.receive_v1': (data: any) => {
       const messageIdForKey = data?.message?.message_id;
       const eventKey = `im.message.receive_v1:${larkAppId}:${eventIdForKey(data) ?? messageIdForKey ?? unkeyableEventKey()}`;

--- a/test/lark-error-format.test.ts
+++ b/test/lark-error-format.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for formatLarkError — condensing the Lark SDK's raw AxiosError into
+ * a single triage line (status + code/msg/log_id) without leaking the bearer
+ * token or dumping the stack/config blob.
+ *
+ * Run:  pnpm vitest run test/lark-error-format.test.ts
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+// bot-registry imports the Lark SDK at module load — stub it so the test needn't
+// open real connections.
+vi.mock('@larksuiteoapi/node-sdk', () => ({ Client: class {}, LoggerLevel: { error: 0 } }));
+
+import { formatLarkError } from '../src/bot-registry.js';
+
+describe('formatLarkError', () => {
+  it('condenses an AxiosError with a Lark business error body to one line', () => {
+    const err = {
+      name: 'AxiosError',
+      message: 'Request failed with status code 400',
+      stack: 'AxiosError: ...long stack...',
+      config: {
+        method: 'patch',
+        url: 'https://open.feishu.cn/open-apis/im/v1/messages/om_xxx',
+        headers: { Authorization: 'Bearer t-secretToken' },
+      },
+      status: 400,
+      response: {
+        status: 400,
+        data: { code: 99991400, msg: 'request trigger frequency limit', log_id: 'LOG123' },
+      },
+    };
+    const line = formatLarkError(err);
+    expect(line).toBe('PATCH im/v1/messages/om_xxx → 400 code=99991400 "request trigger frequency limit" log_id=LOG123');
+  });
+
+  it('never leaks the bearer token or stack', () => {
+    const err = {
+      name: 'AxiosError',
+      config: { method: 'get', url: 'https://open.feishu.cn/open-apis/contact/v3/users/ou_x', headers: { Authorization: 'Bearer t-leakme' } },
+      status: 400,
+      stack: 'secret stack frames',
+    };
+    const line = formatLarkError(err) ?? '';
+    expect(line).not.toContain('Bearer');
+    expect(line).not.toContain('t-leakme');
+    expect(line).not.toContain('secret stack');
+    expect(line).toBe('GET contact/v3/users/ou_x → 400');
+  });
+
+  it('handles a status-only failure with no response body', () => {
+    const err = {
+      name: 'AxiosError',
+      config: { method: 'get', url: 'https://open.feishu.cn/open-apis/contact/v3/users/ou_x' },
+      status: 400,
+    };
+    expect(formatLarkError(err)).toBe('GET contact/v3/users/ou_x → 400');
+  });
+
+  it('detects axios shape via config+response even without name', () => {
+    const err = {
+      config: { method: 'post', url: 'https://open.feishu.cn/open-apis/im/v1/messages' },
+      response: { status: 403, data: { code: 230002, msg: 'bot not in chat' } },
+    };
+    expect(formatLarkError(err)).toBe('POST im/v1/messages → 403 code=230002 "bot not in chat"');
+  });
+
+  it('returns null for non-axios values so callers fall back', () => {
+    expect(formatLarkError('plain string')).toBeNull();
+    expect(formatLarkError({ hello: 'world' })).toBeNull();
+    expect(formatLarkError(null)).toBeNull();
+    expect(formatLarkError(42)).toBeNull();
+  });
+
+  it('falls back gracefully when url is absent', () => {
+    const err = { name: 'AxiosError', status: 500, response: { status: 500, data: { code: 1, msg: 'boom' } } };
+    expect(formatLarkError(err)).toBe('→ 500 code=1 "boom"');
+  });
+});


### PR DESCRIPTION
## 背景
排查「botmux logs 总有错误日志」时发现 `daemon-0-error.log` 单文件 **1GB**。绝大部分是 6/10–6/11 那次 hook 自转发死循环（已被 PR#201 修复）。剩下日常仍在刷的里，`[ERROR] [lark] …400` 这类最碍眼——飞书 SDK 内部 logger 把整个 AxiosError 原样 `JSON.stringify`，每次失败吐数百~上千字符的 stack/config/headers。

**顺带挖出密钥泄漏**：这些 blob 把 `Authorization: Bearer t-…` access token 整个打进日志，全量 **437 次**。

## 改动
- **`formatLarkError`**（bot-registry）：识别 axios 形状，只提取 `method`/path/`status` + 业务 `code`/`msg`/`log_id` 拼成一行，host/token/stack 全砍掉；非 axios 错误走长度封顶 300 的 `safeStringify` 兜底，杜绝任何未来 blob。`error`→`warn` 降级（几乎全是限频/bot 不在群/stale thread 等环境性、调用处已兜底）。

  改造前：
  ```
  [ERROR] [lark] [{"message":"Request failed with status code 400","name":"AxiosError","stack":"…数百字符…","config":{…,"headers":{"Authorization":"Bearer t-…"}},"status":400}]
  ```
  改造后：
  ```
  [lark] PATCH im/v1/messages/om_xxx → 400 code=99991400 "request trigger frequency limit" log_id=20260602…
  ```
- **`parsePositiveIntEnv`**（daemon）：`'0'` 是 daemon spawn always 传的『关闭』哨兵，改为静默 no-op，只对非数字/负数告警——消 `ignoring invalid …="0"` 噪声。
- **event-dispatcher**：给 `im.message.reaction.created/deleted_v1` 注册 no-op handler，消除 SDK `no … handle` 刷屏。

## 测试
- 新增 `test/lark-error-format.test.ts` 6 例（含「token 不泄漏」断言）
- tsc 0；unit 全量 **4509/4509**

> 注：另一项运维建议「配 pm2-logrotate + 清掉 1GB 死日志」是部署侧操作，不在本 PR 代码范围。