### PR TITLE
refactor(platform): 建立平台运行时边界并接入 Lark

### DIFF
--- a/src/adapters/adopt-route.ts
+++ b/src/adapters/adopt-route.ts
@@ -12,6 +12,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { normalizePlatformDescriptor } from '../im/platform-descriptor.js';
 
 // ── 类型 ───────────────────────────────────────────────────────────────────────
 
@@ -19,6 +20,8 @@ import { readFileSync } from 'node:fs';
 export interface AdoptRoute {
   sessionId: string;
   chatId: string;
+  platform: string;
+  instanceId: string;
   larkAppId: string;
   rootMessageId: string;
 }
@@ -130,9 +133,13 @@ export async function queryAdoptSession(
     ) {
       return null;
     }
+    const identity = normalizePlatformDescriptor(b);
+    if (!identity || identity.platform !== 'lark') return null;
     return {
       sessionId: b.sessionId,
       chatId: b.chatId,
+      platform: identity.platform,
+      instanceId: identity.instanceId,
       larkAppId: b.larkAppId,
       rootMessageId: b.rootMessageId,
     };

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -14,6 +14,7 @@ import { normalizeStartupCommandList } from './core/startup-commands.js';
 import { sanitizePerBotEnv } from './core/per-bot-env.js';
 import { normalizeSubstituteMode } from './services/substitute-mode-normalize.js';
 import { normalizePluginIdList } from './core/plugins/ids.js';
+import type { PlatformInstanceRef } from './im/platform.js';
 
 export type ChatReplyMode = 'chat' | 'new-topic' | 'shared' | 'chat-topic';
 export type ContentTriggerScope = 'topic' | 'regularGroup' | 'both';
@@ -878,6 +879,8 @@ export interface BotConfig {
 
 export interface BotState {
   config: BotConfig;
+  /** Derived runtime identity; never written back to bots.json. */
+  platformInstance: PlatformInstanceRef;
   client: Lark.Client;
   botOpenId?: string;
   botName?: string;       // Lark app display name (from /bot/v3/info)
@@ -990,12 +993,18 @@ export function registerBot(cfg: BotConfig): BotState {
   });
   const state: BotState = {
     config: cfg,
+    platformInstance: platformInstanceForBotConfig(cfg),
     client,
     resolvedAllowedUsers: [...(cfg.allowedUsers ?? [])],
     rawAllowedUserResolution: new Map(),
   };
   bots.set(cfg.larkAppId, state);
   return state;
+}
+
+/** Derive the platform identity without changing the legacy BotConfig shape. */
+export function platformInstanceForBotConfig(cfg: Pick<BotConfig, 'larkAppId'>): PlatformInstanceRef {
+  return { platform: 'lark', instanceId: cfg.larkAppId };
 }
 
 export function getBot(larkAppId: string): BotState {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -112,6 +112,7 @@ import {
   describePluginDependencyError,
   enabledPluginDependents,
 } from './core/plugins/dependencies.js';
+import { normalizePlatformDescriptor } from './im/platform-descriptor.js';
 
 // Resolve the CLI's UI locale once from the global config file, so subsequent
 // CLI output (and any t() callers that don't pass an explicit locale) honour
@@ -3586,9 +3587,13 @@ function listOnlineDaemons(): Array<{ ipcPort: number; larkAppId: string; lastHe
     if (!f.endsWith('.json')) continue;
     try {
       const d = JSON.parse(readFileSync(join(regDir, f), 'utf-8'));
-      if (typeof d?.ipcPort !== 'number' || typeof d?.larkAppId !== 'string') continue;
+      const identity = normalizePlatformDescriptor(d);
+      // This private helper serves legacy Lark CLI RPCs. Future platform
+      // descriptors remain discoverable through the generic discovery module,
+      // but must never be routed through larkAppId-based commands here.
+      if (!identity || identity.platform !== 'lark' || typeof d?.ipcPort !== 'number') continue;
       if (now - (d.lastHeartbeat ?? 0) > STALE_MS) continue;
-      all.push({ ipcPort: d.ipcPort, larkAppId: d.larkAppId, lastHeartbeat: d.lastHeartbeat });
+      all.push({ ipcPort: d.ipcPort, larkAppId: identity.larkAppId, lastHeartbeat: d.lastHeartbeat });
     } catch { /* skip malformed */ }
   }
   return all;
@@ -6607,10 +6612,13 @@ export async function runHook(
       // 真非 botmux 会话 → passthrough 放行
       return { stdout: adapter.passthrough(payload) };
     }
+    if ((adopt.platform ?? 'lark') !== 'lark') {
+      return { stdout: adapter.passthrough(payload) };
+    }
     // adopt 命中 → 使用 adopt 路由信息
     routeSessionId = adopt.sessionId;
     routeChatId = adopt.chatId;
-    routeLarkAppId = adopt.larkAppId;
+    routeLarkAppId = adopt.instanceId ?? adopt.larkAppId;
     routeRoot = adopt.rootMessageId;
   }
 

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -337,6 +337,8 @@ export interface CommandHandlerDeps {
   lastRepoScan: Map<string, import('../services/project-scanner.js').ProjectInfo[]>;
   /** 会前预热文档评论会话：立即启动 CLI、读取文档并进入待命。 */
   prewarmDocCommentSession?: (ds: DaemonSession, sub: DocSubscription) => Promise<void>;
+  sendMessage?: typeof sendMessage;
+  sendDirectMessage?: typeof sendUserMessage;
 }
 
 // ─── Schedule command ────────────────────────────────────────────────────────
@@ -836,7 +838,7 @@ async function handleConfigCommand(
     // 在群/话题群里那会让 owner-only 的运营配置卡全员可见（按钮虽仍重验 admin 无法提权，
     // 但卡片本身就违背「始终私信」意图）。只回一句简短文字引导去单聊后重试。
     try {
-      await sendUserMessage(larkAppId, senderId, cardJson, 'interactive');
+      await (deps.sendDirectMessage ?? sendUserMessage)(larkAppId, senderId, cardJson, 'interactive');
     } catch {
       await reply(t('cmd.config.card_dm_failed', undefined, renderLoc));
     }
@@ -1195,7 +1197,12 @@ export async function handleCommand(
             const patchPath = join(config.session.dataDir, 'sandboxes', sid, patchName);
             writeFileSync(patchPath, d.patch);
             const fileKey = await uploadFile(larkAppId, patchPath);
-            await sendMessage(larkAppId, ds.session.chatId, JSON.stringify({ file_key: fileKey }), 'file');
+            await (deps.sendMessage ?? sendMessage)(
+              larkAppId,
+              ds.session.chatId,
+              JSON.stringify({ file_key: fileKey }),
+              'file',
+            );
             patchAttached = true;
           } catch (e) { logger.warn(`[${logTag}] /land patch attach failed: ${(e as Error).message}`); }
         }
@@ -2696,6 +2703,9 @@ export async function handleCommand(
                   targetChatId: newChatId,
                   targetRootMessageId: placeholderRootMessageId,
                   requesterLarkAppId: creatorAppId,
+                  requesterPlatform: 'lark',
+                  requesterInstanceId: creatorAppId,
+                  targetPlatform: 'lark',
                   requestingUserOpenId: senderOpenId,
                   // union_id is cross-app stable within a tenant — peer
                   // compares against its own session.ownerUnionId rather
@@ -2762,7 +2772,7 @@ export async function handleCommand(
           }, loc);
         }
         try {
-          const finalM1Id = await sendMessage(creatorAppId, newChatId, finalM1Text, 'text');
+          const finalM1Id = await (deps.sendMessage ?? sendMessage)(creatorAppId, newChatId, finalM1Text, 'text');
           // Patch the leader's session.rootMessageId to the real M1 id, but
           // only if the leader was actually transferred — for the empty-
           // leader / all_fresh path, ds was either closed or never moved,

--- a/src/core/dashboard-command/groups.ts
+++ b/src/core/dashboard-command/groups.ts
@@ -78,7 +78,7 @@ export async function handleDashboardGroups(
     scope: 'global',
   });
 
-  const sendUserMessage = testDeps.sendUserMessage ?? defaultSendUserMessage;
+  const sendUserMessage = testDeps.sendUserMessage ?? deps.sendDirectMessage ?? defaultSendUserMessage;
   try {
     await sendUserMessage(larkAppId, adminOpenId, cardJson, 'interactive');
     await deps.sessionReply(

--- a/src/core/dashboard-command/index.ts
+++ b/src/core/dashboard-command/index.ts
@@ -62,7 +62,7 @@ export async function handleDashboardCommand(
   // Every admin-gated response goes to the invoking admin's DM. The
   // topic receives only a short confirmation, sharing the `/card` idiom
   // (cmd.config.card_dmd: "configuration card sent to your DM").
-  const sendUserMessage = testDeps.sendUserMessage ?? defaultSendUserMessage;
+  const sendUserMessage = testDeps.sendUserMessage ?? deps.sendDirectMessage ?? defaultSendUserMessage;
   const reply = async (text: string, msgType: 'text' | 'interactive' = 'text'): Promise<void> => {
     if (!larkAppId) {
       await deps.sessionReply(rootId, text, msgType === 'interactive' ? 'interactive' : undefined, larkAppId);

--- a/src/core/dashboard-command/overview.ts
+++ b/src/core/dashboard-command/overview.ts
@@ -97,7 +97,7 @@ export async function handleDashboardOverview(
     { invokerOpenId: adminOpenId, locale },
   );
 
-  const sendUserMessage = testDeps.sendUserMessage ?? defaultSendUserMessage;
+  const sendUserMessage = testDeps.sendUserMessage ?? deps.sendDirectMessage ?? defaultSendUserMessage;
   try {
     await sendUserMessage(larkAppId, adminOpenId, cardJson, 'interactive');
     await deps.sessionReply(

--- a/src/core/dashboard-command/schedules.ts
+++ b/src/core/dashboard-command/schedules.ts
@@ -71,7 +71,7 @@ export async function handleDashboardSchedules(
     nowMs,
   );
 
-  const sendUserMessage = testDeps.sendUserMessage ?? defaultSendUserMessage;
+  const sendUserMessage = testDeps.sendUserMessage ?? deps.sendDirectMessage ?? defaultSendUserMessage;
   try {
     await sendUserMessage(larkAppId, adminOpenId, cardJson, 'interactive');
     await deps.sessionReply(

--- a/src/core/dashboard-command/sessions.ts
+++ b/src/core/dashboard-command/sessions.ts
@@ -69,7 +69,7 @@ export async function handleDashboardSessions(
     nowMs,
   );
 
-  const sendUserMessage = testDeps.sendUserMessage ?? defaultSendUserMessage;
+  const sendUserMessage = testDeps.sendUserMessage ?? deps.sendDirectMessage ?? defaultSendUserMessage;
   try {
     await sendUserMessage(larkAppId, adminOpenId, cardJson, 'interactive');
     await deps.sessionReply(

--- a/src/core/dashboard-command/settings.ts
+++ b/src/core/dashboard-command/settings.ts
@@ -79,7 +79,7 @@ export async function handleDashboardSettings(
 
   // DM the card to the bot admin; the topic gets only a
   // short confirmation. Matches `/card` (cmd.config.card_dmd) idiom.
-  const sendUserMessage = testDeps.sendUserMessage ?? defaultSendUserMessage;
+  const sendUserMessage = testDeps.sendUserMessage ?? deps.sendDirectMessage ?? defaultSendUserMessage;
   try {
     await sendUserMessage(larkAppId, adminOpenId, cardJson, 'interactive');
     await deps.sessionReply(

--- a/src/core/dashboard-command/workflows.ts
+++ b/src/core/dashboard-command/workflows.ts
@@ -70,7 +70,7 @@ export async function handleDashboardWorkflows(
     nowMs,
   );
 
-  const sendUserMessage = testDeps.sendUserMessage ?? defaultSendUserMessage;
+  const sendUserMessage = testDeps.sendUserMessage ?? deps.sendDirectMessage ?? defaultSendUserMessage;
   try {
     await sendUserMessage(larkAppId, adminOpenId, cardJson, 'interactive');
     await deps.sessionReply(

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -63,7 +63,18 @@ import * as chatFirstSeenStore from '../services/chat-first-seen-store.js';
 import * as scheduler from './scheduler.js';
 import { listActiveSessions, findActiveBySessionId, closeSession, getActiveSessionsRegistry, transferSession, deliverWriteLinkCardToOwners, forkWorker, suspendWorker } from './worker-pool.js';
 import { listOnlineDaemons } from '../utils/daemon-discovery.js';
-import { getChatMode, replyMessage, sendMessage, resolveUnionIdFromOpenId, listThreadMessages, listChatMessages, listChatBotMembers, getUserProfile, resolveAllowedUsersWithMap, type ChatBotMember } from '../im/lark/client.js';
+import {
+  getChatMode,
+  replyMessage as replyLarkMessage,
+  sendMessage as sendLarkMessage,
+  resolveUnionIdFromOpenId,
+  listThreadMessages,
+  listChatMessages,
+  listChatBotMembers,
+  getUserProfile,
+  resolveAllowedUsersWithMap,
+  type ChatBotMember,
+} from '../im/lark/client.js';
 import { parseApiMessage, cardContentHasUpgradeFallback, resolveMergedCardContent } from '../im/lark/message-parser.js';
 import { resumeSession, spawnDashboardSession, activateQueuedSession, closeCliMismatchedSessionsForBot, suspendActiveSessionsForBot } from './session-manager.js';
 import { parseSpawnRequest } from './session-create.js';
@@ -89,6 +100,12 @@ import type { TriggerInput, TriggerResult } from '../workflows/trigger-run.js';
 import { validateTriggerRequest, type TriggerResponse } from '../services/trigger-types.js';
 import { resolveCliSelection, selectionKeyForBot } from '../setup/cli-selection.js';
 import { enrichHistorySenders, type HistoryBotInfo } from '../dashboard/history-senders.js';
+import {
+  requireSamePlatformInstance,
+  samePlatform,
+  type PlatformInstanceIdentity,
+} from '../im/platform.js';
+import { requirePlatformPort, type PlatformRuntime } from '../im/ports.js';
 
 // Workflow runner is wired by the daemon (it owns the heavy triggerWorkflowRun
 // deps). Until set, workflow-targeted triggers report not-implemented.
@@ -217,6 +234,60 @@ export function setBotName(name: string): void { setRowsBotName(name); }
 // endpoints below which proxy calls into groups-store on this bot's behalf.
 let cachedLarkAppId = '';
 export function setLarkAppId(id: string): void { cachedLarkAppId = id; }
+let cachedPlatformRuntime: PlatformRuntime | undefined;
+export function setPlatformRuntime(runtime: PlatformRuntime | undefined): void {
+  cachedPlatformRuntime = runtime;
+}
+
+function runtimeForLarkApp(larkAppId: string): PlatformRuntime | undefined {
+  const runtime = cachedPlatformRuntime;
+  if (!runtime) return undefined;
+  requireSamePlatformInstance(runtime.instance, { platform: 'lark', instanceId: larkAppId });
+  return runtime;
+}
+
+async function sendMessage(
+  larkAppId: string,
+  chatId: string,
+  content: string,
+  msgType: string = 'text',
+  uuid?: string,
+  hookContext?: Record<string, unknown>,
+): Promise<string> {
+  const runtime = runtimeForLarkApp(larkAppId);
+  if (!runtime) return sendLarkMessage(larkAppId, chatId, content, msgType, uuid, hookContext);
+  const conversation = {
+    instance: runtime.instance,
+    chatId,
+    conversationType: 'group',
+    scope: 'chat',
+    anchorId: chatId,
+  } as const;
+  const options = { contentType: msgType, idempotencyKey: uuid, context: hookContext };
+  const ref = msgType === 'interactive'
+    ? await requirePlatformPort(runtime, 'cards').sendCard(conversation, { payload: content }, options)
+    : await requirePlatformPort(runtime, 'messaging').sendMessage(conversation, content, options);
+  return ref.messageId;
+}
+
+async function replyMessage(
+  larkAppId: string,
+  messageId: string,
+  content: string,
+  msgType: string = 'text',
+  replyInThread: boolean = false,
+  uuid?: string,
+  hookContext?: Record<string, unknown>,
+): Promise<string> {
+  const runtime = runtimeForLarkApp(larkAppId);
+  if (!runtime) return replyLarkMessage(larkAppId, messageId, content, msgType, replyInThread, uuid, hookContext);
+  const target = { instance: runtime.instance, messageId };
+  const options = { contentType: msgType, inThread: replyInThread, idempotencyKey: uuid, context: hookContext };
+  const ref = msgType === 'interactive'
+    ? await requirePlatformPort(runtime, 'cards').replyCard(target, { payload: content }, options)
+    : await requirePlatformPort(runtime, 'messaging').replyMessage(target, content, options);
+  return ref.messageId;
+}
 
 ipcRoute('GET', '/api/sessions', (_req, res) => {
   // Active first (live state), closed appended (historical)
@@ -325,7 +396,10 @@ ipcRoute('POST', '/api/sessions/:sessionId/suspend', (_req, res, params) => {
 /** 解析 session（活跃优先，已关闭兜底）。活跃会话取 ds.session —— registry 与
  *  store 持有同一对象，改字段后 updateSession 即落盘。 */
 function findSessionRecord(sessionId: string): Session | undefined {
-  return findActiveBySessionId(sessionId)?.session ?? sessionStore.getSession(sessionId);
+  return findActiveBySessionId(sessionId)?.session
+    ?? (cachedLarkAppId
+      ? sessionStore.getSessionForInstance(sessionId, { platform: 'lark', instanceId: cachedLarkAppId })
+      : sessionStore.getLocalSession(sessionId));
 }
 
 function buildAsyncTriggerLookupResponse(sessionId: string, triggerId?: string): TriggerResponse {
@@ -881,6 +955,9 @@ ipcRoute('POST', '/api/sessions/migrate-to-chat', async (req, res) => {
     targetChatId?: string;
     targetRootMessageId?: string;
     requesterLarkAppId?: string;
+    requesterPlatform?: string;
+    requesterInstanceId?: string;
+    targetPlatform?: string;
     requestingUserOpenId?: string;
     requestingUserUnionId?: string;
   };
@@ -894,6 +971,22 @@ ipcRoute('POST', '/api/sessions/migrate-to-chat', async (req, res) => {
     return jsonRes(res, 400, { ok: false, error: 'missing_field' });
   }
 
+  const requesterInstance: PlatformInstanceIdentity = {
+    platform: body.requesterPlatform?.trim() || 'lark',
+    instanceId: body.requesterInstanceId?.trim() || requesterLarkAppId,
+  };
+  const receiverInstance: PlatformInstanceIdentity = {
+    platform: 'lark',
+    instanceId: cachedLarkAppId,
+  };
+  const targetPlatform = body.targetPlatform?.trim() || receiverInstance.platform;
+  // Cross-platform coordination is rejected before registry/session lookup or
+  // any transfer side effect. Legacy bodies omit these fields and derive Lark.
+  if (!samePlatform(requesterInstance, receiverInstance)
+    || !samePlatform(receiverInstance, { platform: targetPlatform })) {
+    return jsonRes(res, 400, { ok: false, error: 'unsupported_cross_platform' });
+  }
+
   // Requester must be a live botmux daemon — not a random localhost process
   // pretending to be one. We check the cross-process daemon registry
   // (~/.botmux/data/dashboard-daemons/<larkAppId>.json + heartbeat) rather
@@ -901,7 +994,13 @@ ipcRoute('POST', '/api/sessions/migrate-to-chat', async (req, res) => {
   // daemon process, and a per-process `getAllBots()` only sees its OWN bot
   // (botmux is one-daemon-per-bot at boot, daemon.ts:2367). Using the
   // registry lets the peer recognise the leader bot.
-  const requesterKnown = listOnlineDaemons().some(d => d.larkAppId === requesterLarkAppId);
+  const requesterKnown = listOnlineDaemons().some(d => {
+    const platform = d.platform ?? 'lark';
+    const instanceId = d.instanceId ?? d.larkAppId;
+    return samePlatform({ platform }, requesterInstance)
+      && instanceId === requesterInstance.instanceId
+      && d.larkAppId === requesterLarkAppId;
+  });
   if (!requesterKnown) return jsonRes(res, 403, { ok: false, error: 'unknown_requester' });
 
   // Locate this daemon's own session at the given source anchor. We match
@@ -959,7 +1058,14 @@ ipcRoute('POST', '/api/sessions/migrate-to-chat', async (req, res) => {
 
   // Target chat was built by the leader's /relay --create — by
   // construction a regular group, chat-scope (M1 is the audit anchor).
-  const result = await transferSession(ds.session.sessionId, targetChatId, targetRootMessageId, 'group', 'chat');
+  const result = await transferSession(
+    ds.session.sessionId,
+    targetChatId,
+    targetRootMessageId,
+    'group',
+    'chat',
+    { targetInstance: receiverInstance },
+  );
   if (!result.ok) {
     return jsonRes(res, 500, { ok: false, error: result.error });
   }
@@ -981,21 +1087,12 @@ ipcRoute('POST', '/api/sessions/:sessionId/locate', async (_req, res, params) =>
   // locate marker is a bare @-mention of the session's owner — no other text,
   // no AppLink redirect on the frontend. The notification on the user's
   // device is enough to navigate them back to the topic.
-  const ds = findActiveBySessionId(sid);
-  const closed = ds ? null : sessionStore.getSession(sid);
-  const ctx = ds
-    ? {
-        larkAppId: ds.larkAppId,
-        rootMessageId: ds.session.rootMessageId,
-        ownerOpenId: ds.session.ownerOpenId,
-      }
-    : closed
-      ? {
-          larkAppId: closed.larkAppId ?? '',
-          rootMessageId: closed.rootMessageId,
-          ownerOpenId: closed.ownerOpenId,
-        }
-      : null;
+  const session = findSessionRecord(sid);
+  const ctx = session ? {
+    larkAppId: session.larkAppId ?? cachedLarkAppId,
+    rootMessageId: session.rootMessageId,
+    ownerOpenId: session.ownerOpenId,
+  } : null;
   if (!ctx || !ctx.larkAppId) {
     return jsonRes(res, 404, { ok: false, error: 'session_not_found' });
   }

--- a/src/core/doc-comment-poller.ts
+++ b/src/core/doc-comment-poller.ts
@@ -1,4 +1,18 @@
-import type { DocComment } from '../im/lark/doc-comment.js';
+/** Platform-neutral minimum shape consumed by the cursor logic. The Lark
+ * adapter's normalized document comments satisfy this structurally without
+ * coupling the core poller back to that adapter. */
+export interface DocCommentPollInput {
+  commentId: string;
+  quote?: string;
+  isWhole?: boolean;
+  replies: Array<{
+    replyId: string;
+    userId?: string;
+    text: string;
+    mentions: string[];
+    createdAt?: number;
+  }>;
+}
 
 export interface DocCommentPollCursor {
   createdAt: number;
@@ -30,7 +44,7 @@ export function compareDocCommentPollCursor(a: DocCommentPollCursor, b: DocComme
   return compareReplyIds(a.replyId, b.replyId);
 }
 
-export function flattenDocCommentReplies(comments: DocComment[]): PolledDocReply[] {
+export function flattenDocCommentReplies(comments: DocCommentPollInput[]): PolledDocReply[] {
   return comments.flatMap(comment => comment.replies.map((reply, index) => ({
     commentId: comment.commentId,
     replyId: reply.replyId,
@@ -48,12 +62,12 @@ export function flattenDocCommentReplies(comments: DocComment[]): PolledDocReply
     .sort(compareDocCommentPollCursor);
 }
 
-export function latestDocCommentPollCursor(comments: DocComment[]): DocCommentPollCursor | undefined {
+export function latestDocCommentPollCursor(comments: DocCommentPollInput[]): DocCommentPollCursor | undefined {
   return flattenDocCommentReplies(comments).at(-1);
 }
 
 export function docCommentRepliesAfterCursor(
-  comments: DocComment[],
+  comments: DocCommentPollInput[],
   cursor: DocCommentPollCursor,
 ): PolledDocReply[] {
   return flattenDocCommentReplies(comments).filter(reply => compareDocCommentPollCursor(reply, cursor) > 0);

--- a/src/core/doc-comment-prompt.ts
+++ b/src/core/doc-comment-prompt.ts
@@ -1,5 +1,8 @@
-import type { Brand } from '../im/lark/lark-hosts.js';
 import type { Locale } from '../i18n/index.js';
+
+/** Brand value needed only to select the public document host. Keep the core
+ * prompt builder independent from the concrete Lark adapter module. */
+export type DocCommentBrand = 'feishu' | 'lark';
 
 export interface DocCommentPromptInput {
   fileToken: string;
@@ -8,14 +11,14 @@ export interface DocCommentPromptInput {
   author: string;
   selectedText?: string;
   priorReplies?: Array<{ author?: string; text: string }>;
-  brand?: Brand;
+  brand?: DocCommentBrand;
   locale?: Locale;
 }
 
 export interface DocWatchWarmupPromptInput {
   fileToken: string;
   fileType: string;
-  brand?: Brand;
+  brand?: DocCommentBrand;
   locale?: Locale;
 }
 

--- a/src/core/inherit-peer.ts
+++ b/src/core/inherit-peer.ts
@@ -22,6 +22,12 @@ import { resolve } from 'node:path';
 import * as sessionStore from '../services/session-store.js';
 import { logger } from '../utils/logger.js';
 import { expandHomePath } from '../utils/working-dir.js';
+import {
+  derivePlatformInstanceIdentity,
+  samePlatform,
+  samePlatformInstance,
+  type PlatformInstanceIdentity,
+} from '../im/platform.js';
 
 export interface InheritOptions {
   scope: 'thread' | 'chat';
@@ -29,6 +35,8 @@ export interface InheritOptions {
   chatId: string;
   chatType: 'group' | 'p2p';
   selfAppId: string;
+  /** Complete receiving-runtime identity. Legacy callers default to Lark. */
+  selfInstance?: PlatformInstanceIdentity;
   /** Per-bot gate on the RECEIVING (self) bot: when false, this bot never
    *  inherits a sibling bot's workingDir — it falls through to its own repo
    *  card / default instead. Default true (undefined = on). Surfaced in the
@@ -56,13 +64,16 @@ function isValidPeerWorkingDir(workingDir: string): boolean {
 
 export function findInheritablePeer(opts: InheritOptions): InheritedPeer | null {
   const { scope, anchor, chatId, selfAppId } = opts;
+  const selfInstance = opts.selfInstance ?? { platform: 'lark', instanceId: selfAppId };
   // Receiving bot opted out of cross-bot same-dir inheritance → never inherit.
   if (opts.botToBotSameDir === false) return null;
   const sameAnchorPeers = scope === 'thread'
     ? sessionStore.findActiveSessionsByRoot(anchor)
     : sessionStore.findActiveChatScopeSessionsByChat(chatId);
   for (const peer of sameAnchorPeers) {
-    if (peer.larkAppId === selfAppId || !peer.workingDir) continue;
+    const peerInstance = derivePlatformInstanceIdentity(peer, peer.larkAppId);
+    if (!peerInstance || !samePlatform(selfInstance, peerInstance)) continue;
+    if (samePlatformInstance(peerInstance, selfInstance) || !peer.workingDir) continue;
     if (isValidPeerWorkingDir(peer.workingDir)) {
       return { sessionId: peer.sessionId, larkAppId: peer.larkAppId, workingDir: peer.workingDir };
     }

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -36,10 +36,18 @@ import {
 } from './session-create.js';
 import { validateZellijAdoptTarget } from './zellij-adopt-discovery.js';
 import type { BackendType } from '../adapters/backend/types.js';
-import type { LarkAttachment, LarkMention, ScheduledTask, SubstituteTrigger } from '../types.js';
+import type { ScheduledTask, Session, SubstituteTrigger } from '../types.js';
+import {
+  derivePlatformInstanceIdentity,
+  requireSamePlatformInstance,
+  samePlatformInstance,
+  type PlatformAttachment,
+  type PlatformMention,
+  type PlatformSender,
+} from '../im/platform.js';
+import { requirePlatformPort, type PlatformRuntime } from '../im/ports.js';
 import type { MessageResource } from '../im/lark/message-parser.js';
-import type { ResolvedSender } from '../im/lark/identity-cache.js';
-import { sessionKey, sessionAnchorId } from './types.js';
+import { createPlatformSessionContext, sessionKey, sessionAnchorId } from './types.js';
 import type { DaemonSession } from './types.js';
 import { announceSessionRow, markSessionActivity, announcePendingRepoSession } from './session-activity.js';
 import { scanMultipleProjects } from '../services/project-scanner.js';
@@ -58,6 +66,91 @@ function sessionCreatedAtMs(session: { createdAt?: string }): number {
 
 function sessionLastMessageAtMs(session: { createdAt?: string; lastMessageAt?: string }): number {
   return session.lastMessageAt ? (Date.parse(session.lastMessageAt) || sessionCreatedAtMs(session)) : sessionCreatedAtMs(session);
+}
+
+function larkPlatformContext(
+  larkAppId: string,
+  chatId: string,
+  chatType: 'group' | 'p2p',
+  scope: 'thread' | 'chat',
+  rootMessageId: string,
+) {
+  return createPlatformSessionContext(
+    { platform: 'lark', instanceId: larkAppId },
+    chatId,
+    chatType,
+    scope,
+    rootMessageId,
+  );
+}
+
+let injectedPlatformRuntime: PlatformRuntime | undefined;
+
+/** Composition-root injection for scheduler/dashboard session paths. */
+export function setSessionManagerPlatformRuntime(runtime: PlatformRuntime | undefined): void {
+  injectedPlatformRuntime = runtime;
+}
+
+function runtimeForLarkApp(larkAppId: string): PlatformRuntime | undefined {
+  const runtime = injectedPlatformRuntime;
+  if (!runtime) return undefined;
+  requireSamePlatformInstance(runtime.instance, { platform: 'lark', instanceId: larkAppId });
+  return runtime;
+}
+
+async function platformSendMessage(
+  larkAppId: string,
+  chatId: string,
+  content: string,
+  msgType: string = 'text',
+): Promise<string> {
+  const runtime = runtimeForLarkApp(larkAppId);
+  if (!runtime) {
+    const { sendMessage } = await import('../im/lark/client.js');
+    return sendMessage(larkAppId, chatId, content, msgType);
+  }
+  const conversation = {
+    instance: runtime.instance,
+    chatId,
+    conversationType: 'group',
+    scope: 'chat',
+    anchorId: chatId,
+  } as const;
+  const ref = msgType === 'interactive'
+    ? await requirePlatformPort(runtime, 'cards').sendCard(conversation, { payload: content })
+    : await requirePlatformPort(runtime, 'messaging').sendMessage(
+      conversation,
+      content,
+      { contentType: msgType },
+    );
+  return ref.messageId;
+}
+
+async function platformReplyMessage(
+  larkAppId: string,
+  messageId: string,
+  content: string,
+  msgType: string = 'text',
+  replyInThread: boolean = false,
+): Promise<string> {
+  const runtime = runtimeForLarkApp(larkAppId);
+  if (!runtime) {
+    const { replyMessage } = await import('../im/lark/client.js');
+    return replyMessage(larkAppId, messageId, content, msgType, replyInThread);
+  }
+  const target = { instance: runtime.instance, messageId };
+  const ref = msgType === 'interactive'
+    ? await requirePlatformPort(runtime, 'cards').replyCard(
+      target,
+      { payload: content },
+      { inThread: replyInThread },
+    )
+    : await requirePlatformPort(runtime, 'messaging').replyMessage(
+      target,
+      content,
+      { contentType: msgType, inThread: replyInThread },
+    );
+  return ref.messageId;
 }
 
 function sameUsageLimit(a: DaemonSession['usageLimit'], b: DaemonSession['usageLimit']): boolean {
@@ -240,10 +333,15 @@ export function getAttachmentsDir(larkAppId: string, messageId: string): string 
   return join(resolve(config.session.dataDir), 'attachments', assertSafeAppId(larkAppId), messageId);
 }
 
-export async function downloadResources(larkAppId: string, messageId: string, resources: MessageResource[]): Promise<{ attachments: LarkAttachment[]; needLogin: boolean }> {
+export async function downloadResources(
+  larkAppId: string,
+  messageId: string,
+  resources: MessageResource[],
+  runtime?: PlatformRuntime,
+): Promise<{ attachments: PlatformAttachment[]; needLogin: boolean }> {
   if (resources.length === 0) return { attachments: [], needLogin: false };
 
-  const attachments: LarkAttachment[] = [];
+  const attachments: PlatformAttachment[] = [];
   // Resolve the per-appId bucket up front. assertSafeAppId (inside getAttachmentsDir)
   // throws on a path-unsafe appId (only reachable via a hand-edited bots.json — real
   // Feishu ids always pass). SOFT-fail rather than let it propagate: an invalid appId
@@ -262,8 +360,21 @@ export async function downloadResources(larkAppId: string, messageId: string, re
     const savePath = join(dir, res.name);
     try {
       const resMessageId = res.messageId ?? messageId;
-      await downloadMessageResource(larkAppId, resMessageId, res.key, res.type, savePath);
-      attachments.push({ type: res.type, path: savePath, name: res.name });
+      if (runtime) {
+        const attachment = await requirePlatformPort(runtime, 'attachments').downloadAttachment({
+          sourceMessage: {
+            instance: { platform: 'lark', instanceId: larkAppId },
+            messageId: resMessageId,
+          },
+          resourceId: res.key,
+          type: res.type,
+          name: res.name,
+        }, savePath);
+        attachments.push(attachment);
+      } else {
+        await downloadMessageResource(larkAppId, resMessageId, res.key, res.type, savePath);
+        attachments.push({ type: res.type, path: savePath, name: res.name });
+      }
     } catch (err: any) {
       // Per-failure log stays at info to aid retries.
       logger.info(`Failed to download ${res.type} ${res.key}: ${err.message}`);
@@ -323,15 +434,28 @@ function xmlEscape(s: string): string {
     .replace(/'/g, '&apos;');
 }
 
+/** Lark prompt compatibility: only the open_id namespace may populate fields
+ * literally named open_id. Other opaque identifiers remain usable by future
+ * platform logic but must not be mislabeled here. */
+function mentionOpenId(mention: PlatformMention): string | undefined {
+  const identity = mention.identity;
+  if (!identity) return undefined;
+  return identity.idType === undefined || identity.idType === 'open_id'
+    ? identity.id
+    : undefined;
+}
+
 /**
  * Render a `<sender>` tag for prompt injection. Caller resolves the sender
  * (open_id + type + optional name) via `resolveSender(...)` in identity-cache.
  * Returns empty string when no sender data is available so the prompt stays
  * clean for synthetic flows (scheduled tasks, no-op spawns).
  */
-export function renderSenderTag(sender?: ResolvedSender): string {
-  if (!sender || !sender.openId) return '';
-  const attrs: string[] = [`type="${xmlEscape(sender.type)}"`, `open_id="${xmlEscape(sender.openId)}"`];
+export function renderSenderTag(sender?: PlatformSender): string {
+  if (!sender || !sender.id) return '';
+  // Keep the legacy prompt attribute name for Lark sessions; the in-memory
+  // sender model itself is platform-neutral and carries only an opaque id.
+  const attrs: string[] = [`type="${xmlEscape(sender.type)}"`, `open_id="${xmlEscape(sender.id)}"`];
   if (sender.name) attrs.push(`name="${xmlEscape(sender.name)}"`);
   return `<sender ${attrs.join(' ')} />`;
 }
@@ -361,7 +485,7 @@ export function renderCursorSenderNote(cliId: CliId | undefined, hasSender: bool
  * may be absent entirely when pendingSender is undefined). Returns '' when
  * there is no sender to attribute.
  */
-export function renderBufferedSenderBlock(sender: ResolvedSender | undefined, cliId: CliId | undefined, locale?: Locale): string {
+export function renderBufferedSenderBlock(sender: PlatformSender | undefined, cliId: CliId | undefined, locale?: Locale): string {
   const tag = renderSenderTag(sender);
   if (!tag) return '';
   const note = renderCursorSenderNote(cliId, true, locale);
@@ -388,7 +512,7 @@ function renderSubstituteTrigger(trigger?: SubstituteTrigger): string {
   ].join('\n');
 }
 
-export function formatAttachmentsHint(attachments?: LarkAttachment[], locale?: Locale): string {
+export function formatAttachmentsHint(attachments?: PlatformAttachment[], locale?: Locale): string {
   if (!attachments || attachments.length === 0) return '';
   let imgN = 0, fileN = 0;
   const items = attachments.map(a => {
@@ -493,13 +617,13 @@ export function buildNewTopicPrompt(
   sessionId: string,
   cliId: CliId,
   cliPathOverride?: string,
-  attachments?: LarkAttachment[],
-  mentions?: LarkMention[],
+  attachments?: PlatformAttachment[],
+  mentions?: PlatformMention[],
   availableBots?: Array<{ name: string; displayName: string; openId: string }>,
   followUps?: string[],
   botIdentity?: { name?: string; openId?: string },
   locale?: Locale,
-  sender?: ResolvedSender,
+  sender?: PlatformSender,
   opts?: { larkAppId?: string; chatId?: string; whiteboardId?: string; substituteTrigger?: SubstituteTrigger },
 ): string {
   const adapter = createCliAdapterSync(cliId, cliPathOverride);
@@ -551,7 +675,8 @@ export function buildNewTopicPrompt(
   let mentionBlock = '';
   if (mentions && mentions.length > 0) {
     const items = mentions.map(m => {
-      const oid = m.openId ? ` open_id="${xmlEscape(m.openId)}"` : '';
+      const id = mentionOpenId(m);
+      const oid = id ? ` open_id="${xmlEscape(id)}"` : '';
       return `  <mention name="${xmlEscape(m.name)}"${oid} />`;
     });
     mentionBlock = `<mentions>\n${items.join('\n')}\n</mentions>`;
@@ -559,7 +684,7 @@ export function buildNewTopicPrompt(
 
   let botBlock = '';
   if (availableBots && availableBots.length > 0) {
-    const mentionedOpenIds = new Set(mentions?.map(m => m.openId).filter(Boolean));
+    const mentionedOpenIds = new Set(mentions?.map(mentionOpenId).filter(Boolean));
     const unmentionedBots = availableBots.filter(b => !mentionedOpenIds.has(b.openId));
     if (unmentionedBots.length > 0) {
       // ≤ threshold peers: inline the full roster with open_ids so any
@@ -646,7 +771,7 @@ export function buildNewTopicPrompt(
 export function buildFollowUpContent(
   content: string,
   sessionId: string,
-  opts?: { attachments?: LarkAttachment[]; mentions?: LarkMention[]; isAdoptMode?: boolean; cliId?: CliId; cliPathOverride?: string; locale?: Locale; sender?: ResolvedSender; larkAppId?: string; chatId?: string; whiteboardId?: string; substituteTrigger?: SubstituteTrigger },
+  opts?: { attachments?: PlatformAttachment[]; mentions?: PlatformMention[]; isAdoptMode?: boolean; cliId?: CliId; cliPathOverride?: string; locale?: Locale; sender?: PlatformSender; larkAppId?: string; chatId?: string; whiteboardId?: string; substituteTrigger?: SubstituteTrigger },
 ): string {
   const parts: string[] = [];
   const roleBlock = renderRoleContextBlock(opts?.larkAppId, opts?.chatId, { followUp: true });
@@ -688,7 +813,8 @@ export function buildFollowUpContent(
 
   if (opts?.mentions && opts.mentions.length > 0) {
     const items = opts.mentions.map(m => {
-      const oid = m.openId ? ` open_id="${xmlEscape(m.openId)}"` : '';
+      const id = mentionOpenId(m);
+      const oid = id ? ` open_id="${xmlEscape(id)}"` : '';
       return `  <mention name="${xmlEscape(m.name)}"${oid} />`;
     });
     parts.push(`<mentions>\n${items.join('\n')}\n</mentions>`);
@@ -713,8 +839,8 @@ export function buildFollowUpContent(
 export function buildBridgeInputContent(
   content: string,
   opts?: {
-    attachments?: LarkAttachment[];
-    mentions?: LarkMention[];
+    attachments?: PlatformAttachment[];
+    mentions?: PlatformMention[];
     selfMention?: { name?: string | null; openId?: string | null };
     locale?: Locale;
   },
@@ -723,16 +849,17 @@ export function buildBridgeInputContent(
   const selfNames = new Set<string>();
   if (selfMention?.name) selfNames.add(selfMention.name);
   for (const m of opts?.mentions ?? []) {
-    if (selfMention?.openId && m.openId === selfMention.openId) selfNames.add(m.name);
+    if (selfMention?.openId && mentionOpenId(m) === selfMention.openId) selfNames.add(m.name);
     if (selfMention?.name && m.name === selfMention.name) selfNames.add(m.name);
   }
 
-  const isSelfMention = (m: LarkMention): boolean => {
+  const isSelfMention = (m: PlatformMention): boolean => {
     // openId is authoritative when both sides have it — avoids classifying
     // a different bot as self in the (theoretical) case where two bots in
     // the same chat share a display name.
-    if (selfMention?.openId && m.openId) {
-      return m.openId === selfMention.openId;
+    const openId = mentionOpenId(m);
+    if (selfMention?.openId && openId) {
+      return openId === selfMention.openId;
     }
     // At least one side is missing openId (cold-start window before
     // probeBotOpenId returns, or a mention without openId): fall back to
@@ -802,13 +929,13 @@ export function buildReforkPrompt(
   ds: DaemonSession,
   content: string,
   opts?: {
-    attachments?: LarkAttachment[];
-    mentions?: LarkMention[];
+    attachments?: PlatformAttachment[];
+    mentions?: PlatformMention[];
     cliId?: CliId;
     cliPathOverride?: string;
     selfMention?: { name?: string | null; openId?: string | null };
     locale?: Locale;
-    sender?: ResolvedSender;
+    sender?: PlatformSender;
   },
 ): string {
   const locale = opts?.locale ?? localeForBot(ds.larkAppId);
@@ -934,7 +1061,28 @@ export async function staggeredRecoveryFork(
 
 export async function restoreActiveSessions(activeSessions: Map<string, DaemonSession>): Promise<void> {
   const sessions = sessionStore.listSessions();
-  const active = sessions.filter(s => s.status === 'active');
+  const runtimeAppId = getAllBots()[0]?.config.larkAppId;
+  const runtimeInstance = runtimeAppId
+    ? { platform: 'lark', instanceId: runtimeAppId }
+    : undefined;
+  const isRuntimeOwned = (session: Session): boolean => {
+    if (!runtimeInstance) return true;
+    const owner = derivePlatformInstanceIdentity(session, runtimeAppId);
+    return !!owner && samePlatformInstance(owner, runtimeInstance);
+  };
+  const active = sessions.filter(s =>
+    s.status === 'active'
+    && isRuntimeOwned(s),
+  );
+  const foreignActive = sessions.filter(s =>
+    s.status === 'active' && runtimeInstance && !isRuntimeOwned(s),
+  );
+  if (foreignActive.length > 0) {
+    logger.warn(
+      `[platform-session] skipped ${foreignActive.length} active session(s) owned by another instance `
+      + `while restoring lark:${runtimeAppId}`,
+    );
+  }
 
   if (active.length === 0) {
     logger.info('No active sessions to restore');
@@ -967,9 +1115,10 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
         continue;
       }
       // Original CLI still alive — re-register and fork adopt worker
-      const larkAppId = session.larkAppId ?? getAllBots()[0]?.config.larkAppId ?? '';
+      const larkAppId = derivePlatformInstanceIdentity(session, runtimeAppId)?.instanceId ?? runtimeAppId ?? '';
       const ds: DaemonSession = {
         session,
+        platform: larkPlatformContext(larkAppId, session.chatId, session.chatType ?? 'group', scope, session.rootMessageId),
         worker: null,
         workerPort: null,
         workerToken: null,
@@ -1025,9 +1174,10 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
     // queued），绝不能走下面 hasHistory:true 的通用分支——否则下一条消息会 --resume 一个
     // 不存在的 CLI 会话。pendingPrompt 从持久化的 queuedPrompt 恢复，供激活时发首轮。
     if (session.queued) {
-      const larkAppId = session.larkAppId ?? getAllBots()[0]?.config.larkAppId ?? '';
+      const larkAppId = derivePlatformInstanceIdentity(session, runtimeAppId)?.instanceId ?? runtimeAppId ?? '';
       const ds: DaemonSession = {
         session,
+        platform: larkPlatformContext(larkAppId, session.chatId, session.chatType ?? 'group', scope, session.rootMessageId),
         worker: null,
         workerPort: null,
         workerToken: null,
@@ -1054,9 +1204,10 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
       continue;
     }
 
-    const larkAppId = session.larkAppId ?? getAllBots()[0]?.config.larkAppId ?? '';
+    const larkAppId = derivePlatformInstanceIdentity(session, runtimeAppId)?.instanceId ?? runtimeAppId ?? '';
     const ds: DaemonSession = {
       session,
+      platform: larkPlatformContext(larkAppId, session.chatId, session.chatType ?? 'group', scope, session.rootMessageId),
       worker: null,
       workerPort: null,
       workerToken: null,
@@ -1257,7 +1408,10 @@ export async function resumeSession(
   activeSessions: Map<string, DaemonSession>,
 ): Promise<{ ok: true; ds: DaemonSession }
 | { ok: false; error: 'not_found' | 'not_closed' | 'anchor_occupied' | 'adopt_unsupported'; activeSessionId?: string }> {
-  const session = sessionStore.getSession(sessionId);
+  const currentLarkAppId = getAllBots()[0]?.config.larkAppId ?? '';
+  const session = currentLarkAppId
+    ? sessionStore.getSessionForInstance(sessionId, { platform: 'lark', instanceId: currentLarkAppId })
+    : sessionStore.getSession(sessionId);
   if (!session) return { ok: false, error: 'not_found' };
   if (session.status !== 'closed') return { ok: false, error: 'not_closed' };
 
@@ -1269,7 +1423,8 @@ export async function resumeSession(
   }
 
   const scope: 'thread' | 'chat' = session.scope === 'chat' ? 'chat' : 'thread';
-  const larkAppId = session.larkAppId ?? getAllBots()[0]?.config.larkAppId ?? '';
+  const larkAppId = derivePlatformInstanceIdentity(session, currentLarkAppId)?.instanceId
+    ?? currentLarkAppId;
   const anchor = scope === 'thread' ? session.rootMessageId : session.chatId;
   const key = sessionKey(anchor, larkAppId);
 
@@ -1322,7 +1477,10 @@ export async function resumeSession(
   const conflicts = sessionStore.listSessions().filter(s =>
     s.sessionId !== sessionId
     && s.status === 'active'
-    && (s.larkAppId ?? '') === larkAppId
+    && samePlatformInstance(
+      derivePlatformInstanceIdentity(s, currentLarkAppId) ?? { platform: '', instanceId: '' },
+      { platform: 'lark', instanceId: larkAppId },
+    )
     && (s.scope === 'chat' ? 'chat' : 'thread') === scope
     && (scope === 'thread' ? s.rootMessageId === anchor : s.chatId === anchor),
   );
@@ -1344,6 +1502,7 @@ export async function resumeSession(
   const now = Date.now();
   const ds: DaemonSession = {
     session,
+    platform: larkPlatformContext(larkAppId, session.chatId, session.chatType ?? 'group', scope, session.rootMessageId),
     worker: null,
     workerPort: null,
     workerToken: null,
@@ -1399,7 +1558,9 @@ export async function executeScheduledTask(
     allBots[0];
   const larkAppId = bot.config.larkAppId;
 
-  const { getChatMode, sendMessage, replyMessage } = await import('../im/lark/client.js');
+  const { getChatMode } = await import('../im/lark/client.js');
+  const sendMessage = platformSendMessage;
+  const replyMessage = platformReplyMessage;
 
   // Scope resolution — explicit task.scope wins; otherwise fall back to legacy
   // semantics (rootMessageId present → thread, absent → chat). Restoring an
@@ -1554,6 +1715,13 @@ export async function executeScheduledTask(
 
   const ds: DaemonSession = {
     session,
+    platform: larkPlatformContext(
+      larkAppId,
+      task.chatId,
+      task.chatType === 'p2p' ? 'p2p' : 'group',
+      runtimeScope,
+      session.rootMessageId,
+    ),
     worker: null,
     workerPort: null,
     workerToken: null,
@@ -1622,12 +1790,11 @@ async function forkOrShowRepoCard(ds: DaemonSession, userContent: string): Promi
       // (The pending dashboard row is announced inside runAutoWorktreeCommit so all
       // three spawn callers get it from one place — no publish needed here.)
       const { runAutoWorktreeCommit } = await import('../im/lark/card-handler.js');
-      const { sendMessage } = await import('../im/lark/client.js');
       void runAutoWorktreeCommit({
         ds, anchor: ds.chatId, larkAppId, baseDir,
         title: ds.session.title, prompt: userContent,
         operatorOpenId: ds.session.ownerOpenId, activeSessions: registry,
-        notify: (m) => sendMessage(larkAppId, ds.chatId, m),
+        notify: (m) => platformSendMessage(larkAppId, ds.chatId, m),
       });
       logger.info(`[createSession] session ${ds.session.sessionId.substring(0, 8)} → pending, building worktree off ${baseDir}`);
       return;
@@ -1648,10 +1815,9 @@ async function forkOrShowRepoCard(ds: DaemonSession, userContent: string): Promi
     if (projects.length > 0) {
       try {
         const card = buildRepoSelectCard(projects, getSessionWorkingDir(ds), ds.chatId, locale, bot.config.worktreeMultiPicker);
-        const { sendMessage } = await import('../im/lark/client.js');
         ds.pendingRepo = true;
         ds.pendingPrompt = userContent;
-        ds.repoCardMessageId = await sendMessage(larkAppId, ds.chatId, card, 'interactive');
+        ds.repoCardMessageId = await platformSendMessage(larkAppId, ds.chatId, card, 'interactive');
         announcePendingRepoSession(ds);
         // 弹卡片这条路不经 forkWorker，session.spawned 不会自动发——手动 upsert 一条，
         // 让 dashboard 显示这条「待选仓库」会话（in_progress 首次 spawn 走这里才会出现）。
@@ -1727,8 +1893,7 @@ export async function spawnDashboardSession(
   let bannerMessageId: string | undefined;
   if (args.postBanner) {
     try {
-      const { sendMessage } = await import('../im/lark/client.js');
-      bannerMessageId = await sendMessage(larkAppId, chatId, t('cmd.createSession.banner', { content }, locale));
+      bannerMessageId = await platformSendMessage(larkAppId, chatId, t('cmd.createSession.banner', { content }, locale));
     } catch (err: any) {
       logger.warn(`[createSession] banner send failed in ${chatId}: ${err?.message ?? err}`);
     }
@@ -1764,6 +1929,7 @@ export async function spawnDashboardSession(
 
   const ds: DaemonSession = {
     session,
+    platform: larkPlatformContext(larkAppId, chatId, 'group', 'chat', session.rootMessageId),
     worker: null,
     workerPort: null,
     workerToken: null,

--- a/src/core/trigger-session.ts
+++ b/src/core/trigger-session.ts
@@ -13,7 +13,7 @@ import { forkWorker, getCurrentCliVersion } from './worker-pool.js';
 import { botAutoWorktreeEnabled } from '../services/default-worktree.js';
 import * as messageQueue from '../services/message-queue.js';
 import type { DaemonSession } from './types.js';
-import { sessionKey } from './types.js';
+import { createPlatformSessionContext, sessionKey } from './types.js';
 import type { TriggerRequest, TriggerResponse } from '../services/trigger-types.js';
 
 export interface TriggerSessionDeps {
@@ -381,6 +381,13 @@ export async function triggerSessionTurn(
 
   const newDs: DaemonSession = {
     session,
+    platform: createPlatformSessionContext(
+      { platform: 'lark', instanceId: larkAppId },
+      chatId,
+      'group',
+      scope,
+      session.rootMessageId,
+    ),
     worker: null,
     workerPort: null,
     workerToken: null,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,13 @@
 import type { ChildProcess } from 'node:child_process';
-import type { Session, DaemonToWorker, LarkAttachment, LarkMention, DisplayMode, StreamStatus } from '../types.js';
+import type { Session, DaemonToWorker, DisplayMode, StreamStatus } from '../types.js';
+import type {
+  PlatformAttachment,
+  PlatformConversationRef,
+  PlatformInstanceIdentity,
+  PlatformInstanceRef,
+  PlatformMention,
+  PlatformSender,
+} from '../im/platform.js';
 import type { CliUsageLimitState } from '../utils/cli-usage-limit.js';
 
 /** Frozen card state — cached content for historical streaming cards that can still be toggled. */
@@ -23,25 +31,22 @@ export function frozenDisplayMode(fc: FrozenCard): DisplayMode {
   return fc.expanded ? 'screenshot' : 'hidden';
 }
 
-/** Core session state — IM-agnostic.
- *  IM-specific rendering state (ImRenderState) is stored separately
- *  in the ImAdapter implementation (e.g. Map<string, ImRenderState>
- *  inside LarkImAdapter), NOT on this type. */
-export interface DaemonSession {
+/** Platform-neutral identity/routing state kept only in memory.
+ *
+ * It deliberately lives beside (not inside) the persisted `Session`: deriving
+ * this context for a legacy row must never rewrite that row with a new schema.
+ */
+export interface PlatformSessionContext {
+  instance: PlatformInstanceRef;
+  conversation: PlatformConversationRef;
+}
+
+/** Runtime state shared by every platform session. */
+export interface DaemonSessionState {
   session: Session;
   worker: ChildProcess | null;   // fork'd worker process
   workerPort: number | null;     // HTTP port for xterm.js
   workerToken: string | null;    // write token for xterm.js
-  larkAppId: string;
-  chatId: string;
-  chatType: 'group' | 'p2p';    // p2p chats need reply_in_thread to create topics
-  /** Routing scope:
-   *   'thread' → routing key = session.rootMessageId, replies use reply_in_thread=true
-   *   'chat'   → routing key = chatId, replies are plain chat messages
-   *  Must be set explicitly at session creation (no implicit default — every
-   *  caller decides based on event context). Restored sessions without a
-   *  persisted scope fall back to 'thread' in the restore path. */
-  scope: 'thread' | 'chat';
   spawnedAt: number;
   cliVersion: string;
   lastMessageAt: number;
@@ -65,13 +70,13 @@ export interface DaemonSession {
    *  the next turn instead of being dropped. In-memory only, like
    *  pendingRawInput. */
   pendingFollowUpInput?: { userPrompt: string; cliInput: string };
-  pendingAttachments?: LarkAttachment[];
-  pendingMentions?: LarkMention[];    // @mentions from initial message, used when building prompt after repo selection
+  pendingAttachments?: PlatformAttachment[];
+  pendingMentions?: PlatformMention[];    // mentions from initial message, used when building prompt after repo selection
   pendingSubstituteTrigger?: import('../types.js').SubstituteTrigger;
   /** Sender (open_id + type + resolved name) of the initial message — stashed
    *  so the deferred spawn after repo-selection still injects a <sender> tag
    *  matching the original caller, not the user who clicked the card. */
-  pendingSender?: import('../im/lark/identity-cache.js').ResolvedSender;
+  pendingSender?: PlatformSender;
   pendingFollowUps?: string[];         // buffered follow-up messages (enriched) sent while waiting for repo selection
   ownerOpenId?: string;          // topic creator's open_id — receives write-enabled terminal link via DM
   streamCardId?: string;         // message_id of the streaming card in group (PATCHed with live output)
@@ -189,14 +194,77 @@ export interface DaemonSession {
   };
 }
 
+/** Current Lark compatibility context.
+ *
+ * The generic `platform` context is authoritative for isolation. Legacy fields
+ * remain during the strangler migration because worker/card/session persistence
+ * protocols still use them and must keep their wire/disk shape unchanged.
+ */
+export interface LarkSessionContext {
+  platform: PlatformSessionContext;
+  larkAppId: string;
+  chatId: string;
+  chatType: 'group' | 'p2p';
+  /** Routing scope:
+   *   'thread' → routing key = session.rootMessageId, replies use reply_in_thread=true
+   *   'chat'   → routing key = chatId, replies are plain chat messages
+   *  Must be set explicitly at session creation. Restored legacy sessions fall
+   *  back to 'thread' in the restore path. */
+  scope: 'thread' | 'chat';
+}
+
+export type DaemonSession = DaemonSessionState & LarkSessionContext;
+
+export function createPlatformSessionContext(
+  instance: PlatformInstanceRef,
+  chatId: string,
+  chatType: 'group' | 'p2p',
+  scope: 'thread' | 'chat',
+  rootMessageId: string,
+): PlatformSessionContext {
+  const anchorId = scope === 'chat' ? chatId : rootMessageId;
+  return {
+    instance,
+    conversation: {
+      instance,
+      chatId,
+      conversationType: chatType === 'p2p' ? 'direct' : 'group',
+      scope,
+      anchorId,
+      ...(scope === 'thread' ? { threadRootId: rootMessageId } : {}),
+    },
+  };
+}
+
+/** Refresh the in-memory generic view after a legacy routing-field rewrite. */
+export function syncPlatformSessionContext(ds: DaemonSession): void {
+  const instance = ds.platform?.instance
+    ?? { platform: 'lark' as const, instanceId: ds.larkAppId };
+  ds.platform = createPlatformSessionContext(
+    instance,
+    ds.chatId,
+    ds.chatType,
+    ds.scope,
+    ds.session.rootMessageId,
+  );
+}
+
 /** Composite key for activeSessions — allows multiple bots to have independent
  *  sessions anchored on the same id. The first arg is the **routing anchor**:
  *  - thread-scope → rootMessageId
  *  - chat-scope   → chatId
  *  Lark message ids start with `om_` and chat ids with `oc_`, so collisions
  *  between the two address spaces are not possible. */
-export function sessionKey(anchorId: string, larkAppId: string): string {
-  return `${anchorId}::${larkAppId}`;
+export function platformSessionKey(anchorId: string, instance: PlatformInstanceIdentity): string {
+  // Zero-migration contract: Lark retains the byte-for-byte legacy key.
+  if (instance.platform === 'lark') return `${anchorId}::${instance.instanceId}`;
+  return `platform:${JSON.stringify([instance.platform, instance.instanceId, anchorId])}`;
+}
+
+export function sessionKey(anchorId: string, instance: string | PlatformInstanceIdentity): string {
+  return typeof instance === 'string'
+    ? platformSessionKey(anchorId, { platform: 'lark', instanceId: instance })
+    : platformSessionKey(anchorId, instance);
 }
 
 /** Resolve the routing anchor for an active session — chatId for chat-scope

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -55,12 +55,19 @@ import { prepareSkillDelivery } from './skills/delivery.js';
 import { resolveEffectivePluginIds } from './plugins/effective.js';
 import { ensureGatewayEntry } from './plugins/mcp/gateway-installer.js';
 import type { DaemonToWorker, WorkerToDaemon, Session, DisplayMode } from '../types.js';
-import { sessionKey, sessionAnchorId, isDocNativeSession, type DaemonSession } from './types.js';
+import { sessionKey, sessionAnchorId, isDocNativeSession, syncPlatformSessionContext, type DaemonSession } from './types.js';
 import { DONE_REACTION_EMOJI_TYPE } from './pending-response.js';
 import { buildTerminalUrl } from './terminal-url.js';
 import { prependBotmuxBin } from './botmux-wrapper.js';
 import { usageLimitStateKey, type CliUsageLimitState } from '../utils/cli-usage-limit.js';
 import { isLocalCliOpenEnabled, isLocalCliOpenReady } from '../services/local-cli-opener.js';
+import {
+  requirePlatformCapability,
+  requireSamePlatformInstance,
+  samePlatform,
+  type PlatformInstanceIdentity,
+} from '../im/platform.js';
+import { requirePlatformPort, type PlatformRuntime } from '../im/ports.js';
 
 type WindowsForkOptions = ForkOptions & { windowsHide?: boolean };
 
@@ -80,6 +87,9 @@ export interface WorkerPoolCallbacks {
   /** Re-check the per-bot resident-session cap after a process starts or an
    * over-cap busy session becomes idle. Optional for unit-test callers. */
   enforceLiveSessionCap?: () => void;
+  /** Platform runtime injected by the daemon composition root. Unit tests and
+   * legacy standalone helpers may omit it and retain the mature Lark seam. */
+  platformRuntime?: PlatformRuntime;
 }
 
 let callbacks: WorkerPoolCallbacks | undefined;
@@ -94,6 +104,68 @@ export function initWorkerPool(cb: WorkerPoolCallbacks): void {
 function requireCallbacks(): WorkerPoolCallbacks {
   if (!callbacks) throw new Error('WorkerPool not initialised — call initWorkerPool() first');
   return callbacks;
+}
+
+function platformRuntimeForSession(ds: DaemonSession): PlatformRuntime | undefined {
+  const runtime = callbacks?.platformRuntime;
+  if (!runtime) return undefined;
+  requireSamePlatformInstance(runtime.instance, ds.platform.instance);
+  return runtime;
+}
+
+async function updateSessionCard(
+  ds: DaemonSession,
+  messageId: string,
+  cardJson: string,
+  streamUpdate: boolean = false,
+): Promise<void> {
+  const runtime = platformRuntimeForSession(ds);
+  if (!runtime) return updateMessage(ds.larkAppId, messageId, cardJson);
+  if (streamUpdate) requirePlatformCapability(runtime, 'streamUpdates');
+  await requirePlatformPort(runtime, 'cards').updateCard(
+    { instance: ds.platform.instance, messageId },
+    { payload: cardJson },
+  );
+}
+
+async function sendSessionDirectMessage(
+  ds: DaemonSession,
+  recipientId: string,
+  content: string,
+  contentType: string,
+): Promise<string> {
+  const runtime = platformRuntimeForSession(ds);
+  if (!runtime) return sendUserMessage(ds.larkAppId, recipientId, content, contentType);
+  if (contentType === 'interactive') requirePlatformCapability(runtime, 'cards');
+  const ref = await requirePlatformPort(runtime, 'directMessages')
+    .sendDirectMessage(recipientId, content, { contentType });
+  return ref.messageId;
+}
+
+async function addSessionReaction(
+  ds: DaemonSession,
+  messageId: string,
+  emoji: string,
+): Promise<string> {
+  const runtime = platformRuntimeForSession(ds);
+  if (!runtime) return addReaction(ds.larkAppId, messageId, emoji);
+  return requirePlatformPort(runtime, 'reactions').addReaction(
+    { instance: ds.platform.instance, messageId },
+    emoji,
+  );
+}
+
+async function removeSessionReaction(
+  ds: DaemonSession,
+  messageId: string,
+  reactionId: string,
+): Promise<void> {
+  const runtime = platformRuntimeForSession(ds);
+  if (!runtime) return removeReaction(ds.larkAppId, messageId, reactionId);
+  await requirePlatformPort(runtime, 'reactions').removeReaction(
+    { instance: ds.platform.instance, messageId },
+    reactionId,
+  );
 }
 
 // ─── Active session registry (daemon-owned, accessor for IPC) ───────────────
@@ -744,7 +816,7 @@ export async function deliverWriteLinkCard(
     }
   }
   try {
-    await sendUserMessage(ds.larkAppId, operatorOpenId, cardJson, 'interactive');
+    await sendSessionDirectMessage(ds, operatorOpenId, cardJson, 'interactive');
     logger.info(`[${tag(ds)}] write link delivered via DM to ${who}…`);
     return 'dm';
   } catch (err) {
@@ -927,7 +999,7 @@ function flushCardPatch(ds: DaemonSession): void {
   ds.pendingCardJson = undefined;
   ds.pendingCardId = undefined;
   ds.cardPatchInFlight = true;
-  updateMessage(ds.larkAppId, cardId, json)
+  updateSessionCard(ds, cardId, json, true)
     .catch(err => {
       if (err instanceof MessageWithdrawnError) {
         // Only clear streamCardId when the withdrawn message is still the
@@ -1321,11 +1393,11 @@ export async function closeSession(
   }
 
   // Persistence path — load → mark closed → save (delegated to sessionStore).
-  const stored = sessionStore.getSession(sessionId);
+  const stored = sessionStore.getLocalSession(sessionId);
   const wasOpen = !!stored && stored.status !== 'closed';
   if (wasOpen) {
     sessionStore.closeSession(sessionId);
-    const after = sessionStore.getSession(sessionId);
+    const after = sessionStore.getLocalSession(sessionId);
     dashboardEventBus.publish({
       type: 'session.update',
       body: {
@@ -1444,6 +1516,9 @@ export async function transferSession(
    */
   targetScope: 'thread' | 'chat',
   opts?: {
+    /** Platform identity of the target conversation. Cross-platform relay is
+     * rejected before cards, workers, persistence, or dashboard state change. */
+    targetInstance?: PlatformInstanceIdentity;
     /** @internal Override for tests — the real implementation forks a child
      *  process and tries to attach to tmux, neither of which is appropriate
      *  in a unit test environment. Defaults to module-level forkWorker. */
@@ -1459,6 +1534,15 @@ export async function transferSession(
   }
   const ds = findActiveBySessionId(sessionId);
   if (!ds) return { ok: false, error: 'session_not_active' };
+  const sourceInstance: PlatformInstanceIdentity = ds.platform?.instance
+    ?? { platform: 'lark', instanceId: ds.larkAppId };
+  // Lark-only callers may omit targetInstance for compatibility. Omission is
+  // therefore a Lark target, not an implicit copy of the source platform.
+  const targetInstance = opts?.targetInstance
+    ?? { platform: 'lark', instanceId: ds.larkAppId };
+  if (!samePlatform(sourceInstance, targetInstance)) {
+    return { ok: false, error: 'unsupported_cross_platform' };
+  }
   // Anchor-based identity. A thread-scope session in the SAME chat (different
   // root) is a legitimate cross-topic move, so we refuse only when the target
   // anchor equals the source anchor (relaying a session onto itself). Replaces
@@ -1558,7 +1642,7 @@ export async function transferSession(
         ds.currentImageKey,
         localeForBot(ds.larkAppId),
       );
-      await updateMessage(ds.larkAppId, ds.streamCardId, frozenJson);
+      await updateSessionCard(ds, ds.streamCardId, frozenJson);
     } catch (err) {
       logger.warn(`[${tagPrefix}] freeze source-chat card failed: ${err instanceof Error ? err.message : err}`);
     }
@@ -1595,6 +1679,7 @@ export async function transferSession(
   ds.streamCardId = undefined;
   ds.streamCardNonce = undefined;
   ds.currentImageKey = undefined;
+  syncPlatformSessionContext(ds);
 
   sessionStore.updateSession(ds.session);
 
@@ -2024,7 +2109,7 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
               writableTerminalLinkFor(ds),
               localCliReadyAtBuild,
             );
-            await updateMessage(ds.larkAppId, restoredCardId, streamCardJson);
+            await updateSessionCard(ds, restoredCardId, streamCardJson, true);
             // Worker IPC handlers may run while the direct restore PATCH is in
             // flight. Re-queue readiness after it completes so an older
             // not-ready payload can never overwrite the cli_session_id PATCH.
@@ -2150,7 +2235,7 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
                 true,
               );
               try {
-                await updateMessage(ds.larkAppId, fallbackCardId, readyCardJson);
+                await updateSessionCard(ds, fallbackCardId, readyCardJson);
               } catch (patchErr) {
                 logger.debug(`[${t}] Failed to add local CLI button to fallback card: ${patchErr}`);
               }
@@ -2467,7 +2552,7 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
         logger.info(`[${t}] TUI prompt resolved${msg.selectedText ? `: ${msg.selectedText}` : ''}`);
         if (ds.tuiPromptCardId) {
           const resolvedCard = buildTuiPromptResolvedCard(msg.selectedText ?? tr('card.action.tui_done', undefined, loc), loc);
-          updateMessage(ds.larkAppId, ds.tuiPromptCardId, resolvedCard).catch(err =>
+          updateSessionCard(ds, ds.tuiPromptCardId, resolvedCard).catch(err =>
             logger.debug(`[${t}] Failed to update TUI prompt card: ${err}`),
           );
           ds.tuiPromptCardId = undefined;
@@ -2812,14 +2897,14 @@ async function finishTurnReactions(ds: DaemonSession): Promise<void> {
   for (const ack of list) {
     if (ack.reactionId) {
       try {
-        await removeReaction(ds.larkAppId, ack.messageId, ack.reactionId);
+        await removeSessionReaction(ds, ack.messageId, ack.reactionId);
       } catch (err: any) {
         logger.debug(`[reaction] failed to remove received reaction ${ack.reactionId}: ${err?.message ?? err}`);
       }
     }
     if (silent) continue;
     try {
-      await addReaction(ds.larkAppId, ack.messageId, doneEmoji);
+      await addSessionReaction(ds, ack.messageId, doneEmoji);
     } catch (err: any) {
       logger.debug(`[reaction] failed to add done reaction to ${ack.messageId}: ${err?.message ?? err}`);
     }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -26,7 +26,16 @@ import {
 } from './core/cli-runtime-update.js';
 import { sendRestartReportIfPending } from './core/restart-report.js';
 import { statSync } from 'node:fs';
-import { addReaction, getChatMode, listChatMemberOpenIds, replyMessage, resolveAllowedUsersWithMap, sendMessage, sendUserMessage, updateMessage } from './im/lark/client.js';
+import {
+  addReaction as addLarkReaction,
+  getChatMode,
+  listChatMemberOpenIds,
+  replyMessage as replyLarkMessage,
+  resolveAllowedUsersWithMap,
+  sendMessage as sendLarkMessage,
+  sendUserMessage as sendLarkUserMessage,
+  updateMessage as updateLarkMessage,
+} from './im/lark/client.js';
 import { resolveGroupJoinPrompt, waitForAllowedUserInChat } from './core/auto-start.js';
 import { loadBotConfigs, registerBot, getBot, getAllBots, getOwnerOpenId, findOncallChat, effectiveDefaultWorkingDir, effectiveBotDisplayName, type BotConfig, type BotState, type OncallChat, type VcMeetingAgentConfig, type VcMeetingConsumerAgentConfig } from './bot-registry.js';
 import { setDisplayNameRefresher, findConfigField, applyConfigField } from './services/bot-config-store.js';
@@ -52,7 +61,7 @@ import { validateWorkingDir } from './core/working-dir.js';
 import type { DaemonToWorker, LarkMessage } from './types.js';
 export type { DaemonSession } from './core/types.js';
 import type { DaemonSession } from './core/types.js';
-import { sessionKey, sessionAnchorId } from './core/types.js';
+import { createPlatformSessionContext, sessionKey, sessionAnchorId } from './core/types.js';
 import { buildTerminalUrl, setTerminalProxyPort, setTerminalExternalPort } from './core/terminal-url.js';
 import { startTerminalProxy, type TerminalProxyHandle } from './core/terminal-proxy.js';
 import type { CliId } from './adapters/cli/types.js';
@@ -79,7 +88,17 @@ import {
   sweepGlobalBotmuxSkills,
   writableTerminalLinkFor,
 } from './core/worker-pool.js';
-import { ipcRoute, jsonRes, readJsonBody, setBotName, setLarkAppId, startIpcServer, setWorkflowRunner, setBotRenamer } from './core/dashboard-ipc-server.js';
+import {
+  ipcRoute,
+  jsonRes,
+  readJsonBody,
+  setBotName,
+  setLarkAppId,
+  setPlatformRuntime,
+  startIpcServer,
+  setWorkflowRunner,
+  setBotRenamer,
+} from './core/dashboard-ipc-server.js';
 import { saveFrozenCards, deleteFrozenCards } from './services/frozen-card-store.js';
 import { DAEMON_COMMANDS, SESSIONLESS_DAEMON_COMMANDS, resolvePassthroughCommands, resolveAdapterDefaultPassthroughCommands, handleCommand, handleCardCommand, handleTermLinkCommand, parseSlashCommandInvocation, parseForceTopicInvocation } from './core/command-handler.js';
 import { docWatchCommandNeedsSession } from './core/doc-watch-command.js';
@@ -107,6 +126,7 @@ import {
   rememberLastCliInput,
   ensureTerminalWorkerPort,
   ensureSessionWhiteboard,
+  setSessionManagerPlatformRuntime,
 } from './core/session-manager.js';
 import { triggerSessionTurn } from './core/trigger-session.js';
 import { findOnlineDaemon, listOnlineDaemons } from './utils/daemon-discovery.js';
@@ -115,6 +135,15 @@ import { sweepOrphanSandboxes } from './adapters/backend/sandbox.js';
 import { sweepIdleWorkers, DEFAULT_MAX_LIVE_WORKERS } from './core/idle-worker-sweeper.js';
 import { handleCardAction, runAutoWorktreeCommit } from './im/lark/card-handler.js';
 import type { CardActionData, CardHandlerDeps } from './im/lark/card-handler.js';
+import { LarkPlatformInstanceMismatchError, LarkPlatformRuntime } from './im/lark/runtime.js';
+import { stopPlatformRuntimeWithRetry } from './im/runtime-lifecycle.js';
+import {
+  requirePlatformCapability,
+  samePlatformInstance,
+  type PlatformCapabilities,
+  type PlatformMention,
+  type PlatformSender,
+} from './im/platform.js';
 import {
   executeWorkflowCommand,
   parseWorkflowCommand,
@@ -144,10 +173,14 @@ import {
 } from './im/lark/workflow-progress-card.js';
 import { EventLog as WorkflowEventLog } from './workflows/events/append.js';
 import { replay as replayWorkflow } from './workflows/events/replay.js';
-import { isBotMentioned, probeBotOpenId, startLarkEventDispatcher, writeBotInfoFile, canOperate, evaluateTalk, grantCommandRestriction, isKnownPeerBot, checkRequiredScopes, type RoutingContext, type TalkEvaluation, type DocCommentContext } from './im/lark/event-dispatcher.js';
+import { isBotMentioned, probeBotOpenId, writeBotInfoFile, canOperate, evaluateTalk, grantCommandRestriction, isKnownPeerBot, checkRequiredScopes, type RoutingContext, type TalkEvaluation, type DocCommentContext } from './im/lark/event-dispatcher.js';
 import { getDocSubscription, listAllDocSubscriptions, listDocSubscriptionsForSession, removeDocSubscription, setDocCommentPollCursor, type DocSubscription } from './services/doc-subs-store.js';
 import { BOT_REPLY_SENTINEL, subscribeDocFile, unsubscribeDocFile, addCommentReaction, hasBotSentinel, isBotAuthoredReply, listDocComments } from './im/lark/doc-comment.js';
-import { learnFromMentions, resolveSender, flushIdentityCacheSync } from './im/lark/identity-cache.js';
+import {
+  learnFromMentions as learnFromLarkMentions,
+  resolveSender as resolveLarkSender,
+  flushIdentityCacheSync,
+} from './im/lark/identity-cache.js';
 import { normalizeBrand } from './im/lark/lark-hosts.js';
 import { buildDocCommentPrompt, buildDocWatchWarmupPrompt } from './core/doc-comment-prompt.js';
 import { advanceDocCommentCursor, docCommentRepliesAfterCursor, latestDocCommentPollCursor } from './core/doc-comment-poller.js';
@@ -239,6 +272,165 @@ import type { TriggerRequest, TriggerResponse } from './services/trigger-types.j
 
 const activeSessions = new Map<string, DaemonSession>();
 const workflowEventWatchers = new Map<string, WorkflowEventWatcher>();
+let activePlatformRuntime: LarkPlatformRuntime | undefined;
+
+function larkPlatformContext(
+  larkAppId: string,
+  chatId: string,
+  chatType: 'group' | 'p2p',
+  scope: 'thread' | 'chat',
+  rootMessageId: string,
+) {
+  return createPlatformSessionContext(
+    { platform: 'lark', instanceId: larkAppId },
+    chatId,
+    chatType,
+    scope,
+    rootMessageId,
+  );
+}
+
+function runtimeForLarkApp(larkAppId: string): LarkPlatformRuntime | undefined {
+  const runtime = activePlatformRuntime;
+  if (!runtime) return undefined;
+  const received = { platform: 'lark' as const, instanceId: larkAppId };
+  if (!samePlatformInstance(runtime.instance, received)) {
+    throw new LarkPlatformInstanceMismatchError(runtime.instance, received);
+  }
+  return runtime;
+}
+
+async function sendMessage(
+  larkAppId: string,
+  chatId: string,
+  content: string,
+  msgType: string = 'text',
+  uuid?: string,
+  hookContext?: Record<string, unknown>,
+): Promise<string> {
+  return sendPlatformMessage(larkAppId, chatId, content, msgType, hookContext, 'group', uuid);
+}
+
+async function replyMessage(
+  larkAppId: string,
+  messageId: string,
+  content: string,
+  msgType: string = 'text',
+  replyInThread: boolean = false,
+  uuid?: string,
+  hookContext?: Record<string, unknown>,
+): Promise<string> {
+  const runtime = runtimeForLarkApp(larkAppId);
+  if (!runtime) return replyLarkMessage(larkAppId, messageId, content, msgType, replyInThread, uuid, hookContext);
+  const target = { instance: { platform: 'lark' as const, instanceId: larkAppId }, messageId };
+  const options = { contentType: msgType, inThread: replyInThread, idempotencyKey: uuid, context: hookContext };
+  const ref = msgType === 'interactive'
+    ? await runtime.cards.replyCard(target, { payload: content }, options)
+    : await runtime.messaging.replyMessage(target, content, options);
+  return ref.messageId;
+}
+
+async function addReaction(larkAppId: string, messageId: string, emojiType: string): Promise<string> {
+  const runtime = runtimeForLarkApp(larkAppId);
+  if (!runtime) return addLarkReaction(larkAppId, messageId, emojiType);
+  return runtime.reactions.addReaction(
+    { instance: { platform: 'lark', instanceId: larkAppId }, messageId },
+    emojiType,
+  );
+}
+
+async function updateMessage(larkAppId: string, messageId: string, cardJson: string): Promise<void> {
+  const runtime = runtimeForLarkApp(larkAppId);
+  if (!runtime) return updateLarkMessage(larkAppId, messageId, cardJson);
+  await runtime.cards.updateCard(
+    { instance: { platform: 'lark', instanceId: larkAppId }, messageId },
+    { payload: cardJson },
+  );
+}
+
+async function sendUserMessage(
+  larkAppId: string,
+  openId: string,
+  content: string,
+  msgType: string = 'text',
+): Promise<string> {
+  const runtime = runtimeForLarkApp(larkAppId);
+  if (!runtime) return sendLarkUserMessage(larkAppId, openId, content, msgType);
+  if (msgType === 'interactive') requirePlatformCapability(runtime, 'cards');
+  const ref = await runtime.directMessages.sendDirectMessage(openId, content, { contentType: msgType });
+  return ref.messageId;
+}
+
+async function resolveSender(
+  larkAppId: string,
+  openId: string | undefined,
+  senderType: string | undefined,
+  hint?: { name?: string; type?: 'user' | 'bot' },
+): Promise<PlatformSender | undefined> {
+  const runtime = runtimeForLarkApp(larkAppId);
+  if (!runtime) return resolveLarkSender(larkAppId, openId, senderType, hint);
+  if (!openId) return undefined;
+  const type = hint?.type ?? (senderType === 'app' || senderType === 'bot' ? 'bot' : 'user');
+  return runtime.identity.resolveSender(openId, type, hint?.name ? { name: hint.name } : undefined);
+}
+
+function learnFromMentions(larkAppId: string, mentions?: readonly PlatformMention[]): void {
+  if (!mentions || mentions.length === 0) return;
+  const runtime = runtimeForLarkApp(larkAppId);
+  if (!runtime) {
+    learnFromLarkMentions(larkAppId, mentions as any);
+    return;
+  }
+  runtime.identity.learnMentions(mentions);
+}
+
+async function sendPlatformMessage(
+  larkAppId: string,
+  chatId: string,
+  content: string,
+  msgType: string,
+  hookContext?: Record<string, unknown>,
+  chatType: 'group' | 'p2p' = 'group',
+  uuid?: string,
+): Promise<string> {
+  const runtime = runtimeForLarkApp(larkAppId);
+  if (!runtime) return sendLarkMessage(larkAppId, chatId, content, msgType, uuid, hookContext);
+  const conversation = {
+    instance: { platform: 'lark', instanceId: larkAppId },
+    chatId,
+    conversationType: chatType === 'p2p' ? 'direct' : 'group',
+    scope: 'chat',
+    anchorId: chatId,
+  } as const;
+  const options = { contentType: msgType, idempotencyKey: uuid, context: hookContext };
+  const ref = msgType === 'interactive'
+    ? await runtime.cards.sendCard(conversation, { payload: content }, options)
+    : await runtime.messaging.sendMessage(conversation, content, options);
+  return ref.messageId;
+}
+
+async function platformReplyMessage(
+  larkAppId: string,
+  messageId: string,
+  content: string,
+  msgType: string,
+  replyInThread: boolean,
+  hookContext?: Record<string, unknown>,
+): Promise<string> {
+  const runtime = runtimeForLarkApp(larkAppId);
+  if (!runtime) return replyLarkMessage(larkAppId, messageId, content, msgType, replyInThread, undefined, hookContext);
+  return replyMessage(larkAppId, messageId, content, msgType, replyInThread, undefined, hookContext);
+}
+
+async function platformAddReaction(
+  larkAppId: string,
+  messageId: string,
+  emojiType: string,
+): Promise<string> {
+  const runtime = runtimeForLarkApp(larkAppId);
+  if (!runtime) return addLarkReaction(larkAppId, messageId, emojiType);
+  return addReaction(larkAppId, messageId, emojiType);
+}
 
 type VcMeetingDaemonSession = {
   larkAppId: string;
@@ -1125,7 +1317,7 @@ export async function noteTurnReceived(
   // so a registered entry is always in place before its own turn can go idle.
   let reactionId: string;
   try {
-    reactionId = await addReaction(ds.larkAppId, triggerMessageId, receivedReactionEmoji ?? receivedReactionEmojiFor(ds));
+    reactionId = await platformAddReaction(ds.larkAppId, triggerMessageId, receivedReactionEmoji ?? receivedReactionEmojiFor(ds));
   } catch (err) {
     logger.debug(`[reaction] received add failed for ${triggerMessageId}: ${err instanceof Error ? err.message : String(err)}`);
     return;
@@ -1181,20 +1373,20 @@ async function sessionReply(anchor: string, content: string, msgType: string = '
       // (drives the real sessionReply) and test/reply-target-fallback.test.ts
       // (the resolveSessionReplyTarget × fallbackTurnId composition it relies on).
       const target = resolveSessionReplyTarget(ds, fallbackTurnId(ds, turnId));
-      if (target.mode === 'thread') return replyMessage(appId, target.rootMessageId, content, msgType, true, undefined, hookContext);
+      if (target.mode === 'thread') return platformReplyMessage(appId, target.rootMessageId, content, msgType, true, hookContext);
       if (ds.session.rootMessageId) {
         const mode = await getChatMode(appId, chatId, { forceRefresh: true });
         if (mode === 'topic') {
           logger.warn(`[routing] Chat-scope session ${ds.session.sessionId.substring(0, 8)} is now topic-mode; replying in original thread ${ds.session.rootMessageId.substring(0, 12)}`);
-          return replyMessage(appId, ds.session.rootMessageId, content, msgType, true, undefined, hookContext);
+          return platformReplyMessage(appId, ds.session.rootMessageId, content, msgType, true, hookContext);
         }
       }
     }
-    return sendMessage(appId, chatId, content, msgType, undefined, hookContext);
+    return sendPlatformMessage(appId, chatId, content, msgType, hookContext, ds?.chatType);
   }
 
   // Thread-scope (or unknown / legacy): reply in thread.
-  return replyMessage(appId, anchor, content, msgType, true, undefined, hookContext);
+  return platformReplyMessage(appId, anchor, content, msgType, true, hookContext);
 }
 
 // Test seams: drive the real sessionReply (the chat-scope thread/top-level
@@ -1407,6 +1599,9 @@ function removePidFile(): void {
 const DAEMON_REGISTRY_DIR = join(homedir(), '.botmux', 'data', 'dashboard-daemons');
 
 interface DaemonDescriptor {
+  platform: 'lark';
+  instanceId: string;
+  capabilities: PlatformCapabilities;
   larkAppId: string;
   botName: string;
   /** CLI adapter id from bots.json, used by dashboard roster before any sessions exist. */
@@ -2365,6 +2560,8 @@ const commandDeps: CommandHandlerDeps = {
   getActiveCount,
   lastRepoScan,
   prewarmDocCommentSession,
+  sendMessage,
+  sendDirectMessage: sendUserMessage,
 };
 
 /**
@@ -2967,6 +3164,8 @@ ipcRoute('GET', '/api/adopt-session/:pid', (_req, res, params) => {
       return jsonRes(res, 200, {
         sessionId: ds.session.sessionId,
         chatId: ds.chatId,
+        platform: ds.platform.instance.platform,
+        instanceId: ds.platform.instance.instanceId,
         larkAppId: ds.larkAppId,
         rootMessageId: sessionAnchorId(ds),
       });
@@ -6464,6 +6663,7 @@ async function startInitialPassthroughSession(args: {
   const autoWt = willAutoWorktree(larkAppId, pinnedWorkingDir, pinnedFromBotDefault);
   const ds: DaemonSession = {
     session,
+    platform: larkPlatformContext(larkAppId, chatId, chatType, scope, session.rootMessageId),
     worker: null,
     workerPort: null,
     workerToken: null,
@@ -6760,6 +6960,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
       sessionStore.updateSession(session);
       activeSessions.set(sessionKey(anchor, larkAppId), {
         session,
+        platform: larkPlatformContext(larkAppId, chatId, chatType, scope, session.rootMessageId),
         worker: null,
         workerPort: null,
         workerToken: null,
@@ -6785,7 +6986,12 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
   }
 
   // Download attachments
-  const { attachments, needLogin } = await downloadResources(larkAppId, messageId, resources);
+  const { attachments, needLogin } = await downloadResources(
+    larkAppId,
+    messageId,
+    resources,
+    runtimeForLarkApp(larkAppId),
+  );
   if (attachments.length > 0) {
     parsed.attachments = attachments;
   }
@@ -6849,6 +7055,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
 
   const ds: DaemonSession = {
     session,
+    platform: larkPlatformContext(larkAppId, chatId, chatType, scope, session.rootMessageId),
     worker: null,
     workerPort: null,
     workerToken: null,
@@ -7070,6 +7277,7 @@ async function handleBotAdded(chatId: string, operatorOpenId: string | undefined
 
     const ds: DaemonSession = {
       session,
+      platform: larkPlatformContext(larkAppId, chatId, chatType, scope, session.rootMessageId),
       worker: null,
       workerPort: null,
       workerToken: null,
@@ -7245,7 +7453,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
   // anchor" all return early; routing them through resolveSender first would
   // tack the 800ms budget onto paths that never see the sender tag. Use the
   // helper below at every actual injection point.
-  let threadSenderCached: import('./im/lark/identity-cache.js').ResolvedSender | undefined;
+  let threadSenderCached: PlatformSender | undefined;
   let threadSenderResolved = false;
   const getThreadSender = async (): Promise<typeof threadSenderCached> => {
     if (threadSenderResolved) return threadSenderCached;
@@ -7467,6 +7675,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
         sessionStore.updateSession(session);
         activeSessions.set(sessionKey(anchor, larkAppId), {
           session,
+          platform: larkPlatformContext(larkAppId, threadChatId, ctxChatType, scope, session.rootMessageId),
           worker: null,
           workerPort: null,
           workerToken: null,
@@ -7551,7 +7760,12 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
 
   // Download attachments
   const effectiveAppId = ds?.larkAppId ?? larkAppId;
-  const { attachments, needLogin } = await downloadResources(effectiveAppId, parsed.messageId, resources);
+  const { attachments, needLogin } = await downloadResources(
+    effectiveAppId,
+    parsed.messageId,
+    resources,
+    runtimeForLarkApp(effectiveAppId),
+  );
   if (attachments.length > 0) {
     parsed.attachments = attachments;
   }
@@ -7598,7 +7812,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
     // pure duplication. A differing sender still gets attributed so the CLI can
     // tell multi-user buffered messages apart after repo selection unlocks.
     const followUpSender = await getThreadSender();
-    if (followUpSender?.openId && followUpSender.openId !== ds.pendingSender?.openId) {
+    if (followUpSender?.id && followUpSender.id !== ds.pendingSender?.id) {
       // This buffer folds into the opening <user_message> after repo selection,
       // so pair the foreign sender tag with the cursor anti-echo note: without
       // the adjacent note a cursor session sees an inline ou_xxx:name with no
@@ -7683,6 +7897,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
     setDirectChatDisplayNameFromSender(session, autoCreateChatType, autoCreateSender);
     const newDs: DaemonSession = {
       session,
+      platform: larkPlatformContext(larkAppId, autoCreateChatId, autoCreateChatType, scope, session.rootMessageId),
       worker: null,
       workerPort: null,
       workerToken: null,
@@ -7906,6 +8121,7 @@ async function autoCreateDocSession(sub: DocSubscription, larkAppId: string, ctx
 
   const ds: DaemonSession = {
     session,
+    platform: larkPlatformContext(larkAppId, virtualChatId, 'group', 'chat', virtualAnchor),
     worker: null,
     workerPort: null,
     workerToken: null,
@@ -8269,13 +8485,48 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   }
   const cfg = botConfigs[idx];
   registerBot(cfg);
+  const platformRuntime: LarkPlatformRuntime = new LarkPlatformRuntime({
+    larkAppId: cfg.larkAppId,
+    larkAppSecret: cfg.larkAppSecret,
+    brand: cfg.brand,
+    eventHandlers: {
+      handleCardAction: (data, appId) => handleCardAction(data, cardDeps, appId),
+      handleNewTopic: (data, ctx) => handleNewTopic(data, ctx),
+      handleThreadReply: (data, ctx) => handleThreadReply(data, ctx),
+      handleBotAdded: (chatId, operatorOpenId, appId) => handleBotAdded(chatId, operatorOpenId, appId),
+      handleDocComment: (ctx) => handleDocComment(ctx),
+      handleVcMeetingPush: (ctx) => handleVcMeetingPush(ctx),
+      beforeSessionTurn: (_data, ctx) => maybeCatchUpVcMeetingConsumerBeforeTurn(ctx),
+      isSessionOwner: (anchor, appId) => appId === platformRuntime.instance.instanceId
+        && activeSessions.has(sessionKey(anchor, platformRuntime.instance)),
+      resolveReplyThreadAlias: (rootId, chatId, appId) => findChatReplyAlias(rootId, chatId, appId),
+      // Chat was converted 普通群 → 话题群 while we held a chat-scope session.
+      // Evict only this runtime instance's stale routing entry. The worker stays
+      // alive until the canonical /close path tears it down.
+      onChatModeConverted: (chatId, appId) => {
+        if (appId !== platformRuntime.instance.instanceId) return;
+        const key = sessionKey(chatId, platformRuntime.instance);
+        const evicted = activeSessions.delete(key);
+        logger.info(`[chat-mode-converted] ${chatId.substring(0, 12)} evicted=${evicted}; worker (if any) keeps running until /close`);
+      },
+    },
+  });
+  if (activePlatformRuntime) {
+    throw new Error(
+      `Platform runtime already bound: ${activePlatformRuntime.instance.platform}:`
+      + activePlatformRuntime.instance.instanceId,
+    );
+  }
+  activePlatformRuntime = platformRuntime;
+  setPlatformRuntime(platformRuntime);
+  setSessionManagerPlatformRuntime(platformRuntime);
   // 启动即为本 bot 的 CLI 预装环境（skills + askUserQuestion hook + 兜底 skill）。
   // 关键：adopt 路径会跳过 ensureCliSkills，若重启后第一次就是 adopt 一个外部
   // claude 会话，必须保证此时全局 ~/.claude/settings.json 已带 hook——否则"全局
   // hook 适配 adopt"不成立。这里幂等、best-effort，不阻塞启动。
   try { ensureCliEnv(cfg.cliId, cfg.cliPathOverride); }
   catch (err) { logger.warn(`[hook] startup ensureCliEnv failed for ${cfg.cliId}: ${err instanceof Error ? err.message : String(err)}`); }
-  sessionStore.init(cfg.larkAppId);
+  sessionStore.init(platformRuntime.instance);
   chatFirstSeenStore.init(cfg.larkAppId);
   // Watch schedules.json for external writes (e.g. `botmux schedule add`
   // running in a separate node process) so dashboard event bus stays in sync.
@@ -8294,6 +8545,9 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   // and watching for mtime updates (heartbeat) / file removal (shutdown).
   const ipcPort = config.dashboard.ipcBasePort + idx;
   const desc: DaemonDescriptor = {
+    platform: platformRuntime.instance.platform,
+    instanceId: platformRuntime.instance.instanceId,
+    capabilities: platformRuntime.capabilities,
     larkAppId: cfg.larkAppId,
     botName: cfg.displayName ?? cfg.larkAppId,
     cliId: cfg.cliId,
@@ -8365,6 +8619,7 @@ export async function startDaemon(botIndex?: number): Promise<void> {
       logger.info(`[${ds.session.sessionId.substring(0, 8)}] Session auto-closed (message withdrawn)`);
     },
     enforceLiveSessionCap: () => enforceLiveSessionCap('session_change'),
+    platformRuntime,
   });
   // Expose the activeSessions Map (owned by daemon) to worker-pool readers,
   // so dashboard IPC and other consumers can list/lookup live sessions.
@@ -8529,31 +8784,9 @@ export async function startDaemon(botIndex?: number): Promise<void> {
       );
     }
 
-    // Start event dispatcher for this bot
-    startLarkEventDispatcher(cfg.larkAppId, cfg.larkAppSecret, {
-      handleCardAction: (data, appId) => handleCardAction(data, cardDeps, appId),
-      handleNewTopic: (data, ctx) => handleNewTopic(data, ctx),
-      handleThreadReply: (data, ctx) => handleThreadReply(data, ctx),
-      handleBotAdded: (chatId, operatorOpenId, appId) => handleBotAdded(chatId, operatorOpenId, appId),
-      handleDocComment: (ctx) => handleDocComment(ctx),
-      handleVcMeetingPush: (ctx) => handleVcMeetingPush(ctx),
-      beforeSessionTurn: (_data, ctx) => maybeCatchUpVcMeetingConsumerBeforeTurn(ctx),
-      isSessionOwner: (anchor, appId) => activeSessions.has(sessionKey(anchor, appId)),
-      resolveReplyThreadAlias: (rootId, chatId, appId) => findChatReplyAlias(rootId, chatId, appId),
-      // Chat was converted 普通群 → 话题群 while we held a chat-scope session.
-      // Evict it from the routing map so subsequent inbound messages can land
-      // on a fresh thread-scope session (dispatcher already rerouted this turn
-      // to handleNewTopic). The worker is left running on purpose: the user may
-      // still have its web terminal open, and `/close` is the canonical cleanup
-      // path. Scheduler tasks tied to this session keep their `scope='chat'`
-      // semantics — that's an edge case worth following up on, not blocking
-      // the main fix.
-      onChatModeConverted: (chatId, appId) => {
-        const key = sessionKey(chatId, appId);
-        const evicted = activeSessions.delete(key);
-        logger.info(`[chat-mode-converted] ${chatId.substring(0, 12)} evicted=${evicted}; worker (if any) keeps running until /close`);
-      },
-    }, normalizeBrand(cfg.brand));
+    // Start the single platform runtime at the exact legacy dispatcher seam,
+    // after permissions/identity setup and without adding work to ACK paths.
+    await platformRuntime.start();
 
     const vcCfg = effectiveVcMeetingAgentConfig(cfg.larkAppId);
     if (vcCfg) restoreVcMeetingRuntimeSessionsForBot(cfg.larkAppId, vcCfg);
@@ -8701,6 +8934,21 @@ export async function startDaemon(botIndex?: number): Promise<void> {
     shuttingDown = true;
     setSessionLifecycleShutdown(true);
     logger.info(`Daemon shutting down... (active: ${getActiveCount()})`);
+    let platformRuntimeStopped = await stopPlatformRuntimeWithRetry(
+      platformRuntime,
+      2,
+      (err, attempt, maxAttempts) => {
+        logger.warn(
+          `[platform-runtime] stop attempt ${attempt}/${maxAttempts} failed: `
+          + `${err instanceof Error ? err.message : String(err)}`,
+        );
+      },
+    );
+    if (platformRuntimeStopped && activePlatformRuntime === platformRuntime) {
+      activePlatformRuntime = undefined;
+      setPlatformRuntime(undefined);
+      setSessionManagerPlatformRuntime(undefined);
+    }
     scheduler.stopScheduler();
     stopMaintenance();
     stopCliRuntimeUpdateMonitor();
@@ -8775,6 +9023,25 @@ export async function startDaemon(botIndex?: number): Promise<void> {
     flushIdentityCacheSync();
 
     removePidFile();
+    // If both early close attempts failed, keep the runtime wired while workers
+    // drain so any late event still uses the same instance boundary. Make one
+    // final close attempt immediately before exit, then clear process-local
+    // bindings regardless because no further work can be accepted.
+    if (!platformRuntimeStopped) {
+      platformRuntimeStopped = await stopPlatformRuntimeWithRetry(
+        platformRuntime,
+        1,
+        (err) => logger.warn(
+          `[platform-runtime] final stop attempt failed: `
+          + `${err instanceof Error ? err.message : String(err)}`,
+        ),
+      );
+    }
+    if (activePlatformRuntime === platformRuntime) {
+      activePlatformRuntime = undefined;
+      setPlatformRuntime(undefined);
+      setSessionManagerPlatformRuntime(undefined);
+    }
     process.exit(0);
   };
 

--- a/src/dashboard/registry.ts
+++ b/src/dashboard/registry.ts
@@ -1,7 +1,17 @@
 import { readdirSync, readFileSync, watch, type FSWatcher } from 'node:fs';
 import { join } from 'node:path';
+import {
+  normalizePlatformDescriptor,
+  platformDescriptorKey,
+  type DescriptorCapabilities,
+  type DescriptorPlatformRef,
+} from '../im/platform-descriptor.js';
 
 export interface DaemonInfo {
+  platform: string;
+  instanceId: string;
+  capabilities?: DescriptorCapabilities;
+  /** Legacy compatibility identity. Prefer platform + instanceId. */
   larkAppId: string;
   botName: string;
   /** CLI adapter id from bots.json, e.g. codex / claude-code / traex. */
@@ -29,6 +39,50 @@ export type RegistryListener = (online: DaemonInfo[]) => void;
 
 export interface DaemonRegistryOptions {
   refreshIntervalMs?: number;
+}
+
+function finiteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function integer(value: unknown): value is number {
+  return finiteNumber(value) && Number.isInteger(value);
+}
+
+function validPort(value: unknown): value is number {
+  return integer(value) && value > 0 && value <= 65_535;
+}
+
+function normalizeDaemonInfo(raw: unknown): DaemonInfo | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const record = raw as Record<string, unknown>;
+  const identity = normalizePlatformDescriptor(record);
+  if (!identity) return null;
+  if (typeof record.botName !== 'string' || !record.botName.trim()) return null;
+  if (!integer(record.botIndex) || !validPort(record.ipcPort) || !integer(record.pid)) return null;
+  if (!finiteNumber(record.startedAt) || !finiteNumber(record.lastHeartbeat)) return null;
+
+  let resolvedAllowedUsers: string[] | undefined;
+  if (record.resolvedAllowedUsers !== undefined) {
+    if (!Array.isArray(record.resolvedAllowedUsers)
+      || !record.resolvedAllowedUsers.every((entry) => typeof entry === 'string')) return null;
+    resolvedAllowedUsers = [...record.resolvedAllowedUsers];
+  }
+
+  return {
+    ...identity,
+    botName: record.botName.trim(),
+    ...(typeof record.cliId === 'string' && record.cliId.trim() ? { cliId: record.cliId.trim() } : {}),
+    ...(typeof record.botAvatarUrl === 'string' && record.botAvatarUrl.trim()
+      ? { botAvatarUrl: record.botAvatarUrl.trim() }
+      : {}),
+    botIndex: record.botIndex,
+    ipcPort: record.ipcPort,
+    pid: record.pid,
+    startedAt: record.startedAt,
+    lastHeartbeat: record.lastHeartbeat,
+    ...(resolvedAllowedUsers === undefined ? {} : { resolvedAllowedUsers }),
+  };
 }
 
 /**
@@ -70,12 +124,29 @@ export class DaemonRegistry {
   }
 
   list(): DaemonInfo[] {
+    // Preserve the legacy dashboard contract: every existing consumer routes
+    // through larkAppId and invokes Lark-only RPCs. Generic callers must opt in
+    // to listAll()/getByRef() until those wire contracts become platform-aware.
+    return this.listAll().filter(d => d.platform === 'lark');
+  }
+
+  listAll(): DaemonInfo[] {
     const now = Date.now();
     return [...this.items.values()].filter(d => now - d.lastHeartbeat <= STALE_MS);
   }
 
   getByAppId(id: string): DaemonInfo | undefined {
-    const d = this.items.get(id);
+    const d = [...this.items.values()].find(item => item.platform === 'lark' && item.larkAppId === id);
+    if (!d) return undefined;
+    return Date.now() - d.lastHeartbeat > STALE_MS ? undefined : d;
+  }
+
+  /** Look up a daemon by the complete platform-neutral instance identity. */
+  getByRef(ref: DescriptorPlatformRef): DaemonInfo | undefined {
+    const platform = typeof ref?.platform === 'string' ? ref.platform.trim() : '';
+    const instanceId = typeof ref?.instanceId === 'string' ? ref.instanceId.trim() : '';
+    if (!platform || !instanceId) return undefined;
+    const d = this.items.get(platformDescriptorKey({ platform, instanceId }));
     if (!d) return undefined;
     return Date.now() - d.lastHeartbeat > STALE_MS ? undefined : d;
   }
@@ -92,8 +163,9 @@ export class DaemonRegistry {
     for (const n of names) {
       if (!n.endsWith('.json')) continue;
       try {
-        const d = JSON.parse(readFileSync(join(this.dir, n), 'utf8')) as DaemonInfo;
-        next.set(d.larkAppId, d);
+        const d = normalizeDaemonInfo(JSON.parse(readFileSync(join(this.dir, n), 'utf8')));
+        if (!d) continue;
+        next.set(platformDescriptorKey(d), d);
       } catch {
         // Skip malformed / partially-written files
       }

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -62,6 +62,17 @@ import type { VcMeetingPushContext, VcMeetingPushEventKind } from '../../vc-agen
 // 大厅回执互教的防环闸：每进程对同一打卡者只回一次（见 hall swallow 分支）。
 const hallEchoReplied = new Set<string>();
 
+// startLarkEventDispatcher historically returned only the SDK WSClient while
+// keeping its revive timer private.  PlatformRuntime.stop() needs to tear down
+// both pieces without changing that public return contract (many callers/tests
+// already hold the WSClient directly), so retain the timer out-of-band.
+interface DispatcherLifecycleState {
+  stopped: boolean;
+  reviveTimer?: NodeJS.Timeout;
+}
+
+const wsLifecycleStates = new WeakMap<Lark.WSClient, DispatcherLifecycleState>();
+
 function vcMeetingEventPayloadForLog(data: any): string {
   try {
     return JSON.stringify(data?.event ?? data);
@@ -2584,7 +2595,16 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
   }
 
   // Start WSClient
-  const wsClient = new Lark.WSClient({
+  const lifecycle: DispatcherLifecycleState = { stopped: false };
+  let wsClient!: Lark.WSClient;
+  const closeLateConnection = (): boolean => {
+    if (!lifecycle.stopped) return false;
+    // The SDK's initial/revive start can finish after stop(). Force-close the
+    // late socket before it can become a second live dispatcher generation.
+    wsClient.close({ force: true });
+    return true;
+  };
+  wsClient = new Lark.WSClient({
     appId: larkAppId,
     appSecret: larkAppSecret,
     // brand → 长连接域名。国际版租户必须连 larksuite.com，否则收不到任何事件。
@@ -2605,11 +2625,15 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
     handshakeTimeoutMs: 15_000,
     // 重连过程打日志，便于事后从 `pnpm daemon:logs` 复盘（warn 默认看不到这些）。
     onReconnecting: () => logger.warn(`[ws] ${larkAppId} reconnecting…`),
-    onReconnected: () => logger.info(`[ws] ${larkAppId} reconnected`),
+    onReady: () => { closeLateConnection(); },
+    onReconnected: () => {
+      if (!closeLateConnection()) logger.info(`[ws] ${larkAppId} reconnected`);
+    },
     onError: (err) => logger.error(`[ws] ${larkAppId} terminal error: ${err.message}`),
   });
 
-  wsClient.start({ eventDispatcher });
+  void wsClient.start({ eventDispatcher })
+    .catch(err => logger.error(`[ws] ${larkAppId} WSClient start failed: ${err?.message ?? err}`));
   logger.info('Daemon WSClient started');
 
   // ② SDK 重连耗尽后停在 terminalError（getConnectionStatus().state === 'failed'）并
@@ -2618,15 +2642,40 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
   //    只在 'failed' 时介入，不打断 SDK 正在进行的 'reconnecting' / 'connecting'。
   let reviving = false;
   const reviveTimer = setInterval(() => {
+    if (lifecycle.stopped) return;
     if (reviving) return;
     if (wsClient.getConnectionStatus().state !== 'failed') return;
     reviving = true;
     logger.warn(`[ws] ${larkAppId} connection failed (reconnect exhausted), restarting WSClient`);
-    wsClient.start({ eventDispatcher })
+    void wsClient.start({ eventDispatcher })
       .catch(err => logger.error(`[ws] ${larkAppId} WSClient restart failed: ${err?.message ?? err}`))
       .finally(() => { reviving = false; });
   }, 60_000);
   reviveTimer.unref();
+  lifecycle.reviveTimer = reviveTimer;
+  wsLifecycleStates.set(wsClient, lifecycle);
 
   return wsClient;
+}
+
+/** Stop a dispatcher created by {@link startLarkEventDispatcher}.
+ *
+ * Kept separate from `startLarkEventDispatcher()` so its long-standing return
+ * type remains the SDK WSClient. Calling this more than once is safe: the timer
+ * entry is removed on the first call and the SDK close operation is idempotent
+ * for an already-idle client.
+ */
+export function stopLarkEventDispatcher(wsClient: Lark.WSClient): void {
+  const lifecycle = wsLifecycleStates.get(wsClient);
+  if (lifecycle) {
+    // Mark stopped before touching timer/socket so an already in-flight start
+    // observes the terminal generation in onReady/onReconnected.
+    const wasStopped = lifecycle.stopped;
+    lifecycle.stopped = true;
+    if (!wasStopped && lifecycle.reviveTimer) clearInterval(lifecycle.reviveTimer);
+    lifecycle.reviveTimer = undefined;
+  }
+  // Always retry the SDK's idempotent close. A prior close may have thrown
+  // after the lifecycle flag/timer were already updated.
+  wsClient.close();
 }

--- a/src/im/lark/identity-cache.ts
+++ b/src/im/lark/identity-cache.ts
@@ -24,6 +24,7 @@ import { getBotClient } from '../../bot-registry.js';
 import { config } from '../../config.js';
 import { logger } from '../../utils/logger.js';
 import { larkGet } from './client.js';
+import type { PlatformSender } from '../platform.js';
 
 export type IdentityType = 'user' | 'bot' | 'app' | 'unknown';
 
@@ -255,7 +256,8 @@ function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
   });
 }
 
-export interface ResolvedSender {
+export interface ResolvedSender extends PlatformSender {
+  /** Lark compatibility field; platform-neutral consumers use `id`. */
   openId: string;
   type: 'user' | 'bot';
   name?: string;
@@ -294,5 +296,10 @@ export async function resolveSender(
   if (!name && type === 'user') {
     name = await resolveName(larkAppId, openId);
   }
-  return { openId, type, name };
+  const sender = { openId, type, name } as ResolvedSender;
+  // Preserve the long-standing enumerable Lark return shape while exposing a
+  // neutral id to the core session model. Object.keys/JSON/deep-equality still
+  // see exactly {openId,type,name}.
+  Object.defineProperty(sender, 'id', { value: openId, enumerable: false });
+  return sender;
 }

--- a/src/im/lark/message-parser.ts
+++ b/src/im/lark/message-parser.ts
@@ -390,14 +390,35 @@ export function parseEventMessage(data: RawEventData): { parsed: LarkMessage; re
   // Extract structured mentions
   const mentions: LarkMention[] | undefined =
     message.mentions && message.mentions.length > 0
-      ? message.mentions.map(m => ({
-          key: m.key,
-          name: m.name,
-          openId: mentionOpenId(m),
-          userId: mentionIdentity(m).userId,
-          unionId: mentionUnionId(m),
-          idType: m.id_type,
-        }))
+      ? message.mentions.map(m => {
+          const openId = mentionOpenId(m);
+          const identity = mentionIdentity(m);
+          const stableId = mentionUnionId(m);
+          const mention = {
+            key: m.key,
+            name: m.name,
+            openId,
+            userId: identity.userId,
+            unionId: stableId,
+            idType: m.id_type,
+          } as LarkMention;
+          Object.defineProperties(mention, {
+            token: { value: m.key, enumerable: false },
+            identity: { value: (!openId && !identity.userId && !stableId) ? undefined : {
+              id: openId ?? identity.userId ?? stableId!,
+              secondaryId: identity.userId,
+              stableId,
+              idType: m.id_type ?? (openId
+                ? 'open_id'
+                : identity.userId
+                  ? 'user_id'
+                  : stableId
+                    ? 'union_id'
+                    : undefined),
+            }, enumerable: false },
+          });
+          return mention;
+        })
       : undefined;
 
   const parsed: LarkMessage = {

--- a/src/im/lark/runtime.ts
+++ b/src/im/lark/runtime.ts
@@ -1,0 +1,402 @@
+import type { WSClient } from '@larksuiteoapi/node-sdk';
+import {
+  addReaction as addLarkReaction,
+  downloadMessageResource,
+  removeReaction as removeLarkReaction,
+  replyMessage as replyLarkMessage,
+  sendMessage as sendLarkMessage,
+  sendUserMessage,
+  updateMessage as updateLarkMessage,
+} from './client.js';
+import {
+  decideRouting,
+  startLarkEventDispatcher,
+  stopLarkEventDispatcher,
+  type EventHandlers,
+} from './event-dispatcher.js';
+import {
+  learnFromMentions,
+  resolveSender,
+  type ResolvedSender,
+} from './identity-cache.js';
+import { normalizeBrand, type Brand } from './lark-hosts.js';
+import {
+  createPlatformCapabilities,
+  PlatformInstanceMismatchError,
+  samePlatformInstance,
+  type PlatformAttachment,
+  type PlatformCapabilities,
+  type PlatformConversationRef,
+  type PlatformInstanceRef,
+  type PlatformMention,
+  type PlatformMessageRef,
+  type PlatformSender,
+} from '../platform.js';
+import type {
+  PlatformAttachmentResource,
+  PlatformAttachmentsPort,
+  PlatformCard,
+  PlatformCardsPort,
+  PlatformConversationPort,
+  PlatformDirectMessageOptions,
+  PlatformDirectMessagesPort,
+  PlatformIdentityPort,
+  PlatformInboundConversation,
+  PlatformMessagingPort,
+  PlatformReactionsPort,
+  PlatformReplyOptions,
+  PlatformRuntime,
+  PlatformSendOptions,
+} from '../ports.js';
+
+export const LARK_PLATFORM_CAPABILITIES: PlatformCapabilities = createPlatformCapabilities({
+  messaging: true,
+  cards: true,
+  streamUpdates: true,
+  reactions: true,
+  attachments: true,
+  identity: true,
+  conversation: true,
+  directMessages: true,
+  threads: true,
+  mentions: true,
+});
+
+export interface LarkPlatformExtension {
+  /** Raw/high-level Lark callbacks (cards, docs, VC, and Lark routing hooks). */
+  readonly eventHandlers: EventHandlers;
+  readonly brand: Brand;
+}
+
+export interface LarkPlatformRuntimeDeps {
+  startEventDispatcher: typeof startLarkEventDispatcher;
+  stopEventDispatcher: typeof stopLarkEventDispatcher;
+  sendMessage: typeof sendLarkMessage;
+  replyMessage: typeof replyLarkMessage;
+  sendUserMessage: typeof sendUserMessage;
+  updateMessage: typeof updateLarkMessage;
+  addReaction: typeof addLarkReaction;
+  removeReaction: typeof removeLarkReaction;
+  downloadMessageResource: typeof downloadMessageResource;
+  resolveSender: typeof resolveSender;
+  learnFromMentions: typeof learnFromMentions;
+  decideRouting: typeof decideRouting;
+}
+
+const DEFAULT_DEPS: LarkPlatformRuntimeDeps = {
+  startEventDispatcher: startLarkEventDispatcher,
+  stopEventDispatcher: stopLarkEventDispatcher,
+  sendMessage: sendLarkMessage,
+  replyMessage: replyLarkMessage,
+  sendUserMessage,
+  updateMessage: updateLarkMessage,
+  addReaction: addLarkReaction,
+  removeReaction: removeLarkReaction,
+  downloadMessageResource,
+  resolveSender,
+  learnFromMentions,
+  decideRouting,
+};
+
+export interface LarkPlatformRuntimeOptions {
+  larkAppId: string;
+  larkAppSecret: string;
+  brand?: Brand;
+  eventHandlers: EventHandlers;
+  /** Dependency seam for compatibility-contract tests. */
+  deps?: Partial<LarkPlatformRuntimeDeps>;
+}
+
+export class LarkPlatformInstanceMismatchError extends PlatformInstanceMismatchError {
+  constructor(
+    expected: PlatformInstanceRef,
+    received: PlatformInstanceRef,
+  ) {
+    super(expected, received);
+    this.name = 'LarkPlatformInstanceMismatchError';
+  }
+}
+
+/** Serialize an adapter-owned card payload without double-encoding raw JSON. */
+function serializeLarkCard(card: PlatformCard): string {
+  if (typeof card.payload === 'string') return card.payload;
+  const serialized = JSON.stringify(card.payload);
+  if (serialized === undefined) {
+    throw new TypeError('Lark card payload is not JSON-serializable');
+  }
+  return serialized;
+}
+
+function mutableContext(options?: PlatformSendOptions): Record<string, unknown> | undefined {
+  return options?.context as Record<string, unknown> | undefined;
+}
+
+function toPlatformSender(sender: ResolvedSender): PlatformSender {
+  return {
+    id: sender.openId,
+    type: sender.type,
+    ...(sender.name ? { name: sender.name } : {}),
+  };
+}
+
+/**
+ * Lark façade for one configured app instance.
+ *
+ * Every port is a thin delegate to the existing production implementation so
+ * its ordering, return values, and thrown error objects remain unchanged. Lark
+ * card serialization and Lark-only event callbacks stay inside this adapter.
+ */
+export class LarkPlatformRuntime implements
+  PlatformRuntime,
+  PlatformMessagingPort,
+  PlatformDirectMessagesPort,
+  PlatformCardsPort,
+  PlatformReactionsPort,
+  PlatformAttachmentsPort,
+  PlatformIdentityPort,
+  PlatformConversationPort {
+  readonly instance: PlatformInstanceRef;
+  readonly capabilities = LARK_PLATFORM_CAPABILITIES;
+
+  readonly messaging: PlatformMessagingPort = this;
+  readonly directMessages: PlatformDirectMessagesPort = this;
+  readonly cards: PlatformCardsPort = this;
+  readonly reactions: PlatformReactionsPort = this;
+  readonly attachments: PlatformAttachmentsPort = this;
+  readonly identity: PlatformIdentityPort = this;
+  readonly conversation: PlatformConversationPort = this;
+
+  readonly extensions: { readonly lark: LarkPlatformExtension };
+
+  private readonly larkAppSecret: string;
+  private readonly deps: LarkPlatformRuntimeDeps;
+  private dispatcher?: WSClient;
+  private lifecycleTail: Promise<void> = Promise.resolve();
+
+  constructor(options: LarkPlatformRuntimeOptions) {
+    this.instance = { platform: 'lark', instanceId: options.larkAppId };
+    this.larkAppSecret = options.larkAppSecret;
+    this.deps = { ...DEFAULT_DEPS, ...options.deps };
+    this.extensions = {
+      lark: {
+        eventHandlers: options.eventHandlers,
+        brand: normalizeBrand(options.brand),
+      },
+    };
+  }
+
+  get isRunning(): boolean {
+    return this.dispatcher !== undefined;
+  }
+
+  /** Serialize lifecycle transitions while allowing a failed transition to be retried. */
+  private enqueueLifecycle(operation: () => void | Promise<void>): Promise<void> {
+    const result = this.lifecycleTail.then(operation, operation);
+    this.lifecycleTail = result.catch(() => { /* keep the queue usable after a failure */ });
+    return result;
+  }
+
+  start(): Promise<void> {
+    return this.enqueueLifecycle(() => {
+      if (this.dispatcher) return;
+      // Do not await or wrap the SDK's connection loop: the legacy start helper
+      // returns its WSClient immediately and owns reconnect/revive behavior.
+      this.dispatcher = this.deps.startEventDispatcher(
+        this.instance.instanceId,
+        this.larkAppSecret,
+        this.extensions.lark.eventHandlers,
+        this.extensions.lark.brand,
+      );
+    });
+  }
+
+  stop(): Promise<void> {
+    return this.enqueueLifecycle(() => {
+      if (!this.dispatcher) return;
+      const dispatcher = this.dispatcher;
+      // Retain the handle when stop throws so a caller can retry teardown.
+      this.deps.stopEventDispatcher(dispatcher);
+      this.dispatcher = undefined;
+    });
+  }
+
+  async sendMessage(
+    conversation: PlatformConversationRef,
+    content: string,
+    options?: PlatformSendOptions,
+  ): Promise<PlatformMessageRef> {
+    this.requireOwnInstance(conversation.instance);
+    const messageId = await this.deps.sendMessage(
+      this.instance.instanceId,
+      conversation.chatId,
+      content,
+      options?.contentType ?? 'text',
+      options?.idempotencyKey,
+      mutableContext(options),
+    );
+    return { instance: this.instance, messageId, conversation };
+  }
+
+  async replyMessage(
+    target: PlatformMessageRef,
+    content: string,
+    options?: PlatformReplyOptions,
+  ): Promise<PlatformMessageRef> {
+    this.requireOwnInstance(target.instance);
+    const messageId = await this.deps.replyMessage(
+      this.instance.instanceId,
+      target.messageId,
+      content,
+      options?.contentType ?? 'text',
+      options?.inThread ?? false,
+      options?.idempotencyKey,
+      mutableContext(options),
+    );
+    return {
+      instance: this.instance,
+      messageId,
+      ...(target.conversation ? { conversation: target.conversation } : {}),
+    };
+  }
+
+  async sendDirectMessage(
+    recipientId: string,
+    content: string,
+    options?: PlatformDirectMessageOptions,
+  ): Promise<PlatformMessageRef> {
+    const messageId = await this.deps.sendUserMessage(
+      this.instance.instanceId,
+      recipientId,
+      content,
+      options?.contentType ?? 'text',
+    );
+    return { instance: this.instance, messageId };
+  }
+
+  async sendCard(
+    conversation: PlatformConversationRef,
+    card: PlatformCard,
+    options?: PlatformSendOptions,
+  ): Promise<PlatformMessageRef> {
+    this.requireOwnInstance(conversation.instance);
+    const messageId = await this.deps.sendMessage(
+      this.instance.instanceId,
+      conversation.chatId,
+      serializeLarkCard(card),
+      'interactive',
+      options?.idempotencyKey,
+      mutableContext(options),
+    );
+    return { instance: this.instance, messageId, conversation };
+  }
+
+  async replyCard(
+    target: PlatformMessageRef,
+    card: PlatformCard,
+    options?: PlatformReplyOptions,
+  ): Promise<PlatformMessageRef> {
+    this.requireOwnInstance(target.instance);
+    const messageId = await this.deps.replyMessage(
+      this.instance.instanceId,
+      target.messageId,
+      serializeLarkCard(card),
+      'interactive',
+      options?.inThread ?? false,
+      options?.idempotencyKey,
+      mutableContext(options),
+    );
+    return {
+      instance: this.instance,
+      messageId,
+      ...(target.conversation ? { conversation: target.conversation } : {}),
+    };
+  }
+
+  async updateCard(target: PlatformMessageRef, card: PlatformCard): Promise<void> {
+    this.requireOwnInstance(target.instance);
+    await this.deps.updateMessage(
+      this.instance.instanceId,
+      target.messageId,
+      serializeLarkCard(card),
+    );
+  }
+
+  async addReaction(target: PlatformMessageRef, reaction: string): Promise<string> {
+    this.requireOwnInstance(target.instance);
+    return this.deps.addReaction(this.instance.instanceId, target.messageId, reaction);
+  }
+
+  async removeReaction(target: PlatformMessageRef, reactionId: string): Promise<void> {
+    this.requireOwnInstance(target.instance);
+    await this.deps.removeReaction(this.instance.instanceId, target.messageId, reactionId);
+  }
+
+  async downloadAttachment(
+    resource: PlatformAttachmentResource,
+    destinationPath: string,
+  ): Promise<PlatformAttachment> {
+    this.requireOwnInstance(resource.sourceMessage.instance);
+    await this.deps.downloadMessageResource(
+      this.instance.instanceId,
+      resource.sourceMessage.messageId,
+      resource.resourceId,
+      resource.type,
+      destinationPath,
+    );
+    return { type: resource.type, path: destinationPath, name: resource.name };
+  }
+
+  async resolveSender(
+    id: string,
+    type: PlatformSender['type'],
+    hint?: Pick<PlatformSender, 'name'>,
+  ): Promise<PlatformSender> {
+    if (!id.trim()) throw new TypeError('Platform sender id must not be empty');
+    const sender = await this.deps.resolveSender(this.instance.instanceId, id, type, {
+      type,
+      ...hint,
+    });
+    // The existing resolver returns undefined only when id is absent. This port
+    // requires a non-empty id and therefore preserves the resolved value shape.
+    return sender ? toPlatformSender(sender) : { id, type, ...hint };
+  }
+
+  learnMentions(mentions: readonly PlatformMention[]): void {
+    this.deps.learnFromMentions(
+      this.instance.instanceId,
+      mentions.map(mention => ({
+        name: mention.name,
+        openId: mention.identity
+          && (mention.identity.idType === undefined || mention.identity.idType === 'open_id')
+          ? mention.identity.id
+          : undefined,
+      })),
+    );
+  }
+
+  async resolveInitialConversation(input: PlatformInboundConversation): Promise<PlatformConversationRef> {
+    this.requireOwnInstance(input.instance);
+    const routing = await this.deps.decideRouting(this.instance.instanceId, {
+      message_id: input.messageId,
+      chat_id: input.chatId,
+      chat_type: input.conversationType === 'direct' ? 'p2p' : 'group',
+      root_id: input.rootMessageId,
+      thread_id: input.threadId,
+    });
+    return {
+      instance: this.instance,
+      chatId: input.chatId,
+      conversationType: input.conversationType,
+      scope: routing.scope,
+      anchorId: routing.anchor,
+      ...(routing.scope === 'thread' ? { threadRootId: routing.anchor } : {}),
+      ...(input.threadId ? { threadId: input.threadId } : {}),
+    };
+  }
+
+  private requireOwnInstance(received: PlatformInstanceRef): void {
+    if (!samePlatformInstance(this.instance, received)) {
+      throw new LarkPlatformInstanceMismatchError(this.instance, received);
+    }
+  }
+}

--- a/src/im/platform-descriptor.ts
+++ b/src/im/platform-descriptor.ts
@@ -1,0 +1,95 @@
+/**
+ * Backward-compatible identity fields shared by daemon descriptor readers.
+ *
+ * Descriptor files historically exposed only `larkAppId`. New writers may
+ * additionally publish a platform-neutral identity. Readers normalize both
+ * shapes without rewriting the descriptor on disk:
+ *
+ *   legacy:  { larkAppId }                    -> lark / larkAppId
+ *   generic: { platform, instanceId, ... }    -> explicit fields win
+ *
+ * `larkAppId` remains populated as a compatibility alias. A future non-Lark
+ * descriptor that omits it receives `instanceId` as the alias so existing
+ * wire consumers keep a stable string while platform-aware consumers use the
+ * `(platform, instanceId)` pair.
+ */
+
+export interface DescriptorPlatformRef {
+  platform: string;
+  instanceId: string;
+}
+
+export type DescriptorCapabilities = Readonly<Record<string, boolean>>;
+
+export interface NormalizedPlatformDescriptor extends DescriptorPlatformRef {
+  /** Legacy compatibility identity. Prefer `platform` + `instanceId`. */
+  larkAppId: string;
+  capabilities?: DescriptorCapabilities;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function normalizeCapabilities(value: unknown): DescriptorCapabilities | null | undefined {
+  if (value === undefined) return undefined;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+
+  const normalized: Record<string, boolean> = {};
+  for (const [key, enabled] of Object.entries(value as Record<string, unknown>)) {
+    const normalizedKey = key.trim();
+    if (!normalizedKey || typeof enabled !== 'boolean') return null;
+    normalized[normalizedKey] = enabled;
+  }
+  return normalized;
+}
+
+/**
+ * Normalize only the shared platform portion of a descriptor. Callers remain
+ * responsible for validating their own required transport/runtime fields.
+ */
+export function normalizePlatformDescriptor(raw: unknown): NormalizedPlatformDescriptor | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const record = raw as Record<string, unknown>;
+
+  const hasLegacyId = Object.prototype.hasOwnProperty.call(record, 'larkAppId');
+  const legacyId = hasLegacyId ? nonEmptyString(record.larkAppId) : null;
+  if (hasLegacyId && !legacyId) return null;
+
+  const hasPlatform = Object.prototype.hasOwnProperty.call(record, 'platform');
+  const hasInstanceId = Object.prototype.hasOwnProperty.call(record, 'instanceId');
+  let platform: string;
+  let instanceId: string;
+  if (hasPlatform || hasInstanceId) {
+    // Generic descriptors are atomic: accepting half of the pair could combine
+    // a future platform with the legacy Lark id and create a split identity.
+    if (!hasPlatform || !hasInstanceId) return null;
+    const genericPlatform = nonEmptyString(record.platform);
+    const genericInstanceId = nonEmptyString(record.instanceId);
+    if (!genericPlatform || !genericInstanceId) return null;
+    platform = genericPlatform;
+    instanceId = genericInstanceId;
+  } else {
+    if (!legacyId) return null;
+    platform = 'lark';
+    instanceId = legacyId;
+  }
+  if (platform === 'lark' && legacyId && legacyId !== instanceId) return null;
+
+  const capabilities = normalizeCapabilities(record.capabilities);
+  if (capabilities === null) return null;
+
+  return {
+    platform,
+    instanceId,
+    larkAppId: legacyId ?? instanceId,
+    ...(capabilities === undefined ? {} : { capabilities }),
+  };
+}
+
+/** Collision-free structured key for an opaque platform instance pair. */
+export function platformDescriptorKey(ref: DescriptorPlatformRef): string {
+  return JSON.stringify([ref.platform, ref.instanceId]);
+}

--- a/src/im/platform.ts
+++ b/src/im/platform.ts
@@ -1,0 +1,250 @@
+/**
+ * Platform-neutral identity and conversation models.
+ *
+ * Platform-specific identifiers are intentionally opaque here. In particular,
+ * Lark open_id / user_id / union_id names belong in the Lark adapter, not in
+ * core session state.
+ */
+
+/** Platforms with a runtime implementation registered in this release. */
+export const PLATFORM_IDS = ['lark'] as const;
+
+export type PlatformId = (typeof PLATFORM_IDS)[number];
+
+/** Opaque identity shape used when reading descriptors from future platforms. */
+export interface PlatformInstanceIdentity {
+  platform: string;
+  instanceId: string;
+}
+
+/** One configured account/application of a platform. */
+export interface PlatformInstanceRef extends PlatformInstanceIdentity {
+  platform: PlatformId;
+}
+
+export type PlatformConversationScope = 'chat' | 'thread';
+export type PlatformConversationType = 'group' | 'direct';
+
+/**
+ * A conversation plus the routing anchor used to look up its session.
+ *
+ * `anchorId` is the chat id for chat-scoped conversations and the thread root
+ * (or the message that will seed a new thread) for thread-scoped ones.
+ * `threadRootId` is the stable routing root when one exists. `threadId` is an
+ * optional distinct native thread identifier; platforms such as Lark may route
+ * by the root message even when no separate thread id is available.
+ */
+export interface PlatformConversationRef {
+  instance: PlatformInstanceRef;
+  chatId: string;
+  conversationType: PlatformConversationType;
+  scope: PlatformConversationScope;
+  anchorId: string;
+  threadRootId?: string;
+  threadId?: string;
+}
+
+/** A message address returned by a messaging or cards port. */
+export interface PlatformMessageRef {
+  instance: PlatformInstanceRef;
+  messageId: string;
+  conversation?: PlatformConversationRef;
+}
+
+/** Downloaded attachment passed to a CLI prompt. */
+export interface PlatformAttachment {
+  type: 'image' | 'file';
+  path: string;
+  name: string;
+}
+
+/** Opaque platform identities attached to a mention. */
+export interface PlatformMentionIdentity {
+  /** Primary identifier in the current platform-instance namespace. */
+  id: string;
+  /** Optional second platform-local identifier. */
+  secondaryId?: string;
+  /** Optional tenant/platform-stable identifier. */
+  stableId?: string;
+  /** Native identifier kind, retained without giving it platform semantics. */
+  idType?: string;
+}
+
+export interface PlatformMention {
+  /** Token embedded in the original message text. */
+  token: string;
+  name: string;
+  identity?: PlatformMentionIdentity;
+}
+
+export interface PlatformSender {
+  id: string;
+  type: 'user' | 'bot';
+  name?: string;
+}
+
+/**
+ * Capabilities are declarations of platform support, not per-bot policy.
+ * For example, disabling streaming cards in configuration does not make the
+ * Lark runtime incapable of cards or stream updates.
+ */
+export const PLATFORM_CAPABILITIES = [
+  'messaging',
+  'cards',
+  'streamUpdates',
+  'reactions',
+  'attachments',
+  'identity',
+  'conversation',
+  'directMessages',
+  'threads',
+  'mentions',
+] as const;
+
+export type PlatformCapability = (typeof PLATFORM_CAPABILITIES)[number];
+
+export type PlatformCapabilities = Readonly<Record<PlatformCapability, boolean>>;
+
+const EMPTY_CAPABILITIES: PlatformCapabilities = {
+  messaging: false,
+  cards: false,
+  streamUpdates: false,
+  reactions: false,
+  attachments: false,
+  identity: false,
+  conversation: false,
+  directMessages: false,
+  threads: false,
+  mentions: false,
+};
+
+/** Build a complete, serializable capability declaration. */
+export function createPlatformCapabilities(
+  supported: Partial<PlatformCapabilities> = {},
+): PlatformCapabilities {
+  return Object.freeze({ ...EMPTY_CAPABILITIES, ...supported });
+}
+
+export interface PlatformCapabilityProvider {
+  instance: PlatformInstanceRef;
+  capabilities: PlatformCapabilities;
+}
+
+export class PlatformCapabilityUnavailableError extends Error {
+  readonly code = 'platform_capability_unavailable';
+
+  constructor(
+    readonly instance: PlatformInstanceRef,
+    readonly capability: PlatformCapability,
+  ) {
+    super(
+      `Platform instance ${instance.platform}:${instance.instanceId} `
+      + `does not support capability ${capability}`,
+    );
+    this.name = 'PlatformCapabilityUnavailableError';
+  }
+}
+
+/**
+ * Require a declared capability before entering a capability-specific path.
+ * Unsupported operations fail explicitly rather than silently using a no-op.
+ */
+export function requirePlatformCapability(
+  provider: PlatformCapabilityProvider,
+  capability: PlatformCapability,
+): void {
+  if (!provider.capabilities[capability]) {
+    throw new PlatformCapabilityUnavailableError(provider.instance, capability);
+  }
+}
+
+/** Read the routing anchor without re-deriving platform-specific topology. */
+export function conversationRoutingAnchor(conversation: PlatformConversationRef): string {
+  return conversation.anchorId;
+}
+
+/** Stable in-memory identity for a configured platform instance. */
+export function platformInstanceKey(instance: PlatformInstanceIdentity): string {
+  return JSON.stringify([instance.platform, instance.instanceId]);
+}
+
+/** Derive identity from new generic fields or legacy Lark fields without
+ * mutating the source object. Explicit generic fields win; missing platform
+ * defaults to Lark for zero-migration compatibility. */
+export function derivePlatformInstanceIdentity(
+  value: unknown,
+  fallbackLarkInstanceId?: string,
+): PlatformInstanceIdentity | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const platform = typeof record.platform === 'string' && record.platform.trim()
+    ? record.platform.trim()
+    : 'lark';
+  const explicitInstanceId = typeof record.instanceId === 'string' && record.instanceId.trim()
+    ? record.instanceId.trim()
+    : undefined;
+  const legacyLarkAppId = typeof record.larkAppId === 'string' && record.larkAppId.trim()
+    ? record.larkAppId.trim()
+    : undefined;
+  if (platform === 'lark' && explicitInstanceId && legacyLarkAppId
+    && explicitInstanceId !== legacyLarkAppId) return null;
+  const instanceId = explicitInstanceId
+    ?? (platform === 'lark' ? legacyLarkAppId ?? fallbackLarkInstanceId?.trim() : undefined);
+  return instanceId ? { platform, instanceId } : null;
+}
+
+/** Shape accepted by cross-platform guards, including future platform ids. */
+export interface PlatformRefLike {
+  platform: string;
+}
+
+export function samePlatform(a: PlatformRefLike, b: PlatformRefLike): boolean {
+  return a.platform === b.platform;
+}
+
+export function samePlatformInstance(a: PlatformInstanceIdentity, b: PlatformInstanceIdentity): boolean {
+  return samePlatform(a, b) && a.instanceId === b.instanceId;
+}
+
+export class PlatformInstanceMismatchError extends Error {
+  readonly code = 'platform_instance_mismatch';
+
+  constructor(
+    readonly expected: PlatformInstanceIdentity,
+    readonly received: PlatformInstanceIdentity,
+  ) {
+    super(
+      `Platform runtime ${expected.platform}:${expected.instanceId} cannot operate on `
+      + `${received.platform}:${received.instanceId}`,
+    );
+    this.name = 'PlatformInstanceMismatchError';
+  }
+}
+
+export function requireSamePlatformInstance(
+  expected: PlatformInstanceIdentity,
+  received: PlatformInstanceIdentity,
+): void {
+  if (!samePlatformInstance(expected, received)) {
+    throw new PlatformInstanceMismatchError(expected, received);
+  }
+}
+
+export class CrossPlatformOperationError extends Error {
+  readonly code = 'unsupported_cross_platform';
+
+  constructor(
+    readonly sourcePlatform: string,
+    readonly targetPlatform: string,
+  ) {
+    super(`Cross-platform operation is unsupported: ${sourcePlatform} -> ${targetPlatform}`);
+    this.name = 'CrossPlatformOperationError';
+  }
+}
+
+/** Guard A2A/relay-style operations that must stay inside one platform. */
+export function requireSamePlatform(source: PlatformRefLike, target: PlatformRefLike): void {
+  if (!samePlatform(source, target)) {
+    throw new CrossPlatformOperationError(source.platform, target.platform);
+  }
+}

--- a/src/im/ports.ts
+++ b/src/im/ports.ts
@@ -1,0 +1,174 @@
+import type {
+  PlatformAttachment,
+  PlatformCapability,
+  PlatformCapabilityProvider,
+  PlatformConversationRef,
+  PlatformInstanceRef,
+  PlatformMention,
+  PlatformMessageRef,
+  PlatformSender,
+} from './platform.js';
+import { requirePlatformCapability } from './platform.js';
+
+export interface PlatformSendOptions {
+  /** Adapter-native content type. Omitted means the platform's text default. */
+  contentType?: string;
+  /** Platform-native idempotency key, when supported by the adapter. */
+  idempotencyKey?: string;
+  /** Opaque context for local hooks/telemetry; never sent as message content. */
+  context?: Readonly<Record<string, unknown>>;
+}
+
+export interface PlatformReplyOptions extends PlatformSendOptions {
+  inThread?: boolean;
+}
+
+export interface PlatformMessagingPort {
+  sendMessage(
+    conversation: PlatformConversationRef,
+    content: string,
+    options?: PlatformSendOptions,
+  ): Promise<PlatformMessageRef>;
+
+  replyMessage(
+    target: PlatformMessageRef,
+    content: string,
+    options?: PlatformReplyOptions,
+  ): Promise<PlatformMessageRef>;
+}
+
+export interface PlatformDirectMessagesPort {
+  sendDirectMessage(
+    recipientId: string,
+    content: string,
+    options?: PlatformDirectMessageOptions,
+  ): Promise<PlatformMessageRef>;
+}
+
+/** DM transports do not currently expose idempotency or hook context. Keeping
+ * this narrower than PlatformSendOptions prevents adapters from silently
+ * dropping those semantics. */
+export interface PlatformDirectMessageOptions {
+  contentType?: string;
+}
+
+/** Platform-native card payload. Rendering remains adapter-owned. */
+export interface PlatformCard {
+  payload: unknown;
+}
+
+export interface PlatformCardsPort {
+  sendCard(
+    conversation: PlatformConversationRef,
+    card: PlatformCard,
+    options?: PlatformSendOptions,
+  ): Promise<PlatformMessageRef>;
+
+  replyCard(
+    target: PlatformMessageRef,
+    card: PlatformCard,
+    options?: PlatformReplyOptions,
+  ): Promise<PlatformMessageRef>;
+
+  updateCard(target: PlatformMessageRef, card: PlatformCard): Promise<void>;
+}
+
+export interface PlatformReactionsPort {
+  addReaction(target: PlatformMessageRef, reaction: string): Promise<string>;
+  removeReaction(target: PlatformMessageRef, reactionId: string): Promise<void>;
+}
+
+export interface PlatformAttachmentResource {
+  sourceMessage: PlatformMessageRef;
+  resourceId: string;
+  type: PlatformAttachment['type'];
+  name: string;
+}
+
+export interface PlatformAttachmentsPort {
+  downloadAttachment(
+    resource: PlatformAttachmentResource,
+    destinationPath: string,
+  ): Promise<PlatformAttachment>;
+}
+
+export interface PlatformIdentityPort {
+  resolveSender(
+    id: string,
+    type: PlatformSender['type'],
+    hint?: Pick<PlatformSender, 'name'>,
+  ): Promise<PlatformSender>;
+
+  learnMentions(mentions: readonly PlatformMention[]): void;
+}
+
+export interface PlatformConversationPort {
+  /** Resolve the platform-native topology before higher-level policies such as
+   * force-topic, aliases, and session ownership adjust the final route. */
+  resolveInitialConversation(input: PlatformInboundConversation): Promise<PlatformConversationRef>;
+}
+
+export interface PlatformInboundConversation {
+  instance: PlatformInstanceRef;
+  chatId: string;
+  messageId: string;
+  conversationType: PlatformConversationRef['conversationType'];
+  rootMessageId?: string;
+  threadId?: string;
+}
+
+export interface PlatformPortMap {
+  messaging: PlatformMessagingPort;
+  directMessages: PlatformDirectMessagesPort;
+  cards: PlatformCardsPort;
+  reactions: PlatformReactionsPort;
+  attachments: PlatformAttachmentsPort;
+  identity: PlatformIdentityPort;
+  conversation: PlatformConversationPort;
+}
+
+export type PlatformPortName = keyof PlatformPortMap;
+
+/**
+ * A running platform instance. Ports are optional and must agree with the
+ * capability declaration; adapters must not install silent no-op ports.
+ */
+export interface PlatformRuntime extends PlatformCapabilityProvider, Partial<PlatformPortMap> {
+  readonly instance: PlatformInstanceRef;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}
+
+export class PlatformPortUnavailableError extends Error {
+  readonly code = 'platform_port_unavailable';
+
+  constructor(
+    readonly instance: PlatformInstanceRef,
+    readonly port: PlatformPortName,
+  ) {
+    super(
+      `Platform instance ${instance.platform}:${instance.instanceId} `
+      + `declares capability ${port} but provides no ${port} port`,
+    );
+    this.name = 'PlatformPortUnavailableError';
+  }
+}
+
+/**
+ * Return an optional port or fail explicitly. A false capability produces
+ * PlatformCapabilityUnavailableError; a declaration/port mismatch produces
+ * PlatformPortUnavailableError.
+ */
+export function requirePlatformPort<K extends PlatformPortName>(
+  runtime: PlatformRuntime,
+  port: K,
+): PlatformPortMap[K] {
+  requirePlatformCapability(runtime, port as PlatformCapability);
+  const value = runtime[port];
+  if (!value) throw new PlatformPortUnavailableError(runtime.instance, port);
+  // TypeScript cannot preserve the correlation between a generic key and an
+  // indexed optional intersection here. The runtime check above establishes
+  // that the selected member exists, and `PlatformRuntime` supplies its value
+  // from the same `PlatformPortMap` key.
+  return value as PlatformPortMap[K];
+}

--- a/src/im/runtime-lifecycle.ts
+++ b/src/im/runtime-lifecycle.ts
@@ -1,0 +1,30 @@
+import type { PlatformRuntime } from './ports.js';
+
+export type PlatformStopFailureHandler = (
+  error: unknown,
+  attempt: number,
+  maxAttempts: number,
+) => void;
+
+/**
+ * Stop a runtime with a bounded retry. Runtime stop implementations retain
+ * their dispatcher after a failed close specifically so the caller can retry;
+ * returning false lets shutdown keep the runtime bindings alive until its
+ * final process-exit cleanup.
+ */
+export async function stopPlatformRuntimeWithRetry(
+  runtime: PlatformRuntime,
+  maxAttempts: number = 2,
+  onFailure?: PlatformStopFailureHandler,
+): Promise<boolean> {
+  const attempts = Math.max(1, Math.floor(maxAttempts));
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      await runtime.stop();
+      return true;
+    } catch (error) {
+      onFailure?.(error, attempt, attempts);
+    }
+  }
+  return false;
+}

--- a/src/im/types.ts
+++ b/src/im/types.ts
@@ -1,90 +1,9 @@
-import type { StreamStatus } from '../types.js';
-
-export interface ImMessage {
-  id: string;
-  threadId: string;
-  senderId: string;
-  senderType: 'user' | 'bot';
-  content: string;
-  msgType: string;
-  attachments?: ImAttachment[];
-  createTime: string;
-}
-
-export interface ImAttachment {
-  type: 'image' | 'file';
-  path: string;
-  name: string;
-}
-
-export interface ImUser {
-  id: string;
-  identifier: string;
-}
-
-export interface ImCard {
-  payload: unknown;
-}
-
-export interface ImCardAction {
-  actionType: string;
-  threadId: string;
-  operatorId?: string;
-  value?: Record<string, unknown>;
-}
-
-export interface ImEventHandler {
-  onNewTopic(msg: ImMessage, chatId: string, chatType: 'group' | 'p2p'): Promise<void>;
-  onThreadReply(msg: ImMessage, threadId: string): Promise<void>;
-  onCardAction(action: ImCardAction): Promise<void>;
-}
-
-export interface ImCardBuilder {
-  buildSessionCard(opts: {
-    sessionId: string;
-    rootMessageId: string;
-    terminalUrl: string;
-    title: string;
-  }): ImCard;
-
-  buildStreamingCard(opts: {
-    sessionId: string;
-    rootMessageId: string;
-    terminalUrl: string;
-    title: string;
-    content: string;
-    status: StreamStatus;
-  }): ImCard;
-
-  buildRepoSelectCard(opts: {
-    projects: Array<{ name: string; path: string; description: string }>;
-    currentCwd: string;
-    rootMessageId: string;
-  }): ImCard;
-}
-
-export interface ImAdapter {
-  start(handler: ImEventHandler): Promise<void>;
-  stop(): Promise<void>;
-
-  cards: ImCardBuilder;
-
-  sendMessage(threadId: string, content: string, format: 'text' | 'rich'): Promise<string>;
-  replyMessage(messageId: string, content: string, format: 'text' | 'rich'): Promise<string>;
-  updateMessage(messageId: string, content: string): Promise<void>;
-  sendCard(threadId: string, card: ImCard): Promise<string>;
-  updateCard(messageId: string, card: ImCard): Promise<void>;
-
-  resolveUsers(identifiers: string[]): Promise<ImUser[]>;
-  sendDirectMessage(userId: string, content: string): Promise<void>;
-
-  downloadAttachment(messageId: string, resourceKey: string): Promise<string>;
-  getThreadMessages(threadId: string, limit: number): Promise<ImMessage[]>;
-
-  /** Add a reaction emoji to a message. Returns the reaction ID. */
-  addReaction(messageId: string, emojiType: string): Promise<string>;
-  /** Remove a reaction by its reaction ID (not emoji type). */
-  removeReaction(messageId: string, reactionId: string): Promise<void>;
-
-  getBotUserId(): string | undefined;
-}
+/**
+ * Compatibility barrel for the platform boundary.
+ *
+ * The former all-in-one ImAdapter draft was never used and competed with the
+ * capability-based runtime model. New code should prefer importing directly
+ * from `im/platform` or `im/ports`.
+ */
+export * from './platform.js';
+export * from './ports.js';

--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -5,10 +5,38 @@ import { config } from '../config.js';
 import { logger } from '../utils/logger.js';
 import { deleteFrozenCards } from './frozen-card-store.js';
 import type { Session } from '../types.js';
+import {
+  derivePlatformInstanceIdentity,
+  samePlatformInstance,
+  type PlatformInstanceIdentity,
+  type PlatformInstanceRef,
+} from '../im/platform.js';
 
 let sessions: Map<string, Session> = new Map();
 let loaded = false;
 let currentAppId: string | undefined;
+let currentInstance: PlatformInstanceRef | undefined;
+
+export class SessionInstanceMismatchError extends Error {
+  readonly code = 'session_instance_mismatch';
+
+  constructor(readonly sessionId: string) {
+    super(`Session ${sessionId} is not owned by the current platform instance`);
+    this.name = 'SessionInstanceMismatchError';
+  }
+}
+
+function currentInstanceOwns(session: Session): boolean {
+  if (!currentInstance) return true;
+  const owner = derivePlatformInstanceIdentity(session, currentInstance.instanceId);
+  return !!owner && samePlatformInstance(owner, currentInstance);
+}
+
+function assertCurrentInstanceOwns(session: Session): void {
+  if (!currentInstanceOwns(session)) {
+    throw new SessionInstanceMismatchError(session.sessionId);
+  }
+}
 
 // Legacy fields from the removed「处理中」placeholder-card PATCH delivery. They
 // no longer exist on Session and nothing reads them, but sessions persisted
@@ -24,8 +52,14 @@ export function stripLegacyPendingCardFields(session: Record<string, unknown>): 
  * When appId is set, sessions are stored in `sessions-{appId}.json`.
  * When unset, uses the legacy `sessions.json`.
  */
-export function init(appId?: string): void {
-  currentAppId = appId;
+export function init(appId?: string | PlatformInstanceRef): void {
+  if (typeof appId === 'object' && appId.platform !== 'lark') {
+    throw new Error(`Session store does not support platform ${appId.platform}`);
+  }
+  currentAppId = typeof appId === 'string' ? appId : appId?.instanceId;
+  currentInstance = currentAppId
+    ? { platform: 'lark', instanceId: currentAppId }
+    : undefined;
   loaded = false;
   sessions = new Map();
 }
@@ -135,6 +169,32 @@ export function getSession(sessionId: string): Session | undefined {
   return sessions.get(sessionId) ?? findInOtherFiles(sessionId);
 }
 
+/** Current store file and current runtime instance only; never scans siblings
+ * or returns an explicitly foreign/corrupt row from this instance's file. */
+export function getLocalSession(sessionId: string): Session | undefined {
+  load();
+  const session = sessions.get(sessionId);
+  return session && currentInstanceOwns(session) ? session : undefined;
+}
+
+/** Mutation-safe lookup scoped to one runtime instance.
+ *
+ * Unlike `getSession()` this never scans sibling session files. Agent-facing
+ * read commands retain the broad lookup above, while resume/restore paths can
+ * no longer accidentally mutate a session owned by another daemon instance.
+ */
+export function getSessionForInstance(
+  sessionId: string,
+  instance: PlatformInstanceIdentity,
+): Session | undefined {
+  load();
+  if (currentInstance && !samePlatformInstance(currentInstance, instance)) return undefined;
+  const session = sessions.get(sessionId);
+  if (!session) return undefined;
+  const owner = derivePlatformInstanceIdentity(session, currentInstance?.instanceId ?? instance.instanceId);
+  return owner && samePlatformInstance(owner, instance) ? session : undefined;
+}
+
 /**
  * Search all session files for a session not found in the current file.
  *
@@ -164,6 +224,7 @@ export function closeSession(sessionId: string): void {
   load();
   const session = sessions.get(sessionId);
   if (session) {
+    assertCurrentInstanceOwns(session);
     session.status = 'closed';
     session.closedAt = new Date().toISOString();
     save();
@@ -176,6 +237,7 @@ export function updateSessionPid(sessionId: string, pid: number | null): void {
   load();
   const session = sessions.get(sessionId);
   if (session) {
+    assertCurrentInstanceOwns(session);
     session.pid = pid ?? undefined;
     save();
   }
@@ -183,13 +245,14 @@ export function updateSessionPid(sessionId: string, pid: number | null): void {
 
 export function updateSession(session: Session): void {
   load();
+  assertCurrentInstanceOwns(session);
   sessions.set(session.sessionId, session);
   save();
 }
 
 export function listSessions(): Session[] {
   load();
-  return [...sessions.values()];
+  return [...sessions.values()].filter(currentInstanceOwns);
 }
 
 /**
@@ -278,7 +341,11 @@ function findActiveSessionsMatching(predicate: (s: Session) => boolean): Session
   load();
   const matches: Session[] = [];
   for (const s of sessions.values()) {
-    if (predicate(s) && s.status === 'active') matches.push(s);
+    const owner = derivePlatformInstanceIdentity(s, currentInstance?.instanceId);
+    // These APIs currently power Lark A2A inheritance. Future-platform rows
+    // may coexist on disk but must not leak into the Lark peer graph.
+    if (owner && owner.platform !== 'lark') continue;
+    if (predicate(s) && s.status === 'active') matches.push(owner ? projectSessionIdentity(s, owner) : s);
   }
   const dataDir = config.session.dataDir;
   const currentFp = getFilePath();
@@ -290,10 +357,28 @@ function findActiveSessionsMatching(predicate: (s: Session) => boolean): Session
       try {
         const data: Record<string, Session> = JSON.parse(readFileSync(fp, 'utf-8'));
         for (const s of Object.values(data)) {
-          if (predicate(s) && s.status === 'active') matches.push(s);
+          const owner = derivePlatformInstanceIdentity(s, instanceIdFromSessionFile(file));
+          if (owner && owner.platform !== 'lark') continue;
+          if (predicate(s) && s.status === 'active') matches.push(owner ? projectSessionIdentity(s, owner) : s);
         }
       } catch { continue; }
     }
   } catch { /* ignore */ }
   return matches;
+}
+
+/** Attach read-only source identity without changing JSON serialization. */
+function projectSessionIdentity(session: Session, owner: PlatformInstanceIdentity): Session {
+  if (derivePlatformInstanceIdentity(session)) return session;
+  const projected = { ...session };
+  Object.defineProperties(projected, {
+    platform: { value: owner.platform, enumerable: false },
+    instanceId: { value: owner.instanceId, enumerable: false },
+  });
+  return projected;
+}
+
+function instanceIdFromSessionFile(file: string): string | undefined {
+  const match = /^sessions-(.+)\.json$/.exec(file);
+  return match?.[1];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { BackendType } from './adapters/backend/types.js';
 import type { BotSkillPolicy } from './core/skills/types.js';
 import type { RiffBackendConfig } from './adapters/backend/riff-backend.js';
+import type { PlatformAttachment, PlatformMention } from './im/platform.js';
 import type { CliUsageLimitState } from './utils/cli-usage-limit.js';
 
 /** Runtime status the worker derives from screen content. */
@@ -205,13 +206,11 @@ export interface Session {
   };
 }
 
-export interface LarkAttachment {
-  type: 'image' | 'file';
-  path: string;       // 本地文件绝对路径
-  name: string;       // 文件名
-}
+/** @deprecated Lark compatibility alias. Core code uses PlatformAttachment. */
+export interface LarkAttachment extends PlatformAttachment {}
 
-export interface LarkMention {
+/** Lark-native mention data plus its platform-neutral projection. */
+export interface LarkMention extends PlatformMention {
   key: string;        // e.g. "@_user_1"
   name: string;       // display name
   openId?: string;    // open_id of the mentioned user/bot

--- a/src/utils/daemon-discovery.ts
+++ b/src/utils/daemon-discovery.ts
@@ -13,8 +13,17 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { config } from '../config.js';
+import {
+  normalizePlatformDescriptor,
+  type DescriptorCapabilities,
+  type DescriptorPlatformRef,
+} from '../im/platform-descriptor.js';
 
 export interface OnlineDaemonInfo {
+  platform: string;
+  instanceId: string;
+  capabilities?: DescriptorCapabilities;
+  /** Legacy compatibility identity. Prefer platform + instanceId. */
   larkAppId: string;
   ipcPort: number;
   botName?: string;
@@ -29,8 +38,19 @@ function registryDir(): string {
   return join(config.session.dataDir, 'dashboard-daemons');
 }
 
+function validPort(value: unknown): value is number {
+  return typeof value === 'number'
+    && Number.isInteger(value)
+    && value > 0
+    && value <= 65_535;
+}
+
+function finiteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
 /** List every daemon whose descriptor file is fresh (heartbeat within STALE_MS). */
-export function listOnlineDaemons(): OnlineDaemonInfo[] {
+export function listOnlinePlatformDaemons(): OnlineDaemonInfo[] {
   const dir = registryDir();
   if (!existsSync(dir)) return [];
   const now = Date.now();
@@ -41,23 +61,37 @@ export function listOnlineDaemons(): OnlineDaemonInfo[] {
     if (!f.endsWith('.json')) continue;
     try {
       const raw = readFileSync(join(dir, f), 'utf-8');
-      const d = JSON.parse(raw) as Partial<OnlineDaemonInfo>;
-      if (typeof d.ipcPort !== 'number' || typeof d.larkAppId !== 'string') continue;
-      if (now - (d.lastHeartbeat ?? 0) > STALE_MS) continue;
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const identity = normalizePlatformDescriptor(parsed);
+      if (!identity || !validPort(parsed.ipcPort) || !finiteNumber(parsed.lastHeartbeat)) continue;
+      if (now - parsed.lastHeartbeat > STALE_MS) continue;
       out.push({
-        larkAppId: d.larkAppId,
-        ipcPort: d.ipcPort,
-        ...(typeof d.botName === 'string' && d.botName.trim() ? { botName: d.botName.trim() } : {}),
-        ...(typeof d.cliId === 'string' && d.cliId.trim() ? { cliId: d.cliId.trim() } : {}),
-        pid: d.pid,
-        lastHeartbeat: d.lastHeartbeat,
+        ...identity,
+        ipcPort: parsed.ipcPort,
+        ...(typeof parsed.botName === 'string' && parsed.botName.trim() ? { botName: parsed.botName.trim() } : {}),
+        ...(typeof parsed.cliId === 'string' && parsed.cliId.trim() ? { cliId: parsed.cliId.trim() } : {}),
+        ...(finiteNumber(parsed.pid) ? { pid: parsed.pid } : {}),
+        lastHeartbeat: parsed.lastHeartbeat,
       });
     } catch { /* malformed — skip */ }
   }
   return out;
 }
 
+/** Legacy Lark-only view used by A2A/relay callers keyed by larkAppId. */
+export function listOnlineDaemons(): OnlineDaemonInfo[] {
+  return listOnlinePlatformDaemons().filter(d => d.platform === 'lark');
+}
+
 /** Find a specific online daemon by larkAppId. Returns null if offline / not found. */
 export function findOnlineDaemon(larkAppId: string): OnlineDaemonInfo | null {
-  return listOnlineDaemons().find(d => d.larkAppId === larkAppId) ?? null;
+  return listOnlineDaemons().find(d => d.platform === 'lark' && d.larkAppId === larkAppId) ?? null;
+}
+
+/** Find an online daemon by its complete platform-neutral instance identity. */
+export function findOnlineDaemonByRef(ref: DescriptorPlatformRef): OnlineDaemonInfo | null {
+  const platform = typeof ref?.platform === 'string' ? ref.platform.trim() : '';
+  const instanceId = typeof ref?.instanceId === 'string' ? ref.instanceId.trim() : '';
+  if (!platform || !instanceId) return null;
+  return listOnlinePlatformDaemons().find(d => d.platform === platform && d.instanceId === instanceId) ?? null;
 }

--- a/test/adopt-route.test.ts
+++ b/test/adopt-route.test.ts
@@ -5,8 +5,8 @@
  * 全部依赖注入，不访问真实 /proc / ps / 网络。
  */
 
-import { describe, it, expect } from 'vitest';
-import { getAncestorPids, resolveAdoptRoute, type AdoptRoute } from '../src/adapters/adopt-route.js';
+import { describe, it, expect, vi } from 'vitest';
+import { getAncestorPids, queryAdoptSession, resolveAdoptRoute, type AdoptRoute } from '../src/adapters/adopt-route.js';
 
 // ── getAncestorPids ────────────────────────────────────────────────────────────
 
@@ -74,9 +74,60 @@ describe('getAncestorPids', () => {
 
 // ── resolveAdoptRoute ──────────────────────────────────────────────────────────
 
+describe('queryAdoptSession platform compatibility', () => {
+  it('derives generic Lark identity from a legacy daemon response', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        sessionId: 's1', chatId: 'oc1', larkAppId: 'cli_legacy', rootMessageId: 'om1',
+      }),
+    })) as any);
+    try {
+      await expect(queryAdoptSession(7950, 123)).resolves.toEqual({
+        sessionId: 's1', chatId: 'oc1', platform: 'lark', instanceId: 'cli_legacy',
+        larkAppId: 'cli_legacy', rootMessageId: 'om1',
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('refuses an adopt route from an unsupported platform', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        sessionId: 's1', chatId: 'channel1', platform: 'discord', instanceId: 'bot1',
+        larkAppId: 'compat', rootMessageId: 'thread1',
+      }),
+    })) as any);
+    try {
+      await expect(queryAdoptSession(7950, 123)).resolves.toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('refuses a split-brain Lark adopt route', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        sessionId: 's1', chatId: 'oc1', platform: 'lark', instanceId: 'cli_a',
+        larkAppId: 'cli_b', rootMessageId: 'om1',
+      }),
+    })) as any);
+    try {
+      await expect(queryAdoptSession(7950, 123)).resolves.toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
 const MOCK_ROUTE: AdoptRoute = {
   sessionId: 's-adopt',
   chatId: 'oc_chat1',
+  platform: 'lark',
+  instanceId: 'cli_apptest',
   larkAppId: 'cli_apptest',
   rootMessageId: 'om_root1',
 };

--- a/test/bot-registry.test.ts
+++ b/test/bot-registry.test.ts
@@ -61,6 +61,7 @@ describe('registerBot', () => {
     const cfg = makeCfg();
     const state = mod.registerBot(cfg);
     expect(state.config).toBe(cfg);
+    expect(state.platformInstance).toEqual({ platform: 'lark', instanceId: 'app_test_001' });
   });
 
   it('should create a Lark Client with appId and appSecret', () => {

--- a/test/bridge-input.test.ts
+++ b/test/bridge-input.test.ts
@@ -8,6 +8,10 @@ import { describe, it, expect } from 'vitest';
 import { buildBridgeInputContent, buildFollowUpContent } from '../src/core/session-manager.js';
 import type { LarkAttachment, LarkMention } from '../src/types.js';
 
+function mention(key: string, name: string, openId: string): LarkMention {
+  return { key, token: key, name, openId, identity: { id: openId } };
+}
+
 describe('buildBridgeInputContent', () => {
   it('returns just the user content when no attachments / mentions', () => {
     expect(buildBridgeInputContent('hello world')).toBe('hello world');
@@ -26,7 +30,7 @@ describe('buildBridgeInputContent', () => {
 
   it('appends attachments and mentions as plain prose', () => {
     const att: LarkAttachment[] = [{ type: 'image', name: 'a.png', path: '/tmp/a.png' }];
-    const mentions: LarkMention[] = [{ key: '@_1', name: 'Codex', openId: 'ou_xxx' }];
+    const mentions: LarkMention[] = [mention('@_1', 'Codex', 'ou_xxx')];
     const out = buildBridgeInputContent('please review', { attachments: att, mentions });
     expect(out).toContain('please review');
     expect(out).toContain('a.png');
@@ -35,7 +39,7 @@ describe('buildBridgeInputContent', () => {
   });
 
   it('strips leading self mention and omits it from mention prose', () => {
-    const mentions: LarkMention[] = [{ key: '@_1', name: 'Codex', openId: 'ou_self' }];
+    const mentions: LarkMention[] = [mention('@_1', 'Codex', 'ou_self')];
     const out = buildBridgeInputContent('@Codex hello', {
       mentions,
       selfMention: { name: 'Codex', openId: 'ou_self' },
@@ -46,8 +50,8 @@ describe('buildBridgeInputContent', () => {
 
   it('keeps non-self mentions while filtering self mentions', () => {
     const mentions: LarkMention[] = [
-      { key: '@_1', name: 'Codex', openId: 'ou_self' },
-      { key: '@_2', name: 'Claude', openId: 'ou_other' },
+      mention('@_1', 'Codex', 'ou_self'),
+      mention('@_2', 'Claude', 'ou_other'),
     ];
     const out = buildBridgeInputContent('@Codex ask Claude', {
       mentions,
@@ -93,7 +97,7 @@ describe('buildBridgeInputContent', () => {
     // yet, but the inbound mention carries the openId — stripping should still
     // pick up the alias from the mentions list.
     const mentions: LarkMention[] = [
-      { key: '@_1', name: 'Codex 分身', openId: 'ou_self' },
+      mention('@_1', 'Codex 分身', 'ou_self'),
     ];
     const out = buildBridgeInputContent('@Codex 分身 hello', {
       mentions,
@@ -107,7 +111,7 @@ describe('buildBridgeInputContent', () => {
     // openId is authoritative — the other bot's mention must survive in
     // the [@提及] block.
     const mentions: LarkMention[] = [
-      { key: '@_1', name: 'Claude', openId: 'ou_other' },
+      mention('@_1', 'Claude', 'ou_other'),
     ];
     const out = buildBridgeInputContent('hi team', {
       mentions,
@@ -117,8 +121,19 @@ describe('buildBridgeInputContent', () => {
     expect(out).toContain('@Claude');
   });
 
+  it('falls back to name matching when a mention identity is not an open_id', () => {
+    const out = buildBridgeInputContent('@Claude hello', {
+      mentions: [{
+        key: '@_1', token: '@_1', name: 'Claude', openId: undefined,
+        identity: { id: 'user-1', idType: 'user_id' },
+      }],
+      selfMention: { name: 'Claude', openId: 'ou_self' },
+    });
+    expect(out).toBe('hello');
+  });
+
   it('does not crash when selfMention is omitted (regression: legacy callers)', () => {
-    const mentions: LarkMention[] = [{ key: '@_1', name: 'Codex', openId: 'ou_xxx' }];
+    const mentions: LarkMention[] = [mention('@_1', 'Codex', 'ou_xxx')];
     const out = buildBridgeInputContent('@Codex hello', { mentions });
     // Without selfMention we keep legacy behavior — leading @Codex stays,
     // mention block stays.

--- a/test/cmd-hook.test.ts
+++ b/test/cmd-hook.test.ts
@@ -145,6 +145,8 @@ describe('runHook', () => {
     const adoptRoute = {
       sessionId: 's-adopt',
       chatId: 'c-adopt',
+      platform: 'lark',
+      instanceId: 'a-adopt',
       larkAppId: 'a-adopt',
       rootMessageId: 'om_x',
     };

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -2976,6 +2976,9 @@ describe('handleCommand', () => {
       // the chatId (cosmetic — chat-scope routing doesn't use rootMessageId).
       expect(body.targetRootMessageId).toBe('oc_new_group');
       expect(body.requesterLarkAppId).toBe(LARK_APP_ID);
+      expect(body.requesterPlatform).toBe('lark');
+      expect(body.requesterInstanceId).toBe(LARK_APP_ID);
+      expect(body.targetPlatform).toBe('lark');
       expect(body.requestingUserOpenId).toBe('ou_sender');
 
       // Reply contains the new chat name and both bot statuses.

--- a/test/daemon-discovery.test.ts
+++ b/test/daemon-discovery.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { config } from '../src/config.js';
-import { listOnlineDaemons } from '../src/utils/daemon-discovery.js';
+import {
+  findOnlineDaemon,
+  findOnlineDaemonByRef,
+  listOnlineDaemons,
+  listOnlinePlatformDaemons,
+} from '../src/utils/daemon-discovery.js';
 
 describe('daemon discovery', () => {
   let dir: string;
@@ -22,7 +27,7 @@ describe('daemon discovery', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it('keeps friendly bot labels from daemon descriptors', () => {
+  it('normalizes legacy descriptors as lark while keeping friendly bot labels', () => {
     writeFileSync(join(dir, 'dashboard-daemons', 'cli_agent.json'), JSON.stringify({
       larkAppId: 'cli_agent',
       ipcPort: 7956,
@@ -32,11 +37,73 @@ describe('daemon discovery', () => {
       lastHeartbeat: Date.now(),
     }));
 
-    expect(listOnlineDaemons()).toEqual([expect.objectContaining({
+    expect(listOnlinePlatformDaemons()).toEqual([expect.objectContaining({
+      platform: 'lark',
+      instanceId: 'cli_agent',
       larkAppId: 'cli_agent',
       ipcPort: 7956,
       botName: 'codex-loopy',
       cliId: 'codex',
     })]);
+    expect(listOnlineDaemons()).toEqual([expect.objectContaining({ larkAppId: 'cli_agent' })]);
+    expect(findOnlineDaemon('cli_agent')?.ipcPort).toBe(7956);
+  });
+
+  it('prefers explicit generic identity fields and exposes capabilities', () => {
+    writeFileSync(join(dir, 'dashboard-daemons', 'generic.json'), JSON.stringify({
+      platform: 'discord',
+      instanceId: 'workspace-bot',
+      larkAppId: 'legacy-compat-id',
+      capabilities: { cards: false, reactions: true },
+      ipcPort: 7957,
+      lastHeartbeat: Date.now(),
+    }));
+
+    expect(listOnlinePlatformDaemons()).toEqual([expect.objectContaining({
+      platform: 'discord',
+      instanceId: 'workspace-bot',
+      larkAppId: 'legacy-compat-id',
+      capabilities: { cards: false, reactions: true },
+    })]);
+    expect(listOnlineDaemons()).toEqual([]);
+    expect(findOnlineDaemonByRef({ platform: 'discord', instanceId: 'workspace-bot' })?.ipcPort).toBe(7957);
+    // The legacy lookup remains specifically Lark-scoped.
+    expect(findOnlineDaemon('legacy-compat-id')).toBeNull();
+  });
+
+  it('keeps same-named instances on different platforms distinct', () => {
+    const common = { instanceId: 'shared', lastHeartbeat: Date.now() };
+    writeFileSync(join(dir, 'dashboard-daemons', 'lark.json'), JSON.stringify({
+      ...common, platform: 'lark', larkAppId: 'shared', ipcPort: 7958,
+    }));
+    writeFileSync(join(dir, 'dashboard-daemons', 'discord.json'), JSON.stringify({
+      ...common, platform: 'discord', larkAppId: 'discord-compat', ipcPort: 7959,
+    }));
+
+    expect(listOnlineDaemons()).toHaveLength(1);
+    expect(listOnlinePlatformDaemons()).toHaveLength(2);
+    expect(findOnlineDaemonByRef({ platform: 'lark', instanceId: 'shared' })?.ipcPort).toBe(7958);
+    expect(findOnlineDaemonByRef({ platform: 'discord', instanceId: 'shared' })?.ipcPort).toBe(7959);
+    expect(findOnlineDaemon('shared')?.ipcPort).toBe(7958);
+  });
+
+  it('skips malformed and incomplete descriptor records', () => {
+    const descriptorDir = join(dir, 'dashboard-daemons');
+    writeFileSync(join(descriptorDir, 'bad-json.json'), '{');
+    writeFileSync(join(descriptorDir, 'bad-platform.json'), JSON.stringify({
+      platform: ' ', instanceId: 'bot', ipcPort: 7960, lastHeartbeat: Date.now(),
+    }));
+    writeFileSync(join(descriptorDir, 'missing-identity.json'), JSON.stringify({
+      ipcPort: 7961, lastHeartbeat: Date.now(),
+    }));
+    writeFileSync(join(descriptorDir, 'bad-capabilities.json'), JSON.stringify({
+      platform: 'lark', instanceId: 'bot', capabilities: { cards: 'yes' },
+      ipcPort: 7962, lastHeartbeat: Date.now(),
+    }));
+    writeFileSync(join(descriptorDir, 'bad-port.json'), JSON.stringify({
+      larkAppId: 'bot', ipcPort: 0, lastHeartbeat: Date.now(),
+    }));
+
+    expect(listOnlineDaemons()).toEqual([]);
   });
 });

--- a/test/dashboard-create-session.test.ts
+++ b/test/dashboard-create-session.test.ts
@@ -32,6 +32,9 @@ vi.mock('../src/services/session-store.js', () => ({
 }));
 
 vi.mock('../src/services/message-queue.js', () => ({ ensureQueue: vi.fn() }));
+vi.mock('../src/services/project-scanner.js', () => ({
+  scanMultipleProjects: vi.fn(() => []),
+}));
 
 const sendMessageMock = vi.fn(async () => 'om_banner_123');
 vi.mock('../src/im/lark/client.js', () => ({
@@ -88,9 +91,17 @@ vi.mock('../src/services/whiteboard-store.js', () => ({
   ensureDefaultWhiteboard: vi.fn(),
 }));
 
-import { spawnDashboardSession, activateQueuedSession } from '../src/core/session-manager.js';
+import {
+  spawnDashboardSession,
+  activateQueuedSession,
+  setSessionManagerPlatformRuntime,
+} from '../src/core/session-manager.js';
 import { sessionKey } from '../src/core/types.js';
 import { dashboardEventBus } from '../src/core/dashboard-events.js';
+import { getBot } from '../src/bot-registry.js';
+import { scanMultipleProjects } from '../src/services/project-scanner.js';
+import { createPlatformCapabilities } from '../src/im/platform.js';
+import type { PlatformRuntime } from '../src/im/ports.js';
 
 const APP = 'cli_app_test';
 const CHAT = 'oc_newgroup';
@@ -101,6 +112,13 @@ beforeEach(() => {
   forkWorkerMock.mockClear();
   sendMessageMock.mockClear();
   (dashboardEventBus.publish as any).mockClear();
+  setSessionManagerPlatformRuntime(undefined);
+  vi.mocked(getBot).mockReturnValue({
+    config: { cliId: 'claude-code', cliPathOverride: undefined, defaultWorkingDir: '/tmp' },
+    botName: 'TestBot',
+    botOpenId: 'ou_bot',
+  } as any);
+  vi.mocked(scanMultipleProjects).mockReturnValue([]);
 });
 
 describe('spawnDashboardSession — backlog (待办池) parks without starting the CLI', () => {
@@ -173,6 +191,64 @@ describe('spawnDashboardSession — in_progress starts immediately', () => {
     const [, prompt] = forkWorkerMock.mock.calls[0];
     expect(prompt).toContain('<botmux_lead_dispatch>');
     expect(prompt).toContain('Sub1');
+  });
+
+  it('routes an interactive repo picker through the injected cards port', async () => {
+    vi.mocked(getBot).mockReturnValue({
+      config: {
+        cliId: 'claude-code',
+        cliPathOverride: undefined,
+        workingDir: '/tmp',
+      },
+      botName: 'TestBot',
+      botOpenId: 'ou_bot',
+    } as any);
+    vi.mocked(scanMultipleProjects).mockReturnValue([
+      { name: 'project-a', path: '/tmp/project-a', type: 'repo', branch: 'main' },
+    ]);
+
+    const instance = { platform: 'lark' as const, instanceId: APP };
+    const sendCard = vi.fn(async (conversation) => ({
+      instance,
+      messageId: 'om_repo_card',
+      conversation,
+    }));
+    const runtime = {
+      instance,
+      capabilities: createPlatformCapabilities({ cards: true }),
+      cards: {
+        sendCard,
+        replyCard: vi.fn(),
+        updateCard: vi.fn(),
+      },
+      start: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+    } satisfies PlatformRuntime;
+    setSessionManagerPlatformRuntime(runtime);
+
+    const active = new Map<string, DaemonSession>();
+    await spawnDashboardSession(active, undefined, {
+      larkAppId: APP,
+      chatId: CHAT,
+      content: '先选仓库',
+      column: 'in_progress',
+      role: 'solo',
+    });
+
+    expect(sendCard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instance,
+        chatId: CHAT,
+        scope: 'chat',
+        anchorId: CHAT,
+      }),
+      { payload: expect.any(String) },
+    );
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(forkWorkerMock).not.toHaveBeenCalled();
+    const ds = active.get(sessionKey(CHAT, APP))!;
+    expect(ds.pendingRepo).toBe(true);
+    expect(ds.repoCardMessageId).toBe('om_repo_card');
   });
 });
 

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -4,7 +4,7 @@ import { createHmac, randomBytes } from 'node:crypto';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { startIpcServer, setLarkAppId, setIpcAuthSecret, setBotRenamer, type IpcServerHandle } from '../src/core/dashboard-ipc-server.js';
+import { startIpcServer, setLarkAppId, setIpcAuthSecret, setBotRenamer, setPlatformRuntime, type IpcServerHandle } from '../src/core/dashboard-ipc-server.js';
 import { dashboardEventBus } from '../src/core/dashboard-events.js';
 import * as groupsStore from '../src/services/groups-store.js';
 import * as oncallStore from '../src/services/oncall-store.js';
@@ -82,6 +82,7 @@ afterEach(async () => {
   // Reset module-level larkAppId between tests so groups endpoints don't
   // leak state across describes.
   setLarkAppId('');
+  setPlatformRuntime(undefined);
   __testOnly_resetBotRegistry();
   setIpcAuthSecret(null);
 });
@@ -185,6 +186,54 @@ describe('POST /api/sessions/:sessionId/lock', () => {
 
     expect(res.status).toBe(400);
     expect(await res.json()).toMatchObject({ ok: false, error: 'bad_locked' });
+  });
+
+  it('does not read, close, locate, or copy a sibling instance session on wrong-daemon requests', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'dashboard-ipc-instance-lock-'));
+    const prevConfigDataDir = config.session.dataDir;
+    const seen: any[] = [];
+    const off = dashboardEventBus.subscribe(event => seen.push(event));
+    const foreign = {
+      sessionId: 'session-b', chatId: 'oc_b', rootMessageId: 'om_b', title: 'foreign',
+      status: 'active', createdAt: new Date().toISOString(), larkAppId: 'app_b', ownerOpenId: 'ou_b',
+    };
+    try {
+      config.session.dataDir = dataDir;
+      writeFileSync(join(dataDir, 'sessions-app_b.json'), JSON.stringify({ [foreign.sessionId]: foreign }));
+      sessionStore.init('app_a');
+      setLarkAppId('app_a');
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+
+      const res = await fetch(`http://127.0.0.1:${handle.port}/api/sessions/${foreign.sessionId}/lock`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ locked: true }),
+      });
+
+      expect(res.status).toBe(404);
+      expect(sessionStore.getLocalSession(foreign.sessionId)).toBeUndefined();
+
+      const closeRes = await fetch(`http://127.0.0.1:${handle.port}/api/sessions/${foreign.sessionId}/close`, {
+        method: 'POST',
+      });
+      expect(closeRes.status).toBe(200);
+      expect(await closeRes.json()).toEqual({ ok: true, alreadyClosed: true });
+
+      const locateRes = await fetch(`http://127.0.0.1:${handle.port}/api/sessions/${foreign.sessionId}/locate`, {
+        method: 'POST',
+      });
+      expect(locateRes.status).toBe(404);
+      expect(await locateRes.json()).toEqual({ ok: false, error: 'session_not_found' });
+
+      expect(seen.some(event => event.body?.sessionId === foreign.sessionId)).toBe(false);
+      expect(JSON.parse(readFileSync(join(dataDir, 'sessions-app_b.json'), 'utf8'))[foreign.sessionId])
+        .toEqual(foreign);
+    } finally {
+      off();
+      sessionStore.init();
+      config.session.dataDir = prevConfigDataDir;
+      rmSync(dataDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/dashboard-registry.test.ts
+++ b/test/dashboard-registry.test.ts
@@ -22,12 +22,109 @@ function writeDesc(larkAppId: string, port: number, hbAgo = 0) {
 }
 
 describe('DaemonRegistry', () => {
-  it('reads existing descriptors on start', async () => {
+  it('reads existing legacy descriptors as lark instances', async () => {
     writeDesc('appA', 7892);
     const reg = new DaemonRegistry(dir);
     await reg.start();
     expect(reg.list().length).toBe(1);
     expect(reg.getByAppId('appA')?.ipcPort).toBe(7892);
+    expect(reg.getByRef({ platform: 'lark', instanceId: 'appA' })).toEqual(expect.objectContaining({
+      platform: 'lark',
+      instanceId: 'appA',
+      larkAppId: 'appA',
+    }));
+    reg.stop();
+  });
+
+  it('prefers explicit generic identity fields and exposes capabilities', async () => {
+    writeFileSync(join(dir, 'generic.json'), JSON.stringify({
+      platform: 'lark',
+      instanceId: 'explicit-instance',
+      larkAppId: 'explicit-instance',
+      capabilities: { cards: true, reactions: false },
+      botName: 'Generic bot',
+      botIndex: 3,
+      ipcPort: 7894,
+      pid: 44,
+      startedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+    }));
+
+    const reg = new DaemonRegistry(dir);
+    await reg.start();
+    expect(reg.getByRef({ platform: 'lark', instanceId: 'explicit-instance' })).toEqual(expect.objectContaining({
+      larkAppId: 'explicit-instance',
+      capabilities: { cards: true, reactions: false },
+    }));
+    expect(reg.getByAppId('explicit-instance')?.instanceId).toBe('explicit-instance');
+    reg.stop();
+  });
+
+  it('keys registry entries by platform and instance id without collisions', async () => {
+    const common = {
+      instanceId: 'same-instance',
+      botIndex: 0,
+      pid: 1,
+      startedAt: Date.now(),
+      lastHeartbeat: Date.now(),
+    };
+    writeFileSync(join(dir, 'lark.json'), JSON.stringify({
+      ...common,
+      platform: 'lark',
+      larkAppId: 'same-instance',
+      botName: 'Lark bot',
+      ipcPort: 7895,
+    }));
+    writeFileSync(join(dir, 'discord.json'), JSON.stringify({
+      ...common,
+      platform: 'discord',
+      larkAppId: 'discord-compat',
+      botName: 'Discord bot',
+      ipcPort: 7896,
+    }));
+
+    const reg = new DaemonRegistry(dir);
+    await reg.start();
+    expect(reg.list()).toHaveLength(1);
+    expect(reg.listAll()).toHaveLength(2);
+    expect(reg.getByRef({ platform: 'lark', instanceId: 'same-instance' })?.ipcPort).toBe(7895);
+    expect(reg.getByRef({ platform: 'discord', instanceId: 'same-instance' })?.ipcPort).toBe(7896);
+    expect(reg.getByAppId('same-instance')?.ipcPort).toBe(7895);
+    expect(reg.getByAppId('discord-compat')).toBeUndefined();
+    reg.stop();
+  });
+
+  it('rejects split-brain Lark descriptors whose generic and legacy ids differ', async () => {
+    writeFileSync(join(dir, 'split.json'), JSON.stringify({
+      platform: 'lark', instanceId: 'generic-id', larkAppId: 'legacy-id',
+      botName: 'Split bot', botIndex: 0, ipcPort: 7899, pid: 1,
+      startedAt: Date.now(), lastHeartbeat: Date.now(),
+    }));
+    const reg = new DaemonRegistry(dir);
+    await reg.start();
+    expect(reg.listAll()).toEqual([]);
+    reg.stop();
+  });
+
+  it('skips malformed descriptor records', async () => {
+    writeFileSync(join(dir, 'bad-json.json'), '{');
+    writeFileSync(join(dir, 'missing-id.json'), JSON.stringify({
+      botName: 'Missing identity', botIndex: 0, ipcPort: 7897,
+      pid: 1, startedAt: Date.now(), lastHeartbeat: Date.now(),
+    }));
+    writeFileSync(join(dir, 'bad-capability.json'), JSON.stringify({
+      platform: 'lark', instanceId: 'bad', capabilities: { cards: 'yes' },
+      botName: 'Bad capability', botIndex: 0, ipcPort: 7898,
+      pid: 1, startedAt: Date.now(), lastHeartbeat: Date.now(),
+    }));
+    writeFileSync(join(dir, 'bad-runtime.json'), JSON.stringify({
+      larkAppId: 'bad-runtime', botName: 'Bad runtime', botIndex: 0, ipcPort: -1,
+      pid: 1, startedAt: Date.now(), lastHeartbeat: Date.now(),
+    }));
+
+    const reg = new DaemonRegistry(dir);
+    await reg.start();
+    expect(reg.list()).toEqual([]);
     reg.stop();
   });
 

--- a/test/download-resources-needlogin.test.ts
+++ b/test/download-resources-needlogin.test.ts
@@ -25,6 +25,7 @@ vi.mock('../src/im/lark/client.js', () => {
 
 import { downloadMessageResource, UserTokenMissingError } from '../src/im/lark/client.js';
 import { downloadResources } from '../src/core/session-manager.js';
+import { createPlatformCapabilities } from '../src/im/platform.js';
 
 const img = { type: 'image' as const, key: 'k', name: 'k.jpg' };
 
@@ -53,6 +54,30 @@ describe('downloadResources — needLogin gating', () => {
     expect(needLogin).toBe(false);
     expect(attachments).toHaveLength(1);
     expect(attachments[0]).toMatchObject({ type: 'image', name: 'k.jpg' });
+  });
+
+  it('uses the injected platform attachments port without calling the legacy client', async () => {
+    const downloadAttachment = vi.fn(async (resource: any, destinationPath: string) => ({
+      type: resource.type, name: resource.name, path: destinationPath,
+    }));
+    const runtime = {
+      instance: { platform: 'lark', instanceId: 'app' },
+      capabilities: createPlatformCapabilities({ attachments: true }),
+      attachments: { downloadAttachment },
+      start: vi.fn(), stop: vi.fn(),
+    } as any;
+
+    const result = await downloadResources('app', 'om_1', [img], runtime);
+
+    expect(result.attachments).toHaveLength(1);
+    expect(downloadAttachment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceMessage: { instance: runtime.instance, messageId: 'om_1' },
+        resourceId: 'k', type: 'image', name: 'k.jpg',
+      }),
+      expect.stringMatching(/\/attachments\/app\/om_1\/k\.jpg$/),
+    );
+    expect(downloadMessageResource).not.toHaveBeenCalled();
   });
 
   it('saves into the per-appId bucket (attachments/<appId>/<messageId>/) for the read-isolation carve-out', async () => {

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -105,6 +105,7 @@ vi.mock('../src/services/substitute-chat-toggle-store.js', () => ({
 
 // Capture the registered event handlers from EventDispatcher.register()
 let capturedHandlers: Record<string, Function> = {};
+let capturedWsOptions: any[] = [];
 
 vi.mock('@larksuiteoapi/node-sdk', () => {
   class MockEventDispatcher {
@@ -114,7 +115,11 @@ vi.mock('@larksuiteoapi/node-sdk', () => {
     }
   }
   class MockWSClient {
+    constructor(options: any) {
+      capturedWsOptions.push(options);
+    }
     start = vi.fn(async () => {});
+    close = vi.fn();
     getConnectionStatus = vi.fn(() => ({ state: 'connected', reconnectAttempts: 0 }));
   }
   return {
@@ -127,7 +132,7 @@ vi.mock('@larksuiteoapi/node-sdk', () => {
 // ─── Imports (must be after mocks) ──────────────────────────────────────────
 
 import { __resetAnchorQueues } from '../src/utils/anchor-serializer.js';
-import { __resetEventClaimsForTest, canOperate, canTalk, decideRouting, ensureBotOpenId, isBotMentioned, mentionsAnotherMember, startLarkEventDispatcher, writeBotInfoFile, type EventHandlers } from '../src/im/lark/event-dispatcher.js';
+import { __resetEventClaimsForTest, canOperate, canTalk, decideRouting, ensureBotOpenId, isBotMentioned, mentionsAnotherMember, startLarkEventDispatcher, stopLarkEventDispatcher, writeBotInfoFile, type EventHandlers } from '../src/im/lark/event-dispatcher.js';
 import {
   VC_BOT_MEETING_ACTIVITY_EVENT,
   VC_BOT_MEETING_ENDED_EVENT,
@@ -147,6 +152,7 @@ const OTHER_BOT_APP_ID = 'app-bot-b';
 const USER_OPEN_ID = 'ou_user_123';
 
 beforeEach(() => {
+  capturedWsOptions = [];
   mockListChatMessages.mockReset().mockResolvedValue([]);
   mockListChatMessagesUntil.mockReset().mockResolvedValue([]);
   mockListThreadMessages.mockReset().mockResolvedValue([]);
@@ -4816,6 +4822,42 @@ describe('ensureBotOpenId — dedup', () => {
 });
 
 describe('startLarkEventDispatcher — 长连接死后自愈 (reconnect-exhausted recovery)', () => {
+  it('stop closes the socket and clears the private revive timer', async () => {
+    vi.useFakeTimers();
+    const ws = startLarkEventDispatcher(MY_APP_ID, 'secret', makeHandlers()) as any;
+    ws.getConnectionStatus.mockReturnValue({ state: 'failed', reconnectAttempts: 9 });
+
+    stopLarkEventDispatcher(ws);
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(ws.close).toHaveBeenCalledTimes(1);
+    expect(ws.start).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it('force-closes a connection that becomes ready or reconnects after stop', () => {
+    const ws = startLarkEventDispatcher(MY_APP_ID, 'secret', makeHandlers()) as any;
+    const options = capturedWsOptions.at(-1);
+
+    stopLarkEventDispatcher(ws);
+    options.onReady();
+    options.onReconnected();
+
+    expect(ws.close).toHaveBeenNthCalledWith(1);
+    expect(ws.close).toHaveBeenNthCalledWith(2, { force: true });
+    expect(ws.close).toHaveBeenNthCalledWith(3, { force: true });
+  });
+
+  it('retries close after an initial stop failure while keeping timer teardown idempotent', () => {
+    const ws = startLarkEventDispatcher(MY_APP_ID, 'secret', makeHandlers()) as any;
+    ws.close.mockImplementationOnce(() => { throw new Error('close failed'); });
+    ws.close.mockImplementationOnce(() => undefined);
+
+    expect(() => stopLarkEventDispatcher(ws)).toThrow('close failed');
+    expect(() => stopLarkEventDispatcher(ws)).not.toThrow();
+    expect(ws.close).toHaveBeenCalledTimes(2);
+  });
+
   it('SDK 重连耗尽 (state=failed) 时，定时探测并重新 start() 重建长连接', async () => {
     vi.useFakeTimers();
     const ws = startLarkEventDispatcher(MY_APP_ID, 'secret', makeHandlers()) as any;

--- a/test/inherit-peer.test.ts
+++ b/test/inherit-peer.test.ts
@@ -24,7 +24,7 @@ vi.mock('../src/utils/logger.js', () => ({
 
 import { findInheritablePeer } from '../src/core/inherit-peer.js';
 
-function makePeer(overrides: Partial<{ sessionId: string; rootMessageId: string; chatId: string; scope: 'thread' | 'chat'; workingDir: string; larkAppId: string }>): any {
+function makePeer(overrides: Partial<{ sessionId: string; rootMessageId: string; chatId: string; scope: 'thread' | 'chat'; workingDir: string; larkAppId: string; platform: string; instanceId: string }>): any {
   return {
     sessionId: overrides.sessionId ?? 's-1',
     rootMessageId: overrides.rootMessageId ?? 'om_root',
@@ -32,6 +32,8 @@ function makePeer(overrides: Partial<{ sessionId: string; rootMessageId: string;
     scope: overrides.scope ?? 'thread',
     workingDir: overrides.workingDir,
     larkAppId: overrides.larkAppId ?? 'app-other',
+    ...(overrides.platform ? { platform: overrides.platform } : {}),
+    ...(overrides.instanceId ? { instanceId: overrides.instanceId } : {}),
   };
 }
 
@@ -68,6 +70,38 @@ describe('findInheritablePeer — layer 1 (cross-bot same-anchor)', () => {
       selfAppId: 'app-self',
     });
     expect(result).toEqual({ sessionId: 'peer-1', larkAppId: 'app-other', workingDir });
+  });
+
+  it('allows another Lark instance but rejects a peer from another platform', () => {
+    const workingDir = tempDir('repo-platform');
+    mockFindByRoot.mockReturnValue([
+      makePeer({ sessionId: 'discord-peer', workingDir, larkAppId: 'same', platform: 'discord', instanceId: 'same' }),
+      makePeer({ sessionId: 'lark-peer', workingDir, larkAppId: 'app-other', platform: 'lark', instanceId: 'app-other' }),
+    ]);
+
+    const result = findInheritablePeer({
+      scope: 'thread',
+      anchor: 'om_root',
+      chatId: 'oc_chat',
+      chatType: 'group',
+      selfAppId: 'app-self',
+      selfInstance: { platform: 'lark', instanceId: 'app-self' },
+    });
+
+    expect(result).toEqual({ sessionId: 'lark-peer', larkAppId: 'app-other', workingDir });
+  });
+
+  it('fails closed when a peer has no derivable platform instance', () => {
+    const workingDir = tempDir('repo-unknown');
+    mockFindByRoot.mockReturnValue([{
+      sessionId: 'unknown-peer', rootMessageId: 'om_root', chatId: 'oc_chat',
+      scope: 'thread', workingDir,
+    }]);
+
+    expect(findInheritablePeer({
+      scope: 'thread', anchor: 'om_root', chatId: 'oc_chat', chatType: 'group',
+      selfAppId: 'app-self', selfInstance: { platform: 'lark', instanceId: 'app-self' },
+    })).toBeNull();
   });
 
   it('skips peer that belongs to the same bot (would be self-inherit)', () => {

--- a/test/lark-platform-runtime.test.ts
+++ b/test/lark-platform-runtime.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { EventHandlers } from '../src/im/lark/event-dispatcher.js';
+import {
+  LARK_PLATFORM_CAPABILITIES,
+  LarkPlatformInstanceMismatchError,
+  LarkPlatformRuntime,
+  type LarkPlatformRuntimeDeps,
+} from '../src/im/lark/runtime.js';
+import { requirePlatformPort } from '../src/im/ports.js';
+import type {
+  PlatformConversationRef,
+  PlatformMessageRef,
+} from '../src/im/platform.js';
+
+const handlers: EventHandlers = {
+  handleCardAction: vi.fn(async () => ({})),
+  handleNewTopic: vi.fn(async () => {}),
+  handleThreadReply: vi.fn(async () => {}),
+};
+
+const dispatcher = { kind: 'fake-ws' } as any;
+
+function makeDeps(overrides: Partial<LarkPlatformRuntimeDeps> = {}): LarkPlatformRuntimeDeps {
+  return {
+    startEventDispatcher: vi.fn(() => dispatcher) as any,
+    stopEventDispatcher: vi.fn() as any,
+    sendMessage: vi.fn(async () => 'om_sent') as any,
+    replyMessage: vi.fn(async () => 'om_reply') as any,
+    sendUserMessage: vi.fn(async () => 'om_dm') as any,
+    updateMessage: vi.fn(async () => {}) as any,
+    addReaction: vi.fn(async () => 'reaction-id') as any,
+    removeReaction: vi.fn(async () => {}) as any,
+    downloadMessageResource: vi.fn(async () => {}) as any,
+    resolveSender: vi.fn(async (_appId, id, type, hint) => ({
+      openId: id,
+      type: type === 'bot' ? 'bot' : 'user',
+      name: hint?.name,
+    })) as any,
+    learnFromMentions: vi.fn() as any,
+    decideRouting: vi.fn(async (_appId, message) => ({
+      scope: 'chat',
+      anchor: message.chat_id,
+    })) as any,
+    ...overrides,
+  };
+}
+
+function makeRuntime(deps = makeDeps()): LarkPlatformRuntime {
+  return new LarkPlatformRuntime({
+    larkAppId: 'cli_app_a',
+    larkAppSecret: 'secret-a',
+    brand: 'lark',
+    eventHandlers: handlers,
+    deps,
+  });
+}
+
+function conversation(runtime: LarkPlatformRuntime): PlatformConversationRef {
+  return {
+    instance: runtime.instance,
+    chatId: 'oc_chat',
+    conversationType: 'group',
+    scope: 'thread',
+    anchorId: 'om_root',
+    threadId: 'omt_thread',
+  };
+}
+
+function message(runtime: LarkPlatformRuntime): PlatformMessageRef {
+  return {
+    instance: runtime.instance,
+    messageId: 'om_target',
+    conversation: conversation(runtime),
+  };
+}
+
+describe('LarkPlatformRuntime lifecycle and capabilities', () => {
+  it('binds one Lark instance, exposes every real port, and keeps advanced handlers explicit', () => {
+    const runtime = makeRuntime();
+
+    expect(runtime.instance).toEqual({ platform: 'lark', instanceId: 'cli_app_a' });
+    expect(runtime.capabilities).toBe(LARK_PLATFORM_CAPABILITIES);
+    expect(Object.values(runtime.capabilities).every(Boolean)).toBe(true);
+    for (const port of ['messaging', 'directMessages', 'cards', 'reactions', 'attachments', 'identity', 'conversation'] as const) {
+      expect(requirePlatformPort(runtime, port)).toBe(runtime[port]);
+    }
+    expect(runtime.extensions.lark).toEqual({ eventHandlers: handlers, brand: 'lark' });
+  });
+
+  it('starts/stops idempotently and serializes lifecycle calls in order', async () => {
+    const order: string[] = [];
+    const deps = makeDeps({
+      startEventDispatcher: vi.fn(() => { order.push('start'); return dispatcher; }) as any,
+      stopEventDispatcher: vi.fn(() => { order.push('stop'); }) as any,
+    });
+    const runtime = makeRuntime(deps);
+
+    await Promise.all([runtime.start(), runtime.start()]);
+    expect(runtime.isRunning).toBe(true);
+    expect(deps.startEventDispatcher).toHaveBeenCalledTimes(1);
+    expect(deps.startEventDispatcher).toHaveBeenCalledWith(
+      'cli_app_a', 'secret-a', handlers, 'lark',
+    );
+
+    await Promise.all([runtime.stop(), runtime.stop()]);
+    expect(runtime.isRunning).toBe(false);
+    expect(deps.stopEventDispatcher).toHaveBeenCalledTimes(1);
+    expect(deps.stopEventDispatcher).toHaveBeenCalledWith(dispatcher);
+
+    await runtime.start();
+    expect(order).toEqual(['start', 'stop', 'start']);
+  });
+
+  it('preserves lifecycle error identity and remains retryable', async () => {
+    const startError = new Error('start failed');
+    const stopError = new Error('stop failed');
+    const deps = makeDeps({
+      startEventDispatcher: vi.fn()
+        .mockImplementationOnce(() => { throw startError; })
+        .mockReturnValue(dispatcher) as any,
+      stopEventDispatcher: vi.fn()
+        .mockImplementationOnce(() => { throw stopError; })
+        .mockReturnValue(undefined) as any,
+    });
+    const runtime = makeRuntime(deps);
+
+    expect(await runtime.start().catch(error => error)).toBe(startError);
+    await runtime.start();
+    expect(await runtime.stop().catch(error => error)).toBe(stopError);
+    expect(runtime.isRunning).toBe(true);
+    await runtime.stop();
+    expect(runtime.isRunning).toBe(false);
+  });
+});
+
+describe('LarkPlatformRuntime port compatibility', () => {
+  it('delegates text send/reply/DM with the original parameter order and maps message refs', async () => {
+    const calls: string[] = [];
+    const deps = makeDeps({
+      sendMessage: vi.fn(async () => { calls.push('send'); return 'om_sent'; }) as any,
+      replyMessage: vi.fn(async () => { calls.push('reply'); return 'om_reply'; }) as any,
+      sendUserMessage: vi.fn(async () => { calls.push('dm'); return 'om_dm'; }) as any,
+    });
+    const runtime = makeRuntime(deps);
+    const conv = conversation(runtime);
+    const target = message(runtime);
+    const context = { sessionId: 'session-a' };
+
+    await expect(runtime.sendMessage(conv, 'hello', {
+      idempotencyKey: 'uuid-send', context,
+    })).resolves.toEqual({ instance: runtime.instance, messageId: 'om_sent', conversation: conv });
+    await expect(runtime.replyMessage(target, 'world', {
+      inThread: true, idempotencyKey: 'uuid-reply', context,
+    })).resolves.toEqual({ instance: runtime.instance, messageId: 'om_reply', conversation: conv });
+    await expect(runtime.sendDirectMessage('ou_user', 'private')).resolves.toEqual({
+      instance: runtime.instance, messageId: 'om_dm',
+    });
+
+    expect(deps.sendMessage).toHaveBeenCalledWith(
+      'cli_app_a', 'oc_chat', 'hello', 'text', 'uuid-send', context,
+    );
+    expect(deps.replyMessage).toHaveBeenCalledWith(
+      'cli_app_a', 'om_target', 'world', 'text', true, 'uuid-reply', context,
+    );
+    expect(deps.sendUserMessage).toHaveBeenCalledWith(
+      'cli_app_a', 'ou_user', 'private', 'text',
+    );
+    expect(calls).toEqual(['send', 'reply', 'dm']);
+  });
+
+  it('serializes cards in the adapter and delegates send/reply/update unchanged', async () => {
+    const deps = makeDeps();
+    const runtime = makeRuntime(deps);
+    const conv = conversation(runtime);
+    const target = message(runtime);
+    const objectCard = { payload: { schema: '2.0', body: { elements: [] } } };
+    const rawCard = { payload: '{"schema":"2.0","body":{}}' };
+
+    await expect(runtime.sendCard(conv, objectCard, { idempotencyKey: 'card-send' }))
+      .resolves.toMatchObject({ messageId: 'om_sent', conversation: conv });
+    await expect(runtime.replyCard(target, rawCard, { inThread: true }))
+      .resolves.toMatchObject({ messageId: 'om_reply', conversation: conv });
+    await runtime.updateCard(target, objectCard);
+
+    expect(deps.sendMessage).toHaveBeenCalledWith(
+      'cli_app_a',
+      'oc_chat',
+      JSON.stringify(objectCard.payload),
+      'interactive',
+      'card-send',
+      undefined,
+    );
+    expect(deps.replyMessage).toHaveBeenCalledWith(
+      'cli_app_a', 'om_target', rawCard.payload, 'interactive', true, undefined, undefined,
+    );
+    expect(deps.updateMessage).toHaveBeenCalledWith(
+      'cli_app_a', 'om_target', JSON.stringify(objectCard.payload),
+    );
+  });
+
+  it('delegates reactions and attachment download with exact identifiers', async () => {
+    const deps = makeDeps();
+    const runtime = makeRuntime(deps);
+    const target = message(runtime);
+
+    await expect(runtime.addReaction(target, 'DONE')).resolves.toBe('reaction-id');
+    await runtime.removeReaction(target, 'reaction-id');
+    await expect(runtime.downloadAttachment({
+      sourceMessage: target,
+      resourceId: 'file-key',
+      type: 'file',
+      name: 'report.pdf',
+    }, '/tmp/report.pdf')).resolves.toEqual({
+      type: 'file', path: '/tmp/report.pdf', name: 'report.pdf',
+    });
+
+    expect(deps.addReaction).toHaveBeenCalledWith('cli_app_a', 'om_target', 'DONE');
+    expect(deps.removeReaction).toHaveBeenCalledWith('cli_app_a', 'om_target', 'reaction-id');
+    expect(deps.downloadMessageResource).toHaveBeenCalledWith(
+      'cli_app_a', 'om_target', 'file-key', 'file', '/tmp/report.pdf',
+    );
+  });
+
+  it('maps neutral identity/mentions and full conversation routing at the Lark boundary', async () => {
+    const deps = makeDeps({
+      resolveSender: vi.fn(async () => ({ openId: 'ou_bot', type: 'bot', name: 'Builder' })) as any,
+      decideRouting: vi.fn()
+        .mockResolvedValueOnce({ scope: 'thread', anchor: 'om_root' })
+        .mockResolvedValueOnce({ scope: 'chat', anchor: 'oc_dm' }) as any,
+    });
+    const runtime = makeRuntime(deps);
+
+    await expect(runtime.resolveSender('ou_bot', 'bot', { name: 'hint' })).resolves.toEqual({
+      id: 'ou_bot', type: 'bot', name: 'Builder',
+    });
+    runtime.learnMentions([
+      { token: '@_user_1', name: 'Alice', identity: { id: 'ou_alice' } },
+      { token: '@_user_2', name: 'Bob', identity: { id: 'on_bob', idType: 'union_id' } },
+      { token: '@_all', name: 'all' },
+    ]);
+    await expect(runtime.resolveInitialConversation({
+      instance: runtime.instance,
+      chatId: 'oc_topic',
+      messageId: 'om_reply',
+      conversationType: 'group',
+      rootMessageId: 'om_root',
+      threadId: 'omt_thread',
+    })).resolves.toEqual({
+      instance: runtime.instance,
+      chatId: 'oc_topic',
+      conversationType: 'group',
+      scope: 'thread',
+      anchorId: 'om_root',
+      threadRootId: 'om_root',
+      threadId: 'omt_thread',
+    });
+    await expect(runtime.resolveInitialConversation({
+      instance: runtime.instance,
+      chatId: 'oc_dm',
+      messageId: 'om_dm',
+      conversationType: 'direct',
+    })).resolves.toMatchObject({ scope: 'chat', anchorId: 'oc_dm' });
+
+    expect(deps.resolveSender).toHaveBeenCalledWith(
+      'cli_app_a', 'ou_bot', 'bot', { type: 'bot', name: 'hint' },
+    );
+    expect(deps.learnFromMentions).toHaveBeenCalledWith('cli_app_a', [
+      { name: 'Alice', openId: 'ou_alice' },
+      { name: 'Bob', openId: undefined },
+      { name: 'all', openId: undefined },
+    ]);
+    expect(deps.decideRouting).toHaveBeenNthCalledWith(
+      1, 'cli_app_a', {
+        message_id: 'om_reply', chat_id: 'oc_topic', chat_type: 'group',
+        root_id: 'om_root', thread_id: 'omt_thread',
+      },
+    );
+    expect(deps.decideRouting).toHaveBeenNthCalledWith(
+      2, 'cli_app_a', {
+        message_id: 'om_dm', chat_id: 'oc_dm', chat_type: 'p2p',
+        root_id: undefined, thread_id: undefined,
+      },
+    );
+  });
+
+  it('rejects empty sender identities instead of fabricating an unusable sender', async () => {
+    const runtime = makeRuntime();
+    await expect(runtime.resolveSender('  ', 'user')).rejects.toThrow(TypeError);
+  });
+
+  it('propagates the exact dependency error object', async () => {
+    const failure = new Error('lark send failed');
+    const deps = makeDeps({ sendMessage: vi.fn(async () => { throw failure; }) as any });
+    const runtime = makeRuntime(deps);
+
+    const caught = await runtime.sendMessage(conversation(runtime), 'hello').catch(error => error);
+    expect(caught).toBe(failure);
+  });
+
+  it('rejects a conversation or message owned by another platform instance', async () => {
+    const runtime = makeRuntime();
+    const foreign = {
+      ...conversation(runtime),
+      instance: { platform: 'lark' as const, instanceId: 'cli_app_b' },
+    };
+
+    await expect(runtime.sendMessage(foreign, 'hello')).rejects.toBeInstanceOf(
+      LarkPlatformInstanceMismatchError,
+    );
+  });
+});

--- a/test/message-parser.test.ts
+++ b/test/message-parser.test.ts
@@ -839,6 +839,15 @@ describe('parseEventMessage: mention identity formats', () => {
       name: 'BotA',
       openId: 'ou_bot_a_open_id',
     });
+    expect(parsed.mentions?.[0].token).toBe('@_bot');
+    expect(parsed.mentions?.[0].identity).toEqual({
+      id: 'ou_bot_a_open_id',
+      secondaryId: undefined,
+      stableId: undefined,
+      idType: 'open_id',
+    });
+    // Neutral projections must not rewrite the legacy persisted/JSON shape.
+    expect(Object.keys(parsed.mentions?.[0] ?? {})).not.toContain('identity');
   });
 
   it('keeps string open_id mention ids as openId', () => {
@@ -867,5 +876,12 @@ describe('parseEventMessage: mention identity formats', () => {
       idType: 'app_id',
     });
     expect(parsed.mentions?.[0].openId).toBeUndefined();
+  });
+
+  it('marks a user_id fallback so the Lark runtime never caches it as open_id', () => {
+    const { parsed } = parseEventMessage(makeMentionEvent({
+      key: '@_user', name: 'User', id: { user_id: 'user-1' },
+    }));
+    expect(parsed.mentions?.[0].identity).toMatchObject({ id: 'user-1', idType: 'user_id' });
   });
 });

--- a/test/migrate-to-chat-endpoint.test.ts
+++ b/test/migrate-to-chat-endpoint.test.ts
@@ -157,6 +157,20 @@ describe('POST /api/sessions/migrate-to-chat', () => {
     expect(r.body.error).toBe('missing_field');
   });
 
+  it('rejects cross-platform requester or target before session lookup', async () => {
+    const requester = await postMigrate({
+      ...validBody(),
+      requesterPlatform: 'discord',
+      requesterInstanceId: 'cli_leader',
+    });
+    expect(requester.status).toBe(400);
+    expect(requester.body.error).toBe('unsupported_cross_platform');
+
+    const target = await postMigrate({ ...validBody(), targetPlatform: 'discord' });
+    expect(target.status).toBe(400);
+    expect(target.body.error).toBe('unsupported_cross_platform');
+  });
+
   it('403 when requesterLarkAppId is not a known bot', async () => {
     const ds = makeDs();
     registry.set(sessionKey('om_thread_root', 'cli_peer'), ds);

--- a/test/platform-architecture.test.ts
+++ b/test/platform-architecture.test.ts
@@ -1,0 +1,166 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import ts from 'typescript';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+/**
+ * Transitional dependency-edge allowlist for platform-neutral code that still
+ * reaches directly into the legacy Lark implementation.
+ *
+ * Keep entries exact (repo-relative file + literal module specifier). During
+ * the strangler migration, remove an entry as soon as the corresponding edge
+ * is routed through a platform port/runtime. Exact comparison below makes a
+ * newly introduced edge fail loudly instead of silently expanding the debt.
+ * `src/core/types.ts` is intentionally absent: the core session model has a
+ * stricter zero-Lark-types invariant asserted separately.
+ */
+const LEGACY_LARK_IMPORTS = new Set([
+  'src/core/closed-session-card.ts -> ../im/lark/card-builder.js',
+  'src/core/command-handler.ts -> ../im/lark/card-builder.js',
+  'src/core/command-handler.ts -> ../im/lark/client.js',
+  'src/core/command-handler.ts -> ../im/lark/doc-comment.js',
+  'src/core/command-handler.ts -> ../im/lark/event-dispatcher.js',
+  'src/core/command-handler.ts -> ../im/lark/lark-hosts.js',
+  'src/core/command-handler.ts -> ../im/lark/relay-target-routing.js',
+  'src/core/dashboard-command/groups.ts -> ../../im/lark/client.js',
+  'src/core/dashboard-command/groups.ts -> ../../im/lark/groups-card.js',
+  'src/core/dashboard-command/index.ts -> ../../im/lark/client.js',
+  'src/core/dashboard-command/overview.ts -> ../../im/lark/client.js',
+  'src/core/dashboard-command/overview.ts -> ../../im/lark/overview-card.js',
+  'src/core/dashboard-command/schedules.ts -> ../../im/lark/client.js',
+  'src/core/dashboard-command/schedules.ts -> ../../im/lark/schedules-card.js',
+  'src/core/dashboard-command/sessions.ts -> ../../im/lark/client.js',
+  'src/core/dashboard-command/sessions.ts -> ../../im/lark/sessions-card.js',
+  'src/core/dashboard-command/settings.ts -> ../../im/lark/client.js',
+  'src/core/dashboard-command/settings.ts -> ../../im/lark/settings-card.js',
+  'src/core/dashboard-command/workflows.ts -> ../../im/lark/client.js',
+  'src/core/dashboard-command/workflows.ts -> ../../im/lark/workflows-card.js',
+  'src/core/dashboard-ipc-server.ts -> ../im/lark/card-builder.js',
+  'src/core/dashboard-ipc-server.ts -> ../im/lark/client.js',
+  'src/core/dashboard-ipc-server.ts -> ../im/lark/message-parser.js',
+  'src/core/dashboard-rows.ts -> ../im/lark/identity-cache.js',
+  'src/core/dashboard-rows.ts -> ../im/lark/lark-hosts.js',
+  'src/core/session-manager.ts -> ../im/lark/card-builder.js',
+  'src/core/session-manager.ts -> ../im/lark/card-handler.js',
+  'src/core/session-manager.ts -> ../im/lark/client.js',
+  'src/core/session-manager.ts -> ../im/lark/message-parser.js',
+  'src/core/trigger-session.ts -> ../im/lark/card-handler.js',
+  'src/core/trigger-session.ts -> ../im/lark/client.js',
+  'src/core/worker-pool.ts -> ../im/lark/card-builder.js',
+  'src/core/worker-pool.ts -> ../im/lark/client.js',
+  'src/core/worker-pool.ts -> ../im/lark/doc-comment.js',
+  'src/core/worker-pool.ts -> ../im/lark/lark-hosts.js',
+  'src/core/worker-pool.ts -> ../im/lark/md-card.js',
+]);
+
+function sourceFilesUnder(root: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const full = join(root, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...sourceFilesUnder(full));
+    } else if (/\.(?:[cm]?ts|tsx)$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function filesInNeutralLayers(): string[] {
+  return [
+    ...sourceFilesUnder(join(REPO_ROOT, 'src/core')),
+    join(REPO_ROOT, 'src/worker.ts'),
+    ...sourceFilesUnder(join(REPO_ROOT, 'src/adapters/cli')),
+    ...sourceFilesUnder(join(REPO_ROOT, 'src/adapters/backend')),
+  ];
+}
+
+function literalText(node: ts.Node | undefined): string | undefined {
+  if (node && (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node))) {
+    return node.text;
+  }
+  return undefined;
+}
+
+function importedSpecifiers(file: string): string[] {
+  const source = readFileSync(file, 'utf8');
+  const kind = file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, kind);
+  const specifiers: string[] = [];
+
+  const visit = (node: ts.Node): void => {
+    // Static imports and `export ... from '...'` re-exports.
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      const specifier = literalText(node.moduleSpecifier);
+      if (specifier) specifiers.push(specifier);
+    }
+
+    // TypeScript's `import foo = require('...')` static-import form.
+    if (
+      ts.isImportEqualsDeclaration(node)
+      && ts.isExternalModuleReference(node.moduleReference)
+    ) {
+      const specifier = literalText(node.moduleReference.expression);
+      if (specifier) specifiers.push(specifier);
+    }
+
+    // Runtime dynamic imports: `await import('...')`.
+    if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+      const specifier = literalText(node.arguments[0]);
+      if (specifier) specifiers.push(specifier);
+    }
+
+    // Type-position imports: `import('...').SomeType`.
+    if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument)) {
+      const specifier = literalText(node.argument.literal);
+      if (specifier) specifiers.push(specifier);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return specifiers;
+}
+
+function isDirectLarkImport(specifier: string): boolean {
+  return /(?:^|\/)im\/lark(?:\/|$)/.test(specifier.replaceAll('\\', '/'));
+}
+
+function directLarkImportEdges(): Set<string> {
+  const edges = new Set<string>();
+  for (const file of filesInNeutralLayers()) {
+    const repoRelative = relative(REPO_ROOT, file).replaceAll('\\', '/');
+    for (const specifier of importedSpecifiers(file)) {
+      if (isDirectLarkImport(specifier)) {
+        edges.add(`${repoRelative} -> ${specifier}`);
+      }
+    }
+  }
+  return edges;
+}
+
+describe('platform architecture boundary', () => {
+  it('does not add direct im/lark dependency edges to platform-neutral layers', () => {
+    const actual = directLarkImportEdges();
+    const unexpected = [...actual].filter(edge => !LEGACY_LARK_IMPORTS.has(edge)).sort();
+    const staleAllowlist = [...LEGACY_LARK_IMPORTS].filter(edge => !actual.has(edge)).sort();
+
+    expect({ unexpected, staleAllowlist }).toEqual({ unexpected: [], staleAllowlist: [] });
+  });
+
+  it('keeps the core session model free of Lark-specific types and imports', () => {
+    const file = join(REPO_ROOT, 'src/core/types.ts');
+    const source = readFileSync(file, 'utf8');
+    const larkImports = importedSpecifiers(file).filter(isDirectLarkImport);
+
+    expect(larkImports).toEqual([]);
+    for (const forbidden of ['LarkAttachment', 'LarkMention', 'ResolvedSender']) {
+      expect(source, `src/core/types.ts must not contain ${forbidden}`).not.toMatch(
+        new RegExp(`\\b${forbidden}\\b`),
+      );
+    }
+  });
+});

--- a/test/platform-runtime.test.ts
+++ b/test/platform-runtime.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CrossPlatformOperationError,
+  PlatformCapabilityUnavailableError,
+  conversationRoutingAnchor,
+  createPlatformCapabilities,
+  derivePlatformInstanceIdentity,
+  platformInstanceKey,
+  requirePlatformCapability,
+  requireSamePlatform,
+  samePlatform,
+  samePlatformInstance,
+  type PlatformAttachment,
+  type PlatformConversationRef,
+  type PlatformInstanceRef,
+  type PlatformMention,
+  type PlatformSender,
+} from '../src/im/platform.js';
+import {
+  PlatformPortUnavailableError,
+  requirePlatformPort,
+  type PlatformMessagingPort,
+  type PlatformRuntime,
+} from '../src/im/ports.js';
+import { stopPlatformRuntimeWithRetry } from '../src/im/runtime-lifecycle.js';
+
+const larkA: PlatformInstanceRef = { platform: 'lark', instanceId: 'cli_app_a' };
+const larkB: PlatformInstanceRef = { platform: 'lark', instanceId: 'cli_app_b' };
+
+describe('platform models', () => {
+  it('keeps platform-instance identity separate from platform identity', () => {
+    expect(platformInstanceKey(larkA)).toBe('["lark","cli_app_a"]');
+    expect(samePlatform(larkA, larkB)).toBe(true);
+    expect(samePlatformInstance(larkA, larkB)).toBe(false);
+    expect(samePlatformInstance(larkA, { ...larkA })).toBe(true);
+  });
+
+  it('normalizes identity without combining future platforms with legacy Lark ids', () => {
+    expect(derivePlatformInstanceIdentity({ platform: ' lark ', instanceId: ' app-a ', larkAppId: 'app-a' }))
+      .toEqual({ platform: 'lark', instanceId: 'app-a' });
+    expect(derivePlatformInstanceIdentity({ platform: 'discord', larkAppId: 'legacy' }, 'fallback'))
+      .toBeNull();
+    expect(derivePlatformInstanceIdentity({ platform: 'lark', instanceId: 'a', larkAppId: 'b' }))
+      .toBeNull();
+  });
+
+  it('represents attachment, mention, and sender identities without Lark field names', () => {
+    const attachment: PlatformAttachment = { type: 'image', path: '/tmp/a.png', name: 'a.png' };
+    const mention: PlatformMention = {
+      token: '@_user_1',
+      name: 'Alice',
+      identity: { id: 'primary', secondaryId: 'secondary', stableId: 'stable', idType: 'opaque' },
+    };
+    const sender: PlatformSender = { id: 'primary', type: 'user', name: 'Alice' };
+
+    expect(attachment).toEqual({ type: 'image', path: '/tmp/a.png', name: 'a.png' });
+    expect(mention.identity).toEqual({
+      id: 'primary', secondaryId: 'secondary', stableId: 'stable', idType: 'opaque',
+    });
+    expect(sender).toEqual({ id: 'primary', type: 'user', name: 'Alice' });
+  });
+
+  it('uses the adapter-computed routing anchor for chat and thread conversations', () => {
+    const chat: PlatformConversationRef = {
+      instance: larkA,
+      chatId: 'chat-a',
+      conversationType: 'group',
+      scope: 'chat',
+      anchorId: 'chat-a',
+    };
+    const thread: PlatformConversationRef = {
+      instance: larkA,
+      chatId: 'chat-a',
+      conversationType: 'group',
+      scope: 'thread',
+      anchorId: 'message-root',
+      threadId: 'thread-a',
+    };
+
+    expect(conversationRoutingAnchor(chat)).toBe('chat-a');
+    expect(conversationRoutingAnchor(thread)).toBe('message-root');
+  });
+});
+
+describe('platform capabilities and ports', () => {
+  it('fills every undeclared capability with false and requires supported ones explicitly', () => {
+    const provider = {
+      instance: larkA,
+      capabilities: createPlatformCapabilities({ messaging: true, threads: true }),
+    };
+
+    expect(provider.capabilities.messaging).toBe(true);
+    expect(provider.capabilities.threads).toBe(true);
+    expect(provider.capabilities.cards).toBe(false);
+    expect(() => requirePlatformCapability(provider, 'threads')).not.toThrow();
+    expect(() => requirePlatformCapability(provider, 'cards')).toThrowError(
+      PlatformCapabilityUnavailableError,
+    );
+
+    try {
+      requirePlatformCapability(provider, 'cards');
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'platform_capability_unavailable',
+        capability: 'cards',
+        instance: larkA,
+      });
+    }
+  });
+
+  it('returns present ports and distinguishes missing capability from a broken runtime declaration', () => {
+    const messaging: PlatformMessagingPort = {
+      sendMessage: vi.fn(),
+      replyMessage: vi.fn(),
+    };
+    const runtime: PlatformRuntime = {
+      instance: larkA,
+      capabilities: createPlatformCapabilities({ messaging: true, reactions: true }),
+      messaging,
+      start: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+    };
+
+    expect(requirePlatformPort(runtime, 'messaging')).toBe(messaging);
+    expect(() => requirePlatformPort(runtime, 'cards')).toThrowError(
+      PlatformCapabilityUnavailableError,
+    );
+    expect(() => requirePlatformPort(runtime, 'reactions')).toThrowError(
+      PlatformPortUnavailableError,
+    );
+  });
+
+  it('exposes an explicit start/stop lifecycle', async () => {
+    let running = false;
+    const runtime: PlatformRuntime = {
+      instance: larkA,
+      capabilities: createPlatformCapabilities(),
+      async start() { running = true; },
+      async stop() { running = false; },
+    };
+
+    await runtime.start();
+    expect(running).toBe(true);
+    await runtime.stop();
+    expect(running).toBe(false);
+  });
+
+  it('retries a failed runtime stop without dropping the original failure', async () => {
+    const firstError = new Error('socket close failed');
+    const stop = vi.fn()
+      .mockRejectedValueOnce(firstError)
+      .mockResolvedValueOnce(undefined);
+    const onFailure = vi.fn();
+    const runtime: PlatformRuntime = {
+      instance: larkA,
+      capabilities: createPlatformCapabilities(),
+      start: vi.fn(async () => {}),
+      stop,
+    };
+
+    await expect(stopPlatformRuntimeWithRetry(runtime, 2, onFailure)).resolves.toBe(true);
+    expect(stop).toHaveBeenCalledTimes(2);
+    expect(onFailure).toHaveBeenCalledWith(firstError, 1, 2);
+  });
+
+  it('reports false only after every bounded stop attempt fails', async () => {
+    const stop = vi.fn(async () => { throw new Error('still open'); });
+    const onFailure = vi.fn();
+    const runtime: PlatformRuntime = {
+      instance: larkA,
+      capabilities: createPlatformCapabilities(),
+      start: vi.fn(async () => {}),
+      stop,
+    };
+
+    await expect(stopPlatformRuntimeWithRetry(runtime, 2, onFailure)).resolves.toBe(false);
+    expect(stop).toHaveBeenCalledTimes(2);
+    expect(onFailure).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('same-platform guard', () => {
+  it('allows different instances of one platform', () => {
+    expect(() => requireSamePlatform(larkA, larkB)).not.toThrow();
+  });
+
+  it('rejects cross-platform routing with a structured error', () => {
+    const futureDiscord = { platform: 'discord', instanceId: 'discord-a' };
+    expect(samePlatform(larkA, futureDiscord)).toBe(false);
+    expect(() => requireSamePlatform(larkA, futureDiscord)).toThrowError(CrossPlatformOperationError);
+
+    try {
+      requireSamePlatform(larkA, futureDiscord);
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'unsupported_cross_platform',
+        sourcePlatform: 'lark',
+        targetPlatform: 'discord',
+      });
+    }
+  });
+});

--- a/test/platform-session-key.test.ts
+++ b/test/platform-session-key.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createPlatformSessionContext,
+  platformSessionKey,
+  sessionKey,
+} from '../src/core/types.js';
+
+describe('platform session identity', () => {
+  it('keeps every legacy Lark session key byte-for-byte identical', () => {
+    const ref = { platform: 'lark' as const, instanceId: 'cli_app_test' };
+    expect(platformSessionKey('om_root', ref)).toBe('om_root::cli_app_test');
+    expect(sessionKey('om_root', ref)).toBe(sessionKey('om_root', 'cli_app_test'));
+  });
+
+  it('namespaces future platforms so equal anchors and instance ids cannot collide', () => {
+    expect(platformSessionKey('root', { platform: 'discord', instanceId: 'same' }))
+      .toBe('platform:["discord","same","root"]');
+    expect(platformSessionKey('root', { platform: 'discord', instanceId: 'same' }))
+      .not.toBe(platformSessionKey('root', { platform: 'lark', instanceId: 'same' }));
+  });
+
+  it('captures chat/thread routing without changing persisted Session data', () => {
+    const instance = { platform: 'lark' as const, instanceId: 'cli_app_test' };
+    const chat = createPlatformSessionContext(instance, 'oc_chat', 'group', 'chat', 'om_seed');
+    const thread = createPlatformSessionContext(instance, 'oc_chat', 'group', 'thread', 'om_root');
+
+    expect(chat.conversation).toMatchObject({ scope: 'chat', anchorId: 'oc_chat' });
+    expect(chat.conversation.threadRootId).toBeUndefined();
+    expect(thread.conversation).toMatchObject({ scope: 'thread', anchorId: 'om_root', threadRootId: 'om_root' });
+  });
+});

--- a/test/prompt-builder.test.ts
+++ b/test/prompt-builder.test.ts
@@ -87,6 +87,20 @@ vi.mock('../src/core/worker-pool.js', () => ({
 import { buildNewTopicPrompt, buildFollowUpContent, buildReforkPrompt, renderSenderTag, renderCursorSenderNote, renderBufferedSenderBlock } from '../src/core/session-manager.js';
 import type { DaemonSession } from '../src/core/types.js';
 
+function senderFixture(id: string, type: 'user' | 'bot', name?: string) {
+  return { id, openId: id, type, name };
+}
+
+function mentionFixture(name: string, id: string, extra: Record<string, string> = {}) {
+  return {
+    token: extra.key ?? `@${id}`,
+    name,
+    identity: { id },
+    openId: id,
+    ...extra,
+  };
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────
 
 describe('buildNewTopicPrompt', () => {
@@ -187,11 +201,19 @@ describe('buildNewTopicPrompt', () => {
       'claude-code',
       undefined,
       undefined,
-      [{ name: 'Alice', openId: 'ou_alice' }],
+      [mentionFixture('Alice', 'ou_alice')],
     );
     expect(prompt).toContain('<mentions>');
     expect(prompt).toContain('name="Alice"');
     expect(prompt).toContain('open_id="ou_alice"');
+  });
+
+  it('does not mislabel a non-open_id mention identity as open_id', () => {
+    const content = buildFollowUpContent('hello', SESSION_ID, {
+      mentions: [{ token: '@_user', name: 'Alice', identity: { id: 'user-1', idType: 'user_id' } }],
+    });
+    expect(content).toContain('name="Alice"');
+    expect(content).not.toContain('open_id="user-1"');
   });
 
   it('puts stable routing and bot identity before the first user message for non-injecting CLIs', () => {
@@ -219,12 +241,12 @@ describe('buildNewTopicPrompt', () => {
       'codex',
       undefined,
       undefined,
-      [{ name: 'Alice', openId: 'ou_alice' }],
+      [mentionFixture('Alice', 'ou_alice')],
       undefined,
       undefined,
       { name: 'Codex Bot', openId: 'ou_bot' },
       undefined,
-      { openId: 'ou_sender', type: 'user', name: 'Sender' },
+      senderFixture('ou_sender', 'user', 'Sender'),
     );
 
     expect(prompt.indexOf('<sender ')).toBeGreaterThan(prompt.indexOf('<user_message>'));
@@ -267,7 +289,7 @@ describe('buildFollowUpContent', () => {
   });
 
   it('should include mention metadata in <mentions>', () => {
-    const mentions = [{ name: 'Bob', openId: 'ou_bob' }];
+    const mentions = [mentionFixture('Bob', 'ou_bob')];
     const content = buildFollowUpContent('hello', SESSION_ID, { mentions });
     expect(content).toContain('<mentions>');
     expect(content).toContain('name="Bob"');
@@ -276,8 +298,8 @@ describe('buildFollowUpContent', () => {
 
   it('includes substitute trigger metadata in follow-up prompts', () => {
     const content = buildFollowUpContent('hello', SESSION_ID, {
-      sender: { openId: 'ou_sender', type: 'user', name: 'Sender' },
-      mentions: [{ name: 'Alice', openId: 'ou_alice', userId: 'u_alice' }],
+      sender: senderFixture('ou_sender', 'user', 'Sender'),
+      mentions: [mentionFixture('Alice', 'ou_alice', { userId: 'u_alice' })],
       substituteTrigger: {
         target: { name: 'Alice', openId: 'ou_alice', userId: 'u_alice' },
         disclosure: 'prefix',
@@ -296,8 +318,8 @@ describe('buildFollowUpContent', () => {
   it('places stable reminder before follow-up user content', () => {
     const content = buildFollowUpContent('hello', SESSION_ID, {
       cliId: 'codex',
-      sender: { openId: 'ou_sender', type: 'user', name: 'Sender' },
-      mentions: [{ name: 'Bob', openId: 'ou_bob' }],
+      sender: senderFixture('ou_sender', 'user', 'Sender'),
+      mentions: [mentionFixture('Bob', 'ou_bob')],
     });
 
     expect(content.indexOf('<session_id>')).toBeLessThan(content.indexOf('<botmux_reminder>'));
@@ -330,7 +352,7 @@ describe('buildFollowUpContent', () => {
   });
 
   it('should omit <session_id> but keep mentions in adopt mode', () => {
-    const mentions = [{ name: 'Charlie', openId: 'ou_charlie' }];
+    const mentions = [mentionFixture('Charlie', 'ou_charlie')];
     const content = buildFollowUpContent('hello', SESSION_ID, {
       isAdoptMode: true,
       mentions,
@@ -363,7 +385,7 @@ describe('buildFollowUpContent', () => {
   it('injects <sender_note> for cursor follow-ups carrying a sender', () => {
     const content = buildFollowUpContent('hi', SESSION_ID, {
       cliId: 'cursor',
-      sender: { openId: 'ou_gp', type: 'user', name: '高鹏' },
+      sender: senderFixture('ou_gp', 'user', '高鹏'),
     });
     // The note must sit right after the <sender> tag so the model reads them together.
     expect(content).toContain('<sender type="user" open_id="ou_gp" name="高鹏" />');
@@ -375,7 +397,7 @@ describe('buildFollowUpContent', () => {
   it('does NOT inject <sender_note> for non-cursor CLIs even with a sender', () => {
     const content = buildFollowUpContent('hi', SESSION_ID, {
       cliId: 'codex',
-      sender: { openId: 'ou_gp', type: 'user', name: '高鹏' },
+      sender: senderFixture('ou_gp', 'user', '高鹏'),
     });
     expect(content).toContain('<sender '); // sender tag still present
     expect(content).not.toContain('<sender_note>');
@@ -464,7 +486,7 @@ describe('buildReforkPrompt', () => {
     const out = buildReforkPrompt(ds, '看图', {
       cliId: 'codex',
       attachments: [{ type: 'image', path: '/tmp/x.jpg', name: 'x.jpg' }],
-      mentions: [{ key: '@_user_1', name: 'Alice', openId: 'ou_alice' }],
+      mentions: [mentionFixture('Alice', 'ou_alice', { key: '@_user_1' })],
     });
     expect(out).toContain('path="/tmp/x.jpg"');
     expect(out).toContain('name="Alice"');
@@ -489,36 +511,32 @@ describe('buildReforkPrompt', () => {
 // ─── renderSenderTag — <sender> attribute rendering / XML escape ────────────
 
 describe('renderSenderTag', () => {
-  it('returns empty string when sender is undefined or has no openId', () => {
+  it('returns empty string when sender is undefined or has no platform id', () => {
     expect(renderSenderTag()).toBe('');
-    expect(renderSenderTag({ openId: '', type: 'user' })).toBe('');
+    expect(renderSenderTag(senderFixture('', 'user'))).toBe('');
   });
 
   it('emits open_id and type even when name is missing', () => {
-    const out = renderSenderTag({ openId: 'ou_xyz', type: 'user' });
+    const out = renderSenderTag(senderFixture('ou_xyz', 'user'));
     expect(out).toBe('<sender type="user" open_id="ou_xyz" />');
     expect(out).not.toContain('name=');
   });
 
   it('includes name attribute when present', () => {
-    const out = renderSenderTag({ openId: 'ou_a', type: 'user', name: '张三' });
+    const out = renderSenderTag(senderFixture('ou_a', 'user', '张三'));
     expect(out).toContain('type="user"');
     expect(out).toContain('open_id="ou_a"');
     expect(out).toContain('name="张三"');
   });
 
   it('preserves bot type for foreign botmux peers', () => {
-    const out = renderSenderTag({ openId: 'ou_b', type: 'bot', name: 'CoCo' });
+    const out = renderSenderTag(senderFixture('ou_b', 'bot', 'CoCo'));
     expect(out).toContain('type="bot"');
     expect(out).toContain('name="CoCo"');
   });
 
   it('XML-escapes name and open_id so quotes/angle brackets can\'t break the tag', () => {
-    const out = renderSenderTag({
-      openId: 'ou_"weird"',
-      type: 'user',
-      name: '<Alice & "Bob"\'s pal>',
-    });
+    const out = renderSenderTag(senderFixture('ou_"weird"', 'user', '<Alice & "Bob"\'s pal>'));
     // Each special char must round-trip via entity references so the attribute
     // string stays well-formed for downstream prompt parsers.
     expect(out).toContain('name="&lt;Alice &amp; &quot;Bob&quot;&apos;s pal&gt;"');
@@ -561,7 +579,7 @@ describe('renderCursorSenderNote', () => {
 // else a folded-in ou_xxx:name reaches cursor unguarded.
 
 describe('renderBufferedSenderBlock', () => {
-  const SENDER = { openId: 'ou_bob', type: 'user', name: 'Bob' } as const;
+  const SENDER = senderFixture('ou_bob', 'user', 'Bob');
 
   it('pairs the <sender> tag with an adjacent <sender_note> for cursor', () => {
     const out = renderBufferedSenderBlock(SENDER, 'cursor');
@@ -587,7 +605,7 @@ describe('renderBufferedSenderBlock', () => {
 
   it('returns empty when there is no resolvable sender', () => {
     expect(renderBufferedSenderBlock(undefined, 'cursor')).toBe('');
-    expect(renderBufferedSenderBlock({ openId: '', type: 'user' }, 'cursor')).toBe('');
+    expect(renderBufferedSenderBlock(senderFixture('', 'user'), 'cursor')).toBe('');
   });
 });
 
@@ -600,13 +618,13 @@ describe('renderBufferedSenderBlock', () => {
 
 describe('buildNewTopicPrompt cursor buffered multi-user follow-up', () => {
   it('keeps the foreign sender note adjacent inside the folded <user_message>', () => {
-    const buffered = `${renderBufferedSenderBlock({ openId: 'ou_bob', type: 'user', name: 'Bob' }, 'cursor')}\nBob 的补充`;
+    const buffered = `${renderBufferedSenderBlock(senderFixture('ou_bob', 'user', 'Bob'), 'cursor')}\nBob 的补充`;
     const prompt = buildNewTopicPrompt(
       '主消息（Alice）', 'sid', 'cursor',
       undefined, undefined, undefined, undefined,
       [buffered],
       undefined, undefined,
-      { openId: 'ou_alice', type: 'user', name: 'Alice' },
+      senderFixture('ou_alice', 'user', 'Alice'),
     );
     const body = prompt.match(/<user_message>\n([\s\S]*?)\n<\/user_message>/)![1];
     expect(body).toContain('open_id="ou_bob"');
@@ -616,13 +634,13 @@ describe('buildNewTopicPrompt cursor buffered multi-user follow-up', () => {
   });
 
   it('omits the buffered note for a codex session (bare foreign tag only)', () => {
-    const buffered = `${renderBufferedSenderBlock({ openId: 'ou_bob', type: 'user', name: 'Bob' }, 'codex')}\nBob 的补充`;
+    const buffered = `${renderBufferedSenderBlock(senderFixture('ou_bob', 'user', 'Bob'), 'codex')}\nBob 的补充`;
     const prompt = buildNewTopicPrompt(
       '主消息（Alice）', 'sid', 'codex',
       undefined, undefined, undefined, undefined,
       [buffered],
       undefined, undefined,
-      { openId: 'ou_alice', type: 'user', name: 'Alice' },
+      senderFixture('ou_alice', 'user', 'Alice'),
     );
     const body = prompt.match(/<user_message>\n([\s\S]*?)\n<\/user_message>/)![1];
     expect(body).toContain('open_id="ou_bob"');
@@ -637,7 +655,7 @@ describe('buildNewTopicPrompt cursor <sender_note>', () => {
     const prompt = buildNewTopicPrompt(
       'hello', 'sid', 'cursor',
       undefined, undefined, undefined, undefined, undefined, undefined, undefined,
-      { openId: 'ou_gp', type: 'user', name: '高鹏' },
+      senderFixture('ou_gp', 'user', '高鹏'),
     );
     expect(prompt).toContain('<sender_note>');
     expect(prompt.indexOf('<sender_note>')).toBeGreaterThan(prompt.indexOf('<sender '));
@@ -647,7 +665,7 @@ describe('buildNewTopicPrompt cursor <sender_note>', () => {
     const prompt = buildNewTopicPrompt(
       'hello', 'sid', 'codex',
       undefined, undefined, undefined, undefined, undefined, undefined, undefined,
-      { openId: 'ou_gp', type: 'user', name: '高鹏' },
+      senderFixture('ou_gp', 'user', '高鹏'),
     );
     expect(prompt).toContain('<sender ');
     expect(prompt).not.toContain('<sender_note>');
@@ -668,8 +686,8 @@ describe('buildNewTopicPrompt with multi-user follow-ups', () => {
     // Builder now merges them all into the single opening <user_message> body
     // rather than separate <follow_up_message> wrappers.
     const followUps = [
-      `${renderSenderTag({ openId: 'ou_alice', type: 'user', name: 'Alice' })}\nAlice 的补充约束 1`,
-      `${renderSenderTag({ openId: 'ou_bob', type: 'user', name: 'Bob' })}\nBob 的补充约束 2`,
+      `${renderSenderTag(senderFixture('ou_alice', 'user', 'Alice'))}\nAlice 的补充约束 1`,
+      `${renderSenderTag(senderFixture('ou_bob', 'user', 'Bob'))}\nBob 的补充约束 2`,
     ];
 
     const prompt = buildNewTopicPrompt(
@@ -683,7 +701,7 @@ describe('buildNewTopicPrompt with multi-user follow-ups', () => {
       followUps,
       undefined,
       undefined,
-      { openId: 'ou_alice', type: 'user', name: 'Alice' },
+      senderFixture('ou_alice', 'user', 'Alice'),
     );
 
     // No separate follow-up blocks — everything folds into the opening turn.

--- a/test/restore-zombie-close.test.ts
+++ b/test/restore-zombie-close.test.ts
@@ -188,6 +188,37 @@ function makeActivePersistentSession(rootMessageId: string) {
 }
 
 describe('restoreActiveSessions — persistent-backend zombie-close decision', () => {
+  it('does not attach or mutate an active row owned by another platform instance', async () => {
+    const foreign = makeActivePersistentSession('om_foreign');
+    foreign.larkAppId = 'app_other';
+    sessionStore.updateSession(foreign);
+    const map = new Map<string, DaemonSession>();
+    wp.registry = map;
+
+    await restoreActiveSessions(map);
+
+    expect(map.size).toBe(0);
+    expect(closeSession).not.toHaveBeenCalled();
+    expect(forkWorker).not.toHaveBeenCalled();
+    expect(sessionStore.getSession(foreign.sessionId)?.status).toBe('active');
+  });
+
+  it('does not attach or mutate an explicitly foreign-platform active row', async () => {
+    const foreign = makeActivePersistentSession('om_discord') as any;
+    foreign.platform = 'discord';
+    foreign.instanceId = 'discord-bot';
+    sessionStore.updateSession(foreign);
+    const map = new Map<string, DaemonSession>();
+    wp.registry = map;
+
+    await restoreActiveSessions(map);
+
+    expect(map.size).toBe(0);
+    expect(closeSession).not.toHaveBeenCalled();
+    expect(forkWorker).not.toHaveBeenCalled();
+    expect(sessionStore.getSession(foreign.sessionId)?.status).toBe('active');
+  });
+
   it('"missing" → closes the zombie (Map eviction + store closed), does not fork', async () => {
     probe.result = 'missing';
     const s = makeActivePersistentSession('om_missing');

--- a/test/role-resolver.test.ts
+++ b/test/role-resolver.test.ts
@@ -206,8 +206,8 @@ describe('buildFollowUpContent role injection', () => {
     const prompt = buildFollowUpContent('follow up', 'sess-follow', {
       larkAppId: 'app1',
       chatId: 'oc_follow',
-      sender: { openId: 'ou_sender', type: 'user', name: 'Sender' },
-      mentions: [{ name: 'Reviewer', openId: 'ou_reviewer' }],
+      sender: { id: 'ou_sender', type: 'user', name: 'Sender' },
+      mentions: [{ token: '@_reviewer', name: 'Reviewer', identity: { id: 'ou_reviewer' } }],
     });
 
     expect(prompt).toContain('<role context="group" chat_id="oc_follow">');

--- a/test/session-resume.test.ts
+++ b/test/session-resume.test.ts
@@ -162,6 +162,13 @@ describe('resumeSession', () => {
       if (!r.ok) expect(r.error).toBe('not_found');
     });
 
+    it('does not resume a session owned by another platform instance', async () => {
+      const foreign = makeClosedSession({ larkAppId: 'app_other' });
+      const r = await resumeSession(foreign.sessionId, new Map());
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toBe('not_found');
+    });
+
     it('returns not_closed when the session is still active', async () => {
       const s = sessionStore.createSession('oc_chat', 'om_root', 'active topic');
       const r = await resumeSession(s.sessionId, new Map());

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -45,6 +45,8 @@ import {
   init,
   createSession,
   getSession,
+  getLocalSession,
+  getSessionForInstance,
   listSessions,
   closeSession,
   updateSession,
@@ -74,6 +76,17 @@ afterEach(() => {
 // ─── init() ───────────────────────────────────────────────────────────────
 
 describe('init()', () => {
+  it('accepts a platform instance while preserving the legacy Lark filename', () => {
+    init({ platform: 'lark', instanceId: 'app-ref' });
+    createSession('chat1', 'root1', 'Test');
+    expect(existsSync(join(tempDir, 'sessions-app-ref.json'))).toBe(true);
+  });
+
+  it('fails explicitly when asked to open an unsupported platform store', () => {
+    expect(() => init({ platform: 'discord', instanceId: 'bot' } as any))
+      .toThrow('Session store does not support platform discord');
+  });
+
   it('should create the data directory on first operation if it does not exist', () => {
     const subDir = join(tempDir, 'nested', 'data');
     tempDir = subDir;
@@ -114,6 +127,77 @@ describe('init()', () => {
     // for a different appId context, it starts fresh
     init('different-app');
     expect(listSessions()).toHaveLength(0);
+  });
+});
+
+describe('platform instance compatibility', () => {
+  it('derives legacy rows in memory without rewriting their schema or bytes', () => {
+    mkdirSync(tempDir, { recursive: true });
+    const fp = join(tempDir, 'sessions-app-legacy.json');
+    const raw = JSON.stringify({
+      s1: {
+        sessionId: 's1', chatId: 'oc_legacy', rootMessageId: 'om_legacy', title: 'Legacy',
+        status: 'closed', createdAt: '2026-01-01T00:00:00.000Z', larkAppId: 'app-legacy',
+      },
+    });
+    writeFileSync(fp, raw);
+
+    init({ platform: 'lark', instanceId: 'app-legacy' });
+    expect(getSessionForInstance('s1', { platform: 'lark', instanceId: 'app-legacy' })?.title).toBe('Legacy');
+    expect(readFileSync(fp, 'utf8')).toBe(raw);
+    expect(JSON.parse(readFileSync(fp, 'utf8')).s1).not.toHaveProperty('platform');
+    expect(JSON.parse(readFileSync(fp, 'utf8')).s1).not.toHaveProperty('instanceId');
+  });
+
+  it('refuses mutation-scoped lookup from a different platform instance', () => {
+    init({ platform: 'lark', instanceId: 'app-a' });
+    const session = createSession('chat1', 'root1', 'Owned');
+    session.larkAppId = 'app-a';
+    updateSession(session);
+
+    expect(getSessionForInstance(session.sessionId, { platform: 'lark', instanceId: 'app-b' })).toBeUndefined();
+    expect(getSessionForInstance(session.sessionId, { platform: 'discord', instanceId: 'app-a' })).toBeUndefined();
+  });
+
+  it('rejects updateSession for a record owned by another instance', () => {
+    init({ platform: 'lark', instanceId: 'app-a' });
+    const foreign = {
+      sessionId: 'foreign', chatId: 'oc', rootMessageId: 'om', title: 'Foreign',
+      status: 'active', createdAt: '2026-01-01T00:00:00.000Z', larkAppId: 'app-b',
+    } as any;
+
+    expect(() => updateSession(foreign)).toThrowError(expect.objectContaining({
+      code: 'session_instance_mismatch', sessionId: 'foreign',
+    }));
+    expect(listSessions()).toEqual([]);
+  });
+
+  it('filters and never rewrites an explicitly foreign row in the current instance file', () => {
+    mkdirSync(tempDir, { recursive: true });
+    const fp = join(tempDir, 'sessions-app-a.json');
+    const raw = JSON.stringify({
+      foreign: {
+        sessionId: 'foreign', chatId: 'oc', rootMessageId: 'om', title: 'Foreign',
+        status: 'active', createdAt: '2026-01-01T00:00:00.000Z',
+        platform: 'lark', instanceId: 'app-b', larkAppId: 'app-b', pid: 123,
+      },
+    });
+    writeFileSync(fp, raw);
+    init({ platform: 'lark', instanceId: 'app-a' });
+
+    // Broad agent-facing lookup remains read-only, while daemon-local views
+    // refuse to treat the corrupt row as app-a state.
+    expect(getSession('foreign')?.title).toBe('Foreign');
+    expect(getLocalSession('foreign')).toBeUndefined();
+    expect(listSessions()).toEqual([]);
+    expect(() => closeSession('foreign')).toThrowError(expect.objectContaining({
+      code: 'session_instance_mismatch', sessionId: 'foreign',
+    }));
+    expect(() => updateSessionPid('foreign', 456)).toThrowError(expect.objectContaining({
+      code: 'session_instance_mismatch', sessionId: 'foreign',
+    }));
+    expect(readFileSync(fp, 'utf8')).toBe(raw);
+    expect(mockDeleteFrozenCards).not.toHaveBeenCalled();
   });
 });
 
@@ -427,6 +511,20 @@ describe('Multi-bot isolation', () => {
 // ─── findActiveSessionsByRoot() — cross-bot lookup ───────────────────────
 
 describe('findActiveSessionsByRoot()', () => {
+  it('excludes future-platform rows from the current Lark A2A peer scan', () => {
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(join(tempDir, 'sessions-discord.json'), JSON.stringify({
+      discord: {
+        sessionId: 'discord', chatId: 'same-chat', rootMessageId: 'root-x', title: 'Other platform',
+        status: 'active', createdAt: '2026-01-01T00:00:00.000Z',
+        platform: 'discord', instanceId: 'workspace-bot', workingDir: '/tmp/discord',
+      },
+    }));
+
+    init({ platform: 'lark', instanceId: 'app-A' });
+    expect(findActiveSessionsByRoot('root-x')).toEqual([]);
+  });
+
   it('finds active sessions across per-bot files for the same rootMessageId', () => {
     // Bot A pins workdir for thread root-x
     init('app-A');
@@ -448,6 +546,26 @@ describe('findActiveSessionsByRoot()', () => {
     expect(found.map(s => s.sessionId).sort()).toEqual([sA.sessionId, sB.sessionId].sort());
     expect(found.find(s => s.sessionId === sA.sessionId)?.workingDir).toBe('/repo/foo');
     expect(found.find(s => s.sessionId === sB.sessionId)?.workingDir).toBe('/repo/bar');
+  });
+
+  it('projects a legacy row owner from its source filename without rewriting JSON', () => {
+    mkdirSync(tempDir, { recursive: true });
+    const fp = join(tempDir, 'sessions-app-legacy.json');
+    const raw = JSON.stringify({
+      legacy: {
+        sessionId: 'legacy', chatId: 'chat1', rootMessageId: 'root-x', title: 'Legacy',
+        status: 'active', createdAt: '2026-01-01T00:00:00.000Z', workingDir: '/repo/legacy',
+      },
+    });
+    writeFileSync(fp, raw);
+    init('app-current');
+
+    const [found] = findActiveSessionsByRoot('root-x') as any[];
+
+    expect(found.platform).toBe('lark');
+    expect(found.instanceId).toBe('app-legacy');
+    expect(Object.keys(found)).not.toContain('instanceId');
+    expect(readFileSync(fp, 'utf8')).toBe(raw);
   });
 
   it('skips closed sessions', () => {

--- a/test/transfer-session.test.ts
+++ b/test/transfer-session.test.ts
@@ -15,7 +15,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 vi.mock('../src/services/session-store.js', () => ({
   updateSession: vi.fn(),
-  getSession: vi.fn(),
+  getLocalSession: vi.fn(),
   closeSession: vi.fn(),
 }));
 
@@ -74,6 +74,13 @@ function makeDs(overrides: Partial<DaemonSession> = {}): DaemonSession {
   };
   return {
     session,
+    platform: {
+      instance: { platform: 'lark', instanceId: 'cli_app_test' },
+      conversation: {
+        instance: { platform: 'lark', instanceId: 'cli_app_test' },
+        chatId: 'oc_source', conversationType: 'group', scope: 'thread', anchorId: 'om_source_root', threadId: 'om_source_root',
+      },
+    },
     worker: null,
     workerPort: null,
     workerToken: null,
@@ -105,7 +112,9 @@ describe('transferSession', () => {
     targetRootMessageId: string,
     targetChatType: 'group' | 'p2p' = 'group',
     targetScope: 'thread' | 'chat' = 'chat',
+    targetInstance?: { platform: string; instanceId: string },
   ) => transferSession(sessionId, targetChatId, targetRootMessageId, targetChatType, targetScope, {
+    targetInstance,
     forkWorkerImpl: forkWorkerSpy as any,
     killWorkerImpl: killWorkerSpy as any,
   });
@@ -162,6 +171,63 @@ describe('transferSession', () => {
     const r = await callTransfer('does-not-exist', 'oc_target', 'om_target_root');
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error).toBe('session_not_active');
+  });
+
+  it('rejects cross-platform relay before any visible or persistent side effect', async () => {
+    const ds = makeDs();
+    registry.set(sessionKey('om_source_root', 'cli_app_test'), ds);
+
+    const r = await callTransfer(
+      ds.session.sessionId,
+      'discord-channel',
+      'discord-thread',
+      'group',
+      'chat',
+      { platform: 'discord', instanceId: 'workspace-bot' },
+    );
+
+    expect(r).toEqual({ ok: false, error: 'unsupported_cross_platform' });
+    expect(updateMessageMock).not.toHaveBeenCalled();
+    expect(killWorkerSpy).not.toHaveBeenCalled();
+    expect(forkWorkerSpy).not.toHaveBeenCalled();
+    expect(sessionStore.updateSession).not.toHaveBeenCalled();
+    expect(dashboardEventBus.publish).not.toHaveBeenCalled();
+    expect(ds.chatId).toBe('oc_source');
+    expect(registry.get(sessionKey('om_source_root', 'cli_app_test'))).toBe(ds);
+  });
+
+  it('treats an omitted target identity as the legacy Lark target, not as the source platform', async () => {
+    const ds = makeDs({
+      platform: {
+        instance: { platform: 'discord', instanceId: 'workspace-bot' },
+        conversation: {
+          instance: { platform: 'discord', instanceId: 'workspace-bot' },
+          chatId: 'discord-source', conversationType: 'group', scope: 'thread',
+          anchorId: 'om_source_root',
+        },
+      } as any,
+    });
+    registry.set(sessionKey('om_source_root', 'cli_app_test'), ds);
+
+    await expect(callTransfer(ds.session.sessionId, 'oc_target', 'om_target'))
+      .resolves.toEqual({ ok: false, error: 'unsupported_cross_platform' });
+    expect(sessionStore.updateSession).not.toHaveBeenCalled();
+    expect(forkWorkerSpy).not.toHaveBeenCalled();
+  });
+
+  it('allows a relay target represented by another instance on the same platform', async () => {
+    const ds = makeDs();
+    registry.set(sessionKey('om_source_root', 'cli_app_test'), ds);
+    const r = await callTransfer(
+      ds.session.sessionId,
+      'oc_target',
+      'om_target',
+      'group',
+      'chat',
+      { platform: 'lark', instanceId: 'another-app-view' },
+    );
+    expect(r.ok).toBe(true);
+    expect(ds.platform.instance).toEqual({ platform: 'lark', instanceId: 'cli_app_test' });
   });
 
   it('returns adopt_not_relayable when source session was attached via /adopt', async () => {
@@ -433,10 +499,10 @@ describe('transferSession', () => {
       scope: 'chat',
     });
     registry.set(sessionKey('oc_target', 'cli_app_test'), scratchDs);
-    // getSession is consulted by closeSession to decide whether to mark
+    // getLocalSession is consulted by closeSession to decide whether to mark
     // the store row closed — return a status='active' record so the store
     // close path fires.
-    vi.mocked(sessionStore.getSession).mockImplementation((sid: string) =>
+    vi.mocked(sessionStore.getLocalSession).mockImplementation((sid: string) =>
       sid === 'scratch-relay-cmd' ? ({ ...scratchDs.session, status: 'active' }) as any : undefined,
     );
 
@@ -607,7 +673,7 @@ describe('setActiveSessionSafe', () => {
     // status='active' as a ghost.
     const prevDs = makeSimpleDs('prev-sess');
     const newDs = makeSimpleDs('new-sess');
-    vi.mocked(sessionStore.getSession).mockImplementation((sid: string) =>
+    vi.mocked(sessionStore.getLocalSession).mockImplementation((sid: string) =>
       sid === 'prev-sess' ? ({ ...prevDs.session, status: 'active' }) as any : undefined,
     );
 

--- a/test/worker-ready-display-mode.test.ts
+++ b/test/worker-ready-display-mode.test.ts
@@ -126,6 +126,7 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
 
 import { CARD_POSTING_SENTINEL, initWorkerPool, __testOnly_setupWorkerHandlers } from '../src/core/worker-pool.js';
 import type { DaemonSession } from '../src/core/types.js';
+import { createPlatformCapabilities } from '../src/im/platform.js';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
@@ -152,6 +153,14 @@ function makeDs(overrides?: Partial<DaemonSession>): DaemonSession {
       updatedAt: Date.now(),
       pid: null,
       chatType: 'group',
+    },
+    platform: {
+      instance: { platform: 'lark', instanceId: 'app_test' },
+      conversation: {
+        instance: { platform: 'lark', instanceId: 'app_test' },
+        chatId: 'oc_chat', conversationType: 'group', scope: 'thread',
+        anchorId: 'om_root', threadRootId: 'om_root',
+      },
     },
     worker: makeFakeWorker(),
     workerPort: null,
@@ -352,6 +361,117 @@ describe('Worker ready: set_display_mode re-sync', () => {
 
     expect(updateMessageMock).toHaveBeenCalledTimes(1);
     expect(JSON.parse(updateMessageMock.mock.calls[0][2])).toMatchObject({ localCliReady: true });
+  });
+
+  it('PATCH path uses the injected platform cards port in production wiring', async () => {
+    const updateCard = vi.fn(async () => {});
+    const runtime = {
+      instance: { platform: 'lark', instanceId: 'app_test' },
+      capabilities: createPlatformCapabilities({ cards: true, streamUpdates: true }),
+      cards: { sendCard: vi.fn(), replyCard: vi.fn(), updateCard },
+      start: vi.fn(async () => {}), stop: vi.fn(async () => {}),
+    } as any;
+    initWorkerPool({
+      sessionReply: sessionReplyMock,
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+      platformRuntime: runtime,
+    });
+    const fakeWorker = makeFakeWorker();
+    const ds = makeDs({
+      streamCardPending: false,
+      streamCardId: 'om_runtime_card',
+      worker: fakeWorker,
+    });
+
+    __testOnly_setupWorkerHandlers(ds, fakeWorker);
+    fakeWorker.emit('message', { type: 'ready', port: 9999, token: 'tok_abc' });
+    await flush();
+
+    expect(updateCard).toHaveBeenCalledWith(
+      { instance: ds.platform.instance, messageId: 'om_runtime_card' },
+      { payload: '{"type":"streaming","localCliReady":false}' },
+    );
+    expect(updateMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('does not PATCH a live card when the runtime lacks stream updates', async () => {
+    const updateCard = vi.fn(async () => {});
+    const runtime = {
+      instance: { platform: 'lark', instanceId: 'app_test' },
+      capabilities: createPlatformCapabilities({ cards: true, streamUpdates: false }),
+      cards: { sendCard: vi.fn(), replyCard: vi.fn(), updateCard },
+      start: vi.fn(async () => {}), stop: vi.fn(async () => {}),
+    } as any;
+    initWorkerPool({
+      sessionReply: sessionReplyMock,
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+      platformRuntime: runtime,
+    });
+    const fakeWorker = makeFakeWorker();
+    const ds = makeDs({
+      streamCardPending: false,
+      streamCardId: 'om_runtime_card',
+      worker: fakeWorker,
+    });
+
+    __testOnly_setupWorkerHandlers(ds, fakeWorker);
+    fakeWorker.emit('message', { type: 'ready', port: 9999, token: 'tok_abc' });
+    await flush();
+
+    expect(updateCard).not.toHaveBeenCalled();
+    // The ready path treats an unavailable stream update like an expired card
+    // and falls back to a one-time card POST through the regular cards path.
+    expect(sessionReplyMock).toHaveBeenCalledTimes(1);
+    expect(ds.streamCardId).toBe('om_new_card');
+  });
+
+  it('updates fallback-card readiness through the injected platform cards port', async () => {
+    const updateCard = vi.fn(async () => {});
+    const runtime = {
+      instance: { platform: 'lark', instanceId: 'app_test' },
+      capabilities: createPlatformCapabilities({ cards: true, streamUpdates: false }),
+      cards: { sendCard: vi.fn(), replyCard: vi.fn(), updateCard },
+      start: vi.fn(async () => {}), stop: vi.fn(async () => {}),
+    } as any;
+    let ds!: DaemonSession;
+    sessionReplyMock
+      .mockRejectedValueOnce(new Error('streaming card unavailable'))
+      .mockImplementationOnce(async () => {
+        ds.session.cliSessionId = 'trae-native-ready';
+        return 'om_fallback_card';
+      });
+    initWorkerPool({
+      sessionReply: sessionReplyMock,
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+      platformRuntime: runtime,
+    });
+    const fakeWorker = makeFakeWorker();
+    ds = makeDs({
+      streamCardPending: true,
+      streamCardId: undefined,
+      worker: fakeWorker,
+      workingDir: '/tmp',
+    });
+    ds.session.cliId = 'traex';
+    ds.session.cliSessionId = undefined;
+    ds.session.workingDir = '/tmp';
+
+    __testOnly_setupWorkerHandlers(ds, fakeWorker);
+    fakeWorker.emit('message', { type: 'ready', port: 9999, token: 'tok_abc' });
+    await flush();
+    await flush();
+
+    expect(updateCard).toHaveBeenCalledWith(
+      { instance: ds.platform.instance, messageId: 'om_fallback_card' },
+      { payload: '{"type":"session"}' },
+    );
+    expect(updateMessageMock).not.toHaveBeenCalled();
   });
 
   // Regression: a re-fork that happens while streamCardPending is true (new turn


### PR DESCRIPTION
## 背景与目标

botmux 当前的生产执行路径以 Lark/飞书为中心，daemon、会话编排、消息发送和持久化身份之间仍有较强的直接耦合。如果继续沿现有路径叠加新 IM，平台差异会进一步渗入 core，也难以可靠约束“一个 session 属于哪个平台实例”。

本 PR 先建立真实可运行的平台边界，并让现有 Lark 路径通过该边界运行：

- 一个部署可以管理多个平台实例，但一个 daemon 进程只运行一个平台实例；
- 一个 session 始终归属一个平台实例，A2A / relay 只在同平台内闭环；
- 核心模型和已迁移的通用调用只依赖平台中立接口；
- Lark runtime 由 daemon composition root 组装和注入；
- 本阶段不引入 Discord SDK、配置或可启动的 Discord runtime；
- 不改变现有配置格式、磁盘数据、dashboard wire shape 和用户可见行为。

## 改了什么

### 平台领域模型与小型 ports

- 新增 `PlatformId`、`PlatformInstanceRef`、`PlatformConversationRef`，以及统一的 message、sender、mention、attachment 模型；
- 按职责拆分 messaging、cards、reactions、attachments、identity、conversation、DM 等 ports；
- 用 `PlatformCapabilities` 显式声明 cards、stream updates、threads、mentions 等能力；
- 能力缺失或声明与 port 不一致时明确报错，不使用空实现伪装支持；
- 收敛此前未落地的巨型 `ImAdapter` 草案，避免两套竞争性抽象；
- 增加架构依赖测试，禁止平台专属类型继续渗入平台中立层。

### Lark runtime 与 composition root

- 新增 `LarkPlatformRuntime`，组合现有 Lark event dispatcher、client、cards、reactions、attachments、identity 和 conversation routing；
- runtime façade 以薄委托方式复用成熟实现，保留原有参数、返回值、异常、调用顺序和重试语义；
- daemon 负责选择 bot 配置、构造单个 runtime，并把所需能力注入会话编排；
- 文档评论、VC、群管理等 Lark 特有能力继续留在 extension/raw event callback 层，不为它们设计虚假的跨平台 parity。

### 会话归属、恢复与兼容层

- 将 `DaemonSession` 拆分为平台中立状态和类型安全的 Lark compatibility context；
- session key 增加基于 `PlatformInstanceRef` 的入口；Lark 仍生成与旧版本相同的 key；
- session store、adopt / restore / resume、A2A / relay 和 dashboard IPC 增加平台实例校验；
- 跨平台路径在进入转发前明确返回 unsupported；
- registry、daemon descriptor 和 dashboard discovery 增加 `(platform, instanceId)` 视图，同时保留 `larkAppId` 及旧字段语义；
- 旧配置、旧 session JSON 和缺少新字段的 descriptor 在读取时默认推导为 Lark，不触发批量迁移或历史文件回写；
- daemon descriptor 增量加入 `platform`、`instanceId` 和 `capabilities`，旧字段与文件名保持不变。

此外补全了 sandbox 新建目录的元数据测试夹具；该项不修改生产行为，可以独立审阅或回退。

## 基本设计

```text
daemon（composition root）
├─ core 会话编排 ──> PlatformRuntime + 按职责拆分的 ports
│  └─ 尚未迁移的专属路径 -. 精确 legacy allowlist .-> 既有 Lark 模块
└─ LarkPlatformRuntime ──> 现有 Lark client / dispatcher / 能力委托
```

这里没有设计一个覆盖所有平台细节的万能 adapter。稳定的跨平台语义进入小型 ports；平台是否支持某项能力由 capability 声明；尚未抽象的 Lark 特有能力继续留在 extension 层。

迁移采用 strangler 方式：已迁移的生产调用先穿过 runtime façade，再委托到原有 Lark 实现。这是第一段迁移，不是一次性清空所有 Lark 耦合；架构测试会冻结既有例外，后续应逐项缩小 allowlist，而不是扩大它。

## 影响面与兼容性

| 维度 | 结论 |
|---|---|
| 平台 | 当前仍只有 Lark runtime；未加入 Discord。Lark 可以是能力超集。 |
| 配置与磁盘数据 | `larkAppId/larkAppSecret/brand`、`sessions-<larkAppId>.json`、旧 descriptor 字段和文件名保持不变。 |
| Dashboard | discovery/registry 内部开始使用平台实例身份；UI、路由、筛选、会话控制和 wire shape 不变。 |
| 会话类型 | 覆盖话题、普通群、chat/thread scope、queued/pending、冷恢复、adopt/restore；旧 Lark session key 与恢复语义保持不变。 |
| CLI / backend | worker/CLI 协议未改；平台改造不改变具体 CLI 的输入输出协议。 |
| A2A / relay | 同平台路径保持原样；跨平台请求明确拒绝。 |
| Lark 专属能力 | 保持在 extension 层，不塞入通用 ports。 |

## 验证方式

通用自动化验证：

```bash
pnpm build
pnpm test

pnpm vitest run --project unit \
  test/platform-runtime.test.ts \
  test/lark-platform-runtime.test.ts \
  test/platform-session-key.test.ts \
  test/platform-architecture.test.ts \
  test/daemon-discovery.test.ts \
  test/dashboard-registry.test.ts

pnpm vitest run --project e2e \
  test/tmux-backend.e2e.ts \
  test/multi-bot-session.e2e.ts \
  test/multi-bot-group-flow.e2e.ts \
  test/web-terminal-scrollback.e2e.ts \
  test/card-toggle.e2e.ts
```

重点断言包括：

- 平台身份、capability 声明与 runtime 生命周期；
- Lark façade 对旧实现的参数、返回值、异常和调用顺序兼容；
- 旧配置、旧 session、旧 descriptor 的读取兼容；
- session key、恢复、adopt、chat/thread scope 与 dashboard discovery；
- cards、reactions、attachments、mentions、A2A / relay；
- 平台中立层不能新增 `im/lark` 依赖。

## Live E2E

真实 Lark 环境的 live E2E 是 opt-in 测试，不进入默认 `pnpm test`，也不要求每位开发者使用个人飞书环境。具备独立测试租户或可接受的临时测试环境时，建议使用每轮新建的隔离群覆盖：

- 同一条消息触发两个 bot，验证平台实例和 session 不串；
- 非流式模式下的 reaction、最终答案和无 streaming status card；
- chat/thread scope、type-ahead、daemon restart recovery；
- 同平台 relay；
- 附件、AskUser / approval，以及至少一项 Lark extension。

所有 live case 应只操作本轮随机命名的临时资源，并在结束后精确清理；不得复用已有工作群或私聊。

Computer Use 仅作为 **best-effort** 的原生客户端渲染观察：没有合适桌面环境、登录态或测试意愿时可以直接跳过，不影响自动化测试结论，也不作为 PR 合并门槛。

## 当前状态

本 PR 保持 Draft。自动化边界与兼容性验证可继续审阅；真实 Lark live E2E 在具备合适的隔离环境后再补充结果。