### PR TITLE
fix(cli): aiden x codex 启动剥掉 botmux 注入的 codex -c（修复 aiden 1.8.38 拒收透传致启动失败）

### DIFF
--- a/src/setup/cli-selection.ts
+++ b/src/setup/cli-selection.ts
@@ -233,9 +233,18 @@ export function parseWrapperCli(wrapperCli: string): string[] {
   return wrapperCli.trim().split(/\s+/).filter(Boolean);
 }
 
-/** 该前缀是否为 `aiden x claude`（仅它需要剥 --settings）。 */
-function isAidenXClaude(tokens: ReadonlyArray<string>): boolean {
-  return tokens[0] === 'aiden' && tokens[1] === 'x' && tokens[2] === 'claude';
+/** wrapper 前缀首 token 是否为 aiden 网关（`aiden x <cli>`）。aiden 会拦截底层 CLI
+ *  的 config 透传参数——`aiden x claude` 拒收 `--settings`、`aiden x codex` 自 1.8.38
+ *  起直接报错拒收 `-c`——故转发前要剥掉 botmux 注入的那部分（见 {@link stripWrapperUnsafeArgs}）。 */
+function isAidenWrapper(tokens: ReadonlyArray<string>): boolean {
+  return tokens[0] === 'aiden';
+}
+
+/** 是否为 botmux 经 codex `-c` 注入的「把 BOTMUX_* 塞进 shell 工具环境」配置覆盖值。
+ *  只认 botmux 自己注入的 `shell_environment_policy.set.BOTMUX_` 前缀，绝不误伤用户
+ *  自带的 `-c key=val`。 */
+function isBotmuxShellEnvConfigValue(value: string | undefined): boolean {
+  return !!value && value.startsWith('shell_environment_policy.set.BOTMUX_');
 }
 
 /**
@@ -248,6 +257,35 @@ export function stripSettingsArgs(args: ReadonlyArray<string>): string[] {
     const a = args[i];
     if (a === '--settings') { i++; continue; }     // 跳过 flag + 紧随其后的值
     if (a.startsWith('--settings=')) continue;       // 跳过 --settings=<v>
+    out.push(a);
+  }
+  return out;
+}
+
+/**
+ * 剥掉 aiden `aiden x <cli>` 网关拒收的、**botmux 注入的**底层 CLI config 覆盖参数：
+ *   - `--settings <v>` / `--settings=<v>`（claude 携带 hook/bypass，aiden x claude 历来就剥）
+ *   - `-c shell_environment_policy.set.BOTMUX_*=…`（codex 用来把 BOTMUX_SESSION_ID 注入
+ *     shell 工具环境；aiden 1.8.38+ 直接报错拒收 `aiden x codex` 透传的 `-c`，正是本次回归）
+ * 这些参数承载的 session 环境已在进程级 env（BOTMUX_SESSION_ID 等）注入、并被 wrapper
+ * 子进程继承（见 worker.ts childEnv），故剥掉只是去掉一条冗余的 belt-and-suspenders
+ * 通道，不丢功能。`-c` 按 botmux 注入特征精确识别——只剥值以 `shell_environment_policy.set.BOTMUX_`
+ * 开头者，用户自带的 `-c key=val` 一律不动；`--settings` 则沿用 aiden x claude 历来的兼容策略
+ * 整体剥离（复用 {@link stripSettingsArgs}，不区分来源）。原生启动及 ttadk/cjadk 等「裸透传」
+ * 网关不走本函数，仍保留 `-c`（它们的 launcher 接受并转发给真 CLI，照常生效）。
+ *
+ * 关键：识别按 botmux 注入特征（`--settings` 的语义 + `-c …BOTMUX_` 前缀）而非按某个具体 CLI——
+ * 任何适配器将来注入**同形态**的 config 覆盖，经 aiden 网关时都会被一并剥掉，不会重蹈 codex 覆辙。
+ * 注意范围仅限上述两种 botmux 注入形态：coco 的 `--config model.name=…`（承载 model、非 session
+ * 管线，且无内置 `aiden x coco` 选项）等不同形态的 config 覆盖**有意不在此剥离**。
+ */
+export function stripWrapperUnsafeArgs(args: ReadonlyArray<string>): string[] {
+  // 先剥 claude 的 --settings（单一事实源 stripSettingsArgs），再剥 codex 注入的 -c override。
+  const afterSettings = stripSettingsArgs(args);
+  const out: string[] = [];
+  for (let i = 0; i < afterSettings.length; i++) {
+    const a = afterSettings[i]!;
+    if (a === '-c' && isBotmuxShellEnvConfigValue(afterSettings[i + 1])) { i++; continue; }
     out.push(a);
   }
   return out;
@@ -320,7 +358,8 @@ export function ttadkConfigModelChoices(wrapperCli: string | undefined): string[
 /**
  * 由 wrapperCli 前缀 + 底层 CLI 的 args 构造实际 spawn 的 `{ bin, args }`。
  *   - bin = 前缀首 token（经 binResolver 走 PATH 解析）
- *   - args = 前缀其余 token + CLI 参数（aiden x claude 形态会先剥掉 --settings）
+ *   - args = 前缀其余 token + CLI 参数（aiden `aiden x <cli>` 形态会先经
+ *     {@link stripWrapperUnsafeArgs} 剥掉 botmux 注入、aiden 拒收的 `--settings`/`-c`）
  *   - ttadk 网关走专门分支注入 `-m <model> --skip-check`（见 {@link buildTtadkLaunch}）
  * 前缀为空时返回 `{ bin: '', args }`，调用方据此跳过（不改写 spawn）。
  */
@@ -333,7 +372,7 @@ export function buildWrappedLaunch(
   const tokens = parseWrapperCli(wrapperCli);
   if (tokens.length === 0) return { bin: '', args: [...cliArgs] };
   if (tokens[0] === 'ttadk') return buildTtadkLaunch(tokens, cliArgs, binResolver, opts.ttadkModel);
-  const forwarded = isAidenXClaude(tokens) ? stripSettingsArgs(cliArgs) : [...cliArgs];
+  const forwarded = isAidenWrapper(tokens) ? stripWrapperUnsafeArgs(cliArgs) : [...cliArgs];
   return { bin: binResolver(tokens[0]), args: [...tokens.slice(1), ...forwarded] };
 }
 

--- a/test/cli-selection.test.ts
+++ b/test/cli-selection.test.ts
@@ -7,6 +7,7 @@ import {
   lookupCliSelection,
   selectionKeyForBot,
   stripSettingsArgs,
+  stripWrapperUnsafeArgs,
   buildWrappedLaunch,
   parseWrapperCli,
   decorateResumeForWrapper,
@@ -16,6 +17,7 @@ import {
   TTADK_DEFAULT_MODEL,
   TTADK_MODEL_SUGGESTIONS,
 } from '../src/setup/cli-selection.js';
+import { createCodexAdapter } from '../src/adapters/cli/codex.js';
 
 describe('CLI_SELECT_OPTIONS / CLI_SELECT_TREE', () => {
   it('includes the two aiden gateway options right after native aiden', () => {
@@ -208,6 +210,46 @@ describe('stripSettingsArgs', () => {
   });
 });
 
+describe('stripWrapperUnsafeArgs', () => {
+  it('strips --settings (both forms) like stripSettingsArgs', () => {
+    expect(stripWrapperUnsafeArgs(['--settings', '{}', '--plugin-dir', '/p'])).toEqual(['--plugin-dir', '/p']);
+    expect(stripWrapperUnsafeArgs(['--settings={}', '--model', 'm'])).toEqual(['--model', 'm']);
+  });
+
+  it('strips the botmux-injected codex -c override (flag + value)', () => {
+    expect(stripWrapperUnsafeArgs([
+      '--no-alt-screen',
+      '-c',
+      'shell_environment_policy.set.BOTMUX_SESSION_ID="s"',
+      '-C',
+      '/repo',
+    ])).toEqual(['--no-alt-screen', '-C', '/repo']);
+  });
+
+  it('strips a botmux override for any BOTMUX_* key, not just SESSION_ID', () => {
+    expect(stripWrapperUnsafeArgs(['-c', 'shell_environment_policy.set.BOTMUX_TURN_ID="t"', '--model', 'm']))
+      .toEqual(['--model', 'm']);
+  });
+
+  it('leaves a user-supplied -c (non-botmux config override) untouched', () => {
+    expect(stripWrapperUnsafeArgs(['-c', 'model_reasoning_effort="high"', '--model', 'm']))
+      .toEqual(['-c', 'model_reasoning_effort="high"', '--model', 'm']);
+  });
+
+  it('handles both --settings and the codex -c override in one pass', () => {
+    expect(stripWrapperUnsafeArgs([
+      '--session-id', 'x',
+      '--settings', '{}',
+      '-c', 'shell_environment_policy.set.BOTMUX_SESSION_ID="s"',
+      '--model', 'm',
+    ])).toEqual(['--session-id', 'x', '--model', 'm']);
+  });
+
+  it('leaves args untouched when nothing is unsafe', () => {
+    expect(stripWrapperUnsafeArgs(['resume', 'cid', '--model', 'm'])).toEqual(['resume', 'cid', '--model', 'm']);
+  });
+});
+
 describe('parseWrapperCli', () => {
   it('splits on whitespace and drops blanks', () => {
     expect(parseWrapperCli('  aiden   x claude ')).toEqual(['aiden', 'x', 'claude']);
@@ -222,10 +264,59 @@ describe('buildWrappedLaunch', () => {
     expect(out.args).toEqual(['x', 'claude', '--session-id', 'sid', '--plugin-dir', '/p']);
   });
 
-  it('prepends the prefix but keeps args verbatim for aiden x codex', () => {
+  it('keeps non-config args verbatim for aiden x codex', () => {
     const out = buildWrappedLaunch('aiden x codex', ['resume', 'cid', '--model', 'm']);
     expect(out.bin).toBe('aiden');
     expect(out.args).toEqual(['x', 'codex', 'resume', 'cid', '--model', 'm']);
+  });
+
+  // Regression: aiden 1.8.38+ rejects `aiden x codex … -c …`. The Codex adapter
+  // injects `-c shell_environment_policy.set.BOTMUX_SESSION_ID=…` (commit 10d3e61),
+  // which previously reached the launcher verbatim and broke spawn. It must now be
+  // stripped for aiden wrappers; everything else (bypass/-C/--model) is preserved.
+  it('strips the botmux-injected codex -c override for aiden x codex', () => {
+    const out = buildWrappedLaunch('aiden x codex', [
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--no-alt-screen',
+      '-c',
+      'shell_environment_policy.set.BOTMUX_SESSION_ID="sess-4"',
+      '-C',
+      '/repo',
+    ]);
+    expect(out.bin).toBe('aiden');
+    expect(out.args).toEqual([
+      'x',
+      'codex',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--no-alt-screen',
+      '-C',
+      '/repo',
+    ]);
+    expect(out.args).not.toContain('-c');
+  });
+
+  it('does not strip a user-supplied -c that is not a botmux override (aiden x codex)', () => {
+    const out = buildWrappedLaunch('aiden x codex', ['-c', 'model_reasoning_effort="high"', '--model', 'm']);
+    expect(out.args).toEqual(['x', 'codex', '-c', 'model_reasoning_effort="high"', '--model', 'm']);
+  });
+
+  it('keeps the codex -c override for the bare-passthrough cjadk codex gateway', () => {
+    const out = buildWrappedLaunch('cjadk codex', [
+      '--no-alt-screen',
+      '-c',
+      'shell_environment_policy.set.BOTMUX_SESSION_ID="sess-4"',
+    ]);
+    // cjadk forwards CLI args verbatim to the real codex, which accepts -c — keep it.
+    expect(out.args).toEqual(['codex', '--no-alt-screen', '-c', 'shell_environment_policy.set.BOTMUX_SESSION_ID="sess-4"']);
+  });
+
+  it('keeps the codex -c override for the bare-passthrough ttadk codex gateway', () => {
+    const out = buildWrappedLaunch('ttadk codex', [
+      '-c',
+      'shell_environment_policy.set.BOTMUX_SESSION_ID="sess-4"',
+    ]);
+    expect(out.args).toContain('-c');
+    expect(out.args).toContain('shell_environment_policy.set.BOTMUX_SESSION_ID="sess-4"');
   });
 
   it('keeps --settings for cjadk claude (forwarded verbatim to real claude)', () => {
@@ -287,6 +378,61 @@ describe('buildWrappedLaunch', () => {
       const out = buildWrappedLaunch('ttadk claude', [], (b) => `/abs/${b}`, { ttadkModel: 'glm-5' });
       expect(out.bin).toBe('/abs/ttadk');
     });
+  });
+});
+
+// End-to-end regression: wire the REAL Codex adapter's buildArgs into the
+// launcher exactly as the worker does. This is the actual failure the user hit
+// (aiden 1.8.38 rejecting `aiden x codex … -c …`). Guards against the adapter
+// and the wrapper layer drifting apart in the future.
+describe('codex adapter × aiden wrapper (regression for commit 10d3e61)', () => {
+  const codex = createCodexAdapter('/usr/bin/codex');
+
+  const BOTMUX_OVERRIDE_RE = /^shell_environment_policy\.set\.BOTMUX_/;
+  const forwardsBotmuxC = (args: ReadonlyArray<string>): boolean =>
+    args.some((a, i) => a === '-c' && BOTMUX_OVERRIDE_RE.test(args[i + 1] ?? ''));
+
+  it('native codex still injects the botmux session-env -c (feature preserved)', () => {
+    const args = codex.buildArgs({ sessionId: 'sess-4', resume: false });
+    expect(forwardsBotmuxC(args)).toBe(true);
+  });
+
+  it('aiden x codex never forwards the botmux -c (fresh launch)', () => {
+    const args = codex.buildArgs({ sessionId: 'sess-4', resume: false, workingDir: '/repo' });
+    const out = buildWrappedLaunch('aiden x codex', args);
+    expect(forwardsBotmuxC(out.args)).toBe(false);
+    expect(out.args).not.toContain('-c');
+  });
+
+  it('aiden x codex never forwards the botmux -c (resume launch)', () => {
+    const args = codex.buildArgs({ sessionId: 'sess-4', resume: true, resumeSessionId: 'codex-uuid' });
+    expect(args).toContain('resume');               // sanity: we exercised the resume branch
+    const out = buildWrappedLaunch('aiden x codex', args);
+    expect(forwardsBotmuxC(out.args)).toBe(false);
+    // resume target + benign flags survive the strip.
+    expect(out.args).toContain('codex-uuid');
+    expect(out.args).toContain('--no-alt-screen');
+  });
+
+  // Cross-CLI guard: any aiden `aiden x <cli>` wrapper must drop a botmux-injected
+  // `-c shell_environment_policy.set.BOTMUX_*` override, so a future adapter that
+  // mirrors Codex's injection cannot re-break aiden launches. Bare-passthrough
+  // gateways (ttadk/cjadk) intentionally keep it.
+  it('no aiden built-in wrapper forwards a botmux -c override', () => {
+    const codexArgs = [
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--no-alt-screen',
+      '-c',
+      'shell_environment_policy.set.BOTMUX_SESSION_ID="s"',
+    ];
+    const aidenWrappers = CLI_SELECT_OPTIONS
+      .map((o) => o.wrapperCli)
+      .filter((w): w is string => !!w && parseWrapperCli(w)[0] === 'aiden');
+    expect(aidenWrappers).toContain('aiden x codex');
+    for (const w of aidenWrappers) {
+      const out = buildWrappedLaunch(w, codexArgs);
+      expect(forwardsBotmuxC(out.args), `${w} must not forward botmux -c`).toBe(false);
+    }
   });
 });
 


### PR DESCRIPTION
## 问题

`wrapperCli = aiden x codex` 的 bot 在 aiden 1.8.38 下启动失败：

> Failed to launch Codex: 不要通过 `aiden x codex` 透传 `-c`。请改用 aiden x 自己的参数……

**根因（确认是 commit 10d3e611 引入）**：2.82.3 起 codex adapter 在 `buildArgs` 里固定加了
`-c shell_environment_policy.set.BOTMUX_SESSION_ID="..."`（把 session id 注入 codex shell 工具环境）。
用 `wrapperCli=aiden x codex` 时，这个 `-c` 被原样透传给 aiden；aiden 1.8.38 明令拒收 `aiden x codex`
透传 `-c` → 在 codex 真正启动前就被拦下。2.82.0~2.82.2 没有这个 `-c`，其余参数（`--no-alt-screen`/`-C`/
bypass/`--model`）aiden 一直接受，所以正常——印证了用户「降级 2.82 就好」。

## 修复

改在 wrapperCli 拼装的唯一收口 `buildWrappedLaunch`（`src/setup/cli-selection.ts`）：

- 把「对 aiden 网关剥掉不兼容参数」从原来只针对 `aiden x claude`（剥 `--settings`）**推广到所有
  `aiden x <cli>`**（`isAidenXClaude` → `isAidenWrapper`）。
- 新增 `stripWrapperUnsafeArgs`：复用 `stripSettingsArgs` 剥 `--settings`，再剥 botmux 注入的 codex
  `-c`——**仅当其值以 `shell_environment_policy.set.BOTMUX_` 开头**（用户自带的 `-c key=val` 不动，
  `-c` 作为末尾 token 无后值也不越界）。
- **原生 codex、以及 ttadk/cjadk 等「裸透传」网关仍保留 `-c`**（它们的 launcher 接受并转发给真 codex，
  功能不变），故不动 `codex.ts`。
- session id 本就经进程级 env（`BOTMUX_SESSION_ID`，见 `worker.ts` childEnv）注入、被 wrapper 子进程继承，
  剥掉 `-c` 只是去掉一条冗余的 belt-and-suspenders 通道，aiden 路径不丢功能。

## 防止其他 CLI 重蹈

识别按 **botmux 注入特征**（`-c …BOTMUX_` 前缀 / `--settings`）而非按具体 CLI——将来任何 adapter 注入
**同形态**的 config 覆盖，经 aiden 网关都会被自动剥掉。新增跨「所有 aiden 内置 wrapper」的守卫测试，
新 wrapper 漏剥会直接红。

## 测试

`test/cli-selection.test.ts`：

- **复现测试**：撤掉修复（`isAidenWrapper` 改回 `isAidenXClaude`）→ 4 条转红（精确命中 `aiden x codex`
  透传 botmux `-c`）；修复后全过。
- 真·codex adapter 端到端（fresh + resume 两分支）、不误伤用户自带 `-c`、ttadk/cjadk 保留 `-c`、
  `stripWrapperUnsafeArgs` 单元边界。
- 全量 `vitest run`：**4970 passed / 0 失败**（15 个文件失败为仓库既有环境基线，与本改动无关）；`tsc --noEmit` 0。

Codex review：无阻塞 LGTM（复跑 `git diff --check` / cli-selection 65 passed / `tsc` 全绿）。