### PR TITLE
fix(runtime): 恢复会话 owner 并隔离 tmux 环境

### DIFF
--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -10,15 +10,34 @@ import { logger } from '../../utils/logger.js';
 import { isExecutable } from '../../utils/executable.js';
 
 /**
+ * Botmux-owned per-session variables must never leak from the shared tmux
+ * server's global environment into a new pane. Every fresh pane unsets them
+ * first, then `/usr/bin/env KEY=VAL ...` injects this session's current values.
+ */
+const BOTMUX_MANAGED_SESSION_ENV_KEYS = [
+  '__OWNER_OPEN_ID',
+  'BOTMUX_SESSION_ID',
+  'BOTMUX_CHAT_ID',
+  'BOTMUX_LARK_APP_ID',
+  'BOTMUX_ROOT_MESSAGE_ID',
+  'BOTMUX_TURN_ID',
+] as const;
+
+/**
  * `unset KEY KEY ...` clause spliced into the shell wrapper before exec. The
  * new tmux pane inherits the tmux *server's* global environment, which the
  * (redacted) client env can't override — so if the server was ever started
  * with bare LARK_APP_* in scope (pre-upgrade botmux, or the user's own tmux),
- * those values reach the CLI despite redactChildEnv(). Unsetting them in the
- * wrapper shell removes them for this pane only, without touching the server
- * global env. Key names are fixed identifiers — no shell-escaping needed.
+ * those values reach the CLI despite redactChildEnv(). It can also inherit
+ * stale botmux session identity from another pane on the shared server (owner,
+ * session/chat/thread/turn ids). Unsetting them in the wrapper shell removes
+ * them for this pane only, without touching the server global env. Key names are
+ * fixed identifiers — no shell-escaping needed.
  */
-const REDACTED_ENV_UNSET_CLAUSE = `unset ${REDACTED_CHILD_ENV_KEYS.join(' ')}`;
+const REDACTED_ENV_UNSET_CLAUSE = `unset ${[
+  ...REDACTED_CHILD_ENV_KEYS,
+  ...BOTMUX_MANAGED_SESSION_ENV_KEYS,
+].join(' ')}`;
 
 /**
  * TmuxBackend — session backend using tmux for process persistence.

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -1069,6 +1069,7 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
       lastMessageAt: sessionLastMessageAtMs(session),
       hasHistory: true,  // restored sessions have prior CLI history
       workingDir: session.workingDir,
+      ownerOpenId: session.ownerOpenId,
       // Restore persisted streaming-card state — next screen_update will PATCH
       // the existing card instead of POSTing a fresh one. If the card was
       // withdrawn while we were down, the PATCH fails with MessageWithdrawnError

--- a/test/session-resume.test.ts
+++ b/test/session-resume.test.ts
@@ -332,6 +332,22 @@ describe('resumeSession', () => {
       expect(restoreUsageLimitRuntimeState).toHaveBeenCalledWith(ds);
     });
 
+    it('restores ownerOpenId for active historical sessions after daemon restart', async () => {
+      const s = sessionStore.createSession('oc_chat_owner', 'om_owner', 'Owner topic');
+      s.larkAppId = 'app_test';
+      s.scope = 'thread';
+      s.workingDir = '/tmp/proj';
+      s.ownerOpenId = 'ou_owner_restore';
+      sessionStore.updateSession(s);
+      const map = new Map<string, DaemonSession>();
+
+      await restoreActiveSessions(map);
+
+      const ds = map.get(sessionKey('om_owner', 'app_test'));
+      expect(ds).toBeDefined();
+      expect(ds!.ownerOpenId).toBe('ou_owner_restore');
+    });
+
     it('flips status back to active, clears closedAt, and registers in the Map (thread-scope)', async () => {
       const closed = makeClosedSession({ rootMessageId: 'om_threadA' });
       (closed as any).lastUserPrompt = '继续修复限额后的任务';

--- a/test/tmux-backend-env.test.ts
+++ b/test/tmux-backend-env.test.ts
@@ -553,6 +553,41 @@ describe('shell wrapper end-to-end (the contract spawn() builds)', () => {
     },
   );
 
+  it.skipIf(!hasEnvBin)(
+    'clears stale botmux-managed session variables before injecting current pane values',
+    () => {
+      const result = spawnSync(
+        '/bin/sh',
+        ['-c', SCRIPT, '_',
+          tmpdir(),
+          'BOTMUX_SESSION_ID=fresh-session',
+          '/usr/bin/env',
+        ],
+        {
+          encoding: 'utf-8',
+          env: {
+            PATH: '/usr/bin:/bin',
+            __OWNER_OPEN_ID: 'stale-owner',
+            BOTMUX_SESSION_ID: 'stale-session',
+            BOTMUX_CHAT_ID: 'stale-chat',
+            BOTMUX_LARK_APP_ID: 'stale-app',
+            BOTMUX_ROOT_MESSAGE_ID: 'stale-root',
+            BOTMUX_TURN_ID: 'stale-turn',
+          },
+        },
+      );
+
+      expect(result.status).toBe(0);
+      const lines = result.stdout.split('\n');
+      expect(lines).toContain('BOTMUX_SESSION_ID=fresh-session');
+      expect(lines).not.toContain('__OWNER_OPEN_ID=stale-owner');
+      expect(lines).not.toContain('BOTMUX_CHAT_ID=stale-chat');
+      expect(lines).not.toContain('BOTMUX_LARK_APP_ID=stale-app');
+      expect(lines).not.toContain('BOTMUX_ROOT_MESSAGE_ID=stale-root');
+      expect(lines).not.toContain('BOTMUX_TURN_ID=stale-turn');
+    },
+  );
+
   const hasTmux = !spawnSync('tmux', ['-V']).error;
   it.skipIf(!hasEnvBin || !hasTmux)(
     'tmux child does NOT inherit bare LARK_APP_* from a server started with them in scope (Codex repro)',


### PR DESCRIPTION
## 改了什么

- 修复 `restoreActiveSessions` 普通历史会话恢复分支漏填 `ownerOpenId` 的问题，和 queued / resume 分支保持一致。
- 在 tmux 新 pane 的 shell wrapper 启动前清理 botmux 管理的 session 环境变量，再注入当前 session 值，避免共享 tmux server 中遗留变量串到新会话。
- 增加两个回归测试：
  - 普通历史 session restore 后保留 `ownerOpenId`。
  - tmux wrapper 清理旧的 botmux session env，并保留当前 pane 注入值。

## 为什么

持久化会话在 daemon 重启后恢复时，如果 `DaemonSession.ownerOpenId` 丢失，后续 worker init 就无法恢复 `__OWNER_OPEN_ID`。在 tmux 共享 server 场景下，新 pane 还可能继承其他会话遗留的 owner/session 环境变量，影响依赖 session owner 的 wrapper、凭证隔离、审计归属和审批识别。

## 影响面

- 影响普通历史 active session 的 daemon restart restore 路径。
- 影响 tmux backend 新建 pane 的环境清理逻辑。
- queued、resume、adopt 分支已有 owner 恢复逻辑，本次保持一致性。
- PTY / zellij / herdr 后端未改动。

## 验证

```bash
pnpm vitest run --project unit test/session-resume.test.ts test/tmux-backend-env.test.ts && pnpm build
```

结果：

- `test/session-resume.test.ts`：15/15 passed
- `test/tmux-backend-env.test.ts`：42/42 passed
- 总计：57/57 passed
- `pnpm build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)
