### PR TITLE
fix(test): 修复 macOS 单测基线

### DIFF
--- a/test/plugin-mcp-gateway.test.ts
+++ b/test/plugin-mcp-gateway.test.ts
@@ -358,8 +358,14 @@ describe('plugin MCP Gateway', () => {
   });
 
   it('rejects a same-UID sibling process that scans the Gateway socket directory', async () => {
-    const socketRoot = join(home, 'socket-root');
-    mkdirSync(socketRoot, { recursive: true });
+    // On macOS keep this mock root directly under /tmp instead of the already
+    // nested per-test HOME. Darwin supports at most 103 bytes for a Unix socket
+    // path; nesting it under HOME produces an unsupported 118-byte fixture and
+    // tests path length rather than the same-UID authentication boundary.
+    const socketRoot = mkdtempSync(join(
+      process.platform === 'darwin' ? '/tmp' : tmpdir(),
+      'botmux-mcp-socket-root-',
+    ));
     vi.stubEnv('TMPDIR', socketRoot);
     const host = await startSessionMcpGatewayHost({
       sessionId: 'same-uid-victim',
@@ -393,6 +399,7 @@ describe('plugin MCP Gateway', () => {
       expect(JSON.parse(result.stdout)).toEqual({ scanned: 1, accepted: 0 });
     } finally {
       await host.close();
+      rmSync(socketRoot, { recursive: true, force: true });
     }
   });
 

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -259,7 +259,13 @@ describe('sandboxedClaudeDataDir (symlink HOME redirect)', () => {
       expect(sandboxedClaudeDataDir('sid-home', join(home, '.claude'), {
         sourceWorkingDir: home,
         dataDir,
-      })).toBe(join(dataDir, 'sandboxes', 'sid-home', 'proj-upper', '.claude'));
+      })).toBe(join(
+        resolveSandboxMountPath(dataDir),
+        'sandboxes',
+        'sid-home',
+        'proj-upper',
+        '.claude',
+      ));
     } finally {
       if (prevHome !== undefined) process.env.HOME = prevHome;
       else delete process.env.HOME;


### PR DESCRIPTION
## 改了什么

- sandbox 单测按 macOS 的 canonical mount root 校验路径，兼容 /var 到 /private/var 的解析。
- MCP Gateway 测试在 macOS 下把 mock socket root 放到短的 /tmp 临时目录，并在测试结束后清理。
- 在 mock 旁补充注释，说明 Darwin Unix socket 103-byte 路径上限，以及原嵌套 fixture 会生成 unsupported 的 118-byte 路径。

## 为什么

这两处失败都是 macOS 测试基线问题：

1. macOS 会把 /var canonicalize 为 /private/var，原断言比较了非 canonical 路径。
2. MCP Gateway 测试把 socket root 嵌套到每测 HOME 下，生成 118-byte socket 路径并触发 Darwin 上限；标准生产 TMPDIR 下实测约 80 bytes，不会触发该问题。

因此本 PR 只调整测试夹具和断言，不修改生产逻辑，也不更新依赖。

## 影响面

- 仅修改 test/sandbox.test.ts 和 test/plugin-mcp-gateway.test.ts。
- 不影响 Linux 生产路径、任何 CLI 适配器、PtyBackend/TmuxBackend 或各类会话。
- 非 macOS 平台继续使用系统 tmpdir；macOS 仅缩短测试 mock 的 socket root。

## 验证

- pnpm exec vitest run --project unit test/sandbox.test.ts test/plugin-mcp-gateway.test.ts test/read-isolation.test.ts
  - 3 files passed；124 passed，9 skipped
- pnpm build
  - 通过
- pnpm test -- --silent=passed-only --reporter=dot
  - 614 files passed，1 skipped；9658 passed，22 skipped
- pnpm daemon:restart
  - botmux-claude、botmux-codex、botmux-dashboard 均 online
