### PR TITLE
fix(platform): dashboard 链接跟随远程访问开关，bind 后默认开启

### DIFF
--- a/src/core/dashboard-url.ts
+++ b/src/core/dashboard-url.ts
@@ -1,0 +1,24 @@
+import { platformMachineBaseUrl } from '../platform/binding.js';
+import { isRemoteAccessEnabled } from '../global-config.js';
+
+/**
+ * Builds the public URL for the web dashboard, given a token.
+ *
+ * When 远程访问 is enabled AND this machine is bound to the central platform, the
+ * URL routes through the machine subdomain
+ * (`https://m-<machineId>.<platformHost>/?t=<token>`): the platform
+ * reverse-proxies that subdomain to this host's local dashboard, which still
+ * enforces the `?t=` token itself, so the link is reachable centrally with no
+ * `:port`. When 远程访问 is off (or the machine isn't bound) the platform base is
+ * null and we fall back to the local `http://<externalHost>:<port>/` form.
+ *
+ * Mirrors buildTerminalUrl (terminal-url.ts) and publicWebhookUrl
+ * (dashboard/connector-api.ts) so dashboard, terminal, and webhook links all
+ * flip to the platform together under the single 远程访问 switch — instead of the
+ * dashboard link being the one place that always stays local.
+ */
+export function buildDashboardUrl(opts: { host: string; port: number | string; token?: string }): string {
+  const platformBase = isRemoteAccessEnabled() ? platformMachineBaseUrl() : null;
+  const origin = platformBase ?? `http://${opts.host}:${opts.port}`;
+  return opts.token ? `${origin}/?t=${opts.token}` : `${origin}/`;
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -9,6 +9,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 import { config, getDashboardExternalHost } from './config.js';
 import { repoPickerScanOptions } from './global-config.js';
+import { buildDashboardUrl } from './core/dashboard-url.js';
 import { writeHeartbeat } from './core/daemon-heartbeat.js';
 import { botmuxWrapperFiles } from './core/botmux-wrapper.js';
 import { startMaintenance, stopMaintenance } from './core/maintenance.js';
@@ -3790,12 +3791,11 @@ function dashboardUrlForReport(): string | undefined {
     const portFile = join(dir, '.dashboard-port');
     const tokenFile = join(dir, '.dashboard-token');
     const port = existsSync(portFile) ? readFileSync(portFile, 'utf8').trim() : String(config.dashboard.port);
-    const base = `http://${getDashboardExternalHost()}:${port}/`;
-    if (existsSync(tokenFile)) {
-      const tok = readFileSync(tokenFile, 'utf8').trim();
-      if (tok) return `${base}?t=${tok}`;
-    }
-    return base;
+    const tok = existsSync(tokenFile) ? readFileSync(tokenFile, 'utf8').trim() : '';
+    // buildDashboardUrl swaps in the central-platform machine subdomain when
+    // 远程访问 is on and this host is bound, so the restart-report DM links to the
+    // platform dashboard instead of an unreachable local host:port.
+    return buildDashboardUrl({ host: getDashboardExternalHost(), port, token: tok || undefined });
   } catch {
     return undefined;
   }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -41,7 +41,8 @@ import {
   TTADK_MODEL_SUGGESTIONS,
 } from './setup/cli-selection.js';
 import { invalidWorkingDirs } from './utils/working-dir.js';
-import { mergeGlobalConfig, readGlobalConfig, type MaintenanceConfig, type RepoPickerMode, type WhiteboardConfig } from './global-config.js';
+import { invalidateGlobalConfigCache, mergeGlobalConfig, readGlobalConfig, type MaintenanceConfig, type RepoPickerMode, type WhiteboardConfig } from './global-config.js';
+import { buildDashboardUrl } from './core/dashboard-url.js';
 import { deleteWhiteboard, listWhiteboards, readWhiteboard, whiteboardEnabled } from './services/whiteboard-store.js';
 import { isLocalDevInstall, botmuxVersion } from './utils/install-info.js';
 import { checkNode, detectBotmuxInstalls, resolveCurrentVersion } from './utils/install-diagnostics.js';
@@ -804,9 +805,11 @@ function verifyCliRequest(req: IncomingMessage, pathname: string):
   return { ok: true };
 }
 
-/** Build the dashboard URL for a token, using the actually-bound port. */
+/** Build the dashboard URL for a token, using the actually-bound port. Routes
+ *  through the central-platform machine subdomain when 远程访问 is on and this
+ *  host is bound (see buildDashboardUrl); falls back to the local host:port. */
 function dashboardUrlFor(token: string): string {
-  return `http://${config.dashboard.externalHost}:${boundDashboardPort}/?t=${token}`;
+  return buildDashboardUrl({ host: config.dashboard.externalHost, port: boundDashboardPort, token });
 }
 
 type SkillJobStatus = 'running' | 'succeeded' | 'failed';
@@ -1068,6 +1071,11 @@ const server = createServer(async (req, res) => {
     if (req.method === 'POST' && url.pathname === '/__cli/reload-binding') {
       const gate = verifyCliRequest(req, url.pathname);
       if (!gate.ok) return jsonRes(res, gate.status, gate.body);
+      // `botmux bind` wrote platform.json + (default-on) remoteAccess in the CLI
+      // process; this dashboard process holds a short-TTL config cache that may
+      // still read the pre-bind value. Drop it so the immediately-following
+      // /__cli/current (and live card links) resolve the platform dashboard URL.
+      invalidateGlobalConfigCache();
       try {
         platformTunnel?.stop();
       } catch {

--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -282,6 +282,15 @@ export function readGlobalConfig(): GlobalConfig {
   return out;
 }
 
+/** Drop the short-TTL read cache so the next readGlobalConfig re-reads from
+ *  disk. Same-process writes invalidate automatically (mergeGlobalConfig); this
+ *  is for cross-process freshness on demand — e.g. the dashboard process after
+ *  `botmux bind` (a different process) flips remoteAccess on, so the post-bind
+ *  dashboard URL reflects the new value without waiting out the TTL. */
+export function invalidateGlobalConfigCache(): void {
+  readCache = null;
+}
+
 /** 远程访问 enabled? Reads the (short-TTL cached) global config — cheap enough to
  *  call per link. False unless explicitly enabled. Gates whether central-platform
  *  URLs are emitted (see buildTerminalUrl / publicWebhookUrl). */

--- a/src/platform/bind.ts
+++ b/src/platform/bind.ts
@@ -6,6 +6,7 @@ import { hostname, homedir } from 'node:os';
 import { join } from 'node:path';
 import { readPlatformBinding, writePlatformBinding } from './binding.js';
 import { callDashboard } from '../cli/dashboard-endpoint.js';
+import { readGlobalConfig, mergeGlobalConfig } from '../global-config.js';
 
 /** 解码平台生成的 bind blob：base64url(JSON{u:平台地址, t:绑定token})。 */
 function decodeBindBlob(blob: string): { platformUrl: string; token: string } | null {
@@ -92,19 +93,39 @@ export async function cmdBind(args: string[]): Promise<void> {
     name,
   });
 
+  // 绑定平台即「默认打开远程访问开关」：之后 dashboard / 终端 / webhook 链接都走中心化平台
+  // 机器子域，而非本机 host:port。只在用户从未显式设置过时写入——已显式开/关的尊重用户选择
+  // （重绑不覆盖）。开关本身仍可在 dashboard 设置里随时改。
+  if (readGlobalConfig().remoteAccess === undefined) {
+    mergeGlobalConfig({ remoteAccess: true });
+  }
+
   console.log(`✓ 已绑定到平台 ${platformUrl}`);
   console.log(`  机器名: ${name}`);
 
   // 事件驱动：写完绑定后直接「捅一下」正在运行的 daemon（走其本地 /__cli HMAC 接口，
   // 复用端口自发现），立即重连平台，无需重启、不轮询。没 daemon 在跑则跳过——下次启动自然读到绑定。
+  const configDir = join(homedir(), '.botmux');
   const poke = await callDashboard({
-    configDir: join(homedir(), '.botmux'),
+    configDir,
     defaultPort: 7891,
     envPort: process.env.BOTMUX_DASHBOARD_PORT,
     path: '/__cli/reload-binding',
   });
   if (poke.ok) {
     console.log('  已通知运行中的 botmux 连接平台 ✓（无需重启）');
+    // reload-binding 已让 dashboard 进程刷新配置缓存，此处读到的就是中心化平台 dashboard 链接。
+    const cur = await callDashboard({
+      configDir,
+      defaultPort: 7891,
+      envPort: process.env.BOTMUX_DASHBOARD_PORT,
+      path: '/__cli/current',
+    });
+    if (cur.ok) {
+      console.log(`  面板: ${cur.url}`);
+    } else {
+      console.log('  面板: 运行 `botmux dashboard` 获取中心化平台链接。');
+    }
   } else {
     console.log('  未发现运行中的 botmux —— 启动它即可连接平台并在网页打开本机 dashboard。');
   }

--- a/test/dashboard-url.test.ts
+++ b/test/dashboard-url.test.ts
@@ -1,0 +1,67 @@
+// test/dashboard-url.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the two gates buildDashboardUrl consults. Defaults: remote access OFF,
+// no platform binding — i.e. an unbound / local-only host.
+vi.mock('../src/global-config.js', () => ({
+  isRemoteAccessEnabled: vi.fn(() => false),
+}));
+vi.mock('../src/platform/binding.js', () => ({
+  platformMachineBaseUrl: vi.fn(() => null),
+}));
+
+import { buildDashboardUrl } from '../src/core/dashboard-url.js';
+import { isRemoteAccessEnabled } from '../src/global-config.js';
+import { platformMachineBaseUrl } from '../src/platform/binding.js';
+
+const setRemote = (on: boolean) => vi.mocked(isRemoteAccessEnabled).mockReturnValue(on);
+const setPlatform = (base: string | null) => vi.mocked(platformMachineBaseUrl).mockReturnValue(base);
+
+describe('buildDashboardUrl', () => {
+  beforeEach(() => {
+    setRemote(false);
+    setPlatform(null);
+  });
+
+  it('builds a local host:port URL with token when remote access is off', () => {
+    expect(buildDashboardUrl({ host: '1.2.3.4', port: 7891, token: 'abc' })).toBe(
+      'http://1.2.3.4:7891/?t=abc',
+    );
+  });
+
+  it('omits the token query when no token is given', () => {
+    expect(buildDashboardUrl({ host: '1.2.3.4', port: 7891 })).toBe('http://1.2.3.4:7891/');
+  });
+
+  it('stays local when remote access is on but the host is not bound', () => {
+    setRemote(true);
+    setPlatform(null);
+    expect(buildDashboardUrl({ host: '1.2.3.4', port: 7891, token: 'abc' })).toBe(
+      'http://1.2.3.4:7891/?t=abc',
+    );
+  });
+
+  it('stays local when bound but remote access is off (switch gates it)', () => {
+    setRemote(false);
+    setPlatform('https://m-deadbeef.botmux.example');
+    expect(buildDashboardUrl({ host: '1.2.3.4', port: 7891, token: 'abc' })).toBe(
+      'http://1.2.3.4:7891/?t=abc',
+    );
+  });
+
+  it('routes through the platform machine subdomain when remote access is on and bound', () => {
+    setRemote(true);
+    setPlatform('https://m-deadbeef.botmux.example');
+    expect(buildDashboardUrl({ host: '1.2.3.4', port: 7891, token: 'abc' })).toBe(
+      'https://m-deadbeef.botmux.example/?t=abc',
+    );
+  });
+
+  it('keeps the platform subdomain token-less when no token is given', () => {
+    setRemote(true);
+    setPlatform('https://m-deadbeef.botmux.example');
+    expect(buildDashboardUrl({ host: '1.2.3.4', port: 7891 })).toBe(
+      'https://m-deadbeef.botmux.example/',
+    );
+  });
+});


### PR DESCRIPTION
## 背景
绑定中心化平台后，部分链接没有被替换成平台机器子域：`botmux restart` 后弹出的面板链接、restart 给 owner 的飞书私信报告里的链接，以及 `botmux dashboard` 的输出都还是本机 `host:port`。根因是 dashboard 链接的生成路径（`dashboardUrlFor` / `dashboardUrlForReport`）**从未经过「远程访问」开关判断**，而终端/webhook 链接早就走了 `isRemoteAccessEnabled() ? platformMachineBaseUrl() : null`。

## 改动
1. 新增共享 `src/core/dashboard-url.ts` 的 `buildDashboardUrl()`——与终端/webhook 同一套开关逻辑：开关开 + 已绑定 → `https://m-<machineId>.<平台域名>/?t=<token>`，否则回退本机 `host:port`。
2. `dashboard.ts` 的 `dashboardUrlFor`、`daemon.ts` 的 `dashboardUrlForReport` 改用它 → 覆盖 restart 终端提示、restart 飞书私信、`botmux dashboard`。
3. `bind.ts`：绑定成功后 ① 若「远程访问」开关从未显式设置则默认置 ON（重绑尊重既有选择）；② 多打印一行中心化平台 dashboard 链接。
4. `global-config.ts` 新增 `invalidateGlobalConfigCache()`，在 `/__cli/reload-binding` 里调用，修 bind 后跨进程配置缓存导致首链接仍是本机地址的时序问题。

## 验证
- `pnpm build` 通过
- 新增 `test/dashboard-url.test.ts`（6 条，全绿）
- 在本机真实 binding 上确认 `buildDashboardUrl` 输出为平台机器子域 URL
- `terminal-url.test.ts` 的 7 条失败是本机已绑平台导致的既有环境性失败，与本次改动无关