### PR TITLE
Run Mira adapter through local mircli

### DIFF
--- a/src/mira-local-runtime.ts
+++ b/src/mira-local-runtime.ts
@@ -1,0 +1,133 @@
+import { existsSync, readFileSync, realpathSync, renameSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+
+type JsonObject = Record<string, any>;
+
+export interface MiraRuntimePaths {
+  cwd: string;
+  home: string;
+  logicalCwd?: string;
+  allowedPathCandidates: string[];
+}
+
+export interface MiramcpPatchResult {
+  configPath: string;
+  changed: boolean;
+  added: string[];
+  skipped?: string;
+}
+
+function unique(paths: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const path of paths) {
+    if (!path || seen.has(path)) continue;
+    seen.add(path);
+    out.push(path);
+  }
+  return out;
+}
+
+function isSubpath(child: string, parent: string): boolean {
+  const rel = relative(parent, child);
+  return rel === '' || (!!rel && !rel.startsWith('..') && !isAbsolute(rel));
+}
+
+function safeRealpath(path: string): string | undefined {
+  try {
+    return realpathSync(path);
+  } catch {
+    return undefined;
+  }
+}
+
+function deriveHomeLogicalCwd(cwd: string, home: string, realHome?: string): string | undefined {
+  if (!realHome || realHome === home) return undefined;
+  const resolvedCwd = resolve(cwd);
+  const resolvedRealHome = resolve(realHome);
+  if (!isSubpath(resolvedCwd, resolvedRealHome)) return undefined;
+  const suffix = relative(resolvedRealHome, resolvedCwd);
+  return suffix ? join(home, suffix) : home;
+}
+
+function pathStartsWithRawPrefix(path: string, prefix: string): boolean {
+  const normalizedPath = resolve(path);
+  const normalizedPrefix = resolve(prefix);
+  if (normalizedPath === normalizedPrefix) return true;
+  const withSep = normalizedPrefix.endsWith(sep) ? normalizedPrefix : `${normalizedPrefix}${sep}`;
+  return normalizedPath.startsWith(withSep);
+}
+
+export function getMiraRuntimePaths(opts: {
+  cwd?: string;
+  home?: string;
+  envPwd?: string;
+  realHome?: string;
+} = {}): MiraRuntimePaths {
+  const cwd = resolve(opts.cwd ?? process.cwd());
+  const home = resolve(opts.home ?? homedir());
+  const envPwd = opts.envPwd && isAbsolute(opts.envPwd) ? resolve(opts.envPwd) : undefined;
+  const realHome = opts.realHome ?? safeRealpath(home);
+  const logicalCwd = deriveHomeLogicalCwd(cwd, home, realHome);
+  const allowedPathCandidates = unique([
+    cwd,
+    logicalCwd,
+    envPwd,
+  ].filter((path): path is string => !!path));
+
+  return { cwd, home, logicalCwd, allowedPathCandidates };
+}
+
+function miramcpConfigPath(): string {
+  return process.env.MIRAMCP_CONFIG_PATH || join(homedir(), '.miramcp', 'config.json');
+}
+
+function findMiraLocalMcp(config: JsonObject): JsonObject | undefined {
+  const mcps = Array.isArray(config.mcps) ? config.mcps : [];
+  return mcps.find((mcp: unknown): mcp is JsonObject =>
+    !!mcp && typeof mcp === 'object' && (mcp as JsonObject).id === 'mira_local',
+  );
+}
+
+export function ensureMiramcpSandboxAllows(paths: string[], configPath = miramcpConfigPath()): MiramcpPatchResult {
+  if (!existsSync(configPath)) {
+    return { configPath, changed: false, added: [], skipped: 'missing_config' };
+  }
+
+  let config: JsonObject;
+  try {
+    config = JSON.parse(readFileSync(configPath, 'utf8'));
+  } catch {
+    return { configPath, changed: false, added: [], skipped: 'invalid_config' };
+  }
+
+  const mcp = findMiraLocalMcp(config);
+  if (!mcp) {
+    return { configPath, changed: false, added: [], skipped: 'missing_mira_local' };
+  }
+
+  const sandbox = (mcp.sandbox && typeof mcp.sandbox === 'object') ? mcp.sandbox as JsonObject : {};
+  mcp.sandbox = sandbox;
+  const writeAllowPaths = Array.isArray(sandbox.write_allow_paths) ? sandbox.write_allow_paths : [];
+  sandbox.write_allow_paths = writeAllowPaths;
+
+  const existing = writeAllowPaths.filter((path): path is string => typeof path === 'string' && path.length > 0);
+  const added: string[] = [];
+  for (const candidate of unique(paths.map(path => resolve(path)))) {
+    if (!isAbsolute(candidate)) continue;
+    if (existing.some(allowed => pathStartsWithRawPrefix(candidate, allowed))) continue;
+    writeAllowPaths.push(candidate);
+    existing.push(candidate);
+    added.push(candidate);
+  }
+
+  if (added.length === 0) {
+    return { configPath, changed: false, added: [] };
+  }
+
+  const tmpPath = `${configPath}.tmp-${process.pid}`;
+  writeFileSync(tmpPath, JSON.stringify(config, null, 2) + '\n', 'utf8');
+  renameSync(tmpPath, configPath);
+  return { configPath, changed: true, added };
+}

--- a/src/mira-runner.ts
+++ b/src/mira-runner.ts
@@ -5,6 +5,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { Buffer } from 'node:buffer';
 import { extractMiraHistoryFinalText, sanitizeMiraFinalText } from './mira-output.js';
+import { ensureMiramcpSandboxAllows, getMiraRuntimePaths } from './mira-local-runtime.js';
 
 type JsonObject = Record<string, any>;
 
@@ -160,15 +161,31 @@ function localPathEnv(): string {
 }
 
 function runtimeSystemPrompt(): string {
-  return [
+  const paths = getMiraRuntimePaths();
+  const lines = [
     'You are invoked by BotMux inside the user machine through the local Mir CLI.',
-    `Actual local runtime cwd: ${process.cwd()}`,
-    `Actual local home: ${homedir()}`,
+    `Actual local runtime cwd: ${paths.cwd}`,
+    `Actual local home: ${paths.home}`,
+  ];
+  if (paths.logicalCwd && paths.logicalCwd !== paths.cwd) {
+    lines.push(
+      `Local tool path alias for the same cwd: ${paths.logicalCwd}`,
+      'If a local tool reports the physical cwd is outside allowed roots, retry the same operation with this local tool path alias.',
+    );
+  }
+  lines.push(
+    `Local tool allowed path candidates: ${paths.allowedPathCandidates.join(', ')}`,
+    'BotMux invokes you in a non-interactive message bridge. NEVER emit ```ask_user_call``` or ```ask_user_form_call``` fences for local path, permission, or environment issues.',
+    'If the target path is not obvious, use the actual local runtime cwd above. Do not ask the user to choose a path when this cwd is provided.',
     'This BotMux session is not running in /home/mira/.session. Do not report /home/mira/.session as the working directory for this session.',
     'Local filesystem, shell/bash, git, and BotMux CLI tools are available through the Mir CLI local tool bridge for this process.',
     'When the user asks to create, read, list, edit, or inspect local files, run bash/shell commands, inspect git, or operate BotMux, you MUST call the local tools against the actual local cwd above.',
+    'Prefer local bash commands that operate from the current cwd with relative paths first; if an absolute physical cwd fails, retry the same operation from the current cwd and then with the local tool path alias before reporting failure.',
     'Do not say the local MCP bridge is disconnected, that only a cloud sandbox is available, or that the operation is cancelled unless a concrete local tool invocation actually returned that error.',
     'If a local tool invocation fails, report the exact failed operation and error concisely, then stop or ask for the missing input.',
+  );
+  return [
+    ...lines,
   ].join('\n');
 }
 
@@ -622,6 +639,16 @@ class MircliClient {
   private runMircli(content: string, sessionId: string): Promise<string> {
     return new Promise((resolve, reject) => {
       const bin = process.env.MIRCLI_BIN || 'mircli';
+      const runtimePaths = getMiraRuntimePaths();
+      if (boolEnv('MIRCLI_PATCH_MIRAMCP_CONFIG', true)) {
+        try {
+          ensureMiramcpSandboxAllows(runtimePaths.allowedPathCandidates);
+        } catch {
+          // Best effort. The system prompt still gives Mira both physical and
+          // logical path aliases so the model can recover when a live bridge has
+          // not reloaded the persistent miramcp config yet.
+        }
+      }
       const args = splitEnvArgs(process.env.MIRCLI_EXTRA_ARGS);
       if (boolEnv('MIRCLI_LEAN', true) && !args.includes('--lean') && !args.includes('--ultra')) {
         args.push('--lean');

--- a/src/mira-runner.ts
+++ b/src/mira-runner.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { execFileSync, spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { Buffer } from 'node:buffer';
@@ -27,8 +27,12 @@ const API_BASE_URL = process.env.MIRA_API_BASE_URL ?? `${MIRA_DOMAIN}/mira/api/v
 const MODEL_METADATA_URL = process.env.MIRA_MODEL_METADATA_URL ?? `${MIRA_DOMAIN}/api/v1/model/metadata`;
 const DEFAULT_DATA_SOURCES = ['manus'];
 const LAST_ROUND_RETRY_DELAYS_MS = [0, 250, 750];
+const DEFAULT_MIRCLI_QUERY_TIMEOUT = '10m';
+const DEFAULT_MIRCLI_RUNNER_TIMEOUT_MS = 12 * 60 * 1000;
 const COOKIE_DB_PATH = process.env.MIRA_COOKIE_DB
   ?? join(homedir(), 'Library', 'Application Support', 'mira', 'Cookies');
+const MIRCLI_CONFIG_PATH = process.env.MIRCLI_CONFIG_PATH
+  ?? join(homedir(), '.mira', 'config.json');
 const OSC_PREFIX = '\x1b]777;botmux:';
 const OSC_END = '\x07';
 
@@ -91,9 +95,19 @@ function runSqliteCookieQuery(dbPath: string): string {
 function readCookieHeader(): string {
   if (process.env.MIRA_COOKIE_HEADER?.trim()) return process.env.MIRA_COOKIE_HEADER.trim();
   if (process.env.MIRA_SESSION?.trim()) return `mira_session=${process.env.MIRA_SESSION.trim()}`;
+  if (existsSync(MIRCLI_CONFIG_PATH)) {
+    try {
+      const config = JSON.parse(readFileSync(MIRCLI_CONFIG_PATH, 'utf8'));
+      if (typeof config.cookies === 'string' && config.cookies.trim()) {
+        return config.cookies.trim();
+      }
+    } catch {
+      // Fall through to the original Mira.app sqlite cookie path.
+    }
+  }
   if (!existsSync(COOKIE_DB_PATH)) {
     throw new Error(
-      `Mira cookie database not found at ${COOKIE_DB_PATH}. Open Mira.app and sign in, or set MIRA_COOKIE_HEADER.`,
+      `Mira cookie database not found at ${COOKIE_DB_PATH}. Open Mira.app and sign in, set MIRA_COOKIE_HEADER, or run mircli login so ${MIRCLI_CONFIG_PATH} contains cookies.`,
     );
   }
 
@@ -126,6 +140,39 @@ function boolEnv(name: string, fallback: boolean): boolean {
   const raw = process.env[name]?.trim().toLowerCase();
   if (!raw) return fallback;
   return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
+}
+
+function splitEnvArgs(value: string | undefined): string[] {
+  return (value || '').split(/\s+/).map(s => s.trim()).filter(Boolean);
+}
+
+function stripAnsi(text: string): string {
+  return text
+    .replace(/\x1b\][\s\S]*?(?:\x07|\x1b\\)/g, '')
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\x1b[@-Z\\-_]/g, '');
+}
+
+function localPathEnv(): string {
+  const existing = process.env.PATH || '';
+  const localBin = join(homedir(), '.local', 'bin');
+  return existing.split(':').includes(localBin) ? existing : `${localBin}:${existing}`;
+}
+
+function runtimeSystemPrompt(): string {
+  return [
+    'You are invoked by BotMux inside the user machine through the local Mir CLI.',
+    `Actual local runtime cwd: ${process.cwd()}`,
+    `Actual local home: ${homedir()}`,
+    'This BotMux session is not running in /home/mira/.session. Do not report /home/mira/.session as the working directory for this session.',
+    'For filesystem, shell, and git work, use the Mir CLI local tools against the actual local cwd above.',
+    'If the Mir local tools are unavailable, say so explicitly instead of using or reporting a cloud sandbox path.',
+  ].join('\n');
+}
+
+function shouldUseApiRunner(): boolean {
+  const raw = process.env.MIRA_RUNNER_MODE?.trim().toLowerCase();
+  return raw === 'api' || raw === 'web';
 }
 
 function extractMiraMessage(data: string): JsonObject | undefined {
@@ -410,6 +457,99 @@ class MiraClient {
   }
 }
 
+class MircliClient {
+  private readonly cliSessionId: string;
+
+  constructor(args: Args) {
+    // Old API-mode sessions persisted a Mira Web session id in --mira-session-id.
+    // mircli expects a local CLI conversation id, so anchor it to BotMux's own
+    // stable session id instead of reusing a Web API id across runner modes.
+    this.cliSessionId = args.sessionId;
+  }
+
+  async ensureSession(): Promise<string> {
+    emitMarker('thread', { threadId: this.cliSessionId });
+    return this.cliSessionId;
+  }
+
+  async complete(content: string): Promise<CompletionResult> {
+    const sessionId = await this.ensureSession();
+    const startedAt = Date.now();
+    const finalText = await this.runMircli(content, sessionId);
+    return {
+      finalText: finalText.trim(),
+      turnId: `mircli-${startedAt}`,
+    };
+  }
+
+  private runMircli(content: string, sessionId: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const bin = process.env.MIRCLI_BIN || 'mircli';
+      const args = splitEnvArgs(process.env.MIRCLI_EXTRA_ARGS);
+      if (boolEnv('MIRCLI_LEAN', true) && !args.includes('--lean') && !args.includes('--ultra')) {
+        args.push('--lean');
+      }
+      args.push(
+        '-p', content,
+        '--output-format', 'text',
+        '--session-id', sessionId,
+        '--query-timeout', process.env.MIRCLI_QUERY_TIMEOUT || DEFAULT_MIRCLI_QUERY_TIMEOUT,
+        '--append-system-prompt', runtimeSystemPrompt(),
+      );
+      if (boolEnv('MIRCLI_YOLO', true)) args.push('-y');
+
+      let closed = false;
+      let timedOut = false;
+      const child = spawn(bin, args, {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          PATH: localPathEnv(),
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      let stdout = '';
+      let stderr = '';
+      const timeoutMs = Number(process.env.MIRCLI_RUNNER_TIMEOUT_MS || DEFAULT_MIRCLI_RUNNER_TIMEOUT_MS);
+      const timer = Number.isFinite(timeoutMs) && timeoutMs > 0
+        ? setTimeout(() => {
+          timedOut = true;
+          child.kill('SIGTERM');
+          setTimeout(() => {
+            if (!closed) child.kill('SIGKILL');
+          }, 5_000).unref();
+        }, timeoutMs)
+        : undefined;
+      timer?.unref();
+
+      child.stdout.on('data', chunk => {
+        stdout += chunk.toString('utf8');
+      });
+      child.stderr.on('data', chunk => {
+        stderr += chunk.toString('utf8');
+      });
+      child.on('error', err => {
+        if (timer) clearTimeout(timer);
+        reject(new Error(`Failed to start mircli (${bin}): ${errorMessage(err)}. Install mircli or set MIRA_RUNNER_MODE=api to use the legacy Web API runner.`));
+      });
+      child.on('close', (code, signal) => {
+        closed = true;
+        if (timer) clearTimeout(timer);
+        const cleanStdout = stripAnsi(stdout).trim();
+        const cleanStderr = stripAnsi(stderr).trim();
+        if (code === 0) {
+          resolve(cleanStdout || cleanStderr);
+          return;
+        }
+        const detail = (cleanStderr || cleanStdout || `signal ${signal ?? 'unknown'}`).slice(0, 1200);
+        const suffix = timedOut ? ` after ${timeoutMs}ms` : '';
+        reject(new Error(`mircli exited with code ${code ?? 'null'}${suffix}: ${detail}`));
+      });
+    });
+  }
+}
+
 let args: Args;
 try {
   args = parseArgs(process.argv.slice(2));
@@ -418,7 +558,7 @@ try {
   process.exit(2);
 }
 
-const client = new MiraClient(args);
+const client = shouldUseApiRunner() ? new MiraClient(args) : new MircliClient(args);
 const queue: string[] = [];
 let inputBuffer = '';
 let processing = false;

--- a/src/mira-runner.ts
+++ b/src/mira-runner.ts
@@ -170,6 +170,66 @@ function runtimeSystemPrompt(): string {
   ].join('\n');
 }
 
+function decodeXmlEntities(text: string): string {
+  return text
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+function extractTaggedBlock(content: string, tag: string): string | undefined {
+  const open = new RegExp(`<${tag}\\b[^>]*>`, 'i').exec(content);
+  if (!open) return undefined;
+  const start = open.index + open[0].length;
+  const close = content.toLowerCase().indexOf(`</${tag}>`, start);
+  if (close < 0) return undefined;
+  return content.slice(start, close).trim();
+}
+
+function extractXmlAttribute(attrs: string, name: string): string | undefined {
+  const pattern = new RegExp(`\\b${name}="([^"]*)"`, 'i');
+  const match = pattern.exec(attrs);
+  return match ? decodeXmlEntities(match[1]) : undefined;
+}
+
+function summarizeAttachments(content: string): string[] {
+  const block = extractTaggedBlock(content, 'attachments');
+  if (!block) return [];
+
+  const out: string[] = [];
+  const itemPattern = /<(image|file)\b([^>]*)\/?>/gi;
+  for (const match of block.matchAll(itemPattern)) {
+    const type = match[1].toLowerCase();
+    const attrs = match[2];
+    const n = extractXmlAttribute(attrs, 'n');
+    const path = extractXmlAttribute(attrs, 'path');
+    const name = extractXmlAttribute(attrs, 'name');
+    if (!path) continue;
+    const label = type === 'image' ? 'image' : 'file';
+    const index = n ? ` ${n}` : '';
+    const suffix = name ? ` (${name})` : '';
+    out.push(`${label}${index}: ${path}${suffix}`);
+  }
+  return out;
+}
+
+function normalizeMircliPrompt(content: string): string {
+  const userMessage = extractTaggedBlock(content, 'user_message');
+  if (!userMessage) return content;
+
+  const sections = [decodeXmlEntities(userMessage)];
+  const attachments = summarizeAttachments(content);
+  if (attachments.length > 0) {
+    sections.push([
+      'Attachments available on the local filesystem:',
+      ...attachments.map(item => `- ${item}`),
+    ].join('\n'));
+  }
+  return sections.join('\n\n');
+}
+
 function shouldUseApiRunner(): boolean {
   const raw = process.env.MIRA_RUNNER_MODE?.trim().toLowerCase();
   return raw === 'api' || raw === 'web';
@@ -475,7 +535,7 @@ class MircliClient {
   async complete(content: string): Promise<CompletionResult> {
     const sessionId = await this.ensureSession();
     const startedAt = Date.now();
-    const finalText = await this.runMircli(content, sessionId);
+    const finalText = await this.runMircli(normalizeMircliPrompt(content), sessionId);
     return {
       finalText: finalText.trim(),
       turnId: `mircli-${startedAt}`,

--- a/src/mira-runner.ts
+++ b/src/mira-runner.ts
@@ -165,8 +165,10 @@ function runtimeSystemPrompt(): string {
     `Actual local runtime cwd: ${process.cwd()}`,
     `Actual local home: ${homedir()}`,
     'This BotMux session is not running in /home/mira/.session. Do not report /home/mira/.session as the working directory for this session.',
-    'For filesystem, shell, and git work, use the Mir CLI local tools against the actual local cwd above.',
-    'If the Mir local tools are unavailable, say so explicitly instead of using or reporting a cloud sandbox path.',
+    'Local filesystem, shell/bash, git, and BotMux CLI tools are available through the Mir CLI local tool bridge for this process.',
+    'When the user asks to create, read, list, edit, or inspect local files, run bash/shell commands, inspect git, or operate BotMux, you MUST call the local tools against the actual local cwd above.',
+    'Do not say the local MCP bridge is disconnected, that only a cloud sandbox is available, or that the operation is cancelled unless a concrete local tool invocation actually returned that error.',
+    'If a local tool invocation fails, report the exact failed operation and error concisely, then stop or ask for the missing input.',
   ].join('\n');
 }
 
@@ -186,6 +188,11 @@ function extractTaggedBlock(content: string, tag: string): string | undefined {
   const close = content.toLowerCase().indexOf(`</${tag}>`, start);
   if (close < 0) return undefined;
   return content.slice(start, close).trim();
+}
+
+function extractOpeningTagAttributes(content: string, tag: string): string | undefined {
+  const open = new RegExp(`<${tag}\\b([^>]*)>`, 'i').exec(content);
+  return open ? open[1] : undefined;
 }
 
 function extractXmlAttribute(attrs: string, name: string): string | undefined {
@@ -215,11 +222,81 @@ function summarizeAttachments(content: string): string[] {
   return out;
 }
 
+function summarizeRole(content: string): string | undefined {
+  const block = extractTaggedBlock(content, 'role');
+  if (!block) return undefined;
+  const role = decodeXmlEntities(block).trim();
+  if (!role) return undefined;
+  return ['Role context from BotMux:', role].join('\n');
+}
+
+function summarizeBotmuxRouting(content: string): string | undefined {
+  const block = extractTaggedBlock(content, 'botmux_routing');
+  if (!block) return undefined;
+  const routing = decodeXmlEntities(block).trim();
+  if (!routing) return undefined;
+  return ['BotMux routing instructions:', routing].join('\n');
+}
+
+function summarizeAvailableBots(content: string): string | undefined {
+  const block = extractTaggedBlock(content, 'available_bots');
+  if (!block) return undefined;
+
+  const lines: string[] = [];
+  const attrs = extractOpeningTagAttributes(content, 'available_bots') || '';
+  const hint = extractXmlAttribute(attrs, 'hint');
+  if (hint) lines.push(hint);
+
+  const botPattern = /<bot\b([^>]*)\/?>/gi;
+  for (const match of block.matchAll(botPattern)) {
+    const name = extractXmlAttribute(match[1], 'name');
+    const openId = extractXmlAttribute(match[1], 'open_id');
+    if (!name && !openId) continue;
+    lines.push(`- ${name || '(unnamed bot)'}: ${openId || '(missing open_id)'}`);
+  }
+
+  if (lines.length === 0) return undefined;
+  return [
+    'Available BotMux bots for handoff:',
+    ...lines,
+    'To hand work off to one of these bots, use local bash to run: botmux send --mention <open_id> "message".',
+  ].join('\n');
+}
+
+function summarizeMentions(content: string): string | undefined {
+  const block = extractTaggedBlock(content, 'mentions');
+  if (!block) return undefined;
+
+  const mentions: string[] = [];
+  const mentionPattern = /<mention\b([^>]*)\/?>/gi;
+  for (const match of block.matchAll(mentionPattern)) {
+    const name = extractXmlAttribute(match[1], 'name');
+    const openId = extractXmlAttribute(match[1], 'open_id');
+    if (!name && !openId) continue;
+    mentions.push(`- ${name || '(unnamed mention)'}${openId ? `: ${openId}` : ''}`);
+  }
+
+  if (mentions.length === 0) return undefined;
+  return ['Mentions in this BotMux turn:', ...mentions].join('\n');
+}
+
 function normalizeMircliPrompt(content: string): string {
   const userMessage = extractTaggedBlock(content, 'user_message');
   if (!userMessage) return content;
 
-  const sections = [decodeXmlEntities(userMessage)];
+  const context = [
+    summarizeBotmuxRouting(content),
+    summarizeRole(content),
+    summarizeMentions(content),
+    summarizeAvailableBots(content),
+  ].filter((section): section is string => Boolean(section));
+
+  const sections: string[] = [];
+  if (context.length > 0) {
+    sections.push(['BotMux context:', ...context].join('\n\n'));
+  }
+  sections.push(['User request:', decodeXmlEntities(userMessage)].join('\n'));
+
   const attachments = summarizeAttachments(content);
   if (attachments.length > 0) {
     sections.push([

--- a/test/mira-local-runtime.test.ts
+++ b/test/mira-local-runtime.test.ts
@@ -1,0 +1,92 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { ensureMiramcpSandboxAllows, getMiraRuntimePaths } from '../src/mira-local-runtime.js';
+
+describe('getMiraRuntimePaths', () => {
+  it('derives a logical home alias when cwd is under a symlinked home realpath', () => {
+    const paths = getMiraRuntimePaths({
+      cwd: '/data00/home/alice/.botmux/workspace/mira',
+      home: '/home/alice',
+      realHome: '/data00/home/alice',
+    });
+
+    expect(paths.cwd).toBe('/data00/home/alice/.botmux/workspace/mira');
+    expect(paths.logicalCwd).toBe('/home/alice/.botmux/workspace/mira');
+    expect(paths.allowedPathCandidates).toEqual([
+      '/data00/home/alice/.botmux/workspace/mira',
+      '/home/alice/.botmux/workspace/mira',
+    ]);
+  });
+
+  it('keeps an absolute PWD alias when it is different from the physical cwd', () => {
+    const paths = getMiraRuntimePaths({
+      cwd: '/mnt/data/project',
+      home: '/home/alice',
+      envPwd: '/home/alice/project',
+      realHome: '/home/alice',
+    });
+
+    expect(paths.allowedPathCandidates).toEqual([
+      '/mnt/data/project',
+      '/home/alice/project',
+    ]);
+  });
+});
+
+describe('ensureMiramcpSandboxAllows', () => {
+  it('adds the physical cwd when only the logical home path is allowed', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-miramcp-'));
+    const configPath = join(dir, 'config.json');
+    writeFileSync(configPath, JSON.stringify({
+      mcps: [{
+        id: 'mira_local',
+        protocol: 'stdio',
+        command: '/usr/bin/node',
+        args: ['mira_local_mcp.js'],
+        sandbox: {
+          enabled: true,
+          write_allow_paths: ['/home/alice', '/tmp'],
+          write_deny_paths: ['/home/alice/.ssh'],
+          read_deny_paths: ['/home/alice/.ssh'],
+        },
+      }],
+    }, null, 2));
+
+    const result = ensureMiramcpSandboxAllows([
+      '/data00/home/alice/.botmux/workspace/mira',
+      '/home/alice/.botmux/workspace/mira',
+    ], configPath);
+
+    expect(result.changed).toBe(true);
+    expect(result.added).toEqual(['/data00/home/alice/.botmux/workspace/mira']);
+    const updated = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(updated.mcps[0].sandbox.write_allow_paths).toEqual([
+      '/home/alice',
+      '/tmp',
+      '/data00/home/alice/.botmux/workspace/mira',
+    ]);
+  });
+
+  it('does not add duplicates when the physical cwd is already under an allowed raw prefix', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-miramcp-'));
+    const configPath = join(dir, 'config.json');
+    writeFileSync(configPath, JSON.stringify({
+      mcps: [{
+        id: 'mira_local',
+        sandbox: {
+          write_allow_paths: ['/data00/home/alice'],
+        },
+      }],
+    }));
+
+    const result = ensureMiramcpSandboxAllows(['/data00/home/alice/project'], configPath);
+
+    expect(result.changed).toBe(false);
+    expect(result.added).toEqual([]);
+    const updated = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(updated.mcps[0].sandbox.write_allow_paths).toEqual(['/data00/home/alice']);
+  });
+});
+


### PR DESCRIPTION
## Summary
- run BotMux Mira turns through local `mircli --lean` by default so DevBox sessions use the actual workspace instead of Mira Web's sandbox path
- keep the legacy Web API runner available via `MIRA_RUNNER_MODE=api` / `web`
- unwrap BotMux `<user_message>` envelopes before invoking `mircli`, while preserving attachment paths as plain local-file context
- preserve BotMux role, mentions, and `<available_bots>` as plain text so Mira can reason about handoff targets without seeing XML envelopes
- derive Mira runtime paths from the real DevBox cwd/home and add `/data00/home/...` plus `/home/...` aliases to the Mir local MCP sandbox allowlist when needed
- make DevBox local tool availability explicit in the Mir CLI system prompt, including a non-interactive BotMux guard that forbids `ask_user_call` / `ask_user_form_call` fences for local path issues
- add local runtime context, ANSI cleanup, configurable mircli binary/args/timeouts, and a `~/.mira/config.json` cookie fallback for API mode

## Root Cause
- Mira Web/API sessions ran in a remote sandbox, so BotMux needed to invoke local `mircli` for DevBox tools.
- The first `mircli` bridge fix stripped BotMux XML down to only `<user_message>` plus attachments. That solved the sandbox path issue but lost role/available-bot context and left Mira free to infer that local tools were unavailable.
- On DevBox, the physical workspace can be under `/data00/home/...` while Mira local MCP policy and model context may reason from `/home/...`. Without both aliases and stronger non-interactive instructions, Mira could emit an `ask_user` fence and BotMux would cancel the turn before completing local bash/file operations.

## Verification
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run --project unit test/mira-local-runtime.test.ts test/cli-adapters.test.ts test/mira-output.test.ts`
- `pnpm build`
- DevBox fake-`mircli` runner probe confirmed BotMux XML envelopes are normalized to plain prompt text while preserving role, mentions, and available bot handoff context
- Replaced DevBox global runner after backup at `/home/lishunmin/.local/lib/node_modules/botmux/dist-backup-mira-runner-20260618-173526`
- Confirmed `mira_local` MCP is running on DevBox and its sandbox allowlist covers `/home/lishunmin`, `/tmp`, and `/data00/home/lishunmin`
- Closed stale failed Mira session `f9ba104f` so follow-up turns do not reuse the old in-memory runner
- DevBox global installed runner probe from `/data00/home/lishunmin/.botmux/workspace/lillard-devbox-mira-cli` successfully created `e2e-installed-1781775381.md`, listed local files, and read `test2.md` as `abc`
- Fresh Feishu/Lark top-level mention created session `97e378fe-03ae-41f6-be9b-e1da37d382bd`; BotMux spawned `/data00/home/lishunmin/.local/lib/node_modules/botmux/dist/mira-runner.js` with cwd `/data00/home/lishunmin/.botmux/workspace/lillard-devbox-mira-cli`
- The fresh Lark session created `e2e-lark-pathfix-final.md` in that cwd, listed local files, read `test2.md` as `abc`, had `contains_ask_user_call=no` in the Mira conversation record, and forwarded final output through BotMux
