### PR TITLE
fix(runtime): 隔离 tmux 环境并恢复会话 owner

### DIFF
--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -3,8 +3,8 @@ import { execSync, execFileSync } from 'node:child_process';
 import { basename } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import type { SessionBackend, SpawnOpts, SessionProbe } from './types.js';
-import { probeTmuxFunctional, tmuxEnv } from '../../setup/ensure-tmux.js';
-import { REDACTED_CHILD_ENV_KEYS } from '../../utils/child-env.js';
+import { probeTmuxFunctional, scrubTmuxServerGlobalEnv, tmuxEnv } from '../../setup/ensure-tmux.js';
+import { BOTMUX_INJECTED_ENV_KEYS, REDACTED_CHILD_ENV_KEYS } from '../../utils/child-env.js';
 import { sanitizePerBotEnv } from '../../core/per-bot-env.js';
 import { logger } from '../../utils/logger.js';
 import { isExecutable } from '../../utils/executable.js';
@@ -12,13 +12,20 @@ import { isExecutable } from '../../utils/executable.js';
 /**
  * `unset KEY KEY ...` clause spliced into the shell wrapper before exec. The
  * new tmux pane inherits the tmux *server's* global environment, which the
- * (redacted) client env can't override — so if the server was ever started
- * with bare LARK_APP_* in scope (pre-upgrade botmux, or the user's own tmux),
- * those values reach the CLI despite redactChildEnv(). Unsetting them in the
- * wrapper shell removes them for this pane only, without touching the server
- * global env. Key names are fixed identifiers — no shell-escaping needed.
+ * client env can't override — so if the server was ever started with stale
+ * botmux routing/profile values or bare LARK_APP_* creds in scope, those values
+ * reach the CLI. Unsetting the complete managed allowlist in the wrapper shell
+ * removes them for this pane only before current values are re-injected. Key
+ * names are fixed identifiers — no shell-escaping needed.
  */
-const REDACTED_ENV_UNSET_CLAUSE = `unset ${REDACTED_CHILD_ENV_KEYS.join(' ')}`;
+const PANE_ENV_UNSET_KEYS = [...new Set([
+  ...REDACTED_CHILD_ENV_KEYS,
+  ...BOTMUX_INJECTED_ENV_KEYS,
+])];
+const PANE_ENV_UNSET_CLAUSE = `unset ${PANE_ENV_UNSET_KEYS.join(' ')}`;
+
+/** Guard so the fallback self-heal runs at most once in this worker process. */
+let serverGlobalEnvScrubbed = false;
 
 /**
  * TmuxBackend — session backend using tmux for process persistence.
@@ -173,6 +180,33 @@ export class TmuxBackend implements SessionBackend {
   }
 
   /**
+   * One-time self-heal: strip botmux-managed keys from the tmux SERVER's global
+   * environment. A server booted by an upgraded botmux is already clean (tmuxEnv
+   * strips the client env before `new-session`), but a server started by an
+   * OLDER botmux — or one that has outlived many daemon restarts — still carries
+   * a stale BOTMUX_SESSION_ID / BOTMUX_CHAT_ID / SESSION_DATA_DIR / … in its
+   * global env. That leaks into every co-tenant session on the socket (the
+   * user's own `tmux`), whose Claude Code then misroutes its AskUserQuestion
+   * hook to the leaked thread.
+   *
+   * Scrubbing the global table does NOT touch already-running panes' process
+   * environments — only panes created AFTER the scrub inherit the cleaned table
+   * — so this is safe to run against a live server with active sessions: no
+   * running bmx-* CLI is disturbed, and the user's next new pane comes up clean.
+   * The daemon proactively runs the same repair at startup, even when there are
+   * no active bmx-* sessions. This worker-local fallback covers standalone
+   * backend use and a transient failure during daemon startup.
+   */
+  static scrubServerGlobalEnvOnce(): void {
+    if (serverGlobalEnvScrubbed) return;
+    serverGlobalEnvScrubbed = true;
+    const result = scrubTmuxServerGlobalEnv();
+    if (result.failed.length > 0) {
+      logger.warn(`[tmux] failed to scrub server-global keys: ${result.failed.join(', ')}`);
+    }
+  }
+
+  /**
    * Create a parked diagnostic session after a CLI has exited. The worker uses
    * this only after it has already captured the failed pane's output, so the
    * browser can still attach to `bmx-*` and see the startup error while daemon
@@ -210,6 +244,9 @@ export class TmuxBackend implements SessionBackend {
   // ─── SessionBackend implementation ────────────────────────────────────────
 
   spawn(bin: string, args: string[], opts: SpawnOpts): void {
+    // Self-heal a server polluted by a pre-upgrade botmux before we touch it
+    // (once per daemon process; no-op on a server this build booted clean).
+    TmuxBackend.scrubServerGlobalEnvOnce();
     this.reattaching = TmuxBackend.hasSession(this.sessionName);
     logger.debug(
       `[tmux:${this.sessionName}] spawn ${this.reattaching ? 'reattach' : 'new'} ` +
@@ -245,14 +282,13 @@ export class TmuxBackend implements SessionBackend {
       //     bash/zsh/sh-specific (bash needs `-i` for .bashrc; zsh needs
       //     `-l -i` for .zprofile + .zshrc). fish/csh/nu are remapped to a
       //     POSIX fallback because our SCRIPT is POSIX-syntax.
-      //   - SCRIPT = `cd -- "$1" && shift && unset <creds> && exec /usr/bin/env "$@"`:
+      //   - SCRIPT = `cd -- "$1" && shift && unset <managed> && exec /usr/bin/env "$@"`:
       //       * `cd -- "$1"` returns to the session's intended cwd even if
       //         the rcfile changed directory mid-load (.zshrc/.bashrc with
       //         a `cd ~/work` left in by mistake stays in opts.cwd).
-      //       * `unset LARK_APP_ID LARK_APP_SECRET CLAUDECODE`: the new pane
-      //         inherits the tmux *server's* global env, which the redacted
-      //         client env can't override — so unset the bare creds for this
-      //         pane only (REDACTED_ENV_UNSET_CLAUSE; see redactChildEnv).
+      //       * `unset <managed>`: the new pane inherits the tmux *server's*
+      //         global env, which the client env can't override. Clear every
+      //         botmux-owned key before this pane's values are re-injected.
       //       * `exec /usr/bin/env "$@"`: env(1) parses the leading KEY=VAL
       //         pairs in argv as overrides for the child process. This lands
       //         AFTER rcfile load, so botmux's per-session values (e.g.
@@ -552,81 +588,11 @@ export class TmuxBackend implements SessionBackend {
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
- * The minimal set of env vars that botmux must inject into the CLI process
- * itself — values that user rcfiles cannot derive on their own (the namespaced
- * Lark app id for `botmux ask`, the daemon-assigned data directory, the BOTMUX
- * marker, the Claude root-mode escape hatch, the session owner's open_id).
- *
- * NOTE: the bot's bare `LARK_APP_ID` / `LARK_APP_SECRET` are deliberately NOT
- * here — the child must not see them (a CLI's own Lark OAuth would be hijacked
- * by the botmux IM app; see worker.ts redactChildEnv). The child resolves Lark
- * via the namespaced `BOTMUX_LARK_APP_ID` below or via bots.json on disk.
- *
- * Anything outside this list (PATH, HOME, NVM_BIN, PNPM_HOME, LANG, …) is
- * deliberately NOT forwarded from the daemon — the wrapping `$SHELL -l -i`
- * pass loads the user's rcfiles, and whatever they set is what the CLI sees.
- * This matches the user's mental model: "the tmux session should be like a
- * fresh terminal where the user runs the CLI manually."
- *
- * These values are injected via `/usr/bin/env KEY=VAL ... cli args` (not tmux
- * `-e`) so they land *after* rcfile load and override any leftover same-named
- * exports in the user's rcfile.
- */
-const BOTMUX_INJECTED_ENV_KEYS = [
-  '__OWNER_OPEN_ID',
-  'BOTMUX',
-  'SESSION_DATA_DIR',
-  'IS_SANDBOX',
-  // §5 of botmux ask v0.1.7: `botmux ask buttons` / `botmux hook <cli>` read
-  // these to locate the daemon, route the card back to this thread, and
-  // resolve approvers from session.owner. Without them, the hook client falls
-  // back to passthrough and the agent never reaches the Lark card.
-  'BOTMUX_SESSION_ID',
-  'BOTMUX_CHAT_ID',
-  'BOTMUX_LARK_APP_ID',
-  'BOTMUX_ROOT_MESSAGE_ID',
-  'BOTMUX_TURN_ID',
-  // Experimental Lark chat bot discovery. The daemon injects a canonical
-  // true/false value so `botmux bots list` inside long-lived panes matches the
-  // daemon's `<available_bots>` behavior instead of reading stale rcfile/tmux env.
-  'BOTMUX_LARK_LIST_BOTS_API_ENABLED',
-  'BOTMUX_LARK_LIST_BOTS_API_TIMEOUT_MS',
-  // Explicit true-ready command for CLIs (Hermes) that notify Botmux once the
-  // real TUI input composer has rendered. It must reach tmux panes via the
-  // per-pane env prefix; otherwise the ready-gate waits for fallback timeouts.
-  'BOTMUX_READY_COMMAND',
-  // Hermes transcript/profile paths. The worker resolves the bridge state DB
-  // from this same child env, so persistent panes must receive these overrides
-  // too; otherwise the reader can watch one profile while Hermes writes another.
-  // BOTMUX_HERMES_STATE_DB intentionally remains unsupported here until its
-  // ownership/configuration contract is defined.
-  'HERMES_HOME',
-  'HERMES_BOTMUX_SOURCE_HOME',
-  'HERMES_BOTMUX_PROFILES_ROOT',
-  // Claude Code 2.1.x resume-summary 菜单的抑制阈值（issue #62）。worker 为
-  // claude-code 注入一个极大值绕过菜单；只有进了这条白名单才会被透传进 tmux pane。
-  'CLAUDE_CODE_RESUME_TOKEN_THRESHOLD',
-  // Seed CLI（Claude Code fork）的数据根目录。worker 为 seed 注入它指向 seed 自己的
-  // `.claude-runtime`，bridge 才能盯对文件；不进白名单 tmux pane 就拿不到。
-  // v2 读隔离也用它把隔离 claude bot 的 config/transcript/memory 重定向进 per-bot
-  // BOT_HOME（`<BOTMUX_HOME>/bots/<appId>/claude`）——不进白名单 tmux pane 拿不到 →
-  // 隔离 bot 会掉回全局 ~/.claude（被 Seatbelt deny）而起不来。
-  'CLAUDE_CONFIG_DIR',
-  // v2 读隔离把隔离 codex bot 的 sessions/memory/state 重定向进 per-bot BOT_HOME
-  // （`<BOTMUX_HOME>/bots/<appId>/codex`）。同理必须透传进 pane。
-  'CODEX_HOME',
-  // cjadk wrapperCli（`cjadk <agent>`）启动时 worker 注入 `0`，让 cjadk 跑非交互模式
-  // （跳过启动选择器、清掉吃首条/碎裂多行的输入怪癖），对齐 cjadk 官方 `cjadk feishu`
-  // wrapper。只有 cjadk 启动会被设上此值，其它 bot 不带 → 不进白名单 tmux pane 拿不到，
-  // cjadk 就回到交互模式（本次 bug 的根因）。
-  'CJADK_INTERACTIVE',
-] as const;
-
-/**
  * Build the `KEY=VAL` argv slice passed to `/usr/bin/env`. Only forwards the
- * keys in `BOTMUX_INJECTED_ENV_KEYS` and only when the value is defined —
- * `IS_SANDBOX` for instance is only set when the daemon is running as root.
- * Pure function for unit-testing without spawning tmux.
+ * centralized BOTMUX_INJECTED_ENV_KEYS allowlist and only when the value is
+ * defined — `IS_SANDBOX` for instance is only set in sandboxed sessions.
+ * Everything else (PATH, HOME, NVM, locale, …) comes from the user's rcfile.
+ * Bare LARK_APP_* credentials are deliberately absent and remain redacted.
  */
 export function buildBotmuxEnvAssignments(
   env: NodeJS.ProcessEnv | undefined,
@@ -660,8 +626,8 @@ export function buildBotmuxEnvAssignments(
  *   $0 = '_' (placeholder), $1 = cwd, $2..N = KEY=VAL... bin args...
  *
  * The `cd` step makes the CLI's cwd survive a wayward `cd` in the user's
- * rcfile. The `unset` step removes bare creds the pane inherited from the tmux
- * server's global env (REDACTED_ENV_UNSET_CLAUSE). The PATH prepend puts the
+ * rcfile. The `unset` step removes stale botmux-owned values the pane inherited
+ * from the tmux server's global env. The PATH prepend puts the
  * daemon-written wrapper dir (~/.botmux/bin, which holds THIS build's `botmux`)
  * ahead of any npm-global botmux the rcfile put earlier in PATH — otherwise the
  * agent's `botmux` could resolve to a stale build. Critical under read isolation:
@@ -673,11 +639,11 @@ export function buildBotmuxEnvAssignments(
  * POSIX-syntax (works in bash/zsh/sh); fish/csh/nu users get remapped to
  * bash/zsh/sh by resolveUserShell() so they hit the same SCRIPT path.
  */
-export const SHELL_WRAPPER_SCRIPT = `cd -- "$1" && shift && ${REDACTED_ENV_UNSET_CLAUSE} && export PATH="$HOME/.botmux/bin:$PATH" && exec /usr/bin/env "$@"`;
+export const SHELL_WRAPPER_SCRIPT = `cd -- "$1" && shift && ${PANE_ENV_UNSET_CLAUSE} && export PATH="$HOME/.botmux/bin:$PATH" && exec /usr/bin/env "$@"`;
 
 export const DIAGNOSTIC_SHELL_SCRIPT = [
   'cd -- "$1" 2>/dev/null || cd "$HOME" 2>/dev/null || cd /',
-  REDACTED_ENV_UNSET_CLAUSE,
+  PANE_ENV_UNSET_CLAUSE,
   'clear',
   `printf '\\033[1;31m[botmux] Agent CLI exited. Auto-restart is paused and the last terminal output is preserved below.\\033[0m\\n\\n'`,
   'cat -- "$2" 2>/dev/null || true',
@@ -702,9 +668,9 @@ export function buildDebugKeepShellScript(shellPath: string): string {
   const safeShell = shellPath.replace(/'/g, `'\\''`);
   return [
     'cd -- "$1" && shift',
-    // Same redaction as SHELL_WRAPPER_SCRIPT — so neither the CLI nor the
-    // interactive debug shell that follows sees server/rcfile-inherited creds.
-    REDACTED_ENV_UNSET_CLAUSE,
+    // Same managed-env cleanup as SHELL_WRAPPER_SCRIPT — so neither the CLI nor
+    // the interactive debug shell sees stale server/rcfile-owned values.
+    PANE_ENV_UNSET_CLAUSE,
     // Same PATH prepend as SHELL_WRAPPER_SCRIPT (wrapper build wins over stale npm-global).
     'export PATH="$HOME/.botmux/bin:$PATH"',
     '/usr/bin/env "$@"',

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -174,6 +174,11 @@ export class TmuxPipeBackend implements SessionBackend {
   /** spawn() sets up the pipe-pane subscription + fifo reader. In managed
    *  mode it first creates a detached bmx-* tmux session that runs the CLI. */
   spawn(bin: string, args: string[], opts: SpawnOpts): void {
+    // Self-heal a server polluted by a pre-upgrade botmux before we touch it
+    // (once per daemon process; no-op on a server this build booted clean).
+    // TmuxPipeBackend is the live backend on this path, so the scrub must be
+    // triggered here — TmuxBackend is only used for its static helpers.
+    TmuxBackend.scrubServerGlobalEnvOnce();
     this.cols = opts.cols;
     this.rows = opts.rows;
 

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -1235,6 +1235,7 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
         lastMessageAt: sessionLastMessageAtMs(session),
         hasHistory: false,
         workingDir: adopted.cwd,
+        ownerOpenId: session.ownerOpenId,
         adoptedFrom: adopted,
         streamCardId: session.streamCardId,
         streamCardNonce: session.streamCardNonce,
@@ -1325,6 +1326,7 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
       lastMessageAt: sessionLastMessageAtMs(session),
       hasHistory: true,  // restored sessions have prior CLI history
       workingDir: session.workingDir,
+      ownerOpenId: session.ownerOpenId,
       // Restore persisted streaming-card state — next screen_update will PATCH
       // the existing card instead of POSTing a fresh one. If the card was
       // withdrawn while we were down, the PATCH fails with MessageWithdrawnError

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -47,6 +47,7 @@ import { BoundedMap } from './utils/bounded-map.js';
 import { checkAllowedChatGroupsConfig } from './services/allowed-chat-groups.js';
 import type { Session } from './types.js';
 import { ensureCjkFontsInstalled } from './utils/font-installer.js';
+import { scrubTmuxServerGlobalEnv } from './setup/ensure-tmux.js';
 import { invalidWorkingDirs } from './utils/working-dir.js';
 import { validateWorkingDir } from './core/working-dir.js';
 import type { DaemonToWorker, LarkMessage } from './types.js';
@@ -8323,6 +8324,18 @@ function dashboardUrlForReport(): { url?: string; localUrl?: string } {
 }
 
 export async function startDaemon(botIndex?: number): Promise<void> {
+  // Repair a shared tmux server polluted by an older botmux immediately on
+  // daemon startup. This must not depend on restoring/spawning a bmx-* session:
+  // a user-held tmux server can outlive every botmux pane and still leak stale
+  // routing/profile env into newly-created user panes.
+  const tmuxEnvScrub = scrubTmuxServerGlobalEnv();
+  if (tmuxEnvScrub.removed.length > 0) {
+    logger.info(`[tmux] scrubbed ${tmuxEnvScrub.removed.length} server-global env key(s): ${tmuxEnvScrub.removed.join(', ')}`);
+  }
+  if (tmuxEnvScrub.failed.length > 0) {
+    logger.warn(`[tmux] failed to scrub server-global env key(s): ${tmuxEnvScrub.failed.join(', ')}`);
+  }
+
   // 首次启动时后台尝试安装 CJK 字体（Debian/Ubuntu），避免截图中文显示豆腐块。
   // 不阻塞：首张截图可能仍是豆腐块，装完重启 daemon 即可正常。
   ensureCjkFontsInstalled();

--- a/src/setup/ensure-tmux.ts
+++ b/src/setup/ensure-tmux.ts
@@ -24,6 +24,7 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { detectPlatform, type PackageManager, type PlatformInfo } from './detect-platform.js';
+import { isBotmuxManagedTmuxEnvKey } from '../utils/child-env.js';
 
 export interface TmuxResult {
   installed: boolean;
@@ -117,6 +118,16 @@ function probeTmuxVersion(): TmuxVersionProbe {
  * when forwarding caller-provided env). TMUX_TMPDIR is intentionally left
  * alone — it just changes the socket directory and is the user's deliberate
  * override if set.
+ *
+ * tmuxEnv ALSO strips botmux's own session/bot-scoped vars
+ * (isBotmuxManagedTmuxEnvKey): when botmux's first `tmux new-session` boots the
+ * server, tmux copies this client env into the server's *global* environment,
+ * which then leaks into every co-tenant session on the socket — including the
+ * user's own interactive tmux, whose Claude Code would then misroute its
+ * AskUserQuestion hook to whatever BOTMUX_SESSION_ID/CHAT_ID it inherited. The
+ * pane gets the correct per-session values from the env(1) wrapper injection
+ * instead, so this strip is invisible to botmux's own sessions. See
+ * TMUX_CLIENT_STRIP_KEYS in utils/child-env.ts.
  */
 const TMUX_PATH_EXTRAS = [
   '/opt/homebrew/bin',
@@ -141,11 +152,77 @@ function withTmuxSearchPath(pathValue: string | undefined): string {
 }
 
 export function tmuxEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
-  const { TMUX: _tmux, TMUX_PANE: _pane, ...rest } = env;
+  const rest: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(env)) {
+    // TMUX/TMUX_PANE would re-target a dead parent server; botmux-managed keys
+    // would seed the server's shared global env and leak to co-tenant sessions.
+    if (key === 'TMUX' || key === 'TMUX_PANE') continue;
+    if (isBotmuxManagedTmuxEnvKey(key)) continue;
+    rest[key] = value;
+  }
   return {
     ...rest,
     PATH: withTmuxSearchPath(rest.PATH),
   };
+}
+
+export interface TmuxGlobalEnvScrubResult {
+  /** False means no tmux server answered (or tmux was temporarily unavailable). */
+  serverFound: boolean;
+  removed: string[];
+  failed: string[];
+}
+
+/**
+ * Remove botmux-managed values from an already-running tmux server's global
+ * environment. This repairs servers started by pre-isolation botmux builds,
+ * including a user-owned server that survives while no bmx-* session exists.
+ * Running panes keep their process environments; only future panes inherit the
+ * cleaned table.
+ *
+ * socketName exists for isolated tests. Production intentionally targets the
+ * default server after tmuxEnv() strips a possibly-stale parent $TMUX pointer.
+ */
+export function scrubTmuxServerGlobalEnv(socketName?: string): TmuxGlobalEnvScrubResult {
+  const socketArgs = socketName ? ['-L', socketName] : [];
+  let output: string;
+  try {
+    output = execFileSync('tmux', [...socketArgs, 'show-environment', '-g'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 3000,
+      env: tmuxEnv(),
+    });
+  } catch {
+    return { serverFound: false, removed: [], failed: [] };
+  }
+  if (typeof output !== 'string') {
+    return { serverFound: false, removed: [], failed: [] };
+  }
+
+  const names = output.split('\n')
+    // `show-environment -g` prints `NAME=value`, or `-NAME` for an explicitly
+    // removed entry. Take the name in both shapes.
+    .map(line => (line.startsWith('-') ? line.slice(1) : line.split('=', 1)[0]).trim())
+    .filter(name => name.length > 0 && isBotmuxManagedTmuxEnvKey(name));
+
+  const removed: string[] = [];
+  const failed: string[] = [];
+  for (const name of new Set(names)) {
+    try {
+      execFileSync('tmux', [...socketArgs, 'set-environment', '-g', '-u', name], {
+        stdio: 'ignore',
+        timeout: 2000,
+        env: tmuxEnv(),
+      });
+      removed.push(name);
+    } catch {
+      // Keep the exact failed key observable to callers without exposing its
+      // (potentially sensitive) old value in logs.
+      failed.push(name);
+    }
+  }
+  return { serverFound: true, removed, failed };
 }
 
 function cleanupTmuxProbeSocket(sockName: string, env: NodeJS.ProcessEnv = process.env): void {

--- a/src/utils/child-env.ts
+++ b/src/utils/child-env.ts
@@ -16,6 +16,68 @@
 export const REDACTED_CHILD_ENV_KEYS = ['LARK_APP_ID', 'LARK_APP_SECRET', 'CLAUDECODE'] as const;
 
 /**
+ * Botmux-managed, session/bot-scoped env keys that reach the CLI pane via the
+ * `/usr/bin/env KEY=VAL` wrapper injection (buildBotmuxEnvAssignments), NOT via
+ * the tmux client env. They MUST be stripped from the env handed to the `tmux`
+ * binary (see tmuxEnv), because the first `tmux new-session` that boots a server
+ * copies its client env into the server's *global* environment — which then
+ * leaks into every co-tenant session sharing that socket, including the user's
+ * own interactive tmux. A leaked `BOTMUX_SESSION_ID` / `BOTMUX_CHAT_ID` makes a
+ * plain Claude Code run in the user's terminal believe it is a botmux session
+ * and misroute its AskUserQuestion hook to a Lark thread. Stripping is invisible
+ * to botmux's own sessions: the pane still gets the correct per-session values
+ * from the env(1) injection, which lands after rcfile load.
+ *
+ * The `BOTMUX` prefix is swept wholesale by {@link isBotmuxManagedTmuxEnvKey}
+ * (covers daemon-internal BOTMUX_BOT_INDEX / BOTMUX_QUIET_RESTART / … that were
+ * never meant to reach a pane). These non-prefixed keys come from
+ * BOTMUX_INJECTED_ENV_KEYS; the bare IM-app creds are folded in from
+ * REDACTED_CHILD_ENV_KEYS so a server botmux bootstraps can never seed them
+ * into its global env either.
+ */
+export const BOTMUX_INJECTED_ENV_KEYS = [
+  '__OWNER_OPEN_ID',
+  'BOTMUX',
+  'SESSION_DATA_DIR',
+  'IS_SANDBOX',
+  // botmux ask/hooks use these to locate the daemon and route back to the
+  // current session/thread. The worker refreshes them per pane/turn.
+  'BOTMUX_SESSION_ID',
+  'BOTMUX_CHAT_ID',
+  'BOTMUX_LARK_APP_ID',
+  'BOTMUX_ROOT_MESSAGE_ID',
+  'BOTMUX_TURN_ID',
+  // Keep `botmux bots list` and ready-gated CLIs aligned with daemon config.
+  'BOTMUX_LARK_LIST_BOTS_API_ENABLED',
+  'BOTMUX_LARK_LIST_BOTS_API_TIMEOUT_MS',
+  'BOTMUX_READY_COMMAND',
+  // Hermes profile roots must match the worker-side transcript reader.
+  'HERMES_HOME',
+  'HERMES_BOTMUX_SOURCE_HOME',
+  'HERMES_BOTMUX_PROFILES_ROOT',
+  // Per-bot isolated data roots for Claude/Codex.
+  'CLAUDE_CONFIG_DIR',
+  'CODEX_HOME',
+  // CLI-specific non-interactive/resume startup controls.
+  'CLAUDE_CODE_RESUME_TOKEN_THRESHOLD',
+  'CJADK_INTERACTIVE',
+] as const;
+
+const TMUX_CLIENT_STRIP_KEYS: ReadonlySet<string> = new Set([
+  ...BOTMUX_INJECTED_ENV_KEYS,
+  ...REDACTED_CHILD_ENV_KEYS,
+]);
+
+/**
+ * True for any env key botmux manages and must keep out of the (shared) tmux
+ * server global environment. Used by tmuxEnv() to strip the tmux client env and
+ * by scrubTmuxServerGlobalEnv() to clean an already-polluted server.
+ */
+export function isBotmuxManagedTmuxEnvKey(key: string): boolean {
+  return key.startsWith('BOTMUX') || TMUX_CLIENT_STRIP_KEYS.has(key);
+}
+
+/**
  * Build the base environment for a spawned CLI child: copy the worker's env
  * and REMOVE the keys in REDACTED_CHILD_ENV_KEYS.
  *

--- a/test/session-resume.test.ts
+++ b/test/session-resume.test.ts
@@ -112,6 +112,8 @@ vi.mock('../src/adapters/backend/tmux-backend.js', () => ({
 
 vi.mock('../src/core/session-discovery.js', () => ({
   validateAdoptTarget: vi.fn(() => true),
+  validateAdoptTargetState: vi.fn(() => 'alive'),
+  adoptTargetLabel: vi.fn(() => 'test-pane'),
 }));
 
 vi.mock('../src/core/session-activity.js', () => ({
@@ -120,7 +122,7 @@ vi.mock('../src/core/session-activity.js', () => ({
 }));
 
 import { restoreActiveSessions, resumeSession } from '../src/core/session-manager.js';
-import { restoreUsageLimitRuntimeState, closeSession } from '../src/core/worker-pool.js';
+import { restoreUsageLimitRuntimeState, closeSession, forkAdoptWorker } from '../src/core/worker-pool.js';
 import * as sessionStore from '../src/services/session-store.js';
 import { sessionKey } from '../src/core/types.js';
 import type { DaemonSession } from '../src/core/types.js';
@@ -330,6 +332,48 @@ describe('resumeSession', () => {
       const ds = map.get(sessionKey('om_limit', 'app_test'));
       expect(ds).toBeDefined();
       expect(restoreUsageLimitRuntimeState).toHaveBeenCalledWith(ds);
+    });
+
+    it('restores ownerOpenId for a regular active session after daemon restart', async () => {
+      const s = sessionStore.createSession('oc_owner', 'om_owner', 'Owned topic');
+      s.larkAppId = 'app_test';
+      s.scope = 'thread';
+      s.cliId = 'claude-code';
+      s.workingDir = '/tmp/owned';
+      s.ownerOpenId = 'ou_persisted_owner';
+      sessionStore.updateSession(s);
+
+      const map = new Map<string, DaemonSession>();
+      await restoreActiveSessions(map);
+
+      expect(map.get(sessionKey('om_owner', 'app_test'))?.ownerOpenId).toBe('ou_persisted_owner');
+    });
+
+    it('restores ownerOpenId before re-forking an adopt session', async () => {
+      const s = sessionStore.createSession('oc_adopt_owner', 'om_adopt_owner', 'Adopt: test-pane');
+      s.larkAppId = 'app_test';
+      s.scope = 'thread';
+      s.cliId = 'claude-code';
+      s.ownerOpenId = 'ou_adopt_owner';
+      s.adoptedFrom = {
+        source: 'tmux',
+        tmuxTarget: 'test:0.0',
+        originalCliPid: 12345,
+        cliId: 'claude-code',
+        cwd: '/tmp/adopted',
+      };
+      sessionStore.updateSession(s);
+      vi.mocked(forkAdoptWorker).mockClear();
+
+      const map = new Map<string, DaemonSession>();
+      await restoreActiveSessions(map);
+
+      const restored = map.get(sessionKey('om_adopt_owner', 'app_test'));
+      expect(restored?.ownerOpenId).toBe('ou_adopt_owner');
+      expect(forkAdoptWorker).toHaveBeenCalledWith(
+        expect.objectContaining({ ownerOpenId: 'ou_adopt_owner' }),
+        { restoredFromMetadata: true },
+      );
     });
 
     it('restores the persisted clean sidecar for a long-running Codex App session', async () => {

--- a/test/tmux-backend-env.test.ts
+++ b/test/tmux-backend-env.test.ts
@@ -553,6 +553,46 @@ describe('shell wrapper end-to-end (the contract spawn() builds)', () => {
     },
   );
 
+  it.skipIf(!hasEnvBin)(
+    'wrapper clears every stale managed value before injecting this pane values',
+    () => {
+      const cwd = tmpdir();
+      const result = spawnSync(
+        '/bin/sh',
+        ['-c', SCRIPT, '_', cwd,
+          '__OWNER_OPEN_ID=ou_fresh',
+          'BOTMUX_SESSION_ID=fresh-session',
+          'BOTMUX_CHAT_ID=fresh-chat',
+          '/usr/bin/env',
+        ],
+        { encoding: 'utf-8', env: {
+          __OWNER_OPEN_ID: 'ou_stale',
+          BOTMUX_SESSION_ID: 'stale-session',
+          BOTMUX_CHAT_ID: 'stale-chat',
+          IS_SANDBOX: '1',
+          CLAUDE_CONFIG_DIR: '/stale/claude',
+          CODEX_HOME: '/stale/codex',
+          HERMES_HOME: '/stale/hermes',
+          HERMES_BOTMUX_SOURCE_HOME: '/stale/hermes-source',
+          HERMES_BOTMUX_PROFILES_ROOT: '/stale/hermes-profiles',
+          PATH: '/usr/bin:/bin',
+          HOME: '/tmp',
+        } },
+      );
+      expect(result.status).toBe(0);
+      const lines = result.stdout.split('\n');
+      expect(lines).toContain('__OWNER_OPEN_ID=ou_fresh');
+      expect(lines).toContain('BOTMUX_SESSION_ID=fresh-session');
+      expect(lines).toContain('BOTMUX_CHAT_ID=fresh-chat');
+      for (const key of [
+        'IS_SANDBOX', 'CLAUDE_CONFIG_DIR', 'CODEX_HOME', 'HERMES_HOME',
+        'HERMES_BOTMUX_SOURCE_HOME', 'HERMES_BOTMUX_PROFILES_ROOT',
+      ]) {
+        expect(lines.some(line => line.startsWith(`${key}=`)), key).toBe(false);
+      }
+    },
+  );
+
   const hasTmux = !spawnSync('tmux', ['-V']).error;
   it.skipIf(!hasEnvBin || !hasTmux)(
     'tmux child does NOT inherit bare LARK_APP_* from a server started with them in scope (Codex repro)',

--- a/test/tmux-env-isolation.test.ts
+++ b/test/tmux-env-isolation.test.ts
@@ -18,10 +18,11 @@
  */
 import { describe, it, expect } from 'vitest';
 import { execSync, spawnSync } from 'node:child_process';
-import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { tmuxEnv, probeTmuxFunctional } from '../src/setup/ensure-tmux.js';
+import { probeTmuxFunctional, scrubTmuxServerGlobalEnv, tmuxEnv } from '../src/setup/ensure-tmux.js';
+import { BOTMUX_INJECTED_ENV_KEYS, REDACTED_CHILD_ENV_KEYS, isBotmuxManagedTmuxEnvKey } from '../src/utils/child-env.js';
 
 describe('tmuxEnv()', () => {
   it('strips TMUX and TMUX_PANE from the env', () => {
@@ -45,6 +46,69 @@ describe('tmuxEnv()', () => {
     });
     expect(stripped.TMUX).toBeUndefined();
     expect(stripped.TMUX_TMPDIR).toBe('/custom/tmp');
+  });
+
+  it('strips botmux session/bot-scoped vars so they never seed the tmux server global env', () => {
+    // The leak this guards against: the first `tmux new-session` copies its
+    // client env into the server's *global* env, which then bleeds into the
+    // user's own co-tenant tmux sessions → a plain Claude Code there inherits
+    // BOTMUX_SESSION_ID/CHAT_ID and misroutes its AskUserQuestion hook to Lark.
+    const stripped = tmuxEnv({
+      BOTMUX: '1',
+      BOTMUX_SESSION_ID: '190222fc-bc5f-4481-849b-6161901b8506',
+      BOTMUX_CHAT_ID: 'oc_abc',
+      BOTMUX_LARK_APP_ID: 'cli_x',
+      BOTMUX_ROOT_MESSAGE_ID: 'om_x',
+      BOTMUX_BOT_INDEX: '12',           // daemon-internal, swept by the BOTMUX prefix
+      BOTMUX_QUIET_RESTART: '1',
+      SESSION_DATA_DIR: '/root/.botmux/data',
+      IS_SANDBOX: '1',
+      CLAUDE_CONFIG_DIR: '/root/.seed/.claude-runtime',
+      CODEX_HOME: '/root/.codex-bot',
+      HERMES_HOME: '/root/.hermes-bot',
+      HERMES_BOTMUX_SOURCE_HOME: '/root/.hermes-source',
+      HERMES_BOTMUX_PROFILES_ROOT: '/root/.hermes-profiles',
+      CLAUDE_CODE_RESUME_TOKEN_THRESHOLD: '2147483647',
+      CJADK_INTERACTIVE: '0',
+      __OWNER_OPEN_ID: 'ou_x',
+      LARK_APP_ID: 'cli_bot',           // bare creds must not seed the global either
+      LARK_APP_SECRET: 'secret',
+      CLAUDECODE: '1',
+      // Legit passthrough — the tmux client still needs these.
+      PATH: '/usr/bin',
+      HOME: '/root',
+      LANG: 'en_US.UTF-8',
+      TERM: 'tmux-256color',
+    });
+    for (const leaked of [
+      'BOTMUX', 'BOTMUX_SESSION_ID', 'BOTMUX_CHAT_ID', 'BOTMUX_LARK_APP_ID',
+      'BOTMUX_ROOT_MESSAGE_ID', 'BOTMUX_BOT_INDEX', 'BOTMUX_QUIET_RESTART',
+      'SESSION_DATA_DIR', 'IS_SANDBOX', 'CLAUDE_CONFIG_DIR', '__OWNER_OPEN_ID',
+      'CODEX_HOME', 'HERMES_HOME', 'HERMES_BOTMUX_SOURCE_HOME',
+      'HERMES_BOTMUX_PROFILES_ROOT', 'CLAUDE_CODE_RESUME_TOKEN_THRESHOLD',
+      'CJADK_INTERACTIVE',
+      'LARK_APP_ID', 'LARK_APP_SECRET', 'CLAUDECODE',
+    ]) {
+      expect(stripped[leaked]).toBeUndefined();
+    }
+    // Non-botmux env the tmux client legitimately needs survives.
+    expect(stripped.HOME).toBe('/root');
+    expect(stripped.LANG).toBe('en_US.UTF-8');
+    expect(stripped.TERM).toBe('tmux-256color');
+    expect(stripped.PATH?.split(':')[0]).toBe('/usr/bin');
+  });
+
+  it('does not strip lookalike keys that merely contain "BOTMUX" mid-name', () => {
+    // The sweep is a prefix match (startsWith), not a substring match, so a
+    // user var like MY_BOTMUX_HINT is left untouched.
+    const stripped = tmuxEnv({ MY_BOTMUX_HINT: 'keep', PATH: '/usr/bin' });
+    expect(stripped.MY_BOTMUX_HINT).toBe('keep');
+  });
+
+  it('classifies every per-pane and redacted key as tmux-managed', () => {
+    for (const key of [...BOTMUX_INJECTED_ENV_KEYS, ...REDACTED_CHILD_ENV_KEYS]) {
+      expect(isBotmuxManagedTmuxEnvKey(key), key).toBe(true);
+    }
   });
 
   it('is safe to call with no args (defaults to process.env)', () => {
@@ -172,5 +236,85 @@ describe('tmux subcommand with stale $TMUX', () => {
         rmSync(probeTmpdir, { recursive: true, force: true });
       }
     },
+  );
+
+  it.skipIf(!tmuxAvailable)(
+    'startup scrub cleans a legacy server without mutating already-running panes',
+    () => {
+      const sock = `bmx-scrub-${process.pid}-${Date.now()}`;
+      const dir = mkdtempSync(join(tmpdir(), 'botmux-tmux-scrub-'));
+      const existingOut = join(dir, 'existing.env');
+      const freshOut = join(dir, 'fresh.env');
+      const pollutedEnv: NodeJS.ProcessEnv = {
+        ...process.env,
+        BOTMUX_SESSION_ID: 'stale-session',
+        BOTMUX_CHAT_ID: 'stale-chat',
+        CODEX_HOME: '/stale/codex',
+        HERMES_HOME: '/stale/hermes',
+        LARK_APP_ID: 'stale-app',
+        HOME: '/safe/home',
+      };
+      delete pollutedEnv.TMUX;
+      delete pollutedEnv.TMUX_PANE;
+
+      try {
+        const started = spawnSync('tmux', [
+          '-L', sock, 'new-session', '-d', '-s', 'holder', '--',
+          '/bin/sh', '-c',
+          'tmux -L "$1" wait-for bmx-go; /usr/bin/env > "$2"; tmux -L "$1" wait-for -S bmx-existing-done; sleep 60',
+          '_', sock, existingOut,
+        ], { env: pollutedEnv, encoding: 'utf-8', timeout: 10_000 });
+        expect(started.status, started.stderr).toBe(0);
+
+        const scrub = scrubTmuxServerGlobalEnv(sock);
+        expect(scrub.serverFound).toBe(true);
+        expect(scrub.failed).toEqual([]);
+        expect(scrub.removed).toEqual(expect.arrayContaining([
+          'BOTMUX_SESSION_ID', 'BOTMUX_CHAT_ID', 'CODEX_HOME', 'HERMES_HOME', 'LARK_APP_ID',
+        ]));
+
+        const globalEnv = spawnSync('tmux', ['-L', sock, 'show-environment', '-g'], {
+          env: tmuxEnv(), encoding: 'utf-8', timeout: 5000,
+        });
+        expect(globalEnv.status, globalEnv.stderr).toBe(0);
+        expect(globalEnv.stdout).toContain('HOME=/safe/home');
+        for (const key of ['BOTMUX_SESSION_ID', 'BOTMUX_CHAT_ID', 'CODEX_HOME', 'HERMES_HOME', 'LARK_APP_ID']) {
+          expect(globalEnv.stdout).not.toMatch(new RegExp(`(?:^|\\n)-?${key}(?:=|\\n|$)`));
+        }
+
+        // The holder existed before the global-table repair, so its process
+        // environment remains untouched.
+        expect(spawnSync('tmux', ['-L', sock, 'wait-for', '-S', 'bmx-go'], {
+          env: tmuxEnv(), timeout: 5000,
+        }).status).toBe(0);
+        expect(spawnSync('tmux', ['-L', sock, 'wait-for', 'bmx-existing-done'], {
+          env: tmuxEnv(), timeout: 5000,
+        }).status).toBe(0);
+        const existingEnv = readFileSync(existingOut, 'utf-8').split('\n');
+        expect(existingEnv).toContain('BOTMUX_SESSION_ID=stale-session');
+        expect(existingEnv).toContain('CODEX_HOME=/stale/codex');
+
+        // A raw pane created after the scrub no longer inherits any stale key.
+        const fresh = spawnSync('tmux', [
+          '-L', sock, 'new-session', '-d', '-s', 'fresh', '--',
+          '/bin/sh', '-c',
+          '/usr/bin/env > "$1"; tmux -L "$2" wait-for -S bmx-fresh-done; sleep 60',
+          '_', freshOut, sock,
+        ], { env: pollutedEnv, encoding: 'utf-8', timeout: 10_000 });
+        expect(fresh.status, fresh.stderr).toBe(0);
+        expect(spawnSync('tmux', ['-L', sock, 'wait-for', 'bmx-fresh-done'], {
+          env: tmuxEnv(), timeout: 5000,
+        }).status).toBe(0);
+        const freshEnv = readFileSync(freshOut, 'utf-8').split('\n');
+        for (const key of ['BOTMUX_SESSION_ID', 'BOTMUX_CHAT_ID', 'CODEX_HOME', 'HERMES_HOME', 'LARK_APP_ID']) {
+          expect(freshEnv.some(line => line.startsWith(`${key}=`)), key).toBe(false);
+        }
+        expect(freshEnv).toContain('HOME=/safe/home');
+      } finally {
+        spawnSync('tmux', ['-L', sock, 'kill-server'], { env: tmuxEnv(), timeout: 5000 });
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+    30_000,
   );
 });


### PR DESCRIPTION
## 问题

botmux 的 tmux 后端与用户交互式 tmux 共用默认 server。旧实现会把当前会话的 `BOTMUX_*`、`SESSION_DATA_DIR`、CLI profile 路径等带入 tmux client env；当 botmux 首次拉起 server 时，这些值会进入 server 全局环境，随后泄漏给同 socket 上新建的用户 pane。普通 Claude Code 因此可能误认成 botmux 会话，把 AskUserQuestion 卡片路由到错误的飞书话题。

同时，daemon 重启恢复普通会话和 Adopt 会话时，持久化的 `session.ownerOpenId` 没有写回 `DaemonSession.ownerOpenId`。恢复后的 `botmux ask` / owner 权限判断可能丢失会话 owner。

本 PR 已吸收 #483 中相关的 pane 启动清理与 owner 恢复思路，并在最新 master 上统一实现。

## 修改

1. **单一环境白名单**：把 `BOTMUX_INJECTED_ENV_KEYS` 集中到 `child-env.ts`，由 tmux client 过滤、pane wrapper 清理和 per-pane 注入共同使用，避免三份名单漂移。当前 `HERMES_*`、`CODEX_HOME`、`CLAUDE_CONFIG_DIR` 等 profile key 均覆盖。
2. **阻断新污染**：`tmuxEnv()` 剥离 `BOTMUX*`、全部 per-pane 托管 key、裸 `LARK_APP_*` 凭据以及 `CLAUDECODE`；botmux pane 仍通过 `/usr/bin/env KEY=VAL` 得到本会话的正确值。
3. **pane 级兜底**：shell wrapper 在注入当前值之前，先 `unset` 完整托管 key 集合。即使共享 server 仍带旧值，缺省/可选字段（如 `IS_SANDBOX`、`CODEX_HOME`、Hermes profile）也不会串到新 pane。
4. **启动即自愈旧 server**：daemon 进入 `startDaemon()` 时主动清理 tmux server 全局环境，不再依赖某个 bmx session spawn/reattach；backend 保留 worker 级 fallback。清理只影响之后创建的 pane，不修改已经运行的进程环境。
5. **恢复 owner**：普通 active 会话和 Adopt 会话恢复时都回填 `ownerOpenId`；queued/resume 路径原有行为保持不变。

## 影响面

- **后端**：`TmuxBackend`、`TmuxPipeBackend` 共享同一策略；`PtyBackend` 不经过 tmux 环境路径。
- **CLI**：所有走 tmux 的 CLI 都使用同一 wrapper；Claude/Codex/Hermes/cjadk 的现有专用变量均在白名单内。
- **会话类型**：普通恢复、Adopt 恢复补齐 owner；运行中的 pane、reattach 会话和 queued 会话不被重置。
- **平台**：调用使用 `execFileSync` 参数数组与 POSIX shell wrapper，覆盖当前 Linux/macOS tmux 路径。

## 实际验证

- `pnpm build`：通过。
- 定向单测：`tmux-backend-env`、`tmux-env-isolation`、`session-resume`，**72 passed**。
- tmux 相关扩展回归：包含 `tmux-pipe-backend`、probe/recovery/reattach/startup gate、session auto-recover；相关用例均通过。
- 全量 unit：**8375 passed / 8380 total**。5 个失败与 master 已知本机基线一致：3 个 host timezone 断言、1 个 dashboard CSS 断言、1 个本机 terminal URL 环境断言，均不在本 PR 改动路径。
- `pnpm vitest run --project e2e test/tmux-backend.e2e.ts`：**4 passed**。
- 隔离 tmux socket 集成用例：确认旧 server 全局 key 被清除、已运行 pane 的原环境不变、清理后新 pane 不再继承污染。
- live daemon：执行 `pnpm switch:here && botmux restart`；预先注入的无害 `BOTMUX_REVIEW_SCRUB_PROBE` 在仅重启 daemon 后被启动阶段 scrub 清除，日志记录成功，全部配置 daemon 与 dashboard 恢复 online，当前持久会话正常续接。
