### PR TITLE
fix(lark): allowedUsers 解析保持配置原序，避免字面 ou_ 抢占 owner

### DIFF
--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -789,12 +789,10 @@ export async function resolveAllowedUsersWithMap(
   larkAppId: string, raw: string[],
 ): Promise<{ resolved: string[]; map: Map<string, string> }> {
   const map = new Map<string, string>();
-  const openIds: string[] = [];
   const emails: string[] = [];
   const unionIds: string[] = [];
   for (const v of raw) {
     if (v.startsWith('ou_')) {
-      openIds.push(v);
       map.set(v, v);
     } else if (v.startsWith('on_')) {
       // union_id (跨应用稳定)：运行时权限/私信/卡片全是 open_id 原生的，
@@ -804,60 +802,74 @@ export async function resolveAllowedUsersWithMap(
       emails.push(v);
     }
   }
-  if (emails.length === 0 && unionIds.length === 0) return { resolved: openIds, map };
 
-  const c = getBotClient(larkAppId);
+  if (emails.length > 0 || unionIds.length > 0) {
+    const c = getBotClient(larkAppId);
 
-  // union_id → 本 app open_id（单条查询；失败则丢弃该条，与 email 解析失败同口径）。
-  for (const uid of unionIds) {
-    try {
-      const res = await (c as any).contact.v3.user.get({
-        path: { user_id: uid },
-        params: { user_id_type: 'union_id' },
-      });
-      const oid = res?.data?.user?.open_id as string | undefined;
-      if (res.code === 0 && oid) {
-        openIds.push(oid);
-        map.set(uid, oid);
-        logger.info(`Resolved ${uid} → ${oid}`);
-      } else {
-        logger.warn(`Failed to resolve union_id ${uid} to open_id: ${res?.msg} (code: ${res?.code})`);
+    // union_id → 本 app open_id（单条查询；失败则丢弃该条，与 email 解析失败同口径）。
+    for (const uid of unionIds) {
+      try {
+        const res = await (c as any).contact.v3.user.get({
+          path: { user_id: uid },
+          params: { user_id_type: 'union_id' },
+        });
+        const oid = res?.data?.user?.open_id as string | undefined;
+        if (res.code === 0 && oid) {
+          map.set(uid, oid);
+          logger.info(`Resolved ${uid} → ${oid}`);
+        } else {
+          logger.warn(`Failed to resolve union_id ${uid} to open_id: ${res?.msg} (code: ${res?.code})`);
+        }
+      } catch (err: any) {
+        logger.warn(`resolve union_id ${uid} failed: ${err?.message ?? err}`);
       }
-    } catch (err: any) {
-      logger.warn(`resolve union_id ${uid} failed: ${err?.message ?? err}`);
+    }
+
+    if (emails.length > 0) {
+      try {
+        const res = await (c as any).contact.v3.user.batchGetId({
+          params: { user_id_type: 'open_id' },
+          data: { emails, include_resigned: false },
+        });
+        if (res.code !== 0) {
+          logger.warn(`Failed to resolve emails to open_ids: ${res.msg} (code: ${res.code})`);
+        } else {
+          const userList: any[] = res.data?.user_list ?? [];
+          // 先按 normalized(email) → user_id 建查找表，再对原始请求的 raw email 逐个回填 map，
+          // 保证 map 的 key 与 allowedUsers 里的字面值完全一致（防 API 大小写/规范化错配）。
+          const byNorm = new Map<string, string>();
+          for (const item of userList) {
+            if (item.user_id && item.email) byNorm.set(String(item.email).toLowerCase(), item.user_id);
+            else if (!item.user_id) logger.warn(`Could not resolve email: ${item.email}`);
+          }
+          for (const rawEmail of emails) {
+            const uid = byNorm.get(rawEmail.toLowerCase());
+            if (uid) {
+              map.set(rawEmail, uid);
+              logger.info(`Resolved ${rawEmail} → ${uid}`);
+            }
+          }
+        }
+      } catch (err: any) {
+        logger.warn(`resolveAllowedUsers failed: ${err.message}`);
+      }
     }
   }
 
-  if (emails.length === 0) return { resolved: openIds, map };
-  try {
-    const res = await (c as any).contact.v3.user.batchGetId({
-      params: { user_id_type: 'open_id' },
-      data: { emails, include_resigned: false },
-    });
-    if (res.code !== 0) {
-      logger.warn(`Failed to resolve emails to open_ids: ${res.msg} (code: ${res.code})`);
-      return { resolved: openIds, map };
+  // 解析不改变顺序：按 allowedUsers 的「原始配置顺序」回填 open_id，使
+  // 「owner = 第一个 ou_」忠实反映配置里的排位（union/邮箱条目不再被甩到 ou_ 之后）。
+  // 不可解析的条目丢弃；同一 open_id 去重并保留首次出现位置（同一人可能同时以
+  // union/邮箱和字面 ou_ 两种形式登记）。
+  const seen = new Set<string>();
+  const resolved: string[] = [];
+  for (const v of raw) {
+    const oid = map.get(v);
+    if (oid && !seen.has(oid)) {
+      seen.add(oid);
+      resolved.push(oid);
     }
-    const userList: any[] = res.data?.user_list ?? [];
-    // 先按 normalized(email) → user_id 建查找表，再对原始请求的 raw email 逐个回填 map，
-    // 保证 map 的 key 与 allowedUsers 里的字面值完全一致（防 API 大小写/规范化错配）。
-    const byNorm = new Map<string, string>();
-    for (const item of userList) {
-      if (item.user_id && item.email) byNorm.set(String(item.email).toLowerCase(), item.user_id);
-      else if (!item.user_id) logger.warn(`Could not resolve email: ${item.email}`);
-    }
-    for (const rawEmail of emails) {
-      const uid = byNorm.get(rawEmail.toLowerCase());
-      if (uid) {
-        openIds.push(uid);
-        map.set(rawEmail, uid);
-        logger.info(`Resolved ${rawEmail} → ${uid}`);
-      }
-    }
-  } catch (err: any) {
-    logger.warn(`resolveAllowedUsers failed: ${err.message}`);
   }
-  return { resolved: openIds, map };
+  return { resolved, map };
 }
 
 /**

--- a/test/resolve-allowed-users-union.test.ts
+++ b/test/resolve-allowed-users-union.test.ts
@@ -41,4 +41,25 @@ describe('resolveAllowedUsersWithMap — on_ union_id entries (PR#72 lockout fix
 
     expect(resolved).toEqual(['ou_plain', 'ou_from_union']);
   });
+
+  // Regression for PR #240: resolution must keep `allowedUsers` config order so
+  // `owner = first ou_` follows the configured ranking. The pre-fix logic bucketed
+  // literal `ou_` ahead of resolved on_/email entries, so an `on_` owner listed
+  // FIRST got displaced by any later literal `ou_` group member. The previous test
+  // happens to put `ou_` first, so it never exercises the reorder — this one does.
+  it('keeps config order when on_ owner precedes literal ou_ members (no displacement)', async () => {
+    stubClient(async ({ path }: any) =>
+      ({ code: 0, data: { user: { open_id: 'ou_owner', union_id: path.user_id, name: 'Owner' } } }));
+
+    // Real-world shape: creator written as on_ (first), then group members appended
+    // as literal ou_, with the creator also re-appearing as a literal ou_ duplicate.
+    const { resolved } = await resolveAllowedUsersWithMap(
+      APP, ['on_owner', 'ou_memberA', 'ou_memberB', 'ou_owner'],
+    );
+
+    // Owner stays first (was displaced to position 3 under the old bucketing),
+    // and the duplicate ou_owner is deduped to its first occurrence.
+    expect(resolved).toEqual(['ou_owner', 'ou_memberA', 'ou_memberB']);
+    expect(resolved[0]).toBe('ou_owner');
+  });
 });


### PR DESCRIPTION
## 问题

`getOwnerOpenId` 把 owner 定义为 `resolvedAllowedUsers` 里**第一个 `ou_`**。但 `resolveAllowedUsersWithMap`（`src/im/lark/client.ts`）解析时是**按前缀分桶**的：字面 `ou_` 条目排在最前（保配置序），`on_`(union_id)/邮箱解析出的 open_id 一律 **append 到末尾**。

结果：只要 allowedUsers 是「字面 `ou_`」与「`on_`/邮箱」的混合名单，owner 就会**无视配置顺序**，被任意一个字面 `ou_` 条目抢占——哪怕真正的 owner 在配置里排第一位。

受影响的不止 `/grant`：所有按「owner = 第一个 ou_」取值的地方都会错位（`/grant`·`/revoke` 闸门、缺权限私信对象、@通知 / 邀请用户 / 转让群主、event-dispatcher 的 owner 判定、dashboard operator 选择等）。

## 复现步骤

1. 建 bot 时，创建者 owner 被自动写成 **`on_`(union_id)** 形式（`cli.ts:648` / `dashboard/bot-onboarding.ts:233` 走 `resolveOpenIdToUnionId`），排在 allowedUsers 第一位。
2. 之后让 bot **「把群里的人都加进 allowedUsers」**——bot 调 `listChatMemberOpenIds`，**该接口返回的是 open_id（`ou_` 形式）**（`client.ts:343-353`），于是群成员被原样写成**字面 `ou_`** 追加进 allowedUsers。
3. 此时 allowedUsers = `[on_(创建者), ou_(成员A), ou_(成员B), …]` 形成混合名单。
4. 重启 daemon（重新解析 allowedUsers）后，旧逻辑把字面 `ou_` 全甩到最前 → 第一个 `ou_`（某群成员）被认成 owner，**真正的创建者反而失去 owner 权限**，发 `/grant` 会被回「仅 owner 可使用 /grant。」

> 注：`/grant` 本身只写 `chatGrants`/`globalGrants`（talk-only），不会污染 `allowedUsers`；混合名单只来自「批量加群成员」或手工配置混用 `ou_` 与 `on_`/邮箱。

## 修复

`resolveAllowedUsersWithMap` 改为**按 `allowedUsers` 的原始配置顺序回填 open_id**——解析只做「翻译」（`on_`/邮箱 → 本 app `ou_`），不再改变顺序；并对同一 open_id 去重、保留首次出现位置（同一人可能同时以 union/邮箱与字面 `ou_` 两种形式登记）。`resolveAllowedUsers` 是其薄包装，一并生效。

修复后，owner 忠实反映 `allowedUsers` 里的排位，无论条目是 `ou_` / `on_` / 邮箱、无论名单怎么混。

## 验证（本地干跑，不连飞书 / 不改配置）

喂一组照线上形态构造的混合名单 `[on_(王旭), ou_(肖敏), ou_(李新聪), ou_(王旭)]`：

- **旧逻辑** → `[ou_肖敏, ou_李新聪, ou_王旭, ou_王旭]`，owner = **肖敏** ❌
- **新逻辑** → `[ou_王旭, ou_肖敏, ou_李新聪]`，owner = **王旭** ✅

owner 从被抢占的「第一个字面 ou_」恢复为配置里排第一的真正 owner。
