### PR TITLE
fix: isolate tmux paste buffers

### DIFF
--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -2,6 +2,7 @@ import * as pty from 'node-pty';
 import { execSync, execFileSync } from 'node:child_process';
 import { accessSync, constants as fsConstants } from 'node:fs';
 import { basename } from 'node:path';
+import { randomBytes } from 'node:crypto';
 import type { SessionBackend, SpawnOpts, SessionProbe } from './types.js';
 import { probeTmuxFunctional, tmuxEnv } from '../../setup/ensure-tmux.js';
 import { REDACTED_CHILD_ENV_KEYS } from '../../utils/child-env.js';
@@ -348,17 +349,33 @@ export class TmuxBackend implements SessionBackend {
    */
   pasteText(text: string): void {
     this.exitCopyModeIfNeeded();
-    execFileSync('tmux', ['load-buffer', '-'], {
-      input: text,
-      stdio: ['pipe', 'ignore', 'ignore'],
-      timeout: 5000,
-      env: tmuxEnv(),
-    });
-    execFileSync('tmux', ['paste-buffer', '-t', this.cmdTarget, '-d', '-p'], {
-      stdio: 'ignore',
-      timeout: 5000,
-      env: tmuxEnv(),
-    });
+    const bufferName = `botmux-${randomBytes(8).toString('hex')}`;
+    let loaded = false;
+    try {
+      execFileSync('tmux', ['load-buffer', '-b', bufferName, '-'], {
+        input: text,
+        stdio: ['pipe', 'ignore', 'ignore'],
+        timeout: 5000,
+        env: tmuxEnv(),
+      });
+      loaded = true;
+      execFileSync('tmux', ['paste-buffer', '-b', bufferName, '-t', this.cmdTarget, '-d', '-p'], {
+        stdio: 'ignore',
+        timeout: 5000,
+        env: tmuxEnv(),
+      });
+      loaded = false;
+    } finally {
+      if (loaded) {
+        try {
+          execFileSync('tmux', ['delete-buffer', '-b', bufferName], {
+            stdio: 'ignore',
+            timeout: 1000,
+            env: tmuxEnv(),
+          });
+        } catch { /* best-effort cleanup after a failed paste */ }
+      }
+    }
   }
 
   private exitCopyModeIfNeeded(): void {

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -264,18 +264,34 @@ export class TmuxPipeBackend implements SessionBackend {
   pasteText(text: string): void {
     if (this.exited) return;
     this.exitCopyModeIfNeeded();
+    const bufferName = `botmux-${randomBytes(8).toString('hex')}`;
     this.guardedSend('paste-buffer', () => {
-      execFileSync('tmux', ['load-buffer', '-'], {
-        input: text,
-        stdio: ['pipe', 'ignore', 'ignore'],
-        timeout: 5000,
-        env: tmuxEnv(),
-      });
-      execFileSync('tmux', ['paste-buffer', '-t', this.paneTarget, '-d', '-p'], {
-        stdio: 'ignore',
-        timeout: 5000,
-        env: tmuxEnv(),
-      });
+      let loaded = false;
+      try {
+        execFileSync('tmux', ['load-buffer', '-b', bufferName, '-'], {
+          input: text,
+          stdio: ['pipe', 'ignore', 'ignore'],
+          timeout: 5000,
+          env: tmuxEnv(),
+        });
+        loaded = true;
+        execFileSync('tmux', ['paste-buffer', '-b', bufferName, '-t', this.paneTarget, '-d', '-p'], {
+          stdio: 'ignore',
+          timeout: 5000,
+          env: tmuxEnv(),
+        });
+        loaded = false;
+      } finally {
+        if (loaded) {
+          try {
+            execFileSync('tmux', ['delete-buffer', '-b', bufferName], {
+              stdio: 'ignore',
+              timeout: 1000,
+              env: tmuxEnv(),
+            });
+          } catch { /* best-effort cleanup after a failed paste */ }
+        }
+      }
     });
   }
 

--- a/test/tmux-backend-input.test.ts
+++ b/test/tmux-backend-input.test.ts
@@ -148,6 +148,42 @@ describe('TmuxBackend.pasteText', () => {
     expect(calls[0].opts?.input).toBe(content);
     expect(calls[0].opts?.stdio).toEqual(['pipe', 'ignore', 'ignore']);
   });
+
+  // Each paste must use its OWN named buffer; reusing a name would reopen the
+  // cross-session race the named-buffer scheme exists to kill.
+  it('uses a fresh named buffer for each paste', () => {
+    const be = createBackend();
+    be.pasteText('one');
+    be.pasteText('two');
+
+    const loadCalls = getCalls().filter(c => c.args.includes('load-buffer'));
+    const firstBuffer = loadCalls[0].args[loadCalls[0].args.indexOf('-b') + 1];
+    const secondBuffer = loadCalls[1].args[loadCalls[1].args.indexOf('-b') + 1];
+    expect(firstBuffer).toMatch(/^botmux-[a-f0-9]{16}$/);
+    expect(secondBuffer).not.toBe(firstBuffer);
+  });
+
+  // load OK but paste-buffer throws: the named buffer was created but -d never
+  // ran, so the finally{} must delete it (else named buffers accumulate on the
+  // tmux server over repeated paste failures).
+  it('deletes the named buffer when paste-buffer fails', () => {
+    const be = createBackend();
+    mockedExecFileSync.mockImplementation(((_cmd: string, args?: string[]) => {
+      if (Array.isArray(args) && args.includes('paste-buffer')) throw new Error('no server running');
+      return '' as any;
+    }) as any);
+
+    // TmuxBackend.pasteText has no guardedSend wrapper, so the paste failure
+    // propagates — but the finally{} cleanup still runs first.
+    expect(() => be.pasteText('boom')).toThrow();
+
+    const calls = getCalls();
+    const loadArgs = calls.find(c => c.args.includes('load-buffer'))!.args;
+    const bufferName = loadArgs[loadArgs.indexOf('-b') + 1];
+    const deleteCall = calls.find(c => c.args.includes('delete-buffer'));
+    expect(deleteCall).toBeDefined();
+    expect(deleteCall!.args[deleteCall!.args.indexOf('-b') + 1]).toBe(bufferName);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/tmux-backend-input.test.ts
+++ b/test/tmux-backend-input.test.ts
@@ -114,10 +114,17 @@ describe('TmuxBackend.pasteText', () => {
     expect(calls[0].args).toContain('load-buffer');
     expect(calls[0].args).toContain('-');
     expect(calls[0].opts?.input).toBe('line1\n\nline2');
+    const bIdx = calls[0].args.indexOf('-b');
+    expect(bIdx).toBeGreaterThanOrEqual(0);
+    const bufferName = calls[0].args[bIdx + 1];
+    expect(bufferName).toMatch(/^botmux-[a-f0-9]{16}$/);
 
     // Call 2: paste-buffer to the session
     expect(calls[1].cmd).toBe('tmux');
     expect(calls[1].args).toContain('paste-buffer');
+    const pasteBIdx = calls[1].args.indexOf('-b');
+    expect(pasteBIdx).toBeGreaterThanOrEqual(0);
+    expect(calls[1].args[pasteBIdx + 1]).toBe(bufferName);
     expect(calls[1].args).toContain('-d');
   });
 

--- a/test/tmux-pipe-backend.test.ts
+++ b/test/tmux-pipe-backend.test.ts
@@ -123,11 +123,19 @@ describe('TmuxPipeBackend input addressing', () => {
     be.pasteText('multi\nline');
 
     const calls = getExecFileCalls();
-    expect(calls[0][1]).toContain('load-buffer');
+    const loadArgs = calls[0][1] as string[];
+    expect(loadArgs).toContain('load-buffer');
     expect((calls[0][2] as any).input).toBe('multi\nline');
+    const bIdx = loadArgs.indexOf('-b');
+    expect(bIdx).toBeGreaterThanOrEqual(0);
+    const bufferName = loadArgs[bIdx + 1];
+    expect(bufferName).toMatch(/^botmux-[a-f0-9]{16}$/);
 
     const pasteArgs = calls[1][1] as string[];
     expect(pasteArgs).toContain('paste-buffer');
+    const pasteBIdx = pasteArgs.indexOf('-b');
+    expect(pasteBIdx).toBeGreaterThanOrEqual(0);
+    expect(pasteArgs[pasteBIdx + 1]).toBe(bufferName);
     const tIdx = pasteArgs.indexOf('-t');
     expect(pasteArgs[tIdx + 1]).toBe('0:5.0');
     // -p forces bracketed-paste markers, REQUIRED for CoCo/Ink to treat the
@@ -136,6 +144,21 @@ describe('TmuxPipeBackend input addressing', () => {
     // the input box (replies-to-previous-message off-by-one). Regression guard
     // for PR #25, which added -p only to the unused TmuxBackend.
     expect(pasteArgs).toContain('-p');
+  });
+
+  it('uses a fresh named tmux buffer for each paste', () => {
+    const be = new TmuxPipeBackend('0:5.0');
+    be.spawn('', [], spawnOpts());
+    mockedExecFileSync.mockClear();
+    be.pasteText('one');
+    be.pasteText('two');
+
+    const loadCalls = getExecFileCalls()
+      .map(call => call[1] as string[])
+      .filter(args => args.includes('load-buffer'));
+    const firstBuffer = loadCalls[0][loadCalls[0].indexOf('-b') + 1];
+    const secondBuffer = loadCalls[1][loadCalls[1].indexOf('-b') + 1];
+    expect(firstBuffer).not.toBe(secondBuffer);
   });
 
   it('write delegates to sendText (literal send-keys)', () => {

--- a/test/tmux-pipe-backend.test.ts
+++ b/test/tmux-pipe-backend.test.ts
@@ -161,6 +161,28 @@ describe('TmuxPipeBackend input addressing', () => {
     expect(firstBuffer).not.toBe(secondBuffer);
   });
 
+  it('deletes the named buffer when paste-buffer fails (cleanup, no leak)', () => {
+    const be = new TmuxPipeBackend('0:5.0');
+    be.spawn('', [], spawnOpts());
+    mockedExecFileSync.mockClear();
+    // load-buffer succeeds, paste-buffer throws → the -d delete never runs, so
+    // the finally{} must delete the SAME named buffer. guardedSend swallows the
+    // failure (pane ALIVE via the default execSync mock) so pasteText must not throw.
+    mockedExecFileSync.mockImplementation(((_cmd: string, args?: string[]) => {
+      if (Array.isArray(args) && args.includes('paste-buffer')) throw new Error('no server running');
+      return '' as any;
+    }) as any);
+
+    expect(() => be.pasteText('boom')).not.toThrow();
+
+    const calls = getExecFileCalls().map(call => call[1] as string[]);
+    const loadArgs = calls.find(args => args.includes('load-buffer'))!;
+    const bufferName = loadArgs[loadArgs.indexOf('-b') + 1];
+    const deleteArgs = calls.find(args => args.includes('delete-buffer'));
+    expect(deleteArgs).toBeDefined();
+    expect(deleteArgs![deleteArgs!.indexOf('-b') + 1]).toBe(bufferName);
+  });
+
   it('write delegates to sendText (literal send-keys)', () => {
     const be = new TmuxPipeBackend('0:2.0');
     be.spawn('', [], spawnOpts());


### PR DESCRIPTION
## Summary
- use unique named tmux buffers for paste operations in both tmux backends
- delete named paste buffers after use to avoid cross-session default-buffer races
- add unit coverage for named-buffer behavior and fresh buffers per paste

## Verification
- corepack pnpm install --frozen-lockfile
- corepack pnpm vitest run --project unit test/tmux-pipe-backend.test.ts test/tmux-backend-input.test.ts test/tmux-copy-mode.test.ts
- corepack pnpm exec tsc --noEmit
- git diff --check