### PR TITLE
feat(lark): 平台团队成员(人)在团队群 talk 免 /grant + 协作群 bot 首次接触腿

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -529,10 +529,12 @@ export async function enforceMessageQuotaForCliInput(
   messageId: string,
   anchor: string,
   senderUnionId?: string,
+  memberUnionId?: string,
 ): Promise<boolean> {
-  // senderUnionId 让 evaluateTalk 认出跨部署团队 peer bot（teamBot 腿）——否则
-  // 外部 bot 闸门放进来的团队 bot 消息会在这里被复查拦掉、静默丢弃。
-  const ev = evaluateTalk(larkAppId, chatId, senderOpenId, senderUnionId);
+  // senderUnionId（bot-locked）让 evaluateTalk 认出跨部署团队 peer bot（teamBot 腿）；
+  // memberUnionId（可为真人 union）走 teamMember 腿——否则外部闸门/群闸门放进来的
+  // 团队 bot 或团队成员消息会在这里复查处被静默丢弃（#332 端到端断点，人腿同理）。
+  const ev = evaluateTalk(larkAppId, chatId, senderOpenId, senderUnionId, memberUnionId);
   if (!ev.allowed) {
     logger.debug(`[quota:${larkAppId}] dropping message ${messageId.substring(0, 12)} from non-allowed sender ${senderOpenId?.substring(0, 12) ?? '?'}`);
     return false;
@@ -2331,8 +2333,10 @@ async function startInitialPassthroughSession(args: {
   parsed: LarkMessage;
   commandContent: string;
   senderOpenId?: string;
-  /** Sender's tenant-stable union_id (quota gate's teamBot leg). */
+  /** Bot-locked union_id (quota gate's teamBot leg — bot senders only). */
   senderUnionId?: string;
+  /** Raw sender union_id (quota gate's teamMember leg — may be a human). */
+  memberUnionId?: string;
   /** Ownership is the CALLER's call — required fields, no sender fallback.
    *  A bot-started cold start must pass undefined (mirrors the auto-create
    *  path): a foreign-bot owner makes daemon-generated footers wake that bot
@@ -2343,9 +2347,9 @@ async function startInitialPassthroughSession(args: {
 }): Promise<void> {
   const {
     larkAppId, chatId, chatType, scope, anchor, messageId, replyRootId,
-    parsed, commandContent, senderOpenId, senderUnionId, ownerOpenId, ownerUnionId, creatorOpenId,
+    parsed, commandContent, senderOpenId, senderUnionId, memberUnionId, ownerOpenId, ownerUnionId, creatorOpenId,
   } = args;
-  if (!await enforceMessageQuotaForCliInput(larkAppId, chatId, senderOpenId, messageId, anchor, senderUnionId)) {
+  if (!await enforceMessageQuotaForCliInput(larkAppId, chatId, senderOpenId, messageId, anchor, senderUnionId, memberUnionId)) {
     return;
   }
 
@@ -2571,6 +2575,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
           commandContent,
           senderOpenId,
           senderUnionId: teamTrustUnionId,
+          memberUnionId: senderUnionId, // 原始 union（人腿），不锁 bot
           // New-topic senders are humans here (mirrors the normal new-topic
           // spawn path, which assigns ownership unconditionally too).
           ownerOpenId: senderOpenId,
@@ -2655,7 +2660,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
     }
   }
 
-  if (!await enforceMessageQuotaForCliInput(larkAppId, chatId, senderOpenId, messageId, anchor, teamTrustUnionId)) {
+  if (!await enforceMessageQuotaForCliInput(larkAppId, chatId, senderOpenId, messageId, anchor, teamTrustUnionId, senderUnionId)) {
     return;
   }
 
@@ -3224,6 +3229,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
           commandContent,
           senderOpenId: threadSenderOpenId,
           senderUnionId: threadTeamTrustUnionId,
+          memberUnionId: threadSenderUnionId, // 原始 union（人腿），不锁 bot
           // Bot-started cold starts get no human owner (mirrors the auto-create
           // path) — see the ownership note on startInitialPassthroughSession.
           ownerOpenId: isForeignBot ? undefined : threadSenderOpenId,
@@ -3373,7 +3379,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
   }
 
   const quotaSenderOpenId = threadSenderOpenId;
-  if (!await enforceMessageQuotaForCliInput(larkAppId, ctxChatId ?? data?.message?.chat_id, quotaSenderOpenId, parsed.messageId, anchor, threadTeamTrustUnionId)) {
+  if (!await enforceMessageQuotaForCliInput(larkAppId, ctxChatId ?? data?.message?.chat_id, quotaSenderOpenId, parsed.messageId, anchor, threadTeamTrustUnionId, threadSenderUnionId)) {
     return;
   }
 

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -19,7 +19,7 @@ import { resolveNonsupportMessage, stripLeadingMentions, mentionOpenId } from '.
 import { recordObservedBots, listObservedBots } from '../../services/observed-bots-store.js';
 import { isTeamBot, recordTeamBot } from '../../services/team-bots-store.js';
 import { isTeamGroupChat } from '../../services/team-groups-store.js';
-import { isPlatformTeamBot, isPlatformHallChat } from '../../services/platform-team-store.js';
+import { isPlatformTeamBot, isPlatformHallChat, isPlatformTeamMemberChat } from '../../services/platform-team-store.js';
 import { recordBotUnionId, recordBotUnionIdFromMentions } from '../../services/bot-union-ids-store.js';
 import { getDocSubscription, listAllDocSubscriptions, type DocSubscription } from '../../services/doc-subs-store.js';
 import { getDocComment, isBotAuthoredReply, hasBotSentinel, commentTriggerAllowed } from './doc-comment.js';
@@ -927,6 +927,7 @@ export type TalkReason =
   | 'oncall'
   | 'peer'
   | 'teamBot'
+  | 'teamMember'
   | 'allowedChatGroup'
   | 'open'
   | 'chatGrant'
@@ -977,11 +978,25 @@ function hasConfiguredAllowlist(bot: ReturnType<typeof getBot>): boolean {
     || (bot.config.globalGrants?.length ?? 0) > 0;
 }
 
-export function canTalk(larkAppId: string, chatId: string | undefined, senderOpenId: string | undefined, senderUnionId?: string): boolean {
-  return evaluateTalk(larkAppId, chatId, senderOpenId, senderUnionId).allowed;
+export function canTalk(
+  larkAppId: string, chatId: string | undefined, senderOpenId: string | undefined,
+  senderUnionId?: string, memberUnionId?: string,
+): boolean {
+  return evaluateTalk(larkAppId, chatId, senderOpenId, senderUnionId, memberUnionId).allowed;
 }
 
-export function evaluateTalk(larkAppId: string, chatId: string | undefined, senderOpenId: string | undefined, senderUnionId?: string): TalkEvaluation {
+/**
+ * @param senderUnionId  BOT-trust union（teamBot 腿）——调用方必须已按 sender_type
+ *   锁定为「飞书盖章的 bot 发送方」（daemon 的 teamTrustUnionId），否则恶意成员把
+ *   真人 union 报成 bot 就能让真人继承 bot 信任。
+ * @param memberUnionId  发送方 union（teamMember 腿）——可为真人 union（未锁 bot）。
+ *   仅授 chat 作用域内的 talk、不授 operate，且要求 union 在该团队的成员名单里
+ *   （memberUnionIds 来自平台鉴权的团队成员，非机器自报），故喂真人 union 是安全的。
+ */
+export function evaluateTalk(
+  larkAppId: string, chatId: string | undefined, senderOpenId: string | undefined,
+  senderUnionId?: string, memberUnionId?: string,
+): TalkEvaluation {
   const bot = getBot(larkAppId);
   // allowedChatGroups 是"talk-open 的 chat_id 列表"：当前消息来自其中之一即放行（仅 canTalk）。
   // 成员关系隐含在"能在该 chat 发言"里 —— 退群者发不了言自动失权，新人进群即生效，无需成员快照。
@@ -1005,6 +1020,12 @@ export function evaluateTalk(larkAppId: string, chatId: string | undefined, send
   // 稳定 union_id（bot 专属，人不会进这两张表），不看 chatId，不授 operate。
   if (senderUnionId && (isTeamBot(config.session.dataDir, senderUnionId) || isPlatformTeamBot(config.session.dataDir, senderUnionId))) {
     return { allowed: true, reason: 'teamBot' };
+  }
+  // 平台团队成员（人）：发送者 union_id 是本群所属平台团队的成员 → talk 免 grant。
+  // 严格 chat 作用域（isPlatformTeamMemberChat 要求成员与群在同一团队），只放 talk：
+  // canOperate 不引这一腿，/restart 等仍限 allowedUsers。滕鹏飞在团队群里 @ bot 即免卡。
+  if (memberUnionId && isPlatformTeamMemberChat(config.session.dataDir, chatId, memberUnionId)) {
+    return { allowed: true, reason: 'teamMember' };
   }
   if (chatId && bot.config.allowedChatGroups?.includes(chatId)) return { allowed: true, reason: 'allowedChatGroup' };
 
@@ -1093,10 +1114,11 @@ async function maybeSendGrantRequestCard(
  * - 'ignore'      -> not addressed to bot at all
  */
 export async function checkGroupMessageAccess(
-  larkAppId: string, message: any, chatId: string, senderOpenId: string | undefined,
+  larkAppId: string, message: any, chatId: string, senderOpenId: string | undefined, memberUnionId?: string,
 ): Promise<'allowed' | 'not_allowed' | 'ignore'> {
   const mentioned = isBotMentioned(larkAppId, message, senderOpenId);
-  const isAllowed = canTalk(larkAppId, chatId, senderOpenId);
+  // 群消息访问检查只在人路径调用，union 走 memberUnionId 腿（不进 bot-trust）。
+  const isAllowed = canTalk(larkAppId, chatId, senderOpenId, undefined, memberUnionId);
 
   logger.debug(`Check group message access: mentioned=${mentioned}, isAllowed=${isAllowed}`);
   if (mentioned) {
@@ -1822,13 +1844,17 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
         }
 
         const senderOpenId = sender?.sender_id?.open_id as string | undefined;
+        // 人的 union_id：平台团队成员 talk-免grant 腿（isPlatformTeamMemberChat）要用。
+        const humanSenderUnionId = sender?.sender_id?.union_id as string | undefined;
         // defaultOncall 自动绑定必须在 canTalk 权限判断前完成，否则已开 defaultOncall
         // 的群首次 @bot 时 oncallChats 中还没有该 chat → evaluateTalk 判无权限 → 误弹
         // 自助授权申请卡。ensureDefaultOncallBound 本身带 fast-path 短路且 idempotent。
         await ensureDefaultOncallBound(larkAppId, chatId, chatType).catch(err =>
           logger.warn(`[oncall:${larkAppId}] pre-permission auto-bind failed for ${chatId.substring(0, 12)}: ${err}`),
         );
-        const isAllowed = canTalk(larkAppId, chatId, senderOpenId);
+        // 人的路径（bot 发送方已在上面的分支 return）：union 走 memberUnionId 腿，
+        // 不进 bot-trust 腿——teamBot 只认 bot-locked union。
+        const isAllowed = canTalk(larkAppId, chatId, senderOpenId, undefined, humanSenderUnionId);
 
         // /introduce — collaboration handshake. Intercept before any routing
         // so the command never reaches a CLI session (each @ed bot's daemon
@@ -2068,7 +2094,7 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
             || (isAllowed && mentionMode === 'topic' && ownsSession && !!message.thread_id)
             || (ownsSession && isAllowed && !!stats && stats.userCount <= 1 && stats.botCount <= 1);
           if (!relax) {
-            const access = await checkGroupMessageAccess(larkAppId, message, chatId, senderOpenId);
+            const access = await checkGroupMessageAccess(larkAppId, message, chatId, senderOpenId, humanSenderUnionId);
             if (access === 'not_allowed') {
               // 入口 A：无权限者 @bot → 弹授权申请卡（@owner），代替「无操作权限」。
               // 覆盖 ownsSession 真假两种情况，但绝不把该消息喂进已有 session。

--- a/src/services/platform-team-store.ts
+++ b/src/services/platform-team-store.ts
@@ -45,6 +45,9 @@ export interface PlatformTeamSyncTeam {
   /** Team-assembled group chats (机器人大厅 first) — trusted like 拉群 groups. */
   groupChatIds: string[];
   bots: PlatformTeamBot[];
+  /** Team members' (people's) union_ids — the human talk-免grant leg: a member
+   *  is trusted to TALK (never operate) inside this team's group chats. */
+  memberUnionIds: string[];
 }
 
 export interface PlatformTeamSyncPayload {
@@ -93,7 +96,10 @@ function sanitizeTeam(raw: unknown): PlatformTeamSyncTeam | null {
       bots.push({ appId, unionId: unionId || undefined, name });
     }
   }
-  return { teamId, teamName, groupChatIds, bots };
+  const memberUnionIds = Array.isArray(t.memberUnionIds)
+    ? t.memberUnionIds.filter((u): u is string => typeof u === 'string' && !!u.trim()).map((u) => u.trim())
+    : [];
+  return { teamId, teamName, groupChatIds, bots, memberUnionIds };
 }
 
 /**
@@ -156,6 +162,28 @@ export function isPlatformTeamBot(dataDir: string, unionId: string | undefined):
   if (!data) return false;
   for (const t of data.teams) {
     for (const b of t.bots) if (b.unionId === id) return true;
+  }
+  return false;
+}
+
+/** Is `unionId` a HUMAN member of a platform team AND is `chatId` one of that
+ *  team's group chats? The talk-免grant leg for people: a teammate speaking in
+ *  the team's own group is trusted to TALK without /grant — but scoped to those
+ *  groups (not everywhere), and TALK only (operate stays allowedUsers-gated, the
+ *  caller must never route this predicate into canOperate). Both conditions must
+ *  hold on the SAME team so cross-team leakage is impossible. */
+export function isPlatformTeamMemberChat(
+  dataDir: string,
+  chatId: string | undefined,
+  unionId: string | undefined,
+): boolean {
+  const cid = (chatId ?? '').trim();
+  const uid = (unionId ?? '').trim();
+  if (!cid || !uid) return false;
+  const data = readFile(dataDir);
+  if (!data) return false;
+  for (const t of data.teams) {
+    if (t.memberUnionIds.includes(uid) && t.groupChatIds.includes(cid)) return true;
   }
   return false;
 }

--- a/test/platform-team-store.test.ts
+++ b/test/platform-team-store.test.ts
@@ -13,6 +13,7 @@ import {
   getPlatformTeamSyncRev,
   isPlatformTeamBot,
   isPlatformHallChat,
+  isPlatformTeamMemberChat,
   listPlatformTeams,
   PLATFORM_TEAM_PREFIX,
 } from '../src/services/platform-team-store.js';
@@ -22,8 +23,12 @@ let dataDir: string;
 beforeEach(() => { dataDir = mkdtempSync(join(tmpdir(), 'botmux-pfteam-')); });
 
 const payload = (rev: string, teams: unknown[]) => ({ rev, teams });
-const team = (teamId: string, chatIds: string[], bots: Array<{ appId: string; unionId?: string }>) =>
-  ({ teamId, teamName: teamId, groupChatIds: chatIds, bots });
+const team = (
+  teamId: string,
+  chatIds: string[],
+  bots: Array<{ appId: string; unionId?: string }>,
+  memberUnionIds: string[] = [],
+) => ({ teamId, teamName: teamId, groupChatIds: chatIds, bots, memberUnionIds });
 
 describe('applyPlatformTeamSync', () => {
   it('persists rev + teams and answers the roster predicate', () => {
@@ -81,6 +86,27 @@ describe('applyPlatformTeamSync', () => {
     // 团队消失后不再命中（follow membership，无残留信任面）
     applyPlatformTeamSync(dataDir, payload('rev2', []));
     expect(isPlatformHallChat(dataDir, 'oc_hall_a')).toBe(false);
+  });
+
+  it('isPlatformTeamMemberChat: member in a team group → true; scoped to same team, talk-only', () => {
+    applyPlatformTeamSync(dataDir, payload('rev1', [
+      team('t1', ['oc_hall1', 'oc_group1'], [{ appId: 'cli_a', unionId: 'on_bot' }], ['on_alice', 'on_bob']),
+      team('t2', ['oc_hall2'], [{ appId: 'cli_b', unionId: 'on_bot2' }], ['on_carol']),
+    ]));
+    // 成员在本团队的群里（大厅或协作群）→ true
+    expect(isPlatformTeamMemberChat(dataDir, 'oc_hall1', 'on_alice')).toBe(true);
+    expect(isPlatformTeamMemberChat(dataDir, 'oc_group1', 'on_bob')).toBe(true);
+    // 跨团队不泄漏：t2 成员在 t1 群里 → false；t1 成员在 t2 群里 → false
+    expect(isPlatformTeamMemberChat(dataDir, 'oc_hall1', 'on_carol')).toBe(false);
+    expect(isPlatformTeamMemberChat(dataDir, 'oc_hall2', 'on_alice')).toBe(false);
+    // 非成员 union、非团队群、空值 → false
+    expect(isPlatformTeamMemberChat(dataDir, 'oc_hall1', 'on_bot')).toBe(false); // bot 不是 member
+    expect(isPlatformTeamMemberChat(dataDir, 'oc_other', 'on_alice')).toBe(false);
+    expect(isPlatformTeamMemberChat(dataDir, '', 'on_alice')).toBe(false);
+    expect(isPlatformTeamMemberChat(dataDir, 'oc_hall1', undefined)).toBe(false);
+    // 团队消失 → 不再命中
+    applyPlatformTeamSync(dataDir, payload('rev2', []));
+    expect(isPlatformTeamMemberChat(dataDir, 'oc_hall1', 'on_alice')).toBe(false);
   });
 
   it('rejects a payload without rev and sanitizes malformed teams', () => {

--- a/test/platform-team-trust.test.ts
+++ b/test/platform-team-trust.test.ts
@@ -32,8 +32,9 @@ function seedPlatformTeam(): void {
   applyPlatformTeamSync(dataDir, {
     rev: 'r1',
     teams: [{
-      teamId: 't1', teamName: 'T1', groupChatIds: ['oc_hall'],
+      teamId: 't1', teamName: 'T1', groupChatIds: ['oc_hall', 'oc_group'],
       bots: [{ appId: 'cli_peer', unionId: 'on_peer', name: 'Peer' }],
+      memberUnionIds: ['on_teammate'],
     }],
   });
 }
@@ -78,5 +79,33 @@ describe('evaluateTalk teamBot leg (quota gate end-to-end hole fix)', () => {
   it('still denies unknown senders without union_id backing', () => {
     expect(evaluateTalk('pf1', 'oc_random', 'ou_x', 'on_unknown').allowed).toBe(false);
     expect(evaluateTalk('pf1', 'oc_random', 'ou_x').allowed).toBe(false);
+  });
+});
+
+describe('evaluateTalk teamMember leg (human 免grant, talk-only, chat-scoped)', () => {
+  it('allows a team member (human) TALK inside a team group via memberUnionId', () => {
+    seedPlatformTeam();
+    // 人的 union 走第 5 参 memberUnionId，不进 bot-trust（第 4 参）
+    const ev = evaluateTalk('pf1', 'oc_group', 'ou_tp', undefined, 'on_teammate');
+    expect(ev.allowed).toBe(true);
+    expect(ev.reason).toBe('teamMember');
+  });
+
+  it('is chat-scoped: same member NOT allowed outside the team groups', () => {
+    seedPlatformTeam();
+    expect(evaluateTalk('pf1', 'oc_random', 'ou_tp', undefined, 'on_teammate').allowed).toBe(false);
+  });
+
+  it('member union in the bot-trust slot must NOT grant operate (talk-only leg)', () => {
+    seedPlatformTeam();
+    // 就算把成员 union 塞进 bot-trust 参，canOperate 也不认（不是 bot、不是 memberleg）
+    expect(canOperate('pf1', 'oc_group', 'ou_tp', 'on_teammate')).toBe(false);
+  });
+
+  it('a member union fed into the bot-trust slot does NOT fire teamBot', () => {
+    seedPlatformTeam();
+    // 第 4 参是 bot-locked：喂成员 union 进去不应命中 teamBot（它不在 bots roster）
+    const ev = evaluateTalk('pf1', 'oc_random', 'ou_tp', 'on_teammate');
+    expect(ev.allowed).toBe(false);
   });
 });


### PR DESCRIPTION
## 背景
双方 botmux 都更新到最新 master 后，平台拉的新群里 **bot 和人仍要 /grant**（申晗实测截图）。定位到两个独立缺口：

1. **bot 弹卡**：代码注释说「平台拉的团队群经 platform: 前缀镜像进受信群清单」，但平台侧 team-sync 的 groupChatIds **只下发大厅、从未下发协作群**，所以「团队群内 bot 首次接触免 grant」这条腿在平台拉的群里一直空转（全靠 union_id roster 腿硬扛，又被建群→互@的 ~30s 竞态窗口打中）。
2. **人弹卡**：整个信任体系只下发 bot 的 union_id roster，**团队成员（人）的身份从未下发**，evaluateTalk 没有「平台团队成员」这条腿——非 allowedUsers 的队友走到哪都要 grant。这是从第一天就缺的功能。

平台侧（已直推 master，配套）：`/api/groups/create` 记协作群进团队 groupChatIds、下发 memberUnionIds、团队变更主动推送消竞态。本 PR 是 daemon 侧。

## 改动
- **evaluateTalk 新增 teamMember 腿**：发送者 union_id 是本群所属平台团队的成员（`isPlatformTeamMemberChat`：成员与群必须同团队）→ talk 免 grant。严格 **chat 作用域**（不是全局）、**talk-only**（canOperate 不引这一腿，/restart/终端写入等仍限 allowedUsers）。
- **安全不变量（重点看这里）**：evaluateTalk/canTalk 拆成两个 union 入参——`senderUnionId` 走 teamBot 腿（调用方必须已按 sender_type 锁定为 bot 发送方），`memberUnionId` 走 teamMember 腿（可为真人 union）。**真人 union 绝不进 bot-trust 腿**，堵住「恶意成员把真人 union_id 报成自家 bot 骗取 talk+operate」——与既有 teamTrustUnionId 守卫同一结构。
- **端到端（#332 同类）**：`enforceMessageQuotaForCliInput` 透传 memberUnionId（原始 union），否则人的团队成员消息会在配额复查处被 evaluateTalk 静默丢弃。三个调用点（初始 passthrough / 普通 / thread）都透传。
- **协作群 bot 首次接触腿**：本就靠 `isTeamGroupChat`（team-sync 镜像的 groupChatIds），平台这次真正下发协作群后自动生效，daemon 零改动。
- platform-team-store：sanitize/落盘 memberUnionIds + `isPlatformTeamMemberChat` 谓词。

## 验证
- 新增 8 条单测：teamMember 腿的 chat 作用域、talk-only、跨团队不泄漏、成员 union 塞进 bot-trust 槽不误命中 teamBot/operate；`isPlatformTeamMemberChat` 边界。
- platform-team-store / platform-team-trust / bot-union-ids 全绿（23 条）；tsc + pnpm build 绿。

## Review 关注点
1. 两个 union 入参的拆分是否严密——真人 union 有没有任何路径漏进 teamBot/canOperate。
2. 三个 quota 调用点透传的 memberUnionId 是否都是「原始 union」而非 bot-locked。
3. teamMember 腿的 chat 作用域是否可能跨团队泄漏。