### PR TITLE
feat(cli): 新增 Mir CLI(mircli) 适配器 mir

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -64,7 +64,7 @@ Compared to OpenClaw-style approaches built on Agent SDKs:
 ## Prerequisites
 
 - **Node.js** >= 20
-- **AI coding CLI / local agent app** installed and authenticated (`claude`, `codex`, `coco`, `cursor-agent`, `gemini`, `opencode`, `hermes`, `seed` (Seed CLI, a Claude Code fork), `relay` (Relay CLI, the new release of Seed), `pi`, `omp` (oh-my-pi, a Pi fork), `copilot` (GitHub Copilot CLI), `traex` (TRAE CLI), or `agy` (Antigravity) in PATH)
+- **AI coding CLI / local agent app** installed and authenticated (`claude`, `codex`, `coco`, `cursor-agent`, `gemini`, `opencode`, `hermes`, `seed` (Seed CLI, a Claude Code fork), `relay` (Relay CLI, the new release of Seed), `pi`, `omp` (oh-my-pi, a Pi fork), `copilot` (GitHub Copilot CLI), `traex` (TRAE CLI), `mircli` (Mir CLI), or `agy` (Antigravity) in PATH)
   - **CoCo requires `0.120.32+`**: type-ahead (sending a new message while a turn is still running, parked in CoCo's own message queue) relies on 0.120.32+ behavior; earlier versions may drop or serialize input while busy — upgrade before use
 - **tmux** >= 3.x (optional — auto-enabled when installed for persistent CLI sessions)
 - **CJK fonts** (only needed for screenshot rendering of Chinese text / emoji):

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ CLI 进入 botmux 会话时自动获得 `~/.botmux/bin` 在 PATH 中，以及一
 ## 前置要求
 
 - **Node.js** >= 20
-- **AI 编程 CLI / 本地 Agent 应用** 已安装并完成认证（`claude`、`codex`、`coco`、`cursor-agent`、`gemini`、`opencode`、`hermes`、`seed`（Seed CLI，Claude Code 衍生）、`relay`（Relay CLI，Seed 新版）、`pi`、`omp`（oh-my-pi，Pi 衍生）、`copilot`（GitHub Copilot CLI）、`traex`（TRAE CLI）或 `agy`（Antigravity）在 PATH 中）
+- **AI 编程 CLI / 本地 Agent 应用** 已安装并完成认证（`claude`、`codex`、`coco`、`cursor-agent`、`gemini`、`opencode`、`hermes`、`seed`（Seed CLI，Claude Code 衍生）、`relay`（Relay CLI，Seed 新版）、`pi`、`omp`（oh-my-pi，Pi 衍生）、`copilot`（GitHub Copilot CLI）、`traex`（TRAE CLI）、`mircli`（Mir CLI）或 `agy`（Antigravity）在 PATH 中）
   - **CoCo 最低版本 `0.120.32`**：type-ahead（会话忙时即可发新消息，由 CoCo 自己的消息队列接住）依赖 0.120.32+ 的行为；更早版本忙时输入可能丢失或串行，请升级后再用
 - **tmux** >= 3.x（可选，安装后自动启用会话常驻）
 - **CJK 字体**（用于截图渲染中文/emoji）：

--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -5,7 +5,7 @@ import { resolveCommand } from './registry.js';
 import { sessionReadyHookCommand } from '../hook-command.js';
 import type { CliAdapter, CliId, PtyHandle } from './types.js';
 import { findJsonlContainingFingerprint, jsonlContainsFingerprint, normaliseForFingerprint } from '../../services/claude-transcript.js';
-import { t } from '../../i18n/index.js';
+import { buildBotmuxSystemPromptText } from './shared-hints.js';
 import { delay, scaleMs } from '../../utils/timing.js';
 import { discoverClaudeFamilySessions } from '../../services/resumable-session-discovery.js';
 
@@ -529,48 +529,7 @@ export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, rawBin: 
       // Keeps them out of the user's global ~/.claude/skills so a standalone
       // `claude` never surfaces/mis-fires `botmux send` etc.
       args.push('--plugin-dir', CLAUDE_PLUGIN_DIR);
-      const unknown = t('ai.identity.unknown', undefined, locale);
-      const identityBlock =
-        botName || botOpenId
-          ? [
-            '',
-            '<identity>',
-            `  <name>${botName ?? unknown}</name>`,
-            `  <open_id>${botOpenId ?? unknown}</open_id>`,
-            '  <routing_rules>',
-            `    ${t('ai.identity.routing_intro', undefined, locale)}`,
-            `    ${t('ai.identity.rule_own_part', undefined, locale)}`,
-            `    ${t('ai.identity.rule_silent_when_other', undefined, locale)}`,
-            `    ${t('ai.identity.rule_no_proactive_pull', undefined, locale)}`,
-            '',
-            `    ${t('ai.identity.mention_intro', undefined, locale)}`,
-            `    ${t('ai.identity.mention_must', undefined, locale)}`,
-            `    ${t('ai.identity.mention_partners', undefined, locale)}`,
-            `    ${t('ai.identity.mention_usage', undefined, locale)}`,
-            `    ${t('ai.identity.mention_when_to', undefined, locale)}`,
-            `    ${t('ai.identity.mention_when_not', undefined, locale)}`,
-            `    ${t('ai.identity.mention_gate', undefined, locale)}`,
-            '  </routing_rules>',
-            '</identity>',
-          ]
-          : [];
-      args.push('--append-system-prompt', [
-        '<botmux_routing>',
-        t('ai.routing.intro', undefined, locale),
-        t('ai.routing.must_use_botmux', undefined, locale),
-        '',
-        t('ai.routing.usage_heading', undefined, locale),
-        t('ai.routing.usage_send_when', undefined, locale),
-        t('ai.routing.usage_send_text', undefined, locale),
-        t('ai.routing.usage_heredoc', undefined, locale),
-        t('ai.routing.heredoc_example', undefined, locale),
-        t('ai.routing.usage_images', undefined, locale),
-        t('ai.routing.usage_files', undefined, locale),
-        t('ai.routing.usage_history', undefined, locale),
-        t('ai.routing.usage_bots_list', undefined, locale),
-        '</botmux_routing>',
-        ...identityBlock,
-      ].join('\n'));
+      args.push('--append-system-prompt', buildBotmuxSystemPromptText({ locale, botName, botOpenId }));
       return args;
     },
 

--- a/src/adapters/cli/mir.ts
+++ b/src/adapters/cli/mir.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import type { CliAdapter, PtyHandle } from './types.js';
 import { writeRunnerInput } from './runner-input.js';
+import { resolveCommand } from './registry.js';
 
 /**
  * Mir CLI (mircli) adapter — drives the local `mircli` in non-interactive Print
@@ -35,7 +36,16 @@ function pushOpt(args: string[], key: string, value: string | undefined): void {
   args.push(key, value);
 }
 
-export function createMirAdapter(_pathOverride?: string): CliAdapter {
+export function createMirAdapter(pathOverride?: string): CliAdapter {
+  // A configured cliPathOverride is the mircli binary the runner should spawn
+  // (resolvedBin is the node runner itself). Resolve a bare name to an absolute
+  // path and hand it to the runner via --mircli-bin; the runner falls back to
+  // MIRCLI_BIN / `mircli` on PATH when unset.
+  let cachedMircliBin: string | undefined;
+  const mircliBin = (): string | undefined => {
+    if (!pathOverride || !pathOverride.trim()) return undefined;
+    return (cachedMircliBin ??= resolveCommand(pathOverride.trim()));
+  };
   return {
     id: 'mir',
     resolvedBin: process.execPath,
@@ -45,6 +55,7 @@ export function createMirAdapter(_pathOverride?: string): CliAdapter {
       pushOpt(args, '--bot-name', botName);
       pushOpt(args, '--bot-open-id', botOpenId);
       pushOpt(args, '--locale', locale);
+      pushOpt(args, '--mircli-bin', mircliBin());
       return args;
     },
 

--- a/src/adapters/cli/mir.ts
+++ b/src/adapters/cli/mir.ts
@@ -1,0 +1,75 @@
+import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import type { CliAdapter, PtyHandle } from './types.js';
+import { writeRunnerInput } from './runner-input.js';
+
+/**
+ * Mir CLI (mircli) adapter — drives the local `mircli` in non-interactive Print
+ * Mode through a small Node runner (src/mir-runner.ts), mirroring the `mira`
+ * (Mira App / Web API) adapter's runner shape. See mir-runner.ts for why Print
+ * Mode (`mircli -p --lean`) is used instead of driving the interactive TUI.
+ *
+ * Distinct from the `mira` adapter:
+ *   - `mira` → Mira Web API (cloud orchestration + remote sandbox; chat/search).
+ *   - `mir`  → local `mircli` (executes on this machine, operates the workspace;
+ *              requires the user's local MCP bridge connected, like mircli).
+ *
+ * Delivery is the runner's stdout (OSC `final` markers parsed by the worker —
+ * `mir` is in APP_RUNNER_OSC_CLI_IDS), so it needs neither `botmux send` nor a
+ * BOTMUX_SESSION_ID. Conversation continuity across turns / resume is handled by
+ * mircli itself via `--session-id` (the runner passes botmux's session id).
+ */
+
+function runnerPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const compiledSibling = resolve(here, '..', '..', 'mir-runner.js');
+  if (existsSync(compiledSibling)) return compiledSibling;
+  const builtFromSourceTree = resolve(here, '..', '..', '..', 'dist', 'mir-runner.js');
+  if (existsSync(builtFromSourceTree)) return builtFromSourceTree;
+  return compiledSibling;
+}
+
+function pushOpt(args: string[], key: string, value: string | undefined): void {
+  if (value === undefined || value.length === 0) return;
+  args.push(key, value);
+}
+
+export function createMirAdapter(_pathOverride?: string): CliAdapter {
+  return {
+    id: 'mir',
+    resolvedBin: process.execPath,
+
+    buildArgs({ sessionId, botName, botOpenId, locale }) {
+      const args = [runnerPath(), '--session-id', sessionId];
+      pushOpt(args, '--bot-name', botName);
+      pushOpt(args, '--bot-open-id', botOpenId);
+      pushOpt(args, '--locale', locale);
+      return args;
+    },
+
+    // The conversation lives in mircli's own per-session store (`--session-id`);
+    // botmux re-spawns the runner with the same id to continue. There's no
+    // portable copy-paste resume command for the user's own terminal.
+    buildResumeCommand() {
+      return null;
+    },
+
+    async writeInput(pty: PtyHandle, content: string) {
+      // Chunked + throttled stdin injection (see runner-input.ts) — same path
+      // the mira / codex-app runners use.
+      return writeRunnerInput(pty, '::botmux-mir:', content);
+    },
+
+    completionPattern: undefined,
+    // The runner prints `› ` as its ready prompt between turns.
+    readyPattern: /›/,
+    systemHints: [],
+    // The runner injects its own local-runtime context; botmux skips appending
+    // routing/identity + session id to every message.
+    injectsSessionContext: true,
+    altScreen: false,
+  };
+}
+
+export const create = createMirAdapter;

--- a/src/adapters/cli/registry.ts
+++ b/src/adapters/cli/registry.ts
@@ -17,6 +17,7 @@ import { createAntigravityAdapter } from './antigravity.js';
 import { createMtrAdapter } from './mtr.js';
 import { createHermesAdapter } from './hermes.js';
 import { createMiraAdapter } from './mira.js';
+import { createMirAdapter } from './mir.js';
 import { createTraexAdapter } from './traex.js';
 import { createPiAdapter } from './pi.js';
 import { createCopilotAdapter } from './copilot.js';
@@ -103,7 +104,7 @@ export async function createCliAdapter(id: CliId, pathOverride?: string): Promis
   return adapter;
 }
 
-export { createClaudeCodeAdapter, createSeedAdapter, createRelayAdapter, createAidenAdapter, createCocoAdapter, createCodexAdapter, createCodexAppAdapter, createCursorAdapter, createGeminiAdapter, createOpenCodeAdapter, createAntigravityAdapter, createMtrAdapter, createHermesAdapter, createMiraAdapter, createTraexAdapter, createPiAdapter, createCopilotAdapter, createOhMyPiAdapter };
+export { createClaudeCodeAdapter, createSeedAdapter, createRelayAdapter, createAidenAdapter, createCocoAdapter, createCodexAdapter, createCodexAppAdapter, createCursorAdapter, createGeminiAdapter, createOpenCodeAdapter, createAntigravityAdapter, createMtrAdapter, createHermesAdapter, createMiraAdapter, createMirAdapter, createTraexAdapter, createPiAdapter, createCopilotAdapter, createOhMyPiAdapter };
 
 /** Synchronous version for use in worker process. */
 export function createCliAdapterSync(id: CliId, pathOverride?: string): CliAdapter {
@@ -122,6 +123,7 @@ export function createCliAdapterSync(id: CliId, pathOverride?: string): CliAdapt
     case 'mtr': return createMtrAdapter(pathOverride);
     case 'hermes': return createHermesAdapter(pathOverride);
     case 'mira': return createMiraAdapter(pathOverride);
+    case 'mir': return createMirAdapter(pathOverride);
     case 'traex': return createTraexAdapter(pathOverride);
     case 'pi': return createPiAdapter(pathOverride);
     case 'copilot': return createCopilotAdapter(pathOverride);

--- a/src/adapters/cli/shared-hints.ts
+++ b/src/adapters/cli/shared-hints.ts
@@ -25,3 +25,65 @@ export function buildBotmuxShellHints(locale?: Locale): string[] {
 
 /** @deprecated Use `buildBotmuxShellHints(locale)` instead. Kept for any external callers. */
 export const BOTMUX_SHELL_HINTS: string[] = buildBotmuxShellHints();
+
+/**
+ * Build the `<botmux_routing>` (+ optional `<identity>`) text injected via a
+ * CLI's system-prompt flag (`--append-system-prompt`) for adapters that set
+ * `injectsSessionContext`. Single source of truth shared by claude-code and
+ * mir — keeps the routing/identity wording from drifting between them. The
+ * session-manager omits these blocks from the per-message envelope for such
+ * adapters, so this is the only place the model learns the routing rules.
+ *
+ * Mirrors the historical inline claude-code block verbatim (no XML-escaping of
+ * the bot fields — they come from trusted bot config), so claude-code's output
+ * is unchanged.
+ */
+export function buildBotmuxSystemPromptText(opts: {
+  locale?: Locale;
+  botName?: string;
+  botOpenId?: string;
+}): string {
+  const { locale, botName, botOpenId } = opts;
+  const unknown = t('ai.identity.unknown', undefined, locale);
+  const identityBlock =
+    botName || botOpenId
+      ? [
+        '',
+        '<identity>',
+        `  <name>${botName ?? unknown}</name>`,
+        `  <open_id>${botOpenId ?? unknown}</open_id>`,
+        '  <routing_rules>',
+        `    ${t('ai.identity.routing_intro', undefined, locale)}`,
+        `    ${t('ai.identity.rule_own_part', undefined, locale)}`,
+        `    ${t('ai.identity.rule_silent_when_other', undefined, locale)}`,
+        `    ${t('ai.identity.rule_no_proactive_pull', undefined, locale)}`,
+        '',
+        `    ${t('ai.identity.mention_intro', undefined, locale)}`,
+        `    ${t('ai.identity.mention_must', undefined, locale)}`,
+        `    ${t('ai.identity.mention_partners', undefined, locale)}`,
+        `    ${t('ai.identity.mention_usage', undefined, locale)}`,
+        `    ${t('ai.identity.mention_when_to', undefined, locale)}`,
+        `    ${t('ai.identity.mention_when_not', undefined, locale)}`,
+        `    ${t('ai.identity.mention_gate', undefined, locale)}`,
+        '  </routing_rules>',
+        '</identity>',
+      ]
+      : [];
+  return [
+    '<botmux_routing>',
+    t('ai.routing.intro', undefined, locale),
+    t('ai.routing.must_use_botmux', undefined, locale),
+    '',
+    t('ai.routing.usage_heading', undefined, locale),
+    t('ai.routing.usage_send_when', undefined, locale),
+    t('ai.routing.usage_send_text', undefined, locale),
+    t('ai.routing.usage_heredoc', undefined, locale),
+    t('ai.routing.heredoc_example', undefined, locale),
+    t('ai.routing.usage_images', undefined, locale),
+    t('ai.routing.usage_files', undefined, locale),
+    t('ai.routing.usage_history', undefined, locale),
+    t('ai.routing.usage_bots_list', undefined, locale),
+    '</botmux_routing>',
+    ...identityBlock,
+  ].join('\n');
+}

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -330,4 +330,4 @@ export interface CliAdapter {
   readonly defaultPassthroughCommands?: readonly string[];
 }
 
-export type CliId = 'claude-code' | 'seed' | 'relay' | 'aiden' | 'coco' | 'codex' | 'codex-app' | 'cursor' | 'gemini' | 'opencode' | 'antigravity' | 'mtr' | 'hermes' | 'mira' | 'traex' | 'pi' | 'copilot' | 'oh-my-pi';
+export type CliId = 'claude-code' | 'seed' | 'relay' | 'aiden' | 'coco' | 'codex' | 'codex-app' | 'cursor' | 'gemini' | 'opencode' | 'antigravity' | 'mtr' | 'hermes' | 'mira' | 'mir' | 'traex' | 'pi' | 'copilot' | 'oh-my-pi';

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -202,13 +202,22 @@ function loadKnownBotOpenIdsForApp(larkAppId: string): Set<string> {
   return knownBotOpenIdsFromCrossRef(crossRef, botEntries, larkAppId);
 }
 
+/** CLIs whose model→Lark delivery is the daemon's stdout-runner fallback card
+ *  (NOT the model calling `botmux send`): mira (Web API runner) and mir (local
+ *  mircli runner). They can't @-trigger a peer bot themselves, so for bot-to-bot
+ *  handoffs the fallback card must carry the real <at> back to the dispatcher. */
+function isRunnerDeliveryCli(cliId?: string): boolean {
+  return cliId === 'mira' || cliId === 'mir';
+}
+
 function daemonCardFooterRecipientOpenId(ds: DaemonSession, effectiveCliId?: string): string | undefined {
   const owner = ds.session.ownerOpenId;
   if (!owner) {
-    // Mira runs through botmux's API runner and cannot execute `botmux send`
-    // itself. For bot-to-bot handoffs, address the daemon fallback card back
-    // to the original dispatcher so orchestration resumes.
-    if (effectiveCliId === 'mira' && ds.session.quoteTargetSenderIsBot && ds.session.creatorOpenId) {
+    // Mira / Mir run through botmux's stdout-runner and cannot execute
+    // `botmux send` to @-trigger a peer bot. For bot-to-bot handoffs, address
+    // the daemon fallback card back to the original dispatcher so orchestration
+    // resumes (the card's real <at> is what re-wakes the dispatching bot).
+    if (isRunnerDeliveryCli(effectiveCliId) && ds.session.quoteTargetSenderIsBot && ds.session.creatorOpenId) {
       return ds.session.creatorOpenId;
     }
     return undefined;
@@ -217,9 +226,10 @@ function daemonCardFooterRecipientOpenId(ds: DaemonSession, effectiveCliId?: str
     if (loadKnownBotOpenIdsForApp(ds.larkAppId).has(owner)) {
       // `/repo`-primed dispatch records the dispatching bot as owner (unlike
       // the @-mention auto-create path, which nulls ownerOpenId for bot
-      // senders). Same Mira constraint applies: the daemon fallback is Mira's
-      // only reply channel, so address the dispatcher bot here too.
-      return effectiveCliId === 'mira' ? owner : undefined;
+      // senders). Same constraint for the stdout-runner CLIs (mira/mir): the
+      // daemon fallback card is their only @-trigger channel, so address the
+      // dispatcher bot here too.
+      return isRunnerDeliveryCli(effectiveCliId) ? owner : undefined;
     }
     return owner;
   } catch {

--- a/src/dashboard/web/workflows.ts
+++ b/src/dashboard/web/workflows.ts
@@ -1456,7 +1456,7 @@ function terminalOpenInTabLabel(kind: TerminalSurface['kind']): string {
  *    server-side.
  */
 const RESUME_REQUIRES_CLI_SESSION_ID = new Set<string>(['antigravity', 'codex-app', 'cursor', 'mira']);
-const RESUME_USES_SESSION_ID = new Set<string>(['aiden', 'coco', 'claude-code', 'seed', 'relay', 'codex', 'mtr', 'hermes', 'pi']);
+const RESUME_USES_SESSION_ID = new Set<string>(['aiden', 'coco', 'claude-code', 'seed', 'relay', 'codex', 'mtr', 'hermes', 'pi', 'mir']);
 function isResumeCapableCli(cliId: string | undefined): boolean {
   return !!cliId && (RESUME_USES_SESSION_ID.has(cliId) || RESUME_REQUIRES_CLI_SESSION_ID.has(cliId));
 }

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -189,6 +189,7 @@ const cliDisplayNames: Record<CliId, string> = {
   'mtr': 'MTR',
   'hermes': 'Hermes',
   'mira': 'Mira',
+  'mir': 'Mir CLI',
   'traex': 'TRAE',
   'pi': 'Pi',
   'copilot': 'Copilot',

--- a/src/mir-local-runtime.ts
+++ b/src/mir-local-runtime.ts
@@ -1,9 +1,44 @@
 // Local-runtime helpers for the mir adapter (driving local mircli -p --lean).
 // Adapted from shunminli (李舜民)'s PR #245 (src/mira-local-runtime.ts) — credit to author.
 // Folded into the `mir` adapter per Plan A (mira stays Web API, mir = local mircli).
-import { existsSync, readFileSync, realpathSync, renameSync, writeFileSync } from 'node:fs';
+import { closeSync, existsSync, openSync, readFileSync, realpathSync, renameSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+
+/** Synchronous sleep without busy-spin (used only for short lock backoff). */
+function syncSleep(ms: number): void {
+  try { Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms); } catch { /* SAB unavailable */ }
+}
+
+/**
+ * Serialize a read-modify-write of a shared config file across concurrent mir
+ * sessions via an O_EXCL lockfile. Without this, two sessions in different
+ * workspaces each read the old config, add their own path, and the last
+ * `renameSync` clobbers the other's addition. Stale locks (crashed holder) are
+ * broken after STALE_MS; if the lock can't be taken within TIMEOUT_MS we run
+ * unlocked (best-effort — the caller already wraps this in try/catch).
+ */
+function withFileLock<T>(targetPath: string, fn: () => T): T {
+  const lockPath = `${targetPath}.lock`;
+  const STALE_MS = 10_000, TIMEOUT_MS = 3_000, STEP_MS = 50;
+  const deadline = Date.now() + TIMEOUT_MS;
+  let fd: number | undefined;
+  for (;;) {
+    try { fd = openSync(lockPath, 'wx'); break; }
+    catch {
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > STALE_MS) { unlinkSync(lockPath); continue; }
+      } catch { continue; } // lock vanished between open and stat — retry immediately
+      if (Date.now() >= deadline) return fn(); // give up locking, proceed best-effort
+      syncSleep(STEP_MS);
+    }
+  }
+  try { return fn(); }
+  finally {
+    try { closeSync(fd); } catch { /* */ }
+    try { unlinkSync(lockPath); } catch { /* */ }
+  }
+}
 
 type JsonObject = Record<string, any>;
 
@@ -94,6 +129,15 @@ function findMiraLocalMcp(config: JsonObject): JsonObject | undefined {
 }
 
 export function ensureMiramcpSandboxAllows(paths: string[], configPath = miramcpConfigPath()): MiramcpPatchResult {
+  if (!existsSync(configPath)) {
+    return { configPath, changed: false, added: [], skipped: 'missing_config' };
+  }
+  // Lock the whole read-modify-write so concurrent mir sessions can't clobber
+  // each other's write_allow_paths additions (see withFileLock).
+  return withFileLock(configPath, () => patchMiramcpSandbox(paths, configPath));
+}
+
+function patchMiramcpSandbox(paths: string[], configPath: string): MiramcpPatchResult {
   if (!existsSync(configPath)) {
     return { configPath, changed: false, added: [], skipped: 'missing_config' };
   }

--- a/src/mir-local-runtime.ts
+++ b/src/mir-local-runtime.ts
@@ -1,0 +1,136 @@
+// Local-runtime helpers for the mir adapter (driving local mircli -p --lean).
+// Adapted from shunminli (李舜民)'s PR #245 (src/mira-local-runtime.ts) — credit to author.
+// Folded into the `mir` adapter per Plan A (mira stays Web API, mir = local mircli).
+import { existsSync, readFileSync, realpathSync, renameSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+
+type JsonObject = Record<string, any>;
+
+export interface MiraRuntimePaths {
+  cwd: string;
+  home: string;
+  logicalCwd?: string;
+  allowedPathCandidates: string[];
+}
+
+export interface MiramcpPatchResult {
+  configPath: string;
+  changed: boolean;
+  added: string[];
+  skipped?: string;
+}
+
+function unique(paths: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const path of paths) {
+    if (!path || seen.has(path)) continue;
+    seen.add(path);
+    out.push(path);
+  }
+  return out;
+}
+
+function isSubpath(child: string, parent: string): boolean {
+  const rel = relative(parent, child);
+  return rel === '' || (!!rel && !rel.startsWith('..') && !isAbsolute(rel));
+}
+
+function safeRealpath(path: string): string | undefined {
+  try {
+    return realpathSync(path);
+  } catch {
+    return undefined;
+  }
+}
+
+function deriveHomeLogicalCwd(cwd: string, home: string, realHome?: string): string | undefined {
+  if (!realHome || realHome === home) return undefined;
+  const resolvedCwd = resolve(cwd);
+  const resolvedRealHome = resolve(realHome);
+  if (!isSubpath(resolvedCwd, resolvedRealHome)) return undefined;
+  const suffix = relative(resolvedRealHome, resolvedCwd);
+  return suffix ? join(home, suffix) : home;
+}
+
+function pathStartsWithRawPrefix(path: string, prefix: string): boolean {
+  const normalizedPath = resolve(path);
+  const normalizedPrefix = resolve(prefix);
+  if (normalizedPath === normalizedPrefix) return true;
+  const withSep = normalizedPrefix.endsWith(sep) ? normalizedPrefix : `${normalizedPrefix}${sep}`;
+  return normalizedPath.startsWith(withSep);
+}
+
+export function getMiraRuntimePaths(opts: {
+  cwd?: string;
+  home?: string;
+  envPwd?: string;
+  realHome?: string;
+} = {}): MiraRuntimePaths {
+  const cwd = resolve(opts.cwd ?? process.cwd());
+  const home = resolve(opts.home ?? homedir());
+  const envPwd = opts.envPwd && isAbsolute(opts.envPwd) ? resolve(opts.envPwd) : undefined;
+  const realHome = opts.realHome ?? safeRealpath(home);
+  const logicalCwd = deriveHomeLogicalCwd(cwd, home, realHome);
+  const allowedPathCandidates = unique([
+    cwd,
+    logicalCwd,
+    envPwd,
+  ].filter((path): path is string => !!path));
+
+  return { cwd, home, logicalCwd, allowedPathCandidates };
+}
+
+function miramcpConfigPath(): string {
+  return process.env.MIRAMCP_CONFIG_PATH || join(homedir(), '.miramcp', 'config.json');
+}
+
+function findMiraLocalMcp(config: JsonObject): JsonObject | undefined {
+  const mcps = Array.isArray(config.mcps) ? config.mcps : [];
+  return mcps.find((mcp: unknown): mcp is JsonObject =>
+    !!mcp && typeof mcp === 'object' && (mcp as JsonObject).id === 'mira_local',
+  );
+}
+
+export function ensureMiramcpSandboxAllows(paths: string[], configPath = miramcpConfigPath()): MiramcpPatchResult {
+  if (!existsSync(configPath)) {
+    return { configPath, changed: false, added: [], skipped: 'missing_config' };
+  }
+
+  let config: JsonObject;
+  try {
+    config = JSON.parse(readFileSync(configPath, 'utf8'));
+  } catch {
+    return { configPath, changed: false, added: [], skipped: 'invalid_config' };
+  }
+
+  const mcp = findMiraLocalMcp(config);
+  if (!mcp) {
+    return { configPath, changed: false, added: [], skipped: 'missing_mira_local' };
+  }
+
+  const sandbox = (mcp.sandbox && typeof mcp.sandbox === 'object') ? mcp.sandbox as JsonObject : {};
+  mcp.sandbox = sandbox;
+  const writeAllowPaths = Array.isArray(sandbox.write_allow_paths) ? sandbox.write_allow_paths : [];
+  sandbox.write_allow_paths = writeAllowPaths;
+
+  const existing = writeAllowPaths.filter((path): path is string => typeof path === 'string' && path.length > 0);
+  const added: string[] = [];
+  for (const candidate of unique(paths.map(path => resolve(path)))) {
+    if (!isAbsolute(candidate)) continue;
+    if (existing.some(allowed => pathStartsWithRawPrefix(candidate, allowed))) continue;
+    writeAllowPaths.push(candidate);
+    existing.push(candidate);
+    added.push(candidate);
+  }
+
+  if (added.length === 0) {
+    return { configPath, changed: false, added: [] };
+  }
+
+  const tmpPath = `${configPath}.tmp-${process.pid}`;
+  writeFileSync(tmpPath, JSON.stringify(config, null, 2) + '\n', 'utf8');
+  renameSync(tmpPath, configPath);
+  return { configPath, changed: true, added };
+}

--- a/src/mir-runner.ts
+++ b/src/mir-runner.ts
@@ -35,6 +35,7 @@ interface Args {
   botName?: string;
   botOpenId?: string;
   locale?: string;
+  mircliBin?: string;
 }
 
 const OSC_PREFIX = '\x1b]777;botmux:';
@@ -57,6 +58,7 @@ function parseArgs(argv: string[]): Args {
     else if (key === '--bot-name' && val !== undefined) { out.botName = val; i++; }
     else if (key === '--bot-open-id' && val !== undefined) { out.botOpenId = val; i++; }
     else if (key === '--locale' && val !== undefined) { out.locale = val; i++; }
+    else if (key === '--mircli-bin' && val !== undefined) { out.mircliBin = val; i++; }
   }
   if (!out.sessionId) throw new Error('--session-id is required');
   return out;
@@ -245,6 +247,21 @@ function summarizeMentions(content: string): string | undefined {
   return ['Mentions in this BotMux turn:', ...mentions].join('\n');
 }
 
+function summarizeSender(content: string): string | undefined {
+  const attrs = extractOpeningTagAttributes(content, 'sender');
+  if (attrs === undefined) return undefined;
+  const type = extractXmlAttribute(attrs, 'type');
+  const name = extractXmlAttribute(attrs, 'name');
+  const openId = extractXmlAttribute(attrs, 'open_id');
+  if (!name && !openId && !type) return undefined;
+  const who = `${name || '(unknown)'}${openId ? ` (${openId})` : ''}${type ? ` [${type}]` : ''}`;
+  const lines = [`Message sender: ${who}`];
+  if (type === 'bot') {
+    lines.push('The sender is another bot — your reply is delivered back to it automatically; do not worry about @-mentioning to wake it.');
+  }
+  return lines.join('\n');
+}
+
 function normalizeMircliPrompt(content: string): string {
   const userMessage = extractTaggedBlock(content, 'user_message');
   if (!userMessage) return content;
@@ -252,6 +269,7 @@ function normalizeMircliPrompt(content: string): string {
   const context = [
     summarizeBotmuxRouting(content),
     summarizeRole(content),
+    summarizeSender(content),
     summarizeMentions(content),
     summarizeAvailableBots(content),
   ].filter((section): section is string => Boolean(section));
@@ -274,9 +292,11 @@ function normalizeMircliPrompt(content: string): string {
 
 class MircliClient {
   private readonly sessionId: string;
+  private readonly mircliBin?: string;
 
   constructor(args: Args) {
     this.sessionId = args.sessionId;
+    this.mircliBin = args.mircliBin;
   }
 
   async ensureSession(): Promise<string> {
@@ -294,7 +314,8 @@ class MircliClient {
 
   private runMircli(content: string): Promise<string> {
     return new Promise((resolve, reject) => {
-      const bin = process.env.MIRCLI_BIN || 'mircli';
+      // Precedence: adapter cliPathOverride (--mircli-bin) > MIRCLI_BIN env > PATH.
+      const bin = this.mircliBin || process.env.MIRCLI_BIN || 'mircli';
       // Patch the local MCP bridge sandbox so writes to this workspace aren't
       // blocked (workspace may sit outside the default /root,/tmp allow-list).
       if (boolEnv('MIRCLI_PATCH_MIRAMCP_CONFIG', true)) {

--- a/src/mir-runner.ts
+++ b/src/mir-runner.ts
@@ -1,0 +1,481 @@
+#!/usr/bin/env node
+/**
+ * Mir CLI (mircli) runner — the `mir` adapter's backend.
+ *
+ * Unlike the interactive PTY adapters, `mir` drives mircli through its
+ * non-interactive Print Mode: each botmux turn spawns
+ *
+ *     mircli -p <content> --lean --output-format text --session-id <sid> -y \
+ *            --append-system-prompt <local-runtime-context>
+ *
+ * in the botmux workspace cwd, captures stdout, and ships it back to the daemon
+ * as an OSC `final` marker (parsed by the worker, see APP_RUNNER_OSC_CLI_IDS).
+ *
+ * Why Print Mode instead of driving the TUI (the original interactive `mir`):
+ *   - no "恢复上次对话? [y/N]" startup prompt, no ≥10-line paste folding, no
+ *     lazy-save (so no MIRA_HOME isolation / /save flush / transcript drain);
+ *   - `mircli` is local-first (`comprehensive=0`): file/bash tools execute on
+ *     THIS machine, so `mir` operates on the real workspace (needs the user's
+ *     local MCP bridge connected — same prerequisite as standalone mircli);
+ *   - delivery is the runner's stdout, so it needs neither `botmux send` nor
+ *     BOTMUX_SESSION_ID injection — the daemon already owns the session.
+ *
+ * Limitation: because delivery is stdout (not `botmux send`), `mir` is a passive
+ * participant — it answers when @-mentioned but cannot proactively @ another bot
+ * (a structured outbound-mention channel is a separate follow-up).
+ */
+import { spawn } from 'node:child_process';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { Buffer } from 'node:buffer';
+import { getMiraRuntimePaths, ensureMiramcpSandboxAllows } from './mir-local-runtime.js';
+
+interface Args {
+  sessionId: string;
+  botName?: string;
+  botOpenId?: string;
+  locale?: string;
+}
+
+const OSC_PREFIX = '\x1b]777;botmux:';
+const OSC_END = '\x07';
+const DEFAULT_QUERY_TIMEOUT = '10m';
+const DEFAULT_RUNNER_TIMEOUT_MS = 12 * 60 * 1000;
+const MARKER_PREFIX = '::botmux-mir:';
+// Backend Claude-harness builtin tools that route to the cloud sandbox; mircli's
+// own local tools are the lowercase equivalents. Optionally hard-disallow these
+// (MIRCLI_DISALLOW_BUILTIN=1) to push the model onto the local tools. Off by
+// default — the validated path relies on --lean + the local MCP bridge.
+const BUILTIN_SANDBOX_TOOLS = ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep'];
+
+function parseArgs(argv: string[]): Args {
+  const out: Args = { sessionId: '' };
+  for (let i = 0; i < argv.length; i++) {
+    const key = argv[i];
+    const val = argv[i + 1];
+    if (key === '--session-id' && val !== undefined) { out.sessionId = val; i++; }
+    else if (key === '--bot-name' && val !== undefined) { out.botName = val; i++; }
+    else if (key === '--bot-open-id' && val !== undefined) { out.botOpenId = val; i++; }
+    else if (key === '--locale' && val !== undefined) { out.locale = val; i++; }
+  }
+  if (!out.sessionId) throw new Error('--session-id is required');
+  return out;
+}
+
+function b64Json(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), 'utf8').toString('base64');
+}
+
+function emitMarker(kind: string, payload: unknown): void {
+  process.stdout.write(`${OSC_PREFIX}${kind}:${b64Json(payload)}${OSC_END}`);
+}
+
+function writeLine(text = ''): void {
+  process.stdout.write(text + '\n');
+}
+
+function prompt(): void {
+  process.stdout.write('› ');
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function boolEnv(name: string, fallback: boolean): boolean {
+  const raw = process.env[name]?.trim().toLowerCase();
+  if (raw === undefined || raw === '') return fallback;
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
+}
+
+function splitEnvArgs(value: string | undefined): string[] {
+  return (value || '').split(/\s+/).map(s => s.trim()).filter(Boolean);
+}
+
+/** Strip OSC/CSI/escape sequences so the captured stdout is plain text. */
+function stripAnsi(text: string): string {
+  return text
+    .replace(/\x1b\][\s\S]*?(?:\x07|\x1b\\)/g, '')
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\x1b[@-Z\\-_]/g, '');
+}
+
+/** Ensure ~/.local/bin (where mircli installs) is on PATH for the child. */
+function localPathEnv(): string {
+  const existing = process.env.PATH || '';
+  const localBin = join(homedir(), '.local', 'bin');
+  return existing.split(':').includes(localBin) ? existing : `${localBin}:${existing}`;
+}
+
+function runtimeSystemPrompt(): string {
+  const paths = getMiraRuntimePaths();
+  const lines = [
+    'You are invoked by BotMux inside the user machine through the local Mir CLI.',
+    `Actual local runtime cwd: ${paths.cwd}`,
+    `Actual local home: ${paths.home}`,
+  ];
+  if (paths.logicalCwd && paths.logicalCwd !== paths.cwd) {
+    lines.push(
+      `Local tool path alias for the same cwd: ${paths.logicalCwd}`,
+      'If a local tool reports the physical cwd is outside allowed roots, retry the same operation with this local tool path alias.',
+    );
+  }
+  lines.push(
+    `Local tool allowed path candidates: ${paths.allowedPathCandidates.join(', ')}`,
+    'BotMux invokes you in a non-interactive message bridge. NEVER emit ```ask_user_call``` or ```ask_user_form_call``` fences for local path, permission, or environment issues.',
+    'If the target path is not obvious, use the actual local runtime cwd above. Do not ask the user to choose a path when this cwd is provided.',
+    'This BotMux session is not running in /home/mira/.session. Do not report /home/mira/.session as the working directory for this session.',
+    'Local filesystem, shell/bash, git, and BotMux CLI tools are available through the Mir CLI local tool bridge for this process.',
+    'When the user asks to create, read, list, edit, or inspect local files, run bash/shell commands, inspect git, or operate BotMux, you MUST call the local tools against the actual local cwd above.',
+    'Prefer local bash commands that operate from the current cwd with relative paths first; if an absolute physical cwd fails, retry the same operation from the current cwd and then with the local tool path alias before reporting failure.',
+    'Do not say the local MCP bridge is disconnected, that only a cloud sandbox is available, or that the operation is cancelled unless a concrete local tool invocation actually returned that error.',
+    'If a local tool invocation fails, report the exact failed operation and error concisely, then stop or ask for the missing input.',
+  );
+  return [
+    ...lines,
+  ].join('\n');
+}
+
+function decodeXmlEntities(text: string): string {
+  return text
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+function extractTaggedBlock(content: string, tag: string): string | undefined {
+  const open = new RegExp(`<${tag}\\b[^>]*>`, 'i').exec(content);
+  if (!open) return undefined;
+  const start = open.index + open[0].length;
+  const close = content.toLowerCase().indexOf(`</${tag}>`, start);
+  if (close < 0) return undefined;
+  return content.slice(start, close).trim();
+}
+
+function extractOpeningTagAttributes(content: string, tag: string): string | undefined {
+  const open = new RegExp(`<${tag}\\b([^>]*)>`, 'i').exec(content);
+  return open ? open[1] : undefined;
+}
+
+function extractXmlAttribute(attrs: string, name: string): string | undefined {
+  const pattern = new RegExp(`\\b${name}="([^"]*)"`, 'i');
+  const match = pattern.exec(attrs);
+  return match ? decodeXmlEntities(match[1]) : undefined;
+}
+
+function summarizeAttachments(content: string): string[] {
+  const block = extractTaggedBlock(content, 'attachments');
+  if (!block) return [];
+
+  const out: string[] = [];
+  const itemPattern = /<(image|file)\b([^>]*)\/?>/gi;
+  for (const match of block.matchAll(itemPattern)) {
+    const type = match[1].toLowerCase();
+    const attrs = match[2];
+    const n = extractXmlAttribute(attrs, 'n');
+    const path = extractXmlAttribute(attrs, 'path');
+    const name = extractXmlAttribute(attrs, 'name');
+    if (!path) continue;
+    const label = type === 'image' ? 'image' : 'file';
+    const index = n ? ` ${n}` : '';
+    const suffix = name ? ` (${name})` : '';
+    out.push(`${label}${index}: ${path}${suffix}`);
+  }
+  return out;
+}
+
+function summarizeRole(content: string): string | undefined {
+  const block = extractTaggedBlock(content, 'role');
+  if (!block) return undefined;
+  const role = decodeXmlEntities(block).trim();
+  if (!role) return undefined;
+  return ['Role context from BotMux:', role].join('\n');
+}
+
+function summarizeBotmuxRouting(content: string): string | undefined {
+  const block = extractTaggedBlock(content, 'botmux_routing');
+  if (!block) return undefined;
+  const routing = decodeXmlEntities(block).trim();
+  if (!routing) return undefined;
+  return ['BotMux routing instructions:', routing].join('\n');
+}
+
+function summarizeAvailableBots(content: string): string | undefined {
+  const block = extractTaggedBlock(content, 'available_bots');
+  if (!block) return undefined;
+
+  const lines: string[] = [];
+  const attrs = extractOpeningTagAttributes(content, 'available_bots') || '';
+  const hint = extractXmlAttribute(attrs, 'hint');
+  if (hint) lines.push(hint);
+
+  const botPattern = /<bot\b([^>]*)\/?>/gi;
+  for (const match of block.matchAll(botPattern)) {
+    const name = extractXmlAttribute(match[1], 'name');
+    const openId = extractXmlAttribute(match[1], 'open_id');
+    if (!name && !openId) continue;
+    lines.push(`- ${name || '(unnamed bot)'}: ${openId || '(missing open_id)'}`);
+  }
+
+  if (lines.length === 0) return undefined;
+  return [
+    'Available BotMux bots for handoff:',
+    ...lines,
+    'To hand work off to one of these bots, use local bash to run: botmux send --mention <open_id> "message".',
+  ].join('\n');
+}
+
+function summarizeMentions(content: string): string | undefined {
+  const block = extractTaggedBlock(content, 'mentions');
+  if (!block) return undefined;
+
+  const mentions: string[] = [];
+  const mentionPattern = /<mention\b([^>]*)\/?>/gi;
+  for (const match of block.matchAll(mentionPattern)) {
+    const name = extractXmlAttribute(match[1], 'name');
+    const openId = extractXmlAttribute(match[1], 'open_id');
+    if (!name && !openId) continue;
+    mentions.push(`- ${name || '(unnamed mention)'}${openId ? `: ${openId}` : ''}`);
+  }
+
+  if (mentions.length === 0) return undefined;
+  return ['Mentions in this BotMux turn:', ...mentions].join('\n');
+}
+
+function normalizeMircliPrompt(content: string): string {
+  const userMessage = extractTaggedBlock(content, 'user_message');
+  if (!userMessage) return content;
+
+  const context = [
+    summarizeBotmuxRouting(content),
+    summarizeRole(content),
+    summarizeMentions(content),
+    summarizeAvailableBots(content),
+  ].filter((section): section is string => Boolean(section));
+
+  const sections: string[] = [];
+  if (context.length > 0) {
+    sections.push(['BotMux context:', ...context].join('\n\n'));
+  }
+  sections.push(['User request:', decodeXmlEntities(userMessage)].join('\n'));
+
+  const attachments = summarizeAttachments(content);
+  if (attachments.length > 0) {
+    sections.push([
+      'Attachments available on the local filesystem:',
+      ...attachments.map(item => `- ${item}`),
+    ].join('\n'));
+  }
+  return sections.join('\n\n');
+}
+
+class MircliClient {
+  private readonly sessionId: string;
+
+  constructor(args: Args) {
+    this.sessionId = args.sessionId;
+  }
+
+  async ensureSession(): Promise<string> {
+    emitMarker('thread', { threadId: this.sessionId });
+    return this.sessionId;
+  }
+
+  async complete(content: string): Promise<{ finalText: string; turnId: string }> {
+    const startedAt = Date.now();
+    // Unwrap botmux's envelope (extract <user_message>, summarize routing/role/
+    // mentions/available_bots) before handing the prompt to mircli.
+    const finalText = await this.runMircli(normalizeMircliPrompt(content));
+    return { finalText: finalText.trim(), turnId: `mircli-${startedAt}` };
+  }
+
+  private runMircli(content: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const bin = process.env.MIRCLI_BIN || 'mircli';
+      // Patch the local MCP bridge sandbox so writes to this workspace aren't
+      // blocked (workspace may sit outside the default /root,/tmp allow-list).
+      if (boolEnv('MIRCLI_PATCH_MIRAMCP_CONFIG', true)) {
+        try {
+          ensureMiramcpSandboxAllows(getMiraRuntimePaths().allowedPathCandidates);
+        } catch {
+          // Best-effort: the system prompt still gives physical + logical cwd
+          // aliases so the model can recover if the bridge hasn't reloaded.
+        }
+      }
+      const args = splitEnvArgs(process.env.MIRCLI_EXTRA_ARGS);
+      if (boolEnv('MIRCLI_LEAN', true) && !args.includes('--lean') && !args.includes('--ultra')) {
+        args.push('--lean');
+      }
+      args.push(
+        '-p', content,
+        '--output-format', 'text',
+        '--session-id', this.sessionId,
+        '--query-timeout', process.env.MIRCLI_QUERY_TIMEOUT || DEFAULT_QUERY_TIMEOUT,
+        '--append-system-prompt', runtimeSystemPrompt(),
+      );
+      if (boolEnv('MIRCLI_YOLO', true)) args.push('-y');
+      // Optional reliability lever: hard-block the backend's cloud-sandbox
+      // builtins so the model is pushed onto mircli's local tools.
+      if (boolEnv('MIRCLI_DISALLOW_BUILTIN', false)) {
+        for (const tool of BUILTIN_SANDBOX_TOOLS) args.push('--disallowed-tool', tool);
+      }
+
+      let closed = false;
+      let timedOut = false;
+      const child = spawn(bin, args, {
+        cwd: process.cwd(),
+        env: { ...process.env, PATH: localPathEnv() },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      let stdout = '';
+      let stderr = '';
+      const timeoutMs = Number(process.env.MIRCLI_RUNNER_TIMEOUT_MS || DEFAULT_RUNNER_TIMEOUT_MS);
+      const timer = Number.isFinite(timeoutMs) && timeoutMs > 0
+        ? setTimeout(() => {
+          timedOut = true;
+          child.kill('SIGTERM');
+          setTimeout(() => { if (!closed) child.kill('SIGKILL'); }, 5_000).unref();
+        }, timeoutMs)
+        : undefined;
+      timer?.unref();
+
+      child.stdout.on('data', chunk => { stdout += chunk.toString('utf8'); });
+      child.stderr.on('data', chunk => { stderr += chunk.toString('utf8'); });
+      child.on('error', err => {
+        if (timer) clearTimeout(timer);
+        reject(new Error(`Failed to start mircli (${bin}): ${errorMessage(err)}. Install mircli (curl -fsSL https://tosv.byted.org/obj/juren-cn/mircli/install.sh | bash) or set MIRCLI_BIN.`));
+      });
+      child.on('close', (code, signal) => {
+        closed = true;
+        if (timer) clearTimeout(timer);
+        const cleanStdout = stripAnsi(stdout).trim();
+        const cleanStderr = stripAnsi(stderr).trim();
+        if (code === 0) { resolve(cleanStdout || cleanStderr); return; }
+        const detail = (cleanStderr || cleanStdout || `signal ${signal ?? 'unknown'}`).slice(0, 1200);
+        const suffix = timedOut ? ` after ${timeoutMs}ms` : '';
+        reject(new Error(`mircli exited with code ${code ?? 'null'}${suffix}: ${detail}`));
+      });
+    });
+  }
+}
+
+let args: Args;
+try {
+  args = parseArgs(process.argv.slice(2));
+} catch (err) {
+  console.error(`Mir runner: ${errorMessage(err)}`);
+  process.exit(2);
+}
+
+const client = new MircliClient(args);
+const queue: string[] = [];
+let inputBuffer = '';
+let processing = false;
+
+async function runTurn(content: string): Promise<void> {
+  const startedAtMs = Date.now();
+  writeLine();
+  writeLine('[user]');
+  writeLine(content);
+  writeLine();
+  writeLine('[mir] thinking...');
+
+  const result = await client.complete(content);
+  const completedAtMs = Date.now();
+  if (result.finalText) {
+    writeLine();
+    writeLine(result.finalText);
+    emitMarker('final', {
+      turnId: result.turnId,
+      content: result.finalText,
+      startedAtMs,
+      completedAtMs,
+    });
+  } else {
+    writeLine('[mir] completed without text output.');
+  }
+}
+
+async function drainQueue(): Promise<void> {
+  if (processing) return;
+  processing = true;
+  try {
+    while (queue.length > 0) {
+      const next = queue.shift()!;
+      try {
+        await runTurn(next);
+      } catch (err) {
+        const now = Date.now();
+        const message = `Mir runner error: ${errorMessage(err)}`;
+        writeLine(message);
+        emitMarker('final', {
+          turnId: `mir-error-${now}`,
+          content: message,
+          startedAtMs: now,
+          completedAtMs: now,
+        });
+      }
+      prompt();
+    }
+  } finally {
+    processing = false;
+  }
+}
+
+function enqueueLine(line: string): void {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  if (trimmed.startsWith(MARKER_PREFIX)) {
+    const encoded = trimmed.slice(MARKER_PREFIX.length);
+    try {
+      const decoded = JSON.parse(Buffer.from(encoded, 'base64').toString('utf8'));
+      if (decoded?.type === 'message' && typeof decoded.content === 'string') {
+        queue.push(decoded.content);
+        void drainQueue();
+      }
+    } catch (err) {
+      writeLine(`[mir] bad botmux input: ${errorMessage(err)}`);
+    }
+    return;
+  }
+  queue.push(line);
+  void drainQueue();
+}
+
+function handleInput(data: Buffer): void {
+  const text = data.toString('utf8');
+  for (const ch of text) {
+    const code = ch.charCodeAt(0);
+    if (code === 3) {           // Ctrl-C
+      process.exit(130);
+    } else if (ch === '\r' || ch === '\n') {
+      const line = inputBuffer;
+      inputBuffer = '';
+      enqueueLine(line);
+    } else if (code === 127 || code === 8) {  // DEL / Backspace
+      inputBuffer = inputBuffer.slice(0, -1);
+    } else {
+      inputBuffer += ch;
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  await client.ensureSession();
+  writeLine('Mir CLI runner ready.');
+  if (process.stdin.isTTY) process.stdin.setRawMode(true);
+  process.stdin.resume();
+  process.stdin.on('data', handleInput);
+  prompt();
+}
+
+process.on('SIGTERM', () => { process.exit(0); });
+
+main().catch(err => {
+  console.error(`Mir runner failed: ${errorMessage(err)}`);
+  process.exit(1);
+});

--- a/src/setup/bot-config-editor.ts
+++ b/src/setup/bot-config-editor.ts
@@ -19,6 +19,7 @@ export const CLI_ID_CHOICES: Record<string, CliId> = {
   '16': 'copilot',
   '17': 'oh-my-pi',
   '18': 'relay',
+  '19': 'mir',
 };
 
 const VALID_CLI_IDS: ReadonlySet<string> = new Set(Object.values(CLI_ID_CHOICES));
@@ -47,6 +48,7 @@ const CLI_DISPLAY_LABELS: Record<CliId, string> = {
   'copilot': 'Copilot',
   'oh-my-pi': 'Oh My Pi',
   'relay': 'Relay',
+  'mir': 'Mir CLI',
 };
 
 /**

--- a/src/setup/cli-selection.ts
+++ b/src/setup/cli-selection.ts
@@ -59,6 +59,36 @@ const AIDEN_X_CODEX: CliSelectOption = { key: 'aiden-x-codex', label: 'Aiden × 
 
 const AIDEN_VARIANTS: ReadonlyArray<CliSelectOption> = [AIDEN_NATIVE, AIDEN_X_CLAUDE, AIDEN_X_CODEX];
 
+// ─── Mira 选项 ───────────────────────────────────────────────────────────────
+// Mira 有两种形态（都是原生 cliId，无 wrapperCli），合并成一个「Mira」二级菜单：
+//   - Mira App  → cliId `mira`：直连 Mira Web API（云端编排 + 远程沙盒，聊天/搜索）
+//   - Mir CLI   → cliId `mir` ：本地 `mircli -p --lean`（在用户机器上执行、操作工作区）
+const MIRA_APP: CliSelectOption = { key: 'mira', label: 'Mira App（Web API）', cliId: 'mira' };
+const MIRA_CLI: CliSelectOption = { key: 'mir', label: 'Mir CLI（本地 mircli）', cliId: 'mir' };
+
+const MIRA_VARIANTS: ReadonlyArray<CliSelectOption> = [MIRA_APP, MIRA_CLI];
+
+// ─── Codex 选项 ──────────────────────────────────────────────────────────────
+// 两种形态合并成一个「Codex」二级菜单（都是原生 cliId，无 wrapperCli）：
+//   - Codex     → cliId `codex`     ：标准 codex CLI
+//   - Codex App → cliId `codex-app` ：Codex 桌面 app 的 app-server runner
+const CODEX_NATIVE: CliSelectOption = { key: 'codex', label: 'Codex', cliId: 'codex' };
+const CODEX_APP: CliSelectOption = { key: 'codex-app', label: 'Codex App', cliId: 'codex-app' };
+const CODEX_VARIANTS: ReadonlyArray<CliSelectOption> = [CODEX_NATIVE, CODEX_APP];
+
+// ─── TRAE 选项 ───────────────────────────────────────────────────────────────
+// TRAE 家族合并成一个「TRAE (CoCo)」二级菜单（都是原生 cliId，无 wrapperCli）：
+//   - TRAE CLI (CoCo) → cliId `coco`  ：Trae CLI 的 CoCo 形态
+//   - traex           → cliId `traex` ：TRAE CLI（traecli）
+const TRAE_COCO: CliSelectOption = { key: 'coco', label: 'TRAE CLI（CoCo）', cliId: 'coco' };
+const TRAE_X: CliSelectOption = { key: 'traex', label: 'traex', cliId: 'traex' };
+const TRAE_VARIANTS: ReadonlyArray<CliSelectOption> = [TRAE_COCO, TRAE_X];
+
+// ─── Pi 选项 ─────────────────────────────────────────────────────────────────
+// Pi 与 Oh My Pi 不合并，但在菜单里相邻摆放（在 Pi 的位置成对发出）。
+const PI_OPTION: CliSelectOption = { key: 'pi', label: 'Pi', cliId: 'pi' };
+const OHMYPI_OPTION: CliSelectOption = { key: 'oh-my-pi', label: 'Oh My Pi', cliId: 'oh-my-pi' };
+
 // ─── cjadk 选项 ──────────────────────────────────────────────────────────────
 // cjadk 没有「原生 agent」模式，只是个装配启动器（`cjadk <agent>`），故只有 × 变体。
 
@@ -122,11 +152,25 @@ const EXTRA_GATEWAY_GROUPS: ReadonlyArray<CliSelectGroup> = [
  * 末尾追加无原生 cliId 的网关分组（CJADK / TTADK）。
  */
 export const CLI_SELECT_TREE: ReadonlyArray<CliSelectGroup> = [
-  ...CLI_OPTIONS.map((o): CliSelectGroup =>
-    o.id === 'aiden'
-      ? { key: 'aiden', label: 'Aiden', children: AIDEN_VARIANTS }
-      : { key: o.id, label: o.label, option: { key: o.id, label: o.label, cliId: o.id } },
-  ),
+  ...CLI_OPTIONS.flatMap((o): CliSelectGroup[] => {
+    if (o.id === 'aiden') return [{ key: 'aiden', label: 'Aiden', children: AIDEN_VARIANTS }];
+    // mira + mir collapse into one「Mira」二级菜单 at mira's position.
+    if (o.id === 'mira') return [{ key: 'mira', label: 'Mira', children: MIRA_VARIANTS }];
+    if (o.id === 'mir') return []; // already a child of the Mira group above
+    // codex + codex-app collapse into one「Codex」二级菜单 at codex's position.
+    if (o.id === 'codex') return [{ key: 'codex', label: 'Codex', children: CODEX_VARIANTS }];
+    if (o.id === 'codex-app') return [];
+    // coco + traex collapse into one「TRAE (CoCo)」二级菜单 at coco's position.
+    if (o.id === 'coco') return [{ key: 'trae', label: 'TRAE (CoCo)', children: TRAE_VARIANTS }];
+    if (o.id === 'traex') return [];
+    // Pi and Oh My Pi are kept as adjacent leaves (emitted together at pi's spot).
+    if (o.id === 'pi') return [
+      { key: 'pi', label: 'Pi', option: PI_OPTION },
+      { key: 'oh-my-pi', label: 'Oh My Pi', option: OHMYPI_OPTION },
+    ];
+    if (o.id === 'oh-my-pi') return [];
+    return [{ key: o.id, label: o.label, option: { key: o.id, label: o.label, cliId: o.id } }];
+  }),
   ...EXTRA_GATEWAY_GROUPS,
 ];
 
@@ -135,11 +179,18 @@ export const CLI_SELECT_TREE: ReadonlyArray<CliSelectGroup> = [
  * 末尾依次追加 cjadk×* 与 ttadk×* 项。
  */
 export const CLI_SELECT_OPTIONS: ReadonlyArray<CliSelectOption> = [
-  ...CLI_OPTIONS.flatMap((o) =>
-    o.id === 'aiden'
-      ? AIDEN_VARIANTS
-      : [{ key: o.id, label: o.label, cliId: o.id }],
-  ),
+  ...CLI_OPTIONS.flatMap((o) => {
+    if (o.id === 'aiden') return AIDEN_VARIANTS;
+    if (o.id === 'mira') return MIRA_VARIANTS;   // expands to Mira App + Mir CLI
+    if (o.id === 'mir') return [];               // already included via MIRA_VARIANTS
+    if (o.id === 'codex') return CODEX_VARIANTS;  // expands to Codex + Codex App
+    if (o.id === 'codex-app') return [];
+    if (o.id === 'coco') return TRAE_VARIANTS;    // expands to TRAE CLI (CoCo) + traex
+    if (o.id === 'traex') return [];
+    if (o.id === 'pi') return [PI_OPTION, OHMYPI_OPTION];  // Pi + Oh My Pi adjacent
+    if (o.id === 'oh-my-pi') return [];
+    return [{ key: o.id, label: o.label, cliId: o.id }];
+  }),
   ...CJADK_VARIANTS,
   ...TTADK_VARIANTS,
 ];

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -159,7 +159,7 @@ function ensureZellijAttachConfig(): string {
 
 let sessionId = '';
 let lastInitConfig: Extract<DaemonToWorker, { type: 'init' }> | null = null;
-const CLI_DISPLAY_NAMES: Record<string, string> = { 'claude-code': 'Claude', seed: 'Seed', relay: 'Relay', aiden: 'Aiden', coco: 'CoCo', codex: 'Codex', 'codex-app': 'Codex App', cursor: 'Cursor', gemini: 'Gemini', opencode: 'OpenCode', antigravity: 'Antigravity', mtr: 'MTR', hermes: 'Hermes', mira: 'Mira', traex: 'TRAE', pi: 'Pi', copilot: 'Copilot', 'oh-my-pi': 'Oh My Pi' };
+const CLI_DISPLAY_NAMES: Record<string, string> = { 'claude-code': 'Claude', seed: 'Seed', relay: 'Relay', aiden: 'Aiden', coco: 'CoCo', codex: 'Codex', 'codex-app': 'Codex App', cursor: 'Cursor', gemini: 'Gemini', opencode: 'OpenCode', antigravity: 'Antigravity', mtr: 'MTR', hermes: 'Hermes', mira: 'Mira', mir: 'Mir CLI', traex: 'TRAE', pi: 'Pi', copilot: 'Copilot', 'oh-my-pi': 'Oh My Pi' };
 function cliName(): string { return CLI_DISPLAY_NAMES[lastInitConfig?.cliId ?? ''] ?? 'CLI'; }
 let isPromptReady = false;
 /** Mutex for async flushPending — prevents concurrent flush loops. */
@@ -2619,7 +2619,7 @@ let trustHandled = false;
 // not pollute the visible terminal. Strip them before xterm rendering and
 // translate them back into worker IPC.
 const CODEX_APP_OSC_PREFIX = '\x1b]777;botmux:';
-const APP_RUNNER_OSC_CLI_IDS = new Set(['codex-app', 'mira']);
+const APP_RUNNER_OSC_CLI_IDS = new Set(['codex-app', 'mira', 'mir']);
 let codexAppOscPending = '';
 
 function decodeCodexAppPayload(payload: string): any | undefined {
@@ -4202,7 +4202,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
 
   // Set up idle detection
   idleDetector = new IdleDetector(cliAdapter);
-  idleDetector.onIdle(() => {
+  idleDetector.onIdle(async () => {
     log('Prompt detected (idle)');
     // Bridge drain MUST run before markPromptReady() — the latter calls
     // flushPending() which can immediately fire the next queued message

--- a/src/workflows/attempt-resume.ts
+++ b/src/workflows/attempt-resume.ts
@@ -30,7 +30,7 @@ export const ATTEMPT_RESUME_SCHEMA_VERSION = 1;
 export const ATTEMPT_RESUME_IDLE_MS = 30 * 60 * 1000;
 export const ATTEMPT_RESUME_GRACE_MS = 5000;
 export const RESUME_REQUIRES_CLI_SESSION_ID = new Set(['antigravity', 'codex-app', 'cursor', 'mira']);
-export const RESUME_USES_SESSION_ID = new Set(['aiden', 'coco', 'claude-code', 'seed', 'relay', 'codex', 'mtr', 'hermes', 'pi']);
+export const RESUME_USES_SESSION_ID = new Set(['aiden', 'coco', 'claude-code', 'seed', 'relay', 'codex', 'mtr', 'hermes', 'pi', 'mir']);
 
 export type AttemptResumeStatus = 'starting' | 'live' | 'closed';
 

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -425,6 +425,19 @@ describe('mir buildArgs (runner model)', () => {
     expect(args).not.toContain('opus4.6');
   });
 
+  it('passes a cliPathOverride to the runner via --mircli-bin (absolute kept as-is)', () => {
+    const overridden = createMirAdapter('/opt/mircli/bin/mircli');
+    const args = overridden.buildArgs({ sessionId: 's', resume: false });
+    const idx = args.indexOf('--mircli-bin');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(args[idx + 1]).toBe('/opt/mircli/bin/mircli');
+  });
+
+  it('omits --mircli-bin when no cliPathOverride is configured', () => {
+    const args = adapter.buildArgs({ sessionId: 's', resume: false });
+    expect(args).not.toContain('--mircli-bin');
+  });
+
   it('has no portable copy-paste resume command (mircli owns the session store)', () => {
     expect(adapter.buildResumeCommand?.({ sessionId: 'sess-mir', cliSessionId: 'conv-abc' })).toBeNull();
   });

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -31,6 +31,7 @@ import { createAntigravityAdapter } from '../src/adapters/cli/antigravity.js';
 import { createMtrAdapter, mtrSessionIdForBotmuxSession } from '../src/adapters/cli/mtr.js';
 import { createHermesAdapter } from '../src/adapters/cli/hermes.js';
 import { createMiraAdapter } from '../src/adapters/cli/mira.js';
+import { createMirAdapter } from '../src/adapters/cli/mir.js';
 import { createTraexAdapter } from '../src/adapters/cli/traex.js';
 import { createPiAdapter } from '../src/adapters/cli/pi.js';
 import { createCopilotAdapter } from '../src/adapters/cli/copilot.js';
@@ -41,7 +42,7 @@ import type { CliAdapter, CliId } from '../src/adapters/cli/types.js';
 // Helpers
 // ---------------------------------------------------------------------------
 
-const ALL_CLI_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'codex-app', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes', 'mira', 'traex', 'pi', 'copilot', 'oh-my-pi'];
+const ALL_CLI_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'codex-app', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes', 'mira', 'mir', 'traex', 'pi', 'copilot', 'oh-my-pi'];
 
 // ---------------------------------------------------------------------------
 // 1. Factory: createCliAdapterSync
@@ -60,7 +61,7 @@ describe('createCliAdapterSync factory', () => {
 
   it.each(ALL_CLI_IDS)('adapter for "%s" has resolvedBin set', (id) => {
     const adapter = createCliAdapterSync(id, `/opt/${id}`);
-    if (id === 'codex-app' || id === 'mira') expect(adapter.resolvedBin).toBe(process.execPath);
+    if (id === 'codex-app' || id === 'mira' || id === 'mir') expect(adapter.resolvedBin).toBe(process.execPath);
     else expect(adapter.resolvedBin).toBe(`/opt/${id}`);
   });
 });
@@ -392,6 +393,49 @@ describe('mira buildArgs', () => {
     });
     expect(args).toContain('--mira-session-id');
     expect(args).toContain('mira-session-123');
+  });
+});
+
+describe('mir buildArgs (runner model)', () => {
+  const adapter = createMirAdapter();
+
+  it('spawns the mir-runner via node with --session-id', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-mir', resume: false });
+    expect(adapter.resolvedBin).toBe(process.execPath);
+    expect(args[0]).toMatch(/mir-runner\.js$/);
+    expect(args).toContain('--session-id');
+    expect(args).toContain('sess-mir');
+  });
+
+  it('forwards bot identity + locale to the runner', () => {
+    const args = adapter.buildArgs({
+      sessionId: 's', resume: false, botName: 'Mir', botOpenId: 'ou_x', locale: 'zh',
+    });
+    expect(args).toContain('--bot-name');
+    expect(args).toContain('Mir');
+    expect(args).toContain('--bot-open-id');
+    expect(args).toContain('ou_x');
+    expect(args).toContain('--locale');
+    expect(args).toContain('zh');
+  });
+
+  it('ignores model (mircli model is a global file, not a flag)', () => {
+    const args = adapter.buildArgs({ sessionId: 's', resume: false, model: 'opus4.6' });
+    expect(args).not.toContain('--model');
+    expect(args).not.toContain('opus4.6');
+  });
+
+  it('has no portable copy-paste resume command (mircli owns the session store)', () => {
+    expect(adapter.buildResumeCommand?.({ sessionId: 'sess-mir', cliSessionId: 'conv-abc' })).toBeNull();
+  });
+
+  it('readyPattern matches the runner prompt indicator', () => {
+    expect(adapter.readyPattern?.test('› ')).toBe(true);
+  });
+
+  it('injectsSessionContext (runner injects its own context) + empty systemHints', () => {
+    expect(adapter.injectsSessionContext).toBe(true);
+    expect(adapter.systemHints).toEqual([]);
   });
 });
 

--- a/test/cli-selection.test.ts
+++ b/test/cli-selection.test.ts
@@ -45,10 +45,60 @@ describe('CLI_SELECT_OPTIONS / CLI_SELECT_TREE', () => {
   it('cascades Aiden into a submenu of three variants', () => {
     const aiden = CLI_SELECT_TREE.find((g) => g.key === 'aiden');
     expect(aiden?.children?.map((c) => c.key)).toEqual(['aiden', 'aiden-x-claude', 'aiden-x-codex']);
-    // every non-aiden top entry is a directly-selectable leaf
+    // an ungrouped top entry is a directly-selectable leaf
+    const gemini = CLI_SELECT_TREE.find((g) => g.key === 'gemini');
+    expect(gemini?.option?.cliId).toBe('gemini');
+    expect(gemini?.children).toBeUndefined();
+  });
+
+  it('cascades Codex into one submenu of Codex + Codex App (no top-level codex-app)', () => {
     const codex = CLI_SELECT_TREE.find((g) => g.key === 'codex');
-    expect(codex?.option?.cliId).toBe('codex');
-    expect(codex?.children).toBeUndefined();
+    expect(codex?.children?.map((c) => c.key)).toEqual(['codex', 'codex-app']);
+    expect(codex?.option).toBeUndefined();
+    expect(CLI_SELECT_TREE.find((g) => g.key === 'codex-app')).toBeUndefined();
+    expect(resolveCliSelection('codex')).toEqual({ cliId: 'codex' });
+    expect(resolveCliSelection('codex-app')).toEqual({ cliId: 'codex-app' });
+  });
+
+  it('cascades TRAE (CoCo) into one submenu of coco + traex (no top-level coco/traex)', () => {
+    const trae = CLI_SELECT_TREE.find((g) => g.key === 'trae');
+    expect(trae?.label).toBe('TRAE (CoCo)');
+    expect(trae?.children?.map((c) => c.key)).toEqual(['coco', 'traex']);
+    expect(trae?.option).toBeUndefined();
+    expect(CLI_SELECT_TREE.find((g) => g.key === 'coco')).toBeUndefined();
+    expect(CLI_SELECT_TREE.find((g) => g.key === 'traex')).toBeUndefined();
+    expect(resolveCliSelection('coco')).toEqual({ cliId: 'coco' });
+    expect(resolveCliSelection('traex')).toEqual({ cliId: 'traex' });
+  });
+
+  it('keeps Pi and Oh My Pi as adjacent top-level leaves', () => {
+    const treeKeys = CLI_SELECT_TREE.map((g) => g.key);
+    const i = treeKeys.indexOf('pi');
+    expect(i).toBeGreaterThanOrEqual(0);
+    expect(treeKeys[i + 1]).toBe('oh-my-pi');
+    // both remain directly-selectable leaves (not a submenu)
+    expect(CLI_SELECT_TREE[i].option?.cliId).toBe('pi');
+    expect(CLI_SELECT_TREE[i + 1].option?.cliId).toBe('oh-my-pi');
+    const flatKeys = CLI_SELECT_OPTIONS.map((o) => o.key);
+    const fi = flatKeys.indexOf('pi');
+    expect(flatKeys[fi + 1]).toBe('oh-my-pi');
+  });
+
+  it('cascades Mira into one submenu of Mira App + Mir CLI (no top-level mir)', () => {
+    const mira = CLI_SELECT_TREE.find((g) => g.key === 'mira');
+    expect(mira?.children?.map((c) => c.key)).toEqual(['mira', 'mir']);
+    expect(mira?.option).toBeUndefined();
+    // mir is no longer a separate top-level entry — it lives under the Mira group.
+    expect(CLI_SELECT_TREE.find((g) => g.key === 'mir')).toBeUndefined();
+    // flat list: both resolvable, mir folded under mira (no duplicate top entry)
+    const keys = CLI_SELECT_OPTIONS.map((o) => o.key);
+    expect(keys).toContain('mira');
+    expect(keys).toContain('mir');
+  });
+
+  it('resolves both Mira variants to their native cliIds (no wrapperCli)', () => {
+    expect(resolveCliSelection('mira')).toEqual({ cliId: 'mira' });
+    expect(resolveCliSelection('mir')).toEqual({ cliId: 'mir' });
   });
 
   it('cascades CJADK into a submenu of its two × variants', () => {

--- a/test/mir-local-runtime.test.ts
+++ b/test/mir-local-runtime.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -88,5 +88,21 @@ describe('ensureMiramcpSandboxAllows', () => {
     const updated = JSON.parse(readFileSync(configPath, 'utf8'));
     expect(updated.mcps[0].sandbox.write_allow_paths).toEqual(['/data00/home/alice']);
   });
-});
 
+  it('accumulates paths across sequential (locked) calls and cleans up the lockfile', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-miramcp-'));
+    const configPath = join(dir, 'config.json');
+    writeFileSync(configPath, JSON.stringify({
+      mcps: [{ id: 'mira_local', sandbox: { write_allow_paths: [] } }],
+    }));
+
+    ensureMiramcpSandboxAllows(['/ws/a'], configPath);
+    ensureMiramcpSandboxAllows(['/ws/b'], configPath);
+
+    const updated = JSON.parse(readFileSync(configPath, 'utf8'));
+    // Second call must NOT clobber the first call's addition.
+    expect(updated.mcps[0].sandbox.write_allow_paths).toEqual(['/ws/a', '/ws/b']);
+    // Lock released (no leftover .lock).
+    expect(existsSync(`${configPath}.lock`)).toBe(false);
+  });
+});

--- a/test/mir-local-runtime.test.ts
+++ b/test/mir-local-runtime.test.ts
@@ -1,0 +1,92 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { ensureMiramcpSandboxAllows, getMiraRuntimePaths } from '../src/mir-local-runtime.js';
+
+describe('getMiraRuntimePaths', () => {
+  it('derives a logical home alias when cwd is under a symlinked home realpath', () => {
+    const paths = getMiraRuntimePaths({
+      cwd: '/data00/home/alice/.botmux/workspace/mira',
+      home: '/home/alice',
+      realHome: '/data00/home/alice',
+    });
+
+    expect(paths.cwd).toBe('/data00/home/alice/.botmux/workspace/mira');
+    expect(paths.logicalCwd).toBe('/home/alice/.botmux/workspace/mira');
+    expect(paths.allowedPathCandidates).toEqual([
+      '/data00/home/alice/.botmux/workspace/mira',
+      '/home/alice/.botmux/workspace/mira',
+    ]);
+  });
+
+  it('keeps an absolute PWD alias when it is different from the physical cwd', () => {
+    const paths = getMiraRuntimePaths({
+      cwd: '/mnt/data/project',
+      home: '/home/alice',
+      envPwd: '/home/alice/project',
+      realHome: '/home/alice',
+    });
+
+    expect(paths.allowedPathCandidates).toEqual([
+      '/mnt/data/project',
+      '/home/alice/project',
+    ]);
+  });
+});
+
+describe('ensureMiramcpSandboxAllows', () => {
+  it('adds the physical cwd when only the logical home path is allowed', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-miramcp-'));
+    const configPath = join(dir, 'config.json');
+    writeFileSync(configPath, JSON.stringify({
+      mcps: [{
+        id: 'mira_local',
+        protocol: 'stdio',
+        command: '/usr/bin/node',
+        args: ['mira_local_mcp.js'],
+        sandbox: {
+          enabled: true,
+          write_allow_paths: ['/home/alice', '/tmp'],
+          write_deny_paths: ['/home/alice/.ssh'],
+          read_deny_paths: ['/home/alice/.ssh'],
+        },
+      }],
+    }, null, 2));
+
+    const result = ensureMiramcpSandboxAllows([
+      '/data00/home/alice/.botmux/workspace/mira',
+      '/home/alice/.botmux/workspace/mira',
+    ], configPath);
+
+    expect(result.changed).toBe(true);
+    expect(result.added).toEqual(['/data00/home/alice/.botmux/workspace/mira']);
+    const updated = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(updated.mcps[0].sandbox.write_allow_paths).toEqual([
+      '/home/alice',
+      '/tmp',
+      '/data00/home/alice/.botmux/workspace/mira',
+    ]);
+  });
+
+  it('does not add duplicates when the physical cwd is already under an allowed raw prefix', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-miramcp-'));
+    const configPath = join(dir, 'config.json');
+    writeFileSync(configPath, JSON.stringify({
+      mcps: [{
+        id: 'mira_local',
+        sandbox: {
+          write_allow_paths: ['/data00/home/alice'],
+        },
+      }],
+    }));
+
+    const result = ensureMiramcpSandboxAllows(['/data00/home/alice/project'], configPath);
+
+    expect(result.changed).toBe(false);
+    expect(result.added).toEqual([]);
+    const updated = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(updated.mcps[0].sandbox.write_allow_paths).toEqual(['/data00/home/alice']);
+  });
+});
+

--- a/test/workflow-attempt-resume.test.ts
+++ b/test/workflow-attempt-resume.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 
 import {
   AttemptResumeManager,
+  RESUME_USES_SESSION_ID,
   type AttemptResumeBot,
 } from '../src/workflows/attempt-resume.js';
 import {
@@ -98,6 +99,12 @@ function seedAttempt(tmp: string, opts: { cliSessionId?: string | null; cliId?: 
   );
   return { runId, activityId, attemptId };
 }
+
+describe('RESUME_USES_SESSION_ID', () => {
+  it('treats mir as session-id-resumable (mir runner continues via --session-id)', () => {
+    expect(RESUME_USES_SESSION_ID.has('mir')).toBe(true);
+  });
+});
 
 describe('AttemptResumeManager', () => {
   afterEach(() => {

--- a/test/write-input-all-cli.e2e.ts
+++ b/test/write-input-all-cli.e2e.ts
@@ -25,6 +25,7 @@ import { createOpenCodeAdapter } from '../src/adapters/cli/opencode.js';
 import { createMtrAdapter } from '../src/adapters/cli/mtr.js';
 import { createHermesAdapter } from '../src/adapters/cli/hermes.js';
 import { createMiraAdapter } from '../src/adapters/cli/mira.js';
+import { createMirAdapter } from '../src/adapters/cli/mir.js';
 import { createCopilotAdapter } from '../src/adapters/cli/copilot.js';
 import { createOhMyPiAdapter } from '../src/adapters/cli/oh-my-pi.js';
 
@@ -127,6 +128,7 @@ const ADAPTERS = [
   { name: 'mtr', create: () => safeCreate(() => createMtrAdapter()) },
   { name: 'hermes', create: () => safeCreate(() => createHermesAdapter()) },
   { name: 'mira', create: () => safeCreate(() => createMiraAdapter()) },
+  { name: 'mir', create: () => safeCreate(() => createMirAdapter()) },
   { name: 'copilot', create: () => safeCreate(() => createCopilotAdapter()) },
   { name: 'oh-my-pi', create: () => safeCreate(() => createOhMyPiAdapter()) },
 ];


### PR DESCRIPTION
## 概述
把字节内部的 **Mir CLI（mircli，Claude-Code-like 交互式编程助手）** 接成新 CLI 适配器，id = `mir`。

## 核心实现
- **`src/adapters/cli/mir.ts`**：交互式 PTY 适配器（同 coco/traex 家族）
  - `-y` 绕权限（disableCliBypass 闸）、`--resume` 无参恢复、`❯`(U+276F) readyPattern、bracketed paste + Enter 提交
  - 无 `--model` 标志（模型是全局文件），故 modelChoices 留空 → setup 跳过选模型
- **每会话隔离 MIRA_HOME（`src/services/mir-paths.ts` + worker 注入）**：mircli 交互模式两个坑迫使隔离——
  1. 启动**总弹**「恢复上次对话?[y/N]」（在 `❯` 之前，会卡死 botmux 首条消息；`--resume` 也跳不过，代码无条件重读 last_conversation）
  2. 交互模式**不认 `--session-id`** 作会话文件名（随机 uuid 存盘）+ 用**全局 `last_conversation` 指针**（同 bot 多话题并发互踩）
  - 解：每会话 `~/.botmux/mir-homes/<sessionId>`，软链回共享 `~/.mira/config.json`（auth，token 刷新写穿持久化）；spawn 前删 `last_conversation`。fresh→无 y/N；resume→`--resume` 加载该 home 唯一会话；并发不互踩。`MIRA_HOME` 进 tmux 注入白名单。
- **`flushBeforeKill` 钩子（新增 CliAdapter 可选方法）**：mircli 只每 10 条 / 优雅退出才存盘，suspend/close 前发 `/save` 刷盘，避免短会话 resume 丢历史。worker 的 close + suspend 两处 best-effort await。

## 接线（CLAUDE.md 8 处）
types/registry/worker/card-builder/bot-config-editor（setup 菜单自动派生）+ README zh/en。

## 测试
- 新增 `test/mir-paths.test.ts`（6）+ cli-adapters mir 块（buildArgs/resume/flushBeforeKill/readyPattern）+ write-input e2e 接入 mir
- 全量 unit 4583 绿、write-input e2e 132 绿、tsc 0 错
- **真机 e2e**：fresh(无 y/N)→paste 发消息→mircli 回复→`/save`→kill→`--resume` → `✓ 已恢复最近会话 (2 条)` 全链路通

## ⚠️ 运维前置（未在代码处理，按设计交给运维）
mircli **默认在远程 sandbox 跑工具，不碰本地仓库**；要操作本地 repo 需先 `mircli mcp start` 起 MCP Bridge，否则 coding 模式 fail-closed 只能聊天。装不装由用户决定（申晗拍板）。

## 已知限制（v1）
- 没做 `/adopt` 导入用户自己的 mir 会话（隔离 home 与共享 ~/.mira 跨目录，留作后续）
- sandbox 会话下 MIRA_HOME 在 overlay 内 → 跨沙盒会话 resume 不持久（auth 仍走 carve-out 正常）
- per-session home 不随会话关闭清理（resume 需要历史，与共享 ~/.mira/conversations 同生命周期）