### PR TITLE
fix(usage): claude project-key 解析软链，修复软链 cwd 下 token 上报静默丢失

### DIFF
--- a/src/services/transcript-resolver.ts
+++ b/src/services/transcript-resolver.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import type { CliId } from '../adapters/cli/types.js';
@@ -63,11 +63,24 @@ export function cachedTranscriptPathLookup(
   return path;
 }
 
+/** cwd → the path Claude Code keys its project dir by: the REALPATH (symlinks
+ *  resolved), falling back to a lexical resolve only when the path isn't on disk.
+ *  Claude keys projects by realpath, so a symlinked cwd (e.g. /home/x →
+ *  /data00/home/x) must resolve to the same string the CLI used — a lexical
+ *  resolve() would point at a project key Claude never writes to. */
+function realCwd(cwd: string): string {
+  const expanded = expandHome(cwd);
+  try { return realpathSync(expanded); } catch { return resolve(expanded); }
+}
+
 export function getClaudeSessionJsonlPath(sessionId: string, cwd: string, dataDir: string): string | null {
-  const resolvedCwd = resolve(expandHome(cwd));
   // Claude stores sessions at ~/.claude/projects/<project-key>/<sessionId>.jsonl
-  // where project-key = absolute path with non [A-Za-z0-9-] chars replaced by -
-  const projectKey = resolvedCwd.replace(/[^A-Za-z0-9-]/g, '-');
+  // where project-key = the REALPATH of cwd with non [A-Za-z0-9-] chars → '-'.
+  // Resolve symlinks (realCwd), NOT just resolve(): under a symlinked cwd a
+  // lexical key points at a dir Claude never wrote, so the transcript is never
+  // found and the usage ledger silently writes no delta (claude-code.ts's
+  // realpathCwd already does this for the idle bridge — this path was the laggard).
+  const projectKey = realCwd(cwd).replace(/[^A-Za-z0-9-]/g, '-');
   const jsonlPath = join(dataDir, 'projects', projectKey, `${sessionId}.jsonl`);
   return existsSync(jsonlPath) ? jsonlPath : null;
 }

--- a/test/transcript-resolver-symlink.test.ts
+++ b/test/transcript-resolver-symlink.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync, realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { getClaudeSessionJsonlPath } from '../src/services/transcript-resolver.js';
+
+// Regression: a symlinked cwd (the real-world case: /home/<user> → /data00/home/<user>)
+// must resolve to the SAME project key Claude Code writes under. Claude keys
+// projects by realpath; a lexical resolve() would key by the symlink path,
+// miss the transcript, and make the usage ledger silently write no delta.
+describe('getClaudeSessionJsonlPath — symlinked cwd', () => {
+  const trash: string[] = [];
+  afterEach(() => { for (const d of trash.splice(0)) rmSync(d, { recursive: true, force: true }); });
+
+  it('keys the project by the realpath of a symlinked cwd, not the lexical path', () => {
+    const base = mkdtempSync(join(tmpdir(), 'botmux-symlink-'));
+    trash.push(base);
+
+    // Real working dir + a symlink pointing at it (mimics /home → /data00).
+    const realDir = join(base, 'data00', 'work');
+    mkdirSync(realDir, { recursive: true });
+    mkdirSync(join(base, 'home'), { recursive: true });
+    const linkDir = join(base, 'home', 'work');
+    symlinkSync(realDir, linkDir);
+
+    // Claude writes the transcript under the REAL path's project key.
+    const dataDir = join(base, '.claude');
+    const realKey = realpathSync(realDir).replace(/[^A-Za-z0-9-]/g, '-');
+    const sid = 'sess-1';
+    mkdirSync(join(dataDir, 'projects', realKey), { recursive: true });
+    const expected = join(dataDir, 'projects', realKey, `${sid}.jsonl`);
+    writeFileSync(expected, '{}');
+
+    // Query with the SYMLINK path (as botmux sessions do) → must still find it.
+    expect(getClaudeSessionJsonlPath(sid, linkDir, dataDir)).toBe(expected);
+  });
+
+  it('still resolves a plain (non-symlinked) cwd', () => {
+    const base = mkdtempSync(join(tmpdir(), 'botmux-symlink-'));
+    trash.push(base);
+    const cwd = join(base, 'work');
+    mkdirSync(cwd, { recursive: true });
+    const dataDir = join(base, '.claude');
+    const key = realpathSync(cwd).replace(/[^A-Za-z0-9-]/g, '-');
+    const sid = 'sess-2';
+    mkdirSync(join(dataDir, 'projects', key), { recursive: true });
+    const expected = join(dataDir, 'projects', key, `${sid}.jsonl`);
+    writeFileSync(expected, '{}');
+
+    expect(getClaudeSessionJsonlPath(sid, cwd, dataDir)).toBe(expected);
+  });
+
+  it('returns null when no transcript exists at the resolved key', () => {
+    const base = mkdtempSync(join(tmpdir(), 'botmux-symlink-'));
+    trash.push(base);
+    const cwd = join(base, 'work');
+    mkdirSync(cwd, { recursive: true });
+    expect(getClaudeSessionJsonlPath('missing', cwd, join(base, '.claude'))).toBeNull();
+  });
+
+  it('falls back to a lexical resolve when cwd is not on disk (realpath throws)', () => {
+    const base = mkdtempSync(join(tmpdir(), 'botmux-symlink-'));
+    trash.push(base);
+    // cwd does not exist → realpathSync throws → lexical fallback keeps old behavior.
+    const ghost = join(base, 'gone', 'work');
+    const dataDir = join(base, '.claude');
+    const key = ghost.replace(/[^A-Za-z0-9-]/g, '-');
+    const sid = 'sess-3';
+    mkdirSync(join(dataDir, 'projects', key), { recursive: true });
+    const expected = join(dataDir, 'projects', key, `${sid}.jsonl`);
+    writeFileSync(expected, '{}');
+
+    expect(getClaudeSessionJsonlPath(sid, ghost, dataDir)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## 问题

cwd 在**软链**下时(真实世界案例:`/home/<user>` → `/data00/home/<user>`),botmux 上报的 **claude token 会静默消失**——usage 账本里该会话的 token 始终为 0,下游用量工具(kaboo)也收不到。

## 根因

`getClaudeSessionJsonlPath`([transcript-resolver.ts](src/services/transcript-resolver.ts))用 `resolve(expandHome(cwd))`(**仅词法规整,不解析软链**)算 Claude 的 project-key。而 Claude Code 用 **realpath** 给 project 目录命名:

- cwd `/home/guoguoliang/code`(软链)→ `resolve` 算出 key `-home-guoguoliang-code`
- Claude 实际写在 `~/.claude/projects/`**`-data00-home-guoguoliang-code`**`/`(realpath)

两者对不上 → botmux 永远找不到 transcript → `getSessionTokenUsage` 返回 `null` → **usage 账本永不写 delta**。

**ownership marker 放大了伤害**:botmux 仍照写零增量 ownership marker(它不依赖 transcript)。下游 kaboo 据此把该会话从 native parser 排除(契约:"botmux 会上报这个会话"),但账本里又没有 delta → **token 两边都没了,静默消失**。讽刺的是:若 botmux 不写 ownership,kaboo 反而能从 native transcript 兜底。

## 关键:同项目两条 project-key 编码不一致

- `claude-code.ts` 的 `claudeJsonlPathForSession` → 用 `realpathCwd`(`realpathSync`,**解析软链** ✅)。这是 idle-detector bridge 用的,所以 botmux 收发消息正常。
- `transcript-resolver.ts` 的 `getClaudeSessionJsonlPath` → 用 `resolve`(**不解析软链** ❌)。这是 usage/cost 用的,在软链下失效。

bridge 那条早就修对了软链,usage 这条是漏网的。

## 改动

`getClaudeSessionJsonlPath` 改用 `realpathSync` 解析软链(路径不在磁盘上时 fallback 到旧的 `resolve` 词法,保持原行为),与 `realpathCwd` 对齐。

## 真实环境验证(开发机)

```
/home/guoguoliang → /data00/home/guoguoliang (软链)
~/.claude/projects/-data00-home-guoguoliang-code      → 50 个 transcript  ✅ Claude 实际写这
~/.claude/projects/-home-guoguoliang-code             → 0 个              ❌ botmux 旧逻辑去这找
~/.botmux/usage/                                       → 空(从没写出 delta)
```

修复后 project-key 算成 `-data00-...`,对上 Claude 实际路径。

## 测试

新增 `test/transcript-resolver-symlink.test.ts`(4 例):软链 cwd 解析到 realpath key / 普通 cwd 仍正常 / 无 transcript 返回 null / cwd 不在磁盘时 fallback 词法保持旧行为。

`tsc` 通过、`pnpm build` 通过、相关既有测试(transcript / cost-calculator / usage-ledger)158 例全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
