### PR TITLE
test(worktree): fix macOS path baseline

### DIFF
--- a/test/git-worktree.test.ts
+++ b/test/git-worktree.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, existsSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -45,11 +45,12 @@ function makeClone(upstream: string, name: string): string {
 }
 
 beforeEach(() => {
-  tempRoot = mkdtempSync(join(tmpdir(), 'git-worktree-test-'));
+  // git worktree canonicalizes macOS /var temp paths to /private/var.
+  tempRoot = realpathSync(mkdtempSync(join(tmpdir(), 'git-worktree-test-')));
 });
 
 afterEach(() => {
-  rmSync(tempRoot, { recursive: true, force: true });
+  rmSync(tempRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 });
 
 describe('createRepoWorktree', () => {


### PR DESCRIPTION
## Summary

- Canonicalize the `git-worktree` test temp root with `realpathSync` so macOS `/var` and `/private/var` paths compare consistently with git's worktree output.
- Add a small retry window to the test temp-dir cleanup, which makes real-git worktree cleanup less flaky on macOS after path canonicalization.

## Validation

- `CI=true npx --yes pnpm@9.5.0 vitest run --project unit test/git-worktree.test.ts`
- `CI=true npx --yes pnpm@9.5.0 build`
- `CI=true npx --yes pnpm@9.5.0 test` no longer reports `test/git-worktree.test.ts` failures. The remaining failures are out of scope for this PR: the group/status baseline covered by #318, plus the existing `test/sandbox.test.ts` opaque-dir case.
