### PR TITLE
fix(worker): 修复 ready-gate settle 卡住首条 prompt

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -399,6 +399,10 @@ let readyFlushSettleTimer: ReturnType<typeof setTimeout> | null = null;
  *  holds (just like the gate) so a message arriving mid-settle can't type-ahead
  *  past the settle and re-trigger paste-burst. */
 let isSettlingFirstFlush = false;
+/** IdleDetector can fire during the post-ready settle. Do not mark the prompt
+ *  ready yet, or flushPending will be blocked by isSettlingFirstFlush and a
+ *  later markPromptReady call would return early with the first prompt stranded. */
+let promptReadyDetectedDuringSettle = false;
 
 /** Wait until the PTY has been quiet for READY_FLUSH_SETTLE_MS (Ink render
  *  drained), capped at READY_FLUSH_SETTLE_CAP_MS, then flush the held prompt.
@@ -411,8 +415,10 @@ function settleThenFlush(startedAtMs: number, promptReadyAfterSettle: boolean): 
   const quietForMs = now - lastPtyOutputAtMs;
   if (quietForMs >= READY_FLUSH_SETTLE_MS || now - startedAtMs >= READY_FLUSH_SETTLE_CAP_MS) {
     isSettlingFirstFlush = false;
-    log(`Ready-gate settle done (quiet ${quietForMs}ms); ${promptReadyAfterSettle ? 'marking prompt ready' : 'delivering held first prompt'}`);
-    if (promptReadyAfterSettle) {
+    const shouldMarkPromptReady = promptReadyAfterSettle || promptReadyDetectedDuringSettle;
+    promptReadyDetectedDuringSettle = false;
+    log(`Ready-gate settle done (quiet ${quietForMs}ms); ${shouldMarkPromptReady ? 'marking prompt ready' : 'delivering held first prompt'}`);
+    if (shouldMarkPromptReady) {
       markPromptReady();
       return;
     }
@@ -3188,6 +3194,11 @@ function markPromptReady(): void {
     log('Idle detected but holding for SessionStart ready signal (startup selector guard)');
     return;
   }
+  if (isSettlingFirstFlush) {
+    promptReadyDetectedDuringSettle = true;
+    log('Idle detected during ready-gate settle; deferring prompt-ready until settle completes');
+    return;
+  }
   isPromptReady = true;
   // CLI 实际启动成功（回到 prompt）：复位连续重启计数。
   // 任何能到这一步的 spawn 都算"成功"——后续即便再崩溃（不是 resume 目标不存在
@@ -4999,6 +5010,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   if (readySignalTimer) { clearTimeout(readySignalTimer); readySignalTimer = null; }
   if (readyFlushSettleTimer) { clearTimeout(readyFlushSettleTimer); readyFlushSettleTimer = null; }
   isSettlingFirstFlush = false;
+  promptReadyDetectedDuringSettle = false;
   // Reset quiescence baseline so the settle measures silence from THIS spawn.
   lastPtyOutputAtMs = Date.now();
   if (shouldArmReadyGate({
@@ -5115,6 +5127,7 @@ function killCli(): void {
   if (readySignalTimer) { clearTimeout(readySignalTimer); readySignalTimer = null; }
   if (readyFlushSettleTimer) { clearTimeout(readyFlushSettleTimer); readyFlushSettleTimer = null; }
   isSettlingFirstFlush = false;
+  promptReadyDetectedDuringSettle = false;
   stopScreenAnalyzer();
   stopScreenUpdates();
   backend?.kill();

--- a/test/worker-pipe-initial-screen-order.test.ts
+++ b/test/worker-pipe-initial-screen-order.test.ts
@@ -92,6 +92,31 @@ describe('worker pipe initial screen ordering', () => {
     expect(timeoutReleaseIdx).toBeGreaterThan(-1);
   });
 
+  it('defers idle detected during ready-gate settle so the first prompt still flushes', () => {
+    const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+    const markStart = source.indexOf('function markPromptReady');
+    const markEnd = source.indexOf('function persistCliSessionId', markStart);
+    const mark = source.slice(markStart, markEnd);
+    const settleStart = source.indexOf('function settleThenFlush');
+    const settleEnd = source.indexOf('/** Release the ready-gate', settleStart);
+    const settle = source.slice(settleStart, settleEnd);
+
+    const settleGuardIdx = mark.indexOf('if (isSettlingFirstFlush)');
+    const deferredFlagIdx = mark.indexOf('promptReadyDetectedDuringSettle = true;', settleGuardIdx);
+    const readySetIdx = mark.indexOf('isPromptReady = true;');
+    expect(settleGuardIdx).toBeGreaterThan(-1);
+    expect(deferredFlagIdx).toBeGreaterThan(settleGuardIdx);
+    expect(deferredFlagIdx).toBeLessThan(readySetIdx);
+
+    expect(settle).toContain('const shouldMarkPromptReady = promptReadyAfterSettle || promptReadyDetectedDuringSettle;');
+    expect(settle.indexOf('promptReadyDetectedDuringSettle = false;')).toBeGreaterThan(
+      settle.indexOf('const shouldMarkPromptReady = promptReadyAfterSettle || promptReadyDetectedDuringSettle;'),
+    );
+    expect(settle.indexOf('markPromptReady();')).toBeGreaterThan(
+      settle.indexOf('const shouldMarkPromptReady = promptReadyAfterSettle || promptReadyDetectedDuringSettle;'),
+    );
+  });
+
   it('honors a true ready signal that arrives AFTER the timeout fallback (slow cold start)', () => {
     // ReadyGate.receive() is one-shot: once the 45s fallback fires, a later
     // releaseReadyGate from the real signal is skipped entirely. A CLI whose


### PR DESCRIPTION
## 改动

修复 worker ready-gate 的一个首条 prompt 卡住问题：当 `SessionStart` ready hook 释放 ready-gate 后，worker 会进入 quiescence settle；如果 IdleDetector 在 settle 窗口里先触发，旧逻辑会提前把 `isPromptReady` 置为 true，但 `flushPending()` 又被 `isSettlingFirstFlush` 拦住。随后 settle 结束再次 `markPromptReady()` 会因为已 ready 直接 return，导致首条 pending prompt 直到下一条消息才被 flush。

本 PR 在 settle 期间只记录 `promptReadyDetectedDuringSettle`，等 settle 完成后统一 mark prompt ready 并 flush pending prompt。

## 影响面

- 影响 worker 层带 ready hook 的 CLI 冷启动首条 prompt 路径，主要覆盖 Claude family / Hermes。
- 不改变 repo picker / card action 语义；repo 直接启动只是更容易观察到该竞态。
- 不影响不走 ready hook 的 CLI 路径。

## 验证

- `pnpm vitest run test/worker-pipe-initial-screen-order.test.ts`
- `git diff --check`
- `pnpm build`