### PR TITLE
feat(relay): 私聊↔群聊接力补全 — picker 搜「单聊」可命中（真实反馈根因）+ 私聊 --create solo 接力

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -20,7 +20,7 @@ import { computeSandboxDiff } from '../services/sandbox-land.js';
 import { handleDashboardCommand } from './dashboard-command/index.js';
 import { createCliAdapterSync } from '../adapters/cli/registry.js';
 import type { CliId, ResumableSession } from '../adapters/cli/types.js';
-import { deleteMessage, sendMessage, sendUserMessage, listChatBotMembers, resolveUserUnionId, getChatModeStrict, uploadFile, UserTokenMissingError } from '../im/lark/client.js';
+import { deleteMessage, sendMessage, sendUserMessage, replyMessage, listChatBotMembers, resolveUserUnionId, getChatModeStrict, uploadFile, UserTokenMissingError } from '../im/lark/client.js';
 import { chatAppLink, normalizeBrand } from '../im/lark/lark-hosts.js';
 import { claimPairing } from '../services/pairing-store.js';
 import { logger } from '../utils/logger.js';
@@ -2608,6 +2608,33 @@ export async function handleCommand(
           });
           const targetScope = targetRouting.scope;
           const targetAnchor = targetRouting.anchor;
+          // ── Reply WHERE the user typed /relay ─────────────────────────────
+          // Not through sessionReply: in chat-scope groups (普通群扁平 /
+          // chat-topic / shared) that path either leaks to the chat top level
+          // (the /relay scratch has no turn state to fold back into) or lands
+          // in the CURRENT turn's 话题 (a real chat-scope session) — both away
+          // from the 话题 the user invoked in (申晗 live 反馈). The target
+          // routing already encodes the invocation spot:
+          //   thread → reply_in_thread into that 话题 (for 话题群 / DM-thread
+          //            top-level this seeds the 话题 on the /relay message —
+          //            same place the relayed session will land);
+          //   chat   → quote-reply the /relay message at the top level.
+          // Fallback to sessionReply if the reply API refuses (e.g. the
+          // command message was withdrawn mid-flight).
+          const replyAtInvocation = async (content: string, msgType?: string): Promise<void> => {
+            try {
+              await replyMessage(
+                myAppId,
+                targetScope === 'thread' ? targetAnchor : message.messageId,
+                content,
+                msgType ?? 'text',
+                /*replyInThread*/ targetScope === 'thread',
+              );
+            } catch (err) {
+              logger.warn(`[${logTag}] /relay reply-at-invocation failed (${err instanceof Error ? err.message : err}); falling back to sessionReply`);
+              await sessionReply(rootId, content, msgType);
+            }
+          };
           // ── Existing-session guard (anchor-based) ─────────────────────────
           // A real session already sitting AT the target anchor would collide
           // on sessionKey(targetAnchor, larkAppId) after transfer — Map.set
@@ -2623,7 +2650,7 @@ export async function handleCommand(
             && !!c.worker   // real running session, not a placeholder
           );
           if (conflict) {
-            await sessionReply(rootId, t('cmd.relay.target_has_session', { title: conflict.session.title || conflict.session.sessionId.substring(0, 8) }, loc));
+            await replyAtInvocation(t('cmd.relay.target_has_session', { title: conflict.session.title || conflict.session.sessionId.substring(0, 8) }, loc));
             break;
           }
           // Shared candidate-collection logic — used here at initial render
@@ -2635,7 +2662,7 @@ export async function handleCommand(
           const entries = await collectRelayPickerEntries(activeSessions, myAppId, targetAnchor, operatorOpenId);
           const { buildRelayPickerCard } = await import('../im/lark/card-builder.js');
           const card = buildRelayPickerCard(entries, targetChatId, targetAnchor, operatorOpenId, loc, undefined, targetScope, targetChatType);
-          await sessionReply(rootId, card, 'interactive');
+          await replyAtInvocation(card, 'interactive');
           break;
         }
         const afterFlag = argsLine.replace(/^--create\s*/i, '').trim();

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -2521,6 +2521,11 @@ export async function handleCommand(
        * the @-mentioned bots, then migrate every bot's session in this
        * thread (including the leader's) into the new chat.
        *
+       * p2p (私聊) variant: `/relay --create [群名]` with NO mentions — DMs
+       * have no member roster so @-ing a bot is impossible there. The bot
+       * itself is the sole participant and leader; the new group is user +
+       * this bot, and the DM session migrates over (solo relay, no peers).
+       *
        * Two-path command:
        *   • `--create` (PR2) — implemented below; creates a new chat.
        *   • no flag (PR3)    — picker card listing user's relayable sessions
@@ -2673,32 +2678,41 @@ export async function handleCommand(
           break;
         }
 
+        // ── p2p (私聊) solo relay: no mention gate, no leader election ──────
+        // 飞书私聊里 @ 不到任何机器人（DM 没有成员列表），mention 门与 leader
+        // 选举在这里没有意义 —— 本 bot 就是唯一参与者兼 leader，新群 = 用户 +
+        // 本 bot，无 peer 协调（peerAppIds 自然为空）。群聊路径语义不变。
+        // chatType 取自 ds（会话创建时从 Lark 事件记录，权威、不漂移）。
+        const sourceIsP2p = ds.chatType === 'p2p';
+
         // ── Mention parsing & leader election (mirror of /group) ───────────
         const mentions = message.mentions ?? [];
         const knownBotNames = globalKnownBotNames();
-        if (knownBotNames.size === 0 && mentions.some(m => !!m.name)) {
-          logger.warn(`[${logTag}] /relay --create: global bot registry empty; cannot elect a creator`);
-          await sessionReply(rootId, t('cmd.relay.resolve_failed', undefined, loc));
-          break;
-        }
-        const botMentions = mentions.filter(m => m.name && knownBotNames.has(m.name.toLowerCase()));
-        if (botMentions.length === 0) {
-          await sessionReply(rootId, t('cmd.relay.no_mentions', undefined, loc));
-          break;
-        }
+        const botMentions = sourceIsP2p ? [] : mentions.filter(m => m.name && knownBotNames.has(m.name.toLowerCase()));
+        if (!sourceIsP2p) {
+          if (knownBotNames.size === 0 && mentions.some(m => !!m.name)) {
+            logger.warn(`[${logTag}] /relay --create: global bot registry empty; cannot elect a creator`);
+            await sessionReply(rootId, t('cmd.relay.resolve_failed', undefined, loc));
+            break;
+          }
+          if (botMentions.length === 0) {
+            await sessionReply(rootId, t('cmd.relay.no_mentions', undefined, loc));
+            break;
+          }
 
-        // Am I `mentions[0]`?
-        const firstBot = botMentions[0];
-        const myOpenId = getBotOpenId(creatorAppId);
-        const myName = getBot(creatorAppId).botName?.toLowerCase();
-        const myNameAmbiguous = !!myName
-          && botMentions.filter(m => m.name?.toLowerCase() === myName).length > 1;
-        const iAmFirstBot =
-          (!!myOpenId && firstBot.openId === myOpenId) ||
-          (!myOpenId && !!myName && !myNameAmbiguous && firstBot.name?.toLowerCase() === myName);
-        if (!iAmFirstBot) {
-          logger.info(`[${logTag}] /relay --create: not the first @-mentioned bot, staying silent`);
-          break;
+          // Am I `mentions[0]`?
+          const firstBot = botMentions[0];
+          const myOpenId = getBotOpenId(creatorAppId);
+          const myName = getBot(creatorAppId).botName?.toLowerCase();
+          const myNameAmbiguous = !!myName
+            && botMentions.filter(m => m.name?.toLowerCase() === myName).length > 1;
+          const iAmFirstBot =
+            (!!myOpenId && firstBot.openId === myOpenId) ||
+            (!myOpenId && !!myName && !myNameAmbiguous && firstBot.name?.toLowerCase() === myName);
+          if (!iAmFirstBot) {
+            logger.info(`[${logTag}] /relay --create: not the first @-mentioned bot, staying silent`);
+            break;
+          }
         }
 
         // Owner-only — only the source session owner may relay this session.
@@ -2708,33 +2722,39 @@ export async function handleCommand(
         }
 
         // ── Resolve @-bots to larkAppIds via the source chat's bot roster ──
+        // p2p: 跳过成员表解析（DM 没有 bot roster，listChatBotMembers 会失败），
+        // 参与者就是本 bot 自己；名字兜底走 botDisplayName（nameOf）。
         const sourceChatId = ds.chatId;
-        let members: Awaited<ReturnType<typeof listChatBotMembers>> = [];
-        try {
-          members = await listChatBotMembers(creatorAppId, sourceChatId);
-        } catch (e: any) {
-          logger.warn(`[${logTag}] /relay --create: failed to list source chat members: ${e?.message ?? e}`);
-        }
-        const memberByOpenId = new Map(members.map(m => [m.openId, m]));
         const appIdToName = new Map<string, string>();
-        for (const m of members) {
-          if (m.larkAppId && m.displayName) appIdToName.set(m.larkAppId, m.displayName);
-        }
         const mentionedBotAppIds: string[] = [];
-        const seenApp = new Set<string>();
-        let unresolved: string | undefined;
-        for (const bm of botMentions) {
-          const mem = bm.openId ? memberByOpenId.get(bm.openId) : undefined;
-          if (!mem || !mem.larkAppId) { unresolved = bm.name; break; }
-          if (!seenApp.has(mem.larkAppId)) {
-            seenApp.add(mem.larkAppId);
-            mentionedBotAppIds.push(mem.larkAppId);
+        if (sourceIsP2p) {
+          mentionedBotAppIds.push(creatorAppId);
+        } else {
+          let members: Awaited<ReturnType<typeof listChatBotMembers>> = [];
+          try {
+            members = await listChatBotMembers(creatorAppId, sourceChatId);
+          } catch (e: any) {
+            logger.warn(`[${logTag}] /relay --create: failed to list source chat members: ${e?.message ?? e}`);
           }
-        }
-        if (unresolved) {
-          logger.warn(`[${logTag}] /relay --create: unresolved bot "${unresolved}"`);
-          await sessionReply(rootId, t('cmd.relay.resolve_failed', undefined, loc));
-          break;
+          const memberByOpenId = new Map(members.map(m => [m.openId, m]));
+          for (const m of members) {
+            if (m.larkAppId && m.displayName) appIdToName.set(m.larkAppId, m.displayName);
+          }
+          const seenApp = new Set<string>();
+          let unresolved: string | undefined;
+          for (const bm of botMentions) {
+            const mem = bm.openId ? memberByOpenId.get(bm.openId) : undefined;
+            if (!mem || !mem.larkAppId) { unresolved = bm.name; break; }
+            if (!seenApp.has(mem.larkAppId)) {
+              seenApp.add(mem.larkAppId);
+              mentionedBotAppIds.push(mem.larkAppId);
+            }
+          }
+          if (unresolved) {
+            logger.warn(`[${logTag}] /relay --create: unresolved bot "${unresolved}"`);
+            await sessionReply(rootId, t('cmd.relay.resolve_failed', undefined, loc));
+            break;
+          }
         }
 
         // ── Group name extraction (mirror of /group) ───────────────────────
@@ -2798,10 +2818,14 @@ export async function handleCommand(
 
         // Resolve friendly source-chat label for the M1 body — falls back to
         // raw chatId if Lark can't return a name. Mirrors picker-path
-        // (card-handler.ts:341) so the message reads the same in both UX
-        // entry points.
+        // (card-handler.ts relay_confirm) so the message reads the same in
+        // both UX entry points; p2p source has no chat name (chat.get often
+        // fails/returns empty for DMs) — use the locale-aware 单聊 label
+        // instead of leaking a raw oc_ id into the M1.
         const { getChatName } = await import('../im/lark/client.js');
-        const sourceLabel = (await getChatName(creatorAppId, sourceChatId).catch(() => null)) ?? sourceChatId;
+        const sourceLabel = sourceIsP2p
+          ? t('card.relay.type_p2p', undefined, loc)
+          : (await getChatName(creatorAppId, sourceChatId).catch(() => null)) ?? sourceChatId;
 
         // ── Step 1: leader transfers its own session (if any) ───────────────
         // Empty-leader handling: daemon auto-creates a placeholder ds for any

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -512,7 +512,7 @@ export const messages: Record<string, string> = {
   'help.heading_collab': '🤝 Multi-bot collaboration:',
   'help.introduce': '/introduce          - Register the bots in this chat with each other by open_id for precise collaboration mentions',
   'help.relay': '/relay              - Pick a live session from another chat/topic and relay it into the current chat/topic',
-  'help.relay_create': '/relay --create [name] - Create a collaboration group and relay the current session there (mention target bots)',
+  'help.relay_create': '/relay --create [name] - Create a collaboration group and relay the current session there (mention target bots in a group; in a DM just send it — new group = you + this bot)',
   'help.heading_login': '🔐 User OAuth:',
   'help.login': '/login              - Lark user OAuth (lets you download images etc. from third-party cards)',
   'help.login_status': '/login status       - Show auth status',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -163,7 +163,7 @@ export const messages: Record<string, string> = {
   // ─── /relay picker card (pull mode) ─────────────────────────────────────
   'card.relay.title': '📋 Pick a session to relay into this chat',
   'card.relay.title_p2p': '📋 Pick a session to relay into this DM',
-  'card.relay.empty': 'No relayable sessions.\n(Picker only lists sessions you own, on this bot, in other chats.)',
+  'card.relay.empty': 'No relayable sessions.\n(Only your **active** sessions on this bot are listed — including DMs (shown as "direct message"); closed sessions do not appear.)',
   'card.relay.btn_pull': 'Pull into this chat',
   'card.relay.btn_confirm': 'Confirm relay into this chat',
   'card.relay.btn_confirm_p2p': 'Confirm relay into this DM',
@@ -173,7 +173,7 @@ export const messages: Record<string, string> = {
   'card.relay.status_idle': '⚪ Idle',
   'card.relay.selected_tag': 'selected',
   'card.relay.hint_pick_first': 'Tap any session above to select it, then press Confirm to relay.',
-  'card.relay.search_placeholder': '🔍 Search sessions (title / chat / path)',
+  'card.relay.search_placeholder': '🔍 Search sessions (title / chat / path; try "dm" for direct messages)',
   'card.relay.btn_search': 'Search',
   'card.relay.btn_prev_page': '← Prev',
   'card.relay.btn_next_page': 'Next →',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -515,7 +515,7 @@ export const messages: Record<string, string> = {
   'help.heading_collab': '🤝 多机器人协作：',
   'help.introduce': '/introduce          - 让本群机器人互相登记 open_id，用于协作时精确 @ 对方',
   'help.relay': '/relay              - 选择一个其他群/话题里的活跃会话，接力到当前群/话题',
-  'help.relay_create': '/relay --create [群名]  - 新建协作群，并把当前会话接力过去（需 @ 目标 bot）',
+  'help.relay_create': '/relay --create [群名]  - 新建协作群，并把当前会话接力过去（群里需 @ 目标 bot；私聊直接发即可，新群 = 你 + 本机器人）',
   'help.heading_login': '🔐 用户授权：',
   'help.login': '/login              - 飞书用户授权（可下载第三方卡片图片等）',
   'help.login_status': '/login status       - 查看授权状态',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -166,7 +166,7 @@ export const messages: Record<string, string> = {
   // ─── /relay picker card (pull mode) ─────────────────────────────────────
   'card.relay.title': '📋 选择要接力到本群的会话',
   'card.relay.title_p2p': '📋 选择要接力到本单聊的会话',
-  'card.relay.empty': '当前没有可接力的会话。\n（picker 只列你作为 owner、同一机器人在其他群里的活跃会话。）',
+  'card.relay.empty': '当前没有可接力的会话。\n（只列同一机器人下你自己的**活跃**会话——含私聊（位置显示为「单聊」）；已关闭的会话不会出现。）',
   'card.relay.btn_pull': '接力到本群',
   'card.relay.btn_confirm': '确认接力到本群',
   'card.relay.btn_confirm_p2p': '确认接力到本单聊',
@@ -176,7 +176,7 @@ export const messages: Record<string, string> = {
   'card.relay.status_idle': '⚪ 空闲',
   'card.relay.selected_tag': '已选中',
   'card.relay.hint_pick_first': '点击上方任意会话以选中，然后再点确认按钮触发接力。',
-  'card.relay.search_placeholder': '🔍 搜索会话（标题/群名/路径）',
+  'card.relay.search_placeholder': '🔍 搜索会话（标题/群名/路径；搜「单聊」找私聊）',
   'card.relay.btn_search': '搜索',
   'card.relay.btn_prev_page': '← 上一页',
   'card.relay.btn_next_page': '下一页 →',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -1522,15 +1522,25 @@ export interface RelayPickerState {
 const RELAY_PICKER_PAGE_SIZE = 5;
 const RELAY_SEARCH_FIELD = 'search';
 
+/** Search aliases appended to a p2p entry's haystack so searching by the
+ *  RENDERED location label finds it. A p2p entry's chatLabel carries the raw
+ *  DM chatId (an oc_ opaque id — never shown), while the card renders the
+ *  localized `card.relay.type_p2p` literal instead; without these aliases,
+ *  typing the label the user actually SEES (「单聊」) returned「没有匹配」.
+ *  Covers both locales' literals plus common synonyms so the filter stays
+ *  locale-agnostic. Keep in sync with the `card.relay.type_p2p` i18n values. */
+const RELAY_P2P_SEARCH_ALIASES = '单聊 私聊 p2p dm direct message';
+
 /**
  * Match against title / chatLabel / workingDir / cliId. Case-insensitive
- * substring. Empty / whitespace query matches everything.
+ * substring. Empty / whitespace query matches everything. p2p entries also
+ * match their rendered location label via RELAY_P2P_SEARCH_ALIASES.
  */
 function relayPickerFilter(entries: RelayPickerEntry[], query: string | undefined): RelayPickerEntry[] {
   const q = (query ?? '').trim().toLowerCase();
   if (!q) return entries;
   return entries.filter((e) => {
-    const haystack = [e.title, e.chatLabel, e.workingDir, e.cliId]
+    const haystack = [e.title, e.chatLabel, e.workingDir, e.cliId, e.chatMode === 'p2p' ? RELAY_P2P_SEARCH_ALIASES : undefined]
       .filter(Boolean)
       .join(' ')
       .toLowerCase();

--- a/test/card-builder.test.ts
+++ b/test/card-builder.test.ts
@@ -1233,6 +1233,26 @@ describe('buildRelayPickerCard', () => {
     expect(allMd).toMatch(/没有匹配|No sessions match/);
   });
 
+  // Regression (申晗现场): a p2p entry's chatLabel is the raw DM chatId while
+  // the card RENDERS the「单聊」literal — searching by the label the user sees
+  // must find the entry, not return「没有匹配」. The DM was also buried on
+  // page ~6 of 38 sessions, so search is the only realistic way to reach it.
+  it('search by the rendered p2p location label (单聊/私聊/dm) finds DM entries', () => {
+    const entries: RelayPickerEntry[] = [
+      { sessionId: 's-dm', chatLabel: 'oc_raw_dm_chat_id', title: '看一下Master分支', chatMode: 'p2p', workingDir: '/work/api' },
+      { sessionId: 's-grp', chatLabel: 'Project Alpha', title: 'PR review', chatMode: 'group', workingDir: '/work/api' },
+    ];
+    for (const q of ['单聊', '私聊', 'dm', 'p2p']) {
+      const card = parse(buildRelayPickerCard(entries, 'oc_t', 'om_r', 'ou_invoker_test', undefined, { searchQuery: q }));
+      const c = containers(card);
+      expect(c, `query "${q}" should match the DM entry`).toHaveLength(1);
+      expect(c[0].behaviors[0].value.session_id).toBe('s-dm');
+    }
+    // Group entries must NOT gain the aliases — searching 单聊 excludes them.
+    const grpOnly = parse(buildRelayPickerCard(entries.slice(1), 'oc_t', 'om_r', 'ou_invoker_test', undefined, { searchQuery: '单聊' }));
+    expect(containers(grpOnly)).toHaveLength(0);
+  });
+
   it('selection highlights the chosen card and appends a confirm button', () => {
     const card = parse(buildRelayPickerCard(fixtureEntries(3), 'oc_t', 'om_r', 'ou_invoker_test', undefined, { selectedSessionId: 'sess-2' }));
     const c = containers(card);

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -229,6 +229,10 @@ vi.mock('../src/im/lark/client.js', () => ({
   },
   deleteMessage: vi.fn(),
   sendMessage: vi.fn(async () => 'card-msg-id'),
+  // /relay picker replies land anchored at the invocation message / 话题 via
+  // replyMessage (reply-at-invocation), not sessionReply. Args mirror the
+  // real signature: (appId, messageId, content, msgType, replyInThread).
+  replyMessage: vi.fn(async () => 'picker-card-msg-id'),
   listChatBotMembers: vi.fn(async () => []),
   // Tests can override per-scenario via vi.mocked(getChatName).mockResolvedValue(...).
   // Default returns null so picker entries fall back to raw chatId.
@@ -450,7 +454,7 @@ import { getSessionWorkingDir, buildNewTopicPrompt, buildNewTopicCliInput, ensur
 import * as sessionStore from '../src/services/session-store.js';
 import * as scheduleStore from '../src/services/schedule-store.js';
 import * as scheduler from '../src/core/scheduler.js';
-import { deleteMessage, sendMessage, listChatBotMembers, UserTokenMissingError } from '../src/im/lark/client.js';
+import { deleteMessage, sendMessage, replyMessage, listChatBotMembers, UserTokenMissingError } from '../src/im/lark/client.js';
 import { buildSlashListCard, buildSessionClosedCard } from '../src/im/lark/card-builder.js';
 import { createGroupWithBots } from '../src/services/group-creator.js';
 import { getAllBots, getBot, findOncallChat, effectiveDefaultWorkingDir } from '../src/bot-registry.js';
@@ -3101,9 +3105,14 @@ describe('handleCommand', () => {
 
       await handleCommand('/relay', ROOT_ID, makeLarkMessage('/relay'), deps, LARK_APP_ID);
 
-      // Reply was an interactive card (msgType='interactive') with v2 schema.
-      const [, replyContent, msgType] = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0];
+      // The card is anchored at the invocation: flat 普通群 (default 'chat'
+      // mode) → quote-reply of the /relay message, NOT reply_in_thread, NOT
+      // sessionReply (which folds into the session's turn topic / top level).
+      const [, anchorMsgId, replyContent, msgType, inThread] = vi.mocked(replyMessage).mock.calls[0];
+      expect(anchorMsgId).toBe('msg_001');
+      expect(inThread).toBe(false);
       expect(msgType).toBe('interactive');
+      expect(deps.sessionReply).not.toHaveBeenCalled();
       const card = JSON.parse(replyContent as string);
       const containers = card.body.elements.filter((e: any) => e.tag === 'interactive_container');
       expect(containers).toHaveLength(1);
@@ -3113,6 +3122,57 @@ describe('handleCommand', () => {
       expect(cb.value.session_id).toBe('sess-other');
       expect(cb.value.target_chat_id).toBe(CHAT_ID);
       expect(mockedCreate).not.toHaveBeenCalled();
+    });
+
+    // Regression (申晗 live 反馈): /relay typed INSIDE a 话题 of a chat-mode
+    // 普通群 rendered the picker at the chat TOP LEVEL — the command routed to
+    // the chat-scope session (scratch, no turn state), so sessionReply's
+    // fold-back had nothing to anchor on and fell through to sendMessage.
+    // The card must instead reply_in_thread into the 话题 the user typed in
+    // (= the thread target the routing already computed).
+    it('picker card replies INTO the 话题 when /relay is typed inside a thread of a chat-mode group', async () => {
+      const ds = makeDaemonSession({ session: makeSession({ ownerOpenId: 'ou_sender', scope: 'chat' }), scope: 'chat' });
+      const otherDs: DaemonSession = {
+        ...makeDaemonSession(),
+        session: makeSession({
+          sessionId: 'sess-other',
+          chatId: 'oc_other',
+          rootMessageId: 'om_other_root',
+          title: 'other task',
+          ownerOpenId: 'ou_sender',
+        }),
+        chatId: 'oc_other',
+      };
+      const deps = makeDeps(ds);
+      deps.activeSessions.set(sessionKey('om_other_root', LARK_APP_ID), otherDs);
+
+      await handleCommand('/relay', ROOT_ID, makeLarkMessage('/relay', {
+        rootId: 'om_topic_root_x',
+        threadId: 'omt_thread_x',
+      }), deps, LARK_APP_ID);
+
+      const [, anchorMsgId, replyContent, msgType, inThread] = vi.mocked(replyMessage).mock.calls[0];
+      expect(anchorMsgId).toBe('om_topic_root_x');
+      expect(inThread).toBe(true);
+      expect(msgType).toBe('interactive');
+      expect(deps.sessionReply).not.toHaveBeenCalled();
+      // The baked target matches where the card sits: the same 话题.
+      const card = JSON.parse(replyContent as string);
+      const containerValue = card.body.elements.find((e: any) => e.tag === 'interactive_container')?.behaviors?.[0]?.value;
+      expect(containerValue?.target_scope).toBe('thread');
+      expect(containerValue?.root_id).toBe('om_topic_root_x');
+    });
+
+    it('picker falls back to sessionReply when reply-at-invocation fails', async () => {
+      vi.mocked(replyMessage).mockRejectedValueOnce(new Error('message withdrawn'));
+      const ds = makeDaemonSession({ session: makeSession({ ownerOpenId: 'ou_sender' }) });
+      const deps = makeDeps(ds);
+
+      await handleCommand('/relay', ROOT_ID, makeLarkMessage('/relay'), deps, LARK_APP_ID);
+
+      const [, replyContent, msgType] = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(msgType).toBe('interactive');
+      expect(JSON.parse(replyContent as string).schema).toBe('2.0');
     });
 
     it('picker excludes daemon-command scratch sessions (worker:null + no persisted CLI markers)', async () => {
@@ -3144,7 +3204,7 @@ describe('handleCommand', () => {
 
       await handleCommand('/relay', ROOT_ID, makeLarkMessage('/relay'), deps, LARK_APP_ID);
 
-      const [, replyContent] = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0];
+      const [, , replyContent] = vi.mocked(replyMessage).mock.calls[0];
       const card = JSON.parse(replyContent as string);
       // Scratch must NOT show — picker empty (no interactive_containers).
       expect(card.body.elements.filter((e: any) => e.tag === 'interactive_container')).toHaveLength(0);
@@ -3170,7 +3230,7 @@ describe('handleCommand', () => {
 
       await handleCommand('/relay', ROOT_ID, makeLarkMessage('/relay'), deps, LARK_APP_ID);
 
-      const [, replyContent] = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0];
+      const [, , replyContent] = vi.mocked(replyMessage).mock.calls[0];
       const card = JSON.parse(replyContent as string);
       // No interactive containers rendered — picker is empty after filtering out the adopt session.
       expect(card.body.elements.filter((e: any) => e.tag === 'interactive_container')).toHaveLength(0);
@@ -3204,7 +3264,11 @@ describe('handleCommand', () => {
       // p2p must NOT hit the chat-mode API (its failure default 'group' would
       // misclassify the DM).
       expect(vi.mocked(getChatNameAndMode)).not.toHaveBeenCalled();
-      const [, replyContent, msgType] = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0];
+      // Thread-mode DM target seeds a 话题 on the /relay message — the card
+      // replies in_thread there so the picker sits where the session lands.
+      const [, anchorMsgId, replyContent, msgType, inThread] = vi.mocked(replyMessage).mock.calls[0];
+      expect(anchorMsgId).toBe('msg_001');
+      expect(inThread).toBe(true);
       expect(msgType).toBe('interactive');
       const card = JSON.parse(replyContent as string);
       const containerValue = card.body.elements.find((e: any) => e.tag === 'interactive_container')?.behaviors?.[0]?.value;
@@ -3239,7 +3303,10 @@ describe('handleCommand', () => {
 
       await handleCommand('/relay', ROOT_ID, makeLarkMessage('/relay'), deps, LARK_APP_ID);
 
-      const [, replyContent, msgType] = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0];
+      // Flat DM → quote-reply of the /relay message (top level, no thread).
+      const [, anchorMsgId, replyContent, msgType, inThread] = vi.mocked(replyMessage).mock.calls[0];
+      expect(anchorMsgId).toBe('msg_001');
+      expect(inThread).toBe(false);
       expect(msgType).toBe('interactive');
       const card = JSON.parse(replyContent as string);
       const containerValue = card.body.elements.find((e: any) => e.tag === 'interactive_container')?.behaviors?.[0]?.value;
@@ -3260,7 +3327,10 @@ describe('handleCommand', () => {
 
       await handleCommand('/relay', ROOT_ID, makeLarkMessage('/relay'), deps, LARK_APP_ID);
 
-      const [, replyContent, msgType] = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0];
+      // 话题群 top-level → card seeds the 话题 on the /relay message itself.
+      const [, anchorMsgId, replyContent, msgType, inThread] = vi.mocked(replyMessage).mock.calls[0];
+      expect(anchorMsgId).toBe('msg_001');
+      expect(inThread).toBe(true);
       expect(msgType).toBe('interactive');
       expect(String(replyContent)).not.toMatch(/话题群不支持|not supported in topic/);
       const card = JSON.parse(replyContent as string);
@@ -3289,7 +3359,7 @@ describe('handleCommand', () => {
 
       await handleCommand('/relay', ROOT_ID, makeLarkMessage('/relay'), deps, LARK_APP_ID);
 
-      const reply = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+      const reply = vi.mocked(replyMessage).mock.calls[0][2] as string;
       expect(reply).toContain('PR review chat');
       expect(reply).toContain('已经有一个活跃会话');
       // Picker card should NOT have been rendered.
@@ -3319,7 +3389,7 @@ describe('handleCommand', () => {
 
       await handleCommand('/relay', ROOT_ID, makeLarkMessage('/relay'), deps, LARK_APP_ID);
 
-      const reply = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+      const reply = vi.mocked(replyMessage).mock.calls[0][2] as string;
       expect(reply).toContain('live work');
       expect(reply).toContain('已经有一个活跃会话');
       // Picker MUST NOT have rendered.
@@ -3344,7 +3414,7 @@ describe('handleCommand', () => {
 
       await handleCommand('/relay', ROOT_ID, makeLarkMessage('/relay'), deps, LARK_APP_ID);
 
-      const [, replyContent] = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0];
+      const [, , replyContent] = vi.mocked(replyMessage).mock.calls[0];
       const card = JSON.parse(replyContent as string);
       // No interactive containers — empty picker (otherUser's session filtered out).
       expect(card.body.elements.filter((e: any) => e.tag === 'interactive_container')).toHaveLength(0);

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -3374,6 +3374,62 @@ describe('handleCommand', () => {
       expect(mockedCreate).not.toHaveBeenCalled();
     });
 
+    // ── p2p (私聊) solo --create ─────────────────────────────────────────────
+    // DMs have no member roster, so @-ing a bot is impossible there — the
+    // mention gate / leader election / roster resolve are all bypassed and the
+    // bot itself is the sole participant. New group = user + this bot; the DM
+    // session migrates over with no peer coordination.
+    it('p2p --create: solo relay without mentions — group is user + this bot, session migrates', async () => {
+      const ds = makeDaemonSession({
+        session: makeSession({ ownerOpenId: 'ou_sender', chatType: 'p2p' }),
+        chatType: 'p2p',
+      });
+      const deps = makeDeps(ds);
+
+      await handleCommand('/relay', ROOT_ID, makeLarkMessage('/relay --create 搬去群里'), deps, LARK_APP_ID);
+
+      // Group created with ONLY this bot; ownership transferred to the sender.
+      expect(mockedCreate).toHaveBeenCalledTimes(1);
+      const opts = mockedCreate.mock.calls[0][0];
+      expect(opts.larkAppIds).toEqual([LARK_APP_ID]);
+      expect(opts.userOpenIds).toEqual(['ou_sender']);
+      expect(opts.transferOwnerTo).toBe('ou_sender');
+
+      // No roster lookup for a DM — listChatBotMembers fails on p2p chats.
+      expect(mockedListBots).not.toHaveBeenCalled();
+
+      // The DM session was transferred into the new chat (chat-scope group).
+      const wp = await import('../src/core/worker-pool.js');
+      expect(wp.transferSession).toHaveBeenCalledWith('sess-001', 'oc_new_group', 'oc_new_group', 'group', 'chat');
+
+      // M1 lands in the new group and labels the source as 单聊 instead of
+      // leaking the raw DM chatId.
+      expect(mockedSend).toHaveBeenCalled();
+      const [, m1ChatId, m1Text] = mockedSend.mock.calls[0];
+      expect(m1ChatId).toBe('oc_new_group');
+      expect(m1Text).toContain('单聊');
+      expect(m1Text).not.toContain(CHAT_ID);
+
+      // Source-side report carries the new group name.
+      const reply = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+      expect(reply).toContain('搬去群里');
+      expect(reply).toContain('Claude');
+    });
+
+    it('p2p --create: owner-only check still enforced', async () => {
+      const ds = makeDaemonSession({
+        session: makeSession({ ownerOpenId: 'ou_other_user', chatType: 'p2p' }),
+        chatType: 'p2p',
+      });
+      const deps = makeDeps(ds);
+
+      await handleCommand('/relay', ROOT_ID, makeLarkMessage('/relay --create G'), deps, LARK_APP_ID);
+
+      const reply = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+      expect(reply).toContain('发起人');
+      expect(mockedCreate).not.toHaveBeenCalled();
+    });
+
     it('rejects --create when sender is not the source session owner', async () => {
       const ds = makeDaemonSession({ session: makeSession({ ownerOpenId: 'ou_other_user' }) });
       const deps = makeDeps(ds);


### PR DESCRIPTION
## 背景：真实用户反馈与根因（live 数据钉死）

用户反馈：**群聊里敲 /relay，picker 找不到私聊会话**。从 daemon 日志定位到 07-16 10:26 / 10:29 两次真实触发现场，结合 sessions store 反推：

- **现场 A（申晗，10:29）**：DM 会话 b4eeaf3c 是活跃的、也确实会进 picker 候选（cap-suspended 懒恢复仍 active），但：① 名下 **38 个活跃会话**、每页 5 条、按活跃倒序，4 天没动的 DM 排第 **26**（第 6 页）；② 按渲染标签搜「单聊」**必空** —— `relayPickerFilter` 的 haystack 用 `chatLabel`，而 p2p 条目的 chatLabel 是裸 DM chatId（渲染时才替换成「单聊」字面量）。搜索是唯一现实入口，而搜索是瞎的。
- **现场 B（另一用户，10:26）**：测试时该用户在该 bot 下的 DM botmux 会话**已全部关闭**（最后一个 07-12 关）。picker 只列活跃会话 —— 行为正确，但零提示。

## 改动 1（9c350959，picker 搜索可发现性）

- `relayPickerFilter`：p2p 条目 haystack 追加 `单聊 私聊 p2p dm direct message` 别名，group 条目不受影响
- 搜索占位符提示「搜『单聊』找私聊」；空态文案说明「只列活跃会话、已关闭不出现」（zh/en）

## 改动 2（717ef372，picker 卡片锚定发起点——申晗 live 实测追加反馈）

chat 模式普通群的**话题里**敲 /relay，卡片漏到群聊顶层。根因：卡片走 `sessionReply`，chat-scope scratch 无 turn 状态可折返 → 兜底 sendMessage 顶层；骑真实会话则折进「当前 turn」话题（也不是发起话题）。修：picker 卡片 + 占位冲突报错改「锚定发起点」——thread 目标 `reply_in_thread` 进发起话题（话题群/DM话题顶层种在 /relay 消息上，与接力落点同处）；chat 目标 quote-reply /relay 消息；失败兜底回 sessionReply。话题群/DM 各形态锚点语义不变；普通群扁平顶层从裸发消息变引用回复（更贴命令）。

## 改动 3（2df36d75，补齐发起方向）

私聊里 `/relay --create [群名]` 可用（原来死在「必须 @ 至少一个机器人」）：源 p2p 时 solo 接力，新群 = 用户 + 本 bot，owner 校验保留，M1 来源标「单聊」。群聊路径逐行保留零语义改动。

## 影响面

- 改动 1：card-builder picker 过滤（仅 p2p 条目）+ i18n 4 条
- 改动 2：command-handler /relay picker 出口（卡片/冲突报错两处 send），confirm/M1/transferSession 链路未动；影响所有发起 /relay 的聊天形态，已逐形态核对锚点语义（见 commit message）
- 改动 3：command-handler /relay --create 分支 + i18n 2 条
- 跨 CLI / 跨后端不涉及

## 测试验证

- `pnpm build` ✅；相关四套件 **338/338**（card-builder 130 / command-handler 187 / relay-picker 4 / relay pickup 18），新增 5 条：p2p 搜索别名（含 group 不误命中）、话题内发起卡片进话题（申晗现场回归）、reply 失败兜底、p2p --create ×2；既有 picker 用例全部改为断言「锚定发起点」新出口（quote-reply / reply_in_thread + 不再走 sessionReply）
- 全量 `pnpm test`：9421 passed / 9 failed，9 败为本机常驻基线（时区×3 + v3-distillation×6），此前已 stash 后纯 master 对照同样 9 败
- live 实测：申晗已在群里实测**能找到私聊会话**（改动 3 的 build）；改动 1/2 需 restart 后复测（搜「单聊」+ 话题内卡片落点）