### PR TITLE
fix(dashboard): 创建会话内容输入框去掉 8000 字上限

### DIFF
--- a/src/core/session-create.ts
+++ b/src/core/session-create.ts
@@ -23,7 +23,6 @@ export type CreateSessionColumn = (typeof CREATE_SESSION_COLUMNS)[number];
 export type SpawnRole = 'solo' | 'lead' | 'collab';
 export const SPAWN_ROLES: readonly SpawnRole[] = ['solo', 'lead', 'collab'];
 
-export const CREATE_SESSION_CONTENT_MAX = 8000;
 const TITLE_MAX = 50;
 
 export interface Coworker {
@@ -141,7 +140,6 @@ export function parseSpawnRequest(body: unknown): ParseResult<SpawnRequest> {
   const rawContent = typeof b.content === 'string' ? b.content : '';
   const content = rawContent.replace(/\s+$/u, '');
   if (!content.trim()) return { ok: false, error: 'empty_content' };
-  if (content.length > CREATE_SESSION_CONTENT_MAX) return { ok: false, error: 'content_too_long' };
   const column = normalizeCreateColumn(b.column);
   if (!column) return { ok: false, error: 'bad_column' };
   const role = normalizeSpawnRole(b.role);

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -2200,7 +2200,6 @@ const server = createServer(async (req, res) => {
       }
       const content = typeof parsed.content === 'string' ? parsed.content.replace(/\s+$/u, '') : '';
       if (!content.trim()) return jsonRes(res, 400, { ok: false, error: 'empty_content' });
-      if (content.length > 8000) return jsonRes(res, 400, { ok: false, error: 'content_too_long' });
       const selectedIds = Array.isArray(parsed.larkAppIds)
         ? Array.from(new Set((parsed.larkAppIds as unknown[]).filter((x): x is string => typeof x === 'string')))
         : [];

--- a/test/session-create.test.ts
+++ b/test/session-create.test.ts
@@ -7,7 +7,6 @@ import {
   composeSpawnUserContent,
   buildLeadDispatchPreamble,
   buildCollabNote,
-  CREATE_SESSION_CONTENT_MAX,
 } from '../src/core/session-create.js';
 
 describe('normalizeCreateMode / normalizeCreateColumn', () => {
@@ -64,9 +63,11 @@ describe('parseSpawnRequest', () => {
     expect(parseSpawnRequest({ ...base, content: '' })).toMatchObject({ ok: false, error: 'empty_content' });
   });
 
-  it('rejects content over the size cap', () => {
-    const huge = 'a'.repeat(CREATE_SESSION_CONTENT_MAX + 1);
-    expect(parseSpawnRequest({ ...base, content: huge })).toMatchObject({ ok: false, error: 'content_too_long' });
+  it('accepts very long content (no size cap — owner-authed input)', () => {
+    const huge = 'a'.repeat(50000);
+    const r = parseSpawnRequest({ ...base, content: huge });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.content.length).toBe(50000);
   });
 
   it('rejects bad column / role', () => {


### PR DESCRIPTION
## 背景
申晗反馈：创建会话的内容输入框看着没有字数上限，感觉没必要加限制。

## 现状
- 前端 textarea **没有 maxlength**（可随意输入）。
- 后端有 **8000 字硬上限**两处：`parseSpawnRequest`（daemon `/api/sessions/spawn`）和聚合器 `/api/sessions/create`，超了返回 `content_too_long`。
- 副作用：前端不限、后端拒，长任务描述会在提交时被静默挡下。

## 改动
去掉两处 `content_too_long` 校验 + 删除 `CREATE_SESSION_CONTENT_MAX` 常量，保留非空校验。dashboard 是 owner 鉴权后的自有输入，内容即用户自己的任务 prompt，无需人为上限。

单测：把「超长拒绝」用例改为「超长（50000 字）应通过」。tsc + 5017 单测全过。