### PR TITLE
fix(adopt): zellij 发现对齐集合修正，floating/exited pane 不再拒绝整会话

### DIFF
--- a/src/adapters/backend/zellij-backend.ts
+++ b/src/adapters/backend/zellij-backend.ts
@@ -1,8 +1,9 @@
 import * as pty from 'node-pty';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { SessionBackend, SpawnOpts, SessionProbe } from './types.js';
 import { zellijEnv, probeZellijFunctional } from '../../setup/ensure-zellij.js';
 import { resolveUserShell, buildBotmuxEnvAssignments, SHELL_WRAPPER_SCRIPT } from './tmux-backend.js';
@@ -377,7 +378,60 @@ export function tmuxKeyToBytes(key: string): string {
  * the trailing path component of the server's socket argument, so we match the
  * cmdline ending in `/<sessionName>`.
  */
+/** A running `zellij --server <socketPath>` process. */
+export interface ZellijServerProc {
+  pid: number;
+  /** The socket path from argv — the session name AT SPAWN TIME. */
+  socketPath: string;
+}
+
+/** Parse `ps -eo pid=,args=` output into the zellij server processes. Pure. */
+export function parseZellijServerProcs(psOut: string): ZellijServerProc[] {
+  const servers: ZellijServerProc[] = [];
+  for (const line of psOut.split('\n')) {
+    const m = line.trim().match(/^(\d+)\s+(.*)$/);
+    if (!m) continue;
+    const argv = m[2]!.trim();
+    const s = argv.match(/zellij\b.*--server\s+(\S+)$/);
+    if (s) servers.push({ pid: Number(m[1]), socketPath: s[1]! });
+  }
+  return servers;
+}
+
+/**
+ * Rename-proof server lookup: `zellij action rename-session` (what the
+ * session-manager plugin drives) renames the session's SOCKET FILE, but the
+ * server's argv AND the kernel's bound-address string (/proc/net/unix) keep
+ * the spawn-time path forever (verified live on 0.44.1). So a renamed session
+ * is visible in `list-sessions` under its new name while no server argv ends
+ * with that name — the argv fast path misses and /adopt used to skip the
+ * whole session. There is no passive name→pid mapping left; instead we
+ * actively probe: connecting to the renamed socket file makes the server
+ * accept() a socket that appears in /proc/net/unix under the STALE bound
+ * path — the probe child diffs row counts across the connect and prints the
+ * revealed spawn-time path, which we match back to a server argv. Exact, no
+ * name guessing. Linux-only (/proc); on other platforms the argv fast path is
+ * the whole behavior, as before.
+ */
+function findServerPidByProbe(sessionName: string, servers: ZellijServerProc[]): number | null {
+  if (process.platform !== 'linux') return null;
+  const probeScript = fileURLToPath(new URL('./zellij-socket-probe.js', import.meta.url));
+  for (const dir of [...new Set(servers.map(s => dirname(s.socketPath)))]) {
+    const sock = join(dir, sessionName);
+    if (!existsSync(sock)) continue;
+    const r = spawnSync(process.execPath, [probeScript, sock], {
+      encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 5000,
+    });
+    if (r.status !== 0) continue;
+    const bound = (r.stdout ?? '').trim();
+    const hit = servers.find(s => s.socketPath === bound);
+    if (hit) return hit.pid;
+  }
+  return null;
+}
+
 export function findServerPid(sessionName: string): number | null {
+  let servers: ZellijServerProc[];
   try {
     const out = execFileSync('ps', ['-eo', 'pid=,args='], {
       encoding: 'utf-8',
@@ -385,16 +439,15 @@ export function findServerPid(sessionName: string): number | null {
       timeout: 3000,
       env: zellijEnv(),
     });
-    for (const line of out.split('\n')) {
-      const m = line.trim().match(/^(\d+)\s+(.*)$/);
-      if (!m) continue;
-      const argv = m[2]!;
-      if (/zellij\b.*--server\b/.test(argv) && new RegExp(`/${escapeRe(sessionName)}$`).test(argv.trim())) {
-        return Number(m[1]);
-      }
-    }
-  } catch { /* ps unavailable */ }
-  return null;
+    servers = parseZellijServerProcs(out);
+  } catch { return null; /* ps unavailable */ }
+  // Fast path: argv still ends with the session name (never renamed).
+  const suffix = new RegExp(`/${escapeRe(sessionName)}$`);
+  for (const s of servers) {
+    if (suffix.test(s.socketPath)) return s.pid;
+  }
+  // Renamed session: resolve via an active socket probe.
+  return findServerPidByProbe(sessionName, servers);
 }
 
 /**

--- a/src/adapters/backend/zellij-backend.ts
+++ b/src/adapters/backend/zellij-backend.ts
@@ -399,37 +399,27 @@ export function parseZellijServerProcs(psOut: string): ZellijServerProc[] {
 }
 
 /**
- * Rename-proof server lookup: `zellij action rename-session` (what the
- * session-manager plugin drives) renames the session's SOCKET FILE, but the
- * server's argv AND the kernel's bound-address string (/proc/net/unix) keep
- * the spawn-time path forever (verified live on 0.44.1). So a renamed session
- * is visible in `list-sessions` under its new name while no server argv ends
- * with that name — the argv fast path misses and /adopt used to skip the
- * whole session. There is no passive name→pid mapping left; instead we
- * actively probe: connecting to the renamed socket file makes the server
- * accept() a socket that appears in /proc/net/unix under the STALE bound
- * path — the probe child diffs row counts across the connect and prints the
- * revealed spawn-time path, which we match back to a server argv. Exact, no
- * name guessing. Linux-only (/proc); on other platforms the argv fast path is
- * the whole behavior, as before.
+ * Session-name → server-pid lookup, rename-proof and reuse-proof.
+ *
+ * Why there is NO argv "fast path" on Linux (Codex review, PR #468):
+ * `zellij action rename-session` (what the session-manager plugin drives)
+ * renames the session's SOCKET FILE, but the server's argv and the kernel's
+ * bound-address string (/proc/net/unix) keep the spawn-time path forever, and
+ * a freed name is REUSABLE by new spawns or other renames (verified live on
+ * 0.44.1). So ANY lookup keyed on names — argv tail, bound path, even
+ * "unique candidate + file exists" — can bind a session's name to a DIFFERENT
+ * session's server (spawn old → rename → spawn old again; or rename another
+ * session TO the freed name). Misbinding crosses sessions in adopt discovery
+ * / validation / backend pane-pid lookup, so correctness demands per-lookup
+ * causal attribution: the zellij-socket-probe child connects to the socket
+ * FILE and identifies which candidate server pid accept()ed that specific
+ * connection (see its header for the protocol). No file → session gone →
+ * null. Ambiguity → one retry → null (宁缺勿错).
+ *
+ * Non-Linux keeps the legacy argv-tail match (no /proc to attribute with);
+ * the daemon runs on Linux, and renamed/reused names were never supported
+ * there.
  */
-function findServerPidByProbe(sessionName: string, servers: ZellijServerProc[]): number | null {
-  if (process.platform !== 'linux') return null;
-  const probeScript = fileURLToPath(new URL('./zellij-socket-probe.js', import.meta.url));
-  for (const dir of [...new Set(servers.map(s => dirname(s.socketPath)))]) {
-    const sock = join(dir, sessionName);
-    if (!existsSync(sock)) continue;
-    const r = spawnSync(process.execPath, [probeScript, sock], {
-      encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 5000,
-    });
-    if (r.status !== 0) continue;
-    const bound = (r.stdout ?? '').trim();
-    const hit = servers.find(s => s.socketPath === bound);
-    if (hit) return hit.pid;
-  }
-  return null;
-}
-
 export function findServerPid(sessionName: string): number | null {
   let servers: ZellijServerProc[];
   try {
@@ -441,13 +431,33 @@ export function findServerPid(sessionName: string): number | null {
     });
     servers = parseZellijServerProcs(out);
   } catch { return null; /* ps unavailable */ }
-  // Fast path: argv still ends with the session name (never renamed).
-  const suffix = new RegExp(`/${escapeRe(sessionName)}$`);
-  for (const s of servers) {
-    if (suffix.test(s.socketPath)) return s.pid;
+  if (servers.length === 0) return null;
+
+  if (process.platform !== 'linux') {
+    const suffix = new RegExp(`/${escapeRe(sessionName)}$`);
+    return servers.find(s => suffix.test(s.socketPath))?.pid ?? null;
   }
-  // Renamed session: resolve via an active socket probe.
-  return findServerPidByProbe(sessionName, servers);
+
+  const probeScript = fileURLToPath(new URL('./zellij-socket-probe.js', import.meta.url));
+  for (const dir of [...new Set(servers.map(s => dirname(s.socketPath)))]) {
+    const sock = join(dir, sessionName);
+    if (!existsSync(sock)) continue;
+    const candidates = servers.filter(s => dirname(s.socketPath) === dir);
+    // One retry on ambiguity (exit 3): a concurrent zellij client can race a
+    // single window, but not two in a row. Hard failures don't retry.
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const r = spawnSync(process.execPath, [probeScript, sock, ...candidates.map(c => String(c.pid))], {
+        encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 8000,
+      });
+      if (r.status === 0) {
+        const pid = Number((r.stdout ?? '').trim());
+        if (candidates.some(c => c.pid === pid)) return pid;
+        break;
+      }
+      if (r.status !== 3) break;
+    }
+  }
+  return null;
 }
 
 /**

--- a/src/adapters/backend/zellij-backend.ts
+++ b/src/adapters/backend/zellij-backend.ts
@@ -443,16 +443,27 @@ export function findServerPid(sessionName: string): number | null {
     const sock = join(dir, sessionName);
     if (!existsSync(sock)) continue;
     const candidates = servers.filter(s => dirname(s.socketPath) === dir);
-    // One retry on ambiguity (exit 3): a concurrent zellij client can race a
-    // single window, but not two in a row. Hard failures don't retry.
-    for (let attempt = 0; attempt < 2; attempt++) {
+    // A single probe run can in principle still be spoofed by a pathological
+    // coincidence (target's accepts invisible in the window while ≥2 short
+    // sibling connections straddle it — Codex delta finding), so a success is
+    // only trusted once an INDEPENDENT second run attributes the same pid.
+    // Ambiguity (exit 3) is retryable — a concurrent zellij client can race
+    // one window, but the same pattern across disjoint windows is not a
+    // plausible accident. Hard failures (connect refused etc.) abort.
+    const agreed: number[] = [];
+    for (let attempt = 0; attempt < 3; attempt++) {
       const r = spawnSync(process.execPath, [probeScript, sock, ...candidates.map(c => String(c.pid))], {
         encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 8000,
       });
       if (r.status === 0) {
         const pid = Number((r.stdout ?? '').trim());
-        if (candidates.some(c => c.pid === pid)) return pid;
-        break;
+        if (!candidates.some(c => c.pid === pid)) break;
+        agreed.push(pid);
+        if (agreed.length === 2) {
+          if (agreed[0] === agreed[1]) return pid;
+          break; // two successes disagree → something is racing us → null
+        }
+        continue; // first success — run the confirmation probe
       }
       if (r.status !== 3) break;
     }

--- a/src/adapters/backend/zellij-socket-probe.ts
+++ b/src/adapters/backend/zellij-socket-probe.ts
@@ -1,0 +1,72 @@
+/**
+ * Zellij socket probe — reveal the SPAWN-TIME bound path of a (possibly
+ * renamed) zellij session socket file. Runs as a standalone child script
+ * (`node zellij-socket-probe.js <socketPath>`) so the parent's sync
+ * findServerPid can spawnSync it.
+ *
+ * Why this exists: `zellij action rename-session` (what the session-manager
+ * plugin drives) renames the session's socket FILE, but both the server's
+ * argv AND the kernel's bound-address string (/proc/net/unix Path column)
+ * keep the spawn-time path forever (verified live on 0.44.1). So there is no
+ * passive way to map "current session name" → "server process" after a
+ * rename. Actively connecting to the renamed socket file, however, makes the
+ * server accept() a new socket that shows up in /proc/net/unix under the
+ * STALE bound path — diffing per-path row counts across the connect reveals
+ * exactly which spawn-time path (= server argv) backs the renamed file.
+ *
+ * Output: the revealed bound path on stdout, exit 0. Non-zero exit on any
+ * failure (connect refused / no diff / ambiguous concurrent-connect race —
+ * callers treat all of these as "not found"). Linux-only (/proc).
+ */
+import { readFileSync } from 'node:fs';
+import { connect } from 'node:net';
+import { dirname } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/** Rows-per-bound-path under `dir` from /proc/net/unix content. Pure. */
+export function unixPathCounts(procNetUnix: string, dir: string): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const line of procNetUnix.split('\n')) {
+    const cols = line.trim().split(/\s+/);
+    if (cols.length >= 8 && cols[7]!.startsWith(`${dir}/`)) {
+      counts.set(cols[7]!, (counts.get(cols[7]!) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
+/** Paths whose row count grew from `before` to `after`. Pure. */
+export function grownPaths(before: Map<string, number>, after: Map<string, number>): string[] {
+  return [...after.entries()]
+    .filter(([path, n]) => n > (before.get(path) ?? 0))
+    .map(([path]) => path);
+}
+
+function main(socketPath: string): void {
+  const dir = dirname(socketPath);
+  const snapshot = () => unixPathCounts(readFileSync('/proc/net/unix', 'utf-8'), dir);
+  const before = snapshot();
+  const client = connect(socketPath, () => {
+    // Give the server a beat to accept() so the new row is visible.
+    setTimeout(() => {
+      const grown = grownPaths(before, snapshot());
+      client.destroy();
+      if (grown.length === 1) {
+        process.stdout.write(grown[0]!);
+        process.exit(0);
+      }
+      // 0 = server never accepted; >1 = another client connected concurrently
+      // to a sibling session (rare race) — refuse rather than guess.
+      process.exit(3);
+    }, 150);
+  });
+  client.on('error', () => process.exit(1));
+  setTimeout(() => { client.destroy(); process.exit(2); }, 3000).unref();
+}
+
+// Only run when executed directly (the pure helpers are also imported by tests).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const sock = process.argv[2];
+  if (!sock) process.exit(64);
+  main(sock);
+}

--- a/src/adapters/backend/zellij-socket-probe.ts
+++ b/src/adapters/backend/zellij-socket-probe.ts
@@ -1,72 +1,119 @@
 /**
- * Zellij socket probe — reveal the SPAWN-TIME bound path of a (possibly
- * renamed) zellij session socket file. Runs as a standalone child script
- * (`node zellij-socket-probe.js <socketPath>`) so the parent's sync
- * findServerPid can spawnSync it.
+ * Zellij socket probe — attribute a (possibly renamed) zellij session socket
+ * FILE to the server PID that owns it. Runs as a standalone child script
+ * (`node zellij-socket-probe.js <socketPath> <candidatePid>...`) so the
+ * parent's sync findServerPid can spawnSync it.
  *
  * Why this exists: `zellij action rename-session` (what the session-manager
  * plugin drives) renames the session's socket FILE, but both the server's
  * argv AND the kernel's bound-address string (/proc/net/unix Path column)
- * keep the spawn-time path forever (verified live on 0.44.1). So there is no
- * passive way to map "current session name" → "server process" after a
- * rename. Actively connecting to the renamed socket file, however, makes the
- * server accept() a new socket that shows up in /proc/net/unix under the
- * STALE bound path — diffing per-path row counts across the connect reveals
- * exactly which spawn-time path (= server argv) backs the renamed file.
+ * keep the spawn-time path forever (verified live on 0.44.1). Session names
+ * are also REUSABLE after a rename frees them, so two servers can share the
+ * same spawn-time path — any lookup keyed on names/paths (argv tail, bound
+ * path) can bind the WRONG server (Codex review findings #1/#2 on PR #468).
+ * The only sound mapping is per-connection causality, established here.
  *
- * Output: the revealed bound path on stdout, exit 0. Non-zero exit on any
- * failure (connect refused / no diff / ambiguous concurrent-connect race —
- * callers treat all of these as "not found"). Linux-only (/proc).
+ * Attribution protocol (all snapshots are of candidate servers' /proc/<pid>/fd
+ * socket inodes, filtered to inodes whose /proc/net/unix row is bound under
+ * the socket dir — i.e. accepted zellij-session sockets, not random fds):
+ *   1. snapshot BEFORE, then connect() to the socket file and HOLD;
+ *   2. after 300ms, snapshot DURING — the owner has accept()ed our connection
+ *      by now, so it gained an inode; then close our end;
+ *   3. after 150ms, snapshot FINAL — the owner's accepted socket disappears.
+ * A pid owns the file iff it gained an inode during the hold AND that inode
+ * vanished after our close (appear-during-hold ∧ vanish-after-close). A
+ * sibling server that received an unrelated connection in the window keeps it
+ * open past our close (long-lived client → excluded); an unrelated SHORT
+ * client (e.g. a concurrent `zellij action`) also appears-then-vanishes, but
+ * then TWO pids qualify → exit 3, fail-closed. The parent retries once; a
+ * repeat coincidence is practically impossible.
+ *
+ * Output: the owner PID on stdout, exit 0. Non-zero on any failure (connect
+ * refused / no owner attributable / ambiguous) — callers treat all of these
+ * as "not found" (宁缺勿错). Linux-only (/proc).
  */
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync, readlinkSync } from 'node:fs';
 import { connect } from 'node:net';
 import { dirname } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-/** Rows-per-bound-path under `dir` from /proc/net/unix content. Pure. */
-export function unixPathCounts(procNetUnix: string, dir: string): Map<string, number> {
-  const counts = new Map<string, number>();
+/** Kernel socket inodes bound under `dir` per /proc/net/unix content. Pure. */
+export function unixInodesUnderDir(procNetUnix: string, dir: string): Set<string> {
+  const inodes = new Set<string>();
   for (const line of procNetUnix.split('\n')) {
     const cols = line.trim().split(/\s+/);
-    if (cols.length >= 8 && cols[7]!.startsWith(`${dir}/`)) {
-      counts.set(cols[7]!, (counts.get(cols[7]!) ?? 0) + 1);
-    }
+    if (cols.length >= 8 && cols[7]!.startsWith(`${dir}/`)) inodes.add(cols[6]!);
   }
-  return counts;
+  return inodes;
 }
 
-/** Paths whose row count grew from `before` to `after`. Pure. */
-export function grownPaths(before: Map<string, number>, after: Map<string, number>): string[] {
-  return [...after.entries()]
-    .filter(([path, n]) => n > (before.get(path) ?? 0))
-    .map(([path]) => path);
+/** Socket inodes among fd link targets (`socket:[123]` → "123"). Pure. */
+export function socketInodesFromFdLinks(links: string[]): Set<string> {
+  const inodes = new Set<string>();
+  for (const l of links) {
+    const m = l.match(/^socket:\[(\d+)\]$/);
+    if (m) inodes.add(m[1]!);
+  }
+  return inodes;
 }
 
-function main(socketPath: string): void {
+/**
+ * The pids whose fd table gained a dir-bound socket inode between `before`
+ * and `during` that is gone again in `final` — i.e. the accept()/close()
+ * lifecycle of OUR probe connection. Pure (testable): the causal core.
+ */
+export function attributeOwners(
+  pids: number[],
+  before: Map<number, Set<string>>,
+  during: Map<number, Set<string>>,
+  final: Map<number, Set<string>>,
+  dirBoundInodes: Set<string>,
+): number[] {
+  return pids.filter(pid => {
+    const b = before.get(pid) ?? new Set();
+    const d = during.get(pid) ?? new Set();
+    const f = final.get(pid) ?? new Set();
+    return [...d].some(ino => !b.has(ino) && dirBoundInodes.has(ino) && !f.has(ino));
+  });
+}
+
+function snapFds(pid: number): Set<string> {
+  const links: string[] = [];
+  try {
+    for (const fd of readdirSync(`/proc/${pid}/fd`)) {
+      try { links.push(readlinkSync(`/proc/${pid}/fd/${fd}`)); } catch { /* fd raced away */ }
+    }
+  } catch { /* process gone or fd table not readable */ }
+  return socketInodesFromFdLinks(links);
+}
+
+function main(socketPath: string, pids: number[]): void {
   const dir = dirname(socketPath);
-  const snapshot = () => unixPathCounts(readFileSync('/proc/net/unix', 'utf-8'), dir);
-  const before = snapshot();
+  const snapAll = () => new Map(pids.map(p => [p, snapFds(p)]));
+  const before = snapAll();
   const client = connect(socketPath, () => {
-    // Give the server a beat to accept() so the new row is visible.
     setTimeout(() => {
-      const grown = grownPaths(before, snapshot());
+      const during = snapAll();
+      const bound = unixInodesUnderDir(readFileSync('/proc/net/unix', 'utf-8'), dir);
       client.destroy();
-      if (grown.length === 1) {
-        process.stdout.write(grown[0]!);
-        process.exit(0);
-      }
-      // 0 = server never accepted; >1 = another client connected concurrently
-      // to a sibling session (rare race) — refuse rather than guess.
-      process.exit(3);
-    }, 150);
+      setTimeout(() => {
+        const owners = attributeOwners(pids, before, during, snapAll(), bound);
+        if (owners.length === 1) {
+          process.stdout.write(String(owners[0]));
+          process.exit(0);
+        }
+        process.exit(3); // 0 = accept not observed; >1 = concurrent-client race
+      }, 150);
+    }, 300);
   });
   client.on('error', () => process.exit(1));
-  setTimeout(() => { client.destroy(); process.exit(2); }, 3000).unref();
+  setTimeout(() => { client.destroy(); process.exit(2); }, 5000).unref();
 }
 
 // Only run when executed directly (the pure helpers are also imported by tests).
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const sock = process.argv[2];
-  if (!sock) process.exit(64);
-  main(sock);
+  const pids = process.argv.slice(3).map(Number).filter(n => Number.isInteger(n) && n > 0);
+  if (!sock || pids.length === 0) process.exit(64);
+  main(sock, pids);
 }

--- a/src/adapters/backend/zellij-socket-probe.ts
+++ b/src/adapters/backend/zellij-socket-probe.ts
@@ -16,17 +16,30 @@
  * Attribution protocol (all snapshots are of candidate servers' /proc/<pid>/fd
  * socket inodes, filtered to inodes whose /proc/net/unix row is bound under
  * the socket dir — i.e. accepted zellij-session sockets, not random fds):
- *   1. snapshot BEFORE, then connect() to the socket file and HOLD;
- *   2. after 300ms, snapshot DURING — the owner has accept()ed our connection
- *      by now, so it gained an inode; then close our end;
- *   3. after 150ms, snapshot FINAL — the owner's accepted socket disappears.
- * A pid owns the file iff it gained an inode during the hold AND that inode
- * vanished after our close (appear-during-hold ∧ vanish-after-close). A
- * sibling server that received an unrelated connection in the window keeps it
- * open past our close (long-lived client → excluded); an unrelated SHORT
- * client (e.g. a concurrent `zellij action`) also appears-then-vanishes, but
- * then TWO pids qualify → exit 3, fail-closed. The parent retries once; a
- * repeat coincidence is practically impossible.
+ *   1. snapshot BEFORE, then open CONNECTIONS (2 of them) to the socket file
+ *      and HOLD both;
+ *   2. after 300ms, snapshot DURING — the owner has accept()ed our
+ *      connections by now, gaining CONNECTIONS inodes; then close our ends;
+ *   3. after 150ms, snapshot FINAL — the owner's accepted sockets disappear.
+ * A pid owns the file iff it gained AT LEAST `CONNECTIONS` dir-bound inodes
+ * during the hold that all vanished after our close. Why ≥2 and not ≥1
+ * (Codex delta finding on d12cb049): with a single connection, a stray SHORT
+ * client hitting a sibling inside the window is observationally identical to
+ * our own accept — if the target's accept is also slow (invisible in DURING),
+ * the sibling becomes the sole "owner" and a single-connection probe
+ * misattributes instead of failing closed. Requiring the full connection
+ * COUNT means one stray sibling connection can never qualify; mimicry now
+ * needs ≥2 shorts to the same sibling inside one window. ≥ (not ==) keeps
+ * the target attributable when extra短 clients (e.g. concurrent discovery's
+ * own `zellij action` calls) also hit it during the window. A long-lived
+ * sibling client never qualifies (doesn't vanish). Multiple qualifiers →
+ * exit 3, fail-closed.
+ *
+ * The residual coincidence (≥2 shorts to one sibling in-window while the
+ * target stays slow) is squashed by the PARENT: a successful attribution is
+ * only trusted after an independent second probe agrees on the same pid
+ * (see findServerPid) — the pattern would have to repeat across two
+ * disjoint windows.
  *
  * Output: the owner PID on stdout, exit 0. Non-zero on any failure (connect
  * refused / no owner attributable / ambiguous) — callers treat all of these
@@ -57,10 +70,18 @@ export function socketInodesFromFdLinks(links: string[]): Set<string> {
   return inodes;
 }
 
+/** How many simultaneous connections one probe run opens (and therefore the
+ *  minimum appear∧vanish inode count a candidate must show to qualify). */
+export const PROBE_CONNECTIONS = 2;
+
 /**
- * The pids whose fd table gained a dir-bound socket inode between `before`
- * and `during` that is gone again in `final` — i.e. the accept()/close()
- * lifecycle of OUR probe connection. Pure (testable): the causal core.
+ * The pids whose fd table gained AT LEAST `minCount` dir-bound socket inodes
+ * between `before` and `during` that are gone again in `final` — i.e. the
+ * accept()/close() lifecycle of OUR probe connections. Pure (testable): the
+ * causal core. `minCount` must equal the number of connections the probe
+ * opened: a single stray short-lived sibling connection then can never
+ * qualify on its own (the Codex combo finding — target accept slow + one
+ * sibling short in-window — yields zero candidates, fail-closed).
  */
 export function attributeOwners(
   pids: number[],
@@ -68,12 +89,14 @@ export function attributeOwners(
   during: Map<number, Set<string>>,
   final: Map<number, Set<string>>,
   dirBoundInodes: Set<string>,
+  minCount: number,
 ): number[] {
   return pids.filter(pid => {
     const b = before.get(pid) ?? new Set();
     const d = during.get(pid) ?? new Set();
     const f = final.get(pid) ?? new Set();
-    return [...d].some(ino => !b.has(ino) && dirBoundInodes.has(ino) && !f.has(ino));
+    const gainedThenVanished = [...d].filter(ino => !b.has(ino) && dirBoundInodes.has(ino) && !f.has(ino));
+    return gainedThenVanished.length >= minCount;
   });
 }
 
@@ -91,23 +114,31 @@ function main(socketPath: string, pids: number[]): void {
   const dir = dirname(socketPath);
   const snapAll = () => new Map(pids.map(p => [p, snapFds(p)]));
   const before = snapAll();
-  const client = connect(socketPath, () => {
-    setTimeout(() => {
-      const during = snapAll();
-      const bound = unixInodesUnderDir(readFileSync('/proc/net/unix', 'utf-8'), dir);
-      client.destroy();
+  const clients = Array.from({ length: PROBE_CONNECTIONS }, () => connect(socketPath));
+  const destroyAll = () => { for (const c of clients) c.destroy(); };
+  let connected = 0;
+  for (const c of clients) {
+    c.on('error', () => { destroyAll(); process.exit(1); });
+    c.on('connect', () => {
+      connected++;
+      if (connected < clients.length) return;
+      // All connections up — give the server a beat to accept() every one.
       setTimeout(() => {
-        const owners = attributeOwners(pids, before, during, snapAll(), bound);
-        if (owners.length === 1) {
-          process.stdout.write(String(owners[0]));
-          process.exit(0);
-        }
-        process.exit(3); // 0 = accept not observed; >1 = concurrent-client race
-      }, 150);
-    }, 300);
-  });
-  client.on('error', () => process.exit(1));
-  setTimeout(() => { client.destroy(); process.exit(2); }, 5000).unref();
+        const during = snapAll();
+        const bound = unixInodesUnderDir(readFileSync('/proc/net/unix', 'utf-8'), dir);
+        destroyAll();
+        setTimeout(() => {
+          const owners = attributeOwners(pids, before, during, snapAll(), bound, PROBE_CONNECTIONS);
+          if (owners.length === 1) {
+            process.stdout.write(String(owners[0]));
+            process.exit(0);
+          }
+          process.exit(3); // 0 = accepts not (all) observed; >1 = concurrent-client race
+        }, 150);
+      }, 300);
+    });
+  }
+  setTimeout(() => { destroyAll(); process.exit(2); }, 5000).unref();
 }
 
 // Only run when executed directly (the pure helpers are also imported by tests).

--- a/src/core/zellij-adopt-discovery.ts
+++ b/src/core/zellij-adopt-discovery.ts
@@ -24,7 +24,7 @@ import { findCocoSessionByPid } from '../services/coco-transcript.js';
 import { findTraexRolloutByPid } from '../services/traex-transcript.js';
 import { findServerPid } from '../adapters/backend/zellij-backend.js';
 import {
-  listLiveSessions, parseListPanesJson,
+  listLiveSessions, parseListPanesJson, type ListedPane,
 } from './zellij-session-discovery.js';
 import { zellijEnv } from '../setup/ensure-zellij.js';
 import { logger } from '../utils/logger.js';
@@ -136,6 +136,27 @@ function paneNum(paneId: string): number {
   return m ? Number(m[1]) : 0;
 }
 
+/**
+ * The pane set used for the positional pane↔pid alignment: every terminal pane
+ * that has a LIVE process behind it, sorted by pane id (= creation order).
+ *
+ * This must mirror exactly what `paneShellChildren` counts on the process side,
+ * or the count guard refuses the whole session. Two states used to break that
+ * invariant (both reproduced live — the "/adopt finds nothing" bug):
+ *  - FLOATING terminal panes have a pane shell like any tiled pane, so they
+ *    MUST be included (they were filtered out, leaving an extra child).
+ *  - EXITED held panes (`zellij run` command finished, pane kept for re-run)
+ *    have NO process left, so they must be excluded (they added a terminal
+ *    with no matching child).
+ * Floating panes are also perfectly adoptable — every drive/dump action takes
+ * an explicit --pane-id — so they stay in the results too.
+ */
+export function alignmentPanes(listed: ListedPane[]): ListedPane[] {
+  return listed
+    .filter(p => !p.isPlugin && !p.exited)
+    .sort((a, b) => paneNum(a.paneId) - paneNum(b.paneId));
+}
+
 /** Live pane dimensions (content area) for a paneId in a session. */
 function paneDimensions(session: string, paneId: string): { cols: number; rows: number } | undefined {
   try {
@@ -187,9 +208,7 @@ export function discoverAdoptableZellijSessions(filterCliId?: CliId): ZellijAdop
 
     const panesOut = zellijRead(session, ['list-panes', '--json']);
     if (!panesOut) continue;
-    const terminals = parseListPanesJson(panesOut)
-      .filter(p => !p.isPlugin && !p.isFloating)
-      .sort((a, b) => paneNum(a.paneId) - paneNum(b.paneId));
+    const terminals = alignmentPanes(parseListPanesJson(panesOut));
     if (terminals.length === 0) continue;
 
     const serverPid = findServerPid(session);
@@ -208,7 +227,9 @@ export function discoverAdoptableZellijSessions(filterCliId?: CliId): ZellijAdop
     // persistent pane shells/commands remain, so the count guard is stable.
     const children = paneShellChildren(serverPid);
     if (children.length !== terminals.length) {
-      logger.debug(`[zellij-adopt] ${session}: pane processes(${children.length}) != terminals(${terminals.length}) — can't align, refusing`);
+      // warn (not debug): this refusal makes every CLI in the session invisible
+      // to /adopt, so it must be diagnosable from live daemon logs.
+      logger.warn(`[zellij-adopt] ${session}: pane processes(${children.length}) != live terminals(${terminals.length}) — can't align, refusing`);
       continue;
     }
 

--- a/src/core/zellij-session-discovery.ts
+++ b/src/core/zellij-session-discovery.ts
@@ -42,6 +42,9 @@ export interface ListedPane {
   paneId: string;
   isPlugin: boolean;
   isFloating: boolean;
+  /** True for a held pane whose command already exited (`zellij run` finished,
+   *  pane shows "press enter to re-run") — it has NO live process behind it. */
+  exited: boolean;
   title?: string;
   terminalCommand?: string | null;
 }
@@ -199,6 +202,7 @@ export function parseListPanesJson(json: string): ListedPane[] {
     paneId: `terminal_${p.id}`,
     isPlugin: !!p.is_plugin,
     isFloating: !!p.is_floating,
+    exited: !!p.exited,
     title: typeof p.title === 'string' ? p.title : undefined,
     terminalCommand: p.terminal_command ?? null,
   }));

--- a/test/zellij-backend-helpers.test.ts
+++ b/test/zellij-backend-helpers.test.ts
@@ -4,7 +4,12 @@ import {
   kdlString,
   buildLayoutString,
   ZELLIJ_CONFIG_KDL,
+  parseZellijServerProcs,
 } from '../src/adapters/backend/zellij-backend.js';
+import {
+  unixPathCounts,
+  grownPaths,
+} from '../src/adapters/backend/zellij-socket-probe.js';
 import {
   parseZellijVersion,
   isZellijVersionSupported,
@@ -78,5 +83,59 @@ describe('zellij version gate', () => {
     expect(isZellijVersionSupported({ major: 0, minor: 43, patch: 9 })).toBe(false);
     expect(isZellijVersionSupported({ major: 0, minor: 45, patch: 0 })).toBe(true);
     expect(isZellijVersionSupported({ major: 1, minor: 0, patch: 0 })).toBe(true);
+  });
+});
+
+// Rename-proof server lookup (session-manager rename-session renames the
+// socket FILE but the server argv keeps the spawn-time path — verified live).
+describe('parseZellijServerProcs', () => {
+  const PS = [
+    ' 1150415 /root/.local/share/mise/installs/zellij/0.44.1/zellij --server /run/user/0/zellij/contract_version_1/zadopt-ren',
+    ' 2836020 /usr/bin/zellij --server /run/user/0/zellij/contract_version_1/other-sess',
+    '    4242 grep zellij --server /tmp/fake', // grep noise: argv matches shape → tolerated by design (inode match rejects it)
+    '    9999 /usr/bin/zsh',
+  ].join('\n');
+
+  it('extracts pid + spawn-time socket path of server processes', () => {
+    const servers = parseZellijServerProcs(PS);
+    expect(servers.map(s => s.pid)).toContain(1150415);
+    expect(servers.find(s => s.pid === 1150415)!.socketPath)
+      .toBe('/run/user/0/zellij/contract_version_1/zadopt-ren');
+    expect(servers.map(s => s.pid)).not.toContain(9999);
+  });
+});
+
+describe('zellij-socket-probe pure helpers', () => {
+  // Real /proc/net/unix shape (verified live): the bound path column carries
+  // the SPAWN-TIME name; listening + accepted rows share it; client ends have
+  // no path column. Connecting to the RENAMED socket file makes the stale
+  // path's row count grow — that diff is the name→server mapping.
+  const DIR = '/run/user/0/zellij/contract_version_1';
+  const BEFORE = [
+    'Num       RefCount Protocol Flags    Type St Inode Path',
+    `ffff0001: 00000002 00000000 00010000 0001 01 111222 ${DIR}/zadopt-ren`,
+    `ffff0003: 00000002 00000000 00010000 0001 01 444555 ${DIR}/other-sess`,
+    'ffff0004: 00000002 00000000 00000000 0001 03 666777',
+    'ffff0005: 00000002 00000000 00010000 0001 01 888999 /run/user/0/other-app/sock',
+  ].join('\n');
+  const AFTER = [
+    BEFORE,
+    `ffff0006: 00000003 00000000 00000000 0001 03 111333 ${DIR}/zadopt-ren`,
+  ].join('\n');
+
+  it('counts rows per bound path scoped to the socket dir', () => {
+    const counts = unixPathCounts(BEFORE, DIR);
+    expect(counts.get(`${DIR}/zadopt-ren`)).toBe(1);
+    expect(counts.get(`${DIR}/other-sess`)).toBe(1);
+    expect(counts.has('/run/user/0/other-app/sock')).toBe(false);
+  });
+
+  it('reveals exactly the stale bound path whose count grew on connect', () => {
+    const grown = grownPaths(unixPathCounts(BEFORE, DIR), unixPathCounts(AFTER, DIR));
+    expect(grown).toEqual([`${DIR}/zadopt-ren`]);
+  });
+
+  it('reports nothing when no accept happened', () => {
+    expect(grownPaths(unixPathCounts(BEFORE, DIR), unixPathCounts(BEFORE, DIR))).toEqual([]);
   });
 });

--- a/test/zellij-backend-helpers.test.ts
+++ b/test/zellij-backend-helpers.test.ts
@@ -10,6 +10,7 @@ import {
   unixInodesUnderDir,
   socketInodesFromFdLinks,
   attributeOwners,
+  PROBE_CONNECTIONS,
 } from '../src/adapters/backend/zellij-socket-probe.js';
 import {
   parseZellijVersion,
@@ -130,48 +131,69 @@ describe('zellij-socket-probe pure helpers', () => {
     expect([...s].sort()).toEqual(['111333', '999']);
   });
 
-  // The causal core (Codex finding #2 on PR #468): a pid owns the probed
-  // socket iff it gained a dir-bound socket inode during our hold AND that
-  // inode vanished after our close. Set-up: two servers A(447407)/B(447915)
-  // whose spawn-time paths are BOTH ".../old" (rename + name reuse).
+  // The causal core (Codex findings #2 + delta combo on PR #468): a pid owns
+  // the probed socket iff it gained ≥ PROBE_CONNECTIONS dir-bound socket
+  // inodes during our hold that ALL vanished after our close. The probe opens
+  // PROBE_CONNECTIONS (=2) simultaneous connections precisely so one stray
+  // short sibling connection can never impersonate us. Set-up: two servers
+  // A(447407)/B(447915) whose spawn-time paths are BOTH ".../old" (rename +
+  // name reuse).
   describe('attributeOwners', () => {
+    const K = PROBE_CONNECTIONS;
     const PIDS = [447407, 447915];
-    const bound = new Set(['111333', '444555']);
+    const bound = new Set(['111333', '111444', '444555', '444666']);
     const snap = (m: Record<number, string[]>) => new Map(Object.entries(m).map(([k, v]) => [Number(k), new Set(v)]));
 
-    it('attributes the pid whose accepted socket appeared then vanished', () => {
+    it('attributes the pid that accepted all K probe connections (appear→vanish)', () => {
       const before = snap({ 447407: ['1'], 447915: ['2'] });
-      const during = snap({ 447407: ['1'], 447915: ['2', '111333'] }); // B accepted us
-      const final = snap({ 447407: ['1'], 447915: ['2'] });            // gone after our close
-      expect(attributeOwners(PIDS, before, during, final, bound)).toEqual([447915]);
+      const during = snap({ 447407: ['1'], 447915: ['2', '111333', '111444'] }); // B accepted both
+      const final = snap({ 447407: ['1'], 447915: ['2'] });                      // gone after our close
+      expect(attributeOwners(PIDS, before, during, final, bound, K)).toEqual([447915]);
+    });
+
+    it('REGRESSION (Codex delta combo): target accept slow + ONE sibling short connection → nobody qualifies, fail-closed', () => {
+      // Old single-connection protocol returned the sibling here (sole
+      // appear→vanish inode) → misattribution. With K=2, one stray short
+      // connection can never reach the required count.
+      const before = snap({ 447407: ['1'], 447915: ['2'] });
+      const during = snap({ 447407: ['1', '444555'], 447915: ['2'] }); // sibling A gained ONE short client; target B slow (our accepts invisible)
+      const final = snap({ 447407: ['1'], 447915: ['2'] });            // sibling's short client also vanished
+      expect(attributeOwners(PIDS, before, during, final, bound, K)).toEqual([]);
+    });
+
+    it('keeps the target attributable when extra short clients hit IT during the window (≥K, not ==K)', () => {
+      const before = snap({ 447915: ['2'] });
+      const during = snap({ 447915: ['2', '111333', '111444', '444555'] }); // our 2 + one unrelated short
+      const final = snap({ 447915: ['2'] });
+      expect(attributeOwners([447915], before, during, final, bound, K)).toEqual([447915]);
     });
 
     it('excludes a sibling whose unrelated client stays connected past our close', () => {
       const before = snap({ 447407: ['1'], 447915: ['2'] });
-      const during = snap({ 447407: ['1', '444555'], 447915: ['2', '111333'] }); // A gained a long-lived client too
-      const final = snap({ 447407: ['1', '444555'], 447915: ['2'] });            // A's client still there
-      expect(attributeOwners(PIDS, before, during, final, bound)).toEqual([447915]);
+      const during = snap({ 447407: ['1', '444555', '444666'], 447915: ['2', '111333', '111444'] });
+      const final = snap({ 447407: ['1', '444555', '444666'], 447915: ['2'] }); // A's clients still there
+      expect(attributeOwners(PIDS, before, during, final, bound, K)).toEqual([447915]);
     });
 
-    it('yields two candidates (ambiguous → fail-closed) when a sibling short client races the window', () => {
+    it('yields two candidates (ambiguous → fail-closed) when ≥K sibling shorts race the window', () => {
       const before = snap({ 447407: ['1'], 447915: ['2'] });
-      const during = snap({ 447407: ['1', '444555'], 447915: ['2', '111333'] });
-      const final = snap({ 447407: ['1'], 447915: ['2'] }); // both vanished
-      expect(attributeOwners(PIDS, before, during, final, bound)).toHaveLength(2);
+      const during = snap({ 447407: ['1', '444555', '444666'], 447915: ['2', '111333', '111444'] });
+      const final = snap({ 447407: ['1'], 447915: ['2'] }); // all vanished
+      expect(attributeOwners(PIDS, before, during, final, bound, K)).toHaveLength(2);
     });
 
-    it('yields nothing when the accept was not yet visible (slow server → fail-closed, not sibling)', () => {
+    it('yields nothing when our accepts were not yet visible (slow server → fail-closed)', () => {
       const before = snap({ 447407: ['1'], 447915: ['2'] });
-      const during = snap({ 447407: ['1'], 447915: ['2'] }); // our accept invisible
+      const during = snap({ 447407: ['1'], 447915: ['2'] });
       const final = snap({ 447407: ['1'], 447915: ['2'] });
-      expect(attributeOwners(PIDS, before, during, final, bound)).toEqual([]);
+      expect(attributeOwners(PIDS, before, during, final, bound, K)).toEqual([]);
     });
 
     it('ignores gained fds that are not dir-bound sockets (random files/pipes)', () => {
       const before = snap({ 447407: ['1'] });
-      const during = snap({ 447407: ['1', '999'] }); // gained socket not bound under dir
+      const during = snap({ 447407: ['1', '999', '998'] }); // gained sockets not bound under dir
       const final = snap({ 447407: ['1'] });
-      expect(attributeOwners([447407], before, during, final, bound)).toEqual([]);
+      expect(attributeOwners([447407], before, during, final, bound, K)).toEqual([]);
     });
   });
 });

--- a/test/zellij-backend-helpers.test.ts
+++ b/test/zellij-backend-helpers.test.ts
@@ -7,8 +7,9 @@ import {
   parseZellijServerProcs,
 } from '../src/adapters/backend/zellij-backend.js';
 import {
-  unixPathCounts,
-  grownPaths,
+  unixInodesUnderDir,
+  socketInodesFromFdLinks,
+  attributeOwners,
 } from '../src/adapters/backend/zellij-socket-probe.js';
 import {
   parseZellijVersion,
@@ -107,35 +108,70 @@ describe('parseZellijServerProcs', () => {
 
 describe('zellij-socket-probe pure helpers', () => {
   // Real /proc/net/unix shape (verified live): the bound path column carries
-  // the SPAWN-TIME name; listening + accepted rows share it; client ends have
-  // no path column. Connecting to the RENAMED socket file makes the stale
-  // path's row count grow — that diff is the name→server mapping.
+  // the SPAWN-TIME name (frozen across renames); listening + accepted rows
+  // share it; client ends have no path column.
   const DIR = '/run/user/0/zellij/contract_version_1';
-  const BEFORE = [
+  const UNIX_TABLE = [
     'Num       RefCount Protocol Flags    Type St Inode Path',
-    `ffff0001: 00000002 00000000 00010000 0001 01 111222 ${DIR}/zadopt-ren`,
+    `ffff0001: 00000002 00000000 00010000 0001 01 111222 ${DIR}/old`,
+    `ffff0002: 00000003 00000000 00000000 0001 03 111333 ${DIR}/old`,
     `ffff0003: 00000002 00000000 00010000 0001 01 444555 ${DIR}/other-sess`,
     'ffff0004: 00000002 00000000 00000000 0001 03 666777',
     'ffff0005: 00000002 00000000 00010000 0001 01 888999 /run/user/0/other-app/sock',
   ].join('\n');
-  const AFTER = [
-    BEFORE,
-    `ffff0006: 00000003 00000000 00000000 0001 03 111333 ${DIR}/zadopt-ren`,
-  ].join('\n');
 
-  it('counts rows per bound path scoped to the socket dir', () => {
-    const counts = unixPathCounts(BEFORE, DIR);
-    expect(counts.get(`${DIR}/zadopt-ren`)).toBe(1);
-    expect(counts.get(`${DIR}/other-sess`)).toBe(1);
-    expect(counts.has('/run/user/0/other-app/sock')).toBe(false);
+  it('unixInodesUnderDir collects inodes bound under the socket dir only', () => {
+    const inodes = unixInodesUnderDir(UNIX_TABLE, DIR);
+    expect([...inodes].sort()).toEqual(['111222', '111333', '444555']);
   });
 
-  it('reveals exactly the stale bound path whose count grew on connect', () => {
-    const grown = grownPaths(unixPathCounts(BEFORE, DIR), unixPathCounts(AFTER, DIR));
-    expect(grown).toEqual([`${DIR}/zadopt-ren`]);
+  it('socketInodesFromFdLinks keeps socket fds only', () => {
+    const s = socketInodesFromFdLinks(['socket:[111333]', '/dev/null', 'pipe:[42]', 'socket:[999]']);
+    expect([...s].sort()).toEqual(['111333', '999']);
   });
 
-  it('reports nothing when no accept happened', () => {
-    expect(grownPaths(unixPathCounts(BEFORE, DIR), unixPathCounts(BEFORE, DIR))).toEqual([]);
+  // The causal core (Codex finding #2 on PR #468): a pid owns the probed
+  // socket iff it gained a dir-bound socket inode during our hold AND that
+  // inode vanished after our close. Set-up: two servers A(447407)/B(447915)
+  // whose spawn-time paths are BOTH ".../old" (rename + name reuse).
+  describe('attributeOwners', () => {
+    const PIDS = [447407, 447915];
+    const bound = new Set(['111333', '444555']);
+    const snap = (m: Record<number, string[]>) => new Map(Object.entries(m).map(([k, v]) => [Number(k), new Set(v)]));
+
+    it('attributes the pid whose accepted socket appeared then vanished', () => {
+      const before = snap({ 447407: ['1'], 447915: ['2'] });
+      const during = snap({ 447407: ['1'], 447915: ['2', '111333'] }); // B accepted us
+      const final = snap({ 447407: ['1'], 447915: ['2'] });            // gone after our close
+      expect(attributeOwners(PIDS, before, during, final, bound)).toEqual([447915]);
+    });
+
+    it('excludes a sibling whose unrelated client stays connected past our close', () => {
+      const before = snap({ 447407: ['1'], 447915: ['2'] });
+      const during = snap({ 447407: ['1', '444555'], 447915: ['2', '111333'] }); // A gained a long-lived client too
+      const final = snap({ 447407: ['1', '444555'], 447915: ['2'] });            // A's client still there
+      expect(attributeOwners(PIDS, before, during, final, bound)).toEqual([447915]);
+    });
+
+    it('yields two candidates (ambiguous → fail-closed) when a sibling short client races the window', () => {
+      const before = snap({ 447407: ['1'], 447915: ['2'] });
+      const during = snap({ 447407: ['1', '444555'], 447915: ['2', '111333'] });
+      const final = snap({ 447407: ['1'], 447915: ['2'] }); // both vanished
+      expect(attributeOwners(PIDS, before, during, final, bound)).toHaveLength(2);
+    });
+
+    it('yields nothing when the accept was not yet visible (slow server → fail-closed, not sibling)', () => {
+      const before = snap({ 447407: ['1'], 447915: ['2'] });
+      const during = snap({ 447407: ['1'], 447915: ['2'] }); // our accept invisible
+      const final = snap({ 447407: ['1'], 447915: ['2'] });
+      expect(attributeOwners(PIDS, before, during, final, bound)).toEqual([]);
+    });
+
+    it('ignores gained fds that are not dir-bound sockets (random files/pipes)', () => {
+      const before = snap({ 447407: ['1'] });
+      const during = snap({ 447407: ['1', '999'] }); // gained socket not bound under dir
+      const final = snap({ 447407: ['1'] });
+      expect(attributeOwners([447407], before, during, final, bound)).toEqual([]);
+    });
   });
 });

--- a/test/zellij-session-discovery.test.ts
+++ b/test/zellij-session-discovery.test.ts
@@ -5,6 +5,7 @@ import {
   parseListPanesJson,
   joinPanes,
 } from '../src/core/zellij-session-discovery.js';
+import { alignmentPanes } from '../src/core/zellij-adopt-discovery.js';
 
 // Real `zellij action dump-layout` output (zellij 0.44.1): a default shell pane
 // where the user interactively typed `claude` (terminal_0) split vertically with
@@ -197,6 +198,39 @@ describe('parseListPanesJson', () => {
 
   it('returns [] for malformed json', () => {
     expect(parseListPanesJson('not json')).toEqual([]);
+  });
+
+  it('flags exited held panes (zellij run command finished)', () => {
+    const panes = parseListPanesJson(JSON.stringify([
+      { id: 0, is_plugin: false, exited: false },
+      { id: 3, is_plugin: false, exited: true, is_held: true, terminal_command: 'sleep 2' },
+    ]));
+    expect(panes.map(p => p.exited)).toEqual([false, true]);
+  });
+});
+
+// Real bug repro (zellij 0.44.1, verified live): the adopt alignment set must
+// contain exactly the terminal panes that have a live process behind them —
+// floating panes DO (their shell is a server child), exited held panes DON'T.
+// Getting either wrong flips the count guard and hides EVERY CLI in the session.
+describe('alignmentPanes', () => {
+  const LISTED = parseListPanesJson(JSON.stringify([
+    { id: 0, is_plugin: true, title: '(.) - zellij:link' },          // plugin → out
+    { id: 2, is_plugin: false, is_floating: true },                  // floating shell → IN
+    { id: 0, is_plugin: false, title: '✳ Claude Code' },             // tiled CLI → IN
+    { id: 3, is_plugin: false, exited: true, is_held: true },        // exited held → out
+    { id: 1, is_plugin: false },                                     // tiled shell → IN
+  ]));
+
+  it('keeps floating panes, drops exited/plugin panes, sorts by pane id', () => {
+    expect(alignmentPanes(LISTED).map(p => p.paneId))
+      .toEqual(['terminal_0', 'terminal_1', 'terminal_2']);
+  });
+
+  it('matches the live-process count 1:1 (the count-guard invariant)', () => {
+    // 3 live pane processes (t0 claude, t1 shell, t2 floating shell) — the
+    // old filter yielded 2 (floating dropped) or 3-with-exited, both refusing.
+    expect(alignmentPanes(LISTED)).toHaveLength(3);
   });
 });
 


### PR DESCRIPTION
## 改了什么

`/adopt` 在 zellij 下查不到手动运行的 CLI（申晗报障）。本机隔离复现出 **两个根因 + 一个更危险的错配隐患**，全部出在 zellij adopt 发现的 pane↔pid 位置对齐计数守卫上（zellij 0.44 `list-panes` 不暴露 pid，只能按「pane id 创建序 ↔ server 子进程 pid 序」对齐，计数不等即拒绝整个会话）：

1. **floating 终端 pane**（如快捷浮动终端）的 shell 是 server 子进程，却被排除在 pane 集合外 → 进程侧多 1 → 计数不等 → **整个会话被拒，里面所有 CLI 隐身**
2. **exited-held pane**（`zellij run` 的命令跑完后停留在「press enter to re-run」）计入 pane 集合但进程已退出 → pane 侧多 1 → 同样全拒
3. **两者并存**时 +1/−1 恰好抵消、守卫误放行，但配对整体错位：实测 floating pane 里的 codex 被绑到了 exited 死 pane 的 id（terminal_3），吸附后会驱动/截屏错误的 pane

修法：对齐集合改为「非 plugin 且未 exited 的全部终端 pane（**含 floating**）」，与 server 存活子进程天然 1:1。floating pane 同时进入可吸附结果（驱动/截屏全走显式 `--pane-id`，实测可用）。拒绝日志 debug→warn，以后线上出现对不齐能直接从 daemon 日志诊断。

## 影响面

- 仅 zellij adopt 发现路径：`discoverAdoptableZellijSessions`（`/adopt` 命令与卡片点击重发现两个入口共用）
- `ListedPane` 新增 `exited` 字段为增量改动；`joinPanes`/dump-layout 位置连接语义未动（其排除 floating 的行为与本修复无关，未触碰）
- `validateZellijAdoptTarget`（吸附前复验）本身按 pid + paneDimensions 校验，对 floating pane 天然成立，无需改
- tmux / herdr 发现路径零触碰；非 zellij 主机 `discoverAdoptableZellijSessions` 照旧返回 []

## 实际测试验证

- `pnpm build` 绿；`npx vitest run test/zellij-session-discovery.test.ts test/zellij-cli-detection.test.ts test/command-handler.test.ts` 185/185 绿（含新增 4 条回归：exited 解析、floating 保留、exited/plugin 排除、计数守卫不变式）
- 真机复现验证（zellij 0.44.1，`zellij attach --create-background` + `write-chars` 手动起 claude/codex，新旧 dist 对比）：
  - 干净单 pane：新旧都能发现 ✓
  - 加 floating pane：旧 `[]`（全拒）→ 新正常发现 ✓
  - 加 exited pane：旧 `[]`（全拒）→ 新正常发现 ✓
  - floating+exited 并存、CLI 在 floating pane：旧把 codex 绑到死 pane terminal_3（错配！）→ 新正确绑 terminal_5（pane 尺寸 22 行 = floating 真实尺寸，进一步佐证）✓
- 全量 vitest 套件结果见 PR 评论/CI

---

## 追加（commit 06b24f7d）：改名会话修复

申晗追加报障：会话管理器改名后 /adopt 也查不到。真机复现确认：`rename-session`（会话管理器同机制）只重命名 socket 文件，**server 进程 argv 与内核 bound-address（/proc/net/unix Path 列）都永远冻结在 spawn 时的旧名**——被动查找无从建立「新名 → server 进程」映射，而 `findServerPid` 按 argv 尾段匹配 → 改名后必然 miss → 整会话被跳过。

**解法 = 主动 socket 探针**（`src/adapters/backend/zellij-socket-probe.ts`，独立子脚本由 `spawnSync` 调用保持同步语义）：对改名后的 socket 文件发起一次连接，server accept 的新 socket 会以旧绑定路径出现在 /proc/net/unix，连接前后行数 diff 精确揭示「新文件名 ↔ spawn 路径」，匹配回 argv 取 pid。

- 快路径不变：argv 尾段命中（未改名会话零额外开销）
- 探针歧义（并发连接竞态）或失败 → 按未找到处理，宁缺勿错
- 非 Linux 维持原 argv 行为（探针依赖 /proc）
- 受益方：adopt 发现、吸附前复验、zellij 后端 pane pid 查找（同一 findServerPid）

**验证**：未改名 / 改名 / 连续改两次名会话全部正确解析；改名会话 discovery + validate 端到端通过；旧名正确返回 null；定向 253/253 绿；CI pass。已发 v2.110.0-canary.1 灰度。

---

## 追加（commit d12cb049）：Codex review 两个 blocking findings 修复

1. **argv 快路径废除（Linux）**：名字可复用（rename 让渡后可被新 spawn 或其它 rename 占用），任何按名字匹配 argv/绑定路径的捷径都可能跨会话错绑（spawn old→rename→再 spawn old 时固定错返旧会话）。现在探针是唯一权威；socket 文件不存在 → null（此前 PR 描述「旧名返回 null」的说法与旧实现不符，本 commit 后成立）。非 Linux 保留原 argv 行为。
2. **探针升级为 pid 级因果归属**：对候选 server 做 /proc/<pid>/fd socket inode 三段快照（连接前/持有中/断开后），归属 = 持有期间新增 dir 绑定 inode ∧ 我方断开后消失。sibling 长连（不消失）排除；sibling 短连（双候选）与慢 accept（零候选）均 fail-closed exit 3，父进程仅对 exit 3 重试一次。

**验证**：复刻 Codex 场景 A(spawn old→rename new)+B(再 spawn old)：`findServerPid(old)=B / findServerPid(new)=A`；C(spawn csess→rename 到 freed 名)：`findServerPid(taken)=C`、让渡旧名 null；归属协议 5 场景纯函数单测；定向 257/257 绿；单次探针 ~650ms 仅在 adopt/绑定路径（getChildPid 有缓存）。

---

## 追加（commit 60c0f6ed）：Codex delta 组合态残洞闭环

**残洞**：目标 accept 在 during 快照不可见 × sibling 短连接恰好 appear→vanish 跨窗口 → 单连接协议下 sibling 成唯一 owner，exit 0 错归属不重试。

**闭环（双层）**：① 探针一次开 `PROBE_CONNECTIONS=2` 条同时连接，归属条件 = appear∧vanish inode 数 **≥2**——单条 stray 短连无法冒充（组合态→0 候选 fail-closed）；≥ 而非 == 容忍并发 discovery 自身短连击中目标；② 父进程对成功结果做**独立二次探针一致性确认**，两次成功且 pid 一致才返回。冒充需在两个不相交窗口重复「≥2 短连贴同一 sibling ∧ 目标持续不 accept」模式。

**验证**：新增 Codex 组合态回归（单 sibling 短连+目标慢 → `[]` 而非 `[sibling]`）等 7 场景；定向 259/259 绿；真机矩阵重跑全过（old=B/new=A/taken=C/让渡与幽灵名 null）；成功查找 ~1.2s 仅 adopt 路径。
