### PR TITLE
fix(ask): 文字作答时在 stderr 提示答案去向，消除静默的空 stdout

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5957,7 +5957,7 @@ async function cmdAsk(sub: string, rest: string[]): Promise<void> {
   const { findMissingAskEnv, parseAskOptions, parseAskTimeoutSeconds, AskArgsError } =
     await import('./core/ask-args.js');
   type AskJsonOutput = import('./core/ask-types.js').AskJsonOutput;
-  const { toLegacySelected } = await import('./core/ask-types.js');
+  const { toLegacySelected, isCustomReply } = await import('./core/ask-types.js');
 
   const missing = findMissingAskEnv(process.env);
   if (missing) {
@@ -6027,7 +6027,17 @@ async function cmdAsk(sub: string, rest: string[]): Promise<void> {
     };
     process.stdout.write(JSON.stringify(out) + '\n');
   } else if (result.kind === 'answered') {
-    // 非 JSON 模式：输出 selected key（单问单选），多选/多问输出空字符串
+    // 非 JSON 模式：输出 selected key（单问单选），多选/多问输出空字符串。
+    //
+    // 用户以文字作答时同样落到空字符串，与多选/多问的降级值无法区分，且 exit 0
+    // ——调用方会静默走进空分支。comment 可能含换行，塞进「一行一个 key」的
+    // stdout 契约并不安全，因此 stdout 保持不变，改由 stderr 指明答案去向。
+    if (isCustomReply(result)) {
+      console.error(
+        'botmux ask: 用户以文字作答，未点选任何选项；stdout 留空（stdout 只承载 option key）。' +
+          ' 用 `--json` 读 comment 字段取回原文。',
+      );
+    }
     process.stdout.write((selected ?? '') + '\n');
   }
 

--- a/src/core/ask-types.ts
+++ b/src/core/ask-types.ts
@@ -152,6 +152,15 @@ export function toLegacySelected(result: AskResult): string | null {
   return null;
 }
 
+/** 用户以文字作答（`submitCustomReply`）而非点选按钮：各问 `answers` 为空数组、
+ *  `comment` 携带原文。此时 `toLegacySelected` 返回 null，非 JSON 模式的 stdout
+ *  与"多选/多问"的降级空值无法区分——调用方据此在 stderr 提示答案去向。 */
+export function isCustomReply(result: AskResult): boolean {
+  if (result.kind !== 'answered') return false;
+  if (result.comment === null) return false;
+  return result.answers.every((keys) => keys.length === 0);
+}
+
 /** Card dispatcher contract. The im/lark side registers a dispatcher via
  *  `setCardDispatcher`; the broker is otherwise IM-agnostic. */
 export interface AskCardDispatcher {

--- a/test/ask-cli.test.ts
+++ b/test/ask-cli.test.ts
@@ -1,0 +1,93 @@
+/**
+ * CLI boundary regression for `botmux ask` custom replies.
+ *
+ * Runs the real cmdAsk dispatch in a subprocess against a tiny fake daemon so
+ * stdout, stderr, and the process exit code are covered together. Using the
+ * source entry through tsx keeps this unit test independent of a prior build.
+ */
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const CLI_PATH = join(__dirname, '..', 'src', 'cli.ts');
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function runAsk(dataDir: string): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ['--import', 'tsx', CLI_PATH, 'ask', 'buttons', '--options', 'yes,no', '请作答'],
+      {
+        env: {
+          ...process.env,
+          SESSION_DATA_DIR: dataDir,
+          BOTMUX_SESSION_ID: 'sess_test',
+          BOTMUX_CHAT_ID: 'oc_test',
+          BOTMUX_LARK_APP_ID: 'cli_test',
+          BOTMUX_ROOT_MESSAGE_ID: 'om_test',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => { stdout += chunk; });
+    child.stderr.on('data', (chunk: string) => { stderr += chunk; });
+    child.once('error', reject);
+    child.once('close', (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+describe('botmux ask — CLI boundary', () => {
+  it('文字作答保持空 stdout / exit 0，并在 stderr 指明用 --json 读取 comment', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-ask-cli-'));
+    tempDirs.push(dataDir);
+
+    const server = createServer((req, res) => {
+      req.resume();
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        kind: 'answered',
+        answers: [[]],
+        by: 'ou_test',
+        comment: '我想先灰度 10% 再全量',
+        timedOut: false,
+      }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+    try {
+      const port = (server.address() as AddressInfo).port;
+      const registryDir = join(dataDir, 'dashboard-daemons');
+      mkdirSync(registryDir, { recursive: true });
+      writeFileSync(
+        join(registryDir, 'cli_test.json'),
+        JSON.stringify({ larkAppId: 'cli_test', ipcPort: port, lastHeartbeat: Date.now() }),
+      );
+
+      const result = await runAsk(dataDir);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe('\n');
+      expect(result.stderr).toContain('用户以文字作答');
+      expect(result.stderr).toContain('--json');
+      expect(result.stderr).toContain('comment');
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => err ? reject(err) : resolve());
+      });
+    }
+  });
+});

--- a/test/ask-types-shape.test.ts
+++ b/test/ask-types-shape.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { toLegacySelected, type AskQuestion, type AskResult } from '../src/core/ask-types.js';
+import { isCustomReply, toLegacySelected, type AskQuestion, type AskResult } from '../src/core/ask-types.js';
 
 describe('ask-types 多问多选模型', () => {
   it('toLegacySelected: 单问单选答案映射回旧 selected 字符串', () => {
@@ -31,5 +31,44 @@ describe('ask-types 多问多选模型', () => {
     };
     expect(custom.comment).toBe('我自己的答案');
     expect(toLegacySelected(custom)).toBeNull();
+  });
+
+  it('isCustomReply: 无选中项且 comment 非 null → 文字作答', () => {
+    const custom: AskResult = {
+      kind: 'answered', answers: [[]], by: 'ou_x', comment: '我发个多行消息试试\n这是第二行', timedOut: false,
+    };
+    expect(isCustomReply(custom)).toBe(true);
+  });
+
+  it('isCustomReply: 多问全部未选中同样成立', () => {
+    const custom: AskResult = {
+      kind: 'answered', answers: [[], []], by: 'ou_x', comment: '都不选', timedOut: false,
+    };
+    expect(isCustomReply(custom)).toBe(true);
+  });
+
+  it('isCustomReply: 按钮路径（有选中项，comment 为 null）→ false', () => {
+    const clicked: AskResult = {
+      kind: 'answered', answers: [['yes']], by: 'ou_x', comment: null, timedOut: false,
+    };
+    expect(isCustomReply(clicked)).toBe(false);
+  });
+
+  it('isCustomReply: 有选中项时即使带 comment 也不算文字作答', () => {
+    const mixed: AskResult = {
+      kind: 'answered', answers: [['yes']], by: 'ou_x', comment: '附注', timedOut: false,
+    };
+    expect(isCustomReply(mixed)).toBe(false);
+  });
+
+  it('isCustomReply: 非 answered 结果一律 false', () => {
+    const timedOut: AskResult = {
+      kind: 'timedOut', selected: null, by: null, comment: null, timedOut: true,
+    };
+    const invalidated: AskResult = {
+      kind: 'invalidated', reason: 'daemon restart', selected: null, by: null, comment: null, timedOut: false,
+    };
+    expect(isCustomReply(timedOut)).toBe(false);
+    expect(isCustomReply(invalidated)).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #434

## 改了什么

用户在话题里**打字作答**（而非点选按钮）时，`botmux ask`（非 `--json`）的 stdout 落到空字符串、exit code 为 0、stderr 一片安静，与「多选/多问」的降级空值**无法区分**。调用方既不知道用户其实已作答，也不知道原文在 `comment` 里，shell 分支会静默走进兜底。

本 PR **不改 stdout、不改 exit code**，只在检测到文字作答时往 stderr 打一行提示：

- `src/core/ask-types.ts` — 新增纯函数 `isCustomReply()`，与既有 `toLegacySelected` 同款风格，判定「各问均无选中项 + `comment` 非 null」
- `src/cli.ts` — `cmdAsk` 的非 JSON 分支调用它，`console.error` 指明用 `--json` 读 `comment` 取回原文
- `test/ask-types-shape.test.ts` — 补 5 条用例

## 为什么这么改

三点前提先确认清楚，避免改错地方：

1. daemon 把 pending ask 期间的话题消息吞成 custom reply 是**有意设计**（`daemon.ts` 注释：「待回答 ask 会把它当答案吞掉」），不该动。
2. `submitCustomReply` 让 `answers` 各问为空数组、`toLegacySelected` 因此返回 `null`，同样是**设计**，`test/ask-types-shape.test.ts` 已有用例锁定。
3. `ask-types.ts` 注释写明 comment 回落是 **hook adapter `formatAnswer`** 的职责，不是 `cmdAsk` 的。

所以真正的缺口只在可观测性：`answered` + 空 stdout + exit 0 + 静默 stderr，让文字作答成为一个不可观测的降级。

**为什么不把 comment 回落进 stdout**：`comment` 可以是多行的（实测回复含换行与空行），而 `ask` 的 stdout 约定是「一行一个 option key」，供 `$(...)` 与字符串比较使用。灌进去会撕碎该约定，且失败得比现状更隐蔽。故只走 stderr。

## 影响面

- `isCustomReply()` 为新增导出，无既有调用方，无副作用
- `cmdAsk` 仅在文字作答分支多一行 stderr；**stdout 与 exit code 零变更**，现有脚本不受影响
- 未触及 CLI adapter、backend、IM 层；`ask-hook/*` 的 `formatAnswer` 回落路径未改动
- `--json` 输出结构不变

## 实际测试验证

```console
$ ./node_modules/.bin/tsc --noEmit
TSC_EXIT=0

$ ./node_modules/.bin/vitest run --project unit test/ask-types-shape.test.ts
 ✓ unit  test/ask-types-shape.test.ts (9 tests) 4ms
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

全部 ask 相关测试文件（`ask-types-shape` / `ask-args` / `ask-broker` / `ask-api` / `ask-card` / `ask-hook-claude` / `ask-hook-codex` / `ask-hook-opencode` / `cmd-hook`）：

```console
 Test Files  9 passed (9)
      Tests  185 passed (185)
```

全量单测回归对比（本机 `node-pty` 的 gyp 编译失败，需 `pnpm install --ignore-scripts`，故有一批与本改动无关的预存失败；用 `git stash` 做了基线对照）：

| | Test Files | Tests |
|---|---|---|
| 基线（未改动） | 76 failed / 397 passed | 71 failed / 6791 passed |
| 本 PR | 76 failed / 397 passed | 71 failed / **6796** passed |

失败数完全一致，通过数 +5，正是本 PR 新增的 5 条用例。

**未做 live daemon 验证**：本机 `node-pty` 编译不过，且 `pnpm switch:here` 会抢占全局 `botmux` 指向（当前会话本身跑在 botmux 上）。鉴于改动只新增一行 stderr、stdout 与 exit code 零变更，判断单测 + typecheck 已足够覆盖。真实载荷则来自线上实测——`{"selected":null,"answers":[[]],"comment":"我发个多行消息试试\n这是第二行\n\n这是第四行","timedOut":false}`，测试用例直接采用了这条真实数据的形状。

## 顺带一提

`ask` 命令在文档站 14 页与 `CONTRIBUTING.md` 的 agent-facing 子命令表里均无记载，使用者无从得知 `--json` 是取回 custom reply 的唯一途径。如果需要，我可以另开一个纯文档 PR 补上。
