### PR TITLE
ci(github): add build smoke workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - run: npm install -g pnpm@9.5.0
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build


### PR DESCRIPTION
## Summary

- add a lightweight CI workflow for pull requests and pushes to `master`
- run the same Node 22 + pnpm install path used by release validation
- validate dependency installation with `--frozen-lockfile` and run `pnpm build`

## Why

The repository currently validates builds during tagged releases, but pull requests can be opened without an automated install/build check. This adds an early smoke gate for TypeScript and dashboard bundle regressions before release time.

## Notes

This first workflow intentionally stays scoped to build smoke. I did not include `pnpm test` here because the current local macOS unit baseline already has unrelated platform-sensitive failures in `test/git-worktree.test.ts`, `test/repo-selection.test.ts`, and `test/sandbox.test.ts`. A follow-up PR can add unit CI after those baseline issues are handled or scoped for CI.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm test` was checked for CI suitability and still fails locally on the existing macOS baseline described above.
