### PR TITLE
fix(team-group): 团队协作群创建后自动转让群主给发起人

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -2229,6 +2229,7 @@ ipcRoute('POST', '/api/groups/create', async (req, res) => {
     larkAppIds?: unknown;
     userOpenIds?: unknown;
     ownerUnionIds?: unknown;
+    transferOwnerUnionId?: unknown;
     transferOwnerTo?: unknown;
     notifyOwnerOpenId?: unknown;
     bindWorkingDir?: unknown;
@@ -2240,6 +2241,7 @@ ipcRoute('POST', '/api/groups/create', async (req, res) => {
       larkAppIds?: string[];
       userOpenIds?: string[];
       ownerUnionIds?: string[];
+      transferOwnerUnionId?: string;
       transferOwnerTo?: string;
       notifyOwnerOpenId?: string;
       bindWorkingDir?: string;
@@ -2263,6 +2265,13 @@ ipcRoute('POST', '/api/groups/create', async (req, res) => {
   const ownerUnionIds = Array.isArray(body.ownerUnionIds) && body.ownerUnionIds.every(x => typeof x === 'string')
     ? (body.ownerUnionIds as string[])
     : [];
+  const transferOwnerUnionId = typeof body.transferOwnerUnionId === 'string' && body.transferOwnerUnionId.trim()
+    ? body.transferOwnerUnionId.trim()
+    : null;
+  if (body.transferOwnerUnionId !== undefined
+    && (!transferOwnerUnionId || !transferOwnerUnionId.startsWith('on_') || !ownerUnionIds.includes(transferOwnerUnionId))) {
+    return jsonRes(res, 400, { ok: false, error: 'invalid_transfer_owner_union_id' });
+  }
   const transferTo = typeof body.transferOwnerTo === 'string' && body.transferOwnerTo.trim()
     ? body.transferOwnerTo.trim()
     : null;
@@ -2289,6 +2298,7 @@ ipcRoute('POST', '/api/groups/create', async (req, res) => {
       name,
       userOpenIds: userIds,
       ownerUnionIds,
+      transferOwnerUnionId: transferOwnerUnionId ?? undefined,
       transferOwnerTo: transferTo ?? undefined,
       notifyOwnerOpenId: notifyTo ?? undefined,
       bindWorkingDir: bindWorkingDir || undefined,

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -9,7 +9,7 @@ import { listenWithProbe } from '../utils/listen-with-probe.js';
 import * as sessionStore from '../services/session-store.js';
 import * as scheduleStore from '../services/schedule-store.js';
 import * as groupsStore from '../services/groups-store.js';
-import { createGroupWithBots } from '../services/group-creator.js';
+import { createGroupWithBots, transferGroupOwner } from '../services/group-creator.js';
 import * as oncallStore from '../services/oncall-store.js';
 import * as brandStore from '../services/brand-store.js';
 import * as sandboxStore from '../services/sandbox-store.js';
@@ -2308,6 +2308,53 @@ ipcRoute('POST', '/api/groups/create', async (req, res) => {
   } catch (e) {
     jsonRes(res, 502, { ok: false, error: String((e as Error).message ?? e) });
   }
+});
+
+// Complete a deferred team-group owner transfer after another deployment has
+// added the operator to the chat. The caller sends union_id so no app-scoped
+// open_id crosses the dashboard/daemon or federation boundary.
+ipcRoute('POST', '/api/groups/transfer-owner', async (req, res) => {
+  if (!cachedLarkAppId) return jsonRes(res, 503, { error: 'larkAppId_not_set' });
+  let body: { chatId?: unknown; ownerUnionId?: unknown };
+  try {
+    body = await readJsonBody<{ chatId?: string; ownerUnionId?: string }>(req);
+  } catch {
+    return jsonRes(res, 400, { ok: false, error: 'bad_json' });
+  }
+  const chatId = typeof body.chatId === 'string' ? body.chatId.trim() : '';
+  const ownerUnionId = typeof body.ownerUnionId === 'string' ? body.ownerUnionId.trim() : '';
+  if (!chatId.startsWith('oc_') || !ownerUnionId.startsWith('on_')) {
+    return jsonRes(res, 400, { ok: false, error: 'invalid_owner_transfer' });
+  }
+
+  const transferred = await transferGroupOwner({
+    creatorLarkAppId: cachedLarkAppId,
+    chatId,
+    ownerId: ownerUnionId,
+    ownerIdType: 'union_id',
+  });
+  let notifyMessageId: string | null = null;
+  let notifyError: string | null = null;
+  if (transferred.ownerTransferredTo) {
+    try {
+      // Feishu accepts union_id in an @ tag; keeping it stable avoids a second
+      // app-scope lookup after the owner was added by another deployment.
+      notifyMessageId = await sendMessage(
+        cachedLarkAppId,
+        chatId,
+        `<at user_id="${ownerUnionId}"></at>`,
+        'text',
+      );
+    } catch (e: any) {
+      notifyError = e?.message ?? String(e);
+    }
+  }
+  return jsonRes(res, 200, {
+    ok: true,
+    ...transferred,
+    notifyMessageId,
+    notifyError,
+  });
 });
 
 // ─── SSE event stream ──────────────────────────────────────────────────────

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -20,7 +20,7 @@ import {
 import { DaemonRegistry } from './dashboard/registry.js';
 import { Aggregator, subscribeDaemon } from './dashboard/aggregator.js';
 import { pickCreatorForGroup } from './dashboard/operator-selector.js';
-import { planGroupCreator } from './dashboard/team-group.js';
+import { buildTeamGroupCreatePayload, planGroupCreator } from './dashboard/team-group.js';
 import { handleWorkflowApi, jsonRes } from './dashboard/workflow-api.js';
 import { handleV3RunsApi } from './dashboard/v3-runs-api.js';
 import { defaultRunsDir as v3RunsDir } from './workflows/v3/ops-projection.js';
@@ -1441,7 +1441,7 @@ function liveBots(): { larkAppId: string; botName: string; cliId?: string }[] {
   });
 }
 
-async function createTeamGroup(args: { name: string; larkAppIds: string[]; userOpenId?: string; preferredCreator?: string; ownerUnionIds?: string[]; roleProfileId?: string }): Promise<{
+async function createTeamGroup(args: { name: string; larkAppIds: string[]; userOpenId?: string; preferredCreator?: string; ownerUnionIds?: string[]; transferOwnerUnionId?: string; roleProfileId?: string }): Promise<{
   ok: boolean; chatId?: string; shareLink?: string; invalidBotIds?: string[]; invalidUserIds?: string[]; invalidOwnerUnionIds?: string[]; error?: string; autoInviteUnavailable?: boolean;
 }> {
   const selectedIds = Array.from(new Set(args.larkAppIds.filter(Boolean)));
@@ -1467,13 +1467,14 @@ async function createTeamGroup(args: { name: string; larkAppIds: string[]; userO
     const upstream = await proxyToDaemon(plan.creatorLarkAppId, '/api/groups/create', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
+      body: JSON.stringify(buildTeamGroupCreatePayload({
         name: args.name,
         larkAppIds: selectedIds,
         userOpenIds,
         ownerUnionIds: args.ownerUnionIds ?? [],
-        ...(args.roleProfileId ? { roleProfileId: args.roleProfileId } : {}),
-      }),
+        transferOwnerUnionId: args.transferOwnerUnionId,
+        roleProfileId: args.roleProfileId,
+      })),
     });
     const text = await upstream.text();
     let parsed: any = null;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -30,6 +30,7 @@ import { redactGroupsForPublic, redactSchedulesForPublic } from './dashboard/pub
 import { handleWebhookRoute } from './dashboard/webhook-routes.js';
 import { handleFederationApi } from './dashboard/federation-api.js';
 import { handleFederationSpokeApi, syncAllMemberships, autoBindOwnerIfUnambiguous, type TeamSessionRowLike } from './dashboard/federation-spoke-api.js';
+import type { TeamGroupCreateResult, TeamGroupOwnerTransferResult } from './dashboard/federated-group-core.js';
 import { getRunsDir } from './workflows/runs-dir.js';
 import { BotOnboardingManager } from './dashboard/bot-onboarding.js';
 import { FeishuLoginManager } from './dashboard/feishu-login.js';
@@ -1441,8 +1442,8 @@ function liveBots(): { larkAppId: string; botName: string; cliId?: string }[] {
   });
 }
 
-async function createTeamGroup(args: { name: string; larkAppIds: string[]; userOpenId?: string; preferredCreator?: string; ownerUnionIds?: string[]; transferOwnerUnionId?: string; roleProfileId?: string }): Promise<{
-  ok: boolean; chatId?: string; shareLink?: string; invalidBotIds?: string[]; invalidUserIds?: string[]; invalidOwnerUnionIds?: string[]; error?: string; autoInviteUnavailable?: boolean;
+async function createTeamGroup(args: { name: string; larkAppIds: string[]; userOpenId?: string; preferredCreator?: string; ownerUnionIds?: string[]; transferOwnerUnionId?: string; roleProfileId?: string }): Promise<TeamGroupCreateResult & {
+  autoInviteUnavailable?: boolean;
 }> {
   const selectedIds = Array.from(new Set(args.larkAppIds.filter(Boolean)));
   if (selectedIds.length === 0) return { ok: false, error: 'no_bots_selected' };
@@ -1482,9 +1483,51 @@ async function createTeamGroup(args: { name: string; larkAppIds: string[]; userO
     if (!upstream.ok || !parsed?.ok || typeof parsed.chatId !== 'string') {
       return { ok: false, error: parsed?.error ?? `group_create_http_${upstream.status}` };
     }
-    return { ok: true, chatId: parsed.chatId, shareLink: typeof parsed.shareLink === 'string' ? parsed.shareLink : undefined, invalidBotIds: parsed.invalidBotIds ?? [], invalidUserIds: parsed.invalidUserIds ?? [], invalidOwnerUnionIds: parsed.invalidOwnerUnionIds ?? [], autoInviteUnavailable: !plan.inviteUser };
+    return {
+      ok: true,
+      chatId: parsed.chatId,
+      creator: plan.creatorLarkAppId,
+      shareLink: typeof parsed.shareLink === 'string' ? parsed.shareLink : undefined,
+      invalidBotIds: parsed.invalidBotIds ?? [],
+      invalidUserIds: parsed.invalidUserIds ?? [],
+      invalidOwnerUnionIds: parsed.invalidOwnerUnionIds ?? [],
+      ownerTransferredTo: parsed.ownerTransferredTo ?? null,
+      transferError: parsed.transferError ?? null,
+      notifyMessageId: parsed.notifyMessageId ?? null,
+      notifyError: parsed.notifyError ?? null,
+      autoInviteUnavailable: !plan.inviteUser,
+    };
   } catch {
     return { ok: false, error: 'group_create_proxy_failed' };
+  }
+}
+
+async function transferTeamGroupOwner(args: {
+  creatorLarkAppId: string;
+  chatId: string;
+  transferOwnerUnionId: string;
+}): Promise<TeamGroupOwnerTransferResult> {
+  try {
+    const upstream = await proxyToDaemon(args.creatorLarkAppId, '/api/groups/transfer-owner', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ chatId: args.chatId, ownerUnionId: args.transferOwnerUnionId }),
+    });
+    const parsed = await upstream.json().catch(() => null) as any;
+    if (!upstream.ok || !parsed?.ok) {
+      return {
+        ownerTransferredTo: null,
+        transferError: parsed?.error ?? `owner_transfer_http_${upstream.status}`,
+      };
+    }
+    return {
+      ownerTransferredTo: parsed.ownerTransferredTo ?? null,
+      transferError: parsed.transferError ?? null,
+      notifyMessageId: parsed.notifyMessageId ?? null,
+      notifyError: parsed.notifyError ?? null,
+    };
+  } catch {
+    return { ownerTransferredTo: null, transferError: 'owner_transfer_proxy_failed' };
   }
 }
 
@@ -1897,7 +1940,7 @@ const server = createServer(async (req, res) => {
     // Federation HUB endpoints — cross-deployment, self-authed by invite code /
     // syncToken, so mounted before the token gate (like webhook/team routes).
     // createTeamGroup injected for the delegate-group path (hub→spoke 拉群).
-    if (await handleFederationApi(req, res, url, { createTeamGroup, liveBots })) {
+    if (await handleFederationApi(req, res, url, { createTeamGroup, transferTeamGroupOwner, liveBots })) {
       return;
     }
 
@@ -2527,7 +2570,7 @@ const server = createServer(async (req, res) => {
     }
 
     // Federation SPOKE endpoints (owner actions) — token-gated above.
-    if (await handleFederationSpokeApi(req, res, url, { createTeamGroup, liveBots })) {
+    if (await handleFederationSpokeApi(req, res, url, { createTeamGroup, transferTeamGroupOwner, liveBots })) {
       return;
     }
 

--- a/src/dashboard/federated-group-core.ts
+++ b/src/dashboard/federated-group-core.ts
@@ -43,7 +43,7 @@ export function hubError(e: unknown): { status: number; error: string } {
 
 export interface OrchestrateGroupDeps {
   /** Picks a LOCAL online creator + proxies to its daemon (federated bots added by app_id). */
-  createTeamGroup: (args: { name: string; larkAppIds: string[]; ownerUnionIds?: string[] }) => Promise<{
+  createTeamGroup: (args: { name: string; larkAppIds: string[]; ownerUnionIds?: string[]; transferOwnerUnionId?: string }) => Promise<{
     ok: boolean; chatId?: string; shareLink?: string; invalidBotIds?: string[]; invalidOwnerUnionIds?: string[]; error?: string;
   }>;
   fetcher: Fetcher;
@@ -98,7 +98,12 @@ export async function orchestrateFederatedGroup(
   ]));
   const missingOperatorIdentity = !operatorUnionId;
 
-  const r = await deps.createTeamGroup({ name, larkAppIds: eligible, ownerUnionIds });
+  const r = await deps.createTeamGroup({
+    name,
+    larkAppIds: eligible,
+    ownerUnionIds,
+    transferOwnerUnionId: operatorUnionId,
+  });
   if (r.ok) {
     // The creator bot adds the owners IT can reach; owners outside its app's
     // visibility scope (Lark code 232024 — typically owners of OTHER deployments)
@@ -125,7 +130,7 @@ export async function orchestrateFederatedGroup(
         const dr = await fetchWithTimeout(deps.fetcher, `${dep.callbackUrl}/api/federation/delegate-group`, {
           method: 'POST',
           headers: { 'content-type': 'application/json', authorization: `Bearer ${dep.delegationToken}` },
-          body: JSON.stringify({ name, larkAppIds: eligible, ownerUnionIds, requestId }),
+          body: JSON.stringify({ name, larkAppIds: eligible, ownerUnionIds, transferOwnerUnionId: operatorUnionId, requestId }),
         });
         const dj = await dr.json().catch(() => ({} as any));
         if (dr.ok && dj?.ok && dj.chatId) {

--- a/src/dashboard/federated-group-core.ts
+++ b/src/dashboard/federated-group-core.ts
@@ -41,11 +41,38 @@ export function hubError(e: unknown): { status: number; error: string } {
   return e instanceof HubTimeout ? { status: 504, error: 'hub_timeout' } : { status: 502, error: 'hub_unreachable' };
 }
 
+export interface TeamGroupCreateResult {
+  ok: boolean;
+  chatId?: string;
+  shareLink?: string;
+  creator?: string;
+  invalidBotIds?: string[];
+  invalidUserIds?: string[];
+  invalidOwnerUnionIds?: string[];
+  ownerTransferredTo?: string | null;
+  transferError?: string | null;
+  notifyMessageId?: string | null;
+  notifyError?: string | null;
+  error?: string;
+}
+
+export interface TeamGroupOwnerTransferResult {
+  ownerTransferredTo: string | null;
+  transferError: string | null;
+  notifyMessageId?: string | null;
+  notifyError?: string | null;
+}
+
 export interface OrchestrateGroupDeps {
   /** Picks a LOCAL online creator + proxies to its daemon (federated bots added by app_id). */
-  createTeamGroup: (args: { name: string; larkAppIds: string[]; ownerUnionIds?: string[]; transferOwnerUnionId?: string }) => Promise<{
-    ok: boolean; chatId?: string; shareLink?: string; invalidBotIds?: string[]; invalidOwnerUnionIds?: string[]; error?: string;
-  }>;
+  createTeamGroup: (args: { name: string; larkAppIds: string[]; ownerUnionIds?: string[]; transferOwnerUnionId?: string }) => Promise<TeamGroupCreateResult>;
+  /** Re-enter the ORIGINAL local creator daemon after a remote deployment has
+   *  added the operator. Uses union_id so no app-scoped open_id crosses layers. */
+  transferTeamGroupOwner?: (args: {
+    creatorLarkAppId: string;
+    chatId: string;
+    transferOwnerUnionId: string;
+  }) => Promise<TeamGroupOwnerTransferResult>;
   fetcher: Fetcher;
   /** Live daemon-registry bots (authoritative local roster source). */
   live?: LiveBot[];
@@ -109,13 +136,17 @@ export async function orchestrateFederatedGroup(
     // visibility scope (Lark code 232024 — typically owners of OTHER deployments)
     // come back as invalidOwnerUnionIds. Add each of those via THEIR OWN
     // deployment's bot (which has them in scope) — hub→spoke delegate-add-owner.
-    let invalidOwners = r.invalidOwnerUnionIds ?? [];
+    const initiallyInvalidOwners = r.invalidOwnerUnionIds ?? [];
+    let invalidOwners = initiallyInvalidOwners;
     if (invalidOwners.length > 0 && r.chatId) {
       invalidOwners = await delegateAddOwners(dataDir, teamId, r.chatId, invalidOwners, eligible, requestId, deps.fetcher);
     }
+    const completed = await completeLocalDeferredOwnerTransfer(
+      r, initiallyInvalidOwners, invalidOwners, operatorUnionId, deps.transferTeamGroupOwner,
+    );
     // 记录 team↔chatId 绑定 —— 看板团队筛选据此识别「dashboard 发起的协作群」。
     if (r.chatId) recordTeamGroup(dataDir, teamId, String(r.chatId));
-    return { status: 200, body: { ...r, invalidOwnerUnionIds: invalidOwners, missingOperatorIdentity, skippedNoOwner } };
+    return { status: 200, body: { ...completed, invalidOwnerUnionIds: invalidOwners, missingOperatorIdentity, skippedNoOwner } };
   }
 
   // No local online creator → delegate to a reachable deployment that owns a
@@ -137,12 +168,16 @@ export async function orchestrateFederatedGroup(
           // The delegate creator added the owners IT could; owners it couldn't
           // reach (e.g. a THIRD deployment's owner) must still be added via their
           // own deployment — same post-create delegation as the local-create path.
-          let invalidOwners = dj.invalidOwnerUnionIds ?? [];
+          const initiallyInvalidOwners: string[] = dj.invalidOwnerUnionIds ?? [];
+          let invalidOwners = initiallyInvalidOwners;
           if (invalidOwners.length > 0) {
             invalidOwners = await delegateAddOwners(dataDir, teamId, dj.chatId, invalidOwners, eligible, requestId, deps.fetcher);
           }
+          const completed = await completeDelegatedDeferredOwnerTransfer(
+            dep, dj, initiallyInvalidOwners, invalidOwners, operatorUnionId, requestId, deps.fetcher,
+          );
           recordTeamGroup(dataDir, teamId, String(dj.chatId));
-          return { status: 200, body: { ...dj, invalidOwnerUnionIds: invalidOwners, delegatedTo: dep.name, missingOperatorIdentity, skippedNoOwner } };
+          return { status: 200, body: { ...completed, invalidOwnerUnionIds: invalidOwners, delegatedTo: dep.name, missingOperatorIdentity, skippedNoOwner } };
         }
         lastErr = dj?.error || `hub_${dr.status}`;
       } catch (e) {
@@ -155,6 +190,76 @@ export async function orchestrateFederatedGroup(
     return { status: 502, body: { ok: false, error: lastErr } };
   }
   return { status: 502, body: r };
+}
+
+function deferredOperatorWasAdded(
+  operatorUnionId: string | undefined,
+  initiallyInvalidOwners: string[],
+  invalidOwners: string[],
+): operatorUnionId is string {
+  return !!operatorUnionId
+    && initiallyInvalidOwners.includes(operatorUnionId)
+    && !invalidOwners.includes(operatorUnionId);
+}
+
+async function completeLocalDeferredOwnerTransfer(
+  created: TeamGroupCreateResult,
+  initiallyInvalidOwners: string[],
+  invalidOwners: string[],
+  operatorUnionId: string | undefined,
+  transfer: OrchestrateGroupDeps['transferTeamGroupOwner'],
+): Promise<TeamGroupCreateResult> {
+  if (!deferredOperatorWasAdded(operatorUnionId, initiallyInvalidOwners, invalidOwners)) return created;
+  if (!created.chatId || !created.creator || !transfer) {
+    return { ...created, ownerTransferredTo: null, transferError: 'owner_transfer_retry_unavailable' };
+  }
+  try {
+    return {
+      ...created,
+      ...await transfer({
+        creatorLarkAppId: created.creator,
+        chatId: created.chatId,
+        transferOwnerUnionId: operatorUnionId,
+      }),
+    };
+  } catch {
+    return { ...created, ownerTransferredTo: null, transferError: 'owner_transfer_retry_failed' };
+  }
+}
+
+async function completeDelegatedDeferredOwnerTransfer(
+  creatorDeployment: { callbackUrl?: string; delegationToken?: string },
+  created: TeamGroupCreateResult,
+  initiallyInvalidOwners: string[],
+  invalidOwners: string[],
+  operatorUnionId: string | undefined,
+  requestId: string,
+  fetcher: Fetcher,
+): Promise<TeamGroupCreateResult> {
+  if (!deferredOperatorWasAdded(operatorUnionId, initiallyInvalidOwners, invalidOwners)) return created;
+  if (!creatorDeployment.callbackUrl || !creatorDeployment.delegationToken) {
+    return { ...created, ownerTransferredTo: null, transferError: 'owner_transfer_retry_unavailable' };
+  }
+  try {
+    const rr = await fetchWithTimeout(fetcher, `${creatorDeployment.callbackUrl}/api/federation/delegate-transfer-owner`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${creatorDeployment.delegationToken}` },
+      body: JSON.stringify({ requestId }),
+    });
+    const rj = await rr.json().catch(() => ({} as any));
+    if (!rr.ok || !rj?.ok) {
+      return { ...created, ownerTransferredTo: null, transferError: rj?.error || `owner_transfer_http_${rr.status}` };
+    }
+    return {
+      ...created,
+      ownerTransferredTo: rj.ownerTransferredTo ?? null,
+      transferError: rj.transferError ?? null,
+      notifyMessageId: rj.notifyMessageId ?? null,
+      notifyError: rj.notifyError ?? null,
+    };
+  } catch (e) {
+    return { ...created, ownerTransferredTo: null, transferError: hubError(e).error };
+  }
 }
 
 /**

--- a/src/dashboard/federation-api.ts
+++ b/src/dashboard/federation-api.ts
@@ -129,7 +129,7 @@ export interface FederationApiDeps {
   liveBots?: () => LiveBot[];
   /** Injected by dashboard.ts — used when a HUB delegates 拉群 to THIS spoke
    *  (we create the chat with one of OUR local online bots as creator). */
-  createTeamGroup?: (args: { name: string; larkAppIds: string[]; ownerUnionIds?: string[] }) => Promise<{
+  createTeamGroup?: (args: { name: string; larkAppIds: string[]; ownerUnionIds?: string[]; transferOwnerUnionId?: string }) => Promise<{
     ok: boolean; chatId?: string; shareLink?: string; invalidBotIds?: string[]; invalidOwnerUnionIds?: string[]; error?: string;
   }>;
   /** Add owners to an existing chat via one of OUR local bots (defaults to
@@ -318,14 +318,26 @@ export async function handleFederationApi(
     // Dedup + cap inputs (pre-auth command endpoint — keep blast radius small).
     const larkAppIds: string[] = Array.from(new Set((Array.isArray(body?.larkAppIds) ? body.larkAppIds : []).filter((x: any) => typeof x === 'string')));
     const ownerUnionIds: string[] = Array.from(new Set((Array.isArray(body?.ownerUnionIds) ? body.ownerUnionIds : []).filter((x: any) => typeof x === 'string')));
+    const transferOwnerUnionId = typeof body?.transferOwnerUnionId === 'string'
+      ? body.transferOwnerUnionId.trim()
+      : '';
     const name = (String(body?.name ?? '').trim()) || '协作群';
     if (larkAppIds.length === 0) { jsonRes(res, 400, { ok: false, error: 'no_bots_selected' }); return true; }
     if (larkAppIds.length > MAX_BOTS || ownerUnionIds.length > MAX_OWNERS) { jsonRes(res, 400, { ok: false, error: 'too_many' }); return true; }
+    if (body?.transferOwnerUnionId !== undefined
+      && (!transferOwnerUnionId.startsWith('on_') || !ownerUnionIds.includes(transferOwnerUnionId))) {
+      jsonRes(res, 400, { ok: false, error: 'invalid_transfer_owner_union_id' }); return true;
+    }
     // Guardrail: the delegation must involve at least one of OUR local bots
     // (otherwise it's unrelated to this deployment — refuse to act as creator).
     const localIds = new Set(buildTeamRoster(dataDir, undefined, undefined, deps.liveBots?.()).bots.map(b => b.larkAppId));
     if (!larkAppIds.some(id => localIds.has(id))) { jsonRes(res, 400, { ok: false, error: 'no_local_bot' }); return true; }
-    const r = await deps.createTeamGroup({ name, larkAppIds, ownerUnionIds });
+    const r = await deps.createTeamGroup({
+      name,
+      larkAppIds,
+      ownerUnionIds,
+      transferOwnerUnionId: transferOwnerUnionId || undefined,
+    });
     const result = { status: r.ok ? 200 : 502, body: r };
     idemSet(idemKey, result); // cache terminal result (success AND failure)
     jsonRes(res, result.status, result.body);

--- a/src/dashboard/federation-api.ts
+++ b/src/dashboard/federation-api.ts
@@ -30,7 +30,12 @@ import {
 import { findMembershipByDelegationToken } from '../services/federation-membership-store.js';
 import { buildTeamRoster, type LiveBot } from '../services/team-roster.js';
 import { getDeploymentIdentity } from '../services/deployment-identity.js';
-import { orchestrateFederatedGroup, type Fetcher } from './federated-group-core.js';
+import {
+  orchestrateFederatedGroup,
+  type Fetcher,
+  type TeamGroupCreateResult,
+  type TeamGroupOwnerTransferResult,
+} from './federated-group-core.js';
 import { addUsersToChatByUnionId } from '../services/groups-store.js';
 import { loadBotConfigs, registerBot, getBot } from '../bot-registry.js';
 
@@ -129,9 +134,14 @@ export interface FederationApiDeps {
   liveBots?: () => LiveBot[];
   /** Injected by dashboard.ts — used when a HUB delegates 拉群 to THIS spoke
    *  (we create the chat with one of OUR local online bots as creator). */
-  createTeamGroup?: (args: { name: string; larkAppIds: string[]; ownerUnionIds?: string[]; transferOwnerUnionId?: string }) => Promise<{
-    ok: boolean; chatId?: string; shareLink?: string; invalidBotIds?: string[]; invalidOwnerUnionIds?: string[]; error?: string;
-  }>;
+  createTeamGroup?: (args: { name: string; larkAppIds: string[]; ownerUnionIds?: string[]; transferOwnerUnionId?: string }) => Promise<TeamGroupCreateResult>;
+  /** Complete a pending transfer through the daemon that originally created
+   *  the chat. Used locally and by delegate-transfer-owner. */
+  transferTeamGroupOwner?: (args: {
+    creatorLarkAppId: string;
+    chatId: string;
+    transferOwnerUnionId: string;
+  }) => Promise<TeamGroupOwnerTransferResult>;
   /** Add owners to an existing chat via one of OUR local bots (defaults to
    *  ensure-client + addUsersToChatByUnionId). Test seam. Returns the rejected ids. */
   addOwners?: (viaLarkAppId: string, chatId: string, ownerUnionIds: string[]) => Promise<{ invalidUserIds: string[] }>;
@@ -291,7 +301,12 @@ export async function handleFederationApi(
     if (cached) { jsonRes(res, cached.status, cached.body); return true; }
     const out = await orchestrateFederatedGroup(dataDir,
       { name, larkAppIds, operatorUnionId: found.deployment.ownerUnionId, requestId, teamId: found.teamId },
-      { createTeamGroup: deps.createTeamGroup, fetcher: deps.fetcher ?? fetch, live: deps.liveBots?.() });
+      {
+        createTeamGroup: deps.createTeamGroup,
+        transferTeamGroupOwner: deps.transferTeamGroupOwner,
+        fetcher: deps.fetcher ?? fetch,
+        live: deps.liveBots?.(),
+      });
     idemSet(idemKey, { status: out.status, body: out.body });
     jsonRes(res, out.status, out.body);
     return true;
@@ -338,8 +353,53 @@ export async function handleFederationApi(
       ownerUnionIds,
       transferOwnerUnionId: transferOwnerUnionId || undefined,
     });
+    if (r.ok
+      && r.chatId
+      && r.creator
+      && transferOwnerUnionId
+      && r.invalidOwnerUnionIds?.includes(transferOwnerUnionId)) {
+      // Mint a short-lived capability bound to THIS authenticated delegate
+      // request. The hub can trigger it only after the owner's deployment has
+      // successfully added the operator; it cannot substitute chat/creator/id.
+      idemSet(`delegate-transfer-pending:${token}:${requestId}`, {
+        creatorLarkAppId: r.creator,
+        chatId: r.chatId,
+        transferOwnerUnionId,
+      });
+    }
     const result = { status: r.ok ? 200 : 502, body: r };
     idemSet(idemKey, result); // cache terminal result (success AND failure)
+    jsonRes(res, result.status, result.body);
+    return true;
+  }
+
+  // Hub finishes a deferred transfer on THIS creator deployment after the
+  // target's own deployment has successfully added them to the chat. The only
+  // client input is requestId; target/chat/creator come from the authenticated
+  // delegate-group result cached above, closing the confused-deputy gap.
+  if (path === '/api/federation/delegate-transfer-owner' && method === 'POST') {
+    if (!deps.transferTeamGroupOwner) { jsonRes(res, 501, { ok: false, error: 'owner_transfer_unavailable' }); return true; }
+    let body: any;
+    try { body = await readBody(req); } catch { jsonRes(res, 400, { ok: false, error: 'bad_json' }); return true; }
+    const token = bearerOnly(req);
+    if (!findMembershipByDelegationToken(dataDir, token)) { jsonRes(res, 403, { ok: false, error: 'unknown_token' }); return true; }
+    const requestId = String(body?.requestId ?? '').trim();
+    if (!requestId) { jsonRes(res, 400, { ok: false, error: 'request_id_required' }); return true; }
+    const resultKey = `delegate-transfer-result:${token}:${requestId}`;
+    const cached = idemGet(resultKey) as { status: number; body: any } | undefined;
+    if (cached) { jsonRes(res, cached.status, cached.body); return true; }
+    const pending = idemGet(`delegate-transfer-pending:${token}:${requestId}`) as {
+      creatorLarkAppId: string;
+      chatId: string;
+      transferOwnerUnionId: string;
+    } | undefined;
+    if (!pending) { jsonRes(res, 409, { ok: false, error: 'owner_transfer_not_pending' }); return true; }
+
+    const transferred = await deps.transferTeamGroupOwner(pending);
+    const result = { status: 200, body: { ok: true, ...transferred } };
+    // Successful transfer is idempotent and may have sent an @ notification;
+    // cache it to suppress duplicate notifications. Failures remain retryable.
+    if (transferred.ownerTransferredTo && !transferred.transferError) idemSet(resultKey, result);
     jsonRes(res, result.status, result.body);
     return true;
   }

--- a/src/dashboard/federation-spoke-api.ts
+++ b/src/dashboard/federation-spoke-api.ts
@@ -301,7 +301,7 @@ export interface FederationSpokeDeps {
   liveBots?: () => LiveBot[];
   /** Injected by dashboard.ts — picks a local online creator + proxies to its
    *  daemon's /api/groups/create (federated bots are added by larkAppId). */
-  createTeamGroup?: (args: { name: string; larkAppIds: string[]; ownerUnionIds?: string[] }) => Promise<{
+  createTeamGroup?: (args: { name: string; larkAppIds: string[]; ownerUnionIds?: string[]; transferOwnerUnionId?: string }) => Promise<{
     ok: boolean; chatId?: string; shareLink?: string; invalidBotIds?: string[]; invalidOwnerUnionIds?: string[]; error?: string;
   }>;
   /** Test seam: resolve owner candidates from allowedUsers (defaults to the real

--- a/src/dashboard/federation-spoke-api.ts
+++ b/src/dashboard/federation-spoke-api.ts
@@ -35,7 +35,14 @@ import { setDeploymentOwner } from '../services/deployment-identity.js';
 import { createPairing, getPairingStatus, consumePairing } from '../services/pairing-store.js';
 import { resolveAllowedUsersWithMap, resolveUserUnionId } from '../im/lark/client.js';
 import { logger } from '../utils/logger.js';
-import { fetchWithTimeout, hubError, orchestrateFederatedGroup, type Fetcher } from './federated-group-core.js';
+import {
+  fetchWithTimeout,
+  hubError,
+  orchestrateFederatedGroup,
+  type Fetcher,
+  type TeamGroupCreateResult,
+  type TeamGroupOwnerTransferResult,
+} from './federated-group-core.js';
 
 export interface OwnerCandidate { unionId: string; name: string }
 
@@ -301,9 +308,12 @@ export interface FederationSpokeDeps {
   liveBots?: () => LiveBot[];
   /** Injected by dashboard.ts — picks a local online creator + proxies to its
    *  daemon's /api/groups/create (federated bots are added by larkAppId). */
-  createTeamGroup?: (args: { name: string; larkAppIds: string[]; ownerUnionIds?: string[]; transferOwnerUnionId?: string }) => Promise<{
-    ok: boolean; chatId?: string; shareLink?: string; invalidBotIds?: string[]; invalidOwnerUnionIds?: string[]; error?: string;
-  }>;
+  createTeamGroup?: (args: { name: string; larkAppIds: string[]; ownerUnionIds?: string[]; transferOwnerUnionId?: string }) => Promise<TeamGroupCreateResult>;
+  transferTeamGroupOwner?: (args: {
+    creatorLarkAppId: string;
+    chatId: string;
+    transferOwnerUnionId: string;
+  }) => Promise<TeamGroupOwnerTransferResult>;
   /** Test seam: resolve owner candidates from allowedUsers (defaults to the real
    *  Feishu-backed resolver). */
   ownerCandidates?: () => Promise<OwnerCandidate[]>;
@@ -390,7 +400,16 @@ export async function handleFederationSpokeApi(
     if (localOnline.size > 0 && !larkAppIds.some(id => localOnline.has(id))) {
       jsonRes(res, 400, { ok: false, error: 'no_local_online_bot' }); return true;
     }
-    const out = await orchestrateFederatedGroup(dataDir, { name, larkAppIds, operatorUnionId, requestId: randomUUID(), teamId }, { createTeamGroup: deps.createTeamGroup, fetcher, live });
+    const out = await orchestrateFederatedGroup(
+      dataDir,
+      { name, larkAppIds, operatorUnionId, requestId: randomUUID(), teamId },
+      {
+        createTeamGroup: deps.createTeamGroup,
+        transferTeamGroupOwner: deps.transferTeamGroupOwner,
+        fetcher,
+        live,
+      },
+    );
     jsonRes(res, out.status, out.body);
     return true;
   }

--- a/src/dashboard/team-group.ts
+++ b/src/dashboard/team-group.ts
@@ -26,3 +26,29 @@ export function planGroupCreator(
   }
   return { creatorLarkAppId: pickFallback(selectedIds), inviteUser: false };
 }
+
+export interface TeamGroupCreatePayloadInput {
+  name: string;
+  larkAppIds: string[];
+  userOpenIds: string[];
+  ownerUnionIds: string[];
+  transferOwnerUnionId?: string;
+  roleProfileId?: string;
+}
+
+/**
+ * Build the daemon request for a team-created group. The caller derives the
+ * initiating operator from authenticated team identity; keep that explicit
+ * instead of guessing from ownerUnionIds, which also contains bot owners.
+ */
+export function buildTeamGroupCreatePayload(args: TeamGroupCreatePayloadInput) {
+  const transferOwnerUnionId = args.transferOwnerUnionId?.trim();
+  return {
+    name: args.name,
+    larkAppIds: args.larkAppIds,
+    userOpenIds: args.userOpenIds,
+    ownerUnionIds: args.ownerUnionIds,
+    ...(transferOwnerUnionId ? { transferOwnerUnionId } : {}),
+    ...(args.roleProfileId ? { roleProfileId: args.roleProfileId } : {}),
+  };
+}

--- a/src/services/group-creator.ts
+++ b/src/services/group-creator.ts
@@ -14,11 +14,12 @@
  * duplicate groups. Only createChat throwing surfaces as an exception.
  *
  * Lark open_id is app-scoped: `userOpenIds`, `transferOwnerTo`, and
- * `notifyOwnerOpenId` MUST be in `creatorLarkAppId`'s app scope. Enforcing
- * this is the decision layer's job — the service trusts its inputs.
+ * `notifyOwnerOpenId` MUST be in `creatorLarkAppId`'s app scope. The team-group
+ * path may instead provide `transferOwnerUnionId`; this service resolves that
+ * tenant-stable ID into the creator app's open_id before transfer.
  */
 import { createChat, transferChatOwner, getChatOwner, getChatShareLink, addUsersToChatByUnionId, addBotToChat } from './groups-store.js';
-import { listChatBotMembers, sendMessage } from '../im/lark/client.js';
+import { listChatBotMembers, resolveAllowedUsersWithMap, sendMessage } from '../im/lark/client.js';
 import { bindOncall } from './oncall-store.js';
 import { isValidRoleProfileId, readRoleProfileEntry } from './role-profile-store.js';
 import { writeRoleFile } from '../core/role-resolver.js';
@@ -35,6 +36,9 @@ export interface CreateGroupOpts {
    *  federated group regardless of which bot they paired through (open_id is
    *  app-scoped, union_id is not). Added after the chat is created. */
   ownerUnionIds?: string[];
+  /** Tenant-stable owner target for federated/team groups. Resolved to an
+   *  app-scoped open_id after the owner has been added to the chat. */
+  transferOwnerUnionId?: string;
   transferOwnerTo?: string;
   notifyOwnerOpenId?: string;
   /** Optional working directory to bind the newly created chat to oncall for
@@ -114,17 +118,33 @@ export async function createGroupWithBots(opts: CreateGroupOpts): Promise<Create
     invalidOwnerUnionIds = ar.invalidUserIds;
   }
 
-  let ownerTransferredTo: string | null = null;
+  let transferOwnerTo = opts.transferOwnerTo?.trim() || null;
+  const transferOwnerUnionId = opts.transferOwnerUnionId?.trim() || null;
   let transferError: string | null = null;
-  if (opts.transferOwnerTo) {
-    // Skip transfer if Feishu rejected the invite — transferring to a
-    // non-member returns "user not in chat" anyway.
-    if (r.invalidUserIds.includes(opts.transferOwnerTo)) {
+  if (!transferOwnerTo && transferOwnerUnionId) {
+    if (invalidOwnerUnionIds.includes(transferOwnerUnionId)) {
       transferError = 'invitee_rejected';
     } else {
-      const tr = await transferChatOwner(opts.creatorLarkAppId, r.chatId, opts.transferOwnerTo);
+      try {
+        const resolved = await resolveAllowedUsersWithMap(opts.creatorLarkAppId, [transferOwnerUnionId]);
+        transferOwnerTo = resolved.map.get(transferOwnerUnionId) ?? null;
+        if (!transferOwnerTo) transferError = 'owner_union_id_unresolved';
+      } catch {
+        transferError = 'owner_union_id_unresolved';
+      }
+    }
+  }
+
+  let ownerTransferredTo: string | null = null;
+  if (transferOwnerTo && !transferError) {
+    // Skip transfer if Feishu rejected the invite — transferring to a
+    // non-member returns "user not in chat" anyway.
+    if (r.invalidUserIds.includes(transferOwnerTo)) {
+      transferError = 'invitee_rejected';
+    } else {
+      const tr = await transferChatOwner(opts.creatorLarkAppId, r.chatId, transferOwnerTo);
       if (tr.ok) {
-        ownerTransferredTo = opts.transferOwnerTo;
+        ownerTransferredTo = transferOwnerTo;
       } else {
         // Lark occasionally ACKs the owner transfer slowly (504 Gateway Timeout
         // or transient network error) even though the write actually committed
@@ -132,8 +152,8 @@ export async function createGroupWithBots(opts: CreateGroupOpts): Promise<Create
         // surfacing the error — if the chat is already owned by the target,
         // the transfer really did succeed and the warning would mislead.
         const currentOwner = await getChatOwner(opts.creatorLarkAppId, r.chatId);
-        if (currentOwner === opts.transferOwnerTo) {
-          ownerTransferredTo = opts.transferOwnerTo;
+        if (currentOwner === transferOwnerTo) {
+          ownerTransferredTo = transferOwnerTo;
         } else {
           transferError = tr.error;
         }
@@ -141,17 +161,19 @@ export async function createGroupWithBots(opts: CreateGroupOpts): Promise<Create
     }
   }
 
+  const notifyOwnerOpenId = opts.notifyOwnerOpenId?.trim()
+    || (transferOwnerUnionId ? transferOwnerTo : null);
   let notifyMessageId: string | null = null;
-  let notifyError: string | null = null;
-  if (opts.notifyOwnerOpenId) {
-    if (r.invalidUserIds.includes(opts.notifyOwnerOpenId)) {
+  let notifyError: string | null = !notifyOwnerOpenId && transferOwnerUnionId ? transferError : null;
+  if (notifyOwnerOpenId) {
+    if (r.invalidUserIds.includes(notifyOwnerOpenId)) {
       notifyError = 'invitee_rejected';
     } else {
       try {
         notifyMessageId = await sendMessage(
           opts.creatorLarkAppId,
           r.chatId,
-          `<at user_id="${opts.notifyOwnerOpenId}"></at>`,
+          `<at user_id="${notifyOwnerOpenId}"></at>`,
           'text',
         );
       } catch (e: any) {

--- a/src/services/group-creator.ts
+++ b/src/services/group-creator.ts
@@ -72,6 +72,41 @@ export interface CreateGroupResult {
   roleProfileBootstrapError: string | null;
 }
 
+export interface TransferGroupOwnerOpts {
+  creatorLarkAppId: string;
+  chatId: string;
+  ownerId: string;
+  ownerIdType?: 'open_id' | 'union_id';
+}
+
+export interface TransferGroupOwnerResult {
+  ownerTransferredTo: string | null;
+  transferError: string | null;
+}
+
+/**
+ * Best-effort ownership transfer for an already-created group. Federation uses
+ * this after an out-of-scope operator has been added by their own deployment;
+ * accepting union_id avoids leaking an app-scoped open_id back to the creator.
+ */
+export async function transferGroupOwner(opts: TransferGroupOwnerOpts): Promise<TransferGroupOwnerResult> {
+  const ownerId = opts.ownerId.trim();
+  if (!ownerId) return { ownerTransferredTo: null, transferError: 'owner_id_required' };
+  const ownerIdType = opts.ownerIdType ?? 'open_id';
+  const tr = ownerIdType === 'open_id'
+    ? await transferChatOwner(opts.creatorLarkAppId, opts.chatId, ownerId)
+    : await transferChatOwner(opts.creatorLarkAppId, opts.chatId, ownerId, ownerIdType);
+  if (tr.ok) return { ownerTransferredTo: ownerId, transferError: null };
+
+  // A timed-out update may still have committed. Read back using the SAME ID
+  // type as the request so union_id retries remain app-scope independent.
+  const currentOwner = ownerIdType === 'open_id'
+    ? await getChatOwner(opts.creatorLarkAppId, opts.chatId)
+    : await getChatOwner(opts.creatorLarkAppId, opts.chatId, ownerIdType);
+  if (currentOwner === ownerId) return { ownerTransferredTo: ownerId, transferError: null };
+  return { ownerTransferredTo: null, transferError: tr.error };
+}
+
 export async function createGroupWithBots(opts: CreateGroupOpts): Promise<CreateGroupResult> {
   // Filter creator out of the bot invite list. createChat does this defensively
   // too, but doing it here makes the service contract explicit and keeps
@@ -142,22 +177,13 @@ export async function createGroupWithBots(opts: CreateGroupOpts): Promise<Create
     if (r.invalidUserIds.includes(transferOwnerTo)) {
       transferError = 'invitee_rejected';
     } else {
-      const tr = await transferChatOwner(opts.creatorLarkAppId, r.chatId, transferOwnerTo);
-      if (tr.ok) {
-        ownerTransferredTo = transferOwnerTo;
-      } else {
-        // Lark occasionally ACKs the owner transfer slowly (504 Gateway Timeout
-        // or transient network error) even though the write actually committed
-        // server-side. Verify by reading back the current owner before
-        // surfacing the error — if the chat is already owned by the target,
-        // the transfer really did succeed and the warning would mislead.
-        const currentOwner = await getChatOwner(opts.creatorLarkAppId, r.chatId);
-        if (currentOwner === transferOwnerTo) {
-          ownerTransferredTo = transferOwnerTo;
-        } else {
-          transferError = tr.error;
-        }
-      }
+      const transferred = await transferGroupOwner({
+        creatorLarkAppId: opts.creatorLarkAppId,
+        chatId: r.chatId,
+        ownerId: transferOwnerTo,
+      });
+      ownerTransferredTo = transferred.ownerTransferredTo;
+      transferError = transferred.transferError;
     }
   }
 

--- a/src/services/groups-store.ts
+++ b/src/services/groups-store.ts
@@ -122,20 +122,22 @@ export async function createChat(
  * is the case right after createChat since the creator bot is the implicit
  * owner.
  *
- * `newOwnerOpenId` must be in the calling bot's app scope — Lark open_ids are
- * app-scoped, see operator-selector.ts for why.
+ * Defaults to open_id for existing callers. Deferred federation completion can
+ * pass union_id after another deployment has added the user, avoiding any
+ * cross-app open_id handoff.
  */
 export async function transferChatOwner(
   ownerLarkAppId: string,
   chatId: string,
-  newOwnerOpenId: string,
+  newOwnerId: string,
+  userIdType: 'open_id' | 'union_id' = 'open_id',
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const client = getBotClient(ownerLarkAppId);
   try {
     const res: any = await (client as any).im.v1.chat.update({
       path: { chat_id: chatId },
-      params: { user_id_type: 'open_id' },
-      data: { owner_id: newOwnerOpenId },
+      params: { user_id_type: userIdType },
+      data: { owner_id: newOwnerId },
     });
     if (res.code !== 0 && res.code !== undefined) {
       return { ok: false, error: `${res.msg ?? 'unknown'} (code: ${res.code})` };
@@ -147,7 +149,8 @@ export async function transferChatOwner(
 }
 
 /**
- * Fetch the current owner of a chat (as an open_id). Used by group-creator to
+ * Fetch the current owner of a chat (open_id by default, optionally union_id).
+ * Used by group-creator to
  * verify the post-transfer state when transferChatOwner returns an error —
  * Lark sometimes ACKs a transfer slowly (e.g. 504 Gateway Timeout) even though
  * the server-side write succeeded, so a follow-up read disambiguates "really
@@ -157,12 +160,14 @@ export async function transferChatOwner(
  * callers treat undefined as "unknown" and keep the original error.
  */
 export async function getChatOwner(
-  larkAppId: string, chatId: string,
+  larkAppId: string,
+  chatId: string,
+  userIdType: 'open_id' | 'union_id' = 'open_id',
 ): Promise<string | undefined> {
   const client = getBotClient(larkAppId);
   try {
     const res: any = await larkGet(client, `/open-apis/im/v1/chats/${encodeURIComponent(chatId)}`, {
-      user_id_type: 'open_id',
+      user_id_type: userIdType,
     });
     if (res.code !== 0 && res.code !== undefined) return undefined;
     const owner = res.data?.owner_id;

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import { startIpcServer, setLarkAppId, setIpcAuthSecret, setBotRenamer, type IpcServerHandle } from '../src/core/dashboard-ipc-server.js';
 import { dashboardEventBus } from '../src/core/dashboard-events.js';
 import * as groupsStore from '../src/services/groups-store.js';
+import * as larkClient from '../src/im/lark/client.js';
 import * as oncallStore from '../src/services/oncall-store.js';
 import * as sessionStore from '../src/services/session-store.js';
 import * as workerPool from '../src/core/worker-pool.js';
@@ -1102,6 +1103,47 @@ describe('POST /api/groups/create', () => {
     bindSpy.mockRestore();
     addSpy.mockRestore();
     createSpy.mockRestore();
+  });
+});
+
+describe('POST /api/groups/transfer-owner', () => {
+  it('completes a deferred transfer by union_id and notifies the new owner', async () => {
+    setLarkAppId('test-app');
+    const transferSpy = vi.spyOn(groupsStore, 'transferChatOwner').mockResolvedValue({ ok: true });
+    const notifySpy = vi.spyOn(larkClient, 'sendMessage').mockResolvedValue('om_owner');
+    handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/groups/transfer-owner`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ chatId: 'oc_new', ownerUnionId: 'on_operator' }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      ok: true,
+      ownerTransferredTo: 'on_operator',
+      transferError: null,
+      notifyMessageId: 'om_owner',
+    });
+    expect(transferSpy).toHaveBeenCalledWith('test-app', 'oc_new', 'on_operator', 'union_id');
+    expect(notifySpy).toHaveBeenCalledWith(
+      'test-app', 'oc_new', '<at user_id="on_operator"></at>', 'text',
+    );
+    notifySpy.mockRestore();
+    transferSpy.mockRestore();
+  });
+
+  it('rejects malformed chat or union ids before calling Feishu', async () => {
+    setLarkAppId('test-app');
+    const transferSpy = vi.spyOn(groupsStore, 'transferChatOwner').mockResolvedValue({ ok: true });
+    handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/groups/transfer-owner`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ chatId: 'bad', ownerUnionId: 'ou_wrong_scope' }),
+    });
+    expect(res.status).toBe(400);
+    expect(transferSpy).not.toHaveBeenCalled();
+    transferSpy.mockRestore();
   });
 });
 

--- a/test/federation-api.test.ts
+++ b/test/federation-api.test.ts
@@ -159,16 +159,22 @@ describe('handleFederationApi', () => {
     const createTeamGroup = vi.fn(async (args: any) => { calls++; captured = args; return { ok: true, chatId: 'oc_deleg', shareLink: 'https://x', invalidBotIds: [] }; });
     // valid token + involves our local bot cli_a → creates
     let res = makeRes();
-    await callWithGroup(makeReq('POST', '/api/federation/delegate-group', { name: 'g', larkAppIds: ['cli_a', 'cli_b'], ownerUnionIds: ['on_1'], requestId: 'req1' }, bearer('DTOK')), res, '/api/federation/delegate-group', createTeamGroup);
+    await callWithGroup(makeReq('POST', '/api/federation/delegate-group', { name: 'g', larkAppIds: ['cli_a', 'cli_b'], ownerUnionIds: ['on_1'], transferOwnerUnionId: 'on_1', requestId: 'req1' }, bearer('DTOK')), res, '/api/federation/delegate-group', createTeamGroup);
     expect(res.statusCode).toBe(200);
     expect(json(res).chatId).toBe('oc_deleg');
-    expect(captured).toMatchObject({ name: 'g', larkAppIds: ['cli_a', 'cli_b'], ownerUnionIds: ['on_1'] });
+    expect(captured).toMatchObject({ name: 'g', larkAppIds: ['cli_a', 'cli_b'], ownerUnionIds: ['on_1'], transferOwnerUnionId: 'on_1' });
     // replay same requestId → cached, createTeamGroup NOT called again (no dup group)
     res = makeRes();
     await callWithGroup(makeReq('POST', '/api/federation/delegate-group', { larkAppIds: ['cli_a'], requestId: 'req1' }, bearer('DTOK')), res, '/api/federation/delegate-group', createTeamGroup);
     expect(res.statusCode).toBe(200);
     expect(json(res).chatId).toBe('oc_deleg');
     expect(calls).toBe(1); // idempotent
+    // transfer target must be one of the trusted owner invitees
+    res = makeRes();
+    await callWithGroup(makeReq('POST', '/api/federation/delegate-group', { larkAppIds: ['cli_a'], ownerUnionIds: ['on_1'], transferOwnerUnionId: 'on_other', requestId: 'bad-owner' }, bearer('DTOK')), res, '/api/federation/delegate-group', createTeamGroup);
+    expect(res.statusCode).toBe(400);
+    expect(json(res).error).toBe('invalid_transfer_owner_union_id');
+    expect(calls).toBe(1);
     // guardrail: no local bot in selection → 400 no_local_bot
     res = makeRes();
     await callWithGroup(makeReq('POST', '/api/federation/delegate-group', { larkAppIds: ['cli_remote_only'], requestId: 'r2' }, bearer('DTOK')), res, '/api/federation/delegate-group', createTeamGroup);
@@ -201,6 +207,7 @@ describe('handleFederationApi', () => {
     expect(res.statusCode).toBe(200);
     expect(json(res).chatId).toBe('oc_g');
     expect(captured.ownerUnionIds).toContain('on_spoke'); // operator from syncToken, NOT request body
+    expect(captured.transferOwnerUnionId).toBe('on_spoke');
     // replay same requestId → idempotent (createTeamGroup not called again)
     res = makeRes();
     await callWithGroup(makeReq('POST', '/api/federation/group', { name: 'g', larkAppIds: ['cli_hub'], requestId: 'r1' }, bearer(syncToken)), res, '/api/federation/group', createTeamGroup);
@@ -335,10 +342,11 @@ describe('handleFederationApi', () => {
     registerDeployment(dataDir, DEFAULT_TEAM_ID, { deploymentId: 'dep_b', name: 'B', ownerUnionId: 'on_b', bots: [{ larkAppId: 'cli_b', botName: 'B1', cliId: 'codex', ownerUnionId: 'on_b' } as any], callbackUrl: 'http://b:7891', delegationToken: 'DTB' });
     const syncToken = (await import('../src/services/federation-store.js')).listFederatedDeployments(dataDir, DEFAULT_TEAM_ID).find(d => d.deploymentId === 'dep_a')!.syncToken;
     const createTeamGroup = vi.fn(async () => ({ ok: false, error: 'no_online_daemon' })); // hub has no local creator
+    let delegateGroupCall: any = null;
     let addOwnerCall: any = null;
     const fetcher = vi.fn(async (u: any, init: any) => {
       const url = String(u);
-      if (url === 'http://a:7891/api/federation/delegate-group') return { ok: true, status: 200, json: async () => ({ ok: true, chatId: 'oc_g', invalidOwnerUnionIds: ['on_b'] }) } as any; // A built, couldn't add B's owner
+      if (url === 'http://a:7891/api/federation/delegate-group') { delegateGroupCall = JSON.parse(init.body); return { ok: true, status: 200, json: async () => ({ ok: true, chatId: 'oc_g', invalidOwnerUnionIds: ['on_b'] }) } as any; } // A built, couldn't add B's owner
       if (url === 'http://b:7891/api/federation/delegate-add-owner') { addOwnerCall = JSON.parse(init.body); return { ok: true, status: 200, json: async () => ({ ok: true, invalidUserIds: [] }) } as any; }
       return { ok: true, status: 200, json: async () => ({}) } as any;
     });
@@ -348,6 +356,7 @@ describe('handleFederationApi', () => {
     expect(json(res).chatId).toBe('oc_g');
     expect(json(res).delegatedTo).toBe('A');
     expect(json(res).invalidOwnerUnionIds).toEqual([]); // on_b added via B after delegate-build
+    expect(delegateGroupCall.transferOwnerUnionId).toBe('on_a'); // operator identity survives hub→spoke delegation
     expect(addOwnerCall).toMatchObject({ chatId: 'oc_g', viaLarkAppId: 'cli_b', ownerUnionIds: ['on_b'] });
   });
 

--- a/test/federation-api.test.ts
+++ b/test/federation-api.test.ts
@@ -156,7 +156,19 @@ describe('handleFederationApi', () => {
     writeBots([{ larkAppId: 'cli_a', botOpenId: null, botName: 'A', cliId: 'claude' }]); // our local bot
     addMembership(dataDir, { hubUrl: 'http://hub:7891', teamId: 'default', teamName: 'T', syncToken: 'st', deploymentId: 'dep_me', delegationToken: 'DTOK' });
     let calls = 0; let captured: any = null;
-    const createTeamGroup = vi.fn(async (args: any) => { calls++; captured = args; return { ok: true, chatId: 'oc_deleg', shareLink: 'https://x', invalidBotIds: [] }; });
+    const createTeamGroup = vi.fn(async (args: any) => {
+      calls++; captured = args;
+      return {
+        ok: true,
+        chatId: 'oc_deleg',
+        creator: 'cli_a',
+        shareLink: 'https://x',
+        invalidBotIds: [],
+        invalidOwnerUnionIds: ['on_1'],
+        ownerTransferredTo: null,
+        transferError: 'invitee_rejected',
+      };
+    });
     // valid token + involves our local bot cli_a → creates
     let res = makeRes();
     await callWithGroup(makeReq('POST', '/api/federation/delegate-group', { name: 'g', larkAppIds: ['cli_a', 'cli_b'], ownerUnionIds: ['on_1'], transferOwnerUnionId: 'on_1', requestId: 'req1' }, bearer('DTOK')), res, '/api/federation/delegate-group', createTeamGroup);
@@ -169,6 +181,48 @@ describe('handleFederationApi', () => {
     expect(res.statusCode).toBe(200);
     expect(json(res).chatId).toBe('oc_deleg');
     expect(calls).toBe(1); // idempotent
+    // Once the hub has added on_1 through its own deployment, the same
+    // authenticated requestId unlocks exactly the cached creator/chat/target.
+    const transferTeamGroupOwner = vi.fn(async (args: any) => ({
+      ownerTransferredTo: args.transferOwnerUnionId,
+      transferError: null,
+      notifyMessageId: 'om_owner',
+      notifyError: null,
+    }));
+    // A caller cannot choose arbitrary transfer inputs or finalize a request
+    // that never minted a pending capability.
+    res = makeRes();
+    await handleFederationApi(
+      makeReq('POST', '/api/federation/delegate-transfer-owner', { requestId: 'not-pending' }, bearer('DTOK')),
+      res,
+      new URL('http://x/api/federation/delegate-transfer-owner'),
+      { dataDir, transferTeamGroupOwner },
+    );
+    expect(res.statusCode).toBe(409);
+    expect(json(res).error).toBe('owner_transfer_not_pending');
+    expect(transferTeamGroupOwner).not.toHaveBeenCalled();
+    res = makeRes();
+    await handleFederationApi(
+      makeReq('POST', '/api/federation/delegate-transfer-owner', { requestId: 'req1' }, bearer('DTOK')),
+      res,
+      new URL('http://x/api/federation/delegate-transfer-owner'),
+      { dataDir, transferTeamGroupOwner },
+    );
+    expect(res.statusCode).toBe(200);
+    expect(json(res)).toMatchObject({ ok: true, ownerTransferredTo: 'on_1', transferError: null });
+    expect(transferTeamGroupOwner).toHaveBeenCalledWith({
+      creatorLarkAppId: 'cli_a', chatId: 'oc_deleg', transferOwnerUnionId: 'on_1',
+    });
+    // Success is cached so a retry does not transfer or notify twice.
+    res = makeRes();
+    await handleFederationApi(
+      makeReq('POST', '/api/federation/delegate-transfer-owner', { requestId: 'req1' }, bearer('DTOK')),
+      res,
+      new URL('http://x/api/federation/delegate-transfer-owner'),
+      { dataDir, transferTeamGroupOwner },
+    );
+    expect(res.statusCode).toBe(200);
+    expect(transferTeamGroupOwner).toHaveBeenCalledTimes(1);
     // transfer target must be one of the trusted owner invitees
     res = makeRes();
     await callWithGroup(makeReq('POST', '/api/federation/delegate-group', { larkAppIds: ['cli_a'], ownerUnionIds: ['on_1'], transferOwnerUnionId: 'on_other', requestId: 'bad-owner' }, bearer('DTOK')), res, '/api/federation/delegate-group', createTeamGroup);
@@ -188,6 +242,49 @@ describe('handleFederationApi', () => {
     res = makeRes();
     await call(makeReq('POST', '/api/federation/delegate-group', { larkAppIds: ['cli_a'] }, bearer('DTOK')), res, '/api/federation/delegate-group');
     expect(res.statusCode).toBe(501);
+  });
+
+  it('delegate-transfer-owner: failed attempts stay retryable, then success is cached', async () => {
+    writeBots([{ larkAppId: 'cli_retry', botOpenId: null, botName: 'Retry', cliId: 'codex' }]);
+    addMembership(dataDir, { hubUrl: 'http://hub:7891', teamId: 'default', teamName: 'T', syncToken: 'st-retry', deploymentId: 'dep-retry', delegationToken: 'DTOK-RETRY' });
+    const createTeamGroup = vi.fn(async () => ({
+      ok: true,
+      chatId: 'oc_retry',
+      creator: 'cli_retry',
+      invalidBotIds: [],
+      invalidOwnerUnionIds: ['on_retry'],
+      ownerTransferredTo: null,
+      transferError: 'invitee_rejected',
+    }));
+    let res = makeRes();
+    await callWithGroup(
+      makeReq('POST', '/api/federation/delegate-group', {
+        larkAppIds: ['cli_retry'], ownerUnionIds: ['on_retry'],
+        transferOwnerUnionId: 'on_retry', requestId: 'retry-transfer',
+      }, bearer('DTOK-RETRY')),
+      res,
+      '/api/federation/delegate-group',
+      createTeamGroup,
+    );
+    expect(res.statusCode).toBe(200);
+
+    const transferTeamGroupOwner = vi.fn()
+      .mockResolvedValueOnce({ ownerTransferredTo: null, transferError: 'readback_mismatch', notifyMessageId: null, notifyError: null })
+      .mockResolvedValue({ ownerTransferredTo: 'on_retry', transferError: null, notifyMessageId: 'om_retry', notifyError: null });
+    const finish = async () => {
+      res = makeRes();
+      await handleFederationApi(
+        makeReq('POST', '/api/federation/delegate-transfer-owner', { requestId: 'retry-transfer' }, bearer('DTOK-RETRY')),
+        res,
+        new URL('http://x/api/federation/delegate-transfer-owner'),
+        { dataDir, transferTeamGroupOwner },
+      );
+      return json(res);
+    };
+    expect(await finish()).toMatchObject({ ownerTransferredTo: null, transferError: 'readback_mismatch' });
+    expect(await finish()).toMatchObject({ ownerTransferredTo: 'on_retry', transferError: null });
+    expect(await finish()).toMatchObject({ ownerTransferredTo: 'on_retry', transferError: null });
+    expect(transferTeamGroupOwner).toHaveBeenCalledTimes(2);
   });
 
   it('federation/group: spoke initiates; operator is hub-derived from syncToken; requestId required + idempotent', async () => {
@@ -337,17 +434,38 @@ describe('handleFederationApi', () => {
     expect(tried).toEqual(['cli_x', 'cli_y']);              // exhausted all candidates
   });
 
-  it('federation/group: no local creator → delegate-build to A, then delegate-add-owner to B for Bs owner', async () => {
+  it('federation/group: remote creator retries owner adds across deployments, then transfers ownership', async () => {
     registerDeployment(dataDir, DEFAULT_TEAM_ID, { deploymentId: 'dep_a', name: 'A', ownerUnionId: 'on_a', bots: [{ larkAppId: 'cli_a', botName: 'A1', cliId: 'codex', ownerUnionId: 'on_a' } as any], callbackUrl: 'http://a:7891', delegationToken: 'DTA' });
     registerDeployment(dataDir, DEFAULT_TEAM_ID, { deploymentId: 'dep_b', name: 'B', ownerUnionId: 'on_b', bots: [{ larkAppId: 'cli_b', botName: 'B1', cliId: 'codex', ownerUnionId: 'on_b' } as any], callbackUrl: 'http://b:7891', delegationToken: 'DTB' });
     const syncToken = (await import('../src/services/federation-store.js')).listFederatedDeployments(dataDir, DEFAULT_TEAM_ID).find(d => d.deploymentId === 'dep_a')!.syncToken;
     const createTeamGroup = vi.fn(async () => ({ ok: false, error: 'no_online_daemon' })); // hub has no local creator
     let delegateGroupCall: any = null;
-    let addOwnerCall: any = null;
+    const addOwnerCalls: any[] = [];
+    let transferOwnerCall: any = null;
     const fetcher = vi.fn(async (u: any, init: any) => {
       const url = String(u);
-      if (url === 'http://a:7891/api/federation/delegate-group') { delegateGroupCall = JSON.parse(init.body); return { ok: true, status: 200, json: async () => ({ ok: true, chatId: 'oc_g', invalidOwnerUnionIds: ['on_b'] }) } as any; } // A built, couldn't add B's owner
-      if (url === 'http://b:7891/api/federation/delegate-add-owner') { addOwnerCall = JSON.parse(init.body); return { ok: true, status: 200, json: async () => ({ ok: true, invalidUserIds: [] }) } as any; }
+      if (url === 'http://a:7891/api/federation/delegate-group') {
+        delegateGroupCall = JSON.parse(init.body);
+        return { ok: true, status: 200, json: async () => ({
+          ok: true,
+          chatId: 'oc_g',
+          creator: 'cli_a',
+          invalidOwnerUnionIds: ['on_a', 'on_b'],
+          ownerTransferredTo: null,
+          transferError: 'invitee_rejected',
+        }) } as any;
+      }
+      if (url.endsWith('/api/federation/delegate-add-owner')) {
+        addOwnerCalls.push({ url, body: JSON.parse(init.body) });
+        return { ok: true, status: 200, json: async () => ({ ok: true, invalidUserIds: [] }) } as any;
+      }
+      if (url === 'http://a:7891/api/federation/delegate-transfer-owner') {
+        transferOwnerCall = JSON.parse(init.body);
+        return { ok: true, status: 200, json: async () => ({
+          ok: true, ownerTransferredTo: 'on_a', transferError: null,
+          notifyMessageId: 'om_owner', notifyError: null,
+        }) } as any;
+      }
       return { ok: true, status: 200, json: async () => ({}) } as any;
     });
     const res = makeRes();
@@ -355,9 +473,15 @@ describe('handleFederationApi', () => {
     expect(res.statusCode).toBe(200);
     expect(json(res).chatId).toBe('oc_g');
     expect(json(res).delegatedTo).toBe('A');
-    expect(json(res).invalidOwnerUnionIds).toEqual([]); // on_b added via B after delegate-build
+    expect(json(res).invalidOwnerUnionIds).toEqual([]); // on_a/on_b added by their own deployments
+    expect(json(res).ownerTransferredTo).toBe('on_a');
+    expect(json(res).transferError).toBeNull();
     expect(delegateGroupCall.transferOwnerUnionId).toBe('on_a'); // operator identity survives hub→spoke delegation
-    expect(addOwnerCall).toMatchObject({ chatId: 'oc_g', viaLarkAppId: 'cli_b', ownerUnionIds: ['on_b'] });
+    expect(addOwnerCalls).toEqual(expect.arrayContaining([
+      expect.objectContaining({ url: 'http://a:7891/api/federation/delegate-add-owner', body: expect.objectContaining({ chatId: 'oc_g', viaLarkAppId: 'cli_a', ownerUnionIds: ['on_a'] }) }),
+      expect.objectContaining({ url: 'http://b:7891/api/federation/delegate-add-owner', body: expect.objectContaining({ chatId: 'oc_g', viaLarkAppId: 'cli_b', ownerUnionIds: ['on_b'] }) }),
+    ]));
+    expect(transferOwnerCall).toEqual({ requestId: 'g2' });
   });
 
   it('federation/group: a remote owner the creator cant add is delegated to its own deployment', async () => {
@@ -365,18 +489,39 @@ describe('handleFederationApi', () => {
     registerDeployment(dataDir, DEFAULT_TEAM_ID, { deploymentId: 'dep_spoke', name: 'Spoke', ownerUnionId: 'on_spoke', bots: [{ larkAppId: 'cli_sp', botName: 'SP', cliId: 'codex', ownerUnionId: 'on_spoke', ownerName: '博文' } as any], callbackUrl: 'http://spoke:7891', delegationToken: 'DT' });
     const syncToken = (await import('../src/services/federation-store.js')).listFederatedDeployments(dataDir, DEFAULT_TEAM_ID)[0].syncToken;
     // creator adds bots fine but can't add the remote owner on_spoke (Lark 232024)
-    const createTeamGroup = vi.fn(async () => ({ ok: true, chatId: 'oc_g', invalidBotIds: [], invalidOwnerUnionIds: ['on_spoke'] }));
+    const createTeamGroup = vi.fn(async () => ({
+      ok: true,
+      chatId: 'oc_g',
+      creator: 'cli_hub',
+      invalidBotIds: [],
+      invalidOwnerUnionIds: ['on_spoke'],
+      ownerTransferredTo: null,
+      transferError: 'invitee_rejected',
+    }));
+    const transferTeamGroupOwner = vi.fn(async () => ({
+      ownerTransferredTo: 'on_spoke',
+      transferError: null,
+      notifyMessageId: 'om_owner',
+      notifyError: null,
+    }));
     let delegated: any = null;
     const fetcher = vi.fn(async (u: any, init: any) => {
       if (String(u).endsWith('/api/federation/delegate-add-owner')) { delegated = JSON.parse(init.body); return { ok: true, status: 200, json: async () => ({ ok: true, invalidUserIds: [] }) } as any; }
       return { ok: true, status: 200, json: async () => ({}) } as any;
     });
     const res = makeRes();
-    await handleFederationApi(makeReq('POST', '/api/federation/group', { name: 'g', larkAppIds: ['cli_hub', 'cli_sp'], requestId: 'g1' }, bearer(syncToken)), res, new URL('http://x/api/federation/group'), { dataDir, createTeamGroup, fetcher: fetcher as any });
+    await handleFederationApi(makeReq('POST', '/api/federation/group', { name: 'g', larkAppIds: ['cli_hub', 'cli_sp'], requestId: 'g1' }, bearer(syncToken)), res, new URL('http://x/api/federation/group'), {
+      dataDir, createTeamGroup, transferTeamGroupOwner, fetcher: fetcher as any,
+    });
     expect(res.statusCode).toBe(200);
     expect(json(res).chatId).toBe('oc_g');
     expect(json(res).invalidOwnerUnionIds).toEqual([]); // on_spoke delegated to dep_spoke → resolved
+    expect(json(res).ownerTransferredTo).toBe('on_spoke');
+    expect(json(res).transferError).toBeNull();
     expect(delegated).toMatchObject({ chatId: 'oc_g', viaLarkAppId: 'cli_sp', ownerUnionIds: ['on_spoke'] });
+    expect(transferTeamGroupOwner).toHaveBeenCalledWith({
+      creatorLarkAppId: 'cli_hub', chatId: 'oc_g', transferOwnerUnionId: 'on_spoke',
+    });
   });
 
   it('federation/group: delegate-add-owner carries ALL of the deployments in-chat bots as viaCandidates (fallback)', async () => {

--- a/test/federation-spoke-api.test.ts
+++ b/test/federation-spoke-api.test.ts
@@ -358,6 +358,7 @@ describe('handleFederationSpokeApi', () => {
     await handleFederationSpokeApi(makeReq('POST', '/api/team/federated-group', { name: 'g', larkAppIds: ['cli_local'] }), res, url('/api/team/federated-group'), { dataDir, createTeamGroup: createTeamGroup as any });
     expect(res.statusCode).toBe(200);
     expect(captured.ownerUnionIds).toContain('on_operator'); // operator pulled in
+    expect(captured.transferOwnerUnionId).toBe('on_operator'); // operator, not an arbitrary bot owner, receives ownership
     expect(json(res).missingOperatorIdentity).toBeFalsy();
   });
 
@@ -402,6 +403,7 @@ describe('handleFederationSpokeApi', () => {
     expect(json(res).chatId).toBe('oc_x');
     expect(captured.larkAppIds.sort()).toEqual(['cli_local', 'cli_remote']);
     expect(captured.ownerUnionIds.sort()).toEqual(['on_local', 'on_remote']); // both bots' owners pulled in
+    expect(captured.transferOwnerUnionId).toBeUndefined(); // deployment operator is unbound; do not pick a bot owner
     // unknown bot (not on aggregated roster) → 400, never delegated
     res = makeRes();
     await handleFederationSpokeApi(makeReq('POST', '/api/team/federated-group', { larkAppIds: ['cli_ghost'] }), res, url, { dataDir, createTeamGroup: createTeamGroup as any });

--- a/test/group-creator.test.ts
+++ b/test/group-creator.test.ts
@@ -34,9 +34,11 @@ const SHARE_LINK = 'https://applink.feishu.cn/client/chat/chatter/add_by_link?li
 
 const mockSendMessage = vi.fn();
 const mockListChatBotMembers = vi.fn();
+const mockResolveAllowedUsersWithMap = vi.fn();
 vi.mock('../src/im/lark/client.js', () => ({
   sendMessage: (...args: any[]) => mockSendMessage(...args),
   listChatBotMembers: (...args: any[]) => mockListChatBotMembers(...args),
+  resolveAllowedUsersWithMap: (...args: any[]) => mockResolveAllowedUsersWithMap(...args),
 }));
 
 const mockBindOncall = vi.fn();
@@ -69,6 +71,7 @@ describe('createGroupWithBots', () => {
     mockGetChatShareLink.mockReset();
     mockSendMessage.mockReset();
     mockListChatBotMembers.mockReset();
+    mockResolveAllowedUsersWithMap.mockReset();
     mockBindOncall.mockReset();
     mockAddUsersByUnionId.mockReset();
     mockAddBotToChat.mockReset();
@@ -78,6 +81,7 @@ describe('createGroupWithBots', () => {
     // createChat; individual tests override to exercise the fallback path.
     mockGetChatShareLink.mockResolvedValue({ ok: true, shareLink: SHARE_LINK });
     mockAddUsersByUnionId.mockResolvedValue({ invalidUserIds: [] });
+    mockResolveAllowedUsersWithMap.mockResolvedValue({ resolved: [], map: new Map() });
     mockAddBotToChat.mockImplementation(async (_app: string, _chatId: string, ids: string[]) =>
       ids.map(id => ({ id, ok: true })),
     );
@@ -96,6 +100,54 @@ describe('createGroupWithBots', () => {
     expect(mockAddUsersByUnionId).toHaveBeenCalledWith(CREATOR, 'oc_fed', ['on_me', 'on_gone']);
     expect(result.invalidOwnerUnionIds).toEqual(['on_gone']);
     expect(result.chatId).toBe('oc_fed');
+  });
+
+  it('resolves the team operator union_id in the creator app scope, then transfers and notifies', async () => {
+    mockCreateChat.mockResolvedValue({ chatId: 'oc_team', invalidBotIds: [], invalidUserIds: [] });
+    mockResolveAllowedUsersWithMap.mockResolvedValue({
+      resolved: [USER_OPEN_ID],
+      map: new Map([['on_operator', USER_OPEN_ID]]),
+    });
+    mockTransferChatOwner.mockResolvedValue({ ok: true });
+    mockSendMessage.mockResolvedValue('om_owner_notify');
+
+    const result = await createGroupWithBots({
+      creatorLarkAppId: CREATOR,
+      larkAppIds: [CREATOR, OTHER_BOT],
+      ownerUnionIds: ['on_operator', 'on_other_owner'],
+      transferOwnerUnionId: 'on_operator',
+    });
+
+    expect(mockResolveAllowedUsersWithMap).toHaveBeenCalledWith(CREATOR, ['on_operator']);
+    expect(mockTransferChatOwner).toHaveBeenCalledWith(CREATOR, 'oc_team', USER_OPEN_ID);
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      CREATOR,
+      'oc_team',
+      `<at user_id="${USER_OPEN_ID}"></at>`,
+      'text',
+    );
+    expect(result.ownerTransferredTo).toBe(USER_OPEN_ID);
+    expect(result.transferError).toBeNull();
+    expect(result.notifyMessageId).toBe('om_owner_notify');
+    expect(result.notifyError).toBeNull();
+  });
+
+  it('does not resolve or transfer when Lark rejected the operator union_id invite', async () => {
+    mockCreateChat.mockResolvedValue({ chatId: 'oc_team', invalidBotIds: [], invalidUserIds: [] });
+    mockAddUsersByUnionId.mockResolvedValue({ invalidUserIds: ['on_operator'] });
+
+    const result = await createGroupWithBots({
+      creatorLarkAppId: CREATOR,
+      larkAppIds: [CREATOR],
+      ownerUnionIds: ['on_operator'],
+      transferOwnerUnionId: 'on_operator',
+    });
+
+    expect(mockResolveAllowedUsersWithMap).not.toHaveBeenCalled();
+    expect(mockTransferChatOwner).not.toHaveBeenCalled();
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(result.transferError).toBe('invitee_rejected');
+    expect(result.notifyError).toBe('invitee_rejected');
   });
 
   it('skips the union_id owner add when no ownerUnionIds given', async () => {

--- a/test/group-creator.test.ts
+++ b/test/group-creator.test.ts
@@ -57,7 +57,7 @@ vi.mock('../src/core/role-resolver.js', () => ({
   writeRoleFile: (...args: any[]) => mockWriteRoleFile(...args),
 }));
 
-import { createGroupWithBots } from '../src/services/group-creator.js';
+import { createGroupWithBots, transferGroupOwner } from '../src/services/group-creator.js';
 
 const CREATOR = 'cli_creator_app';
 const OTHER_BOT = 'cli_other_bot';
@@ -472,5 +472,39 @@ describe('createGroupWithBots', () => {
     expect(mockSendMessage).not.toHaveBeenCalled();
     expect(result.roleProfileBootstrapMessageId).toBeNull();
     expect(result.roleProfileBootstrapError).toBeNull();
+  });
+});
+
+describe('transferGroupOwner', () => {
+  beforeEach(() => {
+    mockTransferChatOwner.mockReset();
+    mockGetChatOwner.mockReset();
+  });
+
+  it('uses union_id for a deferred cross-deployment transfer', async () => {
+    mockTransferChatOwner.mockResolvedValue({ ok: true });
+    const result = await transferGroupOwner({
+      creatorLarkAppId: CREATOR,
+      chatId: 'oc_deferred',
+      ownerId: 'on_operator',
+      ownerIdType: 'union_id',
+    });
+    expect(mockTransferChatOwner).toHaveBeenCalledWith(
+      CREATOR, 'oc_deferred', 'on_operator', 'union_id',
+    );
+    expect(result).toEqual({ ownerTransferredTo: 'on_operator', transferError: null });
+  });
+
+  it('verifies an ambiguous union_id transfer using the same id type', async () => {
+    mockTransferChatOwner.mockResolvedValue({ ok: false, error: 'timeout' });
+    mockGetChatOwner.mockResolvedValue('on_operator');
+    const result = await transferGroupOwner({
+      creatorLarkAppId: CREATOR,
+      chatId: 'oc_deferred',
+      ownerId: 'on_operator',
+      ownerIdType: 'union_id',
+    });
+    expect(mockGetChatOwner).toHaveBeenCalledWith(CREATOR, 'oc_deferred', 'union_id');
+    expect(result).toEqual({ ownerTransferredTo: 'on_operator', transferError: null });
   });
 });

--- a/test/groups-store.test.ts
+++ b/test/groups-store.test.ts
@@ -174,6 +174,15 @@ describe('groups-store wrappers', () => {
     expect(call.data.owner_id).toBe('ou_human');
   });
 
+  it('transferChatOwner can transfer by union_id after a cross-deployment invite', async () => {
+    chatUpdateStub.mockResolvedValueOnce({ code: 0 });
+    const r = await transferChatOwner('cli_creator', 'oc_chat', 'on_human', 'union_id');
+    expect(r).toEqual({ ok: true });
+    const call = chatUpdateStub.mock.calls[0][0];
+    expect(call.params.user_id_type).toBe('union_id');
+    expect(call.data.owner_id).toBe('on_human');
+  });
+
   it('transferChatOwner returns error on non-zero Lark response', async () => {
     chatUpdateStub.mockResolvedValueOnce({ code: 230002, msg: 'user not in chat' });
     const r = await transferChatOwner('cli_creator', 'oc_chat', 'ou_ghost');

--- a/test/team-group.test.ts
+++ b/test/team-group.test.ts
@@ -5,7 +5,7 @@
  * Run: pnpm vitest run test/team-group.test.ts
  */
 import { describe, it, expect } from 'vitest';
-import { planGroupCreator } from '../src/dashboard/team-group.js';
+import { buildTeamGroupCreatePayload, planGroupCreator } from '../src/dashboard/team-group.js';
 
 const onlineAll = () => true;
 const pick = (ids: string[]) => ids[0] ?? null;
@@ -32,5 +32,32 @@ describe('planGroupCreator', () => {
 
   it('null creator when nothing pickable', () => {
     expect(planGroupCreator(['cli_a'], 'cli_x', onlineAll, () => null)).toEqual({ creatorLarkAppId: null, inviteUser: false });
+  });
+});
+
+describe('buildTeamGroupCreatePayload', () => {
+  it('forwards the authenticated operator union_id as the team-group owner transfer target', () => {
+    expect(buildTeamGroupCreatePayload({
+      name: '协作群',
+      larkAppIds: ['cli_a', 'cli_b'],
+      userOpenIds: [],
+      ownerUnionIds: ['on_operator', 'on_other_owner'],
+      transferOwnerUnionId: 'on_operator',
+    })).toEqual({
+      name: '协作群',
+      larkAppIds: ['cli_a', 'cli_b'],
+      userOpenIds: [],
+      ownerUnionIds: ['on_operator', 'on_other_owner'],
+      transferOwnerUnionId: 'on_operator',
+    });
+  });
+
+  it('does not guess a transfer target from bot owners when the operator identity is unavailable', () => {
+    expect(buildTeamGroupCreatePayload({
+      name: '无人群',
+      larkAppIds: ['cli_a'],
+      userOpenIds: [],
+      ownerUnionIds: ['on_bot_owner'],
+    })).not.toHaveProperty('transferOwnerUnionId');
   });
 });


### PR DESCRIPTION
## 问题

从 Dashboard 创建团队/联邦协作群时，群聊由某个在线 bot 代为创建。发起人虽然会被加入群聊，但建群完成后群主仍然是创建群的 bot，没有自动转让给实际发起人。

## 现象

- 发起人成功进入协作群，但群主身份仍属于机器人。
- 本地创建和 Hub → Spoke 委托创建都存在该问题。
- `ownerUnionIds` 中已经包含发起人和各 bot owner，但它只用于拉人，没有作为群主转让目标继续传递。
- 创建服务最终拿不到 `transferOwnerTo`，因此不会调用飞书的群主转让接口。

## 根因

团队建群链路只聚合了成员信息，没有显式表达“谁是本次建群的发起人”：

```text
认证后的 operatorUnionId
        │
        ├── 放入 ownerUnionIds，用于拉人
        │
        └── 未继续传递为群主转让目标  ← 问题点

createTeamGroup
        │
        └── createGroupWithBots
                └── 缺少 transferOwnerTo，跳过群主转让
```

同时，飞书 `open_id` 具有应用隔离属性：发起人在 A bot 下的 `open_id`，不能直接交给实际负责建群的 B bot 使用。因此跨 bot 建群时不能复用原始 `open_id`，必须让实际建群 bot 根据租户稳定的 `union_id`，重新解析自己应用作用域下的 `open_id`。

另外，不能直接取 `ownerUnionIds[0]` 作为群主：该列表还包含 bot owner；当发起人身份未绑定时，列表里甚至可能只有 bot owner，直接猜测会把群主错误转给其他人。

## 期望

- 发起人身份已绑定且成功入群时，建群完成后自动成为群主。
- 本地创建与 Hub → Spoke 委托创建行为一致。
- 发起人身份缺失或入群失败时，不从 bot owner 列表猜测群主，继续保留机器人为群主并返回可观测错误。
- 不影响已有的普通建群及显式 `transferOwnerTo` 行为。

## 修复方案

- 新增独立字段 `transferOwnerUnionId`，只使用服务端认证得到的 `operatorUnionId` 赋值，不信任客户端输入，也不从 `ownerUnionIds` 推断。
- 将该字段贯穿以下链路：
  - Dashboard 团队建群
  - 本地 daemon IPC
  - Hub → Spoke `delegate-group`
  - `createGroupWithBots`
- 实际建群 bot 先通过 `ownerUnionIds` 将发起人加入群聊，再在自己的应用作用域内执行：

```text
transferOwnerUnionId
        │
        ├── creator app scope 解析
        ▼
发起人的 open_id
        │
        ├── transferChatOwner
        └── 群内 @ 发起人通知
```

- 增加输入校验：
  - 必须是 `on_` 开头的合法 `union_id`。
  - 必须包含在 `ownerUnionIds` 中，确保转让目标也是本次待入群成员。
- 保持兼容性：已有显式 `transferOwnerTo` 的场景优先级不变；未传新字段的旧调用行为不变。
- 转让仍采用 best-effort：群聊已经创建后，即使解析或转让失败也不重试建群，避免产生重复群；失败通过 `invitee_rejected` 或 `owner_union_id_unresolved` 返回。

## 影响范围

- 仅影响 Dashboard 发起的团队/联邦协作群创建链路。
- 不涉及数据结构变更和历史数据迁移。
- 不改变普通 CLI 建群及原有基于 `open_id` 的显式转让逻辑。

## 测试

新增并覆盖以下场景：

- 正确透传认证发起人的 `transferOwnerUnionId`。
- 发起人身份缺失时，不从 bot owner 中猜测转让目标。
- 实际建群 bot 能将 `union_id` 解析为自身作用域的 `open_id`，完成转让并发送通知。
- 发起人入群失败时，不执行解析、转让和通知。
- Federation API 拒绝格式非法或不在 `ownerUnionIds` 中的转让目标。
- 本地创建与 Hub → Spoke 委托创建均能正确透传。

验证结果：

- 相关 6 个测试文件，共 146 个测试全部通过。
- `pnpm build` 通过。
- `git diff --check` 通过。
