### PR TITLE
feat(setup): 建 bot 首选「一键智能体」模板接口——出生即带默认事件/回调/长连接

### DIFF
--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -6,6 +6,7 @@
  * create and publish a version. The official SDK registerApp device flow stays
  * available as a fallback (notably for Lark international tenants).
  */
+import { randomUUID } from 'node:crypto';
 import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import { basename, join, dirname } from 'node:path';
 import { homedir } from 'node:os';
@@ -1114,11 +1115,41 @@ function pickPayloadString(payload: unknown, keys: string[]): string | undefined
   return pickString(record, keys) ?? pickString(asRecord(record.data), keys);
 }
 
+/** 「一键创建智能体」(backend_oneclick launcher) 使用的应用清单模板 ID。 */
+export const ONECLICK_APP_MANIFEST_TEMPLATE_ID = 'developer_console';
+
+/**
+ * Build the payload for `POST /developers/v1/manifest/upsert_by_template` —
+ * the console launcher's one-click agent creation endpoint (CDP 抓包确认)。
+ * 该模板建出的应用开箱自带 bot 能力、长连接事件/回调模式、基础事件订阅与
+ * card.action.trigger 回调,正是「正常申请默认带的权限」。
+ */
+export function buildManifestTemplateCreatePayload(
+  name: string,
+  description: string,
+  avatar: string,
+  cid: string,
+) {
+  return {
+    appManifestTemplateID: ONECLICK_APP_MANIFEST_TEMPLATE_ID,
+    createAppUserCustomField: {
+      i18n: { zh_cn: { name, description } },
+      avatar,
+      primaryLang: 'zh_cn',
+    },
+    cid,
+    HTTPHead: {},
+  };
+}
+
 /**
  * 用已经登录的开放平台 Web session 创建一个企业自建应用并读取凭证。
  *
- * 当前 console 前端（2026-07）同款链路：上传 512px botmux 图标 → app/create
- * → 只读 secret 接口。所有 Secret 只存在返回值中，不打印、不写日志。
+ * 首选 console launcher 的「一键创建智能体」模板接口
+ * (manifest/upsert_by_template):模板应用出生即带 bot 能力、长连接、基础
+ * 事件与卡片回调,新建 bot 不再依赖后续订阅补齐。模板 ID 属内部契约,失败
+ * 时自动回退旧 app/create(裸自建应用,事件/回调由 automateOpenPlatformSetup
+ * 增量补齐并 fail-closed 兜底)。所有 Secret 只存在返回值中,不打印、不写日志。
  */
 export async function createOpenPlatformAppWithClient(
   client: OpenPlatformApiClient,
@@ -1140,20 +1171,32 @@ export async function createOpenPlatformAppWithClient(
   if (!avatar) throw new Error('开放平台上传图标后没有返回 url');
 
   const description = options.description?.trim() || 'AI coding assistant powered by botmux';
-  const created = await client.postJson('/developers/v1/app/create', {
-    appSceneType: 0, // SelfBuild
-    name,
-    desc: description,
-    avatar,
-    i18n: { zh_cn: { name, description } },
-    primaryLang: 'zh_cn',
-  });
-  const appId = pickPayloadString(created, ['ClientID', 'clientID', 'clientId', 'appId']);
+  let appId: string | undefined;
+  try {
+    const created = await client.postJson(
+      '/developers/v1/manifest/upsert_by_template',
+      buildManifestTemplateCreatePayload(name, description, avatar, randomUUID()),
+    );
+    appId = pickPayloadString(created, ['ClientID', 'clientID', 'clientId', 'appId']);
+  } catch (err) {
+    console.warn(`一键智能体模板创建失败,回退普通自建应用: ${safeErrorMessage(err)}`);
+  }
+  if (!appId?.startsWith('cli_')) {
+    const created = await client.postJson('/developers/v1/app/create', {
+      appSceneType: 0, // SelfBuild
+      name,
+      desc: description,
+      avatar,
+      i18n: { zh_cn: { name, description } },
+      primaryLang: 'zh_cn',
+    });
+    appId = pickPayloadString(created, ['ClientID', 'clientID', 'clientId', 'appId']);
+  }
   if (!appId?.startsWith('cli_')) throw new Error('开放平台创建应用后没有返回 ClientID');
 
   try {
-    // 普通企业自建应用不像 SDK PersonalAgent 那样默认带 bot + 长连接事件能力。
-    // 这两步是“一扫即用”的必要条件，必须在返回凭证前完成。
+    // 模板应用出生已带 bot + 长连接(重复调用幂等);fallback 的裸自建应用
+    // 则必须显式开启——这两步是「一扫即用」的必要条件,在返回凭证前完成。
     await client.postJson(`/developers/v1/robot/switch/${appId}`, { clientId: appId, enable: true });
     await client.postJson(`/developers/v1/event/switch/${appId}`, { clientId: appId, eventMode: 4 }); // WebSocket
     const appSecret = await fetchOpenPlatformAppSecret(client, appId);

--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -471,34 +471,25 @@ function extractEventIdsFromDetails(value: unknown): string[] {
   return uniqueStrings(value.flatMap(group => extractEventIds(asRecord(group).items)));
 }
 
+/**
+ * 应用版本创建 payload,与 console launcher「一键创建智能体」同款极简结构
+ * (CDP 抓包确认)。⚠️不要重新加回 applyReasonConfig / isAutoAudit:false ——
+ * 那会让版本进入人工审核、发布后应用停在「未上架/未启用」(tenantAppStatus=0),
+ * 事件配置进了草稿也无法在企业内生效。visibleSuggest.members 必须含创建者,
+ * 否则同样不会自动上架启用。
+ */
 export function buildAppVersionCreatePayload(appVersion: string, visibleMemberIds: string[] = []) {
   return {
     appVersion,
     mobileDefaultAbility: 'bot',
     pcDefaultAbility: 'bot',
-    changeLog: 'Init version',
+    changeLog: 'Initial bot release.',
     visibleSuggest: {
       departments: [],
       members: visibleMemberIds,
       groups: [],
       isAll: 0,
     },
-    applyReasonConfig: {
-      apiPrivilegeNeedReason: true,
-      contactPrivilegeNeedReason: true,
-      dataPrivilegeReasonMap: {},
-      visibleScopeNeedReason: true,
-      apiPrivilegeReasonMap: {},
-      contactPrivilegeReason: '',
-      isDataPrivilegeExpandMap: {},
-      visibleScopeReason: '',
-      dataPrivilegeNeedReason: true,
-      isAutoAudit: false,
-      isContactExpand: false,
-    },
-    b2cShareSuggest: false,
-    autoPublish: false,
-    remark: 'Personal AI assistant for self use',
     blackVisibleSuggest: {
       departments: [],
       members: [],
@@ -625,16 +616,21 @@ export async function automateOpenPlatformSetup(
   let csrfToken: string | null = null;
   let apiOrigin = defaultOrigin;
   let appHome = defaultAppHome;
+  // 创建者 userId——版本可见范围要把创建者填进 visibleSuggest.members,否则
+  // 应用发布后不会自动上架启用(tenantAppStatus 停在 0),bot 在企业内不可用。
+  let sessionUserId: string | undefined;
   try {
     const authPage = await session.fetchTextWithUrl(fetcher, `${defaultAppHome}/auth`);
     apiOrigin = new URL(authPage.finalUrl).origin;
     appHome = `${apiOrigin}/app/${options.appId}`;
     csrfToken = extractOpenPlatformCsrfToken(authPage.text);
+    sessionUserId = extractOpenPlatformSessionIdentity(authPage.text)?.userId;
     if (!csrfToken) {
       const homePage = await session.fetchTextWithUrl(fetcher, appHome);
       apiOrigin = new URL(homePage.finalUrl).origin;
       appHome = `${apiOrigin}/app/${options.appId}`;
       csrfToken = extractOpenPlatformCsrfToken(homePage.text);
+      sessionUserId ??= extractOpenPlatformSessionIdentity(homePage.text)?.userId;
     }
   } catch (err: any) {
     return { ok: false, reason: 'network', message: `读取开放平台页面失败: ${safeErrorMessage(err)}`, sessionFile };
@@ -862,7 +858,12 @@ export async function automateOpenPlatformSetup(
   try {
     await postJson(`/developers/v1/safe_setting/update/${options.appId}`, buildSafeSettingPayload(options.appId));
     const contactRange = await postJson(`/developers/v1/contact_range/${options.appId}`, {});
-    const visibleMemberIds = extractContactRangeMemberIds(contactRange);
+    // 可见范围必须包含创建者(launcher 同款):否则版本发布后不会自动上架启用。
+    // contact_range 的成员为辅,创建者 userId 兜底,去重。
+    const visibleMemberIds = uniqueStrings([
+      ...(sessionUserId ? [sessionUserId] : []),
+      ...extractContactRangeMemberIds(contactRange),
+    ]);
     const versionList = await postJson(`/developers/v1/app_version/list/${options.appId}`, {});
     const appVersion = nextAppVersion(versionList);
     const created = await postJson(`/developers/v1/app_version/create/${options.appId}`, buildAppVersionCreatePayload(appVersion, visibleMemberIds));
@@ -1169,7 +1170,7 @@ function isDefiniteTemplateRejection(err: unknown): boolean {
  */
 export async function createOpenPlatformAppWithClient(
   client: OpenPlatformApiClient,
-  options: { name: string; description?: string; iconFilePath?: string },
+  options: { name: string; description?: string; iconFilePath?: string; creatorUserId?: string },
 ): Promise<{ appId: string; appSecret: string }> {
   const name = options.name.trim();
   if (!name) throw new Error('应用名称不能为空');
@@ -1223,6 +1224,25 @@ export async function createOpenPlatformAppWithClient(
     // 则必须显式开启——这两步是「一扫即用」的必要条件,在返回凭证前完成。
     await client.postJson(`/developers/v1/robot/switch/${appId}`, { clientId: appId, enable: true });
     await client.postJson(`/developers/v1/event/switch/${appId}`, { clientId: appId, eventMode: 4 }); // WebSocket
+
+    // 复刻 console launcher「一键创建智能体」的最后一步:立刻用极简版本发布一次,
+    // 让应用**上架启用**(tenantAppStatus 0→2)。这样返回的就是一个「已启用、可
+    // 收发消息」的应用——等价于旧 SDK registerApp 直接产出可用 PersonalAgent 的效果。
+    // 缺这一步,后续 automateOpenPlatformSetup 的改动+发版都无法让裸应用自动上架。
+    // 失败不致命:automateOpenPlatformSetup 结尾仍会再发一次版本兜底。
+    try {
+      const created = await client.postJson(
+        `/developers/v1/app_version/create/${appId}`,
+        buildAppVersionCreatePayload('1.0.0', options.creatorUserId ? [options.creatorUserId] : []),
+      );
+      const versionId = extractVersionId(created);
+      if (versionId) {
+        await client.postJson(`/developers/v1/publish/commit/${appId}/${versionId}`, { clientId: appId });
+      }
+    } catch (err) {
+      console.warn(`模板应用初次发布启用失败(automateOpenPlatformSetup 会再兜底): ${safeErrorMessage(err)}`);
+    }
+
     const appSecret = await fetchOpenPlatformAppSecret(client, appId);
     return { appId, appSecret };
   } catch (err) {
@@ -1277,7 +1297,10 @@ export async function createFeishuOpenPlatformApp(
 
   try {
     await options.onSessionReady?.({ source: prepared.source, identity: clientResult.identity });
-    const credentials = await createOpenPlatformAppWithClient(clientResult.client, options);
+    const credentials = await createOpenPlatformAppWithClient(clientResult.client, {
+      ...options,
+      creatorUserId: clientResult.identity.userId,
+    });
     return {
       ok: true,
       ...credentials,

--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -616,21 +616,16 @@ export async function automateOpenPlatformSetup(
   let csrfToken: string | null = null;
   let apiOrigin = defaultOrigin;
   let appHome = defaultAppHome;
-  // 创建者 userId——版本可见范围要把创建者填进 visibleSuggest.members,否则
-  // 应用发布后不会自动上架启用(tenantAppStatus 停在 0),bot 在企业内不可用。
-  let sessionUserId: string | undefined;
   try {
     const authPage = await session.fetchTextWithUrl(fetcher, `${defaultAppHome}/auth`);
     apiOrigin = new URL(authPage.finalUrl).origin;
     appHome = `${apiOrigin}/app/${options.appId}`;
     csrfToken = extractOpenPlatformCsrfToken(authPage.text);
-    sessionUserId = extractOpenPlatformSessionIdentity(authPage.text)?.userId;
     if (!csrfToken) {
       const homePage = await session.fetchTextWithUrl(fetcher, appHome);
       apiOrigin = new URL(homePage.finalUrl).origin;
       appHome = `${apiOrigin}/app/${options.appId}`;
       csrfToken = extractOpenPlatformCsrfToken(homePage.text);
-      sessionUserId ??= extractOpenPlatformSessionIdentity(homePage.text)?.userId;
     }
   } catch (err: any) {
     return { ok: false, reason: 'network', message: `读取开放平台页面失败: ${safeErrorMessage(err)}`, sessionFile };
@@ -858,12 +853,12 @@ export async function automateOpenPlatformSetup(
   try {
     await postJson(`/developers/v1/safe_setting/update/${options.appId}`, buildSafeSettingPayload(options.appId));
     const contactRange = await postJson(`/developers/v1/contact_range/${options.appId}`, {});
-    // 可见范围必须包含创建者(launcher 同款):否则版本发布后不会自动上架启用。
-    // contact_range 的成员为辅,创建者 userId 兜底,去重。
-    const visibleMemberIds = uniqueStrings([
-      ...(sessionUserId ? [sessionUserId] : []),
-      ...extractContactRangeMemberIds(contactRange),
-    ]);
+    // 镜像应用原有 contact range 作为版本可见范围——绝不注入「当前 Web session
+    // 操作者」:automateOpenPlatformSetup 也被 VC listener 保存 / 权限自愈 / 选择
+    // 已有应用等路径调用,那里操作者不一定是创建者/现有可见成员,注入会悄悄扩大
+    // 已有 bot 的可见范围。新建应用的「上架启用」由 createOpenPlatformAppWithClient
+    // 的首次发布(含创建者可见)完成,与本处无关。
+    const visibleMemberIds = extractContactRangeMemberIds(contactRange);
     const versionList = await postJson(`/developers/v1/app_version/list/${options.appId}`, {});
     const appVersion = nextAppVersion(versionList);
     const created = await postJson(`/developers/v1/app_version/create/${options.appId}`, buildAppVersionCreatePayload(appVersion, visibleMemberIds));
@@ -1170,10 +1165,14 @@ function isDefiniteTemplateRejection(err: unknown): boolean {
  */
 export async function createOpenPlatformAppWithClient(
   client: OpenPlatformApiClient,
-  options: { name: string; description?: string; iconFilePath?: string; creatorUserId?: string },
+  // creatorUserId 必填:首次「启用发布」的版本可见范围必须含创建者,否则发布后
+  // 应用不会自动上架启用。调用方(createFeishuOpenPlatformApp)已保证 session
+  // identity 可用才会走到这里。
+  options: { name: string; description?: string; iconFilePath?: string; creatorUserId: string },
 ): Promise<{ appId: string; appSecret: string }> {
   const name = options.name.trim();
   if (!name) throw new Error('应用名称不能为空');
+  if (!options.creatorUserId) throw new Error('创建应用缺少创建者 userId,无法完成上架启用');
   const iconFile = options.iconFilePath ?? defaultBotmuxAppIconPath();
   if (!iconFile || !existsSync(iconFile)) throw new Error('找不到 botmux 默认应用图标');
 
@@ -1228,20 +1227,19 @@ export async function createOpenPlatformAppWithClient(
     // 复刻 console launcher「一键创建智能体」的最后一步:立刻用极简版本发布一次,
     // 让应用**上架启用**(tenantAppStatus 0→2)。这样返回的就是一个「已启用、可
     // 收发消息」的应用——等价于旧 SDK registerApp 直接产出可用 PersonalAgent 的效果。
-    // 缺这一步,后续 automateOpenPlatformSetup 的改动+发版都无法让裸应用自动上架。
-    // 失败不致命:automateOpenPlatformSetup 结尾仍会再发一次版本兜底。
-    try {
-      const created = await client.postJson(
-        `/developers/v1/app_version/create/${appId}`,
-        buildAppVersionCreatePayload('1.0.0', options.creatorUserId ? [options.creatorUserId] : []),
-      );
-      const versionId = extractVersionId(created);
-      if (versionId) {
-        await client.postJson(`/developers/v1/publish/commit/${appId}/${versionId}`, { clientId: appId });
-      }
-    } catch (err) {
-      console.warn(`模板应用初次发布启用失败(automateOpenPlatformSetup 会再兜底): ${safeErrorMessage(err)}`);
+    // 这一步 fail-closed:拿到 versionId 后 commit 失败、或 code=0 却没 versionId
+    // (可能留下未发布草稿),都视为创建失败抛出(带 appId,由调用方兜底/提示),
+    // 不宣称「后续 setup 会软兜底」——setup 的 nextAppVersion 不复用未发布草稿,
+    // 版本号可能撞车导致二次发版继续失败,应用永远停在未启用。
+    const versionCreated = await client.postJson(
+      `/developers/v1/app_version/create/${appId}`,
+      buildAppVersionCreatePayload('1.0.0', [options.creatorUserId]),
+    );
+    const enableVersionId = extractVersionId(versionCreated);
+    if (!enableVersionId) {
+      throw new Error('上架启用版本创建返回成功但没有 versionId(可能已留下未发布草稿);请到开放平台确认后重试');
     }
+    await client.postJson(`/developers/v1/publish/commit/${appId}/${enableVersionId}`, { clientId: appId });
 
     const appSecret = await fetchOpenPlatformAppSecret(client, appId);
     return { appId, appSecret };
@@ -1664,17 +1662,22 @@ function mapScopeIds(scopeNames: string[], catalog: OpenPlatformScopeEntry[], bu
 export function nextAppVersion(payload: unknown): string {
   const data = asRecord(asRecord(payload).data);
   const versions = Array.isArray(data.versions) ? data.versions : [];
-  const published = versions
-    .map(item => asRecord(item))
-    .filter(item => item.versionStatus === 2)
-    .map(item => pickString(item, ['appVersion']))
-    .filter((version): version is string => Boolean(version));
-  if (published.length === 0) return '0.0.1';
-  const latest = published[0];
-  const parts = latest.split('.').map(part => Number.parseInt(part, 10));
-  if (parts.length < 3 || parts.some(part => !Number.isFinite(part))) return '0.0.1';
-  parts[parts.length - 1] += 1;
-  return parts.join('.');
+  // 取所有版本(含未发布草稿)里的最大三段号 +1——不能只看已发布版本:若存在
+  // 未发布草稿(如上架启用失败留下的 1.0.0),只看已发布会算出 0.0.1 撞车,导致
+  // 二次发版被平台以「版本号未递增」拒掉,应用永远停在未启用。
+  const triples = versions
+    .map(item => pickString(asRecord(item), ['appVersion']))
+    .filter((version): version is string => Boolean(version))
+    .map(version => version.split('.').map(part => Number.parseInt(part, 10)))
+    .filter(parts => parts.length === 3 && parts.every(part => Number.isFinite(part)));
+  if (triples.length === 0) return '0.0.1';
+  const max = triples.reduce((a, b) => {
+    for (let i = 0; i < 3; i++) {
+      if (b[i] !== a[i]) return b[i] > a[i] ? b : a;
+    }
+    return a;
+  });
+  return [max[0], max[1], max[2] + 1].join('.');
 }
 
 function extractContactRangeMemberIds(payload: unknown): string[] {

--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -1143,13 +1143,29 @@ export function buildManifestTemplateCreatePayload(
 }
 
 /**
+ * 模板创建是否属于服务端「明确拒绝」——即可确定应用没有建出来,允许安全
+ * 回退 app/create。业务错误码(code!==0,服务端解析请求后拒绝)与 HTTP 404
+ * (端点不存在)算明确拒绝;传输错误(ECONNRESET/timeout,非
+ * OpenPlatformApiError)、HTTP 5xx、code=0 缺 ClientID 都属「结果未知」——
+ * 服务端可能已 commit,跨端点重建会产生孤儿 + 重复应用,必须 fail-closed。
+ */
+function isDefiniteTemplateRejection(err: unknown): boolean {
+  if (!(err instanceof OpenPlatformApiError)) return false;
+  const code = (asRecord(err.payload) as { code?: unknown }).code;
+  if (typeof code === 'number' && code !== 0) return true;
+  return /^HTTP 404\b/.test(err.message);
+}
+
+/**
  * 用已经登录的开放平台 Web session 创建一个企业自建应用并读取凭证。
  *
  * 首选 console launcher 的「一键创建智能体」模板接口
  * (manifest/upsert_by_template):模板应用出生即带 bot 能力、长连接、基础
- * 事件与卡片回调,新建 bot 不再依赖后续订阅补齐。模板 ID 属内部契约,失败
- * 时自动回退旧 app/create(裸自建应用,事件/回调由 automateOpenPlatformSetup
- * 增量补齐并 fail-closed 兜底)。所有 Secret 只存在返回值中,不打印、不写日志。
+ * 事件与卡片回调,新建 bot 不再依赖后续订阅补齐。模板 ID 属内部契约,被
+ * 服务端明确拒绝时自动回退旧 app/create(裸自建应用,事件/回调由
+ * automateOpenPlatformSetup 增量补齐并 fail-closed 兜底);创建结果未知时
+ * 不回退(见 isDefiniteTemplateRejection)。Secret 只存在返回值中,不打印、
+ * 不写日志。
  */
 export async function createOpenPlatformAppWithClient(
   client: OpenPlatformApiClient,
@@ -1177,11 +1193,19 @@ export async function createOpenPlatformAppWithClient(
       '/developers/v1/manifest/upsert_by_template',
       buildManifestTemplateCreatePayload(name, description, avatar, randomUUID()),
     );
-    appId = pickPayloadString(created, ['ClientID', 'clientID', 'clientId', 'appId']);
+    const templateAppId = pickPayloadString(created, ['ClientID', 'clientID', 'clientId', 'appId']);
+    if (!templateAppId?.startsWith('cli_')) {
+      // code=0 却没有 ClientID:应用可能已建成(响应结构变化),结果未知——
+      // 不能落入 fallback 再 create,让下面的 catch 按「非明确拒绝」抛出。
+      throw new Error('一键智能体模板创建返回成功但没有 ClientID(结果未知);请到开放平台确认是否已创建同名应用后重试');
+    }
+    appId = templateAppId;
   } catch (err) {
-    console.warn(`一键智能体模板创建失败,回退普通自建应用: ${safeErrorMessage(err)}`);
+    if (!isDefiniteTemplateRejection(err)) throw err;
+    console.warn(`一键智能体模板创建被拒,回退普通自建应用: ${safeErrorMessage(err)}`);
+    appId = undefined;
   }
-  if (!appId?.startsWith('cli_')) {
+  if (!appId) {
     const created = await client.postJson('/developers/v1/app/create', {
       appSceneType: 0, // SelfBuild
       name,

--- a/test/setup-open-platform-automation.test.ts
+++ b/test/setup-open-platform-automation.test.ts
@@ -374,6 +374,9 @@ describe('createFeishuOpenPlatformApp', () => {
         expect(body.cid.length).toBeGreaterThan(0);
         return Response.json({ code: 0, data: { clientID: 'cli_created' } });
       }
+      if (path === '/developers/v1/app_version/create/cli_created') {
+        return Response.json({ code: 0, data: { versionId: 'v-enable' } });
+      }
       if (path === '/developers/v1/secret/cli_created') {
         return Response.json({ code: 0, data: { secret: 'created-secret' } });
       }
@@ -396,13 +399,19 @@ describe('createFeishuOpenPlatformApp', () => {
       sessionIdentity: { userId: 'u_1', tenantId: 't_1' },
     });
     expect(qrCount).toBe(0);
+    // 创建后立刻发布一个极简版本让应用上架启用(对齐 launcher),再读 secret
     expect(calls.map(call => call.path)).toEqual([
       '/developers/v1/app/upload/image',
       '/developers/v1/manifest/upsert_by_template',
       '/developers/v1/robot/switch/cli_created',
       '/developers/v1/event/switch/cli_created',
+      '/developers/v1/app_version/create/cli_created',
+      '/developers/v1/publish/commit/cli_created/v-enable',
       '/developers/v1/secret/cli_created',
     ]);
+    // 版本可见成员含当前登录人(session identity userId),否则发布不自动上架
+    const versionCall = calls.find(c => c.path === '/developers/v1/app_version/create/cli_created');
+    expect(JSON.parse(String(versionCall?.body))).toMatchObject({ visibleSuggest: { members: ['u_1'] } });
   });
 
   it('falls back to plain app/create when the one-click template endpoint fails', async () => {
@@ -426,6 +435,9 @@ describe('createFeishuOpenPlatformApp', () => {
         expect(JSON.parse(String(init?.body))).toMatchObject({ name: 'botmux-5', appSceneType: 0 });
         return Response.json({ code: 0, data: { ClientID: 'cli_fallback' } });
       }
+      if (path === '/developers/v1/app_version/create/cli_fallback') {
+        return Response.json({ code: 0, data: { versionId: 'v-enable' } });
+      }
       if (path === '/developers/v1/secret/cli_fallback') {
         return Response.json({ code: 0, data: { secret: 'fallback-secret' } });
       }
@@ -446,6 +458,8 @@ describe('createFeishuOpenPlatformApp', () => {
       '/developers/v1/app/create',
       '/developers/v1/robot/switch/cli_fallback',
       '/developers/v1/event/switch/cli_fallback',
+      '/developers/v1/app_version/create/cli_fallback',
+      '/developers/v1/publish/commit/cli_fallback/v-enable',
       '/developers/v1/secret/cli_fallback',
     ]);
   });

--- a/test/setup-open-platform-automation.test.ts
+++ b/test/setup-open-platform-automation.test.ts
@@ -450,6 +450,75 @@ describe('createFeishuOpenPlatformApp', () => {
     ]);
   });
 
+  function outcomeUnknownFetchImpl(calls: string[], templateResponse: () => Response | Promise<Response>) {
+    return (async (url: string | URL | Request) => {
+      const href = String(url);
+      if (href === 'https://ask.feishu.cn/') return new Response('ask home', { status: 200 });
+      if (href === 'https://open.feishu.cn/app') return new Response(openPlatformPage(), { status: 200 });
+      const path = new URL(href).pathname;
+      calls.push(path);
+      if (path === '/developers/v1/app/upload/image') {
+        return Response.json({ code: 0, data: { url: 'https://cdn.example/botmux.png' } });
+      }
+      if (path === '/developers/v1/manifest/upsert_by_template') {
+        return templateResponse();
+      }
+      return Response.json({ code: 0 });
+    }) as typeof fetch;
+  }
+
+  it('fails closed without cross-endpoint fallback when the template succeeds without a ClientID', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-noid-'));
+    const sessionFile = join(dir, 'feishu-session.json');
+    writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+    const calls: string[] = [];
+    const result = await createFeishuOpenPlatformApp({
+      name: 'botmux-6',
+      sessionFilePath: sessionFile,
+      disableBytedcliFallback: true,
+      // code=0 但响应缺 ClientID:应用可能已建成,禁止再走 app/create 重建
+      fetchImpl: outcomeUnknownFetchImpl(calls, () => Response.json({ code: 0, data: {} })),
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: 'api_error' });
+    if (!result.ok) expect(result.message).toContain('确认');
+    expect(calls.filter(p => p === '/developers/v1/app/create')).toEqual([]);
+  });
+
+  it('fails closed without cross-endpoint fallback on ambiguous transport errors from the template endpoint', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-transport-'));
+    const sessionFile = join(dir, 'feishu-session.json');
+    writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+    const calls: string[] = [];
+    const result = await createFeishuOpenPlatformApp({
+      name: 'botmux-7',
+      sessionFilePath: sessionFile,
+      disableBytedcliFallback: true,
+      // 传输错误(如 ECONNRESET):服务端可能已 commit,结果未知,不得重建
+      fetchImpl: outcomeUnknownFetchImpl(calls, () => { throw new Error('socket hang up (ECONNRESET)'); }),
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: 'api_error' });
+    expect(calls.filter(p => p === '/developers/v1/app/create')).toEqual([]);
+  });
+
+  it('fails closed without cross-endpoint fallback on HTTP 5xx from the template endpoint', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-5xx-'));
+    const sessionFile = join(dir, 'feishu-session.json');
+    writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+    const calls: string[] = [];
+    const result = await createFeishuOpenPlatformApp({
+      name: 'botmux-8',
+      sessionFilePath: sessionFile,
+      disableBytedcliFallback: true,
+      // 5xx:服务端内部错误,可能已部分落库,结果未知
+      fetchImpl: outcomeUnknownFetchImpl(calls, () => new Response('oops', { status: 502 })),
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: 'api_error' });
+    expect(calls.filter(p => p === '/developers/v1/app/create')).toEqual([]);
+  });
+
   it('stops before app/create when the account or tenant changed after the UI confirmation', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-identity-race-'));
     const sessionFile = join(dir, 'feishu-session.json');

--- a/test/setup-open-platform-automation.test.ts
+++ b/test/setup-open-platform-automation.test.ts
@@ -360,9 +360,19 @@ describe('createFeishuOpenPlatformApp', () => {
         expect(init?.body).toBeInstanceOf(FormData);
         return Response.json({ code: 0, data: { url: 'https://cdn.example/botmux.png' } });
       }
-      if (path === '/developers/v1/app/create') {
-        expect(JSON.parse(String(init?.body))).toMatchObject({ name: 'botmux-4', appSceneType: 0 });
-        return Response.json({ code: 0, data: { ClientID: 'cli_created' } });
+      if (path === '/developers/v1/manifest/upsert_by_template') {
+        const body = JSON.parse(String(init?.body));
+        expect(body).toMatchObject({
+          appManifestTemplateID: 'developer_console',
+          createAppUserCustomField: {
+            i18n: { zh_cn: { name: 'botmux-4' } },
+            avatar: 'https://cdn.example/botmux.png',
+            primaryLang: 'zh_cn',
+          },
+        });
+        expect(typeof body.cid).toBe('string');
+        expect(body.cid.length).toBeGreaterThan(0);
+        return Response.json({ code: 0, data: { clientID: 'cli_created' } });
       }
       if (path === '/developers/v1/secret/cli_created') {
         return Response.json({ code: 0, data: { secret: 'created-secret' } });
@@ -388,10 +398,55 @@ describe('createFeishuOpenPlatformApp', () => {
     expect(qrCount).toBe(0);
     expect(calls.map(call => call.path)).toEqual([
       '/developers/v1/app/upload/image',
-      '/developers/v1/app/create',
+      '/developers/v1/manifest/upsert_by_template',
       '/developers/v1/robot/switch/cli_created',
       '/developers/v1/event/switch/cli_created',
       '/developers/v1/secret/cli_created',
+    ]);
+  });
+
+  it('falls back to plain app/create when the one-click template endpoint fails', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-open-platform-fallback-'));
+    const sessionFile = join(dir, 'feishu-session.json');
+    writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+    const calls: string[] = [];
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      const href = String(url);
+      if (href === 'https://ask.feishu.cn/') return new Response('ask home', { status: 200 });
+      if (href === 'https://open.feishu.cn/app') return new Response(openPlatformPage(), { status: 200 });
+      const path = new URL(href).pathname;
+      calls.push(path);
+      if (path === '/developers/v1/app/upload/image') {
+        return Response.json({ code: 0, data: { url: 'https://cdn.example/botmux.png' } });
+      }
+      if (path === '/developers/v1/manifest/upsert_by_template') {
+        return Response.json({ code: 1, msg: 'template not available for this tenant' });
+      }
+      if (path === '/developers/v1/app/create') {
+        expect(JSON.parse(String(init?.body))).toMatchObject({ name: 'botmux-5', appSceneType: 0 });
+        return Response.json({ code: 0, data: { ClientID: 'cli_fallback' } });
+      }
+      if (path === '/developers/v1/secret/cli_fallback') {
+        return Response.json({ code: 0, data: { secret: 'fallback-secret' } });
+      }
+      return Response.json({ code: 0 });
+    }) as typeof fetch;
+
+    const result = await createFeishuOpenPlatformApp({
+      name: 'botmux-5',
+      sessionFilePath: sessionFile,
+      disableBytedcliFallback: true,
+      fetchImpl,
+    });
+
+    expect(result).toMatchObject({ ok: true, appId: 'cli_fallback', appSecret: 'fallback-secret' });
+    expect(calls).toEqual([
+      '/developers/v1/app/upload/image',
+      '/developers/v1/manifest/upsert_by_template',
+      '/developers/v1/app/create',
+      '/developers/v1/robot/switch/cli_fallback',
+      '/developers/v1/event/switch/cli_fallback',
+      '/developers/v1/secret/cli_fallback',
     ]);
   });
 

--- a/test/setup-pickers.test.ts
+++ b/test/setup-pickers.test.ts
@@ -4,6 +4,8 @@ import {
   createOpenPlatformAppWithClient,
   listOpenPlatformApps,
   fetchOpenPlatformAppSecret,
+  nextAppVersion,
+  OpenPlatformApiError,
   type OpenPlatformApiClient,
 } from '../src/setup/open-platform-automation.js';
 
@@ -76,16 +78,25 @@ describe('truncateToWidth', () => {
 function stubClient(responses: unknown[] | ((path: string, body: unknown) => unknown)): OpenPlatformApiClient & { calls: Array<{ path: string; body: unknown }> } {
   const calls: Array<{ path: string; body: unknown }> = [];
   const queue = Array.isArray(responses) ? [...responses] : null;
+  // 镜像真实 client:业务错误码(code!==0)会抛 OpenPlatformApiError,而不是把
+  // 错误响应当正常返回值——否则 catch 分支永远测不到。
+  const throwIfError = (resp: unknown) => {
+    const r = resp as { code?: unknown; msg?: unknown };
+    if (r && typeof r === 'object' && typeof r.code === 'number' && r.code !== 0) {
+      throw new OpenPlatformApiError(`code=${r.code} msg=${r.msg ?? ''}`, resp);
+    }
+    return resp;
+  };
   return {
     apiOrigin: 'https://open.feishu.cn',
     calls,
     async postJson(path: string, body?: unknown) {
       calls.push({ path, body });
-      return queue ? queue.shift() : (responses as (p: string, b: unknown) => unknown)(path, body);
+      return throwIfError(queue ? queue.shift() : (responses as (p: string, b: unknown) => unknown)(path, body));
     },
     async postForm(path: string, body: FormData) {
       calls.push({ path, body });
-      return queue ? queue.shift() : (responses as (p: string, b: unknown) => unknown)(path, body);
+      return throwIfError(queue ? queue.shift() : (responses as (p: string, b: unknown) => unknown)(path, body));
     },
   };
 }
@@ -199,26 +210,41 @@ describe('createOpenPlatformAppWithClient', () => {
     expect(client.calls[5].body).toEqual({ clientId: 'cli_new' });
   });
 
-  it('does not fail creation when the enabling publish errors (setup re-publishes as fallback)', async () => {
+  it('fails closed (with appId) when the enabling publish commit fails — no silent orphan', async () => {
     const client = stubClient([
       { code: 0, data: { url: 'https://cdn.example/botmux.png' } },
-      { code: 0, data: { ClientID: 'cli_pub_soft' } },
+      { code: 0, data: { ClientID: 'cli_commit_fail' } },
       { code: 0 },
       { code: 0 },
-      { code: 1, msg: 'version create rejected' }, // 启用发布失败——不致命
-      { code: 0, data: { secret: 'soft-secret' } }, // secret 仍读到
+      { code: 0, data: { versionId: 'v-init' } }, // 版本创建成功
+      { code: 1, msg: 'publish commit rejected' }, // commit 失败 → 抛
     ]);
-    await expect(createOpenPlatformAppWithClient(client, { name: 'botmux-soft', creatorUserId: 'u_creator' }))
-      .resolves.toEqual({ appId: 'cli_pub_soft', appSecret: 'soft-secret' });
-    // 版本创建失败后不发 publish/commit,直接读 secret
+    await expect(createOpenPlatformAppWithClient(client, { name: 'botmux-cf', creatorUserId: 'u_creator' }))
+      .rejects.toMatchObject({ appId: 'cli_commit_fail' });
+    // 不再有 soft 兜底:走到 publish/commit 就抛,不读 secret
     expect(client.calls.map(c => c.path)).toEqual([
       '/developers/v1/app/upload/image',
       '/developers/v1/manifest/upsert_by_template',
-      '/developers/v1/robot/switch/cli_pub_soft',
-      '/developers/v1/event/switch/cli_pub_soft',
-      '/developers/v1/app_version/create/cli_pub_soft',
-      '/developers/v1/secret/cli_pub_soft',
+      '/developers/v1/robot/switch/cli_commit_fail',
+      '/developers/v1/event/switch/cli_commit_fail',
+      '/developers/v1/app_version/create/cli_commit_fail',
+      '/developers/v1/publish/commit/cli_commit_fail/v-init',
     ]);
+  });
+
+  it('fails closed (with appId) when the enabling version create returns no versionId (outcome unknown)', async () => {
+    const client = stubClient([
+      { code: 0, data: { url: 'https://cdn.example/botmux.png' } },
+      { code: 0, data: { ClientID: 'cli_noverid' } },
+      { code: 0 },
+      { code: 0 },
+      { code: 0, data: {} }, // code=0 但没 versionId → 可能留下未发布草稿
+    ]);
+    await expect(createOpenPlatformAppWithClient(client, { name: 'botmux-nv', creatorUserId: 'u_creator' }))
+      .rejects.toMatchObject({ appId: 'cli_noverid' });
+    // 没 versionId → 不 commit、不读 secret
+    expect(client.calls.some(c => c.path.includes('/publish/commit/'))).toBe(false);
+    expect(client.calls.some(c => c.path.includes('/secret/'))).toBe(false);
   });
 
   it('retains the created app id in the error when secret reading fails', async () => {
@@ -233,5 +259,30 @@ describe('createOpenPlatformAppWithClient', () => {
     ]);
     await expect(createOpenPlatformAppWithClient(client, { name: 'botmux-3', creatorUserId: 'u_creator' }))
       .rejects.toThrow(/cli_orphan_guard.*AppSecret/);
+  });
+});
+
+describe('nextAppVersion', () => {
+  it('increments the patch of the highest PUBLISHED version', () => {
+    expect(nextAppVersion({ data: { versions: [
+      { appVersion: '1.0.0', versionStatus: 2 },
+      { appVersion: '1.0.1', versionStatus: 2 },
+    ] } })).toBe('1.0.2');
+  });
+
+  it('starts at 0.0.1 when there are no versions', () => {
+    expect(nextAppVersion({ data: { versions: [] } })).toBe('0.0.1');
+  });
+
+  it('accounts for UNPUBLISHED draft versions so the next number never collides', () => {
+    // 上架启用发布若留下未发布草稿 1.0.0(status 1),二次发版必须算 1.0.1 而非
+    // 0.0.1——否则平台按「版本号未递增」拒掉,应用永远停在未启用。
+    expect(nextAppVersion({ data: { versions: [
+      { appVersion: '1.0.0', versionStatus: 1 },
+    ] } })).toBe('1.0.1');
+    expect(nextAppVersion({ data: { versions: [
+      { appVersion: '2.3.4', versionStatus: 1 },
+      { appVersion: '1.0.0', versionStatus: 2 },
+    ] } })).toBe('2.3.5');
   });
 });

--- a/test/setup-pickers.test.ts
+++ b/test/setup-pickers.test.ts
@@ -165,7 +165,7 @@ describe('createOpenPlatformAppWithClient', () => {
 
     expect(client.calls.map(call => call.path)).toEqual([
       '/developers/v1/app/upload/image',
-      '/developers/v1/app/create',
+      '/developers/v1/manifest/upsert_by_template',
       '/developers/v1/robot/switch/cli_new',
       '/developers/v1/event/switch/cli_new',
       '/developers/v1/secret/cli_new',
@@ -175,10 +175,12 @@ describe('createOpenPlatformAppWithClient', () => {
     expect(upload.get('isIsv')).toBe('false');
     expect(upload.get('scale')).toBe(JSON.stringify({ width: 512, height: 512 }));
     expect(client.calls[1].body).toMatchObject({
-      appSceneType: 0,
-      name: 'botmux-2',
-      avatar: 'https://cdn.example/botmux.png',
-      primaryLang: 'zh_cn',
+      appManifestTemplateID: 'developer_console',
+      createAppUserCustomField: {
+        i18n: { zh_cn: { name: 'botmux-2' } },
+        avatar: 'https://cdn.example/botmux.png',
+        primaryLang: 'zh_cn',
+      },
     });
     expect(client.calls[2].body).toEqual({ clientId: 'cli_new', enable: true });
     expect(client.calls[3].body).toEqual({ clientId: 'cli_new', eventMode: 4 });

--- a/test/setup-pickers.test.ts
+++ b/test/setup-pickers.test.ts
@@ -149,16 +149,18 @@ describe('fetchOpenPlatformAppSecret', () => {
 });
 
 describe('createOpenPlatformAppWithClient', () => {
-  it('uploads the botmux icon, creates a named self-built app, then reads its secret', async () => {
+  it('uploads the icon, creates via template, publishes an enabling version, then reads its secret', async () => {
     const client = stubClient([
-      { code: 0, data: { url: 'https://cdn.example/botmux.png' } },
-      { code: 0, data: { ClientID: 'cli_new' } },
-      { code: 0 },
-      { code: 0 },
-      { code: 0, data: { secret: 'new-secret' } },
+      { code: 0, data: { url: 'https://cdn.example/botmux.png' } }, // upload/image
+      { code: 0, data: { ClientID: 'cli_new' } },                  // upsert_by_template
+      { code: 0 },                                                 // robot/switch
+      { code: 0 },                                                 // event/switch
+      { code: 0, data: { versionId: 'v-init' } },                  // app_version/create（启用发布）
+      { code: 0 },                                                 // publish/commit
+      { code: 0, data: { secret: 'new-secret' } },                 // secret
     ]);
 
-    await expect(createOpenPlatformAppWithClient(client, { name: 'botmux-2' })).resolves.toEqual({
+    await expect(createOpenPlatformAppWithClient(client, { name: 'botmux-2', creatorUserId: 'u_creator' })).resolves.toEqual({
       appId: 'cli_new',
       appSecret: 'new-secret',
     });
@@ -168,6 +170,8 @@ describe('createOpenPlatformAppWithClient', () => {
       '/developers/v1/manifest/upsert_by_template',
       '/developers/v1/robot/switch/cli_new',
       '/developers/v1/event/switch/cli_new',
+      '/developers/v1/app_version/create/cli_new',
+      '/developers/v1/publish/commit/cli_new/v-init',
       '/developers/v1/secret/cli_new',
     ]);
     const upload = client.calls[0].body as FormData;
@@ -184,6 +188,37 @@ describe('createOpenPlatformAppWithClient', () => {
     });
     expect(client.calls[2].body).toEqual({ clientId: 'cli_new', enable: true });
     expect(client.calls[3].body).toEqual({ clientId: 'cli_new', eventMode: 4 });
+    // 启用发布用极简版本 payload,可见成员含创建者(否则发布后不自动上架启用)
+    expect(client.calls[4].body).toMatchObject({
+      appVersion: '1.0.0',
+      visibleSuggest: { members: ['u_creator'], isAll: 0 },
+      pcDefaultAbility: 'bot',
+      mobileDefaultAbility: 'bot',
+    });
+    expect(client.calls[4].body).not.toHaveProperty('applyReasonConfig');
+    expect(client.calls[5].body).toEqual({ clientId: 'cli_new' });
+  });
+
+  it('does not fail creation when the enabling publish errors (setup re-publishes as fallback)', async () => {
+    const client = stubClient([
+      { code: 0, data: { url: 'https://cdn.example/botmux.png' } },
+      { code: 0, data: { ClientID: 'cli_pub_soft' } },
+      { code: 0 },
+      { code: 0 },
+      { code: 1, msg: 'version create rejected' }, // 启用发布失败——不致命
+      { code: 0, data: { secret: 'soft-secret' } }, // secret 仍读到
+    ]);
+    await expect(createOpenPlatformAppWithClient(client, { name: 'botmux-soft', creatorUserId: 'u_creator' }))
+      .resolves.toEqual({ appId: 'cli_pub_soft', appSecret: 'soft-secret' });
+    // 版本创建失败后不发 publish/commit,直接读 secret
+    expect(client.calls.map(c => c.path)).toEqual([
+      '/developers/v1/app/upload/image',
+      '/developers/v1/manifest/upsert_by_template',
+      '/developers/v1/robot/switch/cli_pub_soft',
+      '/developers/v1/event/switch/cli_pub_soft',
+      '/developers/v1/app_version/create/cli_pub_soft',
+      '/developers/v1/secret/cli_pub_soft',
+    ]);
   });
 
   it('retains the created app id in the error when secret reading fails', async () => {
@@ -192,9 +227,11 @@ describe('createOpenPlatformAppWithClient', () => {
       { code: 0, data: { ClientID: 'cli_orphan_guard' } },
       { code: 0 },
       { code: 0 },
-      { code: 0, data: {} },
+      { code: 0, data: { versionId: 'v-init' } },
+      { code: 0 },
+      { code: 0, data: {} }, // secret 缺失
     ]);
-    await expect(createOpenPlatformAppWithClient(client, { name: 'botmux-3' }))
+    await expect(createOpenPlatformAppWithClient(client, { name: 'botmux-3', creatorUserId: 'u_creator' }))
       .rejects.toThrow(/cli_orphan_guard.*AppSecret/);
   });
 });


### PR DESCRIPTION
## 背景

v2.109.1(#472)用「读现状→增量补→fail-closed」修复了新建 bot 缺事件订阅/卡片回调的问题——那是止血。申晗指出根源:**正常「一键创建智能体」建出的应用默认就带这些配置**,而 botmux(#457 起)走的裸 `app/create`(appSceneType 0)建出的是零订阅应用。本 PR 治本:创建改走智能体模板接口。

## 逆向依据(CDP 实测)

agent-browser 注入 botmux web session,抓 `open.larkoffice.com/page/launcher?from=backend_oneclick` 的 Create 动作,唯一创建请求:

```
POST /developers/v1/manifest/upsert_by_template
{ "appManifestTemplateID": "developer_console",
  "createAppUserCustomField": { "i18n": { "zh_cn": { "name", "description" } }, "avatar": "<upload/image 返回 URL>", "primaryLang": "zh_cn" },
  "cid": "<客户端随机 id>", "HTTPHead": {} }
→ { "code": 0, "data": { "clientID": "cli_xxx" } }
```

对模板建出的探针应用逐项回读:**开箱自带** eventMode=4 长连接、6 个基础事件(im.message.receive_v1 / bot.added / bot.deleted / reaction.created / reaction.deleted / drive.notice.comment_add)、callbackMode=4 + card.action.trigger 回调、bot 能力。

## 变更(src/setup/open-platform-automation.ts)

- `createOpenPlatformAppWithClient` 首选 `manifest/upsert_by_template`(icon 上传流程原样复用做 avatar,`cid` 用 randomUUID)
- **模板 ID `developer_console` 属内部契约**,调用失败(任何错误)自动回退原 `app/create` 路径,并 console.warn 原因;两条路径后续 robot/event switch、secret 读取完全一致
- v2.109.1 的增量补齐 + fail-closed 全部保留:模板还差 drive.file.comment_add_v1 与 4 个 VC bot 事件,照旧由 automateOpenPlatformSetup 增量补;fallback 路径的零订阅应用也由它兜底

## 影响面

- 仅创建入口一个函数;automateOpenPlatformSetup、scope 导入、版本发布逻辑零改动
- 消费方(CLI setup / dashboard onboarding)无接口变化
- lark 品牌不受影响(本来就跳过 Web 自动化)
- 模板应用后续被平台调整时,fallback + 增量补齐 + fail-closed 三层兜底,不会回到「静默建出坏 bot」

## 验证

- `pnpm exec tsc --noEmit` + `pnpm build` 零错误
- 单测:setup-open-platform-automation 28/28(含新 fallback 用例:模板 500 → 走 app/create 全链路)+ setup-pickers 17/17(payload/端点序列断言更新)
- 全套 unit:8169 passed / 5 failed(与干净 master 相同的 pre-existing 集合:scheduler×2、schedule-card×1、monitoring-ui×1、recall-frozen×1)
- **Live e2e(申晗租户)**:新代码建 `bmx-tpl-e2e` → 出生态 eventMode/callbackMode=4、im.message.receive_v1 + card.action.trigger 已订(9 订阅)→ automateOpenPlatformSetup 补齐至 12(298 scopes、无 warning、missingVc 空)→ 独立回读零缺失 → **E2E PASS** → 删除成功无残留

```
# created: cli_aaddd44125f81be2
# 出生态: eventMode 4 | cbMode 4 | im.msg.recv true | card.cb true | events 9
# setup: ok scopes=298 events=12 warn=- missingVc=-
# 终态: eventMode 4 | cbMode 4 | missing baseline: (none) | missing cb: (none)
# E2E PASS
# deleted cli_aaddd44125f81be2
```
