### PR TITLE
fix(scheduler): 用户定时任务统一用系统本地时区(不再写死东8区)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,6 +62,7 @@ import { interactiveSelect, pickChoice, pickCliSelection } from './setup/interac
 import { buildPreset, serializePreset, presetFilename } from './setup/agent-preset.js';
 import type { CliId } from './adapters/cli/types.js';
 import { logger } from './utils/logger.js';
+import { scheduleTimeZone } from './utils/timezone.js';
 import { expandHomePath, invalidWorkingDirs } from './utils/working-dir.js';
 import { firstPositional } from './cli/arg-utils.js';
 import { dispatchPrimaryMessage, findStdinAliasAttachment, sendFileAttachments } from './cli/send-dispatch.js';
@@ -4049,8 +4050,8 @@ async function cmdSchedule(sub: string, rest: string[]): Promise<void> {
     console.log(`定时任务 (${filtered.length}${filter ? '/' + tasks.length : ''}):\n`);
     for (const t of filtered) {
       const status = t.enabled ? '✅' : '⏸️';
-      const next = t.nextRunAt ? new Date(t.nextRunAt).toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' }) : '—';
-      const last = t.lastRunAt ? new Date(t.lastRunAt).toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' }) : '—';
+      const next = t.nextRunAt ? new Date(t.nextRunAt).toLocaleString('zh-CN', { timeZone: scheduleTimeZone() }) : '—';
+      const last = t.lastRunAt ? new Date(t.lastRunAt).toLocaleString('zh-CN', { timeZone: scheduleTimeZone() }) : '—';
       const display = t.parsed?.display ?? t.schedule;
       const prompt = t.prompt ?? '';
       const chatId = t.chatId ?? '—';
@@ -4116,7 +4117,7 @@ async function cmdSchedule(sub: string, rest: string[]): Promise<void> {
       deliver,
     });
 
-    const next = task.nextRunAt ? new Date(task.nextRunAt).toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' }) : '—';
+    const next = task.nextRunAt ? new Date(task.nextRunAt).toLocaleString('zh-CN', { timeZone: scheduleTimeZone() }) : '—';
     console.log(`✅ 已创建定时任务 [${task.id}] ${task.name}`);
     console.log(`   规则: ${parsed.display}`);
     console.log(`   下次执行: ${next}`);

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -23,6 +23,7 @@ import { deleteMessage, sendMessage, sendUserMessage, listChatBotMembers, resolv
 import { chatAppLink, normalizeBrand } from '../im/lark/lark-hosts.js';
 import { claimPairing } from '../services/pairing-store.js';
 import { logger } from '../utils/logger.js';
+import { scheduleTimeZone } from '../utils/timezone.js';
 import { killWorker, forkWorker, forkAdoptWorker, getCurrentCliVersion, postFreshStreamingCard, postPrivateSnapshotCard, resolvePrivateCardAudience, deliverEphemeralOrReply, deliverWritableTerminalCardTo } from './worker-pool.js';
 import { expandHome, getSessionWorkingDir, getProjectScanDir, getProjectScanDirs, rememberLastCliInput } from './session-manager.js';
 import { discoverSlashCommandsForAdapter, listMcpServerNames, supportsFilesystemCommandDiscovery } from './command-discovery.js';
@@ -600,7 +601,7 @@ async function handleScheduleCommand(
   // forms include the wall-clock components the user cares about; the
   // difference is just punctuation and digit order.
   const timeLocale = loc === 'en' ? 'en-US' : 'zh-CN';
-  const timeZone = 'Asia/Shanghai';
+  const timeZone = scheduleTimeZone();
 
   // /schedule list | /schedule 列表
   if (!trimmed || trimmed === 'list' || trimmed === '列表') {

--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -1,5 +1,6 @@
 import { Cron } from 'croner';
 import * as scheduleStore from '../services/schedule-store.js';
+import { scheduleTimeZone } from '../utils/timezone.js';
 import { emitHookEvent } from '../services/hook-runner.js';
 import { logger } from '../utils/logger.js';
 import { dashboardEventBus } from './dashboard-events.js';
@@ -215,7 +216,7 @@ export function parseSchedule(input: string): ParsedSchedule {
   if (/^\d{4}-\d{2}-\d{2}(T| |$)/.test(s)) {
     const dt = new Date(s);
     if (!isNaN(dt.getTime())) {
-      return { kind: 'once', runAt: dt.toISOString(), display: `once at ${dt.toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' })}` };
+      return { kind: 'once', runAt: dt.toISOString(), display: `once at ${dt.toLocaleString('zh-CN', { timeZone: scheduleTimeZone() })}` };
     }
   }
 
@@ -307,7 +308,7 @@ export function computeNextRun(parsed: ParsedSchedule, lastRunAt?: string): stri
   if (parsed.kind === 'cron') {
     if (!parsed.expr) return null;
     try {
-      const job = new Cron(parsed.expr, { timezone: 'Asia/Shanghai' });
+      const job = new Cron(parsed.expr, { timezone: scheduleTimeZone() });
       const next = job.nextRun(new Date(now));
       return next ? next.toISOString() : null;
     } catch {
@@ -325,7 +326,7 @@ function computeGraceSeconds(parsed: ParsedSchedule): number {
     periodSec = parsed.minutes * 60;
   } else if (parsed.kind === 'cron' && parsed.expr) {
     try {
-      const job = new Cron(parsed.expr, { timezone: 'Asia/Shanghai' });
+      const job = new Cron(parsed.expr, { timezone: scheduleTimeZone() });
       const first = job.nextRun(new Date());
       const second = first ? job.nextRun(first) : null;
       periodSec = first && second ? (second.getTime() - first.getTime()) / 1000 : MIN_GRACE_SECONDS;

--- a/src/dashboard/schedule-card-model.ts
+++ b/src/dashboard/schedule-card-model.ts
@@ -16,6 +16,7 @@
 
 import { Cron } from 'croner';
 import type { ParsedSchedule } from '../types.js';
+import { scheduleTimeZone } from '../utils/timezone.js';
 import type {
   ButtonState,
   PaginationMeta,
@@ -23,7 +24,6 @@ import type {
   StatusDot,
 } from './card-model-types.js';
 
-const DEFAULT_TIMEZONE = 'Asia/Shanghai';
 const DEFAULT_PAGE_SIZE = 20;
 const MAX_PAGE_SIZE = 100;
 const DEFAULT_PROMPT_TRUNCATE = 200;
@@ -69,7 +69,7 @@ export interface ScheduleFilterQuery extends PaginationParams {
 export interface RowRenderContext {
   /** Epoch ms — required so relative-time outputs are deterministic. */
   nowMs: number;
-  /** IANA timezone for cron next-run math; defaults to 'Asia/Shanghai'. */
+  /** IANA timezone for cron next-run math; defaults to the host's local zone (scheduleTimeZone()). */
   timezone?: string;
   /** Cap prompt length in detail DTO; defaults to 200. */
   promptTruncateAt?: number;
@@ -273,9 +273,10 @@ export function toScheduleDetailDto(task: ScheduleCardTaskInput, ctx: RowRenderC
  *  - `once`:  one entry if `runAt >= nowMs` AND `lastRunAt` is absent; else [].
  *  - `interval`: minutes>0 required; base = lastRunAt ?? nowMs; aligns to first
  *               future run > nowMs.
- *  - `cron`:  uses `croner` with `Asia/Shanghai` (or override) timezone.
+ *  - `cron`:  uses `croner` with the host's local timezone (or an injected override).
  *
- * Pure: nowMs + timezone injected; no implicit clock reads.
+ * Pure w.r.t. the clock: nowMs is injected. `timezone` is injected too; when
+ * omitted it falls back to the host's local zone (scheduleTimeZone()).
  */
 export function computeNextNRuns(
   task: ScheduleCardTaskInput,
@@ -283,7 +284,7 @@ export function computeNextNRuns(
   ctx: { nowMs: number; timezone?: string },
 ): string[] {
   if (n <= 0) return [];
-  const tz = ctx.timezone ?? DEFAULT_TIMEZONE;
+  const tz = ctx.timezone ?? scheduleTimeZone();
   const { parsed } = task;
 
   if (parsed.kind === 'once') {

--- a/src/utils/timezone.ts
+++ b/src/utils/timezone.ts
@@ -1,0 +1,30 @@
+/**
+ * 用户定时任务(scheduler)统一使用的时区 = 主机的系统本地时区。
+ *
+ * 背景:cron 触发与各处显示历史上写死 'Asia/Shanghai',而一次性「明天HH:MM」用
+ * `Date.setHours()` 走系统本地时间,两者在非 +8 主机上错开一个时差(用户报的
+ * “有时本地有时东8”)。改走本函数后,cron 触发、CLI/卡片显示、dashboard next-run
+ * 预览都跟随系统本地时区,与一次性解析保持一致。
+ *
+ * 以函数(而非常量)导出:每次调用实时解析,便于测试注入,也不把值冻结在模块导入期。
+ * 注:维护窗口(maintenance-schedule.ts 的 MAINTENANCE_TZ)是独立子系统,刻意不走这里。
+ */
+
+/**
+ * 把 `Intl.DateTimeFormat().resolvedOptions().timeZone` 解析出的原始值归一成一个
+ * **一定能被 croner / `toLocaleString({ timeZone })` 接受** 的 IANA 名。
+ *
+ * 边界:某些主机(如 `TZ` 被导出成空串)下 Node 会把本地时区报成哨兵 `Etc/Unknown`,
+ * 它既不是合法 IANA 名 —— croner 会抛 `Invalid timezone` 让 cron next-run 变 null、
+ * `toLocaleString` 会抛 RangeError 让定时任务列表渲染崩。这类不可用值一律回退到 UTC
+ * (对所有消费方都合法、且确定性)。纯函数,便于单测。
+ */
+export function normalizeScheduleTimeZone(raw: string | undefined | null): string {
+  if (!raw || raw === 'Etc/Unknown') return 'UTC';
+  return raw;
+}
+
+/** 主机系统本地时区(经 Intl 解析,遵循 TZ 环境变量),已归一为可用 IANA 名。 */
+export function scheduleTimeZone(): string {
+  return normalizeScheduleTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone);
+}

--- a/test/schedule-card-model.test.ts
+++ b/test/schedule-card-model.test.ts
@@ -243,3 +243,16 @@ describe('schedule-card-model · invariants', () => {
     expect(toScheduleDetailDto(absent, ctx).repeat).toBeUndefined();
   });
 });
+
+describe('schedule-card-model · computeNextNRuns 默认时区 = 本地', () => {
+  it('未注入 timezone 时,cron next-run 落在系统本地整点(默认不再写死 Asia/Shanghai)', () => {
+    const task = makeTask({ parsed: cron('0 9 * * *') });
+    // 不传 timezone → 默认取 scheduleTimeZone()(系统本地)。断言用本地 getHours,
+    // 与实现同源;改动前默认 Asia/Shanghai,在非 +8 机器上此处会 != 9。
+    const runs = computeNextNRuns(task, 1, { nowMs: FIXED_NOW });
+    expect(runs).toHaveLength(1);
+    const d = new Date(runs[0]);
+    expect(d.getHours()).toBe(9);
+    expect(d.getMinutes()).toBe(0);
+  });
+});

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -547,12 +547,16 @@ describe('computeNextRun', () => {
     expect(next).toBeNull();
   });
 
-  it('cron: returns next wall-clock occurrence', () => {
-    // 0 9 * * * — daily at 09:00
+  it('cron: returns next wall-clock occurrence in the HOST-LOCAL timezone', () => {
+    // 0 9 * * * — daily at 09:00. computeNextRun now uses the host's local timezone
+    // (scheduleTimeZone()), matching how one-shot「明天9点」is parsed via setHours().
+    // Pre-fix it was hard-coded to Asia/Shanghai, so on any non-+8 host getHours()
+    // would NOT be 9. Host-independent assertion: both sides read the same local zone.
     const next = computeNextRun({ kind: 'cron', expr: '0 9 * * *', display: '每天 9:00' });
     expect(next).toBeTruthy();
     const nextDate = new Date(next!);
-    // Since timezone is Asia/Shanghai, getUTCHours should be 1 (09 - 08) except during DST (none in CN)
     expect(nextDate.getTime()).toBeGreaterThan(Date.now());
+    expect(nextDate.getHours()).toBe(9);
+    expect(nextDate.getMinutes()).toBe(0);
   });
 });

--- a/test/timezone.test.ts
+++ b/test/timezone.test.ts
@@ -1,0 +1,34 @@
+// test/timezone.test.ts
+import { describe, it, expect } from 'vitest';
+import { normalizeScheduleTimeZone, scheduleTimeZone } from '../src/utils/timezone.js';
+
+describe('normalizeScheduleTimeZone', () => {
+  it('passes through a normal IANA zone', () => {
+    expect(normalizeScheduleTimeZone('Asia/Bangkok')).toBe('Asia/Bangkok');
+    expect(normalizeScheduleTimeZone('America/New_York')).toBe('America/New_York');
+    expect(normalizeScheduleTimeZone('UTC')).toBe('UTC');
+  });
+
+  it("falls back to UTC on the 'Etc/Unknown' sentinel (unresolvable host zone)", () => {
+    // Node reports 'Etc/Unknown' when the local zone can't be resolved (e.g. TZ='').
+    // croner + toLocaleString both REJECT it, which would null cron next-runs and
+    // crash schedule listing — so it must normalize to a value every consumer accepts.
+    expect(normalizeScheduleTimeZone('Etc/Unknown')).toBe('UTC');
+  });
+
+  it('falls back to UTC on empty / nullish', () => {
+    expect(normalizeScheduleTimeZone('')).toBe('UTC');
+    expect(normalizeScheduleTimeZone(undefined)).toBe('UTC');
+    expect(normalizeScheduleTimeZone(null)).toBe('UTC');
+  });
+});
+
+describe('scheduleTimeZone', () => {
+  it('returns a usable IANA zone the scheduler consumers accept (never throws)', () => {
+    const tz = scheduleTimeZone();
+    expect(typeof tz).toBe('string');
+    expect(tz).not.toBe('Etc/Unknown');
+    // Must be accepted by Intl (same API croner/toLocaleString rely on).
+    expect(() => new Intl.DateTimeFormat('en-US', { timeZone: tz }).format(0)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## 问题

用户定时任务的时区处理**自相矛盾**:

- **重复类**(每天/每周/每月/工作日/每N小时/每N分钟/裸 cron)会转成 cron,`computeNextRun` 触发时用**写死的** `new Cron(expr, { timezone: 'Asia/Shanghai' })`。
- **一次性**「明天HH:MM」用 `Date.setHours()`,走**系统本地时间**。

在非 +8 主机上,「每天9点」(北京)与「明天9点」(本地)错开一个时差 —— 即“有时用本地、有时写死东8区”的 bug。各处显示(CLI 列表、飞书卡片、dashboard next-run 预览)也一并写死了 `Asia/Shanghai`,和触发时刻不一致。

## 改动

新增 `src/utils/timezone.ts` 的 `scheduleTimeZone()`,取**主机系统本地时区**(`Intl.DateTimeFormat().resolvedOptions().timeZone`,遵循 `TZ` 环境变量)。把下面 6 处写死的 `'Asia/Shanghai'` 全部替换成它:

- `core/scheduler.ts`:cron 触发(`computeNextRun`)、grace 周期计算、`once` 显示
- `dashboard/schedule-card-model.ts`:dashboard next-run 预览默认时区
- `core/command-handler.ts`:飞书 `/schedule` 列表卡片显示
- `cli.ts`:CLI `schedule` 列表显示(next/last)

触发时刻与所有显示/预览从此统一跟随**系统本地时区**,与一次性「明天X点」解析一致。

### 健壮性

`normalizeScheduleTimeZone()` 对解析失败的哨兵值兜底:某些主机(如 `TZ` 被导出成空串)下 Node 会把本地时区报成 `Etc/Unknown`,它**不是合法 IANA 名** —— croner 会抛 `Invalid timezone`(cron next-run 变 `null`)、`toLocaleString({ timeZone })` 会抛 `RangeError`(定时任务列表渲染崩)。此类不可用值一律回退 `UTC`(对所有消费方合法且确定性)。

## 影响面

- 仅动**用户定时任务**子系统(`scheduler` + 其显示/预览)。
- **维护窗口**(`maintenance-schedule.ts` 的 `MAINTENANCE_TZ`)是独立子系统,**本次刻意不改**。
- 行为变化:已有 cron 类定时任务的触发时刻会从「固定北京时间」变为「主机本地时间」。在 +8 主机上无变化;在其它时区主机上会按本地时间对齐(这正是修复目标)。
- CLI/后端/其它 CLI 无关。

## 测试

- `test/timezone.test.ts`(新增):`normalizeScheduleTimeZone` 对 `Etc/Unknown`/空/`null` 回退 UTC、正常 IANA 透传;`scheduleTimeZone()` 返回值必被 Intl 接受(不抛)。
- `test/scheduler.test.ts`:cron next-run 断言落在**本地** 09:00(机器无关 —— 改动前写死东8区,在非 +8 机器上此断言会失败)。
- `test/schedule-card-model.test.ts`:不注入 timezone 时默认走系统本地。
- 受影响单测(scheduler/schedule-card-model/command-handler/maintenance/timezone)共 **314 全过**;`tsc` 通过。
- codex CLI 代码审查通过(指出的 `Etc/Unknown` 边界 P2 已修复并补测)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
