### PR TITLE
fix(dashboard): 运行时热切 CLI 立即关闭存量失配会话

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -35,7 +35,7 @@ import { listActiveSessions, findActiveBySessionId, closeSession, getActiveSessi
 import { listOnlineDaemons } from '../utils/daemon-discovery.js';
 import { getChatMode, replyMessage, sendMessage, resolveUnionIdFromOpenId, listThreadMessages, listChatMessages, getUserProfile } from '../im/lark/client.js';
 import { parseApiMessage, cardContentHasUpgradeFallback, resolveMergedCardContent } from '../im/lark/message-parser.js';
-import { resumeSession, spawnDashboardSession, activateQueuedSession } from './session-manager.js';
+import { resumeSession, spawnDashboardSession, activateQueuedSession, closeCliMismatchedSessionsForBot } from './session-manager.js';
 import { parseSpawnRequest } from './session-create.js';
 import { getCliDisplayName } from '../im/lark/card-builder.js';
 import { locateLimiter } from './dashboard-locate.js';
@@ -1477,7 +1477,10 @@ ipcRoute('PUT', '/api/bot-brand-label', async (req, res) => {
 
 // Per-bot agent launch settings. Body `{ cliId, model }` where `cliId` is the
 // dashboard selection key (plain adapter id or a wrapper option such as
-// `ttadk-x-codex`). Changes affect the next spawned CLI session.
+// `ttadk-x-codex`). Changes affect the next spawned CLI session; existing
+// sessions frozen on a different cliId/wrapperCli are closed immediately, so
+// a later lazy resume can't resurrect the old CLI (#346 covered the restart
+// path; this covers the hot-switch path).
 ipcRoute('PUT', '/api/bot-agent', async (req, res) => {
   if (!cachedLarkAppId) return jsonRes(res, 503, { error: 'larkAppId_not_set' });
   let body: { cliId?: unknown; model?: unknown };
@@ -1510,6 +1513,10 @@ ipcRoute('PUT', '/api/bot-agent', async (req, res) => {
   else bot.config.wrapperCli = undefined;
   bot.config.model = model || undefined;
 
+  // 热切后立刻清掉本 bot 名下失配的存量会话——否则它们冻结的旧 CLI 会被下一条
+  // 消息 lazy resume 复活，要等下次 daemon 重启才被 restore 守卫清理。
+  const closedMismatchedSessions = await closeCliMismatchedSessionsForBot(cachedLarkAppId);
+
   const selectionKey = selectionKeyForBot(selected.cliId, selected.wrapperCli);
   jsonRes(res, 200, {
     ok: true,
@@ -1517,6 +1524,7 @@ ipcRoute('PUT', '/api/bot-agent', async (req, res) => {
     wrapperCli: selected.wrapperCli ?? null,
     model: model || null,
     selectionKey,
+    closedMismatchedSessions,
   });
 });
 

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -11,7 +11,7 @@ import * as sessionStore from '../services/session-store.js';
 import * as messageQueue from '../services/message-queue.js';
 import { downloadMessageResource, listChatBotMembers, UserTokenMissingError } from '../im/lark/client.js';
 import { logger } from '../utils/logger.js';
-import { forkWorker, forkAdoptWorker, killStalePids, getCurrentCliVersion, restoreUsageLimitRuntimeState, setActiveSessionSafe, isRelayableRealSession, closeSession } from './worker-pool.js';
+import { forkWorker, forkAdoptWorker, killStalePids, getCurrentCliVersion, restoreUsageLimitRuntimeState, setActiveSessionSafe, isRelayableRealSession, closeSession, getActiveSessionsRegistry } from './worker-pool.js';
 import { createCliAdapterSync } from '../adapters/cli/registry.js';
 import { buildBotmuxShellHints } from '../adapters/cli/shared-hints.js';
 import { getSessionPersistentBackendType, persistentSessionName, probePersistentSession, probePersistentBackendServer, killPersistentSession, type PersistentBackendType } from './persistent-backend.js';
@@ -80,7 +80,7 @@ function sessionBotCliMismatch(ds: DaemonSession): { sessionCli: string; botCli:
   return null;
 }
 
-async function closeRestoredSessionIfCliMismatch(ds: DaemonSession): Promise<boolean> {
+async function closeActiveSessionIfCliMismatch(ds: DaemonSession): Promise<boolean> {
   const mismatch = sessionBotCliMismatch(ds);
   if (!mismatch) return false;
 
@@ -88,13 +88,37 @@ async function closeRestoredSessionIfCliMismatch(ds: DaemonSession): Promise<boo
   const backendType = getSessionPersistentBackendType(ds);
   if (backendType) {
     const backendName = persistentSessionName(backendType, ds.session.sessionId);
-    logger.warn(`[${tag}] CLI mismatch (session=${mismatch.sessionCli}, bot=${mismatch.botCli}), closing restored active session and killing ${backendType} ${backendName}`);
+    logger.warn(`[${tag}] CLI mismatch (session=${mismatch.sessionCli}, bot=${mismatch.botCli}), closing active session and killing ${backendType} ${backendName}`);
     killPersistentSession(backendType, backendName);
   } else {
-    logger.warn(`[${tag}] CLI mismatch (session=${mismatch.sessionCli}, bot=${mismatch.botCli}), closing restored active session`);
+    logger.warn(`[${tag}] CLI mismatch (session=${mismatch.sessionCli}, bot=${mismatch.botCli}), closing active session`);
   }
   await closeSession(ds.session.sessionId);
   return true;
+}
+
+/**
+ * Runtime counterpart of the restore-time CLI-mismatch guard（#346 只堵了重启
+ * 路径）：bot 的启动选择（cliId / wrapperCli）在 daemon 运行中被热切后，存量会话
+ * 仍冻结着旧 CLI，下一条消息（或 terminal 唤醒）会把旧 CLI lazy resume 回来。
+ * 热切端点在改完配置后调用本函数，把该 bot 名下失配的活跃会话连同 backing pane
+ * 一起关掉。
+ *
+ * 豁免口径与 restoreActiveSessions 一致：queued（待办池）会话从没起过 CLI；
+ * adopt 会话接管的是用户自己的外部 CLI，其 cliId 与 bot 配置不同是合法状态。
+ */
+export async function closeCliMismatchedSessionsForBot(larkAppId: string): Promise<number> {
+  const registry = getActiveSessionsRegistry();
+  if (!registry) return 0;
+  let closed = 0;
+  // 先快照再遍历：closeSession 会在迭代途中从 registry 删项。
+  for (const ds of [...registry.values()]) {
+    if (ds.larkAppId !== larkAppId) continue;
+    if (ds.session.queued) continue;
+    if (ds.adoptedFrom || ds.session.adoptedFrom || ds.session.title?.startsWith('Adopt:')) continue;
+    if (await closeActiveSessionIfCliMismatch(ds)) closed++;
+  }
+  return closed;
 }
 
 // ─── Path helpers ────────────────────────────────────────────────────────────
@@ -887,7 +911,7 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
       // patch a streaming card. Cleared on the first real CLI input.
       suppressRecoveryCard: true,
     };
-    if (await closeRestoredSessionIfCliMismatch(ds)) continue;
+    if (await closeActiveSessionIfCliMismatch(ds)) continue;
     const anchor = sessionAnchorId(ds);
     messageQueue.ensureQueue(anchor);
     if (ds.usageLimit) restoreUsageLimitRuntimeState(ds);
@@ -969,7 +993,7 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
     // check on the reattach path too — persistent-backend reattach ignores the
     // bin/args handed to backend.spawn(), so anything that slips through here
     // would silently resurrect the old frozen CLI.
-    if (await closeRestoredSessionIfCliMismatch(ds)) continue;
+    if (await closeActiveSessionIfCliMismatch(ds)) continue;
 
     const tag = ds.session.sessionId.substring(0, 8);
     logger.info(`[${tag}] ${backendType} session alive, queued for re-attach`);

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -90,7 +90,7 @@ async function closeActiveSessionIfCliMismatch(ds: DaemonSession): Promise<boole
   // closeSession→killWorker 摸不到 pane，必须在这里亲手杀；而活 worker（运行时
   // 热切场景）走 closeSession 的 close IPC 由 worker 侧优雅拆除 backing——先硬杀
   // pane 会跟 worker 的退出处理赛跑。
-  if (backendType && !ds.worker) {
+  if (backendType && (!ds.worker || ds.worker.killed)) {
     const backendName = persistentSessionName(backendType, ds.session.sessionId);
     logger.warn(`[${tag}] CLI mismatch (session=${mismatch.sessionCli}, bot=${mismatch.botCli}), closing active session and killing ${backendType} ${backendName}`);
     killPersistentSession(backendType, backendName);

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -86,7 +86,11 @@ async function closeActiveSessionIfCliMismatch(ds: DaemonSession): Promise<boole
 
   const tag = ds.session.sessionId.substring(0, 8);
   const backendType = getSessionPersistentBackendType(ds);
-  if (backendType) {
+  // 仅在没有活 worker 时预杀 backing pane：restore 守卫处 ds 尚未进 registry，
+  // closeSession→killWorker 摸不到 pane，必须在这里亲手杀；而活 worker（运行时
+  // 热切场景）走 closeSession 的 close IPC 由 worker 侧优雅拆除 backing——先硬杀
+  // pane 会跟 worker 的退出处理赛跑。
+  if (backendType && !ds.worker) {
     const backendName = persistentSessionName(backendType, ds.session.sessionId);
     logger.warn(`[${tag}] CLI mismatch (session=${mismatch.sessionCli}, bot=${mismatch.botCli}), closing active session and killing ${backendType} ${backendName}`);
     killPersistentSession(backendType, backendName);

--- a/test/restore-zombie-close.test.ts
+++ b/test/restore-zombie-close.test.ts
@@ -67,6 +67,7 @@ vi.mock('../src/core/worker-pool.js', () => ({
   forkWorker: vi.fn(),
   forkAdoptWorker: vi.fn(),
   killStalePids: vi.fn(),
+  getActiveSessionsRegistry: vi.fn(() => wp.registry ?? undefined),
   getCurrentCliVersion: vi.fn(() => '1.0.0-test'),
   restoreUsageLimitRuntimeState: vi.fn(),
   setActiveSessionSafe: vi.fn(async (map: Map<string, any>, key: string, ds: any) => {
@@ -147,7 +148,7 @@ vi.mock('../src/core/session-activity.js', () => ({
   markSessionActivity: vi.fn(),
 }));
 
-import { restoreActiveSessions } from '../src/core/session-manager.js';
+import { restoreActiveSessions, closeCliMismatchedSessionsForBot } from '../src/core/session-manager.js';
 import { forkWorker, closeSession } from '../src/core/worker-pool.js';
 import { announceSessionRow } from '../src/core/session-activity.js';
 import * as sessionStore from '../src/services/session-store.js';
@@ -395,5 +396,99 @@ describe('restoreActiveSessions — persistent-backend zombie-close decision', (
     expect(forkWorker).toHaveBeenCalled();
     expect(vi.mocked(forkWorker).mock.calls[0]![0].session.sessionId).toBe(s.sessionId);
     expect(map.get(sessionKey('om_exists', 'app_test'))).toBeDefined();
+  });
+});
+
+// ─── Runtime hot-switch sweep (closeCliMismatchedSessionsForBot) ─────────────
+//
+// The dashboard PUT /api/bot-agent hot-swaps a bot's cliId/wrapperCli without a
+// daemon restart, so the restore-time guard never runs; this sweep is its
+// runtime counterpart. Same mismatch predicate, same exemptions (queued /
+// adopt), scoped to one bot's larkAppId.
+describe('closeCliMismatchedSessionsForBot — runtime CLI hot-switch sweep', () => {
+  /** Register a minimal restored-style DaemonSession into wp.registry. */
+  function registerDs(s: ReturnType<typeof makeActivePersistentSession>, larkAppId = 'app_test') {
+    const ds = {
+      session: s,
+      worker: null,
+      workerPort: null,
+      workerToken: null,
+      larkAppId,
+      chatId: s.chatId,
+      chatType: 'group' as const,
+      scope: 'thread' as const,
+      spawnedAt: Date.now(),
+      cliVersion: '1.0.0-test',
+      lastMessageAt: Date.now(),
+      hasHistory: true,
+      workingDir: s.workingDir,
+    } as unknown as DaemonSession;
+    wp.registry!.set(sessionKey(s.rootMessageId, larkAppId), ds);
+    return ds;
+  }
+
+  beforeEach(() => {
+    wp.registry = new Map<string, DaemonSession>();
+  });
+
+  it('closes mismatched sessions of this bot, keeps matching ones', async () => {
+    const stale = makeActivePersistentSession('om_rt_stale');
+    stale.cliId = 'codex';
+    sessionStore.updateSession(stale);
+    registerDs(stale);
+    const fresh = makeActivePersistentSession('om_rt_fresh');
+    registerDs(fresh);
+
+    const closed = await closeCliMismatchedSessionsForBot('app_test');
+
+    expect(closed).toBe(1);
+    expect(closeSession).toHaveBeenCalledWith(stale.sessionId);
+    expect(sessionStore.getSession(stale.sessionId)!.status).toBe('closed');
+    expect(wp.registry!.get(sessionKey('om_rt_stale', 'app_test'))).toBeUndefined();
+    expect(sessionStore.getSession(fresh.sessionId)!.status).toBe('active');
+    expect(wp.registry!.get(sessionKey('om_rt_fresh', 'app_test'))).toBeDefined();
+  });
+
+  it('closes wrapper-axis mismatches for frozen sessions', async () => {
+    const s = makeActivePersistentSession('om_rt_wrapper');
+    s.wrapperCli = 'aiden x claude';
+    s.agentFrozen = true;
+    sessionStore.updateSession(s);
+    registerDs(s);
+
+    expect(await closeCliMismatchedSessionsForBot('app_test')).toBe(1);
+    expect(sessionStore.getSession(s.sessionId)!.status).toBe('closed');
+  });
+
+  it('exempts queued and adopt sessions, and other bots\' sessions', async () => {
+    const queued = makeActivePersistentSession('om_rt_queued');
+    queued.cliId = 'codex';
+    queued.queued = true;
+    sessionStore.updateSession(queued);
+    registerDs(queued);
+
+    const adopt = makeActivePersistentSession('om_rt_adopt');
+    adopt.cliId = 'codex';
+    adopt.title = 'Adopt: my-pane';
+    adopt.adoptedFrom = { source: 'tmux', tmuxTarget: 'ext:0.0', cliId: 'codex', cwd: '/tmp' } as any;
+    sessionStore.updateSession(adopt);
+    registerDs(adopt);
+
+    const otherBot = makeActivePersistentSession('om_rt_other');
+    otherBot.cliId = 'codex';
+    otherBot.larkAppId = 'app_other';
+    sessionStore.updateSession(otherBot);
+    registerDs(otherBot, 'app_other');
+
+    expect(await closeCliMismatchedSessionsForBot('app_test')).toBe(0);
+    expect(closeSession).not.toHaveBeenCalled();
+    for (const s of [queued, adopt, otherBot]) {
+      expect(sessionStore.getSession(s.sessionId)!.status).toBe('active');
+    }
+  });
+
+  it('returns 0 when the registry is not initialized', async () => {
+    wp.registry = null;
+    expect(await closeCliMismatchedSessionsForBot('app_test')).toBe(0);
   });
 });

--- a/test/restore-zombie-close.test.ts
+++ b/test/restore-zombie-close.test.ts
@@ -149,6 +149,7 @@ vi.mock('../src/core/session-activity.js', () => ({
 }));
 
 import { restoreActiveSessions, closeCliMismatchedSessionsForBot } from '../src/core/session-manager.js';
+import { TmuxBackend } from '../src/adapters/backend/tmux-backend.js';
 import { forkWorker, closeSession } from '../src/core/worker-pool.js';
 import { announceSessionRow } from '../src/core/session-activity.js';
 import * as sessionStore from '../src/services/session-store.js';
@@ -485,6 +486,22 @@ describe('closeCliMismatchedSessionsForBot — runtime CLI hot-switch sweep', ()
     for (const s of [queued, adopt, otherBot]) {
       expect(sessionStore.getSession(s.sessionId)!.status).toBe('active');
     }
+  });
+
+  it('live-worker mismatch → closes gracefully WITHOUT pre-killing the backing pane', async () => {
+    // With a live worker, closeSession's close IPC lets the worker tear down
+    // its own backing session; a daemon-side hard kill first would race the
+    // worker's exit handling. Pre-kill is reserved for worker-less records.
+    const s = makeActivePersistentSession('om_rt_live');
+    s.cliId = 'codex';
+    sessionStore.updateSession(s);
+    const ds = registerDs(s);
+    (ds as any).worker = { killed: false };
+    vi.mocked(TmuxBackend.killSession).mockClear();
+
+    expect(await closeCliMismatchedSessionsForBot('app_test')).toBe(1);
+    expect(closeSession).toHaveBeenCalledWith(s.sessionId);
+    expect(TmuxBackend.killSession).not.toHaveBeenCalled();
   });
 
   it('returns 0 when the registry is not initialized', async () => {


### PR DESCRIPTION
## 背景

#346 修复了「切换 CLI 后还唤起历史 CLI」，但只覆盖 daemon **重启**路径（restoreActiveSessions 守卫）。dashboard 的 `PUT /api/bot-agent` 热改 cliId/wrapperCli **不重启 daemon**，存量会话冻结的旧 CLI 仍会被下一条消息（或 terminal 唤醒）lazy resume 复活，要等下次重启才被清理——review #346 时确认的 follow-up ①。

## 改动

- `session-manager` 导出 `closeCliMismatchedSessionsForBot(larkAppId)`：按 bot 扫活跃会话 registry，复用 #346 的同一失配判定（含 wrapper 轴），失配即关闭并连带杀 backing pane
- 豁免口径与 restore 完全一致：queued（待办池，从没起过 CLI）与 adopt（接管外部用户 CLI，cliId 不同属合法）不动；只处理本 bot（larkAppId 过滤）
- restore 私有 helper 更名 `closeActiveSessionIfCliMismatch`（不再限 restore 语境），日志措辞中性化
- `PUT /api/bot-agent` 改完配置后调用清理，响应新增 `closedMismatchedSessions` 计数供 dashboard 展示/审计

## 测试

- restore-zombie-close.test.ts 新增 runtime sweep describe ×4：失配关闭（cliId 轴 + wrapper 轴）、queued/adopt/跨 bot 豁免、registry 未初始化兜底；全文件 15/15 绿
- dashboard-ipc.test.ts（含 PUT /api/bot-agent 用例）51/51 绿；tsc 构建通过