### PR TITLE
fix(worker): 修复 Hermes 等非 type-ahead 适配器首条消息概率性卡住

### DIFF
--- a/src/utils/input-gate.ts
+++ b/src/utils/input-gate.ts
@@ -47,3 +47,50 @@ export function shouldReleaseFirstPromptTimeout(state: {
   if (!state.hasReadyPattern) return true;
   return state.elapsedMs >= state.hardTimeoutMs;
 }
+
+/**
+ * After the ready-gate releases (real SessionStart signal OR the timeout
+ * fallback), the worker settles for PTY quiescence and then decides whether to
+ * mark the prompt ready (which flushes for ALL adapters) vs. just calling
+ * flushPending() (which only flushes for type-ahead adapters). Marking ready is
+ * correct when ANY of these hold:
+ *   - promptReadyAfterSettle         — the real SessionStart/BOTMUX_READY_COMMAND
+ *                                      signal fired (authoritative: input box exists).
+ *   - promptReadyDetectedDuringSettle — the idle detector fired during the
+ *                                      settle (a readyPattern/idle proved readiness).
+ *   - readyPatternSeenDuringHold      — a readyPattern fired WHILE the gate was
+ *                                      holding (markPromptReady was blocked by
+ *                                      readyGate.shouldHold()). The input box
+ *                                      exists; the gate only deferred delivery.
+ *
+ * Pins the Hermes regression: a non-type-ahead adapter that renders its prompt
+ * (❯) during the hold but never fires the SessionStart signal must be marked
+ * ready at settle — otherwise settle calls flushPending(), which bails on
+ * !isPromptReady && !typeAheadAllowed and leaves the first message queued until
+ * the hard timeout (and, before the hard-timeout fix, forever).
+ */
+export function decideSettleMarkReady(state: {
+  promptReadyAfterSettle: boolean;
+  promptReadyDetectedDuringSettle: boolean;
+  readyPatternSeenDuringHold: boolean;
+}): boolean {
+  return state.promptReadyAfterSettle || state.promptReadyDetectedDuringSettle || state.readyPatternSeenDuringHold;
+}
+
+/**
+ * At the first-prompt hard timeout the worker has waited the full cap. For
+ * type-ahead adapters flushPending() drains the queue even while !isPromptReady
+ * (the TUI parks input in its own queue). For non-type-ahead adapters
+ * flushPending() bails on !isPromptReady && !typeAheadAllowed, so the worker
+ * must mark the prompt ready first (markPromptReady() then flushes).
+ * Returns the action the worker must take:
+ *   - 'flush'      — call flushPending() (type-ahead adapters).
+ *   - 'mark-ready' — call markPromptReady() (non-type-ahead adapters).
+ *
+ * Pins the regression where non-type-ahead adapters only logged "forcing
+ * queued message flush" at the hard timeout without actually delivering the
+ * held first message.
+ */
+export function decideHardTimeoutAction(supportsTypeAhead: boolean): 'flush' | 'mark-ready' {
+  return supportsTypeAhead ? 'flush' : 'mark-ready';
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -45,7 +45,7 @@ import { readProcessStartIdentity } from './core/session-marker.js';
 import { drainTranscript, joinAssistantText, trailingAssistantText, findJsonlContainingFingerprint, findJsonlsContainingExactContent, findLatestJsonl, extractLastAssistantTurn, stringifyUserContent, extractTurnStartText, splitTranscriptEventsByCutoff, type TranscriptEvent } from './services/claude-transcript.js';
 import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint } from './services/bridge-turn-queue.js';
 import { shouldSuppressBridgeEmit, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
-import { shouldReleaseFirstPromptTimeout, shouldWriteNow } from './utils/input-gate.js';
+import { decideHardTimeoutAction, decideSettleMarkReady, shouldReleaseFirstPromptTimeout, shouldWriteNow } from './utils/input-gate.js';
 import { canStartInjectionFlush, shouldDeferUserFlush, shouldFlushInjectionsFirst, type PendingInjection } from './core/inject-queue-policy.js';
 import { stripAnsiForLog, tailChars } from './utils/crash-log.js';
 import { CodexUpdateDialogGuard } from './utils/codex-update-dialog.js';
@@ -926,6 +926,15 @@ let isSettlingFirstFlush = false;
  *  ready yet, or flushPending will be blocked by isSettlingFirstFlush and a
  *  later markPromptReady call would return early with the first prompt stranded. */
 let promptReadyDetectedDuringSettle = false;
+/** While the ready-gate is holding, the IdleDetector may still fire on a real
+ *  readyPattern (e.g. Hermes's ❯) — proving the input box exists — but
+ *  markPromptReady() returns early because the gate is armed. Record that the
+ *  pattern was seen so the gate's timeout-fallback settle can mark the prompt
+ *  ready immediately instead of delivering into a !isPromptReady state that
+ *  flushPending() rejects for non-type-ahead adapters. Without this, a Hermes
+ *  spawn that renders ❯ but never fires BOTMUX_READY_COMMAND waits the full
+ *  hard timeout (and previously never delivered at all). */
+let readyPatternSeenDuringHold = false;
 
 /** Wait until the PTY has been quiet for READY_FLUSH_SETTLE_MS (Ink render
  *  drained), capped at READY_FLUSH_SETTLE_CAP_MS, then flush the held prompt.
@@ -938,8 +947,13 @@ function settleThenFlush(startedAtMs: number, promptReadyAfterSettle: boolean): 
   const quietForMs = now - lastPtyOutputAtMs;
   if (quietForMs >= READY_FLUSH_SETTLE_MS || now - startedAtMs >= READY_FLUSH_SETTLE_CAP_MS) {
     isSettlingFirstFlush = false;
-    const shouldMarkPromptReady = promptReadyAfterSettle || promptReadyDetectedDuringSettle;
+    const shouldMarkPromptReady = decideSettleMarkReady({
+      promptReadyAfterSettle,
+      promptReadyDetectedDuringSettle,
+      readyPatternSeenDuringHold,
+    });
     promptReadyDetectedDuringSettle = false;
+    readyPatternSeenDuringHold = false;
     log(`Ready-gate settle done (quiet ${quietForMs}ms); ${shouldMarkPromptReady ? 'marking prompt ready' : 'delivering held first prompt'}`);
     if (shouldMarkPromptReady) {
       markPromptReady();
@@ -4524,6 +4538,11 @@ function markPromptReady(): void {
   // releaseReadyGate() drives flushPending() once the real signal lands, and a
   // later genuine idle then runs this fully. No-op for non-armed gates.
   if (readyGate.shouldHold()) {
+    // A real readyPattern fired while the gate was holding — the input box
+    // exists. Remember it so the gate's timeout-fallback settle can mark the
+    // prompt ready (see settleThenFlush) instead of letting flushPending()
+    // reject the held message for non-type-ahead adapters.
+    readyPatternSeenDuringHold = true;
     log('Idle detected but holding for SessionStart ready signal (startup selector guard)');
     return;
   }
@@ -7314,6 +7333,7 @@ async function spawnCli(
   if (readyFlushSettleTimer) { clearTimeout(readyFlushSettleTimer); readyFlushSettleTimer = null; }
   isSettlingFirstFlush = false;
   promptReadyDetectedDuringSettle = false;
+  readyPatternSeenDuringHold = false;
   // Reset quiescence baseline so the settle measures silence from THIS spawn.
   lastPtyOutputAtMs = Date.now();
   const readyHookAvailable = effectiveReadyHookInstall
@@ -7538,7 +7558,23 @@ async function spawnCli(
     // invoking markPromptReady() would claim the CLI is idle while it's still
     // mid-boot, so flushPending() alone is safer — it respects typeAheadAllowed
     // and drains pendingMessages now.
-    if (cliAdapter?.supportsTypeAhead) flushPending();
+    //
+    // Non-type-ahead adapters (Hermes etc.) flushPending() rejects the held
+    // message while isPromptReady is false — it bails on
+    // `!isPromptReady && !typeAheadAllowed`. The hard cap means we've waited
+    // long enough. By now the ready gate's 45s fallback has already released
+    // the gate (READY_SIGNAL_TIMEOUT_MS < this 90s hard cap) and the post-
+    // release settle has drained, so markPromptReady() proceeds: it sets
+    // isPromptReady and drains the held first prompt. Without this, a spawn
+    // that never fires the ready signal (and whose readyPattern the idle
+    // detector never matched) would hold the first queued message forever —
+    // the previous code only logged "forcing flush" without actually flushing
+    // for non-type-ahead adapters.
+    if (decideHardTimeoutAction(cliAdapter?.supportsTypeAhead === true) === 'flush') {
+      flushPending();
+      return;
+    }
+    markPromptReady();
   };
   setTimeout(() => releaseFirstPromptTimeout(FIRST_PROMPT_TIMEOUT_MS, false), FIRST_PROMPT_TIMEOUT_MS);
 
@@ -7566,6 +7602,7 @@ function killCli(opts: { preservePending?: boolean } = {}): void {
   if (readyFlushSettleTimer) { clearTimeout(readyFlushSettleTimer); readyFlushSettleTimer = null; }
   isSettlingFirstFlush = false;
   promptReadyDetectedDuringSettle = false;
+  readyPatternSeenDuringHold = false;
   stopScreenAnalyzer();
   stopScreenUpdates();
   backend?.kill();

--- a/test/input-gate.test.ts
+++ b/test/input-gate.test.ts
@@ -13,7 +13,7 @@
  * Run: pnpm vitest run test/input-gate.test.ts
  */
 import { describe, it, expect } from 'vitest';
-import { shouldReleaseFirstPromptTimeout, shouldWriteNow } from '../src/utils/input-gate.js';
+import { decideHardTimeoutAction, decideSettleMarkReady, shouldReleaseFirstPromptTimeout, shouldWriteNow } from '../src/utils/input-gate.js';
 
 const base = {
   isPromptReady: false,
@@ -81,5 +81,67 @@ describe('shouldReleaseFirstPromptTimeout', () => {
       elapsedMs: 15_000,
       hardTimeoutMs: 90_000,
     })).toBe(true);
+  });
+});
+
+describe('decideSettleMarkReady', () => {
+  it('marks ready when the real SessionStart signal fired (promptReadyAfterSettle)', () => {
+    expect(decideSettleMarkReady({
+      promptReadyAfterSettle: true,
+      promptReadyDetectedDuringSettle: false,
+      readyPatternSeenDuringHold: false,
+    })).toBe(true);
+  });
+
+  it('marks ready when the idle detector fired during settle', () => {
+    expect(decideSettleMarkReady({
+      promptReadyAfterSettle: false,
+      promptReadyDetectedDuringSettle: true,
+      readyPatternSeenDuringHold: false,
+    })).toBe(true);
+  });
+
+  it('THE HERMES FIX: marks ready when a readyPattern fired while the gate held', () => {
+    // Hermes rendered ❯ (readyPattern) during the hold, but never fired the
+    // SessionStart signal. The gate's timeout fallback releases + settles;
+    // readyPatternSeenDuringHold alone must mark the prompt ready so the
+    // held first message flushes (not dropped by !isPromptReady).
+    expect(decideSettleMarkReady({
+      promptReadyAfterSettle: false,
+      promptReadyDetectedDuringSettle: false,
+      readyPatternSeenDuringHold: true,
+    })).toBe(true);
+  });
+
+  it('does NOT mark ready when nothing proved readiness (timeout fallback, no pattern seen)', () => {
+    // A CLI with no readyPattern that never fired the signal settles without
+    // marking ready — flushPending() delivers for type-ahead adapters only.
+    expect(decideSettleMarkReady({
+      promptReadyAfterSettle: false,
+      promptReadyDetectedDuringSettle: false,
+      readyPatternSeenDuringHold: false,
+    })).toBe(false);
+  });
+
+  it('any single signal is sufficient (OR of all three)', () => {
+    expect(decideSettleMarkReady({
+      promptReadyAfterSettle: false,
+      promptReadyDetectedDuringSettle: true,
+      readyPatternSeenDuringHold: true,
+    })).toBe(true);
+  });
+});
+
+describe('decideHardTimeoutAction', () => {
+  it('type-ahead adapters flush directly at the hard timeout', () => {
+    expect(decideHardTimeoutAction(true)).toBe('flush');
+  });
+
+  it('THE HERMES FIX: non-type-ahead adapters mark ready (then flush) at the hard timeout', () => {
+    // Before this fix, non-type-ahead adapters only logged "forcing flush"
+    // without actually delivering — decideHardTimeoutAction(false) must route
+    // to mark-ready so markPromptReady() sets isPromptReady and flushes the
+    // held first message.
+    expect(decideHardTimeoutAction(false)).toBe('mark-ready');
   });
 });

--- a/test/worker-pipe-initial-screen-order.test.ts
+++ b/test/worker-pipe-initial-screen-order.test.ts
@@ -108,13 +108,45 @@ describe('worker pipe initial screen ordering', () => {
     expect(deferredFlagIdx).toBeGreaterThan(settleGuardIdx);
     expect(deferredFlagIdx).toBeLessThan(readySetIdx);
 
-    expect(settle).toContain('const shouldMarkPromptReady = promptReadyAfterSettle || promptReadyDetectedDuringSettle;');
-    expect(settle.indexOf('promptReadyDetectedDuringSettle = false;')).toBeGreaterThan(
-      settle.indexOf('const shouldMarkPromptReady = promptReadyAfterSettle || promptReadyDetectedDuringSettle;'),
-    );
-    expect(settle.indexOf('markPromptReady();')).toBeGreaterThan(
-      settle.indexOf('const shouldMarkPromptReady = promptReadyAfterSettle || promptReadyDetectedDuringSettle;'),
-    );
+    // THE HERMES FIX (gate fallback path): when markPromptReady fires while the
+    // ready-gate is still holding (a readyPattern like ❯ appeared before the
+    // SessionStart signal), it must record readyPatternSeenDuringHold so the
+    // gate's timeout-fallback settle marks the prompt ready — otherwise a
+    // non-type-ahead adapter's held first message is dropped by flushPending()
+    // on !isPromptReady && !typeAheadAllowed.
+    const holdGuardIdx = mark.indexOf('if (readyGate.shouldHold())');
+    const holdFlagIdx = mark.indexOf('readyPatternSeenDuringHold = true;', holdGuardIdx);
+    expect(holdGuardIdx).toBeGreaterThan(-1);
+    expect(holdFlagIdx).toBeGreaterThan(holdGuardIdx);
+    expect(holdFlagIdx).toBeLessThan(readySetIdx);
+
+    const decideIdx = settle.indexOf('const shouldMarkPromptReady = decideSettleMarkReady({');
+    expect(decideIdx).toBeGreaterThan(-1);
+    // readyPatternSeenDuringHold must be wired into the settle decision.
+    expect(settle.indexOf('readyPatternSeenDuringHold,', decideIdx)).toBeGreaterThan(decideIdx);
+    // Both deferred flags are reset after the decision (so the next spawn is clean).
+    expect(settle.indexOf('promptReadyDetectedDuringSettle = false;', decideIdx)).toBeGreaterThan(decideIdx);
+    expect(settle.indexOf('readyPatternSeenDuringHold = false;', decideIdx)).toBeGreaterThan(decideIdx);
+    expect(settle.indexOf('markPromptReady();', decideIdx)).toBeGreaterThan(decideIdx);
+  });
+
+  it('forces the first prompt for non-type-ahead adapters at the hard timeout', () => {
+    // THE HERMES FIX (hard-timeout path): previously the hard cap only logged
+    // "forcing queued message flush" and flushed for type-ahead adapters only;
+    // non-type-ahead adapters (Hermes) never delivered. The release must now
+    // route non-type-ahead adapters to markPromptReady() (which then flushes).
+    const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+    const fallbackStart = source.indexOf('const releaseFirstPromptTimeout =');
+    const decideIdx = source.indexOf("decideHardTimeoutAction(cliAdapter?.supportsTypeAhead === true)", fallbackStart);
+    const markReadyIdx = source.indexOf('markPromptReady();', decideIdx);
+    const flushIdx = source.indexOf("if (decideHardTimeoutAction(cliAdapter?.supportsTypeAhead === true) === 'flush')", fallbackStart);
+
+    expect(fallbackStart).toBeGreaterThan(-1);
+    expect(decideIdx).toBeGreaterThan(fallbackStart);
+    // The type-ahead flush branch and the non-type-ahead mark-ready path both
+    // exist, in the right order.
+    expect(flushIdx).toBeGreaterThan(fallbackStart);
+    expect(markReadyIdx).toBeGreaterThan(flushIdx);
   });
 
   it('honors a true ready signal that arrives AFTER the timeout fallback (slow cold start)', () => {


### PR DESCRIPTION
## 问题

Hermes（以及理论上任何 `injectsReadyHook: true` + `readyPattern` 但不支持 `type-ahead` 的适配器）概率性首条消息永久卡住：消息发出去后石沉大海，Hermes 界面已 connected 且出现 `❯`，但消息从未投递。

## 根因

Hermes 是目前唯一同时满足 `injectsReadyHook: true` + `readyPattern: /❯/` + 无 `supportsTypeAhead` 的适配器，这是只有它中招的原因。

以日志中的会话为例（`src/worker.ts`）：

1. **spawn** — `shouldArmReadyGate()` 因 `injectsReadyHook=true` 返回 true，gate armed，同时设了 45s `readySignalTimer`。
2. **❯ 出现** — idle detector 命中 readyPattern 调 `markPromptReady()`，但 `readyGate.shouldHold()` 为 true 直接 return，`isPromptReady` 始终是 false。
3. **45s gate 兜底释放** — `releaseReadyGate('signal timeout fallback')` 进 settle，1s 后调 `flushPending()`，但被 `if (!isPromptReady && !typeAheadAllowed) return;` 闸口拦死（Hermes 没开 type-ahead）。
4. **90s 硬超时** — 日志写的是 "forcing queued message flush"，但实际执行的是 `if (cliAdapter?.supportsTypeAhead) flushPending();`——Hermes 不支持 type-ahead，这个 `flushPending` 根本没被调用。

结果：首条消息永久留在 `pendingMessages` 队列。

## 修复（两刀）

**刀 1（治本，45s 即可恢复）**：`markPromptReady()` 被 gate hold 住时记录 `readyPatternSeenDuringHold` 标记；`settleThenFlush` 将其 OR 进 `shouldMarkPromptReady`。这样 gate 兜底释放时，只要 hold 期间见过 `❯`，就直接 `markPromptReady()` → isPromptReady=true → flushPending 正常投递。对 Hermes 来说 45s 就能恢复，不用干等到 90s。

**刀 2（兜底，覆盖所有非 type-ahead 适配器）**：硬超时分支从 `if (supportsTypeAhead) flushPending()` 改为对非 type-ahead 适配器也强制 `markPromptReady()` 投递。此时 gate 已释放（45s < 90s）、settle 已结束，markPromptReady 能正常置 isPromptReady 并 flush。这样即便 readyPattern 一直没出现，90s 也能兜底，不会永久卡死。

两处决策均提取为纯函数（`decideSettleMarkReady` / `decideHardTimeoutAction`）放进 `src/utils/input-gate.ts`，便于单测覆盖。

## 影响面

- 刀 1 只影响「injectsReadyHook + 有 readyPattern + 非 type-ahead」组合，目前只有 Hermes。
- 刀 2 影响所有非 type-ahead 适配器的硬超时分支——之前是只打日志不干活，现在真的会投，属于修复而非行为变更。
- platform 侧不涉及。

## 测试

- 新增 `decideSettleMarkReady` / `decideHardTimeoutAction` 单测（`test/input-gate.test.ts`）。
- 更新 `test/worker-pipe-initial-screen-order.test.ts` 源码断言测试，覆盖两条修复路径（hold 期间 readyPattern 标记 + 硬超时非 type-ahead 投递）。
- input-gate / ready-gate / idle-detector / worker / bridge 等核心单测全过（202 tests）。
- 完整套件仅 e2e 与 4 个环境相关单测失败（干净 master 同样失败，与本改动无关）。