### PR TITLE
fix(lark): 修复 adopt 仅历史会话卡片 400

### DIFF
--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -1859,27 +1859,31 @@ export function buildAdoptSelectCard(
     };
   });
 
-  const elements: any[] = [
-    {
-      tag: 'div',
-      text: { tag: 'lark_md', content: t('card.adopt.section_live', undefined, locale) },
-    },
-    {
-      tag: 'action',
-      actions: [
-        {
-          tag: 'select_static',
-          placeholder: { tag: 'plain_text', content: t('card.adopt.placeholder_select', undefined, locale) },
-          options,
-          value: { key: 'adopt_select', root_id: rootMessageId ?? '' },
-        },
-      ],
-    },
-  ];
+  const elements: any[] = [];
+
+  if (options.length > 0) {
+    elements.push(
+      {
+        tag: 'div',
+        text: { tag: 'lark_md', content: t('card.adopt.section_live', undefined, locale) },
+      },
+      {
+        tag: 'action',
+        actions: [
+          {
+            tag: 'select_static',
+            placeholder: { tag: 'plain_text', content: t('card.adopt.placeholder_select', undefined, locale) },
+            options,
+            value: { key: 'adopt_select', root_id: rootMessageId ?? '' },
+          },
+        ],
+      },
+    );
+  }
 
   if (resumeOptions.length > 0) {
     elements.push(
-      { tag: 'hr' },
+      ...(elements.length > 0 ? [{ tag: 'hr' }] : []),
       {
         tag: 'div',
         text: { tag: 'lark_md', content: t('card.adopt.section_resume', undefined, locale) },

--- a/test/card-builder.test.ts
+++ b/test/card-builder.test.ts
@@ -18,6 +18,7 @@ import {
   buildRelayPickerCard,
   buildPrivateSnapshotCard,
   buildConfigCard,
+  buildAdoptSelectCard,
   getCliDisplayName,
 } from '../src/im/lark/card-builder.js';
 import type { RelayPickerEntry } from '../src/im/lark/card-builder.js';
@@ -84,6 +85,10 @@ function expectDirectUrl(actual: string, targetUrl: string): void {
   expect(actual).toBe(targetUrl);
 }
 
+function selectStaticActions(card: any): any[] {
+  return allActions(card).filter((a: any) => a.tag === 'select_static');
+}
+
 /** Opt into the Feishu sidebar wrapper for the current (isolated) HOME. */
 function enableOpenTerminalInFeishu(): void {
   writeFileSync(globalConfigPath(), JSON.stringify({ dashboard: { openTerminalInFeishu: true } }));
@@ -130,6 +135,53 @@ describe('getCliDisplayName', () => {
 
   it('should return "Pi" for pi', () => {
     expect(getCliDisplayName('pi')).toBe('Pi');
+  });
+});
+
+describe('buildAdoptSelectCard', () => {
+  it('does not render an empty live-session select when only resumable sessions exist', () => {
+    const card = parse(buildAdoptSelectCard([], 'om_root', 'zh', [
+      {
+        cliSessionId: 'claude-session-1',
+        cwd: '/repo/botmux',
+        title: '继续之前的排查',
+        lastActivityAt: Date.now(),
+      },
+    ]));
+
+    const selects = selectStaticActions(card);
+    expect(selects).toHaveLength(1);
+    expect(selects[0].value.key).toBe('adopt_resume_select');
+    expect(selects[0].options).toHaveLength(1);
+    expect(selects[0].options.length).toBeGreaterThan(0);
+    expect(card.elements.some((e: any) => e.tag === 'hr')).toBe(false);
+  });
+
+  it('renders both live and resumable selects when both groups are non-empty', () => {
+    const card = parse(buildAdoptSelectCard([
+      {
+        source: 'tmux',
+        tmuxTarget: '0:1.0',
+        cliPid: 1234,
+        cliId: 'claude-code',
+        cwd: '/repo/live',
+        paneCols: 120,
+        paneRows: 40,
+      },
+    ], 'om_root', 'zh', [
+      {
+        cliSessionId: 'claude-session-1',
+        cwd: '/repo/history',
+        title: '历史会话',
+        lastActivityAt: Date.now(),
+      },
+    ]));
+
+    const selects = selectStaticActions(card);
+    expect(selects).toHaveLength(2);
+    expect(selects.map((s: any) => s.value.key)).toEqual(['adopt_select', 'adopt_resume_select']);
+    expect(selects.every((s: any) => s.options.length > 0)).toBe(true);
+    expect(card.elements.some((e: any) => e.tag === 'hr')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## 改了什么

修复 `/adopt` 在“运行中可接管会话为空，但磁盘历史可恢复会话非空”时发送飞书卡片失败的问题。

具体改动：
- `buildAdoptSelectCard` 仅在运行中会话 options 非空时渲染“运行中可接管会话”下拉；
- 仅有历史会话时，只渲染“历史会话”恢复下拉，避免生成 `options=[]` 的 `select_static`；
- 两类会话都存在时仍渲染两个下拉，并保留分隔线；
- 补充单测覆盖 live=0/resume>0 和 live>0/resume>0 两种场景。

## 为什么

Jarvis/Claude Code 的 `/adopt` 会同时查 tmux 活会话和磁盘历史会话。当前机器上可接管的活会话为 0，但可恢复历史会话为 31；handler 没有走“全部为空”的文本短路，而是继续建卡。

原卡片构造逻辑会无条件渲染“运行中会话”下拉，导致卡片里出现空 options 的 `select_static`，被飞书接口以 400 拒收，最终用户侧表现为 `/adopt` 没反应。

## 影响面

- 影响模块：飞书交互卡片生成中的 `/adopt` 选择卡片；
- 影响会话类型：主要是 Claude Code 等走 tmux live adopt + disk resume 的 CLI；Codex app-server 的 `/adopt` 走另一条线程列表卡片路径，不受影响；
- 兼容性：live 和 resume 都有时行为保持不变；live 为空、resume 非空时从失败变为只展示 resume 下拉；两者都为空仍由 handler 返回文本提示。

## 验证

- `pnpm vitest run --project unit test/card-builder.test.ts`
  - 119 tests passed
- `pnpm build`
  - tsc 和 dashboard bundle 均通过
