### PR TITLE
fix(lark): 支持长连接使用环境代理

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "markdown-it": "^14.1.1",
     "node-pty": "^1.1.0",
     "pm2": "^6.0.0",
+    "proxy-agent": "^6.5.0",
     "qrcode-terminal": "^0.12.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       pm2:
         specifier: ^6.0.0
         version: 6.0.14
+      proxy-agent:
+        specifier: ^6.5.0
+        version: 6.5.0
       qrcode-terminal:
         specifier: ^0.12.0
         version: 0.12.0

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -4,6 +4,7 @@
  * Extracted from daemon.ts for modularity.
  */
 import * as Lark from '@larksuiteoapi/node-sdk';
+import { ProxyAgent } from 'proxy-agent';
 import { readFileSync, mkdirSync, existsSync } from 'node:fs';
 import { atomicWriteFileSync } from '../../utils/atomic-write.js';
 import { join } from 'node:path';
@@ -1851,6 +1852,32 @@ async function processCommentEvent(
   });
 }
 
+const LARK_WS_PROXY_ENV_KEYS = [
+  'npm_config_https_proxy',
+  'NPM_CONFIG_HTTPS_PROXY',
+  'https_proxy',
+  'HTTPS_PROXY',
+  'npm_config_proxy',
+  'NPM_CONFIG_PROXY',
+  'all_proxy',
+  'ALL_PROXY',
+] as const;
+
+function createLarkWsAgent(): ProxyAgent | undefined {
+  const hasSecureProxy = LARK_WS_PROXY_ENV_KEYS.some(key => process.env[key]?.trim());
+  if (!hasSecureProxy) return undefined;
+
+  const agent = new ProxyAgent();
+  const resolveEnvProxy = agent.getProxyForUrl;
+  agent.getProxyForUrl = (url, req) => {
+    const target = new URL(url);
+    if (target.protocol === 'wss:') target.protocol = 'https:';
+    else if (target.protocol === 'ws:') target.protocol = 'http:';
+    return resolveEnvProxy(target.href, req);
+  };
+  return agent;
+}
+
 /**
  * Create and start the Lark WSClient with event dispatching.
  * Returns the WSClient instance for lifecycle management.
@@ -2508,6 +2535,10 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
     appSecret: larkAppSecret,
     // brand → 长连接域名。国际版租户必须连 larksuite.com，否则收不到任何事件。
     domain: sdkDomain(brand),
+    // `proxy-from-env` treats WSS_PROXY as distinct from HTTPS_PROXY, while
+    // Lark's preceding Axios bootstrap request uses HTTPS proxy semantics.
+    // The custom resolver keeps both phases aligned and still honors NO_PROXY.
+    agent: createLarkWsAgent(),
     // Default to warn — the SDK is chatty at info ("client ready", reconnect
     // heartbeats, etc.) and floods pm2 error.log when stderr is the only sink.
     // DEBUG=1 widens the level back to info for troubleshooting.

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -105,6 +105,7 @@ vi.mock('../src/services/substitute-chat-toggle-store.js', () => ({
 
 // Capture the registered event handlers from EventDispatcher.register()
 let capturedHandlers: Record<string, Function> = {};
+let capturedWsClientOptions: Record<string, any> | undefined;
 
 vi.mock('@larksuiteoapi/node-sdk', () => {
   class MockEventDispatcher {
@@ -114,6 +115,9 @@ vi.mock('@larksuiteoapi/node-sdk', () => {
     }
   }
   class MockWSClient {
+    constructor(options: Record<string, any>) {
+      capturedWsClientOptions = options;
+    }
     start = vi.fn(async () => {});
     getConnectionStatus = vi.fn(() => ({ state: 'connected', reconnectAttempts: 0 }));
   }
@@ -147,6 +151,7 @@ const OTHER_BOT_APP_ID = 'app-bot-b';
 const USER_OPEN_ID = 'ou_user_123';
 
 beforeEach(() => {
+  capturedWsClientOptions = undefined;
   mockListChatMessages.mockReset().mockResolvedValue([]);
   mockListChatMessagesUntil.mockReset().mockResolvedValue([]);
   mockListThreadMessages.mockReset().mockResolvedValue([]);
@@ -300,6 +305,86 @@ function makeUserMessageEvent(opts: {
     },
   };
 }
+
+const WS_PROXY_ENV_KEYS = [
+  'HTTPS_PROXY',
+  'https_proxy',
+  'HTTP_PROXY',
+  'http_proxy',
+  'ALL_PROXY',
+  'all_proxy',
+  'NO_PROXY',
+  'no_proxy',
+  'NPM_CONFIG_HTTPS_PROXY',
+  'npm_config_https_proxy',
+  'NPM_CONFIG_PROXY',
+  'npm_config_proxy',
+  'NPM_CONFIG_NO_PROXY',
+  'npm_config_no_proxy',
+] as const;
+
+function withWsProxyEnv(values: Partial<Record<(typeof WS_PROXY_ENV_KEYS)[number], string>>, callback: () => void): void {
+  const original = Object.fromEntries(
+    WS_PROXY_ENV_KEYS.map(key => [key, process.env[key]]),
+  );
+  for (const key of WS_PROXY_ENV_KEYS) delete process.env[key];
+  Object.assign(process.env, values);
+
+  try {
+    callback();
+  } finally {
+    for (const key of WS_PROXY_ENV_KEYS) {
+      const value = original[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+describe('startLarkEventDispatcher — WebSocket proxy', () => {
+  it('uses HTTPS proxy precedence for secure WebSocket URLs', () => {
+    withWsProxyEnv({
+      HTTPS_PROXY: 'http://upper-proxy:8118',
+      https_proxy: 'http://lower-proxy:8118',
+    }, () => {
+      startLarkEventDispatcher(MY_APP_ID, 'secret', makeHandlers());
+
+      const agent = capturedWsClientOptions?.agent;
+      expect(agent?.constructor?.name).toBe('ProxyAgent');
+      expect(agent?.getProxyForUrl('wss://msg-frontier.feishu.cn/ws', {})).toBe('http://lower-proxy:8118');
+    });
+  });
+
+  it('honors NO_PROXY for the WebSocket destination', () => {
+    withWsProxyEnv({
+      HTTPS_PROXY: 'http://proxy.example:8118',
+      NO_PROXY: '.feishu.cn',
+    }, () => {
+      startLarkEventDispatcher(MY_APP_ID, 'secret', makeHandlers());
+
+      const agent = capturedWsClientOptions?.agent;
+      expect(agent?.getProxyForUrl('wss://msg-frontier.feishu.cn/ws', {})).toBe('');
+      expect(agent?.getProxyForUrl('wss://msg-frontier.larksuite.com/ws', {})).toBe('http://proxy.example:8118');
+    });
+  });
+
+  it('supports an ALL_PROXY fallback such as SOCKS', () => {
+    withWsProxyEnv({ ALL_PROXY: 'socks5://127.0.0.1:1080' }, () => {
+      startLarkEventDispatcher(MY_APP_ID, 'secret', makeHandlers());
+
+      const agent = capturedWsClientOptions?.agent;
+      expect(agent?.getProxyForUrl('wss://msg-frontier.feishu.cn/ws', {})).toBe('socks5://127.0.0.1:1080');
+    });
+  });
+
+  it('keeps the SDK default agent when no proxy is configured', () => {
+    withWsProxyEnv({}, () => {
+      startLarkEventDispatcher(MY_APP_ID, 'secret', makeHandlers());
+
+      expect(capturedWsClientOptions?.agent).toBeUndefined();
+    });
+  });
+});
 
 describe('startLarkEventDispatcher — VC bot meeting push events', () => {
   beforeEach(() => {


### PR DESCRIPTION
## 变更说明
- 为 Lark `WSClient` 注入动态 `ProxyAgent`，解决 SDK 前置 HTTPS 请求可以走代理、后续 WSS 长连接却直连超时的问题
- 将 `wss:` 按 `https:` 环境代理规则解析，统一大小写优先级，并支持 `NO_PROXY` 与 HTTP(S)/SOCKS `ALL_PROXY`
- 未配置安全代理时不传 `agent`，保持 SDK 默认连接行为

## 影响范围
- 仅修改飞书/Lark 事件 WebSocket 的建连路径，对所有使用该 IM 接入的 bot 生效
- 不改动 CLI 适配器、PTY/Tmux 后端及其它会话路由逻辑

## 测试验证
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm build`
- [x] `pnpm exec vitest run --project unit test/event-dispatcher.test.ts`（194 tests passed）
- [ ] `pnpm test`：7,841 tests passed，另有 2 个与本改动无关的既有/环境相关失败：dashboard monitoring CSS 断言；Node 24 下 session-discovery 读到 `MainThread` 而非 `node`

## Live 验证
- [x] 在必须使用环境代理的机器上，以 PR 中相同的动态 `ProxyAgent` 完成真实 WSS 握手（`OPEN`）
- [x] `pnpm switch:here && botmux restart` 后，分支 daemon 输出 `client ready` / `event-dispatch is ready`，长连接稳定且未再出现 `ws connect failed`
- [x] 重启时已有会话成功恢复，确认改动未影响 CLI、PTY/Tmux 与会话恢复路径

## 回归覆盖
- HTTPS 代理的小写变量优先级
- `NO_PROXY` 对实际 WebSocket 目标域名生效
- SOCKS `ALL_PROXY` fallback
- 无代理配置时保留 SDK 默认 agent

Made with [Cursor](https://cursor.com)