### PR TITLE
fix(send): @别的 bot 时不再默认捎带 owner，正文代码块里的 @Bot 不再误唤醒

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -78,6 +78,7 @@ import {
   hasKnownBotMention,
   knownBotOpenIdsFromCrossRef,
   orderedFooterRecipients,
+  stripCodeSpans,
   type BotMentionEntry,
 } from './utils/bot-routing.js';
 import { isLocale, localeForBot, setDefaultLocale, SUPPORTED_LOCALES, t, type Locale } from './i18n/index.js';
@@ -4605,6 +4606,12 @@ async function cmdSend(rest: string[]): Promise<void> {
       // bot（正是要避免的循环 @）。botEntries/crossRef 仍需加载供 footer 寻址用。
       if (!noMention) {
       const alreadyMentioned = new Set(mentions.map(m => m.open_id));
+      // Scan a code-span-stripped copy so a bot name quoted inside backticks or a
+      // fenced block (e.g. an example `botmux send --mention @Bot …` or an
+      // explanatory `@Bot`) is not auto-injected as a real handoff — that spurious
+      // <at> would wake a bot the model never meant to @. Explicit --mention still
+      // works (it doesn't go through this prose scan).
+      const textForBotScan = stripCodeSpans(text);
       // Sort by name length desc so longer names ("Claude分身") win over their
       // prefix ("Claude") when both could match — break-on-first-hit otherwise
       // routes "@Claude分身" to Claude.
@@ -4648,7 +4655,7 @@ async function cmdSend(rest: string[]): Promise<void> {
           // `@Claude2` doesn't match name "Claude" and `@Claude分身好的` doesn't
           // either-half-match.
           const re = new RegExp(`(?<![A-Za-z0-9_])@${escName}(?![\\p{L}\\p{N}_])`, 'iu');
-          if (!re.test(text)) continue;
+          if (!re.test(textForBotScan)) continue;
           // Lark open_id is per-app scoped. Use sender-scoped id from cross-ref
           // only — falling back to entry.botOpenId would feed Lark a wrong-scope
           // id (target's self-scoped) and the API would reject it. Skip + warn

--- a/src/utils/bot-routing.ts
+++ b/src/utils/bot-routing.ts
@@ -103,12 +103,38 @@ export function hasKnownBotMention(
 }
 
 /**
+ * Blank out Markdown code spans/blocks so a bot name written *inside code* — an
+ * example command in backticks, a fenced snippet, a quoted `@Bot` in an
+ * explanation — is NOT mistaken for a real `@Bot` handoff by the prose
+ * auto-injection scanner (which would otherwise wake that bot). Only presence
+ * detection needs to be code-aware; positions are irrelevant, so each matched
+ * region collapses to a single space.
+ *
+ * Fenced blocks (```…```) are removed first so their triple-backtick fences
+ * aren't misread as inline runs; then balanced inline runs (`…`, ``…``) go.
+ * Unbalanced stray backticks are left as-is — harmless literal chars.
+ */
+export function stripCodeSpans(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/(`+)[\s\S]*?\1/g, ' ');
+}
+
+/**
  * Decide who a botmux-generated reply should @ in the footer.
  *
- * The footer is an implicit convenience for human readers. It must not wake a
+ * The footer's `发送给：@owner` is an implicit convenience for human readers —
+ * it is NOT the message's explicit @ targets (those come from --mention /
+ * --mention-back / prose @Name and are rendered separately). It must not wake a
  * bot: bot-to-bot routing should be explicit in the message body/--mention.
- * When the body already contains an explicit bot target, keep the footer on a
- * human owner if one exists; only bot recipients are suppressed.
+ *
+ * When the reply explicitly targets a known bot (a handoff), this default
+ * owner-courtesy ping is redundant noise, so it is suppressed entirely
+ * (`sendTo: undefined`). To also loop a human in on a handoff, the caller opts
+ * in explicitly via --mention-back / --mention <owner>, which land in
+ * `mentions[]` and render regardless of this function — i.e. owner-addressing
+ * is opt-IN for handoffs, not opt-out. Without an explicit bot target the
+ * default addressing (owner / oncall last-caller) is unchanged.
  */
 export function buildFooterAddressing(
   s: { ownerOpenId?: string; lastCallerOpenId?: string },
@@ -122,12 +148,19 @@ export function buildFooterAddressing(
   const botIds = opts.knownBotOpenIds ?? new Set<string>();
   const ownerHuman = owner && !botIds.has(owner) ? owner : undefined;
 
+  // Explicit bot handoff → drop the default owner/caller courtesy ping. The
+  // message is addressed to another bot; a human who should see it is added
+  // explicitly (--mention-back) and rides in mentions[], not here.
+  if (opts.hasExplicitBotMention) return { sendTo: undefined, cc: [] };
+
   if (!opts.isOncall) return { sendTo: ownerHuman, cc: [] };
 
   const caller = s.lastCallerOpenId ?? owner;
   const callerIsBot = !!caller && botIds.has(caller);
 
-  if (opts.hasExplicitBotMention || callerIsBot) {
+  // Oncall + last caller is a bot (but this reply itself has no explicit bot
+  // target) → fall back to the human owner rather than pinging the bot caller.
+  if (callerIsBot) {
     return { sendTo: ownerHuman, cc: [] };
   }
 

--- a/src/utils/bot-routing.ts
+++ b/src/utils/bot-routing.ts
@@ -110,13 +110,15 @@ export function hasKnownBotMention(
  * detection needs to be code-aware; positions are irrelevant, so each matched
  * region collapses to a single space.
  *
- * Fenced blocks (```…```) are removed first so their triple-backtick fences
- * aren't misread as inline runs; then balanced inline runs (`…`, ``…``) go.
- * Unbalanced stray backticks are left as-is — harmless literal chars.
+ * Fenced blocks (a run of ≥3 backticks or ≥3 tildes, closed by an equal-length
+ * run) are removed first so their fences aren't misread as inline runs; then
+ * balanced inline backtick runs (`…`, ``…``) go. `~~strike~~` (double tilde) is
+ * NOT a fence and is deliberately left intact — an @Bot inside strikethrough is
+ * still a real prose mention. Unbalanced stray backticks are harmless literals.
  */
 export function stripCodeSpans(text: string): string {
   return text
-    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/(`{3,}|~{3,})[\s\S]*?\1/g, ' ')
     .replace(/(`+)[\s\S]*?\1/g, ' ');
 }
 

--- a/test/bot-routing.test.ts
+++ b/test/bot-routing.test.ts
@@ -14,6 +14,7 @@ import {
   hasKnownBotMention,
   orderedFooterRecipients,
   pickBotEntryByName,
+  stripCodeSpans,
 } from '../src/utils/bot-routing.js';
 
 type Entry = { larkAppId: string; botName: string | null };
@@ -150,18 +151,20 @@ describe('buildFooterAddressing', () => {
     )).toEqual({ sendTo: 'ou_human_caller', cc: [] });
   });
 
-  it('falls back to the human owner when the body explicitly targets a bot', () => {
+  it('suppresses owner addressing in oncall when the body explicitly targets a bot', () => {
+    // Handoff to another bot: the default owner-courtesy ping is redundant noise
+    // and is dropped. A human is looped in only via explicit --mention-back.
     expect(buildFooterAddressing(
       { ownerOpenId: 'ou_owner', lastCallerOpenId: 'ou_claude_bot' },
       { isOncall: true, hasExplicitBotMention: true, knownBotOpenIds },
-    )).toEqual({ sendTo: 'ou_owner', cc: [] });
+    )).toEqual({ sendTo: undefined, cc: [] });
   });
 
-  it('keeps human owner footer outside oncall when explicitly targeting a bot', () => {
+  it('suppresses owner addressing outside oncall when explicitly targeting a bot', () => {
     expect(buildFooterAddressing(
       { ownerOpenId: 'ou_owner', lastCallerOpenId: 'ou_human_caller' },
       { isOncall: false, hasExplicitBotMention: true, knownBotOpenIds },
-    )).toEqual({ sendTo: 'ou_owner', cc: [] });
+    )).toEqual({ sendTo: undefined, cc: [] });
   });
 
   it('drops explicit-bot addressing when the owner is also a bot', () => {
@@ -233,5 +236,38 @@ describe('orderedFooterRecipients', () => {
 
   it('returns empty when nothing to address', () => {
     expect(orderedFooterRecipients({})).toEqual([]);
+  });
+});
+
+describe('stripCodeSpans', () => {
+  // The prose `@Bot` auto-injection scans this stripped copy: a bot name inside
+  // code must NOT survive (else it wakes a bot the model only quoted), while a
+  // name in real prose must survive so a genuine handoff still fires.
+  const hasAt = (s: string, name: string) =>
+    new RegExp(`@${name}(?![\\p{L}\\p{N}_])`, 'u').test(stripCodeSpans(s));
+
+  it('blanks an inline single-backtick code span', () => {
+    expect(hasAt('示例：`botmux send --mention @Codex …`', 'Codex')).toBe(false);
+  });
+
+  it('blanks a double-backtick code span', () => {
+    expect(hasAt('写成 ``@Codex`` 只是举例', 'Codex')).toBe(false);
+  });
+
+  it('blanks a fenced code block', () => {
+    expect(hasAt('```\nbotmux send --mention @Codex\n```', 'Codex')).toBe(false);
+  });
+
+  it('keeps a real prose @Bot so genuine handoffs still match', () => {
+    expect(hasAt('@Codex 你接手一下', 'Codex')).toBe(true);
+  });
+
+  it('keeps prose @Bot even when the same name is also quoted in code', () => {
+    // real handoff in prose + an incidental code mention → still detected
+    expect(hasAt('@Codex 看这条 `--mention @Codex`', 'Codex')).toBe(true);
+  });
+
+  it('leaves an unbalanced stray backtick harmless (name still in prose)', () => {
+    expect(hasAt('这里有个 ` 未闭合，@Codex 仍要 @', 'Codex')).toBe(true);
   });
 });

--- a/test/bot-routing.test.ts
+++ b/test/bot-routing.test.ts
@@ -258,6 +258,14 @@ describe('stripCodeSpans', () => {
     expect(hasAt('```\nbotmux send --mention @Codex\n```', 'Codex')).toBe(false);
   });
 
+  it('blanks a tilde-fenced code block', () => {
+    expect(hasAt('~~~\nbotmux send --mention @Codex\n~~~', 'Codex')).toBe(false);
+  });
+
+  it('keeps @Bot inside ~~strikethrough~~ (not a fence)', () => {
+    expect(hasAt('~~@Codex~~ 还是要 @', 'Codex')).toBe(true);
+  });
+
   it('keeps a real prose @Bot so genuine handoffs still match', () => {
     expect(hasAt('@Codex 你接手一下', 'Codex')).toBe(true);
   });


### PR DESCRIPTION
## 背景

话题群里让模型「@ 别的 bot 但别 @ 我」当前表达不出来：@ 别的 bot 必须用 `--mention`，而 `--mention` 不会抑制 footer 默认的「发送给：@owner」寻址；`--no-mention` 又与 `--mention` 互斥。根因是 `buildFooterAddressing` 非-oncall 分支**无条件** `sendTo=owner`，压根没读已经算好并传进来的 `hasExplicitBotMention` 信号（旧逻辑只在 oncall 分支用它，还用反了）。

顺带修一个同族 bug：正文里写在反引号 / 代码块中的 `@Bot`（举例、解释、引用命令）会被「正文 @Bot 自动注入」当成真 handoff 注入 `<at>`，误唤醒对方 bot（本次排查中实测触发过一次）。

## 改了什么

**1. `buildFooterAddressing`（治本，改默认行为）**
- `hasExplicitBotMention` 为真 → 直接 `sendTo=undefined`，oncall / 非-oncall 两分支统一。
- 即：话题回复只要显式 @ 了某个已知 bot（handoff），footer 不再默认捎上 `@owner`。
- 想把人一起捎上 → 显式 `--mention-back` / `--mention <owner>`（落在 `mentions[]`，不受本函数影响）。owner 寻址从 opt-out 变成 opt-in。
- 无显式 bot @ 时，默认寻址（owner / oncall last-caller）**完全不变**。

**2. `stripCodeSpans`（新增）**
- 正文 `@Bot` 自动注入前先剥离反引号 / 代码块，再做 `@名字` 扫描。
- 显式 `--mention` 不走此扫描，不受影响。

不加任何新 flag、不改 `--no-mention` 语义、不动 @ 硬门。

## 为什么不选另两个方案
- ✗ 放开 `--no-mention` + `--mention` 互斥：撕裂 `--no-mention` 语义，且默认没变、模型忘加还是带 owner。治标。
- ✗ 新增 `--no-owner` 标志：加开关面积，仍是 opt-in，模型不会稳定记得加。治标。

## 影响面
- `src/utils/bot-routing.ts`：`buildFooterAddressing` 行为 + 新增 `stripCodeSpans`
- `src/cli.ts`：send 正文 @Bot 扫描改用 `stripCodeSpans` 后的文本
- `test/bot-routing.test.ts`：反转两条旧断言（@bot 时保留 owner → 抑制 owner）+ 新增 `stripCodeSpans` 6 例

## 测试
- `pnpm build` 绿
- `vitest`：`bot-routing`(30) / `md-card`(52) / `message-parser`(69) 全绿

```
Test Files  3 passed (3)
     Tests  151 passed
```