### PR TITLE
fix(tmux): 先 reattach 现存 session，再按探测失败 fallback

### DIFF
--- a/src/setup/ensure-tmux.ts
+++ b/src/setup/ensure-tmux.ts
@@ -21,6 +21,8 @@
  * tmux command would fail. Functional probe + soft fallback fixes both.
  */
 import { execSync, spawnSync } from 'node:child_process';
+import { unlinkSync } from 'node:fs';
+import { join } from 'node:path';
 import { detectPlatform, type PackageManager, type PlatformInfo } from './detect-platform.js';
 
 export interface TmuxResult {
@@ -102,6 +104,18 @@ export function tmuxEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv
   };
 }
 
+function cleanupTmuxProbeSocket(sockName: string, env: NodeJS.ProcessEnv = process.env): void {
+  if (typeof process.getuid !== 'function') return;
+
+  const baseDir = env.TMUX_TMPDIR || '/tmp';
+  const socketPath = join(baseDir, `tmux-${process.getuid()}`, sockName);
+  try {
+    unlinkSync(socketPath);
+  } catch {
+    // Best-effort: some tmux builds unlink the socket themselves.
+  }
+}
+
 /**
  * Functional tmux probe — actually starts a tmux server and tears it down.
  *
@@ -131,13 +145,16 @@ export function probeTmuxFunctional(): { ok: true; version: string } | { ok: fal
     env: tmuxEnv(),
   });
   if (run.status !== 0) {
+    spawnSync('tmux', ['-L', sockName, 'kill-server'], { stdio: 'ignore', timeout: 3000, env: tmuxEnv() });
+    cleanupTmuxProbeSocket(sockName);
     const stderr = (run.stderr?.toString() ?? '').trim();
     return { ok: false, reason: stderr || `tmux new-session 失败 (exit ${run.status})` };
   }
-  // Tear down the probe server. Best-effort — if this leaks, the kernel
-  // will GC the abstract socket when the (now-empty) tmux server exits on
-  // its own once the only client (which we didn't attach) goes away.
+  // Tear down the probe server and remove the socket file. Some platforms leave
+  // bmx-probe-* sockets behind after the server exits; thousands of stale
+  // entries make later probe storms slower and easier to time out.
   spawnSync('tmux', ['-L', sockName, 'kill-server'], { stdio: 'ignore', timeout: 3000, env: tmuxEnv() });
+  cleanupTmuxProbeSocket(sockName);
   return { ok: true, version };
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3571,13 +3571,18 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   cliAdapter = createCliAdapterSync(cfg.cliId as any, cfg.cliPathOverride);
   // backendType=tmux trust-but-verify: an explicit per-bot config (or
   // BACKEND_TYPE=tmux env override) bypasses config.ts's auto-detect, so
-  // the worker re-probes here. If tmux can't start a server we silently
-  // fall back to PTY rather than letting attach-session / new-session spam
-  // the daemon error log every poll cycle.
+  // the worker re-probes here. Existing botmux tmux sessions are more
+  // authoritative than the disposable "can we create a new server?" probe:
+  // abandoning one after a transient probe failure would spawn a duplicate CLI
+  // under raw PTY and make later submits invisible to the real Codex history.
   let effectiveBackend = cfg.backendType;
-  if (effectiveBackend === 'tmux' && !TmuxBackend.isAvailable()) {
-    log('tmux backend requested but functional probe failed — falling back to PTY backend');
-    effectiveBackend = 'pty';
+  if (effectiveBackend === 'tmux') {
+    const existingSessionName = TmuxBackend.sessionName(cfg.sessionId);
+    const hasExistingSession = TmuxBackend.hasSession(existingSessionName);
+    if (!hasExistingSession && !TmuxBackend.isAvailable()) {
+      log('tmux backend requested but functional probe failed and no existing session is available — falling back to PTY backend');
+      effectiveBackend = 'pty';
+    }
   }
   if (effectiveBackend === 'herdr' && !HerdrBackend.isAvailable()) {
     log('herdr backend requested but probe failed — falling back to PTY backend');

--- a/test/tmux-env-isolation.test.ts
+++ b/test/tmux-env-isolation.test.ts
@@ -18,6 +18,9 @@
  */
 import { describe, it, expect } from 'vitest';
 import { execSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { tmuxEnv, probeTmuxFunctional } from '../src/setup/ensure-tmux.js';
 
 describe('tmuxEnv()', () => {
@@ -143,6 +146,30 @@ describe('tmux subcommand with stale $TMUX', () => {
       } finally {
         if (before === undefined) delete process.env.TMUX;
         else process.env.TMUX = before;
+      }
+    },
+  );
+
+  it.skipIf(!tmuxAvailable)(
+    'probeTmuxFunctional() removes its disposable probe socket',
+    () => {
+      const beforeTmpdir = process.env.TMUX_TMPDIR;
+      const probeTmpdir = mkdtempSync(join(tmpdir(), 'botmux-tmux-probe-'));
+      process.env.TMUX_TMPDIR = probeTmpdir;
+
+      try {
+        const result = probeTmuxFunctional();
+        if (!result.ok) return;
+
+        const socketDir = join(probeTmpdir, `tmux-${process.getuid?.() ?? 0}`);
+        const probeSockets = readdirSync(socketDir, { withFileTypes: true })
+          .filter(entry => entry.name.startsWith('bmx-probe-'))
+          .map(entry => entry.name);
+        expect(probeSockets).toEqual([]);
+      } finally {
+        if (beforeTmpdir === undefined) delete process.env.TMUX_TMPDIR;
+        else process.env.TMUX_TMPDIR = beforeTmpdir;
+        rmSync(probeTmpdir, { recursive: true, force: true });
       }
     },
   );

--- a/test/worker-pipe-initial-screen-order.test.ts
+++ b/test/worker-pipe-initial-screen-order.test.ts
@@ -37,4 +37,17 @@ describe('worker pipe initial screen ordering', () => {
     expect(helper).toContain('if (backend !== be || !awaitingFirstPrompt || isPromptReady) return;');
     expect(helper).not.toContain('pendingMessages.length > 0');
   });
+
+  it('checks for an existing tmux session before falling back to pty', () => {
+    const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+    const guardStart = source.indexOf('let effectiveBackend = cfg.backendType;');
+    const guardEnd = source.indexOf("if (effectiveBackend === 'herdr'", guardStart);
+    const guard = source.slice(guardStart, guardEnd);
+
+    expect(guardStart).toBeGreaterThan(-1);
+    expect(guardEnd).toBeGreaterThan(guardStart);
+    expect(guard).toContain('const hasExistingSession = TmuxBackend.hasSession(existingSessionName);');
+    expect(guard).toContain('!hasExistingSession && !TmuxBackend.isAvailable()');
+    expect(guard.indexOf('TmuxBackend.hasSession')).toBeLessThan(guard.indexOf('TmuxBackend.isAvailable'));
+  });
 });


### PR DESCRIPTION
## 现象

最近经常出现这类报错：

> ⚠️ 刚才那条消息发给 Codex 后没能确认提交

有时重试 Enter 后，等了 20s 仍然看不到新的 `~/.codex/history.jsonl` 记录。这个问题不是单次偶发，而是同一类路径在多次会话里都能复现。

## 背景

botmux 在恢复 tmux 会话时，会先跑一次 tmux functional probe。这个 probe 如果偶发失败，worker 会把 backend 从 tmux 降级到 raw PTY。

问题是：原来的 `bmx-*` tmux session 可能还活着。降级后 botmux 会绕开原 pane，另起一个 CLI。后续消息看起来已经写入终端，但没有进入 Codex history，最终触发 `submit not confirmed`。

排查环境是 macOS + tmux 3.6b。现场机器的 `/tmp/tmux-$UID` 下有大量残留 `bmx-probe-*` socket；probe 越密集，越容易踩中这种瞬时失败。

## 修复

- tmux backend 启动时，先检查当前 session 的 `bmx-*` 是否存在。
- 如果存在，继续使用 tmux，让后续流程 reattach 原 session。
- 只有没有现存 session，且 tmux probe 失败时，才 fallback 到 PTY。
- `probeTmuxFunctional()` 结束后清理自己的 `bmx-probe-*` socket，避免 probe socket 长期堆积。

这样可以保留原来的 fallback 保护，同时避免一次临时 probe 失败把一个仍然可恢复的 tmux 会话切到 PTY。

## 验证

```bash
pnpm exec tsc --noEmit
pnpm exec vitest run --project unit test/tmux-env-isolation.test.ts test/worker-pipe-initial-screen-order.test.ts test/tmux-backend-input.test.ts test/tmux-pipe-backend.test.ts test/write-input.test.ts
pnpm build
```

补充：全量 `pnpm test` 也跑过，但当前机器上有几个既有环境失败，和本改动无关：`node-pty` spawn、macOS `/var` vs `/private/var` 路径断言、sandbox opaque-dir 断言。
