### PR TITLE
feat(config): customPassthroughCommands 支持 dashboard 动态配置

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -39,7 +39,7 @@ import {
 import { bindOncall, unbindOncall, getOncallStatus } from '../services/oncall-store.js';
 import {
   CONFIG_FIELDS, findConfigField, settableFieldKeys, parseBooleanValue,
-  applyConfigField, setBotAllowedUsers, getConfigSnapshot, getConfigCardData, type ConfigEffect,
+  applyConfigField, setBotAllowedUsers, getConfigSnapshot, getConfigCardData, coerceConfigValue, type ConfigEffect,
 } from '../services/bot-config-store.js';
 import { resolveCliId, findInvalidAllowedUserEntries } from '../setup/bot-config-editor.js';
 import { buildClosedSessionCard } from './closed-session-card.js';
@@ -692,12 +692,20 @@ async function handleConfigCommand(
     const rawValue = parts.slice(2).join(' ').trim();
     if (!rawValue) { await reply(t('cmd.config.value_required', { field: spec.key }, loc)); return; }
 
-    let value: string | string[] | boolean;
+    let value: string | string[] | boolean | number;
     switch (spec.kind) {
       case 'stringList': {
         const arr = parseCustomPassthroughInput(rawValue);
         if (arr.length === 0) { await reply(t('cmd.config.value_required', { field: spec.key }, loc)); return; }
         value = arr;
+        break;
+      }
+      case 'number': {
+        // 统一走 coerceConfigValue 的 number 校验（正整数），避免文字路径把 '6'
+        // 当字符串写进 maxLiveWorkers（与 card/API 路径同口径）。
+        const coerced = coerceConfigValue(spec, rawValue);
+        if (!coerced.ok) { await reply(t('cmd.config.invalid_number', { field: spec.key, value: rawValue }, loc)); return; }
+        value = coerced.value;
         break;
       }
       case 'boolean': {

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -2366,7 +2366,14 @@ export async function handleCommand(
         const workingDir = getSessionWorkingDir(ds);
         const builtin = [...PASSTHROUGH_COMMANDS];
         const adapterDefaults = resolveAdapterDefaultPassthroughCommands(larkAppId);
-        const custom = botCfg?.customPassthroughCommands ?? [];
+        // 只展示「实际生效」的 custom 命令：用与 resolvePassthroughCommands 同一套
+        // normalize 过滤掉手写 bots.json 里遮蔽 daemon 命令 / 非法的项（parser 出于
+        // 兼容会保留它们，但路由会丢弃），避免 `/status` 之类被展示成可用却走 daemon。
+        const custom = [...new Set(
+          (botCfg?.customPassthroughCommands ?? [])
+            .map(normalizePassthroughCommand)
+            .filter((c): c is string => !!c),
+        )];
         let cliAdapter;
         try {
           cliAdapter = createCliAdapterSync(cliId, botCfg?.cliPathOverride);

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -57,7 +57,13 @@ import { t, localeForBot, type Locale } from '../i18n/index.js';
 
 // ─── Exported constants ──────────────────────────────────────────────────────
 
-export const DAEMON_COMMANDS = new Set(['/close', '/restart', '/status', '/help', '/cd', '/repo', '/schedule', '/role', '/botconfig', '/pair', '/login', '/adopt', '/detach', '/disconnect', '/oncall', '/group', '/g', '/relay', '/card', '/term', '/list-slash-command', '/slash', '/land', '/subscribe-lark-doc']);
+// DAEMON_COMMANDS / PASSTHROUGH_COMMANDS / normalizePassthroughCommand now live
+// in the leaf ./passthrough-commands.js so the config store can share the
+// normalization without a circular import; imported for internal use and
+// re-exported to keep callers (daemon.ts, tests) importing from command-handler
+// unchanged.
+import { DAEMON_COMMANDS, PASSTHROUGH_COMMANDS, normalizePassthroughCommand, parseCustomPassthroughInput } from './passthrough-commands.js';
+export { DAEMON_COMMANDS, PASSTHROUGH_COMMANDS };
 
 /**
  * Daemon commands that act on the chat itself rather than opening a
@@ -68,30 +74,6 @@ export const DAEMON_COMMANDS = new Set(['/close', '/restart', '/status', '/help'
  * that pollutes the dashboard's session list. Handle them without a session.
  */
 export const SESSIONLESS_DAEMON_COMMANDS = new Set(['/group', '/g', '/list-slash-command', '/slash', '/botconfig']);
-
-/**
- * Slash commands that are forwarded verbatim to the underlying CLI (e.g.
- * Claude Code's `/compact`, `/model`, `/usage`). The daemon does NOT handle
- * these — it just relays them to the worker via a raw_input IPC message,
- * bypassing the normal prompt-wrapping and bracketed-paste path so the CLI's
- * own slash-command parser sees them.
- */
-export const PASSTHROUGH_COMMANDS = new Set([
-  '/compact', '/model', '/clear', '/plugin', '/usage',
-  // 只读 / 低副作用，飞书卡片里能直接吐文本：
-  '/context', '/cost', '/mcp', '/diff',
-  '/code-review', '/security-review', '/review',
-  // Codex：/btw 向当前会话追加一条旁注/引导消息
-  '/btw',
-]);
-
-function normalizePassthroughCommand(cmd: unknown): string | null {
-  if (typeof cmd !== 'string') return null;
-  const normalized = cmd.trim().toLowerCase();
-  if (!/^\/[a-z0-9][a-z0-9:_-]*$/.test(normalized)) return null;
-  if (DAEMON_COMMANDS.has(normalized)) return null;
-  return normalized;
-}
 
 export function resolveAdapterDefaultPassthroughCommands(larkAppId?: string): string[] {
   if (!larkAppId) return [];
@@ -710,8 +692,14 @@ async function handleConfigCommand(
     const rawValue = parts.slice(2).join(' ').trim();
     if (!rawValue) { await reply(t('cmd.config.value_required', { field: spec.key }, loc)); return; }
 
-    let value: string | boolean;
+    let value: string | string[] | boolean;
     switch (spec.kind) {
+      case 'stringList': {
+        const arr = parseCustomPassthroughInput(rawValue);
+        if (arr.length === 0) { await reply(t('cmd.config.value_required', { field: spec.key }, loc)); return; }
+        value = arr;
+        break;
+      }
       case 'boolean': {
         const b = parseBooleanValue(rawValue);
         if (b === undefined) { await reply(t('cmd.config.invalid_bool', { field: spec.key, value: rawValue }, loc)); return; }

--- a/src/core/passthrough-commands.ts
+++ b/src/core/passthrough-commands.ts
@@ -29,6 +29,17 @@ export const PASSTHROUGH_COMMANDS = new Set([
 ]);
 
 /**
+ * Shape of a slash-command token: leading `/`, an alphanumeric first char, then
+ * `[a-z0-9:_-]`. Shared by passthrough normalization AND the grant-restriction
+ * gate ({@link ../daemon.js}'s `grantRestrictedSlashCommandText`) so a custom
+ * passthrough command can't slip past the restriction check via a shape one
+ * recognizes but the other doesn't (e.g. `/foo:bar`, `/1cmd` — colon / leading
+ * digit). Keep the two in lockstep: anything passthrough accepts must also be
+ * recognized as a command by the restriction gate.
+ */
+export const SLASH_COMMAND_SHAPE = /^\/[a-z0-9][a-z0-9:_-]*$/;
+
+/**
  * Normalize a single custom passthrough command: lowercase, must match the
  * slash-command shape, and must not shadow a daemon command (passthrough is
  * checked BEFORE DAEMON_COMMANDS in the router). Returns null for anything that
@@ -38,7 +49,7 @@ export const PASSTHROUGH_COMMANDS = new Set([
 export function normalizePassthroughCommand(cmd: unknown): string | null {
   if (typeof cmd !== 'string') return null;
   const normalized = cmd.trim().toLowerCase();
-  if (!/^\/[a-z0-9][a-z0-9:_-]*$/.test(normalized)) return null;
+  if (!SLASH_COMMAND_SHAPE.test(normalized)) return null;
   if (DAEMON_COMMANDS.has(normalized)) return null;
   return normalized;
 }

--- a/src/core/passthrough-commands.ts
+++ b/src/core/passthrough-commands.ts
@@ -1,0 +1,64 @@
+/**
+ * Passthrough / daemon command sets — extracted into a leaf module so both the
+ * command router ({@link ../core/command-handler.js}) and the `/botconfig` config
+ * store ({@link ../services/bot-config-store.js}) can share the normalization
+ * without a circular import (command-handler already imports the config store).
+ */
+
+/**
+ * Slash commands handled by the daemon itself (open a conversation / act on the
+ * chat) rather than relayed to the CLI. Used both for routing and to reject
+ * `customPassthroughCommands` entries that would shadow a daemon command.
+ */
+export const DAEMON_COMMANDS = new Set(['/close', '/restart', '/status', '/help', '/cd', '/repo', '/schedule', '/role', '/botconfig', '/pair', '/login', '/adopt', '/detach', '/disconnect', '/oncall', '/group', '/g', '/relay', '/card', '/term', '/list-slash-command', '/slash', '/land', '/subscribe-lark-doc']);
+
+/**
+ * Slash commands that are forwarded verbatim to the underlying CLI (e.g.
+ * Claude Code's `/compact`, `/model`, `/usage`). The daemon does NOT handle
+ * these — it just relays them to the worker via a raw_input IPC message,
+ * bypassing the normal prompt-wrapping and bracketed-paste path so the CLI's
+ * own slash-command parser sees them.
+ */
+export const PASSTHROUGH_COMMANDS = new Set([
+  '/compact', '/model', '/clear', '/plugin', '/usage',
+  // 只读 / 低副作用，飞书卡片里能直接吐文本：
+  '/context', '/cost', '/mcp', '/diff',
+  '/code-review', '/security-review', '/review',
+  // Codex：/btw 向当前会话追加一条旁注/引导消息
+  '/btw',
+]);
+
+/**
+ * Normalize a single custom passthrough command: lowercase, must match the
+ * slash-command shape, and must not shadow a daemon command (passthrough is
+ * checked BEFORE DAEMON_COMMANDS in the router). Returns null for anything that
+ * doesn't qualify. Does NOT prepend the leading `/` — callers that accept bare
+ * user input should add it first (see {@link parseCustomPassthroughInput}).
+ */
+export function normalizePassthroughCommand(cmd: unknown): string | null {
+  if (typeof cmd !== 'string') return null;
+  const normalized = cmd.trim().toLowerCase();
+  if (!/^\/[a-z0-9][a-z0-9:_-]*$/.test(normalized)) return null;
+  if (DAEMON_COMMANDS.has(normalized)) return null;
+  return normalized;
+}
+
+/**
+ * Parse free-text dashboard / `/botconfig` input (comma, space or newline
+ * separated) into a normalized, deduped custom passthrough command list. The
+ * leading `/` is optional per token (so users can type `goal export` or
+ * `/goal, /export`); illegal and daemon-shadowing tokens are dropped. Mirrors
+ * the normalization {@link ../bot-registry.js}'s parseBotConfigsFromText applies
+ * when loading bots.json, so a round-trip through the card is stable.
+ */
+export function parseCustomPassthroughInput(raw: string): string[] {
+  const out: string[] = [];
+  for (const tok of String(raw ?? '').split(/[\s,]+/)) {
+    const trimmed = tok.trim();
+    if (!trimmed) continue;
+    const withSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+    const norm = normalizePassthroughCommand(withSlash);
+    if (norm) out.push(norm);
+  }
+  return [...new Set(out)];
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -64,6 +64,7 @@ import {
 import { ipcRoute, jsonRes, readJsonBody, setBotName, setLarkAppId, startIpcServer, setWorkflowRunner } from './core/dashboard-ipc-server.js';
 import { saveFrozenCards, deleteFrozenCards } from './services/frozen-card-store.js';
 import { DAEMON_COMMANDS, SESSIONLESS_DAEMON_COMMANDS, resolvePassthroughCommands, resolveAdapterDefaultPassthroughCommands, handleCommand, handleCardCommand, handleTermLinkCommand, parseSlashCommandInvocation, parseForceTopicInvocation } from './core/command-handler.js';
+import { SLASH_COMMAND_SHAPE } from './core/passthrough-commands.js';
 import type { CommandHandlerDeps } from './core/command-handler.js';
 import { findInheritablePeer } from './core/inherit-peer.js';
 import { isCallbackUrl, handleCallbackUrl } from './utils/user-token.js';
@@ -550,7 +551,10 @@ export function grantRestrictedSlashCommandText(
   senderOpenId: string | undefined,
   cmd: string,
 ): string | undefined {
-  if (!/^\/[a-z][a-z0-9_-]*$/.test(cmd)) return undefined;
+  // 用与 passthrough 归一化同一套 shape 正则（SLASH_COMMAND_SHAPE），否则像
+  // `/foo:bar`、`/1cmd` 这类 passthrough 认、本闸不认的命令会让 grant-only 用户在
+  // restrictGrantCommands=true 下绕过限制直达 raw passthrough（路由里本闸在 passthrough 之前）。
+  if (!SLASH_COMMAND_SHAPE.test(cmd)) return undefined;
   return grantRestrictedCommandText(larkAppId, chatId, senderOpenId, cmd);
 }
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -300,6 +300,7 @@ export const messages: Record<string, string> = {
   'cmd.config.value_required': 'Please provide a value for {field}: /botconfig set {field} <value>',
   'cmd.config.invalid_bool': '{field} expects a boolean (on/off), got: {value}',
   'cmd.config.invalid_enum': '{field} must be one of {values}.',
+  'cmd.config.invalid_number': '{field} expects a positive integer, got: {value}',
   'cmd.config.invalid_cli': '⚠️ {msg}',
   'cmd.config.set_ok': '✅ Updated {field}: {old} → {new}\n{effect}',
   'cmd.config.unset_ok': '✅ Cleared {field} (was {old}), reverted to default.\n{effect}',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -333,6 +333,7 @@ export const messages: Record<string, string> = {
   'card.config.text_note': 'Edit then tap Save (one write); leaving a field blank clears it. For long/multi-line roles use `/role team set`.',
   'card.config.lbl_brand': 'Card signature (brandLabel)',
   'card.config.lbl_prompt': 'On-join first prompt',
+  'card.config.lbl_passthrough': 'Extra passthrough slash commands (comma/space separated, e.g. /goal /export)',
   'card.config.lbl_role': 'Default role (team, cross-chat)',
   'card.config.save': '💾 Save',
   'card.config.back': '⬅ Back to config',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -303,6 +303,7 @@ export const messages: Record<string, string> = {
   'cmd.config.value_required': '请提供 {field} 的值：/botconfig set {field} <值>',
   'cmd.config.invalid_bool': '{field} 需要布尔值（on/off），收到：{value}',
   'cmd.config.invalid_enum': '{field} 取值需为 {values} 之一。',
+  'cmd.config.invalid_number': '{field} 需要正整数，收到：{value}',
   'cmd.config.invalid_cli': '⚠️ {msg}',
   'cmd.config.set_ok': '✅ 已更新 {field}：{old} → {new}\n{effect}',
   'cmd.config.unset_ok': '✅ 已清除 {field}（原值 {old}），回退默认。\n{effect}',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -336,6 +336,7 @@ export const messages: Record<string, string> = {
   'card.config.text_note': '改完点「保存」一次写入；某项留空 = 清除该项。角色较长/多行建议改用 `/role team set`。',
   'card.config.lbl_brand': '卡片签名（brandLabel）',
   'card.config.lbl_prompt': '入群首轮 prompt',
+  'card.config.lbl_passthrough': '额外放行的 slash 命令（逗号/空格分隔，如 /goal /export）',
   'card.config.lbl_role': '默认角色（team，跨群）',
   'card.config.save': '💾 保存',
   'card.config.back': '⬅ 返回配置',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -163,6 +163,8 @@ export function buildConfigTextCard(data: ConfigCardData, locale?: Locale): stri
     { tag: 'hr' },
     ...section('card.config.lbl_prompt', 'autoStartPrompt', data.autoStartPrompt),
     { tag: 'hr' },
+    ...section('card.config.lbl_passthrough', 'customPassthroughCommands', data.customPassthroughCommands),
+    { tag: 'hr' },
     ...section('card.config.lbl_role', 'teamRole', data.teamRole),
   ];
   return JSON.stringify({

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -625,7 +625,20 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       }
       const spec = fk ? findConfigField(fk) : undefined;
       if (!spec) return { toast: { type: 'error', content: t('cmd.config.unknown_field', { field: fk ?? '?', fields: '' }, loc) } };
-      const r = await applyConfigField(larkAppId, spec, raw ? raw : null);
+      // 多值字段（stringList，如 customPassthroughCommands）：留空 = 清除，否则按 kind
+      // 归一化成数组再落盘；普通文本字段沿用原始字符串。
+      let valueToApply: string | string[] | null;
+      if (!raw) {
+        valueToApply = null;
+      } else if (spec.kind === 'stringList') {
+        const coerced = coerceConfigValue(spec, raw);
+        if (!coerced.ok) return { toast: { type: 'error', content: t('cmd.config.write_failed', { reason: coerced.reason }, loc) } };
+        // stringList 的 coerce 只会产出 string[]（永不 boolean）；narrow 给 applyConfigField。
+        valueToApply = coerced.value as string[];
+      } else {
+        valueToApply = raw;
+      }
+      const r = await applyConfigField(larkAppId, spec, valueToApply);
       if (!r.ok) return { toast: { type: 'error', content: t('cmd.config.write_failed', { reason: r.reason }, loc) } };
       logger.info(`[config:${larkAppId}] text field ${spec.key} saved via card`);
       return { toast: { type: 'success', content: `✓ ${spec.key} = ${r.newText}` } };

--- a/src/services/bot-config-store.ts
+++ b/src/services/bot-config-store.ts
@@ -17,6 +17,7 @@ import { expandHomePath } from '../utils/working-dir.js';
 import { resolveTeamRoleFile } from '../core/role-resolver.js';
 import { statSync } from 'node:fs';
 import { logger } from '../utils/logger.js';
+import { parseCustomPassthroughInput } from '../core/passthrough-commands.js';
 
 /**
  * 生效时机：
@@ -26,7 +27,7 @@ import { logger } from '../utils/logger.js';
  */
 export type ConfigEffect = 'immediate' | 'next-session';
 
-export type ConfigFieldKind = 'string' | 'boolean' | 'number' | 'enum' | 'cli' | 'dir' | 'allowedUsers';
+export type ConfigFieldKind = 'string' | 'stringList' | 'boolean' | 'number' | 'enum' | 'cli' | 'dir' | 'allowedUsers';
 
 export interface ConfigFieldSpec {
   /** 用户面命令里用的字段名（大小写不敏感匹配，见 {@link findConfigField}）。 */
@@ -65,6 +66,7 @@ export const CONFIG_FIELDS: readonly ConfigFieldSpec[] = [
   { key: 'restrictGrantCommands', configKey: 'restrictGrantCommands', kind: 'boolean', effect: 'immediate', clearable: false, hint: '被授权人仅能纯对话、拦截斜杠命令 on|off' },
   { key: 'p2pMode', configKey: 'p2pMode', kind: 'enum', effect: 'immediate', clearable: true, enumValues: ['thread', 'chat'], hint: '私聊单聊模式 thread|chat；chat=扁平连续会话，thread/unset 回默认（每条 DM 独立会话）' },
   { key: 'maxLiveWorkers', configKey: 'maxLiveWorkers', kind: 'number', effect: 'immediate', clearable: true, hint: '最大同时活跃会话数；超过后最久未用的会话自动休眠（杀 worker+CLI 回收内存，下条消息冷恢复）；unset=默认 30' },
+  { key: 'customPassthroughCommands', configKey: 'customPassthroughCommands', kind: 'stringList', effect: 'immediate', clearable: true, hint: '额外放行透传给 CLI 的 slash 命令（逗号/空格分隔，如 /goal /export）；unset 回仅内置白名单' },
 ];
 
 /** 大小写不敏感地按 key 找字段 spec。 */
@@ -89,7 +91,7 @@ export function parseBooleanValue(raw: string): boolean | undefined {
 /** 展示某字段当前值的人类可读文本。 */
 function formatFieldValue(spec: ConfigFieldSpec, value: unknown): string {
   if (spec.kind === 'boolean') return value === true ? 'on' : 'off';
-  if (spec.kind === 'allowedUsers') {
+  if (spec.kind === 'allowedUsers' || spec.kind === 'stringList') {
     const arr = Array.isArray(value) ? value : [];
     return arr.length ? arr.join(', ') : '∅';
   }
@@ -141,34 +143,37 @@ export type ApplyFieldResult =
 export async function applyConfigField(
   larkAppId: string,
   spec: ConfigFieldSpec,
-  value: string | boolean | number | null,
+  value: string | string[] | boolean | number | null,
 ): Promise<ApplyFieldResult> {
   if (spec.kind === 'allowedUsers') return { ok: false, reason: 'use_setBotAllowedUsers' };
   let bot;
   try { bot = getBot(larkAppId); } catch { return { ok: false, reason: 'bot_not_registered' }; }
   const oldText = formatFieldValue(spec, (bot.config as any)[spec.configKey]);
 
+  // 空数组（stringList 全被过滤）等价清除，bots.json 保持干净。
+  const effective = spec.kind === 'stringList' && Array.isArray(value) && value.length === 0 ? null : value;
+
   const r = await rmwBotEntry<null>(larkAppId, (entry) => {
-    if (value === null) {
+    if (effective === null) {
       delete entry[spec.configKey];
     } else if (spec.kind === 'boolean') {
       // 与 parseBotConfigsFromText 一致：true 才写，false → 删 key（bots.json 保持干净）。
-      if (value === true) entry[spec.configKey] = true;
+      if (effective === true) entry[spec.configKey] = true;
       else delete entry[spec.configKey];
     } else {
-      entry[spec.configKey] = value;
+      entry[spec.configKey] = effective;
     }
     return { write: true, result: null };
   });
   if (!r.ok) return { ok: false, reason: r.reason };
 
   // 同步内存 config（与 oncall/grant-prefs store 一致，路由/spawn 不重启即生效）。
-  if (value === null) {
+  if (effective === null) {
     (bot.config as any)[spec.configKey] = undefined;
   } else if (spec.kind === 'boolean') {
-    (bot.config as any)[spec.configKey] = value || undefined;
+    (bot.config as any)[spec.configKey] = effective || undefined;
   } else {
-    (bot.config as any)[spec.configKey] = value;
+    (bot.config as any)[spec.configKey] = effective;
   }
   const newText = formatFieldValue(spec, (bot.config as any)[spec.configKey]);
   logger.info(`[config:${larkAppId}] set ${spec.key}: ${oldText} -> ${newText}`);
@@ -215,7 +220,7 @@ export async function setBotAllowedUsers(
 }
 
 export type CoerceResult =
-  | { ok: true; value: string | boolean | number }
+  | { ok: true; value: string | string[] | boolean | number }
   | { ok: false; reason: 'invalid_bool' | 'invalid_enum' | 'invalid_cli' | 'invalid_dir' | 'invalid_number' | 'empty' };
 
 /**
@@ -236,6 +241,10 @@ export function coerceConfigValue(spec: ConfigFieldSpec, raw: unknown): CoerceRe
   const s = String(raw ?? '').trim();
   if (!s) return { ok: false, reason: 'empty' };
   switch (spec.kind) {
+    case 'stringList': {
+      const arr = parseCustomPassthroughInput(s);
+      return arr.length ? { ok: true, value: arr } : { ok: false, reason: 'empty' };
+    }
     case 'enum':
       return spec.enumValues?.includes(s.toLowerCase())
         ? { ok: true, value: s.toLowerCase() }
@@ -274,6 +283,8 @@ export interface ConfigCardData {
   defaultWorkingDir: string | null;
   /** 入群主动开工首轮 prompt（autoStartOnGroupJoinPrompt）。 */
   autoStartPrompt: string | null;
+  /** 额外放行透传的 slash 命令（customPassthroughCommands），空格分隔；null = 未设。 */
+  customPassthroughCommands: string | null;
   /** team 级默认角色文本（不在 bots.json，存独立角色文件）。 */
   teamRole: string | null;
   /** messageQuota.defaultLimit（被授权人默认消息额度）；null = 不限。 */
@@ -299,6 +310,7 @@ export function getConfigCardData(larkAppId: string, modelChoices: readonly stri
     brandLabel: cfg.brandLabel ?? null,
     defaultWorkingDir: cfg.defaultWorkingDir ?? null,
     autoStartPrompt: cfg.autoStartOnGroupJoinPrompt ?? null,
+    customPassthroughCommands: cfg.customPassthroughCommands?.length ? cfg.customPassthroughCommands.join(' ') : null,
     teamRole: resolveTeamRoleFile(larkAppId),
     quota: typeof q === 'number' && Number.isInteger(q) && q > 0 ? q : null,
     admins: bot.resolvedAllowedUsers.length,

--- a/test/bot-config-store.test.ts
+++ b/test/bot-config-store.test.ts
@@ -162,6 +162,41 @@ describe('bot-config store', () => {
     expect(registry.getBot('app_default').config.cliId).toBe('codex');
   });
 
+  it('stringList (customPassthroughCommands) coerces, dedupes, drops daemon-shadowing + junk', async () => {
+    const { store } = await freshModules();
+    const spec = store.findConfigField('customPassthroughCommands')!;
+    expect(spec.kind).toBe('stringList');
+    // 逗号/空格混排、缺前导 / 自动补、大写归一、去重；/status 遮蔽 daemon 命令被丢、`/b@d` 非法字符被丢。
+    expect(store.coerceConfigValue(spec, 'goal, /export /GOAL /status /b@d'))
+      .toEqual({ ok: true, value: ['/goal', '/export'] });
+    // 全部非法/被过滤 → empty。
+    expect(store.coerceConfigValue(spec, '/status /!nope')).toEqual({ ok: false, reason: 'empty' });
+  });
+
+  it('stringList field round-trips array to disk + memory; empty/unset clears the key', async () => {
+    const { registry, store } = await loaded();
+    const spec = store.findConfigField('customPassthroughCommands')!;
+
+    const r1 = await store.applyConfigField('app_default', spec, ['/goal', '/export']);
+    expect(r1.ok).toBe(true);
+    if (r1.ok) { expect(r1.oldText).toBe('∅'); expect(r1.newText).toBe('/goal, /export'); expect(r1.effect).toBe('immediate'); }
+    expect(readConfig().customPassthroughCommands).toEqual(['/goal', '/export']);
+    expect(registry.getBot('app_default').config.customPassthroughCommands).toEqual(['/goal', '/export']);
+
+    // 空数组等价清除（bots.json 保持干净）。
+    const r2 = await store.applyConfigField('app_default', spec, []);
+    expect(r2.ok).toBe(true);
+    expect(readConfig().customPassthroughCommands).toBeUndefined();
+    expect(registry.getBot('app_default').config.customPassthroughCommands).toBeUndefined();
+  });
+
+  it('getConfigCardData surfaces customPassthroughCommands as a space-joined string', async () => {
+    const { store } = await loaded({ customPassthroughCommands: ['/goal', '/export'] });
+    expect(store.getConfigCardData('app_default')?.customPassthroughCommands).toBe('/goal /export');
+    const { store: store2 } = await loaded();
+    expect(store2.getConfigCardData('app_default')?.customPassthroughCommands).toBeNull();
+  });
+
   it('getConfigSnapshot reports current values + info', async () => {
     const { store } = await loaded({ model: 'sonnet', disableStreamingCard: true });
     const snap = store.getConfigSnapshot('app_default');

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -544,6 +544,26 @@ describe('/list-slash-command discovery', () => {
     );
   });
 
+  it('shows only effective custom passthrough commands (drops daemon-shadow + junk, normalizes)', async () => {
+    // 手写 bots.json 可能留下 `/status`（遮蔽 daemon 命令，parser 出于兼容会保留但
+    // 路由会丢弃）、非法项、大小写不一；展示侧须与 resolvePassthroughCommands 同口径。
+    vi.mocked(getBot).mockImplementation(((id: string = 'app-1') => {
+      const b = defaultGetBot(id);
+      (b.config as any).customPassthroughCommands = ['/status', '/b@d', '/GOAL', '/export', '/goal'];
+      return b;
+    }) as any);
+    try {
+      const deps = makeDeps(makeDaemonSession());
+      await handleCommand('/slash', ROOT_ID, makeLarkMessage('/slash'), deps, LARK_APP_ID);
+      expect(buildSlashListCard).toHaveBeenCalledWith(
+        expect.objectContaining({ custom: ['/goal', '/export'] }),
+        expect.anything(),
+      );
+    } finally {
+      vi.mocked(getBot).mockImplementation(defaultGetBot as any);
+    }
+  });
+
   it('keeps Claude-family filesystem discovery enabled', async () => {
     const deps = makeDeps(makeDaemonSession());
 

--- a/test/message-quota-enforcement.test.ts
+++ b/test/message-quota-enforcement.test.ts
@@ -126,7 +126,10 @@ describe('message quota enforcement', () => {
       oc_oncall: ['ou_oncall'],
     };
 
-    for (const content of ['/clear', '/btw note', '/somecliskill arg']) {
+    // 含 `/foo:bar`（冒号）与 `/1cmd`（首位数字）—— 它们是合法的 custom passthrough
+    // 形状，受限闸的 shape 正则必须与 passthrough 同口径才拦得住，否则 grant-only
+    // 用户能借已配置的此类命令绕过 restrictGrantCommands 直达 raw passthrough。
+    for (const content of ['/clear', '/btw note', '/somecliskill arg', '/foo:bar x', '/1cmd y']) {
       const invocation = parseSlashCommandInvocation(content);
       expect(invocation).not.toBeNull();
       expect(grantRestrictedSlashCommandText('quota_slash_restrict', 'oc_1', 'ou_chat', invocation!.cmd)).toContain(invocation!.cmd);


### PR DESCRIPTION
## 背景
`customPassthroughCommands`（额外放行透传给 CLI 的 slash 命令）此前只能手写 `bots.json` + 重启 daemon。其实**运行时早就是动态生效的** —— 每次消息路由都调 `resolvePassthroughCommands(larkAppId)` 直接读 `getBot().config.customPassthroughCommands`，改内存配置下一条消息即生效。真正缺的只是从 dashboard/卡片改它的录入口。

## 改动
1. **leaf 模块** `src/core/passthrough-commands.ts`：抽出 `DAEMON_COMMANDS`/`PASSTHROUGH_COMMANDS`/`normalizePassthroughCommand`，新增 `parseCustomPassthroughInput`（逗号/空格分隔、缺 `/` 自动补、去重、丢非法/遮蔽 daemon 命令的项）。command-handler 改为 import + re-export —— daemon 和测试的导入零改动，避免 store↔command-handler 循环依赖。
2. **bot-config-store**：新增 `stringList` kind，把 `customPassthroughCommands` 登记进 `CONFIG_FIELDS`（effect: immediate, clearable）；coerce/applyConfigField/格式化/卡片数据全打通；空数组=清除，bots.json 保持干净。
3. **录入口**：`/botconfig` →「✏️ 文本设置」子卡新增「额外放行的 slash 命令」一行，预填当前值、保存即写即生效、留空=清回仅内置白名单；文字版 `/botconfig set customPassthroughCommands /goal /export` 也通了。
4. **i18n**（中英）+ **3 个新单测**（coerce 归一化 / 落盘往返 / 卡片视图）。

## 验证
- `pnpm build` 通过
- 全量单测 **4570 全绿**（新增 3）