### PR TITLE
fix(sandbox): opencode/mtr/traex/coco 沙盒下保留整个状态目录为真实路径

### DIFF
--- a/src/adapters/cli/coco.ts
+++ b/src/adapters/cli/coco.ts
@@ -119,11 +119,12 @@ export function createCocoAdapter(pathOverride?: string): CliAdapter {
   let cachedBin: string | undefined;
   return {
     id: 'coco',
-    // Whole ~/.trae/cli kept REAL (shared with traex): sessions/events.jsonl and
-    // the codex-style SQLite DBs live here, and the daemon's transcript bridge
-    // reads them at the REAL path — on the overlay they'd be invisible (and a
-    // first login inside the sandbox would be lost with the upper).
-    authPaths: ['~/.trae/cli'],
+    // ~/.trae/cli kept REAL (shared with traex): login + shared Trae state incl.
+    // the codex-style SQLite DBs (fcntl locks don't work on the overlay home).
+    // ~/.cache/coco kept REAL too: the transcript bridge reads events.jsonl at
+    // the REAL ~/.cache/coco/sessions/<sid>/ path (see coco-transcript.ts) — on
+    // the overlay the CLI's writes would be invisible to the daemon.
+    authPaths: ['~/.trae/cli', '~/.cache/coco'],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, model, disableCliBypass }) {

--- a/src/adapters/cli/coco.ts
+++ b/src/adapters/cli/coco.ts
@@ -119,7 +119,11 @@ export function createCocoAdapter(pathOverride?: string): CliAdapter {
   let cachedBin: string | undefined;
   return {
     id: 'coco',
-    authPaths: ['~/.trae/cli/auth.json'],
+    // Whole ~/.trae/cli kept REAL (shared with traex): sessions/events.jsonl and
+    // the codex-style SQLite DBs live here, and the daemon's transcript bridge
+    // reads them at the REAL path — on the overlay they'd be invisible (and a
+    // first login inside the sandbox would be lost with the upper).
+    authPaths: ['~/.trae/cli'],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, model, disableCliBypass }) {

--- a/src/adapters/cli/mtr.ts
+++ b/src/adapters/cli/mtr.ts
@@ -33,7 +33,10 @@ export function createMtrAdapter(pathOverride?: string): CliAdapter {
   let cachedBin: string | undefined;
   return {
     id: 'mtr',
-    authPaths: ['~/.local/share/opencode/auth.json'],
+    // Whole dir kept REAL: mtr shares opencode's data dir and keeps its own SQLite
+    // DB there (mtr.db, WAL mode) — the sandbox home overlay lacks the fcntl locks
+    // SQLite needs (same failure as codex, see codex.ts).
+    authPaths: ['~/.local/share/opencode'],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, resumeSessionId, initialPrompt }) {

--- a/src/adapters/cli/opencode.ts
+++ b/src/adapters/cli/opencode.ts
@@ -153,7 +153,10 @@ export function createOpenCodeAdapter(pathOverride?: string): CliAdapter {
   let cachedBin: string | undefined;
   return {
     id: 'opencode',
-    authPaths: ['~/.local/share/opencode/auth.json'],
+    // Whole dir kept REAL, not just auth.json: opencode keeps its global SQLite DB
+    // (opencode.db, WAL mode) here, and the sandbox home overlay lacks the POSIX
+    // fcntl locks SQLite needs (same failure as codex, see codex.ts).
+    authPaths: ['~/.local/share/opencode'],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, resumeSessionId, initialPrompt, model }) {

--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -150,7 +150,10 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
   let cachedBin: string | undefined;
   return {
     id: 'traex',
-    authPaths: ['~/.trae/cli/auth.json'],
+    // Whole ~/.trae/cli kept REAL: traex is codex-based and keeps the same SQLite
+    // state/log DBs there (state_*.sqlite / logs_*.sqlite) — the sandbox home
+    // overlay lacks the fcntl locks SQLite needs (same failure as codex.ts).
+    authPaths: ['~/.trae/cli'],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, resumeSessionId, workingDir, model, disableCliBypass }) {

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -1390,8 +1390,8 @@ describe('traex/coco sandbox authPaths', () => {
     expect(adapter.authPaths).toEqual(['~/.trae/cli']);
   });
 
-  it('coco keeps the whole ~/.trae/cli real in the sandbox (shared trae dir, bridge reads real paths)', () => {
+  it('coco keeps ~/.trae/cli (shared trae state/SQLite) AND ~/.cache/coco (transcripts the bridge reads) real', () => {
     const adapter = createCocoAdapter('/bin/coco');
-    expect(adapter.authPaths).toEqual(['~/.trae/cli']);
+    expect(adapter.authPaths).toEqual(['~/.trae/cli', '~/.cache/coco']);
   });
 });

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -649,6 +649,12 @@ describe('gemini buildArgs', () => {
 describe('opencode buildArgs', () => {
   const adapter = createOpenCodeAdapter('/usr/bin/opencode');
 
+  it('keeps the whole opencode data dir real in the sandbox (SQLite needs fcntl locks the home overlay lacks)', () => {
+    // Not just auth.json: opencode's global opencode.db (WAL) lives here and
+    // can't lock on the overlayfs home — same failure mode as codex.
+    expect(adapter.authPaths).toEqual(['~/.local/share/opencode']);
+  });
+
   it('returns empty args for basic case', () => {
     const args = adapter.buildArgs({ sessionId: 'sess-6', resume: false });
     expect(args).toEqual([]);
@@ -750,6 +756,10 @@ describe('oh-my-pi buildArgs', () => {
 
 describe('mtr buildArgs', () => {
   const adapter = createMtrAdapter('/usr/bin/mtr');
+
+  it('keeps the whole opencode data dir real in the sandbox (mtr.db needs fcntl locks the home overlay lacks)', () => {
+    expect(adapter.authPaths).toEqual(['~/.local/share/opencode']);
+  });
 
   it('fresh session passes deterministic --set-session and initial prompt', () => {
     const args = adapter.buildArgs({ sessionId: 'bm-session-1', resume: false, initialPrompt: 'hello mtr' });
@@ -1368,5 +1378,20 @@ describe('kimi buildArgs', () => {
 
   it('surfaces curated model choices for setup', () => {
     expect(adapter.modelChoices).toContain('kimi-k2.5');
+  });
+});
+
+describe('traex/coco sandbox authPaths', () => {
+  it('traex keeps the whole ~/.trae/cli real in the sandbox (codex-based, same SQLite lock hazard)', () => {
+    // traex keeps codex-style state_*.sqlite / logs_*.sqlite + rollout sessions
+    // under ~/.trae/cli; the daemon bridge reads them at the REAL path, and the
+    // overlayfs home lacks the fcntl locks SQLite needs (see codex.ts).
+    const adapter = createTraexAdapter('/bin/traex');
+    expect(adapter.authPaths).toEqual(['~/.trae/cli']);
+  });
+
+  it('coco keeps the whole ~/.trae/cli real in the sandbox (shared trae dir, bridge reads real paths)', () => {
+    const adapter = createCocoAdapter('/bin/coco');
+    expect(adapter.authPaths).toEqual(['~/.trae/cli']);
   });
 });


### PR DESCRIPTION
## 背景 / 动机

#356 修复 codex 沙盒 SQLite 锁崩溃后的同型排查（申晗指定扩容 opencode/mtr，并点名 traex 等 codex 系）。这四个 CLI 都在 $HOME 下保留 SQLite/会话状态，但 authPaths 只 carve-out 单个 auth.json：

- opencode / mtr：共享 `~/.local/share/opencode`（opencode.db / mtr.db，均 WAL 模式）
- traex / coco：共享 `~/.trae/cli`（codex 式 state_*.sqlite / logs_*.sqlite + sessions rollout + history.jsonl；实测 coco 也写 state_5.sqlite）

## 实测发现（prepareSandbox 真实 bwrap 参数 + node-pty 驱动真 CLI，含交互提交消息）

与 codex「boot 即崩」不同，四个 CLI 当前版本在沙盒里 boot 和对话都健康（模型正常回复）——但存在三个现行缺陷：

1. **transcript bridge 断链**：daemon 的 codex-bridge 系（cocoEventsPathForSession / findTraexRolloutBySessionId / findMtrSessionById）都按**真实路径**读会话文件，而窄 carve-out 下 CLI 写进 overlay upper → daemon 读不到（claude 系有 homeUpper 重定向，这些 CLI 没有）。实测：master 下沙盒内对话在真实目录零痕迹
2. **首次登录丢失**：authPaths 按「存在才 bind」处理，本机 `~/.local/share/opencode/auth.json` 不存在 → 完全没 bind → 沙盒内 /connect 登录写进 upper，随沙盒销毁丢失
3. **SQLite 锁隐患**：overlayfs 不支持 SQLite 要的 fcntl 锁已被 codex 证明致命（#356）；这四个 CLI 当前版本对锁失败容忍，是版本运气——codex 也是加了 sqlite state runtime 后才开始崩的

## 改动

四个适配器 authPaths 从单文件扩到整个状态目录（与 codex #356 同款语义）+ 对应单测断言。

## 验证

三轮对照（每 CLI 观察 120–150s）：
- master 基线 + 交互：四个全健康但会话只落 overlay upper（真实目录 grep 零命中）
- 修复 build + 交互：四个全健康，bwrap 含目录级 `--bind`；真实目录写入验证——traex 消息原文命中 history.jsonl + rollout jsonl；opencode.db / mtr.db / coco 的 state_5.sqlite-wal mtime 均落在各自测试窗口内（沙盒内 WAL 写锁正常工作）
- `pnpm vitest run test/cli-adapters.test.ts test/sandbox.test.ts test/relay-adapter.test.ts` 308 通过；`pnpm build` 绿

## 代价 / 影响范围

这些 CLI 自身的会话/状态持久化到真实目录、不随沙盒隔离（与 auth 及 codex #356 相同）；**项目代码写入隔离（/land 审阅）不受影响**。未开沙盒的 bot 无变化。当前线上无 sandbox+这四种 CLI 的 bot，属前置修复。