### PR TITLE
fix(repo): 中途 /repo 切库给被顶替的旧会话补「已关闭」卡片

### DIFF
--- a/src/core/closed-session-card.ts
+++ b/src/core/closed-session-card.ts
@@ -1,0 +1,43 @@
+import { getBot } from '../bot-registry.js';
+import { createCliAdapterSync } from '../adapters/cli/registry.js';
+import { decorateResumeForWrapper } from '../setup/cli-selection.js';
+import { buildSessionClosedCard } from '../im/lark/card-builder.js';
+import { sessionAnchorId, type DaemonSession } from './types.js';
+import type { Locale } from '../i18n/index.js';
+
+/**
+ * Build the same "session closed" card `/close` emits for a session that is
+ * about to be displaced (e.g. a mid-session `/repo` switch reuses the SAME
+ * anchor for a fresh session). Without this trace the old context vanishes —
+ * relay/adopt/resume all hit `anchor_occupied` once the new session holds the
+ * anchor — so the card keeps it visible and carries the terminal
+ * `claude --resume` command as the real recovery path.
+ *
+ * MUST be called BEFORE killWorker/closeSession: it reads the live session's
+ * identity (sessionId, cliSessionId, title, workingDir, anchor) straight off
+ * `ds`. Returns the card JSON; the caller decides how to deliver it.
+ */
+export function buildClosedSessionCard(ds: DaemonSession, locale: Locale): string {
+  const botCfg = getBot(ds.larkAppId).config;
+  const closedSessionId = ds.session.sessionId;
+  const closedCliId = ds.session.cliId ?? botCfg.cliId;
+  const cliResumeCommand = (() => {
+    try {
+      const adapter = createCliAdapterSync(closedCliId, botCfg.cliPathOverride);
+      const raw = adapter.buildResumeCommand?.({
+        sessionId: closedSessionId,
+        cliSessionId: ds.session.cliSessionId,
+      }) ?? null;
+      return raw ? decorateResumeForWrapper(raw, botCfg.wrapperCli) : null;
+    } catch { return null; }
+  })();
+  return buildSessionClosedCard(
+    closedSessionId,
+    sessionAnchorId(ds),
+    ds.session.title,
+    closedCliId,
+    ds.session.workingDir,
+    cliResumeCommand,
+    locale,
+  );
+}

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -13,7 +13,7 @@ import * as scheduleStore from '../services/schedule-store.js';
 import * as scheduler from './scheduler.js';
 import { scanProjects, scanMultipleProjects, describeProjectDir } from '../services/project-scanner.js';
 import { createRepoWorktree } from '../services/git-worktree.js';
-import { buildRepoSelectCard, buildAdoptSelectCard, buildCodexAppThreadSelectCard, buildSessionClosedCard, buildSlashListCard, getCliDisplayName, buildConfigCard, buildLandCard } from '../im/lark/card-builder.js';
+import { buildRepoSelectCard, buildAdoptSelectCard, buildCodexAppThreadSelectCard, buildSlashListCard, getCliDisplayName, buildConfigCard, buildLandCard } from '../im/lark/card-builder.js';
 import { computeSandboxDiff } from '../services/sandbox-land.js';
 import { createCliAdapterSync } from '../adapters/cli/registry.js';
 import type { CliId, ResumableSession } from '../adapters/cli/types.js';
@@ -41,7 +41,7 @@ import {
   applyConfigField, setBotAllowedUsers, getConfigSnapshot, getConfigCardData, type ConfigEffect,
 } from '../services/bot-config-store.js';
 import { resolveCliId, findInvalidAllowedUserEntries } from '../setup/bot-config-editor.js';
-import { decorateResumeForWrapper } from '../setup/cli-selection.js';
+import { buildClosedSessionCard } from './closed-session-card.js';
 import { publishAttentionPatch, announcePendingRepoSession } from './session-activity.js';
 import { setCardMode } from '../services/card-mode-store.js';
 import { canOperate } from '../im/lark/event-dispatcher.js';
@@ -904,34 +904,12 @@ export async function handleCommand(
     switch (cmd) {
       case '/close': {
         if (ds) {
-          const closedSessionId = ds.session.sessionId;
-          const closedTitle = ds.session.title;
-          const botCfg = getBot(ds.larkAppId).config;
-          const closedCliId = ds.session.cliId ?? botCfg.cliId;
-          const closedAnchor = sessionAnchorId(ds);
-          const closedWorkingDir = ds.session.workingDir;
-          const cliResumeCommand = (() => {
-            try {
-              const adapter = createCliAdapterSync(closedCliId, botCfg.cliPathOverride);
-              const raw = adapter.buildResumeCommand?.({
-                sessionId: closedSessionId,
-                cliSessionId: ds.session.cliSessionId,
-              }) ?? null;
-              return raw ? decorateResumeForWrapper(raw, botCfg.wrapperCli) : null;
-            } catch { return null; }
-          })();
+          // Capture the closed-session card BEFORE killWorker/closeSession —
+          // it reads the live session's identity off `ds`.
+          const card = buildClosedSessionCard(ds, loc);
           killWorker(ds);
-          sessionStore.closeSession(closedSessionId);
+          sessionStore.closeSession(ds.session.sessionId);
           activeSessions.delete(sessionKey(rootId, larkAppId!));
-          const card = buildSessionClosedCard(
-            closedSessionId,
-            closedAnchor,
-            closedTitle,
-            closedCliId,
-            closedWorkingDir,
-            cliResumeCommand,
-            loc,
-          );
           // 「会话已关闭」卡片优先「仅自己可见」：普通群里走 ephemeral 只发给执行
           // /close 的本人；话题群不支持 ephemeral(18053) 时回退为正常的群内可见回复
           // ——与流式卡片上「关闭会话」按钮的送达方式保持一致。
@@ -1162,35 +1140,9 @@ export async function handleCommand(
             // still hits anchor_occupied while the new session occupies this
             // anchor — expected; `/close` the new one first, or use the
             // command.) Mirrors the `/close` case above.
-            const closedSessionId = ds!.session.sessionId;
-            const closedTitle = ds!.session.title;
-            const oldBotCfg = getBot(ds!.larkAppId).config;
-            const closedCliId = ds!.session.cliId ?? oldBotCfg.cliId;
-            const closedAnchor = sessionAnchorId(ds!);
-            const closedWorkingDir = ds!.session.workingDir;
-            const cliResumeCommand = (() => {
-              try {
-                const adapter = createCliAdapterSync(closedCliId, oldBotCfg.cliPathOverride);
-                const raw = adapter.buildResumeCommand?.({
-                  sessionId: closedSessionId,
-                  cliSessionId: ds!.session.cliSessionId,
-                }) ?? null;
-                return raw ? decorateResumeForWrapper(raw, oldBotCfg.wrapperCli) : null;
-              } catch { return null; }
-            })();
-
+            const closedCard = buildClosedSessionCard(ds!, loc);
             killWorker(ds!);
-            sessionStore.closeSession(closedSessionId);
-
-            const closedCard = buildSessionClosedCard(
-              closedSessionId,
-              closedAnchor,
-              closedTitle,
-              closedCliId,
-              closedWorkingDir,
-              cliResumeCommand,
-              loc,
-            );
+            sessionStore.closeSession(ds!.session.sessionId);
             await deliverEphemeralOrReply(
               ds!,
               message.senderId,

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -1123,11 +1123,11 @@ export async function handleCommand(
         // close + recreate the session (mid-session switch). Used by both the
         // numeric `/repo <N>` form and the `/repo <path|name>` form.
         const commitRepoSelection = async (selectedPath: string, displayName: string, how: string) => {
-          ds!.workingDir = selectedPath;
-          ds!.session.workingDir = selectedPath;
-          sessionStore.updateSession(ds!.session);
-
           if (ds!.pendingRepo) {
+            // First spawn: pin the new cwd onto the CURRENT session, then fork.
+            ds!.workingDir = selectedPath;
+            ds!.session.workingDir = selectedPath;
+            sessionStore.updateSession(ds!.session);
             await forkPendingCli(t('cmd.repo.selected_in_pending', { name: displayName }, loc));
           } else {
             // Safety net: a mid-session `/repo` switch closes the running
@@ -1140,6 +1140,12 @@ export async function handleCommand(
             // still hits anchor_occupied while the new session occupies this
             // anchor — expected; `/close` the new one first, or use the
             // command.) Mirrors the `/close` case above.
+            //
+            // The new cwd is NOT written onto the old session here — it would
+            // pollute the displaced session's stored workingDir (and the closed
+            // card), so `claude --resume` later would reopen the old context in
+            // the new repo's cwd. The new repo is pinned onto the fresh session
+            // below instead.
             const closedCard = buildClosedSessionCard(ds!, loc);
             killWorker(ds!);
             sessionStore.closeSession(ds!.session.sessionId);
@@ -1155,6 +1161,7 @@ export async function handleCommand(
             ds!.session = session;
             ds!.lastUserPrompt = undefined;
             ds!.lastCliInput = undefined;
+            ds!.workingDir = selectedPath;
             ds!.session.workingDir = selectedPath;
             ds!.session.larkAppId = ds!.larkAppId;
             sessionStore.updateSession(ds!.session);

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -1152,8 +1152,53 @@ export async function handleCommand(
           if (ds!.pendingRepo) {
             await forkPendingCli(t('cmd.repo.selected_in_pending', { name: displayName }, loc));
           } else {
+            // Safety net: a mid-session `/repo` switch closes the running
+            // session and spawns a fresh one on the SAME anchor. Without a
+            // trace, the old context silently vanishes (relay/adopt/resume all
+            // hit `anchor_occupied` once the new session holds the anchor).
+            // So, before displacing it, post the same "session closed" card
+            // `/close` emits — it keeps the old session visible and carries the
+            // terminal `claude --resume` command. (Its in-card resume button
+            // still hits anchor_occupied while the new session occupies this
+            // anchor — expected; `/close` the new one first, or use the
+            // command.) Mirrors the `/close` case above.
+            const closedSessionId = ds!.session.sessionId;
+            const closedTitle = ds!.session.title;
+            const oldBotCfg = getBot(ds!.larkAppId).config;
+            const closedCliId = ds!.session.cliId ?? oldBotCfg.cliId;
+            const closedAnchor = sessionAnchorId(ds!);
+            const closedWorkingDir = ds!.session.workingDir;
+            const cliResumeCommand = (() => {
+              try {
+                const adapter = createCliAdapterSync(closedCliId, oldBotCfg.cliPathOverride);
+                const raw = adapter.buildResumeCommand?.({
+                  sessionId: closedSessionId,
+                  cliSessionId: ds!.session.cliSessionId,
+                }) ?? null;
+                return raw ? decorateResumeForWrapper(raw, oldBotCfg.wrapperCli) : null;
+              } catch { return null; }
+            })();
+
             killWorker(ds!);
-            sessionStore.closeSession(ds!.session.sessionId);
+            sessionStore.closeSession(closedSessionId);
+
+            const closedCard = buildSessionClosedCard(
+              closedSessionId,
+              closedAnchor,
+              closedTitle,
+              closedCliId,
+              closedWorkingDir,
+              cliResumeCommand,
+              loc,
+            );
+            await deliverEphemeralOrReply(
+              ds!,
+              message.senderId,
+              closedCard,
+              'interactive',
+              () => sessionReply(rootId, closedCard, 'interactive'),
+            );
+
             const session = sessionStore.createSession(ds!.chatId, rootId, displayName, ds!.chatType);
             ds!.session = session;
             ds!.lastUserPrompt = undefined;

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -9,7 +9,7 @@ import { config } from '../../config.js';
 import { getBot, getAllBots, getOwnerOpenId } from '../../bot-registry.js';
 import { canOperate, canTalk } from './event-dispatcher.js';
 import { updateMessage, deleteMessage, replyMessage, sendMessage, sendUserMessage, sendEphemeralCard, getMessageDetail, isHumanOpenId } from './client.js';
-import { buildSessionCard, buildStreamingCard, buildTuiPromptCard, buildTuiPromptProcessingCard, buildTuiPromptResolvedCard, buildSessionClosedCard, buildGrantResultCard, buildGrantNotifyCard, getCliDisplayName, truncateContent, buildConfigCard, buildConfigTextCard, CONFIG_UNSET, buildLandResultCard } from './card-builder.js';
+import { buildSessionCard, buildStreamingCard, buildTuiPromptCard, buildTuiPromptProcessingCard, buildTuiPromptResolvedCard, buildGrantResultCard, buildGrantNotifyCard, getCliDisplayName, truncateContent, buildConfigCard, buildConfigTextCard, CONFIG_UNSET, buildLandResultCard } from './card-builder.js';
 import { computeSandboxDiff, applySandboxDiff } from '../../services/sandbox-land.js';
 import { findConfigField, applyConfigField, coerceConfigValue, getConfigCardData } from '../../services/bot-config-store.js';
 import { updateBotGrantPrefs } from '../../services/grant-prefs-store.js';
@@ -24,7 +24,7 @@ import {
 } from './workflow-card-handler.js';
 import { handleAskCardAction, isAskCardAction } from './ask-card.js';
 import { createCliAdapterSync } from '../../adapters/cli/registry.js';
-import { decorateResumeForWrapper } from '../../setup/cli-selection.js';
+import { buildClosedSessionCard } from '../../core/closed-session-card.js';
 import { logger } from '../../utils/logger.js';
 import * as sessionStore from '../../services/session-store.js';
 import { loadFrozenCards, saveFrozenCards } from '../../services/frozen-card-store.js';
@@ -242,28 +242,13 @@ async function commitRepoSelection(
     logger.info(`[${tag(ds)}] Repo selected: ${dirPath}, spawning CLI`);
   } else {
     // Mid-session repo switch — close old session, start fresh.
-    // Safety net (mirrors the `/repo` text-command path): capture the old
-    // session's identity BEFORE displacing it so we can post the same
-    // "session closed" card `/close` emits. The new session reuses this
-    // anchor, so the old context would otherwise vanish without a trace
+    // Safety net (mirrors the `/repo` text-command path): build the same
+    // "session closed" card `/close` emits BEFORE displacing the old session
+    // (it reads the live session's identity off `ds`). The new session reuses
+    // this anchor, so the old context would otherwise vanish without a trace
     // (relay/adopt/resume all hit `anchor_occupied`). The card keeps it
     // visible and carries the terminal `claude --resume` command.
-    const closedSessionId = ds.session.sessionId;
-    const closedTitle = ds.session.title;
-    const oldBotCfg = getBot(ds.larkAppId).config;
-    const closedCliId = sessionCliId(ds);
-    const closedAnchor = sessionAnchorId(ds);
-    const closedWorkingDir = ds.session.workingDir;
-    const cliResumeCommand = (() => {
-      try {
-        const adapter = createCliAdapterSync(closedCliId, oldBotCfg.cliPathOverride);
-        const raw = adapter.buildResumeCommand?.({
-          sessionId: closedSessionId,
-          cliSessionId: ds.session.cliSessionId,
-        }) ?? null;
-        return raw ? decorateResumeForWrapper(raw, oldBotCfg.wrapperCli) : null;
-      } catch { return null; }
-    })();
+    const closedCard = buildClosedSessionCard(ds, locTarget);
 
     killWorker(ds);
     // Park the current card in `frozenCards` so the next POST under the new
@@ -275,15 +260,6 @@ async function commitRepoSelection(
     parkStreamCard(ds);
     sessionStore.closeSession(ds.session.sessionId);
 
-    const closedCard = buildSessionClosedCard(
-      closedSessionId,
-      closedAnchor,
-      closedTitle,
-      closedCliId,
-      closedWorkingDir,
-      cliResumeCommand,
-      locTarget,
-    );
     await deliverEphemeralOrReply(
       ds,
       operatorOpenId,
@@ -967,34 +943,13 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     }
 
     if (actionType === 'close' && ds) {
-      const closedSessionId = ds.session.sessionId;
-      const closedTitle = ds.session.title;
       const botCfg = getBot(ds.larkAppId).config;
-      const closedCliId = ds.session.cliId ?? botCfg.cliId;
-      const closedAnchor = sessionAnchorId(ds);
-      const closedWorkingDir = ds.session.workingDir;
-      const cliResumeCommand = (() => {
-        try {
-          const adapter = createCliAdapterSync(closedCliId, botCfg.cliPathOverride);
-          const raw = adapter.buildResumeCommand?.({
-            sessionId: closedSessionId,
-            cliSessionId: ds.session.cliSessionId,
-          }) ?? null;
-          return raw ? decorateResumeForWrapper(raw, botCfg.wrapperCli) : null;
-        } catch { return null; }
-      })();
+      // Build the closed card BEFORE killWorker/closeSession — it reads the
+      // live session's identity off `ds`.
+      const card = buildClosedSessionCard(ds, localeForBot(ds.larkAppId));
       killWorker(ds);
-      sessionStore.closeSession(closedSessionId);
+      sessionStore.closeSession(ds.session.sessionId);
       activeSessions.delete(sKey);
-      const card = buildSessionClosedCard(
-        closedSessionId,
-        closedAnchor,
-        closedTitle,
-        closedCliId,
-        closedWorkingDir,
-        cliResumeCommand,
-        localeForBot(ds.larkAppId),
-      );
       // The closed card carries session title / CLI name / workingDir / resume
       // command. In private-card mode those must not leak to the group — send the
       // closed card ephemeral to the same owner audience instead. No group
@@ -1566,7 +1521,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       const selectedPath = validation.resolvedPath;
       const displayName = pathBasename(selectedPath) || selectedPath;
       await commitRepoSelection(
-        { ds, rootId, cardMessageId, larkAppId, activeSessions, sessionReply },
+        { ds, rootId, cardMessageId, larkAppId, operatorOpenId, activeSessions, sessionReply },
         selectedPath,
         displayName,
       );

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -177,11 +177,12 @@ async function commitRepoSelection(
   const repoSessionKey = larkAppId ? sessionKey(rootId, larkAppId) : rootId;
   const sessionStillActive = () => activeSessions.get(repoSessionKey) === ds;
   const commitGenSessionId = ds.session.sessionId;
-  ds.workingDir = dirPath;
-  ds.session.workingDir = dirPath;
-  sessionStore.updateSession(ds.session);
 
   if (ds.pendingRepo) {
+    // First spawn: pin the new cwd onto the CURRENT session before forking.
+    ds.workingDir = dirPath;
+    ds.session.workingDir = dirPath;
+    sessionStore.updateSession(ds.session);
     const selfBot = getBot(ds.larkAppId);
     const botCfg = selfBot.config;
     const effectiveCliId = sessionCliId(ds);
@@ -248,6 +249,11 @@ async function commitRepoSelection(
     // this anchor, so the old context would otherwise vanish without a trace
     // (relay/adopt/resume all hit `anchor_occupied`). The card keeps it
     // visible and carries the terminal `claude --resume` command.
+    //
+    // The new cwd is NOT written onto the old session here — it would pollute
+    // the displaced session's stored workingDir (and the closed card), so
+    // `claude --resume` later would reopen the old context in the new repo's
+    // cwd. The new repo is pinned onto the fresh session below instead.
     const closedCard = buildClosedSessionCard(ds, locTarget);
 
     killWorker(ds);
@@ -277,6 +283,7 @@ async function commitRepoSelection(
     // workingDir and the worker spawns in the bot's default cwd, so
     // `claude --resume` looks in the wrong .claude/projects/<hash>/ dir and
     // exits code 0 immediately, crash-looping until the rate-limiter trips.
+    ds.workingDir = dirPath;
     ds.session.workingDir = dirPath;
     ds.session.larkAppId = ds.larkAppId;
     sessionStore.updateSession(ds.session);

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -158,6 +158,7 @@ async function commitRepoSelection(
     rootId: string;
     cardMessageId?: string;
     larkAppId?: string;
+    operatorOpenId?: string;
     activeSessions: Map<string, DaemonSession>;
     sessionReply: (rid: string, content: string, msgType?: string, turnId?: string) => Promise<string>;
   },
@@ -168,7 +169,7 @@ async function commitRepoSelection(
   // confirmation so the user sees a single message, not two.
   opts?: { suppressConfirmReply?: boolean },
 ): Promise<void> {
-  const { ds, rootId, cardMessageId, larkAppId, activeSessions, sessionReply } = ctx;
+  const { ds, rootId, cardMessageId, larkAppId, operatorOpenId, activeSessions, sessionReply } = ctx;
   const locTarget = localeForBot(ds.larkAppId);
   // `/close` deletes the active-map entry without touching sessionId or
   // pendingRepo — identity against the map is the only tell that the session
@@ -241,6 +242,29 @@ async function commitRepoSelection(
     logger.info(`[${tag(ds)}] Repo selected: ${dirPath}, spawning CLI`);
   } else {
     // Mid-session repo switch — close old session, start fresh.
+    // Safety net (mirrors the `/repo` text-command path): capture the old
+    // session's identity BEFORE displacing it so we can post the same
+    // "session closed" card `/close` emits. The new session reuses this
+    // anchor, so the old context would otherwise vanish without a trace
+    // (relay/adopt/resume all hit `anchor_occupied`). The card keeps it
+    // visible and carries the terminal `claude --resume` command.
+    const closedSessionId = ds.session.sessionId;
+    const closedTitle = ds.session.title;
+    const oldBotCfg = getBot(ds.larkAppId).config;
+    const closedCliId = sessionCliId(ds);
+    const closedAnchor = sessionAnchorId(ds);
+    const closedWorkingDir = ds.session.workingDir;
+    const cliResumeCommand = (() => {
+      try {
+        const adapter = createCliAdapterSync(closedCliId, oldBotCfg.cliPathOverride);
+        const raw = adapter.buildResumeCommand?.({
+          sessionId: closedSessionId,
+          cliSessionId: ds.session.cliSessionId,
+        }) ?? null;
+        return raw ? decorateResumeForWrapper(raw, oldBotCfg.wrapperCli) : null;
+      } catch { return null; }
+    })();
+
     killWorker(ds);
     // Park the current card in `frozenCards` so the next POST under the new
     // session sweeps it via recall. closeSession() wipes the on-disk
@@ -250,6 +274,24 @@ async function commitRepoSelection(
     // stays in the thread instead of vanishing prematurely.
     parkStreamCard(ds);
     sessionStore.closeSession(ds.session.sessionId);
+
+    const closedCard = buildSessionClosedCard(
+      closedSessionId,
+      closedAnchor,
+      closedTitle,
+      closedCliId,
+      closedWorkingDir,
+      cliResumeCommand,
+      locTarget,
+    );
+    await deliverEphemeralOrReply(
+      ds,
+      operatorOpenId,
+      closedCard,
+      'interactive',
+      () => sessionReply(rootId, closedCard, 'interactive'),
+    );
+
     const session = sessionStore.createSession(ds.chatId, rootId, dirLabel, ds.chatType);
     ds.session = session;
     ds.lastUserPrompt = undefined;
@@ -1726,7 +1768,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
   // Shared commit context for a resolved directory — funnels the dropdown,
   // worktree and manual-entry flows through the same module-level
   // commitRepoSelection (pin dir, then fork pending CLI or close+recreate).
-  const commitCtx = { ds: targetDs, rootId, cardMessageId, larkAppId, activeSessions, sessionReply };
+  const commitCtx = { ds: targetDs, rootId, cardMessageId, larkAppId, operatorOpenId, activeSessions, sessionReply };
 
   if (isWorktreeOpen) {
     // Worktree creation involves a `git fetch` that can take many seconds —

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -220,6 +220,7 @@ describe('repo select card — plain switch', () => {
 
   it('mid-session selection closes the old session and forks a fresh one', async () => {
     const ds = makeDs(); // no pendingRepo
+    ds.session.workingDir = '/repos/gamma'; // old session's actual repo
     const { deps, sessionReply } = makeDeps(ds);
 
     await handleCardAction(makeSelectEvent('repo_switch', '/repos/beta'), deps, APP_ID);
@@ -227,6 +228,7 @@ describe('repo select card — plain switch', () => {
     expect(killWorker).toHaveBeenCalledTimes(1);
     expect(closeSession).toHaveBeenCalledWith('uuid-old');
     expect(ds.session.sessionId).toMatch(/^uuid-new-/);
+    expect(ds.workingDir).toBe('/repos/beta');
     expect(ds.session.workingDir).toBe('/repos/beta');
     expect(forkWorker).toHaveBeenCalledTimes(1);
     expect(vi.mocked(forkWorker).mock.calls[0]![1]).toBe('');
@@ -236,6 +238,10 @@ describe('repo select card — plain switch', () => {
     expect(deliverEphemeralOrReply).toHaveBeenCalledTimes(1);
     const closedCard = vi.mocked(deliverEphemeralOrReply).mock.calls[0]![2] as string;
     expect(closedCard).toContain('uuid-old');
+    // Regression guard: the closed card must carry the OLD session's repo, NOT
+    // the switch target — otherwise `claude --resume` reopens it in the wrong cwd.
+    expect(closedCard).toContain('gamma');
+    expect(closedCard).not.toContain('beta');
   });
 });
 

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -103,7 +103,7 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
 // ─── Imports ──────────────────────────────────────────────────────────────
 
 import { handleCardAction, type CardHandlerDeps } from '../src/im/lark/card-handler.js';
-import { forkWorker, killWorker } from '../src/core/worker-pool.js';
+import { forkWorker, killWorker, deliverEphemeralOrReply } from '../src/core/worker-pool.js';
 import { getAvailableBots } from '../src/core/session-manager.js';
 import { createSession, closeSession } from '../src/services/session-store.js';
 import { createRepoWorktree } from '../src/services/git-worktree.js';
@@ -214,6 +214,8 @@ describe('repo select card — plain switch', () => {
     expect(vi.mocked(forkWorker).mock.calls[0]![1]).toBe('mock-prompt');
     expect(sessionReply.mock.calls.map(c => c[1]).join()).toContain('已选择');
     expect(killWorker).not.toHaveBeenCalled();
+    // First-spawn (pendingRepo) closes nothing, so no "session closed" card.
+    expect(deliverEphemeralOrReply).not.toHaveBeenCalled();
   });
 
   it('mid-session selection closes the old session and forks a fresh one', async () => {
@@ -229,6 +231,11 @@ describe('repo select card — plain switch', () => {
     expect(forkWorker).toHaveBeenCalledTimes(1);
     expect(vi.mocked(forkWorker).mock.calls[0]![1]).toBe('');
     expect(sessionReply.mock.calls.map(c => c[1]).join()).toContain('已切换');
+    // The displaced session gets a "session closed" card (Option C safety net)
+    // so its context stays visible/recoverable instead of vanishing silently.
+    expect(deliverEphemeralOrReply).toHaveBeenCalledTimes(1);
+    const closedCard = vi.mocked(deliverEphemeralOrReply).mock.calls[0]![2] as string;
+    expect(closedCard).toContain('uuid-old');
   });
 });
 


### PR DESCRIPTION
## 问题
会话运行中用 `/repo` 切到另一个库时,旧会话被关闭、新会话**复用同一个 anchor**(thread=rootMessageId / chat=chatId)。因 `sessionKey = anchor::larkAppId` 与旧会话完全相同,旧会话在飞书里**无法恢复**——`resumeSession` 命中 `anchor_occupied`,relay/adopt 也找不到它,旧上下文静默消失。**与 scope 无关**:话题、私聊、普通群都会触发(普通群里顶掉的是全群共享会话,影响更大)。

## 修复(方案 C — 安全网)
在顶替旧会话前,发一张与 `/close` 同款的「会话已关闭」卡片:
- 保留旧会话的**可见入口**,并携带终端 `claude --resume` 命令作为兜底恢复方式。
- 两条切库路径各补一处,行为一致:
  - 文本命令:`command-handler.ts` 的 `commitRepoSelection`
  - 卡片按钮:`card-handler.ts` 的 `commitRepoSelection`(新增 `operatorOpenId` 以支持 ephemeral 投递)

## 已知限制
卡内「恢复」按钮在新会话仍占用该 anchor 期间会命中 `anchor_occupied`——需先 `/close` 新会话,或直接用卡片里的 `claude --resume` 命令。彻底顺滑的「切库即开新话题(旧会话保持开着)」作为后续方案。

## 测试
- 更新 `test/card-handler-repo-select.test.ts`:中途切换断言发出关闭卡(`deliverEphemeralOrReply` 携带旧 sessionId);首次选库(pendingRepo)断言不发关闭卡。
- `tsc` 编译通过;`card-handler-repo-select` / `command-handler` 等相关单测全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)