### PR TITLE
fix(sandbox): 修复 Claude 沙盒启动与消息提交

### DIFF
--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -23,9 +23,9 @@
  * sandbox-exec approach and is handled elsewhere.
  */
 import { homedir } from 'node:os';
-import { mkdirSync, existsSync, writeFileSync, chmodSync, readdirSync, readFileSync, rmSync, statSync, realpathSync, openSync, fstatSync, readSync, writeSync, closeSync, constants as fsConstants } from 'node:fs';
+import { mkdirSync, existsSync, writeFileSync, chmodSync, readdirSync, readFileSync, rmSync, statSync, lstatSync, realpathSync, symlinkSync, unlinkSync, openSync, fstatSync, readSync, writeSync, closeSync, constants as fsConstants } from 'node:fs';
 import { atomicWriteFileSync } from '../../utils/atomic-write.js';
-import { join, dirname, relative, resolve } from 'node:path';
+import { basename, isAbsolute, join, dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn, spawnSync } from 'node:child_process';
 
@@ -193,7 +193,12 @@ export function buildSandboxArgs(plan: SandboxPlan): string[] {
   // Fresh kernel/runtime dirs (the ro-bind of / would otherwise carry host /tmp etc.).
   a.push('--proc', '/proc', '--dev', '/dev', '--tmpfs', '/tmp', '--tmpfs', '/run', '--tmpfs', '/dev/shm');
   // Write-isolated home + project (overlay merged: reads=real lower, writes=upper).
-  a.push('--bind', plan.homeMerged, plan.home);
+  // If cwd IS HOME, two binds to the same destination would make the later
+  // project bind silently shadow the home overlay. Use the project overlay as
+  // the single winning layer in that case.
+  if (plan.projectMount !== plan.home) {
+    a.push('--bind', plan.homeMerged, plan.home);
+  }
   a.push('--bind', plan.projectMerged, plan.projectMount);
   // CLI auth/login dirs kept REAL + writable (bind over the isolated home) so token
   // refresh / login persists. Narrow (auth only) keeps session history isolated;
@@ -296,6 +301,22 @@ function coversRoot(p: string, root: string): boolean {
  *  Falls back to a lexical resolve if realpath fails (e.g. a racing unlink). */
 function canonicalize(p: string): string {
   try { return realpathSync(p); } catch { return resolve(p); }
+}
+
+/** Canonicalize through the deepest existing ancestor while preserving a
+ *  possibly-missing tail. `realpathSync('/home-link/x/missing')` cannot resolve
+ *  `/home-link`, so a lexical fallback would leave a bwrap destination under a
+ *  symlink even though related mounts use the canonical home. */
+function canonicalizeWithMissingTail(p: string): string {
+  let cursor = resolve(p);
+  const tail: string[] = [];
+  while (true) {
+    try { return join(realpathSync(cursor), ...tail); } catch { /* walk upward */ }
+    const parent = dirname(cursor);
+    if (parent === cursor) return resolve(p);
+    tail.unshift(basename(cursor));
+    cursor = parent;
+  }
 }
 
 /** bwrap cannot bind-mount over a symlink mount destination. Some hosts expose
@@ -404,31 +425,65 @@ export interface SandboxSpawn {
   outbox: string;
   /** Project overlay UPPER dir — THE LANDABLE CHANGESET (used by sandbox-land). */
   workDir: string;
-  /** HOME overlay UPPER dir (/var/tmp/botmux-sbx/<sid>/home-upper). The sandboxed
-   *  CLI's $HOME writes — INCLUDING its session jsonl under CLAUDE_CONFIG_DIR —
-   *  land here (invisible at the real path). The worker redirects its bridge/idle
-   *  watch into this via sandboxedClaudeDataDir() so it sees the CLI's turns. */
+  /** HOME overlay UPPER dir (/var/tmp/botmux-sbx/<sid>/home-upper). When the
+   *  project mount equals HOME, the project overlay is the single winning
+   *  layer and this directory is intentionally unused. */
   homeUpper: string;
   /** Unmount the overlays + remove the per-session sandbox tree. */
   cleanup: () => void;
 }
 
-/** The path where a sandboxed session's CLI actually writes a $HOME-relative
- *  data dir (e.g. CLAUDE_CONFIG_DIR / `.claude-runtime`): the HOME overlay's
- *  ephemeral UPPER copy. The worker redirects its jsonl/bridge watch here so it
- *  sees the sandboxed CLI's writes (which are invisible at the real host path).
- *  Mirrors prepareSandbox's homeUpper layout — keep in sync.
+/** The host path where a sandboxed session actually writes a Claude-family
+ *  data dir. Usually this is the HOME overlay upper. If the project mount is
+ *  HOME (or otherwise contains the data dir), the later project overlay is the
+ *  winning mount and the data lands in proj-upper instead.
  *
  *  The home overlay is bound (and $HOME set) at the CANONICAL home, so copy-ups
  *  land relative to that root. Compute the in-home relative path robustly whether
  *  realDataDir arrives in symlink or canonical form: adapters build it from the
  *  raw homedir() (so the raw base cancels cleanly in the common case), but a
- *  canonicalized dataDir under a symlink home would escape home-upper via `..` —
- *  fall back to the canonical base so it can't. */
-export function sandboxedClaudeDataDir(sessionId: string, realDataDir: string): string {
-  const raw = relative(homedir(), realDataDir);
-  const rel = raw.startsWith('..') ? relative(resolveSandboxMountPath(homedir()), realDataDir) : raw;
-  return join(VARTMP_ROOT, sessionId, 'home-upper', rel);
+ *  canonicalized dataDir under a symlink home would otherwise escape via `..`.
+ *  Data roots outside both HOME and the project are returned unchanged because
+ *  neither overlay owns them (Claude read isolation normally relocates those
+ *  roots into BOT_HOME before spawn). */
+export function sandboxedClaudeDataDir(
+  sessionId: string,
+  realDataDir: string,
+  context: { sourceWorkingDir?: string; dataDir?: string } = {},
+): string {
+  const relativeWithin = (root: string, target: string): string | null => {
+    const rel = relative(root, target);
+    return rel === '' || (rel !== '..' && !rel.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`) && !isAbsolute(rel))
+      ? rel
+      : null;
+  };
+
+  const rawHome = homedir();
+  const home = resolveSandboxMountPath(rawHome);
+  const rawHomeRel = relativeWithin(rawHome, realDataDir);
+  const canonicalDataDir = rawHomeRel !== null
+    ? join(home, rawHomeRel)
+    : canonicalize(realDataDir);
+
+  if (context.sourceWorkingDir && context.dataDir) {
+    const projectMount = resolveSandboxMountPath(context.sourceWorkingDir);
+    const projectRel = relativeWithin(projectMount, canonicalDataDir);
+    if (projectRel !== null) {
+      return join(
+        resolveSandboxMountPath(context.dataDir),
+        'sandboxes',
+        sessionId,
+        'proj-upper',
+        projectRel,
+      );
+    }
+  }
+
+  const homeRel = rawHomeRel ?? relativeWithin(home, canonicalDataDir);
+  if (homeRel !== null) {
+    return join(VARTMP_ROOT, sessionId, 'home-upper', homeRel);
+  }
+  return canonicalDataDir;
 }
 
 /** Credential roots that must never be readable inside the file sandbox.
@@ -469,10 +524,11 @@ export function localSandboxApplies(platform: NodeJS.Platform, backendType: stri
  * is off / unsupported / a required overlay mount fails (fail-safe = the worker
  * treats null as a hard error and does NOT silently run unsandboxed).
  *
- * Layout under <dataDir>/sandboxes/<sessionId>/: outbox, shimbin, proj-upper
- * (the landable changeset), and proj-work. Host-only merged mountpoints plus the
- * HOME overlay upper/work live under /var/tmp/botmux-sbx/<sessionId>/ so none of
- * the FUSE mountpoints is nested below the HOME lower layer.
+ * Layout under <dataDir>/sandboxes/<sessionId>/: outbox, shimbin, and the
+ * landable proj-upper. When the project contains dataDir (notably cwd=HOME),
+ * proj-upper is a symlink to scratch under /var/tmp/botmux-sbx/<sessionId>/ so
+ * overlay upper/work never sit inside their own lower. Host-only merged
+ * mountpoints and the HOME overlay upper/work also live under that runtime root.
  */
 export function prepareSandbox(opts: {
   /** Whether the sandbox is on for THIS session (per-bot BotConfig.sandbox OR
@@ -524,8 +580,8 @@ export function prepareSandbox(opts: {
   const outbox = join(sessionRoot, 'outbox');
   const shimBin = join(sessionRoot, 'shimbin');
   const empties = join(sessionRoot, 'empties');
-  const projUpper = join(sessionRoot, 'proj-upper');   // THE LANDABLE CHANGESET
-  const projWork = join(sessionRoot, 'proj-work');
+  const landingProjUpper = join(sessionRoot, 'proj-upper'); // stable /land path
+  const landingProjWork = join(sessionRoot, 'proj-work');
   const projMerged = overlayPaths.projectMerged;
   const homeMerged = overlayPaths.homeMerged;
   // HOME overlay upper/work and both merged mountpoints MUST be outside HOME.
@@ -546,20 +602,87 @@ export function prepareSandbox(opts: {
   // BOTMUX_SANDBOX_SRC overrides the LOWER project source for spike testing only.
   const projectSource = resolveSandboxMountPath(process.env.BOTMUX_SANDBOX_SRC || opts.sourceWorkingDir);
   const projectMount = resolveSandboxMountPath(opts.sourceWorkingDir);
+  const projectSharesHome = projectMount === home;
 
   // A same-session re-spawn (e.g. in-pane /clear) re-enters here; unmount any
   // stale merged overlays first so we don't stack a second mount on the same dir.
   unmountSandboxOverlays(overlayPaths);
 
-  // Mount the HOME overlay (lower=real home → reads pass through, writes isolate).
-  const homeOk = mountOverlay({ lower: home, upper: homeUpper, work: homeWork, merged: homeMerged });
-  if (!homeOk) {
-    return null; // fail-safe: no silent unsandboxed run
+  // overlayfs/fuse-overlayfs upper+work must not live inside lower. The normal
+  // project layout keeps them under dataDir, but cwd=HOME makes dataDir a child
+  // of the project lower. Put the actual scratch outside HOME and leave a
+  // host-only symlink at the stable /land path. Preserve an old real directory
+  // on same-session upgrade so an existing changeset is never discarded.
+  let projUpper = landingProjUpper;
+  let projWork = landingProjWork;
+  if (coversRoot(projectSource, dataDir)) {
+    const externalUpper = join(vartmp, 'proj-upper');
+    const externalWork = join(vartmp, 'proj-work');
+    if (coversRoot(projectSource, vartmp)) {
+      console.error(`[sandbox] cannot place project overlay scratch outside lower ${projectSource}`);
+      return null;
+    }
+    let existing: ReturnType<typeof lstatSync> | null = null;
+    try { existing = lstatSync(landingProjUpper); } catch { /* first spawn */ }
+    if (existing?.isSymbolicLink()) {
+      mkdirSync(externalUpper, { recursive: true });
+      let linked = '';
+      try { linked = realpathSync(landingProjUpper); } catch { /* broken link */ }
+      if (linked && linked !== realpathSync(externalUpper)) {
+        console.error(`[sandbox] refusing unexpected proj-upper symlink target: ${linked}`);
+        return null;
+      }
+      if (!linked) {
+        try { unlinkSync(landingProjUpper); } catch { return null; }
+        symlinkSync(externalUpper, landingProjUpper, 'dir');
+      }
+      projUpper = externalUpper;
+      projWork = externalWork;
+    } else if (!existing) {
+      mkdirSync(externalUpper, { recursive: true });
+      symlinkSync(externalUpper, landingProjUpper, 'dir');
+      projUpper = externalUpper;
+      projWork = externalWork;
+    } else {
+      // Upgrade compatibility: an EMPTY pre-fix upper has no changes to save,
+      // so convert it in place. A non-empty one may contain whiteouts/xattrs
+      // that cannot be copied losslessly across filesystems; fail safe and keep
+      // it untouched rather than reintroducing a recursive in-lower overlay.
+      let entries: string[] | null = null;
+      try { entries = readdirSync(landingProjUpper); } catch { /* not a readable dir */ }
+      if (entries?.length === 0) {
+        try {
+          rmSync(landingProjUpper, { recursive: true, force: true });
+          rmSync(landingProjWork, { recursive: true, force: true });
+          mkdirSync(externalUpper, { recursive: true });
+          symlinkSync(externalUpper, landingProjUpper, 'dir');
+          projUpper = externalUpper;
+          projWork = externalWork;
+        } catch {
+          return null;
+        }
+      } else {
+        console.error(
+          `[sandbox] refusing legacy in-lower proj-upper with pending changes for session ${opts.sessionId}; land or back up the changeset before restarting`,
+        );
+        return null;
+      }
+    }
+  }
+
+  // Mount the HOME overlay unless the project itself is HOME. In that overlap
+  // case the project overlay is the single layer bound at HOME; mounting a
+  // second home overlay would only waste a FUSE mount before being shadowed.
+  if (!projectSharesHome) {
+    const homeOk = mountOverlay({ lower: home, upper: homeUpper, work: homeWork, merged: homeMerged });
+    if (!homeOk) {
+      return null; // fail-safe: no silent unsandboxed run
+    }
   }
   // Mount the PROJECT overlay. proj-upper = the landable changeset.
   const projOk = mountOverlay({ lower: projectSource, upper: projUpper, work: projWork, merged: projMerged });
   if (!projOk) {
-    unmountOverlay(homeMerged);
+    if (!projectSharesHome) unmountOverlay(homeMerged);
     return null; // fail-safe
   }
 
@@ -576,7 +699,10 @@ export function prepareSandbox(opts: {
   chmodSync(shim, 0o755);
 
   // Credential masks are mandatory; per-bot privacy masks extend them.
-  // Existing dirs → tmpfs blank; everything else → empty read-only placeholder.
+  // Existing dirs → tmpfs blank; files → empty read-only placeholder. A missing
+  // path that contains another requested mask must also be a directory: mounting
+  // it as an empty file makes a later child mount fail with ENOTDIR (for example
+  // a missing ~/.lark-cli-bots plus ~/.lark-cli-bots/<sibling>).
   // `~` resolves like the docs' examples (`~/.ssh`) — an unexpanded tilde would
   // fail existsSync and mask a literal `~/...` path, leaving the real one readable.
   const hideDirs: string[] = [];
@@ -593,32 +719,41 @@ export function prepareSandbox(opts: {
     ...sandboxCredentialHidePaths(home, botmuxHome),
     ...(customBotsConfig ? [resolve(customBotsConfig)] : []),
   ];
-  for (const raw of [...credentialPaths, ...(opts.hidePaths ?? [])]) {
-    if (!raw || typeof raw !== 'string') continue;
-    const p = expandTilde(raw, home);
-    let isDir = false;
-    try { isDir = existsSync(p) && statSync(p).isDirectory(); } catch { /* */ }
-    if (isDir) {
-      hideDirs.push(p);
-    } else {
-      const empty = join(empties, `mask-${emptyIdx++}`);
-      try { writeFileSync(empty, ''); } catch { /* */ }
-      hideFiles.push({ path: p, empty });
+  const classifyMasks = (
+    rawPaths: readonly string[],
+    dirs: string[],
+    files: { path: string; empty: string }[],
+  ): void => {
+    const paths = [...new Set(rawPaths
+      .filter((raw): raw is string => typeof raw === 'string' && raw.length > 0)
+      .map(raw => canonicalizeWithMissingTail(expandTilde(raw, home))))];
+    const hasMaskedDescendant = (parent: string): boolean => paths.some(candidate => {
+      if (candidate === parent) return false;
+      const rel = relative(resolve(parent), resolve(candidate));
+      return rel !== ''
+        && rel !== '..'
+        && !rel.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`)
+        && !isAbsolute(rel);
+    });
+
+    for (const p of paths) {
+      let isDir = false;
+      try {
+        isDir = existsSync(p) ? statSync(p).isDirectory() : hasMaskedDescendant(p);
+      } catch {
+        isDir = hasMaskedDescendant(p);
+      }
+      if (isDir) {
+        dirs.push(p);
+      } else {
+        const empty = join(empties, `mask-${emptyIdx++}`);
+        try { writeFileSync(empty, ''); } catch { /* */ }
+        files.push({ path: p, empty });
+      }
     }
-  }
-  for (const raw of opts.finalHidePaths ?? []) {
-    if (!raw || typeof raw !== 'string') continue;
-    const p = expandTilde(raw, home);
-    let isDir = false;
-    try { isDir = existsSync(p) && statSync(p).isDirectory(); } catch { /* */ }
-    if (isDir) {
-      finalHideDirs.push(p);
-    } else {
-      const empty = join(empties, `mask-${emptyIdx++}`);
-      try { writeFileSync(empty, ''); } catch { /* */ }
-      finalHideFiles.push({ path: p, empty });
-    }
-  }
+  };
+  classifyMasks([...credentialPaths, ...(opts.hidePaths ?? [])], hideDirs, hideFiles);
+  classifyMasks(opts.finalHidePaths ?? [], finalHideDirs, finalHideFiles);
 
   // CLI auth/login paths kept real+writable (token refresh / login must persist,
   // unlike isolated project edits). Resolve `~` and bind only existing paths — a
@@ -697,7 +832,7 @@ export function prepareSandbox(opts: {
     args,
     env,
     outbox,
-    workDir: projUpper,
+    workDir: landingProjUpper,
     homeUpper,
     cleanup: () => {
       unmountSandboxOverlays(overlayPaths);

--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -31,6 +31,36 @@ function realpathCwd(cwd: string): string {
  *  `~/.claude` keeps all existing call sites byte-for-byte unchanged. */
 export const DEFAULT_CLAUDE_DATA_DIR = join(homedir(), '.claude');
 
+/** Maximum UTF-8 payload for one tmux `send-keys -l` burst. A whole long line
+ *  is enough to trip Claude Code's paste detector even when line-to-line sends
+ *  are throttled, so split every non-empty line into small, paced chunks. */
+export const CLAUDE_INPUT_CHUNK_BYTES = 96;
+
+/** Split without cutting a Unicode code point or exceeding the byte budget. */
+export function chunkTextByUtf8Bytes(
+  text: string,
+  maxBytes: number = CLAUDE_INPUT_CHUNK_BYTES,
+): string[] {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 4) {
+    throw new RangeError('maxBytes must be an integer >= 4');
+  }
+  const chunks: string[] = [];
+  let chunk = '';
+  let chunkBytes = 0;
+  for (const char of text) {
+    const charBytes = Buffer.byteLength(char, 'utf8');
+    if (chunk && chunkBytes + charBytes > maxBytes) {
+      chunks.push(chunk);
+      chunk = '';
+      chunkBytes = 0;
+    }
+    chunk += char;
+    chunkBytes += charBytes;
+  }
+  if (chunk) chunks.push(chunk);
+  return chunks;
+}
+
 /** Resolve the JSONL transcript path Claude Code writes user/assistant turns to.
  *  Claude Code's project-hash scheme replaces every non-[A-Za-z0-9-] char with `-`
  *  (observed: `/foo/life_workspace` → `-foo-life-workspace`; `/`, `.`, `_` all become `-`).
@@ -589,11 +619,11 @@ export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, rawBin: 
       // making tmux's paste-buffer drop the markers and turning embedded \r
       // into Enters that fragment the message into multiple submits.
       //
-      // Each tmux send-keys is throttled so the cumulative input rate stays
-      // below Claude Code's paste-burst threshold — otherwise on long messages
-      // (~1300+ chars / ~25+ lines) Ink flips into paste mode mid-stream and
-      // subsequent `\` + Enter pairs are kept as literal `\\\r` in the
-      // submitted content instead of being consumed as soft-newline markers.
+      // Each tmux send-keys is byte-bounded AND throttled so the cumulative
+      // input rate stays below Claude Code's paste-burst threshold. Throttling
+      // only between lines is insufficient: one long quoted-message line can
+      // itself flip Ink into paste mode, after which subsequent `\` + Enter
+      // pairs are kept as literal `\\\r` instead of soft-newline markers.
       //
       // The first writeInput after spawn lands before Ink's startup render
       // pass has fully drained, so even short messages trip paste-burst —
@@ -671,8 +701,10 @@ export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, rawBin: 
         const lines = content.split('\n');
         for (let i = 0; i < lines.length; i++) {
           if (lines[i].length > 0) {
-            pty.sendText(lines[i]);
-            await tick();
+            for (const chunk of chunkTextByUtf8Bytes(lines[i])) {
+              pty.sendText(chunk);
+              await tick();
+            }
           }
           if (i < lines.length - 1) {
             if (!keybindings.enterIsNewline) {
@@ -870,7 +902,7 @@ export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, rawBin: 
       format: 'claude-settings',
       // SessionStart 就绪 hook 也写全局：进程级 --settings 那份会被 wrapperCli=`aiden x
       // claude` 剥掉（aiden 硬拒 --settings），全局这条是它唯一能拿到就绪信号的渠道，
-      // 避免首条 prompt 空等 45s。原生 claude 会同时收到进程级+全局两份，幂等无害。
+      // 避免首条 prompt 空等 45s；原生 Claude 也只从这一个来源读取 ready hook。
       sessionStartCommand: sessionReadyHookCommand(),
     },
     asksViaHook: true,

--- a/src/adapters/cli/read-isolation.ts
+++ b/src/adapters/cli/read-isolation.ts
@@ -505,7 +505,8 @@ export interface LinuxReadIsolationInput {
  */
 export function buildLinuxReadIsolationMasks(input: LinuxReadIsolationInput): {
   /** Paths to blank inside bwrap (prepareSandbox stat-classifies: dir→tmpfs,
-   *  file→empty ro-bind, missing→skipped). Feed as prepareSandbox.hidePaths. */
+   *  file→empty ro-bind; a missing ancestor of another mask is treated as a
+   *  directory so nested mounts remain valid). Feed as prepareSandbox.hidePaths. */
   hidePaths: string[];
   /** The bot's OWN BOT_HOME — bound REAL + writable (feed as
    *  prepareSandbox.trustedWritablePaths) so the

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -244,8 +244,8 @@ export interface CliAdapter {
 
   /** When true, the adapter injects a `SessionStart` hook that calls
    *  `botmux session-ready` once the CLI's input box is genuinely rendered —
-   *  Claude-family via process-level `--settings`, Grok via its global
-   *  `hooks/*.json` (see `hookInstall.format: 'grok-hooks'`). The worker arms
+   *  Claude-family via its effective settings.json, Grok via its global
+   *  `hooks/*.json` (see `hookInstall`). The worker arms
    *  a ready-gate on this flag and holds the FIRST prompt until the signal
    *  arrives (or a fallback timeout), so a startup launcher's selector `❯` —
    *  which falsely matches `readyPattern` — can't trip an early flush that

--- a/src/adapters/hook-installer.ts
+++ b/src/adapters/hook-installer.ts
@@ -4,7 +4,7 @@
  * 把 botmux 的 askUserQuestion hook 写入各 CLI 的配置文件。
  * 幂等：写前比对内容，相同则跳过；展开 ~ 路径；出错只 warn 不抛。
  */
-import { readFileSync, mkdirSync, existsSync } from 'node:fs';
+import { readFileSync, mkdirSync, existsSync, chmodSync } from 'node:fs';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
@@ -16,6 +16,11 @@ import { hookCommandParts } from './hook-command.js';
 export interface HookInstallConfig {
   readonly configPath: string;
   readonly format: 'claude-settings' | 'opencode-plugin' | 'grok-hooks';
+  /** Claude read-isolation: merge the shared settings `env` map into a
+   *  per-bot settings file before installing hooks. Shared values win so
+   *  rotated auth/provider/proxy settings refresh on every cold spawn; global
+   *  hooks and unrelated top-level settings are deliberately not inherited. */
+  readonly inheritClaudeEnvFrom?: string;
   /** 可选：SessionStart 就绪 hook 命令。
    *  - claude-settings：写全局 settings.json
    *  - grok-hooks：写 `~/.grok/hooks/*.json` 的 SessionStart
@@ -41,16 +46,19 @@ function readJsonFile<T>(filePath: string): T | null {
 }
 
 /** 幂等写文件：若内容与现有相同则跳过；自动创建目录。 */
-function writeIfChanged(filePath: string, content: string): boolean {
+function writeIfChanged(filePath: string, content: string, mode?: number): boolean {
   try {
     if (existsSync(filePath)) {
       const existing = readFileSync(filePath, 'utf-8');
-      if (existing === content) return false; // 内容相同，无需写入
+      if (existing === content) {
+        if (mode !== undefined) chmodSync(filePath, mode);
+        return false; // 内容相同，无需写入
+      }
     }
     mkdirSync(dirname(filePath), { recursive: true });
     // 原子写：目标是 ~/.claude/settings.json 这类被 CLI 并发读写的热配置，
     // 裸写半截会让并发读者拿到坏 JSON 再整文件覆写回来（cjadk 事故同类）。
-    atomicWriteFileSync(filePath, content);
+    atomicWriteFileSync(filePath, content, mode !== undefined ? { mode } : {});
     return true;
   } catch (err: any) {
     throw new Error(`写入 ${filePath} 失败：${err.message}`);
@@ -73,6 +81,10 @@ interface ClaudeHookGroup {
 interface ClaudeSettings {
   hooks?: Record<string, ClaudeHookGroup[]>;
   [key: string]: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
 /**
@@ -124,9 +136,11 @@ function removeBotmuxAskHookGroups(
  * 不按完整字符串比对——dev checkout 与 npm global 的 cli.js 绝对路径不同。
  */
 function isBotmuxReadyHookGroup(group: ClaudeHookGroup): boolean {
-  return group.hooks.some(
+  return Array.isArray(group?.hooks) && group.hooks.some(
     (e) =>
+      !!e &&
       e.type === 'command' &&
+      typeof e.command === 'string' &&
       e.command.includes('cli.js') &&
       e.command.trimEnd().endsWith('session-ready'),
   );
@@ -140,17 +154,46 @@ function removeBotmuxReadyHookGroups(hooks: Record<string, ClaudeHookGroup[]>, e
 }
 
 /**
+ * Read-only preflight used by the worker before it arms the ready gate.
+ * Installation is intentionally best-effort, so the gate must not assume that
+ * a requested SessionStart hook actually reached the CLI's effective config.
+ */
+export function hasInstalledSessionReadyHook(hookInstall: HookInstallConfig): boolean {
+  if (!hookInstall.sessionStartCommand) return false;
+  if (hookInstall.format !== 'claude-settings' && hookInstall.format !== 'grok-hooks') {
+    return false;
+  }
+  const settings = readJsonFile<ClaudeSettings>(expandHome(hookInstall.configPath));
+  const groups = settings?.hooks?.SessionStart;
+  return Array.isArray(groups) && groups.some(isBotmuxReadyHookGroup);
+}
+
+/**
  * 向 Claude settings.json 的 hooks.PreToolUse 合并 botmux ask hook entry。
  * AskUserQuestion 在 bypassPermissions 模式下不会经过 PermissionRequest，
  * 但 PreToolUse 仍会在工具执行前触发，因此这里必须挂 PreToolUse。
  * 保留其他事件和 entry，不破坏无关配置。
  *
- * 若提供 sessionStartCommand，再把 SessionStart「真就绪」hook 也写进全局 settings.json
- * （为 wrapperCli=`aiden x claude` 这类剥 --settings 的启动器提供就绪信号；原生 claude
- * 会同时收到进程级 --settings 那份，二者幂等无害）。
+ * 若提供 sessionStartCommand，再把 SessionStart「真就绪」hook 写进 settings.json。
+ * 这是 Claude-family 的单一 ready-hook 来源，也覆盖会剥掉进程级 --settings 的
+ * wrapperCli=`aiden x claude`。
  */
-function installClaudeSettings(configPath: string, hookCommand: string, sessionStartCommand?: string): void {
+function installClaudeSettings(
+  configPath: string,
+  hookCommand: string,
+  sessionStartCommand?: string,
+  inheritClaudeEnvFrom?: string,
+): void {
   const settings: ClaudeSettings = readJsonFile<ClaudeSettings>(configPath) ?? {};
+  if (inheritClaudeEnvFrom) {
+    const source = readJsonFile<ClaudeSettings>(expandHome(inheritClaudeEnvFrom));
+    if (isRecord(source?.env)) {
+      const localEnv = isRecord(settings.env) ? settings.env : {};
+      // Preserve per-bot-only env entries, but refresh overlapping shared
+      // provider auth/model/proxy keys from the authoritative global config.
+      settings.env = { ...localEnv, ...source.env };
+    }
+  }
   const existingHooks = settings.hooks ?? {};
 
   // 构造 botmux PreToolUse hook group（只拦截 AskUserQuestion）
@@ -173,7 +216,9 @@ function installClaudeSettings(configPath: string, hookCommand: string, sessionS
 
   settings.hooks = existingHooks;
   const content = JSON.stringify(settings, null, 2) + '\n';
-  const changed = writeIfChanged(configPath, content);
+  // An inherited env can contain provider credentials. Keep the per-bot copy
+  // owner-only even if the pre-existing hook-only file was created as 0644.
+  const changed = writeIfChanged(configPath, content, inheritClaudeEnvFrom ? 0o600 : undefined);
   if (changed) {
     logger.info(`[hook] 已写入 Claude hook → ${configPath}`);
   } else {
@@ -409,7 +454,12 @@ export function installHook(
     const configPath = expandHome(hookInstall.configPath);
     switch (hookInstall.format) {
       case 'claude-settings':
-        installClaudeSettings(configPath, hookCommand, hookInstall.sessionStartCommand);
+        installClaudeSettings(
+          configPath,
+          hookCommand,
+          hookInstall.sessionStartCommand,
+          hookInstall.inheritClaudeEnvFrom,
+        );
         break;
       case 'opencode-plugin':
         // OpenCode 插件走 argv parts（异步 spawn），不复用 shell 字符串，避免被 split 拆坏。

--- a/src/adapters/hook-installer.ts
+++ b/src/adapters/hook-installer.ts
@@ -83,6 +83,11 @@ interface ClaudeSettings {
   [key: string]: unknown;
 }
 
+interface InheritedClaudeEnvState {
+  version: 1;
+  keys: string[];
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
@@ -165,7 +170,12 @@ export function hasInstalledSessionReadyHook(hookInstall: HookInstallConfig): bo
   }
   const settings = readJsonFile<ClaudeSettings>(expandHome(hookInstall.configPath));
   const groups = settings?.hooks?.SessionStart;
-  return Array.isArray(groups) && groups.some(isBotmuxReadyHookGroup);
+  return Array.isArray(groups) && groups.some(group =>
+    Array.isArray(group?.hooks) && group.hooks.some(entry =>
+      entry?.type === 'command'
+      && entry.command === hookInstall.sessionStartCommand,
+    ),
+  );
 }
 
 /**
@@ -185,13 +195,33 @@ function installClaudeSettings(
   inheritClaudeEnvFrom?: string,
 ): void {
   const settings: ClaudeSettings = readJsonFile<ClaudeSettings>(configPath) ?? {};
+  let inheritedEnvState: { path: string; content: string } | undefined;
   if (inheritClaudeEnvFrom) {
     const source = readJsonFile<ClaudeSettings>(expandHome(inheritClaudeEnvFrom));
-    if (isRecord(source?.env)) {
-      const localEnv = isRecord(settings.env) ? settings.env : {};
-      // Preserve per-bot-only env entries, but refresh overlapping shared
-      // provider auth/model/proxy keys from the authoritative global config.
-      settings.env = { ...localEnv, ...source.env };
+    // A malformed/unreadable shared file is treated as a transient failure: do
+    // not erase the last known-good inherited env. A valid file with no `env`,
+    // however, is an authoritative deletion and must remove previously copied
+    // keys from the per-bot settings.
+    if (source) {
+      const inheritedStatePath = `${configPath}.botmux-inherited-env.json`;
+      const previousState = readJsonFile<InheritedClaudeEnvState>(inheritedStatePath);
+      const previousInheritedKeys = previousState?.version === 1 && Array.isArray(previousState.keys)
+        ? previousState.keys.filter((key): key is string => typeof key === 'string')
+        : [];
+      const localEnv = isRecord(settings.env) ? { ...settings.env } : {};
+      for (const key of previousInheritedKeys) delete localEnv[key];
+
+      const sharedEnv = isRecord(source.env) ? source.env : {};
+      const mergedEnv = { ...localEnv, ...sharedEnv };
+      if (Object.keys(mergedEnv).length > 0) settings.env = mergedEnv;
+      else delete settings.env;
+
+      // Track exactly which keys came from the shared file so a later cold
+      // spawn can propagate deletions without discarding per-bot-only entries.
+      inheritedEnvState = {
+        path: inheritedStatePath,
+        content: `${JSON.stringify({ version: 1, keys: Object.keys(sharedEnv).sort() }, null, 2)}\n`,
+      };
     }
   }
   const existingHooks = settings.hooks ?? {};
@@ -219,6 +249,11 @@ function installClaudeSettings(
   // An inherited env can contain provider credentials. Keep the per-bot copy
   // owner-only even if the pre-existing hook-only file was created as 0644.
   const changed = writeIfChanged(configPath, content, inheritClaudeEnvFrom ? 0o600 : undefined);
+  if (inheritedEnvState) {
+    // Publish the ownership record only after the corresponding settings write
+    // succeeds, so a failed settings update cannot claim per-bot keys as shared.
+    writeIfChanged(inheritedEnvState.path, inheritedEnvState.content, 0o600);
+  }
   if (changed) {
     logger.info(`[hook] 已写入 Claude hook → ${configPath}`);
   } else {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -148,6 +148,7 @@ import {
   enabledPluginDependents,
 } from './core/plugins/dependencies.js';
 import { authorizeV3DaemonCommand } from './workflows/v3/cli-daemon-command-authority.js';
+import { resolveDaemonIpcPort } from './utils/daemon-discovery.js';
 
 // Resolve the CLI's UI locale once from the global config file, so subsequent
 // CLI output (and any t() callers that don't pass an explicit locale) honour
@@ -7744,8 +7745,18 @@ async function cmdSessionReady(): Promise<void> {
   // env 缺失 → adopt / 非 botmux 会话；就绪门控对它们不适用，静默放行。
   if (!sessionId || !larkAppId) process.exit(0);
 
-  const daemon = findDaemon(larkAppId);
-  if (daemon) {
+  // Host sessions discover the owning daemon through its descriptor. Linux
+  // bwrap / read-isolated sessions deliberately cannot read that directory,
+  // so use the worker-injected loopback port as a fallback. The port is not a
+  // credential: /api/session-ready still verifies the rotating per-turn
+  // capability carried below.
+  let discoveredPort: number | undefined;
+  try { discoveredPort = findDaemon(larkAppId)?.ipcPort; } catch { /* masked/unreadable registry */ }
+  const ipcPort = resolveDaemonIpcPort(
+    discoveredPort,
+    process.env.BOTMUX_DAEMON_IPC_PORT,
+  );
+  if (ipcPort) {
     try {
       const relayDir = process.env.BOTMUX_SEND_RELAY;
       const originCapability = readManagedOriginCapability(
@@ -7774,9 +7785,9 @@ async function cmdSessionReady(): Promise<void> {
         try { hostSecret = loadDaemonIpcSecret(); } catch { /* Seatbelt/read-isolated CLI */ }
       }
       if (!hostSecret) {
-        await fetch(`http://127.0.0.1:${daemon.ipcPort}/api/session-ready`, init);
+        await fetch(`http://127.0.0.1:${ipcPort}/api/session-ready`, init);
       } else {
-        await fetchDaemonIpc(daemon.ipcPort, '/api/session-ready', init, hostSecret);
+        await fetchDaemonIpc(ipcPort, '/api/session-ready', init, hostSecret);
       }
     } catch { /* daemon 不可达 → 放弃，worker 走超时兜底 */ }
   }

--- a/src/core/managed-origin-capability.ts
+++ b/src/core/managed-origin-capability.ts
@@ -101,3 +101,20 @@ export function readManagedOriginCapability(
     return null;
   }
 }
+
+/**
+ * Verify that the child-visible capability transport contains the exact token
+ * currently authorized by the worker. Existence alone is insufficient: a
+ * writable relay can contain a stale token, malformed JSON, or even a directory
+ * at the reserved path after a prior sandbox generation.
+ */
+export function hasMatchingManagedOriginCapability(
+  dataDir: string,
+  sessionId: string | undefined,
+  expectedCapability: string | undefined,
+  relayDir?: string,
+): boolean {
+  if (!expectedCapability) return false;
+  return readManagedOriginCapability(dataDir, sessionId, relayDir)?.capability
+    === expectedCapability;
+}

--- a/src/utils/daemon-discovery.ts
+++ b/src/utils/daemon-discovery.ts
@@ -33,6 +33,30 @@ function registryDir(): string {
   return join(resolveBotmuxDataDir(), 'dashboard-daemons');
 }
 
+/** Parse a loopback daemon IPC port from a descriptor or injected env value. */
+export function parseDaemonIpcPort(value: unknown): number | undefined {
+  const port = typeof value === 'number'
+    ? value
+    : typeof value === 'string' && value.trim()
+      ? Number(value)
+      : Number.NaN;
+  return Number.isSafeInteger(port) && port >= 1 && port <= 65_535
+    ? port
+    : undefined;
+}
+
+/**
+ * Prefer host-visible daemon discovery, then fall back to the port explicitly
+ * injected into an isolated CLI. The fallback is only a loopback address
+ * marker; individual daemon routes still authenticate their own requests.
+ */
+export function resolveDaemonIpcPort(
+  discovered: unknown,
+  injected: unknown,
+): number | undefined {
+  return parseDaemonIpcPort(discovered) ?? parseDaemonIpcPort(injected);
+}
+
 /** List every daemon whose descriptor file is fresh (heartbeat within STALE_MS). */
 export function listOnlineDaemons(): OnlineDaemonInfo[] {
   const dir = registryDir();

--- a/src/utils/ready-gate.ts
+++ b/src/utils/ready-gate.ts
@@ -34,11 +34,16 @@
 /**
  * Decide whether the worker should ARM the ready-gate for a given spawn. The
  * gate is only valid when a SessionStart hook will actually fire — i.e. a FRESH
- * Claude-family spawn that re-runs the CLI binary with our `--settings`:
+ * ready-gated spawn whose hook/transport preflight succeeded:
  *
  *   - `injectsReadyHook`        — the adapter injects the hook (claude / seed).
+ *   - `readySignalAvailable`    — the effective config contains the hook (or the
+ *                                 CLI has a direct ready-command integration),
+ *                                 and an isolated child has a usable callback
+ *                                 route to the daemon.
  *   - NOT `adoptMode`           — adopt panes are pre-existing, never spawned with
- *                                 our `--settings`, so they can't get the hook.
+ *                                 our ready integration, so they can't get a
+ *                                 fresh SessionStart signal.
  *   - NOT `willReattachPersistent` — on daemon restart / worker recovery the
  *                                 worker re-attaches to an existing tmux/zellij/
  *                                 herdr session and does NOT re-run the CLI's
@@ -51,17 +56,21 @@
  * exactly as before (readyPattern + quiescence).
  *
  * NB: `wrapperCli=aiden x claude` strips our process-level `--settings`, but the
- * SessionStart hook is ALSO installed globally (~/.claude/settings.json — see
+ * SessionStart hook is installed in the effective settings.json (see
  * claude-code.ts hookInstall.sessionStartCommand), which aiden's Claude still
  * reads. So the real signal fires there too → we KEEP arming for that case
  * (no readyPattern fallback, which could misjudge).
  */
 export function shouldArmReadyGate(state: {
   injectsReadyHook: boolean;
+  readySignalAvailable: boolean;
   adoptMode: boolean;
   willReattachPersistent: boolean;
 }): boolean {
-  return state.injectsReadyHook && !state.adoptMode && !state.willReattachPersistent;
+  return state.injectsReadyHook
+    && state.readySignalAvailable
+    && !state.adoptMode
+    && !state.willReattachPersistent;
 }
 
 export class ReadyGate {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -174,8 +174,13 @@ import { config, resolveChatBotDiscoveryConfig } from './config.js';
 import * as sessionStore from './services/session-store.js';
 import * as pty from 'node-pty';
 import { createHash } from 'node:crypto';
-import { installHook, type HookInstallConfig } from './adapters/hook-installer.js';
+import {
+  hasInstalledSessionReadyHook,
+  installHook,
+  type HookInstallConfig,
+} from './adapters/hook-installer.js';
 import { hookCommandFor } from './adapters/hook-command.js';
+import { parseDaemonIpcPort } from './utils/daemon-discovery.js';
 import { withCodexAppContext } from './utils/codex-app-context.js';
 import { resolveCodexAppFinalTurnIdentity } from './adapters/cli/codex-app-turn.js';
 import { RunnerControlDecoder } from './adapters/cli/runner-control-channel.js';
@@ -280,6 +285,23 @@ function provisionIsolatedBotHome(
     if (isClaude) {
       const cdir = join(botHome, 'claude');
       mkdirSync(cdir, { recursive: true });
+      // Settings: read-isolated Claude uses a fresh CLAUDE_CONFIG_DIR, so it
+      // otherwise loses provider auth/model/proxy values held in the shared
+      // ~/.claude/settings.json `env` map. Merge that map on EVERY cold spawn,
+      // then install botmux hooks into the same per-bot file. Global hooks and
+      // unrelated top-level settings are not inherited.
+      const isolatedSettingsPath = join(cdir, 'settings.json');
+      if (hookInstall) {
+        try {
+          installHook(cliId, {
+            ...hookInstall,
+            configPath: isolatedSettingsPath,
+            inheritClaudeEnvFrom: join(homedir(), '.claude', 'settings.json'),
+          }, hookCommandFor(cliId));
+        } catch (e) {
+          log(`[read-isolation] WARN per-bot settings/hook install failed: ${(e as Error).message}`);
+        }
+      }
       // Auth: a fresh CLAUDE_CONFIG_DIR does NOT inherit the shared account's OAuth
       // token → keep <cdir>/.credentials.json synced to the FRESHEST valid credential
       // on EVERY spawn (verified: Claude logs in from that file). Refreshing here (not
@@ -287,20 +309,16 @@ function provisionIsolatedBotHome(
       // spawn — no separate sync step needed. Same shared account for every bot.
       const fresh = freshestClaudeCred();
       if (fresh) writeCredIfChanged(join(cdir, '.credentials.json'), fresh);
-      else if (!existsSync(join(cdir, '.credentials.json'))) {
-        log(`[read-isolation] WARN no Claude credential found (keychain or ~/.claude/.credentials.json) — bot may hit login screen`);
+      else if (
+        !existsSync(join(cdir, '.credentials.json'))
+        && !claudeSettingsHasProviderAuth(isolatedSettingsPath)
+      ) {
+        log(`[read-isolation] WARN no Claude provider auth found (global settings env, keychain, or ~/.claude/.credentials.json) — bot may hit login screen`);
       }
       // State: seed <cdir>/.claude.json from the GLOBAL one MINUS `projects` (keeps the
       // onboarding/promo "seen" flags + account so no dialogs appear, without leaking
       // other projects' data), then trust this bot's cwd. Merge-safe on resume.
       seedAndTrustClaudeState(join(cdir, '.claude.json'), workingDir, log);
-      // Hooks: install the SessionStart-ready + askUserQuestion hooks into the PER-BOT
-      // settings.json (global ~/.claude/settings.json is Seatbelt-denied), else the
-      // worker's ready gate falls back to a slow timeout and AskUserQuestion won't relay.
-      if (hookInstall) {
-        try { installHook(cliId, { ...hookInstall, configPath: join(cdir, 'settings.json') }, hookCommandFor(cliId)); }
-        catch (e) { log(`[read-isolation] WARN per-bot hook install failed: ${(e as Error).message}`); }
-      }
     } else {
       const cdir = join(botHome, 'codex');
       mkdirSync(cdir, { recursive: true });
@@ -315,6 +333,23 @@ function provisionIsolatedBotHome(
     }
   } catch (e) {
     log(`[read-isolation] WARN provisioning bot home failed: ${(e as Error).message}`);
+  }
+}
+
+function claudeSettingsHasProviderAuth(settingsPath: string): boolean {
+  try {
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>;
+    const env = settings.env;
+    if (!env || typeof env !== 'object' || Array.isArray(env)) return false;
+    const record = env as Record<string, unknown>;
+    return (
+      (typeof record.ANTHROPIC_AUTH_TOKEN === 'string' && record.ANTHROPIC_AUTH_TOKEN.length > 0)
+      || (typeof record.ANTHROPIC_API_KEY === 'string' && record.ANTHROPIC_API_KEY.length > 0)
+      || record.CLAUDE_CODE_USE_BEDROCK === '1'
+      || record.CLAUDE_CODE_USE_VERTEX === '1'
+    );
+  } catch {
+    return false;
   }
 }
 
@@ -5340,6 +5375,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   // JSONL/pid/bridge gate below keys off it instead of `cliId === 'claude-code'`,
   // so a fork inherits the whole submit-confirm + bridge-fallback machinery.
   let claudeDataDir = cliAdapter.claudeDataDir;
+  let effectiveReadyHookInstall: HookInstallConfig | undefined = cliAdapter.hookInstall;
   // When this session will be file-sandboxed, the CLI's session jsonl is written
   // into the overlay's EPHEMERAL home upper (CLAUDE_CONFIG_DIR lives under $HOME),
   // invisible at the real path the bridge normally watches → "Bridge mark expired"
@@ -5351,7 +5387,10 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     (effectiveBackendType === 'pty' || effectiveBackendType === 'tmux') &&
     !!process.env.SESSION_DATA_DIR;
   if (claudeDataDir && willFileSandbox) {
-    const redirected = sandboxedClaudeDataDir(cfg.sessionId, claudeDataDir);
+    const redirected = sandboxedClaudeDataDir(cfg.sessionId, claudeDataDir, {
+      sourceWorkingDir: cfg.workingDir,
+      dataDir: process.env.SESSION_DATA_DIR,
+    });
     log(`[sandbox] redirecting Claude bridge dataDir → overlay upper: ${redirected}`);
     claudeDataDir = redirected;
   }
@@ -5432,6 +5471,12 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     // Provision the per-bot config dir (auth + onboarding/trust seed + hooks for claude;
     // auth/config copy for codex) so the CLI starts fully set up under the Seatbelt wrapper.
     provisionIsolatedBotHome(isolationBotHome, cfg.workingDir, isClaudeFam, cfg.cliId, cliAdapter.hookInstall, log);
+    if (isClaudeFam && effectiveReadyHookInstall) {
+      effectiveReadyHookInstall = {
+        ...effectiveReadyHookInstall,
+        configPath: join(claudeDataDir!, 'settings.json'),
+      };
+    }
     if (cliAdapter.mcpGateway) {
       const isolatedConfigPath = isClaudeFam
         ? join(claudeDataDir!, '.claude.json')
@@ -6404,15 +6449,22 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     }
   }
 
-  // Arm the ready-gate for FRESH Claude-family spawns (which inject the
-  // SessionStart hook via --settings; see claude-code.ts buildArgs). Until
+  // Arm the ready-gate for FRESH ready-integrated spawns. Until
   // `botmux session-ready` fires (daemon → 'session_ready' IPC → releaseReadyGate)
   // we hold the first prompt so a cjadk-style startup selector's ❯ can't eat it.
-  // shouldArmReadyGate() excludes adopt (pre-existing pane, no --settings) AND
+  // shouldArmReadyGate() excludes adopt (pre-existing pane, no fresh hook) AND
   // persistent-backend reattach (daemon restart re-attaches an already-running
   // tmux/zellij/herdr Claude WITHOUT re-running its bin/args → no new
   // SessionStart hook → arming would hold the first post-recovery message until
-  // the timeout). Fallback: release after READY_SIGNAL_TIMEOUT_MS → readyPattern.
+  // the timeout).
+  //
+  // Installation is best-effort, so verify the hook in the EFFECTIVE config
+  // (global for ordinary sessions, per-bot CLAUDE_CONFIG_DIR under read
+  // isolation) before arming. Isolated children also need the injected loopback
+  // port plus a published rotating capability; without either the hook could
+  // run but never reach the daemon. A failed preflight leaves the gate open and
+  // immediately falls back to the adapter's normal readyPattern/quiescence path
+  // instead of blindly waiting READY_SIGNAL_TIMEOUT_MS.
   readyGate = new ReadyGate();
   if (readySignalTimer) { clearTimeout(readySignalTimer); readySignalTimer = null; }
   if (readyFlushSettleTimer) { clearTimeout(readyFlushSettleTimer); readyFlushSettleTimer = null; }
@@ -6420,8 +6472,38 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   promptReadyDetectedDuringSettle = false;
   // Reset quiescence baseline so the settle measures silence from THIS spawn.
   lastPtyOutputAtMs = Date.now();
+  const readyHookAvailable = effectiveReadyHookInstall
+    ? hasInstalledSessionReadyHook(effectiveReadyHookInstall)
+    : true; // Hermes emits BOTMUX_READY_COMMAND directly instead of a config hook.
+  const isolatedReadyTransportRequired = sandboxOn || willReadIsolate;
+  const readyPortAvailable = !isolatedReadyTransportRequired
+    || parseDaemonIpcPort(childEnv.BOTMUX_DAEMON_IPC_PORT) !== undefined;
+  const readyCapabilityPath = sandboxRelayOutbox
+    ? join(sandboxRelayOutbox, RELAY_ORIGIN_CAPABILITY_BASENAME)
+    : readIsolationOriginCapabilityFile;
+  const readyCapabilityAvailable = !isolatedReadyTransportRequired
+    || (
+      sandboxRelayCapability !== null
+      && !!readyCapabilityPath
+      && existsSync(readyCapabilityPath)
+    );
+  const readySignalAvailable =
+    readyHookAvailable && readyPortAvailable && readyCapabilityAvailable;
+  const freshReadyGateCandidate =
+    cliAdapter.injectsReadyHook === true
+    && cfg.adoptMode !== true
+    && !willReattachPersistent;
+  if (freshReadyGateCandidate && !readySignalAvailable) {
+    const reasons = [
+      ...(!readyHookAvailable ? ['SessionStart hook missing from effective config'] : []),
+      ...(!readyPortAvailable ? ['BOTMUX_DAEMON_IPC_PORT missing/invalid'] : []),
+      ...(!readyCapabilityAvailable ? ['ready capability transport unavailable'] : []),
+    ];
+    log(`Ready gate skipped — preflight failed: ${reasons.join('; ')}`);
+  }
   if (shouldArmReadyGate({
     injectsReadyHook: cliAdapter.injectsReadyHook === true,
+    readySignalAvailable,
     adoptMode: cfg.adoptMode === true,
     willReattachPersistent,
   })) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -185,6 +185,7 @@ import { withCodexAppContext } from './utils/codex-app-context.js';
 import { resolveCodexAppFinalTurnIdentity } from './adapters/cli/codex-app-turn.js';
 import { RunnerControlDecoder } from './adapters/cli/runner-control-channel.js';
 import {
+  hasMatchingManagedOriginCapability,
   managedOriginCapabilityPath,
   RELAY_ORIGIN_CAPABILITY_BASENAME,
   replaceManagedOriginCapabilityFile,
@@ -856,7 +857,7 @@ let currentBotmuxTurnId: string | undefined;
 let currentBotmuxDispatchAttempt: number | undefined;
 let currentVcMeetingImTurnOrigin: VcMeetingImTurnOrigin | undefined;
 let durableTurnInFlight = false;
-function publishSandboxRelayCapability(opts: { failClosed?: boolean } = {}): void {
+function publishSandboxRelayCapability(opts: { failClosed?: boolean } = {}): boolean {
   const capability = {
     token: randomBytes(32).toString('hex'),
     ...(currentBotmuxTurnId ? { turnId: currentBotmuxTurnId } : {}),
@@ -885,17 +886,32 @@ function publishSandboxRelayCapability(opts: { failClosed?: boolean } = {}): voi
         }]
       : []),
   ];
+  let publishError: unknown;
   for (const file of files) {
     try {
       replaceManagedOriginCapabilityFile(file.path, file.body);
     } catch (err: any) {
       log(`Failed to publish managed origin capability: ${err?.message ?? err}`);
-      if (opts.failClosed) {
-        unlinkManagedOriginCapabilityFiles();
-        throw err;
-      }
+      publishError = err;
+      break;
     }
   }
+
+  if (publishError) {
+    // The disk/daemon/worker views must rotate as one authority generation. If
+    // the child-visible transport cannot publish the new token, revoke the old
+    // generation and leave no in-memory authority for ready/send preflights to
+    // mistake as usable. Any files written before a later failure are removed
+    // by the revocation helper as well.
+    completeManagedTurnOriginRevocation(
+      sandboxRelayCapability,
+      currentBotmuxTurnId,
+      currentBotmuxDispatchAttempt,
+    );
+    if (opts.failClosed) throw publishError;
+    return false;
+  }
+
   sandboxRelayCapability = capability;
   if (sessionId) {
     send({
@@ -908,6 +924,7 @@ function publishSandboxRelayCapability(opts: { failClosed?: boolean } = {}): voi
         : {}),
     });
   }
+  return true;
 }
 
 function unlinkManagedOriginCapabilityFiles(): void {
@@ -6478,14 +6495,12 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
   const isolatedReadyTransportRequired = sandboxOn || willReadIsolate;
   const readyPortAvailable = !isolatedReadyTransportRequired
     || parseDaemonIpcPort(childEnv.BOTMUX_DAEMON_IPC_PORT) !== undefined;
-  const readyCapabilityPath = sandboxRelayOutbox
-    ? join(sandboxRelayOutbox, RELAY_ORIGIN_CAPABILITY_BASENAME)
-    : readIsolationOriginCapabilityFile;
   const readyCapabilityAvailable = !isolatedReadyTransportRequired
-    || (
-      sandboxRelayCapability !== null
-      && !!readyCapabilityPath
-      && existsSync(readyCapabilityPath)
+    || hasMatchingManagedOriginCapability(
+      process.env.SESSION_DATA_DIR ?? '',
+      cfg.sessionId,
+      sandboxRelayCapability?.token,
+      sandboxRelayOutbox ?? undefined,
     );
   const readySignalAvailable =
     readyHookAvailable && readyPortAvailable && readyCapabilityAvailable;
@@ -6497,7 +6512,7 @@ function spawnCli(cfg: Extract<DaemonToWorker, { type: 'init' }>): void {
     const reasons = [
       ...(!readyHookAvailable ? ['SessionStart hook missing from effective config'] : []),
       ...(!readyPortAvailable ? ['BOTMUX_DAEMON_IPC_PORT missing/invalid'] : []),
-      ...(!readyCapabilityAvailable ? ['ready capability transport unavailable'] : []),
+      ...(!readyCapabilityAvailable ? ['ready capability transport missing, unreadable, or stale'] : []),
     ];
     log(`Ready gate skipped — preflight failed: ${reasons.join('; ')}`);
   }

--- a/test/daemon-discovery.test.ts
+++ b/test/daemon-discovery.test.ts
@@ -2,7 +2,25 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { listOnlineDaemons } from '../src/utils/daemon-discovery.js';
+import {
+  listOnlineDaemons,
+  parseDaemonIpcPort,
+  resolveDaemonIpcPort,
+} from '../src/utils/daemon-discovery.js';
+
+describe('daemon IPC port fallback', () => {
+  it('prefers a discovered port and otherwise accepts a valid injected port', () => {
+    expect(resolveDaemonIpcPort(4310, '9999')).toBe(4310);
+    expect(resolveDaemonIpcPort(undefined, '9999')).toBe(9999);
+  });
+
+  it.each([undefined, '', '0', '-1', '65536', '12.5', 'not-a-port'])(
+    'rejects invalid injected port %s',
+    (raw) => {
+      expect(parseDaemonIpcPort(raw)).toBeUndefined();
+    },
+  );
+});
 
 describe('daemon discovery', () => {
   let dir: string;

--- a/test/hook-installer.test.ts
+++ b/test/hook-installer.test.ts
@@ -124,6 +124,8 @@ describe('installHook — claude-settings', () => {
     const botmuxReady = ss.filter((g) => g.hooks?.some((e: any) => e.command.includes('cli.js') && e.command.trimEnd().endsWith('session-ready')));
     expect(botmuxReady.length).toBe(1);
     expect(botmuxReady[0].hooks[0].command).toBe(readyCmd2);
+    expect(hasInstalledSessionReadyHook(hookInstall)).toBe(false);
+    expect(hasInstalledSessionReadyHook({ ...hookInstall, sessionStartCommand: readyCmd2 })).toBe(true);
   });
 
   it('ready preflight fails closed for malformed or unrelated SessionStart config', () => {
@@ -205,6 +207,16 @@ describe('installHook — claude-settings', () => {
     expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe('global-token-v2');
     expect(settings.env.ANTHROPIC_BASE_URL).toBe('https://provider-2.example');
     expect(settings.env.BOT_LOCAL_ONLY).toBe('preserved');
+
+    // Shared deletions are authoritative on the next cold spawn, while keys
+    // that only ever existed in the per-bot file remain untouched.
+    writeFileSync(globalPath, JSON.stringify({ env: {} }));
+    installHook('claude-code', config, hookCommand);
+    settings = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(settings.env.ANTHROPIC_BASE_URL).toBeUndefined();
+    expect(settings.env.BOT_LOCAL_ONLY).toBe('preserved');
+    expect(statSync(`${configPath}.botmux-inherited-env.json`).mode & 0o777).toBe(0o600);
   });
 
   it('(c2) 已有同 hookCommand 的 PreToolUse entry 不会重复追加', () => {

--- a/test/hook-installer.test.ts
+++ b/test/hook-installer.test.ts
@@ -7,10 +7,13 @@
  *   (c) 既有无关配置保留（合并而非覆盖）
  */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { mkdtempSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { installHook } from '../src/adapters/hook-installer.js';
+import {
+  hasInstalledSessionReadyHook,
+  installHook,
+} from '../src/adapters/hook-installer.js';
 
 // ─── 辅助：在临时目录创建独立的 configPath ─────────────────────────────────
 
@@ -100,11 +103,18 @@ describe('installHook — claude-settings', () => {
 
   it('(d) sessionStartCommand 时同时写入 SessionStart 就绪 hook，且幂等去重（路径变化也算同一条）', () => {
     const readyCmd = '/usr/bin/node /path/to/cli.js session-ready';
-    installHook('claude-code', { configPath, format: 'claude-settings', sessionStartCommand: readyCmd }, hookCommand);
+    const hookInstall = {
+      configPath,
+      format: 'claude-settings' as const,
+      sessionStartCommand: readyCmd,
+    };
+    expect(hasInstalledSessionReadyHook(hookInstall)).toBe(false);
+    installHook('claude-code', hookInstall, hookCommand);
 
     let settings = JSON.parse(readFileSync(configPath, 'utf-8'));
     let ss: any[] = settings.hooks?.SessionStart ?? [];
     expect(ss.some((g) => g.hooks?.some((e: any) => e.command === readyCmd))).toBe(true);
+    expect(hasInstalledSessionReadyHook(hookInstall)).toBe(true);
 
     // 幂等：用 npm-global 风格的不同 cli.js 绝对路径再装，应替换而非叠加（仍只有一条 botmux 就绪 hook）
     const readyCmd2 = '/opt/npm/lib/node_modules/botmux/dist/cli.js session-ready';
@@ -116,10 +126,85 @@ describe('installHook — claude-settings', () => {
     expect(botmuxReady[0].hooks[0].command).toBe(readyCmd2);
   });
 
+  it('ready preflight fails closed for malformed or unrelated SessionStart config', () => {
+    mkdirSync(join(tmpDir, '.claude'), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({
+      hooks: {
+        SessionStart: [
+          { matcher: 'malformed-without-hooks' },
+          { hooks: [{ type: 'command', command: '/usr/bin/unrelated-ready-hook' }] },
+        ],
+      },
+    }));
+    expect(hasInstalledSessionReadyHook({
+      configPath,
+      format: 'claude-settings',
+      sessionStartCommand: '/usr/bin/node /path/to/cli.js session-ready',
+    })).toBe(false);
+  });
+
   it('(e) 不传 sessionStartCommand 时不写 SessionStart（保持旧行为）', () => {
     installHook('claude-code', { configPath, format: 'claude-settings' }, hookCommand);
     const settings = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(settings.hooks?.SessionStart).toBeUndefined();
+  });
+
+  it('read-isolation inherits only the global Claude env map and refreshes rotated auth', () => {
+    const globalPath = join(tmpDir, '.claude-global', 'settings.json');
+    mkdirSync(join(tmpDir, '.claude-global'), { recursive: true });
+    mkdirSync(join(tmpDir, '.claude'), { recursive: true });
+    writeFileSync(globalPath, JSON.stringify({
+      env: {
+        ANTHROPIC_AUTH_TOKEN: 'global-token-v1',
+        ANTHROPIC_BASE_URL: 'https://provider.example',
+        HTTP_PROXY: 'http://proxy.example',
+      },
+      hooks: {
+        SessionStart: [
+          { hooks: [{ type: 'command', command: '/usr/bin/global-unrelated-hook' }] },
+        ],
+      },
+      theme: 'global-theme-must-not-be-copied',
+    }));
+    writeFileSync(configPath, JSON.stringify({
+      env: {
+        ANTHROPIC_AUTH_TOKEN: 'stale-local-token',
+        BOT_LOCAL_ONLY: 'preserved',
+      },
+      theme: 'local-theme',
+    }));
+
+    const config = {
+      configPath,
+      format: 'claude-settings' as const,
+      sessionStartCommand: '/usr/bin/node /path/to/cli.js session-ready',
+      inheritClaudeEnvFrom: globalPath,
+    };
+    installHook('claude-code', config, hookCommand);
+
+    let settings = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(settings.env).toEqual({
+      ANTHROPIC_AUTH_TOKEN: 'global-token-v1',
+      BOT_LOCAL_ONLY: 'preserved',
+      ANTHROPIC_BASE_URL: 'https://provider.example',
+      HTTP_PROXY: 'http://proxy.example',
+    });
+    expect(settings.theme).toBe('local-theme');
+    expect(JSON.stringify(settings)).not.toContain('global-unrelated-hook');
+    expect(statSync(configPath).mode & 0o777).toBe(0o600);
+
+    // Shared provider auth rotates: the next cold-spawn install refreshes it.
+    writeFileSync(globalPath, JSON.stringify({
+      env: {
+        ANTHROPIC_AUTH_TOKEN: 'global-token-v2',
+        ANTHROPIC_BASE_URL: 'https://provider-2.example',
+      },
+    }));
+    installHook('claude-code', config, hookCommand);
+    settings = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe('global-token-v2');
+    expect(settings.env.ANTHROPIC_BASE_URL).toBe('https://provider-2.example');
+    expect(settings.env.BOT_LOCAL_ONLY).toBe('preserved');
   });
 
   it('(c2) 已有同 hookCommand 的 PreToolUse entry 不会重复追加', () => {

--- a/test/managed-origin-capability.test.ts
+++ b/test/managed-origin-capability.test.ts
@@ -5,6 +5,7 @@ import {
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import {
+  hasMatchingManagedOriginCapability,
   managedOriginCapabilityPath,
   readManagedOriginCapability,
   RELAY_ORIGIN_CAPABILITY_BASENAME,
@@ -90,5 +91,28 @@ describe('managed origin capability transport', () => {
     });
     writeFileSync(relayPath, JSON.stringify({ token: 'not-a-capability' }));
     expect(readManagedOriginCapability(dir, 'session-a', relay)).toBeNull();
+  });
+
+  it('ready preflight rejects stale, malformed, and non-file relay capabilities', () => {
+    const dir = makeDir();
+    const relay = join(dir, 'relay');
+    mkdirSync(relay);
+    const relayPath = join(relay, RELAY_ORIGIN_CAPABILITY_BASENAME);
+    const current = '12'.repeat(32);
+
+    writeFileSync(relayPath, JSON.stringify({ token: current }));
+    expect(hasMatchingManagedOriginCapability(dir, 'session-a', current, relay)).toBe(true);
+    expect(hasMatchingManagedOriginCapability(dir, 'session-a', '34'.repeat(32), relay)).toBe(false);
+
+    writeFileSync(relayPath, '{broken-json');
+    expect(hasMatchingManagedOriginCapability(dir, 'session-a', current, relay)).toBe(false);
+
+    rmSync(relayPath, { force: true });
+    mkdirSync(relayPath);
+    expect(() => replaceManagedOriginCapabilityFile(
+      relayPath,
+      JSON.stringify({ token: current }),
+    )).toThrow();
+    expect(hasMatchingManagedOriginCapability(dir, 'session-a', current, relay)).toBe(false);
   });
 });

--- a/test/ready-gate.test.ts
+++ b/test/ready-gate.test.ts
@@ -16,7 +16,12 @@ import { describe, it, expect } from 'vitest';
 import { ReadyGate, shouldArmReadyGate } from '../src/utils/ready-gate.js';
 
 describe('shouldArmReadyGate', () => {
-  const base = { injectsReadyHook: true, adoptMode: false, willReattachPersistent: false };
+  const base = {
+    injectsReadyHook: true,
+    readySignalAvailable: true,
+    adoptMode: false,
+    willReattachPersistent: false,
+  };
 
   it('arms a fresh Claude-family spawn (hook will fire)', () => {
     expect(shouldArmReadyGate(base)).toBe(true);
@@ -24,6 +29,10 @@ describe('shouldArmReadyGate', () => {
 
   it('does NOT arm a non-Claude CLI (no SessionStart hook injected)', () => {
     expect(shouldArmReadyGate({ ...base, injectsReadyHook: false })).toBe(false);
+  });
+
+  it('does NOT arm when hook/transport preflight says the signal cannot arrive', () => {
+    expect(shouldArmReadyGate({ ...base, readySignalAvailable: false })).toBe(false);
   });
 
   it('does NOT arm adopt panes (pre-existing, never got our --settings)', () => {
@@ -38,7 +47,12 @@ describe('shouldArmReadyGate', () => {
   });
 
   it('reattach exclusion wins even for an otherwise-eligible fresh-looking spawn', () => {
-    expect(shouldArmReadyGate({ injectsReadyHook: true, adoptMode: false, willReattachPersistent: true })).toBe(false);
+    expect(shouldArmReadyGate({
+      injectsReadyHook: true,
+      readySignalAvailable: true,
+      adoptMode: false,
+      willReattachPersistent: true,
+    })).toBe(false);
   });
 
   it('KEEPS arming for aiden x claude: --settings is stripped but the SessionStart hook is installed globally', () => {

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect } from 'vitest';
 import { tmpdir, homedir } from 'node:os';
 import { join } from 'node:path';
 import { mkdtempSync, existsSync, writeFileSync, readFileSync, symlinkSync, rmSync, mkdirSync, realpathSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { buildSandboxArgs, buildRelayHostEnv, reexposeRunBinArgs, validateRelayRequest, materializeOutboxFile, prepareSandbox, resolveSandboxMountPath, sandboxedClaudeDataDir, sandboxCredentialHidePaths, resolveUserReadonlyRoots, sandboxOverlayPaths, type SandboxPlan } from '../src/adapters/backend/sandbox.js';
 import { createCodexAppAdapter } from '../src/adapters/cli/codex-app.js';
 import { computeSandboxDiff, applySandboxDiff, upperDir } from '../src/services/sandbox-land.js';
@@ -63,6 +64,16 @@ describe('buildSandboxArgs (overlay model)', () => {
     expect(bindDest(a, '--bind', '/data/sandboxes/s1/proj-merged')).toBe('/home/u/proj');
     const ci = a.indexOf('--chdir');
     expect(a[ci + 1]).toBe('/home/u/proj');
+  });
+
+  it('uses one project overlay when projectMount equals HOME (no shadowed home bind)', () => {
+    const a = buildSandboxArgs(plan({
+      home: '/home/u',
+      projectMount: '/home/u',
+    }));
+    expect(bindDest(a, '--bind', '/data/sandboxes/s1/home-merged')).toBeUndefined();
+    expect(bindDest(a, '--bind', '/data/sandboxes/s1/proj-merged')).toBe('/home/u');
+    expect(a.filter(x => x === '--bind')).toHaveLength(2); // project + outbox
   });
 
   it('masks hideDirs with a tmpfs and hideFiles with a read-only empty placeholder', () => {
@@ -216,6 +227,48 @@ describe('sandboxedClaudeDataDir (symlink HOME redirect)', () => {
       expect(sandboxedClaudeDataDir('sid-x', canonicalForm)).toBe(expected);
     } finally {
       if (prevHome !== undefined) process.env.HOME = prevHome;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('maps Claude data to proj-upper when the project mount is HOME', () => {
+    const root = tmp();
+    const home = join(root, 'home');
+    const dataDir = join(home, '.botmux', 'data');
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    mkdirSync(dataDir, { recursive: true });
+    const prevHome = process.env.HOME;
+    process.env.HOME = home;
+    try {
+      expect(sandboxedClaudeDataDir('sid-home', join(home, '.claude'), {
+        sourceWorkingDir: home,
+        dataDir,
+      })).toBe(join(dataDir, 'sandboxes', 'sid-home', 'proj-upper', '.claude'));
+    } finally {
+      if (prevHome !== undefined) process.env.HOME = prevHome;
+      else delete process.env.HOME;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps Claude data in home-upper for an ordinary project below HOME', () => {
+    const root = tmp();
+    const home = join(root, 'home');
+    const project = join(home, 'repo');
+    const dataDir = join(home, '.botmux', 'data');
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    mkdirSync(project, { recursive: true });
+    mkdirSync(dataDir, { recursive: true });
+    const prevHome = process.env.HOME;
+    process.env.HOME = home;
+    try {
+      expect(sandboxedClaudeDataDir('sid-repo', join(home, '.claude'), {
+        sourceWorkingDir: project,
+        dataDir,
+      })).toBe(join('/var/tmp/botmux-sbx', 'sid-repo', 'home-upper', '.claude'));
+    } finally {
+      if (prevHome !== undefined) process.env.HOME = prevHome;
+      else delete process.env.HOME;
       rmSync(root, { recursive: true, force: true });
     }
   });
@@ -746,6 +799,104 @@ describe('resolveUserReadonlyRoots', () => {
 });
 
 describe.skipIf(process.platform !== 'linux')('prepareSandbox hidePaths masks', () => {
+  it('runs with projectMount=HOME using one external project upper (no recursive/shadowed overlay)', () => {
+    const root = tmp();
+    const home = join(root, 'home');
+    const dataDir = join(home, '.botmux', 'data');
+    mkdirSync(dataDir, { recursive: true });
+    const sid = `home-project-${Math.random().toString(36).slice(2)}`;
+    // Simulate an old release's empty in-lower scratch so restart exercises the
+    // upgrade conversion instead of only the brand-new-session path.
+    mkdirSync(join(dataDir, 'sandboxes', sid, 'proj-upper'), { recursive: true });
+    mkdirSync(join(dataDir, 'sandboxes', sid, 'proj-work'), { recursive: true });
+    const prevHome = process.env.HOME;
+    process.env.HOME = home;
+    let r: ReturnType<typeof prepareSandbox> = null;
+    try {
+      r = prepareSandbox({
+        enabled: true,
+        cliId: 'claude-code',
+        sessionId: sid,
+        sourceWorkingDir: home,
+        dataDir,
+        cliBin: '/bin/sh',
+        cliArgs: ['-c', 'printf sandbox-write > probe.txt'],
+      });
+      if (r === null) return; // overlay runtime unavailable in this env
+
+      const run = spawnSync(r.bin, r.args, {
+        env: { ...process.env, ...r.env },
+        encoding: 'utf8',
+        timeout: 10_000,
+      });
+      expect(run.error).toBeUndefined();
+      expect(run.status).toBe(0);
+      expect(realpathSync(r.workDir)).toBe(join('/var/tmp/botmux-sbx', sid, 'proj-upper'));
+      expect(readFileSync(join(r.workDir, 'probe.txt'), 'utf8')).toBe('sandbox-write');
+      expect(existsSync(join(home, 'probe.txt'))).toBe(false);
+
+      const paths = sandboxOverlayPaths(dataDir, sid);
+      const homeBindPresent = r.args.some(
+        (value, index) => value === '--bind' && r!.args[index + 1] === paths.homeMerged,
+      );
+      expect(homeBindPresent).toBe(false);
+    } finally {
+      if (r) r.cleanup();
+      if (prevHome !== undefined) process.env.HOME = prevHome;
+      else delete process.env.HOME;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('treats a missing masked parent as a directory when another mask targets its child', () => {
+    const root = tmp();
+    const home = join(root, 'home');
+    const dataDir = join(home, '.botmux', 'data');
+    mkdirSync(dataDir, { recursive: true });
+    const sid = `missing-mask-parent-${Math.random().toString(36).slice(2)}`;
+    const maskedParent = join(home, '.lark-cli-bots');
+    const maskedChild = join(maskedParent, 'cli_sibling');
+    const prevHome = process.env.HOME;
+    process.env.HOME = home;
+    let r: ReturnType<typeof prepareSandbox> = null;
+    try {
+      r = prepareSandbox({
+        enabled: true,
+        cliId: 'claude-code',
+        sessionId: sid,
+        sourceWorkingDir: home,
+        dataDir,
+        cliBin: '/bin/sh',
+        cliArgs: ['-c', 'test -d "$HOME/.lark-cli-bots"'],
+        hidePaths: [maskedChild],
+      });
+      if (r === null) return; // overlay runtime unavailable in this env
+
+      expect(existsSync(maskedParent)).toBe(false);
+      const parentMaskIdx = r.args.findIndex(
+        (value, index) => value === '--tmpfs' && r!.args[index + 1] === maskedParent,
+      );
+      expect(parentMaskIdx).toBeGreaterThanOrEqual(0);
+      expect(r.args.findIndex(
+        (value, index) => value === '--ro-bind' && r!.args[index + 2] === maskedParent,
+      )).toBe(-1);
+
+      const run = spawnSync(r.bin, r.args, {
+        env: { ...process.env, ...r.env },
+        encoding: 'utf8',
+        timeout: 10_000,
+      });
+      expect(run.error).toBeUndefined();
+      expect(run.stderr).toBe('');
+      expect(run.status).toBe(0);
+    } finally {
+      if (r) r.cleanup();
+      if (prevHome !== undefined) process.env.HOME = prevHome;
+      else delete process.env.HOME;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('tilde-expands hidePaths so the documented `~/...` form masks the real path', () => {
     const src = tmp();
     writeFileSync(join(src, 'file.txt'), 'x');
@@ -843,6 +994,61 @@ describe.skipIf(process.platform !== 'linux')('prepareSandbox hidePaths masks', 
       if (prevHome !== undefined) process.env.HOME = prevHome;
       if (prevSandbox !== undefined) process.env.BOTMUX_SANDBOX = prevSandbox;
       rmSync(linkHome, { force: true });
+    }
+  });
+
+  it('canonicalizes a final credential mask through a symlinked HOME carve-out', () => {
+    const src = tmp();
+    writeFileSync(join(src, 'file.txt'), 'x');
+    const realHome = tmp();
+    const linkHome = join(tmpdir(), 'sbx-final-mask-link-' + Math.random().toString(36).slice(2));
+    symlinkSync(realHome, linkHome);
+    const dataDir = join(linkHome, '.botmux', 'data');
+    const ownBotHome = join(realHome, '.botmux', 'bots', 'cli_self');
+    const rawSendCred = join(linkHome, '.botmux', 'bots', 'cli_self', 'send-cred.json');
+    const canonicalSendCred = join(ownBotHome, 'send-cred.json');
+    mkdirSync(dataDir, { recursive: true });
+    mkdirSync(ownBotHome, { recursive: true });
+    writeFileSync(canonicalSendCred, 'TOP-SECRET');
+    const prevSandbox = process.env.BOTMUX_SANDBOX;
+    const prevHome = process.env.HOME;
+    delete process.env.BOTMUX_SANDBOX;
+    process.env.HOME = linkHome;
+    const sid = 'canonical-final-mask-' + Math.random().toString(36).slice(2);
+    let r: ReturnType<typeof prepareSandbox> = null;
+    try {
+      r = prepareSandbox({
+        enabled: true,
+        cliId: 'claude-code',
+        sessionId: sid,
+        sourceWorkingDir: src,
+        dataDir,
+        cliBin: '/bin/sh',
+        cliArgs: ['-c', 'test ! -s "$HOME/.botmux/bots/cli_self/send-cred.json"'],
+        trustedWritablePaths: [ownBotHome],
+        finalHidePaths: [rawSendCred],
+      });
+      if (r === null) return; // overlay runtime unavailable in this env
+
+      expect(r.args).toContain(canonicalSendCred);
+      expect(r.args).not.toContain(rawSendCred);
+      const run = spawnSync(r.bin, r.args, {
+        env: { ...process.env, ...r.env },
+        encoding: 'utf8',
+        timeout: 10_000,
+      });
+      expect(run.error).toBeUndefined();
+      expect(run.stderr).toBe('');
+      expect(run.status).toBe(0);
+    } finally {
+      if (r) r.cleanup();
+      if (prevHome !== undefined) process.env.HOME = prevHome;
+      else delete process.env.HOME;
+      if (prevSandbox !== undefined) process.env.BOTMUX_SANDBOX = prevSandbox;
+      else delete process.env.BOTMUX_SANDBOX;
+      rmSync(linkHome, { force: true });
+      rmSync(realHome, { recursive: true, force: true });
+      rmSync(src, { recursive: true, force: true });
     }
   });
 });

--- a/test/session-ready-cli.test.ts
+++ b/test/session-ready-cli.test.ts
@@ -1,0 +1,99 @@
+/**
+ * CLI boundary regression for a SessionStart hook running inside file/read
+ * isolation, where dashboard-daemons is deliberately masked. The hook must use
+ * BOTMUX_DAEMON_IPC_PORT and carry the rotating relay capability.
+ */
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { RELAY_ORIGIN_CAPABILITY_BASENAME } from '../src/core/managed-origin-capability.js';
+
+const CLI_PATH = join(__dirname, '..', 'src', 'cli.ts');
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function runSessionReady(
+  dataDir: string,
+  relayDir: string,
+  port: number,
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const env = {
+      ...process.env,
+      SESSION_DATA_DIR: dataDir,
+      BOTMUX_SESSION_ID: 'sess_ready_test',
+      BOTMUX_LARK_APP_ID: 'cli_ready_test',
+      BOTMUX_SEND_RELAY: relayDir,
+      BOTMUX_DAEMON_IPC_PORT: String(port),
+    };
+    delete env.BOTMUX_TURN_ID;
+    delete env.BOTMUX_DISPATCH_ATTEMPT;
+
+    const child = spawn(
+      process.execPath,
+      ['--import', 'tsx', CLI_PATH, 'session-ready'],
+      { env, stdio: ['pipe', 'pipe', 'pipe'] },
+    );
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => { stdout += chunk; });
+    child.stderr.on('data', (chunk: string) => { stderr += chunk; });
+    child.once('error', reject);
+    child.once('close', status => resolve({ status, stdout, stderr }));
+    child.stdin.end(JSON.stringify({ source: 'startup' }));
+  });
+}
+
+describe('botmux session-ready — isolated CLI fallback', () => {
+  it('uses the injected daemon port when the discovery directory is absent', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-session-ready-data-'));
+    const relayDir = mkdtempSync(join(tmpdir(), 'botmux-session-ready-relay-'));
+    tempDirs.push(dataDir, relayDir);
+    const capability = 'a'.repeat(64);
+    mkdirSync(relayDir, { recursive: true });
+    writeFileSync(
+      join(relayDir, RELAY_ORIGIN_CAPABILITY_BASENAME),
+      JSON.stringify({ token: capability }),
+    );
+
+    let receivedBody = '';
+    let receivedUrl = '';
+    const server = createServer((req, res) => {
+      receivedUrl = req.url ?? '';
+      req.setEncoding('utf8');
+      req.on('data', chunk => { receivedBody += chunk; });
+      req.on('end', () => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end('{"ok":true}');
+      });
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+
+    try {
+      const port = (server.address() as AddressInfo).port;
+      const result = await runSessionReady(dataDir, relayDir, port);
+      expect(result).toEqual({ status: 0, stdout: '', stderr: '' });
+      expect(receivedUrl).toBe('/api/session-ready');
+      expect(JSON.parse(receivedBody)).toMatchObject({
+        sessionId: 'sess_ready_test',
+        source: 'startup',
+        originCapability: capability,
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close(err => err ? reject(err) : resolve());
+      });
+    }
+  });
+});

--- a/test/write-input.test.ts
+++ b/test/write-input.test.ts
@@ -37,7 +37,11 @@ vi.mock('node:fs', async () => {
   return memfs.fs;
 });
 
-import { createClaudeCodeAdapter } from '../src/adapters/cli/claude-code.js';
+import {
+  CLAUDE_INPUT_CHUNK_BYTES,
+  chunkTextByUtf8Bytes,
+  createClaudeCodeAdapter,
+} from '../src/adapters/cli/claude-code.js';
 import { createAidenAdapter } from '../src/adapters/cli/aiden.js';
 import { createCocoAdapter } from '../src/adapters/cli/coco.js';
 import { createCodexAdapter } from '../src/adapters/cli/codex.js';
@@ -605,6 +609,30 @@ describe('writeInput: edge cases', () => {
     expect(pty.sendText).toHaveBeenCalledWith('check /tmp/a.png');
     expect(pty.sendText).toHaveBeenCalledWith('Session ID: x');
     expect(pty.sendSpecialKeys).toHaveBeenLastCalledWith('Enter');
+  });
+
+  it('claude-code: chunks one long Unicode line into paced UTF-8-safe sends', async () => {
+    const pty = makeTmuxPty();
+    const adapter = createClaudeCodeAdapter('/bin/claude');
+    const content = `<user_message>${'中文🙂abc'.repeat(80)}</user_message>`;
+
+    await adapter.writeInput(pty, content);
+
+    const chunks = pty.sendText.mock.calls.map(call => call[0]);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join('')).toBe(content);
+    expect(chunks.every(chunk => Buffer.byteLength(chunk, 'utf8') <= CLAUDE_INPUT_CHUNK_BYTES)).toBe(true);
+    expect(pty.sendSpecialKeys).toHaveBeenLastCalledWith('Enter');
+    expect(pty.pasteText).not.toHaveBeenCalled();
+  });
+
+  it('chunkTextByUtf8Bytes never splits surrogate pairs and round-trips exactly', () => {
+    const content = '甲🙂e\u0301乙🚀'.repeat(20);
+    const chunks = chunkTextByUtf8Bytes(content, 11);
+    expect(chunks.join('')).toBe(content);
+    expect(chunks.every(chunk => Buffer.byteLength(chunk, 'utf8') <= 11)).toBe(true);
+    expect(chunks.every(chunk => !/[\uD800-\uDBFF]$/.test(chunk))).toBe(true);
+    expect(chunks.every(chunk => !/^[\uDC00-\uDFFF]/.test(chunk))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## 一句话说明

这次修复覆盖的是一条完整链路：

**飞书首轮消息 → Worker 准备隔离环境 → Claude 启动并发出 ready → Worker 输入 prompt → Claude 写入 JSONL → botmux 确认消息已提交。**

旧实现中，这条链路在 Linux 文件沙盒 / 读隔离组合下有多个相互放大的缺陷，因此不是单独补一个 hook 就能解决。

## 用户可见问题

开启沙盒后，新话题的第一条消息可能出现以下现象：

1. Claude 已显示输入界面，但 botmux 仍等待约 45 秒。
2. 超时后 botmux 才把首轮 prompt 写入终端。
3. 较长的 XML、多行引用或单个长行触发 Claude Code 的粘贴检测。
4. 反斜杠或换行留在输入框中，Enter 没有真正提交。
5. Claude 会话 JSONL 中没有新增 user record，botmux 最终提示“未能确认提交”。

## 根因与对应修复

| 环节 | 旧实现的问题 | 本 PR 的处理 |
| --- | --- | --- |
| Claude 有效配置 | 隔离会话使用独立 `CLAUDE_CONFIG_DIR`，看不到共享 `~/.claude/settings.json` 中的 provider env；SessionStart hook 也可能安装在 Claude 实际不读取的位置 | 每次冷启动把共享配置中的 `env` 合并到 per-bot `settings.json`，再把 botmux hooks 安装到同一个有效配置文件；文件权限收紧为 `0600` |
| ready 回调 | 沙盒会屏蔽 daemon registry，hook 即使执行，也无法通过原来的文件发现机制找到 daemon | Worker 向隔离子进程注入 loopback IPC 端口；`session-ready` 使用该端口回调，并继续携带现有轮换 capability 做鉴权 |
| ready gate | Worker 只根据 adapter 声明就假设 hook 一定可用，hook 缺失或回调链路不可达时仍盲等 45 秒 | 启动前检查有效配置中的 hook、IPC 端口和 capability；任何一项缺失就不武装 ready gate，直接使用已有的 `readyPattern + quiescence` 路径 |
| prompt 输入 | 原来只在“行与行之间”限速；单个超长行仍会一次性写入并触发 Claude Code paste detector | 每个非空行按最多 96 UTF-8 字节拆块并限速发送；按 Unicode code point 切分，不会拆坏中文、Emoji 或代理对 |
| HOME / project overlay | 当工作目录就是 HOME 时，HOME overlay 与 project overlay 被连续 bind 到同一目标，后一个挂载会遮蔽前一个；upper/work 还可能位于自身 lower 内 | `cwd=HOME` 时只创建一个最终生效的 project overlay；实际 upper/work 放在 `/var/tmp/botmux-sbx/<session>/`，稳定 land 路径保留为 symlink |
| JSONL bridge | 代码固定认为 Claude 数据写入 `home-upper`，但 `cwd=HOME` 时真正生效的是 project overlay | 根据实际 winning overlay 计算 Claude data dir：普通项目监听 `home-upper`，HOME 项目监听 `proj-upper` |
| 敏感路径 mask | symlink HOME 下目的路径不一致；缺失父目录会被误判成文件，后续再挂载子 mask 时出现 `ENOTDIR` | 通过最深存在祖先进行规范化；若一个缺失路径包含其他待 mask 子路径，则按目录创建空挂载 |

## 修复后的启动时序

```mermaid
sequenceDiagram
    autonumber
    participant L as 飞书话题
    participant D as botmux Daemon
    participant W as Worker
    participant B as Linux bwrap / overlay
    participant C as Claude Code

    L->>D: 首轮消息
    D->>W: 初始化会话并暂存首轮 prompt
    W->>W: 合并共享 Claude env 到 per-bot settings
    W->>W: 安装 SessionStart / AskUserQuestion hooks
    W->>W: 创建轮换 capability 并注入 daemon IPC 端口
    W->>B: 准备 overlay、敏感路径 masks 和 outbox
    B->>C: 使用隔离后的配置启动 Claude
    C->>D: SessionStart hook 调用 /api/session-ready<br/>携带 sessionId 与 capability
    D-->>W: session_ready IPC
    W->>W: 释放首轮 ready gate
    W->>C: 按 96 UTF-8 字节分块、限速输入 prompt
    C->>B: 提交 user turn 并写入 JSONL
    B-->>W: Bridge 在实际 winning upper 中观察到记录
    W-->>D: 确认首轮消息已提交
```

这里的 daemon 端口本身不是凭证。`/api/session-ready` 仍校验当前会话的轮换 capability；只是把“如何找到 daemon”从被 mask 的 registry 文件，补充为 Worker 明确注入的 loopback 地址。

## Overlay 特殊场景

普通项目目录与 `cwd=HOME` 的落盘位置不同：

```mermaid
flowchart LR
    subgraph Normal["普通项目：HOME 与 project 不重叠"]
        H1["真实 HOME lower"] --> HO["home overlay"]
        HU["/var/tmp/.../home-upper"] --> HO
        P1["真实 project lower"] --> PO["project overlay"]
        PU1["data/sandboxes/.../proj-upper"] --> PO
        HO --> CH1["Claude HOME"]
        PO --> CW1["项目工作目录"]
    end

    subgraph HomeProject["cwd = HOME：只保留一个 winning overlay"]
        H2["真实 HOME / project lower"] --> WO["project overlay"]
        PU2["/var/tmp/.../proj-upper"] --> WO
        WO --> CH2["Claude HOME 与项目工作目录"]
        LP["稳定 land 路径"] -. symlink .-> PU2
    end
```

兼容旧沙盒目录时：

- 旧 `proj-upper` 为空：自动转换为外部 scratch + symlink。
- 旧 `proj-upper` 非空：fail closed，保留原 changeset 并要求先 land / 备份，避免静默丢失 overlay whiteout 或 xattr。

## 代码落点

- `src/worker.ts`、`src/adapters/hook-installer.ts`
  - 准备 Claude 隔离配置、同步 env、安装 hook、执行 ready preflight。
- `src/cli.ts`、`src/utils/daemon-discovery.ts`、`src/utils/ready-gate.ts`
  - 完成隔离环境中的 daemon 回调与 gate 判定。
- `src/adapters/cli/claude-code.ts`
  - 实现 UTF-8 安全的长行分块输入。
- `src/adapters/backend/sandbox.ts`
  - 修复 HOME/project overlay 重叠、bridge 路径、外部 upper/work 和 mask 分类。
- `test/*`
  - 覆盖 hook/env 继承、isolated ready CLI、HOME overlay、嵌套 mask、symlink HOME 和长 Unicode 行。

## 影响面

| 维度 | 影响 |
| --- | --- |
| Linux + 文件沙盒 + Claude fresh spawn | 主要修复场景 |
| Claude read isolation | per-bot settings 会在每次冷启动同步共享 provider env 与 hooks |
| 其他 CLI 的 Linux 文件沙盒 | 共享 HOME 重叠和 mask 分类逻辑会受益；没有修改它们的输入协议 |
| sandbox off | 不进入 overlay / 隔离回调路径，行为不变 |
| macOS / Windows | 不走 Linux bwrap overlay，行为不变 |
| adopt / persistent backend reattach | 仍不武装 fresh SessionStart ready gate，恢复语义不变 |
| 网络策略 | 没有新增外网权限，也没有改变当前 sandbox 网络策略 |

## 部署与会话兼容

- 修复对**新建或冷启动**的沙盒会话生效。
- 已经运行的 persistent pane / bwrap 仍保留创建时的挂载与配置；需要 suspend 后由下一条消息冷启动，或新建话题验证。
- ready preflight 的策略是 fail open to existing readiness detection，而不是 fail open to unsandboxed execution：沙盒创建失败仍保持原有 fail-safe，不会静默退化为无沙盒运行。

## 验证

- `pnpm build`：通过，且已 rebase 到最新 `origin/master` 后重跑。
- 定向回归：6 个文件、224 个测试全部通过。
  - `test/sandbox.test.ts`
  - `test/hook-installer.test.ts`
  - `test/ready-gate.test.ts`
  - `test/daemon-discovery.test.ts`
  - `test/write-input.test.ts`
  - `test/session-ready-cli.test.ts`
- dist / CLI 回归：4 个文件、68 个测试全部通过。
  - `test/workflow-cli.test.ts`
  - `test/preset-export-cli.test.ts`
  - `test/whiteboard-cli.test.ts`
  - `test/workflow-c0-isolation.test.ts`
- GitHub Actions `build`：通过。
- 飞书 live 实测：
  - sandbox on 的 Claude 会话中，一条 633 字符首轮消息成功写入会话 JSONL，并收到 assistant 回复。
  - 隔离配置中同时存在 SessionStart hook、provider auth 和 base URL。
  - `cwd=HOME` 使用单一 project overlay，不再出现 HOME overlay 被遮蔽。

## 本机完整测试基线说明

完整 `pnpm test` 试跑未宣称全绿：本机 Node 24 / Linux 环境中，`test/v3-worker-fence.test.ts` 有 3 个进程发现用例返回 fail-closed `ambiguous`；已在临时 detached、未修改的 `origin/master` 上复现完全相同结果，与本 PR 无关。

此外还有本机 npm `EALLOWSCRIPTS`、`/proc/self/comm=MainThread` 等宿主环境项。最初并行 build/test 导致的 `dist/cli.js missing` 已改为串行补跑，相关 68 个用例全部通过。
