### PR TITLE
fix(worker): 修复 web 终端备用屏 CLI（Claude 系）历史滚动 + 只读/手机/限速

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4786,7 +4786,13 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
             if (msg.type === 'resize' && msg.cols > 0 && msg.rows > 0) {
               backend?.resize(msg.cols, msg.rows);
             } else if (msg.type === 'input' && typeof msg.data === 'string') {
-              if (!authedClients.has(ws)) return; // read-only
+              if (!authedClients.has(ws)) {
+                // Read-only: allow ONLY wheel scroll sequences (SGR buttons 64-67).
+                // Scrolling the CLI's own view is non-destructive and lets read-only
+                // viewers page back through an alt-screen TUI's history (Claude etc.,
+                // which has no local scrollback). Everything else is dropped.
+                if (!/^(\x1b\[<6[4-7];\d+;\d+M)+$/.test(msg.data)) return;
+              }
               backend?.write(msg.data);
             }
           } catch { /* ignore non-JSON or bad messages */ }
@@ -5019,8 +5025,10 @@ if(!${isTmuxMode && !isPipeMode}){
       return;
     }
     // Alternate buffer: no local scrollback — forward the wheel so the CLI scrolls.
+    // Allowed in read-only too: the server lets wheel scroll sequences through for
+    // non-authed clients (scrolling the CLI's own view is non-destructive).
     e.preventDefault();e.stopPropagation();
-    if(!hasToken||!ws_||ws_.readyState!==1)return; // read-only can't reach the app
+    if(!ws_||ws_.readyState!==1)return;
     var btn=e.deltaY<0?64:65; // SGR: 64=wheel-up (history), 65=wheel-down
     var seq='\\x1b[<'+btn+';1;1M';
     ws_.send(JSON.stringify({type:'input',data:seq+seq+seq})); // ~3 lines per notch
@@ -5072,7 +5080,7 @@ if(!${isTmuxMode && !isPipeMode}){
     if(term.buffer.active.type!=='alternate'||_tLastY===null||e.touches.length!==1)return;
     e.preventDefault();e.stopPropagation();
     var y=e.touches[0].clientY;_tAccum+=y-_tLastY;_tLastY=y;
-    if(!hasToken||!ws_||ws_.readyState!==1)return; // read-only: consume, can't forward
+    if(!ws_||ws_.readyState!==1)return; // read-only allowed (server gates to wheel only)
     var data='';
     while(Math.abs(_tAccum)>=_tStep){
       var up=_tAccum>0; // finger drags down → reveal history → wheel-up (64)

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5000,12 +5000,31 @@ window.addEventListener('resize',onViewportResize);
   ws.onerror=function(){ws.close()};
 })();
 
-// ── Read-only scroll handling ──
-if(!hasToken&&!${isTmuxMode && !isPipeMode}){
-  // Non-tmux read-only: CLI mouse mode blocks local scroll, override with scrollLines
+// ── Wheel scroll handling ──
+// Alt-screen + mouse-mode CLIs (e.g. Claude Code) keep NO scrollback in xterm OR
+// tmux — their whole transcript is redrawn by the app inside the fixed alt-screen
+// grid, so term.scrollLines() reveals nothing. When the browser xterm is in the
+// alternate buffer we instead forward the wheel as SGR mouse-wheel events so the
+// CLI scrolls its own transcript and repaints (verified: Claude scrolls on this).
+// Normal-buffer CLIs keep xterm's native scrollback scroll. Capture-phase +
+// stopPropagation pre-empts xterm's own mouse handler so the wheel isn't also
+// re-emitted to the CLI. Skipped for pure tmux/zellij ATTACH (gate), where the
+// attach client owns the wheel via tmux/zellij copy-mode.
+if(!${isTmuxMode && !isPipeMode}){
   document.getElementById('terminal').addEventListener('wheel',function(e){
-    e.preventDefault();term.scrollLines(e.deltaY>0?3:-3);
-  },{passive:false});
+    if(term.buffer.active.type!=='alternate'){
+      // Normal buffer: xterm scrolls its own scrollback natively. In read-only a
+      // mouse-mode CLI could swallow the wheel, so drive scrollback directly.
+      if(!hasToken){e.preventDefault();e.stopPropagation();term.scrollLines(e.deltaY>0?3:-3);}
+      return;
+    }
+    // Alternate buffer: no local scrollback — forward the wheel so the CLI scrolls.
+    e.preventDefault();e.stopPropagation();
+    if(!hasToken||!ws_||ws_.readyState!==1)return; // read-only can't reach the app
+    var btn=e.deltaY<0?64:65; // SGR: 64=wheel-up (history), 65=wheel-down
+    var seq='\\x1b[<'+btn+';1;1M';
+    ws_.send(JSON.stringify({type:'input',data:seq+seq+seq})); // ~3 lines per notch
+  },{capture:true,passive:false});
 }
 
 // ── Touch shortcut toolbar ──

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5006,16 +5006,32 @@ window.addEventListener('resize',onViewportResize);
   ws.onerror=function(){ws.close()};
 })();
 
-// ── Wheel scroll handling ──
+// ── Wheel / touch scroll handling ──
 // Alt-screen + mouse-mode CLIs (e.g. Claude Code) keep NO scrollback in xterm OR
 // tmux — their whole transcript is redrawn by the app inside the fixed alt-screen
-// grid, so term.scrollLines() reveals nothing. When the browser xterm is in the
-// alternate buffer we instead forward the wheel as SGR mouse-wheel events so the
-// CLI scrolls its own transcript and repaints (verified: Claude scrolls on this).
+// grid, so term.scrollLines() reveals nothing. In the alternate buffer we forward
+// scrolling as SGR mouse-wheel events so the CLI scrolls its own transcript and
+// repaints (works in read-only too: the server only lets wheel sequences through).
 // Normal-buffer CLIs keep xterm's native scrollback scroll. Capture-phase +
-// stopPropagation pre-empts xterm's own mouse handler so the wheel isn't also
-// re-emitted to the CLI. Skipped for pure tmux/zellij ATTACH (gate), where the
-// attach client owns the wheel via tmux/zellij copy-mode.
+// stopPropagation pre-empts xterm's own handler. Skipped for pure tmux/zellij
+// ATTACH (gate), where the attach client owns scrolling via copy-mode.
+//
+// Accumulate intended scroll DISTANCE (px) and emit one wheel tick per STEP px —
+// decoupled from how many wheel/touch events the browser fires per gesture
+// (high-res trackpads fire dozens), so a small gesture stays a small scroll and
+// doesn't compound into a whole screen. px<0 = scroll up (toward history). The
+// per-call cap stops a single huge delta (page tick / fling) from over-firing.
+var _scrollAccum=0;var _SCROLL_STEP=33;
+function _fwdScroll(px){
+  if(!ws_||ws_.readyState!==1)return;
+  _scrollAccum+=px;var data='',n=0;
+  while(Math.abs(_scrollAccum)>=_SCROLL_STEP&&n<6){
+    var up=_scrollAccum<0; // px<0 → wheel-up (history)
+    data+='\\x1b[<'+(up?64:65)+';1;1M';
+    _scrollAccum+=up?_SCROLL_STEP:-_SCROLL_STEP;n++;
+  }
+  if(data)ws_.send(JSON.stringify({type:'input',data:data}));
+}
 if(!${isTmuxMode && !isPipeMode}){
   document.getElementById('terminal').addEventListener('wheel',function(e){
     if(term.buffer.active.type!=='alternate'){
@@ -5024,14 +5040,10 @@ if(!${isTmuxMode && !isPipeMode}){
       if(!hasToken){e.preventDefault();e.stopPropagation();term.scrollLines(e.deltaY>0?3:-3);}
       return;
     }
-    // Alternate buffer: no local scrollback — forward the wheel so the CLI scrolls.
-    // Allowed in read-only too: the server lets wheel scroll sequences through for
-    // non-authed clients (scrolling the CLI's own view is non-destructive).
     e.preventDefault();e.stopPropagation();
-    if(!ws_||ws_.readyState!==1)return;
-    var btn=e.deltaY<0?64:65; // SGR: 64=wheel-up (history), 65=wheel-down
-    var seq='\\x1b[<'+btn+';1;1M';
-    ws_.send(JSON.stringify({type:'input',data:seq+seq+seq})); // ~3 lines per notch
+    // Normalise deltaMode to px: line→~16px, page→~one screen.
+    var px=e.deltaMode===1?e.deltaY*16:e.deltaMode===2?e.deltaY*term.rows*16:e.deltaY;
+    _fwdScroll(px);
   },{capture:true,passive:false});
 }
 
@@ -5071,25 +5083,19 @@ if(isTouch&&hasToken){
 // scrollTop. overscroll-behavior:none (see <style>) kills the iOS rubber-band.
 if(!${isTmuxMode && !isPipeMode}){
   var _tTerm=document.getElementById('terminal');
-  var _tLastY=null,_tAccum=0,_tStep=16; // ~px per scrolled line
+  var _tLastY=null;
   _tTerm.addEventListener('touchstart',function(e){
-    if(e.touches.length===1){_tLastY=e.touches[0].clientY;_tAccum=0;}
+    if(e.touches.length===1)_tLastY=e.touches[0].clientY;
   },{capture:true,passive:true});
   _tTerm.addEventListener('touchmove',function(e){
     // Normal buffer / multi-touch / no start → let xterm (or the browser) handle it.
     if(term.buffer.active.type!=='alternate'||_tLastY===null||e.touches.length!==1)return;
     e.preventDefault();e.stopPropagation();
-    var y=e.touches[0].clientY;_tAccum+=y-_tLastY;_tLastY=y;
-    if(!ws_||ws_.readyState!==1)return; // read-only allowed (server gates to wheel only)
-    var data='';
-    while(Math.abs(_tAccum)>=_tStep){
-      var up=_tAccum>0; // finger drags down → reveal history → wheel-up (64)
-      data+='\\x1b[<'+(up?64:65)+';1;1M';
-      _tAccum+=up?-_tStep:_tStep;
-    }
-    if(data)ws_.send(JSON.stringify({type:'input',data:data}));
+    var y=e.touches[0].clientY;
+    _fwdScroll(_tLastY-y); // finger drags down (y grows) → px<0 → scroll up (history)
+    _tLastY=y;
   },{capture:true,passive:false});
-  _tTerm.addEventListener('touchend',function(){_tLastY=null;_tAccum=0;},{capture:true,passive:true});
+  _tTerm.addEventListener('touchend',function(){_tLastY=null;},{capture:true,passive:true});
 }
 </script>
 </body>

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5054,11 +5054,35 @@ if(isTouch&&hasToken){
   }
 }
 
-// Single-finger touch scrolling is handled natively by xterm's own Viewport
-// (handleTouchMove → scrollTop), so no custom handler here — a parallel one
-// would double-drive scrollTop and fight xterm.  overscroll-behavior:none on
-// .xterm-viewport (see <style>) kills the iOS rubber-band; the WebGL/Canvas
-// renderer above is what actually makes scrolling over text smooth.
+// Single-finger touch scrolling: normal-buffer CLIs use xterm's own Viewport
+// (handleTouchMove → scrollTop) natively. Alt-screen CLIs (Claude) have no xterm
+// scrollback, so native touch scroll does nothing — mirror the wheel fix and
+// forward the drag to the CLI as SGR wheel events so it scrolls its own
+// transcript. Only the alternate buffer is intercepted (capture + stopPropagation);
+// the normal buffer falls through to xterm untouched, so no double-drive of
+// scrollTop. overscroll-behavior:none (see <style>) kills the iOS rubber-band.
+if(!${isTmuxMode && !isPipeMode}){
+  var _tTerm=document.getElementById('terminal');
+  var _tLastY=null,_tAccum=0,_tStep=16; // ~px per scrolled line
+  _tTerm.addEventListener('touchstart',function(e){
+    if(e.touches.length===1){_tLastY=e.touches[0].clientY;_tAccum=0;}
+  },{capture:true,passive:true});
+  _tTerm.addEventListener('touchmove',function(e){
+    // Normal buffer / multi-touch / no start → let xterm (or the browser) handle it.
+    if(term.buffer.active.type!=='alternate'||_tLastY===null||e.touches.length!==1)return;
+    e.preventDefault();e.stopPropagation();
+    var y=e.touches[0].clientY;_tAccum+=y-_tLastY;_tLastY=y;
+    if(!hasToken||!ws_||ws_.readyState!==1)return; // read-only: consume, can't forward
+    var data='';
+    while(Math.abs(_tAccum)>=_tStep){
+      var up=_tAccum>0; // finger drags down → reveal history → wheel-up (64)
+      data+='\\x1b[<'+(up?64:65)+';1;1M';
+      _tAccum+=up?-_tStep:_tStep;
+    }
+    if(data)ws_.send(JSON.stringify({type:'input',data:data}));
+  },{capture:true,passive:false});
+  _tTerm.addEventListener('touchend',function(){_tLastY=null;_tAccum=0;},{capture:true,passive:true});
+}
 </script>
 </body>
 </html>`;


### PR DESCRIPTION
## 背景

Claude Code（及 aiden×claude / ttadk·cjadk claude 等同样跑 Claude Code 的会话）的 TUI 运行在**备用屏(alternate screen) + 鼠标上报**模式，xterm 和 tmux 两边都没有 scrollback——整段对话由 Claude 自己在固定栅格里重绘。web 终端原来只在只读模式装了滚轮兜底，写模式滚轮被 xterm 当鼠标事件吞掉/翻成方向键，Claude 不据此滚动，于是滚不动历史。其它 CLI（codex/gemini/traex/coco/relay 等）跑在普通屏、有 scrollback，不受影响。

**非 botmux 引入的回归**：触发点是 Claude Code 自身用了备用屏+鼠标上报（CLI 侧），web 终端从未为备用屏 CLI 接过历史滚动。

## 改动（按浏览器 xterm 当前缓冲区分流，不按 CLI 名）

- **备用屏 CLI**：拦截滚轮/触摸，转发 SGR 滚轮事件给 CLI，由它自己滚 transcript 重绘（捕获阶段 + stopPropagation 防 xterm 二次处理）
- **普通屏 CLI**：维持 xterm 原生 scrollback 滚动，零改动
- **纯 tmux/zellij attach 模式**：不变（仍走各自 copy-mode）

逐 commit：
1. `桌面滚轮`：备用屏写模式转发滚轮
2. `手机触摸`：touch 不触发 wheel，备用屏下拦截单指拖动折算成 SGR 滚轮转发
3. `只读滚动`：服务端 shared-relay 对未鉴权连接只放行滚轮序列（SGR 64-67，正则严格匹配），客户端去掉转发前 !hasToken；只读也能翻历史（附带让 restart 后 token 失效的旧页签至少能滚）
4. `限速`：原来每事件固定转发 3 个 SGR，高分辨率触控板/触屏一手势触发几十个事件→滚一大屏。改为按距离累计（deltaMode 归一到 px，每 ~33px 一个 tick，单事件封顶），与事件频率解耦；鼠标手感不变

## 作用域 & 安全

- 实测线上：备用屏会话全是 Claude 系（native claude / aiden×claude / ttadk·cjadk claude，alt=1 mouse=1），都正确受益；其余 CLI alt=0 走原生滚动零改动
- 扫了一遍**没有任何 alt=1 & mouse=0 的会话**（那是唯一会被注入乱码的情况）→ 当前零风险

## 验证

- 后端：静态空闲 Claude pane 注入 SGR 滚轮 → 真滚（干净复现）
- 只读：不带 token 的 WS 发滚轮 → 滚动 22 行；顺手发字母 X → 被服务端挡掉
- 限速累计逻辑 node 验证：鼠标 1 格仍 3 个，触控板小滑 24→2 / 轻滑 45→5 / 惯性甩封顶 10
- 真机：申晗电脑 + 手机 + 只读均确认 OK，速度合适