### PR TITLE
fix(backend): 显式注入代理变量到 CLI 进程，修复非 sandbox 模式下代理丢失

### DIFF
--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -28,6 +28,7 @@ import { atomicWriteFileSync } from '../../utils/atomic-write.js';
 import { basename, isAbsolute, join, dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn, spawnSync } from 'node:child_process';
+import { PROXY_ENV_KEYS } from '../../utils/child-env.js';
 
 /** Host root for the HOME overlay's upper/work — MUST be OUTSIDE the home lower
  *  (overlayfs forbids upper/work inside lower). */
@@ -502,10 +503,6 @@ export function sandboxCredentialHidePaths(home: string, botmuxHome = join(home,
     join(home, '.lark-cli-bots'),
   ])].sort();
 }
-
-/** Proxy env vars forwarded into the sandbox so the CLI reaches the API even on
- *  the tmux backend (which otherwise only forwards a fixed whitelist). */
-const PROXY_ENV_KEYS = ['http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY', 'no_proxy', 'NO_PROXY', 'all_proxy', 'ALL_PROXY'] as const;
 
 /**
  * Whether the LOCAL bwrap file sandbox applies to this spawn at all.

--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -4,7 +4,7 @@ import { basename } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import type { SessionBackend, SpawnOpts, SessionProbe } from './types.js';
 import { probeTmuxFunctional, scrubTmuxServerGlobalEnv, tmuxEnv } from '../../setup/ensure-tmux.js';
-import { BOTMUX_INJECTED_ENV_KEYS, REDACTED_CHILD_ENV_KEYS } from '../../utils/child-env.js';
+import { BOTMUX_INJECTED_ENV_KEYS, PROXY_ENV_KEYS, REDACTED_CHILD_ENV_KEYS } from '../../utils/child-env.js';
 import { sanitizePerBotEnv } from '../../core/per-bot-env.js';
 import { logger } from '../../utils/logger.js';
 import { isExecutable } from '../../utils/executable.js';
@@ -655,6 +655,15 @@ export function buildBotmuxEnvAssignments(
     for (const key of BOTMUX_INJECTED_ENV_KEYS) {
       const val = env[key];
       if (val === undefined) continue;
+      out.push(`${key}=${val}`);
+    }
+    // Proxy vars are not in BOTMUX_INJECTED_ENV_KEYS (which drives tmuxEnv
+    // stripping + server-global scrub) — inject them explicitly here so the
+    // CLI reaches the API even when the tmux server was started without proxy
+    // in its global env, or the shell rcfile doesn't set them.
+    for (const key of PROXY_ENV_KEYS) {
+      const val = env[key];
+      if (!val) continue;
       out.push(`${key}=${val}`);
     }
   }

--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -663,7 +663,7 @@ export function buildBotmuxEnvAssignments(
     // in its global env, or the shell rcfile doesn't set them.
     for (const key of PROXY_ENV_KEYS) {
       const val = env[key];
-      if (!val) continue;
+      if (val === undefined) continue;
       out.push(`${key}=${val}`);
     }
   }

--- a/src/utils/child-env.ts
+++ b/src/utils/child-env.ts
@@ -77,6 +77,18 @@ export const BOTMUX_INJECTED_ENV_KEYS = [
   'CJADK_INTERACTIVE',
 ] as const;
 
+/** Proxy env vars that must reach the CLI child process so it can dial the
+ *  upstream API on hosts without direct internet access. Forwarded explicitly
+ *  by buildBotmuxEnvAssignments (tmux/tmux-pipe/zellij backends) and
+ *  prepareSandbox (bwrap); the pty backend inherits them via the full child env.
+ *  Deliberately NOT in BOTMUX_INJECTED_ENV_KEYS: that list drives tmuxEnv()
+ *  stripping and scrubTmuxServerGlobalEnv() cleanup — adding proxy keys there
+ *  would delete the user's own tmux server proxy config. */
+export const PROXY_ENV_KEYS = [
+  'http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY',
+  'no_proxy', 'NO_PROXY', 'all_proxy', 'ALL_PROXY',
+] as const;
+
 const TMUX_CLIENT_STRIP_KEYS: ReadonlySet<string> = new Set([
   ...BOTMUX_INJECTED_ENV_KEYS,
   ...REDACTED_CHILD_ENV_KEYS,

--- a/src/utils/child-env.ts
+++ b/src/utils/child-env.ts
@@ -92,6 +92,14 @@ export const PROXY_ENV_KEYS = [
 const TMUX_CLIENT_STRIP_KEYS: ReadonlySet<string> = new Set([
   ...BOTMUX_INJECTED_ENV_KEYS,
   ...REDACTED_CHILD_ENV_KEYS,
+  // Strip proxy vars from the tmux CLIENT env so botmux doesn't seed the
+  // shared server's global env with daemon-side proxy (which may contain
+  // embedded credentials) and leak it to the user's own interactive panes.
+  // Deliberately NOT in TMUX_SERVER_GLOBAL_SCRUB_KEYS: we must not delete
+  // proxy config the user set on their own tmux server. Per-pane injection
+  // via buildBotmuxEnvAssignments reads opts.env directly, so it's unaffected
+  // by this client-side strip.
+  ...PROXY_ENV_KEYS,
 ]);
 
 const TMUX_SERVER_GLOBAL_SCRUB_KEYS: ReadonlySet<string> = new Set([

--- a/test/tmux-backend-env.test.ts
+++ b/test/tmux-backend-env.test.ts
@@ -55,7 +55,6 @@ describe('buildBotmuxEnvAssignments()', () => {
       PATH: '/usr/bin',
       HOME: '/home/u',
       NVM_BIN: '/home/u/.nvm/versions/node/v20/bin',
-      HTTP_PROXY: 'http://proxy:8080',
       LANG: 'en_US.UTF-8',
     });
     expect(out).toEqual([
@@ -144,14 +143,66 @@ describe('buildBotmuxEnvAssignments()', () => {
     expect(out.every(s => !s.endsWith('=undefined'))).toBe(true);
   });
 
-  it('does NOT forward arbitrary env even when set (PATH, HTTP_PROXY, ...)', () => {
+  it('does NOT forward arbitrary env even when set (PATH, LANG, ...)', () => {
     const out = buildBotmuxEnvAssignments({
       PATH: '/should/not/leak',
-      HTTP_PROXY: 'http://should/not/leak',
       LANG: 'should-not-leak',
       BOTMUX: 'kept',
     });
     expect(out).toEqual(['BOTMUX=kept']);
+  });
+
+  // ── Proxy env forwarding (PROXY_ENV_KEYS) ──────────────────────────────────
+  it('forwards proxy vars (HTTP_PROXY, https_proxy, no_proxy, ...) so the CLI can dial the API', () => {
+    // Proxy vars are NOT in BOTMUX_INJECTED_ENV_KEYS (which drives tmux server
+    // scrubbing) — they're injected explicitly here so the pane reaches the
+    // upstream API even when the tmux server / shell rcfile has no proxy set.
+    const out = buildBotmuxEnvAssignments({
+      BOTMUX: '1',
+      HTTP_PROXY: 'http://proxy:8080',
+      https_proxy: 'http://proxy:8080',
+      no_proxy: 'localhost,127.0.0.1',
+      PATH: '/usr/bin',
+    });
+    expect(out).toContain('HTTP_PROXY=http://proxy:8080');
+    expect(out).toContain('https_proxy=http://proxy:8080');
+    expect(out).toContain('no_proxy=localhost,127.0.0.1');
+    expect(out).not.toContain('PATH=/usr/bin');
+  });
+
+  it('preserves empty-string proxy values (HTTP_PROXY=) as an explicit "no proxy" override', () => {
+    // An empty string is a deliberate value (unset the proxy), distinct from
+    // "not set at all" (undefined → skipped). Must survive as `HTTP_PROXY=`.
+    const out = buildBotmuxEnvAssignments({
+      BOTMUX: '1',
+      HTTP_PROXY: '',
+    });
+    expect(out).toContain('HTTP_PROXY=');
+  });
+
+  it('skips proxy keys whose value is undefined (no proxy configured)', () => {
+    const out = buildBotmuxEnvAssignments({
+      BOTMUX: '1',
+      SESSION_DATA_DIR: '/d',
+      // No proxy vars set at all.
+    });
+    expect(out).toEqual(['BOTMUX=1', 'SESSION_DATA_DIR=/d']);
+    expect(out.some(s => /^(HTTP_PROXY|HTTPS_PROXY|http_proxy|https_proxy|no_proxy|NO_PROXY|all_proxy|ALL_PROXY)=/.test(s))).toBe(false);
+  });
+
+  it('per-bot injectEnv proxy overrides the daemon-side proxy (appended last, so it wins)', () => {
+    // injectEnv is appended AFTER the botmux-managed + proxy keys, so a bot's
+    // own HTTPS_PROXY shadows the daemon-side one — last `KEY=VAL` on the argv
+    // wins under `/usr/bin/env`.
+    const out = buildBotmuxEnvAssignments(
+      { BOTMUX: '1', HTTPS_PROXY: 'http://daemon-proxy:8080' },
+      { HTTPS_PROXY: 'http://bot-proxy:3128' },
+    );
+    expect(out).toContain('HTTPS_PROXY=http://daemon-proxy:8080');
+    expect(out).toContain('HTTPS_PROXY=http://bot-proxy:3128');
+    // The per-bot value must come last so env(1) applies it last.
+    expect(out.indexOf('HTTPS_PROXY=http://bot-proxy:3128'))
+      .toBeGreaterThan(out.indexOf('HTTPS_PROXY=http://daemon-proxy:8080'));
   });
 
   it('preserves values with spaces, quotes, equals, newlines (argv array, no shell parsing)', () => {

--- a/test/tmux-env-isolation.test.ts
+++ b/test/tmux-env-isolation.test.ts
@@ -24,6 +24,7 @@ import { join } from 'node:path';
 import { probeTmuxFunctional, scrubTmuxServerGlobalEnv, tmuxEnv } from '../src/setup/ensure-tmux.js';
 import {
   BOTMUX_INJECTED_ENV_KEYS,
+  PROXY_ENV_KEYS,
   REDACTED_CHILD_ENV_KEYS,
   isBotmuxManagedTmuxEnvKey,
   isBotmuxManagedTmuxServerGlobalEnvKey,
@@ -121,6 +122,25 @@ describe('tmuxEnv()', () => {
     expect(isBotmuxManagedTmuxServerGlobalEnvKey('GH_TOKEN')).toBe(false);
     for (const key of ['BOTMUX_SESSION_ID', 'LARK_APP_ID', 'LARK_APP_SECRET', 'CLAUDECODE']) {
       expect(isBotmuxManagedTmuxServerGlobalEnvKey(key), key).toBe(true);
+    }
+  });
+
+  it('classifies every proxy key as tmux client-managed (stripped by tmuxEnv)', () => {
+    // PROXY_ENV_KEYS are in TMUX_CLIENT_STRIP_KEYS so botmux never seeds the
+    // shared tmux server's global env with daemon-side proxy (which may carry
+    // embedded credentials) and leaks it to the user's own interactive panes.
+    for (const key of PROXY_ENV_KEYS) {
+      expect(isBotmuxManagedTmuxEnvKey(key), key).toBe(true);
+    }
+  });
+
+  it('does not classify proxy keys as botmux-owned tmux server-global keys', () => {
+    // PROXY_ENV_KEYS are deliberately NOT in TMUX_SERVER_GLOBAL_SCRUB_KEYS:
+    // scrubTmuxServerGlobalEnv must not delete proxy config the user set on
+    // their own tmux server. Per-pane injection reads opts.env directly, so
+    // the client-side strip above doesn't affect botmux's own sessions.
+    for (const key of PROXY_ENV_KEYS) {
+      expect(isBotmuxManagedTmuxServerGlobalEnvKey(key), key).toBe(false);
     }
   });
 


### PR DESCRIPTION
## 问题

`buildBotmuxEnvAssignments` 不再显式注入代理变量（`http_proxy`/`https_proxy`/`no_proxy` 等 8 个），非 sandbox 模式（默认）下 CLI 只能靠 tmux server global env 或 shell rcfile 间接获取——这两条路都不可靠。

回归引入点：`8cc47400`（2026-05-13，`feat(tmux-backend): 新建 session 包一层 user shell 加载 rcfile`）把透传变量缩减到 6 个必需变量，移除了代理变量。`eb40800`/PR #364 只是把已有白名单集中到 `child-env.ts`，不是回归源头。

在无公网直连的机器上（必须走代理），CLI 拿不到代理 → 直连 API 超时 → stream disconnected / 裸连 gpt，无限重试无法恢复。

## 修复

1. **`src/utils/child-env.ts`**：新增 `export const PROXY_ENV_KEYS`（8 个代理变量）
   - 不加入 `BOTMUX_INJECTED_ENV_KEYS` / `TMUX_SERVER_GLOBAL_SCRUB_KEYS` / `PANE_ENV_UNSET_KEYS`
   - 加入 `TMUX_CLIENT_STRIP_KEYS`：防止 botmux 启动共享 tmux server 时把 daemon 代理（可能含凭证）种入全局环境并泄漏到用户 pane
   - 不 scrub 用户已有的 tmux server 代理配置

2. **`src/adapters/backend/sandbox.ts`**：删除本地 `PROXY_ENV_KEYS` 常量，改为从 `child-env.ts` import（行为不变）

3. **`src/adapters/backend/tmux-backend.ts`**：`buildBotmuxEnvAssignments` 追加代理变量注入
   - `if (val === undefined) continue;` 只跳过 undefined，保留空字符串语义（如 `NO_PROXY=` 表示不绕过）
   - 注入位置在 `BOTMUX_INJECTED_ENV_KEYS` 之后、`injectEnv` 之前，per-bot 配置最后覆盖

4. **`test/tmux-backend-env.test.ts`**：
   - 更新 2 个旧断言（代理变量现在是显式转发的）
   - 新增 4 个测试：代理转发、空值保留、undefined 跳过、per-bot 覆盖

## 影响面

- **后端**：
  - tmux/tmux-pipe/zellij：通过 `buildBotmuxEnvAssignments` 显式注入（本次修复）
  - pty/herdr：通过 worker env 继承（本来就有，无需修改）
  - sandbox：通过 bwrap `--setenv` 注入（本来就有，本次去重常量）
  - riff：远程沙箱，不继承本地代理（固有特性，需用户在 bots.json 显式配置）
- **平台**：Linux/macOS 均覆盖
- **会话类型**：fresh spawn 受益；reattach 和 adopt 不重建 CLI，不会应用新代理（需重启 session 生效）

## 验证

- `pnpm build` 通过
- `pnpm exec vitest run --project unit test/tmux-backend-env.test.ts`：54 passed (50 original + 4 new)