### PR TITLE
fix(pi): probe queued busy messages

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4259,6 +4259,9 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
       awaitingFirstPrompt = false;
       renderer?.markNewTurn();
       log('First prompt timeout — enabling screen updates and flushing queued messages');
+      if (backend && cliAdapter?.busyPattern && probeBusyPatternIdle(`${cliName()} first-prompt-timeout`, backend)) {
+        return;
+      }
       // For type-ahead adapters (Codex/CoCo/TRAE/Claude) the TUI is booted
       // enough to park input even if the idle detector hasn't fired yet.
       // Directly invoking markPromptReady() would claim the CLI is idle

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3156,6 +3156,7 @@ function sendToPty(content: string, turnId?: string): void {
     flushPending();  // fire-and-forget async; no-op if already flushing
   } else {
     if (!mergedQueued) log(`Queued message (${pendingMessages.length} pending): "${content.substring(0, 80)}" — ${cliName()} ${awaitingFirstPrompt ? 'still booting' : 'is busy'}`);
+    scheduleBusyPatternIdleProbe(`${cliName()} queued-message`);
   }
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3396,6 +3396,12 @@ function captureBackendScreen(be: Pick<SessionBackend, 'captureCurrentScreen' | 
   return be.captureViewport?.() ?? be.captureCurrentScreen?.() ?? '';
 }
 
+function busyProbeRegion(content: string): string {
+  const lines = content.split(/\r?\n/);
+  const tailLineCount = Math.max(12, Math.ceil(lines.length / 3));
+  return lines.slice(-tailLineCount).join('\n');
+}
+
 function probeBusyPatternIdle(
   source: string,
   be: Pick<SessionBackend, 'captureCurrentScreen' | 'captureViewport'>,
@@ -3404,7 +3410,7 @@ function probeBusyPatternIdle(
     const content = captureBackendScreen(be);
     if (!content) return false;
     if (cliAdapter?.busyPattern) {
-      if (cliAdapter.busyPattern.test(content)) return false;
+      if (cliAdapter.busyPattern.test(busyProbeRegion(content))) return false;
       log(`${source} idle probe: busy marker absent, marking prompt ready`);
       markPromptReady();
       return true;

--- a/test/worker-pipe-initial-screen-order.test.ts
+++ b/test/worker-pipe-initial-screen-order.test.ts
@@ -26,6 +26,17 @@ describe('worker pipe initial screen ordering', () => {
     expect(probeIdx).toBeGreaterThan(writeIdx);
   });
 
+  it('rechecks busy-pattern adapters when a Lark message is queued while busy', () => {
+    const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+    const queueLogIdx = source.indexOf('Queued message (${pendingMessages.length} pending)');
+    const queuedProbeIdx = source.indexOf('scheduleBusyPatternIdleProbe(`${cliName()} queued-message`);');
+    const helperIdx = source.indexOf('function scheduleBusyPatternIdleProbe(source: string): void');
+
+    expect(helperIdx).toBeGreaterThan(-1);
+    expect(queueLogIdx).toBeGreaterThan(-1);
+    expect(queuedProbeIdx).toBeGreaterThan(queueLogIdx);
+  });
+
   it('limits the reattach idle probe to adapters with a busy marker', () => {
     const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
     const helperStart = source.indexOf('function scheduleReattachIdleProbe');

--- a/test/worker-pipe-initial-screen-order.test.ts
+++ b/test/worker-pipe-initial-screen-order.test.ts
@@ -37,6 +37,20 @@ describe('worker pipe initial screen ordering', () => {
     expect(queuedProbeIdx).toBeGreaterThan(queueLogIdx);
   });
 
+  it('limits busy-pattern idle probes to the active status region', () => {
+    const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+    const helperStart = source.indexOf('function busyProbeRegion(content: string): string');
+    const probeStart = source.indexOf('function probeBusyPatternIdle');
+    const probeEnd = source.indexOf('function scheduleReattachIdleProbe');
+    const helper = source.slice(helperStart, probeEnd);
+    const probe = source.slice(probeStart, probeEnd);
+
+    expect(helperStart).toBeGreaterThan(-1);
+    expect(helper).toContain('const tailLineCount = Math.max(12, Math.ceil(lines.length / 3));');
+    expect(probe).toContain('cliAdapter.busyPattern.test(busyProbeRegion(content))');
+    expect(probe).not.toContain('cliAdapter.busyPattern.test(content)');
+  });
+
   it('limits the reattach idle probe to adapters with a busy marker', () => {
     const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
     const helperStart = source.indexOf('function scheduleReattachIdleProbe');

--- a/test/worker-pipe-initial-screen-order.test.ts
+++ b/test/worker-pipe-initial-screen-order.test.ts
@@ -37,6 +37,15 @@ describe('worker pipe initial screen ordering', () => {
     expect(queuedProbeIdx).toBeGreaterThan(queueLogIdx);
   });
 
+  it('rechecks busy-pattern adapters after first prompt timeout', () => {
+    const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+    const timeoutIdx = source.indexOf("log('First prompt timeout — enabling screen updates and flushing queued messages');");
+    const probeIdx = source.indexOf('probeBusyPatternIdle(`${cliName()} first-prompt-timeout`, backend)', timeoutIdx);
+
+    expect(timeoutIdx).toBeGreaterThan(-1);
+    expect(probeIdx).toBeGreaterThan(timeoutIdx);
+  });
+
   it('limits busy-pattern idle probes to the active status region', () => {
     const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
     const helperStart = source.indexOf('function busyProbeRegion(content: string): string');


### PR DESCRIPTION
## Summary
- add a queued-message busy-pattern idle probe so Pi sessions can recover when new Lark messages arrive while botmux still thinks the CLI is busy
- keep the existing `Working...` marker logic and reuse the bounded idle probe path
- add a regression check that queued busy messages schedule the busy-pattern probe

## Problem
Pi already had `busyPattern: /Working\.\.\./` and the reattach/post-submit probes were working, but a separate path was missing: when a session was already marked busy and another Lark message was queued, no new idle probe was scheduled. If Pi had silently returned to an idle viewport, the pending queue could stay stuck until a restart or reattach.

## Verification
- `pnpm vitest run --project unit test/worker-pipe-initial-screen-order.test.ts`
- `pnpm build`
- `npm install -g .`
- `botmux restart`
- verified PI heartbeat returned `busyCount=0`
- verified `4feb2125` recovered with `busy marker absent, marking prompt ready` and `Pi is ready for input`
