### PR TITLE
docs(faq): 新增「会话起不来/parse error」排错条目 + 发布 assetPrefix v26

### DIFF
--- a/docs-site/docs/en/faq.md
+++ b/docs-site/docs/en/faq.md
@@ -62,6 +62,23 @@ By default it doesn't interrupt the current turn; new messages are queued (type-
 
 Yes. For any "native CLI + wrapper / gateway" combination, write a wrapper script that passes `"$@"` through, then set `cliPathOverride` to that script's path when editing the bot in `botmux setup`.
 
+## Sessions never start / the first message errors with `zsh: parse error near '\n'`?
+
+This usually means your login shell (`$SHELL`, often bash) has logic in its startup file that "switches to another shell" — most typically in `~/.bashrc`:
+
+```bash
+if [ -t 1 ]; then exec zsh; fi   # a common hack when chsh doesn't take effect
+```
+
+botmux launches the session inside tmux via `<$SHELL> -i -c '… start the CLI'`. The `-i` sources that startup file, so `exec zsh` replaces the shell before the command that actually starts the CLI ever runs — the pane is left at a bare shell, and the first message typed into it produces `zsh: parse error`.
+
+Since v2.95.0 botmux detects this "the session never really started" state and posts a diagnostic card instead of typing the message into the bare shell. Two ways to fix it:
+
+- **Set `launchShell` (recommended)**: tell the bot to launch directly under the target shell, bypassing the trampolining startup file. `/config launchShell zsh`, or the dashboard ("Bot defaults → Launch shell"), or add `"launchShell": "zsh"` to `bots.json`. Note: PATH / nvm etc. must then live in the chosen shell's startup files (e.g. `.zshrc`).
+- **Fix the startup file**: guard the switch so it only fires for a real interactive terminal: `[ -z "$BASH_EXECUTION_STRING" ] && [ -t 1 ] && exec zsh` (put PATH / nvm exports before it).
+
+Then `botmux restart` and resend a message. Only the `tmux` / `zellij` backends are affected; the `pty` backend launches the CLI directly and is immune.
+
 ## Can a bot added to a new group see the earlier chat history?
 
 Yes. Just tell it "look at the chat history", or quote a specific message. The prerequisite is that the Lark bot's permissions are fully enabled (including group message reading).

--- a/docs-site/docs/zh/faq.md
+++ b/docs-site/docs/zh/faq.md
@@ -62,6 +62,23 @@
 
 能。任何"原生 CLI + wrapper / 网关"的组合，写一个把 `"$@"` 透传的 wrapper 脚本，在 `botmux setup` 编辑机器人时把 `cliPathOverride` 配成该脚本路径即可。
 
+## 会话怎么都起不来 / 首条消息报 `zsh: parse error near '\n'`？
+
+多半是你的登录 shell（`$SHELL`，常见 bash）的启动文件里有"切到另一个 shell"的逻辑——最典型是 `~/.bashrc` 里：
+
+```bash
+if [ -t 1 ]; then exec zsh; fi   # chsh 不生效时常见的 hack
+```
+
+botmux 在 tmux 里用 `<$SHELL> -i -c '… 启动 CLI'` 拉起会话，`-i` 会 source 这个启动文件，于是 `exec zsh` 把 shell 顶替掉，真正启动 CLI 的那条命令没机会执行——pane 停在一个空 shell，首条消息被打进去就报 `zsh: parse error`。
+
+v2.95.0 起 botmux 会检测这种"会话没真正起来"的情况并发一张诊断卡，不再把消息打进空 shell。修复二选一：
+
+- **配 `launchShell`（推荐）**：给该 bot 指定直接用目标 shell 启动，绕开会跳转的启动文件。`/config launchShell zsh`，或 dashboard「机器人默认设置 → 启动 Shell」，或 `bots.json` 加 `"launchShell": "zsh"`。注意 PATH / nvm 等要放进所选 shell 的启动文件（如 `.zshrc`）。
+- **改启动文件**：给跳转加守卫，只在手动开终端时切：`[ -z "$BASH_EXECUTION_STRING" ] && [ -t 1 ] && exec zsh`（PATH / nvm 等导出放在它之前）。
+
+改完 `botmux restart`，重发一条消息即可。仅 `tmux` / `zellij` 后端涉及；`pty` 后端直接启动 CLI，不受影响。
+
 ## 把机器人拉进新群能看之前的聊天记录吗？
 
 能。直接跟它说"看下历史聊天"，或引用某条消息。前提是飞书机器人权限开全（含群消息读取）。

--- a/docs-site/rspress.config.ts
+++ b/docs-site/rspress.config.ts
@@ -172,7 +172,7 @@ export default defineConfig({
   search: { codeBlocks: true },
   markdown: { link: { checkDeadLinks: true } },
   builderConfig: {
-    output: { assetPrefix: "https://cdn.jsdelivr.net/gh/deepcoldy/botmux@docs-assets-v25/" },
+    output: { assetPrefix: "https://cdn.jsdelivr.net/gh/deepcoldy/botmux@docs-assets-v26/" },
   },
   themeConfig: {
     editLink: {


### PR DESCRIPTION
配合 v2.95.0（裸壳检测 + launchShell）补文档站：

- FAQ（中英）新增排错条目「会话怎么都起不来 / 首条消息报 `zsh: parse error near '\n'`？」——讲清登录 shell 启动文件里 `exec zsh` 跳转致 CLI 没起来的根因，给两种修法（配 `launchShell` / 给跳转加 `BASH_EXECUTION_STRING` 守卫）。
- `bots.json` 表的 `launchShell` 字段已在 #314 加入。
- `assetPrefix` 跟随本次发布升 v26。

已本地 `pnpm build` 通过，launchShell + 新 FAQ 均渲染进 doc_build。合并后跑 `deploy.sh 26` 发布到妙搭。