### PR TITLE
fix(daemon): 同目录拉起优先于自动 worktree

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -13284,13 +13284,15 @@ function resolveBotDefaultWorkingDir(larkAppId: string): string | undefined {
  *      this bot — cross-bot dir alignment is handled by layer 4 inherit-peer)
  *   2) this bot's defaultOncall — auto-binds a brand-new chat when the flag is on
  *      (this WRITES state, so it must run identically on every spawn path)
- *   3) this bot's OWN effective `defaultWorkingDir` (legacy `defaultWorkingDir`,
+ *   3) when auto-worktree is enabled, a sibling session's workingDir if
+ *      "bot@bot 同目录拉起" is on. Reusing the already-running collaborator's
+ *      exact dir must win over creating a second, unrelated worktree.
+ *   4) this bot's OWN effective `defaultWorkingDir` (legacy `defaultWorkingDir`,
  *      or the `defaultOncall.workingDir` all-sessions fallback — see
  *      {@link resolveBotDefaultWorkingDir}). An explicit per-bot config is the
- *      bot's own intent, so it OUTRANKS cross-bot inheritance: a sibling's
- *      incidental session dir must never override a dir this bot configured for
- *      itself. Only a bot that configured nothing of its own falls to layer 4.
- *   4) a sibling session's workingDir (cross-bot / chat-scope inheritance) —
+ *      bot's own intent and normally OUTRANKS cross-bot inheritance. The sole
+ *      exception is the auto-worktree conflict described in layer 3.
+ *   5) a sibling session's workingDir (cross-bot / chat-scope inheritance) —
  *      last-resort convenience so a freshly @mentioned collaborator bot with no
  *      dir of its own follows the topic instead of bouncing through a repo card.
  * Returns the dir plus the oncall / inherited source so callers can log the reason.
@@ -13308,27 +13310,29 @@ async function resolvePinnedWorkingDir(ctx: {
   if (!oncallEntry) {
     oncallEntry = await maybeAutoBindDefaultOncall(ctx.larkAppId, ctx.chatId, ctx.chatType);
   }
-  // Layer 3: this bot's own effective default. Resolved BEFORE inheritance so an
-  // explicit per-bot dir wins over a sibling bot's active session dir.
+  // Resolve the bot default first so we know whether inheritance is only the
+  // ordinary last-resort fallback or must preempt an auto-created worktree.
   const botDefaultWorkingDir = !oncallEntry
     ? resolveBotDefaultWorkingDir(ctx.larkAppId)
     : undefined;
-  // Layer 4: sibling/peer inheritance — only when this bot has neither an oncall
-  // binding nor any default dir of its own.
-  const inheritedFrom = (!oncallEntry && !botDefaultWorkingDir)
+  const preferPeerOverAutoWorktree = !oncallEntry
+    && !!botDefaultWorkingDir
+    && botAutoWorktreeEnabled(ctx.larkAppId);
+  // Peer inheritance is normally the fallback after this bot's own default. When
+  // that default would create a fresh worktree, however, "bot@bot 同目录拉起"
+  // takes priority: a valid same-anchor peer suppresses auto-worktree for this
+  // session. The per-bot gate is enforced inside findInheritablePeer.
+  const inheritedFrom = (!oncallEntry && (!botDefaultWorkingDir || preferPeerOverAutoWorktree))
     ? findInheritablePeer({
         scope: ctx.scope, anchor: ctx.anchor, chatId: ctx.chatId, chatType: ctx.chatType,
         selfAppId: ctx.larkAppId,
         botToBotSameDir: getBot(ctx.larkAppId).config.botToBotSameDir !== false,
       })
     : null;
-  const pinnedWorkingDir = oncallEntry?.workingDir ?? botDefaultWorkingDir ?? inheritedFrom?.workingDir;
-  // Did the pinned dir come from this bot's OWN 仅默认目录 (layer 3)? Only that layer
-  // opts into auto-worktree — oncall bindings / sibling inheritance never do. When
-  // there's no oncall entry, pinnedWorkingDir IS botDefaultWorkingDir whenever the
-  // latter is set (it wins over inherit), so `!oncallEntry && botDefaultWorkingDir`
-  // fully characterizes "came from the bot's own default".
-  const pinnedFromBotDefault = !oncallEntry && !!botDefaultWorkingDir;
+  const pinnedWorkingDir = oncallEntry?.workingDir ?? inheritedFrom?.workingDir ?? botDefaultWorkingDir;
+  // Only the bot-default winner opts into auto-worktree. A same-dir peer winner
+  // keeps its exact workingDir and therefore suppresses worktree creation.
+  const pinnedFromBotDefault = !oncallEntry && !inheritedFrom && !!botDefaultWorkingDir;
   return { pinnedWorkingDir, oncallEntry, inheritedFrom, pinnedFromBotDefault };
 }
 

--- a/test/daemon-pinned-working-dir.test.ts
+++ b/test/daemon-pinned-working-dir.test.ts
@@ -88,6 +88,86 @@ describe('resolvePinnedWorkingDir', () => {
     expect(result.pinnedFromBotDefault).toBe(true);
   });
 
+  it('prefers bot@bot same-dir over auto-worktree when both dashboard options are enabled', async () => {
+    const { botRegistry, sessionStore, daemon } = await loadFreshModules();
+    const peerDir = tempDir('peer-worktree');
+    const defaultDir = tempDir('default-repo');
+    botRegistry.registerBot({ larkAppId: 'app-peer', larkAppSecret: 's', cliId: 'claude-code' });
+    botRegistry.registerBot({
+      larkAppId: 'app-self',
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      defaultWorkingDir: defaultDir,
+      defaultWorkingDirAutoWorktree: true,
+      // botToBotSameDir omitted => default on
+    });
+    const peer = await seedPeerSession(sessionStore, peerDir);
+
+    const result = await daemon.__testOnly_resolvePinnedWorkingDir({
+      scope: 'thread',
+      anchor: 'om_root',
+      chatId: 'oc_chat',
+      chatType: 'group',
+      larkAppId: 'app-self',
+    });
+
+    expect(result.pinnedWorkingDir).toBe(peerDir);
+    expect(result.inheritedFrom).toEqual({ sessionId: peer.sessionId, larkAppId: 'app-peer', workingDir: peerDir });
+    expect(result.pinnedFromBotDefault).toBe(false);
+  });
+
+  it('uses the bot default for auto-worktree when bot@bot same-dir is disabled', async () => {
+    const { botRegistry, sessionStore, daemon } = await loadFreshModules();
+    const peerDir = tempDir('peer-worktree');
+    const defaultDir = tempDir('default-repo');
+    botRegistry.registerBot({ larkAppId: 'app-peer', larkAppSecret: 's', cliId: 'claude-code' });
+    botRegistry.registerBot({
+      larkAppId: 'app-self',
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      defaultWorkingDir: defaultDir,
+      defaultWorkingDirAutoWorktree: true,
+      botToBotSameDir: false,
+    });
+    await seedPeerSession(sessionStore, peerDir);
+
+    const result = await daemon.__testOnly_resolvePinnedWorkingDir({
+      scope: 'thread',
+      anchor: 'om_root',
+      chatId: 'oc_chat',
+      chatType: 'group',
+      larkAppId: 'app-self',
+    });
+
+    expect(result.pinnedWorkingDir).toBe(defaultDir);
+    expect(result.inheritedFrom).toBeNull();
+    expect(result.pinnedFromBotDefault).toBe(true);
+  });
+
+  it('falls back to auto-worktree when same-dir is enabled but no peer exists', async () => {
+    const { botRegistry, daemon } = await loadFreshModules();
+    const defaultDir = tempDir('default-repo');
+    botRegistry.registerBot({
+      larkAppId: 'app-self',
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      defaultWorkingDir: defaultDir,
+      defaultWorkingDirAutoWorktree: true,
+    });
+
+    const result = await daemon.__testOnly_resolvePinnedWorkingDir({
+      scope: 'thread',
+      anchor: 'om_root',
+      chatId: 'oc_chat',
+      chatType: 'group',
+      larkAppId: 'app-self',
+    });
+
+    expect(result.pinnedWorkingDir).toBe(defaultDir);
+    expect(result.inheritedFrom).toBeNull();
+    expect(result.pinnedFromBotDefault).toBe(true);
+  });
+
   it('inherits a same-anchor peer workingDir ONLY when this bot has no oncall binding and no default dir of its own', async () => {
     const { botRegistry, sessionStore, daemon } = await loadFreshModules();
     const peerDir = tempDir('peer-repo');


### PR DESCRIPTION
## 改了什么

修正新会话工作目录解析中「每个新会话自动创建 worktree」与「bot@bot 同目录拉起」同时开启时的优先级：

- 本 bot 的 Oncall 绑定仍保持最高优先级。
- 自动 worktree 开启、同目录拉起开启且同锚点存在有效兄弟 bot 会话时，优先继承兄弟会话的 `workingDir`，并抑制本会话的自动 worktree。
- 同目录拉起关闭或没有有效兄弟会话时，继续从本 bot 默认目录创建 worktree。
- 自动 worktree 未开启时，保留原有“本 bot 默认目录优先于兄弟继承”行为。

同时补充三组回归测试，覆盖两个开关同时开启、同目录拉起关闭、同目录拉起开启但无可继承会话。

## 为什么

旧逻辑在本 bot 配置 `defaultWorkingDir` 后完全不查询兄弟会话，因此两个开关同时开启时会直接创建新的 worktree，违背「bot@bot 同目录拉起」的协作语义。

## 影响面

改动位于 daemon 公共的新会话目录解析，覆盖普通首条消息、透传命令、新话题、主动入群及 bot@bot 自动创建等入口。该判断发生在 CLI adapter 和 backend 之前，因此 Claude/Codex 等所有 CLI 及 PTY/Tmux 等后端行为一致。

Oncall、restore/adopt、HTTP 虚拟会话和普通 webhook 路径不改变。

## 验证

- `pnpm build`：通过
- 相关回归：4 files / 74 tests 全部通过
- 完整 `pnpm test`：9431/9434 通过；3 项失败均由本机 `~/.botmux/config.json` 的 `scheduleTimeZone=Asia/Shanghai` 影响 host-local 时区断言
- 隔离 HOME 复跑时区失败集：2 files / 128 tests 全部通过
- `git diff --check origin/master...HEAD`：通过
- Grok 独立 review：无 Blocking / Medium，结论 **clean 可合入**
