### PR TITLE
fix(worker): 剥离继承的会话级 CLI home 变量，修复非隔离 bot 串到兄弟 bot 的 home

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,7 @@ import { interactiveSelect, pickChoice, pickCliSelection } from './setup/interac
 import { buildPreset, serializePreset, presetFilename } from './setup/agent-preset.js';
 import type { CliId } from './adapters/cli/types.js';
 import { logger } from './utils/logger.js';
+import { scrubSessionCliHomeEnv } from './utils/child-env.js';
 import { scheduleTimeZone } from './utils/timezone.js';
 import { expandHomePath, invalidWorkingDirs } from './utils/working-dir.js';
 import { firstPositional } from './cli/arg-utils.js';
@@ -216,18 +217,16 @@ function pm2Bin(): string {
 /** Env for pm2 invocations with an isolated PM2_HOME. */
 function pm2Env(home: string = PM2_HOME): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env, PM2_HOME: home };
-  // CLAUDE_CONFIG_DIR / CODEX_HOME / GROK_HOME are PER-SESSION CLI data-root
-  // pointers, injected per-pane at spawn time (see worker.ts). They must never be
-  // baked into the long-lived pm2 daemon/worker env: pm2 persists the caller's env
-  // into every managed app (and into dump.pm2 for resurrect), so a
-  // `botmux start/restart` invoked from ANY process that happens to carry one —
-  // most commonly a bot's own session during self-upgrade, whose env holds its
-  // injected CLAUDE_CONFIG_DIR — would poison ALL workers. A non-isolated bot then
-  // inherits that value and its CLI reads/writes a sibling bot's home. Strip them
-  // at this boundary so the daemon stays session-agnostic.
-  delete env.CLAUDE_CONFIG_DIR;
-  delete env.CODEX_HOME;
-  delete env.GROK_HOME;
+  // pm2 persists the caller's env into every managed app (and into dump.pm2
+  // for resurrect), so a `botmux start/restart` invoked from ANY process that
+  // carries a session-level CLI home pointer — most commonly a bot's own
+  // session during self-upgrade, whose env holds its injected
+  // CLAUDE_CONFIG_DIR — would poison ALL workers, making every non-isolated
+  // bot read/write a sibling bot's home. Strip at this boundary so the daemon
+  // stays session-agnostic; daemon/worker boot scrub the same keys against
+  // stale dumps (see SESSION_CLI_HOME_ENV_KEYS for the full story, including
+  // why GROK_HOME is exempt and why deleting beats pinning a default).
+  scrubSessionCliHomeEnv(env);
   return env;
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -215,7 +215,20 @@ function pm2Bin(): string {
 
 /** Env for pm2 invocations with an isolated PM2_HOME. */
 function pm2Env(home: string = PM2_HOME): NodeJS.ProcessEnv {
-  return { ...process.env, PM2_HOME: home };
+  const env: NodeJS.ProcessEnv = { ...process.env, PM2_HOME: home };
+  // CLAUDE_CONFIG_DIR / CODEX_HOME / GROK_HOME are PER-SESSION CLI data-root
+  // pointers, injected per-pane at spawn time (see worker.ts). They must never be
+  // baked into the long-lived pm2 daemon/worker env: pm2 persists the caller's env
+  // into every managed app (and into dump.pm2 for resurrect), so a
+  // `botmux start/restart` invoked from ANY process that happens to carry one —
+  // most commonly a bot's own session during self-upgrade, whose env holds its
+  // injected CLAUDE_CONFIG_DIR — would poison ALL workers. A non-isolated bot then
+  // inherits that value and its CLI reads/writes a sibling bot's home. Strip them
+  // at this boundary so the daemon stays session-agnostic.
+  delete env.CLAUDE_CONFIG_DIR;
+  delete env.CODEX_HOME;
+  delete env.GROK_HOME;
+  return env;
 }
 
 function listPm2GodDaemonPids(home: string = PM2_HOME): number[] {

--- a/src/index-daemon.ts
+++ b/src/index-daemon.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { existsSync } from 'node:fs';
 import { installStdioEpipeGuard } from './utils/stdio-epipe-guard.js';
+import { scrubSessionCliHomeEnv } from './utils/child-env.js';
 
 // Under pm2 the daemon's stdout/stderr are pipes to the God daemon. A broken
 // pipe (log streaming detaches, God daemon restart) would otherwise emit an
@@ -24,6 +25,13 @@ dotenvConfig({ path: existsSync(globalEnv) ? globalEnv : '.env' });
 for (const k of ['BOTMUX_SESSION_ID', 'BOTMUX_LARK_APP_ID', 'BOTMUX_CHAT_ID', 'BOTMUX_CHAT_TYPE', 'BOTMUX_ROOT_MESSAGE_ID']) {
   delete process.env[k];
 }
+// Same vector, session-level CLI data-root pointers (CLAUDE_CONFIG_DIR /
+// CODEX_HOME): a value baked into pm2's saved app env — or resurrected from a
+// stale dump.pm2, which bypasses the pm2Env() strip in cli.ts — would make
+// every worker (forked with this process's env) and every non-isolated CLI
+// child read/write the leaking bot's home. Per-session values are recomputed
+// downstream (worker isolation pins / adapter spawnEnv).
+scrubSessionCliHomeEnv(process.env);
 
 async function main() {
   // Resolve global UI locale from ~/.botmux/config.json BEFORE loading

--- a/src/utils/child-env.ts
+++ b/src/utils/child-env.ts
@@ -16,6 +16,49 @@
 export const REDACTED_CHILD_ENV_KEYS = ['LARK_APP_ID', 'LARK_APP_SECRET', 'CLAUDECODE'] as const;
 
 /**
+ * Session-level CLI data-root pointers: claude-family → CLAUDE_CONFIG_DIR,
+ * codex → CODEX_HOME. Botmux computes these PER SESSION (read isolation pins
+ * `<BOT_HOME>/claude|codex`; Seed/Relay pin their fork dirs via adapter
+ * spawnEnv), so a value INHERITED from the surrounding environment is always
+ * stale. The poisoning path: pm2 persists the env of whichever process ran
+ * `botmux start/restart` into every managed app (and into dump.pm2 for
+ * resurrect), so one self-upgrade issued from a bot session bakes that
+ * session's injected CLAUDE_CONFIG_DIR into ALL daemons and workers — and
+ * every non-isolated sibling bot then reads/writes that bot's home. Scrubbed
+ * at each process boundary botmux owns: the pm2 invocation env (cli.ts
+ * pm2Env), daemon boot (index-daemon.ts) and worker boot (worker.ts) — the
+ * boot scrubs cover envs pm2 resurrects from a stale dump. Scrubbing
+ * process.env (not just the spawned child's env) keeps worker-side resolvers
+ * that consult it dynamically — codex submit confirmation / resume fallback /
+ * transcript bridge (services/codex-paths.ts), slash-command discovery
+ * (core/command-discovery.ts) — consistent with the CLI child.
+ *
+ * Do NOT pin a "default" instead of deleting: CLAUDE_CONFIG_DIR=~/.claude is
+ * not a no-op — once the var is set, Claude Code reads its state file from
+ * $CLAUDE_CONFIG_DIR/.claude.json instead of ~/.claude.json, which lacks
+ * hasCompletedOnboarding → every non-isolated session reruns first-run
+ * onboarding (theme picker + login).
+ *
+ * GROK_HOME is deliberately ABSENT: botmux never injects it per session (grok
+ * has no per-bot isolation, and per-bot env rejects the key — see
+ * core/per-bot-env.ts), so it can never carry a sibling bot's home. Its
+ * contract is the opposite of per-session: process-level only, where worker
+ * and CLI child must resolve the SAME value (the worker installs ready-gate
+ * hooks and drains transcripts under it — see services/grok-paths.ts), so
+ * scrubbing it on any single side would split-brain that documented
+ * configuration channel.
+ */
+export const SESSION_CLI_HOME_ENV_KEYS = ['CLAUDE_CONFIG_DIR', 'CODEX_HOME'] as const;
+
+/** Delete inherited session-level CLI data-root pointers from `env` in place
+ *  (see SESSION_CLI_HOME_ENV_KEYS). Values a session actually needs are
+ *  computed and re-set AFTER this scrub (worker isolation pins / adapter
+ *  spawnEnv). */
+export function scrubSessionCliHomeEnv(env: NodeJS.ProcessEnv): void {
+  for (const key of SESSION_CLI_HOME_ENV_KEYS) delete env[key];
+}
+
+/**
  * Botmux-managed, session/bot-scoped env keys that reach the CLI pane via the
  * `/usr/bin/env KEY=VAL` wrapper injection (buildBotmuxEnvAssignments), NOT via
  * the tmux client env. They MUST be stripped from the env handed to the `tmux`

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -168,7 +168,7 @@ import {
 import { parseWorkerRequestUrl } from './utils/worker-http.js';
 import { detectCliUsageLimit, usageLimitStateKey, type CliUsageLimitState } from './utils/cli-usage-limit.js';
 import { uploadImageBuffer } from './utils/lark-upload.js';
-import { redactChildEnv } from './utils/child-env.js';
+import { redactChildEnv, scrubSessionCliHomeEnv } from './utils/child-env.js';
 import { decideSubmitConfirmationAction, type SubmitActivityEvidence } from './services/submit-confirmation.js';
 import { config, resolveChatBotDiscoveryConfig } from './config.js';
 import * as sessionStore from './services/session-store.js';
@@ -184,6 +184,23 @@ import {
   RELAY_ORIGIN_CAPABILITY_BASENAME,
   replaceManagedOriginCapabilityFile,
 } from './core/managed-origin-capability.js';
+
+// A worker must never trust an INHERITED session-level CLI home pointer
+// (CLAUDE_CONFIG_DIR / CODEX_HOME): a stale pm2 dump can resurrect the daemon
+// with a sibling bot's home baked in (see the index-daemon.ts boot scrub —
+// this one covers any worker spawn path that bypasses it). Scrubbing
+// process.env — not just the spawned child's env — matters because worker-side
+// resolvers consult it dynamically (codex submit confirmation / resume
+// fallback / transcript bridge via services/codex-paths.ts, slash-command
+// discovery), and childEnv is seeded from process.env below: cleaning only one
+// side would leave the worker watching a different data root than the CLI
+// writes (the exact failure mode documented at the isolated-codex re-pin in
+// spawnCli). Per-session values are re-pinned AFTER this scrub — isolation
+// sets process.env.CODEX_HOME / childEnv, adapter spawnEnv re-injects fork
+// dirs. See SESSION_CLI_HOME_ENV_KEYS for why deleting beats pinning a
+// default (~/.claude relocates Claude's state file → onboarding rerun) and
+// why GROK_HOME is exempt.
+scrubSessionCliHomeEnv(process.env);
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
@@ -5827,18 +5844,6 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   }
   if (injectClaudeSandbox) childEnv.IS_SANDBOX = '1';
   if (claudeResumeTokenThreshold) childEnv.CLAUDE_CODE_RESUME_TOKEN_THRESHOLD = claudeResumeTokenThreshold;
-  // Session-level CLI data-root pointers must never be INHERITED from the worker
-  // env — a stale pm2 dump can still carry a sibling bot's home (see pm2Env).
-  // Scrub them BEFORE the adapter/isolation layers below so only values computed
-  // for THIS session survive. Do NOT pin a "default" instead of deleting:
-  // CLAUDE_CONFIG_DIR=~/.claude is not a no-op — setting the var relocates the
-  // CLI's state file from ~/.claude.json to $CLAUDE_CONFIG_DIR/.claude.json,
-  // which lacks hasCompletedOnboarding → the CLI reruns first-run onboarding
-  // (theme picker + login) on every non-isolated session.
-  delete childEnv.CLAUDE_CONFIG_DIR;
-  delete childEnv.CODEX_HOME;
-  delete childEnv.GROK_HOME;
-
   // Adapter-supplied env: points Claude-family forks at their data root (Seed's
   // CLAUDE_CONFIG_DIR → `.claude-runtime`). Keys here are also in the tmux
   // passthrough whitelist (BOTMUX_INJECTED_ENV_KEYS) so the tmux backend forwards
@@ -5850,10 +5855,11 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   // CODEX_HOME. Both are in BOTMUX_INJECTED_ENV_KEYS so the tmux backend forwards
   // them into the pane; without this the CLI falls back to the global
   // ~/.claude|~/.codex which the Seatbelt wrapper denies → it can't read its own
-  // data and won't start. Non-isolated sessions get NO explicit value: the scrub
-  // above plus the pane wrapper's unset clause (PANE_ENV_UNSET_CLAUSE covers
-  // BOTMUX_INJECTED_ENV_KEYS) already guarantee the pane starts clean, and the
-  // CLI's built-in default preserves stock semantics.
+  // data and won't start. Non-isolated sessions get NO explicit value: the
+  // worker-boot scrubSessionCliHomeEnv (module top) plus the pane wrapper's
+  // unset clause (PANE_ENV_UNSET_CLAUSE covers BOTMUX_INJECTED_ENV_KEYS)
+  // already guarantee the pane starts clean, and the CLI's built-in default
+  // preserves stock semantics.
   if (isolationBotHome) {
     if (claudeDataDir) childEnv.CLAUDE_CONFIG_DIR = claudeDataDir; // = <BOT_HOME>/claude
     else childEnv.CODEX_HOME = isolatedCodexHome!;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5827,17 +5827,33 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   }
   if (injectClaudeSandbox) childEnv.IS_SANDBOX = '1';
   if (claudeResumeTokenThreshold) childEnv.CLAUDE_CODE_RESUME_TOKEN_THRESHOLD = claudeResumeTokenThreshold;
+  // Session-level CLI data-root pointers must never be INHERITED from the worker
+  // env — a stale pm2 dump can still carry a sibling bot's home (see pm2Env).
+  // Scrub them BEFORE the adapter/isolation layers below so only values computed
+  // for THIS session survive. Do NOT pin a "default" instead of deleting:
+  // CLAUDE_CONFIG_DIR=~/.claude is not a no-op — setting the var relocates the
+  // CLI's state file from ~/.claude.json to $CLAUDE_CONFIG_DIR/.claude.json,
+  // which lacks hasCompletedOnboarding → the CLI reruns first-run onboarding
+  // (theme picker + login) on every non-isolated session.
+  delete childEnv.CLAUDE_CONFIG_DIR;
+  delete childEnv.CODEX_HOME;
+  delete childEnv.GROK_HOME;
+
   // Adapter-supplied env: points Claude-family forks at their data root (Seed's
   // CLAUDE_CONFIG_DIR → `.claude-runtime`). Keys here are also in the tmux
   // passthrough whitelist (BOTMUX_INJECTED_ENV_KEYS) so the tmux backend forwards
   // them past the server's global env.
   if (cliAdapter.spawnEnv) Object.assign(childEnv, cliAdapter.spawnEnv);
 
-  // v2 read isolation: point the CLI at its PER-BOT config dir (set AFTER spawnEnv so
-  // it overrides any adapter default). claude → CLAUDE_CONFIG_DIR, codex → CODEX_HOME.
-  // Both are in BOTMUX_INJECTED_ENV_KEYS so the tmux backend forwards them into the
-  // pane; without this the CLI falls back to the global ~/.claude|~/.codex which the
-  // Seatbelt wrapper denies → it can't read its own data and won't start.
+  // v2 read isolation: point the CLI at its PER-BOT config dir (set AFTER spawnEnv
+  // so it overrides any adapter default). claude → CLAUDE_CONFIG_DIR, codex →
+  // CODEX_HOME. Both are in BOTMUX_INJECTED_ENV_KEYS so the tmux backend forwards
+  // them into the pane; without this the CLI falls back to the global
+  // ~/.claude|~/.codex which the Seatbelt wrapper denies → it can't read its own
+  // data and won't start. Non-isolated sessions get NO explicit value: the scrub
+  // above plus the pane wrapper's unset clause (PANE_ENV_UNSET_CLAUSE covers
+  // BOTMUX_INJECTED_ENV_KEYS) already guarantee the pane starts clean, and the
+  // CLI's built-in default preserves stock semantics.
   if (isolationBotHome) {
     if (claudeDataDir) childEnv.CLAUDE_CONFIG_DIR = claudeDataDir; // = <BOT_HOME>/claude
     else childEnv.CODEX_HOME = isolatedCodexHome!;

--- a/test/child-env.test.ts
+++ b/test/child-env.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { redactChildEnv } from '../src/utils/child-env.js';
+import { readFileSync } from 'node:fs';
+import { redactChildEnv, scrubSessionCliHomeEnv, SESSION_CLI_HOME_ENV_KEYS } from '../src/utils/child-env.js';
 
 describe('redactChildEnv()', () => {
   it('truly removes leaked keys — absent, not present-with-"undefined"', () => {
@@ -56,5 +57,58 @@ describe('redactChildEnv()', () => {
       if (prev === undefined) delete process.env.LARK_APP_ID;
       else process.env.LARK_APP_ID = prev;
     }
+  });
+});
+
+describe('scrubSessionCliHomeEnv()', () => {
+  it('deletes inherited session-level CLI home pointers in place, keys absent not undefined', () => {
+    const env: NodeJS.ProcessEnv = {
+      CLAUDE_CONFIG_DIR: '/root/.botmux/bots/sibling-bot/claude',
+      CODEX_HOME: '/root/.botmux/bots/sibling-bot/codex',
+      KEEP: 'v',
+      PATH: '/usr/bin',
+    };
+    scrubSessionCliHomeEnv(env);
+    // Same node-pty trap as redactChildEnv: the key must be ABSENT, or the
+    // child sees the literal string "undefined" and still relocates its home.
+    expect('CLAUDE_CONFIG_DIR' in env).toBe(false);
+    expect('CODEX_HOME' in env).toBe(false);
+    expect(env.KEEP).toBe('v');
+    expect(env.PATH).toBe('/usr/bin');
+  });
+
+  it('leaves GROK_HOME alone — process-level by contract, never session-injected', () => {
+    // grok-paths.ts: the worker installs ready-gate hooks and drains
+    // transcripts under the process-level GROK_HOME; botmux never injects a
+    // per-session value, so scrubbing it would only split-brain the worker
+    // from the CLI child. Guards against GROK_HOME creeping into the list.
+    const env: NodeJS.ProcessEnv = { GROK_HOME: '/custom/grok' };
+    scrubSessionCliHomeEnv(env);
+    expect(env.GROK_HOME).toBe('/custom/grok');
+    expect(SESSION_CLI_HOME_ENV_KEYS).not.toContain('GROK_HOME');
+  });
+});
+
+describe('session CLI home scrub call sites', () => {
+  // The scrub only works if every process boundary actually invokes it. These
+  // source-level pins keep a refactor from silently dropping a boundary:
+  // pm2Env (bakes the caller env into pm2 apps + dump.pm2), daemon boot
+  // (resurrected from a stale dump, workers fork from it), worker boot
+  // (worker-side dynamic resolvers + childEnv seeding).
+  const read = (rel: string) =>
+    readFileSync(new URL(`../src/${rel}`, import.meta.url), 'utf-8');
+
+  it('cli.ts pm2Env scrubs the env handed to pm2', () => {
+    const src = read('cli.ts');
+    const fn = src.slice(src.indexOf('function pm2Env('));
+    expect(fn.slice(0, fn.indexOf('\n}'))).toContain('scrubSessionCliHomeEnv(');
+  });
+
+  it('index-daemon.ts scrubs process.env at boot', () => {
+    expect(read('index-daemon.ts')).toContain('scrubSessionCliHomeEnv(process.env)');
+  });
+
+  it('worker.ts scrubs process.env at boot', () => {
+    expect(read('worker.ts')).toContain('scrubSessionCliHomeEnv(process.env)');
   });
 });


### PR DESCRIPTION
## 问题
非隔离 bot 的 CLI 会读写到**某个兄弟隔离 bot 的 home**——`CLAUDE_CONFIG_DIR` 指向 `~/.botmux/bots/<别的bot>/claude`，导致记忆 / transcript 落进别人桶里。现网实测：冷启动、甚至整个 `tmux kill-server` 重启都治不好，因为脏值在 pm2 saved env 与 worker 继承链里。

## 根因（两处）
1. **`pm2Env()`** 把调用方完整 `process.env` 交给 pm2 → pm2 持久化进每个 app（含 `dump.pm2`）。于是任何**环境里带着 `CLAUDE_CONFIG_DIR` 的进程**发起 `botmux start/restart`（最常见：bot 自己的会话跑 `self-upgrade.sh`）就会把该值烙进**全部 worker**，并随 dump 在 God resurrect 时复活。
2. **`worker.ts`** 用 `redactChildEnv(process.env)` 播种 `childEnv`，而 `CLAUDE_CONFIG_DIR` / `CODEX_HOME` / `GROK_HOME` 不在 redact 列表 → 非隔离 bot 直接继承 worker 那份脏值（隔离 bot 因为会显式改写 `CLAUDE_CONFIG_DIR` 而幸免）。

## 修复
- **`pm2Env()`**：起 pm2 前 `delete` 掉这三个 key，让守护 / worker 对会话级变量保持无知。
- **`worker.ts` spawn**：在 adapter / isolation 层之前 `delete` 掉 `childEnv` 继承的这三个 key，只保留为**本会话现算**的值。

## ⚠️ 关键：不能用「钉默认值」来解决
最初尝试给非隔离 bot 钉 `CLAUDE_CONFIG_DIR=~/.claude`，结果触发**全新 onboarding**（主题选择 + 登录）。原因：`CLAUDE_CONFIG_DIR=~/.claude` **不是无操作**——一旦设置该环境变量，Claude Code 的状态文件就从 `~/.claude.json` 改读 `$CLAUDE_CONFIG_DIR/.claude.json`，该文件缺 `hasCompletedOnboarding` → 每个非隔离会话都重跑首次引导。**故非隔离会话不注入、回到 CLI 原生默认；只有隔离会话才钉 `<BOT_HOME>/claude`。**

`delete` 放在 `cliAdapter.spawnEnv` 的 `Object.assign` 之前，故 Seed / Relay 等 fork 的合法 `spawnEnv.CLAUDE_CONFIG_DIR` 注入不受影响。

## 测试
- `pnpm build` ✅
- 相关用例全绿（97 passed）：`tmux-env-isolation` / `tmux-backend-env` / `per-bot-env` / `seed-adapter` / `relay-adapter` / `command-discovery`
- 已在本地非隔离 bot 上实测：修复后 `CLAUDE_CONFIG_DIR` 恢复 unset、无 onboarding、不再串桶；隔离 bot 指向 `<BOT_HOME>/claude` 不受影响。