### PR TITLE
fix(web-terminal): 滚轮/触摸滚动转发指针所在单元格，修复 OpenCode 网页终端无法滚动

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5624,12 +5624,35 @@ window.addEventListener('resize',onViewportResize);
 // doesn't compound into a whole screen. px<0 = scroll up (toward history). The
 // per-call cap stops a single huge delta (page tick / fling) from over-firing.
 var _scrollAccum=0;var _SCROLL_STEP=33;
-function _fwdScroll(px){
+// Map a viewport pixel (clientX/Y) to a 1-based terminal cell "col;row", clamped to
+// the grid. The forwarded SGR wheel event MUST carry the cell UNDER THE POINTER, the
+// way a physical terminal reports it: zone-routed alt-screen TUIs — OpenCode (Bubble
+// Tea + bubblezone) — only scroll when the wheel lands inside the messages viewport's
+// mouse zone. A fixed (1,1) is the top-left border, outside that zone, so every
+// forwarded wheel was dropped and OpenCode wouldn't scroll at all. Coordinate-agnostic
+// CLIs (Claude Code etc.) scroll regardless of coords, which is why ONLY OpenCode broke.
+// Fall back to the grid CENTRE (never 1,1) when the screen geometry can't be read.
+function _cellAt(clientX,clientY){
+  var col=(term.cols>>1)+1,row=(term.rows>>1)+1;
+  try{
+    var sc=term.element&&term.element.querySelector('.xterm-screen');
+    var r=sc&&sc.getBoundingClientRect();
+    if(r&&r.width>0&&r.height>0){
+      col=Math.floor((clientX-r.left)/(r.width/term.cols))+1;
+      row=Math.floor((clientY-r.top)/(r.height/term.rows))+1;
+    }
+  }catch(_e){}
+  if(col<1)col=1;else if(col>term.cols)col=term.cols;
+  if(row<1)row=1;else if(row>term.rows)row=term.rows;
+  return col+';'+row;
+}
+function _fwdScroll(px,coord){
   if(!ws_||ws_.readyState!==1)return;
+  coord=coord||(((term.cols>>1)+1)+';'+((term.rows>>1)+1)); // never (1,1)
   _scrollAccum+=px;var data='',n=0;
   while(Math.abs(_scrollAccum)>=_SCROLL_STEP&&n<6){
     var up=_scrollAccum<0; // px<0 → wheel-up (history)
-    data+='\\x1b[<'+(up?64:65)+';1;1M';
+    data+='\\x1b[<'+(up?64:65)+';'+coord+'M';
     _scrollAccum+=up?_SCROLL_STEP:-_SCROLL_STEP;n++;
   }
   if(data)ws_.send(JSON.stringify({type:'input',data:data}));
@@ -5645,7 +5668,7 @@ if(!${isTmuxMode && !isPipeMode}){
     e.preventDefault();e.stopPropagation();
     // Normalise deltaMode to px: line→~16px, page→~one screen.
     var px=e.deltaMode===1?e.deltaY*16:e.deltaMode===2?e.deltaY*term.rows*16:e.deltaY;
-    _fwdScroll(px);
+    _fwdScroll(px,_cellAt(e.clientX,e.clientY)); // report the cell under the pointer
   },{capture:true,passive:false});
 }
 
@@ -5694,7 +5717,8 @@ if(!${isTmuxMode && !isPipeMode}){
     if(term.buffer.active.type!=='alternate'||_tLastY===null||e.touches.length!==1)return;
     e.preventDefault();e.stopPropagation();
     var y=e.touches[0].clientY;
-    _fwdScroll(_tLastY-y); // finger drags down (y grows) → px<0 → scroll up (history)
+    // finger drags down (y grows) → px<0 → scroll up (history); report the touched cell
+    _fwdScroll(_tLastY-y,_cellAt(e.touches[0].clientX,y));
     _tLastY=y;
   },{capture:true,passive:false});
   _tTerm.addEventListener('touchend',function(){_tLastY=null;},{capture:true,passive:true});


### PR DESCRIPTION
## 问题

网页终端里 **只有 OpenCode** 的会话无法用鼠标滚轮滚动，其它 CLI（Claude Code / Codex / Gemini 等）都正常。

## 根因

alt-screen TUI 在网页终端里没有 xterm 本地 scrollback（整屏由 CLI 自己在 alt buffer 重绘），所以 `worker.ts` 的滚轮处理把滚轮转发成 SGR 鼠标滚轮事件让 CLI 自己滚。问题出在**坐标被写死成 `;1;1`**（左上角）：

```
data+='\x1b[<'+(up?64:65)+';1;1M';   // 永远 (col=1,row=1)
```

- Claude/Codex 等是整屏重绘、**与坐标无关**，滚轮落在哪都滚 → `;1;1` 能用；
- OpenCode 是 Bubble Tea + bubblezone，**按指针所在单元格路由**：只有滚轮落在「消息视口」的 mouse zone 内才滚。`(1,1)` 是左上角边框，落在消息区之外 → 每个转发的滚轮事件都被 OpenCode 丢弃 → 完全滚不动。

这就是「只有 OpenCode 坏」的原因。

## 修复

转发时改为携带**指针真正所在的单元格**（跟物理终端上报的行为一致），而不是固定 `(1,1)`：

- 新增 `_cellAt(clientX,clientY)`：用 `.xterm-screen` 的 `getBoundingClientRect()` ÷ `cols/rows` 把视口像素换算成 1-based 单元格并 clamp 到网格；几何读不到时**回退到网格中心**（绝不再用 `1,1`）。
- 滚轮 handler：`_fwdScroll(px, _cellAt(e.clientX,e.clientY))`
- 单指触摸 handler：`_fwdScroll(_tLastY-y, _cellAt(touch.clientX, y))`
- `_fwdScroll` 增加 `coord` 参数，把 SGR 里的 `;1;1` 换成实际坐标。

改动仅限 `getTerminalHtml()` 里注入前端的那段 JS，纯前端、无协议/后端改动。

## 影响面评估

- **只动 alt-screen 分支**：normal-buffer CLI 仍走 xterm 原生 scrollback（`term.scrollLines`），完全没碰。
- **坐标无关的 alt-screen CLI（Claude/Codex/Gemini）**：本来任意坐标都能滚，从 `(1,1)` 换成指针单元格仍然滚，无回归（不存在「只在左上角才滚」的 TUI）。
- **tmux/zellij pipe 模式**（handler 同样挂载）：转发到指针所在 pane 单元格，与真实终端一致；纯 tmux/zellij **attach**（`isTmuxMode && !isPipeMode`）该 handler 本就不挂载，gate 未变。
- **只读查看**：服务端只放行 `^(\x1b\[<6[4-7];\d+;\d+M)+$`，新序列 `\x1b[<64;56;16M` 仍匹配，只读下照样能滚（下方实测就是只读态验证的）。
- 跨平台：纯浏览器端 JS，与 macOS/Linux 无关。

## 测试验证

`pnpm build` 绿。

在 live OpenCode 会话的网页终端上用无头浏览器实测（只读态，直接对比 xterm 网格指纹）：

| 测试 | 结果 |
|------|------|
| 滚轮 up ×8 @ `(1,1)`（旧行为） | 网格 **不变** —— OpenCode 忽略 |
| 滚轮 up ×8 @ 中心 `(79,15)` | 网格 **改变**，滚入历史 |
| 由 `.xterm-screen` 几何算出的指针单元格（col56,row18）转发 | **滚动成功** |
| 派发**真实 `WheelEvent`** 走修复后 handler（算出指针 `56;16`） | **`scrolledOnRealWheel: true`** |

即：旧的 `(1,1)` 对 OpenCode 完全无效，修复后按指针单元格转发可正常滚动，且真实滚轮事件端到端走通。（截图见 PR 评论 / 飞书）

## 备注

前端注入 JS 不在单测覆盖范围内（历史如此），本次靠上面的 live 端到端实测覆盖。
