### PR TITLE
fix(platform): 隧道不再强制单协议族，改用 happy-eyeballs 自动选路

### DIFF
--- a/src/platform/bind.ts
+++ b/src/platform/bind.ts
@@ -60,9 +60,9 @@ export async function cmdBind(args: string[]): Promise<void> {
   const machineId = existing?.machineId || randomBytes(8).toString('hex');
   const name = existing?.name || hostname();
 
-  // 连平台：先走系统默认解析；不通再依次用 IPv6 / IPv4 单协议族兜底（有的机器 IPv4
-  // 路由是坏的、但 IPv6 通，反之亦然）。哪个兜底成功就把协议族记进绑定文件，之后隧道
-  // 等所有平台连接默认走它；默认路径成功则不记（重绑时顺带清掉过期的偏好）。
+  // 连平台：先走系统默认解析（happy-eyeballs 自动选路）；不通再依次用 IPv6 / IPv4 单协议族兜底
+  // （有的机器 IPv4 路由是坏的、但 IPv6 通，反之亦然）。隧道连接始终不传 family，让 Node
+  // 内置 happy-eyeballs 自动选最优路径，不把单族偏好固化到绑定文件里。
   const bindUrl = `${platformUrl}/api/bind`;
   const bindPayload = { code, machineId };
   const attempts: Array<{ family?: 4 | 6; label: string }> = [
@@ -71,14 +71,10 @@ export async function cmdBind(args: string[]): Promise<void> {
     { family: 4, label: 'IPv4' },
   ];
   let res: PostJsonResult | null = null;
-  let ipFamily: 4 | 6 | undefined;
-  let ipFamilyLabel = '';
   const failures: string[] = [];
   for (const attempt of attempts) {
     try {
       res = await postJson(bindUrl, bindPayload, { family: attempt.family });
-      ipFamily = attempt.family;
-      ipFamilyLabel = attempt.label;
       break;
     } catch (e) {
       const err = (e as { code?: string; message?: string });
@@ -107,7 +103,6 @@ export async function cmdBind(args: string[]): Promise<void> {
     machineId: body.machineId || machineId,
     machineToken: body.machineToken,
     name,
-    ...(ipFamily ? { ipFamily } : {}),
   });
 
   // 绑定平台即「默认打开远程访问开关」：之后 dashboard / 终端 / webhook 链接都走中心化平台
@@ -119,9 +114,6 @@ export async function cmdBind(args: string[]): Promise<void> {
 
   console.log(`✓ 已绑定到平台 ${platformUrl}`);
   console.log(`  机器名: ${name}`);
-  if (ipFamily) {
-    console.log(`  默认网络路径不通，本次经 ${ipFamilyLabel} 连上平台；之后与平台通信（隧道等）默认走 ${ipFamilyLabel}。`);
-  }
 
   // 事件驱动：写完绑定后直接「捅一下」正在运行的 daemon（走其本地 /__cli HMAC 接口，
   // 复用端口自发现），立即重连平台，无需重启、不轮询。没 daemon 在跑则跳过——下次启动自然读到绑定。

--- a/src/platform/binding.ts
+++ b/src/platform/binding.ts
@@ -15,8 +15,9 @@ export interface PlatformBinding {
   name?: string;
   /** 本机所属的平台团队（成员关系下沉到部署本地，平台零存储靠各机上报重组） */
   teams?: PlatformTeam[];
-  /** 与平台通信固定走的 IP 协议族。bind 时默认路径不通、单协议族兜底成功后记下，
-   *  之后隧道等所有平台连接默认走它；缺省表示跟随系统默认解析。 */
+  /** @deprecated 遗留字段：仅为兼容旧 platform.json 而保留解析，运行期已不再读取。
+   *  隧道与所有平台连接现在都不传 family，交给 Node happy-eyeballs 自动选族；
+   *  bind 也不再把兜底成功的协议族落盘。 */
   ipFamily?: 4 | 6;
 }
 

--- a/src/platform/binding.ts
+++ b/src/platform/binding.ts
@@ -81,12 +81,3 @@ export function setPlatformTeams(teams: PlatformTeam[]): PlatformTeam[] {
   writePlatformBinding(b);
   return teams;
 }
-
-/** 更新与平台通信的 IP 协议族偏好并落盘（隧道运行期换族成功后自愈式记忆）。 */
-export function setPlatformIpFamily(family: 4 | 6 | undefined): void {
-  const b = readPlatformBinding();
-  if (!b) return;
-  if (family === undefined) delete b.ipFamily;
-  else b.ipFamily = family;
-  writePlatformBinding(b);
-}

--- a/src/platform/tunnel-client.ts
+++ b/src/platform/tunnel-client.ts
@@ -97,7 +97,6 @@ export function startPlatformTunnelClient(opts: TunnelClientOptions): TunnelClie
   let backoff = BACKOFF_MIN_MS;
   // 本机平台团队（成员关系下沉到部署本地）
   let teams: PlatformTeam[] = opts.binding.teams ? [...opts.binding.teams] : [];
-  let connectFails = 0;
 
   const base = wsBase(opts.binding.platformUrl);
   const tokenQ = encodeURIComponent(opts.binding.machineToken);
@@ -132,8 +131,7 @@ export function startPlatformTunnelClient(opts: TunnelClientOptions): TunnelClie
     const onDialFail = (): void => {
       if (settled) return;
       if (--pending > 0) return; // 本轮还有在拨的，等它们
-      settled = true;
-      connectFails++; // 一整轮都没连上才计一次失败（驱动 backoff + 协议族翻转）
+      settled = true; // 一整轮都没连上才判负，按 backoff 重连
       dropLosers(null);
       scheduleReconnect();
     };
@@ -190,11 +188,10 @@ export function startPlatformTunnelClient(opts: TunnelClientOptions): TunnelClie
     }
   }
 
-  // 采纳某条已握手成功的控制连接：重置失败计数、挂正式收发 handler、发 register、起心跳。
+  // 采纳某条已握手成功的控制连接：重置重连退避、挂正式收发 handler、发 register、起心跳。
   function adoptControl(sock: WebSocket): void {
     ws = sock;
     controlDials = null;
-    connectFails = 0;
     backoff = BACKOFF_MIN_MS;
     opts.log('隧道已连接平台');
     sendRegister(sock);

--- a/src/platform/tunnel-client.ts
+++ b/src/platform/tunnel-client.ts
@@ -4,7 +4,7 @@
 import net from 'node:net';
 import { hostname, networkInterfaces } from 'node:os';
 import { WebSocket, createWebSocketStream } from 'ws';
-import { setPlatformTeams, setPlatformIpFamily, clearPlatformBinding, type PlatformBinding, type PlatformTeam } from './binding.js';
+import { setPlatformTeams, clearPlatformBinding, type PlatformBinding, type PlatformTeam } from './binding.js';
 
 /** 本机一个 botmux bot 的概要（上报给平台，供团队页「人→机器→bot」展示 + 拉群）。 */
 export interface PlatformBotInfo {
@@ -97,16 +97,10 @@ export function startPlatformTunnelClient(opts: TunnelClientOptions): TunnelClie
   let backoff = BACKOFF_MIN_MS;
   // 本机平台团队（成员关系下沉到部署本地）
   let teams: PlatformTeam[] = opts.binding.teams ? [...opts.binding.teams] : [];
-  // 与平台通信的 IP 协议族：bind 时探明的偏好起步（缺省跟随系统默认）。有的机器 IPv4
-  // 路由是坏的、但 IPv6 通（或运行期才坏掉），控制连接连续失败时隔次换协议族试探，
-  // 换族连通即采纳并落盘——之后所有平台连接（含数据流）默认走它，重启也生效。
-  let ipFamily: 4 | 6 | undefined = opts.binding.ipFamily;
   let connectFails = 0;
 
   const base = wsBase(opts.binding.platformUrl);
   const tokenQ = encodeURIComponent(opts.binding.machineToken);
-
-  const flipFamily = (f: 4 | 6 | undefined): 4 | 6 => (f === 6 ? 4 : 6);
 
   // 控制连接并行拨号（happy-eyeballs）。入口 VIP 对「新建连接」丢包很高（实测 ~35%，TLS 握手黑洞、
   // 非 SYN 层），单发+退避会反复撞黑洞、迟迟连不上 → 用户以为「连不上要 restart」。改成一轮并行拨
@@ -116,8 +110,6 @@ export function startPlatformTunnelClient(opts: TunnelClientOptions): TunnelClie
   function connect(): void {
     if (stopped) return;
     const url = `${base}/tunnel/control?token=${tokenQ}`;
-    // 连续 3 次连不上后，每隔一次用另一个协议族试探（默认/4 ↔ 6），兜住单协议族路由坏掉的机器。
-    const attemptFamily = connectFails >= 3 && connectFails % 2 === 1 ? flipFamily(ipFamily) : ipFamily;
 
     let settled = false; // 本轮已有胜者或已判负
     let pending = CONTROL_DIAL_PARALLEL;
@@ -149,7 +141,7 @@ export function startPlatformTunnelClient(opts: TunnelClientOptions): TunnelClie
     for (let k = 0; k < CONTROL_DIAL_PARALLEL; k++) {
       // 关掉 permessage-deflate：隧道是裸字节桥，承载的 HTTP 自己会 gzip，WS 层再压一遍既没收益、
       // 又会在经过中心化网关(TLB)时因压缩扩展协商被改写而触发 "RSV1 must be clear" 断流。
-      const sock = new WebSocket(url, { perMessageDeflate: false, family: attemptFamily });
+      const sock = new WebSocket(url, { perMessageDeflate: false });
       dials.add(sock);
       let done = false;
       const timer = setTimeout(() => {
@@ -172,7 +164,7 @@ export function startPlatformTunnelClient(opts: TunnelClientOptions): TunnelClie
         try { sock.removeAllListeners('open'); } catch { /* ignore */ }
         try { sock.removeAllListeners('error'); } catch { /* ignore */ }
         try { sock.removeAllListeners('unexpected-response'); } catch { /* ignore */ }
-        adoptControl(sock, attemptFamily);
+        adoptControl(sock);
       });
 
       sock.on('unexpected-response', (_req, res) => {
@@ -198,21 +190,12 @@ export function startPlatformTunnelClient(opts: TunnelClientOptions): TunnelClie
     }
   }
 
-  // 采纳某条已握手成功的控制连接：重置失败计数/落盘生效协议族、挂正式收发 handler、发 register、起心跳。
-  function adoptControl(sock: WebSocket, attemptFamily: 4 | 6 | undefined): void {
+  // 采纳某条已握手成功的控制连接：重置失败计数、挂正式收发 handler、发 register、起心跳。
+  function adoptControl(sock: WebSocket): void {
     ws = sock;
     controlDials = null;
     connectFails = 0;
     backoff = BACKOFF_MIN_MS;
-    if (attemptFamily !== ipFamily) {
-      ipFamily = attemptFamily;
-      try {
-        setPlatformIpFamily(attemptFamily);
-      } catch {
-        /* 落盘失败不影响本进程内生效 */
-      }
-      opts.log(`隧道经 IPv${attemptFamily} 连通，已设为本机与平台通信的默认协议族`);
-    }
     opts.log('隧道已连接平台');
     sendRegister(sock);
     heartbeat = setInterval(() => sendHeartbeat(sock), HEARTBEAT_MS);
@@ -386,8 +369,7 @@ export function startPlatformTunnelClient(opts: TunnelClientOptions): TunnelClie
         }
       };
       for (let k = 0; k < DATA_DIAL_PARALLEL; k++) {
-        // 数据流跟随当前生效的协议族（控制连接连得上的那个），不再各自赌路由
-        const data = new WebSocket(url, { perMessageDeflate: false, family: ipFamily });
+        const data = new WebSocket(url, { perMessageDeflate: false });
         inflight.add(data);
         let done = false;
         const timer = setTimeout(() => {

--- a/test/platform-bind-ip-family.test.ts
+++ b/test/platform-bind-ip-family.test.ts
@@ -1,6 +1,6 @@
 // test/platform-bind-ip-family.test.ts
 // botmux bind 的协议族兜底链：默认路径不通 → 依次 IPv6 / IPv4 重试，
-// 兜底成功把 ipFamily 记进绑定文件；默认路径成功则不记（重绑清掉过期偏好）。
+// 但不再把 ipFamily 写进绑定文件（隧道始终用 happy-eyeballs 自动选路）。
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const postJson = vi.fn();
@@ -27,7 +27,7 @@ const blob = Buffer.from(JSON.stringify({ u: 'http://platform.test', t: 'code-1'
 const okRes = { status: 200, json: { machineId: 'm-1', machineToken: 'tok-1' } };
 const netErr = () => Object.assign(new Error('connect ENETUNREACH'), { code: 'ENETUNREACH' });
 
-describe('cmdBind 协议族兜底', () => {
+describe('cmdBind 协议族兜底（不落盘 ipFamily）', () => {
   beforeEach(() => {
     postJson.mockReset();
     readPlatformBinding.mockReset().mockReturnValue(null);
@@ -36,7 +36,7 @@ describe('cmdBind 协议族兜底', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
-  it('默认路径成功：不落 ipFamily', async () => {
+  it('默认路径成功：不写 ipFamily', async () => {
     postJson.mockResolvedValueOnce(okRes);
     await cmdBind([blob]);
     expect(postJson).toHaveBeenCalledTimes(1);
@@ -45,20 +45,21 @@ describe('cmdBind 协议族兜底', () => {
     expect(writePlatformBinding.mock.calls[0][0]).not.toHaveProperty('ipFamily');
   });
 
-  it('默认不通、IPv6 兜底成功：落 ipFamily: 6', async () => {
+  it('默认不通、IPv6 兜底成功：不写 ipFamily', async () => {
     postJson.mockRejectedValueOnce(netErr()).mockResolvedValueOnce(okRes);
     await cmdBind([blob]);
     expect(postJson).toHaveBeenCalledTimes(2);
     expect((postJson.mock.calls[1][2] as { family?: number }).family).toBe(6);
-    expect(writePlatformBinding.mock.calls[0][0]).toMatchObject({ ipFamily: 6, machineToken: 'tok-1' });
+    expect(writePlatformBinding.mock.calls[0][0]).not.toHaveProperty('ipFamily');
+    expect(writePlatformBinding.mock.calls[0][0]).toMatchObject({ machineToken: 'tok-1' });
   });
 
-  it('默认与 IPv6 都不通、IPv4 兜底成功：落 ipFamily: 4', async () => {
+  it('默认与 IPv6 都不通、IPv4 兜底成功：不写 ipFamily', async () => {
     postJson.mockRejectedValueOnce(netErr()).mockRejectedValueOnce(netErr()).mockResolvedValueOnce(okRes);
     await cmdBind([blob]);
     expect(postJson).toHaveBeenCalledTimes(3);
     expect((postJson.mock.calls[2][2] as { family?: number }).family).toBe(4);
-    expect(writePlatformBinding.mock.calls[0][0]).toMatchObject({ ipFamily: 4 });
+    expect(writePlatformBinding.mock.calls[0][0]).not.toHaveProperty('ipFamily');
   });
 
   it('三路全不通：报错退出、不写绑定', async () => {

--- a/test/tunnel-client-ip-family.test.ts
+++ b/test/tunnel-client-ip-family.test.ts
@@ -1,10 +1,9 @@
 // test/tunnel-client-ip-family.test.ts
-// 隧道客户端的协议族逻辑：绑定里的 ipFamily 透传给控制/数据连接；
-// 连续连不上时隔次换协议族试探，换族连通即采纳并落盘为新默认。
+// 隧道客户端不再强制单协议族：WebSocket 构造始终不传 family，
+// 让 Node 内置 happy-eyeballs 自动选最优路径（IPv4/IPv6 谁先到用谁）。
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const { FakeWebSocket } = vi.hoisted(() => {
-  // vi.hoisted 在模块 import 初始化前执行，引用不到 node:events —— 手写极简事件类
   class FakeWebSocket {
     static OPEN = 1;
     static instances: FakeWebSocket[] = [];
@@ -34,18 +33,16 @@ const { FakeWebSocket } = vi.hoisted(() => {
 });
 vi.mock('ws', () => ({ WebSocket: FakeWebSocket, createWebSocketStream: vi.fn() }));
 
-const setPlatformIpFamily = vi.fn();
 vi.mock('../src/platform/binding.js', () => ({
   setPlatformTeams: vi.fn(),
-  setPlatformIpFamily: (...a: unknown[]) => setPlatformIpFamily(...a),
   clearPlatformBinding: vi.fn(),
 }));
 
 import { startPlatformTunnelClient } from '../src/platform/tunnel-client.js';
 
-function makeOpts(ipFamily?: 4 | 6) {
+function makeOpts() {
   return {
-    binding: { platformUrl: 'https://platform.test', machineId: 'm-1', machineToken: 'tok', ipFamily },
+    binding: { platformUrl: 'https://platform.test', machineId: 'm-1', machineToken: 'tok' },
     getDashboardPort: () => 7891,
     getDashboardToken: () => 'dt',
     getVersion: () => '0.0.0-test',
@@ -53,71 +50,61 @@ function makeOpts(ipFamily?: 4 | 6) {
   };
 }
 
-describe('tunnel-client 协议族', () => {
+describe('tunnel-client 不强制协议族', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     FakeWebSocket.instances.length = 0;
-    setPlatformIpFamily.mockReset();
   });
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it('绑定里的 ipFamily 透传给控制连接', () => {
-    const handle = startPlatformTunnelClient(makeOpts(6));
-    expect(FakeWebSocket.instances[0].opts.family).toBe(6);
+  it('控制连接不传 family，让 happy-eyeballs 自动选路', () => {
+    const handle = startPlatformTunnelClient(makeOpts());
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(0);
+    for (const inst of FakeWebSocket.instances) {
+      expect(inst.opts.family).toBeUndefined();
+    }
     handle.stop();
   });
 
-  it('连续 3 次连不上后隔次换协议族；换族连通即落盘并用于数据流', async () => {
+  it('重连时仍然不传 family', async () => {
     const handle = startPlatformTunnelClient(makeOpts());
     const inst = FakeWebSocket.instances;
-    // 前 3 次按默认协议族拨，全部连不上（close 且从未 open）
-    for (let i = 0; i < 3; i++) {
-      expect(inst[i].opts.family).toBeUndefined();
-      inst[i].emit('close');
-      await vi.advanceTimersByTimeAsync(1000 * 2 ** i); // 重连退避 1s/2s/4s
+    // 第一次拨号失败 → 触发重连
+    inst[0].emit('close');
+    await vi.advanceTimersByTimeAsync(2000);
+    // 第二次拨号也不传 family
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(1);
+    for (const s of FakeWebSocket.instances) {
+      expect(s.opts.family).toBeUndefined();
     }
-    // 第 4 次：换 IPv6 试探
-    expect(inst.length).toBe(4);
-    expect(inst[3].opts.family).toBe(6);
-    inst[3].readyState = FakeWebSocket.OPEN;
-    inst[3].emit('open');
-    expect(setPlatformIpFamily).toHaveBeenCalledWith(6);
-    // 数据流跟随已采纳的协议族
-    inst[3].emit('message', JSON.stringify({ type: 'open-stream', streamId: 's-1' }));
-    const dials = inst.slice(4);
-    expect(dials.length).toBeGreaterThan(0);
-    expect(dials.every((d) => d.opts.family === 6)).toBe(true);
     handle.stop();
   });
 
-  it('已固定 IPv6 但连不上时，试探切回 IPv4', async () => {
-    const handle = startPlatformTunnelClient(makeOpts(6));
-    const inst = FakeWebSocket.instances;
-    for (let i = 0; i < 3; i++) {
-      expect(inst[i].opts.family).toBe(6);
-      inst[i].emit('close');
-      await vi.advanceTimersByTimeAsync(1000 * 2 ** i);
-    }
-    expect(inst[3].opts.family).toBe(4);
-    inst[3].readyState = FakeWebSocket.OPEN;
-    inst[3].emit('open');
-    expect(setPlatformIpFamily).toHaveBeenCalledWith(4);
-    handle.stop();
-  });
-
-  it('连上后正常掉线不计入失败，不触发换族', async () => {
+  it('数据流也不传 family', async () => {
     const handle = startPlatformTunnelClient(makeOpts());
     const inst = FakeWebSocket.instances;
-    for (let i = 0; i < 5; i++) {
-      inst[i].readyState = FakeWebSocket.OPEN;
-      inst[i].emit('open'); // 每次都连得上
-      inst[i].emit('close'); // 然后掉线
-      await vi.advanceTimersByTimeAsync(1000); // 连上过 → 退避回到最小 1s
+    // 让控制连接握手成功
+    inst[0].readyState = FakeWebSocket.OPEN;
+    inst[0].emit('open');
+    // 平台下发 open-stream
+    inst[0].emit('message', JSON.stringify({ type: 'open-stream', streamId: 's-1' }));
+    const dataDials = FakeWebSocket.instances.slice(1);
+    expect(dataDials.length).toBeGreaterThan(0);
+    for (const d of dataDials) {
+      expect(d.opts.family).toBeUndefined();
     }
-    expect(inst.every((s) => s.opts.family === undefined)).toBe(true);
-    expect(setPlatformIpFamily).not.toHaveBeenCalled();
+    handle.stop();
+  });
+
+  it('绑定文件里有 ipFamily 也不影响（隧道忽略该字段）', () => {
+    const opts = makeOpts();
+    (opts.binding as Record<string, unknown>).ipFamily = 4;
+    const handle = startPlatformTunnelClient(opts);
+    for (const inst of FakeWebSocket.instances) {
+      expect(inst.opts.family).toBeUndefined();
+    }
     handle.stop();
   });
 });


### PR DESCRIPTION
## 问题

botmux restart 后概率性出现 dashboard 显示「平台未授权」、平台侧机器显示离线。

根因：tunnel-client.ts 会把 platform.json 里的 ipFamily 透传给所有 WebSocket 构造器，强制只用单一协议族。当该协议族路由有 ECMP 黑洞时（实测 ~35% 丢包率），冷启动时控制连接连不上平台。更糟的是，某次侥幸连上后会把 ipFamily 写回绑定文件，锁死在坏路径上。

## 修复

- tunnel-client.ts: 控制连接和数据流都不传 family，让 Node 内置 happy-eyeballs (autoSelectFamily) 同时拨 IPv4+IPv6，谁先握手成功用谁
- 移除 setPlatformIpFamily 运行时落盘：不再因一次侥幸连接把 ipFamily 固化到 platform.json
- bind.ts: 仍保留多族兜底尝试（bind HTTP 请求需要实际打通），但不再把成功的协议族写入绑定文件
- binding.ts: 删除 setPlatformIpFamily（无调用方）

## 影响面

- 改了 src/platform/ 公共层（tunnel-client、bind、binding），影响所有走平台隧道的机器
- 好处：所有机器的隧道连接都会自动用 happy-eyeballs 选最优路径，不再被单协议族锁死
- 风险：低——不传 family 只是回退到 Node 默认行为（happy-eyeballs），比强制单族 strictly 更优

## 测试验证

- pnpm build ✅
- pnpm vitest run test/platform-bind-ip-family.test.ts test/tunnel-client-ip-family.test.ts ✅ (8/8 passed)
- 本机实测：清除 platform.json 里的 ipFamily: 4 后，pnpm daemon:restart 隧道秒连，平台侧机器状态恢复在线