### PR TITLE
fix(skills): 修复本地 skills 根目录发现

### DIFF
--- a/src/services/skill-registry-store.ts
+++ b/src/services/skill-registry-store.ts
@@ -1,7 +1,7 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, realpathSync, rmSync, statSync } from 'node:fs';
 import { execFile, execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { withFileLock, withFileLockSync } from '../utils/file-lock.js';
@@ -206,12 +206,24 @@ function walkSkillDirs(parentDir: string, dir: string, out: DiscoveredSkillCandi
 }
 
 export function discoverLocalSkillCandidates(rootDir: string, opts: { fullDepth?: boolean } = {}): SkillSourceDiscovery {
-  const sourceDir = realpathSync(resolve(rootDir));
+  const requestedDir = resolve(rootDir);
+  const sourceDir = realpathSync(requestedDir);
   const candidates: DiscoveredSkillCandidate[] = [];
   const rootCandidate = candidateFromDir(sourceDir, sourceDir);
   if (rootCandidate) {
     candidates.push(rootCandidate);
     if (!opts.fullDepth) return { skills: dedupeAndSortCandidates(candidates) };
+  }
+  // Native CLI libraries are themselves named `skills` (for example
+  // ~/.claude/skills). When callers pass that library root directly, scan its
+  // immediate children instead of looking for a redundant skills/skills layer.
+  // Check both the requested and canonical paths so a symlink named `skills`
+  // still gets the expected behavior after realpath resolution.
+  if (basename(requestedDir) === 'skills' || basename(sourceDir) === 'skills') {
+    for (const child of listChildDirs(sourceDir)) {
+      const candidate = candidateFromDir(sourceDir, child);
+      if (candidate) candidates.push(candidate);
+    }
   }
   for (const relativeRoot of ['skills', '.agents/skills', '.botmux/skills']) {
     for (const child of listChildDirs(join(sourceDir, relativeRoot))) {

--- a/test/skill-registry-store.test.ts
+++ b/test/skill-registry-store.test.ts
@@ -4,7 +4,7 @@ import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { skillRegistryPath } from '../src/core/skills/registry-paths.js';
-import { installLocalSkill, installLocalSkillLinks, readSkillRegistry, removeInstalledSkill, removeInstalledSkills } from '../src/services/skill-registry-store.js';
+import { discoverLocalSkillCandidates, installLocalSkill, installLocalSkillLinks, readSkillRegistry, removeInstalledSkill, removeInstalledSkills } from '../src/services/skill-registry-store.js';
 
 function write(file: string, content: string): void {
   mkdirSync(dirname(file), { recursive: true });
@@ -25,6 +25,20 @@ describe('skill registry store', () => {
     vi.unstubAllEnvs();
     rmSync(home, { recursive: true, force: true });
     rmSync(src, { recursive: true, force: true });
+  });
+
+  it('discovers direct children when the supplied source is a native skills root', () => {
+    const skillsRoot = join(src, '.claude', 'skills');
+    write(join(skillsRoot, 'deploy', 'SKILL.md'), '---\nname: deploy\n---\n# Deploy');
+    write(join(skillsRoot, 'review', 'SKILL.md'), '---\nname: review\n---\n# Review');
+    write(join(skillsRoot, 'not-a-skill', 'README.md'), '# Ignore');
+
+    const discovery = discoverLocalSkillCandidates(skillsRoot);
+
+    expect(discovery.skills.map(skill => [skill.name, skill.path])).toEqual([
+      ['deploy', 'deploy'],
+      ['review', 'review'],
+    ]);
   });
 
   it('installs a local copy into the botmux store and records registry metadata', () => {


### PR DESCRIPTION
## 改了什么

- 当本地 Skill 安装源本身就是名为 `skills` 的目录时，扫描其直接子目录。
- 同时检查用户输入路径和 `realpath` 后路径的 basename，兼容名为 `skills` 的符号链接。
- 增加 `.claude/skills/<skill>/SKILL.md` 目录结构的回归测试，并确认非 Skill 子目录会被忽略。

## 为什么

Dashboard/CLI 导入本地 Skill 时，填写 `xxxx/.claude/skills` 无法发现其中的 Skill；填写 `xxxx/.claude` 或单个 Skill 目录则可以。原逻辑只会从输入目录继续查找 `skills/`、`.agents/skills/`、`.botmux/skills/`，等价于错误地寻找 `.claude/skills/skills/*`。

## 影响面评估

- **公共路径**：修改 `discoverLocalSkillCandidates`，会影响 Dashboard 本地导入、`botmux skills discover/install`，以及无显式 path 的 Git/GitHub 仓库扫描。
- **CLI**：不是 Claude 专用；所有原生 Skill 根目录（Claude/Codex/Gemini/Cursor 等）在直接传入末级 `skills` 目录时均可受益。
- **远程仓库**：仅当仓库 checkout 根目录本身名为 `skills` 时新增直接子目录扫描；原有标准 `repo/skills/<name>`、`.agents/skills`、`.botmux/skills` 行为不变，候选按路径去重。
- **后端/会话类型/平台**：不涉及 PTY/Tmux、会话恢复、sandbox 或 IM 路由；路径判断使用 Node `basename`，并保留现有跨平台路径解析。

## 实际验证

- `pnpm build`：通过。
- `pnpm exec vitest run --project unit test/skill-registry-store.test.ts test/dashboard-skill-install-request.test.ts test/skill-git-install.test.ts`：3 个文件、29 个测试全部通过。
- `pnpm test`：共 581 个文件、9291 个测试；9285 通过，6 个失败。失败集中在既有 Linux 进程发现/时序测试：
  - `test/session-discovery.smoke.test.ts`（当前环境 comm 返回 `MainThread`）
  - `test/v3-worker-fence.test.ts`（进程发现结果 `ambiguous`）
  - `test/v3-cancel-runtime.test.ts`（2 个 30 秒超时）
- 单独复跑相关 Skill 测试仍为 29/29 通过；单独复跑前两个无关失败测试仍稳定复现，确认与本 PR 改动无关。
