### PR TITLE
feat(opencode): 适配 AskUserQuestion（拦截原生 question 工具经飞书作答）

### DIFF
--- a/src/adapters/hook-installer.ts
+++ b/src/adapters/hook-installer.ts
@@ -184,45 +184,155 @@ function installClaudeSettings(configPath: string, hookCommand: string, sessionS
 
 /**
  * 构造 botmux ask 的 OpenCode 插件内容。
- * 插件监听 question.asked 事件，将 payload JSON 写入 botmux hook opencode 的 stdin，
- * 读取 stdout 作为回答，返回给 OpenCode。
  *
- * TODO(dogfood): 校验 OpenCode 插件 question.asked API
- * OpenCode 插件 API 目前处于 dogfood 阶段，`question.asked` 钩子形状和返回值约定
- * 需要在真实会话中实测确认（stdin/stdout 格式、同步/异步、返回值结构等）。
+ * 机制（已在 OpenCode 1.17.x 实机验证）：
+ *   - OpenCode 自带原生 `question` 工具（= Claude AskUserQuestion 等价物），模型会原生
+ *     调用，无需我们注入。它被调用时，服务端发布 `question.asked` 事件并阻塞，等客户端
+ *     把答案提交到 `/question/{id}/reply`（body `{ answers }`）后才解阻塞、返回给模型。
+ *   - OpenCode 插件 API 没有 `question.asked` 这种专用钩子；要拦截只能用通用 `event` 钩子
+ *     按 `event.type === 'question.asked'` 过滤（plugin 导出必须是「函数」而非对象）。
+ *
+ * 事件 payload 形状：
+ *   { type:'question.asked', properties:{ id:'que_…', sessionID:'ses_…',
+ *     questions:[{ question, header, options:[{label,description}], multiple? }] } }
+ *
+ * 转发策略：把 questions 规范成 `botmux hook opencode` 认识的 payload 喂给它（复用现有
+ * 飞书问答链路：daemon /api/asks → 飞书卡片 → 用户作答 → directive），拿到 stdout 里的
+ * `{ answers }` 后回传给 OpenCode 解阻塞。
+ *   - **回传必须走 OpenCode 注入给插件的 client（`client._client`）**，不能用裸 fetch：
+ *     OpenCode 是「单 server 多 worktree 实例」模型，client 自带 `x-opencode-directory`
+ *     头把 reply 路由到发起 question 的那个实例，且其传输在 daemon 里实际可达
+ *     （裸 fetch 到 `localhost:4096` 在 daemon 里连不上 + 缺 directory 头 → 永远卡 picker）。
+ *   - **异步**作答：飞书侧作答可能耗时很久（默认上限 1h），绝不能用 spawnSync 同步阻塞
+ *     OpenCode 的单线程事件总线（会冻结整个 TUI）。改用异步 spawn + fire-and-forget。
+ *   - stdout 为空（passthrough：daemon 不可达 / 超时 / 非 botmux 会话）→ 不 reply，把问题
+ *     留给 OpenCode 原生 picker（botmux web 终端里仍可人工作答）。
  */
 function buildOpenCodePlugin(parts: { cmd: string; args: string[] }): string {
   // 用 argv 形式嵌入（不拼 shell 字符串、不 split）：含空格/引号的路径也不会被拆坏。
   const cmdLit = JSON.stringify(parts.cmd);
   const argsLit = JSON.stringify(parts.args);
   return `// botmux-ask opencode plugin
-// 将 OpenCode 的 question.asked 事件转发到 botmux hook opencode。
-// TODO(dogfood): 校验 OpenCode 插件 question.asked API
-import { spawnSync } from "child_process";
+// 监听 OpenCode 原生 \`question\` 工具触发的 \`question.asked\` 事件，转发到
+// \`botmux hook opencode\`（飞书问答），再把答案 POST 回 OpenCode 解阻塞。
+import { spawn } from "child_process";
+import { appendFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
 
-export default {
-  name: "botmux-ask",
+const CMD = ${cmdLit};
+const ARGS = ${argsLit};
 
-  // question.asked: OpenCode 向用户提问时触发。
-  // payload 形状待实测（见 TODO 注释）。
-  // 返回值 { type:'answer', answers } 或 undefined（undefined = 由 OpenCode 自行处理）。
-  "question.asked"(payload) {
+// 诊断日志：默认关闭，设 BOTMUX_OPENCODE_ASK_DEBUG=1 后每步落盘到
+// ~/.botmux/opencode-ask-debug.log，用于排查 ask 链路（事件→转发→reply）。
+const DBG_ON = !!process.env.BOTMUX_OPENCODE_ASK_DEBUG;
+const DBG = join(homedir(), ".botmux", "opencode-ask-debug.log");
+function dbg(m) {
+  if (!DBG_ON) return;
+  try { appendFileSync(DBG, new Date().toISOString() + " " + m + "\\n"); } catch {}
+}
+
+// 异步 spawn \`botmux hook opencode\`：stdin 喂 payload，收集 stdout。
+// 任何失败都 resolve("")（= passthrough 放行）。child 自带超时（hook 客户端按
+// BOTMUX_ASK_TIMEOUT_MS 自限），这里再加 25h 兜底 kill 防僵尸（unref 不拖住事件循环）。
+function askBotmux(payload) {
+  return new Promise((resolve) => {
+    let out = "";
+    let settled = false;
+    const done = (v) => { if (!settled) { settled = true; resolve(v); } };
+    let child;
     try {
-      const input = JSON.stringify(payload);
-      const result = spawnSync(${cmdLit}, ${argsLit}, {
-        input,
-        encoding: "utf-8",
-        timeout: 86400000, // 24h，等待用户在飞书回答
-      });
-      // stdout 为空 = hook 客户端 passthrough（放行）→ 返回 undefined，OpenCode 原生处理。
-      if (result.status === 0 && result.stdout && result.stdout.trim()) {
-        return JSON.parse(result.stdout.trim());
-      }
+      child = spawn(CMD, ARGS, { stdio: ["pipe", "pipe", "ignore"] });
     } catch {
-      // 任何失败都降级放行：返回 undefined 让 OpenCode 回退原生终端提问
+      return done("");
     }
-    return undefined;
-  },
+    const backstop = setTimeout(() => { try { child.kill(); } catch {} done(""); }, 90000000);
+    if (typeof backstop.unref === "function") backstop.unref();
+    child.stdout.on("data", (d) => { out += d.toString("utf-8"); });
+    child.on("error", () => { clearTimeout(backstop); done(""); });
+    child.on("close", (code) => { clearTimeout(backstop); done(code === 0 ? out : ""); });
+    try { child.stdin.write(payload); child.stdin.end(); } catch { clearTimeout(backstop); done(""); }
+  });
+}
+
+// 把答案回传给 OpenCode 解阻塞。
+// 必须走 OpenCode 自带的 client（client._client = 已配置的 hey-api client）——
+// 它带着 \`x-opencode-directory\` 头与正确的 baseUrl/传输。OpenCode 用「单 server 多
+// worktree 实例」模型，该头用于把 reply 路由到发起 question 的那个实例；裸 fetch 缺这个
+// 头会打到错误实例（question 找不到 → 永远卡在 picker）。失败再回落裸 fetch（复制其 headers）。
+function safeStr(x) {
+  try { return String(JSON.stringify(x)).slice(0, 120); } catch { return String(x); }
+}
+
+async function postReply(client, serverUrl, id, answers) {
+  const body = { answers };
+  // 1) 经 client._client（带 directory 头 + 正确传输）。这是 daemon 多实例下唯一可达的路径：
+  //    裸 fetch 到 localhost:4096 在 daemon 里根本连不上（OpenCode 用 interceptor 传输）。
+  try {
+    const c = client && client._client;
+    if (c && typeof c.post === "function") {
+      const res = await c.post({ url: "/question/" + id + "/reply", body });
+      const st = res && res.response && res.response.status;
+      const success = (res && res.data === true) || (st && st >= 200 && st < 300);
+      dbg("CLIENT_POST id=" + id + " status=" + st + " data=" + safeStr(res && res.data) + " err=" + safeStr(res && res.error));
+      if (success) return true;
+    } else {
+      dbg("CLIENT_POST_UNAVAILABLE id=" + id);
+    }
+  } catch (e) { dbg("CLIENT_POST_THREW id=" + id + " err=" + String(e)); }
+  // 2) 回落裸 fetch，尽量复制 client 的 headers（含 directory）与 baseUrl
+  try {
+    let base = String(serverUrl).replace(/\\/+$/, "");
+    let headers = { "content-type": "application/json" };
+    try {
+      const cfg = client && client._client && client._client.getConfig && client._client.getConfig();
+      if (cfg) {
+        if (cfg.baseUrl) base = String(cfg.baseUrl).replace(/\\/+$/, "");
+        if (cfg.headers) headers = Object.assign({}, cfg.headers, { "content-type": "application/json" });
+      }
+    } catch {}
+    const url = base + "/question/" + id + "/reply";
+    dbg("FETCH_POST url=" + url + " headers=" + Object.keys(headers).join(","));
+    const r = await fetch(url, { method: "POST", headers, body: JSON.stringify(body) });
+    let txt = ""; try { txt = await r.text(); } catch {}
+    dbg("FETCH_POST_RESULT id=" + id + " status=" + r.status + " body=" + txt.slice(0, 150));
+    return r.ok;
+  } catch (e) { dbg("FETCH_POST_THREW id=" + id + " err=" + String(e)); return false; }
+}
+
+export const BotmuxAsk = async ({ client, serverUrl }) => {
+  dbg("PLUGIN_LOADED serverUrl=" + serverUrl + " hasClient=" + !!(client && client._client));
+  return {
+    event: async ({ event }) => {
+      if (!event || event.type !== "question.asked") return;
+      const props = event.properties || {};
+      const id = props.id;
+      const questions = props.questions;
+      dbg("EVENT question.asked id=" + id + " sessionID=" + props.sessionID + " nQ=" + (Array.isArray(questions) ? questions.length : "?"));
+      if (!id || !Array.isArray(questions) || questions.length === 0) { dbg("SKIP missing id/questions"); return; }
+      // fire-and-forget：不 await，避免阻塞事件总线（飞书作答可能很久）。
+      // 问题在服务端独立阻塞，答案经 reply 回去即可解阻塞。
+      (async () => {
+        const payload = JSON.stringify({
+          hook_event_name: "question.asked",
+          question_id: id,
+          session_id: props.sessionID,
+          tool_input: { questions },
+        });
+        dbg("SPAWN botmux hook opencode id=" + id);
+        const stdout = (await askBotmux(payload)).trim();
+        dbg("HOOK_STDOUT id=" + id + " len=" + stdout.length + " body=" + stdout.slice(0, 300));
+        if (!stdout) { dbg("PASSTHROUGH empty stdout id=" + id); return; } // passthrough/超时 → 不应答，留给原生 picker
+        let directive;
+        try { directive = JSON.parse(stdout); } catch (e) { dbg("PARSE_FAIL id=" + id + " err=" + String(e)); return; }
+        const answers = directive && directive.answers;
+        if (!Array.isArray(answers)) { dbg("NO_ANSWERS id=" + id + " directive=" + JSON.stringify(directive).slice(0, 200)); return; }
+        dbg("REPLY id=" + id + " answers=" + JSON.stringify(answers));
+        const ok = await postReply(client, serverUrl, id, answers);
+        dbg("REPLY_DONE id=" + id + " ok=" + ok);
+      })().catch((e) => { dbg("HANDLER_ERR id=" + id + " err=" + String(e)); });
+    },
+  };
 };
 `;
 }
@@ -262,7 +372,7 @@ export function installHook(
         installClaudeSettings(configPath, hookCommand, hookInstall.sessionStartCommand);
         break;
       case 'opencode-plugin':
-        // OpenCode 插件走 argv parts（spawnSync），不复用 shell 字符串，避免被 split 拆坏。
+        // OpenCode 插件走 argv parts（异步 spawn），不复用 shell 字符串，避免被 split 拆坏。
         installOpenCodePlugin(configPath, hookCommandParts(cliId));
         break;
       default: {

--- a/src/core/ask-hook/opencode.ts
+++ b/src/core/ask-hook/opencode.ts
@@ -1,39 +1,37 @@
 /**
  * OpenCode hook adapter。
  *
- * OpenCode 通过 QuestionAsked 事件发起提问，payload 形状：
+ * OpenCode 自带原生 `question` 工具（= Claude AskUserQuestion 等价物），模型调用时服务端
+ * 发布 `question.asked` 事件并阻塞，等客户端把答案 POST 回 `/question/{id}/reply` 才解阻塞。
+ * botmux 的 OpenCode 插件（见 hook-installer.ts buildOpenCodePlugin）用 `event` 钩子拦截该
+ * 事件，把 questions 规范成下面这个 payload 喂给 `botmux hook opencode`，拿到 directive 里的
+ * `answers` 后再 POST 回 OpenCode：
  *   {
- *     hook_event_name: 'QuestionAsked',
- *     session_id: 'opencode-<id>',
- *     question_id: '<id>',      // 同 _opencode_request_id
- *     question_text: '问题文本（拍平版本）',
+ *     hook_event_name: 'question.asked',
+ *     question_id: 'que_<id>',
+ *     session_id: 'ses_<id>',
  *     tool_input: {
  *       questions: [
  *         {
  *           question: '问题文本',
  *           header: '可选标题',
  *           options: [{ label: '选项文本', description?: '描述' }, ...],
- *           multiple: boolean,
+ *           multiple?: boolean,
  *         }
  *       ]
  *     },
- *     _opencode_request_id: '<id>',
  *   }
  *
- * OpenCode 期望的 answer directive 形状（发往 /question/:id/reply）：
+ * formatAnswer 返回的 directive 形状（插件取其中的 `answers` 作为 reply body）：
  *   { type: 'answer', answers: string[][] }
  *   其中 answers[i] = 第 i 个问题选中的 label 数组；跳过的 question 填 ['']。
+ *   （自由文本作答即把该文字当作选中的 label —— OpenCode question 默认 custom:true 允许任意串。）
  *
- * 若没有结构化 questions（旧版兼容路径），改用：
- *   { type: 'answer', text: '自由文本' }
+ * passthrough（放行）= 空字符串：插件见 stdout 为空 → 不 reply，把问题留给 OpenCode
+ * 原生 picker（botmux web 终端里仍可人工作答）。绝不用空答案顶替这次提问。
  *
- * passthrough（放行）directive 形状：
- *   { type: 'answer', answers: [['']] }
- *   （每条 question 填空哨兵 ['']，让 OpenCode plugin 视为"未答"并继续）
- *
- * 参考来源：x-desktop-app/src/island/main/bridge/adapters/OpenCodeAdapter.ts
- *           x-desktop-app/src/island/main/bridge/BridgeServer.ts buildOpenCodeAnswerDirective
- *           x-desktop-app/src/island/hooks-install/opencode.ts postQuestionReply
+ * 机制已在 OpenCode 1.17.x 端到端实测确认（事件名 `question.asked`、reply 端点
+ * `POST /question/{id}/reply`、body `{ answers }`）。
  */
 
 import type { AskQuestion } from '../ask-types.js';
@@ -44,8 +42,8 @@ const openCodeAdapter: HookAskAdapter = {
     if (!payload || typeof payload !== 'object') return null;
     const p = payload as Record<string, unknown>;
 
-    // 只处理 QuestionAsked 事件
-    if (p.hook_event_name !== 'QuestionAsked') return null;
+    // 只处理 question.asked 事件（OpenCode 原生 question 工具触发，由插件规范后转发）
+    if (p.hook_event_name !== 'question.asked') return null;
 
     // 尝试从结构化 tool_input.questions 解析
     const toolInput = p.tool_input as

--- a/test/ask-hook-opencode.test.ts
+++ b/test/ask-hook-opencode.test.ts
@@ -13,7 +13,7 @@ function loadFixture(name: string): unknown {
 
 describe('OpenCode hook adapter', () => {
   describe('parseQuestions', () => {
-    it('QuestionAsked + 结构化 questions → 解析出 questions', () => {
+    it('question.asked + 结构化 questions → 解析出 questions', () => {
       const payload = loadFixture('opencode-ask-single.json');
       const parsed = opencode.parseQuestions(payload);
       expect(parsed).not.toBeNull();
@@ -46,12 +46,12 @@ describe('OpenCode hook adapter', () => {
       }
     });
 
-    it('旧版兼容：无 tool_input.questions → 使用 question_text', () => {
+    it('降级兼容：question.asked 无 tool_input.questions → 使用 question_text', () => {
       const payload = {
-        hook_event_name: 'QuestionAsked',
-        session_id: 'opencode-ses_x',
+        hook_event_name: 'question.asked',
+        session_id: 'ses_x',
         question_text: '你确定吗？',
-        _opencode_request_id: 'q_x',
+        question_id: 'que_x',
       };
       const parsed = opencode.parseQuestions(payload);
       expect(parsed).not.toBeNull();
@@ -60,17 +60,17 @@ describe('OpenCode hook adapter', () => {
       expect(parsed!.questions[0].options).toHaveLength(0);
     });
 
-    it('非 QuestionAsked 事件 → null', () => {
+    it('非 question.asked 事件 → null', () => {
       const payload = {
         hook_event_name: 'PermissionRequest',
         tool_name: 'Bash',
-        session_id: 'opencode-x',
+        session_id: 'ses_x',
       };
       expect(opencode.parseQuestions(payload)).toBeNull();
     });
 
     it('PreToolUse → null', () => {
-      expect(opencode.parseQuestions({ hook_event_name: 'PreToolUse', session_id: 'opencode-x' })).toBeNull();
+      expect(opencode.parseQuestions({ hook_event_name: 'PreToolUse', session_id: 'ses_x' })).toBeNull();
     });
 
     it('null / undefined → null', () => {
@@ -116,12 +116,12 @@ describe('OpenCode hook adapter', () => {
       expect(answers[1]).toEqual(['QA 团队']);
     });
 
-    it('旧版（无结构化 questions）→ { type: "answer", text: "..." }', () => {
+    it('降级（无结构化 questions）→ { type: "answer", text: "..." }', () => {
       const payload = {
-        hook_event_name: 'QuestionAsked',
-        session_id: 'opencode-ses_x',
+        hook_event_name: 'question.asked',
+        session_id: 'ses_x',
         question_text: '你确定吗？',
-        _opencode_request_id: 'q_x',
+        question_id: 'que_x',
       };
       const parsed = opencode.parseQuestions(payload)!;
       const directiveStr = opencode.formatAnswer([['确定']], parsed);
@@ -150,7 +150,7 @@ describe('OpenCode hook adapter', () => {
     });
 
     it('无 questions 结构 → 空字符串，不含 answer', () => {
-      const payload = { hook_event_name: 'QuestionAsked', session_id: 'opencode-x', question_text: 'ok?' };
+      const payload = { hook_event_name: 'question.asked', session_id: 'ses_x', question_text: 'ok?' };
       const out = opencode.passthrough(payload);
       expect(out).toBe('');
       expect(out).not.toContain('answer');

--- a/test/fixtures/opencode-ask-multi.json
+++ b/test/fixtures/opencode-ask-multi.json
@@ -1,8 +1,7 @@
 {
-  "hook_event_name": "QuestionAsked",
-  "session_id": "opencode-ses_abc123",
-  "question_id": "q_002",
-  "question_text": "选择测试范围？; 通知谁？",
+  "hook_event_name": "question.asked",
+  "session_id": "ses_abc123",
+  "question_id": "que_002",
   "tool_input": {
     "questions": [
       {
@@ -25,6 +24,5 @@
         "multiple": false
       }
     ]
-  },
-  "_opencode_request_id": "q_002"
+  }
 }

--- a/test/fixtures/opencode-ask-single.json
+++ b/test/fixtures/opencode-ask-single.json
@@ -1,8 +1,7 @@
 {
-  "hook_event_name": "QuestionAsked",
-  "session_id": "opencode-ses_abc123",
-  "question_id": "q_001",
-  "question_text": "选择部署策略？",
+  "hook_event_name": "question.asked",
+  "session_id": "ses_abc123",
+  "question_id": "que_001",
   "tool_input": {
     "questions": [
       {
@@ -15,6 +14,5 @@
         "multiple": false
       }
     ]
-  },
-  "_opencode_request_id": "q_001"
+  }
 }

--- a/test/hook-installer.test.ts
+++ b/test/hook-installer.test.ts
@@ -214,12 +214,21 @@ describe('installHook — opencode-plugin', () => {
     configPath = join(tmpDir, '.config', 'opencode', 'plugin', 'botmux-ask.js');
   });
 
-  it('插件用 argv 形式 spawnSync(cmd, args)，不拆 shell 字符串（Codex P1.2 回归）', () => {
+  it('插件用 argv 形式 spawn(cmd, args)，不拆 shell 字符串（Codex P1.2 回归）', () => {
     installHook('opencode', { configPath, format: 'opencode-plugin' }, hookCommand);
     const content = readFileSync(configPath, 'utf-8');
 
+    // 监听 question.asked 事件并经 event 钩子拦截（OpenCode 插件无专用 question 钩子）
     expect(content).toContain('question.asked');
-    expect(content).toContain('spawnSync(');
+    expect(content).toContain('event:');
+    // 插件导出必须是「函数」（OpenCode 要求；导出对象会报 "Plugin export is not a function"）
+    expect(content).toContain('export const BotmuxAsk = async');
+    // 异步 spawn（绝不能用 spawnSync 同步阻塞 OpenCode 单线程事件总线）
+    expect(content).toContain('spawn(');
+    expect(content).not.toContain('spawnSync(');
+    // 答案 POST 回 OpenCode 的 reply 端点解阻塞
+    expect(content).toContain('/question/');
+    expect(content).toContain('/reply');
     // args 以 JSON 数组嵌入，包含 hook 子命令与 cliId
     expect(content).toContain('"hook"');
     expect(content).toContain('"opencode"');


### PR DESCRIPTION
## 背景

此前 OpenCode 的 askUserQuestion 适配是照 `x-desktop-app` 猜的，**从未生效**（带 `TODO(dogfood)` 未验证标记）。实机排查发现两个根因：

1. 插件 `export default {对象}` → OpenCode 报 `Plugin export is not a function`，根本加载不了。
2. 监听的 `question.asked` 在 OpenCode 插件 API 里是**不存在的专用钩子**（可用钩子只有 `event`/`tool`/`permission.ask`/`tool.execute.*` 等）。

## 真实机制（OpenCode 1.17.x 实测）

- OpenCode 自带原生 **`question` 工具**（= Claude AskUserQuestion 等价物），参数结构 `{questions:[{question,header,options:[{label,description}],multiple}]}` 与 Claude 几乎一致，模型原生调用，无需注入。
- 它被调用时服务端发布 **`question.asked`** 事件并阻塞，等客户端把答案提交到 `/question/{id}/reply`（body `{answers: string[][]}`）后才解阻塞、返回给模型。

## 修法

- 插件改为**函数导出** + 通用 `event` 钩子按 `event.type === 'question.asked'` 拦截。
- 把 questions 规范后喂给 `botmux hook opencode`（**复用现有飞书问答链路**：daemon `/api/asks` → 飞书卡片 → 用户作答 → directive），拿到 `{answers}` 后回传。
- **回传走 OpenCode 注入的 client（`client._client`）而非裸 fetch**：OpenCode 是「单 server 多 worktree 实例」模型，client 自带 `x-opencode-directory` 头把 reply 路由到发起 question 的那个实例；裸 fetch 到 `localhost:4096` 在 daemon 里既连不上、又缺该头 → reply 打到错误实例 → 永远卡在 picker。（这是真机调试出的关键坑。）
- **异步 spawn**（非 spawnSync）+ fire-and-forget，避免阻塞 OpenCode 单线程事件总线（飞书作答可能长达 1h）。
- 诊断日志默认关闭，`BOTMUX_OPENCODE_ASK_DEBUG=1` 开启。

## 验证

- 单测：`ask-hook-opencode` / `hook-installer` 等全绿（事件名 `QuestionAsked` → `question.asked`，配套更新 fixtures）。
- 端到端（真实生成的插件 + 免费模型）：模型调 `question` → 飞书卡片 → 作答 → `CLIENT_POST status=200`、`question` 工具 `completed`、答案回传。
- **用户已在飞书真机验证通过。**

## 影响面

仅限 OpenCode ask 链路（`ask-hook/opencode` 适配器 + 生成的插件 + 配套测试），不动其他模块。