### PR TITLE
[codex] 修复 traex 启动提示页的 prompt 误判

### DIFF
--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -238,7 +238,10 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
     completionPattern: undefined,
     // TRAE has shipped both the Codex-style `›` prompt and the Claude-style
     // `❯` prompt; v0.200.7 also renders a "Context 100% left" status bar.
-    readyPattern: /[›❯]|\d+% left/,
+    // Startup advisory / picker screens also use `❯ 1.` as a menu cursor, so
+    // exclude numbered selector rows; otherwise botmux flushes the first prompt
+    // into the advisory instead of TRAE's real composer.
+    readyPattern: /(?:^|[\n\r])\s*[›❯](?!\s*\d+\.)|\d+% left/,
     systemHints: BOTMUX_SHELL_HINTS,
     // TRAE 0.200+ shares Codex's type-ahead behaviour: input submitted while
     // a turn is running is parked and merged into the active turn.

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -788,6 +788,7 @@ describe('readyPattern', () => {
     expect(adapter.readyPattern!.test('›')).toBe(true);
     expect(adapter.readyPattern!.test('❯ Run /review on my current changes')).toBe(true);
     expect(adapter.readyPattern!.test('GPT-5.5 · Context 100% left')).toBe(true);
+    expect(adapter.readyPattern!.test('❯ 1. Continue into TRAE CLI')).toBe(false);
   });
 
   it('codex-app matches runner prompt indicator', () => {


### PR DESCRIPTION
## 变更摘要

- 收紧 TRAE 的 ready prompt 匹配规则，避免把启动提示页或选择器里的 `❯ 1. Continue into TRAE CLI` 误判成真实输入框。
- 增加回归断言，覆盖启动提示页菜单光标，同时保留真实 TRAE prompt 和 context 状态栏的识别。

## 根因

TRAE CLI 0.200.11 在启动时可能先停在网络提示页，还没有进入主输入框。这个提示页的编号菜单同样使用 `❯` 光标，而旧的 botmux `readyPattern` 会匹配任意 `❯`。

因此 worker 会提前把 TRAE 标记为 idle，并把排队输入刷进启动提示页，而不是 TRAE 的真实 composer，表现为界面卡住、输入无法正常退出。

## 验证

- `pnpm vitest run test/cli-adapters.test.ts test/idle-detector.test.ts`
- `pnpm build`