### PR TITLE
fix(cjadk): codex 注入的 -c 被 cjadk --command 吞掉致启动失败（改写为 --config）

### DIFF
--- a/src/setup/cli-selection.ts
+++ b/src/setup/cli-selection.ts
@@ -240,6 +240,15 @@ function isAidenWrapper(tokens: ReadonlyArray<string>): boolean {
   return tokens[0] === 'aiden';
 }
 
+/** wrapper 前缀首 token 是否为 cjadk 装配启动器（`cjadk <agent>`）。cjadk 的 `code` 子命令
+ *  把 `-c, --command` 占为己用（commander 选项），会吞掉 botmux 给 codex 注入的
+ *  `-c shell_environment_policy.set.BOTMUX_*=…`（绑到 cjadk 的 --command，当成"要运行的命令"
+ *  → 报 `… is not installed. Please install it first.`）——故 cjadk codex 转发前要把它改写成
+ *  codex 的长形式 `--config`（见 {@link rewriteCjadkCodexConfigArgs}）。 */
+function isCjadkWrapper(tokens: ReadonlyArray<string>): boolean {
+  return tokens[0] === 'cjadk';
+}
+
 /** 是否为 botmux 经 codex `-c` 注入的「把 BOTMUX_* 塞进 shell 工具环境」配置覆盖值。
  *  只认 botmux 自己注入的 `shell_environment_policy.set.BOTMUX_` 前缀，绝不误伤用户
  *  自带的 `-c key=val`。 */
@@ -271,8 +280,10 @@ export function stripSettingsArgs(args: ReadonlyArray<string>): string[] {
  * 子进程继承（见 worker.ts childEnv），故剥掉只是去掉一条冗余的 belt-and-suspenders
  * 通道，不丢功能。`-c` 按 botmux 注入特征精确识别——只剥值以 `shell_environment_policy.set.BOTMUX_`
  * 开头者，用户自带的 `-c key=val` 一律不动；`--settings` 则沿用 aiden x claude 历来的兼容策略
- * 整体剥离（复用 {@link stripSettingsArgs}，不区分来源）。原生启动及 ttadk/cjadk 等「裸透传」
- * 网关不走本函数，仍保留 `-c`（它们的 launcher 接受并转发给真 CLI，照常生效）。
+ * 整体剥离（复用 {@link stripSettingsArgs}，不区分来源）。原生启动及 ttadk 等「裸透传」网关
+ * 不走本函数，仍保留 `-c`（它们的 launcher 接受并转发给真 CLI，照常生效）。cjadk 走单独的
+ * {@link rewriteCjadkCodexConfigArgs}（它的 `code` 子命令把 `-c` 占为 `--command`，要改写成
+ * `--config` 才能透传，而非剥离——故不复用本函数）。
  *
  * 关键：识别按 botmux 注入特征（`--settings` 的语义 + `-c …BOTMUX_` 前缀）而非按某个具体 CLI——
  * 任何适配器将来注入**同形态**的 config 覆盖，经 aiden 网关时都会被一并剥掉，不会重蹈 codex 覆辙。
@@ -286,6 +297,38 @@ export function stripWrapperUnsafeArgs(args: ReadonlyArray<string>): string[] {
   for (let i = 0; i < afterSettings.length; i++) {
     const a = afterSettings[i]!;
     if (a === '-c' && isBotmuxShellEnvConfigValue(afterSettings[i + 1])) { i++; continue; }
+    out.push(a);
+  }
+  return out;
+}
+
+/**
+ * cjadk codex 专用改写：把 botmux 给 codex 注入的 `-c shell_environment_policy.set.BOTMUX_*=…`
+ * 改写成 codex 的长形式 `--config shell_environment_policy.set.BOTMUX_*=…`。
+ *
+ * 起因：cjadk 的 `code` 子命令用 commander 定义了 `-c, --command <cmd>`（"运行自定义命令而非默认
+ * agent 命令"），即便 `allowUnknownOption(true)`，**已定义**的 `-c` 仍被 cjadk 自己吃掉绑到
+ * `--command`，不会透传给真 codex——于是 cjadk 把 `shell_environment_policy.set.BOTMUX_SESSION_ID="…"`
+ * 当成"要运行的命令"，报 `… is not installed. Please install it first.`（本次只在 cjadk codex 复现的根因；
+ * cjadk claude 不受影响是因为 claude 注入的是 `--settings` 而非 `-c`）。
+ *
+ * codex 的 `--config` 是 `-c` 的长形式（`-c, --config <key=value>`），而 cjadk 的 `code` 子命令**未定义**
+ * `--config`，故 `--config …` 落入 cjadk 的 passthrough（`allowUnknownOption`）原样转发给真 codex，效果与 `-c`
+ * 完全一致。相比 aiden 路径的整条剥离，改写**保留**了把 BOTMUX_SESSION_ID 注入 codex shell 工具环境的通道。
+ *
+ * 只改写 botmux 自己注入的那一处（值以 `shell_environment_policy.set.BOTMUX_` 开头），用户自带的 `-c key=val`
+ * 一律不动。非 codex 的 cjadk 形态（cjadk claude 带 `--settings`、不带 `-c BOTMUX`）经此函数是 no-op，
+ * `--settings` 照常保留透传。
+ */
+export function rewriteCjadkCodexConfigArgs(args: ReadonlyArray<string>): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === '-c' && isBotmuxShellEnvConfigValue(args[i + 1])) {
+      out.push('--config', args[i + 1]!);
+      i++;
+      continue;
+    }
     out.push(a);
   }
   return out;
@@ -359,7 +402,9 @@ export function ttadkConfigModelChoices(wrapperCli: string | undefined): string[
  * 由 wrapperCli 前缀 + 底层 CLI 的 args 构造实际 spawn 的 `{ bin, args }`。
  *   - bin = 前缀首 token（经 binResolver 走 PATH 解析）
  *   - args = 前缀其余 token + CLI 参数（aiden `aiden x <cli>` 形态会先经
- *     {@link stripWrapperUnsafeArgs} 剥掉 botmux 注入、aiden 拒收的 `--settings`/`-c`）
+ *     {@link stripWrapperUnsafeArgs} 剥掉 botmux 注入、aiden 拒收的 `--settings`/`-c`；
+ *     cjadk `cjadk <agent>` 形态走 {@link rewriteCjadkCodexConfigArgs} 把 codex 注入的 `-c`
+ *     改写成 cjadk 不会吞掉的 `--config`）
  *   - ttadk 网关走专门分支注入 `-m <model> --skip-check`（见 {@link buildTtadkLaunch}）
  * 前缀为空时返回 `{ bin: '', args }`，调用方据此跳过（不改写 spawn）。
  */
@@ -372,7 +417,10 @@ export function buildWrappedLaunch(
   const tokens = parseWrapperCli(wrapperCli);
   if (tokens.length === 0) return { bin: '', args: [...cliArgs] };
   if (tokens[0] === 'ttadk') return buildTtadkLaunch(tokens, cliArgs, binResolver, opts.ttadkModel);
-  const forwarded = isAidenWrapper(tokens) ? stripWrapperUnsafeArgs(cliArgs) : [...cliArgs];
+  let forwarded: string[];
+  if (isAidenWrapper(tokens)) forwarded = stripWrapperUnsafeArgs(cliArgs);
+  else if (isCjadkWrapper(tokens)) forwarded = rewriteCjadkCodexConfigArgs(cliArgs);
+  else forwarded = [...cliArgs];
   return { bin: binResolver(tokens[0]), args: [...tokens.slice(1), ...forwarded] };
 }
 

--- a/test/cli-selection.test.ts
+++ b/test/cli-selection.test.ts
@@ -300,14 +300,29 @@ describe('buildWrappedLaunch', () => {
     expect(out.args).toEqual(['x', 'codex', '-c', 'model_reasoning_effort="high"', '--model', 'm']);
   });
 
-  it('keeps the codex -c override for the bare-passthrough cjadk codex gateway', () => {
+  // Regression (only reproduces on cjadk codex): cjadk's `code` subcommand defines
+  // `-c, --command <cmd>` (commander), so botmux's injected
+  // `-c shell_environment_policy.set.BOTMUX_SESSION_ID=…` was captured as cjadk's
+  // --command and NOT forwarded to codex → cjadk tried to run the value as a custom
+  // command and errored `… is not installed. Please install it first.`. Rewrite to
+  // codex's long form `--config` (which cjadk does NOT define → allowUnknownOption
+  // passes it through to real codex), preserving the BOTMUX_SESSION_ID shell-env channel.
+  it('rewrites the botmux codex -c override to --config for cjadk codex', () => {
     const out = buildWrappedLaunch('cjadk codex', [
       '--no-alt-screen',
       '-c',
       'shell_environment_policy.set.BOTMUX_SESSION_ID="sess-4"',
     ]);
-    // cjadk forwards CLI args verbatim to the real codex, which accepts -c — keep it.
-    expect(out.args).toEqual(['codex', '--no-alt-screen', '-c', 'shell_environment_policy.set.BOTMUX_SESSION_ID="sess-4"']);
+    expect(out.bin).toBe('cjadk');
+    expect(out.args).toEqual(['codex', '--no-alt-screen', '--config', 'shell_environment_policy.set.BOTMUX_SESSION_ID="sess-4"']);
+    // cjadk's `-c`/`--command` collision is gone — no bare -c reaches the launcher.
+    expect(out.args).not.toContain('-c');
+  });
+
+  it('does not rewrite a user-supplied -c that is not a botmux override (cjadk codex)', () => {
+    const out = buildWrappedLaunch('cjadk codex', ['-c', 'model_reasoning_effort="high"', '--no-alt-screen']);
+    // User-owned -c is left untouched (its semantics are the user's to own, not ours).
+    expect(out.args).toEqual(['codex', '-c', 'model_reasoning_effort="high"', '--no-alt-screen']);
   });
 
   it('keeps the codex -c override for the bare-passthrough ttadk codex gateway', () => {
@@ -416,8 +431,8 @@ describe('codex adapter × aiden wrapper (regression for commit 10d3e61)', () =>
 
   // Cross-CLI guard: any aiden `aiden x <cli>` wrapper must drop a botmux-injected
   // `-c shell_environment_policy.set.BOTMUX_*` override, so a future adapter that
-  // mirrors Codex's injection cannot re-break aiden launches. Bare-passthrough
-  // gateways (ttadk/cjadk) intentionally keep it.
+  // mirrors Codex's injection cannot re-break aiden launches. ttadk keeps it
+  // (bare-passthrough); cjadk rewrites it to --config (see the cjadk regression below).
   it('no aiden built-in wrapper forwards a botmux -c override', () => {
     const codexArgs = [
       '--dangerously-bypass-approvals-and-sandbox',
@@ -433,6 +448,39 @@ describe('codex adapter × aiden wrapper (regression for commit 10d3e61)', () =>
       const out = buildWrappedLaunch(w, codexArgs);
       expect(forwardsBotmuxC(out.args), `${w} must not forward botmux -c`).toBe(false);
     }
+  });
+});
+
+// End-to-end regression (only reproduces on cjadk codex): cjadk's `code` subcommand
+// owns `-c/--command`, so botmux's injected `-c shell_environment_policy.set.BOTMUX_*`
+// was eaten as cjadk's custom-command and never reached codex (cjadk errored
+// `… is not installed`). The wrapper layer must rewrite it to codex's long-form
+// `--config` (cjadk passes unknown options through), keeping the session-env channel.
+describe('codex adapter × cjadk wrapper (cjadk -c/--command collision)', () => {
+  const codex = createCodexAdapter('/usr/bin/codex');
+
+  const BOTMUX_OVERRIDE_RE = /^shell_environment_policy\.set\.BOTMUX_/;
+  const findConfigOverride = (args: ReadonlyArray<string>, flag: string): string | undefined => {
+    const i = args.findIndex((a, j) => a === flag && BOTMUX_OVERRIDE_RE.test(args[j + 1] ?? ''));
+    return i === -1 ? undefined : args[i + 1];
+  };
+
+  it('cjadk codex rewrites the botmux -c override to --config (fresh launch)', () => {
+    const args = codex.buildArgs({ sessionId: 'sess-4', resume: false, workingDir: '/repo' });
+    const out = buildWrappedLaunch('cjadk codex', args);
+    expect(out.bin).toBe('cjadk');
+    // No bare `-c` survives (would collide with cjadk's --command); the override now rides --config.
+    expect(findConfigOverride(out.args, '-c')).toBeUndefined();
+    expect(findConfigOverride(out.args, '--config')).toBe('shell_environment_policy.set.BOTMUX_SESSION_ID="sess-4"');
+  });
+
+  it('cjadk codex rewrites the botmux -c override to --config (resume launch)', () => {
+    const args = codex.buildArgs({ sessionId: 'sess-4', resume: true, resumeSessionId: 'codex-uuid' });
+    expect(args).toContain('resume');               // sanity: exercised the resume branch
+    const out = buildWrappedLaunch('cjadk codex', args);
+    expect(findConfigOverride(out.args, '-c')).toBeUndefined();
+    expect(findConfigOverride(out.args, '--config')).toBe('shell_environment_policy.set.BOTMUX_SESSION_ID="sess-4"');
+    expect(out.args).toContain('codex-uuid');        // resume target survives
   });
 });
 


### PR DESCRIPTION
## 问题

`cjadk codex` 启动报错，`cjadk claude` 正常：

```
shell_environment_policy.set.BOTMUX_SESSION_ID="..." is not installed. Please install it first.
```

只在 **cjadk × codex** 复现，与 cjadk 版本、devbox 环境无关（新旧版本都复现）。

## 根因（已实证）

cjadk 的 `code` 子命令（`dist/commands/agent/code.js`）用 commander 定义了 `-c, --command <cmd>`（"运行自定义命令而非默认 agent 命令"）。即便它开了 `allowUnknownOption(true)`，**已定义**的 `-c` 仍会被 cjadk 自己绑到 `--command`，不会落入 passthrough、不会转发给真正的 codex。

botmux 的 codex 适配器（`src/adapters/cli/codex.ts`）注入 `-c shell_environment_policy.set.BOTMUX_SESSION_ID="..."`（用于把 `BOTMUX_SESSION_ID` 塞进 codex shell 工具的环境）。于是这串值被 cjadk 当成"要运行的自定义命令"，报 `... is not installed`。

`cjadk × claude` 不复现，是因为 claude 注入的是 `--settings`（cjadk 未定义该选项 → 透传），不撞 `-c`。

用 cjadk 自带的 commander 做了对照实验确认：
- `code codex … -c <BOTMUX值>` → 被 cjadk 的 `--command` 捕获，passthrough 不含它；
- `code codex … --config <BOTMUX值>` → 落入 passthrough，原样转发给真 codex（codex 的 `-c` 长形式就是 `--config`，而 cjadk 未定义 `--config`）。

## 修复

`src/setup/cli-selection.ts` 新增 `rewriteCjadkCodexConfigArgs`：对 **cjadk 形态**，把 botmux 注入的 `-c shell_environment_policy.set.BOTMUX_*` 改写成 codex 长形式 `--config <同值>`。`buildWrappedLaunch` 分支：

- `aiden` → `stripWrapperUnsafeArgs`（剥离，沿用既有）
- `cjadk` → `rewriteCjadkCodexConfigArgs`（改写）
- 其它 → 原样透传

### 为什么选「改写」而非像 aiden 那样「剥离」

改写成 `--config` 后参数仍会透传给真 codex，**保留**了把 `BOTMUX_SESSION_ID` 注入 codex shell 工具环境的通道（aiden 路径是整条剥离、丢这条通道）。

### 影响面

- **不动** `codex.ts` 的 `-c` 发射 → native codex / aiden 路径及其全部测试零改动、零回归。
- 只认 botmux 自己注入的特征值（`shell_environment_policy.set.BOTMUX_` 前缀），用户自带的 `-c key=val` 一律不动。
- `cjadk claude` 经此函数是 no-op（无 `-c BOTMUX`），`--settings` 照常透传。

## 测试

- 新增/改写 cli-selection 单测：cjadk codex 把 `-c` 改写为 `--config`、用户自带 `-c` 不动、真适配器 × cjadk wrapper 的端到端回归（fresh + resume 两路）。
- `pnpm build` 通过；全量单测 **6383 全绿**。
- 已在飞书真机验证 cjadk codex 能正常启动会话。

🤖 本 PR 由 AI（Claude）辅助定位根因与实现，请 Reviewer 重点核查 commander 选项交互的判断与改写边界。
