### PR TITLE
feat(skills): 发现 Claude plugin/marketplace 里的 skill 并纳入 dashboard 可注册

### DIFF
--- a/src/core/skills/discovery.ts
+++ b/src/core/skills/discovery.ts
@@ -1,6 +1,6 @@
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { createCliAdapterSync } from '../../adapters/cli/registry.js';
 import type { CliId } from '../../adapters/cli/types.js';
 import { loadSkillPackage } from './package.js';
@@ -10,6 +10,10 @@ export interface NativeCliSkillGroup {
   cliId: CliId;
   rootDir: string;
   skills: SkillPackage[];
+  /** Dashboard tab label. Absent → render `cliId` (a CLI's flat native skills
+   *  tab). Set for Claude plugin / marketplace groups so they're distinguishable
+   *  from — and from each other beside — the plain `claude` tab. */
+  label?: string;
 }
 
 function expandHome(path: string): string {
@@ -41,6 +45,54 @@ function discoverSkillRoot(root: string): SkillPackage[] {
   return out.sort((a, b) => a.name.localeCompare(b.name));
 }
 
+/**
+ * Discover skills that live inside Claude Code's plugin system — which the flat
+ * `<claudeDataDir>/skills` scan never reaches. Two sources, each surfaced as its
+ * own labelled group so the dashboard can show + register them like any other
+ * discovered skill:
+ *   1. Enabled plugins in `plugins/installed_plugins.json` → each install's
+ *      `<installPath>/skills/<name>/SKILL.md` (e.g. the `frontend-design` plugin).
+ *   2. Marketplace skill collections at `plugins/marketplaces/<m>/skills/`
+ *      (e.g. `anthropic-agent-skills`, the anthropics/skills repo).
+ * Plugins with no `skills/` dir (e.g. gopls-lsp) contribute nothing.
+ */
+export function discoverClaudePluginSkillGroups(
+  claudeDataDir: string,
+  cliId: CliId,
+  seen: Set<string> = new Set(),
+): NativeCliSkillGroup[] {
+  const pluginsRoot = join(claudeDataDir, 'plugins');
+  const out: NativeCliSkillGroup[] = [];
+
+  const addGroup = (skillsRoot: string, label: string): void => {
+    if (seen.has(skillsRoot)) return;
+    const skills = discoverSkillRoot(skillsRoot);
+    if (skills.length === 0) return; // no SKILL.md under here — nothing to show
+    seen.add(skillsRoot);
+    out.push({ cliId, rootDir: skillsRoot, label, skills });
+  };
+
+  // 1. Enabled plugins (installed_plugins.json → <installPath>/skills).
+  try {
+    const parsed = JSON.parse(readFileSync(join(pluginsRoot, 'installed_plugins.json'), 'utf-8')) as {
+      plugins?: Record<string, Array<{ installPath?: string }>>;
+    };
+    for (const [key, entries] of Object.entries(parsed.plugins ?? {})) {
+      const pluginName = key.split('@')[0]; // "frontend-design@marketplace" → "frontend-design"
+      for (const entry of entries ?? []) {
+        if (entry?.installPath) addGroup(join(entry.installPath, 'skills'), `${pluginName} (plugin)`);
+      }
+    }
+  } catch { /* no/unreadable installed_plugins.json — fine */ }
+
+  // 2. Marketplace-level skill collections (marketplaces/<m>/skills).
+  for (const marketplace of listSkillDirs(join(pluginsRoot, 'marketplaces'))) {
+    addGroup(join(marketplace, 'skills'), `${basename(marketplace)} (marketplace)`);
+  }
+
+  return out;
+}
+
 export function discoverNativeCliSkillGroups(cliIds: readonly CliId[]): NativeCliSkillGroup[] {
   const out: NativeCliSkillGroup[] = [];
   const seen = new Set<string>();
@@ -63,6 +115,11 @@ export function discoverNativeCliSkillGroups(cliIds: readonly CliId[]): NativeCl
       if (seen.has(root)) continue;
       seen.add(root);
       out.push({ cliId, rootDir: root, skills: discoverSkillRoot(root) });
+    }
+    // Claude Code plugin system: skills bundled inside enabled plugins or
+    // marketplaces, which the flat native-skills scan above never reaches.
+    if (adapter.claudeDataDir) {
+      out.push(...discoverClaudePluginSkillGroups(expandHome(adapter.claudeDataDir), cliId, seen));
     }
   }
   return out;

--- a/src/dashboard/web/skills.ts
+++ b/src/dashboard/web/skills.ts
@@ -12,6 +12,8 @@ interface NativeSkillGroup {
   cliId: string;
   rootDir: string;
   skills: SkillRow[];
+  /** Tab label (Claude plugin / marketplace groups set this); falls back to cliId. */
+  label?: string;
 }
 
 interface BotRow {
@@ -170,7 +172,7 @@ function renderDiscoveryDialog(): string {
           const key = discoveryGroupKey(group);
           const selected = key === discoveryGroupKey(active);
           return `<button type="button" role="tab" data-discovery-tab="${escapeHtml(key)}" class="${selected ? 'selected' : ''}" aria-selected="${selected ? 'true' : 'false'}">
-            <strong>${escapeHtml(group.cliId)}</strong>
+            <strong>${escapeHtml(group.label ?? group.cliId)}</strong>
             <small>${t('skills.skillCount', { count: group.skills.length })}</small>
           </button>`;
         }).join('')}

--- a/test/skill-discovery.test.ts
+++ b/test/skill-discovery.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'nod
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { discoverNativeCliSkillGroups, discoverProjectSkills } from '../src/core/skills/discovery.js';
+import { discoverClaudePluginSkillGroups, discoverNativeCliSkillGroups, discoverProjectSkills } from '../src/core/skills/discovery.js';
 
 function write(file: string, content: string): void {
   mkdirSync(dirname(file), { recursive: true });
@@ -94,5 +94,59 @@ describe('skill discovery', () => {
     expect(groups[0].rootDir).toBe(join(home, '.trae', 'skills'));
     expect(groups[0].skills.map((s) => s.name)).toEqual(['shared']);
     rmSync(home, { recursive: true, force: true });
+  });
+
+  it('discovers Claude plugin + marketplace skills under a claudeDataDir', () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-claude-data-'));
+    const pluginsRoot = join(dataDir, 'plugins');
+
+    // Enabled plugin WITH skills: installed_plugins.json → <installPath>/skills.
+    const installPath = join(pluginsRoot, 'cache', 'mkt', 'frontend-design', '1.0.0');
+    write(join(installPath, 'skills', 'fe-skill', 'SKILL.md'), '---\nname: fe-skill\ndescription: FE\n---');
+    // Enabled plugin WITHOUT a skills/ dir (e.g. gopls-lsp) → contributes nothing.
+    const lspPath = join(pluginsRoot, 'cache', 'mkt', 'gopls-lsp', '1.0.0');
+    write(join(lspPath, 'README.md'), '# no skills here');
+    write(join(pluginsRoot, 'installed_plugins.json'), JSON.stringify({
+      version: 2,
+      plugins: {
+        'frontend-design@mkt': [{ scope: 'user', installPath }],
+        'gopls-lsp@mkt': [{ scope: 'user', installPath: lspPath }],
+      },
+    }));
+    // Marketplace-level skill collection (e.g. anthropic-agent-skills).
+    write(join(pluginsRoot, 'marketplaces', 'anthropic-agent-skills', 'skills', 'pdf', 'SKILL.md'), '---\nname: pdf\n---');
+
+    const groups = discoverClaudePluginSkillGroups(dataDir, 'claude-code');
+
+    const fe = groups.find((g) => g.label === 'frontend-design (plugin)');
+    expect(fe).toBeDefined();
+    expect(fe?.cliId).toBe('claude-code');
+    expect(fe?.rootDir).toBe(join(installPath, 'skills'));
+    expect(fe?.skills.map((s) => s.name)).toEqual(['fe-skill']);
+
+    // A plugin without a skills/ dir produces no group.
+    expect(groups.some((g) => g.label?.startsWith('gopls-lsp'))).toBe(false);
+
+    const mp = groups.find((g) => g.label === 'anthropic-agent-skills (marketplace)');
+    expect(mp).toBeDefined();
+    expect(mp?.skills.map((s) => s.name)).toEqual(['pdf']);
+
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('honors the shared `seen` set so a root claimed elsewhere is not re-added', () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-claude-data-'));
+    const skillsRoot = join(dataDir, 'plugins', 'marketplaces', 'mp', 'skills');
+    write(join(skillsRoot, 's', 'SKILL.md'), '---\nname: s\n---');
+
+    expect(discoverClaudePluginSkillGroups(dataDir, 'claude-code', new Set([skillsRoot]))).toEqual([]);
+
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('returns [] when the claudeDataDir has no plugins dir', () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-claude-empty-'));
+    expect(discoverClaudePluginSkillGroups(dataDir, 'claude-code')).toEqual([]);
+    rmSync(dataDir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## 问题

dashboard「Skills 工作区 → 发现 skills」此前**完全看不到 Claude Code plugin 体系里的 skill**——只能勾选注册各 CLI native 扁平目录(`~/.claude/skills` 等)里的 skill。用户装了 Claude plugin、或用了 marketplace skill(如 `anthropic-agent-skills` 的 docx/pdf/canvas-design…),在发现列表里一个都看不到,也就没法把它们纳入 botmux 的 per-bot 优先披露。

## 根因

`discoverNativeCliSkillGroups`(`src/core/skills/discovery.ts`)只扫两类根:`adapter.claudeDataDir/skills` 和 `adapter.skillsDir`——都是**扁平的 `skills/<name>/SKILL.md`**。而 Claude plugin 的 skill 在另一套布局里,扫描从不进入:

- 已启用 plugin:`plugins/installed_plugins.json` → 每个 install 的 `<installPath>/skills/<name>/SKILL.md`
- marketplace 级 skill 集:`plugins/marketplaces/<m>/skills/<name>/SKILL.md`

## 改动

对有 `claudeDataDir` 的 adapter,额外发现上述两类 plugin skill(新增 `discoverClaudePluginSkillGroups`),每个 plugin / marketplace 作为一个**带 `label` 的发现 group**,复用现有的展示 + 勾选注册链路:

- 无 `skills/` 目录的 plugin(如 `gopls-lsp`)不产生 group;
- 沿用全局 `seen` 集去重,不会和 native 组重复;
- `NativeCliSkillGroup` 加可选 `label`,前端 tab 用 `label ?? cliId` 渲染,把 `frontend-design (plugin)` / `anthropic-agent-skills (marketplace)` 和裸 `claude-code` tab 区分开。
- dashboard 后端(`dashboardSkillsPayload`)零改动——它本就调 `discoverNativeCliSkillGroups`,透明拿到新 group。

## 验证

**真实环境**(对本机 `~/.claude/plugins` 直接跑):

```
• frontend-design (plugin)            → 1 skills: frontend-design
• anthropic-agent-skills (marketplace) → 18 skills: algorithmic-art, brand-guidelines,
                                          canvas-design, claude-api, doc-coauthoring, docx …
```

**单测**:`test/skill-discovery.test.ts` 新增 3 例(enabled plugin + marketplace 发现 / 无 `skills/` 的 plugin 不产生 group / `seen` 去重 / 无 `plugins` 目录返回 `[]`)。`pnpm build` 通过;发现 + 注册相关既有测试(skill-discovery / skill-package / skill-registry-store / dashboard-skill-install-request / command-handler)全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
