### PR TITLE
feat(cli): 兼容 update 升级命令

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@
  *   botmux restart [--include-pm2] [--with-plugin] — restart daemon, then ensure auto plugin services
  *   botmux logs [--lines] — view daemon logs
  *   botmux status         — show daemon status
- *   botmux upgrade        — upgrade to latest version
+ *   botmux upgrade|update — upgrade to latest version
  *   botmux list           — interactive session picker (TUI), attach to tmux
  *   botmux list --plain   — plain table output (for piping / scripts)
  *   botmux delete <id>    — close a session by ID prefix
@@ -4002,7 +4002,7 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
   restart     重启 daemon（默认不停止插件 service，core 启动后确保 mode=auto 正在运行；--with-plugin 显式先停再启动 auto service；--include-pm2 同时重启 PM2 God）
   logs        查看 daemon 日志（--lines N, --bot <0-based-index|pm2-name|appId>）
   status      查看 daemon 状态
-  upgrade     升级到最新版本
+  upgrade     升级到最新版本（别名：update）
   dashboard   打印新的 Web Dashboard 一次性登录 URL（旧 token 同时失效）
   list        列出活跃会话（交互式选择并连接 tmux）
               --plain  纯文本表格输出（管道/脚本场景）
@@ -8261,7 +8261,8 @@ switch (command) {
   case 'restart': await cmdRestart(); break;
   case 'logs':    cmdLogs(); break;
   case 'status':  cmdStatus(); break;
-  case 'upgrade': cmdUpgrade(); break;
+  case 'upgrade':
+  case 'update':  cmdUpgrade(); break;
   case 'dashboard': await cmdDashboard(); break;
   case 'bind': {
     // `botmux bind <code>` — 把本机绑定到中心化平台

--- a/test/cli-update-alias.test.ts
+++ b/test/cli-update-alias.test.ts
@@ -1,0 +1,52 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const CLI_PATH = join(__dirname, '..', 'src', 'cli.ts');
+const PROJECT_ROOT = join(__dirname, '..');
+
+let home: string;
+
+beforeAll(() => {
+  home = mkdtempSync(join(tmpdir(), 'botmux-update-alias-'));
+});
+
+afterAll(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+function runCli(command: string): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync(process.execPath, ['--import', 'tsx', CLI_PATH, command], {
+    cwd: PROJECT_ROOT,
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      SESSION_DATA_DIR: join(home, 'data'),
+      PATH: '',
+    },
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+describe('botmux update alias', () => {
+  it('behaves exactly like upgrade', () => {
+    const upgrade = runCli('upgrade');
+    const update = runCli('update');
+
+    expect(upgrade.status).toBe(1);
+    expect(upgrade.stderr).toContain('无法安全识别当前安装方式');
+    expect(update).toEqual(upgrade);
+  });
+
+  it('documents the alias in help', () => {
+    const help = runCli('--help');
+
+    expect(help.status).toBe(0);
+    expect(help.stdout).toContain('upgrade     升级到最新版本（别名：update）');
+  });
+});


### PR DESCRIPTION
## 改了什么

- 增加一级命令 `botmux update`，与现有 `botmux upgrade` 共用同一个 `cmdUpgrade()` 执行路径。
- 在 CLI usage 与 `--help` 中标明 `update` 别名。
- 增加真实 CLI 边界测试，对比 `upgrade` / `update` 的退出码、stdout、stderr，防止两条路径以后分叉。

## 为什么

部分用户习惯使用 `update` 表达 CLI 自更新。兼容这个命令可以降低记忆成本，同时保留 `upgrade` 的原有行为和脚本兼容性。

## 影响面

- 仅涉及 CLI 一级命令分发与帮助文案。
- 不修改包管理器识别、安装执行、daemon、IM、会话或平台相关逻辑。
- alias 本身无平台分支，npm / pnpm / Bun 仍走原有 `upgrade` 实现。

## 验证

- `pnpm build`：通过。
- `pnpm exec vitest run --project unit test/cli-update-alias.test.ts test/global-install.test.ts`：2 files / 14 tests 通过。
- `pnpm test`：556 files / 9042 tests 通过；本机 macOS 上另有 2 个未改动的平台相关文件失败（共 83 个用例）：
  - `test/vc-meeting-daemon-session.test.ts`：Darwin 不提供测试所需的 managed side-effect isolation。
  - `test/worker-terminal-read-auth.integration.test.ts`：PTY 写入集成断言超时。
