### PR TITLE
fix(omp): submit prompts through stdin

### DIFF
--- a/src/adapters/cli/oh-my-pi.ts
+++ b/src/adapters/cli/oh-my-pi.ts
@@ -13,8 +13,11 @@ export function createOhMyPiAdapter(pathOverride?: string): CliAdapter {
     resolvedBin: bin,
 
     // oh-my-pi has no --session-id; sessions are managed internally.
-    // buildResumeCommand handles resume separately.
-    buildArgs({ initialPrompt, model, workingDir, disableCliBypass }) {
+    // buildResumeCommand handles resume separately. Do NOT pass Lark prompts
+    // as positional launch args: OMP deposits those in the TUI composer but
+    // does not auto-submit them. Route prompts through writeInput, where botmux
+    // controls the final submit key.
+    buildArgs({ model, workingDir, disableCliBypass }) {
       const args = [
         '--tools', 'read,bash,edit,write,browser,web_search,ast_grep,ast_edit,lsp,debug,find,eval,search,task,ask',
         '--no-title',
@@ -24,9 +27,12 @@ export function createOhMyPiAdapter(pathOverride?: string): CliAdapter {
       }
       if (model?.trim()) args.push('--model', model.trim());
       if (workingDir) args.push('--cwd', workingDir);
-      if (initialPrompt) args.push(initialPrompt);
       return args;
     },
+
+    // OMP positional prompts are not an auto-submit channel; stdin injection is
+    // the reliable path.
+    passesInitialPromptViaArgs: false,
 
     // --continue resumes the latest local session.  No precise session-id
     // mapping exists (gemini/opencode share this limitation), so this is
@@ -35,17 +41,19 @@ export function createOhMyPiAdapter(pathOverride?: string): CliAdapter {
       return 'omp --continue';
     },
 
-    passesInitialPromptViaArgs: true,
-
     async writeInput(pty: PtyHandle, content: string) {
-      if (pty.pasteText && pty.sendSpecialKeys) {
+      // OMP's editor submits on a plain LF (`\n`) in current releases; tmux's
+      // symbolic Enter / CR can leave the text sitting in the composer. Use LF
+      // for both the tmux paste path and raw PTY fallback so every dispatched
+      // Leader→OMP message is actually submitted, not just pasted.
+      if (pty.pasteText) {
         pty.pasteText(content);
         await delay(200);
-        pty.sendSpecialKeys('Enter');
+        pty.write('\n');
       } else {
         pty.write(`\x1b[200~${content}\x1b[201~`);
         await delay(1000);
-        pty.write('\r');
+        pty.write('\n');
       }
     },
 

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -42,7 +42,7 @@ import { createPiAdapter } from '../src/adapters/cli/pi.js';
 import { createCopilotAdapter } from '../src/adapters/cli/copilot.js';
 import { createOhMyPiAdapter } from '../src/adapters/cli/oh-my-pi.js';
 import { createKimiAdapter } from '../src/adapters/cli/kimi.js';
-import type { CliAdapter, CliId } from '../src/adapters/cli/types.js';
+import type { CliAdapter, CliId, PtyHandle } from '../src/adapters/cli/types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -707,8 +707,8 @@ describe('oh-my-pi buildArgs', () => {
     expect(args).toContain('--approval-mode');
     expect(args[args.indexOf('--approval-mode') + 1]).toBe('yolo');
     expect(args).toContain('--no-title');
-    expect(args.at(-1)).toBe('hello omp');
-    expect(adapter.passesInitialPromptViaArgs).toBe(true);
+    expect(args).not.toContain('hello omp');
+    expect(adapter.passesInitialPromptViaArgs).toBe(false);
     expect(adapter.altScreen).toBe(true);
   });
 
@@ -737,6 +737,38 @@ describe('oh-my-pi buildArgs', () => {
     const idx = args.indexOf('--cwd');
     expect(idx).toBeGreaterThanOrEqual(0);
     expect(args[idx + 1]).toBe('/repo/root');
+  });
+
+  it('submits pasted tmux input with LF instead of symbolic Enter', async () => {
+    const events: string[] = [];
+    const pty = {
+      write(data: string) { events.push(`write:${JSON.stringify(data)}`); },
+      resize() {},
+      onData() {},
+      onExit() {},
+      kill() {},
+      pasteText(text: string) { events.push(`paste:${text}`); },
+      sendSpecialKeys(...keys: string[]) { events.push(`keys:${keys.join(',')}`); },
+    } satisfies PtyHandle;
+
+    await adapter.writeInput(pty, 'review this');
+
+    expect(events).toEqual(['paste:review this', 'write:"\\n"']);
+  });
+
+  it('submits raw PTY input with bracketed paste and LF', async () => {
+    const events: string[] = [];
+    const pty = {
+      write(data: string) { events.push(data); },
+      resize() {},
+      onData() {},
+      onExit() {},
+      kill() {},
+    } satisfies PtyHandle;
+
+    await adapter.writeInput(pty, 'review this');
+
+    expect(events).toEqual(['\x1b[200~review this\x1b[201~', '\n']);
   });
 
   it('skillsDir points to ~/.omp/agent/skills', () => {


### PR DESCRIPTION
问题描述：我在飞书话题中使用多agent协作模式，发现leader bot 给 worker bot 发送消息后无响应。排查后发现是发送给worker bot(对应的agent是oh-my-pi)的消息，仅仅停留在输入窗口，没有发送出去。

Route OMP prompts through writeInput instead of positional launch args so botmux owns the submit key for both initial and follow-up messages. Use LF after paste because current OMP releases can leave CR/symbolic Enter in the composer.

Constraint: OMP positional prompt and symbolic Enter can deposit text without submitting

Rejected: Keep passesInitialPromptViaArgs for first turn | only fixes startup and leaves dispatched follow-ups wedged

Confidence: high

Scope-risk: narrow