### PR TITLE
fix(grant): 授权通知卡 bot 有名字用名字、无名字@兜底

### DIFF
--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -1265,11 +1265,13 @@ export function buildGrantCard(o: GrantCardOpts, locale?: Locale): string {
 
 /** 授权成功后给被授权人的通知卡（独立消息）。支持一次通知多个被授权人；带额度时追加"（额度 N 条）"。
  *
- *  **真人 grantee 用 `<at>` 点名，bot grantee 只用纯文本名字**：卡片里的 `<at id=botOpenId>` 会被
- *  对方 bot 的 daemon 当成一次「被 @」消息，从而凭新授权/同伴 peer 关系在本群误拉起一个空会话
- *  （实测 bug：手动 /grant 后面没有 prompt，不该触发自动会话）。纯文本名字不产生 mention 事件，
- *  既保留「谁被授权」的可读信息，又不会唤醒对方 bot。传 string/string[]（无 isBot 信息）时按真人
- *  处理（@ 全部），保持旧调用方/单测兼容。 */
+ *  **bot grantee 有名字就用纯文本名字、拿不到名字才 `<at>` 兜底；真人 grantee 一律 `<at>` 点名**：
+ *  卡片里的 `<at id=botOpenId>` 会被对方 bot 的 daemon 当成一次「被 @」消息，凭新授权/同伴 peer
+ *  关系在本群拉起一个空会话（实测：手动 /grant 后没有 prompt → 空会话「等待输入」）。所以能拿到
+ *  bot 名字时优先用纯文本（不产生 mention、不唤醒对方）；只有名字缺失时才退回 `<at>`——此时飞书
+ *  能据 open_id 展示对方身份（远比裸 open_id 可读），代价是可能偶尔触发一次空会话（产品上可接受，
+ *  且名字缺失是少数边角情况）。真人被 `<at>` 不会自动开会话。传 string/string[]（无 isBot 信息）
+ *  时按真人处理（@ 全部），保持旧调用方/单测兼容。 */
 export function buildGrantNotifyCard(
   kind: 'chat' | 'global',
   target: string | string[] | Array<{ openId: string; name?: string; isBot?: boolean }>,
@@ -1279,9 +1281,9 @@ export function buildGrantNotifyCard(
   const entries = (Array.isArray(target) ? target : [target]).map(tt =>
     typeof tt === 'string' ? { openId: tt, name: undefined as string | undefined, isBot: false } : tt);
   const at = entries.map(e =>
-    e.isBot
-      ? (e.name && e.name.length > 0 ? e.name : e.openId)   // bot：纯文本名字，绝不 <at>（否则唤醒对方 bot）
-      : `<at id=${e.openId}></at>`,                          // 真人：@ 点名（真人被 @ 不会自动开会话）
+    e.isBot && e.name && e.name.length > 0
+      ? e.name                                              // bot 有名字：纯文本，不 <at>（不唤醒对方）
+      : `<at id=${e.openId}></at>`,                          // 真人 / bot 无名字：@ 点名（bot 无名字时靠飞书据 open_id 展示身份，代价=可能一次空会话）
   ).join(' ');
   let content = t(kind === 'chat' ? 'card.grant.notify_chat' : 'card.grant.notify_global', { at }, locale);
   if (quota !== undefined && quota > 0) content += t('card.grant.notify_quota_suffix', { n: quota }, locale);

--- a/test/card-handler-grant.test.ts
+++ b/test/card-handler-grant.test.ts
@@ -238,8 +238,8 @@ describe('card-handler grant actions', () => {
   });
 
   // 实测 bug：手动 /grant 一个 bot 后，通知卡若 <at> 对方 bot 会唤醒其 daemon 误拉空会话。
-  // 修复后通知卡对 bot grantee 只用纯文本名字（无 <at>），对真人仍 @。
-  it('通知卡：bot grantee 用纯文本名字（无 <at>），不唤醒对方 bot', async () => {
+  // 混合规则：能拿到 bot 名字就用纯文本名字（无 <at>，不唤醒对方），对真人仍 @。
+  it('通知卡：有名字的 bot grantee 用纯文本名字（无 <at>），不唤醒对方 bot', async () => {
     const { pending, handler } = await fresh();
     // 默认 isHumanMock=false → ou_bot2 判为 bot。
     const nonce = pending.openPendingMulti('h1', 'oc_1', ['ou_bot2']);
@@ -250,8 +250,24 @@ describe('card-handler grant actions', () => {
     await handler.handleCardAction(data, deps, 'h1');
     await flushBackground();
     const notify = replyMock.mock.calls.at(-1)![2] as string;
-    expect(notify).not.toContain('<at id=ou_bot2');   // bot 绝不被 <at>
+    expect(notify).not.toContain('<at id=ou_bot2');   // 有名字的 bot 不被 <at>
     expect(notify).toContain('Codex');                 // 纯文本名字保留可读信息
+  });
+
+  // 名字缺失（target_names 为空）才退回 @ 兜底：飞书据 open_id 展示身份（远比裸 open_id 可读），
+  // 代价=可能偶尔触发一次空会话（产品上可接受，边角情况）。
+  it('通知卡：拿不到名字的 bot grantee 用 @ 兜底（而非裸 open_id）', async () => {
+    const { pending, handler } = await fresh();
+    // isHumanMock=false → ou_bot2 判为 bot；target_names 缺失 → 名字取不到。
+    const nonce = pending.openPendingMulti('h1', 'oc_1', ['ou_bot2']);
+    const data: any = {
+      operator: { open_id: 'ou_owner' }, context: { open_message_id: 'om_card' },
+      action: { value: { action: 'grant_chat', target_open_ids: ['ou_bot2'], target_names: [], chat_id: 'oc_1', nonce } },
+    };
+    await handler.handleCardAction(data, deps, 'h1');
+    await flushBackground();
+    const notify = replyMock.mock.calls.at(-1)![2] as string;
+    expect(notify).toContain('<at id=ou_bot2></at>');  // 无名字 → @ 兜底
   });
 
   it('通知卡：真人 grantee 仍 @ 点名（真人被 @ 不会自动开会话）', async () => {

--- a/test/grant-card.test.ts
+++ b/test/grant-card.test.ts
@@ -58,24 +58,24 @@ describe('buildGrantCard', () => {
     expect(flat).toContain('<at id=ou_b></at>');
   });
 
-  // 实测 bug 修复：bot grantee 绝不能用 <at>（会唤醒对方 bot 的 daemon 误拉空会话），
-  // 改用纯文本名字；真人 grantee 仍 @ 点名（真人被 @ 不会自动开会话）。
-  it('buildGrantNotifyCard renders bot grantees as PLAIN name (no <at>), humans as @', () => {
+  // 混合规则：bot grantee 有名字 → 纯文本（不 <at>，避免唤醒对方 bot 的 daemon 误拉空会话）；
+  // 真人 grantee → @ 点名（真人被 @ 不会自动开会话）。
+  it('buildGrantNotifyCard renders known-name bot grantees as PLAIN name (no <at>), humans as @', () => {
     const card = JSON.parse(buildGrantNotifyCard('chat', [
       { openId: 'ou_human', name: '张三', isBot: false },
       { openId: 'ou_codex', name: 'Codex', isBot: true },
     ], 'zh'));
     const flat = JSON.stringify(card);
     expect(flat).toContain('<at id=ou_human></at>');   // 真人 → @
-    expect(flat).not.toContain('<at id=ou_codex');     // bot → 绝无 <at>
-    expect(flat).toContain('Codex');                   // bot → 纯文本名字
+    expect(flat).not.toContain('<at id=ou_codex');     // 有名字的 bot → 无 <at>
+    expect(flat).toContain('Codex');                   // 有名字的 bot → 纯文本名字
   });
 
-  it('buildGrantNotifyCard bot grantee without name falls back to open_id (still no <at>)', () => {
+  // 名字缺失才退回 @ 兜底：飞书据 open_id 展示身份（远比裸 open_id 可读），代价=可能偶尔一次空会话（可接受）。
+  it('buildGrantNotifyCard bot grantee WITHOUT name falls back to @mention (no bare open_id)', () => {
     const card = JSON.parse(buildGrantNotifyCard('chat', [{ openId: 'ou_codex', isBot: true }], 'zh'));
     const flat = JSON.stringify(card);
-    expect(flat).not.toContain('<at id=ou_codex');
-    expect(flat).toContain('ou_codex');
+    expect(flat).toContain('<at id=ou_codex></at>');   // 无名字 → @ 兜底
   });
 
   it('buildGrantResultCard has no buttons', () => {


### PR DESCRIPTION
## 背景

授权成功通知卡对 bot 被授权人在**名字缺失**时会展示裸 `ou_...` open_id，可读性很差。

## 改动

`buildGrantNotifyCard` 改为**混合规则**（`src/im/lark/card-builder.ts`）：

- **bot 有名字** → 纯文本名字（不 `<at>`，不产生 mention、不唤醒对方 bot）。
- **bot 拿不到名字** → `<at id>` 兜底：飞书据 open_id 展示对方身份（远比裸 `ou_` 可读），代价是可能偶尔触发对方 bot **一次空会话**（产品上可接受，且名字缺失是少数边角情况）。
- **真人** → 一律 `<at>` 点名（真人被 @ 不会自动开会话）。

### 为什么不用零宽 sentinel 方案

先前实现是「@ 全部被授权人 + 给卡片附零宽路由标记 + 接收 bot 在 dispatcher 路由层识别标记吞掉纯通知」。review 发现它的正确性依赖 sentinel 在**每一种投递路径**（interactive 简化占位 / REST 完整卡、且 `message_type` 可能是 `interactive` 或 `nonsupport`）都可靠命中，较脆弱。本方案只在名字缺失的边角才 `@` bot、并直接接受偶发一次空会话，**无需 sentinel 机制**，实现更简单、不新增 dispatcher / message-parser 依赖。

## 影响面

- **平台**：仅飞书 `im/lark` 授权通知卡渲染；不涉及其它 IM。
- **CLI / 后端**：不改动，逻辑在 session spawn 前。
- **会话类型**：本群/全局授权、单/多目标通知一致；grant 主流程与真人授权行为不变。
- 不再改动 `event-dispatcher` / `message-parser`（已回退到 master 基线）。

## 验证

- `pnpm build`（tsc --noEmit）✅
- `pnpm vitest run test/grant-card.test.ts test/card-handler-grant.test.ts test/event-dispatcher.test.ts test/message-parser.test.ts` ✅（286 tests）
- 新增/改动 grant 用例单跑（防 mock 泄漏）✅
