### PR TITLE
fix(dashboard): 认证用户保持终端可写

### DIFF
--- a/src/dashboard/web/sessions.ts
+++ b/src/dashboard/web/sessions.ts
@@ -109,7 +109,9 @@ export function sessionSearchText(s: any): string {
 export const terminalHref = sessionTerminalHref;
 
 export function shouldOpenWritableTerminal(state: { authed: boolean; publicReadOnly: boolean } = ui): boolean {
-  return state.authed && !state.publicReadOnly;
+  if (state.authed) return true;
+  if (state.publicReadOnly) return false;
+  return false;
 }
 
 // Cohesive icon set for the session-card action bar — stroke-based (CSS sets

--- a/src/dashboard/web/ui.ts
+++ b/src/dashboard/web/ui.ts
@@ -33,10 +33,8 @@ class DashboardUiState {
   // must not see a control whose endpoint they'd 401 on. Defaults true so a
   // transient probe failure never hides it from a real token holder.
   authed = true;
-  // Effective dashboard sharing policy. Session terminal affordances use this
-  // (rather than the current visitor's cookie alone) to choose their default:
-  // private dashboards open a writable terminal, explicitly public dashboards
-  // keep the shared entry read-only.
+  // Effective dashboard sharing policy. When enabled, tokenless visitors may
+  // read allow-listed dashboard data; it does not downgrade authenticated users.
   publicReadOnly = false;
   private listeners = new Set<UiListener>();
   private translate = createDashboardTranslator(this.locale);

--- a/test/dashboard-sessions-ui.test.ts
+++ b/test/dashboard-sessions-ui.test.ts
@@ -109,10 +109,11 @@ describe('dashboard sessions filters', () => {
       .not.toBe(historySenderKey({ senderType: 'bot', senderId: 'ou_bot' }));
   });
 
-  it('defaults terminal entry to writable unless public read-only sharing is enabled', () => {
+  it('prioritizes dashboard auth over public read-only sharing', () => {
     expect(shouldOpenWritableTerminal({ authed: true, publicReadOnly: false })).toBe(true);
-    expect(shouldOpenWritableTerminal({ authed: true, publicReadOnly: true })).toBe(false);
+    expect(shouldOpenWritableTerminal({ authed: true, publicReadOnly: true })).toBe(true);
     expect(shouldOpenWritableTerminal({ authed: false, publicReadOnly: true })).toBe(false);
+    expect(shouldOpenWritableTerminal({ authed: false, publicReadOnly: false })).toBe(false);
   });
 
   it('renders the CLI filter as a multi-select checkbox group, not a dropdown', () => {


### PR DESCRIPTION
## 问题

Dashboard 开启 `publicReadOnly` 后，即使当前浏览器已持有有效 Dashboard token（`authed=true`），会话卡片和终端弹窗仍直接打开只读 URL，不会请求 `/api/sessions/:id/write-link`。

根因是 `shouldOpenWritableTerminal` 同时要求 `authed && !publicReadOnly`，把匿名分享策略错误地当成了认证用户的权限降级。

## 修复

- 明确访问优先级：有效 Dashboard 认证优先于 `publicReadOnly`；认证用户保持可写。
- 未认证且开启 `publicReadOnly` 的访客仍然只读；未认证的私有 Dashboard 仍无写权限。
- 修正 `DashboardUiState.publicReadOnly` 注释，说明它只开放匿名只读数据，不会降级认证用户。
- 补齐 `authed/publicReadOnly` 四种组合的回归测试。

服务端鉴权边界没有放宽：`/api/sessions/:id/write-link` 仍要求有效 Dashboard token。

## 影响面

- 影响 Dashboard 会话卡片和终端弹窗的打开行为。
- 所有 CLI / 会话后端共用该前端判断；会话生命周期和终端服务端鉴权不变。
- 匿名公开访问仍为只读，私有 Dashboard 的未认证访问仍会被拒绝。

## 验证

- `vitest run test/dashboard-sessions-ui.test.ts test/dashboard-auth.test.ts`：61 passed
- `pnpm run build`：passed
- `git diff --check`：passed
