### PR TITLE
修复 Cursor 恢复会话时误用最近会话

### DIFF
--- a/src/services/cursor-resume-policy.ts
+++ b/src/services/cursor-resume-policy.ts
@@ -1,0 +1,21 @@
+import type { CliId } from '../adapters/cli/types.js';
+
+export function shouldObserveCursorChatId(opts: {
+  cliId?: CliId | string;
+  effectiveResume: boolean;
+  effectiveCliSessionId?: string;
+}): boolean {
+  if (opts.cliId !== 'cursor') return false;
+  if (!opts.effectiveResume) return true;
+  return !!opts.effectiveCliSessionId;
+}
+
+export function shouldPersistObservedCursorChatId(opts: {
+  effectiveResume: boolean;
+  effectiveCliSessionId?: string;
+  observedChatId: string;
+}): boolean {
+  if (!opts.observedChatId) return false;
+  if (!opts.effectiveResume) return true;
+  return opts.effectiveCliSessionId === opts.observedChatId;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -38,7 +38,7 @@ import { findTraexRolloutBySessionId, findTraexRolloutByPid } from './services/t
 import { cocoEventsPathForSession, drainCocoEvents, findCocoSessionByPid } from './services/coco-transcript.js';
 import { currentHermesStateOffset, drainHermesStateDb } from './services/hermes-transcript.js';
 import { currentMtrSessionOffset, drainMtrSession, findLatestMtrSessionByDirectory, findMtrSessionById, type MtrTranscriptSource } from './services/mtr-transcript.js';
-import { drainCursorTranscript, findCursorTranscriptByChatId, findCursorTranscriptByPid } from './services/cursor-transcript.js';
+import { drainCursorTranscript, findCursorChatIdByPid, findCursorTranscriptByChatId, findCursorTranscriptByPid } from './services/cursor-transcript.js';
 import { baselineJsonlCursor } from './services/jsonl-cursor.js';
 import { dirname } from 'node:path';
 import { createServer as createHttpServer, type IncomingMessage } from 'node:http';
@@ -2822,6 +2822,33 @@ function persistCliSessionId(cliSessionId: string): void {
   }
 }
 
+function observeCursorCliSessionId(pid: number, label = 'spawn'): void {
+  if (!Number.isInteger(pid) || pid <= 0) return;
+  if (lastInitConfig?.cliId !== 'cursor') return;
+  if (lastInitConfig.cliSessionId) return;
+
+  const backendAtSpawn = backend;
+  let attempts = 0;
+  const maxAttempts = 60; // Cursor may open store.db only after its startup render settles.
+  const tick = () => {
+    if (!backend || lastInitConfig?.cliId !== 'cursor' || lastInitConfig.cliSessionId) return;
+    if (backend !== backendAtSpawn) return;
+    const currentPid = backend.getChildPid?.();
+    if (currentPid && currentPid !== pid) return;
+
+    const realPid = findLaunchedCliPid(pid, 'cursor') ?? pid;
+    const chatId = findCursorChatIdByPid(realPid);
+    if (chatId) {
+      persistCliSessionId(chatId);
+      log(`Observed Cursor chatId via pid ${realPid}${realPid === pid ? '' : ` (launcher ${pid})`} (${label}): ${chatId}`);
+      return;
+    }
+    attempts++;
+    if (attempts < maxAttempts) setTimeout(tick, 500);
+  };
+  setTimeout(tick, 250);
+}
+
 /** How long to wait before re-checking whether a submit-not-confirmed message
  *  eventually landed. Cold-start sessions and slow third-party hooks
  *  (UserPromptSubmit, SessionStart — e.g. superpowers' large skill injection)
@@ -3966,6 +3993,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     });
   };
   if (cliPid) startWrapperRealPidResolve(cliPid);
+  if (cliPid) observeCursorCliSessionId(cliPid);
 
   // Wire pid + cwd so the claude-code adapter's writeInput can read
   // ~/.claude/sessions/<pid>.json — the spawn-time pid-state record. Its
@@ -4012,6 +4040,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
         // LAUNCHER. Kick the descendant resolver so the bridge gets the real CLI
         // pid too (mirrors the synchronous path above). No-op for non-wrapperCli.
         startWrapperRealPidResolve(pid);
+        observeCursorCliSessionId(pid, 'async');
         return;
       }
       if (++attempts < 25) setTimeout(resolveCliPidLate, 120); // ~3s budget

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -39,6 +39,7 @@ import { cocoEventsPathForSession, drainCocoEvents, findCocoSessionByPid } from 
 import { currentHermesStateOffset, drainHermesStateDb } from './services/hermes-transcript.js';
 import { currentMtrSessionOffset, drainMtrSession, findLatestMtrSessionByDirectory, findMtrSessionById, type MtrTranscriptSource } from './services/mtr-transcript.js';
 import { drainCursorTranscript, findCursorChatIdByPid, findCursorTranscriptByChatId, findCursorTranscriptByPid } from './services/cursor-transcript.js';
+import { shouldObserveCursorChatId, shouldPersistObservedCursorChatId } from './services/cursor-resume-policy.js';
 import { baselineJsonlCursor } from './services/jsonl-cursor.js';
 import { dirname } from 'node:path';
 import { createServer as createHttpServer, type IncomingMessage } from 'node:http';
@@ -122,6 +123,7 @@ let reattachIdleProbeTimer: ReturnType<typeof setTimeout> | null = null;
  *  setup so even the tick that fires between spawnCli-start and the
  *  adapter's hermesBridgeAttach reads the correct mode. */
 let lastSpawnEffectiveResume = false;
+let lastSpawnEffectiveCliSessionId: string | undefined;
 let idleDetector: IdleDetector | null = null;
 let isTmuxMode = false;
 /** Adopt-bridge mode using TmuxPipeBackend: not a tmux attach client, all
@@ -2824,14 +2826,21 @@ function persistCliSessionId(cliSessionId: string): void {
 
 function observeCursorCliSessionId(pid: number, label = 'spawn'): void {
   if (!Number.isInteger(pid) || pid <= 0) return;
-  if (lastInitConfig?.cliId !== 'cursor') return;
-  if (lastInitConfig.cliSessionId) return;
+  if (!shouldObserveCursorChatId({
+    cliId: lastInitConfig?.cliId,
+    effectiveResume: lastSpawnEffectiveResume,
+    effectiveCliSessionId: lastSpawnEffectiveCliSessionId,
+  })) return;
 
   const backendAtSpawn = backend;
   let attempts = 0;
   const maxAttempts = 60; // Cursor may open store.db only after its startup render settles.
   const tick = () => {
-    if (!backend || lastInitConfig?.cliId !== 'cursor' || lastInitConfig.cliSessionId) return;
+    if (!backend || !shouldObserveCursorChatId({
+      cliId: lastInitConfig?.cliId,
+      effectiveResume: lastSpawnEffectiveResume,
+      effectiveCliSessionId: lastSpawnEffectiveCliSessionId,
+    })) return;
     if (backend !== backendAtSpawn) return;
     const currentPid = backend.getChildPid?.();
     if (currentPid && currentPid !== pid) return;
@@ -2839,6 +2848,14 @@ function observeCursorCliSessionId(pid: number, label = 'spawn'): void {
     const realPid = findLaunchedCliPid(pid, 'cursor') ?? pid;
     const chatId = findCursorChatIdByPid(realPid);
     if (chatId) {
+      if (!shouldPersistObservedCursorChatId({
+        effectiveResume: lastSpawnEffectiveResume,
+        effectiveCliSessionId: lastSpawnEffectiveCliSessionId,
+        observedChatId: chatId,
+      })) {
+        log(`Observed Cursor chatId via pid ${realPid}${realPid === pid ? '' : ` (launcher ${pid})`} (${label}) but kept existing resume target ${lastSpawnEffectiveCliSessionId}`);
+        return;
+      }
       persistCliSessionId(chatId);
       log(`Observed Cursor chatId via pid ${realPid}${realPid === pid ? '' : ` (launcher ${pid})`} (${label}): ${chatId}`);
       return;
@@ -3679,6 +3696,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   // `lastInitConfig.resume` (= true) and baseline an empty store, swallowing
   // the fresh session's first turn.
   lastSpawnEffectiveResume = effectiveResume;
+  lastSpawnEffectiveCliSessionId = effectiveCliSessionId;
 
   // ttadk 网关：模型走 ttadk 自己的 `-m`（启动期注入到 ttadk 前缀，见下方 wrapperCli
   // 分支），不能再把 cfg.model 透给底层适配器，否则真实 CLI 会再吃一个 --model 重复。

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -24,6 +24,7 @@ import { createAidenAdapter } from '../src/adapters/cli/aiden.js';
 import { createCocoAdapter } from '../src/adapters/cli/coco.js';
 import { createCodexAdapter } from '../src/adapters/cli/codex.js';
 import { createCodexAppAdapter } from '../src/adapters/cli/codex-app.js';
+import { createCursorAdapter } from '../src/adapters/cli/cursor.js';
 import { createGeminiAdapter } from '../src/adapters/cli/gemini.js';
 import { createOpenCodeAdapter } from '../src/adapters/cli/opencode.js';
 import { createAntigravityAdapter } from '../src/adapters/cli/antigravity.js';
@@ -390,6 +391,38 @@ describe('copilot buildArgs', () => {
   it('surfaces curated model choices for setup', () => {
     expect(adapter.modelChoices).toContain('claude-sonnet-4');
     expect(adapter.modelChoices).toContain('gpt-5');
+  });
+});
+
+describe('cursor buildArgs', () => {
+  const adapter = createCursorAdapter('/usr/bin/cursor-agent');
+
+  it('fresh session passes force/model flags without resume flags', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-cursor', resume: false, model: 'gpt-5' });
+    expect(args).toContain('--force');
+    expect(args).toContain('--model');
+    expect(args).toContain('gpt-5');
+    expect(args).not.toContain('--resume');
+    expect(args).not.toContain('--continue');
+  });
+
+  it('resume with persisted Cursor chatId passes --resume <chatId>', () => {
+    const chatId = 'c8c78608-0eef-4930-8007-c41ba71ba05d';
+    const args = adapter.buildArgs({
+      sessionId: 'sess-cursor',
+      resume: true,
+      resumeSessionId: chatId,
+    });
+    expect(args).toContain('--resume');
+    const idx = args.indexOf('--resume');
+    expect(args[idx + 1]).toBe(chatId);
+    expect(args).not.toContain('--continue');
+  });
+
+  it('resume without a persisted chatId falls back to --continue', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-cursor', resume: true });
+    expect(args).toContain('--continue');
+    expect(args).not.toContain('--resume');
   });
 });
 

--- a/test/cursor-resume-policy.test.ts
+++ b/test/cursor-resume-policy.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  shouldObserveCursorChatId,
+  shouldPersistObservedCursorChatId,
+} from '../src/services/cursor-resume-policy.js';
+
+describe('cursor resume policy', () => {
+  it('allows fresh Cursor launches to observe and persist the created chat id', () => {
+    expect(shouldObserveCursorChatId({
+      cliId: 'cursor',
+      effectiveResume: false,
+      effectiveCliSessionId: undefined,
+    })).toBe(true);
+    expect(shouldPersistObservedCursorChatId({
+      effectiveResume: false,
+      effectiveCliSessionId: undefined,
+      observedChatId: 'fresh-chat',
+    })).toBe(true);
+  });
+
+  it('allows fresh-demotion to replace a stale resume id with the new chat id', () => {
+    expect(shouldObserveCursorChatId({
+      cliId: 'cursor',
+      effectiveResume: false,
+      effectiveCliSessionId: undefined,
+    })).toBe(true);
+    expect(shouldPersistObservedCursorChatId({
+      effectiveResume: false,
+      effectiveCliSessionId: 'old-chat',
+      observedChatId: 'new-chat',
+    })).toBe(true);
+  });
+
+  it('allows exact resume only when the observed chat id matches the resume target', () => {
+    expect(shouldObserveCursorChatId({
+      cliId: 'cursor',
+      effectiveResume: true,
+      effectiveCliSessionId: 'chat-1',
+    })).toBe(true);
+    expect(shouldPersistObservedCursorChatId({
+      effectiveResume: true,
+      effectiveCliSessionId: 'chat-1',
+      observedChatId: 'chat-1',
+    })).toBe(true);
+    expect(shouldPersistObservedCursorChatId({
+      effectiveResume: true,
+      effectiveCliSessionId: 'chat-1',
+      observedChatId: 'chat-2',
+    })).toBe(false);
+  });
+
+  it('blocks --continue resumes from observing and persisting Cursor global latest chat', () => {
+    expect(shouldObserveCursorChatId({
+      cliId: 'cursor',
+      effectiveResume: true,
+      effectiveCliSessionId: undefined,
+    })).toBe(false);
+    expect(shouldPersistObservedCursorChatId({
+      effectiveResume: true,
+      effectiveCliSessionId: undefined,
+      observedChatId: 'global-latest-chat',
+    })).toBe(false);
+  });
+
+  it('does not observe non-Cursor sessions', () => {
+    expect(shouldObserveCursorChatId({
+      cliId: 'codex',
+      effectiveResume: false,
+    })).toBe(false);
+  });
+});


### PR DESCRIPTION
## 背景

BotMux 的 Cursor adapter 在恢复会话时，如果没有持久化 Cursor 原生 chatId，会退回到 `cursor-agent --continue`。当 tmux 挂掉导致多个 worker 冷恢复时，多个会话可能并发访问 Cursor 的最近一个会话，导致恢复目标错误或报错。

## 变更

- worker 启动 Cursor 后，通过 pid 观测 cursor-agent 打开的 `store.db`，解析并持久化 Cursor chatId
- 后续 resume 复用已持久化的 chatId，使 Cursor 使用 `--resume <chatId>`，避免退回 `--continue`
- 为 Cursor adapter 补充回归测试，覆盖 fresh、精确 resume、无 chatId fallback 三种参数行为

## 验证

- `pnpm exec tsc --noEmit`
- `pnpm vitest run --project unit test/cli-adapters.test.ts test/cursor-transcript.test.ts test/session-resume.test.ts test/session-discovery.test.ts test/worker-suspend.test.ts`