### PR TITLE
fix(platform): allow slower data tunnel handshakes

### DIFF
--- a/src/platform/tunnel-client.ts
+++ b/src/platform/tunnel-client.ts
@@ -51,15 +51,15 @@ const BACKOFF_MAX_MS = 30_000;
 // 坏的 ECMP 分支「静默黑洞」（不回包、抓包实锤 ClientHello 无响应），好连接 ~90ms 就回。串行「拨一条
 // →黑洞等满超时→再拨」冷启动要赌好几秒；改成每波**并行拨几条、谁先到用谁、其余丢弃**：
 //  - 每波并行 DATA_DIAL_PARALLEL 条：~50% 单条成功率下，3 条里有 1 条好的概率 ~87.5% → 通常 ~90ms 就建好。
-//  - 单条超时 1s（好连接 90ms 就成，1s 足够判黑洞）；一波全黑洞才进下一波，最多 DATA_DIAL_MAX_WAVES 波。
+//  - 单条超时 3s（生产 TLB/TLS 握手可到 ~1.2s，需留足余量）；一波全黑洞才进下一波，最多 DATA_DIAL_MAX_WAVES 波。
 //  - 用完即弃、不常驻空闲连接（区别于「预热连接池」，不随机器数堆连接，可扩展）。
 //  - 平台对同一个 streamId 只 attach 第一条到的、其余自动 4004 关，协议无需改。
 //  - 配合平台连接池：建好的好连接会被复用，拨号（赌）只在冷启动/扩容发生，不是每请求。
-const DATA_DIAL_TIMEOUT_MS = 1_000;
+const DATA_DIAL_TIMEOUT_MS = 3_000;
 const DATA_DIAL_PARALLEL = 3;
 const DATA_DIAL_MAX_WAVES = 2;
 const DATA_DIAL_WAVE_BACKOFF_MS = 150;
-const DATA_DIAL_OVERALL_DEADLINE_MS = 6_000;
+const DATA_DIAL_OVERALL_DEADLINE_MS = 8_000;
 
 // 控制连接并行拨号（happy-eyeballs）：一轮并行拨几条、谁先握手成功用谁，兜住入口 VIP 对新建连接
 // ~35% 的黑洞。单条超时给足 TLS 握手时间（好连接 ~40ms，黑洞则等满超时判负）。

--- a/test/tunnel-client-ip-family.test.ts
+++ b/test/tunnel-client-ip-family.test.ts
@@ -3,7 +3,18 @@
 // 让 Node 内置 happy-eyeballs 自动选最优路径（IPv4/IPv6 谁先到用谁）。
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const { FakeWebSocket } = vi.hoisted(() => {
+const { FakeWebSocket, createWebSocketStream, netConnect } = vi.hoisted(() => {
+  const fakeStream = () => {
+    const stream = {
+      on: vi.fn(),
+      pipe: vi.fn(),
+      destroy: vi.fn(),
+    };
+    stream.on.mockReturnValue(stream);
+    stream.pipe.mockReturnValue(stream);
+    return stream;
+  };
+
   class FakeWebSocket {
     static OPEN = 1;
     static instances: FakeWebSocket[] = [];
@@ -31,11 +42,16 @@ const { FakeWebSocket } = vi.hoisted(() => {
 
     send(): void {}
     close(): void {}
-    terminate(): void {}
+    terminate = vi.fn();
   }
-  return { FakeWebSocket };
+  return {
+    FakeWebSocket,
+    createWebSocketStream: vi.fn(() => fakeStream()),
+    netConnect: vi.fn(() => fakeStream()),
+  };
 });
-vi.mock('ws', () => ({ WebSocket: FakeWebSocket, createWebSocketStream: vi.fn() }));
+vi.mock('ws', () => ({ WebSocket: FakeWebSocket, createWebSocketStream }));
+vi.mock('node:net', () => ({ default: { connect: netConnect } }));
 
 vi.mock('../src/platform/binding.js', () => ({
   setPlatformTeams: vi.fn(),
@@ -60,6 +76,8 @@ describe('tunnel-client 不强制协议族', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     FakeWebSocket.instances.length = 0;
+    createWebSocketStream.mockClear();
+    netConnect.mockClear();
   });
 
   afterEach(() => {
@@ -100,6 +118,26 @@ describe('tunnel-client 不强制协议族', () => {
     for (const d of dataDials) {
       expect(d.opts.family).toBeUndefined();
     }
+    handle.stop();
+  });
+
+  it('数据连接在 1.2s 后握手成功时不会被提前终止', async () => {
+    const handle = startPlatformTunnelClient(makeOpts());
+    const inst = FakeWebSocket.instances;
+    inst[0]!.readyState = FakeWebSocket.OPEN;
+    inst[0]!.emit('open');
+    inst[0]!.emit('message', JSON.stringify({ type: 'open-stream', streamId: 'slow-handshake' }));
+    const dataDials = inst.slice(CONTROL_DIAL_PARALLEL);
+
+    await vi.advanceTimersByTimeAsync(1_200);
+    expect(dataDials).toHaveLength(3);
+    expect(dataDials.every((dial) => dial.terminate.mock.calls.length === 0)).toBe(true);
+
+    dataDials[0]!.readyState = FakeWebSocket.OPEN;
+    dataDials[0]!.emit('open');
+    expect(dataDials[0]!.terminate).not.toHaveBeenCalled();
+    expect(createWebSocketStream).toHaveBeenCalledWith(dataDials[0]);
+    expect(netConnect).toHaveBeenCalledWith(7891, '127.0.0.1');
     handle.stop();
   });
 


### PR DESCRIPTION
## 问题

生产环境中，机器控制隧道在线、本地 Dashboard 正常，但远程 Dashboard 打开会返回 `socket hang up`。

## 根因

数据 WebSocket 的单次拨号超时为 1 秒，而生产 TLB/TLS 握手可达到约 1.2 秒，客户端会在正常握手完成前主动终止连接。

## 修复

- 将数据连接单次拨号超时从 1 秒调整为 3 秒
- 将总体拨号预算从 6 秒调整为 8 秒
- 保持并行数和最大波次数不变

## 验证

- 新增 1.2 秒延迟握手回归测试；旧逻辑会失败，新逻辑通过
- 目标 Vitest：5/5 通过
- TypeScript 编译通过
- Dashboard bundle 构建通过
- 本机应用修复后，生产公网机器子域经数据隧道 2.79 秒返回 Dashboard 预期响应，不再出现 `socket hang up`

## 关联 Platform MR

- https://code.byted.org/botmux/platform/merge_requests/4
- 本 PR 是恢复数据隧道可达性的根修；Platform MR 增加同链路探活、异常状态和“重试打开”反馈。
- 两边可独立合入；旧客户端仍异常时，Platform MR 会准确显示 degraded，完整恢复依赖本 PR。