### PR TITLE
fix(reply-target): shared 模式仓库选择卡等 daemon 侧消息漏到群顶层

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -89,7 +89,7 @@ import {
   ensureTerminalWorkerPort,
   ensureSessionWhiteboard,
 } from './core/session-manager.js';
-import { beginReplyTargetTurn, resolveSessionReplyTarget, syncReplyTargetState } from './core/reply-target.js';
+import { beginReplyTargetTurn, fallbackTurnId, resolveSessionReplyTarget, syncReplyTargetState } from './core/reply-target.js';
 import { sweepOrphanSandboxes } from './adapters/backend/sandbox.js';
 import { sweepIdleWorkers, DEFAULT_MAX_LIVE_WORKERS } from './core/idle-worker-sweeper.js';
 import { handleCardAction } from './im/lark/card-handler.js';
@@ -435,7 +435,18 @@ async function sessionReply(anchor: string, content: string, msgType: string = '
     if (ds?.scope === 'chat') {
       const fresh = readSessionFreshFromDisk(ds.session.sessionId, ds.larkAppId);
       if (fresh) syncReplyTargetState(ds, fresh);
-      const target = resolveSessionReplyTarget(ds, turnId);
+      // Resolve through fallbackTurnId so daemon-side sends that carry no turn of
+      // their own (the repo-select card, skip/switch confirmations, crash notices)
+      // still anchor into the current shared fold-back topic instead of leaking to
+      // the chat top level. Callers that DO pass an explicit turnId are unchanged —
+      // fallbackTurnId returns it verbatim, so the stale-turn hijack guard stays
+      // authoritative. Baking the fallback in HERE (the single chat-scope send
+      // chokepoint) means no individual send site can re-introduce the leak by
+      // forgetting to thread — the recurring failure mode behind this and the
+      // earlier e619250d fix. Guarded by test/session-reply-thread-anchor.test.ts
+      // (drives the real sessionReply) and test/reply-target-fallback.test.ts
+      // (the resolveSessionReplyTarget × fallbackTurnId composition it relies on).
+      const target = resolveSessionReplyTarget(ds, fallbackTurnId(ds, turnId));
       if (target.mode === 'thread') return replyMessage(appId, target.rootMessageId, content, msgType, true, undefined, hookContext);
       if (ds.session.rootMessageId) {
         const mode = await getChatMode(appId, chatId, { forceRefresh: true });
@@ -451,6 +462,13 @@ async function sessionReply(anchor: string, content: string, msgType: string = '
   // Thread-scope (or unknown / legacy): reply in thread.
   return replyMessage(appId, anchor, content, msgType, true, undefined, hookContext);
 }
+
+// Test seams: drive the real sessionReply (the chat-scope thread/top-level
+// chokepoint) against a seeded session, so the shared fold-back leak is guarded
+// at the function that actually routes — not just the resolveSessionReplyTarget
+// composition it relies on. See test/reply-target-fallback.test.ts.
+export const __testOnly_sessionReply = sessionReply;
+export const __testOnly_activeSessions = activeSessions;
 
 async function revokeQuotaGrant(
   larkAppId: string,

--- a/test/session-reply-thread-anchor.test.ts
+++ b/test/session-reply-thread-anchor.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Integration guard for the chat-scope send chokepoint (daemon.ts sessionReply).
+ *
+ * Regression: in `shared` (chat-scope) mode the repo-selection card and other
+ * daemon-side sends that carry NO turnId leaked to the chat top level instead of
+ * threading into the shared fold-back topic — sessionReply resolved the reply
+ * target with the raw turnId rather than fallbackTurnId(ds, turnId), so the
+ * turnId gate never matched (daemon.ts:2491 et al. pass no turnId).
+ *
+ * resolveSessionReplyTarget's composition with fallbackTurnId was already unit
+ * tested (reply-target-fallback.test.ts), but NOTHING asserted that the real
+ * send function WIRES it — which is exactly the gap that let e619250d fix some
+ * sites and miss the repo-card ones. This drives the real sessionReply against a
+ * seeded session so a revert (or a new unguarded send site) re-opens a failing
+ * test, not a silent top-level leak.
+ *
+ * Run:  pnpm vitest run test/session-reply-thread-anchor.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  replyMessage: vi.fn(async () => 'om_reply'),
+  sendMessage: vi.fn(async () => 'om_top'),
+  getChatMode: vi.fn(async () => 'group' as 'group' | 'topic' | 'p2p'),
+}));
+
+vi.mock('@larksuiteoapi/node-sdk', () => {
+  class FakeClient { constructor(public opts: Record<string, unknown>) {} }
+  return { Client: FakeClient };
+});
+
+vi.mock('../src/im/lark/client.js', async () => {
+  const actual = await vi.importActual<any>('../src/im/lark/client.js');
+  return { ...actual, replyMessage: mocks.replyMessage, sendMessage: mocks.sendMessage, getChatMode: mocks.getChatMode };
+});
+
+import { registerBot } from '../src/bot-registry.js';
+import { sessionKey } from '../src/core/types.js';
+import { __testOnly_sessionReply as sessionReply, __testOnly_activeSessions as activeSessions } from '../src/daemon.js';
+import type { DaemonSession } from '../src/core/types.js';
+
+const APP = 'session_reply_anchor_app';
+const CHAT = 'oc_shared_chat';
+const NOW = new Date().toISOString();
+
+type Target = { rootMessageId: string; turnId: string; updatedAt: string };
+
+function seedSharedSession(currentReplyTarget?: Target): DaemonSession {
+  const ds = {
+    scope: 'chat',
+    chatId: CHAT,
+    larkAppId: APP,
+    session: {
+      sessionId: 'sess-anchor-' + Math.random().toString(36).slice(2),
+      chatId: CHAT,
+      rootMessageId: CHAT,
+      title: 't',
+      status: 'active',
+      createdAt: NOW,
+      currentReplyTarget,
+    },
+    currentReplyTarget,
+  } as unknown as DaemonSession;
+  activeSessions.set(sessionKey(CHAT, APP), ds);
+  return ds;
+}
+
+describe('sessionReply chat-scope chokepoint — shared fold-back anchoring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.replyMessage.mockResolvedValue('om_reply');
+    mocks.sendMessage.mockResolvedValue('om_top');
+    mocks.getChatMode.mockResolvedValue('group');
+    activeSessions.clear();
+    registerBot({ larkAppId: APP, larkAppSecret: 's', cliId: 'claude-code', allowedUsers: ['ou_o'] });
+  });
+
+  it('repo-card-style send (interactive, NO turnId) threads into the shared topic, not top-level', async () => {
+    seedSharedSession({ rootMessageId: 'om_topic', turnId: 'turn-1', updatedAt: NOW });
+    // Mirrors daemon.ts:2491 — a card sent with no 5th turnId arg.
+    await sessionReply(CHAT, '{"card":true}', 'interactive', APP);
+    expect(mocks.replyMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.replyMessage).toHaveBeenCalledWith(APP, 'om_topic', '{"card":true}', 'interactive', true, undefined, expect.anything());
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('explicit STALE turnId still routes top-level — the fallback must not weaken the cross-turn hijack guard', async () => {
+    seedSharedSession({ rootMessageId: 'om_topic', turnId: 'turn-1', updatedAt: NOW });
+    await sessionReply(CHAT, 'late', 'text', APP, 'turn-2');
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.replyMessage).not.toHaveBeenCalled();
+  });
+
+  it('plain chat session (no fold-back anchor) keeps replying flat to the chat top-level', async () => {
+    seedSharedSession(undefined);
+    await sessionReply(CHAT, 'hello', 'text', APP);
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.replyMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 现象（申晗报告）

`shared` 模式下，**仓库选择卡**和**选择完的确认卡**没有落进话题，而后续的流式卡片与机器人回复却正常在话题里回复——同一会话里，卡漏到群顶层、回复在话题内，不一致。

## 根因

`shared` 是 chat-scope 会话，所有 daemon 侧发送走 `sessionReply`。是否落进话题由一道「turnId 闸」决定：`resolveSessionReplyTarget` 仅在 `currentReplyTarget.turnId === 传入 turnId` 时才 `replyMessage` 进话题，否则 `sendMessage` 发群顶层。

spawn 时 `beginReplyTargetTurn` 已把话题锚存进 `ds.currentReplyTarget`，但**仓库选择卡的几处发送（`daemon.ts:2158/2491/2693/3239`）以及 skip/switch 确认卡都没传 turnId** → 闸不命中 → 落群顶层。而流式卡与回复都经 `fallbackTurnId(ds, …)` 把当前轮 turnId 带上 → 命中 → 落进话题。这就是不一致的来源。

> 上一轮 `e619250d` 修了流式卡 + 下拉首选确认（逐点补 `fallbackTurnId`），但漏补了仓库选择卡与 skip/switch 确认——典型的「逐点打补丁、新增发送点又复发」。

## 修法（收口，杜绝复发）

在 `sessionReply` 这唯一的 chat-scope 发送收口处统一走 `resolveSessionReplyTarget(ds, fallbackTurnId(ds, turnId))`：

- 显式传 turnId 的调用者**行为不变**（`fallbackTurnId` 原样返回，跨轮劫持的 stale-turn 闸仍然权威）；
- 无自身 turnId 的 daemon 侧消息（仓库卡、skip/switch 确认、崩溃通知）**自动回落到当前轮**，落进 shared 话题。

收口在此处而非逐个 send 点打补丁，从结构上杜绝「新增发送点忘记 thread」这一反复失效模式。`fallbackTurnId × resolveSessionReplyTarget` 的组合本就有单测（`reply-target-fallback.test.ts`），本 PR 补上「`sessionReply` 确实接了这个组合」的守卫。

## 影响面

- **chat 模式 / chat-topic 顶层**：无话题锚 → `fallbackTurnId` 回落 undefined → 仍走顶层，**行为不变**。
- **thread-scope（话题群 / new-topic）**：`sessionReply` 走无条件 thread 分支，turnId 闸根本不适用，**不变**。
- **多话题协作（orchestrate）**：**不命中**。子 bot 被 dispatch 进已建话题（`reply_in_thread=true`）= thread-scope；且 dispatch 用 `/repo <path>` 预钉目录，子 bot 压根不弹仓库卡。

## 测试

新增 `test/session-reply-thread-anchor.test.ts`，驱动**真实** `sessionReply`（seed shared 会话 + mock lark client）：
- 无 turnId 的 interactive 卡 → 落进话题（`replyMessage(om_topic, …, reply_in_thread=true)`，不 `sendMessage`）；
- 显式 **stale** turnId → 仍走顶层（证明回落没削弱跨轮闸）；
- 无锚 plain chat → 仍走顶层（行为不变）。

已验证撤掉修复该测试转红、恢复转绿。全量单测 **378 files / 6389 tests 全绿**，build 绿。

与 chat-topic（#295）无关，独立 PR。