### PR TITLE
feat(lark): add experimental chat bot discovery

### DIFF
--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -579,6 +579,11 @@ const BOTMUX_INJECTED_ENV_KEYS = [
   'BOTMUX_LARK_APP_ID',
   'BOTMUX_ROOT_MESSAGE_ID',
   'BOTMUX_TURN_ID',
+  // Experimental Lark chat bot discovery. The daemon injects a canonical
+  // true/false value so `botmux bots list` inside long-lived panes matches the
+  // daemon's `<available_bots>` behavior instead of reading stale rcfile/tmux env.
+  'BOTMUX_LARK_LIST_BOTS_API_ENABLED',
+  'BOTMUX_LARK_LIST_BOTS_API_TIMEOUT_MS',
   // Claude Code 2.1.x resume-summary 菜单的抑制阈值（issue #62）。worker 为
   // claude-code 注入一个极大值绕过菜单；只有进了这条白名单才会被透传进 tmux pane。
   'CLAUDE_CODE_RESUME_TOKEN_THRESHOLD',

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,24 @@ function detectDefaultBackend(): Exclude<BackendType, 'herdr'> {
 // wrong directory. Mirrors the web/dashboard externalHost getters below.
 const packagedDataDir = new URL('../data', import.meta.url).pathname;
 
+export interface ChatBotDiscoveryConfig {
+  listBotsApiEnabled: boolean;
+  listBotsApiTimeoutMs: number;
+}
+
+/**
+ * Experimental current-chat bot discovery via Lark `/members/bots`.
+ *
+ * The endpoint is useful but not public API, so it must stay explicitly opt-in
+ * and every caller must keep the legacy discovery path as fallback.
+ */
+export function resolveChatBotDiscoveryConfig(env: NodeJS.ProcessEnv = process.env): ChatBotDiscoveryConfig {
+  return {
+    listBotsApiEnabled: (env.BOTMUX_LARK_LIST_BOTS_API_ENABLED ?? '').toLowerCase() === 'true',
+    listBotsApiTimeoutMs: Number(env.BOTMUX_LARK_LIST_BOTS_API_TIMEOUT_MS) || 3_000,
+  };
+}
+
 export const config = {
   lark: {
     appId: process.env.LARK_APP_ID ?? '',
@@ -171,6 +189,7 @@ export const config = {
       catch { return {}; }
     })() as Record<string, unknown>,
   },
+  chatBotDiscovery: resolveChatBotDiscoveryConfig(),
 };
 
 // allowedUsers is mutable — daemon resolves email prefixes to open_ids at startup

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -79,6 +79,11 @@ function getLarkErrorCode(err: any): number | undefined {
 }
 
 const LARK_CODE_MESSAGE_WITHDRAWN = 230011;
+// Capability cache for the undocumented `/members/bots` endpoint. It prevents
+// repeated hits while the tenant/gateway cannot serve the API, but per-request
+// business errors (bad chat id, permission denial) must not poison other chats.
+const LIST_BOTS_API_FAILURE_TTL_MS = 3 * 60 * 1000;
+const listBotsApiFailures = new Map<string, { reason: string; expiresAt: number }>();
 
 /**
  * Send a message to a chat.
@@ -1198,6 +1203,96 @@ export type ChatBotMember = {
   mentionSource: 'cross-ref' | 'self' | 'observed' | 'fallback';
 };
 
+type ChatBotListApiItem = { botId: string; botName: string };
+type ChatBotListApiResult =
+  | { ok: true; items: ChatBotListApiItem[] }
+  | { ok: false; reason: string; cacheable: boolean };
+
+function promiseWithTimeout<T>(p: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return p;
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+  });
+  return Promise.race([p, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+async function listChatBotsViaMembersBots(
+  larkAppId: string,
+  chatId: string,
+  timeoutMs: number,
+): Promise<ChatBotListApiResult> {
+  try {
+    const c = getBotClient(larkAppId);
+    const res = await promiseWithTimeout(
+      larkGet(c, `/open-apis/im/v1/chats/${encodeURIComponent(chatId)}/members/bots`),
+      timeoutMs,
+      'list chat bot members',
+    );
+    if (res?.code !== 0) return { ok: false, reason: `code=${res?.code ?? 'unknown'} msg=${res?.msg ?? ''}`, cacheable: false };
+    const rawItems = res?.data?.items;
+    if (!Array.isArray(rawItems)) return { ok: false, reason: 'invalid_items', cacheable: true };
+    const items = rawItems
+      .map((it: any) => ({
+        botId: String(it?.bot_id ?? '').trim(),
+        botName: String(it?.bot_name ?? '').trim(),
+      }))
+      .filter((it: ChatBotListApiItem) => it.botId && it.botName);
+    return { ok: true, items };
+  } catch (err: any) {
+    return { ok: false, reason: err?.message ?? String(err), cacheable: true };
+  }
+}
+
+// `/members/bots` returns the observer-scoped mention handle (`bot_id`) and
+// display name only. Bind botmux identity only when a configured bot has already
+// been proven to be in this chat and the name match is unique.
+function buildChatBotsFromMembersBotsApi(
+  items: ChatBotListApiItem[],
+  currentLarkAppId: string,
+  configured: ChatBotMember[],
+  crossRef: Map<string, string>,
+  norm: (s: string) => string,
+): ChatBotMember[] {
+  const configuredByName = new Map<string, ChatBotMember[]>();
+  for (const row of configured) {
+    const key = norm(row.displayName);
+    const arr = configuredByName.get(key);
+    if (arr) arr.push(row);
+    else configuredByName.set(key, [row]);
+  }
+
+  const out: ChatBotMember[] = [];
+  const seenOpenIds = new Set<string>();
+  for (const item of items) {
+    if (seenOpenIds.has(item.botId)) continue;
+    const key = norm(item.botName);
+    const matches = configuredByName.get(key) ?? [];
+    const bound = matches.length === 1 ? matches[0] : undefined;
+    const crossHit = crossRef.get(key);
+    const isSelf = bound?.larkAppId === currentLarkAppId;
+    const mentionSource: ChatBotMember['mentionSource'] = crossHit === item.botId
+      ? 'cross-ref'
+      : (isSelf ? 'self' : 'observed');
+
+    out.push({
+      larkAppId: bound?.larkAppId ?? '',
+      openId: item.botId,
+      name: bound?.name ?? item.botName,
+      displayName: item.botName,
+      source: bound ? 'configured' : 'introduce',
+      capability: bound?.capability,
+      hasTeamRole: bound?.hasTeamRole ?? false,
+      mentionable: true,
+      mentionSource,
+    });
+    seenOpenIds.add(item.botId);
+  }
+  return out;
+}
+
 export async function listChatBotMembers(larkAppId: string, chatId: string): Promise<ChatBotMember[]> {
   // Single name-key normalizer used for EVERY cross-source name match below
   // (cross-ref ⇄ bots-info ⇄ observed). Trim-only: strips incidental leading/
@@ -1269,6 +1364,27 @@ export async function listChatBotMembers(larkAppId: string, chatId: string): Pro
     }),
   );
   const configured: ChatBotMember[] = configuredResults.filter((r): r is ChatBotMember => r !== null);
+
+  const discovery = config.chatBotDiscovery;
+  if (discovery?.listBotsApiEnabled) {
+    const failureKey = larkAppId;
+    const cachedFailure = listBotsApiFailures.get(failureKey);
+    const now = Date.now();
+    if (cachedFailure && cachedFailure.expiresAt > now) {
+      logger.debug(`members/bots disabled by recent failure for ${larkAppId}: ${cachedFailure.reason}`);
+    } else {
+      if (cachedFailure) listBotsApiFailures.delete(failureKey);
+      const apiResult = await listChatBotsViaMembersBots(larkAppId, chatId, discovery.listBotsApiTimeoutMs);
+      if (apiResult.ok) {
+        listBotsApiFailures.delete(failureKey);
+        return buildChatBotsFromMembersBotsApi(apiResult.items, larkAppId, configured, crossRef, norm);
+      }
+      if (apiResult.cacheable) {
+        listBotsApiFailures.set(failureKey, { reason: apiResult.reason, expiresAt: now + LIST_BOTS_API_FAILURE_TTL_MS });
+      }
+      logger.warn(`members/bots failed for ${larkAppId} in ${chatId}; falling back to legacy bot discovery: ${apiResult.reason}`);
+    }
+  }
 
   // Merge observed entries (from /introduce), scoped to the caller's observer
   // app so open_ids match how THIS daemon should @-mention them (open_id is

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -1248,7 +1248,12 @@ async function listChatBotsViaMembersBots(
 
 // `/members/bots` returns the observer-scoped mention handle (`bot_id`) and
 // display name only. Bind botmux identity only when a configured bot has already
-// been proven to be in this chat and the name match is unique.
+// been proven to be in this chat and the name match is unique, OR the item's
+// observer-scoped `bot_id` equals a configured row's already-reliable open_id —
+// notably the observer's own bot, whose `/members/bots` `bot_id` IS its self-view
+// open_id. The open_id key guards against display-name drift between
+// `/members/bots` and bots-info.json (e.g. self leaking into <available_bots> as
+// a mentionable peer when its name no longer matches).
 function buildChatBotsFromMembersBotsApi(
   items: ChatBotListApiItem[],
   currentLarkAppId: string,
@@ -1257,11 +1262,13 @@ function buildChatBotsFromMembersBotsApi(
   norm: (s: string) => string,
 ): ChatBotMember[] {
   const configuredByName = new Map<string, ChatBotMember[]>();
+  const configuredByOpenId = new Map<string, ChatBotMember>();
   for (const row of configured) {
     const key = norm(row.displayName);
     const arr = configuredByName.get(key);
     if (arr) arr.push(row);
     else configuredByName.set(key, [row]);
+    if (row.openId) configuredByOpenId.set(row.openId, row);
   }
 
   const out: ChatBotMember[] = [];
@@ -1270,7 +1277,7 @@ function buildChatBotsFromMembersBotsApi(
     if (seenOpenIds.has(item.botId)) continue;
     const key = norm(item.botName);
     const matches = configuredByName.get(key) ?? [];
-    const bound = matches.length === 1 ? matches[0] : undefined;
+    const bound = (matches.length === 1 ? matches[0] : undefined) ?? configuredByOpenId.get(item.botId);
     const crossHit = crossRef.get(key);
     const isSelf = bound?.larkAppId === currentLarkAppId;
     const mentionSource: ChatBotMember['mentionSource'] = crossHit === item.botId

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -92,7 +92,7 @@ import { detectCliUsageLimit, usageLimitStateKey, type CliUsageLimitState } from
 import { uploadImageBuffer } from './utils/lark-upload.js';
 import { redactChildEnv } from './utils/child-env.js';
 import { decideSubmitConfirmationAction, type SubmitActivityEvidence } from './services/submit-confirmation.js';
-import { config } from './config.js';
+import { config, resolveChatBotDiscoveryConfig } from './config.js';
 import * as sessionStore from './services/session-store.js';
 import * as pty from 'node-pty';
 import { createHash } from 'node:crypto';
@@ -4197,6 +4197,11 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   childEnv.BOTMUX_CHAT_ID = cfg.chatId;
   childEnv.BOTMUX_LARK_APP_ID = cfg.larkAppId;
   childEnv.BOTMUX_ROOT_MESSAGE_ID = cfg.rootMessageId;
+  // Inject an explicit false when disabled so child `botmux bots list` cannot
+  // drift from the daemon because of stale rcfile/tmux environment.
+  const chatBotDiscovery = resolveChatBotDiscoveryConfig();
+  childEnv.BOTMUX_LARK_LIST_BOTS_API_ENABLED = chatBotDiscovery.listBotsApiEnabled ? 'true' : 'false';
+  childEnv.BOTMUX_LARK_LIST_BOTS_API_TIMEOUT_MS = String(chatBotDiscovery.listBotsApiTimeoutMs);
   // Initial value only; long-lived panes get the latest turn via the JSON pid marker.
   if (cfg.turnId) childEnv.BOTMUX_TURN_ID = cfg.turnId;
   if (injectClaudeSandbox) childEnv.IS_SANDBOX = '1';

--- a/test/list-chat-bot-members.test.ts
+++ b/test/list-chat-bot-members.test.ts
@@ -3,12 +3,56 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const state = vi.hoisted(() => ({ dataDir: '' }));
+const hoisted = vi.hoisted(() => {
+  const state = {
+    dataDir: '',
+    listBotsApiEnabled: false,
+    listBotsApiTimeoutMs: 3000,
+    listBotsApiItems: undefined as Array<{ bot_id: string; bot_name: string }> | undefined,
+    listBotsApiError: undefined as Error | undefined,
+    listBotsApiCode: 0,
+    listBotsApiCalls: 0,
+  };
+
+  class MockClient {
+    appId: string;
+    im: any;
+
+    constructor(opts: { appId: string }) {
+      this.appId = opts.appId;
+      this.im = { v1: {} };
+    }
+
+    // isInChat and members/bots now route through client.request().
+    async request({ url }: { url: string }) {
+      if (url.includes('/members/bots')) {
+        state.listBotsApiCalls++;
+        if (state.listBotsApiError) throw state.listBotsApiError;
+        return {
+          code: state.listBotsApiCode,
+          msg: state.listBotsApiCode === 0 ? 'success' : 'business error',
+          data: { items: state.listBotsApiItems ?? [] },
+        };
+      }
+      if (url.includes('/members/is_in_chat')) {
+        return { code: 0, data: { is_in_chat: true } };
+      }
+      throw new Error(`unexpected GET url in mock: ${url}`);
+    }
+  }
+
+  return { state, MockClient };
+});
+const { state, MockClient } = hoisted;
 
 vi.mock('../src/config.js', () => ({
   config: {
     session: {
       get dataDir() { return state.dataDir; },
+    },
+    chatBotDiscovery: {
+      get listBotsApiEnabled() { return state.listBotsApiEnabled; },
+      get listBotsApiTimeoutMs() { return state.listBotsApiTimeoutMs; },
     },
   },
 }));
@@ -26,35 +70,121 @@ vi.mock('../src/bot-registry.js', () => ({
     { larkAppId: 'cli_self', larkAppSecret: 's1', cliId: 'codex' },
     { larkAppId: 'cli_peer', larkAppSecret: 's2', cliId: 'codex' },
   ]),
+  getBotClient: vi.fn((appId: string) => new MockClient({ appId })),
 }));
 
 vi.mock('@larksuiteoapi/node-sdk', () => ({
   LoggerLevel: { error: 4 },
-  Client: class MockClient {
-    appId: string;
-    im: any;
-
-    constructor(opts: { appId: string }) {
-      this.appId = opts.appId;
-      this.im = { v1: {} };
-    }
-
-    // isInChat now routes through client.request() (empty-GET-body 411 guard).
-    async request({ url }: { url: string }) {
-      if (url.includes('/members/is_in_chat')) {
-        return { code: 0, data: { is_in_chat: true } };
-      }
-      throw new Error(`unexpected GET url in mock: ${url}`);
-    }
-  },
+  Client: MockClient,
 }));
 
 describe('listChatBotMembers', () => {
   afterEach(() => {
+    vi.useRealTimers();
     if (state.dataDir) {
       rmSync(state.dataDir, { recursive: true, force: true });
       state.dataDir = '';
     }
+    state.listBotsApiEnabled = false;
+    state.listBotsApiTimeoutMs = 3000;
+    state.listBotsApiItems = undefined;
+    state.listBotsApiError = undefined;
+    state.listBotsApiCode = 0;
+    state.listBotsApiCalls = 0;
+  });
+
+  it('does not call /members/bots when the experimental flag is disabled', async () => {
+    state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-list-chat-bots-'));
+    writeFileSync(join(state.dataDir, 'bots-info.json'), JSON.stringify([
+      { larkAppId: 'cli_self', botOpenId: 'ou_self', botName: 'BotSelf', cliId: 'codex' },
+    ]));
+
+    const { listChatBotMembers } = await import('../src/im/lark/client.js');
+    const bots = await listChatBotMembers('cli_self', 'oc_chat');
+
+    expect(state.listBotsApiCalls).toBe(0);
+    expect(bots.some(b => b.larkAppId === 'cli_self')).toBe(true);
+  });
+
+  it('uses /members/bots as current-chat truth when enabled and does not resurrect stale observed rows', async () => {
+    state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-list-chat-bots-'));
+    state.listBotsApiEnabled = true;
+    state.listBotsApiItems = [
+      { bot_id: 'ou_self_from_api', bot_name: 'BotSelf' },
+      { bot_id: 'ou_peer_from_api', bot_name: 'BotPeer' },
+    ];
+    writeFileSync(join(state.dataDir, 'bots-info.json'), JSON.stringify([
+      { larkAppId: 'cli_self', botOpenId: 'ou_self_self_view', botName: 'BotSelf', cliId: 'codex' },
+      { larkAppId: 'cli_peer', botOpenId: 'ou_peer_self_view', botName: 'BotPeer', cliId: 'codex' },
+    ]));
+    const now = Date.now();
+    writeFileSync(join(state.dataDir, 'observed-bots-cli_self-oc_chat.json'), JSON.stringify({
+      ou_stale_peer: { name: 'StalePeer', source: 'introduce', firstSeenAt: now, lastSeenAt: now },
+    }));
+
+    const { listChatBotMembers } = await import('../src/im/lark/client.js');
+    const bots = await listChatBotMembers('cli_self', 'oc_chat');
+
+    expect(state.listBotsApiCalls).toBe(1);
+    expect(bots.map(b => b.openId)).toEqual(['ou_self_from_api', 'ou_peer_from_api']);
+    expect(bots.find(b => b.openId === 'ou_stale_peer')).toBeUndefined();
+    expect(bots.find(b => b.openId === 'ou_peer_from_api')).toMatchObject({
+      larkAppId: 'cli_peer',
+      source: 'configured',
+      mentionable: true,
+      mentionSource: 'observed',
+    });
+  });
+
+  it('treats /members/bots items: [] as authoritative and does not fall back to observed rows', async () => {
+    state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-list-chat-bots-'));
+    state.listBotsApiEnabled = true;
+    state.listBotsApiItems = [];
+    const now = Date.now();
+    writeFileSync(join(state.dataDir, 'observed-bots-cli_self-oc_chat.json'), JSON.stringify({
+      ou_external: { name: 'External', source: 'introduce', firstSeenAt: now, lastSeenAt: now },
+    }));
+
+    const { listChatBotMembers } = await import('../src/im/lark/client.js');
+    const bots = await listChatBotMembers('cli_self', 'oc_chat');
+
+    expect(state.listBotsApiCalls).toBe(1);
+    expect(bots).toEqual([]);
+  });
+
+  it('caches /members/bots failures for 3 minutes before retrying and falls back to legacy discovery', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-30T00:00:00Z'));
+    state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-list-chat-bots-'));
+    state.listBotsApiEnabled = true;
+    state.listBotsApiError = new Error('gateway unavailable');
+    writeFileSync(join(state.dataDir, 'bots-info.json'), JSON.stringify([
+      { larkAppId: 'cli_self', botOpenId: 'ou_self', botName: 'BotSelf', cliId: 'codex' },
+    ]));
+
+    const { listChatBotMembers } = await import('../src/im/lark/client.js');
+    await listChatBotMembers('cli_self', 'oc_chat');
+    await listChatBotMembers('cli_self', 'oc_chat');
+
+    expect(state.listBotsApiCalls).toBe(1);
+    vi.setSystemTime(new Date('2026-06-30T00:03:01Z'));
+    await listChatBotMembers('cli_self', 'oc_chat');
+    expect(state.listBotsApiCalls).toBe(2);
+  });
+
+  it('does not cache non-zero /members/bots business errors as capability failures', async () => {
+    state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-list-chat-bots-'));
+    state.listBotsApiEnabled = true;
+    state.listBotsApiCode = 99992356;
+    writeFileSync(join(state.dataDir, 'bots-info.json'), JSON.stringify([
+      { larkAppId: 'cli_self', botOpenId: 'ou_self', botName: 'BotSelf', cliId: 'codex' },
+    ]));
+
+    const { listChatBotMembers } = await import('../src/im/lark/client.js');
+    await listChatBotMembers('cli_self', 'oc_bad');
+    await listChatBotMembers('cli_self', 'oc_bad');
+
+    expect(state.listBotsApiCalls).toBe(2);
   });
 
   it('returns larkAppId + source="configured" so callers can identify self and provenance', async () => {

--- a/test/list-chat-bot-members.test.ts
+++ b/test/list-chat-bot-members.test.ts
@@ -136,6 +136,31 @@ describe('listChatBotMembers', () => {
     });
   });
 
+  it('binds self by open_id when /members/bots display name drifts from bots-info, so self is not surfaced as a peer', async () => {
+    state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-list-chat-bots-'));
+    state.listBotsApiEnabled = true;
+    // /members/bots returns self under a drifted display name, but its
+    // observer-scoped bot_id is self's self-view open_id (observer == self).
+    state.listBotsApiItems = [
+      { bot_id: 'ou_self', bot_name: 'BotSelf Renamed' },
+    ];
+    writeFileSync(join(state.dataDir, 'bots-info.json'), JSON.stringify([
+      { larkAppId: 'cli_self', botOpenId: 'ou_self', botName: 'BotSelf', cliId: 'codex' },
+    ]));
+
+    const { listChatBotMembers } = await import('../src/im/lark/client.js');
+    const bots = await listChatBotMembers('cli_self', 'oc_chat');
+
+    expect(state.listBotsApiCalls).toBe(1);
+    // Bound to self via open_id despite the name mismatch → caller can exclude
+    // self by larkAppId instead of leaking it into <available_bots>.
+    expect(bots.find(b => b.openId === 'ou_self')).toMatchObject({
+      larkAppId: 'cli_self',
+      source: 'configured',
+      mentionSource: 'self',
+    });
+  });
+
   it('treats /members/bots items: [] as authoritative and does not fall back to observed rows', async () => {
     state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-list-chat-bots-'));
     state.listBotsApiEnabled = true;

--- a/test/tmux-backend-env.test.ts
+++ b/test/tmux-backend-env.test.ts
@@ -91,6 +91,18 @@ describe('buildBotmuxEnvAssignments()', () => {
     expect(buildBotmuxEnvAssignments({ BOTMUX: '1' }).some(s => s.startsWith('CJADK_INTERACTIVE='))).toBe(false);
   });
 
+  it('forwards list-bots API discovery flags so CLI bots list matches daemon behavior', () => {
+    const out = buildBotmuxEnvAssignments({
+      BOTMUX: '1',
+      BOTMUX_LARK_LIST_BOTS_API_ENABLED: 'true',
+      BOTMUX_LARK_LIST_BOTS_API_TIMEOUT_MS: '3000',
+      PATH: '/usr/bin',
+    });
+    expect(out).toContain('BOTMUX_LARK_LIST_BOTS_API_ENABLED=true');
+    expect(out).toContain('BOTMUX_LARK_LIST_BOTS_API_TIMEOUT_MS=3000');
+    expect(out).not.toContain('PATH=/usr/bin');
+  });
+
   it('skips entries whose value is undefined (e.g. IS_SANDBOX outside root mode)', () => {
     const out = buildBotmuxEnvAssignments({
       BOTMUX: '1',


### PR DESCRIPTION
## Summary

Add an experimental Lark chat bot discovery path via `/members/bots`, while keeping the existing legacy discovery flow as fallback.

## Changes

- add `chatBotDiscovery` config parsing from env
- support experimental `/members/bots` bot discovery in Lark client
- cache capability-level `/members/bots` failures for 3 minutes to avoid repeated calls on unsupported tenants/gateways
- do not cache per-chat business errors; those still fall back to legacy discovery
- inject explicit discovery env flags into tmux worker child env so CLI behavior stays consistent with daemon behavior
- add unit tests for disabled mode, enabled mode, empty result, failure cache, and business-error fallback

## Notes

- this feature is explicitly opt-in
- legacy bot discovery remains the fallback path
- `/members/bots` is treated as current-chat truth when enabled and available

## Testing

- `./node_modules/.bin/vitest run --project unit test/list-chat-bot-members.test.ts test/tmux-backend-env.test.ts`