### PR TITLE
feat(herdr): 切换原生终端流

### DIFF
--- a/src/adapters/backend/herdr-backend.ts
+++ b/src/adapters/backend/herdr-backend.ts
@@ -112,7 +112,7 @@ export class HerdrBackend implements SessionBackend {
   private observerBuffer = '';
   private streamDecoder = new StringDecoder('utf8');
   private lastFrameSeq = 0;
-  private dropInitialFullFrame = false;
+  private pendingData = '';
   private readonly dataCbs: Array<(d: string) => void> = [];
   private readonly exitCbs: Array<(code: number | null, signal: string | null) => void> = [];
   private readonly agentName = 'botmux';
@@ -256,7 +256,6 @@ export class HerdrBackend implements SessionBackend {
       }
     }
 
-    this.dropInitialFullFrame = this.isReattach || Boolean(this.opts.externalTarget);
     this.started = true;
     this.startObserver();
   }
@@ -287,12 +286,15 @@ export class HerdrBackend implements SessionBackend {
     this.rows = rows;
     if (!this.started || this.exited) return;
     this.stopObserver();
-    this.dropInitialFullFrame = false;
     this.startObserver();
   }
 
   onData(cb: (data: string) => void): void {
     this.dataCbs.push(cb);
+    if (!this.pendingData || this.exited) return;
+    const pending = this.pendingData;
+    this.pendingData = '';
+    try { cb(pending); } catch { /* listener crash must not kill the observer */ }
   }
 
   onExit(cb: (code: number | null, signal: string | null) => void): void {
@@ -461,13 +463,13 @@ export class HerdrBackend implements SessionBackend {
     const bytes = Buffer.from(message.bytes, 'base64');
     if (message.full) {
       this.streamDecoder = new StringDecoder('utf8');
-      if (this.dropInitialFullFrame) {
-        this.dropInitialFullFrame = false;
-        return;
-      }
     }
     const data = this.streamDecoder.write(bytes);
     if (!data) return;
+    if (this.dataCbs.length === 0) {
+      this.pendingData = message.full ? data : this.pendingData + data;
+      return;
+    }
     for (const cb of this.dataCbs) {
       try { cb(data); } catch { /* listener crash must not kill the observer */ }
     }
@@ -476,7 +478,6 @@ export class HerdrBackend implements SessionBackend {
   private handleObserverDisconnect(child: ChildProcess): void {
     if (this.observerProcess !== child || this.exited) return;
     this.observerProcess = null;
-    this.dropInitialFullFrame = false;
     try { child.kill('SIGTERM'); } catch { /* already gone */ }
 
     const agents = this.listAgents();
@@ -509,6 +510,7 @@ export class HerdrBackend implements SessionBackend {
     if (this.exited) return;
     this.exited = true;
     this.stopObserver();
+    this.pendingData = '';
     for (const cb of this.exitCbs) {
       try { cb(code, signal); } catch { /* listener crash must not kill teardown */ }
     }

--- a/src/adapters/backend/herdr-backend.ts
+++ b/src/adapters/backend/herdr-backend.ts
@@ -1,4 +1,7 @@
 import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
+import { StringDecoder } from 'node:string_decoder';
+import { z } from 'zod';
+import { logger } from '../../utils/logger.js';
 import type { BackendType, SessionBackend, SpawnOpts, SessionProbe } from './types.js';
 
 export type PersistentBackendType = Exclude<BackendType, 'pty'>;
@@ -9,29 +12,31 @@ export interface HerdrExternalTarget {
   paneId?: string;
 }
 
-// Slow output-streaming poll. We deliberately avoid the original 250ms tick:
-// herdr exposes `wait agent-status`, which we use to fire an immediate read on
-// every idle/working/blocked transition. The 500ms timer is a fallback for the
-// in-the-middle-of-working case where output streams without a status flip.
-const POLL_INTERVAL_MS = 500;
+const MIN_STREAMING_VERSION = [0, 7, 2] as const;
+const OBSERVER_RESTART_DELAY_MS = 500;
+// Snapshot reads are now only used on explicit capture calls. Live output uses
+// `terminal session observe` and never scans this fixed window.
 const READ_LINES = 10_000;
-const MAX_AGENT_PROBE_FAILURES = 3;
 // Inter-attempt sleep while waiting for `herdr server` to come up.
 // Synchronous (execFileSync 'sleep') because spawn() must stay sync.
 const SERVER_BOOT_POLL_MS = 100;
 const SERVER_BOOT_DEADLINE_MS = 5000;
-// `herdr wait agent-status` blocks until a transition; we cap it so a
-// long-stuck agent still re-arms the watcher and we never accumulate an
-// indefinitely-orphaned subprocess on process teardown.
-const STATUS_WAIT_TIMEOUT_MS = 30_000;
-// States we treat as "result settled — flush the pane now". `done` and
-// `blocked` are the user-facing signals (turn finished / input requested);
-// `idle` is the degraded form of `done` after the herdr UI marks it seen,
-// included because we read via the socket API and herdr may not register
-// our reads as "seeing" → without it the watcher could miss legitimate
-// turn completions. `working` is intentionally absent: we don't need an
-// event for "started streaming", the slow timer covers that path.
-const SETTLED_STATUSES = ['done', 'blocked', 'idle'] as const;
+
+const TERMINAL_STREAM_MESSAGE_SCHEMA = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('terminal.frame'),
+    seq: z.number().int().nonnegative(),
+    full: z.boolean(),
+    encoding: z.literal('ansi'),
+    width: z.number().int().positive(),
+    height: z.number().int().positive(),
+    bytes: z.string(),
+  }).strict(),
+  z.object({
+    type: z.literal('terminal.closed'),
+    reason: z.string().optional(),
+  }).strict(),
+]);
 
 type JsonCommandResult = { ok: true; value: any | undefined } | { ok: false };
 
@@ -99,28 +104,23 @@ function extractReadText(raw: any): string {
   return typeof raw?.result?.read?.text === 'string' ? raw.result.read.text : '';
 }
 
-function longestSuffixPrefix(previous: string, next: string): number {
-  const max = Math.min(previous.length, next.length);
-  for (let len = max; len > 0; len--) {
-    if (previous.endsWith(next.slice(0, len))) return len;
-  }
-  return 0;
-}
 
 export class HerdrBackend implements SessionBackend {
   private serverProcess: ChildProcess | null = null;
-  private pollTimer: NodeJS.Timeout | null = null;
-  private statusWaitProcesses: ChildProcess[] = [];
+  private observerProcess: ChildProcess | null = null;
+  private observerRestartTimer: NodeJS.Timeout | null = null;
+  private observerBuffer = '';
+  private streamDecoder = new StringDecoder('utf8');
+  private lastFrameSeq = 0;
+  private dropInitialFullFrame = false;
   private readonly dataCbs: Array<(d: string) => void> = [];
   private readonly exitCbs: Array<(code: number | null, signal: string | null) => void> = [];
   private readonly agentName = 'botmux';
   private paneId: string | undefined;
-  private lastText = '';
   private exited = false;
   private started = false;
   private cols = 200;
   private rows = 50;
-  private agentProbeFailures = 0;
 
   private childEnv: Record<string, string> | undefined;
 
@@ -137,7 +137,18 @@ export class HerdrBackend implements SessionBackend {
 
   static isAvailable(): boolean {
     try {
-      execFileSync('herdr', ['--version'], { stdio: 'ignore', timeout: 3000 });
+      const output = execFileSync('herdr', ['--version'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 3000,
+      });
+      const match = /^herdr\s+(\d+)\.(\d+)\.(\d+)/i.exec(output.trim());
+      if (!match) return false;
+      const installed = [Number(match[1]), Number(match[2]), Number(match[3])] as const;
+      for (let index = 0; index < MIN_STREAMING_VERSION.length; index++) {
+        if (installed[index] > MIN_STREAMING_VERSION[index]) return true;
+        if (installed[index] < MIN_STREAMING_VERSION[index]) return false;
+      }
       return true;
     } catch {
       return false;
@@ -245,17 +256,9 @@ export class HerdrBackend implements SessionBackend {
       }
     }
 
+    this.dropInitialFullFrame = this.isReattach || Boolean(this.opts.externalTarget);
     this.started = true;
-    // Baseline policy mirrors the tmux/PTY backends:
-    //   - Fresh spawn: lastText='' so the first poll emits everything from
-    //     t=0 (matches the PTY contract — listeners see all output even if
-    //     the agent echoed before the first read).
-    //   - Re-attach / external adopt: snapshot the current screen so we only
-    //     stream new deltas. Worker.ts explicitly seeds the initial screen
-    //     via captureCurrentScreen() in those paths.
-    this.lastText = (this.isReattach || this.opts.externalTarget) ? this.readRecentAnsi() : '';
-    this.startPolling();
-    this.startStatusWatcher();
+    this.startObserver();
   }
 
   write(data: string): void {
@@ -279,8 +282,13 @@ export class HerdrBackend implements SessionBackend {
   }
 
   resize(cols: number, rows: number): void {
+    if (this.cols === cols && this.rows === rows) return;
     this.cols = cols;
     this.rows = rows;
+    if (!this.started || this.exited) return;
+    this.stopObserver();
+    this.dropInitialFullFrame = false;
+    this.startObserver();
   }
 
   onData(cb: (data: string) => void): void {
@@ -294,8 +302,7 @@ export class HerdrBackend implements SessionBackend {
   kill(): void {
     if (this.exited) return;
     this.exited = true;
-    this.stopPolling();
-    this.stopStatusWatcher();
+    this.stopObserver();
     this.serverProcess = null;
   }
 
@@ -386,171 +393,124 @@ export class HerdrBackend implements SessionBackend {
     ));
   }
 
-  private startPolling(): void {
-    this.stopPolling();
-    this.pollTimer = setInterval(() => this.poll(), POLL_INTERVAL_MS);
-    this.pollTimer.unref?.();
-  }
-
-  private stopPolling(): void {
-    if (this.pollTimer) clearInterval(this.pollTimer);
-    this.pollTimer = null;
-  }
-
-  private poll(): void {
-    if (this.exited) return;
-    const agents = this.listAgents();
-    if (agents === null) {
-      this.agentProbeFailures++;
-      if (this.agentProbeFailures < MAX_AGENT_PROBE_FAILURES) return;
-      this.handleExit(0, null);
-      return;
-    }
-    this.agentProbeFailures = 0;
-    // Exit detection. Verified against herdr v0.6.6: when the CLI process exits,
-    // herdr DROPS the agent row from `agent list` (it does NOT keep a
-    // running:false tombstone). So the primary signal is "our agent is no
-    // longer in the list". We also treat an explicit terminal marker as exited
-    // (agentRowExited) to stay robust if a future herdr keeps a tombstone row —
-    // otherwise name-presence alone would never report the exit and the worker
-    // would never emit `claude_exit`, hanging the session.
-    const matchingAgent = agents.find(agent => agent?.name === this.agentName || agent?.pane_id === this.paneId);
-    const agentExited = matchingAgent ? agentRowExited(matchingAgent) : true;
-    if (this.started && agentExited) {
-      const exitCode = typeof matchingAgent?.exit_code === 'number' ? matchingAgent.exit_code : 0;
-      this.handleExit(exitCode, null);
-      return;
-    }
-
-    this.readAndEmitDelta();
-  }
-
-  /** Read herdr pane recent output and emit the delta vs. last snapshot. */
-  private readAndEmitDelta(): void {
-    if (this.exited) return;
-    const next = this.readRecentAnsi();
-    if (!next || next === this.lastText) return;
-    let delta = '';
-    if (next.startsWith(this.lastText)) {
-      delta = next.slice(this.lastText.length);
-    } else if (this.lastText.endsWith(next)) {
-      this.lastText = next;
-      return;
-    } else {
-      const overlap = longestSuffixPrefix(this.lastText, next);
-      delta = overlap > 0 ? next.slice(overlap) : next;
-    }
-    this.lastText = next;
-    if (!delta) return;
-    for (const cb of this.dataCbs) {
-      try { cb(delta); } catch { /* listener crash shouldn't kill polling */ }
-    }
-  }
-
-  /**
-   * Spawn one `herdr wait agent-status` child per "result settled" status
-   * (done / blocked / idle). The first to fire wins → we read+emit, then
-   * tear down the losers and re-arm a fresh cohort. Parallel watchers are
-   * needed because the herdr CLI only accepts one --status at a time, and
-   * we genuinely care about all three transitions: `done` is "turn finished
-   * with output", `blocked` is "agent wants user input", `idle` is the
-   * degraded form of done after herdr's UI marks it seen.
-   */
-  private startStatusWatcher(): void {
+  private startObserver(): void {
     if (this.exited) return;
     const paneTarget = this.paneId ?? this.agentName;
     if (!paneTarget) return;
-    this.stopStatusWatcher();
-    const cohort: ChildProcess[] = [];
-    const armedAt = Date.now();
-    for (const status of SETTLED_STATUSES) {
-      const child = spawn('herdr', [
-        '--session', this.sessionName,
-        'wait', 'agent-status', paneTarget,
-        '--status', status,
-        '--timeout', String(STATUS_WAIT_TIMEOUT_MS),
-      ], { stdio: ['ignore', 'ignore', 'ignore'] });
-      cohort.push(child);
+    clearTimeout(this.observerRestartTimer ?? undefined);
+    this.observerRestartTimer = null;
+    this.observerBuffer = '';
+    this.streamDecoder = new StringDecoder('utf8');
+    this.lastFrameSeq = 0;
 
-      child.on('exit', (code) => {
-        // Only the first child to finish (across the cohort) drives the
-        // re-arm cycle; later finishers in the same cohort are dropped.
-        if (!this.statusWaitProcesses.includes(child)) return;
-        const wasFirstSettle = this.statusWaitProcesses === cohort;
-        // Drop this child from the active cohort.
-        this.statusWaitProcesses = this.statusWaitProcesses.filter(c => c !== child);
-        if (!wasFirstSettle || this.exited) return;
-        // First exit in this cohort — tear down siblings, then read+re-arm.
-        this.stopStatusWatcher();
-        this.readAndEmitDelta();
+    const child = spawn('herdr', [
+      '--session', this.sessionName,
+      'terminal', 'session', 'observe', paneTarget,
+      '--cols', String(this.cols),
+      '--rows', String(this.rows),
+    ], { stdio: ['ignore', 'pipe', 'ignore'] });
+    this.observerProcess = child;
 
-        // Storm guard. code 0 = the watched status was genuinely reached (a
-        // real transition, which can legitimately happen instantly) → re-arm
-        // immediately, the normal hot path. The danger is a NON-ZERO instant
-        // return: when the agent's pane has gone away (the CLI exited), `herdr
-        // wait agent-status` returns code 1 within MILLISECONDS rather than
-        // after the 30s timeout. The old code re-armed on every non-0 code
-        // synchronously, so a dead pane spun a tight spawn loop (thousands of
-        // `herdr wait` children/sec) that starved the 500ms poll timer → the
-        // session never reported its exit and hung. So for a non-zero code we
-        // first distinguish "real long timeout" (child lived a meaningful
-        // fraction of the window — agent still working, re-arm normally) from
-        // "instant return" (pane likely gone — check liveness; only re-arm via
-        // a deferred timer, never synchronously, so poll() can run and we can't
-        // spin). Verified on v0.6.6: the exited agent's row disappears from
-        // `agent list`.
-        if (code !== 0) {
-          const elapsed = Date.now() - armedAt;
-          const returnedInstantly = elapsed < STATUS_WAIT_TIMEOUT_MS / 2;
-          if (returnedInstantly) {
-            const agents = this.listAgents();
-            if (agents !== null) {
-              const matching = agents.find(a => a?.pane_id === this.paneId || a?.name === this.agentName);
-              const exited = matching ? agentRowExited(matching) : true;
-              if (exited) {
-                const exitCode = typeof matching?.exit_code === 'number' ? matching.exit_code : 0;
-                this.handleExit(exitCode, null);
-                return;
-              }
-            }
-            // Agent still alive but the wait returned instantly (transient
-            // herdr hiccup). Re-arm on a later tick, never synchronously, so we
-            // can't spin: the deferred timer yields the loop to poll(). unref
-            // so we never hold the event loop open.
-            if (this.exited) return;
-            const t = setTimeout(() => { if (!this.exited) this.startStatusWatcher(); }, POLL_INTERVAL_MS);
-            t.unref?.();
-            return;
-          }
-        }
-        // Normal path: a genuine status transition (code 0) or a real
-        // long-timeout (code 1 after ~30s of working) — re-arm immediately.
-        this.startStatusWatcher();
-      });
-      child.on('error', () => {
-        // `herdr` missing or unspawnable: drop from cohort. Timer-based poll
-        // still acts as the fallback signal.
-        this.statusWaitProcesses = this.statusWaitProcesses.filter(c => c !== child);
-      });
-    }
-    this.statusWaitProcesses = cohort;
+    child.stdout?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => this.consumeObserverChunk(child, chunk));
+    child.on('error', error => {
+      logger.warn(`[herdr:${this.sessionName}] terminal observer failed: ${error.message}`);
+      this.handleObserverDisconnect(child);
+    });
+    child.on('exit', (code, signal) => {
+      if (this.observerProcess !== child || this.exited) return;
+      logger.debug(`[herdr:${this.sessionName}] terminal observer exited code=${code} signal=${signal}`);
+      this.handleObserverDisconnect(child);
+    });
   }
 
-  private stopStatusWatcher(): void {
-    const active = this.statusWaitProcesses;
-    this.statusWaitProcesses = [];
-    for (const child of active) {
-      try { child.kill('SIGTERM'); } catch { /* already gone */ }
+  private consumeObserverChunk(child: ChildProcess, chunk: string): void {
+    if (this.observerProcess !== child || this.exited) return;
+    this.observerBuffer += chunk;
+    let newline = this.observerBuffer.indexOf('\n');
+    while (newline >= 0) {
+      const line = this.observerBuffer.slice(0, newline).trim();
+      this.observerBuffer = this.observerBuffer.slice(newline + 1);
+      if (line) this.consumeObserverLine(child, line);
+      if (this.observerProcess !== child || this.exited) return;
+      newline = this.observerBuffer.indexOf('\n');
     }
+  }
+
+  private consumeObserverLine(child: ChildProcess, line: string): void {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(line);
+    } catch (error) {
+      logger.warn(`[herdr:${this.sessionName}] malformed terminal stream JSON: ${error instanceof Error ? error.message : String(error)}`);
+      return;
+    }
+    const parsed = TERMINAL_STREAM_MESSAGE_SCHEMA.safeParse(raw);
+    if (!parsed.success) {
+      logger.warn(`[herdr:${this.sessionName}] unsupported terminal stream record: ${parsed.error.message}`);
+      return;
+    }
+    const message = parsed.data;
+    if (message.type === 'terminal.closed') {
+      logger.debug(`[herdr:${this.sessionName}] terminal stream closed: ${message.reason ?? 'no reason'}`);
+      this.handleObserverDisconnect(child);
+      return;
+    }
+    if (message.seq <= this.lastFrameSeq) return;
+    this.lastFrameSeq = message.seq;
+    const bytes = Buffer.from(message.bytes, 'base64');
+    if (message.full) {
+      this.streamDecoder = new StringDecoder('utf8');
+      if (this.dropInitialFullFrame) {
+        this.dropInitialFullFrame = false;
+        return;
+      }
+    }
+    const data = this.streamDecoder.write(bytes);
+    if (!data) return;
+    for (const cb of this.dataCbs) {
+      try { cb(data); } catch { /* listener crash must not kill the observer */ }
+    }
+  }
+
+  private handleObserverDisconnect(child: ChildProcess): void {
+    if (this.observerProcess !== child || this.exited) return;
+    this.observerProcess = null;
+    this.dropInitialFullFrame = false;
+    try { child.kill('SIGTERM'); } catch { /* already gone */ }
+
+    const agents = this.listAgents();
+    if (agents !== null) {
+      const matching = agents.find(agent => agent?.name === this.agentName || agent?.pane_id === this.paneId);
+      if (!matching || agentRowExited(matching)) {
+        const exitCode = typeof matching?.exit_code === 'number' ? matching.exit_code : 0;
+        this.handleExit(exitCode, null);
+        return;
+      }
+    }
+
+    this.observerRestartTimer = setTimeout(() => {
+      this.observerRestartTimer = null;
+      if (!this.exited) this.startObserver();
+    }, OBSERVER_RESTART_DELAY_MS);
+    this.observerRestartTimer.unref?.();
+  }
+
+  private stopObserver(): void {
+    clearTimeout(this.observerRestartTimer ?? undefined);
+    this.observerRestartTimer = null;
+    const child = this.observerProcess;
+    this.observerProcess = null;
+    if (!child) return;
+    try { child.kill('SIGTERM'); } catch { /* already gone */ }
   }
 
   private handleExit(code: number | null, signal: string | null): void {
     if (this.exited) return;
     this.exited = true;
-    this.stopPolling();
-    this.stopStatusWatcher();
+    this.stopObserver();
     for (const cb of this.exitCbs) {
-      try { cb(code, signal); } catch { /* listener crash shouldn't kill teardown */ }
+      try { cb(code, signal); } catch { /* listener crash must not kill teardown */ }
     }
   }
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4385,11 +4385,11 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
         reason = 'zellij 功能性探针失败（需 zellij >= 0.44）';
       }
     } else if (effectiveBackend === 'herdr') {
-      // herdr's isAvailable() is a cheap, non-destructive `herdr --version`
-      // (not a disposable session probe), so it has no PR#249 false-negative
-      // risk and needs no existing-session exemption.
+      // Native terminal streaming is available from Herdr 0.7.2. The version
+      // probe is cheap and non-destructive, so existing sessions do not bypass
+      // this compatibility gate.
       available = HerdrBackend.isAvailable();
-      reason = 'herdr 功能性探针失败';
+      reason = 'herdr 不可用或版本低于 0.7.2（请执行 herdr update）';
     }
     const decision = decideBackendGate({ requested: effectiveBackend, available, hasExistingSession });
     if (decision.action === 'gate') {

--- a/test/herdr-backend.e2e.ts
+++ b/test/herdr-backend.e2e.ts
@@ -84,33 +84,36 @@ describe('HerdrBackend (e2e)', () => {
     expect(HerdrBackend.hasSession(TEST_SESSION)).toBe(true);
   }, TEST_TIMEOUT);
 
-  it.skipIf(!HerdrBackend.isAvailable())('re-attach observes the same agent without spawning a new one', async () => {
-    // Phase 1: create the session and let it produce a marker line.
+  it.skipIf(!HerdrBackend.isAvailable())('re-attach suppresses the seeded full frame and streams new output', async () => {
+    // Phase 1: create a long-lived interactive agent and detach its observer.
     const be1 = new HerdrBackend(TEST_SESSION);
     const renderer = new TerminalRenderer(80, 24);
     be1.onData(data => renderer.write(data));
-    be1.spawn('/bin/bash', ['-lc', 'echo PHASE1_MARKER; sleep 30'], spawnOpts());
+    be1.spawn('/bin/bash', ['-lc', 'echo PHASE1_MARKER; exec cat'], spawnOpts());
     await waitFor(() => renderer.rawSnapshot().includes('PHASE1_MARKER'), 10_000, 'PHASE1_MARKER');
     be1.kill();
     renderer.dispose();
     expect(HerdrBackend.hasSession(TEST_SESSION)).toBe(true);
 
-    // Phase 2: a second backend attaches to the same session. It must NOT
-    // start a fresh `bash` (the bin/args are ignored on reuse), and it
-    // should see PHASE1_MARKER on its first `pane read --source recent`.
+    // Phase 2: worker reattach seeds the existing screen separately. The
+    // observer must suppress only its first full frame, then stream new data.
     const be2 = new HerdrBackend(TEST_SESSION, { isReattach: true });
     const out2: string[] = [];
-    be2.onData(d => out2.push(d));
+    be2.onData(data => out2.push(data));
     be2.spawn('/bin/bash', ['-lc', 'echo SHOULD_NOT_RUN'], spawnOpts());
     expect(be2.isReattach).toBe(true);
-
-    // Read recent pane content via the backend's capture API. Don't gate on
-    // onData here — the second backend snapshots last-text at spawn time so
-    // the marker shows up in captureCurrentScreen, not the delta stream.
     await waitFor(() => {
       const screen = be2.captureCurrentScreen();
       return screen.includes('PHASE1_MARKER') && !screen.includes('SHOULD_NOT_RUN');
-    }, 10_000, 'pane recent contains PHASE1 but not SHOULD_NOT_RUN');
+    }, 10_000, 'reattach seed contains PHASE1 but not SHOULD_NOT_RUN');
+
+    // Allow the observer's initial full frame to arrive before exercising the
+    // new incremental path, matching normal user input after restore.
+    await new Promise(resolve => setTimeout(resolve, 500));
+    be2.write('PHASE2_DELTA');
+    be2.sendSpecialKeys('Enter');
+    await waitFor(() => out2.join('').includes('PHASE2_DELTA'), 10_000, 'reattach streamed PHASE2_DELTA');
+    expect(out2.join('')).not.toContain('PHASE1_MARKER');
 
     be2.destroySession();
     await waitFor(() => !HerdrBackend.hasSession(TEST_SESSION), 10_000, 'session torn down');

--- a/test/herdr-backend.e2e.ts
+++ b/test/herdr-backend.e2e.ts
@@ -21,6 +21,7 @@ import { rmSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { HerdrBackend } from '../src/adapters/backend/herdr-backend.js';
+import { TerminalRenderer } from '../src/utils/terminal-renderer.js';
 
 // Unique enough to never collide with anything the user has running.
 const TEST_SESSION = 'bmx-e2e7777';
@@ -66,17 +67,18 @@ describe('HerdrBackend (e2e)', () => {
 
   it.skipIf(!HerdrBackend.isAvailable())('spawn captures output from a live herdr agent', async () => {
     const backend = new HerdrBackend(TEST_SESSION);
-    const output: string[] = [];
-    backend.onData(d => output.push(d));
+    const renderer = new TerminalRenderer(80, 24);
+    backend.onData(data => renderer.write(data));
 
     backend.spawn('/bin/bash', ['-lc', 'echo HELLO_HERDR; sleep 30'], spawnOpts());
 
-    await waitFor(() => output.join('').includes('HELLO_HERDR'), 10_000, 'HELLO_HERDR in output');
-    expect(output.join('')).toContain('HELLO_HERDR');
+    await waitFor(() => renderer.rawSnapshot().includes('HELLO_HERDR'), 10_000, 'HELLO_HERDR in output');
+    expect(renderer.rawSnapshot()).toContain('HELLO_HERDR');
     expect(HerdrBackend.hasSession(TEST_SESSION)).toBe(true);
     expect(backend.isReattach).toBe(false);
 
     backend.kill();
+    renderer.dispose();
     // kill() only tears down the backend's observers; the herdr session and
     // its agent process must outlive a detach so daemon restarts can resume.
     expect(HerdrBackend.hasSession(TEST_SESSION)).toBe(true);
@@ -85,11 +87,12 @@ describe('HerdrBackend (e2e)', () => {
   it.skipIf(!HerdrBackend.isAvailable())('re-attach observes the same agent without spawning a new one', async () => {
     // Phase 1: create the session and let it produce a marker line.
     const be1 = new HerdrBackend(TEST_SESSION);
-    const out1: string[] = [];
-    be1.onData(d => out1.push(d));
+    const renderer = new TerminalRenderer(80, 24);
+    be1.onData(data => renderer.write(data));
     be1.spawn('/bin/bash', ['-lc', 'echo PHASE1_MARKER; sleep 30'], spawnOpts());
-    await waitFor(() => out1.join('').includes('PHASE1_MARKER'), 10_000, 'PHASE1_MARKER');
+    await waitFor(() => renderer.rawSnapshot().includes('PHASE1_MARKER'), 10_000, 'PHASE1_MARKER');
     be1.kill();
+    renderer.dispose();
     expect(HerdrBackend.hasSession(TEST_SESSION)).toBe(true);
 
     // Phase 2: a second backend attaches to the same session. It must NOT
@@ -145,22 +148,21 @@ describe('HerdrBackend (e2e)', () => {
 
   it.skipIf(!HerdrBackend.isAvailable())('write() routes input to the pane and the shell echoes it back', async () => {
     const backend = new HerdrBackend(TEST_SESSION);
+    const renderer = new TerminalRenderer(80, 24);
+    backend.onData(data => renderer.write(data));
     backend.spawn('/bin/bash', ['-lc', 'cat'], spawnOpts());
     await waitFor(() => HerdrBackend.hasSession(TEST_SESSION), 10_000, 'session up');
 
-    const seen: string[] = [];
-    backend.onData(d => seen.push(d));
-
-    // `cat` echoes stdin to stdout — verifies the full write→pane→read loop.
-    // PTY line discipline submits on CR (Enter), not LF — use sendSpecialKeys
-    // for the Enter so the line is actually delivered to cat's stdin.
+    // `cat` echoes stdin to stdout — verifies the full write→pane→stream loop.
+    // PTY line discipline submits on CR (Enter), not LF.
     backend.write('PING_FROM_BOTMUX');
     backend.sendSpecialKeys('Enter');
 
-    await waitFor(() => seen.join('').includes('PING_FROM_BOTMUX'), 10_000, 'cat echoed input');
-    expect(seen.join('')).toContain('PING_FROM_BOTMUX');
+    await waitFor(() => renderer.rawSnapshot().includes('PING_FROM_BOTMUX'), 10_000, 'cat echoed input');
+    expect(renderer.rawSnapshot()).toContain('PING_FROM_BOTMUX');
 
     backend.destroySession();
+    renderer.dispose();
   }, TEST_TIMEOUT);
 
   it.skipIf(!HerdrBackend.isAvailable())('destroySession stops the herdr session', async () => {

--- a/test/herdr-backend.e2e.ts
+++ b/test/herdr-backend.e2e.ts
@@ -17,7 +17,7 @@
  */
 import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { rmSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { HerdrBackend } from '../src/adapters/backend/herdr-backend.js';
@@ -26,6 +26,7 @@ import { TerminalRenderer } from '../src/utils/terminal-renderer.js';
 // Unique enough to never collide with anything the user has running.
 const TEST_SESSION = 'bmx-e2e7777';
 const TEST_TIMEOUT = 30_000;
+const REATTACH_SENTINEL = `/tmp/botmux-herdr-reattach-${process.pid}`;
 
 /**
  * Hard reset for a test session. `herdr session stop` is asynchronous and
@@ -59,10 +60,12 @@ async function waitFor(predicate: () => boolean, timeoutMs: number, label = 'con
 describe('HerdrBackend (e2e)', () => {
   beforeEach(() => {
     hardResetSession(TEST_SESSION);
+    rmSync(REATTACH_SENTINEL, { force: true });
   });
 
   afterEach(() => {
     hardResetSession(TEST_SESSION);
+    rmSync(REATTACH_SENTINEL, { force: true });
   });
 
   it.skipIf(!HerdrBackend.isAvailable())('spawn captures output from a live herdr agent', async () => {
@@ -89,27 +92,29 @@ describe('HerdrBackend (e2e)', () => {
     const be1 = new HerdrBackend(TEST_SESSION);
     const renderer = new TerminalRenderer(80, 24);
     be1.onData(data => renderer.write(data));
-    be1.spawn('/bin/bash', ['-lc', 'echo PHASE1_MARKER; exec cat'], spawnOpts());
+    be1.spawn('/bin/bash', ['-lc', `echo PHASE1_MARKER; while [ ! -f ${REATTACH_SENTINEL} ]; do sleep 0.05; done; echo PHASE2_DELTA; sleep 30`], spawnOpts());
     await waitFor(() => renderer.rawSnapshot().includes('PHASE1_MARKER'), 10_000, 'PHASE1_MARKER');
     be1.kill();
     renderer.dispose();
     expect(HerdrBackend.hasSession(TEST_SESSION)).toBe(true);
 
-    // Phase 2: the observer full frame is the authoritative reattach baseline;
-    // subsequent writes must arrive as incremental frames without a seed race.
+    // Phase 2: worker first seeds the static screen, then the observer streams
+    // the next authoritative full redraw and subsequent increments.
     const be2 = new HerdrBackend(TEST_SESSION, { isReattach: true });
-    const out2: string[] = [];
-    be2.onData(data => out2.push(data));
+    const reattachRenderer = new TerminalRenderer(80, 24);
     be2.spawn('/bin/bash', ['-lc', 'echo SHOULD_NOT_RUN'], spawnOpts());
     expect(be2.isReattach).toBe(true);
-    await waitFor(() => out2.join('').includes('PHASE1_MARKER'), 10_000, 'reattach streamed full baseline');
+    reattachRenderer.write(be2.captureCurrentScreen());
+    await waitFor(() => reattachRenderer.rawSnapshot().includes('PHASE1_MARKER'), 5_000, 'reattach rendered seed');
+    be2.onData(data => reattachRenderer.write(data));
 
-    be2.write('PHASE2_DELTA');
-    be2.sendSpecialKeys('Enter');
-    await waitFor(() => out2.join('').includes('PHASE2_DELTA'), 10_000, 'reattach streamed PHASE2_DELTA');
-    expect(out2.join('')).not.toContain('SHOULD_NOT_RUN');
+    writeFileSync(REATTACH_SENTINEL, 'go');
+    await waitFor(() => be2.captureCurrentScreen().includes('PHASE2_DELTA'), 10_000, 'pane produced PHASE2_DELTA');
+    await waitFor(() => reattachRenderer.rawSnapshot().includes('PHASE2_DELTA'), 10_000, 'reattach rendered PHASE2_DELTA');
+    expect(reattachRenderer.rawSnapshot()).not.toContain('SHOULD_NOT_RUN');
 
     be2.destroySession();
+    reattachRenderer.dispose();
     await waitFor(() => !HerdrBackend.hasSession(TEST_SESSION), 10_000, 'session torn down');
   }, TEST_TIMEOUT);
 

--- a/test/herdr-backend.e2e.ts
+++ b/test/herdr-backend.e2e.ts
@@ -84,7 +84,7 @@ describe('HerdrBackend (e2e)', () => {
     expect(HerdrBackend.hasSession(TEST_SESSION)).toBe(true);
   }, TEST_TIMEOUT);
 
-  it.skipIf(!HerdrBackend.isAvailable())('re-attach suppresses the seeded full frame and streams new output', async () => {
+  it.skipIf(!HerdrBackend.isAvailable())('re-attach streams its full baseline and subsequent output', async () => {
     // Phase 1: create a long-lived interactive agent and detach its observer.
     const be1 = new HerdrBackend(TEST_SESSION);
     const renderer = new TerminalRenderer(80, 24);
@@ -95,25 +95,19 @@ describe('HerdrBackend (e2e)', () => {
     renderer.dispose();
     expect(HerdrBackend.hasSession(TEST_SESSION)).toBe(true);
 
-    // Phase 2: worker reattach seeds the existing screen separately. The
-    // observer must suppress only its first full frame, then stream new data.
+    // Phase 2: the observer full frame is the authoritative reattach baseline;
+    // subsequent writes must arrive as incremental frames without a seed race.
     const be2 = new HerdrBackend(TEST_SESSION, { isReattach: true });
     const out2: string[] = [];
     be2.onData(data => out2.push(data));
     be2.spawn('/bin/bash', ['-lc', 'echo SHOULD_NOT_RUN'], spawnOpts());
     expect(be2.isReattach).toBe(true);
-    await waitFor(() => {
-      const screen = be2.captureCurrentScreen();
-      return screen.includes('PHASE1_MARKER') && !screen.includes('SHOULD_NOT_RUN');
-    }, 10_000, 'reattach seed contains PHASE1 but not SHOULD_NOT_RUN');
+    await waitFor(() => out2.join('').includes('PHASE1_MARKER'), 10_000, 'reattach streamed full baseline');
 
-    // Allow the observer's initial full frame to arrive before exercising the
-    // new incremental path, matching normal user input after restore.
-    await new Promise(resolve => setTimeout(resolve, 500));
     be2.write('PHASE2_DELTA');
     be2.sendSpecialKeys('Enter');
     await waitFor(() => out2.join('').includes('PHASE2_DELTA'), 10_000, 'reattach streamed PHASE2_DELTA');
-    expect(out2.join('')).not.toContain('PHASE1_MARKER');
+    expect(out2.join('')).not.toContain('SHOULD_NOT_RUN');
 
     be2.destroySession();
     await waitFor(() => !HerdrBackend.hasSession(TEST_SESSION), 10_000, 'session torn down');

--- a/test/herdr-backend.test.ts
+++ b/test/herdr-backend.test.ts
@@ -551,6 +551,31 @@ describe('HerdrBackend callbacks', () => {
     }
   });
 
+  it('delivers frames emitted before the first onData listener is registered', async () => {
+    setHerdrResponses([
+      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
+      {
+        match: a => a.includes('agent') && a.includes('start'),
+        reply: () => JSON.stringify({ result: { agent: { name: 'botmux', pane_id: 'w1:p1' } } }),
+      },
+    ]);
+
+    const backend = new HerdrBackend(SESSION);
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const observerIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    fakeChildren[observerIndex]!.stdout.write(`${JSON.stringify({
+      type: 'terminal.frame', seq: 1, full: true, encoding: 'ansi', width: 80, height: 24,
+      bytes: Buffer.from('early baseline').toString('base64'),
+    })}\n`);
+    await waitForImmediate();
+
+    const seen: string[] = [];
+    backend.onData(data => seen.push(data));
+    expect(seen).toEqual(['early baseline']);
+    backend.kill();
+  });
+
   it('decodes one UTF-8 character split across consecutive terminal frames', async () => {
     setHerdrResponses([
       { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
@@ -653,7 +678,7 @@ describe('HerdrBackend callbacks', () => {
     expect(exits).toEqual([]);
   });
 
-  it('reattach drops the initial full frame and emits ordered incremental frames once', async () => {
+  it('reattach forwards the observer full frame before ordered incremental frames', async () => {
     setHerdrResponses([
       { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
       { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('w1:p1') },
@@ -669,10 +694,8 @@ describe('HerdrBackend callbacks', () => {
     const observer = observerIndex >= 0 ? fakeChildren[observerIndex] : undefined;
     try {
       expect(observer).toBeDefined();
-      expect(mockedSpawn.mock.calls.some(([, args]) =>
-        Array.isArray(args) && args.includes('wait') && args.includes('agent-status'))).toBe(false);
       for (const frame of [
-        { seq: 1, full: true, text: 'seeded screen' },
+        { seq: 1, full: true, text: 'reattached screen' },
         { seq: 2, full: false, text: ' delta' },
         { seq: 2, full: false, text: ' duplicate' },
         { seq: 1, full: false, text: ' stale' },
@@ -684,7 +707,7 @@ describe('HerdrBackend callbacks', () => {
         })}\n`);
       }
       await waitForImmediate();
-      expect(seen.join('')).toBe(' delta done');
+      expect(seen.join('')).toBe('reattached screen delta done');
       expect(herdrCall('agent', 'read')).toBeUndefined();
       backend.kill();
       expect(observer!.killed).toBe(true);
@@ -692,6 +715,7 @@ describe('HerdrBackend callbacks', () => {
       if (!observer?.killed) backend.kill();
     }
   });
+
   it('terminal.closed emits onExit when the observed agent disappeared', async () => {
     let agentAlive = true;
     setHerdrResponses([

--- a/test/herdr-backend.test.ts
+++ b/test/herdr-backend.test.ts
@@ -95,9 +95,8 @@ beforeEach(() => {
   mockedExecFileSync.mockReset();
   mockedSpawn.mockReset();
   fakeChildren.length = 0;
-  // Default: every spawn (including the bg `wait agent-status` watcher) gets
-  // a fake child whose lifecycle the test fully controls.
-  mockedSpawn.mockImplementation((() => makeFakeChild()) as any);
+  // Every spawned process gets a fake child whose lifecycle the test controls.
+  mockedSpawn.mockImplementation(() => makeFakeChild());
 });
 
 afterEach(() => {
@@ -107,15 +106,17 @@ afterEach(() => {
 // ─── Backend connection surface ────────────────────────────────────────────
 
 describe('HerdrBackend connection surface', () => {
-  it('isAvailable() returns true when `herdr --version` succeeds', () => {
-    mockedExecFileSync.mockImplementation((() => 'herdr 1.0\n') as any);
+  it('isAvailable() requires Herdr 0.7.2 or newer', () => {
+    mockedExecFileSync.mockReturnValue('herdr 0.7.2\n');
     expect(HerdrBackend.isAvailable()).toBe(true);
+    mockedExecFileSync.mockReturnValue('herdr 0.7.1\n');
+    expect(HerdrBackend.isAvailable()).toBe(false);
     const versionCall = mockedExecFileSync.mock.calls.find(c => (c[1] as string[]).includes('--version'));
     expect(versionCall).toBeDefined();
   });
 
   it('isAvailable() returns false when herdr binary is missing', () => {
-    mockedExecFileSync.mockImplementation((() => { throw new Error('ENOENT'); }) as any);
+    mockedExecFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
     expect(HerdrBackend.isAvailable()).toBe(false);
   });
 
@@ -589,224 +590,110 @@ describe('HerdrBackend callbacks', () => {
       if (!observer?.killed) backend.kill();
     }
   });
-  it('onData fires with the prefix-delta when pane recent output grows', () => {
-    let paneText = 'hello';
-    setHerdrResponses([
-      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
-      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('1-1') },
-      { match: a => a.includes('agent') && a.includes('list'), reply: () => AGENT_LIST_REPLY('1-1') },
-      { match: a => a.includes('read') && (a.includes('agent') || a.includes('pane')), reply: () => PANE_READ_REPLY(paneText) },
-    ]);
-
-    vi.useFakeTimers();
-    // Use an isReattach backend so the baseline is captured at spawn
-    // (lastText = current pane content) — that mirrors the worker.ts
-    // reattach contract, where the initial screen is seeded separately and
-    // the data stream emits only deltas.
-    const be = new HerdrBackend(SESSION, { isReattach: true });
-    const seen: string[] = [];
-    be.onData(d => seen.push(d));
-    be.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
-
-    // Reattach captures the current screen as baseline → no immediate emit.
-    expect(seen).toEqual([]);
-
-    paneText = 'hello world';
-    vi.advanceTimersByTime(600); // > POLL_INTERVAL_MS (500ms)
-    expect(seen).toEqual([' world']);
-
-    paneText = 'hello world!';
-    vi.advanceTimersByTime(600);
-    expect(seen).toEqual([' world', '!']);
-
-    be.kill();
-  });
-
-  it('onData fresh-spawn baseline: lastText starts empty so listeners see initial output', () => {
-    // Counterpart to the reattach test: a fresh spawn keeps lastText='' so
-    // listeners attached *before* spawn don't miss output the agent emitted
-    // between agent-start and the first poll tick (the herdr-backend's
-    // missing-initial-output bug we hit in the e2e run).
-    let paneText = '';
-    setHerdrResponses([
-      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
-      { match: a => a.includes('agent') && a.includes('get'), reply: () => '' },
-      {
-        match: a => a.includes('agent') && a.includes('start'),
-        reply: () => JSON.stringify({ result: { agent: { name: 'botmux', pane_id: '1-1' } } }),
-      },
-      { match: a => a.includes('agent') && a.includes('list'), reply: () => AGENT_LIST_REPLY('1-1') },
-      { match: a => a.includes('read') && (a.includes('agent') || a.includes('pane')), reply: () => PANE_READ_REPLY(paneText) },
-    ]);
-
-    vi.useFakeTimers();
-    const be = new HerdrBackend(SESSION);
-    const seen: string[] = [];
-    be.onData(d => seen.push(d));
-    be.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
-
-    paneText = 'HELLO_HERDR\n';
-    vi.advanceTimersByTime(600);
-    expect(seen.join('')).toBe('HELLO_HERDR\n');
-
-    be.kill();
-  });
-
-  it('onExit fires when the agent disappears from `agent list`', () => {
+  it('terminal.closed emits onExit when the observed agent disappeared', async () => {
     let agentAlive = true;
     setHerdrResponses([
       { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
-      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('1-1') },
+      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('w1:p1') },
       {
         match: a => a.includes('agent') && a.includes('list'),
-        reply: () => agentAlive
-          ? AGENT_LIST_REPLY('1-1')
-          : JSON.stringify({ result: { agents: [] } }),
+        reply: () => agentAlive ? AGENT_LIST_REPLY('w1:p1') : JSON.stringify({ result: { agents: [] } }),
       },
-      { match: a => a.includes('read') && (a.includes('agent') || a.includes('pane')), reply: () => PANE_READ_REPLY('') },
     ]);
 
-    vi.useFakeTimers();
-    const be = new HerdrBackend(SESSION, { isReattach: true });
+    const backend = new HerdrBackend(SESSION, { isReattach: true });
     const exits: Array<[number | null, string | null]> = [];
-    be.onExit((code, signal) => exits.push([code, signal]));
-    be.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    backend.onExit((code, signal) => exits.push([code, signal]));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const observerIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    const observer = fakeChildren[observerIndex]!;
 
     agentAlive = false;
-    vi.advanceTimersByTime(600);
+    observer.stdout.write(`${JSON.stringify({ type: 'terminal.closed', reason: 'pane exited' })}\n`);
+    await waitForImmediate();
     expect(exits).toEqual([[0, null]]);
   });
 
-  it('onExit fires when the agent stays in list with running:false (v0.6.6 tombstone)', () => {
-    // herdr v0.6.6+ does NOT drop exited agents from `agent list` — they
-    // stick around with running:false / status:"exited". Without this
-    // detection the worker never sees the CLI exit → claude_exit never
-    // fires → session hangs (the bug deepcoldy reported in PR #81).
+  it('terminal.closed preserves an explicit agent exit code', async () => {
     let agentRunning = true;
     setHerdrResponses([
       { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
-      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('1-1') },
+      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('w1:p1') },
       {
         match: a => a.includes('agent') && a.includes('list'),
         reply: () => agentRunning
-          ? AGENT_LIST_REPLY('1-1')
-          : JSON.stringify({ result: { agents: [{ name: 'botmux', pane_id: '1-1', running: false, status: 'exited', exit_code: 7 }] } }),
+          ? AGENT_LIST_REPLY('w1:p1')
+          : JSON.stringify({ result: { agents: [{ name: 'botmux', pane_id: 'w1:p1', running: false, status: 'exited', exit_code: 7 }] } }),
       },
-      { match: a => a.includes('read') && (a.includes('agent') || a.includes('pane')), reply: () => PANE_READ_REPLY('') },
     ]);
 
-    vi.useFakeTimers();
-    const be = new HerdrBackend(SESSION, { isReattach: true });
+    const backend = new HerdrBackend(SESSION, { isReattach: true });
     const exits: Array<[number | null, string | null]> = [];
-    be.onExit((code, signal) => exits.push([code, signal]));
-    be.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    backend.onExit((code, signal) => exits.push([code, signal]));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const observerIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
 
     agentRunning = false;
-    vi.advanceTimersByTime(600);
-    // exit_code surfaces from the tombstone row so callers can distinguish
-    // clean exits from crashes (mirrors the PTY backend's exit code path).
+    fakeChildren[observerIndex]!.stdout.write(`${JSON.stringify({ type: 'terminal.closed' })}\n`);
+    await waitForImmediate();
     expect(exits).toEqual([[7, null]]);
   });
 
-  it('status watcher: one wait child per settled status (done/blocked/idle), first exit wins', () => {
-    // Capture every fake `wait agent-status` child + its --status arg so the
-    // test can drive a specific watcher's exit and verify the cohort
-    // behaviour (first-to-fire reads, the rest get SIGTERM'd).
-    const waitChildren: Array<{ status: string; child: FakeChild }> = [];
-    mockedSpawn.mockImplementation(((_cmd: any, args: any) => {
-      const child = makeFakeChild();
-      const argv = args as string[];
-      if (argv.includes('wait') && argv.includes('agent-status')) {
-        const statusIdx = argv.indexOf('--status');
-        waitChildren.push({ status: argv[statusIdx + 1]!, child });
-      }
-      return child;
-    }) as any);
-
-    let paneText = 'baseline';
+  it('restarts a disconnected observer when the agent is still alive', () => {
+    vi.useFakeTimers();
     setHerdrResponses([
       { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
-      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('1-1') },
-      { match: a => a.includes('agent') && a.includes('list'), reply: () => AGENT_LIST_REPLY('1-1') },
-      { match: a => a.includes('read') && (a.includes('agent') || a.includes('pane')), reply: () => PANE_READ_REPLY(paneText) },
+      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('w1:p1') },
+      { match: a => a.includes('agent') && a.includes('list'), reply: () => AGENT_LIST_REPLY('w1:p1') },
     ]);
 
-    // Reattach so the baseline is captured at spawn — keeps the assertion
-    // focused on "watcher exit triggers delta", not on the initial screen.
-    const be = new HerdrBackend(SESSION, { isReattach: true });
-    const seen: string[] = [];
-    be.onData(d => seen.push(d));
-    be.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const backend = new HerdrBackend(SESSION, { isReattach: true });
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const observersBefore = mockedSpawn.mock.calls.filter(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    const observerIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    const firstObserver = fakeChildren[observerIndex]!;
 
-    // Cohort = one watcher per settled status.
-    const cohort = waitChildren.slice();
-    expect(cohort.map(w => w.status).sort()).toEqual(['blocked', 'done', 'idle']);
-
-    // Simulate the agent transitioning to `done` mid-turn — that watcher wins.
-    paneText = 'baseline result';
-    const doneWatcher = cohort.find(w => w.status === 'done')!;
-    doneWatcher.child.emit('exit', 0, null);
-
-    // The win triggered a read+emit.
-    expect(seen).toEqual([' result']);
-
-    // The two losing siblings got killed and a fresh cohort got armed.
-    for (const w of cohort) {
-      if (w !== doneWatcher) expect(w.child.killed).toBe(true);
-    }
-    const nextCohort = waitChildren.slice(cohort.length);
-    expect(nextCohort.map(w => w.status).sort()).toEqual(['blocked', 'done', 'idle']);
-
-    be.kill();
-    // kill() tears down the live cohort.
-    for (const w of nextCohort) expect(w.child.killed).toBe(true);
+    firstObserver.emit('exit', 1, null);
+    expect(firstObserver.killed).toBe(true);
+    vi.advanceTimersByTime(500);
+    const observersAfter = mockedSpawn.mock.calls.filter(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    expect(observersAfter).toHaveLength(observersBefore.length + 1);
+    backend.kill();
   });
 
-  it('status watcher: instant non-zero exit on a vanished agent emits onExit and does NOT re-arm (storm guard)', () => {
-    // Regression for the re-arm storm: on herdr v0.6.6 a `herdr wait
-    // agent-status` against a dead pane returns code 1 IMMEDIATELY. The old
-    // code re-armed synchronously on any non-0 code → a tight spawn loop that
-    // starved the poll timer and the session hung. The fix: an instant
-    // non-zero return triggers a liveness check; a vanished agent (empty
-    // `agent list`) emits onExit instead of re-arming.
-    const waitChildren: Array<{ status: string; child: FakeChild }> = [];
-    mockedSpawn.mockImplementation(((_cmd: any, args: any) => {
-      const child = makeFakeChild();
-      const argv = args as string[];
-      if (argv.includes('wait') && argv.includes('agent-status')) {
-        const statusIdx = argv.indexOf('--status');
-        waitChildren.push({ status: argv[statusIdx + 1]!, child });
-      }
-      return child;
-    }) as any);
-
-    // Agent present at spawn, then GONE (empty list) once it has exited.
-    let agentGone = false;
+  it('resize replaces the observer and forwards its full rebaseline frame', async () => {
     setHerdrResponses([
       { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
-      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('1-1') },
-      { match: a => a.includes('agent') && a.includes('list'), reply: () => agentGone ? JSON.stringify({ result: { agents: [] } }) : AGENT_LIST_REPLY('1-1') },
-      { match: a => a.includes('read') && (a.includes('agent') || a.includes('pane')), reply: () => PANE_READ_REPLY('x') },
+      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('w1:p1') },
     ]);
 
-    const be = new HerdrBackend(SESSION, { isReattach: true });
-    const exits: Array<[number | null, string | null]> = [];
-    be.onExit((code, signal) => exits.push([code, signal]));
-    be.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const backend = new HerdrBackend(SESSION, { isReattach: true });
+    const seen: string[] = [];
+    backend.onData(data => seen.push(data));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const firstIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    const firstObserver = fakeChildren[firstIndex]!;
 
-    const cohort = waitChildren.slice();
-    expect(cohort.length).toBe(3);
-
-    // The agent has now exited; the next `wait` returns code 1 instantly.
-    agentGone = true;
-    cohort.find(w => w.status === 'done')!.child.emit('exit', 1, null);
-
-    // onExit fired (storm guard saw the empty agent list)...
-    expect(exits.length).toBe(1);
-    // ...and NO fresh cohort was armed synchronously (the bug spun new ones).
-    const nextCohort = waitChildren.slice(cohort.length);
-    expect(nextCohort.length).toBe(0);
-
-    be.kill();
+    backend.resize(120, 40);
+    expect(firstObserver.killed).toBe(true);
+    const observerCalls = mockedSpawn.mock.calls.filter(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    const resizedArgs = observerCalls.at(-1)?.[1];
+    expect(resizedArgs).toContain('120');
+    expect(resizedArgs).toContain('40');
+    const resizedObserver = fakeChildren.at(-1)!;
+    resizedObserver.stdout.write(`${JSON.stringify({
+      type: 'terminal.frame', seq: 1, full: true, encoding: 'ansi', width: 120, height: 40,
+      bytes: Buffer.from('resized baseline').toString('base64'),
+    })}\n`);
+    await waitForImmediate();
+    expect(seen).toEqual(['resized baseline']);
+    backend.kill();
   });
 });

--- a/test/herdr-backend.test.ts
+++ b/test/herdr-backend.test.ts
@@ -16,6 +16,8 @@
  * Run:  pnpm vitest run test/herdr-backend.test.ts
  */
 import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { setImmediate as waitForImmediate } from 'node:timers/promises';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('node:child_process', () => ({
@@ -33,11 +35,19 @@ const mockedSpawn = vi.mocked(spawn);
 
 class FakeChild extends EventEmitter {
   killed = false;
+  stdout = new PassThrough();
   unref = vi.fn();
   kill = vi.fn(() => { this.killed = true; return true; });
 }
 
-function makeFakeChild(): FakeChild { return new FakeChild(); }
+const fakeChildren: FakeChild[] = [];
+
+function makeFakeChild(): FakeChild {
+  const child = new FakeChild();
+  fakeChildren.push(child);
+  return child;
+}
+
 
 function findCall(predicate: (args: string[]) => boolean): string[] | undefined {
   for (const call of mockedExecFileSync.mock.calls) {
@@ -84,6 +94,7 @@ const PANE_READ_REPLY = (text: string) => JSON.stringify({ result: { read: { tex
 beforeEach(() => {
   mockedExecFileSync.mockReset();
   mockedSpawn.mockReset();
+  fakeChildren.length = 0;
   // Default: every spawn (including the bg `wait agent-status` watcher) gets
   // a fake child whose lifecycle the test fully controls.
   mockedSpawn.mockImplementation((() => makeFakeChild()) as any);
@@ -496,6 +507,88 @@ describe('HerdrBackend message writing', () => {
 // ─── Callbacks: onData delta + onExit ──────────────────────────────────────
 
 describe('HerdrBackend callbacks', () => {
+  it('streams native terminal frames without pane polling or status waiters', async () => {
+    setHerdrResponses([
+      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
+      {
+        match: a => a.includes('agent') && a.includes('start'),
+        reply: () => JSON.stringify({ result: { agent: { name: 'botmux', pane_id: 'w1:p1' } } }),
+      },
+    ]);
+
+    const backend = new HerdrBackend(SESSION);
+    const seen: string[] = [];
+    backend.onData(data => seen.push(data));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+
+    const observerIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('session') && args.includes('observe'));
+    const observer = observerIndex >= 0 ? fakeChildren[observerIndex] : undefined;
+    try {
+      expect(observer).toBeDefined();
+      expect(mockedSpawn.mock.calls.some(([, args]) =>
+        Array.isArray(args) && args.includes('wait') && args.includes('agent-status'))).toBe(false);
+
+      const first = JSON.stringify({
+        type: 'terminal.frame', seq: 1, full: true, encoding: 'ansi', width: 80, height: 24,
+        bytes: Buffer.from('\x1b[31mfirst\x1b[0m').toString('base64'),
+      });
+      const second = JSON.stringify({
+        type: 'terminal.frame', seq: 2, full: false, encoding: 'ansi', width: 80, height: 24,
+        bytes: Buffer.from(' second').toString('base64'),
+      });
+
+      observer!.stdout.write(first.slice(0, 17));
+      observer!.stdout.write(`${first.slice(17)}\n${second}\n`);
+      await waitForImmediate();
+      expect(seen.join('')).toBe('\x1b[31mfirst\x1b[0m second');
+      expect(herdrCall('agent', 'read')).toBeUndefined();
+      backend.kill();
+      expect(observer!.killed).toBe(true);
+    } finally {
+      if (!observer?.killed) backend.kill();
+    }
+  });
+
+  it('reattach drops the initial full frame and emits ordered incremental frames once', async () => {
+    setHerdrResponses([
+      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
+      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('w1:p1') },
+    ]);
+
+    const backend = new HerdrBackend(SESSION, { isReattach: true });
+    const seen: string[] = [];
+    backend.onData(data => seen.push(data));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+
+    const observerIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('session') && args.includes('observe'));
+    const observer = observerIndex >= 0 ? fakeChildren[observerIndex] : undefined;
+    try {
+      expect(observer).toBeDefined();
+      expect(mockedSpawn.mock.calls.some(([, args]) =>
+        Array.isArray(args) && args.includes('wait') && args.includes('agent-status'))).toBe(false);
+      for (const frame of [
+        { seq: 1, full: true, text: 'seeded screen' },
+        { seq: 2, full: false, text: ' delta' },
+        { seq: 2, full: false, text: ' duplicate' },
+        { seq: 1, full: false, text: ' stale' },
+        { seq: 3, full: false, text: ' done' },
+      ]) {
+        observer!.stdout.write(`${JSON.stringify({
+          type: 'terminal.frame', seq: frame.seq, full: frame.full, encoding: 'ansi', width: 80, height: 24,
+          bytes: Buffer.from(frame.text).toString('base64'),
+        })}\n`);
+      }
+      await waitForImmediate();
+      expect(seen.join('')).toBe(' delta done');
+      expect(herdrCall('agent', 'read')).toBeUndefined();
+      backend.kill();
+      expect(observer!.killed).toBe(true);
+    } finally {
+      if (!observer?.killed) backend.kill();
+    }
+  });
   it('onData fires with the prefix-delta when pane recent output grows', () => {
     let paneText = 'hello';
     setHerdrResponses([

--- a/test/herdr-backend.test.ts
+++ b/test/herdr-backend.test.ts
@@ -551,6 +551,108 @@ describe('HerdrBackend callbacks', () => {
     }
   });
 
+  it('decodes one UTF-8 character split across consecutive terminal frames', async () => {
+    setHerdrResponses([
+      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
+      {
+        match: a => a.includes('agent') && a.includes('start'),
+        reply: () => JSON.stringify({ result: { agent: { name: 'botmux', pane_id: 'w1:p1' } } }),
+      },
+    ]);
+
+    const backend = new HerdrBackend(SESSION);
+    const seen: string[] = [];
+    backend.onData(data => seen.push(data));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const observerIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    const observer = fakeChildren[observerIndex]!;
+    const bytes = Buffer.from('你');
+
+    observer.stdout.write(`${JSON.stringify({
+      type: 'terminal.frame', seq: 1, full: true, encoding: 'ansi', width: 80, height: 24,
+      bytes: bytes.subarray(0, 2).toString('base64'),
+    })}\n`);
+    observer.stdout.write(`${JSON.stringify({
+      type: 'terminal.frame', seq: 2, full: false, encoding: 'ansi', width: 80, height: 24,
+      bytes: bytes.subarray(2).toString('base64'),
+    })}\n`);
+    await waitForImmediate();
+
+    expect(seen.join('')).toBe('你');
+    expect(seen.join('')).not.toContain('�');
+    backend.kill();
+  });
+
+  it('restarts a disconnected observer and forwards its full rebaseline before new deltas', async () => {
+    vi.useFakeTimers();
+    setHerdrResponses([
+      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
+      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('w1:p1') },
+      { match: a => a.includes('agent') && a.includes('list'), reply: () => AGENT_LIST_REPLY('w1:p1') },
+    ]);
+
+    const backend = new HerdrBackend(SESSION, { isReattach: true });
+    const seen: string[] = [];
+    const exits: Array<[number | null, string | null]> = [];
+    backend.onData(data => seen.push(data));
+    backend.onExit((code, signal) => exits.push([code, signal]));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const firstObserverIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    const firstObserver = fakeChildren[firstObserverIndex]!;
+
+    firstObserver.emit('exit', 1, null);
+    expect(firstObserver.killed).toBe(true);
+    firstObserver.stdout.write(`${JSON.stringify({
+      type: 'terminal.frame', seq: 99, full: false, encoding: 'ansi', width: 80, height: 24,
+      bytes: Buffer.from('stale observer').toString('base64'),
+    })}\n`);
+    vi.advanceTimersByTime(500);
+
+    const observerCalls = mockedSpawn.mock.calls.filter(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    expect(observerCalls).toHaveLength(2);
+    const restartedObserver = fakeChildren.at(-1)!;
+    restartedObserver.stdout.write(`${JSON.stringify({
+      type: 'terminal.frame', seq: 1, full: true, encoding: 'ansi', width: 80, height: 24,
+      bytes: Buffer.from('reconnected baseline').toString('base64'),
+    })}\n`);
+    restartedObserver.stdout.write(`${JSON.stringify({
+      type: 'terminal.frame', seq: 2, full: false, encoding: 'ansi', width: 80, height: 24,
+      bytes: Buffer.from(' delta').toString('base64'),
+    })}\n`);
+    await vi.runAllTicks();
+
+    expect(seen.join('')).toBe('reconnected baseline delta');
+    expect(exits).toEqual([]);
+    backend.kill();
+  });
+  it('kill cancels a pending observer restart', () => {
+    vi.useFakeTimers();
+    setHerdrResponses([
+      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
+      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('w1:p1') },
+      { match: a => a.includes('agent') && a.includes('list'), reply: () => AGENT_LIST_REPLY('w1:p1') },
+    ]);
+
+    const backend = new HerdrBackend(SESSION, { isReattach: true });
+    const exits: Array<[number | null, string | null]> = [];
+    backend.onExit((code, signal) => exits.push([code, signal]));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const observerIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    fakeChildren[observerIndex]!.emit('exit', 1, null);
+
+    backend.kill();
+    vi.advanceTimersByTime(500);
+
+    const observerCalls = mockedSpawn.mock.calls.filter(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    expect(observerCalls).toHaveLength(1);
+    expect(exits).toEqual([]);
+  });
+
   it('reattach drops the initial full frame and emits ordered incremental frames once', async () => {
     setHerdrResponses([
       { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
@@ -641,30 +743,6 @@ describe('HerdrBackend callbacks', () => {
     expect(exits).toEqual([[7, null]]);
   });
 
-  it('restarts a disconnected observer when the agent is still alive', () => {
-    vi.useFakeTimers();
-    setHerdrResponses([
-      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
-      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('w1:p1') },
-      { match: a => a.includes('agent') && a.includes('list'), reply: () => AGENT_LIST_REPLY('w1:p1') },
-    ]);
-
-    const backend = new HerdrBackend(SESSION, { isReattach: true });
-    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
-    const observersBefore = mockedSpawn.mock.calls.filter(([, args]) =>
-      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
-    const observerIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
-      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
-    const firstObserver = fakeChildren[observerIndex]!;
-
-    firstObserver.emit('exit', 1, null);
-    expect(firstObserver.killed).toBe(true);
-    vi.advanceTimersByTime(500);
-    const observersAfter = mockedSpawn.mock.calls.filter(([, args]) =>
-      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
-    expect(observersAfter).toHaveLength(observersBefore.length + 1);
-    backend.kill();
-  });
 
   it('resize replaces the observer and forwards its full rebaseline frame', async () => {
     setHerdrResponses([


### PR DESCRIPTION
## 改了什么

- 将 `HerdrBackend` 的实时输出从 `500ms agent list + agent read --lines 10000 + 字符串 diff` 迁移到 Herdr `terminal session observe` 原生 NDJSON 终端流。
- 使用 Zod 校验 `terminal.frame` / `terminal.closed`，支持 stdout 拆包/粘包、base64 ANSI 字节和跨 frame UTF-8 解码。
- 按 `seq` 去重并过滤乱序帧；observer 异常退出时单次探测 agent，存活则重连，消失则触发 backend exit。
- resize 时重建 observer，并用新的 full frame 重新建立终端基线；kill/destroy 会清理 observer 和重连 timer。
- 保留 reattach/adopt 的 snapshot seed；observer 的首个 full frame不再被丢弃，因为它可能包含 seed 之后产生的新输出。
- worker 当前在 `spawn()` 后注册 `onData`，backend 会暂存此前到达的最早帧并在首个 listener 注册时交付，避免启动竞态丢失完整画面。
- Herdr 最低版本提升到 `0.7.2`，旧版本明确提示执行 `herdr update`，不保留轮询 fallback。

## 为什么

旧实时路径每个会话持续执行轮询和固定 10,000 行扫描，并在 Node.js 中做全量字符串差分：

- 空闲会话仍产生周期性 Herdr CLI / IPC 开销；
- 长终端历史会重复传输和扫描；
- 固定滚屏窗口跨边界时可能无法可靠恢复增量。

Herdr `0.7.2+` 已提供单个长连接的 ANSI 终端流，可直接传递首帧和后续绘制增量。

## TDD 补充验证

新增并执行了以下回归契约：

- 一个 UTF-8 字符被拆到连续两个 `terminal.frame` 时仍完整解码，不产生 `�`。
- observer 断开重连后转发新的 full rebaseline，再继续接收增量；旧 observer 的迟到帧被忽略。
- backend kill 会取消等待中的 observer 重连，不会后台复活子进程。
- `spawn()` 后、首个 `onData` listener 注册前到达的 full frame 不会丢失。
- 真实 Herdr reattach：snapshot seed 恢复已有画面，现存 shell 后续自主输出通过 observer 到达并由 `TerminalRenderer` 正确渲染。

RED 证据：旧实现 unit 只得到 `delta done`、丢失 reattach full frame；真实 Herdr 0.7.3 reattach 新输出超时。GREEN 后上述路径全部通过。

## 影响面

- **Herdr backend**：实时输出读取、observer 生命周期、resize/reconnect 基线、最低版本检查。
- **保持不变**：Herdr 输入仍走现有 `pane send-text` / `pane send-keys`；显式 screen capture 仍使用 read API。
- **其它 backend**：PTY、Tmux、Zellij、Riff 未修改。
- **会话类型**：fresh、持久会话 reattach、external adopt 均有定向覆盖。
- **平台**：通过 `spawn()` 参数数组调用 Herdr CLI，不新增 shell 或平台专用路径。

## 验证

使用 Node 22：

- `pnpm build`：通过。
- `test/herdr-backend.test.ts`：32/32。
- Herdr discovery + worker initial-screen 契约：67/67。
- 真实 Herdr 0.7.3 `test/herdr-backend.e2e.ts`：8/8。
- 全量 unit：8356 通过、6 跳过、1 个既有失败。
  - 既有失败：`test/dashboard-monitoring-ui.test.ts:326` 期望 `.ui-info-pop-floating` 含 `pointer-events: none`；本 PR 未修改 dashboard CSS 或该测试。
- `git diff --check origin/master...HEAD`：通过。

## 关联

- Herdr CLI reference: https://herdr.dev/docs/cli-reference/
- 与 #419 都会修改 Herdr backend/worker 测试；两者解决不同问题，本 PR 聚焦 daemon 实时输出流，合并时需要保留 #419 的 Web Terminal snapshot/cursor/viewer 契约。
