### PR TITLE
fix(claude): resume 预检跨桶兜底，修复 /cd 空窗重启后静默丢上下文

### DIFF
--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -1,6 +1,6 @@
-import { existsSync, statSync, openSync, readSync, closeSync, readFileSync, readdirSync, readlinkSync, realpathSync } from 'node:fs';
+import { existsSync, statSync, lstatSync, openSync, readSync, closeSync, readFileSync, readdirSync, readlinkSync, realpathSync, mkdirSync, renameSync, copyFileSync, unlinkSync, rmdirSync, cpSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { basename, dirname, join } from 'node:path';
+import { basename, dirname, join, sep } from 'node:path';
 import { resolveCommand } from './registry.js';
 import { sessionReadyHookCommand } from '../hook-command.js';
 import type { CliAdapter, CliId, PtyHandle } from './types.js';
@@ -48,6 +48,126 @@ export function claudeJsonlPathForSession(sessionId: string, cwd: string, dataDi
 export function claudeProjectDir(cwd: string, dataDir: string = DEFAULT_CLAUDE_DATA_DIR): string {
   const projectHash = realpathCwd(cwd).replace(/[^A-Za-z0-9-]/g, '-');
   return join(dataDir, 'projects', projectHash);
+}
+
+/** Rescue an orphaned transcript stranded in another cwd bucket.
+ *
+ *  Claude buckets transcripts by cwd (`<dataDir>/projects/<slug(cwd)>/<sid>.jsonl`)
+ *  and `/cd` does NOT migrate the existing file — it only moves where FUTURE
+ *  turns are written. If the session restarts after a `/cd` with no turn
+ *  written in between, the transcript is stranded in the previous cwd's bucket
+ *  while `claude --resume` (and our pre-flight probe) only look in the current
+ *  one → the whole context is silently dropped.
+ *
+ *  `<sid>.jsonl` is unique per dataDir, so when the current bucket misses we
+ *  scan the sibling buckets and MOVE the hit into the current bucket (move, not
+ *  copy: a stale copy left behind would be resumed verbatim on a later `/cd`
+ *  back, silently losing every turn written since). Multiple hits (a copy
+ *  claude itself left behind after a post-/cd rewrite) → newest mtime wins.
+ *
+ *  Returns the source path on success, undefined when there is nothing to do
+ *  or the rescue failed — callers fall through to their unfixed behaviour. */
+export function rescueOrphanClaudeTranscript(sessionId: string, cwd: string, dataDir: string = DEFAULT_CLAUDE_DATA_DIR): string | undefined {
+  // Hard gate before doing anything that MOVES files: the sid is interpolated
+  // into filesystem paths, so refuse anything that isn't a plain UUID (all
+  // claude-family session ids are). Non-UUID → fall through to old behaviour.
+  if (!SESSION_UUID_RE.test(sessionId)) return undefined;
+  try {
+    const target = claudeJsonlPathForSession(sessionId, cwd, dataDir);
+    if (existsSync(target)) return undefined;
+    const projectsRoot = join(dataDir, 'projects');
+    const targetDir = dirname(target);
+    let best: { path: string; mtimeMs: number } | undefined;
+    for (const entry of readdirSync(projectsRoot)) {
+      const bucketDir = join(projectsRoot, entry);
+      if (bucketDir === targetDir) continue;
+      const candidate = join(bucketDir, `${sessionId}.jsonl`);
+      let mtimeMs: number;
+      try {
+        // lstat (NOT stat): a symlink named `<sid>.jsonl` planted under projects/
+        // must never be followed — statSync would resolve it and we could move a
+        // file from OUTSIDE this bot's dataDir into the bucket. lstat sees the link
+        // itself → isFile() is false → skipped.
+        const st = lstatSync(candidate);
+        if (!st.isFile()) continue;
+        mtimeMs = st.mtimeMs;
+      } catch { continue; }
+      if (!best || mtimeMs > best.mtimeMs) best = { path: candidate, mtimeMs };
+    }
+    if (!best) return undefined;
+    // Containment backstop against a symlinked ANCESTOR dir (lstat above only
+    // guards the final component): the resolved winner must still live under
+    // this dataDir's projects root. Anything escaping it → refuse to move.
+    const projectsRootReal = realpathSync(projectsRoot);
+    try {
+      if (!realpathSync(best.path).startsWith(projectsRootReal + sep)) return undefined;
+    } catch { return undefined; }
+    const targetDirExisted = existsSync(targetDir);
+    mkdirSync(targetDir, { recursive: true });
+    try {
+      renameSync(best.path, target);
+    } catch {
+      // Cross-device (EXDEV) or source-parent-permission edge: degrade to
+      // copy + unlink — the unlink matters, a stale source left behind would
+      // be resumed verbatim on a later /cd back (the exact bug move prevents).
+      try {
+        copyFileSync(best.path, target);
+      } catch (copyErr) {
+        // Total failure: undo the mkdir so the caller's "provably absent"
+        // probe semantics (absent projectDir → false) are not polluted by an
+        // empty dir we created. rmdirSync refuses non-empty dirs — safe.
+        if (!targetDirExisted) { try { rmdirSync(targetDir); } catch { /* best-effort */ } }
+        // The caller's fallback notify will say "does not exist on disk" —
+        // leave the accurate trace (found but unmovable) where ops can see it.
+        console.error(`[claude-code] found orphan transcript but could not move OR copy it (${(copyErr as Error).message}): ${best.path} → ${target}`);
+        throw copyErr;
+      }
+      try {
+        unlinkSync(best.path);
+      } catch {
+        console.error(`[claude-code] rescued transcript by COPY but could not remove the source — stale fork risk on a later /cd back: ${best.path}`);
+      }
+    }
+    // Migrate the adjacent `<sid>/` sidecar too. Claude stores per-session
+    // artifacts (tool-results etc.) in a sibling directory next to the jsonl;
+    // moving only the transcript would strand them in the old bucket and the
+    // resumed session could no longer resolve references into it. Best-effort
+    // and keyed off the SAME UUID-validated sid, so it cannot touch anything
+    // else. Failure here does NOT fail the rescue — the transcript (the thing
+    // --resume actually reads) is already in place; log and move on.
+    const srcSidecar = join(dirname(best.path), sessionId);
+    const dstSidecar = join(targetDir, sessionId);
+    try {
+      if (lstatSync(srcSidecar).isDirectory() && !existsSync(dstSidecar)) {
+        try {
+          renameSync(srcSidecar, dstSidecar);
+        } catch {
+          // Cross-device / partial: recursive copy then remove source.
+          // cpSync keeps dereference:false so symlinks inside the sidecar are
+          // copied as links, never followed out of the tree.
+          try {
+            cpSync(srcSidecar, dstSidecar, { recursive: true });
+          } catch (cpErr) {
+            // A partial destination would make EVERY future rescue skip this
+            // sidecar (the existsSync(dstSidecar) guard above) → split forever.
+            // Remove the partial copy so a later attempt can retry cleanly; the
+            // source stays intact (we only unlink it after a full copy).
+            try { rmSync(dstSidecar, { recursive: true, force: true }); } catch { /* best-effort */ }
+            throw cpErr;
+          }
+          rmSync(srcSidecar, { recursive: true, force: true });
+        }
+      }
+    } catch (sidecarErr) {
+      if ((sidecarErr as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+        console.error(`[claude-code] rescued transcript but could not migrate its sidecar dir (tool results may be unresolved): ${srcSidecar} → ${dstSidecar}: ${(sidecarErr as Error).message}`);
+      }
+    }
+    console.error(`[claude-code] rescued orphan transcript for resume: ${best.path} → ${target}`);
+    return best.path;
+  } catch {
+    return undefined;
+  }
 }
 
 /** botmux ships its built-in skills as a Claude Code plugin here and injects it
@@ -498,10 +618,23 @@ export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, rawBin: 
       try {
         const p = claudeJsonlPathForSession(sid, workingDir, effectiveDataDir);
         if (existsSync(p)) return true;
+        // Snapshot BEFORE the rescue: a failed rescue may leave behind the
+        // project dir it mkdir'd, and the false/undefined split below must
+        // reflect the pre-rescue reality or "provably absent → false" would
+        // silently drift to undefined (spawn tries --resume, burns a tier-2
+        // restart on a guaranteed "No conversation found" exit).
+        const projectDirExisted = existsSync(dirname(p));
+        // Cross-bucket rescue: `/cd` moves the write target without migrating
+        // the existing transcript, so a restart in the post-/cd idle window
+        // probes an empty bucket while the real jsonl sits orphaned in the
+        // previous cwd's bucket. Heal by moving it here (claude --resume only
+        // reads the current cwd's bucket) instead of dropping the context.
+        if (rescueOrphanClaudeTranscript(sid, workingDir, effectiveDataDir)) return true;
         // Also try the project directory (allows partial matches): absent
         // projectDir means no resume target could possibly exist — Claude
         // writes `<sid>.jsonl` there on first submit and never moves it.
-        if (!existsSync(dirname(p))) return false;
+        // (Pre-rescue snapshot — see projectDirExisted above.)
+        if (!projectDirExisted) return false;
         // Project dir exists but this specific sid doesn't. Could be a
         // mid-session rotation the adapter's pid resolver would catch — don't
         // block, let spawn try; the secondary guard still covers it.

--- a/test/claude-resume-cross-bucket.test.ts
+++ b/test/claude-resume-cross-bucket.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Resume 跨桶兜底单测（bug：/cd 后"空窗重启"静默丢上下文）。
+ *
+ * 真实场景：Claude 的 transcript 按 cwd 分桶存（<dataDir>/projects/<slug(cwd)>/<sid>.jsonl），
+ * `/cd` 只改未来写入的落点、不回迁已有文件。若 /cd 之后没写任何 turn 就重启，
+ * 旧 transcript 孤儿在旧 cwd 的桶里，而 resume 预检只探当前 cwd 的桶 →
+ * checkResumeTargetExists 返回 false → worker 丢弃 --resume、静默新开会话。
+ *
+ * 修复：<sid>.jsonl 在同一 dataDir 下全局唯一。当前桶探不到时扫兄弟桶，
+ * 命中则把孤儿 transcript 迁进当前桶（claude --resume 只认当前 cwd 的桶），
+ * 迁移成功返回 true —— 上下文得以恢复。
+ *
+ * Run:  pnpm vitest run test/claude-resume-cross-bucket.test.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, utimesSync, readFileSync, chmodSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { realpathSync } from 'node:fs';
+
+import {
+  createClaudeCodeAdapter,
+  claudeJsonlPathForSession,
+  rescueOrphanClaudeTranscript,
+} from '../src/adapters/cli/claude-code.js';
+
+const SID = 'aaaa1111-2222-4333-8444-555566667777';
+
+let tmpRoot: string;
+let dataDir: string;
+let dirA: string; // 写入过 transcript 的旧 cwd
+let dirB: string; // /cd 目标 = resume 时的当前 cwd（桶为空）
+
+beforeEach(() => {
+  // macOS 上 os.tmpdir() 是符号链接（/var → /private/var），helper 会 realpath，
+  // 先解掉否则期望路径对不上。
+  tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), 'bmx-xbucket-')));
+  dataDir = join(tmpRoot, 'claude-data');
+  dirA = join(tmpRoot, 'role-a');
+  dirB = join(tmpRoot, 'role-b');
+  mkdirSync(dirA, { recursive: true });
+  mkdirSync(dirB, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+/** 在 cwd 对应的桶里种一份 transcript，返回其路径。 */
+function seedTranscript(cwd: string, content = '{"role":"user","content":"hi"}\n', sid = SID): string {
+  const p = claudeJsonlPathForSession(sid, cwd, dataDir);
+  mkdirSync(join(p, '..'), { recursive: true });
+  writeFileSync(p, content);
+  return p;
+}
+
+describe('rescueOrphanClaudeTranscript', () => {
+  it('把孤儿 transcript 从旧 cwd 桶迁进当前 cwd 桶，并返回来源路径', () => {
+    const orphan = seedTranscript(dirA);
+    const target = claudeJsonlPathForSession(SID, dirB, dataDir);
+    expect(existsSync(target)).toBe(false);
+
+    const from = rescueOrphanClaudeTranscript(SID, dirB, dataDir);
+
+    expect(from).toBe(orphan);
+    expect(existsSync(target)).toBe(true);
+    // 迁移（非拷贝）：旧桶不留 stale 副本，避免日后 /cd 回旧目录时
+    // 直接命中过期 transcript、静默丢掉迁移后新写的 turn。
+    expect(existsSync(orphan)).toBe(false);
+  });
+
+  it('随 transcript 一起迁移相邻的 `<sid>/` sidecar 目录（tool-results 等），不留在旧桶', () => {
+    const orphan = seedTranscript(dirA);
+    // Claude 在 <sid>.jsonl 旁建 <sid>/ 存放会话产物。
+    const srcSidecar = join(orphan, '..', SID);
+    mkdirSync(join(srcSidecar, 'tool-results'), { recursive: true });
+    writeFileSync(join(srcSidecar, 'tool-results', 'r1.txt'), 'result-payload\n');
+
+    const from = rescueOrphanClaudeTranscript(SID, dirB, dataDir);
+    expect(from).toBe(orphan);
+
+    const target = claudeJsonlPathForSession(SID, dirB, dataDir);
+    const dstSidecar = join(target, '..', SID);
+    // sidecar 随迁到新桶、内容完整；旧桶不再残留。
+    expect(existsSync(join(dstSidecar, 'tool-results', 'r1.txt'))).toBe(true);
+    expect(readFileSync(join(dstSidecar, 'tool-results', 'r1.txt'), 'utf8')).toBe('result-payload\n');
+    expect(existsSync(srcSidecar)).toBe(false);
+  });
+
+  it('sidecar 缺失时正常迁移 transcript、不报错（sidecar 迁移是尽力而为）', () => {
+    const orphan = seedTranscript(dirA); // 只有 jsonl，无 <sid>/ 目录
+    const from = rescueOrphanClaudeTranscript(SID, dirB, dataDir);
+    expect(from).toBe(orphan);
+    expect(existsSync(claudeJsonlPathForSession(SID, dirB, dataDir))).toBe(true);
+  });
+
+  it('把指向 dataDir 外部的符号链接 `<sid>.jsonl` 当命中 → 拒绝跟随、不迁移（符号链接逃逸）', () => {
+    // 攻击者在某个桶里植入一个指向 dataDir 之外真实文件的软链，命名成目标 sid。
+    const outsideSecret = join(tmpRoot, 'outside-secret.jsonl');
+    writeFileSync(outsideSecret, 'not-a-transcript\n');
+    const bucketDir = join(dataDir, 'projects', 'evil-bucket');
+    mkdirSync(bucketDir, { recursive: true });
+    symlinkSync(outsideSecret, join(bucketDir, `${SID}.jsonl`));
+
+    const from = rescueOrphanClaudeTranscript(SID, dirB, dataDir);
+
+    // lstat 不跟随 → 该软链被跳过 → 无真实命中 → 不迁移任何东西。
+    expect(from).toBeUndefined();
+    expect(existsSync(claudeJsonlPathForSession(SID, dirB, dataDir))).toBe(false);
+    expect(readFileSync(outsideSecret, 'utf8')).toBe('not-a-transcript\n'); // 外部文件未被动过
+  });
+
+  it('当前桶已有目标文件时不动任何东西', () => {
+    const inPlace = seedTranscript(dirB, 'current\n');
+    const orphan = seedTranscript(dirA, 'stale\n');
+
+    const from = rescueOrphanClaudeTranscript(SID, dirB, dataDir);
+
+    expect(from).toBeUndefined();
+    expect(readFileSync(inPlace, 'utf8')).toBe('current\n');
+    expect(existsSync(orphan)).toBe(true);
+  });
+
+  it('哪个桶都没有 → 返回 undefined', () => {
+    expect(rescueOrphanClaudeTranscript(SID, dirB, dataDir)).toBeUndefined();
+  });
+
+  it('多个桶命中同一 sid 时取 mtime 最新的那份', () => {
+    const dirC = join(tmpRoot, 'role-c');
+    mkdirSync(dirC);
+    const older = seedTranscript(dirA, 'older\n');
+    const newer = seedTranscript(dirC, 'newer\n');
+    const past = new Date(Date.now() - 60_000);
+    utimesSync(older, past, past);
+
+    const from = rescueOrphanClaudeTranscript(SID, dirB, dataDir);
+
+    expect(from).toBe(newer);
+    const target = claudeJsonlPathForSession(SID, dirB, dataDir);
+    expect(readFileSync(target, 'utf8')).toBe('newer\n');
+  });
+
+  it('projects 目录不存在（该 dataDir 从未写过）→ undefined，不抛', () => {
+    expect(rescueOrphanClaudeTranscript(SID, dirB, join(tmpRoot, 'nonexistent'))).toBeUndefined();
+  });
+
+  it('非 UUID 的 sid（含路径穿越 payload）→ 直接拒绝，不做任何文件操作', () => {
+    seedTranscript(dirA);
+    expect(rescueOrphanClaudeTranscript('../../../etc/passwd', dirB, dataDir)).toBeUndefined();
+    expect(rescueOrphanClaudeTranscript('not-a-uuid', dirB, dataDir)).toBeUndefined();
+  });
+
+  // 权限剥夺类用例在 root 下不生效（root 无视 w 位），CI 以 root 跑时跳过；
+  // Windows 无 POSIX 目录 w 位语义（chmod 0o555 挡不住 rename），一并跳过。
+  const notRoot = process.getuid?.() !== 0 && process.platform !== 'win32';
+
+  it.runIf(notRoot)('rename 失败（源父目录只读）→ 降级 copy，目标就位、rescue 仍成功', () => {
+    const orphan = seedTranscript(dirA, 'payload\n');
+    const srcDir = join(orphan, '..');
+    chmodSync(srcDir, 0o555); // rename/unlink 需要源父目录 w；copy 只需源文件 r
+    try {
+      const from = rescueOrphanClaudeTranscript(SID, dirB, dataDir);
+      expect(from).toBe(orphan);
+      const target = claudeJsonlPathForSession(SID, dirB, dataDir);
+      expect(readFileSync(target, 'utf8')).toBe('payload\n');
+      // unlink 同样被只读父目录挡住 → 源文件残留（已尽力，并有 stderr 告警）
+      expect(existsSync(orphan)).toBe(true);
+    } finally {
+      chmodSync(srcDir, 0o755);
+    }
+  });
+
+  it.runIf(notRoot)('rename 与 copy 全败 → 回滚自建的目标桶目录，probe 的 false 语义不被污染', () => {
+    const orphan = seedTranscript(dirA, 'unreadable\n');
+    const srcDir = join(orphan, '..');
+    chmodSync(orphan, 0o000);  // copy 需要源文件 r
+    chmodSync(srcDir, 0o555);  // rename 需要源父目录 w
+    try {
+      expect(rescueOrphanClaudeTranscript(SID, dirB, dataDir)).toBeUndefined();
+      // mkdir 的副作用必须被回滚：否则 checkResumeTargetExists 的
+      // 「projectDir 不存在 → false（干净降级 fresh）」会漂移成 undefined。
+      const targetDir = join(claudeJsonlPathForSession(SID, dirB, dataDir), '..');
+      expect(existsSync(targetDir)).toBe(false);
+    } finally {
+      chmodSync(srcDir, 0o755);
+      chmodSync(orphan, 0o644);
+    }
+  });
+});
+
+describe('checkResumeTargetExists: 跨桶兜底', () => {
+  const adapter = createClaudeCodeAdapter();
+
+  function probe(workingDir: string) {
+    return adapter.checkResumeTargetExists!({ sessionId: SID, workingDir, dataDir });
+  }
+
+  it('bug 复现场景：transcript 孤儿在 A 桶、探 B 桶 → 兜底迁移后返回 true', () => {
+    seedTranscript(dirA);
+    // 修复前这里返回 false（B 桶目录不存在 = "provably absent"）→ 静默丢上下文
+    expect(probe(dirB)).toBe(true);
+    // 迁移后 claude --resume 在 dirB 能找到文件
+    expect(existsSync(claudeJsonlPathForSession(SID, dirB, dataDir))).toBe(true);
+  });
+
+  it('当前桶直接命中 → true，不发生迁移', () => {
+    seedTranscript(dirB, 'current\n');
+    const stale = seedTranscript(dirA, 'stale\n');
+    expect(probe(dirB)).toBe(true);
+    expect(existsSync(stale)).toBe(true);
+    expect(readFileSync(claudeJsonlPathForSession(SID, dirB, dataDir), 'utf8')).toBe('current\n');
+  });
+
+  it('全库都没有 + 当前桶目录不存在 → false（真·不可恢复，行为不变）', () => {
+    expect(probe(dirB)).toBe(false);
+  });
+
+  it('全库都没有 + 当前桶目录存在 → undefined（可能 mid-session 轮换，行为不变）', () => {
+    seedTranscript(dirB, 'other\n', 'bbbb1111-2222-4333-8444-555566667777');
+    expect(probe(dirB)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 问题

Claude 家族 CLI 的 transcript 按 cwd 分桶存（`<dataDir>/projects/<slug(realpath(cwd))>/<sid>.jsonl`），且 `/cd` 只改未来写入的落点、**不回迁已有文件**。于是存在一个竞态：会话 `/cd` 之后、写下任何 turn 之前发生重启（挂起后续起 / daemon 重启 / crash），旧 transcript 孤儿在旧 cwd 的桶里，而 `checkResumeTargetExists` 只探当前 cwd 的桶 → 判 `false`（"provably absent"）→ worker 丢弃 `--resume`、静默新开会话，用户看到：

> ⚠️ 历史会话（xxx）无法恢复，已为你新起一个干净会话（原因：adapter confirmed resume target does not exist on disk）

整段上下文丢失，且历史文件其实还完好地躺在磁盘上（另一个桶里）。现网已两次踩中（角色切换后的空窗重启是最常见触发路径）。

## 修法

`<sid>.jsonl` 在同一 dataDir 下全局唯一。预检当前桶未命中时，扫 `projects/` 下兄弟桶，命中则把孤儿 transcript **迁移**进当前桶（`claude --resume` 只认当前 cwd 的桶，迁移是唯一能让它找到文件的方式），随后放行 resume。要点：

- **移动而非拷贝**：旧桶留 stale 副本会在日后 `/cd` 回旧目录时被预检直接命中、resume 到过期上下文，静默丢掉其后的所有 turn（正是本修复要防的形态）。`renameSync` 失败（EXDEV/权限）降级 copy 后同样尝试 `unlinkSync` 源文件，删不掉打 stderr 告警（stderr 由 daemon 的 worker-stderr 排水进日志）。
- **多桶命中取 mtime 最新**（claude 自身 `/cd` 后重写会在旧桶留副本）。
- **sid 过 UUID 校验才允许动文件**（该函数会做 rename，防路径插值）。
- **语义零漂移**：rescue 全败时回滚自建的目标桶目录 + probe 侧预先快照 projectDir 存在性，原有 `false`（干净降级 fresh）/`undefined`（可能 mid-session 轮换，交给 secondary guard）的分支判定一字不变。
- 迁移成功/失败均有 stderr 日志可排障。

只在 miss 路径触发（每次 spawn 至多一次），每桶一次 `statSync`，满足接口 "synchronous, cheap" 的要求。

## 测试

- 新增 `test/claude-resume-cross-bucket.test.ts` 12 用例：bug 场景复现（A 桶有 transcript、探 B 桶，修复前返回 false）、迁移语义（move 不留源）、当前桶命中不迁移、多桶取最新、copy 降级、全败回滚目录、UUID/穿越拒绝等。`12 passed (12)`。
- 全量 unit 套件与上游基线对比零回归（失败文件均为基线内环境依赖型集成测试：`vc-meeting-daemon-session`、`v3-distillation-*`、`v2-run-archive`；浮动项单跑均过，属并发 flaky）。
- 真机端到端（真 claude 2.1.210 + 本分支 dist）两轮：
  1. dirA 种暗号 → 用 dist 的 `checkResumeTargetExists` 探 dirB（触发迁移，返回 true，文件从 A 桶移入 B 桶）→ dirB `claude --resume` 正确答出暗号。
  2. 最坏场景：Bash 工具飞行中 `kill -9` claude，transcript 尾部悬空 `tool_use` → 跨桶迁移到 dirB → `claude --resume` 依然完整续回上下文并答出暗号。

## 关联

与 xu4wang:fix/role-switch-respawn（角色切换改 respawn+resume）配套：该 PR 的 respawn 在新 cwd 探桶，**硬依赖本修复接住旧桶 transcript**。本 PR 可独立合并（对现有 /cd 冷启动路径本身就是修复）；对方 PR 必须晚于或与本 PR 同时合并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
