### PR TITLE
fix(web-terminal): 修复首次打开未定位最新输出

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5548,6 +5548,45 @@ try{
   try{term.loadAddon(new CanvasAddon.CanvasAddon())}catch(_e2){}
 }
 fit.fit();
+// xterm parses writes asynchronously.  On a brand-new page the first tmux /
+// zellij frame (or relay history seed) can therefore finish after the browser
+// has initialised the viewport scrollbar, leaving that viewport at scrollTop=0
+// even though the buffer already contains newer rows.  Follow only the initial
+// write burst and explicitly settle at the bottom.  Any deliberate user scroll
+// cancels this so loading a busy session never fights the reader.
+var _initialFollow=true,_initialFollowT=0;
+function _cancelInitialFollow(){
+  if(!_initialFollow)return;
+  _initialFollow=false;clearTimeout(_initialFollowT);
+}
+function _settleInitialBottom(){
+  if(!_initialFollow)return;
+  try{term.scrollToBottom()}catch(_e){}
+  clearTimeout(_initialFollowT);
+  _initialFollowT=setTimeout(function(){
+    if(!_initialFollow)return;
+    try{term.scrollToBottom()}catch(_e){}
+    _initialFollow=false;
+  },500);
+}
+var _initialViewport=term.element&&term.element.querySelector('.xterm-viewport');
+var _initialTerminalRoot=document.getElementById('terminal');
+if(_initialTerminalRoot){
+  // Listen above xterm's own root: its wheel handler can stop propagation at
+  // the target, while this ancestor still sees capture-phase user intent.
+  _initialTerminalRoot.addEventListener('wheel',_cancelInitialFollow,{capture:true,passive:true});
+  _initialTerminalRoot.addEventListener('touchstart',_cancelInitialFollow,{capture:true,passive:true});
+}
+if(_initialViewport){
+  _initialViewport.addEventListener('pointerdown',function(e){
+    // A pointer press on the native scrollbar targets the viewport itself;
+    // presses on terminal cells target the screen/canvas and keep following.
+    if(e.target===_initialViewport)_cancelInitialFollow();
+  },{capture:true});
+}
+window.addEventListener('keydown',function(e){
+  if(e.key==='PageUp'||e.key==='PageDown'||e.key==='Home'||e.key==='End')_cancelInitialFollow();
+},{capture:true});
 // ── OSC 52 clipboard ──
 var _clipBuf='';
 function _doCopy(text){
@@ -5633,7 +5672,7 @@ window.addEventListener('resize',onViewportResize);
     // Intercept OSC 52 clipboard sequence from tmux (set-clipboard on)
     var m=data.match(/\\x1b\\]52;[^;]*;([A-Za-z0-9+/=]+)(?:\\x07|\\x1b\\\\)/);
     if(m){try{_clipBuf=new TextDecoder().decode(Uint8Array.from(atob(m[1]),function(c){return c.charCodeAt(0)}));_doCopy(_clipBuf);_showCopied()}catch(ex){}}
-    term.write(data);
+    term.write(data,_settleInitialBottom);
   };
   ws.onclose=function(){ws_=null;el.textContent='disconnected';el.className='err';setTimeout(connect,2000)};
   ws.onerror=function(){ws.close()};

--- a/test/web-terminal-initial-follow.test.ts
+++ b/test/web-terminal-initial-follow.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workerSource = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+
+describe('web terminal initial viewport follow', () => {
+  it('settles the first asynchronous xterm write burst at the bottom', () => {
+    expect(workerSource).toContain('term.write(data,_settleInitialBottom)');
+    expect(workerSource).toMatch(
+      /function _settleInitialBottom\(\)\{[\s\S]*?term\.scrollToBottom\(\)[\s\S]*?setTimeout\(function\(\)\{[\s\S]*?term\.scrollToBottom\(\)[\s\S]*?_initialFollow=false;/,
+    );
+  });
+
+  it('stops following as soon as the reader deliberately scrolls', () => {
+    expect(workerSource).toContain(
+      "_initialTerminalRoot.addEventListener('wheel',_cancelInitialFollow,{capture:true,passive:true})",
+    );
+    expect(workerSource).toContain(
+      "_initialTerminalRoot.addEventListener('touchstart',_cancelInitialFollow,{capture:true,passive:true})",
+    );
+    expect(workerSource).toContain("if(e.target===_initialViewport)_cancelInitialFollow()");
+    expect(workerSource).toContain("if(e.key==='PageUp'||e.key==='PageDown'||e.key==='Home'||e.key==='End')_cancelInitialFollow()");
+  });
+});


### PR DESCRIPTION
## 改了什么

- Web 终端首批 xterm 异步写入完成后，显式把 viewport 定位到最新输出
- 初始自动跟随仅覆盖首批输出；检测到滚轮、触摸、滚动条操作或翻页键后立即停止
- 新增回归测试，锁定首屏落底与用户滚动后停止跟随的行为

## 为什么

新 Session 第一次打开 Web 终端时，tmux / zellij 首帧或 relay 历史种子通过 `term.write()` 异步解析。浏览器可能先初始化 scrollbar 并保留 `scrollTop=0`，导致页面停在最早输出而不是最新输出。

## 影响面

改动位于所有 CLI / 后端共用的 Web 终端前端初始化路径：

- CLI：Codex、Claude Code、OpenCode 等共用页面
- 后端：tmux attach、zellij attach、relay
- 终端：桌面滚轮、触摸端、滚动条、PageUp/PageDown/Home/End

未修改后端会话生命周期、PTY 输入或 WebSocket 协议。

## 验证

- `pnpm build`：通过
- `HOME=/tmp/botmux-pr-web-terminal-home TZ=America/Los_Angeles pnpm test`：462 个文件、7596 个测试全部通过
- Web 终端相关定向测试：5 个文件、25 个测试全部通过
- live daemon + 真实浏览器：
  - 首开 `baseY=668`、`viewportY=668`，位于最新输出
  - 用户上翻后新输出令 `baseY: 627 → 637`，`viewportY` 保持 624，未被拉回底部
