### PR TITLE
fix(herdr): 统一原生终端流与 Web 历史

### DIFF
--- a/docs/plans/botmux_herdr_web_terminal_resize.md
+++ b/docs/plans/botmux_herdr_web_terminal_resize.md
@@ -81,7 +81,7 @@
 
 - [ ] 执行 `pnpm switch:here && botmux restart`，确认全局 shim 与 live daemon 都来自当前 checkout。
 - [ ] 在无浏览器 viewer 时，用一次短命 direct attach 把测试会话缩回已知小尺寸，建立可复现的验收前置状态。
-- [ ] 浏览器打开 `http://10.92.191.86:8802/s/a9edf38b-55c1-4056-bcc5-4a307e17672b`。
+- [ ] 浏览器打开测试环境的 Web Terminal URL（不要在文档中记录内网地址或真实 session ID）。
 - [ ] 机器判定 DOM：`#terminal`、`.xterm`、`.xterm-screen` 的 bounding box 各覆盖 viewport 宽高至少 95%；banner 为只读，状态为 connected。
 - [ ] 机器判定尺寸：读取页面主 world 的 `term.cols/rows`，必须与 Herdr server 最新 `TerminalAnsi` attach/resize 的 cols/rows 完全一致。
 - [ ] 机器判定截图：以非页面背景像素计算 OpenCode 内容 bounding box，宽度至少占 viewport 90%（修复前现场约 33%）；`agent read` 行宽仅作辅助证据。

--- a/src/adapters/backend/herdr-backend.ts
+++ b/src/adapters/backend/herdr-backend.ts
@@ -1,6 +1,8 @@
-import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
+import { execFile, execFileSync, spawn, type ChildProcess } from 'node:child_process';
 import * as pty from 'node-pty';
 import xtermHeadless from '@xterm/headless';
+import { StringDecoder } from 'node:string_decoder';
+import { z } from 'zod';
 import type { BackendType, SessionBackend, SpawnOpts, SessionProbe } from './types.js';
 import { logger } from '../../utils/logger.js';
 
@@ -14,29 +16,36 @@ export interface HerdrExternalTarget {
   paneId?: string;
 }
 
-// Slow output-streaming poll. We deliberately avoid the original 250ms tick:
-// herdr exposes `wait agent-status`, which we use to fire an immediate read on
-// every idle/working/blocked transition. The 500ms timer is a fallback for the
-// in-the-middle-of-working case where output streams without a status flip.
-const POLL_INTERVAL_MS = 500;
-const READ_LINES = 10_000;
+const MIN_STREAMING_VERSION = [0, 7, 2] as const;
+const OBSERVER_RESTART_DELAY_MS = 500;
+const OBSERVER_RESTART_MAX_DELAY_MS = 5000;
+const OBSERVER_DEGRADED_AFTER_FAILURES = 3;
 const MAX_AGENT_PROBE_FAILURES = 3;
+const MAX_OBSERVER_BACKOFF_EXPONENT = 8;
+const MAX_PENDING_DATA_CHARS = 1_000_000;
+// Snapshot reads are now only used on explicit capture calls. Live output uses
+// `terminal session observe` and never scans this fixed window.
+const READ_LINES = 10_000;
 // Inter-attempt sleep while waiting for `herdr server` to come up.
 // Synchronous (execFileSync 'sleep') because spawn() must stay sync.
 const SERVER_BOOT_POLL_MS = 100;
 const SERVER_BOOT_DEADLINE_MS = 5000;
-// `herdr wait agent-status` blocks until a transition; we cap it so a
-// long-stuck agent still re-arms the watcher and we never accumulate an
-// indefinitely-orphaned subprocess on process teardown.
-const STATUS_WAIT_TIMEOUT_MS = 30_000;
-// States we treat as "result settled — flush the pane now". `done` and
-// `blocked` are the user-facing signals (turn finished / input requested);
-// `idle` is the degraded form of `done` after the herdr UI marks it seen,
-// included because we read via the socket API and herdr may not register
-// our reads as "seeing" → without it the watcher could miss legitimate
-// turn completions. `working` is intentionally absent: we don't need an
-// event for "started streaming", the slow timer covers that path.
-const SETTLED_STATUSES = ['done', 'blocked', 'idle'] as const;
+
+const TERMINAL_STREAM_MESSAGE_SCHEMA = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('terminal.frame'),
+    seq: z.number().int().nonnegative(),
+    full: z.boolean(),
+    encoding: z.literal('ansi'),
+    width: z.number().int().positive(),
+    height: z.number().int().positive(),
+    bytes: z.string(),
+  }),
+  z.object({
+    type: z.literal('terminal.closed'),
+    reason: z.string().optional(),
+  }),
+]);
 
 type JsonCommandResult = { ok: true; value: any | undefined } | { ok: false };
 
@@ -48,6 +57,15 @@ export interface HerdrWebTerminalSize {
 export interface HerdrWebTerminalCursor {
   col: number;
   row: number;
+}
+
+/** One native Herdr terminal frame. A full frame replaces the current grid. */
+export interface HerdrTerminalFrame {
+  data: string;
+  full: boolean;
+  seq: number;
+  width: number;
+  height: number;
 }
 
 function tryJsonCommand(args: string[], opts?: { timeout?: number; input?: string; env?: NodeJS.ProcessEnv }): JsonCommandResult {
@@ -114,30 +132,31 @@ function extractReadText(raw: any): string {
   return typeof raw?.result?.read?.text === 'string' ? raw.result.read.text : '';
 }
 
-function longestSuffixPrefix(previous: string, next: string): number {
-  const max = Math.min(previous.length, next.length);
-  for (let len = max; len > 0; len--) {
-    if (previous.endsWith(next.slice(0, len))) return len;
-  }
-  return 0;
-}
 
 export class HerdrBackend implements SessionBackend {
   private serverProcess: ChildProcess | null = null;
-  private pollTimer: NodeJS.Timeout | null = null;
-  private statusWaitProcesses: ChildProcess[] = [];
+  private observerProcess: ChildProcess | null = null;
+  private observerRestartTimer: NodeJS.Timeout | null = null;
+  private observerBuffer = '';
+  private streamDecoder = new StringDecoder('utf8');
+  private lastFrameSeq = -1;
+  private observerSawFrame = false;
+  private observerFailures = 0;
+  private agentProbeFailures = 0;
+  private observerProbeGeneration = 0;
+  private pendingFullFrame = false;
+  private pendingData = '';
+  private pendingFrames: HerdrTerminalFrame[] = [];
   private readonly dataCbs: Array<(d: string) => void> = [];
-  private readonly snapshotCbs: Array<(snapshot: string) => void> = [];
+  private readonly frameCbs: Array<(frame: HerdrTerminalFrame) => void> = [];
   private readonly webCursorCbs: Array<(cursor: HerdrWebTerminalCursor) => void> = [];
   private readonly exitCbs: Array<(code: number | null, signal: string | null) => void> = [];
   private readonly agentName = 'botmux';
   private paneId: string | undefined;
-  private lastText = '';
   private exited = false;
   private started = false;
   private cols = 200;
   private rows = 50;
-  private agentProbeFailures = 0;
   private webAttach: pty.IPty | null = null;
   private webCursorTerminal: InstanceType<typeof Terminal> | null = null;
   private webCursor: HerdrWebTerminalCursor | null = null;
@@ -161,7 +180,18 @@ export class HerdrBackend implements SessionBackend {
 
   static isAvailable(): boolean {
     try {
-      execFileSync('herdr', ['--version'], { stdio: 'ignore', timeout: 3000 });
+      const output = execFileSync('herdr', ['--version'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 3000,
+      });
+      const match = /^herdr\s+(\d+)\.(\d+)\.(\d+)/i.exec(output.trim());
+      if (!match) return false;
+      const installed = [Number(match[1]), Number(match[2]), Number(match[3])] as const;
+      for (let index = 0; index < MIN_STREAMING_VERSION.length; index++) {
+        if (installed[index] > MIN_STREAMING_VERSION[index]) return true;
+        if (installed[index] < MIN_STREAMING_VERSION[index]) return false;
+      }
       return true;
     } catch {
       return false;
@@ -270,16 +300,7 @@ export class HerdrBackend implements SessionBackend {
     }
 
     this.started = true;
-    // Baseline policy mirrors the tmux/PTY backends:
-    //   - Fresh spawn: lastText='' so the first poll emits everything from
-    //     t=0 (matches the PTY contract — listeners see all output even if
-    //     the agent echoed before the first read).
-    //   - Re-attach / external adopt: snapshot the current screen so we only
-    //     stream new deltas. Worker.ts explicitly seeds the initial screen
-    //     via captureCurrentScreen() in those paths.
-    this.lastText = (this.isReattach || this.opts.externalTarget) ? this.readRecentAnsi() : '';
-    this.startPolling();
-    this.startStatusWatcher();
+    this.startObserver();
   }
 
   write(data: string): void {
@@ -303,8 +324,12 @@ export class HerdrBackend implements SessionBackend {
   }
 
   resize(cols: number, rows: number): void {
+    if (this.cols === cols && this.rows === rows) return;
     this.cols = cols;
     this.rows = rows;
+    if (!this.started || this.exited) return;
+    this.stopObserver();
+    this.startObserver();
   }
 
   acquireWebTerminal(viewer: object): HerdrWebTerminalSize | null {
@@ -326,9 +351,11 @@ export class HerdrBackend implements SessionBackend {
     } else if (!this.startWebAttach(size)) {
       return null;
     }
-    this.cols = cols;
-    this.rows = rows;
     this.webSize = size;
+    // The managed attach owns the real agent PTY size. Resize it first so the
+    // CLI receives SIGWINCH, then restart the observer at the same grid and
+    // wait for its authoritative full rebaseline.
+    this.resize(cols, rows);
     return size;
   }
 
@@ -353,11 +380,22 @@ export class HerdrBackend implements SessionBackend {
 
   onData(cb: (data: string) => void): void {
     this.dataCbs.push(cb);
+    if (!this.pendingData || this.exited) return;
+    try { cb(this.pendingData); } catch { /* listener crash must not kill the observer */ }
   }
 
-  /** Full interpreted terminal frame for snapshot-aware web history merging. */
-  onSnapshot(cb: (snapshot: string) => void): void {
-    this.snapshotCbs.push(cb);
+  /** Structured native stream; callers must replace rather than append full frames. */
+  onTerminalFrame(cb: (frame: HerdrTerminalFrame) => void): void {
+    this.frameCbs.push(cb);
+    if (this.pendingFrames.length > 0 && !this.exited) {
+      for (const frame of this.pendingFrames) {
+        try { cb(frame); } catch { /* listener crash must not kill the observer */ }
+      }
+    }
+    // A structured consumer has received the same initial frames and will keep
+    // receiving all future data. Do not retain a duplicate compatibility
+    // stream forever when no onData listener exists (the normal worker path).
+    if (this.dataCbs.length === 0) this.pendingData = '';
   }
 
   /** Cursor coordinates from the real managed attach stream (0-based). */
@@ -377,8 +415,9 @@ export class HerdrBackend implements SessionBackend {
     if (this.exited) return;
     this.exited = true;
     this.resetWebTerminal();
-    this.stopPolling();
-    this.stopStatusWatcher();
+    this.stopObserver();
+    this.pendingData = '';
+    this.pendingFrames = [];
     this.serverProcess = null;
   }
 
@@ -403,6 +442,31 @@ export class HerdrBackend implements SessionBackend {
 
   captureCurrentScreen(): string {
     return this.readRecentAnsi();
+  }
+
+  captureCurrentScreenAsync(): Promise<string> {
+    const target = this.paneId ?? this.agentName;
+    return new Promise(resolve => {
+      execFile(
+        'herdr',
+        herdrSessionArgs(this.sessionName, [
+          'agent', 'read', target,
+          '--source', 'recent', '--lines', String(READ_LINES), '--format', 'ansi',
+        ]),
+        { encoding: 'utf8', timeout: 5000, maxBuffer: 16 * 1024 * 1024 },
+        (error, stdout) => {
+          if (error) {
+            resolve('');
+            return;
+          }
+          try {
+            resolve(extractReadText(stdout.trim() ? JSON.parse(stdout) : undefined));
+          } catch {
+            resolve('');
+          }
+        },
+      );
+    });
   }
 
   captureViewport(): string {
@@ -525,9 +589,23 @@ export class HerdrBackend implements SessionBackend {
     return extractAgent(raw);
   }
 
-  private listAgents(): any[] | null {
-    const raw = tryJsonCommand(herdrSessionArgs(this.sessionName, ['agent', 'list']), { timeout: 5000 });
-    return raw.ok ? extractAgents(raw.value) : null;
+  private listAgentsAsync(cb: (agents: any[] | null) => void): void {
+    execFile(
+      'herdr',
+      herdrSessionArgs(this.sessionName, ['agent', 'list']),
+      { encoding: 'utf8', timeout: 5000, maxBuffer: 16 * 1024 * 1024 },
+      (error, stdout) => {
+        if (error) {
+          cb(null);
+          return;
+        }
+        try {
+          cb(extractAgents(stdout.trim() ? JSON.parse(stdout) : undefined));
+        } catch {
+          cb(null);
+        }
+      },
+    );
   }
 
   // NOTE: we use `agent read` (not `pane read`) for capture. Both accept the
@@ -552,175 +630,196 @@ export class HerdrBackend implements SessionBackend {
     ));
   }
 
-  private startPolling(): void {
-    this.stopPolling();
-    this.pollTimer = setInterval(() => this.poll(), POLL_INTERVAL_MS);
-    this.pollTimer.unref?.();
-  }
-
-  private stopPolling(): void {
-    if (this.pollTimer) clearInterval(this.pollTimer);
-    this.pollTimer = null;
-  }
-
-  private poll(): void {
-    if (this.exited) return;
-    const agents = this.listAgents();
-    if (agents === null) {
-      this.agentProbeFailures++;
-      if (this.agentProbeFailures < MAX_AGENT_PROBE_FAILURES) return;
-      this.handleExit(0, null);
-      return;
-    }
-    this.agentProbeFailures = 0;
-    // Exit detection. Verified against herdr v0.6.6: when the CLI process exits,
-    // herdr DROPS the agent row from `agent list` (it does NOT keep a
-    // running:false tombstone). So the primary signal is "our agent is no
-    // longer in the list". We also treat an explicit terminal marker as exited
-    // (agentRowExited) to stay robust if a future herdr keeps a tombstone row —
-    // otherwise name-presence alone would never report the exit and the worker
-    // would never emit `claude_exit`, hanging the session.
-    const matchingAgent = agents.find(agent => agent?.name === this.agentName || agent?.pane_id === this.paneId);
-    const agentExited = matchingAgent ? agentRowExited(matchingAgent) : true;
-    if (this.started && agentExited) {
-      const exitCode = typeof matchingAgent?.exit_code === 'number' ? matchingAgent.exit_code : 0;
-      this.handleExit(exitCode, null);
-      return;
-    }
-
-    this.readAndEmitDelta();
-  }
-
-  /** Read herdr pane recent output and emit the delta vs. last snapshot. */
-  private readAndEmitDelta(): void {
-    if (this.exited) return;
-    const next = this.readRecentAnsi();
-    if (!next || next === this.lastText) return;
-    for (const cb of this.snapshotCbs) {
-      try { cb(next); } catch { /* listener crash shouldn't kill polling */ }
-    }
-    let delta = '';
-    if (next.startsWith(this.lastText)) {
-      delta = next.slice(this.lastText.length);
-    } else if (this.lastText.endsWith(next)) {
-      this.lastText = next;
-      return;
-    } else {
-      const overlap = longestSuffixPrefix(this.lastText, next);
-      delta = overlap > 0 ? next.slice(overlap) : next;
-    }
-    this.lastText = next;
-    if (!delta) return;
-    for (const cb of this.dataCbs) {
-      try { cb(delta); } catch { /* listener crash shouldn't kill polling */ }
-    }
-  }
-
-  /**
-   * Spawn one `herdr wait agent-status` child per "result settled" status
-   * (done / blocked / idle). The first to fire wins → we read+emit, then
-   * tear down the losers and re-arm a fresh cohort. Parallel watchers are
-   * needed because the herdr CLI only accepts one --status at a time, and
-   * we genuinely care about all three transitions: `done` is "turn finished
-   * with output", `blocked` is "agent wants user input", `idle` is the
-   * degraded form of done after herdr's UI marks it seen.
-   */
-  private startStatusWatcher(): void {
+  private startObserver(): void {
     if (this.exited) return;
     const paneTarget = this.paneId ?? this.agentName;
     if (!paneTarget) return;
-    this.stopStatusWatcher();
-    const cohort: ChildProcess[] = [];
-    const armedAt = Date.now();
-    for (const status of SETTLED_STATUSES) {
-      const child = spawn('herdr', [
-        '--session', this.sessionName,
-        'wait', 'agent-status', paneTarget,
-        '--status', status,
-        '--timeout', String(STATUS_WAIT_TIMEOUT_MS),
-      ], { stdio: ['ignore', 'ignore', 'ignore'] });
-      cohort.push(child);
+    clearTimeout(this.observerRestartTimer ?? undefined);
+    this.observerRestartTimer = null;
+    this.observerBuffer = '';
+    this.streamDecoder = new StringDecoder('utf8');
+    this.lastFrameSeq = -1;
+    this.observerSawFrame = false;
+    this.pendingFullFrame = false;
 
-      child.on('exit', (code) => {
-        // Only the first child to finish (across the cohort) drives the
-        // re-arm cycle; later finishers in the same cohort are dropped.
-        if (!this.statusWaitProcesses.includes(child)) return;
-        const wasFirstSettle = this.statusWaitProcesses === cohort;
-        // Drop this child from the active cohort.
-        this.statusWaitProcesses = this.statusWaitProcesses.filter(c => c !== child);
-        if (!wasFirstSettle || this.exited) return;
-        // First exit in this cohort — tear down siblings, then read+re-arm.
-        this.stopStatusWatcher();
-        this.readAndEmitDelta();
+    const child = spawn('herdr', [
+      '--session', this.sessionName,
+      'terminal', 'session', 'observe', paneTarget,
+      '--cols', String(this.cols),
+      '--rows', String(this.rows),
+    ], { stdio: ['ignore', 'pipe', 'ignore'] });
+    this.observerProcess = child;
 
-        // Storm guard. code 0 = the watched status was genuinely reached (a
-        // real transition, which can legitimately happen instantly) → re-arm
-        // immediately, the normal hot path. The danger is a NON-ZERO instant
-        // return: when the agent's pane has gone away (the CLI exited), `herdr
-        // wait agent-status` returns code 1 within MILLISECONDS rather than
-        // after the 30s timeout. The old code re-armed on every non-0 code
-        // synchronously, so a dead pane spun a tight spawn loop (thousands of
-        // `herdr wait` children/sec) that starved the 500ms poll timer → the
-        // session never reported its exit and hung. So for a non-zero code we
-        // first distinguish "real long timeout" (child lived a meaningful
-        // fraction of the window — agent still working, re-arm normally) from
-        // "instant return" (pane likely gone — check liveness; only re-arm via
-        // a deferred timer, never synchronously, so poll() can run and we can't
-        // spin). Verified on v0.6.6: the exited agent's row disappears from
-        // `agent list`.
-        if (code !== 0) {
-          const elapsed = Date.now() - armedAt;
-          const returnedInstantly = elapsed < STATUS_WAIT_TIMEOUT_MS / 2;
-          if (returnedInstantly) {
-            const agents = this.listAgents();
-            if (agents !== null) {
-              const matching = agents.find(a => a?.pane_id === this.paneId || a?.name === this.agentName);
-              const exited = matching ? agentRowExited(matching) : true;
-              if (exited) {
-                const exitCode = typeof matching?.exit_code === 'number' ? matching.exit_code : 0;
-                this.handleExit(exitCode, null);
-                return;
-              }
-            }
-            // Agent still alive but the wait returned instantly (transient
-            // herdr hiccup). Re-arm on a later tick, never synchronously, so we
-            // can't spin: the deferred timer yields the loop to poll(). unref
-            // so we never hold the event loop open.
-            if (this.exited) return;
-            const t = setTimeout(() => { if (!this.exited) this.startStatusWatcher(); }, POLL_INTERVAL_MS);
-            t.unref?.();
-            return;
-          }
-        }
-        // Normal path: a genuine status transition (code 0) or a real
-        // long-timeout (code 1 after ~30s of working) — re-arm immediately.
-        this.startStatusWatcher();
-      });
-      child.on('error', () => {
-        // `herdr` missing or unspawnable: drop from cohort. Timer-based poll
-        // still acts as the fallback signal.
-        this.statusWaitProcesses = this.statusWaitProcesses.filter(c => c !== child);
-      });
-    }
-    this.statusWaitProcesses = cohort;
+    child.stdout?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => this.consumeObserverChunk(child, chunk));
+    child.on('error', error => {
+      logger.warn(`[herdr:${this.sessionName}] terminal observer failed: ${error.message}`);
+      this.handleObserverDisconnect(child);
+    });
+    child.on('exit', (code, signal) => {
+      if (this.observerProcess !== child || this.exited) return;
+      logger.debug(`[herdr:${this.sessionName}] terminal observer exited code=${code} signal=${signal}`);
+      this.handleObserverDisconnect(child);
+    });
   }
 
-  private stopStatusWatcher(): void {
-    const active = this.statusWaitProcesses;
-    this.statusWaitProcesses = [];
-    for (const child of active) {
-      try { child.kill('SIGTERM'); } catch { /* already gone */ }
+  private consumeObserverChunk(child: ChildProcess, chunk: string): void {
+    if (this.observerProcess !== child || this.exited) return;
+    this.observerBuffer += chunk;
+    let newline = this.observerBuffer.indexOf('\n');
+    while (newline >= 0) {
+      const line = this.observerBuffer.slice(0, newline).trim();
+      this.observerBuffer = this.observerBuffer.slice(newline + 1);
+      if (line) this.consumeObserverLine(child, line);
+      if (this.observerProcess !== child || this.exited) return;
+      newline = this.observerBuffer.indexOf('\n');
     }
+  }
+
+  private consumeObserverLine(child: ChildProcess, line: string): void {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(line);
+    } catch (error) {
+      logger.warn(`[herdr:${this.sessionName}] malformed terminal stream JSON: ${error instanceof Error ? error.message : String(error)}`);
+      return;
+    }
+    const parsed = TERMINAL_STREAM_MESSAGE_SCHEMA.safeParse(raw);
+    if (!parsed.success) {
+      logger.warn(`[herdr:${this.sessionName}] unsupported terminal stream record: ${parsed.error.message}`);
+      return;
+    }
+    const message = parsed.data;
+    if (message.type === 'terminal.closed') {
+      logger.debug(`[herdr:${this.sessionName}] terminal stream closed: ${message.reason ?? 'no reason'}`);
+      this.handleObserverDisconnect(child);
+      return;
+    }
+    if (message.seq <= this.lastFrameSeq) return;
+    this.lastFrameSeq = message.seq;
+    const bytes = Buffer.from(message.bytes, 'base64');
+    if (message.full) {
+      this.streamDecoder = new StringDecoder('utf8');
+      this.pendingFullFrame = true;
+    }
+    const data = this.streamDecoder.write(bytes);
+    if (!data) return;
+    const frame: HerdrTerminalFrame = {
+      data,
+      full: this.pendingFullFrame,
+      seq: message.seq,
+      width: message.width,
+      height: message.height,
+    };
+    this.pendingFullFrame = false;
+    this.observerSawFrame = true;
+    this.observerFailures = 0;
+    this.agentProbeFailures = 0;
+
+    if (this.frameCbs.length === 0) {
+      if (frame.full) this.pendingFrames = [frame];
+      else this.pendingFrames.push(frame);
+      // Listener registration is normally immediate after spawn. Keep a hard
+      // bound anyway so a missing consumer cannot retain an unbounded stream.
+      if (this.pendingFrames.length > 1024) this.pendingFrames.splice(0, this.pendingFrames.length - 1024);
+    } else {
+      this.pendingFrames = [];
+      for (const cb of this.frameCbs) {
+        try { cb(frame); } catch { /* listener crash must not kill the observer */ }
+      }
+    }
+
+    // Compatibility surface for direct backend consumers. Worker uses the
+    // structured API above so it can replace full frames instead of appending.
+    if (this.dataCbs.length === 0) {
+      if (this.frameCbs.length > 0) {
+        this.pendingData = '';
+        return;
+      }
+      this.pendingData = frame.full ? data : this.pendingData + data;
+      if (this.pendingData.length > MAX_PENDING_DATA_CHARS) {
+        this.pendingData = this.pendingData.slice(-MAX_PENDING_DATA_CHARS);
+      }
+      return;
+    }
+    this.pendingData = '';
+    for (const cb of this.dataCbs) {
+      try { cb(data); } catch { /* listener crash must not kill the observer */ }
+    }
+  }
+
+  private handleObserverDisconnect(child: ChildProcess): void {
+    if (this.observerProcess !== child || this.exited) return;
+    this.observerProcess = null;
+    try { child.kill('SIGTERM'); } catch { /* already gone */ }
+    const sawFrame = this.observerSawFrame;
+    const generation = ++this.observerProbeGeneration;
+    this.listAgentsAsync(agents => {
+      if (this.exited || generation !== this.observerProbeGeneration) return;
+      if (agents !== null) {
+        this.agentProbeFailures = 0;
+        const matching = agents.find(agent => agent?.name === this.agentName || agent?.pane_id === this.paneId);
+        if (!matching || agentRowExited(matching)) {
+          const exitCode = typeof matching?.exit_code === 'number' ? matching.exit_code : 0;
+          this.handleExit(exitCode, null);
+          return;
+        }
+      } else {
+        this.agentProbeFailures++;
+        if (this.agentProbeFailures >= MAX_AGENT_PROBE_FAILURES) {
+          logger.error(
+            `[herdr:${this.sessionName}] cannot verify agent after ${this.agentProbeFailures} attempts`,
+          );
+          this.handleExit(1, null);
+          return;
+        }
+      }
+
+      // A live agent plus an observer that repeatedly exits before producing
+      // one valid frame can mean another client owns Herdr's single observer
+      // slot. The CLI is still alive, so degrade to a capped retry instead of
+      // fabricating an exit. Only a missing agent or consecutive probe failure
+      // may end the backend.
+      this.observerFailures = sawFrame
+        ? 0
+        : Math.min(this.observerFailures + 1, MAX_OBSERVER_BACKOFF_EXPONENT);
+      if (this.observerFailures === OBSERVER_DEGRADED_AFTER_FAILURES) {
+        logger.error(
+          `[herdr:${this.sessionName}] terminal observer unavailable after ${this.observerFailures} attempts; agent is alive, retrying`,
+        );
+      }
+
+      const delay = Math.min(
+        OBSERVER_RESTART_MAX_DELAY_MS,
+        OBSERVER_RESTART_DELAY_MS * (2 ** Math.max(0, this.observerFailures - 1)),
+      );
+      this.observerRestartTimer = setTimeout(() => {
+        this.observerRestartTimer = null;
+        if (!this.exited) this.startObserver();
+      }, delay);
+      this.observerRestartTimer.unref?.();
+    });
+  }
+
+  private stopObserver(): void {
+    this.observerProbeGeneration++;
+    clearTimeout(this.observerRestartTimer ?? undefined);
+    this.observerRestartTimer = null;
+    const child = this.observerProcess;
+    this.observerProcess = null;
+    if (!child) return;
+    try { child.kill('SIGTERM'); } catch { /* already gone */ }
   }
 
   private handleExit(code: number | null, signal: string | null): void {
     if (this.exited) return;
     this.exited = true;
     this.resetWebTerminal();
-    this.stopPolling();
-    this.stopStatusWatcher();
+    this.stopObserver();
+    this.pendingData = '';
+    this.pendingFrames = [];
     for (const cb of this.exitCbs) {
-      try { cb(code, signal); } catch { /* listener crash shouldn't kill teardown */ }
+      try { cb(code, signal); } catch { /* listener crash must not kill teardown */ }
     }
   }
 }

--- a/src/utils/herdr-web-history.ts
+++ b/src/utils/herdr-web-history.ts
@@ -24,49 +24,73 @@ function lineKey(line: string): string {
   return line.replace(ANSI_OSC_RE, '').replace(ANSI_CSI_RE, '').trimEnd();
 }
 
-function limitHistory(lines: string[], maxChars: number): { lines: string[]; removedLines: number } {
+function limitHistory(
+  lines: string[],
+  maxChars: number,
+  protectedHead = 0,
+): { lines: string[]; removedLines: number } {
   if (!Number.isFinite(maxChars)) return { lines, removedLines: 0 };
   let chars = lines.reduce((total, line) => total + line.length, Math.max(0, lines.length - 1) * 2);
   let removedLines = 0;
-  while (removedLines < lines.length - 1 && chars > maxChars) {
-    chars -= lines[removedLines].length + 2;
+  while (protectedHead + removedLines < lines.length - 1 && chars > maxChars) {
+    chars -= lines[protectedHead + removedLines].length + 2;
     removedLines++;
   }
-  return { lines: removedLines > 0 ? lines.slice(removedLines) : lines, removedLines };
+  if (removedLines === 0) return { lines, removedLines };
+  return {
+    lines: [...lines.slice(0, protectedHead), ...lines.slice(protectedHead + removedLines)],
+    removedLines,
+  };
 }
 
-function longestCommonBlock(previous: string[], next: string[]): {
-  length: number;
-  previousStart: number;
-  nextStart: number;
-} {
+function commonFixedEdges(previous: string[], next: string[]): { head: number; tail: number } {
   const previousKeys = previous.map(lineKey);
   const nextKeys = next.map(lineKey);
-  let prior = new Array<number>(next.length + 1).fill(0);
-  let bestLength = 0;
-  let bestPreviousEnd = 0;
-  let bestNextEnd = 0;
+  const max = Math.min(previous.length, next.length);
+  let head = 0;
+  while (head < max && previousKeys[head] && previousKeys[head] === nextKeys[head]) head++;
+  let tail = 0;
+  while (
+    tail < max - head
+    && previousKeys[previous.length - 1 - tail]
+    && previousKeys[previous.length - 1 - tail] === nextKeys[next.length - 1 - tail]
+  ) tail++;
+  return { head, tail };
+}
 
-  for (let i = 1; i <= previous.length; i++) {
-    const current = new Array<number>(next.length + 1).fill(0);
-    for (let j = 1; j <= next.length; j++) {
-      if (previousKeys[i - 1] && previousKeys[i - 1] === nextKeys[j - 1]) {
-        current[j] = prior[j - 1] + 1;
-        if (current[j] > bestLength) {
-          bestLength = current[j];
-          bestPreviousEnd = i;
-          bestNextEnd = j;
-        }
-      }
-    }
-    prior = current;
+/**
+ * Find the longest prefix of the previous scrolling region inside the next
+ * region. KMP keeps this linear even for 10k-line snapshots and repeated rows.
+ */
+function findPreviousPrefix(previous: string[], next: string[]): {
+  length: number;
+  nextStart: number;
+} {
+  const pattern = previous.map(lineKey);
+  const text = next.map(lineKey);
+  if (pattern.length === 0 || text.length === 0) return { length: 0, nextStart: 0 };
+  const prefix = new Array<number>(pattern.length).fill(0);
+  for (let i = 1; i < pattern.length; i++) {
+    let length = prefix[i - 1];
+    while (length > 0 && pattern[i] !== pattern[length]) length = prefix[length - 1];
+    if (pattern[i] && pattern[i] === pattern[length]) length++;
+    prefix[i] = length;
   }
 
-  return {
-    length: bestLength,
-    previousStart: bestPreviousEnd - bestLength,
-    nextStart: bestNextEnd - bestLength,
-  };
+  let matched = 0;
+  let bestLength = 0;
+  let bestStart = 0;
+  for (let i = 0; i < text.length; i++) {
+    while (matched > 0 && text[i] !== pattern[matched]) matched = prefix[matched - 1];
+    if (text[i] && text[i] === pattern[matched]) matched++;
+    const start = i - matched + 1;
+    if (start > 0 && matched > bestLength) {
+      bestLength = matched;
+      bestStart = start;
+    }
+    if (matched === pattern.length) matched = prefix[matched - 1];
+  }
+  return { length: bestLength, nextStart: bestStart };
 }
 
 export function mergeHerdrWebSnapshot(
@@ -82,13 +106,21 @@ export function mergeHerdrWebSnapshot(
   }
 
   if (direction === 'up') {
-    const overlap = longestCommonBlock(state.frame, frame);
-    if (overlap.length >= 2 && overlap.previousStart === 0 && overlap.nextStart > 0) {
-      const prefix = frame.slice(0, overlap.nextStart);
-      const limited = limitHistory([...prefix, ...state.history], maxChars);
+    const fixed = commonFixedEdges(state.frame, frame);
+    const previousBody = state.frame.slice(fixed.head, state.frame.length - fixed.tail);
+    const nextBody = frame.slice(fixed.head, frame.length - fixed.tail);
+    const overlap = findPreviousPrefix(previousBody, nextBody);
+    if (overlap.length >= 2 && overlap.nextStart > 0) {
+      const revealed = nextBody.slice(0, overlap.nextStart);
+      const combined = [
+        ...state.history.slice(0, fixed.head),
+        ...revealed,
+        ...state.history.slice(fixed.head),
+      ];
+      const limited = limitHistory(combined, maxChars, fixed.head);
       return {
         state: { history: limited.lines, frame },
-        addedLines: Math.max(0, prefix.length - limited.removedLines),
+        addedLines: Math.max(0, revealed.length - Math.min(revealed.length, limited.removedLines)),
       };
     }
   }

--- a/src/utils/max-wait-debouncer.ts
+++ b/src/utils/max-wait-debouncer.ts
@@ -1,0 +1,37 @@
+/**
+ * Trailing debounce with a maximum wait. Repeated schedule() calls postpone
+ * the quiet-period timer, while the first call's max timer guarantees that a
+ * continuously busy source still flushes at a bounded cadence.
+ */
+export class MaxWaitDebouncer {
+  private settleTimer: ReturnType<typeof setTimeout> | null = null;
+  private maxTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private readonly settleMs: number,
+    private readonly maxWaitMs: number,
+    private readonly callback: () => void,
+  ) {}
+
+  schedule(): void {
+    if (!this.maxTimer) {
+      this.maxTimer = setTimeout(this.fire, this.maxWaitMs);
+      this.maxTimer.unref?.();
+    }
+    if (this.settleTimer) clearTimeout(this.settleTimer);
+    this.settleTimer = setTimeout(this.fire, this.settleMs);
+    this.settleTimer.unref?.();
+  }
+
+  cancel(): void {
+    if (this.settleTimer) clearTimeout(this.settleTimer);
+    if (this.maxTimer) clearTimeout(this.maxTimer);
+    this.settleTimer = null;
+    this.maxTimer = null;
+  }
+
+  private readonly fire = (): void => {
+    this.cancel();
+    this.callback();
+  };
+}

--- a/src/utils/terminal-renderer.ts
+++ b/src/utils/terminal-renderer.ts
@@ -82,6 +82,14 @@ export class TerminalRenderer {
     this.terminal.write(data);
   }
 
+  /** Replace the terminal grid with an authoritative full-frame baseline. */
+  replace(data: string, cols = this.terminal.cols, rows = this.terminal.rows): void {
+    this.terminal.dispose();
+    this.terminal = new Terminal({ cols, rows, allowProposedApi: true });
+    this.lastHash = '';
+    this.terminal.write(data);
+  }
+
   /** Reset the change-detection hash so the next snapshot registers as changed. */
   markNewTurn(): void {
     this.lastHash = '';

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -110,6 +110,7 @@ import { createServer as createHttpServer, type IncomingMessage } from 'node:htt
 import { WebSocketServer, WebSocket } from 'ws';
 import { listenWebTerminalWithFallback } from './utils/web-terminal-listen.js';
 import { HerdrWebTerminalBinding } from './utils/herdr-web-terminal-binding.js';
+import { MaxWaitDebouncer } from './utils/max-wait-debouncer.js';
 import { TERMINAL_FAVICON_DATA_URI } from './utils/terminal-favicon.js';
 import type {
   CodexAppTurnInput,
@@ -141,7 +142,11 @@ import { sessionReadyHookCommand } from './adapters/hook-command.js';
 import { mtrSessionIdForBotmuxSession } from './adapters/cli/mtr.js';
 import type { CliAdapter, PtyHandle, SubmitRecheckResult, CliId } from './adapters/cli/types.js';
 import { PtyBackend } from './adapters/backend/pty-backend.js';
-import { HerdrBackend, type HerdrWebTerminalCursor } from './adapters/backend/herdr-backend.js';
+import {
+  HerdrBackend,
+  type HerdrTerminalFrame,
+  type HerdrWebTerminalCursor,
+} from './adapters/backend/herdr-backend.js';
 import { TmuxBackend } from './adapters/backend/tmux-backend.js';
 import { TmuxPipeBackend } from './adapters/backend/tmux-pipe-backend.js';
 import { ZellijBackend, ZELLIJ_CONFIG_KDL } from './adapters/backend/zellij-backend.js';
@@ -3102,6 +3107,18 @@ let scrollback = '';
 let herdrWebHistory: HerdrWebHistoryState | null = null;
 let herdrWebScrollDirection: HerdrWebScrollDirection = null;
 let herdrWebCursor: HerdrWebTerminalCursor | null = null;
+let herdrWebSnapshotGeneration = 0;
+let herdrWebSnapshotPending = false;
+let herdrWebSnapshotInFlight = false;
+let herdrWebRenderMode: 'frame' | 'history' = 'frame';
+const herdrWebNeedsResync = new WeakSet<WebSocket>();
+const HERDR_WEB_SNAPSHOT_SETTLE_MS = 120;
+const HERDR_WEB_SNAPSHOT_MAX_WAIT_MS = 600;
+const herdrWebSnapshotDebouncer = new MaxWaitDebouncer(
+  HERDR_WEB_SNAPSHOT_SETTLE_MS,
+  HERDR_WEB_SNAPSHOT_MAX_WAIT_MS,
+  () => { void captureHerdrWebSnapshot(); },
+);
 const WORKFLOW_TRANSCRIPT_MAX = 2_000_000; // chars (~2MB)
 const WORKFLOW_OUTPUT_END_MARKER = '</WORKFLOW_OUTPUT>';
 const CRASH_DIAGNOSTIC_RAW_MAX = 200_000; // enough scrollback for the web terminal without huge temp files
@@ -3142,12 +3159,127 @@ function relayHerdrWebSnapshot(snapshot: string): void {
     MAX_SCROLLBACK,
   );
   herdrWebHistory = merged.state;
+  herdrWebRenderMode = 'history';
   herdrWebScrollDirection = null;
   scrollback = renderHerdrWebHistory(merged.state);
   const payload = `\x1b]1989;history;${merged.addedLines}\x07${scrollback}${herdrWebCursorSequence()}`;
   for (const ws of wsClients) {
-    if (ws.readyState === WebSocket.OPEN) ws.send(payload);
+    if (ws.readyState !== WebSocket.OPEN) continue;
+    if (ws.bufferedAmount > MAX_SCROLLBACK) {
+      herdrWebNeedsResync.add(ws);
+      continue;
+    }
+    herdrWebNeedsResync.delete(ws);
+    ws.send(payload);
   }
+}
+
+function cancelHerdrWebSnapshotRequests(): void {
+  herdrWebSnapshotDebouncer.cancel();
+  herdrWebSnapshotGeneration++;
+  herdrWebSnapshotPending = false;
+}
+
+function relayHerdrWebFullFrame(frame: HerdrTerminalFrame): void {
+  cancelHerdrWebSnapshotRequests();
+  herdrWebRenderMode = 'frame';
+  herdrWebHistory = null;
+  herdrWebScrollDirection = null;
+  scrollback = frame.data;
+  const payload = `\x1b]1989;frame\x07${frame.data}${herdrWebCursorSequence()}`;
+  for (const ws of wsClients) {
+    if (ws.readyState !== WebSocket.OPEN) continue;
+    if (ws.bufferedAmount > MAX_SCROLLBACK) {
+      herdrWebNeedsResync.add(ws);
+      continue;
+    }
+    herdrWebNeedsResync.delete(ws);
+    ws.send(payload);
+  }
+}
+
+function relayHerdrWebDelta(data: string): void {
+  scrollback += data;
+  if (scrollback.length > MAX_SCROLLBACK) {
+    let cut = scrollback.length - MAX_SCROLLBACK;
+    const escAt = scrollback.indexOf('\x1b', cut);
+    cut = escAt >= 0 ? escAt : cut;
+    scrollback = `\x1bc${scrollback.slice(cut)}`;
+  }
+  for (const ws of wsClients) {
+    if (ws.readyState !== WebSocket.OPEN) continue;
+    if (herdrWebNeedsResync.has(ws)) {
+      if (ws.bufferedAmount <= MAX_SCROLLBACK) {
+        ws.send(`\x1b]1989;history;0\x07${scrollback}${herdrWebCursorSequence()}`);
+        herdrWebNeedsResync.delete(ws);
+      }
+      continue;
+    }
+    if (ws.bufferedAmount > MAX_SCROLLBACK) {
+      herdrWebNeedsResync.add(ws);
+      continue;
+    }
+    ws.send(data);
+  }
+}
+
+async function captureHerdrWebSnapshot(): Promise<void> {
+  const be = backend;
+  if (
+    !(be instanceof HerdrBackend)
+    || !herdrWebSnapshotPending
+    || herdrWebSnapshotInFlight
+    || wsClients.size === 0
+  ) return;
+
+  const generation = herdrWebSnapshotGeneration;
+  herdrWebSnapshotPending = false;
+  herdrWebSnapshotInFlight = true;
+  let snapshot = '';
+  try {
+    snapshot = await be.captureCurrentScreenAsync();
+  } catch (error) {
+    log(`[herdr-web] snapshot capture failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  herdrWebSnapshotInFlight = false;
+
+  if (
+    backend === be
+    && generation === herdrWebSnapshotGeneration
+    && wsClients.size > 0
+    && snapshot.length > 0
+  ) {
+    relayHerdrWebSnapshot(snapshot);
+  }
+
+  // Frames arriving during the async read request one more serialized capture
+  // without invalidating the usable result that is already in flight.
+  if (
+    herdrWebSnapshotPending
+    && backend instanceof HerdrBackend
+    && wsClients.size > 0
+  ) herdrWebSnapshotDebouncer.schedule();
+}
+
+function scheduleHerdrWebSnapshot(be: HerdrBackend): void {
+  if (backend !== be || wsClients.size === 0) return;
+  herdrWebSnapshotPending = true;
+  if (!herdrWebSnapshotInFlight) herdrWebSnapshotDebouncer.schedule();
+}
+
+function relayHerdrTerminalFrame(be: HerdrBackend, frame: HerdrTerminalFrame): void {
+  if (backend !== be) return;
+  onPtyData(frame.data, frame);
+  if (frame.full) {
+    relayHerdrWebFullFrame(frame);
+    return;
+  }
+  // A captured line-history buffer and a native grid delta use different
+  // coordinate spaces. Never apply CUP-based observer deltas to history: it
+  // overwrites older rows. While remotely scrolled, settle another explicit
+  // capture instead; normal live mode remains a zero-poll native stream.
+  if (herdrWebRenderMode === 'frame') relayHerdrWebDelta(frame.data);
+  else scheduleHerdrWebSnapshot(be);
 }
 
 function applyHerdrWebBindingResult(
@@ -3188,7 +3320,6 @@ function restoreHerdrWebBindings(): void {
 }
 
 function wireHerdrWebTerminalRelays(be: HerdrBackend): void {
-  be.onSnapshot(relayHerdrWebSnapshot);
   be.onWebTerminalCursor(relayHerdrWebCursor);
 }
 
@@ -3970,13 +4101,16 @@ function splitCodexAppControl(data: string): string {
 
 // ─── Prompt Detection ────────────────────────────────────────────────────────
 
-function onPtyData(data: string): void {
+function onPtyData(data: string, frame?: HerdrTerminalFrame): void {
   data = splitCodexAppControl(data);
   if (data.length === 0) return;
   lastPtyActivityAtMs = Date.now();
   maybeCaptureKiroSessionId(data);
-  captureWorkflowTranscript(data);
-  renderer?.write(data);
+  // A native full frame is an authoritative grid replacement, not new CLI
+  // transcript. Appending it duplicates or overwrites reattach scrollback.
+  if (!frame?.full) captureWorkflowTranscript(data);
+  if (frame?.full) renderer?.replace(data, frame.width, frame.height);
+  else renderer?.write(data);
 
   // In tmux-attach mode, each web client has its own tmux attach PTY —
   // no relay needed. In non-tmux mode AND in pipe mode (adopt-bridge),
@@ -5116,14 +5250,13 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
       env: process.env as Record<string, string>,
     });
 
+    herdrBe.onTerminalFrame(frame => relayHerdrTerminalFrame(herdrBe, frame));
     wireHerdrWebTerminalRelays(herdrBe);
-    seedBackendScreen('herdr adopt', herdrBe);
 
     setupAdoptTranscriptBridges(cfg);
     setupAdoptInputAdapter(cfg);
     setupAdoptIdleDetection(cfg, 'herdr');
 
-    backend.onData(onPtyData);
     backend.onAccessUrl?.((url) => {
       send({ type: 'riff_access_url', accessUrl: url });
     });
@@ -5235,11 +5368,11 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
         reason = 'zellij 功能性探针失败（需 zellij >= 0.44）';
       }
     } else if (effectiveBackend === 'herdr') {
-      // herdr's isAvailable() is a cheap, non-destructive `herdr --version`
-      // (not a disposable session probe), so it has no PR#249 false-negative
-      // risk and needs no existing-session exemption.
+      // Native terminal streaming is available from Herdr 0.7.2. The version
+      // probe is cheap and non-destructive, so existing sessions do not bypass
+      // this compatibility gate.
       available = HerdrBackend.isAvailable();
-      reason = 'herdr 功能性探针失败';
+      reason = 'herdr 不可用或版本低于 0.7.2（请执行 herdr update）';
     }
     const decision = decideBackendGate({ requested: effectiveBackend, available, hasExistingSession });
     if (decision.action === 'gate') {
@@ -6456,21 +6589,27 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     });
   }
 
-  backend.onData(onPtyData);
   const observedBackend = backend;
-  backend.onAccessUrl?.((url) => {
+  const sessionBackend = backend as SessionBackend;
+  if (backend instanceof HerdrBackend) {
+    const herdrBackend = backend;
+    herdrBackend.onTerminalFrame(frame => relayHerdrTerminalFrame(herdrBackend, frame));
+  } else {
+    backend.onData(onPtyData);
+  }
+  sessionBackend.onAccessUrl?.((url) => {
     send({ type: 'riff_access_url', accessUrl: url });
   });
   // Remote-task turn boundary (riff): flushPending() marks the session busy on
   // every write and riff has no PTY output, so the idle detector never re-arms
   // prompt-ready — without this hook a follow-up arriving mid-task would sit
   // in pendingMessages forever once the task finishes.
-  backend.onTaskDone?.(() => {
+  sessionBackend.onTaskDone?.(() => {
     log(`${cliName()} task finished — re-arming prompt-ready for queued follow-ups`);
     markPromptReady();
   });
   // riff：任务 id 变更同步给 daemon 持久化，daemon 重启后 follow-up 血缘不断。
-  backend.onTaskId?.((taskId) => {
+  sessionBackend.onTaskId?.((taskId) => {
     send({ type: 'riff_task_id', taskId });
   });
   if (backend instanceof HerdrBackend) {
@@ -6561,7 +6700,11 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
 
   if (isPipeMode && backend && 'isReattach' in backend && backend.isReattach) {
     log(`Re-attached to existing ${effectiveBackendType} session via pipe backend: ${persistentSessionName}`);
-    seedBackendScreen(`${effectiveBackendType} reattach`, backend);
+    // Herdr's first observer frame is a full authoritative baseline. Seeding
+    // its renderer first and then appending that frame corrupts scrollback.
+    if (!(backend instanceof HerdrBackend)) {
+      seedBackendScreen(`${effectiveBackendType} reattach`, backend);
+    }
     scheduleReattachIdleProbe(`${effectiveBackendType} reattach`, backend);
   }
 
@@ -6678,6 +6821,8 @@ function killCli(opts: { preservePending?: boolean } = {}): void {
   herdrWebHistory = null;
   herdrWebScrollDirection = null;
   herdrWebCursor = null;
+  cancelHerdrWebSnapshotRequests();
+  herdrWebRenderMode = 'frame';
   altBufferActive = false;
   trustHandled = false;
   codexUpdateDialogGuard.reset();
@@ -7028,6 +7173,12 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
         if (seed.length > 0) {
           ws.send(seed + herdrWebCursorSequence());
         }
+        if (backend instanceof HerdrBackend && herdrWebRenderMode === 'history') {
+          // No captures run without viewers. Refresh the retained seed once a
+          // reader reconnects so output produced in the gap becomes visible.
+          herdrWebScrollDirection = null;
+          scheduleHerdrWebSnapshot(backend);
+        }
 
         ws.on('message', (raw) => {
           try {
@@ -7042,9 +7193,10 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
               // Mouse protocols can encode approvals/actions as well as wheel input.
               // A read-only view capability must never forward bytes to the backend.
               if (!authedClients.has(ws)) return;
-              if (usesHerdrSnapshotWebHistory()) {
+              if (backend instanceof HerdrBackend) {
                 if (msg.data.includes('\x1b[<64;')) herdrWebScrollDirection = 'up';
                 else if (msg.data.includes('\x1b[<65;')) herdrWebScrollDirection = 'down';
+                if (herdrWebScrollDirection) scheduleHerdrWebSnapshot(backend);
               }
               backend?.write(msg.data);
             }
@@ -7054,6 +7206,12 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
         ws.on('close', () => {
           wsClients.delete(ws);
           herdrWebBindings.delete(ws);
+          if (wsClients.size === 0) {
+            // Keep the last bounded history as a reconnect seed, but stop the
+            // 10k-line capture process while nobody is watching.
+            cancelHerdrWebSnapshotRequests();
+            herdrWebScrollDirection = null;
+          }
           const promoted = herdrWebBinding.release() as WebSocket | null;
           if (promoted?.readyState === WebSocket.OPEN) {
             promoted.send('\x1b]1989;owner\x07');
@@ -7266,6 +7424,25 @@ function _settleInitialBottom(){
     _initialFollow=false;
   },500);
 }
+// Serialize every xterm write at the application layer. Calling reset() while
+// an earlier xterm.write() is still queued lets a following full/history frame
+// overtake its own reset and corrupts the grid. One job completes before the
+// next job may reset or write.
+var _termJobs=[],_termJobActive=false;
+function _queueTermWrite(data,replace,after,before){
+  _termJobs.push({data:data,replace:replace,after:after,before:before});
+  _drainTermWrites();
+}
+function _drainTermWrites(){
+  if(_termJobActive||!_termJobs.length)return;
+  _termJobActive=true;var job=_termJobs.shift();
+  if(job.before)job.before();
+  if(job.replace){term.reset();term.clear()}
+  term.write(job.data,function(){
+    if(job.after)job.after();
+    _termJobActive=false;_drainTermWrites();
+  });
+}
 var _initialViewport=term.element&&term.element.querySelector('.xterm-viewport');
 var _initialTerminalRoot=document.getElementById('terminal');
 if(_initialTerminalRoot){
@@ -7363,18 +7540,22 @@ window.addEventListener('resize',onViewportResize);
   ws.onopen=function(){el.textContent='connected';el.className='ok';_lastC=_lastR=0;sendResize()};
   ws.onmessage=function(e){
     var data=typeof e.data==='string'?e.data:new TextDecoder().decode(e.data);
+    // Herdr observer full frames replace the current grid. Reset before
+    // writing them so reconnect/resize baselines never append to scrollback.
+    var _hfr=data.match(/^\x1b\]1989;frame\x07/);
+    if(_hfr){var _hfd=data.slice(_hfr[0].length);_cancelInitialFollow();_queueTermWrite(_hfd,true,_settleInitialBottom);return}
     // Snapshot-aware Herdr history replaces the buffer instead of appending a
     // mostly-overlapping full screen. Preserve the reader's anchor when older
     // rows were prepended; otherwise preserve their current position/follow.
     var _hh=data.match(/^\x1b\]1989;history;([0-9]+)\x07/);
     if(_hh){
-      var _ha=+_hh[1],_hb=term.buffer.active,_hy=_hb.viewportY,_hBottom=_hy===_hb.baseY;
-      data=data.slice(_hh[0].length);_cancelInitialFollow();term.reset();term.clear();
-      data='\\x1b[2J\\x1b[H'+data;
-      term.write(data,function(){
-        if(_ha>0)term.scrollToLine(_hy+_ha);
-        else if(_hBottom)term.scrollToBottom();
-        else term.scrollToLine(_hy);
+      var _ha=+_hh[1],_hd=data.slice(_hh[0].length),_hy=0,_hBottom=false;_cancelInitialFollow();
+      _queueTermWrite('\\x1b[2J\\x1b[H'+_hd,true,function(){
+          if(_ha>0)term.scrollToLine(_hy+_ha);
+          else if(_hBottom)term.scrollToBottom();
+          else term.scrollToLine(_hy);
+        },function(){
+          var _hb=term.buffer.active;_hy=_hb.viewportY;_hBottom=_hy===_hb.baseY;
       });
       return;
     }
@@ -7400,7 +7581,7 @@ window.addEventListener('resize',onViewportResize);
     // Intercept OSC 52 clipboard sequence from tmux (set-clipboard on)
     var m=data.match(/\\x1b\\]52;[^;]*;([A-Za-z0-9+/=]+)(?:\\x07|\\x1b\\\\)/);
     if(m){try{_clipBuf=new TextDecoder().decode(Uint8Array.from(atob(m[1]),function(c){return c.charCodeAt(0)}));_doCopy(_clipBuf);_showCopied()}catch(ex){}}
-    term.write(data,_settleInitialBottom);
+    _queueTermWrite(data,false,_settleInitialBottom);
   };
   ws.onclose=function(){ws_=null;el.textContent='disconnected';el.className='err';setTimeout(connect,2000)};
   ws.onerror=function(){ws.close()};

--- a/test/herdr-backend.e2e.ts
+++ b/test/herdr-backend.e2e.ts
@@ -17,14 +17,16 @@
  */
 import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { rmSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { HerdrBackend } from '../src/adapters/backend/herdr-backend.js';
+import { TerminalRenderer } from '../src/utils/terminal-renderer.js';
 
 // Unique enough to never collide with anything the user has running.
 const TEST_SESSION = 'bmx-e2e7777';
 const TEST_TIMEOUT = 30_000;
+const REATTACH_SENTINEL = `/tmp/botmux-herdr-reattach-${process.pid}`;
 
 /**
  * Hard reset for a test session. `herdr session stop` is asynchronous and
@@ -58,58 +60,68 @@ async function waitFor(predicate: () => boolean, timeoutMs: number, label = 'con
 describe('HerdrBackend (e2e)', () => {
   beforeEach(() => {
     hardResetSession(TEST_SESSION);
+    rmSync(REATTACH_SENTINEL, { force: true });
   });
 
   afterEach(() => {
     hardResetSession(TEST_SESSION);
+    rmSync(REATTACH_SENTINEL, { force: true });
   });
 
   it.skipIf(!HerdrBackend.isAvailable())('spawn captures output from a live herdr agent', async () => {
     const backend = new HerdrBackend(TEST_SESSION);
-    const output: string[] = [];
-    backend.onData(d => output.push(d));
+    const renderer = new TerminalRenderer(80, 24);
+    backend.onData(data => renderer.write(data));
 
     backend.spawn('/bin/bash', ['-lc', 'echo HELLO_HERDR; sleep 30'], spawnOpts());
 
-    await waitFor(() => output.join('').includes('HELLO_HERDR'), 10_000, 'HELLO_HERDR in output');
-    expect(output.join('')).toContain('HELLO_HERDR');
+    await waitFor(() => renderer.rawSnapshot().includes('HELLO_HERDR'), 10_000, 'HELLO_HERDR in output');
+    expect(renderer.rawSnapshot()).toContain('HELLO_HERDR');
     expect(HerdrBackend.hasSession(TEST_SESSION)).toBe(true);
     expect(backend.isReattach).toBe(false);
 
     backend.kill();
+    renderer.dispose();
     // kill() only tears down the backend's observers; the herdr session and
     // its agent process must outlive a detach so daemon restarts can resume.
     expect(HerdrBackend.hasSession(TEST_SESSION)).toBe(true);
   }, TEST_TIMEOUT);
 
-  it.skipIf(!HerdrBackend.isAvailable())('re-attach observes the same agent without spawning a new one', async () => {
-    // Phase 1: create the session and let it produce a marker line.
+  it.skipIf(!HerdrBackend.isAvailable())('re-attach streams its full baseline and subsequent output', async () => {
+    // Phase 1: create a long-lived interactive agent and detach its observer.
     const be1 = new HerdrBackend(TEST_SESSION);
-    const out1: string[] = [];
-    be1.onData(d => out1.push(d));
-    be1.spawn('/bin/bash', ['-lc', 'echo PHASE1_MARKER; sleep 30'], spawnOpts());
-    await waitFor(() => out1.join('').includes('PHASE1_MARKER'), 10_000, 'PHASE1_MARKER');
+    const renderer = new TerminalRenderer(80, 24);
+    be1.onData(data => renderer.write(data));
+    be1.spawn('/bin/bash', ['-lc', `echo PHASE1_MARKER; while [ ! -f ${REATTACH_SENTINEL} ]; do sleep 0.05; done; echo PHASE2_DELTA; sleep 30`], spawnOpts());
+    await waitFor(() => renderer.rawSnapshot().includes('PHASE1_MARKER'), 10_000, 'PHASE1_MARKER');
     be1.kill();
+    renderer.dispose();
     expect(HerdrBackend.hasSession(TEST_SESSION)).toBe(true);
 
-    // Phase 2: a second backend attaches to the same session. It must NOT
-    // start a fresh `bash` (the bin/args are ignored on reuse), and it
-    // should see PHASE1_MARKER on its first `pane read --source recent`.
+    // Phase 2: the worker consumes the first observer record as a full grid
+    // replacement, then applies later records as increments. It must NOT start
+    // a fresh bash or append a separately captured seed before that baseline.
     const be2 = new HerdrBackend(TEST_SESSION, { isReattach: true });
-    const out2: string[] = [];
-    be2.onData(d => out2.push(d));
+    const reattachRenderer = new TerminalRenderer(80, 24);
     be2.spawn('/bin/bash', ['-lc', 'echo SHOULD_NOT_RUN'], spawnOpts());
     expect(be2.isReattach).toBe(true);
+    be2.onTerminalFrame(frame => {
+      if (frame.full) reattachRenderer.replace(frame.data, frame.width, frame.height);
+      else reattachRenderer.write(frame.data);
+    });
+    await waitFor(
+      () => reattachRenderer.rawSnapshot().includes('PHASE1_MARKER'),
+      5_000,
+      'reattach rendered full baseline',
+    );
 
-    // Read recent pane content via the backend's capture API. Don't gate on
-    // onData here — the second backend snapshots last-text at spawn time so
-    // the marker shows up in captureCurrentScreen, not the delta stream.
-    await waitFor(() => {
-      const screen = be2.captureCurrentScreen();
-      return screen.includes('PHASE1_MARKER') && !screen.includes('SHOULD_NOT_RUN');
-    }, 10_000, 'pane recent contains PHASE1 but not SHOULD_NOT_RUN');
+    writeFileSync(REATTACH_SENTINEL, 'go');
+    await waitFor(() => be2.captureCurrentScreen().includes('PHASE2_DELTA'), 10_000, 'pane produced PHASE2_DELTA');
+    await waitFor(() => reattachRenderer.rawSnapshot().includes('PHASE2_DELTA'), 10_000, 'reattach rendered PHASE2_DELTA');
+    expect(reattachRenderer.rawSnapshot()).not.toContain('SHOULD_NOT_RUN');
 
     be2.destroySession();
+    reattachRenderer.dispose();
     await waitFor(() => !HerdrBackend.hasSession(TEST_SESSION), 10_000, 'session torn down');
   }, TEST_TIMEOUT);
 
@@ -145,22 +157,21 @@ describe('HerdrBackend (e2e)', () => {
 
   it.skipIf(!HerdrBackend.isAvailable())('write() routes input to the pane and the shell echoes it back', async () => {
     const backend = new HerdrBackend(TEST_SESSION);
+    const renderer = new TerminalRenderer(80, 24);
+    backend.onData(data => renderer.write(data));
     backend.spawn('/bin/bash', ['-lc', 'cat'], spawnOpts());
     await waitFor(() => HerdrBackend.hasSession(TEST_SESSION), 10_000, 'session up');
 
-    const seen: string[] = [];
-    backend.onData(d => seen.push(d));
-
-    // `cat` echoes stdin to stdout — verifies the full write→pane→read loop.
-    // PTY line discipline submits on CR (Enter), not LF — use sendSpecialKeys
-    // for the Enter so the line is actually delivered to cat's stdin.
+    // `cat` echoes stdin to stdout — verifies the full write→pane→stream loop.
+    // PTY line discipline submits on CR (Enter), not LF.
     backend.write('PING_FROM_BOTMUX');
     backend.sendSpecialKeys('Enter');
 
-    await waitFor(() => seen.join('').includes('PING_FROM_BOTMUX'), 10_000, 'cat echoed input');
-    expect(seen.join('')).toContain('PING_FROM_BOTMUX');
+    await waitFor(() => renderer.rawSnapshot().includes('PING_FROM_BOTMUX'), 10_000, 'cat echoed input');
+    expect(renderer.rawSnapshot()).toContain('PING_FROM_BOTMUX');
 
     backend.destroySession();
+    renderer.dispose();
   }, TEST_TIMEOUT);
 
   it.skipIf(!HerdrBackend.isAvailable())('web attach resizes the real agent terminal', async () => {

--- a/test/herdr-backend.test.ts
+++ b/test/herdr-backend.test.ts
@@ -16,9 +16,12 @@
  * Run:  pnpm vitest run test/herdr-backend.test.ts
  */
 import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { setImmediate as waitForImmediate } from 'node:timers/promises';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
   execFileSync: vi.fn(),
   spawn: vi.fn(),
 }));
@@ -27,10 +30,11 @@ vi.mock('node-pty', () => ({
   spawn: vi.fn(),
 }));
 
-import { execFileSync, spawn } from 'node:child_process';
+import { execFile, execFileSync, spawn } from 'node:child_process';
 import * as pty from 'node-pty';
 import { HerdrBackend } from '../src/adapters/backend/herdr-backend.js';
 
+const mockedExecFile = vi.mocked(execFile);
 const mockedExecFileSync = vi.mocked(execFileSync);
 const mockedSpawn = vi.mocked(spawn);
 const mockedPtySpawn = vi.mocked(pty.spawn);
@@ -39,11 +43,19 @@ const mockedPtySpawn = vi.mocked(pty.spawn);
 
 class FakeChild extends EventEmitter {
   killed = false;
+  stdout = new PassThrough();
   unref = vi.fn();
   kill = vi.fn(() => { this.killed = true; return true; });
 }
 
-function makeFakeChild(): FakeChild { return new FakeChild(); }
+const fakeChildren: FakeChild[] = [];
+
+function makeFakeChild(): FakeChild {
+  const child = new FakeChild();
+  fakeChildren.push(child);
+  return child;
+}
+
 
 class FakePty {
   readonly resize = vi.fn();
@@ -110,13 +122,24 @@ const AGENT_LIST_REPLY = (paneId: string) => JSON.stringify({ result: { agents: 
 const PANE_READ_REPLY = (text: string) => JSON.stringify({ result: { read: { text } } });
 
 beforeEach(() => {
+  mockedExecFile.mockReset();
   mockedExecFileSync.mockReset();
   mockedSpawn.mockReset();
   mockedPtySpawn.mockReset();
-  // Default: every spawn (including the bg `wait agent-status` watcher) gets
-  // a fake child whose lifecycle the test fully controls.
+  fakeChildren.length = 0;
+  // Every spawned process gets a fake child whose lifecycle the test controls.
   mockedSpawn.mockImplementation((() => makeFakeChild()) as any);
   mockedPtySpawn.mockImplementation((() => makeFakePty()) as any);
+  mockedExecFile.mockImplementation(((cmd: any, args: any, opts: any, cb: any) => {
+    queueMicrotask(() => {
+      try {
+        cb(null, mockedExecFileSync(cmd, args, opts), '');
+      } catch (error) {
+        cb(error, '', '');
+      }
+    });
+    return new FakeChild();
+  }) as any);
 });
 
 afterEach(() => {
@@ -126,15 +149,17 @@ afterEach(() => {
 // ─── Backend connection surface ────────────────────────────────────────────
 
 describe('HerdrBackend connection surface', () => {
-  it('isAvailable() returns true when `herdr --version` succeeds', () => {
-    mockedExecFileSync.mockImplementation((() => 'herdr 1.0\n') as any);
+  it('isAvailable() requires Herdr 0.7.2 or newer', () => {
+    mockedExecFileSync.mockReturnValue('herdr 0.7.2\n');
     expect(HerdrBackend.isAvailable()).toBe(true);
+    mockedExecFileSync.mockReturnValue('herdr 0.7.1\n');
+    expect(HerdrBackend.isAvailable()).toBe(false);
     const versionCall = mockedExecFileSync.mock.calls.find(c => (c[1] as string[]).includes('--version'));
     expect(versionCall).toBeDefined();
   });
 
   it('isAvailable() returns false when herdr binary is missing', () => {
-    mockedExecFileSync.mockImplementation((() => { throw new Error('ENOENT'); }) as any);
+    mockedExecFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
     expect(HerdrBackend.isAvailable()).toBe(false);
   });
 
@@ -418,6 +443,14 @@ describe('HerdrBackend web terminal sizing', () => {
     );
     expect(mockedPtySpawn.mock.calls[0]![1]).not.toContain('--takeover');
     expect(attach.onData).toHaveBeenCalledOnce();
+    const observerCallsAfterOwner = mockedSpawn.mock.calls.filter(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    expect(observerCallsAfterOwner).toHaveLength(2);
+    expect(observerCallsAfterOwner.at(-1)?.[1]).toEqual(expect.arrayContaining(['150', '42']));
+    const resizedObserverCallIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe') && args.includes('150'));
+    expect(mockedPtySpawn.mock.invocationCallOrder[0])
+      .toBeLessThan(mockedSpawn.mock.invocationCallOrder[resizedObserverCallIndex]!);
     attach.emitData('ignored attach frame');
     expect(relayed).toEqual([]);
 
@@ -661,228 +694,405 @@ describe('HerdrBackend message writing', () => {
 // ─── Callbacks: onData delta + onExit ──────────────────────────────────────
 
 describe('HerdrBackend callbacks', () => {
-  it('onData fires with the prefix-delta when pane recent output grows', () => {
-    let paneText = 'hello';
+  it('streams native terminal frames without pane polling or status waiters', async () => {
     setHerdrResponses([
       { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
-      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('1-1') },
-      { match: a => a.includes('agent') && a.includes('list'), reply: () => AGENT_LIST_REPLY('1-1') },
-      { match: a => a.includes('read') && (a.includes('agent') || a.includes('pane')), reply: () => PANE_READ_REPLY(paneText) },
-    ]);
-
-    vi.useFakeTimers();
-    // Use an isReattach backend so the baseline is captured at spawn
-    // (lastText = current pane content) — that mirrors the worker.ts
-    // reattach contract, where the initial screen is seeded separately and
-    // the data stream emits only deltas.
-    const be = new HerdrBackend(SESSION, { isReattach: true });
-    const seen: string[] = [];
-    const snapshots: string[] = [];
-    be.onData(d => seen.push(d));
-    be.onSnapshot(frame => snapshots.push(frame));
-    be.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
-
-    // Reattach captures the current screen as baseline → no immediate emit.
-    expect(seen).toEqual([]);
-
-    paneText = 'hello world';
-    vi.advanceTimersByTime(600); // > POLL_INTERVAL_MS (500ms)
-    expect(seen).toEqual([' world']);
-    expect(snapshots).toEqual(['hello world']);
-
-    paneText = 'hello world!';
-    vi.advanceTimersByTime(600);
-    expect(seen).toEqual([' world', '!']);
-    expect(snapshots).toEqual(['hello world', 'hello world!']);
-
-    be.kill();
-  });
-
-  it('onData fresh-spawn baseline: lastText starts empty so listeners see initial output', () => {
-    // Counterpart to the reattach test: a fresh spawn keeps lastText='' so
-    // listeners attached *before* spawn don't miss output the agent emitted
-    // between agent-start and the first poll tick (the herdr-backend's
-    // missing-initial-output bug we hit in the e2e run).
-    let paneText = '';
-    setHerdrResponses([
-      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
-      { match: a => a.includes('agent') && a.includes('get'), reply: () => '' },
       {
         match: a => a.includes('agent') && a.includes('start'),
-        reply: () => JSON.stringify({ result: { agent: { name: 'botmux', pane_id: '1-1' } } }),
+        reply: () => JSON.stringify({ result: { agent: { name: 'botmux', pane_id: 'w1:p1' } } }),
       },
-      { match: a => a.includes('agent') && a.includes('list'), reply: () => AGENT_LIST_REPLY('1-1') },
-      { match: a => a.includes('read') && (a.includes('agent') || a.includes('pane')), reply: () => PANE_READ_REPLY(paneText) },
     ]);
 
-    vi.useFakeTimers();
-    const be = new HerdrBackend(SESSION);
+    const backend = new HerdrBackend(SESSION);
     const seen: string[] = [];
-    be.onData(d => seen.push(d));
-    be.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const frames: Array<{ data: string; full: boolean; seq: number }> = [];
+    backend.onData(data => seen.push(data));
+    backend.onTerminalFrame(frame => frames.push({ data: frame.data, full: frame.full, seq: frame.seq }));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
 
-    paneText = 'HELLO_HERDR\n';
-    vi.advanceTimersByTime(600);
-    expect(seen.join('')).toBe('HELLO_HERDR\n');
+    const observerIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('session') && args.includes('observe'));
+    const observer = observerIndex >= 0 ? fakeChildren[observerIndex] : undefined;
+    try {
+      expect(observer).toBeDefined();
+      expect(mockedSpawn.mock.calls.some(([, args]) =>
+        Array.isArray(args) && args.includes('wait') && args.includes('agent-status'))).toBe(false);
 
-    be.kill();
+      const first = JSON.stringify({
+        type: 'terminal.frame', seq: 0, full: true, encoding: 'ansi', width: 80, height: 24,
+        bytes: Buffer.from('\x1b[31mfirst\x1b[0m').toString('base64'),
+      });
+      const second = JSON.stringify({
+        type: 'terminal.frame', seq: 1, full: false, encoding: 'ansi', width: 80, height: 24,
+        bytes: Buffer.from(' second').toString('base64'), futureField: true,
+      });
+
+      observer!.stdout.write(first.slice(0, 17));
+      observer!.stdout.write(`${first.slice(17)}\n${second}\n`);
+      await waitForImmediate();
+      expect(seen.join('')).toBe('\x1b[31mfirst\x1b[0m second');
+      expect(frames).toEqual([
+        { data: '\x1b[31mfirst\x1b[0m', full: true, seq: 0 },
+        { data: ' second', full: false, seq: 1 },
+      ]);
+      expect(herdrCall('agent', 'read')).toBeUndefined();
+      backend.kill();
+      expect(observer!.killed).toBe(true);
+    } finally {
+      if (!observer?.killed) backend.kill();
+    }
   });
 
-  it('onExit fires when the agent disappears from `agent list`', () => {
+  it('delivers frames emitted before the first onData listener is registered', async () => {
+    setHerdrResponses([
+      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
+      {
+        match: a => a.includes('agent') && a.includes('start'),
+        reply: () => JSON.stringify({ result: { agent: { name: 'botmux', pane_id: 'w1:p1' } } }),
+      },
+    ]);
+
+    const backend = new HerdrBackend(SESSION);
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const observerIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    fakeChildren[observerIndex]!.stdout.write(`${JSON.stringify({
+      type: 'terminal.frame', seq: 1, full: true, encoding: 'ansi', width: 80, height: 24,
+      bytes: Buffer.from('early baseline').toString('base64'),
+    })}\n`);
+    await waitForImmediate();
+
+    const seen: string[] = [];
+    const alsoSeen: string[] = [];
+    backend.onData(data => seen.push(data));
+    backend.onData(data => alsoSeen.push(data));
+    expect(seen).toEqual(['early baseline']);
+    expect(alsoSeen).toEqual(['early baseline']);
+    backend.kill();
+  });
+
+  it('does not retain a duplicate pendingData stream once a frame consumer is attached', async () => {
+    setHerdrResponses([
+      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
+      {
+        match: a => a.includes('agent') && a.includes('start'),
+        reply: () => JSON.stringify({ result: { agent: { name: 'botmux', pane_id: 'w1:p1' } } }),
+      },
+    ]);
+
+    const backend = new HerdrBackend(SESSION);
+    const frames: string[] = [];
+    backend.onTerminalFrame(frame => frames.push(frame.data));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const observerIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    const observer = fakeChildren[observerIndex]!;
+    for (let seq = 0; seq < 3; seq++) {
+      observer.stdout.write(`${JSON.stringify({
+        type: 'terminal.frame', seq, full: seq === 0, encoding: 'ansi', width: 80, height: 24,
+        bytes: Buffer.from(`frame-${seq}`).toString('base64'),
+      })}\n`);
+    }
+    await waitForImmediate();
+
+    const lateData: string[] = [];
+    backend.onData(data => lateData.push(data));
+    expect(frames).toEqual(['frame-0', 'frame-1', 'frame-2']);
+    expect(lateData).toEqual([]);
+    expect((backend as any).pendingData).toBe('');
+    backend.kill();
+  });
+
+  it('decodes one UTF-8 character split across consecutive terminal frames', async () => {
+    setHerdrResponses([
+      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
+      {
+        match: a => a.includes('agent') && a.includes('start'),
+        reply: () => JSON.stringify({ result: { agent: { name: 'botmux', pane_id: 'w1:p1' } } }),
+      },
+    ]);
+
+    const backend = new HerdrBackend(SESSION);
+    const seen: string[] = [];
+    backend.onData(data => seen.push(data));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const observerIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    const observer = fakeChildren[observerIndex]!;
+    const bytes = Buffer.from('你');
+
+    observer.stdout.write(`${JSON.stringify({
+      type: 'terminal.frame', seq: 1, full: true, encoding: 'ansi', width: 80, height: 24,
+      bytes: bytes.subarray(0, 2).toString('base64'),
+    })}\n`);
+    observer.stdout.write(`${JSON.stringify({
+      type: 'terminal.frame', seq: 2, full: false, encoding: 'ansi', width: 80, height: 24,
+      bytes: bytes.subarray(2).toString('base64'),
+    })}\n`);
+    await waitForImmediate();
+
+    expect(seen.join('')).toBe('你');
+    expect(seen.join('')).not.toContain('�');
+    backend.kill();
+  });
+
+  it('restarts a disconnected observer and forwards its full rebaseline before new deltas', async () => {
+    vi.useFakeTimers();
+    setHerdrResponses([
+      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
+      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('w1:p1') },
+      { match: a => a.includes('agent') && a.includes('list'), reply: () => AGENT_LIST_REPLY('w1:p1') },
+    ]);
+
+    const backend = new HerdrBackend(SESSION, { isReattach: true });
+    const seen: string[] = [];
+    const exits: Array<[number | null, string | null]> = [];
+    backend.onData(data => seen.push(data));
+    backend.onExit((code, signal) => exits.push([code, signal]));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const firstObserverIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    const firstObserver = fakeChildren[firstObserverIndex]!;
+
+    firstObserver.emit('exit', 1, null);
+    expect(firstObserver.killed).toBe(true);
+    firstObserver.stdout.write(`${JSON.stringify({
+      type: 'terminal.frame', seq: 99, full: false, encoding: 'ansi', width: 80, height: 24,
+      bytes: Buffer.from('stale observer').toString('base64'),
+    })}\n`);
+    await vi.runAllTicks();
+    vi.advanceTimersByTime(500);
+
+    const observerCalls = mockedSpawn.mock.calls.filter(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    expect(observerCalls).toHaveLength(2);
+    const restartedObserver = fakeChildren.at(-1)!;
+    restartedObserver.stdout.write(`${JSON.stringify({
+      type: 'terminal.frame', seq: 1, full: true, encoding: 'ansi', width: 80, height: 24,
+      bytes: Buffer.from('reconnected baseline').toString('base64'),
+    })}\n`);
+    restartedObserver.stdout.write(`${JSON.stringify({
+      type: 'terminal.frame', seq: 2, full: false, encoding: 'ansi', width: 80, height: 24,
+      bytes: Buffer.from(' delta').toString('base64'),
+    })}\n`);
+    await vi.runAllTicks();
+
+    expect(seen.join('')).toBe('reconnected baseline delta');
+    expect(exits).toEqual([]);
+    backend.kill();
+  });
+  it('kill cancels a pending observer restart', () => {
+    vi.useFakeTimers();
+    setHerdrResponses([
+      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
+      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('w1:p1') },
+      { match: a => a.includes('agent') && a.includes('list'), reply: () => AGENT_LIST_REPLY('w1:p1') },
+    ]);
+
+    const backend = new HerdrBackend(SESSION, { isReattach: true });
+    const exits: Array<[number | null, string | null]> = [];
+    backend.onExit((code, signal) => exits.push([code, signal]));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const observerIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    fakeChildren[observerIndex]!.emit('exit', 1, null);
+
+    backend.kill();
+    vi.advanceTimersByTime(500);
+
+    const observerCalls = mockedSpawn.mock.calls.filter(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    expect(observerCalls).toHaveLength(1);
+    expect(exits).toEqual([]);
+  });
+
+  it('stops after bounded async probe failures instead of reconnecting forever', async () => {
+    vi.useFakeTimers();
+    setHerdrResponses([
+      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
+      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('w1:p1') },
+    ]);
+    mockedExecFile.mockImplementation(((_cmd: any, _args: any, _opts: any, cb: any) => {
+      queueMicrotask(() => cb(new Error('server unavailable'), '', ''));
+      return new FakeChild();
+    }) as any);
+
+    const backend = new HerdrBackend(SESSION, { isReattach: true });
+    const exits: Array<[number | null, string | null]> = [];
+    backend.onExit((code, signal) => exits.push([code, signal]));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+
+    fakeChildren.at(-1)!.emit('exit', 1, null);
+    await vi.runAllTicks();
+    vi.advanceTimersByTime(500);
+    fakeChildren.at(-1)!.emit('exit', 1, null);
+    await vi.runAllTicks();
+    vi.advanceTimersByTime(1000);
+    fakeChildren.at(-1)!.emit('exit', 1, null);
+    await vi.runAllTicks();
+
+    expect(exits).toEqual([[1, null]]);
+    vi.advanceTimersByTime(10_000);
+    const observerCalls = mockedSpawn.mock.calls.filter(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    expect(observerCalls).toHaveLength(3);
+  });
+
+  it('keeps retrying with capped backoff when the agent is alive but its observer slot is unavailable', async () => {
+    vi.useFakeTimers();
+    setHerdrResponses([
+      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
+      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('w1:p1') },
+      { match: a => a.includes('agent') && a.includes('list'), reply: () => AGENT_LIST_REPLY('w1:p1') },
+    ]);
+
+    const backend = new HerdrBackend(SESSION, { isReattach: true });
+    const exits: Array<[number | null, string | null]> = [];
+    backend.onExit((code, signal) => exits.push([code, signal]));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+
+    fakeChildren.at(-1)!.emit('exit', 2, null);
+    await vi.runAllTicks();
+    vi.advanceTimersByTime(500);
+    fakeChildren.at(-1)!.emit('exit', 2, null);
+    await vi.runAllTicks();
+    vi.advanceTimersByTime(1000);
+    fakeChildren.at(-1)!.emit('exit', 2, null);
+    await vi.runAllTicks();
+
+    vi.advanceTimersByTime(2000);
+    fakeChildren.at(-1)!.emit('exit', 2, null);
+    await vi.runAllTicks();
+    vi.advanceTimersByTime(4000);
+    fakeChildren.at(-1)!.emit('exit', 2, null);
+    await vi.runAllTicks();
+    vi.advanceTimersByTime(5000);
+
+    expect(exits).toEqual([]);
+    const observerCalls = mockedSpawn.mock.calls.filter(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    expect(observerCalls).toHaveLength(6);
+    backend.kill();
+  });
+
+  it('reattach forwards the observer full frame before ordered incremental frames', async () => {
+    setHerdrResponses([
+      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
+      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('w1:p1') },
+    ]);
+
+    const backend = new HerdrBackend(SESSION, { isReattach: true });
+    const seen: string[] = [];
+    backend.onData(data => seen.push(data));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+
+    const observerIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('session') && args.includes('observe'));
+    const observer = observerIndex >= 0 ? fakeChildren[observerIndex] : undefined;
+    try {
+      expect(observer).toBeDefined();
+      for (const frame of [
+        { seq: 1, full: true, text: 'reattached screen' },
+        { seq: 2, full: false, text: ' delta' },
+        { seq: 2, full: false, text: ' duplicate' },
+        { seq: 1, full: false, text: ' stale' },
+        { seq: 3, full: false, text: ' done' },
+      ]) {
+        observer!.stdout.write(`${JSON.stringify({
+          type: 'terminal.frame', seq: frame.seq, full: frame.full, encoding: 'ansi', width: 80, height: 24,
+          bytes: Buffer.from(frame.text).toString('base64'),
+        })}\n`);
+      }
+      await waitForImmediate();
+      expect(seen.join('')).toBe('reattached screen delta done');
+      expect(herdrCall('agent', 'read')).toBeUndefined();
+      backend.kill();
+      expect(observer!.killed).toBe(true);
+    } finally {
+      if (!observer?.killed) backend.kill();
+    }
+  });
+
+  it('terminal.closed emits onExit when the observed agent disappeared', async () => {
     let agentAlive = true;
     setHerdrResponses([
       { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
-      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('1-1') },
+      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('w1:p1') },
       {
         match: a => a.includes('agent') && a.includes('list'),
-        reply: () => agentAlive
-          ? AGENT_LIST_REPLY('1-1')
-          : JSON.stringify({ result: { agents: [] } }),
+        reply: () => agentAlive ? AGENT_LIST_REPLY('w1:p1') : JSON.stringify({ result: { agents: [] } }),
       },
-      { match: a => a.includes('read') && (a.includes('agent') || a.includes('pane')), reply: () => PANE_READ_REPLY('') },
     ]);
 
-    vi.useFakeTimers();
-    const be = new HerdrBackend(SESSION, { isReattach: true });
+    const backend = new HerdrBackend(SESSION, { isReattach: true });
     const exits: Array<[number | null, string | null]> = [];
-    be.onExit((code, signal) => exits.push([code, signal]));
-    be.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    backend.onExit((code, signal) => exits.push([code, signal]));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const observerIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    const observer = fakeChildren[observerIndex]!;
 
     agentAlive = false;
-    vi.advanceTimersByTime(600);
+    observer.stdout.write(`${JSON.stringify({ type: 'terminal.closed', reason: 'pane exited' })}\n`);
+    await waitForImmediate();
     expect(exits).toEqual([[0, null]]);
   });
 
-  it('onExit fires when the agent stays in list with running:false (v0.6.6 tombstone)', () => {
-    // herdr v0.6.6+ does NOT drop exited agents from `agent list` — they
-    // stick around with running:false / status:"exited". Without this
-    // detection the worker never sees the CLI exit → claude_exit never
-    // fires → session hangs (the bug deepcoldy reported in PR #81).
+  it('terminal.closed preserves an explicit agent exit code', async () => {
     let agentRunning = true;
     setHerdrResponses([
       { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
-      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('1-1') },
+      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('w1:p1') },
       {
         match: a => a.includes('agent') && a.includes('list'),
         reply: () => agentRunning
-          ? AGENT_LIST_REPLY('1-1')
-          : JSON.stringify({ result: { agents: [{ name: 'botmux', pane_id: '1-1', running: false, status: 'exited', exit_code: 7 }] } }),
+          ? AGENT_LIST_REPLY('w1:p1')
+          : JSON.stringify({ result: { agents: [{ name: 'botmux', pane_id: 'w1:p1', running: false, status: 'exited', exit_code: 7 }] } }),
       },
-      { match: a => a.includes('read') && (a.includes('agent') || a.includes('pane')), reply: () => PANE_READ_REPLY('') },
     ]);
 
-    vi.useFakeTimers();
-    const be = new HerdrBackend(SESSION, { isReattach: true });
+    const backend = new HerdrBackend(SESSION, { isReattach: true });
     const exits: Array<[number | null, string | null]> = [];
-    be.onExit((code, signal) => exits.push([code, signal]));
-    be.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    backend.onExit((code, signal) => exits.push([code, signal]));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const observerIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
 
     agentRunning = false;
-    vi.advanceTimersByTime(600);
-    // exit_code surfaces from the tombstone row so callers can distinguish
-    // clean exits from crashes (mirrors the PTY backend's exit code path).
+    fakeChildren[observerIndex]!.stdout.write(`${JSON.stringify({ type: 'terminal.closed' })}\n`);
+    await waitForImmediate();
     expect(exits).toEqual([[7, null]]);
   });
 
-  it('status watcher: one wait child per settled status (done/blocked/idle), first exit wins', () => {
-    // Capture every fake `wait agent-status` child + its --status arg so the
-    // test can drive a specific watcher's exit and verify the cohort
-    // behaviour (first-to-fire reads, the rest get SIGTERM'd).
-    const waitChildren: Array<{ status: string; child: FakeChild }> = [];
-    mockedSpawn.mockImplementation(((_cmd: any, args: any) => {
-      const child = makeFakeChild();
-      const argv = args as string[];
-      if (argv.includes('wait') && argv.includes('agent-status')) {
-        const statusIdx = argv.indexOf('--status');
-        waitChildren.push({ status: argv[statusIdx + 1]!, child });
-      }
-      return child;
-    }) as any);
 
-    let paneText = 'baseline';
+  it('resize replaces the observer and forwards its full rebaseline frame', async () => {
     setHerdrResponses([
       { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
-      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('1-1') },
-      { match: a => a.includes('agent') && a.includes('list'), reply: () => AGENT_LIST_REPLY('1-1') },
-      { match: a => a.includes('read') && (a.includes('agent') || a.includes('pane')), reply: () => PANE_READ_REPLY(paneText) },
+      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('w1:p1') },
     ]);
 
-    // Reattach so the baseline is captured at spawn — keeps the assertion
-    // focused on "watcher exit triggers delta", not on the initial screen.
-    const be = new HerdrBackend(SESSION, { isReattach: true });
+    const backend = new HerdrBackend(SESSION, { isReattach: true });
     const seen: string[] = [];
-    be.onData(d => seen.push(d));
-    be.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    backend.onData(data => seen.push(data));
+    backend.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
+    const firstIndex = mockedSpawn.mock.calls.findIndex(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    const firstObserver = fakeChildren[firstIndex]!;
 
-    // Cohort = one watcher per settled status.
-    const cohort = waitChildren.slice();
-    expect(cohort.map(w => w.status).sort()).toEqual(['blocked', 'done', 'idle']);
-
-    // Simulate the agent transitioning to `done` mid-turn — that watcher wins.
-    paneText = 'baseline result';
-    const doneWatcher = cohort.find(w => w.status === 'done')!;
-    doneWatcher.child.emit('exit', 0, null);
-
-    // The win triggered a read+emit.
-    expect(seen).toEqual([' result']);
-
-    // The two losing siblings got killed and a fresh cohort got armed.
-    for (const w of cohort) {
-      if (w !== doneWatcher) expect(w.child.killed).toBe(true);
-    }
-    const nextCohort = waitChildren.slice(cohort.length);
-    expect(nextCohort.map(w => w.status).sort()).toEqual(['blocked', 'done', 'idle']);
-
-    be.kill();
-    // kill() tears down the live cohort.
-    for (const w of nextCohort) expect(w.child.killed).toBe(true);
-  });
-
-  it('status watcher: instant non-zero exit on a vanished agent emits onExit and does NOT re-arm (storm guard)', () => {
-    // Regression for the re-arm storm: on herdr v0.6.6 a `herdr wait
-    // agent-status` against a dead pane returns code 1 IMMEDIATELY. The old
-    // code re-armed synchronously on any non-0 code → a tight spawn loop that
-    // starved the poll timer and the session hung. The fix: an instant
-    // non-zero return triggers a liveness check; a vanished agent (empty
-    // `agent list`) emits onExit instead of re-arming.
-    const waitChildren: Array<{ status: string; child: FakeChild }> = [];
-    mockedSpawn.mockImplementation(((_cmd: any, args: any) => {
-      const child = makeFakeChild();
-      const argv = args as string[];
-      if (argv.includes('wait') && argv.includes('agent-status')) {
-        const statusIdx = argv.indexOf('--status');
-        waitChildren.push({ status: argv[statusIdx + 1]!, child });
-      }
-      return child;
-    }) as any);
-
-    // Agent present at spawn, then GONE (empty list) once it has exited.
-    let agentGone = false;
-    setHerdrResponses([
-      { match: a => a[0] === 'session' && a[1] === 'list', reply: () => EXISTING_SESSION_REPLY },
-      { match: a => a.includes('agent') && a.includes('get'), reply: () => AGENT_GET_REPLY('1-1') },
-      { match: a => a.includes('agent') && a.includes('list'), reply: () => agentGone ? JSON.stringify({ result: { agents: [] } }) : AGENT_LIST_REPLY('1-1') },
-      { match: a => a.includes('read') && (a.includes('agent') || a.includes('pane')), reply: () => PANE_READ_REPLY('x') },
-    ]);
-
-    const be = new HerdrBackend(SESSION, { isReattach: true });
-    const exits: Array<[number | null, string | null]> = [];
-    be.onExit((code, signal) => exits.push([code, signal]));
-    be.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
-
-    const cohort = waitChildren.slice();
-    expect(cohort.length).toBe(3);
-
-    // The agent has now exited; the next `wait` returns code 1 instantly.
-    agentGone = true;
-    cohort.find(w => w.status === 'done')!.child.emit('exit', 1, null);
-
-    // onExit fired (storm guard saw the empty agent list)...
-    expect(exits.length).toBe(1);
-    // ...and NO fresh cohort was armed synchronously (the bug spun new ones).
-    const nextCohort = waitChildren.slice(cohort.length);
-    expect(nextCohort.length).toBe(0);
-
-    be.kill();
+    backend.resize(120, 40);
+    expect(firstObserver.killed).toBe(true);
+    const observerCalls = mockedSpawn.mock.calls.filter(([, args]) =>
+      Array.isArray(args) && args.includes('terminal') && args.includes('observe'));
+    const resizedArgs = observerCalls.at(-1)?.[1];
+    expect(resizedArgs).toContain('120');
+    expect(resizedArgs).toContain('40');
+    const resizedObserver = fakeChildren.at(-1)!;
+    resizedObserver.stdout.write(`${JSON.stringify({
+      type: 'terminal.frame', seq: 1, full: true, encoding: 'ansi', width: 120, height: 40,
+      bytes: Buffer.from('resized baseline').toString('base64'),
+    })}\n`);
+    await waitForImmediate();
+    expect(seen).toEqual(['resized baseline']);
+    backend.kill();
   });
 });

--- a/test/herdr-web-history.test.ts
+++ b/test/herdr-web-history.test.ts
@@ -30,6 +30,55 @@ describe('Herdr web snapshot history', () => {
       .toEqual(['X', 'Y', 'A', 'B', 'C', 'D', 'E', 'FOOTER']);
   });
 
+  it('keeps fixed TUI chrome while inserting newly revealed rows into the scroll region', () => {
+    const initial = mergeHerdrWebSnapshot(
+      null,
+      snapshot(['HEADER', 'A', 'B', 'C', 'FOOTER']),
+      null,
+    );
+    const next = mergeHerdrWebSnapshot(
+      initial.state,
+      snapshot(['HEADER', 'X', 'A', 'B', 'FOOTER']),
+      'up',
+    );
+
+    expect(next.addedLines).toBe(1);
+    expect(next.state.history.map(line => line.replace(/\x1b\[[0-9;]*m/g, '')))
+      .toEqual(['HEADER', 'X', 'A', 'B', 'C', 'FOOTER']);
+  });
+
+  it('handles repeated rows without choosing an ambiguous quadratic overlap', () => {
+    const initial = mergeHerdrWebSnapshot(
+      null,
+      snapshot(['HEADER', 'ROW', 'ROW', 'A', 'B', 'FOOTER']),
+      null,
+    );
+    const next = mergeHerdrWebSnapshot(
+      initial.state,
+      snapshot(['HEADER', 'X', 'ROW', 'ROW', 'A', 'FOOTER']),
+      'up',
+    );
+
+    expect(next.addedLines).toBe(1);
+    expect(next.state.history.map(line => line.replace(/\x1b\[[0-9;]*m/g, '')))
+      .toEqual(['HEADER', 'X', 'ROW', 'ROW', 'A', 'B', 'FOOTER']);
+  });
+
+  it('merges a 10k-line snapshot in bounded linear time', () => {
+    const previous = Array.from({ length: 10_000 }, (_, index) => `LINE-${index}`);
+    const initial = mergeHerdrWebSnapshot(null, snapshot(previous), null);
+    const started = performance.now();
+    const next = mergeHerdrWebSnapshot(
+      initial.state,
+      snapshot(['OLDER', ...previous.slice(0, -1)]),
+      'up',
+    );
+
+    expect(performance.now() - started).toBeLessThan(500);
+    expect(next.addedLines).toBe(1);
+    expect(next.state.history).toHaveLength(10_001);
+  });
+
   it('replaces rather than appends when a live frame has no paging direction', () => {
     const initial = mergeHerdrWebSnapshot(null, snapshot(['A', 'B', 'STATUS old']), null);
     const live = mergeHerdrWebSnapshot(initial.state, snapshot(['A', 'B', 'STATUS new']), null);

--- a/test/max-wait-debouncer.test.ts
+++ b/test/max-wait-debouncer.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MaxWaitDebouncer } from '../src/utils/max-wait-debouncer.js';
+
+afterEach(() => vi.useRealTimers());
+
+describe('MaxWaitDebouncer', () => {
+  it('flushes at max-wait even when events stay closer than the settle window', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const firedAt: number[] = [];
+    const debouncer = new MaxWaitDebouncer(120, 600, () => firedAt.push(Date.now()));
+
+    for (let index = 0; index < 12; index++) {
+      debouncer.schedule();
+      vi.advanceTimersByTime(50);
+    }
+
+    expect(firedAt).toEqual([600]);
+  });
+
+  it('still coalesces a short burst at the trailing settle boundary', () => {
+    vi.useFakeTimers();
+    const callback = vi.fn();
+    const debouncer = new MaxWaitDebouncer(120, 600, callback);
+
+    debouncer.schedule();
+    vi.advanceTimersByTime(50);
+    debouncer.schedule();
+    vi.advanceTimersByTime(119);
+    expect(callback).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+  it('cancels both the settle and max-wait timers', () => {
+    vi.useFakeTimers();
+    const callback = vi.fn();
+    const debouncer = new MaxWaitDebouncer(120, 600, callback);
+
+    debouncer.schedule();
+    debouncer.cancel();
+    vi.advanceTimersByTime(1_000);
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/test/terminal-renderer.test.ts
+++ b/test/terminal-renderer.test.ts
@@ -69,6 +69,20 @@ describe('TerminalRenderer width matches source pane', () => {
     r160.dispose();
   });
 
+  it('replaces an old reattach seed with a full observer baseline', async () => {
+    const renderer = new TerminalRenderer(20, 4);
+    await writeAndFlush(renderer, 'OLD-1\r\nOLD-2\r\nOLD-3\r\nOLD-4\r\nOLD-5');
+
+    renderer.replace('\x1b[2J\x1b[HBASE-1\r\nBASE-2', 30, 6);
+    await writeAndFlush(renderer, '');
+
+    expect(renderer.xterm.cols).toBe(30);
+    expect(renderer.xterm.rows).toBe(6);
+    expect(renderer.rawSnapshot()).toContain('BASE-1');
+    expect(renderer.rawSnapshot()).not.toContain('OLD-5');
+    renderer.dispose();
+  });
+
   it('snapshot reads past the old 160-col clamp on a 270-col renderer', async () => {
     // Live failure: snapshot was clamped at 160 cols regardless of the
     // renderer's actual width, silently dropping any pane content past

--- a/test/web-terminal-initial-follow.test.ts
+++ b/test/web-terminal-initial-follow.test.ts
@@ -6,7 +6,7 @@ const workerSource = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
 
 describe('web terminal initial viewport follow', () => {
   it('settles the first asynchronous xterm write burst at the bottom', () => {
-    expect(workerSource).toContain('term.write(data,_settleInitialBottom)');
+    expect(workerSource).toContain('_queueTermWrite(data,false,_settleInitialBottom)');
     expect(workerSource).toMatch(
       /function _settleInitialBottom\(\)\{[\s\S]*?term\.scrollToBottom\(\)[\s\S]*?setTimeout\(function\(\)\{[\s\S]*?term\.scrollToBottom\(\)[\s\S]*?_initialFollow=false;/,
     );

--- a/test/web-terminal-touch-scroll.test.ts
+++ b/test/web-terminal-touch-scroll.test.ts
@@ -39,6 +39,10 @@ describe('web terminal touch scrolling', () => {
       .toBeLessThan(wheelBlock.indexOf('_fwdScroll(px,_cellAt'));
   });
 
+  it('refreshes captured history after every later native output burst', () => {
+    expect(workerSource).toContain("if (herdrWebRenderMode === 'frame') relayHerdrWebDelta(frame.data);\n  else scheduleHerdrWebSnapshot(be);");
+  });
+
   it('bounds remote scroll ticks per gesture instead of per browser event', () => {
     const wheelBlock = scriptBlock('// ── Wheel / touch scroll handling ──');
 
@@ -62,8 +66,8 @@ describe('web terminal touch scrolling', () => {
   it('replaces merged Herdr history and preserves the reader anchor', () => {
     expect(workerSource).toContain('1989;history;${merged.addedLines}');
     expect(workerSource).toContain("var _hh=data.match(/^\\x1b\\]1989;history;([0-9]+)\\x07/)");
-    expect(workerSource).toContain('data=data.slice(_hh[0].length);_cancelInitialFollow();term.reset();term.clear()');
-    expect(workerSource).toContain("data='\\\\x1b[2J\\\\x1b[H'+data");
+    expect(workerSource).toContain("_queueTermWrite('\\\\x1b[2J\\\\x1b[H'+_hd,true");
+    expect(workerSource).toContain('if(job.replace){term.reset();term.clear()}');
     expect(workerSource).toContain('if(_ha>0)term.scrollToLine(_hy+_ha)');
   });
 

--- a/test/worker-herdr-web-terminal.e2e.ts
+++ b/test/worker-herdr-web-terminal.e2e.ts
@@ -12,6 +12,7 @@ import { join, resolve } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { WebSocket } from 'ws';
 import { HerdrBackend } from '../src/adapters/backend/herdr-backend.js';
+import { TerminalRenderer } from '../src/utils/terminal-renderer.js';
 import type { DaemonToWorker, WorkerToDaemon } from '../src/types.js';
 
 const children = new Set<ChildProcess>();
@@ -121,6 +122,15 @@ function agentPaneId(sessionName: string): string {
   return paneId;
 }
 
+function terminalBufferText(renderer: TerminalRenderer): string {
+  const buffer = renderer.xterm.buffer.active;
+  const lines: string[] = [];
+  for (let index = 0; index < buffer.length; index++) {
+    lines.push(buffer.getLine(index)?.translateToString(true) ?? '');
+  }
+  return lines.join('\n');
+}
+
 describe('worker Herdr web terminal lifecycle', () => {
   it.skipIf(!HerdrBackend.isAvailable())(
     'restores the connected browser grid automatically after an in-worker restart',
@@ -158,6 +168,8 @@ while :; do sleep 0.1; done
       child.send(init);
       const ready = await waitForReady(child, logs);
       const ws = await openWriteWebSocket(ready);
+      let received = '';
+      ws.on('message', data => { received += data.toString(); });
       ws.send(JSON.stringify({ type: 'resize', cols: 120, rows: 36 }));
 
       const before = await waitFor(() => {
@@ -178,6 +190,12 @@ while :; do sleep 0.1; done
 
       expect(after.pid).not.toBe(before.pid);
       expect(after.size).toBe('36 120');
+      await waitFor(
+        () => received.includes('\x1b]1989;frame\x07'),
+        5_000,
+        'observer full frame reaches browser after resize',
+      );
+      expect(received).toContain('\x1b]1989;frame\x07');
       expect(ws.readyState).toBe(WebSocket.OPEN);
       ws.close();
       child.send({ type: 'close' } satisfies DaemonToWorker);
@@ -186,18 +204,21 @@ while :; do sleep 0.1; done
   );
 
   it.skipIf(!HerdrBackend.isAvailable())(
-    'streams live snapshots from an adopted external Herdr pane',
+    'streams live native frames from an adopted external Herdr pane',
     async () => {
       const root = mkdtempSync(join(tmpdir(), 'botmux-herdr-adopt-'));
       tempDirs.add(root);
       const trigger = join(root, 'emit-live');
+      const busyDone = join(root, 'emit-live-done');
       const externalSession = `adopt-e2e-${Date.now().toString(36)}`;
       sessions.add(externalSession);
       const external = new HerdrBackend(externalSession);
       external.spawn('/bin/bash', [
         '-lc',
-        `echo ADOPT_INITIAL; while [ ! -f '${trigger}' ]; do sleep 0.1; done; `
-        + 'echo ADOPT_LIVE_UPDATE; while :; do sleep 1; done',
+        `for i in $(seq -w 1 40); do echo HISTORY-$i; done; echo ADOPT_INITIAL; `
+        + `while [ ! -f '${trigger}' ]; do sleep 0.1; done; `
+        + 'for i in $(seq -w 1 40); do echo ADOPT_LIVE_UPDATE-$i; sleep 0.05; done; '
+        + `touch '${busyDone}'; while :; do sleep 1; done`,
       ], {
         cwd: root,
         cols: 100,
@@ -209,6 +230,11 @@ while :; do sleep 0.1; done
         10_000,
         'external pane initial marker',
       );
+      // The fixture backend only starts the external pane. Detach its observer
+      // before the worker adopts the pane: Herdr currently exposes one native
+      // terminal observer stream per pane session.
+      external.kill();
+      await new Promise(resolvePromise => setTimeout(resolvePromise, 500));
 
       const sessionId = `hradp${Date.now().toString(36)}`;
       const logs: string[] = [];
@@ -236,23 +262,72 @@ while :; do sleep 0.1; done
       child.send(init);
       const ready = await waitForReady(child, logs);
       const ws = await openWriteWebSocket(ready);
-      let received = '';
-      ws.on('message', data => { received += data.toString(); });
+      const rendered = new TerminalRenderer(100, 30);
+      const messages: string[] = [];
+      let liveOutputStarted = false;
+      let historyRefreshedWhileBusy = false;
+      ws.on('message', raw => {
+        let data = raw.toString();
+        messages.push(data);
+        if (
+          liveOutputStarted
+          && data.startsWith('\x1b]1989;history;')
+          && data.includes('ADOPT_LIVE_UPDATE')
+          && !existsSync(busyDone)
+        ) historyRefreshedWhileBusy = true;
+        const marker = data.match(/^\x1b\]1989;(?:frame|history;\d+)\x07/);
+        if (marker) {
+          data = data.slice(marker[0].length);
+          rendered.replace(data, 100, 30);
+        } else {
+          rendered.write(data);
+        }
+      });
       await waitFor(
-        () => received.includes('ADOPT_INITIAL'),
+        () => terminalBufferText(rendered).includes('ADOPT_INITIAL'),
         5_000,
-        'adopt initial screen seed',
+        'adopt observer full viewport',
       );
 
-      received = '';
+      // Enter line-history mode through the same mouse-wheel packet used by
+      // the browser. Subsequent native CUP/grid deltas are intentionally not
+      // applied to that coordinate space, so each output burst must schedule
+      // a fresh explicit capture instead of leaving the browser frozen.
+      ws.send(JSON.stringify({ type: 'input', data: '\x1b[<64;1;1M' }));
+      await waitFor(
+        () => messages.some(message => message.startsWith('\x1b]1989;history;')),
+        5_000,
+        'remote scroll enters captured history mode',
+      );
+      const historyMessagesBeforeLive = messages.filter(message =>
+        message.startsWith('\x1b]1989;history;')).length;
+
+      liveOutputStarted = true;
       writeFileSync(trigger, 'go');
       await waitFor(
-        () => received.includes('ADOPT_LIVE_UPDATE'),
+        () => external.captureCurrentScreen().includes('ADOPT_LIVE_UPDATE'),
         5_000,
-        'adopt live snapshot relay',
+        'external pane live marker',
       );
+      try {
+        await waitFor(
+          () => messages.filter(message => message.startsWith('\x1b]1989;history;')).length
+              > historyMessagesBeforeLive
+            && rendered.rawSnapshot().includes('ADOPT_LIVE_UPDATE')
+            && historyRefreshedWhileBusy,
+          5_000,
+          '50ms continuous output refreshes history before the stream becomes quiet',
+        );
+      } catch (error) {
+        throw new Error(
+          `${error instanceof Error ? error.message : String(error)}\n${logs.join('')}`
+          + `\nterminal=${JSON.stringify(terminalBufferText(rendered))}`
+          + `\nlast-message=${JSON.stringify(messages.at(-1)?.slice(-2000))}`,
+        );
+      }
 
-      expect(received).toContain('ADOPT_LIVE_UPDATE');
+      expect(rendered.rawSnapshot()).toContain('ADOPT_LIVE_UPDATE');
+      rendered.dispose();
       ws.close();
       child.send({ type: 'close' } satisfies DaemonToWorker);
       external.destroySession();

--- a/test/worker-pipe-initial-screen-order.test.ts
+++ b/test/worker-pipe-initial-screen-order.test.ts
@@ -207,15 +207,18 @@ describe('worker pipe initial screen ordering', () => {
     expect(herdrBlock).toContain('herdrBe.cliCwd');
   });
 
-  it('wires Herdr adopt snapshots before seeding the initial screen', () => {
+  it('wires Herdr adopt native frames without a duplicate capture seed', () => {
     const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
     const herdrStart = source.indexOf("cfg.adoptSource === 'herdr'");
     const herdrEnd = source.indexOf("log(`Adopt mode (herdr):", herdrStart);
     const herdrBlock = source.slice(herdrStart, herdrEnd);
 
+    const frameIdx = herdrBlock.indexOf('herdrBe.onTerminalFrame(');
     const relayIdx = herdrBlock.indexOf('wireHerdrWebTerminalRelays(herdrBe);');
     const seedIdx = herdrBlock.indexOf("seedBackendScreen('herdr adopt', herdrBe);");
+    expect(frameIdx).toBeGreaterThan(-1);
+    expect(relayIdx).toBeGreaterThan(frameIdx);
     expect(relayIdx).toBeGreaterThan(-1);
-    expect(seedIdx).toBeGreaterThan(relayIdx);
+    expect(seedIdx).toBe(-1);
   });
 });


### PR DESCRIPTION
## 改了什么

- 将 Herdr 终端输出从 500ms 轮询切换为 `terminal session observe` 原生 NDJSON 流，并保留 full/delta/seq/尺寸语义。
- 在已合并的 #419 Web 终端能力上统一 managed `agent attach` 尺寸 ownership、光标、历史合并和 `/restart` 重绑定。
- 修复 full frame 被当增量追加、observer 槽位冲突误报退出、pendingData 无界增长、history 持续输出冻结等问题。
- 历史抓取改为 120ms settle + 600ms max-wait 的串行调度；无人观看时停止抓取，重连后主动刷新。
- 页面 xterm 写入/reset 串行化，WebSocket 增加背压与 resync。
- Herdr 最低版本门槛为 0.7.2，并脱敏计划文档里的内部地址。

## 为什么

PR #484 的原生流方向与已合并 #419 的 Web 终端实现存在强实现冲突。直接按序合并会破坏 scrollback、历史快照与 resize 生命周期。本 PR 在最新 master 上给出经两轮独立审查后的统一实现，作为 #484 的整合替代版本。

## 影响面

- Herdr 后端：spawn / reattach / adopt / reconnect / resize / exit 判活全链路。
- Web terminal：Herdr 历史、光标、触控滚动、重连；页面写队列的等价序列化同时覆盖 Pty/Tmux。
- 其它 CLI 与非 Herdr 后端仍走原 `onData` 路径。

## 验证

- `pnpm build`
- `TZ=Asia/Shanghai pnpm test`：583 files，9324/9324
- `pnpm vitest run test/herdr-backend.e2e.ts test/worker-herdr-web-terminal.e2e.ts`：11/11（真实 Herdr 0.7.3）
- Claude 三轮独立 review：最终 Approve，所有 P2/blocker 已关闭
