### PR TITLE
fix(cli): Windows PowerShell 管道中文 GBK 编码自动探测

### DIFF
--- a/docs/powershell-stdin-encoding.md
+++ b/docs/powershell-stdin-encoding.md
@@ -1,0 +1,100 @@
+PowerShell 5.1 stdin 编码问题 · 处理方案
+
+## 问题描述
+
+在 Windows 上通过 PowerShell 5.1 使用 `botmux send` 发送多行中文消息时，飞书卡片上只能看到第一行，换行后的内容全部丢失。通过 `--content-file` 传入 UTF-8 文件则正常显示。
+
+## 问题复现
+
+### 有问题的操作
+
+```powershell
+# 直接传入多行中文内容（截断！）
+botmux send --mention-back "测试
+
+第一项 配置机器人
+第二项 多话题协作
+第三项 创建飞书群"
+```
+
+### 正常操作
+
+```powershell
+# 先用 UTF-8 文件传入（正常）
+$msg = Join-Path $env:TEMP "test.md"
+Set-Content -LiteralPath $msg -Encoding utf8 -Value @'
+测试
+
+第一项 配置机器人
+第二项 多话题协作
+第三项 创建飞书群
+'@
+botmux send --mention-back --content-file $msg
+```
+
+## 问题根源
+
+PowerShell 5.1 在通过管道向原生可执行文件（node.exe）传递数据时，会将 UTF-16LE 内部字符串转为系统活动代码页（中文 Windows = CP936/GBK）。botmux send 的 readStdin() 以 UTF-8 解码这些 GBK 字节，导致乱码。换行符（0x0D 0x0A）之后的 GBK 字节被截断，表现为"只能看到第一行"。
+
+现有检测 rejectLikelyWindowsStdinMojibake 只捕获中文变 ? 的情况，漏掉了截断场景。
+
+## 编码转换链路
+
+```mermaid
+sequenceDiagram
+    participant User as 用户输入
+    participant PS51 as PowerShell 5.1
+    participant Pipe as 管道 (stdin)
+    participant Node as node.exe
+    participant Lark as 飞书 API
+
+    User->>PS51: "测试\n第一项"
+    PS51->>Pipe: UTF-16LE → GBK (CP936)
+    Note over Pipe: 换行符 0D 0A 后字节被截断
+    Pipe->>Node: GBK 字节（不完整）
+    Node->>Node: toString('utf-8') → 乱码
+    Node->>Lark: 发送乱码 JSON
+    Lark-->>User: 显示乱码/截断内容
+```
+
+## 与 --content-file 的差异
+
+| 传参方式 | 编码路径 | 结果 |
+|---------|---------|------|
+| 位置参数/stdin | UTF-16LE → GBK → 被 Node 当 UTF-8 读 | 乱码/截断 |
+| --content-file | `readFileSync(path, 'utf-8')` 直接读文件 | 正常（文件已 UTF-8 保存） |
+
+## 方案对比
+
+### 方案 A：源码自动编码探测（推荐）
+在 readStdin() 中对 Windows 平台自动检测并转换编码：
+
+Node.js v24.12.0 内置 ICU 支持 new TextDecoder('gbk')，无需额外依赖。收集原始字节后，先用 GBK 解码，检查是否包含 CJK 字符——如果是则使用 GBK 结果，否则回退 UTF-8。
+
+优点：用户无感知、零依赖、适配所有 Windows shell（cmd/PowerShell 5.1/PS7）
+缺点：需要改源码并重新 build
+
+### 方案 B：安装 PowerShell 7+ 替代 5.1
+PowerShell 7+（pwsh.exe）默认以 UTF-8 编码管道数据，不会做代码页转换。
+
+优点：不仅修本问题，还改善所有中文 PowerShell 体验
+缺点：不是每个用户都能升级，团队协作难以统一
+
+### 方案 C：启用系统 UTF-8 支持
+Windows 设置 → 时间和语言 → 语言和区域 → 管理语言设置 → 更改系统区域设置 → 勾选"使用 Unicode UTF-8 提供全球语言支持"（Beta）
+
+优点：一劳永逸
+缺点：Beta 功能，可能影响其他旧应用
+
+### 关于"禁用 PowerShell 5.1"
+
+PowerShell 5.1 是 Windows 10/11 的内置组件，不可删除。但可以：
+- 把默认终端改为 PowerShell 7+（pwsh.exe）
+- VS Code 中设置 terminal.integrated.defaultProfile.windows 为 "PowerShell 7"
+- 不影响 botmux send 的工作——它是独立进程，不依赖 shell 注册
+
+## 我的建议
+
+方案 A（源码自动编码探测）最彻底，用户零感知，一次修好所有人。
+
+已在 botmux 源码中实现方案 A（编码自动探测）。

--- a/docs/powershell-stdin-encoding.md
+++ b/docs/powershell-stdin-encoding.md
@@ -9,13 +9,11 @@ PowerShell 5.1 stdin 编码问题 · 处理方案
 ### 有问题的操作
 
 ```powershell
-# 直接传入多行中文内容（截断！）
-botmux send --mention-back "测试
-
-第一项 配置机器人
-第二项 多话题协作
-第三项 创建飞书群"
+# 通过管道/heredoc 把多行中文喂给 stdin（GBK 乱码！）
+"测试`n第一项 配置机器人`n第二项 多话题协作" | botmux send --mention-back
 ```
+
+> 注：用**位置参数**直接传多行字符串（`botmux send "第一行`n第二行"`）是另一回事——PS5.1 自己在拼 native 命令行时会把多行参数拆断，与编码无关，最稳妥是改用 `--content-file`。本文与下面的修复针对的是 **stdin（管道/heredoc）** 这条路径。
 
 ### 正常操作
 
@@ -34,7 +32,7 @@ botmux send --mention-back --content-file $msg
 
 ## 问题根源
 
-PowerShell 5.1 在通过管道向原生可执行文件（node.exe）传递数据时，会将 UTF-16LE 内部字符串转为系统活动代码页（中文 Windows = CP936/GBK）。botmux send 的 readStdin() 以 UTF-8 解码这些 GBK 字节，导致乱码。换行符（0x0D 0x0A）之后的 GBK 字节被截断，表现为"只能看到第一行"。
+PowerShell 5.1 在通过管道向原生可执行文件（node.exe）传递数据时，会将 UTF-16LE 内部字符串转为系统活动代码页（中文 Windows = CP936/GBK）。botmux send 的 readStdin() 以 UTF-8 解码这些 GBK 字节，得到乱码（夹带 U+FFFD 替换字符），在飞书卡片上表现为"只能看到第一行/乱码"。注意：字节其实都完整到达了 Node，按 GBK 正确解码即可还原全文——并非真的丢字节。
 
 现有检测 rejectLikelyWindowsStdinMojibake 只捕获中文变 ? 的情况，漏掉了截断场景。
 
@@ -50,8 +48,7 @@ sequenceDiagram
 
     User->>PS51: "测试\n第一项"
     PS51->>Pipe: UTF-16LE → GBK (CP936)
-    Note over Pipe: 换行符 0D 0A 后字节被截断
-    Pipe->>Node: GBK 字节（不完整）
+    Pipe->>Node: GBK 字节（完整到达）
     Node->>Node: toString('utf-8') → 乱码
     Node->>Lark: 发送乱码 JSON
     Lark-->>User: 显示乱码/截断内容
@@ -61,7 +58,8 @@ sequenceDiagram
 
 | 传参方式 | 编码路径 | 结果 |
 |---------|---------|------|
-| 位置参数/stdin | UTF-16LE → GBK → 被 Node 当 UTF-8 读 | 乱码/截断 |
+| stdin（管道/heredoc） | UTF-16LE → GBK → 被 Node 当 UTF-8 读 | 乱码（本文修复的对象） |
+| 位置参数（多行） | PS5.1 拼 native 命令行时拆断参数（与编码无关） | 截断 |
 | --content-file | `readFileSync(path, 'utf-8')` 直接读文件 | 正常（文件已 UTF-8 保存） |
 
 ## 方案对比
@@ -69,7 +67,9 @@ sequenceDiagram
 ### 方案 A：源码自动编码探测（推荐）
 在 readStdin() 中对 Windows 平台自动检测并转换编码：
 
-Node.js v24.12.0 内置 ICU 支持 new TextDecoder('gbk')，无需额外依赖。收集原始字节后，先用 GBK 解码，检查是否包含 CJK 字符——如果是则使用 GBK 结果，否则回退 UTF-8。
+Node.js（官方构建默认带 full-ICU）支持 new TextDecoder('gbk')，无需额外依赖。收集原始字节后，**先按严格 UTF-8 解码（fatal: true）**：合法 UTF-8（绝大多数情况——pwsh7 / cmd 开 UTF-8 代码页 / Git Bash / agent 用 heredoc 发的多行中文）必然解码成功、原样返回；只有当字节不是合法 UTF-8（PS5.1 的 GBK 字节序列几乎不可能凑成合法 UTF-8）时才回退 GBK。
+
+> ⚠️ 不能反过来「先 GBK、含 CJK 就用 GBK」：合法 UTF-8 的中文/emoji 用 GBK 去解照样会产出（乱码的）CJK 字符，分不出真假，会把所有正常 UTF-8 输入误解成乱码（如 UTF-8 `测试` → `娴嬭瘯`）。这是本方案最关键的一点。
 
 优点：用户无感知、零依赖、适配所有 Windows shell（cmd/PowerShell 5.1/PS7）
 缺点：需要改源码并重新 build

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,7 +58,7 @@ import { dispatchPrimaryMessage, findStdinAliasAttachment, sendFileAttachments }
 import { buildPm2SpawnCommand } from './cli/pm2-command.js';
 import { callDashboard, type DashboardEndpoint, type DashboardResult } from './cli/dashboard-endpoint.js';
 import { loadDashboardSecret } from './dashboard/auth.js';
-import { rejectLikelyWindowsStdinMojibake } from './cli/stdin-encoding.js';
+import { rejectLikelyWindowsStdinMojibake, decodeStdinBytes } from './cli/stdin-encoding.js';
 import {
   formatBotInfoEntriesForCli,
   formatChatBotsForCli,
@@ -3426,26 +3426,8 @@ function readStdin(): Promise<string> {
   });
 }
 
-/**
- * Decode raw stdin bytes with platform-aware encoding detection.
- *
- * On Windows, PowerShell 5.1 converts UTF-16LE to the active code page
- * (e.g. CP936/GBK on Chinese systems) when piping to native executables.
- * Node.js reading those bytes as UTF-8 produces mojibake and truncation
- * after newlines. We detect this by trying GBK first and checking for CJK
- * characters — if present, the pipe used a non-UTF-8 code page.
- */
-function decodeStdinBytes(raw: Buffer): string {
-  if (process.platform !== 'win32') return raw.toString('utf-8');
-  const utf8 = raw.toString('utf-8');
-  try {
-    const gbk = new TextDecoder('gbk', { fatal: false }).decode(raw);
-    const hasCJK = /[\u4E00-\u9FFF\u3400-\u4DBF\uF900-\uFAFF]/.test(gbk);
-    return hasCJK ? gbk : utf8;
-  } catch {
-    return utf8;
-  }
-}
+// decodeStdinBytes lives in ./cli/stdin-encoding.ts (imported above) so it
+// can be unit-tested with an explicit platform argument.
 
 /** Collect all values for a repeatable flag: --flag v1 --flag v2 */
 function argValues(args: string[], ...flags: string[]): string[] {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2866,7 +2866,7 @@ function readStdinUtf8(): string {
   // a TTY as "no stdin input" so the caller's empty-content guard surfaces a
   // real error instead of an indefinite hang.
   if (process.stdin.isTTY) return '';
-  try { return readFileSync(0, 'utf-8'); } catch { return ''; }
+  try { return decodeStdinBytes(readFileSync(0)); } catch { return ''; }
 }
 
 function currentWhiteboardContext(args: string[]): { session?: SessionData; larkAppId?: string; chatId?: string; workingDir?: string; sessionId?: string } {
@@ -3418,9 +3418,33 @@ function readStdin(): Promise<string> {
     if (process.stdin.isTTY) { resolve(''); return; }
     const chunks: Buffer[] = [];
     process.stdin.on('data', (c) => chunks.push(c));
-    process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    process.stdin.on('end', () => {
+      const raw = Buffer.concat(chunks);
+      resolve(decodeStdinBytes(raw));
+    });
     process.stdin.on('error', () => resolve(''));
   });
+}
+
+/**
+ * Decode raw stdin bytes with platform-aware encoding detection.
+ *
+ * On Windows, PowerShell 5.1 converts UTF-16LE to the active code page
+ * (e.g. CP936/GBK on Chinese systems) when piping to native executables.
+ * Node.js reading those bytes as UTF-8 produces mojibake and truncation
+ * after newlines. We detect this by trying GBK first and checking for CJK
+ * characters — if present, the pipe used a non-UTF-8 code page.
+ */
+function decodeStdinBytes(raw: Buffer): string {
+  if (process.platform !== 'win32') return raw.toString('utf-8');
+  const utf8 = raw.toString('utf-8');
+  try {
+    const gbk = new TextDecoder('gbk', { fatal: false }).decode(raw);
+    const hasCJK = /[\u4E00-\u9FFF\u3400-\u4DBF\uF900-\uFAFF]/.test(gbk);
+    return hasCJK ? gbk : utf8;
+  } catch {
+    return utf8;
+  }
 }
 
 /** Collect all values for a repeatable flag: --flag v1 --flag v2 */

--- a/src/cli/stdin-encoding.ts
+++ b/src/cli/stdin-encoding.ts
@@ -19,3 +19,41 @@ export function rejectLikelyWindowsStdinMojibake(content: string): void {
   console.error('Write the message to a UTF-8 file and use: botmux send --content-file <path>');
   process.exit(2);
 }
+
+/**
+ * Decode raw stdin bytes with platform-aware encoding detection.
+ *
+ * On Windows, PowerShell 5.1 converts an internal UTF-16LE string to the
+ * active code page (e.g. CP936/GBK on Chinese systems) when piping to a
+ * native executable. Reading those bytes as UTF-8 yields mojibake and
+ * truncation after newlines.
+ *
+ * Strategy: try strict UTF-8 first. Valid UTF-8 -- the overwhelmingly common
+ * case (pwsh 7, cmd with UTF-8 code page, Git Bash, and heredoc/pipe input
+ * from agents) -- always decodes cleanly and is returned untouched. Only when
+ * the bytes are NOT valid UTF-8 do we fall back to GBK; GBK lead/trail byte
+ * pairs almost never form a valid UTF-8 sequence, so the PowerShell 5.1 case
+ * lands here.
+ *
+ * Do NOT invert this (decode as GBK first and keep it when the result has CJK
+ * chars): GBK-decoding valid UTF-8 Chinese -- and even emoji -- ALSO produces
+ * CJK characters (garbage ones), so that heuristic silently corrupts every
+ * valid UTF-8 message. e.g. UTF-8 "测试" would come back as "娴嬭瘯".
+ */
+export function decodeStdinBytes(
+  raw: Buffer,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform !== 'win32') return raw.toString('utf-8');
+  try {
+    // fatal:true => throws on any byte sequence that isn't valid UTF-8.
+    return new TextDecoder('utf-8', { fatal: true }).decode(raw);
+  } catch {
+    try {
+      return new TextDecoder('gbk', { fatal: false }).decode(raw);
+    } catch {
+      // Node built without full ICU: no GBK decoder. Best-effort UTF-8.
+      return raw.toString('utf-8');
+    }
+  }
+}

--- a/test/windows-stdin-encoding.test.ts
+++ b/test/windows-stdin-encoding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { looksLikeWindowsStdinMojibake } from '../src/cli/stdin-encoding.js';
+import { looksLikeWindowsStdinMojibake, decodeStdinBytes } from '../src/cli/stdin-encoding.js';
 
 describe('looksLikeWindowsStdinMojibake', () => {
   it('detects question-mark replacement on Windows stdin', () => {
@@ -18,5 +18,33 @@ describe('looksLikeWindowsStdinMojibake', () => {
   it('does not flag ordinary short or low-density question marks', () => {
     expect(looksLikeWindowsStdinMojibake('OK?', 'win32')).toBe(false);
     expect(looksLikeWindowsStdinMojibake('Did this work? Yes, it did.', 'win32')).toBe(false);
+  });
+});
+
+describe('decodeStdinBytes', () => {
+  it('preserves valid UTF-8 Chinese on Windows', () => {
+    const raw = Buffer.from('测试\n第一项 配置机器人', 'utf-8');
+    expect(decodeStdinBytes(raw, 'win32')).toBe('测试\n第一项 配置机器人');
+  });
+
+  it('preserves valid UTF-8 emoji and non-Chinese content on Windows', () => {
+    expect(decodeStdinBytes(Buffer.from('hello 😀 done', 'utf-8'), 'win32')).toBe('hello 😀 done');
+    expect(decodeStdinBytes(Buffer.from('完成 ✅ 第二项', 'utf-8'), 'win32')).toBe('完成 ✅ 第二项');
+  });
+
+  it('decodes GBK (CP936) bytes from PowerShell 5.1 on Windows', () => {
+    // "测试" encoded as GBK/CP936 is 0xB2 0xE2 0xCA 0xD4 -- not valid UTF-8,
+    // so strict UTF-8 throws and we fall back to GBK.
+    expect(decodeStdinBytes(Buffer.from([0xb2, 0xe2, 0xca, 0xd4]), 'win32')).toBe('测试');
+  });
+
+  it('passes bytes through as UTF-8 on non-Windows platforms', () => {
+    const raw = Buffer.from('测试 😀', 'utf-8');
+    expect(decodeStdinBytes(raw, 'linux')).toBe('测试 😀');
+  });
+
+  it('preserves ASCII on every platform', () => {
+    expect(decodeStdinBytes(Buffer.from('hello world', 'utf-8'), 'win32')).toBe('hello world');
+    expect(decodeStdinBytes(Buffer.from('hello world', 'utf-8'), 'linux')).toBe('hello world');
   });
 });


### PR DESCRIPTION
PowerShell 5.1 向原生可执行文件传递数据时会将 UTF-16LE
转为系统活动代码页（中文系统 CP936/GBK），readStdin 以
UTF-8 解码导致乱码和换行后截断。新增 decodeStdinBytes 在
Windows 平台自动探测 GBK 编码并正确解码，用户无感知。