### PR TITLE
feat(setup): 工作目录模式二选一 + 脚本化非 TUI 子命令

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -91,13 +91,36 @@ Run `botmux setup` and follow the interactive menu:
 1. **New config**: type `1` and press Enter (with an existing config, type `2` to add a bot).
 2. **Create the bot**: type `1` → **Scan-to-create (recommended)**: scan with the Lark mobile app and a PersonalAgent app is created with AppID/AppSecret persisted automatically, **with event subscriptions + bot capability pre-configured** — no manual browser navigation. Uses the official `@larksuiteoapi/node-sdk` device flow. (You can also type `2` to paste AppID/Secret manually — see "Create the app manually" folded below.)
 3. **Pick the CLI**: choose the CLI to bridge (e.g. type `1` for Claude Code).
-4. **Default working dir**: usually the **parent directory** of your git projects (e.g. `~/projects`); new topics scan **downward** for git repos (up to 3 levels). Avoid `~` (too many folders to traverse).
+4. **Working dir for new topics** — pick one of two modes:
+   - **Repo-select card (recommended)**: each new topic pops a card listing scanned git repos to choose from. The follow-up question asks for the **repo scan root(s)** — usually the **parent directory** of your git projects (e.g. `~/projects`, comma-separated for multiple); the card scans **downward** for git repos (up to 3 levels). Avoid `~` (too many folders to traverse).
+   - **Fixed default dir**: new topics start straight in the given directory with **no card** (persisted as `defaultWorkingDir`; change later via `/config` or `botmux setup edit`).
 
 Then comes the **2nd scan**: botmux's built-in Feishu Web login automatically imports permissions, configures the `http://127.0.0.1:9768/callback` redirect URL, and creates + submits a publish version. On failure it falls back and prints the manual steps (folded below) without affecting the config already written; importing only part of the permissions still counts as success — add the rest later on the Open Platform.
 
 > ✅ **Both Feishu (feishu.cn) and Lark international (larksuite.com) tenants are supported.** Scan-to-create auto-detects the tenant brand (China / international) and remembers it — no manual choice needed; the manual paste path asks once. Each bot connects to its own brand's domain, so one machine can run Feishu and Lark bots side by side, with login credentials isolated per app.
 
 At the end, setup validates credentials with a `tenant_access_token` call (only writing `bots.json` on success) and writes the full scope JSON to `~/.botmux/lark-scopes.json` for reference.
+
+<details>
+<summary><b>Scripted (non-TUI) setup</b> — field-level subcommands for coding agents / automation, independent of the interactive question order</summary>
+
+```bash
+botmux setup list --json                     # list bots (secret masked)
+botmux setup add \
+  --app-id cli_xxx --app-secret xxx \
+  --allowed-users alice@example.com \
+  --cli codex --working-dir ~/projects       # add (credentials still validated before writing)
+botmux setup edit botmux-0 --cli claude-code \
+  --default-working-dir /data/proj           # per-field edits; pass - to clear a field
+botmux setup remove botmux-1 --yes           # non-interactive removal requires --yes
+botmux setup help                            # full flag reference
+```
+
+- `--working-dir` is the repo-select card's scan root; `--default-working-dir` is the fixed default dir (new topics start there directly, no card) — the same two modes as the TUI question.
+- `--json` prints machine-readable results (with `ok` / `error`); Open Platform auto-config is skipped by default — opt in with `--open-platform-auto` (requires QR scan).
+- If you previously scripted setup by piping numbered answers into the TUI, migrate to these subcommands: whenever the question sequence changes (this release adds the working-dir mode question), piped answers silently shift.
+
+</details>
 
 ### 3. Start
 

--- a/README.en.md
+++ b/README.en.md
@@ -86,11 +86,14 @@ npm install -g botmux
 
 ### 2. Create the App & Configure (`botmux setup`)
 
-Run `botmux setup` and follow the interactive menu:
+Run `botmux setup` — every choice is an interactive picker (↑/↓ to move, type to filter, ⏎ to confirm, Esc to cancel; non-interactive terminals fall back to numbered input):
 
-1. **New config**: type `1` and press Enter (with an existing config, type `2` to add a bot).
-2. **Create the bot**: type `1` → **Scan-to-create (recommended)**: scan with the Lark mobile app and a PersonalAgent app is created with AppID/AppSecret persisted automatically, **with event subscriptions + bot capability pre-configured** — no manual browser navigation. Uses the official `@larksuiteoapi/node-sdk` device flow. (You can also type `2` to paste AppID/Secret manually — see "Create the app manually" folded below.)
-3. **Pick the CLI**: choose the CLI to bridge (e.g. type `1` for Claude Code).
+1. **Action**: a fresh install goes straight into the create flow; with an existing config, first pick "add / reconfigure / edit / remove bot".
+2. **App source** — pick one of three:
+   - **Scan to create a new app (recommended)**: scan with the Lark mobile app and a PersonalAgent app is created with AppID/AppSecret persisted automatically, **with event subscriptions + bot capability pre-configured** — no manual browser navigation. Uses the official `@larksuiteoapi/node-sdk` device flow.
+   - **Pick an existing app**: reuse (or QR-login to get) a Feishu web session, list the apps you previously created on the Open Platform, and have the **AppID/AppSecret fetched automatically** — no digging through the console when re-configuring on a new machine (Feishu tenants only).
+   - **Enter AppID/Secret manually** — see "Create the app manually" folded below.
+3. **Pick the CLI**: choose the CLI to bridge (searchable — type `cla` to filter Claude).
 4. **Working dir for new topics** — pick one of two modes:
    - **Repo-select card (recommended)**: each new topic pops a card listing scanned git repos to choose from. The follow-up question asks for the **repo scan root(s)** — usually the **parent directory** of your git projects (e.g. `~/projects`, comma-separated for multiple); the card scans **downward** for git repos (up to 3 levels). Avoid `~` (too many folders to traverse).
    - **Fixed default dir**: new topics start straight in the given directory with **no card** (persisted as `defaultWorkingDir`; change later via `/config` or `botmux setup edit`).
@@ -151,7 +154,7 @@ botmux autostart enable
 
 <br>
 
-**Create the app manually**: go to the [Lark Open Platform](https://open.larkoffice.com/app), create a "Custom App", copy **App ID / App Secret** from "Credentials & Basic Info", and in `botmux setup`'s "Create the bot" step choose `2` to paste them back.
+**Create the app manually**: go to the [Lark Open Platform](https://open.larkoffice.com/app), create a "Custom App", copy **App ID / App Secret** from "Credentials & Basic Info", and pick "Enter AppID/Secret manually" at `botmux setup`'s "App source" step to paste them back.
 
 ![Create App](docs/setup/create-app.png)
 

--- a/README.md
+++ b/README.md
@@ -232,13 +232,36 @@ npm install -g botmux
 1. **新建配置**：输入 `1` 回车（已有配置时输入 `2` 添加机器人）。
 2. **创建机器人**：输入 `1` → **扫码创建（推荐）**，飞书扫码完成后自动建出 PersonalAgent 应用并落盘 AppID/AppSecret，**事件订阅 + bot 能力默认已配好**，无需手动浏览器创建。底层走 `@larksuiteoapi/node-sdk` 官方 device flow。（也可输入 `2` 手动粘贴 AppID/Secret，见文末折叠的「手动创建应用」。）
 3. **选择 CLI**：选本次要接入的 CLI（如接 Claude Code 就选 `1`）。
-4. **默认工作目录**：通常填 git 项目的**父级目录**（如 `~/projects`），新话题会从该目录**向下**查找 git 仓库（最多 3 层）；尽量别填 `~`（要遍历太多文件夹）。
+4. **新话题工作目录**：二选一——
+   - **仓库选择卡片（推荐）**：新话题先弹卡片，从扫描到的 git 仓库里选一个再启动。下一问填**仓库扫描根目录**，通常是 git 项目的**父级目录**（如 `~/projects`，支持逗号分隔多个），卡片从该目录**向下**查找 git 仓库（最多 3 层）；尽量别填 `~`（要遍历太多文件夹）。
+   - **固定默认目录**：新话题直接在指定目录启动、**不弹卡片**（落 `defaultWorkingDir` 字段，之后可用 `/config` 或 `botmux setup edit` 修改）。
 
 接着进入**第 2 次扫码**：botmux 内置的飞书 Web 登录会自动导入权限、配置 `http://127.0.0.1:9768/callback` 重定向 URL、创建并提交发布版本。失败会自动回退并打印手动步骤（见文末折叠），不影响已写入的配置；权限只导入了一部分也算成功，缺的可事后到开放平台补。
 
 > ✅ **飞书 (feishu.cn) 与 Lark 国际版 (larksuite.com) 均支持**。扫码创建时自动识别租户类型（国内 / 国际）并记住，无需手动选择；手动粘 AppID/Secret 时会让你选一次。每个机器人按所属版本独立连对应域名，同一台机器可同时跑飞书 + Lark 机器人，登录凭证按应用隔离、互不干扰。
 
 setup 末尾会用 `tenant_access_token` 校验凭证（通过才落盘 `bots.json`），并把完整权限 JSON 写到 `~/.botmux/lark-scopes.json` 备查。
+
+<details>
+<summary><b>脚本化（非 TUI）setup</b> —— 给 coding agent / 自动化脚本用的字段级子命令，不依赖交互问答顺序</summary>
+
+```bash
+botmux setup list --json                     # 列出机器人（secret 脱敏）
+botmux setup add \
+  --app-id cli_xxx --app-secret xxx \
+  --allowed-users alice@example.com \
+  --cli codex --working-dir ~/projects       # 添加（写盘前照样校验凭证）
+botmux setup edit botmux-0 --cli claude-code \
+  --default-working-dir /data/proj           # 按字段修改；值传 - 清空
+botmux setup remove botmux-1 --yes           # 非交互删除必须 --yes
+botmux setup help                            # 完整 flag 列表
+```
+
+- `--working-dir` 是仓库选择卡片的扫描根；`--default-working-dir` 是固定默认目录（新话题直接启动、不弹卡），对应 TUI 里工作目录模式的两个选项。
+- `--json` 输出机器可读结果（含 `ok` / `error`）；开放平台自动配置默认跳过，需要时显式加 `--open-platform-auto`（要扫码）。
+- 以前对交互问答「管道喂数字」的脚本请迁移到这些子命令：问答序列一变（本版本就新增了工作目录模式一问），喂数字会静默错位。
+
+</details>
 
 ### 3. 启动
 

--- a/README.md
+++ b/README.md
@@ -227,11 +227,14 @@ npm install -g botmux
 
 ### 2. 创建应用并配置（`botmux setup`）
 
-跑 `botmux setup`，按交互菜单一步步选：
+跑 `botmux setup`，全程交互式选择（↑/↓ 选择、输入即搜索、⏎ 确认、Esc 取消；非交互终端自动回退为序号输入）：
 
-1. **新建配置**：输入 `1` 回车（已有配置时输入 `2` 添加机器人）。
-2. **创建机器人**：输入 `1` → **扫码创建（推荐）**，飞书扫码完成后自动建出 PersonalAgent 应用并落盘 AppID/AppSecret，**事件订阅 + bot 能力默认已配好**，无需手动浏览器创建。底层走 `@larksuiteoapi/node-sdk` 官方 device flow。（也可输入 `2` 手动粘贴 AppID/Secret，见文末折叠的「手动创建应用」。）
-3. **选择 CLI**：选本次要接入的 CLI（如接 Claude Code 就选 `1`）。
+1. **操作**：首次安装直接进入创建流程；已有配置时先选「添加新机器人 / 重新配置 / 编辑现有机器人 / 删除机器人」。
+2. **飞书应用来源**：三选一——
+   - **扫码创建新应用（推荐）**：飞书扫码后自动建出 PersonalAgent 应用并落盘 AppID/AppSecret，**事件订阅 + bot 能力默认已配好**，无需手动浏览器创建。底层走 `@larksuiteoapi/node-sdk` 官方 device flow。
+   - **选择已有应用**：复用（或扫码获取）飞书 Web 登录态，列出你在开放平台创建过的应用，选中后**自动读取 AppID/AppSecret**——换机器重配、复用旧应用不用再去后台翻 Secret（仅飞书租户）。
+   - **手动输入 AppID/Secret**：见文末折叠的「手动创建应用」。
+3. **选择 CLI**：选本次要接入的 CLI（可搜索，如输入 `cla` 过滤出 Claude）。
 4. **新话题工作目录**：二选一——
    - **仓库选择卡片（推荐）**：新话题先弹卡片，从扫描到的 git 仓库里选一个再启动。下一问填**仓库扫描根目录**，通常是 git 项目的**父级目录**（如 `~/projects`，支持逗号分隔多个），卡片从该目录**向下**查找 git 仓库（最多 3 层）；尽量别填 `~`（要遍历太多文件夹）。
    - **固定默认目录**：新话题直接在指定目录启动、**不弹卡片**（落 `defaultWorkingDir` 字段，之后可用 `/config` 或 `botmux setup edit` 修改）。
@@ -292,7 +295,7 @@ botmux autostart enable
 
 <br>
 
-**手动创建应用**：去 [飞书开放平台](https://open.larkoffice.com/app) 建「企业自建应用」，在「凭证与基础信息」复制 **App ID / App Secret**，在 `botmux setup` 的「创建机器人」步骤选 `2` 粘贴回来。
+**手动创建应用**：去 [飞书开放平台](https://open.larkoffice.com/app) 建「企业自建应用」，在「凭证与基础信息」复制 **App ID / App Secret**，在 `botmux setup` 的「飞书应用来源」步骤选「手动输入 AppID/Secret」粘贴回来。
 
 ![创建应用](docs/setup/create-app.png)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@
  * Usage:
  *   botmux setup          — interactive first-time configuration
  *   botmux setup --no-open-platform-auto — skip Feishu Open Platform automation
+ *   botmux setup list|add|edit|remove — scripted (non-TUI) bot management, see `botmux setup help`
  *   botmux start          — start daemon (pm2)
  *   botmux stop           — stop daemon
  *   botmux restart [--include-pm2] — restart daemon (optionally restart PM2 God too)
@@ -21,7 +22,7 @@
 import { execSync, execFileSync, spawnSync, spawn } from 'node:child_process';
 import { existsSync, mkdirSync, copyFileSync, readFileSync, writeFileSync, renameSync, readdirSync, readlinkSync, appendFileSync, statSync, unlinkSync } from 'node:fs';
 import { atomicWriteFileSync } from './utils/atomic-write.js';
-import { join, dirname, basename } from 'node:path';
+import { join, dirname, basename, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { createInterface } from 'node:readline';
@@ -48,11 +49,20 @@ import {
   type BotConfigEditInput,
 } from './setup/bot-config-editor.js';
 import { resolveCliSelection, selectionKeyForBot } from './setup/cli-selection.js';
+import {
+  buildBotFromAddFlags,
+  editInputFromFlags,
+  isScriptedSetupInvocation,
+  maskAppSecret,
+  parseSetupCommand,
+  SETUP_CLI_USAGE,
+  type SetupCommand,
+} from './setup/setup-args.js';
 import { pickCliSelection } from './setup/interactive-select.js';
 import { buildPreset, serializePreset, presetFilename } from './setup/agent-preset.js';
 import type { CliId } from './adapters/cli/types.js';
 import { logger } from './utils/logger.js';
-import { invalidWorkingDirs } from './utils/working-dir.js';
+import { expandHomePath, invalidWorkingDirs } from './utils/working-dir.js';
 import { firstPositional } from './cli/arg-utils.js';
 import { dispatchPrimaryMessage, findStdinAliasAttachment, sendFileAttachments } from './cli/send-dispatch.js';
 import { buildPm2SpawnCommand } from './cli/pm2-command.js';
@@ -263,6 +273,21 @@ function ensureBotWorkingDirsExist(bot: Record<string, any>, context = 'workingD
   console.log(`\n❌ ${context} 指向的目录不存在或不是目录:`);
   for (const dir of invalid) console.log(`   - ${dir}`);
   console.log('   请先创建目录，或重新填写一个已存在的工作目录。');
+  return false;
+}
+
+/**
+ * 固定默认目录（defaultWorkingDir）写盘前的存在性校验。运行时 daemon 对无效
+ * defaultWorkingDir 只是 WARN 后回退弹仓库选择卡，用户很难察觉配置根本没生效，
+ * 所以 setup 侧必须在写盘前就挡下来。未配置视为通过。
+ */
+function ensureBotDefaultWorkingDirExists(bot: Record<string, any>): boolean {
+  const raw = typeof bot.defaultWorkingDir === 'string' ? bot.defaultWorkingDir.trim() : '';
+  if (!raw) return true;
+  const missing = missingDirResolved(raw);
+  if (!missing) return true;
+  console.log(`\n❌ 固定默认目录不存在或不是目录: ${missing}`);
+  console.log('   请先创建目录，或改用仓库选择卡片模式。');
   return false;
 }
 
@@ -689,7 +714,34 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
     console.log('   不写 bots.json。请重新运行 botmux setup。');
     return null;
   }
-  const workingDir = await ask(rl, '默认工作目录 [~]: ');
+  // 新话题工作目录：两种模式二选一。旧问法只问「默认工作目录」但写的是
+  // workingDir——那只是仓库选择卡片的扫描根，新话题照样弹卡，误导性强；
+  // 真正「直接进目录、不弹卡」的是 defaultWorkingDir，现在显式让用户选。
+  printInputHelp('新话题工作目录', [
+    '1) 仓库选择卡片：新话题先弹卡片，从扫描到的 git 仓库中选一个再启动（推荐）。',
+    '2) 固定默认目录：新话题直接在指定目录启动、不弹卡片（之后可用 /config 或 botmux setup edit 修改）。',
+  ]);
+  const dirMode = (await ask(rl, '工作目录模式: 1) 仓库选择卡片  2) 固定默认目录  (1/2) [1]: ')).trim();
+  let workingDir: string | undefined;
+  let defaultWorkingDir: string | undefined;
+  if (dirMode === '2') {
+    // 必填 + 存在性校验循环（与 promptRequiredOwner 同款姿势）——运行时 daemon
+    // 对无效 defaultWorkingDir 只会静默回退弹卡，setup 阶段必须挡住。
+    for (;;) {
+      const dir = (await ask(rl, '默认工作目录（新话题直接在此目录启动）: ')).trim();
+      if (!dir) {
+        console.log('   ❌ 固定默认目录模式必须填写目录。');
+        continue;
+      }
+      if (ensureBotDefaultWorkingDirExists({ defaultWorkingDir: dir })) {
+        defaultWorkingDir = dir;
+        break;
+      }
+    }
+  } else {
+    const raw = await ask(rl, '仓库扫描根目录（卡片会列出其下的 git 仓库，逗号分隔多个）[~]: ');
+    workingDir = raw.trim() || '~';
+  }
 
   const bot: Record<string, any> = {
     larkAppId: creds.appId,
@@ -697,9 +749,11 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
     cliId,
     // aiden × claude/codex 等启动前缀；普通 CLI 不写此字段。
     ...(wrapperCli ? { wrapperCli } : {}),
-    // 总是写 workingDir, 留空用 '~'. 用户手动编辑 bots.json 时一眼能看到字段
-    // 在哪儿, 不用去 README 查字段名.
-    workingDir: workingDir.trim() || '~',
+    // 仓库选择模式总是写 workingDir（留空用 '~'），用户手动编辑 bots.json 时
+    // 一眼能看到字段在哪儿；固定默认目录模式只写 defaultWorkingDir，扫描根
+    // 回退默认 ~，bots.json 不留多余字段。
+    ...(workingDir ? { workingDir } : {}),
+    ...(defaultWorkingDir ? { defaultWorkingDir } : {}),
   };
   // brand 落盘：只在国际版 (lark) 时写字段，feishu 留空——保持旧 bots.json 干净，
   // 且 botBrand()/normalizeBrand() 读不到时 default 到 feishu，向后兼容。
@@ -726,7 +780,7 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
     bot.allowedUsers = await promptRequiredOwner(rl);
   }
 
-  if (!ensureBotWorkingDirsExist(bot, '默认工作目录')) return null;
+  if (!ensureBotWorkingDirsExist(bot, '仓库扫描根目录')) return null;
 
   return normalizeBotConfig(bot);
 }
@@ -834,11 +888,35 @@ async function promptEditBotConfig(
   ]);
   input.backendType = await ask(rl, `会话后端 backendType [${formatOptionalValue(bot.backendType)}]: `);
 
-  printInputHelp('默认工作目录', [
-    '可选。新会话默认进入的目录，支持逗号分隔多个候选目录。',
-    '留空保留当前值；输入 - 清空并回到默认 ~。',
+  // 新话题工作目录：模式二选一（与 promptBotConfig 的新建流程同款问法）。
+  const currentDirMode = bot.defaultWorkingDir
+    ? `2（固定默认目录: ${bot.defaultWorkingDir}）`
+    : `1（仓库选择卡片，扫描根: ${bot.workingDir ?? '~'}）`;
+  printInputHelp('新话题工作目录', [
+    '1) 仓库选择卡片：新话题先弹卡片选 git 仓库；下一问填卡片的扫描根目录。',
+    '2) 固定默认目录：新话题直接在指定目录启动、不弹卡片。',
+    `当前模式: ${currentDirMode}。留空保留当前配置。`,
   ]);
-  input.workingDir = await ask(rl, `默认工作目录 [${formatOptionalValue(bot.workingDir)}]: `);
+  const dirMode = (await ask(rl, '工作目录模式 (1/2) [保留当前]: ')).trim();
+  if (dirMode === '1') {
+    printInputHelp('仓库扫描根目录', [
+      '仓库选择卡片会列出这些目录下的 git 仓库，支持逗号分隔多个。',
+      '留空保留当前值；输入 - 清空并回到默认 ~。',
+    ]);
+    input.workingDir = await ask(rl, `仓库扫描根目录 [${formatOptionalValue(bot.workingDir)}]: `);
+    if (bot.defaultWorkingDir) {
+      console.log('   已切回仓库选择卡片模式，原固定默认目录将被清空。');
+      input.defaultWorkingDir = '-';
+    }
+  } else if (dirMode === '2') {
+    printInputHelp('固定默认目录', [
+      '新话题直接在此目录启动、不弹仓库选择卡片。',
+      '留空保留当前值；输入 - 清空并回到仓库选择卡片模式。',
+    ]);
+    input.defaultWorkingDir = await ask(rl, `固定默认目录 [${formatOptionalValue(bot.defaultWorkingDir)}]: `);
+  } else if (dirMode) {
+    console.log('   ⚠️ 未识别的选择，保留当前工作目录配置。');
+  }
 
   printInputHelp('允许的用户', [
     '可选。限制哪些飞书用户可以操作机器人，支持完整邮箱（如 alice@example.com）、union_id（on_xxx）或 open_id（ou_xxx），多个值用逗号分隔。',
@@ -921,6 +999,253 @@ async function writeSingleBotConfig(): Promise<boolean> {
   return true;
 }
 
+// ─── Scripted (non-TUI) setup ────────────────────────────────────────────────
+
+/** 脚本化 setup 统一失败出口：--json 输出结构化错误到 stdout，退出码 1。 */
+function failSetupScripted(json: boolean, message: string): void {
+  if (json) console.log(JSON.stringify({ ok: false, error: message }));
+  else console.error(`❌ ${message}`);
+  process.exitCode = 1;
+}
+
+/** 某个（可能带 ~ 前缀的）路径若不存在/不是目录，返回展开后的绝对路径；合法返回 null。 */
+function missingDirResolved(raw: string): string | null {
+  const resolved = resolve(expandHomePath(raw));
+  try {
+    if (statSync(resolved).isDirectory()) return null;
+  } catch { /* not a dir */ }
+  return resolved;
+}
+
+/** workingDir / workingDirs / defaultWorkingDir 里所有无效目录（脚本化模式一次性报全）。 */
+function invalidBotDirs(bot: Record<string, any>): string[] {
+  const invalid = [...invalidWorkingDirs(bot)];
+  const raw = typeof bot.defaultWorkingDir === 'string' ? bot.defaultWorkingDir.trim() : '';
+  if (raw) {
+    const missing = missingDirResolved(raw);
+    if (missing) invalid.push(missing);
+  }
+  return invalid;
+}
+
+/** list/add/edit 的 JSON 输出视图：bot 条目 + 进程名，secret 脱敏（stdout 可能被贴进聊天/日志）。 */
+function botJsonView(bot: Record<string, any>, index: number): Record<string, any> {
+  return {
+    processName: botProcessName(bot, index, PM2_NAME),
+    ...bot,
+    larkAppSecret: maskAppSecret(bot?.larkAppSecret),
+  };
+}
+
+/**
+ * `botmux setup list|add|edit|remove` — 脚本化（非 TUI）bot 管理。
+ * 给 coding agent / 脚本一个字段级稳定接口，不依赖交互问答顺序（管道喂数字
+ * 的老姿势在问题序列变化时会静默错位）。校验口径与 TUI 一致：目录存在性、
+ * owner 必填、凭证变更时的 tenant_access_token 校验，任一失败不写盘。
+ */
+async function cmdSetupScripted(argv: string[]): Promise<void> {
+  const wantsJson = argv.includes('--json');
+  let cmd: SetupCommand;
+  try {
+    cmd = parseSetupCommand(argv);
+  } catch (err: any) {
+    failSetupScripted(wantsJson, err?.message ?? String(err));
+    return;
+  }
+
+  if (cmd.action === 'help') {
+    console.log(SETUP_CLI_USAGE);
+    return;
+  }
+
+  ensureConfigDir();
+  const bots = loadBotsJson();
+
+  if (cmd.action === 'list') {
+    if (cmd.json) {
+      console.log(JSON.stringify(bots.map((b, i) => botJsonView(b, i)), null, 2));
+    } else if (bots.length === 0) {
+      console.log('尚未配置机器人。运行 botmux setup（交互式）或 botmux setup add 添加。');
+    } else {
+      console.log(formatBotConfigTable(bots));
+      console.log('\n完整字段用 --json 查看（secret 脱敏；明文只在 ~/.botmux/bots.json）。');
+    }
+    return;
+  }
+
+  if (cmd.action === 'add') {
+    let bot: Record<string, any>;
+    try {
+      bot = buildBotFromAddFlags(cmd.flags);
+    } catch (err: any) {
+      failSetupScripted(cmd.json, err?.message ?? String(err));
+      return;
+    }
+
+    // 单机器人 .env 老配置：与 TUI「添加新机器人」一致，先迁移进 bots.json 再追加。
+    let existing = bots;
+    let migratedEnv = false;
+    if (!existsSync(BOTS_JSON_FILE) && existsSync(ENV_FILE)) {
+      const legacy = parseDotEnvToBotConfig();
+      if (legacy.larkAppId && legacy.larkAppSecret) {
+        existing = [legacy];
+        migratedEnv = true;
+      }
+    }
+
+    if (existing.some(b => b?.larkAppId === bot.larkAppId)) {
+      failSetupScripted(cmd.json, `AppID ${bot.larkAppId} 已存在，修改请用 botmux setup edit ${bot.larkAppId}。`);
+      return;
+    }
+    const badDirs = invalidBotDirs(bot);
+    if (badDirs.length > 0) {
+      failSetupScripted(cmd.json, `目录不存在或不是目录: ${badDirs.join(', ')}。请先创建，未写入配置。`);
+      return;
+    }
+
+    // 凭证校验与 TUI 同口径：换不到 tenant_access_token 一律不写盘。
+    const { validateCredentials } = await import('./setup/verify-permissions.js');
+    const v = await validateCredentials(bot.larkAppId, bot.larkAppSecret, botBrand(bot));
+    if (!v.ok) {
+      failSetupScripted(cmd.json, `凭证校验失败 (${v.error}): ${v.message}`);
+      return;
+    }
+
+    writeBotsJsonAtomic([...existing, bot]);
+    if (migratedEnv) renameSync(ENV_FILE, ENV_FILE + '.bak');
+
+    // 开放平台自动配置（权限导入/发版）需要扫码，脚本化模式默认跳过、显式 opt-in。
+    if (cmd.openPlatformAuto) {
+      await finishOpenPlatformSetup(bot.larkAppId, botBrand(bot));
+    }
+
+    const index = existing.length;
+    if (cmd.json) {
+      console.log(JSON.stringify({
+        ok: true,
+        action: 'add',
+        bot: botJsonView(bot, index),
+        botsFile: BOTS_JSON_FILE,
+        envMigrated: migratedEnv || undefined,
+        openPlatform: cmd.openPlatformAuto ? 'attempted' : 'skipped',
+        next: 'botmux restart',
+      }, null, 2));
+    } else {
+      console.log(`✅ 已添加机器人 ${botProcessName(bot, index, PM2_NAME)} (${bot.larkAppId})，共 ${index + 1} 个`);
+      console.log(`   配置文件: ${BOTS_JSON_FILE}`);
+      if (migratedEnv) console.log(`   旧 .env 已迁移并备份: ${ENV_FILE}.bak`);
+      if (!cmd.openPlatformAuto) {
+        console.log('   已跳过开放平台自动配置（权限导入/发版）。需要时加 --open-platform-auto（要扫码），或运行交互式 botmux setup。');
+      }
+      console.log('下一步: botmux restart');
+    }
+    return;
+  }
+
+  if (cmd.action === 'edit') {
+    const index = parseBotSelection(cmd.selector, bots);
+    if (index === undefined) {
+      failSetupScripted(cmd.json, `找不到机器人 "${cmd.selector}"（接受进程名 botmux-N 或 AppID，botmux setup list 可查）。`);
+      return;
+    }
+    const original = bots[index];
+
+    let edited: Record<string, any>;
+    let modelCleared = false;
+    try {
+      const input = editInputFromFlags(cmd.flags);
+      if (Object.keys(input).length === 0) {
+        throw new Error('edit 至少需要一个字段参数（如 --cli codex）。查看用法：botmux setup help');
+      }
+      // 切换 CLI 强制清空旧 model（与 TUI 同理：旧值属于上一个 CLI，套用会 spawn 报错）。
+      const nextCliId = input.cliChoice ? resolveCliId(input.cliChoice) : undefined;
+      if (nextCliId && nextCliId !== (original.cliId ?? 'claude-code') && original.model && input.model === undefined) {
+        input.model = null;
+        modelCleared = true;
+      }
+      edited = applyBotConfigEdits(original, input);
+      assertOwnerWhenChatGroups(edited);
+    } catch (err: any) {
+      failSetupScripted(cmd.json, err?.message ?? String(err));
+      return;
+    }
+
+    const badDirs = invalidBotDirs(edited);
+    if (badDirs.length > 0) {
+      failSetupScripted(cmd.json, `目录不存在或不是目录: ${badDirs.join(', ')}。配置未修改。`);
+      return;
+    }
+
+    const appIdChanged = edited.larkAppId !== original.larkAppId;
+    if (appIdChanged && bots.some((b, i) => i !== index && b?.larkAppId === edited.larkAppId)) {
+      failSetupScripted(cmd.json, `AppID ${edited.larkAppId} 已被另一个机器人使用，配置未修改。`);
+      return;
+    }
+    if (appIdChanged || edited.larkAppSecret !== original.larkAppSecret) {
+      const { validateCredentials } = await import('./setup/verify-permissions.js');
+      const v = await validateCredentials(edited.larkAppId, edited.larkAppSecret, botBrand(edited));
+      if (!v.ok) {
+        failSetupScripted(cmd.json, `凭证校验失败 (${v.error}): ${v.message}。配置未修改。`);
+        return;
+      }
+    }
+
+    const nextBots = bots.slice();
+    nextBots[index] = edited;
+    copyFileSync(BOTS_JSON_FILE, BOTS_JSON_FILE + '.bak');
+    writeBotsJsonAtomic(nextBots);
+
+    const changed = [...new Set([...Object.keys(original), ...Object.keys(edited)])]
+      .filter(k => JSON.stringify(original[k]) !== JSON.stringify(edited[k]));
+    if (cmd.json) {
+      console.log(JSON.stringify({
+        ok: true,
+        action: 'edit',
+        bot: botJsonView(edited, index),
+        changed,
+        modelCleared: modelCleared || undefined,
+        backup: BOTS_JSON_FILE + '.bak',
+        next: 'botmux restart',
+      }, null, 2));
+    } else {
+      console.log(`✅ 已更新机器人 ${botProcessName(edited, index, PM2_NAME)} (${edited.larkAppId})`);
+      console.log(`   变更字段: ${changed.join(', ') || '（无实际变化）'}`);
+      if (modelCleared) console.log('   ⚠️ 已切换 CLI，原 model 字段已清空（需要时用 --model 或 /config 重设）。');
+      if (appIdChanged) console.log('   ⚠️ LARK_APP_ID 已变更：历史会话/群聊状态不迁移，新应用可能需重新配置开放平台权限。');
+      console.log(`   旧配置已备份: ${BOTS_JSON_FILE}.bak`);
+      console.log('下一步: botmux restart');
+    }
+    return;
+  }
+
+  // remove
+  if (!cmd.yes) {
+    failSetupScripted(cmd.json, '非交互删除需要显式 --yes 确认。');
+    return;
+  }
+  const result = removeBotConfig(bots, cmd.selector);
+  if (!result) {
+    failSetupScripted(cmd.json, `找不到机器人 "${cmd.selector}"（接受进程名 botmux-N 或 AppID，botmux setup list 可查）。`);
+    return;
+  }
+  copyFileSync(BOTS_JSON_FILE, BOTS_JSON_FILE + '.bak');
+  writeBotsJsonAtomic(result.bots);
+  if (cmd.json) {
+    console.log(JSON.stringify({
+      ok: true,
+      action: 'remove',
+      removed: botJsonView(result.removed, result.index),
+      remaining: result.bots.length,
+      backup: BOTS_JSON_FILE + '.bak',
+      next: 'botmux restart',
+    }, null, 2));
+  } else {
+    console.log(`✅ 已删除机器人 ${botProcessName(result.removed, result.index, PM2_NAME)} (${result.removed.larkAppId})，剩余 ${result.bots.length} 个`);
+    console.log(`   旧配置已备份: ${BOTS_JSON_FILE}.bak`);
+    console.log('下一步: botmux restart');
+  }
+}
+
 // ─── Commands ────────────────────────────────────────────────────────────────
 
 async function cmdSetup(): Promise<void> {
@@ -982,7 +1307,7 @@ async function cmdSetup(): Promise<void> {
         console.log(`\n❌ 编辑失败: ${err?.message ?? String(err)}`);
         return;
       }
-      if (!ensureBotWorkingDirsExist(edited, '默认工作目录')) {
+      if (!ensureBotWorkingDirsExist(edited, '仓库扫描根目录') || !ensureBotDefaultWorkingDirExists(edited)) {
         rl.close();
         console.log('   配置未修改。');
         return;
@@ -5697,7 +6022,14 @@ async function cmdVoiceSetup(args: string[]): Promise<void> {
 switch (command) {
   case '--version':
   case '-v':      console.log(getVersion()); break;
-  case 'setup':   await cmdSetup(); break;
+  case 'setup': {
+    // 带子命令（list/add/edit/remove/help）走脚本化非 TUI 模式；空参数 / 纯
+    // flag（如 --no-open-platform-auto）保持原交互 TUI，向后兼容。
+    const setupArgs = process.argv.slice(3);
+    if (isScriptedSetupInvocation(setupArgs)) await cmdSetupScripted(setupArgs);
+    else await cmdSetup();
+    break;
+  }
   case 'start':   await cmdStart(); break;
   case 'stop':    cmdStop(); break;
   case 'restart': await cmdRestart(); break;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,7 +58,7 @@ import {
   SETUP_CLI_USAGE,
   type SetupCommand,
 } from './setup/setup-args.js';
-import { pickCliSelection } from './setup/interactive-select.js';
+import { interactiveSelect, pickChoice, pickCliSelection } from './setup/interactive-select.js';
 import { buildPreset, serializePreset, presetFilename } from './setup/agent-preset.js';
 import type { CliId } from './adapters/cli/types.js';
 import { logger } from './utils/logger.js';
@@ -564,16 +564,95 @@ async function finishOpenPlatformSetup(appId: string, brand: 'feishu' | 'lark'):
  *   AppSecret 通过 rl.question 异步读取, 不会出现在 process.argv)
  * - 任何失败都返回结构化对象, 不抛 (调用方根据 ok=false 回退)
  */
+/**
+ * 「选择已有应用」路径：复用/扫码飞书 Web 登录态 → 拉当前账号可见的自建应用
+ * 列表 → 交互选择 → 自动读取该应用的 AppSecret。任一步失败返回 ok:false，
+ * 调用方降级到手动输入。仅支持飞书 (feishu.cn) 租户（Web console 机制所限）。
+ */
+async function pickExistingAppCredentials(
+  rl: ReturnType<typeof createInterface>,
+): Promise<{ ok: true; appId: string; appSecret: string; brand: Brand } | { ok: false }> {
+  const {
+    prepareFeishuWebSession,
+    createOpenPlatformApiClient,
+    listOpenPlatformApps,
+    fetchOpenPlatformAppSecret,
+  } = await import('./setup/open-platform-automation.js');
+
+  console.log('\n获取飞书 Web 登录态（复用上次登录，过期则需重新扫码）…');
+  const prepared = await prepareFeishuWebSession({
+    onQrCode: (info) => {
+      process.stderr.write('\n请用飞书 App 扫码登录，以读取你创建过的应用列表：\n\n');
+      process.stderr.write(`${info.qrText}\n`);
+    },
+    onStatus: (message) => { process.stderr.write(`${message}\n`); },
+  });
+  if (!prepared.ok) {
+    console.log(`⚠️  飞书 Web 登录失败 (${prepared.reason}): ${prepared.message}`);
+    return { ok: false };
+  }
+
+  const clientRes = await createOpenPlatformApiClient(prepared.cookies);
+  if (!clientRes.ok) {
+    console.log(`⚠️  开放平台访问失败 (${clientRes.reason}): ${clientRes.message}`);
+    return { ok: false };
+  }
+
+  let apps;
+  try {
+    apps = await listOpenPlatformApps(clientRes.client);
+  } catch (err: any) {
+    console.log(`⚠️  拉取应用列表失败: ${err?.message ?? String(err)}`);
+    return { ok: false };
+  }
+  if (apps.length === 0) {
+    console.log('⚠️  当前账号名下没有可选的自建应用。');
+    return { ok: false };
+  }
+
+  // 已在 bots.json 里的应用打标——可以重复选（比如换机器重配），但要让人知道。
+  const configured = new Set(loadBotsJson().map(b => b?.larkAppId));
+  const idx = await pickChoice(rl, {
+    title: '选择已有应用',
+    items: apps.map(a => ({
+      label: a.name,
+      hint: `${a.clientId}${configured.has(a.clientId) ? ' · 已在 bots.json' : ''}`,
+    })),
+    footer: 'Esc 返回',
+  });
+  if (idx === null) return { ok: false };
+  const app = apps[idx];
+
+  try {
+    const appSecret = await fetchOpenPlatformAppSecret(clientRes.client, app.clientId);
+    console.log(`✅ 已选择 ${app.name} (${app.clientId})，AppSecret 已自动获取`);
+    return { ok: true, appId: app.clientId, appSecret, brand: 'feishu' };
+  } catch (err: any) {
+    console.log(`⚠️  自动读取 AppSecret 失败: ${err?.message ?? String(err)}`);
+    const manual = (await ask(rl, `请手动粘贴 ${app.clientId} 的 AppSecret（留空放弃）: `)).trim();
+    if (!manual) return { ok: false };
+    return { ok: true, appId: app.clientId, appSecret: manual, brand: 'feishu' };
+  }
+}
+
 async function obtainCredentials(rl: ReturnType<typeof createInterface>): Promise<
   | { ok: true; appId: string; appSecret: string; brand: Brand; userOpenId?: string }
   | { ok: false; reason: 'cancelled' }
 > {
-  console.log('── 飞书应用建立 ──\n');
-  console.log('1) 扫码建应用（推荐，一步拿到 AppID/Secret，需要飞书 App 扫码）');
-  console.log('2) 手动粘 AppID/Secret（已经在开放平台创建好应用了）\n');
-  const choice = (await ask(rl, '选择 [1]: ')).trim();
+  console.log('── 飞书应用 ──\n');
+  const method = await pickChoice(rl, {
+    title: '飞书应用来源',
+    items: [
+      { label: '扫码创建新应用（推荐）', hint: '飞书 App 扫码，自动创建并拿到 AppID/Secret' },
+      { label: '选择已有应用', hint: '飞书 Web 登录列出你创建过的应用，自动取 AppID/Secret（仅飞书租户）' },
+      { label: '手动输入 AppID/Secret', hint: '已在开放平台创建好应用' },
+    ],
+    defaultIndex: 0,
+    footer: 'Esc 取消 setup',
+  });
+  if (method === null) return { ok: false, reason: 'cancelled' };
 
-  if (choice !== '2') {
+  if (method === 0) {
     // 动态导入避免冷启动加载 SDK
     const { tryRegisterApp } = await import('./setup/register-app.js');
     const result = await tryRegisterApp();
@@ -603,13 +682,23 @@ async function obtainCredentials(rl: ReturnType<typeof createInterface>): Promis
     console.log('   降级到手动输入 AppID/Secret。\n');
   }
 
+  if (method === 1) {
+    const existing = await pickExistingAppCredentials(rl);
+    if (existing.ok) return existing;
+    console.log('   降级到手动输入 AppID/Secret。\n');
+  }
+
   // 手动 fallback / 手动选项：扫码路径已用 tenant_brand 自动识别；手动路径
   // 没有这个信号，兜底让用户手选租户类型（决定建应用 / 运行时的域名）。
-  console.log('\n租户类型：');
-  console.log('  1) 飞书（中国版，open.feishu.cn）');
-  console.log('  2) Lark（国际版，open.larksuite.com）');
-  const brandChoice = (await ask(rl, '选择 [1]: ')).trim();
-  const brand: Brand = brandChoice === '2' ? 'lark' : 'feishu';
+  const brandIdx = await pickChoice(rl, {
+    title: '租户类型',
+    items: [
+      { label: '飞书（中国版）', hint: 'open.feishu.cn' },
+      { label: 'Lark（国际版）', hint: 'open.larksuite.com' },
+    ],
+    defaultIndex: 0,
+  });
+  const brand: Brand = brandIdx === 1 ? 'lark' : 'feishu';
 
   console.log(`\n请在浏览器打开 ${larkHosts(brand).openApi}/app 创建应用，然后回来粘 ID/Secret。\n`);
   const appId = (await ask(rl, 'AppID (cli_xxx): ')).trim();
@@ -717,14 +806,18 @@ async function promptBotConfig(rl: ReturnType<typeof createInterface>): Promise<
   // 新话题工作目录：两种模式二选一。旧问法只问「默认工作目录」但写的是
   // workingDir——那只是仓库选择卡片的扫描根，新话题照样弹卡，误导性强；
   // 真正「直接进目录、不弹卡」的是 defaultWorkingDir，现在显式让用户选。
-  printInputHelp('新话题工作目录', [
-    '1) 仓库选择卡片：新话题先弹卡片，从扫描到的 git 仓库中选一个再启动（推荐）。',
-    '2) 固定默认目录：新话题直接在指定目录启动、不弹卡片（之后可用 /config 或 botmux setup edit 修改）。',
-  ]);
-  const dirMode = (await ask(rl, '工作目录模式: 1) 仓库选择卡片  2) 固定默认目录  (1/2) [1]: ')).trim();
+  const dirMode = await pickChoice(rl, {
+    title: '新话题工作目录',
+    items: [
+      { label: '仓库选择卡片（推荐）', hint: '新话题先弹卡片，从扫描到的 git 仓库中选一个再启动' },
+      { label: '固定默认目录', hint: '新话题直接在指定目录启动、不弹卡片' },
+    ],
+    defaultIndex: 0,
+    footer: '之后可用 /config 或 botmux setup edit 修改',
+  });
   let workingDir: string | undefined;
   let defaultWorkingDir: string | undefined;
-  if (dirMode === '2') {
+  if (dirMode === 1) {
     // 必填 + 存在性校验循环（与 promptRequiredOwner 同款姿势）——运行时 daemon
     // 对无效 defaultWorkingDir 只会静默回退弹卡，setup 阶段必须挡住。
     for (;;) {
@@ -822,6 +915,33 @@ function formatBotConfigTable(bots: any[]): string {
   return [render(headers), ...rows.map(render)].join('\n');
 }
 
+/**
+ * 从 bots 列表交互选择一个机器人，返回下标；取消 / 找不到返回 undefined。
+ * TTY 用可搜索选择器；非 TTY 保持旧文本语义（进程名 / AppID——见
+ * parseBotSelection 上的注释，刻意不接受裸序号，避免 off-by-one 歧义）。
+ */
+async function pickBotSelection(
+  rl: ReturnType<typeof createInterface>,
+  bots: any[],
+  title: string,
+): Promise<number | undefined> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    const selected = await ask(rl, '选择机器人（进程名 或 AppID）: ');
+    return parseBotSelection(selected, bots);
+  }
+  const idx = await interactiveSelect({
+    title,
+    items: bots.map((b, i) => ({
+      label: botProcessName(b, i, PM2_NAME),
+      hint: `${b?.larkAppId ?? ''} · ${b?.cliId ?? 'claude-code'}`,
+    })),
+    footer: 'Esc 取消',
+  });
+  if (idx === null) return undefined;
+  console.log(` ✔ ${title}: ${botProcessName(bots[idx], idx, PM2_NAME)}`);
+  return idx;
+}
+
 async function promptEditBotConfig(
   rl: ReturnType<typeof createInterface>,
   bot: Record<string, any>,
@@ -890,15 +1010,18 @@ async function promptEditBotConfig(
 
   // 新话题工作目录：模式二选一（与 promptBotConfig 的新建流程同款问法）。
   const currentDirMode = bot.defaultWorkingDir
-    ? `2（固定默认目录: ${bot.defaultWorkingDir}）`
-    : `1（仓库选择卡片，扫描根: ${bot.workingDir ?? '~'}）`;
-  printInputHelp('新话题工作目录', [
-    '1) 仓库选择卡片：新话题先弹卡片选 git 仓库；下一问填卡片的扫描根目录。',
-    '2) 固定默认目录：新话题直接在指定目录启动、不弹卡片。',
-    `当前模式: ${currentDirMode}。留空保留当前配置。`,
-  ]);
-  const dirMode = (await ask(rl, '工作目录模式 (1/2) [保留当前]: ')).trim();
-  if (dirMode === '1') {
+    ? `固定默认目录: ${bot.defaultWorkingDir}`
+    : `仓库选择卡片，扫描根: ${bot.workingDir ?? '~'}`;
+  const dirMode = await pickChoice(rl, {
+    title: '新话题工作目录',
+    items: [
+      { label: '保留当前配置', hint: currentDirMode },
+      { label: '仓库选择卡片', hint: '新话题先弹卡片选 git 仓库；下一问填卡片的扫描根目录' },
+      { label: '固定默认目录', hint: '新话题直接在指定目录启动、不弹卡片' },
+    ],
+    defaultIndex: 0,
+  });
+  if (dirMode === 1) {
     printInputHelp('仓库扫描根目录', [
       '仓库选择卡片会列出这些目录下的 git 仓库，支持逗号分隔多个。',
       '留空保留当前值；输入 - 清空并回到默认 ~。',
@@ -908,14 +1031,12 @@ async function promptEditBotConfig(
       console.log('   已切回仓库选择卡片模式，原固定默认目录将被清空。');
       input.defaultWorkingDir = '-';
     }
-  } else if (dirMode === '2') {
+  } else if (dirMode === 2) {
     printInputHelp('固定默认目录', [
       '新话题直接在此目录启动、不弹仓库选择卡片。',
       '留空保留当前值；输入 - 清空并回到仓库选择卡片模式。',
     ]);
     input.defaultWorkingDir = await ask(rl, `固定默认目录 [${formatOptionalValue(bot.defaultWorkingDir)}]: `);
-  } else if (dirMode) {
-    console.log('   ⚠️ 未识别的选择，保留当前工作目录配置。');
   }
 
   printInputHelp('允许的用户', [
@@ -1266,9 +1387,24 @@ async function cmdSetup(): Promise<void> {
     console.log('');
 
     const rl = createInterface({ input: process.stdin, output: process.stdout });
-    const action = await ask(rl, '操作: 1) 添加新机器人  2) 重新配置  3) 编辑现有机器人  4) 删除机器人  (1/2/3/4) [1]: ');
+    const action = await pickChoice(rl, {
+      title: '操作',
+      items: [
+        { label: '添加新机器人' },
+        { label: '重新配置', hint: '丢弃现有配置，重建为单机器人配置' },
+        { label: '编辑现有机器人' },
+        { label: '删除机器人' },
+      ],
+      defaultIndex: 0,
+      footer: 'Esc 退出',
+    });
+    if (action === null) {
+      rl.close();
+      console.log('\n已取消。');
+      return;
+    }
 
-    if (action === '2') {
+    if (action === 1) {
       console.log('\n── 重新配置 ──\n');
       const newBot = await promptBotConfig(rl);
       rl.close();
@@ -1288,13 +1424,12 @@ async function cmdSetup(): Promise<void> {
       return;
     }
 
-    if (action === '3') {
+    if (action === 2) {
       console.log('\n── 编辑现有机器人 ──\n');
-      const selected = await ask(rl, '选择机器人（进程名 或 AppID）: ');
-      const index = parseBotSelection(selected, bots);
+      const index = await pickBotSelection(rl, bots, '选择要编辑的机器人');
       if (index === undefined) {
         rl.close();
-        console.log('\n❌ 找不到指定机器人，配置未修改。');
+        console.log('\n❌ 未选择机器人，配置未修改。');
         return;
       }
 
@@ -1347,18 +1482,19 @@ async function cmdSetup(): Promise<void> {
       return;
     }
 
-    if (action === '4') {
+    if (action === 3) {
       console.log('\n── 删除机器人 ──\n');
-      const selected = await ask(rl, '选择机器人（进程名 或 AppID）: ');
-      const result = removeBotConfig(bots, selected);
-      if (!result) {
+      const delIndex = await pickBotSelection(rl, bots, '选择要删除的机器人');
+      if (delIndex === undefined) {
         rl.close();
-        console.log('\n❌ 找不到指定机器人，配置未修改。');
+        console.log('\n❌ 未选择机器人，配置未修改。');
         return;
       }
+      const nextBots = bots.slice();
+      const [removed] = nextBots.splice(delIndex, 1);
       const confirm = (await ask(
         rl,
-        `确认删除 ${botProcessName(result.removed, result.index, PM2_NAME)} (${result.removed.larkAppId})? (y/N): `,
+        `确认删除 ${botProcessName(removed, delIndex, PM2_NAME)} (${removed.larkAppId})? (y/N): `,
       )).trim().toLowerCase();
       rl.close();
       if (confirm !== 'y' && confirm !== 'yes') {
@@ -1368,8 +1504,8 @@ async function cmdSetup(): Promise<void> {
 
       copyFileSync(BOTS_JSON_FILE, BOTS_JSON_FILE + '.bak');
       console.log(`旧配置已备份: ${BOTS_JSON_FILE}.bak`);
-      writeBotsJsonAtomic(result.bots);
-      console.log(`✅ 已删除机器人 ${botProcessName(result.removed, result.index, PM2_NAME)} (${result.removed.larkAppId})`);
+      writeBotsJsonAtomic(nextBots);
+      console.log(`✅ 已删除机器人 ${botProcessName(removed, delIndex, PM2_NAME)} (${removed.larkAppId})`);
       console.log(`下一步: botmux restart\n`);
       return;
     }
@@ -1391,9 +1527,22 @@ async function cmdSetup(): Promise<void> {
     // --- Single-bot mode (.env exists) ---
     console.log(`当前使用单机器人配置: ${ENV_FILE}`);
     const rl = createInterface({ input: process.stdin, output: process.stdout });
-    const action = await ask(rl, '操作: 1) 添加新机器人  2) 覆盖当前配置  (1/2): ');
+    const action = await pickChoice(rl, {
+      title: '操作',
+      items: [
+        { label: '添加新机器人', hint: '迁移 .env 到 bots.json 多机器人配置' },
+        { label: '覆盖当前配置' },
+      ],
+      defaultIndex: 0,
+      footer: 'Esc 退出',
+    });
+    if (action === null) {
+      rl.close();
+      console.log('\n已取消。');
+      return;
+    }
 
-    if (action === '2') {
+    if (action === 1) {
       rl.close();
       const ok = await writeSingleBotConfig();
       if (ok) {

--- a/src/setup/bot-config-editor.ts
+++ b/src/setup/bot-config-editor.ts
@@ -139,6 +139,12 @@ export interface BotConfigEditInput {
   model?: string | null;
   backendType?: string;
   workingDir?: string;
+  /**
+   * 固定默认目录：新话题直接在此目录启动、不弹仓库选择卡片（与 /config 的
+   * defaultWorkingDir 同字段）。与 workingDir（仓库选择卡片的扫描根）互补：
+   * 留空不动；输入 - 清空、回到弹卡模式。目录存在性由调用方在写盘前校验。
+   */
+  defaultWorkingDir?: string;
   allowedUsers?: string;
   allowedChatGroups?: string;
   /**
@@ -391,6 +397,7 @@ export function applyBotConfigEdits<T extends Record<string, any>>(
   }
 
   applyOptionalString(out, 'workingDir', input.workingDir);
+  applyOptionalString(out, 'defaultWorkingDir', input.defaultWorkingDir);
 
   if (input.allowedUsers !== undefined) {
     const allowedUsers = input.allowedUsers.trim();

--- a/src/setup/interactive-select.ts
+++ b/src/setup/interactive-select.ts
@@ -108,13 +108,55 @@ export function interactiveSelect(opts: {
       }
       // Backspace
       if (key === '\x7f' || key === '\x08') { query = query.slice(0, -1); refilter(); render(); return; }
-      // 普通可打印字符 → 追加到搜索
-      if (isPrintable(key)) { query += key; cursor = 0; refilter(); render(); return; }
+      // 普通可打印字符 → 追加到搜索。粘贴 / 快速输入会把多个字符合并成一个
+      // chunk 送达，逐字符过滤后整段追加（含控制字符的混合序列仍整体忽略）。
+      const printable = [...key].every((ch) => isPrintable(ch));
+      if (key.length > 0 && printable) { query += key; cursor = 0; refilter(); render(); return; }
       // 其它（未识别的转义序列等）忽略
     }
 
     input.on('data', onData);
   });
+}
+
+/**
+ * 通用选择题：TTY 下走 {@link interactiveSelect}（↑/↓ + 搜索 + ⏎），非 TTY
+ * 回退为「打印带序号列表 + readline 读序号」。setup 里所有"从 N 个选项里挑
+ * 一个"的问题统一走这里，与 CLI 适配器选择器同款交互。
+ *
+ * 返回选中项下标；取消（Esc / Ctrl-C）返回 null，由调用方决定取消语义
+ * （保留当前值 / 中止流程）。非 TTY 下留空返回 defaultIndex（未设则 null），
+ * 无效输入重问（stdin 关闭时 readline 读到空串 → 走默认值，不会死循环）。
+ */
+export async function pickChoice(
+  rl: ReturnType<typeof createInterface>,
+  opts: {
+    title: string;
+    items: ReadonlyArray<SelectItem>;
+    defaultIndex?: number;
+    footer?: string;
+  },
+): Promise<number | null> {
+  const { items, defaultIndex } = opts;
+  if (items.length === 0) return null;
+
+  if (!input.isTTY || !output.isTTY) {
+    const lines = items.map((o, i) => `  ${i + 1}) ${o.label}${o.hint ? `（${o.hint}）` : ''}`);
+    output.write(`\n${opts.title}\n${lines.join('\n')}\n`);
+    const defLabel = defaultIndex !== undefined ? ` [${defaultIndex + 1}]` : '';
+    for (;;) {
+      const ans = (await new Promise<string>((res) => rl.question(`选择 (1-${items.length})${defLabel}: `, res))).trim();
+      if (!ans) return defaultIndex ?? null;
+      const n = Number(ans);
+      if (Number.isInteger(n) && n >= 1 && n <= items.length) return n - 1;
+      output.write(`  无效选择: ${ans}\n`);
+    }
+  }
+
+  const idx = await interactiveSelect({ title: opts.title, items, footer: opts.footer });
+  // alt-screen 退出后什么都不留，回显选中项，让上下文可读。
+  if (idx !== null) output.write(` ✔ ${opts.title}: ${items[idx].label}\n`);
+  return idx;
 }
 
 /**

--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -512,6 +512,144 @@ export async function automateOpenPlatformSetup(
   }
 }
 
+// ─── 已有应用列表 / 凭证读取（setup「选择已有应用」路径）───────────────────────
+//
+// 复用同一套 Web session + console CSRF 机制，调 console 前端同款接口
+// （bundle 里的 getAppList / getAppSecret）。与 automateOpenPlatformSetup 的
+// 内联 postJson 少量重复——那条链路已实测稳定且 CSRF 种子页 / referer 都绑定
+// 具体 appId，不强行合并，避免动到已验证的自动配置路径。
+
+export interface OpenPlatformAppSummary {
+  clientId: string;
+  name: string;
+  /** 应用描述（接口给什么用什么，仅展示）。 */
+  description?: string;
+}
+
+export interface OpenPlatformApiClient {
+  apiOrigin: string;
+  postJson(path: string, body?: unknown): Promise<unknown>;
+}
+
+export type OpenPlatformClientResult =
+  | { ok: true; client: OpenPlatformApiClient }
+  | { ok: false; reason: 'missing_csrf' | 'network'; message: string };
+
+/**
+ * 用已就绪的 Web session cookies 构造开放平台 console API 客户端：加载 console
+ * 页面提取 `window.csrfToken` 与最终 origin（部分租户会把控制台重定向到
+ * open.larkoffice.com），返回可调 `/developers/v1/*` 的 postJson。
+ */
+export async function createOpenPlatformApiClient(
+  cookies: StoredCookie[],
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<OpenPlatformClientResult> {
+  const fetcher = opts.fetchImpl ?? fetch;
+  const session = new MutableCookieJar(cookies);
+  let csrfToken: string | null = null;
+  let apiOrigin = 'https://open.feishu.cn';
+  let referer = `${apiOrigin}/app`;
+  try {
+    const page = await session.fetchTextWithUrl(fetcher, `${apiOrigin}/app`);
+    apiOrigin = new URL(page.finalUrl).origin;
+    referer = page.finalUrl;
+    csrfToken = extractOpenPlatformCsrfToken(page.text);
+  } catch (err) {
+    return { ok: false, reason: 'network', message: `读取开放平台页面失败: ${safeErrorMessage(err)}` };
+  }
+  if (!csrfToken) {
+    return {
+      ok: false,
+      reason: 'missing_csrf',
+      message: '开放平台页面没有返回 window.csrfToken；Web session 可能已过期或未完成开放平台登录',
+    };
+  }
+
+  const postJson = async (path: string, body?: unknown): Promise<unknown> => {
+    const url = `${apiOrigin}${path}`;
+    const response = await session.fetchRaw(fetcher, url, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json, text/plain, */*',
+        origin: apiOrigin,
+        referer,
+        'x-csrf-token': csrfToken!,
+        ...(body === undefined ? {} : { 'content-type': 'application/json' }),
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    let data: any;
+    try {
+      data = await response.json();
+    } catch {
+      data = null;
+    }
+    if (!response.ok) {
+      throw new OpenPlatformApiError(`HTTP ${response.status} ${path}: ${summarizeOpenPlatformPayload(data)}`, data);
+    }
+    if (data && typeof data === 'object' && typeof data.code === 'number' && data.code !== 0) {
+      throw new OpenPlatformApiError(`code=${data.code} msg=${data.msg ?? data.message ?? ''}`, data);
+    }
+    return data;
+  };
+
+  return { ok: true, client: { apiOrigin, postJson } };
+}
+
+/**
+ * 列出当前登录人可见的自建应用（console `getAppList` 同款：
+ * POST /developers/v1/app/list，body {Count, Cursor, QueryFilter}，响应
+ * data.apps + totalCount，分页拉全）。console 是内部接口，item 字段名做
+ * 宽松解析，取不到 cli_ 开头 clientId 的条目丢弃。失败抛错（含 API 错误）。
+ */
+export async function listOpenPlatformApps(
+  client: OpenPlatformApiClient,
+  opts: { pageSize?: number; maxApps?: number } = {},
+): Promise<OpenPlatformAppSummary[]> {
+  const pageSize = opts.pageSize ?? 100;
+  const maxApps = opts.maxApps ?? 500;
+  const out: OpenPlatformAppSummary[] = [];
+  for (let cursor = 0; cursor < maxApps; cursor += pageSize) {
+    const payload = await client.postJson('/developers/v1/app/list', {
+      Count: pageSize,
+      Cursor: cursor,
+      QueryFilter: {},
+    });
+    const record = asRecord(payload);
+    const data = asRecord(record.data);
+    const apps = Array.isArray(data.apps) ? data.apps : Array.isArray(record.apps) ? (record.apps as unknown[]) : [];
+    for (const item of apps) {
+      const rec = asRecord(item);
+      const clientId = pickString(rec, ['clientId', 'client_id', 'appId', 'app_id', 'appID']);
+      if (!clientId || !clientId.startsWith('cli_')) continue;
+      const name = pickString(rec, ['name', 'appName', 'app_name']) ?? clientId;
+      const description = pickString(rec, ['description', 'desc', 'appDesc', 'app_desc']);
+      out.push({ clientId, name, ...(description ? { description } : {}) });
+    }
+    const totalCount = typeof data.totalCount === 'number' ? data.totalCount
+      : typeof record.totalCount === 'number' ? (record.totalCount as number) : undefined;
+    if (apps.length < pageSize) break;
+    if (totalCount !== undefined && cursor + pageSize >= totalCount) break;
+  }
+  return out;
+}
+
+/**
+ * 读取指定应用的 App Secret（console `getAppSecret` 同款：
+ * POST /developers/v1/secret/:clientId，响应含 secret 字段）。
+ * 只读接口——绝不触碰 /v1/secret/reset/*（会轮换 secret、打断在跑的 bot）。
+ */
+export async function fetchOpenPlatformAppSecret(
+  client: OpenPlatformApiClient,
+  clientId: string,
+): Promise<string> {
+  const payload = await client.postJson(`/developers/v1/secret/${clientId}`, {});
+  const record = asRecord(payload);
+  const secret = pickString(asRecord(record.data), ['secret']) ?? pickString(record, ['secret']);
+  if (!secret) throw new Error('开放平台没有返回 secret 字段');
+  return secret;
+}
+
 async function validateFeishuWebSession(cookies: StoredCookie[], fetcher: typeof fetch): Promise<boolean> {
   if (cookies.length === 0) return false;
   const session = new MutableCookieJar(cookies);

--- a/src/setup/setup-args.ts
+++ b/src/setup/setup-args.ts
@@ -1,0 +1,287 @@
+/**
+ * `botmux setup <list|add|edit|remove>` 非 TUI（脚本化）模式：argv 解析 + 纯映射。
+ *
+ * 动机：给 coding agent / 脚本一个**字段级**的稳定接口。以前脚本化 setup 只能
+ * 对交互问答「管道喂数字」，TUI 问题序列一变（比如新增一问）答案就静默错位；
+ * flag 形式不依赖问题顺序，天然稳定。
+ *
+ * 本模块保持纯函数（不碰 fs / 网络 / process），可单测；目录存在性校验、
+ * 凭证校验（tenant_access_token）、bots.json 读写等副作用留在 cli.ts 执行层。
+ */
+import {
+  applyBotConfigEdits,
+  assertOwnerWhenChatGroups,
+  hasOwnerEntry,
+  type BotConfigEditInput,
+} from './bot-config-editor.js';
+import { CLI_SELECT_OPTIONS, resolveCliSelection } from './cli-selection.js';
+
+/** add / edit 共用的 bot 字段 flag（原始字符串，'-' 表示清空，语义同 TUI 编辑）。 */
+export interface SetupBotFlags {
+  name?: string;
+  appId?: string;
+  appSecret?: string;
+  /** CLI 选择键：cliId 或网关键（aiden-x-claude / ttadk-x-codex …），见 CLI_SELECT_OPTIONS。 */
+  cli?: string;
+  cliPath?: string;
+  wrapperCli?: string;
+  model?: string;
+  backend?: string;
+  /** 仓库选择卡片的扫描根目录（逗号分隔多个）。 */
+  workingDir?: string;
+  /** 固定默认目录：新话题直接在此目录启动、不弹仓库选择卡片；'-' 清空回弹卡模式。 */
+  defaultWorkingDir?: string;
+  allowedUsers?: string;
+  allowedChatGroups?: string;
+  showInTeam?: string;
+  /** 仅 add：feishu | lark。 */
+  brand?: string;
+}
+
+export type SetupCommand =
+  | { action: 'help' }
+  | { action: 'list'; json: boolean }
+  | { action: 'add'; json: boolean; openPlatformAuto: boolean; flags: SetupBotFlags }
+  | { action: 'edit'; json: boolean; selector: string; flags: SetupBotFlags }
+  | { action: 'remove'; json: boolean; selector: string; yes: boolean };
+
+/**
+ * `botmux setup` 后面第一个参数是否触发脚本化模式：任何**非 flag** 首参数都算
+ * （未知子命令由 parseSetupCommand 报错，而不是掉进交互 TUI 把脚本挂住）。
+ * 空参数 / 纯 flag（如 --no-open-platform-auto）仍走原交互 TUI，保持向后兼容。
+ */
+export function isScriptedSetupInvocation(argv: string[]): boolean {
+  const first = argv[0];
+  if (first === undefined) return false;
+  if (first === '--help' || first === '-h') return true;
+  return !first.startsWith('-');
+}
+
+const BOT_FIELD_FLAGS: Record<string, keyof SetupBotFlags> = {
+  '--name': 'name',
+  '--app-id': 'appId',
+  '--app-secret': 'appSecret',
+  '--cli': 'cli',
+  '--cli-path': 'cliPath',
+  '--wrapper-cli': 'wrapperCli',
+  '--model': 'model',
+  '--backend': 'backend',
+  '--working-dir': 'workingDir',
+  '--default-working-dir': 'defaultWorkingDir',
+  '--allowed-users': 'allowedUsers',
+  '--allowed-chat-groups': 'allowedChatGroups',
+  '--show-in-team': 'showInTeam',
+  '--brand': 'brand',
+};
+
+export const SETUP_CLI_USAGE = `botmux setup — 脚本化（非 TUI）用法
+
+  botmux setup list [--json]
+      列出已配置机器人（--json 输出完整字段，secret 脱敏）。
+
+  botmux setup add --app-id <cli_xxx> --app-secret <secret> --allowed-users <owner> [选项]
+      添加机器人。必填：--app-id / --app-secret / --allowed-users（至少一个
+      完整邮箱、union_id on_xxx 或 open_id ou_xxx 作为 owner）。
+      写盘前会用凭证换 tenant_access_token 校验，校验失败不写盘。
+
+  botmux setup edit <进程名|AppID> [字段选项...]
+      按字段修改机器人（如 botmux setup edit botmux-0 --cli codex）。
+      至少给一个字段选项；值传 - 表示清空该字段。
+
+  botmux setup remove <进程名|AppID> --yes
+      删除机器人（非交互删除必须显式 --yes 确认）。
+
+字段选项（add / edit 通用；edit 中未给出的字段保持不变）：
+  --name <n>                 botmux status 显示名（进程名后缀）
+  --app-id <cli_xxx>         飞书应用 App ID（edit 时改绑另一个应用）
+  --app-secret <secret>      App Secret
+  --cli <key>                CLI 适配器：cliId 或网关键（claude-code / codex /
+                             aiden-x-claude / ttadk-x-codex …）
+  --cli-path <path>          CLI 可执行文件路径覆盖
+  --wrapper-cli <prefix>     通用启动前缀（如 "aiden x claude"），覆盖 --cli 推导值
+  --model <m>                CLI 模型名
+  --backend <b>              会话后端 pty | tmux | herdr | zellij
+  --working-dir <dirs>       仓库选择卡片的扫描根目录（逗号分隔多个）
+  --default-working-dir <d>  固定默认目录：新话题直接在此目录启动、不弹仓库
+                             选择卡片；传 - 清空、回到弹卡模式
+  --allowed-users <a,b>      管理员名单（完整邮箱 / on_xxx / ou_xxx，逗号分隔）
+  --allowed-chat-groups <g>  可对话群 chat_id（oc_xxx，逗号分隔）
+  --show-in-team <bool>      平台团队页是否展示（默认 true）
+  --brand <feishu|lark>      租户类型（仅 add）
+
+通用选项：
+  --json                     输出机器可读 JSON（含 ok / error 字段）
+  --open-platform-auto       add 成功后执行开放平台自动配置（默认跳过；
+                             需要扫码，请在可交互终端使用）
+`;
+
+function parseBotFieldFlags(
+  tokens: string[],
+  opts: { allowFields: boolean; action: string },
+): { flags: SetupBotFlags; json: boolean; yes: boolean; openPlatformAuto: boolean; positional: string[] } {
+  const flags: SetupBotFlags = {};
+  const positional: string[] = [];
+  let json = false;
+  let yes = false;
+  let openPlatformAuto = false;
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (token === '--json') { json = true; continue; }
+    if (token === '--yes' || token === '-y') { yes = true; continue; }
+    if (token === '--open-platform-auto') { openPlatformAuto = true; continue; }
+    if (token === '--no-open-platform-auto') { openPlatformAuto = false; continue; }
+
+    if (token.startsWith('--')) {
+      const eq = token.indexOf('=');
+      const flag = eq >= 0 ? token.slice(0, eq) : token;
+      const field = BOT_FIELD_FLAGS[flag];
+      if (!field) {
+        throw new Error(`未知参数 ${flag}。查看用法：botmux setup help`);
+      }
+      if (!opts.allowFields) {
+        throw new Error(`${opts.action} 不接受字段参数 ${flag}。查看用法：botmux setup help`);
+      }
+      let value: string;
+      if (eq >= 0) {
+        value = token.slice(eq + 1);
+      } else {
+        const next = tokens[i + 1];
+        // '-' 是合法的清空值；以 '--' 开头的下一个 token 视为漏填了取值。
+        if (next === undefined || next.startsWith('--')) {
+          throw new Error(`${flag} 缺少取值。查看用法：botmux setup help`);
+        }
+        value = next;
+        i++;
+      }
+      flags[field] = value;
+      continue;
+    }
+    positional.push(token);
+  }
+  return { flags, json, yes, openPlatformAuto, positional };
+}
+
+/** 解析 `botmux setup` 的脚本化子命令 argv。非法输入抛 Error（message 面向用户）。 */
+export function parseSetupCommand(argv: string[]): SetupCommand {
+  const [action, ...rest] = argv;
+  if (action === 'help' || action === '--help' || action === '-h') return { action: 'help' };
+
+  if (action === 'list') {
+    const { json, positional } = parseBotFieldFlags(rest, { allowFields: false, action: 'list' });
+    if (positional.length > 0) throw new Error(`list 不接受多余参数: ${positional.join(' ')}`);
+    return { action: 'list', json };
+  }
+
+  if (action === 'add') {
+    const { flags, json, openPlatformAuto, positional } = parseBotFieldFlags(rest, { allowFields: true, action: 'add' });
+    if (positional.length > 0) throw new Error(`add 不接受位置参数: ${positional.join(' ')}（字段一律用 --flag 形式）`);
+    return { action: 'add', json, openPlatformAuto, flags };
+  }
+
+  if (action === 'edit') {
+    const { flags, json, positional } = parseBotFieldFlags(rest, { allowFields: true, action: 'edit' });
+    if (positional.length === 0) throw new Error('edit 需要指定机器人（进程名 botmux-N 或 AppID）。');
+    if (positional.length > 1) throw new Error(`edit 只接受一个机器人标识: ${positional.join(' ')}`);
+    return { action: 'edit', json, selector: positional[0], flags };
+  }
+
+  if (action === 'remove') {
+    const { json, yes, positional } = parseBotFieldFlags(rest, { allowFields: false, action: 'remove' });
+    if (positional.length === 0) throw new Error('remove 需要指定机器人（进程名 botmux-N 或 AppID）。');
+    if (positional.length > 1) throw new Error(`remove 只接受一个机器人标识: ${positional.join(' ')}`);
+    return { action: 'remove', json, selector: positional[0], yes };
+  }
+
+  throw new Error(`未知 setup 子命令 "${action}"。查看用法：botmux setup help`);
+}
+
+/**
+ * add flags → 可落盘 bot 对象（纯映射，不做目录存在性 / 凭证校验）。
+ * 必填缺失、CLI 选择键非法、owner 缺失等一律抛 Error。
+ */
+export function buildBotFromAddFlags(flags: SetupBotFlags): Record<string, any> {
+  const missing: string[] = [];
+  if (!flags.appId?.trim()) missing.push('--app-id');
+  if (!flags.appSecret?.trim()) missing.push('--app-secret');
+  if (!flags.allowedUsers?.trim()) missing.push('--allowed-users');
+  if (missing.length > 0) throw new Error(`add 缺少必填参数: ${missing.join(' ')}`);
+
+  const brand = (flags.brand ?? 'feishu').trim().toLowerCase();
+  if (brand !== 'feishu' && brand !== 'lark') {
+    throw new Error(`--brand 必须是 feishu 或 lark: ${flags.brand}`);
+  }
+
+  const sel = resolveCliSelection((flags.cli ?? 'claude-code').trim());
+  const base: Record<string, any> = {
+    larkAppId: flags.appId!.trim(),
+    larkAppSecret: flags.appSecret!.trim(),
+    cliId: sel.cliId,
+    ...(sel.wrapperCli ? { wrapperCli: sel.wrapperCli } : {}),
+    // 与 TUI 同口径：feishu 不落 brand 字段，bots.json 保持干净。
+    ...(brand === 'lark' ? { brand: 'lark' } : {}),
+  };
+
+  const input: BotConfigEditInput = {
+    name: flags.name,
+    cliPathOverride: flags.cliPath,
+    model: flags.model,
+    backendType: flags.backend,
+    // 固定默认目录模式（只给 --default-working-dir）不强写 workingDir，
+    // 扫描根回退默认 ~；其余情况与 TUI 一致，总是落 workingDir（留空 → '~'）。
+    workingDir: flags.workingDir ?? (flags.defaultWorkingDir ? undefined : '~'),
+    defaultWorkingDir: flags.defaultWorkingDir,
+    allowedUsers: flags.allowedUsers,
+    allowedChatGroups: flags.allowedChatGroups,
+    showInTeam: flags.showInTeam,
+    // 显式 --wrapper-cli 覆盖 --cli 推导出的前缀（undefined 时不动 base 里的值）。
+    wrapperCli: flags.wrapperCli,
+  };
+  const bot = applyBotConfigEdits(base, input);
+  if (!hasOwnerEntry(bot.allowedUsers)) {
+    throw new Error('--allowed-users 至少需要一个完整邮箱、union_id（on_xxx）或 open_id（ou_xxx）作为 owner。');
+  }
+  assertOwnerWhenChatGroups(bot);
+  return bot;
+}
+
+/**
+ * edit flags → BotConfigEditInput（纯映射）。--cli 走 resolveCliSelection：
+ * 选普通 CLI 会清掉旧 wrapperCli（与 TUI 一致），显式 --wrapper-cli 再覆盖。
+ */
+export function editInputFromFlags(flags: SetupBotFlags): BotConfigEditInput {
+  if (flags.brand !== undefined) {
+    throw new Error('--brand 仅在 add 时可指定（brand 绑定租户域名，换租户请 remove 后重新 add）。');
+  }
+  const input: BotConfigEditInput = {};
+  if (flags.name !== undefined) input.name = flags.name;
+  if (flags.appId !== undefined) input.larkAppId = flags.appId;
+  if (flags.appSecret !== undefined) input.larkAppSecret = flags.appSecret;
+  if (flags.cli !== undefined) {
+    const sel = resolveCliSelection(flags.cli.trim());
+    input.cliChoice = sel.cliId;
+    input.wrapperCli = sel.wrapperCli ?? null;
+  }
+  if (flags.wrapperCli !== undefined) input.wrapperCli = flags.wrapperCli;
+  if (flags.cliPath !== undefined) input.cliPathOverride = flags.cliPath;
+  if (flags.model !== undefined) input.model = flags.model;
+  if (flags.backend !== undefined) input.backendType = flags.backend;
+  if (flags.workingDir !== undefined) input.workingDir = flags.workingDir;
+  if (flags.defaultWorkingDir !== undefined) input.defaultWorkingDir = flags.defaultWorkingDir;
+  if (flags.allowedUsers !== undefined) input.allowedUsers = flags.allowedUsers;
+  if (flags.allowedChatGroups !== undefined) input.allowedChatGroups = flags.allowedChatGroups;
+  if (flags.showInTeam !== undefined) input.showInTeam = flags.showInTeam;
+  return input;
+}
+
+/** 合法 --cli 取值（报错提示用）。 */
+export function cliSelectionKeys(): string[] {
+  return CLI_SELECT_OPTIONS.map(o => o.key);
+}
+
+/** list --json 输出前的 secret 脱敏（CLI 输出可能被贴进聊天/日志）。 */
+export function maskAppSecret(secret: unknown): string {
+  if (typeof secret !== 'string' || !secret) return '';
+  if (secret.length <= 8) return '••••';
+  return `${secret.slice(0, 4)}••••${secret.slice(-4)}`;
+}

--- a/test/setup-args.test.ts
+++ b/test/setup-args.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBotFromAddFlags,
+  editInputFromFlags,
+  isScriptedSetupInvocation,
+  maskAppSecret,
+  parseSetupCommand,
+} from '../src/setup/setup-args.js';
+import { applyBotConfigEdits } from '../src/setup/bot-config-editor.js';
+
+describe('isScriptedSetupInvocation', () => {
+  it('recognizes scripted subcommands and help aliases', () => {
+    for (const first of ['list', 'add', 'edit', 'remove', 'help', '--help', '-h']) {
+      expect(isScriptedSetupInvocation([first])).toBe(true);
+    }
+  });
+
+  it('keeps bare invocation and TUI-era flags on the interactive path', () => {
+    expect(isScriptedSetupInvocation([])).toBe(false);
+    expect(isScriptedSetupInvocation(['--no-open-platform-auto'])).toBe(false);
+    expect(isScriptedSetupInvocation(['--open-platform-auto'])).toBe(false);
+  });
+
+  it('routes unknown bare words to the scripted parser instead of hanging the TUI', () => {
+    expect(isScriptedSetupInvocation(['frobnicate'])).toBe(true);
+  });
+});
+
+describe('parseSetupCommand', () => {
+  it('parses help', () => {
+    expect(parseSetupCommand(['help'])).toEqual({ action: 'help' });
+    expect(parseSetupCommand(['--help'])).toEqual({ action: 'help' });
+  });
+
+  it('parses list with and without --json', () => {
+    expect(parseSetupCommand(['list'])).toEqual({ action: 'list', json: false });
+    expect(parseSetupCommand(['list', '--json'])).toEqual({ action: 'list', json: true });
+  });
+
+  it('rejects field flags and positionals on list', () => {
+    expect(() => parseSetupCommand(['list', '--cli', 'codex'])).toThrow(/list 不接受字段参数/);
+    expect(() => parseSetupCommand(['list', 'botmux-0'])).toThrow(/不接受多余参数/);
+  });
+
+  it('parses add flags in both --flag value and --flag=value forms', () => {
+    const cmd = parseSetupCommand([
+      'add',
+      '--app-id', 'cli_x',
+      '--app-secret=s3cret',
+      '--allowed-users', 'alice@example.com',
+      '--cli=codex',
+      '--working-dir', '~/projects',
+      '--json',
+    ]);
+    expect(cmd).toMatchObject({
+      action: 'add',
+      json: true,
+      openPlatformAuto: false,
+      flags: {
+        appId: 'cli_x',
+        appSecret: 's3cret',
+        allowedUsers: 'alice@example.com',
+        cli: 'codex',
+        workingDir: '~/projects',
+      },
+    });
+  });
+
+  it('parses --open-platform-auto with last-one-wins against --no-open-platform-auto', () => {
+    const on = parseSetupCommand(['add', '--open-platform-auto']);
+    expect(on).toMatchObject({ action: 'add', openPlatformAuto: true });
+    const off = parseSetupCommand(['add', '--open-platform-auto', '--no-open-platform-auto']);
+    expect(off).toMatchObject({ action: 'add', openPlatformAuto: false });
+  });
+
+  it('accepts "-" as a clear value but treats a following --flag as a missing value', () => {
+    const cmd = parseSetupCommand(['edit', 'botmux-0', '--default-working-dir', '-']);
+    expect(cmd).toMatchObject({ action: 'edit', selector: 'botmux-0', flags: { defaultWorkingDir: '-' } });
+    expect(() => parseSetupCommand(['edit', 'botmux-0', '--model', '--json'])).toThrow(/--model 缺少取值/);
+    expect(() => parseSetupCommand(['edit', 'botmux-0', '--model'])).toThrow(/--model 缺少取值/);
+  });
+
+  it('rejects unknown flags and positionals on add', () => {
+    expect(() => parseSetupCommand(['add', '--nope', 'x'])).toThrow(/未知参数 --nope/);
+    expect(() => parseSetupCommand(['add', 'stray'])).toThrow(/不接受位置参数/);
+  });
+
+  it('requires exactly one selector for edit and remove', () => {
+    expect(() => parseSetupCommand(['edit'])).toThrow(/需要指定机器人/);
+    expect(() => parseSetupCommand(['edit', 'a', 'b'])).toThrow(/只接受一个机器人标识/);
+    expect(parseSetupCommand(['remove', 'botmux-1', '--yes', '--json'])).toEqual({
+      action: 'remove', selector: 'botmux-1', yes: true, json: true,
+    });
+    expect(parseSetupCommand(['remove', 'cli_abc'])).toEqual({
+      action: 'remove', selector: 'cli_abc', yes: false, json: false,
+    });
+  });
+
+  it('rejects unknown subcommands', () => {
+    expect(() => parseSetupCommand(['frobnicate'])).toThrow(/未知 setup 子命令/);
+  });
+});
+
+describe('buildBotFromAddFlags', () => {
+  const REQUIRED = {
+    appId: 'cli_x',
+    appSecret: 's3cret',
+    allowedUsers: 'alice@example.com',
+  };
+
+  it('builds a minimal bot with TUI-compatible defaults', () => {
+    const bot = buildBotFromAddFlags({ ...REQUIRED });
+    expect(bot).toEqual({
+      larkAppId: 'cli_x',
+      larkAppSecret: 's3cret',
+      cliId: 'claude-code',
+      workingDir: '~',
+      allowedUsers: ['alice@example.com'],
+    });
+  });
+
+  it('lists all missing required flags at once', () => {
+    expect(() => buildBotFromAddFlags({})).toThrow(/--app-id --app-secret --allowed-users/);
+  });
+
+  it('resolves gateway cli selection keys into cliId + wrapperCli', () => {
+    const bot = buildBotFromAddFlags({ ...REQUIRED, cli: 'aiden-x-claude' });
+    expect(bot.cliId).toBe('claude-code');
+    expect(bot.wrapperCli).toBe('aiden x claude');
+  });
+
+  it('lets an explicit --wrapper-cli override the --cli derived prefix, and "-" clear it', () => {
+    const overridden = buildBotFromAddFlags({ ...REQUIRED, cli: 'aiden-x-claude', wrapperCli: 'ccr code' });
+    expect(overridden.wrapperCli).toBe('ccr code');
+    const cleared = buildBotFromAddFlags({ ...REQUIRED, cli: 'aiden-x-claude', wrapperCli: '-' });
+    expect(cleared.wrapperCli).toBeUndefined();
+  });
+
+  it('rejects unknown cli selection keys', () => {
+    expect(() => buildBotFromAddFlags({ ...REQUIRED, cli: 'not-a-cli' })).toThrow(/未知 CLI 选择项/);
+  });
+
+  it('persists brand only for lark and rejects other values', () => {
+    expect(buildBotFromAddFlags({ ...REQUIRED, brand: 'lark' }).brand).toBe('lark');
+    expect(buildBotFromAddFlags({ ...REQUIRED, brand: 'feishu' }).brand).toBeUndefined();
+    expect(() => buildBotFromAddFlags({ ...REQUIRED, brand: 'slack' })).toThrow(/--brand 必须是 feishu 或 lark/);
+  });
+
+  it('fixed default dir mode: --default-working-dir alone leaves workingDir unset', () => {
+    const bot = buildBotFromAddFlags({ ...REQUIRED, defaultWorkingDir: '/data/proj' });
+    expect(bot.defaultWorkingDir).toBe('/data/proj');
+    expect(bot.workingDir).toBeUndefined();
+  });
+
+  it('allows scan roots and a pinned default dir to coexist when both flags are given', () => {
+    const bot = buildBotFromAddFlags({ ...REQUIRED, workingDir: '~/a,~/b', defaultWorkingDir: '/data/proj' });
+    expect(bot.workingDir).toBe('~/a,~/b');
+    expect(bot.defaultWorkingDir).toBe('/data/proj');
+  });
+
+  it('rejects allowed-users entries without a resolvable owner', () => {
+    expect(() => buildBotFromAddFlags({ ...REQUIRED, allowedUsers: 'alice' })).toThrow(/完整邮箱/);
+  });
+
+  it('stores showInTeam=false and keeps default true unstored', () => {
+    expect(buildBotFromAddFlags({ ...REQUIRED, showInTeam: 'false' }).showInTeam).toBe(false);
+    expect(buildBotFromAddFlags({ ...REQUIRED, showInTeam: 'true' }).showInTeam).toBeUndefined();
+  });
+});
+
+describe('editInputFromFlags', () => {
+  it('maps only the provided flags', () => {
+    expect(editInputFromFlags({})).toEqual({});
+    expect(editInputFromFlags({ model: 'opus', backend: 'tmux' })).toEqual({
+      model: 'opus',
+      backendType: 'tmux',
+    });
+  });
+
+  it('clears wrapperCli when switching to a plain cli, keeps it for gateway keys', () => {
+    expect(editInputFromFlags({ cli: 'codex' })).toEqual({ cliChoice: 'codex', wrapperCli: null });
+    expect(editInputFromFlags({ cli: 'ttadk-x-codex' })).toEqual({
+      cliChoice: 'codex',
+      wrapperCli: 'ttadk codex',
+    });
+  });
+
+  it('lets an explicit --wrapper-cli outrank the --cli derived value', () => {
+    expect(editInputFromFlags({ cli: 'codex', wrapperCli: 'cjadk codex' })).toEqual({
+      cliChoice: 'codex',
+      wrapperCli: 'cjadk codex',
+    });
+  });
+
+  it('passes tri-state clears through and rejects brand on edit', () => {
+    expect(editInputFromFlags({ defaultWorkingDir: '-' })).toEqual({ defaultWorkingDir: '-' });
+    expect(() => editInputFromFlags({ brand: 'lark' })).toThrow(/--brand 仅在 add 时可指定/);
+  });
+});
+
+describe('applyBotConfigEdits defaultWorkingDir (via edit flags)', () => {
+  it('sets, keeps, and clears defaultWorkingDir tri-state', () => {
+    const base = { larkAppId: 'cli_x', larkAppSecret: 's', workingDir: '~/repos' };
+    const withDefault = applyBotConfigEdits(base, editInputFromFlags({ defaultWorkingDir: '/data/proj' }));
+    expect(withDefault.defaultWorkingDir).toBe('/data/proj');
+    const untouched = applyBotConfigEdits(withDefault, editInputFromFlags({ model: 'opus' }));
+    expect(untouched.defaultWorkingDir).toBe('/data/proj');
+    const cleared = applyBotConfigEdits(withDefault, editInputFromFlags({ defaultWorkingDir: '-' }));
+    expect(cleared.defaultWorkingDir).toBeUndefined();
+  });
+});
+
+describe('maskAppSecret', () => {
+  it('masks short secrets fully and long ones down to head/tail', () => {
+    expect(maskAppSecret(undefined)).toBe('');
+    expect(maskAppSecret('short')).toBe('••••');
+    expect(maskAppSecret('abcd1234efgh5678')).toBe('abcd••••5678');
+  });
+});

--- a/test/setup-pickers.test.ts
+++ b/test/setup-pickers.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { pickChoice } from '../src/setup/interactive-select.js';
+import {
+  listOpenPlatformApps,
+  fetchOpenPlatformAppSecret,
+  type OpenPlatformApiClient,
+} from '../src/setup/open-platform-automation.js';
+
+/** 假 readline：按队列吐答案，队列空了回空串（模拟 stdin 关闭 / EIO 兜底）。 */
+function fakeRl(answers: string[]) {
+  return {
+    question(_q: string, cb: (answer: string) => void) {
+      cb(answers.shift() ?? '');
+    },
+  } as any;
+}
+
+// vitest 进程的 stdin/stdout 不是 TTY，pickChoice 走「序号文本输入」回退分支。
+describe('pickChoice non-TTY fallback', () => {
+  const ITEMS = [{ label: '甲' }, { label: '乙', hint: 'b' }, { label: '丙' }];
+
+  it('returns the default index on empty input', async () => {
+    expect(await pickChoice(fakeRl(['']), { title: 't', items: ITEMS, defaultIndex: 1 })).toBe(1);
+  });
+
+  it('returns null on empty input without a default', async () => {
+    expect(await pickChoice(fakeRl(['']), { title: 't', items: ITEMS })).toBe(null);
+  });
+
+  it('parses a 1-based number into a 0-based index', async () => {
+    expect(await pickChoice(fakeRl(['3']), { title: 't', items: ITEMS, defaultIndex: 0 })).toBe(2);
+  });
+
+  it('re-asks on invalid input until a valid pick, and falls back to default when input dries up', async () => {
+    expect(await pickChoice(fakeRl(['9', 'abc', '2']), { title: 't', items: ITEMS, defaultIndex: 0 })).toBe(1);
+    // 无效输入后 stdin 干涸（后续恒空串）→ 回默认值而不是死循环
+    expect(await pickChoice(fakeRl(['9']), { title: 't', items: ITEMS, defaultIndex: 2 })).toBe(2);
+  });
+
+  it('returns null for an empty item list', async () => {
+    expect(await pickChoice(fakeRl(['1']), { title: 't', items: [] })).toBe(null);
+  });
+});
+
+function stubClient(responses: unknown[] | ((path: string, body: unknown) => unknown)): OpenPlatformApiClient & { calls: Array<{ path: string; body: unknown }> } {
+  const calls: Array<{ path: string; body: unknown }> = [];
+  const queue = Array.isArray(responses) ? [...responses] : null;
+  return {
+    apiOrigin: 'https://open.feishu.cn',
+    calls,
+    async postJson(path: string, body?: unknown) {
+      calls.push({ path, body });
+      return queue ? queue.shift() : (responses as (p: string, b: unknown) => unknown)(path, body);
+    },
+  };
+}
+
+describe('listOpenPlatformApps', () => {
+  it('parses apps with lenient field names and drops non-cli_ entries', async () => {
+    const client = stubClient([{
+      code: 0,
+      data: {
+        apps: [
+          { clientId: 'cli_a', name: 'Bot A', description: 'desc' },
+          { appId: 'cli_b', appName: 'Bot B' },
+          { clientId: 'xx_bad', name: 'nope' },
+          { name: 'no-id' },
+        ],
+        totalCount: 4,
+      },
+    }]);
+    const apps = await listOpenPlatformApps(client);
+    expect(apps).toEqual([
+      { clientId: 'cli_a', name: 'Bot A', description: 'desc' },
+      { clientId: 'cli_b', name: 'Bot B' },
+    ]);
+    expect(client.calls[0]).toEqual({
+      path: '/developers/v1/app/list',
+      body: { Count: 100, Cursor: 0, QueryFilter: {} },
+    });
+  });
+
+  it('pages with Cursor until totalCount is covered', async () => {
+    const client = stubClient([
+      { code: 0, data: { apps: [{ clientId: 'cli_1', name: '1' }, { clientId: 'cli_2', name: '2' }], totalCount: 3 } },
+      { code: 0, data: { apps: [{ clientId: 'cli_3', name: '3' }], totalCount: 3 } },
+    ]);
+    const apps = await listOpenPlatformApps(client, { pageSize: 2 });
+    expect(apps.map(a => a.clientId)).toEqual(['cli_1', 'cli_2', 'cli_3']);
+    expect(client.calls.map(c => (c.body as any).Cursor)).toEqual([0, 2]);
+  });
+
+  it('stops on a short page even without totalCount', async () => {
+    const client = stubClient([
+      { code: 0, data: { apps: [{ clientId: 'cli_1', name: '1' }] } },
+    ]);
+    const apps = await listOpenPlatformApps(client, { pageSize: 2 });
+    expect(apps).toHaveLength(1);
+    expect(client.calls).toHaveLength(1);
+  });
+});
+
+describe('fetchOpenPlatformAppSecret', () => {
+  it('reads data.secret via the read-only secret endpoint', async () => {
+    const client = stubClient([{ code: 0, data: { secret: 's3cret' } }]);
+    await expect(fetchOpenPlatformAppSecret(client, 'cli_a')).resolves.toBe('s3cret');
+    expect(client.calls[0].path).toBe('/developers/v1/secret/cli_a');
+  });
+
+  it('throws when the response has no secret field', async () => {
+    const client = stubClient([{ code: 0, data: {} }]);
+    await expect(fetchOpenPlatformAppSecret(client, 'cli_a')).rejects.toThrow(/secret/);
+  });
+});


### PR DESCRIPTION
## 背景

- setup 里问的「默认工作目录」写的是 `workingDir`，但那只是**仓库选择卡片的扫描根**——新话题照样弹卡；真正「直接进目录、不弹卡」的是 `defaultWorkingDir`（此前只能靠 /config 或 dashboard 设置）。问法与实际行为不符，容易误解。
- 脚本化 setup 此前只能对交互问答「管道喂数字」，TUI 问题序列一变答案就静默错位，coding agent 修改配置很脆。

## 改动

### 1. TUI：新话题工作目录改为显式二选一（新建 + 编辑同款问法）

```
新话题工作目录
  1) 仓库选择卡片：新话题先弹卡片选 git 仓库；下一问填卡片的扫描根目录。
  2) 固定默认目录：新话题直接在指定目录启动、不弹卡片。
```

- 模式 1 → 落 `workingDir`（扫描根，逗号分隔多个）
- 模式 2 → 落 `defaultWorkingDir`，**写盘前校验目录存在**（运行时 daemon 对无效值只 WARN 后静默回退弹卡，用户很难察觉没生效，必须在 setup 侧挡下）；不再强写多余的 `workingDir: "~"`
- 编辑时切回模式 1 会顺带清掉旧 `defaultWorkingDir`，两种模式互切干净；留空保留当前配置

### 2. 脚本化（非 TUI）子命令

```bash
botmux setup list --json
botmux setup add --app-id cli_x --app-secret s --allowed-users <owner> [--cli codex --working-dir ~/projects ...]
botmux setup edit botmux-0 --default-working-dir /data/proj   # 值传 - 清空
botmux setup remove botmux-1 --yes
botmux setup help
```

- 校验口径与 TUI 完全一致：owner 必填（`hasOwnerEntry`）、目录存在性、backendType 枚举、`assertOwnerWhenChatGroups`、add / 凭证变更时 `tenant_access_token` 校验——任一失败**不写盘**（exit 1）
- `--cli` 接受 cliId 或网关选择键（`aiden-x-claude` / `ttadk-x-codex` …，走 `resolveCliSelection`）；切换 CLI 强制清 model（同 TUI）；显式 `--wrapper-cli` 可覆盖推导值
- `--json` 输出机器可读结果（secret 脱敏，防贴进聊天/日志）；edit/remove 写盘前照样备份 `.bak`
- 开放平台自动配置（要扫码）默认跳过，`--open-platform-auto` 显式开
- 未知子命令直接报错退出，**不会**掉进交互 TUI 把脚本挂住
- 复用 `applyBotConfigEdits` 三态语义；新增 `BotConfigEditInput.defaultWorkingDir`；解析层（`src/setup/setup-args.ts`）纯函数无副作用，28 个单测覆盖

## ⚠️ 兼容性

TUI 新增了「工作目录模式」一问：以前对交互问答管道喂答案的脚本会错位（实测该姿势在 master 上本就只喂得进第一问），请迁移到本 PR 的脚本化子命令。

## 测试

- `pnpm test`：新增 28 用例全绿；全量 7067 passed，8 个失败为本机已知环境性既有失败（terminal-url ×7 / recall-frozen-cards ×1）
- 隔离 $HOME 端到端冒烟：
  - scripted：list / list --json / add（缺参、假凭证被飞书 API 拒绝且不写盘）/ edit（成功、坏目录、坏 backend 均不写盘）/ remove（无 --yes 拒绝）
  - TUI（tmux 驱动）：编辑流模式 2 落 `defaultWorkingDir`；切回模式 1 清掉并更新扫描根；不存在的目录被拒且配置未动