### PR TITLE
fix(lark-doc): 评论 mention-only 误把「@ 别人」判成「@ 本 bot」而触发

### DIFF
--- a/src/im/lark/doc-comment.ts
+++ b/src/im/lark/doc-comment.ts
@@ -18,6 +18,7 @@ import { resolveUserToken } from '../../utils/user-token.js';
 import { logger } from '../../utils/logger.js';
 import { UserTokenMissingError } from './client.js';
 import { type Brand, larkHosts, normalizeBrand } from './lark-hosts.js';
+import type { CommentTriggerMode } from '../../services/doc-subs-store.js';
 
 /**
  * bot 回复的隐形哨兵：追加在 bot 发表的评论末尾（零宽字符，用户不可见）。
@@ -44,6 +45,33 @@ export function isBotAuthoredReply(id: string | undefined): boolean {
 }
 export function hasBotSentinel(text: string | undefined): boolean {
   return !!text && text.includes(BOT_REPLY_SENTINEL);
+}
+
+/**
+ * 触发范围闸：给定订阅的 `commentTriggerMode` + 触发评论正文 @ 到的 open_id 列表
+ * + 本 bot 自己的 open_id，判定这条评论是否应触发会话。
+ *
+ *   • 'all'          —— 该文档所有新评论都触发。
+ *   • 'mention-only' —— 仅当评论正文真的 @ 了「本 bot」才触发。
+ *
+ * ⚠️ 这里是用户报的 bug 的根因所在：mention-only **绝不能**用飞书评论事件里的
+ *   `is_mentioned` 字段判定。实测该字段含义是「这条评论里存在任意 @」——@ 了
+ *   别人（同事）时它同样为 true。早先用 `is_mentioned === true || …` 短路放行，
+ *   导致「只 @ 同事、没 @bot」的评论也被误触发，mention-only 形同虚设
+ *   （现象：「只有 @ 别人时才被触发」）。唯一可靠依据是拉到的评论正文
+ *   @person(open_id) 列表里是否含本 bot 自己的 open_id。
+ *
+ * `selfBotOpenId` 缺失（daemon 启动期 open_id 尚未探到）时一律判否：mention-only
+ *   宁可漏触发也不误触发。调用方应在此之前 `await ensureBotOpenId` 关掉该启动
+ *   竞态，避免把合法的 @bot 评论误丢（事件已被 ACK，飞书不会重投）。
+ */
+export function commentTriggerAllowed(
+  mode: CommentTriggerMode,
+  triggerMentions: string[],
+  selfBotOpenId: string | undefined,
+): boolean {
+  if (mode === 'all') return true;
+  return !!selfBotOpenId && triggerMentions.includes(selfBotOpenId);
 }
 
 /** 飞书云文档评论里富文本元素的最小子集（够 bot 发纯文本 + @人）。 */

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -18,7 +18,7 @@ import { shouldAutoStartOnNewTopic } from '../../core/auto-start.js';
 import { stripLeadingMentions } from './message-parser.js';
 import { recordObservedBots, listObservedBots } from '../../services/observed-bots-store.js';
 import { getDocSubscription, listAllDocSubscriptions, type DocSubscription } from '../../services/doc-subs-store.js';
-import { getDocComment, isBotAuthoredReply, hasBotSentinel } from './doc-comment.js';
+import { getDocComment, isBotAuthoredReply, hasBotSentinel, commentTriggerAllowed } from './doc-comment.js';
 import { BOTMUX_REQUIRED_SCOPES, DOC_FEATURE_SCOPES, DOC_COMMENT_EVENT, buildScopeDeepLink } from '../../setup/verify-permissions.js';
 import { type Brand, larkHosts, normalizeBrand, sdkDomain } from './lark-hosts.js';
 import { tryHandleGrantCommand } from './grant-command.js';
@@ -1323,6 +1323,12 @@ async function processCommentEvent(
     return;
   }
 
+  // 关掉 open_id 启动竞态：probeBotOpenId 在启动时 fire-and-forget，若评论事件
+  // 在该窗口内到达，下面 mention-only 闸 / 自触发过滤会拿到 undefined 的 botOpenId
+  // → 合法的 @bot 评论被误丢（事件已被 ACK，飞书不会重投，@ 永久丢失）。await
+  // 去重后的探针把 open_id 补齐；探针失败则降级（心跳会重试）。
+  await ensureBotOpenId(larkAppId).catch(() => { /* degrade; heartbeat retries */ });
+
   // 2) 拉评论 thread 取权威正文 / 作者 / @ 列表（事件 payload 不保证带全），
   //    同时用最新一条回复作为"触发回复"。
   const comment = await getDocComment(larkAppId, { fileToken, fileType: sub.fileType }, commentId);
@@ -1340,14 +1346,13 @@ async function processCommentEvent(
   const selfBotOpenId = getBot(larkAppId).botOpenId;
   if ((selfBotOpenId && trigger.userId === selfBotOpenId) || isBotAuthoredReply(trigger.replyId) || hasBotSentinel(trigger.text)) return;
 
-  // 4) 触发范围：mention-only 要求评论 @ 到本 bot。优先用事件自带的 is_mentioned
-  //    （飞书已判好），拿不到再回退按评论正文里的 @person 列表比对 bot open_id。
-  if (sub.commentTriggerMode === 'mention-only') {
-    const mentioned = parsed.isMentioned === true || (!!selfBotOpenId && trigger.mentions.includes(selfBotOpenId));
-    if (!mentioned) {
-      logger.info(`[doc-comment] event dropped: mention-only 但未 @ 本 bot (comment=${commentId.slice(0, 12)})`);
-      return;
-    }
+  // 4) 触发范围闸（mention-only 仅当评论真的 @ 了本 bot 才触发）。
+  //    ⚠️ 必须以拉到的评论正文 @person(open_id) 列表为准，不能信事件自带的
+  //    `is_mentioned`——它表示「评论里存在任意 @」，@ 别人时也是 true，曾导致
+  //    「@ 同事的评论也被误触发」。详见 commentTriggerAllowed 注释。
+  if (!commentTriggerAllowed(sub.commentTriggerMode, trigger.mentions, selfBotOpenId)) {
+    logger.info(`[doc-comment] event dropped: mention-only 但未 @ 本 bot (comment=${commentId.slice(0, 12)} isMentioned=${parsed.isMentioned} mentions=${trigger.mentions.length} self=${selfBotOpenId ? selfBotOpenId.slice(0, 10) : '?'})`);
+    return;
   }
 
   const text = trigger.text.trim();

--- a/test/doc-comment.test.ts
+++ b/test/doc-comment.test.ts
@@ -7,6 +7,7 @@ import {
   markBotAuthoredReply,
   isBotAuthoredReply,
   hasBotSentinel,
+  commentTriggerAllowed,
   BOT_REPLY_SENTINEL,
 } from '../src/im/lark/doc-comment.js';
 
@@ -68,5 +69,38 @@ describe('bot-authored reply tracking (self-loop guard)', () => {
     expect(hasBotSentinel(`some reply${BOT_REPLY_SENTINEL}`)).toBe(true);
     expect(hasBotSentinel('a normal user comment')).toBe(false);
     expect(hasBotSentinel(undefined)).toBe(false);
+  });
+});
+
+describe('commentTriggerAllowed (mention-only trigger gate)', () => {
+  const SELF = 'ou_selfbot';
+
+  it("'all' mode triggers on any comment, regardless of mentions", () => {
+    expect(commentTriggerAllowed('all', [], SELF)).toBe(true);
+    expect(commentTriggerAllowed('all', ['ou_someone_else'], SELF)).toBe(true);
+    // even when the bot's own open_id isn't known yet
+    expect(commentTriggerAllowed('all', [], undefined)).toBe(true);
+  });
+
+  it("'mention-only' triggers when the comment @s this bot", () => {
+    expect(commentTriggerAllowed('mention-only', [SELF], SELF)).toBe(true);
+    expect(commentTriggerAllowed('mention-only', ['ou_other', SELF], SELF)).toBe(true);
+  });
+
+  it("'mention-only' does NOT trigger when the comment only @s other people (the reported bug)", () => {
+    // 用户报的现象：评论只 @ 同事、没 @bot，却被触发。根因是早先信了事件级
+    // is_mentioned（=「有任意 @」）。这里证明仅按正文 @person 列表判定后不再误触发。
+    expect(commentTriggerAllowed('mention-only', ['ou_qiaoxiang'], SELF)).toBe(false);
+    expect(commentTriggerAllowed('mention-only', ['ou_a', 'ou_b'], SELF)).toBe(false);
+  });
+
+  it("'mention-only' does NOT trigger when the comment @s nobody", () => {
+    expect(commentTriggerAllowed('mention-only', [], SELF)).toBe(false);
+  });
+
+  it("'mention-only' drops conservatively when the bot's own open_id is unknown", () => {
+    // 启动期 open_id 尚未探到：宁可漏触发也不误触发（调用方会先 await ensureBotOpenId）。
+    expect(commentTriggerAllowed('mention-only', [SELF], undefined)).toBe(false);
+    expect(commentTriggerAllowed('mention-only', [SELF], '')).toBe(false);
   });
 });


### PR DESCRIPTION
## 问题
`/subscribe-lark-doc` 订阅设为「仅评论 @ 我才触发(mention-only)」时，评论里 @ 了**别人**（没 @ 本 bot）也会把会话触发起来。现象：普通评论不触发、@ 任意人就触发。

## 根因
`event-dispatcher.ts` 的 `processCommentEvent` 触发范围闸：

```ts
const mentioned = parsed.isMentioned === true || (!!selfBotOpenId && trigger.mentions.includes(selfBotOpenId));
```

飞书评论事件 `drive.notice/file.comment_add_v1` 里的 `is_mentioned` 字段实际含义是「这条评论里存在**任意** @」，**不是**「@ 了本 bot」。`||` 前半段短路放行，于是 @ 同事时 `is_mentioned=true` 被误判成 @ 了本 bot → mention-only 形同虚设。

## 改动
1. **`doc-comment.ts`** — 抽出纯函数 `commentTriggerAllowed(mode, triggerMentions, selfBotOpenId)`：
   - `mention-only` 只认「拉到的评论正文 @person(open_id) 列表是否含本 bot 自己的 `botOpenId`」，**彻底不信事件级 `is_mentioned`**；
   - `all` 模式维持「所有新评论都触发」不变；
   - `selfBotOpenId` 缺失时一律判否（宁可漏触发也不误触发）。
2. **`event-dispatcher.ts`** — 用该函数替换 buggy 闸；并在订阅命中后补 `await ensureBotOpenId`，关掉 open_id 启动竞态（否则启动窗口内到达的合法 @bot 评论会因 `botOpenId` 未就绪被误丢——事件已 ACK、飞书不重投，@ 永久丢失；与 `im.message.receive_v1` 入站路径对齐）；drop 日志补 `isMentioned/mentions/self` 诊断字段。
3. **`doc-comment.test.ts`** — +6 单测，含「只 @ 别人」的 bug 复现用例、open_id 未就绪保守丢弃等。

## 验证
- `pnpm build` 绿；`doc-comment` + `event-dispatcher` 单测全绿（含复现用例）。
- 全量单测另有 10 个失败在 `group-creator` / `dashboard-ipc`——`git stash` 比对确认为 **master 既有、与本修复无关**。

## 待真机确认
本修复前提：在文档评论里 @bot 时，bot 的 open_id 会出现在评论的 @person 列表里。需在真实文档上验证一次。