### PR TITLE
feat(backend): tmux 不可用时明确报错引导，不再静默退回 PTY（PTY 退役第一步）

### DIFF
--- a/src/adapters/backend/session-backend-selector.ts
+++ b/src/adapters/backend/session-backend-selector.ts
@@ -5,6 +5,52 @@ import { TmuxPipeBackend } from './tmux-pipe-backend.js';
 import { ZellijBackend } from './zellij-backend.js';
 import type { BackendType, SessionBackend } from './types.js';
 
+export type BackendGateDecision =
+  | { action: 'spawn' }
+  | { action: 'gate'; reason: string };
+
+/**
+ * Hard gate (PTY 退役): a requested *persistent* backend (tmux/herdr/zellij)
+ * that isn't functional on this host no longer silently degrades to raw PTY.
+ * That silent fallback was the root of the "secretly running on PTY, then
+ * hitting all of PTY's problems (no survival across daemon restart, etc.)"
+ * bug class. Instead the worker refuses to spawn and posts an actionable card.
+ *
+ * PTY stays reachable ONLY as an explicit opt-in — `BACKEND_TYPE=pty` or a
+ * per-bot `backendType: 'pty'` — which arrives here as `requested === 'pty'`
+ * and is always allowed straight through.
+ *
+ * An already-running persistent session reattaches regardless of a transient
+ * probe failure (a disposable "can we start a new server?" probe is far less
+ * authoritative than a live session — see PR#249): abandoning it would spawn a
+ * duplicate CLI and orphan the real conversation.
+ */
+export function decideBackendGate(opts: {
+  requested: BackendType;
+  available: boolean;
+  hasExistingSession: boolean;
+}): BackendGateDecision {
+  if (opts.requested === 'pty') return { action: 'spawn' };
+  if (opts.hasExistingSession) return { action: 'spawn' };
+  if (opts.available) return { action: 'spawn' };
+  return { action: 'gate', reason: `${opts.requested} 后端在本机不可用` };
+}
+
+/** User-facing card shown when {@link decideBackendGate} gates a session. */
+export function backendGateUserMessage(backend: BackendType, reason: string): string {
+  const installHint =
+    backend === 'tmux'
+      ? 'macOS: brew install tmux ｜ Debian/Ubuntu: sudo apt-get install -y tmux ｜ 其它发行版用对应包管理器安装 tmux'
+      : `请确认 ${backend} 已正确安装并可用`;
+  return [
+    `⚠️ 本机 ${backend} 不可用，无法启动会话。`,
+    `原因：${reason}`,
+    `请安装/修复后重试 —— ${installHint}`,
+    `（如确需在没有 ${backend} 的环境运行，可显式设置环境变量 BACKEND_TYPE=pty 用 PTY 后端兜底；` +
+      `但 PTY 会话不跨 daemon 重启存活，仅作应急。）`,
+  ].join('\n');
+}
+
 export interface SelectedSessionBackend {
   backend: SessionBackend;
   isTmuxMode: boolean;

--- a/src/adapters/backend/session-backend-selector.ts
+++ b/src/adapters/backend/session-backend-selector.ts
@@ -20,10 +20,13 @@ export type BackendGateDecision =
  * per-bot `backendType: 'pty'` — which arrives here as `requested === 'pty'`
  * and is always allowed straight through.
  *
- * An already-running persistent session reattaches regardless of a transient
- * probe failure (a disposable "can we start a new server?" probe is far less
- * authoritative than a live session — see PR#249): abandoning it would spawn a
- * duplicate CLI and orphan the real conversation.
+ * `hasExistingSession` lets an already-running persistent session reattach
+ * regardless of a transient probe failure (a disposable "can we start a new
+ * server?" probe is far less authoritative than a live session — see PR#249):
+ * abandoning it would spawn a duplicate CLI and orphan the real conversation.
+ * The caller computes it only for backends whose probe is a disposable
+ * session (tmux, zellij); herdr's probe is a cheap non-destructive
+ * `herdr --version`, so it passes `hasExistingSession: false`.
  */
 export function decideBackendGate(opts: {
   requested: BackendType;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1425,10 +1425,9 @@ async function ensureSystemDependencies(): Promise<void> {
     return;
   }
 
-  let anyBotWantsTmux = false;
-  try {
-    anyBotWantsTmux = loadBotsJson().some(b => (b?.backendType ?? config.daemon.backendType) === 'tmux');
-  } catch { /* no/unreadable bots.json — treat as "no bot wants tmux" */ }
+  // loadBotsJson() returns [] when bots.json is absent (→ no bot wants tmux) and
+  // hard-exits on a malformed file (existing fast-fail) — it never throws here.
+  const anyBotWantsTmux = loadBotsJson().some(b => (b?.backendType ?? config.daemon.backendType) === 'tmux');
   const ptyOptIn = (process.env.BACKEND_TYPE ?? '').toLowerCase() === 'pty';
 
   if (shouldHardFailStartupForMissingTmux({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1404,17 +1404,46 @@ async function cmdRestart(): Promise<void> {
   await printDashboardHintWithRetry();
 }
 
-/** Wraps `ensureDependencies()`. Neither tmux nor fonts are load-bearing —
- *  ensureDependencies surfaces failures as warnings and the daemon continues
- *  on PTY backend. Only an unexpected exception (programmer error) propagates. */
+/** Wraps `ensureDependencies()`. Fonts are nice-to-have (warn only). tmux is
+ *  required since PTY 退役: if it's GENUINELY ABSENT and a bot wants the tmux
+ *  backend (and the operator hasn't opted into BACKEND_TYPE=pty), we hard-fail
+ *  here — non-zero exit, no pm2 spawn — so an unattended `start`/`restart`
+ *  surfaces the failure instead of bringing up a daemon whose every session
+ *  would gate at first message. A present-but-broken tmux (functional probe
+ *  flaked) is NOT fatal: the daemon still starts and degrades per-session, so a
+ *  transient probe failure can't block reattaching live sessions (PR#249). An
+ *  unexpected exception in the probe itself is non-fatal for the same reason. */
 async function ensureSystemDependencies(): Promise<void> {
-  const { ensureDependencies } = await import('./setup/index.js');
+  const { ensureDependencies, shouldHardFailStartupForMissingTmux } = await import('./setup/index.js');
+  let report: Awaited<ReturnType<typeof ensureDependencies>>;
   try {
-    await ensureDependencies();
+    report = await ensureDependencies();
   } catch (err: any) {
     console.error('');
     console.error(`依赖检测内部错误: ${err?.message ?? String(err)}`);
-    // Don't exit — let daemon start try anyway; worst case PTY backend works.
+    // Don't exit — a probe-internal error is not a confirmed "tmux missing".
+    return;
+  }
+
+  let anyBotWantsTmux = false;
+  try {
+    anyBotWantsTmux = loadBotsJson().some(b => (b?.backendType ?? config.daemon.backendType) === 'tmux');
+  } catch { /* no/unreadable bots.json — treat as "no bot wants tmux" */ }
+  const ptyOptIn = (process.env.BACKEND_TYPE ?? '').toLowerCase() === 'pty';
+
+  if (shouldHardFailStartupForMissingTmux({
+    tmuxInstalled: report.tmux.installed,
+    tmuxBinaryPresent: report.tmux.binaryPresent === true,
+    anyBotWantsTmux,
+    ptyOptIn,
+  })) {
+    console.error('');
+    console.error('❌ tmux 未安装，已中止 daemon 启动 —— 默认走 tmux 后端的会话将全部无法运行。');
+    console.error('   请按上方指引安装 tmux 后重试。');
+    console.error('   如确需在没有 tmux 的环境运行，可显式用 PTY 兜底：BACKEND_TYPE=pty botmux start');
+    console.error('   （注意：PTY 会话不跨 daemon 重启存活，仅作应急。）');
+    console.error('');
+    process.exit(1);
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,5 @@
 import { networkInterfaces } from 'node:os';
 import type { BackendType } from './adapters/backend/types.js';
-import { probeTmuxFunctional } from './setup/ensure-tmux.js';
 import { resolveWorkerHttpHost } from './utils/worker-http.js';
 
 /** Get the first non-loopback IPv4 address, fallback to localhost. */
@@ -26,15 +25,19 @@ export function getDashboardExternalHost(): string {
 }
 
 /**
- * Pick the session backend. tmux is preferred (enables /adopt + per-client
- * Web terminal attach) but only if it can actually start a server. The old
- * check was `tmux -V`, which passes on machines where tmux is installed but
- * broken (perms / config / linkage) and leaves the worker spamming "error
- * connecting to /tmp/tmux-UID/default" forever. The functional probe filters
- * those out so we silently fall back to PTY.
+ * Default session backend: always tmux (PTY 退役).
+ *
+ * PTY is no longer an automatic fallback. It used to be picked here whenever
+ * the tmux functional probe failed, which meant hosts with a broken/missing
+ * tmux silently ran on PTY — and then hit PTY's whole problem set (no survival
+ * across daemon restart, scrollback-relay quirks, …) without the user ever
+ * knowing they'd been downgraded. Now the default is tmux unconditionally; if
+ * tmux isn't functional the worker hard-gates the session with an actionable
+ * card (see decideBackendGate). PTY remains reachable only via an explicit
+ * BACKEND_TYPE=pty (or per-bot backendType:'pty') opt-in.
  */
 function detectDefaultBackend(): Exclude<BackendType, 'herdr'> {
-  return probeTmuxFunctional().ok ? 'tmux' : 'pty';
+  return 'tmux';
 }
 
 // Computed once: the packaged fallback data dir. The effective dir is read

--- a/src/core/persistent-backend.ts
+++ b/src/core/persistent-backend.ts
@@ -11,7 +11,6 @@
  * worker-pool and session-manager import it, and those two already form an
  * import cycle with each other.
  */
-import { config } from '../config.js';
 import { getBot } from '../bot-registry.js';
 import { TmuxBackend } from '../adapters/backend/tmux-backend.js';
 import { HerdrBackend } from '../adapters/backend/herdr-backend.js';
@@ -28,19 +27,31 @@ export function isSuspendableBackendType(
 }
 
 /**
- * Resolve which persistent backend (if any) backs a session: prefer the
- * worker's stored init config — the per-session truth captured at spawn time,
- * which survives idle-suspend and tracks bot-config drift — then the bot
- * config, then the daemon default (covers lazy-restored sessions that never
- * forked a worker, where initConfig is unset).
+ * Resolve which persistent backend (if any) backs a session.
+ *
+ * Precedence, most authoritative first:
+ *   1. `ds.initConfig?.backendType` — the live worker's resolved backend this run.
+ *   2. `ds.session.backendType` — the backend stamped on the persisted session
+ *      at spawn time (survives daemon restart; see Session.backendType).
+ *   3. An explicit per-bot `backendType` — authoritative even for legacy
+ *      sessions, since the bot's choice didn't change across the PTY退役 flip.
+ *
+ * If NONE of those resolve, the session predates backendType stamping AND its
+ * bot pins no backend, so it ran on the OLD probe-based daemon default — which
+ * could have been PTY on a tmux-less host. We deliberately do NOT fall back to
+ * the current `config.daemon.backendType` (now always tmux): doing so would
+ * make `restoreActiveSessions` probe for a `bmx-<sid>` pane that never existed,
+ * find it 'missing', and zombie-close a perfectly recoverable session. Treating
+ * it as non-persistent keeps the worker-less active record for lazy resume; a
+ * genuinely surviving tmux pane still reattaches lazily on the next message
+ * (and gets stamped then).
  */
 export function getSessionPersistentBackendType(ds: DaemonSession): PersistentBackendType | undefined {
-  let backendType: BackendType | undefined = ds.initConfig?.backendType;
+  let backendType: BackendType | undefined = ds.initConfig?.backendType ?? ds.session.backendType;
   if (!backendType) {
-    backendType = config.daemon.backendType;
     try {
-      backendType = getBot(ds.larkAppId).config.backendType ?? backendType;
-    } catch { /* bot deregistered — keep daemon default */ }
+      backendType = getBot(ds.larkAppId).config.backendType;
+    } catch { /* bot deregistered */ }
   }
   return isSuspendableBackendType(backendType) ? backendType : undefined;
 }

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1679,6 +1679,18 @@ export function forkWorker(ds: DaemonSession, prompt: string, resume = false): v
     sessionStore.updateSession(ds.session);
   }
 
+  // Stamp the resolved backend on the persisted session. Since PTY退役, the
+  // worker no longer silently downgrades an unavailable backend (it hard-gates
+  // instead), so the requested backend here IS the effective one for any
+  // session that actually runs. Restore reads this back (see
+  // getSessionPersistentBackendType) so an upgraded daemon doesn't re-derive a
+  // session's backend from the now-always-tmux default and misclassify a legacy
+  // PTY session as a tmux zombie.
+  if (ds.session.backendType !== initMsg.backendType) {
+    ds.session.backendType = initMsg.backendType;
+    sessionStore.updateSession(ds.session);
+  }
+
   // Use shared handler for IPC messages and exit
   setupWorkerHandlers(ds, worker);
 

--- a/src/setup/ensure-tmux.ts
+++ b/src/setup/ensure-tmux.ts
@@ -30,6 +30,15 @@ export interface TmuxResult {
   version?: string;
   /** True iff we ran an installer (vs. tmux was already present). */
   freshInstall: boolean;
+  /**
+   * Whether the `tmux` binary is on PATH at all, INDEPENDENT of whether it can
+   * start a server. Lets the start-gate (PR#289 Option A) distinguish "tmux
+   * genuinely absent" (deterministic → safe to hard-fail daemon startup) from
+   * "binary present but the functional probe flaked" (must degrade gracefully
+   * via the per-session gate, never block startup — see
+   * shouldHardFailStartupForMissingTmux). Set on every return.
+   */
+  binaryPresent?: boolean;
   /** Which strategy actually ran the install. */
   strategy?: PackageManager;
   /** When installed=false: human-readable reason for the caller's warning. */
@@ -230,7 +239,7 @@ export async function ensureTmux(info?: PlatformInfo): Promise<TmuxResult> {
   // that pass -V but fail every actual tmux command.
   const initialProbe = probeTmuxFunctional();
   if (initialProbe.ok) {
-    return { installed: true, version: initialProbe.version, freshInstall: false };
+    return { installed: true, version: initialProbe.version, freshInstall: false, binaryPresent: true };
   }
 
   // If the binary exists but the server can't start, no amount of
@@ -241,6 +250,7 @@ export async function ensureTmux(info?: PlatformInfo): Promise<TmuxResult> {
     return {
       installed: false,
       freshInstall: false,
+      binaryPresent: true,
       reason: `${versionPresent} 已安装但启动 server 失败：${initialProbe.reason}`,
       manualCommand: '排查 ~/.tmux.conf / /tmp 权限 / libevent 依赖后再试',
     };
@@ -263,7 +273,7 @@ export async function ensureTmux(info?: PlatformInfo): Promise<TmuxResult> {
       const postInstall = probeTmuxFunctional();
       if (postInstall.ok) {
         console.log(`✅ tmux ${postInstall.version} 安装完成 (via ${pm})`);
-        return { installed: true, version: postInstall.version, freshInstall: true, strategy: pm };
+        return { installed: true, version: postInstall.version, freshInstall: true, strategy: pm, binaryPresent: true };
       }
       tried.push(`${pm}（装上了但 server 起不来：${postInstall.reason}）`);
     } else {
@@ -288,6 +298,10 @@ export async function ensureTmux(info?: PlatformInfo): Promise<TmuxResult> {
   return {
     installed: false,
     freshInstall: false,
+    // An install attempt may have landed the binary even though the server
+    // probe still fails — re-check PATH so the start-gate doesn't treat a
+    // present-but-broken tmux as "genuinely absent".
+    binaryPresent: !!probeTmuxVersion(),
     reason: reasonLines.join('\n'),
     manualCommand: manual,
   };

--- a/src/setup/ensure-zellij.ts
+++ b/src/setup/ensure-zellij.ts
@@ -3,9 +3,10 @@
  *
  * Zellij is an OPT-IN backend (BACKEND_TYPE=zellij) — there's no auto-install
  * here (tmux stays the default). We only need a functional probe so the worker
- * can fall back to PTY when zellij is requested but unusable, and an env
- * sanitiser so nested-session vars don't make our `zellij` calls target the
- * wrong server.
+ * can hard-gate the session (post an actionable card, refuse to start) when
+ * zellij is requested but unusable — it no longer silently falls back to PTY —
+ * and an env sanitiser so nested-session vars don't make our `zellij` calls
+ * target the wrong server.
  *
  * The driveable automation surface (action write/dump-screen/list-panes --json,
  * headless `attach --create-background`) landed in zellij 0.40–0.44; we require

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -3,7 +3,10 @@
  * a fresh machine that just `npm i -g botmux`'d gets tmux + screenshot fonts
  * provisioned without manual setup.
  *
- * - tmux is required: a failed install throws so cli.ts can exit non-zero.
+ * - tmux is required (PTY 退役): when it's GENUINELY ABSENT and a bot wants the
+ *   tmux backend, cli.ts hard-fails `start`/`restart` (non-zero exit, no pm2
+ *   spawn) — see shouldHardFailStartupForMissingTmux. A present-but-broken tmux
+ *   degrades gracefully via the per-session worker gate instead.
  * - fonts are nice-to-have: failures only print a warning.
  * - herdr is on-demand: only runs when at least one bot in bots.json has
  *   `backendType: 'herdr'`. Avoids dragging an extra binary onto every host.
@@ -26,6 +29,37 @@ export interface DependenciesReport {
 }
 
 export { botmuxFontDir } from './ensure-fonts.js';
+
+/**
+ * Decide whether `botmux start`/`restart` should HARD-FAIL (refuse to spawn the
+ * daemon) because tmux is missing. PR#289 Option A.
+ *
+ * Hard-fail ONLY when ALL of:
+ *   - the tmux binary is GENUINELY ABSENT (`tmuxBinaryPresent === false`). This
+ *     is deterministic and implies there is no tmux server — hence no surviving
+ *     session to protect — so refusing to start loses nothing.
+ *   - at least one bot actually wants the tmux backend (`anyBotWantsTmux`). A
+ *     box whose bots all run pty/herdr/zellij doesn't need tmux at all.
+ *   - the operator hasn't opted into the PTY escape hatch (`BACKEND_TYPE=pty`).
+ *
+ * Crucially we do NOT hard-fail when the binary IS present but its functional
+ * probe failed: that probe is the same disposable `tmux new-session` check the
+ * per-session gate retries, and a transient flake there must not block the
+ * daemon from coming up and reattaching live sessions — that would re-introduce
+ * the PR#249 false-negative at startup granularity. Present-but-broken tmux
+ * degrades gracefully via the per-session worker gate (an actionable card).
+ */
+export function shouldHardFailStartupForMissingTmux(opts: {
+  tmuxInstalled: boolean;
+  tmuxBinaryPresent: boolean;
+  anyBotWantsTmux: boolean;
+  ptyOptIn: boolean;
+}): boolean {
+  if (opts.ptyOptIn) return false;
+  if (opts.tmuxInstalled) return false;
+  if (opts.tmuxBinaryPresent) return false;
+  return opts.anyBotWantsTmux;
+}
 
 const BOTS_JSON_FILE = join(homedir(), '.botmux', 'bots.json');
 

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -58,18 +58,30 @@ function herdrCliIds(): CliId[] {
 export async function ensureDependencies(): Promise<DependenciesReport> {
   const platform = detectPlatform();
 
-  // tmux: nice-to-have (enables /adopt + multi-pane Web terminal). Daemon
-  // still works on PTY backend without it, so failure is a warning, not fatal.
+  // tmux: REQUIRED (PTY 退役). PTY is no longer an automatic fallback, so a
+  // host without functional tmux can't start sessions unless the operator
+  // explicitly opts into the PTY escape hatch (BACKEND_TYPE=pty). Surface this
+  // loudly instead of pretending "常规对话不受影响" — that was true under the
+  // old silent-fallback behavior and is now misleading.
   const tmux = await ensureTmux(platform);
+  const ptyOptIn = (process.env.BACKEND_TYPE ?? '').toLowerCase() === 'pty';
   if (tmux.installed) {
     if (!tmux.freshInstall) console.log(`✓ tmux ${tmux.version} (existing)`);
-  } else {
+  } else if (ptyOptIn) {
     console.warn('');
-    console.warn('⚠️  tmux 不可用，已退回到 PTY backend');
+    console.warn('⚠️  tmux 不可用，但已显式设置 BACKEND_TYPE=pty —— 将使用 PTY 后端兜底。');
     console.warn(`    原因：${tmux.reason ?? '未知'}`);
-    if (tmux.manualCommand) console.warn(`    手动尝试：${tmux.manualCommand}`);
-    console.warn('    影响：/adopt（接管已有 CLI 会话）和多人 Web 终端不可用；常规对话不受影响。');
+    console.warn('    注意：PTY 会话不跨 daemon 重启存活，/adopt 与多人 Web 终端不可用。');
     console.warn('');
+  } else {
+    console.error('');
+    console.error('❌  tmux 不可用，botmux 会话将无法启动。');
+    console.error(`    原因：${tmux.reason ?? '未知'}`);
+    if (tmux.manualCommand) console.error(`    请安装：${tmux.manualCommand}`);
+    console.error('    安装好 tmux 后重试即可。');
+    console.error('    （如确需在没有 tmux 的环境运行，可显式设置环境变量 BACKEND_TYPE=pty 用 PTY 后端兜底，');
+    console.error('      但 PTY 会话不跨 daemon 重启存活，仅作应急。）');
+    console.error('');
   }
 
   // Fonts second — best-effort.

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,18 @@ export interface Session {
   /** CLI used to spawn this session — stamped on every save so closed sessions retain it. */
   cliId?: import('./adapters/cli/types.js').CliId;
   /**
+   * Session backend resolved AT SPAWN TIME (tmux/herdr/zellij/pty). Stamped on
+   * fork so restore can resolve the backend authoritatively from the session
+   * itself instead of re-deriving it from the live daemon default — which
+   * changed when PTY stopped being an automatic fallback (default is now always
+   * tmux). Without this, a session that was created under the old probe-based
+   * default (e.g. implicit PTY on a tmux-less host) would, after upgrade +
+   * restart, be misread as tmux and zombie-closed because no `bmx-<sid>` pane
+   * exists. Undefined on sessions persisted before this field existed → treated
+   * conservatively (see getSessionPersistentBackendType).
+   */
+  backendType?: BackendType;
+  /**
    * Sandbox decision RECORDED AT SESSION CREATION (overlay file-isolation). The
    * live bot flag (BotConfig.sandbox) can be toggled later, but a session's
    * sandbox status is frozen here at creation so a restore/restart never

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -76,10 +76,10 @@ import { ZellijBackend, ZELLIJ_CONFIG_KDL } from './adapters/backend/zellij-back
 import { ZellijObserveBackend } from './adapters/backend/zellij-observe-backend.js';
 import { zellijEnv } from './setup/ensure-zellij.js';
 import { isObserveBackend, type ObserveBackend } from './adapters/backend/types.js';
-import { selectSessionBackend } from './adapters/backend/session-backend-selector.js';
+import { selectSessionBackend, decideBackendGate, backendGateUserMessage } from './adapters/backend/session-backend-selector.js';
 import { prepareSandbox, attachSandboxOutbox, startOutboxWatcher, sandboxEnabled, sandboxedClaudeDataDir } from './adapters/backend/sandbox.js';
 import type { BackendType, SessionBackend } from './adapters/backend/types.js';
-import { tmuxEnv } from './setup/ensure-tmux.js';
+import { tmuxEnv, probeTmuxFunctional } from './setup/ensure-tmux.js';
 import { IdleDetector } from './utils/idle-detector.js';
 import { ScreenAnalyzer } from './utils/screen-analyzer.js';
 import { captureToPng } from './utils/screenshot-renderer.js';
@@ -3765,28 +3765,48 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   }
 
   cliAdapter = createCliAdapterSync(cfg.cliId as any, cfg.cliPathOverride);
-  // backendType=tmux trust-but-verify: an explicit per-bot config (or
-  // BACKEND_TYPE=tmux env override) bypasses config.ts's auto-detect, so
-  // the worker re-probes here. Existing botmux tmux sessions are more
-  // authoritative than the disposable "can we create a new server?" probe:
-  // abandoning one after a transient probe failure would spawn a duplicate CLI
-  // under raw PTY and make later submits invisible to the real Codex history.
+  // backendType trust-but-verify + HARD GATE (PTY 退役): an explicit per-bot
+  // config (or BACKEND_TYPE env override) bypasses config.ts's default, so the
+  // worker re-probes the requested persistent backend here. A requested
+  // tmux/herdr/zellij backend that isn't functional NO LONGER silently
+  // degrades to raw PTY — that silent fallback was the root of the "secretly
+  // running on PTY, then hitting all of PTY's problems" bug class. Instead we
+  // refuse to spawn and post an actionable card (user_notify) telling the user
+  // to install the backend, or to explicitly opt into PTY with BACKEND_TYPE=pty.
+  //
+  // Existing botmux sessions stay authoritative over the disposable "can we
+  // create a new server?" probe: a live session reattaches regardless of a
+  // transient probe failure (PR#249), so it's exempt from the gate.
   let effectiveBackend = cfg.backendType;
-  if (effectiveBackend === 'tmux') {
-    const existingSessionName = TmuxBackend.sessionName(cfg.sessionId);
-    const hasExistingSession = TmuxBackend.hasSession(existingSessionName);
-    if (!hasExistingSession && !TmuxBackend.isAvailable()) {
-      log('tmux backend requested but functional probe failed and no existing session is available — falling back to PTY backend');
-      effectiveBackend = 'pty';
+  {
+    let available = true;
+    let reason = '';
+    let hasExistingSession = false;
+    if (effectiveBackend === 'tmux') {
+      hasExistingSession = TmuxBackend.hasSession(TmuxBackend.sessionName(cfg.sessionId));
+      if (!hasExistingSession) {
+        const probe = probeTmuxFunctional();
+        available = probe.ok;
+        if (!probe.ok) reason = probe.reason;
+      }
+    } else if (effectiveBackend === 'herdr') {
+      available = HerdrBackend.isAvailable();
+      reason = 'herdr 功能性探针失败';
+    } else if (effectiveBackend === 'zellij') {
+      available = ZellijBackend.isAvailable();
+      reason = 'zellij 功能性探针失败（需 zellij >= 0.44）';
     }
-  }
-  if (effectiveBackend === 'herdr' && !HerdrBackend.isAvailable()) {
-    log('herdr backend requested but probe failed — falling back to PTY backend');
-    effectiveBackend = 'pty';
-  }
-  if (effectiveBackend === 'zellij' && !ZellijBackend.isAvailable()) {
-    log('zellij backend requested but functional probe failed (need zellij >= 0.44) — falling back to PTY backend');
-    effectiveBackend = 'pty';
+    const decision = decideBackendGate({ requested: effectiveBackend, available, hasExistingSession });
+    if (decision.action === 'gate') {
+      const detail = reason || decision.reason;
+      log(`${effectiveBackend} backend unavailable and silent PTY fallback is disabled (set BACKEND_TYPE=pty to opt in): ${detail}`);
+      // user_notify is delivered to the Lark thread by the daemon (type:'error'
+      // is log-only); send it BEFORE throwing so the card lands. The throw is
+      // caught by the init handler, which sends type:'error' and exits — the
+      // IPC channel flushes these small messages before exit.
+      send({ type: 'user_notify', message: backendGateUserMessage(effectiveBackend, detail), turnId: cfg.turnId });
+      throw new Error(`${effectiveBackend} backend unavailable; refusing silent PTY fallback (set BACKEND_TYPE=pty to opt in): ${detail}`);
+    }
   }
   effectiveBackendType = effectiveBackend;
   const selectedBackend = selectSessionBackend({ sessionId: cfg.sessionId, backendType: effectiveBackend });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3789,12 +3789,21 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
         available = probe.ok;
         if (!probe.ok) reason = probe.reason;
       }
+    } else if (effectiveBackend === 'zellij') {
+      // Like tmux, zellij's probe is a disposable background session, so a
+      // live named session is more authoritative than a transient probe
+      // failure (PR#249 semantics) — check it first so we reattach, not gate.
+      hasExistingSession = ZellijBackend.hasSession(ZellijBackend.sessionName(cfg.sessionId));
+      if (!hasExistingSession) {
+        available = ZellijBackend.isAvailable();
+        reason = 'zellij 功能性探针失败（需 zellij >= 0.44）';
+      }
     } else if (effectiveBackend === 'herdr') {
+      // herdr's isAvailable() is a cheap, non-destructive `herdr --version`
+      // (not a disposable session probe), so it has no PR#249 false-negative
+      // risk and needs no existing-session exemption.
       available = HerdrBackend.isAvailable();
       reason = 'herdr 功能性探针失败';
-    } else if (effectiveBackend === 'zellij') {
-      available = ZellijBackend.isAvailable();
-      reason = 'zellij 功能性探针失败（需 zellij >= 0.44）';
     }
     const decision = decideBackendGate({ requested: effectiveBackend, available, hasExistingSession });
     if (decision.action === 'gate') {

--- a/test/backend-gate.test.ts
+++ b/test/backend-gate.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decideBackendGate,
+  backendGateUserMessage,
+} from '../src/adapters/backend/session-backend-selector.js';
+
+describe('decideBackendGate (PTY 退役 hard gate)', () => {
+  it('always spawns when PTY is explicitly requested (escape hatch), even if "unavailable"', () => {
+    expect(
+      decideBackendGate({ requested: 'pty', available: false, hasExistingSession: false }),
+    ).toEqual({ action: 'spawn' });
+  });
+
+  it('spawns tmux when the functional probe passes', () => {
+    expect(
+      decideBackendGate({ requested: 'tmux', available: true, hasExistingSession: false }),
+    ).toEqual({ action: 'spawn' });
+  });
+
+  it('GATES tmux when probe fails and no live session exists (no silent PTY fallback)', () => {
+    const d = decideBackendGate({ requested: 'tmux', available: false, hasExistingSession: false });
+    expect(d.action).toBe('gate');
+  });
+
+  it('reattaches a live tmux session despite a transient probe failure (PR#249 exemption)', () => {
+    expect(
+      decideBackendGate({ requested: 'tmux', available: false, hasExistingSession: true }),
+    ).toEqual({ action: 'spawn' });
+  });
+
+  it('gates herdr / zellij when unavailable instead of degrading to PTY', () => {
+    expect(decideBackendGate({ requested: 'herdr', available: false, hasExistingSession: false }).action).toBe('gate');
+    expect(decideBackendGate({ requested: 'zellij', available: false, hasExistingSession: false }).action).toBe('gate');
+  });
+});
+
+describe('backendGateUserMessage', () => {
+  it('includes the reason, an install hint, and the explicit PTY escape hatch', () => {
+    const msg = backendGateUserMessage('tmux', 'tmux 二进制不在 PATH 上');
+    expect(msg).toContain('tmux 不可用');
+    expect(msg).toContain('tmux 二进制不在 PATH 上');
+    expect(msg).toContain('brew install tmux');
+    expect(msg).toContain('BACKEND_TYPE=pty');
+  });
+});

--- a/test/persistent-backend-type.test.ts
+++ b/test/persistent-backend-type.test.ts
@@ -1,0 +1,56 @@
+/**
+ * getSessionPersistentBackendType precedence + the PTY退役 legacy-safety fix.
+ *
+ * Regression target (Codex P1 on PR #289): after the default backend flipped to
+ * always-tmux, a session created under the OLD probe-based default (implicit PTY
+ * on a tmux-less host) — with no per-session backendType stamped and a bot that
+ * pins no backend — must NOT be re-derived as tmux. Otherwise restore probes for
+ * a `bmx-<sid>` pane that never existed and zombie-closes a recoverable session.
+ *
+ * Run:  pnpm vitest run test/persistent-backend-type.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mutable per-test bot backend config the mocked getBot returns.
+const bot = vi.hoisted(() => ({ backendType: undefined as string | undefined }));
+
+vi.mock('../src/bot-registry.js', () => ({
+  getBot: vi.fn(() => ({ config: { backendType: bot.backendType } })),
+}));
+
+import { getSessionPersistentBackendType } from '../src/core/persistent-backend.js';
+
+function ds(opts: { initBackend?: string; sessionBackend?: string }): any {
+  return {
+    larkAppId: 'app1',
+    initConfig: opts.initBackend ? { backendType: opts.initBackend } : undefined,
+    session: { sessionId: 'abcdef12', backendType: opts.sessionBackend },
+  };
+}
+
+describe('getSessionPersistentBackendType', () => {
+  beforeEach(() => { bot.backendType = undefined; });
+
+  it('prefers the live worker initConfig backend', () => {
+    expect(getSessionPersistentBackendType(ds({ initBackend: 'tmux', sessionBackend: 'zellij' }))).toBe('tmux');
+  });
+
+  it('falls back to the backend stamped on the persisted session', () => {
+    expect(getSessionPersistentBackendType(ds({ sessionBackend: 'zellij' }))).toBe('zellij');
+  });
+
+  it('uses an explicit per-bot backend when the session has none stamped', () => {
+    bot.backendType = 'herdr';
+    expect(getSessionPersistentBackendType(ds({}))).toBe('herdr');
+  });
+
+  it('LEGACY SAFETY: unstamped session + bot pins no backend → undefined (not tmux), so restore keeps it for lazy resume instead of zombie-closing', () => {
+    bot.backendType = undefined;
+    expect(getSessionPersistentBackendType(ds({}))).toBeUndefined();
+  });
+
+  it('a stamped pty session is not a persistent backend', () => {
+    expect(getSessionPersistentBackendType(ds({ sessionBackend: 'pty' }))).toBeUndefined();
+    expect(getSessionPersistentBackendType(ds({ initBackend: 'pty' }))).toBeUndefined();
+  });
+});

--- a/test/restore-zombie-close.test.ts
+++ b/test/restore-zombie-close.test.ts
@@ -172,6 +172,11 @@ function makeActivePersistentSession(rootMessageId: string) {
   s.workingDir = '/tmp/proj';
   s.cliId = 'claude-code';
   s.scope = 'thread';
+  // Real tmux sessions now carry their backend stamped at spawn time
+  // (Session.backendType); getSessionPersistentBackendType reads it back rather
+  // than re-deriving from the daemon default. Stamp it so this fixture models a
+  // genuine tmux-backed session.
+  s.backendType = 'tmux';
   sessionStore.updateSession(s);
   return s; // left active
 }

--- a/test/startup-tmux-gate.test.ts
+++ b/test/startup-tmux-gate.test.ts
@@ -1,0 +1,53 @@
+/**
+ * shouldHardFailStartupForMissingTmux — PR#289 Option A startup hard-gate.
+ *
+ * The daemon-start hard-fail must fire ONLY when tmux is genuinely absent (a
+ * deterministic, no-surviving-sessions condition) and a bot actually wants the
+ * tmux backend and no PTY opt-in. A present-but-broken tmux (functional probe
+ * flaked) must NOT block startup — it degrades via the per-session worker gate,
+ * so a transient flake can't refuse to reattach live sessions (PR#249).
+ *
+ * Run:  pnpm vitest run test/startup-tmux-gate.test.ts
+ */
+import { describe, it, expect } from 'vitest';
+import { shouldHardFailStartupForMissingTmux } from '../src/setup/index.js';
+
+const base = {
+  tmuxInstalled: false,
+  tmuxBinaryPresent: false,
+  anyBotWantsTmux: true,
+  ptyOptIn: false,
+};
+
+describe('shouldHardFailStartupForMissingTmux', () => {
+  it('HARD-FAILS when tmux is genuinely absent and a bot wants tmux (the ops case)', () => {
+    expect(shouldHardFailStartupForMissingTmux(base)).toBe(true);
+  });
+
+  it('does NOT hard-fail when tmux is functional', () => {
+    expect(shouldHardFailStartupForMissingTmux({ ...base, tmuxInstalled: true })).toBe(false);
+  });
+
+  it('does NOT hard-fail when the binary is present but the probe flaked (graceful per-session gate, PR#249)', () => {
+    expect(shouldHardFailStartupForMissingTmux({ ...base, tmuxBinaryPresent: true })).toBe(false);
+  });
+
+  it('does NOT hard-fail when no bot wants tmux (all pty/herdr/zellij)', () => {
+    expect(shouldHardFailStartupForMissingTmux({ ...base, anyBotWantsTmux: false })).toBe(false);
+  });
+
+  it('does NOT hard-fail when the operator opted into the PTY escape hatch (BACKEND_TYPE=pty)', () => {
+    expect(shouldHardFailStartupForMissingTmux({ ...base, ptyOptIn: true })).toBe(false);
+  });
+
+  it('PTY opt-in wins even with everything else pointing at hard-fail', () => {
+    expect(
+      shouldHardFailStartupForMissingTmux({
+        tmuxInstalled: false,
+        tmuxBinaryPresent: false,
+        anyBotWantsTmux: true,
+        ptyOptIn: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/test/worker-pipe-initial-screen-order.test.ts
+++ b/test/worker-pipe-initial-screen-order.test.ts
@@ -96,16 +96,21 @@ describe('worker pipe initial screen ordering', () => {
     expect(helper).not.toContain('pendingMessages.length > 0');
   });
 
-  it('checks for an existing tmux session before falling back to pty', () => {
+  it('hard-gates an unavailable persistent backend instead of silently falling back to pty', () => {
     const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
     const guardStart = source.indexOf('let effectiveBackend = cfg.backendType;');
-    const guardEnd = source.indexOf("if (effectiveBackend === 'herdr'", guardStart);
+    const guardEnd = source.indexOf('effectiveBackendType = effectiveBackend;', guardStart);
     const guard = source.slice(guardStart, guardEnd);
 
     expect(guardStart).toBeGreaterThan(-1);
     expect(guardEnd).toBeGreaterThan(guardStart);
-    expect(guard).toContain('const hasExistingSession = TmuxBackend.hasSession(existingSessionName);');
-    expect(guard).toContain('!hasExistingSession && !TmuxBackend.isAvailable()');
-    expect(guard.indexOf('TmuxBackend.hasSession')).toBeLessThan(guard.indexOf('TmuxBackend.isAvailable'));
+    // A live tmux session is checked before probing so it can reattach (PR#249).
+    expect(guard).toContain('TmuxBackend.hasSession(TmuxBackend.sessionName(cfg.sessionId))');
+    expect(guard.indexOf('TmuxBackend.hasSession')).toBeLessThan(guard.indexOf('probeTmuxFunctional'));
+    // The decision is made by the pure gate helper, and a gate posts an
+    // actionable card + throws — it must NOT silently downgrade to pty.
+    expect(guard).toContain('decideBackendGate(');
+    expect(guard).toContain("send({ type: 'user_notify'");
+    expect(guard).not.toContain("effectiveBackend = 'pty'");
   });
 });


### PR DESCRIPTION
## 这个 PR 解决什么问题

botmux 每个会话需要一个「终端后端」来跑 CLI，优先用 tmux。以前一旦检测到 tmux 不可用（没装、装坏了、权限不对等），会**悄悄改用 PTY 这个简易后端**继续跑——用户完全不知道自己被降级了，然后就会一个个踩到 PTY 的固有毛病，最典型的是：**PTY 起的会话在 daemon 重启后活不下来**，得重新开一个，容易丢上下文。

申晗定了「让 tmux 当唯一默认后端、逐步淘汰 PTY」。本 PR 是**第一步**，目标很简单：**tmux 不行就当场说清楚、引导你装好，而不是偷偷换成 PTY 跑。** 这一步先不删 PTY 的代码，只是不再自动用它。

## 改了什么

- **默认后端固定为 tmux**：不再因为 tmux 探测失败就自动改成 PTY。（`config.ts`）
- **起会话时，后端不可用就明确拦下**：tmux/herdr/zellij 这些后端如果用不了、且当前也没有正在运行的同名会话，就**在飞书话题里发一张提示卡**（写明原因、安装命令、以及应急开关怎么用），并且不启动这个会话——而不是像以前那样悄悄用 PTY 顶上。已经在运行的 tmux 会话照常重连，不受影响（沿用之前的修复：临时探测失败别误杀已有会话）。（`worker.ts`）
- **安装阶段的提示改成实话**：以前 tmux 装不上会提示「已退回 PTY，常规对话不受影响」——这话现在不成立了。改成明确报错 + 安装命令。（`setup/index.ts`）

## 保留的「应急开关」

如果你确实在一个没法用 tmux 的环境（比如原生 Windows、极简容器），可以**主动**设环境变量 `BACKEND_TYPE=pty`，或给某个机器人单独配 `backendType: pty`，就还能用 PTY 兜底。提示卡里会写清楚：PTY 会话在 daemon 重启后活不下来，仅供应急。

也就是说——默认强制 tmux、用不了就明确报错；PTY 从「自动兜底」变成「需要你手动打开的应急通道」。

## 这次先不做的

不删 PTY 的代码。原因有两点：一是删了收益有限（PTY 和 tmux 等后端共用同一套终端转发逻辑，删 PTY 省不掉多少）；二是有两件事得先解决——所有会话现在共用一个 tmux 服务，是全机的单点故障，强制全员上 tmux 会放大这个风险，应该先把每个机器人拆成独立 tmux 通道；另外原生 Windows 没有 tmux，要不要彻底放弃得先拍板。

## 测试

- 新增针对「该用哪个后端 / 该不该拦」这套判断的单元测试。
- `pnpm build` 通过；`pnpm test` 全绿（376 个测试文件 / 6367 个用例）。

## 怎么验证

开发机上 tmux 是好的，所以合上来现网行为不变（新会话照常用 tmux、老会话照常重连）。那张拦截提示卡只会在「tmux 真的坏了或没装」的机器上出现，本机看不到效果，需要在没有 tmux 的环境、或人为把 tmux 弄坏来复现。
