### PR TITLE
[codex] fix dashboard stale lazy chunk reload

### DIFF
--- a/src/dashboard/web/app.ts
+++ b/src/dashboard/web/app.ts
@@ -11,6 +11,7 @@ import {
   createDashboardRouteState,
   loadAndRenderDashboardRoute,
 } from './route-lifecycle.js';
+import { maybeReloadBrowserForStaleRouteChunk } from './stale-chunk-reload.js';
 
 const root = document.getElementById('root')!;
 
@@ -284,6 +285,12 @@ async function route() {
     );
   } catch (err) {
     if (seq !== routeState.seq) return;
+    if (maybeReloadBrowserForStaleRouteChunk(err, {
+      href: window.location.href,
+      hash,
+      getSessionStorage: () => window.sessionStorage,
+      reload: () => window.location.reload(),
+    })) return;
     root.innerHTML = `<section class="page"><div class="empty">Dashboard route failed: ${escapeHtml(String(err))}</div></section>`;
     routeState.pageDispose = null;
     routeState.rerenderOnUiChange = true;

--- a/src/dashboard/web/stale-chunk-reload.ts
+++ b/src/dashboard/web/stale-chunk-reload.ts
@@ -1,0 +1,68 @@
+export interface StaleChunkReloadEnv {
+  href: string;
+  hash: string;
+  sessionStorage: Pick<Storage, 'getItem' | 'setItem'>;
+  reload(): void;
+}
+
+export interface BrowserStaleChunkReloadEnv {
+  href: string;
+  hash: string;
+  getSessionStorage(): Pick<Storage, 'getItem' | 'setItem'>;
+  reload(): void;
+}
+
+const STALE_CHUNK_RELOAD_KEY_PREFIX = 'botmux.dashboard.stale-chunk-reload.v1:';
+const DYNAMIC_IMPORT_ERROR_RE =
+  /Failed to fetch dynamically imported module|Importing a module script failed|error loading dynamically imported module|dynamically imported module/i;
+const MODULE_URL_RE = /\b(?:https?:\/\/|\/assets\/)\S+?\.js\b/;
+
+function errorText(err: unknown): string {
+  if (err instanceof Error) return `${err.name}: ${err.message}`;
+  return String(err);
+}
+
+export function isLikelyStaleRouteChunkError(err: unknown): boolean {
+  return DYNAMIC_IMPORT_ERROR_RE.test(errorText(err));
+}
+
+function reloadKeyFor(err: unknown, env: StaleChunkReloadEnv): string {
+  const text = errorText(err);
+  const moduleUrl = text.match(MODULE_URL_RE)?.[0];
+  const source = moduleUrl || `${env.href}|${env.hash}`;
+  return `${STALE_CHUNK_RELOAD_KEY_PREFIX}${source.slice(-240)}`;
+}
+
+export function maybeReloadForStaleRouteChunk(err: unknown, env: StaleChunkReloadEnv): boolean {
+  if (!isLikelyStaleRouteChunkError(err)) return false;
+
+  const key = reloadKeyFor(err, env);
+  try {
+    // A loaded app.js can survive a CLI/dashboard upgrade and still point at
+    // removed content-hashed chunks. Reload once to fetch the current shell,
+    // but persist the guard so a real network/build failure does not loop.
+    if (env.sessionStorage.getItem(key) === '1') return false;
+    env.sessionStorage.setItem(key, '1');
+  } catch {
+    return false;
+  }
+
+  env.reload();
+  return true;
+}
+
+export function maybeReloadBrowserForStaleRouteChunk(err: unknown, env: BrowserStaleChunkReloadEnv): boolean {
+  if (!isLikelyStaleRouteChunkError(err)) return false;
+
+  let sessionStorage: Pick<Storage, 'getItem' | 'setItem'>;
+  try {
+    // Some embedded/browser contexts can throw while reading the storage getter.
+    // Treat that as "cannot safely guard a reload" and keep the original route
+    // error path instead of replacing it with a SecurityError.
+    sessionStorage = env.getSessionStorage();
+  } catch {
+    return false;
+  }
+
+  return maybeReloadForStaleRouteChunk(err, { ...env, sessionStorage });
+}

--- a/test/dashboard-stale-chunk-reload.test.ts
+++ b/test/dashboard-stale-chunk-reload.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  isLikelyStaleRouteChunkError,
+  maybeReloadBrowserForStaleRouteChunk,
+  maybeReloadForStaleRouteChunk,
+} from '../src/dashboard/web/stale-chunk-reload.js';
+
+function memorySessionStorage(): Pick<Storage, 'getItem' | 'setItem'> {
+  const values = new Map<string, string>();
+  return {
+    getItem: key => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value); },
+  };
+}
+
+describe('dashboard stale chunk reload', () => {
+  it('reloads once when an upgraded dashboard removed a lazy route chunk', () => {
+    const sessionStorage = memorySessionStorage();
+    const reload = vi.fn();
+    const err = new TypeError(
+      'Failed to fetch dynamically imported module: http://127.0.0.1:7891/assets/chunks/bot-defaults-page-old.js',
+    );
+    const env = {
+      href: 'http://127.0.0.1:7891/#/bot-defaults',
+      hash: '#/bot-defaults',
+      sessionStorage,
+      reload,
+    };
+
+    expect(isLikelyStaleRouteChunkError(err)).toBe(true);
+    expect(maybeReloadForStaleRouteChunk(err, env)).toBe(true);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(maybeReloadForStaleRouteChunk(err, env)).toBe(false);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reload for ordinary route errors', () => {
+    const reload = vi.fn();
+
+    expect(maybeReloadForStaleRouteChunk(new Error('render failed'), {
+      href: 'http://127.0.0.1:7891/#/groups',
+      hash: '#/groups',
+      sessionStorage: memorySessionStorage(),
+      reload,
+    })).toBe(false);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('does not reload when the guard cannot be persisted', () => {
+    const reload = vi.fn();
+    const sessionStorage: Pick<Storage, 'getItem' | 'setItem'> = {
+      getItem: () => { throw new Error('blocked'); },
+      setItem: () => { throw new Error('blocked'); },
+    };
+
+    expect(maybeReloadForStaleRouteChunk(
+      new TypeError('error loading dynamically imported module'),
+      {
+        href: 'http://127.0.0.1:7891/#/roles',
+        hash: '#/roles',
+        sessionStorage,
+        reload,
+      },
+    )).toBe(false);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('keeps the original route error when browser storage cannot be read', () => {
+    const reload = vi.fn();
+
+    expect(maybeReloadBrowserForStaleRouteChunk(
+      new TypeError('Failed to fetch dynamically imported module: /assets/chunks/groups-page-old.js'),
+      {
+        href: 'http://127.0.0.1:7891/#/groups',
+        hash: '#/groups',
+        getSessionStorage: () => { throw new DOMException('blocked', 'SecurityError'); },
+        reload,
+      },
+    )).toBe(false);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('does not read browser storage for ordinary route errors', () => {
+    const getSessionStorage = vi.fn(() => memorySessionStorage());
+
+    expect(maybeReloadBrowserForStaleRouteChunk(new Error('render failed'), {
+      href: 'http://127.0.0.1:7891/#/roles',
+      hash: '#/roles',
+      getSessionStorage,
+      reload: vi.fn(),
+    })).toBe(false);
+    expect(getSessionStorage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Fix dashboard route failures after the CLI/dashboard assets are rebuilt while an existing App or browser window still holds the previous SPA entry script.

## Root Cause

Dashboard route pages are lazy-loaded as content-hashed chunks. If an already-loaded `app.js` points to an old chunk name that has been removed by a rebuild or upgrade, routes such as groups, roles, and bot defaults fail with `Failed to fetch dynamically imported module`.

## Changes

- Add a focused stale lazy-chunk detector for dashboard route imports.
- Reload the dashboard shell once per missing chunk using a `sessionStorage` guard.
- Preserve the original route error path for ordinary render failures or when browser storage cannot be read.
- Add unit coverage for one-time reload behavior, ordinary errors, storage failures, and browser storage getter failures.

## Validation

- `pnpm exec vitest run --project unit test/dashboard-stale-chunk-reload.test.ts test/dashboard-route-lifecycle.test.ts test/dashboard-route-smoke.test.ts`
- `pnpm exec tsc --noEmit`
- `git diff --check`