### PR TITLE
fix(github): 支持 GitHub Releases API token

### DIFF
--- a/docs-site/docs/en/env.md
+++ b/docs-site/docs/en/env.md
@@ -11,6 +11,11 @@
 | `SESSION_DATA_DIR` | `~/.botmux/data` | Session and queue storage directory |
 | `BACKEND_TYPE` | _(auto-detect)_ | `pty` forces a downgrade to pure pty mode |
 | `DEBUG` | _(unset)_ | Set to `1` to enable debug logging |
+| `GITHUB_TOKEN` | _(unset)_ | Auth token for GitHub Releases API requests made by botmux itself, including dashboard changelog, update checks, and restart-report. Takes precedence over `GH_TOKEN`. |
+| `GH_TOKEN` | _(unset)_ | Fallback auth token for GitHub Releases API requests. Used only when `GITHUB_TOKEN` is unset. |
+
+> `GITHUB_TOKEN` / `GH_TOKEN` may be provided in the calling process environment or in `~/.botmux/.env` so both the daemon and the standalone Dashboard process can read them.
+> botmux uses these tokens only for its own GitHub requests and strips them from default worker / agent inheritance. If a specific bot should receive a token explicitly, configure it in that bot's own `env`.
 
 ### Dashboard-related
 

--- a/docs-site/docs/zh/env.md
+++ b/docs-site/docs/zh/env.md
@@ -11,6 +11,11 @@
 | `SESSION_DATA_DIR` | `~/.botmux/data` | 会话和队列存储目录 |
 | `BACKEND_TYPE` | _(自动检测)_ | `pty` 强制降级到纯 pty 模式 |
 | `DEBUG` | _(未设置)_ | 设为 `1` 启用调试日志 |
+| `GITHUB_TOKEN` | _(未设置)_ | GitHub Releases API 认证 token。用于 Dashboard changelog、更新检查、restart-report 等 botmux 自身发起的 GitHub 请求。优先级高于 `GH_TOKEN`。 |
+| `GH_TOKEN` | _(未设置)_ | GitHub Releases API 认证 token 后备变量。仅在 `GITHUB_TOKEN` 未设置时使用。 |
+
+> `GITHUB_TOKEN` / `GH_TOKEN` 可写在调用进程环境，或写入 `~/.botmux/.env` 供 daemon 与独立 Dashboard 进程读取。
+> botmux 只把它们用于自身 GitHub 请求，不会自动下发给 worker / agent；如需某个 bot 显式继承 token，需在该 bot 的 `env` 中单独配置。
 
 ### Dashboard 相关
 

--- a/src/core/github-auth.ts
+++ b/src/core/github-auth.ts
@@ -1,0 +1,59 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { parse as dotenvParse } from 'dotenv';
+
+export interface GithubAuthResolveOptions {
+  env?: NodeJS.ProcessEnv;
+  envFilePath?: string | null;
+  readTextFile?: (path: string) => string;
+  fileExists?: (path: string) => boolean;
+}
+
+function firstNonBlank(values: Array<string | undefined>): string | null {
+  for (const value of values) {
+    const trimmed = typeof value === 'string' ? value.trim() : '';
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function readGithubTokenFromEnvFile(
+  envFilePath: string | null | undefined,
+  readTextFile: (path: string) => string,
+  fileExists: (path: string) => boolean,
+): string | null {
+  if (!envFilePath || !fileExists(envFilePath)) return null;
+  try {
+    const parsed = dotenvParse(readTextFile(envFilePath));
+    return firstNonBlank([parsed.GITHUB_TOKEN, parsed.GH_TOKEN]);
+  } catch {
+    return null;
+  }
+}
+
+function defaultGlobalEnvPath(): string | null {
+  try {
+    return join(homedir(), '.botmux', '.env');
+  } catch {
+    return null;
+  }
+}
+
+function resolveGithubToken(options?: GithubAuthResolveOptions): string | null {
+  const env = options?.env ?? process.env;
+  const processToken = firstNonBlank([env.GITHUB_TOKEN, env.GH_TOKEN]);
+  if (processToken) return processToken;
+
+  const envFilePath = options?.envFilePath === undefined ? defaultGlobalEnvPath() : options.envFilePath;
+  return readGithubTokenFromEnvFile(
+    envFilePath,
+    options?.readTextFile ?? ((path) => readFileSync(path, 'utf8')),
+    options?.fileExists ?? existsSync,
+  );
+}
+
+export function githubAuthHeaders(options?: GithubAuthResolveOptions): Record<string, string> {
+  const token = resolveGithubToken(options);
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}

--- a/src/core/restart-report.ts
+++ b/src/core/restart-report.ts
@@ -6,6 +6,7 @@
  * groups on restart (those stay silent now). See core/maintenance.ts and the
  * daemon startup wiring.
  */
+import { githubAuthHeaders, type GithubAuthResolveOptions } from './github-auth.js';
 import type { RestartKind } from '../services/restart-intent-store.js';
 import { consumeRestartIntent } from '../services/restart-intent-store.js';
 import { countActiveSessionsOnDisk } from '../services/session-store.js';
@@ -87,6 +88,7 @@ export interface RestartReportWiring {
   dashboardLocalUrl?: string | undefined;
   /** Send the interactive card as a p2p DM to the owner. */
   sendCard: (openId: string, cardJson: string) => Promise<void>;
+  githubAuth?: GithubAuthResolveOptions;
   now?: number;
   log?: (msg: string) => void;
 }
@@ -108,7 +110,7 @@ export async function sendRestartReportIfPending(w: RestartReportWiring): Promis
   const version = botmuxVersion();
   let changelog: string | undefined;
   if (intent.kind === 'update' && intent.newVersion) {
-    changelog = (await fetchChangelog(intent.newVersion))
+    changelog = (await fetchChangelog(intent.newVersion, { auth: w.githubAuth }))
       ?? t('restart.changelog_link_fallback', { url: releasesUrl(intent.newVersion) }, locale);
   }
   const card = buildRestartReportCard({
@@ -131,11 +133,19 @@ export async function sendRestartReportIfPending(w: RestartReportWiring): Promis
 
 /** Best-effort GitHub release notes for a version. null on any failure (offline,
  *  rate-limited, release not yet published) — caller falls back to a link. */
-export async function fetchChangelog(newVersion: string): Promise<string | null> {
+export async function fetchChangelog(
+  newVersion: string,
+  opts?: { auth?: GithubAuthResolveOptions; fetchImpl?: typeof fetch; timeoutMs?: number },
+): Promise<string | null> {
+  const fetchImpl = opts?.fetchImpl ?? fetch;
   try {
-    const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${vtag(newVersion)}`, {
-      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'botmux' },
-      signal: AbortSignal.timeout(8_000),
+    const res = await fetchImpl(`https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${vtag(newVersion)}`, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'botmux',
+        ...githubAuthHeaders(opts?.auth),
+      },
+      signal: AbortSignal.timeout(opts?.timeoutMs ?? 8_000),
     });
     if (!res.ok) return null;
     const body = await res.json() as { body?: string };

--- a/src/core/update-check.ts
+++ b/src/core/update-check.ts
@@ -7,6 +7,7 @@
  * failure (offline, rate-limited, registry hiccup) so the card degrades to
  * "couldn't check" rather than erroring. The version math is pure (unit tested).
  */
+import { githubAuthHeaders, type GithubAuthResolveOptions } from './github-auth.js';
 import { GITHUB_REPO } from './restart-report.js';
 
 export interface ReleaseNote {
@@ -99,6 +100,7 @@ const REGISTRY_LATEST_URL = 'https://registry.npmjs.org/botmux/latest';
 export interface FetchOpts {
   timeoutMs?: number;
   fetchImpl?: typeof fetch;
+  auth?: GithubAuthResolveOptions;
 }
 
 /**
@@ -144,7 +146,11 @@ export async function fetchReleasesSince(
   const fetchImpl = opts?.fetchImpl ?? fetch;
   try {
     const res = await fetchImpl(`https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=100`, {
-      headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'botmux' },
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'botmux',
+        ...githubAuthHeaders(opts?.auth),
+      },
       signal: AbortSignal.timeout(opts?.timeoutMs ?? 8_000),
     });
     if (!res.ok) return { ok: false, rateLimited: res.status === 403, releases: [] };

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -109,6 +109,13 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const WORKER_SIGTERM_BACKSTOP_MS = 2_000;
 const WORKER_SIGKILL_BACKSTOP_MS = 7_000;
+const WORKER_REDACTED_ENV_KEYS = ['GITHUB_TOKEN', 'GH_TOKEN'] as const;
+
+function workerForkEnv(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...base };
+  for (const key of WORKER_REDACTED_ENV_KEYS) delete env[key];
+  return env;
+}
 
 // ─── Callbacks set by daemon at startup ─────────────────────────────────────
 
@@ -1946,12 +1953,13 @@ export function forkWorker(
   const botmuxBinDir = join(homedir(), '.botmux', 'bin');
   const pathWithBotmux = prependBotmuxBin(botmuxBinDir, process.env.PATH);
 
+  const forkEnv = workerForkEnv(process.env);
   const worker = fork(workerPath, [], {
     windowsHide: true,
     stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
     cwd,
     env: {
-      ...process.env,
+      ...forkEnv,
       PATH: pathWithBotmux,
       CLAUDECODE: undefined,
       BOTMUX: '1',  // Marker so user scripts/skills can detect a botmux-spawned CLI
@@ -3679,12 +3687,13 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
   const rawAdoptCwd = adopted.cwd ?? ds.workingDir ?? process.cwd();
   const adoptCwd = rawAdoptCwd && existsSync(rawAdoptCwd) ? rawAdoptCwd : homedir();
   if (adoptCwd !== rawAdoptCwd) logger.warn(`[${t}] adopt cwd "${rawAdoptCwd}" does not exist — falling back to ${adoptCwd}`);
+  const forkEnv = workerForkEnv(process.env);
   const worker = fork(workerPath, [], {
     windowsHide: true,
     stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
     cwd: adoptCwd,
     env: {
-      ...process.env,
+      ...forkEnv,
       CLAUDECODE: undefined,
       BOTMUX: '1',
       LARK_APP_ID: botCfg.larkAppId,

--- a/src/setup/ensure-tmux.ts
+++ b/src/setup/ensure-tmux.ts
@@ -24,7 +24,10 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { detectPlatform, type PackageManager, type PlatformInfo } from './detect-platform.js';
-import { isBotmuxManagedTmuxEnvKey } from '../utils/child-env.js';
+import {
+  isBotmuxManagedTmuxEnvKey,
+  isBotmuxManagedTmuxServerGlobalEnvKey,
+} from '../utils/child-env.js';
 
 export interface TmuxResult {
   installed: boolean;
@@ -119,15 +122,13 @@ function probeTmuxVersion(): TmuxVersionProbe {
  * alone — it just changes the socket directory and is the user's deliberate
  * override if set.
  *
- * tmuxEnv ALSO strips botmux's own session/bot-scoped vars
- * (isBotmuxManagedTmuxEnvKey): when botmux's first `tmux new-session` boots the
- * server, tmux copies this client env into the server's *global* environment,
- * which then leaks into every co-tenant session on the socket — including the
- * user's own interactive tmux, whose Claude Code would then misroute its
- * AskUserQuestion hook to whatever BOTMUX_SESSION_ID/CHAT_ID it inherited. The
- * pane gets the correct per-session values from the env(1) wrapper injection
- * instead, so this strip is invisible to botmux's own sessions. See
- * TMUX_CLIENT_STRIP_KEYS in utils/child-env.ts.
+ * tmuxEnv ALSO strips botmux's own session/bot-scoped vars and daemon-side
+ * bare creds (isBotmuxManagedTmuxEnvKey): when botmux's first `tmux
+ * new-session` boots the server, tmux copies this client env into the server's
+ * *global* environment, which then leaks into every co-tenant session on the
+ * socket — including the user's own interactive tmux. The pane gets the
+ * correct per-session values from the env(1) wrapper injection instead, so
+ * this strip is invisible to botmux's own sessions.
  */
 const TMUX_PATH_EXTRAS = [
   '/opt/homebrew/bin',
@@ -204,7 +205,7 @@ export function scrubTmuxServerGlobalEnv(socketName?: string): TmuxGlobalEnvScru
     // `show-environment -g` prints `NAME=value`, or `-NAME` for an explicitly
     // removed entry. Take the name in both shapes.
     .map(line => (line.startsWith('-') ? line.slice(1) : line.split('=', 1)[0]).trim())
-    .filter(name => name.length > 0 && isBotmuxManagedTmuxEnvKey(name));
+    .filter(name => name.length > 0 && isBotmuxManagedTmuxServerGlobalEnvKey(name));
 
   const removed: string[] = [];
   const failed: string[] = [];

--- a/src/utils/child-env.ts
+++ b/src/utils/child-env.ts
@@ -82,13 +82,31 @@ const TMUX_CLIENT_STRIP_KEYS: ReadonlySet<string> = new Set([
   ...REDACTED_CHILD_ENV_KEYS,
 ]);
 
+const TMUX_SERVER_GLOBAL_SCRUB_KEYS: ReadonlySet<string> = new Set([
+  ...BOTMUX_INJECTED_ENV_KEYS,
+  'LARK_APP_ID',
+  'LARK_APP_SECRET',
+  'CLAUDECODE',
+]);
+
 /**
- * True for any env key botmux manages and must keep out of the (shared) tmux
- * server global environment. Used by tmuxEnv() to strip the tmux client env and
- * by scrubTmuxServerGlobalEnv() to clean an already-polluted server.
+ * True for any env key botmux must keep out of the tmux CLIENT env it hands to
+ * the `tmux` binary. This is stricter than server-global scrub: besides
+ * botmux-owned routing/profile vars, we also strip daemon-side GitHub tokens so
+ * a botmux-started tmux server never seeds them into its shared global env.
  */
 export function isBotmuxManagedTmuxEnvKey(key: string): boolean {
   return key.startsWith('BOTMUX') || TMUX_CLIENT_STRIP_KEYS.has(key);
+}
+
+/**
+ * True for env keys botmux is allowed to repair out of an already-running tmux
+ * SERVER global environment. This intentionally excludes user-wide GitHub
+ * tokens: botmux panes must `unset` them locally, but daemon startup must not
+ * rewrite a shared tmux server's general-purpose env table.
+ */
+export function isBotmuxManagedTmuxServerGlobalEnvKey(key: string): boolean {
+  return key.startsWith('BOTMUX') || TMUX_SERVER_GLOBAL_SCRUB_KEYS.has(key);
 }
 
 /**

--- a/src/utils/child-env.ts
+++ b/src/utils/child-env.ts
@@ -2,10 +2,10 @@
  * Env vars that must never reach a spawned CLI child. The bot's IM-app creds
  * (a child CLI's own Lark OAuth reads `process.env.LARK_APP_ID` as the app to
  * authorize and gets hijacked by the botmux IM app → no docs scopes → 403
- * loop) and claude-code's nesting marker. The child resolves Lark via the
- * namespaced `BOTMUX_LARK_APP_ID` or via bots.json on disk (im/lark/client.ts);
- * the worker keeps its own bare creds (worker-pool.ts forkWorker) for
- * lark-upload — only the *child* is redacted.
+ * loop), daemon-side GitHub API tokens, and claude-code's nesting marker. The
+ * child resolves Lark via the namespaced `BOTMUX_LARK_APP_ID` or via bots.json
+ * on disk (im/lark/client.ts); the worker keeps its own bare creds
+ * (worker-pool.ts forkWorker) for lark-upload — only the *child* is redacted.
  *
  * Two leak vectors, two layers (both keyed off this list):
  *  - PTY / direct spawn: `redactChildEnv()` deletes them from the env object.
@@ -13,7 +13,13 @@
  *    client env can't override, so the shell wrapper `unset`s them before exec
  *    (see SHELL_WRAPPER_SCRIPT in tmux-backend.ts).
  */
-export const REDACTED_CHILD_ENV_KEYS = ['LARK_APP_ID', 'LARK_APP_SECRET', 'CLAUDECODE'] as const;
+export const REDACTED_CHILD_ENV_KEYS = [
+  'LARK_APP_ID',
+  'LARK_APP_SECRET',
+  'GITHUB_TOKEN',
+  'GH_TOKEN',
+  'CLAUDECODE',
+] as const;
 
 /**
  * Botmux-managed, session/bot-scoped env keys that reach the CLI pane via the

--- a/test/child-env.test.ts
+++ b/test/child-env.test.ts
@@ -30,6 +30,17 @@ describe('redactChildEnv()', () => {
     expect(base.CLAUDECODE).toBe('1');
   });
 
+  it('removes GitHub tokens from child env', () => {
+    const out = redactChildEnv({
+      GITHUB_TOKEN: 'ghp_secret',
+      GH_TOKEN: 'ghs_secret',
+      KEEP: 'v',
+    });
+    expect('GITHUB_TOKEN' in out).toBe(false);
+    expect('GH_TOKEN' in out).toBe(false);
+    expect(out.KEEP).toBe('v');
+  });
+
   it('real node-pty child does NOT inherit a redacted var (not the string "undefined")', async () => {
     // End-to-end guard for the actual leak vector Codex found: a spawned child
     // must see the redacted var as genuinely UNSET. `${VAR+x}` expands to empty

--- a/test/github-auth.test.ts
+++ b/test/github-auth.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { githubAuthHeaders } from '../src/core/github-auth.js';
+
+describe('githubAuthHeaders', () => {
+  it('prefers process GITHUB_TOKEN over GH_TOKEN', () => {
+    const headers = githubAuthHeaders({
+      env: { GITHUB_TOKEN: ' ghp_primary ', GH_TOKEN: 'ghs_fallback' },
+      envFilePath: null,
+    });
+    expect(headers.Authorization).toBe('Bearer ghp_primary');
+  });
+
+  it('falls back to process GH_TOKEN when GITHUB_TOKEN is absent', () => {
+    const headers = githubAuthHeaders({
+      env: { GH_TOKEN: ' ghs_fallback ' },
+      envFilePath: null,
+    });
+    expect(headers.Authorization).toBe('Bearer ghs_fallback');
+  });
+
+  it('falls back to env-file GITHUB_TOKEN when process env is unset', () => {
+    const headers = githubAuthHeaders({
+      env: {},
+      envFilePath: '/tmp/global.env',
+      fileExists: () => true,
+      readTextFile: () => 'GITHUB_TOKEN=ghp_from_file\nGH_TOKEN=ghs_ignored\n',
+    });
+    expect(headers.Authorization).toBe('Bearer ghp_from_file');
+  });
+
+  it('falls back to env-file GH_TOKEN when file GITHUB_TOKEN is absent', () => {
+    const headers = githubAuthHeaders({
+      env: {},
+      envFilePath: '/tmp/global.env',
+      fileExists: () => true,
+      readTextFile: () => 'GH_TOKEN=ghs_from_file\n',
+    });
+    expect(headers.Authorization).toBe('Bearer ghs_from_file');
+  });
+
+  it('returns no auth header on missing or invalid env file', () => {
+    expect(githubAuthHeaders({
+      env: {},
+      envFilePath: '/tmp/missing.env',
+      fileExists: () => false,
+    })).toEqual({});
+
+    expect(githubAuthHeaders({
+      env: {},
+      envFilePath: '/tmp/bad.env',
+      fileExists: () => true,
+      readTextFile: () => {
+        throw new Error('read failed');
+      },
+    })).toEqual({});
+  });
+});

--- a/test/herdr-backend.test.ts
+++ b/test/herdr-backend.test.ts
@@ -253,6 +253,30 @@ describe('HerdrBackend.spawn', () => {
     be.kill();
   });
 
+  it('per-bot GitHub tokens still flow through injectEnv to the CLI start env', () => {
+    let listCount = 0;
+    setHerdrResponses([
+      {
+        match: a => a[0] === 'session' && a[1] === 'list',
+        reply: () => { listCount++; return listCount >= 2 ? EXISTING_SESSION_REPLY : EMPTY_SESSIONS_REPLY; },
+      },
+      { match: a => a.includes('agent') && a.includes('start'), reply: () => AGENT_GET_REPLY('1-1') },
+      { match: a => a.includes('read') && (a.includes('agent') || a.includes('pane')), reply: () => PANE_READ_REPLY('') },
+    ]);
+    const be = new HerdrBackend(SESSION, { createSession: true });
+    be.spawn('claude', [], {
+      cwd: '/work', cols: 80, rows: 24,
+      env: { BOTMUX_SESSION_ID: 'sess_x' },
+      injectEnv: { GITHUB_TOKEN: 'ghp_explicit_bot' },
+    });
+
+    const serverSpawn = mockedSpawn.mock.calls.find(c => (c[1] as string[]).includes('server'));
+    expect(serverSpawn?.[2].env.GITHUB_TOKEN).toBe('ghp_explicit_bot');
+    const startOpts = findCallOpts(a => a.includes('agent') && a.includes('start'));
+    expect(startOpts?.env?.GITHUB_TOKEN).toBe('ghp_explicit_bot');
+    be.kill();
+  });
+
   it('without injectEnv the server env carries only the base env (no provider keys)', () => {
     let listCount = 0;
     setHerdrResponses([

--- a/test/restart-report.test.ts
+++ b/test/restart-report.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { countActiveSessionsOnDisk } from '../src/services/session-store.js';
-import { buildRestartReportText, sendRestartReportIfPending } from '../src/core/restart-report.js';
+import { buildRestartReportText, sendRestartReportIfPending, fetchChangelog } from '../src/core/restart-report.js';
 import { writeRestartIntentTo, restartIntentPathIn } from '../src/services/restart-intent-store.js';
 
 function writeSessions(dir: string, name: string, sessions: Record<string, { status: string }>) {
@@ -161,5 +161,52 @@ describe('sendRestartReportIfPending', () => {
     await sendRestartReportIfPending(w);
     await sendRestartReportIfPending(w);
     expect(sent).toHaveLength(1);
+  });
+});
+
+describe('fetchChangelog', () => {
+  it('adds GitHub bearer auth when githubToken is configured', async () => {
+    let auth: string | null = null;
+    const notes = await fetchChangelog('2.85.1', {
+      auth: { env: { GITHUB_TOKEN: ' ghp_secret ' }, envFilePath: null },
+      fetchImpl: async (_input, init) => {
+        const headers = init?.headers as Record<string, string> | undefined;
+        auth = headers?.Authorization ?? headers?.authorization ?? null;
+        return { ok: true, json: async () => ({ body: 'notes' }) } as Response;
+      },
+    });
+    expect(notes).toBe('notes');
+    expect(auth).toBe('Bearer ghp_secret');
+  });
+
+  it('omits GitHub bearer auth when githubToken is blank', async () => {
+    let auth: string | null = 'present';
+    await fetchChangelog('2.85.1', {
+      auth: { env: { GITHUB_TOKEN: '   ' }, envFilePath: null },
+      fetchImpl: async (_input, init) => {
+        const headers = init?.headers as Record<string, string> | undefined;
+        auth = headers?.Authorization ?? headers?.authorization ?? null;
+        return { ok: true, json: async () => ({ body: 'notes' }) } as Response;
+      },
+    });
+    expect(auth).toBeNull();
+  });
+
+  it('uses env-file auth fallback when process env is unset', async () => {
+    let auth: string | null = null;
+    await fetchChangelog('2.85.1', {
+      auth: {
+        env: {},
+        envFilePath: '/tmp/global.env',
+        fileExists: () => true,
+        readTextFile: () => 'GITHUB_TOKEN=ghp_from_file\n',
+      },
+      fetchImpl: async (_input, init) => {
+        const headers = init?.headers as Record<string, string> | undefined;
+        auth = headers?.Authorization ?? headers?.authorization ?? null;
+        return { ok: true, json: async () => ({ body: 'notes' }) } as Response;
+      },
+    });
+    expect(auth).toBe('Bearer ghp_from_file');
   });
 });

--- a/test/session-lifecycle-start.test.ts
+++ b/test/session-lifecycle-start.test.ts
@@ -453,6 +453,19 @@ describe('session.start lifecycle integration', () => {
     }));
   });
 
+  it('removes GitHub tokens from the daemon→worker fork env', () => {
+    vi.stubEnv('GITHUB_TOKEN', 'ghp_secret');
+    vi.stubEnv('GH_TOKEN', 'ghs_secret');
+
+    forkWorker(makeDs(), 'hello', false);
+
+    const forkOpts = forkMock.mock.calls.at(-1)?.[2] as { env?: Record<string, string | undefined> } | undefined;
+    expect(forkOpts?.env?.GITHUB_TOKEN).toBeUndefined();
+    expect(forkOpts?.env?.GH_TOKEN).toBeUndefined();
+
+    vi.unstubAllEnvs();
+  });
+
   it('re-checks the resident-session cap after spawn and again on an idle edge', async () => {
     const enforceLiveSessionCap = vi.fn();
     initWorkerPool({
@@ -491,6 +504,27 @@ describe('session.start lifecycle integration', () => {
       adoptedFrom: 'bmx-deadbeef:0.0',
       pid: 12345,
     }));
+  });
+
+  it('removes GitHub tokens from the daemon→adopt-worker fork env', () => {
+    vi.stubEnv('GITHUB_TOKEN', 'ghp_secret');
+    vi.stubEnv('GH_TOKEN', 'ghs_secret');
+
+    forkAdoptWorker(makeDs({
+      adoptedFrom: {
+        tmuxTarget: 'bmx-deadbeef:0.0',
+        originalCliPid: 23456,
+        sessionId: 'codex-session',
+        cliId: 'codex',
+        cwd: '/repo',
+      },
+    }));
+
+    const forkOpts = forkMock.mock.calls.at(-1)?.[2] as { env?: Record<string, string | undefined> } | undefined;
+    expect(forkOpts?.env?.GITHUB_TOKEN).toBeUndefined();
+    expect(forkOpts?.env?.GH_TOKEN).toBeUndefined();
+
+    vi.unstubAllEnvs();
   });
 
   it('passes plugin bindings and Skill policy to the worker for CLI-generation refresh', () => {

--- a/test/tmux-backend-env.test.ts
+++ b/test/tmux-backend-env.test.ts
@@ -569,6 +569,8 @@ describe('shell wrapper end-to-end (the contract spawn() builds)', () => {
           __OWNER_OPEN_ID: 'ou_stale',
           BOTMUX_SESSION_ID: 'stale-session',
           BOTMUX_CHAT_ID: 'stale-chat',
+          GITHUB_TOKEN: 'ghp_stale',
+          GH_TOKEN: 'ghs_stale',
           IS_SANDBOX: '1',
           CLAUDE_CONFIG_DIR: '/stale/claude',
           CODEX_HOME: '/stale/codex',
@@ -585,11 +587,41 @@ describe('shell wrapper end-to-end (the contract spawn() builds)', () => {
       expect(lines).toContain('BOTMUX_SESSION_ID=fresh-session');
       expect(lines).toContain('BOTMUX_CHAT_ID=fresh-chat');
       for (const key of [
+        'GITHUB_TOKEN', 'GH_TOKEN',
         'IS_SANDBOX', 'CLAUDE_CONFIG_DIR', 'CODEX_HOME', 'HERMES_HOME',
         'HERMES_BOTMUX_SOURCE_HOME', 'HERMES_BOTMUX_PROFILES_ROOT',
       ]) {
         expect(lines.some(line => line.startsWith(`${key}=`)), key).toBe(false);
       }
+    },
+  );
+
+  it.skipIf(!hasEnvBin)(
+    'wrapper unsets inherited GitHub tokens before re-adding an explicit per-bot pane token',
+    () => {
+      const cwd = tmpdir();
+      const envAssignments = buildBotmuxEnvAssignments(
+        { BOTMUX: '1', SESSION_DATA_DIR: '/fresh-dir' },
+        { GITHUB_TOKEN: 'ghp_explicit_bot' },
+      );
+      const result = spawnSync(
+        '/bin/sh',
+        ['-c', SCRIPT, '_', cwd, ...envAssignments, '/usr/bin/env'],
+        {
+          encoding: 'utf-8',
+          env: {
+            GITHUB_TOKEN: 'ghp_stale_server',
+            GH_TOKEN: 'ghs_stale_server',
+            PATH: '/usr/bin:/bin',
+            HOME: '/tmp',
+          },
+        },
+      );
+      expect(result.status).toBe(0);
+      const lines = result.stdout.split('\n');
+      expect(lines).toContain('GITHUB_TOKEN=ghp_explicit_bot');
+      expect(lines.some(line => line === 'GITHUB_TOKEN=ghp_stale_server')).toBe(false);
+      expect(lines.some(line => line.startsWith('GH_TOKEN='))).toBe(false);
     },
   );
 

--- a/test/tmux-env-isolation.test.ts
+++ b/test/tmux-env-isolation.test.ts
@@ -22,7 +22,12 @@ import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { probeTmuxFunctional, scrubTmuxServerGlobalEnv, tmuxEnv } from '../src/setup/ensure-tmux.js';
-import { BOTMUX_INJECTED_ENV_KEYS, REDACTED_CHILD_ENV_KEYS, isBotmuxManagedTmuxEnvKey } from '../src/utils/child-env.js';
+import {
+  BOTMUX_INJECTED_ENV_KEYS,
+  REDACTED_CHILD_ENV_KEYS,
+  isBotmuxManagedTmuxEnvKey,
+  isBotmuxManagedTmuxServerGlobalEnvKey,
+} from '../src/utils/child-env.js';
 
 describe('tmuxEnv()', () => {
   it('strips TMUX and TMUX_PANE from the env', () => {
@@ -108,6 +113,14 @@ describe('tmuxEnv()', () => {
   it('classifies every per-pane and redacted key as tmux-managed', () => {
     for (const key of [...BOTMUX_INJECTED_ENV_KEYS, ...REDACTED_CHILD_ENV_KEYS]) {
       expect(isBotmuxManagedTmuxEnvKey(key), key).toBe(true);
+    }
+  });
+
+  it('does not classify GitHub tokens as botmux-owned tmux server-global keys', () => {
+    expect(isBotmuxManagedTmuxServerGlobalEnvKey('GITHUB_TOKEN')).toBe(false);
+    expect(isBotmuxManagedTmuxServerGlobalEnvKey('GH_TOKEN')).toBe(false);
+    for (const key of ['BOTMUX_SESSION_ID', 'LARK_APP_ID', 'LARK_APP_SECRET', 'CLAUDECODE']) {
+      expect(isBotmuxManagedTmuxServerGlobalEnvKey(key), key).toBe(true);
     }
   });
 
@@ -252,6 +265,8 @@ describe('tmux subcommand with stale $TMUX', () => {
         CODEX_HOME: '/stale/codex',
         HERMES_HOME: '/stale/hermes',
         LARK_APP_ID: 'stale-app',
+        GITHUB_TOKEN: 'ghp_server_global',
+        GH_TOKEN: 'ghs_server_global',
         HOME: '/safe/home',
       };
       delete pollutedEnv.TMUX;
@@ -272,15 +287,23 @@ describe('tmux subcommand with stale $TMUX', () => {
         expect(scrub.removed).toEqual(expect.arrayContaining([
           'BOTMUX_SESSION_ID', 'BOTMUX_CHAT_ID', 'CODEX_HOME', 'HERMES_HOME', 'LARK_APP_ID',
         ]));
+        expect(scrub.removed).not.toContain('GITHUB_TOKEN');
+        expect(scrub.removed).not.toContain('GH_TOKEN');
 
         const globalEnv = spawnSync('tmux', ['-L', sock, 'show-environment', '-g'], {
           env: tmuxEnv(), encoding: 'utf-8', timeout: 5000,
         });
         expect(globalEnv.status, globalEnv.stderr).toBe(0);
         expect(globalEnv.stdout).toContain('HOME=/safe/home');
+        expect(globalEnv.stdout).toContain('GITHUB_TOKEN=ghp_server_global');
+        expect(globalEnv.stdout).toContain('GH_TOKEN=ghs_server_global');
         for (const key of ['BOTMUX_SESSION_ID', 'BOTMUX_CHAT_ID', 'CODEX_HOME', 'HERMES_HOME', 'LARK_APP_ID']) {
           expect(globalEnv.stdout).not.toMatch(new RegExp(`(?:^|\\n)-?${key}(?:=|\\n|$)`));
         }
+
+        const strippedClientEnv = tmuxEnv(pollutedEnv);
+        expect(strippedClientEnv.GITHUB_TOKEN).toBeUndefined();
+        expect(strippedClientEnv.GH_TOKEN).toBeUndefined();
 
         // The holder existed before the global-table repair, so its process
         // environment remains untouched.

--- a/test/update-check.test.ts
+++ b/test/update-check.test.ts
@@ -132,6 +132,51 @@ describe('fetchReleasesSince', () => {
     expect(out.ok).toBe(true);
     expect(out.releases.map(r => r.version)).toEqual(['2.85.1']);
   });
+
+  it('adds GitHub bearer auth when githubToken is configured', async () => {
+    let auth: string | null = null;
+    await fetchReleasesSince('2.85.0', {
+      auth: { env: { GITHUB_TOKEN: ' ghp_secret ' }, envFilePath: null },
+      fetchImpl: async (_input, init) => {
+        const headers = init?.headers as Record<string, string> | undefined;
+        auth = headers?.Authorization ?? headers?.authorization ?? null;
+        return jsonResponse(200, []);
+      },
+    });
+    expect(auth).toBe('Bearer ghp_secret');
+  });
+
+  it('omits GitHub bearer auth when githubToken is blank', async () => {
+    let auth: string | null = 'present';
+    await fetchReleasesSince('2.85.0', {
+      auth: { env: { GITHUB_TOKEN: '   ' }, envFilePath: null },
+      fetchImpl: async (_input, init) => {
+        const headers = init?.headers as Record<string, string> | undefined;
+        auth = headers?.Authorization ?? headers?.authorization ?? null;
+        return jsonResponse(200, []);
+      },
+    });
+    expect(auth).toBeNull();
+  });
+
+  it('uses env-file auth fallback when process env is unset', async () => {
+    let auth: string | null = null;
+    await fetchReleasesSince('2.85.0', {
+      auth: {
+        env: {},
+        envFilePath: '/tmp/global.env',
+        fileExists: () => true,
+        readTextFile: () => 'GITHUB_TOKEN=ghp_from_file\n',
+      },
+      fetchImpl: async (_input, init) => {
+        const headers = init?.headers as Record<string, string> | undefined;
+        auth = headers?.Authorization ?? headers?.authorization ?? null;
+        return jsonResponse(200, []);
+      },
+    });
+    expect(auth).toBe('Bearer ghp_from_file');
+  });
+
   it('ok:true with an empty list when already latest (genuinely empty)', async () => {
     const out = await fetchReleasesSince('2.85.1', { fetchImpl: async () => jsonResponse(200, [{ tag_name: 'v2.85.1' }]) });
     expect(out).toMatchObject({ ok: true, releases: [] });


### PR DESCRIPTION
**背景**

Dashboard changelog 与 daemon restart-report 会读取 GitHub Releases API。未认证请求在共享出口 IP 下只有较低的速率额度；同时 Node.js `fetch` 不会自动读取 curl 的 `~/.curlrc` / `~/.netrc` 登录状态，因此需要一条显式、可移植且可审计的认证路径。

**改动**
- 新增共享 GitHub 认证 helper：优先读取 `GITHUB_TOKEN`，后备 `GH_TOKEN`；进程环境缺失时只读解析 `~/.botmux/.env`，不修改 `process.env`，不记录或缓存 token。
- `update-check` 与 `restart-report` 的 GitHub Releases 请求统一使用该 helper，Dashboard 与 daemon 共用同一认证语义。
- 默认阻断 token 从 daemon 继承到 worker、再继承到 CLI/tmux pane。
- tmux 边界做精确隔离：botmux client env 去除继承 token，pane wrapper 先 unset；但不删除用户共享 tmux server 的 global `GITHUB_TOKEN/GH_TOKEN`。
- 保留 per-bot 显式 env 注入能力，需要 token 的特定 bot 仍可显式配置。
- 补充中英文环境变量文档。
本次不新增 Dashboard 设置页、持久化配置或保存接口，也不解析 `.netrc`，不 shell out 到 curl/gh。

**公共层影响**
- 影响 GitHub Releases 更新检查、restart-report、daemon→worker fork 和 worker→CLI/tmux 的默认环境继承。
- 未配置 token 时保持原有匿名请求行为。
- daemon 级 GitHub token 默认不会下发给 worker/agent；特定 bot 如需使用，必须通过其自身 env 显式配置。
- 无 UI 变化，无需截图。
**验证**
- `corepack pnpm exec vitest run test/github-auth.test.ts test/child-env.test.ts test/update-check.test.ts test/restart-report.test.ts test/session-lifecycle-start.test.ts test/herdr-backend.test.ts test/tmux-env-isolation.test.ts`
    - `7 files / 134 tests` 通过。
- `corepack pnpm exec vitest run test/tmux-backend-env.test.ts -t 'wrapper clears every stale managed value|wrapper unsets inherited GitHub tokens'`
    - `2 tests` 通过。
- `PATH=/tmp/botmux-corepack-bin:$PATH pnpm build`
    - 通过。
- `git diff --check`
    - 通过。
- 真实集成验证：显式 unset 当前进程 `GITHUB_TOKEN/GH_TOKEN` 后，helper 可从真实 `~/.botmux/.env` 生成认证 header，且不污染 `process.env`；GitHub `/rate_limit` 返回 200、core limit 5000，Releases 与 changelog 请求成功。
- 标准全量 `pnpm test`：`9079 passed / 31 failed`。相同 31 条失败已在干净 base `53518e5aa459313f64f354bdc069af24ffab58da` 独立复现：25 条来自本机 Git 2.20.1 不支持 `git init -b`，1 条为既有 tmux keep-shell 失败，5 条为既有 v3 timeout/fence 不稳定；因此不声明“全量测试通过”。
- 未重启 live daemon：当前机器存在活跃 botmux 会话，为避免影响线上会话，采用隔离测试、build 与真实只读 GitHub API 请求完成验证。
