### PR TITLE
fix(skills): restore 后补扫全局 botmux skills，兜住重启竞态泄漏

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -947,17 +947,33 @@ export function ensureCliEnv(cliId: CliId, cliPathOverride?: string): void {
   cleanupLegacyMcpConfig(cliId);
 }
 
+/** The user's global skills dir that botmux must NOT pollute (Claude now injects
+ *  its skills per-session via `--plugin-dir`). Single source of truth for the
+ *  path so the early once-pass and the post-restore re-sweep stay in sync. */
+const GLOBAL_CLAUDE_SKILLS_DIR = '~/.claude/skills';
+
+/** Unconditionally sweep botmux-owned skills out of the user's global
+ *  `~/.claude/skills`. botmux owns the `botmux-` namespace there and injects its
+ *  skills per-session via `--plugin-dir`, so anything matching is a leak that
+ *  would otherwise surface (and mis-fire) in the user's standalone `claude`.
+ *  Idempotent & best-effort — safe to call repeatedly. */
+export function sweepGlobalBotmuxSkills(): void {
+  removeGlobalBotmuxSkills(GLOBAL_CLAUDE_SKILLS_DIR);
+}
+
 let globalBotmuxSkillsCleaned = false;
 /** One-time, CLI-independent cleanup of botmux skills that older versions
- *  installed into the global `~/.claude/skills`. Claude now injects skills via
- *  `--plugin-dir`, so any leftover `botmux-*` there leaks into the user's
- *  standalone `claude` regardless of which CLI THIS daemon's bot uses — so the
- *  cleanup must NOT be gated on `adapter.pluginDir` (which only fires for a
- *  Claude bot). Runs at daemon startup via ensureCliEnv. */
+ *  installed into the global `~/.claude/skills`. Runs early at daemon startup
+ *  via ensureCliEnv (CLI-independent: the leak surfaces in standalone `claude`
+ *  no matter which CLI THIS daemon's bot uses, so it must NOT be gated on
+ *  `adapter.pluginDir`). NOTE: this early pass can lose a restart race — an
+ *  outgoing old-build daemon may re-create the dirs a few ms later — so
+ *  {@link sweepGlobalBotmuxSkills} is called again post-restore (see daemon.ts)
+ *  to catch that on the same startup instead of leaving it until next restart. */
 function cleanupGlobalBotmuxSkillsOnce(): void {
   if (globalBotmuxSkillsCleaned) return;
   globalBotmuxSkillsCleaned = true;
-  removeGlobalBotmuxSkills('~/.claude/skills');
+  sweepGlobalBotmuxSkills();
 }
 
 // ─── Claude Code folder-trust pre-acceptance ─────────────────────────────────

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -59,6 +59,7 @@ import {
   parkStreamCard,
   closeSession as closeSessionHelper,
   ensureCliEnv,
+  sweepGlobalBotmuxSkills,
   writableTerminalLinkFor,
 } from './core/worker-pool.js';
 import { ipcRoute, jsonRes, readJsonBody, setBotName, setLarkAppId, startIpcServer, setWorkflowRunner } from './core/dashboard-ipc-server.js';
@@ -3795,6 +3796,17 @@ export async function startDaemon(botIndex?: number): Promise<void> {
 
   // Restore active sessions from previous run
   await restoreActiveSessions(activeSessions);
+
+  // Second global-skills sweep, AFTER restore has settled. The early
+  // cleanupGlobalBotmuxSkillsOnce() pass (in the startup ensureCliEnv above)
+  // runs before any restart overlap settles, so an outgoing old-build daemon
+  // (pre `--plugin-dir` migration) can re-create ~/.claude/skills/botmux-* a few
+  // ms after we cleaned it — leaving it to leak into the user's standalone
+  // `claude` until the *next* restart. Re-sweeping here, once this daemon's own
+  // spawns and the handoff window are done, catches that leak on the same
+  // startup. Idempotent & best-effort — never blocks startup.
+  try { sweepGlobalBotmuxSkills(); }
+  catch (err) { logger.warn(`[skills] post-restore global sweep failed: ${err instanceof Error ? err.message : String(err)}`); }
 
   // 文档订阅恢复：重启后订阅可能已失效，给仍活跃的会话重订阅；会话没恢复
   // （已关/丢失）的订阅则退订 + 清表，避免「命中订阅但无会话」的孤儿。

--- a/test/ensure-plugin-skills.test.ts
+++ b/test/ensure-plugin-skills.test.ts
@@ -74,4 +74,23 @@ describe('removeGlobalBotmuxSkills', () => {
     expect(() => removeGlobalBotmuxSkills(join(dir, 'nope'))).not.toThrow();
     expect(() => removeGlobalBotmuxSkills(undefined)).not.toThrow();
   });
+
+  it('二次扫描：第一次清理后重启竞态又写回的 botmux skill，会被再扫一遍清掉', () => {
+    // 第一道：清理（模拟早期 cleanupGlobalBotmuxSkillsOnce）
+    seed('botmux-send');
+    removeGlobalBotmuxSkills(dir);
+    expect(existsSync(join(dir, 'botmux-send'))).toBe(false);
+
+    // 重启竞态：清理后又被外部老 build / 残留进程写回全局
+    seed('botmux-send');
+    seed('botmux-handoff');
+    seed('my-own-skill');
+    expect(existsSync(join(dir, 'botmux-send'))).toBe(true);
+
+    // 第二道：restore 完成后再扫一遍（本次修复的核心）——botmux 残留清掉、用户 skill 保留
+    removeGlobalBotmuxSkills(dir);
+    expect(existsSync(join(dir, 'botmux-send'))).toBe(false);
+    expect(existsSync(join(dir, 'botmux-handoff'))).toBe(false);
+    expect(existsSync(join(dir, 'my-own-skill'))).toBe(true);
+  });
 });


### PR DESCRIPTION
## 背景

排查「独立 `claude` 里出现全局 botmux skills」时定位到的泄漏：

- 当前设计已是「claude skills 按会话用 `--plugin-dir` 注入」（commit `774987c7`），botmux 内置 skill 落在 `~/.botmux/claude-plugin`，**不写全局** `~/.claude/skills`。
- daemon 还会在启动时 `removeGlobalBotmuxSkills('~/.claude/skills')` 主动清理历史残留（日志可见每次重启都在删）。
- **但全局 `~/.claude/skills/botmux-*` 仍反复出现**：删完 ~95ms 又被写回一次，内容与 plugin 版字节相同，且 10 小时不再变动 → 重启那一刻的一次性写入。

## 根因

`cleanupGlobalBotmuxSkillsOnce` 的 `globalBotmuxSkillsCleaned` once-flag 只在 daemon 启动**最早期**（`ensureCliEnv`，早于会话 restore）跑一次。这个时序卡在重启重叠窗口**之前**：新 build 的 daemon 删掉全局后，正在退场的**老 build daemon**（`--plugin-dir` 迁移之前的版本，claude 仍写全局）几毫秒后又把 `botmux-*` 写回 `~/.claude/skills`，泄漏进用户独立的 `claude`，一直留到下次重启才再被删——然后又泄漏，循环。

早期那道清理因 adopt 模式的全局 hook 安装时序需求不能往后挪，所以保留它、另加一道补扫。

## 改动

- `worker-pool.ts`：提取非门控的 `sweepGlobalBotmuxSkills()`（`~/.claude/skills` 路径单一来源），`cleanupGlobalBotmuxSkillsOnce` 复用它做早期一次性清理。
- `daemon.ts`：在 `restoreActiveSessions` **之后**再调一次 `sweepGlobalBotmuxSkills()`——此时本 daemon 自己的 spawn 与重启交接窗口都已结束，竞态写回的残留会在**同一次启动**里被清掉，而非留到下次重启。幂等、best-effort，`try/catch` 不阻塞启动。
- `test/ensure-plugin-skills.test.ts`：加二次扫描单测（清理 → 写回 → 再清理；botmux 残留清掉、用户自有 skill 保留）。

对 botmux 会话零副作用：claude 一律走 `--plugin-dir`，全局 `~/.claude/skills` 从不需要 botmux skill；补扫只删 botmux 自己的 `botmux-` 命名空间，不碰用户 skill。

## 验证

- `tsc --noEmit` 干净
- `pnpm build` 绿
- `vitest run test/ensure-plugin-skills.test.ts` → 7/7 通过（含新增二次扫描用例）

> 注：泄漏的根源是环境里残留的**老全局 npm botmux**（已卸载、目录都没了，但还吊着 5 月起的孤儿 worker），本次排查时已手动 `rm -rf ~/.claude/skills/botmux-*` + 杀掉那批孤儿进程。本 PR 是代码层根治重启竞态，避免将来再出现同类泄漏。
