### PR TITLE
fix(coco): 兼容 traecli 重命名

### DIFF
--- a/src/adapters/cli/coco.ts
+++ b/src/adapters/cli/coco.ts
@@ -111,6 +111,28 @@ function submitPrefix(content: string): string {
   return content.slice(0, 40);
 }
 
+function resolveCocoCommand(rawBin: string): string {
+  const resolved = resolveCommand(rawBin);
+  // Newer CoCo/Trae installs may only expose the renamed `traecli` executable.
+  // Keep the historical `coco` default for old installs, but transparently
+  // fall back when the shell probe cannot find it. Explicit path/command
+  // overrides are respected as-is so tests and custom bot configs remain
+  // deterministic.
+  if (rawBin === 'coco' && resolved === 'coco') {
+    const traecli = resolveCommand('traecli');
+    if (traecli !== 'traecli') return traecli;
+  }
+  return resolved;
+}
+
+function shellCommandName(resolvedBin: string): string {
+  // User-facing resume hints should stay copy-pasteable across machines. When
+  // fallback selected a PATH-resolved traecli binary, print `traecli` rather
+  // than an absolute path from the daemon host; explicit overrides keep the
+  // historical command string.
+  return resolvedBin.includes('/') && resolvedBin.endsWith('/traecli') ? 'traecli' : 'coco';
+}
+
 export function createCocoAdapter(pathOverride?: string): CliAdapter {
   // resolvedBin is lazy: setup constructs adapters only to read static
   // modelChoices and must not shell out (see resolveCommand); the binary path
@@ -125,7 +147,7 @@ export function createCocoAdapter(pathOverride?: string): CliAdapter {
     // the REAL ~/.cache/coco/sessions/<sid>/ path (see coco-transcript.ts) — on
     // the overlay the CLI's writes would be invisible to the daemon.
     authPaths: ['~/.trae/cli', '~/.cache/coco'],
-    get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
+    get resolvedBin(): string { return (cachedBin ??= resolveCocoCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, model, disableCliBypass }) {
       const args: string[] = [];
@@ -145,7 +167,7 @@ export function createCocoAdapter(pathOverride?: string): CliAdapter {
     },
 
     buildResumeCommand({ sessionId }) {
-      return `coco --resume ${sessionId}`;
+      return `${shellCommandName(this.resolvedBin)} --resume ${sessionId}`;
     },
 
     async writeInput(pty: PtyHandle, content: string) {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -40,7 +40,9 @@ import {
   ttadkAcceptsModel,
   TTADK_DEFAULT_MODEL,
   TTADK_MODEL_SUGGESTIONS,
+  ttadkConfigModelChoices,
 } from './setup/cli-selection.js';
+import { createCliAdapterSync } from './adapters/cli/registry.js';
 import { invalidWorkingDirs } from './utils/working-dir.js';
 import { invalidateGlobalConfigCache, mergeGlobalConfig, readGlobalConfig, type MaintenanceConfig, type RepoPickerMode, type WhiteboardConfig } from './global-config.js';
 import { hostLocalTimeZone, scheduleTimeZone } from './utils/timezone.js';
@@ -2141,6 +2143,8 @@ const server = createServer(async (req, res) => {
         options: CLI_SELECT_OPTIONS.map((o) => ({
           id: o.key,
           label: o.label,
+          modelChoices: ttadkConfigModelChoices(o.wrapperCli)
+            ?? [...(createCliAdapterSync(o.cliId).modelChoices ?? [])],
           // ttadk 网关项: 前端据此把模型框默认成 glm-5.1 并挂候选下拉; CoCo 不接受 -m.
           ...(isTtadkWrapper(o.wrapperCli)
             ? { gateway: 'ttadk' as const, acceptsModel: ttadkAcceptsModel(o.wrapperCli) }

--- a/src/dashboard/web/bot-defaults.ts
+++ b/src/dashboard/web/bot-defaults.ts
@@ -5,6 +5,7 @@ export type CliOption = {
   label: string;
   gateway?: 'ttadk';
   acceptsModel?: boolean;
+  modelChoices?: string[];
 };
 
 export type CliOptionsState = {
@@ -118,7 +119,7 @@ export function selectedCliOption(options: CliOption[], key: string): CliOption 
 
 export function modelSuggestionsForOption(opt: CliOption | undefined, cliState: CliOptionsState): string[] {
   if (opt?.gateway === 'ttadk' && opt.acceptsModel !== false) return cliState.ttadkModelSuggestions;
-  return [];
+  return opt?.modelChoices ?? [];
 }
 
 export async function fetchBotDefaults(): Promise<LoadBotsResult> {
@@ -145,9 +146,17 @@ export async function fetchCliOptions(): Promise<CliOptionsState> {
     const r = await fetch('/api/cli-options');
     const body = await r.json().catch(() => ({}));
     if (!r.ok || !Array.isArray(body?.options)) return fallbackCliOptionsState;
-    const options = body.options.filter((o: any): o is CliOption =>
-      o && typeof o.id === 'string' && typeof o.label === 'string',
-    );
+    const options = body.options
+      .filter((o: any) => o && typeof o.id === 'string' && typeof o.label === 'string')
+      .map((o: any): CliOption => ({
+        id: o.id,
+        label: o.label,
+        gateway: o.gateway === 'ttadk' ? 'ttadk' : undefined,
+        acceptsModel: typeof o.acceptsModel === 'boolean' ? o.acceptsModel : undefined,
+        modelChoices: Array.isArray(o.modelChoices)
+          ? o.modelChoices.filter((m: unknown): m is string => typeof m === 'string')
+          : undefined,
+      }));
     const ttadkModelDefault = typeof body.ttadkModelDefault === 'string' && body.ttadkModelDefault.trim()
       ? body.ttadkModelDefault.trim()
       : fallbackCliOptionsState.ttadkModelDefault;

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -123,6 +123,23 @@ describe('lazy binary resolution', () => {
     expect(probe).not.toHaveBeenCalled();
   });
 
+  it('coco falls back to traecli when the coco binary is absent', async () => {
+    const { spawnSync } = await import('node:child_process');
+    const probe = vi.mocked(spawnSync);
+    probe.mockImplementation((cmd: any, args: any[]) => {
+      const script = String(args.at(-1));
+      if (script === 'which traecli') {
+        return { stdout: '/usr/local/bin/traecli\n', status: 0 } as any;
+      }
+      return { stdout: '', status: 0 } as any;
+    });
+
+    const adapter = createCliAdapterSync('coco');
+    expect(adapter.resolvedBin).toBe('/usr/local/bin/traecli');
+    expect(adapter.buildResumeCommand?.({ sessionId: 'sess-coco' }))
+      .toBe('traecli --resume sess-coco');
+  });
+
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 改动

- CoCo 适配器默认仍优先使用历史 `coco` 命令；当 PATH 中找不到 `coco` 但能找到新版 `traecli` 时，自动 fallback 到 `traecli`。
- resume 提示在 fallback 到绝对路径 `.../traecli` 时显示为可复制的 `traecli --resume <session>`。
- `/api/cli-options` 下发各 CLI 的 `modelChoices`，Bot Defaults 页消费该字段，让非 ttadk CLI 也能展示模型候选。
- 补充 CoCo fallback 单测。

## 影响面

- 主要影响 `coco` CLI 适配器：仅默认命令为 `coco` 且 shell 探测不到 `coco` 时新增探测 `traecli`；显式 path/command override 不变。
- Dashboard `/api/cli-options` 会构造各 CLI adapter 读取静态 `modelChoices`；这些 adapter 已按懒解析设计，不会在此处解析二进制路径。
- Bot Defaults 页公共数据层新增 `modelChoices` 字段解析；React 页面继续使用 datalist 展示候选，不改变保存接口。

## 测试

- ✅ `pnpm build`
- ✅ `pnpm vitest run --project unit test/cli-adapters.test.ts`（279 passed）
- ⚠️ `pnpm test`：当前环境有 15 个既有失败，和本次改动无关：
  - `test/terminal-url.test.ts` / `test/recall-frozen-cards.test.ts` 期望 localhost/自定义 public URL，但环境实际返回 `https://m-a63a837291d638eb.botmux.bytedance.net/...`
  - `test/session-discovery.smoke.test.ts` 当前进程 comm 为 `MainThread`，测试期望 `/^node/i`
  - `test/dashboard-monitoring-ui.test.ts` CSS 断言失败
