### PR TITLE
fix(schedule): 修复 /schedule 创建任务时未继承 defaultWorkingDir/defaultOncall.workingDir

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -603,30 +603,63 @@ async function handleRoleCommand(
  *      defaultOncall.workingDir when Oncall 模式 is on)
  *   4) legacy bot.config.workingDir
  *   5) '~'
+ *
+ * Deliberate deltas vs `resolvePinnedWorkingDir` (do NOT "sync" them away):
+ *   - no sibling-inherit layer (findInheritablePeer) — a schedule needs a
+ *     deterministic dir at create time, not whatever peer session happens to
+ *     be open at that moment;
+ *   - extra layers 4/5 — a schedule has no interactive repo-select card to
+ *     fall back on, so it must always resolve to something;
+ *   - layers 2–4 validate the candidate dir and fall through when it is
+ *     stale (deleted/renamed): a dead path would otherwise be baked into
+ *     schedules.json (workingDir is not editable afterwards) and every fire
+ *     would silently spawn in $HOME.
  */
 function resolveScheduleWorkingDir(
   ds: DaemonSession | undefined,
   chatId: string,
   larkAppId: string | undefined,
 ): string {
-  // Layer 1: existing session dir already pinned.
+  // Layer 1: existing session dir already pinned. Trusted as-is — it is the
+  // dir the live session actually runs in (the spawn path never re-validates
+  // a pinned dir either).
   if (ds?.workingDir) return ds.workingDir;
 
   const appId = ds?.larkAppId ?? larkAppId;
-  const bot = appId ? getBot(appId) : getAllBots()[0];
+  // getBot() throws for unregistered ids — degrade to the '~' fallback
+  // instead of aborting the whole /schedule command.
+  let bot: ReturnType<typeof getBot> | undefined;
+  try {
+    bot = appId ? getBot(appId) : getAllBots()[0];
+  } catch {
+    bot = undefined;
+  }
   if (!bot) return '~';
+
+  // Candidates below are stored config paths that can go stale. Validate and
+  // fall through (returning the RAW form — keep `~`; expansion happens at
+  // fire time via getSessionWorkingDir), matching the other copies of this
+  // ladder (daemon resolveBotDefaultWorkingDir, trigger-session).
+  const usable = (dir: string, layer: string): boolean => {
+    const v = validateWorkingDir(dir);
+    if (v.ok) return true;
+    logger.warn(`[schedule] ${layer} workingDir "${dir}" invalid — falling through: ${v.error}`);
+    return false;
+  };
 
   // Layer 2: oncall binding for this chat (read-only — does NOT auto-bind).
   const oncallEntry = findOncallChat(bot.config.larkAppId, ds?.chatId ?? chatId);
-  if (oncallEntry?.workingDir) return oncallEntry.workingDir;
+  if (oncallEntry?.workingDir && usable(oncallEntry.workingDir, 'oncall-binding')) {
+    return oncallEntry.workingDir;
+  }
 
   // Layer 3: effective default working dir (defaultWorkingDir or
   // defaultOncall.workingDir). Read-only — never writes state.
   const effectiveDefault = effectiveDefaultWorkingDir(bot.config);
-  if (effectiveDefault) return effectiveDefault;
+  if (effectiveDefault && usable(effectiveDefault, 'effective-default')) return effectiveDefault;
 
   // Layer 4: legacy workingDir field.
-  if (bot.config.workingDir) return bot.config.workingDir;
+  if (bot.config.workingDir && usable(bot.config.workingDir, 'legacy')) return bot.config.workingDir;
 
   // Layer 5: home fallback.
   return '~';

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -610,20 +610,31 @@ async function handleRoleCommand(
  *     be open at that moment;
  *   - extra layers 4/5 — a schedule has no interactive repo-select card to
  *     fall back on, so it must always resolve to something;
- *   - layers 2–4 validate the candidate dir and fall through when it is
+ *   - every layer validates the candidate dir and falls through when it is
  *     stale (deleted/renamed): a dead path would otherwise be baked into
  *     schedules.json (workingDir is not editable afterwards) and every fire
- *     would silently spawn in $HOME.
+ *     would silently spawn in $HOME. This includes layer 1 — a ds restored
+ *     by restoreActiveSessions (worker:null) or idle-suspended keeps a
+ *     workingDir no live process is running in, so it can be stale too.
  */
 function resolveScheduleWorkingDir(
   ds: DaemonSession | undefined,
   chatId: string,
   larkAppId: string | undefined,
 ): string {
-  // Layer 1: existing session dir already pinned. Trusted as-is — it is the
-  // dir the live session actually runs in (the spawn path never re-validates
-  // a pinned dir either).
-  if (ds?.workingDir) return ds.workingDir;
+  // Validate candidates and fall through (returning the RAW form — keep `~`;
+  // expansion happens at fire time via getSessionWorkingDir), matching the
+  // other copies of this ladder (daemon resolveBotDefaultWorkingDir,
+  // trigger-session).
+  const usable = (dir: string, layer: string): boolean => {
+    const v = validateWorkingDir(dir);
+    if (v.ok) return true;
+    logger.warn(`[schedule] ${layer} workingDir "${dir}" invalid — falling through: ${v.error}`);
+    return false;
+  };
+
+  // Layer 1: existing session dir already pinned.
+  if (ds?.workingDir && usable(ds.workingDir, 'session')) return ds.workingDir;
 
   const appId = ds?.larkAppId ?? larkAppId;
   // getBot() throws for unregistered ids — degrade to the '~' fallback
@@ -635,17 +646,6 @@ function resolveScheduleWorkingDir(
     bot = undefined;
   }
   if (!bot) return '~';
-
-  // Candidates below are stored config paths that can go stale. Validate and
-  // fall through (returning the RAW form — keep `~`; expansion happens at
-  // fire time via getSessionWorkingDir), matching the other copies of this
-  // ladder (daemon resolveBotDefaultWorkingDir, trigger-session).
-  const usable = (dir: string, layer: string): boolean => {
-    const v = validateWorkingDir(dir);
-    if (v.ok) return true;
-    logger.warn(`[schedule] ${layer} workingDir "${dir}" invalid — falling through: ${v.error}`);
-    return false;
-  };
 
   // Layer 2: oncall binding for this chat (read-only — does NOT auto-bind).
   const oncallEntry = findOncallChat(bot.config.larkAppId, ds?.chatId ?? chatId);

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -6,7 +6,7 @@ import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { join, resolve, basename } from 'node:path';
 import { config } from '../config.js';
 import { buildTerminalUrl } from './terminal-url.js';
-import { getBot, getAllBots, getBotOpenId, getOwnerOpenId } from '../bot-registry.js';
+import { getBot, getAllBots, getBotOpenId, getOwnerOpenId, findOncallChat, effectiveDefaultWorkingDir } from '../bot-registry.js';
 import { repoPickerScanOptions } from '../global-config.js';
 import * as sessionStore from '../services/session-store.js';
 import * as scheduleStore from '../services/schedule-store.js';
@@ -588,6 +588,50 @@ async function handleRoleCommand(
   await sessionReply(rootId, t('role.help', undefined, loc));
 }
 
+/**
+ * Resolve the workingDir for a newly created scheduled task, mirroring the
+ * layered lookup used by the normal new-session spawn path (see
+ * `resolvePinnedWorkingDir` in daemon.ts) but STRICTLY read-only: it never
+ * triggers the defaultOncall auto-bind side effect (which writes to bots.json).
+ * Creating a schedule must not mutate oncall binding state.
+ *
+ * Priority:
+ *   1) existing session workingDir (ds.workingDir — already pinned via /cd or
+ *      a previously-applied oncall bind)
+ *   2) this bot/chat oncall binding (read-only findOncallChat, no auto-bind)
+ *   3) this bot's effective default working dir (defaultWorkingDir, or
+ *      defaultOncall.workingDir when Oncall 模式 is on)
+ *   4) legacy bot.config.workingDir
+ *   5) '~'
+ */
+function resolveScheduleWorkingDir(
+  ds: DaemonSession | undefined,
+  chatId: string,
+  larkAppId: string | undefined,
+): string {
+  // Layer 1: existing session dir already pinned.
+  if (ds?.workingDir) return ds.workingDir;
+
+  const appId = ds?.larkAppId ?? larkAppId;
+  const bot = appId ? getBot(appId) : getAllBots()[0];
+  if (!bot) return '~';
+
+  // Layer 2: oncall binding for this chat (read-only — does NOT auto-bind).
+  const oncallEntry = findOncallChat(bot.config.larkAppId, ds?.chatId ?? chatId);
+  if (oncallEntry?.workingDir) return oncallEntry.workingDir;
+
+  // Layer 3: effective default working dir (defaultWorkingDir or
+  // defaultOncall.workingDir). Read-only — never writes state.
+  const effectiveDefault = effectiveDefaultWorkingDir(bot.config);
+  if (effectiveDefault) return effectiveDefault;
+
+  // Layer 4: legacy workingDir field.
+  if (bot.config.workingDir) return bot.config.workingDir;
+
+  // Layer 5: home fallback.
+  return '~';
+}
+
 async function handleScheduleCommand(
   args: string,
   rootId: string,
@@ -677,7 +721,7 @@ async function handleScheduleCommand(
   const parsed = scheduler.parseNaturalSchedule(trimmed);
   if (parsed) {
     const ds = larkAppId ? activeSessions.get(sessionKey(rootId, larkAppId)) : undefined;
-    const workingDir = ds?.workingDir ?? (ds?.larkAppId ? getBot(ds.larkAppId).config.workingDir ?? '~' : getAllBots()[0]?.config.workingDir ?? '~');
+    const workingDir = resolveScheduleWorkingDir(ds, chatId, larkAppId);
     const taskScope: 'thread' | 'chat' = ds?.scope === 'chat' ? 'chat' : 'thread';
     // "新话题" keyword → every fire opens a brand-new topic in a fresh session.
     const { deliver, prompt: schedPrompt } = scheduler.extractDeliveryMode(parsed.prompt);

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -91,6 +91,11 @@ vi.mock('../src/bot-registry.js', () => ({
       workingDirs: ['~/projects'],
     },
   })),
+  findOncallChat: vi.fn(() => undefined),
+  effectiveDefaultWorkingDir: vi.fn((cfg: any) =>
+    cfg?.defaultWorkingDir
+    || (cfg?.defaultOncall?.enabled ? cfg?.defaultOncall?.workingDir : undefined)
+    || undefined),
   readBotSkillPolicy: vi.fn((raw: unknown) => {
     if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
     const r = raw as Record<string, unknown>;
@@ -147,6 +152,7 @@ vi.mock('../src/core/scheduler.js', () => ({
   parseSchedule: vi.fn(),
   getNextRun: vi.fn(),
   addTask: vi.fn(),
+  extractDeliveryMode: vi.fn((prompt: string) => ({ deliver: 'origin' as const, prompt })),
 }));
 
 vi.mock('../src/services/project-scanner.js', () => ({
@@ -415,7 +421,7 @@ import * as scheduler from '../src/core/scheduler.js';
 import { deleteMessage, sendMessage, listChatBotMembers } from '../src/im/lark/client.js';
 import { buildSlashListCard, buildSessionClosedCard } from '../src/im/lark/card-builder.js';
 import { createGroupWithBots } from '../src/services/group-creator.js';
-import { getAllBots, getBot } from '../src/bot-registry.js';
+import { getAllBots, getBot, findOncallChat, effectiveDefaultWorkingDir } from '../src/bot-registry.js';
 import { generateAuthUrl, getTokenStatus, resolveUserToken, DOC_COMMENT_OAUTH_SCOPES } from '../src/utils/user-token.js';
 import { resolveDocFile, subscribeDocFile, unsubscribeDocFile } from '../src/im/lark/doc-comment.js';
 import { putDocSubscription, removeDocSubscription, listAllDocSubscriptions, getDocSubscription } from '../src/services/doc-subs-store.js';
@@ -2026,6 +2032,154 @@ describe('handleCommand', () => {
 
       const replyContent = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
       expect(replyContent).toContain('无法解析定时任务');
+    });
+
+    it('should inherit defaultWorkingDir (not legacy workingDir) when creating a schedule', async () => {
+      // Bot only configures defaultWorkingDir; legacy workingDir is unset.
+      // The schedule task must pick up defaultWorkingDir, NOT fall back to ~.
+      vi.mocked(getBot).mockImplementation(((id: string = 'app-1') => ({
+        botName: 'Claude',
+        config: {
+          larkAppId: id,
+          larkAppSecret: 'secret-1',
+          cliId: 'claude-code' as const,
+          defaultWorkingDir: '~/repo/oncall',
+          // Intentionally NO workingDir field
+        },
+      })) as any);
+      vi.mocked(findOncallChat).mockReturnValue(undefined);
+      vi.mocked(scheduler.parseNaturalSchedule).mockReturnValue({
+        parsed: { kind: 'cron', expr: '10 10 * * *', display: '每日 10:10' },
+        prompt: '新话题 生成值班日报',
+        name: '新话题 生成值班日报',
+      });
+      vi.mocked(scheduler.extractDeliveryMode).mockReturnValue({
+        deliver: 'new-topic',
+        prompt: '生成值班日报',
+      });
+      vi.mocked(scheduler.addTask).mockReturnValue({ id: 'task-new' } as any);
+      vi.mocked(scheduler.getNextRun).mockReturnValue(new Date('2026-03-27T10:10:00+08:00'));
+
+      const ds = makeDaemonSession({ workingDir: undefined });
+      const deps = makeDeps(ds);
+
+      await handleCommand('/schedule', ROOT_ID, makeLarkMessage('/schedule 每个工作日10:10 新话题 生成值班日报'), deps, LARK_APP_ID);
+
+      expect(scheduler.addTask).toHaveBeenCalledTimes(1);
+      const callArgs = (scheduler.addTask as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      // workingDir must be the bot's defaultWorkingDir, NOT ~
+      expect(callArgs.workingDir).toBe('~/repo/oncall');
+      expect(callArgs.workingDir).not.toBe('~');
+    });
+
+    it('should inherit defaultOncall.workingDir when Oncall mode is enabled', async () => {
+      // Bot configures defaultOncall.workingDir with enabled=true; no
+      // defaultWorkingDir, no legacy workingDir. Schedule must pick it up.
+      vi.mocked(getBot).mockImplementation(((id: string = 'app-1') => ({
+        botName: 'Claude',
+        config: {
+          larkAppId: id,
+          larkAppSecret: 'secret-1',
+          cliId: 'claude-code' as const,
+          defaultOncall: { enabled: true, workingDir: '~/codebase/dcar_bpm/roles/oncall' },
+        },
+      })) as any);
+      vi.mocked(findOncallChat).mockReturnValue(undefined);
+      vi.mocked(scheduler.parseNaturalSchedule).mockReturnValue({
+        parsed: { kind: 'cron', expr: '10 10 * * *', display: '每日 10:10' },
+        prompt: '新话题 生成值班日报',
+        name: '新话题 生成值班日报',
+      });
+      vi.mocked(scheduler.extractDeliveryMode).mockReturnValue({
+        deliver: 'new-topic',
+        prompt: '生成值班日报',
+      });
+      vi.mocked(scheduler.addTask).mockReturnValue({ id: 'task-oncall' } as any);
+      vi.mocked(scheduler.getNextRun).mockReturnValue(new Date('2026-03-27T10:10:00+08:00'));
+
+      const ds = makeDaemonSession({ workingDir: undefined });
+      const deps = makeDeps(ds);
+
+      await handleCommand('/schedule', ROOT_ID, makeLarkMessage('/schedule 每个工作日10:10 新话题 生成值班日报'), deps, LARK_APP_ID);
+
+      const callArgs = (scheduler.addTask as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(callArgs.workingDir).toBe('~/codebase/dcar_bpm/roles/oncall');
+      expect(callArgs.workingDir).not.toBe('~');
+    });
+
+    it('should prefer ds.workingDir over bot defaults when creating a schedule', async () => {
+      // Session already has a pinned workingDir (e.g. via /cd); it must win
+      // over the bot's defaultWorkingDir.
+      vi.mocked(getBot).mockImplementation(((id: string = 'app-1') => ({
+        botName: 'Claude',
+        config: {
+          larkAppId: id,
+          larkAppSecret: 'secret-1',
+          cliId: 'claude-code' as const,
+          defaultWorkingDir: '~/repo/oncall',
+        },
+      })) as any);
+      vi.mocked(findOncallChat).mockReturnValue(undefined);
+      vi.mocked(scheduler.parseNaturalSchedule).mockReturnValue({
+        parsed: { kind: 'cron', expr: '0 10 * * *', display: '每日 10:00' },
+        prompt: '生成日报',
+        name: '生成日报',
+      });
+      vi.mocked(scheduler.extractDeliveryMode).mockReturnValue({
+        deliver: 'origin',
+        prompt: '生成日报',
+      });
+      vi.mocked(scheduler.addTask).mockReturnValue({ id: 'task-ds' } as any);
+      vi.mocked(scheduler.getNextRun).mockReturnValue(new Date('2026-03-27T10:00:00+08:00'));
+
+      const ds = makeDaemonSession({ workingDir: '/home/user/custom-dir' });
+      const deps = makeDeps(ds);
+
+      await handleCommand('/schedule', ROOT_ID, makeLarkMessage('/schedule 每日10:00 生成日报'), deps, LARK_APP_ID);
+
+      const callArgs = (scheduler.addTask as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(callArgs.workingDir).toBe('/home/user/custom-dir');
+    });
+
+    it('should read oncall binding (read-only) without triggering auto-bind side effect', async () => {
+      // An oncall binding exists for this chat — it must be used as the
+      // workingDir. We verify findOncallChat is consulted (read-only) and
+      // the bot's defaultWorkingDir is NOT consulted.
+      vi.mocked(getBot).mockImplementation(((id: string = 'app-1') => ({
+        botName: 'Claude',
+        config: {
+          larkAppId: id,
+          larkAppSecret: 'secret-1',
+          cliId: 'claude-code' as const,
+          defaultWorkingDir: '~/repo/oncall',
+        },
+      })) as any);
+      vi.mocked(findOncallChat).mockReturnValue({
+        chatId: CHAT_ID,
+        workingDir: '~/oncall/bound-dir',
+      });
+      vi.mocked(scheduler.parseNaturalSchedule).mockReturnValue({
+        parsed: { kind: 'cron', expr: '0 10 * * *', display: '每日 10:00' },
+        prompt: '生成日报',
+        name: '生成日报',
+      });
+      vi.mocked(scheduler.extractDeliveryMode).mockReturnValue({
+        deliver: 'origin',
+        prompt: '生成日报',
+      });
+      vi.mocked(scheduler.addTask).mockReturnValue({ id: 'task-oncall-bind' } as any);
+      vi.mocked(scheduler.getNextRun).mockReturnValue(new Date('2026-03-27T10:00:00+08:00'));
+
+      const ds = makeDaemonSession({ workingDir: undefined });
+      const deps = makeDeps(ds);
+
+      await handleCommand('/schedule', ROOT_ID, makeLarkMessage('/schedule 每日10:00 生成日报'), deps, LARK_APP_ID);
+
+      const callArgs = (scheduler.addTask as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      // Oncall binding wins over bot defaults.
+      expect(callArgs.workingDir).toBe('~/oncall/bound-dir');
+      // findOncallChat must be called with the bot's appId and the chatId.
+      expect(findOncallChat).toHaveBeenCalledWith('app-1', CHAT_ID);
     });
   });
 

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -910,6 +910,11 @@ describe('handleCommand', () => {
     vi.mocked(findOncallChat).mockReturnValue(undefined);
     vi.mocked(scheduler.parseNaturalSchedule).mockReturnValue(null);
     vi.mocked(scheduler.extractDeliveryMode).mockImplementation((prompt: string) => ({ deliver: 'origin' as const, prompt }));
+    // Shared fs mocks: other describes set existsSync=false / throwing statSync
+    // without always restoring, and the schedule workingDir validation depends
+    // on them — pin the factory defaults so tests pass in any order (shuffle).
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(statSync).mockReturnValue({ isDirectory: () => true } as any);
   });
 
   describe('doc comment commands', () => {
@@ -2224,6 +2229,43 @@ describe('handleCommand', () => {
 
       const callArgs = (scheduler.addTask as ReturnType<typeof vi.fn>).mock.calls[0][0];
       expect(callArgs.workingDir).toBe('~/live-dir');
+    });
+
+    it('should fall through when the pinned session workingDir is stale', async () => {
+      // ds.workingDir can be stale too: restoreActiveSessions re-registers
+      // persisted sessions (worker:null) and idle suspend keeps ds around —
+      // no live process guarantees the dir still exists. A stale pinned dir
+      // must fall through to the bot's (valid) defaultWorkingDir.
+      vi.mocked(getBot).mockImplementation(((id: string = 'app-1') => ({
+        botName: 'Claude',
+        config: {
+          larkAppId: id,
+          larkAppSecret: 'secret-1',
+          cliId: 'claude-code' as const,
+          defaultWorkingDir: '~/repo/oncall',
+        },
+      })) as any);
+      vi.mocked(existsSync).mockImplementation((p: any) => !String(p).includes('gone-dir'));
+      vi.mocked(scheduler.parseNaturalSchedule).mockReturnValue({
+        parsed: { kind: 'cron', expr: '0 10 * * *', display: '每日 10:00' },
+        prompt: '生成日报',
+        name: '生成日报',
+      });
+      vi.mocked(scheduler.addTask).mockReturnValue({ id: 'task-stale-ds' } as any);
+      vi.mocked(scheduler.getNextRun).mockReturnValue(new Date('2026-03-27T10:00:00+08:00'));
+
+      const ds = makeDaemonSession({ workingDir: '~/gone-dir' });
+      const deps = makeDeps(ds);
+
+      try {
+        await handleCommand('/schedule', ROOT_ID, makeLarkMessage('/schedule 每日10:00 生成日报'), deps, LARK_APP_ID);
+      } finally {
+        // restore the shared existsSync mock for subsequent tests
+        vi.mocked(existsSync).mockReturnValue(true);
+      }
+
+      const callArgs = (scheduler.addTask as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(callArgs.workingDir).toBe('~/repo/oncall');
     });
   });
 

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -901,9 +901,15 @@ describe('handleCommand', () => {
     vi.mocked(resolveDocFile).mockResolvedValue({ fileToken: 'doc_token_12345678901234567890', fileType: 'docx' });
     vi.mocked(getDocSubscription).mockReturnValue(null);
     vi.mocked(putDocSubscription).mockReturnValue({});
-    // clearAllMocks wipes the factory default — restore legacy (include
-    // worktrees) so /repo scan tests aren't passed `undefined` options.
+    // NOTE: vi.clearAllMocks() only clears call history — it does NOT undo
+    // mockReturnValue/mockImplementation overrides set inside individual
+    // tests (verified on vitest 4; resetAllMocks is what restores factory
+    // impls). Every mock that tests override must therefore be restored to
+    // its default here, or the last override leaks into subsequent tests.
     vi.mocked(repoPickerScanOptions).mockReturnValue({ includeWorktrees: true });
+    vi.mocked(findOncallChat).mockReturnValue(undefined);
+    vi.mocked(scheduler.parseNaturalSchedule).mockReturnValue(null);
+    vi.mocked(scheduler.extractDeliveryMode).mockImplementation((prompt: string) => ({ deliver: 'origin' as const, prompt }));
   });
 
   describe('doc comment commands', () => {
@@ -2180,6 +2186,44 @@ describe('handleCommand', () => {
       expect(callArgs.workingDir).toBe('~/oncall/bound-dir');
       // findOncallChat must be called with the bot's appId and the chatId.
       expect(findOncallChat).toHaveBeenCalledWith('app-1', CHAT_ID);
+    });
+
+    it('should fall through when defaultWorkingDir points at a missing directory', async () => {
+      // defaultWorkingDir is configured but the dir no longer exists on disk.
+      // The stale path must NOT be baked into the task (schedules.json is not
+      // editable afterwards) — resolution falls through to the legacy
+      // workingDir, which does exist.
+      vi.mocked(getBot).mockImplementation(((id: string = 'app-1') => ({
+        botName: 'Claude',
+        config: {
+          larkAppId: id,
+          larkAppSecret: 'secret-1',
+          cliId: 'claude-code' as const,
+          defaultWorkingDir: '~/gone-dir',
+          workingDir: '~/live-dir',
+        },
+      })) as any);
+      vi.mocked(existsSync).mockImplementation((p: any) => !String(p).includes('gone-dir'));
+      vi.mocked(scheduler.parseNaturalSchedule).mockReturnValue({
+        parsed: { kind: 'cron', expr: '0 10 * * *', display: '每日 10:00' },
+        prompt: '生成日报',
+        name: '生成日报',
+      });
+      vi.mocked(scheduler.addTask).mockReturnValue({ id: 'task-stale' } as any);
+      vi.mocked(scheduler.getNextRun).mockReturnValue(new Date('2026-03-27T10:00:00+08:00'));
+
+      const ds = makeDaemonSession({ workingDir: undefined });
+      const deps = makeDeps(ds);
+
+      try {
+        await handleCommand('/schedule', ROOT_ID, makeLarkMessage('/schedule 每日10:00 生成日报'), deps, LARK_APP_ID);
+      } finally {
+        // restore the shared existsSync mock for subsequent tests
+        vi.mocked(existsSync).mockReturnValue(true);
+      }
+
+      const callArgs = (scheduler.addTask as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(callArgs.workingDir).toBe('~/live-dir');
     });
   });
 


### PR DESCRIPTION
## 改了什么

修复飞书 `/schedule` 创建定时任务时，workingDir 没有继承 bot 的 `defaultWorkingDir` / `defaultOncall.workingDir`，错误 fallback 到 `~` 的缺陷。

## 为什么

普通新话题会话在 `daemon.ts` 走 `resolvePinnedWorkingDir()`，支持 oncall binding / defaultOncall / `effectiveDefaultWorkingDir()` / sibling inherit。但 `/schedule` 创建分支在 `handleScheduleCommand()` 中只读旧字段 `config.workingDir`，导致：

- bot 配了 `defaultWorkingDir = ~/codebase/dcar_bpm/roles/oncall`
- 普通新话题能正确进入该目录
- 但 `/schedule` 创建的 task `workingDir` 被保存成 `~`，后续执行在 `/home/<user>` 启动 agent

定时执行在 `executeScheduledTask()` 里直接用 `task.workingDir` 设置新 session 的 workingDir，所以创建时保存错会影响真实执行目录。

## 影响面

- **模块**：`src/core/command-handler.ts`（`handleScheduleCommand` 创建路径）
- **会话类型**：仅影响 `/schedule` 创建的定时任务的 workingDir 解析；普通新话题会话路径不变；`executeScheduledTask()` 执行路径不变（创建时存对即可）
- **跨 CLI**：不涉及 CLI 适配器共用基类，仅 workingDir 解析逻辑
- **跨后端**：不涉及 PtyBackend/TmuxBackend

## 修复方案

新增 `resolveScheduleWorkingDir()` 只读辅助函数，复刻普通会话 `resolvePinnedWorkingDir` 的分层查找，但**严格只读**——不触发 defaultOncall auto-bind 写 bots.json 的副作用（创建 schedule 不应意外改变 oncall 绑定状态）。

优先级：
1. `ds.workingDir`（会话已钉目录，如 /cd 或已应用的 oncall bind）
2. oncall binding（只读 `findOncallChat`，不自动绑定）
3. `effectiveDefaultWorkingDir`（defaultWorkingDir 或 defaultOncall.workingDir）
4. 旧字段 `bot.config.workingDir`
5. `~`

## 测试验证

- `pnpm build` ✅
- `npx vitest run test/command-handler.test.ts` — 168 tests passed（含 4 个新增回归测试）
- `npx vitest run test/schedule-store.test.ts test/schedule-store-idempotency.test.ts test/scheduler-toggle-delivery.test.ts` — 221 tests passed
- 新增 4 个回归测试：
  - bot 只配 defaultWorkingDir 时，schedule task 的 workingDir = defaultWorkingDir（不是 ~）
  - bot 配 defaultOncall.workingDir（Oncall 模式开启）时，正确继承
  - ds.workingDir 优先于 bot 默认目录
  - oncall binding 只读解析、不触发 auto-bind 副作用

> 注：`test/scheduler.test.ts` 有 2 个预存时区相关失败，已在原 master 代码上确认同样失败，与本次改动无关。