### PR TITLE
fix(lark): botmux send 正文内联 @中文名 渲染不出 <at>

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3439,6 +3439,7 @@ function argValues(args: string[], ...flags: string[]): string[] {
 // daemon's bridge fallback path can produce identical cards. cmdSend
 // keeps using `buildImageCardElements` from there.
 import { buildImageCardElements, brandFooterSegment } from './im/lark/md-card.js';
+import { applyInlineMentions } from './im/lark/inline-mentions.js';
 import { resolveBrandLabel } from './bot-registry.js';
 import { config } from './config.js';
 import { resolveQuoteTarget, validateMentionDecision, parseAttentionFlag, attentionUsageError } from './services/send-policy.js';
@@ -4001,13 +4002,6 @@ async function cmdSend(rest: string[]): Promise<void> {
           knownBotOpenIds,
         });
 
-    const mentionMap = new Map<string, string>();
-    for (const m of mentions) if (m.name) mentionMap.set(m.name.toLowerCase(), m.open_id);
-    const namedMentions = mentions.filter(m => m.name);
-    const mentionPattern = namedMentions.length > 0
-      ? new RegExp(`@(${namedMentions.map(m => m.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})\\b`, 'gi')
-      : null;
-
     // Capture sentAtMs BEFORE dispatch — the worker's bridge fallback gates
     // on `sentAtMs ∈ [turn.markTimeMs, nextTurn.markTimeMs)`. If we recorded
     // it after dispatch (which can take seconds), a slow Lark RTT could push
@@ -4018,19 +4012,10 @@ async function cmdSend(rest: string[]): Promise<void> {
     let messageId: string;
     {
       // 回复一律卡片（纯文本 post 路径已删）。
-      // Inline @mention → <at id=open_id></at>; explicit --mention args that
-      // weren't inlined are appended to the body. The session owner is
-      // rendered in the footer note instead of the body.
-      const usedIds = new Set<string>();
-      let md = text;
-      if (mentionPattern) {
-        md = text.replace(mentionPattern, (full: string, name: string) => {
-          const openId = mentionMap.get(name.toLowerCase());
-          if (!openId) return full;
-          usedIds.add(openId);
-          return `<at id=${openId}></at>`;
-        });
-      }
+      // Inline `@Name` → `<at id=…>` at the exact spot it's written (CJK-name
+      // aware, see applyInlineMentions); any --mention not inlined here is
+      // rendered on the footer `发送给：` line below, not the body.
+      const { text: md, usedIds } = applyInlineMentions(text, mentions);
       // Non-inlined mentions are no longer dangled as a trailing @ block at the
       // body bottom — they're consolidated onto the footer `发送给：` line below
       // (human addressee first, then explicit targets). See orderedFooterRecipients.

--- a/src/im/lark/inline-mentions.ts
+++ b/src/im/lark/inline-mentions.ts
@@ -14,9 +14,15 @@
  *     `负责人 @张三` and a CJK-prefixed `看看@张三` are accepted (CJK isn't an
  *     ASCII word char);
  *   - lookahead `(?![\p{L}\p{N}_])` (needs the `u` flag) blocks any Unicode
- *     letter/digit so `@Owner2` won't half-match name "Owner", and on a prefix
- *     collision (`@张三丰` with both `张三` and `张三丰` registered) it forces the
- *     engine to backtrack onto the longer, fully-bounded alternative.
+ *     letter/digit so `@Owner2` won't half-match name "Owner".
+ *
+ * Prefix collisions (one registered name is a string-prefix of another, e.g.
+ * `Claude` / `Claude-Code`) are resolved by trying the LONGER name first — the
+ * alternation is built length-descending, mirroring the `@BotName` matcher's
+ * sorted iteration. The lookahead alone is not enough: it only forces the
+ * longer match when the next char is itself a letter/digit (`@张三丰`); when the
+ * separator is `-`/space/emoji (`@Claude-Code`) the short name's lookahead would
+ * otherwise pass and win, @-ing the wrong target and footer-mismatching.
  *
  * This replaces the previous `@(name)\b` matcher whose `\b` word boundary never
  * matched after a CJK character — pure-Chinese display names (`@张三`) silently
@@ -47,10 +53,14 @@ export function applyInlineMentions(
   const map = new Map<string, string>();
   for (const m of named) map.set(m.name.toLowerCase(), m.open_id);
 
+  // Length-descending so a longer name wins over a shorter one it has as a
+  // prefix (`Claude-Code` before `Claude`); see the prefix-collision note above.
+  const alternation = [...named]
+    .sort((a, b) => b.name.length - a.name.length)
+    .map(m => m.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|');
   const pattern = new RegExp(
-    `(?<![A-Za-z0-9_])@(${named
-      .map(m => m.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-      .join('|')})(?![\\p{L}\\p{N}_])`,
+    `(?<![A-Za-z0-9_])@(${alternation})(?![\\p{L}\\p{N}_])`,
     'giu',
   );
 

--- a/src/im/lark/inline-mentions.ts
+++ b/src/im/lark/inline-mentions.ts
@@ -1,0 +1,65 @@
+/**
+ * Inline `@Name` → Lark `<at id=…>` rewriting for outgoing card bodies.
+ *
+ * When `botmux send --mention 'open_id:Name'` registers a name↔open_id map, the
+ * model can write `@Name` anywhere in the prose and we rewrite it in place into
+ * a real `<at id=open_id></at>` so the mention renders exactly where it was
+ * written (next to the relevant line) instead of being dangled in the footer.
+ * The open_ids that were inlined are returned so the caller can drop them from
+ * the footer `发送给：` addressing line (no double @).
+ *
+ * Boundary mirrors the `@BotName` auto-injection matcher in cli.ts:
+ *   - lookbehind `(?<![A-Za-z0-9_])` blocks only ASCII word chars, so an
+ *     email-/handle-like `user@Owner` / `a@张三` is rejected, while a natural
+ *     `负责人 @张三` and a CJK-prefixed `看看@张三` are accepted (CJK isn't an
+ *     ASCII word char);
+ *   - lookahead `(?![\p{L}\p{N}_])` (needs the `u` flag) blocks any Unicode
+ *     letter/digit so `@Owner2` won't half-match name "Owner", and on a prefix
+ *     collision (`@张三丰` with both `张三` and `张三丰` registered) it forces the
+ *     engine to backtrack onto the longer, fully-bounded alternative.
+ *
+ * This replaces the previous `@(name)\b` matcher whose `\b` word boundary never
+ * matched after a CJK character — pure-Chinese display names (`@张三`) silently
+ * fell through to the footer and never rendered inline.
+ */
+export interface NamedMention {
+  open_id: string;
+  name: string;
+}
+
+export interface InlineMentionResult {
+  /** Body text with matched `@Name` rewritten to `<at id=…></at>`. */
+  text: string;
+  /** open_ids that were inlined into the body (skip these in the footer). */
+  usedIds: Set<string>;
+}
+
+export function applyInlineMentions(
+  text: string,
+  mentions: NamedMention[],
+): InlineMentionResult {
+  const usedIds = new Set<string>();
+  const named = mentions.filter(m => m.name);
+  if (named.length === 0) return { text, usedIds };
+
+  // Lowercased lookup map; the `i` flag means the matched text may differ in
+  // case from the registered name.
+  const map = new Map<string, string>();
+  for (const m of named) map.set(m.name.toLowerCase(), m.open_id);
+
+  const pattern = new RegExp(
+    `(?<![A-Za-z0-9_])@(${named
+      .map(m => m.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      .join('|')})(?![\\p{L}\\p{N}_])`,
+    'giu',
+  );
+
+  const out = text.replace(pattern, (full: string, name: string) => {
+    const openId = map.get(name.toLowerCase());
+    if (!openId) return full;
+    usedIds.add(openId);
+    return `<at id=${openId}></at>`;
+  });
+
+  return { text: out, usedIds };
+}

--- a/test/inline-mentions.test.ts
+++ b/test/inline-mentions.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Inline `@Name` → Lark `<at id=…>` rewriting (botmux send body).
+ *
+ * Regression: the old `@(name)\b` matcher's `\b` word boundary never matched
+ * after a CJK character, so pure-Chinese display names (`@张三`) silently fell
+ * through to the footer and never rendered inline. The boundary now mirrors the
+ * `@BotName` auto-injection matcher (ASCII-only lookbehind + Unicode-letter
+ * lookahead), so Chinese names inline at the exact written position while the
+ * `@Owner2` / `user@Owner` guards still hold.
+ *
+ * Run: pnpm vitest run test/inline-mentions.test.ts
+ */
+import { describe, it, expect } from 'vitest';
+import { applyInlineMentions } from '../src/im/lark/inline-mentions.js';
+
+const zhang = { open_id: 'ou_zhangsan', name: '张三' };
+const li = { open_id: 'ou_lisi', name: '李四' };
+const owner = { open_id: 'ou_owner', name: 'Owner' };
+
+describe('applyInlineMentions', () => {
+  it('inlines a pure-Chinese name (the regression)', () => {
+    const r = applyInlineMentions('结果A @张三 请看 MR', [zhang]);
+    expect(r.text).toBe('结果A <at id=ou_zhangsan></at> 请看 MR');
+    expect([...r.usedIds]).toEqual(['ou_zhangsan']);
+  });
+
+  it('inlines a Chinese name at end-of-string and before CJK punctuation', () => {
+    expect(applyInlineMentions('@张三', [zhang]).text).toBe('<at id=ou_zhangsan></at>');
+    expect(applyInlineMentions('@张三：完成', [zhang]).text).toBe('<at id=ou_zhangsan></at>：完成');
+    expect(applyInlineMentions('@张三，已合并', [zhang]).text).toBe('<at id=ou_zhangsan></at>，已合并');
+  });
+
+  it('inlines multiple distinct names across lines, only where written', () => {
+    const r = applyInlineMentions(
+      'MR1 feat/x cc @张三\nMR2 无 MR，无需 @\nMR3 fix/y cc @Owner',
+      [zhang, li, owner],
+    );
+    expect(r.text).toBe(
+      'MR1 feat/x cc <at id=ou_zhangsan></at>\nMR2 无 MR，无需 @\nMR3 fix/y cc <at id=ou_owner></at>',
+    );
+    // 李四 was registered but never written → not inlined (caller footers it).
+    expect(r.usedIds).toEqual(new Set(['ou_zhangsan', 'ou_owner']));
+  });
+
+  it('accepts a CJK-prefixed @ but rejects an ASCII-word-prefixed one (email-like)', () => {
+    expect(applyInlineMentions('看看@张三', [zhang]).text).toBe('看看<at id=ou_zhangsan></at>');
+    // `a@张三` looks like a handle/email local part → not a mention.
+    const r = applyInlineMentions('a@张三', [zhang]);
+    expect(r.text).toBe('a@张三');
+    expect(r.usedIds.size).toBe(0);
+  });
+
+  it('does not half-match a longer name (Unicode-letter lookahead)', () => {
+    // name "Owner" must not match inside "@Owner2".
+    expect(applyInlineMentions('@Owner2 done', [owner]).text).toBe('@Owner2 done');
+    // name "张三" must not match inside "@张三丰"; with both registered, the
+    // longer one wins via backtracking.
+    const both = applyInlineMentions('@张三丰 报告', [zhang, { open_id: 'ou_zsf', name: '张三丰' }]);
+    expect(both.text).toBe('<at id=ou_zsf></at> 报告');
+  });
+
+  it('is case-insensitive against the registered name', () => {
+    expect(applyInlineMentions('@owner ok', [owner]).text).toBe('<at id=ou_owner></at> ok');
+  });
+
+  it('escapes regex metacharacters in names', () => {
+    const dotty = { open_id: 'ou_dot', name: 'a.b' };
+    expect(applyInlineMentions('@a.b hi', [dotty]).text).toBe('<at id=ou_dot></at> hi');
+    // the `.` is literal, so `@axb` must NOT match.
+    expect(applyInlineMentions('@axb hi', [dotty]).text).toBe('@axb hi');
+  });
+
+  it('leaves text untouched when no named mentions are given', () => {
+    const r = applyInlineMentions('@张三 hi', [{ open_id: 'ou_x', name: '' }]);
+    expect(r.text).toBe('@张三 hi');
+    expect(r.usedIds.size).toBe(0);
+  });
+});

--- a/test/inline-mentions.test.ts
+++ b/test/inline-mentions.test.ts
@@ -54,9 +54,29 @@ describe('applyInlineMentions', () => {
     // name "Owner" must not match inside "@Owner2".
     expect(applyInlineMentions('@Owner2 done', [owner]).text).toBe('@Owner2 done');
     // name "张三" must not match inside "@张三丰"; with both registered, the
-    // longer one wins via backtracking.
+    // longer one wins via backtracking (separator is a letter, lookahead fires).
     const both = applyInlineMentions('@张三丰 报告', [zhang, { open_id: 'ou_zsf', name: '张三丰' }]);
     expect(both.text).toBe('<at id=ou_zsf></at> 报告');
+  });
+
+  it('resolves prefix collision when the separator is NOT a letter/digit (length-desc)', () => {
+    // Codex P2: lookahead alone can't fix `Claude` vs `Claude-Code` — after the
+    // short `Claude` the next char `-` passes the lookahead. Length-desc ordering
+    // makes the longer name win.
+    const bots = [
+      { open_id: 'ou_short', name: 'Claude' },
+      { open_id: 'ou_cli', name: 'Claude-Code' },
+    ];
+    expect(applyInlineMentions('@Claude-Code hi', bots).text).toBe('<at id=ou_cli></at> hi');
+    expect([...applyInlineMentions('@Claude-Code hi', bots).usedIds]).toEqual(['ou_cli']);
+    // Reversed registration order must not change the outcome.
+    const rev = [bots[1], bots[0]];
+    expect(applyInlineMentions('@Claude-Code hi', rev).text).toBe('<at id=ou_cli></at> hi');
+    // The bare short name still resolves to the short id when written alone.
+    expect(applyInlineMentions('@Claude hi', bots).text).toBe('<at id=ou_short></at> hi');
+    // Single-char prefix with a hyphen separator (Codex's `A` / `A-B` repro).
+    const ab = [{ open_id: 'ou_a', name: 'A' }, { open_id: 'ou_ab', name: 'A-B' }];
+    expect(applyInlineMentions('@A-B hi', ab).text).toBe('<at id=ou_ab></at> hi');
   });
 
   it('is case-insensitive against the registered name', () => {


### PR DESCRIPTION
## 背景

来自飞书话题里的真实场景：一个定时任务会跑多个 subagent，每个跑完后想在结果正文里 **就地 @ 对应负责人**（有 MR 的 @ 负责人，没 MR 的不 @，避免打扰）。实测发现 `botmux send` **没法在正文里 @ 出具体的中文名**。

## 根因

`botmux send` 其实**早就支持**正文内联 @：`--mention 'open_id:名字'` 注册映射后，正文里写 `@名字` 会被替换成真正的 `<at id=open_id></at>`，渲染在书写的确切位置；没内联到的才落到卡片 footer 的「发送给：」行。

但内联匹配用的正则是 `@(名字)\b`，结尾的 `\b` **词边界在 CJK 字符后永远不成立**（中文不是 `\w`）。所以：

| 写法 | 旧行为 |
| --- | --- |
| `@张三`（纯中文） | ❌ 不命中 → 掉 footer |
| `@Owner`、`@李四-MR`（ASCII 结尾） | ✅ 内联 |

中文名是绝对主力，等于这个能力对中文场景实际不可用。

## 改动

把边界对齐到**同文件里 `@BotName` 自动注入那条已经验证过的匹配**（`src/cli.ts` 中 bot 注入用的就是这套）：

```
- new RegExp(`@(${names})\b`, 'gi')
+ new RegExp(`(?<![A-Za-z0-9_])@(${names})(?![\p{L}\p{N}_])`, 'giu')
```

- **lookbehind `(?<![A-Za-z0-9_])`**：只挡 ASCII 词字符，所以 `负责人 @张三`、`看看@张三`（CJK 前缀）能命中，而 `user@Owner`、`a@张三`（邮箱/handle 样式）被拒。
- **lookahead `(?![\p{L}\p{N}_])`（需 `u` flag）**：挡任意 Unicode 字母/数字，`@Owner2` 不会半匹配到 `Owner`；前缀冲突（`@张三丰` 同时注册了 `张三`/`张三丰`）会回溯到更长的完整匹配。

运行时早已支持 lookbehind + `\p{}`（bot 注入那条就在用），无兼容风险。

顺手把这段内联逻辑从 `cmdSend` 巨函数里抽成纯函数 `applyInlineMentions(text, mentions)`，便于单测（原先无任何测试 pin 这个行为）。

## 用户侧效果

```bash
botmux send --mention 'ou_zhangsan:张三' --mention 'ou_lisi:李四' <<'TXT'
✅ MR1 feat/x 已合并 cc @张三
✅ MR2 fix/y 已合并 cc @李四
ℹ️ 任务C 无 MR，无需 @
TXT
```
→ `@张三`/`@李四` 在各自行就地渲染成真 @，任务C 不打扰任何人。

## 测试

- 新增 `test/inline-mentions.test.ts`（8 例）：纯中文名内联（回归本体）、行尾/中文标点前、多行选择性 @、CJK 前缀放行 vs `a@张三` 拒绝、`@Owner2`/`@张三丰` 不半匹配、大小写不敏感、正则元字符转义、无具名 mention 时原样返回。
- `pnpm test` 全量绿：**376 文件 / 6372 用例通过**。
- `pnpm build` 通过。

## 影响面

- 仅影响 `botmux send` 正文里 `@名字`（带 `--mention` 注册）→ `<at>` 的内联渲染。
- 行为变化：纯中文名现在能内联（修复）；`xyz@Owner` 这类 ASCII-词前缀的从「会匹配」变成「不匹配」——与 bot 注入那条护栏一致，更正确，且无测试依赖旧行为。
- raw `<at id=ou_xxx></at>` 直接写正文的老绕过路径不受影响，照旧透传。
