### PR TITLE
fix(codex): 修复 botmux send 找不到 session id

### DIFF
--- a/src/adapters/cli/codex.ts
+++ b/src/adapters/cli/codex.ts
@@ -125,15 +125,7 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
   return {
     id: 'codex',
     authPaths: ['~/.codex/auth.json'],
-    get resolvedBin() { return cachedBin ??= resolveCommand(rawBin); },
-
-    sandboxExtraExecPaths() {
-      return [(cachedBin ??= resolveCommand(rawBin))];
-    },
-
-    versionCommand() {
-      return { bin: (cachedBin ??= resolveCommand(rawBin)), args: ['--version'] };
-    },
+    get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, resumeSessionId, workingDir, model, disableCliBypass }) {
       const baseArgs = [

--- a/src/adapters/cli/codex.ts
+++ b/src/adapters/cli/codex.ts
@@ -125,12 +125,22 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
   return {
     id: 'codex',
     authPaths: ['~/.codex/auth.json'],
-    get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
+    get resolvedBin() { return cachedBin ??= resolveCommand(rawBin); },
+
+    sandboxExtraExecPaths() {
+      return [(cachedBin ??= resolveCommand(rawBin))];
+    },
+
+    versionCommand() {
+      return { bin: (cachedBin ??= resolveCommand(rawBin)), args: ['--version'] };
+    },
 
     buildArgs({ sessionId, resume, resumeSessionId, workingDir, model, disableCliBypass }) {
       const baseArgs = [
         ...(!disableCliBypass ? ['--dangerously-bypass-approvals-and-sandbox'] : []),
         '--no-alt-screen',
+        '-c',
+        `shell_environment_policy.set.BOTMUX_SESSION_ID=${JSON.stringify(sessionId)}`,
       ];
       if (model && model.trim()) {
         // Codex 接受 `--model <id>` / `-m <id>`，写全名最稳，错的会在 codex 自己启动时报。
@@ -140,11 +150,13 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
       const freshArgs = workingDir
         ? [...baseArgs, '-C', workingDir]
         : baseArgs;
-      if (!resume) return freshArgs;
-
-      const codexSessionId = resumeSessionId ?? latestCodexSessionForBotmuxSession(sessionId);
-      if (!codexSessionId) return freshArgs;
-      return ['resume', ...baseArgs, codexSessionId];
+      const codexSessionId = resume
+        ? resumeSessionId ?? latestCodexSessionForBotmuxSession(sessionId)
+        : undefined;
+      const codexArgs = codexSessionId
+        ? ['resume', ...baseArgs, codexSessionId]
+        : freshArgs;
+      return codexArgs;
     },
 
     buildResumeCommand({ sessionId, cliSessionId }) {

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -72,11 +72,12 @@ describe('createCliAdapterSync factory', () => {
 // ---------------------------------------------------------------------------
 
 describe('lazy binary resolution', () => {
-  // Adapters whose resolvedBin is the resolved CLI (codex-app/mira use
-  // process.execPath and never probe, so they're excluded).
-  const PROBING_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'cursor', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes', 'traex', 'copilot'];
+  // Direct CLI adapters resolve their actual executable lazily. Runner-backed
+  // adapters (codex-app/mira) intentionally use process.execPath and are covered
+  // by their own buildArgs tests below.
+  const DIRECT_CLI_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'cursor', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes', 'traex', 'copilot'];
 
-  it.each(PROBING_IDS)('"%s": construction does not probe; first resolvedBin read does', async (id) => {
+  it.each(DIRECT_CLI_IDS)('"%s": construction does not probe; first resolvedBin read does', async (id) => {
     const { spawnSync } = await import('node:child_process');
     const probe = vi.mocked(spawnSync);
     probe.mockClear();
@@ -96,6 +97,19 @@ describe('lazy binary resolution', () => {
     void adapter.resolvedBin; // resolve + cache
     probe.mockClear();
     void adapter.resolvedBin; // cached → no probe
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it('codex buildArgs reuses the lazily resolved CLI path', async () => {
+    const { spawnSync } = await import('node:child_process');
+    const probe = vi.mocked(spawnSync);
+    probe.mockClear();
+    const adapter = createCliAdapterSync('codex');
+    expect(probe).not.toHaveBeenCalled();
+    void adapter.resolvedBin;
+    expect(probe).toHaveBeenCalled();
+    probe.mockClear();
+    adapter.buildArgs({ sessionId: 's', resume: false });
     expect(probe).not.toHaveBeenCalled();
   });
 
@@ -252,7 +266,32 @@ describe('coco buildArgs', () => {
 describe('codex buildArgs', () => {
   const adapter = createCodexAdapter('/usr/bin/codex');
 
-  it('always returns fixed args regardless of session/resume', () => {
+  it('spawns the Codex binary directly', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-4', resume: false });
+    expect(adapter.resolvedBin).toBe('/usr/bin/codex');
+    expect(args[0]).toBe('--dangerously-bypass-approvals-and-sandbox');
+    expect(args).not.toContain('--codex-bin');
+  });
+
+  it('injects botmux session id through Codex shell environment policy', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-4', resume: false });
+    const idx = args.indexOf('-c');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(args[idx + 1]).toBe('shell_environment_policy.set.BOTMUX_SESSION_ID="sess-4"');
+  });
+
+  it('does not inject a stale turn id into Codex shell environment policy', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-4', resume: false });
+    expect(args.join('\n')).not.toContain('BOTMUX_TURN_ID');
+  });
+
+  it('keeps Codex home untouched', () => {
+    expect(adapter.buildSpawnEnv).toBeUndefined();
+    expect(adapter.authPaths).toEqual(['~/.codex/auth.json']);
+    expect(adapter.skillsDir).toBe('~/.codex/skills');
+  });
+
+  it('passes fixed Codex args regardless of session/resume when no resume target is known', () => {
     const args1 = adapter.buildArgs({ sessionId: 'sess-4', resume: false });
     const args2 = adapter.buildArgs({ sessionId: 'sess-4', resume: true });
     expect(args1).toEqual(args2);
@@ -260,9 +299,10 @@ describe('codex buildArgs', () => {
     expect(args1).toContain('--no-alt-screen');
   });
 
-  it('does not include session id', () => {
-    const args = adapter.buildArgs({ sessionId: 'sess-4', resume: false });
-    expect(args).not.toContain('sess-4');
+  it('TOML-quotes session id values for Codex config override', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess with "quote"', resume: false });
+    const idx = args.indexOf('-c');
+    expect(args[idx + 1]).toBe('shell_environment_policy.set.BOTMUX_SESSION_ID="sess with \\"quote\\""');
   });
 
   it('passes the effective working directory as Codex agent root', () => {
@@ -270,6 +310,8 @@ describe('codex buildArgs', () => {
     expect(args).toEqual([
       '--dangerously-bypass-approvals-and-sandbox',
       '--no-alt-screen',
+      '-c',
+      'shell_environment_policy.set.BOTMUX_SESSION_ID="sess-4"',
       '-C',
       '/repo/root',
     ]);
@@ -277,7 +319,13 @@ describe('codex buildArgs', () => {
 
   it('omits approval/sandbox bypass flag when disableCliBypass is true', () => {
     const args = adapter.buildArgs({ sessionId: 'sess-4', resume: false, workingDir: '/repo/root', disableCliBypass: true });
-    expect(args).toEqual(['--no-alt-screen', '-C', '/repo/root']);
+    expect(args).toEqual([
+      '--no-alt-screen',
+      '-c',
+      'shell_environment_policy.set.BOTMUX_SESSION_ID="sess-4"',
+      '-C',
+      '/repo/root',
+    ]);
   });
 
   it('passes configured model with --model', () => {

--- a/test/write-input.test.ts
+++ b/test/write-input.test.ts
@@ -903,6 +903,8 @@ describe('codex writeInput submission confirmation', () => {
       'resume',
       '--dangerously-bypass-approvals-and-sandbox',
       '--no-alt-screen',
+      '-c',
+      'shell_environment_policy.set.BOTMUX_SESSION_ID="botmux-session"',
       '019dd3e2-f2da-7592-86b5-a43d4cd0772f',
     ]);
   });
@@ -920,6 +922,8 @@ describe('codex writeInput submission confirmation', () => {
       'resume',
       '--dangerously-bypass-approvals-and-sandbox',
       '--no-alt-screen',
+      '-c',
+      'shell_environment_policy.set.BOTMUX_SESSION_ID="botmux-session"',
       '019dd3e2-f2da-7592-86b5-a43d4cd0772f',
     ]);
   });
@@ -935,6 +939,8 @@ describe('codex writeInput submission confirmation', () => {
       'resume',
       '--dangerously-bypass-approvals-and-sandbox',
       '--no-alt-screen',
+      '-c',
+      'shell_environment_policy.set.BOTMUX_SESSION_ID="botmux-session"',
       'new-codex-session',
     ]);
   });
@@ -951,6 +957,8 @@ describe('codex writeInput submission confirmation', () => {
         'resume',
         '--dangerously-bypass-approvals-and-sandbox',
         '--no-alt-screen',
+        '-c',
+        'shell_environment_policy.set.BOTMUX_SESSION_ID="custom-botmux-session"',
         'custom-codex-session',
       ]);
 
@@ -972,6 +980,8 @@ describe('codex writeInput submission confirmation', () => {
     expect(adapter.buildArgs({ sessionId: 'botmux-session', resume: true })).toEqual([
       '--dangerously-bypass-approvals-and-sandbox',
       '--no-alt-screen',
+      '-c',
+      'shell_environment_policy.set.BOTMUX_SESSION_ID="botmux-session"',
     ]);
   });
 
@@ -986,6 +996,8 @@ describe('codex writeInput submission confirmation', () => {
     })).toEqual([
       '--dangerously-bypass-approvals-and-sandbox',
       '--no-alt-screen',
+      '-c',
+      'shell_environment_policy.set.BOTMUX_SESSION_ID="botmux-session"',
       '-C',
       '/repo/root',
     ]);


### PR DESCRIPTION
## 背景 / 动机

修复前，raw `codex` 会话里模型调用 `botmux send --no-mention ...` 时，终端可能先打印：

```text
无法推断 session-id。请在 Lark 话题内的 CLI 会话中运行，或传 --session-id <id>。
```

这条 explicit send 会在解析 session 阶段直接退出，因此不会真正按本次 `botmux send` 的参数发送，也不会写入 `turn-sends` marker。随后 Codex transcript bridge fallback 可能仍会在最终回答 ready 时把 transcript 里的 final answer 发回 Lark，所以用户侧看起来像“命令报错了，但最后还是有消息发出”。实际成功的是 worker 的兜底路径，不是这次 `botmux send` 本身；进度消息、显式 `--no-mention/--mention` 等发送语义都可能丢失。

根因是新版 Codex TUI 已经运行在 app-server 实现之上：

- [openai/codex#14717](https://github.com/openai/codex/pull/14717) / `db89b73a`：引入 app-server backed TUI 的并行实现。
- [openai/codex#15661](https://github.com/openai/codex/pull/15661) / `e7139e14`：默认启用 `tui_app_server`。
- [openai/codex#15922](https://github.com/openai/codex/pull/15922) / `d65deec6`：移除 legacy TUI split。

在这个路径里，Codex shell tool 进程不一定能沿祖先进程找到 botmux CLI marker，也不一定继承了 botmux worker 注入的 `BOTMUX_SESSION_ID`。

## 改动

raw `codex` adapter 继续直接启动 Codex CLI，但在 Codex 参数里加入：

```text
-c shell_environment_policy.set.BOTMUX_SESSION_ID="<botmux-session-id>"
```

Codex 生成 shell tool 执行环境时会把 `shell_environment_policy.set` 写入子进程 env，因此由 Codex tool 调起的 `botmux send` 可以继续走现有的 `BOTMUX_SESSION_ID` fallback 拿到当前 botmux session。

## 默认值 / 兼容性依据

`BOTMUX_SESSION_ID` 是 botmux 已有的通用 session 归属变量：worker 会把它注入 CLI 子进程，`botmux send` 在进程树 marker 失效时已经用它做 fallback。本 PR 没有新增 Codex 专属的 session-id 语义，只是通过 Codex 自己支持的 config override 通道，把同一个既有变量传给 Codex shell tool 进程。

这次只传 session 级稳定值 `BOTMUX_SESSION_ID`，不把 turn 级状态写进长期 Codex 会话参数。现有 `cliId=codex` 配置继续使用同一个 adapter。

## 测试覆盖

- 覆盖 `codex` 仍作为 direct CLI adapter 懒解析真实 Codex binary。
- 覆盖 raw `codex` 启动参数会注入 `shell_environment_policy.set.BOTMUX_SESSION_ID`。
- 覆盖不会把易过期的 `BOTMUX_TURN_ID` 注入 Codex config。
- 保留 `botmux send` session 推断的 marker 优先、env fallback 回归测试。

## 验证

- `pnpm vitest run test/cli-adapters.test.ts test/session-marker-resolve.test.ts`
- `pnpm build`
- `codex -c 'shell_environment_policy.set.BOTMUX_SESSION_ID="probe-session"' --version`
- `git diff --check`

## 影响范围

仅 raw `codex` adapter 的启动参数新增一条 Codex config override；没有新增 runner、socket、app-server 进程或 `CODEX_HOME` 隔离。
