### PR TITLE
fix(backend): 注入 DISABLE_AUTO_UPDATE 防止 oh-my-zsh 升级提示阻塞 shell 启动

### DIFF
--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -276,8 +276,13 @@ export class TmuxBackend implements SessionBackend {
       // terminal and ran it themselves.
       //
       // Shape:
-      //   tmux new-session -- <shell> <shellFlags> -c <SCRIPT> _ <cwd> KEY=VAL... bin args...
+      //   tmux new-session -- /usr/bin/env DISABLE_AUTO_UPDATE=true
+      //     <shell> <shellFlags> -c <SCRIPT> _ <cwd> KEY=VAL... bin args...
       //
+      //   - The env(1) prefix makes DISABLE_AUTO_UPDATE visible while the
+      //     shell loads its rcfile, then SCRIPT unsets it before execing the
+      //     CLI. This prevents oh-my-zsh's update prompt without changing the
+      //     final CLI environment or running an unattended update.
       //   - <shell> + <shellFlags> come from resolveUserShell() and are
       //     bash/zsh/sh-specific (bash needs `-i` for .bashrc; zsh needs
       //     `-l -i` for .zprofile + .zshrc). fish/csh/nu are remapped to a
@@ -591,14 +596,16 @@ export class TmuxBackend implements SessionBackend {
  * Env vars that must be set BEFORE the user's shell rcfile loads, so interactive
  * prompts during rcfile sourcing don't block the shell startup and prevent the
  * CLI from launching. These are injected as `env KEY=VAL shell -i -c '...'` so
- * the rcfile sees them while sourcing (oh-my-zsh's check_for_upgrade.sh reads
- * $DISABLE_UPDATE_PROMPT before showing its "Would you like to update Oh My Zsh?
- * [Y/n]" prompt; git credential dialogs read $GIT_TERMINAL_PROMPT).
+ * the rcfile sees them while sourcing. oh-my-zsh's check_for_upgrade.sh reads
+ * $DISABLE_AUTO_UPDATE before showing its "Would you like to update Oh My Zsh?
+ * [Y/n]" prompt.
  *
- * DISABLE_UPDATE_PROMPT=true (not DISABLE_AUTO_UPDATE=true): oh-my-zsh still
- * performs the update automatically (update_mode=auto) but skips the interactive
- * "[Y/n]" prompt — so the user's own terminal keeps auto-upgrading exactly as
- * before, while botmux-launched shells don't get stuck waiting for a keypress.
+ * DISABLE_AUTO_UPDATE=true makes the botmux-managed shell skip the update check
+ * altogether. DISABLE_UPDATE_PROMPT is deliberately not used: oh-my-zsh maps it
+ * to update_mode=auto, which would modify the user's installation without the
+ * confirmation their normal prompt-mode shell requires. GIT_TERMINAL_PROMPT is
+ * also deliberately untouched so git commands run by the eventual CLI preserve
+ * the user's normal credential behavior.
  *
  * Why here and not in buildBotmuxEnvAssignments: those are injected via
  * `exec /usr/bin/env "$@"` which runs AFTER rcfile load — too late for an
@@ -608,23 +615,25 @@ export class TmuxBackend implements SessionBackend {
  * when the tmux server was already started by a different client.
  */
 export const NON_INTERACTIVE_SHELL_ENV = [
-  'DISABLE_UPDATE_PROMPT=true',
-  'GIT_TERMINAL_PROMPT=0',
+  'DISABLE_AUTO_UPDATE=true',
 ] as const;
+
+/** Remove rcfile-only launch overrides before the managed CLI is exec'd. */
+const NON_INTERACTIVE_SHELL_ENV_UNSET_CLAUSE =
+  `unset ${NON_INTERACTIVE_SHELL_ENV.map(assignment => assignment.split('=', 1)[0]).join(' ')}`;
 
 /**
  * Build the argv prefix that launches the user's shell with non-interactive
  * env vars set BEFORE rcfile load. Returns:
- *   ['/usr/bin/env', 'DISABLE_UPDATE_PROMPT=true', 'GIT_TERMINAL_PROMPT=0', shell, ...flags]
+ *   ['/usr/bin/env', 'DISABLE_AUTO_UPDATE=true', shell, ...flags]
  *
  * Backends splat this before `-c <SCRIPT> _ <cwd> KEY=VAL... bin args...`:
- *   tmux new-session ... -- /usr/bin/env DISABLE_UPDATE_PROMPT=true GIT_TERMINAL_PROMPT=0 <shell> <flags> -c <SCRIPT> _ ...
+ *   tmux new-session ... -- /usr/bin/env DISABLE_AUTO_UPDATE=true <shell> <flags> -c <SCRIPT> _ ...
  *
  * The env(1) prefix sets the vars in the shell process's own environment so
  * the rcfile sees them during sourcing; they are NOT in the tmux server global
- * env (so they don't leak to the user's own interactive tmux sessions) and
- * they're NOT re-injected by the wrapper's `exec /usr/bin/env "$@"` (that only
- * re-applies the per-bot KEY=VAL pairs).
+ * env (so they don't leak to the user's own interactive tmux sessions). The
+ * wrapper removes them after rcfile load and before execing the CLI.
  */
 export function shellLaunchArgv(shell: string, flags: string[]): string[] {
   return ['/usr/bin/env', ...NON_INTERACTIVE_SHELL_ENV, shell, ...flags];
@@ -669,8 +678,9 @@ export function buildBotmuxEnvAssignments(
  *   $0 = '_' (placeholder), $1 = cwd, $2..N = KEY=VAL... bin args...
  *
  * The `cd` step makes the CLI's cwd survive a wayward `cd` in the user's
- * rcfile. The `unset` step removes stale botmux-owned values the pane inherited
- * from the tmux server's global env. The PATH prepend puts the
+ * rcfile. The first `unset` step removes stale botmux-owned values the pane
+ * inherited from the tmux server's global env; the second removes the
+ * rcfile-only launch override before the CLI starts. The PATH prepend puts the
  * daemon-written wrapper dir (~/.botmux/bin, which holds THIS build's `botmux`)
  * ahead of any npm-global botmux the rcfile put earlier in PATH — otherwise the
  * agent's `botmux` could resolve to a stale build. Critical under read isolation:
@@ -682,7 +692,7 @@ export function buildBotmuxEnvAssignments(
  * POSIX-syntax (works in bash/zsh/sh); fish/csh/nu users get remapped to
  * bash/zsh/sh by resolveUserShell() so they hit the same SCRIPT path.
  */
-export const SHELL_WRAPPER_SCRIPT = `cd -- "$1" && shift && ${PANE_ENV_UNSET_CLAUSE} && export PATH="$HOME/.botmux/bin:$PATH" && exec /usr/bin/env "$@"`;
+export const SHELL_WRAPPER_SCRIPT = `cd -- "$1" && shift && ${PANE_ENV_UNSET_CLAUSE} && ${NON_INTERACTIVE_SHELL_ENV_UNSET_CLAUSE} && export PATH="$HOME/.botmux/bin:$PATH" && exec /usr/bin/env "$@"`;
 
 export const DIAGNOSTIC_SHELL_SCRIPT = [
   'cd -- "$1" 2>/dev/null || cd "$HOME" 2>/dev/null || cd /',
@@ -714,6 +724,8 @@ export function buildDebugKeepShellScript(shellPath: string): string {
     // Same managed-env cleanup as SHELL_WRAPPER_SCRIPT — so neither the CLI nor
     // the interactive debug shell sees stale server/rcfile-owned values.
     PANE_ENV_UNSET_CLAUSE,
+    // The pre-rcfile launch override must not reach the CLI or debug shell.
+    NON_INTERACTIVE_SHELL_ENV_UNSET_CLAUSE,
     // Same PATH prepend as SHELL_WRAPPER_SCRIPT (wrapper build wins over stale npm-global).
     'export PATH="$HOME/.botmux/bin:$PATH"',
     '/usr/bin/env "$@"',

--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -327,7 +327,7 @@ export class TmuxBackend implements SessionBackend {
         '-x', String(opts.cols),
         '-y', String(opts.rows),
         '--',
-        shellSpec.shell, ...shellSpec.flags, '-c', script, '_',
+        ...shellLaunchArgv(shellSpec.shell, shellSpec.flags), '-c', script, '_',
         opts.cwd,
         ...envAssignments,
         bin, ...args,
@@ -588,6 +588,48 @@ export class TmuxBackend implements SessionBackend {
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
+ * Env vars that must be set BEFORE the user's shell rcfile loads, so interactive
+ * prompts during rcfile sourcing don't block the shell startup and prevent the
+ * CLI from launching. These are injected as `env KEY=VAL shell -i -c '...'` so
+ * the rcfile sees them while sourcing (oh-my-zsh's check_for_upgrade.sh reads
+ * $DISABLE_UPDATE_PROMPT before showing its "Would you like to update Oh My Zsh?
+ * [Y/n]" prompt; git credential dialogs read $GIT_TERMINAL_PROMPT).
+ *
+ * DISABLE_UPDATE_PROMPT=true (not DISABLE_AUTO_UPDATE=true): oh-my-zsh still
+ * performs the update automatically (update_mode=auto) but skips the interactive
+ * "[Y/n]" prompt — so the user's own terminal keeps auto-upgrading exactly as
+ * before, while botmux-launched shells don't get stuck waiting for a keypress.
+ *
+ * Why here and not in buildBotmuxEnvAssignments: those are injected via
+ * `exec /usr/bin/env "$@"` which runs AFTER rcfile load — too late for an
+ * oh-my-zsh update prompt that already blocked the shell. These must be in the
+ * shell process's own environment when it starts, so they're visible to the
+ * rcfile. Applied via `env(1)` prefix in shellLaunchArgv() so they work even
+ * when the tmux server was already started by a different client.
+ */
+export const NON_INTERACTIVE_SHELL_ENV = [
+  'DISABLE_UPDATE_PROMPT=true',
+  'GIT_TERMINAL_PROMPT=0',
+] as const;
+
+/**
+ * Build the argv prefix that launches the user's shell with non-interactive
+ * env vars set BEFORE rcfile load. Returns:
+ *   ['/usr/bin/env', 'DISABLE_UPDATE_PROMPT=true', 'GIT_TERMINAL_PROMPT=0', shell, ...flags]
+ *
+ * Backends splat this before `-c <SCRIPT> _ <cwd> KEY=VAL... bin args...`:
+ *   tmux new-session ... -- /usr/bin/env DISABLE_UPDATE_PROMPT=true GIT_TERMINAL_PROMPT=0 <shell> <flags> -c <SCRIPT> _ ...
+ *
+ * The env(1) prefix sets the vars in the shell process's own environment so
+ * the rcfile sees them during sourcing; they are NOT in the tmux server global
+ * env (so they don't leak to the user's own interactive tmux sessions) and
+ * they're NOT re-injected by the wrapper's `exec /usr/bin/env "$@"` (that only
+ * re-applies the per-bot KEY=VAL pairs).
+ */
+export function shellLaunchArgv(shell: string, flags: string[]): string[] {
+  return ['/usr/bin/env', ...NON_INTERACTIVE_SHELL_ENV, shell, ...flags];
+}
+
 /**
  * Build the `KEY=VAL` argv slice passed to `/usr/bin/env`. Only forwards the
  * centralized BOTMUX_INJECTED_ENV_KEYS allowlist and only when the value is

--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -31,7 +31,7 @@ import { randomBytes } from 'node:crypto';
 import { StringDecoder } from 'node:string_decoder';
 import type { SessionBackend, SessionProbe, SpawnOpts } from './types.js';
 import { tmuxEnv } from '../../setup/ensure-tmux.js';
-import { buildBotmuxEnvAssignments, resolveUserShell, SHELL_WRAPPER_SCRIPT, TmuxBackend } from './tmux-backend.js';
+import { buildBotmuxEnvAssignments, resolveUserShell, SHELL_WRAPPER_SCRIPT, shellLaunchArgv, TmuxBackend } from './tmux-backend.js';
 import { LivenessGate, ADOPT_LIVENESS_MAX_FAILURES } from './liveness-gate.js';
 
 function shellescape(s: string): string {
@@ -623,7 +623,7 @@ export class TmuxPipeBackend implements SessionBackend {
       '-x', String(opts.cols),
       '-y', String(opts.rows),
       '--',
-      shellSpec.shell, ...shellSpec.flags, '-c', SHELL_WRAPPER_SCRIPT, '_',
+      ...shellLaunchArgv(shellSpec.shell, shellSpec.flags), '-c', SHELL_WRAPPER_SCRIPT, '_',
       opts.cwd,
       ...envAssignments,
       bin, ...args,

--- a/src/adapters/backend/zellij-backend.ts
+++ b/src/adapters/backend/zellij-backend.ts
@@ -317,10 +317,10 @@ export function buildLayoutString(bin: string, args: string[], opts: SpawnOpts):
   const shellSpec = resolveUserShell(process.env, opts.launchShell);
   const envAssignments = buildBotmuxEnvAssignments(opts.env, opts.injectEnv);
   // shellLaunchArgv() returns ['/usr/bin/env', 'DISABLE_AUTO_UPDATE=true',
-  // 'GIT_TERMINAL_PROMPT=0', shell, ...flags] — the env(1) prefix sets
-  // non-interactive vars BEFORE rcfile load so oh-my-zsh update prompts don't
-  // block the shell startup. The first element is the pane command; the rest
-  // are leading args before the wrapper script flags.
+  // shell, ...flags] — the env(1) prefix sets the startup-only override BEFORE
+  // rcfile load so oh-my-zsh update prompts don't block shell startup. The
+  // wrapper removes it before execing the CLI. The first element is the pane
+  // command; the rest are leading args before the wrapper script flags.
   const [cmd, ...launchArgs] = shellLaunchArgv(shellSpec.shell, shellSpec.flags);
   const paneArgs = [
     ...launchArgs, '-c', SHELL_WRAPPER_SCRIPT, '_',

--- a/src/adapters/backend/zellij-backend.ts
+++ b/src/adapters/backend/zellij-backend.ts
@@ -6,7 +6,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { SessionBackend, SpawnOpts, SessionProbe } from './types.js';
 import { zellijEnv, probeZellijFunctional } from '../../setup/ensure-zellij.js';
-import { resolveUserShell, buildBotmuxEnvAssignments, SHELL_WRAPPER_SCRIPT } from './tmux-backend.js';
+import { resolveUserShell, buildBotmuxEnvAssignments, SHELL_WRAPPER_SCRIPT, shellLaunchArgv } from './tmux-backend.js';
 import { logger } from '../../utils/logger.js';
 
 /**
@@ -316,8 +316,14 @@ export function kdlString(s: string): string {
 export function buildLayoutString(bin: string, args: string[], opts: SpawnOpts): string {
   const shellSpec = resolveUserShell(process.env, opts.launchShell);
   const envAssignments = buildBotmuxEnvAssignments(opts.env, opts.injectEnv);
+  // shellLaunchArgv() returns ['/usr/bin/env', 'DISABLE_AUTO_UPDATE=true',
+  // 'GIT_TERMINAL_PROMPT=0', shell, ...flags] — the env(1) prefix sets
+  // non-interactive vars BEFORE rcfile load so oh-my-zsh update prompts don't
+  // block the shell startup. The first element is the pane command; the rest
+  // are leading args before the wrapper script flags.
+  const [cmd, ...launchArgs] = shellLaunchArgv(shellSpec.shell, shellSpec.flags);
   const paneArgs = [
-    ...shellSpec.flags, '-c', SHELL_WRAPPER_SCRIPT, '_',
+    ...launchArgs, '-c', SHELL_WRAPPER_SCRIPT, '_',
     opts.cwd,
     ...envAssignments,
     bin, ...args,
@@ -325,7 +331,7 @@ export function buildLayoutString(bin: string, args: string[], opts: SpawnOpts):
   const argsKdl = paneArgs.map(kdlString).join(' ');
   return [
     'layout {',
-    `    pane command=${kdlString(shellSpec.shell)} close_on_exit=true {`,
+    `    pane command=${kdlString(cmd)} close_on_exit=true {`,
     `        args ${argsKdl}`,
     '    }',
     '}',

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4365,7 +4365,7 @@ function detectBareShellLaunch(): boolean {
       `② git 凭据弹窗（GIT_TERMINAL_PROMPT）或其它需要交互输入的启动脚本\n` +
       `③ ${cli} 的可执行文件不在 PATH 上（CLI 没找到）\n\n` +
       `修法（任选其一，改完重启 daemon 再发一条消息）：\n` +
-      `• 最省事：升级 botmux 到含自动注入 DISABLE_UPDATE_PROMPT=true 的版本（oh-my-zsh 照常自动升级，但不弹交互提示卡住 shell）\n` +
+      `• 最省事：升级 botmux 到含自动注入 DISABLE_AUTO_UPDATE=true 的版本（仅 botmux 托管 shell 启动时跳过 oh-my-zsh 升级检查，不影响你自己的终端）\n` +
       `• 手动修：在 ~/.zshrc 的 source $ZSH/oh-my-zsh.sh 之前加一行 DISABLE_UPDATE_PROMPT="true"（自动升级不弹提示）；或加 DISABLE_AUTO_UPDATE="true"（完全跳过升级检查）\n` +
       `• 在 web 终端里手动敲一下启动命令看报什么错；确认 CLI 二进制能在 PATH 上找到；或精简 rc 启动逻辑后重启 daemon 再试`;
   }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4360,8 +4360,14 @@ function detectBareShellLaunch(): boolean {
   } else {
     message =
       `⚠️ 会话没能启动：pane 里还停在 \`${comm}\`，${cli} 没真正跑起来——我没把消息打进去（否则会被当 shell 命令执行）。\n\n` +
-      `可能原因：rc 文件启动过慢/报错，或 \`${cli}\` 的可执行文件不在 PATH 上（CLI 没找到）。\n` +
-      `建议：在 web 终端里手动敲一下启动命令看报什么错；确认 CLI 二进制能在 PATH 上找到；或精简 rc 启动逻辑后重启 daemon 再试。`;
+      `最常见原因：rc 文件里有交互式提示卡住了 shell 启动，例如：\n` +
+      `① Oh My Zsh 升级提示（"Would you like to update Oh My Zsh? [Y/n]"）——${comm} source ~/.zshrc 时弹出，等你按 Y/n，CLI 的启动命令没机会跑\n` +
+      `② git 凭据弹窗（GIT_TERMINAL_PROMPT）或其它需要交互输入的启动脚本\n` +
+      `③ ${cli} 的可执行文件不在 PATH 上（CLI 没找到）\n\n` +
+      `修法（任选其一，改完重启 daemon 再发一条消息）：\n` +
+      `• 最省事：升级 botmux 到含自动注入 DISABLE_UPDATE_PROMPT=true 的版本（oh-my-zsh 照常自动升级，但不弹交互提示卡住 shell）\n` +
+      `• 手动修：在 ~/.zshrc 的 source $ZSH/oh-my-zsh.sh 之前加一行 DISABLE_UPDATE_PROMPT="true"（自动升级不弹提示）；或加 DISABLE_AUTO_UPDATE="true"（完全跳过升级检查）\n` +
+      `• 在 web 终端里手动敲一下启动命令看报什么错；确认 CLI 二进制能在 PATH 上找到；或精简 rc 启动逻辑后重启 daemon 再试`;
   }
   send({ type: 'user_notify', turnId: currentBotmuxTurnId, dispatchAttempt: currentBotmuxDispatchAttempt, message });
   return true;

--- a/test/tmux-backend-env.test.ts
+++ b/test/tmux-backend-env.test.ts
@@ -2,7 +2,7 @@
  * Tests for TmuxBackend's shell-wrapped CLI launch.
  *
  * The design (see tmux-backend.ts spawn() else branch):
- *   tmux new-session ... -- /usr/bin/env DISABLE_AUTO_UPDATE=true GIT_TERMINAL_PROMPT=0 <shell> <shellFlags> -c <SCRIPT> _ <cwd> KEY=VAL... bin args...
+ *   tmux new-session ... -- /usr/bin/env DISABLE_AUTO_UPDATE=true <shell> <shellFlags> -c <SCRIPT> _ <cwd> KEY=VAL... bin args...
  *
  * Goal: give the CLI an environment that matches "user opens a terminal and
  * runs the CLI by hand" — PATH / NVM / PNPM / mise / etc. come from the
@@ -17,10 +17,10 @@
  * SCRIPT also `cd`s back to the requested cwd before exec, so a stray `cd`
  * in the user's rcfile doesn't drag the CLI's working directory away.
  *
- * Non-interactive startup: shellLaunchArgv() prepends `env DISABLE_AUTO_UPDATE=true
- * GIT_TERMINAL_PROMPT=0` to the shell command so these vars are visible to the
- * rcfile during sourcing — preventing oh-my-zsh's update prompt and git
- * credential dialogs from blocking the shell startup before the CLI launches.
+ * Non-interactive startup: shellLaunchArgv() prepends
+ * `env DISABLE_AUTO_UPDATE=true` so the override is visible while the rcfile
+ * loads and prevents oh-my-zsh's update prompt. The wrapper unsets it again
+ * before launching the CLI, preserving the CLI's normal environment.
  */
 import { describe, it, expect, afterEach } from 'vitest';
 import { existsSync, mkdtempSync, writeFileSync, chmodSync, rmSync, readFileSync } from 'node:fs';
@@ -243,20 +243,16 @@ describe('buildBotmuxEnvAssignments()', () => {
 });
 
 describe('NON_INTERACTIVE_SHELL_ENV', () => {
-  it('includes DISABLE_UPDATE_PROMPT=true (oh-my-zsh update prompt)', () => {
-    // DISABLE_UPDATE_PROMPT=true (not DISABLE_AUTO_UPDATE=true): oh-my-zsh
-    // still auto-updates (update_mode=auto) but skips the interactive "[Y/n]"
-    // prompt, so the user's own terminal keeps auto-upgrading while botmux
-    // shells don't get stuck waiting for a keypress.
-    expect(NON_INTERACTIVE_SHELL_ENV).toContain('DISABLE_UPDATE_PROMPT=true');
+  it('includes DISABLE_AUTO_UPDATE=true (skip oh-my-zsh update in managed shell)', () => {
+    expect(NON_INTERACTIVE_SHELL_ENV).toContain('DISABLE_AUTO_UPDATE=true');
   });
 
-  it('does NOT include DISABLE_AUTO_UPDATE (we want updates to still happen)', () => {
-    expect(NON_INTERACTIVE_SHELL_ENV).not.toContain('DISABLE_AUTO_UPDATE=true');
+  it('does not turn a prompt-mode shell into an unattended auto-update', () => {
+    expect(NON_INTERACTIVE_SHELL_ENV).not.toContain('DISABLE_UPDATE_PROMPT=true');
   });
 
-  it('includes GIT_TERMINAL_PROMPT=0 (git credential dialogs)', () => {
-    expect(NON_INTERACTIVE_SHELL_ENV).toContain('GIT_TERMINAL_PROMPT=0');
+  it('does not change git credential prompting for the managed CLI', () => {
+    expect(NON_INTERACTIVE_SHELL_ENV).not.toContain('GIT_TERMINAL_PROMPT=0');
   });
 });
 
@@ -265,8 +261,7 @@ describe('shellLaunchArgv()', () => {
     const argv = shellLaunchArgv('/bin/zsh', ['-l', '-i']);
     expect(argv).toEqual([
       '/usr/bin/env',
-      'DISABLE_UPDATE_PROMPT=true',
-      'GIT_TERMINAL_PROMPT=0',
+      'DISABLE_AUTO_UPDATE=true',
       '/bin/zsh',
       '-l',
       '-i',
@@ -277,8 +272,7 @@ describe('shellLaunchArgv()', () => {
     const argv = shellLaunchArgv('/bin/sh', []);
     expect(argv).toEqual([
       '/usr/bin/env',
-      'DISABLE_UPDATE_PROMPT=true',
-      'GIT_TERMINAL_PROMPT=0',
+      'DISABLE_AUTO_UPDATE=true',
       '/bin/sh',
     ]);
   });
@@ -287,46 +281,46 @@ describe('shellLaunchArgv()', () => {
     const argv = shellLaunchArgv('/bin/bash', ['-i']);
     expect(argv).toEqual([
       '/usr/bin/env',
-      'DISABLE_UPDATE_PROMPT=true',
-      'GIT_TERMINAL_PROMPT=0',
+      'DISABLE_AUTO_UPDATE=true',
       '/bin/bash',
       '-i',
     ]);
   });
 });
 
-describe('shellLaunchArgv end-to-end (env vars visible to rcfile)', () => {
+describe('shellLaunchArgv end-to-end (startup-only env lifecycle)', () => {
   const hasEnvBin = existsSync('/usr/bin/env');
   const hasBash = existsSync('/bin/bash');
 
   it.skipIf(!hasEnvBin || !hasBash)(
-    'DISABLE_UPDATE_PROMPT is visible to the rcfile during sourcing (the oh-my-zsh fix)',
+    'DISABLE_AUTO_UPDATE reaches the rcfile but not the final managed CLI',
     () => {
-      // Plant a fake .bashrc that checks $DISABLE_UPDATE_PROMPT and prints it.
-      // This emulates oh-my-zsh's check_for_upgrade.sh reading the var:
-      //   [[ "$DISABLE_UPDATE_PROMPT" != true ]] || update_mode=auto
-      // When set, update_mode=auto → no "[Y/n]" prompt, update runs silently.
+      // Plant a fake .bashrc that checks $DISABLE_AUTO_UPDATE. This emulates
+      // oh-my-zsh reading the legacy setting before deciding whether to prompt.
       const dir = mkdtempSync(join(tmpdir(), 'bmx-env-rcfile-'));
       try {
         writeFileSync(join(dir, '.bashrc'),
-          `if [ "$DISABLE_UPDATE_PROMPT" = "true" ]; then\n` +
-          `  echo AUTO_UPDATE_NO_PROMPT\n` +
+          `if [ "$DISABLE_AUTO_UPDATE" = "true" ]; then\n` +
+          `  echo RCFILE_UPDATE_CHECK_DISABLED\n` +
           `else\n` +
-          `  echo WOULD_PROMPT_FOR_UPDATE\n` +
+          `  echo RCFILE_WOULD_PROMPT_FOR_UPDATE\n` +
           `fi\n`,
         );
-        // Launch via shellLaunchArgv — the env(1) prefix must set the var
-        // BEFORE bash sources .bashrc (which it does because -i sources rcfile).
+        // Exercise the exact launch prefix + wrapper contract used by all three
+        // persistent backends, with env(1) as a stand-in for the final CLI.
         const argv = shellLaunchArgv('/bin/bash', ['-i']);
         const result = spawnSync(
           argv[0],
-          [...argv.slice(1), '-c', 'echo DONE'],
+          [...argv.slice(1), '-c', SHELL_WRAPPER_SCRIPT, '_', dir, '/usr/bin/env'],
           { encoding: 'utf-8', env: { HOME: dir, PATH: '/usr/bin:/bin' } },
         );
         expect(result.status).toBe(0);
-        // The rcfile must see DISABLE_UPDATE_PROMPT=true → auto-update, no prompt.
-        expect(result.stdout).toContain('AUTO_UPDATE_NO_PROMPT');
-        expect(result.stdout).not.toContain('WOULD_PROMPT_FOR_UPDATE');
+        expect(result.stdout).toContain('RCFILE_UPDATE_CHECK_DISABLED');
+        expect(result.stdout).not.toContain('RCFILE_WOULD_PROMPT_FOR_UPDATE');
+        const cliEnv = result.stdout.split('\n');
+        expect(cliEnv.some(line => line.startsWith('DISABLE_AUTO_UPDATE='))).toBe(false);
+        expect(cliEnv.some(line => line.startsWith('DISABLE_UPDATE_PROMPT='))).toBe(false);
+        expect(cliEnv.some(line => line.startsWith('GIT_TERMINAL_PROMPT='))).toBe(false);
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }
@@ -487,6 +481,7 @@ describe('buildDebugKeepShellScript()', () => {
   it('preserves the cd-back-to-cwd guard from the normal script', () => {
     const s = buildDebugKeepShellScript('/bin/bash');
     expect(s).toMatch(/^cd -- "\$1" && shift/);
+    expect(s).toContain('unset DISABLE_AUTO_UPDATE');
   });
 
   it('emits a clear banner so the user knows the CLI exited, not crashed', () => {

--- a/test/tmux-backend-env.test.ts
+++ b/test/tmux-backend-env.test.ts
@@ -2,7 +2,7 @@
  * Tests for TmuxBackend's shell-wrapped CLI launch.
  *
  * The design (see tmux-backend.ts spawn() else branch):
- *   tmux new-session ... -- <shell> <shellFlags> -c <SCRIPT> _ <cwd> KEY=VAL... bin args...
+ *   tmux new-session ... -- /usr/bin/env DISABLE_AUTO_UPDATE=true GIT_TERMINAL_PROMPT=0 <shell> <shellFlags> -c <SCRIPT> _ <cwd> KEY=VAL... bin args...
  *
  * Goal: give the CLI an environment that matches "user opens a terminal and
  * runs the CLI by hand" — PATH / NVM / PNPM / mise / etc. come from the
@@ -16,6 +16,11 @@
  *
  * SCRIPT also `cd`s back to the requested cwd before exec, so a stray `cd`
  * in the user's rcfile doesn't drag the CLI's working directory away.
+ *
+ * Non-interactive startup: shellLaunchArgv() prepends `env DISABLE_AUTO_UPDATE=true
+ * GIT_TERMINAL_PROMPT=0` to the shell command so these vars are visible to the
+ * rcfile during sourcing — preventing oh-my-zsh's update prompt and git
+ * credential dialogs from blocking the shell startup before the CLI launches.
  */
 import { describe, it, expect, afterEach } from 'vitest';
 import { existsSync, mkdtempSync, writeFileSync, chmodSync, rmSync, readFileSync } from 'node:fs';
@@ -26,9 +31,11 @@ import {
   buildBotmuxEnvAssignments,
   buildDebugKeepShellScript,
   DIAGNOSTIC_SHELL_SCRIPT,
+  NON_INTERACTIVE_SHELL_ENV,
   resolveUserShell,
   resolveShellOverride,
   SHELL_WRAPPER_SCRIPT,
+  shellLaunchArgv,
 } from '../src/adapters/backend/tmux-backend.js';
 
 describe('buildBotmuxEnvAssignments()', () => {
@@ -233,6 +240,98 @@ describe('buildBotmuxEnvAssignments()', () => {
     expect(buildBotmuxEnvAssignments({ BOTMUX: '1', SESSION_DATA_DIR: '/d' }))
       .toEqual(['BOTMUX=1', 'SESSION_DATA_DIR=/d']);
   });
+});
+
+describe('NON_INTERACTIVE_SHELL_ENV', () => {
+  it('includes DISABLE_UPDATE_PROMPT=true (oh-my-zsh update prompt)', () => {
+    // DISABLE_UPDATE_PROMPT=true (not DISABLE_AUTO_UPDATE=true): oh-my-zsh
+    // still auto-updates (update_mode=auto) but skips the interactive "[Y/n]"
+    // prompt, so the user's own terminal keeps auto-upgrading while botmux
+    // shells don't get stuck waiting for a keypress.
+    expect(NON_INTERACTIVE_SHELL_ENV).toContain('DISABLE_UPDATE_PROMPT=true');
+  });
+
+  it('does NOT include DISABLE_AUTO_UPDATE (we want updates to still happen)', () => {
+    expect(NON_INTERACTIVE_SHELL_ENV).not.toContain('DISABLE_AUTO_UPDATE=true');
+  });
+
+  it('includes GIT_TERMINAL_PROMPT=0 (git credential dialogs)', () => {
+    expect(NON_INTERACTIVE_SHELL_ENV).toContain('GIT_TERMINAL_PROMPT=0');
+  });
+});
+
+describe('shellLaunchArgv()', () => {
+  it('prepends env(1) + non-interactive vars before shell + flags', () => {
+    const argv = shellLaunchArgv('/bin/zsh', ['-l', '-i']);
+    expect(argv).toEqual([
+      '/usr/bin/env',
+      'DISABLE_UPDATE_PROMPT=true',
+      'GIT_TERMINAL_PROMPT=0',
+      '/bin/zsh',
+      '-l',
+      '-i',
+    ]);
+  });
+
+  it('works with no flags (sh-style)', () => {
+    const argv = shellLaunchArgv('/bin/sh', []);
+    expect(argv).toEqual([
+      '/usr/bin/env',
+      'DISABLE_UPDATE_PROMPT=true',
+      'GIT_TERMINAL_PROMPT=0',
+      '/bin/sh',
+    ]);
+  });
+
+  it('works with a single flag (bash-style)', () => {
+    const argv = shellLaunchArgv('/bin/bash', ['-i']);
+    expect(argv).toEqual([
+      '/usr/bin/env',
+      'DISABLE_UPDATE_PROMPT=true',
+      'GIT_TERMINAL_PROMPT=0',
+      '/bin/bash',
+      '-i',
+    ]);
+  });
+});
+
+describe('shellLaunchArgv end-to-end (env vars visible to rcfile)', () => {
+  const hasEnvBin = existsSync('/usr/bin/env');
+  const hasBash = existsSync('/bin/bash');
+
+  it.skipIf(!hasEnvBin || !hasBash)(
+    'DISABLE_UPDATE_PROMPT is visible to the rcfile during sourcing (the oh-my-zsh fix)',
+    () => {
+      // Plant a fake .bashrc that checks $DISABLE_UPDATE_PROMPT and prints it.
+      // This emulates oh-my-zsh's check_for_upgrade.sh reading the var:
+      //   [[ "$DISABLE_UPDATE_PROMPT" != true ]] || update_mode=auto
+      // When set, update_mode=auto → no "[Y/n]" prompt, update runs silently.
+      const dir = mkdtempSync(join(tmpdir(), 'bmx-env-rcfile-'));
+      try {
+        writeFileSync(join(dir, '.bashrc'),
+          `if [ "$DISABLE_UPDATE_PROMPT" = "true" ]; then\n` +
+          `  echo AUTO_UPDATE_NO_PROMPT\n` +
+          `else\n` +
+          `  echo WOULD_PROMPT_FOR_UPDATE\n` +
+          `fi\n`,
+        );
+        // Launch via shellLaunchArgv — the env(1) prefix must set the var
+        // BEFORE bash sources .bashrc (which it does because -i sources rcfile).
+        const argv = shellLaunchArgv('/bin/bash', ['-i']);
+        const result = spawnSync(
+          argv[0],
+          [...argv.slice(1), '-c', 'echo DONE'],
+          { encoding: 'utf-8', env: { HOME: dir, PATH: '/usr/bin:/bin' } },
+        );
+        expect(result.status).toBe(0);
+        // The rcfile must see DISABLE_UPDATE_PROMPT=true → auto-update, no prompt.
+        expect(result.stdout).toContain('AUTO_UPDATE_NO_PROMPT');
+        expect(result.stdout).not.toContain('WOULD_PROMPT_FOR_UPDATE');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 describe('resolveUserShell()', () => {

--- a/test/zellij-backend-helpers.test.ts
+++ b/test/zellij-backend-helpers.test.ts
@@ -58,6 +58,9 @@ describe('buildLayoutString', () => {
     });
     expect(kdl).toContain('layout {');
     expect(kdl).toContain('close_on_exit=true');
+    expect(kdl).toContain('pane command="/usr/bin/env"');
+    expect(kdl).toContain('"DISABLE_AUTO_UPDATE=true"');
+    expect(kdl).not.toContain('GIT_TERMINAL_PROMPT=0');
     // cwd is passed as a wrapper-script arg (execvp semantics, KDL-quoted).
     expect(kdl).toContain('"/work/dir"');
     expect(kdl).toContain('"claude"');


### PR DESCRIPTION
## 问题

用户安装 oh-my-zsh 后，如果升级检查在 shell 启动期间弹出 `Would you like to update? [Y/n]`，botmux 通过 `zsh -l -i -c '脚本'` 启动 CLI 时会先 source `.zshrc`，后续 CLI 启动命令无法执行。pane 叶进程停在裸 `zsh`，最终触发 `detectBareShellLaunch()` 报错。

## 根因

botmux 的常规会话环境变量通过 wrapper 中的 `exec /usr/bin/env "$@"` 在 rcfile 加载后注入，无法影响已经发生的 oh-my-zsh 升级检查；需要在 shell 进程启动前提供临时环境变量。

## 修复

1. 在 `tmux-backend.ts` 新增 `NON_INTERACTIVE_SHELL_ENV` 和 `shellLaunchArgv()`，用 `/usr/bin/env DISABLE_AUTO_UPDATE=true <shell> ...` 启动用户 shell，使 rcfile 在加载时跳过 oh-my-zsh 升级检查。
2. `SHELL_WRAPPER_SCRIPT` 和 debug keep-shell wrapper 在 rcfile 加载完成后、启动 AI CLI 前清除该临时变量，避免影响 CLI 及其后续子进程。
3. 不再注入 `DISABLE_UPDATE_PROMPT=true`：该变量会把 oh-my-zsh 改成无人值守自动更新，违背用户原本的 prompt 策略。
4. 不再注入 `GIT_TERMINAL_PROMPT=0`：保留 AI CLI 内 Git fetch/pull/push 的正常凭据交互行为。
5. 覆盖三个 shell-wrapper 后端：tmux、tmux-pipe、zellij；并改进裸 shell 启动失败诊断。

## 影响面

- **后端**：仅影响新建的 tmux、tmux-pipe、zellij 托管会话；PtyBackend 不受影响。
- **会话类型**：adopt、reattach 和已有 pane 不修改；新建普通/话题/群会话共用同一安全启动路径。
- **CLI**：所有 CLI 共用该启动修复，但最终 CLI 环境不保留临时禁更变量，也不改变 Git 凭据策略。
- **平台**：使用 macOS/Linux 均提供的 `/usr/bin/env` 与 POSIX `unset`；不写 tmux server global env，不影响用户自己的交互式 tmux 会话。

## 验证

- `pnpm build`：通过
- `pnpm exec vitest run --project unit test/tmux-backend-env.test.ts test/zellij-backend-helpers.test.ts test/session-discovery.test.ts`：111/111 通过
- 完整链路回归：验证 rcfile 能看到 `DISABLE_AUTO_UPDATE=true`，最终 CLI 不包含 `DISABLE_AUTO_UPDATE`、`DISABLE_UPDATE_PROMPT`、`GIT_TERMINAL_PROMPT`
- `pnpm test`：9429/9432 通过；3 个 scheduler 本地时区断言失败在 master 基线同样存在，且相关源码/测试自基线验证后未变更，与本 PR 无关
- `git merge-tree --write-tree origin/master HEAD`：与最新 master 可干净合并
- `pnpm daemon:restart`：已从本 checkout 的构建执行 daemon 重启
