### PR TITLE
fix(core): /adopt 发现兼容含空格的 tmux 会话名

### DIFF
--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -671,8 +671,10 @@ export function discoverAdoptableSessions(filterCliId?: CliId): AdoptableSession
     const lines = panesRaw.split('\n').filter(Boolean);
 
     for (const line of lines) {
-      // Parse: "session_name:window_index.pane_index pane_pid"
-      const spaceIdx = line.indexOf(' ');
+      // Parse: "session_name:window_index.pane_index pane_pid"。
+      // 必须按最后一个空格切分：会话名本身可能含空格（如「AD 智投星:0.0 651511」），
+      // 按第一个空格切会把 pid 解析成 NaN，pane 被静默跳过、/adopt 扫不到。
+      const spaceIdx = line.lastIndexOf(' ');
       if (spaceIdx === -1) continue;
 
       const tmuxTarget = line.slice(0, spaceIdx);

--- a/test/session-discovery.test.ts
+++ b/test/session-discovery.test.ts
@@ -278,6 +278,30 @@ describe('discoverAdoptableSessions', () => {
     });
   });
 
+  it('should discover panes in sessions whose name contains spaces', () => {
+    // 真实回归：tmux 会话名可以含空格（如「AD 智投星核心指标」）。list-panes 输出
+    // 变成 "AD 智投星核心指标:0.0 1000"，按第一个空格切分会把 pid 解析成 NaN，
+    // pane 被静默跳过，/adopt 永远扫不到这个会话。
+    setupMocks({
+      paneLines: 'AD 智投星核心指标:0.0 1000\n',
+      commMap: { 1000: 'fish', 1001: 'claude' },
+      childMap: { 1000: [1001] },
+      cwdMap: { 1001: '/home/user/project' },
+      dimsMap: { 'AD 智投星核心指标:0.0': '210 61' },
+      claudeMeta: {
+        1001: JSON.stringify({ sessionId: 'sess-spaced', cwd: '/home/user/project', startedAt: 1700000000000 }),
+      },
+    });
+
+    const results = discoverAdoptableSessions();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.tmuxTarget).toBe('AD 智投星核心指标:0.0');
+    expect(results[0]!.panePid).toBe(1000);
+    expect(results[0]!.cliPid).toBe(1001);
+    expect(results[0]!.sessionId).toBe('sess-spaced');
+  });
+
   it('should discover multiple CLI types', () => {
     setupMocks({
       paneLines: 'dev:0.0 1000\ndev:1.0 2000\n',


### PR DESCRIPTION
## 改了什么 & 为什么

`discoverAdoptableSessions` 解析 `tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{pane_pid}'` 输出时按**第一个空格**切分（`line.indexOf(' ')`）。tmux 会话名本身可以含空格（真实场景：用户手动命名的「测试 A」），此时第一个空格落在会话名内部，pid 段被解析成 NaN，该 pane 被静默 `continue` 跳过——`/adopt` 无参卡片和直连目标都永远扫不到这个会话，且无任何报错提示。

修复：改为按**最后一个空格**切分（`lastIndexOf`）。format 串中 `pane_pid` 恒为行尾 token 且不含空格，因此对任意会话名都成立。

## 影响面评估

- 只动 `src/core/session-discovery.ts` 中 tmux pane 行解析一处；`bmx-*` 过滤基于切分后的 tmuxTarget，无空格会话名的行为与原先逐字节一致
- zellij / herdr 的发现走各自独立解析（`zellij-adopt-discovery` / `discoverHerdrAdoptableSessions`），不受影响
- 纯字符串解析，macOS / Linux 同一路径，无平台差异
- 下游 `getPaneDimensions` / `validateTmuxAdoptTarget` 均已用 shellescape 包 target，含空格 target 传递无问题（已在真实 tmux 验证）

## 实际测试验证

- 新增回归用例「should discover panes in sessions whose name contains spaces」，红绿验证：撤销 src 修复后该用例失败（pid=NaN 被跳过），恢复后通过
- `npx vitest run test/session-discovery.test.ts` → 44 passed（44）
- `pnpm build` → 通过（tsc + dashboard bundle + build-audit）
- `pnpm test` 全量 unit 与本地 origin/master 基线对照：失败测试文件集**逐文件一致**（均为本机环境性失败，如 node comm 显示 MainThread），差集为空，本 PR 零回归；通过数 7620→7621（+1 为新增用例）
- 真机复现：Linux 上名为「测试 A」的 tmux 会话内跑 claude，修复前 discovery 返回不含该 pane，修复后返回 ` 测试 A:0.0` 且 sessionId/cwd 正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)