### PR TITLE
feat(lark): 平台团队 bot 免 /grant——union_id 自学、roster team-sync 落盘与闸门接入

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -16,6 +16,7 @@ import * as sandboxStore from '../services/sandbox-store.js';
 import * as cardPrefsStore from '../services/card-prefs-store.js';
 import * as observedBotsStore from '../services/observed-bots-store.js';
 import { getDeploymentIdentity } from '../services/deployment-identity.js';
+import { getBotUnionId } from '../services/bot-union-ids-store.js';
 import * as grantPrefsStore from '../services/grant-prefs-store.js';
 import { findConfigField, applyConfigField, coerceConfigValue } from '../services/bot-config-store.js';
 import { summaryRangeFromBotConfig, updateDashboardSummaryRange } from '../services/summary-range-store.js';
@@ -1071,6 +1072,26 @@ ipcRoute('POST', '/api/groups/:chatId/leave', async (_req, res, p) => {
   if (!cachedLarkAppId) return jsonRes(res, 503, { error: 'larkAppId_not_set' });
   const r = await groupsStore.leaveChat(cachedLarkAppId, p.chatId);
   jsonRes(res, 200, r);
+});
+
+// 平台团队大厅打卡：dashboard 在 team-sync 后让"还没学到自己 union_id"的 bot 往
+// 大厅（bot-only 群）发一条消息 —— 自家消息回声带回 union_id（event-dispatcher
+// 的 isSelfMessage 捕获落盘），随心跳上报平台进团队 roster。学到后幂等跳过。
+ipcRoute('POST', '/api/platform/hall-announce', async (req, res) => {
+  if (!cachedLarkAppId) return jsonRes(res, 503, { ok: false, error: 'larkAppId_not_set' });
+  let body: { chatId?: unknown };
+  try { body = await readJsonBody(req); } catch { return jsonRes(res, 400, { ok: false, error: 'bad_json' }); }
+  const chatId = typeof body.chatId === 'string' ? body.chatId.trim() : '';
+  if (!/^oc_[0-9a-f]+$/i.test(chatId)) return jsonRes(res, 400, { ok: false, error: 'bad_chat_id' });
+  if (getBotUnionId(config.session.dataDir, cachedLarkAppId)) {
+    return jsonRes(res, 200, { ok: true, skipped: 'already_learned' });
+  }
+  try {
+    await sendMessage(cachedLarkAppId, chatId, t('platform.hall_announce', undefined, localeForBot(cachedLarkAppId)), 'text');
+    jsonRes(res, 200, { ok: true });
+  } catch (e) {
+    jsonRes(res, 502, { ok: false, error: `send_failed: ${(e as Error).message}` });
+  }
 });
 
 // ─── Oncall bindings (dashboard) ───────────────────────────────────────────

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -528,8 +528,11 @@ export async function enforceMessageQuotaForCliInput(
   senderOpenId: string | undefined,
   messageId: string,
   anchor: string,
+  senderUnionId?: string,
 ): Promise<boolean> {
-  const ev = evaluateTalk(larkAppId, chatId, senderOpenId);
+  // senderUnionId 让 evaluateTalk 认出跨部署团队 peer bot（teamBot 腿）——否则
+  // 外部 bot 闸门放进来的团队 bot 消息会在这里被复查拦掉、静默丢弃。
+  const ev = evaluateTalk(larkAppId, chatId, senderOpenId, senderUnionId);
   if (!ev.allowed) {
     logger.debug(`[quota:${larkAppId}] dropping message ${messageId.substring(0, 12)} from non-allowed sender ${senderOpenId?.substring(0, 12) ?? '?'}`);
     return false;
@@ -2328,6 +2331,8 @@ async function startInitialPassthroughSession(args: {
   parsed: LarkMessage;
   commandContent: string;
   senderOpenId?: string;
+  /** Sender's tenant-stable union_id (quota gate's teamBot leg). */
+  senderUnionId?: string;
   /** Ownership is the CALLER's call — required fields, no sender fallback.
    *  A bot-started cold start must pass undefined (mirrors the auto-create
    *  path): a foreign-bot owner makes daemon-generated footers wake that bot
@@ -2338,9 +2343,9 @@ async function startInitialPassthroughSession(args: {
 }): Promise<void> {
   const {
     larkAppId, chatId, chatType, scope, anchor, messageId, replyRootId,
-    parsed, commandContent, senderOpenId, ownerOpenId, ownerUnionId, creatorOpenId,
+    parsed, commandContent, senderOpenId, senderUnionId, ownerOpenId, ownerUnionId, creatorOpenId,
   } = args;
-  if (!await enforceMessageQuotaForCliInput(larkAppId, chatId, senderOpenId, messageId, anchor)) {
+  if (!await enforceMessageQuotaForCliInput(larkAppId, chatId, senderOpenId, messageId, anchor, senderUnionId)) {
     return;
   }
 
@@ -2479,6 +2484,14 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
 
   // senderOpenId 已在上方（force-topic grant 限制前）声明；这里只补 master 新增的 senderUnionId。
   const senderUnionId: string | undefined = data.sender?.sender_id?.union_id;
+  // union_id 信任腿（canOperate/evaluateTalk 的 teamBot）只对**飞书盖章的 bot 发送方**
+  // 生效：平台 roster 是成员机器自报的，若不锁 sender_type，恶意成员把某个真人的
+  // union_id 报成"自家 bot"，那个真人就会在全团队机器上被当队友 bot 放行（talk +
+  // operate），破坏「人绝不继承 bot 信任」的边界。旧联邦 team-bots 表结构上只收
+  // bot（学习入口限 bot sender），这里对齐同一不变量。senderUnionId 本身保持原义
+  //（人类会话的 ownerUnionId 还靠它）。
+  const teamTrustUnionId: string | undefined =
+    (data.sender?.sender_type === 'app' || data.sender?.sender_type === 'bot') ? senderUnionId : undefined;
   const botCfg = getBot(larkAppId).config;
   logger.info(`New session: "${content.substring(0, 60)}" (scope=${scope}, anchor=${anchor.substring(0, 12)}, resources: ${resources.length}, active: ${getActiveCount()}, messageId: ${messageId}, chatId: ${chatId})`);
   emitHookEvent('topic.new', {
@@ -2557,6 +2570,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
           parsed,
           commandContent,
           senderOpenId,
+          senderUnionId: teamTrustUnionId,
           // New-topic senders are humans here (mirrors the normal new-topic
           // spawn path, which assigns ownership unconditionally too).
           ownerOpenId: senderOpenId,
@@ -2574,7 +2588,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
       // chat-granted users (who only pass canTalk) management commands like
       // /cd /restart /oncall bind. Previously this gate only fired in oncall chats,
       // which left a hole once per-chat grants flow through canTalk.
-      if (!canOperate(larkAppId, chatId, senderOpenId, senderUnionId)) {
+      if (!canOperate(larkAppId, chatId, senderOpenId, teamTrustUnionId)) {
         await sessionReply(anchor, tr('daemon.cmd_allowed_users_only', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
         return;
       }
@@ -2641,7 +2655,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
     }
   }
 
-  if (!await enforceMessageQuotaForCliInput(larkAppId, chatId, senderOpenId, messageId, anchor)) {
+  if (!await enforceMessageQuotaForCliInput(larkAppId, chatId, senderOpenId, messageId, anchor, teamTrustUnionId)) {
     return;
   }
 
@@ -3106,6 +3120,11 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
   // operate, parity with same-deployment siblings (option B). undefined for
   // senders Lark didn't stamp a union_id on → no team-operate, falls back.
   const threadSenderUnionId = data?.sender?.sender_id?.union_id as string | undefined;
+  // union_id 信任腿只对**飞书盖章的 bot 发送方**生效（isForeignBot 兜 sender_type
+  // 缺失但 cross-ref 认识的自家 peer）：平台 roster 是成员机器自报的，不锁 sender
+  // 类型的话，把真人 union_id 报成 bot 就能让真人在全团队被当队友 bot 放行
+  //（talk + operate）。与旧联邦 team-bots「学习入口限 bot sender」同一不变量。
+  const threadTeamTrustUnionId = (isBotSenderType || isForeignBot) ? threadSenderUnionId : undefined;
   const threadChatId = ctxChatId ?? data?.message?.chat_id;
   const clearAgentAttentionForHumanInbound = (): void => {
     if (isForeignBot || isBotSenderType) return;
@@ -3204,6 +3223,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
           parsed,
           commandContent,
           senderOpenId: threadSenderOpenId,
+          senderUnionId: threadTeamTrustUnionId,
           // Bot-started cold starts get no human owner (mirrors the auto-create
           // path) — see the ownership note on startInitialPassthroughSession.
           ownerOpenId: isForeignBot ? undefined : threadSenderOpenId,
@@ -3246,7 +3266,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
       }
       // canOperate gate for thread-reply daemon commands — required in every chat
       // (see spawn-path gate above). Denies chat-granted users management commands.
-      if (!canOperate(larkAppId, effectiveThreadChatId, threadSenderOpenId, threadSenderUnionId)) {
+      if (!canOperate(larkAppId, effectiveThreadChatId, threadSenderOpenId, threadTeamTrustUnionId)) {
         sessionReply(anchor, tr('daemon.cmd_allowed_users_only', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
         return;
       }
@@ -3353,7 +3373,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
   }
 
   const quotaSenderOpenId = threadSenderOpenId;
-  if (!await enforceMessageQuotaForCliInput(larkAppId, ctxChatId ?? data?.message?.chat_id, quotaSenderOpenId, parsed.messageId, anchor)) {
+  if (!await enforceMessageQuotaForCliInput(larkAppId, ctxChatId ?? data?.message?.chat_id, quotaSenderOpenId, parsed.messageId, anchor, threadTeamTrustUnionId)) {
     return;
   }
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -96,7 +96,9 @@ import { isValidRoleProfileId } from './services/role-profile-store.js';
 import { mergeSafeInsightOverviews } from './services/insight/report.js';
 import type { SafeInsightOverview } from './services/insight/types.js';
 import { readPlatformBinding } from './platform/binding.js';
-import { startPlatformTunnelClient, type PlatformBotInfo } from './platform/tunnel-client.js';
+import { startPlatformTunnelClient, type PlatformBotInfo, type PlatformTeamSyncMessage } from './platform/tunnel-client.js';
+import { applyPlatformTeamSync, getPlatformTeamSyncRev, listPlatformTeams } from './services/platform-team-store.js';
+import { getBotUnionId } from './services/bot-union-ids-store.js';
 import { cleanupIdleSessions, parseIdleCleanupHours } from './dashboard/session-cleanup.js';
 
 const SECRET_PATH = join(homedir(), '.botmux', '.dashboard-secret');
@@ -2711,6 +2713,9 @@ function readPlatformBotsInfo(): PlatformBotInfo[] {
           avatar: e.botAvatarUrl || undefined,
           cli: e.cliId,
           showInTeam: cfg?.showInTeam !== false, // default true
+          // 自家消息回声学到的租户稳定 union_id（可能尚未学到 → undefined）。
+          // 平台聚合团队 roster 用，见 bot-union-ids-store / platform-team-store。
+          unionId: e.larkAppId ? getBotUnionId(config.session.dataDir, e.larkAppId) : undefined,
         };
       })
       .filter((b) => b.appId);
@@ -2730,11 +2735,79 @@ function startPlatformTunnelIfBound(): void {
       getDashboardToken: () => activeToken,
       getVersion: () => version,
       getBots: () => readPlatformBotsInfo(),
+      getTeamSyncRev: () => getPlatformTeamSyncRev(config.session.dataDir),
+      onTeamSync: handlePlatformTeamSync,
       log: (msg, extra) => logger.info(`[platform-tunnel] ${msg}${extra ? ' ' + JSON.stringify(extra) : ''}`),
     });
     logger.info(`[platform-tunnel] 绑定到 ${binding.platformUrl}，启动隧道`);
+    // 大厅打卡自愈重试：team-sync 应用时会立即尝试一次；这里的低频周期兜住
+    // "当时 daemon 离线 / bot 还没进大厅 / 发送失败"的漏拍。无平台绑定不启动。
+    const hallTimer = setInterval(() => { void maybeAnnounceHallPresence(); }, 5 * 60 * 1000);
+    hallTimer.unref();
   } catch (e) {
     logger.warn(`[platform-tunnel] 启动失败: ${(e as Error).message}`);
+  }
+}
+
+/** 平台 team-sync 落盘（roster + 团队群镜像），随后触发一轮大厅打卡检查。 */
+function handlePlatformTeamSync(payload: PlatformTeamSyncMessage): void {
+  const applied = applyPlatformTeamSync(config.session.dataDir, payload);
+  if (!applied) {
+    logger.warn('[platform-tunnel] team-sync 负载无效，忽略');
+    return;
+  }
+  logger.info(`[platform-tunnel] team-sync 已应用 rev=${applied.rev} teams=${applied.teams.length}`);
+  void maybeAnnounceHallPresence();
+}
+
+// 大厅打卡（union_id 自学触发）节流：per-bot 最小间隔 + 每进程尝试上限。打卡消息
+// 本身只有 bot 可见（大厅是 bot-only 群），上限只是防御发送持续失败时的无谓重试。
+const hallAnnounceState = new Map<string, { lastAt: number; tries: number }>();
+const HALL_ANNOUNCE_MIN_INTERVAL_MS = 10 * 60 * 1000;
+const HALL_ANNOUNCE_MAX_TRIES = 6;
+
+/**
+ * 让还没学到自己 union_id 的本地 bot 去团队大厅发一条打卡消息：自家消息回声
+ * （event-dispatcher isSelfMessage 分支）带回 sender.sender_id.union_id → 落盘
+ * bot-union-ids → 下个心跳上报平台进 roster。一辈子一次；学到即永久跳过。
+ * 顺带的副作用：大厅在各成员机器的 team-groups 里（team-sync 镜像），其他
+ * daemon 收到这条消息会直接 recordTeamBot 学到该 bot——roster 之外的即时互学。
+ */
+async function maybeAnnounceHallPresence(): Promise<void> {
+  try {
+    const dataDir = config.session.dataDir;
+    const teams = listPlatformTeams(dataDir);
+    if (teams.length === 0) return;
+    const localBotIds = new Set(readPlatformBotsInfo().map(b => b.appId));
+    const now = Date.now();
+    for (const team of teams) {
+      const hallChatId = team.groupChatIds[0];
+      if (!hallChatId) continue;
+      for (const bot of team.bots) {
+        if (!localBotIds.has(bot.appId)) continue;            // 别的机器的 bot
+        if (getBotUnionId(dataDir, bot.appId)) continue;      // 已学到 → 永久跳过
+        const st = hallAnnounceState.get(bot.appId);
+        if (st && (now - st.lastAt < HALL_ANNOUNCE_MIN_INTERVAL_MS || st.tries >= HALL_ANNOUNCE_MAX_TRIES)) continue;
+        hallAnnounceState.set(bot.appId, { lastAt: now, tries: (st?.tries ?? 0) + 1 });
+        try {
+          const r = await proxyToDaemon(bot.appId, '/api/platform/hall-announce', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ chatId: hallChatId }),
+          });
+          const j = await r.json().catch(() => ({} as { ok?: boolean; error?: string }));
+          if (!r.ok || !(j as { ok?: boolean }).ok) {
+            logger.warn(`[platform-tunnel] 大厅打卡失败 bot=${bot.appId} chat=${hallChatId.substring(0, 12)}: ${(j as { error?: string }).error ?? r.status}`);
+          } else {
+            logger.info(`[platform-tunnel] 大厅打卡已发 bot=${bot.appId} chat=${hallChatId.substring(0, 12)}（等待回声学 union_id）`);
+          }
+        } catch (e) {
+          logger.warn(`[platform-tunnel] 大厅打卡请求异常 bot=${bot.appId}: ${(e as Error).message}`);
+        }
+      }
+    }
+  } catch (e) {
+    logger.warn(`[platform-tunnel] 大厅打卡检查异常: ${(e as Error).message}`);
   }
 }
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -72,6 +72,9 @@ export const messages: Record<string, string> = {
   'card.repo.worktree_rolled_back': 'Worktree creation failed on {repo}: {error}. Rolled back {count} worktree(s) already created in this batch.',
   'card.repo.toast_worktree_creating': 'Creating worktree — will post in the thread when done…',
 
+  // Platform team hall check-in (bot-only group, visible to bots only)
+  'platform.hall_announce': '🤖 Team check-in: this bot is online (registers its union_id, no reply needed)',
+
   // In-group authorization card
   'card.grant.title': '🔑 Access Request',
   'card.grant.body_request': 'Sender **{name}** is requesting to use me in this chat. <at id={owner}></at> allow them to talk to me here?',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -75,6 +75,9 @@ export const messages: Record<string, string> = {
   'card.repo.worktree_rolled_back': '{repo} 创建 worktree 失败：{error}。已回滚本批次此前创建的 {count} 个 worktree。',
   'card.repo.toast_worktree_creating': '正在创建 worktree，完成后会在话题里通知…',
 
+  // 平台团队大厅打卡（bot-only 群，仅 bot 可见）
+  'platform.hall_announce': '🤖 团队登记打卡：本 bot 上线（登记身份 union_id 用，无需回复）',
+
   // 群内授权卡片
   'card.grant.title': '🔑 使用授权',
   'card.grant.body_request': '发送方 **{name}** 申请在本群使用我。<at id={owner}></at> 是否允许 ta 在本群与我对话？',

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -19,6 +19,8 @@ import { resolveNonsupportMessage, stripLeadingMentions, mentionOpenId } from '.
 import { recordObservedBots, listObservedBots } from '../../services/observed-bots-store.js';
 import { isTeamBot, recordTeamBot } from '../../services/team-bots-store.js';
 import { isTeamGroupChat } from '../../services/team-groups-store.js';
+import { isPlatformTeamBot } from '../../services/platform-team-store.js';
+import { recordBotUnionId } from '../../services/bot-union-ids-store.js';
 import { getDocSubscription, listAllDocSubscriptions, type DocSubscription } from '../../services/doc-subs-store.js';
 import { getDocComment, isBotAuthoredReply, hasBotSentinel, commentTriggerAllowed } from './doc-comment.js';
 import { BOTMUX_REQUIRED_SCOPES, DOC_FEATURE_SCOPES, DOC_COMMENT_EVENT, buildScopeDeepLink } from '../../setup/verify-permissions.js';
@@ -614,13 +616,20 @@ export function isKnownPeerBot(dataDir: string, larkAppId: string, senderOpenId:
  * `isKnownPeerBot` (same-deployment siblings) is checked separately by callers;
  * this covers cross-deployment TEAM peers. Returns false when neither holds, so
  * the caller falls back to the /grant request card.
+ *
+ * 平台团队与旧版联邦团队同权：isPlatformTeamBot（平台 team-sync 下发的团队 bot
+ * union_id roster）与 isTeamBot（团队群里学来的 union_id）都是 union_id 锚定的
+ * bot 专属信任；平台拉的团队群则经 platform: 前缀镜像进 team-groups，走同一个
+ * isTeamGroupChat。两条路都算团队模式，都不需要 /grant。
  */
 export function isTrustedTeamBotSender(
   dataDir: string,
   chatId: string | undefined,
   senderUnionId: string | undefined,
 ): boolean {
-  return isTeamBot(dataDir, senderUnionId) || isTeamGroupChat(dataDir, chatId);
+  return isTeamBot(dataDir, senderUnionId)
+    || isPlatformTeamBot(dataDir, senderUnionId)
+    || isTeamGroupChat(dataDir, chatId);
 }
 
 /** Update the per-bot cross-reference from @mention data in an event.
@@ -914,6 +923,7 @@ export type TalkReason =
   | 'allowedUser'
   | 'oncall'
   | 'peer'
+  | 'teamBot'
   | 'allowedChatGroup'
   | 'open'
   | 'chatGrant'
@@ -964,11 +974,11 @@ function hasConfiguredAllowlist(bot: ReturnType<typeof getBot>): boolean {
     || (bot.config.globalGrants?.length ?? 0) > 0;
 }
 
-export function canTalk(larkAppId: string, chatId: string | undefined, senderOpenId: string | undefined): boolean {
-  return evaluateTalk(larkAppId, chatId, senderOpenId).allowed;
+export function canTalk(larkAppId: string, chatId: string | undefined, senderOpenId: string | undefined, senderUnionId?: string): boolean {
+  return evaluateTalk(larkAppId, chatId, senderOpenId, senderUnionId).allowed;
 }
 
-export function evaluateTalk(larkAppId: string, chatId: string | undefined, senderOpenId: string | undefined): TalkEvaluation {
+export function evaluateTalk(larkAppId: string, chatId: string | undefined, senderOpenId: string | undefined, senderUnionId?: string): TalkEvaluation {
   const bot = getBot(larkAppId);
   // allowedChatGroups 是"talk-open 的 chat_id 列表"：当前消息来自其中之一即放行（仅 canTalk）。
   // 成员关系隐含在"能在该 chat 发言"里 —— 退群者发不了言自动失权，新人进群即生效，无需成员快照。
@@ -985,6 +995,14 @@ export function evaluateTalk(larkAppId: string, chatId: string | undefined, send
     return { allowed: true, reason: 'oncall' };
   }
   if (isKnownPeerBot(config.session.dataDir, larkAppId, senderOpenId)) return { allowed: true, reason: 'peer' };
+  // 跨部署团队 peer bot（旧版联邦学来的 union_id / 平台 roster 下发的 union_id）——
+  // 与 isKnownPeerBot 兄弟 bot 对等的 talk 放行。没有这一腿，外部 bot 闸门
+  //（isTrustedTeamBotSender）放进来的团队 bot 消息会在 enforceMessageQuotaForCliInput
+  // 的 evaluateTalk 复查处被静默丢弃（受限 bot 上 #332 的端到端断点）。仅认租户
+  // 稳定 union_id（bot 专属，人不会进这两张表），不看 chatId，不授 operate。
+  if (senderUnionId && (isTeamBot(config.session.dataDir, senderUnionId) || isPlatformTeamBot(config.session.dataDir, senderUnionId))) {
+    return { allowed: true, reason: 'teamBot' };
+  }
   if (chatId && bot.config.allowedChatGroups?.includes(chatId)) return { allowed: true, reason: 'allowedChatGroup' };
 
   // globalGrants 与 allowedChatGroups 同样确立"有白名单"语义：只配 globalGrants 也算限制态，
@@ -1015,11 +1033,12 @@ export function canOperate(
   // 命令（让编排者能对子 bot 跑 /repo /cd 等）。
   if (isKnownPeerBot(config.session.dataDir, larkAppId, senderOpenId)) return true;
   // L2 跨部署「团队 peer bot」互信 operate（与 L1 兄弟 bot 对等，覆盖编排者给
-  // 队友派 /repo /cd 等）。**只认租户稳定的 union_id**（isTeamBot），不走
-  // isTrustedTeamBotSender 的「团队群成员」分支——那条按 chat 放行是 sender 无关
-  // 的，会把「团队群里的真人」也误放进 operate，破坏 allowedUsers 边界。union_id
-  // 是发送方专属、且必须先在团队群里被认证学习过才进表，所以人不会命中。
+  // 队友派 /repo /cd 等）。**只认租户稳定的 union_id**（isTeamBot / 平台 roster），
+  // 不走 isTrustedTeamBotSender 的「团队群成员」分支——那条按 chat 放行是 sender
+  // 无关的，会把「团队群里的真人」也误放进 operate，破坏 allowedUsers 边界。union_id
+  // 是发送方专属、且必须先被团队背书（团队群学习 / 平台 roster）才进表，人不会命中。
   if (isTeamBot(config.session.dataDir, senderUnionId)) return true;
+  if (isPlatformTeamBot(config.session.dataDir, senderUnionId)) return true;
   const allowedUsers = bot.resolvedAllowedUsers;
   // globalGrants（与 allowedChatGroups 同理）确立"有白名单"语义：只配 globalGrants 也算限制态，
   // 否则 canOperate 会 fall through 到"全开放"，把 talk-only 授权变成 operate 全开——正是 PR #46
@@ -1646,8 +1665,14 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
         if (isBotSenderType) {
           const senderOpenId = sender.sender_id?.open_id;
           const isSelfMessage = senderOpenId === getBot(larkAppId).botOpenId;
-          // Self messages: only echoed `/close` commands matter.
+          // Self messages: learn our OWN union_id from the echo first (the only
+          // reliable source — see bot-union-ids-store; reported to the platform
+          // on heartbeat for the team roster), then only echoed `/close` matters.
           if (isSelfMessage) {
+            const selfUnionId = sender.sender_id?.union_id as string | undefined;
+            if (selfUnionId && recordBotUnionId(config.session.dataDir, larkAppId, selfUnionId)) {
+              logger.info(`[${larkAppId}] learned own bot union_id from self-message echo`);
+            }
             try {
               const body = JSON.parse(message.content ?? '{}');
               if (body.text?.trim() !== '/close') return;

--- a/src/platform/tunnel-client.ts
+++ b/src/platform/tunnel-client.ts
@@ -15,6 +15,15 @@ export interface PlatformBotInfo {
   cli?: string;
   /** 团队页是否展示这个 bot（默认 true，按 bot 配置 showInTeam 上报）。 */
   showInTeam?: boolean;
+  /** bot 自己的租户稳定 union_id（自家消息回声学到，见 bot-union-ids-store）。
+   *  平台按团队聚合成 roster 随 team-sync 下发，成员机器据此免 /grant 互信。 */
+  unionId?: string;
+}
+
+/** 平台 team-sync 下发的原始负载（校验/落盘在 platform-team-store）。 */
+export interface PlatformTeamSyncMessage {
+  rev: string;
+  teams: unknown[];
 }
 
 export interface TunnelClientOptions {
@@ -26,6 +35,12 @@ export interface TunnelClientOptions {
   getVersion: () => string;
   /** 本机的 bot 清单（每次读最新；随心跳上报） */
   getBots?: () => PlatformBotInfo[];
+  /** 本机已应用的 team-sync rev（每次读最新；随 register/heartbeat 上报，平台
+   *  据此做版本比对：不一致才下发全量 team-sync）。 */
+  getTeamSyncRev?: () => string;
+  /** 平台下发 team-sync（团队 bot roster + 团队群清单）时回调；落盘与公告由
+   *  dashboard 侧处理，tunnel-client 只做传输。 */
+  onTeamSync?: (payload: PlatformTeamSyncMessage) => void;
   log: (msg: string, extra?: Record<string, unknown>) => void;
 }
 
@@ -97,7 +112,7 @@ export function startPlatformTunnelClient(opts: TunnelClientOptions): TunnelClie
     });
 
     sock.on('message', (data) => {
-      let msg: { type?: string; streamId?: string; teamId?: string; teamName?: string };
+      let msg: { type?: string; streamId?: string; teamId?: string; teamName?: string; rev?: string; teams?: unknown[] };
       try {
         msg = JSON.parse(data.toString());
       } catch {
@@ -109,6 +124,15 @@ export function startPlatformTunnelClient(opts: TunnelClientOptions): TunnelClie
         joinTeam(msg.teamId, msg.teamName || msg.teamId, sock);
       } else if (msg.type === 'leave-team' && msg.teamId) {
         leaveTeam(msg.teamId, sock);
+      } else if (msg.type === 'team-sync' && typeof msg.rev === 'string') {
+        opts.log('收到 team-sync', { rev: msg.rev, teams: Array.isArray(msg.teams) ? msg.teams.length : 0 });
+        try {
+          opts.onTeamSync?.({ rev: msg.rev, teams: Array.isArray(msg.teams) ? msg.teams : [] });
+        } catch (e) {
+          opts.log('team-sync 应用失败', { err: String(e) });
+        }
+        // 立即回一拍心跳带上新 rev，平台好知道已收敛（否则等下个 30s 周期）。
+        sendHeartbeat(sock);
       } else if (msg.type === 'unbound') {
         handleUnbound(sock);
       }
@@ -155,6 +179,7 @@ export function startPlatformTunnelClient(opts: TunnelClientOptions): TunnelClie
       directHosts: localDirectHosts(opts.getDashboardPort()),
       memberships: teams,
       bots: opts.getBots?.() ?? [],
+      teamSyncRev: opts.getTeamSyncRev?.() ?? '',
     });
   }
 
@@ -166,6 +191,7 @@ export function startPlatformTunnelClient(opts: TunnelClientOptions): TunnelClie
       directHosts: localDirectHosts(opts.getDashboardPort()),
       memberships: teams,
       bots: opts.getBots?.() ?? [],
+      teamSyncRev: opts.getTeamSyncRev?.() ?? '',
     });
   }
 

--- a/src/services/bot-union-ids-store.ts
+++ b/src/services/bot-union-ids-store.ts
@@ -1,0 +1,64 @@
+/**
+ * Self bot union_id store: each LOCAL bot's own tenant-stable `union_id`.
+ *
+ * Why we need it: the platform aggregates a team roster of bot union_ids and
+ * pushes it to member deployments (see [[platform-team-store]]), so receivers
+ * can trust a teammate bot in ANY chat without /grant. But a bot cannot ask
+ * Feishu for its own union_id — /bot/v3/info doesn't return it and the contact
+ * API can't resolve bot open_ids. The only reliable source is the bot's own
+ * message ECHO: a group message the bot sends is delivered back to its own
+ * daemon (im:message.group_msg) with `sender.sender_id.union_id` stamped.
+ *
+ * Written from the event dispatcher's self-message branch (once per bot —
+ * idempotent), read by the platform tunnel heartbeat (PlatformBotInfo.unionId).
+ *
+ * Storage: `{dataDir}/bot-union-ids.json` — { [larkAppId]: { unionId, learnedAt } }
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
+
+type FileEntry = { unionId: string; learnedAt: number };
+type FileShape = Record<string, FileEntry>;
+
+function filePath(dataDir: string): string {
+  return join(dataDir, 'bot-union-ids.json');
+}
+
+function readFile(dataDir: string): FileShape {
+  const fp = filePath(dataDir);
+  if (!existsSync(fp)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(fp, 'utf-8'));
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed as FileShape;
+  } catch { /* corrupt — fall through */ }
+  return {};
+}
+
+/** This bot's own learned union_id, or undefined if not yet echoed. */
+export function getBotUnionId(dataDir: string, larkAppId: string): string | undefined {
+  const id = (larkAppId ?? '').trim();
+  if (!id) return undefined;
+  return readFile(dataDir)[id]?.unionId;
+}
+
+/**
+ * Persist a bot's own union_id learned from its message echo. Returns true iff
+ * the store changed (first learn or a corrected value), so callers can log
+ * exactly once. No-op on empty ids.
+ */
+export function recordBotUnionId(
+  dataDir: string,
+  larkAppId: string,
+  unionId: string,
+  now: number = Date.now(),
+): boolean {
+  const app = (larkAppId ?? '').trim();
+  const uid = (unionId ?? '').trim();
+  if (!app || !uid) return false;
+  const data = readFile(dataDir);
+  if (data[app]?.unionId === uid) return false;
+  data[app] = { unionId: uid, learnedAt: now };
+  atomicWriteFileSync(filePath(dataDir), JSON.stringify(data, null, 2) + '\n');
+  return true;
+}

--- a/src/services/platform-team-store.ts
+++ b/src/services/platform-team-store.ts
@@ -1,0 +1,148 @@
+/**
+ * Platform-team trust store: the centralized botmux platform's view of the
+ * teams THIS machine belongs to — teammate bot union_ids + team group chats
+ * (机器人大厅 etc.), pushed by the platform over the tunnel control channel
+ * (`team-sync`, see platform repo tunnel/protocol).
+ *
+ * This is the PLATFORM counterpart of the legacy federation trust stores
+ * ([[team-bots-store]] / [[team-groups-store]]): both feed the same auth gate
+ * (isTrustedTeamBotSender / canOperate / evaluateTalk), so 平台团队 and 旧版
+ * hub/spoke 团队 are equally "team mode" — neither needs /grant.
+ *
+ * Semantics differ from the learned store on purpose:
+ * - Entries are AUTHORITATIVE roster state, not passively learned — they are
+ *   replaced wholesale on every sync and follow team membership. No 30d expiry:
+ *   a bot removed from the team disappears on the next sync instead of aging out.
+ * - The version compare is declarative: the daemon reports `rev` (see
+ *   getPlatformTeamSyncRev) on register/heartbeat; the platform pushes the full
+ *   payload whenever its authoritative rev differs. Missed pushes self-heal on
+ *   the next heartbeat; a lost/corrupt local file self-heals the same way.
+ *
+ * Group chats are additionally mirrored into [[team-groups-store]] under the
+ * `platform:<teamId>` teamId prefix (replace-by-prefix, never touching legacy
+ * federation entries) so every existing isTeamGroupChat consumer — the
+ * first-contact trust leg AND the recordTeamBot learning gate — works unchanged.
+ *
+ * Storage: `{dataDir}/platform-team-sync.json`.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
+import { replaceTeamGroupsByPrefix } from './team-groups-store.js';
+
+/** teamId prefix used when mirroring platform team groups into team-groups.json. */
+export const PLATFORM_TEAM_PREFIX = 'platform:';
+
+export interface PlatformTeamBot {
+  appId: string;
+  unionId?: string;
+  name?: string;
+}
+
+export interface PlatformTeamSyncTeam {
+  teamId: string;
+  teamName: string;
+  /** Team-assembled group chats (机器人大厅 first) — trusted like 拉群 groups. */
+  groupChatIds: string[];
+  bots: PlatformTeamBot[];
+}
+
+export interface PlatformTeamSyncPayload {
+  rev: string;
+  teams: PlatformTeamSyncTeam[];
+}
+
+interface FileShape extends PlatformTeamSyncPayload {
+  updatedAt: number;
+}
+
+function filePath(dataDir: string): string {
+  return join(dataDir, 'platform-team-sync.json');
+}
+
+function readFile(dataDir: string): FileShape | null {
+  const fp = filePath(dataDir);
+  if (!existsSync(fp)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(fp, 'utf-8'));
+    if (parsed && typeof parsed === 'object' && typeof parsed.rev === 'string' && Array.isArray(parsed.teams)) {
+      return parsed as FileShape;
+    }
+  } catch { /* corrupt — fall through to null (rev mismatch → platform re-pushes) */ }
+  return null;
+}
+
+/** Sanitize one team entry from an untrusted tunnel payload. Null → drop. */
+function sanitizeTeam(raw: unknown): PlatformTeamSyncTeam | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const t = raw as Record<string, unknown>;
+  const teamId = typeof t.teamId === 'string' ? t.teamId.trim() : '';
+  if (!teamId) return null;
+  const teamName = typeof t.teamName === 'string' ? t.teamName : teamId;
+  const groupChatIds = Array.isArray(t.groupChatIds)
+    ? t.groupChatIds.filter((c): c is string => typeof c === 'string' && !!c.trim())
+    : [];
+  const bots: PlatformTeamBot[] = [];
+  if (Array.isArray(t.bots)) {
+    for (const b of t.bots) {
+      if (!b || typeof b !== 'object') continue;
+      const appId = typeof (b as Record<string, unknown>).appId === 'string' ? String((b as Record<string, unknown>).appId).trim() : '';
+      if (!appId) continue;
+      const unionId = typeof (b as Record<string, unknown>).unionId === 'string' ? String((b as Record<string, unknown>).unionId).trim() : '';
+      const name = typeof (b as Record<string, unknown>).name === 'string' ? String((b as Record<string, unknown>).name) : undefined;
+      bots.push({ appId, unionId: unionId || undefined, name });
+    }
+  }
+  return { teamId, teamName, groupChatIds, bots };
+}
+
+/**
+ * Apply a platform `team-sync` push: persist the payload (full-replace — it is
+ * the platform's complete view of THIS machine's teams) and mirror the group
+ * chats into team-groups.json under the platform prefix. Teams absent from the
+ * payload (machine left the team / team deleted) drop out of both stores.
+ */
+export function applyPlatformTeamSync(
+  dataDir: string,
+  payload: { rev?: unknown; teams?: unknown },
+  now: number = Date.now(),
+): PlatformTeamSyncPayload | null {
+  const rev = typeof payload?.rev === 'string' ? payload.rev.trim() : '';
+  if (!rev) return null;
+  const teams = (Array.isArray(payload?.teams) ? payload.teams : [])
+    .map(sanitizeTeam)
+    .filter((t): t is PlatformTeamSyncTeam => !!t);
+  const shape: FileShape = { rev, teams, updatedAt: now };
+  atomicWriteFileSync(filePath(dataDir), JSON.stringify(shape, null, 2) + '\n');
+  replaceTeamGroupsByPrefix(
+    dataDir,
+    PLATFORM_TEAM_PREFIX,
+    teams.flatMap(t => t.groupChatIds.map(chatId => ({ teamId: `${PLATFORM_TEAM_PREFIX}${t.teamId}`, chatId }))),
+    now,
+  );
+  return { rev, teams };
+}
+
+/** The rev of the last applied team-sync ('' when none) — reported on
+ *  register/heartbeat so the platform knows whether to re-push. */
+export function getPlatformTeamSyncRev(dataDir: string): string {
+  return readFile(dataDir)?.rev ?? '';
+}
+
+/** All platform teams this machine belongs to (last applied sync). */
+export function listPlatformTeams(dataDir: string): PlatformTeamSyncTeam[] {
+  return readFile(dataDir)?.teams ?? [];
+}
+
+/** Is `unionId` a bot in ANY platform team this machine belongs to? The auth
+ *  gate's platform-mode predicate — membership-driven, no expiry. */
+export function isPlatformTeamBot(dataDir: string, unionId: string | undefined): boolean {
+  const id = (unionId ?? '').trim();
+  if (!id) return false;
+  const data = readFile(dataDir);
+  if (!data) return false;
+  for (const t of data.teams) {
+    for (const b of t.bots) if (b.unionId === id) return true;
+  }
+  return false;
+}

--- a/src/services/team-groups-store.ts
+++ b/src/services/team-groups-store.ts
@@ -34,13 +34,43 @@ export function recordTeamGroup(dataDir: string, teamId: string, chatId: string,
   atomicWriteFileSync(filePath(dataDir), JSON.stringify(all, null, 2) + '\n');
 }
 
+/**
+ * Replace ALL entries whose teamId starts with `prefix` by `groups`, leaving
+ * other entries (e.g. legacy federation teams) untouched. Used by the platform
+ * team-sync mirror ([[platform-team-store]], prefix `platform:`): the platform
+ * push is the authoritative full view, so removal must work — append-only
+ * recordTeamGroup can't drop a dissolved hall / left team. Survivors keep
+ * their original createdAt.
+ */
+export function replaceTeamGroupsByPrefix(
+  dataDir: string,
+  prefix: string,
+  groups: Array<{ teamId: string; chatId: string }>,
+  now: number = Date.now(),
+): void {
+  if (!prefix) return;
+  const all = listTeamGroups(dataDir);
+  const kept = all.filter(b => !b.teamId.startsWith(prefix));
+  const prior = new Map(all.filter(b => b.teamId.startsWith(prefix)).map(b => [`${b.teamId}\u0000${b.chatId}`, b]));
+  const seen = new Set<string>();
+  for (const g of groups) {
+    if (!g.teamId.startsWith(prefix) || !g.chatId) continue; // caller must pre-prefix — never let platform data shadow legacy ids
+    const key = `${g.teamId}\u0000${g.chatId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    kept.push(prior.get(key) ?? { teamId: g.teamId, chatId: g.chatId, createdAt: now });
+  }
+  atomicWriteFileSync(filePath(dataDir), JSON.stringify(kept, null, 2) + '\n');
+}
+
 /** Is `chatId` a team-assembled (拉群) group of ANY team? This is the TRUST ROOT
  *  for team-bot collaboration: such a group is built by the team (bots added by
  *  larkAppId from the federated roster), so a bot speaking there is a vouched
  *  teammate (see [[team-bots-store]]). Recorded on the orchestrating deployment
  *  by recordTeamGroup, and mirrored onto member deployments when the hub returns
  *  groupChatIds on federation sync — so every member's auth gate sees the same
- *  trust boundary. */
+ *  trust boundary. Platform-mode 拉群 groups land here too, mirrored from
+ *  team-sync under the `platform:` teamId prefix (see [[platform-team-store]]). */
 export function isTeamGroupChat(dataDir: string, chatId: string | undefined): boolean {
   if (!chatId) return false;
   return listTeamGroups(dataDir).some(b => b.chatId === chatId);

--- a/test/bot-union-ids-store.test.ts
+++ b/test/bot-union-ids-store.test.ts
@@ -1,0 +1,44 @@
+/**
+ * bot-union-ids-store: a local bot's OWN union_id learned from its message echo
+ * (the platform roster's source of truth).
+ * Run: pnpm vitest run test/bot-union-ids-store.test.ts
+ */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { getBotUnionId, recordBotUnionId } from '../src/services/bot-union-ids-store.js';
+
+let dataDir: string;
+beforeEach(() => { dataDir = mkdtempSync(join(tmpdir(), 'botmux-unionid-')); });
+
+describe('bot-union-ids-store', () => {
+  it('records and reads back a bot union_id', () => {
+    expect(getBotUnionId(dataDir, 'cli_a')).toBeUndefined();
+    expect(recordBotUnionId(dataDir, 'cli_a', 'on_a')).toBe(true);
+    expect(getBotUnionId(dataDir, 'cli_a')).toBe('on_a');
+  });
+
+  it('is idempotent — same value reports no change', () => {
+    recordBotUnionId(dataDir, 'cli_a', 'on_a');
+    expect(recordBotUnionId(dataDir, 'cli_a', 'on_a')).toBe(false);
+    // a corrected value still writes
+    expect(recordBotUnionId(dataDir, 'cli_a', 'on_b')).toBe(true);
+    expect(getBotUnionId(dataDir, 'cli_a')).toBe('on_b');
+  });
+
+  it('rejects empty ids without polluting the store', () => {
+    expect(recordBotUnionId(dataDir, '', 'on_a')).toBe(false);
+    expect(recordBotUnionId(dataDir, 'cli_a', '')).toBe(false);
+    expect(recordBotUnionId(dataDir, 'cli_a', '   ')).toBe(false);
+    expect(getBotUnionId(dataDir, 'cli_a')).toBeUndefined();
+  });
+
+  it('keeps per-bot entries independent', () => {
+    recordBotUnionId(dataDir, 'cli_a', 'on_a');
+    recordBotUnionId(dataDir, 'cli_b', 'on_b');
+    expect(getBotUnionId(dataDir, 'cli_a')).toBe('on_a');
+    expect(getBotUnionId(dataDir, 'cli_b')).toBe('on_b');
+  });
+});

--- a/test/platform-team-store.test.ts
+++ b/test/platform-team-store.test.ts
@@ -1,0 +1,82 @@
+/**
+ * platform-team-store: apply/rev/roster predicate + the team-groups mirror
+ * (replace-by-prefix that must never touch legacy federation entries).
+ * Run: pnpm vitest run test/platform-team-store.test.ts
+ */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  applyPlatformTeamSync,
+  getPlatformTeamSyncRev,
+  isPlatformTeamBot,
+  listPlatformTeams,
+  PLATFORM_TEAM_PREFIX,
+} from '../src/services/platform-team-store.js';
+import { recordTeamGroup, isTeamGroupChat, listTeamGroups } from '../src/services/team-groups-store.js';
+
+let dataDir: string;
+beforeEach(() => { dataDir = mkdtempSync(join(tmpdir(), 'botmux-pfteam-')); });
+
+const payload = (rev: string, teams: unknown[]) => ({ rev, teams });
+const team = (teamId: string, chatIds: string[], bots: Array<{ appId: string; unionId?: string }>) =>
+  ({ teamId, teamName: teamId, groupChatIds: chatIds, bots });
+
+describe('applyPlatformTeamSync', () => {
+  it('persists rev + teams and answers the roster predicate', () => {
+    expect(getPlatformTeamSyncRev(dataDir)).toBe('');
+    const applied = applyPlatformTeamSync(dataDir, payload('rev1', [
+      team('t1', ['oc_hall'], [{ appId: 'cli_a', unionId: 'on_a' }, { appId: 'cli_b' }]),
+    ]));
+    expect(applied?.rev).toBe('rev1');
+    expect(getPlatformTeamSyncRev(dataDir)).toBe('rev1');
+    expect(listPlatformTeams(dataDir)).toHaveLength(1);
+    expect(isPlatformTeamBot(dataDir, 'on_a')).toBe(true);
+    expect(isPlatformTeamBot(dataDir, 'on_unknown')).toBe(false);
+    expect(isPlatformTeamBot(dataDir, undefined)).toBe(false);
+  });
+
+  it('mirrors group chats into team-groups under the platform prefix', () => {
+    applyPlatformTeamSync(dataDir, payload('rev1', [team('t1', ['oc_hall'], [])]));
+    expect(isTeamGroupChat(dataDir, 'oc_hall')).toBe(true);
+    const entry = listTeamGroups(dataDir).find(g => g.chatId === 'oc_hall');
+    expect(entry?.teamId).toBe(`${PLATFORM_TEAM_PREFIX}t1`);
+  });
+
+  it('re-apply REPLACES platform entries (left team / dissolved hall drop out)', () => {
+    applyPlatformTeamSync(dataDir, payload('rev1', [
+      team('t1', ['oc_hall1'], [{ appId: 'cli_a', unionId: 'on_a' }]),
+      team('t2', ['oc_hall2'], [{ appId: 'cli_b', unionId: 'on_b' }]),
+    ]));
+    // t2 gone, t1's hall rebuilt under a new chat id
+    applyPlatformTeamSync(dataDir, payload('rev2', [
+      team('t1', ['oc_hall1b'], [{ appId: 'cli_a', unionId: 'on_a' }]),
+    ]));
+    expect(isTeamGroupChat(dataDir, 'oc_hall1')).toBe(false);
+    expect(isTeamGroupChat(dataDir, 'oc_hall1b')).toBe(true);
+    expect(isTeamGroupChat(dataDir, 'oc_hall2')).toBe(false);
+    expect(isPlatformTeamBot(dataDir, 'on_b')).toBe(false);
+    expect(isPlatformTeamBot(dataDir, 'on_a')).toBe(true);
+  });
+
+  it('never touches legacy federation team-groups entries', () => {
+    recordTeamGroup(dataDir, 'legacyTeam', 'oc_legacy');
+    applyPlatformTeamSync(dataDir, payload('rev1', [team('t1', ['oc_hall'], [])]));
+    applyPlatformTeamSync(dataDir, payload('rev2', [])); // machine left all platform teams
+    expect(isTeamGroupChat(dataDir, 'oc_legacy')).toBe(true);
+    expect(isTeamGroupChat(dataDir, 'oc_hall')).toBe(false);
+  });
+
+  it('rejects a payload without rev and sanitizes malformed teams', () => {
+    expect(applyPlatformTeamSync(dataDir, { rev: '', teams: [] })).toBeNull();
+    const applied = applyPlatformTeamSync(dataDir, payload('rev1', [
+      null,
+      { teamName: 'no-id' },
+      team('ok', ['oc_x'], [{ appId: '' }, { appId: 'cli_a', unionId: 'on_a' }]),
+    ]));
+    expect(applied?.teams).toHaveLength(1);
+    expect(applied?.teams[0].bots).toEqual([{ appId: 'cli_a', unionId: 'on_a', name: undefined }]);
+  });
+});

--- a/test/platform-team-trust.test.ts
+++ b/test/platform-team-trust.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Platform-team trust through the auth gates: isTrustedTeamBotSender /
+ * canOperate / evaluateTalk must honour the platform roster (union_id) at
+ * parity with legacy federation team trust — 双模式都免 /grant.
+ * Run: pnpm vitest run test/platform-team-trust.test.ts
+ */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@larksuiteoapi/node-sdk', () => {
+  class FakeClient { constructor(public opts: Record<string, unknown>) {} }
+  return { Client: FakeClient };
+});
+
+import { config } from '../src/config.js';
+import { registerBot } from '../src/bot-registry.js';
+import { canOperate, evaluateTalk, isTrustedTeamBotSender } from '../src/im/lark/event-dispatcher.js';
+import { applyPlatformTeamSync } from '../src/services/platform-team-store.js';
+import { recordTeamBot } from '../src/services/team-bots-store.js';
+
+let dataDir: string;
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), 'botmux-pftrust-'));
+  config.session.dataDir = dataDir;
+  const bot = registerBot({ larkAppId: 'pf1', larkAppSecret: 's', cliId: 'claude-code', allowedUsers: ['ou_owner'] });
+  bot.resolvedAllowedUsers = ['ou_owner'];
+});
+
+function seedPlatformTeam(): void {
+  applyPlatformTeamSync(dataDir, {
+    rev: 'r1',
+    teams: [{
+      teamId: 't1', teamName: 'T1', groupChatIds: ['oc_hall'],
+      bots: [{ appId: 'cli_peer', unionId: 'on_peer', name: 'Peer' }],
+    }],
+  });
+}
+
+describe('isTrustedTeamBotSender (platform mode)', () => {
+  it('trusts a platform roster bot by union_id in ANY chat', () => {
+    seedPlatformTeam();
+    expect(isTrustedTeamBotSender(dataDir, 'oc_random', 'on_peer')).toBe(true);
+    expect(isTrustedTeamBotSender(dataDir, 'oc_random', 'on_stranger')).toBe(false);
+  });
+
+  it('trusts first contact inside the mirrored 大厅/团队群', () => {
+    seedPlatformTeam();
+    // union_id not in roster yet (fresh bot, not yet echoed) but the hall is trusted
+    expect(isTrustedTeamBotSender(dataDir, 'oc_hall', 'on_fresh')).toBe(true);
+  });
+});
+
+describe('canOperate (platform mode)', () => {
+  it('grants operate to a platform roster bot by union_id', () => {
+    seedPlatformTeam();
+    expect(canOperate('pf1', 'oc_random', 'ou_scoped', 'on_peer')).toBe(true);
+    expect(canOperate('pf1', 'oc_random', 'ou_scoped', 'on_human')).toBe(false);
+  });
+});
+
+describe('evaluateTalk teamBot leg (quota gate end-to-end hole fix)', () => {
+  it('allows a platform roster bot on a RESTRICTED receiver', () => {
+    seedPlatformTeam();
+    const ev = evaluateTalk('pf1', 'oc_random', 'ou_peer_scoped', 'on_peer');
+    expect(ev.allowed).toBe(true);
+    expect(ev.reason).toBe('teamBot');
+  });
+
+  it('allows a LEGACY learned team bot too (parity across 两条路)', () => {
+    recordTeamBot(dataDir, { unionId: 'on_legacy', name: 'Legacy' });
+    const ev = evaluateTalk('pf1', 'oc_random', 'ou_legacy_scoped', 'on_legacy');
+    expect(ev.allowed).toBe(true);
+    expect(ev.reason).toBe('teamBot');
+  });
+
+  it('still denies unknown senders without union_id backing', () => {
+    expect(evaluateTalk('pf1', 'oc_random', 'ou_x', 'on_unknown').allowed).toBe(false);
+    expect(evaluateTalk('pf1', 'oc_random', 'ou_x').allowed).toBe(false);
+  });
+});


### PR DESCRIPTION
## 背景

平台团队（中心化 botmux platform）拉的群里 bot 互 @ 仍弹 /grant 卡：平台拉群不经 daemon（platform dc677d1 起平台直建，旧链路的 daemon `/api/groups/create` 也不写 recordTeamGroup），信任根 team-groups/team-bots 两头落空；而学习 union_id 的入口（event-dispatcher recordTeamBot）又要求群先命中 team-groups——鸡生蛋，两条信任腿全断。

## 方案（与申晗讨论收敛）

平台每团队建一个 bot-only「机器人大厅」作 union_id 自学回声室 + 受信团队群；bot 自学 union_id 随心跳上报，平台聚合 roster 按版本比对下发；接收侧按团队成员关系落盘。**平台团队与旧版联邦团队同权，双模式都免 /grant。**

## 改动

- **bot-union-ids-store（新）**：bot 从自家群消息回声（isSelfMessage 分支）自学自己的 union_id 落盘（一次性）。这是唯一可靠来源——bot/v3/info 不返回 union_id、contact API 查不了 bot、单聊事件只推用户→bot。
- **platform-team-store（新）**：平台 team-sync（rev 版本比对，随隧道心跳应答）下发的团队 bot roster + 团队群清单落盘；群清单以 `platform:` 前缀镜像进 team-groups（replace-by-prefix，绝不动旧联邦条目），isTeamGroupChat / recordTeamBot 消费路径零改动。
- **闸门**：isTrustedTeamBotSender / canOperate 接入 isPlatformTeamBot（union_id 锚定；按团队成员关系增删、不设 30d 过期）。
- **evaluateTalk 新增 teamBot 腿** 并在 enforceMessageQuotaForCliInput 透传 union_id：修复 #332 在受限 bot 上的端到端断点——外部 bot 闸门放行的团队 bot 消息，此前会在配额复查处被 evaluateTalk 静默丢弃（evaluateTalk 只有 peer 腿，没有团队腿）。
- **安全不变量**：union_id 信任腿只对飞书盖章的 bot 发送方生效（`teamTrustUnionId` call-site 门）。roster 是成员机器自报的，不锁 sender_type 的话，恶意成员把真人 union_id 报成"自家 bot"即可让真人在全团队获得 talk+operate——与旧联邦"学习入口限 bot sender"对齐同一结构保证。
- **dashboard**：tunnel-client 处理 team-sync 下行 + 上报 teamSyncRev / PlatformBotInfo.unionId；大厅打卡（无 union_id 的本地 bot 经 daemon IPC `/api/platform/hall-announce` 往大厅发一条，回声自学；10min 节流 + 每进程 6 次上限）。

配套平台侧已上线（platform master 7c26d8d）：大厅建群（app_id 批 5 + 整批拒逐个重试、群主不转让、不拉人）、团队加 bot 时探测大厅已解散 → 自动重建重拉全部 bot、team-sync 聚合与版本比对下发、瞬时 DB 故障跳过本轮（绝不当空团队下发吊销全网信任）。

## 兼容与降级

- 老 daemon 不上报 teamSyncRev → 平台不对它下发，完全向后兼容。
- self-echo 事件不带 union_id / bot-only 群不推事件的 bot：自动退回大厅群 chatId 兜底腿（团队群内首次接触仍免 grant，接收方顺带学 union_id），不会比现状差。

## 验证

- 新增 15 条单测（bot-union-ids-store / platform-team-store / platform-team-trust）全绿；
- 全量 7280 条测试：30 个失败与干净基线（HEAD worktree 复跑）完全一致——19 个环境依赖单测 + 11 个需真实飞书的 e2e，零回归；
- tsc + pnpm build 绿。