### PR TITLE
[codex] fix dashboard oversized usage transcript scans

### DIFF
--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -301,10 +301,14 @@ const USAGE_FILE_CACHE_MAX_ENTRIES = 512;
 /** While a transcript keeps changing, serve the cached value and reparse at
  *  most once per interval — keeps row composition off the disk. */
 const USAGE_REPARSE_MIN_INTERVAL_MS = 15_000;
+/** Token usage is advisory. Never let dashboard row rendering synchronously
+ *  scan pathological multi-GB transcripts. */
+export const MAX_USAGE_TRANSCRIPT_BYTES = 64 * 1024 * 1024;
 
 /** Aiden checkpoint paths move as the session progresses (latest.json points
  *  at a new checkpoint id per turn), so positive hits expire quickly too. */
 const AIDEN_PATH_HIT_TTL_MS = 15_000;
+const warnedOversizedUsageFiles = new Set<string>();
 
 export function __resetSessionUsageCachesForTest(): void {
   usageFileCache.clear();
@@ -364,6 +368,19 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, op
     if (unchanged || throttled) {
       return { agg: cached.previewAgg, result: cached.result };
     }
+  }
+
+  if (st.size > MAX_USAGE_TRANSCRIPT_BYTES) {
+    const warnKey = `${key}:${st.size}`;
+    if (!warnedOversizedUsageFiles.has(warnKey)) {
+      warnedOversizedUsageFiles.add(warnKey);
+      logger.warn(
+        `Skipping token usage scan for oversized transcript ${path} ` +
+        `(${st.size} bytes > ${MAX_USAGE_TRANSCRIPT_BYTES} bytes)`,
+      );
+    }
+    if (cached) return { agg: cached.previewAgg, result: cached.result };
+    return { agg: newTokenUsageAggregate(), result: null };
   }
 
   if (usageFileCache.size >= USAGE_FILE_CACHE_MAX_ENTRIES && !usageFileCache.has(key)) {

--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -312,6 +312,7 @@ const warnedOversizedUsageFiles = new Set<string>();
 
 export function __resetSessionUsageCachesForTest(): void {
   usageFileCache.clear();
+  warnedOversizedUsageFiles.clear();
   __resetTranscriptResolverCacheForTest();
 }
 
@@ -371,9 +372,10 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, op
   }
 
   if (st.size > MAX_USAGE_TRANSCRIPT_BYTES) {
-    const warnKey = `${key}:${st.size}`;
-    if (!warnedOversizedUsageFiles.has(warnKey)) {
-      warnedOversizedUsageFiles.add(warnKey);
+    // Warn once per transcript, not per observed size: an actively-growing
+    // oversized file would otherwise re-warn and leak a Set entry every reparse.
+    if (!warnedOversizedUsageFiles.has(key)) {
+      warnedOversizedUsageFiles.add(key);
       logger.warn(
         `Skipping token usage scan for oversized transcript ${path} ` +
         `(${st.size} bytes > ${MAX_USAGE_TRANSCRIPT_BYTES} bytes)`,

--- a/test/cost-calculator-cache.test.ts
+++ b/test/cost-calculator-cache.test.ts
@@ -15,7 +15,7 @@ vi.mock('node:fs', async (importOriginal) => {
   };
 });
 
-import { mkdtempSync, writeFileSync, appendFileSync, rmSync, readFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, appendFileSync, rmSync, readFileSync, truncateSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -24,9 +24,11 @@ vi.mock('../src/utils/logger.js', () => ({
 }));
 
 import {
+  MAX_USAGE_TRANSCRIPT_BYTES,
   readSessionTokenUsageFile,
   __resetSessionUsageCachesForTest,
 } from '../src/core/cost-calculator.js';
+import { logger } from '../src/utils/logger.js';
 
 function claudeLine(id: string | null, input: number, output: number): string {
   return JSON.stringify({
@@ -55,6 +57,7 @@ beforeEach(() => {
   now = 1_000_000_000;
   vi.spyOn(Date, 'now').mockImplementation(() => now);
   vi.mocked(readFileSync).mockClear();
+  vi.mocked(logger.warn).mockClear();
 });
 
 afterEach(() => {
@@ -181,6 +184,28 @@ describe('readSessionTokenUsageFile caching', () => {
     appendFileSync(p, `${codexCountLine(150, 30)}\n`);
     // Latest cumulative snapshot wins — not 100+150.
     expect(readSessionTokenUsageFile(p, 'codex')).toMatchObject({ in: 150, out: 30 });
+  });
+
+  it('skips oversized transcripts instead of scanning them from byte zero', () => {
+    const p = join(dir, 'oversized.jsonl');
+    writeFileSync(p, '');
+    truncateSync(p, MAX_USAGE_TRANSCRIPT_BYTES + 1);
+
+    expect(readSessionTokenUsageFile(p, 'coco')).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Skipping token usage scan for oversized transcript'));
+  });
+
+  it('keeps the cached usage if a transcript grows past the scan cap', () => {
+    const p = join(dir, 'grows-too-large.jsonl');
+    writeFileSync(p, `${claudeLine('msg_a', 100, 10)}\n`);
+    const first = readSessionTokenUsageFile(p, 'claude');
+    expect(first).toMatchObject({ turns: 1, inputTokens: 100 });
+
+    now += 20_000;
+    truncateSync(p, MAX_USAGE_TRANSCRIPT_BYTES + 1);
+
+    expect(readSessionTokenUsageFile(p, 'claude', { fresh: true })).toBe(first);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Skipping token usage scan for oversized transcript'));
   });
 
   it('returns null and drops the cache entry when the file disappears', () => {

--- a/test/cost-calculator-cache.test.ts
+++ b/test/cost-calculator-cache.test.ts
@@ -208,6 +208,19 @@ describe('readSessionTokenUsageFile caching', () => {
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Skipping token usage scan for oversized transcript'));
   });
 
+  it('warns once per oversized transcript even as it keeps growing', () => {
+    const p = join(dir, 'still-growing.jsonl');
+    writeFileSync(p, '');
+    truncateSync(p, MAX_USAGE_TRANSCRIPT_BYTES + 1);
+    expect(readSessionTokenUsageFile(p, 'coco')).toBeNull();
+
+    now += 20_000;
+    truncateSync(p, MAX_USAGE_TRANSCRIPT_BYTES + 4096);
+    expect(readSessionTokenUsageFile(p, 'coco', { fresh: true })).toBeNull();
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
   it('returns null and drops the cache entry when the file disappears', () => {
     const p = join(dir, 's.jsonl');
     writeFileSync(p, `${claudeLine('msg_a', 100, 10)}\n`);


### PR DESCRIPTION
## Summary
- add a 64 MiB cap before dashboard token-usage row rendering scans transcript files
- skip advisory token usage for oversized transcripts while preserving cached usage when available
- cover oversized cold reads and cached-growth behavior in cost-calculator cache tests

## Root Cause
Dashboard hydration calls `/api/sessions`, which composes rows for closed sessions and asks `cost-calculator` for native token usage. A Coco closed session had a roughly 14 GB `events.jsonl`; after the transcript reader was made chunked, it avoided whole-file allocation but could still synchronously scan from byte zero on the daemon main thread. That blocked Coco's IPC server long enough for dashboard hydration to time out, so the dashboard only showed the healthy Codex daemon.

## Validation
- `corepack pnpm vitest run test/cost-calculator-cache.test.ts`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`
- source-level smoke against the real 14 GB Coco transcript returned `null` in ~0.7s with the oversized-scan warning instead of scanning the file