### PR TITLE
fix(herdr): 修复状态 watcher 重启风暴

### DIFF
--- a/src/adapters/backend/herdr-backend.ts
+++ b/src/adapters/backend/herdr-backend.ts
@@ -25,18 +25,19 @@ const MAX_AGENT_PROBE_FAILURES = 3;
 // Synchronous (execFileSync 'sleep') because spawn() must stay sync.
 const SERVER_BOOT_POLL_MS = 100;
 const SERVER_BOOT_DEADLINE_MS = 5000;
-// `herdr wait agent-status` blocks until a transition; we cap it so a
-// long-stuck agent still re-arms the watcher and we never accumulate an
+// `herdr wait agent-status` blocks until the requested status, or succeeds
+// immediately when that status is already current. We cap it so a long-stuck
+// agent still re-arms the watcher and we never accumulate an
 // indefinitely-orphaned subprocess on process teardown.
 const STATUS_WAIT_TIMEOUT_MS = 30_000;
-// States we treat as "result settled — flush the pane now". `done` and
-// `blocked` are the user-facing signals (turn finished / input requested);
-// `idle` is the degraded form of `done` after the herdr UI marks it seen,
-// included because we read via the socket API and herdr may not register
-// our reads as "seeing" → without it the watcher could miss legitimate
-// turn completions. `working` is intentionally absent: we don't need an
-// event for "started streaming", the slow timer covers that path.
-const SETTLED_STATUSES = ['done', 'blocked', 'idle'] as const;
+// Watch the full useful lifecycle, not just settled statuses. Herdr's
+// `wait agent-status --status X` is level-triggered: when the pane is already
+// in X it succeeds immediately. After one status wins we therefore exclude it
+// from the next cohort until another lifecycle status wins. Watching `working`
+// is what re-enables `done`/`blocked`/`idle` for the following turn without
+// hot-looping on the settled state between turns.
+const WATCHED_STATUSES = ['working', 'done', 'blocked', 'idle'] as const;
+type WatchedStatus = typeof WATCHED_STATUSES[number];
 
 type JsonCommandResult = { ok: true; value: any | undefined } | { ok: false };
 
@@ -617,22 +618,25 @@ export class HerdrBackend implements SessionBackend {
   }
 
   /**
-   * Spawn one `herdr wait agent-status` child per "result settled" status
-   * (done / blocked / idle). The first to fire wins → we read+emit, then
-   * tear down the losers and re-arm a fresh cohort. Parallel watchers are
-   * needed because the herdr CLI only accepts one --status at a time, and
-   * we genuinely care about all three transitions: `done` is "turn finished
-   * with output", `blocked` is "agent wants user input", `idle` is the
-   * degraded form of done after herdr's UI marks it seen.
+   * Spawn one `herdr wait agent-status` child per useful status other than the
+   * current one. The first to fire wins → we read+emit, tear down the losers,
+   * and re-arm while excluding the winning (now-current) status.
+   *
+   * Excluding the current status is essential because Herdr waits are
+   * level-triggered. Re-arming the same status immediately would make a pane
+   * parked at `idle`/`done` spawn a new wait cohort every ~20ms and saturate
+   * the Herdr API socket. `working` participates solely to advance the state
+   * machine so settled statuses are eligible again on the next turn.
    */
-  private startStatusWatcher(): void {
+  private startStatusWatcher(currentStatus?: WatchedStatus): void {
     if (this.exited) return;
     const paneTarget = this.paneId ?? this.agentName;
     if (!paneTarget) return;
     this.stopStatusWatcher();
     const cohort: ChildProcess[] = [];
     const armedAt = Date.now();
-    for (const status of SETTLED_STATUSES) {
+    for (const status of WATCHED_STATUSES) {
+      if (status === currentStatus) continue;
       const child = spawn('herdr', [
         '--session', this.sessionName,
         'wait', 'agent-status', paneTarget,
@@ -645,20 +649,26 @@ export class HerdrBackend implements SessionBackend {
         // Only the first child to finish (across the cohort) drives the
         // re-arm cycle; later finishers in the same cohort are dropped.
         if (!this.statusWaitProcesses.includes(child)) return;
-        const wasFirstSettle = this.statusWaitProcesses === cohort;
+        const wasFirstExit = this.statusWaitProcesses === cohort;
         // Drop this child from the active cohort.
         this.statusWaitProcesses = this.statusWaitProcesses.filter(c => c !== child);
-        if (!wasFirstSettle || this.exited) return;
+        if (!wasFirstExit || this.exited) return;
         // First exit in this cohort — tear down siblings, then read+re-arm.
         this.stopStatusWatcher();
         this.readAndEmitDelta();
 
-        // Storm guard. code 0 = the watched status was genuinely reached (a
-        // real transition, which can legitimately happen instantly) → re-arm
-        // immediately, the normal hot path. The danger is a NON-ZERO instant
-        // return: when the agent's pane has gone away (the CLI exited), `herdr
-        // wait agent-status` returns code 1 within MILLISECONDS rather than
-        // after the 30s timeout. The old code re-armed on every non-0 code
+        // code 0 means the watched status is now current. Re-arm immediately,
+        // but exclude that status from the next cohort: Herdr returns success
+        // immediately while a status remains current, so including it again is
+        // the level-triggered success storm this state machine prevents.
+        if (code === 0) {
+          this.startStatusWatcher(status);
+          return;
+        }
+
+        // Non-zero storm guard: when the agent's pane has gone away (the CLI
+        // exited), `herdr wait agent-status` returns code 1 within MILLISECONDS
+        // rather than after the 30s timeout. The old code re-armed on every non-0 code
         // synchronously, so a dead pane spun a tight spawn loop (thousands of
         // `herdr wait` children/sec) that starved the 500ms poll timer → the
         // session never reported its exit and hung. So for a non-zero code we
@@ -668,33 +678,34 @@ export class HerdrBackend implements SessionBackend {
         // a deferred timer, never synchronously, so poll() can run and we can't
         // spin). Verified on v0.6.6: the exited agent's row disappears from
         // `agent list`.
-        if (code !== 0) {
-          const elapsed = Date.now() - armedAt;
-          const returnedInstantly = elapsed < STATUS_WAIT_TIMEOUT_MS / 2;
-          if (returnedInstantly) {
-            const agents = this.listAgents();
-            if (agents !== null) {
-              const matching = agents.find(a => a?.pane_id === this.paneId || a?.name === this.agentName);
-              const exited = matching ? agentRowExited(matching) : true;
-              if (exited) {
-                const exitCode = typeof matching?.exit_code === 'number' ? matching.exit_code : 0;
-                this.handleExit(exitCode, null);
-                return;
-              }
+        const elapsed = Date.now() - armedAt;
+        const returnedInstantly = elapsed < STATUS_WAIT_TIMEOUT_MS / 2;
+        if (returnedInstantly) {
+          const agents = this.listAgents();
+          if (agents !== null) {
+            const matching = agents.find(a => a?.pane_id === this.paneId || a?.name === this.agentName);
+            const exited = matching ? agentRowExited(matching) : true;
+            if (exited) {
+              const exitCode = typeof matching?.exit_code === 'number' ? matching.exit_code : 0;
+              this.handleExit(exitCode, null);
+              return;
             }
-            // Agent still alive but the wait returned instantly (transient
-            // herdr hiccup). Re-arm on a later tick, never synchronously, so we
-            // can't spin: the deferred timer yields the loop to poll(). unref
-            // so we never hold the event loop open.
-            if (this.exited) return;
-            const t = setTimeout(() => { if (!this.exited) this.startStatusWatcher(); }, POLL_INTERVAL_MS);
-            t.unref?.();
-            return;
           }
+          // Agent still alive but the wait returned instantly (transient
+          // herdr hiccup). Re-arm on a later tick, never synchronously, so we
+          // can't spin: the deferred timer yields the loop to poll(). unref
+          // so we never hold the event loop open.
+          if (this.exited) return;
+          const t = setTimeout(() => {
+            if (!this.exited) this.startStatusWatcher(currentStatus);
+          }, POLL_INTERVAL_MS);
+          t.unref?.();
+          return;
         }
-        // Normal path: a genuine status transition (code 0) or a real
-        // long-timeout (code 1 after ~30s of working) — re-arm immediately.
-        this.startStatusWatcher();
+        // A real long-timeout after ~30s: preserve the last winning status so
+        // the periodic timeout itself cannot re-introduce a level-triggered
+        // waiter for the unchanged current state.
+        this.startStatusWatcher(currentStatus);
       });
       child.on('error', () => {
         // `herdr` missing or unspawnable: drop from cohort. Timer-based poll

--- a/test/herdr-backend.test.ts
+++ b/test/herdr-backend.test.ts
@@ -784,7 +784,7 @@ describe('HerdrBackend callbacks', () => {
     expect(exits).toEqual([[7, null]]);
   });
 
-  it('status watcher: one wait child per settled status (done/blocked/idle), first exit wins', () => {
+  it('status watcher: excludes the current status when re-arming, preventing level-triggered success storms', () => {
     // Capture every fake `wait agent-status` child + its --status arg so the
     // test can drive a specific watcher's exit and verify the cohort
     // behaviour (first-to-fire reads, the rest get SIGTERM'd).
@@ -814,9 +814,11 @@ describe('HerdrBackend callbacks', () => {
     be.onData(d => seen.push(d));
     be.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
 
-    // Cohort = one watcher per settled status.
+    // The initial cohort also watches `working`: after a settled state fires,
+    // observing the next working transition is what makes that settled state
+    // eligible again for the following turn.
     const cohort = waitChildren.slice();
-    expect(cohort.map(w => w.status).sort()).toEqual(['blocked', 'done', 'idle']);
+    expect(cohort.map(w => w.status).sort()).toEqual(['blocked', 'done', 'idle', 'working']);
 
     // Simulate the agent transitioning to `done` mid-turn — that watcher wins.
     paneText = 'baseline result';
@@ -826,16 +828,25 @@ describe('HerdrBackend callbacks', () => {
     // The win triggered a read+emit.
     expect(seen).toEqual([' result']);
 
-    // The two losing siblings got killed and a fresh cohort got armed.
+    // The losing siblings got killed and a fresh cohort got armed. Crucially,
+    // `done` is excluded while it remains the current status: Herdr's wait is
+    // level-triggered, so immediately watching `done` again would return code
+    // 0 in ~20ms forever and saturate the API socket.
     for (const w of cohort) {
       if (w !== doneWatcher) expect(w.child.killed).toBe(true);
     }
     const nextCohort = waitChildren.slice(cohort.length);
-    expect(nextCohort.map(w => w.status).sort()).toEqual(['blocked', 'done', 'idle']);
+    expect(nextCohort.map(w => w.status).sort()).toEqual(['blocked', 'idle', 'working']);
+
+    // Once the agent starts the next turn, `working` becomes current and
+    // `done` is armed again for that turn's completion.
+    nextCohort.find(w => w.status === 'working')!.child.emit('exit', 0, null);
+    const thirdCohort = waitChildren.slice(cohort.length + nextCohort.length);
+    expect(thirdCohort.map(w => w.status).sort()).toEqual(['blocked', 'done', 'idle']);
 
     be.kill();
     // kill() tears down the live cohort.
-    for (const w of nextCohort) expect(w.child.killed).toBe(true);
+    for (const w of thirdCohort) expect(w.child.killed).toBe(true);
   });
 
   it('status watcher: instant non-zero exit on a vanished agent emits onExit and does NOT re-arm (storm guard)', () => {
@@ -871,7 +882,7 @@ describe('HerdrBackend callbacks', () => {
     be.spawn('claude', [], { cwd: '/work', cols: 80, rows: 24, env: {} });
 
     const cohort = waitChildren.slice();
-    expect(cohort.length).toBe(3);
+    expect(cohort.length).toBe(4);
 
     // The agent has now exited; the next `wait` returns code 1 instantly.
     agentGone = true;


### PR DESCRIPTION
## 改了什么

- 将 Herdr 状态 watcher 扩展为监听完整生命周期：`working`、`done`、`blocked`、`idle`。
- 每次状态命中后，下一轮 watcher 排除当前状态；进入 `working` 后再重新启用 settled 状态。
- 保留既有非零退出防风暴与 agent 存活检查，并让延迟/超时重挂继续携带当前状态。
- 增加回归测试，覆盖 `done → working → done` 的 watcher 重挂状态机和消失 agent 的非零退出路径。

## 为什么

Herdr 0.7.4 的 `wait agent-status --status X` 是电平触发：当 pane 已处于 X 时会立即以 0 返回。Botmux 之前在 watcher 成功后立刻重挂同一状态，导致 `herdr wait agent-status` 每 20–30ms 重启一次，打满 Herdr API socket，并让本地 `herdr` CLI 调用卡死。

## 影响面

- **后端**：仅修改 HerdrBackend 的状态 watcher；PTY、tmux、zellij、riff 路径不受影响。
- **CLI / 会话类型**：所有使用 Herdr 后端的新建、恢复和接管会话共享该 watcher；不改变具体 CLI 适配器行为。
- **平台**：继续通过参数数组调用 Herdr CLI，无平台专属 shell 行为；macOS 与 Linux 使用同一状态机。
- **兜底行为**：500ms 输出轮询、30s wait 超时和退出探测保持不变。

## 实际验证

- `pnpm exec vitest run --configLoader runner --project unit test/herdr-backend.test.ts test/backend-availability.test.ts test/tmux-reattach-backend.test.ts`：3 files / 42 tests 全通过（基于远程 PR head `0287652`）。
- `pnpm build`：通过。
- `git diff --check origin/master...HEAD`：通过。
