### PR TITLE
feat(cli): OpenCode 会话 resume（--session + SQLite 会话发现）

### DIFF
--- a/src/adapters/cli/opencode.ts
+++ b/src/adapters/cli/opencode.ts
@@ -1,8 +1,149 @@
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { resolveCommand } from './registry.js';
 import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
-import type { CliAdapter, PtyHandle } from './types.js';
+import type { CliAdapter, PtyHandle, ResumableSession } from './types.js';
+import { opencodeDbPath } from '../../services/opencode-paths.js';
 
 import { delay } from '../../utils/timing.js';
+
+/**
+ * OpenCode 会话存储：1.17+ 是一个全局 SQLite 库（opencode.db），session 表一行一个
+ * 会话（id 形如 `ses_…`，带 directory/title/时间戳），message/part 表存对话内容。
+ * TUI 用 `-s/--session <id>` 精确续接既有会话（实测 1.17.11：同目录重启后历史完整
+ * 加载、新消息落在同一 session 行；不存在的 id 会立即 exit 1 "Session not found"，
+ * 所以 checkResumeTargetExists 必须先探测，否则 daemon 自动重启路径会 crash-loop）。
+ *
+ * 会话 id 的发现走 traex 同款两条路：
+ *   - writeInput 后到 DB 里验证 user part 是否落库（顺带拿到 session_id 持久化）；
+ *   - 兜底：botmux 每条 prompt 都嵌 `<session_id>` 块，直接在 part 表按文本反查。
+ */
+
+const OPENCODE_SESSION_ID_RE = /^ses_[0-9A-Za-z]+$/;
+
+function isOpenCodeSessionId(value: string | undefined): value is string {
+  return typeof value === 'string' && OPENCODE_SESSION_ID_RE.test(value);
+}
+
+function normaliseText(text: string): string {
+  return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+function textMatches(actual: string, expected: string): boolean {
+  if (actual === expected) return true;
+  const na = normaliseText(actual);
+  const ne = normaliseText(expected);
+  if (na === ne) return true;
+  // 宽容前缀匹配：多行内容在 TUI 里可能被嵌入换行提前提交（只提交了第一段），
+  // 或 DB 侧截断。宁可认作已提交，也不误报"未确认"（与旧盲发行为对齐，不回退）。
+  if (na.length > 0 && (ne.startsWith(na) || na.startsWith(ne.slice(0, na.length)))) return true;
+  return false;
+}
+
+// -- SQLite helpers (node:sqlite, Node 22+ experimental) -----------------
+
+type DatabaseSyncLike = {
+  prepare(sql: string): StatementSyncLike;
+  close(): void;
+};
+type StatementSyncLike = {
+  get(...params: unknown[]): any;
+  all(...params: unknown[]): any[];
+};
+
+let sqliteModule: { DatabaseSync: new (path: string, opts?: { readOnly?: boolean }) => DatabaseSyncLike } | null = null;
+let sqliteLoadAttempted = false;
+
+function loadSqlite(): typeof sqliteModule {
+  if (sqliteLoadAttempted) return sqliteModule;
+  sqliteLoadAttempted = true;
+  // ESM 下没有裸 require（ReferenceError），必须走 createRequire —— traex.ts 曾因
+  // 裸 require 被 try/catch 吞掉而在生产 dist 里整条 SQLite 链路静默失效。
+  try {
+    const req = createRequire(import.meta.url);
+    sqliteModule = req('node:sqlite') as typeof sqliteModule;
+  } catch {
+    sqliteModule = null;
+  }
+  return sqliteModule;
+}
+
+/** 只读打开 opencode.db 执行一次查询。DB 是 WAL 模式且被活跃 OpenCode 进程持有，
+ *  read-only 连接可并发读；任何失败（模块缺失/文件不存在/短暂锁忙）都回落 null，
+ *  上层按"无法验证"降级，不影响输入投递本身。 */
+function withDb<T>(fn: (db: DatabaseSyncLike) => T): T | null {
+  const mod = loadSqlite();
+  if (!mod) return null;
+  const dbPath = opencodeDbPath();
+  if (!existsSync(dbPath)) return null;
+  let db: DatabaseSyncLike | undefined;
+  try {
+    db = new mod.DatabaseSync(dbPath, { readOnly: true });
+    return fn(db);
+  } catch {
+    return null;
+  } finally {
+    try { db?.close(); } catch { /* ignore */ }
+  }
+}
+
+/** 提交验证基线：part 表当前最大 time_created（epoch ms，与 worker 同机同钟）。
+ *  之后只认 >= 基线的新行，避免历史消息误配。 */
+function snapPartBaseline(): number | null {
+  return withDb((db) => {
+    const row = db.prepare('SELECT COALESCE(MAX(time_created), 0) AS ts FROM part').get() as { ts: number } | undefined;
+    return row?.ts ?? 0;
+  });
+}
+
+/** 基线之后是否出现文本匹配的 user part；命中则带回其 session_id（= OpenCode 原生
+ *  会话 id）。全局 DB 多实例并发写也安全：靠文本相等排除别的会话的行。
+ *  严格 `>` 基线：`>=` 会在"用户因疑似丢失而重发同一段文本"时误配上一条的行，
+ *  把真丢失误报为已提交；同毫秒漏检的窗口可忽略（新行时间戳必然晚于既有最大值）。 */
+function detectNewSubmit(baseline: number, expectedText: string): { found: boolean; cliSessionId?: string } {
+  return withDb((db) => {
+    const rows = db.prepare(
+      "SELECT p.session_id AS sid, json_extract(p.data, '$.text') AS text " +
+      'FROM part p JOIN message m ON m.id = p.message_id ' +
+      "WHERE json_extract(m.data, '$.role') = 'user' " +
+      "  AND json_extract(p.data, '$.type') = 'text' " +
+      '  AND p.time_created > ? ' +
+      'ORDER BY p.time_created DESC LIMIT 20',
+    ).all(baseline) as { sid: string; text?: string }[];
+    for (const r of rows) {
+      if (r.text && textMatches(r.text, expectedText)) {
+        return { found: true, cliSessionId: r.sid };
+      }
+    }
+    return { found: false };
+  }) ?? { found: false };
+}
+
+/** 兜底反查：botmux 每条 prompt 都带 `<session_id>xxx</session_id>` 块，按该文本在
+ *  user part 里找最近命中的 OpenCode 会话。用于 cliSessionId 尚未持久化时的 resume
+ *  （典型：首条消息经 --prompt 注入、没走 writeInput 就被 suspend/重启）。 */
+function latestOpenCodeSessionForBotmuxSession(botmuxSessionId: string): string | undefined {
+  return withDb((db) => {
+    const row = db.prepare(
+      'SELECT p.session_id AS sid ' +
+      'FROM part p JOIN message m ON m.id = p.message_id ' +
+      "WHERE json_extract(m.data, '$.role') = 'user' " +
+      "  AND json_extract(p.data, '$.type') = 'text' " +
+      '  AND instr(p.data, ?) > 0 ' +
+      'ORDER BY p.time_created DESC LIMIT 1',
+    ).get(botmuxSessionId) as { sid?: string } | undefined;
+    return row?.sid;
+  }) ?? undefined;
+}
+
+function sessionRowExists(cliSessionId: string): boolean | null {
+  return withDb((db) => {
+    const row = db.prepare('SELECT 1 AS ok FROM session WHERE id = ? LIMIT 1').get(cliSessionId) as { ok?: number } | undefined;
+    return !!row?.ok;
+  });
+}
+
+// -------------------------------------------------------------------------
 
 export function createOpenCodeAdapter(pathOverride?: string): CliAdapter {
   // resolvedBin is lazy: setup constructs adapters only to read static
@@ -15,18 +156,26 @@ export function createOpenCodeAdapter(pathOverride?: string): CliAdapter {
     authPaths: ['~/.local/share/opencode/auth.json'],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
-    buildArgs({ initialPrompt, model }) {
-      // OpenCode manages sessions internally (SQLite store).
-      // Resume not supported — always start fresh.  --continue exits
-      // immediately (code 0) when there is no prior session, causing a
-      // crash-loop in the daemon auto-restart path.
+    buildArgs({ sessionId, resume, resumeSessionId, initialPrompt, model }) {
       const args: string[] = [];
       if (model && model.trim()) {
         args.push('--model', model.trim());
       }
+      // Resume：优先用持久化的 cliSessionId，否则按 botmux session id 文本反查。
+      // 找不到就退化为全新会话（与旧行为一致）——绝不带无效 id 启动，
+      // `opencode -s <不存在的id>` 会立即 exit 1 → daemon 自动重启 crash-loop。
+      const openCodeSessionId = resume
+        ? (isOpenCodeSessionId(resumeSessionId) ? resumeSessionId : latestOpenCodeSessionForBotmuxSession(sessionId))
+        : undefined;
+      if (openCodeSessionId) {
+        args.push('--session', openCodeSessionId);
+      }
       // Use --prompt for the initial prompt.  OpenCode's Bubble Tea TUI
       // has an async startup phase; writing to stdin during this window
       // may be lost.  --prompt injects it once the TUI is ready.
+      // 注意：`-s` resume 下 --prompt 会被 OpenCode 忽略（实测 1.17.11），worker 靠
+      // initialPromptArgsIgnoredOnResume 在 resume 时把 prompt 改走输入队列，
+      // 所以这里 resume 分支收到的 initialPrompt 恒为 undefined。
       if (initialPrompt) {
         args.push('--prompt', initialPrompt);
       }
@@ -34,17 +183,111 @@ export function createOpenCodeAdapter(pathOverride?: string): CliAdapter {
     },
 
     passesInitialPromptViaArgs: true,
+    // OpenCode 只在"新会话"应用 --prompt，`-s` 续接时静默忽略（消息会丢）。
+    // 置位后 worker 在 resume spawn 时把初始 prompt 转入常规输入队列。
+    initialPromptArgsIgnoredOnResume: true,
+
+    buildResumeCommand({ sessionId, cliSessionId }) {
+      const sid = isOpenCodeSessionId(cliSessionId) ? cliSessionId : latestOpenCodeSessionForBotmuxSession(sessionId);
+      if (!sid) return null;
+      return `opencode -s ${sid}`;
+    },
+
+    /** Resume 目标预检：id 不在 session 表 → false（worker 落回全新会话并提示），
+     *  避免 `Session not found` exit 1 被放大成自动重启 crash-loop。DB 读不了
+     *  （node:sqlite 缺失 / 首次运行 / sandbox overlay 挡住）→ undefined，交给
+     *  worker 的二级重启护栏。 */
+    checkResumeTargetExists({ sessionId, cliSessionId }) {
+      const sid = isOpenCodeSessionId(cliSessionId) ? cliSessionId : latestOpenCodeSessionForBotmuxSession(sessionId);
+      if (!sid) {
+        // 反查也找不到 → buildArgs 会退化为全新会话，spawn 本身不会失败。
+        // 返回 undefined 让 spawn 正常走（fresh），不触发"无法恢复"提示误报。
+        return withDb(() => true) === null ? undefined : false;
+      }
+      const exists = sessionRowExists(sid);
+      return exists === null ? undefined : exists;
+    },
+
+    /** Import path（/adopt 第二过滤器）：从全局 session 表列出可续接的顶层会话
+     *  （parent_id 非空的是子代理会话，跳过）。title 是 OpenCode 自动生成的摘要。 */
+    listResumableSessions({ limit, exclude }) {
+      const rows = withDb((db) => db.prepare(
+        'SELECT id, directory, title, time_updated AS timeUpdated FROM session ' +
+        'WHERE parent_id IS NULL AND time_archived IS NULL ' +
+        'ORDER BY time_updated DESC LIMIT ?',
+      ).all(limit + (exclude?.size ?? 0)) as { id: string; directory: string; title?: string; timeUpdated: number }[]) ?? [];
+      const out: ResumableSession[] = [];
+      for (const r of rows) {
+        if (out.length >= limit) break;
+        if (exclude?.has(r.id)) continue;
+        if (!r.directory || !existsSync(r.directory)) continue;
+        out.push({
+          cliSessionId: r.id,
+          cwd: r.directory,
+          title: (r.title ?? '').trim() || r.id,
+          lastActivityAt: r.timeUpdated,
+        });
+      }
+      return Promise.resolve(out);
+    },
 
     async writeInput(pty: PtyHandle, content: string) {
-      if (pty.sendText && pty.sendSpecialKeys) {
-        pty.sendText(content);
-        await delay(200);
-        pty.sendSpecialKeys('Enter');
-      } else {
-        pty.write(content);
-        await delay(1000);
-        pty.write('\r');
+      // 提交验证基线先于写入采样（traex 同款）。斜杠命令是 TUI 命令面板输入，
+      // 不产生 user message 行，跳过验证（重试 Enter 还可能误触面板项）。
+      const isSlashCommand = content.startsWith('/');
+      const baseline = isSlashCommand ? null : snapPartBaseline();
+
+      const trySendEnter = (): boolean => {
+        try {
+          if (pty.sendSpecialKeys) pty.sendSpecialKeys('Enter');
+          else pty.write('\r');
+          return true;
+        } catch {
+          return false;
+        }
+      };
+
+      try {
+        if (pty.sendText && pty.sendSpecialKeys) {
+          pty.sendText(content);
+          await delay(200);
+          pty.sendSpecialKeys('Enter');
+        } else {
+          pty.write(content);
+          await delay(1000);
+          pty.write('\r');
+        }
+      } catch {
+        return { submitted: false };
       }
+
+      // DB-backed submit verification + cliSessionId 捕获。node:sqlite 不可用或
+      // DB 缺失（首次运行 / sandbox overlay）→ 维持旧行为：盲发、假定成功。
+      if (baseline === null) return undefined;
+
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const match = detectNewSubmit(baseline, content);
+        if (match.found) {
+          return match.cliSessionId
+            ? { submitted: true, cliSessionId: match.cliSessionId }
+            : { submitted: true };
+        }
+        await delay(800);
+        if (!trySendEnter()) return { submitted: false };
+      }
+      const finalMatch = detectNewSubmit(baseline, content);
+      if (finalMatch.found) {
+        return finalMatch.cliSessionId
+          ? { submitted: true, cliSessionId: finalMatch.cliSessionId }
+          : { submitted: true };
+      }
+      const recheck = () => {
+        const late = detectNewSubmit(baseline, content);
+        return late.found
+          ? { submitted: true, cliSessionId: late.cliSessionId }
+          : false;
+      };
+      return { submitted: false, recheck };
     },
 
     completionPattern: undefined,   // quiescence only — no explicit completion marker

--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { resolveCommand } from './registry.js';
 import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
 import type { CliAdapter, PtyHandle } from './types.js';
@@ -55,13 +56,14 @@ function loadSqlite(): typeof sqliteModule {
   if (sqliteLoadAttempted) return sqliteModule;
   sqliteLoadAttempted = true;
   // node:sqlite is the built-in experimental SQLite binding available in
-  // Node 22+. It requires --experimental-sqlite at the time of writing
-  // (2026-06), but the import succeeds even without the flag; the first
-  // `new DatabaseSync(...)` throws if the runtime didn't opt in. We swallow
-  // that at query time and degrade gracefully.
+  // Node 22+. The runtime may still reject it (older Node without the
+  // feature); we swallow that and degrade gracefully.
+  // 必须走 createRequire：本包是 ESM（"type":"module"），裸 require 是
+  // ReferenceError —— 之前就是被这里的 try/catch 吞掉，导致生产 dist 里
+  // SQLite 提交验证/会话反查整条链路静默失效。
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    sqliteModule = require('node:sqlite') as typeof sqliteModule;
+    const req = createRequire(import.meta.url);
+    sqliteModule = req('node:sqlite') as typeof sqliteModule;
   } catch {
     sqliteModule = null;
   }

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -89,15 +89,23 @@ export interface CliAdapter {
    *  The worker skips queuing the prompt for stdin write. */
   readonly passesInitialPromptViaArgs?: boolean;
 
+  /** Only meaningful with passesInitialPromptViaArgs. When true, the CLI
+   *  silently drops its initial-prompt launch flag on a RESUME spawn (e.g.
+   *  OpenCode applies `--prompt` to new sessions only and ignores it with
+   *  `-s <id>`), so the worker routes the initial prompt through the normal
+   *  input queue instead of baking it into args — otherwise the message that
+   *  triggered the resume would be lost. */
+  readonly initialPromptArgsIgnoredOnResume?: boolean;
+
   /** Build a shell command string the user can paste into a terminal to
    *  resume this CLI session locally — independent of botmux. Used by the
    *  "session closed" card so users have an obvious way to keep the
    *  conversation outside the bot.
    *
    *  Returns `null` when the CLI doesn't support precise per-session resume
-   *  from CLI args (e.g. opencode, gemini's "latest only" mode), or when
-   *  the CLI-native session id can't be resolved (e.g. codex history file
-   *  is missing). The card falls back to a static note in those cases.
+   *  from CLI args (e.g. gemini's "latest only" mode), or when the CLI-native
+   *  session id can't be resolved (e.g. codex history file is missing).
+   *  The card falls back to a static note in those cases.
    *
    *  Implementations should print the *default* binary name (`claude`,
    *  `codex`, etc.) rather than `cliPathOverride` — the override is a

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -328,8 +328,8 @@ export function buildSessionCard(
  * `claude --resume <id>`), built by the per-CLI adapter's
  * `buildResumeCommand`. That keeps the conversation portable: users can
  * pick it up locally without going through botmux. CLIs that can't resume
- * a specific session from CLI args (gemini's "latest only", opencode)
- * surface a fallback note instead of a fake command.
+ * a specific session from CLI args (gemini's "latest only") surface a
+ * fallback note instead of a fake command.
  *
  * The "▶️ 恢复会话" button still goes through botmux — it re-enables the
  * Lark bridge so future replies route back into this topic.

--- a/src/services/opencode-paths.ts
+++ b/src/services/opencode-paths.ts
@@ -1,0 +1,20 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+function expandHome(path: string): string {
+  return path.startsWith('~') ? join(homedir(), path.slice(1)) : path;
+}
+
+/** OpenCode 的数据根目录：跟随 XDG_DATA_HOME，默认 ~/.local/share/opencode。
+ *  保持动态解析（不在模块加载时固化），测试/子进程改 env 后仍能命中。 */
+export function opencodeDataRoot(): string {
+  const xdg = process.env.XDG_DATA_HOME?.trim();
+  const base = xdg ? expandHome(xdg) : join(homedir(), '.local', 'share');
+  return join(base, 'opencode');
+}
+
+/** OpenCode 1.17+ 的全局 SQLite 库（session/message/part 表，所有项目共用一个）。
+ *  作为 resume 目标探测、submit 验证与 cliSessionId 捕获的数据源。 */
+export function opencodeDbPath(): string {
+  return join(opencodeDataRoot(), 'opencode.db');
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4158,11 +4158,14 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   // route it through the input queue instead so startupCommands run first
   // (flushPending's hook can't precede an args-baked prompt). The init handler
   // mirrors this when deciding whether to enqueue the prompt.
+  // Also defer on RESUME for adapters whose initial-prompt launch flag is
+  // silently ignored when continuing a session (OpenCode `--prompt` + `-s`):
+  // baking it into args would drop the message that triggered the resume.
   const deferInitialPrompt = shouldDeferInitialPromptForStartup({
     hasStartupCommands: !!cfg.startupCommands?.length,
     adoptMode: cfg.adoptMode === true,
     passesInitialPromptViaArgs: cliAdapter.passesInitialPromptViaArgs === true,
-  });
+  }) || (effectiveResume && cliAdapter.initialPromptArgsIgnoredOnResume === true);
   const args = cliAdapter.buildArgs({
     sessionId: effectiveAdapterSessionId,
     resume: effectiveResume,
@@ -5432,11 +5435,16 @@ process.on('message', async (raw: unknown) => {
         // NOT bake the prompt (deferInitialPrompt) so the commands can precede it
         // — so we MUST queue it here. shouldDeferInitialPromptForStartup mirrors
         // spawnCli's decision exactly. Bridge mark is deferred to flushPending.
+        // lastSpawnEffectiveResume was just written by spawnCli(msg) above, so
+        // this mirrors spawnCli's resume-defer condition exactly (incl. the
+        // Tier-1/Tier-2 fresh demotion, which clears the flag). Adopt spawns
+        // return from spawnCli before that write — exclude them explicitly so
+        // the stale module-level value can't leak in.
         const deferInitialPrompt = shouldDeferInitialPromptForStartup({
           hasStartupCommands: !!msg.startupCommands?.length,
           adoptMode: msg.adoptMode === true,
           passesInitialPromptViaArgs: cliAdapter?.passesInitialPromptViaArgs === true,
-        });
+        }) || (msg.adoptMode !== true && lastSpawnEffectiveResume && cliAdapter?.initialPromptArgsIgnoredOnResume === true);
         if (msg.prompt && cliAdapter?.passesInitialPromptViaArgs && !deferInitialPrompt && codexBridgeFallbackActive()) {
           // Args-baked first prompts (notably Pi) never pass through the normal
           // 'message' IPC path, so the structured bridge would otherwise see the

--- a/src/workflows/attempt-resume.ts
+++ b/src/workflows/attempt-resume.ts
@@ -29,7 +29,10 @@ import { prependBotmuxBin } from '../core/botmux-wrapper.js';
 export const ATTEMPT_RESUME_SCHEMA_VERSION = 1;
 export const ATTEMPT_RESUME_IDLE_MS = 30 * 60 * 1000;
 export const ATTEMPT_RESUME_GRACE_MS = 5000;
-export const RESUME_REQUIRES_CLI_SESSION_ID = new Set(['antigravity', 'codex-app', 'cursor', 'mira']);
+// opencode 也在此列：它的 --session 需要 DB 里真实存在的 ses_* id。主路径（daemon
+// 会话）有 <session_id> 文本反查兜底，但 workflow attempt 的 prompt 不带该块，
+// 只能依赖 writeInput 捕获到的 cliSessionId；缺失时宁可明确报错也不静默新起会话。
+export const RESUME_REQUIRES_CLI_SESSION_ID = new Set(['antigravity', 'codex-app', 'cursor', 'mira', 'opencode']);
 export const RESUME_USES_SESSION_ID = new Set(['aiden', 'coco', 'claude-code', 'seed', 'relay', 'codex', 'mtr', 'hermes', 'pi', 'mir']);
 
 export type AttemptResumeStatus = 'starting' | 'live' | 'closed';

--- a/test/bot-config-editor.test.ts
+++ b/test/bot-config-editor.test.ts
@@ -295,17 +295,20 @@ describe('resolveCliId', () => {
   });
 
   it('maps setup menu indices to cliIds', () => {
+    // 序号以 src/setup/bot-config-editor.ts 的 CLI_ID_CHOICES 为准
+    //（#336 接入 Genius 在 7 号插位，其后整体顺移一位）。
     expect(resolveCliId('1')).toBe('claude-code');
     expect(resolveCliId('4')).toBe('codex');
-    expect(resolveCliId('7')).toBe('opencode');
-    expect(resolveCliId('9')).toBe('mtr');
-    expect(resolveCliId('10')).toBe('hermes');
-    expect(resolveCliId('11')).toBe('codex-app');
-    expect(resolveCliId('12')).toBe('mira');
-    expect(resolveCliId('13')).toBe('seed');
-    expect(resolveCliId('14')).toBe('traex');
-    expect(resolveCliId('15')).toBe('pi');
-    expect(resolveCliId('16')).toBe('copilot');
+    expect(resolveCliId('7')).toBe('genius');
+    expect(resolveCliId('8')).toBe('opencode');
+    expect(resolveCliId('10')).toBe('mtr');
+    expect(resolveCliId('11')).toBe('hermes');
+    expect(resolveCliId('12')).toBe('codex-app');
+    expect(resolveCliId('13')).toBe('mira');
+    expect(resolveCliId('14')).toBe('seed');
+    expect(resolveCliId('15')).toBe('traex');
+    expect(resolveCliId('16')).toBe('pi');
+    expect(resolveCliId('17')).toBe('copilot');
   });
 
   it('passes through literal cliIds unchanged', () => {

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -1252,9 +1252,10 @@ describe('buildResumeCommand', () => {
     expect(a.buildResumeCommand).toBeUndefined();
   });
 
-  it('opencode does not implement buildResumeCommand', () => {
+  it('opencode emits `opencode -s <cliSessionId>` when known', () => {
     const a = createOpenCodeAdapter('/bin/opencode');
-    expect(a.buildResumeCommand).toBeUndefined();
+    expect(a.buildResumeCommand?.({ sessionId: 'bm-oc', cliSessionId: 'ses_0123abcDEF' }))
+      .toBe('opencode -s ses_0123abcDEF');
   });
 
   it('mtr emits `mtr --session <native-session-id>`', () => {

--- a/test/opencode-input.e2e.ts
+++ b/test/opencode-input.e2e.ts
@@ -259,22 +259,36 @@ describe('OpenCode first input submission', () => {
       console.log('>>> No useful session to continue — --continue is unreliable for restart');
     }
 
-    // The fix: buildArgs should NOT include --continue on resume
+    // The fix: buildArgs must NEVER include --continue on resume. Use a
+    // UUID-shaped botmux session id so the opencode.db text lookup can't
+    // accidentally match unrelated rows on the test machine.
     const adapter = createOpenCodeAdapter();
-    const resumeArgs = adapter.buildArgs({ sessionId: 'test', resume: true });
+    const resumeArgs = adapter.buildArgs({ sessionId: 'f0e1d2c3-0000-4000-8000-badbadbadbad', resume: true });
     expect(resumeArgs).not.toContain('--continue');
-    expect(resumeArgs, 'resume should produce empty args (start fresh)').toEqual([]);
+    expect(resumeArgs, 'resume without a discoverable session should produce empty args (start fresh)').toEqual([]);
   }, 15_000);
 
-  it('adapter: resume starts fresh (no --continue)', () => {
+  it('adapter: resume uses --session when the native id is known, else starts fresh', () => {
     const adapter = createOpenCodeAdapter();
-    // resume: true should NOT add --continue — always start fresh
-    expect(adapter.buildArgs({ sessionId: 'test', resume: true })).toEqual([]);
-    // resume with prompt should only have --prompt
-    const args = adapter.buildArgs({ sessionId: 'test', resume: true, initialPrompt: 'hello' });
+    const nowhereSession = 'f0e1d2c3-0000-4000-8000-badbadbadbad';
+    // resume with a persisted OpenCode session id → precise --session resume
+    expect(adapter.buildArgs({ sessionId: nowhereSession, resume: true, resumeSessionId: 'ses_0123abcDEF' }))
+      .toEqual(['--session', 'ses_0123abcDEF']);
+    // a non-OpenCode-shaped id (e.g. another CLI's UUID after a CLI switch) is rejected
+    const foreignId = adapter.buildArgs({ sessionId: nowhereSession, resume: true, resumeSessionId: '01234567-89ab-cdef-0123-456789abcdef' });
+    expect(foreignId).not.toContain('--session');
+    // resume: true with no discoverable session → fresh, never --continue
+    expect(adapter.buildArgs({ sessionId: nowhereSession, resume: true })).toEqual([]);
+    // fresh-degraded resume with prompt keeps --prompt delivery
+    const args = adapter.buildArgs({ sessionId: nowhereSession, resume: true, initialPrompt: 'hello' });
     expect(args).not.toContain('--continue');
     expect(args).toContain('--prompt');
     expect(args).toContain('hello');
+  });
+
+  it('adapter: initialPromptArgsIgnoredOnResume is set (opencode drops --prompt with -s)', () => {
+    const adapter = createOpenCodeAdapter();
+    expect(adapter.initialPromptArgsIgnoredOnResume).toBe(true);
   });
 
   it('adapter: altScreen is true (Bubble Tea)', () => {

--- a/test/opencode-resume.test.ts
+++ b/test/opencode-resume.test.ts
@@ -1,0 +1,247 @@
+/**
+ * OpenCode resume 单测：用假 opencode.db（XDG_DATA_HOME 指向临时目录）驱动
+ * 适配器的 SQLite 路径 —— buildArgs 的 --session 解析与文本反查兜底、
+ * checkResumeTargetExists 预检、listResumableSessions、writeInput 的
+ * DB 提交验证 + cliSessionId 捕获。
+ *
+ * Run:  pnpm vitest run test/opencode-resume.test.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
+
+import { createOpenCodeAdapter } from '../src/adapters/cli/opencode.js';
+import { opencodeDbPath } from '../src/services/opencode-paths.js';
+import type { PtyHandle } from '../src/adapters/cli/types.js';
+
+const BOTMUX_SESSION_ID = '0a1b2c3d-1111-4222-8333-444455556666';
+
+let tmpRoot: string;
+let savedXdg: string | undefined;
+
+function openDb(): DatabaseSync {
+  const dbPath = opencodeDbPath();
+  mkdirSync(join(dbPath, '..'), { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS session (
+      id TEXT PRIMARY KEY,
+      parent_id TEXT,
+      directory TEXT NOT NULL,
+      title TEXT NOT NULL DEFAULT '',
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      time_archived INTEGER
+    );
+    CREATE TABLE IF NOT EXISTS message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+  `);
+  return db;
+}
+
+let idSeq = 0;
+
+function seedSession(db: DatabaseSync, opts: {
+  id: string; directory?: string; title?: string; parentId?: string | null;
+  timeUpdated?: number; timeArchived?: number | null;
+}): void {
+  db.prepare('INSERT INTO session (id, parent_id, directory, title, time_created, time_updated, time_archived) VALUES (?,?,?,?,?,?,?)')
+    .run(opts.id, opts.parentId ?? null, opts.directory ?? tmpRoot, opts.title ?? 'seeded', opts.timeUpdated ?? 1000, opts.timeUpdated ?? 1000, opts.timeArchived ?? null);
+}
+
+function seedUserPart(db: DatabaseSync, sessionId: string, text: string, timeCreated: number): void {
+  const mid = `msg_${++idSeq}`;
+  db.prepare('INSERT INTO message (id, session_id, time_created, data) VALUES (?,?,?,?)')
+    .run(mid, sessionId, timeCreated, JSON.stringify({ role: 'user' }));
+  db.prepare('INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?,?,?,?,?)')
+    .run(`prt_${++idSeq}`, mid, sessionId, timeCreated, JSON.stringify({ type: 'text', text }));
+}
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'oc-resume-unit-'));
+  savedXdg = process.env.XDG_DATA_HOME;
+  process.env.XDG_DATA_HOME = tmpRoot;
+});
+
+afterEach(() => {
+  if (savedXdg === undefined) delete process.env.XDG_DATA_HOME;
+  else process.env.XDG_DATA_HOME = savedXdg;
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('opencode buildArgs resume', () => {
+  it('falls back to the <session_id> text lookup when no cliSessionId persisted', () => {
+    const db = openDb();
+    seedSession(db, { id: 'ses_old', timeUpdated: 1000 });
+    seedSession(db, { id: 'ses_new', timeUpdated: 2000 });
+    seedUserPart(db, 'ses_old', `<session_id>${BOTMUX_SESSION_ID}</session_id>\n\nhi`, 1000);
+    seedUserPart(db, 'ses_new', `<session_id>${BOTMUX_SESSION_ID}</session_id>\n\nlater turn`, 2000);
+    db.close();
+
+    const adapter = createOpenCodeAdapter();
+    const args = adapter.buildArgs({ sessionId: BOTMUX_SESSION_ID, resume: true });
+    // 命中最近的那个 OpenCode 会话（同一 botmux 会话曾 fresh 降级重开时取最新）
+    expect(args).toEqual(['--session', 'ses_new']);
+  });
+
+  it('prefers the persisted cliSessionId over the text lookup', () => {
+    const db = openDb();
+    seedSession(db, { id: 'ses_bytext' });
+    seedUserPart(db, 'ses_bytext', `<session_id>${BOTMUX_SESSION_ID}</session_id>`, 1000);
+    db.close();
+
+    const adapter = createOpenCodeAdapter();
+    const args = adapter.buildArgs({ sessionId: BOTMUX_SESSION_ID, resume: true, resumeSessionId: 'ses_persisted' });
+    expect(args).toEqual(['--session', 'ses_persisted']);
+  });
+
+  it('keeps model flag ordering with --session', () => {
+    const adapter = createOpenCodeAdapter();
+    const args = adapter.buildArgs({ sessionId: BOTMUX_SESSION_ID, resume: true, resumeSessionId: 'ses_x', model: 'anthropic/claude-sonnet-4' });
+    expect(args).toEqual(['--model', 'anthropic/claude-sonnet-4', '--session', 'ses_x']);
+  });
+});
+
+describe('opencode checkResumeTargetExists', () => {
+  it('true when the session row exists', () => {
+    const db = openDb();
+    seedSession(db, { id: 'ses_here' });
+    db.close();
+    const adapter = createOpenCodeAdapter();
+    expect(adapter.checkResumeTargetExists!({ sessionId: BOTMUX_SESSION_ID, cliSessionId: 'ses_here' })).toBe(true);
+  });
+
+  it('false when the session row is gone (prevents "Session not found" crash-loop)', () => {
+    const db = openDb();
+    seedSession(db, { id: 'ses_other' });
+    db.close();
+    const adapter = createOpenCodeAdapter();
+    expect(adapter.checkResumeTargetExists!({ sessionId: BOTMUX_SESSION_ID, cliSessionId: 'ses_gone' })).toBe(false);
+  });
+
+  it('false when nothing resolvable (fresh fallback with user notice)', () => {
+    openDb().close();
+    const adapter = createOpenCodeAdapter();
+    expect(adapter.checkResumeTargetExists!({ sessionId: BOTMUX_SESSION_ID })).toBe(false);
+  });
+
+  it('undefined when the DB does not exist (secondary guard handles it)', () => {
+    const adapter = createOpenCodeAdapter();
+    expect(adapter.checkResumeTargetExists!({ sessionId: BOTMUX_SESSION_ID, cliSessionId: 'ses_x' })).toBeUndefined();
+  });
+});
+
+describe('opencode buildResumeCommand', () => {
+  it('emits opencode -s with the known id', () => {
+    const adapter = createOpenCodeAdapter();
+    expect(adapter.buildResumeCommand!({ sessionId: BOTMUX_SESSION_ID, cliSessionId: 'ses_abc123' })).toBe('opencode -s ses_abc123');
+  });
+
+  it('returns null when nothing resolvable', () => {
+    openDb().close();
+    const adapter = createOpenCodeAdapter();
+    expect(adapter.buildResumeCommand!({ sessionId: BOTMUX_SESSION_ID })).toBeNull();
+  });
+});
+
+describe('opencode listResumableSessions', () => {
+  it('lists top-level, unarchived sessions with existing directories, newest first', async () => {
+    const db = openDb();
+    seedSession(db, { id: 'ses_a', timeUpdated: 3000, title: 'newest' });
+    seedSession(db, { id: 'ses_b', timeUpdated: 2000, title: 'older' });
+    seedSession(db, { id: 'ses_child', timeUpdated: 5000, parentId: 'ses_a' });        // 子代理会话
+    seedSession(db, { id: 'ses_archived', timeUpdated: 4000, timeArchived: 4100 });     // 已归档
+    seedSession(db, { id: 'ses_gone_dir', timeUpdated: 4500, directory: join(tmpRoot, 'no-such-dir') });
+    db.close();
+
+    const adapter = createOpenCodeAdapter();
+    const rows = await adapter.listResumableSessions!({ limit: 10 });
+    expect(rows.map(r => r.cliSessionId)).toEqual(['ses_a', 'ses_b']);
+    expect(rows[0]).toMatchObject({ title: 'newest', cwd: tmpRoot, lastActivityAt: 3000 });
+  });
+
+  it('applies exclude before limit', async () => {
+    const db = openDb();
+    seedSession(db, { id: 'ses_live', timeUpdated: 3000 });
+    seedSession(db, { id: 'ses_free', timeUpdated: 2000 });
+    db.close();
+
+    const adapter = createOpenCodeAdapter();
+    const rows = await adapter.listResumableSessions!({ limit: 1, exclude: new Set(['ses_live']) });
+    expect(rows.map(r => r.cliSessionId)).toEqual(['ses_free']);
+  });
+});
+
+describe('opencode writeInput DB verification', () => {
+  function stubPty(onEnter?: () => void): PtyHandle & { enters: number } {
+    const handle = {
+      enters: 0,
+      write(_data: string) { /* raw pty path unused in this stub */ },
+      sendText(_text: string) { /* typed */ },
+      sendSpecialKeys(..._keys: string[]) {
+        handle.enters++;
+        onEnter?.();
+      },
+    };
+    return handle;
+  }
+
+  it('captures cliSessionId when the user part lands after the baseline', async () => {
+    const db = openDb();
+    seedSession(db, { id: 'ses_target' });
+    seedUserPart(db, 'ses_target', 'earlier turn', 1000);
+    const content = `<session_id>${BOTMUX_SESSION_ID}</session_id>\n\nhello from lark`;
+    // 模拟 OpenCode：Enter 落下时把 user part 写库
+    const pty = stubPty(() => {
+      if (pty.enters === 1) seedUserPart(db, 'ses_target', content, Date.now());
+    });
+
+    const adapter = createOpenCodeAdapter();
+    const result = await adapter.writeInput(pty, content);
+    db.close();
+    expect(result).toMatchObject({ submitted: true, cliSessionId: 'ses_target' });
+  });
+
+  it('does not re-match an identical pre-existing message (strict > baseline)', async () => {
+    const db = openDb();
+    seedSession(db, { id: 'ses_target' });
+    const content = 'same text resent';
+    seedUserPart(db, 'ses_target', content, Date.now());  // 上一轮同文本，就在基线上
+    db.close();
+    const pty = stubPty();
+
+    const adapter = createOpenCodeAdapter();
+    const result = await adapter.writeInput(pty, content);
+    expect(result).toMatchObject({ submitted: false });
+    expect((result as any).recheck).toBeTypeOf('function');
+  }, 15_000);
+
+  it('skips verification for slash commands (TUI command palette, no user row)', async () => {
+    openDb().close();
+    const pty = stubPty();
+    const adapter = createOpenCodeAdapter();
+    const result = await adapter.writeInput(pty, '/help');
+    expect(result).toBeUndefined();
+    expect(pty.enters).toBe(1);  // 无重试 Enter，避免误触面板
+  });
+
+  it('stays blind (undefined) when the DB is missing', async () => {
+    const pty = stubPty();
+    const adapter = createOpenCodeAdapter();
+    const result = await adapter.writeInput(pty, 'no db yet');
+    expect(result).toBeUndefined();
+  });
+});

--- a/test/workflow-attempt-resume.test.ts
+++ b/test/workflow-attempt-resume.test.ts
@@ -229,6 +229,28 @@ describe('AttemptResumeManager', () => {
 
   it('rejects CLIs without precise resume support', async () => {
     const tmp = join(tmpdir(), `wf-resume-${Date.now()}-${Math.random()}`);
+    const ids = seedAttempt(tmp, { cliSessionId: null, cliId: 'gemini' });
+    const { factory, spawns } = makeFactory();
+    try {
+      const manager = new AttemptResumeManager({
+        runsDir: tmp,
+        externalHost: 'dash.local',
+        workerPath: '/worker.js',
+        factory,
+        resolveBot: () => ({ ...bot, cliId: 'gemini' }),
+      });
+
+      const result = await manager.start(ids);
+
+      expect(result).toMatchObject({ ok: false, error: 'resume_unsupported_cli' });
+      expect(spawns).toHaveLength(0);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('opencode requires a captured native cliSessionId (no <session_id> block in workflow prompts)', async () => {
+    const tmp = join(tmpdir(), `wf-resume-${Date.now()}-${Math.random()}`);
     const ids = seedAttempt(tmp, { cliSessionId: null, cliId: 'opencode' });
     const { factory, spawns } = makeFactory();
     try {
@@ -242,7 +264,7 @@ describe('AttemptResumeManager', () => {
 
       const result = await manager.start(ids);
 
-      expect(result).toMatchObject({ ok: false, error: 'resume_unsupported_cli' });
+      expect(result).toMatchObject({ ok: false, error: 'missing_cli_session_id' });
       expect(spawns).toHaveLength(0);
     } finally {
       rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
## 背景

OpenCode 适配器此前不支持 resume——注释里写着「Resume not supported — always start fresh」。后果：idle 挂起（suspendWorker 冷恢复）、daemon 重启、CLI 崩溃自动重启时 **上下文全丢**。用户建议试试 `opencode -s <session_id>`。

## 实测结论（opencode 1.17.11）

- ✅ `-s/--session <id>` 可精确续接：同目录重启后历史完整加载，新消息落在同一 session 行
- ⚠️ `-s` + `--prompt` 组合下 **--prompt 被静默忽略**（新消息不会提交）——resume 时初始 prompt 必须改走 stdin
- ⚠️ `-s <不存在的id>` 立即 exit 1 `Session not found`——不预检会被 daemon 自动重启放大成 crash-loop
- OpenCode 1.17 会话存储是全局 SQLite（`~/.local/share/opencode/opencode.db`，session/message/part 表），WAL 模式可并发只读

## 实现

**适配器（traex 同款 node:sqlite 模式）**
- `buildArgs`：resume 时优先用持久化 cliSessionId（校验 `ses_*` 形状，防 CLI 切换后串用别家 id）；否则按 botmux prompt 里的 `<session_id>` 块在 part 表文本反查（codex history 兜底同款）；都找不到→退化 fresh，绝不带无效 id 启动
- `writeInput`：DB 提交验证（**严格 > 基线**——`>=` 会在用户重发同文本时把真丢失误报成已提交）+ 重试 Enter + 延迟 recheck，顺带捕获 cliSessionId 持久化；斜杠命令跳过验证（TUI 命令面板不落 user 行，重试 Enter 还可能误触面板项）
- `checkResumeTargetExists`：session 表预检，防 crash-loop；DB 不可读（node:sqlite 缺失/首次运行/sandbox overlay）→ undefined 交给二级护栏
- `buildResumeCommand` → `opencode -s <id>`（closed-session 卡片可复制命令）
- `listResumableSessions` → /adopt 导入支持（顶层未归档会话，按 time_updated 倒序）

**worker（resume 时 prompt 改走输入队列）**
- 新增 `CliAdapter.initialPromptArgsIgnoredOnResume`；spawnCli 与 init handler 两处 defer 条件镜像（用 spawnCli 写回的 `lastSpawnEffectiveResume`，adopt 显式排除防脏读）

**workflow attempt-resume**
- opencode 归入 `RESUME_REQUIRES_CLI_SESSION_ID`：workflow prompt 不带 `<session_id>` 块，反查兜底不可用，缺捕获 id 时明确报错而不是静默新起会话

**顺手修的两个既有问题**
- `traex.ts`：ESM 下裸 `require('node:sqlite')` 抛 ReferenceError 被 try/catch 吞掉 → 生产 dist 里 traex 的 SQLite 提交验证/会话反查**整条链路静默失效**（实测确认），改用 `createRequire`
- `test/bot-config-editor.test.ts`：#336 接入 Genius 在 setup 菜单 7 号插位后序号顺移，断言过期（master 上已红）

## 测试

- 新增 `test/opencode-resume.test.ts` ×15（假 DB 驱动：buildArgs 反查/优先级、probe 三态、listResumableSessions 过滤、writeInput 捕获/严格基线/斜杠跳过/无 DB 盲发）
- 真机全链路 e2e（真 opencode 二进制）：fresh(--prompt 含 session_id 块) → DB 反查发现 → probe true/false → `--session` 重启 → writeInput 验证+捕获 → 追问落在同一 session、目录下仅 1 个会话 ✅
- `BOTMUX_E2E=1 vitest --project e2e test/opencode-input.e2e.ts` 10/10 ✅
- 全量单测：仅剩本机已知环境性失败（terminal-url ×7、recall-frozen-cards ×1）