### PR TITLE
fix(hermes): 持久化原生会话用于冷恢复

### DIFF
--- a/src/adapters/cli/hermes.ts
+++ b/src/adapters/cli/hermes.ts
@@ -3,6 +3,7 @@ import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
 import type { CliAdapter, PtyHandle } from './types.js';
 
 import { delay } from '../../utils/timing.js';
+import { hermesSessionExists } from '../../services/hermes-transcript.js';
 
 export function createHermesAdapter(pathOverride?: string): CliAdapter {
   // resolvedBin is lazy: setup constructs adapters only to read static
@@ -14,16 +15,20 @@ export function createHermesAdapter(pathOverride?: string): CliAdapter {
     id: 'hermes',
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
-    buildArgs({ sessionId, resume, disableCliBypass }) {
+    buildArgs({ sessionId, resume, resumeSessionId, disableCliBypass }) {
       const args: string[] = [];
-      if (resume) args.push('--resume', sessionId);
+      if (resume) args.push('--resume', resumeSessionId ?? sessionId);
       if (!disableCliBypass) args.push('--yolo', '--accept-hooks');
       args.push('--pass-session-id');
       return args;
     },
 
-    buildResumeCommand({ sessionId }) {
-      return `hermes --resume ${sessionId}`;
+    buildResumeCommand({ sessionId, cliSessionId }) {
+      return `hermes --resume ${cliSessionId ?? sessionId}`;
+    },
+
+    checkResumeTargetExists({ sessionId, cliSessionId, stateDbPath }) {
+      return hermesSessionExists(cliSessionId ?? sessionId, stateDbPath);
     },
 
     async writeInput(pty: PtyHandle, content: string) {

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -432,6 +432,9 @@ export interface CliAdapter {
     /** Claude-family data dir (~/.claude, ~/.claude-runtime, …) so the probe
      *  targets the SAME root the adapter will actually write into. */
     dataDir?: string;
+    /** Optional CLI-specific resume store path resolved by the worker after
+     *  applying per-bot env/profile settings (for example Hermes state.db). */
+    stateDbPath?: string;
   }): boolean | undefined;
 
   /** Optional: discover sessions resumable from this CLI's on-disk transcript

--- a/src/services/hermes-transcript.ts
+++ b/src/services/hermes-transcript.ts
@@ -134,3 +134,36 @@ print(row[0] or 0)
   if (proc.status !== 0) return 0;
   return Number.parseInt(proc.stdout.trim(), 10) || 0;
 }
+
+export function hermesSessionExists(sessionId: string | undefined, dbPath = HERMES_STATE_DB): boolean | undefined {
+  const sid = sessionId?.trim();
+  if (!sid || !existsSync(dbPath)) return undefined;
+  const script = `
+import sqlite3
+conn = sqlite3.connect(${JSON.stringify(dbPath)})
+sid = ${JSON.stringify(sid)}
+
+def has_table(name):
+    row = conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1", (name,)).fetchone()
+    return row is not None
+
+if has_table('sessions'):
+    row = conn.execute("SELECT 1 FROM sessions WHERE id = ? LIMIT 1", (sid,)).fetchone()
+    if row is not None:
+        print('1')
+        raise SystemExit(0)
+
+if has_table('messages'):
+    row = conn.execute("SELECT 1 FROM messages WHERE session_id = ? LIMIT 1", (sid,)).fetchone()
+    print('1' if row is not None else '0')
+    raise SystemExit(0)
+
+print('0')
+`;
+  const proc = spawnSync('python3', ['-c', script], { encoding: 'utf8' });
+  if (proc.status !== 0) return undefined;
+  const out = proc.stdout.trim();
+  if (out === '1') return true;
+  if (out === '0') return false;
+  return undefined;
+}

--- a/src/services/hermes-transcript.ts
+++ b/src/services/hermes-transcript.ts
@@ -138,6 +138,20 @@ print(row[0] or 0)
 export function hermesSessionExists(sessionId: string | undefined, dbPath = HERMES_STATE_DB): boolean | undefined {
   const sid = sessionId?.trim();
   if (!sid || !existsSync(dbPath)) return undefined;
+  // Three-state, deliberately conservative (the CliAdapter contract only lets us
+  // force a fresh session when we can PROVE the target is absent):
+  //   1       -> session provably exists  -> true
+  //   0       -> session provably absent  -> false
+  //   unknown -> can't tell (unrecognized schema / query error) -> undefined
+  //
+  // Hermes resume is authoritative on `sessions.id` (SessionDB.get_session in
+  // hermes-agent 0.18.x). An orphan row in `messages` whose session_id is not
+  // in `sessions` is NOT resumable, so once a `sessions` table is present we
+  // trust it alone and never let a stray message vote "exists". The `messages`
+  // fallback is only for older schemas that predate the `sessions` table. If we
+  // recognize neither table (unknown/future schema) we return unknown rather
+  // than "absent", so the worker keeps the resume attempt instead of silently
+  // dropping context to a fresh start.
   const script = `
 import sqlite3
 conn = sqlite3.connect(${JSON.stringify(dbPath)})
@@ -149,16 +163,15 @@ def has_table(name):
 
 if has_table('sessions'):
     row = conn.execute("SELECT 1 FROM sessions WHERE id = ? LIMIT 1", (sid,)).fetchone()
-    if row is not None:
-        print('1')
-        raise SystemExit(0)
+    print('1' if row is not None else '0')
+    raise SystemExit(0)
 
 if has_table('messages'):
     row = conn.execute("SELECT 1 FROM messages WHERE session_id = ? LIMIT 1", (sid,)).fetchone()
     print('1' if row is not None else '0')
     raise SystemExit(0)
 
-print('0')
+print('unknown')
 `;
   const proc = spawnSync('python3', ['-c', script], { encoding: 'utf8' });
   if (proc.status !== 0) return undefined;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3321,6 +3321,7 @@ function hermesBridgeIngest(): void {
   // `/clear`-rotates mid-batch; the daemon accumulates them into its authorized
   // set, so a completed turn from an earlier source is not dropped as foreign.
   for (const boundSourceSessionId of filtered.newlyBoundSourceSessionIds) {
+    persistCliSessionId(boundSourceSessionId);
     send({ type: 'bridge_source_session', bridge: 'hermes', sourceSessionId: boundSourceSessionId });
     log(`Hermes bridge bound sourceSessionId=${boundSourceSessionId}`);
   }
@@ -6662,6 +6663,16 @@ async function spawnCli(
       log(`WARN Claude resume transcript sync failed: ${(err as Error).message}`);
     }
   }
+  // Hermes stores sessions in a SQLite state.db (not cwd-scoped JSONL). Resolve
+  // the same path the bridge uses — honoring per-bot env, the forced
+  // BOTMUX_SESSION_ID, and the hermes-botmux-session wrapper profile — so the
+  // adapter probe below queries the exact DB Hermes will `--resume` against.
+  const hermesResumeStateDbPath = cfg.cliId === 'hermes'
+    ? resolveHermesStateDbPath(
+      { ...process.env, ...sanitizePerBotEnv(cfg.env), BOTMUX_SESSION_ID: cfg.sessionId },
+      { botmuxSessionProfile: basename(cfg.cliPathOverride ?? '') === 'hermes-botmux-session' },
+    )
+    : undefined;
   const tier2ForceFresh = effectiveResume && consecutiveInWorkerRestarts >= 2;
   let tier1ProbeFalse = false;
   if (effectiveResume && !tier2ForceFresh && !willReattachPersistent) {
@@ -6670,6 +6681,7 @@ async function spawnCli(
       cliSessionId: effectiveCliSessionId,
       workingDir: cfg.workingDir,
       dataDir: claudeDataDir,
+      stateDbPath: hermesResumeStateDbPath,
     });
     if (probe === false) tier1ProbeFalse = true;
   }

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -1033,6 +1033,22 @@ describe('hermes buildArgs', () => {
     expect(args).toEqual(['--resume', 'bm-hermes-1', '--yolo', '--accept-hooks', '--pass-session-id']);
   });
 
+  it('resume session prefers persisted Hermes native session id', () => {
+    const args = adapter.buildArgs({
+      sessionId: 'bm-hermes-1',
+      resume: true,
+      resumeSessionId: '20260716_163643_7782fd',
+    });
+    expect(args).toEqual(['--resume', '20260716_163643_7782fd', '--yolo', '--accept-hooks', '--pass-session-id']);
+  });
+
+  it('buildResumeCommand prefers persisted Hermes native session id', () => {
+    expect(adapter.buildResumeCommand?.({
+      sessionId: 'bm-hermes-1',
+      cliSessionId: '20260716_163643_7782fd',
+    })).toBe('hermes --resume 20260716_163643_7782fd');
+  });
+
   it('omits yolo and hook acceptance when disableCliBypass is true', () => {
     const args = adapter.buildArgs({ sessionId: 'bm-hermes-1', resume: false, disableCliBypass: true });
     expect(args).toEqual(['--pass-session-id']);
@@ -1565,9 +1581,11 @@ describe('buildResumeCommand', () => {
       .toBe('mtr --session ses_001122334455abcdefABCDEF12');
   });
 
-  it('hermes emits `hermes --resume <sessionId>`', () => {
+  it('hermes emits `hermes --resume <cliSessionId>` when known', () => {
     const a = createHermesAdapter('/bin/hermes');
     expect(a.buildResumeCommand?.({ sessionId: 'bm-hermes', cliSessionId: 'ignored' }))
+      .toBe('hermes --resume ignored');
+    expect(a.buildResumeCommand?.({ sessionId: 'bm-hermes' }))
       .toBe('hermes --resume bm-hermes');
   });
 

--- a/test/hermes-session-exists.realdb.test.ts
+++ b/test/hermes-session-exists.realdb.test.ts
@@ -1,0 +1,107 @@
+// Real-SQLite coverage for hermesSessionExists() — the three-state resume probe.
+//
+// The sibling hermes-transcript.test.ts mocks node:child_process wholesale, so
+// it only asserts the stdout->return mapping and never exercises the Python
+// control flow inside the probe. This file drives the *un-mocked* probe against
+// real state.db files so the actual schema-detection branches are covered:
+//   - `sessions` table present, id hit          -> true
+//   - `sessions` table present, id missing       -> false (NO messages fallback,
+//                                                    even if an orphan message row
+//                                                    with that session_id exists)
+//   - only legacy `messages` table, id hit/miss   -> true / false
+//   - neither known table (unknown schema)        -> undefined
+//   - db file absent                              -> undefined
+import { mkdtempSync, rmSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { hermesSessionExists } from '../src/services/hermes-transcript.js';
+
+// The probe shells out to python3 + sqlite3; skip gracefully if unavailable so
+// the suite stays green on hosts without a Python interpreter.
+const pythonProbe = spawnSync('python3', ['-c', 'import sqlite3'], { encoding: 'utf8' });
+const hasPython = pythonProbe.status === 0;
+const maybe = hasPython ? it : it.skip;
+
+function buildDb(dir: string, name: string, sql: string): string {
+  const dbPath = join(dir, name);
+  const script = `
+import sqlite3
+conn = sqlite3.connect(${JSON.stringify(dbPath)})
+conn.executescript(${JSON.stringify(sql)})
+conn.commit()
+conn.close()
+`;
+  const proc = spawnSync('python3', ['-c', script], { encoding: 'utf8' });
+  if (proc.status !== 0) throw new Error(`failed to build fixture db: ${proc.stderr}`);
+  return dbPath;
+}
+
+describe('hermesSessionExists (real sqlite)', () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'hermes-session-exists-'));
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  maybe('returns true when the id is present in the sessions table', () => {
+    const db = buildDb(dir, 'sessions-hit.db', `
+      CREATE TABLE sessions (id TEXT PRIMARY KEY, title TEXT);
+      INSERT INTO sessions (id, title) VALUES ('20260716_163643_7782fd', 'x');
+    `);
+    expect(hermesSessionExists('20260716_163643_7782fd', db)).toBe(true);
+  });
+
+  maybe('returns false when sessions table exists but the id is absent — even with an orphan message', () => {
+    // The critical regression: a message row references a session_id that has
+    // no row in `sessions`. Hermes resume keys on sessions.id, so this target is
+    // NOT resumable and the probe must say false (previously it leaked to a
+    // messages fallback and returned a false-positive true).
+    const db = buildDb(dir, 'orphan-message.db', `
+      CREATE TABLE sessions (id TEXT PRIMARY KEY, title TEXT);
+      INSERT INTO sessions (id, title) VALUES ('some-other-session', 'x');
+      CREATE TABLE messages (id INTEGER PRIMARY KEY, session_id TEXT, role TEXT, content TEXT);
+      INSERT INTO messages (session_id, role, content) VALUES ('20260716_163643_7782fd', 'user', 'orphan');
+    `);
+    expect(hermesSessionExists('20260716_163643_7782fd', db)).toBe(false);
+  });
+
+  maybe('falls back to the messages table only when there is no sessions table (legacy schema)', () => {
+    const hit = buildDb(dir, 'legacy-hit.db', `
+      CREATE TABLE messages (id INTEGER PRIMARY KEY, session_id TEXT, role TEXT, content TEXT);
+      INSERT INTO messages (session_id, role, content) VALUES ('legacy-1', 'user', 'hi');
+    `);
+    expect(hermesSessionExists('legacy-1', hit)).toBe(true);
+
+    const miss = buildDb(dir, 'legacy-miss.db', `
+      CREATE TABLE messages (id INTEGER PRIMARY KEY, session_id TEXT, role TEXT, content TEXT);
+      INSERT INTO messages (session_id, role, content) VALUES ('legacy-1', 'user', 'hi');
+    `);
+    expect(hermesSessionExists('nope', miss)).toBe(false);
+  });
+
+  maybe('returns undefined for an unrecognized schema (neither sessions nor messages)', () => {
+    const db = buildDb(dir, 'unknown-schema.db', `
+      CREATE TABLE conversations (uuid TEXT PRIMARY KEY, blob BLOB);
+      INSERT INTO conversations (uuid, blob) VALUES ('whatever', x'00');
+    `);
+    expect(hermesSessionExists('20260716_163643_7782fd', db)).toBeUndefined();
+  });
+
+  maybe('returns undefined when the db file is absent', () => {
+    expect(hermesSessionExists('20260716_163643_7782fd', join(dir, 'does-not-exist.db'))).toBeUndefined();
+  });
+
+  maybe('returns undefined for a blank/whitespace session id', () => {
+    const db = buildDb(dir, 'blank-id.db', `
+      CREATE TABLE sessions (id TEXT PRIMARY KEY, title TEXT);
+    `);
+    expect(hermesSessionExists('   ', db)).toBeUndefined();
+  });
+});

--- a/test/hermes-transcript.test.ts
+++ b/test/hermes-transcript.test.ts
@@ -88,4 +88,33 @@ describe('hermes transcript reader', () => {
 
     expect(currentHermesStateOffset('/tmp/state.db')).toBe(42);
   });
+
+  it('checks whether a Hermes native session exists', async () => {
+    existsSyncMock.mockReturnValue(true);
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: '1\n', stderr: '' } as any);
+    const { hermesSessionExists } = await import('../src/services/hermes-transcript.js');
+
+    expect(hermesSessionExists('20260716_163643_7782fd', '/tmp/state.db')).toBe(true);
+    expect(spawnSyncMock.mock.calls[0]?.[1]).toEqual(['-c', expect.stringContaining('SELECT 1 FROM sessions WHERE id = ? LIMIT 1')]);
+  });
+
+  it('returns false when Hermes session is provably absent', async () => {
+    existsSyncMock.mockReturnValue(true);
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: '0\n', stderr: '' } as any);
+    const { hermesSessionExists } = await import('../src/services/hermes-transcript.js');
+
+    expect(hermesSessionExists('missing-session', '/tmp/state.db')).toBe(false);
+  });
+
+  it('returns undefined when Hermes state.db is missing or unreadable', async () => {
+    const { hermesSessionExists } = await import('../src/services/hermes-transcript.js');
+
+    existsSyncMock.mockReturnValue(false);
+    expect(hermesSessionExists('20260716_163643_7782fd', '/tmp/missing.db')).toBeUndefined();
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+
+    existsSyncMock.mockReturnValue(true);
+    spawnSyncMock.mockReturnValue({ status: 1, stdout: '', stderr: 'broken' } as any);
+    expect(hermesSessionExists('20260716_163643_7782fd', '/tmp/state.db')).toBeUndefined();
+  });
 });

--- a/test/hermes-worker-bridge-wiring.test.ts
+++ b/test/hermes-worker-bridge-wiring.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('Hermes worker bridge wiring', () => {
+  it('persists each newly bound Hermes native source session id before announcing it', () => {
+    const source = readFileSync(new URL('../src/worker.ts', import.meta.url), 'utf8');
+    const loopStart = source.indexOf('for (const boundSourceSessionId of filtered.newlyBoundSourceSessionIds)');
+    expect(loopStart).toBeGreaterThan(0);
+    const loopEnd = source.indexOf('\n  }\n  hermesBridgeSourceSessionId = filtered.boundSourceSessionId;', loopStart);
+    expect(loopEnd).toBeGreaterThan(loopStart);
+    const body = source.slice(loopStart, loopEnd);
+
+    expect(body).toContain('persistCliSessionId(boundSourceSessionId);');
+    expect(body.indexOf('persistCliSessionId(boundSourceSessionId);')).toBeLessThan(
+      body.indexOf("send({ type: 'bridge_source_session'"),
+    );
+  });
+});


### PR DESCRIPTION
## 改动说明

修复 Hermes 适配器冷恢复时使用 botmux 逻辑 sessionId 作为 `hermes --resume` 目标，导致 Hermes 报 `Session not found`、上下文丢失的问题。

主要改动：
- Hermes bridge 识别到 native `sourceSessionId` 后，复用现有 `cli_session_id` 链路持久化到 botmux session 的 `cliSessionId`。
- Hermes adapter resume 时优先使用持久化的 `resumeSessionId` / `cliSessionId`，缺失时才 fallback 到 botmux `sessionId`。
- 为 Hermes 增加 resume target 预检查：查询 Hermes `state.db` 中 `sessions.id`，并 fallback 查询 `messages.session_id`；能确认不存在时复用 worker 现有 fresh fallback，避免 crash-loop。
- worker 传入 Hermes 实际使用的 `state.db` 路径，覆盖 `HERMES_HOME` / `BOTMUX_HERMES_STATE_DB` / `hermes-botmux-session` profile 场景。

## 影响面

- 主要影响 Hermes CLI 的冷恢复路径（daemon 重启、worker 回收/关闭、机器重启后的 PTY/Tmux 冷启动）。
- 改动触达通用 `CliAdapter.checkResumeTargetExists` 参数，新增可选 `stateDbPath`，不改变其它 CLI 既有行为。
- Hermes bridge 绑定 native source 时会更新 session store / dashboard 可见的 `cliSessionId`；多个 Hermes Bot 共享 state.db 时仍依赖现有 marker 过滤逻辑隔离。
- `/clear` 导致一次 drain 绑定多个 Hermes source 时，会按顺序持久化，最后一个 source 成为后续冷恢复目标，符合恢复最新 Hermes 上下文的预期。

## 测试验证

已通过：

```bash
pnpm vitest run --project unit test/cli-adapters.test.ts test/hermes-transcript.test.ts test/hermes-worker-bridge-wiring.test.ts test/hermes-session-filter.test.ts
# Test Files  4 passed (4)
# Tests  314 passed (314)

pnpm build
# tsc + dashboard bundle + dist audit 通过
```

补充执行：

```bash
pnpm test
```

结果：整体测试执行到 `564 passed / 567 files`、`9089 passed / 9095 tests`，失败 6 个，均与本次 Hermes 改动无关，集中在 Linux 进程发现/worker fence 类测试：
- `test/session-discovery.smoke.test.ts` 期望 node comm，实际为 `MainThread`
- `test/v3-cancel-runtime.test.ts` 2 个 timeout
- `test/v3-worker-fence.test.ts` 3 个进程发现结果从 one/recovered 变 ambiguous

## 后续验证建议

发布 canary 后请在 macOS + PTY + Hermes 0.18.2 环境验证：
1. 首轮 Hermes 对话成功。
2. botmux session 中写入 Hermes native `cliSessionId`（如 `20260716_163643_7782fd`）。
3. 强制关闭 worker / 重启 daemon。
4. 下一条消息冷启动执行 `hermes --resume <Hermes native id>`，上下文仍可恢复。
