### PR TITLE
test(groups): fix group creation unit baseline

### DIFF
--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -46,6 +46,7 @@ vi.mock('../src/config.js', () => ({
 
 vi.mock('../src/global-config.js', () => ({
   readGlobalConfig: vi.fn(() => ({})),
+  isRemoteAccessEnabled: vi.fn(() => false),
   // repoPickerScanOptions is the shared helper command-handler depends on;
   // default to legacy (include worktrees), overridden per-test.
   repoPickerScanOptions: vi.fn(() => ({ includeWorktrees: true })),

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -756,6 +756,9 @@ describe('POST /api/groups/create', () => {
       invalidBotIds: [],
       invalidUserIds: [],
     });
+    const addSpy = vi.spyOn(groupsStore, 'addBotToChat').mockResolvedValue([
+      { id: 'cli_X', ok: true },
+    ]);
     handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
     const res = await fetch(`http://127.0.0.1:${handle.port}/api/groups/create`, {
       method: 'POST',
@@ -770,8 +773,15 @@ describe('POST /api/groups/create', () => {
       { larkAppId: 'test-app', ok: true, created: true },
       { larkAppId: 'cli_X', ok: true, created: true },
     ]);
+    expect(createSpy).toHaveBeenCalledWith('test-app', {
+      name: undefined,
+      botIds: [],
+      userIds: [],
+    });
+    expect(addSpy).toHaveBeenCalledWith('test-app', 'oc_new', ['cli_X']);
     expect(spy).toHaveBeenCalledWith('test-app', 'oc_new', process.cwd());
     expect(spy).toHaveBeenCalledWith('cli_X', 'oc_new', process.cwd());
+    addSpy.mockRestore();
     spy.mockRestore();
     createSpy.mockRestore();
   });
@@ -783,6 +793,12 @@ describe('POST /api/groups/create', () => {
       invalidBotIds: [],
       invalidUserIds: [],
     });
+    const addSpy = vi.spyOn(groupsStore, 'addBotToChat').mockResolvedValue([]);
+    const bindSpy = vi.spyOn(oncallStore, 'bindOncall').mockResolvedValue({
+      ok: true,
+      entry: { chatId: 'oc_should_not_bind', workingDir: process.cwd() },
+      created: true,
+    });
     handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
     const res = await fetch(`http://127.0.0.1:${handle.port}/api/groups/create`, {
       method: 'POST',
@@ -791,6 +807,10 @@ describe('POST /api/groups/create', () => {
     });
     expect(res.status).toBe(400);
     expect(createSpy).not.toHaveBeenCalled();
+    expect(addSpy).not.toHaveBeenCalled();
+    expect(bindSpy).not.toHaveBeenCalled();
+    bindSpy.mockRestore();
+    addSpy.mockRestore();
     createSpy.mockRestore();
   });
 });

--- a/test/group-creator.test.ts
+++ b/test/group-creator.test.ts
@@ -20,12 +20,14 @@ const mockTransferChatOwner = vi.fn();
 const mockGetChatOwner = vi.fn();
 const mockGetChatShareLink = vi.fn();
 const mockAddUsersByUnionId = vi.fn();
+const mockAddBotToChat = vi.fn();
 vi.mock('../src/services/groups-store.js', () => ({
   createChat: (...args: any[]) => mockCreateChat(...args),
   transferChatOwner: (...args: any[]) => mockTransferChatOwner(...args),
   getChatOwner: (...args: any[]) => mockGetChatOwner(...args),
   getChatShareLink: (...args: any[]) => mockGetChatShareLink(...args),
   addUsersToChatByUnionId: (...args: any[]) => mockAddUsersByUnionId(...args),
+  addBotToChat: (...args: any[]) => mockAddBotToChat(...args),
 }));
 
 const SHARE_LINK = 'https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=tok';
@@ -69,12 +71,16 @@ describe('createGroupWithBots', () => {
     mockListChatBotMembers.mockReset();
     mockBindOncall.mockReset();
     mockAddUsersByUnionId.mockReset();
+    mockAddBotToChat.mockReset();
     mockReadRoleProfileEntry.mockReset();
     mockWriteRoleFile.mockReset();
     // Default: share-link fetch succeeds. group-creator always calls this after
     // createChat; individual tests override to exercise the fallback path.
     mockGetChatShareLink.mockResolvedValue({ ok: true, shareLink: SHARE_LINK });
     mockAddUsersByUnionId.mockResolvedValue({ invalidUserIds: [] });
+    mockAddBotToChat.mockImplementation(async (_app: string, _chatId: string, ids: string[]) =>
+      ids.map(id => ({ id, ok: true })),
+    );
   });
 
   it('pulls bot owners into the chat by union_id; reports invalidOwnerUnionIds', async () => {
@@ -157,7 +163,8 @@ describe('createGroupWithBots', () => {
     expect(mockCreateChat).toHaveBeenCalledTimes(1);
     const args = mockCreateChat.mock.calls[0];
     expect(args[0]).toBe(CREATOR);
-    expect(args[1].botIds).toEqual([OTHER_BOT]);  // creator filtered out
+    expect(args[1].botIds).toEqual([]);  // bots are added after createChat
+    expect(mockAddBotToChat).toHaveBeenCalledWith(CREATOR, 'oc_x', [OTHER_BOT]);
   });
 
   it('skips transfer when invitee was rejected by Lark', async () => {
@@ -259,9 +266,14 @@ describe('createGroupWithBots', () => {
   it('binds the newly created chat for joined bots when bindWorkingDir is provided', async () => {
     mockCreateChat.mockResolvedValue({
       chatId: 'oc_bound',
-      invalidBotIds: ['cli_rejected_bot'],
+      invalidBotIds: [],
       invalidUserIds: [],
     });
+    mockAddBotToChat.mockImplementation(async (_app: string, _chatId: string, ids: string[]) =>
+      ids.map(id => id === 'cli_rejected_bot'
+        ? { id, ok: false, error: 'invalid_id' }
+        : { id, ok: true }),
+    );
     mockBindOncall.mockResolvedValue({ ok: true, created: true });
 
     const result = await createGroupWithBots({
@@ -313,9 +325,14 @@ describe('createGroupWithBots', () => {
   it('reports invalidBotIds/invalidUserIds passthrough from createChat', async () => {
     mockCreateChat.mockResolvedValue({
       chatId: 'oc_x',
-      invalidBotIds: ['cli_zombie'],
+      invalidBotIds: [],
       invalidUserIds: ['ou_banned'],
     });
+    mockAddBotToChat.mockImplementation(async (_app: string, _chatId: string, ids: string[]) =>
+      ids.map(id => id === 'cli_zombie'
+        ? { id, ok: false, error: 'invalid_id' }
+        : { id, ok: true }),
+    );
     const result = await createGroupWithBots({
       creatorLarkAppId: CREATOR,
       larkAppIds: [CREATOR, 'cli_zombie'],


### PR DESCRIPTION
## Summary

- Sync group creation unit tests with the current create-then-add-bots flow: `createChat` creates the creator chat, while additional bots are added through `addBotToChat`.
- Update Dashboard IPC group-create tests to mock `addBotToChat` and keep invalid working-directory validation fail-fast before group creation side effects.
- Add the missing `isRemoteAccessEnabled` global-config mock required by the `/status` terminal URL fixture.

## Validation

- `CI=true npx --yes pnpm@9.5.0 vitest run --project unit test/group-creator.test.ts test/dashboard-ipc.test.ts test/command-handler.test.ts`
- `CI=true npx --yes pnpm@9.5.0 build`
- `CI=true npx --yes pnpm@9.5.0 test` still has known out-of-scope failures only in `test/git-worktree.test.ts` macOS `/private/var` path normalization and `test/sandbox.test.ts` opaque-dir handling.
