### PR TITLE
feat(session): 支持 spawn 复用指定话题

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -63,10 +63,10 @@ import * as chatFirstSeenStore from '../services/chat-first-seen-store.js';
 import * as scheduler from './scheduler.js';
 import { listActiveSessions, findActiveBySessionId, closeSession, getActiveSessionsRegistry, transferSession, deliverWriteLinkCardToOwners, forkWorker, suspendWorker } from './worker-pool.js';
 import { listOnlineDaemons } from '../utils/daemon-discovery.js';
-import { getChatMode, replyMessage, sendMessage, resolveUnionIdFromOpenId, listThreadMessages, listChatMessages, listChatBotMembers, getUserProfile, resolveAllowedUsersWithMap, type ChatBotMember } from '../im/lark/client.js';
+import { getChatMode, replyMessage, sendMessage, resolveUnionIdFromOpenId, listThreadMessages, listChatMessages, listChatBotMembers, getUserProfile, resolveAllowedUsersWithMap, getMessageChatId, type ChatBotMember } from '../im/lark/client.js';
 import { parseApiMessage, cardContentHasUpgradeFallback, resolveMergedCardContent } from '../im/lark/message-parser.js';
 import { resumeSession, spawnDashboardSession, activateQueuedSession, closeCliMismatchedSessionsForBot, suspendActiveSessionsForBot } from './session-manager.js';
-import { parseSpawnRequest } from './session-create.js';
+import { parseSpawnRequest, validateInheritedTopicTarget } from './session-create.js';
 import { getCliDisplayName } from '../im/lark/card-builder.js';
 import { locateLimiter } from './dashboard-locate.js';
 import { buildTerminalUrl } from './terminal-url.js';
@@ -426,10 +426,20 @@ ipcRoute('POST', '/api/sessions/spawn', async (req, res) => {
   try { body = await readJsonBody(req); } catch { return jsonRes(res, 400, { ok: false, error: 'invalid_json' }); }
   const parsed = parseSpawnRequest(body);
   if (!parsed.ok) return jsonRes(res, 400, { ok: false, error: parsed.error });
+  if (parsed.value.topicPolicy === 'inherit') {
+    const rootTarget = await validateInheritedTopicTarget({
+      larkAppId: cachedLarkAppId,
+      chatId: parsed.value.chatId,
+      rootMessageId: parsed.value.rootMessageId!,
+      getMessageChatId,
+    });
+    if (!rootTarget.ok) return jsonRes(res, 400, { ok: false, error: rootTarget.error });
+  }
   const postBanner = !!(body as any).postBanner;
   const r = await spawnDashboardSession(activeSessions, undefined, {
     larkAppId: cachedLarkAppId,
     chatId: parsed.value.chatId,
+    rootMessageId: parsed.value.topicPolicy === 'inherit' ? parsed.value.rootMessageId : undefined,
     content: parsed.value.content,
     column: parsed.value.column,
     role: parsed.value.role,

--- a/src/core/session-create.ts
+++ b/src/core/session-create.ts
@@ -23,6 +23,13 @@ export type CreateSessionColumn = (typeof CREATE_SESSION_COLUMNS)[number];
 export type SpawnRole = 'solo' | 'lead' | 'collab';
 export const SPAWN_ROLES: readonly SpawnRole[] = ['solo', 'lead', 'collab'];
 
+/** Optional routing policy for /api/sessions/spawn.
+ *  - absent: keep the existing dashboard-created chat-scope session behavior.
+ *  - inherit: create a new botmux/CLI session but route all replies to an
+ *    existing Lark topic identified by rootMessageId. */
+export type SpawnTopicPolicy = 'inherit';
+export const SPAWN_TOPIC_POLICIES: readonly SpawnTopicPolicy[] = ['inherit'];
+
 const TITLE_MAX = 50;
 
 export interface Coworker {
@@ -45,6 +52,12 @@ export function normalizeCreateColumn(value: unknown): CreateSessionColumn | nul
 function normalizeSpawnRole(value: unknown): SpawnRole | null {
   return typeof value === 'string' && (SPAWN_ROLES as readonly string[]).includes(value)
     ? (value as SpawnRole)
+    : null;
+}
+
+function normalizeSpawnTopicPolicy(value: unknown): SpawnTopicPolicy | null {
+  return typeof value === 'string' && (SPAWN_TOPIC_POLICIES as readonly string[]).includes(value)
+    ? (value as SpawnTopicPolicy)
     : null;
 }
 
@@ -107,6 +120,8 @@ export interface SpawnRequest {
   column: CreateSessionColumn;
   role: SpawnRole;
   coworkers: Coworker[];
+  topicPolicy?: SpawnTopicPolicy;
+  rootMessageId?: string;
   ownerOpenId?: string;
   ownerUnionId?: string;
   title?: string;
@@ -144,6 +159,18 @@ export function parseSpawnRequest(body: unknown): ParseResult<SpawnRequest> {
   if (!column) return { ok: false, error: 'bad_column' };
   const role = normalizeSpawnRole(b.role);
   if (!role) return { ok: false, error: 'bad_role' };
+  const rawTopicPolicy = typeof b.topicPolicy === 'string' ? b.topicPolicy.trim() : '';
+  const rootMessageId = typeof b.rootMessageId === 'string' ? b.rootMessageId.trim() : '';
+  const topicPolicy = rawTopicPolicy ? normalizeSpawnTopicPolicy(rawTopicPolicy) : undefined;
+  if (rawTopicPolicy && !topicPolicy) return { ok: false, error: 'bad_topic_policy' };
+  if (topicPolicy === 'inherit') {
+    if (!rootMessageId) return { ok: false, error: 'root_message_id_required' };
+    if (!rootMessageId.startsWith('om_')) return { ok: false, error: 'bad_root_message_id' };
+  } else if (rootMessageId) {
+    // Avoid silently accepting a rootMessageId that would be ignored by the
+    // legacy/default path. Callers must opt in explicitly with topicPolicy.
+    return { ok: false, error: 'topic_policy_required' };
+  }
   const title = typeof b.title === 'string' && b.title.trim() ? b.title.trim().slice(0, 200) : undefined;
   return {
     ok: true,
@@ -153,9 +180,27 @@ export function parseSpawnRequest(body: unknown): ParseResult<SpawnRequest> {
       column,
       role,
       coworkers: parseCoworkers(b.coworkers),
+      ...(topicPolicy ? { topicPolicy } : {}),
+      ...(rootMessageId ? { rootMessageId } : {}),
       ownerOpenId: typeof b.ownerOpenId === 'string' && b.ownerOpenId.trim() ? b.ownerOpenId.trim() : undefined,
       ownerUnionId: typeof b.ownerUnionId === 'string' && b.ownerUnionId.trim() ? b.ownerUnionId.trim() : undefined,
       title,
     },
   };
+}
+
+export async function validateInheritedTopicTarget(args: {
+  larkAppId: string;
+  chatId: string;
+  rootMessageId: string;
+  getMessageChatId: (larkAppId: string, messageId: string) => Promise<string | null>;
+}): Promise<ParseResult<{ chatId: string; rootMessageId: string }>> {
+  const actualChatId = await args.getMessageChatId(args.larkAppId, args.rootMessageId);
+  if (!actualChatId) {
+    return { ok: false, error: 'root_message_not_found' };
+  }
+  if (actualChatId !== args.chatId) {
+    return { ok: false, error: 'root_message_chat_mismatch' };
+  }
+  return { ok: true, value: { chatId: args.chatId, rootMessageId: args.rootMessageId } };
 }

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -1605,6 +1605,13 @@ async function forkOrShowRepoCard(ds: DaemonSession, userContent: string): Promi
   const larkAppId = ds.larkAppId;
   const bot = getBot(larkAppId);
   const locale = localeForBot(larkAppId);
+  const anchor = sessionAnchorId(ds);
+  const sendSpawnScopedMessage = async (content: string, msgType: 'text' | 'interactive' = 'text'): Promise<string> => {
+    const { replyMessage, sendMessage } = await import('../im/lark/client.js');
+    return ds.scope === 'thread'
+      ? replyMessage(larkAppId, anchor, content, msgType, true)
+      : sendMessage(larkAppId, ds.chatId, content, msgType);
+  };
 
   // 仅默认目录 + auto-worktree：ds.workingDir 命中本 bot 自己的默认目录（且非本群 oncall 绑定）时，
   // 走 pendingRepo 挂起 + 异步提交：把会话置 pendingRepo（入站路由 buffer 并发消息、不抢 fork），
@@ -1622,12 +1629,11 @@ async function forkOrShowRepoCard(ds: DaemonSession, userContent: string): Promi
       // (The pending dashboard row is announced inside runAutoWorktreeCommit so all
       // three spawn callers get it from one place — no publish needed here.)
       const { runAutoWorktreeCommit } = await import('../im/lark/card-handler.js');
-      const { sendMessage } = await import('../im/lark/client.js');
       void runAutoWorktreeCommit({
-        ds, anchor: ds.chatId, larkAppId, baseDir,
+        ds, anchor, larkAppId, baseDir,
         title: ds.session.title, prompt: userContent,
         operatorOpenId: ds.session.ownerOpenId, activeSessions: registry,
-        notify: (m) => sendMessage(larkAppId, ds.chatId, m),
+        notify: (m) => sendSpawnScopedMessage(m),
       });
       logger.info(`[createSession] session ${ds.session.sessionId.substring(0, 8)} → pending, building worktree off ${baseDir}`);
       return;
@@ -1647,11 +1653,10 @@ async function forkOrShowRepoCard(ds: DaemonSession, userContent: string): Promi
     const projects = scanDirs.length > 0 ? scanMultipleProjects(scanDirs, 3, repoPickerScanOptions()) : [];
     if (projects.length > 0) {
       try {
-        const card = buildRepoSelectCard(projects, getSessionWorkingDir(ds), ds.chatId, locale, bot.config.worktreeMultiPicker);
-        const { sendMessage } = await import('../im/lark/client.js');
+        const card = buildRepoSelectCard(projects, getSessionWorkingDir(ds), anchor, locale, bot.config.worktreeMultiPicker);
         ds.pendingRepo = true;
         ds.pendingPrompt = userContent;
-        ds.repoCardMessageId = await sendMessage(larkAppId, ds.chatId, card, 'interactive');
+        ds.repoCardMessageId = await sendSpawnScopedMessage(card, 'interactive');
         announcePendingRepoSession(ds);
         // 弹卡片这条路不经 forkWorker，session.spawned 不会自动发——手动 upsert 一条，
         // 让 dashboard 显示这条「待选仓库」会话（in_progress 首次 spawn 走这里才会出现）。
@@ -1678,6 +1683,9 @@ export interface SpawnDashboardSessionArgs {
   larkAppId: string;
   /** 新建的飞书群（chat-scope 锚点）。 */
   chatId: string;
+  /** Optional existing topic root. When set, create a fresh session/CLI but
+   *  route all bot replies into this topic instead of the chat top level. */
+  rootMessageId?: string;
   /** 用户在弹框里写的原始任务内容。 */
   content: string;
   /** in_progress=立即开跑；backlog=入待办池（parked，不起 CLI）。 */
@@ -1695,7 +1703,9 @@ export interface SpawnDashboardSessionArgs {
   ownerUnionId?: string;
 }
 
-/** 在新建的飞书群里为某个 bot 拉起一条 chat-scope 会话（dashboard「创建会话」用）。
+/** 在飞书群里为某个 bot 拉起一条会话（dashboard「创建会话」/ API spawn 用）。
+ *  默认是 chat-scope；传入 rootMessageId 时创建 thread-scope：仍然是新的
+ *  botmux session + 新 CLI 进程，但回复锚到指定已有话题。
  *  column='in_progress' → 立即 forkWorker 把内容当首轮发给 CLI；
  *  column='backlog'     → 入待办池（parked：worker:null + session.queued + queuedPrompt），
  *                          等被激活（拖到进行中 / 点开始 / 群里来消息）再起 CLI。
@@ -1710,27 +1720,34 @@ export async function spawnDashboardSession(
   try { bot = getBot(larkAppId); } catch { return { ok: false, error: 'bot_not_found' }; }
   const locale = localeForBot(larkAppId);
 
-  // chat-scope：锚点就是 chatId。先挡掉「同群同 bot 已有真会话」的撞键（会被
-  // Map.set 覆盖而泄漏 worker）。queued 占位 / 纯 scratch 不算冲突。
-  const anchor = chatId;
+  const scope: 'thread' | 'chat' = args.rootMessageId ? 'thread' : 'chat';
+  // chat-scope：锚点是 chatId；thread-scope：锚点是 rootMessageId。先挡掉
+  //「同 anchor 同 bot 已有真会话」的撞键（会被 Map.set 覆盖而泄漏 worker）。
+  // queued / pendingRepo are real user-visible sessions and must not be
+  // overwritten; pure daemon-command scratches are allowed to be displaced.
+  const anchor = scope === 'thread' ? args.rootMessageId! : chatId;
   const existing = activeSessions.get(sessionKey(anchor, larkAppId));
-  if (existing && (existing.worker || existing.session.queued || isRelayableRealSession(existing))) {
+  if (existing && (existing.worker || existing.session.queued || existing.pendingRepo || isRelayableRealSession(existing))) {
     return { ok: false, error: 'session_exists' };
   }
 
   refreshCliVersion?.(bot.config.cliId, bot.config.cliPathOverride);
 
   // 可见任务横幅：只由 creator/lead 那次 spawn 发一条，给群成员交代这群是干嘛的。
-  // 纯文本、不 @ 任何 bot，不会误触发其它 bot。rootMessageId 存它仅为留痕（chat-scope
-  // 路由不看 rootMessageId）。失败不致命。横幅发完整内容——之前 slice(0,300) 会把超
-  // 300 字的任务在群里截断（用户看着像"内容丢了"，其实会话拿到的是全文，只是横幅被切）。
+  // 纯文本、不 @ 任何 bot，不会误触发其它 bot。thread-scope spawn 时横幅也回到
+  // 目标话题，避免任务生命周期消息散落到群顶层。失败不致命。横幅发完整内容——
+  // 之前 slice(0,300) 会把超 300 字的任务在群里截断（用户看着像"内容丢了"，
+  // 其实会话拿到的是全文，只是横幅被切）。
   let bannerMessageId: string | undefined;
   if (args.postBanner) {
     try {
-      const { sendMessage } = await import('../im/lark/client.js');
-      bannerMessageId = await sendMessage(larkAppId, chatId, t('cmd.createSession.banner', { content }, locale));
+      const { replyMessage, sendMessage } = await import('../im/lark/client.js');
+      const bannerText = t('cmd.createSession.banner', { content }, locale);
+      bannerMessageId = scope === 'thread'
+        ? await replyMessage(larkAppId, anchor, bannerText, 'text', true)
+        : await sendMessage(larkAppId, chatId, bannerText);
     } catch (err: any) {
-      logger.warn(`[createSession] banner send failed in ${chatId}: ${err?.message ?? err}`);
+      logger.warn(`[createSession] banner send failed in ${chatId}/${anchor}: ${err?.message ?? err}`);
     }
   }
 
@@ -1741,10 +1758,11 @@ export async function spawnDashboardSession(
   const userContent = composeSpawnUserContent({ content, role, coworkers: args.coworkers, locale });
 
   const resolvedTitle = args.title || deriveSessionTitleFromContent(content);
-  const session = sessionStore.createSession(chatId, bannerMessageId ?? chatId, resolvedTitle, 'group');
+  const rootIdForStore = scope === 'thread' ? anchor : (bannerMessageId ?? chatId);
+  const session = sessionStore.createSession(chatId, rootIdForStore, resolvedTitle, 'group');
   const now = Date.now();
   session.larkAppId = larkAppId;
-  session.scope = 'chat';
+  session.scope = scope;
   session.ownerOpenId = args.ownerOpenId ?? getOwnerOpenId(larkAppId);
   session.creatorOpenId = session.ownerOpenId;
   if (args.ownerUnionId) session.ownerUnionId = args.ownerUnionId;
@@ -1770,7 +1788,7 @@ export async function spawnDashboardSession(
     larkAppId,
     chatId,
     chatType: 'group',
-    scope: 'chat',
+    scope,
     spawnedAt: sessionCreatedAtMs(session),
     cliVersion: getCurrentCliVersion(),
     lastMessageAt: now,

--- a/test/dashboard-create-session.test.ts
+++ b/test/dashboard-create-session.test.ts
@@ -34,12 +34,13 @@ vi.mock('../src/services/session-store.js', () => ({
 vi.mock('../src/services/message-queue.js', () => ({ ensureQueue: vi.fn() }));
 
 const sendMessageMock = vi.fn(async () => 'om_banner_123');
+const replyMessageMock = vi.fn(async () => 'om_thread_banner_123');
 vi.mock('../src/im/lark/client.js', () => ({
   sendMessage: (...a: any[]) => sendMessageMock(...a),
+  replyMessage: (...a: any[]) => replyMessageMock(...a),
   downloadMessageResource: vi.fn(),
   listChatBotMembers: vi.fn(async () => []),
   getChatMode: vi.fn(),
-  replyMessage: vi.fn(),
   UserTokenMissingError: class extends Error {},
 }));
 
@@ -100,6 +101,7 @@ beforeEach(() => {
   sessionSeq = 0;
   forkWorkerMock.mockClear();
   sendMessageMock.mockClear();
+  replyMessageMock.mockClear();
   (dashboardEventBus.publish as any).mockClear();
 });
 
@@ -174,6 +176,25 @@ describe('spawnDashboardSession — in_progress starts immediately', () => {
     expect(prompt).toContain('<botmux_lead_dispatch>');
     expect(prompt).toContain('Sub1');
   });
+
+  it('can create a fresh session/CLI routed to an inherited topic root', async () => {
+    const active = new Map<string, DaemonSession>();
+    const rootMessageId = 'om_existing_topic';
+    const r = await spawnDashboardSession(active, undefined, {
+      larkAppId: APP, chatId: CHAT, rootMessageId, content: '继续这个任务', column: 'in_progress', role: 'solo', postBanner: true,
+    });
+    expect(r.ok).toBe(true);
+    expect(active.get(sessionKey(CHAT, APP))).toBeUndefined();
+    const ds = active.get(sessionKey(rootMessageId, APP))!;
+    expect(ds).toBeTruthy();
+    expect(ds.scope).toBe('thread');
+    expect(ds.session.scope).toBe('thread');
+    expect(ds.session.chatId).toBe(CHAT);
+    expect(ds.session.rootMessageId).toBe(rootMessageId);
+    expect(forkWorkerMock).toHaveBeenCalledTimes(1);
+    expect(replyMessageMock).toHaveBeenCalledWith(APP, rootMessageId, expect.stringContaining('继续这个任务'), 'text', true);
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('spawnDashboardSession — guards', () => {
@@ -182,6 +203,37 @@ describe('spawnDashboardSession — guards', () => {
     await spawnDashboardSession(active, undefined, { larkAppId: APP, chatId: CHAT, content: 'a', column: 'backlog', role: 'solo' });
     const r2 = await spawnDashboardSession(active, undefined, { larkAppId: APP, chatId: CHAT, content: 'b', column: 'in_progress', role: 'solo' });
     expect(r2).toMatchObject({ ok: false, error: 'session_exists' });
+  });
+
+  it('guards collisions by inherited topic root rather than chatId', async () => {
+    const active = new Map<string, DaemonSession>();
+    await spawnDashboardSession(active, undefined, { larkAppId: APP, chatId: CHAT, rootMessageId: 'om_topic_a', content: 'a', column: 'backlog', role: 'solo' });
+    const sameTopic = await spawnDashboardSession(active, undefined, { larkAppId: APP, chatId: CHAT, rootMessageId: 'om_topic_a', content: 'b', column: 'in_progress', role: 'solo' });
+    expect(sameTopic).toMatchObject({ ok: false, error: 'session_exists' });
+    const otherTopic = await spawnDashboardSession(active, undefined, { larkAppId: APP, chatId: CHAT, rootMessageId: 'om_topic_b', content: 'c', column: 'backlog', role: 'solo' });
+    expect(otherTopic.ok).toBe(true);
+  });
+
+  it('treats pendingRepo inherited-topic sessions as collisions too', async () => {
+    const active = new Map<string, DaemonSession>();
+    const rootMessageId = 'om_topic_pending';
+    active.set(sessionKey(rootMessageId, APP), {
+      session: { sessionId: 'pending', chatId: CHAT, rootMessageId, title: 'pending', status: 'active', createdAt: new Date().toISOString(), scope: 'thread' } as Session,
+      worker: null,
+      workerPort: null,
+      workerToken: null,
+      larkAppId: APP,
+      chatId: CHAT,
+      chatType: 'group',
+      scope: 'thread',
+      spawnedAt: 0,
+      cliVersion: 'test',
+      lastMessageAt: 0,
+      hasHistory: false,
+      pendingRepo: true,
+    });
+    const r = await spawnDashboardSession(active, undefined, { larkAppId: APP, chatId: CHAT, rootMessageId, content: 'new', column: 'in_progress', role: 'solo' });
+    expect(r).toMatchObject({ ok: false, error: 'session_exists' });
   });
 });
 

--- a/test/session-create.test.ts
+++ b/test/session-create.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeCreateColumn,
   deriveSessionTitleFromContent,
   parseSpawnRequest,
+  validateInheritedTopicTarget,
   composeSpawnUserContent,
   buildLeadDispatchPreamble,
   buildCollabNote,
@@ -53,6 +54,15 @@ describe('parseSpawnRequest', () => {
     }
   });
 
+  it('accepts topicPolicy=inherit with a rootMessageId', () => {
+    const r = parseSpawnRequest({ ...base, topicPolicy: 'inherit', rootMessageId: 'om_root_123' });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.topicPolicy).toBe('inherit');
+      expect(r.value.rootMessageId).toBe('om_root_123');
+    }
+  });
+
   it('rejects a non-oc_ chatId', () => {
     expect(parseSpawnRequest({ ...base, chatId: 'om_msg' })).toMatchObject({ ok: false, error: 'bad_chat_id' });
     expect(parseSpawnRequest({ ...base, chatId: '' })).toMatchObject({ ok: false, error: 'bad_chat_id' });
@@ -75,9 +85,37 @@ describe('parseSpawnRequest', () => {
     expect(parseSpawnRequest({ ...base, role: 'boss' })).toMatchObject({ ok: false, error: 'bad_role' });
   });
 
+  it('rejects malformed inherited-topic routing fields', () => {
+    expect(parseSpawnRequest({ ...base, topicPolicy: 'inherit' })).toMatchObject({ ok: false, error: 'root_message_id_required' });
+    expect(parseSpawnRequest({ ...base, topicPolicy: 'inherit', rootMessageId: 'oc_chat' })).toMatchObject({ ok: false, error: 'bad_root_message_id' });
+    expect(parseSpawnRequest({ ...base, topicPolicy: 'reuse', rootMessageId: 'om_root' })).toMatchObject({ ok: false, error: 'bad_topic_policy' });
+    expect(parseSpawnRequest({ ...base, rootMessageId: 'om_root' })).toMatchObject({ ok: false, error: 'topic_policy_required' });
+  });
+
   it('rejects a non-object body', () => {
     expect(parseSpawnRequest(null)).toMatchObject({ ok: false, error: 'bad_request' });
     expect(parseSpawnRequest('nope')).toMatchObject({ ok: false, error: 'bad_request' });
+  });
+});
+
+describe('validateInheritedTopicTarget', () => {
+  it('passes when the root message belongs to the requested chat', async () => {
+    const r = await validateInheritedTopicTarget({
+      larkAppId: 'cli_app',
+      chatId: 'oc_chat',
+      rootMessageId: 'om_root',
+      getMessageChatId: async () => 'oc_chat',
+    });
+    expect(r).toEqual({ ok: true, value: { chatId: 'oc_chat', rootMessageId: 'om_root' } });
+  });
+
+  it('fails closed when the root message is invisible or belongs to another chat', async () => {
+    await expect(validateInheritedTopicTarget({
+      larkAppId: 'cli_app', chatId: 'oc_chat', rootMessageId: 'om_root', getMessageChatId: async () => null,
+    })).resolves.toMatchObject({ ok: false, error: 'root_message_not_found' });
+    await expect(validateInheritedTopicTarget({
+      larkAppId: 'cli_app', chatId: 'oc_chat', rootMessageId: 'om_root', getMessageChatId: async () => 'oc_other',
+    })).resolves.toMatchObject({ ok: false, error: 'root_message_chat_mismatch' });
   });
 });
 


### PR DESCRIPTION
## 改了什么
- `/api/sessions/spawn` 新增可选参数 `topicPolicy: "inherit"` 与 `rootMessageId`，用于创建新的 botmux session / CLI 进程，但将后续消息路由到已有飞书话题。
- 不传 `topicPolicy/rootMessageId` 时保持原来的 chat-scope 默认行为。
- 增加 `rootMessageId` 所属 `chatId` 校验：无法读取或不属于目标群时 fail closed，避免跨群误发。
- inherited topic 场景下，横幅、仓库选择卡片、auto-worktree 通知等创建阶段消息也会回复到目标话题内。
- 补充解析、校验、thread-scope session 创建和冲突保护相关单测。

## 为什么
业务任务可能由脚本拆成多个执行 session 继续跑，但希望这些 session 的飞书消息仍聚合在同一个话题里，便于追踪完整生命周期。

## 影响面
- API：仅影响 `/api/sessions/spawn`，新增字段为显式 opt-in。
- 会话类型：默认 chat-scope 逻辑保持不变；传入 `topicPolicy=inherit` 时创建 thread-scope session，active session key 使用 `rootMessageId + larkAppId`。
- 飞书路由：新增 rootMessageId → chatId 校验，避免跨群复用；校验失败返回 400。
- CLI / backend：仍复用现有 `spawnDashboardSession` / `forkWorker` 流程，会创建新 CLI 进程；未改 CLI adapter 或 PTY/Tmux backend。

## 验证
- `git diff --check`
- `pnpm test -- test/session-create.test.ts test/dashboard-create-session.test.ts`：32 tests passed
- `pnpm build`：passed

## 备注
尚未执行 live daemon 切换验证；如需要飞书端手动验证，再执行 `pnpm switch:here && botmux restart`，注意这会让所有 bot 暂时跑当前 checkout。
