### PR TITLE
fix(terminal): 私密操作链接免平台登录可写

### DIFF
--- a/src/core/terminal-url.ts
+++ b/src/core/terminal-url.ts
@@ -72,9 +72,9 @@ export function buildTerminalUrl(ds: TerminalUrlSession, opts: { write?: boolean
   // proxies `/s/*` to the local terminal proxy — so terminals are reachable
   // centrally with no `:port`. Platform owner login grants write access, and an
   // explicitly requested private write link keeps its worker token as an
-  // alternative capability. Public/read-only links never carry that token. When
-  // 远程访问 is off the platform base is null and we fall through — first to a
-  // self-hosted reverse proxy base (`BOTMUX_PUBLIC_URL`, same front-door
+  // alternative capability. Public/read-only links never carry that token.
+  // When 远程访问 is off the platform base is null and we fall through — first
+  // to a self-hosted reverse proxy base (`BOTMUX_PUBLIC_URL`, same front-door
   // `/s/<id>` form), then to the local proxy/worker port.
   if (proxyReady) {
     const platformBase = isRemoteAccessEnabled() ? platformMachineBaseUrl() : null;

--- a/src/core/terminal-url.ts
+++ b/src/core/terminal-url.ts
@@ -70,14 +70,19 @@ export function buildTerminalUrl(ds: TerminalUrlSession, opts: { write?: boolean
   // subdomain (`https://m-<machineId>.<platformHost>/s/<sessionId>`). The platform
   // reverse-proxies that subdomain to this daemon's dashboard, which in turn
   // proxies `/s/*` to the local terminal proxy — so terminals are reachable
-  // centrally with no `:port`. Write access there is gated by the platform login
-  // (not a URL token), so we deliberately omit `?token=`. When 远程访问 is off the
-  // platform base is null and we fall through — first to a self-hosted reverse
-  // proxy base (`BOTMUX_PUBLIC_URL`, same front-door `/s/<id>` form but token-
-  // bearing since there's no platform SSO), then to the local proxy/worker port.
+  // centrally with no `:port`. Platform owner login grants write access, and an
+  // explicitly requested private write link keeps its worker token as an
+  // alternative capability. Public/read-only links never carry that token. When
+  // 远程访问 is off the platform base is null and we fall through — first to a
+  // self-hosted reverse proxy base (`BOTMUX_PUBLIC_URL`, same front-door
+  // `/s/<id>` form), then to the local proxy/worker port.
   if (proxyReady) {
     const platformBase = isRemoteAccessEnabled() ? platformMachineBaseUrl() : null;
-    if (platformBase) return `${platformBase}/s/${ds.session.sessionId}`;
+    if (platformBase) {
+      const base = `${platformBase}/s/${ds.session.sessionId}`;
+      if (opts.write && ds.workerToken) return `${base}?token=${ds.workerToken}`;
+      return base;
+    }
     // 自建反代（BOTMUX_PUBLIC_URL）：走 dashboard 前门 `/s/<id>`，无 per-bot 端口、
     // 对所有 bot 通。这里没有平台 SSO 兜底，故写链接必须像本地分支一样保留 token，
     // 否则终端会裸暴露在对外域名上。

--- a/src/core/terminal-write-auth.ts
+++ b/src/core/terminal-write-auth.ts
@@ -2,11 +2,13 @@
 //
 // The web terminal grants write access one of two ways:
 //
-//  1. Platform-injected role — when a central platform fronts `/s`, it
+//  1. Private write-link token — the `?token=<workerToken>` query param. An
+//     explicitly issued write link is an independent capability and wins
+//     outright, including for a viewer the platform sees as guest/teammate.
+//
+//  2. Platform-injected role — when a central platform fronts `/s`, it
 //     authenticates the viewer and injects `X-Botmux-Role` (owner | teammate |
 //     guest), first stripping any client-supplied copy. Only `owner` may write.
-//
-//  2. Legacy write token — the `?token=<workerToken>` query param.
 //
 // The role header is trustworthy ONLY on a request that actually came through
 // the platform's authenticated reverse proxy. The dashboard `/s` bridge and the
@@ -41,11 +43,14 @@ export interface TerminalWriteInput {
 export function resolveTerminalWrite(
   { role, tokenMatches, platformBound, platformProxied }: TerminalWriteInput,
 ): { hasWrite: boolean; platformReadonly: boolean } {
+  // The private URL is an explicit capability; platform role verification is a
+  // separate login-based path, not an extra factor that may revoke the token.
+  if (tokenMatches) return { hasWrite: true, platformReadonly: false };
   if (platformBound && platformProxied && typeof role === 'string' && role) {
     const hasWrite = role === 'owner';
     return { hasWrite, platformReadonly: !hasWrite };
   }
-  return { hasWrite: tokenMatches, platformReadonly: false };
+  return { hasWrite: false, platformReadonly: false };
 }
 
 /** Constant-time equality (avoids leaking the dashboard token through compare timing). */

--- a/src/core/terminal-write-auth.ts
+++ b/src/core/terminal-write-auth.ts
@@ -43,8 +43,10 @@ export interface TerminalWriteInput {
 export function resolveTerminalWrite(
   { role, tokenMatches, platformBound, platformProxied }: TerminalWriteInput,
 ): { hasWrite: boolean; platformReadonly: boolean } {
-  // The private URL is an explicit capability; platform role verification is a
-  // separate login-based path, not an extra factor that may revoke the token.
+  // A matching private write-link token is an independent capability: the owner
+  // explicitly issued that link, so it grants write even for a viewer the
+  // platform authenticated as guest/teammate. Without it, a verified platform
+  // role decides; a role header outside the verified-proxy path is ignored.
   if (tokenMatches) return { hasWrite: true, platformReadonly: false };
   if (platformBound && platformProxied && typeof role === 'string' && role) {
     const hasWrite = role === 'owner';

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -327,8 +327,9 @@ const DASHBOARD_TOKEN_PATH = join(homedir(), '.botmux', '.dashboard-token');
  * `X-Botmux-Role` header is trusted only when this machine is bound to a central
  * platform AND the request actually came through the platform proxy (proven by a
  * matching `botmux_dashboard_token` cookie — a secret a direct caller lacks).
- * Otherwise write falls back to the `?token=` gate. See
- * ./core/terminal-write-auth for the full rationale.
+ * A matching private write-link `?token=` remains an independent capability,
+ * including when the platform sees the viewer as guest. See
+ * ./core/terminal-write-auth for the full rationale and precedence.
  *
  * Both the binding and the token are read PER REQUEST, never snapshotted:
  * `botmux bind`/unbind and dashboard token rotation are hot-reloaded without

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -327,9 +327,10 @@ const DASHBOARD_TOKEN_PATH = join(homedir(), '.botmux', '.dashboard-token');
  * `X-Botmux-Role` header is trusted only when this machine is bound to a central
  * platform AND the request actually came through the platform proxy (proven by a
  * matching `botmux_dashboard_token` cookie — a secret a direct caller lacks).
- * A matching private write-link `?token=` remains an independent capability,
- * including when the platform sees the viewer as guest. See
- * ./core/terminal-write-auth for the full rationale and precedence.
+ * A matching private write-link `?token=` is an independent capability that
+ * grants write regardless of platform role (an explicitly issued write link
+ * must work for a viewer the platform sees as guest). See
+ * ./core/terminal-write-auth for the full rationale.
  *
  * Both the binding and the token are read PER REQUEST, never snapshotted:
  * `botmux bind`/unbind and dashboard token rotation are hot-reloaded without

--- a/test/terminal-url.test.ts
+++ b/test/terminal-url.test.ts
@@ -1,6 +1,22 @@
 // test/terminal-url.test.ts
-import { describe, it, expect, beforeEach, afterEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
 import { config } from '../src/config.js';
+
+vi.mock('../src/global-config.js', () => ({
+  isRemoteAccessEnabled: vi.fn(() => false),
+}));
+
+// Keep publicReverseProxyBaseUrl real: the BOTMUX_PUBLIC_URL suite below drives
+// it through process.env. Only the platform machine URL is isolated from the
+// developer machine's live platform binding.
+vi.mock('../src/platform/binding.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/platform/binding.js')>();
+  return { ...actual, platformMachineBaseUrl: vi.fn(() => null) };
+});
+
+import { isRemoteAccessEnabled } from '../src/global-config.js';
+import { platformMachineBaseUrl } from '../src/platform/binding.js';
+
 import {
   setTerminalProxyPort,
   setTerminalExternalPort,
@@ -25,7 +41,11 @@ afterAll(() => {
 });
 
 describe('buildTerminalUrl', () => {
-  beforeEach(() => setTerminalProxyPort(8801));
+  beforeEach(() => {
+    vi.mocked(isRemoteAccessEnabled).mockReturnValue(false);
+    vi.mocked(platformMachineBaseUrl).mockReturnValue(null);
+    setTerminalProxyPort(8801);
+  });
 
   it('builds a read-only sub-path URL on the proxy port', () => {
     expect(buildTerminalUrl(ds)).toBe(`http://${config.web.externalHost}:8801/s/sess-123`);
@@ -46,6 +66,30 @@ describe('buildTerminalUrl', () => {
   it('reflects an updated proxy port', () => {
     setTerminalProxyPort(8899);
     expect(buildTerminalUrl(ds)).toBe(`http://${config.web.externalHost}:8899/s/sess-123`);
+  });
+});
+
+describe('buildTerminalUrl — platform remote access', () => {
+  beforeEach(() => {
+    setTerminalProxyPort(8801);
+    vi.mocked(isRemoteAccessEnabled).mockReturnValue(true);
+    vi.mocked(platformMachineBaseUrl).mockReturnValue('https://m-machine.botmux.example');
+  });
+
+  afterEach(() => {
+    vi.mocked(isRemoteAccessEnabled).mockReturnValue(false);
+    vi.mocked(platformMachineBaseUrl).mockReturnValue(null);
+    resetTerminalProxy();
+  });
+
+  it('keeps public platform links read-only', () => {
+    expect(buildTerminalUrl(ds)).toBe('https://m-machine.botmux.example/s/sess-123');
+  });
+
+  it('preserves the private write token on platform links', () => {
+    expect(buildTerminalUrl(ds, { write: true })).toBe(
+      'https://m-machine.botmux.example/s/sess-123?token=wtok',
+    );
   });
 });
 

--- a/test/terminal-url.test.ts
+++ b/test/terminal-url.test.ts
@@ -6,12 +6,15 @@ vi.mock('../src/global-config.js', () => ({
   isRemoteAccessEnabled: vi.fn(() => false),
 }));
 
-// Keep publicReverseProxyBaseUrl real: the BOTMUX_PUBLIC_URL suite below drives
-// it through process.env. Only the platform machine URL is isolated from the
-// developer machine's live platform binding.
+// Partial mock: platformMachineBaseUrl is stubbed (no real platform.json on the
+// test box should leak in), but publicReverseProxyBaseUrl stays REAL — the
+// BOTMUX_PUBLIC_URL suite below drives it through process.env per test.
 vi.mock('../src/platform/binding.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../src/platform/binding.js')>();
-  return { ...actual, platformMachineBaseUrl: vi.fn(() => null) };
+  return {
+    ...actual,
+    platformMachineBaseUrl: vi.fn(() => null),
+  };
 });
 
 import { isRemoteAccessEnabled } from '../src/global-config.js';

--- a/test/terminal-write-auth.test.ts
+++ b/test/terminal-write-auth.test.ts
@@ -10,8 +10,10 @@
 // cannot supply the secret dashboard token. The gate therefore honors the role
 // header only when the machine is platform-bound AND the request carries the
 // matching dashboard-token cookie; otherwise write falls back to `?token=`.
-// A matching private write-link token is independently sufficient even when a
-// verified platform role identifies the viewer as guest or teammate.
+//
+// Independently of the role, a matching private write-link `?token=` is a
+// capability in its own right: the owner explicitly issued that link, so it
+// grants write even when the platform authenticated the viewer as guest.
 import { describe, it, expect } from 'vitest';
 import {
   resolveTerminalWrite,
@@ -50,12 +52,12 @@ describe('resolveTerminalWrite (pure gate)', () => {
         .toEqual({ hasWrite: true, platformReadonly: false });
     });
 
-    it('allows a valid private token for a platform guest', () => {
+    it('a matching private write-link token grants write even for role guest (capability)', () => {
       expect(resolveTerminalWrite({ role: 'guest', tokenMatches: true, platformBound: true, platformProxied: true }))
         .toEqual({ hasWrite: true, platformReadonly: false });
     });
 
-    it('forces read-only for a platform guest without a token', () => {
+    it('forces read-only for a non-owner role (guest) without a token', () => {
       expect(resolveTerminalWrite({ role: 'guest', tokenMatches: false, platformBound: true, platformProxied: true }))
         .toEqual({ hasWrite: false, platformReadonly: true });
     });

--- a/test/terminal-write-auth.test.ts
+++ b/test/terminal-write-auth.test.ts
@@ -10,6 +10,8 @@
 // cannot supply the secret dashboard token. The gate therefore honors the role
 // header only when the machine is platform-bound AND the request carries the
 // matching dashboard-token cookie; otherwise write falls back to `?token=`.
+// A matching private write-link token is independently sufficient even when a
+// verified platform role identifies the viewer as guest or teammate.
 import { describe, it, expect } from 'vitest';
 import {
   resolveTerminalWrite,
@@ -48,8 +50,13 @@ describe('resolveTerminalWrite (pure gate)', () => {
         .toEqual({ hasWrite: true, platformReadonly: false });
     });
 
-    it('forces read-only for a non-owner role (guest), overriding a matching token', () => {
+    it('allows a valid private token for a platform guest', () => {
       expect(resolveTerminalWrite({ role: 'guest', tokenMatches: true, platformBound: true, platformProxied: true }))
+        .toEqual({ hasWrite: true, platformReadonly: false });
+    });
+
+    it('forces read-only for a platform guest without a token', () => {
+      expect(resolveTerminalWrite({ role: 'guest', tokenMatches: false, platformBound: true, platformProxied: true }))
         .toEqual({ hasWrite: false, platformReadonly: true });
     });
 


### PR DESCRIPTION
## 问题

设备绑定平台并开启远程访问后，`buildTerminalUrl(..., { write: true })` 会丢弃 worker write token。即使用户从私密「获取操作链接」进入，平台若将其识别为 guest，终端仍被降为只读并要求登录。

## 修复

本 PR 已重放到最新 `master` 的 `terminal-write-auth` 安全模型上：

- 保留 master 的防伪造边界：`X-Botmux-Role` 只有在机器已绑定平台且 dashboard-token cookie 验签通过时才可信。
- 私密 write token 作为独立 capability，优先于平台角色；持有有效私密链接即可写。
- 平台远程 URL 在明确请求 write link 时保留 per-worker token。
- 普通平台链接仍不携带 token；未登录 guest / teammate 仍只读。
- `BOTMUX_PUBLIC_URL` 自建反代逻辑保持不变。

## 验证

- 定向测试：4 files / 113 tests passed。
- `pnpm exec tsc --noEmit` passed。
- `pnpm build` passed。
- verified-delivery live 平台链路已验证：私密 URL 带 token，终端页面 write enabled，WebSocket 日志 `write: true`。

## 安全边界

write token 为 per-worker 128-bit 随机 capability，仅显式私密操作链接携带；公开只读链接及 master 新增的平台角色验签行为不变。