### PR TITLE
fix(hermes): 修复 hermes 场景下重复回复问题

### DIFF
--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -362,6 +362,30 @@ function renderWhiteboardBlock(opts?: { whiteboardId?: string }): string {
   ].join('\n');
 }
 
+function buildHermesBotmuxHints(locale?: Locale): string[] {
+  if (locale === 'en') {
+    return [
+      'You are running in a Feishu/Lark chat through botmux. For ordinary text replies, write the user-facing answer as your final assistant message; botmux automatically forwards that final output to Feishu/Lark.',
+      'Do not call `botmux send` for normal text answers. Use `botmux send` only for special delivery needs: files/images, voice, cross-chat/top-level sends, or explicit mention routing to another person/bot.',
+      '`botmux send` / `botmux history` / `botmux quoted` / `botmux bots` are shell commands installed in $PATH; run them via Bash/terminal tools when needed.',
+      'If you already used `botmux send` for special delivery in this turn, do not put a second copy of the answer, messageId, or send-success receipt in the final assistant message.',
+    ];
+  }
+  return [
+    '你运行在飞书（Lark）聊天中。普通文字回复请直接写在 assistant final 里，botmux 会自动把 final_output 转发到飞书。',
+    '普通文本答案不要调用 `botmux send`。只有需要图片/文件/语音、跨群或顶层发送、显式 @ 某人/某 bot 等特殊投递能力时，才使用 `botmux send`。',
+    '`botmux send` / `botmux history` / `botmux quoted` / `botmux bots` 是已安装在 $PATH 的 shell 命令；需要时通过 Bash/terminal 工具执行。',
+    '如果本轮已经为了特殊投递调用过 `botmux send`，final 里不要再写第二份正文、messageId 或“发送成功/已处理”回执。',
+  ];
+}
+
+function hermesFollowupReminder(locale?: Locale): string {
+  if (locale === 'en') {
+    return 'For ordinary text replies, do not call `botmux send`; put the user-facing answer in final and botmux will forward it to Feishu/Lark. Use `botmux send` only for special delivery such as files/images, voice, cross-chat/top-level sends, or explicit mention routing. If already used, do not add a second answer or send-success receipt in final.';
+  }
+  return '普通文字回复不要调用 `botmux send`；直接把给用户看的答案写在 final，botmux 会自动转发到飞书。只有图片/文件/语音、跨群/顶层发送、特殊 @ 路由等特殊投递才用 `botmux send`；如果本轮已经用过，不要在 final 里再写第二份答案或发送成功回执。';
+}
+
 export function buildNewTopicPrompt(
   userMessage: string,
   sessionId: string,
@@ -381,7 +405,7 @@ export function buildNewTopicPrompt(
   // (Claude Code builds its own via --append-system-prompt). Source hints
   // freshly from i18n so they respect the resolved locale instead of the
   // static `adapter.systemHints` array that was baked at module load.
-  const hints = adapter.injectsSessionContext ? [] : buildBotmuxShellHints(locale);
+  const hints = adapter.injectsSessionContext ? [] : (cliId === 'hermes' ? buildHermesBotmuxHints(locale) : buildBotmuxShellHints(locale));
 
   const routingBlock = hints.length > 0
     ? `<botmux_routing>\n${hints.join('\n')}\n</botmux_routing>`
@@ -496,7 +520,10 @@ export function buildFollowUpContent(
   if (!skipSessionId) parts.push(`<session_id>${xmlEscape(sessionId)}</session_id>`);
   if (roleBlock) parts.push(roleBlock);
   if (opts?.cliId !== 'mira') {
-    parts.push(`<botmux_reminder>${t('ai.followup.reminder', undefined, opts?.locale)}</botmux_reminder>`);
+    const reminder = opts?.cliId === 'hermes'
+      ? hermesFollowupReminder(opts?.locale)
+      : t('ai.followup.reminder', undefined, opts?.locale);
+    parts.push(`<botmux_reminder>${reminder}</botmux_reminder>`);
   }
   if (whiteboardBlock) parts.push(whiteboardBlock);
 

--- a/src/services/codex-bridge-queue.ts
+++ b/src/services/codex-bridge-queue.ts
@@ -71,6 +71,7 @@ export class CodexBridgeQueue {
   private collecting: CodexPendingTurn | null = null;
   private localTurnsEnabled = false;
   private bufferedUnmatched: CodexBridgeEvent[] = [];
+  private lastClosedAssistantFinalTimeMs: number | undefined;
   /** Lower bound (ms) for synthesising local turns — protects against a
    *  fresh-empty attach replaying historical iTerm conversation as
    *  "live" local input. Typically set to the moment adopt was wired up. */
@@ -113,6 +114,7 @@ export class CodexBridgeQueue {
     const dropped = this.queue.splice(0);
     if (this.collecting && dropped.includes(this.collecting)) this.collecting = null;
     this.bufferedUnmatched = [];
+    this.lastClosedAssistantFinalTimeMs = undefined;
     return dropped;
   }
 
@@ -193,8 +195,25 @@ export class CodexBridgeQueue {
         // mark, and the -5s tooOld tolerance must not be able to widen the
         // window into a previous turn's sends. Mirrors what Claude's
         // BridgeTurnQueue.handleTurnStart does with eventTimeMs.
-        if (next!.markTimeMs === undefined) next!.markTimeMs = ev.timestampMs;
-        else next!.markTimeMs = Math.max(next!.markTimeMs, ev.timestampMs);
+        //
+        // Hermes is the exception: its SQLite message timestamps can be
+        // committed near turn completion, after in-turn `botmux send` markers
+        // have already landed. Preserve the original worker mark so those
+        // markers stay inside the bridge-fallback suppression window. For
+        // adjacent queued Hermes turns, still advance the next turn to at
+        // least the previous assistant final so batch-drain boundaries don't
+        // collapse to back-to-back enqueue times.
+        if (next!.markTimeMs === undefined) {
+          next!.markTimeMs = ev.preserveMarkTimeMs === true && this.lastClosedAssistantFinalTimeMs !== undefined
+            ? this.lastClosedAssistantFinalTimeMs
+            : ev.timestampMs;
+        } else if (ev.preserveMarkTimeMs === true) {
+          if (this.lastClosedAssistantFinalTimeMs !== undefined) {
+            next!.markTimeMs = Math.max(next!.markTimeMs, this.lastClosedAssistantFinalTimeMs);
+          }
+        } else {
+          next!.markTimeMs = Math.max(next!.markTimeMs, ev.timestampMs);
+        }
         this.collecting = next!;
       } else if (willSynthLocal) {
         // Adopt mode local input: user typed in iTerm, no Lark
@@ -223,6 +242,7 @@ export class CodexBridgeQueue {
       if (this.collecting) {
         if (this.collecting.sourceSessionId && ev.sourceSessionId && this.collecting.sourceSessionId !== ev.sourceSessionId) return;
         this.collecting.finalText = ev.text;
+        this.lastClosedAssistantFinalTimeMs = ev.timestampMs;
         this.collecting = null;
       } else if (bufferUnmatched && !this.localTurnsEnabled) {
         this.rememberUnmatched(ev);

--- a/src/services/codex-transcript.ts
+++ b/src/services/codex-transcript.ts
@@ -113,6 +113,10 @@ export interface CodexBridgeEvent {
    *  user, output_text for assistant). */
   text: string;
   sourceSessionId?: string;
+  /** Keep the pending turn's original markTimeMs instead of moving it to the
+   *  transcript user timestamp. Used by bridges whose committed user
+   *  timestamp can lag behind in-turn delivery markers. */
+  preserveMarkTimeMs?: boolean;
 }
 
 /** Extract the last completed user/assistant turn from a Codex / CoCo bridge

--- a/src/services/hermes-transcript.ts
+++ b/src/services/hermes-transcript.ts
@@ -92,7 +92,7 @@ export function drainHermesStateDb(fromOffset: number, dbPath = HERMES_STATE_DB)
     if (!text) continue;
     const timestampMs = typeof row.timestamp === 'number' ? row.timestamp * 1000 : Date.now();
     if (row.role === 'user') {
-      events.push({ uuid: `hermes:${row.id}`, timestampMs, kind: 'user', text, sourceSessionId: row.session_id });
+      events.push({ uuid: `hermes:${row.id}`, timestampMs, kind: 'user', text, sourceSessionId: row.session_id, preserveMarkTimeMs: true });
     } else if (row.role === 'assistant') {
       if (row.finish_reason !== 'stop') continue;
       events.push({ uuid: `hermes:${row.id}`, timestampMs, kind: 'assistant_final', text, sourceSessionId: row.session_id });

--- a/test/codex-bridge-queue.test.ts
+++ b/test/codex-bridge-queue.test.ts
@@ -417,6 +417,42 @@ describe('CodexBridgeQueue', () => {
 });
 
 describe('CodexBridgeQueue + bridge-fallback gate (type-ahead suppression windows)', () => {
+  it('preserves Hermes markTime so late-committed user rows do not miss in-turn sends', () => {
+    const q = new CodexBridgeQueue();
+    q.mark('t1', 'hermes prompt', 1_000);
+    q.ingest([
+      { ...userEv('hermes prompt', 'u-hermes', 12_000), preserveMarkTimeMs: true },
+      asstEv('hermes reply', 'a-hermes', 15_000),
+    ]);
+
+    const markers: BridgeSendMarker[] = [{ sentAtMs: 8_000 }];
+    expect(emitDecisions(q, markers)).toEqual([{ turnId: 't1', suppressed: true }]);
+  });
+
+  it('keeps adjacent Hermes queued-turn windows separate during batch drains', () => {
+    const makeQueue = () => {
+      const q = new CodexBridgeQueue();
+      q.mark('t1', 'first hermes prompt', 1_000);
+      q.mark('t2', 'second hermes prompt', 1_001);
+      q.ingest([
+        { ...userEv('first hermes prompt', `u1-${++nextUuid}`, 12_000), preserveMarkTimeMs: true },
+        asstEv('first hermes reply', `a1-${++nextUuid}`, 15_000),
+        { ...userEv('second hermes prompt', `u2-${++nextUuid}`, 22_000), preserveMarkTimeMs: true },
+        asstEv('second hermes reply', `a2-${++nextUuid}`, 25_000),
+      ]);
+      return q;
+    };
+
+    expect(emitDecisions(makeQueue(), [{ sentAtMs: 14_000 }, { sentAtMs: 20_000 }])).toEqual([
+      { turnId: 't1', suppressed: true },
+      { turnId: 't2', suppressed: true },
+    ]);
+    expect(emitDecisions(makeQueue(), [{ sentAtMs: 20_000 }])).toEqual([
+      { turnId: 't1', suppressed: false },
+      { turnId: 't2', suppressed: true },
+    ]);
+  });
+
   it('does not let explicit progress sends suppress a later transcript final answer', () => {
     const q = new CodexBridgeQueue();
     q.mark('t1', 'please design the sync plan', 1_000);

--- a/test/hermes-transcript.test.ts
+++ b/test/hermes-transcript.test.ts
@@ -54,7 +54,7 @@ describe('hermes transcript reader', () => {
     expect(drainHermesStateDb(1, '/tmp/state.db')).toEqual({
       newOffset: 5,
       events: [
-        { uuid: 'hermes:2', timestampMs: 100000, kind: 'user', text: 'hello', sourceSessionId: 'h1' },
+        { uuid: 'hermes:2', timestampMs: 100000, kind: 'user', text: 'hello', sourceSessionId: 'h1', preserveMarkTimeMs: true },
         { uuid: 'hermes:4', timestampMs: 102000, kind: 'assistant_final', text: 'hi', sourceSessionId: 'h1' },
       ],
     });

--- a/test/prompt-builder.test.ts
+++ b/test/prompt-builder.test.ts
@@ -96,6 +96,14 @@ describe('buildNewTopicPrompt', () => {
     expect(prompt).toContain('字面量');
   });
 
+  it('uses final-output routing hints for Hermes instead of normal botmux send guidance', () => {
+    const prompt = buildNewTopicPrompt('hello', SESSION_ID, 'hermes');
+    expect(prompt).toContain('普通文字回复请直接写在 assistant final');
+    expect(prompt).toContain('普通文本答案不要调用 `botmux send`');
+    expect(prompt).not.toContain("botmux send <<'EOF'");
+    expect(prompt).not.toContain('回复必须 botmux send');
+  });
+
   it('should NOT embed <session_id> for CLIs with injectsSessionContext (claude-code)', () => {
     const prompt = buildNewTopicPrompt('hello', SESSION_ID, 'claude-code');
     expect(prompt).not.toContain('<session_id>');
@@ -262,6 +270,14 @@ describe('buildFollowUpContent', () => {
     expect(content.indexOf('<botmux_reminder>')).toBeLessThan(content.indexOf('<user_message>'));
     expect(content.indexOf('<sender ')).toBeGreaterThan(content.indexOf('</user_message>'));
     expect(content.indexOf('<mentions>')).toBeGreaterThan(content.indexOf('</user_message>'));
+  });
+
+  it('uses final-output reminder for Hermes follow-ups', () => {
+    const content = buildFollowUpContent('hello', SESSION_ID, { cliId: 'hermes' });
+
+    expect(content).toContain('普通文字回复不要调用 `botmux send`');
+    expect(content).toContain('直接把给用户看的答案写在 final');
+    expect(content).not.toContain('回复必须 botmux send');
   });
 
   it('places the short whiteboard hint before follow-up user content', () => {


### PR DESCRIPTION
## 问题

hermes 场景下会出现重复回复。hermes 属于 bridge-fallback 类 CLI，助手的 final_output 会被 botmux 自动转发到飞书；但旧的通用 prompt 引导（`buildBotmuxShellHints`）会告诉它「回复必须 `botmux send`」，于是同一条答案既被 `botmux send` 发一次、又被转录 final 自动转发一次 → 重复。另外 hermes 的 SQLite user 时间戳提交偏晚，会让 bridge-fallback 的抑制窗口错位，导致图片/文件等特殊投递时同样重复。

## 改了什么

1. **Prompt 引导（`src/core/session-manager.ts`）**：给 hermes 专属路由提示（`buildHermesBotmuxHints` / `hermesFollowupReminder`）——普通文字回复直接写在 assistant final，botmux 自动转发；只有图片/文件/语音、跨群/顶层发送、显式 @ 某人/某 bot 等特殊投递才用 `botmux send`；本轮已 `botmux send` 过就别在 final 再写第二份正文/回执。new-topic 与 follow-up 两处都覆盖。
2. **抑制窗口（`codex-bridge-queue.ts` + `codex-transcript.ts` + `hermes-transcript.ts`）**：bridge 事件新增 `preserveMarkTimeMs` 标志，仅 hermes 的 user 事件设 `true`。hermes 的 SQLite user 时间戳在 turn 快结束时才落库，原逻辑把抑制窗口下界推到这个晚时间戳，导致 turn 内的 `botmux send` 落在窗口外 → 转录 final 不被抑制 → 重复发。改为：hermes 保留 worker mark（真正的 turn 起点）；相邻排队 turn 推进到上一条 assistant final（`lastClosedAssistantFinalTimeMs`），保住批量 drain 的窗口边界。

## 影响面（仅 hermes，其它 CLI / 会话类型零影响）

- `session-manager` 的 hints 与 follow-up reminder 都硬 gate 在 `cliId === 'hermes'`；其它 CLI 仍走原 `buildBotmuxShellHints` / `ai.followup.reminder`，mira 照旧不加 reminder。
- `codex-bridge-queue` 新增的三路分支在 `preserveMarkTimeMs` 缺省时**逐字等价**于原来的两行；`preserveMarkTimeMs: true` 全仓只有 `hermes-transcript.ts` 设，codex/coco 均不设。
- `lastClosedAssistantFinalTimeMs` 对所有 bridge 都会写，但只有 hermes（preserve=true）才读 → 对 codex/coco 是死写入、无行为变化；为 per-queue 实例字段，无跨会话串扰。
- `codex-transcript` 只新增一个 optional 字段，无行为变化。

## 测试验证

- `pnpm build`（tsc typecheck）通过。
- 改动涉及的 3 个测试文件全绿：`codex-bridge-queue.test.ts` / `hermes-transcript.test.ts` / `prompt-builder.test.ts`（91 tests）。
- 扩跑非 hermes 的 bridge/transcript 套件确认无回归：`bridge-turn-queue` / `bridge-fallback-gate` / `bridge-final-output-retry` / `codex-transcript` / `coco-transcript`（合计 207 tests 全绿）。
