### PR TITLE
fix(sandbox): let ACE sandbox reuse host bytedcli and moderation-cli auth

### DIFF
--- a/docs-site/docs/en/bots-json.md
+++ b/docs-site/docs/en/bots-json.md
@@ -83,8 +83,9 @@ There are many fields, listed below grouped by purpose. The vast majority are **
 
 | Field | Description |
 |------|------|
-| `autoStartOnGroupJoin` | When `true`, the bot starts working automatically when added to a new group containing at least one `allowedUsers` member (no @ needed). Requires subscribing the `im.chat.member.bot.added_v1` event for this app in the Lark admin console |
+| `autoStartOnGroupJoin` | When `true`, the bot attempts to auto-start when added to a new group (no @ needed). Requires subscribing the `im.chat.member.bot.added_v1` event for this app in the Lark admin console |
 | `autoStartOnGroupJoinPrompt` | Paired with the above: the first-round prompt for proactive start; if empty / blank, opens with an empty message and lets the bot read the group context itself. Meaningless when `autoStartOnGroupJoin` is off |
+| `autoStartOnGroupJoinChatNameRegex` | Optional. When set, only groups whose display name matches this regex auto-start on join (skips the `allowedUsers` membership gate). When unset, the `allowedUsers` membership gate still applies |
 | `autoStartOnNewTopic` | When `true`, the first message of every new topic in a topic group starts working automatically without an @ (no effect in plain groups). Defaults to passive (only @ triggers) |
 
 ## Voice

--- a/docs-site/docs/zh/bots-json.md
+++ b/docs-site/docs/zh/bots-json.md
@@ -83,8 +83,9 @@
 
 | 字段 | 说明 |
 |------|------|
-| `autoStartOnGroupJoin` | `true` 时，被拉入含至少一名 `allowedUsers` 的新群即自动开工（不必 @）。需在飞书后台为该应用订阅 `im.chat.member.bot.added_v1` 事件 |
+| `autoStartOnGroupJoin` | `true` 时，被拉入新群即尝试自动开工（不必 @）。需在飞书后台为该应用订阅 `im.chat.member.bot.added_v1` 事件 |
 | `autoStartOnGroupJoinPrompt` | 配合上面：自动开工的首轮 prompt；留空 / 空白则空消息开场，让 bot 自己读群上下文。`autoStartOnGroupJoin` 关闭时无意义 |
+| `autoStartOnGroupJoinChatNameRegex` | 可选。设置后**仅**群显示名匹配该正则的群会入群自动开工（跳过 `allowedUsers` 成员门禁）。未配置时仍走 `allowedUsers` 成员门禁 |
 | `autoStartOnNewTopic` | `true` 时，话题群里每个新话题的首条消息无需 @ 也自动开工（普通群无效）。默认被动（仅 @ 触发） |
 
 ## 语音

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -20,7 +20,7 @@
  * sandbox-exec approach and is handled elsewhere.
  */
 import { homedir } from 'node:os';
-import { mkdirSync, existsSync, writeFileSync, chmodSync, readdirSync, readFileSync, rmSync, statSync, openSync, fstatSync, readSync, writeSync, closeSync, constants as fsConstants } from 'node:fs';
+import { mkdirSync, existsSync, writeFileSync, chmodSync, readdirSync, readFileSync, rmSync, statSync, openSync, fstatSync, readSync, writeSync, closeSync, constants as fsConstants, realpathSync } from 'node:fs';
 import { atomicWriteFileSync } from '../../utils/atomic-write.js';
 import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -29,6 +29,28 @@ import { spawn, spawnSync } from 'node:child_process';
 /** Host root for the HOME overlay's upper/work — MUST be OUTSIDE the home lower
  *  (overlayfs forbids upper/work inside lower). */
 const VARTMP_ROOT = '/var/tmp/botmux-sbx';
+
+/**
+ * Canonical $HOME for sandbox overlay lower, bwrap bind target, and child HOME.
+ * bwrap cannot bind-mount onto a symlink mountpoint (e.g. /home/u → /data00/home/u);
+ * overlay lower must be the resolved directory too.
+ */
+export function resolveSandboxHome(homeDir: string = homedir()): string {
+  try {
+    return realpathSync(homeDir);
+  } catch {
+    return homeDir;
+  }
+}
+
+/** Resolve an existing path for overlay lower / bwrap bind targets. */
+export function resolveSandboxPath(path: string): string {
+  try {
+    return existsSync(path) ? realpathSync(path) : path;
+  } catch {
+    return path;
+  }
+}
 
 // ───────────────────────────── overlay primitives ────────────────────────────
 
@@ -254,7 +276,14 @@ export interface SandboxSpawn {
  *  sees the sandboxed CLI's writes (which are invisible at the real host path).
  *  Mirrors prepareSandbox's homeUpper layout — keep in sync. */
 export function sandboxedClaudeDataDir(sessionId: string, realDataDir: string): string {
-  return join(VARTMP_ROOT, sessionId, 'home-upper', relative(homedir(), realDataDir));
+  const home = resolveSandboxHome();
+  let rel: string;
+  try {
+    rel = relative(home, realpathSync(realDataDir));
+  } catch {
+    rel = relative(homedir(), realDataDir);
+  }
+  return join(VARTMP_ROOT, sessionId, 'home-upper', rel);
 }
 
 /** Proxy env vars forwarded into the sandbox so the CLI reaches the API even on
@@ -303,7 +332,8 @@ export function prepareSandbox(opts: {
   const needFuse = process.env.BOTMUX_SANDBOX_FUSE === '1' || process.getuid?.() !== 0;
   if (!ensureSandboxDeps(needFuse)) return null;
 
-  const sessionRoot = join(opts.dataDir, 'sandboxes', opts.sessionId);
+  const dataDir = resolveSandboxPath(opts.dataDir);
+  const sessionRoot = join(dataDir, 'sandboxes', opts.sessionId);
   const outbox = join(sessionRoot, 'outbox');
   const shimBin = join(sessionRoot, 'shimbin');
   const empties = join(sessionRoot, 'empties');
@@ -317,10 +347,10 @@ export function prepareSandbox(opts: {
   const homeWork = join(vartmp, 'home-work');
   for (const d of [outbox, shimBin, empties]) mkdirSync(d, { recursive: true });
 
-  const home = homedir();
+  const home = resolveSandboxHome();
   // BOTMUX_SANDBOX_SRC overrides the LOWER project source for spike testing only.
-  const projectSource = process.env.BOTMUX_SANDBOX_SRC || opts.sourceWorkingDir;
-  const projectMount = opts.sourceWorkingDir;
+  const projectSource = resolveSandboxPath(process.env.BOTMUX_SANDBOX_SRC || opts.sourceWorkingDir);
+  const projectMount = resolveSandboxPath(opts.sourceWorkingDir);
 
   // A same-session re-spawn (e.g. in-pane /clear) re-enters here; unmount any
   // stale merged overlays first so we don't stack a second mount on the same dir.
@@ -358,14 +388,15 @@ export function prepareSandbox(opts: {
   let emptyIdx = 0;
   for (const p of opts.hidePaths ?? []) {
     if (!p || typeof p !== 'string') continue;
+    const resolved = resolveSandboxPath(p);
     let isDir = false;
-    try { isDir = existsSync(p) && statSync(p).isDirectory(); } catch { /* */ }
+    try { isDir = existsSync(resolved) && statSync(resolved).isDirectory(); } catch { /* */ }
     if (isDir) {
-      hideDirs.push(p);
+      hideDirs.push(resolved);
     } else {
       const empty = join(empties, `mask-${emptyIdx++}`);
       try { writeFileSync(empty, ''); } catch { /* */ }
-      hideFiles.push({ path: p, empty });
+      hideFiles.push({ path: resolved, empty });
     }
   }
 
@@ -420,7 +451,7 @@ export function prepareSandbox(opts: {
   // Authoritative child env via bwrap --setenv (works on pty AND tmux — the tmux
   // backend only forwards a fixed whitelist, which excludes HOME/PATH/relay).
   const env: Record<string, string> = {
-    HOME: home,                                      // home overlay is bound AT the real home path
+    HOME: home,                                      // canonical path (not a symlink)
     BOTMUX_SEND_RELAY: outbox,                       // routes `botmux send` to the daemon outbox watcher
     PATH: `/run/sbxbin:${process.env.PATH ?? ''}`,   // /run/sbxbin first so `botmux` = the relay shim
   };

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -388,7 +388,7 @@ export function prepareSandbox(opts: {
   let emptyIdx = 0;
   for (const p of opts.hidePaths ?? []) {
     if (!p || typeof p !== 'string') continue;
-    const resolved = resolveSandboxPath(p);
+    const resolved = resolveSandboxPath(p.replace(/^~(?=\/|$)/, home));
     let isDir = false;
     try { isDir = existsSync(resolved) && statSync(resolved).isDirectory(); } catch { /* */ }
     if (isDir) {

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -211,7 +211,7 @@ export class TmuxPipeBackend implements SessionBackend {
     try {
       execSync(
         `tmux pipe-pane -O -t ${shellescape(this.paneTarget)} 'cat > ${shellescape(this.fifoPath)}'`,
-        { stdio: 'ignore', timeout: 5000, env: tmuxEnv() },
+        { stdio: 'ignore', timeout: 15000, env: tmuxEnv() },
       );
       this.pipeAttached = true;
       this.startLifecycleWatcher();

--- a/src/adapters/cli/ace.ts
+++ b/src/adapters/cli/ace.ts
@@ -1,0 +1,171 @@
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { resolveCommand } from './registry.js';
+import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
+import { delay, scaleMs } from '../../utils/timing.js';
+import type { CliAdapter, PtyHandle } from './types.js';
+
+const ACE_DIR = join(homedir(), '.ace');
+
+function aceProjectSlug(cwd: string): string | undefined {
+  const projectsPath = join(ACE_DIR, 'projects.json');
+  if (!existsSync(projectsPath)) return undefined;
+  try {
+    const parsed = JSON.parse(readFileSync(projectsPath, 'utf8')) as { projects?: Record<string, string> };
+    const projects = parsed.projects ?? {};
+    const candidates = [cwd, resolve(cwd)];
+    try { candidates.push(realpathSync(cwd)); } catch { /* best effort */ }
+    for (const key of candidates) {
+      if (projects[key]) return projects[key];
+    }
+  } catch { /* corrupt projects.json */ }
+  return undefined;
+}
+
+export function aceLogsPath(cwd: string): string {
+  const slug = aceProjectSlug(cwd);
+  if (!slug) return join(ACE_DIR, 'tmp', '_unknown', 'logs.json');
+  return join(ACE_DIR, 'tmp', slug, 'logs.json');
+}
+
+function readUserMessages(path: string): string[] {
+  if (!existsSync(path)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8'));
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((entry) => entry?.type === 'user' && typeof entry?.message === 'string')
+      .map((entry) => entry.message as string);
+  } catch {
+    return [];
+  }
+}
+
+function currentFileSize(path: string): number {
+  if (!existsSync(path)) return 0;
+  try { return statSync(path).size; } catch { return 0; }
+}
+
+function logsContainNewUserMessage(path: string, beforeCount: number, prefix: string): boolean {
+  const messages = readUserMessages(path);
+  if (messages.length <= beforeCount) return false;
+  return messages.slice(beforeCount).some((msg) => msg.startsWith(prefix));
+}
+
+async function waitForLogsAppend(
+  path: string, beforeCount: number, prefix: string, timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + scaleMs(timeoutMs);
+  while (Date.now() < deadline) {
+    if (logsContainNewUserMessage(path, beforeCount, prefix)) return true;
+    await delay(100);
+  }
+  return false;
+}
+
+function submitPrefix(content: string): string {
+  return content.slice(0, 40);
+}
+
+export function createAceAdapter(pathOverride?: string): CliAdapter {
+  const rawBin = pathOverride ?? 'ace';
+  let cachedBin: string | undefined;
+  let activeWorkingDir: string | undefined;
+  let spawnEnvForNext: Readonly<Record<string, string>> = {
+    ACE_NETWORK_TYPE: 'office',
+    ACE_ACP_SINGLE_PROVIDER: '1',
+  };
+
+  return {
+    id: 'ace',
+    authPaths: ['~/.ace/oauth_creds.json'],
+    get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
+
+    buildArgs({ workingDir, initialPrompt, model, disableCliBypass }) {
+      if (workingDir) activeWorkingDir = workingDir;
+      spawnEnvForNext = {
+        ACE_NETWORK_TYPE: 'office',
+        // Match ACP serve.ts: avoid modelhub fallback with openai/gpt-5.5 (400 product not right).
+        ACE_ACP_SINGLE_PROVIDER: '1',
+        ...(model?.trim() ? { AIDP_MODEL: model.trim() } : {}),
+      };
+
+      const args: string[] = [];
+      if (!disableCliBypass) args.push('-y');
+      // Ace manages sessions internally; CLI --resume is not wired yet.
+      if (initialPrompt) args.push(initialPrompt);
+      return args;
+    },
+
+    get spawnEnv(): Readonly<Record<string, string>> {
+      return spawnEnvForNext;
+    },
+
+    passesInitialPromptViaArgs: true,
+
+    async writeInput(pty: PtyHandle, content: string) {
+      const logsPath = aceLogsPath(pty.cliCwd ?? activeWorkingDir ?? process.cwd());
+      const beforeCount = readUserMessages(logsPath).length;
+      const prefix = submitPrefix(content);
+      const hasImagePath = /\.(jpe?g|png|gif|webp|svg|bmp)\b/i.test(content);
+      const submitDelay = hasImagePath ? 800 : 500;
+
+      const trySendEnter = (): boolean => {
+        try {
+          if (pty.sendSpecialKeys) pty.sendSpecialKeys('Enter');
+          else pty.write('\r');
+          return true;
+        } catch {
+          return false;
+        }
+      };
+
+      try {
+        if (pty.pasteText) {
+          pty.pasteText(content);
+        } else if (pty.sendText && pty.sendSpecialKeys) {
+          pty.sendText(content);
+        } else {
+          pty.write('\x1b[200~' + content + '\x1b[201~');
+        }
+      } catch {
+        return { submitted: false };
+      }
+
+      await delay(submitDelay);
+      if (!trySendEnter()) return { submitted: false };
+
+      if (!existsSync(logsPath) && beforeCount === 0) {
+        if (await waitForLogsAppend(logsPath, beforeCount, prefix, 1200)) {
+          return undefined;
+        }
+        if (!existsSync(logsPath)) {
+          return undefined;
+        }
+      }
+
+      for (let attempt = 0; attempt < 3; attempt++) {
+        if (await waitForLogsAppend(logsPath, beforeCount, prefix, 800)) {
+          return undefined;
+        }
+        if (!trySendEnter()) return { submitted: false };
+      }
+      if (await waitForLogsAppend(logsPath, beforeCount, prefix, 800)) {
+        return undefined;
+      }
+
+      const recheck = (): boolean => logsContainNewUserMessage(logsPath, beforeCount, prefix);
+      return { submitted: false, recheck };
+    },
+
+    completionPattern: undefined,
+    readyPattern: /Type your message|Action Required/,
+    systemHints: BOTMUX_SHELL_HINTS,
+    altScreen: true,
+    skillsDir: '~/.ace/skills',
+    modelChoices: ['openai/gpt-5.5', 'openai/gpt-4.1'],
+  };
+}
+
+export const create = createAceAdapter;

--- a/src/adapters/cli/ace.ts
+++ b/src/adapters/cli/ace.ts
@@ -102,7 +102,14 @@ export function createAceAdapter(pathOverride?: string): CliAdapter {
 
   return {
     id: 'ace',
-    authPaths: ['~/.ace/oauth_creds.json'],
+    // Keep bytedcli SSO + moderation-cli cookie cache on the REAL host (not the
+    // home overlay) so `bytedcli auth login --session` and moderation-cli
+    // helpers can reuse the devbox browser/Feishu session inside the sandbox.
+    authPaths: [
+      '~/.ace/oauth_creds.json',
+      '~/.local/share/bytedcli',
+      '~/.cache/moderation-cli',
+    ],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ workingDir, initialPrompt, model, disableCliBypass }) {

--- a/src/adapters/cli/ace.ts
+++ b/src/adapters/cli/ace.ts
@@ -68,6 +68,29 @@ function submitPrefix(content: string): string {
   return content.slice(0, 40);
 }
 
+/** Match Ace TUI InputPrompt large-paste collapse (text-buffer.ts). */
+export const ACE_LARGE_PASTE_LINE_THRESHOLD = 5;
+export const ACE_LARGE_PASTE_CHAR_THRESHOLD = 500;
+
+/** Ace collapses pastes above these limits to `[Pasted Text: N lines]`. */
+export function isAceLargePaste(content: string): boolean {
+  const lineCount = content.split('\n').length;
+  return lineCount > ACE_LARGE_PASTE_LINE_THRESHOLD
+    || content.length > ACE_LARGE_PASTE_CHAR_THRESHOLD;
+}
+
+/** Delay after paste before the first Enter — longer when Ace will show a paste placeholder. */
+export function acePasteSettleDelayMs(content: string, hasImagePath: boolean): number {
+  const base = hasImagePath ? 800 : 500;
+  if (!isAceLargePaste(content)) return base;
+  const lineCount = content.split('\n').length;
+  const extraLines = Math.max(0, lineCount - ACE_LARGE_PASTE_LINE_THRESHOLD);
+  return Math.min(2500, base + 400 + extraLines * 35);
+}
+
+/** Extra beat between first and second Enter on large pastes. */
+const ACE_LARGE_PASTE_SECOND_ENTER_DELAY_MS = 500;
+
 export function createAceAdapter(pathOverride?: string): CliAdapter {
   const rawBin = pathOverride ?? 'ace';
   let cachedBin: string | undefined;
@@ -109,7 +132,8 @@ export function createAceAdapter(pathOverride?: string): CliAdapter {
       const beforeCount = readUserMessages(logsPath).length;
       const prefix = submitPrefix(content);
       const hasImagePath = /\.(jpe?g|png|gif|webp|svg|bmp)\b/i.test(content);
-      const submitDelay = hasImagePath ? 800 : 500;
+      const largePaste = isAceLargePaste(content);
+      const submitDelay = acePasteSettleDelayMs(content, hasImagePath);
 
       const trySendEnter = (): boolean => {
         try {
@@ -135,6 +159,17 @@ export function createAceAdapter(pathOverride?: string): CliAdapter {
 
       await delay(submitDelay);
       if (!trySendEnter()) return { submitted: false };
+
+      // Large botmux-wrapped prompts collapse to `[Pasted Text: N lines]` in Ace.
+      // tmux paste + a single quick Enter often strands the message in the input
+      // box; a second Enter after extra settle time commits reliably.
+      if (largePaste) {
+        await delay(ACE_LARGE_PASTE_SECOND_ENTER_DELAY_MS);
+        if (!logsContainNewUserMessage(logsPath, beforeCount, prefix)) {
+          if (!trySendEnter()) return { submitted: false };
+          await delay(200);
+        }
+      }
 
       if (!existsSync(logsPath) && beforeCount === 0) {
         if (await waitForLogsAppend(logsPath, beforeCount, prefix, 1200)) {

--- a/src/adapters/cli/registry.ts
+++ b/src/adapters/cli/registry.ts
@@ -22,6 +22,7 @@ import { createTraexAdapter } from './traex.js';
 import { createPiAdapter } from './pi.js';
 import { createCopilotAdapter } from './copilot.js';
 import { createOhMyPiAdapter } from './oh-my-pi.js';
+import { createAceAdapter } from './ace.js';
 
 /** Resolve a command name to its absolute path via shell `which`.
  *  Tries login shell first (-lc), then interactive shell (-ic) for tools
@@ -104,7 +105,7 @@ export async function createCliAdapter(id: CliId, pathOverride?: string): Promis
   return adapter;
 }
 
-export { createClaudeCodeAdapter, createSeedAdapter, createRelayAdapter, createAidenAdapter, createCocoAdapter, createCodexAdapter, createCodexAppAdapter, createCursorAdapter, createGeminiAdapter, createOpenCodeAdapter, createAntigravityAdapter, createMtrAdapter, createHermesAdapter, createMiraAdapter, createMirAdapter, createTraexAdapter, createPiAdapter, createCopilotAdapter, createOhMyPiAdapter };
+export { createClaudeCodeAdapter, createSeedAdapter, createRelayAdapter, createAidenAdapter, createCocoAdapter, createCodexAdapter, createCodexAppAdapter, createCursorAdapter, createGeminiAdapter, createOpenCodeAdapter, createAntigravityAdapter, createMtrAdapter, createHermesAdapter, createMiraAdapter, createMirAdapter, createTraexAdapter, createPiAdapter, createCopilotAdapter, createOhMyPiAdapter, createAceAdapter };
 
 /** Synchronous version for use in worker process. */
 export function createCliAdapterSync(id: CliId, pathOverride?: string): CliAdapter {
@@ -128,6 +129,7 @@ export function createCliAdapterSync(id: CliId, pathOverride?: string): CliAdapt
     case 'pi': return createPiAdapter(pathOverride);
     case 'copilot': return createCopilotAdapter(pathOverride);
     case 'oh-my-pi': return createOhMyPiAdapter(pathOverride);
+    case 'ace': return createAceAdapter(pathOverride);
     default: throw new Error(`Unknown CLI adapter: ${id}`);
   }
 }

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -343,4 +343,4 @@ export interface CliAdapter {
   readonly defaultPassthroughCommands?: readonly string[];
 }
 
-export type CliId = 'claude-code' | 'seed' | 'relay' | 'aiden' | 'coco' | 'codex' | 'codex-app' | 'cursor' | 'gemini' | 'opencode' | 'antigravity' | 'mtr' | 'hermes' | 'mira' | 'mir' | 'traex' | 'pi' | 'copilot' | 'oh-my-pi';
+export type CliId = 'claude-code' | 'seed' | 'relay' | 'aiden' | 'coco' | 'codex' | 'codex-app' | 'cursor' | 'gemini' | 'opencode' | 'antigravity' | 'mtr' | 'hermes' | 'mira' | 'mir' | 'traex' | 'pi' | 'copilot' | 'oh-my-pi' | 'ace';

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -252,6 +252,12 @@ export interface BotConfig {
    */
   autoStartOnGroupJoinPrompt?: string;
   /**
+   * 主动开工 — 场景① optional chat-name gate. When set, only chats whose
+   * display name matches this regex auto-start on join (D7 allowedUser
+   * membership is skipped). When unset, only the D7 allowedUser gate applies.
+   */
+  autoStartOnGroupJoinChatNameRegex?: string;
+  /**
    * 主动开工 — 场景②. When true, in a 话题群 (topic mode) every new topic's first
    * message auto-starts a session even without an @mention (the default role +
    * the user's first message form the prompt). No effect in regular groups.
@@ -813,6 +819,9 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
       // so an empty string doesn't linger in bots.json.
       autoStartOnGroupJoinPrompt: typeof entry.autoStartOnGroupJoinPrompt === 'string' && entry.autoStartOnGroupJoinPrompt.trim()
         ? entry.autoStartOnGroupJoinPrompt
+        : undefined,
+      autoStartOnGroupJoinChatNameRegex: typeof entry.autoStartOnGroupJoinChatNameRegex === 'string' && entry.autoStartOnGroupJoinChatNameRegex.trim()
+        ? entry.autoStartOnGroupJoinChatNameRegex.trim()
         : undefined,
       autoStartOnNewTopic: entry.autoStartOnNewTopic === true || undefined,
       // Per-bot regular-group default mode. Only 'new-topic' | 'shared' are

--- a/src/core/auto-start.ts
+++ b/src/core/auto-start.ts
@@ -84,6 +84,24 @@ export function resolveGroupJoinPrompt(configured: string | undefined): string {
 }
 
 /**
+ * 场景① optional gate: does the chat display name match the configured regex?
+ * Returns false when the name is blank, the pattern is blank, or the regex is invalid.
+ */
+export function chatNameMatchesAutoStartRegex(
+  chatName: string | null | undefined,
+  pattern: string | undefined,
+): boolean {
+  const name = (chatName ?? '').trim();
+  const raw = (pattern ?? '').trim();
+  if (!name || !raw) return false;
+  try {
+    return new RegExp(raw).test(name);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * 场景①: D7 gate with retry — wait for an allowedUser to appear in the chat.
  *
  * Alarm/oncall platforms that auto-create incident chats (e.g. ByteDance

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -224,15 +224,85 @@ export function renderBufferedSenderBlock(sender: ResolvedSender | undefined, cl
   return note ? `${tag}\n${note}` : tag;
 }
 
-export function formatAttachmentsHint(attachments?: LarkAttachment[], locale?: Locale): string {
+/** CLIs whose @path handler inlines images into the first user turn (Ace vision). */
+export function supportsInlineVisionAttachments(cliId?: CliId): boolean {
+  return cliId === 'ace';
+}
+
+function atPathRef(filePath: string): string {
+  return /[\s]/.test(filePath) ? `@"${filePath}"` : `@${filePath}`;
+}
+
+/**
+ * Replace `[图片 N]` placeholders (or append) with Ace @path refs so handleAtCommand
+ * inlines pixels on the first turn — no Read-tool round trip.
+ */
+export function inlineImageAttachmentsInMessage(message: string, attachments: LarkAttachment[]): string {
+  const images = attachments.filter(a => a.type === 'image');
+  if (images.length === 0) return message;
+
+  let result = message;
+  const appended: string[] = [];
+
+  images.forEach((a, idx) => {
+    const n = idx + 1;
+    const ref = atPathRef(a.path);
+    const numbered = [`[图片 ${n}]`, `[Image ${n}]`, `[image ${n}]`];
+    let replaced = false;
+    for (const pat of numbered) {
+      if (result.includes(pat)) {
+        result = result.replace(pat, ref);
+        replaced = true;
+        break;
+      }
+    }
+    if (!replaced && images.length === 1 && result.includes('[图片]') && !result.includes('[图片 1]')) {
+      result = result.replace('[图片]', ref);
+      replaced = true;
+    }
+    if (!replaced) appended.push(ref);
+  });
+
+  if (appended.length > 0) {
+    result = `${result.trimEnd()}\n\n${appended.join('\n')}`;
+  }
+  return result;
+}
+
+export function formatAttachmentsHint(
+  attachments?: LarkAttachment[],
+  locale?: Locale,
+  cliId?: CliId,
+): string {
   if (!attachments || attachments.length === 0) return '';
+
+  const inlineVision = supportsInlineVisionAttachments(cliId);
+  const listed = inlineVision ? attachments.filter(a => a.type !== 'image') : attachments;
+  if (listed.length === 0) return '';
+
   let imgN = 0, fileN = 0;
-  const items = attachments.map(a => {
+  const items = listed.map(a => {
     const tag = a.type === 'image' ? 'image' : 'file';
     const n = a.type === 'image' ? ++imgN : ++fileN;
     return `  <${tag} n="${n}" path="${xmlEscape(a.path)}" />`;
   });
-  return `<attachments hint="${xmlEscape(t('ai.attach.hint', undefined, locale))}">\n${items.join('\n')}\n</attachments>`;
+  const hintKey = inlineVision ? 'ai.attach.hint.files_only' : 'ai.attach.hint';
+  return `<attachments hint="${xmlEscape(t(hintKey, undefined, locale))}">\n${items.join('\n')}\n</attachments>`;
+}
+
+/** Enrich raw user text with inline vision refs + attachment XML (repo-select buffer). */
+export function enrichContentWithAttachments(
+  content: string,
+  attachments: LarkAttachment[] | undefined,
+  locale: Locale | undefined,
+  cliId?: CliId,
+): string {
+  if (!attachments || attachments.length === 0) return content;
+  let body = supportsInlineVisionAttachments(cliId)
+    ? inlineImageAttachmentsInMessage(content, attachments)
+    : content;
+  const hint = formatAttachmentsHint(attachments, locale, cliId);
+  return hint ? `${body}${hint}` : body;
 }
 
 function renderRoleContextBlock(larkAppId: string | undefined, chatId: string | undefined): string {
@@ -311,9 +381,12 @@ export function buildNewTopicPrompt(
   // block per message: the deferred spawn is conceptually one opening turn, so
   // one block reads cleanly and the surrounding metadata envelope
   // (sender/mention) isn't repeated for every buffered line.
-  const mergedMessage = followUps && followUps.length > 0
+  let mergedMessage = followUps && followUps.length > 0
     ? [userMessage, ...followUps].join('\n\n')
     : userMessage;
+  if (attachments && attachments.length > 0 && supportsInlineVisionAttachments(cliId)) {
+    mergedMessage = inlineImageAttachmentsInMessage(mergedMessage, attachments);
+  }
   const userBlock = `<user_message>\n${mergedMessage}\n</user_message>`;
   const parts: string[] = [];
 
@@ -335,7 +408,7 @@ export function buildNewTopicPrompt(
   const senderNote = renderCursorSenderNote(cliId, !!senderBlock, locale);
   if (senderNote) parts.push(senderNote);
 
-  const attachHint = formatAttachmentsHint(attachments, locale);
+  const attachHint = formatAttachmentsHint(attachments, locale, cliId);
   if (attachHint) parts.push(attachHint);
 
   // CLIs with injectsSessionContext (Claude Code) get Lark routing/identity
@@ -374,7 +447,11 @@ export function buildFollowUpContent(
     parts.push(`<botmux_reminder>${t('ai.followup.reminder', undefined, opts?.locale)}</botmux_reminder>`);
   }
 
-  parts.push(`<user_message>\n${content}\n</user_message>`);
+  let userBody = content;
+  if (opts?.attachments && opts.attachments.length > 0 && supportsInlineVisionAttachments(opts.cliId)) {
+    userBody = inlineImageAttachmentsInMessage(userBody, opts.attachments);
+  }
+  parts.push(`<user_message>\n${userBody}\n</user_message>`);
 
   const senderBlock = renderSenderTag(opts?.sender);
   if (senderBlock) parts.push(senderBlock);
@@ -383,7 +460,7 @@ export function buildFollowUpContent(
   if (senderNote) parts.push(senderNote);
 
   const attachHint = opts?.attachments && opts.attachments.length > 0
-    ? formatAttachmentsHint(opts.attachments, opts.locale)
+    ? formatAttachmentsHint(opts.attachments, opts.locale, opts.cliId)
     : '';
   if (attachHint) parts.push(attachHint);
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -77,7 +77,7 @@ import {
   getProjectScanDirs,
   expandHome,
   downloadResources,
-  formatAttachmentsHint,
+  enrichContentWithAttachments,
   buildNewTopicPrompt,
   buildFollowUpContent,
   buildBridgeInputContent,
@@ -3074,7 +3074,12 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
   if (ds?.pendingRepo) {
     // Enrich content with attachment hints and mention metadata (same as normal send)
     let enriched = attachments.length > 0
-      ? `${promptContent}${formatAttachmentsHint(attachments)}`
+      ? enrichContentWithAttachments(
+        promptContent,
+        attachments,
+        localeForBot(larkAppId),
+        getBot(larkAppId).config.cliId,
+      )
       : promptContent;
     if (parsed.mentions && parsed.mentions.length > 0) {
       const mentionLines = parsed.mentions.map(m => {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -14,8 +14,8 @@ import { botmuxWrapperFiles } from './core/botmux-wrapper.js';
 import { startMaintenance, stopMaintenance } from './core/maintenance.js';
 import { sendRestartReportIfPending } from './core/restart-report.js';
 import { statSync } from 'node:fs';
-import { getChatMode, listChatMemberOpenIds, replyMessage, resolveAllowedUsersWithMap, sendMessage, sendUserMessage, updateMessage } from './im/lark/client.js';
-import { resolveGroupJoinPrompt, waitForAllowedUserInChat } from './core/auto-start.js';
+import { getChatMode, getChatName, listChatMemberOpenIds, replyMessage, resolveAllowedUsersWithMap, sendMessage, sendUserMessage, updateMessage } from './im/lark/client.js';
+import { chatNameMatchesAutoStartRegex, resolveGroupJoinPrompt, waitForAllowedUserInChat } from './core/auto-start.js';
 import { loadBotConfigs, registerBot, getBot, getAllBots, findOncallChatForAnyBot, type BotState, type OncallChat } from './bot-registry.js';
 import * as sessionStore from './services/session-store.js';
 import * as chatFirstSeenStore from './services/chat-first-seen-store.js';
@@ -2532,8 +2532,9 @@ async function warnGroupJoinScopeOnce(larkAppId: string, detail: string): Promis
 
 /**
  * 主动开工 — 场景①: the bot was added to a chat. Auto-start a session when
- * (1) the bot opted in via `autoStartOnGroupJoin`, and (2) at least one of its
- * allowedUsers is a member of the chat (D7). Working dir per D6: the bot's
+ * (1) the bot opted in via `autoStartOnGroupJoin`, and (2) either the chat
+ * display name matches `autoStartOnGroupJoinChatNameRegex` (name gate), or
+ * at least one allowedUser is a member (D7). Working dir per D6: the bot's
  * default working dir, else degrade to the repo-selection card. The first-turn
  * prompt is the configured prompt, or empty (the role/identity envelope still
  * makes it a non-empty CLI turn — the bot reads the group context itself, D8).
@@ -2566,28 +2567,44 @@ async function handleBotAdded(chatId: string, operatorOpenId: string | undefined
   if (priorAnchorKey) groupJoinAnchorByChat.delete(chatLiveKey); // stale entry, will re-register below
   autoStartJoinInFlight.add(lockKey);
   try {
-    // D7 gate: an allowedUser must be a member of the chat. Alarm/oncall
-    // platforms (e.g. Nexus) create the chat, add bots first and the human
-    // members moments later — a one-shot membership snapshot here races
-    // against that and loses, so re-check with backoff before giving up
-    // (the in-flight lock above keeps duplicate bot.added events deduped
-    // while we wait).
-    let hasAllowedUser: boolean;
-    try {
-      hasAllowedUser = await waitForAllowedUserInChat({
-        listMembers: () => listChatMemberOpenIds(larkAppId, chatId),
-        allowedUsers: bot.resolvedAllowedUsers,
-        onRetry: (attempt, delayMs) =>
-          logger.info(`[auto-start:入群] ${chatId.substring(0, 12)} 暂无 allowedUser 成员，${delayMs}ms 后重查（第 ${attempt} 次）`),
-      });
-    } catch (err: any) {
-      logger.warn(`[auto-start:入群] ${chatId.substring(0, 12)} 拉群成员失败：${err?.message ?? err}`);
-      await warnGroupJoinScopeOnce(larkAppId, String(err?.message ?? err));
-      return;
-    }
-    if (!hasAllowedUser) {
-      logger.info(`[auto-start:入群] ${chatId.substring(0, 12)} 群内无 allowedUser 成员，忽略`);
-      return;
+    const nameRegex = botCfg.autoStartOnGroupJoinChatNameRegex;
+    if (nameRegex) {
+      const chatName = await getChatName(larkAppId, chatId);
+      if (!chatNameMatchesAutoStartRegex(chatName, nameRegex)) {
+        logger.info(
+          `[auto-start:入群] ${chatId.substring(0, 12)} 群名未命中 regex，忽略`
+          + (chatName ? `（${chatName.substring(0, 60)}）` : '（群名不可用）'),
+        );
+        return;
+      }
+      logger.info(
+        `[auto-start:入群] ${chatId.substring(0, 12)} 群名命中 regex，开工`
+        + (chatName ? `（${chatName.substring(0, 60)}）` : ''),
+      );
+    } else {
+      // D7 gate: an allowedUser must be a member of the chat. Alarm/oncall
+      // platforms (e.g. Nexus) create the chat, add bots first and the human
+      // members moments later — a one-shot membership snapshot here races
+      // against that and loses, so re-check with backoff before giving up
+      // (the in-flight lock above keeps duplicate bot.added events deduped
+      // while we wait).
+      let hasAllowedUser: boolean;
+      try {
+        hasAllowedUser = await waitForAllowedUserInChat({
+          listMembers: () => listChatMemberOpenIds(larkAppId, chatId),
+          allowedUsers: bot.resolvedAllowedUsers,
+          onRetry: (attempt, delayMs) =>
+            logger.info(`[auto-start:入群] ${chatId.substring(0, 12)} 暂无 allowedUser 成员，${delayMs}ms 后重查（第 ${attempt} 次）`),
+        });
+      } catch (err: any) {
+        logger.warn(`[auto-start:入群] ${chatId.substring(0, 12)} 拉群成员失败：${err?.message ?? err}`);
+        await warnGroupJoinScopeOnce(larkAppId, String(err?.message ?? err));
+        return;
+      }
+      if (!hasAllowedUser) {
+        logger.info(`[auto-start:入群] ${chatId.substring(0, 12)} 群内无 allowedUser 成员，忽略`);
+        return;
+      }
     }
 
     const chatType: 'group' = 'group';

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -498,6 +498,7 @@ export const messages: Record<string, string> = {
 
   // ─── AI prompt blocks (session-manager) ──────────────────────────────────
   'ai.attach.hint': 'Read these with the Read tool. The index matches the [image N] / [file N] placeholders in the body.',
+  'ai.attach.hint.files_only': 'Non-image files below — use the Read tool. Images were attached inline via @path for vision.',
   'ai.identity.short_routing': 'Reminder: handing work off to another bot REQUIRES `botmux send --mention <their open_id>` — without it, the other bot is not triggered.',
   'ai.available_bots.hint': 'To hand work off to a bot listed here you MUST --mention its open_id (botmux send --mention ou_xxx ...). Without --mention the other bot receives nothing.',
   'ai.followup.reminder': 'Replies must go via `botmux send` — terminal output does not reach the user.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -501,6 +501,7 @@ export const messages: Record<string, string> = {
 
   // ─── AI prompt blocks (session-manager) ──────────────────────────────────
   'ai.attach.hint': '使用 Read 工具查看，序号与正文中的 [图片 N] / [文件 N] 占位符对应',
+  'ai.attach.hint.files_only': '以下为非图片附件，请用 Read 工具查看。图片已通过 @路径 内联，可直接视觉理解。',
   'ai.identity.short_routing': '提醒：让别的 bot 接力干活必须 `botmux send --mention <对方 open_id>`，否则对方 bot 不会被触发。',
   'ai.available_bots.hint': '让这里的某个 bot 接力干活必须 --mention 它的 open_id（botmux send --mention ou_xxx ...），不 --mention 对方 bot 完全收不到消息',
   'ai.followup.reminder': '回复必须 botmux send，终端输出用户看不到',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -268,14 +268,6 @@ export function buildSessionCard(
       multi_url: terminalMultiUrl(terminalUrl),
     },
   ];
-  if (!showManageButtons) {
-    actions.push({
-      tag: 'button',
-      text: { tag: 'plain_text', content: t('card.btn.get_write_link', undefined, locale) },
-      type: 'default',
-      value: { action: 'get_write_link', ...actionBase },
-    });
-  }
   if (showManageButtons && !adoptMode) {
     actions.push({
       tag: 'button',
@@ -754,12 +746,6 @@ export function buildStreamingCard(
       value: { action: 'retry_last_task', ...actionBase },
     });
   }
-  headerActions.push({
-    tag: 'button',
-    text: { tag: 'plain_text', content: t('card.btn.get_write_link', undefined, locale) },
-    type: 'default',
-    value: { action: 'get_write_link', ...actionBase },
-  });
   if (adoptMode) {
     if (showTakeover) {
       headerActions.push({
@@ -909,12 +895,6 @@ export function buildPrivateSnapshotCard(
         text: { tag: 'plain_text', content: t('card.btn.open_terminal', undefined, locale) },
         type: 'primary',
         multi_url: terminalMultiUrl(terminalUrl),
-      },
-      {
-        tag: 'button',
-        text: { tag: 'plain_text', content: t('card.btn.get_write_link', undefined, locale) },
-        type: 'default',
-        value: { action: 'get_write_link', ...actionBase },
       },
       {
         tag: 'button',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -194,6 +194,7 @@ const cliDisplayNames: Record<CliId, string> = {
   'pi': 'Pi',
   'copilot': 'Copilot',
   'oh-my-pi': 'Oh My Pi',
+  'ace': 'Ace',
 };
 
 export function getCliDisplayName(cliId: CliId): string {

--- a/src/setup/bot-config-editor.ts
+++ b/src/setup/bot-config-editor.ts
@@ -20,6 +20,7 @@ export const CLI_ID_CHOICES: Record<string, CliId> = {
   '17': 'oh-my-pi',
   '18': 'relay',
   '19': 'mir',
+  '20': 'ace',
 };
 
 const VALID_CLI_IDS: ReadonlySet<string> = new Set(Object.values(CLI_ID_CHOICES));
@@ -49,6 +50,7 @@ const CLI_DISPLAY_LABELS: Record<CliId, string> = {
   'oh-my-pi': 'Oh My Pi',
   'relay': 'Relay',
   'mir': 'Mir CLI',
+  'ace': 'Ace',
 };
 
 /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -159,7 +159,7 @@ function ensureZellijAttachConfig(): string {
 
 let sessionId = '';
 let lastInitConfig: Extract<DaemonToWorker, { type: 'init' }> | null = null;
-const CLI_DISPLAY_NAMES: Record<string, string> = { 'claude-code': 'Claude', seed: 'Seed', relay: 'Relay', aiden: 'Aiden', coco: 'CoCo', codex: 'Codex', 'codex-app': 'Codex App', cursor: 'Cursor', gemini: 'Gemini', opencode: 'OpenCode', antigravity: 'Antigravity', mtr: 'MTR', hermes: 'Hermes', mira: 'Mira', mir: 'Mir CLI', traex: 'TRAE', pi: 'Pi', copilot: 'Copilot', 'oh-my-pi': 'Oh My Pi' };
+const CLI_DISPLAY_NAMES: Record<string, string> = { 'claude-code': 'Claude', seed: 'Seed', relay: 'Relay', aiden: 'Aiden', coco: 'CoCo', codex: 'Codex', 'codex-app': 'Codex App', cursor: 'Cursor', gemini: 'Gemini', opencode: 'OpenCode', antigravity: 'Antigravity', mtr: 'MTR', hermes: 'Hermes', mira: 'Mira', mir: 'Mir CLI', traex: 'TRAE', pi: 'Pi', copilot: 'Copilot', 'oh-my-pi': 'Oh My Pi', ace: 'Ace' };
 function cliName(): string { return CLI_DISPLAY_NAMES[lastInitConfig?.cliId ?? ''] ?? 'CLI'; }
 let isPromptReady = false;
 /** Mutex for async flushPending — prevents concurrent flush loops. */

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5028,7 +5028,17 @@ process.on('message', async (raw: unknown) => {
       // process would never actually restart. destroySession() tears the session
       // down so the respawn starts a fresh CLI. (PTY has no destroySession, so
       // the ?. no-ops and killCli()'s kill() does the teardown.)
+      // onExit nulls backend before the daemon's restart message arrives, so
+      // destroySession() is often a no-op — kill the tmux session by name so
+      // spawnCli doesn't reattach to a dead pane and crash on pipe-pane.
       backend?.destroySession?.();
+      if (lastInitConfig?.backendType === 'tmux') {
+        const stale = TmuxBackend.sessionName(lastInitConfig.sessionId);
+        if (TmuxBackend.hasSession(stale)) {
+          TmuxBackend.killSession(stale);
+          log(`Restart: killed stale tmux session ${stale}`);
+        }
+      }
       killCli();
       awaitingFirstPrompt = true;
       setTimeout(() => {

--- a/test/auto-start.test.ts
+++ b/test/auto-start.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   chatHasAllowedUser,
+  chatNameMatchesAutoStartRegex,
   resolveGroupJoinPrompt,
   shouldAutoStartOnNewTopic,
   waitForAllowedUserInChat,
@@ -75,6 +76,35 @@ describe('resolveGroupJoinPrompt (场景① D8)', () => {
 
   it('returns empty string for a blank prompt', () => {
     expect(resolveGroupJoinPrompt('   ')).toBe('');
+  });
+});
+
+describe('chatNameMatchesAutoStartRegex (场景① 群名 gate)', () => {
+  const tcsRegex = '(TCS/OPUS TX / #|TCS / #|TCS_EU)';
+
+  it('matches TCS transfer group names', () => {
+    expect(
+      chatNameMatchesAutoStartRegex(
+        '[Transfer] S2 / TCS / #40644053 / malabonga.9 / Domain: UPL I...',
+        tcsRegex,
+      ),
+    ).toBe(true);
+    expect(
+      chatNameMatchesAutoStartRegex(
+        '[Transfer] TCS_EU / #7787 / mootez.sahbani / The video is not...',
+        tcsRegex,
+      ),
+    ).toBe(true);
+  });
+
+  it('does not match unrelated group names', () => {
+    expect(chatNameMatchesAutoStartRegex('Botmux-Ace-B2B-Test', tcsRegex)).toBe(false);
+  });
+
+  it('returns false for empty name, blank regex, or invalid regex', () => {
+    expect(chatNameMatchesAutoStartRegex(null, tcsRegex)).toBe(false);
+    expect(chatNameMatchesAutoStartRegex('TCS / #', '')).toBe(false);
+    expect(chatNameMatchesAutoStartRegex('foo', '(unclosed')).toBe(false);
   });
 });
 

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -36,13 +36,14 @@ import { createTraexAdapter } from '../src/adapters/cli/traex.js';
 import { createPiAdapter } from '../src/adapters/cli/pi.js';
 import { createCopilotAdapter } from '../src/adapters/cli/copilot.js';
 import { createOhMyPiAdapter } from '../src/adapters/cli/oh-my-pi.js';
+import { createAceAdapter } from '../src/adapters/cli/ace.js';
 import type { CliAdapter, CliId } from '../src/adapters/cli/types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-const ALL_CLI_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'codex-app', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes', 'mira', 'mir', 'traex', 'pi', 'copilot', 'oh-my-pi'];
+const ALL_CLI_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'codex-app', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes', 'mira', 'mir', 'traex', 'pi', 'copilot', 'oh-my-pi', 'ace'];
 
 // ---------------------------------------------------------------------------
 // 1. Factory: createCliAdapterSync
@@ -75,9 +76,9 @@ describe('createCliAdapterSync factory', () => {
 
 describe('lazy binary resolution', () => {
   // Direct CLI adapters resolve their actual executable lazily. Runner-backed
-  // adapters (codex-app/mira) intentionally use process.execPath and are covered
+  // adapters (codex-app/mira/mir) intentionally use process.execPath and are covered
   // by their own buildArgs tests below.
-  const DIRECT_CLI_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'cursor', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes', 'traex', 'copilot'];
+  const DIRECT_CLI_IDS: CliId[] = ['claude-code', 'seed', 'aiden', 'coco', 'codex', 'cursor', 'gemini', 'opencode', 'antigravity', 'mtr', 'hermes', 'traex', 'copilot', 'ace'];
 
   it.each(DIRECT_CLI_IDS)('"%s": construction does not probe; first resolvedBin read does', async (id) => {
     const { spawnSync } = await import('node:child_process');
@@ -567,6 +568,45 @@ describe('gemini buildArgs', () => {
   it('does not include session id', () => {
     const args = adapter.buildArgs({ sessionId: 'sess-5', resume: false });
     expect(args).not.toContain('sess-5');
+  });
+});
+
+describe('ace buildArgs', () => {
+  const adapter = createAceAdapter('/usr/bin/ace');
+
+  it('basic args include -y', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-ace', resume: false });
+    expect(args).toContain('-y');
+  });
+
+  it('omits -y when disableCliBypass is true while preserving initial prompt', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-ace', resume: false, initialPrompt: 'do something', disableCliBypass: true });
+    expect(args).not.toContain('-y');
+    expect(args).toEqual(['do something']);
+  });
+
+  it('passes initialPrompt as positional arg', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-ace', resume: false, initialPrompt: 'do something' });
+    expect(args.at(-1)).toBe('do something');
+  });
+
+  it('passesInitialPromptViaArgs is true', () => {
+    expect(adapter.passesInitialPromptViaArgs).toBe(true);
+  });
+
+  it('sets spawn env for model and office network', () => {
+    adapter.buildArgs({ sessionId: 'sess-ace', resume: false, model: 'openai/gpt-5.5', workingDir: '/tmp/ws' });
+    expect(adapter.spawnEnv).toEqual({
+      ACE_NETWORK_TYPE: 'office',
+      ACE_ACP_SINGLE_PROVIDER: '1',
+      AIDP_MODEL: 'openai/gpt-5.5',
+    });
+  });
+
+  it('does not include session id or resume', () => {
+    const args = adapter.buildArgs({ sessionId: 'sess-ace', resume: true });
+    expect(args).not.toContain('sess-ace');
+    expect(args).not.toContain('--resume');
   });
 });
 

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -37,6 +37,12 @@ import { createPiAdapter } from '../src/adapters/cli/pi.js';
 import { createCopilotAdapter } from '../src/adapters/cli/copilot.js';
 import { createOhMyPiAdapter } from '../src/adapters/cli/oh-my-pi.js';
 import { createAceAdapter } from '../src/adapters/cli/ace.js';
+import {
+  acePasteSettleDelayMs,
+  isAceLargePaste,
+  ACE_LARGE_PASTE_CHAR_THRESHOLD,
+  ACE_LARGE_PASTE_LINE_THRESHOLD,
+} from '../src/adapters/cli/ace.js';
 import type { CliAdapter, CliId } from '../src/adapters/cli/types.js';
 
 // ---------------------------------------------------------------------------
@@ -607,6 +613,23 @@ describe('ace buildArgs', () => {
     const args = adapter.buildArgs({ sessionId: 'sess-ace', resume: true });
     expect(args).not.toContain('sess-ace');
     expect(args).not.toContain('--resume');
+  });
+});
+
+describe('ace large paste submit timing', () => {
+  it('detects large paste by line and char thresholds', () => {
+    expect(isAceLargePaste('a\nb\nc\nd\ne')).toBe(false);
+    expect(isAceLargePaste('a\nb\nc\nd\ne\nf')).toBe(true);
+    expect(isAceLargePaste('x'.repeat(ACE_LARGE_PASTE_CHAR_THRESHOLD))).toBe(false);
+    expect(isAceLargePaste('x'.repeat(ACE_LARGE_PASTE_CHAR_THRESHOLD + 1))).toBe(true);
+  });
+
+  it('uses longer settle delay for large pastes', () => {
+    const small = acePasteSettleDelayMs('hello', false);
+    const large = acePasteSettleDelayMs(`${'<line>\n'.repeat(ACE_LARGE_PASTE_LINE_THRESHOLD + 10)}`, false);
+    expect(small).toBe(500);
+    expect(large).toBeGreaterThan(small);
+    expect(large).toBeLessThanOrEqual(2500);
   });
 });
 

--- a/test/prompt-builder.test.ts
+++ b/test/prompt-builder.test.ts
@@ -56,7 +56,7 @@ vi.mock('../src/core/worker-pool.js', () => ({
 
 // ─── Imports ──────────────────────────────────────────────────────────────
 
-import { buildNewTopicPrompt, buildFollowUpContent, buildReforkPrompt, renderSenderTag, renderCursorSenderNote, renderBufferedSenderBlock } from '../src/core/session-manager.js';
+import { buildNewTopicPrompt, buildFollowUpContent, buildReforkPrompt, renderSenderTag, renderCursorSenderNote, renderBufferedSenderBlock, inlineImageAttachmentsInMessage, formatAttachmentsHint } from '../src/core/session-manager.js';
 import type { DaemonSession } from '../src/core/types.js';
 
 // ─── Tests ────────────────────────────────────────────────────────────────
@@ -274,6 +274,57 @@ describe('buildFollowUpContent', () => {
   it('does NOT inject <sender_note> for cursor when there is no sender', () => {
     const content = buildFollowUpContent('hi', SESSION_ID, { cliId: 'cursor' });
     expect(content).not.toContain('<sender_note>');
+  });
+});
+
+// ─── Ace inline vision attachments (@path, no Read round-trip) ──────────────
+
+describe('Ace inline vision attachments', () => {
+  const SESSION_ID = 'ace-vision-session';
+  const imgPath = '/tmp/attachments/img_abc.jpg';
+
+  it('replaces [图片 N] with @path in user_message for ace', () => {
+    const attachments = [{ type: 'image' as const, path: imgPath, name: 'img_abc.jpg' }];
+    const prompt = buildNewTopicPrompt('请看 [图片 1]', SESSION_ID, 'ace', undefined, attachments);
+    expect(prompt).toContain(`<user_message>\n请看 @${imgPath}\n</user_message>`);
+    expect(prompt).not.toContain('<image ');
+    expect(prompt).not.toContain('<attachments');
+  });
+
+  it('keeps file attachments in XML for ace when images are inlined', () => {
+    const attachments = [
+      { type: 'image' as const, path: imgPath, name: 'img_abc.jpg' },
+      { type: 'file' as const, path: '/tmp/spec.pdf', name: 'spec.pdf' },
+    ];
+    const prompt = buildFollowUpContent('混合 [图片 1] [文件 1: spec.pdf]', SESSION_ID, {
+      cliId: 'ace',
+      attachments,
+    });
+    expect(prompt).toContain(`@${imgPath}`);
+    expect(prompt).toContain('<file n="1" path="/tmp/spec.pdf"');
+    expect(prompt).not.toContain('<image ');
+  });
+
+  it('does NOT inline images for non-ace CLIs', () => {
+    const attachments = [{ type: 'image' as const, path: imgPath, name: 'img_abc.jpg' }];
+    const prompt = buildNewTopicPrompt('[图片 1]', SESSION_ID, 'codex', undefined, attachments);
+    expect(prompt).toContain('[图片 1]');
+    expect(prompt).not.toContain(`@${imgPath}`);
+    expect(prompt).toContain('<image n="1"');
+  });
+
+  it('inlineImageAttachmentsInMessage appends @path when placeholder missing', () => {
+    const out = inlineImageAttachmentsInMessage('纯文字', [
+      { type: 'image', path: imgPath, name: 'img_abc.jpg' },
+    ]);
+    expect(out).toBe(`纯文字\n\n@${imgPath}`);
+  });
+
+  it('formatAttachmentsHint omits images for ace', () => {
+    const hint = formatAttachmentsHint([
+      { type: 'image', path: imgPath, name: 'img_abc.jpg' },
+    ], 'zh', 'ace');
+    expect(hint).toBe('');
   });
 });
 

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -11,11 +11,41 @@ import { describe, it, expect } from 'vitest';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { mkdtempSync, existsSync, writeFileSync, readFileSync, symlinkSync, rmSync, mkdirSync } from 'node:fs';
-import { buildSandboxArgs, reexposeRunBinArgs, validateRelayRequest, materializeOutboxFile, prepareSandbox, type SandboxPlan } from '../src/adapters/backend/sandbox.js';
+import { buildSandboxArgs, reexposeRunBinArgs, validateRelayRequest, materializeOutboxFile, prepareSandbox, resolveSandboxHome, resolveSandboxPath, type SandboxPlan } from '../src/adapters/backend/sandbox.js';
 import { createCodexAppAdapter } from '../src/adapters/cli/codex-app.js';
 import { computeSandboxDiff, applySandboxDiff, upperDir } from '../src/services/sandbox-land.js';
 
 const tmp = () => mkdtempSync(join(tmpdir(), 'sbx-'));
+
+describe('resolveSandboxHome', () => {
+  it('follows a symlinked home to its real directory', () => {
+    const root = tmp();
+    const realHome = join(root, 'real-home');
+    const linkHome = join(root, 'link-home');
+    mkdirSync(realHome);
+    symlinkSync(realHome, linkHome);
+    expect(resolveSandboxHome(linkHome)).toBe(realHome);
+  });
+
+  it('returns the input when realpath fails', () => {
+    expect(resolveSandboxHome('/nonexistent/home/path')).toBe('/nonexistent/home/path');
+  });
+});
+
+describe('resolveSandboxPath', () => {
+  it('follows symlinks for existing paths', () => {
+    const root = tmp();
+    const realDir = join(root, 'real-proj');
+    const linkDir = join(root, 'link-proj');
+    mkdirSync(realDir);
+    symlinkSync(realDir, linkDir);
+    expect(resolveSandboxPath(linkDir)).toBe(realDir);
+  });
+
+  it('returns the input when the path does not exist', () => {
+    expect(resolveSandboxPath('/nonexistent/project')).toBe('/nonexistent/project');
+  });
+});
 
 function plan(over: Partial<SandboxPlan> = {}): SandboxPlan {
   return {


### PR DESCRIPTION
## Summary
- Add `~/.local/share/bytedcli` and `~/.cache/moderation-cli` to ACE `authPaths` so sandboxed sessions read/write real host auth state instead of the isolated home overlay
- Expand `~` in `sandboxHidePaths` when resolving privacy masks
- Increase tmux `pipe-pane` attach timeout and kill stale tmux sessions on worker restart

## Why
In ACE sandbox, `bytedcli auth login --session --auto --yes` failed because bytedcli session writes went to the overlay copy and could not reuse the devbox browser/Feishu session.

## Test plan
- [ ] Restart botmux daemon
- [ ] Start a new ACE sandbox session
- [ ] Run `bytedcli --site i18n-tt auth login --session --auto --yes` inside sandbox
- [ ] Verify moderation-cli `add-queue-owner` can obtain cookies and execute