### PR TITLE
feat(core): 支持 BOTMUX_PUBLIC_URL 让自建反代场景的 dashboard/终端链接走单域名前门

### DIFF
--- a/src/core/dashboard-url.ts
+++ b/src/core/dashboard-url.ts
@@ -1,4 +1,4 @@
-import { platformMachineBaseUrl } from '../platform/binding.js';
+import { platformMachineBaseUrl, publicReverseProxyBaseUrl } from '../platform/binding.js';
 import { isRemoteAccessEnabled } from '../global-config.js';
 
 export interface DashboardUrls {
@@ -24,11 +24,12 @@ export interface DashboardUrls {
  * (`https://m-<machineId>.<platformHost>/?t=<token>`): the platform
  * reverse-proxies that subdomain to this host's local dashboard, which still
  * enforces the `?t=` token itself, so the link is reachable centrally with no
- * `:port`. In that case `localUrl` additionally carries the local
- * `http://<externalHost>:<port>/?t=<token>` form so callers can advertise a
- * direct fallback for when the platform is unreachable. When 远程访问 is off (or
- * the machine isn't bound) the primary `url` is already the local form and
- * `localUrl` is left undefined.
+ * `:port`. Failing that, if `BOTMUX_PUBLIC_URL` is set (self-hosted reverse
+ * proxy in front of the dashboard, e.g. nginx), the primary `url` uses that base
+ * — same no-`:port` form, token still enforced. In either remote case `localUrl`
+ * additionally carries the local `http://<externalHost>:<port>/?t=<token>` form
+ * so callers can advertise a direct fallback. When neither applies the primary
+ * `url` is already the local form and `localUrl` is left undefined.
  *
  * Mirrors buildTerminalUrl (terminal-url.ts) and publicWebhookUrl
  * (dashboard/connector-api.ts) so dashboard, terminal, and webhook links all
@@ -37,12 +38,14 @@ export interface DashboardUrls {
  */
 export function buildDashboardUrls(opts: { host: string; port: number | string; token?: string }): DashboardUrls {
   const localOrigin = `http://${opts.host}:${opts.port}`;
+  // 对外基址：中心平台优先（远程访问开 + 已绑定），否则自建反代基址 BOTMUX_PUBLIC_URL。
   const platformBase = isRemoteAccessEnabled() ? platformMachineBaseUrl() : null;
-  const primaryOrigin = platformBase ?? localOrigin;
+  const remoteBase = platformBase ?? publicReverseProxyBaseUrl();
+  const primaryOrigin = remoteBase ?? localOrigin;
   const suffix = opts.token ? `/?t=${opts.token}` : '/';
   return {
     url: `${primaryOrigin}${suffix}`,
-    localUrl: platformBase ? `${localOrigin}${suffix}` : undefined,
+    localUrl: remoteBase ? `${localOrigin}${suffix}` : undefined,
   };
 }
 

--- a/src/core/terminal-url.ts
+++ b/src/core/terminal-url.ts
@@ -1,5 +1,5 @@
 import { config } from '../config.js';
-import { platformMachineBaseUrl } from '../platform/binding.js';
+import { platformMachineBaseUrl, publicReverseProxyBaseUrl } from '../platform/binding.js';
 import { isRemoteAccessEnabled } from '../global-config.js';
 
 /**
@@ -72,10 +72,20 @@ export function buildTerminalUrl(ds: TerminalUrlSession, opts: { write?: boolean
   // proxies `/s/*` to the local terminal proxy — so terminals are reachable
   // centrally with no `:port`. Write access there is gated by the platform login
   // (not a URL token), so we deliberately omit `?token=`. When 远程访问 is off the
-  // platform base is null and we fall through to the local URL behavior.
+  // platform base is null and we fall through — first to a self-hosted reverse
+  // proxy base (`BOTMUX_PUBLIC_URL`, same front-door `/s/<id>` form but token-
+  // bearing since there's no platform SSO), then to the local proxy/worker port.
   if (proxyReady) {
     const platformBase = isRemoteAccessEnabled() ? platformMachineBaseUrl() : null;
     if (platformBase) return `${platformBase}/s/${ds.session.sessionId}`;
+    // 自建反代（BOTMUX_PUBLIC_URL）：走 dashboard 前门 `/s/<id>`，无 per-bot 端口、
+    // 对所有 bot 通。这里没有平台 SSO 兜底，故写链接必须像本地分支一样保留 token，
+    // 否则终端会裸暴露在对外域名上。
+    const publicBase = publicReverseProxyBaseUrl();
+    if (publicBase) {
+      const url = `${publicBase}/s/${ds.session.sessionId}`;
+      return opts.write && ds.workerToken ? `${url}?token=${ds.workerToken}` : url;
+    }
   }
   const base = proxyReady
     ? `http://${config.web.externalHost}:${getTerminalAdvertisedPort()}/s/${ds.session.sessionId}`

--- a/src/core/terminal-write-auth.ts
+++ b/src/core/terminal-write-auth.ts
@@ -1,0 +1,57 @@
+// Terminal write-permission gate.
+//
+// The web terminal grants write access one of two ways:
+//
+//  1. Platform-injected role — when a central platform fronts `/s`, it
+//     authenticates the viewer and injects `X-Botmux-Role` (owner | teammate |
+//     guest), first stripping any client-supplied copy. Only `owner` may write.
+//
+//  2. Legacy write token — the `?token=<workerToken>` query param.
+//
+// The role header is trustworthy ONLY behind that platform boundary. A
+// self-hosted deployment (not bound to a platform) has no boundary stripping the
+// header, and the dashboard/terminal-proxy replay request headers verbatim — so
+// a client could send `X-Botmux-Role: owner` and bypass the token gate =
+// unauthenticated terminal write = RCE. We therefore honor the role header ONLY
+// when this machine is bound to a central platform; otherwise the header is
+// ignored and write falls back to the `?token=` gate.
+
+export interface TerminalWriteInput {
+  /** Value of the `X-Botmux-Role` request header (normalized to a single string, or undefined). */
+  role: string | undefined;
+  /** Whether the request's `?token=` matched the worker's write token. */
+  tokenMatches: boolean;
+  /** Whether this machine is bound to a central platform (a trusted boundary fronts `/s`). */
+  platformBound: boolean;
+}
+
+export function resolveTerminalWrite(
+  { role, tokenMatches, platformBound }: TerminalWriteInput,
+): { hasWrite: boolean; platformReadonly: boolean } {
+  if (platformBound && typeof role === 'string' && role) {
+    const hasWrite = role === 'owner';
+    return { hasWrite, platformReadonly: !hasWrite };
+  }
+  return { hasWrite: tokenMatches, platformReadonly: false };
+}
+
+/**
+ * Resolve terminal write for one request: extract the `X-Botmux-Role` header
+ * (a duplicated/array header is treated as absent) and gate it on the machine's
+ * platform binding.
+ *
+ * `isPlatformBound` is a thunk evaluated on EVERY call — never snapshotted.
+ * `botmux bind`/unbind rewrites platform.json and the dashboard hot-reloads the
+ * tunnel WITHOUT restarting live workers; a cached value would keep trusting a
+ * forged role header after an unbind (the RCE would reappear until restart) and
+ * would deny legitimate platform writes to sessions that predate a bind.
+ */
+export function resolveTerminalWriteForRequest(
+  headers: Record<string, string | string[] | undefined>,
+  tokenMatches: boolean,
+  isPlatformBound: () => boolean,
+): { hasWrite: boolean; platformReadonly: boolean } {
+  const rawRole = headers['x-botmux-role'];
+  const role = typeof rawRole === 'string' ? rawRole : undefined;
+  return resolveTerminalWrite({ role, tokenMatches, platformBound: isPlatformBound() });
+}

--- a/src/platform/binding.ts
+++ b/src/platform/binding.ts
@@ -73,6 +73,20 @@ export function platformMachineBaseUrl(): string | null {
   }
 }
 
+/**
+ * 自建反代对外基址（`BOTMUX_PUBLIC_URL`）：没接中心平台、但自己用 nginx 等反代把
+ * dashboard 暴露到单一公网/内网域名时，设成 `http://botmux.example.com`
+ * （scheme + host[:port]，尾部斜杠会被去掉）。设了之后 dashboard / 卡片终端链接改吐
+ * `<基址>/…`、`<基址>/s/<sessionId>`，走 dashboard 前门、无需 per-bot 端口。未设返回
+ * null → 调用方回退本地 `host:port`。它与 {@link platformMachineBaseUrl} 是「中心平台
+ * vs 自建反代」两条对外基址来源；优先级由调用方定（平台 > 本函数 > 本地）。
+ */
+export function publicReverseProxyBaseUrl(): string | null {
+  const raw = process.env.BOTMUX_PUBLIC_URL?.trim();
+  if (!raw) return null;
+  return raw.replace(/\/+$/, '');
+}
+
 /** 更新本机平台团队列表并落盘（读最新 binding 防覆盖其它字段）。返回更新后的列表。 */
 export function setPlatformTeams(teams: PlatformTeam[]): PlatformTeam[] {
   const b = readPlatformBinding();

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -40,6 +40,8 @@ import { mergeQueuedCliInput, type PendingCliInput } from './utils/pending-input
 import { ReadyGate, shouldArmReadyGate } from './utils/ready-gate.js';
 import { shouldRunStartupCommandsOnSpawn, shouldDeferInitialPromptForStartup } from './core/startup-commands.js';
 import { sanitizePerBotEnv } from './core/per-bot-env.js';
+import { resolveTerminalWriteForRequest } from './core/terminal-write-auth.js';
+import { readPlatformBinding } from './platform/binding.js';
 import { InflightInputTracker } from './core/inflight-input-tracker.js';
 import {
   shouldRunQuietRotation,
@@ -301,22 +303,20 @@ const clientPtys = new Map<WebSocket, pty.IPty>();
 const writeToken = randomBytes(16).toString('hex');
 
 /**
- * Resolve terminal write permission for one request, honoring a platform-injected
- * `X-Botmux-Role` header. The central platform fronts `/s/*` and sets the role
- * (owner | teammate | guest) after authenticating the viewer, stripping any
- * client-supplied header; it reaches the worker via dashboard /s bridge →
- * terminal-proxy → here. When the header is present we trust it (platform-fronted
- * access): only `owner` may drive the terminal; everything else (teammate / guest
- * / anything else) is read-only. When the header is absent (local direct access,
- * no platform in front), fall back to the legacy write-token query param.
+ * Resolve terminal write permission for one request. Trust of the
+ * platform-injected `X-Botmux-Role` header is gated on this machine's platform
+ * binding: a self-hosted (unbound) deployment has no boundary stripping that
+ * header, so it must never be trusted — otherwise a client forging
+ * `X-Botmux-Role: owner` bypasses the `?token=` gate (= unauthenticated terminal
+ * write = RCE). See ./core/terminal-write-auth for the full rationale.
+ *
+ * The binding is read PER REQUEST, never snapshotted: `botmux bind`/unbind
+ * rewrites platform.json and the dashboard hot-reloads the tunnel without
+ * restarting this worker, so a cached value would go stale (trusting forged
+ * headers after an unbind / denying platform writes after a bind).
  */
-function resolveTerminalWrite(req: IncomingMessage, tokenMatches: boolean): { hasWrite: boolean; platformReadonly: boolean } {
-  const role = req.headers['x-botmux-role'];
-  if (typeof role === 'string' && role) {
-    const hasWrite = role === 'owner';
-    return { hasWrite, platformReadonly: !hasWrite };
-  }
-  return { hasWrite: tokenMatches, platformReadonly: false };
+function resolveTerminalWriteForReq(req: IncomingMessage, tokenMatches: boolean): { hasWrite: boolean; platformReadonly: boolean } {
+  return resolveTerminalWriteForRequest(req.headers, tokenMatches, () => readPlatformBinding() !== null);
 }
 
 /** Lazily-written locked-mode zellij config for per-WS web-terminal attach
@@ -5162,7 +5162,7 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
         return;
       }
       const tokenMatches = url.searchParams.get('token') === writeToken;
-      const { hasWrite, platformReadonly } = resolveTerminalWrite(req, tokenMatches);
+      const { hasWrite, platformReadonly } = resolveTerminalWriteForReq(req, tokenMatches);
       const loginHdr = req.headers['x-botmux-login-url'];
       const loginUrl = typeof loginHdr === 'string' && /^https?:\/\/[^"'<>\s]+$/.test(loginHdr) ? loginHdr : '';
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
@@ -5183,7 +5183,7 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
         return;
       }
       const tokenMatches = url.searchParams.get('token') === writeToken;
-      const { hasWrite } = resolveTerminalWrite(req, tokenMatches);
+      const { hasWrite } = resolveTerminalWriteForReq(req, tokenMatches);
       if (hasWrite) authedClients.add(ws);
       log(`WS client connected (total: ${wsClients.size}, write: ${hasWrite})`);
 

--- a/test/dashboard-url.test.ts
+++ b/test/dashboard-url.test.ts
@@ -8,19 +8,22 @@ vi.mock('../src/global-config.js', () => ({
 }));
 vi.mock('../src/platform/binding.js', () => ({
   platformMachineBaseUrl: vi.fn(() => null),
+  publicReverseProxyBaseUrl: vi.fn(() => null),
 }));
 
 import { buildDashboardUrl, buildDashboardUrls } from '../src/core/dashboard-url.js';
 import { isRemoteAccessEnabled } from '../src/global-config.js';
-import { platformMachineBaseUrl } from '../src/platform/binding.js';
+import { platformMachineBaseUrl, publicReverseProxyBaseUrl } from '../src/platform/binding.js';
 
 const setRemote = (on: boolean) => vi.mocked(isRemoteAccessEnabled).mockReturnValue(on);
 const setPlatform = (base: string | null) => vi.mocked(platformMachineBaseUrl).mockReturnValue(base);
+const setPublic = (base: string | null) => vi.mocked(publicReverseProxyBaseUrl).mockReturnValue(base);
 
 describe('buildDashboardUrl', () => {
   beforeEach(() => {
     setRemote(false);
     setPlatform(null);
+    setPublic(null);
   });
 
   it('builds a local host:port URL with token when remote access is off', () => {
@@ -64,12 +67,29 @@ describe('buildDashboardUrl', () => {
       'https://m-deadbeef.botmux.example/',
     );
   });
+
+  it('routes through BOTMUX_PUBLIC_URL when set and no platform (self-hosted nginx)', () => {
+    setPublic('https://botmux.example.com');
+    expect(buildDashboardUrl({ host: '1.2.3.4', port: 7891, token: 'abc' })).toBe(
+      'https://botmux.example.com/?t=abc',
+    );
+  });
+
+  it('lets the platform subdomain win over BOTMUX_PUBLIC_URL when both apply', () => {
+    setRemote(true);
+    setPlatform('https://m-deadbeef.botmux.example');
+    setPublic('https://botmux.example.com');
+    expect(buildDashboardUrl({ host: '1.2.3.4', port: 7891, token: 'abc' })).toBe(
+      'https://m-deadbeef.botmux.example/?t=abc',
+    );
+  });
 });
 
 describe('buildDashboardUrls', () => {
   beforeEach(() => {
     setRemote(false);
     setPlatform(null);
+    setPublic(null);
   });
 
   it('local-only: no localUrl fallback when the primary is already local', () => {
@@ -103,6 +123,14 @@ describe('buildDashboardUrls', () => {
     expect(buildDashboardUrls({ host: '1.2.3.4', port: 7891 })).toEqual({
       url: 'https://m-deadbeef.botmux.example/',
       localUrl: 'http://1.2.3.4:7891/',
+    });
+  });
+
+  it('BOTMUX_PUBLIC_URL: public primary + local ip:port fallback (same token)', () => {
+    setPublic('https://botmux.example.com');
+    expect(buildDashboardUrls({ host: '1.2.3.4', port: 7891, token: 'abc' })).toEqual({
+      url: 'https://botmux.example.com/?t=abc',
+      localUrl: 'http://1.2.3.4:7891/?t=abc',
     });
   });
 });

--- a/test/terminal-url.test.ts
+++ b/test/terminal-url.test.ts
@@ -1,5 +1,5 @@
 // test/terminal-url.test.ts
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll } from 'vitest';
 import { config } from '../src/config.js';
 import {
   setTerminalProxyPort,
@@ -10,6 +10,19 @@ import {
 } from '../src/core/terminal-url.js';
 
 const ds = { session: { sessionId: 'sess-123' }, workerPort: 9090, workerToken: 'wtok' };
+
+// Keep the whole file hermetic w.r.t. BOTMUX_PUBLIC_URL, which buildTerminalUrl
+// now reads live and may be set in the shell running the suite (in prod it IS).
+// Clear it before every test so the default (local proxy/worker port) suites are
+// deterministic; the public-url suite below opts in per test. Restore on exit.
+const ORIGINAL_PUBLIC_URL = process.env.BOTMUX_PUBLIC_URL;
+beforeEach(() => {
+  delete process.env.BOTMUX_PUBLIC_URL;
+});
+afterAll(() => {
+  if (ORIGINAL_PUBLIC_URL === undefined) delete process.env.BOTMUX_PUBLIC_URL;
+  else process.env.BOTMUX_PUBLIC_URL = ORIGINAL_PUBLIC_URL;
+});
 
 describe('buildTerminalUrl', () => {
   beforeEach(() => setTerminalProxyPort(8801));
@@ -85,6 +98,45 @@ describe('getTerminalAdvertisedPort — shared port for card + dashboard links',
     resetTerminalProxy();
     setTerminalExternalPort(9000);
     expect(getTerminalAdvertisedPort()).toBe(0);
+  });
+});
+
+// Self-hosted reverse proxy (nginx etc.) in front of the dashboard, no central
+// platform binding. Setting BOTMUX_PUBLIC_URL makes card terminal links route
+// through the dashboard front door `<base>/s/<id>` — no per-bot proxy port, one
+// domain for every bot. Token is kept (no platform SSO to gate write access).
+describe('buildTerminalUrl — BOTMUX_PUBLIC_URL (self-hosted reverse proxy)', () => {
+  beforeEach(() => setTerminalProxyPort(8801));
+  afterEach(() => {
+    resetTerminalProxy();
+    delete process.env.BOTMUX_PUBLIC_URL;
+  });
+
+  it('routes read-only links through the front door with no port', () => {
+    process.env.BOTMUX_PUBLIC_URL = 'https://botmux.example.com';
+    expect(buildTerminalUrl(ds)).toBe('https://botmux.example.com/s/sess-123');
+  });
+
+  it('keeps the write token on the front-door link (no platform SSO here)', () => {
+    process.env.BOTMUX_PUBLIC_URL = 'https://botmux.example.com';
+    expect(buildTerminalUrl(ds, { write: true })).toBe(
+      'https://botmux.example.com/s/sess-123?token=wtok',
+    );
+  });
+
+  it('trims a trailing slash on the configured base', () => {
+    process.env.BOTMUX_PUBLIC_URL = 'https://botmux.example.com/';
+    expect(buildTerminalUrl(ds)).toBe('https://botmux.example.com/s/sess-123');
+  });
+
+  it('overrides the local proxy-port form when set', () => {
+    process.env.BOTMUX_PUBLIC_URL = 'http://botmux.example.com';
+    // even with a proxy port bound, the public base wins over host:8801
+    expect(buildTerminalUrl(ds)).toBe('http://botmux.example.com/s/sess-123');
+  });
+
+  it('falls back to the local proxy port when unset', () => {
+    expect(buildTerminalUrl(ds)).toBe(`http://${config.web.externalHost}:8801/s/sess-123`);
   });
 });
 

--- a/test/terminal-write-auth.test.ts
+++ b/test/terminal-write-auth.test.ts
@@ -1,0 +1,110 @@
+// test/terminal-write-auth.test.ts
+//
+// Security regression guard for the terminal write-permission gate.
+//
+// The `X-Botmux-Role` header is only trustworthy when a central platform fronts
+// `/s` and authoritatively injects it (after stripping any client copy). A
+// self-hosted deployment (NOT bound to a platform) has no such boundary, so a
+// client can forge `X-Botmux-Role: owner` and bypass the `?token=` gate =
+// unauthenticated terminal write = RCE. The gate must therefore honor the role
+// header ONLY when this machine is platform-bound.
+import { describe, it, expect } from 'vitest';
+import { resolveTerminalWrite, resolveTerminalWriteForRequest } from '../src/core/terminal-write-auth.js';
+
+describe('resolveTerminalWrite', () => {
+  describe('self-hosted (not platform-bound): role header must NOT be trusted', () => {
+    it('ignores a forged owner role with no token → no write (the RCE fix)', () => {
+      expect(resolveTerminalWrite({ role: 'owner', tokenMatches: false, platformBound: false }))
+        .toEqual({ hasWrite: false, platformReadonly: false });
+    });
+
+    it('still grants write via a matching ?token= even with a forged role present', () => {
+      expect(resolveTerminalWrite({ role: 'owner', tokenMatches: true, platformBound: false }))
+        .toEqual({ hasWrite: true, platformReadonly: false });
+    });
+
+    it('grants write via matching token when no role header is present', () => {
+      expect(resolveTerminalWrite({ role: undefined, tokenMatches: true, platformBound: false }))
+        .toEqual({ hasWrite: true, platformReadonly: false });
+    });
+
+    it('denies write when neither role trust nor token applies', () => {
+      expect(resolveTerminalWrite({ role: undefined, tokenMatches: false, platformBound: false }))
+        .toEqual({ hasWrite: false, platformReadonly: false });
+    });
+  });
+
+  describe('platform-bound: trust the platform-injected role', () => {
+    it('grants write for role owner (token irrelevant)', () => {
+      expect(resolveTerminalWrite({ role: 'owner', tokenMatches: false, platformBound: true }))
+        .toEqual({ hasWrite: true, platformReadonly: false });
+    });
+
+    it('forces read-only for a non-owner role (guest), overriding a matching token', () => {
+      expect(resolveTerminalWrite({ role: 'guest', tokenMatches: true, platformBound: true }))
+        .toEqual({ hasWrite: false, platformReadonly: true });
+    });
+
+    it('forces read-only for role teammate', () => {
+      expect(resolveTerminalWrite({ role: 'teammate', tokenMatches: false, platformBound: true }))
+        .toEqual({ hasWrite: false, platformReadonly: true });
+    });
+
+    it('falls back to token when no role header is present (local direct hit on a bound box)', () => {
+      expect(resolveTerminalWrite({ role: undefined, tokenMatches: true, platformBound: true }))
+        .toEqual({ hasWrite: true, platformReadonly: false });
+      expect(resolveTerminalWrite({ role: '', tokenMatches: false, platformBound: true }))
+        .toEqual({ hasWrite: false, platformReadonly: false });
+    });
+  });
+});
+
+describe('resolveTerminalWriteForRequest', () => {
+  const bound = () => true;
+  const unbound = () => false;
+
+  it('extracts a string role header and honors it when bound', () => {
+    expect(resolveTerminalWriteForRequest({ 'x-botmux-role': 'owner' }, false, bound))
+      .toEqual({ hasWrite: true, platformReadonly: false });
+  });
+
+  it('ignores a forged role when unbound → token fallback (the RCE fix)', () => {
+    expect(resolveTerminalWriteForRequest({ 'x-botmux-role': 'owner' }, false, unbound))
+      .toEqual({ hasWrite: false, platformReadonly: false });
+  });
+
+  it('treats a duplicated (array) role header as absent → token fallback', () => {
+    expect(resolveTerminalWriteForRequest({ 'x-botmux-role': ['owner', 'guest'] }, false, bound))
+      .toEqual({ hasWrite: false, platformReadonly: false });
+    expect(resolveTerminalWriteForRequest({ 'x-botmux-role': ['owner', 'guest'] }, true, bound))
+      .toEqual({ hasWrite: true, platformReadonly: false });
+  });
+
+  it('falls back to token when no role header is present', () => {
+    expect(resolveTerminalWriteForRequest({}, true, bound))
+      .toEqual({ hasWrite: true, platformReadonly: false });
+  });
+
+  // Regression guard for the codex finding: binding must be evaluated per request,
+  // not snapshotted. `botmux bind`/unbind hot-reloads binding without restarting
+  // live workers — a snapshot would keep trusting forged headers after an unbind.
+  it('evaluates the binding check on every call (not cached)', () => {
+    let boundNow = false;
+    const isBound = () => boundNow;
+    const forgedNoToken = { 'x-botmux-role': 'owner' };
+
+    // Unbound: forged owner is ignored.
+    expect(resolveTerminalWriteForRequest(forgedNoToken, false, isBound))
+      .toEqual({ hasWrite: false, platformReadonly: false });
+
+    // Machine gets bound — the very next request must reflect it.
+    boundNow = true;
+    expect(resolveTerminalWriteForRequest(forgedNoToken, false, isBound))
+      .toEqual({ hasWrite: true, platformReadonly: false });
+
+    // And after an unbind, trust must drop again (no stale RCE window).
+    boundNow = false;
+    expect(resolveTerminalWriteForRequest(forgedNoToken, false, isBound))
+      .toEqual({ hasWrite: false, platformReadonly: false });
+  });
+});


### PR DESCRIPTION
## 背景 / 为什么

没接中心平台、但用 nginx 等反向代理把 dashboard 暴露到单一公网/内网域名的用户,此前:

- dashboard 链接始终带 `:7891`(没有外部端口开关),走不到 nginx `:80` vhost;
- 卡片「打开web终端 / 获取操作链接」吐的是 per-bot 终端代理的 `IP:端口`(如 `192.168.28.45:8801/s/<id>`),外网打不开;且多 bot 各自不同端口,单口反代覆盖不到。

中心平台模式(远程访问 + 绑定)本就会把这些链接翻转成 `https://m-<id>.<平台域名>/…` 的干净无端口形态。本 PR 把同样的能力开放给「自建反代」场景,无需接平台。

## 改了什么

新增环境变量 `BOTMUX_PUBLIC_URL`(`scheme://host[:port]`,尾斜杠会被去掉)。设置后:

- dashboard 链接 → `<BASE>/?t=<token>`
- 卡片终端链接 → `<BASE>/s/<sessionId>`(读)/ `<BASE>/s/<sessionId>?token=<workerToken>`(写)

二者都走 dashboard 前门(dashboard 已把 `/s/<sessionId>` 反代到对应 bot 的终端代理),因此**无端口、对所有 bot 通用**。

优先级:**中心平台 > `BOTMUX_PUBLIC_URL` > 本地 `host:port`**。

改动文件:

- `src/platform/binding.ts`:新增纯函数 `publicReverseProxyBaseUrl()`(读取并归一化 env)
- `src/core/dashboard-url.ts`:插入 PUBLIC_URL 兜底;`?t=` token 保留
- `src/core/terminal-url.ts`:同款兜底;平台模式不带 token(平台 SSO 兜底),自建反代**保留 token**(无 SSO,否则终端裸暴露在域名上)
- `test/{dashboard-url,terminal-url}.test.ts`:补用例 + terminal-url 对该 env 做隔离

## 影响面

- **纯 opt-in**:未设 `BOTMUX_PUBLIC_URL` 时行为与改动前逐字节一致。
- **不影响中心平台用户**:平台分支优先命中,`buildDashboardUrls` / `buildTerminalUrl` 的平台形态完全不变。
- 仅动公共层 `core/dashboard-url`、`core/terminal-url`、`platform/binding`,**CLI/后端无关**,对所有 bot 一视同仁。
- webhook 链接**未改动**:它已按请求 `Host` 头推导 origin(反代 `Host` 透传时本就是域名),不需要该 env。

## 测试验证

- 单测 `test/dashboard-url` + `test/terminal-url` 共 **32 全过**;terminal-url 在 env 设/空两种条件下均绿(hermetic)。
- dist 级实测编译产物:
  - 设 env → `http://<域名>/s/<id>`、写链接 `…?token=wtok`、dashboard `http://<域名>/?t=abc`(无 `:7891`)
  - 不设 env → 回退 `http://192.168.28.45:8801/s/…`(证明 opt-in、默认不变)
- **live 部署实证**:daemon 重启后日志里 4 个会话「Worker ready, terminal at …」全部由 `192.168.28.45:88xx` 变为 `http://<域名>/s/<id>`;`curl <域名>/s/<id>` 返回 `200 + <title>Claude…</title>`(xterm 页面);使用者在飞书点卡片按钮实测打开终端通过。
- codex CLI 代码审查通过(仅 1 个 P2 测试隔离问题,已修复并复验)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
