### PR TITLE
fix(sandbox): codex 沙盒下保留整个 ~/.codex 为真实路径，修复 SQLite 锁超时起不来

### DIFF
--- a/src/adapters/cli/codex-app.ts
+++ b/src/adapters/cli/codex-app.ts
@@ -27,7 +27,9 @@ export function createCodexAppAdapter(pathOverride?: string): CliAdapter {
   let cachedCodexBin: string | undefined;
   return {
     id: 'codex-app',
-    authPaths: ['~/.codex/auth.json'],
+    // Whole ~/.codex kept REAL (see codex.ts): its SQLite state/log DBs can't get
+    // fcntl locks on the sandbox home overlay, so codex hangs ~57s then exits 1.
+    authPaths: ['~/.codex'],
     resolvedBin: process.execPath,
 
     // resolvedBin is node-running-the-runner; the REAL codex is spawned later for

--- a/src/adapters/cli/codex.ts
+++ b/src/adapters/cli/codex.ts
@@ -125,7 +125,13 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
   let cachedBin: string | undefined;
   return {
     id: 'codex',
-    authPaths: ['~/.codex/auth.json'],
+    // Whole ~/.codex kept REAL, not just auth.json: codex opens SQLite state/log
+    // DBs there (state_*.sqlite / logs_*.sqlite). Under the file sandbox the home
+    // is an overlayfs merge, and overlayfs (kernel + fuse) doesn't support the
+    // POSIX fcntl locks SQLite needs — the connection pool blocks ~57s then codex
+    // exits 1 ("pool timed out"). Binding the dir real gives working locks and
+    // keeps login/history persistent (same rationale as auth.json).
+    authPaths: ['~/.codex'],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, resumeSessionId, workingDir, model, disableCliBypass }) {

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -308,9 +308,12 @@ describe('codex buildArgs', () => {
     expect(args.join('\n')).not.toContain('BOTMUX_TURN_ID');
   });
 
-  it('keeps Codex home untouched', () => {
+  it('keeps the whole ~/.codex real in the sandbox (SQLite needs fcntl locks the home overlay lacks)', () => {
     expect(adapter.buildSpawnEnv).toBeUndefined();
-    expect(adapter.authPaths).toEqual(['~/.codex/auth.json']);
+    // Not just auth.json: codex's state_*.sqlite / logs_*.sqlite live under
+    // ~/.codex and time out (~57s → exit 1) if the dir is on the overlayfs home,
+    // which doesn't support POSIX byte-range locks. Bind the whole dir real.
+    expect(adapter.authPaths).toEqual(['~/.codex']);
     // skillsDir resolves under CODEX_HOME (default ~/.codex) so it tracks where
     // Codex actually scans skills when CODEX_HOME is overridden.
     expect(adapter.skillsDir).toBe(join(codexHome(), 'skills'));


### PR DESCRIPTION
## 背景 / 现象

开了 `sandbox: true` 的 codex bot 无法启动：spawn 后约 1 分钟 codex 进程退出 code 1，daemon 侧表现为 pane 消失、`consecutive restart x2 — 2nd failed resume attempt`、疑似卡在输入框。实际是 codex 自身启动报错：

```
ERROR: failed to initialize sqlite local db at /root/.codex/state_5.sqlite ...
failed to open log DB at /root/.codex/logs_2.sqlite:
pool timed out while waiting for an open connection
```

## 根因

codex 在 `~/.codex` 下打开 SQLite 状态/日志库（`state_*.sqlite` / `logs_*.sqlite`）。文件沙盒把 home 以 overlayfs 合并挂载（lower=真实 home，写入隔离到 upper）。overlayfs（内核与 fuse-overlayfs 均是）**不支持 SQLite 需要的 POSIX fcntl 字节范围锁**，codex 连接池拿不到锁、阻塞约 57s 后超时退出 code 1。

- 与 tmux 后端无关：在纯 PTY 里（不经 tmux）用真实 bwrap 参数复现，同样 ~57s 必崩。
- 所有 codex + sandbox 组合通用，非单个 bot。

## 改动

把 `codex` 与 `codex-app` 适配器的 `authPaths` 从 `['~/.codex/auth.json']` 扩到整个 `['~/.codex']`。authReal 是真实可写 `--bind`，整目录绕开 overlay 后 SQLite 锁正常工作；登录态/会话历史也照旧持久（与 auth.json 同理）。

**代价**：codex 自身的 state / 会话记录落到真实 `~/.codex`、不随沙盒隔离（与 auth 一样）。**项目代码的写入隔离（`/land` 审阅）不受影响**。

## 验证

- 以 prepareSandbox 生成真实 bwrap argv + `node-pty` 拉起真 codex TUI 复现：旧值 `['~/.codex/auth.json']` → ~57s 必现 `pool timed out` 崩溃；新值 `['~/.codex']` → 稳跑 90s+ 无 SQLite 报错，bwrap 参数含 `--bind /root/.codex /root/.codex`。
- 更新适配器 `authPaths` 单测断言（含 why 注释）：`pnpm vitest run test/cli-adapters.test.ts test/relay-adapter.test.ts` 256 通过。
- `pnpm build` 绿。

## 影响范围

仅改 codex/codex-app 适配器的 sandbox 真实路径集合。未开沙盒、非 codex bot 均不受影响。