### PR TITLE
feat(lark): 团队 bot 协作免 introduce/grant（按 union_id 与团队群信任）

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2562,7 +2562,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
       // chat-granted users (who only pass canTalk) management commands like
       // /cd /restart /oncall bind. Previously this gate only fired in oncall chats,
       // which left a hole once per-chat grants flow through canTalk.
-      if (!canOperate(larkAppId, chatId, senderOpenId)) {
+      if (!canOperate(larkAppId, chatId, senderOpenId, senderUnionId)) {
         await sessionReply(anchor, tr('daemon.cmd_allowed_users_only', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
         return;
       }
@@ -3089,6 +3089,11 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
   // Strip leading @<bot> mentions so "@bot /restart" is recognized as a command.
   const cmdContent = stripLeadingMentions(content, parsed.mentions);
   const threadSenderOpenId = parsed.senderId || data?.sender?.sender_id?.open_id;
+  // Tenant-stable union_id of the thread sender — lets canOperate recognise a
+  // cross-deployment TEAM peer bot (isTeamBot) and grant it daemon-command
+  // operate, parity with same-deployment siblings (option B). undefined for
+  // senders Lark didn't stamp a union_id on → no team-operate, falls back.
+  const threadSenderUnionId = data?.sender?.sender_id?.union_id as string | undefined;
   const threadChatId = ctxChatId ?? data?.message?.chat_id;
   const clearAgentAttentionForHumanInbound = (): void => {
     if (isForeignBot || isBotSenderType) return;
@@ -3222,7 +3227,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
       }
       // canOperate gate for thread-reply daemon commands — required in every chat
       // (see spawn-path gate above). Denies chat-granted users management commands.
-      if (!canOperate(larkAppId, effectiveThreadChatId, threadSenderOpenId)) {
+      if (!canOperate(larkAppId, effectiveThreadChatId, threadSenderOpenId, threadSenderUnionId)) {
         sessionReply(anchor, tr('daemon.cmd_allowed_users_only', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
         return;
       }

--- a/src/dashboard/federation-spoke-api.ts
+++ b/src/dashboard/federation-spoke-api.ts
@@ -25,7 +25,7 @@ import { addMembership, listMemberships, removeMembership } from '../services/fe
 import type { FederatedBot } from '../services/federation-store.js';
 import { listFederatedDeployments } from '../services/federation-store.js';
 import { ensureDefaultTeam, DEFAULT_TEAM_ID, listTeams, createTeam, deleteTeam, getTeam } from '../services/team-store.js';
-import { listTeamGroups } from '../services/team-groups-store.js';
+import { listTeamGroups, recordTeamGroup } from '../services/team-groups-store.js';
 import { createInvite, deleteInvitesForTeam } from '../services/invite-store.js';
 import { removeTeamFederation, removeDeployment } from '../services/federation-store.js';
 import { loadBotConfigs, registerBot, getBot, type BotConfig } from '../bot-registry.js';
@@ -203,11 +203,17 @@ export async function syncAllMemberships(
         body: JSON.stringify({ syncToken: m.syncToken, bots, ownerUnionId: me.ownerUnionId, ownerName: me.ownerName, name: me.name }),
       });
       if (r.ok) synced++; else failed++;
-      if (r.ok && sessionsProvider) {
+      if (r.ok) {
         try {
           const j = await r.json().catch(() => ({} as any));
           const groupChatIds: unknown[] = Array.isArray(j?.groupChatIds) ? j.groupChatIds : [];
-          if (groupChatIds.length) {
+          // Mirror this team's 拉群 groups onto THIS (member) deployment so its
+          // auth gate sees the same trust boundary as the hub — a teammate bot
+          // talking in one of these groups is then learned + trusted locally
+          // (see [[team-bots-store]] / isTeamGroupChat). Recorded regardless of
+          // sessionsProvider; the session-report below is the separate concern.
+          for (const cid of groupChatIds) recordTeamGroup(dataDir, m.teamId, String(cid));
+          if (groupChatIds.length && sessionsProvider) {
             const teamChats = new Set(groupChatIds.map(String));
             const sessions = sessionsProvider()
               .filter(s => teamChats.has(String(s.chatId)))

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -17,6 +17,8 @@ import { parseForceTopicInvocation } from '../../core/command-handler.js';
 import { shouldAutoStartOnNewTopic } from '../../core/auto-start.js';
 import { resolveNonsupportMessage, stripLeadingMentions, mentionOpenId } from './message-parser.js';
 import { recordObservedBots, listObservedBots } from '../../services/observed-bots-store.js';
+import { isTeamBot, recordTeamBot } from '../../services/team-bots-store.js';
+import { isTeamGroupChat } from '../../services/team-groups-store.js';
 import { getDocSubscription, listAllDocSubscriptions, type DocSubscription } from '../../services/doc-subs-store.js';
 import { getDocComment, isBotAuthoredReply, hasBotSentinel, commentTriggerAllowed } from './doc-comment.js';
 import { BOTMUX_REQUIRED_SCOPES, DOC_FEATURE_SCOPES, DOC_COMMENT_EVENT, buildScopeDeepLink } from '../../setup/verify-permissions.js';
@@ -597,6 +599,30 @@ export function isKnownPeerBot(dataDir: string, larkAppId: string, senderOpenId:
   return false;
 }
 
+/**
+ * Should a FOREIGN bot sender be trusted to collaborate (route/spawn a session)
+ * WITHOUT `/grant`, because it's a teammate? Two trust sources, both rooted in
+ * tenant-stable identity or team-controlled group membership — never a name:
+ *
+ *  1. **Learned teammate** — its `union_id` (from the inbound event's
+ *     `sender.sender_id.union_id`) is in the team-bot store, i.e. we've seen it
+ *     vouched inside a team-assembled group before. Honoured in ANY chat.
+ *  2. **Team-assembled group** — the chat itself is a 拉群 group (team-controlled
+ *     membership), so a botmux bot speaking there is a vouched teammate even on
+ *     first contact (mirrors the existing oncall-chat exemption).
+ *
+ * `isKnownPeerBot` (same-deployment siblings) is checked separately by callers;
+ * this covers cross-deployment TEAM peers. Returns false when neither holds, so
+ * the caller falls back to the /grant request card.
+ */
+export function isTrustedTeamBotSender(
+  dataDir: string,
+  chatId: string | undefined,
+  senderUnionId: string | undefined,
+): boolean {
+  return isTeamBot(dataDir, senderUnionId) || isTeamGroupChat(dataDir, chatId);
+}
+
 /** Update the per-bot cross-reference from @mention data in an event.
  *  mentionsList comes from Lark event message.mentions array. */
 export function updateBotOpenIdCrossRef(
@@ -976,14 +1002,24 @@ export function evaluateTalk(larkAppId: string, chatId: string | undefined, send
   return { allowed: false, reason: 'none' };
 }
 
-export function canOperate(larkAppId: string, _chatId: string | undefined, senderOpenId: string | undefined): boolean {
+export function canOperate(
+  larkAppId: string,
+  _chatId: string | undefined,
+  senderOpenId: string | undefined,
+  senderUnionId?: string | undefined,
+): boolean {
   const bot = getBot(larkAppId);
   // L1 同部署兄弟 bot 互信 operate：与 canTalk 一致——isKnownPeerBot 只认本部署
   // bots-info.json 里注册过的自家 bot。这不重开 PR #46 的封堵：人的 talk 授权
   // （chatGrant/globalGrant）仍不漏成 operate；这里只放行「自家 bot 之间」的 /
-  // 命令（让编排者能对子 bot 跑 /repo /cd 等）。跨团队/外部 bot 仍走 allowedUsers /
-  // 后续的 operate 级 grant。
+  // 命令（让编排者能对子 bot 跑 /repo /cd 等）。
   if (isKnownPeerBot(config.session.dataDir, larkAppId, senderOpenId)) return true;
+  // L2 跨部署「团队 peer bot」互信 operate（与 L1 兄弟 bot 对等，覆盖编排者给
+  // 队友派 /repo /cd 等）。**只认租户稳定的 union_id**（isTeamBot），不走
+  // isTrustedTeamBotSender 的「团队群成员」分支——那条按 chat 放行是 sender 无关
+  // 的，会把「团队群里的真人」也误放进 operate，破坏 allowedUsers 边界。union_id
+  // 是发送方专属、且必须先在团队群里被认证学习过才进表，所以人不会命中。
+  if (isTeamBot(config.session.dataDir, senderUnionId)) return true;
   const allowedUsers = bot.resolvedAllowedUsers;
   // globalGrants（与 allowedChatGroups 同理）确立"有白名单"语义：只配 globalGrants 也算限制态，
   // 否则 canOperate 会 fall through 到"全开放"，把 talk-only 授权变成 operate 全开——正是 PR #46
@@ -1627,6 +1663,15 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
               .catch(err => logger.error(`Error handling message event: ${err}`));
             return;
           }
+          // Learn teammate identity from team-assembled groups (the trust root):
+          // any bot talking in a 拉群 group is a vouched teammate, so capture its
+          // tenant-stable union_id — we then honour it as a teammate in ANY chat
+          // (see team-bots-store). Done BEFORE the @mention gate so even a non-@
+          // message in a team group teaches us the teammate. Cheap + idempotent.
+          const senderUnionId = sender.sender_id?.union_id as string | undefined;
+          if (senderUnionId && isTeamGroupChat(config.session.dataDir, chatId)) {
+            recordTeamBot(config.session.dataDir, { unionId: senderUnionId });
+          }
           // Foreign bot: only route on @mention of us.
           if (!isBotMentioned(larkAppId, message, undefined)) return;
           const decision = await decideRoutingWithSource(larkAppId, message);
@@ -1647,6 +1692,7 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
             : false;
           const canFoldForeignBotThread = findOncallChat(larkAppId, chatId)
             || isKnownPeerBot(config.session.dataDir, larkAppId, senderOpenId)
+            || isTrustedTeamBotSender(config.session.dataDir, chatId, senderUnionId)
             || hasChatGrant(larkAppId, chatId, senderOpenId)
             || hasGlobalGrant(larkAppId, senderOpenId);
           let replyRootId = await maybeFoldMentionedRegularGroupThreadToChat({
@@ -1689,10 +1735,17 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
           // 同一存储、同一 per-chat 语义）。命中 chatGrants 的 bot 即便不在 cross-ref，
           // 也与已注册 peer 同等放行——这是「授权外部 bot 在本群协作」的入口。
           // 全局授权（globalGrants）同理：命中即在任意群放行，是上面的全局版。
+          //
+          // 团队 bot 免 /grant：isTrustedTeamBotSender 命中（sender 的租户稳定
+          // union_id 已学进 team-bots，或本群就是团队拉群组建的协作群）即放行——
+          // 与「同部署兄弟 bot」(isKnownPeerBot) 对等，但覆盖跨部署的团队 peer。
+          // 这正是「加入团队即免 introduce/grant」的接收闸：身份只认 union_id /
+          // 团队群成员，绝不认自报名字（防同名 bot 冒名蹭权）。
           if ((ctx.scope === 'chat' || decision.source === 'regular-group-thread' || forcedTopic) && !findOncallChat(larkAppId, chatId)) {
             const ownsSession = handlers.isSessionOwner?.(ctx.anchor, larkAppId) ?? false;
             if (!ownsSession
                 && !isKnownPeerBot(config.session.dataDir, larkAppId, senderOpenId)
+                && !isTrustedTeamBotSender(config.session.dataDir, chatId, senderUnionId)
                 && !hasChatGrant(larkAppId, chatId, senderOpenId)
                 && !hasGlobalGrant(larkAppId, senderOpenId)) {
               await maybeSendGrantRequestCard(larkAppId, message, chatId, senderOpenId);

--- a/src/services/team-bots-store.ts
+++ b/src/services/team-bots-store.ts
@@ -1,0 +1,131 @@
+/**
+ * Team-bot identity store: the tenant-stable `union_id` set of bots this
+ * deployment has learned are TEAMMATES, so the auth gate can let them
+ * collaborate without `/grant` (and without `/introduce` for discovery).
+ *
+ * Why union_id is the key (not name, not open_id):
+ * - **name is spoofable** — anyone in the tenant can run a bot called "Claude".
+ *   Trust must never hinge on a self-reported display name.
+ * - **open_id is per-app scoped** — bot B's open_id as seen by app A ≠ as seen
+ *   by app B, so it can't be a shared trust key across deployments.
+ * - **union_id is tenant-stable and cross-app consistent** — the same value in
+ *   every app's view of the same bot, and Feishu vouches for it (it arrives on
+ *   inbound events as `sender.sender_id.union_id`). It is the only sound key.
+ *
+ * Where entries come from (the trust ROOT — see recordTeamBot callers):
+ * - A bot observed talking inside a TEAM-ASSEMBLED group (a 拉群 group recorded
+ *   in [[team-groups-store]]). Such groups are built by the team itself, adding
+ *   bots by `larkAppId` from the federated roster — membership is team-controlled,
+ *   so a bot speaking there is a vouched teammate. We capture its union_id here,
+ *   then honour that union_id as a teammate in ANY group (incl. manually-created
+ *   ones), without re-deriving trust from a spoofable name.
+ *
+ * Revocation / self-healing: entries carry lastSeenAt and expire after
+ * DEFAULT_EXPIRY_MS if the bot stops appearing in team contexts — so a bot that
+ * leaves the team ages out of the trusted set on its own.
+ *
+ * Storage: `{dataDir}/team-bots.json`, deployment-wide (not per-chat: trust in a
+ * teammate is global once established). Atomic writes via the shared helper.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
+
+/** Learned-teammate entries older than this (by lastSeenAt) are ignored by
+ *  isTeamBot / listTeamBots — the bot hasn't shown up in a team context for a
+ *  month, so we stop vouching for it until it's seen again. */
+export const DEFAULT_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000;
+
+export interface TeamBot {
+  unionId: string;
+  name: string;
+  firstSeenAt: number;
+  lastSeenAt: number;
+}
+
+type FileEntry = { name: string; firstSeenAt: number; lastSeenAt: number };
+type FileShape = Record<string, FileEntry>;
+
+function filePath(dataDir: string): string {
+  return join(dataDir, 'team-bots.json');
+}
+
+function readFile(dataDir: string): FileShape {
+  const fp = filePath(dataDir);
+  if (!existsSync(fp)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(fp, 'utf-8'));
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed as FileShape;
+  } catch { /* corrupt — fall through */ }
+  return {};
+}
+
+/**
+ * Upsert a learned teammate bot by union_id. Existing entry keeps firstSeenAt
+ * and bumps lastSeenAt (+ refreshes name); new entry stamps both.
+ *
+ * No-op when unionId is empty — many inbound bot events DO carry
+ * `sender.sender_id.union_id`, but the ones that don't simply can't be learned
+ * (and fall back to the existing /grant path), never polluting the store with a
+ * keyless entry. name may be empty (we still record the trusted union_id).
+ *
+ * Returns true iff the store changed (new entry or refreshed timestamp/name),
+ * so callers can skip a redundant log.
+ */
+export function recordTeamBot(
+  dataDir: string,
+  bot: { unionId: string | undefined; name?: string },
+  now: number = Date.now(),
+): boolean {
+  const unionId = (bot.unionId ?? '').trim();
+  if (!unionId) return false;
+  const name = (bot.name ?? '').trim();
+  const data = readFile(dataDir);
+  const prior = data[unionId];
+  data[unionId] = prior
+    ? { ...prior, name: name || prior.name, lastSeenAt: now }
+    : { name, firstSeenAt: now, lastSeenAt: now };
+  atomicWriteFileSync(filePath(dataDir), JSON.stringify(data, null, 2) + '\n');
+  return true;
+}
+
+/** Is `unionId` a known (non-expired) teammate bot? The auth gate's predicate.
+ *  Empty/unknown/expired → false (caller falls back to /grant). */
+export function isTeamBot(
+  dataDir: string,
+  unionId: string | undefined,
+  maxAgeMs: number = DEFAULT_EXPIRY_MS,
+  now: number = Date.now(),
+): boolean {
+  const id = (unionId ?? '').trim();
+  if (!id) return false;
+  const entry = readFile(dataDir)[id];
+  if (!entry) return false;
+  return now - entry.lastSeenAt <= maxAgeMs;
+}
+
+/** All non-expired learned teammate bots (for discovery / debugging). Unordered. */
+export function listTeamBots(
+  dataDir: string,
+  maxAgeMs: number = DEFAULT_EXPIRY_MS,
+  now: number = Date.now(),
+): TeamBot[] {
+  const data = readFile(dataDir);
+  const out: TeamBot[] = [];
+  for (const [unionId, entry] of Object.entries(data)) {
+    if (now - entry.lastSeenAt > maxAgeMs) continue;
+    out.push({ unionId, name: entry.name, firstSeenAt: entry.firstSeenAt, lastSeenAt: entry.lastSeenAt });
+  }
+  return out;
+}
+
+/** Forget a learned teammate (explicit revoke). Returns true if removed. */
+export function removeTeamBot(dataDir: string, unionId: string | undefined): boolean {
+  const id = (unionId ?? '').trim();
+  if (!id) return false;
+  const data = readFile(dataDir);
+  if (!(id in data)) return false;
+  delete data[id];
+  atomicWriteFileSync(filePath(dataDir), JSON.stringify(data, null, 2) + '\n');
+  return true;
+}

--- a/src/services/team-groups-store.ts
+++ b/src/services/team-groups-store.ts
@@ -33,3 +33,15 @@ export function recordTeamGroup(dataDir: string, teamId: string, chatId: string,
   all.push({ teamId, chatId, createdAt: now });
   atomicWriteFileSync(filePath(dataDir), JSON.stringify(all, null, 2) + '\n');
 }
+
+/** Is `chatId` a team-assembled (拉群) group of ANY team? This is the TRUST ROOT
+ *  for team-bot collaboration: such a group is built by the team (bots added by
+ *  larkAppId from the federated roster), so a bot speaking there is a vouched
+ *  teammate (see [[team-bots-store]]). Recorded on the orchestrating deployment
+ *  by recordTeamGroup, and mirrored onto member deployments when the hub returns
+ *  groupChatIds on federation sync — so every member's auth gate sees the same
+ *  trust boundary. */
+export function isTeamGroupChat(dataDir: string, chatId: string | undefined): boolean {
+  if (!chatId) return false;
+  return listTeamGroups(dataDir).some(b => b.chatId === chatId);
+}

--- a/test/team-bots-store.test.ts
+++ b/test/team-bots-store.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Team-bot identity store: union_id-keyed trust set learned from team groups.
+ * Run: pnpm vitest run test/team-bots-store.test.ts
+ */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  recordTeamBot, isTeamBot, listTeamBots, removeTeamBot, DEFAULT_EXPIRY_MS,
+} from '../src/services/team-bots-store.js';
+
+let dataDir: string;
+beforeEach(() => { dataDir = mkdtempSync(join(tmpdir(), 'botmux-teambots-')); });
+
+describe('team-bots-store', () => {
+  it('records a teammate by union_id and recognises it', () => {
+    expect(isTeamBot(dataDir, 'on_b')).toBe(false);
+    expect(recordTeamBot(dataDir, { unionId: 'on_b', name: 'Codex' })).toBe(true);
+    expect(isTeamBot(dataDir, 'on_b')).toBe(true);
+    expect(listTeamBots(dataDir)).toMatchObject([{ unionId: 'on_b', name: 'Codex' }]);
+  });
+
+  it('ignores empty/undefined union_id (no keyless entry) — falls back to /grant', () => {
+    expect(recordTeamBot(dataDir, { unionId: undefined, name: 'x' })).toBe(false);
+    expect(recordTeamBot(dataDir, { unionId: '   ', name: 'x' })).toBe(false);
+    expect(listTeamBots(dataDir)).toEqual([]);
+    expect(isTeamBot(dataDir, undefined)).toBe(false);
+    expect(isTeamBot(dataDir, '')).toBe(false);
+  });
+
+  it('upsert keeps firstSeenAt, bumps lastSeenAt, refreshes name', () => {
+    recordTeamBot(dataDir, { unionId: 'on_b', name: 'Codex' }, 1_000);
+    recordTeamBot(dataDir, { unionId: 'on_b', name: 'Codex v2' }, 5_000);
+    const [e] = listTeamBots(dataDir, DEFAULT_EXPIRY_MS, 5_000);
+    expect(e).toMatchObject({ unionId: 'on_b', name: 'Codex v2', firstSeenAt: 1_000, lastSeenAt: 5_000 });
+  });
+
+  it('keeps the prior name when a later sighting carries no name', () => {
+    recordTeamBot(dataDir, { unionId: 'on_b', name: 'Codex' }, 1_000);
+    recordTeamBot(dataDir, { unionId: 'on_b' }, 2_000); // union_id only (typical event)
+    expect(listTeamBots(dataDir, DEFAULT_EXPIRY_MS, 2_000)[0]).toMatchObject({ name: 'Codex', lastSeenAt: 2_000 });
+  });
+
+  it('expires entries not seen within maxAge (self-healing revocation)', () => {
+    const t0 = 1_000_000;
+    recordTeamBot(dataDir, { unionId: 'on_b', name: 'Codex' }, t0);
+    const later = t0 + DEFAULT_EXPIRY_MS + 1;
+    expect(isTeamBot(dataDir, 'on_b', DEFAULT_EXPIRY_MS, later)).toBe(false);
+    expect(listTeamBots(dataDir, DEFAULT_EXPIRY_MS, later)).toEqual([]);
+    // still trusted just within the window
+    expect(isTeamBot(dataDir, 'on_b', DEFAULT_EXPIRY_MS, t0 + DEFAULT_EXPIRY_MS)).toBe(true);
+  });
+
+  it('removeTeamBot forgets a teammate (explicit revoke)', () => {
+    recordTeamBot(dataDir, { unionId: 'on_b' });
+    expect(removeTeamBot(dataDir, 'on_b')).toBe(true);
+    expect(isTeamBot(dataDir, 'on_b')).toBe(false);
+    expect(removeTeamBot(dataDir, 'on_b')).toBe(false);
+    expect(removeTeamBot(dataDir, undefined)).toBe(false);
+  });
+});

--- a/test/team-operate.test.ts
+++ b/test/team-operate.test.ts
@@ -1,0 +1,55 @@
+/**
+ * canOperate team-peer trust (option B): a cross-deployment TEAM peer bot gets
+ * daemon-command operate by its tenant-stable union_id, at parity with same-
+ * deployment siblings — WITHOUT leaking operate to humans who happen to be in a
+ * team group.
+ * Run: pnpm vitest run test/team-operate.test.ts
+ */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@larksuiteoapi/node-sdk', () => {
+  class FakeClient { constructor(public opts: Record<string, unknown>) {} }
+  return { Client: FakeClient };
+});
+
+import { config } from '../src/config.js';
+import { registerBot } from '../src/bot-registry.js';
+import { canOperate } from '../src/im/lark/event-dispatcher.js';
+import { recordTeamBot } from '../src/services/team-bots-store.js';
+import { recordTeamGroup } from '../src/services/team-groups-store.js';
+
+let dataDir: string;
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), 'botmux-teamop-'));
+  config.session.dataDir = dataDir; // canOperate reads team-bots from here
+  // Restricted bot (has an allowlist) so canOperate isn't open-mode.
+  const bot = registerBot({ larkAppId: 'op1', larkAppSecret: 's', cliId: 'claude-code', allowedUsers: ['ou_owner'] });
+  bot.resolvedAllowedUsers = ['ou_owner'];
+});
+
+describe('canOperate team-peer trust (B)', () => {
+  it('grants operate to a learned team peer bot by union_id, in ANY chat', () => {
+    recordTeamBot(dataDir, { unionId: 'on_codex', name: 'Codex' });
+    expect(canOperate('op1', 'oc_random', 'ou_codex_scoped', 'on_codex')).toBe(true);
+  });
+
+  it('does NOT grant operate to an unknown bot union_id', () => {
+    expect(canOperate('op1', 'oc_random', 'ou_x', 'on_unknown')).toBe(false);
+  });
+
+  it('SAFETY: a human in a team group does NOT inherit operate', () => {
+    // The chat is a team-assembled group, and the human is talking in it...
+    recordTeamGroup(dataDir, 'team1', 'oc_team');
+    // ...but canOperate keys on the per-sender union_id (isTeamBot), not group
+    // membership, so a non-teammate-bot union_id (a human's) is rejected.
+    expect(canOperate('op1', 'oc_team', 'ou_human', 'on_human')).toBe(false);
+    expect(canOperate('op1', 'oc_team', 'ou_human', undefined)).toBe(false);
+  });
+
+  it('still honours the existing allowedUsers operator', () => {
+    expect(canOperate('op1', 'oc_team', 'ou_owner')).toBe(true);
+  });
+});

--- a/test/team-peer-trust.test.ts
+++ b/test/team-peer-trust.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Team-peer trust: isTeamGroupChat (trust root) + isTrustedTeamBotSender (the
+ * foreign-bot gate predicate that lets teammates collaborate without /grant).
+ * Run: pnpm vitest run test/team-peer-trust.test.ts
+ */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@larksuiteoapi/node-sdk', () => {
+  class FakeClient { constructor(public opts: Record<string, unknown>) {} }
+  return { Client: FakeClient };
+});
+
+import { recordTeamGroup, isTeamGroupChat } from '../src/services/team-groups-store.js';
+import { recordTeamBot } from '../src/services/team-bots-store.js';
+import { isTrustedTeamBotSender } from '../src/im/lark/event-dispatcher.js';
+
+let dataDir: string;
+beforeEach(() => { dataDir = mkdtempSync(join(tmpdir(), 'botmux-teampeer-')); });
+
+describe('isTeamGroupChat', () => {
+  it('recognises a recorded 拉群 group of any team', () => {
+    expect(isTeamGroupChat(dataDir, 'oc_team')).toBe(false);
+    recordTeamGroup(dataDir, 'team1', 'oc_team');
+    expect(isTeamGroupChat(dataDir, 'oc_team')).toBe(true);
+    expect(isTeamGroupChat(dataDir, 'oc_other')).toBe(false);
+    expect(isTeamGroupChat(dataDir, undefined)).toBe(false);
+  });
+});
+
+describe('isTrustedTeamBotSender (gate predicate)', () => {
+  it('trusts a learned teammate union_id in ANY chat (no /grant)', () => {
+    recordTeamBot(dataDir, { unionId: 'on_codex', name: 'Codex' });
+    expect(isTrustedTeamBotSender(dataDir, 'oc_random', 'on_codex')).toBe(true);
+    // a stranger bot (unknown union_id) in a non-team chat is NOT trusted
+    expect(isTrustedTeamBotSender(dataDir, 'oc_random', 'on_stranger')).toBe(false);
+  });
+
+  it('trusts any bot inside a team-assembled group even on first contact', () => {
+    recordTeamGroup(dataDir, 'team1', 'oc_team');
+    // union_id not yet learned, but the chat itself is team-controlled
+    expect(isTrustedTeamBotSender(dataDir, 'oc_team', 'on_fresh')).toBe(true);
+  });
+
+  it('does NOT trust on a spoofable-name basis — only union_id / team group', () => {
+    // no team group, union_id unknown → must fall back to /grant
+    expect(isTrustedTeamBotSender(dataDir, 'oc_random', undefined)).toBe(false);
+    expect(isTrustedTeamBotSender(dataDir, 'oc_random', 'on_unknown')).toBe(false);
+  });
+});


### PR DESCRIPTION
## 背景

此前「团队内的 bot 协作」仍需 owner 对每个外部 bot 跑 `/grant`（拿 canTalk）+ `/introduce`（发现/可@）。鉴权闸（`evaluateTalk`/`canOperate`/`isKnownPeerBot`）只信任**同部署**的兄弟 bot，跨部署的团队 bot 一律走 grant。本 PR 让**加入同一团队**的 bot 免 introduce/grant 直接协作。

## 信任模型（关键）

只认两种**不可冒名**的依据，**绝不认显示名**：

1. **租户稳定的 `union_id`** —— 飞书入站事件自带 `sender.sender_id.union_id`，跨 app 一致，飞书背书。
2. **团队拉群协作群成员关系** —— dashboard「拉群」组建的协作群（`team-groups`，hub→spoke 已同步），成员按 `larkAppId` 受团队控制，群里说话的 bot 即为可信队友。

**信任根 = 团队拉群群**：bot 在团队群说话/被@，就把它的 `union_id` 学进 `team-bots`，此后在**任意群**都认它为队友。这样既不依赖「自解析 bot 自身 union_id」那个不确定的飞书 API，也杜绝同名 bot 冒名蹭权。

## 改了什么

- **`team-bots-store`（新）**：`union_id` 维度的「已认证队友 bot」表，30 天 TTL 自愈（离队自动失信）。
- **`team-groups-store`**：加 `isTeamGroupChat()`；`federation-spoke-api` 让 spoke 把 hub 同步的拉群协作群落盘，使每个成员的鉴权闸看到同一条信任边界。
- **`event-dispatcher`**：
  - `isTrustedTeamBotSender()`（union_id ∈ team-bots **或** 本群是团队拉群群）接进外部 bot 的 fold/spawn 闸 → 队友 bot 免 `/grant` 卡（**canTalk**）。
  - 团队群里任何 bot 说话即学习其 union_id。
  - **`canOperate`** 新增按 `union_id`（`isTeamBot`）放行 → 队友 bot 可跑 `/repo` `/cd` `/restart` 等，与同部署兄弟 bot 对等（产品选择 B）。
- **`daemon`**：两处命令闸（new-topic / thread-reply）把 sender `union_id` 透传进 `canOperate`。

## 安全性

`canOperate` **只认发送方自身的 `union_id`**（`isTeamBot`），**不**走「团队群成员」那条 chat 级、sender 无关的分支——否则团队群里的**真人**会被误授 operate、击穿 `allowedUsers` 边界。专门加了用例锁死此性质。未学到 union_id / 非团队群的陌生 bot 仍回退 `/grant`（保守安全）。

## introduce

团队流程现在功能上**已不需要** `/introduce`：`/members/bots` 提供群内发现+可@，新闸提供鉴权。`/introduce` 保留为无害兜底，未删除。

## 范围

仅改 **botmux**。`platform`（零持久化隧道/反代/SSO/团队邀请）不参与 canTalk/canOperate/grant 任何判定，无需改动；本 PR 复用已有 federation 同步（`groupChatIds` 本就 hub→spoke 下发）。

## 测试

新增 14 条用例：`team-bots-store`（store + TTL）、`team-peer-trust`（`isTeamGroupChat` / `isTrustedTeamBotSender`）、`team-operate`（canOperate B + **真人在团队群不得 operate** 安全用例）。改动涉及面（event-dispatcher / grant-gates / federation-spoke / card-handler-grant 等）回归全绿，`pnpm build` 端到端通过。

## Review 重点（@Codex）

1. 信任根是否稳妥：以「团队拉群群成员」为学习根、`union_id` 为信任键，有没有冒名/越权路径？
2. `canOperate` 的真人不泄漏 operate 这条边界是否真的不可绕过（尤其 group 级 vs sender 级分支的区分）。
3. spoke 侧 `recordTeamGroup` 落盘后无「撤销同步」——团队群解绑后 spoke 端的 `isTeamGroupChat` 会滞留（canTalk 轻度过度信任；canOperate 走 union_id+TTL 可自愈）。是否需要补撤销同步。
4. 学习时机：学习 hook 在 fold/spawn 闸**之前**，故首条命令即可命中 isTeamBot——这个顺序假设是否在所有路由分支都成立。
