### PR TITLE
feat(dashboard): 连中心化平台后 dashboard 链接附带本地 ip:port 兜底

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2221,6 +2221,8 @@ async function printDashboardHintWithRetry(): Promise<void> {
     last = await callDashboardEndpoint('/__cli/current');
     if (last.ok) {
       console.log(`   面板: botmux dashboard (${last.url})`);
+      // 走中心化平台链接时，附带本地直连兜底，平台异常也能直接 ip:port 访问。
+      if (last.localUrl) console.log(`   本地直连(平台异常时可用): ${last.localUrl}`);
       return;
     }
     // Terminal states — file-backed secret/token won't appear mid-poll, unlike
@@ -2250,7 +2252,9 @@ async function printDashboardHintWithRetry(): Promise<void> {
 async function cmdDashboard(): Promise<void> {
   const r = await callDashboardEndpoint('/__cli/rotate');
   if (r.ok) {
+    // 首行保持纯 URL（脚本/复制取第一行即可）；走中心化平台时再补一行本地直连兜底。
     console.log(r.url);
+    if (r.localUrl) console.log(`本地直连(平台异常时可用): ${r.localUrl}`);
     return;
   }
   const portFile = join(CONFIG_DIR, '.dashboard-port');

--- a/src/cli/dashboard-endpoint.ts
+++ b/src/cli/dashboard-endpoint.ts
@@ -40,7 +40,7 @@ export type DashboardFailReason =
   | 'wrong-service';
 
 export type DashboardResult =
-  | { ok: true; url: string }
+  | { ok: true; url: string; localUrl?: string }
   | { ok: false; reason: DashboardFailReason; detail?: string };
 
 type FetchImpl = typeof fetch;
@@ -127,9 +127,11 @@ export async function requestDashboardAt(opts: {
   }
   // reload-binding 不返回 url，200 即成功（仅用于「捅一下 daemon 重连」）
   if (path === '/__cli/reload-binding') return { ok: true, url: '' };
-  const body = await res.json().catch(() => ({})) as { url?: string };
+  const body = await res.json().catch(() => ({})) as { url?: string; localUrl?: string };
   if (!body.url) return { ok: false, reason: 'http-error', detail: 'malformed response (no url)' };
-  return { ok: true, url: body.url };
+  // localUrl is present only when the dashboard link routes through the central
+  // platform — a direct host:port fallback for when the platform is down.
+  return { ok: true, url: body.url, localUrl: body.localUrl };
 }
 
 /** A result that proves we actually reached the dashboard (vs. wrong port). */

--- a/src/core/dashboard-url.ts
+++ b/src/core/dashboard-url.ts
@@ -1,24 +1,52 @@
 import { platformMachineBaseUrl } from '../platform/binding.js';
 import { isRemoteAccessEnabled } from '../global-config.js';
 
+export interface DashboardUrls {
+  /**
+   * The link to show first: the central-platform machine subdomain when 远程访问
+   * is on and this host is bound, otherwise the local `http://<host>:<port>/`.
+   */
+  url: string;
+  /**
+   * The local `http://<host>:<port>/` direct link — populated ONLY when `url`
+   * routes through the central platform (i.e. differs from the local form).
+   * It's the escape hatch to reach the dashboard directly when the platform is
+   * down. When `url` is already local this is undefined (nothing to add).
+   */
+  localUrl?: string;
+}
+
 /**
- * Builds the public URL for the web dashboard, given a token.
+ * Builds the dashboard URL(s) for a token.
  *
  * When 远程访问 is enabled AND this machine is bound to the central platform, the
- * URL routes through the machine subdomain
+ * primary `url` routes through the machine subdomain
  * (`https://m-<machineId>.<platformHost>/?t=<token>`): the platform
  * reverse-proxies that subdomain to this host's local dashboard, which still
  * enforces the `?t=` token itself, so the link is reachable centrally with no
- * `:port`. When 远程访问 is off (or the machine isn't bound) the platform base is
- * null and we fall back to the local `http://<externalHost>:<port>/` form.
+ * `:port`. In that case `localUrl` additionally carries the local
+ * `http://<externalHost>:<port>/?t=<token>` form so callers can advertise a
+ * direct fallback for when the platform is unreachable. When 远程访问 is off (or
+ * the machine isn't bound) the primary `url` is already the local form and
+ * `localUrl` is left undefined.
  *
  * Mirrors buildTerminalUrl (terminal-url.ts) and publicWebhookUrl
  * (dashboard/connector-api.ts) so dashboard, terminal, and webhook links all
  * flip to the platform together under the single 远程访问 switch — instead of the
  * dashboard link being the one place that always stays local.
  */
-export function buildDashboardUrl(opts: { host: string; port: number | string; token?: string }): string {
+export function buildDashboardUrls(opts: { host: string; port: number | string; token?: string }): DashboardUrls {
+  const localOrigin = `http://${opts.host}:${opts.port}`;
   const platformBase = isRemoteAccessEnabled() ? platformMachineBaseUrl() : null;
-  const origin = platformBase ?? `http://${opts.host}:${opts.port}`;
-  return opts.token ? `${origin}/?t=${opts.token}` : `${origin}/`;
+  const primaryOrigin = platformBase ?? localOrigin;
+  const suffix = opts.token ? `/?t=${opts.token}` : '/';
+  return {
+    url: `${primaryOrigin}${suffix}`,
+    localUrl: platformBase ? `${localOrigin}${suffix}` : undefined,
+  };
+}
+
+/** Convenience: just the primary dashboard URL (see {@link buildDashboardUrls}). */
+export function buildDashboardUrl(opts: { host: string; port: number | string; token?: string }): string {
+  return buildDashboardUrls(opts).url;
 }

--- a/src/core/restart-report.ts
+++ b/src/core/restart-report.ts
@@ -21,6 +21,10 @@ export interface RestartReportInput {
   /** Unfinished sessions across all bots. */
   sessionCount: number;
   dashboardUrl?: string;
+  /** Local host:port direct link — set only when `dashboardUrl` routes through
+   *  the central platform, so the owner can still reach the dashboard if the
+   *  platform is down. */
+  dashboardLocalUrl?: string;
   /** kind==='update' only: the version delta + changelog body. */
   oldVersion?: string;
   newVersion?: string;
@@ -46,6 +50,7 @@ export function buildRestartReportText(input: RestartReportInput, locale?: Local
 
   lines.push(t('restart.unfinished_sessions', { count: input.sessionCount }, locale));
   if (input.dashboardUrl) lines.push(t('restart.dashboard', { url: input.dashboardUrl }, locale));
+  if (input.dashboardLocalUrl) lines.push(t('restart.dashboard_local', { url: input.dashboardLocalUrl }, locale));
 
   if (input.kind === 'update' && input.changelog && input.changelog.trim()) {
     lines.push('');
@@ -77,6 +82,9 @@ export interface RestartReportWiring {
   /** Owner to DM (bot-0's first resolved allowedUser); undefined → skip the DM. */
   ownerOpenId: string | undefined;
   dashboardUrl: string | undefined;
+  /** Local host:port direct fallback link (set only when dashboardUrl is a
+   *  central-platform link). */
+  dashboardLocalUrl?: string | undefined;
   /** Send the interactive card as a p2p DM to the owner. */
   sendCard: (openId: string, cardJson: string) => Promise<void>;
   now?: number;
@@ -108,6 +116,7 @@ export async function sendRestartReportIfPending(w: RestartReportWiring): Promis
     version,
     sessionCount,
     dashboardUrl: w.dashboardUrl,
+    dashboardLocalUrl: w.dashboardLocalUrl,
     oldVersion: intent.oldVersion,
     newVersion: intent.newVersion,
     changelog,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -9,7 +9,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 import { config, getDashboardExternalHost } from './config.js';
 import { repoPickerScanOptions } from './global-config.js';
-import { buildDashboardUrl } from './core/dashboard-url.js';
+import { buildDashboardUrls } from './core/dashboard-url.js';
 import { writeHeartbeat } from './core/daemon-heartbeat.js';
 import { botmuxWrapperFiles } from './core/botmux-wrapper.js';
 import { startMaintenance, stopMaintenance } from './core/maintenance.js';
@@ -3842,19 +3842,21 @@ function resolvePrimaryOwnerOpenId(larkAppId: string): string | undefined {
 /** Build the current dashboard URL (active token, not a rotation) from the
  *  dashboard process's persisted `.dashboard-port` / `.dashboard-token`. Falls
  *  back to a token-less base URL if the dashboard hasn't published a token yet. */
-function dashboardUrlForReport(): string | undefined {
+function dashboardUrlForReport(): { url?: string; localUrl?: string } {
   try {
     const dir = join(homedir(), '.botmux');
     const portFile = join(dir, '.dashboard-port');
     const tokenFile = join(dir, '.dashboard-token');
     const port = existsSync(portFile) ? readFileSync(portFile, 'utf8').trim() : String(config.dashboard.port);
     const tok = existsSync(tokenFile) ? readFileSync(tokenFile, 'utf8').trim() : '';
-    // buildDashboardUrl swaps in the central-platform machine subdomain when
+    // buildDashboardUrls swaps in the central-platform machine subdomain when
     // 远程访问 is on and this host is bound, so the restart-report DM links to the
-    // platform dashboard instead of an unreachable local host:port.
-    return buildDashboardUrl({ host: getDashboardExternalHost(), port, token: tok || undefined });
+    // platform dashboard instead of an unreachable local host:port. In that case
+    // localUrl carries the direct host:port fallback so the owner can still reach
+    // the dashboard if the platform is down.
+    return buildDashboardUrls({ host: getDashboardExternalHost(), port, token: tok || undefined });
   } catch {
-    return undefined;
+    return {};
   }
 }
 
@@ -4245,10 +4247,12 @@ export async function startDaemon(botIndex?: number): Promise<void> {
     // After an intentional restart, DM the owner a summary. Delayed a few
     // seconds so the dashboard process can publish its token first.
     setTimeout(() => {
+      const dash = dashboardUrlForReport();
       void sendRestartReportIfPending({
         primaryLarkAppId: cfg.larkAppId,
         ownerOpenId: resolvePrimaryOwnerOpenId(cfg.larkAppId),
-        dashboardUrl: dashboardUrlForReport(),
+        dashboardUrl: dash.url,
+        dashboardLocalUrl: dash.localUrl,
         sendCard: (openId, card) => sendUserMessage(cfg.larkAppId, openId, card, 'interactive').then(() => undefined),
         log: (m) => logger.info(`[restart-report] ${m}`),
       });

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -43,7 +43,7 @@ import {
 } from './setup/cli-selection.js';
 import { invalidWorkingDirs } from './utils/working-dir.js';
 import { invalidateGlobalConfigCache, mergeGlobalConfig, readGlobalConfig, type MaintenanceConfig, type RepoPickerMode, type WhiteboardConfig } from './global-config.js';
-import { buildDashboardUrl } from './core/dashboard-url.js';
+import { buildDashboardUrls, type DashboardUrls } from './core/dashboard-url.js';
 import { deleteWhiteboard, listWhiteboards, readWhiteboard, whiteboardEnabled } from './services/whiteboard-store.js';
 import { isLocalDevInstall, botmuxVersion, botmuxCliEntry } from './utils/install-info.js';
 import { checkNode, detectBotmuxInstalls, resolveCurrentVersion } from './utils/install-diagnostics.js';
@@ -868,11 +868,12 @@ function verifyCliRequest(req: IncomingMessage, pathname: string):
   return { ok: true };
 }
 
-/** Build the dashboard URL for a token, using the actually-bound port. Routes
- *  through the central-platform machine subdomain when 远程访问 is on and this
- *  host is bound (see buildDashboardUrl); falls back to the local host:port. */
-function dashboardUrlFor(token: string): string {
-  return buildDashboardUrl({ host: config.dashboard.externalHost, port: boundDashboardPort, token });
+/** Build the dashboard URL(s) for a token, using the actually-bound port. The
+ *  primary `url` routes through the central-platform machine subdomain when
+ *  远程访问 is on and this host is bound (see buildDashboardUrls); `localUrl`
+ *  carries the direct host:port fallback in that case (undefined otherwise). */
+function dashboardUrlsFor(token: string): DashboardUrls {
+  return buildDashboardUrls({ host: config.dashboard.externalHost, port: boundDashboardPort, token });
 }
 
 type SkillJobStatus = 'running' | 'succeeded' | 'failed';
@@ -1124,7 +1125,7 @@ const server = createServer(async (req, res) => {
       } catch (e) {
         logger.warn(`[dashboard] Failed to persist token to ${TOKEN_PATH}: ${(e as Error).message}`);
       }
-      return jsonRes(res, 200, { url: dashboardUrlFor(activeToken) });
+      return jsonRes(res, 200, dashboardUrlsFor(activeToken));
     }
 
     // CLI read current URL (HMAC + loopback only) — for the start/restart hint.
@@ -1135,7 +1136,7 @@ const server = createServer(async (req, res) => {
       const gate = verifyCliRequest(req, url.pathname);
       if (!gate.ok) return jsonRes(res, gate.status, gate.body);
       if (!activeToken) return jsonRes(res, 404, { error: 'no_active_token' });
-      return jsonRes(res, 200, { url: dashboardUrlFor(activeToken) });
+      return jsonRes(res, 200, dashboardUrlsFor(activeToken));
     }
 
     // CLI 通知绑定变化（HMAC + loopback）——`botmux bind` 写完绑定后捅一下，立即重连平台，

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1090,6 +1090,7 @@ export const messages: Record<string, string> = {
   'restart.version': 'Version: {version}',
   'restart.unfinished_sessions': 'Unfinished sessions: {count}',
   'restart.dashboard': 'Dashboard: {url}',
+  'restart.dashboard_local': 'Local direct (if the platform is down): {url}',
   'restart.changelog_label': 'What’s new:',
   'restart.changelog_link_fallback': 'Details: {url}',
   'restart.card_title': 'botmux maintenance notice',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -1093,6 +1093,7 @@ export const messages: Record<string, string> = {
   'restart.version': '版本：{version}',
   'restart.unfinished_sessions': '未结束会话：{count} 个',
   'restart.dashboard': 'Dashboard：{url}',
+  'restart.dashboard_local': '本地直连（平台异常时可用）：{url}',
   'restart.changelog_label': '更新内容：',
   'restart.changelog_link_fallback': '详情：{url}',
   'restart.card_title': 'botmux 维护通知',

--- a/src/platform/bind.ts
+++ b/src/platform/bind.ts
@@ -143,6 +143,8 @@ export async function cmdBind(args: string[]): Promise<void> {
     });
     if (cur.ok) {
       console.log(`  面板: ${cur.url}`);
+      // 附带本地直连兜底：中心化平台异常时仍可直接 ip:port 访问 dashboard。
+      if (cur.localUrl) console.log(`  本地直连(平台异常时可用): ${cur.localUrl}`);
     } else {
       console.log('  面板: 运行 `botmux dashboard` 获取中心化平台链接。');
     }

--- a/test/dashboard-endpoint.test.ts
+++ b/test/dashboard-endpoint.test.ts
@@ -127,6 +127,17 @@ describe('callDashboard', () => {
     expect(r).toEqual({ ok: true, url: 'http://host:7891/?t=fresh' });
   });
 
+  it('surfaces the dashboard-provided localUrl fallback (platform link case)', async () => {
+    setPort(7891);
+    // Dashboard returns both a platform primary URL and a local ip:port fallback.
+    const fetchImpl = (async () => new Response(
+      JSON.stringify({ url: 'https://m-x.example/?t=fresh', localUrl: 'http://10.0.0.1:7891/?t=fresh' }),
+      { status: 200 },
+    )) as unknown as typeof fetch;
+    const r = await callDashboard({ configDir: dir, defaultPort: 7891, path: '/__cli/rotate', fetchImpl });
+    expect(r).toEqual({ ok: true, url: 'https://m-x.example/?t=fresh', localUrl: 'http://10.0.0.1:7891/?t=fresh' });
+  });
+
   it('does NOT mislabel a daemon-IPC 404 as no-active-token; self-heals to the real dashboard', async () => {
     // Recorded port points at daemon IPC (the reported bug); real dashboard is 7901.
     setPort(7893);

--- a/test/dashboard-url.test.ts
+++ b/test/dashboard-url.test.ts
@@ -10,7 +10,7 @@ vi.mock('../src/platform/binding.js', () => ({
   platformMachineBaseUrl: vi.fn(() => null),
 }));
 
-import { buildDashboardUrl } from '../src/core/dashboard-url.js';
+import { buildDashboardUrl, buildDashboardUrls } from '../src/core/dashboard-url.js';
 import { isRemoteAccessEnabled } from '../src/global-config.js';
 import { platformMachineBaseUrl } from '../src/platform/binding.js';
 
@@ -63,5 +63,46 @@ describe('buildDashboardUrl', () => {
     expect(buildDashboardUrl({ host: '1.2.3.4', port: 7891 })).toBe(
       'https://m-deadbeef.botmux.example/',
     );
+  });
+});
+
+describe('buildDashboardUrls', () => {
+  beforeEach(() => {
+    setRemote(false);
+    setPlatform(null);
+  });
+
+  it('local-only: no localUrl fallback when the primary is already local', () => {
+    expect(buildDashboardUrls({ host: '1.2.3.4', port: 7891, token: 'abc' })).toEqual({
+      url: 'http://1.2.3.4:7891/?t=abc',
+      localUrl: undefined,
+    });
+  });
+
+  it('remote-on but unbound: stays local, still no fallback (primary is local)', () => {
+    setRemote(true);
+    setPlatform(null);
+    expect(buildDashboardUrls({ host: '1.2.3.4', port: 7891, token: 'abc' })).toEqual({
+      url: 'http://1.2.3.4:7891/?t=abc',
+      localUrl: undefined,
+    });
+  });
+
+  it('remote-on + bound: platform primary + local ip:port fallback (same token)', () => {
+    setRemote(true);
+    setPlatform('https://m-deadbeef.botmux.example');
+    expect(buildDashboardUrls({ host: '1.2.3.4', port: 7891, token: 'abc' })).toEqual({
+      url: 'https://m-deadbeef.botmux.example/?t=abc',
+      localUrl: 'http://1.2.3.4:7891/?t=abc',
+    });
+  });
+
+  it('remote-on + bound, token-less: both forms drop the token query', () => {
+    setRemote(true);
+    setPlatform('https://m-deadbeef.botmux.example');
+    expect(buildDashboardUrls({ host: '1.2.3.4', port: 7891 })).toEqual({
+      url: 'https://m-deadbeef.botmux.example/',
+      localUrl: 'http://1.2.3.4:7891/',
+    });
   });
 });

--- a/test/restart-report.test.ts
+++ b/test/restart-report.test.ts
@@ -49,6 +49,29 @@ describe('buildRestartReportText', () => {
     expect(md.toLowerCase()).not.toContain('changelog');
   });
 
+  it('adds a local ip:port fallback line when the dashboard link is a platform URL', () => {
+    const md = buildRestartReportText({
+      kind: 'manual',
+      version: '2.65.0',
+      sessionCount: 0,
+      dashboardUrl: 'https://m-deadbeef.example/?t=tok',
+      dashboardLocalUrl: 'http://10.0.0.1:7891/?t=tok',
+    });
+    expect(md).toContain('https://m-deadbeef.example/?t=tok'); // platform primary
+    expect(md).toContain('http://10.0.0.1:7891/?t=tok');       // local fallback
+  });
+
+  it('omits the local fallback line when there is no platform URL (local-only host)', () => {
+    const md = buildRestartReportText({
+      kind: 'manual',
+      version: '2.65.0',
+      sessionCount: 0,
+      dashboardUrl: 'http://10.0.0.1:7891/?t=tok',
+    });
+    // Only the single dashboard line — no separate "本地直连 / Local direct" line.
+    expect(md).not.toMatch(/本地直连|Local direct/);
+  });
+
   it('update restart: shows old→new and the changelog body', () => {
     const md = buildRestartReportText({
       kind: 'update',


### PR DESCRIPTION
## 改了什么
绑定中心化平台 + 开启「远程访问终端」后，dashboard/终端/webhook 链接会切成平台机器子域（`m-<id>.<平台域名>`）。此时若平台侧异常，展示出来的就只剩平台链接，用户无法回退到本机 `ip:port` 直连 dashboard。

本 PR 让**所有展示 dashboard 链接的地方**在走平台链接时，连带显示本地 `ip:port` 直连兜底。

## 实现
- `core/dashboard-url.ts`：新增 `buildDashboardUrls()` 返回 `{ url, localUrl }`。`url` 仍是「远程访问 ON 且已绑定 → 平台子域；否则本地 `host:port`」；`localUrl` 仅在 `url` 走平台时补上本地 `http://host:port` 直连（未绑定 / 远程访问 OFF 时 `url` 本就是本地，`localUrl=undefined` 不重复显示）。保留旧 `buildDashboardUrl()` 作兼容 wrapper。
- 四处链接展示全部覆盖：
  1. `botmux dashboard`（CLI）—— 首行仍是纯 URL（脚本/复制取第一行不变），追加本地直连行
  2. `botmux restart` / `start` 终端「面板:」提示 —— 追加本地直连行
  3. 飞书「botmux 维护通知」卡片 —— 新增「本地直连（平台异常时可用）」行（i18n zh+en）
  4. `botmux bind` 绑定成功提示 —— 同步追加（同属"连上平台展示链接"场景）
- dashboard 进程 `/__cli/rotate`、`/__cli/current` 响应体从 `{url}` 扩成 `{url, localUrl}`（`localUrl` 为 undefined 时 JSON 自动省略，旧客户端无感）；CLI loopback 客户端 `DashboardResult` 透传 `localUrl`。

## 影响面
- 公共层：`core/dashboard-url.ts`、`dashboard.ts`、`cli.ts`、`daemon.ts`、`platform/bind.ts`、`cli/dashboard-endpoint.ts`、i18n。
- 跨 CLI / 后端：这几处均为 daemon 级、与具体 CLI / 后端无关，无适配器改动。
- 响应体扩字段为纯增量，唯一消费者是 `dashboard-endpoint.ts` 客户端，已同步。

## 验证
- `pnpm build` 通过
- 新增/更新单测；`dashboard-url` / `restart-report` / `dashboard-endpoint` / `dashboard-i18n-c5` / `platform-bind-ip-family` 5 个 suite 共 **534 passed**
- 本机真实绑定态渲染确认，三处均输出「平台链接 + 本地兜底」：

\`\`\`
# botmux dashboard
https://m-xxxx.<平台域名>/?t=TOKEN
本地直连(平台异常时可用): http://10.8.9.42:7891/?t=TOKEN

# 飞书维护通知卡片正文
🔄 botmux 已重启
版本：v2.99.0
未结束会话：3 个
Dashboard：https://m-xxxx.<平台域名>/?t=TOKEN
本地直连（平台异常时可用）：http://10.8.9.42:7891/?t=TOKEN
\`\`\`