### PR TITLE
fix(worker): 保留 CLI 崩溃诊断终端

### DIFF
--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -153,6 +153,41 @@ export class TmuxBackend implements SessionBackend {
     }
   }
 
+  /**
+   * Create a parked diagnostic session after a CLI has exited. The worker uses
+   * this only after it has already captured the failed pane's output, so the
+   * browser can still attach to `bmx-*` and see the startup error while daemon
+   * auto-restart is paused.
+   */
+  static parkDiagnosticSession(name: string, opts: { cwd: string; cols: number; rows: number; contentPath: string }): boolean {
+    try {
+      TmuxBackend.killSession(name);
+      const shellSpec = resolveUserShell();
+      execFileSync('tmux', [
+        'new-session',
+        '-d',
+        '-s', name,
+        '-x', String(opts.cols),
+        '-y', String(opts.rows),
+        '--',
+        shellSpec.shell, ...shellSpec.flags, '-c', DIAGNOSTIC_SHELL_SCRIPT, '_',
+        opts.cwd,
+        opts.contentPath,
+        shellSpec.shell,
+      ], {
+        stdio: 'ignore',
+        cwd: opts.cwd,
+        env: tmuxEnv(),
+        timeout: 5000,
+      });
+      configureTmuxSessionOptions(name);
+      return true;
+    } catch (err) {
+      logger.warn(`[tmux:${name}] failed to park diagnostic session: ${err instanceof Error ? err.message : err}`);
+      return false;
+    }
+  }
+
   // ─── SessionBackend implementation ────────────────────────────────────────
 
   spawn(bin: string, args: string[], opts: SpawnOpts): void {
@@ -256,21 +291,7 @@ export class TmuxBackend implements SessionBackend {
     // backfill options added after the session was originally created.
     // Setting an already-applied option is idempotent.
     setTimeout(() => {
-      try {
-        const t = shellescape(this.sessionName);
-        const env = tmuxEnv();
-        execSync(`tmux set-option -t ${t} status off`, { stdio: 'ignore', env });
-        execSync(`tmux set-option -t ${t} mouse on`, { stdio: 'ignore', env });
-        // set-clipboard is a server option — enable OSC 52 passthrough for web copy
-        execSync(`tmux set-option -s set-clipboard on`, { stdio: 'ignore', env });
-        execSync(`tmux set-option -t ${t} history-limit 50000`, { stdio: 'ignore', env });
-        // Prevent web terminal clients (smaller viewport) from shrinking the
-        // tmux window.  If a web client at 80×24 causes tmux to resize the
-        // window down, reflowed content shifts buffer positions and the
-        // terminal renderer's baseline tracking breaks — historical output
-        // leaks into the streaming card.
-        execSync(`tmux set-option -t ${t} window-size largest`, { stdio: 'ignore', env });
-      } catch { /* session may not be ready yet — benign */ }
+      configureTmuxSessionOptions(this.sessionName);
     }, 500);
   }
 
@@ -591,6 +612,16 @@ export function buildBotmuxEnvAssignments(
  */
 export const SHELL_WRAPPER_SCRIPT = `cd -- "$1" && shift && ${REDACTED_ENV_UNSET_CLAUSE} && exec /usr/bin/env "$@"`;
 
+export const DIAGNOSTIC_SHELL_SCRIPT = [
+  'cd -- "$1" 2>/dev/null || cd "$HOME" 2>/dev/null || cd /',
+  REDACTED_ENV_UNSET_CLAUSE,
+  'clear',
+  `printf '\\033[1;31m[botmux] Agent CLI exited. Auto-restart is paused and the last terminal output is preserved below.\\033[0m\\n\\n'`,
+  'cat -- "$2" 2>/dev/null || true',
+  `printf '\\n\\033[1;33m[botmux] Fix the startup error, then send a new message to retry. Type exit to close this diagnostic shell.\\033[0m\\n'`,
+  'exec "$3" -i',
+].join('; ');
+
 /**
  * Debug variant of the wrapper script — same prelude, but the CLI runs as
  * a *child* (no `exec`) and the wrapper hands off to an interactive shell
@@ -641,6 +672,23 @@ function specForKind(shell: string, kind: ShellKind): ShellSpec {
   else if (kind === 'zsh') flags.push('-l', '-i');
   // 'sh' adds nothing — POSIX sh has no portable interactive rcfile.
   return { shell, flags };
+}
+
+function configureTmuxSessionOptions(sessionName: string): void {
+  try {
+    const t = shellescape(sessionName);
+    const env = tmuxEnv();
+    execSync(`tmux set-option -t ${t} status off`, { stdio: 'ignore', env });
+    execSync(`tmux set-option -t ${t} mouse on`, { stdio: 'ignore', env });
+    // set-clipboard is a server option — enable OSC 52 passthrough for web copy
+    execSync(`tmux set-option -s set-clipboard on`, { stdio: 'ignore', env });
+    execSync(`tmux set-option -t ${t} history-limit 50000`, { stdio: 'ignore', env });
+    // Prevent web terminal clients (smaller viewport) from shrinking the
+    // tmux window. If a web client at 80x24 causes tmux to resize the window
+    // down, reflowed content shifts buffer positions and historical output
+    // leaks into the streaming card.
+    execSync(`tmux set-option -t ${t} window-size largest`, { stdio: 'ignore', env });
+  } catch { /* session may not be ready yet — benign */ }
 }
 
 /** Classify a shell binary path by basename. Returns null for shells whose

--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -70,6 +70,17 @@ export class TmuxBackend implements SessionBackend {
     return `bmx-${sessionId.slice(0, 8)}`;
   }
 
+  /**
+   * Name of the parked crash-diagnostic shell session. DISTINCT from
+   * {@link sessionName} on purpose: the diagnostic shell must never collide with
+   * the live CLI's backing-session name, or restore/cold-resume/`botmux resume`
+   * would reattach the bare shell as if it were the CLI. Stays `bmx-`-prefixed
+   * so adopt-discovery still skips it.
+   */
+  static diagnosticSessionName(sessionId: string): string {
+    return `bmx-diag-${sessionId.slice(0, 8)}`;
+  }
+
   /** Check if a named tmux session exists. */
   static hasSession(name: string): boolean {
     return TmuxBackend.probeSession(name) === 'exists';

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -2228,7 +2228,7 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
 
         if (rc.count > 3) {
           logger.warn(`[${t}] ${getCliDisplayName(effectiveCliId)} crashed ${rc.count} times in 1 min, not auto-restarting`);
-          const keepDiagnosticWorker = msg.diagnosticTerminal === 'tmux';
+          const keepDiagnosticWorker = !!msg.canParkDiagnostic && !!ds.worker && !ds.worker.killed;
           // Freeze the last streaming card so it doesn't stay at "working" forever
           if (ds.streamCardId && ds.workerPort) {
             const readUrl = buildTerminalUrl(ds);
@@ -2242,10 +2242,12 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
             scheduleCardPatch(ds, frozenCard);
           }
           if (keepDiagnosticWorker) {
-            // The worker parked a lightweight tmux diagnostic shell under
-            // bmx-diag-<sid>. Keep its web server alive so the existing terminal
-            // URL can show the startup failure; the next user message tells that
-            // same worker to destroy the diagnostic shell and retry.
+            // Ask the worker to park a lightweight tmux diagnostic shell under
+            // bmx-diag-<sid> NOW (deferred from its exit so transient restarts
+            // don't pay for it). Keep its web server alive so the existing
+            // terminal URL can show the startup failure; the next user message
+            // tells that same worker to destroy the diagnostic shell and retry.
+            ds.worker!.send({ type: 'park_diagnostic' } as DaemonToWorker);
             restartCounts.delete(key);
             ds.lastScreenStatus = 'idle';
             // Survive a daemon restart: mark this as a lazy cold-resume so

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -5,7 +5,7 @@
 import { fork, execSync, type ChildProcess, type ForkOptions } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
-import { readFileSync, readdirSync, mkdirSync, existsSync, realpathSync } from 'node:fs';
+import { readFileSync, readdirSync, mkdirSync, existsSync, realpathSync, unlinkSync } from 'node:fs';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { fileURLToPath } from 'node:url';
 import { ensureSkills, ensureAskSkill, ensurePluginSkills, removeGlobalBotmuxSkills } from '../skills/installer.js';
@@ -1023,10 +1023,7 @@ export function killWorker(ds: DaemonSession): void {
  */
 function destroyOrphanedBackingSession(ds: DaemonSession): void {
   if (ds.initConfig?.adoptMode || ds.adoptedFrom) return;
-  // A crash diagnostic shell parks under bmx-diag-<sid>. If the worker was hard
-  // -killed (OOM/SIGKILL) while parked, its killCli() never ran and the shell
-  // leaks; tear it down here too. No-op when absent / for non-tmux backends.
-  try { TmuxBackend.killSession(TmuxBackend.diagnosticSessionName(ds.session.sessionId)); } catch { /* benign */ }
+  reclaimParkedCrashDiagnostic(ds);
   const backendType = getSessionPersistentBackendType(ds);
   if (!backendType) return;
   try {
@@ -1035,6 +1032,20 @@ function destroyOrphanedBackingSession(ds: DaemonSession): void {
   } catch (err) {
     logger.warn(`[${tag(ds)}] killWorker: failed to destroy orphaned ${backendType} backing session: ${err}`);
   }
+}
+
+/**
+ * Reclaim a session's parked crash-diagnostic shell (`bmx-diag-<sid>`) and its
+ * captured `.ansi` file. The worker normally tears these down itself (killCli /
+ * suspend / next-message retry), but it CAN'T when it is hard-killed
+ * (OOM/SIGKILL) while parked — then the daemon must do it, on the next refork
+ * (forkWorker) or on close (destroyOrphanedBackingSession). Both ops are no-ops
+ * when absent, so this is safe to call unconditionally for tmux sessions.
+ */
+function reclaimParkedCrashDiagnostic(ds: DaemonSession): void {
+  if (getSessionPersistentBackendType(ds) !== 'tmux') return;
+  try { TmuxBackend.killSession(TmuxBackend.diagnosticSessionName(ds.session.sessionId)); } catch { /* benign */ }
+  try { unlinkSync(join(config.session.dataDir, 'crash-diagnostics', `${ds.session.sessionId}.ansi`)); } catch { /* absent — benign */ }
 }
 
 export function suspendWorker(ds: DaemonSession, reason = 'suspended_idle'): boolean {
@@ -1512,6 +1523,12 @@ export function forkWorker(ds: DaemonSession, prompt: string, resume = false): v
     ds.session.suspendedColdResume = undefined;
     sessionStore.updateSession(ds.session);
   }
+
+  // Re-establishing a worker also reclaims any crash-diagnostic shell a prior
+  // worker left parked but couldn't clean (hard-killed while parked, daemon
+  // still alive → next message reforks here). The fresh CLI spawns under the
+  // real bmx-<sid>; without this, bmx-diag-<sid> + its .ansi file would leak.
+  if (!ds.initConfig?.adoptMode && !ds.adoptedFrom) reclaimParkedCrashDiagnostic(ds);
 
   ensureCliEnv(botCfg.cliId, botCfg.cliPathOverride);
   // Claude Code blocks on the interactive folder-trust dialog the first time
@@ -2220,6 +2237,13 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
             // same worker to destroy the diagnostic shell and retry.
             restartCounts.delete(key);
             ds.lastScreenStatus = 'idle';
+            // Survive a daemon restart: mark this as a lazy cold-resume so
+            // restore keeps the session active (re-spawns the CLI on the next
+            // message) instead of zombie-closing it when the real bmx-<sid> is
+            // found missing. ds.hasHistory is already true (set at the top of
+            // claude_exit); forkWorker clears suspendedColdResume on re-spawn.
+            ds.session.suspendedColdResume = true;
+            sessionStore.updateSession(ds.session);
           } else {
             // Non-tmux or failed diagnostic parking: keep the historical
             // cleanup path so we do not leave an unusable worker around.

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1023,6 +1023,10 @@ export function killWorker(ds: DaemonSession): void {
  */
 function destroyOrphanedBackingSession(ds: DaemonSession): void {
   if (ds.initConfig?.adoptMode || ds.adoptedFrom) return;
+  // A crash diagnostic shell parks under bmx-diag-<sid>. If the worker was hard
+  // -killed (OOM/SIGKILL) while parked, its killCli() never ran and the shell
+  // leaks; tear it down here too. No-op when absent / for non-tmux backends.
+  try { TmuxBackend.killSession(TmuxBackend.diagnosticSessionName(ds.session.sessionId)); } catch { /* benign */ }
   const backendType = getSessionPersistentBackendType(ds);
   if (!backendType) return;
   try {
@@ -2210,10 +2214,10 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
             scheduleCardPatch(ds, frozenCard);
           }
           if (keepDiagnosticWorker) {
-            // The worker parked a lightweight tmux diagnostic pane under the
-            // usual bmx-* name. Keep its web server alive so the existing
-            // terminal URL can show the startup failure; the next user message
-            // tells that same worker to destroy the diagnostic pane and retry.
+            // The worker parked a lightweight tmux diagnostic shell under
+            // bmx-diag-<sid>. Keep its web server alive so the existing terminal
+            // URL can show the startup failure; the next user message tells that
+            // same worker to destroy the diagnostic shell and retry.
             restartCounts.delete(key);
             ds.lastScreenStatus = 'idle';
           } else {
@@ -2224,12 +2228,10 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
           const cliName = getCliDisplayName(effectiveCliId);
           const parts = [tr('worker.crash_loop_stopped', { cliName, count: rc.count }, loc)];
           if (keepDiagnosticWorker) {
-            parts.push(loc === 'zh'
-              ? 'Web 终端已保留最后一次启动输出，可直接打开查看；修复问题后发新消息会重新启动。'
-              : 'The web terminal now preserves the last startup output. Fix the issue, then send a new message to retry.');
+            parts.push(tr('worker.crash_diagnostic_terminal', undefined, loc));
           }
           if (msg.logTail?.trim()) {
-            parts.push((loc === 'zh' ? '最近终端输出：' : 'Recent terminal output:') + `\n${msg.logTail.trim()}`);
+            parts.push(`${tr('worker.crash_recent_output', undefined, loc)}\n${msg.logTail.trim()}`);
           }
           try {
             await scopedReply(parts.join('\n\n'), 'text', undefined);

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -2196,6 +2196,7 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
 
         if (rc.count > 3) {
           logger.warn(`[${t}] ${getCliDisplayName(effectiveCliId)} crashed ${rc.count} times in 1 min, not auto-restarting`);
+          const keepDiagnosticWorker = msg.diagnosticTerminal === 'tmux';
           // Freeze the last streaming card so it doesn't stay at "working" forever
           if (ds.streamCardId && ds.workerPort) {
             const readUrl = buildTerminalUrl(ds);
@@ -2208,11 +2209,30 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
             );
             scheduleCardPatch(ds, frozenCard);
           }
-          // Kill the worker process to free resources
-          killWorker(ds);
+          if (keepDiagnosticWorker) {
+            // The worker parked a lightweight tmux diagnostic pane under the
+            // usual bmx-* name. Keep its web server alive so the existing
+            // terminal URL can show the startup failure; the next user message
+            // tells that same worker to destroy the diagnostic pane and retry.
+            restartCounts.delete(key);
+            ds.lastScreenStatus = 'idle';
+          } else {
+            // Non-tmux or failed diagnostic parking: keep the historical
+            // cleanup path so we do not leave an unusable worker around.
+            killWorker(ds);
+          }
           const cliName = getCliDisplayName(effectiveCliId);
+          const parts = [tr('worker.crash_loop_stopped', { cliName, count: rc.count }, loc)];
+          if (keepDiagnosticWorker) {
+            parts.push(loc === 'zh'
+              ? 'Web 终端已保留最后一次启动输出，可直接打开查看；修复问题后发新消息会重新启动。'
+              : 'The web terminal now preserves the last startup output. Fix the issue, then send a new message to retry.');
+          }
+          if (msg.logTail?.trim()) {
+            parts.push((loc === 'zh' ? '最近终端输出：' : 'Recent terminal output:') + `\n${msg.logTail.trim()}`);
+          }
           try {
-            await scopedReply(tr('worker.crash_loop_stopped', { cliName, count: rc.count }, loc), 'text', undefined);
+            await scopedReply(parts.join('\n\n'), 'text', undefined);
           } catch (replyErr) {
             if (replyErr instanceof MessageWithdrawnError) {
               logger.warn(`[${t}] Root message withdrawn, closing stale session`);

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1904,6 +1904,17 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
 
       case 'prompt_ready': {
         logger.info(`[${t}] ${getCliDisplayName(effectiveCliId)} is ready for input`);
+        // A live prompt means a (re)spawn reached a working CLI — clear the lazy
+        // cold-resume marker set when we parked a crash diagnostic shell. The
+        // common retry path respawns IN-PLACE (worker.ts case 'message'), not via
+        // forkWorker, so without this the stale marker survives in the store and a
+        // LATER genuine zombie (bmx-<sid> actually gone) would be kept active by
+        // restore instead of being closed. If retry never reaches a prompt the
+        // marker persists, preserving the cross-daemon-restart lazy-retry intent.
+        if (ds.session.suspendedColdResume) {
+          ds.session.suspendedColdResume = undefined;
+          sessionStore.updateSession(ds.session);
+        }
         if (ds.pendingRawInput && ds.worker && !ds.worker.killed) {
           const rawInput = ds.pendingRawInput;
           ds.pendingRawInput = undefined;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -605,7 +605,7 @@ export const messages: Record<string, string> = {
   // ─── Worker → daemon notices ─────────────────────────────────────────────
   'worker.adopted_session_exited': '⏏ Adopted CLI session has exited.',
   'worker.crash_loop_stopped': '⚠️ {cliName} crashed {count} times in 1 minute. Auto-restart disabled. Send a message to retry.',
-  'worker.crash_diagnostic_terminal': 'The web terminal now preserves the last startup output. Fix the issue, then send a new message to retry.',
+  'worker.crash_diagnostic_terminal': 'The web terminal, where available, preserves the last startup output. Fix the issue, then send a new message to retry.',
   'worker.crash_recent_output': 'Recent terminal output:',
 
   // ─── CLI setup wizard / pm2 lifecycle (no per-bot context) ───────────────

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -605,6 +605,8 @@ export const messages: Record<string, string> = {
   // ─── Worker → daemon notices ─────────────────────────────────────────────
   'worker.adopted_session_exited': '⏏ Adopted CLI session has exited.',
   'worker.crash_loop_stopped': '⚠️ {cliName} crashed {count} times in 1 minute. Auto-restart disabled. Send a message to retry.',
+  'worker.crash_diagnostic_terminal': 'The web terminal now preserves the last startup output. Fix the issue, then send a new message to retry.',
+  'worker.crash_recent_output': 'Recent terminal output:',
 
   // ─── CLI setup wizard / pm2 lifecycle (no per-bot context) ───────────────
   'setup.lark_create_app': 'First create a Lark app at: https://open.feishu.cn/app',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -608,6 +608,8 @@ export const messages: Record<string, string> = {
   // ─── Worker → daemon notices ─────────────────────────────────────────────
   'worker.adopted_session_exited': '⏏ /adopt的 CLI 会话已断开',
   'worker.crash_loop_stopped': '⚠️ {cliName} 在 1 分钟内崩溃 {count} 次，已停止自动重启。发消息可触发重新启动。',
+  'worker.crash_diagnostic_terminal': 'Web 终端已保留最后一次启动输出，可直接打开查看；修复问题后发新消息会重新启动。',
+  'worker.crash_recent_output': '最近终端输出：',
 
   // ─── CLI setup wizard / pm2 lifecycle (no per-bot context) ───────────────
   'setup.lark_create_app': '请先在飞书开放平台创建应用: https://open.feishu.cn/app',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -608,7 +608,7 @@ export const messages: Record<string, string> = {
   // ─── Worker → daemon notices ─────────────────────────────────────────────
   'worker.adopted_session_exited': '⏏ /adopt的 CLI 会话已断开',
   'worker.crash_loop_stopped': '⚠️ {cliName} 在 1 分钟内崩溃 {count} 次，已停止自动重启。发消息可触发重新启动。',
-  'worker.crash_diagnostic_terminal': 'Web 终端已保留最后一次启动输出，可直接打开查看；修复问题后发新消息会重新启动。',
+  'worker.crash_diagnostic_terminal': 'Web 终端（若可用）保留了最后一次启动输出，可打开查看；修复问题后发新消息会重新启动。',
   'worker.crash_recent_output': '最近终端输出：',
 
   // ─── CLI setup wizard / pm2 lifecycle (no per-bot context) ───────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -273,6 +273,10 @@ export type DaemonToWorker =
   | { type: 'close' }
   | { type: 'suspend' }
   | { type: 'restart' }
+  // Crash loop: daemon gave up auto-restarting and asks the worker to park a
+  // diagnostic shell (bmx-diag-<sid>) preserving the last output. Deferred from
+  // onExit so transient auto-restarted exits don't park-then-tear-down.
+  | { type: 'park_diagnostic' }
   | { type: 'tui_keys'; keys: string[]; isFinal: boolean }
   | { type: 'tui_text_input'; keys: string[]; text: string }
   // CoCo AskUserQuestion 作答：daemon 在 ask 结算后下发，worker 等原生 picker 渲染后
@@ -294,7 +298,7 @@ export type DaemonToWorker =
 export type WorkerToDaemon =
   | { type: 'ready'; port: number; token: string; turnId?: string }
   | { type: 'cli_session_id'; cliSessionId: string }
-  | { type: 'claude_exit'; code: number | null; signal: string | null; logTail?: string; diagnosticTerminal?: 'tmux' }
+  | { type: 'claude_exit'; code: number | null; signal: string | null; logTail?: string; canParkDiagnostic?: boolean }
   | { type: 'prompt_ready' }
   | { type: 'screen_update'; content: string; status: ScreenStatus; usageLimit?: CliUsageLimitState; turnId?: string }
   | { type: 'error'; message: string }

--- a/src/types.ts
+++ b/src/types.ts
@@ -294,7 +294,7 @@ export type DaemonToWorker =
 export type WorkerToDaemon =
   | { type: 'ready'; port: number; token: string; turnId?: string }
   | { type: 'cli_session_id'; cliSessionId: string }
-  | { type: 'claude_exit'; code: number | null; signal: string | null }
+  | { type: 'claude_exit'; code: number | null; signal: string | null; logTail?: string; diagnosticTerminal?: 'tmux' }
   | { type: 'prompt_ready' }
   | { type: 'screen_update'; content: string; status: ScreenStatus; usageLimit?: CliUsageLimitState; turnId?: string }
   | { type: 'error'; message: string }

--- a/src/utils/crash-log.ts
+++ b/src/utils/crash-log.ts
@@ -1,0 +1,37 @@
+/**
+ * Bounded, ANSI-stripped extraction of recent terminal scrollback for crash
+ * diagnostics. Lives in its own leaf module (no worker.ts globals) so the
+ * stripping/tailing logic — including the ReDoS regression guard — is unit
+ * testable in isolation.
+ */
+
+/** Return at most the last `max` chars of `text`. */
+export function tailChars(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(text.length - max);
+}
+
+/**
+ * Strip ANSI/VT control sequences for a plaintext crash log.
+ *
+ * The OSC branch deliberately (a) excludes ESC from the body class and (b)
+ * makes the terminator optional. Without (a)/(b) — i.e. `\x1b\][^\x07]*(?:…)` —
+ * a long run of `\x1b]` with no terminating BEL (a half-written OSC, or binary
+ * garbage flushed to the TTY right before a crash) forces catastrophic
+ * backtracking: O(n²) over the 200 KB tail, measured at ~18 s of synchronous
+ * main-loop freeze inside the worker's exit handler. Excluding ESC bounds each
+ * match to the next ESC and drops it to a few ms while still stripping real
+ * OSC-8 hyperlinks (`ESC]8;;url BEL`) and OSC-0 titles (`ESC]0;title BEL`/`ST`).
+ */
+export function stripAnsiForLog(text: string): string {
+  return text
+    // OSC sequences (non-backtracking body + optional terminator).
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?/g, '')
+    // CSI/SGR and most cursor/control sequences.
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+    // Remaining one-byte ESC commands.
+    .replace(/\x1b[ -/]*[@-~]/g, '')
+    .replace(/\r/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -20,6 +20,7 @@ import { drainTranscript, joinAssistantText, trailingAssistantText, findJsonlCon
 import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint } from './services/bridge-turn-queue.js';
 import { shouldSuppressBridgeEmit, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
 import { shouldWriteNow } from './utils/input-gate.js';
+import { stripAnsiForLog, tailChars } from './utils/crash-log.js';
 import { installStdioEpipeGuard, isIgnorableStreamError } from './utils/stdio-epipe-guard.js';
 import { mergeQueuedCliInput, type PendingCliInput } from './utils/pending-input-queue.js';
 import { ReadyGate, shouldArmReadyGate } from './utils/ready-gate.js';
@@ -2211,24 +2212,6 @@ let altBufferActive = false;
 const ALT_ENTER_RE = /\x1b\[\?(1049|1047|47)h/g;
 const ALT_EXIT_RE = /\x1b\[\?(1049|1047|47)l/g;
 
-function tailChars(text: string, max: number): string {
-  if (text.length <= max) return text;
-  return text.slice(text.length - max);
-}
-
-function stripAnsiForLog(text: string): string {
-  return text
-    // OSC sequences.
-    .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '')
-    // CSI/SGR and most cursor/control sequences.
-    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
-    // Remaining one-byte ESC commands.
-    .replace(/\x1b[ -/]*[@-~]/g, '')
-    .replace(/\r/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
-}
-
 function recentTerminalLogTail(): string | undefined {
   const plain = stripAnsiForLog(tailChars(scrollback, CRASH_DIAGNOSTIC_RAW_MAX));
   if (!plain) return undefined;
@@ -2244,11 +2227,15 @@ function crashDiagnosticPath(): string | undefined {
 function destroyCrashDiagnosticTerminal(reason: string): void {
   if (!crashDiagnosticTmuxParked || !sessionId) return;
   try {
-    TmuxBackend.killSession(TmuxBackend.sessionName(sessionId));
+    TmuxBackend.killSession(TmuxBackend.diagnosticSessionName(sessionId));
     log(`Crash diagnostic tmux session destroyed (${reason})`);
   } catch (err: any) {
     log(`Crash diagnostic tmux cleanup failed (${reason}): ${err?.message ?? err}`);
   }
+  // Best-effort: drop the captured .ansi file too so a long-lived daemon does
+  // not accumulate one ~200 KB file per crashed session forever.
+  const path = crashDiagnosticPath();
+  if (path) { try { unlinkSync(path); } catch { /* already gone — benign */ } }
   crashDiagnosticTmuxParked = false;
 }
 
@@ -2268,7 +2255,16 @@ function parkCrashDiagnosticTerminal(code: number | null, signal: string | null)
     return false;
   }
 
-  const ok = TmuxBackend.parkDiagnosticSession(TmuxBackend.sessionName(sessionId), {
+  // Park under a DISTINCT name (`bmx-diag-<sid>`), never the live CLI's
+  // `bmx-<sid>` backing-session name. The whole persistent-backend machinery
+  // (restore probe, hasSession reattach, idle-sweep cold-resume, `botmux
+  // resume`) keys off `bmx-<sid>` to mean "the live CLI". Reusing that name for
+  // a bare diagnostic shell makes restore/cold-resume reattach the shell as if
+  // it were the CLI and type the user's next message into raw bash. With a
+  // distinct name, `bmx-<sid>` is correctly absent after the crash, so every
+  // one of those paths sees "no live CLI" and does the right thing; the web
+  // terminal is pointed at the diagnostic name explicitly (see the WS attach).
+  const ok = TmuxBackend.parkDiagnosticSession(TmuxBackend.diagnosticSessionName(sessionId), {
     cwd: lastInitConfig?.workingDir ?? process.cwd(),
     cols: renderCols || PTY_COLS,
     rows: renderRows || PTY_ROWS,
@@ -2279,7 +2275,14 @@ function parkCrashDiagnosticTerminal(code: number | null, signal: string | null)
   isTmuxMode = true;
   isPipeMode = false;
   isZellijMode = false;
-  log(`Crash diagnostic tmux session parked at ${TmuxBackend.sessionName(sessionId)}`);
+  // The CLI is gone; stop the screen-update + analyzer loops so a stale
+  // `status='working'` tick can't un-freeze the daemon's frozen crash card.
+  // The web terminal is served by per-client tmux-attach PTYs, not these loops,
+  // so the diagnostic shell stays visible. flushPending's retry path restarts
+  // both when the next message respawns the CLI.
+  stopScreenUpdates();
+  stopScreenAnalyzer();
+  log(`Crash diagnostic tmux session parked at ${TmuxBackend.diagnosticSessionName(sessionId)}`);
   return true;
 }
 
@@ -4555,7 +4558,13 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
         // byte-for-byte (empty, separators, etc.) are not retransmitted, so
         // the earlier frame "bleeds through" — visible as a second
         // banner/prompt stacked above the new layout when scrolling up.
-        const tmuxTarget = lastInitConfig?.adoptTmuxTarget ?? TmuxBackend.sessionName(sessionId);
+        // While a crash diagnostic shell is parked it lives under bmx-diag-<sid>
+        // (not the live CLI's bmx-<sid>), so attach there to surface the startup
+        // error; otherwise attach the normal backing session.
+        const tmuxTarget = lastInitConfig?.adoptTmuxTarget
+          ?? (crashDiagnosticTmuxParked
+            ? TmuxBackend.diagnosticSessionName(sessionId)
+            : TmuxBackend.sessionName(sessionId));
         let cp: pty.IPty | null = null;
         const pendingInput: string[] = [];
 
@@ -5331,6 +5340,11 @@ process.on('message', async (raw: unknown) => {
       log('Suspend requested');
       stopScreenshotLoop();
       stopBridgeWatcher();
+      // A parked crash diagnostic shell has backend===null, so the
+      // destroySession/kill below is a no-op and would otherwise leak the
+      // bmx-diag-<sid> session. Tear it down explicitly. (The session then
+      // cold-resumes a FRESH CLI on the next message — bmx-<sid> is absent.)
+      destroyCrashDiagnosticTerminal('suspend');
       // Free the CLI's memory, not just the worker's: destroySession kills the
       // backing tmux/herdr/zellij session AND the CLI process inside it (kill()
       // would only detach the pty viewer and leave the CLI running in the

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -130,7 +130,17 @@ let lastSpawnEffectiveResume = false;
 let lastSpawnEffectiveCliSessionId: string | undefined;
 let idleDetector: IdleDetector | null = null;
 let isTmuxMode = false;
+/** True once a crash diagnostic tmux shell (bmx-diag-<sid>) is live. */
 let crashDiagnosticTmuxParked = false;
+/** True once the daemon told us to stop & park a crash diagnostic (crash loop):
+ *  the next user message retries the CLI. Distinct from the flag above because
+ *  retry must still fire even if the tmux park itself failed (no hang). */
+let crashDiagnosticStopped = false;
+/** Exit code/signal of the just-exited CLI, stashed so a deferred park
+ *  (park_diagnostic IPC) can stamp the captured log even though the park no
+ *  longer happens inline in onExit. */
+let lastCliExitCode: number | null = null;
+let lastCliExitSignal: string | null = null;
 /** Adopt-bridge mode using TmuxPipeBackend: not a tmux attach client, all
  *  web-terminal updates flow through the shared scrollback fan-out instead
  *  of per-WS attach-session PTYs. Set in spawnCli's adopt branch. */
@@ -2225,6 +2235,10 @@ function crashDiagnosticPath(): string | undefined {
 }
 
 function destroyCrashDiagnosticTerminal(reason: string): void {
+  // Leaving the stopped-awaiting-retry state regardless of whether a tmux shell
+  // was actually parked (park may have failed); the next retry/close/suspend
+  // funnels through here.
+  crashDiagnosticStopped = false;
   if (!crashDiagnosticTmuxParked || !sessionId) return;
   try {
     TmuxBackend.killSession(TmuxBackend.diagnosticSessionName(sessionId));
@@ -2270,7 +2284,11 @@ function parkCrashDiagnosticTerminal(code: number | null, signal: string | null)
     rows: renderRows || PTY_ROWS,
     contentPath: path,
   });
-  if (!ok) return false;
+  if (!ok) {
+    // tmux spawn failed after the .ansi was written — drop the orphan file.
+    try { unlinkSync(path); } catch { /* benign */ }
+    return false;
+  }
   crashDiagnosticTmuxParked = true;
   isTmuxMode = true;
   isPipeMode = false;
@@ -4423,7 +4441,15 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   backend.onExit((code, signal) => {
     log(`${cliName()} exited (code: ${code}, signal: ${signal})`);
     const logTail = recentTerminalLogTail();
-    const diagnosticTerminal = parkCrashDiagnosticTerminal(code, signal) ? 'tmux' as const : undefined;
+    // Don't park a diagnostic shell here: most exits are immediately
+    // auto-restarted by the daemon, so an inline park would just be torn down
+    // again (a wasted tmux session + .ansi write on every restart). Instead
+    // report whether we COULD park; the daemon asks us to (park_diagnostic) only
+    // when it actually gives up restarting (crash loop). Stash the exit reason
+    // for that deferred park.
+    lastCliExitCode = code;
+    lastCliExitSignal = signal;
+    const canParkDiagnostic = !lastInitConfig?.adoptMode && effectiveBackendType === 'tmux' && !!sessionId;
     // Inputs written but not yet consumed (no idle since the write) die with
     // the CLI — codex crashing mid-submit never records them, and the fresh
     // respawn comes up empty. Stash them so the next spawnCli re-queues and
@@ -4434,7 +4460,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     }
     backend = null;
     isPromptReady = false;
-    send({ type: 'claude_exit', code, signal, logTail, diagnosticTerminal });
+    send({ type: 'claude_exit', code, signal, logTail, canParkDiagnostic });
   });
 
   if (isPipeMode && backend && 'isReattach' in backend && backend.isReattach) {
@@ -5101,8 +5127,8 @@ process.on('message', async (raw: unknown) => {
       const content = msg.content;
       currentBotmuxTurnId = msg.turnId;
       writeCliPidMarker();
-      if (!backend && crashDiagnosticTmuxParked && lastInitConfig && !lastInitConfig.adoptMode) {
-        log('Message received while crash diagnostic terminal is parked; retrying CLI start');
+      if (!backend && crashDiagnosticStopped && lastInitConfig && !lastInitConfig.adoptMode) {
+        log('Message received after crash-loop stop; retrying CLI start');
         destroyCrashDiagnosticTerminal('retry after message');
         stopScreenAnalyzer();
         stopScreenUpdates();
@@ -5224,6 +5250,17 @@ process.on('message', async (raw: unknown) => {
           log(`Enqueued follow-up after raw input (${msg.followUpContent.length} chars)`);
         }
       }
+      break;
+    }
+
+    case 'park_diagnostic': {
+      // The daemon gave up auto-restarting (crash loop) and wants the last
+      // terminal output preserved. Park the diagnostic shell now — deferred from
+      // onExit so transient (auto-restarted) exits never pay for it. Mark the
+      // stopped state even if the tmux park fails, so the next message still
+      // retries the CLI (no hang) rather than writing into a dead pane.
+      parkCrashDiagnosticTerminal(lastCliExitCode, lastCliExitSignal);
+      crashDiagnosticStopped = true;
       break;
     }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -129,6 +129,7 @@ let lastSpawnEffectiveResume = false;
 let lastSpawnEffectiveCliSessionId: string | undefined;
 let idleDetector: IdleDetector | null = null;
 let isTmuxMode = false;
+let crashDiagnosticTmuxParked = false;
 /** Adopt-bridge mode using TmuxPipeBackend: not a tmux attach client, all
  *  web-terminal updates flow through the shared scrollback fan-out instead
  *  of per-WS attach-session PTYs. Set in spawnCli's adopt branch. */
@@ -2196,6 +2197,8 @@ const MAX_SCROLLBACK = 1_000_000; // chars (~1MB)
 let scrollback = '';
 const WORKFLOW_TRANSCRIPT_MAX = 2_000_000; // chars (~2MB)
 const WORKFLOW_OUTPUT_END_MARKER = '</WORKFLOW_OUTPUT>';
+const CRASH_DIAGNOSTIC_RAW_MAX = 200_000; // enough scrollback for the web terminal without huge temp files
+const CRASH_LOG_TAIL_MAX = 2_500; // bounded Feishu text payload
 let workflowTranscript = '';
 let workflowFinalOutputSent = false;
 /** Tracks whether the CLI is currently in the alt screen buffer. Updated by
@@ -2207,6 +2210,78 @@ let workflowFinalOutputSent = false;
 let altBufferActive = false;
 const ALT_ENTER_RE = /\x1b\[\?(1049|1047|47)h/g;
 const ALT_EXIT_RE = /\x1b\[\?(1049|1047|47)l/g;
+
+function tailChars(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(text.length - max);
+}
+
+function stripAnsiForLog(text: string): string {
+  return text
+    // OSC sequences.
+    .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '')
+    // CSI/SGR and most cursor/control sequences.
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+    // Remaining one-byte ESC commands.
+    .replace(/\x1b[ -/]*[@-~]/g, '')
+    .replace(/\r/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function recentTerminalLogTail(): string | undefined {
+  const plain = stripAnsiForLog(tailChars(scrollback, CRASH_DIAGNOSTIC_RAW_MAX));
+  if (!plain) return undefined;
+  return tailChars(plain, CRASH_LOG_TAIL_MAX);
+}
+
+function crashDiagnosticPath(): string | undefined {
+  const dataDir = process.env.SESSION_DATA_DIR;
+  if (!dataDir || !sessionId) return undefined;
+  return join(dataDir, 'crash-diagnostics', `${sessionId}.ansi`);
+}
+
+function destroyCrashDiagnosticTerminal(reason: string): void {
+  if (!crashDiagnosticTmuxParked || !sessionId) return;
+  try {
+    TmuxBackend.killSession(TmuxBackend.sessionName(sessionId));
+    log(`Crash diagnostic tmux session destroyed (${reason})`);
+  } catch (err: any) {
+    log(`Crash diagnostic tmux cleanup failed (${reason}): ${err?.message ?? err}`);
+  }
+  crashDiagnosticTmuxParked = false;
+}
+
+function parkCrashDiagnosticTerminal(code: number | null, signal: string | null): boolean {
+  if (lastInitConfig?.adoptMode || effectiveBackendType !== 'tmux' || !sessionId) return false;
+  const path = crashDiagnosticPath();
+  if (!path) return false;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    const rawTail = tailChars(scrollback, CRASH_DIAGNOSTIC_RAW_MAX);
+    const header =
+      `[botmux] ${cliName()} exited (code: ${code ?? 'null'}, signal: ${signal ?? 'null'}).\n` +
+      `[botmux] Captured at ${new Date().toISOString()}.\n\n`;
+    writeFileSync(path, header + rawTail);
+  } catch (err: any) {
+    log(`Crash diagnostic log write failed: ${err?.message ?? err}`);
+    return false;
+  }
+
+  const ok = TmuxBackend.parkDiagnosticSession(TmuxBackend.sessionName(sessionId), {
+    cwd: lastInitConfig?.workingDir ?? process.cwd(),
+    cols: renderCols || PTY_COLS,
+    rows: renderRows || PTY_ROWS,
+    contentPath: path,
+  });
+  if (!ok) return false;
+  crashDiagnosticTmuxParked = true;
+  isTmuxMode = true;
+  isPipeMode = false;
+  isZellijMode = false;
+  log(`Crash diagnostic tmux session parked at ${TmuxBackend.sessionName(sessionId)}`);
+  return true;
+}
 
 // ─── Screen Analyzer (AI-based TUI prompt detection) ────────────────────────
 
@@ -4344,6 +4419,8 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   backend.onData(onPtyData);
   backend.onExit((code, signal) => {
     log(`${cliName()} exited (code: ${code}, signal: ${signal})`);
+    const logTail = recentTerminalLogTail();
+    const diagnosticTerminal = parkCrashDiagnosticTerminal(code, signal) ? 'tmux' as const : undefined;
     // Inputs written but not yet consumed (no idle since the write) die with
     // the CLI — codex crashing mid-submit never records them, and the fresh
     // respawn comes up empty. Stash them so the next spawnCli re-queues and
@@ -4354,7 +4431,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     }
     backend = null;
     isPromptReady = false;
-    send({ type: 'claude_exit', code, signal });
+    send({ type: 'claude_exit', code, signal, logTail, diagnosticTerminal });
   });
 
   if (isPipeMode && backend && 'isReattach' in backend && backend.isReattach) {
@@ -4388,6 +4465,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
 }
 
 function killCli(): void {
+  destroyCrashDiagnosticTerminal('killCli');
   idleDetector?.dispose();
   idleDetector = null;
   stopReattachIdleProbe();
@@ -5014,6 +5092,16 @@ process.on('message', async (raw: unknown) => {
       const content = msg.content;
       currentBotmuxTurnId = msg.turnId;
       writeCliPidMarker();
+      if (!backend && crashDiagnosticTmuxParked && lastInitConfig && !lastInitConfig.adoptMode) {
+        log('Message received while crash diagnostic terminal is parked; retrying CLI start');
+        destroyCrashDiagnosticTerminal('retry after message');
+        stopScreenAnalyzer();
+        stopScreenUpdates();
+        awaitingFirstPrompt = true;
+        startScreenUpdates();
+        startScreenAnalyzer();
+        spawnCli({ ...lastInitConfig, resume: true, prompt: '' });
+      }
       if (lastInitConfig?.adoptMode) {
         // Bridge mode: capture transcript baseline BEFORE writing to the pane,
         // so any assistant uuids appended after this point are attributed to

--- a/src/workflows/daemon-spawn.ts
+++ b/src/workflows/daemon-spawn.ts
@@ -63,7 +63,7 @@ type WorkerEvent =
       status: 'working' | 'idle' | 'analyzing';
     }
   | { type: 'prompt_ready' }
-  | { type: 'claude_exit'; code: number | null; signal: string | null }
+  | { type: 'claude_exit'; code: number | null; signal: string | null; logTail?: string; diagnosticTerminal?: 'tmux' }
   | { type: 'error'; message: string };
 
 // ─── Worker process abstraction (factory + handle) ────────────────────────

--- a/src/workflows/daemon-spawn.ts
+++ b/src/workflows/daemon-spawn.ts
@@ -63,7 +63,7 @@ type WorkerEvent =
       status: 'working' | 'idle' | 'analyzing';
     }
   | { type: 'prompt_ready' }
-  | { type: 'claude_exit'; code: number | null; signal: string | null; logTail?: string; diagnosticTerminal?: 'tmux' }
+  | { type: 'claude_exit'; code: number | null; signal: string | null; logTail?: string; canParkDiagnostic?: boolean }
   | { type: 'error'; message: string };
 
 // ─── Worker process abstraction (factory + handle) ────────────────────────

--- a/test/crash-log.test.ts
+++ b/test/crash-log.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { stripAnsiForLog, tailChars } from '../src/utils/crash-log.js';
+
+describe('tailChars', () => {
+  it('returns the input unchanged when within the cap', () => {
+    expect(tailChars('hello', 10)).toBe('hello');
+    expect(tailChars('hello', 5)).toBe('hello');
+  });
+
+  it('keeps only the last `max` chars when over the cap', () => {
+    expect(tailChars('abcdefg', 3)).toBe('efg');
+  });
+});
+
+describe('stripAnsiForLog', () => {
+  it('strips SGR / CSI color and cursor sequences', () => {
+    expect(stripAnsiForLog('\x1b[1;31mred\x1b[0m text')).toBe('red text');
+    expect(stripAnsiForLog('a\x1b[2Kb')).toBe('ab');
+  });
+
+  it('strips OSC-8 hyperlinks and OSC-0 titles (BEL- and ST-terminated)', () => {
+    const s = 'before\x1b]8;;https://x.com\x07link\x1b]8;;\x07\x1b]0;title\x07after';
+    expect(stripAnsiForLog(s)).toBe('beforelinkafter');
+    // ST (ESC \) terminator variant.
+    expect(stripAnsiForLog('x\x1b]0;t\x1b\\y')).toBe('xy');
+  });
+
+  it('normalizes CR to LF and collapses 3+ blank lines', () => {
+    expect(stripAnsiForLog('a\r\n\n\n\nb')).toBe('a\n\nb');
+  });
+
+  it('does NOT catastrophically backtrack on a dense run of unterminated OSC (ReDoS guard)', () => {
+    // A 200 KB tail of `ESC]` with no BEL/ST is exactly what a corrupted /
+    // binary stream flushed to the TTY right before a crash looks like. The
+    // pre-fix regex took ~18 s here (O(n²) backtracking) and froze the worker's
+    // synchronous exit handler. The fix must complete in well under a second.
+    const pathological = '\x1b]'.repeat(100_000); // ~200 KB
+    const start = Date.now();
+    const out = stripAnsiForLog(pathological);
+    const elapsedMs = Date.now() - start;
+    expect(elapsedMs).toBeLessThan(1000);
+    expect(out).toBe('');
+  });
+});

--- a/test/crash-loop-diagnostic.test.ts
+++ b/test/crash-loop-diagnostic.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Daemon-side crash-loop handling — worker-pool `case 'claude_exit'`, rc.count > 3.
+ *
+ *   - diagnosticTerminal:'tmux'  → KEEP the worker (no kill), reset the restart
+ *     counter, status → idle, and mark the session suspendedColdResume so the
+ *     parked diagnostic shell's "send a message to retry" affordance survives a
+ *     daemon restart (restore lazy-resumes instead of zombie-closing).
+ *   - no diagnosticTerminal      → historical path: kill the worker.
+ *
+ * Run:  pnpm vitest run --project unit test/crash-loop-diagnostic.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+// ─── Mocks (mirror worker-ready-display-mode.test.ts harness) ────────────────
+
+vi.mock('../src/im/lark/client.js', () => {
+  class MessageWithdrawnError extends Error {
+    constructor(id: string) { super(`withdrawn: ${id}`); this.name = 'MessageWithdrawnError'; }
+  }
+  return {
+    updateMessage: vi.fn(async () => {}),
+    deleteMessage: vi.fn(async () => {}),
+    MessageWithdrawnError,
+  };
+});
+
+vi.mock('../src/im/lark/card-builder.js', () => ({
+  buildStreamingCard: vi.fn(() => '{"type":"streaming"}'),
+  buildSessionCard: vi.fn(() => '{"type":"session"}'),
+  buildTuiPromptCard: vi.fn(() => '{}'),
+  buildTuiPromptResolvedCard: vi.fn(() => '{}'),
+  getCliDisplayName: vi.fn(() => 'Claude'),
+}));
+
+vi.mock('../src/bot-registry.js', () => ({
+  getBot: vi.fn(() => ({
+    config: { larkAppId: 'app_test', larkAppSecret: 'secret', cliId: 'claude-code' },
+    resolvedAllowedUsers: [],
+    botOpenId: 'ou_bot',
+    botName: 'TestBot',
+  })),
+  getAllBots: vi.fn(() => []),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    web: { externalHost: 'localhost' },
+    session: { dataDir: '/tmp/test-sessions' },
+    daemon: { backendType: 'tmux', cliId: 'claude-code' },
+  },
+}));
+
+const updateSessionMock = vi.fn();
+vi.mock('../src/services/session-store.js', () => ({
+  closeSession: vi.fn(),
+  updateSession: (...args: any[]) => updateSessionMock(...args),
+}));
+
+vi.mock('../src/services/frozen-card-store.js', () => ({
+  loadFrozenCards: vi.fn(() => new Map()),
+  saveFrozenCards: vi.fn(),
+}));
+
+vi.mock('../src/core/session-manager.js', () => ({
+  persistStreamCardState: vi.fn(),
+  ensureSessionWhiteboard: vi.fn(),
+  rememberLastCliInput: vi.fn(),
+}));
+
+vi.mock('../src/core/dashboard-events.js', () => ({
+  dashboardEventBus: { publish: vi.fn() },
+}));
+
+vi.mock('../src/core/dashboard-rows.js', () => ({
+  composeRowFromActive: vi.fn(),
+}));
+
+vi.mock('../src/skills/installer.js', () => ({
+  ensureSkills: vi.fn(),
+}));
+
+vi.mock('../src/adapters/cli/registry.js', () => ({
+  createCliAdapterSync: vi.fn(),
+}));
+
+vi.mock('../src/adapters/cli/claude-code.js', () => ({
+  claudeJsonlPathForSession: vi.fn(),
+}));
+
+vi.mock('../src/adapters/backend/tmux-backend.js', () => ({
+  TmuxBackend: class {},
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@larksuiteoapi/node-sdk', () => ({
+  Client: class { constructor() {} },
+  WSClient: class { start() {} },
+  EventDispatcher: class { register() {} },
+  LoggerLevel: { info: 2 },
+}));
+
+// ─── Imports under test ──────────────────────────────────────────────────────
+
+import { initWorkerPool, __testOnly_setupWorkerHandlers, restartCounts } from '../src/core/worker-pool.js';
+import type { DaemonSession } from '../src/core/types.js';
+
+function makeFakeWorker() {
+  const w = new EventEmitter() as any;
+  w.killed = false;
+  w.send = vi.fn();
+  w.kill = vi.fn();
+  w.pid = 12345;
+  w.stdout = new EventEmitter();
+  w.stderr = new EventEmitter();
+  return w;
+}
+
+function makeDs(sessionId: string, worker: any): DaemonSession {
+  return {
+    session: {
+      sessionId,
+      rootMessageId: 'om_root',
+      chatId: 'oc_chat',
+      title: 'Test Session',
+      status: 'active' as any,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      pid: null,
+      chatType: 'group',
+    },
+    worker,
+    workerPort: null,
+    workerToken: null,
+    larkAppId: 'app_test',
+    chatId: 'oc_chat',
+    chatType: 'group',
+    spawnedAt: Date.now(),
+    cliVersion: '1.0',
+    lastMessageAt: Date.now(),
+    hasHistory: false,
+    displayMode: 'hidden',
+    lastScreenContent: '',
+    lastScreenStatus: 'working',
+    currentTurnTitle: 'Test task',
+  } as DaemonSession;
+}
+
+const flush = () => new Promise<void>(r => setTimeout(r, 0));
+
+async function crashTimes(worker: any, n: number, diagnosticTerminal?: 'tmux') {
+  for (let i = 0; i < n; i++) {
+    worker.emit('message', { type: 'claude_exit', code: 1, signal: null, diagnosticTerminal });
+  }
+  await flush();
+}
+
+describe("crash-loop diagnostic terminal (daemon 'claude_exit' handler)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restartCounts.clear();
+    initWorkerPool({
+      sessionReply: vi.fn(async () => 'om_reply'),
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    } as any);
+  });
+
+  it('after >3 tmux crashes: keeps the worker + marks lazy cold-resume (survives restart)', async () => {
+    const worker = makeFakeWorker();
+    const ds = makeDs('sid-diag-keep', worker);
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    await crashTimes(worker, 4, 'tmux');
+
+    // First 3 auto-restart in place; the 4th parks (no close, no further restart).
+    expect(worker.send).toHaveBeenCalledWith({ type: 'restart' });
+    expect(worker.send).not.toHaveBeenCalledWith({ type: 'close' });
+    // Survives daemon restart: lazy cold-resume + idle, restart counter reset.
+    expect(ds.session.suspendedColdResume).toBe(true);
+    expect(ds.lastScreenStatus).toBe('idle');
+    expect(restartCounts.has('sid-diag-keep')).toBe(false);
+    expect(updateSessionMock).toHaveBeenCalled();
+  });
+
+  it('after >3 crashes with NO diagnostic terminal: kills the worker (historical path)', async () => {
+    const worker = makeFakeWorker();
+    const ds = makeDs('sid-diag-nokeep', worker);
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    await crashTimes(worker, 4, undefined);
+
+    expect(worker.send).toHaveBeenCalledWith({ type: 'close' });
+    expect(ds.session.suspendedColdResume).toBeFalsy();
+  });
+});

--- a/test/crash-loop-diagnostic.test.ts
+++ b/test/crash-loop-diagnostic.test.ts
@@ -187,6 +187,22 @@ describe("crash-loop diagnostic terminal (daemon 'claude_exit' handler)", () => 
     expect(updateSessionMock).toHaveBeenCalled();
   });
 
+  it('clears suspendedColdResume once the retried CLI reaches prompt_ready (in-place retry path)', async () => {
+    const worker = makeFakeWorker();
+    const ds = makeDs('sid-diag-cleared', worker);
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    await crashTimes(worker, 4, 'tmux');
+    expect(ds.session.suspendedColdResume).toBe(true); // parked → marked for restart survival
+
+    // The in-place retry (worker.ts) respawns the CLI WITHOUT going through
+    // forkWorker; prompt_ready is the daemon's signal that retry succeeded.
+    worker.emit('message', { type: 'prompt_ready' });
+    await flush();
+
+    expect(ds.session.suspendedColdResume).toBeFalsy();
+  });
+
   it('after >3 crashes with NO diagnostic terminal: kills the worker (historical path)', async () => {
     const worker = makeFakeWorker();
     const ds = makeDs('sid-diag-nokeep', worker);

--- a/test/crash-loop-diagnostic.test.ts
+++ b/test/crash-loop-diagnostic.test.ts
@@ -1,11 +1,12 @@
 /**
  * Daemon-side crash-loop handling — worker-pool `case 'claude_exit'`, rc.count > 3.
  *
- *   - diagnosticTerminal:'tmux'  → KEEP the worker (no kill), reset the restart
- *     counter, status → idle, and mark the session suspendedColdResume so the
- *     parked diagnostic shell's "send a message to retry" affordance survives a
- *     daemon restart (restore lazy-resumes instead of zombie-closing).
- *   - no diagnosticTerminal      → historical path: kill the worker.
+ *   - canParkDiagnostic:true   → KEEP the worker (ask it to park via park_diagnostic),
+ *     reset the restart counter, status → idle, and mark the session
+ *     suspendedColdResume so the parked diagnostic shell's "send a message to
+ *     retry" affordance survives a daemon restart (restore lazy-resumes
+ *     instead of zombie-closing).
+ *   - canParkDiagnostic:false  → historical path: kill the worker.
  *
  * Run:  pnpm vitest run --project unit test/crash-loop-diagnostic.test.ts
  */
@@ -151,9 +152,9 @@ function makeDs(sessionId: string, worker: any): DaemonSession {
 
 const flush = () => new Promise<void>(r => setTimeout(r, 0));
 
-async function crashTimes(worker: any, n: number, diagnosticTerminal?: 'tmux') {
+async function crashTimes(worker: any, n: number, canParkDiagnostic?: boolean) {
   for (let i = 0; i < n; i++) {
-    worker.emit('message', { type: 'claude_exit', code: 1, signal: null, diagnosticTerminal });
+    worker.emit('message', { type: 'claude_exit', code: 1, signal: null, canParkDiagnostic });
   }
   await flush();
 }
@@ -175,10 +176,12 @@ describe("crash-loop diagnostic terminal (daemon 'claude_exit' handler)", () => 
     const ds = makeDs('sid-diag-keep', worker);
     __testOnly_setupWorkerHandlers(ds, worker);
 
-    await crashTimes(worker, 4, 'tmux');
+    await crashTimes(worker, 4, true);
 
-    // First 3 auto-restart in place; the 4th parks (no close, no further restart).
+    // First 3 auto-restart in place; the 4th asks the worker to park a
+    // diagnostic shell (deferred park) and keeps it alive (no close).
     expect(worker.send).toHaveBeenCalledWith({ type: 'restart' });
+    expect(worker.send).toHaveBeenCalledWith({ type: 'park_diagnostic' });
     expect(worker.send).not.toHaveBeenCalledWith({ type: 'close' });
     // Survives daemon restart: lazy cold-resume + idle, restart counter reset.
     expect(ds.session.suspendedColdResume).toBe(true);
@@ -192,7 +195,7 @@ describe("crash-loop diagnostic terminal (daemon 'claude_exit' handler)", () => 
     const ds = makeDs('sid-diag-cleared', worker);
     __testOnly_setupWorkerHandlers(ds, worker);
 
-    await crashTimes(worker, 4, 'tmux');
+    await crashTimes(worker, 4, true);
     expect(ds.session.suspendedColdResume).toBe(true); // parked → marked for restart survival
 
     // The in-place retry (worker.ts) respawns the CLI WITHOUT going through

--- a/test/tmux-backend-env.test.ts
+++ b/test/tmux-backend-env.test.ts
@@ -25,6 +25,7 @@ import { join } from 'node:path';
 import {
   buildBotmuxEnvAssignments,
   buildDebugKeepShellScript,
+  DIAGNOSTIC_SHELL_SCRIPT,
   resolveUserShell,
   SHELL_WRAPPER_SCRIPT,
 } from '../src/adapters/backend/tmux-backend.js';
@@ -350,6 +351,39 @@ describe('debug keep-shell wrapper end-to-end', () => {
       expect(result.stderr).toContain('[botmux debug]');
       expect(result.stderr).toContain('status 7'); // surfaced fake CLI exit
       expect(result.stdout).toContain('PROBE-RAN');
+    },
+  );
+});
+
+describe('diagnostic shell wrapper', () => {
+  const hasEnvBin = existsSync('/usr/bin/env');
+
+  it('keeps a shell alive after printing the preserved output', () => {
+    expect(DIAGNOSTIC_SHELL_SCRIPT).toContain('cat -- "$2"');
+    expect(DIAGNOSTIC_SHELL_SCRIPT).toContain('Auto-restart is paused');
+    expect(DIAGNOSTIC_SHELL_SCRIPT).toMatch(/exec "\$3" -i$/);
+  });
+
+  it.skipIf(!hasEnvBin)(
+    'prints the diagnostic file and then hands off to the shell',
+    () => {
+      const dir = mkdtempSync(join(tmpdir(), 'bmx-diag-'));
+      try {
+        const diag = join(dir, 'diag.ansi');
+        writeFileSync(diag, 'startup failed\nmissing token\n');
+        const probeScript = DIAGNOSTIC_SHELL_SCRIPT.replace('exec "$3" -i', 'echo DIAG-SHELL-READY');
+        const result = spawnSync(
+          '/bin/sh',
+          ['-c', probeScript, '_', dir, diag, '/bin/sh'],
+          { encoding: 'utf-8', env: { HOME: dir, PATH: '/usr/bin:/bin' } },
+        );
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('startup failed');
+        expect(result.stdout).toContain('missing token');
+        expect(result.stdout).toContain('DIAG-SHELL-READY');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     },
   );
 });


### PR DESCRIPTION
## 变更内容

- 当 agent CLI 连续崩溃并暂停自动重启时，保留最后一次 tmux 终端输出。
- 在原有 `bmx-*` 名称下停放一个轻量诊断 tmux 会话，让现有 Web 终端链接可以直接查看启动失败原因。
- 在崩溃循环回复里附带有长度限制的纯文本终端尾部日志，并在下一条用户消息到来时重新尝试启动 CLI。
- 为诊断 shell wrapper 补充单元测试。

## 验证

- `pnpm exec vitest run --project unit test/tmux-backend-env.test.ts`
- `pnpm build`

## 备注

本地未跟踪的 `docs/` 调研/审计文档没有放进这个 PR。