### PR TITLE
test(platform): 修复 macOS 测试基线

### DIFF
--- a/src/services/vc-meeting-consumer-isolation.ts
+++ b/src/services/vc-meeting-consumer-isolation.ts
@@ -12,14 +12,16 @@ export type VcMeetingConsumerIsolationResult =
 /**
  * VC meeting entries are untrusted input, while their consumer role can request
  * externally-visible side effects.  A receiver is therefore eligible only
- * when the whole CLI is inside the Linux bwrap boundary whose mandatory
+ * when the whole CLI is inside the Linux bwrap boundary. Its mandatory
  * credential masks and host-authorized outbox relay make the managed action
  * ledger the only credentialed Lark output path.
  *
- * macOS `sandbox: true` currently provides write isolation only; riff injects
- * the Lark app secret into the remote task; herdr/zellij are not wrapped by the
- * local bwrap implementation.  All are intentionally rejected instead of
- * treating a prompt instruction as a security boundary.
+ * On macOS, `sandbox: true` can also add Seatbelt read isolation for supported
+ * CLIs, but the ordinary sandbox still exposes this bot's own send credential
+ * and has no host-authorized outbox relay. Riff injects the Lark app secret into
+ * the remote task; herdr/zellij are not wrapped by the local bwrap
+ * implementation. All are intentionally rejected instead of treating a prompt
+ * instruction as a security boundary.
  */
 export function evaluateVcMeetingConsumerIsolation(input: {
   sandbox: boolean | undefined;

--- a/src/workflows/ops-projection.ts
+++ b/src/workflows/ops-projection.ts
@@ -18,7 +18,7 @@
  *     runDir + blobDir, which is wrong for a read-only API.
  */
 import { promises as fs } from 'node:fs';
-import { relative, resolve, sep, join, dirname } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 
 import {
   parseWorkflowDefinition,
@@ -601,14 +601,34 @@ async function previewRef(
     cache.set(key, res);
     return res;
   }
-  if (!isPathInside(runDir, ref.outputPath)) {
-    const res = { ...base, error: 'outputPath is outside run directory' };
+  let outputPath: string;
+  try {
+    const [canonicalRunDir, canonicalOutputPath] = await Promise.all([
+      fs.realpath(runDir),
+      fs.realpath(ref.outputPath),
+    ]);
+    if (!isPathInside(canonicalRunDir, canonicalOutputPath)) {
+      const res = { ...base, error: 'outputPath is outside run directory' };
+      cache.set(key, res);
+      return res;
+    }
+    outputPath = canonicalOutputPath;
+  } catch (err) {
+    if (!isPathInside(runDir, ref.outputPath)) {
+      const res = { ...base, error: 'outputPath is outside run directory' };
+      cache.set(key, res);
+      return res;
+    }
+    const res = {
+      ...base,
+      error: err instanceof Error ? err.message : String(err),
+    };
     cache.set(key, res);
     return res;
   }
 
   try {
-    const handle = await fs.open(ref.outputPath, 'r');
+    const handle = await fs.open(outputPath, 'r');
     try {
       const stat = await handle.stat();
       const bytesToRead = Math.min(stat.size, BLOB_PREVIEW_MAX_BYTES);
@@ -648,7 +668,8 @@ async function previewRef(
 
 function isPathInside(parent: string, child: string): boolean {
   const rel = relative(resolve(parent), resolve(child));
-  return rel === '' || (!!rel && !rel.startsWith('..') && !rel.startsWith(sep));
+  return rel === '' ||
+    (!!rel && !rel.startsWith('..') && !rel.startsWith(sep) && !isAbsolute(rel));
 }
 
 function isJsonContent(contentType?: string): boolean {

--- a/src/workflows/v3/distillation-runner.ts
+++ b/src/workflows/v3/distillation-runner.ts
@@ -139,6 +139,8 @@ export interface V3DistillationRunnerDeps {
   removeScratch?: (path: string) => Promise<void>;
   /** Test seam for Linux endpoint-managed Claude policy discovery. */
   managedPolicyRoot?: string;
+  /** Test-only frozen Linux `/etc` view. */
+  etcSnapshot?: readonly string[];
   /** Test-only bwrap seam. Production always invokes the stock `bwrap`. */
   sandboxBin?: string;
 }
@@ -148,8 +150,10 @@ export async function sweepAbandonedV3DistillationScratch(input: {
   scratchParent?: string;
   nowMs?: number;
   maxAgeMs?: number;
+  /** Test-only platform seam for host-independent cleanup cases. */
+  platform?: NodeJS.Platform;
 } = {}): Promise<number> {
-  if (process.platform !== 'linux') return 0;
+  if ((input.platform ?? process.platform) !== 'linux') return 0;
   const parent = await realpath(
     input.scratchParent ?? ensureV3DistillationScratchRoot(),
   );
@@ -411,7 +415,9 @@ export async function runV3DistillationModel(
   }
   const managedPolicyRoot = deps.managedPolicyRoot ?? DEFAULT_MANAGED_POLICY_ROOT;
   const managedPolicyRootExists = assertNoLinuxManagedClaudePolicy(managedPolicyRoot);
-  const etcSnapshot = snapshotDistillationEtcEntries();
+  const etcSnapshot = deps.etcSnapshot === undefined
+    ? snapshotDistillationEtcEntries()
+    : [...deps.etcSnapshot];
   const modelInput = normalizeModelFields(input.fields);
   const timeoutMs = normalizeTimeout(input.timeoutMs);
   let scratchDir: string | undefined;

--- a/test/plugin-init.test.ts
+++ b/test/plugin-init.test.ts
@@ -72,14 +72,27 @@ function createTemplateFixture(root: string): string {
 
 function packTemplateFixture(template: string, destination: string): string {
   mkdirSync(destination, { recursive: true });
-  const result = JSON.parse(execFileSync('npm', [
+  const result: unknown = JSON.parse(execFileSync('npm', [
     'pack',
     '--ignore-scripts',
     '--json',
     '--pack-destination',
     destination,
   ], { cwd: template, encoding: 'utf-8' }));
-  return join(destination, result[0].filename);
+  const packed = Array.isArray(result)
+    ? result[0]
+    : result && typeof result === 'object'
+      ? Object.values(result)[0]
+      : undefined;
+  if (
+    !packed ||
+    typeof packed !== 'object' ||
+    !('filename' in packed) ||
+    typeof packed.filename !== 'string'
+  ) {
+    throw new Error('npm pack returned no filename');
+  }
+  return join(destination, packed.filename);
 }
 
 describe('plugin init', () => {

--- a/test/v2-run-archive.test.ts
+++ b/test/v2-run-archive.test.ts
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   readdirSync,
   rmSync,
   symlinkSync,
@@ -357,6 +358,7 @@ describe('v2 workflow-run content-addressed archive', () => {
 
   it('requires daemon-stop acknowledgement, quarantines atomically, and replays idempotently', async () => {
     seedTerminal();
+    const canonicalRunsDir = realpathSync(runsDir);
     const archived = await commitV2RunArchive({ runsDir, archiveBaseDir });
     await expect(retireV2RunSource({
       runsDir,
@@ -381,7 +383,7 @@ describe('v2 workflow-run content-addressed archive', () => {
     expect(lstatSync(retired.receiptPath).mode & 0o777).toBe(0o600);
     expect(retired.receipt).toMatchObject({
       archiveId: archived.manifest.archiveId,
-      sourceRunsDir: runsDir,
+      sourceRunsDir: canonicalRunsDir,
       quarantineDir: retired.quarantineDir,
       retiredAt: '2026-07-11T01:00:00.000Z',
     });
@@ -467,13 +469,22 @@ describe('v2 workflow-run content-addressed archive', () => {
   });
 
   it('retires absolute OutputRef paths and recovers after rename without replaying relocated projections', async () => {
+    const physicalRoot = join(root, 'physical');
+    const aliasRoot = join(root, 'alias');
+    mkdirSync(physicalRoot);
+    symlinkSync(physicalRoot, aliasRoot, 'dir');
+    runsDir = join(aliasRoot, 'workflow-runs');
+    mkdirSync(runsDir);
+
     seedSucceededWithAbsoluteOutputPath();
+    const canonicalRunsDir = realpathSync(runsDir);
     const archived = await commitV2RunArchive({ runsDir, archiveBaseDir });
     const projection = JSON.parse(readFileSync(
       join(archived.archiveDir, 'runs', 'run-absolute-output', 'projection.json'),
       'utf-8',
     ));
     expect(projection.attemptIO['att-1'].input.value).toEqual({ ok: true });
+    runsDir = canonicalRunsDir;
 
     await expect(retireV2RunSource({
       runsDir,

--- a/test/v3-distillation-private-root.test.ts
+++ b/test/v3-distillation-private-root.test.ts
@@ -2,6 +2,7 @@ import {
   lstatSync,
   mkdirSync,
   mkdtempSync,
+  realpathSync,
   rmSync,
   symlinkSync,
 } from 'node:fs';
@@ -22,7 +23,7 @@ afterEach(() => {
 
 describe('v3 distillation private scratch root', () => {
   it('is private and idempotent in a uid-qualified host tmp root', () => {
-    const base = mkdtempSync(join(tmpdir(), 'v3-distill-private-root-'));
+    const base = realpathSync(mkdtempSync(join(tmpdir(), 'v3-distill-private-root-')));
     roots.push(base);
 
     const expected = v3DistillationScratchRoot(base);
@@ -35,7 +36,7 @@ describe('v3 distillation private scratch root', () => {
   });
 
   it('rejects a pre-created symlink at the uid-qualified root', () => {
-    const base = mkdtempSync(join(tmpdir(), 'v3-distill-private-root-'));
+    const base = realpathSync(mkdtempSync(join(tmpdir(), 'v3-distill-private-root-')));
     roots.push(base);
     const target = join(base, 'target');
     mkdirSync(target, { mode: 0o700 });

--- a/test/v3-distillation-runner.test.ts
+++ b/test/v3-distillation-runner.test.ts
@@ -44,11 +44,12 @@ function runV3DistillationModel(
   input: Parameters<typeof runV3DistillationModelImpl>[0],
   deps: NonNullable<Parameters<typeof runV3DistillationModelImpl>[1]> = {},
 ) {
-  const adapterBin = deps.adapterBin === process.execPath
+  const useHostPortableSeams = process.platform !== 'linux';
+  const adapterBin = useHostPortableSeams && deps.adapterBin === process.execPath
     ? hostPortableStockClaudeFixture(deps.scratchParent)
     : deps.adapterBin;
   return runV3DistillationModelImpl(input, {
-    etcSnapshot: ['hosts'],
+    ...(useHostPortableSeams ? { etcSnapshot: ['hosts'] } : {}),
     ...deps,
     adapterBin,
   });

--- a/test/v3-distillation-runner.test.ts
+++ b/test/v3-distillation-runner.test.ts
@@ -11,7 +11,7 @@ import {
 } from 'node:fs';
 import { spawn } from 'node:child_process';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -23,8 +23,8 @@ import {
   V3DistillationRunnerError,
   buildV3DistillationModelPrompt,
   buildV3DistillationSystemPrompt,
-  runV3DistillationModel,
-  sweepAbandonedV3DistillationScratch,
+  runV3DistillationModel as runV3DistillationModelImpl,
+  sweepAbandonedV3DistillationScratch as sweepAbandonedV3DistillationScratchImpl,
   type V3DistillationStructuredInvocation,
 } from '../src/workflows/v3/distillation-runner.js';
 import type { V3DistillationModelFieldV1 } from '../src/workflows/v3/distillation-compiler.js';
@@ -32,6 +32,36 @@ import type { BotSnapshot } from '../src/workflows/v3/contract.js';
 
 const roots: string[] = [];
 const originalAnthropicApiKey = process.env.ANTHROPIC_API_KEY;
+
+function hostPortableStockClaudeFixture(scratchParent: string | undefined): string {
+  if (!scratchParent) throw new Error('test fixture requires scratchParent');
+  const executable = join(dirname(scratchParent), 'synthetic-claude');
+  writeFileSync(executable, '#!/usr/bin/env node\n', { mode: 0o700 });
+  return executable;
+}
+
+function runV3DistillationModel(
+  input: Parameters<typeof runV3DistillationModelImpl>[0],
+  deps: NonNullable<Parameters<typeof runV3DistillationModelImpl>[1]> = {},
+) {
+  const adapterBin = deps.adapterBin === process.execPath
+    ? hostPortableStockClaudeFixture(deps.scratchParent)
+    : deps.adapterBin;
+  return runV3DistillationModelImpl(input, {
+    etcSnapshot: ['hosts'],
+    ...deps,
+    adapterBin,
+  });
+}
+
+function sweepAbandonedV3DistillationScratch(
+  input: Parameters<typeof sweepAbandonedV3DistillationScratchImpl>[0] = {},
+) {
+  return sweepAbandonedV3DistillationScratchImpl({
+    platform: 'linux',
+    ...input,
+  });
+}
 
 beforeEach(() => {
   process.env.ANTHROPIC_API_KEY = 'synthetic-test-api-key';
@@ -319,8 +349,9 @@ describe('runV3DistillationModel', () => {
     expect(readdirSync(dirs.scratchParent)).toEqual([]);
   });
 
-  it('collapses the PID namespace before cleaning scratch', async () => {
-    if (process.platform !== 'linux') return;
+  it.skipIf(process.platform !== 'linux')(
+    'collapses the PID namespace before cleaning scratch',
+    async () => {
     const dirs = fixture();
     const executable = join(dirs.root, 'synthetic-model-runner.cjs');
     writeFileSync(executable, `#!/usr/bin/env node
@@ -361,7 +392,8 @@ setInterval(() => {}, 1000);
     expect(Date.now() - startedAt).toBeGreaterThanOrEqual(900);
     expect(() => process.kill(helperPid, 0)).toThrow();
     expect(readdirSync(dirs.scratchParent)).toEqual([]);
-  });
+    },
+  );
 
   it('rejects unsupported platforms, CLIs, and malformed fields before invocation', async () => {
     const dirs = fixture();
@@ -928,8 +960,9 @@ describe('sweepAbandonedV3DistillationScratch', () => {
     expect(existsSync(unrelated)).toBe(true);
   });
 
-  it('kills an exact orphaned model process group before removing its scratch', async () => {
-    if (process.platform !== 'linux') return;
+  it.skipIf(process.platform !== 'linux')(
+    'kills an exact orphaned model process group before removing its scratch',
+    async () => {
     const dirs = fixture();
     const scratch = join(dirs.scratchParent, 'botmux-v3-distill-orphan123');
     mkdirSync(scratch, { mode: 0o700 });
@@ -969,10 +1002,12 @@ describe('sweepAbandonedV3DistillationScratch', () => {
       new Promise<never>((_, reject) => setTimeout(() => reject(new Error('orphan remained alive')), 2_000)),
     ]);
     expect(existsSync(scratch)).toBe(false);
-  });
+    },
+  );
 
-  it('never signals a PID/start-tick collision recorded by a previous boot', async () => {
-    if (process.platform !== 'linux') return;
+  it.skipIf(process.platform !== 'linux')(
+    'never signals a PID/start-tick collision recorded by a previous boot',
+    async () => {
     const dirs = fixture();
     const scratch = join(dirs.scratchParent, 'botmux-v3-distill-oldboot123');
     mkdirSync(scratch, { mode: 0o700 });
@@ -1011,10 +1046,12 @@ describe('sweepAbandonedV3DistillationScratch', () => {
     child.kill('SIGKILL');
     await new Promise<void>((resolve) => child.once('close', () => resolve()));
     expect(existsSync(scratch)).toBe(false);
-  });
+    },
+  );
 
-  it('never blind-kills or ages out a leaderless legacy process-group marker', async () => {
-    if (process.platform !== 'linux') return;
+  it.skipIf(process.platform !== 'linux')(
+    'never blind-kills or ages out a leaderless legacy process-group marker',
+    async () => {
     const dirs = fixture();
     const scratch = join(dirs.scratchParent, 'botmux-v3-distill-legacy123');
     mkdirSync(scratch, { mode: 0o700 });
@@ -1032,7 +1069,8 @@ describe('sweepAbandonedV3DistillationScratch', () => {
       maxAgeMs: 31 * 60_000,
     })).toBe(0);
     expect(existsSync(scratch)).toBe(true);
-  });
+    },
+  );
 
   it('retains corrupt ownership markers instead of treating them as markerless', async () => {
     const dirs = fixture();
@@ -1079,8 +1117,9 @@ describe('sweepAbandonedV3DistillationScratch', () => {
     expect(existsSync(live)).toBe(true);
   });
 
-  it('removes preparing-only scratch after a boot-id mismatch without waiting for age', async () => {
-    if (process.platform !== 'linux') return;
+  it.skipIf(process.platform !== 'linux')(
+    'removes preparing-only scratch after a boot-id mismatch without waiting for age',
+    async () => {
     const dirs = fixture();
     const scratch = join(dirs.scratchParent, 'botmux-v3-distill-preparing-boot');
     mkdirSync(scratch, { mode: 0o700 });
@@ -1099,7 +1138,8 @@ describe('sweepAbandonedV3DistillationScratch', () => {
       maxAgeMs: 31 * 60_000,
     })).toBe(1);
     expect(existsSync(scratch)).toBe(false);
-  });
+    },
+  );
 
   it('retains corrupt preparing markers instead of aging them out', async () => {
     const dirs = fixture();

--- a/test/vc-meeting-consumer-isolation.test.ts
+++ b/test/vc-meeting-consumer-isolation.test.ts
@@ -32,7 +32,7 @@ describe('VC meeting consumer managed side-effect isolation', () => {
     },
   );
 
-  it('rejects macOS because its current sandbox does not confine credential reads', () => {
+  it('rejects macOS because its sandbox exposes the bot credential without a host relay', () => {
     expect(evaluateVcMeetingConsumerIsolation({
       sandbox: true,
       platform: 'darwin',

--- a/test/vc-meeting-daemon-session.test.ts
+++ b/test/vc-meeting-daemon-session.test.ts
@@ -76,6 +76,20 @@ const realtimeVoiceSpeakHolds = vi.hoisted(() => ({
   resolvers: [] as Array<() => void>,
 }));
 
+vi.mock('../src/services/vc-meeting-consumer-isolation.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/services/vc-meeting-consumer-isolation.js')>();
+  return {
+    ...actual,
+    // The lifecycle below is platform-independent and models the supported
+    // receiver path. Keep every case running on macOS while using the real
+    // policy logic with Linux selected; platform rejection remains covered by
+    // the focused isolation tests.
+    evaluateVcMeetingConsumerIsolation: (
+      input: Parameters<typeof actual.evaluateVcMeetingConsumerIsolation>[0],
+    ) => actual.evaluateVcMeetingConsumerIsolation({ ...input, platform: 'linux' }),
+  };
+});
+
 vi.mock('@larksuiteoapi/node-sdk', () => {
   class FakeClient {
     opts: Record<string, unknown>;

--- a/test/workflow-ops-projection.test.ts
+++ b/test/workflow-ops-projection.test.ts
@@ -1,5 +1,12 @@
 /** Frozen v2 read-only projection coverage retained for archive verification. */
-import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -44,6 +51,7 @@ async function seedRun(input: {
   terminal?: 'succeeded' | 'failed';
   timestamp?: number;
   binding?: boolean;
+  escapeOutputPath?: boolean;
 }): Promise<FrozenV2EventLog> {
   const { runId } = input;
   const log = new FrozenV2EventLog(runId, runsDir);
@@ -57,7 +65,13 @@ async function seedRun(input: {
     outputSchemaVersion: 1,
     contentType: 'application/json',
   };
-  writeFileSync(outputPath, '{"ok":true}\n', 'utf-8');
+  if (input.escapeOutputPath) {
+    const outsidePath = join(root, `${runId}-outside.json`);
+    writeFileSync(outsidePath, '{"ok":true}\n', 'utf-8');
+    symlinkSync(outsidePath, outputPath);
+  } else {
+    writeFileSync(outputPath, '{"ok":true}\n', 'utf-8');
+  }
   writeFileSync(join(log.runDir, 'workflow.json'), canonicalJsonStringify(DEF), 'utf-8');
   if (input.binding) {
     writeFileSync(
@@ -193,6 +207,21 @@ describe('frozen v2 snapshot and event window', () => {
     expect(after?.events.map((event) => event.eventId)).toEqual(['window-4', 'window-5']);
     expect(await readEventWindow(runsDir, '../window')).toBeNull();
     expect(await readRunSnapshot(runsDir, 'missing')).toBeNull();
+  });
+
+  it('rejects an OutputRef symlink that resolves outside the run directory', async () => {
+    await seedRun({
+      runId: 'escape',
+      terminal: 'succeeded',
+      escapeOutputPath: true,
+    });
+    const snapshot = await readRunSnapshot(runsDir, 'escape');
+    const preview = Object.values(snapshot?.attemptIO ?? {})[0]?.output;
+    expect(preview).toMatchObject({
+      error: 'outputPath is outside run directory',
+    });
+    expect(preview).not.toHaveProperty('value');
+    expect(preview).not.toHaveProperty('text');
   });
 });
 


### PR DESCRIPTION
## 说明

替代 #518。原 PR 的作者分支关闭了 maintainer edit，无法直接补推；本 PR 保留作者原有两笔提交，并追加 `f8a484c1` 修复二审发现的 Linux 测试覆盖回退。

## 改了什么

- 恢复 macOS 全量单测基线，并按真实平台能力区分“应跨平台执行”和“确实 Linux-only”的测试。
- VC lifecycle 测试固定使用受支持的 Linux receiver policy，同时继续调用真实 isolation evaluator；macOS production eligibility 的 focused test 仍验证 fail-close。
- V3 distillation 的宿主无关测试在非 Linux 使用确定的 `/etc` 快照与跨平台 stock-Claude 启动器；Linux 保留真实 `/etc` snapshot 与 ELF/native launcher 覆盖。
- 5 个依赖 bwrap、PID namespace 或 Linux boot identity 的内核级用例使用 `skipIf` 明确标记。
- macOS 临时目录断言使用 canonical path，兼容 `/var` → `/private/var`。
- V2 冻结投影器使用真实路径校验 OutputRef containment：允许指向同一物理目录的祖先别名，同时拒绝 run 目录内指向外部的 symlink，并打开 canonical child。
- plugin-init 测试夹具兼容 npm 11 的数组格式与 npm 12 的包名键控对象格式。

## 原因

macOS 基线中的测试覆盖不同边界：VC lifecycle、V3 policy/清理逻辑、npm fixture 和路径投影均可在 macOS 可靠执行，不应整体跳过；只有依赖 Linux 内核隔离能力的用例应明确显示为 skipped。

V2 的 `/var` 与 `/private/var` 差异属于同一物理目录的路径别名。使用 canonical containment 既修复合法读取，也收紧了 symlink 越界读取边界。

二审指出可移植 helper 原先在 Linux 也无条件替换 `process.execPath` 并冻结 `/etc`，会绕过真实 Linux 生产路径。现在仅在非 Linux 启用这两个 seam。

## 影响面

- VC production 判定不变：仍只接受 `sandbox: true + Linux + pty/tmux`，macOS managed receiver 仍为 fail-close。
- V3 distillation production 仍为 Linux-only；测试 seam 默认读取真实宿主状态，daemon 调用行为不变。
- V2 改动仅影响已退休 workflow v2 的只读投影与归档验证路径，当前 v3 执行不受影响。
- 不涉及其它 CLI 共用启动路径、IM 会话、卡片或 dashboard UI。

## 实际验证

- `pnpm exec vitest run --project unit test/v3-distillation-runner.test.ts --reporter=dot`：33 passed。
- `pnpm build`：通过。
- `TZ=Asia/Shanghai pnpm exec vitest run --project unit`：2261/2261 suites passed，9426/9426 tests passed。
- `pnpm daemon:restart && pnpm daemon:status`：通过，所有进程 online。
