### PR TITLE
feat(setup): 交互式 setup 支持 --default-cli 预选并高亮当前 CLI

### DIFF
--- a/src/setup/interactive-select.ts
+++ b/src/setup/interactive-select.ts
@@ -71,12 +71,16 @@ export function interactiveSelect(opts: {
   title: string;
   items: ReadonlyArray<SelectItem>;
   footer?: string;
+  /** Initially highlighted item (used by setup defaults/editors). */
+  initialIndex?: number;
 }): Promise<number | null> {
   const { items } = opts;
   if (!input.isTTY || !output.isTTY || items.length === 0) return Promise.resolve(null);
 
   let query = '';
-  let cursor = 0;
+  let cursor = Number.isInteger(opts.initialIndex) && opts.initialIndex! >= 0 && opts.initialIndex! < items.length
+    ? opts.initialIndex!
+    : 0;
   let top = 0;
   let filtered: number[] = items.map((_, i) => i);
 
@@ -242,21 +246,45 @@ export async function pickCliSelection(
 
   // ── TTY：级联 ──
   // 顶层循环：选中带二级菜单的项后进子菜单，子菜单取消则退回顶层。
+  const currentPath = cliSelectionCursorPath(opts.currentKey);
   for (;;) {
     const topItems: SelectItem[] = CLI_SELECT_TREE.map((g) => ({
       label: g.label,
       hint: g.children ? '' : g.option?.key,
       submenu: !!g.children,
     }));
-    const ti = await interactiveSelect({ title, items: topItems, footer: '选 Aiden 进入子菜单（× Claude / × Codex）' });
+    const ti = await interactiveSelect({
+      title,
+      items: topItems,
+      footer: '带 ▸ 的项目进入子菜单',
+      initialIndex: currentPath.topIndex,
+    });
     if (ti === null) return null;
     const group = CLI_SELECT_TREE[ti];
     if (group.option) return group.option.key;
     if (group.children) {
       const subItems: SelectItem[] = group.children.map((c) => ({ label: c.label, hint: c.wrapperCli ?? c.key }));
-      const si = await interactiveSelect({ title: `${title} › ${group.label}`, items: subItems, footer: 'Esc 返回上一级' });
+      const si = await interactiveSelect({
+        title: `${title} › ${group.label}`,
+        items: subItems,
+        footer: 'Esc 返回上一级',
+        initialIndex: ti === currentPath.topIndex ? currentPath.childIndex : undefined,
+      });
       if (si === null) continue; // 退回顶层
       return group.children[si].key;
     }
   }
+}
+
+/** Resolve a selection key to its top-level and optional child cursor. */
+export function cliSelectionCursorPath(currentKey?: string): { topIndex: number; childIndex?: number } {
+  if (currentKey) {
+    for (let topIndex = 0; topIndex < CLI_SELECT_TREE.length; topIndex++) {
+      const group = CLI_SELECT_TREE[topIndex]!;
+      if (group.option?.key === currentKey) return { topIndex };
+      const childIndex = group.children?.findIndex(child => child.key === currentKey) ?? -1;
+      if (childIndex >= 0) return { topIndex, childIndex };
+    }
+  }
+  return { topIndex: 0 };
 }

--- a/src/setup/setup-args.ts
+++ b/src/setup/setup-args.ts
@@ -57,6 +57,42 @@ export function isScriptedSetupInvocation(argv: string[]): boolean {
   return !first.startsWith('-');
 }
 
+export interface InteractiveSetupOptions {
+  /** CLI selection key preselected by the interactive setup wizard. */
+  defaultCli?: string;
+}
+
+/**
+ * Parse flags accepted by the interactive `botmux setup` path. Keeping this
+ * separate from the scripted subcommand parser lets bootstrap installers pick
+ * a sensible CLI without depending on TUI key presses or answer ordering.
+ */
+export function parseInteractiveSetupOptions(argv: string[]): InteractiveSetupOptions {
+  let defaultCli: string | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i]!;
+    if (token === '--open-platform-auto' || token === '--no-open-platform-auto') continue;
+    if (token === '--default-cli') {
+      const value = argv[i + 1];
+      if (!value || value.startsWith('--')) throw new Error('--default-cli 缺少取值');
+      defaultCli = value;
+      i++;
+      continue;
+    }
+    if (token.startsWith('--default-cli=')) {
+      defaultCli = token.slice('--default-cli='.length);
+      if (!defaultCli) throw new Error('--default-cli 缺少取值');
+      continue;
+    }
+    throw new Error(`交互式 setup 不支持参数 ${token}`);
+  }
+  if (defaultCli !== undefined) {
+    // Validate the key now so the wizard fails before the first QR scan.
+    resolveCliSelection(defaultCli);
+  }
+  return defaultCli ? { defaultCli } : {};
+}
+
 const BOT_FIELD_FLAGS: Record<string, keyof SetupBotFlags> = {
   '--name': 'name',
   '--app-id': 'appId',

--- a/test/setup-args.test.ts
+++ b/test/setup-args.test.ts
@@ -4,6 +4,7 @@ import {
   editInputFromFlags,
   isScriptedSetupInvocation,
   maskAppSecret,
+  parseInteractiveSetupOptions,
   parseSetupCommand,
 } from '../src/setup/setup-args.js';
 import { applyBotConfigEdits } from '../src/setup/bot-config-editor.js';
@@ -19,10 +20,26 @@ describe('isScriptedSetupInvocation', () => {
     expect(isScriptedSetupInvocation([])).toBe(false);
     expect(isScriptedSetupInvocation(['--no-open-platform-auto'])).toBe(false);
     expect(isScriptedSetupInvocation(['--open-platform-auto'])).toBe(false);
+    expect(isScriptedSetupInvocation(['--default-cli', 'traex'])).toBe(false);
   });
 
   it('routes unknown bare words to the scripted parser instead of hanging the TUI', () => {
     expect(isScriptedSetupInvocation(['frobnicate'])).toBe(true);
+  });
+});
+
+describe('parseInteractiveSetupOptions', () => {
+  it('parses and validates a default CLI without changing open-platform flags', () => {
+    expect(parseInteractiveSetupOptions(['--default-cli', 'traex', '--open-platform-auto']))
+      .toEqual({ defaultCli: 'traex' });
+    expect(parseInteractiveSetupOptions(['--no-open-platform-auto', '--default-cli=codex']))
+      .toEqual({ defaultCli: 'codex' });
+  });
+
+  it('rejects missing, unknown, or invalid values before setup scans', () => {
+    expect(() => parseInteractiveSetupOptions(['--default-cli'])).toThrow(/缺少取值/);
+    expect(() => parseInteractiveSetupOptions(['--default-cli=nope'])).toThrow(/未知 CLI/);
+    expect(() => parseInteractiveSetupOptions(['--wat'])).toThrow(/不支持参数/);
   });
 });
 

--- a/test/setup-pickers.test.ts
+++ b/test/setup-pickers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeViewportTop, pickChoice, truncateToWidth } from '../src/setup/interactive-select.js';
+import { cliSelectionCursorPath, computeViewportTop, pickChoice, truncateToWidth } from '../src/setup/interactive-select.js';
 import {
   listOpenPlatformApps,
   fetchOpenPlatformAppSecret,
@@ -57,6 +57,18 @@ describe('computeViewportTop (长列表视口滚动)', () => {
   it('scrolls up when the cursor wraps back above the window', () => {
     expect(computeViewportTop(0, 30, 40, 10)).toBe(0);   // 底部 wrap 回顶部
     expect(computeViewportTop(29, 30, 40, 10)).toBe(29);
+  });
+});
+
+describe('cliSelectionCursorPath', () => {
+  it('preselects nested and top-level CLI choices', () => {
+    const trae = cliSelectionCursorPath('traex');
+    expect(trae.topIndex).toBeGreaterThan(0);
+    expect(trae.childIndex).toBe(1);
+
+    const claude = cliSelectionCursorPath('claude-code');
+    expect(claude).toEqual({ topIndex: 0 });
+    expect(cliSelectionCursorPath('not-a-cli')).toEqual({ topIndex: 0 });
   });
 });
 


### PR DESCRIPTION
## 改了什么
- **`interactive-select.ts`**：`interactiveSelect` 新增 `initialIndex`；`pickCliSelection` 据传入的当前 key 用新导出的 `cliSelectionCursorPath` 定位顶层/子菜单，进入即**预高亮当前已选 CLI**（越界回退 0）；顶层 footer 文案改为「带 ▸ 的项目进入子菜单」。
- **`setup-args.ts`**：新增 `InteractiveSetupOptions` + `parseInteractiveSetupOptions`，解析交互式 setup 的 `--default-cli`（支持 `--default-cli=xxx` 形式；缺值/未知 key **立即抛错，在第一次扫码前就失败**），未知 flag 也报错。

## 为什么
bootstrap 安装脚本或再次进 setup 时，希望默认选中某个 CLI，之前只能靠 TUI 手按或答案顺序，不稳定。程序化预选让安装器无需依赖按键时序。

## 影响面
- 仅 `botmux setup` 交互路径；scripted setup 子命令解析（`isScriptedSetupInvocation` 及 `BOT_FIELD_FLAGS` 那套）完全不变。
- 非 TTY 下 `interactiveSelect` 仍直接返回 null，行为不变。

## 测试
- `pnpm build` ✅
- `vitest run test/setup-args.test.ts test/setup-pickers.test.ts` → **46 passed**