### PR TITLE
feat(permissions): canTalkDaemonCommands — 把选定 daemon 命令从 canOperate 降到 canTalk

### DIFF
--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -1074,8 +1074,11 @@ export interface BotConfig {
    * canTalk（oncall 群成员 / allowedChatGroups / chatGrant / globalGrant / p2pOpen 私聊
    * 等对话放行腿）。与 passthrough 无关——命令仍由 daemon 自己处理，只是准入门槛不同。
    * 解析时归一化（转小写、自动补 `/`、去重），且**只接受 DAEMON_COMMANDS 内的命令**，
-   * 其余条目丢弃。带 handler 内部第二道 owner 闸的命令（/card /term /insight /land）
+   * 其余条目丢弃并 warn。带 handler 内部第二道 owner 闸的命令（/card /term /insight /land）
    * 即使列入也仍会被内部闸拒绝（fail-closed，不视为本字段的适用对象）。
+   * ⚠️ 与 `restrictGrantCommands` 的组合：那个开关在路由里先于本名单生效——开着时
+   * chatGrant/globalGrant 被授权人发任何 slash 命令都被更早的限制闸挡下，本名单
+   * 对他们不生效（oncall / allowedChatGroups / p2pOpen 等其余 canTalk 腿不受影响）。
    * 未配置（undefined）→ 全部 daemon 命令保持 owner-only（现状）。
    */
   canTalkDaemonCommands?: string[];
@@ -1792,15 +1795,19 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
     // canTalkDaemonCommands：daemon 命令的权限例外名单（canOperate → canTalk）。
     // 归一化同 customPassthroughCommands（小写、补 `/`、去重），但语义相反——
     // **只接受 DAEMON_COMMANDS 内的命令**（这里列的是 daemon 自己处理的命令，
-    // 不是透传）；不在集合内的条目（passthrough、拼错的）直接丢弃。
+    // 不是透传）；不在集合内的条目（passthrough、拼错的）丢弃并 warn——丢弃是
+    // fail-closed 安全的，但静默会让配错的 owner 以为已生效。
     let canTalkDaemonCommands: string[] | undefined;
     if (Array.isArray(entry.canTalkDaemonCommands)) {
-      const normalized = entry.canTalkDaemonCommands
+      const strs = entry.canTalkDaemonCommands
         .filter((x: any): x is string => typeof x === 'string')
         .map((x: string) => x.trim().toLowerCase())
-        .map((x: string) => (x.startsWith('/') ? x : `/${x}`))
-        .filter((x: string) => DAEMON_COMMANDS.has(x));
-      const uniq = [...new Set<string>(normalized)];
+        .map((x: string) => (x.startsWith('/') ? x : `/${x}`));
+      const dropped = strs.filter((x: string) => !DAEMON_COMMANDS.has(x));
+      if (dropped.length > 0) {
+        logger.warn(`[bot-registry:${entry.larkAppId}] canTalkDaemonCommands 丢弃非 daemon 命令条目: ${[...new Set(dropped)].join(' ')}（仅接受 daemon 命令，透传命令写 customPassthroughCommands）`);
+      }
+      const uniq = [...new Set<string>(strs.filter((x: string) => DAEMON_COMMANDS.has(x)))];
       if (uniq.length > 0) canTalkDaemonCommands = uniq;
     }
 

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -11,6 +11,7 @@ import type { VoiceConfig } from './services/voice/types.js';
 import { type Brand, sdkDomain, normalizeBrand } from './im/lark/lark-hosts.js';
 import type { BotSkillPolicy, SkillSelector } from './core/skills/types.js';
 import { normalizeStartupCommandList } from './core/startup-commands.js';
+import { DAEMON_COMMANDS } from './core/passthrough-commands.js';
 import { sanitizePerBotEnv } from './core/per-bot-env.js';
 import { normalizeSubstituteMode } from './services/substitute-mode-normalize.js';
 import { normalizePluginIdList } from './core/plugins/ids.js';
@@ -1069,6 +1070,16 @@ export interface BotConfig {
    */
   customPassthroughCommands?: string[];
   /**
+   * Daemon 命令的权限例外名单：列出的命令把权限闸从 canOperate（仅 allowedUsers）降到
+   * canTalk（oncall 群成员 / allowedChatGroups / chatGrant / globalGrant / p2pOpen 私聊
+   * 等对话放行腿）。与 passthrough 无关——命令仍由 daemon 自己处理，只是准入门槛不同。
+   * 解析时归一化（转小写、自动补 `/`、去重），且**只接受 DAEMON_COMMANDS 内的命令**，
+   * 其余条目丢弃。带 handler 内部第二道 owner 闸的命令（/card /term /insight /land）
+   * 即使列入也仍会被内部闸拒绝（fail-closed，不视为本字段的适用对象）。
+   * 未配置（undefined）→ 全部 daemon 命令保持 owner-only（现状）。
+   */
+  canTalkDaemonCommands?: string[];
+  /**
    * Optional per-bot startup commands: slash-command lines the worker types into
    * a freshly spawned CLI right after it's ready, BEFORE the user's first prompt
    * (e.g. `/effort ultracode`, `/model opus`). Sent in order, one submit each,
@@ -1778,6 +1789,21 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
       if (uniq.length > 0) customPassthroughCommands = uniq;
     }
 
+    // canTalkDaemonCommands：daemon 命令的权限例外名单（canOperate → canTalk）。
+    // 归一化同 customPassthroughCommands（小写、补 `/`、去重），但语义相反——
+    // **只接受 DAEMON_COMMANDS 内的命令**（这里列的是 daemon 自己处理的命令，
+    // 不是透传）；不在集合内的条目（passthrough、拼错的）直接丢弃。
+    let canTalkDaemonCommands: string[] | undefined;
+    if (Array.isArray(entry.canTalkDaemonCommands)) {
+      const normalized = entry.canTalkDaemonCommands
+        .filter((x: any): x is string => typeof x === 'string')
+        .map((x: string) => x.trim().toLowerCase())
+        .map((x: string) => (x.startsWith('/') ? x : `/${x}`))
+        .filter((x: string) => DAEMON_COMMANDS.has(x));
+      const uniq = [...new Set<string>(normalized)];
+      if (uniq.length > 0) canTalkDaemonCommands = uniq;
+    }
+
     // tuiSlashAllow：botmux 通用 slash 注入通道（inject_command，见
     // core/slash-inject.ts）的 CLI 原生命令 allowlist。归一化规则与
     // customPassthroughCommands 同款：转小写、自动补前导 `/`、按
@@ -1896,6 +1922,7 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
       // Default is ON, so only explicit false is meaningful/persisted.
       autoGrantRequestCards: entry.autoGrantRequestCards === false ? false : undefined,
       customPassthroughCommands,
+      canTalkDaemonCommands,
       tuiSlashAllow,
       startupCommands,
       env,

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -990,7 +990,11 @@ async function handleConfigCommand(
     let value: unknown;
     switch (spec.kind) {
       case 'stringList': {
-        const arr = parseCustomPassthroughInput(rawValue);
+        // 与 card/config-store 路径（bot-config-store.ts 的 coerce）同口径：优先用
+        // 字段自带的 parseList——canTalkDaemonCommands / startupCommands 的解析规则
+        // 与默认的 parseCustomPassthroughInput 相反或不同，硬编码默认解析器会把
+        // 合法输入静默滤光成"空值"。
+        const arr = (spec.parseList ?? parseCustomPassthroughInput)(rawValue);
         if (arr.length === 0) { await reply(t('cmd.config.value_required', { field: spec.key }, loc)); return; }
         value = arr;
         break;

--- a/src/core/passthrough-commands.ts
+++ b/src/core/passthrough-commands.ts
@@ -74,3 +74,21 @@ export function parseCustomPassthroughInput(raw: string): string[] {
   }
   return [...new Set(out)];
 }
+
+/**
+ * Parse free-text input for `canTalkDaemonCommands` — the inverse filter of
+ * {@link parseCustomPassthroughInput}: after the same normalization (lowercase,
+ * auto `/`), keep ONLY entries that ARE daemon commands. The default stringList
+ * parser (parseCustomPassthroughInput) rejects every daemon command, so wiring
+ * it to this field would silently drop all valid input.
+ */
+export function parseCanTalkDaemonCommandsInput(raw: string): string[] {
+  const out: string[] = [];
+  for (const tok of String(raw ?? '').split(/[\s,]+/)) {
+    const trimmed = tok.trim().toLowerCase();
+    if (!trimmed) continue;
+    const withSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+    if (DAEMON_COMMANDS.has(withSlash)) out.push(withSlash);
+  }
+  return [...new Set(out)];
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -240,7 +240,7 @@ let selfV3BootInstanceId: string | undefined;
  *  VC listener switch, every agent daemon may receive a fenced membership. */
 let selfDaemonLarkAppId: string | undefined;
 let vcMeetingTerminalReconciler: VcMeetingTerminalReconciler | undefined;
-import { isBotMentioned, probeBotOpenId, startLarkEventDispatcher, markForwardFollowupsSessionsReady, writeBotInfoFile, canOperate, evaluateTalk, grantCommandRestriction, isKnownPeerBot, checkRequiredScopes, type RoutingContext, type TalkEvaluation, type DocCommentContext, type EventHandlers } from './im/lark/event-dispatcher.js';
+import { isBotMentioned, probeBotOpenId, startLarkEventDispatcher, markForwardFollowupsSessionsReady, writeBotInfoFile, canOperate, canRunDaemonCommand, evaluateTalk, grantCommandRestriction, isKnownPeerBot, checkRequiredScopes, type RoutingContext, type TalkEvaluation, type DocCommentContext, type EventHandlers } from './im/lark/event-dispatcher.js';
 import { getDocSubscription, listAllDocSubscriptions, listDocSubscriptionsForSession, removeDocSubscription, setDocCommentPollCursor, type DocSubscription } from './services/doc-subs-store.js';
 import { BOT_REPLY_SENTINEL, subscribeDocFile, unsubscribeDocFile, addCommentReaction, hasBotSentinel, isBotAuthoredReply, listDocComments } from './im/lark/doc-comment.js';
 import { learnFromMentions, resolveSender, flushIdentityCacheSync } from './im/lark/identity-cache.js';
@@ -14397,7 +14397,9 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
       // chat-granted users (who only pass canTalk) management commands like
       // /cd /restart /oncall bind. Previously this gate only fired in oncall chats,
       // which left a hole once per-chat grants flow through canTalk.
-      if (!canOperate(larkAppId, chatId, senderOpenId, teamTrustUnionId)) {
+      // canRunDaemonCommand = canOperate ∪（cmd ∈ canTalkDaemonCommands && canTalk）：
+      // bot 可通过名单把选定命令（如 /status）降到 canTalk；未配置时与 canOperate 全等。
+      if (!canRunDaemonCommand(larkAppId, chatId, senderOpenId, teamTrustUnionId, cmd, senderUnionId, chatType)) {
         await sessionReply(anchor, tr('daemon.cmd_allowed_users_only', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
         return;
       }
@@ -15203,7 +15205,9 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
       }
       // canOperate gate for thread-reply daemon commands — required in every chat
       // (see spawn-path gate above). Denies chat-granted users management commands.
-      if (!canOperate(larkAppId, effectiveThreadChatId, threadSenderOpenId, threadTeamTrustUnionId)) {
+      // canRunDaemonCommand：canTalkDaemonCommands 名单内的命令降到 canTalk，
+      // 与 new-topic 路径的统一闸同款（未配置时与 canOperate 全等）。
+      if (!canRunDaemonCommand(larkAppId, effectiveThreadChatId, threadSenderOpenId, threadTeamTrustUnionId, cmd, threadSenderUnionId, ctxChatType)) {
         sessionReply(anchor, tr('daemon.cmd_allowed_users_only', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
         return;
       }

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -1334,6 +1334,33 @@ export function canOperate(
 }
 
 /**
+ * Daemon 命令统一闸：canOperate 恒放行；此外，bot 配置的 `canTalkDaemonCommands`
+ * 名单内的命令降到 canTalk 判定（oncall / allowedChatGroup / grant / p2pOpen 等
+ * 对话放行腿命中即可）。名单外或未配置 → 与 canOperate 完全等价（现状不变）。
+ *
+ * 只作用于 daemon.ts 两条路由的 DAEMON_COMMANDS 统一闸；在统一闸之前特判的命令
+ * （/vc-auth /term）与 handler 内部自带 owner 闸的命令（/card /insight /land）
+ * 不受影响——内部闸仍是最终权威（fail-closed）。
+ *
+ * chatType 省略时 p2pOpen 腿不生效（fail-closed），与 canTalk 语义一致——
+ * 私聊路径的调用点必须把 chatType 传进来。
+ */
+export function canRunDaemonCommand(
+  larkAppId: string,
+  chatId: string | undefined,
+  senderOpenId: string | undefined,
+  senderUnionId: string | undefined,
+  cmd: string,
+  memberUnionId?: string | undefined,
+  chatType?: 'p2p' | 'group',
+): boolean {
+  if (canOperate(larkAppId, chatId, senderOpenId, senderUnionId)) return true;
+  const list = getBot(larkAppId).config.canTalkDaemonCommands;
+  if (!list?.includes(cmd)) return false;
+  return canTalk(larkAppId, chatId, senderOpenId, senderUnionId, memberUnionId, chatType);
+}
+
+/**
  * 入口 A：无权限者 @bot 时弹授权申请卡（正文 @owner，由 owner 处置）。
  * 受 grant-pending 节流：pending 中 / deny 冷却期内静默不发。开放模式（无 owner）兜底不发。
  */

--- a/src/services/bot-config-store.ts
+++ b/src/services/bot-config-store.ts
@@ -17,7 +17,7 @@ import { expandHomePath } from '../utils/working-dir.js';
 import { resolveTeamRoleFile } from '../core/role-resolver.js';
 import { statSync } from 'node:fs';
 import { logger } from '../utils/logger.js';
-import { parseCustomPassthroughInput } from '../core/passthrough-commands.js';
+import { parseCustomPassthroughInput, parseCanTalkDaemonCommandsInput } from '../core/passthrough-commands.js';
 import { parseStartupCommandsInput } from '../core/startup-commands.js';
 import { isReservedPerBotEnvKey, sanitizePerBotEnv } from '../core/per-bot-env.js';
 
@@ -82,6 +82,7 @@ export const CONFIG_FIELDS: readonly ConfigFieldSpec[] = [
   { key: 'p2pMode', configKey: 'p2pMode', kind: 'enum', effect: 'immediate', clearable: true, enumValues: ['thread', 'chat'], hint: '私聊单聊模式 thread|chat；chat=扁平连续会话，thread/unset 回默认（每条 DM 独立会话）' },
   { key: 'maxLiveWorkers', configKey: 'maxLiveWorkers', kind: 'number', effect: 'immediate', clearable: true, hint: '最大常驻会话数；超过后最久未用的会话自动休眠（退出后台进程和 CLI、回收内存，下条消息冷恢复）；unset=默认 30' },
   { key: 'customPassthroughCommands', configKey: 'customPassthroughCommands', kind: 'stringList', effect: 'immediate', clearable: true, hint: '额外放行透传给 CLI 的 slash 命令（逗号/空格分隔，如 /goal /export）；unset 回仅内置白名单' },
+  { key: 'canTalkDaemonCommands', configKey: 'canTalkDaemonCommands', kind: 'stringList', effect: 'immediate', clearable: true, parseList: parseCanTalkDaemonCommandsInput, hint: '把列出的 daemon 命令权限从 canOperate（仅管理员）降到 canTalk（对话放行即可用），如 /status /help；仅认 daemon 命令，透传命令无效；unset 回全部仅管理员' },
   { key: 'startupCommands', configKey: 'startupCommands', kind: 'stringList', effect: 'next-session', clearable: true, parseList: parseStartupCommandsInput, hint: '开会话后、首条消息前自动发给 CLI 的命令（逗号/换行分隔，可带参数，如 /effort ultracode）；unset 回不发' },
   { key: 'env', configKey: 'env', kind: 'json', effect: 'next-session', clearable: true, hint: 'per-bot 环境变量 JSON（如 {"ANTHROPIC_BASE_URL":"…","ANTHROPIC_AUTH_TOKEN":"…"} 让本 bot 走 GLM/第三方服务商，或设 HTTPS_PROXY）；注入到本 bot 的 CLI 进程，下个会话生效；值不显示（脱敏）；unset 清除' },
   { key: 'backendType', configKey: 'backendType', kind: 'enum', effect: 'next-session', clearable: true, enumValues: ['pty', 'tmux', 'herdr', 'zellij', 'riff'], hint: '会话后端类型：pty=本地 PTY 子进程（默认）｜tmux=tmux 会话｜herdr=herdr 终端复用｜zellij=zellij 多路复用｜riff=远程 riff agent 服务；选 riff 时需配置 riff 字段；unset 回 pty' },

--- a/test/can-talk-daemon-commands.test.ts
+++ b/test/can-talk-daemon-commands.test.ts
@@ -1,0 +1,105 @@
+/**
+ * canTalkDaemonCommands：把选定的 daemon 命令的权限闸从 canOperate 降到 canTalk。
+ * - 解析：parseBotConfigsFromText 归一化（小写/补斜杠/仅认 DAEMON_COMMANDS/去重）
+ * - 闸：canRunDaemonCommand = canOperate ∪ (cmd ∈ 名单 && canTalk)
+ * Run: pnpm vitest run test/can-talk-daemon-commands.test.ts
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('@larksuiteoapi/node-sdk', () => {
+  class FakeClient { constructor(public opts: Record<string, unknown>) {} }
+  return { Client: FakeClient };
+});
+
+import { vi } from 'vitest';
+import { parseBotConfigsFromText, registerBot, getBot } from '../src/bot-registry.js';
+import { canRunDaemonCommand, canOperate, canTalk } from '../src/im/lark/event-dispatcher.js';
+import { parseCanTalkDaemonCommandsInput } from '../src/core/passthrough-commands.js';
+
+describe('parseCanTalkDaemonCommandsInput (/botconfig input path)', () => {
+  it('normalizes and keeps ONLY daemon commands (inverse of passthrough parser)', () => {
+    // 默认的 parseCustomPassthroughInput 会拒绝 daemon 命令——本字段必须用自己的解析器
+    expect(parseCanTalkDaemonCommandsInput('status, Help /STATUS')).toEqual(['/status', '/help']);
+    expect(parseCanTalkDaemonCommandsInput('/compact /goal status')).toEqual(['/status']);
+    expect(parseCanTalkDaemonCommandsInput('')).toEqual([]);
+  });
+});
+
+describe('canTalkDaemonCommands parsing', () => {
+  const parse = (v: unknown) =>
+    parseBotConfigsFromText(JSON.stringify([{ larkAppId: 'p1', larkAppSecret: 's', canTalkDaemonCommands: v }]))[0]
+      .canTalkDaemonCommands;
+
+  it('normalizes case and adds leading slash', () => {
+    expect(parse(['STATUS', '/Help'])).toEqual(['/status', '/help']);
+  });
+
+  it('drops entries that are not daemon commands (passthrough or unknown)', () => {
+    // /compact 是 passthrough、/nope 不存在 —— 都不属于 DAEMON_COMMANDS
+    expect(parse(['/status', '/compact', '/nope'])).toEqual(['/status']);
+  });
+
+  it('dedupes', () => {
+    expect(parse(['/status', 'status', '/STATUS'])).toEqual(['/status']);
+  });
+
+  it('undefined when absent / empty / all-invalid', () => {
+    expect(parse(undefined)).toBeUndefined();
+    expect(parse([])).toBeUndefined();
+    expect(parse(['/compact', 42, ''])).toBeUndefined();
+  });
+});
+
+describe('canRunDaemonCommand gate', () => {
+  beforeEach(() => {
+    const bot = registerBot({
+      larkAppId: 'ct1', larkAppSecret: 's', cliId: 'claude-code',
+      allowedUsers: ['ou_owner'],
+    } as any);
+    bot.resolvedAllowedUsers = ['ou_owner'];
+    bot.config.chatGrants = { oc_1: ['ou_guest'] };
+    bot.config.oncallChats = [{ chatId: 'oc_oncall', workingDir: '/tmp' }];
+    bot.config.canTalkDaemonCommands = ['/status', '/help'];
+  });
+
+  it('owner always passes regardless of the list', () => {
+    expect(canRunDaemonCommand('ct1', 'oc_1', 'ou_owner', undefined, '/restart')).toBe(true);
+    expect(canRunDaemonCommand('ct1', 'oc_1', 'ou_owner', undefined, '/status')).toBe(true);
+  });
+
+  it('listed command + canTalk-granted sender passes', () => {
+    // chatGrant 放行 canTalk 但不放行 canOperate —— 名单把 /status 降到 canTalk
+    expect(canTalk('ct1', 'oc_1', 'ou_guest')).toBe(true);
+    expect(canOperate('ct1', 'oc_1', 'ou_guest')).toBe(false);
+    expect(canRunDaemonCommand('ct1', 'oc_1', 'ou_guest', undefined, '/status')).toBe(true);
+  });
+
+  it('listed command + oncall-chat member passes', () => {
+    expect(canRunDaemonCommand('ct1', 'oc_oncall', 'ou_stranger', undefined, '/help')).toBe(true);
+  });
+
+  it('unlisted command + canTalk-granted sender is denied', () => {
+    expect(canRunDaemonCommand('ct1', 'oc_1', 'ou_guest', undefined, '/restart')).toBe(false);
+    expect(canRunDaemonCommand('ct1', 'oc_1', 'ou_guest', undefined, '/cd')).toBe(false);
+  });
+
+  it('listed command + sender without canTalk is denied', () => {
+    expect(canRunDaemonCommand('ct1', 'oc_other', 'ou_stranger', undefined, '/status')).toBe(false);
+  });
+
+  it('no list configured → behaves exactly like canOperate', () => {
+    getBot('ct1').config.canTalkDaemonCommands = undefined;
+    expect(canRunDaemonCommand('ct1', 'oc_1', 'ou_guest', undefined, '/status')).toBe(false);
+    expect(canRunDaemonCommand('ct1', 'oc_1', 'ou_owner', undefined, '/status')).toBe(true);
+  });
+
+  it('p2pOpen leg works only when chatType is passed (fail-closed without)', () => {
+    const bot = getBot('ct1');
+    bot.config.p2pOpen = true;
+    expect(canRunDaemonCommand('ct1', 'p2p_chat', 'ou_p2p_user', undefined, '/status', undefined, 'p2p')).toBe(true);
+    // chatType 省略 → p2pOpen 腿 fail-closed，不放行
+    expect(canRunDaemonCommand('ct1', 'p2p_chat', 'ou_p2p_user', undefined, '/status')).toBe(false);
+    // p2p 里名单外的命令仍拒
+    expect(canRunDaemonCommand('ct1', 'p2p_chat', 'ou_p2p_user', undefined, '/restart', undefined, 'p2p')).toBe(false);
+  });
+});

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -784,6 +784,53 @@ describe('/botconfig skills JSON text command', () => {
   });
 });
 
+describe('/botconfig canTalkDaemonCommands uses the field parser (not the passthrough one)', () => {
+  it('persists daemon commands via the text command path', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-botconfig-ctdc-'));
+    const configPath = join(dir, 'bots.json');
+    process.env.BOTS_CONFIG = configPath;
+    writeFileSync(configPath, JSON.stringify([{
+      larkAppId: 'app-1',
+      larkAppSecret: 'secret-1',
+      cliId: 'codex',
+      allowedUsers: ['ou_sender'],
+    }]));
+    const bot = {
+      botName: 'Codex',
+      config: {
+        larkAppId: 'app-1',
+        larkAppSecret: 'secret-1',
+        cliId: 'codex' as const,
+        allowedUsers: ['ou_sender'],
+        workingDir: '~/projects',
+        workingDirs: ['~/projects'],
+      },
+      resolvedAllowedUsers: ['ou_sender'],
+    };
+    vi.mocked(getBot).mockReturnValue(bot as any);
+
+    try {
+      await handleCommand(
+        '/botconfig',
+        ROOT_ID,
+        // 默认 stringList 解析器（parseCustomPassthroughInput）会拒绝一切 daemon
+        // 命令——本字段必须走 spec.parseList，否则这里被当成"空值"拒绝。
+        makeLarkMessage('/botconfig set canTalkDaemonCommands status /Help', { senderId: 'ou_sender' }),
+        makeDeps(),
+        'app-1',
+      );
+
+      const stored = JSON.parse(readFileSync(configPath, 'utf-8'))[0];
+      expect(stored.canTalkDaemonCommands).toEqual(['/status', '/help']);
+      expect((bot.config as any).canTalkDaemonCommands).toEqual(['/status', '/help']);
+    } finally {
+      delete process.env.BOTS_CONFIG;
+      rmSync(dir, { recursive: true, force: true });
+      vi.mocked(getBot).mockImplementation(defaultGetBot as any);
+    }
+  });
+});
+
 describe('/botconfig string field goes through coerceConfigValue (maxLen)', () => {
   it('rejects an over-long displayName and persists a valid one', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'botmux-botconfig-displayname-'));


### PR DESCRIPTION
## 动机

daemon 命令目前一刀切 owner-only（canOperate），但像 `/status` `/help` 这类低危命令，bot 主人常希望开放给能对话的人（oncall 群成员、被授权人、p2pOpen 私聊用户）。此前没有中间态：要么把人塞进 `allowedUsers`（全权限），要么完全不配名单（open 模式人人 admin）。

## 方案

新增 per-bot 配置 `canTalkDaemonCommands: string[]`：列出的 daemon 命令权限闸从 canOperate 降到 canTalk。未配置时行为与现状完全一致。

```jsonc
{ "canTalkDaemonCommands": ["/status", "/help"] }
```

也支持热配置：`/botconfig set canTalkDaemonCommands /status /help`（immediate 生效）。

## 实现

- **bot-registry**：解析 + 归一化（小写、自动补 `/`、去重、**仅接受 DAEMON_COMMANDS 内的命令**，丢弃条目打 warn）
- **event-dispatcher**：新增 `canRunDaemonCommand()` = canOperate ∪（cmd ∈ 名单 ∧ canTalk）；chatType 省略时 p2pOpen 腿保持 fail-closed
- **daemon**：两条路由（new-topic / thread-reply）的 DAEMON_COMMANDS 统一闸换用 `canRunDaemonCommand`，各自传入正确的 unionId 与 chatType
- **bot-config-store / command-handler**：`/botconfig` 的 stringList 文字命令路径改为尊重字段自带的 `parseList`（默认解析器 `parseCustomPassthroughInput` 刻意拒绝 daemon 命令，硬编码会把本字段的合法输入静默滤光；此修顺带修复 `startupCommands` 在同一路径的同款潜伏 bug），并为本字段提供专用解析器 `parseCanTalkDaemonCommandsInput`（反向过滤：只留 daemon 命令）

## 刻意保守的边界（fail-closed）

- `/vc-auth`、`/term` 在统一闸之前特判，不受名单影响，仍 owner-only
- `/card` `/insight` `/land` 等 handler 内部自带第二道 owner 闸的命令：即使列入名单，内部闸仍是最终权威
- `restrictGrantCommands: true` 时，chatGrant/globalGrant 被授权人被更早的限制闸挡下，本名单对他们不生效（其余 canTalk 腿不受影响）——已写进字段文档

## 已知次要行为（记录在案，未改）

- canTalk 用户在新话题发列入名单的会话类命令（如 `/status`）会走既有的 pre-create 路径产生一个 `worker:null` 会话记录（会话列表污染，无权限影响）——既有路由行为，改 SESSIONLESS 集合影响面大于收益
- 拒绝文案沿用 `daemon.cmd_allowed_users_only`（"仅限 allowedUsers"），对配了名单的 bot 严格说不完全精确，但触发场景极窄（连 canTalk 都没过的发送者）

## 测试

- 新增 `test/can-talk-daemon-commands.test.ts`：13 用例覆盖解析归一化（大小写/补斜杠/非 daemon 条目丢弃/去重/空值）、闸逻辑（owner 恒通过/名单内+canTalk 通过/名单外拒绝/无 canTalk 拒绝/未配置等价 canOperate）、p2p fail-closed、`/botconfig` 输入解析器
- `command-handler.test.ts` 新增 `/botconfig set canTalkDaemonCommands` 文字命令路径回归测试（修复前红、修复后绿）
- 相邻测试面（grant-gates / bot-registry / bot-config-store / event-dispatcher / command-handler / daemon-rename-route / initial-passthrough-ownership）全部通过；仅剩 1 个失败为 master 基线自带的环境相关用例（Terminal URL 端口断言），已对照干净 master 确认非本 PR 回归
- 已过 codex review（read-only 全 diff）：安全面无发现（无越权路径、参数顺序正确、特判命令闸完好），其 MEDIUM 发现（/botconfig 解析器错配）已修复在第二个 commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
