### PR TITLE
feat(backend): per-bot env 覆盖 herdr 后端（补 #148 遗漏）

### DIFF
--- a/src/adapters/backend/herdr-backend.ts
+++ b/src/adapters/backend/herdr-backend.ts
@@ -204,7 +204,18 @@ export class HerdrBackend implements SessionBackend {
     //     into the CLI process via plain process.env inheritance
     // Skip on externalTarget: that's the user's own pre-existing herdr
     // session; we can't (and shouldn't) re-env an already-running CLI.
-    this.childEnv = this.opts.externalTarget ? undefined : { ...opts.env };
+    //
+    // Per-bot env (opts.injectEnv, e.g. ANTHROPIC_BASE_URL/AUTH_TOKEN for a GLM
+    // bot): herdr runs a per-session server (one `herdr --session <name> server`
+    // per botmux session, see ensureServer), so unlike tmux/zellij there is no
+    // shared cross-bot server whose global env we'd pollute — merging it into
+    // childEnv is safe (same reasoning as the pty backend). childEnv flows to
+    // both the daemon spawn and the agent-start call, and the daemon forks the
+    // CLI as its child, so the per-bot env reaches the CLI. Already sanitized by
+    // the worker. Appended last so it wins over a same-named key in opts.env.
+    this.childEnv = this.opts.externalTarget
+      ? undefined
+      : { ...opts.env, ...(opts.injectEnv ?? {}) };
     this.ensureServer();
 
     const external = this.opts.externalTarget;

--- a/test/herdr-backend.test.ts
+++ b/test/herdr-backend.test.ts
@@ -222,6 +222,55 @@ describe('HerdrBackend.spawn', () => {
     be.kill();
   });
 
+  it('per-bot injectEnv is threaded into the herdr server + agent-start env (so the forked CLI inherits it)', () => {
+    // Fresh start so ensureServer actually boots a `herdr server`: first
+    // session-list probe empty (→ boot), subsequent probes running (→ ready).
+    let listCount = 0;
+    setHerdrResponses([
+      {
+        match: a => a[0] === 'session' && a[1] === 'list',
+        reply: () => { listCount++; return listCount >= 2 ? EXISTING_SESSION_REPLY : EMPTY_SESSIONS_REPLY; },
+      },
+      { match: a => a.includes('agent') && a.includes('start'), reply: () => AGENT_GET_REPLY('1-1') },
+      { match: a => a.includes('read') && (a.includes('agent') || a.includes('pane')), reply: () => PANE_READ_REPLY('') },
+    ]);
+    const be = new HerdrBackend(SESSION, { createSession: true });
+    be.spawn('claude', [], {
+      cwd: '/work', cols: 80, rows: 24,
+      env: { BOTMUX_SESSION_ID: 'sess_x' },
+      injectEnv: { ANTHROPIC_BASE_URL: 'https://api.z.ai/api/anthropic', ANTHROPIC_AUTH_TOKEN: 'glm-key' },
+    });
+
+    // The daemon forks the CLI, so the SERVER spawn env is what the CLI inherits.
+    const serverSpawn = mockedSpawn.mock.calls.find(c => (c[1] as string[]).includes('server'));
+    expect(serverSpawn).toBeDefined();
+    expect(serverSpawn![2].env.ANTHROPIC_BASE_URL).toBe('https://api.z.ai/api/anthropic');
+    expect(serverSpawn![2].env.ANTHROPIC_AUTH_TOKEN).toBe('glm-key');
+    expect(serverSpawn![2].env.BOTMUX_SESSION_ID).toBe('sess_x'); // base env preserved
+    // agent-start call carries it too (defense in depth).
+    const startOpts = findCallOpts(a => a.includes('agent') && a.includes('start'));
+    expect(startOpts?.env?.ANTHROPIC_AUTH_TOKEN).toBe('glm-key');
+    be.kill();
+  });
+
+  it('without injectEnv the server env carries only the base env (no provider keys)', () => {
+    let listCount = 0;
+    setHerdrResponses([
+      {
+        match: a => a[0] === 'session' && a[1] === 'list',
+        reply: () => { listCount++; return listCount >= 2 ? EXISTING_SESSION_REPLY : EMPTY_SESSIONS_REPLY; },
+      },
+      { match: a => a.includes('agent') && a.includes('start'), reply: () => AGENT_GET_REPLY('1-1') },
+      { match: a => a.includes('read') && (a.includes('agent') || a.includes('pane')), reply: () => PANE_READ_REPLY('') },
+    ]);
+    const be = new HerdrBackend(SESSION, { createSession: true });
+    be.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: { BOTMUX_SESSION_ID: 'sess_x' } });
+    const serverSpawn = mockedSpawn.mock.calls.find(c => (c[1] as string[]).includes('server'));
+    expect(serverSpawn![2].env.BOTMUX_SESSION_ID).toBe('sess_x');
+    expect(serverSpawn![2].env.ANTHROPIC_BASE_URL).toBeUndefined();
+    be.kill();
+  });
+
   it('reattach reuses an existing agent without re-running `agent start`', () => {
     // Reuse is gated on isReattach: only a genuine daemon-restart reattach to a
     // still-alive session adopts the existing `botmux` row. A fresh spawn (incl.


### PR DESCRIPTION
## 背景

#148（per-bot env，已合）给 tmux/tmux-pipe/zellij/pty 接了 `SpawnOpts.injectEnv`，但**漏了 herdr** 后端。配置层不限制后端 → `backendType=herdr` 的用户会以为也支持 per-bot env，实为静默 no-op（与 #148 原 bug 同类）。Codex 在 #148 review 中指出，作为小 follow-up。

## 改动

- herdr 跑 **per-session server**（每个 botmux 会话一个 `herdr --session <name> server`），不像 tmux/zellij 有跨 bot 共享 server，所以把 sanitized `injectEnv` 合进 `childEnv` 是安全的（与 pty 同款，无串台风险）。
- `childEnv` 同时是 herdr daemon 与 agent-start 的 env；daemon fork CLI，故 CLI 继承 provider env。`externalTarget`（用户既有会话）不注入。
- 补 herdr-backend 单测：注入时 server spawn + agent-start env 带 provider key；不注入时只有 base env。

## 测试

`pnpm build` 0 错；`herdr-backend.test.ts` 29 测绿（+2）。

关联 #258。Codex 说作为小 follow-up 看 diff 即可。