### PR TITLE
fix(ask): askUserQuestion 选完后卡片同步更新为终态

### DIFF
--- a/src/im/lark/ask-card.ts
+++ b/src/im/lark/ask-card.ts
@@ -91,11 +91,21 @@ export async function handleAskCardAction(
     return staleToast(locale);
   }
 
-  // 旧单选即答路径：按钮直接携带 key，调用 tryResolveAsk（单问单选便捷封装）
+  // 旧单选即答路径：按钮直接携带 key，调用 tryResolveAsk（单问单选便捷封装）。
+  // accepted 时直接返回终态卡片，让飞书在回调响应里同步替换——不依赖 onSettle 异步 PATCH
+  // （异步 PATCH 在飞书侧常因回调已返回而被忽略，导致卡片停在未作答态）。
   if (action === ASK_SELECT_ACTION) {
     const selected = asString(value?.key);
     if (!selected) return staleToast(locale);
-    return toastForOutcome(tryResolveAsk({ askId, nonce, selected, by }), locale);
+    const outcome = tryResolveAsk({ askId, nonce, selected, by });
+    if (outcome !== 'accepted') return toastForOutcome(outcome, locale);
+    return settledCardResponse(askId, {
+      kind: 'answered',
+      answers: [[selected]],
+      by,
+      comment: null,
+      timedOut: false,
+    });
   }
 
   if (action === ASK_TOGGLE_ACTION) {
@@ -110,18 +120,53 @@ export async function handleAskCardAction(
   }
 
   // 新 Submit 路径：优先从按钮累积态提交；兼容旧 form_value 回调。
+  // 同 ASK_SELECT_ACTION：accepted 时同步返回终态卡片。
   if (action === ASK_SUBMIT_ACTION) {
     const formValue = data.action?.form_value ?? {};
     if (Object.keys(formValue).length > 0) {
       // 推断问题数量：找最大 qN 的 N+1
       const questionCount = guessQuestionCount(formValue);
       const selections = parseFormSelections(formValue, questionCount);
-      return toastForOutcome(submitAsk({ askId, nonce, by, selections }), locale);
+      const outcome = submitAsk({ askId, nonce, by, selections });
+      if (outcome !== 'accepted') return toastForOutcome(outcome, locale);
+      return settledCardResponse(askId, {
+        kind: 'answered',
+        answers: selections,
+        by,
+        comment: null,
+        timedOut: false,
+      });
     }
-    return toastForOutcome(submitAsk({ askId, nonce, by }), locale);
+    const outcome = submitAsk({ askId, nonce, by });
+    if (outcome !== 'accepted') return toastForOutcome(outcome, locale);
+    const updated = getAskSnapshot(askId);
+    const answers = updated?.selections ?? updated?.questions.map(() => []) ?? [];
+    return settledCardResponse(askId, {
+      kind: 'answered',
+      answers,
+      by,
+      comment: null,
+      timedOut: false,
+    });
   }
 
   return staleToast(locale);
+}
+
+/**
+ * 构建 settled 终态卡片响应，让飞书在卡片回调响应里**同步**替换原卡片。
+ *
+ * 为什么需要这个：ASK_SELECT / ASK_SUBMIT 成功 settle 后，若只返回 `undefined`
+ * （toastForOutcome('accepted')），飞书不会原地更新卡片，只能依赖 settle() 里
+ * dispatcher.onSettle 异步调 updateMessage 去 PATCH——但异步 PATCH 在飞书侧常因
+ * 回调响应已返回而被忽略/时序竞争，导致卡片停在未作答态。
+ * 这里直接返回终态卡片 JSON，飞书在同一次回调响应里替换，与 ASK_TOGGLE / grant
+ * card 的同步替换路径一致。onSettle 仍保留作兜底（双重更新同内容，幂等无害）。
+ */
+function settledCardResponse(askId: string, result: AskResult): Record<string, unknown> | undefined {
+  const updated = getAskSnapshot(askId);
+  if (!updated) return undefined;
+  return JSON.parse(buildAskCard(updated, result)) as Record<string, unknown>;
 }
 
 /**

--- a/test/ask-card.test.ts
+++ b/test/ask-card.test.ts
@@ -205,7 +205,7 @@ describe('buildAskCard', () => {
 });
 
 describe('handleAskCardAction', () => {
-  it('旧单选路径 ask_select：resolves pending ask，返回 undefined（无 toast）', async () => {
+  it('旧单选路径 ask_select：resolves pending ask，返回终态卡片（同步替换）', async () => {
     let askId = '';
     setCardDispatcher({
       async send(ask) {
@@ -239,7 +239,7 @@ describe('handleAskCardAction', () => {
     });
     expect(stale?.toast.content).toContain('失效');
 
-    // 正确 nonce + key → accepted
+    // 正确 nonce + key → accepted，返回终态卡片（飞书同步替换，不依赖 onSettle 异步 PATCH）
     const accepted = await handleAskCardAction({
       operator: { open_id: 'ou_owner' },
       action: {
@@ -251,7 +251,9 @@ describe('handleAskCardAction', () => {
         },
       },
     });
-    expect(accepted).toBeUndefined();
+    expect(accepted).toBeDefined();
+    expect(accepted?.toast).toBeUndefined();
+    expect((accepted as Record<string, any>)?.header?.title?.content).toContain('已结束');
     await expect(promise).resolves.toMatchObject({ kind: 'answered', answers: [['deploy']], by: 'ou_owner' });
   });
 
@@ -555,6 +557,77 @@ describe('handleAskCardAction: ask_submit 路径', () => {
     });
 
     expect(result?.toast.content).toContain('失效');
+  });
+
+  it('ask_submit（form_value 单选）accepted → 返回终态卡片，飞书同步替换', async () => {
+    const captured = await registerTestAsk();
+
+    const result = await handleAskCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: {
+        value: { action: ASK_SUBMIT_ACTION, ask_id: captured.askId, nonce: captured.nonce },
+        form_value: { q0: '0::y' },
+      },
+    });
+
+    // 返回终态卡片（非 undefined、非 toast），飞书在回调响应里同步替换
+    expect(result).toBeDefined();
+    expect(result?.toast).toBeUndefined();
+    const card = result as Record<string, any>;
+    expect(card.header?.title?.content).toContain('已结束');
+    expect(card.header?.template).toBe('green');
+    // 终态卡片包含选中的答案摘要
+    expect(JSON.stringify(card)).toContain('是');
+  });
+
+  it('ask_submit（累积勾选后提交）accepted → 返回终态卡片，含已选状态', async () => {
+    // 注册一个多选问题的 ask
+    let captured: PendingAsk | undefined;
+    setCardDispatcher({
+      async send(ask) {
+        captured = ask;
+        return { messageId: 'om_ask' };
+      },
+    });
+    registerAsk({
+      larkAppId: 'cli_ask',
+      chatId: 'oc_chat',
+      rootMessageId: 'om_root',
+      sessionId: 'sess-1',
+      questions: [
+        { prompt: 'q', multiSelect: true, options: [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }] },
+      ],
+      timeoutMs: 10_000,
+    });
+    await Promise.resolve();
+
+    // 先勾选 a
+    await handleAskCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: {
+        value: {
+          action: ASK_TOGGLE_ACTION,
+          ask_id: captured!.askId,
+          nonce: captured!.nonce,
+          question_index: '0',
+          key: 'a',
+        },
+      },
+    });
+
+    // 再提交（无 form_value，使用累积勾选）
+    const result = await handleAskCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: {
+        value: { action: ASK_SUBMIT_ACTION, ask_id: captured!.askId, nonce: captured!.nonce },
+      },
+    });
+
+    expect(result).toBeDefined();
+    expect(result?.toast).toBeUndefined();
+    const card = result as Record<string, any>;
+    expect(card.header?.title?.content).toContain('已结束');
+    expect(JSON.stringify(card)).toContain('A');
   });
 });
 


### PR DESCRIPTION
## 问题

`askUserQuestion` 选完后，飞书卡片没有更新为终态（仍显示未作答的按钮）。

## 根因

`ASK_SELECT` / `ASK_SUBMIT` 成功 settle 后，`handleAskCardAction` 返回 `undefined`，飞书不原地更新卡片，只能依赖 `settle()` 里 `dispatcher.onSettle` 异步调 `updateMessage` 去 PATCH——但异步 PATCH 在飞书侧常因回调响应已返回而被忽略/时序竞争，导致卡片停在未作答态。

`ASK_TOGGLE` 路径一直是 `return JSON.parse(buildAskCard(...))` 同步替换，所以勾选时卡片会更新、提交时不会。

回归引入点：`de10f83c fix: keep card actions within callback deadline` 把 `card.action.trigger` 改成 `handleCardActionAckSafe`，超时后 `patchTimedOutCardActionResult` 只在返回值含 `card` 时才 PATCH——而 `ask_select`/`ask_submit` accepted 时返回 `undefined`，所以超时后不会 PATCH 卡片。

## 修复

`src/im/lark/ask-card.ts`：`ASK_SELECT` / `ASK_SUBMIT` 在 `accepted` 时直接返回终态卡片 JSON，走飞书回调同步替换路径（与 `ASK_TOGGLE` / grant card 一致）。`onSettle` 异步 PATCH 保留作兜底（双重更新同内容，幂等无害）。

## 测试加固

`test/ask-card.test.ts`（25 → 27 passed）：
- 更新 `ask_select` 用例：验证 accepted 返回终态卡片（标题含已结束、template=green、含答案摘要）
- 新增 `ask_submit`（form_value 单选）accepted → 返回终态卡片
- 新增 `ask_submit`（累积勾选后提交）accepted → 返回终态卡片，含已选状态

## 验证

- `pnpm build` 通过，无类型错误
- `test/ask-card.test.ts` 27 passed
- `test/ask-broker.test.ts` 41 passed