### PR TITLE
fix(dashboard): 修复筛选输入白屏

### DIFF
--- a/src/dashboard/web/schedules-page.tsx
+++ b/src/dashboard/web/schedules-page.tsx
@@ -220,7 +220,10 @@ function SchedulesPage() {
             type="checkbox"
             name="enabled"
             checked={filters.enabledOnly}
-            onChange={e => setFilters(f => ({ ...f, enabledOnly: e.currentTarget.checked }))}
+            onChange={event => {
+              const enabledOnly = event.currentTarget.checked;
+              setFilters(f => ({ ...f, enabledOnly }));
+            }}
           />
           <span className="filter-toggle-label">{tr('schedules.enabledOnly')}</span>
           <span className="filter-toggle-switch" aria-hidden="true" />

--- a/src/dashboard/web/sessions-page.tsx
+++ b/src/dashboard/web/sessions-page.tsx
@@ -472,7 +472,10 @@ function SessionsFilters(props: {
         name="q"
         placeholder={t('sessions.search')}
         value={props.filters.q}
-        onChange={event => props.setFilters(prev => ({ ...prev, q: event.currentTarget.value }))}
+        onChange={event => {
+          const q = event.currentTarget.value;
+          props.setFilters(prev => ({ ...prev, q }));
+        }}
       />
       <DropdownMenu
         label={statusLabel}
@@ -523,7 +526,10 @@ function SessionsFilters(props: {
           type="checkbox"
           name="active"
           checked={props.filters.active}
-          onChange={event => props.setFilters(prev => ({ ...prev, active: event.currentTarget.checked }))}
+          onChange={event => {
+            const active = event.currentTarget.checked;
+            props.setFilters(prev => ({ ...prev, active }));
+          }}
         />
         <span className="filter-toggle-label">{t('sessions.activeOnly')}</span>
         <span className="filter-toggle-switch" aria-hidden="true" />

--- a/test/dashboard-schedules-ui.test.ts
+++ b/test/dashboard-schedules-ui.test.ts
@@ -1,7 +1,16 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { filterSchedules, fmtScheduleDate } from '../src/dashboard/web/schedules-page.js';
 
 describe('dashboard schedules React page helpers', () => {
+  it('reads enabled filter checkbox state before entering React state updaters', () => {
+    const page = readFileSync(new URL('../src/dashboard/web/schedules-page.tsx', import.meta.url), 'utf8');
+
+    expect(page).toContain('const enabledOnly = event.currentTarget.checked;');
+    expect(page).not.toContain('enabledOnly: e.currentTarget.checked');
+    expect(page).not.toContain('enabledOnly: event.currentTarget.checked');
+  });
+
   it('filters by kind, enabled state, and text query', () => {
     const rows = [
       { id: 'daily', name: 'Daily Standup', enabled: true, parsed: { kind: 'cron', display: '0 9 * * *' }, nextRunAt: '2026-06-30T09:00:00.000Z' },

--- a/test/dashboard-sessions-ui.test.ts
+++ b/test/dashboard-sessions-ui.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -60,6 +61,15 @@ function renderKanban(state: Partial<SessionsKanbanState>): string {
 }
 
 describe('dashboard sessions filters', () => {
+  it('reads filter input values before entering React state updaters', () => {
+    const page = readFileSync(new URL('../src/dashboard/web/sessions-page.tsx', import.meta.url), 'utf8');
+
+    expect(page).toContain('const q = event.currentTarget.value;');
+    expect(page).toContain('const active = event.currentTarget.checked;');
+    expect(page).not.toContain('q: event.currentTarget.value');
+    expect(page).not.toContain('active: event.currentTarget.checked');
+  });
+
   it('derives CLI filter options from the shared CLI registry', () => {
     expect(CLI_FILTER_OPTIONS).toContain('codex');
     expect(CLI_FILTER_OPTIONS).toContain('codex-app');


### PR DESCRIPTION
## 改动
- 修复 Dashboard 会话控制页搜索框/活跃筛选在 React state updater 内读取 `event.currentTarget` 的问题。
- 顺手修复日程页“仅启用”筛选同类潜在问题。
- 补充源码级回归测试，避免再次把 `event.currentTarget.value/checked` 放入函数式 updater。

## 原因
用户反馈会话控制页搜索框输入任意 2 个字符后白屏，Console 栈为：

`Cannot read properties of null (reading 'value')`

定位到搜索框 `onChange` 中：

`setFilters(prev => ({ ...prev, q: event.currentTarget.value }))`

React 在执行函数式 updater 时事件回调已结束，`event.currentTarget` 可能为 `null`，从而触发白屏。改为在事件回调同步阶段先读取 `value/checked`，再传给 updater。

## 影响面
- 影响 Dashboard 前端筛选控件：
  - 会话控制页搜索框
  - 会话控制页“仅活跃”筛选
  - 日程页“仅启用”筛选
- 不涉及 daemon、worker、CLI adapter、会话后端、飞书消息链路。
- 仅改变事件处理时机，不改变筛选逻辑/数据结构。

## 测试
- `pnpm exec vitest run --project unit test/dashboard-sessions-ui.test.ts test/dashboard-schedules-ui.test.ts test/webhook-logs-dashboard.test.ts`
  - 3 files passed / 20 tests passed
- `pnpm build`
