### PR TITLE
feat(session): 新增安全原子自关闭接口

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -329,6 +329,7 @@ When a CLI spawns inside a botmux session it automatically gets
 - `botmux quoted <message_id>` — when the user @ed the bot via Lark's quote-reply UI, fetch the quoted message on demand
 - `botmux bots list` — discover bots + their `open_id`s
 - `botmux schedule` — manage scheduled tasks
+- `botmux session close-self` — safely and atomically close only the current logical session after its checkpoint/receipt; it accepts no target session ID and must be the caller's final action
 - `botmux-workflow` — orchestrate bounded multi-step work with natural language or `/workflow`, then save successful runs for reuse
 
 These capabilities are wired via `--append-system-prompt` and Skill

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ CLI 进入 botmux 会话时自动获得 `~/.botmux/bin` 在 PATH 中，以及一
 - `botmux quoted <message_id>` — 用户用引用 UI @ 机器人时，按需读取被引用的那条消息
 - `botmux bots list` — 查询当前群聊的机器人及 open_id
 - `botmux schedule` — 增删改查定时任务
+- `botmux session close-self` — 在 checkpoint / 回执完成后安全、原子地关闭当前逻辑会话；不接受目标 session ID，调用后应立即退出
 - `botmux-workflow` — 用自然语言或 `/workflow` 编排有界多步任务；成功 run 可保存为 Saved Workflow 并复用
 
 这些能力通过 `--append-system-prompt` 注入和 Skill 描述自动引导 agent 使用。Skill + CLI 的组合相比 Anthropic 官方 Telegram channel 那套 MCP 方案：CLI 启动不用做 MCP 握手、不占用工具列表 token，且对 Claude Code / Codex / Cursor / Gemini / OpenCode / Antigravity / GitHub Copilot 通用 —— 只要 CLI 能读 system prompt 跑 shell 命令就行，不依赖任何 MCP 协议支持。

--- a/docs-site/docs/en/cli-commands.md
+++ b/docs-site/docs/en/cli-commands.md
@@ -42,3 +42,12 @@ Session info is inferred automatically from ancestor-process markers, so the age
 | `botmux history [--limit N]` | Pull the session history (JSON) |
 | `botmux quoted <message_id>` | Pull a single quoted message (JSON) |
 | `botmux schedule add/list/remove/pause/resume/run` | Manage scheduled tasks |
+| `botmux session close-self` | Safely and atomically close the current logical session (no target ID accepted) |
+
+### Safe self-close
+
+`botmux session close-self` is available only inside a running Botmux session. It proves the caller with an action-scoped capability for the current turn, and the daemon resolves the one matching session from that capability. The request carries and accepts no `sessionId`, bot ID, or other target selector.
+
+The daemon first commits a synchronous logical-close barrier (persist `closed`, revoke authority, and remove the route), then returns success and asynchronously cleans up the worker, backend bridge, and subscriptions. The next message in the same chat or thread therefore creates a fresh Botmux session and provider session instead of resuming the closed provider session. Adopted sessions only detach the Botmux bridge; the user's tmux pane is not killed.
+
+Call it only after the result checkpoint, receipt, or handoff has been persisted. A successful call must be the caller's final action. An exact retry of an already committed request returns `alreadyClosed` without repeating close side effects.

--- a/docs-site/docs/zh/cli-commands.md
+++ b/docs-site/docs/zh/cli-commands.md
@@ -42,3 +42,12 @@ session 信息通过祖先进程标记自动推断，agent 直接调：
 | `botmux history [--limit N]` | 拉会话历史（JSON） |
 | `botmux quoted <message_id>` | 拉被引用的单条消息（JSON） |
 | `botmux schedule add/list/remove/pause/resume/run` | 管理定时任务 |
+| `botmux session close-self` | 安全、原子地关闭当前逻辑会话（不接受目标 ID） |
+
+### 安全自关闭
+
+`botmux session close-self` 只在运行中的 Botmux 会话内可用。命令以当前轮次的 action-scoped capability 证明调用方身份，由 daemon 从 capability 反查唯一会话；请求体不携带也不接受 `sessionId`、机器人 ID 或其他目标选择器。
+
+daemon 会先同步提交逻辑关闭屏障（持久化 `closed`、撤销能力、移除路由），再返回成功并异步清理 worker、后端桥接和订阅。因此同一群聊或话题的下一条消息会创建全新的 Botmux 会话和 provider 会话，不会 resume 已关闭的 provider session。接入（adopt）的会话只断开 Botmux 桥接，不会杀掉用户自己的 tmux pane。
+
+只应在结果 checkpoint、回执或交接信息已经持久化后调用；成功调用后必须立即退出，不再发送消息或执行其他副作用。完全相同的已提交重试会返回 `alreadyClosed`，不会重复执行关闭副作用。

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@
  *   botmux list --plain   — plain table output (for piping / scripts)
  *   botmux delete <id>    — close a session by ID prefix
  *   botmux delete all     — close all active sessions
+ *   botmux session close-self — atomically close only the calling session
  *   botmux autostart enable|disable|status — manage boot-time autostart (launchd / user systemd / Windows Task Scheduler)
  *   botmux whiteboard status|enable|disable|current|list|read|update|write — local project whiteboard
  */
@@ -30,6 +31,7 @@ import { createRequire } from 'node:module';
 import { randomBytes } from 'node:crypto';
 import { validateWorkingDir } from './core/working-dir.js';
 import { resolveSessionContext } from './core/session-marker.js';
+import { deriveSessionSelfCloseCapability } from './core/session-self-close.js';
 import { resolveBotmuxDataDir } from './core/data-dir.js';
 import { dashboardSecretPath } from './core/dashboard-secret.js';
 import { parseDispatchBotSpec, buildDispatchMessages, buildRepoPrimeText, buildReportContent, eligibleAutoMentionAliases, offTopicSubBotTopic, resolveReportTarget, resolveSendTarget } from './core/dispatch.js';
@@ -4506,6 +4508,7 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
   schedule run <id>                    标记立即执行
 
 飞书消息（在 CLI 会话内自动推断 session）:
+  session close-self                   安全、原子地关闭当前逻辑会话（不接受目标 ID）
   send [content]                       发消息到当前话题（支持 stdin / --content-file）
        --images <path>                 内联图片（可重复）
        --files <path>                  附件（可重复）
@@ -7897,6 +7900,97 @@ async function cmdHook(cliId: string): Promise<void> {
   process.exit(0);
 }
 
+// ─── botmux session close-self ────────────────────────────────────────────────
+//
+// The daemon commits a logical barrier before it acknowledges this final-action
+// command. Identity comes only from the current managed-turn origin; no target
+// session id is accepted or sent.
+async function cmdSessionCloseSelf(args: string[]): Promise<void> {
+  if (args.length > 0) {
+    console.error('用法: botmux session close-self');
+    console.error('close-self 只能关闭当前会话，不接受 sessionId 或其他目标参数。');
+    process.exitCode = 2;
+    return;
+  }
+
+  const context = findAncestorSessionContext();
+  const sessionId = context?.sessionId ?? process.env.BOTMUX_SESSION_ID;
+  const larkAppId = process.env.BOTMUX_LARK_APP_ID;
+  if (!sessionId || !larkAppId) {
+    console.error('✗ 无法定位当前 botmux 会话；close-self 只能在运行中的会话内调用。');
+    process.exitCode = 1;
+    return;
+  }
+
+  const origin = readManagedOriginCapability(
+    resolveDataDir(),
+    sessionId,
+    process.env.BOTMUX_SEND_RELAY,
+  );
+  const turnId = origin?.turnId ?? context?.turnId ?? process.env.BOTMUX_TURN_ID;
+  const envAttempt = Number(process.env.BOTMUX_DISPATCH_ATTEMPT);
+  const dispatchAttempt = origin?.dispatchAttempt
+    ?? context?.dispatchAttempt
+    ?? (Number.isSafeInteger(envAttempt) && envAttempt > 0 ? envAttempt : undefined);
+  if (!origin || !turnId) {
+    console.error('✗ 当前轮次的 self-close capability 缺失或已过期。');
+    process.exitCode = 1;
+    return;
+  }
+
+  // Select only the owning daemon. Descriptor discovery is preferred on the
+  // host; isolated sessions use the port injected by their own worker. Never
+  // fall back to the first online daemon in a multi-bot deployment.
+  let discoveredPort: number | undefined;
+  try { discoveredPort = findDaemon(larkAppId)?.ipcPort; } catch { /* masked registry */ }
+  const ipcPort = resolveDaemonIpcPort(
+    discoveredPort,
+    process.env.BOTMUX_DAEMON_IPC_PORT,
+  );
+  if (!ipcPort) {
+    console.error('✗ 找不到当前会话所属的 botmux daemon。');
+    process.exitCode = 1;
+    return;
+  }
+
+  const init = {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      capability: deriveSessionSelfCloseCapability(origin.capability),
+      turnId,
+      ...(dispatchAttempt !== undefined
+        ? { dispatchAttempt }
+        : {}),
+    }),
+  } satisfies RequestInit;
+
+  try {
+    // This endpoint intentionally never uses the trusted-host secret. Its only
+    // authority is the current turn's action-domain-separated capability.
+    const res = await fetch(`http://127.0.0.1:${ipcPort}/api/sessions/self/close`, init);
+    const body = await res.json().catch(() => ({})) as {
+      ok?: boolean;
+      accepted?: boolean;
+      sessionId?: string;
+      alreadyClosed?: boolean;
+      error?: string;
+    };
+    if (res.ok && body.ok && body.accepted) {
+      console.log(
+        body.alreadyClosed
+          ? `✓ 会话已经关闭: ${body.sessionId ?? sessionId}`
+          : `✓ 会话关闭已提交: ${body.sessionId ?? sessionId}`,
+      );
+      return;
+    }
+    console.error(`✗ self-close 被拒绝: ${body.error ?? `HTTP ${res.status}`}`);
+  } catch (err: any) {
+    console.error(`✗ self-close 请求失败: ${err?.message ?? err}`);
+  }
+  process.exitCode = 1;
+}
+
 // ─── botmux session-ready ─────────────────────────────────────────────────────
 //
 // Claude 家族（claude/seed）的 SessionStart hook 客户端。Claude 在 TUI 输入框
@@ -9038,6 +9132,16 @@ switch (command) {
   case 'suspend': await cmdSuspend(); break;
   case 'slash':   await cmdSlash(); break;
   case 'cd':      await cmdCd(); break;
+  case 'session': {
+    const sub = process.argv[3] ?? '';
+    if (sub !== 'close-self') {
+      console.error('用法: botmux session close-self');
+      process.exitCode = 2;
+      break;
+    }
+    await cmdSessionCloseSelf(process.argv.slice(4));
+    break;
+  }
   case 'term-link': await cmdTermLink(process.argv.slice(3)); break;
   case 'schedule': await cmdSchedule(process.argv[3] ?? '', process.argv.slice(4)); break;
   case 'ask': {

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -64,7 +64,19 @@ import { readGlobalConfig } from '../global-config.js';
 import { normalizeChatReplyMode, setChatReplyMode, type ChatReplyMode } from '../services/chat-reply-mode-store.js';
 import * as chatFirstSeenStore from '../services/chat-first-seen-store.js';
 import * as scheduler from './scheduler.js';
-import { listActiveSessions, findActiveBySessionId, closeSession, getActiveSessionsRegistry, transferSession, deliverWriteLinkCardToOwners, forkWorker, suspendWorker, killWorker } from './worker-pool.js';
+import {
+  cleanupCommittedSessionSelfClose,
+  closeSession,
+  commitSessionSelfClose,
+  deliverWriteLinkCardToOwners,
+  findActiveBySessionId,
+  forkWorker,
+  getActiveSessionsRegistry,
+  killWorker,
+  listActiveSessions,
+  suspendWorker,
+  transferSession,
+} from './worker-pool.js';
 import { listOnlineDaemons } from '../utils/daemon-discovery.js';
 import { getChatMode, replyMessage, sendMessage, resolveUnionIdFromOpenId, listThreadMessages, listChatMessages, listChatBotMembers, getUserProfile, getUserProfileStrict, resolveAllowedUsersWithMap, type ChatBotMember } from '../im/lark/client.js';
 import { parseApiMessage, cardContentHasUpgradeFallback, resolveMergedCardContent } from '../im/lark/message-parser.js';
@@ -127,6 +139,10 @@ import { validateSlashInjection } from './slash-inject.js';
 import { validateRoleLibraryPath } from './role-library.js';
 import { repinSessionWorkingDir } from './session-cwd.js';
 import { authorizeSessionScopedIpc } from './daemon-ipc-session-auth.js';
+import {
+  authorizeSessionSelfClose,
+  recordCommittedSessionSelfClose,
+} from './session-self-close.js';
 import type { CliId } from '../adapters/cli/types.js';
 import { updateSessionTitle } from './session-title.js';
 import { requestAgentSessionRename } from './session-rename.js';
@@ -233,6 +249,10 @@ function routeHasNarrowUntrustedAuth(method: string, pathname: string): boolean 
   // forge readiness or an ask for that session.
   if (method === 'POST' && pathname === '/api/session-ready') return true;
   if (method === 'POST' && pathname === '/api/asks') return true;
+  // Session self-close accepts only an action-domain-separated capability and
+  // derives its target from the matching live origin. The handler never trusts
+  // loopback, host HMAC, or a caller-selected session id as self identity.
+  if (method === 'POST' && pathname === '/api/sessions/self/close') return true;
   // botmux slash / botmux cd（角色切换）：合法调用方是会话内的 CLI 自身，沙箱 /
   // 读隔离下读不到 host secret。两个 handler 内验证该会话的 rotating per-turn
   // capability 并绑定到 URL 里的 sessionId（同 /api/asks 姿势）——capability 只
@@ -318,6 +338,84 @@ ipcRoute('GET', '/api/sessions/:sessionId', (_req, res, params) => {
   const closed = sessionStore.listSessions().find(s => s.sessionId === params.sessionId);
   if (closed) return jsonRes(res, 200, { session: composeRowFromClosed(closed) });
   jsonRes(res, 404, { error: 'not_found' });
+});
+
+ipcRoute('POST', '/api/sessions/self/close', async (req, res) => {
+  const body = await readJsonBody<Record<string, unknown>>(req)
+    .catch(() => ({} as Record<string, unknown>));
+  const authorization = authorizeSessionSelfClose(body, listActiveSessions());
+  if (!authorization.ok) {
+    logger.warn(
+      `[session-self-close] capability=denied reason=${authorization.reason}`,
+    );
+    return jsonRes(res, 403, {
+      ok: false,
+      accepted: false,
+      error: 'self_close_denied',
+    });
+  }
+
+  if (authorization.alreadyClosed) {
+    const stored = sessionStore.getSession(authorization.sessionId);
+    logger.info(
+      `[session-self-close] capability=idempotent sessionId=${authorization.sessionId} `
+      + `larkAppId=${stored?.larkAppId ?? '-'} scope=${stored?.scope ?? '-'} `
+      + 'barrier=committed alreadyClosed=true',
+    );
+    return jsonRes(res, 200, {
+      ok: true,
+      accepted: true,
+      sessionId: authorization.sessionId,
+      alreadyClosed: true,
+    });
+  }
+
+  const ds = authorization.session;
+  let committed: ReturnType<typeof commitSessionSelfClose>;
+  try {
+    committed = commitSessionSelfClose(ds);
+  } catch (err: any) {
+    logger.error(
+      `[session-self-close] capability=accepted sessionId=${ds.session.sessionId} `
+      + `larkAppId=${ds.larkAppId} scope=${ds.scope} barrier=failed `
+      + `reason=${err?.message ?? err}`,
+    );
+    return jsonRes(res, 503, {
+      ok: false,
+      accepted: false,
+      error: 'close_barrier_failed',
+    });
+  }
+
+  recordCommittedSessionSelfClose(authorization.claim, committed.sessionId);
+  logger.info(
+    `[session-self-close] capability=accepted sessionId=${committed.sessionId} `
+    + `larkAppId=${ds.larkAppId} scope=${ds.scope} barrier=committed`,
+  );
+
+  // Do not kill the caller while its acceptance response is still being
+  // handed to the loopback socket. `finish` fires after res.end() has flushed
+  // to the kernel; `close` covers an abruptly disconnected caller. The guard
+  // keeps backend/lifecycle cleanup single-shot.
+  let cleanupStarted = false;
+  const startCleanup = (): void => {
+    if (cleanupStarted) return;
+    cleanupStarted = true;
+    void cleanupCommittedSessionSelfClose(committed).catch((err: any) => {
+      logger.error(
+        `[session-self-close] sessionId=${committed.sessionId} `
+        + `cleanup=failed reason=${err?.message ?? err}`,
+      );
+    });
+  };
+  res.once('finish', startCleanup);
+  res.once('close', startCleanup);
+  jsonRes(res, 200, {
+    ok: true,
+    accepted: true,
+    sessionId: committed.sessionId,
+    alreadyClosed: false,
+  });
 });
 
 ipcRoute('POST', '/api/sessions/:sessionId/close', async (_req, res, params) => {

--- a/src/core/session-self-close.ts
+++ b/src/core/session-self-close.ts
@@ -1,0 +1,168 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+import type { DaemonSession } from './types.js';
+
+const SELF_CLOSE_CAPABILITY_DOMAIN = 'botmux:session:self-close:v1';
+const SELF_CLOSE_RECEIPT_TTL_MS = 5 * 60_000;
+const SELF_CLOSE_RECEIPT_LIMIT = 1024;
+const HEX_CAPABILITY_RE = /^[a-f0-9]{64}$/i;
+
+export interface SessionSelfCloseClaim {
+  capability: string;
+  turnId: string;
+  dispatchAttempt?: number;
+}
+
+interface SessionSelfCloseReceipt extends SessionSelfCloseClaim {
+  sessionId: string;
+  committedAt: number;
+}
+
+export type SessionSelfCloseAuthorization =
+  | { ok: true; alreadyClosed: false; claim: SessionSelfCloseClaim; session: DaemonSession }
+  | { ok: true; alreadyClosed: true; claim: SessionSelfCloseClaim; sessionId: string }
+  | {
+      ok: false;
+      reason:
+        | 'target_not_allowed'
+        | 'capability_missing'
+        | 'capability_malformed'
+        | 'turn_missing'
+        | 'dispatch_attempt_malformed'
+        | 'origin_unproven'
+        | 'origin_ambiguous'
+        | 'turn_mismatch'
+        | 'dispatch_attempt_mismatch';
+    };
+
+const committedReceipts = new Map<string, SessionSelfCloseReceipt>();
+
+/**
+ * Domain-separate self-close authority from the generic rotating origin token.
+ * The daemon retains only the generic token on the live session; the CLI derives
+ * this action-specific proof locally, and no other IPC endpoint accepts it.
+ */
+export function deriveSessionSelfCloseCapability(originCapability: string): string {
+  return createHmac('sha256', originCapability)
+    .update(SELF_CLOSE_CAPABILITY_DOMAIN)
+    .digest('hex');
+}
+
+function capabilityDigest(capability: string): string {
+  return createHash('sha256').update(capability).digest('hex');
+}
+
+function capabilitiesEqual(left: string, right: string): boolean {
+  if (!HEX_CAPABILITY_RE.test(left) || !HEX_CAPABILITY_RE.test(right)) return false;
+  return timingSafeEqual(Buffer.from(left, 'hex'), Buffer.from(right, 'hex'));
+}
+
+function parseClaim(body: Record<string, unknown>): SessionSelfCloseAuthorization | SessionSelfCloseClaim {
+  // A self-close request has no caller-selectable target. Reject target-like
+  // fields instead of silently ignoring them so a session can never believe it
+  // closed a sibling because a legacy/admin-shaped payload happened to succeed.
+  if ('sessionId' in body || 'targetSessionId' in body || 'target' in body) {
+    return { ok: false, reason: 'target_not_allowed' };
+  }
+  if (typeof body.capability !== 'string') {
+    return { ok: false, reason: 'capability_missing' };
+  }
+  if (!HEX_CAPABILITY_RE.test(body.capability)) {
+    return { ok: false, reason: 'capability_malformed' };
+  }
+  if (typeof body.turnId !== 'string' || body.turnId.length === 0 || body.turnId.length > 256) {
+    return { ok: false, reason: 'turn_missing' };
+  }
+  if (body.dispatchAttempt !== undefined
+    && (typeof body.dispatchAttempt !== 'number'
+      || !Number.isSafeInteger(body.dispatchAttempt)
+      || body.dispatchAttempt < 1)) {
+    return { ok: false, reason: 'dispatch_attempt_malformed' };
+  }
+  return {
+    capability: body.capability,
+    turnId: body.turnId,
+    ...(body.dispatchAttempt !== undefined
+      ? { dispatchAttempt: body.dispatchAttempt as number }
+      : {}),
+  };
+}
+
+function pruneReceipts(now: number): void {
+  for (const [key, receipt] of committedReceipts) {
+    if (now - receipt.committedAt > SELF_CLOSE_RECEIPT_TTL_MS) {
+      committedReceipts.delete(key);
+    }
+  }
+  while (committedReceipts.size > SELF_CLOSE_RECEIPT_LIMIT) {
+    const oldest = committedReceipts.keys().next().value as string | undefined;
+    if (!oldest) break;
+    committedReceipts.delete(oldest);
+  }
+}
+
+/**
+ * Resolve the caller exclusively from an action-scoped capability. The request
+ * never supplies a session id, bot id, chat id, or route key. A committed
+ * duplicate is the sole replay exception: it returns the prior receipt without
+ * executing lifecycle side effects again.
+ */
+export function authorizeSessionSelfClose(
+  body: Record<string, unknown>,
+  activeSessions: Iterable<DaemonSession>,
+  now: number = Date.now(),
+): SessionSelfCloseAuthorization {
+  const parsed = parseClaim(body);
+  if ('ok' in parsed) return parsed;
+  const claim = parsed;
+  pruneReceipts(now);
+
+  const receipt = committedReceipts.get(capabilityDigest(claim.capability));
+  if (receipt) {
+    if (receipt.turnId !== claim.turnId
+      || receipt.dispatchAttempt !== claim.dispatchAttempt) {
+      return { ok: false, reason: 'origin_unproven' };
+    }
+    return {
+      ok: true,
+      alreadyClosed: true,
+      claim,
+      sessionId: receipt.sessionId,
+    };
+  }
+
+  const matches: DaemonSession[] = [];
+  for (const session of activeSessions) {
+    const origin = session.managedTurnOrigin;
+    if (!origin?.capability || !origin.turnId) continue;
+    const expected = deriveSessionSelfCloseCapability(origin.capability);
+    if (capabilitiesEqual(claim.capability, expected)) matches.push(session);
+  }
+  if (matches.length === 0) return { ok: false, reason: 'origin_unproven' };
+  if (matches.length !== 1) return { ok: false, reason: 'origin_ambiguous' };
+
+  const session = matches[0];
+  const origin = session.managedTurnOrigin!;
+  if (origin.turnId !== claim.turnId) return { ok: false, reason: 'turn_mismatch' };
+  if (origin.dispatchAttempt !== claim.dispatchAttempt) {
+    return { ok: false, reason: 'dispatch_attempt_mismatch' };
+  }
+  return { ok: true, alreadyClosed: false, claim, session };
+}
+
+export function recordCommittedSessionSelfClose(
+  claim: SessionSelfCloseClaim,
+  sessionId: string,
+  now: number = Date.now(),
+): void {
+  pruneReceipts(now);
+  committedReceipts.set(capabilityDigest(claim.capability), {
+    ...claim,
+    sessionId,
+    committedAt: now,
+  });
+  pruneReceipts(now);
+}
+
+export function __testOnly_resetSessionSelfCloseReceipts(): void {
+  committedReceipts.clear();
+}

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1456,15 +1456,142 @@ function armWorkerKillBackstop(w: ChildProcess, label: string, sigtermMs: number
   });
 }
 
-// ─── Idempotent session close (dashboard IPC) ───────────────────────────────
+// ─── Session close paths ────────────────────────────────────────────────────
+
+export interface CommittedSessionSelfClose {
+  sessionId: string;
+  session: DaemonSession;
+}
 
 /**
- * Idempotent close: kill worker if alive, mark Session status='closed' + closedAt,
- * publish session.exited (if a live worker was killed) and session.update
- * (if the persistence row transitioned to closed).
- *
- * Calling this on an unknown sessionId, an already-closed session, or a session
- * whose worker died asynchronously must still resolve with `{ ok: true }`.
+ * Synchronously commit the self-close barrier. There is deliberately no
+ * `await` in this function: once it returns, routing cannot find the old
+ * DaemonSession, persistence says `closed`, and lifecycle observers have seen
+ * the same transition. Slow worker/backend/subscription cleanup happens only
+ * after the HTTP response is handed off.
+ */
+export function commitSessionSelfClose(ds: DaemonSession): CommittedSessionSelfClose {
+  const sessionId = ds.session.sessionId;
+  if (findActiveBySessionId(sessionId) !== ds) {
+    throw new Error('self-close session lost active ownership before commit');
+  }
+  if (!sessionStore.getSession(sessionId)) {
+    throw new Error('self-close session is missing its persistence row');
+  }
+
+  restartCounts.delete(sessionId);
+  recordUsageForDaemonSession(ds);
+  // Persistence is synchronous. Complete it before mutating the live route so
+  // an ENOSPC/EACCES failure leaves the caller retryable instead of creating a
+  // route-less but non-durable half-close. No inbound message can interleave in
+  // this same event-loop turn.
+  const previousStatus = ds.session.status;
+  const previousClosedAt = ds.session.closedAt;
+  const previousDashboardAttachments = ds.session.dashboardAttachments;
+  const previousQueuedAttachments = ds.session.queuedAttachments;
+  try {
+    sessionStore.closeSession(sessionId);
+  } catch (err) {
+    // session-store mutates its in-memory row before the atomic file write. If
+    // that write fails, restore the live row so the capability remains usable
+    // for a clean retry instead of exposing a half-closed in-memory session.
+    ds.session.status = previousStatus;
+    ds.session.closedAt = previousClosedAt;
+    ds.session.dashboardAttachments = previousDashboardAttachments;
+    ds.session.queuedAttachments = previousQueuedAttachments;
+    throw err;
+  }
+  const after = sessionStore.getSession(sessionId);
+  if (after?.status !== 'closed') {
+    throw new Error('self-close persistence did not reach closed state');
+  }
+  // Revoke authority and evict the route before publishing lifecycle events.
+  // The worker is intentionally still alive until post-response cleanup, but
+  // it can no longer authorize IPC or receive a newly-routed chat turn.
+  ds.managedTurnOrigin = undefined;
+  activeSessionsRegistry?.delete(activeSessionKey(ds));
+
+  dashboardEventBus.publish({
+    type: 'session.update',
+    body: {
+      sessionId,
+      patch: {
+        status: 'closed',
+        closedAt: after?.closedAt ? Date.parse(after.closedAt) : Date.now(),
+        tokenUsage: after ? composeRowFromClosed(after).tokenUsage : null,
+      },
+    },
+  });
+  if (!ds.exitEventEmitted) {
+    ds.exitEventEmitted = true;
+    dashboardEventBus.publish({
+      type: 'session.exited',
+      body: { sessionId, reason: 'self-close' },
+    });
+    emitSessionLifecycleHook(ds, 'session.exit', {
+      reason: 'self-close',
+      source: 'self-close',
+    });
+  }
+  logger.info(
+    `[session-close] action=self-close sessionId=${sessionId} `
+    + `larkAppId=${ds.larkAppId} scope=${ds.scope} adopted=${Boolean(ds.adoptedFrom)} `
+    + 'barrier=committed',
+  );
+  return { sessionId, session: ds };
+}
+
+/**
+ * Complete process/backend and external subscription teardown after the
+ * logical barrier. Cleanup failures are observable but never roll a closed
+ * session back to active. Adopted backends are safe because killWorker's
+ * destroy path detaches their bridge without killing the user-owned pane.
+ */
+export async function cleanupCommittedSessionSelfClose(
+  committed: CommittedSessionSelfClose,
+): Promise<void> {
+  const { sessionId, session: ds } = committed;
+  let workerCleanup = 'ok';
+  try {
+    killWorker(ds);
+  } catch (err: any) {
+    workerCleanup = `failed:${err?.message ?? err}`;
+    logger.warn(
+      `[session-close] action=self-close sessionId=${sessionId} `
+      + `worker_cleanup=${workerCleanup}`,
+    );
+  }
+
+  let subscriptionCleanup = 'ok';
+  try {
+    const anchor = sessionAnchorId(ds);
+    const subs = listDocSubscriptionsForSession(config.session.dataDir, ds.larkAppId, anchor);
+    for (const sub of subs) {
+      if (sub.managedBy !== 'watch-comment') {
+        await unsubscribeDocFile(ds.larkAppId, {
+          fileToken: sub.fileToken,
+          fileType: sub.fileType,
+        });
+      }
+      removeDocSubscription(config.session.dataDir, ds.larkAppId, sub.fileToken);
+    }
+  } catch (err: any) {
+    subscriptionCleanup = `failed:${err?.message ?? err}`;
+    logger.warn(
+      `[session-close] action=self-close sessionId=${sessionId} `
+      + `subscription_cleanup=${subscriptionCleanup}`,
+    );
+  }
+
+  logger.info(
+    `[session-close] action=self-close sessionId=${sessionId} `
+    + `worker_cleanup=${workerCleanup} subscription_cleanup=${subscriptionCleanup}`,
+  );
+}
+
+/**
+ * Idempotent dashboard close: kill worker if alive, mark Session closed, and
+ * publish lifecycle updates. Unknown/already-closed ids remain successful.
  */
 export async function closeSession(
   sessionId: string,

--- a/test/ipc-session-self-close.test.ts
+++ b/test/ipc-session-self-close.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  setIpcAuthSecret,
+  startIpcServer,
+  type IpcServerHandle,
+} from '../src/core/dashboard-ipc-server.js';
+import {
+  __testOnly_resetSessionSelfCloseReceipts,
+  deriveSessionSelfCloseCapability,
+} from '../src/core/session-self-close.js';
+import * as workerPool from '../src/core/worker-pool.js';
+import type { DaemonSession } from '../src/core/types.js';
+
+const HOST_SECRET = 'self-close-route-host-secret';
+const ORIGIN_CAPABILITY = '12'.repeat(32);
+const ACTION_CAPABILITY = deriveSessionSelfCloseCapability(ORIGIN_CAPABILITY);
+
+let handle: IpcServerHandle | null = null;
+
+function session(adopted = false): DaemonSession {
+  return {
+    session: { sessionId: adopted ? 'session-adopted' : 'session-a' },
+    larkAppId: 'app-a',
+    chatId: 'chat-a',
+    chatType: 'group',
+    scope: 'chat',
+    spawnedAt: 1,
+    lastMessageAt: 1,
+    hasHistory: true,
+    managedTurnOrigin: {
+      capability: ORIGIN_CAPABILITY,
+      turnId: 'turn-a',
+      dispatchAttempt: 3,
+    },
+    ...(adopted
+      ? { adoptedFrom: { cliId: 'claude-code', sessionId: 'external-session' } }
+      : {}),
+  } as DaemonSession;
+}
+
+function body(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    capability: ACTION_CAPABILITY,
+    turnId: 'turn-a',
+    dispatchAttempt: 3,
+    ...overrides,
+  };
+}
+
+async function post(payload: Record<string, unknown>): Promise<Response> {
+  if (!handle) {
+    setIpcAuthSecret(HOST_SECRET);
+    handle = await startIpcServer({
+      port: 0,
+      host: '127.0.0.1',
+      authRequired: true,
+    });
+  }
+  return fetch(`http://127.0.0.1:${handle.port}/api/sessions/self/close`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+afterEach(async () => {
+  if (handle) await handle.close();
+  handle = null;
+  setIpcAuthSecret(null);
+  __testOnly_resetSessionSelfCloseReceipts();
+  vi.restoreAllMocks();
+});
+
+describe('POST /api/sessions/self/close', () => {
+  it('accepts an unsigned action capability and cleans up only after commit', async () => {
+    const ds = session();
+    vi.spyOn(workerPool, 'listActiveSessions').mockReturnValue([ds]);
+    const committed = { sessionId: ds.session.sessionId, session: ds };
+    const commit = vi.spyOn(workerPool, 'commitSessionSelfClose')
+      .mockReturnValue(committed);
+    const cleanup = vi.spyOn(workerPool, 'cleanupCommittedSessionSelfClose')
+      .mockResolvedValue();
+
+    const res = await post(body());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      accepted: true,
+      sessionId: 'session-a',
+      alreadyClosed: false,
+    });
+    expect(commit).toHaveBeenCalledOnce();
+    expect(commit).toHaveBeenCalledWith(ds);
+    await new Promise(resolve => setImmediate(resolve));
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(cleanup).toHaveBeenCalledWith(committed);
+  });
+
+  it('rejects missing, generic, stale, and caller-targeted proofs', async () => {
+    const ds = session();
+    vi.spyOn(workerPool, 'listActiveSessions').mockReturnValue([ds]);
+    const commit = vi.spyOn(workerPool, 'commitSessionSelfClose');
+
+    for (const payload of [
+      {},
+      body({ capability: ORIGIN_CAPABILITY }),
+      body({ capability: '34'.repeat(32) }),
+      body({ sessionId: 'session-b' }),
+      body({ turnId: 'turn-old' }),
+      body({ dispatchAttempt: 2 }),
+    ]) {
+      const res = await post(payload);
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({
+        ok: false,
+        accepted: false,
+        error: 'self_close_denied',
+      });
+    }
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  it('makes an exact duplicate idempotent without lifecycle side effects', async () => {
+    const ds = session();
+    const list = vi.spyOn(workerPool, 'listActiveSessions').mockReturnValue([ds]);
+    const committed = { sessionId: ds.session.sessionId, session: ds };
+    const commit = vi.spyOn(workerPool, 'commitSessionSelfClose')
+      .mockReturnValue(committed);
+    const cleanup = vi.spyOn(workerPool, 'cleanupCommittedSessionSelfClose')
+      .mockResolvedValue();
+
+    const first = await post(body());
+    expect(first.status).toBe(200);
+    await first.json();
+    list.mockReturnValue([]);
+    const second = await post(body());
+    expect(second.status).toBe(200);
+    expect(await second.json()).toEqual({
+      ok: true,
+      accepted: true,
+      sessionId: 'session-a',
+      alreadyClosed: true,
+    });
+    expect(commit).toHaveBeenCalledOnce();
+    await new Promise(resolve => setImmediate(resolve));
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+
+  it('does not report success or start cleanup when the logical barrier fails', async () => {
+    const ds = session();
+    vi.spyOn(workerPool, 'listActiveSessions').mockReturnValue([ds]);
+    vi.spyOn(workerPool, 'commitSessionSelfClose')
+      .mockImplementation(() => { throw new Error('persistence unavailable'); });
+    const cleanup = vi.spyOn(workerPool, 'cleanupCommittedSessionSelfClose');
+
+    const res = await post(body());
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({
+      ok: false,
+      accepted: false,
+      error: 'close_barrier_failed',
+    });
+    expect(cleanup).not.toHaveBeenCalled();
+  });
+
+  it('closes an adopted botmux bridge instead of rejecting the session type', async () => {
+    const ds = session(true);
+    vi.spyOn(workerPool, 'listActiveSessions').mockReturnValue([ds]);
+    const committed = { sessionId: ds.session.sessionId, session: ds };
+    vi.spyOn(workerPool, 'commitSessionSelfClose').mockReturnValue(committed);
+    const cleanup = vi.spyOn(workerPool, 'cleanupCommittedSessionSelfClose')
+      .mockResolvedValue();
+
+    const res = await post(body());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      ok: true,
+      sessionId: 'session-adopted',
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    expect(cleanup).toHaveBeenCalledWith(committed);
+  });
+});

--- a/test/session-close-self-cli.test.ts
+++ b/test/session-close-self-cli.test.ts
@@ -1,0 +1,131 @@
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { RELAY_ORIGIN_CAPABILITY_BASENAME } from '../src/core/managed-origin-capability.js';
+import { deriveSessionSelfCloseCapability } from '../src/core/session-self-close.js';
+
+const CLI_PATH = join(__dirname, '..', 'src', 'cli.ts');
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function runCloseSelf(
+  dataDir: string,
+  relayDir: string,
+  port: number,
+  extraArgs: string[] = [],
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ['--import', 'tsx', CLI_PATH, 'session', 'close-self', ...extraArgs],
+      {
+        env: {
+          ...process.env,
+          SESSION_DATA_DIR: dataDir,
+          BOTMUX_SESSION_ID: 'session-cli-a',
+          BOTMUX_LARK_APP_ID: 'app-cli-a',
+          BOTMUX_SEND_RELAY: relayDir,
+          BOTMUX_DAEMON_IPC_PORT: String(port),
+          BOTMUX_TURN_ID: 'turn-cli-a',
+          BOTMUX_DISPATCH_ATTEMPT: '4',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => { stdout += chunk; });
+    child.stderr.on('data', (chunk: string) => { stderr += chunk; });
+    child.once('error', reject);
+    child.once('close', status => resolve({ status, stdout, stderr }));
+  });
+}
+
+describe('botmux session close-self CLI', () => {
+  it('uses the owning injected daemon port without sending a target session id', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-close-self-data-'));
+    const relayDir = mkdtempSync(join(tmpdir(), 'botmux-close-self-relay-'));
+    tempDirs.push(dataDir, relayDir);
+    const originCapability = '56'.repeat(32);
+    writeFileSync(
+      join(relayDir, RELAY_ORIGIN_CAPABILITY_BASENAME),
+      JSON.stringify({ token: originCapability }),
+    );
+
+    let receivedUrl = '';
+    let receivedBody = '';
+    const server = createServer((req, res) => {
+      receivedUrl = req.url ?? '';
+      req.setEncoding('utf8');
+      req.on('data', chunk => { receivedBody += chunk; });
+      req.on('end', () => {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({
+          ok: true,
+          accepted: true,
+          sessionId: 'session-cli-a',
+          alreadyClosed: false,
+        }));
+      });
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+
+    try {
+      const port = (server.address() as AddressInfo).port;
+      const result = await runCloseSelf(dataDir, relayDir, port);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('会话关闭已提交');
+      expect(result.stderr).toBe('');
+      expect(receivedUrl).toBe('/api/sessions/self/close');
+      expect(JSON.parse(receivedBody)).toEqual({
+        capability: deriveSessionSelfCloseCapability(originCapability),
+        turnId: 'turn-cli-a',
+        dispatchAttempt: 4,
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close(err => err ? reject(err) : resolve());
+      });
+    }
+  });
+
+  it('rejects every caller-selected target argument before contacting daemon', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-close-self-data-'));
+    const relayDir = mkdtempSync(join(tmpdir(), 'botmux-close-self-relay-'));
+    tempDirs.push(dataDir, relayDir);
+    writeFileSync(
+      join(relayDir, RELAY_ORIGIN_CAPABILITY_BASENAME),
+      JSON.stringify({ token: '78'.repeat(32) }),
+    );
+    let requests = 0;
+    const server = createServer((_req, res) => {
+      requests += 1;
+      res.writeHead(500);
+      res.end();
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+
+    try {
+      const port = (server.address() as AddressInfo).port;
+      const result = await runCloseSelf(dataDir, relayDir, port, ['session-b']);
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('不接受 sessionId');
+      expect(requests).toBe(0);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close(err => err ? reject(err) : resolve());
+      });
+    }
+  });
+});

--- a/test/session-self-close-barrier.test.ts
+++ b/test/session-self-close-barrier.test.ts
@@ -1,0 +1,187 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { config } from '../src/config.js';
+import * as sessionStore from '../src/services/session-store.js';
+import {
+  cleanupCommittedSessionSelfClose,
+  commitSessionSelfClose,
+  findActiveBySessionId,
+  setActiveSessionsRegistry,
+} from '../src/core/worker-pool.js';
+import { sessionKey, type DaemonSession } from '../src/core/types.js';
+import { TmuxBackend } from '../src/adapters/backend/tmux-backend.js';
+
+const tempDirs: string[] = [];
+const originalDataDir = config.session.dataDir;
+
+function daemonSession(
+  session: ReturnType<typeof sessionStore.createSession>,
+  worker: DaemonSession['worker'],
+): DaemonSession {
+  return {
+    session,
+    worker,
+    workerPort: worker ? 1234 : null,
+    workerToken: worker ? 'worker-token' : null,
+    larkAppId: 'app-a',
+    chatId: session.chatId,
+    chatType: 'group',
+    scope: 'chat',
+    spawnedAt: 1,
+    lastMessageAt: 1,
+    hasHistory: true,
+    managedTurnOrigin: {
+      capability: '90'.repeat(32),
+      turnId: 'turn-a',
+    },
+  } as DaemonSession;
+}
+
+function setupSession(worker: DaemonSession['worker'] = null): {
+  ds: DaemonSession;
+  registry: Map<string, DaemonSession>;
+} {
+  const dataDir = mkdtempSync(join(tmpdir(), 'botmux-self-close-barrier-'));
+  tempDirs.push(dataDir);
+  config.session.dataDir = dataDir;
+  sessionStore.init('app-a');
+  const session = sessionStore.createSession('chat-a', 'root-a', 'old', 'group');
+  session.larkAppId = 'app-a';
+  session.scope = 'chat';
+  session.cliId = 'codex';
+  session.cliSessionId = 'provider-old';
+  sessionStore.updateSession(session);
+  const ds = daemonSession(session, worker);
+  const registry = new Map([[sessionKey('chat-a', 'app-a'), ds]]);
+  setActiveSessionsRegistry(registry);
+  return { ds, registry };
+}
+
+afterEach(() => {
+  setActiveSessionsRegistry(new Map());
+  sessionStore.init();
+  config.session.dataDir = originalDataDir;
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  vi.restoreAllMocks();
+});
+
+describe('self-close logical barrier', () => {
+  it('evicts and persists before worker cleanup, then cannot remove a fresh route', async () => {
+    const send = vi.fn();
+    const worker = {
+      killed: false,
+      connected: true,
+      send,
+      once: vi.fn(),
+      exitCode: null,
+      signalCode: null,
+      kill: vi.fn(),
+    } as unknown as DaemonSession['worker'];
+    const { ds, registry } = setupSession(worker);
+    const oldSessionId = ds.session.sessionId;
+
+    const committed = commitSessionSelfClose(ds);
+
+    expect(findActiveBySessionId(oldSessionId)).toBeUndefined();
+    expect(registry.has(sessionKey('chat-a', 'app-a'))).toBe(false);
+    expect(sessionStore.getSession(oldSessionId)).toMatchObject({
+      status: 'closed',
+      cliSessionId: 'provider-old',
+    });
+    expect(send).not.toHaveBeenCalled();
+
+    // Model the next chat message arriving after the barrier but before slow
+    // cleanup. Its new logical/provider identity must not be touched by cleanup
+    // of the old session.
+    const fresh = sessionStore.createSession('chat-a', 'root-b', 'fresh', 'group');
+    fresh.larkAppId = 'app-a';
+    fresh.scope = 'chat';
+    sessionStore.updateSession(fresh);
+    const freshDs = daemonSession(fresh, null);
+    registry.set(sessionKey('chat-a', 'app-a'), freshDs);
+
+    await cleanupCommittedSessionSelfClose(committed);
+
+    expect(send).toHaveBeenCalledWith({ type: 'close' });
+    expect(registry.get(sessionKey('chat-a', 'app-a'))).toBe(freshDs);
+    expect(fresh.sessionId).not.toBe(oldSessionId);
+    expect(fresh.cliSessionId).toBeUndefined();
+  });
+
+  it('uses the same fresh-session barrier for thread scope and TRAE', async () => {
+    const { ds, registry } = setupSession(null);
+    ds.scope = 'thread';
+    ds.session.scope = 'thread';
+    ds.session.cliId = 'traex';
+    ds.session.cliSessionId = 'trae-provider-old';
+    sessionStore.updateSession(ds.session);
+    registry.clear();
+    registry.set(sessionKey('root-a', 'app-a'), ds);
+    const oldSessionId = ds.session.sessionId;
+
+    const committed = commitSessionSelfClose(ds);
+    expect(registry.has(sessionKey('root-a', 'app-a'))).toBe(false);
+
+    const fresh = sessionStore.createSession(
+      'chat-a',
+      'root-a',
+      'fresh-thread',
+      'group',
+      'thread',
+    );
+    fresh.larkAppId = 'app-a';
+    sessionStore.updateSession(fresh);
+    const freshDs = daemonSession(fresh, null);
+    freshDs.scope = 'thread';
+    registry.set(sessionKey('root-a', 'app-a'), freshDs);
+
+    await cleanupCommittedSessionSelfClose(committed);
+
+    expect(registry.get(sessionKey('root-a', 'app-a'))).toBe(freshDs);
+    expect(fresh.sessionId).not.toBe(oldSessionId);
+    expect(fresh.cliSessionId).toBeUndefined();
+    expect(sessionStore.getSession(oldSessionId)).toMatchObject({
+      status: 'closed',
+      cliId: 'traex',
+      cliSessionId: 'trae-provider-old',
+    });
+  });
+
+  it('keeps the route and capability retryable when persistence fails', () => {
+    const { ds, registry } = setupSession(null);
+    const origin = ds.managedTurnOrigin;
+    vi.spyOn(sessionStore, 'closeSession').mockImplementation(() => {
+      ds.session.status = 'closed';
+      ds.session.closedAt = '2026-07-22T00:00:00.000Z';
+      throw new Error('disk unavailable');
+    });
+
+    expect(() => commitSessionSelfClose(ds)).toThrow('disk unavailable');
+
+    expect(registry.get(sessionKey('chat-a', 'app-a'))).toBe(ds);
+    expect(ds.managedTurnOrigin).toBe(origin);
+    expect(ds.session.status).toBe('active');
+    expect(ds.session.closedAt).toBeUndefined();
+  });
+
+  it('does not kill a user-owned pane for an adopted session with no live bridge', async () => {
+    const { ds } = setupSession(null);
+    ds.adoptedFrom = {
+      cliId: 'claude-code',
+      sessionId: 'user-owned-provider-session',
+    } as DaemonSession['adoptedFrom'];
+    ds.session.backendType = 'tmux';
+    sessionStore.updateSession(ds.session);
+    const killSession = vi.spyOn(TmuxBackend, 'killSession');
+
+    const committed = commitSessionSelfClose(ds);
+    await cleanupCommittedSessionSelfClose(committed);
+
+    expect(killSession).not.toHaveBeenCalled();
+    expect(sessionStore.getSession(ds.session.sessionId)?.status).toBe('closed');
+  });
+});

--- a/test/session-self-close.test.ts
+++ b/test/session-self-close.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  __testOnly_resetSessionSelfCloseReceipts,
+  authorizeSessionSelfClose,
+  deriveSessionSelfCloseCapability,
+  recordCommittedSessionSelfClose,
+} from '../src/core/session-self-close.js';
+import type { DaemonSession } from '../src/core/types.js';
+
+const ORIGIN_CAPABILITY = 'ab'.repeat(32);
+const SELF_CLOSE_CAPABILITY = deriveSessionSelfCloseCapability(ORIGIN_CAPABILITY);
+const TURN_ID = 'turn-current';
+
+function session(overrides: Partial<DaemonSession> = {}): DaemonSession {
+  return {
+    session: { sessionId: 'session-a' },
+    larkAppId: 'app-a',
+    chatId: 'chat-a',
+    chatType: 'group',
+    scope: 'chat',
+    spawnedAt: 1,
+    lastMessageAt: 1,
+    hasHistory: true,
+    managedTurnOrigin: {
+      capability: ORIGIN_CAPABILITY,
+      turnId: TURN_ID,
+      dispatchAttempt: 2,
+    },
+    ...overrides,
+  } as DaemonSession;
+}
+
+function claim(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    capability: SELF_CLOSE_CAPABILITY,
+    turnId: TURN_ID,
+    dispatchAttempt: 2,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  __testOnly_resetSessionSelfCloseReceipts();
+});
+
+describe('session self-close capability authorization', () => {
+  it('domain-separates self-close from the generic rotating origin capability', () => {
+    expect(SELF_CLOSE_CAPABILITY).toMatch(/^[a-f0-9]{64}$/);
+    expect(SELF_CLOSE_CAPABILITY).not.toBe(ORIGIN_CAPABILITY);
+    expect(deriveSessionSelfCloseCapability(ORIGIN_CAPABILITY))
+      .toBe(SELF_CLOSE_CAPABILITY);
+
+    expect(authorizeSessionSelfClose(claim(), [session()])).toMatchObject({
+      ok: true,
+      alreadyClosed: false,
+      session: { session: { sessionId: 'session-a' } },
+    });
+    expect(authorizeSessionSelfClose(
+      claim({ capability: ORIGIN_CAPABILITY }),
+      [session()],
+    )).toEqual({ ok: false, reason: 'origin_unproven' });
+  });
+
+  it('rejects missing, malformed, stale, and caller-selected target claims', () => {
+    expect(authorizeSessionSelfClose({}, [session()]))
+      .toEqual({ ok: false, reason: 'capability_missing' });
+    expect(authorizeSessionSelfClose(claim({ capability: 'not-a-token' }), [session()]))
+      .toEqual({ ok: false, reason: 'capability_malformed' });
+    expect(authorizeSessionSelfClose(claim({ capability: 'cd'.repeat(32) }), [session()]))
+      .toEqual({ ok: false, reason: 'origin_unproven' });
+    expect(authorizeSessionSelfClose(
+      claim({ sessionId: 'session-b' }),
+      [session()],
+    )).toEqual({ ok: false, reason: 'target_not_allowed' });
+  });
+
+  it('binds the proof to the live turn and dispatch attempt', () => {
+    expect(authorizeSessionSelfClose(claim({ turnId: 'turn-old' }), [session()]))
+      .toEqual({ ok: false, reason: 'turn_mismatch' });
+    expect(authorizeSessionSelfClose(claim({ dispatchAttempt: 1 }), [session()]))
+      .toEqual({ ok: false, reason: 'dispatch_attempt_mismatch' });
+    const withoutAttempt = claim();
+    delete withoutAttempt.dispatchAttempt;
+    expect(authorizeSessionSelfClose(withoutAttempt, [session()]))
+      .toEqual({ ok: false, reason: 'dispatch_attempt_mismatch' });
+  });
+
+  it('returns one idempotent receipt for an exact committed duplicate', () => {
+    const accepted = authorizeSessionSelfClose(claim(), [session()]);
+    expect(accepted.ok && !accepted.alreadyClosed).toBe(true);
+    if (!accepted.ok || accepted.alreadyClosed) throw new Error('expected active authorization');
+    recordCommittedSessionSelfClose(accepted.claim, 'session-a', 1_000);
+
+    expect(authorizeSessionSelfClose(claim(), [], 1_001)).toMatchObject({
+      ok: true,
+      alreadyClosed: true,
+      sessionId: 'session-a',
+    });
+    expect(authorizeSessionSelfClose(claim({ turnId: 'turn-replay' }), [], 1_001))
+      .toEqual({ ok: false, reason: 'origin_unproven' });
+    expect(authorizeSessionSelfClose(claim(), [], 301_001))
+      .toEqual({ ok: false, reason: 'origin_unproven' });
+  });
+
+  it('fails closed if one action capability ambiguously matches two live sessions', () => {
+    const sibling = session({
+      session: { sessionId: 'session-b' },
+      larkAppId: 'app-b',
+    } as Partial<DaemonSession>);
+    expect(authorizeSessionSelfClose(claim(), [session(), sibling]))
+      .toEqual({ ok: false, reason: 'origin_ambiguous' });
+  });
+});


### PR DESCRIPTION
## 背景

NDBFlow 的两阶段 session handoff 需要在 checkpoint/receipt 已落盘后，由当前会话安全终结自己的逻辑 session。现有 `botmux delete <id>` 只适合 host/admin 清理，无法保证 owning daemon 的 `activeSessions`、持久化状态与 provider resume 语义原子收敛。

## 改动

- 新增稳定 CLI：`botmux session close-self`
  - 只从当前进程上下文定位 owning daemon 与当前轮次 capability
  - 不接受 sessionId、前缀、`all` 或跨 bot 参数
  - 不读取或发送 trusted-host secret
- 新增 daemon API：`POST /api/sessions/self/close`
  - 使用 action-domain-separated、session/turn/dispatch-bound rotating capability
  - daemon 从实时 capability 唯一反查 caller session；请求不携带目标 sessionId
  - 缺失、畸形、过期、轮次不匹配、attempt 不匹配及歧义 capability 全部 fail closed
  - 完全相同的已提交重试返回 `alreadyClosed=true`，不重复生命周期副作用
- 新增同步逻辑关闭屏障
  - 先持久化 `closed`，再撤销 capability、移除 active route、发布一致的 lifecycle/dashboard 事件
  - 屏障函数无 `await`，失败时恢复内存状态并保留 route/capability 供安全重试
  - HTTP 响应交给 socket 后才清理 worker、botmux-owned backend 与文档订阅
  - adopted session 沿用 `ownsSession=false` 语义，只断开 Botmux bridge，不杀用户 pane
- 补充中英文 README 与 CLI 文档，明确 checkpoint 必须先完成，成功调用必须是最后一个动作
- 不修改现有 trusted-host HMAC 管理接口，也不改变 `botmux delete` 语义

## 验证

已通过：

- `pnpm build`
- `tsc --noEmit`
- self-close 与相关回归：10 个测试文件、122 项测试全部通过
  - capability/action/turn/attempt 绑定、旧 proof/target 拒绝
  - unsigned self-close IPC、屏障失败不误报成功、幂等 receipt
  - chat/thread 关闭后新 route 使用新 botmux sessionId，provider cliSessionId 不继承
  - close 与下一条消息并发窗口（屏障后、慢清理前）旧 session 不复活
  - Codex/Claude/adopted/TRAE 共用同一 provider-agnostic 路径
  - adopted 用户 pane 不被 daemon orphan cleanup 杀死
  - 既有 Dashboard IPC、session-ready、zombie close 与 orphan backend 回归
- 构建后 CLI smoke：help 展示新命令；传目标 ID 返回 rc=2 且不发请求

全量 `pnpm test` 在当前 CentOS 节点结果为 9859 passed / 32 failed。失败均为当前机器/上游 master 基线问题，与本次文件无交集：

- 系统 Git 2.20.1 不支持测试使用的 `git init -b`（25 项）；切换本机已有 Git 2.31 后对应 31 项测试全部通过
- `/bin/sh` 与 `/proc` PID namespace/worker discovery 相关 7 项；在 `origin/master` 独立 worktree 同条件复现了对应 shell/worker-fence/distillation 基线失败，cancel 的 2 个 timeout 也来自同一 worker discovery 环境

未重启当前共享 Lark daemon，也未在当前开发会话执行真实 provider 自关闭，以避免把未合并分支部署到所有机器人并终止正在提交本 PR 的会话；真实 HTTP/CLI 与 handoff 并发语义由上述集成测试覆盖。
