### PR TITLE
docs(faq): 补 macOS keychain/文件双存储导致 /login 的排错与推荐

### DIFF
--- a/docs-site/docs/en/faq.md
+++ b/docs-site/docs/en/faq.md
@@ -28,6 +28,19 @@ First figure out which `/login` it is:
 - **Lark-side App Token rejected when calling the API**: Send `/login` in the topic → click the authorization link → copy the callback URL the browser redirects to (`http://127.0.0.1:9768/callback?...`; it's normal for the page not to load) back into the topic.
 - **Model-gateway-side 403**: This is unrelated to Lark authorization and is usually an environment-variable / gateway-token issue. A common root cause is bash users putting variables in `.bash_profile` where `bash -i` doesn't read them (see [Common Pitfalls](/en/pitfalls)).
 
+**macOS note: claude's login token has two stores — keychain and file — and a split between them is the main reason claude shows `Please run /login` on macOS.**
+
+- **keychain** (the keychain item `Claude Code-credentials`): used by **claude running in the GUI** and by **botmux's default (non-isolated) config**;
+- **file** (`~/.claude/.credentials.json`): running `/login` over **SSH can only write here**.
+
+The catch: **as long as the keychain item exists, claude reads the token from the keychain and never reads the file** — even when the file holds the freshly updated token. So you get "SSH `/login` clearly succeeded (it only wrote the file), yet the GUI / non-isolated bot still reads the stale keychain token and says `Please run /login`." On top of that, claude rotates the refresh token on each refresh, so whichever process refreshes first invalidates the other's token, dropping everyone's login.
+
+**Recommended (converge onto the file as the single source):**
+
+1. **Don't use claude code in the GUI** — the GUI writes / refreshes the token into the keychain, creating a second source out of nowhere;
+2. **Update the token by running `/login` over SSH**, so both SSH and botmux use the file as the login-token source;
+3. If a stale keychain item already exists, delete it to converge onto the single file source.
+
 ## Does it support Lark (international, larksuite.com)?
 
 Yes. Both Feishu (feishu.cn) and Lark (international, larksuite.com) work: when you scan to create an app, the tenant type (China / international) is **detected automatically** and remembered; when you paste the AppID/Secret manually, it asks you to choose once. Each bot independently connects to the corresponding domain based on its edition, and the same machine can run Feishu and Lark bots simultaneously, with login credentials isolated per app and not interfering with each other.

--- a/docs-site/docs/zh/faq.md
+++ b/docs-site/docs/zh/faq.md
@@ -28,6 +28,19 @@
 - **飞书侧 App Token 调 API 被拒**：话题里发 `/login` → 点授权链接 → 把浏览器跳转的 callback URL（`http://127.0.0.1:9768/callback?...`，页面打不开是正常的）复制回话题。
 - **模型网关侧 403**：跟飞书授权无关，多为环境变量 / 网关 token 问题，常见根因是 bash 用户把变量写在 `.bash_profile` 没被 `bash -i` 读到（见 [常见踩坑](/pitfalls)）。
 
+**macOS 补充：claude 的登录 token 有 keychain / 文件「双存储」，两者分裂是 macOS 下 claude 报 `Please run /login` 的主要原因。**
+
+- **keychain**（钥匙串条目 `Claude Code-credentials`）：**GUI 里跑 claude** 和 **botmux 默认（非隔离）配置**都走这里；
+- **文件**（`~/.claude/.credentials.json`）：**SSH 里跑 `/login` 只能写到这里**。
+
+坑点：**只要 keychain 条目存在，claude 就只读 keychain 里的 token、不会去读文件**——哪怕文件里才是刚更新的新 token。于是会出现「SSH `/login` 明明成功了（只写进了文件），GUI / 非隔离 bot 却仍读 keychain 里的旧 token、报 `Please run /login`」。再叠加 claude 刷新时 refresh token 会轮换，谁先刷就把对方的 token 作废，导致集体掉登录。
+
+**推荐做法（统一收敛到「文件」单一源）：**
+
+1. **禁止在 GUI 下使用 claude code**——GUI 会往 keychain 写 / 刷 token，凭空制造第二个源；
+2. **统一通过 SSH 跑 `/login` 更新 token**，让 SSH 和 botmux 都以文件作为登录 token 的来源；
+3. keychain 里若已残留旧条目，删掉它、收敛到单一文件源。
+
 ## 支持 Lark 国际版（larksuite.com）吗？
 
 支持。飞书 (feishu.cn) 和 Lark 国际版 (larksuite.com) 都能用：扫码建应用时**自动识别**租户类型（国内 / 国际）并记住，手动粘 AppID/Secret 时会让你选一次。每个机器人按所属版本独立连对应域名，同一台机器可同时跑飞书和 Lark 机器人，登录凭证按应用隔离、互不干扰。


### PR DESCRIPTION
## 改了什么

在 zh/en FAQ 的「`Please run /login · API Error: 403`」条目下，补充 macOS 凭证「双存储」这一高频根因与推荐处理。

## 为什么

macOS 上 claude 的登录 token 有两处存储：

- keychain 条目 `Claude Code-credentials`：GUI 里跑 claude、以及 botmux 默认（非隔离）配置都走这里；
- 文件 `~/.claude/.credentials.json`：SSH 里跑 `/login` 只能写到这里。

**只要 keychain 条目存在，claude 就只读 keychain 里的 token、不会去读文件**——哪怕文件里才是刚更新的新 token。于是会出现「SSH `/login` 明明成功了（只写进了文件），GUI / 非隔离 bot 却仍读 keychain 里的旧 token、报 `Please run /login`」。再叠加 claude 刷新时 refresh token 会轮换，谁先刷就把对方的 token 作废，导致集体掉登录。这是 macOS 下该报错的**主要原因**，原 FAQ 未覆盖。

## 推荐处理（统一收敛到「文件」单一源）

1. 禁止在 GUI 下使用 claude code；
2. 统一通过 SSH 跑 `/login` 更新 token，让 SSH 和 botmux 都以文件作为登录 token 的来源；
3. keychain 里若已残留旧条目，删掉它、收敛到单一文件源。

## 影响面

仅文档站 markdown（`docs-site/docs/zh/faq.md`、`docs-site/docs/en/faq.md`，纯新增 +26 行），无代码 / 共用路径改动，无需 build；中英双语同步。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
