### PR TITLE
fix(dashboard): 修复弹窗内提示浮层被遮挡

### DIFF
--- a/src/dashboard/web/dashboard-components.tsx
+++ b/src/dashboard/web/dashboard-components.tsx
@@ -121,6 +121,16 @@ export function RefreshIconButton(props: Omit<ButtonHTMLAttributes<HTMLButtonEle
   );
 }
 
+/**
+ * Native modal dialogs live in the browser's top layer. A floating element
+ * portaled to document.body therefore stays behind an open dialog regardless
+ * of its z-index. Keep floating UI in the nearest open dialog when there is
+ * one, while retaining document.body as the normal page-level host.
+ */
+export function floatingPortalHost(anchor: Element | null, fallback: HTMLElement): Element {
+  return anchor?.closest('dialog[open]') ?? fallback;
+}
+
 export function InfoTip(props: {
   children: ReactNode;
   label?: string;
@@ -189,7 +199,7 @@ export function InfoTip(props: {
       >
         {props.children}
       </span>,
-      document.body,
+      floatingPortalHost(tipRef.current, document.body),
     )
     : null;
 
@@ -306,7 +316,7 @@ export function OverflowText(props: {
       >
         {props.text}
       </span>,
-      document.body,
+      floatingPortalHost(anchorRef.current, document.body),
     )
     : null;
 

--- a/test/dashboard-tooltip-layering.test.ts
+++ b/test/dashboard-tooltip-layering.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { floatingPortalHost } from '../src/dashboard/web/dashboard-components.js';
+
+describe('dashboard floating tooltip layering', () => {
+  it('portals into the nearest open native dialog', () => {
+    const dialog = {} as HTMLDialogElement;
+    const fallback = {} as HTMLElement;
+    const closest = vi.fn().mockReturnValue(dialog);
+    const anchor = { closest } as unknown as Element;
+
+    expect(floatingPortalHost(anchor, fallback)).toBe(dialog);
+    expect(closest).toHaveBeenCalledWith('dialog[open]');
+  });
+
+  it('uses the page host when the trigger is outside a modal dialog', () => {
+    const fallback = {} as HTMLElement;
+    const anchor = { closest: vi.fn().mockReturnValue(null) } as unknown as Element;
+
+    expect(floatingPortalHost(anchor, fallback)).toBe(fallback);
+    expect(floatingPortalHost(null, fallback)).toBe(fallback);
+  });
+});


### PR DESCRIPTION
## 改了什么

- 新增公共 `floatingPortalHost`：浮层触发点位于已打开的原生 `<dialog>` 内时，将 portal 挂到最近的 dialog；普通页面仍挂到 `document.body`。
- `InfoTip` 与 `OverflowText` 统一使用该宿主选择逻辑。
- 新增回归测试，覆盖弹窗内宿主选择和普通页面 fallback。

## 为什么

原生 `<dialog>` 进入浏览器 top layer 后，挂在 `document.body` 的 Tooltip 即便设置最大 z-index，仍会被 dialog 盖住。Webhook「新建 Webhook」里的问号提示因此不可见。

## 影响面

- 影响：Dashboard 所有原生 dialog 内的问号提示与溢出文本浮层。
- 不影响：普通页面浮层行为、飞书卡片、CLI 适配器、PTY/Tmux 后端及各类会话生命周期。
- 平台：纯浏览器 DOM/React 逻辑，不涉及 macOS/Linux 差异。

## 验证

- `pnpm exec vitest run --project unit test/dashboard-tooltip-layering.test.ts test/dashboard-monitoring-ui.test.ts`：14/14 通过。
- `pnpm build`：通过。
- `pnpm test`：9811/9814 通过；3 个失败均为未修改的 scheduler 本地时区断言（当前 America/Los_Angeles 环境中期望 9、实际 18）。
- 真实 Chromium 实测 Webhook「每次新建群 → 相同事件复用一个群 → 去重字段」：
  - 1440×1000、900×700 均完整显示；
  - Tooltip portal 宿主为打开的 `DIALOG`；
  - hover 命中和视口边界检查通过。

## 截图

修复后实测截图已同步在对应飞书需求话题，供 reviewer 对照。