### PR TITLE
fix(transcript): harden large transcript reads

### DIFF
--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -234,10 +234,12 @@ function readTokenUsageAggregate(path: string, kind: UsageKind): TokenUsageAggre
   const seenMessageIds = new Set<string>();
 
   try {
+    let scanError: unknown = null;
     const scanned = scanJsonlFromOffset(path, 0, {
       onLine: (line) => foldUsageJsonLine(kind, agg, seenMessageIds, line),
+      onError: (error) => { scanError = error; },
     });
-    if (!scanned) throw new Error('scan failed');
+    if (!scanned) throw scanError instanceof Error ? scanError : new Error('scan failed');
     if (scanned.pendingTail.trim()) {
       foldUsageJsonLine(kind, agg, seenMessageIds, scanned.pendingTail);
     }
@@ -394,12 +396,14 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, op
     baseOffset = 0;
   }
 
+  let scanError: unknown = null;
   const scanned = scanJsonlFromOffset(path, baseOffset, {
     endOffset: st.size,
     onLine: (line) => foldUsageJsonLine(kind, state, seenMessageIds, line),
+    onError: (error) => { scanError = error; },
   });
   if (!scanned) {
-    logger.error(`Failed to read transcript slice ${path}: scan failed`);
+    logger.error(`Failed to read transcript slice ${path}: ${scanError instanceof Error ? scanError.message : String(scanError)}`);
     usageFileCache.delete(key);
     return null;
   }

--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -1,7 +1,7 @@
 /**
  * Session cost calculator — computes token usage from JSONL logs.
  */
-import { closeSync, existsSync, openSync, readFileSync, readSync, statSync, type Stats } from 'node:fs';
+import { existsSync, readFileSync, statSync, type Stats } from 'node:fs';
 import { logger } from '../utils/logger.js';
 import type { CliId } from '../adapters/cli/types.js';
 import { findAidenLatestCheckpointByBotmuxSessionId, findAidenLatestCheckpointBySessionId } from '../services/aiden-checkpoints.js';
@@ -10,6 +10,7 @@ import {
   cachedTranscriptPathLookup,
   resolveSessionTranscriptPath,
 } from '../services/transcript-resolver.js';
+import { scanJsonlFromOffset } from '../services/jsonl-cursor.js';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -233,13 +234,12 @@ function readTokenUsageAggregate(path: string, kind: UsageKind): TokenUsageAggre
   const seenMessageIds = new Set<string>();
 
   try {
-    const content = readFileSync(path, 'utf-8');
-    for (const line of content.split('\n')) {
-      if (!line.trim()) continue;
-      try {
-        const entry = JSON.parse(line);
-        foldUsageLine(kind, agg, seenMessageIds, entry);
-      } catch { /* skip malformed lines */ }
+    const scanned = scanJsonlFromOffset(path, 0, {
+      onLine: (line) => foldUsageJsonLine(kind, agg, seenMessageIds, line),
+    });
+    if (!scanned) throw new Error('scan failed');
+    if (scanned.pendingTail.trim()) {
+      foldUsageJsonLine(kind, agg, seenMessageIds, scanned.pendingTail);
     }
   } catch (err: any) {
     logger.error(`Failed to read session token usage JSONL (${kind}): ${err.message}`);
@@ -316,25 +316,11 @@ function foldUsageText(kind: UsageKind, agg: TokenUsageAggregate, seenMessageIds
   }
 }
 
-function readFileSlice(path: string, start: number, length: number): Buffer | null {
+function foldUsageJsonLine(kind: UsageKind, agg: TokenUsageAggregate, seenMessageIds: Set<string>, line: string): void {
+  if (!line.trim()) return;
   try {
-    const fd = openSync(path, 'r');
-    const buf = Buffer.alloc(length);
-    let bytesRead = 0;
-    try {
-      while (bytesRead < length) {
-        const n = readSync(fd, buf, bytesRead, length - bytesRead, start + bytesRead);
-        if (n <= 0) break;
-        bytesRead += n;
-      }
-    } finally {
-      closeSync(fd);
-    }
-    return buf.subarray(0, bytesRead);
-  } catch (err: any) {
-    logger.error(`Failed to read transcript slice ${path}: ${err.message}`);
-    return null;
-  }
+    foldUsageLine(kind, agg, seenMessageIds, JSON.parse(line));
+  } catch { /* skip malformed lines */ }
 }
 
 interface UsageReadResult {
@@ -408,22 +394,23 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, op
     baseOffset = 0;
   }
 
-  const chunk = readFileSlice(path, baseOffset, st.size - baseOffset);
-  if (!chunk) {
+  const scanned = scanJsonlFromOffset(path, baseOffset, {
+    endOffset: st.size,
+    onLine: (line) => foldUsageJsonLine(kind, state, seenMessageIds, line),
+  });
+  if (!scanned) {
+    logger.error(`Failed to read transcript slice ${path}: scan failed`);
     usageFileCache.delete(key);
     return null;
   }
-
-  const lastNewline = chunk.lastIndexOf(0x0a);
-  const completeBytes = lastNewline >= 0 ? lastNewline + 1 : 0;
-  foldUsageText(kind, state, seenMessageIds, chunk.toString('utf8', 0, completeBytes));
+  const completeBytes = scanned.newOffset - baseOffset;
 
   // The bytes after the last newline may still be a complete JSON record
   // (writer mid-flush). Fold them into a preview copy only — the durable
   // frontier stays at the newline, so the line is folded durably exactly
   // once when its terminator arrives.
   let previewAgg = state;
-  const tailText = chunk.toString('utf8', completeBytes).trim();
+  const tailText = scanned.pendingTail.trim();
   if (tailText) {
     previewAgg = cloneAggregate(state);
     foldUsageText(kind, previewAgg, new Set(seenMessageIds), tailText);

--- a/src/services/coco-transcript.ts
+++ b/src/services/coco-transcript.ts
@@ -13,11 +13,13 @@
  * user messages whose `extra.is_original_user_input === true` so a Lark
  * turn fingerprints against the user's prompt, not injected context.
  */
-import { existsSync, statSync, openSync, readSync, closeSync, readdirSync, readlinkSync } from 'node:fs';
+import { existsSync, statSync, readdirSync, readlinkSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { platform } from 'node:os';
 import { join } from 'node:path';
 import { cocoCacheRoot } from './coco-paths.js';
+import { scanJsonlFromOffset } from './jsonl-cursor.js';
+import { logger } from '../utils/logger.js';
 
 const COCO_SESSIONS_ROOT = join(cocoCacheRoot(), 'sessions');
 const SESSION_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -111,6 +113,40 @@ function messageText(content: unknown): string {
   return typeof content === 'string' ? content : '';
 }
 
+function parseCocoBridgeEvent(path: string, line: string, lineStart: number): CocoBridgeEvent | null {
+  let obj: any;
+  try { obj = JSON.parse(line); } catch { return null; }
+  const msg = obj?.message?.message;
+  if (!msg || typeof msg !== 'object') return null;
+  const ts = typeof obj.created_at === 'string' ? Date.parse(obj.created_at) : NaN;
+  const timestampMs = Number.isFinite(ts) ? ts : Date.now();
+
+  if (msg.role === 'user') {
+    if (msg.extra?.is_original_user_input !== true) return null;
+    const content = messageText(msg.content);
+    if (!content) return null;
+    return { uuid: `${path}:${lineStart}`, timestampMs, kind: 'user', text: content };
+  }
+  if (msg.role === 'assistant') {
+    // CoCo emits two assistant shapes per turn:
+    //   - finish_reason:'tool_calls' — mid-turn "thinking out loud" before
+    //     a tool call. Sometimes carries visible text (e.g. "Let me run
+    //     the tests..."). Treating these as final would close the
+    //     pending Lark turn early with mid-turn narration; the actual
+    //     `stop` message that follows would then drop on the floor
+    //     because the queue's collecting slot is already cleared.
+    //   - finish_reason:'stop' — the model's terminal answer. This is
+    //     what the bridge fallback should forward.
+    // Only the latter becomes assistant_final; everything else is skipped.
+    const finishReason = msg.response_meta?.finish_reason;
+    if (finishReason !== 'stop') return null;
+    const content = messageText(msg.content);
+    if (!content) return null;
+    return { uuid: `${path}:${lineStart}`, timestampMs, kind: 'assistant_final', text: content };
+  }
+  return null;
+}
+
 /** Increment-read a CoCo events.jsonl from `fromOffset`. */
 export function drainCocoEvents(path: string, fromOffset: number): CocoDrainResult {
   if (!existsSync(path)) return { events: [], newOffset: 0, pendingTail: '' };
@@ -120,57 +156,19 @@ export function drainCocoEvents(path: string, fromOffset: number): CocoDrainResu
   if (size < start) start = 0;
   if (size === start) return { events: [], newOffset: start, pendingTail: '' };
 
-  const len = size - start;
-  const buf = Buffer.alloc(len);
-  const fd = openSync(path, 'r');
-  try { readSync(fd, buf, 0, len, start); } finally { closeSync(fd); }
-
-  const text = buf.toString('utf8');
-  const lastNl = text.lastIndexOf('\n');
-  const completeText = lastNl >= 0 ? text.slice(0, lastNl + 1) : '';
-  const pendingTail = lastNl >= 0 ? text.slice(lastNl + 1) : text;
-  const newOffset = start + Buffer.byteLength(completeText, 'utf8');
-
   const events: CocoBridgeEvent[] = [];
-  let cursor = start;
-  for (const line of completeText.split('\n')) {
-    if (line.length === 0) {
-      cursor += 1;
-      continue;
-    }
-    const lineStart = cursor;
-    cursor += Buffer.byteLength(line, 'utf8') + 1;
-
-    let obj: any;
-    try { obj = JSON.parse(line); } catch { continue; }
-    const msg = obj?.message?.message;
-    if (!msg || typeof msg !== 'object') continue;
-    const ts = typeof obj.created_at === 'string' ? Date.parse(obj.created_at) : NaN;
-    const timestampMs = Number.isFinite(ts) ? ts : Date.now();
-
-    if (msg.role === 'user') {
-      if (msg.extra?.is_original_user_input !== true) continue;
-      const content = messageText(msg.content);
-      if (!content) continue;
-      events.push({ uuid: `${path}:${lineStart}`, timestampMs, kind: 'user', text: content });
-    } else if (msg.role === 'assistant') {
-      // CoCo emits two assistant shapes per turn:
-      //   - finish_reason:'tool_calls' — mid-turn "thinking out loud" before
-      //     a tool call. Sometimes carries visible text (e.g. "Let me run
-      //     the tests..."). Treating these as final would close the
-      //     pending Lark turn early with mid-turn narration; the actual
-      //     `stop` message that follows would then drop on the floor
-      //     because the queue's collecting slot is already cleared.
-      //   - finish_reason:'stop' — the model's terminal answer. This is
-      //     what the bridge fallback should forward.
-      // Only the latter becomes assistant_final; everything else is skipped.
-      const finishReason = msg.response_meta?.finish_reason;
-      if (finishReason !== 'stop') continue;
-      const content = messageText(msg.content);
-      if (!content) continue;
-      events.push({ uuid: `${path}:${lineStart}`, timestampMs, kind: 'assistant_final', text: content });
-    }
-  }
-
-  return { events, newOffset, pendingTail };
+  const scanned = scanJsonlFromOffset(path, start, {
+    endOffset: size,
+    onLine: (line, lineStart) => {
+      const event = parseCocoBridgeEvent(path, line, lineStart);
+      if (event) events.push(event);
+    },
+    onError: (error) => {
+      logger.warn(
+        `[coco-transcript] failed to scan ${path}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    },
+  });
+  if (!scanned) return { events: [], newOffset: start, pendingTail: '' };
+  return { events, newOffset: scanned.newOffset, pendingTail: scanned.pendingTail };
 }

--- a/src/services/jsonl-cursor.ts
+++ b/src/services/jsonl-cursor.ts
@@ -1,11 +1,71 @@
 import { closeSync, existsSync, openSync, readSync, statSync } from 'node:fs';
+import { StringDecoder } from 'node:string_decoder';
 
 export interface JsonlCursor {
   newOffset: number;
   pendingTail: string;
 }
 
+export interface JsonlScanOptions {
+  endOffset?: number;
+  chunkSize?: number;
+  onLine?: (line: string, lineStart: number) => void;
+  onError?: (error: unknown) => void;
+}
+
 const TAIL_PROBE_BYTES = 64 * 1024;
+const JSONL_SCAN_CHUNK_BYTES = 64 * 1024;
+
+/**
+ * Scan an append-only JSONL file from `fromOffset` using bounded-memory chunked
+ * reads. Calls `onLine` for each COMPLETE line, and returns the durable byte
+ * frontier plus any trailing partial line text left after the last newline.
+ */
+export function scanJsonlFromOffset(path: string, fromOffset: number, opts: JsonlScanOptions = {}): JsonlCursor | null {
+  const endOffset = opts.endOffset;
+  const chunkSize = Math.max(1, opts.chunkSize ?? JSONL_SCAN_CHUNK_BYTES);
+  let fd: number | null = null;
+  let nextReadOffset = Math.max(0, fromOffset);
+  let lineStartOffset = nextReadOffset;
+  let carry = '';
+  const decoder = new StringDecoder('utf8');
+  const buf = Buffer.alloc(chunkSize);
+
+  try {
+    fd = openSync(path, 'r');
+    while (true) {
+      const remaining = endOffset === undefined ? chunkSize : endOffset - nextReadOffset;
+      if (remaining <= 0) break;
+      const toRead = Math.min(chunkSize, remaining);
+      const bytesRead = readSync(fd, buf, 0, toRead, nextReadOffset);
+      if (bytesRead <= 0) break;
+      nextReadOffset += bytesRead;
+
+      const decoded = decoder.write(buf.subarray(0, bytesRead));
+      const text = carry + decoded;
+      let searchFrom = 0;
+      let currentLineStart = lineStartOffset;
+      while (true) {
+        const nl = text.indexOf('\n', searchFrom);
+        if (nl < 0) break;
+        opts.onLine?.(text.slice(searchFrom, nl), currentLineStart);
+        currentLineStart += Buffer.byteLength(text.slice(searchFrom, nl), 'utf8') + 1;
+        searchFrom = nl + 1;
+      }
+      carry = text.slice(searchFrom);
+      lineStartOffset = currentLineStart;
+    }
+    return {
+      newOffset: lineStartOffset,
+      pendingTail: carry + decoder.end(),
+    };
+  } catch (error) {
+    opts.onError?.(error);
+    return null;
+  } finally {
+    if (fd !== null) closeSync(fd);
+  }
+}
 
 /**
  * Return a baseline cursor for an append-only JSONL file without parsing the
@@ -35,17 +95,17 @@ export function baselineJsonlCursor(path: string): JsonlCursor {
     closeSync(fd);
   }
 
-  const text = buf.subarray(0, read).toString('utf8');
-  const lastNl = text.lastIndexOf('\n');
+  const probe = buf.subarray(0, read);
+  const lastNl = probe.lastIndexOf(0x0a);
   if (lastNl < 0) {
     // A single very long partial line. Treat it as historical and skip it
     // rather than allocating/parsing the whole file just to preserve a tail.
     return { newOffset: size, pendingTail: '' };
   }
 
-  const pendingTail = text.slice(lastNl + 1);
+  const pendingTail = probe.subarray(lastNl + 1).toString('utf8');
   return {
-    newOffset: start + Buffer.byteLength(text.slice(0, lastNl + 1), 'utf8'),
+    newOffset: start + lastNl + 1,
     pendingTail,
   };
 }

--- a/src/services/jsonl-cursor.ts
+++ b/src/services/jsonl-cursor.ts
@@ -45,12 +45,16 @@ export function scanJsonlFromOffset(path: string, fromOffset: number, opts: Json
       const text = carry + decoded;
       let searchFrom = 0;
       let currentLineStart = lineStartOffset;
-      while (true) {
-        const nl = text.indexOf('\n', searchFrom);
-        if (nl < 0) break;
-        opts.onLine?.(text.slice(searchFrom, nl), currentLineStart);
-        currentLineStart += Buffer.byteLength(text.slice(searchFrom, nl), 'utf8') + 1;
+      // carry never contains '\n', so newlines can only appear at or after
+      // carry.length — starting there avoids re-scanning a growing carry on
+      // every chunk when a single record spans many chunks.
+      let nl = text.indexOf('\n', carry.length);
+      while (nl >= 0) {
+        const line = text.slice(searchFrom, nl);
+        opts.onLine?.(line, currentLineStart);
+        currentLineStart += Buffer.byteLength(line, 'utf8') + 1;
         searchFrom = nl + 1;
+        nl = text.indexOf('\n', searchFrom);
       }
       carry = text.slice(searchFrom);
       lineStartOffset = currentLineStart;

--- a/test/coco-transcript.test.ts
+++ b/test/coco-transcript.test.ts
@@ -105,6 +105,62 @@ describe('drainCocoEvents', () => {
     const r2 = drainCocoEvents(path, r1.newOffset);
     expect(r2.events.map(e => e.text)).toEqual(['new']);
   });
+
+  it('drains large records across chunk boundaries without allocating the full delta as one string', () => {
+    const hugePrompt = 'p'.repeat(80_000);
+    const hugeReply = 'r'.repeat(90_000);
+    writeFileSync(path, line(originalUser(hugePrompt)) + line(assistant(hugeReply)));
+
+    const r = drainCocoEvents(path, 0);
+
+    expect(r.events.map((e) => [e.kind, e.text.length])).toEqual([
+      ['user', hugePrompt.length],
+      ['assistant_final', hugeReply.length],
+    ]);
+    expect(r.pendingTail).toBe('');
+    expect(r.newOffset).toBe(statSync(path).size);
+  });
+
+  it('preserves UTF-8 multi-byte characters split across the default scan chunk boundary', () => {
+    const chunkBoundary = 64 * 1024;
+    const marker = '你';
+    const suffix = '尾巴';
+    const buildOriginalUserLine = (content: string) => line({
+      id: 'fixed-user-id',
+      created_at: '2026-04-30T02:33:13.000+08:00',
+      message: { message: { role: 'user', content, extra: { is_original_user_input: true } } },
+    });
+    const prefixBytes = Buffer.byteLength(buildOriginalUserLine(`${marker}${suffix}`).split(marker)[0], 'utf8');
+    const fillerLen = chunkBoundary - prefixBytes - 1;
+    const promptText = `${'a'.repeat(fillerLen)}${marker}${suffix}`;
+    const promptLine = buildOriginalUserLine(promptText);
+    const markerOffset = Buffer.byteLength(promptLine.slice(0, promptLine.indexOf(marker)), 'utf8');
+
+    expect(markerOffset).toBeGreaterThanOrEqual(chunkBoundary - 2);
+    expect(markerOffset).toBeLessThan(chunkBoundary);
+
+    writeFileSync(path, promptLine + line(assistant('收到')));
+
+    const r = drainCocoEvents(path, 0);
+
+    expect(r.events.map((e) => [e.kind, e.text])).toEqual([
+      ['user', promptText],
+      ['assistant_final', '收到'],
+    ]);
+  });
+
+  it('preserves a large partial trailing line as pendingTail until newline arrives', () => {
+    const hugePrompt = 'q'.repeat(80_000);
+    writeFileSync(path, line(originalUser('seed')) + JSON.stringify(originalUser(hugePrompt)).slice(0, -10));
+
+    const r1 = drainCocoEvents(path, 0);
+    expect(r1.events.map((e) => e.text)).toEqual(['seed']);
+    expect(r1.pendingTail.length).toBeGreaterThan(70_000);
+
+    appendFileSync(path, JSON.stringify(originalUser(hugePrompt)).slice(-10) + '\n');
+    const r2 = drainCocoEvents(path, r1.newOffset);
+    expect(r2.events.map((e) => e.text)).toEqual([hugePrompt]);
+  });
 });
 
 describe('findCocoSessionByPid', () => {

--- a/test/cost-calculator-cache.test.ts
+++ b/test/cost-calculator-cache.test.ts
@@ -7,7 +7,15 @@
  * Run:  pnpm vitest run test/cost-calculator-cache.test.ts
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, writeFileSync, appendFileSync, readFileSync, rmSync } from 'node:fs';
+vi.mock('node:fs', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...original,
+    readFileSync: vi.fn(original.readFileSync),
+  };
+});
+
+import { mkdtempSync, writeFileSync, appendFileSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -46,6 +54,7 @@ beforeEach(() => {
   __resetSessionUsageCachesForTest();
   now = 1_000_000_000;
   vi.spyOn(Date, 'now').mockImplementation(() => now);
+  vi.mocked(readFileSync).mockClear();
 });
 
 afterEach(() => {
@@ -54,6 +63,17 @@ afterEach(() => {
 });
 
 describe('readSessionTokenUsageFile caching', () => {
+  it('cold reads avoid readFileSync whole-file fallback for large transcripts', () => {
+    const p = join(dir, 'large.jsonl');
+    const hugeId = 'msg_' + 'x'.repeat(70_000);
+    writeFileSync(p, `${claudeLine(hugeId, 123, 45)}\n`);
+
+    const usage = readSessionTokenUsageFile(p, 'claude');
+
+    expect(usage).toMatchObject({ inputTokens: 123, outputTokens: 45, turns: 1 });
+    expect(readFileSync).not.toHaveBeenCalled();
+  });
+
   it('returns the cached result object while the file is unchanged', () => {
     const p = join(dir, 's.jsonl');
     writeFileSync(p, `${claudeLine('msg_a', 100, 10)}\n`);
@@ -113,6 +133,20 @@ describe('readSessionTokenUsageFile caching', () => {
     // msg_b is complete JSON but has no trailing newline yet — and no id, so
     // a double fold would visibly double count it.
     writeFileSync(p, `${claudeLine('msg_a', 100, 10)}\n${claudeLine(null, 200, 20)}`);
+    const first = readSessionTokenUsageFile(p, 'claude');
+    expect(first).toMatchObject({ turns: 2, inputTokens: 300, outputTokens: 30 });
+
+    now += 20_000;
+    appendFileSync(p, `\n${claudeLine('msg_c', 1, 1)}\n`);
+    const second = readSessionTokenUsageFile(p, 'claude');
+    expect(second).toMatchObject({ turns: 3, inputTokens: 301, outputTokens: 31 });
+  });
+
+  it('handles a large unterminated tail line without rereading the whole transcript', () => {
+    const p = join(dir, 'tail.jsonl');
+    const hugeId = 'msg_' + 'y'.repeat(70_000);
+    writeFileSync(p, `${claudeLine('msg_a', 100, 10)}\n${claudeLine(hugeId, 200, 20)}`);
+
     const first = readSessionTokenUsageFile(p, 'claude');
     expect(first).toMatchObject({ turns: 2, inputTokens: 300, outputTokens: 30 });
 

--- a/test/cost-calculator.test.ts
+++ b/test/cost-calculator.test.ts
@@ -44,6 +44,24 @@ vi.mock('../src/services/aiden-checkpoints.js', () => ({
   findAidenLatestCheckpointByBotmuxSessionId: vi.fn(() => undefined),
 }));
 
+vi.mock('../src/services/jsonl-cursor.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../src/services/jsonl-cursor.js')>();
+  return {
+    ...original,
+    scanJsonlFromOffset: vi.fn((path: string, fromOffset: number, opts?: { onLine?: (line: string, lineStart: number) => void }) => {
+      const text = String(vi.mocked(readFileSync)(path, 'utf-8')).slice(Math.max(0, fromOffset));
+      let cursor = Math.max(0, fromOffset);
+      const lines = text.split('\n');
+      const pendingTail = lines.pop() ?? '';
+      for (const line of lines) {
+        opts?.onLine?.(line, cursor);
+        cursor += Buffer.byteLength(line, 'utf8') + 1;
+      }
+      return { newOffset: cursor, pendingTail };
+    }),
+  };
+});
+
 // Seed/Relay data root resolution goes through the adapter (binary realpath →
 // <pkg>/.claude-runtime). Mock it to a deterministic package-local root so the
 // path assertion below proves we no longer read from ~/.claude-runtime.

--- a/test/jsonl-cursor.test.ts
+++ b/test/jsonl-cursor.test.ts
@@ -3,7 +3,7 @@ import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { baselineJsonlCursor } from '../src/services/jsonl-cursor.js';
+import { baselineJsonlCursor, scanJsonlFromOffset } from '../src/services/jsonl-cursor.js';
 
 let dir: string;
 let path: string;
@@ -20,6 +20,35 @@ afterEach(() => {
 describe('baselineJsonlCursor', () => {
   it('returns zero cursor for a missing file', () => {
     expect(baselineJsonlCursor(path)).toEqual({ newOffset: 0, pendingTail: '' });
+  });
+
+  it('keeps trailing partial tail when the tail probe starts mid-UTF8 codepoint', () => {
+    const totalBytes = 64 * 1024 + 1;
+    const prefix = '你';
+    const pendingTail = '{"uuid":"partial"';
+    const fillerBytes = totalBytes - Buffer.byteLength(prefix, 'utf8') - 1 - Buffer.byteLength(pendingTail, 'utf8');
+    const history = `${prefix}${'a'.repeat(fillerBytes)}\n`;
+    writeFileSync(path, history + pendingTail, 'utf8');
+
+    const cursor = baselineJsonlCursor(path);
+    expect(cursor).toEqual({
+      newOffset: Buffer.byteLength(history, 'utf8'),
+      pendingTail,
+    });
+  });
+
+  it('keeps exact end offset when the tail probe starts mid-UTF8 codepoint and file ends with newline', () => {
+    const totalBytes = 64 * 1024 + 1;
+    const prefix = '你';
+    const fillerBytes = totalBytes - Buffer.byteLength(prefix, 'utf8') - 1;
+    const content = `${prefix}${'a'.repeat(fillerBytes)}\n`;
+    writeFileSync(path, content, 'utf8');
+
+    const cursor = baselineJsonlCursor(path);
+    expect(cursor).toEqual({
+      newOffset: Buffer.byteLength(content, 'utf8'),
+      pendingTail: '',
+    });
   });
 
   it('jumps to the end of complete JSONL history without parsing it', () => {
@@ -43,5 +72,24 @@ describe('baselineJsonlCursor', () => {
     const cursor = baselineJsonlCursor(path);
     expect(cursor.newOffset).toBe(Buffer.byteLength(largeHistory));
     expect(cursor.pendingTail).toBe('{"uuid":"tail"}');
+  });
+});
+
+describe('scanJsonlFromOffset', () => {
+  it('preserves UTF-8 multi-byte characters split across chunk boundaries', () => {
+    const text = '{"text":"ab你cd"}\n';
+    writeFileSync(path, text, 'utf8');
+
+    const lines: Array<{ line: string; lineStart: number }> = [];
+    const cursor = scanJsonlFromOffset(path, 0, {
+      chunkSize: Buffer.byteLength('ab', 'utf8') + 1,
+      onLine: (line, lineStart) => lines.push({ line, lineStart }),
+    });
+
+    expect(lines).toEqual([{ line: '{"text":"ab你cd"}', lineStart: 0 }]);
+    expect(cursor).toEqual({
+      newOffset: Buffer.byteLength(text, 'utf8'),
+      pendingTail: '',
+    });
   });
 });


### PR DESCRIPTION
- harden shared transcript usage scanning against large-file stringification across supported CLIs
- harden CoCo bridge transcript draining with bounded-memory chunked reads
- preserve incremental offset semantics while fixing UTF-8 tail baseline offset handling at chunk boundaries
- add regressions for large records, partial tails, and mid-codepoint baseline probing