### PR TITLE
fix(codex): 修复提交重试和告警锚点

### DIFF
--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -282,11 +282,11 @@ export class TmuxPipeBackend implements SessionBackend {
    * NB: TmuxPipeBackend is the only backend used at runtime (see
    * selectSessionBackend), so this is the path that actually matters.
    */
-  pasteText(text: string): void {
-    if (this.exited) return;
+  pasteText(text: string): boolean {
+    if (this.exited) return false;
     this.exitCopyModeIfNeeded();
     const bufferName = `botmux-${randomBytes(8).toString('hex')}`;
-    this.guardedSend('paste-buffer', () => {
+    return this.guardedSend('paste-buffer', () => {
       let loaded = false;
       try {
         execFileSync('tmux', ['load-buffer', '-b', bufferName, '-'], {

--- a/src/adapters/cli/codex.ts
+++ b/src/adapters/cli/codex.ts
@@ -26,6 +26,7 @@ interface CodexSubmitResult {
   submitted: boolean;
   cliSessionId?: string;
   recheck?: () => { submitted: boolean; cliSessionId?: string } | false;
+  recover?: () => Promise<{ submitted: boolean; cliSessionId?: string } | false>;
 }
 
 function readCliSessionId(parsed: unknown): string | undefined {
@@ -128,24 +129,19 @@ function isReattachPty(pty: PtyHandle): boolean {
   return pty.isReattach === true;
 }
 
-function clearCodexComposer(pty: PtyHandle): boolean {
-  try {
-    if (pty.sendSpecialKeys) {
-      if (pty.sendSpecialKeys('C-u') === false) return false;
-    }
-    else pty.write('\x15');
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 function normaliseComposerText(text: string): string {
   return stripAnsiForLog(text).replace(/\s+/g, ' ').trim();
 }
 
 function screenShowsCodexPaste(screen: string, content: string): boolean {
-  const actual = normaliseComposerText(screen);
+  const stripped = stripAnsiForLog(screen);
+  // capture-pane contains the whole viewport, including earlier user prompts.
+  // Only inspect the latest Codex composer (the last line beginning with ›),
+  // otherwise old transcript text can masquerade as a still-pending paste.
+  const lineStart = stripped.lastIndexOf('\n›');
+  const composerStart = lineStart >= 0 ? lineStart + 1 : stripped.startsWith('›') ? 0 : -1;
+  if (composerStart < 0) return false;
+  const actual = normaliseComposerText(stripped.slice(composerStart));
   const expected = normaliseComposerText(content);
   if (!actual || !expected) return false;
   const visibleTail = expected.length > 80 ? expected.slice(-80) : expected;
@@ -188,6 +184,47 @@ function codexHistoryRecheck(
       ? { submitted: true, cliSessionId: late.cliSessionId }
       : false;
   };
+}
+
+async function recoverCodexSubmit(
+  pty: PtyHandle,
+  content: string,
+  historyPath: string,
+  baseByte: number,
+): Promise<{ submitted: boolean; cliSessionId?: string } | false> {
+  // History is authoritative. Check it again immediately before touching the
+  // terminal so a slow first submit can never be followed by another action.
+  const late = matchHistoryDelta(historyPath, baseByte, content);
+  if (late.found) {
+    return late.cliSessionId
+      ? { submitted: true, cliSessionId: late.cliSessionId }
+      : { submitted: true };
+  }
+
+  // Never paste the prompt again: identical history rows cannot tell which
+  // attempt they confirm, so a delayed first append could falsely bless a
+  // second paste and leave it queued as a duplicate. The only safe recovery is
+  // one Enter when the original text is visibly still in Codex's composer.
+  if (!pty.captureViewport) return false;
+  let screen: string;
+  try { screen = pty.captureViewport(); } catch { return false; }
+  if (!screenShowsCodexPaste(screen, content)) return false;
+
+  try {
+    if (pty.sendSpecialKeys) {
+      if (pty.sendSpecialKeys('Enter') === false) return false;
+    } else {
+      pty.write('\r');
+    }
+  } catch {
+    return false;
+  }
+
+  const recovered = await waitForHistoryAppend(historyPath, baseByte, content, 3_200);
+  if (!recovered.found) return false;
+  return recovered.cliSessionId
+    ? { submitted: true, cliSessionId: recovered.cliSessionId }
+    : { submitted: true };
 }
 
 async function submitCodexPrompt(
@@ -357,9 +394,11 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
       // bracketed paste lands the whole multi-line message in the composer
       // un-submitted, with the process staying alive and \t absorbed cleanly.
       //
-      // The history.jsonl verification loop below still polls for the
-      // submitted prefix; on a hard miss it now clears the composer and
-      // re-drives the submit once before handing the worker a deferred recheck.
+      // The history.jsonl verification loop below still polls for the exact
+      // submitted text. On a hard miss it hands the worker a deferred recheck
+      // plus an evidence-gated Enter recovery; it never pastes the same prompt
+      // twice because a slow first history append makes attempt attribution
+      // fundamentally ambiguous.
       const historyPath = codexHistoryPath();
       const baseByte = currentFileSize(historyPath);
       const reattach = isReattachPty(pty);
@@ -367,25 +406,11 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
       const firstAttempt = await submitCodexPrompt(pty, content, historyPath, baseByte, initialSettleMs, reattach);
       if (firstAttempt.submitted) return firstAttempt;
 
-      if (!clearCodexComposer(pty)) return firstAttempt;
-      await delay(150);
-
-      // The last Enter may have committed even though history.jsonl missed the
-      // first attempt's in-band budget. Recheck after the clear/settle gap and
-      // before repasting: otherwise a late history append would prove the first
-      // submit landed only after we had already driven the same prompt twice.
-      const lateFirstSubmit = firstAttempt.recheck?.();
-      if (lateFirstSubmit && lateFirstSubmit.submitted) return lateFirstSubmit;
-
-      const retrySettleMs = reattach ? 800 : 400;
-      const secondAttempt = await submitCodexPrompt(pty, content, historyPath, baseByte, retrySettleMs, reattach);
-      if (secondAttempt.submitted) return secondAttempt;
-
-      // In-band budget exhausted. Hand the worker a recheck closure: a
-      // slow-startup Codex (or one whose first turn is delayed by a heavy
-      // initial prompt) may still append our marker after the retries gave
-      // up, and the worker re-scans on a delay before warning the user.
-      return secondAttempt;
+      if (!firstAttempt.recheck) return firstAttempt;
+      return {
+        ...firstAttempt,
+        recover: () => recoverCodexSubmit(pty, content, historyPath, baseByte),
+      };
     },
 
     completionPattern: undefined,

--- a/src/adapters/cli/codex.ts
+++ b/src/adapters/cli/codex.ts
@@ -6,6 +6,7 @@ import type { CliAdapter, PtyHandle } from './types.js';
 import { codexHistoryPath, codexHome, codexSessionsRoot } from '../../services/codex-paths.js';
 import { discoverRolloutSessions } from '../../services/resumable-session-discovery.js';
 import { delay, scaleMs } from '../../utils/timing.js';
+import { stripAnsiForLog } from '../../utils/crash-log.js';
 
 /** Global submit log — Codex appends one JSON line here on every successful
  *  user submit across all sessions. Far better than the per-session rollout
@@ -124,17 +125,69 @@ function latestCodexSessionForBotmuxSession(botmuxSessionId: string): string | u
 }
 
 function isReattachPty(pty: PtyHandle): boolean {
-  return Boolean((pty as any).isReattach);
+  return pty.isReattach === true;
 }
 
 function clearCodexComposer(pty: PtyHandle): boolean {
   try {
-    if (pty.sendSpecialKeys) pty.sendSpecialKeys('C-u');
+    if (pty.sendSpecialKeys) {
+      if (pty.sendSpecialKeys('C-u') === false) return false;
+    }
     else pty.write('\x15');
     return true;
   } catch {
     return false;
   }
+}
+
+function normaliseComposerText(text: string): string {
+  return stripAnsiForLog(text).replace(/\s+/g, ' ').trim();
+}
+
+function screenShowsCodexPaste(screen: string, content: string): boolean {
+  const actual = normaliseComposerText(screen);
+  const expected = normaliseComposerText(content);
+  if (!actual || !expected) return false;
+  const visibleTail = expected.length > 80 ? expected.slice(-80) : expected;
+  return actual.includes(visibleTail)
+    || /\bpasted\s+content\b[^\r\n]{0,40}\b(?:chars?|lines?)\b/i.test(actual);
+}
+
+async function waitForCodexComposerPaste(
+  pty: PtyHandle,
+  content: string,
+  beforePasteScreen: string,
+  timeoutMs: number,
+): Promise<'confirmed' | 'unavailable' | 'missing'> {
+  if (!pty.captureViewport) return 'unavailable';
+  const deadline = Date.now() + scaleMs(timeoutMs);
+  let capturedNonEmptyScreen = false;
+  do {
+    try {
+      const screen = pty.captureViewport();
+      if (screen.trim()) capturedNonEmptyScreen = true;
+      if (normaliseComposerText(screen) !== normaliseComposerText(beforePasteScreen)
+        && screenShowsCodexPaste(screen, content)) return 'confirmed';
+    } catch {
+      // A transient capture failure should not turn into a blind Enter. Keep
+      // polling; if every capture fails we use the legacy settle delay below.
+    }
+    await delay(100);
+  } while (Date.now() < deadline);
+  return capturedNonEmptyScreen ? 'missing' : 'unavailable';
+}
+
+function codexHistoryRecheck(
+  historyPath: string,
+  baseByte: number,
+  content: string,
+): CodexSubmitResult['recheck'] {
+  return () => {
+    const late = matchHistoryDelta(historyPath, baseByte, content);
+    return late.found
+      ? { submitted: true, cliSessionId: late.cliSessionId }
+      : false;
+  };
 }
 
 async function submitCodexPrompt(
@@ -143,13 +196,18 @@ async function submitCodexPrompt(
   historyPath: string,
   baseByte: number,
   settleMs: number,
+  requireComposerEvidence: boolean,
 ): Promise<CodexSubmitResult> {
+  let beforePasteScreen = '';
+  if (requireComposerEvidence && pty.captureViewport) {
+    try { beforePasteScreen = pty.captureViewport(); } catch { /* fallback handled below */ }
+  }
   try {
     if (pty.pasteText) {
       // tmux mode: load-buffer + paste-buffer -d -p. The `-p` flag emits
       // bracketed-paste markers when the pane has them on (Codex default);
       // `-d` deletes the buffer after so it doesn't accumulate.
-      pty.pasteText(content);
+      if (pty.pasteText(content) === false) return { submitted: false };
     } else {
       // Non-tmux fallback (raw PTY): wrap the markers ourselves.
       pty.write('\x1b[200~' + content + '\x1b[201~');
@@ -158,10 +216,20 @@ async function submitCodexPrompt(
     return { submitted: false };
   }
 
-  await delay(settleMs);
+  if (requireComposerEvidence) {
+    const composer = await waitForCodexComposerPaste(pty, content, beforePasteScreen, 2_400);
+    if (composer === 'missing') {
+      return { submitted: false, recheck: codexHistoryRecheck(historyPath, baseByte, content) };
+    }
+    if (composer === 'unavailable') await delay(settleMs);
+  } else {
+    await delay(settleMs);
+  }
   const trySendEnter = (): boolean => {
     try {
-      if (pty.sendSpecialKeys) pty.sendSpecialKeys('Enter');
+      if (pty.sendSpecialKeys) {
+        if (pty.sendSpecialKeys('Enter') === false) return false;
+      }
       else pty.write('\r');
       return true;
     } catch {
@@ -187,13 +255,7 @@ async function submitCodexPrompt(
       : { submitted: true };
   }
 
-  const recheck = () => {
-    const late = matchHistoryDelta(historyPath, baseByte, content);
-    return late.found
-      ? { submitted: true, cliSessionId: late.cliSessionId }
-      : false;
-  };
-  return { submitted: false, recheck };
+  return { submitted: false, recheck: codexHistoryRecheck(historyPath, baseByte, content) };
 }
 
 export function createCodexAdapter(pathOverride?: string): CliAdapter {
@@ -302,13 +364,21 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
       const baseByte = currentFileSize(historyPath);
       const reattach = isReattachPty(pty);
       const initialSettleMs = reattach ? 800 : 200;
-      const firstAttempt = await submitCodexPrompt(pty, content, historyPath, baseByte, initialSettleMs);
+      const firstAttempt = await submitCodexPrompt(pty, content, historyPath, baseByte, initialSettleMs, reattach);
       if (firstAttempt.submitted) return firstAttempt;
 
       if (!clearCodexComposer(pty)) return firstAttempt;
+      await delay(150);
+
+      // The last Enter may have committed even though history.jsonl missed the
+      // first attempt's in-band budget. Recheck after the clear/settle gap and
+      // before repasting: otherwise a late history append would prove the first
+      // submit landed only after we had already driven the same prompt twice.
+      const lateFirstSubmit = firstAttempt.recheck?.();
+      if (lateFirstSubmit && lateFirstSubmit.submitted) return lateFirstSubmit;
 
       const retrySettleMs = reattach ? 800 : 400;
-      const secondAttempt = await submitCodexPrompt(pty, content, historyPath, baseByte, retrySettleMs);
+      const secondAttempt = await submitCodexPrompt(pty, content, historyPath, baseByte, retrySettleMs, reattach);
       if (secondAttempt.submitted) return secondAttempt;
 
       // In-band budget exhausted. Hand the worker a recheck closure: a

--- a/src/adapters/cli/codex.ts
+++ b/src/adapters/cli/codex.ts
@@ -21,6 +21,12 @@ interface HistoryMatch {
   cliSessionId?: string;
 }
 
+interface CodexSubmitResult {
+  submitted: boolean;
+  cliSessionId?: string;
+  recheck?: () => { submitted: boolean; cliSessionId?: string } | false;
+}
+
 function readCliSessionId(parsed: unknown): string | undefined {
   return parsed && typeof parsed === 'object' && typeof (parsed as any).session_id === 'string'
     ? (parsed as any).session_id
@@ -115,6 +121,79 @@ function latestCodexSessionForBotmuxSession(botmuxSessionId: string): string | u
     return undefined;
   }
   return undefined;
+}
+
+function isReattachPty(pty: PtyHandle): boolean {
+  return Boolean((pty as any).isReattach);
+}
+
+function clearCodexComposer(pty: PtyHandle): boolean {
+  try {
+    if (pty.sendSpecialKeys) pty.sendSpecialKeys('C-u');
+    else pty.write('\x15');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function submitCodexPrompt(
+  pty: PtyHandle,
+  content: string,
+  historyPath: string,
+  baseByte: number,
+  settleMs: number,
+): Promise<CodexSubmitResult> {
+  try {
+    if (pty.pasteText) {
+      // tmux mode: load-buffer + paste-buffer -d -p. The `-p` flag emits
+      // bracketed-paste markers when the pane has them on (Codex default);
+      // `-d` deletes the buffer after so it doesn't accumulate.
+      pty.pasteText(content);
+    } else {
+      // Non-tmux fallback (raw PTY): wrap the markers ourselves.
+      pty.write('\x1b[200~' + content + '\x1b[201~');
+    }
+  } catch {
+    return { submitted: false };
+  }
+
+  await delay(settleMs);
+  const trySendEnter = (): boolean => {
+    try {
+      if (pty.sendSpecialKeys) pty.sendSpecialKeys('Enter');
+      else pty.write('\r');
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  if (!trySendEnter()) return { submitted: false };
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const match = await waitForHistoryAppend(historyPath, baseByte, content, 800);
+    if (match.found) {
+      return match.cliSessionId
+        ? { submitted: true, cliSessionId: match.cliSessionId }
+        : { submitted: true };
+    }
+    if (!trySendEnter()) return { submitted: false };
+  }
+
+  const match = await waitForHistoryAppend(historyPath, baseByte, content, 800);
+  if (match.found) {
+    return match.cliSessionId
+      ? { submitted: true, cliSessionId: match.cliSessionId }
+      : { submitted: true };
+  }
+
+  const recheck = () => {
+    const late = matchHistoryDelta(historyPath, baseByte, content);
+    return late.found
+      ? { submitted: true, cliSessionId: late.cliSessionId }
+      : false;
+  };
+  return { submitted: false, recheck };
 }
 
 export function createCodexAdapter(pathOverride?: string): CliAdapter {
@@ -216,67 +295,27 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
       // bracketed paste lands the whole multi-line message in the composer
       // un-submitted, with the process staying alive and \t absorbed cleanly.
       //
-      // The history.jsonl verification loop below is unchanged: it polls for
-      // the submitted prefix and, if it never appears, surfaces the failure
-      // via the worker's deferred recheck + Lark warning rather than silently
-      // dropping the message.
-      const trySendEnter = (): boolean => {
-        try {
-          if (pty.sendSpecialKeys) pty.sendSpecialKeys('Enter');
-          else pty.write('\r');
-          return true;
-        } catch {
-          // tmux session is gone (CLI exited mid-write) — bail out cleanly
-          // rather than crashing the worker on an unhandled execFileSync error.
-          return false;
-        }
-      };
-
+      // The history.jsonl verification loop below still polls for the
+      // submitted prefix; on a hard miss it now clears the composer and
+      // re-drives the submit once before handing the worker a deferred recheck.
       const historyPath = codexHistoryPath();
       const baseByte = currentFileSize(historyPath);
+      const reattach = isReattachPty(pty);
+      const initialSettleMs = reattach ? 800 : 200;
+      const firstAttempt = await submitCodexPrompt(pty, content, historyPath, baseByte, initialSettleMs);
+      if (firstAttempt.submitted) return firstAttempt;
 
-      try {
-        if (pty.pasteText) {
-          // tmux mode: load-buffer + paste-buffer -d -p. The `-p` flag emits
-          // bracketed-paste markers when the pane has them on (Codex default);
-          // `-d` deletes the buffer after so it doesn't accumulate.
-          pty.pasteText(content);
-        } else {
-          // Non-tmux fallback (raw PTY): wrap the markers ourselves.
-          pty.write('\x1b[200~' + content + '\x1b[201~');
-        }
-      } catch {
-        return { submitted: false };
-      }
-      await delay(200);
-      if (!trySendEnter()) return { submitted: false };
+      if (!clearCodexComposer(pty)) return firstAttempt;
 
-      for (let attempt = 0; attempt < 3; attempt++) {
-        const match = await waitForHistoryAppend(historyPath, baseByte, content, 800);
-        if (match.found) {
-          return match.cliSessionId
-            ? { submitted: true, cliSessionId: match.cliSessionId }
-            : undefined;
-        }
-        if (!trySendEnter()) return { submitted: false };
-      }
-      const match = await waitForHistoryAppend(historyPath, baseByte, content, 800);
-      if (match.found) {
-        return match.cliSessionId
-          ? { submitted: true, cliSessionId: match.cliSessionId }
-          : undefined;
-      }
+      const retrySettleMs = reattach ? 800 : 400;
+      const secondAttempt = await submitCodexPrompt(pty, content, historyPath, baseByte, retrySettleMs);
+      if (secondAttempt.submitted) return secondAttempt;
+
       // In-band budget exhausted. Hand the worker a recheck closure: a
       // slow-startup Codex (or one whose first turn is delayed by a heavy
       // initial prompt) may still append our marker after the retries gave
       // up, and the worker re-scans on a delay before warning the user.
-      const recheck = () => {
-        const late = matchHistoryDelta(historyPath, baseByte, content);
-        return late.found
-          ? { submitted: true, cliSessionId: late.cliSessionId }
-          : false;
-      };
-      return { submitted: false, recheck };
+      return secondAttempt;
     },
 
     completionPattern: undefined,

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -8,8 +8,14 @@ export interface PtyHandle {
   /** Send special keys via tmux send-keys, e.g. 'Enter', 'Escape', 'C-c' (tmux mode only).
    *  Returns `false` on a dropped write (see sendText). */
   sendSpecialKeys?(...keys: string[]): void | boolean;
-  /** Paste text via tmux load-buffer + paste-buffer (auto-brackets if terminal supports it). */
-  pasteText?(text: string): void;
+  /** Paste text via tmux load-buffer + paste-buffer (auto-brackets if terminal supports it).
+   *  Returns `false` when a backend can prove the paste was dropped. */
+  pasteText?(text: string): void | boolean;
+  /** True when this handle re-attached to a persistent pane after daemon restart. */
+  readonly isReattach?: boolean;
+  /** Current visible pane snapshot. Reattach-sensitive adapters may use this
+   *  to prove a paste reached the real composer before pressing Enter. */
+  captureViewport?(): string;
   /** Absolute path to Claude Code's session JSONL; set by worker for claude-code adapter.
    *  Used by writeInput to verify a paste+Enter actually committed (new user-content
    *  line appended) and retry Enter if not — rather than trusting fixed sleep timing. */

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -146,7 +146,11 @@ export interface CliAdapter {
    *  slow-path submits (cold-start, slow UserPromptSubmit hooks, busy disk)
    *  that landed *after* the in-band retry budget exhausted are recognised
    *  and the user_notify warning is suppressed. The closure must be cheap
-   *  and idempotent — worker may invoke it multiple times. */
+   *  and idempotent — worker may invoke it multiple times. An adapter may also
+   *  attach a `recover` closure for a delayed, evidence-gated submit retry.
+   *  Recovery must not duplicate the user content: for example, an adapter may
+   *  press Enter only when it can still prove the original text is sitting in
+   *  the composer, but must not blindly paste the same prompt again. */
   writeInput(
     pty: PtyHandle,
     content: string,
@@ -158,6 +162,7 @@ export interface CliAdapter {
      *  terminal keybinding). Worker surfaces this immediately. */
     failureReason?: string;
     recheck?: () => SubmitRecheckResult | Promise<SubmitRecheckResult>;
+    recover?: () => SubmitRecheckResult | Promise<SubmitRecheckResult>;
   }>;
 
   /** Optional: absolute path (with ~ expansion handled by caller) to the CLI's

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -68,6 +68,9 @@ const WORKER_SIGKILL_BACKSTOP_MS = 7_000;
 
 export interface WorkerPoolCallbacks {
   sessionReply: (rootId: string, content: string, msgType?: string, larkAppId?: string, turnId?: string) => Promise<string>;
+  /** Reply directly under the triggering Lark message. Used for submit-failure
+   *  alerts so they cannot drift to the topic root or a later turn. */
+  userNotifyReply?: (messageId: string, content: string, larkAppId: string) => Promise<string>;
   getSessionWorkingDir: (ds?: DaemonSession) => string;
   getActiveCount: () => number;
   /** Close a stale session (message withdrawn, etc.) */
@@ -75,6 +78,12 @@ export interface WorkerPoolCallbacks {
   /** Re-check the per-bot resident-session cap after a process starts or an
    * over-cap busy session becomes idle. Optional for unit-test callers. */
   enforceLiveSessionCap?: () => void;
+}
+
+export function formatUserNotifyMessage(message: string, mentionOpenId?: string): string {
+  return mentionOpenId && /^ou_[A-Za-z0-9_-]+$/.test(mentionOpenId)
+    ? `<at user_id="${mentionOpenId}"></at> ${message}`
+    : message;
 }
 
 let callbacks: WorkerPoolCallbacks | undefined;
@@ -1823,7 +1832,9 @@ export function forkWorker(ds: DaemonSession, prompt: string, resumeOrTurnId: bo
     botName: bot.botName,
     botOpenId: bot.botOpenId,
     locale: botLocale(botCfg),
-    turnId: initTurnId ?? ds.currentReplyTarget?.turnId,
+    turnId: initTurnId ?? ds.currentReplyTarget?.turnId
+      ?? (ds.scope === 'thread' ? ds.session.rootMessageId : undefined),
+    turnSenderOpenId: ds.session.quoteTargetSenderIsBot ? undefined : ds.session.lastCallerOpenId,
     skillPluginDir,
     skillReadonlyRoots,
   };
@@ -2520,10 +2531,18 @@ function setupWorkerHandlers(ds: DaemonSession, worker: ChildProcess): void {
           reason: 'user_notify',
           message: msg.message,
         });
+        const content = formatUserNotifyMessage(msg.message, msg.mentionOpenId);
         try {
-          await scopedReply(msg.message, 'text', msg.turnId);
+          if (msg.turnId?.startsWith('om_') && cb.userNotifyReply) {
+            await cb.userNotifyReply(msg.turnId, content, ds.larkAppId);
+          } else {
+            await scopedReply(content, 'text', msg.turnId);
+          }
         } catch (err: any) {
           logger.error(`[${t}] Failed to deliver user_notify to Lark: ${err.message}`);
+          if (msg.turnId?.startsWith('om_') && cb.userNotifyReply) {
+            try { await scopedReply(content, 'text', msg.turnId); } catch { /* already logged */ }
+          }
         }
         break;
       }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -7694,7 +7694,12 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
     beginNewTurn(ds, parsed.content);
     rememberLastCliInput(ds, promptContent, msgContent);
     await noteTurnReceived(ds, parsed.messageId, parsed.content, await getThreadSender(), parsed.messageId, substituteTrigger ? SUBSTITUTE_RECEIVED_REACTION_EMOJI_TYPE : undefined);
-    ds.worker.send({ type: 'message', content: msgContent, turnId: parsed.messageId } as DaemonToWorker);
+    ds.worker.send({
+      type: 'message',
+      content: msgContent,
+      turnId: parsed.messageId,
+      senderOpenId: (!isForeignBot && !isBotSenderType) ? threadSenderOpenId : undefined,
+    } as DaemonToWorker);
   } else {
     // Worker not running — re-fork with resume. This is a NEW turn, so drop
     // any restored streaming-card reference; worker_ready will POST a fresh
@@ -8025,6 +8030,13 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   // Initialise worker pool with daemon callbacks
   initWorkerPool({
     sessionReply,
+    userNotifyReply: (messageId, content, larkAppId) => replyMessage(
+      larkAppId,
+      messageId,
+      content,
+      'text',
+      true,
+    ),
     getSessionWorkingDir,
     getActiveCount,
     closeSession(ds: DaemonSession) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -321,8 +321,8 @@ export type TermActionKey =
 
 /** Messages sent from Daemon to Worker */
 export type DaemonToWorker =
-  | { type: 'init'; sessionId: string; chatId: string; rootMessageId: string; workingDir: string; cliId: string; cliPathOverride?: string; wrapperCli?: string; launchShell?: string; model?: string; disableCliBypass?: boolean; startupCommands?: string[]; env?: Record<string, string>; sandbox?: boolean; sandboxHidePaths?: string[]; sandboxReadonlyPaths?: string[]; sandboxNetwork?: boolean; readIsolation?: boolean; readDenyExtraPaths?: string[]; daemonBootId?: string; backendType: BackendType; prompt: string; resume?: boolean; cliSessionId?: string; originalSessionId?: string; ownerOpenId?: string; webPort?: number; larkAppId: string; larkAppSecret: string; brand?: 'feishu' | 'lark'; botName?: string; botOpenId?: string; locale?: 'zh' | 'en'; turnId?: string; skillPluginDir?: string; skillReadonlyRoots?: string[]; adoptMode?: boolean; adoptSource?: 'tmux' | 'herdr' | 'zellij'; adoptTmuxTarget?: string; adoptZellijSession?: string; adoptZellijPaneId?: string; adoptHerdrSessionName?: string; adoptHerdrTarget?: string; adoptHerdrPaneId?: string; adoptPaneCols?: number; adoptPaneRows?: number; bridgeJsonlPath?: string; adoptCliPid?: number; adoptCwd?: string; adoptRestoredFromMetadata?: boolean }
-  | { type: 'message'; content: string; turnId?: string }
+  | { type: 'init'; sessionId: string; chatId: string; rootMessageId: string; workingDir: string; cliId: string; cliPathOverride?: string; wrapperCli?: string; launchShell?: string; model?: string; disableCliBypass?: boolean; startupCommands?: string[]; env?: Record<string, string>; sandbox?: boolean; sandboxHidePaths?: string[]; sandboxReadonlyPaths?: string[]; sandboxNetwork?: boolean; readIsolation?: boolean; readDenyExtraPaths?: string[]; daemonBootId?: string; backendType: BackendType; prompt: string; resume?: boolean; cliSessionId?: string; originalSessionId?: string; ownerOpenId?: string; webPort?: number; larkAppId: string; larkAppSecret: string; brand?: 'feishu' | 'lark'; botName?: string; botOpenId?: string; locale?: 'zh' | 'en'; turnId?: string; turnSenderOpenId?: string; skillPluginDir?: string; skillReadonlyRoots?: string[]; adoptMode?: boolean; adoptSource?: 'tmux' | 'herdr' | 'zellij'; adoptTmuxTarget?: string; adoptZellijSession?: string; adoptZellijPaneId?: string; adoptHerdrSessionName?: string; adoptHerdrTarget?: string; adoptHerdrPaneId?: string; adoptPaneCols?: number; adoptPaneRows?: number; bridgeJsonlPath?: string; adoptCliPid?: number; adoptCwd?: string; adoptRestoredFromMetadata?: boolean }
+  | { type: 'message'; content: string; turnId?: string; senderOpenId?: string }
   /** Literal slash-command passthrough. `followUpContent` rides along so the
    *  worker enqueues it strictly AFTER the slash command's Enter — two separate
    *  IPCs would race: process.on('message') handlers don't serialize, and the
@@ -365,7 +365,7 @@ export type WorkerToDaemon =
   | { type: 'tui_prompt'; description: string; options: Array<{ label?: string; text: string; selected: boolean; type?: string; keys?: string[] }>; multiSelect?: boolean; turnId?: string }
   | { type: 'tui_prompt_resolved'; selectedText?: string }
   | { type: 'screenshot_uploaded'; imageKey: string; status: ScreenStatus; usageLimit?: CliUsageLimitState }
-  | { type: 'user_notify'; message: string; turnId?: string }
+  | { type: 'user_notify'; message: string; turnId?: string; mentionOpenId?: string }
   | {
       type: 'final_output';
       /** Worker-side botmux session identity. Daemon validates this before

--- a/src/utils/pending-input-queue.ts
+++ b/src/utils/pending-input-queue.ts
@@ -1,6 +1,7 @@
 export interface PendingCliInput {
   content: string;
   turnId?: string;
+  senderOpenId?: string;
 }
 
 export function mergeQueuedCliInput(
@@ -11,5 +12,6 @@ export function mergeQueuedCliInput(
   if (!tail) return false;
   tail.content = `${tail.content}\n\n${next.content}`;
   tail.turnId = next.turnId ?? tail.turnId;
+  if (next.senderOpenId !== undefined) tail.senderOpenId = next.senderOpenId;
   return true;
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -554,6 +554,7 @@ const inflightInputs = new InflightInputTracker();
  *  start work before their history/transcript submit marker is observable. */
 let lastPtyActivityAtMs = 0;
 let currentBotmuxTurnId: string | undefined;
+let currentBotmuxTurnSenderOpenId: string | undefined;
 function readProcStarttime(pid: number): string | undefined {
   try {
     const raw = readFileSync(`/proc/${pid}/stat`, 'utf8');
@@ -3366,6 +3367,7 @@ function scheduleSubmitFailureNotify(
   bridgeTurnId?: string,
   failureReason?: string,
   turnId = currentBotmuxTurnId,
+  mentionOpenId = currentBotmuxTurnSenderOpenId,
   turnSeq = usageLimitTracker.currentTurn(),
 ): void {
   const preview = msg.length > 60 ? msg.slice(0, 60) + '…' : msg;
@@ -3390,6 +3392,7 @@ function scheduleSubmitFailureNotify(
     send({
       type: 'user_notify',
       turnId: notifyTurnId,
+      mentionOpenId,
       message: t('worker.submit_impossible', { cliName: cliName(), reason, preview }),
     });
     return;
@@ -3446,6 +3449,7 @@ function scheduleSubmitFailureNotify(
     send({
       type: 'user_notify',
       turnId: notifyTurnId,
+      mentionOpenId,
       message: t('worker.submit_unconfirmed', { cliName: cliName(), secs: Math.round(SUBMIT_DEFERRED_RECHECK_MS / 1000), transcriptLabel, preview }),
     });
   }, SUBMIT_DEFERRED_RECHECK_MS);
@@ -3603,7 +3607,10 @@ async function flushPending(): Promise<void> {
       // If the CLI exits first, onExit stashes these for re-queue on respawn.
       inflightInputs.onWrite(item);
       const msg = item.content;
-      currentBotmuxTurnId = item.turnId;
+      const submitTurnId = item.turnId;
+      const submitSenderOpenId = item.senderOpenId;
+      currentBotmuxTurnId = submitTurnId;
+      currentBotmuxTurnSenderOpenId = submitSenderOpenId;
       writeCliPidMarker();
       const turnSeq = usageLimitTracker.beginTurn(currentUsageLimitSnapshot());
       // Bridge fallback: mark immediately before writeInput. Doing it here
@@ -3641,7 +3648,7 @@ async function flushPending(): Promise<void> {
         // nulled `backend` and told the user the CLI exited) — nothing more to
         // do. Otherwise surface it as a submit failure so the message isn't
         // silently lost.
-        if (backend) scheduleSubmitFailureNotify(msg, undefined, '会话 JSONL', bridgeTurnId, undefined, currentBotmuxTurnId, turnSeq);
+        if (backend) scheduleSubmitFailureNotify(msg, undefined, '会话 JSONL', bridgeTurnId, undefined, submitTurnId, submitSenderOpenId, turnSeq);
         break;
       }
       // Persist any sessionId the adapter observed via authoritative sources
@@ -3659,7 +3666,7 @@ async function flushPending(): Promise<void> {
       // nulled backend) the user already got a "CLI exited" notice; don't also
       // nag that the submit wasn't confirmed.
       if (result && result.submitted === false && backend) {
-        scheduleSubmitFailureNotify(msg, result.recheck, '会话 JSONL', bridgeTurnId, result.failureReason, currentBotmuxTurnId, turnSeq);
+        scheduleSubmitFailureNotify(msg, result.recheck, '会话 JSONL', bridgeTurnId, result.failureReason, submitTurnId, submitSenderOpenId, turnSeq);
       }
       // All structured bridges now drain every pending message in one flush:
       // Claude's BridgeTurnQueue handles `attachment(queued_command)` events
@@ -3675,9 +3682,9 @@ async function flushPending(): Promise<void> {
   }
 }
 
-function sendToPty(content: string, turnId?: string): void {
+function sendToPty(content: string, turnId?: string, senderOpenId?: string): void {
   if (!backend || !cliAdapter) return;
-  const next = { content, turnId };
+  const next = { content, turnId, senderOpenId };
   const shouldMergeQueued = !isFlushing && !shouldWriteNow({
     isPromptReady,
     isFlushing,
@@ -5901,8 +5908,9 @@ process.on('message', async (raw: unknown) => {
       log(`Init: session=${sessionId}, cwd=${msg.workingDir}, render=${renderCols}x${renderRows}${msg.adoptMode ? ' (adopt-pane)' : ''}`);
 
       try {
+        currentBotmuxTurnId = msg.turnId;
+        currentBotmuxTurnSenderOpenId = msg.turnSenderOpenId;
         if (msg.turnId) {
-          currentBotmuxTurnId = msg.turnId;
           writeCliPidMarker();
         }
         let port = 0;
@@ -5947,7 +5955,7 @@ process.on('message', async (raw: unknown) => {
           codexBridgeMarkPendingTurn(msg.prompt, msg.turnId);
         }
         if (msg.prompt && (!cliAdapter?.passesInitialPromptViaArgs || deferInitialPrompt)) {
-          pendingMessages.push({ content: msg.prompt, turnId: msg.turnId });
+          pendingMessages.push({ content: msg.prompt, turnId: msg.turnId, senderOpenId: msg.turnSenderOpenId });
         }
 
         send({ type: 'ready', port, token: writeToken, turnId: currentBotmuxTurnId });
@@ -5965,7 +5973,10 @@ process.on('message', async (raw: unknown) => {
       // Cancel any active tmux copy-mode scroll so user input reaches the CLI.
       if (tmuxScrolledHalfPages > 0) exitTmuxScrollMode();
       const content = msg.content;
-      currentBotmuxTurnId = msg.turnId;
+      const submitTurnId = msg.turnId;
+      const submitSenderOpenId = msg.senderOpenId;
+      currentBotmuxTurnId = submitTurnId;
+      currentBotmuxTurnSenderOpenId = submitSenderOpenId;
       writeCliPidMarker();
       if (!backend && crashDiagnosticStopped && lastInitConfig && !lastInitConfig.adoptMode) {
         log('Message received after crash-loop stop; retrying CLI start');
@@ -6026,7 +6037,7 @@ process.on('message', async (raw: unknown) => {
                 codexBridgeNotifyCliSessionId(result.cliSessionId);
               }
               if (result && result.submitted === false) {
-                scheduleSubmitFailureNotify(content, result.recheck, 'Codex history', undefined, result.failureReason, currentBotmuxTurnId, turnSeq);
+                scheduleSubmitFailureNotify(content, result.recheck, 'Codex history', undefined, result.failureReason, submitTurnId, submitSenderOpenId, turnSeq);
               }
             } catch (err: any) {
               log(`Codex adopt writeInput error: ${err.message}`);
@@ -6055,7 +6066,7 @@ process.on('message', async (raw: unknown) => {
         // arrival. Marking now would race with a still-running previous
         // turn whose `botmux send` could sneak its sentAtMs past this
         // turn's markTimeMs and falsely suppress its fallback.
-        sendToPty(content, msg.turnId);
+        sendToPty(content, msg.turnId, msg.senderOpenId);
       }
       break;
     }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3365,9 +3365,11 @@ function scheduleSubmitFailureNotify(
   transcriptLabel: string,
   bridgeTurnId?: string,
   failureReason?: string,
+  turnId = currentBotmuxTurnId,
   turnSeq = usageLimitTracker.currentTurn(),
 ): void {
   const preview = msg.length > 60 ? msg.slice(0, 60) + '…' : msg;
+  const notifyTurnId = turnId;
   const dropBridgeMark = (): void => {
     if (!bridgeTurnId) return;
     const dropped = bridgeQueue.dropPendingTurn(bridgeTurnId);
@@ -3387,7 +3389,7 @@ function scheduleSubmitFailureNotify(
     log(`writeInput: submit impossible — notifying user immediately. reason="${reason}" preview="${preview}"`);
     send({
       type: 'user_notify',
-      turnId: currentBotmuxTurnId,
+      turnId: notifyTurnId,
       message: t('worker.submit_impossible', { cliName: cliName(), reason, preview }),
     });
     return;
@@ -3443,7 +3445,7 @@ function scheduleSubmitFailureNotify(
     log(`Deferred recheck still missing — notifying user. preview="${preview}"`);
     send({
       type: 'user_notify',
-      turnId: currentBotmuxTurnId,
+      turnId: notifyTurnId,
       message: t('worker.submit_unconfirmed', { cliName: cliName(), secs: Math.round(SUBMIT_DEFERRED_RECHECK_MS / 1000), transcriptLabel, preview }),
     });
   }, SUBMIT_DEFERRED_RECHECK_MS);
@@ -3639,7 +3641,7 @@ async function flushPending(): Promise<void> {
         // nulled `backend` and told the user the CLI exited) — nothing more to
         // do. Otherwise surface it as a submit failure so the message isn't
         // silently lost.
-        if (backend) scheduleSubmitFailureNotify(msg, undefined, '会话 JSONL', bridgeTurnId, undefined, turnSeq);
+        if (backend) scheduleSubmitFailureNotify(msg, undefined, '会话 JSONL', bridgeTurnId, undefined, currentBotmuxTurnId, turnSeq);
         break;
       }
       // Persist any sessionId the adapter observed via authoritative sources
@@ -3657,7 +3659,7 @@ async function flushPending(): Promise<void> {
       // nulled backend) the user already got a "CLI exited" notice; don't also
       // nag that the submit wasn't confirmed.
       if (result && result.submitted === false && backend) {
-        scheduleSubmitFailureNotify(msg, result.recheck, '会话 JSONL', bridgeTurnId, result.failureReason, turnSeq);
+        scheduleSubmitFailureNotify(msg, result.recheck, '会话 JSONL', bridgeTurnId, result.failureReason, currentBotmuxTurnId, turnSeq);
       }
       // All structured bridges now drain every pending message in one flush:
       // Claude's BridgeTurnQueue handles `attachment(queued_command)` events
@@ -6024,7 +6026,7 @@ process.on('message', async (raw: unknown) => {
                 codexBridgeNotifyCliSessionId(result.cliSessionId);
               }
               if (result && result.submitted === false) {
-                scheduleSubmitFailureNotify(content, result.recheck, 'Codex history', undefined, result.failureReason, turnSeq);
+                scheduleSubmitFailureNotify(content, result.recheck, 'Codex history', undefined, result.failureReason, currentBotmuxTurnId, turnSeq);
               }
             } catch (err: any) {
               log(`Codex adopt writeInput error: ${err.message}`);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3362,7 +3362,9 @@ const SUBMIT_DEFERRED_RECHECK_MS = 20_000;
 /** Worker-side handler for `submitted: false`. Defers the user-facing
  *  warning and runs the adapter-supplied `recheck` closure first; if the
  *  message has shown up in the transcript by then (slow path, hook delay),
- *  suppresses the warning entirely. Adapters without a recheck still fall
+ *  suppresses the warning entirely. When the message is still stuck and the
+ *  adapter supplies an evidence-gated `recover`, the worker tries that once
+ *  before warning. Adapters without a recheck still fall
  *  through to the warning after the same delay so the UX is uniform.
  *
  *  `bridgeTurnId` is the BridgeTurnQueue mark created right before the
@@ -3374,6 +3376,7 @@ const SUBMIT_DEFERRED_RECHECK_MS = 20_000;
 function scheduleSubmitFailureNotify(
   msg: string,
   recheck: (() => SubmitRecheckResult | Promise<SubmitRecheckResult>) | undefined,
+  recover: (() => SubmitRecheckResult | Promise<SubmitRecheckResult>) | undefined,
   transcriptLabel: string,
   bridgeTurnId?: string,
   failureReason?: string,
@@ -3427,11 +3430,35 @@ function scheduleSubmitFailureNotify(
       }
     }
 
-    const action = decideSubmitConfirmationAction({
+    let action = decideSubmitConfirmationAction({
       recheckSubmitted,
       usageLimitDetected: usageLimitTracker.detectedThisTurn(turnSeq),
       activityEvidence: submitActivityEvidenceSince(activityBaselineMs),
     });
+
+    // Recovery is deliberately last and narrow: only a conclusively stuck
+    // submit reaches this branch. Codex uses it to press Enter once when the
+    // original prompt is visibly still in the composer; it never re-pastes.
+    if (action.kind === 'notify-stuck' && recover) {
+      try {
+        const recoverResult = await recover();
+        const recovered = typeof recoverResult === 'boolean'
+          ? recoverResult
+          : recoverResult.submitted === true;
+        if (recovered) {
+          cliSessionId = typeof recoverResult === 'object' && recoverResult && typeof recoverResult.cliSessionId === 'string'
+            ? recoverResult.cliSessionId
+            : cliSessionId;
+          action = decideSubmitConfirmationAction({
+            recheckSubmitted: true,
+            usageLimitDetected: false,
+          });
+          log(`Deferred evidence-gated recovery confirmed submit in ${transcriptLabel}. preview="${preview}"`);
+        }
+      } catch (err: any) {
+        log(`Deferred recovery threw (${err?.message ?? err}); falling through to warning.`);
+      }
+    }
 
     switch (action.kind) {
       case 'suppress-confirmed':
@@ -3659,7 +3686,7 @@ async function flushPending(): Promise<void> {
         // nulled `backend` and told the user the CLI exited) — nothing more to
         // do. Otherwise surface it as a submit failure so the message isn't
         // silently lost.
-        if (backend) scheduleSubmitFailureNotify(msg, undefined, '会话 JSONL', bridgeTurnId, undefined, submitTurnId, submitSenderOpenId, turnSeq);
+        if (backend) scheduleSubmitFailureNotify(msg, undefined, undefined, '会话 JSONL', bridgeTurnId, undefined, submitTurnId, submitSenderOpenId, turnSeq);
         break;
       }
       // Persist any sessionId the adapter observed via authoritative sources
@@ -3677,7 +3704,7 @@ async function flushPending(): Promise<void> {
       // nulled backend) the user already got a "CLI exited" notice; don't also
       // nag that the submit wasn't confirmed.
       if (result && result.submitted === false && backend) {
-        scheduleSubmitFailureNotify(msg, result.recheck, '会话 JSONL', bridgeTurnId, result.failureReason, submitTurnId, submitSenderOpenId, turnSeq);
+        scheduleSubmitFailureNotify(msg, result.recheck, result.recover, '会话 JSONL', bridgeTurnId, result.failureReason, submitTurnId, submitSenderOpenId, turnSeq);
       }
       // All structured bridges now drain every pending message in one flush:
       // Claude's BridgeTurnQueue handles `attachment(queued_command)` events
@@ -6048,7 +6075,7 @@ process.on('message', async (raw: unknown) => {
                 codexBridgeNotifyCliSessionId(result.cliSessionId);
               }
               if (result && result.submitted === false) {
-                scheduleSubmitFailureNotify(content, result.recheck, 'Codex history', undefined, result.failureReason, submitTurnId, submitSenderOpenId, turnSeq);
+                scheduleSubmitFailureNotify(content, result.recheck, result.recover, 'Codex history', undefined, result.failureReason, submitTurnId, submitSenderOpenId, turnSeq);
               }
             } catch (err: any) {
               log(`Codex adopt writeInput error: ${err.message}`);

--- a/test/session-lifecycle-hooks.test.ts
+++ b/test/session-lifecycle-hooks.test.ts
@@ -106,6 +106,9 @@ import {
 import { initWorkerPool, __testOnly_setupWorkerHandlers } from '../src/core/worker-pool.js';
 import type { DaemonSession } from '../src/core/types.js';
 
+const sessionReplyMock = vi.fn(async () => 'om_reply');
+const userNotifyReplyMock = vi.fn(async () => 'om_notify');
+
 function makeFakeWorker() {
   const worker = new EventEmitter() as any;
   worker.killed = false;
@@ -222,7 +225,8 @@ describe('session lifecycle hook helper', () => {
 describe('worker-pool lifecycle hook integration', () => {
   beforeEach(() => {
     initWorkerPool({
-      sessionReply: vi.fn(async () => 'om_reply'),
+      sessionReply: sessionReplyMock,
+      userNotifyReply: userNotifyReplyMock,
       getSessionWorkingDir: () => '/repo',
       getActiveCount: () => 1,
       closeSession: vi.fn(),
@@ -284,6 +288,27 @@ describe('worker-pool lifecycle hook integration', () => {
       reason: 'user_notify',
       message: 'Need manual input',
     }));
+  });
+
+  it('mentions the sender and replies under the exact failed input message', async () => {
+    const worker = makeFakeWorker();
+    const ds = makeDs({ worker });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    worker.emit('message', {
+      type: 'user_notify',
+      message: 'Submit was not confirmed',
+      turnId: 'om_failed_input',
+      mentionOpenId: 'ou_sender123',
+    });
+    await flush();
+
+    expect(userNotifyReplyMock).toHaveBeenCalledWith(
+      'om_failed_input',
+      '<at user_id="ou_sender123"></at> Submit was not confirmed',
+      'app_test',
+    );
+    expect(sessionReplyMock).not.toHaveBeenCalled();
   });
 
   it('emits session.exit from worker process exit', () => {

--- a/test/tmux-pipe-backend.test.ts
+++ b/test/tmux-pipe-backend.test.ts
@@ -741,7 +741,7 @@ describe('TmuxPipeBackend send failure handling', () => {
     });
     mockedExecSync.mockImplementation(() => { throw new Error('no server running'); });
 
-    expect(() => be.pasteText('hello')).not.toThrow();
+    expect(be.pasteText('hello')).toBe(false);
     expect(exits).toEqual([[1, null]]);
   });
 });

--- a/test/worker-queue-merge.test.ts
+++ b/test/worker-queue-merge.test.ts
@@ -16,4 +16,20 @@ describe('mergeQueuedCliInput', () => {
 
     expect(pending).toEqual([{ content: 'first\n\nsecond', turnId: 't2' }]);
   });
+
+  it('keeps the latest turn sender with merged input for failure notifications', () => {
+    const pending = [{ content: 'first', turnId: 't1', senderOpenId: 'ou_first' }];
+
+    expect(mergeQueuedCliInput(pending, {
+      content: 'second',
+      turnId: 't2',
+      senderOpenId: 'ou_second',
+    })).toBe(true);
+
+    expect(pending).toEqual([{
+      content: 'first\n\nsecond',
+      turnId: 't2',
+      senderOpenId: 'ou_second',
+    }]);
+  });
 });

--- a/test/write-input.test.ts
+++ b/test/write-input.test.ts
@@ -1242,6 +1242,29 @@ describe('codex writeInput submission confirmation', () => {
     expect(pty.sendSpecialKeys).toHaveBeenCalledWith('Enter');
   });
 
+  it('does not repaste when the first submit appears during the recovery gap', async () => {
+    resetCodexHistory();
+    let submittedText = '';
+    const pty: PtyHandle = {
+      write: vi.fn(),
+      pasteText: vi.fn((text: string) => { submittedText = text; }),
+      sendSpecialKeys: vi.fn((key: string) => {
+        if (key !== 'C-u') return;
+        // Model Codex accepting an earlier Enter while history.jsonl becomes
+        // observable only after the first attempt exhausted its poll budget.
+        appendCodexHistory(submittedText, 'late-first-thread');
+        submittedText = '';
+      }),
+    };
+    const adapter = createCodexAdapter('/bin/codex');
+    const result = await adapter.writeInput(pty, MULTILINE);
+
+    expect(result).toEqual({ submitted: true, cliSessionId: 'late-first-thread' });
+    expect(pty.pasteText).toHaveBeenCalledTimes(1);
+    expect(pty.sendSpecialKeys).toHaveBeenCalledWith('C-u');
+    expect((pty.sendSpecialKeys as any).mock.calls.filter((c: string[]) => c[0] === 'Enter')).toHaveLength(4);
+  });
+
   it('waits longer before the first Enter when the tmux pane is reattached', async () => {
     resetCodexHistory();
     vi.useFakeTimers();
@@ -1261,6 +1284,40 @@ describe('codex writeInput submission confirmation', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('waits for reattached composer evidence before pressing Enter', async () => {
+    resetCodexHistory();
+    let submittedText = '';
+    let composerVisible = false;
+    let captures = 0;
+    const pty: PtyHandle & { isReattach: boolean; captureViewport(): string } = {
+      write: vi.fn(),
+      pasteText: vi.fn((text: string) => { submittedText = text; }),
+      captureViewport: vi.fn(() => {
+        captures++;
+        if (captures >= 4) composerVisible = true;
+        return composerVisible ? `› ${submittedText}` : '›';
+      }),
+      sendSpecialKeys: vi.fn((key: string) => {
+        if (key === 'C-u') {
+          submittedText = '';
+          composerVisible = false;
+          return;
+        }
+        if (key === 'Enter' && composerVisible) {
+          appendCodexHistory(submittedText, 'composer-ready-thread');
+        }
+      }),
+      isReattach: true,
+    };
+    const adapter = createCodexAdapter('/bin/codex');
+    const result = await adapter.writeInput(pty, MULTILINE);
+
+    expect(result).toEqual({ submitted: true, cliSessionId: 'composer-ready-thread' });
+    expect(pty.captureViewport).toHaveBeenCalled();
+    expect(pty.sendSpecialKeys).toHaveBeenCalledTimes(1);
+    expect(pty.sendSpecialKeys).toHaveBeenCalledWith('Enter');
   });
 });
 

--- a/test/write-input.test.ts
+++ b/test/write-input.test.ts
@@ -115,24 +115,33 @@ function removeClaudeKeybindings(): void {
   try { rmSync(CLAUDE_KEYBINDINGS_PATH); } catch { /* absent */ }
 }
 
-function makeTmuxPty(opts?: { confirmCodexSubmit?: boolean; codexSessionId?: string }) {
+function makeTmuxPty(opts?: { confirmCodexSubmit?: boolean; codexSessionId?: string; isReattach?: boolean }) {
   const confirmCodexSubmit = opts?.confirmCodexSubmit ?? true;
   let submittedText = '';
   return {
     write: vi.fn(),
     sendText: vi.fn((text: string) => { submittedText = text; }),
     sendSpecialKeys: vi.fn((key: string) => {
+      if (key === 'C-u') {
+        submittedText = '';
+        return;
+      }
       if (confirmCodexSubmit && key === 'Enter') appendCodexHistory(submittedText, opts?.codexSessionId);
     }),
     pasteText: vi.fn((text: string) => { submittedText = text; }),
+    isReattach: opts?.isReattach ?? false,
   } satisfies PtyHandle;
 }
 
-function makeRawPty(opts?: { confirmCodexSubmit?: boolean; codexSessionId?: string }) {
+function makeRawPty(opts?: { confirmCodexSubmit?: boolean; codexSessionId?: string; isReattach?: boolean }) {
   const confirmCodexSubmit = opts?.confirmCodexSubmit ?? true;
   let submittedText = '';
   return {
     write: vi.fn((data: string) => {
+      if (data === '\x15') {
+        submittedText = '';
+        return;
+      }
       if (data === '\r') {
         if (confirmCodexSubmit) appendCodexHistory(submittedText, opts?.codexSessionId);
         return;
@@ -144,6 +153,7 @@ function makeRawPty(opts?: { confirmCodexSubmit?: boolean; codexSessionId?: stri
       }
       submittedText += data;
     }),
+    isReattach: opts?.isReattach ?? false,
   } satisfies PtyHandle;
 }
 
@@ -978,7 +988,7 @@ describe('genius writeInput submission confirmation', () => {
 
     expect(result).toMatchObject({ submitted: false });
     expect((result as any).recheck()).toBe(false);
-    expect(pty.sendSpecialKeys).toHaveBeenCalledTimes(4);
+    expect((pty.sendSpecialKeys as any).mock.calls.filter((c: string[]) => c[0] === 'Enter')).toHaveLength(4);
   });
 });
 
@@ -1101,7 +1111,7 @@ describe('codex writeInput submission confirmation', () => {
     const adapter = createCodexAdapter('/bin/codex');
     const result = await adapter.writeInput(pty, MULTILINE);
 
-    expect(result).toBeUndefined();
+    expect(result).toEqual({ submitted: true });
     expect(pty.pasteText).toHaveBeenCalledWith(MULTILINE);
     expect(pty.sendText).not.toHaveBeenCalled();
     expect(pty.sendSpecialKeys).toHaveBeenCalledTimes(1);
@@ -1193,7 +1203,64 @@ describe('codex writeInput submission confirmation', () => {
     expect((result as any).recheck()).toEqual({ submitted: true, cliSessionId: 'late-codex-thread' });
     expect(pty.pasteText).toHaveBeenCalledWith(MULTILINE);
     expect(pty.sendText).not.toHaveBeenCalled();
-    expect(pty.sendSpecialKeys).toHaveBeenCalledTimes(4);
+    expect((pty.sendSpecialKeys as any).mock.calls.filter((c: string[]) => c[0] === 'Enter')).toHaveLength(8);
+    expect(pty.sendSpecialKeys).toHaveBeenCalledWith('C-u');
+  });
+
+  it('re-drives a failed submit by clearing the composer and repasting once', async () => {
+    resetCodexHistory();
+    let submittedText = '';
+    let enterCount = 0;
+    const pty: PtyHandle & { isReattach: boolean } = {
+      write: vi.fn((data: string) => {
+        if (data === '\x15') {
+          submittedText = '';
+          return;
+        }
+        submittedText += data;
+      }),
+      sendText: vi.fn((text: string) => { submittedText = text; }),
+      sendSpecialKeys: vi.fn((key: string) => {
+        if (key === 'C-u') {
+          submittedText = '';
+          return;
+        }
+        if (key !== 'Enter') return;
+        enterCount++;
+        if (enterCount <= 4) return;
+        appendCodexHistory(submittedText, 'retry-thread');
+      }),
+      pasteText: vi.fn((text: string) => { submittedText = text; }),
+      isReattach: false,
+    };
+    const adapter = createCodexAdapter('/bin/codex');
+    const result = await adapter.writeInput(pty, MULTILINE);
+
+    expect(result).toEqual({ submitted: true, cliSessionId: 'retry-thread' });
+    expect(pty.pasteText).toHaveBeenCalledTimes(2);
+    expect(pty.sendSpecialKeys).toHaveBeenCalledWith('C-u');
+    expect(pty.sendSpecialKeys).toHaveBeenCalledWith('Enter');
+  });
+
+  it('waits longer before the first Enter when the tmux pane is reattached', async () => {
+    resetCodexHistory();
+    vi.useFakeTimers();
+    try {
+      const pty = makeTmuxPty({ codexSessionId: 'reattach-thread', isReattach: true });
+      const adapter = createCodexAdapter('/bin/codex');
+      const promise = adapter.writeInput(pty, MULTILINE);
+
+      await vi.advanceTimersByTimeAsync(39);
+      expect(pty.sendSpecialKeys).not.toHaveBeenCalledWith('Enter');
+
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await expect(promise).resolves.toEqual({ submitted: true, cliSessionId: 'reattach-thread' });
+      expect(pty.sendSpecialKeys).toHaveBeenCalledWith('Enter');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/test/write-input.test.ts
+++ b/test/write-input.test.ts
@@ -1198,71 +1198,123 @@ describe('codex writeInput submission confirmation', () => {
     // (cold-start / heavy UserPromptSubmit hook) so they don't false-warn;
     // before any append it must report the submit still missing.
     expect(typeof (result as any)?.recheck).toBe('function');
+    expect(typeof (result as any)?.recover).toBe('function');
     expect((result as any).recheck()).toBe(false);
     appendCodexHistory(MULTILINE, 'late-codex-thread');
     expect((result as any).recheck()).toEqual({ submitted: true, cliSessionId: 'late-codex-thread' });
     expect(pty.pasteText).toHaveBeenCalledWith(MULTILINE);
     expect(pty.sendText).not.toHaveBeenCalled();
-    expect((pty.sendSpecialKeys as any).mock.calls.filter((c: string[]) => c[0] === 'Enter')).toHaveLength(8);
-    expect(pty.sendSpecialKeys).toHaveBeenCalledWith('C-u');
+    expect((pty.sendSpecialKeys as any).mock.calls.filter((c: string[]) => c[0] === 'Enter')).toHaveLength(4);
+    expect(pty.sendSpecialKeys).not.toHaveBeenCalledWith('C-u');
   });
 
-  it('re-drives a failed submit by clearing the composer and repasting once', async () => {
+  it('recovers a stuck composer by pressing Enter without repasting', async () => {
     resetCodexHistory();
     let submittedText = '';
     let enterCount = 0;
-    const pty: PtyHandle & { isReattach: boolean } = {
-      write: vi.fn((data: string) => {
-        if (data === '\x15') {
-          submittedText = '';
-          return;
-        }
-        submittedText += data;
-      }),
+    const pty: PtyHandle & { isReattach: boolean; captureViewport(): string } = {
+      write: vi.fn(),
       sendText: vi.fn((text: string) => { submittedText = text; }),
       sendSpecialKeys: vi.fn((key: string) => {
-        if (key === 'C-u') {
-          submittedText = '';
-          return;
-        }
         if (key !== 'Enter') return;
         enterCount++;
         if (enterCount <= 4) return;
         appendCodexHistory(submittedText, 'retry-thread');
       }),
       pasteText: vi.fn((text: string) => { submittedText = text; }),
+      captureViewport: vi.fn(() => `› ${submittedText}`),
       isReattach: false,
     };
     const adapter = createCodexAdapter('/bin/codex');
     const result = await adapter.writeInput(pty, MULTILINE);
 
-    expect(result).toEqual({ submitted: true, cliSessionId: 'retry-thread' });
-    expect(pty.pasteText).toHaveBeenCalledTimes(2);
-    expect(pty.sendSpecialKeys).toHaveBeenCalledWith('C-u');
-    expect(pty.sendSpecialKeys).toHaveBeenCalledWith('Enter');
+    expect(result).toMatchObject({ submitted: false });
+    await expect((result as any).recover()).resolves.toEqual({ submitted: true, cliSessionId: 'retry-thread' });
+    expect(pty.pasteText).toHaveBeenCalledTimes(1);
+    expect(pty.sendSpecialKeys).not.toHaveBeenCalledWith('C-u');
+    expect((pty.sendSpecialKeys as any).mock.calls.filter((c: string[]) => c[0] === 'Enter')).toHaveLength(5);
   });
 
-  it('does not repaste when the first submit appears during the recovery gap', async () => {
+  it('does not touch the terminal when the first submit appears before deferred recovery', async () => {
     resetCodexHistory();
     let submittedText = '';
     const pty: PtyHandle = {
       write: vi.fn(),
       pasteText: vi.fn((text: string) => { submittedText = text; }),
+      sendSpecialKeys: vi.fn(),
+    };
+    const adapter = createCodexAdapter('/bin/codex');
+    const result = await adapter.writeInput(pty, MULTILINE);
+    // Model Codex accepting an earlier Enter while history.jsonl becomes
+    // observable only after the first attempt exhausted its poll budget.
+    appendCodexHistory(submittedText, 'late-first-thread');
+
+    await expect((result as any).recover()).resolves.toEqual({ submitted: true, cliSessionId: 'late-first-thread' });
+    expect(pty.pasteText).toHaveBeenCalledTimes(1);
+    expect(pty.sendSpecialKeys).not.toHaveBeenCalledWith('C-u');
+    expect((pty.sendSpecialKeys as any).mock.calls.filter((c: string[]) => c[0] === 'Enter')).toHaveLength(4);
+  });
+
+  it('does not queue a duplicate when the first submit is accepted before history is visible', async () => {
+    resetCodexHistory();
+    let composer = '';
+    let processing = false;
+    const accepted: string[] = [];
+    const pty: PtyHandle = {
+      write: vi.fn(),
+      pasteText: vi.fn((text: string) => { composer = text; }),
+      // The old prompt remains visible in scrollback, but the latest composer
+      // is empty. Recovery must inspect the composer rather than matching the
+      // earlier transcript text and blindly pressing Enter.
+      captureViewport: vi.fn(() => processing
+        ? `${MULTILINE}\n\n› Implement {feature}\n\n  gpt-5 · 90% left`
+        : `› ${composer}`),
       sendSpecialKeys: vi.fn((key: string) => {
-        if (key !== 'C-u') return;
-        // Model Codex accepting an earlier Enter while history.jsonl becomes
-        // observable only after the first attempt exhausted its poll budget.
-        appendCodexHistory(submittedText, 'late-first-thread');
-        submittedText = '';
+        if (key !== 'Enter' || !composer) return;
+        // Codex accepts the first prompt immediately but does not append its
+        // global history row until startup finishes. A second paste while it
+        // is processing becomes the identical "Queued follow-up input" seen
+        // in the real TUI screenshot.
+        accepted.push(composer);
+        composer = '';
+        processing = true;
       }),
     };
     const adapter = createCodexAdapter('/bin/codex');
     const result = await adapter.writeInput(pty, MULTILINE);
 
-    expect(result).toEqual({ submitted: true, cliSessionId: 'late-first-thread' });
+    expect(processing).toBe(true);
+    expect(result).toMatchObject({ submitted: false });
+    await expect((result as any).recover()).resolves.toBe(false);
+    expect(accepted).toEqual([MULTILINE]);
     expect(pty.pasteText).toHaveBeenCalledTimes(1);
-    expect(pty.sendSpecialKeys).toHaveBeenCalledWith('C-u');
     expect((pty.sendSpecialKeys as any).mock.calls.filter((c: string[]) => c[0] === 'Enter')).toHaveLength(4);
+  });
+
+  it('recovers a late reattach paste with one Enter and no second paste', async () => {
+    resetCodexHistory();
+    let composer = '';
+    let composerVisible = false;
+    const pty: PtyHandle & { isReattach: boolean; captureViewport(): string } = {
+      write: vi.fn(),
+      pasteText: vi.fn((text: string) => { composer = text; }),
+      captureViewport: vi.fn(() => composerVisible ? `› ${composer}` : '›'),
+      sendSpecialKeys: vi.fn((key: string) => {
+        if (key !== 'Enter' || !composerVisible) return;
+        appendCodexHistory(composer, 'late-reattach-thread');
+        composer = '';
+      }),
+      isReattach: true,
+    };
+    const adapter = createCodexAdapter('/bin/codex');
+    const result = await adapter.writeInput(pty, MULTILINE);
+
+    expect(result).toMatchObject({ submitted: false });
+    expect(pty.sendSpecialKeys).not.toHaveBeenCalledWith('Enter');
+    composerVisible = true;
+    await expect((result as any).recover()).resolves.toEqual({ submitted: true, cliSessionId: 'late-reattach-thread' });
+    expect(pty.pasteText).toHaveBeenCalledTimes(1);
+    expect((pty.sendSpecialKeys as any).mock.calls.filter((c: string[]) => c[0] === 'Enter')).toHaveLength(1);
   });
 
   it('waits longer before the first Enter when the tmux pane is reattached', async () => {


### PR DESCRIPTION
### 变更

- Codex 的 `writeInput` 增加一次硬失败自愈：首次提交未被 `history.jsonl` 确认时，先清空 composer，再重新粘贴并再次提交。
- 重新提交的节奏对 reattach 场景更保守：初次 Enter 延后，避免静默重连窗口里过早按下提交。
- `user_notify` 的 deferred warning 现在冻结当次 submit 的 turnId，避免后来的消息把失败卡漂到别的 turn 上。

### 根因

- Codex 在 daemon 静默重连后存在“粘进 composer 但 Enter 没真正提交”的窗口，原逻辑只会继续报错，不会自动重驱。
- worker 之前使用全局 `currentBotmuxTurnId` 发送 deferred 告警，turn 在队列继续推进后会漂移。

### 验证

- `pnpm build`
- `pnpm vitest run test/write-input.test.ts`
- `pnpm vitest run test/session-lifecycle-hooks.test.ts`
