### PR TITLE
fix(platform): 并行拨号 terminate 未建成连接崩溃 → machine_offline

### DIFF
--- a/src/platform/tunnel-client.ts
+++ b/src/platform/tunnel-client.ts
@@ -128,6 +128,10 @@ export function startPlatformTunnelClient(opts: TunnelClientOptions): TunnelClie
       for (const c of dials) {
         if (c === winner) continue;
         try { c.removeAllListeners(); } catch { /* ignore */ }
+        // 关键：补一个吞异常的 error handler。对仍在 CONNECTING 的 ws 调 terminate() 会「异步」emit('error')
+        //（"WebSocket was closed before the connection was established"）；上面刚把 error listener 摘了，
+        // 没 handler 就成未捕获 'error' 事件把 dashboard 进程打挂 → 无限重连、平台侧 machine_offline。
+        c.on('error', () => { /* swallow */ });
         try { c.terminate(); } catch { /* ignore */ }
       }
       dials.clear();
@@ -428,6 +432,7 @@ export function startPlatformTunnelClient(opts: TunnelClientOptions): TunnelClie
       if (controlDials) {
         for (const c of controlDials) {
           try { c.removeAllListeners(); } catch { /* ignore */ }
+          c.on('error', () => { /* swallow：同 dropLosers，terminate CONNECTING 态会异步 emit('error') */ });
           try { c.terminate(); } catch { /* ignore */ }
         }
         controlDials = null;


### PR DESCRIPTION
## 背景
#384 的 happy-eyeballs 引入了一个真机 crash（PR 时未做真连接 e2e，已复现）：

`dropLosers` / `stop()` 里对**仍在 CONNECTING 的落败连接**先 `removeAllListeners()` 再 `terminate()`。ws 对没建成的连接调 `terminate()` 会**异步** `emit('error')`（`WebSocket was closed before the connection was established`）；由于 error listener 刚被摘掉，就成**未捕获 'error' 事件**把 dashboard 进程打挂 → PM2 每 ~3.5s 无限重连 → 平台侧持续 **machine_offline**、dashboard 打不开。

## 修法
`terminate()` 前补一个吞异常的 `error` handler（两处：dropLosers + stop）。

## 验证（真机）
worktree 改好 → `pnpm build` → `botmux restart`：dashboard 进程 uptime 稳定增长、**重启计数 0**、无新报错；平台反代打机器子域返回 401 鉴权（非 machine_offline/超时），机器重新上线。`tsc --noEmit` 通过。