### PR TITLE
fix(traex): 用 task_complete 边界识别 final，修复 /adopt 兜底不回传飞书

### DIFF
--- a/src/services/codex-transcript.ts
+++ b/src/services/codex-transcript.ts
@@ -10,6 +10,9 @@
  *   - role=user             → the user's prompt text (input_text content)
  *   - role=assistant +
  *     phase=final_answer    → the model's final reply (output_text content)
+ *     (or NO phase field at all — TRAE's codex fork strips it, and some
+ *     codex builds emit phase-less finals; mid-turn commentary is always
+ *     explicitly phase=commentary, so "absent" safely means final)
  *
  * Why these and not `event_msg`:
  *   - `response_item` is the canonical transcript record; `event_msg` is a
@@ -327,7 +330,11 @@ export function drainCodexRollout(path: string, fromOffset: number): CodexDrainR
       const text = joinTextBlocks(p.content, 'input_text');
       if (!text) continue;
       events.push({ uuid: `${path}:${lineStart}`, timestampMs, kind: 'user', text });
-    } else if (p.role === 'assistant' && p.phase === 'final_answer') {
+    } else if (p.role === 'assistant' && (p.phase === 'final_answer' || p.phase == null)) {
+      // phase absent ⇒ final: TRAE (codex fork) never writes the phase
+      // field, and pre-phase codex builds also omitted it on finals.
+      // Mid-turn status is always an explicit phase=commentary, so this
+      // widening cannot surface half-finished turns.
       const text = joinTextBlocks(p.content, 'output_text');
       if (!text) continue;
       events.push({ uuid: `${path}:${lineStart}`, timestampMs, kind: 'assistant_final', text });

--- a/src/services/codex-transcript.ts
+++ b/src/services/codex-transcript.ts
@@ -10,9 +10,6 @@
  *   - role=user             → the user's prompt text (input_text content)
  *   - role=assistant +
  *     phase=final_answer    → the model's final reply (output_text content)
- *     (or NO phase field at all — TRAE's codex fork strips it, and some
- *     codex builds emit phase-less finals; mid-turn commentary is always
- *     explicitly phase=commentary, so "absent" safely means final)
  *
  * Why these and not `event_msg`:
  *   - `response_item` is the canonical transcript record; `event_msg` is a
@@ -284,10 +281,23 @@ function joinTextBlocks(content: unknown, kind: 'input_text' | 'output_text'): s
   return parts.join('');
 }
 
-/** Increment-read the rollout from `fromOffset`. Mirrors the byte-offset
- *  contract of claude-transcript.drainTranscript so callers can swap them
- *  out and reuse the existing fs.watch / poll wakeup machinery. */
-export function drainCodexRollout(path: string, fromOffset: number): CodexDrainResult {
+/** Classify one parsed rollout record into a bridge event, or undefined to
+ *  skip it. `lineStart` is the record's byte offset (for the synthetic uuid).
+ *  Codex and TRAE share the append-only JSONL container but disagree on which
+ *  record marks a final answer — see the two classifiers below. */
+type RolloutLineClassifier = (
+  obj: any,
+  lineStart: number,
+  path: string,
+) => CodexBridgeEvent | undefined;
+
+/** Increment-read the rollout from `fromOffset`, classifying each complete
+ *  line with `classify`. Mirrors the byte-offset contract of
+ *  claude-transcript.drainTranscript so callers can swap them out and reuse
+ *  the existing fs.watch / poll wakeup machinery. The container walk (offset
+ *  tracking, truncation handling, partial-tail hold-back, stable uuids) is
+ *  identical for Codex and TRAE; only the per-line classifier differs. */
+function drainRolloutLines(path: string, fromOffset: number, classify: RolloutLineClassifier): CodexDrainResult {
   if (!existsSync(path)) return { events: [], newOffset: 0, pendingTail: '' };
   let size: number;
   try { size = statSync(path).size; } catch { return { events: [], newOffset: fromOffset, pendingTail: '' }; }
@@ -321,27 +331,83 @@ export function drainCodexRollout(path: string, fromOffset: number): CodexDrainR
     cursor += lineByteLen;
     let obj: any;
     try { obj = JSON.parse(line); } catch { continue; }
-    if (obj?.type !== 'response_item') continue;
-    const p = obj.payload;
-    if (!p || typeof p !== 'object' || p.type !== 'message') continue;
-    const ts = typeof obj.timestamp === 'string' ? Date.parse(obj.timestamp) : NaN;
-    const timestampMs = Number.isFinite(ts) ? ts : Date.now();
-    if (p.role === 'user') {
-      const text = joinTextBlocks(p.content, 'input_text');
-      if (!text) continue;
-      events.push({ uuid: `${path}:${lineStart}`, timestampMs, kind: 'user', text });
-    } else if (p.role === 'assistant' && (p.phase === 'final_answer' || p.phase == null)) {
-      // phase absent ⇒ final: TRAE (codex fork) never writes the phase
-      // field, and pre-phase codex builds also omitted it on finals.
-      // Mid-turn status is always an explicit phase=commentary, so this
-      // widening cannot surface half-finished turns.
-      const text = joinTextBlocks(p.content, 'output_text');
-      if (!text) continue;
-      events.push({ uuid: `${path}:${lineStart}`, timestampMs, kind: 'assistant_final', text });
-    }
-    // Skip role=developer (instructions), phase=commentary (mid-turn
-    // status), and any reasoning / function_call* events — see file
-    // header for rationale.
+    const ev = classify(obj, lineStart, path);
+    if (ev) events.push(ev);
   }
   return { events, newOffset, pendingTail };
+}
+
+/** Codex classifier: user prompt and final answer both live in
+ *  `response_item.payload.type === 'message'`. The final answer is the
+ *  assistant message explicitly tagged `phase=final_answer`; mid-turn status
+ *  is `phase=commentary` and is skipped. role=developer (instructions),
+ *  reasoning, and function_call* are ignored — see file header. */
+function classifyCodexLine(obj: any, lineStart: number, path: string): CodexBridgeEvent | undefined {
+  if (obj?.type !== 'response_item') return undefined;
+  const p = obj.payload;
+  if (!p || typeof p !== 'object' || p.type !== 'message') return undefined;
+  const ts = typeof obj.timestamp === 'string' ? Date.parse(obj.timestamp) : NaN;
+  const timestampMs = Number.isFinite(ts) ? ts : Date.now();
+  if (p.role === 'user') {
+    const text = joinTextBlocks(p.content, 'input_text');
+    if (!text) return undefined;
+    return { uuid: `${path}:${lineStart}`, timestampMs, kind: 'user', text };
+  }
+  if (p.role === 'assistant' && p.phase === 'final_answer') {
+    const text = joinTextBlocks(p.content, 'output_text');
+    if (!text) return undefined;
+    return { uuid: `${path}:${lineStart}`, timestampMs, kind: 'assistant_final', text };
+  }
+  return undefined;
+}
+
+/** Increment-read a Codex rollout. See drainRolloutLines / classifyCodexLine. */
+export function drainCodexRollout(path: string, fromOffset: number): CodexDrainResult {
+  return drainRolloutLines(path, fromOffset, classifyCodexLine);
+}
+
+/** TRAE classifier: TRAE's codex fork writes assistant `response_item`
+ *  messages with NO `phase` field, and it emits one for every mid-turn step
+ *  before a tool call — 791 of 831 assistant messages in a real-machine
+ *  scan were followed by a function_call, i.e. were NOT final. So the Codex
+ *  rule (assistant message ⇒ final) would fire on mid-turn commentary and
+ *  close the bridge turn early, orphaning the true answer.
+ *
+ *  The reliable per-turn boundary is instead `event_msg` with
+ *  `payload.type === 'task_complete'`: TRAE writes exactly one at the end of
+ *  each turn, carrying the final text verbatim in `last_agent_message` (48
+ *  genuine completions vs 831 ambiguous assistant messages in that same
+ *  scan). We take the final answer from there and skip the assistant
+ *  `response_item` messages entirely. User prompts still come from
+ *  `response_item` (identical shape to Codex).
+ *
+ *  A `task_complete` with an empty/null `last_agent_message` marks a turn
+ *  that produced no textual answer (e.g. turn_aborted) — skipped, matching
+ *  the Codex behaviour of never emitting empty finals. */
+function classifyTraexLine(obj: any, lineStart: number, path: string): CodexBridgeEvent | undefined {
+  const ts = typeof obj?.timestamp === 'string' ? Date.parse(obj.timestamp) : NaN;
+  const timestampMs = Number.isFinite(ts) ? ts : Date.now();
+  const p = obj?.payload;
+  if (obj?.type === 'response_item') {
+    if (!p || typeof p !== 'object' || p.type !== 'message') return undefined;
+    if (p.role === 'user') {
+      const text = joinTextBlocks(p.content, 'input_text');
+      if (!text) return undefined;
+      return { uuid: `${path}:${lineStart}`, timestampMs, kind: 'user', text };
+    }
+    // assistant / developer response_item messages are mid-turn or system —
+    // finals come from task_complete below.
+    return undefined;
+  }
+  if (obj?.type === 'event_msg' && p && typeof p === 'object' && p.type === 'task_complete') {
+    const text = typeof p.last_agent_message === 'string' ? p.last_agent_message : '';
+    if (!text) return undefined;
+    return { uuid: `${path}:${lineStart}`, timestampMs, kind: 'assistant_final', text };
+  }
+  return undefined;
+}
+
+/** Increment-read a TRAE rollout. See drainRolloutLines / classifyTraexLine. */
+export function drainTraexRollout(path: string, fromOffset: number): CodexDrainResult {
+  return drainRolloutLines(path, fromOffset, classifyTraexLine);
 }

--- a/src/services/traex-transcript.ts
+++ b/src/services/traex-transcript.ts
@@ -2,21 +2,28 @@
  * Reader for TRAE CLI (traex / traecli) per-session rollout JSONL.
  *
  * TRAE is a Codex-family CLI:
- *   - Rollout content format is byte-identical to Codex (response_item with
- *     role=user / role=assistant+phase=final_answer message blocks).
+ *   - Rollout container format is byte-identical to Codex (append-only JSONL
+ *     of response_item / event_msg records). BUT the final-answer marker
+ *     differs: Codex tags its final assistant message `phase=final_answer`,
+ *     whereas TRAE's fork writes phase-less assistant messages for every
+ *     mid-turn step and only signals turn completion via an `event_msg`
+ *     `task_complete` record (final text in `last_agent_message`). The
+ *     TRAE-specific drainer therefore lives in codex-transcript.ts as
+ *     `drainTraexRollout`; do NOT re-use `drainCodexRollout` here.
  *   - Directory layout differs: sessions live under
  *     ~/.trae/cli/sessions/<YYYY>/<MM>/<DD>/rollout-<ts>-<uuid>.jsonl
  *     (note the extra `cli/` level vs Codex's ~/.codex/sessions/...).
  *
- * This module therefore re-exports drainCodexRollout and friends directly,
- * and only provides TRAE-specific path finders (by pid / by session id).
+ * This module therefore re-exports the TRAE drainer and the shared
+ * split/extract helpers, and only provides TRAE-specific path finders
+ * (by pid / by session id).
  */
 import { existsSync, statSync, readdirSync, readlinkSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { platform } from 'node:os';
 import { join } from 'node:path';
 import {
-  drainCodexRollout,
+  drainTraexRollout,
   splitCodexEventsByCutoff,
   extractLastCodexTurn,
   type CodexBridgeEvent,
@@ -25,7 +32,7 @@ import {
 } from './codex-transcript.js';
 import { traeSessionsRoot } from './traex-paths.js';
 
-export { drainCodexRollout as drainTraexRollout };
+export { drainTraexRollout };
 export { splitCodexEventsByCutoff as splitTraexEventsByCutoff };
 export { extractLastCodexTurn as extractLastTraexTurn };
 export type { CodexBridgeEvent as TraexBridgeEvent, CodexDrainResult as TraexDrainResult };

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -63,7 +63,7 @@ import {
 } from './services/bridge-rotation-policy.js';
 import { CodexBridgeQueue } from './services/codex-bridge-queue.js';
 import { codexSessionIdFromRolloutPath, drainCodexRollout, findCodexRolloutBySessionId, findCodexRolloutByPid, splitCodexEventsByCutoff, extractLastCodexTurn, type CodexBridgeEvent } from './services/codex-transcript.js';
-import { findTraexRolloutBySessionId, findTraexRolloutByPid } from './services/traex-transcript.js';
+import { findTraexRolloutBySessionId, findTraexRolloutByPid, drainTraexRollout } from './services/traex-transcript.js';
 import { cocoEventsPathForSession, drainCocoEvents, findCocoSessionByPid } from './services/coco-transcript.js';
 import { currentHermesStateOffset, drainHermesStateDb, resolveHermesStateDbPath } from './services/hermes-transcript.js';
 import { filterHermesEventsForBotmuxSession } from './services/hermes-session-filter.js';
@@ -1968,10 +1968,16 @@ function codexBridgeFallbackActive(): boolean {
   return isStructuredBridgeFallbackActive(lastInitConfig?.cliId, lastInitConfig?.adoptMode === true);
 }
 
-// Both Codex and TRAE share the same rollout JSONL layout (response_item
-// messages), so drainCodexRollout works for both.
+// Codex and TRAE share the same rollout JSONL container, but TRAE marks its
+// final answer differently (event_msg/task_complete rather than an assistant
+// message with phase=final_answer), so each has its own drainer. The rest of
+// the bridge machinery (queue, gate, split/absorb) is shared.
 function structuredBridgeIsCodex(): boolean {
   return lastInitConfig?.cliId === 'codex' || lastInitConfig?.cliId === 'traex';
+}
+
+function structuredBridgeIsTraex(): boolean {
+  return lastInitConfig?.cliId === 'traex';
 }
 
 function structuredBridgeIsHermes(): boolean {
@@ -1999,6 +2005,7 @@ function currentHermesBridgeDbPath(): string {
 }
 
 function structuredBridgeIngestPath(path: string, offset: number) {
+  if (structuredBridgeIsTraex()) return drainTraexRollout(path, offset);
   if (structuredBridgeIsCodex()) return drainCodexRollout(path, offset);
   if (codexBridgeIsCursor()) return drainCursorTranscript(path, offset);
   if (structuredBridgeIsPi()) return drainPiTranscript(path, offset);

--- a/test/codex-transcript.test.ts
+++ b/test/codex-transcript.test.ts
@@ -267,6 +267,27 @@ describe('drainCodexRollout', () => {
     expect(r.events[0].text).toBe('done');
   });
 
+  it('treats phase-less assistant message as final (TRAE fork / pre-phase codex)', () => {
+    // TRAE 的 rollout 与 codex 同构，但 assistant message 完全不写 phase 字段
+    // （payload 只有 content/role/type）。此前按 phase === 'final_answer' 硬匹配
+    // 会让 TRAE 的兜底永远不触发（adopt 后模型回复从不回传飞书）。
+    writeFileSync(path,
+      ev(userResponseItem('给我打个招呼')) +
+      ev({
+        timestamp: '2026-07-14T17:11:24.582Z',
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: '你好！有什么可以帮你的吗？' }],
+        },
+      }));
+    const r = drainCodexRollout(path, 0);
+    expect(r.events).toHaveLength(2);
+    expect(r.events[1].kind).toBe('assistant_final');
+    expect(r.events[1].text).toBe('你好！有什么可以帮你的吗？');
+  });
+
   it('skips reasoning / function_call / function_call_output / event_msg', () => {
     writeFileSync(path,
       ev({ type: 'response_item', payload: { type: 'reasoning' } }) +

--- a/test/codex-transcript.test.ts
+++ b/test/codex-transcript.test.ts
@@ -267,25 +267,25 @@ describe('drainCodexRollout', () => {
     expect(r.events[0].text).toBe('done');
   });
 
-  it('treats phase-less assistant message as final (TRAE fork / pre-phase codex)', () => {
-    // TRAE 的 rollout 与 codex 同构，但 assistant message 完全不写 phase 字段
-    // （payload 只有 content/role/type）。此前按 phase === 'final_answer' 硬匹配
-    // 会让 TRAE 的兜底永远不触发（adopt 后模型回复从不回传飞书）。
+  it('skips assistant message with NO phase field (mid-turn; not a codex final)', () => {
+    // Guards the codex predicate against over-widening: a phase-less
+    // assistant message is NOT a codex final. TRAE emits these for every
+    // mid-turn step; treating them as final would close the bridge turn
+    // early and orphan the real answer. Codex finals are always tagged
+    // phase=final_answer, so the codex drainer must ignore phase-less ones.
     writeFileSync(path,
-      ev(userResponseItem('给我打个招呼')) +
+      ev(userResponseItem('hi')) +
       ev({
-        timestamp: '2026-07-14T17:11:24.582Z',
         type: 'response_item',
         payload: {
           type: 'message',
           role: 'assistant',
-          content: [{ type: 'output_text', text: '你好！有什么可以帮你的吗？' }],
+          content: [{ type: 'output_text', text: 'mid-turn note before a tool call' }],
         },
       }));
     const r = drainCodexRollout(path, 0);
-    expect(r.events).toHaveLength(2);
-    expect(r.events[1].kind).toBe('assistant_final');
-    expect(r.events[1].text).toBe('你好！有什么可以帮你的吗？');
+    expect(r.events).toHaveLength(1);
+    expect(r.events[0].kind).toBe('user');
   });
 
   it('skips reasoning / function_call / function_call_output / event_msg', () => {

--- a/test/traex-transcript.test.ts
+++ b/test/traex-transcript.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, appendFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { drainTraexRollout } from '../src/services/traex-transcript.js';
+
+let dir: string;
+let path: string;
+
+function ev(obj: any): string {
+  return JSON.stringify(obj) + '\n';
+}
+
+// TRAE user prompts share Codex's response_item/message shape.
+function userResponseItem(text: string, ts = '2026-07-14T17:11:00.000Z') {
+  return {
+    timestamp: ts,
+    type: 'response_item',
+    payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text }] },
+  };
+}
+
+// TRAE assistant messages are written WITHOUT a phase field, one per mid-turn
+// step (commentary before a tool call as well as the final utterance). They
+// are indistinguishable from each other in the response_item stream, so the
+// drainer must NOT key finals off them.
+function assistantMessage(text: string, ts = '2026-07-14T17:11:01.000Z') {
+  return {
+    timestamp: ts,
+    type: 'response_item',
+    payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text }] },
+  };
+}
+
+function functionCall(name = 'shell', ts = '2026-07-14T17:11:02.000Z') {
+  return { timestamp: ts, type: 'response_item', payload: { type: 'function_call', name } };
+}
+
+// The real per-turn completion boundary: exactly one task_complete event_msg
+// per turn, carrying the final text verbatim in last_agent_message.
+function taskComplete(lastAgentMessage: string | null, ts = '2026-07-14T17:11:03.000Z') {
+  return {
+    timestamp: ts,
+    type: 'event_msg',
+    payload: { type: 'task_complete', turn_id: 'turn-1', last_agent_message: lastAgentMessage, completed_at: 1, duration_ms: 1 },
+  };
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'traex-transcript-'));
+  path = join(dir, 'rollout.jsonl');
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('drainTraexRollout', () => {
+  it('takes the final answer from task_complete, not the assistant message', () => {
+    // Real-shape simple turn: user prompt → phase-less assistant reply →
+    // task_complete echoing the same text. Only ONE assistant_final, sourced
+    // from task_complete.
+    writeFileSync(path,
+      ev(userResponseItem('给我打个招呼')) +
+      ev(assistantMessage('你好！有什么可以帮你的吗？')) +
+      ev(taskComplete('你好！有什么可以帮你的吗？')));
+    const r = drainTraexRollout(path, 0);
+    expect(r.events).toHaveLength(2);
+    expect(r.events[0].kind).toBe('user');
+    expect(r.events[0].text).toBe('给我打个招呼');
+    expect(r.events[1].kind).toBe('assistant_final');
+    expect(r.events[1].text).toBe('你好！有什么可以帮你的吗？');
+  });
+
+  it('does NOT emit mid-turn assistant messages that precede tool calls', () => {
+    // The core bug this fix targets: a tool-using turn emits several phase-less
+    // assistant messages (each followed by a function_call) before the real
+    // answer. Only the terminal task_complete must close the turn — the mid-
+    // turn "我先查一下…" must never surface as assistant_final.
+    writeFileSync(path,
+      ev(userResponseItem('查一下再回答')) +
+      ev(assistantMessage('我先查一下……')) +
+      ev(functionCall('shell')) +
+      ev(assistantMessage('还需要再看一个文件……')) +
+      ev(functionCall('shell')) +
+      ev(assistantMessage('查完了，答案是 42。')) +
+      ev(taskComplete('查完了，答案是 42。')));
+    const r = drainTraexRollout(path, 0);
+    // 1 user + exactly 1 final; the two mid-turn notes are dropped.
+    expect(r.events.filter(e => e.kind === 'assistant_final')).toHaveLength(1);
+    expect(r.events.find(e => e.kind === 'assistant_final')!.text).toBe('查完了，答案是 42。');
+    // No mid-turn note leaked through.
+    expect(r.events.some(e => e.text === '我先查一下……')).toBe(false);
+    expect(r.events.some(e => e.text === '还需要再看一个文件……')).toBe(false);
+  });
+
+  it('one final per turn across multiple turns', () => {
+    writeFileSync(path,
+      ev(userResponseItem('第一个问题')) +
+      ev(assistantMessage('中途…')) +
+      ev(functionCall()) +
+      ev(assistantMessage('答案一')) +
+      ev(taskComplete('答案一', '2026-07-14T17:11:05.000Z')) +
+      ev(userResponseItem('第二个问题', '2026-07-14T17:12:00.000Z')) +
+      ev(assistantMessage('答案二', '2026-07-14T17:12:01.000Z')) +
+      ev(taskComplete('答案二', '2026-07-14T17:12:02.000Z')));
+    const r = drainTraexRollout(path, 0);
+    const finals = r.events.filter(e => e.kind === 'assistant_final').map(e => e.text);
+    expect(finals).toEqual(['答案一', '答案二']);
+    const users = r.events.filter(e => e.kind === 'user').map(e => e.text);
+    expect(users).toEqual(['第一个问题', '第二个问题']);
+  });
+
+  it('skips task_complete with empty / null last_agent_message (aborted / no-text turn)', () => {
+    writeFileSync(path,
+      ev(userResponseItem('start')) +
+      ev(taskComplete(null)) +
+      ev(userResponseItem('again', '2026-07-14T17:11:10.000Z')) +
+      ev(taskComplete('')));
+    const r = drainTraexRollout(path, 0);
+    expect(r.events.filter(e => e.kind === 'assistant_final')).toHaveLength(0);
+    expect(r.events.filter(e => e.kind === 'user')).toHaveLength(2);
+  });
+
+  it('incrementally drains an appended turn (mid-turn note then final)', () => {
+    // Mirrors live split-live drain: attach mid-turn, then the tool call and
+    // task_complete arrive later. The re-drain from newOffset must not double
+    // count and must surface the final exactly once.
+    writeFileSync(path,
+      ev(userResponseItem('增量问题')) +
+      ev(assistantMessage('我先查一下……')));
+    const r1 = drainTraexRollout(path, 0);
+    expect(r1.events.filter(e => e.kind === 'assistant_final')).toHaveLength(0);
+    expect(r1.events.filter(e => e.kind === 'user')).toHaveLength(1);
+    appendFileSync(path,
+      ev(functionCall()) +
+      ev(assistantMessage('查完了。')) +
+      ev(taskComplete('查完了。')));
+    const r2 = drainTraexRollout(path, r1.newOffset);
+    expect(r2.events).toHaveLength(1);
+    expect(r2.events[0].kind).toBe('assistant_final');
+    expect(r2.events[0].text).toBe('查完了。');
+  });
+
+  it('uuid encodes path:byteStart and is stable across re-drains', () => {
+    writeFileSync(path,
+      ev(userResponseItem('u')) +
+      ev(assistantMessage('mid')) +
+      ev(taskComplete('final')));
+    const r = drainTraexRollout(path, 0);
+    expect(r.events[0].uuid).toMatch(/^.+\.jsonl:0$/);
+    const r2 = drainTraexRollout(path, 0);
+    expect(r2.events.map(e => e.uuid)).toEqual(r.events.map(e => e.uuid));
+  });
+});


### PR DESCRIPTION
## 问题

申晗在飞书实测：traex 会话 `/adopt` 接入后，TRAE 在终端里的回复没有像 codex 一样兜底自动发回飞书话题。

## 根因（live 日志 + 磁盘 rollout 全量扫描）

事发会话 `019f619b`（daemon 日志）显示 bridge 一切正常：split-live 成功 attach 到正确的 rollout 文件，用户消息「给我打个招呼」成功提交，TRAE 在终端完成回复，rollout 被追加——但之后**零 emit**，回复从未回传飞书。

真正的差异在 rollout 事件格式：

- **codex**：assistant `response_item` 消息带 `phase` 字段（`commentary`=中途 / `final_answer`=最终）。`drainCodexRollout` 硬匹配 `phase === 'final_answer'` 识别 final。
- **TRAE 0.200.17**：assistant 消息**完全不写 `phase` 字段**（本机 50 个 rollout 831 条 assistant 全部无 phase），导致 codex 判定永远不命中 → CodexBridgeQueue 的 turn 永不闭合，兜底永不触发。

## 为什么不能简单放宽成「无 phase = final」

第一版曾把判定放宽为 `phase === 'final_answer' || phase == null`。复核（感谢 @-codex）发现前提不成立：

- 831 条无 phase assistant 中，**791 条后面紧跟 `function_call`**，即「工具调用前的中途说明」，并非 final。
- 真正的完成边界只有 **48 个 `event_msg/task_complete`**。

「无 phase = final」会把每条中途说明判成 `assistant_final`，turn 提前闭合并触发 idle，真正答案随后变 orphan → 工具型任务必然误发半截回复。故此路不通。

## 修复：TRAE 用 task_complete 边界识别 final

1. **还原** `drainCodexRollout` 的 codex 判定（仍严格 `phase === 'final_answer'`），codex 行为零变化。
2. 抽出共享的字节游标 walker `drainRolloutLines(path, offset, classify)`——codex/traex 复用同一套 offset / 截断 / pendingTail / 稳定 uuid 逻辑，只把「每行如何归类」下沉到各自 classifier。
3. 新增 TRAE 专用 `drainTraexRollout`：
   - user 仍取自 `response_item`（与 codex 同构）
   - **final 改取自 `event_msg/task_complete.last_agent_message`**（每 turn 恰一个，携带 final 原文）；`last_agent_message` 空/null（turn_aborted 等）跳过
   - assistant `response_item` 消息一律不作为 final
4. worker `structuredBridgeIngestPath` 对 traex 路由到 `drainTraexRollout`（traex 优先于 codex 分支）；`traex-transcript` 不再 re-export `drainCodexRollout`。

## 影响面

- 动的共用路径已拆分：codex 仍走 `drainCodexRollout`（判定未变），traex 走新的 `drainTraexRollout`，两者只共用无状态的字节 walker。其它 CLI（coco/cursor/pi/grok/hermes/mtr）各有独立 drainer，不受影响。
- 会话类型：adopt（事发场景）与普通 spawn/resume 的兜底 harvest 都经唯一入口 `structuredBridgeIngestPath` 走到新 drainer。
- 跨平台：纯 JSON 解析逻辑，无平台差异。

## 测试验证

- `tsc --noEmit` ✅
- `test/codex-transcript.test.ts` 30 绿（含新增回归：无 phase 的 assistant 消息**不**被 codex 判成 final）
- 新增 `test/traex-transcript.test.ts` 6 绿：中途说明 + function_call 穿插 → 只出 1 个 final / 一 turn 一 final / 空 `last_agent_message` 跳过 / 增量 drain / 稳定 uuid
- bridge 全家桶回归：codex-bridge-queue、bridge-fallback-gate、bridge-final-output-retry、bridge-input、bridge-rotation-policy、bridge-turn-queue、structured-bridge-clis、adopt-route、session-adopt → **180 绿**
- **真实数据端到端**：对本机 50 个 TRAE rollout 跑 `drainTraexRollout`，emit 的 `assistant_final` 数 = 非空 `task_complete` 数（**38 == 38**），逐文件零 mismatch（旧「无 phase=final」逻辑会误 emit 831）；事发会话 `019f619b` 的「给我打个招呼」turn 精确提取出 final 原文。

## 部署提示

合并后需在 canonical checkout `git pull && pnpm build && botmux restart` 才对 live 的 traex bot 生效。