### PR TITLE
fix(worker): CoCo slash 命令逐字符敲入，修复 /model 被当对话发给模型

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -235,7 +235,12 @@ export function parseForceTopicInvocation(content: string): { prompt: string } |
  *  daemon; otherwise discussion text such as `/adopt <pane>` can accidentally
  *  trigger real daemon actions. */
 export function parseSlashCommandInvocation(content: string): SlashCommandInvocation | null {
-  const trimmed = content.trimStart();
+  // trim BOTH ends: a trailing newline/space rides into the returned `content`
+  // and, for a passthrough command relayed verbatim to the CLI (raw_input), gets
+  // typed as a literal trailing newline — which breaks the CLI's slash-command
+  // detection (it sees a multi-line message, not a `/cmd`). Internal newlines for
+  // MULTILINE_COMMANDS are preserved (trim only touches the ends).
+  const trimmed = content.trim();
   if (!trimmed.startsWith('/')) return null;
 
   const lines = trimmed.split(/\r?\n/);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -294,6 +294,13 @@ function releaseReadyGate(reason: string): void {
 const STARTUP_CMD_QUIET_MS = 500;
 const STARTUP_CMD_CAP_MS = 4_000;
 
+/** Inter-keystroke spacing when typing a slash command into CoCo char-by-char.
+ *  CoCo (Trae CLI, Ink TUI) treats "several bytes delivered in one PTY read" as a
+ *  paste, which skips command mode + the slash picker — so each char must land as
+ *  its own keystroke. 40ms is comfortably above CoCo's coalescing window (verified
+ *  against Trae CLI 0.120.45) while keeping a short command sub-second. */
+const COCO_SLASH_TYPE_THROTTLE_MS = 40;
+
 /** Type one literal input LINE into the CLI exactly like a passthrough slash
  *  command: raw text → a 200ms beat (so the TUI's slash-command picker registers
  *  the match before submit) → a separate Enter. Non-TUI backends fall back to a
@@ -301,6 +308,29 @@ const STARTUP_CMD_CAP_MS = 4_000;
  *  so both stay in lockstep. */
 async function sendRawCommandLine(be: NonNullable<typeof backend>, content: string): Promise<void> {
   if ('sendText' in be && 'sendSpecialKeys' in be) {
+    if (lastInitConfig?.cliId === 'coco') {
+      // CoCo (Trae CLI, Ink TUI) detects "several bytes in one PTY read = paste",
+      // so a one-shot sendText('/model') lands as PASTED text: command mode + the
+      // slash picker never activate and the trailing Enter submits `/model` to the
+      // model (the "/model 多一个换行" bug). Fix: type char-by-char (throttled) so
+      // each char is a distinct keystroke that opens command mode, and append ONE
+      // trailing space to a bare command so the suggestion popup is dismissed.
+      // Without that dismissal the popup captures the first Enter (CoCo then needs
+      // two), and for an interactive command like /model — which opens a model
+      // selector — a stray second Enter would confirm whatever model is highlighted.
+      // Popup gone ⇒ exactly one Enter executes (/model just opens the selector and
+      // waits). trim() first so a trailing newline carried from the Lark message
+      // isn't typed as a literal newline that re-breaks command detection.
+      const cmd = content.trim();
+      const typed = cmd.includes(' ') ? cmd : `${cmd} `;
+      for (const ch of typed) {
+        (be as any).sendText(ch);
+        await new Promise(r => setTimeout(r, COCO_SLASH_TYPE_THROTTLE_MS));
+      }
+      await new Promise(r => setTimeout(r, 200));
+      (be as any).sendSpecialKeys('Enter');
+      return;
+    }
     (be as any).sendText(content);
     await new Promise(r => setTimeout(r, 200));
     (be as any).sendSpecialKeys('Enter');

--- a/test/raw-input-followup-atomicity.test.ts
+++ b/test/raw-input-followup-atomicity.test.ts
@@ -50,15 +50,40 @@ describe('worker raw_input handler', () => {
 });
 
 describe('worker sendRawCommandLine helper', () => {
-  const helper = caseRegion(workerSrc, 'async function sendRawCommandLine', 500);
+  const helper = caseRegion(workerSrc, 'async function sendRawCommandLine', 2200);
 
-  it('submits literal text → 200ms beat → Enter in order (slash-picker safe)', () => {
+  it('generic CLIs: literal text → 200ms beat → Enter in order (slash-picker safe)', () => {
     const textIdx = helper.indexOf('sendText(content)');
-    const beatIdx = helper.indexOf('setTimeout(r, 200)');
-    const enterIdx = helper.indexOf("sendSpecialKeys('Enter')");
     expect(textIdx).toBeGreaterThanOrEqual(0);
+    // Anchor the beat/Enter lookups AFTER the text write so the CoCo branch's own
+    // 200ms beat (which precedes the generic path) can't be mistaken for this one.
+    const beatIdx = helper.indexOf('setTimeout(r, 200)', textIdx);
+    const enterIdx = helper.indexOf("sendSpecialKeys('Enter')", beatIdx);
     expect(beatIdx).toBeGreaterThan(textIdx);
     expect(enterIdx).toBeGreaterThan(beatIdx);
+  });
+
+  it('CoCo: types char-by-char (throttled) before a single Enter (paste-coalescing safe)', () => {
+    const cocoIdx = helper.indexOf("cliId === 'coco'");
+    expect(cocoIdx, 'CoCo branch present').toBeGreaterThanOrEqual(0);
+    const genericTextIdx = helper.indexOf('sendText(content)');
+    // The CoCo branch fully precedes the generic one-shot path.
+    expect(cocoIdx).toBeLessThan(genericTextIdx);
+    // Per-char keystrokes spaced by the throttle — a one-shot write coalesces into
+    // a paste on CoCo, which skips command mode + the slash picker.
+    const charIdx = helper.indexOf('sendText(ch)', cocoIdx);
+    const throttleIdx = helper.indexOf('COCO_SLASH_TYPE_THROTTLE_MS', cocoIdx);
+    expect(charIdx).toBeGreaterThan(cocoIdx);
+    expect(charIdx).toBeLessThan(genericTextIdx);
+    expect(throttleIdx).toBeGreaterThan(cocoIdx);
+    // Exactly one Enter, after the beat (a stray 2nd Enter would confirm a /model
+    // selector pick); the branch returns immediately after.
+    const cocoEnterIdx = helper.indexOf("sendSpecialKeys('Enter')", throttleIdx);
+    const returnIdx = helper.indexOf('return;', throttleIdx);
+    expect(cocoEnterIdx).toBeGreaterThan(throttleIdx);
+    expect(cocoEnterIdx).toBeLessThan(genericTextIdx);
+    expect(returnIdx).toBeGreaterThan(cocoEnterIdx);
+    expect(returnIdx).toBeLessThan(genericTextIdx);
   });
 });
 


### PR DESCRIPTION
## 问题
用户在飞书给 CoCo 发 `/model`（以及 `/clear` 等 slash 透传命令）时，命令没被 CLI 消费（不弹切换面板），反而「多一个换行」被当成普通对话发给了模型。

## 根因（已在真机 coco v0.120.45 复现确认）
CoCo（Trae CLI，Ink TUI）把「一次 PTY read 收到多个字节」判定为**粘贴**。slash 透传 / 启动命令共用的 `sendRawCommandLine` 用单次 `tmux send-keys -l` **整串写入**，CoCo 据此把 `/model` 当**粘贴文本**插入输入框：

- 命令模式 + slash 选择器都**不会激活**（只对逐键输入触发）；
- 随后的回车就把 `/model` 当普通 prompt **提交给模型**。

「多一个换行」另一来源：`parseSlashCommandInvocation` 返回的 content 只做了 `trimStart()`，飞书消息的尾随换行被原样打进 CLI。

> 对比：Claude 适配器的 writeInput 逐键限速敲入、且其 TUI 对短突发更宽容，所以不受影响。slash 路径是另一条共享的、未限速的整串 `sendText`，CoCo 的粘贴判定更激进（哪怕 6 个字符也算粘贴）。

## 改动
1. **`src/worker.ts` `sendRawCommandLine`**：CoCo 单独走逐字符敲入路径（40ms 间隔），每个字符都是独立按键，命令模式才会激活；**bare 命令末尾补一个空格**关掉建议浮窗，避免浮窗吃掉第一记回车——否则 CoCo 需两记回车，且 `/model` 这类带选择面板的命令会被多敲的回车**误选模型**。浮窗关闭后**正好一记回车**执行，`/model` 打开 Select Model 面板并停住。
2. **`src/core/command-handler.ts` `parseSlashCommandInvocation`**：返回的 content 改为 `trim()` 两端（原来只 `trimStart`），根除尾随换行被原样打进 CLI。内部换行（`MULTILINE_COMMANDS`：`/schedule`、`/role`）不受影响。
3. **`test/raw-input-followup-atomicity.test.ts`**：同步更新源码序断言，覆盖 CoCo 逐字符分支与通用整串分支两条路径。

## 验证
- **真机 coco v0.120.45**：复刻编译后精确序列（trim→补空格→逐字符@40ms→200ms→单回车），`/model` 正常弹出 **Select Model** 面板，不再被当 prompt 发给模型；逐字符路径 + 单回车对 `/clear`、带参数的 `/model GPT-5.4` 也验证安全（不会误选）。
- **单测全绿**：command-handler(153) / raw-input-atomicity(5) / coco-picker-keys(7) / coco-transcript(10)。
- `pnpm build` 通过。

## 影响面
- 仅改变 CoCo 的 slash 透传 / 启动命令输入方式；其它 CLI 走原通用整串路径不变。
- `parseSlashCommandInvocation` 的 trailing-trim 对所有 CLI 都是无害加固（无命令依赖尾随空白）。