### PR TITLE
fix(dashboard): 修正「自动创建 worktree」开关布局（开关与文字改为同行）

### DIFF
--- a/src/dashboard/web/bot-defaults.ts
+++ b/src/dashboard/web/bot-defaults.ts
@@ -410,14 +410,12 @@ export function wireBotDefaultsPage(root: HTMLElement): PageDisposer {
                   value="${escapeHtml(wdDirValue)}">
               </label>
             </div>
-            <div class="bd-row" data-wd-worktree-row ${wdMode === 'default' ? '' : 'hidden'}>
-              <label class="toggle-row">
-                <input type="checkbox" data-input="autoWorktree" ${b.defaultWorkingDirAutoWorktree ? 'checked' : ''}>
-                <span class="switch" aria-hidden="true"></span>
-                <span class="toggle-tx"><strong>${t('botDefaults.autoWorktree')}</strong>
-                <small>${t('botDefaults.autoWorktreeHelp')}</small></span>
-              </label>
-            </div>
+            <label class="toggle-row" data-wd-worktree-row ${wdMode === 'default' ? '' : 'hidden'}>
+              <input type="checkbox" data-input="autoWorktree" ${b.defaultWorkingDirAutoWorktree ? 'checked' : ''}>
+              <span class="switch" aria-hidden="true"></span>
+              <span class="toggle-tx"><strong>${t('botDefaults.autoWorktree')}</strong>
+              <small>${t('botDefaults.autoWorktreeHelp')}</small></span>
+            </label>
             <div class="actions">
               <button type="button" class="primary" data-action="save-working-dir">${t('botDefaults.save')}</button>
               <span class="oncall-status" data-status></span>


### PR DESCRIPTION
## 问题
PR #385 加的「每个新会话自动创建 worktree」开关布局怪异——开关（pill switch）浮在文字上方竖排，而非像其它 toggle 那样开关在文字左侧同行。

## 原因
该开关外面多套了一层 `<div class="bd-row">`，命中 `style.css` 的 `.bd-body .bd-row label { display:block }`（line 2441），把 `.toggle-row` 的 `display:flex` 横向布局覆盖成 block 竖排。

## 修法
去掉 `.bd-row` wrapper，`data-wd-worktree-row`（show/hide 用）直接挂到 `<label class="toggle-row">` 上，使其与「禁用流式卡片」「sandbox」等其它 toggle-row 结构完全一致 → 开关回到文字左侧同行。**纯 UI 布局修正，无逻辑改动。**

帮助文字默认单行截断、点击展开是所有 toggle-row 的既有统一行为，非本次问题。

## 测试
- `pnpm build` 绿
- 仅一处 markup 改动（去掉一层 wrapper div），与既有 toggle 结构对齐