### PR TITLE
fix(dashboard): 创建会话群横幅发完整内容,去掉 300 字截断

### DIFF
--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -1458,12 +1458,13 @@ export async function spawnDashboardSession(
 
   // 可见任务横幅：只由 creator/lead 那次 spawn 发一条，给群成员交代这群是干嘛的。
   // 纯文本、不 @ 任何 bot，不会误触发其它 bot。rootMessageId 存它仅为留痕（chat-scope
-  // 路由不看 rootMessageId）。失败不致命。
+  // 路由不看 rootMessageId）。失败不致命。横幅发完整内容——之前 slice(0,300) 会把超
+  // 300 字的任务在群里截断（用户看着像"内容丢了"，其实会话拿到的是全文，只是横幅被切）。
   let bannerMessageId: string | undefined;
   if (args.postBanner) {
     try {
       const { sendMessage } = await import('../im/lark/client.js');
-      bannerMessageId = await sendMessage(larkAppId, chatId, t('cmd.createSession.banner', { content: content.slice(0, 300) }, locale));
+      bannerMessageId = await sendMessage(larkAppId, chatId, t('cmd.createSession.banner', { content }, locale));
     } catch (err: any) {
       logger.warn(`[createSession] banner send failed in ${chatId}: ${err?.message ?? err}`);
     }

--- a/test/dashboard-create-session.test.ts
+++ b/test/dashboard-create-session.test.ts
@@ -117,6 +117,18 @@ describe('spawnDashboardSession — backlog (待办池) parks without starting t
     expect(sendMessageMock).toHaveBeenCalledTimes(1);
   });
 
+  it('banner posts the FULL content (no 300-char truncation that dropped the tail in the group)', async () => {
+    const active = new Map<string, DaemonSession>();
+    // >300 chars so the tail sits past the old slice(0,300) cutoff
+    const longContent = '前缀内容'.repeat(90) + '怎么验\n1. 第一步\n2. 第二步收尾';
+    expect(longContent.length).toBeGreaterThan(300);
+    await spawnDashboardSession(active, undefined, {
+      larkAppId: APP, chatId: CHAT, content: longContent, column: 'backlog', role: 'solo', postBanner: true,
+    });
+    const bannerText = sendMessageMock.mock.calls[0][2] as string;
+    expect(bannerText).toContain('第二步收尾'); // tail must survive — was dropped by the 300-char slice
+  });
+
   it('lead-role backlog stores the orchestration preamble in queuedPrompt (preserved through activation)', async () => {
     const active = new Map<string, DaemonSession>();
     await spawnDashboardSession(active, undefined, {


### PR DESCRIPTION
## 现象
申晗反馈：创建会话后，发到飞书群里的任务内容在「怎么验」之后就没了——超过约 300 字的部分没出现在群里。

## 根因
`spawnDashboardSession` 发到群里的「📋 新会话任务」横幅用了 `content.slice(0, 300)`，把超过 300 字的任务在群里截断。用户的内容超过 300 字，「怎么验」恰好落在 300 字附近，所以群里横幅在那里被切。

**注意**：被截断的只是群里的展示横幅；会话真正喂给机器人的 prompt（queuedPrompt / lead 首轮内容）一直是**全文**，没丢——只是用户从群里看不到全部。

## 改动
去掉横幅的 `slice(0, 300)`，发完整内容（与刚去掉的 8000 字上限一致，不再人为截断）。加回归测试：>300 字内容的横幅必须包含末尾文字。

tsc + 5018 单测全过。