### PR TITLE
feat(cli): 卡片结构化数据出口——quoted --raw / history --with-card-json + 渲染三修

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4652,8 +4652,9 @@ async function cmdHistory(rest: string[]): Promise<void> {
     process.exit(1);
   }
 
+  const withCardJson = rest.includes('--with-card-json');
   const { getMessageDetail, listAmbientChatMessages, listThreadMessages, listChatMessages } = await import('./im/lark/client.js');
-  const { parseApiMessage, cardContentHasUpgradeFallback, resolveMergedCardContent } = await import('./im/lark/message-parser.js');
+  const { parseApiMessage, cardContentHasUpgradeFallback, resolveMergedCardContent, extractResources, createImgNumberer } = await import('./im/lark/message-parser.js');
   const { expandMergeForward } = await import('./im/lark/merge-forward.js');
   try {
     // Chat-scope sessions (普通群整群一会话) have no thread to walk — list the
@@ -4698,24 +4699,50 @@ async function cmdHistory(rest: string[]): Promise<void> {
           })
         : await listThreadMessages(appId, s.chatId, s.rootMessageId, limit);
     // Expand merge_forward to <forwarded_messages> XML, mirroring the live event
-    // path in daemon.ts. Each merge_forward gets its own numberer (we don't
-    // download resources here — only [图片 N] placeholders matter).
+    // path in daemon.ts. Each message gets its own numberer with resources
+    // assigned BEFORE text extraction, so in-body [图片 N] placeholders match
+    // the surfaced `resources` order (same contract as parseEventMessage).
+    // Resources carry key+name only — no download here; `botmux quoted <om_id>`
+    // fetches any message's full text AND downloads its attachments locally.
     const messages = await Promise.all(raw.map(async (m: any) => {
-      let parsed = parseApiMessage(m);
+      const numberer = createImgNumberer();
+      let resources = extractResources(m.msg_type ?? 'text', m.body?.content ?? '', numberer);
+      const parsed = parseApiMessage(m, numberer);
+      let cardJson: unknown;
       // `im.v1.message.list` returns Lark's simplified "请升级客户端" fallback for
       // complex cards — the whole body (user-forwarded) or nested sub-cards
       // buried mid-body (Argos alarms). Those are the cards where the list view
       // alone is incomplete, so resolve them by unioning both `im.message.get`
       // representations (server-rendered + full structured). Failures keep the
-      // list text. Simple cards (no fallback) already render fully here.
-      if (parsed.msgType === 'interactive' && cardContentHasUpgradeFallback(parsed.content)) {
-        const merged = await resolveMergedCardContent(appId, parsed.messageId).catch(() => null);
-        if (merged) parsed.content = merged.text;
+      // list text. Simple cards (no fallback) already render fully here —
+      // --with-card-json resolves ALL cards since the structured JSON only
+      // exists on the `im.message.get` representation.
+      if (parsed.msgType === 'interactive' && (withCardJson || cardContentHasUpgradeFallback(parsed.content))) {
+        // Fresh numberer: the resolve REPLACES both content and resources, so
+        // its [图片 N] numbering must restart at 1 alongside merged.resources.
+        // Keeping the list-view resources would leak the upgrade-fallback
+        // shell's phantom image (a "请升级" placeholder, absent from the real
+        // card) into every complex card's resource list.
+        const cardNumberer = createImgNumberer();
+        const merged = await resolveMergedCardContent(appId, parsed.messageId, cardNumberer).catch(() => null);
+        if (merged) {
+          parsed.content = merged.text;
+          resources = merged.resources;
+          if (withCardJson) {
+            try { cardJson = JSON.parse(merged.structuredContent); }
+            catch { cardJson = merged.structuredContent; }
+          }
+        }
       }
       if (parsed.msgType === 'merge_forward') {
-        await expandMergeForward(appId, parsed.messageId, parsed);
+        const { extraResources } = await expandMergeForward(appId, parsed.messageId, parsed, numberer);
+        if (extraResources.length) resources = [...resources, ...extraResources];
       }
-      return parsed;
+      return {
+        ...parsed,
+        ...(resources.length ? { resources } : {}),
+        ...(cardJson !== undefined ? { cardJson } : {}),
+      };
     }));
     console.log(JSON.stringify({
       sessionId: sid,
@@ -4732,6 +4759,11 @@ async function cmdHistory(rest: string[]): Promise<void> {
       } : {}),
       messages,
       total: messages.length,
+      // Discoverability: agents reading history often need the actual image
+      // bytes (alert charts) or the raw card JSON — both live one command away.
+      ...(messages.some(m => (m as any).resources?.length || m.msgType === 'interactive') ? {
+        hint: '查看某条消息的附件图片/文件或卡片全文：botmux quoted <messageId>（任意消息 id 均可，附件会下载到本地）；需要原始卡片 JSON：botmux quoted <messageId> --raw 或本命令加 --with-card-json',
+      } : {}),
     }, null, 2));
   } catch (err: any) {
     console.error(`获取消息失败: ${err.message}`);
@@ -4748,8 +4780,9 @@ async function cmdQuoted(rest: string[]): Promise<void> {
   // its value so `botmux quoted --session-id <uuid> om_xxx` doesn't pick up
   // the uuid as the message id.
   const messageId = firstPositional(rest, ['--session-id']);
+  const rawFlag = rest.includes('--raw');
   if (!messageId) {
-    console.error('用法: botmux quoted <message_id> [--session-id <id>]');
+    console.error('用法: botmux quoted <message_id> [--raw] [--session-id <id>]');
     process.exit(1);
   }
 
@@ -4779,7 +4812,20 @@ async function cmdQuoted(rest: string[]): Promise<void> {
     // so there's no cheap local signal that a merge would add anything.
     if (rendered.msgType === 'interactive') {
       const merged = await resolveMergedCardContent(appId, messageId).catch(() => null);
-      if (merged) rendered.content = merged.text;
+      if (merged) {
+        rendered.content = merged.text;
+        // --raw: surface the full structured card JSON (v2 body/elements) so
+        // automation can read exact field values, button URLs and image keys
+        // instead of re-parsing the rendered text (告警自动化场景).
+        if (rawFlag) {
+          try { (rendered as { cardJson?: unknown }).cardJson = JSON.parse(merged.structuredContent); }
+          catch { (rendered as { cardJson?: unknown }).cardJson = merged.structuredContent; }
+        }
+      }
+    } else if (rawFlag) {
+      // Non-card messages: expose the original body content verbatim (post/
+      // text/... structured JSON string) for the same automation use case.
+      (rendered as { rawContent?: string }).rawContent = msg.body?.content ?? '';
     }
     // The referenced message's file/media resources arrive as key+name only. A
     // read-isolated agent can't call the Lark resource API itself (bots.json

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4077,10 +4077,12 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
     纯记录/低优先级进度/简短确认→--no-mention；没信息量的"收到"不如不发。
     （可设 BOTMUX_REQUIRE_MENTION_DECISION=false 关闭硬门）
   bots list                            列出当前群聊中的机器人（含 open_id）
-  history [--limit N] [--scope session|thread|chat|ambient]
+  history [--limit N] [--scope session|thread|chat|ambient] [--with-card-json]
                                        拉取当前会话的消息历史 (JSON)。默认按 session scope：话题/话题群 → 话题内，普通群 → 整群；
-                                       thread 会话里可用 --scope ambient 读取 thread 外的群聊上下文
-  quoted <message_id>                  拉取被引用的单条消息 (JSON)，message_id 取自 daemon 注入的引用提示行
+                                       thread 会话里可用 --scope ambient 读取 thread 外的群聊上下文；
+                                       --with-card-json 为每张卡片附原始结构化 JSON（消息均带 resources 附件 key）
+  quoted <message_id> [--raw]          按消息 id 拉取单条消息 (JSON) 并下载附件到本地；id 取自引用提示行或 history 输出，
+                                       --raw 附原始内容（卡片 → cardJson，其它 → rawContent）
   ask buttons --options "a,b" "<问题>"  把选择题做成按钮卡片抛给飞书，等用户点选后返回其选择
                                        （无 hook 的 CLI 用它把决策引到人；也可省略 buttons 走裸别名）
   skill list                           列出本会话可用的技能（用户自定义 + botmux 内置）及其描述
@@ -4804,29 +4806,24 @@ async function cmdQuoted(rest: string[]): Promise<void> {
       console.error(`未找到消息 ${messageId}`);
       process.exit(1);
     }
-    const rendered = await renderQuotedMessage(appId, msg, expandMergeForward);
-    // Interactive cards: union both im.message.get representations so the quoted
-    // view matches history/live (recovers names + sub-card content + options).
-    // This single-message path always merges — unlike history (which starts
-    // from the hole-bearing list view), the quoted base is the hole-free B view
-    // so there's no cheap local signal that a merge would add anything.
-    if (rendered.msgType === 'interactive') {
-      const merged = await resolveMergedCardContent(appId, messageId).catch(() => null);
-      if (merged) {
-        rendered.content = merged.text;
+    // Interactive cards are re-resolved inside the render pipeline (both
+    // im.message.get representations unioned, content + resources replaced
+    // wholesale with fresh [图片 N] numbering — see renderQuotedMessage).
+    const rendered = await renderQuotedMessage(appId, msg, expandMergeForward, resolveMergedCardContent);
+    if (rawFlag) {
+      if (rendered.mergedStructuredContent !== undefined) {
         // --raw: surface the full structured card JSON (v2 body/elements) so
         // automation can read exact field values, button URLs and image keys
         // instead of re-parsing the rendered text (告警自动化场景).
-        if (rawFlag) {
-          try { (rendered as { cardJson?: unknown }).cardJson = JSON.parse(merged.structuredContent); }
-          catch { (rendered as { cardJson?: unknown }).cardJson = merged.structuredContent; }
-        }
+        try { (rendered as { cardJson?: unknown }).cardJson = JSON.parse(rendered.mergedStructuredContent); }
+        catch { (rendered as { cardJson?: unknown }).cardJson = rendered.mergedStructuredContent; }
+      } else {
+        // Non-card messages (and cards whose merge failed): expose the
+        // original body content verbatim for the same automation use case.
+        (rendered as { rawContent?: string }).rawContent = msg.body?.content ?? '';
       }
-    } else if (rawFlag) {
-      // Non-card messages: expose the original body content verbatim (post/
-      // text/... structured JSON string) for the same automation use case.
-      (rendered as { rawContent?: string }).rawContent = msg.body?.content ?? '';
     }
+    delete rendered.mergedStructuredContent;
     // The referenced message's file/media resources arrive as key+name only. A
     // read-isolated agent can't call the Lark resource API itself (bots.json
     // creds are deny-read), so download the bytes HERE — via the bot client

--- a/src/cli/quoted-render.ts
+++ b/src/cli/quoted-render.ts
@@ -21,8 +21,20 @@ export type ExpandMergeForwardFn = (
   numberer: ReturnType<typeof createImgNumberer>,
 ) => Promise<{ extraResources: MessageResource[] }>;
 
+/** Subset of resolveMergedCardContent used here (dependency-injected so tests
+ *  can stub it): resolves an interactive card to its merged text + structured
+ *  JSON + resources, numbering [图片 N] via the given numberer. */
+export type ResolveMergedCardFn = (
+  larkAppId: string,
+  messageId: string,
+  numberer: ReturnType<typeof createImgNumberer>,
+) => Promise<{ text: string; structuredContent: string; resources: MessageResource[] } | null>;
+
 export interface RenderedQuotedMessage extends LarkMessage {
   resources: MessageResource[];
+  /** Structured card JSON from the merge pass — set only for interactive
+   *  messages that were successfully re-resolved (`quoted --raw` → cardJson). */
+  mergedStructuredContent?: string;
 }
 
 /**
@@ -41,6 +53,7 @@ export async function renderQuotedMessage(
   larkAppId: string,
   rawMessage: any,
   expandMergeForward: ExpandMergeForwardFn,
+  resolveMergedCard?: ResolveMergedCardFn,
 ): Promise<RenderedQuotedMessage> {
   const numberer = createImgNumberer();
   // Order: extractResources first so top-level keys get their numbers, then
@@ -53,6 +66,21 @@ export async function renderQuotedMessage(
   if (parsed.msgType === 'merge_forward') {
     const { extraResources } = await expandMergeForward(larkAppId, parsed.messageId, parsed, numberer);
     resources.push(...extraResources);
+  }
+  // Interactive cards: union both im.message.get representations so the quoted
+  // view matches history/live. Fresh numberer + FULL replacement (content AND
+  // resources): the merge re-renders the card from scratch, so [图片 N] must
+  // restart at 1 aligned with merged.resources — reusing the numberer above
+  // would leave merged text misnumbered, and keeping the pre-merge resources
+  // would let the list view's upgrade-fallback shell image linger. Attachment
+  // download (in cmdQuoted) runs on the replaced list.
+  if (parsed.msgType === 'interactive' && resolveMergedCard) {
+    const cardNumberer = createImgNumberer();
+    const merged = await resolveMergedCard(larkAppId, parsed.messageId, cardNumberer).catch(() => null);
+    if (merged) {
+      parsed.content = merged.text;
+      return { ...parsed, resources: merged.resources, mergedStructuredContent: merged.structuredContent };
+    }
   }
   return { ...parsed, resources };
 }

--- a/src/dashboard/web/insights.ts
+++ b/src/dashboard/web/insights.ts
@@ -469,7 +469,7 @@ export function cleanPromptText(raw: string): string {
     .replace(/<mention\b[^>]*\/?>/g, ' ')
     .replace(/\[用户引用了消息[\s\S]*?\]/g, ' ')
     .replace(/\[来自[^\]]*@mention\]/g, ' ')
-    .replace(/\[(图片|文件)\s*\d+\][^\n]*/g, ' ');
+    .replace(/\[(图片|文件)\s*\d+[^\]\n]*\][^\n]*/g, ' ');
   return s
     .replace(/[ \t]+/g, ' ')
     .replace(/ *\n */g, '\n')

--- a/src/im/lark/message-parser.ts
+++ b/src/im/lark/message-parser.ts
@@ -677,8 +677,15 @@ export function extractCardContent(rawContent: string, numberer?: ImgNumberer): 
             else if (node.tag === 'a') {
               // Keep the href so links survive — Format A separates text/href,
               // and dropping href loses real content (规则配置/详情/Trace 链接).
+              // Bare long URLs (e.g. Argos Kibana 处理建议) come back with
+              // text === href, both cut at the same offset, and the remainder
+              // spilling into the FOLLOWING text nodes of the same paragraph.
+              // Emitting `text(href)` would double the truncated URL and
+              // corrupt the line; a single copy lets join('') below reconnect
+              // the full URL from those remainder nodes.
               const t = node.text ?? '';
-              textNodes.push(node.href && t ? `${t}(${node.href})` : (t || node.href || ''));
+              if (t && t === node.href) textNodes.push(t);
+              else textNodes.push(node.href && t ? `${t}(${node.href})` : (t || node.href || ''));
             }
             else if (node.tag === 'at') textNodes.push(`@${node.user_name ?? 'unknown'}`);
             else if (node.tag === 'img' || node.tag === 'image') {
@@ -824,7 +831,7 @@ export function mergeCardText(textA: string, textB: string): string {
  */
 export async function resolveMergedCardContent(
   larkAppId: string, messageId: string, numberer?: ImgNumberer,
-): Promise<{ text: string; structuredContent: string } | null> {
+): Promise<{ text: string; structuredContent: string; resources: MessageResource[] } | null> {
   const [aRes, bRes] = await Promise.all([
     getMessageDetail(larkAppId, messageId, { userCardContent: false }).catch(() => null),
     getMessageDetail(larkAppId, messageId, { userCardContent: true }).catch(() => null),
@@ -832,6 +839,12 @@ export async function resolveMergedCardContent(
   const aContent = aRes?.items?.[0]?.body?.content;
   const bContent = bRes?.items?.[0]?.body?.content;
   if (!aContent && !bContent) return null;
+  const structuredContent = (bContent ?? aContent)!;
+  // Resources BEFORE text so the shared numberer assigns [图片 N] in attachment
+  // order and the text extraction below reuses those numbers (same ordering
+  // contract as parseEventMessage / buildForwardedTree). Callers that don't
+  // pass a numberer are unaffected (fresh internal one, unnumbered text).
+  const resources = extractResources('interactive', structuredContent, numberer);
   const textA = aContent ? extractCardContent(normalizeApiMessageContent('interactive', aContent), numberer) : '';
   const textB = bContent ? extractCardContent(normalizeApiMessageContent('interactive', bContent), numberer) : '';
   const merged = mergeCardText(textA, textB);
@@ -839,7 +852,7 @@ export async function resolveMergedCardContent(
   // Carry the structured card JSON (B preferred) alongside the merged text so
   // resource extraction (image_key/file_key) keeps working — extractResources
   // walks elements/body, extractCardContent short-circuits on the text key.
-  return { text: merged, structuredContent: (bContent ?? aContent)! };
+  return { text: merged, structuredContent, resources };
 }
 
 /**
@@ -860,6 +873,30 @@ export async function resolveEventCard(data: RawEventData, larkAppId: string): P
     return;
   }
   unwrapUserDsl(data);
+}
+
+/** Resolve a card button's jump target across schema generations: v1 `url` /
+ *  `multi_url.url`, v2 `behaviors: [{type:'open_url', default_url, pc_url}]`.
+ *  Returns undefined for callback-only buttons (they have no followable URL). */
+function buttonOpenUrl(el: any): string | undefined {
+  if (typeof el.url === 'string' && el.url) return el.url;
+  const multi = el.multi_url?.url ?? el.multi_url?.pc_url;
+  if (typeof multi === 'string' && multi) return multi;
+  if (Array.isArray(el.behaviors)) {
+    for (const b of el.behaviors) {
+      if (b?.type !== 'open_url') continue;
+      const u = b.default_url ?? b.pc_url ?? b.url;
+      if (typeof u === 'string' && u) return u;
+    }
+  }
+  return undefined;
+}
+
+/** Fold an image's alt text into its placeholder: `[图片 2]` + alt →
+ *  `[图片 2: 报警前30分钟今(红)昨(蓝)同比]`. Consumers that pattern-match the
+ *  placeholder tolerate the suffix (they match `[图片…]` loosely). */
+function withImgAlt(label: string, alt: string): string {
+  return label.endsWith(']') ? `${label.slice(0, -1)}: ${alt}]` : `${label} (${alt})`;
 }
 
 type ResourcePusher = (resources: MessageResource[], r: MessageResource) => void;
@@ -927,9 +964,15 @@ function extractElementText(el: any, parts: string[], imgLabel: (key: string) =>
   }
 
   // button — text may be a plain_text object (v2) or a string (v1 simplified).
+  // Jump buttons carry their target as v1 `url`/`multi_url` or v2 `behaviors`
+  // open_url; keep it so the reader can actually follow the link (e.g. Argos
+  // [分析报告] → the report URL). Callback buttons have no URL and stay bare.
   if (tag === 'button') {
     const btnText = typeof el.text === 'string' ? el.text : el.text?.content;
-    if (btnText) parts.push(`[${btnText}]`);
+    if (btnText) {
+      const url = buttonOpenUrl(el);
+      parts.push(url ? `[${btnText}](${url})` : `[${btnText}]`);
+    }
   }
 
   // input — surface the placeholder so the reader knows the field is there.
@@ -950,9 +993,12 @@ function extractElementText(el: any, parts: string[], imgLabel: (key: string) =>
   }
 
   // image — emit a numbered placeholder matching the attachment list order.
+  // Carry the alt text when present: for chart images (Argos 同比曲线图) the
+  // alt is often the only machine-readable description of what the image shows.
   if (tag === 'img' || tag === 'image') {
     const k = el.image_key ?? el.img_key;
-    if (k) parts.push(imgLabel(k));
+    const alt = (typeof el.alt === 'string' ? el.alt : el.alt?.content)?.trim();
+    if (k) parts.push(alt ? withImgAlt(imgLabel(k), alt) : imgLabel(k));
   }
 
   // note blocks (v1 only — v2 removed the tag but we still parse v1 cards)

--- a/src/im/lark/message-parser.ts
+++ b/src/im/lark/message-parser.ts
@@ -693,8 +693,14 @@ export function extractCardContent(rawContent: string, numberer?: ImgNumberer): 
               if (k) textNodes.push(imgLabel(k));
             }
             else if (node.tag === 'button') {
+              // Same jump-URL policy as Format B: simple cards reach history
+              // via the Format A list view WITHOUT a resolve pass, so dropping
+              // the URL here would lose button links on that main path.
               const btnText = typeof node.text === 'string' ? node.text : node.text?.content;
-              if (btnText) buttons.push(`[${btnText}]`);
+              if (btnText) {
+                const url = buttonOpenUrl(node);
+                buttons.push(url ? `[${btnText}](${url})` : `[${btnText}]`);
+              }
             }
             else if (node.tag === 'input') {
               const ph = typeof node.placeholder === 'string' ? node.placeholder : node.placeholder?.content;
@@ -875,18 +881,31 @@ export async function resolveEventCard(data: RawEventData, larkAppId: string): P
   unwrapUserDsl(data);
 }
 
+/** First non-empty string among the candidates. Deliberately NOT `??` — Lark
+ *  payloads carry empty-string placeholders (e.g. multi_url: {url: '', pc_url:
+ *  'https://…'}) which nullish coalescing would return, swallowing the valid
+ *  platform URL behind it. */
+function firstNonEmptyString(...candidates: unknown[]): string | undefined {
+  for (const c of candidates) {
+    if (typeof c === 'string' && c) return c;
+  }
+  return undefined;
+}
+
 /** Resolve a card button's jump target across schema generations: v1 `url` /
- *  `multi_url.url`, v2 `behaviors: [{type:'open_url', default_url, pc_url}]`.
+ *  `multi_url`, v2 `behaviors: [{type:'open_url', default_url, pc_url, …}]`.
  *  Returns undefined for callback-only buttons (they have no followable URL). */
 function buttonOpenUrl(el: any): string | undefined {
-  if (typeof el.url === 'string' && el.url) return el.url;
-  const multi = el.multi_url?.url ?? el.multi_url?.pc_url;
-  if (typeof multi === 'string' && multi) return multi;
+  const direct = firstNonEmptyString(
+    el.url,
+    el.multi_url?.url, el.multi_url?.pc_url, el.multi_url?.android_url, el.multi_url?.ios_url,
+  );
+  if (direct) return direct;
   if (Array.isArray(el.behaviors)) {
     for (const b of el.behaviors) {
       if (b?.type !== 'open_url') continue;
-      const u = b.default_url ?? b.pc_url ?? b.url;
-      if (typeof u === 'string' && u) return u;
+      const u = firstNonEmptyString(b.default_url, b.pc_url, b.url, b.android_url, b.ios_url);
+      if (u) return u;
     }
   }
   return undefined;

--- a/src/skills/definitions.ts
+++ b/src/skills/definitions.ts
@@ -139,6 +139,9 @@ botmux history --scope ambient --limit 20
 
 # 在 thread 内强制读取整个群聊最近消息（包含其他话题/卡片，噪音更大）
 botmux history --scope chat --limit 50
+
+# 附带每张卡片的原始结构化 JSON（告警卡等自动化解析场景；输出会变大）
+botmux history --with-card-json
 \`\`\`
 
 ## 输出
@@ -158,9 +161,13 @@ JSON 格式，字段：
     "excludeRootMessageId": "..."
   },
   "messages": [
-    { "messageId": "...", "senderId": "...", "senderType": "user|app", "msgType": "text|post|interactive", "content": "...", "createTime": "..." }
+    { "messageId": "...", "senderId": "...", "senderType": "user|app", "msgType": "text|post|interactive", "content": "...", "createTime": "...",
+      "resources": [{"type":"image","key":"img_v3_xxx","name":"img_v3_xxx.jpg"}],  // 仅含附件的消息有；key+name，不自动下载
+      "cardJson": { }              // 仅 --with-card-json 且 msgType=interactive 时有：原始卡片结构化 JSON
+    }
   ],
-  "total": 17
+  "total": 17,
+  "hint": "..."                    // 有附件/卡片时出现：提示用 botmux quoted 查看附件与卡片全文
 }
 \`\`\`
 
@@ -171,15 +178,16 @@ JSON 格式，字段：
 - \`scope=ambient\`：返回当前 thread 外的群聊上下文，默认排除当前 thread，并优先限制在 thread root 创建前，适合 \`/t\` 后补充群内讨论背景；仅在用户明确需要群聊背景时使用，并优先小 \`--limit\`
 - \`senderType="app"\` 表示机器人发的消息（包括 Claude Code / Codex / 其它 bot），\`"user"\` 表示用户
 - **合并转发**消息会自动展开：\`msgType\` 变为 \`merge_forward_expanded\`，\`content\` 是 \`<forwarded_messages>...</forwarded_messages>\` XML（含 \`<participants>\` 别名表 + 嵌套 \`<msg from="A">\` 节点），与 daemon 实时事件路径一致
+- **卡片消息**的 \`content\` 是可读文本渲染；图片只有 \`[图片 N]\` 占位符 + \`resources\` 里的 key，**不自动下载**。要看图片实际内容（如报警卡里的趋势图）或消息全文，对该条消息的 id 跑 \`botmux quoted <messageId>\`（任意消息 id 均可，附件会下载到本地）；要机器可读的原始卡片 JSON，用 \`--with-card-json\` 或 \`botmux quoted <messageId> --raw\`
 - 需要先把 JSON 读进来再做总结，不要直接把 JSON 扔给用户
 `;
 
 const QUOTED_SKILL = `---
 name: botmux-quoted
-description: 当 prompt 顶部出现 \`[用户引用了消息 用 botmux quoted om_xxx 查看]\` 提示时，用本技能按需读取被引用的那条消息内容。看到这种提示就该判断引用内容是否对当前任务必要，必要就调用，不必要就跳过。
+description: 当 prompt 顶部出现 \`[用户引用了消息 用 botmux quoted om_xxx 查看]\` 提示时，用本技能按需读取被引用的那条消息内容。看到这种提示就该判断引用内容是否对当前任务必要，必要就调用，不必要就跳过。也可对任意消息 id 使用（如从 botmux history 拿到的卡片/图片消息 id）：拉取消息全文、下载附件到本地、--raw 获取原始卡片 JSON。
 ---
 
-# botmux-quoted — 读取被引用的消息
+# botmux-quoted — 按消息 id 读取单条消息
 
 用户在飞书里使用"引用回复" UI @ 机器人时，daemon 会在喂给你的 prompt 头部加一行：
 
@@ -190,17 +198,23 @@ description: 当 prompt 顶部出现 \`[用户引用了消息 用 botmux quoted 
 
 看到这种提示，先判断引用内容是否对当前任务必要：必要就调用 \`botmux quoted om_xxx\` 拉取，不必要就忽略（不要无脑调用、污染上下文）。
 
+**不限于引用场景**：\`message_id\` 可以是任意你可见的消息 id——典型用法是从 \`botmux history\` 的输出里拿到某张卡片/图片消息的 \`messageId\`，再用本命令拉全文 + 把附件下载到本地（history 本身不下载附件）。
+
 ## 用法
 
 \`\`\`bash
 botmux quoted <message_id>
+
+# 附带原始内容：卡片消息输出 cardJson（结构化卡片 JSON，含精确字段值/按钮链接/图片 key），
+# 其它类型输出 rawContent（原始 body content）。适合告警卡等自动化解析场景。
+botmux quoted <message_id> --raw
 \`\`\`
 
-\`message_id\` 直接从提示行里复制即可。
+\`message_id\` 从提示行或 \`botmux history\` 输出里复制即可。
 
 ## 输出
 
-JSON 格式，与 \`botmux history\` 的单条消息字段一致，并附带 \`resources\` 列表：
+JSON 格式，与 \`botmux history\` 的单条消息字段一致，并附带 \`resources\` / \`attachments\` 列表：
 
 \`\`\`json
 {
@@ -210,16 +224,18 @@ JSON 格式，与 \`botmux history\` 的单条消息字段一致，并附带 \`r
   "msgType": "text|post|interactive|image|file|merge_forward_expanded",
   "content": "...",
   "createTime": "1234567890000",
-  "resources": [{"type":"image","key":"img_v3_xxx","name":"img_v3_xxx.jpg"}]
+  "resources": [{"type":"image","key":"img_v3_xxx","name":"img_v3_xxx.jpg"}],
+  "attachments": [{"type":"image","path":"~/.botmux/data/attachments/<appId>/<messageId>/img_v3_xxx.jpg","name":"img_v3_xxx.jpg"}],
+  "cardJson": { }
 }
 \`\`\`
 
 ## 注意
 
-- 图片/文件渲染成 \`[图片 N]\` / \`[文件 N: name.pdf]\` 占位符（与 \`botmux history\` 一致），实际附件 key 在 \`resources\` 列表里
-- 卡片消息会被解析成可读文本
-- 合并转发消息会自动展开
-- 当前不支持自动下载附件本地化；要看图片实际内容，目前只能让用户单独转发或 \`botmux send\` 询问
+- 图片/文件渲染成 \`[图片 N]\` / \`[文件 N: name.pdf]\` 占位符（与 \`botmux history\` 一致），序号与 \`resources\`/\`attachments\` 顺序对应
+- **附件会自动下载到本地**，路径在 \`attachments\` 列表里，用读文件工具直接查看（如报警卡里的趋势图）
+- 卡片消息会被解析成可读文本；需要机器可读的结构化数据用 \`--raw\` 拿 \`cardJson\`
+- 合并转发消息会自动展开（内嵌子卡片只有文本渲染，\`--raw\` 不覆盖子消息）
 `;
 
 const SEND_SKILL = `---

--- a/test/card-json-export.test.ts
+++ b/test/card-json-export.test.ts
@@ -18,6 +18,7 @@ import {
   createImgNumberer,
   resolveMergedCardContent,
 } from '../src/im/lark/message-parser.js';
+import { renderQuotedMessage } from '../src/cli/quoted-render.js';
 import { cleanPromptText } from '../src/dashboard/web/insights.js';
 import { BUILTIN_SKILLS } from '../src/skills/definitions.js';
 
@@ -102,6 +103,47 @@ describe('Format B button: jump URL is kept, callback buttons stay bare', () => 
     expect(result.content).toContain('[打开终端](https://t.example.com/x)');
     expect(result.content).toContain('[查看文档](https://doc.example.com/y)');
   });
+
+  it('empty-string URLs fall through to the next platform URL (not ??-swallowed)', () => {
+    const card = {
+      config: {},
+      elements: [
+        { tag: 'action', actions: [
+          { tag: 'button', text: { tag: 'plain_text', content: '多端' }, multi_url: { url: '', pc_url: 'https://pc.example/x' } },
+          { tag: 'button', text: { tag: 'plain_text', content: '行为' }, behaviors: [{ type: 'open_url', default_url: '', pc_url: 'https://pc.example/y' }] },
+          { tag: 'button', text: { tag: 'plain_text', content: '全空' }, multi_url: { url: '', pc_url: '' } },
+        ] },
+      ],
+    };
+    const result = parseApiMessage(makeMsg('interactive', card));
+    expect(result.content).toContain('[多端](https://pc.example/x)');
+    expect(result.content).toContain('[行为](https://pc.example/y)');
+    expect(result.content).toContain('[全空]');
+    expect(result.content).not.toContain('[全空](');
+  });
+});
+
+// ─── Format A button: url/multi_url on the message.list main path ─────────
+
+describe('Format A button: jump URL survives the un-resolved list view', () => {
+  it('v1 url / multi_url render as [text](url); bare buttons stay bare', () => {
+    // Simple cards (no upgrade fallback) reach `botmux history` straight from
+    // im.v1.message.list Format A without a resolve pass — the URL must
+    // survive HERE, not only in the Format B path.
+    const card = {
+      title: 'x',
+      elements: [[
+        { tag: 'button', text: '查看', url: 'https://example.com/report' },
+        { tag: 'button', text: '多端', multi_url: { url: '', pc_url: 'https://pc.example/z' } },
+        { tag: 'button', text: '回调', type: 'default' },
+      ]],
+    };
+    const result = parseApiMessage(makeMsg('interactive', card));
+    expect(result.content).toContain('[查看](https://example.com/report)');
+    expect(result.content).toContain('[多端](https://pc.example/z)');
+    expect(result.content).toContain('[回调]');
+    expect(result.content).not.toContain('[回调](');
+  });
 });
 
 // ─── Format B: img alt carried into the placeholder ───────────────────────
@@ -164,6 +206,74 @@ describe('resolveMergedCardContent: returns resources aligned with [图片 N]', 
   it('returns null when both representations fail', async () => {
     vi.mocked(getMessageDetail).mockRejectedValue(new Error('boom'));
     expect(await resolveMergedCardContent('app', 'om_card')).toBeNull();
+  });
+});
+
+// ─── quoted pipeline: merge replaces content + resources wholesale ────────
+
+describe('renderQuotedMessage: interactive merge replaces content AND resources', () => {
+  // List/API view carries the upgrade-fallback shell: a phantom img + "请升级"
+  // text. The merge pass must drop that shell resource and renumber from 1.
+  const shellMsg = {
+    message_id: 'om_card',
+    msg_type: 'interactive',
+    create_time: '1000',
+    sender: { id: 'ou_bot', sender_type: 'app' },
+    body: { content: JSON.stringify({
+      title: 'alarm',
+      elements: [[{ tag: 'img', image_key: 'img_shell' }, { tag: 'text', text: '请升级至最新版本客户端，以查看内容' }]],
+    }) },
+  };
+  const noExpand = async () => ({ extraResources: [] });
+
+  it('numbered [图片 N] aligns with merged.resources; shell image is dropped; structured JSON surfaced', async () => {
+    const structured = JSON.stringify({
+      config: {},
+      elements: [
+        { tag: 'img', img_key: 'img_curve_a', alt: { tag: 'plain_text', content: '同比A' } },
+        { tag: 'img', img_key: 'img_curve_b', alt: { tag: 'plain_text', content: '同比B' } },
+      ],
+    });
+    const resolveStub = async (_app: string, _id: string, numberer: ReturnType<typeof createImgNumberer>) => {
+      // Mirror resolveMergedCardContent's ordering contract: resources first,
+      // then text reuses the numbers.
+      const resources = [
+        { type: 'image' as const, key: 'img_curve_a', name: 'img_curve_a.jpg' },
+        { type: 'image' as const, key: 'img_curve_b', name: 'img_curve_b.jpg' },
+      ];
+      for (const r of resources) numberer.assign(`image:${r.key}`);
+      const text = `[图片 ${numberer.assign('image:img_curve_a').num}: 同比A]\n[图片 ${numberer.assign('image:img_curve_b').num}: 同比B]`;
+      return { text, structuredContent: structured, resources };
+    };
+
+    const rendered = await renderQuotedMessage('app', shellMsg, noExpand, resolveStub);
+    expect(rendered.content).toBe('[图片 1: 同比A]\n[图片 2: 同比B]');
+    expect(rendered.resources).toEqual([
+      { type: 'image', key: 'img_curve_a', name: 'img_curve_a.jpg' },
+      { type: 'image', key: 'img_curve_b', name: 'img_curve_b.jpg' },
+    ]);
+    expect(rendered.resources.map(r => r.key)).not.toContain('img_shell');
+    expect(rendered.mergedStructuredContent).toBe(structured);
+  });
+
+  it('merge failure keeps the pre-merge render and resources (no structured JSON)', async () => {
+    const rendered = await renderQuotedMessage('app', shellMsg, noExpand, async () => null);
+    expect(rendered.resources).toEqual([{ type: 'image', key: 'img_shell', name: 'img_shell.jpg' }]);
+    expect(rendered.mergedStructuredContent).toBeUndefined();
+  });
+
+  it('end-to-end with the real resolver: numbering restarts at 1 aligned with resources', async () => {
+    const structuredB = JSON.stringify({
+      config: {},
+      elements: [{ tag: 'img', img_key: 'img_real', alt: { tag: 'plain_text', content: '曲线' } }],
+    });
+    vi.mocked(getMessageDetail).mockImplementation(async (_app: string, _id: string, opts?: { userCardContent?: boolean }) => ({
+      items: [{ body: { content: opts?.userCardContent === false ? shellMsg.body.content : structuredB } }],
+    }));
+    const rendered = await renderQuotedMessage('app', shellMsg, noExpand, resolveMergedCardContent);
+    expect(rendered.content).toContain('[图片 1: 曲线]');
+    expect(rendered.resources).toEqual([{ type: 'image', key: 'img_real', name: 'img_real.jpg' }]);
+    expect(rendered.mergedStructuredContent).toBe(structuredB);
   });
 });
 

--- a/test/card-json-export.test.ts
+++ b/test/card-json-export.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for the card structured-data export + render fixes
+ * (quoted --raw / history --with-card-json / a-node URL dedup /
+ *  button open_url / img alt).
+ *
+ * Shapes mirror REAL Argos alarm cards captured live (2026-07-15):
+ *  - Format A `a` nodes for bare long URLs come back with text === href, both
+ *    cut at the same offset, remainder spilling into following text nodes.
+ *  - v2 buttons carry behaviors [{type:'open_url', default_url}]; callback
+ *    buttons have no URL.
+ *  - v1 img elements carry alt: {tag:'plain_text', content:'报警前30分钟…'}.
+ *
+ * Run:  pnpm vitest run test/card-json-export.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  parseApiMessage,
+  createImgNumberer,
+  resolveMergedCardContent,
+} from '../src/im/lark/message-parser.js';
+import { cleanPromptText } from '../src/dashboard/web/insights.js';
+import { BUILTIN_SKILLS } from '../src/skills/definitions.js';
+
+vi.mock('../src/im/lark/client.js', () => ({
+  getMessageDetail: vi.fn(),
+}));
+import { getMessageDetail } from '../src/im/lark/client.js';
+
+function makeMsg(msgType: string, content: object | string) {
+  return {
+    message_id: 'om_test',
+    msg_type: msgType,
+    create_time: '1000',
+    sender: { id: 'ou_sender', sender_type: 'user' },
+    body: { content: typeof content === 'string' ? content : JSON.stringify(content) },
+  };
+}
+
+// ─── Format A: bare long URL split across a-node + text remainders ────────
+
+describe('Format A a-node: text === href dedup (Argos Kibana 处理建议 URL)', () => {
+  const HEAD = "https://kibana.example.net/app/discover#/?_g=(filters:!(),index:'system_east-";
+  const REST1 = "*',key:service,negate:!f),query:(match_phrase:(service:gateway)))";
+
+  it('emits a single copy so join() reconstructs the full URL from remainder nodes', () => {
+    const card = {
+      title: 'alarm',
+      elements: [[
+        { tag: 'text', text: '[ 处理建议 ]：' },
+        { tag: 'a', text: HEAD, href: HEAD },
+        { tag: 'text', text: REST1 },
+      ]],
+    };
+    const result = parseApiMessage(makeMsg('interactive', card));
+    expect(result.content).toContain(`[ 处理建议 ]：${HEAD}${REST1}`);
+    // The doubled `url(url)` form must be gone.
+    expect(result.content).not.toContain(`${HEAD}(${HEAD}`);
+  });
+
+  it('keeps text(href) for genuine labeled links', () => {
+    const card = {
+      title: 'alarm',
+      elements: [[
+        { tag: 'a', text: '[点击查看详情]', href: 'https://argos.example.net/detail/1' },
+      ]],
+    };
+    const result = parseApiMessage(makeMsg('interactive', card));
+    expect(result.content).toContain('[点击查看详情](https://argos.example.net/detail/1)');
+  });
+});
+
+// ─── Format B: button open_url across schema generations ──────────────────
+
+describe('Format B button: jump URL is kept, callback buttons stay bare', () => {
+  it('v2 behaviors open_url → [text](url); callback → [text]', () => {
+    const card = {
+      config: {},
+      elements: [
+        { tag: 'action', actions: [
+          { tag: 'button', text: { tag: 'plain_text', content: '深度分析' }, behaviors: [{ type: 'callback' }] },
+          { tag: 'button', text: { tag: 'plain_text', content: '分析报告' }, behaviors: [{ type: 'open_url', default_url: 'http://argos.example.net/report/1' }] },
+        ] },
+      ],
+    };
+    const result = parseApiMessage(makeMsg('interactive', card));
+    expect(result.content).toContain('[深度分析]');
+    expect(result.content).not.toContain('[深度分析](');
+    expect(result.content).toContain('[分析报告](http://argos.example.net/report/1)');
+  });
+
+  it('v1 url and multi_url variants are honored', () => {
+    const card = {
+      config: {},
+      elements: [
+        { tag: 'action', actions: [
+          { tag: 'button', text: { tag: 'plain_text', content: '打开终端' }, multi_url: { url: 'https://t.example.com/x', pc_url: '' } },
+          { tag: 'button', text: { tag: 'plain_text', content: '查看文档' }, url: 'https://doc.example.com/y' },
+        ] },
+      ],
+    };
+    const result = parseApiMessage(makeMsg('interactive', card));
+    expect(result.content).toContain('[打开终端](https://t.example.com/x)');
+    expect(result.content).toContain('[查看文档](https://doc.example.com/y)');
+  });
+});
+
+// ─── Format B: img alt carried into the placeholder ───────────────────────
+
+describe('Format B img alt: chart description survives into the placeholder', () => {
+  const card = {
+    config: {},
+    elements: [
+      { tag: 'img', img_key: 'img_chart_1', alt: { tag: 'plain_text', content: '报警前30分钟今(红)昨(蓝)同比' } },
+      { tag: 'img', img_key: 'img_plain_2', alt: { tag: 'plain_text', content: '' } },
+    ],
+  };
+
+  it('with numberer: [图片 N: alt]; empty alt keeps the bare placeholder', () => {
+    const numberer = createImgNumberer();
+    const result = parseApiMessage(makeMsg('interactive', card), numberer);
+    expect(result.content).toContain('[图片 1: 报警前30分钟今(红)昨(蓝)同比]');
+    expect(result.content).toContain('[图片 2]');
+    expect(result.content).not.toContain('[图片 2:');
+  });
+
+  it('without numberer: [图片: alt]', () => {
+    const result = parseApiMessage(makeMsg('interactive', card));
+    expect(result.content).toContain('[图片: 报警前30分钟今(红)昨(蓝)同比]');
+  });
+});
+
+// ─── resolveMergedCardContent: resources surfaced, numbered before text ───
+
+describe('resolveMergedCardContent: returns resources aligned with [图片 N]', () => {
+  beforeEach(() => {
+    vi.mocked(getMessageDetail).mockReset();
+  });
+
+  const structuredB = JSON.stringify({
+    config: {},
+    elements: [
+      { tag: 'div', text: { tag: 'lark_md', content: '**分析结论**' } },
+      { tag: 'img', img_key: 'img_curve', alt: { tag: 'plain_text', content: '同比曲线' } },
+    ],
+  });
+  const simplifiedA = JSON.stringify({
+    title: 'alarm',
+    elements: [[{ tag: 'text', text: '分析结论' }], [{ tag: 'img', image_key: 'img_curve' }]],
+  });
+
+  it('exposes structuredContent + resources; shared numberer keeps text/resource numbers aligned', async () => {
+    vi.mocked(getMessageDetail).mockImplementation(async (_app: string, _id: string, opts?: { userCardContent?: boolean }) => ({
+      items: [{ body: { content: opts?.userCardContent === false ? simplifiedA : structuredB } }],
+    }));
+    const numberer = createImgNumberer();
+    const merged = await resolveMergedCardContent('app', 'om_card', numberer);
+    expect(merged).not.toBeNull();
+    expect(merged!.structuredContent).toBe(structuredB);
+    expect(merged!.resources).toEqual([{ type: 'image', key: 'img_curve', name: 'img_curve.jpg' }]);
+    // Resources were numbered BEFORE text extraction → placeholder is [图片 1].
+    expect(merged!.text).toContain('[图片 1: 同比曲线]');
+  });
+
+  it('returns null when both representations fail', async () => {
+    vi.mocked(getMessageDetail).mockRejectedValue(new Error('boom'));
+    expect(await resolveMergedCardContent('app', 'om_card')).toBeNull();
+  });
+});
+
+// ─── insights cleanPromptText tolerates the alt suffix ────────────────────
+
+describe('cleanPromptText: strips [图片 N: alt] placeholder lines', () => {
+  it('placeholder with alt suffix is removed like the bare form', () => {
+    const out = cleanPromptText('看这个\n[图片 1: 报警前30分钟今(红)昨(蓝)同比] 其余\n[文件 2: spec.pdf] x\n正文');
+    expect(out).not.toContain('图片 1');
+    expect(out).not.toContain('文件 2');
+    expect(out).toContain('正文');
+  });
+});
+
+// ─── skill docs teach the new flags ───────────────────────────────────────
+
+describe('builtin skill docs: card JSON export + attachment guidance', () => {
+  it('botmux-history documents --with-card-json, resources and the quoted handoff', () => {
+    const history = BUILTIN_SKILLS.find(s => s.name === 'botmux-history')!;
+    expect(history.content).toContain('--with-card-json');
+    expect(history.content).toContain('resources');
+    expect(history.content).toContain('botmux quoted <messageId>');
+  });
+
+  it('botmux-quoted documents --raw, auto-download and any-message-id usage', () => {
+    const quoted = BUILTIN_SKILLS.find(s => s.name === 'botmux-quoted')!;
+    expect(quoted.content).toContain('--raw');
+    expect(quoted.content).toContain('cardJson');
+    expect(quoted.content).toContain('附件会自动下载到本地');
+    expect(quoted.content).toContain('任意');
+    expect(quoted.content).not.toContain('当前不支持自动下载');
+  });
+});


### PR DESCRIPTION
## 背景

用户（梁志浩）搭建告警自动化分析时反馈：`botmux history` 读飞书卡片只能拿到文本渲染，原始卡片 JSON 得绕道 larkcli 按 id 再拉一次，链路不顺。结合真实 Argos 报警卡片排查，本 PR 补齐卡片的结构化数据出口，并顺手修掉三处渲染丢信息。

## 改了什么

**1️⃣ 卡片原始 JSON 出口**
- `botmux quoted <om_id> --raw`：interactive 消息输出 `cardJson`（完整结构化卡片 JSON），其它类型输出 `rawContent`（原始 body content）
- `botmux history --with-card-json`：每张卡片都 resolve 并附 `cardJson`
- 实现上零新增请求：`resolveMergedCardContent` 本就拿到了 `structuredContent`，之前在 CLI 层被丢弃

**2️⃣ history 消息附 `resources` + 文档指路**
- history 每条消息现在带 `resources`（key+name，不下载），编号与正文 `[图片 N]` 对齐（资源先编号、文本复用，同 `parseEventMessage`/`buildForwardedTree` 契约）
- merge_forward 展开时收集的 `extraResources` 之前被直接丢弃，现在露出
- 输出带 `hint` 提示：任意 om_id 都能用 `botmux quoted` 拉全文+下载附件（此能力一直存在但没有文档）
- 修正 botmux-quoted skill 文档过时内容（「不支持自动下载附件」实际早已支持），补 `--raw`/`--with-card-json` 用法
- ⭐ 修掉一个隐蔽噪音：复杂卡片 list 视图的「请升级客户端」壳图会混进 resources（resolve 成功时用独立 numberer 整体替换 resources 解决，编号从 1 与替换后的文本对齐）

**3️⃣ 渲染丢信息三修（message-parser）**
- **长 URL 复原**：Format A 裸长 URL 被 Lark 切成 `a` 节点（text===href 同截断点）+ 后续 text 余段，原渲染 `text(href)` 把截断 URL 翻倍成乱码；现在 text===href 时只输出一份，`join('')` 自动拼回完整 URL（实测 Argos Kibana 处理建议链接 773 字符完整复原）
- **按钮跳转链接保留**：v1 `url`/`multi_url.url`、v2 `behaviors open_url` 的按钮渲染成 `[文字](url)`（如 Argos `[分析报告](http://aiops-argos...)`）；callback 按钮无 URL 保持 `[文字]`
- **img alt 保留**：`[图片 2: 报警前30分钟今(红)昨(蓝)同比]`——图表的 alt 常是图片内容唯一的机器可读描述

## 影响面评估

- **message-parser 为共用层**：渲染三修影响所有读卡片文本的路径（live 事件 prompt、history、quoted、merge_forward 展开、dashboard 会话历史弹窗）。均为增量信息（原来丢的现在保留），无格式收窄
- `[图片 N: alt]` 占位符消费方核过：`isPureCardUpgradeFallback` 用 `[^\]]*` 宽松匹配天然兼容；`insights.ts cleanPromptText` 正则已同步放宽（本 PR 内）
- `resolveMergedCardContent` 返回类型加宽（新增 `resources` 字段），全部调用点核过：`resolveEventCard`/`dashboard-ipc-server` 只取 `.text`/`.structuredContent`，不受影响
- **按钮 URL 与安全**：写终端链接（`?token=`）只出现在 ephemeral「仅你可见」卡或 DM 兜底卡，群历史枚举不到；群内会话卡按钮是只读链接无 token。且卡片 `a` 节点/markdown 链接本就保留 URL，按钮补齐与现行策略一致
- 不涉及跨 CLI 适配器、后端（Pty/Tmux）、sandbox 路径

## 测试验证

- `pnpm build` 绿；新增 `test/card-json-export.test.ts` 11 tests 单跑绿（真实 Argos 卡片节点形态做 fixture）
- 相关既有套件绿：message-parser(69) / builtin-skills(17) / merge-forward + forwarded-renderer + download-resources + event-dispatcher(212)
- 全量 vitest 见评论
- **真实消息端到端实测**（本会话所在话题）：
  - `quoted om_xxx --raw` → `cardJson` schema 2.0 完整结构 ✅；文本消息 → `rawContent` ✅
  - `history --with-card-json` → 每张卡 `cardJson` ✅、壳图噪音消失 ✅
  - merge_forward 3 张 Argos 趋势图 resources 露出、`[图片 1..3: 报警前30分钟今(红)昨(蓝)同比]` 编号+alt 对齐 ✅
  - Kibana 长链接（含引号括号）渲染为单份完整 URL ✅；`[分析报告](http://aiops-argos...)` 按钮链接保留 ✅
