### PR TITLE
fix(lark): guard voice summary while worker busy

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -630,6 +630,7 @@ export const messages: Record<string, string> = {
   'card.voice.toast_already': '🔊 A voice summary for this reply is already on the way.',
   'card.voice.toast_session_gone': '⚠️ Session is offline; cannot generate a voice summary.',
   'card.voice.toast_need_auth': '🔒 You are not authorized to use this bot, so you cannot generate a voice summary. Ask an admin for access.',
+  'card.voice.toast_worker_busy': '⚠️ The session is still running. Wait for it to go idle, then generate the voice summary.',
   'card.action.takeover_retired': '⚠️ The old "Take Over" button is retired. In bridge mode, botmux bridges the original CLI so replies still come back to Lark — no takeover needed. Full takeover (`/adopt --takeover`) is on the roadmap.',
   'card.action.terminal_not_ready': '⚠️ Terminal is not ready yet, please try again shortly.',
   'card.action.local_terminal_opened': '💻 Requested opening local {cliName}.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -633,6 +633,7 @@ export const messages: Record<string, string> = {
   'card.voice.toast_already': '🔊 这条已经在生成语音啦，请稍候',
   'card.voice.toast_session_gone': '⚠️ 会话已不在线，无法生成语音总结',
   'card.voice.toast_need_auth': '🔒 你没有该机器人的使用权限，无法生成语音总结，请联系管理员授权',
+  'card.voice.toast_worker_busy': '⚠️ 会话当前还在执行中，请等它空闲后再生成语音总结。',
   'card.action.takeover_retired': '⚠️ 旧版"接管"按钮已停用。bridge 模式下原 CLI 由 botmux 桥接，无需接管即可在飞书中收到回答。如需 /resume 完整接管能力，请等待 /adopt --takeover 命令上线。',
   'card.action.terminal_not_ready': '⚠️ 终端尚未就绪，请稍后再试。',
   'card.action.local_terminal_opened': '💻 已请求打开本机 {cliName}',

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -207,6 +207,11 @@ function voiceSummaryInstruction(locale?: Locale): string {
   return t('card.voice.summary_instruction', undefined, locale);
 }
 
+function isLiveWorkerIdleOrLimited(ds: DaemonSession): boolean {
+  if (!ds.worker || ds.worker.killed) return true;
+  return ds.lastScreenStatus === 'idle' || ds.lastScreenStatus === 'limited';
+}
+
 function isLegacySelfHealAction(actionType?: string): boolean {
   return !!actionType && LEGACY_SELF_HEAL_ACTIONS.has(actionType);
 }
@@ -1297,6 +1302,10 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       if (!canTalk(ds.larkAppId, ds.chatId, operatorOpenId) && !canOperate(ds.larkAppId, ds.chatId, operatorOpenId)) {
         logger.info(`[${tag(ds)}] voice_summary blocked for unauthorized user: ${operatorOpenId ?? '?'}`);
         return { toast: { type: 'warning', content: t('card.voice.toast_need_auth', undefined, locDs) } };
+      }
+      if (!isLiveWorkerIdleOrLimited(ds)) {
+        logger.info(`[${tag(ds)}] voice_summary blocked because worker is busy: ${ds.lastScreenStatus ?? 'unknown'}`);
+        return { toast: { type: 'warning', content: t('card.voice.toast_worker_busy', undefined, locDs) } };
       }
       const dedupeKey = cardMessageId ?? `${sessionAnchorId(ds)}::voice`;
       if (voicedCardIds.has(dedupeKey)) {

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -1303,13 +1303,19 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
         logger.info(`[${tag(ds)}] voice_summary blocked for unauthorized user: ${operatorOpenId ?? '?'}`);
         return { toast: { type: 'warning', content: t('card.voice.toast_need_auth', undefined, locDs) } };
       }
-      if (!isLiveWorkerIdleOrLimited(ds)) {
-        logger.info(`[${tag(ds)}] voice_summary blocked because worker is busy: ${ds.lastScreenStatus ?? 'unknown'}`);
-        return { toast: { type: 'warning', content: t('card.voice.toast_worker_busy', undefined, locDs) } };
-      }
+      // Dedupe read BEFORE the busy guard: a card whose voice is already being
+      // generated will have its worker back in `working`, so the busy guard would
+      // otherwise shadow the "already on the way" hint with a misleading
+      // "wait for idle" toast. Read first (correct message), guard second, and
+      // only `add` after the guard so a genuinely-busy first click still doesn't
+      // burn the dedupe key.
       const dedupeKey = cardMessageId ?? `${sessionAnchorId(ds)}::voice`;
       if (voicedCardIds.has(dedupeKey)) {
         return { toast: { type: 'info', content: t('card.voice.toast_already', undefined, locDs) } };
+      }
+      if (!isLiveWorkerIdleOrLimited(ds)) {
+        logger.info(`[${tag(ds)}] voice_summary blocked because worker is busy: ${ds.lastScreenStatus ?? 'unknown'}`);
+        return { toast: { type: 'warning', content: t('card.voice.toast_worker_busy', undefined, locDs) } };
       }
       voicedCardIds.add(dedupeKey);
       if (voicedCardIds.size > 5000) { voicedCardIds.clear(); voicedCardIds.add(dedupeKey); }

--- a/test/card-handler-voice.test.ts
+++ b/test/card-handler-voice.test.ts
@@ -100,6 +100,26 @@ describe('card-handler voice_summary', () => {
     expect(send).toHaveBeenCalledTimes(1);
   });
 
+  it('a re-click while the voice is still generating (worker back to working) says "already", not "busy"', async () => {
+    const { types, handler } = await fresh();
+    const send = vi.fn();
+    const ds = fakeSession(send, false, 'idle');
+    deps.activeSessions.set(types.sessionKey('om_root', 'h1'), ds);
+
+    const first = await handler.handleCardAction(voiceAction('om_card1'), deps, 'h1');
+    expect(first?.toast?.type).toBe('success'); // triggered
+    expect(send).toHaveBeenCalledTimes(1);
+
+    // Injecting the voice instruction flips the worker back to working; a second
+    // click on the same card must surface the dedupe "already on the way" hint,
+    // not the busy toast (dedupe read is ordered before the busy guard).
+    ds.lastScreenStatus = 'working';
+    const second = await handler.handleCardAction(voiceAction('om_card1'), deps, 'h1');
+    expect(second?.toast?.type).toBe('info');
+    expect(second?.toast?.content).toContain('已经在生成语音');
+    expect(send).toHaveBeenCalledTimes(1); // no re-inject
+  });
+
   it('session offline → warning toast, no injection', async () => {
     const { handler } = await fresh();
     // activeSessions empty → ds resolves to undefined

--- a/test/card-handler-voice.test.ts
+++ b/test/card-handler-voice.test.ts
@@ -1,5 +1,5 @@
 /**
- * card-handler 🔊 语音总结 动作：注入会话精简指令 + 请耐心等待 toast + 只生成一次去重。
+ * card-handler 🔊 语音总结 动作：空闲时注入会话精简指令；执行中只提示，不打断当前回合。
  * Run: pnpm vitest run test/card-handler-voice.test.ts
  */
 import { mkdtempSync, writeFileSync } from 'node:fs';
@@ -14,7 +14,7 @@ vi.mock('@larksuiteoapi/node-sdk', () => {
 
 const deps = { activeSessions: new Map(), sessionReply: vi.fn(async () => 'mid'), lastRepoScan: new Map() } as any;
 
-function fakeSession(workerSend: ReturnType<typeof vi.fn>, killed = false): any {
+function fakeSession(workerSend: ReturnType<typeof vi.fn>, killed = false, lastScreenStatus = 'idle'): any {
   return {
     larkAppId: 'h1',
     chatId: 'oc_1',
@@ -22,6 +22,7 @@ function fakeSession(workerSend: ReturnType<typeof vi.fn>, killed = false): any 
     scope: 'thread',
     hasHistory: true,
     worker: { send: workerSend, killed },
+    lastScreenStatus,
     session: { sessionId: 'sess1', cliId: 'claude-code' },
   };
 }
@@ -80,6 +81,23 @@ describe('card-handler voice_summary', () => {
     expect(r1?.toast?.type).toBe('success');
     expect(r2?.toast?.type).toBe('info'); // already-on-the-way
     expect(send).toHaveBeenCalledTimes(1); // only the first click injected
+  });
+
+  it('does not inject when the worker is mid-turn, and does not consume the dedupe key', async () => {
+    const { types, handler } = await fresh();
+    const send = vi.fn();
+    const ds = fakeSession(send, false, 'working');
+    deps.activeSessions.set(types.sessionKey('om_root', 'h1'), ds);
+
+    const busy = await handler.handleCardAction(voiceAction('om_card1'), deps, 'h1');
+    expect(busy?.toast?.type).toBe('warning');
+    expect(busy?.toast?.content).toContain('执行中');
+    expect(send).not.toHaveBeenCalled();
+
+    ds.lastScreenStatus = 'idle';
+    const idle = await handler.handleCardAction(voiceAction('om_card1'), deps, 'h1');
+    expect(idle?.toast?.type).toBe('success');
+    expect(send).toHaveBeenCalledTimes(1);
   });
 
   it('session offline → warning toast, no injection', async () => {


### PR DESCRIPTION
## Summary
- block voice-summary card clicks while the target live worker is mid-turn
- allow injection only when the worker status is `idle` or `limited`
- keep busy clicks from consuming the voice-summary dedupe key so users can retry after the session goes idle
- add zh/en busy toast copy and focused card-handler coverage

## Validation
- `pnpm vitest run test/card-handler-voice.test.ts`
- `pnpm exec tsc --noEmit`
- `git diff --check`