### PR TITLE
fix(lark): 话题群 owned-topic 免@续话改为遵循「群聊 @ 策略」配置

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -233,7 +233,7 @@ On mobile/tablet, a floating shortcut toolbar provides Esc, Ctrl+C, Tab, arrow k
 
 ### Multi-Bot Collaboration
 
-Run multiple Lark bots on a single machine, each mapped to a different CLI. In the same group chat, messages are routed via @mention — each bot gets its own isolated CLI process. With a single bot in the group, it responds automatically without @. In a regular (non-topic) group, `@<bot1> @<bot2> /t xxx` spawns one independent thread per mentioned bot anchored at the same message. Send `@<bot1> @<bot2> /introduce` once so they register each other's open_id; afterwards each bot can explicitly @-mention the others from within its own session (commands: [📖 Docs · Slash Commands](https://deepcoldy.github.io/botmux/en/slash-commands)).
+Run multiple Lark bots on a single machine, each mapped to a different CLI. In the same group chat, messages are routed via @mention — each bot gets its own isolated CLI process. In a 1:1 group (you + one bot) it responds automatically without @; multi-person groups require @ by default (the per-bot "Group @ policy" can relax this inside owned topics or group-wide). In a regular (non-topic) group, `@<bot1> @<bot2> /t xxx` spawns one independent thread per mentioned bot anchored at the same message. Send `@<bot1> @<bot2> /introduce` once so they register each other's open_id; afterwards each bot can explicitly @-mention the others from within its own session (commands: [📖 Docs · Slash Commands](https://deepcoldy.github.io/botmux/en/slash-commands)).
 
 ### Multi-Topic Collaboration
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ botmux 可以管理 CLI 无关的自定义 Skill Registry，并按 bot 配置在
 
 ### 多机器人协作
 
-同一台机器上可运行多个飞书机器人，每个机器人可对应不同的 CLI。同一群聊中通过 @mention 路由消息，仅有一个机器人时无需 @ 自动响应；多机器人时 `@<bot1> @<bot2> /t xxx` 可让每个被 @ 的机器人在同一条消息上各自独立开新话题。先发一次 `@<bot1> @<bot2> /introduce` 让它们互相登记 open_id，之后各 bot 就能在自己的会话里显式 @mention 对方协作（命令详见 [📖 文档 · 斜杠命令](https://deepcoldy.github.io/botmux/slash-commands)）。
+同一台机器上可运行多个飞书机器人，每个机器人可对应不同的 CLI。同一群聊中通过 @mention 路由消息，仅「你 + 1 个机器人」的 1v1 群无需 @ 自动响应，多人群默认必须 @（可通过「群聊 @ 策略」配置话题内免 @ / 全群免 @）；多机器人时 `@<bot1> @<bot2> /t xxx` 可让每个被 @ 的机器人在同一条消息上各自独立开新话题。先发一次 `@<bot1> @<bot2> /introduce` 让它们互相登记 open_id，之后各 bot 就能在自己的会话里显式 @mention 对方协作（命令详见 [📖 文档 · 斜杠命令](https://deepcoldy.github.io/botmux/slash-commands)）。
 
 ### 多话题协作模式
 

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -2496,28 +2496,15 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
           // permitted senders. (The shared fold-back's replyRootId is already
           // handled by the first clause.)
           const mentionMode = resolveGroupMentionMode(larkAppId);
-          // 话题群 owned-topic 免@续话 — single-bot groups only. In a multi-bot
-          // topic every co-resident bot owns a session on the same thread anchor,
-          // so relaxing here would make ALL of them answer a message that
-          // @mentioned only one (or none) of them; botCount > 1 keeps the
-          // "@ required" contract. `stats` is the cached group stats (fetched
-          // above when ownsSession; its 999/999 API-failure fallback also lands
-          // on the safe "require @" side). A message that @mentions another
-          // specific member is a redirect to someone else → back off, mirroring
-          // the ambient carve-out.
-          const ownedTopicGroupFollowup = !explicitlyMentionedThisBot
-            && isAllowed
-            && ownsSession
-            && !!stats && stats.botCount <= 1
-            && !mentionsAnotherMember(larkAppId, message)
-            && routing.scope === 'thread'
-            && !!message.thread_id
-            && await getChatMode(larkAppId, chatId) === 'topic';
+          // 话题群 owned-topic 免@续话不再无条件放行（#336 引入的默认行为回归：
+          // 多人群里旁人不 @ 也会触发 bot）。现在与普通群共用同一套「群聊 @ 策略」:
+          // 默认 'always' 在多人群里必须 @，想要话题内免@续话就把 mentionMode 配成
+          // 'topic'（下方条款已同时覆盖话题群 thread 与普通群 shared topic），
+          // 'never'/'ambient' 亦按各自语义生效。1人1bot 的 solo 群仍走末条放行。
           const relax = (!!replyRootId && isAllowed)
             || (!!substituteTrigger && isAllowed)
             || (isAllowed && mentionMode === 'never')
             || (isAllowed && mentionMode === 'ambient' && !mentionsAnotherMember(larkAppId, message))
-            || ownedTopicGroupFollowup
             || (isAllowed && mentionMode === 'topic' && ownsSession && !!message.thread_id && !mentionsAnotherMember(larkAppId, message))
             || (ownsSession && isAllowed && !!stats && stats.userCount <= 1 && stats.botCount <= 1);
           if (!relax) {

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -2595,7 +2595,9 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
   });
 
-  it('topic group default: a non-@ reply inside an owned topic continues the session', async () => {
+  it('topic group default (always): a non-@ reply inside an owned topic is ignored in a multi-person group', async () => {
+    // #336 曾无条件放行「owned-topic 免@续话」，导致多人话题群里旁人不 @ 也触发
+    // bot。现在话题群与普通群共用「群聊 @ 策略」：默认 always 必须 @。
     setupBotState({ allowedUsers: [USER_OPEN_ID] }); // default always
     mockGetChatMode.mockResolvedValue('topic');
     mockGetChatInfo.mockResolvedValue({ userCount: 3, botCount: 1 });
@@ -2608,6 +2610,57 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
       threadId: 'owned-topic-root',
       messageId: 'msg-in-owned-topic-group',
       chatId: 'chat-topic-group',
+      chatType: 'group',
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+  });
+
+  it('topic group + mention mode topic: a non-@ reply inside an owned topic continues the session', async () => {
+    setupBotState({ allowedUsers: [USER_OPEN_ID], regularGroupMentionMode: 'topic' });
+    mockGetChatMode.mockResolvedValue('topic');
+    mockGetChatInfo.mockResolvedValue({ userCount: 3, botCount: 1 });
+    handlers.resolveReplyThreadAlias.mockReturnValue(null);
+    handlers.isSessionOwner.mockImplementation((anchor: string) => anchor === 'owned-topic-root');
+    const event = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'continue without @ under topic tier' }),
+      rootId: 'owned-topic-root',
+      threadId: 'owned-topic-root',
+      messageId: 'msg-in-owned-topic-tier',
+      chatId: 'chat-topic-group-tier',
+      chatType: 'group',
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
+      scope: 'thread',
+      anchor: 'owned-topic-root',
+      larkAppId: MY_APP_ID,
+    }));
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+  });
+
+  it('topic group default, solo 1v1: a non-@ reply inside an owned topic still continues the session', async () => {
+    // 1人1bot 的 solo 群保留免@体验（走 userCount<=1 && botCount<=1 的末条放行）。
+    setupBotState({ allowedUsers: [USER_OPEN_ID] }); // default always
+    mockGetChatMode.mockResolvedValue('topic');
+    mockGetChatInfo.mockResolvedValue({ userCount: 1, botCount: 1 });
+    handlers.resolveReplyThreadAlias.mockReturnValue(null);
+    handlers.isSessionOwner.mockImplementation((anchor: string) => anchor === 'owned-topic-root');
+    const event = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'solo group, continue without @' }),
+      rootId: 'owned-topic-root',
+      threadId: 'owned-topic-root',
+      messageId: 'msg-in-owned-topic-solo',
+      chatId: 'chat-topic-group-solo',
       chatType: 'group',
     });
 


### PR DESCRIPTION
## 背景

申晗报告：话题群多人场景下，未 @ 机器人也会回复。

排查结论：PR #336（45bc65e3，接入 Genius 适配器）夹带引入了 `ownedTopicGroupFollowup` 无条件放行——单 bot 话题群里，bot 拥有话题会话后，**任何**有发言权限的人不 @ 也会触发回复，不检查群内人数。同日 c984c385 收紧到单 bot 群（恢复多 bot「必须 @」契约），但「多个人类」维度仍然放行。这使话题群完全绕过了「群聊 @ 策略」（默认「都需要 @」）配置。

## 改了什么

移除 `ownedTopicGroupFollowup` 无条件放行条款，话题群与普通群统一由 `regularGroupMentionMode`（群聊 @ 策略）管辖（方案 C，申晗拍板）：

- 默认 `always`：多人群里必须 @ ——恢复 #336 之前的契约
- `topic`：话题内免@续话 —— 该条款原本就同时覆盖话题群 thread 与普通群共享话题（`ownsSession && message.thread_id && !mentionsAnotherMember`），删掉夹带条款后自然接管
- `never` / `ambient`：按各自语义生效，不受影响
- **1人1bot solo 群体验不变**：仍走 `userCount<=1 && botCount<=1` 末条放行

README 中「仅有一个机器人时无需 @ 自动响应」的过宽表述同步修正（中英双份）。

## 影响面评估

- 只动 `src/im/lark/event-dispatcher.ts` 群消息 @ 门控的 relax 表达式一处，不涉及 CLI 适配器 / 后端 / worker 共用路径
- 受影响会话类型：话题群 owned-topic 免@续话（行为变更，默认收紧）；多 bot 话题群（不变，仍必须 @）；solo 群（不变）；普通群 shared/new-topic、substituteTrigger、replyRootId 折返、p2p（均不动，relax 其余条款原样保留）
- **用户可感知变化**：多人话题群里想保留「话题内不用每条都 @」体验的 bot，需在 dashboard 把「群聊 @ 策略」设为「仅话题内不需要 @」（bot 级配置）

## 测试

- `npx vitest run test/event-dispatcher.test.ts` → 200/200 通过
  - 翻转「话题群默认免@续话」断言为默认忽略
  - 新增：话题群 + mentionMode='topic' 免@续话生效；话题群 solo 1v1 免@保留
- `pnpm build` 通过
- `pnpm test` 全量：9129 passed / 3 failed —— 失败为 scheduler/schedule-card 时间敏感用例（本机 America/Los_Angeles 时区的既有环境基线），在干净 master（/root/iserver/botmux）对照跑同样 3 个失败，与本改动无关
- live 验证：待部署后在多人话题群实测「不 @ 不回复、@ 了回复、solo 群免@不变」