### PR TITLE
feat(cli): 内置支持 cjadk 网关 (cjadk claude/codex) + 非交互启动

### DIFF
--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -502,6 +502,11 @@ const BOTMUX_INJECTED_ENV_KEYS = [
   // Seed CLI（Claude Code fork）的数据根目录。worker 为 seed 注入它指向 seed 自己的
   // `.claude-runtime`，bridge 才能盯对文件；不进白名单 tmux pane 就拿不到。
   'CLAUDE_CONFIG_DIR',
+  // cjadk wrapperCli（`cjadk <agent>`）启动时 worker 注入 `0`，让 cjadk 跑非交互模式
+  // （跳过启动选择器、清掉吃首条/碎裂多行的输入怪癖），对齐 cjadk 官方 `cjadk feishu`
+  // wrapper。只有 cjadk 启动会被设上此值，其它 bot 不带 → 不进白名单 tmux pane 拿不到，
+  // cjadk 就回到交互模式（本次 bug 的根因）。
+  'CJADK_INTERACTIVE',
 ] as const;
 
 /**

--- a/src/setup/cli-selection.ts
+++ b/src/setup/cli-selection.ts
@@ -2,14 +2,20 @@
  * cli-selection.ts
  *
  * 单一事实源：把「用户可选的 CLI 形态」从「原始 cliId 列表」抽象成一层
- * **可级联的选择项**。除了原生 CLI，额外提供两个 aiden 网关形态：
+ * **可级联的选择项**。除了原生 CLI，额外提供若干网关形态：
  *   - Aiden × Claude → 底层 cliId=claude-code，启动前缀 `aiden x claude`
  *   - Aiden × Codex  → 底层 cliId=codex，启动前缀 `aiden x codex`
+ *   - CJADK × Claude → 底层 cliId=claude-code，启动前缀 `cjadk claude`
+ *   - CJADK × Codex  → 底层 cliId=codex，启动前缀 `cjadk codex`
  *
- * 这两个形态**不生成任何 wrapper 脚本**：通过 bot 配置的 `wrapperCli`（通用启动前缀）
+ * 这些形态**不生成任何 wrapper 脚本**：通过 bot 配置的 `wrapperCli`（通用启动前缀）
  * 实现——worker 在 spawn 时把启动命令拼成 `<wrapperCli> <CLI 参数>`（纯 argv，跨系统）。
- * `wrapperCli` 是通用机制（也能承载 ccr / claude-w 等），不止 aiden。见 worker.ts 的
+ * `wrapperCli` 是通用机制（也能承载 ccr / claude-w 等），不止 aiden / cjadk。见 worker.ts 的
  * wrapperCli 处理与 {@link buildWrappedLaunch} / {@link stripSettingsArgs}。
+ *
+ * aiden 与 cjadk 的差异：`aiden x claude` 不收 `--settings`（要剥掉），而 cjadk
+ * （`allowUnknownOption`）把全部 passthrough 参数原样转发给真正的 claude/codex，
+ * `--settings`（承载 bypass 键）必须保留，故不走剥离分支。
  *
  * 三处入口（终端 setup / 终端 bot 编辑 / dashboard 网页添加机器人）共用本模块：
  *   - 展示：`CLI_SELECT_OPTIONS`（扁平，web 下拉 + 非 TTY 回退）/ `CLI_SELECT_TREE`（级联，终端 TUI）
@@ -53,25 +59,46 @@ const AIDEN_X_CODEX: CliSelectOption = { key: 'aiden-x-codex', label: 'Aiden × 
 
 const AIDEN_VARIANTS: ReadonlyArray<CliSelectOption> = [AIDEN_NATIVE, AIDEN_X_CLAUDE, AIDEN_X_CODEX];
 
+// ─── cjadk 选项 ──────────────────────────────────────────────────────────────
+// cjadk 没有「原生 agent」模式，只是个装配启动器（`cjadk <agent>`），故只有 × 变体。
+
+const CJADK_X_CLAUDE: CliSelectOption = { key: 'cjadk-x-claude', label: 'CJADK × Claude', cliId: 'claude-code', wrapperCli: 'cjadk claude' };
+const CJADK_X_CODEX: CliSelectOption = { key: 'cjadk-x-codex', label: 'CJADK × Codex', cliId: 'codex', wrapperCli: 'cjadk codex' };
+
+const CJADK_VARIANTS: ReadonlyArray<CliSelectOption> = [CJADK_X_CLAUDE, CJADK_X_CODEX];
+
+/** 顶层 CLI 之外、纯 wrapperCli 网关分组（不对应任何原生 cliId），追加到树/列表末尾。 */
+const EXTRA_GATEWAY_GROUPS: ReadonlyArray<CliSelectGroup> = [
+  { key: 'cjadk', label: 'CJADK', children: CJADK_VARIANTS },
+];
+
 // ─── 扁平 / 级联 视图（均派生自 bot-config-editor 的 CLI_OPTIONS，避免再抄一份）──
 
 /**
- * 级联树（终端 TUI 用）：顺序同 CLI_OPTIONS；'aiden' 一项展开成 children。
+ * 级联树（终端 TUI 用）：顺序同 CLI_OPTIONS；'aiden' 一项展开成 children；
+ * 末尾追加无原生 cliId 的网关分组（CJADK）。
  */
-export const CLI_SELECT_TREE: ReadonlyArray<CliSelectGroup> = CLI_OPTIONS.map((o) =>
-  o.id === 'aiden'
-    ? { key: 'aiden', label: 'Aiden', children: AIDEN_VARIANTS }
-    : { key: o.id, label: o.label, option: { key: o.id, label: o.label, cliId: o.id } },
-);
+export const CLI_SELECT_TREE: ReadonlyArray<CliSelectGroup> = [
+  ...CLI_OPTIONS.map((o): CliSelectGroup =>
+    o.id === 'aiden'
+      ? { key: 'aiden', label: 'Aiden', children: AIDEN_VARIANTS }
+      : { key: o.id, label: o.label, option: { key: o.id, label: o.label, cliId: o.id } },
+  ),
+  ...EXTRA_GATEWAY_GROUPS,
+];
 
 /**
- * 扁平选项（web 下拉 + 非 TTY 回退用）：在 'aiden' 之后紧跟两个 aiden×* 项。
+ * 扁平选项（web 下拉 + 非 TTY 回退用）：'aiden' 之后紧跟两个 aiden×* 项，
+ * 末尾追加 cjadk×* 项。
  */
-export const CLI_SELECT_OPTIONS: ReadonlyArray<CliSelectOption> = CLI_OPTIONS.flatMap((o) =>
-  o.id === 'aiden'
-    ? AIDEN_VARIANTS
-    : [{ key: o.id, label: o.label, cliId: o.id }],
-);
+export const CLI_SELECT_OPTIONS: ReadonlyArray<CliSelectOption> = [
+  ...CLI_OPTIONS.flatMap((o) =>
+    o.id === 'aiden'
+      ? AIDEN_VARIANTS
+      : [{ key: o.id, label: o.label, cliId: o.id }],
+  ),
+  ...CJADK_VARIANTS,
+];
 
 const OPTION_BY_KEY: ReadonlyMap<string, CliSelectOption> = new Map(
   CLI_SELECT_OPTIONS.map((o) => [o.key, o]),

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -57,7 +57,7 @@ import {
   resolveRenderDimensions,
 } from './utils/render-dimensions.js';
 import { createCliAdapterSync, locateOnPath } from './adapters/cli/registry.js';
-import { buildWrappedLaunch } from './setup/cli-selection.js';
+import { buildWrappedLaunch, parseWrapperCli } from './setup/cli-selection.js';
 import { findLaunchedCliPid, scheduleWrapperRealCliPid } from './core/session-discovery.js';
 import { claudeJsonlPathForSession, resolveJsonlFromPid, findOpenClaudeSessionIds, DEFAULT_CLAUDE_DATA_DIR } from './adapters/cli/claude-code.js';
 import { mtrSessionIdForBotmuxSession } from './adapters/cli/mtr.js';
@@ -3784,6 +3784,19 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
         spawnBin = launch.bin;
         spawnArgs = launch.args;
         log(`Launch prefix: spawning ${spawnBin} ${spawnArgs.slice(0, 2).join(' ')} … (cliId=${cfg.cliId})`);
+        // cjadk runs its launched agent in an INTERACTIVE wrapper by default —
+        // a model/session selector at startup plus terminal quirks that fight
+        // botmux's automated input (the selector eats the first prompt; the
+        // pre-render lag fragments multi-line messages; follow-ups can stick in
+        // the input box). cjadk's own botmux integration (`cjadk feishu`, see its
+        // botmux-wrapper-writer) sets CJADK_INTERACTIVE=0 to disable all of that.
+        // We mirror it here so a `cjadk <agent>` wrapperCli is driven the way
+        // cjadk intends — no selector, clean soft-newline input. Keyed on the
+        // wrapper's leading token so only cjadk launches are affected.
+        if (parseWrapperCli(cfg.wrapperCli)[0] === 'cjadk') {
+          (childEnv as Record<string, string>).CJADK_INTERACTIVE = '0';
+          log('cjadk launcher: set CJADK_INTERACTIVE=0 (non-interactive, mirrors cjadk feishu wrapper)');
+        }
       }
     }
   }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3775,6 +3775,14 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   // bin 走 PATH 解析），无需 wrapper 脚本、跨系统。aiden x claude 形态会剥掉 aiden 拒收的
   // --settings（见 buildWrappedLaunch）。与文件沙盒互斥：沙盒已把命令重写成 bwrap，叠加
   // 前缀会破坏隔离，故 sandboxOn 时跳过并告警（网关 + oncall 沙盒本就不是合理组合）。
+  // CJADK_INTERACTIVE is a cjadk-only knob we set on the cjadk wrapper branch
+  // below. Strip any value inherited from the daemon's own env first so a
+  // daemon launched under `cjadk feishu` (which exports it) can't leak it via
+  // the tmux env allowlist into EVERY bot's pane — only the cjadk branch should
+  // ever (re)set it. Harmless for non-cjadk CLIs (they don't read it), but this
+  // keeps the behaviour intentional rather than ambient. (Codex review note.)
+  delete (childEnv as Record<string, string>).CJADK_INTERACTIVE;
+
   if (cfg.wrapperCli && cfg.wrapperCli.trim()) {
     if (sandboxOn) {
       log(`wrapperCli="${cfg.wrapperCli}" ignored: file sandbox enabled and takes precedence (cannot combine launch prefix with bwrap)`);

--- a/test/cli-selection.test.ts
+++ b/test/cli-selection.test.ts
@@ -23,6 +23,14 @@ describe('CLI_SELECT_OPTIONS / CLI_SELECT_TREE', () => {
     expect(keys[i + 2]).toBe('aiden-x-codex');
   });
 
+  it('appends the two cjadk gateway options after the native CLIs', () => {
+    const keys = CLI_SELECT_OPTIONS.map((o) => o.key);
+    expect(keys).toContain('cjadk-x-claude');
+    expect(keys).toContain('cjadk-x-codex');
+    const i = keys.indexOf('cjadk-x-claude');
+    expect(keys[i + 1]).toBe('cjadk-x-codex');
+  });
+
   it('keeps every plain CliId selectable by its own key', () => {
     expect(lookupCliSelection('claude-code')?.cliId).toBe('claude-code');
     expect(lookupCliSelection('codex')?.cliId).toBe('codex');
@@ -36,6 +44,12 @@ describe('CLI_SELECT_OPTIONS / CLI_SELECT_TREE', () => {
     const codex = CLI_SELECT_TREE.find((g) => g.key === 'codex');
     expect(codex?.option?.cliId).toBe('codex');
     expect(codex?.children).toBeUndefined();
+  });
+
+  it('cascades CJADK into a submenu of its two × variants', () => {
+    const cjadk = CLI_SELECT_TREE.find((g) => g.key === 'cjadk');
+    expect(cjadk?.children?.map((c) => c.key)).toEqual(['cjadk-x-claude', 'cjadk-x-codex']);
+    expect(cjadk?.option).toBeUndefined();
   });
 });
 
@@ -57,6 +71,14 @@ describe('resolveCliSelection', () => {
     expect(resolveCliSelection('aiden')).toEqual({ cliId: 'aiden' });
   });
 
+  it('maps cjadk×claude to claude-code + wrapperCli "cjadk claude"', () => {
+    expect(resolveCliSelection('cjadk-x-claude')).toEqual({ cliId: 'claude-code', wrapperCli: 'cjadk claude' });
+  });
+
+  it('maps cjadk×codex to codex + wrapperCli "cjadk codex"', () => {
+    expect(resolveCliSelection('cjadk-x-codex')).toEqual({ cliId: 'codex', wrapperCli: 'cjadk codex' });
+  });
+
   it('throws on an unknown key', () => {
     expect(() => resolveCliSelection('nope')).toThrow(/未知 CLI 选择项/);
   });
@@ -66,6 +88,11 @@ describe('selectionKeyForBot', () => {
   it('round-trips aiden gateway bots back to their selection key', () => {
     expect(selectionKeyForBot('claude-code', 'aiden x claude')).toBe('aiden-x-claude');
     expect(selectionKeyForBot('codex', 'aiden x codex')).toBe('aiden-x-codex');
+  });
+
+  it('round-trips cjadk gateway bots back to their selection key', () => {
+    expect(selectionKeyForBot('claude-code', 'cjadk claude')).toBe('cjadk-x-claude');
+    expect(selectionKeyForBot('codex', 'cjadk codex')).toBe('cjadk-x-codex');
   });
 
   it('falls back to cliId for plain bots or unrecognised prefixes', () => {
@@ -109,6 +136,18 @@ describe('buildWrappedLaunch', () => {
     const out = buildWrappedLaunch('aiden x codex', ['resume', 'cid', '--model', 'm']);
     expect(out.bin).toBe('aiden');
     expect(out.args).toEqual(['x', 'codex', 'resume', 'cid', '--model', 'm']);
+  });
+
+  it('keeps --settings for cjadk claude (forwarded verbatim to real claude)', () => {
+    const out = buildWrappedLaunch('cjadk claude', ['--session-id', 'sid', '--settings', '{}', '--plugin-dir', '/p']);
+    expect(out.bin).toBe('cjadk');
+    expect(out.args).toEqual(['claude', '--session-id', 'sid', '--settings', '{}', '--plugin-dir', '/p']);
+  });
+
+  it('prepends the prefix for cjadk codex', () => {
+    const out = buildWrappedLaunch('cjadk codex', ['resume', 'cid']);
+    expect(out.bin).toBe('cjadk');
+    expect(out.args).toEqual(['codex', 'resume', 'cid']);
   });
 
   it('works for a generic single-token prefix (ccr) without stripping --settings', () => {

--- a/test/tmux-backend-env.test.ts
+++ b/test/tmux-backend-env.test.ts
@@ -74,6 +74,21 @@ describe('buildBotmuxEnvAssignments()', () => {
     expect(out).not.toContain('PATH=/usr/bin');
   });
 
+  it('forwards CJADK_INTERACTIVE so cjadk runs non-interactive in the tmux pane', () => {
+    // The worker injects CJADK_INTERACTIVE=0 for `cjadk <agent>` wrapperCli
+    // launches (mirrors cjadk's own `cjadk feishu` wrapper). Like every other
+    // injected key it ONLY reaches the pane via this allowlist — without it the
+    // pane inherits an interactive cjadk (startup selector + input quirks).
+    const out = buildBotmuxEnvAssignments({
+      BOTMUX: '1',
+      CJADK_INTERACTIVE: '0',
+      PATH: '/usr/bin',
+    });
+    expect(out).toContain('CJADK_INTERACTIVE=0');
+    // Non-cjadk bots don't set it → it must not appear.
+    expect(buildBotmuxEnvAssignments({ BOTMUX: '1' }).some(s => s.startsWith('CJADK_INTERACTIVE='))).toBe(false);
+  });
+
   it('skips entries whose value is undefined (e.g. IS_SANDBOX outside root mode)', () => {
     const out = buildBotmuxEnvAssignments({
       BOTMUX: '1',


### PR DESCRIPTION
## 背景
参考 aiden 的接入方式，内置支持 cjadk（`cjadk claude` / `cjadk codex`）。

## 改动
1. **cli-selection**：新增 `CJADK × Claude` / `CJADK × Codex` 两个网关选择项，复用通用 `wrapperCli` 机制（启动前缀 `cjadk claude` / `cjadk codex`，纯 argv 跨系统，不生成 wrapper 脚本）。三处入口（终端 setup / bot 编辑 / dashboard 添加机器人）共用。与 `aiden x claude` 不同，cjadk 把 passthrough 参数原样转发给真 claude/codex，故 **不剥 `--settings`**。
2. **非交互启动（关键）**：cjadk 默认以**交互模式**启动其包装的 agent —— 弹模型/会话选择器，且终端有「吃掉首条 / 打碎多行 / follow-up 卡输入框」怪癖。对齐 cjadk 官方 botmux 集成（`cjadk feishu` 的 `botmux-wrapper-writer`，wrapper 第一行即 `export CJADK_INTERACTIVE=0`），worker 在 wrapperCli 首 token 为 `cjadk` 时给子进程注入 `CJADK_INTERACTIVE=0`。
3. **env 透传修复**：tmux 后端给 pane 注入 env 走白名单 `BOTMUX_INJECTED_ENV_KEYS`（经 `/usr/bin/env KEY=VAL ...` 落地），故把 `CJADK_INTERACTIVE` 加进白名单 —— 否则该 env 被丢弃、cjadk 仍跑交互态（开发中踩过的坑）。仅 cjadk 启动带值。

## 真机验证
- 全新 cjadk 会话：无启动选择器（~2.5s 就绪）、多行 + follow-up 软换行**干净提交零碎裂零卡死**（`/proc/<pid>/environ` 实测带 `CJADK_INTERACTIVE=0`）。
- 已知遗留（**不在本 PR 范围**）：cjadk gpt-5.5 网关版 claude 开终端鼠标追踪（DECSET 1003）→ 网页终端滚轮滚不动，与本改动无关（native claude 不开；`CJADK_INTERACTIVE=0` 不影响该标志），后续单独处理。

## 测试
- 新增/更新 `test/cli-selection.test.ts` + `test/tmux-backend-env.test.ts`；全量 unit 4517 绿，tsc 0 报错。