### PR TITLE
fix(lark): bots list 不再被 is_in_chat 探测的 AxiosError dump 污染

### DIFF
--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -1,8 +1,8 @@
 import { readFileSync, writeFileSync, createWriteStream, mkdirSync, existsSync } from 'node:fs';
 import { dirname, extname, basename, join } from 'node:path';
 import { pipeline } from 'node:stream/promises';
-import { Client, LoggerLevel } from '@larksuiteoapi/node-sdk';
-import { getBotClient, getAllBots, getBot } from '../../bot-registry.js';
+import { Client } from '@larksuiteoapi/node-sdk';
+import { getBotClient, getAllBots, getBot, formatLarkError } from '../../bot-registry.js';
 import { loadBotConfigs } from '../../bot-registry.js';
 import { config } from '../../config.js';
 import { emitHookEvent } from '../../services/hook-runner.js';
@@ -35,14 +35,34 @@ export async function larkGet(c: any, url: string, params: LarkRequestParams = {
   return c.request({ method: 'GET', url, params });
 }
 
-// Cached lightweight Lark clients for all configured bots (for isInChat checks)
+// Cached lightweight Lark clients for all configured bots (for isInChat checks).
+//
+// These clients exist solely for the is_in_chat probe below, where failures are
+// EXPECTED for configured bots that can't be checked against this chat
+// (other-tenant bot → 232010, app missing im:chat scopes → 99991672). The SDK's
+// generic request() dumps the full AxiosError through its logger before
+// rethrowing, so with the default console logger every probe miss splashed a
+// ~100-line stack/config blob into `botmux bots list` stdout / daemon logs.
+// Silencing via loggerLevel is impossible — the SDK's LoggerProxy does
+// `params.loggerLevel || LoggerLevel.info` and `LoggerLevel.fatal` is 0/falsy —
+// so route the SDK's own logging to a condensed debug line instead. The probe's
+// catch below stays the primary reporter (also one debug line per miss).
+const fmtProbe = (msg: any[]) => msg.map((m) => formatLarkError(m) ?? (typeof m === 'string' ? m : String(m))).join(' ');
+const probeLarkLogger = {
+  fatal: (...msg: any[]) => logger.debug(`[lark:isInChat] ${fmtProbe(msg)}`),
+  error: (...msg: any[]) => logger.debug(`[lark:isInChat] ${fmtProbe(msg)}`),
+  warn:  (...msg: any[]) => logger.debug(`[lark:isInChat] ${fmtProbe(msg)}`),
+  info:  (..._msg: any[]) => { /* 'client ready' × every configured bot — noise */ },
+  debug: (..._msg: any[]) => { /* dropped */ },
+  trace: (..._msg: any[]) => { /* dropped */ },
+};
 let allBotClients: Array<{ appId: string; cliId: string; client: InstanceType<typeof Client> }> | null = null;
 function getAllBotClients() {
   if (!allBotClients) {
     allBotClients = loadBotConfigs().map((cfg) => ({
       appId: cfg.larkAppId,
       cliId: cfg.cliId,
-      client: new Client({ appId: cfg.larkAppId, appSecret: cfg.larkAppSecret, domain: sdkDomain(normalizeBrand(cfg.brand)), loggerLevel: LoggerLevel.error }),
+      client: new Client({ appId: cfg.larkAppId, appSecret: cfg.larkAppSecret, domain: sdkDomain(normalizeBrand(cfg.brand)), logger: probeLarkLogger }),
     }));
   }
   return allBotClients;
@@ -1365,7 +1385,7 @@ export async function listChatBotMembers(larkAppId: string, chatId: string): Pro
           };
         }
       } catch (err) {
-        logger.debug(`isInChat check failed for ${appId}: ${err}`);
+        logger.debug(`isInChat check failed for ${appId}: ${formatLarkError(err) ?? err}`);
       }
       return null;
     }),


### PR DESCRIPTION
## 现象

`botmux bots list` 每次运行,stdout 里 JSON 花名册前会混入 **6 段 ~100 行的 AxiosError dump**(`[error]: [ AxiosError: Request failed with status code 400 ... ]`),污染 skill 输出、浪费读取方 token。

## 根因(与此前群里的初步诊断不同)

实测直接裸 token 调 `GET /open-apis/im/v1/chats/{chat_id}/members/is_in_chat`,**同租户 bot 全部 200 正常返回布尔值**——该接口按调用方 token 隐式判身份,**不需要也不接受 `member_id_type`/`member_id` 参数**,「空参导致 400」的推断不成立。

真实的 400 全部是**预期内失败**,来自本机 bots.json 里配置的、无法对当前群做此检查的 bot:
- `232010` Operator and chat can NOT be in different tenants —— 跨租户 test bot ×5
- `99991672` 缺 `im:chat` 系 scope 的 app ×1

call site 对这些失败本来就正确降级为「不在群/由 introduce/observed/cross-ref 合并兜底」,**花名册结果一直是对的**,坏的只是日志面。

噪声源:SDK 的 generic `client.request()` 在 rethrow 前会 `this.logger.error(e)` 把原始 AxiosError 整个 dump 出来,而 `getAllBotClients()` 的 probe client 用的是 SDK 默认 console logger。

## 为什么不能用 loggerLevel 静音

SDK `LoggerProxy` 构造是 `params.loggerLevel || LoggerLevel.info`,而 **`LoggerLevel.fatal = 0` 是 falsy** —— 传 fatal 会静默回退到 info,反而额外打出每 bot 一条 `[info]: client ready`(实测踩到)。

## 修法

沿用 `bot-registry.ts` 里 `larkLogger` 的既有思路(SDK 错误压缩成一行 triage),给 probe client 传专用 logger:

- `error/warn` → `formatLarkError` 压缩成一行进 `logger.debug`(probe 失败是预期事件,不该进 warn/error 日志)
- `info/trace` 丢弃(`client ready` × 每个 configured bot 纯噪声)
- probe 的 catch 升级为带飞书 `code/msg` 的一行:`isInChat check failed for cli_xxx: GET im/v1/chats/.../members/is_in_chat → 400 code=232010 "Operator and chat can NOT be in different tenants."`

## 验证

- 修复前:stdout 6 段 AxiosError blob + JSON;修复后:stdout **纯 JSON**(python json.load 通过),stderr 0 字节
- `DEBUG=1` 时每个 miss 在 stderr 一行 triage(飞书 code/msg 齐全),stdout 仍纯 JSON
- 花名册内容不变:7 bot,与群内实际一致
- `pnpm test`:8 failed 全部为既有环境基线(terminal-url ×7 / recall-frozen ×1),无新增失败

## 未动的同类点(留意)

`utils/lark-upload.ts:18` 的 upload client 也是独立 client + `LoggerLevel.error`,上传失败同样会 dump;但上传失败非预期事件、路径不同,不在本 PR 范围。