### PR TITLE
fix: 保留切换仓库后的普通群会话作用域

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -129,7 +129,7 @@ import {
 } from './services/whiteboard-store.js';
 import { buildBridgeSendMarkerContent } from './services/bridge-fallback-gate.js';
 import { bindRestartLeaseTo, writeManualIntentIfAbsentTo } from './services/restart-intent-store.js';
-import { stripLegacyPendingCardFields } from './services/session-store.js';
+import { repairMissingChatScope, stripLegacyPendingCardFields } from './services/session-store.js';
 import {
   evaluateVcMeetingManagedSend,
   isTrustedVcMeetingHostRelayParent,
@@ -2918,7 +2918,9 @@ function loadSessions(): Map<string, SessionData> {
       legacyData = JSON.parse(readFileSync(legacyFp, 'utf-8'));
       for (const [, v] of Object.entries(legacyData)) {
         const s = v as SessionData;
-        if (s.sessionId) sessions.set(s.sessionId, s);
+        if (!s || typeof s !== 'object' || !s.sessionId) continue;
+        repairMissingChatScope(s);
+        sessions.set(s.sessionId, s);
       }
     } catch { /* ignore */ }
   }
@@ -2933,7 +2935,8 @@ function loadSessions(): Map<string, SessionData> {
           const data = JSON.parse(readFileSync(join(dataDir, file), 'utf-8'));
           for (const [, v] of Object.entries(data)) {
             const session = v as SessionData;
-            if (!session.sessionId) continue;
+            if (!session || typeof session !== 'object' || !session.sessionId) continue;
+            repairMissingChatScope(session);
             // Stamp larkAppId so saveSession writes back to the correct file
             if (!session.larkAppId) session.larkAppId = appId;
             sessions.set(session.sessionId, session);

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -1627,7 +1627,18 @@ export async function handleCommand(
             );
 
             const oldSession = ds!.session;
-            const session = sessionStore.createSession(ds!.chatId, rootId, displayName, ds!.chatType);
+            // `rootId` is the routing anchor. For chat-scope sessions it is the
+            // `oc_...` chat id, not the traceable `om_...` message root stored on
+            // Session. Preserve the old identity and explicitly persist scope so
+            // repo switches cannot turn a chat session into a legacy scope-less
+            // record that the CLI later mistakes for a thread.
+            const session = sessionStore.createSession(
+              ds!.chatId,
+              ds!.scope === 'chat' ? oldSession.rootMessageId : rootId,
+              displayName,
+              ds!.chatType,
+              ds!.scope,
+            );
             ds!.session = session;
             ds!.lastUserPrompt = undefined;
             ds!.lastCliInput = undefined;

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -585,7 +585,17 @@ export async function commitRepoSelection(
     );
 
     const oldSession = ds.session;
-    const session = sessionStore.createSession(ds.chatId, rootId, dirLabel, ds.chatType);
+    // `rootId` is the routing anchor. For chat-scope sessions it is the
+    // `oc_...` chat id, not the traceable `om_...` message root stored on
+    // Session. Preserve the old identity and explicitly persist scope so card
+    // switches cannot recreate the session as a legacy scope-less thread.
+    const session = sessionStore.createSession(
+      ds.chatId,
+      ds.scope === 'chat' ? oldSession.rootMessageId : rootId,
+      dirLabel,
+      ds.chatType,
+      ds.scope,
+    );
     ds.session = session;
     ds.lastUserPrompt = undefined;
     ds.lastCliInput = undefined;

--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -48,13 +48,17 @@ function ensureDir(): void {
 // narrow signature so ordinary legacy records without scope keep their
 // documented thread fallback. The original trace message cannot be recovered,
 // but chat routing does not use rootMessageId.
-function repairMissingChatScope(session: Session): boolean {
+export function repairMissingChatScope(session: unknown): boolean {
+  if (!session || typeof session !== 'object' || Array.isArray(session)) return false;
+  const record = session as Record<string, unknown>;
   if (
-    session.scope === undefined
-    && session.chatId.startsWith('oc_')
-    && session.rootMessageId === session.chatId
+    record.scope === undefined
+    && typeof record.chatId === 'string'
+    && record.chatId.startsWith('oc_')
+    && typeof record.rootMessageId === 'string'
+    && record.rootMessageId === record.chatId
   ) {
-    session.scope = 'chat';
+    record.scope = 'chat';
     return true;
   }
   return false;

--- a/src/services/session-store.ts
+++ b/src/services/session-store.ts
@@ -42,6 +42,32 @@ function ensureDir(): void {
   }
 }
 
+// A short-lived /repo bug recreated chat-scope sessions with the chat routing
+// anchor (`oc_...`) copied into rootMessageId and omitted scope. That shape is
+// impossible for a real thread: Lark message ids are `om_...`. Repair only this
+// narrow signature so ordinary legacy records without scope keep their
+// documented thread fallback. The original trace message cannot be recovered,
+// but chat routing does not use rootMessageId.
+function repairMissingChatScope(session: Session): boolean {
+  if (
+    session.scope === undefined
+    && session.chatId.startsWith('oc_')
+    && session.rootMessageId === session.chatId
+  ) {
+    session.scope = 'chat';
+    return true;
+  }
+  return false;
+}
+
+function repairMissingChatScopes(): number {
+  let repaired = 0;
+  for (const session of sessions.values()) {
+    if (repairMissingChatScope(session)) repaired += 1;
+  }
+  return repaired;
+}
+
 // Sessions persisted before 2026-04-29 lack `cliId`; consumers must fall back to 'unknown' at the render boundary.
 function load(): void {
   if (loaded) return;
@@ -51,11 +77,24 @@ function load(): void {
     try {
       const data = JSON.parse(readFileSync(fp, 'utf-8'));
       sessions = new Map(Object.entries(data));
-      logger.info(`Loaded ${sessions.size} sessions from ${fp}`);
     } catch (err) {
       logger.error(`Failed to load sessions: ${err}`);
       sessions = new Map();
+      loaded = true;
+      return;
     }
+    const repaired = repairMissingChatScopes();
+    if (repaired > 0) {
+      try {
+        save();
+        logger.info(`Repaired ${repaired} scope-less chat session(s) in ${fp}`);
+      } catch (err) {
+        // Loading succeeded, so keep the in-memory sessions available even if
+        // this best-effort migration cannot be persisted yet (ENOSPC/EACCES).
+        logger.error(`Failed to persist repaired chat session scopes: ${err}`);
+      }
+    }
+    logger.info(`Loaded ${sessions.size} sessions from ${fp}`);
   } else if (currentAppId) {
     // Per-bot file doesn't exist — migrate matching sessions from legacy sessions.json
     const legacyFp = join(config.session.dataDir, 'sessions.json');
@@ -69,8 +108,12 @@ function load(): void {
           }
         }
         if (sessions.size > 0) {
+          const repaired = repairMissingChatScopes();
           save();
           logger.info(`Migrated ${sessions.size} sessions from sessions.json to ${fp}`);
+          if (repaired > 0) {
+            logger.info(`Repaired ${repaired} scope-less chat session(s) during migration`);
+          }
         }
       } catch (err) {
         logger.error(`Failed to migrate sessions from legacy file: ${err}`);
@@ -113,13 +156,20 @@ function save(): void {
   renameSync(tmpFp, fp);
 }
 
-export function createSession(chatId: string, rootMessageId: string, title: string, chatType?: 'group' | 'p2p'): Session {
+export function createSession(
+  chatId: string,
+  rootMessageId: string,
+  title: string,
+  chatType?: 'group' | 'p2p',
+  scope?: 'thread' | 'chat',
+): Session {
   load();
   const session: Session = {
     sessionId: randomUUID(),
     chatId,
     chatType,
     rootMessageId,
+    scope,
     title,
     status: 'active',
     createdAt: new Date().toISOString(),

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -127,7 +127,7 @@ import { handleCardAction, type CardHandlerDeps } from '../src/im/lark/card-hand
 import { forkWorker, killWorker, deliverEphemeralOrReply, deliverWriteLinkCard } from '../src/core/worker-pool.js';
 import { buildNewTopicCliInput, getAvailableBots, getSessionWorkingDir } from '../src/core/session-manager.js';
 import { getBot } from '../src/bot-registry.js';
-import { createSession, closeSession } from '../src/services/session-store.js';
+import { createSession, closeSession, updateSession } from '../src/services/session-store.js';
 import { createRepoWorktree, pushWorktreeBranch, removeRepoWorktree } from '../src/services/git-worktree.js';
 import { applyConfigField } from '../src/services/bot-config-store.js';
 import { deleteMessage } from '../src/im/lark/client.js';
@@ -243,10 +243,11 @@ beforeEach(() => {
     botOpenId: 'ou_bot',
   }) as any);
   let n = 0;
-  vi.mocked(createSession).mockImplementation((chatId: string, rootId: string, title: string, chatType?: string) => ({
+  vi.mocked(createSession).mockImplementation((chatId: string, rootId: string, title: string, chatType?: string, scope?: 'thread' | 'chat') => ({
     sessionId: `uuid-new-${++n}`,
     chatId,
     rootMessageId: rootId,
+    scope,
     title,
     status: 'active',
     createdAt: new Date().toISOString(),
@@ -710,6 +711,46 @@ describe('repo select card — plain switch', () => {
     expect(forkWorker).not.toHaveBeenCalled();
     expect(ds.session.sessionId).toBe('uuid-old');
     expect(ds.session.workingDir).toBe('/repos/gamma');
+  });
+
+  it('mid-session chat selection preserves scope and the original message root', async () => {
+    const originalRoot = 'om_original_chat_start';
+    const ds = makeDs({
+      scope: 'chat',
+      session: {
+        ...makeDs().session,
+        scope: 'chat',
+        rootMessageId: originalRoot,
+      },
+    });
+    ds.session.workingDir = '/repos/gamma';
+    const activeSessions = new Map([[sessionKey(CHAT_ID, APP_ID), ds]]);
+    const sessionReply = vi.fn(async () => 'om_reply');
+    const deps: CardHandlerDeps = {
+      activeSessions,
+      sessionReply,
+      lastRepoScan: new Map([[CHAT_ID, PROJECTS]]),
+    };
+    const event = {
+      ...makeSelectEvent('repo_switch', '/repos/beta'),
+      action: {
+        option: '/repos/beta',
+        value: { key: 'repo_switch' as const, root_id: CHAT_ID },
+      },
+    };
+
+    await handleCardAction(event, deps, APP_ID);
+
+    expect(createSession).toHaveBeenCalledWith(CHAT_ID, originalRoot, 'beta (main)', 'group', 'chat');
+    expect(ds.session.scope).toBe('chat');
+    expect(ds.session.rootMessageId).toBe(originalRoot);
+    const persisted = vi.mocked(updateSession).mock.calls.find(
+      ([s]) => s.sessionId.startsWith('uuid-new-'),
+    )?.[0];
+    expect(persisted).toEqual(expect.objectContaining({
+      scope: 'chat',
+      rootMessageId: originalRoot,
+    }));
   });
 
   it('ignores a keyless dropdown (option + root_id, no repo_switch/repo_worktree key)', async () => {

--- a/test/cli-send-hook-context.test.ts
+++ b/test/cli-send-hook-context.test.ts
@@ -7,6 +7,17 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const cliSource = readFileSync(join(__dirname, '..', 'src', 'cli.ts'), 'utf8');
 
 describe('cmdSend hook context wiring', () => {
+  it('repairs scope-less chat records in both CLI session file loaders', () => {
+    const loadSessionsStart = cliSource.indexOf('function loadSessions()');
+    const saveSessionStart = cliSource.indexOf('function saveSession(', loadSessionsStart);
+    const loadSessions = cliSource.slice(loadSessionsStart, saveSessionStart);
+
+    expect(loadSessionsStart).toBeGreaterThanOrEqual(0);
+    expect(loadSessions.match(/repairMissingChatScope\(/g)).toHaveLength(2);
+    expect(loadSessions).toMatch(/repairMissingChatScope\(s\);[\s\S]*?sessions\.set\(s\.sessionId, s\)/);
+    expect(loadSessions).toMatch(/repairMissingChatScope\(session\);[\s\S]*?sessions\.set\(session\.sessionId, session\)/);
+  });
+
   it('passes the current session id into outbound send/reply hooks', () => {
     expect(cliSource).toContain('const hookContext = {');
     expect(cliSource).toMatch(/sendMessage\(\s*appId,\s*sendTarget\.chatId,\s*content,\s*msgType,\s*uuid,\s*hookContext,/);

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -138,10 +138,11 @@ vi.mock('../src/bot-registry.js', () => ({
 
 vi.mock('../src/services/session-store.js', () => ({
   closeSession: vi.fn(),
-  createSession: vi.fn((_chatId: string, _rootId: string, title: string, chatType: string) => ({
+  createSession: vi.fn((_chatId: string, _rootId: string, title: string, chatType: string, scope?: 'thread' | 'chat') => ({
     sessionId: 'new-session-123',
     chatId: _chatId,
     rootMessageId: _rootId,
+    scope,
     title,
     status: 'active' as const,
     createdAt: new Date().toISOString(),
@@ -1863,11 +1864,43 @@ describe('handleCommand', () => {
       expect(killWorker).toHaveBeenCalledWith(ds);
       expect(sessionStore.closeSession).toHaveBeenCalled();
       expect(sessionStore.createSession).toHaveBeenCalledWith(
-        CHAT_ID, ROOT_ID, 'project-b (dev)', 'group',
+        CHAT_ID, ROOT_ID, 'project-b (dev)', 'group', undefined,
       );
       expect(ds.session.sessionId).toBe('new-session-123');
       expect(ds.hasHistory).toBe(false);
       expect(forkWorker).toHaveBeenCalledWith(ds, '', false);
+    });
+
+    it('mid-session chat switch preserves scope and the original message root', async () => {
+      const originalRoot = 'om_original_chat_start';
+      const ds = makeDaemonSession({
+        pendingRepo: false,
+        scope: 'chat',
+        session: makeSession({ scope: 'chat', rootMessageId: originalRoot }),
+      });
+      const deps = makeDeps(ds);
+      deps.activeSessions.clear();
+      deps.activeSessions.set(sessionKey(CHAT_ID, LARK_APP_ID), ds);
+      deps.lastRepoScan.set(CHAT_ID, [
+        { name: 'project-a', path: '/home/testuser/project-a', branch: 'main' },
+      ]);
+
+      // A chat-scope command is routed with the oc_ chat anchor, not the
+      // traceable om_ message root stored on Session.
+      await handleCommand('/repo', CHAT_ID, makeLarkMessage('/repo 1'), deps, LARK_APP_ID);
+
+      expect(sessionStore.createSession).toHaveBeenCalledWith(
+        CHAT_ID, originalRoot, 'project-a (main)', 'group', 'chat',
+      );
+      expect(ds.session.scope).toBe('chat');
+      expect(ds.session.rootMessageId).toBe(originalRoot);
+      const persisted = vi.mocked(sessionStore.updateSession).mock.calls.find(
+        ([s]) => s.sessionId === 'new-session-123',
+      )?.[0];
+      expect(persisted).toEqual(expect.objectContaining({
+        scope: 'chat',
+        rootMessageId: originalRoot,
+      }));
     });
 
     it('mid-session switch should persist workingDir + larkAppId on the new session', async () => {
@@ -1945,7 +1978,7 @@ describe('handleCommand', () => {
 
       expect(ds.workingDir).toBe('/home/testuser/payments');
       expect(sessionStore.createSession).toHaveBeenCalledWith(
-        CHAT_ID, ROOT_ID, 'payments (main)', 'group',
+        CHAT_ID, ROOT_ID, 'payments (main)', 'group', undefined,
       );
       expect(forkWorker).toHaveBeenCalledWith(ds, '', false);
       // the pending repo-selection card must be withdrawn after resolving

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -13,6 +13,20 @@ import { tmpdir } from 'os';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────
 
+const fsControl = vi.hoisted(() => ({ failSessionWrite: false }));
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    writeFileSync: (...args: Parameters<typeof actual.writeFileSync>) => {
+      if (fsControl.failSessionWrite && String(args[0]).includes('sessions.json.')) {
+        throw new Error('simulated session repair write failure');
+      }
+      return actual.writeFileSync(...args);
+    },
+  };
+});
+
 // Mock config so we can point session.dataDir at a temp directory
 let tempDir: string;
 
@@ -62,6 +76,7 @@ function makeTempDir(): string {
 
 beforeEach(() => {
   tempDir = makeTempDir();
+  fsControl.failSessionWrite = false;
   mockDeleteFrozenCards.mockReset();
   // Reset module state for each test
   init();
@@ -104,6 +119,70 @@ describe('init()', () => {
     expect(loaded).toBeDefined();
     expect(loaded!.title).toBe('Pre-existing');
     expect(loaded!.status).toBe('active');
+  });
+
+  it('repairs only the scope-less oc_=root chat corruption signature', () => {
+    mkdirSync(tempDir, { recursive: true });
+    const records = {
+      broken: {
+        sessionId: 'broken',
+        chatId: 'oc_chat',
+        rootMessageId: 'oc_chat',
+        title: 'Broken repo switch',
+        status: 'active',
+        createdAt: '2026-07-18T00:00:00.000Z',
+      },
+      legacyThread: {
+        sessionId: 'legacyThread',
+        chatId: 'oc_chat',
+        rootMessageId: 'om_thread',
+        title: 'Legacy thread',
+        status: 'active',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    };
+    const fp = join(tempDir, 'sessions.json');
+    writeFileSync(fp, JSON.stringify(records));
+
+    init();
+
+    expect(getSession('broken')?.scope).toBe('chat');
+    expect(getSession('legacyThread')?.scope).toBeUndefined();
+    const persisted = JSON.parse(readFileSync(fp, 'utf-8'));
+    expect(persisted.broken.scope).toBe('chat');
+    expect(persisted.legacyThread.scope).toBeUndefined();
+  });
+
+  it('keeps loaded sessions available when persisting a scope repair fails', () => {
+    mkdirSync(tempDir, { recursive: true });
+    const fp = join(tempDir, 'sessions.json');
+    writeFileSync(fp, JSON.stringify({
+      broken: {
+        sessionId: 'broken',
+        chatId: 'oc_chat',
+        rootMessageId: 'oc_chat',
+        title: 'Broken repo switch',
+        status: 'active',
+        createdAt: '2026-07-18T00:00:00.000Z',
+      },
+      healthy: {
+        sessionId: 'healthy',
+        chatId: 'oc_chat',
+        rootMessageId: 'om_thread',
+        scope: 'thread',
+        title: 'Healthy thread',
+        status: 'active',
+        createdAt: '2026-07-18T00:00:00.000Z',
+      },
+    }));
+
+    fsControl.failSessionWrite = true;
+    init();
+
+    expect(getSession('broken')?.scope).toBe('chat');
+    expect(getSession('healthy')?.title).toBe('Healthy thread');
+    expect(listSessions()).toHaveLength(2);
+    expect(JSON.parse(readFileSync(fp, 'utf-8')).broken.scope).toBeUndefined();
   });
 
   it('should reset state when called again', () => {

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -64,6 +64,7 @@ import {
   updateSession,
   updateSessionPid,
   findActiveSessionsByRoot,
+  repairMissingChatScope,
 } from '../src/services/session-store.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
@@ -151,6 +152,52 @@ describe('init()', () => {
     const persisted = JSON.parse(readFileSync(fp, 'utf-8'));
     expect(persisted.broken.scope).toBe('chat');
     expect(persisted.legacyThread.scope).toBeUndefined();
+  });
+
+  it('ignores malformed entries while repairing healthy sessions', () => {
+    mkdirSync(tempDir, { recursive: true });
+    const fp = join(tempDir, 'sessions.json');
+    writeFileSync(fp, JSON.stringify({
+      missingChatId: { sessionId: 'missing-chat-id' },
+      primitive: 'not-a-session',
+      broken: {
+        sessionId: 'broken',
+        chatId: 'oc_chat',
+        rootMessageId: 'oc_chat',
+        title: 'Broken repo switch',
+        status: 'active',
+        createdAt: '2026-07-18T00:00:00.000Z',
+      },
+      healthy: {
+        sessionId: 'healthy',
+        chatId: 'oc_chat',
+        rootMessageId: 'om_thread',
+        scope: 'thread',
+        title: 'Healthy thread',
+        status: 'active',
+        createdAt: '2026-07-18T00:00:00.000Z',
+      },
+    }));
+
+    init();
+
+    expect(getSession('broken')?.scope).toBe('chat');
+    expect(getSession('healthy')?.title).toBe('Healthy thread');
+    expect(listSessions()).toHaveLength(4);
+  });
+
+  it('repairs the corruption signature through the shared deserialization helper', () => {
+    const record: Record<string, unknown> = {
+      sessionId: 'broken',
+      chatId: 'oc_chat',
+      rootMessageId: 'oc_chat',
+    };
+
+    expect(repairMissingChatScope(record)).toBe(true);
+    expect(record.scope).toBe('chat');
+    expect(repairMissingChatScope(record)).toBe(false);
+    expect(repairMissingChatScope(null)).toBe(false);
+    expect(repairMissingChatScope({ sessionId: 'malformed' })).toBe(false);
   });
 
   it('keeps loaded sessions available when persisting a scope repair fails', () => {


### PR DESCRIPTION
## 问题现象

普通群使用 chat scope 时，先通过 `/repo`（或仓库选择卡片）切换工作目录，再由会话内的 Claude Code 调用 `botmux send`，消息会发送失败。

典型错误链路是：BotMux 把 Lark 群 ID（`oc_...`）当作消息 ID，用 thread reply API 尝试回复，最终被 Lark 拒绝。daemon 重启后，受影响会话也会按错误的 thread scope 恢复。

## 复现步骤

1. 在 Lark 普通群中启动一个 chat-scope BotMux 会话。
2. 确认初始持久化 session 形态正常：

   ```json
   {
     "chatId": "oc_xxx",
     "rootMessageId": "om_xxx",
     "scope": "chat"
   }
   ```

3. 在群中执行 `/repo 1`；也可通过仓库选择卡片切换目录。
4. 查看对应 `sessions-<appId>.json`，切换后重建的记录会变成：

   ```json
   {
     "chatId": "oc_xxx",
     "rootMessageId": "oc_xxx"
   }
   ```

   即 `scope` 丢失，且 `rootMessageId` 被写成 chat routing anchor。

5. 在该会话中执行 `botmux send ...`。CLI 读取 scope-less session 后按兼容逻辑将其视作 thread session，并尝试回复 `rootMessageId = oc_xxx`，从而发送失败。

## 根因

文本 `/repo` 与仓库选择卡片的 mid-session 切换路径都会调用 `createSession()` 重建 session：

- chat scope 下传入的 `rootId` 实际是路由用的 `chatId`（`oc_...`），不是用于追踪的原始消息 ID（`om_...`）；
- 重建时没有传递 `ds.scope`；
- `createSession()` 会立即保存，所以如果在调用后再补 `session.scope`，磁盘上仍存在先写入坏记录的窗口。

运行中的 daemon 仍持有 `ds.scope = "chat"`，因此问题在当前内存路由中不明显；但 `botmux send` 和 daemon 重启恢复读取的是持久化 session，因而会触发错误。

## 修复方案

- 扩展 `createSession()`，允许在首次落盘时原子写入 scope。
- 文本 `/repo` 与仓库选择卡片重建 session 时：
  - 显式传递原有 `ds.scope`；
  - chat scope 保留旧 session 的原始 `om_...` `rootMessageId`；
  - thread scope 继续使用当前 `rootId`，保持原行为。
- 加入窄范围历史数据修复，仅匹配以下已知坏记录：
  - `scope === undefined`；
  - `chatId` 以 `oc_` 开头；
  - `rootMessageId === chatId`。

  对这些记录补上 `scope: "chat"`。普通 scope-less 旧版 thread session 不受影响。已经丢失的原始 `om_...` trace root 无法恢复，但 chat scope 实际按 `chatId` 路由，不影响消息投递。

- 修复数据写回失败时，保留已经成功加载并在内存中修复的 session，避免 ENOSPC/EACCES 等错误将有效会话清空。

## 测试

新增/更新回归覆盖：

- chat-scope 文本 `/repo` 保留 scope 与原始 trace root；
- chat-scope 仓库选择卡片保留 scope 与原始 trace root；
- 精确迁移已知坏记录；
- 不迁移普通旧版 scope-less thread 记录；
- 迁移写回失败时仍保留全部已加载 session。

验证结果：

- 相关回归测试：267 项通过；
- `pnpm build`：通过；
- `git diff --check`：通过；
- 独立只读代码审查：无发现。

全量单测在清洁环境中仍有 1 个可独立复现、与本 PR 无关的既有失败：`test/v3-distillation-runner.test.ts` 的 PID namespace 用例中 helper PID 为 0；本 PR 涉及的测试均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
