### PR TITLE
feat(cli): 新增 Relay CLI 适配器（Seed 新版）+ 补 seed/relay adopt-by-comm

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -64,7 +64,7 @@ Compared to OpenClaw-style approaches built on Agent SDKs:
 ## Prerequisites
 
 - **Node.js** >= 20
-- **AI coding CLI / local agent app** installed and authenticated (`claude`, `codex`, `coco`, `cursor-agent`, `gemini`, `opencode`, `hermes`, `seed` (Seed CLI, a Claude Code fork), `pi`, `omp` (oh-my-pi, a Pi fork), `copilot` (GitHub Copilot CLI), `traex` (TRAE CLI), or `agy` (Antigravity) in PATH)
+- **AI coding CLI / local agent app** installed and authenticated (`claude`, `codex`, `coco`, `cursor-agent`, `gemini`, `opencode`, `hermes`, `seed` (Seed CLI, a Claude Code fork), `relay` (Relay CLI, the new release of Seed), `pi`, `omp` (oh-my-pi, a Pi fork), `copilot` (GitHub Copilot CLI), `traex` (TRAE CLI), or `agy` (Antigravity) in PATH)
   - **CoCo requires `0.120.32+`**: type-ahead (sending a new message while a turn is still running, parked in CoCo's own message queue) relies on 0.120.32+ behavior; earlier versions may drop or serialize input while busy — upgrade before use
 - **tmux** >= 3.x (optional — auto-enabled when installed for persistent CLI sessions)
 - **CJK fonts** (only needed for screenshot rendering of Chinese text / emoji):

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ CLI 进入 botmux 会话时自动获得 `~/.botmux/bin` 在 PATH 中，以及一
 ## 前置要求
 
 - **Node.js** >= 20
-- **AI 编程 CLI / 本地 Agent 应用** 已安装并完成认证（`claude`、`codex`、`coco`、`cursor-agent`、`gemini`、`opencode`、`hermes`、`seed`（Seed CLI，Claude Code 衍生）、`pi`、`omp`（oh-my-pi，Pi 衍生）、`copilot`（GitHub Copilot CLI）、`traex`（TRAE CLI）或 `agy`（Antigravity）在 PATH 中）
+- **AI 编程 CLI / 本地 Agent 应用** 已安装并完成认证（`claude`、`codex`、`coco`、`cursor-agent`、`gemini`、`opencode`、`hermes`、`seed`（Seed CLI，Claude Code 衍生）、`relay`（Relay CLI，Seed 新版）、`pi`、`omp`（oh-my-pi，Pi 衍生）、`copilot`（GitHub Copilot CLI）、`traex`（TRAE CLI）或 `agy`（Antigravity）在 PATH 中）
   - **CoCo 最低版本 `0.120.32`**：type-ahead（会话忙时即可发新消息，由 CoCo 自己的消息队列接住）依赖 0.120.32+ 的行为；更早版本忙时输入可能丢失或串行，请升级后再用
 - **tmux** >= 3.x（可选，安装后自动启用会话常驻）
 - **CJK 字体**（用于截图渲染中文/emoji）：

--- a/src/adapters/cli/registry.ts
+++ b/src/adapters/cli/registry.ts
@@ -5,6 +5,7 @@ import { isAbsolute, join } from 'node:path';
 import type { CliAdapter, CliId } from './types.js';
 import { createClaudeCodeAdapter } from './claude-code.js';
 import { createSeedAdapter } from './seed.js';
+import { createRelayAdapter } from './relay.js';
 import { createAidenAdapter } from './aiden.js';
 import { createCocoAdapter } from './coco.js';
 import { createCodexAdapter } from './codex.js';
@@ -102,13 +103,14 @@ export async function createCliAdapter(id: CliId, pathOverride?: string): Promis
   return adapter;
 }
 
-export { createClaudeCodeAdapter, createSeedAdapter, createAidenAdapter, createCocoAdapter, createCodexAdapter, createCodexAppAdapter, createCursorAdapter, createGeminiAdapter, createOpenCodeAdapter, createAntigravityAdapter, createMtrAdapter, createHermesAdapter, createMiraAdapter, createTraexAdapter, createPiAdapter, createCopilotAdapter, createOhMyPiAdapter };
+export { createClaudeCodeAdapter, createSeedAdapter, createRelayAdapter, createAidenAdapter, createCocoAdapter, createCodexAdapter, createCodexAppAdapter, createCursorAdapter, createGeminiAdapter, createOpenCodeAdapter, createAntigravityAdapter, createMtrAdapter, createHermesAdapter, createMiraAdapter, createTraexAdapter, createPiAdapter, createCopilotAdapter, createOhMyPiAdapter };
 
 /** Synchronous version for use in worker process. */
 export function createCliAdapterSync(id: CliId, pathOverride?: string): CliAdapter {
   switch (id.toLowerCase() as CliId) {
     case 'claude-code': return createClaudeCodeAdapter(pathOverride);
     case 'seed': return createSeedAdapter(pathOverride);
+    case 'relay': return createRelayAdapter(pathOverride);
     case 'aiden': return createAidenAdapter(pathOverride);
     case 'coco': return createCocoAdapter(pathOverride);
     case 'codex': return createCodexAdapter(pathOverride);

--- a/src/adapters/cli/relay.ts
+++ b/src/adapters/cli/relay.ts
@@ -1,0 +1,73 @@
+import { realpathSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { resolveCommand } from './registry.js';
+import { createClaudeFamilyAdapter } from './claude-code.js';
+import { logger } from '../../utils/logger.js';
+import type { CliAdapter } from './types.js';
+
+/** Relay CLI (`@bytedance-relay/claude-code`, binary `relay`) is the current
+ *  release name of what used to ship as Seed — a ByteDance fork of Claude Code.
+ *  It is identical to Claude Code in flags, slash commands and on-disk session
+ *  layout (per-project JSONL transcripts, `sessions/<pid>.json`, `tasks/` fd
+ *  locks, keybindings.json, settings.json hooks); it differs only in the binary
+ *  name, its auth (ByteCloud / bytedcli / SuperRelay), and its data root — which
+ *  it isolates to a `.claude-runtime` directory *inside its own install package*
+ *  (rather than `~/.claude`), respecting `CLAUDE_CONFIG_DIR` when set.
+ *
+ *  Relay and Seed share the same package internals, so this adapter is a near
+ *  clone of `seed.ts`; it lives as its own file (and CliId) because they are
+ *  distinct binaries with distinct npm packages — a user may have either one,
+ *  or both, on PATH, and botmux must spawn/resume each by its real name. */
+
+/** Derive Relay's `.claude-runtime` data root from the resolved binary.
+ *
+ *  `which relay` returns an ephemeral fnm/nvm shim (e.g.
+ *  `/run/user/.../fnm_multishells/<pid>_.../bin/relay`); realpath follows the
+ *  symlink chain to the package's `dist/cli.js`, whose package root is two
+ *  levels up. `.claude-runtime` sits at that package root. Deriving from the
+ *  binary on every spawn means a node/fnm switch (which moves the binary)
+ *  auto-tracks to the matching runtime dir — and it equals the path a bare
+ *  `relay` uses by default, so botmux-spawned and hand-started Relay sessions
+ *  share one config (settings, history, cross-resume).
+ *
+ *  Falls back to `~/.claude-runtime` only if realpath fails (unusual install
+ *  layout) — Relay still runs, but the JSONL bridge may target the wrong dir;
+ *  we log so it's diagnosable rather than silently degraded. */
+export function deriveRelayDataDir(bin: string): string {
+  try {
+    const real = realpathSync(bin);          // <pkg>/dist/cli.js
+    const pkgRoot = dirname(dirname(real));   // <pkg>
+    return join(pkgRoot, '.claude-runtime');
+  } catch (err) {
+    const fallback = join(homedir(), '.claude-runtime');
+    logger.warn(`[relay] could not resolve .claude-runtime from binary "${bin}" (${err instanceof Error ? err.message : String(err)}); falling back to ${fallback}`);
+    return fallback;
+  }
+}
+
+export function createRelayAdapter(pathOverride?: string): CliAdapter {
+  const bin = resolveCommand(pathOverride ?? 'relay');
+  const dataDir = deriveRelayDataDir(bin);
+  return createClaudeFamilyAdapter({
+    id: 'relay',
+    // Relay reuses bytedcli login state (RELAY_BYTEDCLI_DATA_DIR overrides it;
+    // SEED_BYTEDCLI_DATA_DIR is a migration-era fallback) — keep the bytedcli
+    // dir real + writable inside the file sandbox so token refresh/login persist.
+    authPaths: ['~/.local/share/bytedcli'],
+    resumeBin: 'relay',
+    dataDir,
+    // Relay keeps `.claude.json` inside its data root (CLAUDE_CONFIG_DIR layout),
+    // unlike Claude Code which puts it at `~/.claude.json`.
+    stateJsonPath: join(dataDir, '.claude.json'),
+    // Pin CLAUDE_CONFIG_DIR to Relay's own default so the dir botmux watches and
+    // the dir Relay writes to are provably identical — and still equal to what a
+    // hand-started `relay` resolves, preserving config alignment.
+    spawnEnv: { CLAUDE_CONFIG_DIR: dataDir },
+    // Relay's model set is SuperRelay-gateway-defined, not the Anthropic
+    // aliases — skip the setup model prompt; users pick via /model.
+    modelChoices: undefined,
+  }, bin);
+}
+
+export const create = createRelayAdapter;

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -319,4 +319,4 @@ export interface CliAdapter {
   readonly defaultPassthroughCommands?: readonly string[];
 }
 
-export type CliId = 'claude-code' | 'seed' | 'aiden' | 'coco' | 'codex' | 'codex-app' | 'cursor' | 'gemini' | 'opencode' | 'antigravity' | 'mtr' | 'hermes' | 'mira' | 'traex' | 'pi' | 'copilot' | 'oh-my-pi';
+export type CliId = 'claude-code' | 'seed' | 'relay' | 'aiden' | 'coco' | 'codex' | 'codex-app' | 'cursor' | 'gemini' | 'opencode' | 'antigravity' | 'mtr' | 'hermes' | 'mira' | 'traex' | 'pi' | 'copilot' | 'oh-my-pi';

--- a/src/core/ask-hook/registry.ts
+++ b/src/core/ask-hook/registry.ts
@@ -10,6 +10,9 @@ const REGISTRY: Record<string, HookAskAdapter> = {
   // so it reuses the claude hook adapter (the `botmux hook seed` command's
   // payload parses the same way).
   seed: claude,
+  // Relay is the current release name of the Seed fork — same Claude-compatible
+  // AskUserQuestion hook payload, so `botmux hook relay` reuses the claude adapter.
+  relay: claude,
   codex,
   opencode,
   // CoCo (Trae CLI): AskUserQuestion payload is Claude-compatible (parseQuestions

--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -547,23 +547,23 @@ function readTokenUsageFromAidenCheckpoint(path: string): SessionTokenUsage | nu
   };
 }
 
-/** Resolve a Claude-family fork's (seed / relay) data root the SAME way its
- *  adapter does — by realpath-resolving the binary to `<pkg>/.claude-runtime`
- *  (see deriveSeedDataDir / deriveRelayDataDir). The previous
- *  `process.env.CLAUDE_CONFIG_DIR || ~/.claude-runtime` was wrong on a default
- *  install: the adapter injects CLAUDE_CONFIG_DIR only into the *child*, so the
- *  daemon's own env has it unset, and the real root is the package-local
- *  `.claude-runtime`, not `~/.claude-runtime` — so usage reads missed the
- *  transcript entirely. Cached so the dashboard read path doesn't shell out
- *  (`which`) on every refresh. An explicit CLAUDE_CONFIG_DIR on the daemon still
- *  wins, matching the adapter's spawnEnv precedence.
+/** Resolve a Claude-family fork's (seed / relay) data root EXACTLY as the worker
+ *  does, so usage reads hit the same transcript the CLI wrote. The adapter
+ *  derives the root by realpath-resolving the binary to `<pkg>/.claude-runtime`
+ *  (see deriveSeedDataDir / deriveRelayDataDir) and the worker spawns the CLI
+ *  with `spawnEnv = { CLAUDE_CONFIG_DIR: <that root> }`, which *overrides* any
+ *  inherited env (worker.ts: process.env first, then adapter.spawnEnv). So a
+ *  botmux-spawned seed/relay ALWAYS writes to the adapter-derived root —
+ *  regardless of whether the daemon itself has CLAUDE_CONFIG_DIR set. We must
+ *  read from the same place; consulting the daemon's own env (the old
+ *  `process.env.CLAUDE_CONFIG_DIR || ~/.claude-runtime`) would diverge from
+ *  where the CLI actually wrote. `claudeDataDir` is the single source of truth.
+ *  Cached so the dashboard read path doesn't shell out (`which`) per refresh.
  *
  *  Uses the DEFAULT binary (no per-bot cliPathOverride); a custom path would
  *  resolve a different root, but that narrow case was already unsupported here. */
 const claudeForkDataDirCache = new Map<string, string>();
 function claudeForkDataDir(cliId: 'seed' | 'relay'): string {
-  const env = process.env.CLAUDE_CONFIG_DIR;
-  if (env) return env;
   const cached = claudeForkDataDirCache.get(cliId);
   if (cached) return cached;
   const dir = createCliAdapterSync(cliId).claudeDataDir ?? join(homedir(), '.claude-runtime');

--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -7,6 +7,7 @@ import { homedir } from 'node:os';
 import { logger } from '../utils/logger.js';
 import { expandHome } from './working-dir.js';
 import type { CliId } from '../adapters/cli/types.js';
+import { createCliAdapterSync } from '../adapters/cli/registry.js';
 import { findAidenLatestCheckpointByBotmuxSessionId, findAidenLatestCheckpointBySessionId } from '../services/aiden-checkpoints.js';
 import { findCodexRolloutBySessionId, findCodexSessionIdByBotmuxSessionId } from '../services/codex-transcript.js';
 import { cocoEventsPathForSession } from '../services/coco-transcript.js';
@@ -546,6 +547,30 @@ function readTokenUsageFromAidenCheckpoint(path: string): SessionTokenUsage | nu
   };
 }
 
+/** Resolve a Claude-family fork's (seed / relay) data root the SAME way its
+ *  adapter does — by realpath-resolving the binary to `<pkg>/.claude-runtime`
+ *  (see deriveSeedDataDir / deriveRelayDataDir). The previous
+ *  `process.env.CLAUDE_CONFIG_DIR || ~/.claude-runtime` was wrong on a default
+ *  install: the adapter injects CLAUDE_CONFIG_DIR only into the *child*, so the
+ *  daemon's own env has it unset, and the real root is the package-local
+ *  `.claude-runtime`, not `~/.claude-runtime` — so usage reads missed the
+ *  transcript entirely. Cached so the dashboard read path doesn't shell out
+ *  (`which`) on every refresh. An explicit CLAUDE_CONFIG_DIR on the daemon still
+ *  wins, matching the adapter's spawnEnv precedence.
+ *
+ *  Uses the DEFAULT binary (no per-bot cliPathOverride); a custom path would
+ *  resolve a different root, but that narrow case was already unsupported here. */
+const claudeForkDataDirCache = new Map<string, string>();
+function claudeForkDataDir(cliId: 'seed' | 'relay'): string {
+  const env = process.env.CLAUDE_CONFIG_DIR;
+  if (env) return env;
+  const cached = claudeForkDataDirCache.get(cliId);
+  if (cached) return cached;
+  const dir = createCliAdapterSync(cliId).claudeDataDir ?? join(homedir(), '.claude-runtime');
+  claudeForkDataDirCache.set(cliId, dir);
+  return dir;
+}
+
 function tokenUsagePathForSession(q: SessionTokenUsageQuery): string | null {
   const sid = q.cliSessionId || q.sessionId;
   switch (q.cliId) {
@@ -553,7 +578,7 @@ function tokenUsagePathForSession(q: SessionTokenUsageQuery): string | null {
       return q.cwd ? getClaudeSessionJsonlPath(sid, q.cwd, join(homedir(), '.claude')) : null;
     case 'seed':
     case 'relay':
-      return q.cwd ? getClaudeSessionJsonlPath(sid, q.cwd, process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude-runtime')) : null;
+      return q.cwd ? getClaudeSessionJsonlPath(sid, q.cwd, claudeForkDataDir(q.cliId)) : null;
     case 'codex':
       return cachedPathLookup(`codex:${q.sessionId}:${q.cliSessionId ?? ''}`, null, () => {
         const codexSid = q.cliSessionId || findCodexSessionIdByBotmuxSessionId(q.sessionId) || q.sessionId;

--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -134,6 +134,7 @@ function usageKindForCli(cliId: SessionTokenUsageQuery['cliId']): UsageKind {
   switch (cliId) {
     case 'claude-code':
     case 'seed':
+    case 'relay':
       return 'claude';
     case 'codex':
       return 'codex';
@@ -551,6 +552,7 @@ function tokenUsagePathForSession(q: SessionTokenUsageQuery): string | null {
     case 'claude-code':
       return q.cwd ? getClaudeSessionJsonlPath(sid, q.cwd, join(homedir(), '.claude')) : null;
     case 'seed':
+    case 'relay':
       return q.cwd ? getClaudeSessionJsonlPath(sid, q.cwd, process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude-runtime')) : null;
     case 'codex':
       return cachedPathLookup(`codex:${q.sessionId}:${q.cliSessionId ?? ''}`, null, () => {

--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -41,6 +41,14 @@ export interface AdoptableSession {
 
 const CLI_COMM_MAP: Record<string, CliId> = {
   claude: 'claude-code',
+  // Seed / Relay are ByteDance Claude Code forks (Relay is Seed's new release
+  // name). Both rebrand process.title to their product name, so a running
+  // session's `/proc/<pid>/comm` is literally `seed` / `relay` (verified on a
+  // live host) — map them so `/adopt` can discover live panes by comm, the same
+  // way `claude` resolves to claude-code. filterCliId keeps a seed/relay bot
+  // from adopting the other's (or claude's) sessions.
+  seed: 'seed',
+  relay: 'relay',
   codex: 'codex',
   aiden: 'aiden',
   coco: 'coco',

--- a/src/dashboard/web/sessions.ts
+++ b/src/dashboard/web/sessions.ts
@@ -48,6 +48,7 @@ function formatTokenCount(value: unknown): string {
 const CLI_FILTER_OPTIONS = [
   'claude-code',
   'seed',
+  'relay',
   'codex',
   'codex-app',
   'cursor',

--- a/src/dashboard/web/workflows.ts
+++ b/src/dashboard/web/workflows.ts
@@ -1456,7 +1456,7 @@ function terminalOpenInTabLabel(kind: TerminalSurface['kind']): string {
  *    server-side.
  */
 const RESUME_REQUIRES_CLI_SESSION_ID = new Set<string>(['antigravity', 'codex-app', 'cursor', 'mira']);
-const RESUME_USES_SESSION_ID = new Set<string>(['aiden', 'coco', 'claude-code', 'seed', 'codex', 'mtr', 'hermes', 'pi']);
+const RESUME_USES_SESSION_ID = new Set<string>(['aiden', 'coco', 'claude-code', 'seed', 'relay', 'codex', 'mtr', 'hermes', 'pi']);
 function isResumeCapableCli(cliId: string | undefined): boolean {
   return !!cliId && (RESUME_USES_SESSION_ID.has(cliId) || RESUME_REQUIRES_CLI_SESSION_ID.has(cliId));
 }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -571,7 +571,7 @@ export const messages: Record<string, string> = {
   'setup.lark_perm_chat': '  - im:chat (group info)',
   'setup.lark_perm_user_base': '  - contact:user.base:readonly (user info)',
   'setup.lark_enable_events': 'Enable Event Subscription (WebSocket mode):',
-  'setup.supported_clis': 'Supported CLIs: 1) claude-code  2) aiden  3) coco  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira',
+  'setup.supported_clis': 'Supported CLIs: 1) claude-code  2) aiden  3) coco  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed  14) traex  15) pi  16) copilot  17) oh-my-pi  18) relay',
   'setup.prompt_cli_choice': 'CLI adapter [1]: ',
   'setup.prompt_working_dir': 'Default working directory [~]: ',
   'setup.prompt_allowed_users': 'Allowed users (emails or open_ids, comma-separated; empty = no restriction): ',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -574,7 +574,7 @@ export const messages: Record<string, string> = {
   'setup.lark_perm_chat': '  - im:chat (群信息)',
   'setup.lark_perm_user_base': '  - contact:user.base:readonly (用户信息)',
   'setup.lark_enable_events': '启用事件订阅 (WebSocket 模式):',
-  'setup.supported_clis': '支持的 CLI: 1) claude-code  2) aiden  3) coco  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira',
+  'setup.supported_clis': '支持的 CLI: 1) claude-code  2) aiden  3) coco  4) codex  5) cursor  6) gemini  7) opencode  8) antigravity  9) mtr  10) hermes  11) codex-app  12) mira  13) seed  14) traex  15) pi  16) copilot  17) oh-my-pi  18) relay',
   'setup.prompt_cli_choice': 'CLI 适配器 [1]: ',
   'setup.prompt_working_dir': '默认工作目录 [~]: ',
   'setup.prompt_allowed_users': '允许的用户 (邮箱或 open_id，逗号分隔，留空=不限制): ',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -175,6 +175,7 @@ export function buildConfigTextCard(data: ConfigCardData, locale?: Locale): stri
 const cliDisplayNames: Record<CliId, string> = {
   'claude-code': 'Claude',
   'seed': 'Seed',
+  'relay': 'Relay',
   'aiden': 'Aiden',
   'coco': 'CoCo',
   'codex': 'Codex',

--- a/src/services/resumable-session-discovery.ts
+++ b/src/services/resumable-session-discovery.ts
@@ -6,7 +6,7 @@
  * runs `<cli> --resume <id>` in the recorded cwd.
  *
  * Three storage shapes are covered (one parser each, shared across CLIs):
- *   - Claude-family JSONL  (`claude-code`, `seed`): <dataDir>/projects/<hash>/<id>.jsonl
+ *   - Claude-family JSONL  (`claude-code`, `seed`, `relay`): <dataDir>/projects/<hash>/<id>.jsonl
  *   - Codex/TRAE rollout   (`codex`, `traex`):       <sessionsRoot>/YYYY/MM/DD/rollout-*.jsonl
  *   - Antigravity history  (`antigravity`):          <home>/history.jsonl (flat submit log)
  *
@@ -166,7 +166,7 @@ async function collectRecentJsonl(
   return out.sort((a, b) => b.mtimeMs - a.mtimeMs).slice(0, limit);
 }
 
-// ─── Claude-family JSONL (claude-code, seed) ─────────────────────────────────
+// ─── Claude-family JSONL (claude-code, seed, relay) ──────────────────────────
 
 /** Parse one Claude JSONL transcript. The session id is the filename; cwd +
  *  first user prompt come from the content (streamed line by line, stopping

--- a/src/setup/bot-config-editor.ts
+++ b/src/setup/bot-config-editor.ts
@@ -18,6 +18,7 @@ export const CLI_ID_CHOICES: Record<string, CliId> = {
   '15': 'pi',
   '16': 'copilot',
   '17': 'oh-my-pi',
+  '18': 'relay',
 };
 
 const VALID_CLI_IDS: ReadonlySet<string> = new Set(Object.values(CLI_ID_CHOICES));
@@ -45,6 +46,7 @@ const CLI_DISPLAY_LABELS: Record<CliId, string> = {
   'pi': 'Pi',
   'copilot': 'Copilot',
   'oh-my-pi': 'Oh My Pi',
+  'relay': 'Relay',
 };
 
 /**

--- a/src/setup/bot-config-editor.ts
+++ b/src/setup/bot-config-editor.ts
@@ -50,8 +50,8 @@ const CLI_DISPLAY_LABELS: Record<CliId, string> = {
 };
 
 /**
- * 有序 CLI 选项 (id + 展示名), 顺序与 setup 交互菜单 (CLI_ID_CHOICES 序号
- * 1..16) 一致. dashboard "添加机器人" 的 CLI 下拉直接读这里, 避免再抄一份
+ * 有序 CLI 选项 (id + 展示名), 顺序与 setup 交互菜单 (CLI_ID_CHOICES 序号)
+ * 一致. dashboard "添加机器人" 的 CLI 下拉直接读这里, 避免再抄一份
  * 列表. 单一事实源: CLI_ID_CHOICES 的值序.
  */
 export const CLI_OPTIONS: ReadonlyArray<{ id: CliId; label: string }> =
@@ -60,7 +60,7 @@ export const CLI_OPTIONS: ReadonlyArray<{ id: CliId; label: string }> =
 /**
  * 把 setup 里"CLI 适配器"那一格的原始输入解析成合法的 CliId.
  *   - 空 → undefined (调用方决定 "preserve current" 还是套默认 'claude-code')
- *   - "1".."16" → CLI_ID_CHOICES 映射
+ *   - 序号 (CLI_ID_CHOICES 的键) → 映射成 cliId
  *   - 已是合法 cliId 字面值 → 原样返回
  *   - 其它 → throw (typo 不该静默落盘成 cliId)
  */
@@ -70,8 +70,10 @@ export function resolveCliId(input: string | undefined): CliId | undefined {
   const mapped = CLI_ID_CHOICES[raw];
   if (mapped) return mapped;
   if (VALID_CLI_IDS.has(raw)) return raw as CliId;
+  // 序号上界从 CLI_ID_CHOICES 派生, 新增 CLI 时自动跟随, 不再手写硬编码区间.
+  const maxChoice = Object.keys(CLI_ID_CHOICES).length;
   throw new Error(
-    `Unknown CLI 适配器 "${raw}"。请输入序号 1-17 或合法 ID 之一: ${[...VALID_CLI_IDS].join(', ')}`,
+    `Unknown CLI 适配器 "${raw}"。请输入序号 1-${maxChoice} 或合法 ID 之一: ${[...VALID_CLI_IDS].join(', ')}`,
   );
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -152,7 +152,7 @@ function ensureZellijAttachConfig(): string {
 
 let sessionId = '';
 let lastInitConfig: Extract<DaemonToWorker, { type: 'init' }> | null = null;
-const CLI_DISPLAY_NAMES: Record<string, string> = { 'claude-code': 'Claude', seed: 'Seed', aiden: 'Aiden', coco: 'CoCo', codex: 'Codex', 'codex-app': 'Codex App', cursor: 'Cursor', gemini: 'Gemini', opencode: 'OpenCode', antigravity: 'Antigravity', mtr: 'MTR', hermes: 'Hermes', mira: 'Mira', traex: 'TRAE', pi: 'Pi', copilot: 'Copilot', 'oh-my-pi': 'Oh My Pi' };
+const CLI_DISPLAY_NAMES: Record<string, string> = { 'claude-code': 'Claude', seed: 'Seed', relay: 'Relay', aiden: 'Aiden', coco: 'CoCo', codex: 'Codex', 'codex-app': 'Codex App', cursor: 'Cursor', gemini: 'Gemini', opencode: 'OpenCode', antigravity: 'Antigravity', mtr: 'MTR', hermes: 'Hermes', mira: 'Mira', traex: 'TRAE', pi: 'Pi', copilot: 'Copilot', 'oh-my-pi': 'Oh My Pi' };
 function cliName(): string { return CLI_DISPLAY_NAMES[lastInitConfig?.cliId ?? ''] ?? 'CLI'; }
 let isPromptReady = false;
 /** Mutex for async flushPending — prevents concurrent flush loops. */

--- a/src/workflows/attempt-resume.ts
+++ b/src/workflows/attempt-resume.ts
@@ -29,7 +29,7 @@ export const ATTEMPT_RESUME_SCHEMA_VERSION = 1;
 export const ATTEMPT_RESUME_IDLE_MS = 30 * 60 * 1000;
 export const ATTEMPT_RESUME_GRACE_MS = 5000;
 export const RESUME_REQUIRES_CLI_SESSION_ID = new Set(['antigravity', 'codex-app', 'cursor', 'mira']);
-export const RESUME_USES_SESSION_ID = new Set(['aiden', 'coco', 'claude-code', 'seed', 'codex', 'mtr', 'hermes', 'pi']);
+export const RESUME_USES_SESSION_ID = new Set(['aiden', 'coco', 'claude-code', 'seed', 'relay', 'codex', 'mtr', 'hermes', 'pi']);
 
 export type AttemptResumeStatus = 'starting' | 'live' | 'closed';
 

--- a/test/cost-calculator.test.ts
+++ b/test/cost-calculator.test.ts
@@ -44,6 +44,14 @@ vi.mock('../src/services/aiden-checkpoints.js', () => ({
   findAidenLatestCheckpointByBotmuxSessionId: vi.fn(() => undefined),
 }));
 
+// Seed/Relay data root resolution goes through the adapter (binary realpath →
+// <pkg>/.claude-runtime). Mock it to a deterministic package-local root so the
+// path assertion below proves we no longer read from ~/.claude-runtime.
+const FORK_DATA_DIR = '/fake/pkg/.claude-runtime';
+vi.mock('../src/adapters/cli/registry.js', () => ({
+  createCliAdapterSync: vi.fn(() => ({ claudeDataDir: FORK_DATA_DIR })),
+}));
+
 import { existsSync, readFileSync } from 'node:fs';
 import { findAidenLatestCheckpointByBotmuxSessionId, findAidenLatestCheckpointBySessionId } from '../src/services/aiden-checkpoints.js';
 import { findCodexRolloutBySessionId, findCodexSessionIdByBotmuxSessionId } from '../src/services/codex-transcript.js';
@@ -385,6 +393,32 @@ describe('getSessionTokenUsage', () => {
       sessionId: 's1',
       cwd: '/tmp',
     })).toBeNull();
+  });
+
+  it('resolves relay usage under the adapter\'s package-local .claude-runtime (not ~/.claude-runtime)', () => {
+    delete process.env.CLAUDE_CONFIG_DIR;
+    setupJsonl(assistantLine({ input: 100, output: 50, model: 'ark/relay-code' }));
+
+    const usage = getSessionTokenUsage({ cliId: 'relay', sessionId: 's1', cwd: '/tmp' });
+
+    expect(usage).toMatchObject({ inputTokens: 100, outputTokens: 50, turns: 1 });
+    // The jsonl path must sit under the adapter-derived package root, never the
+    // old ~/.claude-runtime fallback that the daemon's unset env produced.
+    const readPaths = vi.mocked(readFileSync).mock.calls.map((c) => String(c[0]));
+    expect(readPaths.some((p) => p.startsWith(`${FORK_DATA_DIR}/projects/`))).toBe(true);
+    expect(readPaths.every((p) => !p.startsWith('/home/testuser/.claude-runtime/'))).toBe(true);
+  });
+
+  it('prefers an explicit CLAUDE_CONFIG_DIR on the daemon for seed/relay usage', () => {
+    process.env.CLAUDE_CONFIG_DIR = '/explicit/config-dir';
+    setupJsonl(assistantLine({ input: 10, output: 5 }));
+    try {
+      getSessionTokenUsage({ cliId: 'seed', sessionId: 's1', cwd: '/tmp', fresh: true });
+      const readPaths = vi.mocked(readFileSync).mock.calls.map((c) => String(c[0]));
+      expect(readPaths.some((p) => p.startsWith('/explicit/config-dir/projects/'))).toBe(true);
+    } finally {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    }
   });
 
   it('reports Codex token_count totals without double-counting cached input', () => {

--- a/test/cost-calculator.test.ts
+++ b/test/cost-calculator.test.ts
@@ -409,13 +409,18 @@ describe('getSessionTokenUsage', () => {
     expect(readPaths.every((p) => !p.startsWith('/home/testuser/.claude-runtime/'))).toBe(true);
   });
 
-  it('prefers an explicit CLAUDE_CONFIG_DIR on the daemon for seed/relay usage', () => {
+  it('ignores the daemon CLAUDE_CONFIG_DIR for seed/relay, matching the worker (adapter-forced dataDir)', () => {
+    // worker.ts spawns seed/relay with spawnEnv={CLAUDE_CONFIG_DIR: <adapter dataDir>},
+    // overriding any inherited env — so the transcript is ALWAYS under the package
+    // .claude-runtime. The calculator must read that same root, not the daemon's env,
+    // else usage reads diverge from where the CLI actually wrote.
     process.env.CLAUDE_CONFIG_DIR = '/explicit/config-dir';
     setupJsonl(assistantLine({ input: 10, output: 5 }));
     try {
       getSessionTokenUsage({ cliId: 'seed', sessionId: 's1', cwd: '/tmp', fresh: true });
       const readPaths = vi.mocked(readFileSync).mock.calls.map((c) => String(c[0]));
-      expect(readPaths.some((p) => p.startsWith('/explicit/config-dir/projects/'))).toBe(true);
+      expect(readPaths.some((p) => p.startsWith(`${FORK_DATA_DIR}/projects/`))).toBe(true);
+      expect(readPaths.every((p) => !p.startsWith('/explicit/config-dir/'))).toBe(true);
     } finally {
       delete process.env.CLAUDE_CONFIG_DIR;
     }

--- a/test/relay-adapter.test.ts
+++ b/test/relay-adapter.test.ts
@@ -1,0 +1,112 @@
+/**
+ * relay-adapter.test.ts
+ *
+ * Relay CLI (`@bytedance-relay/claude-code`) is the current release name of the
+ * Seed fork — a Claude Code fork that reuses the entire Claude-family adapter,
+ * only relocating its data root to the package's `.claude-runtime` and renaming
+ * the binary. These tests lock in the variant wiring: data-root derivation,
+ * CLAUDE_CONFIG_DIR injection, the `.claude.json` location, the `relay --resume`
+ * handoff, and that it inherits Claude's bridge machinery (claudeDataDir / hook /
+ * type-ahead) verbatim — i.e. parity with the Seed adapter under a new id/binary.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { join, dirname } from 'node:path';
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, realpathSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+
+// resolveCommand() shells out to probe for the binary; mock it so an absolute
+// pathOverride is returned as-is (resolveCommand short-circuits absolute paths
+// before probing anyway).
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(() => ''),
+  spawnSync: vi.fn(() => ({ stdout: '', status: 0 })),
+}));
+
+import { createRelayAdapter, deriveRelayDataDir } from '../src/adapters/cli/relay.js';
+
+describe('deriveRelayDataDir', () => {
+  it('derives <pkg>/.claude-runtime from a binary realpath (symlink shim → dist/cli.js)', () => {
+    // Mirror the real install layout: <pkg>/dist/cli.js, reached via a shim symlink.
+    const root = realpathSync(mkdtempSync(join(tmpdir(), 'relay-pkg-')));
+    const pkg = join(root, 'node_modules', '@bytedance-relay', 'claude-code');
+    mkdirSync(join(pkg, 'dist'), { recursive: true });
+    writeFileSync(join(pkg, 'dist', 'cli.js'), '// relay');
+    const shimDir = join(root, 'shim', 'bin');
+    mkdirSync(shimDir, { recursive: true });
+    const shim = join(shimDir, 'relay');
+    symlinkSync(join(pkg, 'dist', 'cli.js'), shim);
+
+    expect(deriveRelayDataDir(shim)).toBe(join(pkg, '.claude-runtime'));
+  });
+
+  it('falls back to ~/.claude-runtime when the binary cannot be realpath-resolved', () => {
+    expect(deriveRelayDataDir('/nonexistent/path/to/relay')).toBe(join(homedir(), '.claude-runtime'));
+  });
+});
+
+describe('createRelayAdapter', () => {
+  // Use a real on-disk layout so dataDir is the package's .claude-runtime.
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'relay-adapter-')));
+  const pkg = join(root, 'pkg', 'claude-code');
+  mkdirSync(join(pkg, 'dist'), { recursive: true });
+  writeFileSync(join(pkg, 'dist', 'cli.js'), '// relay');
+  const bin = join(pkg, 'dist', 'cli.js'); // absolute → resolveCommand returns as-is
+  const expectedDataDir = join(pkg, '.claude-runtime');
+  const adapter = createRelayAdapter(bin);
+
+  it('has id "relay"', () => {
+    expect(adapter.id).toBe('relay');
+  });
+
+  it('exposes claudeDataDir at the package .claude-runtime', () => {
+    expect(adapter.claudeDataDir).toBe(expectedDataDir);
+  });
+
+  it('keeps .claude.json inside the data root (CLAUDE_CONFIG_DIR layout, not ~/.claude.json)', () => {
+    expect(adapter.claudeStateJsonPath).toBe(join(expectedDataDir, '.claude.json'));
+  });
+
+  it('pins CLAUDE_CONFIG_DIR to the data root so the bridge watches where relay writes', () => {
+    expect(adapter.spawnEnv).toEqual({ CLAUDE_CONFIG_DIR: expectedDataDir });
+  });
+
+  it('hookInstall targets the data root settings.json (isolated from ~/.claude)', () => {
+    expect(adapter.hookInstall).toMatchObject({
+      configPath: join(expectedDataDir, 'settings.json'),
+      format: 'claude-settings',
+    });
+    expect(adapter.hookInstall?.sessionStartCommand).toMatch(/session-ready$/);
+  });
+
+  it('keeps bytedcli auth real inside the file sandbox', () => {
+    expect(adapter.authPaths).toEqual(['~/.local/share/bytedcli']);
+  });
+
+  it('prints a `relay --resume` handoff, preferring the CLI-native session id', () => {
+    expect(adapter.buildResumeCommand?.({ sessionId: 'botmux-sid', cliSessionId: 'cli-sid' }))
+      .toBe('relay --resume cli-sid');
+    expect(adapter.buildResumeCommand?.({ sessionId: 'botmux-sid' }))
+      .toBe('relay --resume botmux-sid');
+  });
+
+  it('inherits Claude-family behavior (type-ahead, hook-driven asks, no model curation)', () => {
+    expect(adapter.supportsTypeAhead).toBe(true);
+    expect(adapter.asksViaHook).toBe(true);
+    expect(adapter.injectsSessionContext).toBe(true);
+    expect(adapter.modelChoices).toBeUndefined(); // gateway-defined, not Anthropic aliases
+  });
+
+  it('buildArgs uses --session-id for fresh and --resume for resume (Claude protocol)', () => {
+    const fresh = adapter.buildArgs({ sessionId: 'abc', resume: false });
+    expect(fresh).toContain('--session-id');
+    expect(fresh).toContain('abc');
+    const resumed = adapter.buildArgs({ sessionId: 'abc', resume: true, resumeSessionId: 'xyz' });
+    expect(resumed).toContain('--resume');
+    expect(resumed).toContain('xyz');
+  });
+
+  it('keeps the data root out of ~/.claude (no pollution of the user config)', () => {
+    expect(adapter.claudeDataDir).not.toBe(join(homedir(), '.claude'));
+    expect(dirname(adapter.claudeStateJsonPath!)).toBe(expectedDataDir);
+  });
+});

--- a/test/session-discovery.test.ts
+++ b/test/session-discovery.test.ts
@@ -263,6 +263,22 @@ describe('discoverAdoptableSessions', () => {
     expect(results[1]!.paneRows).toBe(50);
   });
 
+  it('should discover seed and relay processes by comm (Claude Code forks)', () => {
+    setupMocks({
+      paneLines: 'dev:0.0 1000\ndev:1.0 2000\n',
+      commMap: { 1000: 'bash', 1100: 'seed', 2000: 'zsh', 2100: 'relay' },
+      childMap: { 1000: [1100], 2000: [2100] },
+      cwdMap: { 1100: '/project/seed', 2100: '/project/relay' },
+      dimsMap: { 'dev:0.0': '80 24', 'dev:1.0': '200 50' },
+    });
+
+    const results = discoverAdoptableSessions();
+
+    expect(results).toHaveLength(2);
+    expect(results[0]!.cliId).toBe('seed');
+    expect(results[1]!.cliId).toBe('relay');
+  });
+
   it('should discover cursor-agent processes as Cursor sessions', () => {
     setupMocks({
       paneLines: 'cursor:0.0 1000\n',


### PR DESCRIPTION
## 背景

支持 Relay CLI。Relay 是 Seed 的新发行名（包名 `@bytedance-relay/claude-code`，命令 `relay`），区别不大，但单独提供一个适配器更清晰。

## 判断

Relay 内部与 Seed 完全同构：都是 Claude Code fork，把数据根隔离到安装包内的 `.claude-runtime`（认 `CLAUDE_CONFIG_DIR`），走 bytedcli / ByteCloud / SuperRelay 认证。所以新建的 `relay.ts` 是 `seed.ts` 的近镜像，复用整套 Claude 家族适配器（JSONL bridge / ready-hook / type-ahead / askUserQuestion hook 全继承），只换 `id` 与二进制名。作为独立 `CliId` 而非 seed 别名——它们是两个不同的 npm 包/二进制，用户可能装其一或两者都装。

## 改动

**新增适配器**（按 CLAUDE.md「添加新 CLI」清单全量接线）
- `src/adapters/cli/relay.ts`：id=`relay`，binary=`relay`，data root 同 `.claude-runtime` 推导
- CliId 联合类型 + registry import/switch/export
- worker / card-builder / bot-config-editor 三处展示名 = "Relay"，setup 序号 18（dashboard 下拉 + 终端级联选择自动带上，单一事实源）
- cost-calculator（usageKind + transcript 路径）、ask-hook registry（复用 claude）、dashboard CLI 过滤、两处 `RESUME_USES_SESSION_ID`、resumable-discovery 注释、README 中英

**顺手修 adopt-by-comm**
- `CLI_COMM_MAP` 补 `seed: 'seed'` + `relay: 'relay'`。实测 `/proc/<pid>/comm` 真值即 `seed`/`relay`（两 fork 都 rebrand `process.title`），之前漏登记导致 `/adopt` 无法按进程名发现正在跑的本地 pane。`filterCliId` 守卫保证 relay bot 只 adopt relay 会话，不串到 seed/claude。

## 测试

- 新增 `test/relay-adapter.test.ts`（12 测，镜像 seed-adapter 锁定 data-root 推导 / CLAUDE_CONFIG_DIR / .claude.json / resume handoff / Claude 家族继承）
- `session-discovery.test.ts` 加 seed/relay 按 comm 发现用例
- `tsc` 0 错；全量 unit **4521 通过**
