### PR TITLE
fix(adopt): /adopt liveness 单次探测失败误报断开 → pane 探测连续失败才断

### DIFF
--- a/src/adapters/backend/liveness-gate.ts
+++ b/src/adapters/backend/liveness-gate.ts
@@ -1,0 +1,54 @@
+/**
+ * LivenessGate — debounce transient liveness-probe failures for /adopt backends.
+ *
+ * The adopt observers (TmuxPipeBackend, ZellijObserveBackend) poll the external
+ * pane/CLI once per second to detect when the adopted target really exited. The
+ * original logic tore the session down on the FIRST failed probe, so any
+ * transient hiccup — a `tmux display-message` timeout, a busy zellij server, fd
+ * pressure (EMFILE) when many workers are live — produced a spurious
+ * "⏏ /adopt的 CLI 会话已断开" even though the CLI was still alive and still
+ * receiving messages.
+ *
+ * This gate counts CONSECUTIVE failures and only reports the target as gone once
+ * `threshold` failures pile up with no intervening success. Any single success
+ * resets the counter, so steady-state liveness never trips it. Callers should
+ * follow a tripped gate with one final authoritative re-probe (ideally with a
+ * more lenient timeout) before actually tearing down — see the backends.
+ */
+export class LivenessGate {
+  private failures = 0;
+
+  constructor(private readonly threshold: number) {
+    if (threshold < 1) throw new Error(`LivenessGate threshold must be >= 1, got ${threshold}`);
+  }
+
+  /**
+   * Feed one probe verdict.
+   * @returns true iff this verdict pushed the consecutive-failure count to the
+   *          threshold — the caller should now confirm + tear down. A success
+   *          resets the counter and always returns false.
+   */
+  record(alive: boolean): boolean {
+    if (alive) {
+      this.failures = 0;
+      return false;
+    }
+    this.failures += 1;
+    return this.failures >= this.threshold;
+  }
+
+  /** Consecutive failures observed so far (0 once a success resets it). */
+  get consecutiveFailures(): number {
+    return this.failures;
+  }
+
+  reset(): void {
+    this.failures = 0;
+  }
+}
+
+/** Default consecutive-failure budget before an adopt backend declares its
+ *  target gone. 3 one-second probes (~3s of sustained failure) plus a final
+ *  lenient confirm — enough to ride out command timeouts / server hiccups while
+ *  still detecting a genuine exit promptly. */
+export const ADOPT_LIVENESS_MAX_FAILURES = 3;

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -32,6 +32,7 @@ import { StringDecoder } from 'node:string_decoder';
 import type { SessionBackend, SpawnOpts } from './types.js';
 import { tmuxEnv } from '../../setup/ensure-tmux.js';
 import { buildBotmuxEnvAssignments, resolveUserShell, SHELL_WRAPPER_SCRIPT, TmuxBackend } from './tmux-backend.js';
+import { LivenessGate, ADOPT_LIVENESS_MAX_FAILURES } from './liveness-gate.js';
 
 function shellescape(s: string): string {
   // Single-quote-escape, replacing internal ' with '\''
@@ -109,6 +110,10 @@ export class TmuxPipeBackend implements SessionBackend {
   private static readonly RECENT_OUTPUT_MAX = 4096;
   private readonly exitCbs: Array<(code: number | null, signal: string | null) => void> = [];
   private lifecycleTimer: NodeJS.Timeout | null = null;
+  /** Debounce transient pane-probe failures so one flaky `tmux display-message`
+   *  (timeout / server hiccup under fd pressure) doesn't tear down an adopted
+   *  pane that's still alive. See recordPaneProbe. (pid-death stays decisive.) */
+  private readonly livenessGate = new LivenessGate(ADOPT_LIVENESS_MAX_FAILURES);
   private cols = 200;
   private rows = 50;
   private exited = false;
@@ -463,23 +468,72 @@ export class TmuxPipeBackend implements SessionBackend {
 
   private startLifecycleWatcher(): void {
     this.stopLifecycleWatcher();
+    this.livenessGate.reset();
     this.lifecycleTimer = setInterval(() => {
       if (this.exited) return;
+      // The watched CLI pid (adopt mode) is a pure process.kill(pid,0) syscall —
+      // it can only report ESRCH (gone) or EPERM (alive), never a transient
+      // timeout / EMFILE failure. So pid-death is DECISIVE: tear down at once.
+      // This keeps the ≤1s guard against routing Lark input into the user's bare
+      // shell after the CLI exits to a still-alive pane. Only the flaky pane
+      // probe below gets debounced.
       if (!this.isCliPidAlive()) {
         process.stderr.write(`[tmux-pipe-backend] adopted CLI pid ${this.watchCliPid} exited; detaching observer\n`);
         this.handlePaneExit();
         return;
       }
-      try {
-        const paneId = execSync(
-          `tmux display-message -p -t ${shellescape(this.paneTarget)} '#{pane_id}'`,
-          { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 2000, env: tmuxEnv() },
-        ).trim();
-        if (!paneId) this.handlePaneExit();
-      } catch {
-        this.handlePaneExit();
-      }
+      this.recordPaneProbe(this.isPaneAddressable(2000));
     }, 1000);
+  }
+
+  /** Is the pane still addressable in tmux? This `display-message` IS the flaky,
+   *  fd/server-dependent signal (command timeout / busy server under EMFILE) —
+   *  which is why recordPaneProbe debounces it. `timeoutMs` lets the final
+   *  confirm wait longer than the 1s poll so an overloaded server can still
+   *  answer before we declare a live pane dead. */
+  private isPaneAddressable(timeoutMs: number): boolean {
+    try {
+      const paneId = execSync(
+        `tmux display-message -p -t ${shellescape(this.paneTarget)} '#{pane_id}'`,
+        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: timeoutMs, env: tmuxEnv() },
+      ).trim();
+      return paneId.length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Debounce the (flaky) pane-addressability probe. Tearing down on the FIRST
+   * failed probe produced the spurious "⏏ /adopt的 CLI 会话已断开" — a tmux command
+   * timeout / busy server (e.g. under EMFILE fd pressure) momentarily fails the
+   * probe while the pane is still alive and the CLI still receiving messages.
+   * Only after ADOPT_LIVENESS_MAX_FAILURES consecutive failures, AND a final
+   * lenient-timeout re-probe that still fails, do we detach. Any success resets.
+   * (pid-death is handled decisively in the watcher — see startLifecycleWatcher.)
+   */
+  private recordPaneProbe(alive: boolean): void {
+    if (this.exited) return;
+    if (!this.livenessGate.record(alive)) {
+      if (!alive) {
+        process.stderr.write(
+          `[tmux-pipe-backend] adopt pane probe failed (${this.livenessGate.consecutiveFailures}/${ADOPT_LIVENESS_MAX_FAILURES}); retrying before teardown\n`,
+        );
+      }
+      return;
+    }
+    // Threshold reached — one final authoritative probe with a more lenient
+    // timeout so a transiently overloaded tmux server gets a fair chance to
+    // answer before we detach a pane that's actually still alive.
+    if (this.isPaneAddressable(3000)) {
+      this.livenessGate.reset();
+      process.stderr.write('[tmux-pipe-backend] adopt pane recovered on final check; staying attached\n');
+      return;
+    }
+    process.stderr.write(
+      `[tmux-pipe-backend] adopted pane gone after ${ADOPT_LIVENESS_MAX_FAILURES} consecutive probe failures; detaching observer\n`,
+    );
+    this.handlePaneExit();
   }
 
   private stopLifecycleWatcher(): void {

--- a/src/adapters/backend/zellij-observe-backend.ts
+++ b/src/adapters/backend/zellij-observe-backend.ts
@@ -4,6 +4,7 @@ import { tmuxKeyToBytes } from './zellij-backend.js';
 import { normaliseCaptureLineEndings } from './tmux-pipe-backend.js';
 import { zellijEnv } from '../../setup/ensure-zellij.js';
 import { logger } from '../../utils/logger.js';
+import { LivenessGate, ADOPT_LIVENESS_MAX_FAILURES } from './liveness-gate.js';
 
 /**
  * ZellijObserveBackend — the zellij analogue of TmuxPipeBackend, for /adopt.
@@ -43,6 +44,10 @@ export class ZellijObserveBackend implements ObserveBackend {
   private exitCbs: Array<(code: number | null, signal: string | null) => void> = [];
   private pollTimer: ReturnType<typeof setInterval> | null = null;
   private livenessTimer: ReturnType<typeof setInterval> | null = null;
+  /** Debounce transient pane-probe failures so one busy `zellij action
+   *  list-panes` doesn't tear down a pane that's still alive. See recordPaneProbe.
+   *  (pid-death stays decisive — a pure syscall can't false-fail under load.) */
+  private readonly livenessGate = new LivenessGate(ADOPT_LIVENESS_MAX_FAILURES);
   private lastSnapshot = '';
   private exited = false;
   /** # of live web-terminal `zellij attach` clients currently connected. While
@@ -83,20 +88,45 @@ export class ZellijObserveBackend implements ObserveBackend {
 
   private checkLiveness(): void {
     if (this.exited) return;
+    // (b) The adopted CLI pid is a pure process.kill(pid,0) syscall — ESRCH
+    // (gone) or EPERM (alive), never a transient/busy-server failure. So
+    // pid-death is DECISIVE: tear down at once. Essential for user-typed CLIs,
+    // where the pane drops back to a still-"alive" shell on exit and a pane-only
+    // check would route subsequent Lark input INTO that shell.
+    if (!this.isCliPidAlive()) { this.handlePaneExit(); return; }
     // While a live web-attach client is connected, skip the list-panes `action`
     // (it makes the zellij server repaint every attached client → flicker). The
-    // pid syscall covers CLI exit; the attach PTY's own exit covers pane/session
-    // death, and full pane liveness resumes the moment the client detaches.
-    if (this.liveAttachCount > 0) {
-      if (!this.isCliPidAlive()) this.handlePaneExit();
+    // attach PTY's own exit covers pane/session death and the pid check above
+    // covers CLI exit — nothing flaky left to probe. Discard any partial pane
+    // failure streak so it can't bite the moment the client detaches.
+    if (this.liveAttachCount > 0) { this.livenessGate.reset(); return; }
+    // (a) The list-panes pane probe IS the flaky signal (busy server) — debounce.
+    this.recordPaneProbe(this.isPaneAlive());
+  }
+
+  /**
+   * Debounce the (flaky) pane probe — mirror of TmuxPipeBackend.recordPaneProbe.
+   * Tearing down on the FIRST failed probe produced the spurious
+   * "⏏ /adopt的 CLI 会话已断开" — a busy zellij server momentarily fails list-panes
+   * while the pane is still alive. Only after ADOPT_LIVENESS_MAX_FAILURES
+   * consecutive failures, AND a final re-probe that still fails, do we detach.
+   * Any success resets the counter. (pid-death is handled decisively above.)
+   */
+  private recordPaneProbe(alive: boolean): void {
+    if (this.exited) return;
+    if (!this.livenessGate.record(alive)) {
+      if (!alive) {
+        logger.debug(`[zellij-observe] pane probe failed (${this.livenessGate.consecutiveFailures}/${ADOPT_LIVENESS_MAX_FAILURES}); retrying before teardown`);
+      }
       return;
     }
-    // Two exit signals: (a) the pane vanished, (b) the adopted CLI pid is gone.
-    // (b) is essential for user-typed CLIs: when the CLI exits, the pane drops
-    // back to a shell and stays "alive", so a pane-only check would keep the
-    // worker running and route subsequent Lark input INTO the user's shell.
-    // Mirrors the pid guard the restore path already uses.
-    if (!this.isPaneAlive() || !this.isCliPidAlive()) this.handlePaneExit();
+    // Threshold reached — one final authoritative re-probe before tearing down.
+    if (this.isPaneAlive()) {
+      this.livenessGate.reset();
+      logger.debug('[zellij-observe] pane recovered on final check; staying attached');
+      return;
+    }
+    this.handlePaneExit();
   }
 
   /**

--- a/src/adapters/backend/zellij-observe-backend.ts
+++ b/src/adapters/backend/zellij-observe-backend.ts
@@ -97,9 +97,11 @@ export class ZellijObserveBackend implements ObserveBackend {
     // While a live web-attach client is connected, skip the list-panes `action`
     // (it makes the zellij server repaint every attached client → flicker). The
     // attach PTY's own exit covers pane/session death and the pid check above
-    // covers CLI exit — nothing flaky left to probe. Discard any partial pane
-    // failure streak so it can't bite the moment the client detaches.
-    if (this.liveAttachCount > 0) { this.livenessGate.reset(); return; }
+    // covers CLI exit — nothing flaky left to probe. The partial pane-failure
+    // streak was already discarded the moment the client attached (see
+    // setLiveAttach), and nothing increments the gate while attached, so there's
+    // nothing to reset here.
+    if (this.liveAttachCount > 0) return;
     // (a) The list-panes pane probe IS the flaky signal (busy server) — debounce.
     this.recordPaneProbe(this.isPaneAlive());
   }
@@ -144,6 +146,11 @@ export class ZellijObserveBackend implements ObserveBackend {
     this.liveAttachCount = Math.max(0, this.liveAttachCount + (active ? 1 : -1));
     if (this.exited) return;
     if (this.liveAttachCount > 0) {
+      // Pane probing pauses while attached → discard any partial pane-failure
+      // streak NOW, at the attach transition, not on the next liveness tick. A
+      // brief attach that opens and closes BETWEEN ticks would otherwise leave a
+      // stale streak that trips the moment the client detaches.
+      this.livenessGate.reset();
       if (this.pollTimer) { clearInterval(this.pollTimer); this.pollTimer = null; }
     } else if (!this.pollTimer) {
       this.pollTimer = setInterval(() => this.poll(), POLL_MS);

--- a/test/liveness-gate.test.ts
+++ b/test/liveness-gate.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { LivenessGate, ADOPT_LIVENESS_MAX_FAILURES } from '../src/adapters/backend/liveness-gate.js';
+
+describe('LivenessGate', () => {
+  it('only trips after `threshold` consecutive failures', () => {
+    const gate = new LivenessGate(3);
+    expect(gate.record(false)).toBe(false);   // 1
+    expect(gate.consecutiveFailures).toBe(1);
+    expect(gate.record(false)).toBe(false);   // 2
+    expect(gate.consecutiveFailures).toBe(2);
+    expect(gate.record(false)).toBe(true);    // 3 → trips
+    expect(gate.consecutiveFailures).toBe(3);
+  });
+
+  it('a single success resets the counter (no trip across a recovery)', () => {
+    const gate = new LivenessGate(3);
+    gate.record(false);
+    gate.record(false);
+    expect(gate.record(true)).toBe(false);     // recovery resets
+    expect(gate.consecutiveFailures).toBe(0);
+    expect(gate.record(false)).toBe(false);    // counting starts over
+    expect(gate.record(false)).toBe(false);
+    expect(gate.consecutiveFailures).toBe(2);  // still under threshold
+  });
+
+  it('keeps reporting tripped while failures persist past the threshold', () => {
+    const gate = new LivenessGate(2);
+    expect(gate.record(false)).toBe(false);
+    expect(gate.record(false)).toBe(true);
+    expect(gate.record(false)).toBe(true);     // still gone
+  });
+
+  it('reset() clears the counter', () => {
+    const gate = new LivenessGate(2);
+    gate.record(false);
+    gate.reset();
+    expect(gate.consecutiveFailures).toBe(0);
+    expect(gate.record(false)).toBe(false);    // back to needing 2
+  });
+
+  it('threshold of 1 trips on the first failure (no debounce)', () => {
+    const gate = new LivenessGate(1);
+    expect(gate.record(false)).toBe(true);
+  });
+
+  it('rejects a threshold below 1', () => {
+    expect(() => new LivenessGate(0)).toThrow();
+  });
+
+  it('ships a sane default budget (>= 3 so transient hiccups are tolerated)', () => {
+    expect(ADOPT_LIVENESS_MAX_FAILURES).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/test/tmux-pipe-backend.test.ts
+++ b/test/tmux-pipe-backend.test.ts
@@ -417,57 +417,141 @@ describe('TmuxPipeBackend managed session', () => {
 });
 
 describe('TmuxPipeBackend lifecycle watcher', () => {
-  it('fires exit when the tmux pane disappears', () => {
+  const PANE_OK = (cmd: any) =>
+    (String(cmd).includes('display-message') && String(cmd).includes('#{pane_id}')) ? '%1\n' as any : '' as any;
+  const PANE_GONE = (cmd: any) => {
+    if (String(cmd).includes('display-message') && String(cmd).includes('#{pane_id}')) throw new Error('no pane');
+    return '' as any;
+  };
+
+  it('fires exit when the tmux pane disappears — but only after 3 consecutive failures', () => {
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     vi.useFakeTimers();
     try {
-      mockedExecSync.mockImplementation((cmd: any) => {
-        if (String(cmd).includes("display-message") && String(cmd).includes("#{pane_id}")) return '%1\n' as any;
-        return '' as any;
-      });
+      mockedExecSync.mockImplementation(PANE_OK);
       const be = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
       const exits: Array<[number | null, string | null]> = [];
       be.onExit((code, signal) => exits.push([code, signal]));
       be.spawn('', [], spawnOpts());
+      mockedExecSync.mockImplementation(PANE_GONE);
+
+      // Two failed probes are NOT enough — the debounce gate must ride them out.
+      vi.advanceTimersByTime(2_000);
+      expect(exits).toEqual([]);
+
+      // 3rd consecutive failure trips the gate; the final lenient confirm also
+      // fails ⇒ now we detach.
+      vi.advanceTimersByTime(1_000);
+      expect(exits).toEqual([[1, null]]);
+    } finally {
+      vi.useRealTimers();
+      errSpy.mockRestore();
+    }
+  });
+
+  it('treats an empty pane id as a failure (debounced the same way)', () => {
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.useFakeTimers();
+    try {
+      mockedExecSync.mockImplementation(PANE_OK);
+      const be = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
+      const exits: Array<[number | null, string | null]> = [];
+      be.onExit((code, signal) => exits.push([code, signal]));
+      be.spawn('', [], spawnOpts());
+      mockedExecSync.mockImplementation((cmd: any) =>
+        (String(cmd).includes('display-message') && String(cmd).includes('#{pane_id}')) ? '\n' as any : '' as any);
+
+      vi.advanceTimersByTime(2_000);
+      expect(exits).toEqual([]);
+      vi.advanceTimersByTime(1_000);
+      expect(exits).toEqual([[1, null]]);
+    } finally {
+      vi.useRealTimers();
+      errSpy.mockRestore();
+    }
+  });
+
+  it('does NOT detach on a single transient probe failure that then recovers', () => {
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.useFakeTimers();
+    try {
+      mockedExecSync.mockImplementation(PANE_OK);
+      const be = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
+      const exits: Array<[number | null, string | null]> = [];
+      be.onExit((code, signal) => exits.push([code, signal]));
+      be.spawn('', [], spawnOpts());
+
+      // One failure, then sustained success — the false signal must be ignored.
+      mockedExecSync.mockImplementation(PANE_GONE);
+      vi.advanceTimersByTime(1_000);
+      mockedExecSync.mockImplementation(PANE_OK);
+      vi.advanceTimersByTime(10_000);
+
+      expect(exits).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+      errSpy.mockRestore();
+    }
+  });
+
+  it('resets the failure counter on an intervening success (never 3-in-a-row)', () => {
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.useFakeTimers();
+    try {
+      mockedExecSync.mockImplementation(PANE_OK);
+      const be = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
+      const exits: Array<[number | null, string | null]> = [];
+      be.onExit((code, signal) => exits.push([code, signal]));
+      be.spawn('', [], spawnOpts());
+
+      mockedExecSync.mockImplementation(PANE_GONE);
+      vi.advanceTimersByTime(2_000);          // 2 failures (gate at 2)
+      mockedExecSync.mockImplementation(PANE_OK);
+      vi.advanceTimersByTime(1_000);          // success → reset
+      mockedExecSync.mockImplementation(PANE_GONE);
+      vi.advanceTimersByTime(2_000);          // 2 more failures (gate back to 2)
+
+      expect(exits).toEqual([]);              // never reached 3 consecutive
+    } finally {
+      vi.useRealTimers();
+      errSpy.mockRestore();
+    }
+  });
+
+  it('stays attached when the final lenient confirm probe succeeds (overload, not death)', () => {
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.useFakeTimers();
+    try {
+      let paneIdCalls = 0;
       mockedExecSync.mockImplementation((cmd: any) => {
-        if (String(cmd).includes("display-message") && String(cmd).includes("#{pane_id}")) {
-          throw new Error('no pane');
+        const s = String(cmd);
+        if (s.includes('display-message') && s.includes('#{pane_id}')) {
+          paneIdCalls += 1;
+          // The three 1s-poll probes (timeout 2000) all time out under load…
+          if (paneIdCalls <= 3) throw new Error('server overloaded');
+          // …but the final lenient-timeout confirm gets an answer ⇒ still alive.
+          return '%1\n' as any;
         }
         return '' as any;
       });
-
-      vi.advanceTimersByTime(2_000);
-
-      expect(exits).toEqual([[1, null]]);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('fires exit when tmux display-message succeeds with empty pane id', () => {
-    vi.useFakeTimers();
-    try {
-      mockedExecSync.mockImplementation((cmd: any) => {
-        if (String(cmd).includes("display-message") && String(cmd).includes("#{pane_id}")) return '%1\n' as any;
-        return '' as any;
-      });
       const be = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
       const exits: Array<[number | null, string | null]> = [];
       be.onExit((code, signal) => exits.push([code, signal]));
       be.spawn('', [], spawnOpts());
-      mockedExecSync.mockImplementation((cmd: any) => {
-        if (String(cmd).includes("display-message") && String(cmd).includes("#{pane_id}")) return '\n' as any;
-        return '' as any;
-      });
 
-      vi.advanceTimersByTime(2_000);
-
-      expect(exits).toEqual([[1, null]]);
+      vi.advanceTimersByTime(3_000);          // 3 failed polls + 1 successful confirm
+      expect(exits).toEqual([]);              // recovered on the confirm, no detach
+      expect(paneIdCalls).toBe(4);
     } finally {
       vi.useRealTimers();
+      errSpy.mockRestore();
     }
   });
 
-  it('fires exit when adopted CLI pid disappears while the pane stays alive', () => {
+  it('fires exit IMMEDIATELY when the adopted CLI pid disappears (pid is decisive, not debounced)', () => {
+    // The pid check is a pure process.kill(pid,0) syscall — it can only report
+    // ESRCH/EPERM, never a transient timeout — so it must NOT be debounced:
+    // delaying teardown would route Lark input into the user's bare shell.
     vi.useFakeTimers();
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: NodeJS.Signals | 0) => {
       if (pid === 4242 && signal === 0) {
@@ -479,19 +563,16 @@ describe('TmuxPipeBackend lifecycle watcher', () => {
     }) as typeof process.kill);
     const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     try {
-      mockedExecSync.mockImplementation((cmd: any) => {
-        if (String(cmd).includes("display-message") && String(cmd).includes("#{pane_id}")) return '%1\n' as any;
-        return '' as any;
-      });
+      mockedExecSync.mockImplementation(PANE_OK);
       const be = new TmuxPipeBackend('0:2.0', { cliPid: 4242 });
       const exits: Array<[number | null, string | null]> = [];
       be.onExit((code, signal) => exits.push([code, signal]));
       be.spawn('', [], spawnOpts());
       mockedExecSync.mockClear();
 
-      vi.advanceTimersByTime(1_000);
-
+      vi.advanceTimersByTime(1_000);          // first tick: pid gone ⇒ detach now
       expect(exits).toEqual([[1, null]]);
+
       const cancelCall = mockedExecSync.mock.calls
         .map(c => String(c[0]))
         .find(c => c.includes('pipe-pane'));
@@ -502,6 +583,35 @@ describe('TmuxPipeBackend lifecycle watcher', () => {
       errSpy.mockRestore();
       killSpy.mockRestore();
       vi.useRealTimers();
+    }
+  });
+
+  it('kill() during a pending (sub-threshold) failure streak stops the watcher cleanly', () => {
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.useFakeTimers();
+    try {
+      mockedExecSync.mockImplementation(PANE_OK);
+      const be = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
+      const exits: Array<[number | null, string | null]> = [];
+      be.onExit((code, signal) => exits.push([code, signal]));
+      be.spawn('', [], spawnOpts());
+
+      mockedExecSync.mockImplementation(PANE_GONE);
+      vi.advanceTimersByTime(2_000);          // gate at 2 — no teardown yet
+      expect(exits).toEqual([]);
+
+      be.kill();                              // explicit close mid-streak
+      mockedExecSync.mockClear();
+      vi.advanceTimersByTime(10_000);         // watcher must be stopped
+
+      expect(exits).toEqual([]);              // kill() does not fire onExit
+      const probeAfterKill = mockedExecSync.mock.calls
+        .map(c => String(c[0]))
+        .some(c => c.includes('display-message'));
+      expect(probeAfterKill).toBe(false);     // no further probing after kill
+    } finally {
+      vi.useRealTimers();
+      errSpy.mockRestore();
     }
   });
 });

--- a/test/zellij-observe-backend.test.ts
+++ b/test/zellij-observe-backend.test.ts
@@ -2,11 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Capture every `zellij` invocation the observe backend makes. dump-screen
 // returns bare-`\n` content (as real zellij does) so we can assert normalisation.
+// `listPanesResult` is mutable so the liveness tests can simulate a pane that
+// transiently disappears and comes back.
 const calls: string[][] = [];
+let listPanesResult: () => string = () => JSON.stringify([{ id: 2, is_plugin: false }]);
 vi.mock('node:child_process', () => ({
   execFileSync: (bin: string, args: string[]) => {
     calls.push([bin, ...args]);
     if (args.includes('dump-screen')) return 'line one\nline two\nline three\n';
+    if (args.includes('list-panes')) return listPanesResult();
     return '';
   },
 }));
@@ -65,5 +69,135 @@ describe('ZellijObserveBackend input encoding', () => {
     // continues from the previous end column (the misalignment 申晗 hit).
     expect(be.captureViewport()).toBe('line one\r\nline two\r\nline three\r\n');
     expect(be.captureCurrentScreen()).toBe('line one\r\nline two\r\nline three\r\n');
+  });
+});
+
+describe('ZellijObserveBackend liveness debounce', () => {
+  const ALIVE = () => JSON.stringify([{ id: 2, is_plugin: false }]);
+  const GONE = () => '[]';
+  const opts = () => ({ cwd: '/tmp', cols: 80, rows: 24, env: process.env as Record<string, string> });
+
+  beforeEach(() => {
+    calls.length = 0;
+    listPanesResult = ALIVE;
+  });
+
+  it('does NOT detach on a single transient list-panes failure that recovers', () => {
+    vi.useFakeTimers();
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+    try {
+      const be = new ZellijObserveBackend(S, P, { cliPid: 999 });
+      const exits: Array<[number | null, string | null]> = [];
+      be.onExit((c, s) => exits.push([c, s]));
+      be.spawn('', [], opts());
+
+      listPanesResult = GONE;
+      vi.advanceTimersByTime(1_000);   // 1 failed liveness probe
+      listPanesResult = ALIVE;
+      vi.advanceTimersByTime(8_000);   // sustained recovery
+      expect(exits).toEqual([]);
+    } finally {
+      killSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('detaches only after 3 consecutive pane-gone probes + a failed confirm', () => {
+    vi.useFakeTimers();
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+    try {
+      const be = new ZellijObserveBackend(S, P, { cliPid: 999 });
+      const exits: Array<[number | null, string | null]> = [];
+      be.onExit((c, s) => exits.push([c, s]));
+      be.spawn('', [], opts());
+
+      listPanesResult = GONE;
+      vi.advanceTimersByTime(2_000);   // 2 failures — debounced
+      expect(exits).toEqual([]);
+      vi.advanceTimersByTime(1_000);   // 3rd + failed confirm ⇒ detach
+      expect(exits).toEqual([[0, null]]);
+    } finally {
+      killSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('detaches IMMEDIATELY when the pid is gone (pid is decisive, not debounced)', () => {
+    // process.kill(pid,0) can only report ESRCH/EPERM — never a transient
+    // failure — so a dead pid tears down on the first tick to keep the user's
+    // Lark input out of the shell the pane drops back to.
+    vi.useFakeTimers();
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((pid: number, sig?: NodeJS.Signals | 0) => {
+      if (pid === 999 && sig === 0) {
+        const e: NodeJS.ErrnoException = new Error('gone');
+        e.code = 'ESRCH';
+        throw e;
+      }
+      return true;
+    }) as typeof process.kill);
+    try {
+      listPanesResult = ALIVE;          // pane never disappears — only the pid is gone
+      const be = new ZellijObserveBackend(S, P, { cliPid: 999 });
+      const exits: Array<[number | null, string | null]> = [];
+      be.onExit((c, s) => exits.push([c, s]));
+      be.spawn('', [], opts());
+
+      vi.advanceTimersByTime(1_000);    // first liveness tick ⇒ detach now
+      expect(exits).toEqual([[0, null]]);
+    } finally {
+      killSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('stays attached when the pane reappears on the final confirm (overload, not death)', () => {
+    vi.useFakeTimers();
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+    try {
+      let listCalls = 0;
+      listPanesResult = () => {
+        listCalls += 1;
+        // 3 polled probes miss the pane (busy server) …
+        if (listCalls <= 3) return '[]';
+        // … but the final confirm re-probe finds it ⇒ still alive.
+        return JSON.stringify([{ id: 2, is_plugin: false }]);
+      };
+      const be = new ZellijObserveBackend(S, P, { cliPid: 999 });
+      const exits: Array<[number | null, string | null]> = [];
+      be.onExit((c, s) => exits.push([c, s]));
+      be.spawn('', [], opts());
+
+      vi.advanceTimersByTime(3_000);   // 3 failed polls + 1 successful confirm
+      expect(exits).toEqual([]);       // recovered on the confirm — no detach
+      expect(listCalls).toBe(4);
+    } finally {
+      killSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('a live web-attach client resets a partial pane-failure streak (no detach across attach)', () => {
+    // While attached we don't pane-probe (avoids flicker); the streak must be
+    // discarded so it can't trip the instant the client connects.
+    vi.useFakeTimers();
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+    try {
+      const be = new ZellijObserveBackend(S, P, { cliPid: 999 });
+      const exits: Array<[number | null, string | null]> = [];
+      be.onExit((c, s) => exits.push([c, s]));
+      be.spawn('', [], opts());
+
+      listPanesResult = GONE;
+      vi.advanceTimersByTime(2_000);   // 2 pane failures (gate at 2, no detach)
+      expect(exits).toEqual([]);
+
+      be.setLiveAttach(true);          // web terminal connects → pane probe paused
+      vi.advanceTimersByTime(10_000);  // pid stays alive; streak was reset
+
+      expect(exits).toEqual([]);
+    } finally {
+      killSpy.mockRestore();
+      vi.useRealTimers();
+    }
   });
 });

--- a/test/zellij-observe-backend.test.ts
+++ b/test/zellij-observe-backend.test.ts
@@ -176,9 +176,13 @@ describe('ZellijObserveBackend liveness debounce', () => {
     }
   });
 
-  it('a live web-attach client resets a partial pane-failure streak (no detach across attach)', () => {
-    // While attached we don't pane-probe (avoids flicker); the streak must be
-    // discarded so it can't trip the instant the client connects.
+  it('setLiveAttach(true) resets a partial pane-failure streak at the attach transition', () => {
+    // 2 failures, then a brief attach+detach that crosses NO liveness tick. If
+    // setLiveAttach reset the streak, a single post-detach failure leaves the
+    // gate at 1 (no detach). If it did NOT reset (e.g. relying only on the
+    // per-tick reset), the gate would still be 2 and this one failure would hit
+    // the threshold → detach. So this pins the reset to setLiveAttach itself —
+    // it would go red if that reset were removed.
     vi.useFakeTimers();
     const killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
     try {
@@ -191,10 +195,15 @@ describe('ZellijObserveBackend liveness debounce', () => {
       vi.advanceTimersByTime(2_000);   // 2 pane failures (gate at 2, no detach)
       expect(exits).toEqual([]);
 
-      be.setLiveAttach(true);          // web terminal connects → pane probe paused
-      vi.advanceTimersByTime(10_000);  // pid stays alive; streak was reset
+      be.setLiveAttach(true);          // attach resets the streak immediately…
+      be.setLiveAttach(false);         // …and detaches before any liveness tick
 
+      vi.advanceTimersByTime(1_000);   // ONE more failure → gate is 1, not 3
       expect(exits).toEqual([]);
+
+      // And the gate genuinely counts from 1: two further failures DO trip it.
+      vi.advanceTimersByTime(2_000);
+      expect(exits).toEqual([[0, null]]);
     } finally {
       killSpy.mockRestore();
       vi.useRealTimers();


### PR DESCRIPTION
## 问题

`/adopt` 模式下，tmux (`TmuxPipeBackend`) / zellij (`ZellijObserveBackend`) 的 liveness 监视器**单次探测失败**就走断开流程，daemon 随即发「⏏ /adopt的 CLI 会话已断开」。

`tmux display-message` / `zellij list-panes` 这类「问 server」的命令在高负载下（日志里的 `EMFILE: too many open files`、worker 过多）会偶发超时/失败，但被 adopt 的 CLI 其实还活着 → **误报断开**。用户现象：网络正常、提示断开后继续发消息原 session 仍能收到。

## 改动

- 新增 `src/adapters/backend/liveness-gate.ts`：`LivenessGate` 连续失败计数器（阈值 `ADOPT_LIVENESS_MAX_FAILURES = 3`，任意一次成功清零）。
- **易抖动的 pane 探测**接入闸门：连续失败 ≥3 次、且最后一次更宽松超时的强校验仍失败，才真正 `handlePaneExit()`。
- **CLI pid 检测保持单次即决、不防抖**：`process.kill(pid,0)` 是纯系统调用，只会返回 ESRCH(gone)/EPERM(alive)，不可能因负载抖动误判。若把它也防抖，CLI 真退出后会多 ~2s 把用户消息打进裸 shell（破坏既有安全不变量）。所以拆成两条信号：
  - pid 没了 → 立即断开（决定性，保持原 ≤1s 行为）
  - pane 探测抖动 → 重试 3 次 + 强校验才断（这才是误报源头）

## 不在范围（有意不动）

- `guardedSend`：需「发送失败 + pane 消失」双重证据，非被动误报来源。
- herdr backend：事件驱动模型，已对 `listAgents()` 瞬时失败有兜底。
- daemon 重启恢复路径：一次性校验，行为正确。

## 验证

- `pnpm build` 通过；`pnpm test` **4948** 单测全绿。
- 新增 `test/liveness-gate.test.ts` + 扩展 tmux/zellij backend liveness 测试（防抖容忍瞬时失败、成功清零、连续3次+强校验才断、pid 即决、kill 中途清理、live-attach 重置等）。
- 已先经一轮多-agent 对抗 review（其指出「pid 不该防抖」的 major 已在本 PR 修正）。

> 本 PR 请 @Codex 二次独立 review。base 已 rebase 到最新 master（含 #271 paste-buffer 隔离）。