### PR TITLE
fix(lark): 授权提醒卡片@被授权人

### DIFF
--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -1233,8 +1233,12 @@ export interface GrantCardOpts {
 export function buildGrantCard(o: GrantCardOpts, locale?: Locale): string {
   const names = o.targets.map(t => `**${escapeMd(t.name)}**`).join('、');
   const single = o.targets[0];
+  // In request mode the requester can be an external bot, so it may not be
+  // present in message.mentions and its display name would otherwise fall
+  // back to a raw `ou_...` id. Mention the actual grantee in the card instead.
+  const requestName = single ? `<at id=${single.openId}></at>` : '';
   const body = o.mode === 'request'
-    ? t('card.grant.body_request', { name: escapeMd(single?.name ?? ''), owner: o.ownerOpenId }, locale)
+    ? t('card.grant.body_request', { name: requestName, owner: o.ownerOpenId }, locale)
     : o.targets.length > 1
       ? t('card.grant.body_owner_multi', { names, owner: o.ownerOpenId }, locale)
       : t('card.grant.body_owner', { name: escapeMd(single?.name ?? ''), owner: o.ownerOpenId }, locale);

--- a/test/grant-card.test.ts
+++ b/test/grant-card.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { buildGrantCard, buildGrantResultCard, buildGrantNotifyCard } from '../src/im/lark/card-builder.js';
 
 describe('buildGrantCard', () => {
-  it('embeds @owner, requester name, and nonce-bearing actions', () => {
+  it('embeds @owner, @requester, and nonce-bearing actions', () => {
     const json = buildGrantCard(
       { ownerOpenId: 'ou_owner', targets: [{ openId: 'ou_g', name: '张三' }], chatId: 'oc_1', nonce: 'n1', mode: 'request' },
       'zh',
@@ -10,7 +10,7 @@ describe('buildGrantCard', () => {
     const card = JSON.parse(json);
     const flat = JSON.stringify(card);
     expect(flat).toContain('<at id=ou_owner></at>');
-    expect(flat).toContain('张三');
+    expect(flat).toContain('<at id=ou_g></at>');
     const actions = card.elements.find((e: any) => e.tag === 'action').actions;
     const byAction = Object.fromEntries(actions.map((a: any) => [a.value.action, a.value]));
     expect(byAction.grant_chat).toMatchObject({ target_open_ids: ['ou_g'], chat_id: 'oc_1', nonce: 'n1' });


### PR DESCRIPTION
## 变更
授权申请卡片在请求方名称解析不到时不再展示裸 ou_ ID，改为直接 @ 被授权人。

## 原因
外部 bot/用户可能不出现在当前消息 mentions，名称回退为 open_id。

## 验证
- pnpm build
- pnpm test -- --run test/grant-card.test.ts