### PR TITLE
feat(backend): tmux 会话默认开启状态栏，手动 attach 可见 window 列表

### DIFF
--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -711,7 +711,11 @@ function configureTmuxSessionOptions(sessionName: string): void {
   try {
     const t = shellescape(sessionName);
     const env = tmuxEnv();
-    execSync(`tmux set-option -t ${t} status off`, { stdio: 'ignore', env });
+    // status bar ON — see TmuxPipeBackend.applySessionOptions for the rationale:
+    // shows the window list to a user who manually `tmux attach`es, and is a
+    // client-level overlay that never enters the pane stream the card / web
+    // terminal capture, so it has zero effect on them.
+    execSync(`tmux set-option -t ${t} status on`, { stdio: 'ignore', env });
     execSync(`tmux set-option -t ${t} mouse on`, { stdio: 'ignore', env });
     // set-clipboard is a server option — enable OSC 52 passthrough for web copy
     execSync(`tmux set-option -s set-clipboard on`, { stdio: 'ignore', env });

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -588,7 +588,16 @@ export class TmuxPipeBackend implements SessionBackend {
     const t = shellescape(this.paneTarget);
     const env = tmuxEnv();
     try {
-      execSync(`tmux set-option -t ${t} status off`, { stdio: 'ignore', env });
+      // status bar ON: shows tmux's window list so a user who manually
+      // `tmux attach -t <session>`es can navigate windows. Zero effect on the
+      // Lark card / web terminal — both read PANE bytes (capture-pane /
+      // pipe-pane), while the status bar is a client-level overlay that never
+      // enters the pane stream (and capture-pane never includes it). The
+      // original `status off` was a defensive guard from the early
+      // capture-screenshot backend; verified geometry-neutral on the pipe
+      // backend (toggling status on a detached session changes neither pane
+      // size nor cursor), so it's safe to default ON.
+      execSync(`tmux set-option -t ${t} status on`, { stdio: 'ignore', env });
       execSync(`tmux set-option -t ${t} mouse on`, { stdio: 'ignore', env });
       execSync(`tmux set-option -s set-clipboard on`, { stdio: 'ignore', env });
       execSync(`tmux set-option -t ${t} history-limit 50000`, { stdio: 'ignore', env });

--- a/test/tmux-pipe-backend.test.ts
+++ b/test/tmux-pipe-backend.test.ts
@@ -397,7 +397,7 @@ describe('TmuxPipeBackend managed session', () => {
     expect(newSessionCall![1]).toContain('bmx-owned');
 
     const optionCalls = mockedExecSync.mock.calls.map(c => String(c[0]));
-    expect(optionCalls.some(c => c.includes('set-option') && c.includes('status off'))).toBe(true);
+    expect(optionCalls.some(c => c.includes('set-option') && c.includes('status on'))).toBe(true);
     expect(optionCalls.some(c => c.includes('set-option') && c.includes('mouse on'))).toBe(true);
     expect(optionCalls.some(c => c.includes('set-option') && c.includes('history-limit 50000'))).toBe(true);
     expect(optionCalls.some(c => c.includes('set-option') && c.includes('window-size largest'))).toBe(true);


### PR DESCRIPTION
## 背景
用户反馈：botmux 启动的 tmux 会话手动 `tmux attach` 时没有底部状态栏，无法在多个 window 间导航（见反馈截图的 powerline 状态栏对比）。

## 根因
状态栏在最初引入 tmux 后端的提交（`041792a8`）里被一行防御设置关掉，注释原文「Disable status bar to avoid cursor-positioning noise that can interfere with xterm.js rendering」——那是早期基于截屏的老后端时代怕状态栏光标定位干扰 xterm.js 的顾虑。

## 改动
两处 tmux 后端的 `set-option` 由 `status off` 改为 `status on`，默认开启：
- `src/adapters/backend/tmux-pipe-backend.ts`（默认后端 `applySessionOptions`）
- `src/adapters/backend/tmux-backend.ts`（`configureTmuxSessionOptions`）
- `test/tmux-pipe-backend.test.ts` 断言同步改为 `status on`

## 为什么对飞书卡片/网页终端零副作用
默认后端 `TmuxPipeBackend` 的卡片截图与网页终端都只读 **pane** 内容（`capture-pane` / `pipe-pane`），而 tmux 状态栏是 **client 层覆盖层**，不进 pane 数据流（`capture-pane` 也从不包含它）。实测：detached 会话上 `status on/off` 既不改 pane 尺寸也不改 cursor。状态栏只在真正 attach 一个交互式 client 时出现——正好对症本反馈。

> 已知小副作用：仅当某 bot 跑 legacy 非 pipe tmux 后端时，网页 attach client 自身会少 1 行可视区（状态栏占用）。默认 pipe 后端不受影响。

## 验证
- `pnpm build` 绿
- `test/tmux-pipe-backend.test.ts` 39/39 通过
- e2e：attach 后状态栏显示 window 列表（`0:bash 1:editor 2:logs`），`capture-pane` 仍只含 pane 内容
- Codex review：LGTM，核对了「status 不进 pane 流」的核心判断