### PR TITLE
fix(auth): /login 回调 URL 在话题回复里被 @bot 前缀挡住

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -3106,9 +3106,16 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
   // returns so those paths cannot leave stale needs-you rows behind.
   clearAgentAttentionForHumanInbound();
 
-  // Intercept OAuth callback URLs (from /login flow)
-  if (isCallbackUrl(content)) {
-    const result = await handleCallbackUrl(content);
+  // Intercept OAuth callback URLs (from /login flow). Feishu auto-prepends an
+  // @<bot> mention to every reply inside a bot-created topic, so the raw
+  // `content` reads "@bot http://127.0.0.1...". isCallbackUrl is anchored at
+  // ^https?://127.0.0.1, so the mention prefix breaks the match — fall back to
+  // the mention-stripped cmdContent so pasting the callback back into the
+  // topic still works.
+  const callbackText = isCallbackUrl(content) ? content
+    : isCallbackUrl(cmdContent) ? cmdContent : null;
+  if (callbackText) {
+    const result = await handleCallbackUrl(callbackText);
     if (result) {
       // Route through sessionReply so chat-scope (普通群) lands as a plain
       // chat message instead of a forced new thread.


### PR DESCRIPTION
## 问题

飞书在「@机器人创建的话题」里会给**每条回复自动加 `@bot` 前缀**。用户在话题里贴回 OAuth 回调 URL 时，实际内容是：

```
@畏寒-claude http://127.0.0.1:9768/callback?code=xxx&state=xxx
```

而 `handleThreadReply` 用**原始 content** 检测回调（`src/daemon.ts:3110`）：

```ts
if (isCallbackUrl(content)) { ... }
```

`isCallbackUrl` 的正则锚定开头 `^https?://127\.0\.0\.1...`，`@bot` 前缀使匹配失败 → 回调 URL 不被拦截，被当普通消息发给了 CLI，`/login` 流程无法完成。

## 根因补充

这个 bug 之前曾被「直接 patch 编译产物 `daemon.js`」临时修过，但**源码从未改动**（自 `/login` 功能引入 commit `0c81a1b5` 起一直是 `isCallbackUrl(content)`）。任何一次 `pnpm build` 都会把补丁覆盖掉，问题复活。本 PR 在源码层面修复。

## 修复

`handleThreadReply` 改为对去掉 @ 前缀的 `cmdContent`（`stripLeadingMentions(content, parsed.mentions)`，已在上文计算）兜底匹配：

```ts
const callbackText = isCallbackUrl(content) ? content
  : isCallbackUrl(cmdContent) ? cmdContent : null;
if (callbackText) {
  const result = await handleCallbackUrl(callbackText);
  ...
}
```

原始 content 命中则用 content（无前缀场景不变），否则回退到 mention-stripped 的 cmdContent。

## 验证

- `pnpm build` 通过
- 单测核对匹配逻辑：带 `@bot` 前缀的原始内容 → `isCallbackUrl` false；`stripLeadingMentions` 后 → true；修复后正确取到回调 URL
- ⏳ 待飞书里走一遍 `/login` 回贴流程做端到端确认