### PR TITLE
fix(plugin): recover MCP gateway session context

### DIFF
--- a/src/core/plugins/mcp/gateway.ts
+++ b/src/core/plugins/mcp/gateway.ts
@@ -38,6 +38,7 @@ import { config } from '../../../config.js';
 import { readGlobalConfig } from '../../../global-config.js';
 import { readPluginRegistry } from '../../../services/plugin-registry-store.js';
 import { atomicWriteFileSync } from '../../../utils/atomic-write.js';
+import { resolveSessionContext } from '../../session-marker.js';
 import { normalizePluginIdList } from '../ids.js';
 import { pluginHome, pluginRuntimeDir, resolvePluginPath } from '../paths.js';
 import { readSessionPluginManifest } from '../session-manifest.js';
@@ -45,6 +46,15 @@ import type { PluginMcpServer } from '../types.js';
 
 const GATEWAY_VERSION = '1.0.0';
 const DOWNSTREAM_INITIALIZE_TIMEOUT_MS = 10_000;
+
+export function resolveGatewayEnvironment(
+  env: NodeJS.ProcessEnv = process.env,
+  startPid: number = process.ppid,
+): NodeJS.ProcessEnv {
+  if (env.BOTMUX_SESSION_ID?.trim()) return env;
+  const sessionId = resolveSessionContext(config.session.dataDir, undefined, startPid)?.sessionId.trim();
+  return sessionId ? { ...env, BOTMUX_SESSION_ID: sessionId } : env;
+}
 
 interface GatewayDescriptor {
   key: string;
@@ -194,6 +204,7 @@ function allocateName(
 
 export class PluginMcpGateway {
   readonly server: Server;
+  private readonly env: NodeJS.ProcessEnv;
   private readonly pluginIds: string[];
   private readonly descriptors: GatewayDescriptor[];
   private readonly diagnostics: McpGatewayDiagnostic[] = [];
@@ -204,9 +215,10 @@ export class PluginMcpGateway {
   private resourceRoutes = new Map<string, ResourceRoute>();
   private resourceTemplateRoutes: ResourceRoute[] = [];
 
-  constructor(pluginIds: string[] = gatewayPluginIds()) {
-    this.pluginIds = pluginIds;
-    this.descriptors = gatewayDescriptors(pluginIds);
+  constructor(pluginIds?: string[], env: NodeJS.ProcessEnv = process.env) {
+    this.env = env;
+    this.pluginIds = pluginIds ?? gatewayPluginIds(env);
+    this.descriptors = gatewayDescriptors(this.pluginIds);
     this.server = new Server(
       { name: 'botmux', version: GATEWAY_VERSION },
       {
@@ -243,7 +255,7 @@ export class PluginMcpGateway {
   private persistDiagnostics(): void {
     writeDiagnostics({
       schemaVersion: 1,
-      sessionId: process.env.BOTMUX_SESSION_ID?.trim() || undefined,
+      sessionId: this.env.BOTMUX_SESSION_ID?.trim() || undefined,
       pluginIds: this.pluginIds,
       generatedAt: new Date().toISOString(),
       servers: this.diagnostics,
@@ -280,7 +292,7 @@ export class PluginMcpGateway {
             BOTMUX_PLUGIN_ID: descriptor.pluginId,
             BOTMUX_PLUGIN_DIR: descriptor.pluginDir,
             BOTMUX_PLUGIN_HOME: pluginHome(descriptor.pluginId),
-            ...(process.env.BOTMUX_SESSION_ID ? { BOTMUX_SESSION_ID: process.env.BOTMUX_SESSION_ID } : {}),
+            ...(this.env.BOTMUX_SESSION_ID ? { BOTMUX_SESSION_ID: this.env.BOTMUX_SESSION_ID } : {}),
           },
           stderr: 'inherit',
         });
@@ -602,7 +614,7 @@ export class PluginMcpGateway {
 }
 
 export async function runMcpGateway(): Promise<void> {
-  const gateway = new PluginMcpGateway();
+  const gateway = new PluginMcpGateway(undefined, resolveGatewayEnvironment());
   const transport = new StdioServerTransport();
   const close = () => { void gateway.close(); };
   process.once('SIGINT', close);

--- a/test/fixtures/plugin-mcp-server.mjs
+++ b/test/fixtures/plugin-mcp-server.mjs
@@ -40,7 +40,10 @@ server.setRequestHandler(ListToolsRequestSchema, request => request.params?.curs
     });
 
 server.setRequestHandler(CallToolRequestSchema, request => ({
-  content: [{ type: 'text', text: `${serverName}:${request.params.name}:${JSON.stringify(request.params.arguments ?? {})}` }],
+  content: [{
+    type: 'text',
+    text: `${serverName}:${request.params.name}:${JSON.stringify(request.params.arguments ?? {})}:session=${process.env.BOTMUX_SESSION_ID || ''}`,
+  }],
 }));
 
 server.setRequestHandler(ListPromptsRequestSchema, () => ({

--- a/test/plugin-mcp-gateway.test.ts
+++ b/test/plugin-mcp-gateway.test.ts
@@ -5,7 +5,7 @@ import { join, resolve } from 'node:path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { installLocalPlugin } from '../src/core/plugins/install.js';
-import { PluginMcpGateway } from '../src/core/plugins/mcp/gateway.js';
+import { PluginMcpGateway, resolveGatewayEnvironment } from '../src/core/plugins/mcp/gateway.js';
 
 describe('plugin MCP Gateway', () => {
   let home: string;
@@ -95,6 +95,35 @@ describe('plugin MCP Gateway', () => {
     await Promise.all([gateway.connect(serverTransport), client.connect(clientTransport)]);
     expect((await client.listTools()).tools.map(tool => tool.name).sort()).toEqual(['alpha_unique', 'echo']);
     expect(connectSpy).toHaveBeenCalledWith(expect.anything(), { timeout: 10_000 });
+    await client.close();
+    await gateway.close();
+  });
+
+  it('recovers the Botmux session from the CLI ancestor marker', () => {
+    const markerPid = 24680;
+    const markerDir = join(home, '.botmux', 'data', '.botmux-cli-pids');
+    mkdirSync(markerDir, { recursive: true });
+    writeFileSync(join(markerDir, String(markerPid)), JSON.stringify({ sessionId: 'session-from-marker' }));
+
+    const resolved = resolveGatewayEnvironment({ HOME: home }, markerPid);
+    expect(resolved.BOTMUX_SESSION_ID).toBe('session-from-marker');
+    expect(resolveGatewayEnvironment({ BOTMUX_SESSION_ID: 'session-from-env' }, markerPid).BOTMUX_SESSION_ID)
+      .toBe('session-from-env');
+  });
+
+  it('forwards the Botmux session to plugin MCP processes', async () => {
+    installFixturePlugin('plugin-a', 'alpha');
+    const gateway = new PluginMcpGateway(
+      ['plugin-a'],
+      { ...process.env, BOTMUX_SESSION_ID: 'session-downstream' },
+    );
+    const client = new Client({ name: 'gateway-test', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([gateway.connect(serverTransport), client.connect(clientTransport)]);
+
+    const result = await client.callTool({ name: 'echo', arguments: {} });
+    expect((result.content[0] as any).text).toContain('session=session-downstream');
+
     await client.close();
     await gateway.close();
   });


### PR DESCRIPTION
## Summary
- recover `BOTMUX_SESSION_ID` from the ancestor CLI marker when the MCP host omits it
- keep an explicit environment value authoritative
- propagate the recovered session id to plugin MCP subprocesses and diagnostics

## Verification
- `pnpm exec vitest run --project unit test/plugin-mcp-gateway.test.ts`