### PR TITLE
feat(im): 消息读取带上服务端发送者名称（with_sender_name=true）

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -481,6 +481,9 @@ ipcRoute('GET', '/api/sessions/:sessionId/history', async (req, res, params) => 
         messageId: parsed.messageId,
         senderId: parsed.senderId,
         senderType: parsed.senderType,
+        // 服务端返回的发送者名（with_sender_name=true，bot 也有）。enrich 阶段
+        // 本地花名册/contact 解析不到时兜底用它——第三方 bot 不再是一串 open_id。
+        ...(parsed.senderName ? { senderName: parsed.senderName } : {}),
         msgType: parsed.msgType,
         content: parsed.content,
         // Lark create_time 是毫秒 epoch 字符串——规范成数字，前端 new Date 直接用

--- a/src/dashboard/history-senders.ts
+++ b/src/dashboard/history-senders.ts
@@ -2,6 +2,9 @@ export interface HistoryMessage {
   messageId: string;
   senderId: string;
   senderType: string;
+  /** Server-provided display name (`with_sender_name=true` read APIs). Used as
+   *  the fallback when local rosters / contact profiles can't name the sender. */
+  senderName?: string;
   msgType: string;
   content: string;
   createTime?: number;

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -671,6 +671,10 @@ export async function getMessageDetail(
   const userCardContent = options.userCardContent ?? true;
   const res = await larkGet(c, `/open-apis/im/v1/messages/${encodeURIComponent(messageId)}`, {
     ...(userCardContent ? { card_msg_content_type: 'user_card_content' } : {}),
+    // Opt into server-side sender names (sender_name / sender_i18n_names, for
+    // user AND bot senders); without it the server omits them. Matters here for
+    // merge_forward sub-messages, whose senders appear nowhere else.
+    with_sender_name: 'true',
   });
   if (res.code !== 0) {
     throw new Error(`Failed to get message: ${res.msg} (code: ${res.code})`);
@@ -1014,6 +1018,7 @@ async function listByThread(c: any, threadId: string, pageSize: number): Promise
       container_id: threadId,
       page_size: unlimited ? LARK_MESSAGE_LIST_MAX_PAGE : Math.min(pageSize, LARK_MESSAGE_LIST_MAX_PAGE),
       sort_type: 'ByCreateTimeAsc',
+      with_sender_name: 'true',
       ...(pageToken ? { page_token: pageToken } : {}),
     });
 
@@ -1052,6 +1057,7 @@ export async function listChatMessages(
       container_id: chatId,
       page_size: unlimited ? LARK_MESSAGE_LIST_MAX_PAGE : Math.min(pageSize, LARK_MESSAGE_LIST_MAX_PAGE),
       sort_type: 'ByCreateTimeDesc',
+      with_sender_name: 'true',
       ...(pageToken ? { page_token: pageToken } : {}),
     });
 
@@ -1100,6 +1106,7 @@ export async function listChatMessagesUntil(
       container_id: chatId,
       page_size: pageSize,
       sort_type: 'ByCreateTimeDesc',
+      with_sender_name: 'true',
       ...(pageToken ? { page_token: pageToken } : {}),
     });
 
@@ -1188,6 +1195,7 @@ async function listByChatFilter(c: any, chatId: string, rootMessageId: string, p
       container_id: chatId,
       page_size: unlimited ? LARK_MESSAGE_LIST_MAX_PAGE : Math.min(pageSize, LARK_MESSAGE_LIST_MAX_PAGE),
       sort_type: 'ByCreateTimeDesc',
+      with_sender_name: 'true',
       ...(pageToken ? { page_token: pageToken } : {}),
     });
 

--- a/src/im/lark/merge-forward.ts
+++ b/src/im/lark/merge-forward.ts
@@ -103,6 +103,11 @@ export async function buildForwardedTree(
         : msg.sender?.sender_type === 'user' ? 'user'
         : 'unknown';
       const senderOpenId = msg.sender?.id ?? '';
+      // Server-side name from with_sender_name=true on the parent fetch — the
+      // only name source for forwarded senders (they may not be in this chat).
+      const senderName = typeof msg.sender?.sender_name === 'string' && msg.sender.sender_name.trim()
+        ? msg.sender.sender_name.trim()
+        : undefined;
 
       // userCardContent:true above usually delivers the real card. Fallback
       // path (false) leaves the simplified shape; we still try user_dsl
@@ -123,10 +128,10 @@ export async function buildForwardedTree(
 
       if (msg.msg_type === 'merge_forward' && depth < maxDepth) {
         const inner = walk(msg.message_id, depth + 1);
-        nodes.push({ senderOpenId, senderType, children: inner });
+        nodes.push({ senderOpenId, senderType, ...(senderName ? { senderName } : {}), children: inner });
       } else {
         const sub = parseApiMessage(msg, numberer);
-        nodes.push({ senderOpenId, senderType, content: sub.content });
+        nodes.push({ senderOpenId, senderType, ...(senderName ? { senderName } : {}), content: sub.content });
       }
     }
     return nodes;

--- a/src/im/lark/message-parser.ts
+++ b/src/im/lark/message-parser.ts
@@ -419,11 +419,18 @@ export function parseEventMessage(data: RawEventData): { parsed: LarkMessage; re
 export function parseApiMessage(msg: any, numberer?: ImgNumberer): LarkMessage {
   const msgType = msg.msg_type ?? 'text';
   const rawContent = msg.body?.content ?? '';
+  // sender_name is only present when the fetch opted in via with_sender_name=true
+  // (all client.ts message read paths do). Covers bot senders too — the one case
+  // local rosters can't resolve for third-party bots.
+  const senderName = typeof msg.sender?.sender_name === 'string' && msg.sender.sender_name.trim()
+    ? msg.sender.sender_name.trim()
+    : undefined;
   return {
     messageId: msg.message_id ?? '',
     rootId: msg.root_id ?? msg.thread_id ?? '',
     senderId: msg.sender?.id ?? '',
     senderType: msg.sender?.sender_type ?? 'unknown',
+    ...(senderName ? { senderName } : {}),
     msgType,
     content: extractTextContent(msgType, normalizeApiMessageContent(msgType, rawContent), undefined, numberer),
     createTime: msg.create_time ?? '',

--- a/src/types.ts
+++ b/src/types.ts
@@ -250,6 +250,10 @@ export interface LarkMessage {
    *  messages). */
   senderUnionId?: string;
   senderType: string;
+  /** Server-provided sender display name (works for user AND bot senders).
+   *  Only populated on API-fetched messages read with `with_sender_name=true`
+   *  (history/quoted paths); live receive_v1 events don't carry it. */
+  senderName?: string;
   msgType: string;
   content: string;
   createTime: string;

--- a/test/dashboard-history-senders.test.ts
+++ b/test/dashboard-history-senders.test.ts
@@ -37,6 +37,32 @@ describe('dashboard history sender enrichment', () => {
     expect(message).not.toHaveProperty('senderAvatar');
   });
 
+  it('keeps the server-provided senderName when local rosters cannot resolve the sender', () => {
+    const out = enrichHistorySenders(
+      [
+        // Third-party bot not in bots.json / observed roster — server name survives.
+        { messageId: 'm1', senderId: 'ou_foreign_bot', senderType: 'app', msgType: 'text', content: 'x', senderName: 'ForeignBot' },
+        // Human outside the app's visible range (contact lookup returned null).
+        { messageId: 'm2', senderId: 'ou_stranger', senderType: 'user', msgType: 'text', content: 'y', senderName: '张三' },
+      ],
+      new Map([['ou_stranger', null]]),
+      [],
+      [],
+    );
+    expect(out[0]).toMatchObject({ senderName: 'ForeignBot' });
+    expect(out[1]).toMatchObject({ senderName: '张三' });
+  });
+
+  it('prefers the locally-resolved name over the server-provided one', () => {
+    const [message] = enrichHistorySenders(
+      [{ messageId: 'm1', senderId: 'ou_bot', senderType: 'app', msgType: 'text', content: 'x', senderName: 'ServerName' }],
+      new Map(),
+      [{ openId: 'ou_bot', displayName: 'Local Display', larkAppId: 'cli_x' }],
+      [{ larkAppId: 'cli_x', botName: 'Local Display', botAvatarUrl: 'https://img/x' }],
+    );
+    expect(message).toMatchObject({ senderName: 'Local Display' });
+  });
+
   it('resolves app senders that Lark history identifies by stable cli app id', () => {
     const [message] = enrichHistorySenders(
       [{ messageId: 'm1', senderId: 'cli_peer', senderType: 'app', msgType: 'text', content: 'done' }],

--- a/test/merge-forward.test.ts
+++ b/test/merge-forward.test.ts
@@ -57,6 +57,25 @@ describe('expandMergeForward: flat tree', () => {
     expect(parsed.content).toContain('<msg from="A">again</msg>');
     expect(extraResources).toEqual([]);
   });
+
+  it('carries server-provided sender_name into participant name attrs', async () => {
+    getMessageDetailMock.mockResolvedValueOnce({
+      items: [
+        { message_id: 'om_a', upper_message_id: 'om_root', msg_type: 'text',
+          sender: { id: 'ou_alice', sender_type: 'user', sender_name: '爱丽丝' },
+          body: { content: JSON.stringify({ text: 'hi' }) } },
+        { message_id: 'om_b', upper_message_id: 'om_root', msg_type: 'text',
+          sender: { id: 'ou_bot', sender_type: 'app', sender_name: 'CoCo' },
+          body: { content: JSON.stringify({ text: 'beep' }) } },
+      ],
+    });
+
+    const parsed = fakeParsed();
+    await expandMergeForward('app_test', 'om_root', parsed);
+
+    expect(parsed.content).toContain('<p id="A" open_id="ou_alice" type="user" name="爱丽丝" />');
+    expect(parsed.content).toContain('<p id="B" open_id="ou_bot" type="app" name="CoCo" />');
+  });
 });
 
 describe('expandMergeForward: nested merge_forward', () => {

--- a/test/message-parser.test.ts
+++ b/test/message-parser.test.ts
@@ -41,6 +41,21 @@ describe('parseApiMessage metadata', () => {
     });
     expect(result.rootId).toBe('omt_thread');
   });
+
+  it('surfaces server-provided sender_name (with_sender_name=true reads)', () => {
+    const msg = makeMsg('text', { text: 'hi' });
+    msg.sender = { id: 'ou_bot', sender_type: 'app', sender_name: 'Premium(Claude)' } as any;
+    const result = parseApiMessage(msg);
+    expect(result.senderName).toBe('Premium(Claude)');
+    expect(result.senderType).toBe('app');
+  });
+
+  it('omits senderName when the server supplies none or blank', () => {
+    expect(parseApiMessage(makeMsg('text', { text: 'hi' })).senderName).toBeUndefined();
+    const blank = makeMsg('text', { text: 'hi' });
+    blank.sender = { id: 'ou_x', sender_type: 'user', sender_name: '  ' } as any;
+    expect(parseApiMessage(blank).senderName).toBeUndefined();
+  });
 });
 
 // ─── Interactive card: Format A (Lark API simplified) ─────────────────────


### PR DESCRIPTION
## 改了什么

lark-cli v1.0.69 的 [#1829](https://github.com/larksuite/cli/pull/1829) 揭示了一个服务端 API 能力：消息 list/get 带 `with_sender_name=true` 时，服务端直接返回发送者显示名（**user 和 bot 都给**）。本 PR 让 botmux 的 API 读消息路径全部用上：

- `src/im/lark/client.ts`：5 个消息读取调用点（`listByThread` / `listChatMessages` / `listChatMessagesUntil` / `listByChatFilter` / `getMessageDetail`）统一带上 `with_sender_name=true`
- `src/im/lark/message-parser.ts`：`parseApiMessage` 读取 `sender.sender_name`，透出为可选字段 `senderName`（空白视为无）
- `src/types.ts`：`LarkMessage` 增加可选 `senderName`
- `src/im/lark/merge-forward.ts`：合并转发展开时把 `sender_name` 填进 `ForwardedNode.senderName` —— 渲染器的 `<p name=…>` 支持早就存在，之前一直没有数据源
- dashboard 会话历史（`dashboard-ipc-server.ts` + `history-senders.ts`）：服务端名字随消息透传，本地花名册 / contact 解析不到时兜底用它；**本地解析到的名字优先级不变**（`...message` 展开在前，本地名仅在存在时覆盖）

## 为什么

之前 `botmux history` / `quoted` / 合并转发展开的输出里发送者只有 open_id + sender_type：
- 人类名字要靠额外调 contact API（依赖 contact scope，不在可见范围还查不到）
- bot 名字只有 bots.json / 观察名册里认识的自家 bot 有，第三方 bot 是一串裸 id——多 bot 群里 agent 读上下文分不清谁说的

现在服务端一把给全，第三方 bot 也有名字，还省 contact 往返。

## 影响面

仅 **API 读消息路径**（history / quoted / 合并转发展开 / dashboard 会话历史）。实时事件路径（`receive_v1`）不带 `sender_name`，不受影响；daemon 现有 contact / 花名册解析逻辑原样保留，服务端名字只作补充。`senderName` 为可选字段，纯增量，旧消费方无感。

跨 CLI / 跨后端无涉——改动都在 Lark API 读链路和纯函数渲染层。

## 测试验证

- `pnpm build` ✅
- 新增单测 6 个，全绿：
  - `parseApiMessage` 透出 sender_name / 空白时省略（message-parser.test.ts）
  - 合并转发 participants 带 name 属性（merge-forward.test.ts）
  - dashboard enrich：本地解析不到时保留服务端名、本地名优先（dashboard-history-senders.test.ts）
- `npx vitest run` 定向 4 个受影响文件：94/94 通过
- 全量 `pnpm test`：8261 passed / 5 failed——失败的 5 个（scheduler 时区 ×3、dashboard popover、restore limit session）在干净 master 上同样失败，与本 PR 无关（已用 `git stash` 对照验证）
- **live 实测**：用本分支构建直接跑 `node dist/cli.js history --limit 4` 打真实 Lark API——bot 消息（sender id 为 `cli_a9f66d03be385ceb`，本地花名册无法匹配的形态）返回 `"senderName": "Premium(Claude)"`，用户消息返回 `"senderName": "申晗"`，未调用 contact API