### PR TITLE
fix(sandbox): 将 outbox 移出 home overlay

### DIFF
--- a/docs/file-sandbox.md
+++ b/docs/file-sandbox.md
@@ -1,6 +1,6 @@
 # 文件沙盒（oncall 安全共享）
 
-把某个 bot 的 CLI 会话关进一个**按会话隔离的文件沙盒**，让你能把机器人放心分享给半受信任的人（oncall）：对方可以读真实工具链/CLI 配置并操作项目，但对 `$HOME` 和项目目录的写入会落到 overlay upper，不直接改宿主真实文件；飞书凭证也不会进入沙盒。
+把某个 bot 的 CLI 会话关进一个**按会话隔离的文件沙盒**，让你能把机器人放心分享给半受信任的人（oncall）：对方可以读真实工具链/CLI 配置并操作项目，但对 `$HOME` 和项目目录的写入会落到 overlay upper，不直接改宿主真实文件；`botmux send` 通过 relay 代发，不把发送凭证通过 env/argv/IPC 注入沙盒。
 
 > 调研与威胁模型见 [`sandbox-oncall-research-20260605.md`](./sandbox-oncall-research-20260605.md)。
 > 当前 scope = **只隔离文件**（Linux）。网络**不**隔离（`npm install` / `git fetch` 照常）；不防内核级容器逃逸——面向半受信任用户，不是面向恶意攻击者。
@@ -54,23 +54,25 @@ worker spawnCli
 
 ## botmux send 中转（关键）
 
-`botmux send` 原本**直连飞书**（读 `bots.json` 拿密钥）。沙盒里没有宿主 bot 配置/凭证，所以：
+`botmux send` 原本**直连飞书**（读 `bots.json` 拿密钥）。沙盒内的 shim 会改走 relay，中转本身不把发送凭证通过 env/argv/IPC 交给沙盒进程：
 
 1. 沙盒内 `botmux send` 检测到 `BOTMUX_SEND_RELAY=/var/tmp/botmux-sbx-<uid>/<sid>/outbox`，把内容、附件和 allowlist 后的展示参数写进 outbox，**不直连飞书**。
 2. daemon 侧 `startOutboxWatcher` 拾取 `.req.json`，把 outbox 内的内容/附件 TOCTOU-safe 地复制到 host-private staging。
 3. daemon 在**沙盒外**用真实凭证重跑 `send` 投递，并把 `.res.json` 写回 outbox。
 
-→ **所有飞书密钥全程不进沙盒**。
+→ relay 只保证「代发链路」不注入发送凭证。当前模型是 read-all/write-isolated，真实 HOME/配置文件默认仍可读；如果需要隐藏磁盘上的 botmux 配置、飞书密钥或其它敏感文件，必须额外配置 `sandboxHidePaths` / read isolation。
 
 ### 升级兼容
 
-旧版本已经运行中的 persistent sandbox 会话可能仍在使用旧 outbox：
+旧版本已经运行中的 persistent sandbox 会话可能仍在使用旧 HOME upper / outbox：
 
 ```
+/var/tmp/botmux-sbx/<sid>/home-upper
+/var/tmp/botmux-sbx/<sid>/outbox
 <dataDir>/sandboxes/<sid>/outbox
 ```
 
-daemon restart reattach 时会优先寻找新路径 `/var/tmp/botmux-sbx-<uid>/<sid>/outbox`；如果不存在，会 fallback 到旧路径，以便升级前已经运行的 sandbox 会话继续 relay。新建 sandbox 会话只使用 `/var/tmp/botmux-sbx-<uid>/<sid>/outbox`。
+daemon restart reattach 时会优先寻找新路径 `/var/tmp/botmux-sbx-<uid>/<sid>/outbox`；如果不存在，会 fallback 到旧路径，以便升级前已经运行的 sandbox 会话继续 relay。Claude bridge 的 HOME upper redirect 也会在旧 `/var/tmp/botmux-sbx/<sid>/home-upper` 存在且新路径不存在时继续指向旧路径，避免 persistent tmux sandbox 升级后看不到 CLI 写入。新建 sandbox 会话只使用 `/var/tmp/botmux-sbx-<uid>/<sid>/...`。
 
 ## 落盘（把改动交回）
 
@@ -80,7 +82,7 @@ agent 在 overlay 项目目录内改完后，改动位于 `<dataDir>/sandboxes/<
 
 - 文件隔离：项目/HOME 写入进入 upper，原文件未直接修改。
 - auth/login 路径：按 CLI adapter 声明真实可写，token refresh 可持久化。
-- send 中转：沙盒内 `botmux send`（含文件附件）→ outbox → daemon 代投 → 真实到达飞书，全程零凭证入沙盒。
+- send 中转：沙盒内 `botmux send`（含文件附件）→ outbox → daemon 代投 → 真实到达飞书；relay 链路不向沙盒注入发送凭证。
 - 真实 worker：CLI 经 worker spawn 钩子在 bwrap 内正常启动运行。
 
 ## 后续

--- a/docs/file-sandbox.md
+++ b/docs/file-sandbox.md
@@ -1,6 +1,6 @@
 # 文件沙盒（oncall 安全共享）
 
-把某个 bot 的 CLI 会话关进一个**按会话隔离的文件沙盒**，让你能把机器人放心分享给半受信任的人（oncall）：对方只能操作 agent + 一份项目副本，**碰不到你磁盘上的真实文件、密钥、别的会话数据**。
+把某个 bot 的 CLI 会话关进一个**按会话隔离的文件沙盒**，让你能把机器人放心分享给半受信任的人（oncall）：对方可以读真实工具链/CLI 配置并操作项目，但对 `$HOME` 和项目目录的写入会落到 overlay upper，不直接改宿主真实文件；飞书凭证也不会进入沙盒。
 
 > 调研与威胁模型见 [`sandbox-oncall-research-20260605.md`](./sandbox-oncall-research-20260605.md)。
 > 当前 scope = **只隔离文件**（Linux）。网络**不**隔离（`npm install` / `git fetch` 照常）；不防内核级容器逃逸——面向半受信任用户，不是面向恶意攻击者。
@@ -11,59 +11,80 @@
 - per-bot 手动：`bots.json` 里给该 bot 加 `"sandbox": true`
 - 临时/测试：环境变量 `BOTMUX_SANDBOX=1`（对该 daemon 的所有会话强制开）
 
-仅 Linux 生效（依赖 bubblewrap）；非 Linux 自动跳过。需要 PTY 后端（tmux/zellij 后端暂不包裹，自动回退直跑）。macOS 的 `sandbox-exec` 后端是后续工作。
+仅 Linux 生效（依赖 bubblewrap + overlayfs；非 root 通常需要 fuse-overlayfs）。非 Linux 自动跳过。macOS 的 `sandbox-exec` 后端是后续工作。
 
 ## 工作原理
 
+当前实现是 **overlayfs read-all / write-isolated** 模型：
+
 ```
 worker spawnCli
-  └─ prepareSandbox()                      adapters/backend/sandbox.ts
-       ├─ 每会话目录 <dataDir>/sandboxes/<sid>/{home,work,outbox,shimbin}
-       ├─ git clone --no-hardlinks 源项目 → work（独立 .git，动不了源仓库）
-       ├─ seedScopedConfig(cliId)          只拷认证(auth.json/config…)，剔历史
-       ├─ 写 botmux shim → PATH 头（让沙盒内 botmux 走本 build 的 relay）
-       └─ buildSandboxArgs()               bwrap 参数
-  └─ bwrap … -- <cli> <原 args>            把 CLI 关进沙盒
-  └─ startOutboxWatcher()                  daemon 侧代投递（持凭证）
+  └─ prepareSandbox()                              adapters/backend/sandbox.ts
+       ├─ <dataDir>/sandboxes/<sid>/proj-upper     项目改动 upper（可落盘 changeset）
+       ├─ <dataDir>/sandboxes/<sid>/proj-work      项目 overlay workdir
+       ├─ <dataDir>/sandboxes/<sid>/proj-merged    项目 overlay merged
+       ├─ <dataDir>/sandboxes/<sid>/home-merged    HOME overlay merged
+       ├─ <dataDir>/sandboxes/<sid>/shimbin        botmux relay shim
+       ├─ /var/tmp/botmux-sbx/<sid>/home-upper     HOME 写入 upper
+       ├─ /var/tmp/botmux-sbx/<sid>/home-work      HOME overlay workdir
+       └─ /var/tmp/botmux-sbx/<sid>/outbox         botmux send relay outbox
+  └─ bwrap … -- <cli> <原 args>                    把 CLI 关进 namespace
+  └─ startOutboxWatcher()                          daemon 侧代投递（持凭证）
 ```
+
+说明：
+
+- 真实文件系统先以只读方式暴露，CLI 启动所需的系统工具链、Node、CLI 安装目录、认证配置等可以正常读取。
+- `$HOME` 和项目目录分别由 host 侧 overlay merged 目录 bind 回原路径；读走真实 lower，写入 copy-up 到对应 upper。
+- 项目改动集中在 `<dataDir>/sandboxes/<sid>/proj-upper`，供后续 diff/land 使用。
+- HOME 写入集中在 `/var/tmp/botmux-sbx/<sid>/home-upper`，避免 overlayfs upper/work 位于 HOME lower 内部。
+- outbox 放在 `/var/tmp/botmux-sbx/<sid>/outbox`，避免在 HOME overlay 内部再 bind 子目录导致部分 bwrap 环境卡在挂载阶段。
+- `/var/tmp/botmux-sbx`、`<sid>`、`outbox` 都会收紧到 `0700`；relay 内容/附件/请求/响应文件以 `0600` 写入，避免公共多用户机器上被其他本地用户读取。
 
 **bwrap 绑定策略**（`buildSandboxArgs`）：
 
-- `--ro-bind` 系统工具链（`/usr` `/bin` …）+ fnm node/CLI 安装目录 + botmux dist + node_modules
-- `--bind scopedHome → $HOME`：脱敏家目录盖住真实家目录，于是 `~/.codex`、`~/.claude` 等都落在脱敏区
-- `--bind 项目副本 → 原 workingDir`：副本挂在 CLI 原本认得的路径上，所以 `codex -C <dir>` 之类参数无需改写
-- `--bind outbox`：沙盒内回消息的**唯一** IPC 出口
-- 不绑：`~/.ssh`、`~/.aws`、`bots.json`、别的会话/项目、各 CLI 历史
-- `--unshare-user/pid/ipc/uts/cgroup`，默认保留网络
-
-**per-CLI 脱敏配置**（`seedScopedConfig` + `CONFIG_SCOPE`）：每会话新建配置目录，**只**拷该 CLI 启动所需的认证/配置，历史/会话/日志一律不进沙盒。已覆盖 codex、claude-code；新 CLI 加一条 `CONFIG_SCOPE` 即可。
+- `--ro-bind / /`：真实文件系统只读暴露。
+- `--bind home-merged → $HOME`：HOME 写隔离；`~/.codex`、`~/.claude` 等写入 copy-up 到 `home-upper`。
+- `--bind proj-merged → 原 workingDir`：项目写隔离；CLI 原本的 `-C <dir>` 等路径无需改写。
+- CLI auth/login 路径按适配器声明 bind 为真实可写，用于 token refresh / 登录状态持久化。
+- per-bot `hidePaths` 可用 tmpfs/empty file 遮蔽敏感路径。
+- `sandboxReadonlyPaths` 可额外只读暴露参考资料，但不能覆盖 HOME/项目 overlay root。
+- `--bind outbox`：沙盒内回消息的**唯一** IPC 出口，且最后 bind，避免被 mask 盖掉。
+- `--unshare-user/pid/ipc/uts/cgroup`，默认保留网络。
 
 ## botmux send 中转（关键）
 
-`botmux send` 原本**直连飞书**（读 `bots.json` 拿密钥）。沙盒里没有 `bots.json`，所以：
+`botmux send` 原本**直连飞书**（读 `bots.json` 拿密钥）。沙盒里没有宿主 bot 配置/凭证，所以：
 
-1. 沙盒内 `botmux send` 检测到 `BOTMUX_SEND_RELAY`，把请求（argv + 内容文件 + 附件）写进 `outbox`，**不直连飞书**
-2. daemon 侧 `startOutboxWatcher` 拾取请求，在**沙盒外**用真实凭证重跑 `send` 投递，结果写回
-3. 附件被拷进 `outbox`（共享路径）后路径改写，host 侧才读得到
+1. 沙盒内 `botmux send` 检测到 `BOTMUX_SEND_RELAY=/var/tmp/botmux-sbx/<sid>/outbox`，把内容、附件和 allowlist 后的展示参数写进 outbox，**不直连飞书**。
+2. daemon 侧 `startOutboxWatcher` 拾取 `.req.json`，把 outbox 内的内容/附件 TOCTOU-safe 地复制到 host-private staging。
+3. daemon 在**沙盒外**用真实凭证重跑 `send` 投递，并把 `.res.json` 写回 outbox。
 
 → **所有飞书密钥全程不进沙盒**。
 
+### 升级兼容
+
+旧版本已经运行中的 persistent sandbox 会话可能仍在使用旧 outbox：
+
+```
+<dataDir>/sandboxes/<sid>/outbox
+```
+
+daemon restart reattach 时会优先寻找新路径 `/var/tmp/botmux-sbx/<sid>/outbox`；如果不存在，会 fallback 到旧路径，以便升级前已经运行的 sandbox 会话继续 relay。新建 sandbox 会话只使用 `/var/tmp/botmux-sbx/<sid>/outbox`。
+
 ## 落盘（把改动交回）
 
-agent 在副本上改完，用 `botmux send --files <patch>`（`git diff` 出来的补丁）把改动交回话题，owner review 后手动应用。**交互式「应用到磁盘」确认卡是后续工作**（复用现有授权卡基建）。
+agent 在 overlay 项目目录内改完后，改动位于 `<dataDir>/sandboxes/<sid>/proj-upper`。后续可通过 sandbox land/diff 逻辑把 upper changeset 展示给 owner review，再应用到真实项目。**交互式「应用到磁盘」确认卡是后续工作**（复用现有授权卡基建）。
 
 ## 已验证（本机实测）
 
-- 文件隔离：宿主密钥/家目录读不到，原文件未动
-- per-CLI 脱敏：codex `auth.json` 进得去、`history.jsonl` 进不去
-- 项目副本独立（`git clone --no-hardlinks`）
-- send 中转：沙盒内 `botmux send`（含文件附件）→ outbox → daemon 代投 → 真实到达飞书，全程零凭证入沙盒
-- 真实 worker：codex 经 worker spawn 钩子在 bwrap 内正常启动运行
+- 文件隔离：项目/HOME 写入进入 upper，原文件未直接修改。
+- auth/login 路径：按 CLI adapter 声明真实可写，token refresh 可持久化。
+- send 中转：沙盒内 `botmux send`（含文件附件）→ outbox → daemon 代投 → 真实到达飞书，全程零凭证入沙盒。
+- 真实 worker：CLI 经 worker spawn 钩子在 bwrap 内正常启动运行。
 
 ## 后续
 
 - 交互式落盘确认卡（apply/discard 按钮 + `git apply`）
 - macOS `sandbox-exec` 后端
-- tmux/zellij 后端支持
-- 沙盒目录 GC / 生命周期
 - 出口网络管控（升级到「不止隔离文件」时）

--- a/docs/file-sandbox.md
+++ b/docs/file-sandbox.md
@@ -25,9 +25,9 @@ worker spawnCli
        ├─ <dataDir>/sandboxes/<sid>/proj-merged    项目 overlay merged
        ├─ <dataDir>/sandboxes/<sid>/home-merged    HOME overlay merged
        ├─ <dataDir>/sandboxes/<sid>/shimbin        botmux relay shim
-       ├─ /var/tmp/botmux-sbx/<sid>/home-upper     HOME 写入 upper
-       ├─ /var/tmp/botmux-sbx/<sid>/home-work      HOME overlay workdir
-       └─ /var/tmp/botmux-sbx/<sid>/outbox         botmux send relay outbox
+       ├─ /var/tmp/botmux-sbx-<uid>/<sid>/home-upper     HOME 写入 upper
+       ├─ /var/tmp/botmux-sbx-<uid>/<sid>/home-work      HOME overlay workdir
+       └─ /var/tmp/botmux-sbx-<uid>/<sid>/outbox         botmux send relay outbox
   └─ bwrap … -- <cli> <原 args>                    把 CLI 关进 namespace
   └─ startOutboxWatcher()                          daemon 侧代投递（持凭证）
 ```
@@ -37,9 +37,9 @@ worker spawnCli
 - 真实文件系统先以只读方式暴露，CLI 启动所需的系统工具链、Node、CLI 安装目录、认证配置等可以正常读取。
 - `$HOME` 和项目目录分别由 host 侧 overlay merged 目录 bind 回原路径；读走真实 lower，写入 copy-up 到对应 upper。
 - 项目改动集中在 `<dataDir>/sandboxes/<sid>/proj-upper`，供后续 diff/land 使用。
-- HOME 写入集中在 `/var/tmp/botmux-sbx/<sid>/home-upper`，避免 overlayfs upper/work 位于 HOME lower 内部。
-- outbox 放在 `/var/tmp/botmux-sbx/<sid>/outbox`，避免在 HOME overlay 内部再 bind 子目录导致部分 bwrap 环境卡在挂载阶段。
-- `/var/tmp/botmux-sbx`、`<sid>`、`outbox` 都会收紧到 `0700`；relay 内容/附件/请求/响应文件以 `0600` 写入，避免公共多用户机器上被其他本地用户读取。
+- HOME 写入集中在 `/var/tmp/botmux-sbx-<uid>/<sid>/home-upper`，避免 overlayfs upper/work 位于 HOME lower 内部。
+- outbox 放在 `/var/tmp/botmux-sbx-<uid>/<sid>/outbox`，避免在 HOME overlay 内部再 bind 子目录导致部分 bwrap 环境卡在挂载阶段。
+- `/var/tmp/botmux-sbx-<uid>`、`<sid>`、`outbox` 都会收紧到 `0700`；relay 内容/附件/请求/响应文件以 `0600` 写入，避免公共多用户机器上被其他本地用户读取。
 
 **bwrap 绑定策略**（`buildSandboxArgs`）：
 
@@ -56,7 +56,7 @@ worker spawnCli
 
 `botmux send` 原本**直连飞书**（读 `bots.json` 拿密钥）。沙盒里没有宿主 bot 配置/凭证，所以：
 
-1. 沙盒内 `botmux send` 检测到 `BOTMUX_SEND_RELAY=/var/tmp/botmux-sbx/<sid>/outbox`，把内容、附件和 allowlist 后的展示参数写进 outbox，**不直连飞书**。
+1. 沙盒内 `botmux send` 检测到 `BOTMUX_SEND_RELAY=/var/tmp/botmux-sbx-<uid>/<sid>/outbox`，把内容、附件和 allowlist 后的展示参数写进 outbox，**不直连飞书**。
 2. daemon 侧 `startOutboxWatcher` 拾取 `.req.json`，把 outbox 内的内容/附件 TOCTOU-safe 地复制到 host-private staging。
 3. daemon 在**沙盒外**用真实凭证重跑 `send` 投递，并把 `.res.json` 写回 outbox。
 
@@ -70,7 +70,7 @@ worker spawnCli
 <dataDir>/sandboxes/<sid>/outbox
 ```
 
-daemon restart reattach 时会优先寻找新路径 `/var/tmp/botmux-sbx/<sid>/outbox`；如果不存在，会 fallback 到旧路径，以便升级前已经运行的 sandbox 会话继续 relay。新建 sandbox 会话只使用 `/var/tmp/botmux-sbx/<sid>/outbox`。
+daemon restart reattach 时会优先寻找新路径 `/var/tmp/botmux-sbx-<uid>/<sid>/outbox`；如果不存在，会 fallback 到旧路径，以便升级前已经运行的 sandbox 会话继续 relay。新建 sandbox 会话只使用 `/var/tmp/botmux-sbx-<uid>/<sid>/outbox`。
 
 ## 落盘（把改动交回）
 

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -824,6 +824,39 @@ export function materializeOutboxFile(outbox: string, name: string, dest: string
   finally { closeSync(fd); if (outFd !== null) closeSync(outFd); }
 }
 
+const RELAY_REQUEST_MAX_BYTES = 64 * 1024;
+
+/**
+ * TOCTOU-safe read of the `.req.json` trigger file itself. The request file is
+ * also sandbox-controlled input, so it needs the same hardening as content and
+ * attachments: no symlinks, no FIFO/device files, no blocking opens, and a small
+ * size cap before JSON.parse. Returns null on any unsafe/non-regular/oversized
+ * input so the watcher can reject and keep its event loop moving.
+ */
+export function readRelayRequestFile(reqPath: string): string | null {
+  let fd: number;
+  try { fd = openSync(reqPath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK); }
+  catch { return null; }
+  try {
+    const st = fstatSync(fd);
+    if (!st.isFile()) return null;
+    if (st.size > RELAY_REQUEST_MAX_BYTES) return null;
+
+    const chunks: Buffer[] = [];
+    let total = 0;
+    const buf = Buffer.alloc(Math.min(8192, RELAY_REQUEST_MAX_BYTES));
+    for (;;) {
+      const n = readSync(fd, buf, 0, buf.length, null);
+      if (n <= 0) break;
+      total += n;
+      if (total > RELAY_REQUEST_MAX_BYTES) return null;
+      chunks.push(Buffer.from(buf.subarray(0, n)));
+    }
+    return Buffer.concat(chunks, total).toString('utf8');
+  } catch { return null; }
+  finally { closeSync(fd); }
+}
+
 /**
  * Daemon/worker-side outbox watcher. The sandboxed `botmux send` (relay mode)
  * drops `<id>.req.json`; we validate (validateRelayRequest) and then MATERIALIZE
@@ -859,7 +892,9 @@ export function startOutboxWatcher(outbox: string, baseEnv: NodeJS.ProcessEnv, s
       const id = name.slice(0, -'.req.json'.length);
       const staged: string[] = [];
       let req: RelayRequest;
-      try { req = JSON.parse(readFileSync(reqPath, 'utf8')); }
+      const reqText = readRelayRequestFile(reqPath);
+      if (reqText === null) { finish(id, reqPath, name, staged, 1, '', 'relay rejected: request not a regular file or too large'); continue; }
+      try { req = JSON.parse(reqText); }
       catch { finish(id, reqPath, name, staged, 1, '', 'relay: bad json'); continue; }
 
       const v = validateRelayRequest(req);

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -20,7 +20,7 @@
  * sandbox-exec approach and is handled elsewhere.
  */
 import { homedir } from 'node:os';
-import { mkdirSync, existsSync, writeFileSync, chmodSync, readdirSync, readFileSync, rmSync, statSync, realpathSync, openSync, fstatSync, readSync, writeSync, closeSync, constants as fsConstants } from 'node:fs';
+import { mkdirSync, existsSync, writeFileSync, chmodSync, readdirSync, readFileSync, rmSync, statSync, lstatSync, realpathSync, openSync, fstatSync, readSync, writeSync, closeSync, constants as fsConstants } from 'node:fs';
 import { atomicWriteFileSync } from '../../utils/atomic-write.js';
 import { join, dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -30,21 +30,48 @@ import { spawn, spawnSync } from 'node:child_process';
  *  (overlayfs forbids upper/work inside lower). Keep it per-uid: /var/tmp is a
  *  shared multi-user surface, and a global 0700 root would let the first user
  *  that starts sandbox block every other Unix user on the same machine. */
+const LEGACY_VARTMP_ROOT = '/var/tmp/botmux-sbx';
+
 export function sandboxVartmpRoot(): string {
   const uid = process.getuid?.() ?? 0;
   return `/var/tmp/botmux-sbx-${uid}`;
 }
 
+function legacySandboxVartmpDir(sessionId: string): string {
+  return join(LEGACY_VARTMP_ROOT, sessionId);
+}
+
+function sandboxVartmpDir(sessionId: string): string {
+  return join(sandboxVartmpRoot(), sessionId);
+}
+
+function sandboxHomeUpperDir(sessionId: string): string {
+  const next = join(sandboxVartmpDir(sessionId), 'home-upper');
+  const legacy = join(legacySandboxVartmpDir(sessionId), 'home-upper');
+  // Published versions stored HOME upper under the global /var/tmp/botmux-sbx.
+  // A daemon upgrade may reattach a still-running tmux sandbox whose bwrap
+  // namespace continues writing that old overlay upper. If the new per-uid upper
+  // does not exist, keep the bridge pointed at the legacy path.
+  if (existsSync(legacy) && !existsSync(next)) return legacy;
+  return next;
+}
+
 /** Create a daemon-private directory and repair legacy/default mkdir modes.
  *  Anything under /var/tmp is on a shared multi-user surface, while the outbox
  *  carries in-flight Lark message bodies/attachments. Refuse to proceed unless
- *  group/other bits are gone after chmod. */
+ *  the path is a real directory owned by this daemon user, and group/other bits
+ *  are gone after chmod. */
 function ensurePrivateDir(dir: string): boolean {
   try {
     mkdirSync(dir, { recursive: true, mode: 0o700 });
+    const lst = lstatSync(dir);
+    if (lst.isSymbolicLink() || !lst.isDirectory()) return false;
+    const stBefore = statSync(dir);
+    const uid = process.getuid?.();
+    if (typeof uid === 'number' && stBefore.uid !== uid) return false;
     chmodSync(dir, 0o700); // repair dirs created before this hardening or under a loose umask
     const st = statSync(dir);
-    return st.isDirectory() && (st.mode & 0o077) === 0;
+    return st.isDirectory() && (typeof uid !== 'number' || st.uid === uid) && (st.mode & 0o077) === 0;
   } catch (err) {
     console.error(`[sandbox] failed to prepare private dir ${dir}: ${err instanceof Error ? err.message : String(err)}`);
     return false;
@@ -369,7 +396,7 @@ export interface SandboxSpawn {
 export function sandboxedClaudeDataDir(sessionId: string, realDataDir: string): string {
   const raw = relative(homedir(), realDataDir);
   const rel = raw.startsWith('..') ? relative(resolveSandboxMountPath(homedir()), realDataDir) : raw;
-  return join(sandboxVartmpRoot(), sessionId, 'home-upper', rel);
+  return join(sandboxHomeUpperDir(sessionId), rel);
 }
 
 /** Proxy env vars forwarded into the sandbox so the CLI reaches the API even on
@@ -436,7 +463,7 @@ export function prepareSandbox(opts: {
   const projMerged = join(sessionRoot, 'proj-merged');
   const homeMerged = join(sessionRoot, 'home-merged');  // merged may live under sessionRoot
   // HOME overlay upper/work MUST be OUTSIDE the home lower (overlayfs constraint).
-  const vartmp = join(sandboxVartmpRoot(), opts.sessionId);
+  const vartmp = sandboxVartmpDir(opts.sessionId);
   const outbox = join(vartmp, 'outbox');
   const homeUpper = join(vartmp, 'home-upper');
   const homeWork = join(vartmp, 'home-work');
@@ -566,6 +593,7 @@ export function prepareSandbox(opts: {
       unmountOverlay(homeMerged);
       try { rmSync(sessionRoot, { recursive: true, force: true }); } catch { /* */ }
       try { rmSync(vartmp, { recursive: true, force: true }); } catch { /* */ }
+      try { rmSync(legacySandboxVartmpDir(opts.sessionId), { recursive: true, force: true }); } catch { /* */ }
     },
   };
 }
@@ -580,23 +608,26 @@ export function prepareSandbox(opts: {
  * the workDir (upper changeset for landing) and a cleanup that tears the residue
  * down at close/exit. Returns null if the session has no sandbox tree on disk
  * (never sandboxed). Linux-only, mirrors prepareSandbox's layout. New sessions
- * keep outbox under /var/tmp/botmux-sbx-<uid>/<sid>/outbox; fall back to the legacy
- * <dataDir>/sandboxes/<sid>/outbox for sessions that were already running
- * before the layout changed.
+ * keep outbox under /var/tmp/botmux-sbx-<uid>/<sid>/outbox; fall back to legacy
+ * /var/tmp/botmux-sbx/<sid>/outbox or <dataDir>/sandboxes/<sid>/outbox for
+ * sessions that were already running before the layout changed.
  */
 export function attachSandboxOutbox(opts: { sessionId: string; dataDir: string }): { outbox: string; workDir: string; cleanup: () => void } | null {
   if (process.platform !== 'linux') return null;
   const dataDir = resolveSandboxMountPath(opts.dataDir);
   const sessionRoot = join(dataDir, 'sandboxes', opts.sessionId);
-  const vartmp = join(sandboxVartmpRoot(), opts.sessionId);
+  const vartmp = sandboxVartmpDir(opts.sessionId);
   const newOutbox = join(vartmp, 'outbox');
+  const legacyVartmpOutbox = join(legacySandboxVartmpDir(opts.sessionId), 'outbox');
   const legacyOutbox = join(sessionRoot, 'outbox');
   const projUpper = join(sessionRoot, 'proj-upper');
-  if (!existsSync(newOutbox) && !existsSync(legacyOutbox) && !existsSync(projUpper)) return null; // never sandboxed
-  const outbox = existsSync(newOutbox) ? newOutbox : (existsSync(legacyOutbox) ? legacyOutbox : newOutbox);
+  if (!existsSync(newOutbox) && !existsSync(legacyVartmpOutbox) && !existsSync(legacyOutbox) && !existsSync(projUpper)) return null; // never sandboxed
+  const outbox = existsSync(newOutbox) ? newOutbox : (existsSync(legacyVartmpOutbox) ? legacyVartmpOutbox : (existsSync(legacyOutbox) ? legacyOutbox : newOutbox));
   // Ensure the outbox exists (the watcher reads it); never (re)mount here.
   if (outbox === newOutbox) {
     if (!ensurePrivateDir(sandboxVartmpRoot()) || !ensurePrivateDir(vartmp) || !ensurePrivateDir(outbox)) return null;
+  } else if (outbox === legacyVartmpOutbox) {
+    if (!ensurePrivateDir(legacySandboxVartmpDir(opts.sessionId)) || !ensurePrivateDir(outbox)) return null;
   } else if (!ensurePrivateDir(outbox)) return null;
   const projMerged = join(sessionRoot, 'proj-merged');
   const homeMerged = join(sessionRoot, 'home-merged');
@@ -608,6 +639,7 @@ export function attachSandboxOutbox(opts: { sessionId: string; dataDir: string }
       unmountOverlay(homeMerged);
       try { rmSync(sessionRoot, { recursive: true, force: true }); } catch { /* */ }
       try { rmSync(vartmp, { recursive: true, force: true }); } catch { /* */ }
+      try { rmSync(legacySandboxVartmpDir(opts.sessionId), { recursive: true, force: true }); } catch { /* */ }
     },
   };
 }
@@ -620,6 +652,7 @@ function reclaimSandbox(dataDir: string, sid: string): void {
   unmountOverlay(join(sessionRoot, 'home-merged'));
   try { rmSync(sessionRoot, { recursive: true, force: true }); } catch { /* */ }
   try { rmSync(join(sandboxVartmpRoot(), sid), { recursive: true, force: true }); } catch { /* */ }
+  try { rmSync(legacySandboxVartmpDir(sid), { recursive: true, force: true }); } catch { /* */ }
 }
 
 /** Scan the process table for sandbox session-ids referenced by any running

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -30,6 +30,22 @@ import { spawn, spawnSync } from 'node:child_process';
  *  (overlayfs forbids upper/work inside lower). */
 const VARTMP_ROOT = '/var/tmp/botmux-sbx';
 
+/** Create a daemon-private directory and repair legacy/default mkdir modes.
+ *  Anything under /var/tmp is on a shared multi-user surface, while the outbox
+ *  carries in-flight Lark message bodies/attachments. Refuse to proceed unless
+ *  group/other bits are gone after chmod. */
+function ensurePrivateDir(dir: string): boolean {
+  try {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    chmodSync(dir, 0o700); // repair dirs created before this hardening or under a loose umask
+    const st = statSync(dir);
+    return st.isDirectory() && (st.mode & 0o077) === 0;
+  } catch (err) {
+    console.error(`[sandbox] failed to prepare private dir ${dir}: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
+}
+
 // ───────────────────────────── overlay primitives ────────────────────────────
 
 /**
@@ -419,6 +435,7 @@ export function prepareSandbox(opts: {
   const outbox = join(vartmp, 'outbox');
   const homeUpper = join(vartmp, 'home-upper');
   const homeWork = join(vartmp, 'home-work');
+  if (!ensurePrivateDir(VARTMP_ROOT) || !ensurePrivateDir(vartmp) || !ensurePrivateDir(outbox)) return null;
   for (const d of [outbox, shimBin, empties]) mkdirSync(d, { recursive: true });
 
   const home = resolveSandboxMountPath(homedir());
@@ -573,7 +590,9 @@ export function attachSandboxOutbox(opts: { sessionId: string; dataDir: string }
   if (!existsSync(newOutbox) && !existsSync(legacyOutbox) && !existsSync(projUpper)) return null; // never sandboxed
   const outbox = existsSync(newOutbox) ? newOutbox : (existsSync(legacyOutbox) ? legacyOutbox : newOutbox);
   // Ensure the outbox exists (the watcher reads it); never (re)mount here.
-  try { mkdirSync(outbox, { recursive: true }); } catch { /* */ }
+  if (outbox === newOutbox) {
+    if (!ensurePrivateDir(VARTMP_ROOT) || !ensurePrivateDir(vartmp) || !ensurePrivateDir(outbox)) return null;
+  } else if (!ensurePrivateDir(outbox)) return null;
   const projMerged = join(sessionRoot, 'proj-merged');
   const homeMerged = join(sessionRoot, 'home-merged');
   return {
@@ -786,7 +805,7 @@ export function startOutboxWatcher(outbox: string, baseEnv: NodeJS.ProcessEnv, s
 
   const finish = (id: string, reqPath: string, name: string, staged: string[], code: number, stdout: string, stderr: string) => {
     // 原子写：沙盒侧 CLI 在 existsSync 轮询这个 res.json，rename 保证它读到完整 JSON。
-    try { atomicWriteFileSync(join(outbox, `${id}.res.json`), JSON.stringify({ code, stdout, stderr })); } catch { /* */ }
+    try { atomicWriteFileSync(join(outbox, `${id}.res.json`), JSON.stringify({ code, stdout, stderr }), { mode: 0o600 }); } catch { /* */ }
     try { rmSync(reqPath, { force: true }); } catch { /* */ }
     for (const p of staged) { try { rmSync(p, { force: true }); } catch { /* */ } }
     inFlight.delete(name);
@@ -808,7 +827,7 @@ export function startOutboxWatcher(outbox: string, baseEnv: NodeJS.ProcessEnv, s
       const v = validateRelayRequest(req);
       if (!v.ok) { finish(id, reqPath, name, staged, 1, '', `relay rejected: ${v.error}`); continue; }
 
-      try { mkdirSync(staging, { recursive: true }); } catch { /* */ }
+      try { mkdirSync(staging, { recursive: true, mode: 0o700 }); chmodSync(staging, 0o700); } catch { /* */ }
       // Materialize content (TOCTOU-safe) into the private staging dir.
       const contentDest = join(staging, `${id}.content`);
       if (!materializeOutboxFile(outbox, v.value.contentName, contentDest)) {

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -27,8 +27,13 @@ import { fileURLToPath } from 'node:url';
 import { spawn, spawnSync } from 'node:child_process';
 
 /** Host root for the HOME overlay's upper/work — MUST be OUTSIDE the home lower
- *  (overlayfs forbids upper/work inside lower). */
-const VARTMP_ROOT = '/var/tmp/botmux-sbx';
+ *  (overlayfs forbids upper/work inside lower). Keep it per-uid: /var/tmp is a
+ *  shared multi-user surface, and a global 0700 root would let the first user
+ *  that starts sandbox block every other Unix user on the same machine. */
+export function sandboxVartmpRoot(): string {
+  const uid = process.getuid?.() ?? 0;
+  return `/var/tmp/botmux-sbx-${uid}`;
+}
 
 /** Create a daemon-private directory and repair legacy/default mkdir modes.
  *  Anything under /var/tmp is on a shared multi-user surface, while the outbox
@@ -340,7 +345,7 @@ export interface SandboxSpawn {
   outbox: string;
   /** Project overlay UPPER dir — THE LANDABLE CHANGESET (used by sandbox-land). */
   workDir: string;
-  /** HOME overlay UPPER dir (/var/tmp/botmux-sbx/<sid>/home-upper). The sandboxed
+  /** HOME overlay UPPER dir (/var/tmp/botmux-sbx-<uid>/<sid>/home-upper). The sandboxed
    *  CLI's $HOME writes — INCLUDING its session jsonl under CLAUDE_CONFIG_DIR —
    *  land here (invisible at the real path). The worker redirects its bridge/idle
    *  watch into this via sandboxedClaudeDataDir() so it sees the CLI's turns. */
@@ -364,7 +369,7 @@ export interface SandboxSpawn {
 export function sandboxedClaudeDataDir(sessionId: string, realDataDir: string): string {
   const raw = relative(homedir(), realDataDir);
   const rel = raw.startsWith('..') ? relative(resolveSandboxMountPath(homedir()), realDataDir) : raw;
-  return join(VARTMP_ROOT, sessionId, 'home-upper', rel);
+  return join(sandboxVartmpRoot(), sessionId, 'home-upper', rel);
 }
 
 /** Proxy env vars forwarded into the sandbox so the CLI reaches the API even on
@@ -379,7 +384,7 @@ const PROXY_ENV_KEYS = ['http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'
  * Layout under <dataDir>/sandboxes/<sessionId>/: shimbin, proj-upper (the
  * landable changeset), proj-work, proj-merged, home-merged. The HOME overlay's
  * upper/work and the daemon-mediated outbox live under
- * /var/tmp/botmux-sbx/<sessionId>/ because overlayfs forbids upper/work inside
+ * /var/tmp/botmux-sbx-<uid>/<sessionId>/ because overlayfs forbids upper/work inside
  * the lower (= the real home), and keeping the outbox outside HOME avoids a
  * nested bind under the HOME overlay on bwrap hosts that hang on that pattern.
  */
@@ -431,11 +436,11 @@ export function prepareSandbox(opts: {
   const projMerged = join(sessionRoot, 'proj-merged');
   const homeMerged = join(sessionRoot, 'home-merged');  // merged may live under sessionRoot
   // HOME overlay upper/work MUST be OUTSIDE the home lower (overlayfs constraint).
-  const vartmp = join(VARTMP_ROOT, opts.sessionId);
+  const vartmp = join(sandboxVartmpRoot(), opts.sessionId);
   const outbox = join(vartmp, 'outbox');
   const homeUpper = join(vartmp, 'home-upper');
   const homeWork = join(vartmp, 'home-work');
-  if (!ensurePrivateDir(VARTMP_ROOT) || !ensurePrivateDir(vartmp) || !ensurePrivateDir(outbox)) return null;
+  if (!ensurePrivateDir(sandboxVartmpRoot()) || !ensurePrivateDir(vartmp) || !ensurePrivateDir(outbox)) return null;
   for (const d of [outbox, shimBin, empties]) mkdirSync(d, { recursive: true });
 
   const home = resolveSandboxMountPath(homedir());
@@ -575,7 +580,7 @@ export function prepareSandbox(opts: {
  * the workDir (upper changeset for landing) and a cleanup that tears the residue
  * down at close/exit. Returns null if the session has no sandbox tree on disk
  * (never sandboxed). Linux-only, mirrors prepareSandbox's layout. New sessions
- * keep outbox under /var/tmp/botmux-sbx/<sid>/outbox; fall back to the legacy
+ * keep outbox under /var/tmp/botmux-sbx-<uid>/<sid>/outbox; fall back to the legacy
  * <dataDir>/sandboxes/<sid>/outbox for sessions that were already running
  * before the layout changed.
  */
@@ -583,7 +588,7 @@ export function attachSandboxOutbox(opts: { sessionId: string; dataDir: string }
   if (process.platform !== 'linux') return null;
   const dataDir = resolveSandboxMountPath(opts.dataDir);
   const sessionRoot = join(dataDir, 'sandboxes', opts.sessionId);
-  const vartmp = join(VARTMP_ROOT, opts.sessionId);
+  const vartmp = join(sandboxVartmpRoot(), opts.sessionId);
   const newOutbox = join(vartmp, 'outbox');
   const legacyOutbox = join(sessionRoot, 'outbox');
   const projUpper = join(sessionRoot, 'proj-upper');
@@ -591,7 +596,7 @@ export function attachSandboxOutbox(opts: { sessionId: string; dataDir: string }
   const outbox = existsSync(newOutbox) ? newOutbox : (existsSync(legacyOutbox) ? legacyOutbox : newOutbox);
   // Ensure the outbox exists (the watcher reads it); never (re)mount here.
   if (outbox === newOutbox) {
-    if (!ensurePrivateDir(VARTMP_ROOT) || !ensurePrivateDir(vartmp) || !ensurePrivateDir(outbox)) return null;
+    if (!ensurePrivateDir(sandboxVartmpRoot()) || !ensurePrivateDir(vartmp) || !ensurePrivateDir(outbox)) return null;
   } else if (!ensurePrivateDir(outbox)) return null;
   const projMerged = join(sessionRoot, 'proj-merged');
   const homeMerged = join(sessionRoot, 'home-merged');
@@ -614,19 +619,19 @@ function reclaimSandbox(dataDir: string, sid: string): void {
   unmountOverlay(join(sessionRoot, 'proj-merged'));
   unmountOverlay(join(sessionRoot, 'home-merged'));
   try { rmSync(sessionRoot, { recursive: true, force: true }); } catch { /* */ }
-  try { rmSync(join(VARTMP_ROOT, sid), { recursive: true, force: true }); } catch { /* */ }
+  try { rmSync(join(sandboxVartmpRoot(), sid), { recursive: true, force: true }); } catch { /* */ }
 }
 
 /** Scan the process table for sandbox session-ids referenced by any running
  *  process's argv. A live bwrap's bind/overlay paths contain `sandboxes/<sid>`
- *  and `botmux-sbx/<sid>`, so this physically detects which sandbox dirs are
+ *  and `botmux-sbx-<uid>/<sid>`, so this physically detects which sandbox dirs are
  *  still in use — by overlay sessions AND old clone-model sessions alike. Used as
  *  a hard guard so the sweep never deletes a dir out from under a live CLI. */
 function liveSandboxSids(): Set<string> {
   const live = new Set<string>();
   let pids: string[];
   try { pids = readdirSync('/proc'); } catch { return live; }
-  const re = /(?:sandboxes|botmux-sbx)\/([^/\0]+)/g;
+  const re = /(?:sandboxes|botmux-sbx(?:-[^/\0]+)?)\/([^/\0]+)/g;
   for (const pid of pids) {
     if (!/^\d+$/.test(pid)) continue;
     let cmd: string;

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -360,10 +360,12 @@ const PROXY_ENV_KEYS = ['http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'
  * is off / unsupported / a required overlay mount fails (fail-safe = the worker
  * treats null as a hard error and does NOT silently run unsandboxed).
  *
- * Layout under <dataDir>/sandboxes/<sessionId>/: outbox, shimbin, proj-upper
- * (the landable changeset), proj-work, proj-merged, home-merged. The HOME
- * overlay's upper/work live under /var/tmp/botmux-sbx/<sessionId>/ because
- * overlayfs forbids upper/work inside the lower (= the real home).
+ * Layout under <dataDir>/sandboxes/<sessionId>/: shimbin, proj-upper (the
+ * landable changeset), proj-work, proj-merged, home-merged. The HOME overlay's
+ * upper/work and the daemon-mediated outbox live under
+ * /var/tmp/botmux-sbx/<sessionId>/ because overlayfs forbids upper/work inside
+ * the lower (= the real home), and keeping the outbox outside HOME avoids a
+ * nested bind under the HOME overlay on bwrap hosts that hang on that pattern.
  */
 export function prepareSandbox(opts: {
   /** Whether the sandbox is on for THIS session (per-bot BotConfig.sandbox OR
@@ -406,7 +408,6 @@ export function prepareSandbox(opts: {
 
   const dataDir = resolveSandboxMountPath(opts.dataDir);
   const sessionRoot = join(dataDir, 'sandboxes', opts.sessionId);
-  const outbox = join(sessionRoot, 'outbox');
   const shimBin = join(sessionRoot, 'shimbin');
   const empties = join(sessionRoot, 'empties');
   const projUpper = join(sessionRoot, 'proj-upper');   // THE LANDABLE CHANGESET
@@ -415,6 +416,7 @@ export function prepareSandbox(opts: {
   const homeMerged = join(sessionRoot, 'home-merged');  // merged may live under sessionRoot
   // HOME overlay upper/work MUST be OUTSIDE the home lower (overlayfs constraint).
   const vartmp = join(VARTMP_ROOT, opts.sessionId);
+  const outbox = join(vartmp, 'outbox');
   const homeUpper = join(vartmp, 'home-upper');
   const homeWork = join(vartmp, 'home-work');
   for (const d of [outbox, shimBin, empties]) mkdirSync(d, { recursive: true });
@@ -555,20 +557,25 @@ export function prepareSandbox(opts: {
  * path back so the watcher can keep servicing the live CLI's `botmux send`, plus
  * the workDir (upper changeset for landing) and a cleanup that tears the residue
  * down at close/exit. Returns null if the session has no sandbox tree on disk
- * (never sandboxed). Linux-only, mirrors prepareSandbox's layout.
+ * (never sandboxed). Linux-only, mirrors prepareSandbox's layout. New sessions
+ * keep outbox under /var/tmp/botmux-sbx/<sid>/outbox; fall back to the legacy
+ * <dataDir>/sandboxes/<sid>/outbox for sessions that were already running
+ * before the layout changed.
  */
 export function attachSandboxOutbox(opts: { sessionId: string; dataDir: string }): { outbox: string; workDir: string; cleanup: () => void } | null {
   if (process.platform !== 'linux') return null;
   const dataDir = resolveSandboxMountPath(opts.dataDir);
   const sessionRoot = join(dataDir, 'sandboxes', opts.sessionId);
-  const outbox = join(sessionRoot, 'outbox');
+  const vartmp = join(VARTMP_ROOT, opts.sessionId);
+  const newOutbox = join(vartmp, 'outbox');
+  const legacyOutbox = join(sessionRoot, 'outbox');
   const projUpper = join(sessionRoot, 'proj-upper');
-  if (!existsSync(outbox) && !existsSync(projUpper)) return null; // never sandboxed
+  if (!existsSync(newOutbox) && !existsSync(legacyOutbox) && !existsSync(projUpper)) return null; // never sandboxed
+  const outbox = existsSync(newOutbox) ? newOutbox : (existsSync(legacyOutbox) ? legacyOutbox : newOutbox);
   // Ensure the outbox exists (the watcher reads it); never (re)mount here.
   try { mkdirSync(outbox, { recursive: true }); } catch { /* */ }
   const projMerged = join(sessionRoot, 'proj-merged');
   const homeMerged = join(sessionRoot, 'home-merged');
-  const vartmp = join(VARTMP_ROOT, opts.sessionId);
   return {
     outbox,
     workDir: projUpper,
@@ -639,9 +646,9 @@ export function sweepOrphanSandboxes(dataDir: string, activeSessionIds: Set<stri
   let sids: string[] = [];
   try { sids = readdirSync(root); } catch { return; } // no sandboxes dir yet
   // Grace before reclaiming an ACTIVE-but-unmounted sandbox: a worker that just
-  // (re)spawned creates the outbox/shimbin dirs a few syscalls BEFORE it mounts
-  // the overlay. Without this, a sweep firing in that tiny window would nuke an
-  // in-progress session's outbox. Non-active orphans are reclaimed immediately
+  // (re)spawned creates the sandbox dirs a few syscalls BEFORE it mounts the
+  // overlay. Without this, a sweep firing in that tiny window would nuke an
+  // in-progress session's shimbin/project tree. Non-active orphans are reclaimed immediately
   // (no live worker can be mid-spawn for a session that isn't active).
   const ACTIVE_DEAD_GRACE_MS = 60_000;
   const now = Date.now();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4415,14 +4415,14 @@ async function relaySend(rest: string[], relayDir: string): Promise<void> {
   // sandbox: the sandbox can't make the host read an arbitrary path.
   const contentBase = `${id}.content`;
   const cfile = join(relayDir, contentBase);
-  writeFileSync(cfile, content);
+  writeFileSync(cfile, content, { mode: 0o600 });
 
   // Copy any --image/--file attachment into the outbox; carry only basenames.
   const attachments: string[] = [];
   for (const p of argValues(rest, '--image', '--images', '--file', '--files')) {
     if (!p || !existsSync(p)) continue;
     const base = `${id}-${randomBytes(4).toString('hex')}-${basename(p)}`;
-    try { writeFileSync(join(relayDir, base), readFileSync(p)); attachments.push(base); } catch { /* skip unreadable */ }
+    try { writeFileSync(join(relayDir, base), readFileSync(p), { mode: 0o600 }); attachments.push(base); } catch { /* skip unreadable */ }
   }
 
   // Forward only presentation flags (must match the watcher's allowlist); path,
@@ -4439,7 +4439,7 @@ async function relaySend(rest: string[], relayDir: string): Promise<void> {
   }
   // 原子写：req.json 是 host watcher 的触发文件，rename 让它「完整出现」，
   // watcher 永远不会读到半截 JSON（tmp 后缀不匹配 .req.json 过滤）。
-  atomicWriteFileSync(join(relayDir, `${id}.req.json`), JSON.stringify({ contentFile: contentBase, attachments, flags }));
+  atomicWriteFileSync(join(relayDir, `${id}.req.json`), JSON.stringify({ contentFile: contentBase, attachments, flags }), { mode: 0o600 });
 
   const resPath = join(relayDir, `${id}.res.json`);
   const deadlineMs = Date.now() + 120_000;

--- a/test/cli-send-hook-context.test.ts
+++ b/test/cli-send-hook-context.test.ts
@@ -13,3 +13,15 @@ describe('cmdSend hook context wiring', () => {
     expect(cliSource).toMatch(/replyMessage\(appId,\s*sendTarget\.rootMessageId,\s*content,\s*msgType,\s*true,\s*undefined,\s*hookContext\)/);
   });
 });
+
+describe('relaySend outbox privacy', () => {
+  it('writes relay payload files with private permissions', () => {
+    const relayIdx = cliSource.indexOf('async function relaySend(');
+    expect(relayIdx).toBeGreaterThanOrEqual(0);
+    const cmdSendIdx = cliSource.indexOf('async function cmdSend(');
+    const region = cliSource.slice(relayIdx, cmdSendIdx);
+    expect(region).toContain("writeFileSync(cfile, content, { mode: 0o600 })");
+    expect(region).toContain("writeFileSync(join(relayDir, base), readFileSync(p), { mode: 0o600 })");
+    expect(region).toContain("atomicWriteFileSync(join(relayDir, `${id}.req.json`), JSON.stringify({ contentFile: contentBase, attachments, flags }), { mode: 0o600 })");
+  });
+});

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -11,7 +11,8 @@ import { describe, it, expect } from 'vitest';
 import { tmpdir, homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { mkdtempSync, existsSync, writeFileSync, readFileSync, symlinkSync, rmSync, mkdirSync, realpathSync, statSync } from 'node:fs';
-import { buildSandboxArgs, reexposeRunBinArgs, validateRelayRequest, materializeOutboxFile, prepareSandbox, attachSandboxOutbox, resolveSandboxMountPath, sandboxedClaudeDataDir, sandboxVartmpRoot, resolveUserReadonlyRoots, type SandboxPlan } from '../src/adapters/backend/sandbox.js';
+import { spawnSync } from 'node:child_process';
+import { buildSandboxArgs, reexposeRunBinArgs, validateRelayRequest, materializeOutboxFile, readRelayRequestFile, startOutboxWatcher, prepareSandbox, attachSandboxOutbox, resolveSandboxMountPath, sandboxedClaudeDataDir, sandboxVartmpRoot, resolveUserReadonlyRoots, type SandboxPlan } from '../src/adapters/backend/sandbox.js';
 import { createCodexAppAdapter } from '../src/adapters/cli/codex-app.js';
 import { computeSandboxDiff, applySandboxDiff, upperDir } from '../src/services/sandbox-land.js';
 
@@ -363,6 +364,82 @@ describe('materializeOutboxFile (TOCTOU)', () => {
     expect(r).toBe(false);            // rejected (not a regular file)
     expect(existsSync(dest)).toBe(false);
     expect(elapsed).toBeLessThan(2000); // returned immediately, did NOT block
+  });
+});
+
+describe('readRelayRequestFile (TOCTOU)', () => {
+  it('reads a small regular request file', () => {
+    const outbox = tmp();
+    const req = join(outbox, 'x.req.json');
+    writeFileSync(req, JSON.stringify({ contentFile: 'c.content', flags: [] }));
+    try {
+      expect(readRelayRequestFile(req)).toContain('c.content');
+    } finally {
+      rmSync(outbox, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses a symlink request file', () => {
+    const outbox = tmp(); const secretDir = tmp();
+    const secret = join(secretDir, 'secret.req.json');
+    writeFileSync(secret, JSON.stringify({ contentFile: 'secret.content' }));
+    symlinkSync(secret, join(outbox, 'x.req.json'));
+    try {
+      expect(readRelayRequestFile(join(outbox, 'x.req.json'))).toBeNull();
+    } finally {
+      rmSync(outbox, { recursive: true, force: true });
+      rmSync(secretDir, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform !== 'linux')('refuses a FIFO request file without blocking', () => {
+    const outbox = tmp();
+    const fifo = join(outbox, 'x.req.json');
+    spawnSync('mkfifo', [fifo]);
+    const start = Date.now();
+    try {
+      expect(readRelayRequestFile(fifo)).toBeNull();
+      expect(Date.now() - start).toBeLessThan(2000);
+    } finally {
+      rmSync(outbox, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses an oversized request file', () => {
+    const outbox = tmp();
+    const req = join(outbox, 'x.req.json');
+    writeFileSync(req, 'x'.repeat(64 * 1024 + 1));
+    try {
+      expect(readRelayRequestFile(req)).toBeNull();
+    } finally {
+      rmSync(outbox, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('startOutboxWatcher request hardening', () => {
+  it.skipIf(process.platform !== 'linux')('rejects a FIFO .req.json without blocking the worker tick', async () => {
+    const root = tmp();
+    const outbox = join(root, 'outbox');
+    mkdirSync(outbox, { recursive: true });
+    const req = join(outbox, 'bad.req.json');
+    spawnSync('mkfifo', [req]);
+
+    const stop = startOutboxWatcher(outbox, process.env, 'sid-hardening');
+    try {
+      const deadline = Date.now() + 3000;
+      let res: string | null = null;
+      while (Date.now() < deadline) {
+        const p = join(outbox, 'bad.res.json');
+        if (existsSync(p)) { res = readFileSync(p, 'utf8'); break; }
+        await new Promise(r => setTimeout(r, 50));
+      }
+      expect(res).not.toBeNull();
+      expect(JSON.parse(res!).stderr).toContain('relay rejected: request not a regular file or too large');
+    } finally {
+      stop();
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -9,7 +9,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { tmpdir, homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { mkdtempSync, existsSync, writeFileSync, readFileSync, symlinkSync, rmSync, mkdirSync, realpathSync, statSync } from 'node:fs';
 import { buildSandboxArgs, reexposeRunBinArgs, validateRelayRequest, materializeOutboxFile, prepareSandbox, attachSandboxOutbox, resolveSandboxMountPath, sandboxedClaudeDataDir, sandboxVartmpRoot, resolveUserReadonlyRoots, type SandboxPlan } from '../src/adapters/backend/sandbox.js';
 import { createCodexAppAdapter } from '../src/adapters/cli/codex-app.js';
@@ -176,15 +176,37 @@ describe('sandboxedClaudeDataDir (symlink HOME redirect)', () => {
     symlinkSync(realHome, linkHome);
     const prevHome = process.env.HOME;
     process.env.HOME = linkHome; // os.homedir() reads $HOME per call on Linux
+    const sid = 'sid-x-' + Math.random().toString(36).slice(2);
     try {
+      rmSync(join('/var/tmp/botmux-sbx', sid), { recursive: true, force: true });
+      rmSync(join(sandboxVartmpRoot(), sid), { recursive: true, force: true });
       const symlinkForm = join(linkHome, '.claude');
       const canonicalForm = join(realpathSync(linkHome), '.claude');
-      const expected = join(sandboxVartmpRoot(), 'sid-x', 'home-upper', '.claude');
-      expect(sandboxedClaudeDataDir('sid-x', symlinkForm)).toBe(expected);
-      expect(sandboxedClaudeDataDir('sid-x', canonicalForm)).toBe(expected);
+      const expected = join(sandboxVartmpRoot(), sid, 'home-upper', '.claude');
+      expect(sandboxedClaudeDataDir(sid, symlinkForm)).toBe(expected);
+      expect(sandboxedClaudeDataDir(sid, canonicalForm)).toBe(expected);
     } finally {
       if (prevHome !== undefined) process.env.HOME = prevHome;
+      rmSync(join('/var/tmp/botmux-sbx', sid), { recursive: true, force: true });
+      rmSync(join(sandboxVartmpRoot(), sid), { recursive: true, force: true });
       rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform !== 'linux')('falls back to legacy /var/tmp home-upper for upgraded persistent sessions', () => {
+    const sid = 'legacy-home-upper-' + Math.random().toString(36).slice(2);
+    const legacyHomeUpper = join('/var/tmp/botmux-sbx', sid, 'home-upper');
+    const nextHomeUpper = join(sandboxVartmpRoot(), sid, 'home-upper');
+    const dataDir = join(homedir(), '.claude');
+    try {
+      rmSync(join('/var/tmp/botmux-sbx', sid), { recursive: true, force: true });
+      rmSync(join(sandboxVartmpRoot(), sid), { recursive: true, force: true });
+      mkdirSync(legacyHomeUpper, { recursive: true });
+      expect(existsSync(nextHomeUpper)).toBe(false);
+      expect(sandboxedClaudeDataDir(sid, dataDir)).toBe(join(legacyHomeUpper, '.claude'));
+    } finally {
+      rmSync(join('/var/tmp/botmux-sbx', sid), { recursive: true, force: true });
+      rmSync(join(sandboxVartmpRoot(), sid), { recursive: true, force: true });
     }
   });
 });
@@ -402,6 +424,57 @@ describe.skipIf(process.platform !== 'linux')('sandbox outbox layout', () => {
       expect(statSync(legacyOutbox).mode & 0o077).toBe(0);
     } finally {
       r?.cleanup();
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to legacy /var/tmp outbox for upgraded persistent sessions', () => {
+    const dataDir = tmp();
+    const sid = 'outbox-legacy-vartmp-' + Math.random().toString(36).slice(2);
+    const sessionRoot = join(resolveSandboxMountPath(dataDir), 'sandboxes', sid);
+    const projUpper = join(sessionRoot, 'proj-upper');
+    const legacyVartmp = join('/var/tmp/botmux-sbx', sid);
+    const legacyOutbox = join(legacyVartmp, 'outbox');
+    const nextVartmp = join(sandboxVartmpRoot(), sid);
+    mkdirSync(projUpper, { recursive: true });
+    rmSync(legacyVartmp, { recursive: true, force: true });
+    rmSync(nextVartmp, { recursive: true, force: true });
+    mkdirSync(legacyOutbox, { recursive: true });
+
+    const r = attachSandboxOutbox({ sessionId: sid, dataDir });
+    try {
+      expect(r).not.toBeNull();
+      expect(r!.outbox).toBe(legacyOutbox);
+      expect(r!.workDir).toBe(projUpper);
+      expect(statSync(legacyVartmp).mode & 0o077).toBe(0);
+      expect(statSync(legacyOutbox).mode & 0o077).toBe(0);
+    } finally {
+      r?.cleanup();
+      expect(existsSync(legacyVartmp)).toBe(false);
+      expect(existsSync(nextVartmp)).toBe(false);
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an outbox symlink on the shared /var/tmp surface', () => {
+    const dataDir = tmp();
+    const sid = 'outbox-symlink-' + Math.random().toString(36).slice(2);
+    const sessionRoot = join(resolveSandboxMountPath(dataDir), 'sandboxes', sid);
+    const projUpper = join(sessionRoot, 'proj-upper');
+    const legacyVartmp = join('/var/tmp/botmux-sbx', sid);
+    const legacyOutbox = join(legacyVartmp, 'outbox');
+    const target = join(tmp(), 'attacker-outbox');
+    mkdirSync(projUpper, { recursive: true });
+    rmSync(legacyVartmp, { recursive: true, force: true });
+    mkdirSync(legacyVartmp, { recursive: true });
+    mkdirSync(target, { recursive: true });
+    symlinkSync(target, legacyOutbox);
+
+    try {
+      expect(attachSandboxOutbox({ sessionId: sid, dataDir })).toBeNull();
+    } finally {
+      rmSync(legacyVartmp, { recursive: true, force: true });
+      rmSync(dirname(target), { recursive: true, force: true });
       rmSync(dataDir, { recursive: true, force: true });
     }
   });

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect } from 'vitest';
 import { tmpdir, homedir } from 'node:os';
 import { join } from 'node:path';
-import { mkdtempSync, existsSync, writeFileSync, readFileSync, symlinkSync, rmSync, mkdirSync, realpathSync } from 'node:fs';
+import { mkdtempSync, existsSync, writeFileSync, readFileSync, symlinkSync, rmSync, mkdirSync, realpathSync, statSync } from 'node:fs';
 import { buildSandboxArgs, reexposeRunBinArgs, validateRelayRequest, materializeOutboxFile, prepareSandbox, attachSandboxOutbox, resolveSandboxMountPath, sandboxedClaudeDataDir, resolveUserReadonlyRoots, type SandboxPlan } from '../src/adapters/backend/sandbox.js';
 import { createCodexAppAdapter } from '../src/adapters/cli/codex-app.js';
 import { computeSandboxDiff, applySandboxDiff, upperDir } from '../src/services/sandbox-land.js';
@@ -371,6 +371,9 @@ describe.skipIf(process.platform !== 'linux')('sandbox outbox layout', () => {
       expect(r!.outbox).toBe(newOutbox);
       expect(r!.outbox.startsWith(sessionRoot)).toBe(false);
       expect(r!.workDir).toBe(projUpper);
+      expect(statSync(join('/var/tmp/botmux-sbx')).mode & 0o077).toBe(0);
+      expect(statSync(join('/var/tmp/botmux-sbx', sid)).mode & 0o077).toBe(0);
+      expect(statSync(newOutbox).mode & 0o077).toBe(0);
     } finally {
       r?.cleanup();
       rmSync(dataDir, { recursive: true, force: true });
@@ -391,6 +394,7 @@ describe.skipIf(process.platform !== 'linux')('sandbox outbox layout', () => {
       expect(r).not.toBeNull();
       expect(r!.outbox).toBe(legacyOutbox);
       expect(r!.workDir).toBe(projUpper);
+      expect(statSync(legacyOutbox).mode & 0o077).toBe(0);
     } finally {
       r?.cleanup();
       rmSync(dataDir, { recursive: true, force: true });
@@ -415,6 +419,9 @@ describe.skipIf(process.platform !== 'linux')('sandbox outbox layout', () => {
       expect(r.env.BOTMUX_SEND_RELAY).toBe(expected);
       expect(r.outbox.startsWith(sessionRoot)).toBe(false);
       expect(r.args.some((x, i) => x === '--bind' && r!.args[i + 1] === expected && r!.args[i + 2] === expected)).toBe(true);
+      expect(statSync(join('/var/tmp/botmux-sbx')).mode & 0o077).toBe(0);
+      expect(statSync(join('/var/tmp/botmux-sbx', sid)).mode & 0o077).toBe(0);
+      expect(statSync(expected).mode & 0o077).toBe(0);
     } finally {
       r?.cleanup();
       rmSync(dataDir, { recursive: true, force: true });

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect } from 'vitest';
 import { tmpdir, homedir } from 'node:os';
 import { join } from 'node:path';
 import { mkdtempSync, existsSync, writeFileSync, readFileSync, symlinkSync, rmSync, mkdirSync, realpathSync, statSync } from 'node:fs';
-import { buildSandboxArgs, reexposeRunBinArgs, validateRelayRequest, materializeOutboxFile, prepareSandbox, attachSandboxOutbox, resolveSandboxMountPath, sandboxedClaudeDataDir, resolveUserReadonlyRoots, type SandboxPlan } from '../src/adapters/backend/sandbox.js';
+import { buildSandboxArgs, reexposeRunBinArgs, validateRelayRequest, materializeOutboxFile, prepareSandbox, attachSandboxOutbox, resolveSandboxMountPath, sandboxedClaudeDataDir, sandboxVartmpRoot, resolveUserReadonlyRoots, type SandboxPlan } from '../src/adapters/backend/sandbox.js';
 import { createCodexAppAdapter } from '../src/adapters/cli/codex-app.js';
 import { computeSandboxDiff, applySandboxDiff, upperDir } from '../src/services/sandbox-land.js';
 
@@ -179,7 +179,7 @@ describe('sandboxedClaudeDataDir (symlink HOME redirect)', () => {
     try {
       const symlinkForm = join(linkHome, '.claude');
       const canonicalForm = join(realpathSync(linkHome), '.claude');
-      const expected = join('/var/tmp/botmux-sbx', 'sid-x', 'home-upper', '.claude');
+      const expected = join(sandboxVartmpRoot(), 'sid-x', 'home-upper', '.claude');
       expect(sandboxedClaudeDataDir('sid-x', symlinkForm)).toBe(expected);
       expect(sandboxedClaudeDataDir('sid-x', canonicalForm)).toBe(expected);
     } finally {
@@ -356,12 +356,17 @@ describe('prepareSandbox enabled gate', () => {
 });
 
 describe.skipIf(process.platform !== 'linux')('sandbox outbox layout', () => {
+  it('uses a per-uid /var/tmp root so users do not contend for one global 0700 dir', () => {
+    const uid = process.getuid?.() ?? 0;
+    expect(sandboxVartmpRoot()).toBe(`/var/tmp/botmux-sbx-${uid}`);
+  });
+
   it('reattaches to the new /var/tmp outbox outside dataDir', () => {
     const dataDir = tmp();
     const sid = 'outbox-new-' + Math.random().toString(36).slice(2);
     const sessionRoot = join(resolveSandboxMountPath(dataDir), 'sandboxes', sid);
     const projUpper = join(sessionRoot, 'proj-upper');
-    const newOutbox = join('/var/tmp/botmux-sbx', sid, 'outbox');
+    const newOutbox = join(sandboxVartmpRoot(), sid, 'outbox');
     mkdirSync(projUpper, { recursive: true });
     mkdirSync(newOutbox, { recursive: true });
 
@@ -371,8 +376,8 @@ describe.skipIf(process.platform !== 'linux')('sandbox outbox layout', () => {
       expect(r!.outbox).toBe(newOutbox);
       expect(r!.outbox.startsWith(sessionRoot)).toBe(false);
       expect(r!.workDir).toBe(projUpper);
-      expect(statSync(join('/var/tmp/botmux-sbx')).mode & 0o077).toBe(0);
-      expect(statSync(join('/var/tmp/botmux-sbx', sid)).mode & 0o077).toBe(0);
+      expect(statSync(sandboxVartmpRoot()).mode & 0o077).toBe(0);
+      expect(statSync(join(sandboxVartmpRoot(), sid)).mode & 0o077).toBe(0);
       expect(statSync(newOutbox).mode & 0o077).toBe(0);
     } finally {
       r?.cleanup();
@@ -413,14 +418,14 @@ describe.skipIf(process.platform !== 'linux')('sandbox outbox layout', () => {
         dataDir, cliBin: '/bin/true', cliArgs: [],
       });
       if (r === null) return; // overlay mount unavailable in this env — skip assertions
-      const expected = join('/var/tmp/botmux-sbx', sid, 'outbox');
+      const expected = join(sandboxVartmpRoot(), sid, 'outbox');
       const sessionRoot = join(resolveSandboxMountPath(dataDir), 'sandboxes', sid);
       expect(r.outbox).toBe(expected);
       expect(r.env.BOTMUX_SEND_RELAY).toBe(expected);
       expect(r.outbox.startsWith(sessionRoot)).toBe(false);
       expect(r.args.some((x, i) => x === '--bind' && r!.args[i + 1] === expected && r!.args[i + 2] === expected)).toBe(true);
-      expect(statSync(join('/var/tmp/botmux-sbx')).mode & 0o077).toBe(0);
-      expect(statSync(join('/var/tmp/botmux-sbx', sid)).mode & 0o077).toBe(0);
+      expect(statSync(sandboxVartmpRoot()).mode & 0o077).toBe(0);
+      expect(statSync(join(sandboxVartmpRoot(), sid)).mode & 0o077).toBe(0);
       expect(statSync(expected).mode & 0o077).toBe(0);
     } finally {
       r?.cleanup();

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect } from 'vitest';
 import { tmpdir, homedir } from 'node:os';
 import { join } from 'node:path';
 import { mkdtempSync, existsSync, writeFileSync, readFileSync, symlinkSync, rmSync, mkdirSync, realpathSync } from 'node:fs';
-import { buildSandboxArgs, reexposeRunBinArgs, validateRelayRequest, materializeOutboxFile, prepareSandbox, resolveSandboxMountPath, sandboxedClaudeDataDir, resolveUserReadonlyRoots, type SandboxPlan } from '../src/adapters/backend/sandbox.js';
+import { buildSandboxArgs, reexposeRunBinArgs, validateRelayRequest, materializeOutboxFile, prepareSandbox, attachSandboxOutbox, resolveSandboxMountPath, sandboxedClaudeDataDir, resolveUserReadonlyRoots, type SandboxPlan } from '../src/adapters/backend/sandbox.js';
 import { createCodexAppAdapter } from '../src/adapters/cli/codex-app.js';
 import { computeSandboxDiff, applySandboxDiff, upperDir } from '../src/services/sandbox-land.js';
 
@@ -352,6 +352,74 @@ describe('prepareSandbox enabled gate', () => {
       dataDir: tmp(), cliBin: '/bin/true', cliArgs: [],
     });
     expect(r).toBeNull();
+  });
+});
+
+describe.skipIf(process.platform !== 'linux')('sandbox outbox layout', () => {
+  it('reattaches to the new /var/tmp outbox outside dataDir', () => {
+    const dataDir = tmp();
+    const sid = 'outbox-new-' + Math.random().toString(36).slice(2);
+    const sessionRoot = join(resolveSandboxMountPath(dataDir), 'sandboxes', sid);
+    const projUpper = join(sessionRoot, 'proj-upper');
+    const newOutbox = join('/var/tmp/botmux-sbx', sid, 'outbox');
+    mkdirSync(projUpper, { recursive: true });
+    mkdirSync(newOutbox, { recursive: true });
+
+    const r = attachSandboxOutbox({ sessionId: sid, dataDir });
+    try {
+      expect(r).not.toBeNull();
+      expect(r!.outbox).toBe(newOutbox);
+      expect(r!.outbox.startsWith(sessionRoot)).toBe(false);
+      expect(r!.workDir).toBe(projUpper);
+    } finally {
+      r?.cleanup();
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to legacy dataDir outbox for already-running sessions', () => {
+    const dataDir = tmp();
+    const sid = 'outbox-legacy-' + Math.random().toString(36).slice(2);
+    const sessionRoot = join(resolveSandboxMountPath(dataDir), 'sandboxes', sid);
+    const projUpper = join(sessionRoot, 'proj-upper');
+    const legacyOutbox = join(sessionRoot, 'outbox');
+    mkdirSync(projUpper, { recursive: true });
+    mkdirSync(legacyOutbox, { recursive: true });
+
+    const r = attachSandboxOutbox({ sessionId: sid, dataDir });
+    try {
+      expect(r).not.toBeNull();
+      expect(r!.outbox).toBe(legacyOutbox);
+      expect(r!.workDir).toBe(projUpper);
+    } finally {
+      r?.cleanup();
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it('prepareSandbox exposes BOTMUX_SEND_RELAY from /var/tmp when mounts are available', () => {
+    const src = tmp();
+    writeFileSync(join(src, 'file.txt'), 'x');
+    const dataDir = tmp();
+    const sid = 'outbox-prepare-' + Math.random().toString(36).slice(2);
+    let r: ReturnType<typeof prepareSandbox> = null;
+    try {
+      r = prepareSandbox({
+        enabled: true, cliId: 'codex', sessionId: sid, sourceWorkingDir: src,
+        dataDir, cliBin: '/bin/true', cliArgs: [],
+      });
+      if (r === null) return; // overlay mount unavailable in this env — skip assertions
+      const expected = join('/var/tmp/botmux-sbx', sid, 'outbox');
+      const sessionRoot = join(resolveSandboxMountPath(dataDir), 'sandboxes', sid);
+      expect(r.outbox).toBe(expected);
+      expect(r.env.BOTMUX_SEND_RELAY).toBe(expected);
+      expect(r.outbox.startsWith(sessionRoot)).toBe(false);
+      expect(r.args.some((x, i) => x === '--bind' && r!.args[i + 1] === expected && r!.args[i + 2] === expected)).toBe(true);
+    } finally {
+      r?.cleanup();
+      rmSync(dataDir, { recursive: true, force: true });
+      rmSync(src, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## 改了什么

- 将 sandbox relay outbox 从 `<dataDir>/sandboxes/<sid>/outbox` 移到 `/var/tmp/botmux-sbx-<uid>/<sid>/outbox`。
- `prepareSandbox()` 中 `BOTMUX_SEND_RELAY` 和 bwrap outbox bind 都使用新路径。
- `/var/tmp` 下的 sandbox root 改为按 Unix uid 隔离，避免共享 Linux 机器上第一个用户创建全局 `0700` 目录后阻塞其他用户。
- `/var/tmp/botmux-sbx-<uid>`、`<sid>`、`outbox` 创建/reattach 时显式收紧到 `0700`；relay 内容、附件、视频、视频封面、请求、响应文件显式写成 `0600`。
- `ensurePrivateDir()` 加固为 fail-closed：拒绝 symlink / 非目录，校验 owner 是当前 daemon uid，再收紧并检查 mode。
- `.req.json` relay 请求文件改为安全读取：`O_NOFOLLOW | O_NONBLOCK` 打开，`fstat().isFile()` 校验 regular file，64KB 上限读取后再 `JSON.parse`，避免 FIFO/symlink/special file/超大文件卡住 worker 或越界读取。
- 兼容最新 master 的视频预览发送能力：sandbox relay 会透传 `videos` / `videoCovers`，并保持 master 的 `--videos` / `--video-covers` 语义，同时对这些 outbox 文件应用 `0600` 权限硬化。
- `attachSandboxOutbox()` 优先 reattach 新 outbox，并兼容 fallback 到旧的 `/var/tmp/botmux-sbx/<sid>/outbox` 和 `<dataDir>/sandboxes/<sid>/outbox`，避免升级时已有 sandbox session 失联。
- `sandboxedClaudeDataDir()` 对升级前已在运行的 persistent sandbox 增加 legacy HOME upper fallback：当旧 `/var/tmp/botmux-sbx/<sid>/home-upper` 存在且新路径不存在时，Claude bridge 继续指向旧 upper。
- cleanup / reclaim 同时 best-effort 删除新旧 vartmp sid 目录，避免旧 `/var/tmp/botmux-sbx/<sid>` residue 残留。
- 更新 `docs/file-sandbox.md`：同步 overlay 模型、`/var/tmp/botmux-sbx-<uid>/<sid>/outbox`、权限策略、legacy fallback 规则，并修正凭据说明：relay 不注入发送凭据；磁盘上的 botmux 配置/密钥如需隐藏需配置 `sandboxHidePaths` / read isolation。
- 增加单测覆盖 per-uid vartmp root、新 outbox 路径、legacy vartmp/dataDir fallback、legacy HOME upper bridge fallback、目录 mode、symlink 拒绝、`.req.json` FIFO/symlink/超限拒绝、watcher 对非法 request 写 rejected res、`BOTMUX_SEND_RELAY`/bwrap bind 路径、relay payload 文件 mode，以及视频/视频封面 relay 校验。

## 为什么

在部分 DevBox 上，sandbox 当前布局会先把整个 HOME 做 overlay 后挂回 HOME，再把 outbox bind 到 HOME 内部：

```text
home-merged -> /data00/home/<user>
<dataDir>/sandboxes/<sid>/outbox -> /data00/home/<user>/.botmux/data/sandboxes/<sid>/outbox
```

当 `<dataDir>` 位于 HOME 下时，这会形成 “HOME overlay 内部再 bind 子目录” 的嵌套挂载组合。实测该组合会导致 `bwrap` 卡在挂载阶段，表现为进程树只有 `bwrap -> bwrap`，没有真正 exec 到 Traex/node；将最终命令替换成 `/bin/true` 也仍然超时。

把 outbox 放到 `/var/tmp/botmux-sbx-<uid>/<sid>/outbox` 后，它不再位于 HOME overlay 内部，可以避免该嵌套 bind 卡死。由于 `/var/tmp` 是共享多用户路径，本 PR 同时做多层处理：root 按 uid 拆分，避免多用户争抢一个全局 `0700` 目录；每个用户自己的 root/session/outbox 继续收紧为 `0700`，relay 文件为 `0600`；对已存在目录校验 symlink 和 owner；对 outbox 内的 request/content/attachment 都按 sandbox 不可信输入做 no-follow、non-blocking、regular-file 校验。

## 影响面

- 影响 sandbox backend 的共用逻辑，所有 CLI 开启 sandbox 时都会使用新 outbox 路径。
- 项目写隔离不变：仍使用 `<dataDir>/sandboxes/<sid>/proj-upper`。
- HOME 写隔离仍使用 `/var/tmp` 下的 upper/work，但路径从全局 `/var/tmp/botmux-sbx/<sid>/home-upper` 调整为 per-user `/var/tmp/botmux-sbx-<uid>/<sid>/home-upper`。
- relay 安全边界不变：sandbox 内 `botmux send` 仍只写 outbox，宿主 watcher 代发；relay 链路不通过 env/argv/IPC 给沙盒注入发送凭据。
- 已 rebase/merge 到最新 master（含 `--videos` / `--video-covers`），relay 请求中同时保留 `attachments`、`videos`、`videoCovers`、`flags`，且所有 relay 文件均为 `0600`。
- reattach 对旧 outbox 和旧 HOME upper 保留 fallback，降低升级中已有 persistent sandbox session 的兼容风险。
- cleanup 同时清理 `sessionRoot`、新 per-uid vartmp sid 目录和旧全局 vartmp sid 目录。

## 测试验证

```bash
pnpm test -- test/sandbox.test.ts test/cli-send-hook-context.test.ts test/cli-send-dispatch.test.ts
# ✓ 3 files passed, 87 tests passed

pnpm build
# tsc + dashboard bundle 成功
```
