### PR TITLE
fix(pi): 避免长首条消息触发 tmux argv 限制

### DIFF
--- a/src/adapters/cli/pi.ts
+++ b/src/adapters/cli/pi.ts
@@ -27,6 +27,10 @@ export function createPiAdapter(pathOverride?: string): CliAdapter {
     },
 
     passesInitialPromptViaArgs: true,
+    // tmux reports "command too long" around ~12KB total launch argv on some
+    // deployments, well below OS ARG_MAX. Keep short Pi prompts on argv (legacy
+    // behavior) but route long first messages/cards through writeInput instead.
+    maxInitialPromptArgBytes: 4096,
 
     async writeInput(pty: PtyHandle, content: string) {
       if (pty.pasteText && pty.sendSpecialKeys) {

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -113,8 +113,16 @@ export interface CliAdapter {
   }): string[];
 
   /** When true, the adapter passes the initial prompt via CLI args (e.g. -i).
-   *  The worker skips queuing the prompt for stdin write. */
+   *  The worker skips queuing the prompt for stdin write unless another
+   *  defer condition routes it through the post-start input queue. */
   readonly passesInitialPromptViaArgs?: boolean;
+
+  /** Only meaningful with passesInitialPromptViaArgs. If set, prompts whose
+   *  UTF-8 byte length is GREATER than this adapter-specific limit are not
+   *  baked into launch args; the worker defers them to the normal post-start
+   *  input queue. This guards backend launchers (notably tmux) whose command
+   *  string limit can be much lower than OS ARG_MAX. */
+  readonly maxInitialPromptArgBytes?: number;
 
   /** Only meaningful with passesInitialPromptViaArgs. When true, the CLI
    *  silently drops its initial-prompt launch flag on a RESUME spawn (e.g.

--- a/src/utils/pending-input-queue.ts
+++ b/src/utils/pending-input-queue.ts
@@ -56,6 +56,23 @@ export function shouldDeferArgsBakedDurablePrompt(opts: {
     && opts.dispatchAttempt !== undefined;
 }
 
+/** Some backends (tmux in particular) reject long launch command strings before
+ *  the spawned CLI ever sees argv. For adapters that normally bake the first
+ *  prompt into args, route over-limit prompts through the regular input queue
+ *  instead. The comparison is strictly `>` so a prompt exactly at the adapter's
+ *  declared budget keeps legacy args-baked behavior. */
+export function shouldDeferInitialPromptForArgLimit(opts: {
+  passesInitialPromptViaArgs: boolean;
+  prompt?: string;
+  maxInitialPromptArgBytes?: number;
+}): boolean {
+  if (!opts.passesInitialPromptViaArgs) return false;
+  if (!opts.prompt) return false;
+  const limit = opts.maxInitialPromptArgBytes;
+  if (typeof limit !== 'number' || !Number.isFinite(limit) || limit < 0) return false;
+  return Buffer.byteLength(opts.prompt, 'utf8') > limit;
+}
+
 /** Once either side of a queue boundary is durable, stop this batch and wait
  *  for the next reliable idle edge before writing the following turn. */
 export function shouldStopPendingBatch(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -49,6 +49,7 @@ import {
   pendingInputMayFlush,
   pendingInputAllowsTypeAhead,
   shouldDeferArgsBakedDurablePrompt,
+  shouldDeferInitialPromptForArgLimit,
   shouldStopPendingBatch,
   terminalReleasesDurableTurn,
   type PendingCliInput,
@@ -6107,6 +6108,8 @@ async function spawnCli(
   // Also defer on RESUME for adapters whose initial-prompt launch flag is
   // silently ignored when continuing a session (OpenCode `--prompt` + `-s`):
   // baking it into args would drop the message that triggered the resume.
+  // Finally, defer adapter-declared over-limit prompts to avoid backend command
+  // string limits (tmux "command too long") while preserving short argv prompts.
   const deferInitialPrompt = shouldDeferInitialPromptForStartup({
     hasStartupCommands: !!cfg.startupCommands?.length,
     adoptMode: cfg.adoptMode === true,
@@ -6115,7 +6118,12 @@ async function spawnCli(
     passesInitialPromptViaArgs: cliAdapter.passesInitialPromptViaArgs === true,
     adoptMode: cfg.adoptMode === true,
     dispatchAttempt: cfg.dispatchAttempt,
-  }) || (effectiveResume && cliAdapter.initialPromptArgsIgnoredOnResume === true);
+  }) || (effectiveResume && cliAdapter.initialPromptArgsIgnoredOnResume === true)
+    || shouldDeferInitialPromptForArgLimit({
+      passesInitialPromptViaArgs: cliAdapter.passesInitialPromptViaArgs === true,
+      prompt: cfg.prompt,
+      maxInitialPromptArgBytes: cliAdapter.maxInitialPromptArgBytes,
+    });
   kiroSessionIdCaptureArmed = cfg.cliId === 'kiro-cli' && !effectiveCliSessionId && !willReattachPersistent;
   kiroSessionIdCaptureBuffer = '';
   // Per-bot local read isolation: assemble the Seatbelt profile context (the gate
@@ -8642,7 +8650,12 @@ process.on('message', async (raw: unknown) => {
           passesInitialPromptViaArgs: cliAdapter?.passesInitialPromptViaArgs === true,
           adoptMode: msg.adoptMode === true,
           dispatchAttempt: msg.dispatchAttempt,
-        }) || (msg.adoptMode !== true && lastSpawnEffectiveResume && cliAdapter?.initialPromptArgsIgnoredOnResume === true);
+        }) || (msg.adoptMode !== true && lastSpawnEffectiveResume && cliAdapter?.initialPromptArgsIgnoredOnResume === true)
+          || shouldDeferInitialPromptForArgLimit({
+            passesInitialPromptViaArgs: cliAdapter?.passesInitialPromptViaArgs === true,
+            prompt: msg.prompt,
+            maxInitialPromptArgBytes: cliAdapter?.maxInitialPromptArgBytes,
+          });
         if (msg.prompt && cliAdapter?.passesInitialPromptViaArgs && !deferInitialPrompt && codexBridgeFallbackActive()) {
           // Args-baked first prompts (notably Pi) never pass through the normal
           // 'message' IPC path, so the structured bridge would otherwise see the

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -773,6 +773,7 @@ describe('pi buildArgs', () => {
     expect(args).not.toContain('--tools');
     expect(args.at(-1)).toBe('hello pi');
     expect(adapter.passesInitialPromptViaArgs).toBe(true);
+    expect(adapter.maxInitialPromptArgBytes).toBe(4096);
     expect(adapter.altScreen).toBe(true);
   });
 });

--- a/test/codex-rpc-lifecycle.test.ts
+++ b/test/codex-rpc-lifecycle.test.ts
@@ -248,7 +248,7 @@ describe('shouldQueueInitialPrompt — the worker queuing wiring (exactly-once, 
   it('args-baked prompt (not deferred) → not queued even in paste', () => {
     expect(shouldQueueInitialPrompt({ ...base, passesInitialPromptViaArgs: true })).toBe(false);
   });
-  it('args-baked prompt deferred for startupCommands → queued', () => {
+  it('args-baked prompt deferred (startup commands / arg limit / resume ignore) → queued', () => {
     expect(shouldQueueInitialPrompt({ ...base, passesInitialPromptViaArgs: true, deferInitialPrompt: true })).toBe(true);
   });
 });

--- a/test/initial-prompt-arg-limit.test.ts
+++ b/test/initial-prompt-arg-limit.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createPiAdapter } from '../src/adapters/cli/pi.js';
+import type { PtyHandle } from '../src/adapters/cli/types.js';
+import { shouldQueueInitialPrompt } from '../src/codex-rpc-lifecycle.js';
+import { shouldDeferInitialPromptForArgLimit } from '../src/utils/pending-input-queue.js';
+
+process.env.BOTMUX_TIME_SCALE ??= '0.01';
+
+describe('initial prompt argv byte-limit fallback', () => {
+  it('does not defer when the adapter does not pass initial prompts via args', () => {
+    expect(shouldDeferInitialPromptForArgLimit({
+      passesInitialPromptViaArgs: false,
+      prompt: 'x'.repeat(10_000),
+      maxInitialPromptArgBytes: 4096,
+    })).toBe(false);
+  });
+
+  it('keeps short Pi first prompts on argv for legacy startup behavior', () => {
+    const adapter = createPiAdapter('/bin/pi');
+    const prompt = 'short prompt';
+
+    const deferInitialPrompt = shouldDeferInitialPromptForArgLimit({
+      passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
+      prompt,
+      maxInitialPromptArgBytes: adapter.maxInitialPromptArgBytes,
+    });
+    const args = adapter.buildArgs({
+      sessionId: 'sess-pi',
+      resume: false,
+      initialPrompt: deferInitialPrompt ? undefined : prompt,
+    });
+
+    expect(deferInitialPrompt).toBe(false);
+    expect(args.at(-1)).toBe(prompt);
+    expect(shouldQueueInitialPrompt({
+      hasPrompt: true,
+      rpcEngineActive: false,
+      queuePrompt: false,
+      passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
+      deferInitialPrompt,
+    })).toBe(false);
+  });
+
+  it('routes over-limit Pi first prompts out of spawn args and into the worker queue exactly once', async () => {
+    const adapter = createPiAdapter('/bin/pi');
+    const prompt = '长卡片'.repeat(2500); // > 10KB UTF-8, above Pi's tmux-safe argv budget.
+
+    const deferInitialPrompt = shouldDeferInitialPromptForArgLimit({
+      passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
+      prompt,
+      maxInitialPromptArgBytes: adapter.maxInitialPromptArgBytes,
+    });
+    const args = adapter.buildArgs({
+      sessionId: 'sess-pi-long',
+      resume: false,
+      initialPrompt: deferInitialPrompt ? undefined : prompt,
+    });
+    const shouldQueue = shouldQueueInitialPrompt({
+      hasPrompt: true,
+      rpcEngineActive: false,
+      queuePrompt: false,
+      passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
+      deferInitialPrompt,
+    });
+
+    expect(adapter.maxInitialPromptArgBytes).toBe(4096);
+    expect(Buffer.byteLength(prompt, 'utf8')).toBeGreaterThan(10_000);
+    expect(deferInitialPrompt).toBe(true);
+    expect(args).toEqual(['--session-id', 'sess-pi-long']);
+    expect(args).not.toContain(prompt);
+    expect(shouldQueue).toBe(true);
+
+    const pty = {
+      write: vi.fn(),
+      pasteText: vi.fn(),
+      sendSpecialKeys: vi.fn(),
+    } satisfies PtyHandle;
+    if (shouldQueue) await adapter.writeInput(pty, prompt);
+
+    expect(pty.pasteText).toHaveBeenCalledTimes(1);
+    expect(pty.pasteText).toHaveBeenCalledWith(prompt);
+    expect(pty.sendSpecialKeys).toHaveBeenCalledTimes(1);
+    expect(pty.sendSpecialKeys).toHaveBeenCalledWith('Enter');
+  });
+});

--- a/test/startup-commands.test.ts
+++ b/test/startup-commands.test.ts
@@ -98,9 +98,12 @@ describe('worker.ts startup-commands wiring', () => {
       .toBeGreaterThan(src.indexOf('const willReattachPersistent ='));
   });
 
-  it('defers the args-baked initial prompt when startup commands are present', () => {
+  it('defers args-baked initial prompts for startup commands and adapter argv byte limits', () => {
     // buildArgs gets undefined (not baked) and the init handler queues it instead.
     expect(src).toContain('initialPrompt: deferInitialPrompt ? undefined : (cfg.prompt || undefined)');
+    expect(src).toContain('shouldDeferInitialPromptForArgLimit({');
+    expect(src).toContain('maxInitialPromptArgBytes: cliAdapter.maxInitialPromptArgBytes,');
+    expect(src).toContain('maxInitialPromptArgBytes: cliAdapter?.maxInitialPromptArgBytes,');
     expect(src).toContain('shouldQueueInitialPrompt({');
     expect(src).toContain('passesInitialPromptViaArgs: cliAdapter?.passesInitialPromptViaArgs === true,');
     expect(src).toContain('deferInitialPrompt,');

--- a/test/worker-queue-merge.test.ts
+++ b/test/worker-queue-merge.test.ts
@@ -4,6 +4,7 @@ import {
   pendingInputMayFlush,
   pendingInputAllowsTypeAhead,
   shouldDeferArgsBakedDurablePrompt,
+  shouldDeferInitialPromptForArgLimit,
   shouldStopPendingBatch,
   terminalReleasesDurableTurn,
 } from '../src/utils/pending-input-queue.js';
@@ -57,6 +58,37 @@ describe('mergeQueuedCliInput', () => {
       content: 'human B',
       turnId: 'im-2',
       vcMeetingImTurnOrigin: { ...imOrigin, larkMessageId: 'im-2' },
+    })).toBe(true);
+  });
+});
+
+describe('initial prompt args deferral', () => {
+  it('does not defer queue-input CLIs even when the prompt exceeds the limit', () => {
+    expect(shouldDeferInitialPromptForArgLimit({
+      passesInitialPromptViaArgs: false,
+      prompt: 'x'.repeat(10_000),
+      maxInitialPromptArgBytes: 4096,
+    })).toBe(false);
+  });
+
+  it('keeps args-baked prompts at or below the adapter byte limit on argv', () => {
+    expect(shouldDeferInitialPromptForArgLimit({
+      passesInitialPromptViaArgs: true,
+      prompt: 'abcd',
+      maxInitialPromptArgBytes: 4,
+    })).toBe(false);
+    expect(shouldDeferInitialPromptForArgLimit({
+      passesInitialPromptViaArgs: true,
+      prompt: '你', // 3 UTF-8 bytes, not 1 JS code unit.
+      maxInitialPromptArgBytes: 3,
+    })).toBe(false);
+  });
+
+  it('defers args-baked prompts whose UTF-8 byte length exceeds the adapter limit', () => {
+    expect(shouldDeferInitialPromptForArgLimit({
+      passesInitialPromptViaArgs: true,
+      prompt: '你', // 3 UTF-8 bytes.
+      maxInitialPromptArgBytes: 2,
     })).toBe(true);
   });
 });


### PR DESCRIPTION
## 改了什么

修复 Pi bot 在首条超长消息 / 长飞书卡片启动时，由于 `initialPrompt` 被直接放入 CLI argv 导致 `tmux new-session ... command too long` 的问题。

具体改动：
- 在 `CliAdapter` 增加可选能力字段 `maxInitialPromptArgBytes?: number`。
- 新增 pure helper `shouldDeferInitialPromptForArgLimit(...)`：当 adapter `passesInitialPromptViaArgs=true` 且首条 prompt UTF-8 字节数超过阈值时，将首条 prompt 从 argv 降级到启动后输入队列。
- Pi adapter 配置 `maxInitialPromptArgBytes: 4096`：
  - 短首条消息保持原行为，继续走 `pi --session-id <id> <initialPrompt>`。
  - 长首条消息不再进入 tmux argv，而是通过 `pendingMessages -> writeInput(pasteText + Enter)` 发送。
- worker 的 `spawnCli()` 与 init handler 复用同一个 defer 判断，避免出现启动参数已 defer 但 init 队列未 queue 的首条消息丢失问题。
- 补充测试覆盖短 prompt 保持 argv、10KB+ prompt 不进入 args 且只通过 writeInput 发送一次。

## 为什么

Pi adapter 原先声明 `passesInitialPromptViaArgs: true`，并在 `buildArgs` 中把 `initialPrompt` 直接追加为 positional argv。长飞书卡片作为首条消息时，完整 `tmux new-session ... argv` 会撞上 tmux 自身命令长度限制（本机复现约 12KB 完整 argv 已失败），导致 Pi 会话启动失败。

Claude bot 不受影响，因为 Claude 原本就不把首条正文放 argv，而是启动后通过 `writeInput` 分块输入。

## 影响面

- 主要影响：`passesInitialPromptViaArgs=true` 的 CLI adapter 首条 prompt 启动路径。
- 实际启用阈值的 adapter：当前仅 Pi 配置 `maxInitialPromptArgBytes`，其它 Gemini/OpenCode/MTR/Grok 等未配置该字段，因此行为不变。
- Pi：短首条消息继续走 argv；超长首条消息改走启动后输入队列。
- pending / durable 语义：复用现有 `shouldQueueInitialPrompt(...)` 和 `pendingMessages` 路径，保持首条消息 exactly-once；durable args-baked defer 逻辑未改语义。
- 后端：主要规避 tmux command length 限制；其它 backend 不受负面影响。

## 验证

已执行：

```bash
pnpm vitest run test/initial-prompt-arg-limit.test.ts test/worker-queue-merge.test.ts test/codex-rpc-lifecycle.test.ts test/cli-adapters.test.ts test/startup-commands.test.ts
# 386 passed

pnpm build
# passed
```

也执行过全量：

```bash
pnpm test
```

全量当前有 10 个失败，集中在既有 / 环境相关路径（如 `repo-selection` 临时目录 ENOTEMPTY、symlink/rmSync 目录清理、`v3-distillation-runner` INVALID_MODEL_INPUT），与本次 Pi initialPrompt / worker 队列路径无关。

另外已请 Cursor 做代码 review，结论：通过；P0/P1 无，P2 仅建议未来可选补 total argv budget / worker-backend mock e2e。

## 手动验证建议

如需 live 验证，可部署本 checkout：

```bash
pnpm switch:here && pnpm daemon:restart
```

然后用 Pi bot 转发 / 发送一条 7KB+ 长卡片作为首条消息，预期可正常启动并处理，不再出现 `tmux ... command too long`。
