### PR TITLE
feat(vc-agent): 支持本场会议自动语音

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -317,7 +317,7 @@ type VcMeetingConsumerInjectResult = {
 };
 
 type VcMeetingOutputChannel = 'text' | 'voice';
-type VcMeetingOutputDecision = 'approve_voice' | 'send_text' | 'allow_text_and_send' | 'reject';
+type VcMeetingOutputDecision = 'approve_voice' | 'allow_voice_and_approve' | 'send_text' | 'allow_text_and_send' | 'reject';
 type VcMeetingOutputSubmitResult =
   | { ok: true; status: 'sent' | 'pending'; requestId?: string; merged?: boolean }
   | { ok: false; error: string };
@@ -4611,6 +4611,26 @@ async function rejectVcMeetingOutputRequest(
   }
 }
 
+function enqueueVcMeetingOutputOperation<T>(
+  session: VcMeetingDaemonSession,
+  channel: VcMeetingOutputChannel,
+  operation: () => Promise<T>,
+): Promise<T> {
+  session.outputSubmitPromises ??= {};
+  const prior = session.outputSubmitPromises[channel] ?? Promise.resolve();
+  const run = prior
+    .catch(() => undefined)
+    .then(operation);
+  const tracked = run.catch(() => undefined);
+  session.outputSubmitPromises[channel] = tracked;
+  tracked.finally(() => {
+    if (session.outputSubmitPromises?.[channel] === tracked) {
+      delete session.outputSubmitPromises[channel];
+    }
+  });
+  return run;
+}
+
 async function submitVcMeetingOutputRequest(input: {
   larkAppId: string;
   meetingId: string;
@@ -4621,19 +4641,11 @@ async function submitVcMeetingOutputRequest(input: {
 }): Promise<VcMeetingOutputSubmitResult> {
   const session = vcMeetingSessions.get(vcMeetingSessionKey(input.larkAppId, input.meetingId));
   if (!session) return submitVcMeetingOutputRequestImpl(input);
-  session.outputSubmitPromises ??= {};
-  const prior = session.outputSubmitPromises[input.channel] ?? Promise.resolve();
-  const run = prior
-    .catch(() => undefined)
-    .then(() => submitVcMeetingOutputRequestImpl(input));
-  const tracked = run.catch(() => undefined);
-  session.outputSubmitPromises[input.channel] = tracked;
-  tracked.finally(() => {
-    if (session.outputSubmitPromises?.[input.channel] === tracked) {
-      delete session.outputSubmitPromises[input.channel];
-    }
-  });
-  return run;
+  return enqueueVcMeetingOutputOperation(
+    session,
+    input.channel,
+    () => submitVcMeetingOutputRequestImpl(input),
+  );
 }
 
 async function submitVcMeetingOutputRequestImpl(input: {
@@ -4843,17 +4855,24 @@ async function reviewVcMeetingOutputRequest(input: {
         : '你的会中弹幕输出请求已由授权人同意并发送。').catch(() => { /* best effort */ });
       return vcMeetingOutputReviewCardForRequest(session, req, 'sentText');
     }
-    if (input.decision === 'approve_voice') {
-      if (channel !== 'voice') throw new Error('approve_voice only applies to voice requests');
+    if (input.decision === 'approve_voice' || input.decision === 'allow_voice_and_approve') {
+      if (channel !== 'voice') throw new Error('voice approval only applies to voice requests');
+      const allowFutureVoice = input.decision === 'allow_voice_and_approve';
+      if (allowFutureVoice) {
+        setVcMeetingOutputPolicyForChannel(session, 'voice', 'allow');
+        persistVcMeetingRuntimeSession(session, cfg);
+      }
       keepApplying = true;
-      void (async () => {
+      const applyVoiceApproval = async () => {
         try {
           await speakVcMeetingOutput(session, cfg, req);
           if (session.pendingOutputRequests[channel]?.id === req.id) delete session.pendingOutputRequests[channel];
           await patchVcMeetingOutputReviewCard(session, req, 'sentVoice').catch((err) => {
             logger.warn(`[vc-agent] output review card patch failed meeting=${session.state.meeting.id}: ${err instanceof Error ? err.message : String(err)}`);
           });
-          void notifyVcMeetingConsumerAgent(session, '你的语音输出请求已由授权人同意并播报。').catch(() => { /* best effort */ });
+          void notifyVcMeetingConsumerAgent(session, allowFutureVoice
+            ? '你的语音输出请求已播报；本场会议后续语音输出将自动执行，无需逐条审批。'
+            : '你的语音输出请求已由授权人同意并播报。').catch(() => { /* best effort */ });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           logger.warn(`[vc-agent] approved voice output failed meeting=${input.meetingId} request=${input.requestId}: ${message}`);
@@ -4864,7 +4883,12 @@ async function reviewVcMeetingOutputRequest(input: {
         } finally {
           req.applying = false;
         }
-      })();
+      };
+      if (allowFutureVoice) {
+        void enqueueVcMeetingOutputOperation(session, channel, applyVoiceApproval);
+      } else {
+        void applyVoiceApproval();
+      }
       return vcMeetingOutputReviewCardForRequest(session, req, 'processing');
     }
     throw new Error('unknown output decision');
@@ -5769,6 +5793,7 @@ async function handleVcMeetingCardAction(data: CardActionData, larkAppId: string
     const decision = value.decision;
     if (
       decision !== 'approve_voice'
+      && decision !== 'allow_voice_and_approve'
       && decision !== 'send_text'
       && decision !== 'allow_text_and_send'
       && decision !== 'reject'

--- a/src/vc-agent/cards.ts
+++ b/src/vc-agent/cards.ts
@@ -487,6 +487,18 @@ export function buildVcMeetingOutputReviewCard(input: VcMeetingOutputReviewCardI
               nonce: input.nonce,
             },
           },
+          {
+            tag: 'button',
+            text: { tag: 'plain_text', content: '本场自动语音' },
+            type: 'default',
+            value: {
+              action: 'vc_meeting_output_review',
+              decision: 'allow_voice_and_approve',
+              meeting_id: input.meeting.id,
+              request_id: input.requestId,
+              nonce: input.nonce,
+            },
+          },
           ...(textOutputAvailable ? [{
             tag: 'button',
             text: { tag: 'plain_text', content: '改发会中弹幕' },

--- a/test/vc-meeting-daemon-session.test.ts
+++ b/test/vc-meeting-daemon-session.test.ts
@@ -3151,6 +3151,149 @@ describe('VC meeting daemon session lifecycle', () => {
     expect(JSON.parse(patchedMessages.at(-1)!.content).header.title.content).toBe('已同意语音发言');
   });
 
+  it('can approve one voice request and allow automatic voice for the rest of the meeting', async () => {
+    registerConsumerAgentBot();
+    registerBot({
+      larkAppId: APP_ID,
+      larkAppSecret: 'secret',
+      cliId: 'claude-code',
+      vcMeetingAgent: {
+        enabled: true,
+        larkCliProfile: APP_ID,
+        attentionTargetOpenId: TARGET_OPEN_ID,
+        realtimeVoice: {
+          enabled: true,
+        },
+        meetingConsumer: {
+          enabled: true,
+          defaultMode: 'listenOnly',
+          agentCandidates: [
+            { larkAppId: AGENT_APP_ID, label: 'Claude Loopy' },
+          ],
+        },
+      },
+    });
+
+    await __vcMeetingAgentTest.handlePush({
+      larkAppId: APP_ID,
+      kind: 'meeting_invited',
+      eventType: 'vc.bot.meeting_invited_v1',
+      eventId: 'evt_invite_output_voice_allow',
+      meeting: { id: 'm_output_voice_allow', meetingNo: '343434343', topic: 'Output voice auto approval' },
+      raw: { event: { meeting: { id: 'm_output_voice_allow', meeting_no: '343434343' } } },
+    });
+    await selectConsumerAgentViaCard('Claude Loopy');
+    realtimeVoiceEvents.length = 0;
+
+    const submitted = await __vcMeetingAgentTest.submitOutput({
+      larkAppId: APP_ID,
+      meetingId: 'm_joined_343434343',
+      channel: 'voice',
+      content: '第一条语音需要审批。',
+    });
+    expect(submitted).toMatchObject({ ok: true, status: 'pending' });
+
+    const allowed = await __vcMeetingAgentTest.handleCardAction({
+      operator: { open_id: TARGET_OPEN_ID },
+      action: { value: lastInteractiveCardButton('本场自动语音') },
+    }, APP_ID);
+
+    expect(allowed.header.title.content).toBe('语音播报处理中');
+    await new Promise(resolve => setTimeout(resolve, 2));
+    expect(realtimeVoiceEvents).toContain('speak:第一条语音需要审批。');
+    expect(runtimeStoreRecords.find(record => record.meeting.id === 'm_joined_343434343')?.voiceOutputPolicy).toBe('allow');
+
+    const second = await __vcMeetingAgentTest.submitOutput({
+      larkAppId: APP_ID,
+      meetingId: 'm_joined_343434343',
+      channel: 'voice',
+      content: '第二条语音自动播报。',
+    });
+
+    expect(second).toMatchObject({ ok: true, status: 'sent' });
+    expect(realtimeVoiceEvents).toContain('speak:第二条语音自动播报。');
+  });
+
+  it('serializes automatic voice behind the initial approved voice playback', async () => {
+    registerConsumerAgentBot();
+    registerBot({
+      larkAppId: APP_ID,
+      larkAppSecret: 'secret',
+      cliId: 'claude-code',
+      vcMeetingAgent: {
+        enabled: true,
+        larkCliProfile: APP_ID,
+        attentionTargetOpenId: TARGET_OPEN_ID,
+        realtimeVoice: {
+          enabled: true,
+        },
+        meetingConsumer: {
+          enabled: true,
+          defaultMode: 'listenOnly',
+          agentCandidates: [
+            { larkAppId: AGENT_APP_ID, label: 'Claude Loopy' },
+          ],
+        },
+      },
+    });
+
+    await __vcMeetingAgentTest.handlePush({
+      larkAppId: APP_ID,
+      kind: 'meeting_invited',
+      eventType: 'vc.bot.meeting_invited_v1',
+      eventId: 'evt_invite_output_voice_allow_serial',
+      meeting: { id: 'm_output_voice_allow_serial', meetingNo: '454545454', topic: 'Output voice auto approval serial' },
+      raw: { event: { meeting: { id: 'm_output_voice_allow_serial', meeting_no: '454545454' } } },
+    });
+    await selectConsumerAgentViaCard('Claude Loopy');
+    realtimeVoiceEvents.length = 0;
+
+    const submitted = await __vcMeetingAgentTest.submitOutput({
+      larkAppId: APP_ID,
+      meetingId: 'm_joined_454545454',
+      channel: 'voice',
+      content: '第一条语音正在播报。',
+    });
+    expect(submitted).toMatchObject({ ok: true, status: 'pending' });
+
+    realtimeVoiceSpeakHolds.count = 1;
+    const allowed = await __vcMeetingAgentTest.handleCardAction({
+      operator: { open_id: TARGET_OPEN_ID },
+      action: { value: lastInteractiveCardButton('本场自动语音') },
+    }, APP_ID);
+    expect(allowed.header.title.content).toBe('语音播报处理中');
+
+    for (let i = 0; i < 20 && realtimeVoiceSpeakHolds.resolvers.length === 0; i += 1) {
+      await Promise.resolve();
+    }
+    expect(realtimeVoiceSpeakHolds.resolvers).toHaveLength(1);
+
+    let secondSettled = false;
+    const secondPromise = __vcMeetingAgentTest.submitOutput({
+      larkAppId: APP_ID,
+      meetingId: 'm_joined_454545454',
+      channel: 'voice',
+      content: '第二条语音等待串行播报。',
+    }).finally(() => {
+      secondSettled = true;
+    });
+
+    await Promise.resolve();
+    expect(secondSettled).toBe(false);
+    expect(realtimeVoiceEvents.filter(event => event.startsWith('speak:'))).toEqual([
+      'speak:第一条语音正在播报。',
+    ]);
+
+    realtimeVoiceSpeakHolds.resolvers.shift()?.();
+    const second = await secondPromise;
+
+    expect(second).toMatchObject({ ok: true, status: 'sent' });
+    expect(realtimeVoiceEvents.filter(event => event.startsWith('speak:'))).toEqual([
+      'speak:第一条语音正在播报。',
+      'speak:第二条语音等待串行播报。',
+    ]);
+  });
+
   it('merges a same-channel pending text output request into the existing review card', async () => {
     registerConsumerAgentBot();
     __vcMeetingAgentTest.setOutputTextSenderForTest(async (session, req) => {


### PR DESCRIPTION
## 背景

会议 agent 每次语音发言都需要授权人逐条审批。连续问答时操作成本较高，但直接开放全局自动语音又会扩大授权范围。

## 改动

- 在会议语音审批卡中新增「本场自动语音」操作。
- 点击后批准当前语音，并仅在当前会议运行期内将后续语音设为自动执行；会议结束后随运行会话自动失效。
- 首次批准播报和后续自动语音共用现有 voice 通道串行队列，避免同时调用同一个 RealtimeVoiceSession.speak() 导致音频帧交错。
- 普通「同意语音」仍保持单次审批与“执行中拒绝新请求”的原有语义。
- 补充自动授权持久化、后续自动播报及首条未结束时禁止并发的回归测试。

## 影响面

- 仅影响 VC meeting consumer 的语音输出审批路径。
- 队列按 larkAppId + meetingId 的会话、再按输出通道隔离；不同 bot、会议及文本输出互不影响。
- 与 Codex、Claude Code 等具体 CLI 以及 PTY/Tmux 后端无关。

## UI 预览

<img width="725" height="520" alt="会议语音审批卡新增本场自动语音按钮" src="https://github.com/user-attachments/assets/5525f475-6602-407c-9f72-77c67b168745" />

## 验证

- `pnpm vitest run --project unit test/vc-meeting-daemon-session.test.ts`：63/63 通过。
- 竞态回归：首条自动批准语音挂起时，第二条不会进入 speak；释放首条后才串行播报。
- `pnpm build`：通过。
- `pnpm test`：8100 通过、6 跳过；仅 `test/dashboard-monitoring-ui.test.ts:326` 的既有 CSS 断言失败，本分支未修改 Dashboard CSS，且该失败可独立复现。
- `git diff --check`：通过。