### PR TITLE
fix(omp): 避免长输入卡在粘贴占位符

### DIFF
--- a/src/adapters/cli/oh-my-pi.ts
+++ b/src/adapters/cli/oh-my-pi.ts
@@ -5,34 +5,67 @@ import type { CliAdapter, PtyHandle } from './types.js';
 import { delay } from '../../utils/timing.js';
 
 const OMP_INPUT_CHUNK_CHARS = 512;
+const OMP_INPUT_CHUNK_NEWLINES = 9;
 const OMP_INPUT_THROTTLE_MS = 20;
+const OMP_CLEAR_COOLDOWN_MS = 550;
+const BRACKETED_PASTE_START = '\x1b[200~';
+const BRACKETED_PASTE_END = '\x1b[201~';
 
-function chunkTextByCodePoint(text: string, maxChars: number): string[] {
+/** Match OMP's paste semantics before putting content on a key-event path. */
+function normalizeOmpInput(text: string): string {
+  return text
+    // Strip ANSI/VT sequences as whole units so removing ESC does not leave
+    // printable tails such as `[31m` in pasted terminal logs.
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?/g, '')
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\x1b[ -/]*[@-~]/g, '')
+    .replace(/\r\n?/g, '\n')
+    .normalize('NFC')
+    .replace(/\t/g, '   ')
+    // Literal terminal input would interpret these as keys (Backspace, DEL,
+    // Escape, etc.). Newlines are preserved and delivered inside paste mode.
+    .replace(/[\x00-\x09\x0B-\x1F\x7F-\x9F]/g, '');
+}
+
+/** Keep every paste below OMP's `[Paste #N]` thresholds (>1000 chars or >10 lines). */
+function chunkOmpInput(text: string): string[] {
   const chunks: string[] = [];
   let current = '';
+  let newlines = 0;
   for (const ch of text) {
-    current += ch;
-    if (current.length >= maxChars) {
+    if (
+      current &&
+      (current.length + ch.length > OMP_INPUT_CHUNK_CHARS ||
+        (ch === '\n' && newlines >= OMP_INPUT_CHUNK_NEWLINES))
+    ) {
       chunks.push(current);
       current = '';
+      newlines = 0;
     }
+    current += ch;
+    if (ch === '\n') newlines++;
   }
   if (current) chunks.push(current);
   return chunks;
 }
 
-async function typeText(pty: PtyHandle, content: string): Promise<boolean> {
-  const chunks = chunkTextByCodePoint(content, OMP_INPUT_CHUNK_CHARS);
+function sendLiteral(pty: PtyHandle, text: string): boolean {
+  try {
+    if (pty.sendText) return pty.sendText(text) !== false;
+    pty.write(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function pasteTextInSafeChunks(pty: PtyHandle, content: string): Promise<boolean> {
+  const chunks = chunkOmpInput(content);
   for (const chunk of chunks) {
-    try {
-      if (pty.sendText) {
-        if (pty.sendText(chunk) === false) return false;
-      } else {
-        pty.write(chunk);
-      }
-    } catch {
-      return false;
-    }
+    // Emit the markers ourselves instead of relying on backend pasteText():
+    // tmux/zellij implement bracketed paste, while herdr's pasteText is only a
+    // literal write. One explicit wire format keeps every backend equivalent.
+    if (!sendLiteral(pty, `${BRACKETED_PASTE_START}${chunk}${BRACKETED_PASTE_END}`)) return false;
     await delay(OMP_INPUT_THROTTLE_MS);
   }
   return true;
@@ -57,6 +90,24 @@ function submitEnter(pty: PtyHandle, attempts = 3): boolean {
 /** Adapter for oh-my-pi coding agent's native TUI (`omp`). */
 export function createOhMyPiAdapter(pathOverride?: string): CliAdapter {
   const bin = resolveCommand(pathOverride ?? 'omp');
+  let composerDirty = false;
+  let lastClearAttemptAt = 0;
+
+  const clearComposer = async (pty: PtyHandle): Promise<boolean> => {
+    // OMP treats a second Ctrl+C within 500 ms as exit. Keep recovery clears
+    // outside that window even when consecutive terminal writes fail quickly.
+    const waitMs = OMP_CLEAR_COOLDOWN_MS - (Date.now() - lastClearAttemptAt);
+    if (waitMs > 0) await delay(waitMs);
+    lastClearAttemptAt = Date.now();
+    try {
+      if (pty.sendSpecialKeys) return pty.sendSpecialKeys('C-c') !== false;
+      pty.write('\x03');
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
   return {
     id: 'oh-my-pi',
     authPaths: ['~/.omp/agent/auth.json'],
@@ -92,15 +143,40 @@ export function createOhMyPiAdapter(pathOverride?: string): CliAdapter {
     },
 
     async writeInput(pty: PtyHandle, content: string) {
-      // OMP collapses large bracketed pastes into a `[Paste #N]` placeholder.
-      // A programmatic Enter immediately after that placeholder can be ignored,
-      // leaving the message stranded until a human presses Enter. Type literal
-      // text instead: OMP preserves embedded newlines in the composer, and the
-      // final real Enter submits one user message. Chunking avoids tmux/PTY input
-      // buffer pressure on long botmux briefs.
-      const typed = await typeText(pty, content);
-      if (!typed) return { submitted: false };
-      if (!submitEnter(pty)) return { submitted: false };
+      const normalized = normalizeOmpInput(content);
+      if (!normalized) {
+        return {
+          submitted: false,
+          failureReason: 'OMP 输入清理控制字符后为空，未发送空消息。',
+        };
+      }
+
+      // A previous best-effort clear may itself have been dropped. Never append
+      // a new message to that unknown buffer: clear it successfully first.
+      if (composerDirty) {
+        if (!(await clearComposer(pty))) {
+          return {
+            submitted: false,
+            failureReason: 'OMP 输入框可能残留未完整消息，自动清理失败；请在终端按 Ctrl+C 清空后重试。',
+          };
+        }
+        composerDirty = false;
+      }
+
+      // OMP collapses a single large bracketed paste into `[Paste #N]`, whose
+      // immediately-following programmatic Enter can be ignored. Preserve paste
+      // sanitization (so tabs/newlines/control bytes are text, not key events),
+      // but split below both placeholder thresholds before the final real Enter.
+      const pasted = await pasteTextInSafeChunks(pty, normalized);
+      if (!pasted) {
+        composerDirty = !(await clearComposer(pty));
+        return { submitted: false };
+      }
+      if (!submitEnter(pty)) {
+        composerDirty = !(await clearComposer(pty));
+        return { submitted: false };
+      }
+      composerDirty = false;
       return { submitted: true };
     },
 

--- a/src/adapters/cli/oh-my-pi.ts
+++ b/src/adapters/cli/oh-my-pi.ts
@@ -4,6 +4,56 @@ import type { CliAdapter, PtyHandle } from './types.js';
 
 import { delay } from '../../utils/timing.js';
 
+const OMP_INPUT_CHUNK_CHARS = 512;
+const OMP_INPUT_THROTTLE_MS = 20;
+
+function chunkTextByCodePoint(text: string, maxChars: number): string[] {
+  const chunks: string[] = [];
+  let current = '';
+  for (const ch of text) {
+    current += ch;
+    if (current.length >= maxChars) {
+      chunks.push(current);
+      current = '';
+    }
+  }
+  if (current) chunks.push(current);
+  return chunks;
+}
+
+async function typeText(pty: PtyHandle, content: string): Promise<boolean> {
+  const chunks = chunkTextByCodePoint(content, OMP_INPUT_CHUNK_CHARS);
+  for (const chunk of chunks) {
+    try {
+      if (pty.sendText) {
+        if (pty.sendText(chunk) === false) return false;
+      } else {
+        pty.write(chunk);
+      }
+    } catch {
+      return false;
+    }
+    await delay(OMP_INPUT_THROTTLE_MS);
+  }
+  return true;
+}
+
+function submitEnter(pty: PtyHandle, attempts = 3): boolean {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      if (pty.sendSpecialKeys) {
+        if (pty.sendSpecialKeys('Enter') !== false) return true;
+      } else {
+        pty.write('\r');
+        return true;
+      }
+    } catch {
+      // retry below
+    }
+  }
+  return false;
+}
+
 /** Adapter for oh-my-pi coding agent's native TUI (`omp`). */
 export function createOhMyPiAdapter(pathOverride?: string): CliAdapter {
   const bin = resolveCommand(pathOverride ?? 'omp');
@@ -42,19 +92,16 @@ export function createOhMyPiAdapter(pathOverride?: string): CliAdapter {
     },
 
     async writeInput(pty: PtyHandle, content: string) {
-      // OMP's editor submits on a plain LF (`\n`) in current releases; tmux's
-      // symbolic Enter / CR can leave the text sitting in the composer. Use LF
-      // for both the tmux paste path and raw PTY fallback so every dispatched
-      // Leader→OMP message is actually submitted, not just pasted.
-      if (pty.pasteText) {
-        pty.pasteText(content);
-        await delay(200);
-        pty.write('\n');
-      } else {
-        pty.write(`\x1b[200~${content}\x1b[201~`);
-        await delay(1000);
-        pty.write('\n');
-      }
+      // OMP collapses large bracketed pastes into a `[Paste #N]` placeholder.
+      // A programmatic Enter immediately after that placeholder can be ignored,
+      // leaving the message stranded until a human presses Enter. Type literal
+      // text instead: OMP preserves embedded newlines in the composer, and the
+      // final real Enter submits one user message. Chunking avoids tmux/PTY input
+      // buffer pressure on long botmux briefs.
+      const typed = await typeText(pty, content);
+      if (!typed) return { submitted: false };
+      if (!submitEnter(pty)) return { submitted: false };
+      return { submitted: true };
     },
 
     completionPattern: undefined,

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -745,7 +745,9 @@ describe('oh-my-pi buildArgs', () => {
     expect(args[idx + 1]).toBe('/repo/root');
   });
 
-  it('types tmux input and submits with symbolic Enter', async () => {
+  const ompPaste = (text: string) => `\x1b[200~${text}\x1b[201~`;
+
+  it('pastes tmux input below OMP placeholder thresholds and submits with Enter', async () => {
     const events: string[] = [];
     const pty = {
       write(data: string) { events.push(`write:${JSON.stringify(data)}`); },
@@ -760,10 +762,10 @@ describe('oh-my-pi buildArgs', () => {
 
     await adapter.writeInput(pty, 'review this');
 
-    expect(events).toEqual(['text:review this', 'keys:Enter']);
+    expect(events).toEqual([`text:${ompPaste('review this')}`, 'keys:Enter']);
   });
 
-  it('types raw PTY input and submits with CR', async () => {
+  it('uses the same explicit bracketed-paste wire format on raw PTY', async () => {
     const events: string[] = [];
     const pty = {
       write(data: string) { events.push(data); },
@@ -775,28 +777,70 @@ describe('oh-my-pi buildArgs', () => {
 
     await adapter.writeInput(pty, 'review this');
 
-    expect(events).toEqual(['review this', '\r']);
+    expect(events).toEqual([ompPaste('review this'), '\r']);
   });
 
-  it('chunks long tmux input without bracketed paste placeholder path', async () => {
-    const events: string[] = [];
+  it('chunks long and many-line input below both OMP placeholder thresholds', async () => {
+    const pasted: string[] = [];
+    const keys: string[] = [];
     const pty = {
-      write(data: string) { events.push(`write:${data.length}`); },
+      write() {},
       resize() {},
       onData() {},
       onExit() {},
       kill() {},
-      pasteText(text: string) { events.push(`paste:${text.length}`); },
-      sendText(text: string) { events.push(`text:${text.length}`); },
+      pasteText() { throw new Error('adapter must use one consistent explicit wire format'); },
+      sendText(text: string) { pasted.push(text); },
+      sendSpecialKeys(...sent: string[]) { keys.push(...sent); },
+    } satisfies PtyHandle;
+
+    const content = Array.from({ length: 25 }, (_, i) => `${i}: ${'x'.repeat(60)}`).join('\n');
+    await adapter.writeInput(pty, content);
+
+    const payloads = pasted.map(text => text.slice('\x1b[200~'.length, -'\x1b[201~'.length));
+    expect(payloads.join('')).toBe(content);
+    expect(payloads.length).toBeGreaterThan(2);
+    expect(payloads.every(text => text.length <= 512)).toBe(true);
+    expect(payloads.every(text => (text.match(/\n/g) ?? []).length <= 9)).toBe(true);
+    expect(keys).toEqual(['Enter']);
+  });
+
+  it('normalizes paste text so terminal control bytes cannot become OMP key events', async () => {
+    const events: string[] = [];
+    const pty = {
+      write() {},
+      resize() {},
+      onData() {},
+      onExit() {},
+      kill() {},
+      sendText(text: string) { events.push(text); },
       sendSpecialKeys(...keys: string[]) { events.push(`keys:${keys.join(',')}`); },
     } satisfies PtyHandle;
 
-    await adapter.writeInput(pty, 'x'.repeat(1200));
+    await adapter.writeInput(pty, 'a\tb\r\nc\x7fd\x1b[31mred\x1b[0m e\u0301');
 
-    expect(events).toEqual(['text:512', 'text:512', 'text:176', 'keys:Enter']);
+    expect(events).toEqual([ompPaste('a   b\ncdred é'), 'keys:Enter']);
   });
 
-  it('reports not submitted when tmux literal text write is dropped', async () => {
+  it('clears the OMP composer when a later paste chunk is dropped', async () => {
+    const events: string[] = [];
+    let textCall = 0;
+    const pty = {
+      write(data: string) { events.push(`write:${data}`); },
+      resize() {},
+      onData() {},
+      onExit() {},
+      kill() {},
+      sendText(text: string) { events.push(`text:${text.length}`); return ++textCall !== 2; },
+      sendSpecialKeys(...keys: string[]) { events.push(`keys:${keys.join(',')}`); },
+    } satisfies PtyHandle;
+
+    await expect(adapter.writeInput(pty, 'x'.repeat(1200))).resolves.toEqual({ submitted: false });
+
+    expect(events).toEqual(['text:524', 'text:524', 'keys:C-c']);
+  });
+
+  it('clears the OMP composer when Enter retries are all dropped', async () => {
     const events: string[] = [];
     const pty = {
       write(data: string) { events.push(`write:${data}`); },
@@ -804,32 +848,52 @@ describe('oh-my-pi buildArgs', () => {
       onData() {},
       onExit() {},
       kill() {},
-      pasteText(text: string) { events.push(`paste:${text}`); },
-      sendText(text: string) { events.push(`text:${text}`); return false; },
-      sendSpecialKeys(...keys: string[]) { events.push(`keys:${keys.join(',')}`); },
-    } satisfies PtyHandle;
-
-    await expect(adapter.writeInput(pty, 'review this')).resolves.toEqual({ submitted: false });
-
-    expect(events).toEqual(['text:review this']);
-  });
-
-  it('reports not submitted when tmux Enter is dropped after typing content', async () => {
-    const events: string[] = [];
-    const pty = {
-      write(data: string) { events.push(`write:${data}`); },
-      resize() {},
-      onData() {},
-      onExit() {},
-      kill() {},
-      pasteText(text: string) { events.push(`paste:${text}`); },
       sendText(text: string) { events.push(`text:${text}`); },
-      sendSpecialKeys(...keys: string[]) { events.push(`keys:${keys.join(',')}`); return false; },
+      sendSpecialKeys(...keys: string[]) {
+        events.push(`keys:${keys.join(',')}`);
+        return keys[0] === 'C-c';
+      },
     } satisfies PtyHandle;
 
     await expect(adapter.writeInput(pty, 'review this')).resolves.toEqual({ submitted: false });
 
-    expect(events).toEqual(['text:review this', 'keys:Enter', 'keys:Enter', 'keys:Enter']);
+    expect(events).toEqual([
+      `text:${ompPaste('review this')}`,
+      'keys:Enter',
+      'keys:Enter',
+      'keys:Enter',
+      'keys:C-c',
+    ]);
+  });
+
+  it('blocks new text behind an uncleared partial composer and retries cleanup first', async () => {
+    const isolatedAdapter = createOhMyPiAdapter('/usr/bin/omp');
+    const events: string[] = [];
+    let cleanupAttempts = 0;
+    const pty = {
+      write() {},
+      resize() {},
+      onData() {},
+      onExit() {},
+      kill() {},
+      sendText(text: string) { events.push(`text:${text}`); return false; },
+      sendSpecialKeys(...keys: string[]) {
+        events.push(`keys:${keys.join(',')}`);
+        if (keys[0] === 'C-c') return ++cleanupAttempts > 1;
+        return true;
+      },
+    } satisfies PtyHandle;
+
+    await expect(isolatedAdapter.writeInput(pty, 'first')).resolves.toEqual({ submitted: false });
+    await expect(isolatedAdapter.writeInput(pty, 'second')).resolves.toEqual({ submitted: false });
+
+    expect(events).toEqual([
+      `text:${ompPaste('first')}`,
+      'keys:C-c',
+      'keys:C-c',
+      `text:${ompPaste('second')}`,
+      'keys:C-c',
+    ]);
   });
 
   it('skillsDir points to ~/.omp/agent/skills', () => {

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -745,7 +745,7 @@ describe('oh-my-pi buildArgs', () => {
     expect(args[idx + 1]).toBe('/repo/root');
   });
 
-  it('submits pasted tmux input with LF instead of symbolic Enter', async () => {
+  it('types tmux input and submits with symbolic Enter', async () => {
     const events: string[] = [];
     const pty = {
       write(data: string) { events.push(`write:${JSON.stringify(data)}`); },
@@ -754,15 +754,16 @@ describe('oh-my-pi buildArgs', () => {
       onExit() {},
       kill() {},
       pasteText(text: string) { events.push(`paste:${text}`); },
+      sendText(text: string) { events.push(`text:${text}`); },
       sendSpecialKeys(...keys: string[]) { events.push(`keys:${keys.join(',')}`); },
     } satisfies PtyHandle;
 
     await adapter.writeInput(pty, 'review this');
 
-    expect(events).toEqual(['paste:review this', 'write:"\\n"']);
+    expect(events).toEqual(['text:review this', 'keys:Enter']);
   });
 
-  it('submits raw PTY input with bracketed paste and LF', async () => {
+  it('types raw PTY input and submits with CR', async () => {
     const events: string[] = [];
     const pty = {
       write(data: string) { events.push(data); },
@@ -774,7 +775,61 @@ describe('oh-my-pi buildArgs', () => {
 
     await adapter.writeInput(pty, 'review this');
 
-    expect(events).toEqual(['\x1b[200~review this\x1b[201~', '\n']);
+    expect(events).toEqual(['review this', '\r']);
+  });
+
+  it('chunks long tmux input without bracketed paste placeholder path', async () => {
+    const events: string[] = [];
+    const pty = {
+      write(data: string) { events.push(`write:${data.length}`); },
+      resize() {},
+      onData() {},
+      onExit() {},
+      kill() {},
+      pasteText(text: string) { events.push(`paste:${text.length}`); },
+      sendText(text: string) { events.push(`text:${text.length}`); },
+      sendSpecialKeys(...keys: string[]) { events.push(`keys:${keys.join(',')}`); },
+    } satisfies PtyHandle;
+
+    await adapter.writeInput(pty, 'x'.repeat(1200));
+
+    expect(events).toEqual(['text:512', 'text:512', 'text:176', 'keys:Enter']);
+  });
+
+  it('reports not submitted when tmux literal text write is dropped', async () => {
+    const events: string[] = [];
+    const pty = {
+      write(data: string) { events.push(`write:${data}`); },
+      resize() {},
+      onData() {},
+      onExit() {},
+      kill() {},
+      pasteText(text: string) { events.push(`paste:${text}`); },
+      sendText(text: string) { events.push(`text:${text}`); return false; },
+      sendSpecialKeys(...keys: string[]) { events.push(`keys:${keys.join(',')}`); },
+    } satisfies PtyHandle;
+
+    await expect(adapter.writeInput(pty, 'review this')).resolves.toEqual({ submitted: false });
+
+    expect(events).toEqual(['text:review this']);
+  });
+
+  it('reports not submitted when tmux Enter is dropped after typing content', async () => {
+    const events: string[] = [];
+    const pty = {
+      write(data: string) { events.push(`write:${data}`); },
+      resize() {},
+      onData() {},
+      onExit() {},
+      kill() {},
+      pasteText(text: string) { events.push(`paste:${text}`); },
+      sendText(text: string) { events.push(`text:${text}`); },
+      sendSpecialKeys(...keys: string[]) { events.push(`keys:${keys.join(',')}`); return false; },
+    } satisfies PtyHandle;
+
+    await expect(adapter.writeInput(pty, 'review this')).resolves.toEqual({ submitted: false });
+
+    expect(events).toEqual(['text:review this', 'keys:Enter', 'keys:Enter', 'keys:Enter']);
   });
 
   it('skillsDir points to ~/.omp/agent/skills', () => {


### PR DESCRIPTION
# 问题

OMP 会把较长的 bracketed paste 输入折叠成 `[Paste #N]` 占位符。此前 botmux 在写入长 brief 后追加程序化 Enter，但真实会话中仍出现内容停留在 OMP 输入框、未实际提交的问题，需要用户手动再按一次回车。

PR 初版改为 `sendText` 逐字输入后又暴露两个问题：

1. Tab、CR、DEL、ESC/ANSI 等控制字符会被 OMP 当作按键；CRLF 文本可能提前拆成多个 agent turn。
2. 分块或 Enter 中途失败会在 composer 留下半条消息，下一条输入可能与残片拼接。

# 修复

- 将 PR 提交 rebase 到最新 `master`。
- OMP adapter 不再发送一个超大 paste，也不把原始内容直接送入按键路径。
- 先按 OMP paste 语义规范化输入：
  - CRLF / CR → LF
  - NFC 规范化
  - Tab 展开为空格
  - 删除 ANSI/VT 序列及其余终端控制字符
- 使用显式 bracketed-paste wire format 分块写入；每块同时控制在 512 字符、最多 9 个换行，低于 OMP 16.4.4 的 `[Paste #N]` 字符数和行数阈值。
- tmux、raw PTY、zellij、herdr 统一走相同 wire format，不依赖各 backend 的 `pasteText` 实现差异。
- 写入 chunk 或最终 Enter 失败时用 Ctrl+C 清空 OMP composer：
  - 避开 OMP 500ms 内双 Ctrl+C 退出语义；
  - 清理本身失败时标记 composer dirty，下一条消息必须先清理成功，避免拼接脏内容；
  - 清理持续失败时返回明确恢复提示。
- 最终使用真实 Enter 提交，并保留 `{ submitted: false }` 供 worker 上报。

# 影响范围

- **CLI**：仅修改 `oh-my-pi` adapter；未修改 adapter 公共基类、其它 20+ CLI 的输入路径。
- **后端**：覆盖 tmux（生产主路径）、raw PTY fallback、zellij、herdr 的统一 bracketed-paste 输入语义。
- **会话类型**：普通/话题/群会话以及 fresh/resume/adopt 最终都复用该 adapter 的 `writeInput`；失败状态按 adapter 实例隔离。
- **平台**：规范化与分块为纯 TypeScript 字符串逻辑，无平台路径、shell 或进程差异；Linux + tmux 已真实验证，raw PTY 由单测覆盖。
- **sandbox / v3 workflow**：未修改 sandbox、worker queue 或 workflow 公共层；只影响最终派发到 OMP composer 的内容编码。

# 验证

- `pnpm build`：通过。
- `pnpm test -- --run test/cli-adapters.test.ts`：255/255 通过。
  - 覆盖 tmux / raw PTY wire format；
  - 长文本和多行双阈值分块；
  - Tab、CRLF、DEL、ANSI、NFD → NFC；
  - 中途 chunk 失败清理；
  - Enter 三次失败清理；
  - 清理失败后阻断后续脏拼接。
- 最新 OMP 16.4.4 真实 tmux：
  - 约 1.7K 字符、25+ 行，含 Tab / CRLF / DEL / ANSI / NFD；
  - adapter 返回 `submitted: true`；
  - session JSONL 只产生 1 条 user message；
  - 规范化后内容 SHA-256 与期望完全一致；
  - 模型正常回复 `OK`。
- 全量 unit：7726/7738 通过（470 files 通过，5 files 共 12 个失败）。
  - 失败均不在本 PR 文件/路径：本机 public terminal URL 配置污染、America/Los_Angeles 与用例默认时区假设、dashboard monitoring CSS 基线；
  - OMP 定向用例和构建均通过。