### PR TITLE
fix(lark): 兼容 mention.id 的对象/字符串两形态，防 @ 路由静默失灵

### DIFF
--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -15,7 +15,7 @@ import { BoundedMap } from '../../utils/bounded-map.js';
 import { serializeByAnchor } from '../../utils/anchor-serializer.js';
 import { parseForceTopicInvocation } from '../../core/command-handler.js';
 import { shouldAutoStartOnNewTopic } from '../../core/auto-start.js';
-import { stripLeadingMentions } from './message-parser.js';
+import { stripLeadingMentions, mentionOpenId } from './message-parser.js';
 import { recordObservedBots, listObservedBots } from '../../services/observed-bots-store.js';
 import { getDocSubscription, listAllDocSubscriptions, type DocSubscription } from '../../services/doc-subs-store.js';
 import { getDocComment, isBotAuthoredReply, hasBotSentinel, commentTriggerAllowed } from './doc-comment.js';
@@ -592,7 +592,7 @@ export function isKnownPeerBot(dataDir: string, larkAppId: string, senderOpenId:
 export function updateBotOpenIdCrossRef(
   dataDir: string,
   larkAppId: string,
-  mentionsList: Array<{ name?: string; id?: { open_id?: string } }>,
+  mentionsList: Array<{ name?: string; id?: { open_id?: string } | string; id_type?: string }>,
 ): void {
   if (!mentionsList || mentionsList.length === 0) return;
 
@@ -620,7 +620,7 @@ export function updateBotOpenIdCrossRef(
   let changed = false;
   for (const m of mentionsList) {
     const name = m.name;
-    const openId = m.id?.open_id;
+    const openId = mentionOpenId(m);
     if (!name || !openId) continue;
     if (!knownBotNames.has(name.toLowerCase())) continue;
     if (existing[name] === openId) continue;
@@ -694,9 +694,9 @@ export async function tryHandleIntroduceCommand(
   }
 
   const selfOpenId = getBot(larkAppId).botOpenId;
-  const rawMentions: Array<{ name?: string; id?: { open_id?: string } }> = message.mentions ?? [];
+  const rawMentions: Array<{ name?: string; id?: { open_id?: string } | string; id_type?: string }> = message.mentions ?? [];
   const all = rawMentions
-    .map(m => ({ openId: m.id?.open_id ?? '', name: m.name ?? '' }))
+    .map(m => ({ openId: mentionOpenId(m) ?? '', name: m.name ?? '' }))
     .filter(m => m.openId && m.name);
   const hasExternal = all.some(m => m.openId !== selfOpenId);
   if (!hasExternal) {
@@ -735,6 +735,10 @@ export async function tryHandleIntroduceCommand(
 
 // ─── @mention detection ──────────────────────────────────────────────────
 
+/** One-shot guard so the mention-shape early-warning logs at most once per
+ *  process instead of flooding once Lark converges the shapes (see below). */
+let warnedStringMentionShape = false;
+
 /** Check if the bot was @mentioned in this message */
 export function isBotMentioned(larkAppId: string, message: any, _senderOpenId: string | undefined): boolean {
   const botOpenId = getBot(larkAppId).botOpenId;
@@ -746,9 +750,20 @@ export function isBotMentioned(larkAppId: string, message: any, _senderOpenId: s
     return false;
   }
 
-  // 1. Check message.mentions array (populated for user-sent text messages)
+  // 1. Check message.mentions array (populated for user-sent text messages).
+  //    mentionOpenId() tolerates both the WS event object shape and the REST
+  //    string shape, so a Lark mention-shape change can't silently break
+  //    @-detection (which would make the bot ignore every @ with no error).
   const mentions: any[] = message.mentions ?? [];
-  if (mentions.some((m: any) => m.id?.open_id === botOpenId)) {
+  // Early-warning: today's WS events carry mention.id as an object; the REST
+  // API carries a bare string. A string-form id on the event path means Lark
+  // has converged the event onto the REST shape — surface it (once) so a silent
+  // @-routing regression announces itself even though mentionOpenId absorbs it.
+  if (!warnedStringMentionShape && mentions.some((m: any) => typeof m?.id === 'string')) {
+    warnedStringMentionShape = true;
+    logger.warn(`[${larkAppId}] mention.id arrived in string form on the event path — Lark may have converged the WS event onto the REST shape. mentionOpenId() absorbs it, but verify group @-routing. (logged once per process)`);
+  }
+  if (mentions.some((m: any) => mentionOpenId(m) === botOpenId)) {
     return true;
   }
 
@@ -909,7 +924,7 @@ async function maybeSendGrantRequestCard(
   // 名字优先级：本消息 mentions（真人发送方、被 @ 目标都在此）→ observed-bots 花名册
   // （/introduce 登记过的 (open_id,name)）→ 裸 open_id 兜底。外部 bot 发送方不在自己
   // 消息的 mentions 里（那是 @ 目标），只靠 mentions 会让 owner 只看到 open_id。
-  const mentionName = (message?.mentions ?? []).find((m: any) => m?.id?.open_id === requesterOpenId)?.name;
+  const mentionName = (message?.mentions ?? []).find((m: any) => mentionOpenId(m) === requesterOpenId)?.name;
   const observedName = mentionName
     ? undefined
     : listObservedBots(config.session.dataDir, larkAppId, chatId).find(b => b.openId === requesterOpenId)?.name;

--- a/src/im/lark/grant-command.ts
+++ b/src/im/lark/grant-command.ts
@@ -6,7 +6,7 @@
  */
 import { getOwnerOpenId, getBotOpenId, getBot } from '../../bot-registry.js';
 import { isBotMentioned, extractMessageTextForRouting } from './event-dispatcher.js';
-import { stripLeadingMentions } from './message-parser.js';
+import { stripLeadingMentions, mentionOpenId } from './message-parser.js';
 import { buildGrantCard } from './card-builder.js';
 import { openPendingMulti } from './grant-pending.js';
 import { revokeGrant, addAllowedChatGroup, removeAllowedChatGroup } from '../../services/grant-store.js';
@@ -42,7 +42,7 @@ export function parseGrantTargets(message: any, botOpenId: string | undefined): 
   const seen = new Set<string>();
   const out: Array<{ openId: string; name: string }> = [];
   for (const x of (message?.mentions ?? [])) {
-    const oid = x?.id?.open_id;
+    const oid = mentionOpenId(x);
     if (!oid || oid === botOpenId || seen.has(oid)) continue;
     seen.add(oid);
     out.push({ openId: oid, name: x.name ?? oid });
@@ -60,7 +60,7 @@ function parseTextTargetsAfterCommand(
   const seen = new Set<string>();
   const out: Array<{ openId: string; name: string }> = [];
   for (const m of mentions) {
-    const oid = m?.id?.open_id;
+    const oid = mentionOpenId(m);
     if (!oid || oid === botOpenId || seen.has(oid)) continue;
     const key = m?.key;
     if (cmdIdx >= 0 && typeof key === 'string' && key.length > 0) {
@@ -155,7 +155,7 @@ export function isGrantTargetOnly(message: any, botOpenId: string | undefined): 
   try { content = JSON.parse(message?.content ?? '{}'); } catch { return false; }
 
   if (typeof content?.text === 'string') {
-    const key = (message?.mentions ?? []).find((m: any) => m?.id?.open_id === botOpenId)?.key;
+    const key = (message?.mentions ?? []).find((m: any) => mentionOpenId(m) === botOpenId)?.key;
     if (!key) return false;
     const cmdIdx = content.text.search(/\/(?:grant|revoke)\b/i);
     const keyMatch = new RegExp(`${escapeRe(key)}(?!\\d)`).exec(content.text);

--- a/src/im/lark/message-parser.ts
+++ b/src/im/lark/message-parser.ts
@@ -27,10 +27,48 @@ interface RawEventData {
     mentions?: Array<{
       key: string;       // e.g. "@_user_1"
       name: string;      // display name
-      id?: { open_id?: string; user_id?: string; union_id?: string };
+      // Two shapes exist in the wild. The WS event (im.message.receive_v1)
+      // delivers an OBJECT: { open_id, union_id, user_id }. The REST API
+      // (im.message.get / list) delivers a bare STRING ("ou_xxx") plus a
+      // sibling `id_type`. Always read the open_id via mentionOpenId() so both
+      // forms are handled — see its doc-comment for why this matters.
+      id?: { open_id?: string; user_id?: string; union_id?: string } | string;
+      id_type?: string;  // present only in the REST string form, e.g. "open_id"
       tenant_key?: string;
     }>;
   };
+}
+
+/**
+ * Extract a mention's open_id, tolerating BOTH Lark shapes for `mention.id`:
+ *
+ *   - WebSocket event (im.message.receive_v1): `id` is an OBJECT
+ *       { open_id, union_id, user_id }            ← what botmux has always seen
+ *   - Message REST API (im.message.get / list):  `id` is a bare STRING "ou_xxx"
+ *       with a sibling `id_type` ("open_id" | "union_id" | "user_id")
+ *
+ * The two diverged in production: the API already ships the flat-string form
+ * while the event still ships the object form. If Lark ever converges the event
+ * onto the string form, every `m.id.open_id` read across botmux would silently
+ * become `undefined` and @-detection (isBotMentioned) would fail closed with no
+ * log. Reading through this helper keeps every caller robust regardless of
+ * which shape arrives.
+ *
+ * For the string form we return the value only when it actually IS an open_id
+ * (id_type === 'open_id', or absent — mentions are open_id-keyed by default). A
+ * string carrying a non-open_id id_type (union_id / user_id, which Lark may
+ * return when the app lacks the open_id scope) yields `undefined` rather than
+ * being mis-compared against a botOpenId.
+ */
+export function mentionOpenId(m: { id?: { open_id?: string } | string | null; id_type?: string } | null | undefined): string | undefined {
+  const id = m?.id;
+  if (id == null) return undefined;
+  if (typeof id === 'object') return id.open_id || undefined;
+  if (typeof id === 'string') {
+    if (m?.id_type && m.id_type !== 'open_id') return undefined;
+    return id || undefined;
+  }
+  return undefined;
 }
 
 /**
@@ -271,7 +309,7 @@ export function parseEventMessage(data: RawEventData): { parsed: LarkMessage; re
       ? message.mentions.map(m => ({
           key: m.key,
           name: m.name,
-          openId: m.id?.open_id,
+          openId: mentionOpenId(m),
         }))
       : undefined;
 

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -293,6 +293,36 @@ describe('isBotMentioned', () => {
     expect(isBotMentioned(MY_APP_ID, message, undefined)).toBe(true);
   });
 
+  it('detects @mention via REST string-form id (im.message.get shape)', () => {
+    // The message REST API delivers mention.id as a bare string "ou_xxx" with a
+    // sibling id_type, unlike the WS event's { open_id } object. mentionOpenId
+    // must absorb this so a Lark shape convergence can't silently break @-routing.
+    const message = {
+      mentions: [{ key: '@_bot', name: 'BotA', id: MY_OPEN_ID, id_type: 'open_id' }],
+      content: JSON.stringify({ text: '@BotA hello' }),
+    };
+    expect(isBotMentioned(MY_APP_ID, message, undefined)).toBe(true);
+  });
+
+  it('detects string-form id with no id_type (defaults to open_id)', () => {
+    const message = {
+      mentions: [{ key: '@_bot', name: 'BotA', id: MY_OPEN_ID }],
+      content: JSON.stringify({ text: '@BotA hello' }),
+    };
+    expect(isBotMentioned(MY_APP_ID, message, undefined)).toBe(true);
+  });
+
+  it('does NOT match a string-form id whose id_type is not open_id', () => {
+    // Guard: Lark may return a union_id/user_id string when the app lacks the
+    // open_id scope. Even if its value coincided with our open_id it must not be
+    // compared as one.
+    const message = {
+      mentions: [{ key: '@_bot', name: 'BotA', id: MY_OPEN_ID, id_type: 'union_id' }],
+      content: JSON.stringify({ text: '@BotA hello' }),
+    };
+    expect(isBotMentioned(MY_APP_ID, message, undefined)).toBe(false);
+  });
+
   it('detects @mention in post content at tags (bot-sent messages)', () => {
     // Bot-sent post messages embed @mentions as inline `at` nodes in content,
     // NOT in the message.mentions array

--- a/test/grant-command.test.ts
+++ b/test/grant-command.test.ts
@@ -85,6 +85,17 @@ describe('parseGrantTargets (multi)', () => {
     expect(parseGrantTargets({ mentions: [{ id: { open_id: 'ou_bot' }, name: 'Claude' }] }, 'ou_bot')).toEqual([]);
   });
 
+  // REST string-form mention.id ("ou_xxx" + id_type) must parse identically to
+  // the WS object form — grant is security-sensitive, so a shape change must not
+  // mis-identify the target (or fail to exclude the operator bot itself).
+  it('parses REST string-form mention.id, still excluding the bot', () => {
+    const msg = { mentions: [
+      { id: 'ou_bot', id_type: 'open_id', name: 'Claude' },
+      { id: 'ou_a', id_type: 'open_id', name: '张三' },
+    ] };
+    expect(parseGrantTargets(msg, 'ou_bot')).toEqual([{ openId: 'ou_a', name: '张三' }]);
+  });
+
   // post 形态 mentions 为空 → 回退到 inline `at` 节点解析（否则误判成裸 /grant）。
   it('post fallback: parses non-bot at-nodes when mentions empty', () => {
     const postMsg = {

--- a/test/message-parser.test.ts
+++ b/test/message-parser.test.ts
@@ -7,7 +7,7 @@
  * Run:  pnpm vitest run test/message-parser.test.ts
  */
 import { describe, it, expect } from 'vitest';
-import { parseApiMessage, extractResources, parseEventMessage, stripLeadingMentions, createImgNumberer, cardContentHasUpgradeFallback, isPureCardUpgradeFallback, mergeCardText, wrapResolvedCardText, CARD_EMBEDDED_PLACEHOLDER } from '../src/im/lark/message-parser.js';
+import { parseApiMessage, extractResources, parseEventMessage, stripLeadingMentions, createImgNumberer, cardContentHasUpgradeFallback, isPureCardUpgradeFallback, mergeCardText, wrapResolvedCardText, mentionOpenId, CARD_EMBEDDED_PLACEHOLDER } from '../src/im/lark/message-parser.js';
 import { buildMarkdownCard } from '../src/im/lark/md-card.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
@@ -772,5 +772,69 @@ describe('parseEventMessage: parentId surfacing', () => {
   it('treats empty-string parent_id as absent', () => {
     const { parsed } = parseEventMessage(makeEvent({ parent_id: '' }));
     expect(parsed.parentId).toBeUndefined();
+  });
+});
+
+// ─── mentionOpenId: tolerate both Lark mention.id shapes ──────────────────
+//
+// WS event (im.message.receive_v1) → id is an OBJECT { open_id, ... }.
+// REST API (im.message.get / list) → id is a bare STRING "ou_xxx" + id_type.
+// The helper must read open_id from either so a Lark shape convergence can't
+// silently break @-detection.
+
+describe('mentionOpenId', () => {
+  it('reads open_id from the WS event object form', () => {
+    expect(mentionOpenId({ id: { open_id: 'ou_abc', union_id: 'on_x', user_id: '' } })).toBe('ou_abc');
+  });
+
+  it('reads the bare string form when id_type is open_id', () => {
+    expect(mentionOpenId({ id: 'ou_abc', id_type: 'open_id' })).toBe('ou_abc');
+  });
+
+  it('reads the bare string form when id_type is absent (mentions are open_id-keyed)', () => {
+    expect(mentionOpenId({ id: 'ou_abc' })).toBe('ou_abc');
+  });
+
+  it('returns undefined for a string id whose id_type is not open_id', () => {
+    // union_id/user_id strings (possible without open_id scope) must not be
+    // returned as an open_id and mis-compared against a botOpenId.
+    expect(mentionOpenId({ id: 'on_abc', id_type: 'union_id' })).toBeUndefined();
+    expect(mentionOpenId({ id: 'b199821f', id_type: 'user_id' })).toBeUndefined();
+  });
+
+  it('returns undefined for empty / missing ids', () => {
+    expect(mentionOpenId({ id: { open_id: '' } })).toBeUndefined();
+    expect(mentionOpenId({ id: '' })).toBeUndefined();
+    expect(mentionOpenId({ id: null })).toBeUndefined();
+    expect(mentionOpenId({})).toBeUndefined();
+    expect(mentionOpenId(undefined)).toBeUndefined();
+    expect(mentionOpenId(null)).toBeUndefined();
+  });
+});
+
+describe('parseEventMessage: mention open_id across both id shapes', () => {
+  function makeEvent(mentions: any[]) {
+    return {
+      sender: { sender_id: { open_id: 'ou_user' }, sender_type: 'user' },
+      message: {
+        message_id: 'om_msg',
+        message_type: 'text',
+        content: JSON.stringify({ text: '@Claude hi' }),
+        chat_id: 'oc_chat',
+        chat_type: 'group',
+        create_time: '1000',
+        mentions,
+      },
+    };
+  }
+
+  it('surfaces openId from the WS event object form', () => {
+    const { parsed } = parseEventMessage(makeEvent([{ key: '@_user_1', name: 'Claude', id: { open_id: 'ou_claude' } }]));
+    expect(parsed.mentions?.[0]?.openId).toBe('ou_claude');
+  });
+
+  it('surfaces openId from the REST string form', () => {
+    const { parsed } = parseEventMessage(makeEvent([{ key: '@_user_1', name: 'Claude', id: 'ou_claude', id_type: 'open_id' }]));
+    expect(parsed.mentions?.[0]?.openId).toBe('ou_claude');
   });
 });


### PR DESCRIPTION
## 背景

飞书两套接口对 `mention.id` 的形态**已不一致**：

| 来源 | `mention.id` 形态 |
| --- | --- |
| 长连接事件 `im.message.receive_v1` | 对象 `{open_id, union_id, user_id}` + `mentioned_type` |
| 消息 REST API `im.message.get/list` | 裸字符串 `"ou_xxx"` + `id_type` |

（已用 Claude 自己的 app 真实调用 `im.message.get` 验证字符串形态；并扒线上 daemon 日志确认事件仍是对象形态。）

botmux 原先全仓 **7 处**写死读 `m.id.open_id`，最致命的是 `isBotMentioned`——群里判断「是否 @ 本 bot」的核心闸。**一旦飞书把长连接事件也收敛成 API 的字符串形态**，`m.id.open_id` 全部变 `undefined`，`isBotMentioned` 会静默 `return false` → **所有群里 @ bot 全部失灵，且零报错日志**，属最难排查的黑洞。

当前线上事件仍是对象形态，所以**现在没坏**；本 PR 是主动加固（保险）。

## 改动

- 新增导出 `mentionOpenId(m)` 归一化两形态：对象取 `id.open_id`；字符串且 `id_type==='open_id'`（或缺省，mention 默认按 open_id 键）取 `id`；字符串带 `union_id`/`user_id` 等非 open_id 的 `id_type` 返 `undefined`，避免把别的 id 误当 open_id 比对。
- **8 处调用全部改走该 helper**：`isBotMentioned`、`parseEventMessage`、跨 bot open_id 学习、`/introduce`、grant 卡片名字、grant 目标解析×3。
- `isBotMentioned` 加**一次性 WARN 诊断**：事件路径一旦出现字符串形态 id 即报警（module 级 flag，每进程一次），把潜在的形态收敛从静默黑洞变成显式告警。
- 放宽类型 `id?: {open_id}|string` + `id_type?`。

## 兼容性 & 测试

- **纯向后兼容**：对象形态行为字节不变，仅新增字符串形态的处理。
- 补 **11 条两形态回归测试**（`mentionOpenId` 单测、`isBotMentioned`、`parseEventMessage`、grant 目标解析）。
- `pnpm build` 绿；改动相关 3 测试文件 255 用例全过。
- ⚠️ 全量单测有 10 条 `group-creator`/`dashboard-ipc` 失败，但**与本 PR 无关**：master 自身既有（`addBotToChat` 加进 `groups-store` 后测试 mock 未补 export），stash 本 PR 改动后干净树同样挂。CI 的 `ci.yml` 在 PR 上只跑 `pnpm build` 不跑单测，故不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
