### PR TITLE
fix(tmux): 避免探针抖动触发会话重启踩踏

### DIFF
--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -148,7 +148,14 @@ export class TmuxBackend implements SessionBackend {
   /** Kill a named tmux session (no-op if it doesn't exist). */
   static killSession(name: string): void {
     try {
-      execSync(`tmux kill-session -t ${shellescape(name)}`, { stdio: 'ignore', env: tmuxEnv() });
+      // Runtime recovery calls this from many workers. Bound the command so a
+      // wedged shared server cannot pin every worker forever; restart jitter
+      // keeps the bounded attempts from landing simultaneously.
+      execFileSync('tmux', ['kill-session', '-t', name], {
+        stdio: 'ignore',
+        timeout: 3000,
+        env: tmuxEnv(),
+      });
     } catch { /* session doesn't exist */ }
   }
 

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -29,7 +29,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import { StringDecoder } from 'node:string_decoder';
-import type { SessionBackend, SpawnOpts } from './types.js';
+import type { SessionBackend, SessionProbe, SpawnOpts } from './types.js';
 import { tmuxEnv } from '../../setup/ensure-tmux.js';
 import { buildBotmuxEnvAssignments, resolveUserShell, SHELL_WRAPPER_SCRIPT, TmuxBackend } from './tmux-backend.js';
 import { LivenessGate, ADOPT_LIVENESS_MAX_FAILURES } from './liveness-gate.js';
@@ -82,6 +82,21 @@ export function composeSeedBody(
   return body + `\x1b[${cursor.y + 1};${cursor.x + 1}H`;
 }
 
+/**
+ * Spread lifecycle probes after a mass daemon restore. Workers are separate
+ * processes, so a process-local mutex cannot prevent them all from hitting the
+ * same default tmux server on the same millisecond. A stable target-derived
+ * offset keeps probes distributed without introducing test/runtime randomness.
+ */
+export function tmuxLifecycleInitialDelayMs(target: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < target.length; i += 1) {
+    hash ^= target.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return 1000 + ((hash >>> 0) % 750);
+}
+
 export class TmuxPipeBackend implements SessionBackend {
   /** Real tmux pane address (e.g. "0:2.0") or botmux session name (bmx-*). */
   private readonly paneTarget: string;
@@ -110,9 +125,10 @@ export class TmuxPipeBackend implements SessionBackend {
   private static readonly RECENT_OUTPUT_MAX = 4096;
   private readonly exitCbs: Array<(code: number | null, signal: string | null) => void> = [];
   private lifecycleTimer: NodeJS.Timeout | null = null;
-  /** Debounce transient pane-probe failures so one flaky `tmux display-message`
-   *  (timeout / server hiccup under fd pressure) doesn't tear down an adopted
-   *  pane that's still alive. See recordPaneProbe. (pid-death stays decisive.) */
+  private lastUnknownProbeLogAt = 0;
+  /** Debounce authoritative pane-missing replies. Probe timeouts / EMFILE /
+   *  spawn failures are classified as unknown and never enter this destructive
+   *  counter. (Adopted CLI pid-death stays decisive.) */
   private readonly livenessGate = new LivenessGate(ADOPT_LIVENESS_MAX_FAILURES);
   private cols = 200;
   private rows = 50;
@@ -336,11 +352,11 @@ export class TmuxPipeBackend implements SessionBackend {
       // A kill()/handlePaneExit() may have flipped exited between the guard
       // and here; if so the teardown already happened.
       if (this.exited) return false;
-      const alive = this.isPaneAlive();
+      const paneProbe = this.probePaneAddressability(2000);
       process.stderr.write(
-        `[tmux-pipe-backend] ${op} failed (pane ${alive ? 'ALIVE' : 'GONE'}): ${err?.message ?? err}\n`,
+        `[tmux-pipe-backend] ${op} failed (pane ${paneProbe.state.toUpperCase()}): ${err?.message ?? err}\n`,
       );
-      if (!alive) {
+      if (paneProbe.state === 'missing') {
         // Diagnostic: the pane is gone, so capture-pane can't read the final
         // screen. Instead dump the tail tmux already replicated over the pipe
         // — the CLI's real last stdout/stderr before it exited, which often
@@ -469,7 +485,7 @@ export class TmuxPipeBackend implements SessionBackend {
   private startLifecycleWatcher(): void {
     this.stopLifecycleWatcher();
     this.livenessGate.reset();
-    this.lifecycleTimer = setInterval(() => {
+    const poll = () => {
       if (this.exited) return;
       // The watched CLI pid (adopt mode) is a pure process.kill(pid,0) syscall —
       // it can only report ESRCH (gone) or EPERM (alive), never a transient
@@ -482,42 +498,70 @@ export class TmuxPipeBackend implements SessionBackend {
         this.handlePaneExit();
         return;
       }
-      this.recordPaneProbe(this.isPaneAddressable(2000));
-    }, 1000);
+      this.recordPaneProbe(this.probePaneAddressability(2000));
+      if (!this.exited) this.lifecycleTimer = setTimeout(poll, 1000);
+    };
+    this.lifecycleTimer = setTimeout(poll, tmuxLifecycleInitialDelayMs(this.paneTarget));
   }
 
-  /** Is the pane still addressable in tmux? This `display-message` IS the flaky,
-   *  fd/server-dependent signal (command timeout / busy server under EMFILE) —
-   *  which is why recordPaneProbe debounces it. `timeoutMs` lets the final
-   *  confirm wait longer than the 1s poll so an overloaded server can still
-   *  answer before we declare a live pane dead. */
-  private isPaneAddressable(timeoutMs: number): boolean {
+  /**
+   * Tri-state pane probe. A clean tmux rejection is `missing`; timeout, signal,
+   * EMFILE/ENFILE and spawn failures are `unknown`, because the shared server
+   * never answered. Collapsing those into false caused every worker to destroy
+   * a live bmx-* session when the default server had a short outage.
+   */
+  private probePaneAddressability(timeoutMs: number): { state: SessionProbe; reason?: string } {
     try {
-      const paneId = execSync(
-        `tmux display-message -p -t ${shellescape(this.paneTarget)} '#{pane_id}'`,
+      const paneId = execFileSync(
+        'tmux', ['display-message', '-p', '-t', this.paneTarget, '#{pane_id}'],
         { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: timeoutMs, env: tmuxEnv() },
       ).trim();
-      return paneId.length > 0;
-    } catch {
-      return false;
+      return { state: paneId.length > 0 ? 'exists' : 'missing', reason: paneId.length > 0 ? undefined : 'empty pane id' };
+    } catch (err: any) {
+      if (err && typeof err.status === 'number' && !err.signal) {
+        const stderr = (err.stderr?.toString?.() ?? '').trim();
+        return { state: 'missing', reason: stderr || `tmux display-message exited ${err.status}` };
+      }
+      const detail = (err?.stderr?.toString?.() ?? '').trim()
+        || err?.code
+        || err?.signal
+        || err?.message
+        || 'tmux probe got no answer';
+      return { state: 'unknown', reason: String(detail) };
     }
   }
 
   /**
-   * Debounce the (flaky) pane-addressability probe. Tearing down on the FIRST
-   * failed probe produced the spurious "⏏ /adopt的 CLI 会话已断开" — a tmux command
-   * timeout / busy server (e.g. under EMFILE fd pressure) momentarily fails the
-   * probe while the pane is still alive and the CLI still receiving messages.
-   * Only after ADOPT_LIVENESS_MAX_FAILURES consecutive failures, AND a final
-   * lenient-timeout re-probe that still fails, do we detach. Any success resets.
+   * Debounce authoritative pane-missing replies. Tearing down on the FIRST
+   * failed probe used to produce spurious disconnects; worse, timeout/EMFILE
+   * were collapsed into the same boolean false and could accumulate to the
+   * threshold. Unknown results now keep the session attached and reset the
+   * destructive streak. Only consecutive `missing` replies plus a final
+   * `missing` confirmation detach the observer. Any success resets.
    * (pid-death is handled decisively in the watcher — see startLifecycleWatcher.)
    */
-  private recordPaneProbe(alive: boolean): void {
+  private recordPaneProbe(probe: { state: SessionProbe; reason?: string }): void {
     if (this.exited) return;
-    if (!this.livenessGate.record(alive)) {
-      if (!alive) {
+    if (probe.state === 'unknown') {
+      // Unknown is not evidence of death. Reset the destructive streak so a
+      // timeout cannot combine with later unrelated misses, and rate-limit the
+      // diagnostic because every managed worker polls this shared server.
+      this.livenessGate.reset();
+      const now = Date.now();
+      if (now - this.lastUnknownProbeLogAt >= 30_000) {
+        this.lastUnknownProbeLogAt = now;
         process.stderr.write(
-          `[tmux-pipe-backend] adopt pane probe failed (${this.livenessGate.consecutiveFailures}/${ADOPT_LIVENESS_MAX_FAILURES}); retrying before teardown\n`,
+          `[tmux-pipe-backend] tmux pane probe unavailable; keeping ${this.ownsSession ? 'managed' : 'adopted'} session attached (${probe.reason ?? 'unknown error'})\n`,
+        );
+      }
+      return;
+    }
+
+    const alive = probe.state === 'exists';
+    if (!this.livenessGate.record(alive)) {
+      if (probe.state === 'missing') {
+        process.stderr.write(
+          `[tmux-pipe-backend] ${this.ownsSession ? 'managed' : 'adopted'} pane missing (${this.livenessGate.consecutiveFailures}/${ADOPT_LIVENESS_MAX_FAILURES}); retrying before teardown\n`,
         );
       }
       return;
@@ -525,13 +569,16 @@ export class TmuxPipeBackend implements SessionBackend {
     // Threshold reached — one final authoritative probe with a more lenient
     // timeout so a transiently overloaded tmux server gets a fair chance to
     // answer before we detach a pane that's actually still alive.
-    if (this.isPaneAddressable(3000)) {
+    const confirm = this.probePaneAddressability(3000);
+    if (confirm.state !== 'missing') {
       this.livenessGate.reset();
-      process.stderr.write('[tmux-pipe-backend] adopt pane recovered on final check; staying attached\n');
+      process.stderr.write(
+        `[tmux-pipe-backend] pane ${confirm.state === 'exists' ? 'recovered' : 'probe remained unavailable'} on final check; staying attached${confirm.reason ? ` (${confirm.reason})` : ''}\n`,
+      );
       return;
     }
     process.stderr.write(
-      `[tmux-pipe-backend] adopted pane gone after ${ADOPT_LIVENESS_MAX_FAILURES} consecutive probe failures; detaching observer\n`,
+      `[tmux-pipe-backend] ${this.ownsSession ? 'managed' : 'adopted'} pane gone after ${ADOPT_LIVENESS_MAX_FAILURES} consecutive authoritative misses; detaching observer\n`,
     );
     this.handlePaneExit();
   }
@@ -720,16 +767,7 @@ export class TmuxPipeBackend implements SessionBackend {
    *  used by callers to detect "user closed the pane while we were piping". */
   isPaneAlive(): boolean {
     if (this.exited) return false;
-    try {
-      execSync(`tmux display-message -p -t ${shellescape(this.paneTarget)} ''`, {
-        stdio: 'ignore',
-        timeout: 2000,
-        env: tmuxEnv(),
-      });
-      return true;
-    } catch {
-      return false;
-    }
+    return this.probePaneAddressability(2000).state === 'exists';
   }
 
   /** Unknown pid → pane-only liveness. EPERM still means the process exists. */

--- a/src/core/tmux-recovery.ts
+++ b/src/core/tmux-recovery.ts
@@ -1,0 +1,18 @@
+/**
+ * Deterministic restart jitter for tmux-backed workers.
+ *
+ * A shared tmux outage makes many worker processes emit `claude_exit` together.
+ * Delaying teardown by a target-specific amount prevents all of them from
+ * running kill-session / has-session / functional probes in the same instant.
+ * Deterministic jitter is preferable to Math.random here: the value is easy to
+ * unit-test and still distributes independent bmx-* session ids uniformly.
+ */
+export function tmuxRestartJitterMs(sessionId: string, restartOrdinal: number): number {
+  const input = `${sessionId}:${restartOrdinal}`;
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return 250 + ((hash >>> 0) % 1750);
+}

--- a/src/setup/ensure-tmux.ts
+++ b/src/setup/ensure-tmux.ts
@@ -20,7 +20,7 @@
  * /tmp/tmux-UID/default"), because `tmux -V` would pass but every subsequent
  * tmux command would fail. Functional probe + soft fallback fixes both.
  */
-import { execSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { detectPlatform, type PackageManager, type PlatformInfo } from './detect-platform.js';
@@ -31,11 +31,10 @@ export interface TmuxResult {
   /** True iff we ran an installer (vs. tmux was already present). */
   freshInstall: boolean;
   /**
-   * Whether the `tmux` binary is on PATH at all, INDEPENDENT of whether it can
-   * start a server. Lets the start-gate (PR#289 Option A) distinguish "tmux
-   * genuinely absent" (deterministic → safe to hard-fail daemon startup) from
-   * "binary present but the functional probe flaked" (must degrade gracefully
-   * via the per-session gate, never block startup — see
+   * False only when the version probe authoritatively returns ENOENT. True also
+   * covers timeout/EMFILE/EACCES, where presence cannot be disproved and startup
+   * must not hard-fail with a misleading PATH diagnosis. Lets the start-gate
+   * distinguish "tmux genuinely absent" from "probe got no answer" (see
    * shouldHardFailStartupForMissingTmux). Set on every return.
    */
   binaryPresent?: boolean;
@@ -47,17 +46,53 @@ export interface TmuxResult {
   manualCommand?: string;
 }
 
-function probeTmuxVersion(): string | undefined {
+type TmuxVersionProbe =
+  | { ok: true; version: string }
+  | { ok: false; reason: string; binaryPresent: boolean; retryable: boolean };
+
+export type TmuxFunctionalProbe =
+  | { ok: true; version: string }
+  | { ok: false; reason: string; binaryPresent: boolean; retryable: boolean; version?: string };
+
+function childFailureReason(command: string, failure: any, timeoutMs: number): string {
+  const nested = failure?.error;
+  const code = failure?.code ?? nested?.code;
+  const signal = failure?.signal ?? nested?.signal;
+  const stderr = (failure?.stderr?.toString?.() ?? nested?.stderr?.toString?.() ?? '').trim();
+
+  if (code === 'ENOENT') return `${command} 启动失败：找不到 tmux 可执行文件（ENOENT）`;
+  if (code === 'EACCES') return `${command} 启动失败：tmux 不可执行（EACCES）`;
+  if (code === 'EMFILE' || code === 'ENFILE') return `${command} 启动失败：文件描述符耗尽（${code}）`;
+  if (code === 'ETIMEDOUT' || signal || failure?.killed || nested?.killed) {
+    const detail = signal ? `，signal=${signal}` : '';
+    return `${command} 探测超时（${timeoutMs}ms${detail}）`;
+  }
+  if (stderr) return `${command} 失败：${stderr}`;
+  if (typeof failure?.status === 'number') return `${command} 失败（exit ${failure.status}）`;
+  const message = nested?.message ?? failure?.message;
+  return `${command} 启动/探测失败${message ? `：${message}` : ''}`;
+}
+
+function probeTmuxVersion(): TmuxVersionProbe {
   try {
-    const out = execSync('tmux -V', {
+    const out = execFileSync('tmux', ['-V'], {
       encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
+      stdio: ['ignore', 'pipe', 'pipe'],
       timeout: 3000,
       env: tmuxEnv(),
     });
-    return out.trim();
-  } catch {
-    return undefined;
+    return { ok: true, version: out.trim() };
+  } catch (err: any) {
+    const code = err?.code;
+    return {
+      ok: false,
+      reason: childFailureReason('tmux -V', err, 3000),
+      // Only ENOENT proves absence. Timeout/EMFILE/EACCES must not be turned
+      // into the old, misleading "not on PATH" diagnosis or a startup hard
+      // gate; they prove only that this particular probe got no answer.
+      binaryPresent: code !== 'ENOENT',
+      retryable: code !== 'ENOENT' && code !== 'EACCES',
+    };
   }
 }
 
@@ -140,9 +175,10 @@ function cleanupTmuxProbeSocket(sockName: string, env: NodeJS.ProcessEnv = proce
  * reason can surface in the bootstrap warning without spilling onto the
  * user's terminal.
  */
-export function probeTmuxFunctional(): { ok: true; version: string } | { ok: false; reason: string } {
-  const version = probeTmuxVersion();
-  if (!version) return { ok: false, reason: 'tmux 二进制不在 PATH 上' };
+export function probeTmuxFunctional(): TmuxFunctionalProbe {
+  const versionProbe = probeTmuxVersion();
+  if (!versionProbe.ok) return versionProbe;
+  const version = versionProbe.version;
   const sockName = `bmx-probe-${process.pid}-${Date.now()}`;
   // env: tmuxEnv() — without this, if the daemon inherited TMUX from a tmux
   // session that has since died, this probe would target the dead server
@@ -156,8 +192,13 @@ export function probeTmuxFunctional(): { ok: true; version: string } | { ok: fal
   if (run.status !== 0) {
     spawnSync('tmux', ['-L', sockName, 'kill-server'], { stdio: 'ignore', timeout: 3000, env: tmuxEnv() });
     cleanupTmuxProbeSocket(sockName);
-    const stderr = (run.stderr?.toString() ?? '').trim();
-    return { ok: false, reason: stderr || `tmux new-session 失败 (exit ${run.status})` };
+    return {
+      ok: false,
+      reason: childFailureReason('tmux new-session', run, 5000),
+      binaryPresent: true,
+      retryable: (run.error as NodeJS.ErrnoException | undefined)?.code !== 'EACCES',
+      version,
+    };
   }
   // Tear down the probe server and remove the socket file. Some platforms leave
   // bmx-probe-* sockets behind after the server exits; thousands of stale
@@ -165,6 +206,35 @@ export function probeTmuxFunctional(): { ok: true; version: string } | { ok: fal
   spawnSync('tmux', ['-L', sockName, 'kill-server'], { stdio: 'ignore', timeout: 3000, env: tmuxEnv() });
   cleanupTmuxProbeSocket(sockName);
   return { ok: true, version };
+}
+
+/**
+ * Worker-side gate probe with a short exponential backoff. A daemon restart can
+ * wake many worker processes at once; if the host is briefly under fd/process
+ * pressure, one failed spawn must not immediately become a user-facing hard
+ * gate. The retries stay local to the worker and callers should still stagger
+ * their restart path so all workers do not retry in lockstep.
+ */
+export function probeTmuxFunctionalWithRetry(opts: { attempts?: number; baseDelayMs?: number } = {}): TmuxFunctionalProbe {
+  const attempts = Math.max(1, Math.floor(opts.attempts ?? 3));
+  const baseDelayMs = Math.max(0, Math.floor(opts.baseDelayMs ?? 150));
+  let result = probeTmuxFunctional();
+  let completed = 1;
+
+  while (!result.ok && result.retryable && completed < attempts) {
+    const backoff = baseDelayMs * (2 ** (completed - 1));
+    const jitter = baseDelayMs > 0 ? Math.floor(Math.random() * baseDelayMs) : 0;
+    try {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, backoff + jitter);
+    } catch { /* SharedArrayBuffer unavailable: retry immediately */ }
+    result = probeTmuxFunctional();
+    completed += 1;
+  }
+
+  if (!result.ok && completed > 1) {
+    return { ...result, reason: `${result.reason}（已退避重试 ${completed - 1} 次）` };
+  }
+  return result;
 }
 
 /** Wrap a system command with the appropriate sudo prefix for the current
@@ -242,16 +312,18 @@ export async function ensureTmux(info?: PlatformInfo): Promise<TmuxResult> {
     return { installed: true, version: initialProbe.version, freshInstall: false, binaryPresent: true };
   }
 
-  // If the binary exists but the server can't start, no amount of
-  // `apt-get install tmux` will help — surface the underlying reason and
-  // let the caller fall back to PTY backend.
-  const versionPresent = probeTmuxVersion();
-  if (versionPresent) {
+  // Only an authoritative ENOENT should enter the installer path. A timeout,
+  // EMFILE or permission failure is not evidence that PATH is missing; surface
+  // the real probe reason and let the per-session gate retry later.
+  if (initialProbe.binaryPresent) {
     return {
       installed: false,
       freshInstall: false,
       binaryPresent: true,
-      reason: `${versionPresent} 已安装但启动 server 失败：${initialProbe.reason}`,
+      version: initialProbe.version,
+      reason: initialProbe.version
+        ? `${initialProbe.version} 已安装但启动 server 失败：${initialProbe.reason}`
+        : initialProbe.reason,
       manualCommand: '排查 ~/.tmux.conf / /tmp 权限 / libevent 依赖后再试',
     };
   }
@@ -295,13 +367,14 @@ export async function ensureTmux(info?: PlatformInfo): Promise<TmuxResult> {
   if (!platform.hasTty && !platform.isRoot && !platform.passwordlessSudo && platform.os === 'linux') {
     reasonLines.push('提示：当前不是交互式 TTY 且 sudo 需要密码，systemd/pm2 自启下无法弹密码 — 先在 shell 跑一次 `botmux start`，或配置 NOPASSWD sudoers。');
   }
+  const finalVersionProbe = probeTmuxVersion();
   return {
     installed: false,
     freshInstall: false,
     // An install attempt may have landed the binary even though the server
     // probe still fails — re-check PATH so the start-gate doesn't treat a
     // present-but-broken tmux as "genuinely absent".
-    binaryPresent: !!probeTmuxVersion(),
+    binaryPresent: finalVersionProbe.ok || finalVersionProbe.binaryPresent,
     reason: reasonLines.join('\n'),
     manualCommand: manual,
   };

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -96,7 +96,8 @@ import { isObserveBackend, type ObserveBackend } from './adapters/backend/types.
 import { selectSessionBackend, decideBackendGate, backendGateUserMessage } from './adapters/backend/session-backend-selector.js';
 import { prepareSandbox, attachSandboxOutbox, startOutboxWatcher, sandboxEnabled, sandboxedClaudeDataDir } from './adapters/backend/sandbox.js';
 import type { BackendType, SessionBackend } from './adapters/backend/types.js';
-import { tmuxEnv, probeTmuxFunctional } from './setup/ensure-tmux.js';
+import { tmuxEnv, probeTmuxFunctionalWithRetry } from './setup/ensure-tmux.js';
+import { tmuxRestartJitterMs } from './core/tmux-recovery.js';
 import { IdleDetector } from './utils/idle-detector.js';
 import { ScreenAnalyzer } from './utils/screen-analyzer.js';
 import { captureToPng } from './utils/screenshot-renderer.js';
@@ -131,6 +132,7 @@ let sandboxTeardownDone = false;                     // guards the exit-time bes
  *  (non-forced) config, so healthy restarts (e.g. user `/restart`) are
  *  unaffected. */
 let consecutiveInWorkerRestarts = 0;
+let tmuxRestartTimer: NodeJS.Timeout | null = null;
 /** Guard: user_notify for "resume → fresh fallback" is sent once per worker
  *  lifecycle so a 4× crash loop does not spam the Lark thread with 4 copies
  *  of the same warning. */
@@ -4140,7 +4142,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     if (effectiveBackend === 'tmux') {
       hasExistingSession = TmuxBackend.hasSession(TmuxBackend.sessionName(cfg.sessionId));
       if (!hasExistingSession) {
-        const probe = probeTmuxFunctional();
+        const probe = probeTmuxFunctionalWithRetry();
         available = probe.ok;
         if (!probe.ok) reason = probe.reason;
       }
@@ -6083,16 +6085,27 @@ process.on('message', async (raw: unknown) => {
       // process would never actually restart. destroySession() tears the session
       // down so the respawn starts a fresh CLI. (PTY has no destroySession, so
       // the ?. no-ops and killCli()'s kill() does the teardown.)
-      backend?.destroySession?.();
-      killCli();
-      awaitingFirstPrompt = true;
-      setTimeout(() => {
-        if (lastInitConfig) {
-          startScreenUpdates();
-          startScreenAnalyzer();
-          spawnCli({ ...lastInitConfig, resume: true, prompt: '' });
-        }
-      }, 500);
+      const restart = () => {
+        tmuxRestartTimer = null;
+        backend?.destroySession?.();
+        killCli();
+        awaitingFirstPrompt = true;
+        setTimeout(() => {
+          if (lastInitConfig) {
+            startScreenUpdates();
+            startScreenAnalyzer();
+            spawnCli({ ...lastInitConfig, resume: true, prompt: '' });
+          }
+        }, 500);
+      };
+      if (effectiveBackendType === 'tmux') {
+        const delayMs = tmuxRestartJitterMs(lastInitConfig?.sessionId ?? '', consecutiveInWorkerRestarts);
+        log(`Staggering tmux teardown/restart by ${delayMs}ms to avoid shared-server probe storms`);
+        if (tmuxRestartTimer) clearTimeout(tmuxRestartTimer);
+        tmuxRestartTimer = setTimeout(restart, delayMs);
+      } else {
+        restart();
+      }
       break;
     }
 
@@ -6219,6 +6232,10 @@ process.on('message', async (raw: unknown) => {
 // ─── Cleanup ─────────────────────────────────────────────────────────────────
 
 function cleanup(): void {
+  if (tmuxRestartTimer) {
+    clearTimeout(tmuxRestartTimer);
+    tmuxRestartTimer = null;
+  }
   for (const [, cp] of clientPtys) {
     try { cp.kill(); } catch { /* already dead */ }
   }

--- a/test/tmux-functional-probe.test.ts
+++ b/test/tmux-functional-probe.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+  spawnSync: vi.fn(),
+}));
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  probeTmuxFunctional,
+  probeTmuxFunctionalWithRetry,
+} from '../src/setup/ensure-tmux.js';
+
+const mockedExecFileSync = vi.mocked(execFileSync);
+const mockedSpawnSync = vi.mocked(spawnSync);
+
+beforeEach(() => {
+  mockedExecFileSync.mockReset();
+  mockedSpawnSync.mockReset();
+});
+
+describe('tmux functional probe diagnostics', () => {
+  it('reports ENOENT as an authoritative missing binary', () => {
+    mockedExecFileSync.mockImplementation(() => {
+      throw Object.assign(new Error('spawn tmux ENOENT'), { code: 'ENOENT' });
+    });
+
+    const result = probeTmuxFunctional();
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.binaryPresent).toBe(false);
+    expect(result.retryable).toBe(false);
+    expect(result.reason).toContain('ENOENT');
+  });
+
+  it('preserves timeout details instead of claiming tmux is missing from PATH', () => {
+    mockedExecFileSync.mockImplementation(() => {
+      throw Object.assign(new Error('timed out'), {
+        code: 'ETIMEDOUT', signal: 'SIGTERM', killed: true,
+      });
+    });
+
+    const result = probeTmuxFunctional();
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.binaryPresent).toBe(true);
+    expect(result.retryable).toBe(true);
+    expect(result.reason).toContain('超时');
+    expect(result.reason).not.toContain('不在 PATH');
+  });
+
+  it('surfaces functional-probe stderr', () => {
+    mockedExecFileSync.mockReturnValue('tmux 3.3a\n' as any);
+    mockedSpawnSync.mockImplementation((_bin: any, args: any) =>
+      (args as string[]).includes('new-session')
+        ? ({ status: 1, signal: null, stderr: Buffer.from('server temporarily busy') } as any)
+        : ({ status: 0 } as any));
+
+    const result = probeTmuxFunctional();
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.version).toBe('tmux 3.3a');
+    expect(result.reason).toContain('server temporarily busy');
+  });
+
+  it('backs off and retries transient EMFILE failures before gating', () => {
+    mockedExecFileSync.mockReturnValue('tmux 3.3a\n' as any);
+    let newSessionAttempts = 0;
+    mockedSpawnSync.mockImplementation((_bin: any, args: any) => {
+      if (!(args as string[]).includes('new-session')) return { status: 0 } as any;
+      newSessionAttempts += 1;
+      if (newSessionAttempts < 3) {
+        return { status: null, signal: null, error: Object.assign(new Error('EMFILE'), { code: 'EMFILE' }) } as any;
+      }
+      return { status: 0, signal: null, stderr: Buffer.alloc(0) } as any;
+    });
+
+    const result = probeTmuxFunctionalWithRetry({ attempts: 3, baseDelayMs: 0 });
+    expect(result).toEqual({ ok: true, version: 'tmux 3.3a' });
+    expect(newSessionAttempts).toBe(3);
+  });
+});

--- a/test/tmux-pipe-backend.test.ts
+++ b/test/tmux-pipe-backend.test.ts
@@ -39,7 +39,11 @@ vi.mock('node:fs', async () => {
 
 import { execSync, execFileSync, spawnSync } from 'node:child_process';
 import { unlinkSync, createReadStream } from 'node:fs';
-import { TmuxPipeBackend, normaliseCaptureLineEndings } from '../src/adapters/backend/tmux-pipe-backend.js';
+import {
+  TmuxPipeBackend,
+  normaliseCaptureLineEndings,
+  tmuxLifecycleInitialDelayMs,
+} from '../src/adapters/backend/tmux-pipe-backend.js';
 
 const mockedExecSync = vi.mocked(execSync);
 const mockedExecFileSync = vi.mocked(execFileSync);
@@ -417,10 +421,11 @@ describe('TmuxPipeBackend managed session', () => {
 });
 
 describe('TmuxPipeBackend lifecycle watcher', () => {
-  const PANE_OK = (cmd: any) =>
-    (String(cmd).includes('display-message') && String(cmd).includes('#{pane_id}')) ? '%1\n' as any : '' as any;
-  const PANE_GONE = (cmd: any) => {
-    if (String(cmd).includes('display-message') && String(cmd).includes('#{pane_id}')) throw new Error('no pane');
+  const isPaneProbe = (args: any) =>
+    Array.isArray(args) && args.includes('display-message') && args.includes('#{pane_id}');
+  const PANE_OK = (_bin: any, args: any) => isPaneProbe(args) ? '%1\n' as any : '' as any;
+  const PANE_GONE = (_bin: any, args: any) => {
+    if (isPaneProbe(args)) throw Object.assign(new Error('no pane'), { status: 1, signal: null });
     return '' as any;
   };
 
@@ -428,15 +433,15 @@ describe('TmuxPipeBackend lifecycle watcher', () => {
     const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     vi.useFakeTimers();
     try {
-      mockedExecSync.mockImplementation(PANE_OK);
+      mockedExecFileSync.mockImplementation(PANE_OK);
       const be = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
       const exits: Array<[number | null, string | null]> = [];
       be.onExit((code, signal) => exits.push([code, signal]));
       be.spawn('', [], spawnOpts());
-      mockedExecSync.mockImplementation(PANE_GONE);
+      mockedExecFileSync.mockImplementation(PANE_GONE);
 
       // Two failed probes are NOT enough — the debounce gate must ride them out.
-      vi.advanceTimersByTime(2_000);
+      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned') + 1_000);
       expect(exits).toEqual([]);
 
       // 3rd consecutive failure trips the gate; the final lenient confirm also
@@ -453,15 +458,14 @@ describe('TmuxPipeBackend lifecycle watcher', () => {
     const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     vi.useFakeTimers();
     try {
-      mockedExecSync.mockImplementation(PANE_OK);
+      mockedExecFileSync.mockImplementation(PANE_OK);
       const be = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
       const exits: Array<[number | null, string | null]> = [];
       be.onExit((code, signal) => exits.push([code, signal]));
       be.spawn('', [], spawnOpts());
-      mockedExecSync.mockImplementation((cmd: any) =>
-        (String(cmd).includes('display-message') && String(cmd).includes('#{pane_id}')) ? '\n' as any : '' as any);
+      mockedExecFileSync.mockImplementation((_bin: any, args: any) => isPaneProbe(args) ? '\n' as any : '' as any);
 
-      vi.advanceTimersByTime(2_000);
+      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned') + 1_000);
       expect(exits).toEqual([]);
       vi.advanceTimersByTime(1_000);
       expect(exits).toEqual([[1, null]]);
@@ -475,16 +479,16 @@ describe('TmuxPipeBackend lifecycle watcher', () => {
     const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     vi.useFakeTimers();
     try {
-      mockedExecSync.mockImplementation(PANE_OK);
+      mockedExecFileSync.mockImplementation(PANE_OK);
       const be = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
       const exits: Array<[number | null, string | null]> = [];
       be.onExit((code, signal) => exits.push([code, signal]));
       be.spawn('', [], spawnOpts());
 
       // One failure, then sustained success — the false signal must be ignored.
-      mockedExecSync.mockImplementation(PANE_GONE);
-      vi.advanceTimersByTime(1_000);
-      mockedExecSync.mockImplementation(PANE_OK);
+      mockedExecFileSync.mockImplementation(PANE_GONE);
+      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned'));
+      mockedExecFileSync.mockImplementation(PANE_OK);
       vi.advanceTimersByTime(10_000);
 
       expect(exits).toEqual([]);
@@ -498,17 +502,17 @@ describe('TmuxPipeBackend lifecycle watcher', () => {
     const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     vi.useFakeTimers();
     try {
-      mockedExecSync.mockImplementation(PANE_OK);
+      mockedExecFileSync.mockImplementation(PANE_OK);
       const be = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
       const exits: Array<[number | null, string | null]> = [];
       be.onExit((code, signal) => exits.push([code, signal]));
       be.spawn('', [], spawnOpts());
 
-      mockedExecSync.mockImplementation(PANE_GONE);
-      vi.advanceTimersByTime(2_000);          // 2 failures (gate at 2)
-      mockedExecSync.mockImplementation(PANE_OK);
+      mockedExecFileSync.mockImplementation(PANE_GONE);
+      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned') + 1_000); // 2 failures
+      mockedExecFileSync.mockImplementation(PANE_OK);
       vi.advanceTimersByTime(1_000);          // success → reset
-      mockedExecSync.mockImplementation(PANE_GONE);
+      mockedExecFileSync.mockImplementation(PANE_GONE);
       vi.advanceTimersByTime(2_000);          // 2 more failures (gate back to 2)
 
       expect(exits).toEqual([]);              // never reached 3 consecutive
@@ -518,18 +522,17 @@ describe('TmuxPipeBackend lifecycle watcher', () => {
     }
   });
 
-  it('stays attached when the final lenient confirm probe succeeds (overload, not death)', () => {
+  it('stays attached when the final lenient confirm probe succeeds', () => {
     const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     vi.useFakeTimers();
     try {
       let paneIdCalls = 0;
-      mockedExecSync.mockImplementation((cmd: any) => {
-        const s = String(cmd);
-        if (s.includes('display-message') && s.includes('#{pane_id}')) {
+      mockedExecFileSync.mockImplementation((_bin: any, args: any) => {
+        if (isPaneProbe(args)) {
           paneIdCalls += 1;
-          // The three 1s-poll probes (timeout 2000) all time out under load…
-          if (paneIdCalls <= 3) throw new Error('server overloaded');
-          // …but the final lenient-timeout confirm gets an answer ⇒ still alive.
+          if (paneIdCalls <= 3) {
+            throw Object.assign(new Error('no pane'), { status: 1, signal: null });
+          }
           return '%1\n' as any;
         }
         return '' as any;
@@ -539,9 +542,33 @@ describe('TmuxPipeBackend lifecycle watcher', () => {
       be.onExit((code, signal) => exits.push([code, signal]));
       be.spawn('', [], spawnOpts());
 
-      vi.advanceTimersByTime(3_000);          // 3 failed polls + 1 successful confirm
+      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned') + 2_000);
       expect(exits).toEqual([]);              // recovered on the confirm, no detach
       expect(paneIdCalls).toBe(4);
+    } finally {
+      vi.useRealTimers();
+      errSpy.mockRestore();
+    }
+  });
+
+  it('never detaches when tmux probes time out or fail to spawn (unknown, not missing)', () => {
+    const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.useFakeTimers();
+    try {
+      const be = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
+      const exits: Array<[number | null, string | null]> = [];
+      be.onExit((code, signal) => exits.push([code, signal]));
+      be.spawn('', [], spawnOpts());
+      mockedExecFileSync.mockImplementation((_bin: any, args: any) => {
+        if (isPaneProbe(args)) {
+          throw Object.assign(new Error('spawn tmux EMFILE'), { code: 'EMFILE', status: null, signal: null });
+        }
+        return '' as any;
+      });
+
+      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned') + 10_000);
+      expect(exits).toEqual([]);
+      expect(errSpy.mock.calls.some(call => String(call[0]).includes('keeping managed session attached'))).toBe(true);
     } finally {
       vi.useRealTimers();
       errSpy.mockRestore();
@@ -563,14 +590,14 @@ describe('TmuxPipeBackend lifecycle watcher', () => {
     }) as typeof process.kill);
     const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     try {
-      mockedExecSync.mockImplementation(PANE_OK);
+      mockedExecFileSync.mockImplementation(PANE_OK);
       const be = new TmuxPipeBackend('0:2.0', { cliPid: 4242 });
       const exits: Array<[number | null, string | null]> = [];
       be.onExit((code, signal) => exits.push([code, signal]));
       be.spawn('', [], spawnOpts());
       mockedExecSync.mockClear();
 
-      vi.advanceTimersByTime(1_000);          // first tick: pid gone ⇒ detach now
+      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('0:2.0'));
       expect(exits).toEqual([[1, null]]);
 
       const cancelCall = mockedExecSync.mock.calls
@@ -590,24 +617,23 @@ describe('TmuxPipeBackend lifecycle watcher', () => {
     const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     vi.useFakeTimers();
     try {
-      mockedExecSync.mockImplementation(PANE_OK);
+      mockedExecFileSync.mockImplementation(PANE_OK);
       const be = new TmuxPipeBackend('bmx-owned', { ownsSession: true });
       const exits: Array<[number | null, string | null]> = [];
       be.onExit((code, signal) => exits.push([code, signal]));
       be.spawn('', [], spawnOpts());
 
-      mockedExecSync.mockImplementation(PANE_GONE);
-      vi.advanceTimersByTime(2_000);          // gate at 2 — no teardown yet
+      mockedExecFileSync.mockImplementation(PANE_GONE);
+      vi.advanceTimersByTime(tmuxLifecycleInitialDelayMs('bmx-owned') + 1_000);
       expect(exits).toEqual([]);
 
       be.kill();                              // explicit close mid-streak
-      mockedExecSync.mockClear();
+      mockedExecFileSync.mockClear();
       vi.advanceTimersByTime(10_000);         // watcher must be stopped
 
       expect(exits).toEqual([]);              // kill() does not fire onExit
-      const probeAfterKill = mockedExecSync.mock.calls
-        .map(c => String(c[0]))
-        .some(c => c.includes('display-message'));
+      const probeAfterKill = mockedExecFileSync.mock.calls
+        .some(c => (c[1] as string[]).includes('display-message'));
       expect(probeAfterKill).toBe(false);     // no further probing after kill
     } finally {
       vi.useRealTimers();
@@ -649,10 +675,28 @@ describe('TmuxPipeBackend send failure handling', () => {
 
     mockedExecFileSync.mockImplementation((_bin: any, args: any) => {
       if ((args as string[]).includes('send-keys')) throw new Error('transient tmux error');
+      if ((args as string[]).includes('#{pane_id}')) return '%1\n' as any;
       return '' as any;
     });
     // Liveness probe succeeds ⇒ pane ALIVE ⇒ transient error, just dropped.
-    mockedExecSync.mockReturnValue('' as any);
+
+    expect(() => be.sendText('hi')).not.toThrow();
+    expect(exits).toEqual([]);
+  });
+
+  it('drops the write without teardown when the follow-up pane probe is unknown', () => {
+    const be = new TmuxPipeBackend('bmx-busy', { ownsSession: true });
+    const exits: Array<[number | null, string | null]> = [];
+    be.onExit((c, s) => exits.push([c, s]));
+    be.spawn('', [], spawnOpts());
+
+    mockedExecFileSync.mockImplementation((_bin: any, args: any) => {
+      if ((args as string[]).includes('send-keys')) throw new Error('tmux write timed out');
+      if ((args as string[]).includes('#{pane_id}')) {
+        throw Object.assign(new Error('spawn tmux EMFILE'), { code: 'EMFILE', status: null, signal: null });
+      }
+      return '' as any;
+    });
 
     expect(() => be.sendText('hi')).not.toThrow();
     expect(exits).toEqual([]);

--- a/test/tmux-probe.test.ts
+++ b/test/tmux-probe.test.ts
@@ -104,3 +104,15 @@ describe('TmuxBackend.serverState', () => {
     expect(TmuxBackend.serverState()).toBe('unknown');
   });
 });
+
+describe('TmuxBackend.killSession', () => {
+  it('bounds teardown against a wedged shared server', () => {
+    mockedExecFileSync.mockImplementation((() => '') as any);
+    TmuxBackend.killSession(NAME);
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'tmux',
+      ['kill-session', '-t', NAME],
+      expect.objectContaining({ timeout: 3000 }),
+    );
+  });
+});

--- a/test/tmux-recovery.test.ts
+++ b/test/tmux-recovery.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { tmuxRestartJitterMs } from '../src/core/tmux-recovery.js';
+import { tmuxLifecycleInitialDelayMs } from '../src/adapters/backend/tmux-pipe-backend.js';
+
+describe('tmux restart jitter', () => {
+  it('is deterministic and bounded', () => {
+    const delay = tmuxRestartJitterMs('session-a', 1);
+    expect(tmuxRestartJitterMs('session-a', 1)).toBe(delay);
+    expect(delay).toBeGreaterThanOrEqual(250);
+    expect(delay).toBeLessThan(2000);
+  });
+
+  it('spreads independent sessions across the restart window', () => {
+    const delays = new Set(
+      Array.from({ length: 32 }, (_, i) => tmuxRestartJitterMs(`session-${i}`, 1)),
+    );
+    expect(delays.size).toBeGreaterThan(24);
+  });
+});
+
+describe('tmux lifecycle probe staggering', () => {
+  it('keeps the first probe bounded and distributes restored sessions', () => {
+    const delays = Array.from(
+      { length: 32 },
+      (_, i) => tmuxLifecycleInitialDelayMs(`bmx-${i.toString(16).padStart(8, '0')}`),
+    );
+    expect(Math.min(...delays)).toBeGreaterThanOrEqual(1000);
+    expect(Math.max(...delays)).toBeLessThan(1750);
+    expect(new Set(delays).size).toBeGreaterThan(24);
+  });
+});


### PR DESCRIPTION
## 背景

生产日志中出现过共享 tmux server 瞬时不可用后，多批 managed `bmx-*` worker 同时经历：

`pane probe failed → pane gone → claude_exit → auto-restart`

其中 2026-06-24 的一轮在不到 1 秒内触发约 30 个 worker 重启；2026-07-06 还记录到约 30 个 worker 在同一毫秒发起首轮探针。

代码核对后确认两个核心问题：

1. `TmuxPipeBackend` 把 `display-message` 的 timeout、signal、EMFILE/ENFILE、spawn failure 与“pane 明确不存在”都压成 boolean `false`，累计 3 次后会错误 teardown 活会话；send 失败后的二次判活也有相同问题。
2. `tmux -V` 的所有异常都被统一描述为“tmux 二进制不在 PATH 上”，丢失真实 stderr / error code / timeout 信息。

补充：功能探针使用独立的 `-L bmx-probe-*` socket，不直接访问默认 server；但多 worker 同时 fork/探测会继续放大宿主机 fd/进程压力。

## 改动

- 将 tmux pane 判活改为 `exists / missing / unknown` 三态：
  - timeout、signal、EMFILE/ENFILE、spawn failure → `unknown`，保持会话并重置 destructive streak；
  - 只有连续 3 次 authoritative `missing`，且最终宽限探针仍为 `missing`，才 teardown；
  - send-keys / paste-buffer 失败后的二次判活复用同一三态语义。
- managed/adopt 日志文案分开；unknown 原因限频输出，避免共享故障时刷屏。
- daemon 恢复后，按 session target 的稳定 hash 将首轮 lifecycle probe 错开到 1.0–1.749 秒。
- tmux auto-restart 在 `destroySession()` 前按 session 稳定错开 250–1999ms；`kill-session` 增加 3 秒超时。
- 将版本探针改为直接执行 `tmux -V` 并保留 ENOENT / EACCES / EMFILE / timeout / signal / exit / stderr；只有 ENOENT 被视作权威缺失。
- worker gate 在 transient failure 时做最多 3 次短指数退避重试，最终卡片展示真实原因。
- 增加功能探针诊断、三态判活、send failure unknown、probe/restart 错峰和 teardown timeout 回归测试。

## 影响面

- **CLI**：所有 CLI 共享的 tmux managed backend 都受益；未改 CLI adapter 层。额外用 Herdr 回归确认公共 worker 重启路径未破坏其它 CLI/backend。
- **会话类型**：覆盖普通 managed tmux 与 tmux adopt；adopt 的 CLI pid syscall 判活仍保持立即生效，不被 debounce。
- **后端**：PTY、Herdr、Zellij 的判活逻辑未改；重启 jitter 仅在 `effectiveBackendType === 'tmux'` 时启用。
- **平台**：使用 Node/execFileSync/定时器与稳定整数 hash，无 macOS/Linux 分支；真实 Linux tmux e2e 已通过。
- **运维**：不自动轮换长寿命默认 tmux server，避免无条件中断现有会话。

## 实际验证

- `pnpm exec tsc --noEmit`：通过
- tmux/后端定向 unit：12 files，128/128 通过
- `HOME=<isolated> BOTMUX_SCHEDULE_TIMEZONE=America/Los_Angeles pnpm test`：465 files，7639/7639 通过
- `pnpm build`：通过
- `pnpm exec vitest run --project e2e test/tmux-backend.e2e.ts`：4/4 通过
- live checkout 已完成 build + daemon restart：42 个 PM2 服务 online、152 个 worker 恢复，启动后未观察到新的 pane-missing/backend-gate/auto-restart 异常。
