### PR TITLE
fix(role-switch): 角色切换从会话内注入 /cd 改为带 --resume 的进程 respawn

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4071,9 +4071,11 @@ async function cmdCd(): Promise<void> {
   const res = await postSessionCliIpc(daemon.ipcPort, s.sessionId, 'cd', { dir });
   const body: any = await res.json().catch(() => ({}));
   if (res.ok && body?.ok) {
-    console.log(body.mode === 'inject'
-      ? `✓ 已切换到 ${body.dir}（会话空闲时生效，进程不重启）`
-      : `✓ 已切换到 ${body.dir}（下条消息在新目录冷启动）`);
+    console.log(body.mode === 'respawn-resume'
+      ? `✓ 已切换到 ${body.dir}（进程即将在新目录重启并续回上下文）`
+      : body.mode === 'inject'  // 兼容旧 daemon 的注入模式
+        ? `✓ 已切换到 ${body.dir}（会话空闲时生效，进程不重启）`
+        : `✓ 已切换到 ${body.dir}（下条消息在新目录冷启动）`);
     return;
   }
   console.error(`✗ 切换被拒绝: ${body?.error ?? `HTTP ${res.status}`}`);

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -655,7 +655,9 @@ ipcRoute('POST', '/api/sessions/:sessionId/slash', async (req, res, params) => {
  *  切换后模型仍拿着旧角色的记忆索引读写（读旧索引、写错桶）。respawn 让「开场」在
  *  新 cwd 重新发生：新角色的 CLAUDE.md/记忆索引开场即注入，--resume 回放对话历史
  *  保留上下文（“换角色外壳、留对话内核”）。旧桶 transcript 由 claude-code 适配器的
- *  resume 预检跨桶迁移接住（rescueOrphanClaudeTranscript），不会探空丢上下文。
+ *  resume 预检 syncClaudeResumeTargetToCwd（worker.ts 每次 resume respawn、probe 之前
+ *  把最新 <sid>.jsonl COPY 进新 cwd 的 project 目录，已在 master）接住，不会探空丢
+ *  上下文。故本改动可独立部署，不硬依赖任何跨桶迁移专项 PR。
  *
  *  鉴权双路径（见 sessionCliIpcAuth）：trusted-host 签名或本会话 rotating
  *  capability；目录面由 validateRoleLibraryPath 硬校验承担（realpath 归一 +

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -132,7 +132,6 @@ import { validateSlashInjection } from './slash-inject.js';
 import { validateRoleLibraryPath } from './role-library.js';
 import { repinSessionWorkingDir } from './session-cwd.js';
 import { authorizeSessionScopedIpc } from './daemon-ipc-session-auth.js';
-import type { CliId } from '../adapters/cli/types.js';
 import { updateSessionTitle } from './session-title.js';
 import { requestAgentSessionRename } from './session-rename.js';
 import type { DaemonToWorker, ScheduledTask, ParsedSchedule, ScheduleExecutionPosition, Session } from '../types.js';
@@ -648,7 +647,16 @@ ipcRoute('POST', '/api/sessions/:sessionId/slash', async (req, res, params) => {
 });
 
 /** 会话内切换工作目录（角色切换专用）：硬校验角色库根 → 更新记录落盘（唯一事实源）
- *  → 按能力位选择 idle 注入 /cd（进程不死）或杀进程冷启动兜底。
+ *  → 活 worker 走「带 --resume 的进程重启、respawn 在新 cwd」，无活 worker 杀残留
+ *  pane 让下条消息冷启动。
+ *
+ *  为什么是 respawn 而不是向活进程注入 /cd（旧实现）：CLI 的系统上下文（CLAUDE.md、
+ *  记忆路径/索引）是开场按启动 cwd 注入一次的静态快照，/cd 只改 cwd 不重刷——注入
+ *  切换后模型仍拿着旧角色的记忆索引读写（读旧索引、写错桶）。respawn 让「开场」在
+ *  新 cwd 重新发生：新角色的 CLAUDE.md/记忆索引开场即注入，--resume 回放对话历史
+ *  保留上下文（“换角色外壳、留对话内核”）。旧桶 transcript 由 claude-code 适配器的
+ *  resume 预检跨桶迁移接住（rescueOrphanClaudeTranscript），不会探空丢上下文。
+ *
  *  鉴权双路径（见 sessionCliIpcAuth）：trusted-host 签名或本会话 rotating
  *  capability；目录面由 validateRoleLibraryPath 硬校验承担（realpath 归一 +
  *  dev/ino 包含判断，角色库根之外一律拒）。
@@ -670,17 +678,13 @@ ipcRoute('POST', '/api/sessions/:sessionId/cd', async (req, res, params) => {
     return jsonRes(res, v.error === 'outside_role_library' ? 403 : 400, { ok: false, error: v.error });
   }
   repinSessionWorkingDir(ds, v.resolvedPath);
-  const cliId = ds.session.cliId;
-  let canInject = false;
-  try { canInject = !!(cliId && createCliAdapterSync(cliId as CliId).supportsSessionCwdMove); } catch { /* unknown cli */ }
-  if (ds.worker && !ds.worker.killed && canInject) {
-    // updateWorkingDir 随 inject_command 带给 worker：会话内 /cd 后 worker 内部的
-    // respawn（claude_exit 自动重启 / IM /restart / dashboard restart）必须收敛到
-    // 新目录，而不是陈旧的 lastInitConfig.workingDir。daemon 侧的 ds.initConfig 同步
-    // 更新，保持与 worker 侧一致（下次 forkWorker 用它重建 init 消息）。
+  if (ds.worker && !ds.worker.killed) {
+    // updateWorkingDir 随 restart 带给 worker：respawn 必须收敛到新目录，而不是
+    // 陈旧的 lastInitConfig.workingDir。daemon 侧的 ds.initConfig 同步更新，保持
+    // 与 worker 侧一致（下次 forkWorker 用它重建 init 消息）。
     if (ds.initConfig) ds.initConfig.workingDir = v.resolvedPath;
     try {
-      ds.worker.send({ type: 'inject_command', command: `/cd ${v.resolvedPath}`, updateWorkingDir: v.resolvedPath } as DaemonToWorker);
+      ds.worker.send({ type: 'restart', updateWorkingDir: v.resolvedPath } as DaemonToWorker);
     } catch {
       // send() 抛异常：worker 进程实际上已经不可达（管道已断），但 above 的
       // repinSessionWorkingDir 已经把记录改成了新目录——绝不能留下「记录新、
@@ -688,7 +692,7 @@ ipcRoute('POST', '/api/sessions/:sessionId/cd', async (req, res, params) => {
       killWorker(ds);
       return jsonRes(res, 200, { ok: true, mode: 'cold-restart', dir: v.resolvedPath });
     }
-    return jsonRes(res, 200, { ok: true, mode: 'inject', dir: v.resolvedPath });
+    return jsonRes(res, 200, { ok: true, mode: 'respawn-resume', dir: v.resolvedPath });
   }
   // Unconditional (no `ds.worker` guard), matching the IM `/cd` command handler
   // (src/core/command-handler.ts) — killWorker() already no-ops safely when there

--- a/src/core/restart-followup-policy.ts
+++ b/src/core/restart-followup-policy.ts
@@ -76,3 +76,65 @@ export function decideRestartFollowup(input: RestartFollowupInput): RestartFollo
   if (!input.backendAlive) return { kind: 'replacement-recovery', skipRestartBudget: false };
   return { kind: 'none' };
 }
+
+/**
+ * Settle an in-flight durable turn that a restart is about to interrupt —
+ * the P1 ordering, made unit-testable via dependency injection.
+ *
+ * The restart `case` kills the CLI, so a durable turn (VC-meeting delivery /
+ * silent-schedule) that was executing dies with it. We must emit a terminal
+ * receipt or the daemon lease watchdog only settles it after a slow timeout.
+ * But emitting a blind `ambiguous` is a correctness hazard: a `reliableTurnTerminal`
+ * CLI may have durably written its `completed` line microseconds before the
+ * kill, with the fs.watch/1s poller not yet having consumed it. So the ordering
+ * is: drain first (publishing that `completed` claims the worker deduper) →
+ * re-check whether the turn is still in flight → only then emit `ambiguous` →
+ * always release the durable-turn latch so a respawn isn't stranded.
+ *
+ * Callbacks (all injected so tests need no real JSONL / IPC):
+ *  - `drain`: run the reliable-terminal drain (publishes a persisted completed).
+ *  - `isStillInFlight`: read `durableTurnInFlight` AFTER the drain.
+ *  - `emitAmbiguous`: emit the fail-closed ambiguous terminal.
+ *  - `release`: reset the latch + retire the inflight input (fallback path).
+ *
+ * Returns counts so callers/tests can assert exactly how many times each ran.
+ */
+export interface DurableTurnSettleDeps {
+  hasInFlightTurn: boolean;
+  hasCurrentTurnId: boolean;
+  drain: () => void;
+  isStillInFlight: () => boolean;
+  emitAmbiguous: () => void;
+  release: () => void;
+}
+
+export interface DurableTurnSettleResult {
+  drained: boolean;
+  ambiguousEmitted: boolean;
+  released: boolean;
+}
+
+export function settleDurableTurnForRestart(deps: DurableTurnSettleDeps): DurableTurnSettleResult {
+  const result: DurableTurnSettleResult = { drained: false, ambiguousEmitted: false, released: false };
+  if (!deps.hasInFlightTurn) return result;
+  if (deps.hasCurrentTurnId) {
+    // Drain persisted completeds FIRST so a just-finished turn claims the
+    // deduper; a blind ambiguous here would re-dispatch a completed delivery.
+    deps.drain();
+    result.drained = true;
+    // Only emit ambiguous if the drain did NOT already settle this turn.
+    if (deps.isStillInFlight()) {
+      deps.emitAmbiguous();
+      result.ambiguousEmitted = true;
+    }
+  }
+  // Fallback: if nothing settled the latch (no matching turn to emit, or drain
+  // published a completed for a different attempt), still release it so the
+  // respawn isn't blocked by a stuck durableTurnInFlight flag.
+  if (deps.isStillInFlight()) {
+    deps.release();
+    result.released = true;
+  }
+  return result;
+}
+

--- a/src/core/restart-followup-policy.ts
+++ b/src/core/restart-followup-policy.ts
@@ -15,11 +15,16 @@
  *     `cliRestartInProgress` gate covers spawnCli() AND the trailing
  *     `prepareCodexNativeTitleGeneration()` (Codex resume + native title ≈
  *     several seconds). If the freshly-spawned CLI dies inside it, its onExit
- *     nulls `backend` and the daemon's auto-restart `restart` IPC is swallowed
- *     by the merge guard (which sets `restartRequestedDuringInFlight`). Either
- *     signal — a null backend (ground truth the replacement is gone) or the
- *     armed flag — must trigger recovery, or the session strands with no CLI
- *     and only a manual `/restart` recovers it.
+ *     nulls `backend` SYNCHRONOUSLY, so by continuation time `!backendAlive` is
+ *     the ground truth that the replacement is gone. The daemon's auto-restart
+ *     `restart` IPC (swallowed by the merge guard) is NOT needed as a signal —
+ *     and must not be used: a `restart` message carries no trustworthy source,
+ *     so a healthy duplicate `/restart` (double click, two `/restart`s) during
+ *     the window is indistinguishable from a crash auto-restart. Treating a
+ *     merged request as recovery would force a second restart on a HEALTHY
+ *     generation, burn the tier-2 budget, and drop `--resume` → context lost —
+ *     re-creating exactly what the merge guard exists to prevent. So recovery
+ *     keys ONLY on `!backendAlive`.
  *
  * Extracted from worker.ts (a process entrypoint that can't be unit-tested
  * without installing IPC/signal handlers) so the branch order and the
@@ -31,40 +36,43 @@ export interface RestartFollowupInput {
   spawnedWorkingDir: string | undefined;
   /** current lastInitConfig.workingDir after the spawn (undefined if lastInitConfig absent). */
   currentWorkingDir: string | undefined;
-  /** false once the replacement CLI's onExit ran during the in-flight window. */
+  /** false once the replacement CLI's onExit ran during the in-flight window
+   *  (onExit sets `backend = null` synchronously). The ONLY recovery signal. */
   backendAlive: boolean;
-  /** merge guard armed this when it swallowed a `restart` IPC during the in-flight window. */
-  restartRequestedDuringInFlight: boolean;
 }
 
 export type RestartFollowupDecision =
   | { kind: 'none' }
   /** A merged cwd-move diverged from the spawned cwd — respawn to converge.
-   *  User-initiated move, not crash recovery → skip the tier-2 FRESH budget. */
-  | { kind: 'cwd-move'; skipRestartBudget: true }
-  /** Replacement exited (or a restart was requested) during the in-flight
-   *  window — recover. Genuine crash recovery → COUNTS toward tier-2 FRESH. */
+   *  `skipRestartBudget` is true ONLY when the replacement is still alive (a
+   *  pure user-initiated move). If the replacement also DIED, this is real
+   *  crash recovery wearing a cwd-move hat: converge the cwd but still COUNT
+   *  the budget so a crashing replacement can't hide behind a directory change. */
+  | { kind: 'cwd-move'; skipRestartBudget: boolean }
+  /** Replacement exited during the in-flight window — recover. Genuine crash
+   *  recovery → COUNTS toward tier-2 FRESH (skipRestartBudget: false). */
   | { kind: 'replacement-recovery'; skipRestartBudget: false };
 
 /**
  * Decide whether the just-finished in-flight restart must chain another.
  *
  * Order matters and is load-bearing:
- *  - cwd-move convergence is checked FIRST. It re-spawns with the newest
- *    workingDir and (being a fresh restartCliProcess call) resets the armed
- *    flag, so a replacement that also died will be re-evaluated by that new
- *    restart's own continuation. Running it first keeps the cwd authoritative.
- *  - Otherwise, a dead/again-requested replacement recovers via a plain
- *    restart (which reuses `{...lastInitConfig}`, preserving any converged cwd).
+ *  - cwd-move convergence is checked FIRST so the directory target stays
+ *    authoritative. It re-spawns with the newest workingDir; a replacement
+ *    that also died is re-evaluated by that new restart's own continuation.
+ *    Budget is skipped only if the backend is alive (pure move); a dead
+ *    backend means we must NOT lose the crash evidence, so count it.
+ *  - Otherwise, a dead replacement recovers via a plain restart (which reuses
+ *    `{...lastInitConfig}`, preserving any converged cwd), budgeted.
+ *  - A healthy generation with no cwd move needs nothing — crucially, a merged
+ *    duplicate restart is NOT a follow-up trigger (see the header note).
  */
 export function decideRestartFollowup(input: RestartFollowupInput): RestartFollowupDecision {
   const cwdMoved =
     input.spawnedWorkingDir !== undefined &&
     input.currentWorkingDir !== undefined &&
     input.currentWorkingDir !== input.spawnedWorkingDir;
-  if (cwdMoved) return { kind: 'cwd-move', skipRestartBudget: true };
-  if (!input.backendAlive || input.restartRequestedDuringInFlight) {
-    return { kind: 'replacement-recovery', skipRestartBudget: false };
-  }
+  if (cwdMoved) return { kind: 'cwd-move', skipRestartBudget: input.backendAlive };
+  if (!input.backendAlive) return { kind: 'replacement-recovery', skipRestartBudget: false };
   return { kind: 'none' };
 }

--- a/src/core/restart-followup-policy.ts
+++ b/src/core/restart-followup-policy.ts
@@ -1,0 +1,70 @@
+/**
+ * Worker restart follow-up policy — pure decision for whether an in-flight
+ * `restartCliProcess()` must chain one more restart when its continuation
+ * completes.
+ *
+ * Two independent hazards make a single restart insufficient:
+ *
+ *  1. **cwd-move landed after the config snapshot.** A role-switch `restart`
+ *     that arrives after `restartCfg` was snapshotted (but before spawn
+ *     finished) updated `lastInitConfig.workingDir` while the CLI is coming up
+ *     in the OLD cwd — daemon record and process diverge. Detect by comparing
+ *     the workingDir we actually spawned with the current `lastInitConfig`.
+ *
+ *  2. **The replacement generation exited during the in-flight window.** The
+ *     `cliRestartInProgress` gate covers spawnCli() AND the trailing
+ *     `prepareCodexNativeTitleGeneration()` (Codex resume + native title ≈
+ *     several seconds). If the freshly-spawned CLI dies inside it, its onExit
+ *     nulls `backend` and the daemon's auto-restart `restart` IPC is swallowed
+ *     by the merge guard (which sets `restartRequestedDuringInFlight`). Either
+ *     signal — a null backend (ground truth the replacement is gone) or the
+ *     armed flag — must trigger recovery, or the session strands with no CLI
+ *     and only a manual `/restart` recovers it.
+ *
+ * Extracted from worker.ts (a process entrypoint that can't be unit-tested
+ * without installing IPC/signal handlers) so the branch order and the
+ * budget-skip decision have an executable test surface — the same rationale
+ * as inject-queue-policy.ts.
+ */
+export interface RestartFollowupInput {
+  /** workingDir captured into `restartCfg` at spawn time (undefined if lastInitConfig was absent). */
+  spawnedWorkingDir: string | undefined;
+  /** current lastInitConfig.workingDir after the spawn (undefined if lastInitConfig absent). */
+  currentWorkingDir: string | undefined;
+  /** false once the replacement CLI's onExit ran during the in-flight window. */
+  backendAlive: boolean;
+  /** merge guard armed this when it swallowed a `restart` IPC during the in-flight window. */
+  restartRequestedDuringInFlight: boolean;
+}
+
+export type RestartFollowupDecision =
+  | { kind: 'none' }
+  /** A merged cwd-move diverged from the spawned cwd — respawn to converge.
+   *  User-initiated move, not crash recovery → skip the tier-2 FRESH budget. */
+  | { kind: 'cwd-move'; skipRestartBudget: true }
+  /** Replacement exited (or a restart was requested) during the in-flight
+   *  window — recover. Genuine crash recovery → COUNTS toward tier-2 FRESH. */
+  | { kind: 'replacement-recovery'; skipRestartBudget: false };
+
+/**
+ * Decide whether the just-finished in-flight restart must chain another.
+ *
+ * Order matters and is load-bearing:
+ *  - cwd-move convergence is checked FIRST. It re-spawns with the newest
+ *    workingDir and (being a fresh restartCliProcess call) resets the armed
+ *    flag, so a replacement that also died will be re-evaluated by that new
+ *    restart's own continuation. Running it first keeps the cwd authoritative.
+ *  - Otherwise, a dead/again-requested replacement recovers via a plain
+ *    restart (which reuses `{...lastInitConfig}`, preserving any converged cwd).
+ */
+export function decideRestartFollowup(input: RestartFollowupInput): RestartFollowupDecision {
+  const cwdMoved =
+    input.spawnedWorkingDir !== undefined &&
+    input.currentWorkingDir !== undefined &&
+    input.currentWorkingDir !== input.spawnedWorkingDir;
+  if (cwdMoved) return { kind: 'cwd-move', skipRestartBudget: true };
+  if (!input.backendAlive || input.restartRequestedDuringInFlight) {
+    return { kind: 'replacement-recovery', skipRestartBudget: false };
+  }
+  return { kind: 'none' };
+}

--- a/src/core/restart-followup-policy.ts
+++ b/src/core/restart-followup-policy.ts
@@ -137,4 +137,3 @@ export function settleDurableTurnForRestart(deps: DurableTurnSettleDeps): Durabl
   }
   return result;
 }
-

--- a/src/types.ts
+++ b/src/types.ts
@@ -584,7 +584,11 @@ export type DaemonToWorker =
   | { type: 'rename_session'; title: string }
   | { type: 'close' }
   | { type: 'suspend' }
-  | { type: 'restart' }
+  /** Kill the CLI and respawn it with --resume. `updateWorkingDir`（可选）
+   *  用于角色切换的 cwd-move respawn：respawn 前把 worker 侧 lastInitConfig
+   *  收敛到新目录，让 CLI 在新 cwd 冷启动（新 CLAUDE.md/记忆索引开场注入）
+   *  同时 --resume 续回对话上下文。 */
+  | { type: 'restart'; updateWorkingDir?: string }
   /** Lease watchdog fencing: only the exact still-running durable attempt may
    * tear down/restart the CLI. A late command after terminal/current-turn
    * advance is ignored worker-side. */
@@ -598,10 +602,9 @@ export type DaemonToWorker =
   // onExit so transient auto-restarted exits don't park-then-tear-down.
   | { type: 'park_diagnostic' }
   | { type: 'tui_keys'; keys: string[]; isFinal: boolean; rearmStuckDetector?: boolean; stuckNonce?: number; stuckCliLifetime?: number; stuckPageType?: string }
-  // updateWorkingDir：会话内 /cd 移动 cwd 后随附的新目录，worker 记入
-  // lastInitConfig.workingDir，使内部三条 respawn 路径（claude_exit 自动重启 /
-  // IM /restart / dashboard restart）收敛到新目录而非陈旧的初始 cwd。
-  | { type: 'inject_command'; command: string; updateWorkingDir?: string }
+  // 白名单 TUI 命令注入（/slash 路由）。cwd 移动不走注入——角色切换用
+  // restart+updateWorkingDir 的 respawn，避免绕过 cd 路由的角色库硬校验。
+  | { type: 'inject_command'; command: string }
   | { type: 'tui_text_input'; keys: string[]; text: string }
   // CoCo AskUserQuestion 作答：daemon 在 ask 结算后下发，worker 等原生 picker 渲染后
   // 用 navKeys 驱动它选择+导航。needsReviewSubmit=true（多题）时 navKeys 停在 Review

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -46,7 +46,7 @@ import {
   shouldWriteNow,
 } from './utils/input-gate.js';
 import { canStartInjectionFlush, shouldDeferUserFlush, shouldFlushInjectionsFirst, type PendingInjection } from './core/inject-queue-policy.js';
-import { decideRestartFollowup } from './core/restart-followup-policy.js';
+import { decideRestartFollowup, settleDurableTurnForRestart } from './core/restart-followup-policy.js';
 import { stripAnsiForLog, tailChars } from './utils/crash-log.js';
 import { CodexUpdateDialogGuard } from './utils/codex-update-dialog.js';
 import { installStdioEpipeGuard, isIgnorableStreamError } from './utils/stdio-epipe-guard.js';
@@ -9981,26 +9981,21 @@ process.on('message', async (raw: unknown) => {
       // emitTurnTerminal 自带释放（复位 durableTurnInFlight、退休 inflight input、
       // 撤销 turn-origin relay、丢弃 bridge 尝试）并对后续 CLI-exit 终端去重；它排的
       // flushPending 微任务会因下面 restartCliProcess 同步置位 cliRestartInProgress 而空跑。
-      if (durableTurnInFlight) {
-        if (currentBotmuxTurnId) {
-          // 与 onExit 对齐：emit 'ambiguous' 前先 drain 已落盘的可靠终态，让「刚好在
-          // kill 前完成、watcher 尚未消费」的 durable turn 以 'completed' 抢占 deduper。
-          // 否则无条件 ambiguous 会误标已完成投递 → 同 key 可重派 → 外部副作用执行两次。
-          drainReliableTerminalBeforeInterrupt();
-          // drain 可能已发布 completed 并经 terminalReleasesDurableTurn 复位
-          // durableTurnInFlight——此时该 attempt 已结算，不再补发 ambiguous（emit 的
-          // claim 去重也会兜底，这里显式判断只为语义清晰、少一次空 emit）。
-          if (durableTurnInFlight) {
-            emitTurnTerminal(currentBotmuxTurnId, 'ambiguous', undefined, currentBotmuxDispatchAttempt);
-          }
-        }
-        // 兜底：若无匹配 durable turn 可释放（emit 空操作 / drain 已结算），仍复位，
-        // 避免残留 flag 卡住 respawn。
-        if (durableTurnInFlight) {
-          durableTurnInFlight = false;
-          inflightInputs.onTurnComplete();
-        }
-      }
+      // 结算被 restart 打断的在飞 durable turn（编排见 settleDurableTurnForRestart，
+      // 已单测）：drain 已落盘可靠终态让「刚好在 kill 前完成、watcher 未消费」的 turn
+      // 以 completed 抢占 deduper → 复检仍在飞才补发 ambiguous（否则无条件 ambiguous
+      // 会误标已完成投递 → 同 key 可重派 → 副作用两次）→ 兜底释放 latch 免卡 respawn。
+      // emitTurnTerminal 自带释放（复位 durableTurnInFlight、退休 inflight input、撤销
+      // turn-origin relay、丢弃 bridge 尝试）；它排的 flushPending 微任务会因下面
+      // restartCliProcess 同步置位 cliRestartInProgress 而空跑。
+      settleDurableTurnForRestart({
+        hasInFlightTurn: durableTurnInFlight,
+        hasCurrentTurnId: !!currentBotmuxTurnId,
+        drain: () => drainReliableTerminalBeforeInterrupt(),
+        isStillInFlight: () => durableTurnInFlight,
+        emitAmbiguous: () => emitTurnTerminal(currentBotmuxTurnId!, 'ambiguous', undefined, currentBotmuxDispatchAttempt),
+        release: () => { durableTurnInFlight = false; inflightInputs.onTurnComplete(); },
+      });
       await restartCliProcess(
         msg.updateWorkingDir ? `cwd-move respawn → ${msg.updateWorkingDir}` : 'daemon request',
         // cwd-move 是用户主动的目录迁移、不是崩溃恢复，不计入 tier-2 强制

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4500,11 +4500,12 @@ async function handleTuiKeys(keys: string[], isFinal: boolean): Promise<boolean>
 
 // 待注入的 TUI 命令队列。生命周期绑定当前 CLI 进程：killCli() 会清空它，
 // 防止 restart 后残留命令重放进新 CLI——新增清理状态时记得同步那里。
-// barrier=true 标记该注入携带 updateWorkingDir（cwd-move，如 /cd）：markPromptReady
-// 里 barrier 注入必须先于本次 pending 用户消息落地，防止用户消息在「记录已是新
-// cwd、进程仍在旧 cwd」的窗口里被写进旧目录的 CLI。排队策略判定收敛到
-// core/inject-queue-policy.ts（shouldDeferUserFlush / shouldFlushInjectionsFirst）
-// 以获得可单测的纯函数单元——本文件只持有队列状态。
+// barrier 语义：barrier=true 的注入必须先于本次 pending 用户消息落地。历史上
+// 唯一的 barrier 来源是 cwd-move 的 /cd 注入；角色切换改为 restart respawn 后
+// 现存发送方（/slash 白名单注入）全部 barrier=false，机制保留供未来有顺序
+// 依赖的注入复用。排队策略判定收敛到 core/inject-queue-policy.ts
+// （shouldDeferUserFlush / shouldFlushInjectionsFirst）以获得可单测的纯函数
+// 单元——本文件只持有队列状态。
 const pendingInjections: PendingInjection[] = [];
 let injectionFlushing = false;
 
@@ -5031,13 +5032,11 @@ function markPromptReady(): void {
     const { content } = renderer.snapshot();
     send({ type: 'screen_update', content, ...usageLimitTracker.classify(content, 'idle'), turnId: currentBotmuxTurnId, dispatchAttempt: currentBotmuxDispatchAttempt });
   }
-  // cwd-move 注入（barrier=true，如 /cd）必须先于本次 pending 用户消息落地：
-  // 用户在 bot 发完「已切换角色」确认后立刻发下一条消息是最常见路径——若
-  // flushPending 先跑，该消息会在 barrier 注入之前被写进旧 cwd 的 CLI（daemon
-  // 记录已是新目录，实际执行仍在旧目录）。跳过本次 flushPending 不会饿死用户
-  // 消息：flushPending 自身的 injectionFlushing 守卫会挡住并发写入，
-  // flushPendingInjections 的 finally 会在注入完成、CLI 重新 idle 后补踢一次
-  // flushPending 排空 pendingMessages。
+  // barrier 注入必须先于本次 pending 用户消息落地（现存发送方均 barrier=false，
+  // 该分支目前不触发；机制保留见 pendingInjections 声明处注释）。跳过本次
+  // flushPending 不会饿死用户消息：flushPending 自身的 injectionFlushing 守卫
+  // 会挡住并发写入，flushPendingInjections 的 finally 会在注入完成、CLI 重新
+  // idle 后补踢一次 flushPending 排空 pendingMessages。
   if (shouldFlushInjectionsFirst(pendingInjections)) {
     void flushPendingInjections();
   } else {
@@ -8188,7 +8187,7 @@ function killCli(opts: { preservePending?: boolean } = {}): void {
 
 async function restartCliProcess(
   reason: string,
-  opts: { immediate?: boolean; preservePending?: boolean } = {},
+  opts: { immediate?: boolean; preservePending?: boolean; skipRestartBudget?: boolean } = {},
 ): Promise<void> {
   if (lastInitConfig?.adoptMode) {
     log(`Restart ignored in adopt mode (${reason})`);
@@ -8208,9 +8207,13 @@ async function restartCliProcess(
   revokeManagedTurnOriginForRestart();
   log(`Restart requested (${reason})`);
   // Tier-2 guard: 2nd consecutive in-worker restart forces FRESH. Tier-1
-  // adapter probing is still re-run on every spawn.
-  consecutiveInWorkerRestarts++;
-  log(`Restart count: ${consecutiveInWorkerRestarts} (>=2 forces FRESH)`);
+  // adapter probing is still re-run on every spawn. skipRestartBudget（角色
+  // 切换的 cwd-move respawn）不计入：那是用户主动迁移不是崩溃恢复，计进去
+  // 会让「切角色 + 一次无关重启」无故触发强制 FRESH 丢上下文。
+  if (!opts.skipRestartBudget) {
+    consecutiveInWorkerRestarts++;
+    log(`Restart count: ${consecutiveInWorkerRestarts} (>=2 forces FRESH)`);
+  }
   const restart = async (): Promise<void> => {
     try {
       tmuxRestartTimer = null;
@@ -9901,7 +9904,46 @@ process.on('message', async (raw: unknown) => {
     }
 
     case 'restart': {
-      await restartCliProcess('daemon request', { preservePending: true });
+      // 角色切换的 cwd-move respawn：respawn 用 {...lastInitConfig, resume:true}，
+      // 先收敛 workingDir 才能让 CLI 在新目录重启（新 cwd 的 CLAUDE.md/记忆索引
+      // 开场注入）。旧桶 transcript 由 resume 预检的跨桶迁移接住，上下文不丢。
+      if (msg.updateWorkingDir && lastInitConfig) {
+        lastInitConfig.workingDir = msg.updateWorkingDir;
+      }
+      // restart 合并：已有一轮 restart 在飞（teardown 进行中，或 tmux jitter
+      // 定时器未触发）时不叠加第二轮——叠加会 clearTimeout 吃掉首轮 teardown、
+      // 把重启预算无故烧到 tier-2 强制 FRESH（丢上下文），非 tmux 路径还会
+      // 双 spawn。workingDir 已收敛进 lastInitConfig，pending 的 spawn 展开
+      // {...lastInitConfig} 时自然拿到新目录。
+      if (cliRestartInProgress || tmuxRestartTimer) {
+        log(`Restart request merged into in-flight restart${msg.updateWorkingDir ? ` (workingDir → ${msg.updateWorkingDir})` : ''}`);
+        break;
+      }
+      // restart 杀死 CLI，在飞的 durable turn 随之死亡。对被杀的那次投递，主动发一个
+      // 'ambiguous' 终端回执：CLI 被中途杀掉，副作用到底发没发是**真的无法证明**
+      // （故不能报 'cancelled'），交由 daemon 的重试策略即时对账。不发的话 receipt 会
+      // 悬着，等 daemon 租约到期走 expire_durable_turn 的「无法证明 → 扣 ACK → 超时
+      // fencing teardown」慢路径（还会把刚 respawn 的新 CLI 二次 teardown）。
+      // emitTurnTerminal 自带释放（复位 durableTurnInFlight、退休 inflight input、
+      // 撤销 turn-origin relay、丢弃 bridge 尝试）并对后续 CLI-exit 终端去重；它排的
+      // flushPending 微任务会因下面 restartCliProcess 同步置位 cliRestartInProgress 而空跑。
+      if (durableTurnInFlight) {
+        if (currentBotmuxTurnId) {
+          emitTurnTerminal(currentBotmuxTurnId, 'ambiguous', undefined, currentBotmuxDispatchAttempt);
+        }
+        // 兜底：若无匹配 durable turn 可释放（emit 空操作），仍复位，避免残留 flag 卡住 respawn。
+        if (durableTurnInFlight) {
+          durableTurnInFlight = false;
+          inflightInputs.onTurnComplete();
+        }
+      }
+      await restartCliProcess(
+        msg.updateWorkingDir ? `cwd-move respawn → ${msg.updateWorkingDir}` : 'daemon request',
+        // cwd-move 是用户主动的目录迁移、不是崩溃恢复，不计入 tier-2 强制
+        // FRESH 的重启预算；respawn 真失败仍有 claude_exit → daemon
+        // auto-restart 那条裸 restart 的计数兜底。
+        { preservePending: true, skipRestartBudget: !!msg.updateWorkingDir },
+      );
       break;
     }
 
@@ -10041,12 +10083,10 @@ process.on('message', async (raw: unknown) => {
     }
 
     case 'inject_command': {
-      // 会话内 /cd 移动后，worker 内部 respawn（claude_exit 自动重启 / IM /restart /
-      // dashboard restart）必须收敛到新目录，而不是陈旧的 lastInitConfig.workingDir。
-      if (msg.updateWorkingDir && lastInitConfig) {
-        lastInitConfig.workingDir = msg.updateWorkingDir;
-      }
-      pendingInjections.push({ command: msg.command, barrier: !!msg.updateWorkingDir });
+      // 唯一发送方是 /slash 路由的白名单 TUI 命令注入。cwd 移动不再走注入
+      // （角色切换已改为 restart+updateWorkingDir 的 respawn），这里不接受
+      // 任何 workingDir 改写——那会绕过 cd 路由的角色库硬校验。
+      pendingInjections.push({ command: msg.command, barrier: false });
       void flushPendingInjections();
       break;
     }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8241,12 +8241,14 @@ async function restartCliProcess(
       killCli({ preservePending: opts.preservePending });
       awaitingFirstPrompt = true;
       setTimeout(async () => {
+        let spawnedWorkingDir: string | undefined;
         if (lastInitConfig) {
           startScreenUpdates();
           startScreenAnalyzer();
           startStuckDetector();
           try {
             const restartCfg = { ...lastInitConfig, resume: true, prompt: '', cliSessionId: rpcThreadId ?? lastInitConfig.cliSessionId };
+            spawnedWorkingDir = restartCfg.workingDir;
             // Re-engage RPC so the new --remote pane binds to the CURRENT app-server
             // (a fresh port), not the dead prior one. engageCodexRpc only sets
             // remote* on success, else spawnCli falls back to paste.
@@ -8267,6 +8269,15 @@ async function restartCliProcess(
           }
         }
         cliRestartInProgress = false;
+        // 合并进本轮的 cwd-move 若在 restartCfg 快照之后才到达，刚 spawn 的 CLI
+        // 仍在旧目录，而 daemon 侧已把会话重钉到新目录（状态分裂）。对账快照与
+        // lastInitConfig：发散 → 立即补一轮 respawn 收敛到最新 cwd（restart 合并
+        // 护栏对已完成的本轮不再拦截；skipRestartBudget 同 cwd-move 语义）。
+        if (spawnedWorkingDir && lastInitConfig && lastInitConfig.workingDir !== spawnedWorkingDir) {
+          log(`Merged cwd-move landed after restart snapshot (${spawnedWorkingDir} → ${lastInitConfig.workingDir}) — follow-up respawn`);
+          void restartCliProcess(`cwd-move follow-up respawn → ${lastInitConfig.workingDir}`, { preservePending: true, skipRestartBudget: true });
+          return;
+        }
         // Riff marks itself prompt-ready inside spawnCli(); that early flush is
         // intentionally held by the restart gate above. Release its raw-input
         // fence now; other backends keep it until their later markPromptReady().

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1194,15 +1194,6 @@ let isFlushing = false;
  * cancellation; this gate prevents new input or an old idle callback from
  * crossing that teardown fence. */
 let cliRestartInProgress = false;
-/** A `restart` IPC that arrived while a restart was already in flight and got
- *  merged (see the merge guard in the `restart` case). The in-flight restart's
- *  continuation checks this after it clears `cliRestartInProgress` and honors
- *  exactly one follow-up restart. Critical for a REPLACEMENT-generation exit:
- *  the new CLI can die during the window `cliRestartInProgress` still covers
- *  (spawnCli + prepareCodexNativeTitleGeneration), firing claude_exit →
- *  daemon auto-restart (bare `restart`); without this its request would be
- *  swallowed by the merge guard and the session would strand at backend=null. */
-let pendingRestartAfterInFlight = false;
 /** Raw slash commands require a real prompt and cannot use the ordinary
  * type-ahead fallback. Keep them fenced across an owned restart until the
  * replacement generation reaches its prompt. */
@@ -8225,10 +8216,6 @@ async function restartCliProcess(
   // remain queued until a replacement backend has been installed.
   cliRestartInProgress = true;
   rawInputRestartGate = true;
-  // Consume any prior arming: from here on, only a `restart` IPC that arrives
-  // DURING this restart should trigger a follow-up. (The continuation re-checks
-  // and re-arms as needed.)
-  pendingRestartAfterInFlight = false;
   // The Node worker stays alive through this restart, so the daemon will see
   // neither claude_exit nor worker-exit. Explicitly revoke the old turn's
   // authority now, before jitter/async teardown leaves a stale-send window.
@@ -8302,26 +8289,27 @@ async function restartCliProcess(
         // Follow-up decision (pure, unit-tested in restart-followup-policy.ts):
         //  - cwd-move: a role-switch restart landed after restartCfg was
         //    snapshotted → CLI came up in the old cwd while daemon repinned to
-        //    the new one. Respawn to converge; user-move, so skip FRESH budget.
+        //    the new one. Respawn to converge (budget skipped only if the
+        //    backend is still alive; a dead one keeps the crash evidence).
         //  - replacement-recovery: the freshly-spawned CLI exited inside the
         //    window cliRestartInProgress still covers (spawnCli +
-        //    prepareCodexNativeTitleGeneration), so its daemon auto-restart was
-        //    swallowed by the merge guard (which armed pendingRestartAfterInFlight)
-        //    and/or onExit nulled `backend`. Recover now or the session strands
-        //    at backend=null needing a manual /restart. Genuine crash recovery →
-        //    COUNTS toward tier-2 FRESH so a persistently-dying replacement
-        //    eventually falls back to FRESH instead of resume-looping.
+        //    prepareCodexNativeTitleGeneration). onExit nulled `backend`
+        //    synchronously, so `!backend` is the ground-truth recovery signal —
+        //    NOT a merged daemon auto-restart (a restart message carries no
+        //    trustworthy source, so a healthy duplicate /restart during the
+        //    window must NOT be misread as a crash and force a budget-burning
+        //    second restart). Recover now or the session strands at
+        //    backend=null needing a manual /restart. Genuine crash recovery →
+        //    COUNTS toward tier-2 FRESH.
         const followup = decideRestartFollowup({
           spawnedWorkingDir,
           currentWorkingDir: lastInitConfig?.workingDir,
           backendAlive: !!backend,
-          restartRequestedDuringInFlight: pendingRestartAfterInFlight,
         });
         if (followup.kind !== 'none') {
-          pendingRestartAfterInFlight = false;
           const reason = followup.kind === 'cwd-move'
             ? `cwd-move follow-up respawn → ${lastInitConfig?.workingDir}`
-            : `replacement-exit follow-up restart (${backend ? 'restart requested during in-flight' : 'replacement exited'})`;
+            : 'replacement-exit follow-up restart (replacement exited during in-flight restart)';
           log(reason);
           void restartCliProcess(reason, { preservePending: true, skipRestartBudget: followup.skipRestartBudget });
           return;
@@ -9965,7 +9953,8 @@ process.on('message', async (raw: unknown) => {
     case 'restart': {
       // 角色切换的 cwd-move respawn：respawn 用 {...lastInitConfig, resume:true}，
       // 先收敛 workingDir 才能让 CLI 在新目录重启（新 cwd 的 CLAUDE.md/记忆索引
-      // 开场注入）。旧桶 transcript 由 resume 预检的跨桶迁移接住，上下文不丢。
+      // 开场注入）。旧桶 transcript 由 resume 预检的 syncClaudeResumeTargetToCwd
+      // （COPY 最新 <sid>.jsonl 进新 cwd 桶，已在 master）接住，上下文不丢。
       if (msg.updateWorkingDir && lastInitConfig) {
         lastInitConfig.workingDir = msg.updateWorkingDir;
       }
@@ -9974,15 +9963,14 @@ process.on('message', async (raw: unknown) => {
       // 把重启预算无故烧到 tier-2 强制 FRESH（丢上下文），非 tmux 路径还会
       // 双 spawn。workingDir 已收敛进 lastInitConfig，pending 的 spawn 展开
       // {...lastInitConfig} 时自然拿到新目录。
+      //
+      // 这里**只 break、不记任何 flag**：restart 消息不带可信来源，无法区分
+      // 「replacement 崩溃触发的 auto-restart」与「用户重复点了一次 restart」。
+      // replacement 真退出时 onExit 已同步把 backend 置 null，续体用 !backend 即可
+      // 补 recovery（见 decideRestartFollowup）；健康的重复 restart 就该被合并掉，
+      // 记 flag 反而会逼健康进程再重启一轮、烧预算丢 --resume（正是合并要防的）。
       if (cliRestartInProgress || tmuxRestartTimer) {
-        // 但不能简单丢弃：replacement generation 可能在续体仍持 cliRestartInProgress
-        // 的窗口内（spawnCli + prepareCodexNativeTitleGeneration）退出 → claude_exit →
-        // daemon auto-restart 发来这条裸 restart。若直接吞掉，续体清 flag 后只会 flush
-        // 到 backend=null 的死会话。置位 pendingRestartAfterInFlight，让续体在清
-        // cliRestartInProgress 后补跑一轮 restart 收敛（cwd-move 的收敛另由
-        // lastInitConfig.workingDir + 续体发散检查覆盖，二者独立不冲突）。
-        pendingRestartAfterInFlight = true;
-        log(`Restart request merged into in-flight restart${msg.updateWorkingDir ? ` (workingDir → ${msg.updateWorkingDir})` : ''} — follow-up armed`);
+        log(`Restart request merged into in-flight restart${msg.updateWorkingDir ? ` (workingDir → ${msg.updateWorkingDir})` : ''}`);
         break;
       }
       // restart 杀死 CLI，在飞的 durable turn 随之死亡。对被杀的那次投递，主动发一个

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -46,6 +46,7 @@ import {
   shouldWriteNow,
 } from './utils/input-gate.js';
 import { canStartInjectionFlush, shouldDeferUserFlush, shouldFlushInjectionsFirst, type PendingInjection } from './core/inject-queue-policy.js';
+import { decideRestartFollowup } from './core/restart-followup-policy.js';
 import { stripAnsiForLog, tailChars } from './utils/crash-log.js';
 import { CodexUpdateDialogGuard } from './utils/codex-update-dialog.js';
 import { installStdioEpipeGuard, isIgnorableStreamError } from './utils/stdio-epipe-guard.js';
@@ -1193,6 +1194,15 @@ let isFlushing = false;
  * cancellation; this gate prevents new input or an old idle callback from
  * crossing that teardown fence. */
 let cliRestartInProgress = false;
+/** A `restart` IPC that arrived while a restart was already in flight and got
+ *  merged (see the merge guard in the `restart` case). The in-flight restart's
+ *  continuation checks this after it clears `cliRestartInProgress` and honors
+ *  exactly one follow-up restart. Critical for a REPLACEMENT-generation exit:
+ *  the new CLI can die during the window `cliRestartInProgress` still covers
+ *  (spawnCli + prepareCodexNativeTitleGeneration), firing claude_exit →
+ *  daemon auto-restart (bare `restart`); without this its request would be
+ *  swallowed by the merge guard and the session would strand at backend=null. */
+let pendingRestartAfterInFlight = false;
 /** Raw slash commands require a real prompt and cannot use the ordinary
  * type-ahead fallback. Keep them fenced across an owned restart until the
  * replacement generation reaches its prompt. */
@@ -3697,6 +3707,31 @@ function codexBridgeDrainAndMaybeEmit(opts: { signalIdle?: boolean } = {}): void
     try { codexBridgeIngest(opts); } catch (err: any) { log(`Codex bridge ingest error: ${err.message}`); }
   }
   emitReadyCodexTurns();
+}
+
+/** Before we emit a fail-closed `ambiguous` terminal for a durable turn that a
+ *  CLI kill is about to interrupt, give an already-persisted `completed` record
+ *  a chance to win the worker-local terminal deduper. `reliableTurnTerminal`
+ *  CLIs (claude-code / codex / grok / traex) durably append their terminal line
+ *  to the transcript; if that line landed microseconds before the kill but the
+ *  fs.watch/1s poller hasn't consumed it yet, an unconditional `ambiguous` would
+ *  claim the deduper first and needlessly mark a turn that actually completed →
+ *  same durable key re-dispatchable → external side effect executed twice.
+ *  Draining here publishes that `completed` (claiming the deduper) so the later
+ *  `ambiguous` becomes a no-op. Shared by the CLI `onExit` path and the daemon
+ *  `restart` IPC path — both must drain identically before their ambiguous emit. */
+function drainReliableTerminalBeforeInterrupt(): void {
+  if (cliAdapter?.reliableTurnTerminal !== true) return;
+  if (bridgeJsonlPath) {
+    try { bridgeDrainAndMaybeEmit(); } catch (err: any) {
+      log(`Bridge terminal drain failed: ${err.message}`);
+    }
+  }
+  if (codexBridgeFallbackActive()) {
+    try { codexBridgeDrainAndMaybeEmit({ signalIdle: false }); } catch (err: any) {
+      log(`Codex bridge terminal drain failed: ${err.message}`);
+    }
+  }
 }
 
 function emitReadyCodexTurns(): void {
@@ -7975,16 +8010,7 @@ async function spawnCli(
       // before exiting while fs.watch/the 1s poller is still queued. Drain it
       // synchronously before claiming `cli_exit`; otherwise ambiguous wins the
       // deduper and needlessly replays a turn that actually completed.
-      if (bridgeJsonlPath) {
-        try { bridgeDrainAndMaybeEmit(); } catch (err: any) {
-          log(`Bridge exit drain failed: ${err.message}`);
-        }
-      }
-      if (codexBridgeFallbackActive()) {
-        try { codexBridgeDrainAndMaybeEmit({ signalIdle: false }); } catch (err: any) {
-          log(`Codex bridge exit drain failed: ${err.message}`);
-        }
-      }
+      drainReliableTerminalBeforeInterrupt();
       // Race-safe with transcript final / submit-failure: the worker-local
       // terminal deduper lets exactly one status win for this attempt.
       emitTurnTerminal(
@@ -8199,6 +8225,10 @@ async function restartCliProcess(
   // remain queued until a replacement backend has been installed.
   cliRestartInProgress = true;
   rawInputRestartGate = true;
+  // Consume any prior arming: from here on, only a `restart` IPC that arrives
+  // DURING this restart should trigger a follow-up. (The continuation re-checks
+  // and re-arms as needed.)
+  pendingRestartAfterInFlight = false;
   // The Node worker stays alive through this restart, so the daemon will see
   // neither claude_exit nor worker-exit. Explicitly revoke the old turn's
   // authority now, before jitter/async teardown leaves a stale-send window.
@@ -8269,13 +8299,31 @@ async function restartCliProcess(
           }
         }
         cliRestartInProgress = false;
-        // 合并进本轮的 cwd-move 若在 restartCfg 快照之后才到达，刚 spawn 的 CLI
-        // 仍在旧目录，而 daemon 侧已把会话重钉到新目录（状态分裂）。对账快照与
-        // lastInitConfig：发散 → 立即补一轮 respawn 收敛到最新 cwd（restart 合并
-        // 护栏对已完成的本轮不再拦截；skipRestartBudget 同 cwd-move 语义）。
-        if (spawnedWorkingDir && lastInitConfig && lastInitConfig.workingDir !== spawnedWorkingDir) {
-          log(`Merged cwd-move landed after restart snapshot (${spawnedWorkingDir} → ${lastInitConfig.workingDir}) — follow-up respawn`);
-          void restartCliProcess(`cwd-move follow-up respawn → ${lastInitConfig.workingDir}`, { preservePending: true, skipRestartBudget: true });
+        // Follow-up decision (pure, unit-tested in restart-followup-policy.ts):
+        //  - cwd-move: a role-switch restart landed after restartCfg was
+        //    snapshotted → CLI came up in the old cwd while daemon repinned to
+        //    the new one. Respawn to converge; user-move, so skip FRESH budget.
+        //  - replacement-recovery: the freshly-spawned CLI exited inside the
+        //    window cliRestartInProgress still covers (spawnCli +
+        //    prepareCodexNativeTitleGeneration), so its daemon auto-restart was
+        //    swallowed by the merge guard (which armed pendingRestartAfterInFlight)
+        //    and/or onExit nulled `backend`. Recover now or the session strands
+        //    at backend=null needing a manual /restart. Genuine crash recovery →
+        //    COUNTS toward tier-2 FRESH so a persistently-dying replacement
+        //    eventually falls back to FRESH instead of resume-looping.
+        const followup = decideRestartFollowup({
+          spawnedWorkingDir,
+          currentWorkingDir: lastInitConfig?.workingDir,
+          backendAlive: !!backend,
+          restartRequestedDuringInFlight: pendingRestartAfterInFlight,
+        });
+        if (followup.kind !== 'none') {
+          pendingRestartAfterInFlight = false;
+          const reason = followup.kind === 'cwd-move'
+            ? `cwd-move follow-up respawn → ${lastInitConfig?.workingDir}`
+            : `replacement-exit follow-up restart (${backend ? 'restart requested during in-flight' : 'replacement exited'})`;
+          log(reason);
+          void restartCliProcess(reason, { preservePending: true, skipRestartBudget: followup.skipRestartBudget });
           return;
         }
         // Riff marks itself prompt-ready inside spawnCli(); that early flush is
@@ -9927,7 +9975,14 @@ process.on('message', async (raw: unknown) => {
       // 双 spawn。workingDir 已收敛进 lastInitConfig，pending 的 spawn 展开
       // {...lastInitConfig} 时自然拿到新目录。
       if (cliRestartInProgress || tmuxRestartTimer) {
-        log(`Restart request merged into in-flight restart${msg.updateWorkingDir ? ` (workingDir → ${msg.updateWorkingDir})` : ''}`);
+        // 但不能简单丢弃：replacement generation 可能在续体仍持 cliRestartInProgress
+        // 的窗口内（spawnCli + prepareCodexNativeTitleGeneration）退出 → claude_exit →
+        // daemon auto-restart 发来这条裸 restart。若直接吞掉，续体清 flag 后只会 flush
+        // 到 backend=null 的死会话。置位 pendingRestartAfterInFlight，让续体在清
+        // cliRestartInProgress 后补跑一轮 restart 收敛（cwd-move 的收敛另由
+        // lastInitConfig.workingDir + 续体发散检查覆盖，二者独立不冲突）。
+        pendingRestartAfterInFlight = true;
+        log(`Restart request merged into in-flight restart${msg.updateWorkingDir ? ` (workingDir → ${msg.updateWorkingDir})` : ''} — follow-up armed`);
         break;
       }
       // restart 杀死 CLI，在飞的 durable turn 随之死亡。对被杀的那次投递，主动发一个
@@ -9940,9 +9995,19 @@ process.on('message', async (raw: unknown) => {
       // flushPending 微任务会因下面 restartCliProcess 同步置位 cliRestartInProgress 而空跑。
       if (durableTurnInFlight) {
         if (currentBotmuxTurnId) {
-          emitTurnTerminal(currentBotmuxTurnId, 'ambiguous', undefined, currentBotmuxDispatchAttempt);
+          // 与 onExit 对齐：emit 'ambiguous' 前先 drain 已落盘的可靠终态，让「刚好在
+          // kill 前完成、watcher 尚未消费」的 durable turn 以 'completed' 抢占 deduper。
+          // 否则无条件 ambiguous 会误标已完成投递 → 同 key 可重派 → 外部副作用执行两次。
+          drainReliableTerminalBeforeInterrupt();
+          // drain 可能已发布 completed 并经 terminalReleasesDurableTurn 复位
+          // durableTurnInFlight——此时该 attempt 已结算，不再补发 ambiguous（emit 的
+          // claim 去重也会兜底，这里显式判断只为语义清晰、少一次空 emit）。
+          if (durableTurnInFlight) {
+            emitTurnTerminal(currentBotmuxTurnId, 'ambiguous', undefined, currentBotmuxDispatchAttempt);
+          }
         }
-        // 兜底：若无匹配 durable turn 可释放（emit 空操作），仍复位，避免残留 flag 卡住 respawn。
+        // 兜底：若无匹配 durable turn 可释放（emit 空操作 / drain 已结算），仍复位，
+        // 避免残留 flag 卡住 respawn。
         if (durableTurnInFlight) {
           durableTurnInFlight = false;
           inflightInputs.onTurnComplete();

--- a/test/ipc-cd-route.test.ts
+++ b/test/ipc-cd-route.test.ts
@@ -199,10 +199,10 @@ describe('POST /api/sessions/:sessionId/cd', () => {
     expect(killSpy).not.toHaveBeenCalled();
   });
 
-  it('200 mode:inject — live worker + claude-code capability: repin FIRST, then inject /cd <resolvedPath>', async () => {
+  it('200 mode:respawn-resume — live worker: repin FIRST, then send restart carrying updateWorkingDir', async () => {
     const send = vi.fn();
     const ds = {
-      session: { sessionId: 's-inject', cliId: 'claude-code' },
+      session: { sessionId: 's-respawn', cliId: 'claude-code' },
       managedTurnOrigin: { capability: CAP },
       worker: { send, killed: false },
       adoptedFrom: undefined,
@@ -212,15 +212,16 @@ describe('POST /api/sessions/:sessionId/cd', () => {
     const repinSpy = vi.spyOn(sessionCwd, 'repinSessionWorkingDir').mockImplementation(() => {});
     const killSpy = vi.spyOn(workerPool, 'killWorker').mockImplementation(() => {});
 
-    const res = await postCd('s-inject', roleDir);
+    const res = await postCd('s-respawn', roleDir);
 
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true, mode: 'inject', dir: roleDirReal });
-    // TOCTOU 契约：注入命令原样使用校验产出 resolvedPath（realpath 归一），
-    // 而非请求原始输入。updateWorkingDir 随行，供 worker 侧收敛 lastInitConfig。
-    expect(send).toHaveBeenCalledWith({ type: 'inject_command', command: `/cd ${roleDirReal}`, updateWorkingDir: roleDirReal });
+    expect(await res.json()).toEqual({ ok: true, mode: 'respawn-resume', dir: roleDirReal });
+    // TOCTOU 契约：restart 携带的 updateWorkingDir 原样使用校验产出 resolvedPath
+    // （realpath 归一），而非请求原始输入。worker 侧据此收敛 lastInitConfig 后
+    // respawn（--resume 续上下文 + 新 cwd 开场注入新角色 CLAUDE.md/记忆索引）。
+    expect(send).toHaveBeenCalledWith({ type: 'restart', updateWorkingDir: roleDirReal });
     expect(repinSpy).toHaveBeenCalledWith(ds, roleDirReal);
-    // 落盘重钉必须先于注入（记录 = 唯一事实源；注入只是让活进程跟上）。
+    // 落盘重钉必须先于 restart（记录 = 唯一事实源；respawn 只是让活进程跟上）。
     expect(repinSpy.mock.invocationCallOrder[0]).toBeLessThan(send.mock.invocationCallOrder[0]);
     expect(killSpy).not.toHaveBeenCalled();
     // daemon 侧 ds.initConfig 同步更新，与 worker 侧收敛到同一新目录，避免下次
@@ -276,10 +277,12 @@ describe('POST /api/sessions/:sessionId/cd', () => {
     expect(repinSpy).toHaveBeenCalledWith(ds, roleDirReal);
   });
 
-  it('200 mode:cold-restart — live worker but capability-less CLI (codex): kill, never inject', async () => {
+  it('200 mode:respawn-resume — respawn 对 CLI 一视同仁（codex 等非 claude 家族同样走 restart）', async () => {
+    // 旧实现按 supportsSessionCwdMove 能力位分流（claude 注入 /cd、codex 杀进程
+    // 冷启动）。respawn 方案与 /restart 同机制、适配器无关，能力位不再进场。
     const send = vi.fn();
     const ds = {
-      session: { sessionId: 's-cold-codex', cliId: 'codex' },
+      session: { sessionId: 's-respawn-codex', cliId: 'codex' },
       managedTurnOrigin: { capability: CAP },
       worker: { send, killed: false },
       adoptedFrom: undefined,
@@ -288,31 +291,32 @@ describe('POST /api/sessions/:sessionId/cd', () => {
     const repinSpy = vi.spyOn(sessionCwd, 'repinSessionWorkingDir').mockImplementation(() => {});
     const killSpy = vi.spyOn(workerPool, 'killWorker').mockImplementation(() => {});
 
-    const res = await postCd('s-cold-codex', roleDir);
+    const res = await postCd('s-respawn-codex', roleDir);
 
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true, mode: 'cold-restart', dir: roleDirReal });
-    expect(send).not.toHaveBeenCalled();
-    expect(killSpy).toHaveBeenCalledTimes(1);
-    expect(killSpy).toHaveBeenCalledWith(ds);
+    expect(await res.json()).toEqual({ ok: true, mode: 'respawn-resume', dir: roleDirReal });
+    expect(send).toHaveBeenCalledWith({ type: 'restart', updateWorkingDir: roleDirReal });
+    expect(killSpy).not.toHaveBeenCalled();
     expect(repinSpy).toHaveBeenCalledWith(ds, roleDirReal);
   });
 
-  it('200 mode:cold-restart — unknown cliId falls through the catch (no crash)', async () => {
+  it('200 mode:respawn-resume — unknown cliId 不再查适配器，同样 respawn（no crash）', async () => {
+    const send = vi.fn();
     const ds = {
-      session: { sessionId: 's-cold-unknown', cliId: 'no-such-cli' },
+      session: { sessionId: 's-respawn-unknown', cliId: 'no-such-cli' },
       managedTurnOrigin: { capability: CAP },
-      worker: { send: vi.fn(), killed: false },
+      worker: { send, killed: false },
       adoptedFrom: undefined,
     } as any;
     vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue(ds);
     vi.spyOn(sessionCwd, 'repinSessionWorkingDir').mockImplementation(() => {});
     const killSpy = vi.spyOn(workerPool, 'killWorker').mockImplementation(() => {});
 
-    const res = await postCd('s-cold-unknown', roleDir);
+    const res = await postCd('s-respawn-unknown', roleDir);
 
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true, mode: 'cold-restart', dir: roleDirReal });
-    expect(killSpy).toHaveBeenCalledTimes(1);
+    expect(await res.json()).toEqual({ ok: true, mode: 'respawn-resume', dir: roleDirReal });
+    expect(send).toHaveBeenCalledWith({ type: 'restart', updateWorkingDir: roleDirReal });
+    expect(killSpy).not.toHaveBeenCalled();
   });
 });

--- a/test/restart-followup-policy.test.ts
+++ b/test/restart-followup-policy.test.ts
@@ -9,47 +9,51 @@ import { decideRestartFollowup } from '../src/core/restart-followup-policy.js';
  *    restartCfg snapshot.
  *  - replacement-exit recovery (Codex P2): the freshly-spawned CLI dying inside
  *    the window cliRestartInProgress still covers (spawnCli +
- *    prepareCodexNativeTitleGeneration) → daemon auto-restart swallowed by the
- *    merge guard → session strands at backend=null without this.
+ *    prepareCodexNativeTitleGeneration) → session strands at backend=null.
+ *
+ * Recovery keys ONLY on `!backendAlive` (onExit nulls backend synchronously) —
+ * NOT on any "a restart was requested during the window" signal, because a
+ * restart message carries no trustworthy source: a healthy duplicate /restart
+ * would otherwise be misread as a crash and force a budget-burning re-restart
+ * that drops --resume (the exact regression Codex's 2nd review caught).
  */
 describe('decideRestartFollowup', () => {
   const healthy = {
     spawnedWorkingDir: '/roles/pm',
     currentWorkingDir: '/roles/pm',
     backendAlive: true,
-    restartRequestedDuringInFlight: false,
   };
 
-  it('no follow-up on a clean restart (backend alive, cwd unchanged, no request)', () => {
+  it('no follow-up on a clean restart (backend alive, cwd unchanged)', () => {
     expect(decideRestartFollowup(healthy)).toEqual({ kind: 'none' });
   });
 
-  it('cwd-move: workingDir diverged after the snapshot → converge, skip FRESH budget', () => {
+  it('a healthy duplicate restart during the window is merged to none (no budget burn)', () => {
+    // The merge guard already swallowed the duplicate; the continuation must
+    // NOT manufacture a second restart on a healthy generation. This is the
+    // Codex-2 regression guard: backend alive + cwd unchanged → none.
+    expect(decideRestartFollowup({ ...healthy })).toEqual({ kind: 'none' });
+  });
+
+  it('cwd-move with a LIVE backend → converge, skip FRESH budget (pure user move)', () => {
     const d = decideRestartFollowup({ ...healthy, currentWorkingDir: '/roles/after-sales' });
     expect(d).toEqual({ kind: 'cwd-move', skipRestartBudget: true });
+  });
+
+  it('cwd-move with a DEAD backend → converge but COUNT budget (crash evidence kept)', () => {
+    // Codex-2 point #2: a replacement that crashed must not hide behind a
+    // concurrent directory change — converge the cwd yet still burn budget.
+    const d = decideRestartFollowup({
+      spawnedWorkingDir: '/roles/pm',
+      currentWorkingDir: '/roles/after-sales',
+      backendAlive: false,
+    });
+    expect(d).toEqual({ kind: 'cwd-move', skipRestartBudget: false });
   });
 
   it('replacement-recovery: backend died in the window → recover, COUNT FRESH budget', () => {
     const d = decideRestartFollowup({ ...healthy, backendAlive: false });
     expect(d).toEqual({ kind: 'replacement-recovery', skipRestartBudget: false });
-  });
-
-  it('replacement-recovery: a restart was requested (merge-guard-armed) during the window', () => {
-    const d = decideRestartFollowup({ ...healthy, restartRequestedDuringInFlight: true });
-    expect(d).toEqual({ kind: 'replacement-recovery', skipRestartBudget: false });
-  });
-
-  it('cwd-move wins over replacement-recovery when both hold (cwd must stay authoritative)', () => {
-    // A cwd-move respawn whose replacement also died: converge cwd FIRST — the
-    // fresh restart it triggers reuses {...lastInitConfig} (new cwd) and its own
-    // continuation re-evaluates a still-dead backend. Ordering is load-bearing.
-    const d = decideRestartFollowup({
-      spawnedWorkingDir: '/roles/pm',
-      currentWorkingDir: '/roles/after-sales',
-      backendAlive: false,
-      restartRequestedDuringInFlight: true,
-    });
-    expect(d).toEqual({ kind: 'cwd-move', skipRestartBudget: true });
   });
 
   it('no cwd-move when lastInitConfig was absent (workingDir undefined on either side)', () => {
@@ -59,13 +63,11 @@ describe('decideRestartFollowup', () => {
       spawnedWorkingDir: undefined,
       currentWorkingDir: '/roles/pm',
       backendAlive: true,
-      restartRequestedDuringInFlight: false,
     })).toEqual({ kind: 'none' });
     expect(decideRestartFollowup({
       spawnedWorkingDir: '/roles/pm',
       currentWorkingDir: undefined,
       backendAlive: true,
-      restartRequestedDuringInFlight: false,
     })).toEqual({ kind: 'none' });
   });
 
@@ -74,7 +76,6 @@ describe('decideRestartFollowup', () => {
       spawnedWorkingDir: undefined,
       currentWorkingDir: undefined,
       backendAlive: false,
-      restartRequestedDuringInFlight: false,
     })).toEqual({ kind: 'replacement-recovery', skipRestartBudget: false });
   });
 });

--- a/test/restart-followup-policy.test.ts
+++ b/test/restart-followup-policy.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { decideRestartFollowup } from '../src/core/restart-followup-policy.js';
+
+/**
+ * Pure decision for whether an in-flight restart must chain another. This is
+ * the executable core of PR #507's two restart-race fixes:
+ *  - cwd-move convergence (2nd commit): a role-switch restart landing after the
+ *    restartCfg snapshot.
+ *  - replacement-exit recovery (Codex P2): the freshly-spawned CLI dying inside
+ *    the window cliRestartInProgress still covers (spawnCli +
+ *    prepareCodexNativeTitleGeneration) → daemon auto-restart swallowed by the
+ *    merge guard → session strands at backend=null without this.
+ */
+describe('decideRestartFollowup', () => {
+  const healthy = {
+    spawnedWorkingDir: '/roles/pm',
+    currentWorkingDir: '/roles/pm',
+    backendAlive: true,
+    restartRequestedDuringInFlight: false,
+  };
+
+  it('no follow-up on a clean restart (backend alive, cwd unchanged, no request)', () => {
+    expect(decideRestartFollowup(healthy)).toEqual({ kind: 'none' });
+  });
+
+  it('cwd-move: workingDir diverged after the snapshot → converge, skip FRESH budget', () => {
+    const d = decideRestartFollowup({ ...healthy, currentWorkingDir: '/roles/after-sales' });
+    expect(d).toEqual({ kind: 'cwd-move', skipRestartBudget: true });
+  });
+
+  it('replacement-recovery: backend died in the window → recover, COUNT FRESH budget', () => {
+    const d = decideRestartFollowup({ ...healthy, backendAlive: false });
+    expect(d).toEqual({ kind: 'replacement-recovery', skipRestartBudget: false });
+  });
+
+  it('replacement-recovery: a restart was requested (merge-guard-armed) during the window', () => {
+    const d = decideRestartFollowup({ ...healthy, restartRequestedDuringInFlight: true });
+    expect(d).toEqual({ kind: 'replacement-recovery', skipRestartBudget: false });
+  });
+
+  it('cwd-move wins over replacement-recovery when both hold (cwd must stay authoritative)', () => {
+    // A cwd-move respawn whose replacement also died: converge cwd FIRST — the
+    // fresh restart it triggers reuses {...lastInitConfig} (new cwd) and its own
+    // continuation re-evaluates a still-dead backend. Ordering is load-bearing.
+    const d = decideRestartFollowup({
+      spawnedWorkingDir: '/roles/pm',
+      currentWorkingDir: '/roles/after-sales',
+      backendAlive: false,
+      restartRequestedDuringInFlight: true,
+    });
+    expect(d).toEqual({ kind: 'cwd-move', skipRestartBudget: true });
+  });
+
+  it('no cwd-move when lastInitConfig was absent (workingDir undefined on either side)', () => {
+    // A missing lastInitConfig must never be read as a divergence (undefined !==
+    // "/x" would misfire); only two concrete, differing dirs count as a move.
+    expect(decideRestartFollowup({
+      spawnedWorkingDir: undefined,
+      currentWorkingDir: '/roles/pm',
+      backendAlive: true,
+      restartRequestedDuringInFlight: false,
+    })).toEqual({ kind: 'none' });
+    expect(decideRestartFollowup({
+      spawnedWorkingDir: '/roles/pm',
+      currentWorkingDir: undefined,
+      backendAlive: true,
+      restartRequestedDuringInFlight: false,
+    })).toEqual({ kind: 'none' });
+  });
+
+  it('backend death still recovers even when workingDir is undefined on both sides', () => {
+    expect(decideRestartFollowup({
+      spawnedWorkingDir: undefined,
+      currentWorkingDir: undefined,
+      backendAlive: false,
+      restartRequestedDuringInFlight: false,
+    })).toEqual({ kind: 'replacement-recovery', skipRestartBudget: false });
+  });
+});

--- a/test/restart-followup-policy.test.ts
+++ b/test/restart-followup-policy.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { decideRestartFollowup } from '../src/core/restart-followup-policy.js';
+import { decideRestartFollowup, settleDurableTurnForRestart } from '../src/core/restart-followup-policy.js';
 
 /**
  * Pure decision for whether an in-flight restart must chain another. This is
@@ -77,5 +77,79 @@ describe('decideRestartFollowup', () => {
       currentWorkingDir: undefined,
       backendAlive: false,
     })).toEqual({ kind: 'replacement-recovery', skipRestartBudget: false });
+  });
+});
+
+/**
+ * P1 executable coverage (Codex's suggested DI approach — no real JSONL/IPC):
+ * the drain-before-ambiguous ordering that stops a just-completed durable turn
+ * from being re-dispatched. Stubs stand in for drain / isStillInFlight / emit /
+ * release so we can assert the exact call pattern per scenario.
+ */
+describe('settleDurableTurnForRestart', () => {
+  function harness(opts: {
+    hasInFlightTurn: boolean;
+    hasCurrentTurnId: boolean;
+    // inFlight readings returned by successive isStillInFlight() calls
+    inFlightReadings: boolean[];
+  }) {
+    const drain = vi.fn();
+    const emitAmbiguous = vi.fn();
+    const release = vi.fn();
+    let i = 0;
+    const isStillInFlight = vi.fn(() => opts.inFlightReadings[Math.min(i++, opts.inFlightReadings.length - 1)]);
+    const result = settleDurableTurnForRestart({
+      hasInFlightTurn: opts.hasInFlightTurn,
+      hasCurrentTurnId: opts.hasCurrentTurnId,
+      drain,
+      isStillInFlight,
+      emitAmbiguous,
+      release,
+    });
+    return { result, drain, emitAmbiguous, release };
+  }
+
+  it('no in-flight durable turn → does nothing (no drain / emit / release)', () => {
+    const h = harness({ hasInFlightTurn: false, hasCurrentTurnId: true, inFlightReadings: [true] });
+    expect(h.drain).not.toHaveBeenCalled();
+    expect(h.emitAmbiguous).not.toHaveBeenCalled();
+    expect(h.release).not.toHaveBeenCalled();
+    expect(h.result).toEqual({ drained: false, ambiguousEmitted: false, released: false });
+  });
+
+  it('drain SETTLES the turn (completed won the deduper) → drains, 0 ambiguous, no release', () => {
+    // isStillInFlight: after drain → false (settled). emit skipped; release skipped.
+    const h = harness({ hasInFlightTurn: true, hasCurrentTurnId: true, inFlightReadings: [false, false] });
+    expect(h.drain).toHaveBeenCalledTimes(1);
+    expect(h.emitAmbiguous).not.toHaveBeenCalled();
+    expect(h.release).not.toHaveBeenCalled();
+    expect(h.result).toEqual({ drained: true, ambiguousEmitted: false, released: false });
+  });
+
+  it('turn STILL in flight after drain → drains then emits ambiguous exactly once', () => {
+    // isStillInFlight: after drain → true (emit). emitTurnTerminal itself resets
+    // the latch, so the post-emit reading → false (no redundant release).
+    const h = harness({ hasInFlightTurn: true, hasCurrentTurnId: true, inFlightReadings: [true, false] });
+    expect(h.drain).toHaveBeenCalledTimes(1);
+    expect(h.emitAmbiguous).toHaveBeenCalledTimes(1);
+    expect(h.release).not.toHaveBeenCalled();
+    expect(h.result).toEqual({ drained: true, ambiguousEmitted: true, released: false });
+  });
+
+  it('emit did not clear the latch (mismatched attempt) → fallback release fires', () => {
+    // still in flight after drain (emit), and STILL in flight after emit → release.
+    const h = harness({ hasInFlightTurn: true, hasCurrentTurnId: true, inFlightReadings: [true, true] });
+    expect(h.emitAmbiguous).toHaveBeenCalledTimes(1);
+    expect(h.release).toHaveBeenCalledTimes(1);
+    expect(h.result).toEqual({ drained: true, ambiguousEmitted: true, released: true });
+  });
+
+  it('in-flight but no currentTurnId (nothing to emit) → skip drain+emit, release the latch', () => {
+    // Can't emit without a turn id; still must release so respawn isn't stranded.
+    const h = harness({ hasInFlightTurn: true, hasCurrentTurnId: false, inFlightReadings: [true] });
+    expect(h.drain).not.toHaveBeenCalled();
+    expect(h.emitAmbiguous).not.toHaveBeenCalled();
+    expect(h.release).toHaveBeenCalledTimes(1);
+    expect(h.result).toEqual({ drained: false, ambiguousEmitted: false, released: true });
   });
 });

--- a/test/worker-backend-exit-crash-order.test.ts
+++ b/test/worker-backend-exit-crash-order.test.ts
@@ -43,13 +43,28 @@ describe('worker backend exit crash ordering', () => {
     const callback = workerSource.slice(start, end);
 
     const reliable = callback.indexOf('cliAdapter?.reliableTurnTerminal === true');
-    const claudeDrain = callback.indexOf('bridgeDrainAndMaybeEmit();', reliable);
-    const structuredDrain = callback.indexOf('codexBridgeDrainAndMaybeEmit({ signalIdle: false });', reliable);
+    // The inline bridge/codex drain was extracted into the shared
+    // drainReliableTerminalBeforeInterrupt() helper (PR #507) so the restart
+    // IPC path drains identically before its own ambiguous emit; onExit calls
+    // it before claiming cli_exit ambiguous. Drain-before-ambiguous ordering is
+    // still what matters and is unit-tested against the helper's internals.
+    const drain = callback.indexOf('drainReliableTerminalBeforeInterrupt();', reliable);
     const ambiguous = callback.indexOf("'ambiguous'", reliable);
 
     expect(reliable).toBeGreaterThanOrEqual(0);
+    expect(drain).toBeGreaterThan(reliable);
+    expect(ambiguous).toBeGreaterThan(drain);
+  });
+
+  it('the shared drain helper keeps claude-before-codex drain order', () => {
+    const fn = workerSource.indexOf('function drainReliableTerminalBeforeInterrupt');
+    expect(fn).toBeGreaterThanOrEqual(0);
+    const body = workerSource.slice(fn, fn + 700);
+    const reliable = body.indexOf('cliAdapter?.reliableTurnTerminal !== true');
+    const claudeDrain = body.indexOf('bridgeDrainAndMaybeEmit();', reliable);
+    const structuredDrain = body.indexOf('codexBridgeDrainAndMaybeEmit({ signalIdle: false });', claudeDrain);
+    expect(reliable).toBeGreaterThanOrEqual(0);
     expect(claudeDrain).toBeGreaterThan(reliable);
     expect(structuredDrain).toBeGreaterThan(claudeDrain);
-    expect(ambiguous).toBeGreaterThan(structuredDrain);
   });
 });

--- a/test/worker-restart-race.test.ts
+++ b/test/worker-restart-race.test.ts
@@ -50,34 +50,29 @@ describe('worker restart P1 — drain reliable terminal before ambiguous emit', 
   });
 });
 
-describe('worker restart P2 — merge guard preserves replacement-exit recovery', () => {
-  it('the merge guard arms pendingRestartAfterInFlight instead of silently dropping', () => {
+describe('worker restart P2 — merge guard + replacement-exit recovery (no spurious re-restart)', () => {
+  it('the merge guard plainly breaks — it does NOT arm any "restart requested" flag', () => {
     const branch = restartCaseBranch();
     const guard = branch.indexOf('if (cliRestartInProgress || tmuxRestartTimer)');
-    const arm = branch.indexOf('pendingRestartAfterInFlight = true', guard);
-    const brk = branch.indexOf('break;', arm);
+    const brk = branch.indexOf('break;', guard);
     expect(guard).toBeGreaterThanOrEqual(0);
-    // arm the follow-up flag before breaking out — otherwise a replacement that
-    // died during the in-flight window loses its daemon auto-restart.
-    expect(arm).toBeGreaterThan(guard);
-    expect(brk).toBeGreaterThan(arm);
+    expect(brk).toBeGreaterThan(guard);
+    // Codex-2 regression guard: a source-carrying flag would misread a healthy
+    // duplicate /restart as a crash and force a budget-burning re-restart.
+    expect(workerSource).not.toContain('pendingRestartAfterInFlight');
+    expect(workerSource).not.toContain('restartRequestedDuringInFlight');
   });
 
-  it('restartCliProcess consumes the flag at entry so only in-window requests count', () => {
-    const start = workerSource.indexOf('async function restartCliProcess');
-    const body = workerSource.slice(start, start + 1200);
-    expect(body).toContain('pendingRestartAfterInFlight = false');
-  });
-
-  it('the continuation feeds backend liveness + armed flag into decideRestartFollowup', () => {
+  it('the continuation feeds ONLY backend liveness + cwd into decideRestartFollowup', () => {
     const start = workerSource.indexOf('async function restartCliProcess');
     const end = workerSource.indexOf('// ─── HTTP', start);
     const body = workerSource.slice(start, end);
     const decide = body.indexOf('decideRestartFollowup({');
     expect(decide).toBeGreaterThan(0);
-    const call = body.slice(decide, decide + 320);
+    const call = body.slice(decide, decide + 260);
     expect(call).toContain('backendAlive: !!backend');
-    expect(call).toContain('restartRequestedDuringInFlight: pendingRestartAfterInFlight');
     expect(call).toContain('currentWorkingDir: lastInitConfig?.workingDir');
+    // recovery must NOT depend on any merged-request signal.
+    expect(call).not.toContain('restartRequestedDuringInFlight');
   });
 });

--- a/test/worker-restart-race.test.ts
+++ b/test/worker-restart-race.test.ts
@@ -1,0 +1,83 @@
+/**
+ * worker.ts is a process entrypoint (installs IPC/signal handlers on import),
+ * so — like worker-durable-expiry-order.test.ts — pin the exact wiring of
+ * PR #507's two restart-race fixes by asserting source structure. The pure
+ * decision they feed is executed in restart-followup-policy.test.ts; these
+ * assertions guard the ordering/guards that a refactor could silently break.
+ */
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const workerSource = readFileSync(new URL('../src/worker.ts', import.meta.url), 'utf8');
+
+function restartCaseBranch(): string {
+  const start = workerSource.indexOf("case 'restart': {");
+  const end = workerSource.indexOf("case 'expire_durable_turn':", start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return workerSource.slice(start, end);
+}
+
+describe('worker restart P1 — drain reliable terminal before ambiguous emit', () => {
+  it('the restart case drains BEFORE emitting ambiguous for an in-flight durable turn', () => {
+    const branch = restartCaseBranch();
+    const durableGuard = branch.indexOf('if (durableTurnInFlight)');
+    const drain = branch.indexOf('drainReliableTerminalBeforeInterrupt()', durableGuard);
+    const emit = branch.indexOf("emitTurnTerminal(currentBotmuxTurnId, 'ambiguous'", drain);
+    expect(durableGuard).toBeGreaterThanOrEqual(0);
+    expect(drain).toBeGreaterThan(durableGuard);
+    // drain must precede the ambiguous emit so an already-persisted completed
+    // claims the deduper first (else a just-completed turn is re-dispatchable).
+    expect(emit).toBeGreaterThan(drain);
+  });
+
+  it('the shared drain helper is gated on reliableTurnTerminal (matches onExit)', () => {
+    const fn = workerSource.indexOf('function drainReliableTerminalBeforeInterrupt');
+    expect(fn).toBeGreaterThanOrEqual(0);
+    const body = workerSource.slice(fn, fn + 600);
+    expect(body).toContain("cliAdapter?.reliableTurnTerminal !== true");
+    expect(body).toContain('bridgeDrainAndMaybeEmit()');
+    expect(body).toContain('codexBridgeDrainAndMaybeEmit');
+  });
+
+  it('onExit reuses the same shared drain helper (no divergent duplicate)', () => {
+    // Both the CLI onExit path and the restart IPC path must drain identically;
+    // the shared helper is the single source, so onExit calls it too.
+    const onExitAmbiguous = workerSource.indexOf("'ambiguous',\n        'cli_exit'");
+    expect(onExitAmbiguous).toBeGreaterThan(0);
+    const before = workerSource.slice(onExitAmbiguous - 400, onExitAmbiguous);
+    expect(before).toContain('drainReliableTerminalBeforeInterrupt()');
+  });
+});
+
+describe('worker restart P2 — merge guard preserves replacement-exit recovery', () => {
+  it('the merge guard arms pendingRestartAfterInFlight instead of silently dropping', () => {
+    const branch = restartCaseBranch();
+    const guard = branch.indexOf('if (cliRestartInProgress || tmuxRestartTimer)');
+    const arm = branch.indexOf('pendingRestartAfterInFlight = true', guard);
+    const brk = branch.indexOf('break;', arm);
+    expect(guard).toBeGreaterThanOrEqual(0);
+    // arm the follow-up flag before breaking out — otherwise a replacement that
+    // died during the in-flight window loses its daemon auto-restart.
+    expect(arm).toBeGreaterThan(guard);
+    expect(brk).toBeGreaterThan(arm);
+  });
+
+  it('restartCliProcess consumes the flag at entry so only in-window requests count', () => {
+    const start = workerSource.indexOf('async function restartCliProcess');
+    const body = workerSource.slice(start, start + 1200);
+    expect(body).toContain('pendingRestartAfterInFlight = false');
+  });
+
+  it('the continuation feeds backend liveness + armed flag into decideRestartFollowup', () => {
+    const start = workerSource.indexOf('async function restartCliProcess');
+    const end = workerSource.indexOf('// ─── HTTP', start);
+    const body = workerSource.slice(start, end);
+    const decide = body.indexOf('decideRestartFollowup({');
+    expect(decide).toBeGreaterThan(0);
+    const call = body.slice(decide, decide + 320);
+    expect(call).toContain('backendAlive: !!backend');
+    expect(call).toContain('restartRequestedDuringInFlight: pendingRestartAfterInFlight');
+    expect(call).toContain('currentWorkingDir: lastInitConfig?.workingDir');
+  });
+});

--- a/test/worker-restart-race.test.ts
+++ b/test/worker-restart-race.test.ts
@@ -19,15 +19,21 @@ function restartCaseBranch(): string {
 }
 
 describe('worker restart P1 — drain reliable terminal before ambiguous emit', () => {
-  it('the restart case drains BEFORE emitting ambiguous for an in-flight durable turn', () => {
+  it('the restart case delegates durable settle to settleDurableTurnForRestart with drain wired before emit', () => {
     const branch = restartCaseBranch();
-    const durableGuard = branch.indexOf('if (durableTurnInFlight)');
-    const drain = branch.indexOf('drainReliableTerminalBeforeInterrupt()', durableGuard);
-    const emit = branch.indexOf("emitTurnTerminal(currentBotmuxTurnId, 'ambiguous'", drain);
-    expect(durableGuard).toBeGreaterThanOrEqual(0);
-    expect(drain).toBeGreaterThan(durableGuard);
-    // drain must precede the ambiguous emit so an already-persisted completed
-    // claims the deduper first (else a just-completed turn is re-dispatchable).
+    const call = branch.indexOf('settleDurableTurnForRestart({');
+    expect(call).toBeGreaterThanOrEqual(0);
+    const deps = branch.slice(call, branch.indexOf('});', call) + 3);
+    // the settle orchestration (unit-tested in restart-followup-policy.test.ts)
+    // enforces drain → re-check → emit; here just pin that the restart case
+    // injects the right callbacks so a just-completed turn claims the deduper.
+    const drain = deps.indexOf('drainReliableTerminalBeforeInterrupt()');
+    const emit = deps.indexOf("emitTurnTerminal(currentBotmuxTurnId!, 'ambiguous'");
+    const isStill = deps.indexOf('isStillInFlight:');
+    expect(drain).toBeGreaterThanOrEqual(0);
+    expect(emit).toBeGreaterThan(0);
+    expect(isStill).toBeGreaterThan(0);
+    // the drain callback is declared before the emitAmbiguous callback in deps.
     expect(emit).toBeGreaterThan(drain);
   });
 


### PR DESCRIPTION
## 问题

Claude 家族 CLI 的系统上下文（CLAUDE.md、记忆路径/索引）是**开场按启动 cwd 注入一次的静态快照**，会话内 `/cd` 只改 cwd、不重刷这份注入（CLI 原生行为，botmux 无独立修复点）。当前角色切换走「向活 CLI 注入 `/cd`」（进程不重启），后果是切换后模型仍拿旧角色的记忆索引读写：读旧索引（新角色表现为"没记忆"）、按旧路径写记忆进错桶。实测验证：`/cd` 后的系统提示只报 cwd 变更，模型手里的记忆路径仍是开场那份冻结快照（甚至指向已不存在的目录）。

## 修法

「换角色外壳、留对话内核」：cd IPC 路由对活 worker 不再注入 `/cd`，改发带 `updateWorkingDir` 的 `restart` 消息；worker 先把 `lastInitConfig.workingDir` 收敛到新目录，再走既有 restart 机制（杀 CLI + `{...lastInitConfig, resume: true}` respawn）。`--resume` 回放对话历史保留上下文；新 cwd 冷启动让新角色的 CLAUDE.md/记忆索引在开场注入。respawn 与 `/restart` 同机制、适配器无关，`supportsSessionCwdMove` 能力位分流随之退场（字段保留，其它路径未动）。

worker 的 `restart` case 配套（对抗式复验驱动，含 Codex 三轮复审修正）：

- **restart 合并**：已有 restart 在飞（teardown 中 / tmux jitter 定时器未触发）时不叠加第二轮——叠加会 `clearTimeout` 吃掉首轮 teardown、把重启预算无故烧到 tier-2 强制 FRESH（丢上下文），非 tmux 路径还会双 spawn。合并处**只 break、不记任何来源 flag**（restart 消息不带可信来源，无法区分 replacement 崩溃的 auto-restart 与用户重复点击）。
- **replacement-exit recovery**：`cliRestartInProgress` 覆盖到续体 `spawnCli()` 之后的 `prepareCodexNativeTitleGeneration()`（Codex resume + native title ≈ 数秒）。新 CLI 若在此窗口退出，`onExit` 已**同步**把 `backend` 置 null；续体清 `cliRestartInProgress` 后以 `!backend`（地面真相）补跑一轮 restart 收敛，否则会话卡在 `backend=null` 需人工 `/restart`。健康的重复 restart（backend 非 null、cwd 未变）继续被合并、不误触发二次重启。
- **cwd-move respawn 不计入 `consecutiveInWorkerRestarts`**：用户主动迁移不是崩溃恢复；但 cwd 发散与 backend death 同时发生时，cwd 目标可优先收敛、`skipRestartBudget` 仅在 backend 存活时为 true——backend 已死则**计入**预算，不漏计真实 crash 证据。
- **复位在飞的 durable turn**：restart 杀掉在飞的 durable turn（VC 会议投递 / silent-schedule）时，先 drain 已落盘的可靠终态（让「刚好在 kill 前完成、watcher 未消费」的 turn 以 `completed` 抢占 worker deduper），**复检仍在飞才**主动发 `ambiguous`——CLI 中途被杀、副作用是否已发无法证明（故非 `cancelled`），交 daemon 重试策略即时对账，取代等 lease 过期的慢路径（该慢路径还会把刚 respawn 的新 CLI 二次 teardown）。若无 drain 直接 emit，会把已完成投递误标 `ambiguous` → 同 key 可重派 → 外部副作用执行两次（Codex 二审抓出，已修）。此结算与普通 `/restart` 同族问题一并覆盖。

顺带收掉 `inject_command.updateWorkingDir` 死通道：唯一发送方已不存在，留着是一个绕过 cd 路由角色库硬校验（`validateRoleLibraryPath`）的免检 cwd 移动口。`/slash` 路由测试已断言 `not.toHaveProperty('updateWorkingDir')` 把封口写进契约。

## 部署

respawn 后 resume 探的是新 cwd 桶，旧桶 transcript 由 **`syncClaudeResumeTargetToCwd`** 接住——它已在 master，`worker.ts` 在每次 resume respawn、adapter probe 之前把最新 `<sid>.jsonl` COPY 进新 cwd 的 project 目录，故 `--resume` 探得到、上下文不丢。**本 PR 可独立合并/部署，不硬依赖任何跨桶迁移专项 PR。**（后续 move-not-copy 加固等属独立优化，非本 PR 前置。）

## 测试

- **`src/core/restart-followup-policy.ts`（新增纯函数 + 执行级单测 12 例）**：
  - `decideRestartFollowup`：四格状态（cwd 同/异 × backend 活/死）的 follow-up 类型与 `skipRestartBudget` 语义——健康重复 restart → `none`（不烧预算）、cwd-move+live → skip、cwd-move+dead → 收敛但计预算、backend death → recovery 计预算、`workingDir` 未定不误判为迁移。
  - `settleDurableTurnForRestart`：P1 的 drain-before-ambiguous 编排（DI 注入 drain/isStillInFlight/emitAmbiguous/release，无需真实 JSONL）——drain 已结算 → 0 次 ambiguous；drain 后仍在飞 → 恰好 1 次；emit 未清 latch → 兜底 release；无 turnId → 跳过 emit 但仍 release。
- **`test/worker-restart-race.test.ts`（源码结构 pin）**：merge guard 纯 break（无来源 flag 残留）、续体只喂 `!!backend`+cwd 给 `decideRestartFollowup`、restart case 接线 `settleDurableTurnForRestart` 且 drain 先于 emit、drain helper `reliableTurnTerminal` 门控、onExit 复用同一 helper。
- **`test/worker-backend-exit-crash-order.test.ts`**：适配 drain 抽取（onExit 调共享 helper + helper 内 claude-before-codex 顺序）。
- **`test/ipc-cd-route.test.ts`** 全分支矩阵：`mode:respawn-resume`（restart 携带校验产出的 resolvedPath、repin 先于 send、不 kill、initConfig 同步）、send 抛错回落 cold-restart、无 worker 无条件 killWorker、codex/未知 cliId 一视同仁 respawn。
- `pnpm build` 通过；`pnpm test` **10571 passed**，10 failed 全为本机环境基线（`v3-distillation` 的 `ANTHROPIC_AUTH_TOKEN`/`CLAUDE_CODE_*TOKEN*`、`scheduler`+`schedule-card` 的 host 时区、`fs-policy-bwrap` 的 root DAC_OVERRIDE），与本改动无关文件、**零回归**。
- 真机最坏场景（真 claude 2.1.210）：Bash 工具飞行中 `kill -9`（transcript 尾悬空 `tool_use`）→ `syncClaudeResumeTargetToCwd` 跨桶 → 新目录 `--resume` 完整续回上下文。

## 已知项（不阻塞）

- gemini 等 `buildArgs` 不支持 resume 的适配器，respawn 实为全新会话（与旧 cold-restart 行为一致、无回归），但 `respawn-resume` 文案对其是过度承诺，后续可按适配器能力降级文案。
- durable turn 结算走「drain → 复检 → 主动 ambiguous」即时对账；真实 I/O 整链（写 JSONL → fs.watch → drain → dedupe）的端到端验证属 live 范畴，核心时序已由上述执行级单测覆盖。

## 复审轨迹

首审（Claude）→ Codex 复审抓出 2 条 restart 共用路径竞态（ambiguous 绕过 drain / 合并护栏吞 replacement auto-restart）→ 修复 → Codex 二审确认 P1，抓出 P2 修法引入的新 P1（无来源 flag 误报致健康进程烧预算丢 `--resume`）→ 改为只认 `!backend` + 预算不漏计 crash → Codex 三审代码通过 → 本次补 body 收尾 + P1 行为测试加分项。

🤖 Generated with [Riff](https://riff.dev)
