### PR TITLE
fix(setup): 新建机器人补齐事件订阅与卡片回调——console 增量契约 + fail-closed

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -115,7 +115,7 @@ import { applyPlatformTeamSync, getPlatformTeamSyncRev, listPlatformTeams } from
 import { getBotUnionId } from './services/bot-union-ids-store.js';
 import { cleanupIdleSessions, parseIdleCleanupHours } from './dashboard/session-cleanup.js';
 import { aggregateRoleBatch, parseRoleBatchTargets } from './dashboard/roles-batch.js';
-import { automateOpenPlatformSetup } from './setup/open-platform-automation.js';
+import { automateOpenPlatformSetup, vcListenerEventGateError } from './setup/open-platform-automation.js';
 import { VC_MEETING_FEATURE_SCOPES, VC_MEETING_REALTIME_VOICE_SCOPES } from './setup/verify-permissions.js';
 import { maybeInstallTraexPluginOnSettingsChange, TRAEX_RECOMMENDED_SOURCE, TRAEX_RECOMMENDED_REF } from './setup/ensure-herdr-integrations.js';
 import { checkLarkCliVersion, MIN_LARK_CLI_VERSION_FOR_VC_BOT } from './vc-agent/polling-source.js';
@@ -576,13 +576,13 @@ async function syncVcMeetingListenerBotConfig(listenerBotAppId: string | null, p
               };
             }
           }
-          // Event subscription is also critical: if all 3 event update endpoints
-          // failed (eventWarning set, subscribedEventCount === 0), the bot won't
-          // receive vc.bot.meeting_*_v1 push events → meeting invite black hole.
-          if (result.eventWarning && result.subscribedEventCount === 0) {
+          // Event subscription is also critical: listener 缺任一 VC 事件都收不到
+          // 会议邀请(missingVcEvents 判定,总 count 无法区分缺的是不是 VC)。
+          const eventGateError = vcListenerEventGateError(result);
+          if (eventGateError) {
             return {
               ok: false,
-              error: `vcMeetingAgent_listenerBot_event_subscribe_failed: 事件订阅全部失败(${result.eventWarning})，bot 无法接收会议邀请事件。请到开放平台手动订阅 VC 会议事件后重试。`,
+              error: `vcMeetingAgent_listenerBot_event_subscribe_failed: ${eventGateError}，bot 无法接收会议邀请事件。请到开放平台手动订阅 VC 会议事件后重试。`,
             };
           }
         } else {
@@ -624,13 +624,13 @@ async function syncVcMeetingListenerBotConfig(listenerBotAppId: string | null, p
               };
             }
           }
-          // Also check event subscription status — if event update failed (all 3
-          // endpoints) before the downstream api_error hit, the bot still won't
-          // receive meeting invite events → listener black hole.
-          if (result.eventWarning && (result.subscribedEventCount ?? 0) === 0) {
+          // Also check event subscription status — automation 走到订阅阶段时
+          // missingVcEvents 会带回来;listener 缺任一 VC 事件都不能保存。
+          const eventGateError = vcListenerEventGateError(result);
+          if (eventGateError) {
             return {
               ok: false,
-              error: `vcMeetingAgent_listenerBot_event_subscribe_failed: 事件订阅失败(${result.eventWarning})，bot 无法接收会议邀请事件。自动化配置失败(${reason})，请手动订阅 VC 会议事件后重试。`,
+              error: `vcMeetingAgent_listenerBot_event_subscribe_failed: ${eventGateError}，bot 无法接收会议邀请事件。自动化配置失败(${reason})，请手动订阅 VC 会议事件后重试。`,
             };
           }
         }

--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -118,6 +118,8 @@ export type OpenPlatformAutomationResult =
       eventWarning?: string;
       /** 回读后仍缺失的 VC 会议事件。普通建 bot 不阻断,VC listener 保存前必须为空。 */
       missingVcEvents: string[];
+      /** 回读确认事件接收方式已是长连接(ok:true 时恒为 true,显式带回供门函数统一判定)。 */
+      eventModeReady: boolean;
       versionId?: string;
     }
   | {
@@ -141,6 +143,8 @@ export type OpenPlatformAutomationResult =
       eventWarning?: string;
       /** 回读后仍缺失的 VC 会议事件(走到订阅阶段才有)。 */
       missingVcEvents?: string[];
+      /** 事件接收方式是否回读确认为长连接(走到订阅阶段才有;早期失败为 undefined)。 */
+      eventModeReady?: boolean;
     };
 
 export interface OpenPlatformAutomationOptions {
@@ -832,8 +836,10 @@ export async function automateOpenPlatformSetup(
     ...missingCallbacks,
   ];
   // 长连接模式必须以回读为准:switch 接口返回成功≠生效,mode 不是 4 时
-  // daemon 走长连接同样收不到事件/回调。
-  if (eventState?.eventMode !== LONG_CONNECTION_EVENT_MODE) {
+  // daemon 走长连接同样收不到事件/回调。eventModeReady 显式带回结果——
+  // dashboard listener 门要靠它识别「订阅名齐但接收方式不对」的黑洞。
+  const eventModeReady = eventState?.eventMode === LONG_CONNECTION_EVENT_MODE;
+  if (!eventModeReady) {
     criticalIssues.push(`事件接收模式=${eventState?.eventMode ?? '未知'}(需长连接 ${LONG_CONNECTION_EVENT_MODE})`);
   }
   if (callbackState?.callbackMode !== LONG_CONNECTION_EVENT_MODE) {
@@ -848,6 +854,7 @@ export async function automateOpenPlatformSetup(
       subscribedEventCount,
       eventWarning,
       missingVcEvents,
+      eventModeReady,
     };
   }
 
@@ -873,6 +880,7 @@ export async function automateOpenPlatformSetup(
       subscribedEventCount,
       eventWarning,
       missingVcEvents,
+      eventModeReady,
       versionId,
     };
   } catch (err: any) {
@@ -884,6 +892,7 @@ export async function automateOpenPlatformSetup(
       subscribedEventCount,
       eventWarning,
       missingVcEvents,
+      eventModeReady,
     };
   }
 }
@@ -898,9 +907,15 @@ export function vcListenerEventGateError(result: {
   eventWarning?: string;
   subscribedEventCount?: number;
   missingVcEvents?: string[];
+  eventModeReady?: boolean;
 }): string | null {
   if (result.eventWarning && (result.subscribedEventCount ?? 0) === 0) {
     return `事件订阅全部失败(${result.eventWarning})`;
+  }
+  // 订阅名齐但接收方式不是长连接同样收不到——eventModeReady 显式 false 才阻断,
+  // undefined(走到订阅阶段前就失败)保持原 best-effort 语义。
+  if (result.eventModeReady === false) {
+    return `事件接收方式未确认为长连接${result.eventWarning ? `(${result.eventWarning})` : ''}`;
   }
   const missingVc = result.missingVcEvents ?? [];
   if (missingVc.length > 0) {

--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -14,21 +14,42 @@ import qrcode from 'qrcode-terminal';
 import { VC_MEETING_BOT_EVENTS } from './verify-permissions.js';
 
 /**
- * All non-VC events that botmux dispatcher consumes. Must be included in every
- * event subscription update — the internal `/event/update` endpoint is
- * replacement-style, so omitting any of these would silently disable the
- * corresponding botmux capability (receiving messages, card actions, being
- * added to groups, doc comments, message reactions).
+ * All non-VC events (application identity) that the botmux dispatcher consumes.
+ * `card.action.trigger` is intentionally NOT here: the Open Platform treats it
+ * as a "callback" configured via `/developers/v1/callback/*`, see
+ * BOT_BASELINE_CALLBACKS.
  */
-export const BOT_BASELINE_EVENTS = [
+export const BOT_BASELINE_APP_EVENTS = [
   'im.message.receive_v1',
-  'card.action.trigger',
   'im.chat.member.bot.added_v1',
   'drive.file.comment_add_v1',
   'drive.notice.comment_add_v1',
   'im.message.reaction.created_v1',
   'im.message.reaction.deleted_v1',
 ] as const;
+
+/** 缺了它 daemon 完全收不到消息——回读确认失败时整个自动配置 fail-closed。 */
+export const BOT_CRITICAL_APP_EVENTS = ['im.message.receive_v1'] as const;
+
+/** 卡片交互回调。缺了它卡片按钮点击无响应,同样 fail-closed。 */
+export const BOT_BASELINE_CALLBACKS = ['card.action.trigger'] as const;
+
+/** 开放平台「使用长连接接收事件/回调」对应的 mode 值。 */
+export const LONG_CONNECTION_EVENT_MODE = 4;
+
+const VC_MEETING_EVENT_IDENTITY = {
+  'vc.bot.meeting_invited_v1': 'app',
+  'vc.bot.meeting_activity_v1': 'app',
+  'vc.bot.meeting_ended_v1': 'app',
+  'vc.meeting.participant_meeting_joined_v1': 'user',
+} as const satisfies Record<(typeof VC_MEETING_BOT_EVENTS)[number], 'app' | 'user'>;
+
+export const VC_MEETING_APP_EVENTS = VC_MEETING_BOT_EVENTS.filter(
+  eventName => VC_MEETING_EVENT_IDENTITY[eventName] === 'app',
+);
+export const VC_MEETING_USER_EVENTS = VC_MEETING_BOT_EVENTS.filter(
+  eventName => VC_MEETING_EVENT_IDENTITY[eventName] === 'user',
+);
 
 export const BOTMUX_REDIRECT_URL = 'http://127.0.0.1:9768/callback';
 const FEISHU_ACCOUNTS_ORIGIN = 'https://accounts.feishu.cn';
@@ -343,13 +364,101 @@ export function buildSafeSettingPayload(appId: string) {
   };
 }
 
-/** Build payload for subscribing events via the developer console internal API. */
-export function buildEventSubscriptionPayload(appId: string, events: string[]) {
+/**
+ * Build the incremental event-subscription payload used by the developer
+ * console (`updateEvent` in the console frontend bundle):
+ * `{clientId, operation:'add', events, appEvents, userEvents, eventMode}`。
+ * eventMode 必须回填读接口返回的当前值,事件按接收身份分桶(应用/用户)。
+ */
+export function buildEventSubscriptionPayload(
+  appId: string,
+  eventMode: number,
+  appEvents: string[],
+  userEvents: string[],
+  events: string[] = [],
+) {
   return {
     clientId: appId,
-    eventNames: events,
-    isDeveloperPanel: true,
+    operation: 'add',
+    events,
+    appEvents,
+    userEvents,
+    eventMode,
   };
+}
+
+/** 同款增量契约的回调版(console frontend `updateCallback`)。 */
+export function buildCallbackSubscriptionPayload(appId: string, callbackMode: number, callbacks: string[]) {
+  return {
+    clientId: appId,
+    operation: 'add',
+    callbacks,
+    callbackMode,
+  };
+}
+
+export interface OpenPlatformEventState {
+  eventMode?: number;
+  /** 所有已订阅事件(顶层 events + 应用/用户身份分组的并集)。 */
+  events: string[];
+  appEvents: string[];
+  userEvents: string[];
+}
+
+export interface OpenPlatformCallbackState {
+  callbackMode?: number;
+  callbacks: string[];
+}
+
+/** Extract the event mode and subscribed event ids from `/developers/v1/event/:clientId`. */
+export function extractOpenPlatformEventState(payload: unknown): OpenPlatformEventState {
+  const root = asRecord(payload);
+  const wrapped = asRecord(root.data);
+  const data = Object.keys(wrapped).length > 0 ? wrapped : root;
+  const appEvents = uniqueStrings([
+    ...extractEventIds(data.appEvents),
+    ...extractEventIdsFromDetails(data.appEventDetails),
+  ]);
+  const userEvents = uniqueStrings([
+    ...extractEventIds(data.userEvents),
+    ...extractEventIdsFromDetails(data.userEventDetails),
+  ]);
+  const genericEvents = uniqueStrings([
+    ...extractEventIds(data.events),
+    ...extractEventIdsFromDetails(data.eventDetails),
+  ]);
+  const eventMode = typeof data.eventMode === 'number' && Number.isFinite(data.eventMode)
+    ? data.eventMode
+    : undefined;
+  return {
+    eventMode,
+    events: uniqueStrings([...genericEvents, ...appEvents, ...userEvents]),
+    appEvents,
+    userEvents,
+  };
+}
+
+/** Extract the callback mode and subscribed callback ids from `/developers/v1/callback/:clientId`. */
+export function extractOpenPlatformCallbackState(payload: unknown): OpenPlatformCallbackState {
+  const root = asRecord(payload);
+  const wrapped = asRecord(root.data);
+  const data = Object.keys(wrapped).length > 0 ? wrapped : root;
+  const callbackMode = typeof data.callbackMode === 'number' && Number.isFinite(data.callbackMode)
+    ? data.callbackMode
+    : undefined;
+  return { callbackMode, callbacks: extractEventIds(data.callbacks) };
+}
+
+function extractEventIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return uniqueStrings(value
+    .map(item => typeof item === 'string' ? item : pickString(asRecord(item), ['id']))
+    .filter((item): item is string => Boolean(item)));
+}
+
+function extractEventIdsFromDetails(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return uniqueStrings(value.flatMap(group => extractEventIds(asRecord(group).items)));
 }
 
 export function buildAppVersionCreatePayload(appVersion: string, visibleMemberIds: string[] = []) {
@@ -602,47 +711,124 @@ export async function automateOpenPlatformSetup(
     };
   }
 
-  // Best-effort auto-subscribe VC meeting bot events. Non-fatal: if the endpoint
-  // doesn't exist or fails, the user can still add them manually in the console.
-  // We try multiple known internal API patterns since the console frontend
-  // endpoint varies by tenant/version.
-  // IMPORTANT: Always include BOT_BASELINE_EVENTS alongside VC events — the
-  // internal update endpoint is replacement-style, so sending only VC events
-  // would wipe im.message.receive_v1 / card.action.trigger and break messaging.
-  const allEvents = [...BOT_BASELINE_EVENTS, ...VC_MEETING_BOT_EVENTS];
-  let subscribedEventCount = 0;
-  let eventWarning: string | undefined;
-  const eventEndpoints = [
-    {
-      path: `/developers/v1/event/update/${options.appId}`,
-      body: buildEventSubscriptionPayload(options.appId, allEvents),
-    },
-    {
-      path: `/developers/v1/event/update/${options.appId}`,
-      body: {
-        clientId: options.appId,
-        eventNameList: allEvents,
-        isDeveloperPanel: true,
-      },
-    },
-    {
-      path: `/developers/v1/event_callback/update/${options.appId}`,
-      body: {
-        clientId: options.appId,
-        eventNames: allEvents,
-        isDeveloperPanel: true,
-      },
-    },
-  ];
-  for (const attempt of eventEndpoints) {
+  // 事件与回调都走 console 前端同款「增量」契约:先读现状 → operation:add 只补
+  // 缺失 → 回读确认。旧实现的 eventNames/eventNameList 参数和
+  // /event_callback/update 端点在开放平台并不存在,请求全部失败还被吞成
+  // warning——新建应用因此落地就没有任何事件订阅。核心项(im.message.receive_v1
+  // 事件 + card.action.trigger 回调)回读仍缺失时直接判失败:缺了它们 daemon
+  // 收不到消息/卡片点击,静默降级只会产出一个「建好了却不回话」的坏 bot。
+  const eventWarnings: string[] = [];
+  const readEventState = async () =>
+    extractOpenPlatformEventState(await postJson(`/developers/v1/event/${options.appId}`, { needEventDetail: true }));
+  const addEvents = async (appEvents: string[], userEvents: string[], eventMode: number) => {
+    await postJson(
+      `/developers/v1/event/update/${options.appId}`,
+      buildEventSubscriptionPayload(options.appId, eventMode, appEvents, userEvents),
+    );
+  };
+
+  let eventState: OpenPlatformEventState | undefined;
+  try {
+    eventState = await readEventState();
+  } catch (err: any) {
+    eventWarnings.push(`读取当前事件订阅失败: ${safeErrorMessage(err)}`);
+  }
+  const hasEvent = (name: string) => Boolean(eventState?.events.includes(name));
+  const wantedAppEvents = [...BOT_BASELINE_APP_EVENTS, ...VC_MEETING_APP_EVENTS];
+  const missingAppEvents = wantedAppEvents.filter(name => !hasEvent(name));
+  const missingUserEvents = VC_MEETING_USER_EVENTS.filter(name => !hasEvent(name));
+  if (missingAppEvents.length > 0 || missingUserEvents.length > 0) {
+    const eventMode = eventState?.eventMode ?? LONG_CONNECTION_EVENT_MODE;
     try {
-      await postJson(attempt.path, attempt.body);
-      subscribedEventCount = allEvents.length;
-      eventWarning = undefined;
-      break;
-    } catch (err: any) {
-      eventWarning = safeErrorMessage(err);
+      await addEvents(missingAppEvents, missingUserEvents, eventMode);
+    } catch {
+      // 部分租户个别事件依赖的权限不可授予会拒掉整批——逐个补,别让长尾事件拖垮核心事件
+      for (const name of missingAppEvents) {
+        try {
+          await addEvents([name], [], eventMode);
+        } catch (err: any) {
+          eventWarnings.push(`订阅事件 ${name} 失败: ${safeErrorMessage(err)}`);
+        }
+      }
+      for (const name of missingUserEvents) {
+        try {
+          await addEvents([], [name], eventMode);
+        } catch (err: any) {
+          eventWarnings.push(`订阅事件 ${name} 失败: ${safeErrorMessage(err)}`);
+        }
+      }
     }
+    try {
+      eventState = await readEventState();
+    } catch (err: any) {
+      eventWarnings.push(`回读事件订阅失败: ${safeErrorMessage(err)}`);
+    }
+  }
+  const missingBaselineEvents = BOT_BASELINE_APP_EVENTS.filter(name => !hasEvent(name));
+  if (missingBaselineEvents.length > 0) {
+    eventWarnings.push(`基础事件未确认订阅: ${missingBaselineEvents.join(', ')}`);
+  }
+
+  // 卡片回调(card.action.trigger)在开放平台是「回调」不是「事件」,配置走
+  // /developers/v1/callback/*;回调接收方式独立于事件,需要单独切到长连接。
+  const readCallbackState = async () =>
+    extractOpenPlatformCallbackState(await postJson(`/developers/v1/callback/${options.appId}`, {}));
+  let callbackState: OpenPlatformCallbackState | undefined;
+  try {
+    callbackState = await readCallbackState();
+  } catch (err: any) {
+    eventWarnings.push(`读取当前回调订阅失败: ${safeErrorMessage(err)}`);
+  }
+  if (callbackState && callbackState.callbackMode !== LONG_CONNECTION_EVENT_MODE) {
+    try {
+      await postJson(`/developers/v1/callback/switch/${options.appId}`, {
+        clientId: options.appId,
+        callbackMode: LONG_CONNECTION_EVENT_MODE,
+      });
+      callbackState = await readCallbackState();
+    } catch (err: any) {
+      eventWarnings.push(`切换回调长连接模式失败: ${safeErrorMessage(err)}`);
+    }
+  }
+  let missingCallbacks = BOT_BASELINE_CALLBACKS.filter(name => !callbackState?.callbacks.includes(name));
+  if (missingCallbacks.length > 0) {
+    try {
+      await postJson(
+        `/developers/v1/callback/update/${options.appId}`,
+        buildCallbackSubscriptionPayload(
+          options.appId,
+          callbackState?.callbackMode ?? LONG_CONNECTION_EVENT_MODE,
+          [...missingCallbacks],
+        ),
+      );
+    } catch (err: any) {
+      eventWarnings.push(`订阅卡片回调失败: ${safeErrorMessage(err)}`);
+    }
+    try {
+      callbackState = await readCallbackState();
+    } catch (err: any) {
+      eventWarnings.push(`回读回调订阅失败: ${safeErrorMessage(err)}`);
+    }
+    missingCallbacks = BOT_BASELINE_CALLBACKS.filter(name => !callbackState?.callbacks.includes(name));
+  }
+
+  const subscribedEventCount =
+    [...wantedAppEvents, ...VC_MEETING_USER_EVENTS].filter(name => hasEvent(name)).length
+    + BOT_BASELINE_CALLBACKS.filter(name => callbackState?.callbacks.includes(name)).length;
+  const eventWarning = eventWarnings.length > 0 ? eventWarnings.join('; ') : undefined;
+  const missingCritical = [
+    ...BOT_CRITICAL_APP_EVENTS.filter(name => !hasEvent(name)),
+    ...missingCallbacks,
+  ];
+  if (missingCritical.length > 0) {
+    return {
+      ok: false,
+      reason: 'api_error',
+      message: `核心事件/回调订阅未生效(${missingCritical.join(', ')}),机器人将收不到消息或卡片点击;请到开放平台「事件与回调」手动补齐后重试`,
+      sessionFile,
+      subscribedEventCount,
+      eventWarning,
+    };
   }
 
   try {

--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -116,6 +116,8 @@ export type OpenPlatformAutomationResult =
       scopeWarning?: string;
       subscribedEventCount: number;
       eventWarning?: string;
+      /** 回读后仍缺失的 VC 会议事件。普通建 bot 不阻断,VC listener 保存前必须为空。 */
+      missingVcEvents: string[];
       versionId?: string;
     }
   | {
@@ -137,6 +139,8 @@ export type OpenPlatformAutomationResult =
       subscribedEventCount?: number;
       /** Warning from event subscription attempt, if any. */
       eventWarning?: string;
+      /** 回读后仍缺失的 VC 会议事件(走到订阅阶段才有)。 */
+      missingVcEvents?: string[];
     };
 
 export interface OpenPlatformAutomationOptions {
@@ -769,6 +773,12 @@ export async function automateOpenPlatformSetup(
   if (missingBaselineEvents.length > 0) {
     eventWarnings.push(`基础事件未确认订阅: ${missingBaselineEvents.join(', ')}`);
   }
+  // VC 事件缺失不阻断普通建 bot,但要显式带回给 VC listener 保存门
+  // (vcListenerEventGateError)——只看总 count 无法区分「缺的是不是 VC」。
+  const missingVcEvents: string[] = VC_MEETING_BOT_EVENTS.filter(name => !hasEvent(name));
+  if (missingVcEvents.length > 0) {
+    eventWarnings.push(`VC 会议事件未确认订阅: ${missingVcEvents.join(', ')}`);
+  }
 
   // 卡片回调(card.action.trigger)在开放平台是「回调」不是「事件」,配置走
   // /developers/v1/callback/*;回调接收方式独立于事件,需要单独切到长连接。
@@ -817,18 +827,27 @@ export async function automateOpenPlatformSetup(
     [...wantedAppEvents, ...VC_MEETING_USER_EVENTS].filter(name => hasEvent(name)).length
     + BOT_BASELINE_CALLBACKS.filter(name => callbackState?.callbacks.includes(name)).length;
   const eventWarning = eventWarnings.length > 0 ? eventWarnings.join('; ') : undefined;
-  const missingCritical = [
+  const criticalIssues: string[] = [
     ...BOT_CRITICAL_APP_EVENTS.filter(name => !hasEvent(name)),
     ...missingCallbacks,
   ];
-  if (missingCritical.length > 0) {
+  // 长连接模式必须以回读为准:switch 接口返回成功≠生效,mode 不是 4 时
+  // daemon 走长连接同样收不到事件/回调。
+  if (eventState?.eventMode !== LONG_CONNECTION_EVENT_MODE) {
+    criticalIssues.push(`事件接收模式=${eventState?.eventMode ?? '未知'}(需长连接 ${LONG_CONNECTION_EVENT_MODE})`);
+  }
+  if (callbackState?.callbackMode !== LONG_CONNECTION_EVENT_MODE) {
+    criticalIssues.push(`回调接收模式=${callbackState?.callbackMode ?? '未知'}(需长连接 ${LONG_CONNECTION_EVENT_MODE})`);
+  }
+  if (criticalIssues.length > 0) {
     return {
       ok: false,
       reason: 'api_error',
-      message: `核心事件/回调订阅未生效(${missingCritical.join(', ')}),机器人将收不到消息或卡片点击;请到开放平台「事件与回调」手动补齐后重试`,
+      message: `核心事件/回调订阅未生效(${criticalIssues.join('; ')}),机器人将收不到消息或卡片点击;请到开放平台「事件与回调」手动补齐后重试`,
       sessionFile,
       subscribedEventCount,
       eventWarning,
+      missingVcEvents,
     };
   }
 
@@ -853,6 +872,7 @@ export async function automateOpenPlatformSetup(
       scopeWarning,
       subscribedEventCount,
       eventWarning,
+      missingVcEvents,
       versionId,
     };
   } catch (err: any) {
@@ -863,8 +883,30 @@ export async function automateOpenPlatformSetup(
       sessionFile,
       subscribedEventCount,
       eventWarning,
+      missingVcEvents,
     };
   }
+}
+
+/**
+ * dashboard 保存 VC 会议监听 bot 前的事件订阅门。普通建 bot 允许 VC 事件缺失
+ * (只记 warning),但 listener 缺 VC 事件=会议邀请黑洞,必须阻断保存。
+ * 只看 subscribedEventCount 总数无法区分「缺的是不是 VC」,所以要看
+ * missingVcEvents。返回错误描述;可保存时返回 null。
+ */
+export function vcListenerEventGateError(result: {
+  eventWarning?: string;
+  subscribedEventCount?: number;
+  missingVcEvents?: string[];
+}): string | null {
+  if (result.eventWarning && (result.subscribedEventCount ?? 0) === 0) {
+    return `事件订阅全部失败(${result.eventWarning})`;
+  }
+  const missingVc = result.missingVcEvents ?? [];
+  if (missingVc.length > 0) {
+    return `VC 会议事件未订阅成功(${missingVc.join(', ')})${result.eventWarning ? `;${result.eventWarning}` : ''}`;
+  }
+  return null;
 }
 
 // ─── 已有应用列表 / 凭证读取（setup「选择已有应用」路径）───────────────────────

--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -22,6 +22,7 @@ import { VC_MEETING_BOT_EVENTS } from './verify-permissions.js';
 export const BOT_BASELINE_APP_EVENTS = [
   'im.message.receive_v1',
   'im.chat.member.bot.added_v1',
+  'im.chat.member.bot.deleted_v1',
   'drive.file.comment_add_v1',
   'drive.notice.comment_add_v1',
   'im.message.reaction.created_v1',

--- a/test/setup-open-platform-automation.test.ts
+++ b/test/setup-open-platform-automation.test.ts
@@ -46,6 +46,64 @@ window.csrfToken="${csrf}";
 window.user={"id":"u_1","name":"Alice","email":"alice@example.com","tenantId":"t_1","tenantName":"Example","tenantDisplayName":{"value":"Example"}};
 </script>`;
 
+/**
+ * 有状态的事件/回调订阅 mock:read 返回当前订阅,operation:add 增量写入,
+ * 与开放平台 console 的增量契约同形。automateOpenPlatformSetup 现在会回读
+ * 确认核心事件/回调,mock 不落库就会 fail-closed。
+ */
+function openPlatformSubscriptionMock(appId: string, opts: {
+  failEventUpdate?: boolean;
+  failCallbackUpdate?: boolean;
+  initial?: { appEvents?: string[]; userEvents?: string[]; callbacks?: string[]; callbackMode?: number };
+} = {}) {
+  const state = {
+    eventMode: 4,
+    appEvents: [...(opts.initial?.appEvents ?? [])],
+    userEvents: [...(opts.initial?.userEvents ?? [])],
+    callbackMode: opts.initial?.callbackMode ?? 1,
+    callbacks: [...(opts.initial?.callbacks ?? [])],
+  };
+  const updateBodies: Array<Record<string, unknown>> = [];
+  const handle = (href: string, init?: RequestInit): Response | null => {
+    if (href.endsWith(`/developers/v1/event/update/${appId}`)) {
+      const body = JSON.parse(String(init?.body));
+      updateBodies.push(body);
+      if (opts.failEventUpdate) return Response.json({ code: 1, msg: 'event update rejected' });
+      state.appEvents.push(...(body.appEvents ?? []));
+      state.userEvents.push(...(body.userEvents ?? []));
+      return Response.json({ code: 0 });
+    }
+    if (href.endsWith(`/developers/v1/event/${appId}`)) {
+      return Response.json({
+        code: 0,
+        data: {
+          eventMode: state.eventMode,
+          events: [...state.appEvents, ...state.userEvents],
+          appEventDetails: [{ items: state.appEvents.map(id => ({ id })) }],
+          userEventDetails: [{ items: state.userEvents.map(id => ({ id })) }],
+        },
+      });
+    }
+    if (href.endsWith(`/developers/v1/callback/switch/${appId}`)) {
+      const body = JSON.parse(String(init?.body));
+      state.callbackMode = body.callbackMode;
+      return Response.json({ code: 0 });
+    }
+    if (href.endsWith(`/developers/v1/callback/update/${appId}`)) {
+      const body = JSON.parse(String(init?.body));
+      updateBodies.push(body);
+      if (opts.failCallbackUpdate) return Response.json({ code: 1, msg: 'callback update rejected' });
+      state.callbacks.push(...(body.callbacks ?? []));
+      return Response.json({ code: 0 });
+    }
+    if (href.endsWith(`/developers/v1/callback/${appId}`)) {
+      return Response.json({ code: 0, data: { callbackMode: state.callbackMode, callbacks: [...state.callbacks] } });
+    }
+    return null;
+  };
+  return { state, updateBodies, handle };
+}
+
 describe('parseSetupOpenPlatformAutoFlag', () => {
   it('is enabled by default, supports explicit skip, and keeps --open-platform-auto compatible', () => {
     expect(parseSetupOpenPlatformAutoFlag([])).toBe(true);
@@ -375,6 +433,7 @@ describe('automateOpenPlatformSetup', () => {
     const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-'));
     const sessionFile = join(dir, 'feishu-session.json');
     writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+    const sub = openPlatformSubscriptionMock('cli_x');
     const calls: Array<{ url: string; init: RequestInit }> = [];
     const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
       const href = String(url);
@@ -393,7 +452,7 @@ describe('automateOpenPlatformSetup', () => {
         });
       }
       if (href.includes('/app_version/create/')) return Response.json({ code: 0, data: { versionId: 'v1' } });
-      return Response.json({ code: 0 });
+      return sub.handle(href, init) ?? Response.json({ code: 0 });
     }) as typeof fetch;
 
     const result = await automateOpenPlatformSetup({
@@ -411,7 +470,14 @@ describe('automateOpenPlatformSetup', () => {
       '/developers/v1/scope/update/cli_x',
       '/developers/v1/robot/switch/cli_x',
       '/developers/v1/event/switch/cli_x',
+      '/developers/v1/event/cli_x',
       '/developers/v1/event/update/cli_x',
+      '/developers/v1/event/cli_x',
+      '/developers/v1/callback/cli_x',
+      '/developers/v1/callback/switch/cli_x',
+      '/developers/v1/callback/cli_x',
+      '/developers/v1/callback/update/cli_x',
+      '/developers/v1/callback/cli_x',
       '/developers/v1/safe_setting/update/cli_x',
       '/developers/v1/contact_range/cli_x',
       '/developers/v1/app_version/list/cli_x',
@@ -432,6 +498,7 @@ describe('automateOpenPlatformSetup', () => {
     const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-'));
     const sessionFile = join(dir, 'feishu-session.json');
     writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+    const sub = openPlatformSubscriptionMock('cli_x');
     const calls: Array<{ url: string; init: RequestInit }> = [];
     const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
       const href = String(url);
@@ -461,7 +528,7 @@ describe('automateOpenPlatformSetup', () => {
         });
       }
       if (href.includes('/app_version/create/')) return Response.json({ code: 0, data: { versionId: 'v1' } });
-      return Response.json({ code: 0 });
+      return sub.handle(href, init) ?? Response.json({ code: 0 });
     }) as typeof fetch;
 
     const result = await automateOpenPlatformSetup({
@@ -478,7 +545,14 @@ describe('automateOpenPlatformSetup', () => {
       '/developers/v1/scope/update/cli_x',
       '/developers/v1/robot/switch/cli_x',
       '/developers/v1/event/switch/cli_x',
+      '/developers/v1/event/cli_x',
       '/developers/v1/event/update/cli_x',
+      '/developers/v1/event/cli_x',
+      '/developers/v1/callback/cli_x',
+      '/developers/v1/callback/switch/cli_x',
+      '/developers/v1/callback/cli_x',
+      '/developers/v1/callback/update/cli_x',
+      '/developers/v1/callback/cli_x',
       '/developers/v1/safe_setting/update/cli_x',
       '/developers/v1/contact_range/cli_x',
       '/developers/v1/app_version/list/cli_x',
@@ -497,8 +571,9 @@ describe('automateOpenPlatformSetup', () => {
     const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-'));
     const sessionFile = join(dir, 'feishu-session.json');
     writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+    const sub = openPlatformSubscriptionMock('cli_x');
     const calls: string[] = [];
-    const fetchImpl = (async (url: string | URL | Request) => {
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
       const href = String(url);
       calls.push(href);
       if (href === 'https://ask.feishu.cn/') return new Response('ask home', { status: 200 });
@@ -508,7 +583,7 @@ describe('automateOpenPlatformSetup', () => {
       }
       if (href.includes('/scope/update/')) return Response.json({ code: 1, msg: 'scope not grantable for tenant' });
       if (href.includes('/app_version/create/')) return Response.json({ code: 0, data: { versionId: 'v1' } });
-      return Response.json({ code: 0 });
+      return sub.handle(href, init) ?? Response.json({ code: 0 });
     }) as typeof fetch;
 
     const result = await automateOpenPlatformSetup({
@@ -533,8 +608,9 @@ describe('automateOpenPlatformSetup', () => {
     const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-'));
     const sessionFile = join(dir, 'feishu-session.json');
     writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+    const sub = openPlatformSubscriptionMock('cli_x');
     const calls: string[] = [];
-    const fetchImpl = (async (url: string | URL | Request) => {
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
       const href = String(url);
       calls.push(href);
       if (href === 'https://ask.feishu.cn/') return new Response('ask home', { status: 200 });
@@ -543,7 +619,7 @@ describe('automateOpenPlatformSetup', () => {
         return Response.json({ code: 0, data: { appScopeList: [], userScopeList: [] } });
       }
       if (href.includes('/app_version/create/')) return Response.json({ code: 0, data: { versionId: 'v1' } });
-      return Response.json({ code: 0 });
+      return sub.handle(href, init) ?? Response.json({ code: 0 });
     }) as typeof fetch;
 
     const result = await automateOpenPlatformSetup({
@@ -559,5 +635,107 @@ describe('automateOpenPlatformSetup', () => {
       expect(result.skippedScopeCount).toBe(3);
     }
     expect(calls.some(u => u.includes('/scope/update/'))).toBe(false);
+  });
+
+  function subscriptionFetchImpl(sub: ReturnType<typeof openPlatformSubscriptionMock>, calls: string[]) {
+    return (async (url: string | URL | Request, init?: RequestInit) => {
+      const href = String(url);
+      calls.push(href);
+      if (href === 'https://ask.feishu.cn/') return new Response('ask home', { status: 200 });
+      if (href.endsWith('/auth')) return new Response('<script>window.csrfToken="csrf_auto"</script>', { status: 200 });
+      if (href.includes('/scope/all/')) {
+        return Response.json({ code: 0, data: { appScopeList: [{ id: 't1', name: 'im:message' }], userScopeList: [] } });
+      }
+      if (href.includes('/app_version/create/')) return Response.json({ code: 0, data: { versionId: 'v1' } });
+      return sub.handle(href, init) ?? Response.json({ code: 0 });
+    }) as typeof fetch;
+  }
+
+  async function runSetupWithMock(sessionDirPrefix: string, sub: ReturnType<typeof openPlatformSubscriptionMock>, calls: string[]) {
+    const dir = mkdtempSync(join(tmpdir(), sessionDirPrefix));
+    const sessionFile = join(dir, 'feishu-session.json');
+    writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+    return automateOpenPlatformSetup({
+      appId: 'cli_x',
+      sessionFilePath: sessionFile,
+      fetchImpl: subscriptionFetchImpl(sub, calls),
+      scopeManifest: { scopes: { tenant: ['im:message'], user: [] } },
+    });
+  }
+
+  it('subscribes baseline app events incrementally and the card callback via /callback endpoints', async () => {
+    const sub = openPlatformSubscriptionMock('cli_x');
+    const calls: string[] = [];
+    const result = await runSetupWithMock('botmux-sub-', sub, calls);
+
+    expect(result.ok).toBe(true);
+    const eventUpdate = sub.updateBodies.find(body => Array.isArray(body.appEvents));
+    expect(eventUpdate).toMatchObject({ clientId: 'cli_x', operation: 'add', eventMode: 4, events: [] });
+    expect(eventUpdate?.appEvents).toContain('im.message.receive_v1');
+    expect(eventUpdate?.appEvents).toContain('im.chat.member.bot.added_v1');
+    expect(eventUpdate?.appEvents).toContain('vc.bot.meeting_invited_v1');
+    expect(eventUpdate?.appEvents).not.toContain('card.action.trigger');
+    expect(eventUpdate?.userEvents).toEqual(['vc.meeting.participant_meeting_joined_v1']);
+    const callbackUpdate = sub.updateBodies.find(body => Array.isArray(body.callbacks));
+    expect(callbackUpdate).toMatchObject({ clientId: 'cli_x', operation: 'add', callbacks: ['card.action.trigger'], callbackMode: 4 });
+    // 回调接收方式初始是 webhook(1),必须先切长连接再订阅
+    expect(sub.state.callbackMode).toBe(4);
+    if (result.ok) {
+      expect(result.subscribedEventCount).toBeGreaterThanOrEqual(8);
+      expect(result.eventWarning).toBeUndefined();
+    }
+  });
+
+  it('is idempotent: already-subscribed apps get no event/callback update calls', async () => {
+    const sub = openPlatformSubscriptionMock('cli_x', {
+      initial: {
+        appEvents: [
+          'im.message.receive_v1',
+          'im.chat.member.bot.added_v1',
+          'drive.file.comment_add_v1',
+          'drive.notice.comment_add_v1',
+          'im.message.reaction.created_v1',
+          'im.message.reaction.deleted_v1',
+          'vc.bot.meeting_invited_v1',
+          'vc.bot.meeting_activity_v1',
+          'vc.bot.meeting_ended_v1',
+        ],
+        userEvents: ['vc.meeting.participant_meeting_joined_v1'],
+        callbacks: ['card.action.trigger'],
+        callbackMode: 4,
+      },
+    });
+    const calls: string[] = [];
+    const result = await runSetupWithMock('botmux-sub-idem-', sub, calls);
+
+    expect(result.ok).toBe(true);
+    expect(sub.updateBodies).toEqual([]);
+    expect(calls.some(u => u.includes('/callback/switch/'))).toBe(false);
+  });
+
+  it('fails closed when im.message.receive_v1 cannot be subscribed', async () => {
+    const sub = openPlatformSubscriptionMock('cli_x', { failEventUpdate: true });
+    const calls: string[] = [];
+    const result = await runSetupWithMock('botmux-sub-fail-', sub, calls);
+
+    expect(result).toMatchObject({ ok: false, reason: 'api_error' });
+    if (!result.ok) {
+      expect(result.message).toContain('im.message.receive_v1');
+      expect(result.eventWarning).toBeTruthy();
+    }
+    // 批量失败后逐个重试过:baseline 6 + VC app 3 + VC user 1 = 批量 1 次 + 单个 10 次
+    expect(sub.updateBodies.filter(body => Array.isArray(body.appEvents)).length).toBe(11);
+    // 核心事件缺失时不再继续发版,避免发布一个收不到消息的版本
+    expect(calls.some(u => u.includes('/publish/commit/'))).toBe(false);
+  });
+
+  it('fails closed when the card.action.trigger callback cannot be subscribed', async () => {
+    const sub = openPlatformSubscriptionMock('cli_x', { failCallbackUpdate: true });
+    const calls: string[] = [];
+    const result = await runSetupWithMock('botmux-sub-cbfail-', sub, calls);
+
+    expect(result).toMatchObject({ ok: false, reason: 'api_error' });
+    if (!result.ok) expect(result.message).toContain('card.action.trigger');
+    expect(calls.some(u => u.includes('/publish/commit/'))).toBe(false);
   });
 });

--- a/test/setup-open-platform-automation.test.ts
+++ b/test/setup-open-platform-automation.test.ts
@@ -692,6 +692,7 @@ describe('automateOpenPlatformSetup', () => {
         appEvents: [
           'im.message.receive_v1',
           'im.chat.member.bot.added_v1',
+          'im.chat.member.bot.deleted_v1',
           'drive.file.comment_add_v1',
           'drive.notice.comment_add_v1',
           'im.message.reaction.created_v1',
@@ -723,8 +724,8 @@ describe('automateOpenPlatformSetup', () => {
       expect(result.message).toContain('im.message.receive_v1');
       expect(result.eventWarning).toBeTruthy();
     }
-    // 批量失败后逐个重试过:baseline 6 + VC app 3 + VC user 1 = 批量 1 次 + 单个 10 次
-    expect(sub.updateBodies.filter(body => Array.isArray(body.appEvents)).length).toBe(11);
+    // 批量失败后逐个重试过:baseline 7 + VC app 3 + VC user 1 = 批量 1 次 + 单个 11 次
+    expect(sub.updateBodies.filter(body => Array.isArray(body.appEvents)).length).toBe(12);
     // 核心事件缺失时不再继续发版,避免发布一个收不到消息的版本
     expect(calls.some(u => u.includes('/publish/commit/'))).toBe(false);
   });

--- a/test/setup-open-platform-automation.test.ts
+++ b/test/setup-open-platform-automation.test.ts
@@ -24,6 +24,7 @@ import {
   prepareFeishuWebSession,
   readStoredCookiesFromSessionFile,
   type StoredCookie,
+  vcListenerEventGateError,
   writeStoredCookiesToSessionFile,
 } from '../src/setup/open-platform-automation.js';
 
@@ -54,6 +55,12 @@ window.user={"id":"u_1","name":"Alice","email":"alice@example.com","tenantId":"t
 function openPlatformSubscriptionMock(appId: string, opts: {
   failEventUpdate?: boolean;
   failCallbackUpdate?: boolean;
+  /** callback/switch 直接报错。 */
+  failCallbackSwitch?: boolean;
+  /** callback/switch 返回成功但 mode 实际不变(回读兜底用例)。 */
+  callbackSwitchNoop?: boolean;
+  /** event/update 中包含这些事件时整批被拒(逐个重试时对应单个失败)。 */
+  rejectEventNames?: string[];
   initial?: { appEvents?: string[]; userEvents?: string[]; callbacks?: string[]; callbackMode?: number };
 } = {}) {
   const state = {
@@ -68,7 +75,10 @@ function openPlatformSubscriptionMock(appId: string, opts: {
     if (href.endsWith(`/developers/v1/event/update/${appId}`)) {
       const body = JSON.parse(String(init?.body));
       updateBodies.push(body);
-      if (opts.failEventUpdate) return Response.json({ code: 1, msg: 'event update rejected' });
+      const requested: string[] = [...(body.appEvents ?? []), ...(body.userEvents ?? [])];
+      if (opts.failEventUpdate || requested.some(name => (opts.rejectEventNames ?? []).includes(name))) {
+        return Response.json({ code: 1, msg: 'event update rejected' });
+      }
       state.appEvents.push(...(body.appEvents ?? []));
       state.userEvents.push(...(body.userEvents ?? []));
       return Response.json({ code: 0 });
@@ -85,8 +95,9 @@ function openPlatformSubscriptionMock(appId: string, opts: {
       });
     }
     if (href.endsWith(`/developers/v1/callback/switch/${appId}`)) {
+      if (opts.failCallbackSwitch) return Response.json({ code: 1, msg: 'callback switch rejected' });
       const body = JSON.parse(String(init?.body));
-      state.callbackMode = body.callbackMode;
+      if (!opts.callbackSwitchNoop) state.callbackMode = body.callbackMode;
       return Response.json({ code: 0 });
     }
     if (href.endsWith(`/developers/v1/callback/update/${appId}`)) {
@@ -738,5 +749,64 @@ describe('automateOpenPlatformSetup', () => {
     expect(result).toMatchObject({ ok: false, reason: 'api_error' });
     if (!result.ok) expect(result.message).toContain('card.action.trigger');
     expect(calls.some(u => u.includes('/publish/commit/'))).toBe(false);
+  });
+
+  it('fails closed when the callback long-connection switch fails even with the callback already subscribed', async () => {
+    const sub = openPlatformSubscriptionMock('cli_x', {
+      failCallbackSwitch: true,
+      initial: { callbacks: ['card.action.trigger'], callbackMode: 1 },
+    });
+    const calls: string[] = [];
+    const result = await runSetupWithMock('botmux-sub-swfail-', sub, calls);
+
+    expect(result).toMatchObject({ ok: false, reason: 'api_error' });
+    if (!result.ok) expect(result.message).toContain('回调接收模式');
+    expect(sub.state.callbackMode).toBe(1);
+    expect(calls.some(u => u.includes('/publish/commit/'))).toBe(false);
+  });
+
+  it('fails closed when callback mode readback still shows webhook after a successful switch call', async () => {
+    const sub = openPlatformSubscriptionMock('cli_x', {
+      callbackSwitchNoop: true,
+      initial: { callbacks: ['card.action.trigger'], callbackMode: 1 },
+    });
+    const calls: string[] = [];
+    const result = await runSetupWithMock('botmux-sub-swnoop-', sub, calls);
+
+    expect(result).toMatchObject({ ok: false, reason: 'api_error' });
+    if (!result.ok) expect(result.message).toContain('回调接收模式');
+    expect(calls.some(u => u.includes('/publish/commit/'))).toBe(false);
+  });
+
+  it('keeps plain bot setup ok when only VC events fail, but reports missingVcEvents for the listener gate', async () => {
+    const vcEvents = [
+      'vc.bot.meeting_invited_v1',
+      'vc.bot.meeting_activity_v1',
+      'vc.bot.meeting_ended_v1',
+      'vc.meeting.participant_meeting_joined_v1',
+    ];
+    const sub = openPlatformSubscriptionMock('cli_x', { rejectEventNames: vcEvents });
+    const calls: string[] = [];
+    const result = await runSetupWithMock('botmux-sub-vc-', sub, calls);
+
+    // 普通建 bot:baseline+回调齐 → 不阻断,照常发版
+    expect(result.ok).toBe(true);
+    expect(calls.some(u => u.includes('/publish/commit/'))).toBe(true);
+    if (result.ok) {
+      expect(result.missingVcEvents).toEqual(vcEvents);
+      expect(result.subscribedEventCount).toBe(8); // 7 baseline 事件 + 1 回调
+      expect(result.eventWarning).toContain('VC 会议事件未确认订阅');
+      // VC listener 保存门必须拦下这种结果(dashboard 两条分支都走这个门)
+      expect(vcListenerEventGateError(result)).toContain('vc.bot.meeting_invited_v1');
+    }
+  });
+
+  it('vcListenerEventGateError passes clean results and blocks zero-subscription or missing-VC results', () => {
+    expect(vcListenerEventGateError({ subscribedEventCount: 12, missingVcEvents: [] })).toBeNull();
+    expect(vcListenerEventGateError({ eventWarning: 'boom', subscribedEventCount: 0 })).toContain('事件订阅全部失败');
+    expect(vcListenerEventGateError({ subscribedEventCount: 8, missingVcEvents: ['vc.bot.meeting_ended_v1'] }))
+      .toContain('vc.bot.meeting_ended_v1');
+    // 走不到订阅阶段的早期失败(missingVcEvents undefined)保持原 best-effort 语义
+    expect(vcListenerEventGateError({})).toBeNull();
   });
 });

--- a/test/setup-open-platform-automation.test.ts
+++ b/test/setup-open-platform-automation.test.ts
@@ -61,10 +61,10 @@ function openPlatformSubscriptionMock(appId: string, opts: {
   callbackSwitchNoop?: boolean;
   /** event/update 中包含这些事件时整批被拒(逐个重试时对应单个失败)。 */
   rejectEventNames?: string[];
-  initial?: { appEvents?: string[]; userEvents?: string[]; callbacks?: string[]; callbackMode?: number };
+  initial?: { appEvents?: string[]; userEvents?: string[]; callbacks?: string[]; callbackMode?: number; eventMode?: number };
 } = {}) {
   const state = {
-    eventMode: 4,
+    eventMode: opts.initial?.eventMode ?? 4,
     appEvents: [...(opts.initial?.appEvents ?? [])],
     userEvents: [...(opts.initial?.userEvents ?? [])],
     callbackMode: opts.initial?.callbackMode ?? 1,
@@ -801,12 +801,51 @@ describe('automateOpenPlatformSetup', () => {
     }
   });
 
-  it('vcListenerEventGateError passes clean results and blocks zero-subscription or missing-VC results', () => {
-    expect(vcListenerEventGateError({ subscribedEventCount: 12, missingVcEvents: [] })).toBeNull();
+  it('fails closed and blocks the listener gate when event mode readback stays webhook despite full subscriptions', async () => {
+    // event/switch 返回成功(mock 默认 code 0)但回读 eventMode 仍是 1:
+    // 订阅名齐、count=12、missingVcEvents=[],唯一异常是接收方式。
+    const sub = openPlatformSubscriptionMock('cli_x', {
+      initial: {
+        eventMode: 1,
+        appEvents: [
+          'im.message.receive_v1',
+          'im.chat.member.bot.added_v1',
+          'im.chat.member.bot.deleted_v1',
+          'drive.file.comment_add_v1',
+          'drive.notice.comment_add_v1',
+          'im.message.reaction.created_v1',
+          'im.message.reaction.deleted_v1',
+          'vc.bot.meeting_invited_v1',
+          'vc.bot.meeting_activity_v1',
+          'vc.bot.meeting_ended_v1',
+        ],
+        userEvents: ['vc.meeting.participant_meeting_joined_v1'],
+        callbacks: ['card.action.trigger'],
+        callbackMode: 4,
+      },
+    });
+    const calls: string[] = [];
+    const result = await runSetupWithMock('botmux-sub-evmode-', sub, calls);
+
+    expect(result).toMatchObject({ ok: false, reason: 'api_error' });
+    if (!result.ok) {
+      expect(result.message).toContain('事件接收模式');
+      expect(result.eventModeReady).toBe(false);
+      expect(result.missingVcEvents).toEqual([]);
+      // dashboard 非登录失败分支的 listener 门必须拦下(此前 count=12/missingVc=[] 会放行)
+      expect(vcListenerEventGateError(result)).toContain('长连接');
+    }
+    expect(calls.some(u => u.includes('/publish/commit/'))).toBe(false);
+  });
+
+  it('vcListenerEventGateError passes clean results and blocks zero-subscription, missing-VC or mode-not-ready results', () => {
+    expect(vcListenerEventGateError({ subscribedEventCount: 12, missingVcEvents: [], eventModeReady: true })).toBeNull();
     expect(vcListenerEventGateError({ eventWarning: 'boom', subscribedEventCount: 0 })).toContain('事件订阅全部失败');
-    expect(vcListenerEventGateError({ subscribedEventCount: 8, missingVcEvents: ['vc.bot.meeting_ended_v1'] }))
+    expect(vcListenerEventGateError({ subscribedEventCount: 8, missingVcEvents: ['vc.bot.meeting_ended_v1'], eventModeReady: true }))
       .toContain('vc.bot.meeting_ended_v1');
-    // 走不到订阅阶段的早期失败(missingVcEvents undefined)保持原 best-effort 语义
+    expect(vcListenerEventGateError({ subscribedEventCount: 12, missingVcEvents: [], eventModeReady: false }))
+      .toContain('长连接');
+    // 走不到订阅阶段的早期失败(missingVcEvents/eventModeReady 均 undefined)保持原 best-effort 语义
     expect(vcListenerEventGateError({})).toBeNull();
   });
 });


### PR DESCRIPTION
## 背景(用户反馈的紧急问题)

用户反馈**新创建的机器人缺 `im.message.receive_v1` / `card.action.trigger`**,收不到消息、卡片按钮无响应。

根因是两层叠加:
1. **v2.106.0 (PR #412)** 引入的事件自动订阅从一开始契约就是错的:`/developers/v1/event/update` 发 `eventNames`/`eventNameList`、fallback 到不存在的 `/event_callback/update`,三连全失败且被吞成 warning。当时没暴露——建 bot 走 SDK PersonalAgent 扫码注册,事件平台默认配好。
2. **v2.109.0 (PR #457)** 把建 bot 切到开放平台 Web `app/create`(普通企业自建应用,**默认零事件订阅**),订阅全指望上面那个坏掉的调用 → 新建 bot 落地即缺核心事件/回调。

另一个独立事实:`card.action.trigger` 在开放平台是「**回调**」不是「事件」,有独立配置接口(`/developers/v1/callback/*`)和独立的长连接开关,塞进事件列表本身就订不上。

## 变更(src/setup/open-platform-automation.ts)

- **事件订阅走 console 前端同款增量契约**(从 console 前端 bundle 逆向确认,live 实测通过):先读 `/developers/v1/event/:id` 现状 → `operation:'add'` 只补缺失(按 app/user 身份分桶,`eventMode` 回填读接口返回值)→ 回读确认;整批被拒时逐个补,不让长尾事件(如 drive 评论事件依赖的 scope 不可授予)拖垮核心事件
- **卡片回调独立处理**:读 `/developers/v1/callback/:id` → 非长连接先 `callback/switch` 切 mode 4 → `callback/update` 增量订阅 `card.action.trigger` → 回读
- **fail-closed**:核心项(`im.message.receive_v1` 事件 + `card.action.trigger` 回调)回读仍缺失时,自动配置直接返回失败并**停止发版**,不再静默产出「建好了却不回话」的坏 bot;其余基础事件缺失记 warning
- **VC 会议事件同批带上**(app 3 项 / user 1 项),给会议监听 bot 顺带止血。PR #454 后续可在此契约上做更严格的身份验证

`BOT_BASELINE_EVENTS` 拆为 `BOT_BASELINE_APP_EVENTS`(7 事件,a213472c 按申晗核对补上 im.chat.member.bot.deleted_v1 对齐存量 bot)+ `BOT_BASELINE_CALLBACKS`(卡片回调)+ `BOT_CRITICAL_APP_EVENTS`(fail-closed 集),原常量无仓库外消费者。

## 影响面

- 仅 `automateOpenPlatformSetup`(botmux setup CLI / dashboard 添加机器人 / VC listener 保存共用)的事件订阅段;scope 导入、redirect、发版逻辑不动
- 结果字段 `subscribedEventCount`/`eventWarning` 形状不变(dashboard VC 流程与 event-dispatcher 日志按原语义消费)
- 与开放 PR #454 会在同函数冲突——本 PR 先止血用户问题,#454 rebase 后做 VC 深度验证
- 对已有订阅齐全的 app 幂等:回读命中即不发任何写请求(有单测)

## 验证

- `pnpm exec tsc --noEmit` + `pnpm build`:零错误
- 本文件单测 22/22(新增 4:增量契约 payload / 幂等零写 / 事件 fail-closed(批量失败逐个重试 11 次)/ 回调 fail-closed);关联 5 文件 73/73 绿
- 全套 unit:8163 passed / 5 failed——同 5 个失败在干净 origin/master 复现(scheduler×2、schedule-card×1、monitoring-ui×1、recall-frozen×1),pre-existing 与本 PR 无关
- **Live e2e(申晗租户实测)**:用缓存 web session 真实创建测试应用 `bmx-e2e-tmp` → 跑修复后 `automateOpenPlatformSetup`(298 scopes、11 订阅、发版成功)→ **独立回读确认** 6 基础事件 + 4 VC 事件全订阅、`card.action.trigger` 回调订阅、事件/回调均 mode 4 长连接 → `/developers/v1/app/delete` 删除测试应用无残留

```
# eventMode: 4 | callbackMode: 4
# subscribed events: im.message.receive_v1, im.chat.member.bot.added_v1, drive.file.comment_add_v1, drive.notice.comment_add_v1, im.message.reaction.created_v1, im.message.reaction.deleted_v1, vc.bot.meeting_invited_v1, vc.bot.meeting_activity_v1, vc.bot.meeting_ended_v1, vc.meeting.participant_meeting_joined_v1
# subscribed callbacks: card.action.trigger
# missing baseline events: (none)
# missing callbacks: (none)
# E2E PASS
```

