### PR TITLE
fix(usage): traex 走 codex 方言捕获 model；coco 补写 cliSessionId/ownership 标记

### DIFF
--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -127,6 +127,12 @@ function usageKindForCli(cliId: SessionTokenUsageQuery['cliId']): UsageKind {
     case 'relay':
       return 'claude';
     case 'codex':
+    // TRAE rollouts are byte-identical to Codex (see traex-transcript.ts):
+    // token_count events carry the cumulative totals, and the active model
+    // rides on turn_context/session_meta payloads. The generic fold picked up
+    // the tokens but never the model, so traex ledger records shipped with
+    // model "" (consumers like kaboo fall back to "unknown").
+    case 'traex':
       return 'codex';
     case 'coco':
       return 'coco';

--- a/src/services/usage-ledger.ts
+++ b/src/services/usage-ledger.ts
@@ -379,6 +379,18 @@ interface DaemonSessionLedgerOpts {
   ledgerDir?: string;
 }
 
+/** The CLI-native session id a ledger record should carry. coco is spawned
+ *  with `--session-id <botmux sessionId>` and the worker never sets a separate
+ *  cliSessionId (there is nothing to adopt) — but the botmux session id IS
+ *  coco's on-disk session identity (~/.cache/coco/sessions/<sessionId>/), and
+ *  ledger consumers (kaboo) key their native-parser exclusions on
+ *  cliSessionId. Defaulting it closes the gap: coco sessions get ownership
+ *  markers and self-describing usage records like every other CLI. */
+function ledgerCliSessionId(s: { cliId?: string; sessionId: string; cliSessionId?: string }): string | undefined {
+  if (s.cliSessionId) return s.cliSessionId;
+  return s.cliId === 'coco' ? s.sessionId : undefined;
+}
+
 function ledgerArgsForDaemonSession(ds: DaemonSession): Omit<RecordSessionUsageArgs, 'usage'> & { usage: SessionTokenUsage | null } {
   const s = ds.session;
   const workingDir = ds.workingDir ?? s.workingDir;
@@ -396,7 +408,7 @@ function ledgerArgsForDaemonSession(ds: DaemonSession): Omit<RecordSessionUsageA
     usage,
     larkAppId: ds.larkAppId ?? s.larkAppId,
     cliId: s.cliId,
-    cliSessionId: s.cliSessionId,
+    cliSessionId: ledgerCliSessionId(s),
     chatId: s.chatId,
     title: s.title,
     workingDir,
@@ -490,7 +502,7 @@ export function recordOwnershipForDaemonSession(ds: DaemonSession, opts?: Daemon
     const s = ds.session;
     return recordSessionOwnership({
       sessionId: s.sessionId,
-      cliSessionId: s.cliSessionId,
+      cliSessionId: ledgerCliSessionId(s),
       larkAppId: ds.larkAppId ?? s.larkAppId,
       cliId: s.cliId,
       chatId: s.chatId,

--- a/test/cost-calculator.test.ts
+++ b/test/cost-calculator.test.ts
@@ -39,6 +39,10 @@ vi.mock('../src/services/codex-transcript.js', () => ({
   findCodexSessionIdByBotmuxSessionId: vi.fn(() => undefined),
 }));
 
+vi.mock('../src/services/traex-transcript.js', () => ({
+  findTraexRolloutBySessionId: vi.fn(() => undefined),
+}));
+
 vi.mock('../src/services/aiden-checkpoints.js', () => ({
   findAidenLatestCheckpointBySessionId: vi.fn(() => undefined),
   findAidenLatestCheckpointByBotmuxSessionId: vi.fn(() => undefined),
@@ -73,6 +77,7 @@ vi.mock('../src/adapters/cli/registry.js', () => ({
 import { existsSync, readFileSync } from 'node:fs';
 import { findAidenLatestCheckpointByBotmuxSessionId, findAidenLatestCheckpointBySessionId } from '../src/services/aiden-checkpoints.js';
 import { findCodexRolloutBySessionId, findCodexSessionIdByBotmuxSessionId } from '../src/services/codex-transcript.js';
+import { findTraexRolloutBySessionId } from '../src/services/traex-transcript.js';
 import {
   getSessionJsonlPath,
   getSessionCost,
@@ -121,6 +126,8 @@ beforeEach(() => {
   vi.mocked(findCodexRolloutBySessionId).mockReturnValue(undefined);
   vi.mocked(findCodexSessionIdByBotmuxSessionId).mockReset();
   vi.mocked(findCodexSessionIdByBotmuxSessionId).mockReturnValue(undefined);
+  vi.mocked(findTraexRolloutBySessionId).mockReset();
+  vi.mocked(findTraexRolloutBySessionId).mockReturnValue(undefined);
   vi.mocked(findAidenLatestCheckpointBySessionId).mockReset();
   vi.mocked(findAidenLatestCheckpointBySessionId).mockReturnValue(undefined);
   vi.mocked(findAidenLatestCheckpointByBotmuxSessionId).mockReset();
@@ -491,6 +498,48 @@ describe('getSessionTokenUsage', () => {
     });
     expect(findCodexSessionIdByBotmuxSessionId).toHaveBeenCalledWith('botmux-sid');
     expect(findCodexRolloutBySessionId).toHaveBeenCalledWith('codex-sid');
+  });
+
+  it('reports TraeX rollouts via the codex fold, capturing the turn_context model', () => {
+    vi.mocked(findTraexRolloutBySessionId).mockReturnValue('/home/testuser/.trae/cli/sessions/2026/06/30/rollout-traex-sid.jsonl');
+    // Real TRAE rollout shapes: codex-format turn_context carries the model;
+    // token_count carries cumulative totals. Under the old 'generic' fold the
+    // model was never read and records shipped with model "".
+    setupJsonl([
+      JSON.stringify({
+        type: 'turn_context',
+        payload: { turn_id: 't-1', model: 'openrouter-1', model_provider: 'trae' },
+      }),
+      JSON.stringify({
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: {
+            total_token_usage: {
+              input_tokens: 52634,
+              cached_input_tokens: 0,
+              output_tokens: 307,
+            },
+          },
+        },
+      }),
+    ].join('\n'));
+
+    expect(getSessionTokenUsage({
+      cliId: 'traex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'traex-sid',
+    })).toEqual({
+      in: 52634,
+      out: 307,
+      inputTokens: 52634,
+      outputTokens: 307,
+      cacheReadTokens: 0,
+      cacheCreateTokens: 0,
+      turns: 0,
+      model: 'openrouter-1',
+    });
+    expect(findTraexRolloutBySessionId).toHaveBeenCalledWith('traex-sid');
   });
 
   it('reports CoCo nested response_meta usage without counting agent_end duplicates', () => {

--- a/test/usage-ledger.test.ts
+++ b/test/usage-ledger.test.ts
@@ -469,4 +469,31 @@ describe('ownership records', () => {
     const rec = recordOwnershipForDaemonSession(ds, { ledgerDir: dir });
     expect(rec).toMatchObject({ kind: 'ownership', cliSessionId: 'cli-sess-own' });
   });
+
+  it('recordOwnershipForDaemonSession defaults coco cliSessionId to the botmux sessionId', () => {
+    vi.mocked(getSessionTokenUsage).mockReturnValue(null);
+    // botmux spawns coco with `--session-id <botmux sessionId>` and never sets
+    // a separate cliSessionId — without the default no coco ownership marker
+    // was ever written (recordSessionOwnership bails on empty cliSessionId),
+    // so consumers could not exclude the on-disk coco session before its
+    // first usage delta landed.
+    const ds = {
+      larkAppId: 'cli_app',
+      workingDir: '/live-repo',
+      session: {
+        sessionId: 'aee4d7b5-966f-4c04-87fa-9d08aca80a92',
+        cliId: 'coco',
+        chatId: 'oc_chat',
+        title: 'coco 会话',
+      },
+    } as any;
+
+    const rec = recordOwnershipForDaemonSession(ds, { ledgerDir: dir });
+    expect(rec).toMatchObject({
+      kind: 'ownership',
+      cliId: 'coco',
+      sessionId: 'aee4d7b5-966f-4c04-87fa-9d08aca80a92',
+      cliSessionId: 'aee4d7b5-966f-4c04-87fa-9d08aca80a92',
+    });
+  });
 });


### PR DESCRIPTION
usage ledger 对 trae 系工具的两处补齐，配合 kaboo 侧 trae-cli/traex ledger 导入上线。

## 改动

**1. traex usage kind: generic → codex**（`src/core/cost-calculator.ts`）

traex rollout 与 codex 格式完全一致（`traex-transcript.ts` 本来就直接 re-export codex 的 reader），但 `usageKindForCli` 一直让它走 generic fold：token_count 的 token 能取到，`turn_context.payload.model` 取不到 —— ledger 里的 traex 记录 model 长期为空串（本机真实 ledger 27 条 traex usage 记录全部 model=""）。改为复用 codex fold 后新记录带上真实 model（如 `openrouter-1`）。

**2. coco 记录补写 cliSessionId，ownership 标记落地**（`src/services/usage-ledger.ts`）

coco 由 botmux 以 `--session-id <botmux sessionId>` 拉起，worker 从不设 cliSessionId，导致：
- `recordSessionOwnership` 对空 cliSessionId 直接 bail —— coco 会话从来没有 ownership 标记（本机 ledger：coco usage 32 条 / ownership 0 条），消费方在首个 usage delta 落盘前有一个小的双计窗口；
- usage 记录不带 cliSessionId，消费方只能靠 sessionId 回退猜磁盘会话身份。

ledger 侧新增 `ledgerCliSessionId()`：coco 默认回填 cliSessionId = sessionId（即 `~/.cache/coco/sessions/<sessionId>/` 的目录名），ownership / usage 记录与其他 CLI 对齐。只动 ledger 包装层，不碰 worker 的 cliSessionId 语义。

## 测试

- `cost-calculator` / `usage-ledger` / `cost-calculator-cache` 74 用例全绿（含 2 个新用例：traex model 捕获、coco ownership 默认 cliSessionId）
- `tsc --noEmit` 干净
- 全量 unit 中 workflow-cli / terminal-url 的 30 个失败在干净 master 基线上复现（环境依赖），与本改动无关

## 兼容性

kaboo 侧对两种记录形态都兼容：coco 排除键有 sessionId 回退，traex 空 model 回退 "unknown"。本 PR 合入后新 ledger 记录质量更高，旧记录不受影响。