### PR TITLE
feat(workflow): v3 worker 透传标准 BOTMUX_* 身份 env 给 CLI 子进程

### DIFF
--- a/src/index-daemon.ts
+++ b/src/index-daemon.ts
@@ -22,7 +22,11 @@ dotenvConfig({ path: existsSync(globalEnv) ? globalEnv : '.env' });
 // hook-runner's CLI gate would then mistake the daemon for CLI context and
 // forward every hook event to the daemon itself (/api/hooks/emit) in an
 // infinite self-loop. Scrub unconditionally at boot.
-for (const k of ['BOTMUX_SESSION_ID', 'BOTMUX_LARK_APP_ID', 'BOTMUX_CHAT_ID', 'BOTMUX_CHAT_TYPE', 'BOTMUX_ROOT_MESSAGE_ID']) {
+// BOTMUX_OWNER_OPEN_ID / __OWNER_OPEN_ID additionally leak a stale *identity*:
+// v3 workflow workers spread this process's env into their spawn env, so a
+// restart issued from a bot session would otherwise pin that session's owner
+// onto every workflow CLI child.
+for (const k of ['BOTMUX_SESSION_ID', 'BOTMUX_LARK_APP_ID', 'BOTMUX_CHAT_ID', 'BOTMUX_CHAT_TYPE', 'BOTMUX_ROOT_MESSAGE_ID', 'BOTMUX_OWNER_OPEN_ID', '__OWNER_OPEN_ID']) {
   delete process.env[k];
 }
 // Same vector, session-level CLI data-root pointers (CLAUDE_CONFIG_DIR /

--- a/src/utils/child-env.ts
+++ b/src/utils/child-env.ts
@@ -102,6 +102,9 @@ export const BOTMUX_INJECTED_ENV_KEYS = [
   'BOTMUX_CHAT_TYPE',
   'BOTMUX_LARK_APP_ID',
   'BOTMUX_ROOT_MESSAGE_ID',
+  // Session owner (standard name; `__OWNER_OPEN_ID` above is the legacy
+  // channel). Custom CLI wrappers read it for per-user permission isolation.
+  'BOTMUX_OWNER_OPEN_ID',
   'BOTMUX_TURN_ID',
   'BOTMUX_DISPATCH_ATTEMPT',
   // Loopback port of the owning daemon's agent-facing IPC. Read-isolated CLIs

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -6318,6 +6318,13 @@ async function spawnCli(
   else delete childEnv.BOTMUX_CHAT_TYPE;
   childEnv.BOTMUX_LARK_APP_ID = cfg.larkAppId;
   childEnv.BOTMUX_ROOT_MESSAGE_ID = cfg.rootMessageId;
+  // Session owner under the standard BOTMUX_* name (the riff backend already
+  // exposes it; `__OWNER_OPEN_ID` stays for back-compat). Custom CLI wrappers
+  // use it for per-user permission isolation. Advisory identity only — botmux's
+  // own authz paths (v3 command authority, host.ts) ignore env owner values and
+  // resolve the current-turn caller from turn provenance instead.
+  if (cfg.ownerOpenId) childEnv.BOTMUX_OWNER_OPEN_ID = cfg.ownerOpenId;
+  else delete childEnv.BOTMUX_OWNER_OPEN_ID;
   // NOTE: under read isolation `botmux send` gets this bot's secret from the worker-
   // written cred FILE in its BOT_HOME (send-cred.json, see sendCredFilePath) located
   // via the BOTMUX_LARK_APP_ID above — NOT from the env. The secret is deliberately kept OUT

--- a/src/workflows/v3/contract.ts
+++ b/src/workflows/v3/contract.ts
@@ -16,6 +16,7 @@
 
 import type { CliId } from '../../adapters/cli/types.js';
 import type { V3GoalNode } from './dag.js';
+import type { RunChatBinding } from './grill-state.js';
 import type { V3ArmedAttemptWorkerFence } from './worker-fence.js';
 
 // ─── Manifest (node product declaration) ───────────────────────────────────
@@ -258,6 +259,13 @@ export interface RunNodeRequest {
   outputDir: string;
   /** Already includes the GOAL_ENV keys; pool merges into the worker env. */
   env: Record<string, string>;
+  /** The run's authenticated chat binding (recorded by the daemon at run
+   *  birth).  The pool threads it into the worker init so the CLI child sees
+   *  the standard BOTMUX_* identity env (real chatId / ownerOpenId / …)
+   *  instead of synthetic `v3-chat-*` values — custom CLI wrappers rely on
+   *  `BOTMUX_OWNER_OPEN_ID` for per-user permission isolation.  Absent for
+   *  standalone/dev runs → synthetic values, no owner env. */
+  chatBinding?: RunChatBinding;
   /** Durable pre-fork ownership record. The pool must activate this exact
    * fence before it sends init, and may resolve only after outer `close`. */
   workerFence?: V3ArmedAttemptWorkerFence;

--- a/src/workflows/v3/daemon-run.ts
+++ b/src/workflows/v3/daemon-run.ts
@@ -883,6 +883,8 @@ export async function driveV3Run(runId: string, deps: V3DaemonRunDeps): Promise<
     ...(context.resolvedWorkflowData ? { resolvedWorkflowData: context.resolvedWorkflowData } : {}),
     ...(deps.maxParallel ? { globalConcurrency: deps.maxParallel } : {}),
     ...(deps.cancelSignal ? { cancelSignal: deps.cancelSignal } : {}),
+    // Real BOTMUX_* identity env for worker CLI children (see RunNodeRequest.chatBinding).
+    ...(binding ? { chatBinding: binding } : {}),
   };
 
   const outcome = await runWorkflow(dag, runtimeDeps, opts);

--- a/src/workflows/v3/ephemeral-pool.ts
+++ b/src/workflows/v3/ephemeral-pool.ts
@@ -212,11 +212,19 @@ async function runNodeImpl(
 
   drainWorkerDiagnostics(worker, req);
 
+  // Real chat binding (when the run was born in chat) over synthetic ids: the
+  // worker forwards chatId/chatType/rootMessageId/ownerOpenId into the CLI
+  // child's BOTMUX_* env, which custom CLI wrappers consume for per-user
+  // permission isolation (BOTMUX_OWNER_OPEN_ID is daemon-authenticated at run
+  // birth — a CLI child cannot forge it).  Standalone/dev runs keep synthetic
+  // values and get no owner env at all.
   const init = {
     type: 'init' as const,
     sessionId,
-    chatId: `v3-chat-${req.runId}`,
-    rootMessageId: `v3-root-${req.attemptId}`,
+    chatId: req.chatBinding?.chatId ?? `v3-chat-${req.runId}`,
+    ...(req.chatBinding?.chatType ? { chatType: req.chatBinding.chatType } : {}),
+    rootMessageId: req.chatBinding?.rootMessageId ?? `v3-root-${req.attemptId}`,
+    ...(req.chatBinding?.ownerOpenId ? { ownerOpenId: req.chatBinding.ownerOpenId } : {}),
     workingDir: cwd,
     cliId: req.botSnapshot.cliId,
     cliPathOverride: req.botSnapshot.cliPathOverride,

--- a/src/workflows/v3/runtime.ts
+++ b/src/workflows/v3/runtime.ts
@@ -66,6 +66,7 @@ import {
   type V3ArmedAttemptWorkerFence,
 } from './worker-fence.js';
 import { normalizeGateWaitInput, v3GateWaitId, writePendingWait } from './human-gate.js';
+import type { RunChatBinding } from './grill-state.js';
 import {
   ASK_HUMAN_ERROR_CODE,
   GOAL_ASK_FILE,
@@ -589,6 +590,10 @@ export interface V3RuntimeOptions {
   /** How long the scheduler waits for the original host SDK promise before
    *  detaching and reconciling the still-open durable intent with the same key. */
   hostResponseWaitMs?: number;
+  /** The run's authenticated chat binding — threaded verbatim into every
+   *  RunNodeRequest so worker CLI children get real BOTMUX_* identity env.
+   *  See RunNodeRequest.chatBinding. */
+  chatBinding?: RunChatBinding;
 }
 
 export interface V3PendingGate {
@@ -2714,6 +2719,7 @@ export async function runWorkflow(
       inputsPath,
       outputDir,
       env,
+      ...(opts.chatBinding ? { chatBinding: opts.chatBinding } : {}),
       workerFence,
       timeoutMs: (node.timeoutSec ?? DEFAULT_NODE_TIMEOUT_SEC) * 1000,
       cancelSignal: controller.signal,

--- a/test/tmux-backend-env.test.ts
+++ b/test/tmux-backend-env.test.ts
@@ -69,6 +69,20 @@ describe('buildBotmuxEnvAssignments()', () => {
     expect(out.some(s => s.startsWith('LARK_APP_SECRET='))).toBe(false);
   });
 
+  it('forwards BOTMUX_OWNER_OPEN_ID so custom CLI wrappers see the session owner in tmux panes', () => {
+    // The worker injects the standard owner key alongside the legacy
+    // __OWNER_OPEN_ID; like every injected key it only reaches the pane via
+    // this allowlist.
+    const out = buildBotmuxEnvAssignments({
+      BOTMUX: '1',
+      BOTMUX_OWNER_OPEN_ID: 'ou_owner',
+      PATH: '/usr/bin',
+    });
+    expect(out).toContain('BOTMUX_OWNER_OPEN_ID=ou_owner');
+    // Ownerless sessions (foreign-bot auto-create) don't set it → absent.
+    expect(buildBotmuxEnvAssignments({ BOTMUX: '1' }).some(s => s.startsWith('BOTMUX_OWNER_OPEN_ID='))).toBe(false);
+  });
+
   it('forwards CLAUDE_CODE_RESUME_TOKEN_THRESHOLD so the resume-summary bypass reaches the tmux pane (issue #62)', () => {
     // The worker injects this for claude-code to suppress Claude Code 2.1.x's
     // blocking resume-summary menu. Under the tmux backend it ONLY reaches the

--- a/test/v3-daemon-run.test.ts
+++ b/test/v3-daemon-run.test.ts
@@ -263,6 +263,39 @@ describe('driveV3Run — suspend gate → 发卡 → 点击 redrive', () => {
       rmSync(base, { recursive: true, force: true });
     }
   });
+
+  it('saved-definition run 的 runNode chatBinding 是 envelope 记录的当前触发者（非定义创建者）', async () => {
+    const base = freshBase();
+    try {
+      // The envelope binding for a saved-definition run records the actor who
+      // TRIGGERED this run (library-service pins ownerOpenId=context.actor);
+      // the runtime must hand exactly that principal to worker CLI env.
+      const actorBinding = { ...BINDING, ownerOpenId: 'ou_trigger_actor' };
+      const runDir = seedSavedDefinitionRun(base, 'saved-actor-run', {
+        binding: actorBinding,
+        resolvedContext: { larkAppId: BINDING.larkAppId, chatId: BINDING.chatId },
+      });
+      const seen: unknown[] = [];
+      const shared = stubDeps(base, {
+        makeRunNode: () => async (req) => {
+          seen.push(req.chatBinding);
+          return { status: 'ok', manifestPath: join(req.outputDir, 'manifest.json') };
+        },
+      });
+
+      await driveV3Run('saved-actor-run', shared.deps); // → awaitingGate
+      resolveWait(runDir, 'deploy#001-gate', 'approved', 'ou_user');
+      appendEvent(join(runDir, 'journal.ndjson'), {
+        type: 'gateResolved', nodeId: 'deploy', waitId: 'deploy#001-gate', resolution: 'approved', by: 'ou_user',
+      } as any);
+      const outcome = await driveV3Run('saved-actor-run', shared.deps); // redrive
+
+      expect(outcome.reason).toBe('terminal');
+      expect(seen).toEqual([actorBinding]);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('driveV3Run — 错误路径', () => {

--- a/test/v3-daemon-run.test.ts
+++ b/test/v3-daemon-run.test.ts
@@ -237,6 +237,32 @@ describe('driveV3Run — suspend gate → 发卡 → 点击 redrive', () => {
       rmSync(base, { recursive: true, force: true });
     }
   });
+
+  it('runNode 收到 run 的 chatBinding（真实 BOTMUX_* 身份 env 透传链路）', async () => {
+    const base = freshBase();
+    try {
+      const runDir = seedApprovedRun(base, 'bind-run', { binding: BINDING });
+      const seen: unknown[] = [];
+      const shared = stubDeps(base, {
+        makeRunNode: () => async (req) => {
+          seen.push(req.chatBinding);
+          return { status: 'ok', manifestPath: join(req.outputDir, 'manifest.json') };
+        },
+      });
+
+      await driveV3Run('bind-run', shared.deps); // → awaitingGate
+      resolveWait(runDir, 'deploy#001-gate', 'approved', 'ou_user');
+      appendEvent(join(runDir, 'journal.ndjson'), {
+        type: 'gateResolved', nodeId: 'deploy', waitId: 'deploy#001-gate', resolution: 'approved', by: 'ou_user',
+      } as any);
+      const outcome = await driveV3Run('bind-run', shared.deps); // redrive
+
+      expect(outcome.reason).toBe('terminal');
+      expect(seen).toEqual([BINDING]);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('driveV3Run — 错误路径', () => {

--- a/test/v3-library-service.test.ts
+++ b/test/v3-library-service.test.ts
@@ -514,6 +514,37 @@ describe('Saved Workflow application service', () => {
     expect(existsSync(join(runsDir, 'missing-param-run'))).toBe(false);
   });
 
+  it('global saved workflow triggered by a non-owner pins the CURRENT actor as run owner (owner ≠ actor)', async () => {
+    // Regression pin for the chatBinding→worker-env chain (PR #552): the
+    // ownerOpenId a workflow CLI child will see under BOTMUX_OWNER_OPEN_ID is
+    // the authenticated actor of THIS run, never the definition creator.
+    const created = await createSavedWorkflow(dataDir, {
+      displayName: '全局周报',
+      owner: OWNER,
+      scope: { kind: 'global' },
+      revision: parameterizedRevision(),
+      publish: true,
+    });
+    expect(created.metadata.owner.openId).not.toBe(OTHER.openId);
+
+    const materialized = await instantiatePublishedSavedWorkflow({
+      dataDir,
+      ref: created.metadata.workflowId,
+      context: context(OTHER, 'oc_other_chat'),
+      rawParams: { city: { kind: 'string', value: '上海' } },
+      bots: [bot()],
+      baseDir: runsDir,
+      runId: 'global-actor-run',
+    });
+
+    expect(materialized.envelope.chatBinding).toMatchObject({
+      larkAppId: OTHER.larkAppId,
+      chatId: 'oc_other_chat',
+      ownerOpenId: OTHER.openId,
+    });
+    expect(materialized.envelope.chatBinding?.ownerOpenId).not.toBe(OWNER.openId);
+  });
+
   it.each(['group', 'p2p'] as const)(
     'carries authenticated %s chatType into a Saved Workflow schedule run',
     async (chatType) => {

--- a/test/workflow-v3-ephemeral-pool.test.ts
+++ b/test/workflow-v3-ephemeral-pool.test.ts
@@ -66,6 +66,65 @@ describe('v3 ephemeral pool', () => {
     expect(worker.rawInputs).toEqual([buildGoalCommand(req)]);
   });
 
+  it('threads the run chat binding into worker init so CLI children get real BOTMUX_* identity env', async () => {
+    const worker = new ScriptedWorker();
+    const factory = factoryFor(worker);
+    const req: RunNodeRequest = {
+      ...request(),
+      chatBinding: {
+        larkAppId: 'cli_app',
+        chatId: 'oc_real_chat',
+        chatType: 'group',
+        rootMessageId: 'om_real_root',
+        ownerOpenId: 'ou_real_owner',
+      },
+    };
+    const pool = createEphemeralPool({
+      factory,
+      workerPath: '/tmp/worker.js',
+      quiesceMs: 1,
+      resolveLarkAppSecret: () => 'secret',
+    });
+
+    const promise = pool.runNode(req);
+    await waitFor(() => factory.lastOpts !== undefined);
+    await worker.waitForInit();
+
+    expect(worker.init).toMatchObject({
+      chatId: 'oc_real_chat',
+      chatType: 'group',
+      rootMessageId: 'om_real_root',
+      ownerOpenId: 'ou_real_owner',
+    });
+
+    worker.emitExit(0);
+    await promise;
+  });
+
+  it('keeps synthetic chat ids and no owner for standalone runs without a chat binding', async () => {
+    const worker = new ScriptedWorker();
+    const factory = factoryFor(worker);
+    const req = request();
+    const pool = createEphemeralPool({
+      factory,
+      workerPath: '/tmp/worker.js',
+      quiesceMs: 1,
+      resolveLarkAppSecret: () => 'secret',
+    });
+
+    const promise = pool.runNode(req);
+    await waitFor(() => factory.lastOpts !== undefined);
+    await worker.waitForInit();
+
+    expect(worker.init?.chatId).toBe(`v3-chat-${req.runId}`);
+    expect(worker.init?.rootMessageId).toBe(`v3-root-${req.attemptId}`);
+    expect('chatType' in worker.init).toBe(false);
+    expect('ownerOpenId' in worker.init).toBe(false);
+
+    worker.emitExit(0);
+    await promise;
+  });
+
   it('passes frozen sandbox policy to the goal-mode worker init', async () => {
     const worker = new ScriptedWorker();
     const factory = factoryFor(worker);


### PR DESCRIPTION
## 背景

workflow v3 ephemeral worker spawn 的 CLI 子进程此前只能看到合成上下文（`BOTMUX_CHAT_ID=v3-chat-<runId>`、`BOTMUX_ROOT_MESSAGE_ID=v3-root-<attemptId>`），且完全没有会话 owner 身份。自定义 CLI wrapper 需要 `BOTMUX_OWNER_OPEN_ID` 做用户级权限隔离，在 workflow 节点里无值可用。

需求来源：申晗在飞书群转交的整理版 prompt（om_x100b69366ac490b4b48174794e415ab）。

## 与原 prompt 的两处机制修正

1. **spawn-env 注入是死路径**：原 prompt 建议在 `ephemeral-pool` 的 `factory.spawn` env 里追加 `BOTMUX_CHAT_ID` 等键。实际上 worker 构建 CLI childEnv 时会用 init 消息里的 `cfg.chatId/chatType/rootMessageId` **无条件覆盖**这些键（`worker.ts` childEnv 注入段），spawn env 里除 `BOTMUX_OWNER_OPEN_ID` 外全部会被合成值清零。因此本 PR 走 **init 消息穿真实值**（init 类型本来就有可选 `ownerOpenId`/`chatType` 字段），worker 既有注入逻辑自然生效，单一注入点。
2. **`BOTMUX_OWNER_OPEN_ID` 在普通 PTY/tmux 会话里也不存在**：源码里只有 riff 后端注入它（`worker.ts` riff sessionEnv），PTY/tmux 会话只有内部命名 `__OWNER_OPEN_ID`（已在 live 会话 env 实测确认）。原 prompt 把它当"标准 env"的前提不成立。本 PR 在 worker childEnv 补上标准命名（保留 `__OWNER_OPEN_ID` 兼容），使它在**所有会话类型**（普通 PTY/tmux/sandbox/riff/workflow）真正标准化——wrapper 在普通会话里同样需要它。

## 改动点

- `src/workflows/v3/contract.ts` — `RunNodeRequest` 增加 `chatBinding?: RunChatBinding`（复用 grill-state 既有类型，不重复定义）
- `src/workflows/v3/runtime.ts` — `V3RuntimeOptions.chatBinding`，构建 req 时穿线
- `src/workflows/v3/daemon-run.ts` — 从 run envelope 的已认证 `binding` 传入 opts（cli-run 手动/dev 路径故意不传 → 合成值语义不变）
- `src/workflows/v3/ephemeral-pool.ts` — init 用真实 `chatId/chatType/rootMessageId/ownerOpenId`；无 binding 时保持合成值且**不注入 owner 键**（缺省即缺省，不用空字符串，wrapper fallback 判据=键不存在）
- `src/worker.ts` — PTY/tmux childEnv：`if (cfg.ownerOpenId) childEnv.BOTMUX_OWNER_OPEN_ID = …; else delete`（镜像 chatType 的 else-delete 防继承残留）
- `src/utils/child-env.ts` — `BOTMUX_INJECTED_ENV_KEYS` 增加该键（tmux/zellij per-pane env(1) 注入按**精确键名**遍历该列表，不加就到不了 pane；同时被 server-global scrub / pane unset 清单覆盖）
- `src/index-daemon.ts` — boot scrub 增加 `BOTMUX_OWNER_OPEN_ID` + `__OWNER_OPEN_ID`。后者是**既存同类泄漏面**：普通会话 CLI env 就带 `__OWNER_OPEN_ID`，会话内 `botmux restart` 会经 pm2 烙进 daemon env，再经 workflow worker 的 `...process.env` spread 漏给所有节点 CLI

## Owner 语义（二审修正）

`ownerOpenId` = **本次 run 的已认证触发者（actor）**，对所有来源一致：

- grill 出生的 run：发起 `/workflow` 的当前轮调用者（turn provenance 认证）
- saved definition 触发的 run：`library-service` 物化时写入 `context.actor.openId`——**当前触发者，不是定义创建者**。这正确匹配"按本次执行用户做权限隔离"的需求语义，与 `context.initiatorOpenId` 一致
- 回归测试钉死：global 定义被非 owner 触发时 envelope `chatBinding.ownerOpenId` = actor（v3-library-service），且 runtime 把 envelope 记录的 actor 原样交给 runNode（v3-daemon-run）

初版描述误写为"定义创建者"（沿袭原需求 prompt 的注意事项），二审核对 `library-service.ts` 实际代码后修正。

## 安全评估

- `BOTMUX_OWNER_OPEN_ID` 是**咨询性身份**（daemon 认证后写入 envelope，CLI 子进程无法伪造自己看到的值），但 botmux 自身鉴权路径均不消费它：v3 命令鉴权（`cli-daemon-command-authority.ts`）与 `host.ts` 都显式忽略 env owner，走 turn provenance。注入不新增提权面。
- **workflow C0 安全门不受影响**：节点内 `botmux send`/`ask`/`restart` 等 chat-facing/mutating 命令仍被 `BOTMUX_WORKFLOW=1` 门（root allowlist default-deny）拒绝，真实 chatId 不会使它们变得可用。
- **实际新增的数据可见面**：节点内**只读 introspection**（`botmux history`/`quoted`/`bots` 等 allowlist 放行命令）此前拿合成 chatId 必然空手而归，现在能命中发起会话的真实数据。该可见面与"run 由该 chat 的已认证 actor 发起"一致（同一 actor 在普通会话里的 CLI 本就可见同样数据），属有意变更。

## 影响面

- **会话类型**：普通话题/群会话（PTY+tmux）多一个 childEnv 键，行为无变化；riff 已有该键（语义一致）；v3 workflow worker init 值变真实（`cfg.chatId` 在 worker 内仅 env 注入两处消费，已枚举确认无其它耦合）；standalone/dev run 语义不变。
- **合成 id 依赖**：`v3-chat-*`/`v3-root-*` 全仓只有 ephemeral-pool 注入点自身引用，无下游依赖。
- **跨平台**：纯 env/字符串逻辑，无平台分支。

## Wrapper 口径（二审澄清）

本 PR 覆盖的"自定义 CLI wrapper"= **`cliPathOverride` 指向的可执行文件 / PATH 上替换的 CLI**（v3 `BotSnapshot` 冻结并经 init 透传 `cliPathOverride`，wrapper 即节点启动的 CLI 本体，直接读子进程 env）。

`BotConfig.wrapperCli` 字段**不在本 PR 范围**：v3 `BotSnapshot` 目前不冻结该字段、init 也不传，配置了 `wrapperCli` 的 bot 在 workflow 节点本就不经 wrapper 启动（既有现状，非本 PR 引入）。若线上需求方用的是该字段，需另开 PR 把 `wrapperCli` 加入 snapshot 序列化/校验 + init 透传并补测试。

## 测试

- 新增 6 测试：ephemeral-pool binding→init 真实值 / 无 binding→合成值+无 owner 键；daemon-run→runNode 端到端 chatBinding 穿线（grill 出生 + saved-definition owner≠定义创建者两条）；library-service global 定义非 owner 触发钉 owner=actor；tmux `buildBotmuxEnvAssignments` 转发新键
- `pnpm build` ✅
- 定向：workflow-v3-ephemeral-pool(19)+tmux-backend-env(56)+v3-daemon-run(52)+v3-library-service(15)+child-env(9)+tmux-env-isolation(16)+v3-runtime(33) = 200 全绿
- 全量（head c9d76337 实跑）：9816 passed / 9 failed——失败清单与改动前完全一致，全部为本机已知环境基线（时区 scheduler×2+schedule-card×1、v3-distillation×6），与本 diff 零交集

## Live 验证步骤（部署后）

1. 触发一个 chat 出生的 workflow，在节点 goal 里让 CLI 执行 `echo $BOTMUX_OWNER_OPEN_ID`（写进产物）——应为**本次触发者** open_id；`$BOTMUX_CHAT_ID` 为真实 chat
2. 在**普通 botmux 会话**里执行 `botmux restart`，重启后 `tr '\0' '\n' < /proc/<daemon pid>/environ | grep -E 'OWNER_OPEN_ID'` 应为空（workflow 内 restart 会被 C0 门拒绝，不能用来验证）
3. standalone `botmux workflow run` 的节点 CLI 内 `BOTMUX_OWNER_OPEN_ID` 应不存在（wrapper 走 fallback）
4. （可选）workflow 节点内 `botmux send` 仍应被拒绝退出码 2——确认 C0 门不因真实 chatId 而松动
