### PR TITLE
fix(dashboard): 修改CLI选wrapper网关时回传agentSelectionKey，修复下拉高亮/静默剥离

### DIFF
--- a/src/dashboard/bot-payload.ts
+++ b/src/dashboard/bot-payload.ts
@@ -1,4 +1,5 @@
 import { defaultSummaryRangePrefs, summaryRangeFromLegacyContentTriggers } from '../services/summary-range-store.js';
+import { selectionKeyForBot } from '../setup/cli-selection.js';
 
 export interface DashboardBotDescriptor {
   larkAppId: string;
@@ -25,6 +26,10 @@ export function botDefaultsPayload(bot: DashboardBotDescriptor, j?: any, error?:
     ...(bot.cliId ? { cliId: bot.cliId } : {}),
     ...(bot.wrapperCli ? { wrapperCli: bot.wrapperCli } : {}),
     ...(bot.model ? { model: bot.model } : {}),
+    // 「修改 CLI」下拉的当前选中项（cliId+wrapperCli → 选择键），wrapper 网关形态
+    // （aiden×claude / ttadk×codex 等）据此才能高亮回对应选项，否则前端回落到裸
+    // cliId、丢失 wrapper 语义（重载后下拉复位、再保存会把 wrapper 剥掉）。
+    ...(bot.cliId ? { agentSelectionKey: selectionKeyForBot(bot.cliId, bot.wrapperCli) } : {}),
     online: true,
   };
   if (error) return { ...base, error };

--- a/test/dashboard-bot-payload.test.ts
+++ b/test/dashboard-bot-payload.test.ts
@@ -36,6 +36,37 @@ describe('dashboard bot payload helpers', () => {
     });
   });
 
+  it('derives agentSelectionKey from cliId + wrapperCli so the 修改CLI dropdown highlights wrapper gateways', () => {
+    // 裸 CLI：选择键 = cliId。
+    expect(botDefaultsPayload(
+      { larkAppId: 'app_a', botName: 'BotA', cliId: 'claude-code' },
+      { defaultOncall: { enabled: false } },
+    )).toMatchObject({ cliId: 'claude-code', agentSelectionKey: 'claude-code' });
+
+    // wrapper 网关：选择键 = 对应的 aiden×/ttadk×/cjadk× 选项键（而非裸 cliId），
+    // 否则前端下拉高亮回落到裸 cliId，重载后 wrapper 丢失、再保存被剥掉。
+    expect(botDefaultsPayload(
+      { larkAppId: 'app_a', botName: 'BotA', cliId: 'claude-code', wrapperCli: 'aiden x claude' },
+      { defaultOncall: { enabled: false } },
+    )).toMatchObject({
+      cliId: 'claude-code',
+      wrapperCli: 'aiden x claude',
+      agentSelectionKey: 'aiden-x-claude',
+    });
+    expect(botDefaultsPayload(
+      { larkAppId: 'app_a', botName: 'BotA', cliId: 'codex', wrapperCli: 'ttadk codex' },
+      { defaultOncall: { enabled: false } },
+    )).toMatchObject({ agentSelectionKey: 'ttadk-x-codex' });
+    expect(botDefaultsPayload(
+      { larkAppId: 'app_a', botName: 'BotA', cliId: 'codex', wrapperCli: 'cjadk codex' },
+      { defaultOncall: { enabled: false } },
+    )).toMatchObject({ agentSelectionKey: 'cjadk-x-codex' });
+
+    // 无 cliId（配置缺失）→ 不下发 agentSelectionKey，前端回落默认 claude-code。
+    expect(botDefaultsPayload({ larkAppId: 'app_a' }, {}))
+      .not.toHaveProperty('agentSelectionKey');
+  });
+
   it('passes through displayName / larkBotName and normalizes missing to null', () => {
     const daemon = { larkAppId: 'app_a', botName: '小助手', cliId: 'codex' };
     expect(botDefaultsPayload(daemon, { displayName: '小助手', larkBotName: 'Claude' })).toMatchObject({


### PR DESCRIPTION
## 问题

dashboard「Bot Defaults / 修改 CLI」下拉选 **wrapper 网关形态**（aiden×claude / ttadk×codex / cjadk×codex 等）时出现逻辑异常：

- wrapper bot 打开页面，下拉「当前选中项」高亮成**底层 CLI**（如 `aiden x claude` 显示成「Claude」）而非 wrapper 选项
- 重载后 wrapper 选择丢失；若原样再点保存，会把 wrapper **静默剥掉**

## 根因

daemon 端 `/api/bot-default-oncall` 本来已算好 `agentSelectionKey`（`selectionKeyForBot(cliId, wrapperCli)`，`dashboard-ipc-server.ts:1406`），但汇总 `/api/bots` 响应的 `botDefaultsPayload()`（`bot-payload.ts`）**漏传**该字段。前端 `agentSelectionKey(bot)` 拿不到它，回落到裸 `bot.cliId`，从而丢失 wrapper 语义。之前那版 payload 迁移 PR 没兼容 wrapper 形态。

## 改动

`src/dashboard/bot-payload.ts` 一处：payload 补 `agentSelectionKey = selectionKeyForBot(bot.cliId, bot.wrapperCli)`。直接由 `cliId+wrapperCli` 计算（不依赖 daemon 那份、错误路径也稳），单一事实源。

## 影响面

- 仅影响 dashboard「Bot Defaults / 修改 CLI」下拉的**当前选中项展示**
- 裸 CLI：选择键 == cliId，行为不变、无回归
- 纯 payload 字段补齐，不涉及跨平台 / 跨 CLI 适配器 / 跨后端 / 跨会话类型

## 测试验证

- `pnpm build` 绿
- 复刻前端下拉高亮逻辑做 before→after 对比（修复前 → 修复后）：

```
aiden x claude | Claude（claude-code）      → Aiden × Claude（aiden-x-claude）
ttadk codex    | Codex（codex）             → TTADK × Codex（ttadk-x-codex）
ttadk coco     | TRAE CLI（CoCo）（coco）    → TTADK × CoCo（ttadk-x-coco）
cjadk codex    | Codex（codex）             → CJADK × Codex（cjadk-x-codex）
claude-code    | Claude（claude-code）      → Claude（claude-code）  （裸 CLI 无回归）
```

- 相关单测 87/87 绿（`dashboard-bot-payload` / `cli-selection` / `dashboard-bot-onboarding`），新增 1 条回归用例锁死各 wrapper 网关的 `agentSelectionKey` 映射