### PR TITLE
[Fix] fix dashboard restored session rows

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -546,6 +546,11 @@ ipcRoute('POST', '/api/sessions/:sessionId/resume', async (req, res, params) => 
   }
 
   const ds = result.ds;
+  // `?wake=1` is an opt-in operational hook (no UI/CLI caller wires it today —
+  // it's meant for direct `curl` recovery): instead of the default lazy
+  // cold-resume on the next inbound message, fork the worker immediately so the
+  // session is usable right away. Off by default keeps every existing caller's
+  // behaviour unchanged.
   const wake = new URL(req.url ?? '/', 'http://localhost').searchParams.get('wake') === '1';
   // Tell the dashboard the row flipped back to active (mirror of session.update
   // emitted by closeSession). Use `null` for closedAt — `undefined` would be
@@ -579,14 +584,19 @@ ipcRoute('POST', '/api/sessions/:sessionId/resume', async (req, res, params) => 
     }
   }
 
-  if (wake && (!ds.worker || ds.worker.killed)) {
+  // Report the EFFECTIVE action, not the raw request flag: only fork when wake
+  // was asked AND there's no live worker to clobber. (resumeSession always hands
+  // back a worker:null ds today, so this matches `wake` in practice — but
+  // reporting the action keeps the response honest if the guard ever broadens.)
+  const woke = wake && (!ds.worker || ds.worker.killed);
+  if (woke) {
     forkWorker(ds, '', true);
   }
 
   jsonRes(res, 200, {
     ok: true,
     sessionId,
-    wake,
+    wake: woke,
     title: ds.session.title,
     chatId: ds.chatId,
     rootMessageId: ds.session.rootMessageId,

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -535,7 +535,7 @@ ipcRoute('POST', '/api/sessions/:sessionId/sandbox-land/:action', (_req, res, pa
  * CLI command (via this HTTP route). The CLI route also drops a notice into
  * the original Lark thread so users see why the session is alive again.
  */
-ipcRoute('POST', '/api/sessions/:sessionId/resume', async (_req, res, params) => {
+ipcRoute('POST', '/api/sessions/:sessionId/resume', async (req, res, params) => {
   const sessionId = params.sessionId;
   const reg = getActiveSessionsRegistry();
   if (!reg) return jsonRes(res, 503, { ok: false, error: 'registry_unavailable' });
@@ -546,6 +546,7 @@ ipcRoute('POST', '/api/sessions/:sessionId/resume', async (_req, res, params) =>
   }
 
   const ds = result.ds;
+  const wake = new URL(req.url ?? '/', 'http://localhost').searchParams.get('wake') === '1';
   // Tell the dashboard the row flipped back to active (mirror of session.update
   // emitted by closeSession). Use `null` for closedAt — `undefined` would be
   // dropped by JSON.stringify on the SSE wire and the aggregator's spread
@@ -578,9 +579,14 @@ ipcRoute('POST', '/api/sessions/:sessionId/resume', async (_req, res, params) =>
     }
   }
 
+  if (wake && (!ds.worker || ds.worker.killed)) {
+    forkWorker(ds, '', true);
+  }
+
   jsonRes(res, 200, {
     ok: true,
     sessionId,
+    wake,
     title: ds.session.title,
     chatId: ds.chatId,
     rootMessageId: ds.session.rootMessageId,

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -1580,9 +1580,31 @@ ipcRoute('GET', '/api/events', (_req, res) => {
   // Initial flush so the client sees the connection alive immediately.
   res.write('retry: 5000\n\n');
 
+  // Subscribe BEFORE snapshotting so no event published in the gap is missed.
   const off = dashboardEventBus.subscribe(ev => {
     res.write(`event: ${ev.type}\ndata: ${JSON.stringify(ev.body)}\n\n`);
   });
+
+  // Replay the current active sessions as `session.spawned` right after
+  // subscribing. `DashboardEventBus` has no buffer/replay, and the daemon
+  // publishes its discovery descriptor BEFORE restoreActiveSessions() runs
+  // (daemon.ts) — so a dashboard that hydrates (GET /api/sessions) during the
+  // descriptor→restore window gets an EMPTY snapshot, and any restore-time
+  // `announceSessionRow()` that fires before THIS subscription is established is
+  // dropped. Without this replay the aggregator would then have neither a
+  // snapshot row nor a spawned row, and later session.update/close patches would
+  // be discarded as unknown-row. Replaying here makes SSE attach deterministic:
+  // a row registered before subscribe arrives via this snapshot; one registered
+  // after arrives via the live subscription above. Idempotent — both the
+  // aggregator and the browser store upsert by sessionId, so any row also
+  // delivered live just refreshes the same entry.
+  try {
+    for (const ds of listActiveSessions()) {
+      res.write(`event: session.spawned\ndata: ${JSON.stringify({ session: composeRowFromActive(ds) })}\n\n`);
+    }
+  } catch (err) {
+    logger.warn(`[dashboard-ipc] /api/events snapshot replay failed: ${err}`);
+  }
 
   const hb = setInterval(() => {
     res.write(`event: heartbeat\ndata: ${JSON.stringify({ ts: Date.now() })}\n\n`);

--- a/src/core/session-activity.ts
+++ b/src/core/session-activity.ts
@@ -51,6 +51,13 @@ export function clearAgentAttention(ds: DaemonSession): boolean {
   return true;
 }
 
+export function announceSessionRow(ds: DaemonSession): void {
+  dashboardEventBus.publish({
+    type: 'session.spawned',
+    body: { session: composeRowFromActive(ds) },
+  });
+}
+
 /** Announce a repo-selection-pending session to dashboard SSE subscribers.
  *
  *  `session.spawned` is normally published when the worker process spawns —
@@ -62,8 +69,5 @@ export function clearAgentAttention(ds: DaemonSession): boolean {
  *  the non-pending branch is announced by the real spawn moments later. */
 export function announcePendingRepoSession(ds: DaemonSession): void {
   if (!ds.pendingRepo) return;
-  dashboardEventBus.publish({
-    type: 'session.spawned',
-    body: { session: composeRowFromActive(ds) },
-  });
+  announceSessionRow(ds);
 }

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -25,7 +25,7 @@ import type { MessageResource } from '../im/lark/message-parser.js';
 import type { ResolvedSender } from '../im/lark/identity-cache.js';
 import { sessionKey, sessionAnchorId } from './types.js';
 import type { DaemonSession } from './types.js';
-import { markSessionActivity } from './session-activity.js';
+import { announceSessionRow, markSessionActivity } from './session-activity.js';
 import { usageLimitStateKey } from '../utils/cli-usage-limit.js';
 import { t, localeForBot, type Locale } from '../i18n/index.js';
 import { parseWorkingDirList } from '../utils/working-dir.js';
@@ -757,6 +757,7 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
       // relayed real session from a prior buggy run), close the loser
       // rather than silently overwriting it.
       await setActiveSessionSafe(activeSessions, sessionKey(anchor, larkAppId), ds);
+      announceSessionRow(ds);
       forkAdoptWorker(ds, { restoredFromMetadata: true });
       logger.info(`[${session.sessionId.substring(0, 8)}] Restored adopt session (target: ${adoptTargetLabel(adopted)}, scope: ${scope})`);
       continue;
@@ -807,6 +808,7 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
     if (ds.usageLimit) restoreUsageLimitRuntimeState(ds);
     // Same-key collision guard — see adopt-branch comment above.
     await setActiveSessionSafe(activeSessions, sessionKey(anchor, larkAppId), ds);
+    announceSessionRow(ds);
 
     logger.debug(`Registered session ${session.sessionId} (scope: ${scope}, anchor: ${anchor})`);
   }

--- a/test/dashboard-attention-signals.test.ts
+++ b/test/dashboard-attention-signals.test.ts
@@ -9,7 +9,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { readFileSync } from 'fs';
 import { composeRowFromActive } from '../src/core/dashboard-rows.js';
-import { publishAttentionPatch, announcePendingRepoSession, clearAgentAttention } from '../src/core/session-activity.js';
+import { announcePendingRepoSession, announceSessionRow, clearAgentAttention, publishAttentionPatch } from '../src/core/session-activity.js';
 import { dashboardEventBus, type DashboardEvent } from '../src/core/dashboard-events.js';
 import { attentionWaitSince } from '../src/dashboard/web/ui.js';
 import {
@@ -145,6 +145,17 @@ describe('attention signals', () => {
     expect(row.sessionId).toBe('sess-1');
     expect(row.pendingRepo).toBe(true);
     expect(row.status).toBe('starting'); // no screen yet → starting
+  });
+
+  it('announceSessionRow publishes a full session.spawned row for restored active sessions', () => {
+    const seen = collectEvents();
+    announceSessionRow(makeDs({ hasHistory: true }));
+    expect(seen).toHaveLength(1);
+    expect(seen[0].type).toBe('session.spawned');
+    const row = (seen[0] as any).body.session;
+    expect(row.sessionId).toBe('sess-1');
+    expect(row.hasHistory).toBe(true);
+    expect(row.status).toBe('starting');
   });
 
   it('announcePendingRepoSession is a no-op when the session is not pending', () => {

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -8,9 +8,11 @@ import { startIpcServer, setLarkAppId, setIpcAuthSecret, type IpcServerHandle } 
 import { dashboardEventBus } from '../src/core/dashboard-events.js';
 import * as groupsStore from '../src/services/groups-store.js';
 import * as oncallStore from '../src/services/oncall-store.js';
+import * as sessionStore from '../src/services/session-store.js';
 import * as workerPool from '../src/core/worker-pool.js';
 import { registerBot } from '../src/bot-registry.js';
 import { config } from '../src/config.js';
+import { sessionKey } from '../src/core/types.js';
 import { writeTeamRoleFile } from '../src/core/role-resolver.js';
 
 // Loopback-HMAC the write-link routes require. Inject a known secret per test
@@ -163,6 +165,50 @@ describe('POST /api/sessions/:sessionId/restart', () => {
     expect(res.status).toBe(502);
     expect(await res.json()).toMatchObject({ ok: false });
     findSpy.mockRestore();
+  });
+});
+
+describe('POST /api/sessions/:sessionId/resume', () => {
+  it('wakes a resumed session immediately when wake=1 is set', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'dashboard-ipc-resume-'));
+    const prevDataDir = process.env.SESSION_DATA_DIR;
+    const prevConfigDataDir = config.session.dataDir;
+    const registry = new Map<string, any>();
+    const forkSpy = vi.spyOn(workerPool, 'forkWorker').mockImplementation(() => {});
+    try {
+      config.session.dataDir = dataDir;
+      sessionStore.init();
+      workerPool.setActiveSessionsRegistry(registry);
+
+      const session = sessionStore.createSession('oc_resume', 'om_resume', 'resume topic', 'group');
+      session.larkAppId = '';
+      session.scope = 'thread';
+      session.cliId = 'codex' as any;
+      session.workingDir = process.cwd();
+      sessionStore.updateSession(session);
+      sessionStore.closeSession(session.sessionId);
+
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      const res = await fetch(`http://127.0.0.1:${handle.port}/api/sessions/${session.sessionId}/resume?wake=1`, { method: 'POST' });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toMatchObject({ ok: true, sessionId: session.sessionId, wake: true });
+      expect(registry.get(sessionKey('om_resume', ''))?.session.sessionId).toBe(session.sessionId);
+      expect(forkSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ session: expect.objectContaining({ sessionId: session.sessionId }) }),
+        '',
+        true,
+      );
+    } finally {
+      forkSpy.mockRestore();
+      workerPool.setActiveSessionsRegistry(new Map());
+      sessionStore.init();
+      if (prevDataDir === undefined) delete process.env.SESSION_DATA_DIR;
+      else process.env.SESSION_DATA_DIR = prevDataDir;
+      config.session.dataDir = prevConfigDataDir;
+      rmSync(dataDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -210,6 +210,47 @@ describe('POST /api/sessions/:sessionId/resume', () => {
       rmSync(dataDir, { recursive: true, force: true });
     }
   });
+
+  it('default resume (no wake) reactivates without forking a worker', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'dashboard-ipc-resume-'));
+    const prevDataDir = process.env.SESSION_DATA_DIR;
+    const prevConfigDataDir = config.session.dataDir;
+    const registry = new Map<string, any>();
+    const forkSpy = vi.spyOn(workerPool, 'forkWorker').mockImplementation(() => {});
+    try {
+      config.session.dataDir = dataDir;
+      sessionStore.init();
+      workerPool.setActiveSessionsRegistry(registry);
+
+      const session = sessionStore.createSession('oc_resume', 'om_resume', 'resume topic', 'group');
+      session.larkAppId = '';
+      session.scope = 'thread';
+      session.cliId = 'codex' as any;
+      session.workingDir = process.cwd();
+      sessionStore.updateSession(session);
+      sessionStore.closeSession(session.sessionId);
+
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      const res = await fetch(`http://127.0.0.1:${handle.port}/api/sessions/${session.sessionId}/resume`, { method: 'POST' });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Reactivated, but NO eager fork — the session cold-resumes lazily on the
+      // next inbound message. This guards the `wake &&` short-circuit against a
+      // refactor that reverts to forking on every resume.
+      expect(body).toMatchObject({ ok: true, sessionId: session.sessionId, wake: false });
+      expect(registry.get(sessionKey('om_resume', ''))?.session.sessionId).toBe(session.sessionId);
+      expect(forkSpy).not.toHaveBeenCalled();
+    } finally {
+      forkSpy.mockRestore();
+      workerPool.setActiveSessionsRegistry(new Map());
+      sessionStore.init();
+      if (prevDataDir === undefined) delete process.env.SESSION_DATA_DIR;
+      else process.env.SESSION_DATA_DIR = prevDataDir;
+      config.session.dataDir = prevConfigDataDir;
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('GET /api/sessions/:sessionId/write-link', () => {

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -26,6 +26,54 @@ function tokenAuthHeaders(secret = TEST_IPC_SECRET): Record<string, string> {
   return { 'X-Botmux-Cli-Ts': ts, 'X-Botmux-Cli-Nonce': nonce, 'X-Botmux-Cli-Auth': sig };
 }
 
+function parseSseFrame(raw: string): { type: string; body: any } | null {
+  let type: string | undefined;
+  let data: string | undefined;
+  for (const line of raw.split('\n')) {
+    if (line.startsWith('event:')) type = line.slice(6).trim();
+    else if (line.startsWith('data:')) data = line.slice(5).trim();
+  }
+  if (!type) return null;
+  let body: any;
+  try { body = data ? JSON.parse(data) : undefined; } catch { body = undefined; }
+  return { type, body };
+}
+
+/** Connect to an SSE endpoint and resolve with the first event matching the
+ *  predicate, or null on timeout. Aborts the stream when done. */
+async function readSseEvent(
+  url: string,
+  predicate: (e: { type: string; body: any }) => boolean,
+  timeoutMs = 3000,
+): Promise<{ type: string; body: any } | null> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal });
+    if (!res.body) return null;
+    const reader = res.body.getReader();
+    const dec = new TextDecoder();
+    let buf = '';
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) return null;
+      buf += dec.decode(value, { stream: true });
+      let idx: number;
+      while ((idx = buf.indexOf('\n\n')) !== -1) {
+        const frame = parseSseFrame(buf.slice(0, idx));
+        buf = buf.slice(idx + 2);
+        if (frame && predicate(frame)) return frame;
+      }
+    }
+  } catch (e) {
+    if (ctrl.signal.aborted) return null;
+    throw e;
+  } finally {
+    clearTimeout(timer);
+    ctrl.abort();
+  }
+}
+
 let handle: IpcServerHandle | null = null;
 
 afterEach(async () => {
@@ -249,6 +297,39 @@ describe('POST /api/sessions/:sessionId/resume', () => {
       else process.env.SESSION_DATA_DIR = prevDataDir;
       config.session.dataDir = prevConfigDataDir;
       rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('GET /api/events', () => {
+  it('replays current active sessions as session.spawned on connect (snapshot-on-connect)', async () => {
+    // Guards the descriptor→restore race: a dashboard that subscribes AFTER an
+    // empty hydrate (or after a restore-time announce it missed) must still learn
+    // every active row. The SSE handler subscribes then replays the live registry.
+    const registry = new Map<string, any>();
+    workerPool.setActiveSessionsRegistry(registry);
+    try {
+      registry.set(sessionKey('om_snap', 'cli_app'), {
+        session: {
+          sessionId: 'snap-1', chatId: 'oc_snap', rootMessageId: 'om_snap',
+          title: 't', status: 'active', createdAt: new Date(1000).toISOString(),
+          scope: 'thread', cliId: 'codex',
+        },
+        worker: null, workerPort: null, workerToken: null,
+        larkAppId: 'cli_app', chatId: 'oc_snap', chatType: 'group', scope: 'thread',
+        spawnedAt: 1000, cliVersion: 'test', lastMessageAt: 1000, hasHistory: true,
+      });
+
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      const ev = await readSseEvent(
+        `http://127.0.0.1:${handle.port}/api/events`,
+        e => e.type === 'session.spawned' && e.body?.session?.sessionId === 'snap-1',
+      );
+      expect(ev).not.toBeNull();
+      expect(ev!.body.session.status).toBe('starting'); // worker:null → no screen yet
+      expect(ev!.body.session.hasHistory).toBe(true);
+    } finally {
+      workerPool.setActiveSessionsRegistry(new Map());
     }
   });
 });

--- a/test/restore-zombie-close.test.ts
+++ b/test/restore-zombie-close.test.ts
@@ -140,11 +140,13 @@ vi.mock('../src/core/session-discovery.js', () => ({
 }));
 
 vi.mock('../src/core/session-activity.js', () => ({
+  announceSessionRow: vi.fn(),
   markSessionActivity: vi.fn(),
 }));
 
 import { restoreActiveSessions } from '../src/core/session-manager.js';
 import { forkWorker, closeSession } from '../src/core/worker-pool.js';
+import { announceSessionRow } from '../src/core/session-activity.js';
 import * as sessionStore from '../src/services/session-store.js';
 import { sessionKey } from '../src/core/types.js';
 import type { DaemonSession } from '../src/core/types.js';
@@ -157,6 +159,7 @@ beforeEach(() => {
   server.state = 'running';
   vi.mocked(closeSession).mockClear();
   vi.mocked(forkWorker).mockClear();
+  vi.mocked(announceSessionRow).mockClear();
 });
 
 afterEach(() => {
@@ -182,6 +185,10 @@ describe('restoreActiveSessions — persistent-backend zombie-close decision', (
 
     await restoreActiveSessions(map);
 
+    expect(announceSessionRow).toHaveBeenCalledTimes(1);
+    expect(announceSessionRow).toHaveBeenCalledWith(expect.objectContaining({
+      session: expect.objectContaining({ sessionId: s.sessionId }),
+    }));
     expect(closeSession).toHaveBeenCalledWith(s.sessionId);
     expect([...map.values()].some(v => v.session.sessionId === s.sessionId)).toBe(false);
     expect(sessionStore.getSession(s.sessionId)!.status).toBe('closed');
@@ -201,6 +208,7 @@ describe('restoreActiveSessions — persistent-backend zombie-close decision', (
 
     await restoreActiveSessions(map);
 
+    expect(announceSessionRow).toHaveBeenCalledTimes(1);
     expect(closeSession).not.toHaveBeenCalled();
     const ds = map.get(sessionKey('om_reboot', 'app_test'));
     expect(ds).toBeDefined();              // active record retained…
@@ -220,6 +228,7 @@ describe('restoreActiveSessions — persistent-backend zombie-close decision', (
 
     await restoreActiveSessions(map);
 
+    expect(announceSessionRow).toHaveBeenCalledTimes(3);
     expect(closeSession).not.toHaveBeenCalled();
     for (const s of [a, b, c]) {
       expect(map.get(sessionKey(s.rootMessageId, 'app_test'))).toBeDefined();

--- a/test/session-resume.test.ts
+++ b/test/session-resume.test.ts
@@ -115,6 +115,7 @@ vi.mock('../src/core/session-discovery.js', () => ({
 }));
 
 vi.mock('../src/core/session-activity.js', () => ({
+  announceSessionRow: vi.fn(),
   markSessionActivity: vi.fn(),
 }));
 


### PR DESCRIPTION
## 背景 / Problem Found

这次修改是排查线上问题时发现的：botmux 重启前有 3 个会话在 dashboard 上表现为 `starting`，重启后这些会话在 dashboard 里看不到了。

排查后确认，`starting` 不是持久化的 `Session.status`，而是 dashboard 根据 active session 缺少 screen/status 派生出来的展示状态。daemon 重启时 `restoreActiveSessions()` 会把 active session 注册回内存，但此前不会向 dashboard SSE 广播完整 session row。如果 dashboard 在 hydrate/SSE 时序上先收到后续 `session.update` / close 事件，却本地还没有对应 row，这些 patch 就会被当成 unknown row 忽略，最终表现为恢复/关闭状态在 dashboard 消失。

## What Changed

- Added `announceSessionRow(ds)` to publish a full `session.spawned` dashboard row from `composeRowFromActive(ds)`.
- Reused that helper from `announcePendingRepoSession()` so session row announcements share one path.
- Updated `restoreActiveSessions()` to announce restored normal sessions and restored adopt sessions immediately after they are registered into `activeSessions`.
- Added optional `wake=1` support to `POST /api/sessions/:sessionId/resume`.
  - Default behavior is unchanged: resume marks a closed session active and waits for the next inbound message to cold-resume the CLI.
  - With `wake=1`, the route immediately calls `forkWorker(ds, '', true)` after a successful resume, which is useful for operational recovery when a session must be usable right away.

## Impact

- Restored sessions become visible to dashboard subscribers even when dashboard hydrate and daemon restore race with each other.
- Subsequent status/close updates are applied to a known row instead of being dropped as unknown.
- Existing resume callers keep the same behavior unless they explicitly opt into `wake=1`.

## Validation

- `corepack pnpm vitest run --project unit test/dashboard-ipc.test.ts test/dashboard-attention-signals.test.ts test/restore-zombie-close.test.ts`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`