### PR TITLE
fix(codex): 修复冷启动首条消息误判裸壳

### DIFF
--- a/src/adapters/cli/codex.ts
+++ b/src/adapters/cli/codex.ts
@@ -327,6 +327,10 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
     // but reject numbered menu choices. This remains necessary for wrappers
     // such as Aiden that cannot forward the startup-update config override.
     readyPattern: /›(?!\s*\d+\.)|\d+% left/,
+    // Codex cold starts can exceed the worker's 15s soft first-prompt timeout.
+    // Wait for the real composer marker so the bare-shell guard does not treat
+    // a still-loading zsh wrapper as a failed launch.
+    deferFirstPromptTimeoutUntilReady: true,
     defaultPassthroughCommands: ['/goal'],
     buildSessionRenameCommand: (title) => `/rename ${title}`,
     systemHints: BOTMUX_SHELL_HINTS,

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -1266,6 +1266,14 @@ describe('readyPattern', () => {
     expect(adapter.readyPattern!.test('\n  › 2. Skip')).toBe(false);
   });
 
+  it('codex defers the first-prompt timeout until its readyPattern appears', () => {
+    // Codex can cold-start slower than the worker's 15s soft timeout; keep the
+    // first Lark message queued until the composer is visible.
+    const adapter = createCodexAdapter('/bin/codex');
+    expect(adapter.deferFirstPromptTimeoutUntilReady).toBe(true);
+    expect(adapter.supportsTypeAhead).toBe(true);
+  });
+
   it('traex matches prompt and context indicators', () => {
     const adapter = createTraexAdapter('/bin/traex');
     expect(adapter.readyPattern).toBeDefined();


### PR DESCRIPTION
## 改了什么

给 Codex 适配器补上一个**已有的**启动门控开关，让冷启动的首条消息别被误判丢弃：

```ts
// src/adapters/cli/codex.ts
readyPattern: /›(?!\s*\d+\.)|\d+% left/,   // 主干既有：composer 标记，排除更新菜单项
deferFirstPromptTimeoutUntilReady: true,   // 本 PR 新增：首条消息等到 composer 真出现再 flush
```

外加一条回归单测（`test/cli-adapters.test.ts`），钉住 `deferFirstPromptTimeoutUntilReady` 与 `supportsTypeAhead` 皆为 true，防止以后被回退。

净改动 **2 文件 / +12 行**。

## 为什么（Root Cause）

Codex 冷启动较慢，可能超过 worker 的 **15s 首条消息软超时**。软超时一到，botmux 就把第一条 Lark 消息 flush 进 PTY；而 flush 前的**裸壳保护**会看 pane 里当前跑的是什么进程——此时 zsh wrapper 还没 `exec` 进 Codex composer，保护看到的是个光 shell，于是误判「Codex 没起来」，把首条消息拦下并弹出「会话没能启动」的诊断。

`deferFirstPromptTimeoutUntilReady` 打开后，worker 的 `shouldReleaseFirstPromptTimeout()`（`src/utils/input-gate.ts`）不再在软超时时放消息，而是 hold 到 `readyPattern`（`›` composer 或 `X% left` 状态栏）真的出现——证明 composer 已就绪——才 flush。若 ready marker 始终不出现，还有 `FIRST_PROMPT_HARD_TIMEOUT_MS`（90s）硬上限兜底，不会死锁。

这不是新机制：**grok / hermes / traex 三个适配器早已在用**这个开关，本 PR 只是把 Codex 补齐——此前 Codex 是唯一慢冷启动却没 opt-in 的适配器。

## 影响面

- 仅影响 **Codex 冷启动首条输入的门控时序**；15s 软超时只被 Codex 这一个 adapter opt-in 改变，worker 默认值与其它 20+ CLI 不受影响。
- 生效前提已满足：Codex 有可用 `readyPattern`（IdleDetector 匹配后走 `markPromptReady()` 立即 flush，不会白等 90s）+ `supportsTypeAhead: true`。
- adopt / reattach 路径会各自清掉或 seed `awaitingFirstPrompt`，无 90s 回归；更新弹窗在进 IdleDetector 前另有专门 guard，加上 `readyPattern` 的负向前瞻，双层保护均在。
- **不涉及隧道控制协议**，无需同步 platform 仓。

## Rebase 说明

原分支基于 3 周前基线、落后主干约 527 commits（`CONFLICTING / DIRTY`）。已 rebase 到最新 master（`0 behind / 1 ahead`）。唯一冲突在 `readyPattern` 那一 hunk——主干在本 PR 之后修过一个误匹配（Codex 更新弹窗渲染的 `› 1. Update now` 会被裸 `/›/` 当成 composer）。冲突解法：**保留主干修过误匹配的新版 `readyPattern`（含负向前瞻），再叠加本 PR 的 defer 开关**。测试文件自动合并干净，主干的更新菜单反例（`› 1. Update now` / `› 2. Skip` → false）与本 PR 的 flag 断言并存。

## 实际验证（rebased head `f2d32f1b`）

- `pnpm build` ✅ 通过（含公开域名审计 + dist 审计）
- `pnpm test cli-adapters input-gate` ✅ **326 passed**
- `pnpm test idle-detector`（+ Codex 更新弹窗回归）✅ 通过
- 独立复核（@codex）：`cli-adapters + input-gate` 326 passed、`idle-detector + codex-update-dialog` 50 passed、build 通过，结论 **LGTM 无阻塞**
- GitHub：`MERGEABLE`，CI build + CodeQL 全绿（`BLOCKED` 仅为 draft / review-required，非冲突）
