### PR TITLE
feat(send): support lark video previews

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ teach the agent when/how to use them.
 
 | Subcommand | Description |
 |------------|-------------|
-| `botmux send [content]` | Send message to current thread (stdin / heredoc / `--content-file`; `--images` / `--files` / `--mention` flags) |
+| `botmux send [content]` | Send message to current thread (stdin / heredoc / `--content-file`; `--images` / `--files` / `--videos` / `--mention` flags) |
 | `botmux bots list` | List bots in current chat with their `open_id`s |
 | `botmux thread messages [--limit N]` | Fetch thread message history (JSON) |
 | `botmux schedule add <schedule> <prompt>` | Create scheduled task bound to current thread |

--- a/docs-site/docs/en/cli-commands.md
+++ b/docs-site/docs/en/cli-commands.md
@@ -37,7 +37,7 @@ Session info is inferred automatically from ancestor-process markers, so the age
 
 | Command | Description |
 |------|------|
-| `botmux send [content]` | Send a message to the current topic (stdin / heredoc / `--content-file`; `--images`/`--files`/`--mention`) |
+| `botmux send [content]` | Send a message to the current topic (stdin / heredoc / `--content-file`; `--images`/`--files`/`--videos`/`--mention`) |
 | `botmux bots list` | List the bots in the current group (including open_id) |
 | `botmux history [--limit N]` | Pull the session history (JSON) |
 | `botmux quoted <message_id>` | Pull a single quoted message (JSON) |

--- a/docs-site/docs/zh/cli-commands.md
+++ b/docs-site/docs/zh/cli-commands.md
@@ -37,7 +37,7 @@ session 信息通过祖先进程标记自动推断，agent 直接调：
 
 | 命令 | 说明 |
 |------|------|
-| `botmux send [content]` | 向当前话题发消息（stdin / heredoc / `--content-file`；`--images`/`--files`/`--mention`） |
+| `botmux send [content]` | 向当前话题发消息（stdin / heredoc / `--content-file`；`--images`/`--files`/`--videos`/`--mention`） |
 | `botmux bots list` | 列出当前群里的机器人（含 open_id） |
 | `botmux history [--limit N]` | 拉会话历史（JSON） |
 | `botmux quoted <message_id>` | 拉被引用的单条消息（JSON） |

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -675,25 +675,34 @@ export function sweepOrphanSandboxes(dataDir: string, activeSessionIds: Set<stri
 // watcher NEVER executes sandbox-supplied argv — it rebuilds the command from
 // these validated fields. This is the security boundary: a malicious agent can
 // write any outbox file, so everything here is treated as untrusted.
-//   { contentFile: <basename in outbox>, attachments: [<basename>...], flags: [...] }
+//   { contentFile: <basename in outbox>, attachments: [<basename>...], videos: [<basename>...], videoCovers: [<basename>...], flags: [...] }
 export interface RelayRequest {
   contentFile?: unknown;
   attachments?: unknown;
+  videos?: unknown;
+  videoCovers?: unknown;
   flags?: unknown;
 }
 // Presentation-only flags the sandbox may pass through. Path-bearing flags
-// (--content-file/--file(s)/--image(s)), routing flags (--chat-id/--into/
-// --top-level), and --session-id are NOT allowlisted: content/attachments come
-// from validated outbox files, and session-id is forced by the worker.
+// (--content-file/--file(s)/--image(s)/--video(s)), routing flags
+// (--chat-id/--into/--top-level), and --session-id are NOT allowlisted:
+// content/attachments come from validated outbox files, and session-id is
+// forced by the worker.
 const RELAY_FLAGS_NOVAL = new Set(['--mention-back', '--no-mention', '--no-quote', '--voice']);
 const RELAY_FLAGS_VAL = new Set(['--mention', '--quote']);
 
-export interface ValidatedRelay { contentName: string; attachmentNames: string[]; flags: string[]; }
+export interface ValidatedRelay {
+  contentName: string;
+  attachmentNames: string[];
+  videoNames: string[];
+  videoCoverNames: string[];
+  flags: string[];
+}
 
 /**
  * PURE validation of an outbox relay request (schema + flag allowlist only — no
  * filesystem access, so it's deterministically testable):
- *  - contentFile/attachments must be plain basenames (no `/`, `\`, `..`).
+ *  - contentFile/attachments/videos/videoCovers must be plain basenames (no `/`, `\`, `..`).
  *  - only allowlisted presentation flags pass; any other flag → reject (this
  *    rejects raw `--content-file`/`--session-id`/path flags etc.).
  * The TOCTOU-safe filesystem read is handled separately by materializeOutboxFile,
@@ -708,6 +717,16 @@ export function validateRelayRequest(req: RelayRequest): { ok: true; value: Vali
   for (const a of Array.isArray(req.attachments) ? req.attachments : []) {
     if (!safeName(a)) return { ok: false, error: 'attachment must be a plain outbox basename' };
     attachmentNames.push(a);
+  }
+  const videoNames: string[] = [];
+  for (const a of Array.isArray(req.videos) ? req.videos : []) {
+    if (!safeName(a)) return { ok: false, error: 'video must be a plain outbox basename' };
+    videoNames.push(a);
+  }
+  const videoCoverNames: string[] = [];
+  for (const a of Array.isArray(req.videoCovers) ? req.videoCovers : []) {
+    if (!safeName(a)) return { ok: false, error: 'video cover must be a plain outbox basename' };
+    videoCoverNames.push(a);
   }
   const flags: string[] = [];
   const rawFlags = Array.isArray(req.flags) ? req.flags : [];
@@ -726,7 +745,7 @@ export function validateRelayRequest(req: RelayRequest): { ok: true; value: Vali
     }
     return { ok: false, error: `flag not allowed: ${f}` };
   }
-  return { ok: true, value: { contentName: req.contentFile, attachmentNames, flags } };
+  return { ok: true, value: { contentName: req.contentFile, attachmentNames, videoNames, videoCoverNames, flags } };
 }
 
 /**
@@ -818,11 +837,31 @@ export function startOutboxWatcher(outbox: string, baseEnv: NodeJS.ProcessEnv, s
         staged.push(dest); attPaths.push(dest);
       });
       if (attBad) { finish(id, reqPath, name, staged, 1, '', 'relay rejected: attachment not a regular file in outbox'); continue; }
+      let videoBad = false;
+      const videoPaths: string[] = [];
+      v.value.videoNames.forEach((vn, i) => {
+        if (videoBad) return;
+        const dest = join(staging, `${id}-video${i}-${vn}`);
+        if (!materializeOutboxFile(outbox, vn, dest)) { videoBad = true; return; }
+        staged.push(dest); videoPaths.push(dest);
+      });
+      if (videoBad) { finish(id, reqPath, name, staged, 1, '', 'relay rejected: video not a regular file in outbox'); continue; }
+      let coverBad = false;
+      const videoCoverPaths: string[] = [];
+      v.value.videoCoverNames.forEach((cn, i) => {
+        if (coverBad) return;
+        const dest = join(staging, `${id}-video-cover${i}-${cn}`);
+        if (!materializeOutboxFile(outbox, cn, dest)) { coverBad = true; return; }
+        staged.push(dest); videoCoverPaths.push(dest);
+      });
+      if (coverBad) { finish(id, reqPath, name, staged, 1, '', 'relay rejected: video cover not a regular file in outbox'); continue; }
 
       const hostArgs = [
         ...v.value.flags,
         '--content-file', contentDest,
         ...attPaths.flatMap(a => ['--files', a]),
+        ...videoPaths.flatMap(a => ['--videos', a]),
+        ...videoCoverPaths.flatMap(a => ['--video-covers', a]),
         '--session-id', sessionId,  // forced — sandbox cannot target another session
       ];
       const child = spawn(process.execPath, [cli, 'send', ...hostArgs], { env });

--- a/src/adapters/cli/shared-hints.ts
+++ b/src/adapters/cli/shared-hints.ts
@@ -107,6 +107,7 @@ export function buildBotmuxSystemPromptText(opts: {
     t('ai.routing.heredoc_example', undefined, locale),
     t('ai.routing.usage_images', undefined, locale),
     t('ai.routing.usage_files', undefined, locale),
+    t('ai.routing.usage_videos', undefined, locale),
     t('ai.routing.usage_history', undefined, locale),
     t('ai.routing.usage_bots_list', undefined, locale),
     ...whiteboardRouting,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,7 +64,7 @@ import type { CliId } from './adapters/cli/types.js';
 import { logger } from './utils/logger.js';
 import { expandHomePath, invalidWorkingDirs } from './utils/working-dir.js';
 import { firstPositional } from './cli/arg-utils.js';
-import { dispatchPrimaryMessage, findStdinAliasAttachment, sendFileAttachments } from './cli/send-dispatch.js';
+import { dispatchPrimaryMessage, findStdinAliasAttachment, sendFileAttachments, sendVideoAttachments, validateVideoAttachments } from './cli/send-dispatch.js';
 import { buildPm2SpawnCommand } from './cli/pm2-command.js';
 import { callDashboard, type DashboardEndpoint, type DashboardResult } from './cli/dashboard-endpoint.js';
 import { npmGlobalUpdateCwd } from './core/maintenance.js';
@@ -3631,6 +3631,8 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
   send [content]                       发消息到当前话题（支持 stdin / --content-file）
        --images <path>                 内联图片（可重复）
        --files <path>                  附件（可重复）
+       --videos <path>                 视频预览 MP4（可重复，需配套 --video-covers）
+       --video-covers <path>           视频封面图片（可重复，按顺序对应 --videos）
        --mention <open_id:name>        @提及（可重复）
        --mention-back                  @回本轮触发消息的发送者（open_id 自动取自会话）
        --no-mention                    明确声明本条不@任何人
@@ -4416,12 +4418,23 @@ async function relaySend(rest: string[], relayDir: string): Promise<void> {
   const cfile = join(relayDir, contentBase);
   writeFileSync(cfile, content);
 
-  // Copy any --image/--file attachment into the outbox; carry only basenames.
+  // Copy attachments into the outbox; carry only basenames.
+  const copyOutboxAttachment = (p: string, out: string[]): void => {
+    if (!p || !existsSync(p)) return;
+    const base = `${id}-${randomBytes(4).toString('hex')}-${basename(p)}`;
+    try { writeFileSync(join(relayDir, base), readFileSync(p)); out.push(base); } catch { /* skip unreadable */ }
+  };
   const attachments: string[] = [];
   for (const p of argValues(rest, '--image', '--images', '--file', '--files')) {
-    if (!p || !existsSync(p)) continue;
-    const base = `${id}-${randomBytes(4).toString('hex')}-${basename(p)}`;
-    try { writeFileSync(join(relayDir, base), readFileSync(p)); attachments.push(base); } catch { /* skip unreadable */ }
+    copyOutboxAttachment(p, attachments);
+  }
+  const videos: string[] = [];
+  for (const p of argValues(rest, '--video', '--videos')) {
+    copyOutboxAttachment(p, videos);
+  }
+  const videoCovers: string[] = [];
+  for (const p of argValues(rest, '--video-cover', '--video-covers')) {
+    copyOutboxAttachment(p, videoCovers);
   }
 
   // Forward only presentation flags (must match the watcher's allowlist); path,
@@ -4438,7 +4451,7 @@ async function relaySend(rest: string[], relayDir: string): Promise<void> {
   }
   // 原子写：req.json 是 host watcher 的触发文件，rename 让它「完整出现」，
   // watcher 永远不会读到半截 JSON（tmp 后缀不匹配 .req.json 过滤）。
-  atomicWriteFileSync(join(relayDir, `${id}.req.json`), JSON.stringify({ contentFile: contentBase, attachments, flags }));
+  atomicWriteFileSync(join(relayDir, `${id}.req.json`), JSON.stringify({ contentFile: contentBase, attachments, videos, videoCovers, flags }));
 
   const resPath = join(relayDir, `${id}.res.json`);
   const deadlineMs = Date.now() + 120_000;
@@ -4513,16 +4526,30 @@ async function cmdSend(rest: string[]): Promise<void> {
   // from its own worker-written cred file instead (see registerSelfFromCredFile).
   await registerSelfFromCredFile();
   const sessionIdArg = argValue(rest, '--session-id');
+  for (const flag of ['--video', '--videos', '--video-cover', '--video-covers']) {
+    if (flagPresentButValueMissing(rest, flag, true)) {
+      console.error(`botmux send: ${flag} 需要路径参数`);
+      process.exit(2);
+    }
+  }
   const images = argValues(rest, '--image', '--images');
   const files = argValues(rest, '--file', '--files');
+  const videos = argValues(rest, '--video', '--videos');
+  const videoCovers = argValues(rest, '--video-cover', '--video-covers');
+  const videoValidation = validateVideoAttachments(videos, videoCovers);
+  if (!videoValidation.ok) {
+    console.error(`botmux send: ${videoValidation.error}`);
+    process.exit(2);
+  }
+  const videoAttachments = videoValidation.videos;
   // stdin can't be both the message body (which `botmux send` reads from it) and
-  // a `--file`/`--image` attachment — the second read sees EOF and the upload
+  // a `--file`/`--image`/`--video` attachment — the second read sees EOF and the upload
   // fails *after* the message is already sent, leaving the caller to resend.
   // Reject up front so exit≠0 reliably means "nothing was sent".
-  const stdinAlias = findStdinAliasAttachment([...images, ...files]);
+  const stdinAlias = findStdinAliasAttachment([...images, ...files, ...videos, ...videoCovers]);
   if (stdinAlias) {
     console.error(
-      `不能把 stdin（${stdinAlias}）当作 --file/--image 附件：botmux send 已从 stdin 读取消息正文，\n` +
+      `不能把 stdin（${stdinAlias}）当作 --file/--image/--video 附件：botmux send 已从 stdin 读取消息正文，\n` +
       `同一个 stdin 没法既当正文又当附件（第二次读到的是 EOF）。\n` +
       `要发送管道内容，先落到临时文件：  数据来源 > /tmp/x && botmux send --files /tmp/x …`,
     );
@@ -4586,8 +4613,8 @@ async function cmdSend(rest: string[]): Promise<void> {
   }
   if (!contentFile) rejectLikelyWindowsStdinMojibake(content);
 
-  if (!content.trim() && images.length === 0 && files.length === 0) {
-    console.error('没有内容可发送。用法:\n  echo "消息" | botmux send\n  botmux send "消息"\n  botmux send --content-file /tmp/msg.md --images /tmp/chart.png');
+  if (!content.trim() && images.length === 0 && files.length === 0 && videoAttachments.length === 0) {
+    console.error('没有内容可发送。用法:\n  echo "消息" | botmux send\n  botmux send "消息"\n  botmux send --content-file /tmp/msg.md --images /tmp/chart.png\n  botmux send --videos /tmp/replay.mp4 --video-covers /tmp/cover.png --no-mention "视频预览"');
     process.exit(1);
   }
 
@@ -4729,8 +4756,11 @@ async function cmdSend(rest: string[]): Promise<void> {
   }
 
   // Validate file paths
-  for (const p of [...images, ...files]) {
+  for (const p of [...images, ...files, ...videos, ...videoCovers]) {
     if (!existsSync(p)) { console.error(`文件不存在: ${p}`); process.exit(1); }
+  }
+  for (const p of [...videos, ...videoCovers]) {
+    if (!statSync(p).isFile()) { console.error(`不是普通文件: ${p}`); process.exit(1); }
   }
 
   // Register bots so Lark client works
@@ -4989,7 +5019,20 @@ async function cmdSend(rest: string[]): Promise<void> {
     // we committed to sending — that's the boundary the gate cares about.
     const sentAtMs = Date.now();
     let messageId: string;
-    {
+    let failedAttachments: { path: string; error: string }[] = [];
+    let failedVideoAttachments: { path: string; coverPath: string; error: string }[] = [];
+    const pureVideoSend = !text.trim() && imageKeys.length === 0 && files.length === 0 && videoAttachments.length > 0;
+    if (pureVideoSend) {
+      const videoResult = await sendVideoAttachments(
+        { uploadFile, uploadImage, dispatch }, appId, videoAttachments,
+      );
+      failedVideoAttachments = videoResult.failed;
+      if (videoResult.sent.length === 0) {
+        const first = failedVideoAttachments[0]?.error ?? 'unknown error';
+        throw new Error(`视频发送失败: ${first}`);
+      }
+      messageId = videoResult.sent[0];
+    } else {
       // 回复一律卡片（纯文本 post 路径已删）。
       // Inline `@Name` → `<at id=…>` at the exact spot it's written (CJK-name
       // aware, see applyInlineMentions); any --mention not inlined here is
@@ -5094,16 +5137,27 @@ async function cmdSend(rest: string[]): Promise<void> {
     // closed a pending response card for this turn.
     if (shouldRecordBridgeMarker) recordBridgeSendMarker(sentAtMs, messageId, text);
 
-    // Send file attachments as separate messages — best-effort. The primary
-    // message is already delivered above; a failing attachment must not throw
-    // out to the catch below (which would report total failure / exit 1 for an
-    // already-sent message and make the caller resend). Warn instead, and list
-    // the failures in the success JSON.
-    const { failed: failedAttachments } = await sendFileAttachments(
-      { uploadFile, dispatch }, appId, files,
-    );
+    // Send attachments as separate messages — best-effort. The primary message
+    // is already delivered above; a failing attachment must not throw out to the
+    // catch below (which would report total failure / exit 1 for an already-sent
+    // message and make the caller resend). Warn instead, and list failures in
+    // the success JSON. Pure-video sends have no text/card primary, so the media
+    // message above is the primary and failures before any media is sent still
+    // surface as command failure.
+    if (!pureVideoSend) {
+      ({ failed: failedAttachments } = await sendFileAttachments(
+        { uploadFile, dispatch }, appId, files,
+      ));
+      const videoResult = await sendVideoAttachments(
+        { uploadFile, uploadImage, dispatch }, appId, videoAttachments,
+      );
+      failedVideoAttachments = videoResult.failed;
+    }
     for (const f of failedAttachments) {
       console.error(`⚠️ 附件未发送（主消息已送达 ${messageId}，请勿重发）: ${f.path} — ${f.error}`);
+    }
+    for (const f of failedVideoAttachments) {
+      console.error(`⚠️ 视频未发送（主消息已送达 ${messageId}，请勿重发）: ${f.path} / cover ${f.coverPath} — ${f.error}`);
     }
 
     // Bot-to-bot 转发依赖飞书"获取群组中其他机器人和用户@当前机器人的消息"权限：
@@ -5151,6 +5205,9 @@ async function cmdSend(rest: string[]): Promise<void> {
       ...(attention.requested ? { attentionRaised, attentionError } : {}),
       ...(failedAttachments.length > 0
         ? { failedAttachments: failedAttachments.map(f => f.path) }
+        : {}),
+      ...(failedVideoAttachments.length > 0
+        ? { failedVideoAttachments: failedVideoAttachments.map(f => f.path) }
         : {}),
     }));
   } catch (err: any) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5035,8 +5035,13 @@ async function cmdSend(rest: string[]): Promise<void> {
       mentionCount: mentions.length,
     });
     if (pureVideoSend) {
+      // No card/text primary here, so the FIRST media message must carry the
+      // quote chain itself (dispatchPrimary applies the chat-scope quoteTargetId
+      // and updates primaryQuotedId). Otherwise a bare `--videos … --no-mention`
+      // reply in a 普通群 lands as a standalone message that doesn't quote the
+      // trigger — unlike file-only/image-only sends whose primary card quotes.
       const videoResult = await sendVideoAttachments(
-        { uploadFile, uploadImage, dispatch }, appId, videoAttachments,
+        { uploadFile, uploadImage, dispatch, primaryDispatch: dispatchPrimary }, appId, videoAttachments,
       );
       failedVideoAttachments = videoResult.failed;
       if (videoResult.sent.length === 0) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,7 +64,7 @@ import type { CliId } from './adapters/cli/types.js';
 import { logger } from './utils/logger.js';
 import { expandHomePath, invalidWorkingDirs } from './utils/working-dir.js';
 import { firstPositional } from './cli/arg-utils.js';
-import { dispatchPrimaryMessage, findStdinAliasAttachment, sendFileAttachments, sendVideoAttachments, validateVideoAttachments } from './cli/send-dispatch.js';
+import { dispatchPrimaryMessage, findStdinAliasAttachment, sendFileAttachments, sendVideoAttachments, shouldSendAsPureVideo, validateVideoAttachments } from './cli/send-dispatch.js';
 import { buildPm2SpawnCommand } from './cli/pm2-command.js';
 import { callDashboard, type DashboardEndpoint, type DashboardResult } from './cli/dashboard-endpoint.js';
 import { npmGlobalUpdateCwd } from './core/maintenance.js';
@@ -5021,7 +5021,19 @@ async function cmdSend(rest: string[]): Promise<void> {
     let messageId: string;
     let failedAttachments: { path: string; error: string }[] = [];
     let failedVideoAttachments: { path: string; coverPath: string; error: string }[] = [];
-    const pureVideoSend = !text.trim() && imageKeys.length === 0 && files.length === 0 && videoAttachments.length > 0;
+    // Pure-video fast path: send the preview as a standalone media message.
+    // A send that also carries mentions is deliberately excluded (media messages
+    // can't embed `<at>`), so it falls through to the card branch which renders
+    // the @ on the footer and sends the video as a follow-up attachment — same
+    // shape as an attachment-only `--files … --mention …` send, whose card body
+    // is likewise empty. See shouldSendAsPureVideo.
+    const pureVideoSend = shouldSendAsPureVideo({
+      hasBodyText: !!text.trim(),
+      imageCount: imageKeys.length,
+      fileCount: files.length,
+      videoCount: videoAttachments.length,
+      mentionCount: mentions.length,
+    });
     if (pureVideoSend) {
       const videoResult = await sendVideoAttachments(
         { uploadFile, uploadImage, dispatch }, appId, videoAttachments,

--- a/src/cli/send-dispatch.ts
+++ b/src/cli/send-dispatch.ts
@@ -153,6 +153,13 @@ export type SendVideoAttachmentsDeps = {
   uploadFile: (appId: string, path: string) => Promise<string>;
   uploadImage: (appId: string, path: string) => Promise<string>;
   dispatch: (content: string, msgType: string) => Promise<string>;
+  // Optional: dispatch used for the FIRST successfully-sent video only. A
+  // pure-video send (no text/card primary) has no other message to carry the
+  // quote/reply chain, so its first media message must go through the primary
+  // dispatch (which applies the chat-scope quoteTargetId) to stay consistent
+  // with card/file/image sends. Later videos remain best-effort via `dispatch`.
+  // Omitted for secondary sends (card is already the primary) → all use `dispatch`.
+  primaryDispatch?: (content: string, msgType: string) => Promise<string>;
 };
 
 export type SendVideoAttachmentsResult = {
@@ -167,6 +174,10 @@ export async function sendVideoAttachments(
 ): Promise<SendVideoAttachmentsResult> {
   const sent: string[] = [];
   const failed: { path: string; coverPath: string; error: string }[] = [];
+  // The first video that actually goes out uses `primaryDispatch` (quote chain);
+  // every later one uses plain `dispatch`. Tracked on success only, so if the
+  // first video's upload fails the next one inherits the primary slot.
+  let primaryUsed = false;
   for (const video of videos) {
     try {
       const fileKey = await deps.uploadFile(appId, video.videoPath);
@@ -176,7 +187,10 @@ export async function sendVideoAttachments(
         image_key: imageKey,
         duration: video.durationMs,
       });
-      sent.push(await deps.dispatch(content, 'media'));
+      const send = (!primaryUsed && deps.primaryDispatch) ? deps.primaryDispatch : deps.dispatch;
+      const messageId = await send(content, 'media');
+      primaryUsed = true;
+      sent.push(messageId);
     } catch (err: any) {
       failed.push({
         path: video.videoPath,

--- a/src/cli/send-dispatch.ts
+++ b/src/cli/send-dispatch.ts
@@ -82,6 +82,29 @@ export async function sendFileAttachments(
 const VIDEO_EXTENSIONS = new Set(['.mp4']);
 const VIDEO_COVER_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);
 
+/**
+ * Decide whether a send is a "pure video" send — one delivered as a standalone
+ * Lark media message with no text/card primary.
+ *
+ * A media message CANNOT embed an `<at>`, so a send that also carries mentions
+ * must NOT be pure-video: it has to go through the card path (which renders the
+ * @ on the footer) and send the video as a follow-up attachment. Otherwise the
+ * mention silently never fires while the success output still reports it.
+ */
+export function shouldSendAsPureVideo(input: {
+  hasBodyText: boolean;
+  imageCount: number;
+  fileCount: number;
+  videoCount: number;
+  mentionCount: number;
+}): boolean {
+  return !input.hasBodyText
+    && input.imageCount === 0
+    && input.fileCount === 0
+    && input.videoCount > 0
+    && input.mentionCount === 0;
+}
+
 export type VideoAttachmentInput = {
   videoPath: string;
   coverPath: string;

--- a/src/cli/send-dispatch.ts
+++ b/src/cli/send-dispatch.ts
@@ -1,3 +1,5 @@
+import { extname } from 'node:path';
+
 export type SendMessageFn = (
   larkAppId: string,
   chatId: string,
@@ -72,6 +74,92 @@ export async function sendFileAttachments(
       sent.push(await deps.dispatch(JSON.stringify({ file_key: fileKey }), 'file'));
     } catch (err: any) {
       failed.push({ path: fp, error: err?.message ?? String(err) });
+    }
+  }
+  return { sent, failed };
+}
+
+const VIDEO_EXTENSIONS = new Set(['.mp4']);
+const VIDEO_COVER_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);
+
+export type VideoAttachmentInput = {
+  videoPath: string;
+  coverPath: string;
+  durationMs: number;
+};
+
+export type VideoAttachmentValidationResult =
+  | { ok: true; videos: VideoAttachmentInput[] }
+  | { ok: false; error: string };
+
+export function validateVideoAttachments(
+  videos: readonly string[],
+  covers: readonly string[],
+): VideoAttachmentValidationResult {
+  if (videos.length === 0 && covers.length > 0) {
+    return { ok: false, error: '--video-covers 需要配套 --videos 使用' };
+  }
+  if (videos.length !== covers.length) {
+    return {
+      ok: false,
+      error: `--videos 与 --video-covers 数量必须一致（videos=${videos.length}, covers=${covers.length}）`,
+    };
+  }
+
+  const out: VideoAttachmentInput[] = [];
+  for (let i = 0; i < videos.length; i++) {
+    const videoPath = videos[i];
+    const coverPath = covers[i];
+    const videoExt = extname(videoPath).toLowerCase();
+    if (!VIDEO_EXTENSIONS.has(videoExt)) {
+      return { ok: false, error: `不支持的视频格式: ${videoPath}（目前仅支持 .mp4）` };
+    }
+    const coverExt = extname(coverPath).toLowerCase();
+    if (!VIDEO_COVER_EXTENSIONS.has(coverExt)) {
+      return {
+        ok: false,
+        error: `不支持的视频封面格式: ${coverPath}（支持 .png/.jpg/.jpeg/.gif/.webp/.bmp）`,
+      };
+    }
+    out.push({ videoPath, coverPath, durationMs: 0 });
+  }
+  return { ok: true, videos: out };
+}
+
+export type SendVideoAttachmentsDeps = {
+  uploadFile: (appId: string, path: string) => Promise<string>;
+  uploadImage: (appId: string, path: string) => Promise<string>;
+  dispatch: (content: string, msgType: string) => Promise<string>;
+};
+
+export type SendVideoAttachmentsResult = {
+  sent: string[];
+  failed: { path: string; coverPath: string; error: string }[];
+};
+
+export async function sendVideoAttachments(
+  deps: SendVideoAttachmentsDeps,
+  appId: string,
+  videos: readonly VideoAttachmentInput[],
+): Promise<SendVideoAttachmentsResult> {
+  const sent: string[] = [];
+  const failed: { path: string; coverPath: string; error: string }[] = [];
+  for (const video of videos) {
+    try {
+      const fileKey = await deps.uploadFile(appId, video.videoPath);
+      const imageKey = await deps.uploadImage(appId, video.coverPath);
+      const content = JSON.stringify({
+        file_key: fileKey,
+        image_key: imageKey,
+        duration: video.durationMs,
+      });
+      sent.push(await deps.dispatch(content, 'media'));
+    } catch (err: any) {
+      failed.push({
+        path: video.videoPath,
+        coverPath: video.coverPath,
+        error: err?.message ?? String(err),
+      });
     }
   }
   return { sent, failed };

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -382,7 +382,7 @@ function buildHermesBotmuxHints(locale?: Locale): string[] {
   if (locale === 'en') {
     return [
       'You are running in a Feishu/Lark chat through botmux. For ordinary text replies, write the user-facing answer as your final assistant message; botmux automatically forwards that final output to Feishu/Lark.',
-      'Do not call `botmux send` for normal text answers. Use `botmux send` only for special delivery needs: files/images, voice, cross-chat/top-level sends, or explicit mention routing to another person/bot.',
+      'Do not call `botmux send` for normal text answers. Use `botmux send` only for special delivery needs: files/images/videos, voice, cross-chat/top-level sends, or explicit mention routing to another person/bot.',
       '`botmux send` / `botmux history` / `botmux quoted` / `botmux bots` are shell commands installed in $PATH; run them via Bash/terminal tools when needed.',
       'If you already used `botmux send` for special delivery in this turn, do not put a second copy of the answer, messageId, or send-success receipt in the final assistant message.',
     ];
@@ -397,7 +397,7 @@ function buildHermesBotmuxHints(locale?: Locale): string[] {
 
 function hermesFollowupReminder(locale?: Locale): string {
   if (locale === 'en') {
-    return 'For ordinary text replies, do not call `botmux send`; put the user-facing answer in final and botmux will forward it to Feishu/Lark. Use `botmux send` only for special delivery such as files/images, voice, cross-chat/top-level sends, or explicit mention routing. If already used, do not add a second answer or send-success receipt in final.';
+    return 'For ordinary text replies, do not call `botmux send`; put the user-facing answer in final and botmux will forward it to Feishu/Lark. Use `botmux send` only for special delivery such as files/images/videos, voice, cross-chat/top-level sends, or explicit mention routing. If already used, do not add a second answer or send-success receipt in final.';
   }
   return '普通文字回复不要调用 `botmux send`；直接把给用户看的答案写在 final，botmux 会自动转发到飞书。只有图片/文件/语音、跨群/顶层发送、特殊 @ 路由等特殊投递才用 `botmux send`；如果本轮已经用过，不要在 final 里再写第二份答案或发送成功回执。';
 }

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -389,7 +389,7 @@ function buildHermesBotmuxHints(locale?: Locale): string[] {
   }
   return [
     '你运行在飞书（Lark）聊天中。普通文字回复请直接写在 assistant final 里，botmux 会自动把 final_output 转发到飞书。',
-    '普通文本答案不要调用 `botmux send`。只有需要图片/文件/语音、跨群或顶层发送、显式 @ 某人/某 bot 等特殊投递能力时，才使用 `botmux send`。',
+    '普通文本答案不要调用 `botmux send`。只有需要图片/文件/视频/语音、跨群或顶层发送、显式 @ 某人/某 bot 等特殊投递能力时，才使用 `botmux send`。',
     '`botmux send` / `botmux history` / `botmux quoted` / `botmux bots` 是已安装在 $PATH 的 shell 命令；需要时通过 Bash/terminal 工具执行。',
     '如果本轮已经为了特殊投递调用过 `botmux send`，final 里不要再写第二份正文、messageId 或“发送成功/已处理”回执。',
   ];
@@ -399,7 +399,7 @@ function hermesFollowupReminder(locale?: Locale): string {
   if (locale === 'en') {
     return 'For ordinary text replies, do not call `botmux send`; put the user-facing answer in final and botmux will forward it to Feishu/Lark. Use `botmux send` only for special delivery such as files/images/videos, voice, cross-chat/top-level sends, or explicit mention routing. If already used, do not add a second answer or send-success receipt in final.';
   }
-  return '普通文字回复不要调用 `botmux send`；直接把给用户看的答案写在 final，botmux 会自动转发到飞书。只有图片/文件/语音、跨群/顶层发送、特殊 @ 路由等特殊投递才用 `botmux send`；如果本轮已经用过，不要在 final 里再写第二份答案或发送成功回执。';
+  return '普通文字回复不要调用 `botmux send`；直接把给用户看的答案写在 final，botmux 会自动转发到飞书。只有图片/文件/视频/语音、跨群/顶层发送、特殊 @ 路由等特殊投递才用 `botmux send`；如果本轮已经用过，不要在 final 里再写第二份答案或发送成功回执。';
 }
 
 export function buildNewTopicPrompt(

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -523,6 +523,7 @@ export const messages: Record<string, string> = {
   'ai.routing.heredoc_example': "  Correct multi-line example:\n```bash\nbotmux send <<'EOF'\nline 1\nline 2\nEOF\n```",
   'ai.routing.usage_images': '- Attach images: `botmux send --images /path/to/img.png "caption"`',
   'ai.routing.usage_files': '- Attach files: `botmux send --files /path/to/file.pdf "FYI"`',
+  'ai.routing.usage_videos': '- Attach video previews: `botmux send --videos /path/to/replay.mp4 --video-covers /path/to/cover.png --no-mention "preview"`',
   'ai.routing.usage_history': '- Need prior context? Use `botmux history` to read this session\'s history.',
   'ai.routing.usage_bots_list': '- List collaborator bots in the group: `botmux bots list`',
 
@@ -543,7 +544,7 @@ export const messages: Record<string, string> = {
   // ─── AI hints (non-Claude CLIs: BOTMUX_SHELL_HINTS) ──────────────────────
   'ai.shell.intro': 'You are running inside a Lark (Feishu) topic group. The user reads on Lark and cannot see your terminal output.',
   'ai.shell.commands_are_shell': 'IMPORTANT: `botmux send` / `botmux history` / `botmux quoted` / `botmux bots` are SHELL commands (CLI programs installed in $PATH), NOT MCP tools. Run them via the Bash tool — don\'t look for them in the MCP tool list.',
-  'ai.shell.how_to_send': 'To send a message to the user (the only way): run `botmux send "your message"` via Bash. Attach images with `--images /path`, files with `--files /path`.',
+  'ai.shell.how_to_send': 'To send a message to the user (the only way): run `botmux send "your message"` via Bash. Attach images with `--images /path`, files with `--files /path`, video previews with `--videos /path.mp4 --video-covers /cover.png`.',
   'ai.shell.multiline_heredoc': 'Multi-line messages MUST use a heredoc — never `botmux send "line1\\nline2"`, since `\\n` may appear literally in Lark.',
   'ai.shell.heredoc_example': "Correct multi-line example:\n```bash\nbotmux send <<'EOF'\nline 1\nline 2\nEOF\n```",
   'ai.shell.helpers': 'Helpers: `botmux history` (read this session\'s history — thread/topic sessions are topic-scoped; regular-group chat-scope sessions are group-wide), `botmux quoted <message_id>` (fetch a quoted message — only use it when the prompt header shows `[user quoted message ...]`), `botmux bots list` (list other bots in the group).',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -526,6 +526,7 @@ export const messages: Record<string, string> = {
   'ai.routing.heredoc_example': "  正确多行示例：\n```bash\nbotmux send <<'EOF'\n第一行\n第二行\nEOF\n```",
   'ai.routing.usage_images': '- 附带图片：`botmux send --images /path/to/img.png "说明文字"`',
   'ai.routing.usage_files': '- 附带文件：`botmux send --files /path/to/file.pdf "请查收"`',
+  'ai.routing.usage_videos': '- 附带视频预览：`botmux send --videos /path/to/replay.mp4 --video-covers /path/to/cover.png --no-mention "预览"`',
   'ai.routing.usage_history': '- 需要上下文时用 `botmux history` 读取之前的对话。',
   'ai.routing.usage_bots_list': '- 查看可协作的机器人：`botmux bots list`',
 
@@ -546,7 +547,7 @@ export const messages: Record<string, string> = {
   // ─── AI hints (non-Claude CLIs: BOTMUX_SHELL_HINTS) ──────────────────────
   'ai.shell.intro': '你运行在飞书（Lark）话题群中。用户在飞书阅读回复，看不到你的终端输出。',
   'ai.shell.commands_are_shell': '重要：botmux send / botmux history / botmux quoted / botmux bots 都是 shell 命令（CLI 程序，已安装在 $PATH），不是 MCP 工具。必须通过 Bash 工具执行，不要到 MCP 工具列表里找。',
-  'ai.shell.how_to_send': '把消息发给用户（唯一方式）：用 Bash 执行 `botmux send "消息内容"`；附带图片用 `--images /path`，附带文件用 `--files /path`。',
+  'ai.shell.how_to_send': '把消息发给用户（唯一方式）：用 Bash 执行 `botmux send "消息内容"`；附带图片用 `--images /path`，附带文件用 `--files /path`，附带视频预览用 `--videos /path.mp4 --video-covers /cover.png`。',
   'ai.shell.multiline_heredoc': '多行消息必须用 heredoc，禁止写成 `botmux send "第一行\\n第二行"`；否则 `\\n` 可能按字面量显示在飞书里。',
   'ai.shell.heredoc_example': "正确多行示例：\n```bash\nbotmux send <<'EOF'\n第一行\n第二行\nEOF\n```",
   'ai.shell.helpers': '辅助命令：`botmux history`（读此会话历史；thread/话题会话拉话题内，普通群 chat-scope 会话拉整群）、`botmux quoted <message_id>`（按需读取被引用的消息，仅在 prompt 头部出现 `[用户引用了消息 ...]` 提示时使用）、`botmux bots list`（查群内其他机器人）。',

--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -355,6 +355,14 @@ EOF
 botmux send --files /tmp/report.pdf "报告已生成，请查收附件。"
 \`\`\`
 
+### 带视频预览
+
+\`--videos <path>\` 发送本地 H.264 MP4 预览消息，可重复；\`--video-covers <path>\` 按顺序提供每个视频的封面图片（当前必须显式提供 cover）。视频会作为飞书/Lark media message 单独发送；正文存在时先发正文卡片，再发视频。
+
+\`\`\`bash
+botmux send --videos /tmp/replay.mp4 --video-covers /tmp/cover.png --no-mention "RRH replay preview"
+\`\`\`
+
 ### @mention 其他机器人协作
 
 \`\`\`bash
@@ -434,6 +442,8 @@ botmux send --top-level --chat-id oc_xxxxxxxxxxxx "📦 自动推送内容..."
 | \`--content-file <path>\` | 从文件读取内容（优先于 stdin/positional） |
 | \`--images <path>\` | 内联图片，可重复多次 |
 | \`--files <path>\` | 附件文件，可重复多次，每个单独发送 |
+| \`--videos <path>\` | 视频预览 MP4，可重复；每个必须有对应 \`--video-covers\` |
+| \`--video-covers <path>\` | 视频封面图片，可重复，按顺序对应 \`--videos\` |
 | \`--mention <open_id[:name]>\` | @mention，可重复。带 \`:name\` 时文本里的 \`@name\` 会被替换成 \<at\> 标签；只传 open_id 则在消息末尾追加 @。用 \`botmux bots list\` 查 open_id |
 | \`--mention-back\` | @ 回本轮触发消息的发送者（open_id 自动从会话取）。满足 @ 硬门 |
 | \`--no-mention\` | 明确声明本条不 @ 任何人。满足 @ 硬门 |

--- a/test/cli-send-dispatch.test.ts
+++ b/test/cli-send-dispatch.test.ts
@@ -280,4 +280,54 @@ describe('sendVideoAttachments (best-effort media messages)', () => {
       failed: [{ path: '/tmp/b.mp4', coverPath: '/tmp/b.png', error: 'dispatch failed' }],
     });
   });
+
+  it('routes the FIRST video through primaryDispatch (quote chain) and later videos through dispatch', async () => {
+    // Pure-video sends have no card primary, so the first media message must go
+    // through primaryDispatch to keep the chat-scope quote/reply chain — the rest
+    // stay best-effort via plain dispatch. Regression guard for Codex P2.
+    const uploadFile = vi.fn(async (_app: string, p: string) => `file:${p}`);
+    const uploadImage = vi.fn(async (_app: string, p: string) => `image:${p}`);
+    const primaryDispatch = vi.fn(async (content: string) => `primary:${content}`);
+    const dispatch = vi.fn(async (content: string) => `plain:${content}`);
+
+    const res = await sendVideoAttachments(
+      { uploadFile, uploadImage, dispatch, primaryDispatch },
+      'cli_app',
+      [
+        { videoPath: '/tmp/a.mp4', coverPath: '/tmp/a.png', durationMs: 0 },
+        { videoPath: '/tmp/b.mp4', coverPath: '/tmp/b.png', durationMs: 0 },
+      ],
+    );
+
+    expect(primaryDispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(res.failed).toEqual([]);
+    expect(res.sent[0]).toBe('primary:{"file_key":"file:/tmp/a.mp4","image_key":"image:/tmp/a.png","duration":0}');
+    expect(res.sent[1]).toBe('plain:{"file_key":"file:/tmp/b.mp4","image_key":"image:/tmp/b.png","duration":0}');
+  });
+
+  it('hands the primary (quote) slot to the next video when the first one fails to send', async () => {
+    const uploadFile = vi.fn(async (_app: string, p: string) => {
+      if (p === '/tmp/a.mp4') throw new Error('upload failed');
+      return `file:${p}`;
+    });
+    const uploadImage = vi.fn(async (_app: string, p: string) => `image:${p}`);
+    const primaryDispatch = vi.fn(async (content: string) => `primary:${content}`);
+    const dispatch = vi.fn(async (content: string) => `plain:${content}`);
+
+    const res = await sendVideoAttachments(
+      { uploadFile, uploadImage, dispatch, primaryDispatch },
+      'cli_app',
+      [
+        { videoPath: '/tmp/a.mp4', coverPath: '/tmp/a.png', durationMs: 0 },
+        { videoPath: '/tmp/b.mp4', coverPath: '/tmp/b.png', durationMs: 0 },
+      ],
+    );
+
+    // a.mp4 upload failed → primary slot inherited by b.mp4.
+    expect(primaryDispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(res.sent).toEqual(['primary:{"file_key":"file:/tmp/b.mp4","image_key":"image:/tmp/b.png","duration":0}']);
+    expect(res.failed).toEqual([{ path: '/tmp/a.mp4', coverPath: '/tmp/a.png', error: 'upload failed' }]);
+  });
 });

--- a/test/cli-send-dispatch.test.ts
+++ b/test/cli-send-dispatch.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { dispatchPrimaryMessage, findStdinAliasAttachment, sendFileAttachments } from '../src/cli/send-dispatch.js';
+import {
+  dispatchPrimaryMessage,
+  findStdinAliasAttachment,
+  sendFileAttachments,
+  sendVideoAttachments,
+  validateVideoAttachments,
+} from '../src/cli/send-dispatch.js';
 
 class MessageWithdrawnError extends Error {}
 
@@ -134,5 +140,117 @@ describe('sendFileAttachments (best-effort, never throws after primary send)', (
       { path: '/x', error: 'dispatch down' },
       { path: '/y', error: 'dispatch down' },
     ]);
+  });
+});
+
+describe('validateVideoAttachments', () => {
+  it('accepts repeated mp4 videos with matching image covers', () => {
+    expect(validateVideoAttachments(['/tmp/a.mp4', '/tmp/b.MP4'], ['/tmp/a.png', '/tmp/b.JPG'])).toEqual({
+      ok: true,
+      videos: [
+        { videoPath: '/tmp/a.mp4', coverPath: '/tmp/a.png', durationMs: 0 },
+        { videoPath: '/tmp/b.MP4', coverPath: '/tmp/b.JPG', durationMs: 0 },
+      ],
+    });
+  });
+
+  it('rejects missing or mismatched covers as usage errors', () => {
+    expect(validateVideoAttachments(['/tmp/a.mp4'], [])).toEqual({
+      ok: false,
+      error: '--videos 与 --video-covers 数量必须一致（videos=1, covers=0）',
+    });
+    expect(validateVideoAttachments([], ['/tmp/a.png'])).toEqual({
+      ok: false,
+      error: '--video-covers 需要配套 --videos 使用',
+    });
+  });
+
+  it('rejects unsupported video and cover extensions', () => {
+    expect(validateVideoAttachments(['/tmp/a.mov'], ['/tmp/a.png'])).toEqual({
+      ok: false,
+      error: '不支持的视频格式: /tmp/a.mov（目前仅支持 .mp4）',
+    });
+    expect(validateVideoAttachments(['/tmp/a.mp4'], ['/tmp/a.svg'])).toEqual({
+      ok: false,
+      error: '不支持的视频封面格式: /tmp/a.svg（支持 .png/.jpg/.jpeg/.gif/.webp/.bmp）',
+    });
+  });
+});
+
+describe('sendVideoAttachments (best-effort media messages)', () => {
+  it('uploads the mp4 and cover, then dispatches Lark media content', async () => {
+    const uploadFile = vi.fn(async (_app: string, p: string) => `file:${p}`);
+    const uploadImage = vi.fn(async (_app: string, p: string) => `image:${p}`);
+    const dispatch = vi.fn(async (content: string, msgType: string) => `om:${msgType}:${content}`);
+
+    const res = await sendVideoAttachments(
+      { uploadFile, uploadImage, dispatch },
+      'cli_app',
+      [{ videoPath: '/tmp/replay.mp4', coverPath: '/tmp/cover.png', durationMs: 0 }],
+    );
+
+    expect(res.failed).toEqual([]);
+    expect(res.sent).toEqual([
+      'om:media:{"file_key":"file:/tmp/replay.mp4","image_key":"image:/tmp/cover.png","duration":0}',
+    ]);
+    expect(uploadFile).toHaveBeenCalledWith('cli_app', '/tmp/replay.mp4');
+    expect(uploadImage).toHaveBeenCalledWith('cli_app', '/tmp/cover.png');
+    expect(dispatch).toHaveBeenCalledWith(
+      '{"file_key":"file:/tmp/replay.mp4","image_key":"image:/tmp/cover.png","duration":0}',
+      'media',
+    );
+  });
+
+  it('captures a failing video upload without rejecting and still sends later videos', async () => {
+    const uploadFile = vi.fn(async (_app: string, p: string) => {
+      if (p === '/tmp/bad.mp4') throw new Error('upload failed');
+      return `file:${p}`;
+    });
+    const uploadImage = vi.fn(async (_app: string, p: string) => `image:${p}`);
+    const dispatch = vi.fn(async (content: string) => `om:${content}`);
+
+    const res = await sendVideoAttachments(
+      { uploadFile, uploadImage, dispatch },
+      'cli_app',
+      [
+        { videoPath: '/tmp/bad.mp4', coverPath: '/tmp/bad.png', durationMs: 0 },
+        { videoPath: '/tmp/good.mp4', coverPath: '/tmp/good.png', durationMs: 0 },
+      ],
+    );
+
+    expect(res.sent).toEqual([
+      'om:{"file_key":"file:/tmp/good.mp4","image_key":"image:/tmp/good.png","duration":0}',
+    ]);
+    expect(res.failed).toEqual([{ path: '/tmp/bad.mp4', coverPath: '/tmp/bad.png', error: 'upload failed' }]);
+  });
+
+  it('captures cover upload and dispatch failures without rejecting', async () => {
+    const coverUploadFails = await sendVideoAttachments(
+      {
+        uploadFile: vi.fn(async () => 'file:key'),
+        uploadImage: vi.fn(async () => { throw new Error('cover failed'); }),
+        dispatch: vi.fn(async () => 'om_media'),
+      },
+      'cli_app',
+      [{ videoPath: '/tmp/a.mp4', coverPath: '/tmp/a.png', durationMs: 0 }],
+    );
+    expect(coverUploadFails).toEqual({
+      sent: [],
+      failed: [{ path: '/tmp/a.mp4', coverPath: '/tmp/a.png', error: 'cover failed' }],
+    });
+
+    const dispatchFails = await sendVideoAttachments(
+      {
+        uploadFile: vi.fn(async () => 'file:key'),
+        uploadImage: vi.fn(async () => 'image:key'),
+        dispatch: vi.fn(async () => { throw new Error('dispatch failed'); }),
+      },
+      'cli_app',
+      [{ videoPath: '/tmp/b.mp4', coverPath: '/tmp/b.png', durationMs: 0 }],
+    );
+    expect(dispatchFails).toEqual({
+      sent: [],
+      failed: [{ path: '/tmp/b.mp4', coverPath: '/tmp/b.png', error: 'dispatch failed' }],
+    });
   });
 });

--- a/test/cli-send-dispatch.test.ts
+++ b/test/cli-send-dispatch.test.ts
@@ -5,6 +5,7 @@ import {
   findStdinAliasAttachment,
   sendFileAttachments,
   sendVideoAttachments,
+  shouldSendAsPureVideo,
   validateVideoAttachments,
 } from '../src/cli/send-dispatch.js';
 
@@ -140,6 +141,32 @@ describe('sendFileAttachments (best-effort, never throws after primary send)', (
       { path: '/x', error: 'dispatch down' },
       { path: '/y', error: 'dispatch down' },
     ]);
+  });
+});
+
+describe('shouldSendAsPureVideo', () => {
+  const base = { hasBodyText: false, imageCount: 0, fileCount: 0, videoCount: 1, mentionCount: 0 };
+
+  it('is a pure media send only for a bare video with no text/attachments/mentions', () => {
+    expect(shouldSendAsPureVideo(base)).toBe(true);
+    expect(shouldSendAsPureVideo({ ...base, videoCount: 2 })).toBe(true);
+  });
+
+  it('is NOT pure-video when mentions are present (media messages cannot embed <at>)', () => {
+    // Regression guard: with a mention the send must go through the card path so
+    // the @ actually fires — otherwise the mention silently drops while the
+    // success output still reports `mentioned`.
+    expect(shouldSendAsPureVideo({ ...base, mentionCount: 1 })).toBe(false);
+  });
+
+  it('is NOT pure-video when text/image/file body content coexists', () => {
+    expect(shouldSendAsPureVideo({ ...base, hasBodyText: true })).toBe(false);
+    expect(shouldSendAsPureVideo({ ...base, imageCount: 1 })).toBe(false);
+    expect(shouldSendAsPureVideo({ ...base, fileCount: 1 })).toBe(false);
+  });
+
+  it('is NOT pure-video when there is no video at all', () => {
+    expect(shouldSendAsPureVideo({ ...base, videoCount: 0 })).toBe(false);
   });
 });
 

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -270,11 +270,19 @@ describe('codex-app sandboxExtraExecPaths', () => {
 // path flags / sandbox-chosen session-id are rejected.
 describe('validateRelayRequest', () => {
   it('accepts plain basenames + allowlisted presentation flags', () => {
-    const r = validateRelayRequest({ contentFile: 'c.content', attachments: ['a.png'], flags: ['--mention-back', '--mention', 'ou:X', '--voice'] });
+    const r = validateRelayRequest({
+      contentFile: 'c.content',
+      attachments: ['a.png'],
+      videos: ['replay.mp4'],
+      videoCovers: ['cover.png'],
+      flags: ['--mention-back', '--mention', 'ou:X', '--voice'],
+    });
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     expect(r.value.contentName).toBe('c.content');
     expect(r.value.attachmentNames).toEqual(['a.png']);
+    expect(r.value.videoNames).toEqual(['replay.mp4']);
+    expect(r.value.videoCoverNames).toEqual(['cover.png']);
     expect(r.value.flags).toEqual(['--mention-back', '--mention', 'ou:X', '--voice']);
   });
 
@@ -295,6 +303,8 @@ describe('validateRelayRequest', () => {
   it('rejects non-basename content / attachment names (../ traversal)', () => {
     expect(validateRelayRequest({ contentFile: '../../etc/passwd' }).ok).toBe(false);
     expect(validateRelayRequest({ contentFile: 'c.content', attachments: ['../secret'] }).ok).toBe(false);
+    expect(validateRelayRequest({ contentFile: 'c.content', videos: ['../secret.mp4'] }).ok).toBe(false);
+    expect(validateRelayRequest({ contentFile: 'c.content', videoCovers: ['../cover.png'] }).ok).toBe(false);
     expect(validateRelayRequest({ contentFile: 'a/b' }).ok).toBe(false);
     expect(validateRelayRequest({ /* missing contentFile */ flags: [] }).ok).toBe(false);
   });


### PR DESCRIPTION
## Summary

- Add native `botmux send --videos <path>` and `--video-covers <path>` support for Lark/Feishu media preview messages.
- Reuse botmux's existing Lark app identity and internal `uploadFile` / `uploadImage` / send/reply dispatch APIs instead of bytedcli or user-token scopes.
- Preserve existing send semantics: text/card first, then video media attachments; pure video sends are allowed after the existing mention decision gate; attachment failures remain best-effort warnings after a primary message succeeds.
- Extend sandbox relay, agent hints, skill/help docs, and docs-site command summaries so isolated agents can use video sends consistently.

## Validation

- `pnpm vitest run --project unit test/cli-send-dispatch.test.ts test/sandbox.test.ts test/cli-send-hook-context.test.ts`
- `pnpm build`
- `git diff --check`
- `node dist/cli.js --help | rg -- '--videos|--video-covers'`
- Dogfood on the current botmux Lark group: pure video media message sent successfully with a local RRH H.264 MP4 + PNG cover.

## Notes

MVP requires each video to provide an explicit cover via `--video-covers`; automatic ffmpeg frame extraction is intentionally left out for this change.