### PR TITLE
feat(worktree): 多仓库 worktree 创建 + 可持久切换的选择器模式（基于 #257）

### DIFF
--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -282,6 +282,13 @@ export interface BotConfig {
    */
   autoStartOnNewTopic?: boolean;
   /**
+   * Worktree picker mode on the repo-select card. When true, the worktree
+   * control renders the multi-repo selector (pick N repos + branch) instead of
+   * the single-select dropdown. Toggled from the card's 「切换多仓库选择器」button;
+   * persists so all of this bot's future sessions default to it. Default false.
+   */
+  worktreeMultiPicker?: boolean;
+  /**
    * Per-bot DEFAULT session mode for regular Lark groups (overridable per-chat
    * via `/reply-mode` → `chatReplyModes`). Resolved by
    * `chat-reply-mode-store.regularGroupDefaultMode`.
@@ -851,6 +858,7 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
         ? entry.autoStartOnGroupJoinPrompt
         : undefined,
       autoStartOnNewTopic: entry.autoStartOnNewTopic === true || undefined,
+      worktreeMultiPicker: entry.worktreeMultiPicker === true || undefined,
       // Per-bot regular-group default mode. Only 'new-topic' | 'shared' are
       // meaningful; 'chat' (the flat default) and anything else normalize to
       // undefined so bots.json stays clean.

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -1585,7 +1585,7 @@ export async function handleCommand(
         }
         if (ds) lastRepoScan.set(ds.chatId, projects);
         const currentCwd = getSessionWorkingDir(ds);
-        const cardJson = buildRepoSelectCard(projects, currentCwd, rootId, loc);
+        const cardJson = buildRepoSelectCard(projects, currentCwd, rootId, loc, ds ? getBot(ds.larkAppId).config.worktreeMultiPicker : undefined);
         const repoCardMsgId = await sessionReply(rootId, cardJson, 'interactive');
         if (ds) {
           ds.repoCardMessageId = repoCardMsgId;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -51,7 +51,6 @@ export interface DaemonSession {
   pendingRepo?: boolean;         // waiting for repo selection before spawning CLI
   repoCardMessageId?: string;    // message_id of the repo selection card — for withdrawal
   worktreeCreating?: boolean;    // a worktree-open is in flight — dedups repeated card clicks / `/repo wt`
-  pendingWorktreePaths?: string[]; // selected repo paths from the worktree multi-select card
   pendingPrompt?: string;        // original user message to send after repo is selected
   /** One-shot CLI slash command to send literally after the worker reports
    *  prompt_ready. Used when a new topic starts with an adapter-default

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -51,6 +51,7 @@ export interface DaemonSession {
   pendingRepo?: boolean;         // waiting for repo selection before spawning CLI
   repoCardMessageId?: string;    // message_id of the repo selection card — for withdrawal
   worktreeCreating?: boolean;    // a worktree-open is in flight — dedups repeated card clicks / `/repo wt`
+  pendingWorktreePaths?: string[]; // selected repo paths from the worktree multi-select card
   pendingPrompt?: string;        // original user message to send after repo is selected
   /** One-shot CLI slash command to send literally after the worker reports
    *  prompt_ready. Used when a new topic starts with an adapter-default

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2147,7 +2147,7 @@ async function startInitialPassthroughSession(args: {
   const projects = scanDirs.length > 0 ? scanMultipleProjects(scanDirs, 3, repoPickerScanOptions()) : [];
   if (projects.length > 0) {
     lastRepoScan.set(chatId, projects);
-    const cardJson = buildRepoSelectCard(projects, getSessionWorkingDir(ds), anchor, localeForBot(larkAppId));
+    const cardJson = buildRepoSelectCard(projects, getSessionWorkingDir(ds), anchor, localeForBot(larkAppId), getBot(larkAppId).config.worktreeMultiPicker);
     ds.repoCardMessageId = await sessionReply(anchor, cardJson, 'interactive', larkAppId);
     announcePendingRepoSession(ds);
     logger.info(`[${tag(ds)}] Waiting for repo selection before initial raw passthrough (${projects.length} projects)`);
@@ -2480,7 +2480,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
   if (projects.length > 0) {
     lastRepoScan.set(chatId, projects);
     const currentCwd = getSessionWorkingDir(ds);
-    const cardJson = buildRepoSelectCard(projects, currentCwd, anchor, localeForBot(larkAppId));
+    const cardJson = buildRepoSelectCard(projects, currentCwd, anchor, localeForBot(larkAppId), getBot(larkAppId).config.worktreeMultiPicker);
     ds.repoCardMessageId = await sessionReply(anchor, cardJson, 'interactive', larkAppId);
     announcePendingRepoSession(ds);
     logger.info(`[${tag(ds)}] Waiting for repo selection (${projects.length} projects)`);
@@ -2682,7 +2682,7 @@ async function handleBotAdded(chatId: string, operatorOpenId: string | undefined
     const projects = scanDirs.length > 0 ? scanMultipleProjects(scanDirs, 3, repoPickerScanOptions()) : [];
     if (projects.length > 0) {
       lastRepoScan.set(chatId, projects);
-      const cardJson = buildRepoSelectCard(projects, getSessionWorkingDir(ds), anchor, localeForBot(larkAppId));
+      const cardJson = buildRepoSelectCard(projects, getSessionWorkingDir(ds), anchor, localeForBot(larkAppId), getBot(larkAppId).config.worktreeMultiPicker);
       ds.repoCardMessageId = await sessionReply(anchor, cardJson, 'interactive', larkAppId);
       announcePendingRepoSession(ds);
       logger.info(`[auto-start:入群] ${chatId.substring(0, 12)} 无默认目录，弹 repo 选择卡（${projects.length} 个项目）`);
@@ -3228,7 +3228,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
     if (projects.length > 0) {
       lastRepoScan.set(autoCreateChatId, projects);
       const currentCwd = getSessionWorkingDir(newDs);
-      const cardJson = buildRepoSelectCard(projects, currentCwd, anchor, localeForBot(larkAppId));
+      const cardJson = buildRepoSelectCard(projects, currentCwd, anchor, localeForBot(larkAppId), getBot(larkAppId).config.worktreeMultiPicker);
       newDs.repoCardMessageId = await sessionReply(anchor, cardJson, 'interactive', larkAppId);
       announcePendingRepoSession(newDs);
       logger.info(`[${tag(newDs)}] Waiting for repo selection (${projects.length} projects)`);

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -17,6 +17,8 @@ export const messages: Record<string, string> = {
   'card.btn.skip_repo': '▶️ Start Session Directly',
   'card.btn.manual_repo': 'Use This Directory',
   'card.btn.worktree_repo': 'Create Worktree',
+  'card.btn.worktree_to_multi': '🔀 Multi-repo',
+  'card.btn.worktree_to_single': '🔀 Single-repo',
   'card.btn.half_page_up': '⇞ Page ½ Up',
   'card.btn.half_page_down': '⇟ Page ½ Down',
   'card.btn.send_custom': '📝 Send Custom Reply',
@@ -61,7 +63,12 @@ export const messages: Record<string, string> = {
   'card.repo.current_active': 'Current working directory:',
   'card.repo.current_marker': ' ← current',
   'card.repo.note': 'You can also reply `/repo <N>` (e.g. `/repo 1`), or `/repo <path|name>` directly (e.g. `/repo botmux`, `/repo ~/projects/foo`) to skip this card. `/repo wt <N|name> [branch]` opens a fresh worktree off the remote default branch.',
-  'card.repo.placeholder_worktree': '🌿 Select one or more repos for new worktrees',
+  'card.repo.placeholder_worktree': '🌿 Open a repo as a new worktree',
+  'card.repo.placeholder_worktree_multi': '🌿 Select one or more repos for new worktrees',
+  'card.repo.worktree_now_multi': 'Multi-repo picker on (default for this bot’s future sessions)',
+  'card.repo.toast_worktree_mode_switched': 'Switched to the multi-repo picker; default for this bot’s future sessions (tap again to switch back).',
+  'card.repo.toast_worktree_mode_switched_back': 'Switched back to the single-repo picker; default for this bot’s future sessions (tap again for multi).',
+  'card.repo.worktree_rolled_back': 'Worktree creation failed on {repo}: {error}. Rolled back {count} worktree(s) already created in this batch.',
   'card.repo.toast_worktree_creating': 'Creating worktree — will post in the thread when done…',
 
   // In-group authorization card

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -16,6 +16,7 @@ export const messages: Record<string, string> = {
   'card.btn.takeover': '🔄 Take Over',
   'card.btn.skip_repo': '▶️ Start Session Directly',
   'card.btn.manual_repo': 'Use This Directory',
+  'card.btn.worktree_repo': 'Create Worktree',
   'card.btn.half_page_up': '⇞ Page ½ Up',
   'card.btn.half_page_down': '⇟ Page ½ Down',
   'card.btn.send_custom': '📝 Send Custom Reply',
@@ -54,10 +55,13 @@ export const messages: Record<string, string> = {
   'card.repo.placeholder_switch': 'Pick a repo to switch to',
   'card.repo.manual_placeholder': 'Enter any working directory, e.g. /path/to/project or ~/projects/foo',
   'card.repo.manual_empty': 'Please enter a working directory path',
+  'card.repo.worktree_empty': 'Please select at least one repo',
+  'card.repo.worktree_branch_placeholder': 'Branch name (optional; used as parent dir for multi-select)',
+  'card.repo.worktree_child_conflict': 'Multiple repos would map to the same worktree child directory: {names}. Rename the project first or create one worktree at a time.',
   'card.repo.current_active': 'Current working directory:',
   'card.repo.current_marker': ' ← current',
   'card.repo.note': 'You can also reply `/repo <N>` (e.g. `/repo 1`), or `/repo <path|name>` directly (e.g. `/repo botmux`, `/repo ~/projects/foo`) to skip this card. `/repo wt <N|name> [branch]` opens a fresh worktree off the remote default branch.',
-  'card.repo.placeholder_worktree': '🌿 Open a repo as a new worktree',
+  'card.repo.placeholder_worktree': '🌿 Select one or more repos for new worktrees',
   'card.repo.toast_worktree_creating': 'Creating worktree — will post in the thread when done…',
 
   // In-group authorization card

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -20,6 +20,8 @@ export const messages: Record<string, string> = {
   'card.btn.skip_repo': '▶️ 直接开启会话',
   'card.btn.manual_repo': '使用此目录',
   'card.btn.worktree_repo': '创建 worktree',
+  'card.btn.worktree_to_multi': '🔀 多仓库',
+  'card.btn.worktree_to_single': '🔀 单仓库',
   'card.btn.half_page_up': '⇞ 上半屏',
   'card.btn.half_page_down': '⇟ 下半屏',
   'card.btn.send_custom': '📝 发送自定义回复',
@@ -64,7 +66,12 @@ export const messages: Record<string, string> = {
   'card.repo.current_active': '当前工作目录：',
   'card.repo.current_marker': ' ← 当前',
   'card.repo.note': '也可以回复 `/repo <编号>` 切换（如 `/repo 1`），或直接 `/repo <路径|项目名>`（如 `/repo botmux`、`/repo ~/projects/foo`）跳过本卡片；`/repo wt <编号|项目名> [分支名]` 基于远端默认分支新建 worktree 打开',
-  'card.repo.placeholder_worktree': '🌿 选择一个或多个仓库新建 worktree',
+  'card.repo.placeholder_worktree': '🌿 选仓库新建 worktree 打开',
+  'card.repo.placeholder_worktree_multi': '🌿 选择一个或多个仓库新建 worktree',
+  'card.repo.worktree_now_multi': '多仓库选择器已开启（本 bot 后续会话默认）',
+  'card.repo.toast_worktree_mode_switched': '已切到多仓库选择器，本 bot 后续会话默认生效（可再点切回）。',
+  'card.repo.toast_worktree_mode_switched_back': '已切回单仓库选择器，本 bot 后续会话默认生效（可再点切到多仓库）。',
+  'card.repo.worktree_rolled_back': '{repo} 创建 worktree 失败：{error}。已回滚本批次此前创建的 {count} 个 worktree。',
   'card.repo.toast_worktree_creating': '正在创建 worktree，完成后会在话题里通知…',
 
   // 群内授权卡片

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -19,6 +19,7 @@ export const messages: Record<string, string> = {
   'card.btn.takeover': '🔄 接管',
   'card.btn.skip_repo': '▶️ 直接开启会话',
   'card.btn.manual_repo': '使用此目录',
+  'card.btn.worktree_repo': '创建 worktree',
   'card.btn.half_page_up': '⇞ 上半屏',
   'card.btn.half_page_down': '⇟ 下半屏',
   'card.btn.send_custom': '📝 发送自定义回复',
@@ -57,10 +58,13 @@ export const messages: Record<string, string> = {
   'card.repo.placeholder_switch': '选择仓库并切换',
   'card.repo.manual_placeholder': '输入任意工作目录，如 /path/to/project 或 ~/projects/foo',
   'card.repo.manual_empty': '请输入工作目录路径',
+  'card.repo.worktree_empty': '请至少选择一个仓库',
+  'card.repo.worktree_branch_placeholder': '分支名（可选；多选时作为父目录名）',
+  'card.repo.worktree_child_conflict': '多个仓库会映射到相同 worktree 子目录：{names}。请先调整项目名或改用单项目创建。',
   'card.repo.current_active': '当前工作目录：',
   'card.repo.current_marker': ' ← 当前',
   'card.repo.note': '也可以回复 `/repo <编号>` 切换（如 `/repo 1`），或直接 `/repo <路径|项目名>`（如 `/repo botmux`、`/repo ~/projects/foo`）跳过本卡片；`/repo wt <编号|项目名> [分支名]` 基于远端默认分支新建 worktree 打开',
-  'card.repo.placeholder_worktree': '🌿 选仓库新建 worktree 打开',
+  'card.repo.placeholder_worktree': '🌿 选择一个或多个仓库新建 worktree',
   'card.repo.toast_worktree_creating': '正在创建 worktree，完成后会在话题里通知…',
 
   // 群内授权卡片

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -910,7 +910,58 @@ export function buildPrivateSnapshotCard(
  * Build a Feishu interactive card with a dropdown selector for projects.
  * Returns a JSON string suitable for msg_type: 'interactive'.
  */
-export function buildRepoSelectCard(projects: ProjectInfo[], currentPath?: string, rootMessageId?: string, locale?: Locale): string {
+/** The worktree multi-select form element (multi_select + branch input + submit),
+ *  inlined into the repo card when the bot is in multi-repo-picker mode. */
+function worktreeMultiForm(worktreeOptions: Array<{ text: { tag: 'plain_text'; content: string }; value: string }>, rootMessageId?: string, locale?: Locale): any {
+  return {
+    tag: 'form',
+    name: 'repo_worktree_submit_form',
+    elements: [
+      {
+        tag: 'column_set',
+        flex_mode: 'none',
+        horizontal_spacing: 'default',
+        columns: [
+          {
+            tag: 'column', width: 'weighted', weight: 2, vertical_align: 'center',
+            elements: [{
+              tag: 'multi_select_static',
+              name: 'repo_worktree_paths',
+              required: true,
+              width: 'fill',
+              placeholder: { tag: 'plain_text', content: t('card.repo.placeholder_worktree_multi', undefined, locale) },
+              options: worktreeOptions,
+            }],
+          },
+          {
+            tag: 'column', width: 'weighted', weight: 1, vertical_align: 'center',
+            elements: [{
+              tag: 'input',
+              name: 'repo_worktree_branch',
+              placeholder: { tag: 'plain_text', content: t('card.repo.worktree_branch_placeholder', undefined, locale) },
+            }],
+          },
+          {
+            tag: 'column', width: 'auto', vertical_align: 'center',
+            elements: [{
+              tag: 'button',
+              name: 'repo_worktree_submit',
+              text: { tag: 'plain_text', content: t('card.btn.worktree_repo', undefined, locale) },
+              type: 'default',
+              action_type: 'form_submit',
+              value: { action: 'repo_worktree_submit', root_id: rootMessageId ?? '' },
+            }],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+/** Repo selection card. `multiPicker` (persisted per-bot via worktreeMultiPicker)
+ *  flips the worktree control between an instant single-select dropdown (false)
+ *  and the inline multi-select form (true). */
+export function buildRepoSelectCard(projects: ProjectInfo[], currentPath?: string, rootMessageId?: string, locale?: Locale, multiPicker?: boolean): string {
   const currentMarker = t('card.repo.current_marker', undefined, locale);
   const options = projects.map((p, i) => {
     const currentTag = p.path === currentPath ? currentMarker : '';
@@ -994,63 +1045,66 @@ export function buildRepoSelectCard(projects: ProjectInfo[], currentPath?: strin
           },
         ],
       },
-      ...(worktreeOptions.length > 0 ? [{
-        tag: 'form',
-        name: 'repo_worktree_submit_form',
-        elements: [
+      // Worktree open. Two modes, persisted per-bot (worktreeMultiPicker):
+      //   • single (default) — instant single-select dropdown + a short 「🔀 多仓库」
+      //     button on the SAME action row (a select_static can't live in a
+      //     column_set, so it can't be weight-filled like the manual input; a short
+      //     a column_set so the dropdown weight-fills and the toggle button hugs
+      //     the right edge — same row, same alignment as the manual-entry row,
+      //     and it never wraps on mobile (the column_set forces one line). A
+      //     select_static CAN live in a column_set (it renders + fires); only the
+      //     `action` *container* tag is rejected inside a column.
+      //   • multi — the inline multi-select form, with a 「🔀 单仓库」toggle on its
+      //     own right-aligned row below (the form already fills its row).
+      // The toggle flips the persisted mode for all of this bot's future sessions
+      // (only shown with 2+ main repos — batching a single repo is pointless).
+      ...(worktreeOptions.length > 0 ? (multiPicker ? [
+        worktreeMultiForm(worktreeOptions, rootMessageId, locale),
+        ...(worktreeOptions.length > 1 ? [{
+          tag: 'column_set',
+          flex_mode: 'none',
+          horizontal_spacing: 'default',
+          columns: [
+            {
+              tag: 'column', width: 'weighted', weight: 1, vertical_align: 'center',
+              elements: [{ tag: 'div', text: { tag: 'lark_md', content: t('card.repo.worktree_now_multi', undefined, locale) } }],
+            },
+            {
+              tag: 'column', width: 'auto', vertical_align: 'center',
+              elements: [{
+                tag: 'button',
+                text: { tag: 'plain_text', content: t('card.btn.worktree_to_single', undefined, locale) },
+                type: 'default',
+                value: { action: 'worktree_toggle_mode', root_id: rootMessageId ?? '' },
+              }],
+            },
+          ],
+        }] : []),
+      ] : [{
+        tag: 'column_set',
+        flex_mode: 'none',
+        horizontal_spacing: 'default',
+        columns: [
           {
-            tag: 'column_set',
-            flex_mode: 'none',
-            horizontal_spacing: 'default',
-            columns: [
-              {
-                tag: 'column',
-                width: 'weighted',
-                weight: 2,
-                vertical_align: 'center',
-                elements: [
-                  {
-                    tag: 'multi_select_static',
-                    name: 'repo_worktree_paths',
-                    required: true,
-                    width: 'fill',
-                    placeholder: { tag: 'plain_text', content: t('card.repo.placeholder_worktree', undefined, locale) },
-                    options: worktreeOptions,
-                  },
-                ],
-              },
-              {
-                tag: 'column',
-                width: 'weighted',
-                weight: 1,
-                vertical_align: 'center',
-                elements: [
-                  {
-                    tag: 'input',
-                    name: 'repo_worktree_branch',
-                    placeholder: { tag: 'plain_text', content: t('card.repo.worktree_branch_placeholder', undefined, locale) },
-                  },
-                ],
-              },
-              {
-                tag: 'column',
-                width: 'auto',
-                vertical_align: 'center',
-                elements: [
-                  {
-                    tag: 'button',
-                    name: 'repo_worktree_submit',
-                    text: { tag: 'plain_text', content: t('card.btn.worktree_repo', undefined, locale) },
-                    type: 'default',
-                    action_type: 'form_submit',
-                    value: { action: 'repo_worktree_submit', root_id: rootMessageId ?? '' },
-                  },
-                ],
-              },
-            ],
+            tag: 'column', width: 'weighted', weight: 1, vertical_align: 'center',
+            elements: [{
+              tag: 'select_static',
+              placeholder: { tag: 'plain_text', content: t('card.repo.placeholder_worktree', undefined, locale) },
+              options: worktreeOptions,
+              value: { key: 'repo_worktree', root_id: rootMessageId ?? '' },
+            }],
           },
+          ...(worktreeOptions.length > 1 ? [{
+            tag: 'column', width: 'auto', vertical_align: 'center',
+            elements: [{
+              tag: 'button',
+              text: { tag: 'plain_text', content: t('card.btn.worktree_to_multi', undefined, locale) },
+              type: 'default',
+              value: { action: 'worktree_toggle_mode', root_id: rootMessageId ?? '' },
+            }],
+          }] : []),
         ],
-      }] : []),
+      }]) : []),
       // Manual entry: type any existing local directory the scan didn't surface
       // (mirrors `/repo <path>`). form_submit hands the input back under
       // value.action='repo_manual_submit' with form_value.repo_manual_path.

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -995,16 +995,6 @@ export function buildRepoSelectCard(projects: ProjectInfo[], currentPath?: strin
         ],
       },
       ...(worktreeOptions.length > 0 ? [{
-        tag: 'action',
-        actions: [
-          {
-            tag: 'multi_select_static',
-            placeholder: { tag: 'plain_text', content: t('card.repo.placeholder_worktree', undefined, locale) },
-            options: worktreeOptions,
-            value: { key: 'repo_worktree_select', root_id: rootMessageId ?? '' },
-          },
-        ],
-      }, {
         tag: 'form',
         name: 'repo_worktree_submit_form',
         elements: [
@@ -1013,6 +1003,22 @@ export function buildRepoSelectCard(projects: ProjectInfo[], currentPath?: strin
             flex_mode: 'none',
             horizontal_spacing: 'default',
             columns: [
+              {
+                tag: 'column',
+                width: 'weighted',
+                weight: 2,
+                vertical_align: 'center',
+                elements: [
+                  {
+                    tag: 'multi_select_static',
+                    name: 'repo_worktree_paths',
+                    required: true,
+                    width: 'fill',
+                    placeholder: { tag: 'plain_text', content: t('card.repo.placeholder_worktree', undefined, locale) },
+                    options: worktreeOptions,
+                  },
+                ],
+              },
               {
                 tag: 'column',
                 width: 'weighted',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -998,10 +998,50 @@ export function buildRepoSelectCard(projects: ProjectInfo[], currentPath?: strin
         tag: 'action',
         actions: [
           {
-            tag: 'select_static',
+            tag: 'multi_select_static',
             placeholder: { tag: 'plain_text', content: t('card.repo.placeholder_worktree', undefined, locale) },
             options: worktreeOptions,
-            value: { key: 'repo_worktree', root_id: rootMessageId ?? '' },
+            value: { key: 'repo_worktree_select', root_id: rootMessageId ?? '' },
+          },
+        ],
+      }, {
+        tag: 'form',
+        name: 'repo_worktree_submit_form',
+        elements: [
+          {
+            tag: 'column_set',
+            flex_mode: 'none',
+            horizontal_spacing: 'default',
+            columns: [
+              {
+                tag: 'column',
+                width: 'weighted',
+                weight: 1,
+                vertical_align: 'center',
+                elements: [
+                  {
+                    tag: 'input',
+                    name: 'repo_worktree_branch',
+                    placeholder: { tag: 'plain_text', content: t('card.repo.worktree_branch_placeholder', undefined, locale) },
+                  },
+                ],
+              },
+              {
+                tag: 'column',
+                width: 'auto',
+                vertical_align: 'center',
+                elements: [
+                  {
+                    tag: 'button',
+                    name: 'repo_worktree_submit',
+                    text: { tag: 'plain_text', content: t('card.btn.worktree_repo', undefined, locale) },
+                    type: 'default',
+                    action_type: 'form_submit',
+                    value: { action: 'repo_worktree_submit', root_id: rootMessageId ?? '' },
+                  },
+                ],
+              },
+            ],
           },
         ],
       }] : []),

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -9,7 +9,7 @@ import { config } from '../../config.js';
 import { getBot, getAllBots, getOwnerOpenId } from '../../bot-registry.js';
 import { canOperate, canTalk } from './event-dispatcher.js';
 import { updateMessage, deleteMessage, replyMessage, sendMessage, sendUserMessage, sendEphemeralCard, getMessageDetail, isHumanOpenId } from './client.js';
-import { buildSessionCard, buildStreamingCard, buildTuiPromptCard, buildTuiPromptProcessingCard, buildTuiPromptResolvedCard, buildGrantResultCard, buildGrantNotifyCard, getCliDisplayName, truncateContent, buildConfigCard, buildConfigTextCard, CONFIG_UNSET, buildLandResultCard } from './card-builder.js';
+import { buildSessionCard, buildStreamingCard, buildTuiPromptCard, buildTuiPromptProcessingCard, buildTuiPromptResolvedCard, buildGrantResultCard, buildGrantNotifyCard, getCliDisplayName, truncateContent, buildConfigCard, buildConfigTextCard, CONFIG_UNSET, buildLandResultCard, buildRepoSelectCard } from './card-builder.js';
 import { computeSandboxDiff, applySandboxDiff } from '../../services/sandbox-land.js';
 import { findConfigField, applyConfigField, coerceConfigValue, getConfigCardData } from '../../services/bot-config-store.js';
 import { updateBotGrantPrefs } from '../../services/grant-prefs-store.js';
@@ -39,7 +39,7 @@ import { sessionKey, sessionAnchorId, frozenDisplayMode } from '../../core/types
 import type { DaemonSession } from '../../core/types.js';
 import { buildTerminalUrl } from '../../core/terminal-url.js';
 import type { ProjectInfo } from '../../services/project-scanner.js';
-import { createRepoWorktree, dirSuffixForBranch } from '../../services/git-worktree.js';
+import { createRepoWorktree, removeRepoWorktree, dirSuffixForBranch } from '../../services/git-worktree.js';
 import { worktreeSlugFromContextAI } from '../../services/worktree-slug-ai.js';
 import { t, localeForBot, isLocale, type Locale } from '../../i18n/index.js';
 
@@ -864,7 +864,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     return { toast: { type: 'success', content: t('card.relay.toast_success', undefined, loc) } };
   }
 
-  const isSensitive = value?.action && ['restart', 'close', 'resume', 'skip_repo', 'repo_manual_submit', 'repo_worktree_submit', 'retry_last_task', 'get_write_link', 'toggle_stream', 'toggle_display', 'export_text', 'term_action', 'refresh_screenshot', 'takeover', 'disconnect', 'tui_keys', 'tui_text_input', 'wf_approve', 'wf_reject', 'wf_cancel'].includes(value.action);
+  const isSensitive = value?.action && ['restart', 'close', 'resume', 'skip_repo', 'repo_manual_submit', 'repo_worktree_submit', 'worktree_toggle_mode', 'retry_last_task', 'get_write_link', 'toggle_stream', 'toggle_display', 'export_text', 'term_action', 'refresh_screenshot', 'takeover', 'disconnect', 'tui_keys', 'tui_text_input', 'wf_approve', 'wf_reject', 'wf_cancel'].includes(value.action);
   if (isSensitive) {
     const rootId = value?.root_id;
     // activeSessions is keyed by sessionKey(anchor, larkAppId) — `${anchor}::${larkAppId}`
@@ -888,7 +888,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     // pendingRepo 阶段，会话发起人（含 chat-granted 用户）可以 skip_repo / 手动填目录
     // 起会话——与 repo 下拉选择同款例外，否则被授权人连自己的首次会话都启动不了。
     const pendingRepoOwnerException =
-      (value.action === 'skip_repo' || value.action === 'repo_manual_submit' || value.action === 'repo_worktree_submit') && !!ds?.pendingRepo &&
+      (value.action === 'skip_repo' || value.action === 'repo_manual_submit' || value.action === 'repo_worktree_submit' || value.action === 'worktree_toggle_mode') && !!ds?.pendingRepo &&
       !!operatorOpenId && operatorOpenId === ds.session.ownerOpenId;
     if (effectiveAppId) {
       if (!pendingRepoOwnerException && !canOperate(effectiveAppId, chatId, operatorOpenId)) {
@@ -1593,6 +1593,23 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       );
     }
 
+    if (actionType === 'worktree_toggle_mode' && ds) {
+      // Flip the persisted per-bot worktree picker mode (single ⇄ multi), then
+      // re-send a fresh repo card in the new mode — a form can't ride an
+      // in-place patch, so the old card is withdrawn and a new one posted.
+      const locDs = localeForBot(ds.larkAppId);
+      const spec = findConfigField('worktreeMultiPicker');
+      if (!spec) return;
+      const next = getBot(ds.larkAppId).config.worktreeMultiPicker !== true;
+      const r = await applyConfigField(ds.larkAppId, spec, next);
+      if (!r.ok) return { toast: { type: 'error', content: t('cmd.config.write_failed', { reason: r.reason }, locDs) } };
+      const projects = lastRepoScan.get(ds.chatId) ?? [];
+      if (ds.repoCardMessageId && ds.larkAppId) { try { deleteMessage(ds.larkAppId, ds.repoCardMessageId); } catch { /* card already gone */ } }
+      const newCard = buildRepoSelectCard(projects, getSessionWorkingDir(ds), rootId, locDs, next);
+      ds.repoCardMessageId = await sessionReply(rootId, newCard, 'interactive');
+      return { toast: { type: 'info', content: t(next ? 'card.repo.toast_worktree_mode_switched' : 'card.repo.toast_worktree_mode_switched_back', undefined, locDs) } };
+    }
+
     if (actionType === 'repo_worktree_submit' && ds) {
       const locDs = localeForBot(ds.larkAppId);
       const selectedPaths = stringListFromLarkMultiSelect(action?.form_value?.repo_worktree_paths);
@@ -1875,29 +1892,43 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     void (async () => {
       try {
         let creation;
+        // Track each successful (sourceRepo → created worktree) so a later repo's
+        // failure in a multi-repo batch can roll the earlier ones back instead of
+        // leaking orphaned worktree dirs/branches.
+        const created: Array<{ repo: string; result: { path: string; branch: string; baseRef: string } }> = [];
         try {
           const branch = action?.value?.branch?.trim() || undefined;
           const slug = branch ? undefined : await worktreeSlugFromContextAI(targetDs.session.title, targetDs.pendingPrompt);
-          const creations = [];
           for (const repoPath of selectedWorktreePaths) {
-            creations.push(await createRepoWorktree(repoPath, {
+            const result = await createRepoWorktree(repoPath, {
               branch,
               slug,
               worktreePath: selectedWorktreePaths.length > 1 && parentPath
                 ? join(parentPath, worktreeChildNameForRepo(repoPath, cached))
                 : undefined,
-            }));
+            });
+            created.push({ repo: repoPath, result });
           }
           creation = selectedWorktreePaths.length > 1 && parentPath
             ? {
                 path: parentPath,
-                branch: branch ?? creations.map(c => c.branch).join(', '),
-                baseRef: Array.from(new Set(creations.map(c => c.baseRef))).join(', '),
+                branch: branch ?? created.map(c => c.result.branch).join(', '),
+                baseRef: Array.from(new Set(created.map(c => c.result.baseRef))).join(', '),
               }
-            : creations[0]!;
+            : created[0]!.result;
         } catch (e) {
-          logger.warn(`[${tag(targetDs)}] Worktree creation failed for ${selectedPath}: ${e instanceof Error ? e.message : e}`);
-          await sessionReply(rootId, t('cmd.repo.worktree_failed', { error: e instanceof Error ? e.message : String(e) }, locTarget));
+          // The repo that threw is the one right after the last success.
+          const failedRepo = selectedWorktreePaths[created.length] ?? selectedPath;
+          const errMsg = e instanceof Error ? e.message : String(e);
+          logger.warn(`[${tag(targetDs)}] Worktree creation failed for ${failedRepo}: ${errMsg}`);
+          let rolledBack = 0;
+          for (const c of created) {
+            try { await removeRepoWorktree(c.repo, c.result.path); rolledBack++; }
+            catch (re) { logger.warn(`[${tag(targetDs)}] rollback of ${c.result.path} failed: ${re instanceof Error ? re.message : re}`); }
+          }
+          await sessionReply(rootId, rolledBack > 0
+            ? t('card.repo.worktree_rolled_back', { repo: pathBasename(failedRepo), error: errMsg, count: rolledBack }, locTarget)
+            : t('cmd.repo.worktree_failed', { error: errMsg }, locTarget));
           return;
         }
         if (sessionChanged()) return notSwitched(creation, 'mid-flight');

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -57,9 +57,9 @@ interface CardActionData {
   operator?: { open_id?: string };
   action?: {
     value?: Record<string, string>;
-    option?: string | string[];
-    selected_options?: string[];
-    form_value?: Record<string, string>;  // V2 form input values
+    option?: unknown;
+    options?: unknown;
+    form_value?: Record<string, unknown>;  // V2 form input values
   };
   context?: { open_message_id?: string };
   open_message_id?: string;
@@ -147,12 +147,10 @@ function validateCardCliBinding(ds: DaemonSession, value?: Record<string, string
   return false;
 }
 
-function stringListFromFormValue(raw: unknown): string[] {
+function stringListFromLarkMultiSelect(raw: unknown): string[] {
   const tokens = Array.isArray(raw)
-    ? raw.filter((v): v is string => typeof v === 'string')
-    : typeof raw === 'string'
-      ? raw.split(/[,;]/).map(s => s.trim()).filter(Boolean)
-      : [];
+    ? raw.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    : [];
   const seen = new Set<string>();
   const result: string[] = [];
   for (const token of tokens) {
@@ -915,7 +913,8 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
 
   if (isWorkflowApprovalAction(value?.action)) {
     const locWf = localeForBot(larkAppId);
-    const result = await handleWorkflowApprovalAction(data, deps.workflowApprovalDeps, locWf);
+    const workflowData = data as Parameters<typeof handleWorkflowApprovalAction>[0];
+    const result = await handleWorkflowApprovalAction(workflowData, deps.workflowApprovalDeps, locWf);
     const runId = value?.run_id;
     if (result?.ok && !result.duplicate && runId) {
       await deps.workflowApprovalResolved?.(runId);
@@ -1214,7 +1213,8 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     }
 
     if (actionType === 'tui_text_input' && ds) {
-      const inputText = action?.form_value?.tui_custom_input ?? '';
+      const inputTextRaw = action?.form_value?.tui_custom_input;
+      const inputText = typeof inputTextRaw === 'string' ? inputTextRaw : '';
       let inputKeys: string[] = [];
       try { inputKeys = JSON.parse(value?.input_keys ?? '[]'); } catch { /* bad json */ }
       const locDs = localeForBot(ds.larkAppId);
@@ -1595,14 +1595,13 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
 
     if (actionType === 'repo_worktree_submit' && ds) {
       const locDs = localeForBot(ds.larkAppId);
-      const selectedPaths = ds.pendingWorktreePaths ?? stringListFromFormValue(action?.form_value?.repo_worktree_paths);
+      const selectedPaths = stringListFromLarkMultiSelect(action?.form_value?.repo_worktree_paths);
       if (selectedPaths.length === 0) {
         return { toast: { type: 'error', content: t('card.repo.worktree_empty', undefined, locDs) } };
       }
       if (ds.worktreeCreating) {
         return { toast: { type: 'info', content: t('cmd.repo.worktree_in_progress', undefined, locDs) } };
       }
-      ds.pendingWorktreePaths = selectedPaths;
       const branch = String(action?.form_value?.repo_worktree_branch ?? '').trim() || undefined;
       const multiParent = selectedPaths.length > 1
         ? multiWorktreeParentPath(selectedPaths, branch ?? await worktreeSlugFromContextAI(ds.session.title, ds.pendingPrompt) ?? 'worktree')
@@ -1617,7 +1616,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       void handleCardAction({
         ...data,
         action: {
-          value: { key: 'repo_worktree', root_id: rootIdForAction, ...(branch ? { branch } : {}), ...(multiParent ? { parent_path: multiParent } : {}) },
+          value: { key: 'repo_worktree', root_id: rootIdForAction, repo_worktree_paths_json: JSON.stringify(selectedPaths), ...(branch ? { branch } : {}), ...(multiParent ? { parent_path: multiParent } : {}) },
           option: selectedPaths[0],
         },
       }, deps, larkAppId);
@@ -1628,28 +1627,16 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
 
   // Handle dropdown selections (option-based)
   const option = action?.option;
-  if (action?.value?.key === 'repo_worktree_select') {
-    const rootId = action?.value?.root_id;
-    if (!rootId) return;
-    const targetDs = larkAppId ? activeSessions.get(sessionKey(rootId, larkAppId)) : undefined;
-    if (!targetDs) return;
-    const isSessionOwnerOp = !!operatorOpenId && operatorOpenId === targetDs.session.ownerOpenId;
-    const allowRepo = targetDs.pendingRepo
-      ? (isSessionOwnerOp || canOperate(targetDs.larkAppId, targetDs.chatId, operatorOpenId))
-      : canOperate(targetDs.larkAppId, targetDs.chatId, operatorOpenId);
-    if (!allowRepo) {
-      logger.info(`Repo worktree multi-select blocked for ${operatorOpenId} (pending=${targetDs.pendingRepo})`);
-      return { toast: { type: 'error', content: t('card.grant.toast_no_repo_perm', undefined, localeForBot(targetDs.larkAppId)) } };
-    }
-    targetDs.pendingWorktreePaths = stringListFromFormValue(action?.selected_options ?? option);
-    return;
-  }
   if (!option) {
     logger.warn('Card action received but no option or action value');
     return;
   }
   if (Array.isArray(option)) {
     logger.warn('Card action received multi options for a single-select handler');
+    return;
+  }
+  if (typeof option !== 'string') {
+    logger.warn('Card action received non-string option for a single-select handler');
     return;
   }
 
@@ -1828,9 +1815,17 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
   const cached = lastRepoScan.get(targetDs.chatId);
   const project = cached?.find(p => p.path === selectedPath);
   const displayName = project ? `${project.name} (${project.branch})` : selectedPath;
-  const selectedWorktreePaths = isWorktreeOpen
-    ? (targetDs.pendingWorktreePaths?.length ? targetDs.pendingWorktreePaths : [selectedPath])
-    : [selectedPath];
+  let selectedWorktreePaths = [selectedPath];
+  if (isWorktreeOpen && typeof action?.value?.repo_worktree_paths_json === 'string') {
+    try {
+      selectedWorktreePaths = stringListFromLarkMultiSelect(JSON.parse(action.value.repo_worktree_paths_json));
+    } catch {
+      selectedWorktreePaths = [];
+    }
+    if (selectedWorktreePaths.length === 0) {
+      return { toast: { type: 'error', content: t('card.repo.worktree_empty', undefined, localeForBot(targetDs.larkAppId)) } };
+    }
+  }
 
   const locTarget = localeForBot(targetDs.larkAppId);
 
@@ -1926,7 +1921,6 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
         }
       } finally {
         targetDs.worktreeCreating = false;
-        targetDs.pendingWorktreePaths = undefined;
       }
     })();
     return { toast: { type: 'info', content: t('card.repo.toast_worktree_creating', undefined, locTarget) } };

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -4,7 +4,7 @@
  * Extracted from daemon.ts for modularity.
  */
 import { execSync } from 'node:child_process';
-import { basename as pathBasename } from 'node:path';
+import { basename as pathBasename, dirname, join } from 'node:path';
 import { config } from '../../config.js';
 import { getBot, getAllBots, getOwnerOpenId } from '../../bot-registry.js';
 import { canOperate, canTalk } from './event-dispatcher.js';
@@ -39,7 +39,7 @@ import { sessionKey, sessionAnchorId, frozenDisplayMode } from '../../core/types
 import type { DaemonSession } from '../../core/types.js';
 import { buildTerminalUrl } from '../../core/terminal-url.js';
 import type { ProjectInfo } from '../../services/project-scanner.js';
-import { createRepoWorktree } from '../../services/git-worktree.js';
+import { createRepoWorktree, dirSuffixForBranch } from '../../services/git-worktree.js';
 import { worktreeSlugFromContextAI } from '../../services/worktree-slug-ai.js';
 import { t, localeForBot, isLocale, type Locale } from '../../i18n/index.js';
 
@@ -57,7 +57,8 @@ interface CardActionData {
   operator?: { open_id?: string };
   action?: {
     value?: Record<string, string>;
-    option?: string;
+    option?: string | string[];
+    selected_options?: string[];
     form_value?: Record<string, string>;  // V2 form input values
   };
   context?: { open_message_id?: string };
@@ -144,6 +145,43 @@ function validateCardCliBinding(ds: DaemonSession, value?: Record<string, string
     `action=${value?.action ?? '?'} expected=${expected} actual=${actual}`,
   );
   return false;
+}
+
+function stringListFromFormValue(raw: unknown): string[] {
+  const tokens = Array.isArray(raw)
+    ? raw.filter((v): v is string => typeof v === 'string')
+    : typeof raw === 'string'
+      ? raw.split(/[,;]/).map(s => s.trim()).filter(Boolean)
+      : [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const token of tokens) {
+    if (seen.has(token)) continue;
+    seen.add(token);
+    result.push(token);
+  }
+  return result;
+}
+
+function multiWorktreeParentPath(repoPaths: string[], name: string): string {
+  const first = repoPaths[0];
+  const parentRoot = first ? dirname(first) : process.cwd();
+  return join(parentRoot, dirSuffixForBranch(name));
+}
+
+function worktreeChildNameForRepo(repoPath: string, projects: ProjectInfo[] | undefined): string {
+  return projects?.find(p => p.path === repoPath)?.name ?? pathBasename(repoPath);
+}
+
+function duplicateMultiWorktreeChildNames(repoPaths: string[], projects: ProjectInfo[] | undefined): string[] {
+  const seen = new Set<string>();
+  const dupes = new Set<string>();
+  for (const repoPath of repoPaths) {
+    const childName = worktreeChildNameForRepo(repoPath, projects);
+    if (seen.has(childName)) dupes.add(childName);
+    else seen.add(childName);
+  }
+  return [...dupes];
 }
 
 /**
@@ -828,7 +866,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     return { toast: { type: 'success', content: t('card.relay.toast_success', undefined, loc) } };
   }
 
-  const isSensitive = value?.action && ['restart', 'close', 'resume', 'skip_repo', 'repo_manual_submit', 'retry_last_task', 'get_write_link', 'toggle_stream', 'toggle_display', 'export_text', 'term_action', 'refresh_screenshot', 'takeover', 'disconnect', 'tui_keys', 'tui_text_input', 'wf_approve', 'wf_reject', 'wf_cancel'].includes(value.action);
+  const isSensitive = value?.action && ['restart', 'close', 'resume', 'skip_repo', 'repo_manual_submit', 'repo_worktree_submit', 'retry_last_task', 'get_write_link', 'toggle_stream', 'toggle_display', 'export_text', 'term_action', 'refresh_screenshot', 'takeover', 'disconnect', 'tui_keys', 'tui_text_input', 'wf_approve', 'wf_reject', 'wf_cancel'].includes(value.action);
   if (isSensitive) {
     const rootId = value?.root_id;
     // activeSessions is keyed by sessionKey(anchor, larkAppId) — `${anchor}::${larkAppId}`
@@ -852,7 +890,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     // pendingRepo 阶段，会话发起人（含 chat-granted 用户）可以 skip_repo / 手动填目录
     // 起会话——与 repo 下拉选择同款例外，否则被授权人连自己的首次会话都启动不了。
     const pendingRepoOwnerException =
-      (value.action === 'skip_repo' || value.action === 'repo_manual_submit') && !!ds?.pendingRepo &&
+      (value.action === 'skip_repo' || value.action === 'repo_manual_submit' || value.action === 'repo_worktree_submit') && !!ds?.pendingRepo &&
       !!operatorOpenId && operatorOpenId === ds.session.ownerOpenId;
     if (effectiveAppId) {
       if (!pendingRepoOwnerException && !canOperate(effectiveAppId, chatId, operatorOpenId)) {
@@ -1554,13 +1592,64 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
         displayName,
       );
     }
+
+    if (actionType === 'repo_worktree_submit' && ds) {
+      const locDs = localeForBot(ds.larkAppId);
+      const selectedPaths = ds.pendingWorktreePaths ?? stringListFromFormValue(action?.form_value?.repo_worktree_paths);
+      if (selectedPaths.length === 0) {
+        return { toast: { type: 'error', content: t('card.repo.worktree_empty', undefined, locDs) } };
+      }
+      if (ds.worktreeCreating) {
+        return { toast: { type: 'info', content: t('cmd.repo.worktree_in_progress', undefined, locDs) } };
+      }
+      ds.pendingWorktreePaths = selectedPaths;
+      const branch = String(action?.form_value?.repo_worktree_branch ?? '').trim() || undefined;
+      const multiParent = selectedPaths.length > 1
+        ? multiWorktreeParentPath(selectedPaths, branch ?? await worktreeSlugFromContextAI(ds.session.title, ds.pendingPrompt) ?? 'worktree')
+        : undefined;
+      if (multiParent) {
+        const duplicateNames = duplicateMultiWorktreeChildNames(selectedPaths, lastRepoScan.get(ds.chatId));
+        if (duplicateNames.length > 0) {
+          return { toast: { type: 'error', content: t('card.repo.worktree_child_conflict', { names: duplicateNames.join(', ') }, locDs) } };
+        }
+      }
+      const rootIdForAction = rootId;
+      void handleCardAction({
+        ...data,
+        action: {
+          value: { key: 'repo_worktree', root_id: rootIdForAction, ...(branch ? { branch } : {}), ...(multiParent ? { parent_path: multiParent } : {}) },
+          option: selectedPaths[0],
+        },
+      }, deps, larkAppId);
+      return { toast: { type: 'info', content: t('card.repo.toast_worktree_creating', undefined, locDs) } };
+    }
     return;
   }
 
   // Handle dropdown selections (option-based)
   const option = action?.option;
+  if (action?.value?.key === 'repo_worktree_select') {
+    const rootId = action?.value?.root_id;
+    if (!rootId) return;
+    const targetDs = larkAppId ? activeSessions.get(sessionKey(rootId, larkAppId)) : undefined;
+    if (!targetDs) return;
+    const isSessionOwnerOp = !!operatorOpenId && operatorOpenId === targetDs.session.ownerOpenId;
+    const allowRepo = targetDs.pendingRepo
+      ? (isSessionOwnerOp || canOperate(targetDs.larkAppId, targetDs.chatId, operatorOpenId))
+      : canOperate(targetDs.larkAppId, targetDs.chatId, operatorOpenId);
+    if (!allowRepo) {
+      logger.info(`Repo worktree multi-select blocked for ${operatorOpenId} (pending=${targetDs.pendingRepo})`);
+      return { toast: { type: 'error', content: t('card.grant.toast_no_repo_perm', undefined, localeForBot(targetDs.larkAppId)) } };
+    }
+    targetDs.pendingWorktreePaths = stringListFromFormValue(action?.selected_options ?? option);
+    return;
+  }
   if (!option) {
     logger.warn('Card action received but no option or action value');
+    return;
+  }
+  if (Array.isArray(option)) {
+    logger.warn('Card action received multi options for a single-select handler');
     return;
   }
 
@@ -1739,6 +1828,9 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
   const cached = lastRepoScan.get(targetDs.chatId);
   const project = cached?.find(p => p.path === selectedPath);
   const displayName = project ? `${project.name} (${project.branch})` : selectedPath;
+  const selectedWorktreePaths = isWorktreeOpen
+    ? (targetDs.pendingWorktreePaths?.length ? targetDs.pendingWorktreePaths : [selectedPath])
+    : [selectedPath];
 
   const locTarget = localeForBot(targetDs.larkAppId);
 
@@ -1764,6 +1856,13 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       // would yank the session the winner just spawned.
       return { toast: { type: 'info', content: t('cmd.repo.worktree_in_progress', undefined, locTarget) } };
     }
+    const parentPath = action?.value?.parent_path;
+    if (selectedWorktreePaths.length > 1 && parentPath) {
+      const duplicateNames = duplicateMultiWorktreeChildNames(selectedWorktreePaths, cached);
+      if (duplicateNames.length > 0) {
+        return { toast: { type: 'error', content: t('card.repo.worktree_child_conflict', { names: duplicateNames.join(', ') }, locTarget) } };
+      }
+    }
     targetDs.worktreeCreating = true;
     // Session generation snapshot: if another selection lands while git runs
     // (pendingRepo consumed, or the session swapped), committing this worktree
@@ -1782,8 +1881,25 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       try {
         let creation;
         try {
-          const slug = await worktreeSlugFromContextAI(targetDs.session.title, targetDs.pendingPrompt);
-          creation = await createRepoWorktree(selectedPath, { slug });
+          const branch = action?.value?.branch?.trim() || undefined;
+          const slug = branch ? undefined : await worktreeSlugFromContextAI(targetDs.session.title, targetDs.pendingPrompt);
+          const creations = [];
+          for (const repoPath of selectedWorktreePaths) {
+            creations.push(await createRepoWorktree(repoPath, {
+              branch,
+              slug,
+              worktreePath: selectedWorktreePaths.length > 1 && parentPath
+                ? join(parentPath, worktreeChildNameForRepo(repoPath, cached))
+                : undefined,
+            }));
+          }
+          creation = selectedWorktreePaths.length > 1 && parentPath
+            ? {
+                path: parentPath,
+                branch: branch ?? creations.map(c => c.branch).join(', '),
+                baseRef: Array.from(new Set(creations.map(c => c.baseRef))).join(', '),
+              }
+            : creations[0]!;
         } catch (e) {
           logger.warn(`[${tag(targetDs)}] Worktree creation failed for ${selectedPath}: ${e instanceof Error ? e.message : e}`);
           await sessionReply(rootId, t('cmd.repo.worktree_failed', { error: e instanceof Error ? e.message : String(e) }, locTarget));
@@ -1810,6 +1926,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
         }
       } finally {
         targetDs.worktreeCreating = false;
+        targetDs.pendingWorktreePaths = undefined;
       }
     })();
     return { toast: { type: 'info', content: t('card.repo.toast_worktree_creating', undefined, locTarget) } };

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -887,8 +887,11 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     const chatId = ds?.chatId ?? closedForCtx?.chatId;
     // pendingRepo 阶段，会话发起人（含 chat-granted 用户）可以 skip_repo / 手动填目录
     // 起会话——与 repo 下拉选择同款例外，否则被授权人连自己的首次会话都启动不了。
+    // 注意：worktree_toggle_mode 故意不在此列——它持久写 bot 级 worktreeMultiPicker
+    // （影响该 bot 所有后续会话），属管理动作，必须走 canOperate，不能让 talk-only/
+    // chat-granted 用户借「开自己的 pending 卡」绕过去改 bot 配置。
     const pendingRepoOwnerException =
-      (value.action === 'skip_repo' || value.action === 'repo_manual_submit' || value.action === 'repo_worktree_submit' || value.action === 'worktree_toggle_mode') && !!ds?.pendingRepo &&
+      (value.action === 'skip_repo' || value.action === 'repo_manual_submit' || value.action === 'repo_worktree_submit') && !!ds?.pendingRepo &&
       !!operatorOpenId && operatorOpenId === ds.session.ownerOpenId;
     if (effectiveAppId) {
       if (!pendingRepoOwnerException && !canOperate(effectiveAppId, chatId, operatorOpenId)) {
@@ -1604,7 +1607,9 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       const r = await applyConfigField(ds.larkAppId, spec, next);
       if (!r.ok) return { toast: { type: 'error', content: t('cmd.config.write_failed', { reason: r.reason }, locDs) } };
       const projects = lastRepoScan.get(ds.chatId) ?? [];
-      if (ds.repoCardMessageId && ds.larkAppId) { try { deleteMessage(ds.larkAppId, ds.repoCardMessageId); } catch { /* card already gone */ } }
+      // await so a rejected delete is caught here (not an unhandled rejection);
+      // a missing/already-gone card is fine — we post the fresh one regardless.
+      if (ds.repoCardMessageId && ds.larkAppId) { try { await deleteMessage(ds.larkAppId, ds.repoCardMessageId); } catch { /* card already gone */ } }
       const newCard = buildRepoSelectCard(projects, getSessionWorkingDir(ds), rootId, locDs, next);
       ds.repoCardMessageId = await sessionReply(rootId, newCard, 'interactive');
       return { toast: { type: 'info', content: t(next ? 'card.repo.toast_worktree_mode_switched' : 'card.repo.toast_worktree_mode_switched_back', undefined, locDs) } };

--- a/src/services/bot-config-store.ts
+++ b/src/services/bot-config-store.ts
@@ -69,6 +69,7 @@ export const CONFIG_FIELDS: readonly ConfigFieldSpec[] = [
   { key: 'privateCard', configKey: 'privateCard', kind: 'boolean', effect: 'immediate', clearable: false, hint: '/card 发 owner-only 私有快照 on|off' },
   { key: 'autoStartOnGroupJoin', configKey: 'autoStartOnGroupJoin', kind: 'boolean', effect: 'immediate', clearable: false, hint: '被拉进新群即主动开工 on|off' },
   { key: 'autoStartOnNewTopic', configKey: 'autoStartOnNewTopic', kind: 'boolean', effect: 'immediate', clearable: false, hint: '话题群每个新话题自动开工 on|off' },
+  { key: 'worktreeMultiPicker', configKey: 'worktreeMultiPicker', kind: 'boolean', effect: 'immediate', clearable: false, hint: 'repo 卡片 worktree 选择器默认多仓库模式 on|off（卡片「切换多仓库选择器」按钮同款）' },
   { key: 'disableCliBypass', configKey: 'disableCliBypass', kind: 'boolean', effect: 'next-session', clearable: false, hint: '不加 CLI 审批/sandbox 绕过参数 on|off' },
   { key: 'restrictGrantCommands', configKey: 'restrictGrantCommands', kind: 'boolean', effect: 'immediate', clearable: false, hint: '被授权人仅能纯对话、拦截斜杠命令 on|off' },
   { key: 'p2pMode', configKey: 'p2pMode', kind: 'enum', effect: 'immediate', clearable: true, enumValues: ['thread', 'chat'], hint: '私聊单聊模式 thread|chat；chat=扁平连续会话，thread/unset 回默认（每条 DM 独立会话）' },

--- a/src/services/git-worktree.ts
+++ b/src/services/git-worktree.ts
@@ -234,3 +234,13 @@ export async function createRepoWorktree(
   logger.info(`[git-worktree] created ${wtPath} (branch ${branch} from ${baseRef})`);
   return { path: wtPath, branch, baseRef };
 }
+
+/** Remove a worktree created by {@link createRepoWorktree}. Used to roll back the
+ *  worktrees already built when a later repo in a multi-repo batch fails — leaves
+ *  the branch in place (it may be a pre-existing branch we only checked out, and a
+ *  dangling auto-named branch is harmless) and only detaches/deletes the worktree
+ *  dir so a retry doesn't trip over "worktree target already exists". */
+export async function removeRepoWorktree(repo: string, worktreePath: string): Promise<void> {
+  await git(['worktree', 'remove', '--force', worktreePath], repo, 30_000);
+  logger.info(`[git-worktree] removed worktree ${worktreePath}`);
+}

--- a/src/services/git-worktree.ts
+++ b/src/services/git-worktree.ts
@@ -9,7 +9,7 @@
  */
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 import { basename, dirname, join, resolve } from 'node:path';
 import { logger } from '../utils/logger.js';
 
@@ -30,6 +30,8 @@ export interface CreateRepoWorktreeOptions {
   branch?: string;
   /** Semantic auto-name seed; creates `wt/<slug>` and dir `<repo>-wt-<slug>`. */
   slug?: string;
+  /** Explicit target directory. Used by multi-repo worktree groups. */
+  worktreePath?: string;
 }
 
 async function git(args: string[], cwd: string, timeoutMs = 10_000): Promise<string> {
@@ -71,7 +73,7 @@ async function resolveBaseRef(repo: string): Promise<string> {
 }
 
 /** Branch names may contain `/` etc. — flatten to a filesystem-safe suffix. */
-function dirSuffixForBranch(branch: string): string {
+export function dirSuffixForBranch(branch: string): string {
   return branch.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'branch';
 }
 
@@ -144,37 +146,66 @@ export async function createRepoWorktree(
 
   let branch = opts.branch?.trim() ?? '';
   let wtPath: string;
+  const explicitPath = opts.worktreePath ? resolve(opts.worktreePath) : undefined;
   // Sanitize the auto-name seed up front: a slug with no latin/digit tokens
   // (e.g. all-CJK) collapses to nothing → fall through to the `wt/N` path
   // rather than throwing or emitting an opaque hash.
   const slug = branch ? undefined : slugFromWorktreeText(opts.slug);
   if (branch) {
-    wtPath = join(parent, `${repoBase}-${dirSuffixForBranch(branch)}`);
+    wtPath = explicitPath ?? join(parent, `${repoBase}-${dirSuffixForBranch(branch)}`);
     if (existsSync(wtPath)) throw new Error(`worktree target already exists: ${wtPath}`);
   } else if (slug) {
-    for (let n = 1;; n++) {
-      if (n > 1000) throw new Error(`no free wt/${slug} slot under 1000`);
-      const candidateSlug = n === 1 ? slug : `${slug}-${n}`;
-      const candidateBranch = `wt/${candidateSlug}`;
-      const candPath = join(parent, `${repoBase}-${dirSuffixForBranch(candidateBranch)}`);
-      if (existsSync(candPath) ||
-        (await localBranchExists(repo, candidateBranch)) ||
-        (await remoteBranchExists(repo, candidateBranch))) continue;
-      branch = candidateBranch;
-      wtPath = candPath;
-      break;
+    if (explicitPath) {
+      for (let n = 1;; n++) {
+        if (n > 1000) throw new Error(`no free wt/${slug} slot under 1000`);
+        const candidateSlug = n === 1 ? slug : `${slug}-${n}`;
+        const candidateBranch = `wt/${candidateSlug}`;
+        if ((await localBranchExists(repo, candidateBranch)) ||
+          (await remoteBranchExists(repo, candidateBranch))) continue;
+        branch = candidateBranch;
+        wtPath = explicitPath;
+        break;
+      }
+      if (existsSync(wtPath)) throw new Error(`worktree target already exists: ${wtPath}`);
+    } else {
+      for (let n = 1;; n++) {
+        if (n > 1000) throw new Error(`no free wt/${slug} slot under 1000`);
+        const candidateSlug = n === 1 ? slug : `${slug}-${n}`;
+        const candidateBranch = `wt/${candidateSlug}`;
+        const candPath = join(parent, `${repoBase}-${dirSuffixForBranch(candidateBranch)}`);
+        if (existsSync(candPath) ||
+          (await localBranchExists(repo, candidateBranch)) ||
+          (await remoteBranchExists(repo, candidateBranch))) continue;
+        branch = candidateBranch;
+        wtPath = candPath;
+        break;
+      }
     }
   } else {
-    let n = 1;
-    for (;; n++) {
-      if (n > 1000) throw new Error('no free wt/N slot under 1000');
-      const candPath = join(parent, `${repoBase}-wt-${n}`);
-      if (existsSync(candPath) || (await localBranchExists(repo, `wt/${n}`))) continue;
-      branch = `wt/${n}`;
-      wtPath = candPath;
-      break;
+    if (explicitPath) {
+      let n = 1;
+      for (;; n++) {
+        if (n > 1000) throw new Error('no free wt/N slot under 1000');
+        if (await localBranchExists(repo, `wt/${n}`)) continue;
+        branch = `wt/${n}`;
+        wtPath = explicitPath;
+        break;
+      }
+      if (existsSync(wtPath)) throw new Error(`worktree target already exists: ${wtPath}`);
+    } else {
+      let n = 1;
+      for (;; n++) {
+        if (n > 1000) throw new Error('no free wt/N slot under 1000');
+        const candPath = join(parent, `${repoBase}-wt-${n}`);
+        if (existsSync(candPath) || (await localBranchExists(repo, `wt/${n}`))) continue;
+        branch = `wt/${n}`;
+        wtPath = candPath;
+        break;
+      }
     }
   }
+
+  mkdirSync(dirname(wtPath), { recursive: true });
 
   if (await localBranchExists(repo, branch)) {
     // Existing branch: check it out as-is (git rejects it if the branch is

--- a/src/services/worktree-slug-ai.ts
+++ b/src/services/worktree-slug-ai.ts
@@ -30,7 +30,7 @@ function sanitizeModelSlug(raw: string | undefined): string | undefined {
 
 function aiSlugConfigured(): boolean {
   const c = config.worktreeSlugAI;
-  return !!(c.enabled && c.baseUrl && c.apiKey && c.model);
+  return !!(c?.enabled && c.baseUrl && c.apiKey && c.model);
 }
 
 export function localWorktreeSlugFromContext(title?: string, firstPrompt?: string): string | undefined {
@@ -45,6 +45,7 @@ export async function worktreeSlugFromContextAI(title?: string, firstPrompt?: st
   if (!text) return fallback;
 
   const c = config.worktreeSlugAI;
+  if (!c) return fallback;
   try {
     const url = `${c.baseUrl.replace(/\/+$/, '')}/chat/completions`;
     const resp = await fetch(url, {

--- a/test/card-builder.test.ts
+++ b/test/card-builder.test.ts
@@ -747,15 +747,58 @@ describe('buildRepoSelectCard', () => {
   // ── Element structure ─────────────────────────────────────────────────
 
   describe('element structure', () => {
-    it('should have 6 top-level elements: dir+skip, switch, worktree form, manual form, note', () => {
+    it('single mode (default): 6 elements — dir+skip, switch, worktree row, manual form, note', () => {
       const card = parse(buildRepoSelectCard(projects));
       expect(card.elements).toHaveLength(6);
       expect(card.elements[0].tag).toBe('column_set'); // 当前工作目录 + 直接开启会话
       expect(card.elements[1].tag).toBe('hr');
       expect(card.elements[2].tag).toBe('action');     // 选择仓库并切换 dropdown
-      expect(card.elements[3].tag).toBe('form');       // worktree multi-select + branch + submit
+      expect(card.elements[3].tag).toBe('column_set'); // worktree dropdown + 🔀 多仓库 toggle (one row)
       expect(card.elements[4].tag).toBe('form');       // manual entry
       expect(card.elements[5].tag).toBe('note');
+    });
+
+    it('single mode: worktree dropdown weight-fills + toggle button auto-right in ONE column_set (mirrors manual row, no wrap)', () => {
+      const card = parse(buildRepoSelectCard(projects, undefined, 'om_root'));
+      const row = card.elements[3];
+      expect(row.tag).toBe('column_set');
+      expect(row.flex_mode).toBe('none');                       // forces one line on mobile too
+      expect(row.columns[0].width).toBe('weighted');            // dropdown fills, like the manual input
+      const sel = row.columns[0].elements[0];
+      expect(sel.tag).toBe('select_static');
+      expect(sel.value.key).toBe('repo_worktree');
+      const btnCol = row.columns[row.columns.length - 1];
+      expect(btnCol.width).toBe('auto');                        // button hugs the right edge, aligns with 使用此目录
+      const toggle = btnCol.elements[0];
+      expect(toggle.tag).toBe('button');
+      expect(toggle.value.action).toBe('worktree_toggle_mode');
+      expect(toggle.value.root_id).toBe('om_root');
+    });
+
+    it('multi mode: worktree row becomes the inline multi-select form + a 🔀 单仓库 toggle row', () => {
+      const card = parse(buildRepoSelectCard(projects, undefined, 'om_root', undefined, true));
+      const form = card.elements.find((e: any) => e.tag === 'form' && e.name === 'repo_worktree_submit_form');
+      expect(form).toBeDefined();
+      const sel = deepFind({ elements: [form] }, 'multi_select_static').find((s: any) => s.name === 'repo_worktree_paths');
+      expect(sel?.required).toBe(true);
+      const branch = deepFind({ elements: [form] }, 'input').find((i: any) => i.name === 'repo_worktree_branch');
+      expect(branch).toBeDefined();
+      const submit = deepFind({ elements: [form] }, 'button').find((b: any) => b.name === 'repo_worktree_submit');
+      expect(submit.value.action).toBe('repo_worktree_submit');
+      // No single-select dropdown in multi mode
+      expect(deepFind(card, 'select_static').find((s: any) => s.value?.key === 'repo_worktree')).toBeUndefined();
+      // a right-aligned toggle row to switch back to single
+      const toggleBtn = deepFind(card, 'button').find((b: any) => b.value?.action === 'worktree_toggle_mode');
+      expect(toggleBtn).toBeDefined();
+    });
+
+    it('mode toggle is omitted with only one main repo (batching one repo is pointless)', () => {
+      const single: ProjectInfo[] = [
+        { name: 'alpha', path: '/home/user/alpha', type: 'repo', branch: 'main' },
+        { name: 'beta', path: '/home/user/beta', type: 'worktree', branch: 'feat-x' },
+      ];
+      const card = parse(buildRepoSelectCard(single));
+      expect(deepFind(card, 'button').find((b: any) => b.value?.action === 'worktree_toggle_mode')).toBeUndefined();
     });
 
     it('manual-entry form carries an input + form_submit button (same row via column_set)', () => {
@@ -784,44 +827,33 @@ describe('buildRepoSelectCard', () => {
 
   // ── Worktree-open dropdown ─────────────────────────────────────────────
 
-  describe('worktree-open dropdown', () => {
+  describe('worktree-open dropdown (single mode)', () => {
+    // Single mode (default): the worktree control is an INSTANT single-select
+    // (pick a repo → fires immediately, no submit). Multi mode is reached via the
+    // persisted 「切换多仓库选择器」toggle (covered above).
     function worktreeSelect(card: any): any {
-      return deepFind(card, 'multi_select_static').find((sel: any) => sel.name === 'repo_worktree_paths');
+      return deepFind(card, 'select_static').find((sel: any) => sel.value?.key === 'repo_worktree');
     }
 
     it('should list only main repos (no existing worktrees)', () => {
       const card = parse(buildRepoSelectCard(projects));
       const sel = worktreeSelect(card);
-      expect(sel.tag).toBe('multi_select_static');
-      expect(sel.required).toBe(true);
-      expect(sel.width).toBe('fill');
-      expect(sel.options).toHaveLength(2);
+      expect(sel.tag).toBe('select_static');
+      expect(sel.value.key).toBe('repo_worktree');
       const labels = sel.options.map((o: any) => o.text.content);
+      expect(labels).toHaveLength(2);
       expect(labels.join()).toContain('alpha');
       expect(labels.join()).toContain('gamma');
       expect(labels.join()).not.toContain('beta');
     });
 
-    it('should carry the repo path as the option value and root_id on the form submit button', () => {
+    it('fires instantly: carries the repo path as the option value and root_id (no submit button)', () => {
       const card = parse(buildRepoSelectCard(projects, undefined, 'om_root'));
       const sel = worktreeSelect(card);
       expect(sel.options[0].value).toBe('/home/user/alpha');
-      const form = card.elements.find((e: any) => e.tag === 'form' && e.name === 'repo_worktree_submit_form');
-      const btn = deepFind({ elements: [form] }, 'button').find((b: any) => b.name === 'repo_worktree_submit');
-      expect(btn.value.root_id).toBe('om_root');
-    });
-
-    it('renders a branch input and submit button for selected worktree repos', () => {
-      const card = parse(buildRepoSelectCard(projects, undefined, 'om_root'));
-      const form = card.elements.find((e: any) => e.tag === 'form' && e.name === 'repo_worktree_submit_form');
-      expect(form).toBeDefined();
-      const input = deepFind({ elements: [form] }, 'input').find((i: any) => i.name === 'repo_worktree_branch');
-      expect(input).toBeDefined();
-      const btn = deepFind({ elements: [form] }, 'button').find((b: any) => b.name === 'repo_worktree_submit');
-      expect(btn.text.content).toBe('创建 worktree');
-      expect(btn.action_type).toBe('form_submit');
-      expect(btn.value.action).toBe('repo_worktree_submit');
-      expect(btn.value.root_id).toBe('om_root');
+      expect(sel.value.root_id).toBe('om_root');
+      // No worktree form / submit button in single mode.
+      expect(card.elements.find((e: any) => e.tag === 'form' && e.name === 'repo_worktree_submit_form')).toBeUndefined();
     });
 
     it('should be omitted when no main repos exist', () => {

--- a/test/card-builder.test.ts
+++ b/test/card-builder.test.ts
@@ -747,15 +747,16 @@ describe('buildRepoSelectCard', () => {
   // ── Element structure ─────────────────────────────────────────────────
 
   describe('element structure', () => {
-    it('should have 6 top-level elements: dir+skip column_set, hr, switch action, worktree action, manual form, note', () => {
+    it('should have 7 top-level elements: dir+skip, switch, worktree multi-select, worktree submit, manual form, note', () => {
       const card = parse(buildRepoSelectCard(projects));
-      expect(card.elements).toHaveLength(6);
+      expect(card.elements).toHaveLength(7);
       expect(card.elements[0].tag).toBe('column_set'); // 当前工作目录 + 直接开启会话
       expect(card.elements[1].tag).toBe('hr');
       expect(card.elements[2].tag).toBe('action');     // 选择仓库并切换 dropdown
-      expect(card.elements[3].tag).toBe('action');     // worktree dropdown
-      expect(card.elements[4].tag).toBe('form');       // manual entry
-      expect(card.elements[5].tag).toBe('note');
+      expect(card.elements[3].tag).toBe('action');     // worktree multi-select
+      expect(card.elements[4].tag).toBe('form');       // worktree branch + submit
+      expect(card.elements[5].tag).toBe('form');       // manual entry
+      expect(card.elements[6].tag).toBe('note');
     });
 
     it('manual-entry form carries an input + form_submit button (same row via column_set)', () => {
@@ -788,7 +789,7 @@ describe('buildRepoSelectCard', () => {
     function worktreeSelect(card: any): any {
       const actionEls = card.elements.filter((e: any) => e.tag === 'action');
       for (const el of actionEls) {
-        const sel = el.actions.find((a: any) => a.value?.key === 'repo_worktree');
+        const sel = el.actions.find((a: any) => a.value?.key === 'repo_worktree_select');
         if (sel) return sel;
       }
       return undefined;
@@ -797,6 +798,7 @@ describe('buildRepoSelectCard', () => {
     it('should list only main repos (no existing worktrees)', () => {
       const card = parse(buildRepoSelectCard(projects));
       const sel = worktreeSelect(card);
+      expect(sel.tag).toBe('multi_select_static');
       expect(sel.options).toHaveLength(2);
       const labels = sel.options.map((o: any) => o.text.content);
       expect(labels.join()).toContain('alpha');
@@ -809,6 +811,18 @@ describe('buildRepoSelectCard', () => {
       const sel = worktreeSelect(card);
       expect(sel.options[0].value).toBe('/home/user/alpha');
       expect(sel.value.root_id).toBe('om_root');
+    });
+
+    it('renders a branch input and submit button for selected worktree repos', () => {
+      const card = parse(buildRepoSelectCard(projects, undefined, 'om_root'));
+      const form = card.elements.find((e: any) => e.tag === 'form' && e.name === 'repo_worktree_submit_form');
+      expect(form).toBeDefined();
+      const input = deepFind({ elements: [form] }, 'input').find((i: any) => i.name === 'repo_worktree_branch');
+      expect(input).toBeDefined();
+      const btn = deepFind({ elements: [form] }, 'button').find((b: any) => b.name === 'repo_worktree_submit');
+      expect(btn.action_type).toBe('form_submit');
+      expect(btn.value.action).toBe('repo_worktree_submit');
+      expect(btn.value.root_id).toBe('om_root');
     });
 
     it('should be omitted when no main repos exist', () => {

--- a/test/card-builder.test.ts
+++ b/test/card-builder.test.ts
@@ -747,16 +747,15 @@ describe('buildRepoSelectCard', () => {
   // ── Element structure ─────────────────────────────────────────────────
 
   describe('element structure', () => {
-    it('should have 7 top-level elements: dir+skip, switch, worktree multi-select, worktree submit, manual form, note', () => {
+    it('should have 6 top-level elements: dir+skip, switch, worktree form, manual form, note', () => {
       const card = parse(buildRepoSelectCard(projects));
-      expect(card.elements).toHaveLength(7);
+      expect(card.elements).toHaveLength(6);
       expect(card.elements[0].tag).toBe('column_set'); // 当前工作目录 + 直接开启会话
       expect(card.elements[1].tag).toBe('hr');
       expect(card.elements[2].tag).toBe('action');     // 选择仓库并切换 dropdown
-      expect(card.elements[3].tag).toBe('action');     // worktree multi-select
-      expect(card.elements[4].tag).toBe('form');       // worktree branch + submit
-      expect(card.elements[5].tag).toBe('form');       // manual entry
-      expect(card.elements[6].tag).toBe('note');
+      expect(card.elements[3].tag).toBe('form');       // worktree multi-select + branch + submit
+      expect(card.elements[4].tag).toBe('form');       // manual entry
+      expect(card.elements[5].tag).toBe('note');
     });
 
     it('manual-entry form carries an input + form_submit button (same row via column_set)', () => {
@@ -787,18 +786,15 @@ describe('buildRepoSelectCard', () => {
 
   describe('worktree-open dropdown', () => {
     function worktreeSelect(card: any): any {
-      const actionEls = card.elements.filter((e: any) => e.tag === 'action');
-      for (const el of actionEls) {
-        const sel = el.actions.find((a: any) => a.value?.key === 'repo_worktree_select');
-        if (sel) return sel;
-      }
-      return undefined;
+      return deepFind(card, 'multi_select_static').find((sel: any) => sel.name === 'repo_worktree_paths');
     }
 
     it('should list only main repos (no existing worktrees)', () => {
       const card = parse(buildRepoSelectCard(projects));
       const sel = worktreeSelect(card);
       expect(sel.tag).toBe('multi_select_static');
+      expect(sel.required).toBe(true);
+      expect(sel.width).toBe('fill');
       expect(sel.options).toHaveLength(2);
       const labels = sel.options.map((o: any) => o.text.content);
       expect(labels.join()).toContain('alpha');
@@ -806,11 +802,13 @@ describe('buildRepoSelectCard', () => {
       expect(labels.join()).not.toContain('beta');
     });
 
-    it('should carry the repo path as the option value and root_id in value', () => {
+    it('should carry the repo path as the option value and root_id on the form submit button', () => {
       const card = parse(buildRepoSelectCard(projects, undefined, 'om_root'));
       const sel = worktreeSelect(card);
       expect(sel.options[0].value).toBe('/home/user/alpha');
-      expect(sel.value.root_id).toBe('om_root');
+      const form = card.elements.find((e: any) => e.tag === 'form' && e.name === 'repo_worktree_submit_form');
+      const btn = deepFind({ elements: [form] }, 'button').find((b: any) => b.name === 'repo_worktree_submit');
+      expect(btn.value.root_id).toBe('om_root');
     });
 
     it('renders a branch input and submit button for selected worktree repos', () => {
@@ -820,6 +818,7 @@ describe('buildRepoSelectCard', () => {
       const input = deepFind({ elements: [form] }, 'input').find((i: any) => i.name === 'repo_worktree_branch');
       expect(input).toBeDefined();
       const btn = deepFind({ elements: [form] }, 'button').find((b: any) => b.name === 'repo_worktree_submit');
+      expect(btn.text.content).toBe('创建 worktree');
       expect(btn.action_type).toBe('form_submit');
       expect(btn.value.action).toBe('repo_worktree_submit');
       expect(btn.value.root_id).toBe('om_root');

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -37,6 +37,15 @@ vi.mock('../src/bot-registry.js', () => ({
   getBotClient: vi.fn(),
 }));
 
+vi.mock('../src/services/bot-config-store.js', () => ({
+  findConfigField: vi.fn((key: string) => key === 'worktreeMultiPicker'
+    ? { key, configKey: 'worktreeMultiPicker', kind: 'boolean', effect: 'immediate', clearable: false }
+    : undefined),
+  applyConfigField: vi.fn(async () => ({ ok: true, newText: 'on' })),
+  coerceConfigValue: vi.fn(),
+  getConfigCardData: vi.fn(),
+}));
+
 vi.mock('../src/config.js', () => ({
   config: {
     web: { externalHost: 'localhost' },
@@ -92,6 +101,7 @@ vi.mock('../src/services/frozen-card-store.js', () => ({
 
 vi.mock('../src/services/git-worktree.js', () => ({
   createRepoWorktree: vi.fn(),
+  removeRepoWorktree: vi.fn(async () => {}),
   dirSuffixForBranch: (branch: string) => branch.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'branch',
 }));
 
@@ -115,7 +125,9 @@ import { handleCardAction, type CardHandlerDeps } from '../src/im/lark/card-hand
 import { forkWorker, killWorker, deliverEphemeralOrReply } from '../src/core/worker-pool.js';
 import { getAvailableBots } from '../src/core/session-manager.js';
 import { createSession, closeSession } from '../src/services/session-store.js';
-import { createRepoWorktree } from '../src/services/git-worktree.js';
+import { createRepoWorktree, removeRepoWorktree } from '../src/services/git-worktree.js';
+import { applyConfigField } from '../src/services/bot-config-store.js';
+import { deleteMessage } from '../src/im/lark/client.js';
 import { sessionKey } from '../src/core/types.js';
 import type { DaemonSession } from '../src/core/types.js';
 import type { ProjectInfo } from '../src/services/project-scanner.js';
@@ -599,6 +611,50 @@ describe('repo select card — worktree open', () => {
       worktreePath: undefined,
     });
     expect(ds.workingDir).toBe('/repos/alpha-feat-one');
+  });
+
+  it('worktree_toggle_mode flips the persisted picker mode and re-sends a fresh repo card', async () => {
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null, repoCardMessageId: 'om_old_card' });
+    const { deps, sessionReply } = makeDeps(ds);
+    const event = {
+      operator: { open_id: OWNER },
+      action: { value: { action: 'worktree_toggle_mode', root_id: ROOT_ID } },
+      context: { open_message_id: 'om_card' },
+    };
+
+    const res = await handleCardAction(event, deps, APP_ID);
+
+    expect(res?.toast?.type).toBe('info');
+    // persisted the flipped mode (config undefined → true)
+    expect(vi.mocked(applyConfigField)).toHaveBeenCalledWith('app_test', expect.objectContaining({ configKey: 'worktreeMultiPicker' }), true);
+    // withdrew the old card and posted a fresh interactive repo card
+    expect(vi.mocked(deleteMessage)).toHaveBeenCalledWith('app_test', 'om_old_card');
+    const interactiveCall = sessionReply.mock.calls.find(c => c[2] === 'interactive');
+    expect(interactiveCall).toBeDefined();
+    expect(createRepoWorktree).not.toHaveBeenCalled();
+    expect(forkWorker).not.toHaveBeenCalled();
+    expect(ds.worktreeCreating).not.toBe(true);
+  });
+
+  it('rolls back already-created worktrees when a later repo in the batch fails', async () => {
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null });
+    const { deps, sessionReply } = makeDeps(ds);
+    vi.mocked(createRepoWorktree)
+      .mockResolvedValueOnce({ path: '/repos/feat-multi/alpha', branch: 'feat/multi', baseRef: 'origin/master' })
+      .mockRejectedValueOnce(new Error('boom on beta'));
+
+    await handleCardAction(makeWorktreeSubmitEvent('feat/multi', ['/repos/alpha', '/repos/beta']), deps, APP_ID);
+    await vi.waitFor(() => expect(ds.worktreeCreating).toBe(false));
+
+    expect(createRepoWorktree).toHaveBeenCalledTimes(2);
+    // the first repo's worktree (already on disk) is rolled back, not leaked
+    expect(removeRepoWorktree).toHaveBeenCalledTimes(1);
+    expect(removeRepoWorktree).toHaveBeenCalledWith('/repos/alpha', '/repos/feat-multi/alpha');
+    expect(forkWorker).not.toHaveBeenCalled();
+    expect(ds.pendingRepo).toBe(true); // still recoverable — card stays
+    const replies = sessionReply.mock.calls.map(c => c[1]).join();
+    expect(replies).toContain('回滚');
+    expect(replies).toContain('boom on beta');
   });
 });
 

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -186,34 +186,15 @@ function makeManualEvent(path: string, operator = OWNER) {
   };
 }
 
-function makeWorktreeMultiSelectEvent(paths: string[], operator = OWNER) {
-  return {
-    operator: { open_id: operator },
-    action: {
-      option: paths,
-      value: { key: 'repo_worktree_select', root_id: ROOT_ID },
-    },
-    context: { open_message_id: 'om_card' },
-  };
-}
-
-function makeWorktreeSelectedOptionsEvent(paths: string[], operator = OWNER) {
-  return {
-    operator: { open_id: operator },
-    action: {
-      selected_options: paths,
-      value: { key: 'repo_worktree_select', root_id: ROOT_ID },
-    },
-    context: { open_message_id: 'om_card' },
-  };
-}
-
-function makeWorktreeSubmitEvent(branch = '', operator = OWNER) {
+function makeWorktreeSubmitEvent(branch = '', paths?: string[], operator = OWNER) {
   return {
     operator: { open_id: operator },
     action: {
       value: { action: 'repo_worktree_submit', root_id: ROOT_ID },
-      form_value: { repo_worktree_branch: branch },
+      form_value: {
+        repo_worktree_branch: branch,
+        ...(paths ? { repo_worktree_paths: paths } : {}),
+      },
     },
     context: { open_message_id: 'om_card' },
   };
@@ -479,8 +460,7 @@ describe('repo select card — worktree open', () => {
       .mockResolvedValueOnce({ path: '/repos/feat-multi/alpha', branch: 'feat/multi', baseRef: 'origin/master' })
       .mockResolvedValueOnce({ path: '/repos/feat-multi/beta', branch: 'feat/multi', baseRef: 'origin/master' });
 
-    await handleCardAction(makeWorktreeMultiSelectEvent(['/repos/alpha', '/repos/beta']), deps, APP_ID);
-    const res = await handleCardAction(makeWorktreeSubmitEvent('feat/multi'), deps, APP_ID);
+    const res = await handleCardAction(makeWorktreeSubmitEvent('feat/multi', ['/repos/alpha', '/repos/beta']), deps, APP_ID);
     expect(res?.toast?.content).toContain('正在创建');
     await vi.waitFor(() => expect(ds.worktreeCreating).toBe(false));
 
@@ -501,15 +481,14 @@ describe('repo select card — worktree open', () => {
     expect(sessionReply.mock.calls.map(c => c[1]).join()).toContain('worktree 已创建');
   });
 
-  it('reads multi-select values from action.selected_options and creates all selected repos', async () => {
+  it('reads official form multi-select values from action.form_value and creates all selected repos', async () => {
     const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null });
     const { deps } = makeDeps(ds);
     vi.mocked(createRepoWorktree)
       .mockResolvedValueOnce({ path: '/repos/feat-selected/alpha', branch: 'feat/selected', baseRef: 'origin/master' })
       .mockResolvedValueOnce({ path: '/repos/feat-selected/beta', branch: 'feat/selected', baseRef: 'origin/master' });
 
-    await handleCardAction(makeWorktreeSelectedOptionsEvent(['/repos/alpha', '/repos/beta']), deps, APP_ID);
-    await handleCardAction(makeWorktreeSubmitEvent('feat/selected'), deps, APP_ID);
+    await handleCardAction(makeWorktreeSubmitEvent('feat/selected', ['/repos/alpha', '/repos/beta']), deps, APP_ID);
     await vi.waitFor(() => expect(ds.worktreeCreating).toBe(false));
 
     expect(createRepoWorktree).toHaveBeenCalledTimes(2);
@@ -527,6 +506,67 @@ describe('repo select card — worktree open', () => {
     expect(ds.workingDir).toBe('/repos/feat-selected');
   });
 
+  it('multi-select without explicit branch uses the default slug parent and child naming', async () => {
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null });
+    const { deps } = makeDeps(ds);
+    vi.mocked(createRepoWorktree)
+      .mockResolvedValueOnce({ path: '/repos/repo-test/alpha', branch: 'repo-test', baseRef: 'origin/master' })
+      .mockResolvedValueOnce({ path: '/repos/repo-test/beta', branch: 'repo-test', baseRef: 'origin/master' });
+
+    const res = await handleCardAction(makeWorktreeSubmitEvent('', ['/repos/alpha', '/repos/beta']), deps, APP_ID);
+    expect(res?.toast?.content).toContain('正在创建');
+    await vi.waitFor(() => expect(ds.worktreeCreating).toBe(false));
+
+    expect(createRepoWorktree).toHaveBeenCalledTimes(2);
+    expect(createRepoWorktree).toHaveBeenNthCalledWith(1, '/repos/alpha', {
+      branch: undefined,
+      slug: 'repo-test',
+      worktreePath: '/repos/repo-test/alpha',
+    });
+    expect(createRepoWorktree).toHaveBeenNthCalledWith(2, '/repos/beta', {
+      branch: undefined,
+      slug: 'repo-test',
+      worktreePath: '/repos/repo-test/beta',
+    });
+    expect(forkWorker).toHaveBeenCalledTimes(1);
+    expect(ds.workingDir).toBe('/repos/repo-test');
+  });
+
+  it('rejects empty repo_worktree_paths from the official form value', async () => {
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null });
+    const { deps } = makeDeps(ds);
+
+    const res = await handleCardAction(makeWorktreeSubmitEvent('feat/empty', []), deps, APP_ID);
+
+    expect(res?.toast?.type).toBe('error');
+    expect(res?.toast?.content).toContain('至少选择一个仓库');
+    expect(createRepoWorktree).not.toHaveBeenCalled();
+    expect(forkWorker).not.toHaveBeenCalled();
+    expect(ds.worktreeCreating).not.toBe(true);
+  });
+
+  it('rejects missing repo_worktree_paths and does not fall back to standalone multi-select options', async () => {
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null });
+    const { deps } = makeDeps(ds);
+    const event = {
+      operator: { open_id: OWNER },
+      action: {
+        value: { action: 'repo_worktree_submit', root_id: ROOT_ID },
+        form_value: { repo_worktree_branch: 'feat/missing' },
+        options: ['/repos/alpha', '/repos/beta'],
+      },
+      context: { open_message_id: 'om_card' },
+    };
+
+    const res = await handleCardAction(event, deps, APP_ID);
+
+    expect(res?.toast?.type).toBe('error');
+    expect(res?.toast?.content).toContain('至少选择一个仓库');
+    expect(createRepoWorktree).not.toHaveBeenCalled();
+    expect(forkWorker).not.toHaveBeenCalled();
+    expect(ds.worktreeCreating).not.toBe(true);
+  });
+
   it('rejects multi-select repos that map to the same child directory before creating worktrees', async () => {
     const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null });
     const duplicateProjects: ProjectInfo[] = [
@@ -535,8 +575,7 @@ describe('repo select card — worktree open', () => {
     ];
     const { deps } = makeDeps(ds, duplicateProjects);
 
-    await handleCardAction(makeWorktreeMultiSelectEvent(['/repos/team-a/same', '/repos/team-b/same']), deps, APP_ID);
-    const res = await handleCardAction(makeWorktreeSubmitEvent('feat/collision'), deps, APP_ID);
+    const res = await handleCardAction(makeWorktreeSubmitEvent('feat/collision', ['/repos/team-a/same', '/repos/team-b/same']), deps, APP_ID);
 
     expect(res?.toast?.type).toBe('error');
     expect(res?.toast?.content).toContain('相同 worktree 子目录');
@@ -551,8 +590,7 @@ describe('repo select card — worktree open', () => {
     const { deps } = makeDeps(ds);
     vi.mocked(createRepoWorktree).mockResolvedValue({ path: '/repos/alpha-feat-one', branch: 'feat/one', baseRef: 'origin/master' });
 
-    await handleCardAction(makeWorktreeMultiSelectEvent(['/repos/alpha']), deps, APP_ID);
-    await handleCardAction(makeWorktreeSubmitEvent('feat/one'), deps, APP_ID);
+    await handleCardAction(makeWorktreeSubmitEvent('feat/one', ['/repos/alpha']), deps, APP_ID);
     await vi.waitFor(() => expect(ds.worktreeCreating).toBe(false));
 
     expect(createRepoWorktree).toHaveBeenCalledWith('/repos/alpha', {

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -128,6 +128,7 @@ import { createSession, closeSession } from '../src/services/session-store.js';
 import { createRepoWorktree, removeRepoWorktree } from '../src/services/git-worktree.js';
 import { applyConfigField } from '../src/services/bot-config-store.js';
 import { deleteMessage } from '../src/im/lark/client.js';
+import { canOperate } from '../src/im/lark/event-dispatcher.js';
 import { sessionKey } from '../src/core/types.js';
 import type { DaemonSession } from '../src/core/types.js';
 import type { ProjectInfo } from '../src/services/project-scanner.js';
@@ -634,6 +635,25 @@ describe('repo select card — worktree open', () => {
     expect(createRepoWorktree).not.toHaveBeenCalled();
     expect(forkWorker).not.toHaveBeenCalled();
     expect(ds.worktreeCreating).not.toBe(true);
+  });
+
+  it('worktree_toggle_mode requires canOperate — a non-operator (even the pending-session owner) cannot flip bot config', async () => {
+    // It writes bot-level worktreeMultiPicker (bots.json), so it must NOT ride
+    // the pendingRepoOwnerException that lets talk-only users start their own session.
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null, repoCardMessageId: 'om_old_card' });
+    const { deps } = makeDeps(ds);
+    vi.mocked(canOperate).mockReturnValueOnce(false); // non-operator
+    const event = {
+      operator: { open_id: OWNER }, // session owner, but NOT an operator
+      action: { value: { action: 'worktree_toggle_mode', root_id: ROOT_ID } },
+      context: { open_message_id: 'om_card' },
+    };
+
+    const res = await handleCardAction(event, deps, APP_ID);
+
+    expect(res?.toast).toBeUndefined();                // sensitive gate blocks silently (logs only)
+    expect(vi.mocked(applyConfigField)).not.toHaveBeenCalled(); // no bot-config write
+    expect(vi.mocked(deleteMessage)).not.toHaveBeenCalled();
   });
 
   it('rolls back already-created worktrees when a later repo in the batch fails', async () => {

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -92,6 +92,7 @@ vi.mock('../src/services/frozen-card-store.js', () => ({
 
 vi.mock('../src/services/git-worktree.js', () => ({
   createRepoWorktree: vi.fn(),
+  dirSuffixForBranch: (branch: string) => branch.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'branch',
 }));
 
 vi.mock('../src/services/worktree-slug-ai.js', () => ({
@@ -159,10 +160,10 @@ function makeDs(overrides?: Partial<DaemonSession>): DaemonSession {
   } as unknown as DaemonSession;
 }
 
-function makeDeps(ds: DaemonSession) {
+function makeDeps(ds: DaemonSession, projects = PROJECTS) {
   const activeSessions = new Map([[sessionKey(ROOT_ID, APP_ID), ds]]);
   const sessionReply = vi.fn(async () => 'om_reply');
-  const deps: CardHandlerDeps = { activeSessions, sessionReply, lastRepoScan: new Map([[CHAT_ID, PROJECTS]]) };
+  const deps: CardHandlerDeps = { activeSessions, sessionReply, lastRepoScan: new Map([[CHAT_ID, projects]]) };
   return { deps, sessionReply };
 }
 
@@ -180,6 +181,39 @@ function makeManualEvent(path: string, operator = OWNER) {
     action: {
       value: { action: 'repo_manual_submit', root_id: ROOT_ID },
       form_value: { repo_manual_path: path },
+    },
+    context: { open_message_id: 'om_card' },
+  };
+}
+
+function makeWorktreeMultiSelectEvent(paths: string[], operator = OWNER) {
+  return {
+    operator: { open_id: operator },
+    action: {
+      option: paths,
+      value: { key: 'repo_worktree_select', root_id: ROOT_ID },
+    },
+    context: { open_message_id: 'om_card' },
+  };
+}
+
+function makeWorktreeSelectedOptionsEvent(paths: string[], operator = OWNER) {
+  return {
+    operator: { open_id: operator },
+    action: {
+      selected_options: paths,
+      value: { key: 'repo_worktree_select', root_id: ROOT_ID },
+    },
+    context: { open_message_id: 'om_card' },
+  };
+}
+
+function makeWorktreeSubmitEvent(branch = '', operator = OWNER) {
+  return {
+    operator: { open_id: operator },
+    action: {
+      value: { action: 'repo_worktree_submit', root_id: ROOT_ID },
+      form_value: { repo_worktree_branch: branch },
     },
     context: { open_message_id: 'om_card' },
   };
@@ -436,6 +470,97 @@ describe('repo select card — worktree open', () => {
     expect(forkWorker).not.toHaveBeenCalled();
     expect(ds.pendingRepo).toBe(true); // still recoverable — card stays
     expect(sessionReply.mock.calls.map(c => c[1]).join()).toContain('fetch blew up');
+  });
+
+  it('multi-select creates all selected repos under one parent path and opens that parent', async () => {
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null });
+    const { deps, sessionReply } = makeDeps(ds);
+    vi.mocked(createRepoWorktree)
+      .mockResolvedValueOnce({ path: '/repos/feat-multi/alpha', branch: 'feat/multi', baseRef: 'origin/master' })
+      .mockResolvedValueOnce({ path: '/repos/feat-multi/beta', branch: 'feat/multi', baseRef: 'origin/master' });
+
+    await handleCardAction(makeWorktreeMultiSelectEvent(['/repos/alpha', '/repos/beta']), deps, APP_ID);
+    const res = await handleCardAction(makeWorktreeSubmitEvent('feat/multi'), deps, APP_ID);
+    expect(res?.toast?.content).toContain('正在创建');
+    await vi.waitFor(() => expect(ds.worktreeCreating).toBe(false));
+
+    expect(createRepoWorktree).toHaveBeenCalledTimes(2);
+    expect(createRepoWorktree).toHaveBeenNthCalledWith(1, '/repos/alpha', {
+      branch: 'feat/multi',
+      slug: undefined,
+      worktreePath: '/repos/feat-multi/alpha',
+    });
+    expect(createRepoWorktree).toHaveBeenNthCalledWith(2, '/repos/beta', {
+      branch: 'feat/multi',
+      slug: undefined,
+      worktreePath: '/repos/feat-multi/beta',
+    });
+    expect(forkWorker).toHaveBeenCalledTimes(1);
+    expect(ds.workingDir).toBe('/repos/feat-multi');
+    expect(ds.session.workingDir).toBe('/repos/feat-multi');
+    expect(sessionReply.mock.calls.map(c => c[1]).join()).toContain('worktree 已创建');
+  });
+
+  it('reads multi-select values from action.selected_options and creates all selected repos', async () => {
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null });
+    const { deps } = makeDeps(ds);
+    vi.mocked(createRepoWorktree)
+      .mockResolvedValueOnce({ path: '/repos/feat-selected/alpha', branch: 'feat/selected', baseRef: 'origin/master' })
+      .mockResolvedValueOnce({ path: '/repos/feat-selected/beta', branch: 'feat/selected', baseRef: 'origin/master' });
+
+    await handleCardAction(makeWorktreeSelectedOptionsEvent(['/repos/alpha', '/repos/beta']), deps, APP_ID);
+    await handleCardAction(makeWorktreeSubmitEvent('feat/selected'), deps, APP_ID);
+    await vi.waitFor(() => expect(ds.worktreeCreating).toBe(false));
+
+    expect(createRepoWorktree).toHaveBeenCalledTimes(2);
+    expect(createRepoWorktree).toHaveBeenNthCalledWith(1, '/repos/alpha', {
+      branch: 'feat/selected',
+      slug: undefined,
+      worktreePath: '/repos/feat-selected/alpha',
+    });
+    expect(createRepoWorktree).toHaveBeenNthCalledWith(2, '/repos/beta', {
+      branch: 'feat/selected',
+      slug: undefined,
+      worktreePath: '/repos/feat-selected/beta',
+    });
+    expect(forkWorker).toHaveBeenCalledTimes(1);
+    expect(ds.workingDir).toBe('/repos/feat-selected');
+  });
+
+  it('rejects multi-select repos that map to the same child directory before creating worktrees', async () => {
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null });
+    const duplicateProjects: ProjectInfo[] = [
+      { name: 'same', path: '/repos/team-a/same', type: 'repo', branch: 'master' },
+      { name: 'same', path: '/repos/team-b/same', type: 'repo', branch: 'main' },
+    ];
+    const { deps } = makeDeps(ds, duplicateProjects);
+
+    await handleCardAction(makeWorktreeMultiSelectEvent(['/repos/team-a/same', '/repos/team-b/same']), deps, APP_ID);
+    const res = await handleCardAction(makeWorktreeSubmitEvent('feat/collision'), deps, APP_ID);
+
+    expect(res?.toast?.type).toBe('error');
+    expect(res?.toast?.content).toContain('相同 worktree 子目录');
+    expect(res?.toast?.content).toContain('same');
+    expect(createRepoWorktree).not.toHaveBeenCalled();
+    expect(forkWorker).not.toHaveBeenCalled();
+    expect(ds.worktreeCreating).not.toBe(true);
+  });
+
+  it('single selection from the new form keeps the existing single-repo path convention and passes branch', async () => {
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null });
+    const { deps } = makeDeps(ds);
+    vi.mocked(createRepoWorktree).mockResolvedValue({ path: '/repos/alpha-feat-one', branch: 'feat/one', baseRef: 'origin/master' });
+
+    await handleCardAction(makeWorktreeMultiSelectEvent(['/repos/alpha']), deps, APP_ID);
+    await handleCardAction(makeWorktreeSubmitEvent('feat/one'), deps, APP_ID);
+    await vi.waitFor(() => expect(ds.worktreeCreating).toBe(false));
+
+    expect(createRepoWorktree).toHaveBeenCalledWith('/repos/alpha', {
+      branch: 'feat/one',
+      slug: undefined,
+      worktreePath: undefined,
+    });
+    expect(ds.workingDir).toBe('/repos/alpha-feat-one');
   });
 });
 

--- a/test/git-worktree.test.ts
+++ b/test/git-worktree.test.ts
@@ -12,7 +12,7 @@ import { mkdtempSync, mkdirSync, rmSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { createRepoWorktree, slugFromWorktreeText } from '../src/services/git-worktree.js';
+import { createRepoWorktree, removeRepoWorktree, slugFromWorktreeText } from '../src/services/git-worktree.js';
 import { localWorktreeSlugFromContext } from '../src/services/worktree-slug-ai.js';
 
 let tempRoot: string;
@@ -151,6 +151,20 @@ describe('createRepoWorktree', () => {
     expect(res.branch).toBe('feat/group');
     expect(existsSync(join(target, '.git'))).toBe(true);
     expect(git(target, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('feat/group');
+  });
+
+  it('removeRepoWorktree detaches the worktree dir so the slot is reusable (rollback)', async () => {
+    const upstream = makeUpstream('upstream');
+    const repo = makeClone(upstream, 'proj');
+    const target = join(tempRoot, 'rollback-parent', 'proj');
+    const res = await createRepoWorktree(repo, { branch: 'feat/rollback', worktreePath: target });
+    expect(existsSync(join(target, '.git'))).toBe(true);
+
+    await removeRepoWorktree(repo, res.path);
+
+    expect(existsSync(target)).toBe(false);
+    // git no longer tracks the worktree, so the path is free for a retry
+    expect(git(repo, 'worktree', 'list')).not.toContain(target);
   });
 
   it('checks out an existing local branch instead of recreating it', async () => {

--- a/test/git-worktree.test.ts
+++ b/test/git-worktree.test.ts
@@ -140,6 +140,19 @@ describe('createRepoWorktree', () => {
     expect(git(res.path, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('feat/foo');
   });
 
+  it('uses an explicit worktree path when provided', async () => {
+    const upstream = makeUpstream('upstream');
+    const repo = makeClone(upstream, 'proj');
+    const target = join(tempRoot, 'feat-parent', 'proj');
+
+    const res = await createRepoWorktree(repo, { branch: 'feat/group', worktreePath: target });
+
+    expect(res.path).toBe(target);
+    expect(res.branch).toBe('feat/group');
+    expect(existsSync(join(target, '.git'))).toBe(true);
+    expect(git(target, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('feat/group');
+  });
+
   it('checks out an existing local branch instead of recreating it', async () => {
     const upstream = makeUpstream('upstream');
     const repo = makeClone(upstream, 'proj');

--- a/test/worktree-slug-ai.test.ts
+++ b/test/worktree-slug-ai.test.ts
@@ -4,6 +4,7 @@ import { worktreeSlugFromContextAI } from '../src/services/worktree-slug-ai.js';
 
 describe('worktreeSlugFromContextAI', () => {
   const original = { ...config.worktreeSlugAI };
+  const originalDescriptor = Object.getOwnPropertyDescriptor(config, 'worktreeSlugAI');
   let originalFetch: typeof globalThis.fetch;
 
   beforeEach(() => {
@@ -21,7 +22,12 @@ describe('worktreeSlugFromContextAI', () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
-    Object.assign(config.worktreeSlugAI, original);
+    const currentConfig = config.worktreeSlugAI;
+    if (currentConfig) {
+      Object.assign(currentConfig, original);
+    } else if (originalDescriptor) {
+      Object.defineProperty(config, 'worktreeSlugAI', { ...originalDescriptor, value: { ...original } });
+    }
     vi.restoreAllMocks();
   });
 
@@ -51,5 +57,13 @@ describe('worktreeSlugFromContextAI', () => {
     config.worktreeSlugAI.enabled = true;
     globalThis.fetch = vi.fn(async () => new Response('bad gateway', { status: 502 })) as any;
     await expect(worktreeSlugFromContextAI('看下新开 worktree 的时候，命名逻辑是啥？')).resolves.toBe('worktree');
+  });
+
+  it('falls back locally when the deployed config has no worktree slug AI section', async () => {
+    Reflect.deleteProperty(config, 'worktreeSlugAI');
+    globalThis.fetch = vi.fn();
+
+    await expect(worktreeSlugFromContextAI('repo test')).resolves.toBe('repo-test');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
基于 @qqxhb 的 #257（多仓库 worktree 创建）重做交互，并修复 review 发现的问题。保留 qqxhb 的原始两个 commit（多仓库循环 / 表单提交），我的 rework 作为第三个 commit。

## 背景
#257 把 worktree 选择器从单选下拉改成多选表单，给单仓库（多数）用户增加了操作步骤。申晗要求：默认不影响老用户，多仓库做成 opt-in。

## 改动
- **持久模式开关**：新增 per-bot 配置 `worktreeMultiPicker`（bots.json，`/botconfig` + dashboard 可配）。repo 卡片按它渲染 worktree 行：
  - **单仓库模式（默认）**：即点即建下拉 + 「🔀 多仓库」开关，用与「使用此目录」相同的 `column_set` 结构（下拉 weighted 撑满 + 按钮 auto 贴右），手机不折行、按钮对齐。
  - **多仓库模式**：内嵌多选表单（多选 + 分支名 + 创建）+ 「🔀 单仓库」开关行。
  - 「切换」翻转持久配置 → 撤旧卡重发新模式卡（飞书表单卡不能就地 patch）。该 bot 后续所有会话默认走切换后的模式，随时切回。
- **修复部分失败无回滚（原 #257 的 Major）**：多仓库串行创建中途失败时，对已成功的逐个 `git worktree remove --force` 回滚（新增 `removeRepoWorktree`），避免残留目录致重试撞 "already exists"。
- 清理：删死字段 `pendingWorktreePaths`；失败日志指向真正失败的仓库。

## 验证
- `tsc --noEmit` 干净
- 全量 vitest：4949 passed，22 failed 均为环境性基线（e2e-browser 需浏览器 / workflow-cli 等），与 master 同（零新增失败）
- 卡片渲染已用网页版飞书真机核对（单/多模式、手机不折行、按钮对齐、select_static 入列可渲染+触发回调均确认）

合并后请关闭 #257。