### PR TITLE
fix(workflow): propagate sandbox policy to worker spawns

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -255,6 +255,10 @@ const workflowAttemptResumes = new AttemptResumeManager({
         botName: bot.botName ?? terminal.botName,
         botOpenId: bot.botOpenId,
         locale: botLocale(bot.config),
+        sandbox: terminal.sandbox ?? (bot.config.sandbox === true),
+        sandboxHidePaths: terminal.sandboxHidePaths ?? bot.config.sandboxHidePaths ?? [],
+        sandboxReadonlyPaths: terminal.sandboxReadonlyPaths ?? bot.config.sandboxReadonlyPaths ?? [],
+        sandboxNetwork: terminal.sandboxNetwork ?? (bot.config.sandboxNetwork !== false),
       };
     } catch {
       return undefined;

--- a/src/im/lark/workflow-slash-command.ts
+++ b/src/im/lark/workflow-slash-command.ts
@@ -335,6 +335,10 @@ function snapshotFromConfig(
     name?: string;
     workingDir?: string;
     cliPathOverride?: string;
+    sandbox?: boolean;
+    sandboxHidePaths?: string[];
+    sandboxReadonlyPaths?: string[];
+    sandboxNetwork?: boolean;
   },
 ): BotSnapshot {
   return {
@@ -343,6 +347,10 @@ function snapshotFromConfig(
     displayName: cfg.name ?? requestedName,
     ...(cfg.workingDir ? { workingDir: cfg.workingDir } : {}),
     ...(cfg.cliPathOverride ? { cliPathOverride: cfg.cliPathOverride } : {}),
+    ...(cfg.sandbox === true ? { sandbox: true } : {}),
+    ...(cfg.sandboxHidePaths?.length ? { sandboxHidePaths: [...cfg.sandboxHidePaths] } : {}),
+    ...(cfg.sandboxReadonlyPaths?.length ? { sandboxReadonlyPaths: [...cfg.sandboxReadonlyPaths] } : {}),
+    ...(cfg.sandboxNetwork === false ? { sandboxNetwork: false } : {}),
   };
 }
 

--- a/src/workflows/attempt-resume.ts
+++ b/src/workflows/attempt-resume.ts
@@ -19,6 +19,7 @@ import {
   type WorkerHandle,
   type WorkerProcessFactory,
 } from './daemon-spawn.js';
+import { workflowSandboxInitFields } from './spawn-policy.js';
 import {
   isPathInsideDir,
   isValidPathSegment,
@@ -69,6 +70,10 @@ export type AttemptResumeBot = {
   botName?: string;
   botOpenId?: string;
   locale?: Locale;
+  sandbox?: boolean;
+  sandboxHidePaths?: string[];
+  sandboxReadonlyPaths?: string[];
+  sandboxNetwork?: boolean;
 };
 
 export type AttemptResumeStartResult =
@@ -294,6 +299,7 @@ export class AttemptResumeManager {
       resume: true,
       originalSessionId,
       ...(terminal.terminal.cliSessionId ? { cliSessionId: terminal.terminal.cliSessionId } : {}),
+      ...workflowSandboxInitFields(bot),
       larkAppId: bot.larkAppId,
       larkAppSecret: bot.larkAppSecret,
       botName: bot.botName ?? terminal.terminal.botName,

--- a/src/workflows/attempt-terminal.ts
+++ b/src/workflows/attempt-terminal.ts
@@ -16,6 +16,10 @@ export type AttemptTerminalSidecar = {
   botName?: string;
   cliId?: string;
   workingDir?: string;
+  sandbox?: boolean;
+  sandboxHidePaths?: string[];
+  sandboxReadonlyPaths?: string[];
+  sandboxNetwork?: boolean;
   logPath?: string;
   startedAt: number;
   updatedAt: number;

--- a/src/workflows/daemon-spawn.ts
+++ b/src/workflows/daemon-spawn.ts
@@ -34,6 +34,7 @@ import type {
 } from './spawn-bot.js';
 import { WorkflowSpawnCancelledError } from './spawn-bot.js';
 import type { AbortCancelReason, WorkerSessionInfo } from './runtime.js';
+import { workflowSandboxInitFields } from './spawn-policy.js';
 import {
   ATTEMPT_TERMINAL_SCHEMA_VERSION,
   ATTEMPT_TERMINAL_SIDECAR,
@@ -252,6 +253,7 @@ async function runOneShotImpl(
     backendType: 'pty' as const,
     prompt: input.prompt,
     resume: false,
+    ...workflowSandboxInitFields(input.botSnapshot),
     larkAppId: creds.larkAppId,
     larkAppSecret: creds.larkAppSecret,
     botName: input.botName,
@@ -364,6 +366,7 @@ async function runOneShotImpl(
         workingDir: cwd,
         webPort,
         logPath: input.attemptLogPath,
+        ...workflowSandboxInitFields(input.botSnapshot),
         startedAt,
         endedAt: Date.now(),
       };
@@ -567,6 +570,10 @@ function writeAttemptTerminalSidecar(
       botName: session.botName,
       cliId: session.cliId,
       workingDir: session.workingDir,
+      sandbox: session.sandbox,
+      sandboxHidePaths: session.sandboxHidePaths,
+      sandboxReadonlyPaths: session.sandboxReadonlyPaths,
+      sandboxNetwork: session.sandboxNetwork,
       logPath: session.logPath,
       startedAt: session.startedAt,
       updatedAt: now,

--- a/src/workflows/events/payloads.ts
+++ b/src/workflows/events/payloads.ts
@@ -108,6 +108,10 @@ export const BotSnapshotSchema = z.object({
   displayName: z.string().optional(),
   workingDir: z.string().optional(),
   cliPathOverride: z.string().optional(),
+  sandbox: z.boolean().optional(),
+  sandboxHidePaths: z.array(z.string()).optional(),
+  sandboxReadonlyPaths: z.array(z.string()).optional(),
+  sandboxNetwork: z.boolean().optional(),
 });
 export type BotSnapshot = z.infer<typeof BotSnapshotSchema>;
 

--- a/src/workflows/runtime.ts
+++ b/src/workflows/runtime.ts
@@ -101,6 +101,10 @@ export type WorkerSessionInfo = {
   botName: string;
   cliId?: string;
   workingDir?: string;
+  sandbox?: boolean;
+  sandboxHidePaths?: string[];
+  sandboxReadonlyPaths?: string[];
+  sandboxNetwork?: boolean;
   webPort?: number;
   logPath?: string;
   startedAt: number;

--- a/src/workflows/spawn-policy.ts
+++ b/src/workflows/spawn-policy.ts
@@ -1,0 +1,26 @@
+import type { DaemonToWorker } from '../types.js';
+
+type WorkerInit = Extract<DaemonToWorker, { type: 'init' }>;
+
+export type WorkflowSandboxPolicySource = {
+  sandbox?: boolean;
+  sandboxHidePaths?: string[];
+  sandboxReadonlyPaths?: string[];
+  sandboxNetwork?: boolean;
+};
+
+export type WorkflowSandboxInitFields = Pick<
+  WorkerInit,
+  'sandbox' | 'sandboxHidePaths' | 'sandboxReadonlyPaths' | 'sandboxNetwork'
+>;
+
+export function workflowSandboxInitFields(
+  policy: WorkflowSandboxPolicySource | undefined,
+): WorkflowSandboxInitFields {
+  return {
+    sandbox: policy?.sandbox === true,
+    sandboxHidePaths: [...(policy?.sandboxHidePaths ?? [])],
+    sandboxReadonlyPaths: [...(policy?.sandboxReadonlyPaths ?? [])],
+    sandboxNetwork: policy?.sandboxNetwork !== false,
+  };
+}

--- a/src/workflows/v3/bot-resolve.ts
+++ b/src/workflows/v3/bot-resolve.ts
@@ -46,6 +46,10 @@ export function botToSnapshot(bot: BotConfig, workingDirOverride?: string): BotS
     ...(bot.model ? { model: bot.model } : {}),
     // 受限 bot 的全部节点保持受限（P2 不可提权红线的 bot 侧入口）。
     ...(bot.disableCliBypass === true ? { disableCliBypass: true } : {}),
+    ...(bot.sandbox === true ? { sandbox: true } : {}),
+    ...(bot.sandboxHidePaths?.length ? { sandboxHidePaths: [...bot.sandboxHidePaths] } : {}),
+    ...(bot.sandboxReadonlyPaths?.length ? { sandboxReadonlyPaths: [...bot.sandboxReadonlyPaths] } : {}),
+    ...(bot.sandboxNetwork === false ? { sandboxNetwork: false } : {}),
     workingDir: botWorkingDir(bot, workingDirOverride),
   };
 }

--- a/src/workflows/v3/cli-run.ts
+++ b/src/workflows/v3/cli-run.ts
@@ -226,6 +226,10 @@ export async function cmdV3(sub: string, rest: string[]): Promise<void> {
       ...(bot.model ? { model: bot.model } : {}),
       // 受限 bot 的全部节点保持受限（P2 不可提权红线的 bot 侧入口）。
       ...(bot.disableCliBypass === true ? { disableCliBypass: true } : {}),
+      ...(bot.sandbox === true ? { sandbox: true } : {}),
+      ...(bot.sandboxHidePaths?.length ? { sandboxHidePaths: [...bot.sandboxHidePaths] } : {}),
+      ...(bot.sandboxReadonlyPaths?.length ? { sandboxReadonlyPaths: [...bot.sandboxReadonlyPaths] } : {}),
+      ...(bot.sandboxNetwork === false ? { sandboxNetwork: false } : {}),
       workingDir: botWorkingDir(bot, args.workingDir),
     };
   };

--- a/src/workflows/v3/contract.ts
+++ b/src/workflows/v3/contract.ts
@@ -224,6 +224,12 @@ export interface BotSnapshot {
    *  `override.permissionMode:'restricted'` can additionally set this per
    *  dispatch; nothing can clear it (no-escalation red line, P2). */
   disableCliBypass?: boolean;
+  /** Frozen per-bot sandbox policy. Workflow workers must not silently lose
+   *  these fields when spawning outside the main forkWorker path. */
+  sandbox?: boolean;
+  sandboxHidePaths?: string[];
+  sandboxReadonlyPaths?: string[];
+  sandboxNetwork?: boolean;
   /** The resolved working directory for this run. */
   workingDir: string;
 }

--- a/src/workflows/v3/ephemeral-pool.ts
+++ b/src/workflows/v3/ephemeral-pool.ts
@@ -27,6 +27,7 @@ import {
   type RunNodeResult,
   type WorkerSessionInfo,
 } from './contract.js';
+import { workflowSandboxInitFields } from '../spawn-policy.js';
 
 type WorkerEvent = WorkerToDaemon;
 
@@ -111,6 +112,7 @@ async function runNodeImpl(
     // P2: 受限 bot / restricted 节点 → worker 关闭 CLI 权限旁路（adapter 据此
     // 不再注入 --dangerously-skip-permissions / --yolo 等 bypass flag）。
     disableCliBypass: req.botSnapshot.disableCliBypass === true,
+    ...workflowSandboxInitFields(req.botSnapshot),
     backendType: 'pty' as const,
     prompt: '',
     resume: false,

--- a/test/workflow-attempt-resume.test.ts
+++ b/test/workflow-attempt-resume.test.ts
@@ -165,6 +165,45 @@ describe('AttemptResumeManager', () => {
     }
   });
 
+  it('passes sandbox policy to the dashboard resume worker init', async () => {
+    const tmp = join(tmpdir(), `wf-resume-${Date.now()}-${Math.random()}`);
+    const ids = seedAttempt(tmp);
+    const { factory, handles } = makeFactory((h) => {
+      h.emit({ type: 'ready', port: 4567, token: 'write-token' });
+    });
+    try {
+      const manager = new AttemptResumeManager({
+        runsDir: tmp,
+        externalHost: 'dash.local',
+        workerPath: '/worker.js',
+        factory,
+        resolveBot: () => ({
+          ...bot,
+          sandbox: true,
+          sandboxHidePaths: ['~/.ssh'],
+          sandboxReadonlyPaths: ['/srv/readonly'],
+          sandboxNetwork: false,
+        }),
+      });
+
+      const result = await manager.start(ids);
+
+      expect(result.ok).toBe(true);
+      const init = handles[0]?.sent.find(
+        (msg): msg is Record<string, unknown> =>
+          typeof msg === 'object' && msg !== null && (msg as any).type === 'init',
+      );
+      expect(init).toMatchObject({
+        sandbox: true,
+        sandboxHidePaths: ['~/.ssh'],
+        sandboxReadonlyPaths: ['/srv/readonly'],
+        sandboxNetwork: false,
+      });
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('allows session-id based CLIs to resume without a native cliSessionId', async () => {
     const tmp = join(tmpdir(), `wf-resume-${Date.now()}-${Math.random()}`);
     const ids = seedAttempt(tmp, { cliSessionId: null, cliId: 'coco' });

--- a/test/workflow-daemon-spawn.test.ts
+++ b/test/workflow-daemon-spawn.test.ts
@@ -15,6 +15,7 @@ import {
   WORKFLOW_OUTPUT_BEGIN,
   WORKFLOW_OUTPUT_END,
 } from '../src/workflows/spawn-bot.js';
+import { ATTEMPT_TERMINAL_SIDECAR } from '../src/workflows/attempt-terminal.js';
 
 // ─── scripted worker process ──────────────────────────────────────────────
 
@@ -206,6 +207,61 @@ describe('createWorkflowDaemonSpawn', () => {
       ),
     );
     expect(init!.chatId).toContain('wf-chat');
+  });
+
+  it('passes frozen sandbox policy to the one-shot worker init', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wf-sandbox-'));
+    const sent: unknown[] = [];
+    const factory = scriptedFactory((s) => {
+      s.onSend((msg) => sent.push(msg));
+      s.emit({ type: 'ready', port: 1, token: 't' });
+      s.emit({
+        type: 'final_output',
+        content: `${WORKFLOW_OUTPUT_BEGIN}{}${WORKFLOW_OUTPUT_END}`,
+        lastUuid: 'u',
+        turnId: 't1',
+      });
+      s.emit({ type: 'screen_update', content: '', status: 'idle' });
+    });
+    const deps = createWorkflowDaemonSpawn({
+      resolveLarkCredentials: () => fakeCreds,
+      quiesceMs: 30,
+      factory,
+    });
+
+    try {
+      await deps.runOneShot({
+        ...baseInput,
+        attemptLogPath: join(dir, 'terminal.log'),
+        botSnapshot: {
+          ...baseInput.botSnapshot,
+          sandbox: true,
+          sandboxHidePaths: ['~/.ssh'],
+          sandboxReadonlyPaths: ['/srv/readonly'],
+          sandboxNetwork: false,
+        },
+      });
+
+      const init = sent.find(
+        (m): m is Record<string, unknown> =>
+          typeof m === 'object' && m !== null && (m as Record<string, unknown>).type === 'init',
+      );
+      expect(init).toMatchObject({
+        sandbox: true,
+        sandboxHidePaths: ['~/.ssh'],
+        sandboxReadonlyPaths: ['/srv/readonly'],
+        sandboxNetwork: false,
+      });
+      const sidecar = JSON.parse(readFileSync(join(dir, ATTEMPT_TERMINAL_SIDECAR), 'utf-8'));
+      expect(sidecar).toMatchObject({
+        sandbox: true,
+        sandboxHidePaths: ['~/.ssh'],
+        sandboxReadonlyPaths: ['/srv/readonly'],
+        sandboxNetwork: false,
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('credential resolver gets the bot name from input', async () => {

--- a/test/workflow-v3-ephemeral-pool.test.ts
+++ b/test/workflow-v3-ephemeral-pool.test.ts
@@ -61,6 +61,42 @@ describe('v3 ephemeral pool', () => {
     expect(worker.rawInputs).toEqual([buildGoalCommand(req)]);
   });
 
+  it('passes frozen sandbox policy to the goal-mode worker init', async () => {
+    const worker = new ScriptedWorker();
+    const factory = factoryFor(worker);
+    const base = request();
+    const req = {
+      ...base,
+      botSnapshot: {
+        ...base.botSnapshot,
+        sandbox: true,
+        sandboxHidePaths: ['~/.ssh'],
+        sandboxReadonlyPaths: ['/srv/readonly'],
+        sandboxNetwork: false,
+      },
+    };
+    const pool = createEphemeralPool({
+      factory,
+      workerPath: '/tmp/worker.js',
+      quiesceMs: 1,
+      resolveLarkAppSecret: () => 'secret',
+    });
+
+    const promise = pool.runNode(req);
+    await waitFor(() => factory.lastOpts !== undefined);
+    await worker.waitForInit();
+
+    expect(worker.init).toMatchObject({
+      sandbox: true,
+      sandboxHidePaths: ['~/.ssh'],
+      sandboxReadonlyPaths: ['/srv/readonly'],
+      sandboxNetwork: false,
+    });
+
+    worker.emitExit(0);
+    await promise;
+  });
+
   it('notifies session readiness as soon as the worker web terminal is ready', async () => {
     const worker = new ScriptedWorker();
     const factory = factoryFor(worker);


### PR DESCRIPTION
## Summary

Fixes #344.

This makes workflow worker spawns carry the same per-bot sandbox policy fields that the main `forkWorker` path already sends to `worker` init:

- one-shot workflow workers now include frozen `sandbox`, `sandboxHidePaths`, `sandboxReadonlyPaths`, and `sandboxNetwork` from the bot snapshot
- v3 goal-mode ephemeral workers freeze and forward the same policy fields
- dashboard attempt-resume workers include the policy as well, preferring the terminal sidecar's frozen policy and falling back to the current bot config for older sidecars
- the attempt terminal sidecar persists the sandbox policy so resume does not silently drop it

## Validation

- `./node_modules/.bin/vitest run test/workflow-daemon-spawn.test.ts test/workflow-v3-ephemeral-pool.test.ts test/workflow-attempt-resume.test.ts` -> 35 passed
- `./node_modules/.bin/vitest run test/workflow-run-init.test.ts test/workflow-trigger-run.test.ts test/bot-registry.test.ts` -> 60 passed
- `./node_modules/.bin/tsc --noEmit` -> passed
- `git diff --check` -> passed

I also attempted `./node_modules/.bin/vitest run --project unit` in this fresh checkout. It ran most of the suite (7191 passed) but the overall run is not a clean signal here because several CLI subprocess tests expect a built `dist/cli.js` and failed with `MODULE_NOT_FOUND`; there were also broader environment/mock-sensitive failures outside this workflow sandbox path.
