### PR TITLE
fix(adopt): 修复 Codex PID 绑定和重启恢复

### DIFF
--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -337,7 +337,7 @@ function findCliProcess(
   rootPid: number,
   maxDepth: number,
   filterCliId?: CliId,
-): { pid: number; cliId: CliId } | undefined {
+): { pid: number; cliId: CliId; matchedByComm: boolean } | undefined {
   // BFS through the process tree
   let current = [rootPid];
 
@@ -347,8 +347,9 @@ function findCliProcess(
     for (const pid of current) {
       const comm = readComm(pid);
       if (comm) {
+        const commCliId = cliIdForComm(comm, filterCliId);
         const cliId = cliIdFromCommArgv(comm, readCmdline(pid), filterCliId);
-        if (cliId) return { pid, cliId };
+        if (cliId) return { pid, cliId, matchedByComm: commCliId === cliId };
       }
       next.push(...getChildPids(pid));
     }
@@ -722,11 +723,12 @@ export function discoverAdoptableSessions(filterCliId?: CliId): AdoptableSession
       if (filterCliId && match.cliId !== filterCliId) continue;
 
       // npm's `codex` shim can remain as a Node launcher whose argv matches
-      // before generic discovery reaches the native child. Adopt the native
-      // pid so worker-side late transcript binding keeps polling the process
-      // that actually opens rollout files. Other CLIs preserve legacy pid
-      // selection; their wrapper behavior is handled by explicit wrapperCli.
-      const cliPid = match.cliId === 'codex'
+      // before generic discovery reaches the native child. Only follow that
+      // launcher: a process whose comm is already `codex` is the selected CLI
+      // itself and may legitimately have another Codex deeper in its tree.
+      // Other CLIs preserve legacy pid selection; their wrapper behavior is
+      // handled by explicit wrapperCli.
+      const cliPid = match.cliId === 'codex' && !match.matchedByComm
         ? (findLaunchedCliPid(match.pid, 'codex') ?? match.pid)
         : match.pid;
 

--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -359,6 +359,35 @@ function findCliProcess(
   return undefined;
 }
 
+/** Verify a specific pid is still a matching CLI within the pane process tree.
+ * Unlike findCliProcess, this does not stop at an argv-matched launcher. */
+function hasCliProcess(
+  rootPid: number,
+  expectedPid: number,
+  maxDepth: number,
+  filterCliId?: CliId,
+): boolean {
+  let frontier = [rootPid];
+  const seen = new Set<number>();
+
+  for (let depth = 0; depth <= maxDepth && frontier.length > 0; depth++) {
+    const next: number[] = [];
+    for (const pid of frontier) {
+      if (seen.has(pid)) continue;
+      seen.add(pid);
+      if (pid === expectedPid) {
+        const comm = readComm(pid);
+        return comm !== undefined
+          && cliIdFromCommArgv(comm, readCmdline(pid), filterCliId) !== undefined;
+      }
+      next.push(...getChildPids(pid));
+    }
+    frontier = next;
+  }
+
+  return false;
+}
+
 /**
  * Resolve the REAL CLI pid spawned underneath a wrapperCli launcher
  * (e.g. `aiden x claude`, where the launcher forks real Claude Code as a child).
@@ -692,38 +721,46 @@ export function discoverAdoptableSessions(filterCliId?: CliId): AdoptableSession
       // 3b. Filter by CLI type if requested
       if (filterCliId && match.cliId !== filterCliId) continue;
 
+      // npm's `codex` shim can remain as a Node launcher whose argv matches
+      // before generic discovery reaches the native child. Adopt the native
+      // pid so worker-side late transcript binding keeps polling the process
+      // that actually opens rollout files. Other CLIs preserve legacy pid
+      // selection; their wrapper behavior is handled by explicit wrapperCli.
+      const cliPid = match.cliId === 'codex'
+        ? (findLaunchedCliPid(match.pid, 'codex') ?? match.pid)
+        : match.pid;
+
       // 4. Read CLI working directory (Linux: /proc; macOS: lsof)
-      const cwd = readCwd(match.pid);
+      const cwd = readCwd(cliPid);
       if (!cwd) continue;
 
       // 5. Try to read CLI session metadata
       let sessionId: string | undefined;
       let startedAt: number | undefined;
       if (match.cliId === 'claude-code') {
-        const meta = readClaudeSessionMeta(match.pid);
+        const meta = readClaudeSessionMeta(cliPid);
         if (meta) {
           sessionId = meta.sessionId;
           startedAt = meta.startedAt;
         }
       } else if (match.cliId === 'codex') {
-        // Codex has no per-pid state file — bind via the open rollout fd in
-        // /proc. Worker-side has the same probe as a fallback so this is
-        // best-effort: we resolve here so the daemon-side adopt UI shows
-        // an accurate "currently in session X" hint.
-        const rollout = findCodexRolloutByPid(match.pid);
+        // Codex has no per-pid state file — bind via the native process's open
+        // rollout fd. Missing is acceptable: the worker keeps polling cliPid
+        // and attaches when the first post-adopt turn creates/opens the file.
+        const rollout = findCodexRolloutByPid(cliPid);
         if (rollout) sessionId = rollout.cliSessionId;
       } else if (match.cliId === 'coco') {
         // CoCo: probe /proc/<pid>/fd for an open file under the session dir
         // (session.log / traces.jsonl). events.jsonl itself is opened-written-
         // closed per event so it's not reliable on its own. Worker-side
         // re-probes too, so undefined here is acceptable.
-        const cocoSession = findCocoSessionByPid(match.pid);
+        const cocoSession = findCocoSessionByPid(cliPid);
         if (cocoSession) sessionId = cocoSession.sessionId;
       } else if (match.cliId === 'traex') {
         // TRAE: same open-rollout-fd probe as Codex, with a TRAE-specific
         // path matcher (~/.trae/cli/sessions/...). Worker-side re-probes by
         // pid as a fallback, so undefined here is acceptable.
-        const rollout = findTraexRolloutByPid(match.pid);
+        const rollout = findTraexRolloutByPid(cliPid);
         if (rollout) sessionId = rollout.cliSessionId;
       }
 
@@ -731,7 +768,7 @@ export function discoverAdoptableSessions(filterCliId?: CliId): AdoptableSession
       // this only Claude (which has a session JSON with startedAt) shows a real
       // uptime; every other CLI — cursor/codex/coco/gemini… — rendered "未知".
       if (startedAt === undefined) {
-        startedAt = readProcessStartTime(match.pid);
+        startedAt = readProcessStartTime(cliPid);
       }
 
       // 6. Get pane dimensions
@@ -742,7 +779,7 @@ export function discoverAdoptableSessions(filterCliId?: CliId): AdoptableSession
         source: 'tmux',
         tmuxTarget,
         panePid,
-        cliPid: match.pid,
+        cliPid,
         cliId: match.cliId,
         sessionId,
         cwd,
@@ -780,9 +817,10 @@ export function validateTmuxAdoptTarget(tmuxTarget: string, expectedPid: number,
     return false;
   }
 
-  // Search the process tree for the expected CLI PID
-  const match = findCliProcess(panePid, 3, filterCliId);
-  return match !== undefined && match.pid === expectedPid;
+  // Search for the expected PID itself. A Codex Node launcher can match by
+  // argv before the native Codex child, so validating only the first generic
+  // match would reject the native pid returned by discovery.
+  return hasCliProcess(panePid, expectedPid, 6, filterCliId);
 }
 
 

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -1198,8 +1198,9 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
     // 'thread' — that matches the legacy thread-only behaviour.
     const scope: 'thread' | 'chat' = session.scope === 'chat' ? 'chat' : 'thread';
 
-    // Adopt sessions: restore if original CLI is still alive, otherwise close
-    if (session.title?.startsWith('Adopt:') && session.adoptedFrom) {
+    // Persisted metadata is the authoritative adopt marker. The title is
+    // user-editable via /rename and must not change restore semantics.
+    if (session.adoptedFrom) {
       const adopted = session.adoptedFrom as NonNullable<DaemonSession['adoptedFrom']>;
       const validation = adopted.zellijPaneId
         ? (typeof adopted.originalCliPid === 'number' && validateZellijAdoptTarget(adopted.zellijSession ?? '', adopted.zellijPaneId, adopted.originalCliPid, adopted.cliId) ? 'alive' : 'missing')
@@ -1263,7 +1264,8 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
       logger.info(`[${session.sessionId.substring(0, 8)}] Restored adopt session (target: ${adoptTargetLabel(adopted)}, scope: ${scope})`);
       continue;
     }
-    // Adopt sessions without persisted metadata — close (legacy)
+    // Title-only adopt sessions have no target metadata and can only come from
+    // legacy records. They cannot be validated or safely restored.
     if (session.title?.startsWith('Adopt:')) {
       logger.debug(`Closing adopt session ${session.sessionId} (no persisted metadata)`);
       sessionStore.closeSession(session.sessionId);

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -1372,6 +1372,11 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
     // Queued（待办池）会话从没起过 CLI，没有任何后端会话——别去探它，否则 tmux 后端
     // 会把「找不到 backing」误判成僵尸而关掉它。
     if (ds.session.queued) continue;
+    // External /adopt sessions were already validated and re-forked above
+    // against their real tmux/zellij target. They never own Botmux's
+    // deterministic bmx-<sessionId> backing session, so probing that name here
+    // would immediately zombie-close the session we just restored.
+    if (ds.adoptedFrom) continue;
     const backendType = getSessionPersistentBackendType(ds);
     if (!backendType) continue;
     if (!shouldAutoForkOnRestore(backendType)) continue;

--- a/test/session-discovery.test.ts
+++ b/test/session-discovery.test.ts
@@ -322,6 +322,31 @@ describe('discoverAdoptableSessions', () => {
     expect(results[1]!.paneRows).toBe(50);
   });
 
+  it('should bind a Codex rollout opened by the native child below its Node launcher', () => {
+    const cliSessionId = '019f829a-3c55-75c3-b408-bb44fd88c067';
+    setupMocks({
+      paneLines: 'codex:0.0 1000\n',
+      // npm's `codex` shim stays alive as a Node launcher. Its argv matches
+      // Codex before discovery reaches the native child that owns the rollout.
+      commMap: { 1000: 'zsh', 1001: 'node', 1002: 'codex' },
+      cmdlineMap: { 1001: ['node', '/opt/codex/bin/codex'] },
+      childMap: { 1000: [1001], 1001: [1002] },
+      cwdMap: { 1001: '/workspace/project', 1002: '/workspace/project' },
+      dimsMap: { 'codex:0.0': '160 50' },
+      procFdMap: {
+        1002: [`/home/testuser/.codex/sessions/2026/07/21/rollout-2026-07-21T03-00-00-${cliSessionId}.jsonl`],
+      },
+    });
+
+    const results = discoverAdoptableSessions('codex');
+
+    expect(results).toHaveLength(1);
+    // The worker must poll the native pid so it can late-bind a rollout that
+    // is not open yet when `/adopt` first scans the pane.
+    expect(results[0]!.cliPid).toBe(1002);
+    expect(results[0]!.sessionId).toBe(cliSessionId);
+  });
+
   it('should discover seed and relay processes by comm (Claude Code forks)', () => {
     setupMocks({
       paneLines: 'dev:0.0 1000\ndev:1.0 2000\n',
@@ -871,6 +896,19 @@ describe('validateAdoptTarget', () => {
 
     const result = validateAdoptTarget(tmuxTarget('mysession:0.0', 1002, 'aiden'));
     expect(result).toBe(true);
+  });
+
+  it('should validate the native Codex pid below an argv-matched Node launcher', () => {
+    setupMocks({
+      paneLines: 'codex:0.0 1000\n',
+      commMap: { 1000: 'zsh', 1001: 'node', 1002: 'codex' },
+      cmdlineMap: { 1001: ['node', '/opt/codex/bin/codex'] },
+      childMap: { 1000: [1001], 1001: [1002] },
+      cwdMap: {},
+      dimsMap: {},
+    });
+
+    expect(validateAdoptTarget(tmuxTarget('codex:0.0', 1002, 'codex'))).toBe(true);
   });
 
   // Regression: a Cursor agent installed under the generic name `agent` is only

--- a/test/session-discovery.test.ts
+++ b/test/session-discovery.test.ts
@@ -347,6 +347,29 @@ describe('discoverAdoptableSessions', () => {
     expect(results[0]!.sessionId).toBe(cliSessionId);
   });
 
+  it('should keep the outer native Codex pid when it launches a shell with an inner Codex', () => {
+    const outerSessionId = '019f829a-3c55-75c3-b408-bb44fd88c068';
+    const innerSessionId = '019f829a-3c55-75c3-b408-bb44fd88c069';
+    setupMocks({
+      paneLines: 'codex:0.0 1000\n',
+      commMap: { 1000: 'zsh', 1001: 'codex', 1002: 'bash', 1003: 'codex' },
+      childMap: { 1000: [1001], 1001: [1002], 1002: [1003] },
+      cwdMap: { 1001: '/workspace/outer', 1003: '/workspace/inner' },
+      dimsMap: { 'codex:0.0': '160 50' },
+      procFdMap: {
+        1001: [`/home/testuser/.codex/sessions/2026/07/21/rollout-2026-07-21T03-00-00-${outerSessionId}.jsonl`],
+        1003: [`/home/testuser/.codex/sessions/2026/07/21/rollout-2026-07-21T03-01-00-${innerSessionId}.jsonl`],
+      },
+    });
+
+    const results = discoverAdoptableSessions('codex');
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.cliPid).toBe(1001);
+    expect(results[0]!.sessionId).toBe(outerSessionId);
+    expect(results[0]!.cwd).toBe('/workspace/outer');
+  });
+
   it('should discover seed and relay processes by comm (Claude Code forks)', () => {
     setupMocks({
       paneLines: 'dev:0.0 1000\ndev:1.0 2000\n',

--- a/test/session-resume.test.ts
+++ b/test/session-resume.test.ts
@@ -139,6 +139,7 @@ vi.mock('../src/core/session-activity.js', () => ({
 
 import { restoreActiveSessions, resumeSession } from '../src/core/session-manager.js';
 import { restoreUsageLimitRuntimeState, closeSession, forkAdoptWorker } from '../src/core/worker-pool.js';
+import { TmuxBackend } from '../src/adapters/backend/tmux-backend.js';
 import * as sessionStore from '../src/services/session-store.js';
 import { sessionKey } from '../src/core/types.js';
 import type { DaemonSession } from '../src/core/types.js';
@@ -486,6 +487,37 @@ describe('resumeSession', () => {
         expect.objectContaining({ adoptedFrom: s.adoptedFrom }),
         { restoredFromMetadata: true },
       );
+      expect(closeSession).not.toHaveBeenCalledWith(s.sessionId);
+    });
+
+    it('restores a renamed adopt session from metadata without probing a bmx backing session', async () => {
+      daemonConfig.backendType = 'tmux';
+      const s = sessionStore.createSession('oc_adopt_renamed', 'om_adopt_renamed', 'Renamed topic');
+      s.larkAppId = 'app_test';
+      s.scope = 'thread';
+      s.cliId = 'claude-code';
+      s.adoptedFrom = {
+        source: 'tmux',
+        tmuxTarget: 'external:0.0',
+        originalCliPid: 12345,
+        cliId: 'claude-code',
+        cwd: '/tmp/adopted',
+      };
+      sessionStore.updateSession(s);
+      vi.mocked(forkAdoptWorker).mockClear();
+      vi.mocked(TmuxBackend.probeSession).mockClear();
+
+      const map = new Map<string, DaemonSession>();
+      wp.registry = map;
+      await restoreActiveSessions(map);
+
+      expect(sessionStore.getSession(s.sessionId)?.status).toBe('active');
+      expect(map.get(sessionKey('om_adopt_renamed', 'app_test'))?.session.sessionId).toBe(s.sessionId);
+      expect(forkAdoptWorker).toHaveBeenCalledWith(
+        expect.objectContaining({ adoptedFrom: s.adoptedFrom }),
+        { restoredFromMetadata: true },
+      );
+      expect(TmuxBackend.probeSession).not.toHaveBeenCalled();
       expect(closeSession).not.toHaveBeenCalledWith(s.sessionId);
     });
 

--- a/test/session-resume.test.ts
+++ b/test/session-resume.test.ts
@@ -15,13 +15,18 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 
 let tempDir: string;
+const daemonConfig = vi.hoisted(() => ({ backendType: 'pty' as 'pty' | 'tmux' }));
 
 vi.mock('../src/config.js', () => ({
   config: {
     session: {
       get dataDir() { return tempDir; },
     },
-    daemon: { backendType: 'pty', workingDir: '~', workingDirs: ['~'] },
+    daemon: {
+      get backendType() { return daemonConfig.backendType; },
+      workingDir: '~',
+      workingDirs: ['~'],
+    },
   },
 }));
 
@@ -80,7 +85,13 @@ vi.mock('../src/core/worker-pool.js', () => ({
 
 vi.mock('../src/bot-registry.js', () => ({
   getBot: vi.fn(() => ({
-    config: { larkAppId: 'app_test', cliId: 'claude-code', workingDir: '~', workingDirs: ['~'] },
+    config: {
+      larkAppId: 'app_test',
+      cliId: 'claude-code',
+      workingDir: '~',
+      workingDirs: ['~'],
+      get backendType() { return daemonConfig.backendType === 'tmux' ? 'tmux' : undefined; },
+    },
     botName: 'TestBot',
     botOpenId: 'ou_test',
     resolvedAllowedUsers: [],
@@ -107,7 +118,12 @@ vi.mock('../src/adapters/cli/registry.js', () => ({
 }));
 
 vi.mock('../src/adapters/backend/tmux-backend.js', () => ({
-  TmuxBackend: { sessionName: vi.fn((id: string) => `bmx-${id.slice(0, 8)}`), hasSession: vi.fn(() => false) },
+  TmuxBackend: {
+    sessionName: vi.fn((id: string) => `bmx-${id.slice(0, 8)}`),
+    hasSession: vi.fn(() => false),
+    probeSession: vi.fn(() => 'missing'),
+    serverState: vi.fn(() => 'running'),
+  },
 }));
 
 vi.mock('../src/core/session-discovery.js', () => ({
@@ -129,6 +145,7 @@ import type { DaemonSession } from '../src/core/types.js';
 
 beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), 'session-resume-test-'));
+  daemonConfig.backendType = 'pty';
   sessionStore.init();
   wp.registry = null;
   vi.mocked(closeSession).mockClear();
@@ -442,6 +459,34 @@ describe('resumeSession', () => {
         expect.objectContaining({ ownerOpenId: 'ou_adopt_owner' }),
         { restoredFromMetadata: true },
       );
+    });
+
+    it('does not zombie-close a restored external adopt session when the daemon backend is tmux', async () => {
+      daemonConfig.backendType = 'tmux';
+      const s = sessionStore.createSession('oc_adopt_tmux', 'om_adopt_tmux', 'Adopt: test-pane');
+      s.larkAppId = 'app_test';
+      s.scope = 'thread';
+      s.cliId = 'codex';
+      s.adoptedFrom = {
+        source: 'tmux',
+        tmuxTarget: 'external:0.0',
+        originalCliPid: 12345,
+        cliId: 'codex',
+        cwd: '/tmp/adopted',
+      };
+      sessionStore.updateSession(s);
+
+      const map = new Map<string, DaemonSession>();
+      wp.registry = map;
+      await restoreActiveSessions(map);
+
+      expect(sessionStore.getSession(s.sessionId)?.status).toBe('active');
+      expect(map.get(sessionKey('om_adopt_tmux', 'app_test'))?.session.sessionId).toBe(s.sessionId);
+      expect(forkAdoptWorker).toHaveBeenCalledWith(
+        expect.objectContaining({ adoptedFrom: s.adoptedFrom }),
+        { restoredFromMetadata: true },
+      );
+      expect(closeSession).not.toHaveBeenCalledWith(s.sessionId);
     });
 
     it('restores the persisted clean sidecar for a long-running Codex App session', async () => {


### PR DESCRIPTION
## 背景

通过 npm shim 启动 Codex 时，tmux pane 下会同时存在命令行包含 `codex` 的 Node launcher 和真正打开 rollout JSONL 的原生 Codex 子进程。

`/adopt` 的通用进程发现会先按 launcher argv 命中 Codex，并把 launcher PID 交给 worker。由于 launcher 不持有 rollout fd，Codex bridge 无法立即绑定 session，也无法在首个 post-adopt turn 出现后通过 PID late-bind，表现为 tmux 中有回复但飞书收不到结构化对话内容。

另外，daemon restart 恢复 external `/adopt` session 时，会先按真实 external target 校验并 re-fork worker，随后又进入 Botmux 自建 persistent backend 的 zombie 扫描。external adopt session 本来就没有 `bmx-<sessionId>` backing session，因此刚恢复就会被误判为 zombie 并关闭。

## 改动

- Codex `/adopt` 发现命中 launcher 后，使用现有 `findLaunchedCliPid` 继续解析原生 Codex 子进程 PID。
- 使用原生 PID 读取 cwd、启动时间和 rollout session，并把它交给 worker 做后续 late-bind。
- adopt target 校验改为在 pane 进程树中查找并校验指定 PID，避免先命中的 launcher 导致原生 PID 被误判为已退出。
- 增加 Node launcher → 原生 Codex → rollout 的发现与校验回归测试。
- persistent-backend zombie 扫描跳过已经按 external target 校验并 re-fork 的 `/adopt` session，避免 daemon restart 后立即误关。
- 增加 tmux backend 下 external adopt restart 恢复的回归测试。

## 影响面

- 进程解析行为只对 `cliId === 'codex'` 启用；Claude、CoCo、TRAE 等其它 CLI 保持原有 PID 选择逻辑。
- target 校验仍要求 tmux pane、PID 和 CLI 类型同时匹配，只是从“比较第一个通用命中”改为“验证指定 PID 是否位于进程树中”。
- 影响 tmux `/adopt` 和重启后的 adopted target 校验；Botmux 自行创建的新会话不经过该发现路径。
- macOS 通过 `lsof` 查 rollout fd，Linux 继续使用 `/proc/<pid>/fd`，复用既有跨平台 helper。
- 普通 Botmux 自建 tmux/herdr/zellij session 继续执行原有 zombie 检查；仅 `ds.adoptedFrom` external session 跳过第二次 backing-name 检查。

## 验证

```text
pnpm vitest run --project unit \
  test/session-resume.test.ts \
  test/restore-zombie-close.test.ts \
  test/session-discovery.test.ts \
  test/find-launched-cli-pid.test.ts \
  test/codex-coco-pid-discovery.smoke.test.ts

Test Files  5 passed (5)
Tests       106 passed (106)
```

- `pnpm build`：通过，dist audit 通过。
- `git diff --check origin/master...HEAD`：通过。
- macOS live 验证：现有 6 个 tmux Codex pane 均发现成功且 target 校验通过；无需重启 tmux/Codex，重新 `/adopt` 后飞书双向收发通过。
- daemon restart live 验证：同一 external adopt session `cd211812` 重启前后保持 `active`，worker 从 PID `35212` 重建为 `38468`，继续观察 `17:0.0`；日志出现 `Restored adopt session` / `Worker ready`，未再被 `bmx-*` zombie 检查关闭。
