### PR TITLE
fix(lark): allowedUsers 用户查询改走无 body GET

### DIFF
--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -813,10 +813,7 @@ export async function resolveAllowedUsersWithMap(
     // into this bot's allowedUsers and owner checks silently lock everyone out.
     for (const oid of openIds) {
       try {
-        const res = await (c as any).contact.v3.user.get({
-          path: { user_id: oid },
-          params: { user_id_type: 'open_id' },
-        });
+        const res = await larkGet(c, `/open-apis/contact/v3/users/${encodeURIComponent(oid)}`, { user_id_type: 'open_id' });
         if (res?.code === 99992361) {
           logger.warn(`allowedUsers open_id ${oid} belongs to another app for ${larkAppId}; use email or union_id (on_) instead.`);
         } else if (res?.code && res.code !== 0) {
@@ -830,10 +827,7 @@ export async function resolveAllowedUsersWithMap(
     // union_id → 本 app open_id（单条查询；失败则丢弃该条，与 email 解析失败同口径）。
     for (const uid of unionIds) {
       try {
-        const res = await (c as any).contact.v3.user.get({
-          path: { user_id: uid },
-          params: { user_id_type: 'union_id' },
-        });
+        const res = await larkGet(c, `/open-apis/contact/v3/users/${encodeURIComponent(uid)}`, { user_id_type: 'union_id' });
         const oid = res?.data?.user?.open_id as string | undefined;
         if (res.code === 0 && oid) {
           map.set(uid, oid);
@@ -902,10 +896,7 @@ export async function resolveUserUnionId(larkAppId: string, openId: string): Pro
   if (!openId) return {};
   try {
     const c = getBotClient(larkAppId);
-    const res = await (c as any).contact.v3.user.get({
-      path: { user_id: openId },
-      params: { user_id_type: 'open_id' },
-    });
+    const res = await larkGet(c, `/open-apis/contact/v3/users/${encodeURIComponent(openId)}`, { user_id_type: 'open_id' });
     if (res.code === 0 && res.data?.user) {
       return { unionId: res.data.user.union_id ?? undefined, name: res.data.user.name ?? undefined };
     }


### PR DESCRIPTION
## 改动

- 将 `resolveAllowedUsersWithMap` 里的 open_id 校验改为 `larkGet()`。
- 将 `allowedUsers` 的 union_id -> open_id 解析改为 `larkGet()`。
- 将 `resolveUserUnionId` 的 open_id -> union_id 查询改为 `larkGet()`。

## 原因

`@larksuiteoapi/node-sdk` 生成的 `contact.v3.user.get` 会在 GET 请求里带空 body，部分飞书网关会直接返回 411。这样会导致 union_id 配置无法解析成当前 app 视角下的 open_id，进而让 owner / allowedUsers 判断失效。

PR #49 已经修过同一根因下的大部分只读 GET 调用，这里补齐 `allowedUsers` 和 `union_id` 解析路径。

## 验证

- `pnpm exec tsc --noEmit`