### PR TITLE
fix(mir-runner): default to disallow cloud-sandbox builtins and drop --lean

### DIFF
--- a/src/adapters/cli/mir.ts
+++ b/src/adapters/cli/mir.ts
@@ -9,7 +9,7 @@ import { resolveCommand } from './registry.js';
  * Mir CLI (mircli) adapter — drives the local `mircli` in non-interactive Print
  * Mode through a small Node runner (src/mir-runner.ts), mirroring the `mira`
  * (Mira App / Web API) adapter's runner shape. See mir-runner.ts for why Print
- * Mode (`mircli -p --lean`) is used instead of driving the interactive TUI.
+ * Mode (`mircli -p`) is used instead of driving the interactive TUI.
  *
  * Distinct from the `mira` adapter:
  *   - `mira` → Mira Web API (cloud orchestration + remote sandbox; chat/search).

--- a/src/mir-runner.ts
+++ b/src/mir-runner.ts
@@ -5,7 +5,7 @@
  * Unlike the interactive PTY adapters, `mir` drives mircli through its
  * non-interactive Print Mode: each botmux turn spawns
  *
- *     mircli -p <content> --lean --output-format text --session-id <sid> -y \
+ *     mircli -p <content> --output-format text --session-id <sid> -y \
  *            --append-system-prompt <local-runtime-context>
  *
  * in the botmux workspace cwd, captures stdout, and ships it back to the daemon
@@ -50,9 +50,11 @@ const DEFAULT_QUERY_TIMEOUT = '10m';
 const DEFAULT_RUNNER_TIMEOUT_MS = 12 * 60 * 1000;
 const MARKER_PREFIX = '::botmux-mir:';
 // Backend Claude-harness builtin tools that route to the cloud sandbox; mircli's
-// own local tools are the lowercase equivalents. Optionally hard-disallow these
-// (MIRCLI_DISALLOW_BUILTIN=1) to push the model onto the local tools. Off by
-// default — the validated path relies on --lean + the local MCP bridge.
+// own local tools are the lowercase equivalents. Hard-disallow these by
+// default to push the model onto Mir CLI local MCP tools. Do not enable Mir CLI
+// lean mode by default: mircli v2.10.0 skips the LocalMcp tool list in lean
+// mode, so the bot cannot see mira_local_bash or local filesystem tools even
+// when miramcp is connected.
 const BUILTIN_SANDBOX_TOOLS = ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep'];
 
 function parseArgs(argv: string[]): Args {
@@ -150,6 +152,8 @@ function runtimeSystemPrompt(): string {
     'If the target path is not obvious, use the actual local runtime cwd above. Do not ask the user to choose a path when this cwd is provided.',
     'This BotMux session is not running in /home/mira/.session. Do not report /home/mira/.session as the working directory for this session.',
     'Local filesystem, shell/bash, git, and BotMux CLI tools are available through the Mir CLI local tool bridge for this process.',
+    'Use MCP proxy tools whose names contain mira_local, such as the tool ending in mira_local_bash for shell commands.',
+    'Never use default cloud sandbox tools named Bash, Read, Write, Edit, Glob, or Grep for local work; those are not the local machine and may be rejected.',
     'When the user asks to create, read, list, edit, or inspect local files, run bash/shell commands, inspect git, or operate BotMux, you MUST call the local tools against the actual local cwd above.',
     'Prefer local bash commands that operate from the current cwd with relative paths first; if an absolute physical cwd fails, retry the same operation from the current cwd and then with the local tool path alias before reporting failure.',
     'Do not say the local MCP bridge is disconnected, that only a cloud sandbox is available, or that the operation is cancelled unless a concrete local tool invocation actually returned that error.',
@@ -206,7 +210,7 @@ class MircliClient {
         }
       }
       const args = splitEnvArgs(process.env.MIRCLI_EXTRA_ARGS);
-      if (boolEnv('MIRCLI_LEAN', true) && !args.includes('--lean') && !args.includes('--ultra')) {
+      if (boolEnv('MIRCLI_LEAN', false) && !args.includes('--lean') && !args.includes('--ultra')) {
         args.push('--lean');
       }
       args.push(
@@ -219,7 +223,7 @@ class MircliClient {
       if (boolEnv('MIRCLI_YOLO', true)) args.push('-y');
       // Optional reliability lever: hard-block the backend's cloud-sandbox
       // builtins so the model is pushed onto mircli's local tools.
-      if (boolEnv('MIRCLI_DISALLOW_BUILTIN', false)) {
+      if (boolEnv('MIRCLI_DISALLOW_BUILTIN', true)) {
         for (const tool of BUILTIN_SANDBOX_TOOLS) args.push('--disallowed-tool', tool);
       }
 


### PR DESCRIPTION
## Summary
- Stop adding `--lean` to `mircli` by default in the BotMux mir runner.
- Default `MIRCLI_DISALLOW_BUILTIN` to `true`, adding `--disallowed-tool Bash/Read/Write/Edit/Glob/Grep` so the model is pushed toward Mir CLI local MCP tools.
- Add runtime prompt guidance to use MCP proxy tools whose names contain `mira_local`, and update the mir adapter comment to no longer document `mircli -p --lean` as the default path.

## Root Cause
`mircli` v2.10.0 lean mode skips the `LocalMcp` tool list. In BotMux mir sessions, that means the model cannot see tools such as `mira_local_bash` / local filesystem tools, then falls back to backend cloud-sandbox builtins like `Bash` / `Read`, which are not the user machine and can be rejected by the local-only guard.

## Validation
- `git diff --check`
- `vitest run --project unit test/cli-adapters.test.ts`
- `tsc --pretty false`
- Manual equivalent of `pnpm build`: `tsc && cp src/setup/lark-scopes.json dist/setup/ && corepack pnpm dashboard:bundle && chmod +x dist/cli.js`
- Runner dry-run with fake `mircli`: `HAS_LEAN=0`, `MISSING_DISALLOWED=none`, `PROMPT_HAS_MIRA_LOCAL=1`, `PROMPT_HAS_CLOUD_SANDBOX_WARNING=1`