### PR TITLE
fix(dashboard): SSE 建连回放本进程关闭的会话，修 restore 期 zombie row 看板丢失/残留 stale-active

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -76,6 +76,12 @@ import type { DaemonSession } from './types.js';
 import { attachSkillPolicy, detachSkillPolicy } from './skills/im-command.js';
 import { readSkillRegistry } from '../services/skill-registry-store.js';
 
+// Daemon process start (module load ≈ daemon boot). Used by the SSE snapshot
+// replay to bound the "recently closed" set to sessions that flipped
+// active→closed during THIS run — i.e. restore-time zombies — without replaying
+// the entire closed-session history on every connect.
+const PROCESS_START_MS = Date.now();
+
 export interface IpcServerHandle {
   port: number;
   close: () => Promise<void>;
@@ -1602,8 +1608,30 @@ ipcRoute('GET', '/api/events', (_req, res) => {
   // aggregator and the browser store upsert by sessionId, so any row also
   // delivered live just refreshes the same entry.
   try {
+    const activeIds = new Set<string>();
     for (const ds of listActiveSessions()) {
+      activeIds.add(ds.session.sessionId);
       res.write(`event: session.spawned\ndata: ${JSON.stringify({ session: composeRowFromActive(ds) })}\n\n`);
+    }
+    // Also replay sessions CLOSED during this run as `session.spawned` carrying a
+    // closed row. The active-only replay above can't cover a restore-time zombie:
+    // restoreActiveSessions registers it, announces it, then immediately probes it
+    // 'missing' and closeSession()s it (evicting it from the active Map) — all
+    // before a racing dashboard's SSE subscription exists. By connect time it is
+    // neither in the active Map nor was it a closed row at the dashboard's early
+    // (pre-restore) hydrate, so without this it stays invisible (or, if the
+    // dashboard cached it active from before the restart, lingers as a stale
+    // active row — hydrateSessions only upserts, never deletes absent rows).
+    // Bounded to closedAt >= PROCESS_START_MS so we replay only this run's
+    // closures (the full closed history is already served by GET /api/sessions
+    // on hydrate). `session.spawned` (not session.update) because the row may be
+    // unknown to the client — both consumers upsert by sessionId, and the closed
+    // row's status:'closed' overwrites any stale active entry.
+    for (const s of sessionStore.listSessions()) {
+      if (s.status !== 'closed' || activeIds.has(s.sessionId)) continue;
+      const closedMs = s.closedAt ? Date.parse(s.closedAt) : NaN;
+      if (!Number.isFinite(closedMs) || closedMs < PROCESS_START_MS) continue;
+      res.write(`event: session.spawned\ndata: ${JSON.stringify({ session: composeRowFromClosed(s) })}\n\n`);
     }
   } catch (err) {
     logger.warn(`[dashboard-ipc] /api/events snapshot replay failed: ${err}`);

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -332,6 +332,47 @@ describe('GET /api/events', () => {
       workerPool.setActiveSessionsRegistry(new Map());
     }
   });
+
+  it('replays this-run closed sessions as session.spawned (zombie-close visibility)', async () => {
+    // A restore-time zombie is registered, announced, then immediately
+    // closeSession()'d (evicted from the active Map) — all before a racing
+    // dashboard's SSE subscription exists. By connect time it's gone from the Map,
+    // so the active-only replay can't surface it. The closed-since-process-start
+    // replay must still deliver it as a closed row so the dashboard doesn't lose
+    // it (or keep a stale active entry).
+    const dataDir = mkdtempSync(join(tmpdir(), 'dashboard-ipc-sse-closed-'));
+    const prevDataDir = process.env.SESSION_DATA_DIR;
+    const prevConfigDataDir = config.session.dataDir;
+    const registry = new Map<string, any>();
+    try {
+      config.session.dataDir = dataDir;
+      sessionStore.init();
+      workerPool.setActiveSessionsRegistry(registry); // empty — zombie already evicted
+
+      const session = sessionStore.createSession('oc_zombie', 'om_zombie', 'zombie topic', 'group');
+      session.larkAppId = '';
+      session.scope = 'thread';
+      session.cliId = 'codex' as any;
+      sessionStore.updateSession(session);
+      sessionStore.closeSession(session.sessionId); // closedAt = now ≥ PROCESS_START_MS
+
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      const ev = await readSseEvent(
+        `http://127.0.0.1:${handle.port}/api/events`,
+        e => e.type === 'session.spawned' && e.body?.session?.sessionId === session.sessionId,
+      );
+      expect(ev).not.toBeNull();
+      expect(ev!.body.session.status).toBe('closed');
+      expect(typeof ev!.body.session.closedAt).toBe('number');
+    } finally {
+      workerPool.setActiveSessionsRegistry(new Map());
+      sessionStore.init();
+      if (prevDataDir === undefined) delete process.env.SESSION_DATA_DIR;
+      else process.env.SESSION_DATA_DIR = prevDataDir;
+      config.session.dataDir = prevConfigDataDir;
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('GET /api/sessions/:sessionId/write-link', () => {


### PR DESCRIPTION
## 背景

#277（已合并）的 follow-up，处理 Codex 二审第三轮发现的残留时序洞。

#277 让 `GET /api/events` 建连时**先 subscribe 再回放当前活跃会话快照**，确定性修住了「daemon 重启后仍 active 的恢复会话在看板消失」。但那次回放只遍历 active Map，没覆盖 **restore 期间被关闭的 zombie 会话**。

## 问题

restore 期间，一个「backing pane 单独死掉」的 zombie 会话会被 `restoreActiveSessions()`：注册进 active Map → `announceSessionRow()` 广播 `session.spawned` → 立刻 probe 到 `missing` → `closeSession()`（从 active Map 删除、置 store 行 closed）。

如果一个 dashboard 恰好在 daemon「发布发现 descriptor（restore 之前）→ restore 完成」这个窗口里重连：
- 它的初始 `GET /api/sessions` hydrate 在 restore 前发生，拿到的 active 为空、该 zombie 当时还是 `status=active` 不在 closed rows 里 → **完全没拿到**；
- 上面那两个事件（spawned + close）都早于它的 SSE 订阅建立 → `DashboardEventBus` 无 buffer 全丢；
- 等它 SSE 连上，zombie 已不在 active Map → #277 的 active-only 回放补不到它。

结果：新建 aggregator 永远看不到它；若该 dashboard 进程**原本缓存它为 active**，`hydrateSessions()` 只 upsert 不删 absent 行 → **残留一条 stale active**（已死会话在看板显示成活的）。

## 改动

`/api/events` 的 snapshot-on-connect 在回放活跃会话后，**再回放「`closedAt ≥ 进程启动时刻` 的已关会话」**（`composeRowFromClosed` 作 `session.spawned` 发出）：

- 按**进程启动时刻**过滤 = 只补本次 run 内发生的关闭（正好覆盖 restore 期 zombie 与本 run 内任何关闭），不回放整个 closed 历史——完整历史本就由 `GET /api/sessions` hydrate 提供。
- 用 `session.spawned`（而非 `session.update`）：目标行可能对该客户端未知，`update` 会被当 unknown row 丢；两端（aggregator / 前端 store）均按 `sessionId` upsert，closed 行的 `status:'closed'` 会覆盖任何 stale active 条目，stale-active 一并修掉。
- active 行已收集进 `activeIds`，跳过避免与活跃会话重复。

## 验证

- `pnpm exec tsc --noEmit` 绿。
- 新增回归测试：注册表为空（zombie 已被 evict）+ store 里有本 run 关闭的会话 → 连 `/api/events` 仍收到该会话的 `session.spawned`（`status==='closed'`、`closedAt` 为数字）。
- 全量 `pnpm test`：4946 passed，22 failed 全是已知 env 失败（`workflow-cli*` / `whiteboard-cli` / `preset-export-cli` / `workflow-c0-isolation`，CLI 子进程测试，与本 PR 无关）。