### PR TITLE
fix(usage-ledger): 让「使用 bot 默认 workingDir」的会话也能记 token

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1465,6 +1465,17 @@ export function forkWorker(ds: DaemonSession, prompt: string, resume = false): v
   const cwd = rawCwd && existsSync(rawCwd) ? rawCwd : homedir();
   if (cwd !== rawCwd) logger.warn(`[${t}] workingDir "${rawCwd}" does not exist — falling back to ${cwd}`);
 
+  // Materialise the resolved launch dir on the live session. getSessionWorkingDir()
+  // falls back to the bot-default workingDir, but the usage ledger and dashboard read
+  // `ds.workingDir ?? s.workingDir` RAW (without that fallback). A session that inherits
+  // the bot-default workingDir — i.e. one never pinned via /repo or /cd — therefore leaves
+  // ds.workingDir undefined, so getSessionTokenUsage() is handed cwd=undefined, cannot
+  // locate the CLI transcript, and the session's token usage silently never records.
+  // Pinning the resolved cwd here (it equals what the worker actually forked into) closes
+  // that gap without touching the persisted session.workingDir "unset = follow default"
+  // semantics: this is re-derived on every fork/restore.
+  ds.workingDir = cwd;
+
   // Sandbox decision is RECORDED ON THE SESSION at creation and reused on
   // restore — so toggling the live bot flag never retroactively (un)sandboxes a
   // historical session. A brand-new session (resume=false) with no recorded


### PR DESCRIPTION
## 问题

`usage` 账本对没有显式设过 `workingDir` 的会话完全记不到 token——`~/.botmux/usage/usage-*.jsonl` 只有 `kind:"ownership"`，无 token 增量、无 `state-*.json`。（详见关联 issue。）

根因：worker 启动走 `getSessionWorkingDir(ds)`（带回退 bot 默认），但账本 `ledgerArgsForDaemonSession` 直接读原始 `ds.workingDir ?? s.workingDir`，**不回退默认**。跟随 bot 默认 workingDir 的会话这两个字段都是 `undefined` → `getSessionTokenUsage({cwd: undefined})` 对 claude-code 返回 null → `recordUsageForDaemonSession` 在 `if (!args.usage) return null` 静默退出。`ownership` 不读 transcript 所以照写。

## 改动

`src/core/worker-pool.ts` 的 `forkWorker`——所有 spawn/restore/resume 的唯一入口——在算出并校验 `cwd` 后，加一行把它物化到 `ds.workingDir`：

```ts
const rawCwd = cb.getSessionWorkingDir(ds);
const cwd = rawCwd && existsSync(rawCwd) ? rawCwd : homedir();
if (cwd !== rawCwd) logger.warn(...);

// 把解析后的启动目录落到 live session 上：账本/面板读的是 raw 的
// ds.workingDir ?? s.workingDir（不带 getSessionWorkingDir 的默认回退），
// 跟随 bot 默认目录的会话否则 ds.workingDir 一直 undefined，token 永不入账。
ds.workingDir = cwd;
```

## 为什么安全

- `cwd` 正是 worker 实际 fork 进去的目录；对默认会话 `ds.workingDir = cwd` 即 bot 默认值，`getSessionWorkingDir(ds)` 返回值不变；对 `/repo`/`/cd` 设过的会话本就相等，是 no-op。
- **不碰持久化的 `session.workingDir`**，保留「未设=跟随 bot 默认」语义；每次 fork 重新派生。
- 逐个核对了 `ds.workingDir` 的读取点（`getSessionWorkingDir`、`invalidConfiguredWorkingDirs`、`composeRowFromActive`、`/repo`/`/cd`）：默认会话下取值与原先一致，无行为变化；dashboard active 行的 token/workingDir 显示由「空」变「真实目录」，属修复。
- 唯一语义微调：bot 默认 workingDir 若在会话存活期间被改，`getSessionWorkingDir(ds)` 会返回 fork 时钉住的旧值——但 worker 本就跑在旧目录，这反而更贴合实际运行 cwd。

## 验证

- 修复前：默认会话只产出 `kind:"ownership"`、无 `state-*.json`。
- 手动用正确 cwd 调 `recordSessionUsage` 能立即写出真实 delta，证明账本逻辑本身正确，缺的只是 cwd。
- 修复后：默认会话在每个 idle turn 边界正常写出 token delta 并生成 `state-*.json`。

closes #252