### PR TITLE
[codex] Auto-start miramcp for Mir CLI

### DIFF
--- a/docs-site/docs/en/adapters.md
+++ b/docs-site/docs/en/adapters.md
@@ -20,6 +20,40 @@ botmux bridges different CLIs through adapters, selected via `cliId` in `bots.js
 
 > There are also community-contributed integrations such as MTR, ttadk, and Mira. The `model` field only takes effect for adapters that support a model parameter; others ignore it.
 
+## Mir CLI and MCP Bridge
+
+When you choose **Mira -> Mir CLI (local mircli)** in `botmux setup`, the bot is configured with `cliId: "mir"`. This adapter runs the local `mircli -p --lean`, so the same system user that runs the botmux daemon must already have Mir CLI authenticated and initialized.
+
+BotMux does not need any DevBox-specific configuration. The same rules apply on DevBox, local macOS, or other Linux machines:
+
+- `mircli` can be found by botmux, or the bot config points `cliPathOverride` at the absolute `mircli` path.
+- `~/.mira/config.json` already contains a `device_id`. This is usually written by `mircli mcp --device-id <id>` or Mir CLI's own initialization flow.
+- `miramcp` is installed in a standard Mir CLI location such as `~/.local/bin/miramcp` or `~/.local/bin/mira_cli`, or `MIRAMCP_BIN` points at the executable.
+
+When a `cliId: "mir"` session starts and receives a message, BotMux best-effort starts the MCP Bridge before invoking `mircli`:
+
+```bash
+miramcp run --device-id <device_id>
+```
+
+It first checks `~/.mira/miramcp/miramcp.pid` and local port `9801`, so an already-running bridge is reused instead of started twice. To inspect the bridge, run this as the same user that runs the botmux daemon:
+
+```bash
+mircli mcp status
+```
+
+To disable this autostart behavior, either set this in `~/.mira/config.json`:
+
+```json
+{"auto_start_bridge": false}
+```
+
+or disable it only for BotMux:
+
+```bash
+MIRCLI_AUTO_START_MIRAMCP=0 botmux start
+```
+
 ## Wrapping a wrapper / gateway integration
 
 In many cases you don't run the native CLI directly but wrap it with a gateway / router (internal proxy + SSO, model routing, etc.), such as `ccr`, `ttadk`, `aiden x claude`, `aiden x codex`. In this case you **don't need a new adapter**: `cliId` still holds the real underlying CLI (`claude-code` / `codex` …), and you only swap the launch entry point for a **wrapper script**, pointing to it with `cliPathOverride` (the "CLI executable path override" when editing a bot in `botmux setup` is exactly this).

--- a/docs-site/docs/zh/adapters.md
+++ b/docs-site/docs/zh/adapters.md
@@ -20,6 +20,40 @@ botmux 通过适配器桥接不同 CLI，`bots.json` 里用 `cliId` 选择。一
 
 > 还有社区贡献的 MTR、ttadk、Mira 等接入方式。`model` 字段只对支持模型参数的适配器生效，其它会忽略。
 
+## Mir CLI 与 MCP Bridge
+
+`botmux setup` 里选择 **Mira -> Mir CLI（本地 mircli）** 后，机器人配置会使用 `cliId: "mir"`。这个适配器通过本机 `mircli -p --lean` 执行，因此需要运行 botmux daemon 的同一系统用户已经完成 Mir CLI 登录和初始化。
+
+BotMux 不需要额外的 DevBox 专属配置；在 DevBox、本地 macOS 或其它 Linux 机器上规则相同：
+
+- `mircli` 能被 botmux 找到，或在机器人配置里用 `cliPathOverride` 指向 `mircli` 的绝对路径。
+- `~/.mira/config.json` 里已有 `device_id`。首次使用 Mir CLI 时通常通过 `mircli mcp --device-id <id>` 或 Mir CLI 自身初始化流程写入。
+- `miramcp` 已安装在 Mir CLI 的标准位置（例如 `~/.local/bin/miramcp`、`~/.local/bin/mira_cli`），或通过 `MIRAMCP_BIN` 指向可执行文件。
+
+当 `cliId: "mir"` 会话启动并收到消息时，BotMux 会在调用 `mircli` 前 best-effort 拉起 MCP Bridge：
+
+```bash
+miramcp run --device-id <device_id>
+```
+
+它会先检查 `~/.mira/miramcp/miramcp.pid` 和本机 `9801` 端口，已在运行就不会重复启动。要确认状态，可以在运行 botmux daemon 的同一用户下执行：
+
+```bash
+mircli mcp status
+```
+
+如果你想禁用这个自动拉起行为，可以任选一种方式：
+
+```json
+{"auto_start_bridge": false}
+```
+
+或只对 BotMux 进程禁用：
+
+```bash
+MIRCLI_AUTO_START_MIRAMCP=0 botmux start
+```
+
 ## 套 wrapper / 网关接入
 
 很多场景下你不是直接跑原生 CLI，而是套一层网关 / 路由（内网代理 + SSO、模型路由等），比如 `ccr`、`ttadk`、`aiden x claude`、`aiden x codex`。这时**不需要新适配器**：`cliId` 仍填底层真实 CLI（`claude-code` / `codex` …），只把启动入口换成一个 **wrapper 脚本**，用 `cliPathOverride` 指过去（`botmux setup` 编辑机器人时的「CLI 可执行文件路径覆盖」就是填它）。

--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -1,6 +1,5 @@
 import * as pty from 'node-pty';
 import { execSync, execFileSync } from 'node:child_process';
-import { accessSync, constants as fsConstants } from 'node:fs';
 import { basename } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import type { SessionBackend, SpawnOpts, SessionProbe } from './types.js';
@@ -8,6 +7,7 @@ import { probeTmuxFunctional, tmuxEnv } from '../../setup/ensure-tmux.js';
 import { REDACTED_CHILD_ENV_KEYS } from '../../utils/child-env.js';
 import { sanitizePerBotEnv } from '../../core/per-bot-env.js';
 import { logger } from '../../utils/logger.js';
+import { isExecutable } from '../../utils/executable.js';
 
 /**
  * `unset KEY KEY ...` clause spliced into the shell wrapper before exec. The
@@ -727,15 +727,6 @@ function classifyShell(path: string): ShellKind | null {
   if (base === 'zsh') return 'zsh';
   if (base === 'sh' || base === 'dash' || base === 'ash') return 'sh';
   return null;
-}
-
-function isExecutable(path: string): boolean {
-  try {
-    accessSync(path, fsConstants.X_OK);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 /**

--- a/src/adapters/cli/registry.ts
+++ b/src/adapters/cli/registry.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from 'node:child_process';
-import { accessSync, constants, existsSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
+import { locateExecutable } from '../../utils/executable.js';
 import type { CliAdapter, CliId } from './types.js';
 import { createClaudeCodeAdapter } from './claude-code.js';
 import { createSeedAdapter } from './seed.js';
@@ -82,14 +83,7 @@ export function resolveCommand(cmd: string): string {
  * silent crash-loop. Cheap and shell-free (no rc side effects).
  */
 export function locateOnPath(cmd: string): string | null {
-  if (isAbsolute(cmd)) {
-    try { accessSync(cmd, constants.X_OK); return cmd; } catch { return null; }
-  }
-  for (const dir of (process.env.PATH ?? '').split(':').filter(Boolean)) {
-    const candidate = join(dir, cmd);
-    try { accessSync(candidate, constants.X_OK); return candidate; } catch { /* next dir */ }
-  }
-  return null;
+  return locateExecutable(cmd);
 }
 
 const adapterCache = new Map<string, CliAdapter>();

--- a/src/mir-local-runtime.ts
+++ b/src/mir-local-runtime.ts
@@ -1,43 +1,17 @@
 // Local-runtime helpers for the mir adapter (driving local mircli -p --lean).
 // Adapted from shunminli (李舜民)'s PR #245 (src/mira-local-runtime.ts) — credit to author.
 // Folded into the `mir` adapter per Plan A (mira stays Web API, mir = local mircli).
-import { closeSync, existsSync, openSync, readFileSync, realpathSync, renameSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { isExecutable, locateExecutable } from './utils/executable.js';
+import { withFileLockSync } from './utils/file-lock.js';
+import { logger } from './utils/logger.js';
 
-/** Synchronous sleep without busy-spin (used only for short lock backoff). */
+/** Synchronous sleep without busy-spin (used only for short startup polling). */
 function syncSleep(ms: number): void {
   try { Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms); } catch { /* SAB unavailable */ }
-}
-
-/**
- * Serialize a read-modify-write of a shared config file across concurrent mir
- * sessions via an O_EXCL lockfile. Without this, two sessions in different
- * workspaces each read the old config, add their own path, and the last
- * `renameSync` clobbers the other's addition. Stale locks (crashed holder) are
- * broken after STALE_MS; if the lock can't be taken within TIMEOUT_MS we run
- * unlocked (best-effort — the caller already wraps this in try/catch).
- */
-function withFileLock<T>(targetPath: string, fn: () => T): T {
-  const lockPath = `${targetPath}.lock`;
-  const STALE_MS = 10_000, TIMEOUT_MS = 3_000, STEP_MS = 50;
-  const deadline = Date.now() + TIMEOUT_MS;
-  let fd: number | undefined;
-  for (;;) {
-    try { fd = openSync(lockPath, 'wx'); break; }
-    catch {
-      try {
-        if (Date.now() - statSync(lockPath).mtimeMs > STALE_MS) { unlinkSync(lockPath); continue; }
-      } catch { continue; } // lock vanished between open and stat — retry immediately
-      if (Date.now() >= deadline) return fn(); // give up locking, proceed best-effort
-      syncSleep(STEP_MS);
-    }
-  }
-  try { return fn(); }
-  finally {
-    try { closeSync(fd); } catch { /* */ }
-    try { unlinkSync(lockPath); } catch { /* */ }
-  }
 }
 
 type JsonObject = Record<string, any>;
@@ -54,6 +28,64 @@ export interface MiramcpPatchResult {
   changed: boolean;
   added: string[];
   skipped?: string;
+}
+
+export type MiramcpAutostartStatus =
+  | 'started'
+  | 'started_pending'
+  | 'already_running'
+  | 'disabled'
+  | 'missing_device_id'
+  | 'missing_bin'
+  | 'missing_config'
+  | 'invalid_config'
+  | 'spawn_failed';
+
+export interface MiramcpAutostartResult {
+  status: MiramcpAutostartStatus;
+  configPath: string;
+  pidFile: string;
+  deviceId?: string;
+  binPath?: string;
+  pid?: number;
+  error?: string;
+}
+
+type SpawnLike = (
+  command: string,
+  args: readonly string[],
+  options: {
+    detached: true;
+    stdio: 'ignore';
+    env: NodeJS.ProcessEnv;
+  },
+) => { pid?: number; unref?: () => void; once?: (event: 'error' | 'exit', listener: (...args: any[]) => void) => unknown };
+
+type SpawnSyncLike = (
+  command: string,
+  args: readonly string[],
+  options: {
+    encoding: 'utf8';
+    timeout: number;
+    stdio: 'pipe';
+  },
+) => { stdout?: string | Buffer | null; error?: unknown };
+
+const DEFAULT_STARTUP_TIMEOUT_MS = 5_000;
+const STARTUP_PENDING_PID_GRACE_MS = 30_000;
+const STARTUP_TIMEOUT_ERROR = 'miramcp did not bind port 9801 during startup';
+const PENDING_PORT_ERROR = 'miramcp pid is still starting; port 9801 is not listening yet';
+
+export interface MiramcpAutostartOptions {
+  configPath?: string;
+  pidFile?: string;
+  binPath?: string;
+  mircliBin?: string;
+  env?: NodeJS.ProcessEnv;
+  spawnImpl?: SpawnLike;
+  spawnSyncImpl?: SpawnSyncLike;
+  processExists?: (pid: number) => boolean;
+  startupTimeoutMs?: number;
 }
 
 function unique(paths: string[]): string[] {
@@ -121,6 +153,14 @@ function miramcpConfigPath(): string {
   return process.env.MIRAMCP_CONFIG_PATH || join(homedir(), '.miramcp', 'config.json');
 }
 
+function miraConfigPath(env: NodeJS.ProcessEnv = process.env): string {
+  return env.MIRA_CONFIG_PATH || join(homedir(), '.mira', 'config.json');
+}
+
+function miramcpPidFile(env: NodeJS.ProcessEnv = process.env): string {
+  return env.MIRAMCP_PID_FILE || join(homedir(), '.mira', 'miramcp', 'miramcp.pid');
+}
+
 function findMiraLocalMcp(config: JsonObject): JsonObject | undefined {
   const mcps = Array.isArray(config.mcps) ? config.mcps : [];
   return mcps.find((mcp: unknown): mcp is JsonObject =>
@@ -133,8 +173,8 @@ export function ensureMiramcpSandboxAllows(paths: string[], configPath = miramcp
     return { configPath, changed: false, added: [], skipped: 'missing_config' };
   }
   // Lock the whole read-modify-write so concurrent mir sessions can't clobber
-  // each other's write_allow_paths additions (see withFileLock).
-  return withFileLock(configPath, () => patchMiramcpSandbox(paths, configPath));
+  // each other's write_allow_paths additions (see withFileLockSync).
+  return withFileLockSync(configPath, () => patchMiramcpSandbox(paths, configPath));
 }
 
 function patchMiramcpSandbox(paths: string[], configPath: string): MiramcpPatchResult {
@@ -177,4 +217,238 @@ function patchMiramcpSandbox(paths: string[], configPath: string): MiramcpPatchR
   writeFileSync(tmpPath, JSON.stringify(config, null, 2) + '\n', 'utf8');
   renameSync(tmpPath, configPath);
   return { configPath, changed: true, added };
+}
+
+function detectMiramcpBin(opts: MiramcpAutostartOptions, env: NodeJS.ProcessEnv): string | undefined {
+  const explicit = locateExecutable(opts.binPath || env.MIRAMCP_BIN, env);
+  if (explicit) return explicit;
+
+  const candidates: string[] = [];
+  const mircliBin = opts.mircliBin || env.MIRCLI_BIN;
+  if (mircliBin && isAbsolute(mircliBin)) {
+    candidates.push(join(dirname(mircliBin), 'miramcp'), join(dirname(mircliBin), 'mira_cli'));
+  }
+  candidates.push(
+    join(homedir(), '.local', 'bin', 'miramcp'),
+    join(homedir(), '.local', 'bin', 'mira_cli'),
+  );
+  for (const candidate of candidates) {
+    if (isExecutable(candidate)) return candidate;
+  }
+  return locateExecutable('miramcp', env) || locateExecutable('mira_cli', env) || undefined;
+}
+
+function defaultProcessExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runningPidFromFile(pidFile: string, processExists: (pid: number) => boolean): number | undefined {
+  if (!existsSync(pidFile)) return undefined;
+  try {
+    const pid = Number(readFileSync(pidFile, 'utf8').trim());
+    if (Number.isInteger(pid) && pid > 0 && processExists(pid)) return pid;
+  } catch {
+    // ignore invalid pid file
+  }
+  try { unlinkSync(pidFile); } catch { /* best effort */ }
+  return undefined;
+}
+
+function removePidFileIfMatches(pidFile: string, pid: number): void {
+  try {
+    if (readFileSync(pidFile, 'utf8').trim() === String(pid)) unlinkSync(pidFile);
+  } catch {
+    // Best-effort cleanup; a later turn re-checks pid + port before reuse.
+  }
+}
+
+function pidFileAgeMs(pidFile: string): number | undefined {
+  try {
+    return Date.now() - statSync(pidFile).mtimeMs;
+  } catch {
+    return undefined;
+  }
+}
+
+function portHasListener(spawnSyncImpl: SpawnSyncLike): boolean | undefined {
+  if (process.platform === 'win32') return undefined;
+  try {
+    const result = spawnSyncImpl('lsof', ['-ti:9801'], {
+      encoding: 'utf8',
+      timeout: 3_000,
+      stdio: 'pipe',
+    });
+    if (result.error) return undefined;
+    return Boolean((result.stdout || '').toString().trim());
+  } catch {
+    return undefined;
+  }
+}
+
+function startupTimeoutMs(opts: MiramcpAutostartOptions): number {
+  const raw = opts.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS;
+  return Number.isFinite(raw) && raw >= 0 ? raw : DEFAULT_STARTUP_TIMEOUT_MS;
+}
+
+function waitForMiramcpStartup(opts: {
+  pid: number;
+  processExists: (pid: number) => boolean;
+  spawnSyncImpl: SpawnSyncLike;
+  timeoutMs: number;
+  asyncFailure: () => string | undefined;
+}): { ok: true } | { ok: false; error: string } {
+  const deadline = Date.now() + opts.timeoutMs;
+  let portCheckUnknown = false;
+  for (;;) {
+    const asyncError = opts.asyncFailure();
+    if (asyncError) return { ok: false, error: asyncError };
+    if (!opts.processExists(opts.pid)) return { ok: false, error: 'miramcp exited during startup' };
+    const portListening = portHasListener(opts.spawnSyncImpl);
+    if (portListening === true) return { ok: true };
+    if (portListening === undefined) portCheckUnknown = true;
+    if (Date.now() >= deadline) {
+      if (portCheckUnknown) return { ok: true };
+      return { ok: false, error: STARTUP_TIMEOUT_ERROR };
+    }
+    syncSleep(Math.min(50, Math.max(1, deadline - Date.now())));
+  }
+}
+
+function readMiraConfig(configPath: string): JsonObject | undefined | null {
+  if (!existsSync(configPath)) return undefined;
+  try {
+    const parsed = JSON.parse(readFileSync(configPath, 'utf8'));
+    return parsed && typeof parsed === 'object' ? parsed as JsonObject : null;
+  } catch {
+    return null;
+  }
+}
+
+export function ensureMiramcpBridgeStarted(opts: MiramcpAutostartOptions = {}): MiramcpAutostartResult {
+  const env = opts.env || process.env;
+  const configPath = opts.configPath || miraConfigPath(env);
+  const pidFile = opts.pidFile || miramcpPidFile(env);
+  const preflightConfig = readMiraConfig(configPath);
+  if (preflightConfig === undefined && !env.MIRA_DEVICE_ID) {
+    return { status: 'missing_config', configPath, pidFile };
+  }
+  if (preflightConfig === null) {
+    return { status: 'invalid_config', configPath, pidFile };
+  }
+  if (preflightConfig?.auto_start_bridge === false) {
+    return { status: 'disabled', configPath, pidFile };
+  }
+  if (!String(env.MIRA_DEVICE_ID || preflightConfig?.device_id || '').trim()) {
+    return { status: 'missing_device_id', configPath, pidFile };
+  }
+
+  try {
+    mkdirSync(dirname(pidFile), { recursive: true });
+    return withFileLockSync(pidFile, () => ensureMiramcpBridgeStartedUnlocked(opts, env, configPath, pidFile));
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return { status: 'spawn_failed', configPath, pidFile, error };
+  }
+}
+
+function ensureMiramcpBridgeStartedUnlocked(
+  opts: MiramcpAutostartOptions,
+  env: NodeJS.ProcessEnv,
+  configPath: string,
+  pidFile: string,
+): MiramcpAutostartResult {
+  const config = readMiraConfig(configPath);
+  if (config === undefined && !env.MIRA_DEVICE_ID) {
+    return { status: 'missing_config', configPath, pidFile };
+  }
+  if (config === null) {
+    return { status: 'invalid_config', configPath, pidFile };
+  }
+  if (config?.auto_start_bridge === false) {
+    return { status: 'disabled', configPath, pidFile };
+  }
+
+  const deviceId = String(env.MIRA_DEVICE_ID || config?.device_id || '').trim();
+  if (!deviceId) {
+    return { status: 'missing_device_id', configPath, pidFile };
+  }
+
+  const processExists = opts.processExists || defaultProcessExists;
+  const spawnSyncImpl = opts.spawnSyncImpl || spawnSync;
+  const pid = runningPidFromFile(pidFile, processExists);
+  if (pid) {
+    const portListening = portHasListener(spawnSyncImpl);
+    if (portListening !== false) {
+      return { status: 'already_running', configPath, pidFile, deviceId, pid };
+    }
+    const ageMs = pidFileAgeMs(pidFile);
+    if (ageMs !== undefined && ageMs < STARTUP_PENDING_PID_GRACE_MS) {
+      return { status: 'started_pending', configPath, pidFile, deviceId, pid, error: PENDING_PORT_ERROR };
+    }
+    removePidFileIfMatches(pidFile, pid);
+    logger.warn(`[miramcp-autostart] pidfile ${pidFile} pointed at live pid ${pid}, but port 9801 is not listening; treating it as stale`);
+  }
+
+  if (portHasListener(spawnSyncImpl)) {
+    return { status: 'already_running', configPath, pidFile, deviceId };
+  }
+
+  const binPath = detectMiramcpBin(opts, env);
+  if (!binPath) {
+    return { status: 'missing_bin', configPath, pidFile, deviceId };
+  }
+
+  try {
+    mkdirSync(dirname(pidFile), { recursive: true });
+    const child = (opts.spawnImpl || spawn)(binPath, ['run', '--device-id', deviceId], {
+      detached: true,
+      stdio: 'ignore',
+      env,
+    });
+    let pidWritten = false;
+    let asyncFailure: string | undefined;
+    const cleanup = (reason: string): void => {
+      asyncFailure ??= reason;
+      if (child.pid && pidWritten) removePidFileIfMatches(pidFile, child.pid);
+      logger.warn(`[miramcp-autostart] bridge process ended before/after startup: ${reason}`);
+    };
+    child.once?.('error', (err: Error) => {
+      cleanup(`spawn error: ${err instanceof Error ? err.message : String(err)}`);
+    });
+    child.once?.('exit', (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup(`exit code=${code ?? 'null'} signal=${signal ?? 'null'}`);
+    });
+    child.unref?.();
+    if (!child.pid) {
+      return { status: 'spawn_failed', configPath, pidFile, deviceId, binPath, error: 'missing child pid' };
+    }
+    const timeoutMs = startupTimeoutMs(opts);
+    const startup = waitForMiramcpStartup({
+      pid: child.pid,
+      processExists,
+      spawnSyncImpl,
+      timeoutMs,
+      asyncFailure: () => asyncFailure,
+    });
+    if (!startup.ok) {
+      if (startup.error === STARTUP_TIMEOUT_ERROR && processExists(child.pid)) {
+        writeFileSync(pidFile, String(child.pid), 'utf8');
+        pidWritten = true;
+        logger.warn(`[miramcp-autostart] bridge pid ${child.pid} still starting after ${timeoutMs}ms; wrote pidfile to avoid duplicate autostarts`);
+        return { status: 'started_pending', configPath, pidFile, deviceId, binPath, pid: child.pid, error: startup.error };
+      }
+      return { status: 'spawn_failed', configPath, pidFile, deviceId, binPath, pid: child.pid, error: startup.error };
+    }
+    writeFileSync(pidFile, String(child.pid), 'utf8');
+    pidWritten = true;
+    return { status: 'started', configPath, pidFile, deviceId, binPath, pid: child.pid };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return { status: 'spawn_failed', configPath, pidFile, deviceId, binPath, error };
+  }
 }

--- a/src/mir-runner.ts
+++ b/src/mir-runner.ts
@@ -28,7 +28,12 @@ import { spawn } from 'node:child_process';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { Buffer } from 'node:buffer';
-import { getMiraRuntimePaths, ensureMiramcpSandboxAllows } from './mir-local-runtime.js';
+import {
+  getMiraRuntimePaths,
+  ensureMiramcpBridgeStarted,
+  ensureMiramcpSandboxAllows,
+  type MiramcpAutostartResult,
+} from './mir-local-runtime.js';
 
 interface Args {
   sessionId: string;
@@ -83,6 +88,21 @@ function prompt(): void {
 function errorMessage(err: unknown): string {
   if (err instanceof Error) return err.message;
   return String(err);
+}
+
+function logMiramcpAutostart(result: MiramcpAutostartResult): void {
+  const details = [
+    `status=${result.status}`,
+    result.pid ? `pid=${result.pid}` : '',
+    result.binPath ? `bin=${result.binPath}` : '',
+    result.error ? `error=${result.error}` : '',
+  ].filter(Boolean).join(' ');
+  const message = `[mir] miramcp auto-start ${details}\n`;
+  if (result.status === 'started_pending' || result.status === 'missing_bin' || result.status === 'spawn_failed' || result.status === 'invalid_config' || result.status === 'missing_device_id') {
+    process.stderr.write(message);
+    return;
+  }
+  if (process.env.DEBUG) process.stderr.write(message);
 }
 
 function boolEnv(name: string, fallback: boolean): boolean {
@@ -316,6 +336,15 @@ class MircliClient {
     return new Promise((resolve, reject) => {
       // Precedence: adapter cliPathOverride (--mircli-bin) > MIRCLI_BIN env > PATH.
       const bin = this.mircliBin || process.env.MIRCLI_BIN || 'mircli';
+      if (boolEnv('MIRCLI_AUTO_START_MIRAMCP', true)) {
+        try {
+          logMiramcpAutostart(ensureMiramcpBridgeStarted({ mircliBin: bin }));
+        } catch (err) {
+          process.stderr.write(`[mir] miramcp auto-start threw error=${errorMessage(err)}\n`);
+          // Best-effort: mircli will surface the concrete MCP error if the
+          // bridge is still unavailable.
+        }
+      }
       // Patch the local MCP bridge sandbox so writes to this workspace aren't
       // blocked (workspace may sit outside the default /root,/tmp allow-list).
       if (boolEnv('MIRCLI_PATCH_MIRAMCP_CONFIG', true)) {

--- a/src/utils/executable.ts
+++ b/src/utils/executable.ts
@@ -1,0 +1,21 @@
+import { accessSync, constants } from 'node:fs';
+import { delimiter, isAbsolute, join } from 'node:path';
+
+export function isExecutable(path: string): boolean {
+  try {
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function locateExecutable(cmd: string | undefined, env: NodeJS.ProcessEnv = process.env): string | null {
+  if (!cmd) return null;
+  if (isAbsolute(cmd)) return isExecutable(cmd) ? cmd : null;
+  for (const dir of (env.PATH ?? '').split(delimiter).filter(Boolean)) {
+    const candidate = join(dir, cmd);
+    if (isExecutable(candidate)) return candidate;
+  }
+  return null;
+}

--- a/test/mir-local-runtime.test.ts
+++ b/test/mir-local-runtime.test.ts
@@ -1,8 +1,8 @@
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { ensureMiramcpSandboxAllows, getMiraRuntimePaths } from '../src/mir-local-runtime.js';
+import { ensureMiramcpBridgeStarted, ensureMiramcpSandboxAllows, getMiraRuntimePaths } from '../src/mir-local-runtime.js';
 
 describe('getMiraRuntimePaths', () => {
   it('derives a logical home alias when cwd is under a symlinked home realpath', () => {
@@ -104,5 +104,249 @@ describe('ensureMiramcpSandboxAllows', () => {
     expect(updated.mcps[0].sandbox.write_allow_paths).toEqual(['/ws/a', '/ws/b']);
     // Lock released (no leftover .lock).
     expect(existsSync(`${configPath}.lock`)).toBe(false);
+  });
+});
+
+describe('ensureMiramcpBridgeStarted', () => {
+  it('starts miramcp in the background when enabled and not already running', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-miramcp-start-'));
+    const configPath = join(dir, 'mira-config.json');
+    const pidFile = join(dir, 'miramcp.pid');
+    const binPath = join(dir, 'miramcp');
+    writeFileSync(configPath, JSON.stringify({ device_id: 'alice_devbox' }));
+    writeFileSync(binPath, '#!/bin/sh\n', 'utf8');
+    chmodSync(binPath, 0o755);
+
+    const calls: Array<{ command: string; args: readonly string[] }> = [];
+    let lockSeenDuringSpawn = false;
+    let errorListener: ((err: Error) => void) | undefined;
+    let lsofCalls = 0;
+    const result = ensureMiramcpBridgeStarted({
+      configPath,
+      pidFile,
+      binPath,
+      env: { PATH: '' },
+      processExists: pid => pid === 4242,
+      spawnSyncImpl: () => ({ stdout: ++lsofCalls >= 2 ? '4242\n' : '' }),
+      startupTimeoutMs: 0,
+      spawnImpl: (command, args) => {
+        calls.push({ command, args });
+        lockSeenDuringSpawn = existsSync(`${pidFile}.lock`);
+        return {
+          pid: 4242,
+          unref() { /* detached */ },
+          once(event, listener) {
+            if (event === 'error') errorListener = listener;
+          },
+        };
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: 'started',
+      deviceId: 'alice_devbox',
+      binPath,
+      pid: 4242,
+    });
+    expect(calls).toEqual([{ command: binPath, args: ['run', '--device-id', 'alice_devbox'] }]);
+    expect(lockSeenDuringSpawn).toBe(true);
+    expect(existsSync(`${pidFile}.lock`)).toBe(false);
+    expect(errorListener).toBeDefined();
+    expect(readFileSync(pidFile, 'utf8')).toBe('4242');
+    expect(() => errorListener?.(new Error('async spawn failure'))).not.toThrow();
+    expect(existsSync(pidFile)).toBe(false);
+  });
+
+  it('removes the pid file when a started bridge exits', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-miramcp-exit-'));
+    const configPath = join(dir, 'mira-config.json');
+    const pidFile = join(dir, 'miramcp.pid');
+    const binPath = join(dir, 'miramcp');
+    writeFileSync(configPath, JSON.stringify({ device_id: 'alice_devbox' }));
+    writeFileSync(binPath, '#!/bin/sh\n', 'utf8');
+    chmodSync(binPath, 0o755);
+
+    let exitListener: ((code: number | null, signal: NodeJS.Signals | null) => void) | undefined;
+    let lsofCalls = 0;
+    const result = ensureMiramcpBridgeStarted({
+      configPath,
+      pidFile,
+      binPath,
+      env: { PATH: '' },
+      processExists: pid => pid === 4242,
+      spawnSyncImpl: () => ({ stdout: ++lsofCalls >= 2 ? '4242\n' : '' }),
+      startupTimeoutMs: 0,
+      spawnImpl: () => ({
+        pid: 4242,
+        unref() { /* detached */ },
+        once(event, listener) {
+          if (event === 'exit') exitListener = listener as (code: number | null, signal: NodeJS.Signals | null) => void;
+        },
+      }),
+    });
+
+    expect(result.status).toBe('started');
+    expect(readFileSync(pidFile, 'utf8')).toBe('4242');
+    expect(exitListener).toBeDefined();
+    exitListener?.(1, null);
+    expect(existsSync(pidFile)).toBe(false);
+  });
+
+  it('does not write a pid file when the spawned bridge dies during startup', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-miramcp-dies-'));
+    const configPath = join(dir, 'mira-config.json');
+    const pidFile = join(dir, 'miramcp.pid');
+    const binPath = join(dir, 'miramcp');
+    writeFileSync(configPath, JSON.stringify({ device_id: 'alice_devbox' }));
+    writeFileSync(binPath, '#!/bin/sh\n', 'utf8');
+    chmodSync(binPath, 0o755);
+
+    const result = ensureMiramcpBridgeStarted({
+      configPath,
+      pidFile,
+      binPath,
+      env: { PATH: '' },
+      processExists: () => false,
+      spawnSyncImpl: () => ({ stdout: '' }),
+      startupTimeoutMs: 0,
+      spawnImpl: () => ({
+        pid: 4343,
+        unref() { /* detached */ },
+        once() { /* listeners attached by production code */ },
+      }),
+    });
+
+    expect(result).toMatchObject({
+      status: 'spawn_failed',
+      pid: 4343,
+      error: 'miramcp exited during startup',
+    });
+    expect(existsSync(pidFile)).toBe(false);
+  });
+
+  it('tracks a slow-starting bridge after startup timeout and avoids duplicate spawns', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-miramcp-pending-'));
+    const configPath = join(dir, 'mira-config.json');
+    const pidFile = join(dir, 'miramcp.pid');
+    const binPath = join(dir, 'miramcp');
+    writeFileSync(configPath, JSON.stringify({ device_id: 'alice_devbox' }));
+    writeFileSync(binPath, '#!/bin/sh\n', 'utf8');
+    chmodSync(binPath, 0o755);
+
+    let spawnCount = 0;
+    const common = {
+      configPath,
+      pidFile,
+      binPath,
+      env: { PATH: '' },
+      processExists: (pid: number) => pid === 4242,
+      spawnSyncImpl: () => ({ stdout: '' }),
+      startupTimeoutMs: 0,
+    };
+
+    const first = ensureMiramcpBridgeStarted({
+      ...common,
+      spawnImpl: () => {
+        spawnCount++;
+        return {
+          pid: 4242,
+          unref() { /* detached */ },
+          once() { /* listeners attached by production code */ },
+        };
+      },
+    });
+
+    expect(first).toMatchObject({
+      status: 'started_pending',
+      pid: 4242,
+      error: 'miramcp did not bind port 9801 during startup',
+    });
+    expect(readFileSync(pidFile, 'utf8')).toBe('4242');
+
+    const second = ensureMiramcpBridgeStarted({
+      ...common,
+      spawnImpl: () => {
+        throw new Error('must not spawn twice');
+      },
+    });
+
+    expect(second).toMatchObject({
+      status: 'started_pending',
+      pid: 4242,
+      error: 'miramcp pid is still starting; port 9801 is not listening yet',
+    });
+    expect(spawnCount).toBe(1);
+    expect(readFileSync(pidFile, 'utf8')).toBe('4242');
+  });
+
+  it('does not trust a live pid file when port 9801 is not listening', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-miramcp-stale-pid-'));
+    const configPath = join(dir, 'mira-config.json');
+    const pidFile = join(dir, 'miramcp.pid');
+    const binPath = join(dir, 'miramcp');
+    writeFileSync(configPath, JSON.stringify({ device_id: 'alice_devbox' }));
+    writeFileSync(pidFile, '1234');
+    const old = new Date(Date.now() - 60_000);
+    utimesSync(pidFile, old, old);
+    writeFileSync(binPath, '#!/bin/sh\n', 'utf8');
+    chmodSync(binPath, 0o755);
+
+    let lsofCalls = 0;
+    const result = ensureMiramcpBridgeStarted({
+      configPath,
+      pidFile,
+      binPath,
+      env: { PATH: '' },
+      processExists: pid => pid === 1234 || pid === 4242,
+      spawnSyncImpl: () => ({ stdout: ++lsofCalls >= 3 ? '4242\n' : '' }),
+      startupTimeoutMs: 0,
+      spawnImpl: () => ({
+        pid: 4242,
+        unref() { /* detached */ },
+        once() { /* listeners attached by production code */ },
+      }),
+    });
+
+    expect(result).toMatchObject({ status: 'started', pid: 4242 });
+    expect(readFileSync(pidFile, 'utf8')).toBe('4242');
+  });
+
+  it('respects auto_start_bridge false in ~/.mira/config.json', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-miramcp-disabled-'));
+    const configPath = join(dir, 'mira-config.json');
+    writeFileSync(configPath, JSON.stringify({ device_id: 'alice_devbox', auto_start_bridge: false }));
+
+    const result = ensureMiramcpBridgeStarted({
+      configPath,
+      pidFile: join(dir, 'miramcp.pid'),
+      binPath: join(dir, 'miramcp'),
+      env: { PATH: '' },
+      spawnImpl: () => {
+        throw new Error('must not spawn');
+      },
+    });
+
+    expect(result.status).toBe('disabled');
+  });
+
+  it('does not spawn when the pid file points to a live process', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-miramcp-running-'));
+    const configPath = join(dir, 'mira-config.json');
+    const pidFile = join(dir, 'miramcp.pid');
+    writeFileSync(configPath, JSON.stringify({ device_id: 'alice_devbox' }));
+    writeFileSync(pidFile, '1234');
+
+    const result = ensureMiramcpBridgeStarted({
+      configPath,
+      pidFile,
+      env: { PATH: '' },
+      processExists: pid => pid === 1234,
+      spawnSyncImpl: () => ({ stdout: '1234\n' }),
+      spawnImpl: () => {
+        throw new Error('must not spawn');
+      },
+    });
+
+    expect(result).toMatchObject({ status: 'already_running', deviceId: 'alice_devbox', pid: 1234 });
   });
 });


### PR DESCRIPTION
## Summary

- Add a Mir local-runtime helper that mirrors Mir CLI's default MCP bridge startup behavior for BotMux-spawned `mir` sessions.
- Start `miramcp run --device-id <device_id>` before invoking `mircli -p` when `~/.mira/config.json` has a `device_id` and `auto_start_bridge` is not false.
- Document the Mir CLI + MCP Bridge prerequisites, DevBox behavior, status command, and disable switches in the zh/en adapter docs.
- Reuse the existing Mir runtime test file to cover start, disabled, and already-running cases.

## Behavior

When a user selects `Mira -> Mir CLI` during `botmux setup`, the configured adapter is `cliId: "mir"`. On each runner turn, BotMux now best-effort ensures the local MCP bridge is running before invoking Mir CLI, so local MCP tools are available without requiring a separate manual `mircli mcp start` step.

BotMux does not require DevBox-specific configuration. The daemon just needs to run as the same system user that has Mir CLI initialized, with `device_id` in `~/.mira/config.json` and `miramcp` installed or pointed to by `MIRAMCP_BIN`.

The behavior can be disabled with either existing Mira config:

```json
{"auto_start_bridge": false}
```

or per BotMux runtime:

```bash
MIRCLI_AUTO_START_MIRAMCP=0
```

## Validation

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run --project unit test/mir-local-runtime.test.ts test/cli-selection.test.ts`
- `./node_modules/.bin/esbuild src/dashboard/web/app.ts --bundle --outfile=dist/dashboard-web/app.js --platform=browser --format=iife --minify`

Note: `npm run build` was blocked in this local environment because the globally resolved pnpm 11 install policy rejected dependency build scripts during the nested `pnpm dashboard:bundle` step; the underlying TypeScript and dashboard bundle steps were run directly and passed.