### PR TITLE
fix(routing): 自己的 defaultWorkingDir 优先于兄弟继承，避免两 bot 默认目录互串

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2243,11 +2243,18 @@ function resolveBotDefaultWorkingDir(larkAppId: string): string | undefined {
 /**
  * Resolve the pinned working dir for a brand-new topic via the layered lookup:
  *   1) this bot's OWN oncall binding (per-bot: another bot's binding never pins
- *      this bot — cross-bot dir alignment is handled by layer 3 inherit-peer)
+ *      this bot — cross-bot dir alignment is handled by layer 4 inherit-peer)
  *   2) this bot's defaultOncall — auto-binds a brand-new chat when the flag is on
  *      (this WRITES state, so it must run identically on every spawn path)
- *   3) a sibling session's workingDir (cross-bot / chat-scope inheritance)
- *   4) this bot's `defaultWorkingDir` (pure runtime fallback)
+ *   3) this bot's OWN effective `defaultWorkingDir` (legacy `defaultWorkingDir`,
+ *      or the `defaultOncall.workingDir` all-sessions fallback — see
+ *      {@link resolveBotDefaultWorkingDir}). An explicit per-bot config is the
+ *      bot's own intent, so it OUTRANKS cross-bot inheritance: a sibling's
+ *      incidental session dir must never override a dir this bot configured for
+ *      itself. Only a bot that configured nothing of its own falls to layer 4.
+ *   4) a sibling session's workingDir (cross-bot / chat-scope inheritance) —
+ *      last-resort convenience so a freshly @mentioned collaborator bot with no
+ *      dir of its own follows the topic instead of bouncing through a repo card.
  * Returns the dir plus the oncall / inherited source so callers can log the reason.
  * Shared by the normal spawn path and the first-message `/repo` command branch so
  * both honor the defaultOncall auto-bind the same way.
@@ -2263,17 +2270,21 @@ async function resolvePinnedWorkingDir(ctx: {
   if (!oncallEntry) {
     oncallEntry = await maybeAutoBindDefaultOncall(ctx.larkAppId, ctx.chatId, ctx.chatType);
   }
-  const inheritedFrom = !oncallEntry
+  // Layer 3: this bot's own effective default. Resolved BEFORE inheritance so an
+  // explicit per-bot dir wins over a sibling bot's active session dir.
+  const botDefaultWorkingDir = !oncallEntry
+    ? resolveBotDefaultWorkingDir(ctx.larkAppId)
+    : undefined;
+  // Layer 4: sibling/peer inheritance — only when this bot has neither an oncall
+  // binding nor any default dir of its own.
+  const inheritedFrom = (!oncallEntry && !botDefaultWorkingDir)
     ? findInheritablePeer({
         scope: ctx.scope, anchor: ctx.anchor, chatId: ctx.chatId, chatType: ctx.chatType,
         selfAppId: ctx.larkAppId,
         botToBotSameDir: getBot(ctx.larkAppId).config.botToBotSameDir !== false,
       })
     : null;
-  const botDefaultWorkingDir = (!oncallEntry && !inheritedFrom)
-    ? resolveBotDefaultWorkingDir(ctx.larkAppId)
-    : undefined;
-  const pinnedWorkingDir = oncallEntry?.workingDir ?? inheritedFrom?.workingDir ?? botDefaultWorkingDir;
+  const pinnedWorkingDir = oncallEntry?.workingDir ?? botDefaultWorkingDir ?? inheritedFrom?.workingDir;
   return { pinnedWorkingDir, oncallEntry, inheritedFrom };
 }
 

--- a/test/daemon-pinned-working-dir.test.ts
+++ b/test/daemon-pinned-working-dir.test.ts
@@ -57,10 +57,14 @@ afterEach(() => {
 });
 
 describe('resolvePinnedWorkingDir', () => {
-  it('inherits a same-anchor peer workingDir when the directory exists', async () => {
+  it('prefers THIS bot\'s own defaultWorkingDir over a valid same-anchor peer (no cross-bot dir pollution)', async () => {
     const { botRegistry, sessionStore, daemon } = await loadFreshModules();
     const peerDir = tempDir('peer-repo');
     const defaultDir = tempDir('default-repo');
+    // app-peer is already running in the same thread at peerDir; app-self has its
+    // OWN defaultWorkingDir. The bot's explicit config must win — it must NOT
+    // inherit the sibling's dir. This is the core of the per-bot-default-over-
+    // inherit fix: two bots with distinct default dirs never leak into each other.
     botRegistry.registerBot({ larkAppId: 'app-peer', larkAppSecret: 's', cliId: 'claude-code' });
     botRegistry.registerBot({
       larkAppId: 'app-self',
@@ -68,6 +72,27 @@ describe('resolvePinnedWorkingDir', () => {
       cliId: 'claude-code',
       defaultWorkingDir: defaultDir,
     });
+    await seedPeerSession(sessionStore, peerDir);
+
+    const result = await daemon.__testOnly_resolvePinnedWorkingDir({
+      scope: 'thread',
+      anchor: 'om_root',
+      chatId: 'oc_chat',
+      chatType: 'group',
+      larkAppId: 'app-self',
+    });
+
+    expect(result.pinnedWorkingDir).toBe(defaultDir);
+    expect(result.inheritedFrom).toBeNull();
+  });
+
+  it('inherits a same-anchor peer workingDir ONLY when this bot has no oncall binding and no default dir of its own', async () => {
+    const { botRegistry, sessionStore, daemon } = await loadFreshModules();
+    const peerDir = tempDir('peer-repo');
+    // app-self configures nothing of its own → the last-resort inherit kicks in
+    // so a freshly @mentioned collaborator follows the topic.
+    botRegistry.registerBot({ larkAppId: 'app-peer', larkAppSecret: 's', cliId: 'claude-code' });
+    botRegistry.registerBot({ larkAppId: 'app-self', larkAppSecret: 's', cliId: 'claude-code' });
     const peer = await seedPeerSession(sessionStore, peerDir);
 
     const result = await daemon.__testOnly_resolvePinnedWorkingDir({
@@ -82,8 +107,10 @@ describe('resolvePinnedWorkingDir', () => {
     expect(result.inheritedFrom).toEqual({ sessionId: peer.sessionId, larkAppId: 'app-peer', workingDir: peerDir });
   });
 
-  it('ignores a stale inherited peer workingDir and falls back to this bot defaultWorkingDir', async () => {
+  it('uses this bot defaultWorkingDir and never consults the peer (default outranks inherit)', async () => {
     const { botRegistry, sessionStore, daemon } = await loadFreshModules();
+    // A stale peer is present, but with a default dir set the peer is never even
+    // consulted — default outranks inherit, so peer validity is irrelevant.
     const stalePeerDir = join(tmpRoot, 'deleted-peer-repo');
     const defaultDir = tempDir('default-repo');
     botRegistry.registerBot({ larkAppId: 'app-peer', larkAppSecret: 's', cliId: 'claude-code' });
@@ -165,13 +192,13 @@ describe('resolvePinnedWorkingDir', () => {
   it('does NOT inherit a valid peer when botToBotSameDir=false (per-bot opt-out)', async () => {
     const { botRegistry, sessionStore, daemon } = await loadFreshModules();
     const peerDir = tempDir('peer-repo');
-    const defaultDir = tempDir('default-repo');
+    // No default dir of its own, so the gate is what decides: off → ignore the
+    // peer entirely and fall through to the repo card (no pinned dir).
     botRegistry.registerBot({ larkAppId: 'app-peer', larkAppSecret: 's', cliId: 'claude-code' });
     botRegistry.registerBot({
       larkAppId: 'app-self',
       larkAppSecret: 's',
       cliId: 'claude-code',
-      defaultWorkingDir: defaultDir,
       botToBotSameDir: false,
     });
     await seedPeerSession(sessionStore, peerDir);
@@ -184,22 +211,19 @@ describe('resolvePinnedWorkingDir', () => {
       larkAppId: 'app-self',
     });
 
-    // Gate off → ignore the valid peer, fall through to own defaultWorkingDir.
     expect(result.inheritedFrom).toBeNull();
-    expect(result.pinnedWorkingDir).toBe(defaultDir);
+    expect(result.pinnedWorkingDir).toBeUndefined();
   });
 
-  it('inherits a valid peer when botToBotSameDir is default (on)', async () => {
+  it('inherits a valid peer when botToBotSameDir is default (on) and the bot has no default dir', async () => {
     const { botRegistry, sessionStore, daemon } = await loadFreshModules();
     const peerDir = tempDir('peer-repo');
-    const defaultDir = tempDir('default-repo');
     botRegistry.registerBot({ larkAppId: 'app-peer', larkAppSecret: 's', cliId: 'claude-code' });
     botRegistry.registerBot({
       larkAppId: 'app-self',
       larkAppSecret: 's',
       cliId: 'claude-code',
-      defaultWorkingDir: defaultDir,
-      // botToBotSameDir omitted → default on
+      // botToBotSameDir omitted → default on; no defaultWorkingDir → inherit reachable
     });
     const peer = await seedPeerSession(sessionStore, peerDir);
 
@@ -232,6 +256,31 @@ describe('resolvePinnedWorkingDir', () => {
       chatId: 'oc_dm',
       chatType: 'p2p',
       larkAppId: 'app-self',
+    });
+
+    expect(result.oncallEntry).toBeFalsy();
+    expect(result.inheritedFrom).toBeNull();
+    expect(result.pinnedWorkingDir).toBe(oncallDir);
+  });
+
+  it('Oncall-mode bot with a tombstoned chat uses its OWN defaultOncall dir, not a sibling peer', async () => {
+    const { botRegistry, sessionStore, daemon } = await loadFreshModules();
+    const oncallDir = tempDir('self-oncall-repo');
+    const peerDir = tempDir('peer-repo');
+    // Reproduces the reported incident: bot is in Oncall mode but this group was
+    // /oncall-unbound once (tombstone) so auto-bind no longer fires → no oncall
+    // entry. A sibling bot is active in the same thread at peerDir. The bot must
+    // still land in its OWN configured oncall dir, never the sibling's.
+    botRegistry.registerBot({ larkAppId: 'app-peer', larkAppSecret: 's', cliId: 'claude-code' });
+    botRegistry.registerBot({
+      larkAppId: 'app-self', larkAppSecret: 's', cliId: 'claude-code',
+      defaultOncall: { enabled: true, workingDir: oncallDir, since: 1 },
+      defaultOncallAutoboundChats: ['oc_chat'],
+    });
+    await seedPeerSession(sessionStore, peerDir);
+
+    const result = await daemon.__testOnly_resolvePinnedWorkingDir({
+      scope: 'thread', anchor: 'om_root', chatId: 'oc_chat', chatType: 'group', larkAppId: 'app-self',
     });
 
     expect(result.oncallEntry).toBeFalsy();


### PR DESCRIPTION
## 背景

飞书话题群里两个 bot 各自配了**不同**的默认工作目录，结果后进话题的 bot 首轮 prompt 用了**先起来那个 bot 的目录**（用户实测 Codex 侧 `Init: cwd=...` / `Spawning fresh CLI -C ...` 都是第一个 bot 的路径）。

## 根因

`resolvePinnedWorkingDir()` 的四层优先级里，**第 3 层「兄弟 bot 活跃 session 继承」排在第 4 层「本 bot 自己的 defaultWorkingDir」之上**。所以同话题/同 chat-scope 里，bot A 先起了 session，bot B 被 @ 进来会继承 A 的目录，把 B 自己显式配的默认目录盖掉。`#307` 只加了 `botToBotSameDir` 手动开关（默认开），没动这个排序。

## 改动

把「本 bot 自己 effective 的 defaultWorkingDir」（含 Oncall 模式 `defaultOncall.workingDir` 兜底）提到兄弟继承之上。新优先级：

1. 本 bot 自己的 oncall 绑定
2. 本 bot 的 defaultOncall 自动绑定
3. **本 bot 自己的 effective defaultWorkingDir** ← 提到继承之上
4. 兄弟 session 继承（**仅当本 bot 什么都没配时**）

即：显式 per-bot 配置不再被兄弟的临时 session 目录覆盖；只有自己完全没配默认目录时，才走兄弟继承（多 bot 协作「跟随同一仓库」的便利保留）。

顺带修好一个边角：Oncall 模式下该群被 tombstone（曾 `/oncall unbind`）时，旧逻辑会继承兄弟目录；现在落回自己的 `defaultOncall.workingDir`。

> 注：已存在的旧 session 仍会沿用已持久化的 `workingDir`（resolve 只在新建 session 时跑），被污染的旧会话需 `/close` 重开——这不在本 PR 范围。

## 测试

`test/daemon-pinned-working-dir.test.ts` 新增/调整：
- 新增：自己 `defaultWorkingDir` 压过**有效**兄弟 peer（核心回归）
- 新增：Oncall 模式 + 该群 tombstone 时用自己的 oncall 目录、不继承兄弟
- 调整：兄弟继承只在「无 oncall 且无自己默认目录」时发生
- 调整：`botToBotSameDir` 开关在「无默认目录」时才决定是否继承（去掉默认目录干扰，让开关本身可被测）

`pnpm vitest run test/daemon-pinned-working-dir.test.ts test/inherit-peer.test.ts` → 24 passed；相关面 `auto-start/session-create/event-dispatcher/oncall-store/repo-selection` → 226 passed；`tsc --noEmit` 干净。