### PR TITLE
fix(desktop): APP/CLI 启动的 shell PATH 探测兼容 zsh 与 bash

### DIFF
--- a/src/adapters/cli/registry.ts
+++ b/src/adapters/cli/registry.ts
@@ -109,8 +109,13 @@ export function resolveCommand(cmd: string): string {
         timeout: 5_000,
         stdio: ['ignore', 'pipe', 'ignore'],
       });
-      const found = (result.stdout ?? '').trim();
-      if (found && isAbsolute(found)) return found;
+      // Rc files may echo banners to stdout before the `which` output, so take
+      // the LAST absolute line — and only after a clean exit, so a failed
+      // `which` can't let an echoed path-looking line masquerade as a result.
+      if (result.status !== 0) continue;
+      const lines = (result.stdout ?? '').split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+      const found = lines.reverse().find(line => isAbsolute(line));
+      if (found) return found;
     }
   }
   if (process.platform === 'darwin' && cmd === 'codex') {

--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -6,6 +6,7 @@ import { autoStartCliRuntimeOnLaunch, shouldTakeOverExternalRuntime } from './ma
 import { createRuntimeStateMonitor, registerDesktopIpc } from './main/ipc.js';
 import { resolveDesktopPaths } from './main/paths.js';
 import { resolveBundledRuntimeCandidate } from './main/bundled-runtime.js';
+import { probeShellPathEnv } from './main/external-runtime.js';
 import { listPm2Apps } from './main/pm2-apps.js';
 import { createRuntimeService } from './main/runtime-service.js';
 import { createDesktopTray } from './main/tray.js';
@@ -76,7 +77,10 @@ async function bootstrap(): Promise<void> {
     env: process.env,
     fs: { existsSync, readFileSync },
     bundledRuntime,
-    pm2Apps: async selectedRuntime => listPm2Apps(paths, selectedRuntime),
+    // Finder-launched apps inherit launchd's minimal PATH; the daemon needs the
+    // user's real shell PATH (zsh/bash, profile+rc) to find per-bot CLIs.
+    shellPathEnv: () => probeShellPathEnv(),
+    pm2Apps: async selectedRuntime => listPm2Apps(paths, selectedRuntime, { pathEnv: probeShellPathEnv() }),
   });
 
   const win = createMainWindow(join(desktopDir, 'preload.cjs'), join(desktopDir, 'renderer'));

--- a/src/desktop/main/external-runtime.ts
+++ b/src/desktop/main/external-runtime.ts
@@ -209,10 +209,11 @@ function runWhich(execFile: ExecFile, platform: NodeJS.Platform): string[] {
 // Runtime state is polled every ~5s (createRuntimeStateMonitor) and each poll
 // re-runs discovery. Spawning up to 4 rc-sourcing shells per poll is far too
 // heavy, so the probe result is cached: shell PATH essentially never changes
-// mid-run. A miss (no bins) is cached briefly so a user who installs botmux
-// while the app shows "install CLI" is picked up within a few polls.
+// mid-run. A miss (no bins) expires within one poll period so a user who
+// installs botmux while the app shows "install CLI" (or hits an explicit
+// retry) never sees a stale miss for more than ~one refresh.
 const SHELL_PROBE_HIT_TTL_MS = 5 * 60_000;
-const SHELL_PROBE_MISS_TTL_MS = 20_000;
+const SHELL_PROBE_MISS_TTL_MS = 5_000;
 let shellProbeCache: { at: number; value: { bins: string[]; pathEnv?: string } } | null = null;
 
 /**

--- a/src/desktop/main/external-runtime.ts
+++ b/src/desktop/main/external-runtime.ts
@@ -1,7 +1,8 @@
 import { execFileSync as defaultExecFileSync } from 'node:child_process';
 import { existsSync as defaultExistsSync, readFileSync as defaultReadFileSync, realpathSync as defaultRealpathSync, statSync as defaultStatSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { delimiter, dirname, join, resolve } from 'node:path';
 import type { DesktopPaths } from '../shared/types.js';
+import { shellPathProbes } from '../shared/shell-path-probes.js';
 import type { ExternalRuntimeCandidate } from './runtime-service.js';
 import { resolveEffectiveBotmuxVersion } from '../../utils/version-info.js';
 
@@ -34,6 +35,7 @@ interface InstallProbeDeps {
 export interface ExternalRuntimeDiscoveryDeps {
   binPaths?: string[];
   platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
   execFileSync?: ExecFile;
   existsSync?: (path: string) => boolean;
   readFileSync?: ReadTextFile;
@@ -157,15 +159,23 @@ function resolveBotmuxBin(binPath: string, deps: InstallProbeDeps): { root: stri
 function listBotmuxBins(paths: DesktopPaths, deps: ExternalRuntimeDiscoveryDeps): DiscoveredBin[] {
   const execFile = deps.execFileSync ?? (defaultExecFileSync as unknown as ExecFile);
   const platform = deps.platform ?? process.platform;
+  // macOS GUI apps miss the user's shell PATH, so ask the user's shell (zsh or
+  // bash, profile and rc flavors) — see shellPathProbes for the ladder.
+  const shellProbe = platform === 'darwin'
+    ? cachedShellPathWhich(execFile, deps)
+    : { bins: [], pathEnv: undefined };
+  // The merged shell PATH is attached to every candidate (not only shell-found
+  // ones): whichever bin wins, the daemon it starts needs that PATH to find
+  // `node` and the per-bot CLIs when they live in nvm/fnm-managed directories.
+  const pathEnv = shellProbe.pathEnv;
   const bins: DiscoveredBin[] = [
-    ...runWhich(execFile, platform).map(binPath => ({ binPath })),
-    // macOS GUI apps often miss the user's login shell PATH, so ask zsh too.
-    ...(platform === 'darwin' ? runLoginShellWhich(execFile) : []),
+    ...runWhich(execFile, platform).map(binPath => ({ binPath, pathEnv })),
+    ...shellProbe.bins.map(binPath => ({ binPath, pathEnv })),
     // User-owned wrappers are useful fallbacks, but should not override the CLI
     // that the user's shell actually resolves for `botmux`.
-    { binPath: join(paths.botmuxHome, 'bin', 'botmux') },
-    { binPath: '/opt/homebrew/bin/botmux' },
-    { binPath: '/usr/local/bin/botmux' },
+    { binPath: join(paths.botmuxHome, 'bin', 'botmux'), pathEnv },
+    { binPath: '/opt/homebrew/bin/botmux', pathEnv },
+    { binPath: '/usr/local/bin/botmux', pathEnv },
   ];
 
   const byBin = new Map<string, DiscoveredBin>();
@@ -196,17 +206,78 @@ function runWhich(execFile: ExecFile, platform: NodeJS.Platform): string[] {
   }
 }
 
-function runLoginShellWhich(execFile: ExecFile): DiscoveredBin[] {
-  try {
-    const out = execFile('/bin/zsh', ['-lc', `printf '${LOGIN_SHELL_PATH_MARKER}%s\\n' "$PATH"; which -a botmux`], {
-      encoding: 'utf-8',
-      timeout: 3_000,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    });
-    return splitLoginShellWhichOutput(out);
-  } catch {
-    return [];
+// Runtime state is polled every ~5s (createRuntimeStateMonitor) and each poll
+// re-runs discovery. Spawning up to 4 rc-sourcing shells per poll is far too
+// heavy, so the probe result is cached: shell PATH essentially never changes
+// mid-run. A miss (no bins) is cached briefly so a user who installs botmux
+// while the app shows "install CLI" is picked up within a few polls.
+const SHELL_PROBE_HIT_TTL_MS = 5 * 60_000;
+const SHELL_PROBE_MISS_TTL_MS = 20_000;
+let shellProbeCache: { at: number; value: { bins: string[]; pathEnv?: string } } | null = null;
+
+/**
+ * Merged login+interactive shell PATH for GUI-launched processes (darwin only;
+ * undefined elsewhere or when probing fails). The bundled-runtime daemon spawn
+ * uses this so per-bot CLIs installed via nvm/fnm/homebrew stay findable —
+ * PtyBackend spawns CLIs without any rc-sourcing shell wrapper, so whatever
+ * PATH the daemon starts with is what `#!/usr/bin/env node` resolves against.
+ */
+export function probeShellPathEnv(): string | undefined {
+  if (process.platform !== 'darwin') return undefined;
+  const execFile = defaultExecFileSync as unknown as ExecFile;
+  return cachedShellPathWhich(execFile, {}).pathEnv;
+}
+
+function cachedShellPathWhich(
+  execFile: ExecFile,
+  deps: ExternalRuntimeDiscoveryDeps,
+): { bins: string[]; pathEnv?: string } {
+  // Tests inject execFileSync/env; caching across injected deps would leak
+  // state between tests, so the cache only serves the production defaults.
+  const cacheable = !deps.execFileSync && !deps.env;
+  if (cacheable && shellProbeCache) {
+    const ttl = shellProbeCache.value.bins.length ? SHELL_PROBE_HIT_TTL_MS : SHELL_PROBE_MISS_TTL_MS;
+    if (Date.now() - shellProbeCache.at < ttl) return shellProbeCache.value;
   }
+  const value = runShellPathWhich(execFile, deps.env ?? process.env);
+  if (cacheable) shellProbeCache = { at: Date.now(), value };
+  return value;
+}
+
+function runShellPathWhich(execFile: ExecFile, env: NodeJS.ProcessEnv): { bins: string[]; pathEnv?: string } {
+  const bins: string[] = [];
+  const pathParts: string[] = [];
+  const seenBins = new Set<string>();
+  const seenParts = new Set<string>();
+
+  for (const probe of shellPathProbes(env)) {
+    let out: string;
+    try {
+      // `|| true` keeps the probe's $PATH usable even when this particular
+      // shell flavor cannot see botmux — the PATH is still needed downstream.
+      out = execFile(probe.shell, [probe.flags, `printf '${LOGIN_SHELL_PATH_MARKER}%s\\n' "$PATH"; which -a botmux || true`], {
+        encoding: 'utf-8',
+        timeout: 3_000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+    } catch {
+      continue;
+    }
+    const parsed = splitLoginShellWhichOutput(out);
+    for (const bin of parsed.bins) {
+      if (seenBins.has(bin)) continue;
+      seenBins.add(bin);
+      bins.push(bin);
+    }
+    for (const part of parsed.pathEnv?.split(delimiter) ?? []) {
+      const trimmed = part.trim();
+      if (!trimmed || seenParts.has(trimmed)) continue;
+      seenParts.add(trimmed);
+      pathParts.push(trimmed);
+    }
+  }
+
+  return { bins, ...(pathParts.length ? { pathEnv: pathParts.join(delimiter) } : {}) };
 }
 
 function readPackageVersion(
@@ -234,14 +305,16 @@ function splitCommandOutput(out: string): string[] {
   return out.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
 }
 
-function splitLoginShellWhichOutput(out: string): DiscoveredBin[] {
+function splitLoginShellWhichOutput(out: string): { bins: string[]; pathEnv?: string } {
   const lines = splitCommandOutput(out);
   const markerIndex = lines.findIndex(line => line.startsWith(LOGIN_SHELL_PATH_MARKER));
   const pathEnv = markerIndex >= 0
     ? lines[markerIndex]!.slice(LOGIN_SHELL_PATH_MARKER.length).trim() || undefined
     : undefined;
   const binLines = markerIndex >= 0 ? lines.slice(markerIndex + 1) : lines;
-  return binLines.map(binPath => ({ binPath, ...(pathEnv ? { pathEnv } : {}) }));
+  // Interactive rc files can echo arbitrary text and zsh's `which` prints
+  // "botmux not found" to stdout — keep only absolute paths.
+  return { bins: binLines.filter(line => line.startsWith('/')), ...(pathEnv ? { pathEnv } : {}) };
 }
 
 function isSemverVersion(version: string): boolean {

--- a/src/desktop/main/node-command.ts
+++ b/src/desktop/main/node-command.ts
@@ -87,7 +87,17 @@ export function buildExternalBotmuxCommand(input: BuildExternalBotmuxCommandInpu
   };
 }
 
-function buildBundledPath(current: string | undefined, nodePath: string, pathEnv: string | undefined): string {
+/**
+ * PATH for anything spawned on behalf of the bundled runtime (daemon start and
+ * pm2 contact alike — pm2's daemon env sticks and propagates into resurrected
+ * apps, so BOTH chains must agree on ordering or which `node` a per-bot CLI
+ * gets would depend on pm2 startup order). User shell PATH first: their
+ * nvm/fnm node keeps winning like in a terminal; the bundled node dir is only
+ * the fallback for `#!/usr/bin/env node` when the user has no node at all.
+ * Callers never rely on this PATH to locate node/pm2 themselves — both are
+ * invoked via absolute paths.
+ */
+export function buildBundledPath(current: string | undefined, nodePath: string, pathEnv: string | undefined): string {
   return joinPathEntries([
     pathEnv,
     dirname(nodePath),

--- a/src/desktop/main/node-command.ts
+++ b/src/desktop/main/node-command.ts
@@ -28,6 +28,8 @@ export interface BuildBundledBotmuxCommandInput {
   botmuxHome: string;
   args: string[];
   baseEnv: NodeJS.ProcessEnv;
+  /** Probed user shell PATH (zsh/bash, profile+rc) — see probeShellPathEnv. */
+  pathEnv?: string;
 }
 
 export function buildBotmuxCommand(input: BuildBotmuxCommandInput): BotmuxCommand {
@@ -48,6 +50,13 @@ export function buildBotmuxCommand(input: BuildBotmuxCommandInput): BotmuxComman
 export function buildBundledBotmuxCommand(input: BuildBundledBotmuxCommandInput): BotmuxCommand {
   const env: NodeJS.ProcessEnv = {
     ...input.baseEnv,
+    // Finder-launched apps only carry launchd's minimal PATH. The daemon this
+    // command starts must still find per-bot CLIs (claude/codex/traex/... via
+    // nvm/fnm/homebrew) and a `node` for their `#!/usr/bin/env node` shebangs,
+    // so repair PATH: user's shell PATH first (their nvm node keeps winning,
+    // matching terminal behavior), bundled node as fallback, then well-known
+    // install dirs.
+    PATH: buildBundledPath(input.baseEnv.PATH, input.nodePath, input.pathEnv),
     PM2_HOME: join(input.botmuxHome, 'pm2'),
     SESSION_DATA_DIR: join(input.botmuxHome, 'data'),
   };
@@ -76,6 +85,18 @@ export function buildExternalBotmuxCommand(input: BuildExternalBotmuxCommandInpu
     args: input.args,
     env,
   };
+}
+
+function buildBundledPath(current: string | undefined, nodePath: string, pathEnv: string | undefined): string {
+  return joinPathEntries([
+    pathEnv,
+    dirname(nodePath),
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+    '/usr/bin',
+    '/bin',
+    current,
+  ]);
 }
 
 function buildExternalPath(current: string | undefined, binPath: string, pathEnv: string | undefined): string {

--- a/src/desktop/main/pm2-apps.ts
+++ b/src/desktop/main/pm2-apps.ts
@@ -2,6 +2,7 @@ import { spawn as spawnProcess, type ChildProcessWithoutNullStreams } from 'node
 import { existsSync as pathExistsSync } from 'node:fs';
 import { delimiter, dirname, join } from 'node:path';
 import type { DesktopPaths } from '../shared/types.js';
+import { buildBundledPath } from './node-command.js';
 import type { RuntimeLaunchTarget } from './runtime-service.js';
 import { parsePm2Apps, type Pm2AppSummary } from './runtime-source.js';
 
@@ -38,9 +39,11 @@ export function listPm2Apps(
     // repaired PATH so discovery does not depend on the user's shell startup.
     // jlist may be the first pm2 contact and thus start the pm2 daemon, whose
     // env sticks and propagates into resurrected apps — so the bundled branch
-    // must carry the probed shell PATH too, not only the daemon-start spawn.
+    // carries the probed shell PATH with the SAME ordering as the daemon-start
+    // spawn (buildBundledPath); pm2 itself is launched via the absolute
+    // nodePath and never resolves node through this PATH.
     PATH: runtime.kind === 'bundled'
-      ? withRuntimePath(baseEnv.PATH, runtime.nodePath, deps.pathEnv)
+      ? buildBundledPath(baseEnv.PATH, runtime.nodePath, deps.pathEnv)
       : withRuntimePath(baseEnv.PATH, runtime.binPath, runtime.pathEnv),
     PM2_HOME: paths.pm2Home,
     SESSION_DATA_DIR: paths.dataDir,

--- a/src/desktop/main/pm2-apps.ts
+++ b/src/desktop/main/pm2-apps.ts
@@ -11,6 +11,8 @@ interface Pm2ListDeps {
   execPath?: string;
   env?: NodeJS.ProcessEnv;
   timeoutMs?: number;
+  /** Probed user shell PATH for bundled runtimes (see probeShellPathEnv). */
+  pathEnv?: string;
 }
 
 export const defaultPm2ListTimeoutMs = 25_000;
@@ -34,8 +36,11 @@ export function listPm2Apps(
     ...baseEnv,
     // External PM2 bins use /usr/bin/env node; Finder-launched apps need a
     // repaired PATH so discovery does not depend on the user's shell startup.
+    // jlist may be the first pm2 contact and thus start the pm2 daemon, whose
+    // env sticks and propagates into resurrected apps — so the bundled branch
+    // must carry the probed shell PATH too, not only the daemon-start spawn.
     PATH: runtime.kind === 'bundled'
-      ? withRuntimePath(baseEnv.PATH, runtime.nodePath, undefined)
+      ? withRuntimePath(baseEnv.PATH, runtime.nodePath, deps.pathEnv)
       : withRuntimePath(baseEnv.PATH, runtime.binPath, runtime.pathEnv),
     PM2_HOME: paths.pm2Home,
     SESSION_DATA_DIR: paths.dataDir,

--- a/src/desktop/main/runtime-service.ts
+++ b/src/desktop/main/runtime-service.ts
@@ -111,6 +111,8 @@ export interface RuntimeServiceDeps {
   externalRuntime?: ExternalRuntimeCandidate | null;
   discoverExternalRuntime?: () => ExternalRuntimeCandidate | null;
   bundledRuntime?: BundledRuntimeCandidate;
+  /** Probed user shell PATH for bundled-runtime spawns (see probeShellPathEnv). */
+  shellPathEnv?: () => string | undefined;
   pm2Apps?: (runtime: RuntimeLaunchTarget) => Promise<Pm2AppSummary[]>;
 }
 
@@ -129,6 +131,7 @@ export function createRuntimeService(deps: RuntimeServiceDeps) {
         botmuxHome: deps.paths.botmuxHome,
         args,
         baseEnv: deps.env,
+        pathEnv: deps.shellPathEnv?.(),
       });
     }
     return buildExternalBotmuxCommand({

--- a/src/desktop/shared/shell-path-probes.ts
+++ b/src/desktop/shared/shell-path-probes.ts
@@ -1,0 +1,45 @@
+import { basename } from 'node:path';
+
+export interface ShellPathProbe {
+  /** Absolute path of the shell binary to spawn. */
+  shell: string;
+  /** `-ic` sources .zshrc/.bashrc; `-lc` sources .zprofile/.bash_profile. */
+  flags: '-ic' | '-lc';
+}
+
+/**
+ * Shell probe ladder for PATH / binary discovery when botmux was launched from
+ * the macOS GUI (Finder/Dock) instead of a terminal.
+ *
+ * GUI-launched apps inherit launchd's minimal PATH, so the desktop app asks the
+ * user's shell for the real one. A single `zsh -lc` is not enough:
+ *  - `-lc` (login, non-interactive) sources .zprofile but NOT .zshrc — nvm/fnm
+ *    and many CLI installers edit only the rc file;
+ *  - users whose login shell is bash never had .bash_profile/.bashrc read at all.
+ *
+ * The ladder probes the user's own `$SHELL` (when it is zsh or bash) before the
+ * macOS default /bin/zsh, and probes `-ic` before `-lc`: a real terminal runs a
+ * login+interactive shell where rc-file prepends (nvm's node dir) end up in
+ * front of profile entries, so the interactive snapshot is the closer match for
+ * PATH ordering. Bounded at ≤4 spawns so a slow rc cannot stall app startup.
+ */
+export function shellPathProbes(env: NodeJS.ProcessEnv = process.env): ShellPathProbe[] {
+  const probes: ShellPathProbe[] = [];
+  const seen = new Set<string>();
+  const add = (shell: string, flags: ShellPathProbe['flags']) => {
+    const key = `${shell} ${flags}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    probes.push({ shell, flags });
+  };
+
+  const userShell = env.SHELL?.trim();
+  const shells = userShell && ['zsh', 'bash'].includes(basename(userShell))
+    ? [userShell, '/bin/zsh']
+    : ['/bin/zsh'];
+  for (const shell of shells) {
+    add(shell, '-ic');
+    add(shell, '-lc');
+  }
+  return probes;
+}

--- a/src/desktop/smoke.ts
+++ b/src/desktop/smoke.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { normalizeBotmuxVersion } from '../utils/version-info.js';
+import { shellPathProbes } from './shared/shell-path-probes.js';
 
 export interface RunCaptureOptions {
   env?: NodeJS.ProcessEnv;
@@ -275,9 +276,15 @@ function runBotmuxStatus(deps: AppSmokeDeps, appPath: string): RunCaptureResult 
   const direct = deps.runCapture('botmux', ['status'], { timeout: 25000, env: deps.env });
   if (direct.status === 0 || deps.platform !== 'darwin' || !direct.error) return direct;
 
-  // macOS GUI/Codex environments can miss the user's login-shell PATH even when
-  // `botmux` is installed globally. Retry through zsh before reporting no CLI.
-  return deps.runCapture('/bin/zsh', ['-lc', 'botmux status'], { timeout: 25000, env: deps.env });
+  // macOS GUI/Codex environments can miss the user's shell PATH even when
+  // `botmux` is installed globally. Retry through the user's shell — both rc
+  // (-ic) and profile (-lc) flavors, zsh and bash — before reporting no CLI.
+  let last = direct;
+  for (const probe of shellPathProbes(deps.env)) {
+    last = deps.runCapture(probe.shell, [probe.flags, 'botmux status'], { timeout: 25000, env: deps.env });
+    if (last.status === 0) return last;
+  }
+  return last;
 }
 
 function commandError(result: RunCaptureResult): string {

--- a/test/desktop/desktop-external-runtime.test.ts
+++ b/test/desktop/desktop-external-runtime.test.ts
@@ -193,6 +193,104 @@ describe('desktop external CLI runtime discovery', () => {
     });
   });
 
+  it('discovers an rc-only (nvm-in-.zshrc) install through the interactive zsh probe', () => {
+    const nvmBin = '/Users/me/.nvm/versions/node/v22.22.2/bin';
+    const files = new Map([
+      [`/Users/me/.nvm/versions/node/v22.22.2/lib/node_modules/botmux/package.json`, JSON.stringify({ name: 'botmux', version: '2.32.0' })],
+      [`/Users/me/.nvm/versions/node/v22.22.2/lib/node_modules/botmux/dist/cli.js`, ''],
+    ]);
+
+    const candidate = discoverExternalRuntimeCandidate(paths, {
+      platform: 'darwin',
+      env: {},
+      execFileSync: (file, args) => {
+        if (file !== '/bin/zsh') return '';
+        // Login shell (.zprofile) has no nvm dir and no botmux; only the
+        // interactive rc (.zshrc) probe surfaces both.
+        if (args[0] === '-lc') return '__BOTMUX_PATH__/usr/bin:/bin\n';
+        return `Welcome banner from .zshrc\n__BOTMUX_PATH__${nvmBin}:/usr/bin:/bin\n${nvmBin}/botmux\n`;
+      },
+      existsSync: path => files.has(path),
+      readFileSync: path => files.get(path) ?? '',
+      realpathSync: path => path === `${nvmBin}/botmux`
+        ? '/Users/me/.nvm/versions/node/v22.22.2/lib/node_modules/botmux/dist/cli.js'
+        : path,
+      statSync: path => ({ size: files.get(path)?.length ?? 100_000 }),
+    });
+
+    expect(candidate).toMatchObject({
+      binPath: `${nvmBin}/botmux`,
+      version: '2.32.0',
+      // Interactive PATH is probed first, so nvm's prepend stays in front.
+      pathEnv: `${nvmBin}:/usr/bin:/bin`,
+    });
+  });
+
+  it('probes the bash login shell for bash users', () => {
+    const nvmBin = '/Users/me/.nvm/versions/node/v22.22.2/bin';
+    const files = new Map([
+      [`/Users/me/.nvm/versions/node/v22.22.2/lib/node_modules/botmux/package.json`, JSON.stringify({ name: 'botmux', version: '2.32.0' })],
+      [`/Users/me/.nvm/versions/node/v22.22.2/lib/node_modules/botmux/dist/cli.js`, ''],
+    ]);
+
+    const candidate = discoverExternalRuntimeCandidate(paths, {
+      platform: 'darwin',
+      env: { SHELL: '/bin/bash' },
+      execFileSync: (file, args) => {
+        // Only the user's bash rc file knows about the nvm install.
+        if (file === '/bin/bash' && args[0] === '-ic') {
+          return `__BOTMUX_PATH__${nvmBin}:/usr/bin:/bin\n${nvmBin}/botmux\n`;
+        }
+        return '';
+      },
+      existsSync: path => files.has(path),
+      readFileSync: path => files.get(path) ?? '',
+      realpathSync: path => path === `${nvmBin}/botmux`
+        ? '/Users/me/.nvm/versions/node/v22.22.2/lib/node_modules/botmux/dist/cli.js'
+        : path,
+      statSync: path => ({ size: files.get(path)?.length ?? 100_000 }),
+    });
+
+    expect(candidate).toMatchObject({
+      binPath: `${nvmBin}/botmux`,
+      version: '2.32.0',
+      pathEnv: `${nvmBin}:/usr/bin:/bin`,
+    });
+  });
+
+  it('attaches the probed shell PATH to bins found outside the shell probe', () => {
+    const files = new Map([
+      ['/usr/local/lib/node_modules/botmux/package.json', JSON.stringify({ name: 'botmux', version: '2.9.0' })],
+      ['/usr/local/lib/node_modules/botmux/dist/cli.js', ''],
+    ]);
+
+    const candidate = discoverExternalRuntimeCandidate(paths, {
+      platform: 'darwin',
+      env: {},
+      execFileSync: (file, args) => {
+        // `which` (GUI PATH) finds the bin; the shell probes only know the PATH.
+        if (file === 'which') return '/usr/local/bin/botmux\n';
+        if (file === '/bin/zsh' && args[0] === '-ic') {
+          return '__BOTMUX_PATH__/Users/me/.nvm/versions/node/v22.22.2/bin:/usr/local/bin:/usr/bin:/bin\n';
+        }
+        return '';
+      },
+      existsSync: path => files.has(path),
+      readFileSync: path => files.get(path) ?? '',
+      realpathSync: path => path === '/usr/local/bin/botmux'
+        ? '/usr/local/lib/node_modules/botmux/dist/cli.js'
+        : path,
+      statSync: path => ({ size: files.get(path)?.length ?? 100_000 }),
+    });
+
+    // The daemon started from this bin still needs the shell PATH to find
+    // nvm-managed `node` and per-bot CLIs.
+    expect(candidate).toMatchObject({
+      binPath: '/usr/local/bin/botmux',
+      pathEnv: '/Users/me/.nvm/versions/node/v22.22.2/bin:/usr/local/bin:/usr/bin:/bin',
+    });
+  });
+
   it('does not invent an app-private runtime when no global CLI can be resolved', () => {
     const candidate = discoverExternalRuntimeCandidate(paths, {
       binPaths: [],

--- a/test/desktop/desktop-pm2-apps.test.ts
+++ b/test/desktop/desktop-pm2-apps.test.ts
@@ -80,11 +80,13 @@ describe('desktop PM2 app listing', () => {
     child.emit('close', 0);
     await expect(promise).resolves.toEqual([]);
     const env = (spawn.mock.calls[0] as unknown as [string, string[], { env: NodeJS.ProcessEnv }])[2].env;
-    // Bundled node stays first (pm2 itself must run on it); the probed shell
-    // PATH follows so the pm2 daemon's sticky env can resolve user CLIs.
+    // Must match the daemon-start ordering exactly (buildBundledPath): pm2's
+    // sticky daemon env propagates into resurrected apps, so which node a
+    // per-bot CLI resolves must not depend on pm2 startup order. pm2 itself is
+    // launched via the absolute nodePath, never through this PATH.
     expect(env.PATH).toBe([
-      '/Applications/Botmux.app/Contents/Resources/node/darwin-arm64/bin',
       '/Users/me/.nvm/versions/node/v22.22.2/bin',
+      '/Applications/Botmux.app/Contents/Resources/node/darwin-arm64/bin',
       '/opt/homebrew/bin',
       '/usr/local/bin',
       '/usr/bin',

--- a/test/desktop/desktop-pm2-apps.test.ts
+++ b/test/desktop/desktop-pm2-apps.test.ts
@@ -58,6 +58,40 @@ describe('desktop PM2 app listing', () => {
     );
   });
 
+  it('keeps the probed shell PATH in the bundled PM2 environment', async () => {
+    const child = childProcessStub();
+    const spawn = vi.fn(() => child);
+    const bundled: RuntimeLaunchTarget = {
+      kind: 'bundled',
+      root: '/Applications/Botmux.app/Contents/Resources/runtime',
+      cliPath: '/Applications/Botmux.app/Contents/Resources/runtime/dist/cli.js',
+      nodePath: '/Applications/Botmux.app/Contents/Resources/node/darwin-arm64/bin/node',
+      version: '3.0.0',
+      runtimeSource: 'bundled',
+    };
+    const promise = listPm2Apps(paths, bundled, {
+      existsSync: () => true,
+      spawn: spawn as any,
+      env: { PATH: '/usr/bin:/bin' },
+      pathEnv: '/Users/me/.nvm/versions/node/v22.22.2/bin',
+    });
+
+    child.stdout.emit('data', '[]');
+    child.emit('close', 0);
+    await expect(promise).resolves.toEqual([]);
+    const env = (spawn.mock.calls[0] as unknown as [string, string[], { env: NodeJS.ProcessEnv }])[2].env;
+    // Bundled node stays first (pm2 itself must run on it); the probed shell
+    // PATH follows so the pm2 daemon's sticky env can resolve user CLIs.
+    expect(env.PATH).toBe([
+      '/Applications/Botmux.app/Contents/Resources/node/darwin-arm64/bin',
+      '/Users/me/.nvm/versions/node/v22.22.2/bin',
+      '/opt/homebrew/bin',
+      '/usr/local/bin',
+      '/usr/bin',
+      '/bin',
+    ].join(':'));
+  });
+
   it('rejects when the selected runtime does not contain a PM2 binary', async () => {
     await expect(listPm2Apps(paths, runtime, {
       existsSync: () => false,

--- a/test/desktop/desktop-runtime-service.test.ts
+++ b/test/desktop/desktop-runtime-service.test.ts
@@ -63,6 +63,33 @@ describe('runtime service', () => {
     expect(run.mock.calls[0]![0].env).not.toHaveProperty('ELECTRON_RUN_AS_NODE');
   });
 
+  it('repairs the bundled daemon PATH with the probed shell PATH', async () => {
+    const run = vi.fn().mockResolvedValue({ code: 0, stdout: 'ok', stderr: '' });
+    const svc = createRuntimeService({
+      paths,
+      appVersion: '3.0.0',
+      execPath: '/Electron',
+      env: { PATH: '/usr/bin:/bin' },
+      fs: { existsSync: () => true, readFileSync: () => configuredBots },
+      run,
+      bundledRuntime: bundledRuntime(),
+      // nvm-in-.zshrc user: their node must stay ahead of the bundled fallback
+      // so PtyBackend-spawned CLIs resolve `#!/usr/bin/env node` like a terminal.
+      shellPathEnv: () => '/Users/me/.nvm/versions/node/v22.22.2/bin:/opt/homebrew/bin',
+      pm2Apps: async () => [],
+    });
+
+    await svc.start();
+    expect(run.mock.calls[0]![0].env.PATH).toBe([
+      '/Users/me/.nvm/versions/node/v22.22.2/bin',
+      '/opt/homebrew/bin',
+      '/Applications/Botmux.app/Contents/Resources/node/darwin-arm64/bin',
+      '/usr/local/bin',
+      '/usr/bin',
+      '/bin',
+    ].join(':'));
+  });
+
   it('detects an external fleet and replaces it through the bundled runtime', async () => {
     const run = vi.fn().mockResolvedValue({ code: 0, stdout: 'ok', stderr: '' });
     const svc = createRuntimeService({

--- a/test/desktop/desktop-smoke.test.ts
+++ b/test/desktop/desktop-smoke.test.ts
@@ -166,6 +166,44 @@ describe('desktop smoke', () => {
     expect(deps.output.join('\n')).toContain('botmux CLI status');
   });
 
+  it('falls back to the bash rc shell for bash users when botmux is missing from PATH', async () => {
+    const deps = makeDeps(appPaths, {
+      'plutil -extract CFBundleShortVersionString raw -o - /Applications/Botmux.app/Contents/Info.plist': {
+        status: 0,
+        stdout: '2.96.0\n',
+        stderr: '',
+      },
+      'codesign --verify --deep --strict --verbose=2 /Applications/Botmux.app': {
+        status: 0,
+        stdout: '',
+        stderr: '',
+      },
+      'botmux status': {
+        status: null,
+        stdout: '',
+        stderr: '',
+        error: new Error('spawnSync botmux ENOENT'),
+      },
+      // nvm-in-.bashrc install: only the interactive bash probe can see botmux.
+      '/bin/bash -ic botmux status': {
+        status: 0,
+        stdout: 'botmux running\n',
+        stderr: '',
+      },
+      'curl -fsS --max-time 5 http://127.0.0.1:7891/__desktop/compat': {
+        status: 0,
+        stdout: JSON.stringify({ schemaVersion: 1, product: 'botmux', runtimeVersion: '2.96.0', dashboardProtocolVersion: 1 }),
+        stderr: '',
+      },
+    });
+    deps.env.SHELL = '/bin/bash';
+
+    const code = await runAppSmokeCommand([], deps);
+
+    expect(code).toBe(0);
+    expect(deps.output.join('\n')).toContain('botmux CLI status');
+  });
+
   it('fails when the installed app still has the placeholder version', async () => {
     const deps = makeDeps(appPaths, {
       'plutil -extract CFBundleShortVersionString raw -o - /Applications/Botmux.app/Contents/Info.plist': {

--- a/test/resolve-command-shell-parse.test.ts
+++ b/test/resolve-command-shell-parse.test.ts
@@ -1,0 +1,76 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { resolveCommand } from '../src/adapters/cli/registry.js';
+import { shellPathProbes } from '../src/desktop/shared/shell-path-probes.js';
+
+describe('shellPathProbes ladder', () => {
+  it('defaults to zsh, interactive flavor first', () => {
+    expect(shellPathProbes({})).toEqual([
+      { shell: '/bin/zsh', flags: '-ic' },
+      { shell: '/bin/zsh', flags: '-lc' },
+    ]);
+  });
+
+  it('probes the bash login shell before the zsh fallback for bash users', () => {
+    expect(shellPathProbes({ SHELL: '/bin/bash' })).toEqual([
+      { shell: '/bin/bash', flags: '-ic' },
+      { shell: '/bin/bash', flags: '-lc' },
+      { shell: '/bin/zsh', flags: '-ic' },
+      { shell: '/bin/zsh', flags: '-lc' },
+    ]);
+  });
+
+  it('dedupes when $SHELL already is /bin/zsh', () => {
+    expect(shellPathProbes({ SHELL: '/bin/zsh' })).toEqual([
+      { shell: '/bin/zsh', flags: '-ic' },
+      { shell: '/bin/zsh', flags: '-lc' },
+    ]);
+  });
+
+  it('ignores non-POSIX shells like fish', () => {
+    expect(shellPathProbes({ SHELL: '/usr/local/bin/fish' })).toEqual([
+      { shell: '/bin/zsh', flags: '-ic' },
+      { shell: '/bin/zsh', flags: '-lc' },
+    ]);
+  });
+});
+
+describe('resolveCommand shell output parsing', () => {
+  let dir: string;
+  let savedShell: string | undefined;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'botmux-shell-parse-'));
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    if (savedShell === undefined) delete process.env.SHELL;
+    else process.env.SHELL = savedShell;
+  });
+
+  function useFakeShell(script: string): void {
+    savedShell = process.env.SHELL;
+    const shellPath = join(dir, `fake-shell-${Math.random().toString(36).slice(2)}`);
+    writeFileSync(shellPath, script);
+    chmodSync(shellPath, 0o755);
+    process.env.SHELL = shellPath;
+  }
+
+  it('takes the last absolute line so rc-file banners cannot break resolution', () => {
+    // Simulates an rc file that echoes a banner before `which` prints its path.
+    useFakeShell('#!/bin/sh\necho "Welcome to devbox!"\necho "/opt/fake/bin/mytool"\nexit 0\n');
+    expect(resolveCommand('mytool')).toBe('/opt/fake/bin/mytool');
+  });
+
+  it('rejects output from probes that did not exit cleanly', () => {
+    // A failed `which` must not let an echoed path masquerade as the result.
+    useFakeShell('#!/bin/sh\necho "/opt/fake/bin/botmux-test-no-such-tool"\nexit 3\n');
+    expect(resolveCommand('botmux-test-no-such-tool')).toBe('botmux-test-no-such-tool');
+  });
+});


### PR DESCRIPTION
## 背景

用户（远东）反馈：traex 从命令行启动 botmux 正常，但 macOS APP 启动的 daemon 报「找不到 traex」。排查结论（飞书内讨论）指向 APP 的 PATH 继承问题。本 PR 核实确认了问题，并给 APP 与 CLI 两种启动方式补全 zsh/bash 兼容。

## 问题核实（逐条）

1. **`external-runtime.ts` 硬编码 `/bin/zsh -lc` 探测** ✅ 属实：`-lc`（login 非交互）只读 `.zshenv`/`.zprofile`，**不读 `.zshrc`**——nvm/fnm 恰恰默认写在 `.zshrc`；且 bash 用户（`SHELL=bash`）的 `.bash_profile`/`.bashrc` 完全不被读取。
2. **master 切 bundled runtime 后问题被放大** ⚠️ 新发现：`buildBundledBotmuxCommand`（dc7ec9b4 起打包版 APP 的生产路径）**完全没有 PATH 修复**——Finder 启动的 daemon 直接拿 launchd 最小 PATH（连 `/opt/homebrew/bin` 都没有）。PtyBackend 直接 `pty.spawn(bin)` 不经 shell rc，npm 全局 CLI 的 `#!/usr/bin/env node` shebang 完全依赖 daemon PATH 里有 node → nvm 用户必挂。
3. **CLI 启动的 daemon** 基本已兼容（终端继承完整 PATH；`resolveCommand` 本就探测 `$SHELL`/zsh/bash × `-lc`/`-ic`；tmux wrapper 对 bash `-i` / zsh `-l -i` 的 rcfile 差异已正确处理）。但 `resolveCommand` 解析有脆弱点：rc 文件往 stdout echo 任何内容（欢迎语等）都会破坏「整段 stdout 必须是绝对路径」的判断，`-ic` 探测遇 echo 即失效。

## 改动

- **新增 `src/desktop/shared/shell-path-probes.ts`**：探测阶梯——用户 `$SHELL`（zsh/bash 才认）优先、`/bin/zsh` 兜底；`-ic`（rc）先于 `-lc`（profile），因为真实终端是 login+interactive，rc 的 prepend（nvm node 目录）排在 profile 条目前面；上限 4 次 spawn。
- **`external-runtime.ts`**：单一 zsh 探测 → 多 shell × 多口味探测，PATH 取并集、bin 去重；并集 PATH 附着到**所有**候选（含 `which`/硬编码路径发现的），保证无论哪个 bin 胜出 daemon 都拿到 shell PATH；`which -a botmux || true` 让「该口味看不到 botmux」时 PATH 仍可用；输出只认绝对路径行（防 rc echo 与 zsh "not found" 混入）。**TTL 缓存**（命中 5min / 未命中 20s）：runtime state 5s 轮询会反复触发 discovery，无缓存会每 5s spawn 4 个 rc shell；测试注入 deps 时绕过缓存防状态泄漏。
- **`node-command.ts` + `runtime-service.ts` + `main.ts`**：bundled daemon spawn 注入探测 PATH——顺序为「用户 shell PATH → bundled node 目录（shebang 兜底）→ homebrew 等常规目录 → 原 PATH」，用户自己的 nvm node 保持优先（与终端行为一致）。
- **`pm2-apps.ts`**：bundled 分支的 jlist env 同样携带探测 PATH——jlist 可能是首个 pm2 接触点、会拉起 pm2 daemon，其 env 会固化并传给后续 resurrect 的进程（#505 的教训）。
- **`smoke.ts`**：CLI status 重试从单发 `/bin/zsh -lc` 改走同一探测阶梯（bundled node 直连路径不变）。
- **`registry.ts` `resolveCommand`**：要求 shell **干净退出**（此前不查 status，echo 出的伪路径可能被误收）＋ 取 stdout **最后一行绝对路径**（rc banner 不再破坏解析）。此为全 CLI × 两种启动方式共用路径的加固。

## 影响面评估

- **跨平台**：shell 探测阶梯仅 darwin 生效（`probeShellPathEnv` 非 darwin 返回 undefined；external-runtime 探测本就 darwin-guard）；`resolveCommand` 加固平台无关，Linux daemon 同样受益（更严格：拒绝非零退出的探测结果；rc echo 场景从必败变可用）。
- **跨 CLI**：`resolveCommand` 是 20+ CLI 共用的解析口。行为变化仅两处：rc-echo 时从「探测失败」变「正确解析」；`which` 失败但 stdout 有绝对路径行时从「误收」变「拒绝」。探测顺序（`-lc` 先于 `-ic`、shell 序）未动，既有用户的解析结果不漂移。
- **跨后端**：PtyBackend 受益最大（无 rc wrapper，全靠 daemon PATH）；tmux/zellij wrapper 逻辑未动。
- **APP vs CLI**：CLI 启动路径除 `resolveCommand` 加固外零改动。
- **性能**：APP 侧探测从每次 discovery 1 spawn → 缓存后每 5min 4 spawn（未安装态每 20s），净减少。

## 测试验证

- `pnpm build` 通过（tsc + esbuild）。
- 新增/改动测试 24 个全绿（隔离跑）：
  - `test/resolve-command-shell-parse.test.ts`（新）：探测阶梯 4 用例（默认 zsh / bash 用户 / dedup / fish 回退）＋ 用**真实假 shell 可执行文件**验证 rc-banner 解析与非零退出拒收；
  - `desktop-external-runtime.test.ts` ＋3：rc-only（nvm-in-.zshrc）经 `-ic` 发现、bash 用户经 bash 探测、shell PATH 附着到 `which` 发现的 bin；
  - `desktop-runtime-service.test.ts` ＋1：bundled daemon PATH 精确断言（用户 nvm 在 bundled node 之前）；
  - `desktop-pm2-apps.test.ts` ＋1：bundled jlist env PATH 精确断言（bundled node 最前）；
  - `desktop-smoke.test.ts` ＋1：bash 用户经 `/bin/bash -ic` 重试成功。
- `test/desktop/` 全套 129/129 绿；相邻套件（cli-availability / seed / relay / backend-availability）144/144 绿。
- 全量 `pnpm test`：9879 passed / 9 failed，失败均为本机已知基线（v3-distillation ×6 常驻败＋ scheduler/schedule-card ×3 时区漂移），与本 diff 零交集。
- 未做 live 部署（改动主体在 macOS APP 侧，本 daemon 机为 Linux；`resolveCommand` 加固已被单测覆盖）。**APP 侧建议由有 macOS 打包环境的同学在 nvm-in-.zshrc 或 bash 用户环境实测**：Finder 启动 APP → 建 traex/claude 会话应能直接找到 CLI。