### PR TITLE
fix(platform): webhook 触发遵循「普通群会话模式」(new-topic 每次新开会话)

### DIFF
--- a/src/core/trigger-session.ts
+++ b/src/core/trigger-session.ts
@@ -3,7 +3,8 @@ import * as groupsStore from '../services/groups-store.js';
 import * as oncallStore from '../services/oncall-store.js';
 import { randomUUID } from 'node:crypto';
 import { getBot } from '../bot-registry.js';
-import { getChatMode, sendMessage } from '../im/lark/client.js';
+import { getChatMode, sendMessage, type ChatMode } from '../im/lark/client.js';
+import { resolveRegularGroupMode, type ChatReplyMode } from '../services/chat-reply-mode-store.js';
 import { localeForBot, t } from '../i18n/index.js';
 import { validateWorkingDir } from './working-dir.js';
 import { buildFollowUpContent, buildNewTopicPrompt, ensureSessionWhiteboard, getAvailableBots, rememberLastCliInput } from './session-manager.js';
@@ -56,6 +57,17 @@ export function buildUntrustedEventPrompt(req: TriggerRequest, triggerId: string
   return lines.join('\n');
 }
 
+/** Whether a webhook external-event turn for this chat should open its own topic
+ *  + session (thread-scope) instead of folding into the group's one chat-scope
+ *  session. Mirrors the inbound @mention routing (event-dispatcher's
+ *  `regularGroupRouting`): a 话题群 always sessions per-topic, and a 普通群 only when
+ *  its reply mode is `new-topic`. The other 普通群 modes (chat / shared / chat-topic)
+ *  keep a top-level external event flat in the group chat-scope session, exactly
+ *  as they route a top-level @mention. Exported for unit tests. */
+export function externalEventOpensOwnTopic(chatMode: ChatMode, regularGroupMode: ChatReplyMode): boolean {
+  return chatMode === 'topic' || regularGroupMode === 'new-topic';
+}
+
 function resolveWorkingDir(larkAppId: string, chatId: string): { ok: true; workingDir: string } | { ok: false; error: string } {
   const bot = getBot(larkAppId);
   const candidate =
@@ -106,7 +118,16 @@ export async function triggerSessionTurn(
     return { ok: false, errorCode: 'bot_not_in_chat', error: `bot ${larkAppId} is not in chat ${chatId}` };
   }
 
-  if (!ds && !req.target.sessionId) {
+  // Mirror the inbound @ routing: a 普通群 in `new-topic` mode forks a fresh
+  // session per top-level event, so an external event must NOT fold into the
+  // group's chat-scope session. resolveRegularGroupMode is the same single source
+  // of truth event-dispatcher's regularGroupRouting reads — webhook delivery was
+  // the one path that ignored it. (A 话题群 keys its sessions by anchor message id,
+  // so its chat-scope key is never populated; the reuse lookup is already a no-op
+  // there and the scope branch below routes it per-topic via externalEventOpensOwnTopic
+  // regardless.) chat / shared / chat-topic keep folding, as they do for a top-level @.
+  const regularGroupMode = resolveRegularGroupMode(larkAppId, chatId);
+  if (!ds && !req.target.sessionId && regularGroupMode !== 'new-topic') {
     ds = deps.activeSessions.get(sessionKey(chatId, larkAppId));
   }
 
@@ -152,7 +173,7 @@ export async function triggerSessionTurn(
   const chatMode = await getChatMode(larkAppId, chatId, { forceRefresh: true });
   let scope: 'thread' | 'chat' = 'chat';
   let anchor = chatId;
-  if (chatMode === 'topic') {
+  if (externalEventOpensOwnTopic(chatMode, regularGroupMode)) {
     anchor = await sendMessage(larkAppId, chatId, t('trigger.external_event', { source: req.envelope.sourceName }, localeForBot(larkAppId)));
     scope = 'thread';
   }

--- a/test/trigger-session-reply-mode.test.ts
+++ b/test/trigger-session-reply-mode.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// triggerSessionTurn must mirror the inbound @ routing: in a 普通群 `new-topic`
+// chat every webhook opens its own topic + session instead of folding into the
+// group's one chat-scope session. These tests pin both halves — the pure
+// per-topic decision and the chat-scope reuse-skip exercised via the dry-run path.
+
+const mockGetBot = vi.fn();
+vi.mock('../src/bot-registry.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/bot-registry.js')>();
+  return { ...actual, getBot: (...a: any[]) => mockGetBot(...a) };
+});
+
+const mockIsInChat = vi.fn(async () => true);
+vi.mock('../src/services/groups-store.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/services/groups-store.js')>();
+  return { ...actual, isInChat: (...a: any[]) => mockIsInChat(...a) };
+});
+
+import { triggerSessionTurn, externalEventOpensOwnTopic } from '../src/core/trigger-session.js';
+import type { TriggerRequest } from '../src/services/trigger-types.js';
+import { sessionKey, type DaemonSession } from '../src/core/types.js';
+import type { ChatReplyMode } from '../src/bot-registry.js';
+
+const APP = 'app1';
+const CHAT = 'oc_1';
+
+function dryRunReq(): TriggerRequest {
+  return {
+    source: { type: 'webhook', connectorId: 'c1', requestId: 'req_1' },
+    target: { kind: 'turn', botId: APP, chatId: CHAT },
+    envelope: { format: 'botmux.webhook.v1', sourceName: 'alertmanager', trusted: false, payload: { alert: 'x' } },
+    options: { dryRun: true },
+  };
+}
+
+function liveChatScopeSession(): DaemonSession {
+  return { session: { sessionId: 'sess_existing' }, worker: { killed: false } } as unknown as DaemonSession;
+}
+
+function setMode(mode: ChatReplyMode | undefined, perChat?: ChatReplyMode) {
+  mockGetBot.mockReturnValue({
+    config: { regularGroupReplyMode: mode, chatReplyModes: perChat ? { [CHAT]: perChat } : undefined },
+    botName: 'Bot',
+    botOpenId: 'ou_bot',
+  });
+}
+
+describe('externalEventOpensOwnTopic', () => {
+  it('话题群 always opens its own topic, regardless of reply mode', () => {
+    for (const m of ['chat', 'shared', 'chat-topic', 'new-topic'] as const) {
+      expect(externalEventOpensOwnTopic('topic', m)).toBe(true);
+    }
+  });
+
+  it('普通群 opens its own topic only in new-topic mode', () => {
+    expect(externalEventOpensOwnTopic('group', 'new-topic')).toBe(true);
+    for (const m of ['chat', 'shared', 'chat-topic'] as const) {
+      expect(externalEventOpensOwnTopic('group', m)).toBe(false);
+    }
+  });
+});
+
+describe('triggerSessionTurn — webhook honors 普通群会话模式 (chat-scope reuse)', () => {
+  beforeEach(() => {
+    mockGetBot.mockReset();
+    mockIsInChat.mockClear();
+    mockIsInChat.mockResolvedValue(true);
+  });
+
+  async function run() {
+    const activeSessions = new Map<string, DaemonSession>();
+    activeSessions.set(sessionKey(CHAT, APP), liveChatScopeSession());
+    return triggerSessionTurn(dryRunReq(), { larkAppId: APP, activeSessions });
+  }
+
+  it('chat mode reuses the group chat-scope session', async () => {
+    setMode('chat');
+    const res = await run();
+    expect(res.ok).toBe(true);
+    expect(res.message).toContain('would inject into existing session');
+    expect(res.target?.sessionId).toBe('sess_existing');
+  });
+
+  it('default (no mode set) reuses the group chat-scope session', async () => {
+    setMode(undefined);
+    const res = await run();
+    expect(res.message).toContain('would inject into existing session');
+  });
+
+  it('shared and chat-topic still reuse the chat-scope session at top level', async () => {
+    for (const mode of ['shared', 'chat-topic'] as const) {
+      setMode(mode);
+      const res = await run();
+      expect(res.message, mode).toContain('would inject into existing session');
+    }
+  });
+
+  it('new-topic mode does NOT reuse — each webhook opens its own session', async () => {
+    setMode('new-topic');
+    const res = await run();
+    expect(res.ok).toBe(true);
+    expect(res.message).toContain('would create or deliver a new session turn');
+    expect(res.target?.sessionId).toBeUndefined();
+  });
+
+  it('per-chat new-topic override beats a chat per-bot default', async () => {
+    setMode('chat', 'new-topic');
+    const res = await run();
+    expect(res.message).toContain('would create or deliver a new session turn');
+  });
+
+  it('an explicit sessionId target still wins over new-topic (deliberate reuse)', async () => {
+    setMode('new-topic');
+    const activeSessions = new Map<string, DaemonSession>();
+    const existing = liveChatScopeSession();
+    activeSessions.set(sessionKey(CHAT, APP), existing);
+    const req = dryRunReq();
+    req.target.sessionId = 'sess_existing';
+    const res = await triggerSessionTurn(req, { larkAppId: APP, activeSessions });
+    expect(res.target?.sessionId).toBe('sess_existing');
+    expect(res.message).toContain('would inject into existing session');
+  });
+});


### PR DESCRIPTION
## 问题

bot 在 dashboard 配了「普通群会话模式 = new-topic」（每条顶层 @ 各开独立话题与会话）后：

- ✅ **手动 @** 机器人 —— 每条都新开独立会话（符合配置）
- ❌ **webhook（接入点）触发** —— 把所有外部事件都折进**同一个**群级会话，不新开

即 webhook 完全没有遵循「普通群会话模式」配置。

## 根因

「普通群会话模式」(`regularGroupReplyMode`) 只被**飞书入站 @ 消息**这一条路读取：`event-dispatcher` 的 `regularGroupRouting` → `resolveRegularGroupMode()`。

webhook 走的是另一条**完全独立的管线**：`webhook-routes → dispatchTriggerRequest → core/trigger-session.ts 的 triggerSessionTurn`。它：

- 复用会话用群级 `sessionKey(chatId, larkAppId)`（chat-scope）；
- 新建会话时普通群一律写死 `scope='chat'`，只有飞书**原生话题群**（`getChatMode==='topic'`）才转 thread；
- **全程不调 `resolveRegularGroupMode`** —— 是唯一忽略该配置的投递路径。

## 修复

`triggerSessionTurn` 改读同一份 `resolveRegularGroupMode` 单一真源，与入站 @ 的 `regularGroupRouting` 对齐：

- **new-topic 普通群**：每个外部事件先发一条「外部事件」锚点消息、起独立 `thread-scope` 会话（与顶层 @ / 话题群同款），且**不**复用群级 chat-scope 会话；
- **chat / shared / chat-topic**：维持顶层平铺、复用群级会话（与它们路由顶层 @ 的行为一致）。

抽出纯函数 `externalEventOpensOwnTopic(chatMode, mode)` 作为单一判定点（`话题群 || new-topic`），既给复用判定也给 scope 判定使用。

```
chatMode   mode         opensOwnTopic
topic      *            true   （话题群本就每条独立）
group      new-topic    true   （← 本次修复点）
group      chat/shared/chat-topic   false  （维持原状）
```

## 测试

新增 `test/trigger-session-reply-mode.test.ts`（8 例）：

- `externalEventOpensOwnTopic` 真值表（话题群 × 4 模式、普通群 × 4 模式）；
- 经 dry-run 验证 chat-scope 复用判定：chat / 默认 / shared / chat-topic 复用群级会话，new-topic（含 per-chat 覆盖）不复用，显式 `sessionId` 目标仍优先复用。

`pnpm build` 通过；`pnpm test` 全量 **6407 用例全绿**。

## 范围说明

`shared` 模式「复用会话但把回复落在话题里」的显示语义（入站路径的 `maybeApplySharedTopicSeed`）对 webhook 暂未复刻，留作 follow-up —— 其「复用同一会话」的核心语义本就正确，只差话题气泡展示。