### PR TITLE
fix(mir): 默认关闭 --lean 并修正桥接工具 cwd 指引，修复本地 MCP 工具不暴露

### DIFF
--- a/src/adapters/cli/mir.ts
+++ b/src/adapters/cli/mir.ts
@@ -9,7 +9,7 @@ import { resolveCommand } from './registry.js';
  * Mir CLI (mircli) adapter — drives the local `mircli` in non-interactive Print
  * Mode through a small Node runner (src/mir-runner.ts), mirroring the `mira`
  * (Mira App / Web API) adapter's runner shape. See mir-runner.ts for why Print
- * Mode (`mircli -p --lean`) is used instead of driving the interactive TUI.
+ * Mode (`mircli -p`) is used instead of driving the interactive TUI.
  *
  * Distinct from the `mira` adapter:
  *   - `mira` → Mira Web API (cloud orchestration + remote sandbox; chat/search).

--- a/src/mir-local-runtime.ts
+++ b/src/mir-local-runtime.ts
@@ -1,4 +1,4 @@
-// Local-runtime helpers for the mir adapter (driving local mircli -p --lean).
+// Local-runtime helpers for the mir adapter (driving local mircli -p).
 // Adapted from shunminli (李舜民)'s PR #245 (src/mira-local-runtime.ts) — credit to author.
 // Folded into the `mir` adapter per Plan A (mira stays Web API, mir = local mircli).
 import { spawn, spawnSync } from 'node:child_process';

--- a/src/mir-runner.ts
+++ b/src/mir-runner.ts
@@ -5,7 +5,7 @@
  * Unlike the interactive PTY adapters, `mir` drives mircli through its
  * non-interactive Print Mode: each botmux turn spawns
  *
- *     mircli -p <content> --lean --output-format text --session-id <sid> -y \
+ *     mircli -p <content> --output-format text --session-id <sid> -y \
  *            --append-system-prompt <local-runtime-context>
  *
  * in the botmux workspace cwd, captures stdout, and ships it back to the daemon
@@ -52,7 +52,7 @@ const MARKER_PREFIX = '::botmux-mir:';
 // Backend Claude-harness builtin tools that route to the cloud sandbox; mircli's
 // own local tools are the lowercase equivalents. Optionally hard-disallow these
 // (MIRCLI_DISALLOW_BUILTIN=1) to push the model onto the local tools. Off by
-// default — the validated path relies on --lean + the local MCP bridge.
+// default — the validated path relies on the full tool_list + local MCP bridge.
 const BUILTIN_SANDBOX_TOOLS = ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep'];
 
 function parseArgs(argv: string[]): Args {
@@ -149,9 +149,15 @@ function runtimeSystemPrompt(): string {
     'BotMux invokes you in a non-interactive message bridge. NEVER emit ```ask_user_call``` or ```ask_user_form_call``` fences for local path, permission, or environment issues.',
     'If the target path is not obvious, use the actual local runtime cwd above. Do not ask the user to choose a path when this cwd is provided.',
     'This BotMux session is not running in /home/mira/.session. Do not report /home/mira/.session as the working directory for this session.',
-    'Local filesystem, shell/bash, git, and BotMux CLI tools are available through the Mir CLI local tool bridge for this process.',
+    'Local filesystem, shell/bash, git, and BotMux CLI tools are available through the Mir CLI local tool bridge (mira_local_bash / mira_local_read_file / local_filesystem_* tools) for this process.',
     'When the user asks to create, read, list, edit, or inspect local files, run bash/shell commands, inspect git, or operate BotMux, you MUST call the local tools against the actual local cwd above.',
-    'Prefer local bash commands that operate from the current cwd with relative paths first; if an absolute physical cwd fails, retry the same operation from the current cwd and then with the local tool path alias before reporting failure.',
+    // The bridged local tools execute inside the user's miramcp bridge process,
+    // whose working directory is wherever the bridge was started — NOT this
+    // session's workspace. Relative paths therefore resolve against the wrong
+    // directory (observed live: `cat file.txt` returning empty in a workspace
+    // that clearly contained it).
+    `IMPORTANT: local tools execute in a separate bridge process whose working directory is NOT this session's cwd. NEVER rely on relative paths or an implied cwd. Prefix EVERY local bash command with \`cd ${paths.cwd} && \`, and pass absolute paths (under the actual local runtime cwd above) to every local file tool.`,
+    'If an absolute path under the actual cwd fails as outside allowed roots, retry the same operation with the local tool path alias above before reporting failure.',
     'Do not say the local MCP bridge is disconnected, that only a cloud sandbox is available, or that the operation is cancelled unless a concrete local tool invocation actually returned that error.',
     'If a local tool invocation fails, report the exact failed operation and error concisely, then stop or ask for the missing input.',
   );
@@ -206,7 +212,15 @@ class MircliClient {
         }
       }
       const args = splitEnvArgs(process.env.MIRCLI_EXTRA_ARGS);
-      if (boolEnv('MIRCLI_LEAN', true) && !args.includes('--lean') && !args.includes('--ultra')) {
+      // MIRCLI_LEAN defaults OFF: the Mira completion API only enables tools the
+      // client lists in config.tool_list (it accepts no client tool schemas), and
+      // `--lean` skips that injection entirely. Lean sessions therefore never get
+      // the LocalMcp package — mira_local_bash / local_filesystem_* via the user's
+      // miramcp bridge — leaving only the cloud-sandbox builtins, which mircli's
+      // local-only coding mode hard-blocks. Net effect: no usable local tools
+      // ("本地工具没有暴露"). Verified against mircli v2.10.0: full mode exposes
+      // mcp__proxy___<device>__mira_local_bash etc., lean mode exposes none.
+      if (boolEnv('MIRCLI_LEAN', false) && !args.includes('--lean') && !args.includes('--ultra')) {
         args.push('--lean');
       }
       args.push(

--- a/src/setup/cli-selection.ts
+++ b/src/setup/cli-selection.ts
@@ -62,7 +62,7 @@ const AIDEN_VARIANTS: ReadonlyArray<CliSelectOption> = [AIDEN_NATIVE, AIDEN_X_CL
 // ─── Mira 选项 ───────────────────────────────────────────────────────────────
 // Mira 有两种形态（都是原生 cliId，无 wrapperCli），合并成一个「Mira」二级菜单：
 //   - Mira App  → cliId `mira`：直连 Mira Web API（云端编排 + 远程沙盒，聊天/搜索）
-//   - Mir CLI   → cliId `mir` ：本地 `mircli -p --lean`（在用户机器上执行、操作工作区）
+//   - Mir CLI   → cliId `mir` ：本地 `mircli -p`（在用户机器上执行、操作工作区）
 const MIRA_APP: CliSelectOption = { key: 'mira', label: 'Mira App（Web API）', cliId: 'mira' };
 const MIRA_CLI: CliSelectOption = { key: 'mir', label: 'Mir CLI（本地 mircli）', cliId: 'mir' };
 


### PR DESCRIPTION
## 背景

飞书话题反馈：mir（Mira CLI）bot 在 botmux 里一直连不上本地 MCP，模型回复「可用的 Bash 属于远程沙箱工具，被 Mira coding mode 拦截了，本地工具（mira_local_bash / local_filesystem_*）没有暴露」；而同一台机器上 standalone 交互式 `mircli` 可以连上。

## 根因（结合 mir_tools 源码 + 实测定位）

**根因一：`--lean` 导致后端从不启用本地 MCP 工具包。**
mircli 源码（`mir_tools/cli/mircli.py`）明确：Mira completion API **不接受客户端工具 schema**，模型能调用的工具 = 后端内建 harness 工具 + `config.tool_list` 注入的工具包。`--lean` 的定义就是「不发 tool_list/skill_list」，于是 `LocalMcp` 工具包（含经 miramcp 桥接的 `mira_local_bash` / `local_filesystem_*`）从未启用；模型只剩云沙箱内建 `Bash/Read/Write/Edit/Glob/Grep`，而这些又被 mircli 的 local-only coding mode 硬拦截（`FORBIDDEN_BUILTIN_TOOL_NAMES`）→ 两头堵死，正好是用户看到的报错。botmux runner 此前默认 `MIRCLI_LEAN=true`，所以**所有** botmux mir 会话必现。

**根因二：桥接工具的 cwd 不是会话工作区。**
桥接的本地工具在用户的 miramcp 桥进程里执行，cwd 是桥启动目录（本机实测 `/root/iserver`），不是 mircli 会话 cwd。原 runner system prompt 却建议「优先用相对路径」，实测相对路径 `cat` 读到错误目录。

## 改动

- `src/mir-runner.ts`：`MIRCLI_LEAN` 默认 `true → false`（仍可 `MIRCLI_LEAN=1` 显式开回，`--ultra`/`MIRCLI_EXTRA_ARGS` 不受影响）；system prompt 改为「本地工具在独立桥进程执行、cwd 非会话工作区，每条本地 bash 必须前缀 `cd <工作区> &&`、文件工具一律绝对路径」
- `src/adapters/cli/mir.ts` / `src/mir-local-runtime.ts` / `src/setup/cli-selection.ts`：同步注释（纯注释）

## 影响面

只影响 `mir` 适配器的 runner 路径（`mir-runner.ts` 为 mir 专用，无共用代码改动）；`mira`（Web API）及其它 CLI 不受影响。代价：非 lean 模式每轮多注入 tool_list/skill_list（token 增加），换取本地工具可用——这正是 standalone 已验证的路径。

## 实测验证

- `pnpm build` 绿；`vitest run test/mir-local-runtime.test.ts test/cli-adapters.test.ts test/mira-output.test.ts` 311/311 绿
- 对照实验（本机 mircli v2.10.0，miramcp 桥在跑）：
  - `mircli --lean -p "列出你真实工具列表"` → 只有 `Bash/Read/Write/...` 云沙箱内建，**无任何 mira_local 工具**
  - 去掉 `--lean` 同问 → 拿到 `mcp__proxy___<server>__mira_local_bash`、`mira_local_read_file` 等完整本地桥接工具
- 端到端走真实 runner（`node dist/mir-runner.js` + stdin 消息）：修复后模型成功调用本地桥接工具执行 bash（不再报「工具未暴露」）

## 已知边界（非本 PR 范畴，账号级配置）

本地工具**在哪台机器执行**由 Mira 账号 web MCP 配置里那条 entry 的 `x-mira-device-id` 决定（谁的 miramcp 用该 device-id 连桥，就路由到谁）。本 daemon 机的账号当前 entry 指向 MBP（server 名 `local_MBP`），故 e2e 中命令实际落在 MBP 上执行——要访问 daemon 机文件，需在 Mira web MCP 配置把 device-id 对准本机 `~/.mira/config.json` 的 device_id。用户 devbox 场景（device-id 已对准 devbox 自己）合入后即可正常。