### PR TITLE
fix(upgrade): 固定 npm 更新执行目录

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,6 +67,7 @@ import { firstPositional } from './cli/arg-utils.js';
 import { dispatchPrimaryMessage, findStdinAliasAttachment, sendFileAttachments } from './cli/send-dispatch.js';
 import { buildPm2SpawnCommand } from './cli/pm2-command.js';
 import { callDashboard, type DashboardEndpoint, type DashboardResult } from './cli/dashboard-endpoint.js';
+import { npmGlobalUpdateCwd } from './core/maintenance.js';
 import { loadDashboardSecret } from './dashboard/auth.js';
 import { rejectLikelyWindowsStdinMojibake, decodeStdinBytes } from './cli/stdin-encoding.js';
 import {
@@ -2182,7 +2183,7 @@ function cmdStatus(): void {
 function cmdUpgrade(): void {
   console.log('🔄 升级中...');
   try {
-    execSync('npm install -g botmux@latest', { stdio: 'inherit' });
+    execSync('npm install -g botmux@latest', { cwd: npmGlobalUpdateCwd(), stdio: 'inherit' });
     console.log('\n✅ 升级完成。运行 botmux restart 以应用更新。');
   } catch {
     console.error('❌ 升级失败，请手动运行: npm install -g botmux@latest');

--- a/src/core/maintenance.ts
+++ b/src/core/maintenance.ts
@@ -144,6 +144,11 @@ export function maintenanceRestartLogPath(): string {
   return join(homedir(), '.botmux', 'logs', 'maintenance-restart.log');
 }
 
+/** Stable cwd for global npm updates; avoids inheriting a deleted daemon cwd. */
+export function npmGlobalUpdateCwd(): string {
+  return homedir();
+}
+
 /**
  * Cross-process lock target that serializes `npm install -g botmux@latest`
  * between the scheduled auto-update (this daemon process) and a
@@ -235,7 +240,7 @@ function productionDeps(): MaintenanceDeps {
       // timeout fast so the tick logs it and slips to the next day (the manual
       // update is already bumping to latest anyway).
       withFileLockSync(npmGlobalUpdateLockTarget(), () => {
-        execSync('npm install -g botmux@latest', { stdio: 'inherit' });
+        execSync('npm install -g botmux@latest', { cwd: npmGlobalUpdateCwd(), stdio: 'inherit' });
       }, { maxWaitMs: 500 });
     },
     writeIntent: (intent) => writeRestartIntent(intent),

--- a/src/core/maintenance.ts
+++ b/src/core/maintenance.ts
@@ -144,7 +144,14 @@ export function maintenanceRestartLogPath(): string {
   return join(homedir(), '.botmux', 'logs', 'maintenance-restart.log');
 }
 
-/** Stable cwd for global npm updates; avoids inheriting a deleted daemon cwd. */
+/**
+ * Stable cwd (HOME) for spawns that must not inherit a possibly-deleted cwd.
+ * A global npm update replaces the botmux package dir, so any process whose cwd
+ * points there (notably the dashboard, started by pm2 with `cwd: PKG_ROOT`) is
+ * left holding a deleted directory. Both the `npm install -g` child and the
+ * detached restart driver spawned afterwards would then die at startup reading
+ * cwd (`uv_cwd`/ENOENT). Pinning them to HOME sidesteps that entirely.
+ */
 export function npmGlobalUpdateCwd(): string {
   return homedir();
 }
@@ -213,6 +220,10 @@ export function spawnDetachedRestart(reason: string): void {
     detached: true,
     stdio: fd !== undefined ? ['ignore', fd, fd] : 'ignore',
     env: process.env,
+    // Run from HOME, not the caller's cwd: the dashboard (cwd: PKG_ROOT) triggers
+    // this right after a global npm update replaced that dir, so inheriting it
+    // would start the restart driver in a deleted directory. See npmGlobalUpdateCwd.
+    cwd: npmGlobalUpdateCwd(),
   });
   // A detached child's 'error' (e.g. spawn ENOENT) would otherwise throw
   // unhandled and crash this process — log it instead.

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -49,7 +49,7 @@ import { isLocalDevInstall, botmuxVersion, botmuxCliEntry } from './utils/instal
 import { checkNode, detectBotmuxInstalls, resolveCurrentVersion } from './utils/install-diagnostics.js';
 import { fetchLatestVersion, fetchReleasesSince, isNewerVersion, type ChangelogResult } from './core/update-check.js';
 import { GITHUB_REPO } from './core/restart-report.js';
-import { spawnDetachedRestart, npmGlobalUpdateLockTarget } from './core/maintenance.js';
+import { spawnDetachedRestart, npmGlobalUpdateLockTarget, npmGlobalUpdateCwd } from './core/maintenance.js';
 import { writeRestartIntent } from './services/restart-intent-store.js';
 import { withFileLock } from './utils/file-lock.js';
 import { spawn } from 'node:child_process';
@@ -422,6 +422,7 @@ async function cachedChangelog(current: string, now = Date.now()): Promise<Chang
 function runNpmInstallLatest(): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const child = spawn('npm', ['install', '-g', 'botmux@latest'], {
+      cwd: npmGlobalUpdateCwd(),
       env: process.env,
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: process.platform === 'win32', // resolve npm.cmd on Windows

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -235,6 +235,10 @@ function spawnStartBotLive(appId: string): Promise<{ ok: boolean; message?: stri
       const child = spawn(process.execPath, [botmuxCliEntry(), 'start-bot', appId, '--json'], {
         stdio: ['ignore', 'pipe', 'pipe'],
         env: process.env,
+        // Run from HOME, not the dashboard's cwd (pm2 `cwd: PKG_ROOT`): a global
+        // npm update replaces that dir, so a still-running dashboard would spawn
+        // start-bot in a deleted directory (uv_cwd/ENOENT). See npmGlobalUpdateCwd.
+        cwd: npmGlobalUpdateCwd(),
       });
       const timer = setTimeout(() => {
         try { child.kill('SIGKILL'); } catch { /* already gone */ }

--- a/test/maintenance.test.ts
+++ b/test/maintenance.test.ts
@@ -8,6 +8,7 @@ import {
   writeMaintenanceStateTo,
   buildRestartLauncher,
   maintenanceRestartLogPath,
+  npmGlobalUpdateCwd,
   type MaintenanceDeps,
   type MaintenanceState,
 } from '../src/core/maintenance.js';
@@ -167,6 +168,14 @@ describe('maintenanceRestartLogPath', () => {
   it('points at ~/.botmux/logs/maintenance-restart.log', () => {
     vi.stubEnv('HOME', '/home/bot');
     expect(maintenanceRestartLogPath()).toBe('/home/bot/.botmux/logs/maintenance-restart.log');
+  });
+});
+
+describe('npmGlobalUpdateCwd', () => {
+  afterEach(() => vi.unstubAllEnvs());
+  it('runs npm global updates from HOME instead of inheriting the process cwd', () => {
+    vi.stubEnv('HOME', '/home/bot');
+    expect(npmGlobalUpdateCwd()).toBe('/home/bot');
   });
 });
 


### PR DESCRIPTION
## 背景 / 动机

手动更新、定时维护更新和 `botmux upgrade` 都会执行 `npm install -g botmux@latest`。这些入口此前会继承当前进程的 cwd；如果 cwd 在 npm 启动或安装过程中失效，npm 会因为读取当前目录失败而退出，常见报错是 `uv_cwd` / `ENOENT`。

一个可稳定触发的路径是 npm-global 部署下的 dashboard 自更新：

1. dashboard 进程从当前 botmux 全局包目录启动，cwd 指向 `npm root -g` 下的 `botmux` 包目录。
2. botmux 已经被更新过一次，但 dashboard 进程尚未重启，仍然持有旧包目录作为 cwd。
3. npm 更新会删除/替换旧的全局包目录；运行中的 dashboard 仍然可服务页面，但它的 cwd 已经变成失效目录。
4. 再从 dashboard 触发“更新到最新版”时，更新子进程继承这个失效 cwd，npm 启动阶段读取 cwd 即失败。

也就是说，用户不需要手动删除任何目录；botmux 自更新替换全局包目录本身就可能制造这个失效 cwd。即使某些入口当前的 cwd 恰好安全，升级逻辑也不应该依赖调用者或 daemon 当前所在目录仍然存在。

## 改动

- 新增 `npmGlobalUpdateCwd()`，统一把全局 npm 更新的 cwd 固定到用户 HOME。
- dashboard 手动更新、maintenance 自动更新和 CLI `upgrade` 共用该 cwd，避免继承已失效目录。
- 增加单测覆盖该 cwd 选择。

## 测试覆盖

新增测试覆盖全局 npm 更新必须从 HOME 启动，而不是继承当前进程 cwd。

## 验证

- `pnpm vitest run test/maintenance.test.ts`
- `pnpm build`
- `git diff --check`

## 影响范围

只影响 botmux 自身升级时启动 npm 的工作目录；不改变安装命令、锁逻辑、重启流程或用户配置。