### PR TITLE
fix(read-isolation): botmux quoted 在隔离 bot 下可用 + 下载被引用消息的文件

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4320,6 +4320,11 @@ async function cmdQuoted(rest: string[]): Promise<void> {
     process.exit(1);
   }
 
+  // Read isolation: register this bot from its own send-cred file so the Lark
+  // client (getMessageDetail below) is available WITHOUT reading the denied
+  // bots.json — same as cmdHistory / cmdSend. Missing this was why a sandboxed
+  // isolated bot's `botmux quoted` failed "Bot not registered".
+  await registerSelfFromCredFile();
   const { larkAppId: appId } = await resolveSessionAppId(sessionIdArg);
 
   const { getMessageDetail } = await import('./im/lark/client.js');
@@ -4342,6 +4347,19 @@ async function cmdQuoted(rest: string[]): Promise<void> {
     if (rendered.msgType === 'interactive') {
       const merged = await resolveMergedCardContent(appId, messageId).catch(() => null);
       if (merged) rendered.content = merged.text;
+    }
+    // The referenced message's file/media resources arrive as key+name only. A
+    // read-isolated agent can't call the Lark resource API itself (bots.json
+    // creds are deny-read), so download the bytes HERE — via the bot client
+    // registered above — into this bot's OWN attachment bucket
+    // (attachments/<appId>/<messageId>/, read-allowed by its carve-out; sandbox
+    // denies file *reads*, not writes). Surface the local paths so the agent can
+    // actually open the file instead of only seeing its key.
+    if (rendered.resources?.length) {
+      const { downloadResources } = await import('./core/session-manager.js');
+      const { attachments, needLogin } = await downloadResources(appId, messageId, rendered.resources);
+      (rendered as { attachments?: unknown }).attachments = attachments;
+      if (needLogin) (rendered as { needLogin?: boolean }).needLogin = true;
     }
     console.log(JSON.stringify(rendered, null, 2));
   } catch (err: any) {


### PR DESCRIPTION
## ⚠️ 依赖:stack 在 #387 之上

本 PR 依赖 #387（read-isolation 附件分桶）引入的 `registerSelfFromCredFile` / `downloadResources` / appId 分桶，基于其分支 `pr/read-isolation-attachments` 开出。**请在 #387 之后 review/合并**。在 #387 合入 master 前，本 PR 的 diff 会包含 #387 的改动；#387 合并后 GitHub 会自动收敛成仅剩本 PR 的增量（`src/cli.ts` cmdQuoted）。

## 问题

隔离 bot 的 sandbox 里 `~/.botmux/bots.json`（含所有 bot 的 app_id/app_secret）被 read-isolation deny（必须 deny，否则跨 bot 凭证泄露）。这导致 `botmux quoted` 对隔离 bot 两处不可用：

1. **`Bot not registered`**：`cmdQuoted → resolveSessionAppId → loadBotConfigs()` 读 `bots.json` → 被 deny → 注册静默失败 → `getMessageDetail` 找不到已注册 bot → 抛 `Bot not registered: <appId>`。`cmdHistory` / `cmdSend` 早已用 send-cred 兜过这层，`cmdQuoted` 漏了。
2. **文件字节拿不到**：即便修好 ①，被引用消息的文件资源也只返回 `key`+`name`；隔离 bot 无凭证自己调 Lark resource API 下载，`botmux quoted` 又没把字节落盘。

## 改动（仅 `src/cli.ts` 的 `cmdQuoted`）

1. 开头补 `await registerSelfFromCredFile();` —— 用注入的 `BOTMUX_LARK_APP_ID` + 该 bot 自己 BOT_HOME 里的 `send-cred.json` 注册，**不读 bots.json**，与 `cmdHistory` / `cmdSend` 一致。
2. 渲染后对 `rendered.resources` 调 daemon 同款 `downloadResources(appId, messageId, resources)` —— 用上一步注册的 bot client（tenant token）把文件字节下到该 bot **自己的 appId 桶** `attachments/<appId>/<messageId>/`（read-isolation carve-out 允许读自己桶；sandbox 只 deny 文件*读*、不 deny 写），并把 `attachments:[{type,path,name}]` 塞进 quoted 的 JSON 输出，agent 直接读 `path` 即可打开文件。

## 影响面

- 只动 `cmdQuoted`，对非隔离 bot 无行为变化：`registerSelfFromCredFile()` 在无 send-cred 时 no-op，`downloadResources` 与直发消息附件走完全相同的既有路径。
- 复用已验证的 `downloadResources`（daemon 直发附件同款），文件类型/失败处理/`needLogin` 语义一致。

## 测试验证

- codex CLI 代码审查 **两轮**（先 register、后 download）均**零 findings**。
- **用户 live 实测**：隔离 bot（`cli_aab4eaea…`）在群里引用回复一条文件消息 → `botmux quoted <msgId>` 先返回 `resources`（`{type:file, key, name}`），补下载后输出含 `attachments[].path`，隔离 bot 直接读该本地路径成功拿到文件内容（此前 `Bot not registered` + 文件不落盘）。
- `tsc` 通过。
- cmdQuoted 是 CLI I/O，暂无单测（需 mock `getMessageDetail`/`downloadResources`）；可按需补。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
