### PR TITLE
fix(lark): 修复话题群多机器人让路

### DIFF
--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -847,14 +847,21 @@ export function mentionsAnotherMember(larkAppId: string, message: any): boolean 
   const mentions: any[] = message.mentions ?? [];
   for (const m of mentions) {
     // mentionOpenId() tolerates both the WS event object shape ({ open_id }) and
-    // the REST bare-string shape (a bot @ is a "cli_…" string). A naked
-    // m.id.open_id silently misses the string form → the redirect carve-out
-    // breaks and the ambient bot keeps answering instead of backing off.
+    // the REST bare-string shape. Bot mentions may also arrive as app_id
+    // (id_type='app_id' / { app_id }) with no open_id; isBotMentioned handles
+    // that shape via mentionMatchesBot(), so the redirect/yield check must too.
     const oid = mentionOpenId(m);
-    if (!oid) continue;
-    if (oid === botOpenId) continue; // that's me
-    if (oid === 'all') continue;     // @all → everyone incl. me
-    return true;                     // a specific other member
+    if (oid) {
+      if (oid === botOpenId) continue; // that's me
+      if (oid === 'all') continue;     // @all → everyone incl. me
+      return true;                     // a specific other member
+    }
+    const appId = mentionAppId(m);
+    if (appId) {
+      if (appId === larkAppId) continue; // that's me, addressed by app_id
+      if (appId === 'all') continue;
+      return true;                       // another bot addressed by app_id
+    }
   }
 
   // 2. inline `at` nodes in post content (bot-sent / rich messages)
@@ -1915,13 +1922,14 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
         // "@ required" so this fold-back is skipped (non-@ thread chatter falls
         // through to the gate below and is ignored — only an explicit @ continues
         // a shared topic); 'topic', 'never' and 'ambient' enable the seamless
-        // no-@ fold-back. Carve-out: under 'ambient', a non-@ reply that @mentions
-        // another specific member (person/bot) is a redirect to someone else →
-        // back off, don't fold it in (mentionsAnotherMember). 'never'
-        // (unconditional) and 'topic' are unaffected.
+        // no-@ fold-back. Carve-out: under 'topic' / 'ambient', a non-@ reply
+        // that @mentions another specific member (person/bot) is a redirect to
+        // someone else → back off, don't fold it in (mentionsAnotherMember).
+        // 'never' stays unconditional by design.
+        const mentionModeForAlias = resolveGroupMentionMode(larkAppId);
         if (!explicitlyMentionedThisBot
-            && resolveGroupMentionMode(larkAppId) !== 'always'
-            && !(resolveGroupMentionMode(larkAppId) === 'ambient' && mentionsAnotherMember(larkAppId, message))
+            && mentionModeForAlias !== 'always'
+            && !((mentionModeForAlias === 'topic' || mentionModeForAlias === 'ambient') && mentionsAnotherMember(larkAppId, message))
             && routing.scope === 'thread' && message.root_id && message.thread_id && chatType === 'group') {
           const alias = handlers.resolveReplyThreadAlias?.(message.root_id, chatId, larkAppId) ?? null;
           if (alias) {
@@ -2074,7 +2082,9 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
           //   • 'topic' — only inside a topic the bot already owns: a non-@ reply
           //     INSIDE such a thread (new-topic / 话题群 thread the bot owns, or a
           //     shared-topic alias via replyRootId) continues without @, while a
-          //     brand-new top-level conversation still requires @.
+          //     brand-new top-level conversation still requires @. If the user
+          //     explicitly @mentions another member/bot without @ing this bot,
+          //     treat it as a hand-off and stay quiet.
           // Both gated on isAllowed so restricted groups still only react to
           // permitted senders. (The shared fold-back's replyRootId is already
           // handled by the first clause.)
@@ -2100,7 +2110,7 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
             || (isAllowed && mentionMode === 'never')
             || (isAllowed && mentionMode === 'ambient' && !mentionsAnotherMember(larkAppId, message))
             || ownedTopicGroupFollowup
-            || (isAllowed && mentionMode === 'topic' && ownsSession && !!message.thread_id)
+            || (isAllowed && mentionMode === 'topic' && ownsSession && !!message.thread_id && !mentionsAnotherMember(larkAppId, message))
             || (ownsSession && isAllowed && !!stats && stats.userCount <= 1 && stats.botCount <= 1);
           if (!relax) {
             const access = await checkGroupMessageAccess(larkAppId, message, chatId, senderOpenId, humanSenderUnionId);

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -120,6 +120,7 @@ import { _resetForTest as _resetGrantPending } from '../src/im/lark/grant-pendin
 const MY_APP_ID = 'app-bot-a';
 const MY_OPEN_ID = 'ou_bot_a_open_id';
 const OTHER_BOT_OPEN_ID = 'ou_bot_b_open_id';
+const OTHER_BOT_APP_ID = 'app-bot-b';
 const USER_OPEN_ID = 'ou_user_123';
 
 beforeEach(() => {
@@ -150,7 +151,7 @@ function setupBotState(opts?: {
   configAllowedUsers?: string[];
   restrictGrantCommands?: boolean;
   regularGroupReplyMode?: 'chat' | 'new-topic' | 'shared' | 'chat-topic';
-	  regularGroupMentionMode?: 'always' | 'topic' | 'never';
+	  regularGroupMentionMode?: 'always' | 'topic' | 'never' | 'ambient';
 	  autoStartOnNewTopic?: boolean;
 	  autoGrantRequestCards?: boolean;
 	  chatReplyModes?: Record<string, 'chat' | 'new-topic' | 'shared' | 'chat-topic'>;
@@ -365,6 +366,14 @@ describe('isBotMentioned', () => {
     expect(isBotMentioned(MY_APP_ID, message, undefined)).toBe(false);
   });
 
+  it('does not treat another app_id object as this bot mention', () => {
+    const message = {
+      mentions: [{ key: '@_other', name: 'Other', id: { app_id: 'app-other' } }],
+      content: JSON.stringify({ text: '@Other hello' }),
+    };
+    expect(isBotMentioned(MY_APP_ID, message, undefined)).toBe(false);
+  });
+
   it('detects @mention in post content at tags (bot-sent messages)', () => {
     // Bot-sent post messages embed @mentions as inline `at` nodes in content,
     // NOT in the message.mentions array
@@ -432,6 +441,30 @@ describe('mentionsAnotherMember (ambient redirect carve-out)', () => {
       content: JSON.stringify({ text: '@Other 你看下' }),
     };
     expect(mentionsAnotherMember(MY_APP_ID, message)).toBe(true);
+  });
+
+  it('returns true when another bot is @mentioned via app_id string form', () => {
+    const message = {
+      mentions: [{ key: '@_other', name: 'OtherBot', id: 'app-other-bot', id_type: 'app_id' }],
+      content: JSON.stringify({ text: '@OtherBot 你来答' }),
+    };
+    expect(mentionsAnotherMember(MY_APP_ID, message)).toBe(true);
+  });
+
+  it('returns true when another bot is @mentioned via app_id object form', () => {
+    const message = {
+      mentions: [{ key: '@_other', name: 'OtherBot', id: { app_id: 'app-other-bot' } }],
+      content: JSON.stringify({ text: '@OtherBot 你来答' }),
+    };
+    expect(mentionsAnotherMember(MY_APP_ID, message)).toBe(true);
+  });
+
+  it('returns false when only THIS bot is @mentioned via app_id string form', () => {
+    const message = {
+      mentions: [{ key: '@_bot', name: 'BotA', id: MY_APP_ID, id_type: 'app_id' }],
+      content: JSON.stringify({ text: '@BotA hello' }),
+    };
+    expect(mentionsAnotherMember(MY_APP_ID, message)).toBe(false);
   });
 
   it('returns false when only THIS bot is @mentioned via string-form id (no false redirect)', () => {
@@ -1863,6 +1896,30 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
   });
 
+  it('shared follow-up with mention mode topic yields when the reply @mentions ANOTHER bot', async () => {
+    setupBotState({ allowedUsers: [USER_OPEN_ID], regularGroupMentionMode: 'topic' });
+    mockGetChatMode.mockResolvedValue('group');
+    handlers.resolveReplyThreadAlias.mockReturnValue({ chatId: 'chat-reply-mode', sessionId: 'sess-chat' });
+    handlers.isSessionOwner.mockImplementation((anchor: string) => anchor === 'chat-reply-mode');
+    const event = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: '@BotB 这个交给你' }),
+      mentions: [{ key: '@_bot_b', name: 'BotB', id: OTHER_BOT_APP_ID, id_type: 'app_id' }],
+      rootId: 'msg-topic-alias-1',
+      threadId: 'msg-topic-alias-1',
+      messageId: 'msg-topic-alias-other-bot',
+      chatId: 'chat-reply-mode',
+      chatType: 'group',
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+    expect(handlers.resolveReplyThreadAlias).not.toHaveBeenCalled();
+  });
+
   it('shared follow-up thread reply WITHOUT @ is ignored by default (mention mode always → @ required even in topics)', async () => {
     setupBotState({ allowedUsers: [USER_OPEN_ID] }); // default = always
     mockGetChatMode.mockResolvedValue('group');
@@ -1936,6 +1993,30 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
       anchor: 'owned-topic-root',
       larkAppId: MY_APP_ID,
     }));
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+  });
+
+  it('mention mode topic: a reply inside an owned thread that @mentions ANOTHER bot is ignored — yields the turn', async () => {
+    setupBotState({ allowedUsers: [USER_OPEN_ID], regularGroupMentionMode: 'topic' });
+    mockGetChatMode.mockResolvedValue('group');
+    mockGetChatInfo.mockResolvedValue({ userCount: 3, botCount: 2 });
+    handlers.resolveReplyThreadAlias.mockReturnValue(null);
+    handlers.isSessionOwner.mockImplementation((anchor: string) => anchor === 'owned-topic-root');
+    const event = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: '@BotB 你来看这个' }),
+      mentions: [{ key: '@_bot_b', name: 'BotB', id: { app_id: OTHER_BOT_APP_ID } }],
+      rootId: 'owned-topic-root',
+      threadId: 'owned-topic-root',
+      messageId: 'msg-topic-tier-other-bot',
+      chatId: 'chat-topic-tier-other-bot',
+      chatType: 'group',
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(handlers.handleThreadReply).not.toHaveBeenCalled();
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
   });
 

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -1899,6 +1899,7 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
   it('shared follow-up with mention mode topic yields when the reply @mentions ANOTHER bot', async () => {
     setupBotState({ allowedUsers: [USER_OPEN_ID], regularGroupMentionMode: 'topic' });
     mockGetChatMode.mockResolvedValue('group');
+    mockGetChatInfo.mockResolvedValue({ userCount: 3, botCount: 2 });
     handlers.resolveReplyThreadAlias.mockReturnValue({ chatId: 'chat-reply-mode', sessionId: 'sess-chat' });
     handlers.isSessionOwner.mockImplementation((anchor: string) => anchor === 'chat-reply-mode');
     const event = makeUserMessageEvent({


### PR DESCRIPTION
## 改了什么

- 修复话题群多机器人协作时，用户在已有 topic 中明确 @ 其中一个机器人，其他机器人仍因 `regularGroupMentionMode: topic` + owned session 放行而一起响应的问题。
- `mentionsAnotherMember()` 补齐 app_id 形态的 bot mention 识别，和 `isBotMentioned()` 的 app_id 支持保持一致。
- shared-topic alias fold-back 在 `topic` / `ambient` 模式下遇到“@ 其他成员/机器人”时让路，不再折回当前 bot 的 chat session。
- `topic` 模式的 owned-thread 免 @ 续话增加“@ 其他成员/机器人则让路”的限制。

## 为什么

用户通过 npm 安装运行自己的 botmux daemon，在一个话题群中由主机器人分派任务给子机器人后，后续明确 @ 任意一个机器人时，多个机器人都会响应。根因是多个 bot 都可能拥有同一个 thread/alias 的 session，`topic` 模式把它们都放行了；同时飞书 bot mention 可能以 `app_id` 形态出现，旧 redirect 判断漏识别。

## 影响面

- 影响 Lark `im.message.receive_v1` 人类消息路径下的群聊/话题群路由。
- 主要涉及 `regularGroupMentionMode: topic` 和 shared-topic alias；`never` 保持无条件响应语义不变。
- `ambient` 保持原本“@ 别人让路”的语义，并补齐 app_id mention 形态。
- 不改 CLI 适配器、PTY/Tmux backend、dashboard UI。

## 验证

- `pnpm vitest run test/event-dispatcher.test.ts`：181 tests passed
- `pnpm build`：passed

补充：当前环境跑完整 `pnpm test` 有 12 个与本次改动无关的既有/环境失败：
- `test/dashboard-create-session.test.ts` 的 role-resolver mock 缺 `resolveRoleInjection`
- `test/recall-frozen-cards.test.ts` / `test/terminal-url.test.ts` 受当前 dashboard tunnel URL 环境影响
- `test/session-discovery.smoke.test.ts` 在本机 `/proc` comm 读到 `MainThread` 而非 `node`
