### PR TITLE
fix(workflow): 修复首轮变更授权丢失

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -1538,10 +1538,19 @@ export async function handleCommand(
             ds!.pendingFollowUpTurnId = undefined;
             ds!.pendingTurnId = undefined;
             committed = true;
+
+            // Hold the claim through confirmation + card consumption. Releasing
+            // right after forkWorker lets a concurrent card click / second /repo
+            // see pendingRepo=false and treat this as a mid-session switch that
+            // kills the just-started worker and drops the first-turn task.
+            await sessionReply(rootId, replyText);
+            if (ds!.repoCardMessageId) {
+              deleteMessage(ds!.larkAppId, ds!.repoCardMessageId);
+              ds!.repoCardMessageId = undefined;
+            }
           } finally {
             ds!.pendingRepoCommitInFlight = false;
           }
-          if (committed) await sessionReply(rootId, replyText);
           return committed;
         };
 
@@ -1563,6 +1572,7 @@ export async function handleCommand(
               ds!.session.workingDir = selectedPath;
               ds!.session.riffRepoDirs = undefined;
               sessionStore.updateSession(ds!.session);
+              // forkPendingCli owns claim release + confirm reply + card withdraw.
               if (!await forkPendingCli(t('cmd.repo.selected_in_pending', { name: displayName }, loc), true)) {
                 return false;
               }
@@ -1614,10 +1624,10 @@ export async function handleCommand(
             ds!.hasHistory = false;
             forkWorker(ds!, '', false);
             await sessionReply(rootId, t('cmd.repo.switched_to', { name: displayName }, loc));
-          }
-          if (ds!.repoCardMessageId) {
-            deleteMessage(ds!.larkAppId, ds!.repoCardMessageId);
-            ds!.repoCardMessageId = undefined;
+            if (ds!.repoCardMessageId) {
+              deleteMessage(ds!.larkAppId, ds!.repoCardMessageId);
+              ds!.repoCardMessageId = undefined;
+            }
           }
           logger.info(`[${logTag}] Repo selected via ${how}: ${selectedPath}`);
           return true;
@@ -1788,11 +1798,10 @@ export async function handleCommand(
             break;
           }
           const cwd = getSessionWorkingDir(ds);
+          // bare /repo is the text twin of skip_repo: launch in the default
+          // cwd without pinning it (forkPendingCli does not write workingDir).
+          // Confirmation + card withdraw run under the claim inside forkPendingCli.
           await forkPendingCli(t('cmd.skip.opened', { cwd }, loc));
-          if (ds.repoCardMessageId) {
-            deleteMessage(ds.larkAppId, ds.repoCardMessageId);
-            ds.repoCardMessageId = undefined;
-          }
           logger.info(`[${logTag}] Bare /repo while pending → launch in workingDir ${cwd}`);
           break;
         }

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -86,7 +86,7 @@ import {
   writeRoleProfileEntry,
 } from '../services/role-profile-store.js';
 import type { LarkMessage, DaemonToWorker } from '../types.js';
-import { sessionKey, sessionAnchorId, markRepoCardConsumed } from './types.js';
+import { sessionKey, sessionAnchorId, markRepoCardConsumed, claimCurrentRepoCard } from './types.js';
 import type { DaemonSession } from './types.js';
 import { t, localeForBot, type Locale } from '../i18n/index.js';
 import { runSkillsImCommand } from './skills/im-command.js';
@@ -1599,11 +1599,15 @@ export async function handleCommand(
             // anchor — expected; `/close` the new one first, or use the
             // command.) Mirrors the `/close` case above.
             //
+            // Claim any open repo card BEFORE killWorker / await so a concurrent
+            // card click cannot double-switch while this text path runs.
+            //
             // The new cwd is NOT written onto the old session here — it would
             // pollute the displaced session's stored workingDir (and the closed
             // card), so `claude --resume` later would reopen the old context in
             // the new repo's cwd. The new repo is pinned onto the fresh session
             // below instead.
+            const claimedCard = claimCurrentRepoCard(ds!, undefined);
             const closedCard = buildClosedSessionCard(ds!, loc);
             killWorker(ds!);
             sessionStore.closeSession(ds!.session.sessionId);
@@ -1630,12 +1634,13 @@ export async function handleCommand(
             sessionStore.updateSession(ds!.session);
             ds!.hasHistory = false;
             forkWorker(ds!, '', false);
-            await sessionReply(rootId, t('cmd.repo.switched_to', { name: displayName }, loc));
-            const midCard = ds!.repoCardMessageId;
-            markRepoCardConsumed(ds!, midCard);
-            ds!.repoCardMessageId = undefined;
-            if (midCard) {
-              try { await deleteMessage(ds!.larkAppId, midCard); } catch { /* best-effort */ }
+            try {
+              await sessionReply(rootId, t('cmd.repo.switched_to', { name: displayName }, loc));
+            } catch (e) {
+              logger.warn(`[${logTag}] Confirm reply after mid-session repo switch failed: ${e instanceof Error ? e.message : e}`);
+            }
+            if (claimedCard) {
+              try { await deleteMessage(ds!.larkAppId, claimedCard); } catch { /* best-effort */ }
             }
           }
           logger.info(`[${logTag}] Repo selected via ${how}: ${selectedPath}`);

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -26,7 +26,16 @@ import { claimPairing } from '../services/pairing-store.js';
 import { logger } from '../utils/logger.js';
 import { scheduleTimeZone } from '../utils/timezone.js';
 import { killWorker, suspendWorker, forkWorker, forkAdoptWorker, getCurrentCliVersion, postFreshStreamingCard, postPrivateSnapshotCard, resolvePrivateCardAudience, deliverEphemeralOrReply, deliverWritableTerminalCardTo } from './worker-pool.js';
-import { expandHome, getSessionWorkingDir, getProjectScanDir, getProjectScanDirs, rememberLastCliInput } from './session-manager.js';
+import {
+  expandHome,
+  getSessionWorkingDir,
+  getProjectScanDir,
+  getProjectScanDirs,
+  rememberLastCliInput,
+  buildNewTopicCliInput,
+  ensureSessionWhiteboard,
+  getAvailableBots,
+} from './session-manager.js';
 import { discoverSlashCommandsForAdapter, listMcpServerNames, supportsFilesystemCommandDiscovery } from './command-discovery.js';
 import { validateWorkingDir } from './working-dir.js';
 import { repinSessionWorkingDir } from './session-cwd.js';
@@ -1420,136 +1429,147 @@ export async function handleCommand(
         // CLI in whatever workingDir is currently set on the session. Shared by
         // `commitRepoSelection` (a repo was named) and the bare-`/repo` launch
         // (use the default workingDir) — both only run while `pendingRepo`.
-        const forkPendingCli = async (replyText: string) => {
+        const forkPendingCli = async (replyText: string, claimAlready = false): Promise<boolean> => {
+          if (!claimAlready) {
+            if (ds!.pendingRepoCommitInFlight) {
+              await sessionReply(rootId, t('cmd.repo.worktree_in_progress', undefined, loc));
+              return false;
+            }
+            ds!.pendingRepoCommitInFlight = true;
+          }
           const selfBot = getBot(ds!.larkAppId);
           const botCfg = selfBot.config;
           const commitGenSessionId = ds!.session.sessionId;
-          ds!.pendingRepo = false;
-          publishAttentionPatch(ds!);
-          const pendingPrompt = ds!.pendingPrompt ?? '';
-          const pendingRawInput = ds!.pendingRawInput;
-          // Was there an actual buffered user message to deliver? A session
-          // launched *via* `/repo` (the command itself is the first message) has
-          // none — so boot the CLI idle and let the user's NEXT message be the
-          // first prompt, instead of submitting an empty/boilerplate user_message.
-          const hasBufferedInput =
-            pendingPrompt.trim().length > 0 ||
-            (ds!.pendingAttachments?.length ?? 0) > 0 ||
-            (ds!.pendingFollowUps?.length ?? 0) > 0;
-          if (pendingRawInput) {
-            // Messages buffered while the repo card was pending must not be
-            // dropped: wrap them now (full prompt-building context lives here)
-            // and stash for delivery right after the raw input on prompt_ready.
-            if (hasBufferedInput) {
-              const { buildNewTopicCliInput, ensureSessionWhiteboard, getAvailableBots } = await import('./session-manager.js');
-              ensureSessionWhiteboard(ds!);
-              const followUpInput = buildNewTopicCliInput(
-                pendingPrompt,
-                ds!.session.sessionId,
-                ds!.session.cliId ?? botCfg.cliId,
-                ds!.session.cliPathOverride ?? botCfg.cliPathOverride,
-                ds!.pendingAttachments,
-                ds!.pendingMentions,
-                await getAvailableBots(ds!.larkAppId, ds!.chatId),
-                ds!.pendingFollowUps,
-                { name: selfBot.botName, openId: selfBot.botOpenId },
-                loc,
-                ds!.pendingSender,
-                {
-                  larkAppId,
-                  chatId: ds!.chatId,
-                  whiteboardId: ds!.session.whiteboardId,
-                  substituteTrigger: ds!.pendingSubstituteTrigger,
-                  codexAppText: ds!.pendingCodexAppText,
-                  codexAppApplicationContext: ds!.pendingCodexAppApplicationContext,
-                  codexAppMessageContext: ds!.pendingCodexAppMessageContext,
-                  codexAppFollowUps: ds!.pendingCodexAppFollowUps,
-                  codexAppFollowUpContexts: ds!.pendingCodexAppFollowUpContexts,
-                },
-              );
+          let committed = false;
+          try {
+            // Keep pendingRepo=true while prompt context is awaited. Incoming
+            // messages stay in the same buffer and card selections see the
+            // shared in-flight claim instead of treating this as a repo switch.
+            const initiallyBuffered =
+              (ds!.pendingPrompt?.trim().length ?? 0) > 0 ||
+              (ds!.pendingAttachments?.length ?? 0) > 0 ||
+              (ds!.pendingFollowUps?.length ?? 0) > 0;
+            const availableBots = initiallyBuffered
+              ? await getAvailableBots(ds!.larkAppId, ds!.chatId)
+              : [];
+            const stillActive = activeSessions.get(sessionKey(rootId, larkAppId!)) === ds;
+            if (!stillActive || ds!.session.sessionId !== commitGenSessionId ||
+                !ds!.pendingRepo || (ds!.worker && !ds!.worker.killed)) {
+              logger.warn(`[${logTag}] Session changed while preparing the pending CLI (${commitGenSessionId} → ${ds!.session.sessionId}, active=${stillActive}, pending=${!!ds!.pendingRepo}, worker=${!!ds!.worker})`);
+              return false;
+            }
+
+            const pendingPrompt = ds!.pendingPrompt ?? '';
+            const pendingRawInput = ds!.pendingRawInput;
+            const hasBufferedInput =
+              pendingPrompt.trim().length > 0 ||
+              (ds!.pendingAttachments?.length ?? 0) > 0 ||
+              (ds!.pendingFollowUps?.length ?? 0) > 0;
+            if (hasBufferedInput) ensureSessionWhiteboard(ds!);
+            const wrappedInput = hasBufferedInput
+              ? buildNewTopicCliInput(
+                  pendingPrompt,
+                  ds!.session.sessionId,
+                  ds!.session.cliId ?? botCfg.cliId,
+                  ds!.session.cliPathOverride ?? botCfg.cliPathOverride,
+                  ds!.pendingAttachments,
+                  ds!.pendingMentions,
+                  availableBots,
+                  ds!.pendingFollowUps,
+                  { name: selfBot.botName, openId: selfBot.botOpenId },
+                  loc,
+                  ds!.pendingSender,
+                  {
+                    larkAppId,
+                    chatId: ds!.chatId,
+                    whiteboardId: ds!.session.whiteboardId,
+                    substituteTrigger: ds!.pendingSubstituteTrigger,
+                    codexAppText: ds!.pendingCodexAppText,
+                    codexAppApplicationContext: ds!.pendingCodexAppApplicationContext,
+                    codexAppMessageContext: ds!.pendingCodexAppMessageContext,
+                    codexAppFollowUps: ds!.pendingCodexAppFollowUps,
+                    codexAppFollowUpContexts: ds!.pendingCodexAppFollowUpContexts,
+                  },
+                )
+              : { content: '' };
+            const pendingTurnId = ds!.pendingTurnId;
+            const previousPendingFollowUpInput = ds!.pendingFollowUpInput;
+            if (pendingRawInput && hasBufferedInput) {
               ds!.pendingFollowUpInput = {
                 userPrompt: ds!.pendingCodexAppText !== undefined || ds!.pendingCodexAppFollowUps
                   ? [ds!.pendingCodexAppText ?? '', ...(ds!.pendingCodexAppFollowUps ?? [])].filter(Boolean).join('\n\n')
                   : pendingPrompt || ds!.pendingFollowUps?.join('\n\n') || '',
-                cliInput: followUpInput.content,
-                ...((ds!.session.cliId ?? botCfg.cliId) === 'codex-app' && botCfg.codexAppCleanInput === true && followUpInput.codexAppInput
-                  ? { codexAppInput: followUpInput.codexAppInput }
+                cliInput: wrappedInput.content,
+                ...(ds!.pendingFollowUpTurnId ? { turnId: ds!.pendingFollowUpTurnId } : {}),
+                ...((ds!.session.cliId ?? botCfg.cliId) === 'codex-app' && botCfg.codexAppCleanInput === true && wrappedInput.codexAppInput
+                  ? { codexAppInput: wrappedInput.codexAppInput }
                   : {}),
                 codexAppInputGateFrozen: true,
               };
             }
-            rememberLastCliInput(ds!, pendingRawInput, pendingRawInput);
-            forkWorker(ds!, '', false);
-          } else if (hasBufferedInput) {
-            const { buildNewTopicCliInput, ensureSessionWhiteboard, getAvailableBots } = await import('./session-manager.js');
-            ensureSessionWhiteboard(ds!);
-            const prompt = buildNewTopicCliInput(
-              pendingPrompt,
-              ds!.session.sessionId,
-              ds!.session.cliId ?? botCfg.cliId,
-              ds!.session.cliPathOverride ?? botCfg.cliPathOverride,
-              ds!.pendingAttachments,
-              ds!.pendingMentions,
-              await getAvailableBots(ds!.larkAppId, ds!.chatId),
-              ds!.pendingFollowUps,
-              { name: selfBot.botName, openId: selfBot.botOpenId },
-              loc,
-              ds!.pendingSender,
-              {
-                larkAppId,
-                chatId: ds!.chatId,
-                whiteboardId: ds!.session.whiteboardId,
-                substituteTrigger: ds!.pendingSubstituteTrigger,
-                codexAppText: ds!.pendingCodexAppText,
-                codexAppApplicationContext: ds!.pendingCodexAppApplicationContext,
-                codexAppMessageContext: ds!.pendingCodexAppMessageContext,
-                codexAppFollowUps: ds!.pendingCodexAppFollowUps,
-                codexAppFollowUpContexts: ds!.pendingCodexAppFollowUpContexts,
-              },
-            );
-            // Last-line defence: prompt prep awaited above — if anything
-            // replaced OR closed the session in that window (`/close` deletes
-            // the active-map entry without touching sessionId), forking now
-            // would clobber it or resurrect a closed session.
-            const stillActive = activeSessions.get(sessionKey(rootId, larkAppId!)) === ds;
-            if (!stillActive || ds!.session.sessionId !== commitGenSessionId) {
-              logger.warn(`[${logTag}] Session replaced or closed while preparing the pending-CLI prompt (${commitGenSessionId} → ${ds!.session.sessionId}, active=${stillActive}) — aborting this fork`);
-              return;
+
+            ds!.pendingRepo = false;
+            publishAttentionPatch(ds!);
+            try {
+              if (pendingRawInput) forkWorker(ds!, '', false);
+              else if (pendingTurnId && hasBufferedInput) forkWorker(ds!, wrappedInput, { turnId: pendingTurnId });
+              else if (hasBufferedInput) forkWorker(ds!, wrappedInput);
+              else forkWorker(ds!, '', false);
+            } catch (e) {
+              ds!.pendingRepo = true;
+              ds!.pendingFollowUpInput = previousPendingFollowUpInput;
+              publishAttentionPatch(ds!);
+              throw e;
             }
-            rememberLastCliInput(ds!, pendingPrompt, prompt);
-            forkWorker(ds!, prompt);
-          } else {
-            // Empty initial prompt → worker spawns the CLI without submitting
-            // anything (see worker.ts: the init prompt is only queued when truthy).
-            forkWorker(ds!, '', false);
+            if (pendingRawInput || hasBufferedInput) {
+              rememberLastCliInput(ds!, pendingRawInput ?? pendingPrompt, pendingRawInput ?? wrappedInput);
+            }
+            ds!.pendingPrompt = undefined;
+            ds!.pendingCodexAppText = undefined;
+            ds!.pendingCodexAppApplicationContext = undefined;
+            ds!.pendingCodexAppMessageContext = undefined;
+            ds!.pendingAttachments = undefined;
+            ds!.pendingMentions = undefined;
+            ds!.pendingSubstituteTrigger = undefined;
+            ds!.pendingSender = undefined;
+            ds!.pendingFollowUps = undefined;
+            ds!.pendingCodexAppFollowUps = undefined;
+            ds!.pendingCodexAppFollowUpContexts = undefined;
+            ds!.pendingFollowUpTurnId = undefined;
+            ds!.pendingTurnId = undefined;
+            committed = true;
+          } finally {
+            ds!.pendingRepoCommitInFlight = false;
           }
-          ds!.pendingPrompt = undefined;
-          ds!.pendingCodexAppText = undefined;
-          ds!.pendingCodexAppApplicationContext = undefined;
-          ds!.pendingCodexAppMessageContext = undefined;
-          ds!.pendingAttachments = undefined;
-          ds!.pendingMentions = undefined;
-          ds!.pendingSubstituteTrigger = undefined;
-          ds!.pendingSender = undefined;
-          ds!.pendingFollowUps = undefined;
-          ds!.pendingCodexAppFollowUps = undefined;
-          ds!.pendingCodexAppFollowUpContexts = undefined;
-          await sessionReply(rootId, replyText);
+          if (committed) await sessionReply(rootId, replyText);
+          return committed;
         };
 
         // Shared commit path for an already-resolved repo: update the session's
         // working dir, then either fork into the pending CLI (first spawn) or
         // close + recreate the session (mid-session switch). Used by both the
         // numeric `/repo <N>` form and the `/repo <path|name>` form.
-        const commitRepoSelection = async (selectedPath: string, displayName: string, how: string) => {
+        const commitRepoSelection = async (selectedPath: string, displayName: string, how: string): Promise<boolean> => {
           if (ds!.pendingRepo) {
-            // First spawn: pin the new cwd onto the CURRENT session, then fork.
-            ds!.workingDir = selectedPath;
-            ds!.session.workingDir = selectedPath;
-            // A single repo selection supersedes any stale multi-Riff stamp.
-            ds!.session.riffRepoDirs = undefined;
-            sessionStore.updateSession(ds!.session);
-            await forkPendingCli(t('cmd.repo.selected_in_pending', { name: displayName }, loc));
+            if (ds!.pendingRepoCommitInFlight) {
+              await sessionReply(rootId, t('cmd.repo.worktree_in_progress', undefined, loc));
+              return false;
+            }
+            ds!.pendingRepoCommitInFlight = true;
+            try {
+              // Claim before changing cwd so a card selection cannot overwrite
+              // this choice while the pending prompt is prepared.
+              ds!.workingDir = selectedPath;
+              ds!.session.workingDir = selectedPath;
+              ds!.session.riffRepoDirs = undefined;
+              sessionStore.updateSession(ds!.session);
+              if (!await forkPendingCli(t('cmd.repo.selected_in_pending', { name: displayName }, loc), true)) {
+                return false;
+              }
+            } catch (e) {
+              ds!.pendingRepoCommitInFlight = false;
+              throw e;
+            }
           } else {
             // Safety net: a mid-session `/repo` switch closes the running
             // session and spawns a fresh one on the SAME anchor. Without a
@@ -1600,6 +1620,7 @@ export async function handleCommand(
             ds!.repoCardMessageId = undefined;
           }
           logger.info(`[${logTag}] Repo selected via ${how}: ${selectedPath}`);
+          return true;
         };
 
         // `/repo wt <N|name|path> [branch]` → create a worktree off the repo's
@@ -1634,7 +1655,7 @@ export async function handleCommand(
             }
             repoPath = resolved.path;
           }
-          if (ds.worktreeCreating) {
+          if (ds.worktreeCreating || ds.pendingRepoCommitInFlight) {
             await sessionReply(rootId, t('cmd.repo.worktree_in_progress', undefined, loc));
             break;
           }
@@ -1718,7 +1739,7 @@ export async function handleCommand(
         // would double-fork. One lock gates both kinds until the commit
         // settles. (Bare `/repo` without pending only posts the picker card —
         // harmless, so it stays open.)
-        if (ds?.worktreeCreating && (repoArg || ds.pendingRepo)) {
+        if ((ds?.worktreeCreating || ds?.pendingRepoCommitInFlight) && (repoArg || ds?.pendingRepo)) {
           await sessionReply(rootId, t('cmd.repo.worktree_in_progress', undefined, loc));
           break;
         }

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -86,7 +86,7 @@ import {
   writeRoleProfileEntry,
 } from '../services/role-profile-store.js';
 import type { LarkMessage, DaemonToWorker } from '../types.js';
-import { sessionKey, sessionAnchorId } from './types.js';
+import { sessionKey, sessionAnchorId, markRepoCardConsumed } from './types.js';
 import type { DaemonSession } from './types.js';
 import { t, localeForBot, type Locale } from '../i18n/index.js';
 import { runSkillsImCommand } from './skills/im-command.js';
@@ -1539,14 +1539,21 @@ export async function handleCommand(
             ds!.pendingTurnId = undefined;
             committed = true;
 
-            // Hold the claim through confirmation + card consumption. Releasing
-            // right after forkWorker lets a concurrent card click / second /repo
-            // see pendingRepo=false and treat this as a mid-session switch that
-            // kills the just-started worker and drops the first-turn task.
-            await sessionReply(rootId, replyText);
-            if (ds!.repoCardMessageId) {
-              deleteMessage(ds!.larkAppId, ds!.repoCardMessageId);
-              ds!.repoCardMessageId = undefined;
+            // Local one-shot consume BEFORE network awaits. Feishu withdraw is
+            // best-effort; stale card clicks must be rejected via this mark even
+            // if sessionReply throws or deleteMessage lags/fails.
+            const cardToWithdraw = ds!.repoCardMessageId;
+            markRepoCardConsumed(ds!, cardToWithdraw);
+            ds!.repoCardMessageId = undefined;
+
+            // Hold the claim through confirmation + best-effort card withdraw.
+            try {
+              await sessionReply(rootId, replyText);
+            } catch (e) {
+              logger.warn(`[${logTag}] Confirm reply after pending repo commit failed: ${e instanceof Error ? e.message : e}`);
+            }
+            if (cardToWithdraw) {
+              try { await deleteMessage(ds!.larkAppId, cardToWithdraw); } catch { /* best-effort */ }
             }
           } finally {
             ds!.pendingRepoCommitInFlight = false;
@@ -1624,9 +1631,11 @@ export async function handleCommand(
             ds!.hasHistory = false;
             forkWorker(ds!, '', false);
             await sessionReply(rootId, t('cmd.repo.switched_to', { name: displayName }, loc));
-            if (ds!.repoCardMessageId) {
-              deleteMessage(ds!.larkAppId, ds!.repoCardMessageId);
-              ds!.repoCardMessageId = undefined;
+            const midCard = ds!.repoCardMessageId;
+            markRepoCardConsumed(ds!, midCard);
+            ds!.repoCardMessageId = undefined;
+            if (midCard) {
+              try { await deleteMessage(ds!.larkAppId, midCard); } catch { /* best-effort */ }
             }
           }
           logger.info(`[${logTag}] Repo selected via ${how}: ${selectedPath}`);

--- a/src/core/session-marker.ts
+++ b/src/core/session-marker.ts
@@ -163,9 +163,14 @@ export function findAuthenticatedAncestorSessionContext(
           `无法读取 CLI process marker ${markerPath}：${err instanceof Error ? err.message : String(err)}`,
         );
       }
-      if (!marker.sessionId || !marker.turnId || !marker.procStart) {
+      if (!marker.sessionId || !marker.procStart) {
         throw new SessionMarkerAuthenticationError(
-          `CLI process marker ${markerPath} 缺少 sessionId/turnId/procStart，不能用于变更操作授权`,
+          '后台进程信息不完整，暂时不能执行变更。请运行 botmux restart 后重试。',
+        );
+      }
+      if (!marker.turnId) {
+        throw new SessionMarkerAuthenticationError(
+          '当前会话还没有绑定到这条消息，暂时不能执行变更。请在原话题重新发送一次；如果仍失败，请运行 botmux restart。',
         );
       }
       const liveStart = readProcessStartIdentity(pid);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -293,6 +293,45 @@ export function isRepoCardConsumed(ds: DaemonSession, cardMessageId: string | un
   return !!cardMessageId && !!ds.consumedRepoCardMessageIds?.includes(cardMessageId);
 }
 
+/**
+ * Whether a card callback may drive repo selection for this session.
+ * Only the currently posted card (`ds.repoCardMessageId`) is valid — after it
+ * is claimed/cleared, or after a daemon restart (field is in-memory), stale
+ * Feishu cards must not mid-session-switch. Previously-consumed ids are also
+ * rejected while the process is still up.
+ */
+export function isActiveRepoCard(ds: DaemonSession, cardMessageId: string | undefined): boolean {
+  if (!cardMessageId) return false;
+  if (isRepoCardConsumed(ds, cardMessageId)) return false;
+  return ds.repoCardMessageId === cardMessageId;
+}
+
+/**
+ * Atomically claim the session's current repo-select card for this action.
+ * Succeeds only when `cardMessageId` is the live `ds.repoCardMessageId` (or
+ * `cardMessageId` is omitted and a current card exists — text path withdrawing
+ * the open card). On success: clears `repoCardMessageId` and marks consumed
+ * BEFORE any killWorker / network await so concurrent callbacks cannot
+ * double-switch. Returns the claimed id, or undefined if the action must not
+ * proceed as a card-driven selection.
+ */
+export function claimCurrentRepoCard(ds: DaemonSession, cardMessageId: string | undefined): string | undefined {
+  const current = ds.repoCardMessageId;
+  if (!current) {
+    // No live card — reject any card id (restart / already claimed). Text path
+    // with no cardMessageId also gets undefined (caller proceeds without card).
+    return undefined;
+  }
+  if (cardMessageId && cardMessageId !== current) return undefined;
+  if (isRepoCardConsumed(ds, current)) {
+    ds.repoCardMessageId = undefined;
+    return undefined;
+  }
+  ds.repoCardMessageId = undefined;
+  markRepoCardConsumed(ds, current);
+  return current;
+}
+
 /** Resolve the routing anchor for an active session — chatId for chat-scope
  *  sessions, rootMessageId for thread-scope. Used to compute `sessionKey()` at
  *  storage and lookup time. */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -69,6 +69,14 @@ export interface DaemonSession {
    *  also await prompt context before the fork. */
   pendingRepoCommitInFlight?: boolean;
   repoCardMessageId?: string;    // message_id of the repo selection card — for withdrawal
+  /**
+   * Repo-select card message ids already consumed by a successful pending→worker
+   * transition (or an explicit mid-session card switch). Stale clicks on these
+   * cards must not be treated as a new mid-session switch that kills the just-
+   * started worker — Feishu card withdraw is best-effort and may lag or fail.
+   * In-memory only; not persisted.
+   */
+  consumedRepoCardMessageIds?: string[];
   worktreeCreating?: boolean;    // a worktree-open is in flight — dedups repeated card clicks / `/repo wt`
   pendingPrompt?: string;        // original user message to send after repo is selected
   /** Exact Lark message id whose user input is waiting for the first worker
@@ -268,6 +276,21 @@ export interface DaemonSession {
  *  between the two address spaces are not possible. */
 export function sessionKey(anchorId: string, larkAppId: string): string {
   return `${anchorId}::${larkAppId}`;
+}
+
+const CONSUMED_REPO_CARD_CAP = 16;
+
+/** Record a repo-select card as already consumed. Correctness for stale clicks
+ *  depends on this local mark — not on Feishu deleteMessage succeeding. */
+export function markRepoCardConsumed(ds: DaemonSession, cardMessageId: string | undefined): void {
+  if (!cardMessageId) return;
+  const ids = ds.consumedRepoCardMessageIds ?? (ds.consumedRepoCardMessageIds = []);
+  if (!ids.includes(cardMessageId)) ids.push(cardMessageId);
+  if (ids.length > CONSUMED_REPO_CARD_CAP) ids.splice(0, ids.length - CONSUMED_REPO_CARD_CAP);
+}
+
+export function isRepoCardConsumed(ds: DaemonSession, cardMessageId: string | undefined): boolean {
+  return !!cardMessageId && !!ds.consumedRepoCardMessageIds?.includes(cardMessageId);
 }
 
 /** Resolve the routing anchor for an active session — chatId for chat-scope

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -64,9 +64,18 @@ export interface DaemonSession {
   workingDir?: string;
   initConfig?: Extract<DaemonToWorker, { type: 'init' }>;   // stored for restart
   pendingRepo?: boolean;         // waiting for repo selection before spawning CLI
+  /** One in-memory owner is preparing the pending repo's first worker. Kept
+   *  separate from worktreeCreating because plain select, skip, and /repo can
+   *  also await prompt context before the fork. */
+  pendingRepoCommitInFlight?: boolean;
   repoCardMessageId?: string;    // message_id of the repo selection card — for withdrawal
   worktreeCreating?: boolean;    // a worktree-open is in flight — dedups repeated card clicks / `/repo wt`
   pendingPrompt?: string;        // original user message to send after repo is selected
+  /** Exact Lark message id whose user input is waiting for the first worker
+   *  spawn. This is intentionally in-memory and must come from the accepted
+   *  inbound event: restoring a session must never recover per-turn authority
+   *  from an older persisted quote target. */
+  pendingTurnId?: string;
   /** Clean Codex App text/context retained alongside pendingPrompt while repo
    * selection delays the first turn. The legacy enriched prompt remains the
    * compatibility source for every other CLI. */
@@ -81,6 +90,11 @@ export interface DaemonSession {
    *  botmux-wrapped `<user_message>`. In-memory only to avoid replaying after
    *  daemon restart. */
   pendingRawInput?: string;
+  /** Exact accepted turn for pendingRawInput. Kept until prompt_ready delivers
+   *  the literal command. Raw cold-start workers deliberately spawn without
+   *  human turn authority; the worker rotates this turn immediately before
+   *  the command is written to the CLI. */
+  pendingRawTurnId?: string;
   /** Wrapped prompt for messages buffered while a pendingRawInput session
    *  waited for repo selection (pendingFollowUps / attachments). Built at the
    *  fork site (where prompt-building context lives) and delivered right
@@ -90,6 +104,7 @@ export interface DaemonSession {
   pendingFollowUpInput?: {
     userPrompt: string;
     cliInput: string;
+    turnId?: string;
     codexAppInput?: CodexAppTurnInput;
     /** The clean-input feature gate was evaluated when this follow-up was
      * staged; prompt_ready must not re-read a later config value. */
@@ -103,6 +118,9 @@ export interface DaemonSession {
    *  matching the original caller, not the user who clicked the card. */
   pendingSender?: import('../im/lark/identity-cache.js').ResolvedSender;
   pendingFollowUps?: string[];         // buffered follow-up messages (enriched) sent while waiting for repo selection
+  /** Exact turn for a same-caller pendingRawInput follow-up batch. Cleared on
+   *  mixed callers so the combined prompt fails closed instead of borrowing. */
+  pendingFollowUpTurnId?: string;
   pendingCodexAppFollowUps?: string[]; // matching raw user texts for clean Codex App materialization
   pendingCodexAppFollowUpContexts?: string[]; // matching metadata-only context; never duplicates the raw follow-up text
   ownerOpenId?: string;          // topic creator's open_id — receives write-enabled terminal link via DM

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1900,14 +1900,12 @@ export function forkWorker(
     resume = resumeOrTurnId;
   }
 
-  // An empty prompt is a pure worker reattach/restore, not a newly accepted
-  // user turn. Never inherit the previous reply target in that case: doing so
-  // would re-publish stale per-turn authority (notably an explicit meeting IM
-  // origin) into a fresh worker lifetime after a daemon restart. Non-empty
-  // prompts keep the historical fallback for callers that accepted a turn
-  // before they learned to pass its id explicitly.
-  const initAttributionTurnId = initTurnId
-    ?? (prompt.length > 0 ? ds.currentReplyTarget?.turnId : undefined);
+  // Per-turn authority is never inferred from mutable session state. Human
+  // message routes pass their accepted Lark message id explicitly; restore,
+  // scheduler, card retry and other system starts stay unattributed. Falling
+  // back to currentReplyTarget here would let a later system prompt reuse an
+  // older human turn after a worker replacement.
+  const initAttributionTurnId = initTurnId;
 
   // A fork() whose cwd no longer exists emits an unhandled 'error' (spawn
   // ENOENT) that crashes the WHOLE daemon (→ pm2 crash-loop). Fall back to
@@ -2588,6 +2586,8 @@ function setupWorkerHandlers(
         if (ds.pendingRawInput && ds.worker && !ds.worker.killed) {
           const rawInput = ds.pendingRawInput;
           ds.pendingRawInput = undefined;
+          const rawTurnId = ds.pendingRawTurnId;
+          ds.pendingRawTurnId = undefined;
           // Input buffered while the repo card was pending rides on the SAME
           // IPC: worker message handlers run concurrently (async handlers
           // don't serialize), so a separate `message` IPC could write into
@@ -2601,7 +2601,9 @@ function setupWorkerHandlers(
           ds.worker.send({
             type: 'raw_input',
             content: rawInput,
+            ...(rawTurnId ? { turnId: rawTurnId } : {}),
             followUpContent: followUp?.cliInput,
+            ...(followUp?.turnId ? { followUpTurnId: followUp.turnId } : {}),
             ...(followUpCodexAppInput ? { followUpCodexAppInput } : {}),
           } as DaemonToWorker);
           logger.info(`[${t}] Sent pending raw input after prompt_ready: ${rawInput.substring(0, 80)}${followUp ? ` (+follow-up ${followUp.cliInput.length} chars)` : ''}`);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -14039,6 +14039,15 @@ async function startInitialPassthroughSession(args: {
   const directChatSender = chatType === 'p2p'
     ? await resolveSender(larkAppId, senderOpenId, parsed.senderType)
     : undefined;
+  // Group cold-start passthroughs only need a stable caller identity while the
+  // repo picker is pending. Avoid adding a contact lookup to every /goal start;
+  // an optional display name can be learned later from the normal cache path.
+  const initialPassthroughSender = directChatSender ?? (senderOpenId
+    ? {
+      openId: senderOpenId,
+      type: parsed.senderType === 'app' || parsed.senderType === 'bot' ? 'bot' as const : 'user' as const,
+    }
+    : undefined);
   const rootIdForStore = scope === 'thread' ? anchor : messageId;
   const session = sessionStore.createSession(chatId, rootIdForStore, commandContent.substring(0, 50), chatType);
   const now = Date.now();
@@ -14077,6 +14086,8 @@ async function startInitialPassthroughSession(args: {
     pendingRepo: !pinnedWorkingDir || autoWt,
     pendingPrompt: '',
     pendingRawInput: commandContent,
+    pendingRawTurnId: messageId,
+    pendingSender: (!pinnedWorkingDir || autoWt) ? initialPassthroughSender : undefined,
     ownerOpenId,
     currentTurnTitle: commandContent.substring(0, 50),
     workingDir: pinnedWorkingDir,
@@ -14100,6 +14111,8 @@ async function startInitialPassthroughSession(args: {
   if (pinnedWorkingDir) {
     if (await replyInvalidWorkingDirs(anchor, larkAppId, ds)) return;
     rememberLastCliInput(ds, commandContent, commandContent);
+    // Raw passthrough gets its human turn only at the literal PTY write
+    // boundary (prompt_ready -> raw_input), never during CLI startup.
     forkWorker(ds, '', false);
     const reason = oncallEntry
       ? `oncall-bound chat ${chatId}`
@@ -14551,6 +14564,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
     hasHistory: false,
     pendingRepo: !pinnedWorkingDir || autoWt,
     pendingPrompt: promptContent,
+    pendingTurnId: messageId,
     pendingCodexAppText: codexAppVisibleText,
     pendingCodexAppApplicationContext: codexAppApplicationContext || undefined,
     pendingCodexAppMessageContext: codexAppMessageContext,
@@ -14591,7 +14605,8 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
     const prompt = buildNewTopicCliInput(promptContent, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, chatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId }, localeForBot(larkAppId), newTopicSender, { larkAppId, chatId, whiteboardId: ds.session.whiteboardId, substituteTrigger, codexAppText: codexAppVisibleText, codexAppApplicationContext, codexAppMessageContext });
     await noteTurnReceived(ds, messageId, content, newTopicSender, messageId, substituteTrigger ? SUBSTITUTE_RECEIVED_REACTION_EMOJI_TYPE : undefined);
     rememberLastCliInput(ds, promptContent, prompt);
-    forkWorker(ds, prompt);
+    forkWorker(ds, prompt, { turnId: messageId });
+    ds.pendingTurnId = undefined;
     const reason = oncallEntry
       ? `oncall-bound chat ${chatId}`
       : inheritedFrom
@@ -14623,7 +14638,8 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
     const prompt = buildNewTopicCliInput(promptContent, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, chatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId }, localeForBot(larkAppId), newTopicSender, { larkAppId, chatId, whiteboardId: ds.session.whiteboardId, substituteTrigger, codexAppText: codexAppVisibleText, codexAppApplicationContext, codexAppMessageContext });
     await noteTurnReceived(ds, messageId, content, newTopicSender, messageId, substituteTrigger ? SUBSTITUTE_RECEIVED_REACTION_EMOJI_TYPE : undefined);
     rememberLastCliInput(ds, promptContent, prompt);
-    forkWorker(ds, prompt);
+    forkWorker(ds, prompt, { turnId: messageId });
+    ds.pendingTurnId = undefined;
     logger.info(`Session ${session.sessionId} ready (no projects to select), total active: ${getActiveCount()}`);
   }
 }
@@ -15127,11 +15143,32 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
       // 收紧到与 daemon 命令同档；这会同时改变真人 oncall 成员的现有行为，应单独评估。
       const ds = existingDs;
       if (ds?.worker && !ds.worker.killed) {
+        // Passthrough commands bypass the normal message-forwarding block
+        // below, so bind this accepted Lark turn here before the worker rotates
+        // its marker at the actual PTY write boundary.
+        ds.session.quoteTargetId = parsed.messageId;
+        ds.session.quoteTargetSenderOpenId = threadSenderOpenId;
+        ds.session.quoteTargetSenderIsBot = isForeignBot;
+        const substituteReplyMode = substituteTrigger
+          ? (getBot(larkAppId).config.substituteMode?.replyMode ?? 'thread')
+          : 'thread';
+        beginReplyTargetTurn(ds, replyRootId, parsed.messageId, new Date().toISOString(), {
+          quoteOnly: substituteReplyMode === 'quote',
+          substitute: !!substituteTrigger,
+        });
+        if (threadSenderOpenId && ds.session.lastCallerOpenId !== threadSenderOpenId) {
+          ds.session.lastCallerOpenId = threadSenderOpenId;
+        }
+        sessionStore.updateSession(ds.session);
         // Mark a new turn so the CLI's response to /model, /clear, /compact, etc.
         // shows up as a fresh streaming card instead of silently PATCH-ing the
         // previous turn's card.
         beginNewTurn(ds, commandContent);
-        ds.worker.send({ type: 'raw_input', content: commandContent } as DaemonToWorker);
+        ds.worker.send({
+          type: 'raw_input',
+          content: commandContent,
+          turnId: parsed.messageId,
+        } as DaemonToWorker);
         markSessionActivity(ds);
         logger.info(`[${anchor.substring(0, 12)}] Passthrough ${cmd} → worker`);
       } else {
@@ -15295,9 +15332,9 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
   // Update last message time + last caller (used by `botmux send` to address
   // reply cards to whoever triggered this turn — matters in oncall groups
   // where the caller is often not the session owner).
+  const callerOpenId = parsed.senderId || data?.sender?.sender_id?.open_id;
   if (ds) {
     markSessionActivity(ds);
-    const callerOpenId = parsed.senderId || data?.sender?.sender_id?.open_id;
     // quoteTargetId changes every inbound message (always a new message_id), so
     // — unlike lastCallerOpenId — persist unconditionally. Powers `botmux send`'s
     // default chat-scope quote chain + --mention-back.
@@ -15322,7 +15359,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
   }
 
   // If waiting for repo selection, buffer the message and remind user
-  if (ds?.pendingRepo) {
+  if (ds?.pendingRepo || ds?.pendingRepoCommitInFlight) {
     // Enrich content with attachment hints and mention metadata (same as normal send)
     const codexAppFollowUpContextParts: string[] = [];
     if (codexAppMessageContext) codexAppFollowUpContextParts.push(codexAppMessageContext);
@@ -15346,7 +15383,15 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
     // follow-ups now fold into the same <user_message>, so a same-user tag is
     // pure duplication. A differing sender still gets attributed so the CLI can
     // tell multi-user buffered messages apart after repo selection unlocks.
-    const followUpSender = await getThreadSender();
+    // This branch is also the synchronization barrier for a pending first
+    // worker. Do not await contact/name resolution here: a commit waiting on
+    // getAvailableBots could otherwise resume first, snapshot stale buffers,
+    // and fork before this message is appended. Event identity is sufficient
+    // for caller equality and sender attribution; names remain optional.
+    const followUpSender: import('./im/lark/identity-cache.js').ResolvedSender | undefined = callerOpenId
+      ? { openId: callerOpenId, type: isForeignBot ? 'bot' : 'user' }
+      : undefined;
+    const hadBufferedFollowUps = (ds.pendingFollowUps?.length ?? 0) > 0;
     if (followUpSender?.openId && followUpSender.openId !== ds.pendingSender?.openId) {
       // This buffer folds into the opening <user_message> after repo selection,
       // so pair the foreign sender tag with the cursor anti-echo note: without
@@ -15359,6 +15404,34 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
       if (followUpSenderBlock) {
         enriched = `${followUpSenderBlock}\n${enriched}`;
         codexAppFollowUpContextParts.unshift(followUpSenderBlock);
+      }
+    }
+    const sameInitialCaller = !!followUpSender?.openId
+      && followUpSender.openId === ds.pendingSender?.openId;
+    if (ds.pendingRawInput) {
+      if ((!hadBufferedFollowUps || ds.pendingFollowUpTurnId) && sameInitialCaller) {
+        // The persisted quote target is a single latest-turn pointer. Treat a
+        // same-caller raw command + buffered follow-ups as one batch and join
+        // every staged PTY input to that latest turn. Keeping the raw command
+        // on its older id would fail provenance as soon as the follow-up moves
+        // the durable pointer forward.
+        ds.pendingRawTurnId = parsed.messageId;
+        ds.pendingFollowUpTurnId = parsed.messageId;
+      } else {
+        // Mixed callers cannot share one durable turn pointer. Revoke the
+        // entire batch rather than letting either identity borrow the other.
+        ds.pendingRawTurnId = undefined;
+        ds.pendingFollowUpTurnId = undefined;
+      }
+    } else if (ds.pendingTurnId) {
+      // One deferred model prompt may fold several same-user messages together;
+      // bind it to the newest exact message so the durable quote and marker
+      // still join. If another user contributes, clear authority instead of
+      // letting either identity authorize the combined prompt.
+      if (sameInitialCaller) {
+        ds.pendingTurnId = parsed.messageId;
+      } else {
+        ds.pendingTurnId = undefined;
       }
     }
     if (!ds.pendingFollowUps) ds.pendingFollowUps = [];
@@ -15376,7 +15449,9 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
     // Auto-worktree pending (worktreeCreating) has no repo card to point at — the
     // message IS buffered (folded on commit), so just say "hold on, building worktree"
     // instead of the misleading "pick a repo from the card above".
-    const pendingReplyKey = ds.worktreeCreating ? 'daemon.worktree_building_wait' : 'daemon.choose_repo_first';
+    const pendingReplyKey = (ds.worktreeCreating || ds.pendingRepoCommitInFlight)
+      ? 'daemon.worktree_building_wait'
+      : 'daemon.choose_repo_first';
     await sessionReply(anchor, tr(pendingReplyKey, undefined, localeForBot(larkAppId)), 'text', larkAppId);
     return;
   }
@@ -15465,6 +15540,7 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
       hasHistory: false,
       pendingRepo: !pinnedWorkingDir || autoWt,
       pendingPrompt: promptContent,
+      pendingTurnId: parsed.messageId,
       pendingCodexAppText: parsed.content,
       pendingCodexAppApplicationContext: codexAppApplicationContext,
       pendingCodexAppMessageContext: codexAppMessageContext,
@@ -15504,7 +15580,8 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
       const prompt = buildNewTopicCliInput(promptContent, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, autoCreateChatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId }, localeForBot(larkAppId), autoCreateSender, { larkAppId, chatId: autoCreateChatId, whiteboardId: newDs.session.whiteboardId, substituteTrigger, codexAppText: parsed.content, codexAppApplicationContext, codexAppMessageContext });
       await noteTurnReceived(newDs, parsed.messageId, parsed.content, autoCreateSender, parsed.messageId, substituteTrigger ? SUBSTITUTE_RECEIVED_REACTION_EMOJI_TYPE : undefined);
       rememberLastCliInput(newDs, promptContent, prompt);
-      forkWorker(newDs, prompt);
+      forkWorker(newDs, prompt, { turnId: parsed.messageId });
+      newDs.pendingTurnId = undefined;
       const reason = oncallEntry
         ? `oncall-bound chat ${autoCreateChatId}`
         : inheritedFrom
@@ -15536,7 +15613,8 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
       const prompt = buildNewTopicCliInput(promptContent, session.sessionId, botCfg.cliId, botCfg.cliPathOverride, attachments, parsed.mentions, await getAvailableBots(larkAppId, autoCreateChatId), undefined, { name: selfBot.botName, openId: selfBot.botOpenId }, localeForBot(larkAppId), autoCreateSender, { larkAppId, chatId: autoCreateChatId, whiteboardId: newDs.session.whiteboardId, substituteTrigger, codexAppText: parsed.content, codexAppApplicationContext, codexAppMessageContext });
       await noteTurnReceived(newDs, parsed.messageId, parsed.content, autoCreateSender, parsed.messageId, substituteTrigger ? SUBSTITUTE_RECEIVED_REACTION_EMOJI_TYPE : undefined);
       rememberLastCliInput(newDs, promptContent, prompt);
-      forkWorker(newDs, prompt);
+      forkWorker(newDs, prompt, { turnId: parsed.messageId });
+      newDs.pendingTurnId = undefined;
     }
 
     return;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -274,6 +274,7 @@ export const messages: Record<string, string> = {
   'cmd.repo.worktree_created': '🌿 Worktree created: `{path}`\nBranch `{branch}`, based on `{base}`',
   'cmd.repo.worktree_failed': '❌ Worktree creation failed: {error}',
   'cmd.repo.worktree_in_progress': '⏳ A worktree is already being created — please wait…',
+  'cmd.repo.card_already_consumed': '✅ Repo already selected — please ignore the old card',
   'cmd.repo.worktree_created_not_switched': '🌿 Worktree created: `{path}` (branch `{branch}`), but the session changed meanwhile — not switched automatically. Use `/repo {path}` to open it.',
   'cmd.repo.worktree_switch_failed': '⚠️ Worktree created at `{path}`, but switching to it failed: {error}\nUse `/repo {path}` to open it manually.',
   // Used when 「default-directory-only」mode has「auto-create worktree」on, at new

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -277,6 +277,7 @@ export const messages: Record<string, string> = {
   'cmd.repo.worktree_created': '🌿 worktree 已创建：`{path}`\n分支 `{branch}`，基于 `{base}`',
   'cmd.repo.worktree_failed': '❌ 创建 worktree 失败：{error}',
   'cmd.repo.worktree_in_progress': '⏳ 已有一个 worktree 正在创建，请稍候…',
+  'cmd.repo.card_already_consumed': '✅ 仓库已选定，请忽略旧的选仓卡片',
   'cmd.repo.worktree_created_not_switched': '🌿 worktree 已创建：`{path}`（分支 `{branch}`），但会话状态已变化，未自动切换。需要时可用 `/repo {path}` 打开。',
   'cmd.repo.worktree_switch_failed': '⚠️ worktree 已创建：`{path}`，但自动切换失败：{error}\n可用 `/repo {path}` 手动打开。',
   // 「仅默认目录」模式开启「自动创建 worktree」后，新会话启动时用（daemon 交互新话题 /

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -65,7 +65,7 @@ import { publishAttentionPatch, announcePendingRepoSession } from '../../core/se
 import { fallbackTurnId } from '../../core/reply-target.js';
 import { validateWorkingDir } from '../../core/working-dir.js';
 import type { DaemonToWorker, DisplayMode, TermActionKey } from '../../types.js';
-import { sessionKey, sessionAnchorId, frozenDisplayMode, markRepoCardConsumed, isRepoCardConsumed } from '../../core/types.js';
+import { sessionKey, sessionAnchorId, frozenDisplayMode, markRepoCardConsumed, isRepoCardConsumed, isActiveRepoCard, claimCurrentRepoCard } from '../../core/types.js';
 import type { DaemonSession } from '../../core/types.js';
 import { buildTerminalUrl } from '../../core/terminal-url.js';
 import type { ProjectInfo } from '../../services/project-scanner.js';
@@ -542,6 +542,17 @@ export async function commitRepoSelection(
     return;
   } else {
     // Mid-session repo switch — close old session, start fresh.
+    // Claim the current card BEFORE killWorker / any await. A concurrent click
+    // on the same Feishu card must not pass a second kill+fork while the first
+    // switch is still awaiting confirm replies. Correctness does not depend on
+    // deleteMessage succeeding.
+    const claimedCard = claimCurrentRepoCard(ds, cardMessageId);
+    if (cardMessageId && !claimedCard) {
+      // Stale / already-claimed card (entry check races can still reach here).
+      logger.info(`[${tag(ds)}] Ignoring stale mid-session repo card ${cardMessageId}`);
+      return;
+    }
+
     // Safety net (mirrors the `/repo` text-command path): build the same
     // "session closed" card `/close` emits BEFORE displacing the old session
     // (it reads the live session's identity off `ds`). The new session reuses
@@ -611,18 +622,17 @@ export async function commitRepoSelection(
     ds.lastScreenStatus = undefined;
     forkWorker(ds, '', false);
     if (!opts?.suppressConfirmReply) {
-      await sessionReply(rootId, t('cmd.repo.switched_to', { name: dirLabel }, locTarget));
+      try {
+        await sessionReply(rootId, t('cmd.repo.switched_to', { name: dirLabel }, locTarget));
+      } catch (e) {
+        logger.warn(`[${tag(ds)}] Confirm reply after mid-session repo switch failed: ${e instanceof Error ? e.message : e}`);
+      }
     }
     logger.info(`[${tag(ds)}] Repo switched to ${dirPath}, new session created`);
-  }
-
-  // Withdraw the repo selection card (mid-session path). Mark consumed first so
-  // a second click on the same card cannot double-switch while delete lags.
-  const midCard = cardMessageId ?? ds.repoCardMessageId;
-  markRepoCardConsumed(ds, midCard);
-  ds.repoCardMessageId = undefined;
-  if (midCard && larkAppId) {
-    try { await deleteMessage(larkAppId, midCard); } catch { /* best-effort */ }
+    // Best-effort withdraw — card already claimed above.
+    if (claimedCard && larkAppId) {
+      try { await deleteMessage(larkAppId, claimedCard); } catch { /* best-effort */ }
+    }
   }
 }
 
@@ -2139,7 +2149,9 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
 
     if (actionType === 'skip_repo' && ds) {
       const locDs = localeForBot(ds.larkAppId);
-      if (isRepoCardConsumed(ds, cardMessageId)) {
+      // Only the live posted card may act — covers consumed, wrong card, and
+      // post-restart (repoCardMessageId is in-memory and empty after reboot).
+      if (cardMessageId && !isActiveRepoCard(ds, cardMessageId)) {
         return { toast: { type: 'info', content: t('cmd.repo.card_already_consumed', undefined, locDs) } };
       }
       if (ds.pendingRepo) {
@@ -2180,7 +2192,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     // needs a scanned git repo root, not an arbitrary path.
     if (actionType === 'repo_manual_submit' && ds) {
       const locDs = localeForBot(ds.larkAppId);
-      if (isRepoCardConsumed(ds, cardMessageId)) {
+      if (cardMessageId && !isActiveRepoCard(ds, cardMessageId)) {
         return { toast: { type: 'info', content: t('cmd.repo.card_already_consumed', undefined, locDs) } };
       }
       const rawPath = String(action?.form_value?.repo_manual_path ?? '').trim();
@@ -2226,7 +2238,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
 
     if (actionType === 'repo_worktree_submit' && ds) {
       const locDs = localeForBot(ds.larkAppId);
-      if (isRepoCardConsumed(ds, cardMessageId)) {
+      if (cardMessageId && !isActiveRepoCard(ds, cardMessageId)) {
         return { toast: { type: 'info', content: t('cmd.repo.card_already_consumed', undefined, locDs) } };
       }
       const selectedPaths = stringListFromLarkMultiSelect(action?.form_value?.repo_worktree_paths);
@@ -2443,10 +2455,10 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     return;
   }
 
-  // Stale click on a card already used for a successful pending→worker (or
-  // mid-session) commit. Must reject before the mid-session switch path can
-  // killWorker — Feishu withdraw may still show the card.
-  if (isRepoCardConsumed(targetDs, cardMessageId)) {
+  // Only the live posted card may drive selection. Covers: already-consumed,
+  // wrong/old card, and post-restart (repoCardMessageId is in-memory). Must
+  // reject before mid-session switch can killWorker.
+  if (cardMessageId && !isActiveRepoCard(targetDs, cardMessageId)) {
     return { toast: { type: 'info', content: t('cmd.repo.card_already_consumed', undefined, localeForBot(targetDs.larkAppId)) } };
   }
 

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -360,7 +360,17 @@ export async function commitRepoSelection(
   // The worktree flow already posted a precise "worktree 已创建：path 分支 …"
   // line before funnelling in here — suppress the redundant "已选择/已切换"
   // confirmation so the user sees a single message, not two.
-  opts?: { suppressConfirmReply?: boolean; riffRepoDirs?: string[] },
+  // pinWorkingDir=false: "直接开始"/skip keeps the default cwd for this launch
+  // without persisting it (esp. $HOME) onto session.workingDir — sibling bots
+  // must still get their own repo card instead of inheriting HOME.
+  // confirmReplyText: optional confirmation to send under the same claim
+  // (used by skip_repo so the post-fork reply window cannot race a second click).
+  opts?: {
+    suppressConfirmReply?: boolean;
+    confirmReplyText?: string;
+    pinWorkingDir?: boolean;
+    riffRepoDirs?: string[];
+  },
 ): Promise<void> {
   const { ds, rootId, cardMessageId, larkAppId, operatorOpenId, activeSessions, sessionReply } = ctx;
   const locTarget = localeForBot(ds.larkAppId);
@@ -370,6 +380,7 @@ export async function commitRepoSelection(
   const repoSessionKey = larkAppId ? sessionKey(rootId, larkAppId) : rootId;
   const sessionStillActive = () => activeSessions.get(repoSessionKey) === ds;
   const commitGenSessionId = ds.session.sessionId;
+  const pinWorkingDir = opts?.pinWorkingDir !== false;
 
   if (ds.pendingRepo) {
     // Card select/skip and auto-worktree converge here; the text /repo path
@@ -384,8 +395,12 @@ export async function commitRepoSelection(
     try {
       // Claim before mutating the selected directory so two different card
       // choices cannot overwrite each other while one prompt is being built.
-      ds.workingDir = dirPath;
-      ds.session.workingDir = dirPath;
+      // Skip/bare-start may intentionally leave workingDir unpinned so the
+      // launch uses the bot default without persisting $HOME for siblings.
+      if (pinWorkingDir) {
+        ds.workingDir = dirPath;
+        ds.session.workingDir = dirPath;
+      }
       ds.session.riffRepoDirs = opts?.riffRepoDirs;
       sessionStore.updateSession(ds.session);
       const selfBot = getBot(ds.larkAppId);
@@ -492,17 +507,28 @@ export async function commitRepoSelection(
       ds.pendingFollowUpTurnId = undefined;
       ds.pendingTurnId = undefined;
       committed = true;
+
+      // Hold the claim through confirmation + card consumption. Releasing right
+      // after forkWorker leaves a window where a second card click sees
+      // pendingRepo=false and pendingRepoCommitInFlight=false, and is treated as
+      // a mid-session switch that kills the just-started worker.
+      if (!opts?.suppressConfirmReply) {
+        // A card click has no turn of its own — anchor the confirmation to the
+        // session's current reply-target turn so a shared fold-back topic keeps
+        // it in-thread (same leak as the /repo command path).
+        await sessionReply(rootId, t('cmd.repo.selected_in_pending', { name: dirLabel }, locTarget), undefined, fallbackTurnId(ds, undefined));
+      } else if (opts.confirmReplyText) {
+        await sessionReply(rootId, opts.confirmReplyText, undefined, fallbackTurnId(ds, undefined));
+      }
+      const cardToWithdraw = cardMessageId ?? ds.repoCardMessageId;
+      if (cardToWithdraw && larkAppId) deleteMessage(larkAppId, cardToWithdraw);
+      ds.repoCardMessageId = undefined;
     } finally {
       ds.pendingRepoCommitInFlight = false;
     }
     if (!committed) return;
-    // A card click has no turn of its own — anchor the confirmation to the
-    // session's current reply-target turn so a shared fold-back topic keeps
-    // it in-thread (same leak as the /repo command path).
-    if (!opts?.suppressConfirmReply) {
-      await sessionReply(rootId, t('cmd.repo.selected_in_pending', { name: dirLabel }, locTarget), undefined, fallbackTurnId(ds, undefined));
-    }
     logger.info(`[${tag(ds)}] Repo selected: ${dirPath}, spawning CLI`);
+    return;
   } else {
     // Mid-session repo switch — close old session, start fresh.
     // Safety net (mirrors the `/repo` text-command path): build the same
@@ -2104,22 +2130,28 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
         const cwd = getSessionWorkingDir(ds);
         // Reuse the same claimed pending->worker transition as a normal repo
         // selection. This keeps buffering active across prompt preparation and
-        // makes skip/select races single-winner.
+        // makes skip/select races single-winner. Do NOT pin the resolved default
+        // cwd (often $HOME) onto session.workingDir — that would let sibling
+        // bots inherit HOME instead of getting their own repo card. Confirmation
+        // + card withdraw run under the claim inside commitRepoSelection.
         await commitRepoSelection(
-          { ds, rootId, cardMessageId: undefined, larkAppId, operatorOpenId, activeSessions, sessionReply },
+          { ds, rootId, cardMessageId, larkAppId, operatorOpenId, activeSessions, sessionReply },
           cwd,
           pathBasename(cwd) || cwd,
-          { suppressConfirmReply: true },
+          {
+            suppressConfirmReply: true,
+            confirmReplyText: t('cmd.skip.opened', { cwd }, locDs),
+            pinWorkingDir: false,
+          },
         );
         if (!ds.pendingRepo) {
-          await sessionReply(rootId, t('cmd.skip.opened', { cwd }, locDs));
           logger.info(`[${tag(ds)}] Skip repo, spawning CLI in ${cwd}`);
         }
       } else {
         await sessionReply(rootId, t('card.action.continue_using_current_repo', { cwd: getSessionWorkingDir(ds) }, locDs));
+        if (cardMessageId && larkAppId) deleteMessage(larkAppId, cardMessageId);
+        ds.repoCardMessageId = undefined;
       }
-      if (cardMessageId && larkAppId) deleteMessage(larkAppId, cardMessageId);
-      ds.repoCardMessageId = undefined;
     }
 
     // Manual working-directory entry from the repo card form. The project scan

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -65,7 +65,7 @@ import { publishAttentionPatch, announcePendingRepoSession } from '../../core/se
 import { fallbackTurnId } from '../../core/reply-target.js';
 import { validateWorkingDir } from '../../core/working-dir.js';
 import type { DaemonToWorker, DisplayMode, TermActionKey } from '../../types.js';
-import { sessionKey, sessionAnchorId, frozenDisplayMode } from '../../core/types.js';
+import { sessionKey, sessionAnchorId, frozenDisplayMode, markRepoCardConsumed, isRepoCardConsumed } from '../../core/types.js';
 import type { DaemonSession } from '../../core/types.js';
 import { buildTerminalUrl } from '../../core/terminal-url.js';
 import type { ProjectInfo } from '../../services/project-scanner.js';
@@ -508,21 +508,32 @@ export async function commitRepoSelection(
       ds.pendingTurnId = undefined;
       committed = true;
 
-      // Hold the claim through confirmation + card consumption. Releasing right
-      // after forkWorker leaves a window where a second card click sees
-      // pendingRepo=false and pendingRepoCommitInFlight=false, and is treated as
-      // a mid-session switch that kills the just-started worker.
-      if (!opts?.suppressConfirmReply) {
-        // A card click has no turn of its own — anchor the confirmation to the
-        // session's current reply-target turn so a shared fold-back topic keeps
-        // it in-thread (same leak as the /repo command path).
-        await sessionReply(rootId, t('cmd.repo.selected_in_pending', { name: dirLabel }, locTarget), undefined, fallbackTurnId(ds, undefined));
-      } else if (opts.confirmReplyText) {
-        await sessionReply(rootId, opts.confirmReplyText, undefined, fallbackTurnId(ds, undefined));
-      }
+      // Local one-shot consume BEFORE any network await. Feishu withdraw is
+      // best-effort and may lag/fail; correctness for stale card clicks depends
+      // on this mark so a second callback cannot mid-session-switch after claim
+      // release (and so a sessionReply throw that jumps to finally still leaves
+      // the card locally invalid).
       const cardToWithdraw = cardMessageId ?? ds.repoCardMessageId;
-      if (cardToWithdraw && larkAppId) deleteMessage(larkAppId, cardToWithdraw);
+      markRepoCardConsumed(ds, cardToWithdraw);
       ds.repoCardMessageId = undefined;
+
+      // Hold the claim through confirmation + best-effort card withdraw so a
+      // concurrent in-flight select still sees pendingRepoCommitInFlight.
+      try {
+        if (!opts?.suppressConfirmReply) {
+          // A card click has no turn of its own — anchor the confirmation to the
+          // session's current reply-target turn so a shared fold-back topic keeps
+          // it in-thread (same leak as the /repo command path).
+          await sessionReply(rootId, t('cmd.repo.selected_in_pending', { name: dirLabel }, locTarget), undefined, fallbackTurnId(ds, undefined));
+        } else if (opts.confirmReplyText) {
+          await sessionReply(rootId, opts.confirmReplyText, undefined, fallbackTurnId(ds, undefined));
+        }
+      } catch (e) {
+        logger.warn(`[${tag(ds)}] Confirm reply after pending repo commit failed: ${e instanceof Error ? e.message : e}`);
+      }
+      if (cardToWithdraw && larkAppId) {
+        try { await deleteMessage(larkAppId, cardToWithdraw); } catch { /* card may already be gone */ }
+      }
     } finally {
       ds.pendingRepoCommitInFlight = false;
     }
@@ -605,9 +616,14 @@ export async function commitRepoSelection(
     logger.info(`[${tag(ds)}] Repo switched to ${dirPath}, new session created`);
   }
 
-  // Withdraw the repo selection card
-  if (cardMessageId && larkAppId) deleteMessage(larkAppId, cardMessageId);
+  // Withdraw the repo selection card (mid-session path). Mark consumed first so
+  // a second click on the same card cannot double-switch while delete lags.
+  const midCard = cardMessageId ?? ds.repoCardMessageId;
+  markRepoCardConsumed(ds, midCard);
   ds.repoCardMessageId = undefined;
+  if (midCard && larkAppId) {
+    try { await deleteMessage(larkAppId, midCard); } catch { /* best-effort */ }
+  }
 }
 
 /**
@@ -2123,6 +2139,9 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
 
     if (actionType === 'skip_repo' && ds) {
       const locDs = localeForBot(ds.larkAppId);
+      if (isRepoCardConsumed(ds, cardMessageId)) {
+        return { toast: { type: 'info', content: t('cmd.repo.card_already_consumed', undefined, locDs) } };
+      }
       if (ds.pendingRepo) {
         if (ds.worktreeCreating || ds.pendingRepoCommitInFlight) {
           return { toast: { type: 'info', content: t('cmd.repo.worktree_in_progress', undefined, locDs) } };
@@ -2161,6 +2180,9 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     // needs a scanned git repo root, not an arbitrary path.
     if (actionType === 'repo_manual_submit' && ds) {
       const locDs = localeForBot(ds.larkAppId);
+      if (isRepoCardConsumed(ds, cardMessageId)) {
+        return { toast: { type: 'info', content: t('cmd.repo.card_already_consumed', undefined, locDs) } };
+      }
       const rawPath = String(action?.form_value?.repo_manual_path ?? '').trim();
       if (!rawPath) {
         return { toast: { type: 'error', content: t('card.repo.manual_empty', undefined, locDs) } };
@@ -2204,6 +2226,9 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
 
     if (actionType === 'repo_worktree_submit' && ds) {
       const locDs = localeForBot(ds.larkAppId);
+      if (isRepoCardConsumed(ds, cardMessageId)) {
+        return { toast: { type: 'info', content: t('cmd.repo.card_already_consumed', undefined, locDs) } };
+      }
       const selectedPaths = stringListFromLarkMultiSelect(action?.form_value?.repo_worktree_paths);
       if (selectedPaths.length === 0) {
         return { toast: { type: 'error', content: t('card.repo.worktree_empty', undefined, locDs) } };
@@ -2416,6 +2441,13 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
   if (!targetDs) {
     logger.warn(`Card action: no active session found for root ${rootId}`);
     return;
+  }
+
+  // Stale click on a card already used for a successful pending→worker (or
+  // mid-session) commit. Must reject before the mid-session switch path can
+  // killWorker — Feishu withdraw may still show the card.
+  if (isRepoCardConsumed(targetDs, cardMessageId)) {
+    return { toast: { type: 'info', content: t('cmd.repo.card_already_consumed', undefined, localeForBot(targetDs.larkAppId)) } };
   }
 
   // 权限边界：pendingRepo（首次选 repo 才能 spawn）放行「会话发起人 或 canOperate」，

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -372,87 +372,130 @@ export async function commitRepoSelection(
   const commitGenSessionId = ds.session.sessionId;
 
   if (ds.pendingRepo) {
-    // First spawn: pin the new cwd onto the CURRENT session before forking.
-    ds.workingDir = dirPath;
-    ds.session.workingDir = dirPath;
-    // riff 多仓 stamp：只有多仓 worktree 流显式传入（保留用户选择顺序，首仓=primary）；
-    // 其它选仓路径一律清除旧 stamp——workingDir 变了，旧的多仓组合不再成立。
-    ds.session.riffRepoDirs = opts?.riffRepoDirs;
-    sessionStore.updateSession(ds.session);
-    const selfBot = getBot(ds.larkAppId);
-    const botCfg = selfBot.config;
-    const effectiveCliId = sessionCliId(ds);
-    // First-time repo selection — now spawn CLI with the original prompt
-    ds.pendingRepo = false;
-    publishAttentionPatch(ds);
-    const pendingPrompt = ds.pendingPrompt ?? '';
-    const pendingRawInput = ds.pendingRawInput;
-    // Raw-input cold start still wraps any input buffered while the repo card
-    // was pending — see the skip_repo branch for the rationale.
-    const hasBufferedInput =
-      pendingPrompt.trim().length > 0 ||
-      (ds.pendingAttachments?.length ?? 0) > 0 ||
-      (ds.pendingFollowUps?.length ?? 0) > 0;
-    if (!pendingRawInput || hasBufferedInput) ensureSessionWhiteboard(ds);
-    const wrappedInput = (!pendingRawInput || hasBufferedInput)
-      ? buildNewTopicCliInput(
-          pendingPrompt,
-          ds.session.sessionId,
-          effectiveCliId,
-          botCfg.cliPathOverride,
-          ds.pendingAttachments,
-          ds.pendingMentions,
-          await getAvailableBots(ds.larkAppId, ds.chatId),
-          ds.pendingFollowUps,
-          { name: selfBot.botName, openId: selfBot.botOpenId },
-          locTarget,
-          ds.pendingSender,
-          {
-            larkAppId: ds.larkAppId,
-            chatId: ds.chatId,
-            whiteboardId: ds.session.whiteboardId,
-            substituteTrigger: ds.pendingSubstituteTrigger,
-            codexAppText: ds.pendingCodexAppText,
-            codexAppApplicationContext: ds.pendingCodexAppApplicationContext,
-            codexAppMessageContext: ds.pendingCodexAppMessageContext,
-            codexAppFollowUps: ds.pendingCodexAppFollowUps,
-            codexAppFollowUpContexts: ds.pendingCodexAppFollowUpContexts,
-          },
-        )
-      : { content: '' };
-    const prompt = pendingRawInput ? '' : wrappedInput;
-    // Last-line defence: prompt prep awaited above — if anything replaced
-    // OR closed the session in that window, forking now would clobber it
-    // (or resurrect a /close'd session).
-    if (!sessionStillActive() || ds.session.sessionId !== commitGenSessionId) {
-      logger.warn(`[${tag(ds)}] Session replaced or closed while preparing the pending-CLI prompt (${commitGenSessionId} → ${ds.session.sessionId}, active=${sessionStillActive()}) — aborting this fork`);
+    // Card select/skip and auto-worktree converge here; the text /repo path
+    // mirrors this transaction through the same in-memory claim. Only one may
+    // own the pending -> worker transition, including prompt preparation.
+    if (ds.pendingRepoCommitInFlight) {
+      logger.info(`[${tag(ds)}] Pending repo commit already in flight — ignoring duplicate selection`);
       return;
     }
-    if (pendingRawInput && hasBufferedInput) {
-      ds.pendingFollowUpInput = {
-        userPrompt: ds.pendingCodexAppText !== undefined || ds.pendingCodexAppFollowUps
-          ? [ds.pendingCodexAppText ?? '', ...(ds.pendingCodexAppFollowUps ?? [])].filter(Boolean).join('\n\n')
-          : pendingPrompt || ds.pendingFollowUps?.join('\n\n') || '',
-        cliInput: wrappedInput.content,
-        ...(effectiveCliId === 'codex-app' && botCfg.codexAppCleanInput === true && wrappedInput.codexAppInput
-          ? { codexAppInput: wrappedInput.codexAppInput }
-          : {}),
-        codexAppInputGateFrozen: true,
-      };
+    ds.pendingRepoCommitInFlight = true;
+    let committed = false;
+    try {
+      // Claim before mutating the selected directory so two different card
+      // choices cannot overwrite each other while one prompt is being built.
+      ds.workingDir = dirPath;
+      ds.session.workingDir = dirPath;
+      ds.session.riffRepoDirs = opts?.riffRepoDirs;
+      sessionStore.updateSession(ds.session);
+      const selfBot = getBot(ds.larkAppId);
+      const botCfg = selfBot.config;
+      const effectiveCliId = sessionCliId(ds);
+
+      // Keep pendingRepo=true across this await. New topic messages therefore
+      // remain buffered on this same session instead of racing a worker-null
+      // safety-net fork. Snapshot every pending field only after it settles.
+      const needsPromptContext = !ds.pendingRawInput ||
+        (ds.pendingPrompt?.trim().length ?? 0) > 0 ||
+        (ds.pendingAttachments?.length ?? 0) > 0 ||
+        (ds.pendingFollowUps?.length ?? 0) > 0;
+      const availableBots = needsPromptContext
+        ? await getAvailableBots(ds.larkAppId, ds.chatId)
+        : [];
+      if (!sessionStillActive() || ds.session.sessionId !== commitGenSessionId ||
+          !ds.pendingRepo || (ds.worker && !ds.worker.killed)) {
+        logger.warn(`[${tag(ds)}] Session changed while preparing the pending-CLI prompt (${commitGenSessionId} → ${ds.session.sessionId}, active=${sessionStillActive()}, pending=${!!ds.pendingRepo}, worker=${!!ds.worker}) — aborting this fork`);
+        return;
+      }
+
+      const pendingPrompt = ds.pendingPrompt ?? '';
+      const pendingRawInput = ds.pendingRawInput;
+      const hasBufferedInput =
+        pendingPrompt.trim().length > 0 ||
+        (ds.pendingAttachments?.length ?? 0) > 0 ||
+        (ds.pendingFollowUps?.length ?? 0) > 0;
+      if (!pendingRawInput || hasBufferedInput) ensureSessionWhiteboard(ds);
+      const wrappedInput = (!pendingRawInput || hasBufferedInput)
+        ? buildNewTopicCliInput(
+            pendingPrompt,
+            ds.session.sessionId,
+            effectiveCliId,
+            botCfg.cliPathOverride,
+            ds.pendingAttachments,
+            ds.pendingMentions,
+            availableBots,
+            ds.pendingFollowUps,
+            { name: selfBot.botName, openId: selfBot.botOpenId },
+            locTarget,
+            ds.pendingSender,
+            {
+              larkAppId: ds.larkAppId,
+              chatId: ds.chatId,
+              whiteboardId: ds.session.whiteboardId,
+              substituteTrigger: ds.pendingSubstituteTrigger,
+              codexAppText: ds.pendingCodexAppText,
+              codexAppApplicationContext: ds.pendingCodexAppApplicationContext,
+              codexAppMessageContext: ds.pendingCodexAppMessageContext,
+              codexAppFollowUps: ds.pendingCodexAppFollowUps,
+              codexAppFollowUpContexts: ds.pendingCodexAppFollowUpContexts,
+            },
+          )
+        : { content: '' };
+      const prompt = pendingRawInput ? '' : wrappedInput;
+      const pendingTurnId = ds.pendingTurnId;
+      const previousPendingFollowUpInput = ds.pendingFollowUpInput;
+      if (pendingRawInput && hasBufferedInput) {
+        ds.pendingFollowUpInput = {
+          userPrompt: ds.pendingCodexAppText !== undefined || ds.pendingCodexAppFollowUps
+            ? [ds.pendingCodexAppText ?? '', ...(ds.pendingCodexAppFollowUps ?? [])].filter(Boolean).join('\n\n')
+            : pendingPrompt || ds.pendingFollowUps?.join('\n\n') || '',
+          cliInput: wrappedInput.content,
+          ...(ds.pendingFollowUpTurnId ? { turnId: ds.pendingFollowUpTurnId } : {}),
+          ...(effectiveCliId === 'codex-app' && botCfg.codexAppCleanInput === true && wrappedInput.codexAppInput
+            ? { codexAppInput: wrappedInput.codexAppInput }
+            : {}),
+          codexAppInputGateFrozen: true,
+        };
+      }
+
+      // From here through forkWorker there is no await: publish the state
+      // transition atomically from the router's point of view.
+      ds.pendingRepo = false;
+      publishAttentionPatch(ds);
+      try {
+        if (pendingRawInput) {
+          // pendingRawTurnId is applied at the literal PTY write boundary.
+          forkWorker(ds, '', false);
+        } else if (pendingTurnId && hasBufferedInput) {
+          forkWorker(ds, prompt, { turnId: pendingTurnId });
+        } else {
+          forkWorker(ds, prompt);
+        }
+      } catch (e) {
+        ds.pendingRepo = true;
+        ds.pendingFollowUpInput = previousPendingFollowUpInput;
+        publishAttentionPatch(ds);
+        throw e;
+      }
+      rememberLastCliInput(ds, pendingRawInput ?? pendingPrompt, pendingRawInput ?? wrappedInput);
+      ds.pendingPrompt = undefined;
+      ds.pendingCodexAppText = undefined;
+      ds.pendingCodexAppApplicationContext = undefined;
+      ds.pendingCodexAppMessageContext = undefined;
+      ds.pendingAttachments = undefined;
+      ds.pendingMentions = undefined;
+      ds.pendingSubstituteTrigger = undefined;
+      ds.pendingSender = undefined;
+      ds.pendingFollowUps = undefined;
+      ds.pendingCodexAppFollowUps = undefined;
+      ds.pendingCodexAppFollowUpContexts = undefined;
+      ds.pendingFollowUpTurnId = undefined;
+      ds.pendingTurnId = undefined;
+      committed = true;
+    } finally {
+      ds.pendingRepoCommitInFlight = false;
     }
-    rememberLastCliInput(ds, pendingRawInput ?? pendingPrompt, pendingRawInput ?? wrappedInput);
-    ds.pendingPrompt = undefined;
-    ds.pendingCodexAppText = undefined;
-    ds.pendingCodexAppApplicationContext = undefined;
-    ds.pendingCodexAppMessageContext = undefined;
-    ds.pendingAttachments = undefined;
-    ds.pendingMentions = undefined;
-    ds.pendingSubstituteTrigger = undefined;
-    ds.pendingSender = undefined;
-    ds.pendingFollowUps = undefined;
-    ds.pendingCodexAppFollowUps = undefined;
-    ds.pendingCodexAppFollowUpContexts = undefined;
-    forkWorker(ds, prompt);
+    if (!committed) return;
     // A card click has no turn of its own — anchor the confirmation to the
     // session's current reply-target turn so a shared fold-back topic keeps
     // it in-thread (same leak as the /repo command path).
@@ -2055,77 +2098,23 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     if (actionType === 'skip_repo' && ds) {
       const locDs = localeForBot(ds.larkAppId);
       if (ds.pendingRepo) {
-        const selfBot = getBot(ds.larkAppId);
-        const botCfg = selfBot.config;
-        const effectiveCliId = sessionCliId(ds);
-        // Skip repo selection — spawn CLI with default working dir
-        ds.pendingRepo = false;
-        publishAttentionPatch(ds);
-        const pendingPrompt = ds.pendingPrompt ?? '';
-        const pendingRawInput = ds.pendingRawInput;
-        // Raw-input cold start still wraps any input buffered while the repo
-        // card was pending (follow-ups / attachments) — delivered right after
-        // the raw input on prompt_ready instead of being dropped.
-        const hasBufferedInput =
-          pendingPrompt.trim().length > 0 ||
-          (ds.pendingAttachments?.length ?? 0) > 0 ||
-          (ds.pendingFollowUps?.length ?? 0) > 0;
-        if (!pendingRawInput || hasBufferedInput) ensureSessionWhiteboard(ds);
-        const wrappedInput = (!pendingRawInput || hasBufferedInput)
-          ? buildNewTopicCliInput(
-              pendingPrompt,
-              ds.session.sessionId,
-              effectiveCliId,
-              botCfg.cliPathOverride,
-              ds.pendingAttachments,
-              ds.pendingMentions,
-              await getAvailableBots(ds.larkAppId, ds.chatId),
-              ds.pendingFollowUps,
-              { name: selfBot.botName, openId: selfBot.botOpenId },
-              locDs,
-              ds.pendingSender,
-              {
-                larkAppId: ds.larkAppId,
-                chatId: ds.chatId,
-                whiteboardId: ds.session.whiteboardId,
-                substituteTrigger: ds.pendingSubstituteTrigger,
-                codexAppText: ds.pendingCodexAppText,
-                codexAppApplicationContext: ds.pendingCodexAppApplicationContext,
-                codexAppMessageContext: ds.pendingCodexAppMessageContext,
-                codexAppFollowUps: ds.pendingCodexAppFollowUps,
-                codexAppFollowUpContexts: ds.pendingCodexAppFollowUpContexts,
-              },
-            )
-          : { content: '' };
-        const prompt = pendingRawInput ? '' : wrappedInput;
-        if (pendingRawInput && hasBufferedInput) {
-          ds.pendingFollowUpInput = {
-              userPrompt: ds.pendingCodexAppText !== undefined || ds.pendingCodexAppFollowUps
-                ? [ds.pendingCodexAppText ?? '', ...(ds.pendingCodexAppFollowUps ?? [])].filter(Boolean).join('\n\n')
-                : pendingPrompt || ds.pendingFollowUps?.join('\n\n') || '',
-              cliInput: wrappedInput.content,
-              ...(effectiveCliId === 'codex-app' && botCfg.codexAppCleanInput === true && wrappedInput.codexAppInput
-                ? { codexAppInput: wrappedInput.codexAppInput }
-                : {}),
-              codexAppInputGateFrozen: true,
-            };
-          }
-        rememberLastCliInput(ds, pendingRawInput ?? pendingPrompt, pendingRawInput ?? wrappedInput);
-        ds.pendingPrompt = undefined;
-        ds.pendingCodexAppText = undefined;
-        ds.pendingCodexAppApplicationContext = undefined;
-        ds.pendingCodexAppMessageContext = undefined;
-        ds.pendingAttachments = undefined;
-        ds.pendingMentions = undefined;
-        ds.pendingSubstituteTrigger = undefined;
-        ds.pendingSender = undefined;
-        ds.pendingFollowUps = undefined;
-        ds.pendingCodexAppFollowUps = undefined;
-        ds.pendingCodexAppFollowUpContexts = undefined;
-        forkWorker(ds, prompt);
+        if (ds.worktreeCreating || ds.pendingRepoCommitInFlight) {
+          return { toast: { type: 'info', content: t('cmd.repo.worktree_in_progress', undefined, locDs) } };
+        }
         const cwd = getSessionWorkingDir(ds);
-        await sessionReply(rootId, t('cmd.skip.opened', { cwd }, locDs));
-        logger.info(`[${tag(ds)}] Skip repo, spawning CLI in ${cwd}`);
+        // Reuse the same claimed pending->worker transition as a normal repo
+        // selection. This keeps buffering active across prompt preparation and
+        // makes skip/select races single-winner.
+        await commitRepoSelection(
+          { ds, rootId, cardMessageId: undefined, larkAppId, operatorOpenId, activeSessions, sessionReply },
+          cwd,
+          pathBasename(cwd) || cwd,
+          { suppressConfirmReply: true },
+        );
+        if (!ds.pendingRepo) {
+          await sessionReply(rootId, t('cmd.skip.opened', { cwd }, locDs));
+          logger.info(`[${tag(ds)}] Skip repo, spawning CLI in ${cwd}`);
+        }
       } else {
         await sessionReply(rootId, t('card.action.continue_using_current_repo', { cwd: getSessionWorkingDir(ds) }, locDs));
       }
@@ -2150,7 +2139,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       }
       // A worktree creation in flight holds the commit lock — a manual switch
       // interleaving there would double-fork (same guard as the plain switch).
-      if (ds.worktreeCreating) {
+      if (ds.worktreeCreating || ds.pendingRepoCommitInFlight) {
         return { toast: { type: 'info', content: t('cmd.repo.worktree_in_progress', undefined, locDs) } };
       }
       const selectedPath = validation.resolvedPath;
@@ -2187,7 +2176,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       if (selectedPaths.length === 0) {
         return { toast: { type: 'error', content: t('card.repo.worktree_empty', undefined, locDs) } };
       }
-      if (ds.worktreeCreating) {
+      if (ds.worktreeCreating || ds.pendingRepoCommitInFlight) {
         return { toast: { type: 'info', content: t('cmd.repo.worktree_in_progress', undefined, locDs) } };
       }
       const branch = String(action?.form_value?.repo_worktree_branch ?? '').trim() || undefined;
@@ -2442,7 +2431,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     // ack the card action immediately with a toast and finish asynchronously.
     // On failure the card (and pendingRepo state) stays put so the user can
     // pick again or fall back to a plain switch.
-    if (targetDs.worktreeCreating) {
+    if (targetDs.worktreeCreating || targetDs.pendingRepoCommitInFlight) {
       // The async path escapes the card-action in-flight dedup — gate repeats
       // here, or two creations would race and the loser's commitSelection
       // would yank the session the winner just spawned.
@@ -2560,7 +2549,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
   // worktree commit awaits (Lark replies, prompt prep) after its generation
   // checks; a plain selection interleaving there would double-fork. One lock
   // gates both kinds until the commit settles.
-  if (targetDs.worktreeCreating) {
+  if (targetDs.worktreeCreating || targetDs.pendingRepoCommitInFlight) {
     return { toast: { type: 'info', content: t('cmd.repo.worktree_in_progress', undefined, locTarget) } };
   }
   await commitRepoSelection(commitCtx, selectedPath, displayName);

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -2222,6 +2222,11 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       // re-send a fresh repo card in the new mode — a form can't ride an
       // in-place patch, so the old card is withdrawn and a new one posted.
       const locDs = localeForBot(ds.larkAppId);
+      // Same active-card gate as skip/manual/worktree: a stale card must not
+      // flip bot config or replace the live repo card after claim/restart.
+      if (cardMessageId && !isActiveRepoCard(ds, cardMessageId)) {
+        return { toast: { type: 'info', content: t('cmd.repo.card_already_consumed', undefined, locDs) } };
+      }
       const spec = findConfigField('worktreeMultiPicker');
       if (!spec) return;
       const next = getBot(ds.larkAppId).config.worktreeMultiPicker !== true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -508,7 +508,7 @@ export type DaemonToWorker =
    *  IPCs would race: process.on('message') handlers don't serialize, and the
    *  raw_input branch awaits 200ms between sendText and Enter, a window where
    *  a separate `message` IPC could write into the PTY first. */
-  | { type: 'raw_input'; content: string; followUpContent?: string; followUpCodexAppInput?: CodexAppTurnInput }
+  | { type: 'raw_input'; content: string; turnId?: string; followUpContent?: string; followUpTurnId?: string; followUpCodexAppInput?: CodexAppTurnInput }
   /** Rename the current CLI-native interactive session. The worker queues this
    *  administrative slash command until the TUI is idle and does not treat it
    *  as a model turn. Only adapters declaring buildSessionRenameCommand handle

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -826,6 +826,16 @@ async function deliverRawInput(msg: Extract<DaemonToWorker, { type: 'raw_input' 
   const targetBackend = backend;
   if (!targetBackend) return;
 
+  // A passthrough is still an accepted input boundary. Rotate (or revoke) the
+  // marker immediately before the literal command reaches the CLI so it can
+  // never inherit a previous human turn. System-generated raw commands omit
+  // turnId and therefore publish an explicitly unattributed marker.
+  currentBotmuxTurnId = msg.turnId;
+  currentBotmuxDispatchAttempt = undefined;
+  currentVcMeetingImTurnOrigin = undefined;
+  writeCliPidMarker();
+  publishSandboxRelayCapability();
+
   let sent = false;
   try {
     await sendRawCommandLineSerially(targetBackend, msg.content);
@@ -843,7 +853,7 @@ async function deliverRawInput(msg: Extract<DaemonToWorker, { type: 'raw_input' 
   // Enter lands. sendToPty also observes commandLineWritesPending, so another
   // raw command's text -> Enter window cannot be interrupted by the follow-up.
   if (sent && msg.followUpContent) {
-    sendToPty(msg.followUpContent, undefined, {
+    sendToPty(msg.followUpContent, msg.followUpTurnId, {
       codexAppInput: msg.followUpCodexAppInput,
     });
     log(`Enqueued follow-up after raw input (${msg.followUpContent.length} chars)`);

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -172,6 +172,9 @@ function makeDs(overrides?: Partial<DaemonSession>): DaemonSession {
     cliVersion: '1.0.0',
     lastMessageAt: Date.now(),
     hasHistory: true,
+    // Match makeSelectEvent / makeSkipEvent / makeManualEvent open_message_id —
+    // only the live posted card may drive selection.
+    repoCardMessageId: 'om_card',
     ...overrides,
   } as unknown as DaemonSession;
 }
@@ -650,6 +653,63 @@ describe('repo select card — plain switch', () => {
     // the switch target — otherwise `claude --resume` reopens it in the wrong cwd.
     expect(closedCard).toContain('gamma');
     expect(closedCard).not.toContain('beta');
+    expect(ds.repoCardMessageId).toBeUndefined();
+    expect(ds.consumedRepoCardMessageIds).toContain('om_card');
+  });
+
+  it('mid-session claims the card before confirm await so a second click cannot double kill/fork', async () => {
+    // Regression: mid-session used to mark consumed only after sessionReply.
+    // Park the "已切换" reply; a second click on the same card must toast and
+    // not kill/create/fork again.
+    const ds = makeDs();
+    ds.session.workingDir = '/repos/gamma';
+    const { deps, sessionReply } = makeDeps(ds);
+    let releaseReply: (() => void) | undefined;
+    sessionReply.mockImplementation(async (_root, text) => {
+      if (typeof text === 'string' && text.includes('已切换') && !releaseReply) {
+        return new Promise<string>(res => { releaseReply = () => res('om_switched'); });
+      }
+      return 'om_reply';
+    });
+
+    const first = handleCardAction(makeSelectEvent('repo_switch', '/repos/alpha'), deps, APP_ID);
+    await vi.waitFor(() => expect(forkWorker).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(releaseReply).toBeTruthy());
+    // Card must already be claimed before the hung confirm reply.
+    expect(ds.repoCardMessageId).toBeUndefined();
+    expect(ds.consumedRepoCardMessageIds).toContain('om_card');
+    expect(ds.session.sessionId).toMatch(/^uuid-new-/);
+    const sessionAfterFirst = ds.session.sessionId;
+
+    const late = await handleCardAction(makeSelectEvent('repo_switch', '/repos/beta'), deps, APP_ID);
+    expect(late?.toast?.content).toMatch(/仓库已选定|ignore the old card/i);
+    expect(killWorker).toHaveBeenCalledTimes(1);
+    expect(createSession).toHaveBeenCalledTimes(1);
+    expect(forkWorker).toHaveBeenCalledTimes(1);
+    expect(ds.session.sessionId).toBe(sessionAfterFirst);
+    expect(ds.workingDir).toBe('/repos/alpha');
+
+    releaseReply!();
+    await first;
+    expect(killWorker).toHaveBeenCalledTimes(1);
+    expect(forkWorker).toHaveBeenCalledTimes(1);
+    expect(ds.session.sessionId).toBe(sessionAfterFirst);
+  });
+
+  it('rejects a card click after restart-like state (no live repoCardMessageId)', async () => {
+    // P2: consumed list is in-memory; after daemon restart both it and
+    // repoCardMessageId are empty. Old Feishu cards must still be rejected.
+    const ds = makeDs({ repoCardMessageId: undefined, consumedRepoCardMessageIds: undefined });
+    ds.session.workingDir = '/repos/gamma';
+    const { deps } = makeDeps(ds);
+
+    const late = await handleCardAction(makeSelectEvent('repo_switch', '/repos/beta'), deps, APP_ID);
+    expect(late?.toast?.content).toMatch(/仓库已选定|ignore the old card/i);
+    expect(killWorker).not.toHaveBeenCalled();
+    expect(createSession).not.toHaveBeenCalled();
+    expect(forkWorker).not.toHaveBeenCalled();
+    expect(ds.session.sessionId).toBe('uuid-old');
+    expect(ds.session.workingDir).toBe('/repos/gamma');
   });
 
   it('ignores a keyless dropdown (option + root_id, no repo_switch/repo_worktree key)', async () => {

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -1179,7 +1179,8 @@ describe('repo select card — worktree open', () => {
   });
 
   it('worktree_toggle_mode flips the persisted picker mode and re-sends a fresh repo card', async () => {
-    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null, repoCardMessageId: 'om_old_card' });
+    // Callback open_message_id must match the live posted card.
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null, repoCardMessageId: 'om_card' });
     const { deps, sessionReply } = makeDeps(ds);
     const event = {
       operator: { open_id: OWNER },
@@ -1193,7 +1194,7 @@ describe('repo select card — worktree open', () => {
     // persisted the flipped mode (config undefined → true)
     expect(vi.mocked(applyConfigField)).toHaveBeenCalledWith('app_test', expect.objectContaining({ configKey: 'worktreeMultiPicker' }), true);
     // withdrew the old card and posted a fresh interactive repo card
-    expect(vi.mocked(deleteMessage)).toHaveBeenCalledWith('app_test', 'om_old_card');
+    expect(vi.mocked(deleteMessage)).toHaveBeenCalledWith('app_test', 'om_card');
     const interactiveCall = sessionReply.mock.calls.find(c => c[2] === 'interactive');
     expect(interactiveCall).toBeDefined();
     expect(createRepoWorktree).not.toHaveBeenCalled();
@@ -1201,10 +1202,49 @@ describe('repo select card — worktree open', () => {
     expect(ds.worktreeCreating).not.toBe(true);
   });
 
+  it('worktree_toggle_mode rejects a stale/wrong card id before flipping config', async () => {
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null, repoCardMessageId: 'om_live_card' });
+    const { deps } = makeDeps(ds);
+    const event = {
+      operator: { open_id: OWNER },
+      action: { value: { action: 'worktree_toggle_mode', root_id: ROOT_ID } },
+      context: { open_message_id: 'om_stale_card' },
+    };
+
+    const res = await handleCardAction(event, deps, APP_ID);
+
+    expect(res?.toast?.content).toMatch(/仓库已选定|ignore the old card/i);
+    expect(vi.mocked(applyConfigField)).not.toHaveBeenCalled();
+    expect(vi.mocked(deleteMessage)).not.toHaveBeenCalled();
+    expect(ds.repoCardMessageId).toBe('om_live_card');
+  });
+
+  it('worktree_toggle_mode rejects restart-like state with no live repoCardMessageId', async () => {
+    const ds = makeDs({
+      pendingRepo: true,
+      pendingPrompt: 'hi',
+      worker: null,
+      repoCardMessageId: undefined,
+      consumedRepoCardMessageIds: undefined,
+    });
+    const { deps } = makeDeps(ds);
+    const event = {
+      operator: { open_id: OWNER },
+      action: { value: { action: 'worktree_toggle_mode', root_id: ROOT_ID } },
+      context: { open_message_id: 'om_card' },
+    };
+
+    const res = await handleCardAction(event, deps, APP_ID);
+
+    expect(res?.toast?.content).toMatch(/仓库已选定|ignore the old card/i);
+    expect(vi.mocked(applyConfigField)).not.toHaveBeenCalled();
+    expect(vi.mocked(deleteMessage)).not.toHaveBeenCalled();
+  });
+
   it('worktree_toggle_mode requires canOperate — a non-operator (even the pending-session owner) cannot flip bot config', async () => {
     // It writes bot-level worktreeMultiPicker (bots.json), so it must NOT ride
     // the pendingRepoOwnerException that lets talk-only users start their own session.
-    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null, repoCardMessageId: 'om_old_card' });
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null, repoCardMessageId: 'om_card' });
     const { deps } = makeDeps(ds);
     vi.mocked(canOperate).mockReturnValueOnce(false); // non-operator
     const event = {

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -460,12 +460,15 @@ describe('repo select card — plain switch', () => {
     expect(ds.session.sessionId).toBe('uuid-old');
 
     const late = await handleCardAction(makeSelectEvent('repo_switch', '/repos/beta'), deps, APP_ID);
-    expect(late?.toast?.content).toContain('已有一个 worktree 正在创建');
+    // After successful fork the card is marked consumed before confirm reply,
+    // so the second click is rejected even while claim is still held.
+    expect(late?.toast?.content).toMatch(/仓库已选定|worktree 正在创建|ignore the old card/i);
     expect(forkWorker).toHaveBeenCalledTimes(1);
     expect(killWorker).not.toHaveBeenCalled();
     expect(createSession).not.toHaveBeenCalled();
     expect(ds.session.sessionId).toBe('uuid-old');
     expect(ds.workingDir).toBe('/repos/alpha');
+    expect(ds.consumedRepoCardMessageIds).toContain('om_card');
 
     releaseReply!();
     await first;
@@ -503,6 +506,91 @@ describe('repo select card — plain switch', () => {
     expect(ds.session.workingDir).toBeUndefined();
     expect(sessionReply.mock.calls.map(c => c[1]).join()).toContain('已直接开启会话');
     expect(deleteMessage).toHaveBeenCalledWith(APP_ID, 'om_card');
+  });
+
+  it('rejects a stale card click while deleteMessage is still pending (local consume mark)', async () => {
+    // Regression: deleteMessage used to be fire-and-forget after claim release.
+    // We now mark the card consumed before network awaits and hold the claim
+    // through best-effort withdraw. A second click on the still-visible card
+    // must never mid-session-switch (killWorker), whether claim is still held
+    // or Feishu withdraw hangs / returns false.
+    const ds = makeDs({
+      pendingRepo: true,
+      pendingPrompt: 'hello world',
+      pendingTurnId: 'om_first_turn',
+      repoCardMessageId: 'om_card',
+      worker: null,
+    });
+    // Simulate a live worker after the first fork so a mid-session path would
+    // call killWorker if the stale click were allowed through.
+    vi.mocked(forkWorker).mockImplementationOnce((session) => {
+      (session as any).worker = { killed: false, send: vi.fn() };
+    });
+    const { deps } = makeDeps(ds);
+    let releaseDelete: (() => void) | undefined;
+    vi.mocked(deleteMessage).mockImplementationOnce(() => new Promise<boolean>(res => {
+      releaseDelete = () => res(false); // withdraw "failed" / no-op
+    }) as any);
+
+    const first = handleCardAction(makeSelectEvent('repo_switch', '/repos/alpha'), deps, APP_ID);
+    await vi.waitFor(() => expect(forkWorker).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(releaseDelete).toBeTruthy());
+    // Consume is local and synchronous before the hung delete.
+    expect(ds.consumedRepoCardMessageIds).toContain('om_card');
+    expect(ds.session.sessionId).toBe('uuid-old');
+
+    const lateWhileDeletePending = await handleCardAction(makeSelectEvent('repo_switch', '/repos/beta'), deps, APP_ID);
+    expect(lateWhileDeletePending?.toast?.content).toMatch(/仓库已选定|worktree 正在创建|ignore the old card/i);
+    expect(killWorker).not.toHaveBeenCalled();
+    expect(createSession).not.toHaveBeenCalled();
+    expect(forkWorker).toHaveBeenCalledTimes(1);
+
+    releaseDelete!();
+    await first;
+    expect(ds.pendingRepoCommitInFlight).toBe(false);
+    expect(ds.session.sessionId).toBe('uuid-old');
+    expect(ds.workingDir).toBe('/repos/alpha');
+
+    // After claim release, Feishu may still show the card (delete returned false).
+    // Consume mark alone must keep rejecting.
+    const lateAfter = await handleCardAction(makeSelectEvent('repo_switch', '/repos/beta'), deps, APP_ID);
+    expect(lateAfter?.toast?.content).toMatch(/仓库已选定|ignore the old card/i);
+    expect(killWorker).not.toHaveBeenCalled();
+    expect(createSession).not.toHaveBeenCalled();
+    expect(forkWorker).toHaveBeenCalledTimes(1);
+    expect(ds.session.sessionId).toBe('uuid-old');
+  });
+
+  it('keeps the first-spawn session when confirm sessionReply throws (card still marked consumed)', async () => {
+    // Sibling window: sessionReply throws → finally releases claim, card may
+    // still be visible. Consume mark must still reject the second click.
+    const ds = makeDs({
+      pendingRepo: true,
+      pendingPrompt: 'hello world',
+      pendingTurnId: 'om_first_turn',
+      repoCardMessageId: 'om_card',
+      worker: null,
+    });
+    vi.mocked(forkWorker).mockImplementationOnce((session) => {
+      (session as any).worker = { killed: false, send: vi.fn() };
+    });
+    const { deps, sessionReply } = makeDeps(ds);
+    sessionReply.mockRejectedValueOnce(new Error('reply boom'));
+
+    await handleCardAction(makeSelectEvent('repo_switch', '/repos/alpha'), deps, APP_ID);
+
+    expect(forkWorker).toHaveBeenCalledTimes(1);
+    expect(ds.pendingRepo).toBe(false);
+    expect(ds.pendingRepoCommitInFlight).toBe(false);
+    expect(ds.consumedRepoCardMessageIds).toContain('om_card');
+    expect(ds.workingDir).toBe('/repos/alpha');
+
+    const late = await handleCardAction(makeSelectEvent('repo_switch', '/repos/beta'), deps, APP_ID);
+    expect(late?.toast?.content).toMatch(/仓库已选定|ignore the old card/i);
+    expect(killWorker).not.toHaveBeenCalled();
+    expect(createSession).not.toHaveBeenCalled();
+    expect(forkWorker).toHaveBeenCalledTimes(1);
+    expect(ds.session.sessionId).toBe('uuid-old');
   });
 
   it('keeps pending buffers and releases the claim when forkWorker throws, then allows retry', async () => {

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -125,7 +125,7 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
 
 import { handleCardAction, type CardHandlerDeps } from '../src/im/lark/card-handler.js';
 import { forkWorker, killWorker, deliverEphemeralOrReply, deliverWriteLinkCard } from '../src/core/worker-pool.js';
-import { buildNewTopicCliInput, getAvailableBots } from '../src/core/session-manager.js';
+import { buildNewTopicCliInput, getAvailableBots, getSessionWorkingDir } from '../src/core/session-manager.js';
 import { getBot } from '../src/bot-registry.js';
 import { createSession, closeSession } from '../src/services/session-store.js';
 import { createRepoWorktree, pushWorktreeBranch, removeRepoWorktree } from '../src/services/git-worktree.js';
@@ -136,7 +136,7 @@ import { sessionKey } from '../src/core/types.js';
 import type { DaemonSession } from '../src/core/types.js';
 import type { ProjectInfo } from '../src/services/project-scanner.js';
 import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
@@ -432,6 +432,77 @@ describe('repo select card — plain switch', () => {
     expect(forkWorker).toHaveBeenCalledTimes(1);
     expect(ds.pendingRepo).toBe(false);
     expect(ds.pendingRepoCommitInFlight).toBe(false);
+  });
+
+  it('holds the pending claim through post-fork confirmation so a second card click cannot mid-session-switch', async () => {
+    // Regression: previously pendingRepoCommitInFlight was cleared right after
+    // forkWorker, while sessionReply was still awaiting. A second card option
+    // in that window saw pendingRepo=false + claim released → treated as
+    // mid-session switch → killWorker + empty new session.
+    const ds = makeDs({
+      pendingRepo: true,
+      pendingPrompt: 'hello world',
+      pendingTurnId: 'om_first_turn',
+      repoCardMessageId: 'om_card',
+      worker: null,
+    });
+    const { deps, sessionReply } = makeDeps(ds);
+    let releaseReply: (() => void) | undefined;
+    sessionReply.mockImplementation(async () => new Promise<string>(res => {
+      releaseReply = () => res('om_confirm');
+    }));
+
+    const first = handleCardAction(makeSelectEvent('repo_switch', '/repos/alpha'), deps, APP_ID);
+    await vi.waitFor(() => expect(forkWorker).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(releaseReply).toBeTruthy());
+    expect(ds.pendingRepo).toBe(false);
+    expect(ds.pendingRepoCommitInFlight).toBe(true);
+    expect(ds.session.sessionId).toBe('uuid-old');
+
+    const late = await handleCardAction(makeSelectEvent('repo_switch', '/repos/beta'), deps, APP_ID);
+    expect(late?.toast?.content).toContain('已有一个 worktree 正在创建');
+    expect(forkWorker).toHaveBeenCalledTimes(1);
+    expect(killWorker).not.toHaveBeenCalled();
+    expect(createSession).not.toHaveBeenCalled();
+    expect(ds.session.sessionId).toBe('uuid-old');
+    expect(ds.workingDir).toBe('/repos/alpha');
+
+    releaseReply!();
+    await first;
+
+    expect(forkWorker).toHaveBeenCalledTimes(1);
+    expect(ds.pendingRepoCommitInFlight).toBe(false);
+    expect(ds.session.sessionId).toBe('uuid-old');
+    expect(deleteMessage).toHaveBeenCalledWith(APP_ID, 'om_card');
+    expect(ds.repoCardMessageId).toBeUndefined();
+  });
+
+  it('skip_repo does not persist the default $HOME cwd onto session.workingDir', async () => {
+    // Regression: skip reused commitRepoSelection which always pinned dirPath.
+    // getSessionWorkingDir falls back to $HOME when unset; pinning that lets a
+    // sibling bot inherit HOME instead of getting its own repo card.
+    const home = homedir();
+    vi.mocked(getSessionWorkingDir).mockReturnValueOnce(home);
+    const ds = makeDs({
+      pendingRepo: true,
+      pendingPrompt: 'hello world',
+      pendingTurnId: 'om_skip_home',
+      repoCardMessageId: 'om_card',
+      worker: null,
+    });
+    // Explicitly unpinned — the default-dir case.
+    ds.workingDir = undefined;
+    ds.session.workingDir = undefined;
+    const { deps, sessionReply } = makeDeps(ds);
+
+    await handleCardAction(makeSkipEvent(), deps, APP_ID);
+
+    expect(forkWorker).toHaveBeenCalledTimes(1);
+    expect(ds.pendingRepo).toBe(false);
+    expect(ds.workingDir).toBeUndefined();
+    expect(ds.session.workingDir).toBeUndefined();
+    expect(sessionReply.mock.calls.map(c => c[1]).join()).toContain('已直接开启会话');
+    expect(deleteMessage).toHaveBeenCalledWith(APP_ID, 'om_card');
   });
 
   it('keeps pending buffers and releases the claim when forkWorker throws, then allows retry', async () => {

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -255,7 +255,17 @@ beforeEach(() => {
 
 describe('repo select card — plain switch', () => {
   it('pendingRepo selection forks the CLI with the buffered prompt', async () => {
-    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hello world', worker: null });
+    const ds = makeDs({
+      pendingRepo: true,
+      pendingPrompt: 'hello world',
+      pendingTurnId: 'om_initial_turn',
+      currentReplyTarget: {
+        rootMessageId: ROOT_ID,
+        turnId: 'om_stale_reply_target',
+        updatedAt: new Date().toISOString(),
+      },
+      worker: null,
+    });
     ds.session.riffRepoDirs = ['/stale/riff/repo'];
     const { deps, sessionReply } = makeDeps(ds);
 
@@ -265,7 +275,12 @@ describe('repo select card — plain switch', () => {
     expect(ds.workingDir).toBe('/repos/alpha');
     expect(ds.session.workingDir).toBe('/repos/alpha');
     expect(forkWorker).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(forkWorker).mock.calls[0]![1]).toEqual({ content: 'mock-prompt' });
+    expect(forkWorker).toHaveBeenCalledWith(
+      ds,
+      { content: 'mock-prompt' },
+      { turnId: 'om_initial_turn' },
+    );
+    expect(ds.pendingTurnId).toBeUndefined();
     expect(ds.session.riffRepoDirs).toBeUndefined();
     expect(sessionReply.mock.calls.map(c => c[1]).join()).toContain('已选择');
     expect(killWorker).not.toHaveBeenCalled();
@@ -299,13 +314,19 @@ describe('repo select card — plain switch', () => {
       content: 'mock-prompt',
       codexAppInput,
     });
+    expect(vi.mocked(forkWorker).mock.calls[0]).toHaveLength(2);
     expect(vi.mocked(buildNewTopicCliInput).mock.calls[0]![11]).toEqual(expect.objectContaining({
       substituteTrigger,
     }));
   });
 
   it('skip_repo also forwards the complete Codex App sidecar to forkWorker', async () => {
-    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hello world', worker: null });
+    const ds = makeDs({
+      pendingRepo: true,
+      pendingPrompt: 'hello world',
+      pendingTurnId: 'om_skip_turn',
+      worker: null,
+    });
     ds.session.cliId = 'codex-app';
     const substituteTrigger = {
       target: { userId: 'u_configured' },
@@ -326,13 +347,124 @@ describe('repo select card — plain switch', () => {
     await handleCardAction(makeSkipEvent(), deps, APP_ID);
 
     expect(forkWorker).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(forkWorker).mock.calls[0]![1]).toEqual({
-      content: 'mock-prompt',
-      codexAppInput,
-    });
+    expect(forkWorker).toHaveBeenCalledWith(
+      ds,
+      {
+        content: 'mock-prompt',
+        codexAppInput,
+      },
+      { turnId: 'om_skip_turn' },
+    );
+    expect(ds.pendingTurnId).toBeUndefined();
     expect(vi.mocked(buildNewTopicCliInput).mock.calls[0]![11]).toEqual(expect.objectContaining({
       substituteTrigger,
     }));
+  });
+
+  it('keeps the pending repo card untouched when skip_repo is clicked while a worktree is being created', async () => {
+    const ds = makeDs({
+      pendingRepo: true,
+      pendingPrompt: 'hello world',
+      pendingTurnId: 'om_pending_turn',
+      repoCardMessageId: 'om_card',
+      worktreeCreating: true,
+      worker: null,
+    });
+    const { deps } = makeDeps(ds);
+
+    const result = await handleCardAction(makeSkipEvent(), deps, APP_ID);
+
+    expect(result?.toast?.content).toContain('已有一个 worktree 正在创建');
+    expect(forkWorker).not.toHaveBeenCalled();
+    expect(ds.pendingRepo).toBe(true);
+    expect(ds.pendingPrompt).toBe('hello world');
+    expect(ds.pendingTurnId).toBe('om_pending_turn');
+    expect(ds.repoCardMessageId).toBe('om_card');
+    expect(deleteMessage).not.toHaveBeenCalled();
+  });
+
+  it('lets a pending plain selection win over a concurrent skip_repo during prompt preparation', async () => {
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hello world', worker: null });
+    const { deps } = makeDeps(ds);
+    let releaseBots: (() => void) | undefined;
+    vi.mocked(getAvailableBots).mockImplementationOnce(() => new Promise(resolve => {
+      releaseBots = () => resolve([]);
+    }));
+
+    const first = handleCardAction(makeSelectEvent('repo_switch', '/repos/alpha'), deps, APP_ID);
+    await vi.waitFor(() => expect(releaseBots).toBeTruthy());
+    expect(ds.pendingRepo).toBe(true);
+    expect(ds.pendingRepoCommitInFlight).toBe(true);
+
+    const late = await handleCardAction(makeSkipEvent(), deps, APP_ID);
+    expect(late?.toast?.content).toContain('已有一个 worktree 正在创建');
+    expect(forkWorker).not.toHaveBeenCalled();
+
+    releaseBots!();
+    await first;
+
+    expect(forkWorker).toHaveBeenCalledTimes(1);
+    expect(ds.workingDir).toBe('/repos/alpha');
+    expect(ds.pendingRepo).toBe(false);
+    expect(ds.pendingRepoCommitInFlight).toBe(false);
+  });
+
+  it('lets skip_repo win over a concurrent plain selection during prompt preparation', async () => {
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hello world', worker: null });
+    const { deps } = makeDeps(ds);
+    let releaseBots: (() => void) | undefined;
+    vi.mocked(getAvailableBots).mockImplementationOnce(() => new Promise(resolve => {
+      releaseBots = () => resolve([]);
+    }));
+
+    const first = handleCardAction(makeSkipEvent(), deps, APP_ID);
+    await vi.waitFor(() => expect(releaseBots).toBeTruthy());
+    expect(ds.pendingRepo).toBe(true);
+    expect(ds.pendingRepoCommitInFlight).toBe(true);
+
+    const late = await handleCardAction(makeSelectEvent('repo_switch', '/repos/alpha'), deps, APP_ID);
+    expect(late?.toast?.content).toContain('已有一个 worktree 正在创建');
+    expect(forkWorker).not.toHaveBeenCalled();
+
+    releaseBots!();
+    await first;
+
+    expect(forkWorker).toHaveBeenCalledTimes(1);
+    expect(ds.pendingRepo).toBe(false);
+    expect(ds.pendingRepoCommitInFlight).toBe(false);
+  });
+
+  it('keeps pending buffers and releases the claim when forkWorker throws, then allows retry', async () => {
+    const pendingFollowUps = ['buffered follow-up'];
+    const ds = makeDs({
+      pendingRepo: true,
+      pendingPrompt: 'hello world',
+      pendingFollowUps,
+      pendingTurnId: 'om_buffered_turn',
+      worker: null,
+    });
+    const { deps } = makeDeps(ds);
+    vi.mocked(forkWorker).mockImplementationOnce(() => { throw new Error('fork boom'); });
+
+    await expect(
+      handleCardAction(makeSelectEvent('repo_switch', '/repos/alpha'), deps, APP_ID),
+    ).rejects.toThrow('fork boom');
+
+    expect(ds.pendingRepo).toBe(true);
+    expect(ds.pendingRepoCommitInFlight).toBe(false);
+    expect(ds.pendingPrompt).toBe('hello world');
+    expect(ds.pendingFollowUps).toBe(pendingFollowUps);
+    expect(ds.pendingTurnId).toBe('om_buffered_turn');
+    expect(deleteMessage).not.toHaveBeenCalled();
+
+    await handleCardAction(makeSelectEvent('repo_switch', '/repos/alpha'), deps, APP_ID);
+
+    expect(forkWorker).toHaveBeenCalledTimes(2);
+    expect(ds.pendingRepo).toBe(false);
+    expect(ds.pendingRepoCommitInFlight).toBe(false);
+    expect(ds.pendingPrompt).toBeUndefined();
+    expect(ds.pendingFollowUps).toBeUndefined();
+    expect(ds.pendingTurnId).toBeUndefined();
   });
 
   it('mid-session selection closes the old session and forks a fresh one', async () => {

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -2176,8 +2176,34 @@ describe('handleCommand', () => {
   // ─── bare /repo while pending (replaces the old /skip command) ────────────
 
   describe('/repo (bare) while pending', () => {
+    it('does not consume the pending launch while a card commit owns the shared claim', async () => {
+      const ds = makeDaemonSession({
+        pendingRepo: true,
+        pendingRepoCommitInFlight: true,
+        pendingPrompt: 'hello world',
+        pendingTurnId: 'om_pending_turn',
+      });
+      const deps = makeDeps(ds);
+
+      await handleCommand('/repo', ROOT_ID, makeLarkMessage('/repo'), deps, LARK_APP_ID);
+
+      expect(forkWorker).not.toHaveBeenCalled();
+      expect(getAvailableBots).not.toHaveBeenCalled();
+      expect(ds.pendingRepo).toBe(true);
+      expect(ds.pendingRepoCommitInFlight).toBe(true);
+      expect(ds.pendingPrompt).toBe('hello world');
+      expect(ds.pendingTurnId).toBe('om_pending_turn');
+      const replies = vi.mocked(deps.sessionReply).mock.calls.map(c => c[1]).join();
+      expect(replies).toContain('已有一个 worktree 正在创建');
+    });
+
     it('should boot the CLI idle (no prompt submitted) when launched via /repo itself', async () => {
-      const ds = makeDaemonSession({ pendingRepo: true, pendingPrompt: '', repoCardMessageId: 'om_card' });
+      const ds = makeDaemonSession({
+        pendingRepo: true,
+        pendingPrompt: '',
+        pendingTurnId: 'om_repo_command_only',
+        repoCardMessageId: 'om_card',
+      });
       const deps = makeDeps(ds);
 
       await handleCommand('/repo', ROOT_ID, makeLarkMessage('/repo'), deps, LARK_APP_ID);
@@ -2191,6 +2217,7 @@ describe('handleCommand', () => {
       // Cleared pending state + withdrew the (already-sent) card.
       expect(ds.pendingRepo).toBe(false);
       expect(ds.pendingPrompt).toBeUndefined();
+      expect(ds.pendingTurnId).toBeUndefined();
       expect(deleteMessage).toHaveBeenCalledWith(LARK_APP_ID, 'om_card');
       expect(ds.repoCardMessageId).toBeUndefined();
       const replyContent = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
@@ -2202,7 +2229,11 @@ describe('handleCommand', () => {
     it('should still submit a buffered first message when bare /repo skips the card', async () => {
       // Normal flow: real first message → card shown → user types bare /repo to
       // skip. The buffered message must be delivered, not dropped.
-      const ds = makeDaemonSession({ pendingRepo: true, pendingPrompt: '帮我看看这个 bug' });
+      const ds = makeDaemonSession({
+        pendingRepo: true,
+        pendingPrompt: '帮我看看这个 bug',
+        pendingTurnId: 'om_buffered_first',
+      });
       const deps = makeDeps(ds);
 
       await handleCommand('/repo', ROOT_ID, makeLarkMessage('/repo'), deps, LARK_APP_ID);
@@ -2212,8 +2243,13 @@ describe('handleCommand', () => {
       expect(ensureSessionWhiteboard).toHaveBeenCalledWith(ds);
       expect((buildNewTopicCliInput as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe('帮我看看这个 bug');
       expect((buildNewTopicCliInput as ReturnType<typeof vi.fn>).mock.calls[0][11]).toMatchObject({ whiteboardId: 'wb_test' });
-      expect(forkWorker).toHaveBeenCalledWith(ds, { content: 'WRAPPED:帮我看看这个 bug' });
+      expect(forkWorker).toHaveBeenCalledWith(
+        ds,
+        { content: 'WRAPPED:帮我看看这个 bug' },
+        { turnId: 'om_buffered_first' },
+      );
       expect(ds.pendingRepo).toBe(false);
+      expect(ds.pendingTurnId).toBeUndefined();
     });
 
     it('forwards the pending substitute trigger and complete Codex App sidecar', async () => {
@@ -2256,7 +2292,13 @@ describe('handleCommand', () => {
       // /goal cold start → repo card → bare /repo skip: the raw command must
       // NOT be wrapped into a prompt; it stays on ds.pendingRawInput and the
       // prompt_ready handler delivers it literally.
-      const ds = makeDaemonSession({ pendingRepo: true, pendingPrompt: '', pendingRawInput: '/goal 发布 onboarding' });
+      const ds = makeDaemonSession({
+        pendingRepo: true,
+        pendingPrompt: '',
+        pendingTurnId: 'om_goal_first',
+        pendingRawInput: '/goal 发布 onboarding',
+        pendingRawTurnId: 'om_goal_first',
+      });
       const deps = makeDeps(ds);
 
       await handleCommand('/repo', ROOT_ID, makeLarkMessage('/repo'), deps, LARK_APP_ID);
@@ -2264,7 +2306,9 @@ describe('handleCommand', () => {
       expect(forkWorker).toHaveBeenCalledWith(ds, '', false);
       expect(buildNewTopicPrompt).not.toHaveBeenCalled();
       expect(ds.pendingRawInput).toBe('/goal 发布 onboarding');
+      expect(ds.pendingRawTurnId).toBe('om_goal_first');
       expect(ds.pendingFollowUpInput).toBeUndefined();
+      expect(ds.pendingTurnId).toBeUndefined();
     });
 
     it('raw-input cold start wraps follow-ups buffered during repo wait into pendingFollowUpInput', async () => {

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -2226,6 +2226,71 @@ describe('handleCommand', () => {
       expect(scanMultipleProjects).not.toHaveBeenCalled();
     });
 
+    it('bare /repo does not pin the default workingDir onto the session record', async () => {
+      // Text twin of skip_repo: launch in default cwd without persisting it, so
+      // sibling bots still get their own repo card instead of inheriting HOME.
+      const ds = makeDaemonSession({
+        pendingRepo: true,
+        pendingPrompt: '',
+        repoCardMessageId: 'om_card',
+      });
+      ds.workingDir = undefined;
+      ds.session.workingDir = undefined;
+      const deps = makeDeps(ds);
+
+      await handleCommand('/repo', ROOT_ID, makeLarkMessage('/repo'), deps, LARK_APP_ID);
+
+      expect(forkWorker).toHaveBeenCalledTimes(1);
+      expect(ds.workingDir).toBeUndefined();
+      expect(ds.session.workingDir).toBeUndefined();
+    });
+
+    it('holds the pending claim through confirmation so a second /repo cannot mid-session-switch', async () => {
+      const ds = makeDaemonSession({
+        pendingRepo: true,
+        pendingPrompt: 'hello world',
+        pendingTurnId: 'om_first_turn',
+        repoCardMessageId: 'om_card',
+      });
+      const deps = makeDeps(ds);
+      deps.lastRepoScan.set(CHAT_ID, [
+        { name: 'project-a', path: '/home/testuser/project-a', branch: 'main' },
+        { name: 'project-b', path: '/home/testuser/project-b', branch: 'dev' },
+      ]);
+      let releaseReply: (() => void) | undefined;
+      vi.mocked(deps.sessionReply).mockImplementation(async (_root, text) => {
+        if (typeof text === 'string' && text.includes('已选择') && !releaseReply) {
+          return new Promise<string>(res => { releaseReply = () => res('reply-msg-id'); });
+        }
+        return 'reply-msg-id';
+      });
+
+      const first = handleCommand('/repo', ROOT_ID, makeLarkMessage('/repo 1'), deps, LARK_APP_ID);
+      await vi.waitFor(() => expect(forkWorker).toHaveBeenCalledTimes(1));
+      await vi.waitFor(() => expect(releaseReply).toBeTruthy());
+      expect(ds.pendingRepo).toBe(false);
+      expect(ds.pendingRepoCommitInFlight).toBe(true);
+      const sessionIdAfterFirstFork = ds.session.sessionId;
+
+      await handleCommand('/repo', ROOT_ID, makeLarkMessage('/repo 2'), deps, LARK_APP_ID);
+
+      expect(forkWorker).toHaveBeenCalledTimes(1);
+      expect(killWorker).not.toHaveBeenCalled();
+      expect(sessionStore.createSession).not.toHaveBeenCalled();
+      expect(ds.session.sessionId).toBe(sessionIdAfterFirstFork);
+      expect(ds.workingDir).toBe('/home/testuser/project-a');
+      const replies = vi.mocked(deps.sessionReply).mock.calls.map(c => c[1]).join();
+      expect(replies).toContain('已有一个 worktree 正在创建');
+
+      releaseReply!();
+      await first;
+
+      expect(forkWorker).toHaveBeenCalledTimes(1);
+      expect(ds.pendingRepoCommitInFlight).toBe(false);
+      expect(deleteMessage).toHaveBeenCalledWith(LARK_APP_ID, 'om_card');
+      expect(ds.repoCardMessageId).toBeUndefined();
+    });
+
     it('should still submit a buffered first message when bare /repo skips the card', async () => {
       // Normal flow: real first message → card shown → user types bare /repo to
       // skip. The buffered message must be delivered, not dropped.

--- a/test/current-turn-provenance.test.ts
+++ b/test/current-turn-provenance.test.ts
@@ -116,7 +116,22 @@ describe('resolveCurrentTurnProvenance', () => {
       dataDir,
       envSessionId: 'sess-1',
       startPid: process.pid,
-    })).toThrow(/缺少 sessionId\/turnId\/procStart/);
+    })).toThrow(/后台进程信息不完整/);
+  });
+
+  it('explains an idle marker without trusting the inherited session env', () => {
+    const procStart = readProcessStartIdentity(process.pid);
+    if (!procStart) throw new Error('test process start identity unavailable');
+    writeFileSync(
+      join(dataDir, '.botmux-cli-pids', String(process.pid)),
+      JSON.stringify({ sessionId: 'sess-1', turnId: null, procStart }),
+    );
+    writeSession();
+    expect(() => resolveCurrentTurnProvenance({
+      dataDir,
+      envSessionId: 'sess-1',
+      startPid: process.pid,
+    })).toThrow(/还没有绑定到这条消息.*重新发送一次/);
   });
 
   it('fails closed for a detached in-session invocation instead of trusting env', () => {

--- a/test/daemon-rename-route.test.ts
+++ b/test/daemon-rename-route.test.ts
@@ -37,6 +37,12 @@ const mocks = vi.hoisted(() => {
     replyMessage: vi.fn(async () => 'om_reply'),
     sendMessage: vi.fn(async () => 'om_top'),
     getChatMode: vi.fn(async () => 'group' as 'group' | 'topic' | 'p2p'),
+    resolveSender: vi.fn(async (_appId: string, openId: string | undefined, senderType: string | undefined) => (
+      openId
+        ? { openId, type: senderType === 'app' || senderType === 'bot' ? 'bot' as const : 'user' as const }
+        : undefined
+    )),
+    forkWorker: vi.fn(),
     createSession: vi.fn((chatId: string, rootMessageId: string, title: string, chatType?: 'group' | 'p2p') => ({
       sessionId: `sess-fake-${++seq}`,
       chatId,
@@ -63,6 +69,16 @@ vi.mock('../src/im/lark/client.js', async () => {
 vi.mock('../src/services/session-store.js', async () => {
   const actual = await vi.importActual<any>('../src/services/session-store.js');
   return { ...actual, createSession: mocks.createSession, updateSession: mocks.updateSession };
+});
+
+vi.mock('../src/im/lark/identity-cache.js', async () => {
+  const actual = await vi.importActual<any>('../src/im/lark/identity-cache.js');
+  return { ...actual, resolveSender: (...args: any[]) => mocks.resolveSender(...args) };
+});
+
+vi.mock('../src/core/worker-pool.js', async () => {
+  const actual = await vi.importActual<any>('../src/core/worker-pool.js');
+  return { ...actual, forkWorker: (...args: any[]) => mocks.forkWorker(...args) };
 });
 
 import { registerBot } from '../src/bot-registry.js';
@@ -132,6 +148,58 @@ function seedThreadSession(anchor: string, title: string): DaemonSession {
   return ds;
 }
 
+function seedLiveChatSession(send = vi.fn()): DaemonSession {
+  const ds = {
+    scope: 'chat',
+    chatId: CHAT,
+    chatType: 'group',
+    larkAppId: APP,
+    worker: { killed: false, send },
+    workerPort: null,
+    workerToken: null,
+    spawnedAt: Date.now(),
+    cliVersion: '1.0.0',
+    lastMessageAt: Date.now(),
+    hasHistory: false,
+    ownerOpenId: OWNER,
+    currentReplyTarget: {
+      rootMessageId: 'om_stale_root',
+      turnId: 'om_stale_turn',
+      updatedAt: NOW,
+    },
+    session: {
+      sessionId: 'sess-live-chat-' + Math.random().toString(36).slice(2),
+      chatId: CHAT,
+      rootMessageId: 'om_original_root',
+      title: 'live chat',
+      status: 'active',
+      createdAt: NOW,
+      larkAppId: APP,
+      scope: 'chat',
+      quoteTargetId: 'om_stale_quote',
+      quoteTargetSenderOpenId: 'ou_stale_caller',
+      lastCallerOpenId: 'ou_stale_caller',
+      currentReplyTarget: {
+        rootMessageId: 'om_stale_root',
+        turnId: 'om_stale_turn',
+        updatedAt: NOW,
+      },
+    },
+  } as unknown as DaemonSession;
+  activeSessions.set(sessionKey(CHAT, APP), ds);
+  return ds;
+}
+
+function seedPendingRawSession(anchor: string): DaemonSession {
+  const ds = seedThreadSession(anchor, 'pending raw');
+  ds.pendingRepo = true;
+  ds.pendingPrompt = '';
+  ds.pendingRawInput = '/goal start';
+  ds.pendingRawTurnId = 'om_initial_raw';
+  ds.pendingSender = { openId: OWNER, type: 'user' };
+  return ds;
+}
+
 /** All text replied through the mocked Lark client in this test, joined. */
 function repliedText(): string {
   return [...mocks.replyMessage.mock.calls, ...mocks.sendMessage.mock.calls]
@@ -146,7 +214,13 @@ describe('/rename production routing — must not pre-create a session (review P
     mocks.sendMessage.mockResolvedValue('om_top');
     mocks.getChatMode.mockResolvedValue('group');
     activeSessions.clear();
-    const bot = registerBot({ larkAppId: APP, larkAppSecret: 's', cliId: 'claude-code', allowedUsers: [OWNER] });
+    const bot = registerBot({
+      larkAppId: APP,
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: [OWNER],
+      oncallChats: [{ chatId: CHAT, workingDir: '/tmp' }],
+    });
     bot.resolvedAllowedUsers = [OWNER];
   });
 
@@ -221,5 +295,97 @@ describe('/rename production routing — must not pre-create a session (review P
 
     expect(mocks.createSession).toHaveBeenCalledTimes(1);
     expect(activeSessions.has(sessionKey('om_new_2', APP))).toBe(true);
+  });
+
+  it('new topic: passes the accepted Lark message id into the first worker', async () => {
+    await handleNewTopic(
+      makeEventData('om_workflow_new', '/workflow new 修复首轮授权'),
+      makeCtx('om_workflow_new', 'om_workflow_new'),
+    );
+
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+    expect(mocks.forkWorker.mock.calls[0]?.[2]).toEqual({ turnId: 'om_workflow_new' });
+  });
+
+  it('thread safety-net: passes the accepted reply id into the first worker', async () => {
+    await handleThreadReply(
+      makeEventData('om_workflow_reply', '/workflow new 修复首轮授权', 'om_fresh_root'),
+      makeCtx('om_fresh_root', 'om_workflow_reply'),
+    );
+
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+    expect(mocks.forkWorker.mock.calls[0]?.[2]).toEqual({ turnId: 'om_workflow_reply' });
+  });
+
+  it('live passthrough binds raw input and reply metadata to the accepted message', async () => {
+    const send = vi.fn();
+    const ds = seedLiveChatSession(send);
+    const messageId = 'om_model_turn';
+    const replyRootId = 'om_model_reply_root';
+
+    await handleThreadReply(
+      makeEventData(messageId, '/model opus', replyRootId),
+      {
+        chatId: CHAT,
+        messageId,
+        chatType: 'group' as const,
+        scope: 'chat' as const,
+        anchor: CHAT,
+        replyRootId,
+        larkAppId: APP,
+      },
+    );
+
+    expect(send).toHaveBeenCalledWith({
+      type: 'raw_input',
+      content: '/model opus',
+      turnId: messageId,
+    });
+    expect(ds.session.quoteTargetId).toBe(messageId);
+    expect(ds.session.quoteTargetSenderOpenId).toBe(OWNER);
+    expect(ds.session.lastCallerOpenId).toBe(OWNER);
+    expect(ds.currentReplyTarget).toMatchObject({ rootMessageId: replyRootId, turnId: messageId });
+    expect(ds.session.currentReplyTarget).toMatchObject({ rootMessageId: replyRootId, turnId: messageId });
+    expect(mocks.updateSession).toHaveBeenCalledWith(ds.session);
+  });
+
+  it('pending raw same-caller follow-up rotates both staged turns to the latest message', async () => {
+    const anchor = 'om_pending_raw_root';
+    const ds = seedPendingRawSession(anchor);
+    const messageId = 'om_pending_raw_followup';
+
+    await handleThreadReply(
+      makeEventData(messageId, '补充同一个人的要求', anchor),
+      makeCtx(anchor, messageId),
+    );
+
+    expect(ds.pendingRawTurnId).toBe(messageId);
+    expect(ds.pendingFollowUpTurnId).toBe(messageId);
+    expect(ds.pendingFollowUps).toHaveLength(1);
+    expect(ds.session.quoteTargetId).toBe(messageId);
+  });
+
+  it('pending raw mixed-caller follow-up clears both staged turns', async () => {
+    const anchor = 'om_pending_raw_mixed_root';
+    const ds = seedPendingRawSession(anchor);
+    const ownerMessageId = 'om_pending_owner_followup';
+
+    await handleThreadReply(
+      makeEventData(ownerMessageId, '先由原调用者补充', anchor),
+      makeCtx(anchor, ownerMessageId),
+    );
+    expect(ds.pendingRawTurnId).toBe(ownerMessageId);
+    expect(ds.pendingFollowUpTurnId).toBe(ownerMessageId);
+
+    const strangerMessageId = 'om_pending_stranger_followup';
+    const strangerData = makeEventData(strangerMessageId, '再由另一个人补充', anchor);
+    strangerData.sender = { sender_id: { open_id: 'ou_stranger' }, sender_type: 'user' };
+    await handleThreadReply(strangerData, makeCtx(anchor, strangerMessageId));
+
+    expect(ds.pendingRawTurnId).toBeUndefined();
+    expect(ds.pendingFollowUpTurnId).toBeUndefined();
+    expect(ds.pendingFollowUps).toHaveLength(2);
+    expect(ds.session.quoteTargetId).toBe(strangerMessageId);
+    expect(ds.session.lastCallerOpenId).toBe('ou_stranger');
   });
 });

--- a/test/raw-input-followup-atomicity.test.ts
+++ b/test/raw-input-followup-atomicity.test.ts
@@ -74,8 +74,19 @@ describe('worker raw_input delivery', () => {
   });
 
   it('routes the follow-up through sendToPty (normal busy-queue semantics)', () => {
-    expect(region).toContain('sendToPty(msg.followUpContent, undefined, {');
+    expect(region).toContain('sendToPty(msg.followUpContent, msg.followUpTurnId, {');
     expect(region).toContain('codexAppInput: msg.followUpCodexAppInput');
+  });
+
+  it('rotates or revokes the marker immediately before writing the raw command', () => {
+    const bindIdx = region.indexOf('currentBotmuxTurnId = msg.turnId');
+    const markerIdx = region.indexOf('writeCliPidMarker()');
+    const capabilityIdx = region.indexOf('publishSandboxRelayCapability()');
+    const sendIdx = region.indexOf('await sendRawCommandLineSerially(targetBackend, msg.content)');
+    expect(bindIdx).toBeGreaterThanOrEqual(0);
+    expect(markerIdx).toBeGreaterThan(bindIdx);
+    expect(capabilityIdx).toBeGreaterThan(markerIdx);
+    expect(sendIdx).toBeGreaterThan(capabilityIdx);
   });
 
   it('holds ordinary prompt flushes only for the text-to-Enter critical window', () => {

--- a/test/session-lifecycle-start.test.ts
+++ b/test/session-lifecycle-start.test.ts
@@ -326,7 +326,7 @@ describe('Codex App clean-input feature gate', () => {
     expect(ds.managedTurnOrigin).toBeUndefined();
   });
 
-  it('keeps previous-turn attribution fallback for a non-empty accepted prompt', () => {
+  it('does not lend a previous human turn to a non-empty system prompt', () => {
     vi.mocked(getBot).mockImplementation(() => defaultBot({ cliId: 'codex-app', codexAppCleanInput: true }));
     const ds = makeDs({
       currentReplyTarget: {
@@ -346,12 +346,13 @@ describe('Codex App clean-input feature gate', () => {
     forkWorker(ds, payload, { resume: true });
 
     const worker = forkMock.mock.results.at(-1)!.value;
-    expect(vi.mocked(worker.send).mock.calls[0][0]).toEqual(expect.objectContaining({
+    const init = vi.mocked(worker.send).mock.calls[0][0];
+    expect(init).toEqual(expect.objectContaining({
       prompt: payload.content,
-      promptCodexAppInput: { text: 'clean', clientUserMessageId: 'om_current_vc' },
-      turnId: 'om_current_vc',
-      vcMeetingImTurnOrigin: origin,
+      promptCodexAppInput: { text: 'clean' },
     }));
+    expect(init.turnId).toBeUndefined();
+    expect(init.vcMeetingImTurnOrigin).toBeUndefined();
   });
 
   it('starts an old queued activation without a sidecar and a modern one with exactly one', () => {

--- a/test/worker-ready-display-mode.test.ts
+++ b/test/worker-ready-display-mode.test.ts
@@ -526,9 +526,11 @@ describe('Worker ready: set_display_mode re-sync', () => {
     const ds = makeDs({
       worker: fakeWorker,
       pendingRawInput: '/goal ship the onboarding flow',
+      pendingRawTurnId: 'om_goal_turn',
       pendingFollowUpInput: {
         userPrompt: '另外帮我顺手看下 CI',
         cliInput: '<user_message>另外帮我顺手看下 CI</user_message>',
+        turnId: 'om_followup_turn',
       },
     } as Partial<DaemonSession>);
 
@@ -542,9 +544,12 @@ describe('Worker ready: set_display_mode re-sync', () => {
     expect(fakeWorker.send).toHaveBeenCalledWith({
       type: 'raw_input',
       content: '/goal ship the onboarding flow',
+      turnId: 'om_goal_turn',
       followUpContent: '<user_message>另外帮我顺手看下 CI</user_message>',
+      followUpTurnId: 'om_followup_turn',
     });
     expect(ds.pendingRawInput).toBeUndefined();
+    expect(ds.pendingRawTurnId).toBeUndefined();
     expect(ds.pendingFollowUpInput).toBeUndefined();
 
     fakeWorker.send.mockClear();


### PR DESCRIPTION
## 改了什么

- 把新话题首条飞书消息的 ID 一直带到首个 CLI 请求，工作流一启动就能执行需要用户确认的操作。
- 补齐选择仓库、创建 worktree、原样 `/goal` 命令和紧接着的补充消息，确保它们都绑定到正确消息。
- 多条消息同时到达时只启动一次；启动失败会保留待处理内容，用户可以重试。
- 系统恢复和后台启动不会误用上一条用户消息。
- 当前消息无法确认时，给出更容易理解的提示。

## 为什么

新话题第一次启动 CLI 时，当前飞书消息的 ID 没有传进去。工作流虽然能触发，但首轮执行修改时可能因无法确认消息来源而被拒绝。等待选仓库和连续补充消息时也有相同风险。

## 影响范围

影响飞书新话题首轮、群会话自动创建、仓库/worktree 选择、`/goal` 和等待期间的补充消息。公共的 daemon/worker 输入路径有调整，PTY 与 tmux、各 CLI 共用；没有修改具体 CLI 适配器，也没有配置或数据迁移。恢复会话和系统发起的输入仍不会获得用户操作权限。

本 PR 基于最新 `master`，只有一个修复提交，不包含原功能分支的其他改动。

## 验证

- `pnpm build`：通过
- 相关测试：9 个文件、339 项全部通过
- `pnpm test`：608 个文件、9,571 项全部通过
- 飞书 dogfood：工作流触发、编排、执行均正常，用户已确认

## 关联

这项修复原本也在 #278 中。该独立 PR 合入后，#278 重新基于 `master` 整理时会去掉等价提交，避免重复。
