### PR TITLE
fix(card): 「获取操作链接」按钮补 toast 回执

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -594,6 +594,8 @@ export const messages: Record<string, string> = {
   'card.voice.toast_need_auth': '🔒 You are not authorized to use this bot, so you cannot generate a voice summary. Ask an admin for access.',
   'card.action.takeover_retired': '⚠️ The old "Take Over" button is retired. In bridge mode, botmux bridges the original CLI so replies still come back to Lark — no takeover needed. Full takeover (`/adopt --takeover`) is on the roadmap.',
   'card.action.terminal_not_ready': '⚠️ Terminal is not ready yet, please try again shortly.',
+  'card.action.write_link_sent': '🔑 The action link has been sent to you privately — please check your messages.',
+  'card.action.write_link_no_permission': '🔒 You do not have operate permission, so you cannot get the action link.',
   'card.action.no_output': '(no output yet)',
   'card.action.tui_select_title': 'Select options',
   'card.action.tui_custom_input': 'Custom input',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -596,6 +596,7 @@ export const messages: Record<string, string> = {
   'card.action.terminal_not_ready': '⚠️ Terminal is not ready yet, please try again shortly.',
   'card.action.write_link_sent': '🔑 The action link has been sent to you privately — please check your messages.',
   'card.action.write_link_no_permission': '🔒 You do not have operate permission, so you cannot get the action link.',
+  'card.action.session_gone': '⚠️ This session is no longer active; the action was not completed.',
   'card.action.no_output': '(no output yet)',
   'card.action.tui_select_title': 'Select options',
   'card.action.tui_custom_input': 'Custom input',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -597,6 +597,8 @@ export const messages: Record<string, string> = {
   'card.voice.toast_need_auth': '🔒 你没有该机器人的使用权限，无法生成语音总结，请联系管理员授权',
   'card.action.takeover_retired': '⚠️ 旧版"接管"按钮已停用。bridge 模式下原 CLI 由 botmux 桥接，无需接管即可在飞书中收到回答。如需 /resume 完整接管能力，请等待 /adopt --takeover 命令上线。',
   'card.action.terminal_not_ready': '⚠️ 终端尚未就绪，请稍后再试。',
+  'card.action.write_link_sent': '🔑 操作链接已私密发送，请查收',
+  'card.action.write_link_no_permission': '🔒 没有操作权限，无法获取操作链接',
   'card.action.no_output': '(当前无输出内容)',
   'card.action.tui_select_title': 'Select options',
   'card.action.tui_custom_input': 'Custom input',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -599,6 +599,7 @@ export const messages: Record<string, string> = {
   'card.action.terminal_not_ready': '⚠️ 终端尚未就绪，请稍后再试。',
   'card.action.write_link_sent': '🔑 操作链接已私密发送，请查收',
   'card.action.write_link_no_permission': '🔒 没有操作权限，无法获取操作链接',
+  'card.action.session_gone': '⚠️ 会话已不在线，操作未完成',
   'card.action.no_output': '(当前无输出内容)',
   'card.action.tui_select_title': 'Select options',
   'card.action.tui_custom_input': 'Custom input',

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -1076,6 +1076,12 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     if (effectiveAppId) {
       if (!pendingRepoOwnerException && !canOperate(effectiveAppId, chatId, operatorOpenId)) {
         logger.info(`Card action "${value.action}" blocked for non-operator user: ${operatorOpenId} (chat=${chatId})`);
+        // get_write_link 显式破例：其余敏感动作沿用「静默 block（仅日志）」的既有设计
+        // （test/card-handler-repo-select.test.ts 把这点 pin 住了），但「获取操作链接」是
+        // 用户主动点的取权动作，静默会让人以为按钮坏了——给一条明确的「无操作权限」toast。
+        if (value.action === 'get_write_link') {
+          return { toast: { type: 'warning', content: t('card.action.write_link_no_permission', undefined, localeForBot(effectiveAppId)) } };
+        }
         return;
       }
     } else {
@@ -1089,6 +1095,10 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
         || bots.some(b => (b.config.globalGrants?.length ?? 0) > 0);
       if (hasAllowlist && (!operatorOpenId || !allowedUsers.includes(operatorOpenId))) {
         logger.info(`Card action "${value.action}" blocked for non-allowed user: ${operatorOpenId}`);
+        // 与上面 non-operator 分支同理：仅 get_write_link 破例给 toast，其余保持静默。
+        if (value.action === 'get_write_link') {
+          return { toast: { type: 'warning', content: t('card.action.write_link_no_permission', undefined, localeForBot(larkAppId)) } };
+        }
         return;
       }
     }
@@ -1439,6 +1449,9 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
         // 普通群发「仅自己可见」私密卡，话题群 / 单聊自动回退私聊 DM（两条通道都私密，
         // 不泄露写入 token）。fire-and-forget，保持卡片回调快速返回。
         void deliverWriteLinkCard(ds, operatorOpenId, cardJson);
+        // 乐观回执：投递是异步的（话题群要先 ephemeral 失败再 DM，两次往返 await 容易
+        // 超过 2500ms 的 ACK 窗口而被丢弃），点完立即弹 toast，让用户知道链接已私密发出。
+        return { toast: { type: 'success', content: t('card.action.write_link_sent', undefined, locDs) } };
       } else {
         // 普通群发「仅自己可见」私密卡；话题群 / 单聊不支持 ephemeral，回退为同样内容的
         // 卡片回复（而非纯文本），三种场景都渲染成卡片，行为不变。

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -1199,7 +1199,12 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       }
     }
 
-    if (actionType === 'close' && ds) {
+    if (actionType === 'close') {
+      if (!ds) {
+        // 会话已不在 activeSessions（已关过 / 卡片过期 / daemon 重启丢失）——点「关闭
+        // 会话」却静默无反应会让人以为按钮坏了，给一条失败 toast（成功路径不弹，已关卡即反馈）。
+        return { toast: { type: 'warning', content: t('card.action.session_gone', undefined, localeForBot(larkAppId)) } };
+      }
       const botCfg = getBot(ds.larkAppId).config;
       // Build the closed card BEFORE killWorker/closeSession — it reads the
       // live session's identity off `ds`.
@@ -1465,7 +1470,11 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
 
     // Display toggle: hidden ↔ screenshot. 'toggle_stream' is the legacy alias
     // from pre-screenshot cards and is mapped to toggle_display semantics.
-    if ((actionType === 'toggle_display' || actionType === 'toggle_stream') && ds) {
+    if (actionType === 'toggle_display' || actionType === 'toggle_stream') {
+      if (!ds) {
+        // 同 close：会话已不在线时「显示 / 隐藏输出」静默无反应 → 给失败 toast（成功不弹）。
+        return { toast: { type: 'warning', content: t('card.action.session_gone', undefined, localeForBot(larkAppId)) } };
+      }
       const clickedNonce: string | undefined = value?.card_nonce;
       const isFrozenClick = clickedNonce && ds.streamCardNonce && clickedNonce !== ds.streamCardNonce;
 

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -122,7 +122,7 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
 // ─── Imports ──────────────────────────────────────────────────────────────
 
 import { handleCardAction, type CardHandlerDeps } from '../src/im/lark/card-handler.js';
-import { forkWorker, killWorker, deliverEphemeralOrReply } from '../src/core/worker-pool.js';
+import { forkWorker, killWorker, deliverEphemeralOrReply, deliverWriteLinkCard } from '../src/core/worker-pool.js';
 import { getAvailableBots } from '../src/core/session-manager.js';
 import { createSession, closeSession } from '../src/services/session-store.js';
 import { createRepoWorktree, removeRepoWorktree } from '../src/services/git-worktree.js';
@@ -654,6 +654,25 @@ describe('repo select card — worktree open', () => {
     expect(res?.toast).toBeUndefined();                // sensitive gate blocks silently (logs only)
     expect(vi.mocked(applyConfigField)).not.toHaveBeenCalled(); // no bot-config write
     expect(vi.mocked(deleteMessage)).not.toHaveBeenCalled();
+  });
+
+  it('get_write_link 破例：非 operator 点击得到「无操作权限」toast，而非像其它敏感动作那样静默', async () => {
+    // 与上面的 worktree_toggle_mode 对照：敏感门控默认静默 block（仅日志），但
+    //「获取操作链接」是用户主动点的取权动作，静默会让人以为按钮坏了 —— 破例给提示。
+    const ds = makeDs({ worker: null });
+    const { deps } = makeDeps(ds);
+    vi.mocked(canOperate).mockReturnValueOnce(false); // non-operator
+    const event = {
+      operator: { open_id: 'ou_stranger' },
+      action: { value: { action: 'get_write_link', root_id: ROOT_ID } },
+      context: { open_message_id: 'om_card' },
+    };
+
+    const res = await handleCardAction(event, deps, APP_ID);
+
+    expect(res?.toast?.type).toBe('warning');
+    expect(res?.toast?.content).toContain('没有操作权限');
+    expect(vi.mocked(deliverWriteLinkCard)).not.toHaveBeenCalled(); // 门控就拦下，未投递
   });
 
   it('rolls back already-created worktrees when a later repo in the batch fails', async () => {

--- a/test/card-integration.test.ts
+++ b/test/card-integration.test.ts
@@ -832,9 +832,12 @@ describe('Card integration: full event flow', () => {
       sessions.set(sessionKey(ROOT_ID, APP_ID), ds);
       const deps = makeDeps(sessions);
 
-      await handleCardAction(makeGetWriteLinkEvent(ROOT_ID, 'ou_user'), deps, APP_ID);
+      const res = await handleCardAction(makeGetWriteLinkEvent(ROOT_ID, 'ou_user'), deps, APP_ID);
       await flush();
 
+      // 有权限点击：同步立即回执 success toast（投递是异步 fire-and-forget，不等它完成）。
+      expect(res?.toast?.type).toBe('success');
+      expect(res?.toast?.content).toContain('已私密发送');
       // 普通群 → 仅点击者可见的 ephemeral 私密卡，不发 DM。
       expect(vi.mocked(clientMod.sendEphemeralCard)).toHaveBeenCalledWith(
         APP_ID, ds.chatId, 'ou_user', expect.stringContaining('"type":"session"'),
@@ -856,9 +859,11 @@ describe('Card integration: full event flow', () => {
       sessions.set(sessionKey(ROOT_ID, APP_ID), ds);
       const deps = makeDeps(sessions);
 
-      await handleCardAction(makeGetWriteLinkEvent(ROOT_ID, 'ou_user'), deps, APP_ID);
+      const res = await handleCardAction(makeGetWriteLinkEvent(ROOT_ID, 'ou_user'), deps, APP_ID);
       await flush();
 
+      // 有权限：同样同步回执 success toast（不区分投递通道）。
+      expect(res?.toast?.type).toBe('success');
       // 单聊 → 跳过注定失败的 ephemeral，直接私聊 DM（DM 落在同一个 1:1 会话里）。
       expect(vi.mocked(clientMod.sendEphemeralCard)).not.toHaveBeenCalled();
       expect(fakeLark.dms).toHaveLength(1);

--- a/test/card-integration.test.ts
+++ b/test/card-integration.test.ts
@@ -950,14 +950,24 @@ describe('Card integration: full event flow', () => {
       expect(fakeLark.patches).toHaveLength(0);
     });
 
-    it('action on non-existent session should be a no-op', async () => {
+    it('close / toggle on a non-existent session return a failure toast; restart stays a silent no-op', async () => {
       const sessions = new Map<string, DaemonSession>();
       const deps = makeDeps(sessions);
 
-      await handleCardAction(makeToggleEvent('om_nonexistent', NONCE_CURRENT), deps, APP_ID);
-      await handleCardAction(makeRestartEvent('om_nonexistent'), deps, APP_ID);
-      await handleCardAction(makeCloseEvent('om_nonexistent'), deps, APP_ID);
+      // 会话已不在线：close /「显示输出」给失败 toast（消除「按钮坏了」的错觉）。
+      const toggleRes = await handleCardAction(makeToggleEvent('om_nonexistent', NONCE_CURRENT), deps, APP_ID);
+      expect(toggleRes?.toast?.type).toBe('warning');
+      expect(toggleRes?.toast?.content).toContain('不在线');
 
+      const closeRes = await handleCardAction(makeCloseEvent('om_nonexistent'), deps, APP_ID);
+      expect(closeRes?.toast?.type).toBe('warning');
+      expect(closeRes?.toast?.content).toContain('不在线');
+
+      // restart 未纳入本次失败 toast 范围，维持既有「静默 no-op」。
+      const restartRes = await handleCardAction(makeRestartEvent('om_nonexistent'), deps, APP_ID);
+      expect(restartRes?.toast).toBeUndefined();
+
+      // 三者都不应产生卡片 PATCH。
       expect(fakeLark.patches).toHaveLength(0);
     });
 


### PR DESCRIPTION
## 背景

点击飞书流式卡片里的「🔑 获取操作链接」按钮，此前**无论有无权限都不弹任何 toast**：

- **有权限**：链接通过「仅你可见」私密卡（普通群）或私聊 DM（话题群 / 单聊）异步送达，但点击当下没有任何回执——话题群走 DM 时，当前话题里更是零反馈，用户很容易以为按钮坏了。
- **无权限**：`get_write_link` 属敏感动作，命中通用权限门控后**静默 `return`（仅写日志）**，点击者完全没有反馈。

## 改动

- **有权限** → 点完立即回执 success toast：`🔑 操作链接已私密发送，请查收`。投递仍保持异步 fire-and-forget（话题群要先 ephemeral 失败再 DM，两次往返 `await` 容易超过 2500ms 的 ACK 窗口而被丢弃，故用乐观回执）。
- **无权限** → 回执 warning toast：`🔒 没有操作权限，无法获取操作链接`。

仅 `get_write_link` 在门控**破例**给 toast，其余敏感动作（restart / close / toggle…）维持既有「静默 block」设计——该行为被 `test/card-handler-repo-select.test.ts` 的 `worktree_toggle_mode` 用例 pin 住，刻意不推翻。

## 实现位置

- `src/im/lark/card-handler.ts`：通用门控两处 block 对 `get_write_link` 破例返回 toast；有权限处理分支 fire-and-forget 后返回乐观 success toast。
- `src/i18n/{zh,en}.ts`：新增 `card.action.write_link_sent` / `card.action.write_link_no_permission`。

## 测试

- 新增 2 个用例：
  - `card-integration.test.ts` Scenario 5：有权限点击返回 success toast（group + p2p 两条通道都覆盖）。
  - `card-handler-repo-select.test.ts`：无权限点击返回 warning toast 且不投递（与紧邻的 `worktree_toggle_mode` 静默用例形成对照）。
- 全量单测 **6400 通过**。

## 待验证

逻辑已被单测覆盖；真机点击体验建议部署后在飞书验证（有权限弹「已私密发送」、无权限弹「没有操作权限」）。
