### PR TITLE
fix(lark): 入站消息按 message_id 持久化去重，挡住飞书跨重启/6h档重推

### DIFF
--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -27,6 +27,7 @@ import { buildGrantCard } from './card-builder.js';
 import { openPending, isThrottled, clearPending } from './grant-pending.js';
 import { localeForBot, t } from '../../i18n/index.js';
 import { chatQuotaKey, globalQuotaKey } from '../../services/grant-store.js';
+import { claimMessageOnce, _resetCacheForTest as _resetSeenMessagesForTest } from '../../services/seen-message-store.js';
 import { ensureDefaultOncallBound } from '../../services/oncall-store.js';
 import { resolveRegularGroupMode, resolveGroupMentionMode } from '../../services/chat-reply-mode-store.js';
 import { buildSummaryCommandPrompt, type SummaryChatKind, type SummaryCommandMatch, type SummaryCommandRuntimeContext } from './summary-command.js';
@@ -368,12 +369,16 @@ function claimEventOnce(key: string): boolean {
   return true;
 }
 
-function scheduleAckSafeEvent(key: string, work: () => Promise<void>, label: string): void {
-  if (!claimEventOnce(key)) {
+// `claim` defaults to the in-memory event-id claim; the message path passes a
+// persistent message_id claim (claimMessageOnce) so a daemon restart or the 6h
+// re-push tier can't replay an already-handled message. The claim MUST be fully
+// synchronous (see INVARIANT below) — both claimEventOnce and claimMessageOnce are.
+function scheduleAckSafeEvent(key: string, work: () => Promise<void>, label: string, claim: () => boolean = () => claimEventOnce(key)): void {
+  if (!claim()) {
     logger.info(`[event-dedupe] duplicate ${label} ignored: ${key}`);
     return;
   }
-  // INVARIANT: claimEventOnce + this setImmediate scheduling must stay fully
+  // INVARIANT: the claim above + this setImmediate scheduling must stay fully
   // synchronous (no await before we get here). WS events arrive in order and
   // setImmediate is FIFO, so same-anchor messages reach serializeByAnchor in
   // arrival order ONLY while nothing awaits ahead of the schedule. An await here
@@ -531,6 +536,9 @@ async function handleCardActionAckSafe(data: any, larkAppId: string, handlers: E
 export function __resetEventClaimsForTest(): void {
   eventClaims.clear();
   cardActionInFlight.clear();
+  // The message path now dedupes via the persistent seen-message store; clear its
+  // in-memory cache too so cases reusing the same message_id don't suppress each other.
+  _resetSeenMessagesForTest();
 }
 
 export async function getGroupStats(larkAppId: string, chatId: string): Promise<{ userCount: number; botCount: number }> {
@@ -1554,8 +1562,15 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
     'im.message.reaction.created_v1': () => {},
     'im.message.reaction.deleted_v1': () => {},
     'im.message.receive_v1': (data: any) => {
+      // Dedupe by message_id (stable across re-pushes / event_id re-mints /
+      // daemon restarts), persisted so the 6h re-push tier or a restart can't
+      // replay an already-handled message. Fall back to the in-memory event-id
+      // claim only when message_id is absent (shouldn't happen for real messages).
       const messageIdForKey = data?.message?.message_id;
-      const eventKey = `im.message.receive_v1:${larkAppId}:${eventIdForKey(data) ?? messageIdForKey ?? unkeyableEventKey()}`;
+      const eventKey = `im.message.receive_v1:${larkAppId}:${messageIdForKey ?? eventIdForKey(data) ?? unkeyableEventKey()}`;
+      const claim = messageIdForKey
+        ? () => claimMessageOnce(larkAppId, messageIdForKey)
+        : () => claimEventOnce(eventKey);
       scheduleAckSafeEvent(eventKey, async () => {
       try {
         const message = data.message;
@@ -1987,7 +2002,7 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
       } catch (err) {
         logger.error(`Error handling message event: ${err}`);
       }
-      }, 'message event');
+      }, 'message event', claim);
     },
   });
 

--- a/src/services/seen-message-store.ts
+++ b/src/services/seen-message-store.ts
@@ -1,0 +1,123 @@
+/**
+ * seen-message-store.ts — 跨重启的入站消息去重（按 message_id 持久化）。
+ *
+ * 为什么需要它：飞书长连接 (WS) 是 at-least-once，且每个事件只回**一帧** ACK——
+ * 一旦 ACK 没及时回达（主机内存压力把事件循环卡住超过 ~3s 预算 / 网络抖动把那帧
+ * ACK 丢了），飞书就按 15s / 5min / 1h / 6h（最多 4 次）重推同一条消息事件。
+ *
+ * event-dispatcher 原有的内存去重 (`eventClaims`, key=event_id, TTL 2h) 有两个缺口：
+ *   1. **纯内存** —— daemon 重启 / 崩溃循环 / 被 OOM 杀掉一次，去重表就清空，之后任何
+ *      重推都当新消息重新触发；
+ *   2. **2h TTL** —— 盖不住 6h 那一档重推。
+ * 此外它 key 用 `event_id ?? message_id`：`event_id` 标识「一次投递事件」，跨连接重投
+ * 可能变；`message_id` 标识「消息」本身，对同一条逻辑消息恒定不变。要做「同一条消息
+ * 只处理一次」，`message_id` 才是正确且充分的幂等键。
+ *
+ * 本 store 因此按 `message_id` **落盘**去重，TTL 8h 覆盖整条重推梯度 + 余量，重启后
+ * 仍能挡住旧消息重放。每个 larkAppId 一份文件（key 已隐含 app 维度，且多 bot 各自
+ * 独立、无跨进程写竞争）。
+ *
+ * 同步落盘的理由：`claimMessageOnce` 必须**全同步**返回（event-dispatcher 在 ACK 前的
+ * 同步段里调用它，且依赖「claim + setImmediate 之间不 await」来保住同 anchor 消息的
+ * 到达序）。落盘走 `atomicWriteFileSync`（tmp + rename，崩溃安全、无半截读），只在
+ * 见到**新** message_id 时写一次快照；重复命中直接返回、不写盘。聊天桥接是人类节奏，
+ * 每条新消息一次小快照写（个位数 ms）远在 3s ACK 预算之内。
+ */
+import { existsSync, readFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
+import { config } from '../config.js';
+import { logger } from '../utils/logger.js';
+
+/** 8h —— 覆盖飞书 15s/5min/1h/6h 的全部重推档，外加余量。 */
+const TTL_MS = 8 * 60 * 60_000;
+/** 有界：超限按最旧（Map 迭代序即插入序）淘汰，防文件无界增长。 */
+const MAX_ENTRIES = 5000;
+
+interface AppCache {
+  /** message_id → 过期时间戳（ms）。 */
+  map: Map<string, number>;
+  loaded: boolean;
+}
+const caches = new Map<string, AppCache>();
+
+function fileFor(larkAppId: string): string {
+  return join(config.session.dataDir, 'dedup', `seen-messages-${larkAppId}.json`);
+}
+
+/** 懒加载：进程内首次用到某 app 时从盘载入（已过期的条目载入时即丢弃）。 */
+function load(larkAppId: string): AppCache {
+  const existing = caches.get(larkAppId);
+  if (existing?.loaded) return existing;
+
+  const map = new Map<string, number>();
+  const file = fileFor(larkAppId);
+  try {
+    if (existsSync(file)) {
+      const parsed = JSON.parse(readFileSync(file, 'utf-8'));
+      // 兜底：只接受 `{ key: number }` 形态；数组/损坏内容当空表，绝不抛。
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const now = Date.now();
+        for (const [k, exp] of Object.entries(parsed)) {
+          if (typeof exp === 'number' && exp > now) map.set(k, exp);
+        }
+      }
+    }
+  } catch (err) {
+    logger.warn(`[seen-message-store] load failed (${file}): ${err}`);
+  }
+
+  const cache: AppCache = { map, loaded: true };
+  caches.set(larkAppId, cache);
+  return cache;
+}
+
+function persist(larkAppId: string, map: Map<string, number>): void {
+  const file = fileFor(larkAppId);
+  try {
+    mkdirSync(dirname(file), { recursive: true });
+    const obj: Record<string, number> = {};
+    for (const [k, v] of map) obj[k] = v;
+    atomicWriteFileSync(file, JSON.stringify(obj));
+  } catch (err) {
+    // 落盘失败不阻断处理：退化为「本进程内仍去重，但重启后这条不再被挡」，
+    // 与未持久化前的旧行为一致，绝不因写盘失败丢消息。
+    logger.warn(`[seen-message-store] persist failed (${file}): ${err}`);
+  }
+}
+
+/** 删过期 + 超限淘汰最旧，保持 map / 文件有界。 */
+function pruneAndCap(map: Map<string, number>, now: number): void {
+  for (const [k, exp] of map) if (exp <= now) map.delete(k);
+  if (map.size > MAX_ENTRIES) {
+    let drop = map.size - MAX_ENTRIES;
+    for (const k of map.keys()) {
+      map.delete(k);
+      if (--drop <= 0) break;
+    }
+  }
+}
+
+/**
+ * 首次见到此 `messageId` → 记录 + 落盘，返回 `true`（调用方应处理这条消息）。
+ * 8h 内重复命中（飞书重推 / at-least-once 重复）→ 返回 `false`（重投，应丢弃）。
+ * 空 `messageId` 无法去重 → 永远 `true`（绝不因缺 id 而误吞真实消息）。
+ */
+export function claimMessageOnce(larkAppId: string, messageId: string, now = Date.now()): boolean {
+  if (!messageId) return true;
+  const cache = load(larkAppId);
+  const exp = cache.map.get(messageId);
+  if (exp && exp > now) return false; // 命中未过期记录 → 重投
+  pruneAndCap(cache.map, now);
+  cache.map.set(messageId, now + TTL_MS);
+  persist(larkAppId, cache.map);
+  return true;
+}
+
+/**
+ * Test-only：清空进程内缓存（**不删盘**），用于模拟「daemon 重启」后从盘重新载入，
+ * 验证去重跨重启仍生效。
+ */
+export function _resetCacheForTest(): void {
+  caches.clear();
+}

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -487,6 +487,59 @@ describe('mentionsAnotherMember (ambient redirect carve-out)', () => {
   });
 });
 
+describe('im.message.receive_v1 — message_id dedupe (re-push protection)', () => {
+  let handlers: ReturnType<typeof makeHandlers>;
+
+  beforeEach(() => {
+    capturedHandlers = {};
+    __resetAnchorQueues();
+    __resetEventClaimsForTest();
+    _resetGrantPending();
+    mockReplyMessage.mockClear();
+    mockGetOwnerOpenId.mockReset().mockReturnValue(undefined);
+    mockGetCachedChatMode.mockReset().mockReturnValue(undefined);
+    setupBotState();
+    handlers = makeHandlers();
+    mockIsChatOncallBoundForAnyBot.mockReturnValue(false);
+    mockFindOncallChat.mockReturnValue(undefined);
+    startLarkEventDispatcher(MY_APP_ID, 'secret', handlers);
+  });
+
+  // A bot @mention in a thread routes to handleThreadReply exactly once per
+  // distinct message. We reuse that path to count how many times a (re-)delivered
+  // message is actually processed.
+  const mentionEvent = (messageId: string, eventId?: string) => {
+    const event: any = makeBotMessageEvent({
+      senderOpenId: OTHER_BOT_OPEN_ID,
+      content: JSON.stringify({ text: '@BotA check this' }),
+      rootId: 'root-thread-dedupe',
+      messageId,
+      mentions: [{ key: '@_bot_a', name: 'BotA', id: { open_id: MY_OPEN_ID } }],
+    });
+    if (eventId) event.event_id = eventId; // mirror SDK parse: header.event_id is spread onto data
+    return event;
+  };
+
+  it('suppresses a re-push with the SAME message_id but a NEW event_id (old event_id-keyed dedupe would not)', async () => {
+    await capturedHandlers['im.message.receive_v1'](mentionEvent('om_repush', 'ev_first'));
+    await flushEventWork();
+    // Feishu re-delivers the same message; event_id may differ on the new delivery.
+    await capturedHandlers['im.message.receive_v1'](mentionEvent('om_repush', 'ev_second'));
+    await flushEventWork();
+
+    expect(handlers.handleThreadReply).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT over-suppress: two distinct messages (distinct message_id) both process', async () => {
+    await capturedHandlers['im.message.receive_v1'](mentionEvent('om_a', 'ev_a'));
+    await flushEventWork();
+    await capturedHandlers['im.message.receive_v1'](mentionEvent('om_b', 'ev_b'));
+    await flushEventWork();
+
+    expect(handlers.handleThreadReply).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
   let handlers: ReturnType<typeof makeHandlers>;
 

--- a/test/seen-message-store.test.ts
+++ b/test/seen-message-store.test.ts
@@ -1,0 +1,94 @@
+/**
+ * seen-message-store: 按 message_id 的**持久化**去重。
+ *
+ * 重点验证它相对旧的内存去重 (event_id, 2h, 重启即清空) 补上的两个缺口：
+ *  - 跨「daemon 重启」仍去重（_resetCacheForTest 模拟重启从盘重载）；
+ *  - 8h TTL 盖住飞书 6h 那一档重推（旧的 2h 盖不住）。
+ *
+ * Run: pnpm vitest run test/seen-message-store.test.ts
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { claimMessageOnce, _resetCacheForTest } from '../src/services/seen-message-store.js';
+
+const APP = 'app-test';
+const HOUR = 60 * 60_000;
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), 'botmux-seen-msg-'));
+  vi.stubEnv('SESSION_DATA_DIR', dataDir);
+  _resetCacheForTest();
+});
+
+afterEach(() => {
+  _resetCacheForTest();
+  vi.unstubAllEnvs();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('seen-message-store', () => {
+  it('first claim processes, immediate duplicate is suppressed', () => {
+    expect(claimMessageOnce(APP, 'om_1')).toBe(true);
+    expect(claimMessageOnce(APP, 'om_1')).toBe(false);
+  });
+
+  it('distinct message_ids are independent', () => {
+    expect(claimMessageOnce(APP, 'om_a')).toBe(true);
+    expect(claimMessageOnce(APP, 'om_b')).toBe(true);
+  });
+
+  it('empty message_id can never be deduped (never silently drops)', () => {
+    expect(claimMessageOnce(APP, '')).toBe(true);
+    expect(claimMessageOnce(APP, '')).toBe(true);
+  });
+
+  it('persists the claim to disk under the app-namespaced file', () => {
+    claimMessageOnce(APP, 'om_disk');
+    expect(existsSync(join(dataDir, 'dedup', `seen-messages-${APP}.json`))).toBe(true);
+  });
+
+  it('CORE: dedup survives a daemon restart (reloads from disk)', () => {
+    expect(claimMessageOnce(APP, 'om_persist')).toBe(true);
+    _resetCacheForTest(); // 模拟 daemon 重启 / 崩溃循环：内存表清空，但盘上还在
+    expect(claimMessageOnce(APP, 'om_persist')).toBe(false);
+  });
+
+  it('CORE: suppresses the 6h re-push tier (beyond the old 2h TTL)', () => {
+    const t0 = 1_000_000_000_000;
+    expect(claimMessageOnce(APP, 'om_6h', t0)).toBe(true);
+    // 旧实现 2h TTL 在这里会漏；新实现 8h TTL 仍挡住。
+    expect(claimMessageOnce(APP, 'om_6h', t0 + 6 * HOUR)).toBe(false);
+  });
+
+  it('lets a genuinely old (>8h) re-arrival through after TTL expiry', () => {
+    const t0 = 1_000_000_000_000;
+    expect(claimMessageOnce(APP, 'om_ttl', t0)).toBe(true);
+    expect(claimMessageOnce(APP, 'om_ttl', t0 + 8 * HOUR + 1)).toBe(true);
+  });
+
+  it('expired entries are dropped on reload, not resurrected', () => {
+    const t0 = 1_000_000_000_000;
+    claimMessageOnce(APP, 'om_exp', t0);
+    _resetCacheForTest();
+    // 重载时已过期 → 当作没见过 → 放行。
+    expect(claimMessageOnce(APP, 'om_exp', t0 + 9 * HOUR)).toBe(true);
+  });
+
+  it('different apps with the same message_id do not collide', () => {
+    expect(claimMessageOnce('app-x', 'om_same')).toBe(true);
+    expect(claimMessageOnce('app-y', 'om_same')).toBe(true);
+    expect(claimMessageOnce('app-x', 'om_same')).toBe(false);
+  });
+
+  it('a corrupt store file is treated as empty (never throws, never drops)', () => {
+    claimMessageOnce(APP, 'om_seed'); // create the file
+    _resetCacheForTest();
+    // 覆写成损坏内容
+    const file = join(dataDir, 'dedup', `seen-messages-${APP}.json`);
+    writeFileSync(file, 'not json at all');
+    expect(claimMessageOnce(APP, 'om_after_corrupt')).toBe(true);
+  });
+});


### PR DESCRIPTION
## 背景 / 现象

mac 上的 bot（czy）反复收到**几天前的旧消息被重新触发**——同一条消息最多被处理 4 次，回复刷屏（话题里能看到 bot 自己都在说"（飞书重发的旧消息）…"）。用户没在中间发任何消息。相关旧 issue：#111。

## 根因

飞书长连接 (WS) 是 **at-least-once**，且每个事件只回**一帧** ACK。一旦 ACK 没及时回达——主机内存压力把事件循环卡住超过 ~3s 预算（≠ 15s，15s 只是第一次*重推间隔*）/ 网络抖动把那帧 ACK 丢了——飞书就按 **15s / 5min / 1h / 6h（最多 4 次）** 重推同一条消息事件。这与现场"同一条 4 次"完全吻合。

原有内存去重 (`eventClaims`，key=`event_id ?? message_id`，TTL 2h) 有两个缺口：
1. **纯内存** —— daemon 重启 / 崩溃循环 / 被 OOM 杀一次就清空，之后任何重推都当新消息重新触发；
2. **2h TTL** —— 盖不住 6h 那一档重推。

且 key 优先用 `event_id`：`event_id` 标识"一次投递事件"，跨连接重投可能变；`message_id` 标识"消息"本身、对同一条逻辑消息恒定。要做"同一条消息只处理一次"，**message_id 才是正确且充分的幂等键**。

> 工程立场：飞书 at-least-once + 跨网络丢一帧 ACK 是物理现实，堵不住；正解是让**处理幂等**。

## 改动

- **新增 `src/services/seen-message-store.ts`**：按 `message_id` **落盘**去重。
  - `atomicWriteFileSync`（tmp+rename，崩溃安全、无半截读）；**同步**落盘，保住 event-dispatcher「claim + setImmediate 之间不 await」的同步不变量，且 ACK 前完成（聊天人类节奏，单条小快照写个位数 ms，远在 3s 预算内）。
  - **TTL 8h** 覆盖整条 15s/5min/1h/6h 重推梯度 + 余量。
  - per-`larkAppId` 文件隔离；有界（prune 过期 + 超 5000 淘汰最旧）；corrupt/缺失文件兜底为空表，**绝不抛、绝不误吞真实消息**（落盘失败退化为旧的内存级行为）。
- **`im.message.receive_v1`** 改为优先按 `message_id` 持久 claim（仅当缺 `message_id` 才回退到 `event_id` 内存 claim）；`scheduleAckSafeEvent` 支持注入 `claim` thunk（默认仍是原内存 event-id claim，其它事件类型不受影响）。

## 测试

- `test/seen-message-store.test.ts`（新增，10 例）：首见/重复、跨**重启**（reload 自盘）仍去重、**6h 档**（>旧 2h TTL）仍挡、TTL 过期放行、过期条目重载不复活、多 app 隔离、corrupt 文件兜底、空 message_id 永不吞。
- `test/event-dispatcher.test.ts`（+2 例）：同 `message_id` 换 `event_id` 重投被挡（旧 event_id-keyed 去重挡不住）、不同 `message_id` 不误吞。
- 全量单测：本改动**零新增失败**（event-dispatcher 171 ✅ / seen-message-store 10 ✅；仓库 base 上 `terminal-url`/`recall-frozen-cards`/`e2e-browser` 的失败为环境/构建态预存，与本改动无关，已 stash 对比确认）。
- `tsc --noEmit` 干净；`pnpm build` 通过。

## 留作后续（本 PR 未做，对应当时讨论的 ②③）

- `message.create_time` 过旧消息只告警不触发（纵深防御）；
- 在出问题的 mac 上加一行诊断日志（打 `event_id / message_id / create_time / 间隔 / 是否重启`），抓一次真实重复以**坐实假设**：飞书同一条消息重推时 `message_id` 恒定（本 PR 按飞书数据模型假定，store 测试 + 逻辑 demo 支撑）。