### PR TITLE
feat(create-group): 新增 --kickoff-bot/--kickoff-prompt 自动触发 bot 干活

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7347,6 +7347,7 @@ botmux create-group — 用一组机器人新建飞书群
 用法:
   botmux create-group --bot <name|larkAppId> [--bot ...] [--name "群名"]
                       [--working-dir <path>]
+                      [--kickoff-bot <open_id> --kickoff-prompt "文本"]
 
 参数:
   --bot <ref>     至少一个，可多次。ref 推荐用 bot 显示名（同 botmux send 的 @<name>）或完整 larkAppId；
@@ -7357,6 +7358,10 @@ botmux create-group — 用一组机器人新建飞书群
   --working-dir <path>
                  可选；创建成功后，把新群为所有成功入群的 bot 绑定到该目录（等价于逐个 /oncall bind），
                  下次在群里开新话题时直接使用该目录，跳过仓库选择卡片。也可写作 --cwd / --dir。
+  --kickoff-bot <open_id>  可选；建群成功后由 creator @ 该 bot 并发送 --kickoff-prompt，
+                 触发该 bot 自动开始工作（如 PR review）。需配合 --kickoff-prompt 使用。
+                 该 bot 必须已在 --bot 列表中（即已是群成员）。
+  --kickoff-prompt "文本"  可选；与 --kickoff-bot 配合使用，@ bot 后发送的 prompt 文本。
 
 行为:
   - 第一个解析到的 bot 作为 creator（决定建群身份 + 初始群主 + open_id app scope）。
@@ -7364,6 +7369,8 @@ botmux create-group — 用一组机器人新建飞书群
     转不出来或为空则跳过对应步骤，stderr warning）。
   - 不依赖 botmux 会话，任何环境都能跑。
   - --working-dir 会先校验路径存在且是目录；绑定失败不会重复建群，会在 stderr 给出逐 bot 结果。
+  - --kickoff-bot/--kickoff-prompt：creator 建群后 @ 指定 bot 并发 prompt；该 bot 收到 @ 会自动起会话。
+    注意：creator 不能 @ 自己（自消息被忽略），故 --kickoff-bot 应选 creator 之外的 bot。
 
 输出协议（skill 友好）:
   - 成功（即使 transfer/notify 部分失败）：stdout 单行 chatId，exit 0；stderr 打人类提示 + applink。
@@ -7377,6 +7384,8 @@ botmux create-group — 用一组机器人新建飞书群
   const botRefs = argValues(rest, '--bot');
   const name = argValue(rest, '--name');
   const workingDirArg = argValue(rest, '--working-dir', '--cwd', '--dir');
+  const kickoffBot = argValue(rest, '--kickoff-bot');
+  const kickoffPrompt = argValue(rest, '--kickoff-prompt');
 
   let bindWorkingDir: string | undefined;
   let bindWorkingDirResolved: string | undefined;
@@ -7418,7 +7427,7 @@ botmux create-group — 用一组机器人新建飞书群
   let botInfoEntries: BotInfoEntry[] = [];
   try { if (existsSync(botInfoPath)) botInfoEntries = JSON.parse(readFileSync(botInfoPath, 'utf-8')); } catch { /* */ }
 
-  const { resolveBotRefs } = await import('./cli/create-group-resolver.js');
+  const { resolveBotRefs, resolveKickoff } = await import('./cli/create-group-resolver.js');
   const resolved = resolveBotRefs(
     botRefs,
     botConfigs,
@@ -7441,6 +7450,16 @@ botmux create-group — 用一组机器人新建飞书群
   }
 
   const creatorLarkAppId = resolved.larkAppIds[0];
+  const kickoff = resolveKickoff(
+    kickoffBot,
+    kickoffPrompt,
+    resolved.larkAppIds,
+    botInfoEntries.map(b => ({ larkAppId: b.larkAppId, botOpenId: b.botOpenId })),
+  );
+  if (!kickoff.ok) {
+    console.error(kickoff.error);
+    process.exit(1);
+  }
 
   // Register bots so getBotClient works inside service
   const fullConfigs = loadBotConfigs();
@@ -7479,6 +7498,8 @@ botmux create-group — 用一组机器人新建飞书群
       transferOwnerTo: targetOpenId,
       notifyOwnerOpenId: targetOpenId,
       bindWorkingDir,
+      kickoffBotLarkAppId: kickoff.targetLarkAppId,
+      kickoffPrompt: kickoff.prompt,
     });
   } catch (err: any) {
     console.error(`建群失败: ${err?.message ?? err}`);
@@ -7507,6 +7528,11 @@ botmux create-group — 用一组机器人新建飞书群
     console.error(`⚠️  @通知发送失败: ${result.notifyError}`);
   } else if (result.notifyMessageId) {
     console.error(`✅ @通知已发送 (msg ${result.notifyMessageId})`);
+  }
+  if (result.kickoffError) {
+    console.error(`⚠️  kickoff 消息发送失败: ${result.kickoffError}`);
+  } else if (result.kickoffMessageId) {
+    console.error(`✅ kickoff 消息已发送 (msg ${result.kickoffMessageId})`);
   }
   if (bindWorkingDir) {
     const ok = result.oncallBindings.filter(b => b.ok).length;

--- a/src/cli/create-group-resolver.ts
+++ b/src/cli/create-group-resolver.ts
@@ -23,6 +23,15 @@ export interface BotInfoForResolve {
   botName: string | null;
 }
 
+export interface BotInfoForKickoff {
+  larkAppId: string;
+  botOpenId: string | null;
+}
+
+export type ResolvedKickoff =
+  | { ok: true; targetLarkAppId?: string; prompt?: string }
+  | { ok: false; error: string };
+
 export interface ResolvedBots {
   /** Resolved larkAppIds in input order, deduped. First element is creator. */
   larkAppIds: string[];
@@ -95,4 +104,43 @@ export function resolveBotRefs(
   }
 
   return { larkAppIds: out, invalid, ambiguousWarnings };
+}
+
+/**
+ * Validate the optional kickoff pair and resolve the user-facing bot open_id
+ * back to a selected larkAppId. The service later obtains the target bot's
+ * observer-scoped open_id from the creator app before sending the @mention;
+ * a bot's self-reported open_id is not valid across Lark apps.
+ */
+export function resolveKickoff(
+  botOpenIdRaw: string | undefined,
+  promptRaw: string | undefined,
+  selectedLarkAppIds: string[],
+  botInfo: BotInfoForKickoff[],
+): ResolvedKickoff {
+  const botOpenId = botOpenIdRaw?.trim() || undefined;
+  const prompt = promptRaw?.trim() || undefined;
+
+  if (!botOpenId && !prompt) return { ok: true };
+  if (!botOpenId || !prompt) {
+    return { ok: false, error: '--kickoff-bot 与 --kickoff-prompt 必须同时提供且不能为空。' };
+  }
+
+  const matches = botInfo.filter(info => info.botOpenId?.trim() === botOpenId);
+  if (matches.length === 0) {
+    return { ok: false, error: `--kickoff-bot 未匹配到本机 bot: ${botOpenId}` };
+  }
+  if (matches.length > 1) {
+    return { ok: false, error: `--kickoff-bot 匹配到多个本机 bot，请检查 bots-info.json: ${botOpenId}` };
+  }
+
+  const targetLarkAppId = matches[0].larkAppId;
+  if (!selectedLarkAppIds.includes(targetLarkAppId)) {
+    return { ok: false, error: '--kickoff-bot 必须属于本次 --bot 列表。' };
+  }
+  if (targetLarkAppId === selectedLarkAppIds[0]) {
+    return { ok: false, error: '--kickoff-bot 不能是 creator（第一个 --bot）。' };
+  }
+
+  return { ok: true, targetLarkAppId, prompt };
 }

--- a/src/services/group-creator.ts
+++ b/src/services/group-creator.ts
@@ -49,6 +49,12 @@ export interface CreateGroupOpts {
    *  local entry directly; peer bots are prompted by a multi-mention
    *  `/role profile apply` command in the newly created chat. */
   roleProfileId?: string;
+  /** Optional kickoff: after the chat is created, the creator @-mentions this
+   *  bot and posts `kickoffPrompt` as a top-level message. Used to
+   *  auto-trigger a bot (e.g. a reviewer) in the new group without a human
+   *  having to @ it. The kickoff bot must be present in `larkAppIds`. */
+  kickoffBotLarkAppId?: string;
+  kickoffPrompt?: string;
 }
 
 export interface CreateGroupResult {
@@ -70,6 +76,8 @@ export interface CreateGroupResult {
   oncallBindings: { larkAppId: string; ok: boolean; created?: boolean; error?: string }[];
   roleProfileBootstrapMessageId: string | null;
   roleProfileBootstrapError: string | null;
+  kickoffMessageId: string | null;
+  kickoffError: string | null;
 }
 
 export interface TransferGroupOwnerOpts {
@@ -276,6 +284,47 @@ export async function createGroupWithBots(opts: CreateGroupOpts): Promise<Create
     }
   }
 
+  // Kickoff: creator @-mentions a target bot with a prompt so it auto-starts
+  // working (e.g. a PR review). Resolve the @ handle from the creator's view of
+  // the new chat: Lark open_id values are app-scoped, so the target bot's
+  // self-reported open_id cannot be used directly by the creator app.
+  let kickoffMessageId: string | null = null;
+  let kickoffError: string | null = null;
+  const kickoffBot = opts.kickoffBotLarkAppId?.trim();
+  const kickoffPrompt = opts.kickoffPrompt?.trim();
+  if (!!kickoffBot !== !!kickoffPrompt) {
+    kickoffError = 'kickoff_args_must_be_paired';
+  } else if (kickoffBot && kickoffPrompt) {
+    if (kickoffBot === opts.creatorLarkAppId) {
+      kickoffError = 'creator_cannot_kickoff_self';
+    } else if (!opts.larkAppIds.includes(kickoffBot)) {
+      kickoffError = 'kickoff_bot_not_selected';
+    } else if (r.invalidBotIds.includes(kickoffBot)) {
+      kickoffError = 'invitee_rejected';
+    }
+
+    try {
+      if (!kickoffError) {
+        const members = await listChatBotMembers(opts.creatorLarkAppId, r.chatId);
+        const target = members.find(member => member.larkAppId === kickoffBot);
+        if (!target) {
+          kickoffError = 'kickoff_bot_not_found_in_chat';
+        } else if (!target.mentionable) {
+          kickoffError = 'kickoff_bot_not_mentionable';
+        } else {
+          kickoffMessageId = await sendMessage(
+            opts.creatorLarkAppId,
+            r.chatId,
+            `<at user_id="${target.openId}"></at> ${kickoffPrompt}`,
+            'text',
+          );
+        }
+      }
+    } catch (e: any) {
+      kickoffError = e?.message ?? String(e);
+    }
+  }
+
   return {
     ok: true,
     chatId: r.chatId,
@@ -292,5 +341,7 @@ export async function createGroupWithBots(opts: CreateGroupOpts): Promise<Create
     oncallBindings,
     roleProfileBootstrapMessageId,
     roleProfileBootstrapError,
+    kickoffMessageId,
+    kickoffError,
   };
 }

--- a/test/create-group-resolver.test.ts
+++ b/test/create-group-resolver.test.ts
@@ -10,7 +10,7 @@
  *  - unresolvable refs → reported in `invalid`
  */
 import { describe, it, expect } from 'vitest';
-import { resolveBotRefs } from '../src/cli/create-group-resolver.js';
+import { resolveBotRefs, resolveKickoff } from '../src/cli/create-group-resolver.js';
 
 const CFG_CLAUDE = { larkAppId: 'cli_claude_1', cliId: 'claude-code' };
 const CFG_COCO_1 = { larkAppId: 'cli_coco_1', cliId: 'claude-code' };
@@ -112,5 +112,49 @@ describe('resolveBotRefs', () => {
     const r = resolveBotRefs(['cli_claude_1'], [CFG_CLAUDE], [INFO_CLAUDE]);
     expect(r.larkAppIds).toEqual(['cli_claude_1']);
     expect(r.ambiguousWarnings).toEqual([]);
+  });
+});
+
+describe('resolveKickoff', () => {
+  const selected = ['cli_creator', 'cli_reviewer'];
+  const botInfo = [
+    { larkAppId: 'cli_creator', botOpenId: 'ou_creator_self' },
+    { larkAppId: 'cli_reviewer', botOpenId: 'ou_reviewer_self' },
+    { larkAppId: 'cli_unselected', botOpenId: 'ou_unselected_self' },
+  ];
+
+  it('accepts an omitted kickoff pair', () => {
+    expect(resolveKickoff(undefined, undefined, selected, botInfo)).toEqual({ ok: true });
+  });
+
+  it('requires both kickoff arguments and rejects whitespace-only values', () => {
+    expect(resolveKickoff('ou_reviewer_self', undefined, selected, botInfo)).toEqual({
+      ok: false,
+      error: '--kickoff-bot 与 --kickoff-prompt 必须同时提供且不能为空。',
+    });
+    expect(resolveKickoff('   ', 'review this', selected, botInfo).ok).toBe(false);
+  });
+
+  it('resolves a selected non-creator bot and trims the prompt', () => {
+    expect(resolveKickoff(' ou_reviewer_self ', ' review this ', selected, botInfo)).toEqual({
+      ok: true,
+      targetLarkAppId: 'cli_reviewer',
+      prompt: 'review this',
+    });
+  });
+
+  it('rejects an unknown or unselected bot open_id', () => {
+    expect(resolveKickoff('ou_unknown', 'review', selected, botInfo).ok).toBe(false);
+    expect(resolveKickoff('ou_unselected_self', 'review', selected, botInfo)).toEqual({
+      ok: false,
+      error: '--kickoff-bot 必须属于本次 --bot 列表。',
+    });
+  });
+
+  it('rejects the creator bot', () => {
+    expect(resolveKickoff('ou_creator_self', 'review', selected, botInfo)).toEqual({
+      ok: false,
+      error: '--kickoff-bot 不能是 creator（第一个 --bot）。',
+    });
   });
 });

--- a/test/group-creator.test.ts
+++ b/test/group-creator.test.ts
@@ -191,6 +191,8 @@ describe('createGroupWithBots', () => {
       oncallBindings: [],
       roleProfileBootstrapMessageId: null,
       roleProfileBootstrapError: null,
+      kickoffMessageId: null,
+      kickoffError: null,
     });
   });
 
@@ -392,6 +394,99 @@ describe('createGroupWithBots', () => {
     });
     expect(result.invalidBotIds).toEqual(['cli_zombie']);
     expect(result.invalidUserIds).toEqual(['ou_banned']);
+  });
+
+  it('sends kickoff using the target bot open_id observed by the creator app', async () => {
+    mockCreateChat.mockResolvedValue({ chatId: 'oc_kickoff', invalidBotIds: [], invalidUserIds: [] });
+    mockListChatBotMembers.mockResolvedValue([
+      { larkAppId: CREATOR, openId: 'ou_creator', mentionable: true },
+      { larkAppId: OTHER_BOT, openId: 'ou_other_seen_by_creator', mentionable: true },
+    ]);
+    mockSendMessage.mockResolvedValue('om_kickoff');
+
+    const result = await createGroupWithBots({
+      creatorLarkAppId: CREATOR,
+      larkAppIds: [CREATOR, OTHER_BOT],
+      kickoffBotLarkAppId: OTHER_BOT,
+      kickoffPrompt: 'Review PR 562',
+    });
+
+    expect(mockListChatBotMembers).toHaveBeenCalledWith(CREATOR, 'oc_kickoff');
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      CREATOR,
+      'oc_kickoff',
+      '<at user_id="ou_other_seen_by_creator"></at> Review PR 562',
+      'text',
+    );
+    expect(result.kickoffMessageId).toBe('om_kickoff');
+    expect(result.kickoffError).toBeNull();
+  });
+
+  it('does not send kickoff when Lark rejected the target bot invite', async () => {
+    mockCreateChat.mockResolvedValue({ chatId: 'oc_kickoff', invalidBotIds: [], invalidUserIds: [] });
+    mockAddBotToChat.mockResolvedValue([{ id: OTHER_BOT, ok: false, error: 'invalid_id' }]);
+
+    const result = await createGroupWithBots({
+      creatorLarkAppId: CREATOR,
+      larkAppIds: [CREATOR, OTHER_BOT],
+      kickoffBotLarkAppId: OTHER_BOT,
+      kickoffPrompt: 'Review PR 562',
+    });
+
+    expect(mockListChatBotMembers).not.toHaveBeenCalled();
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(result.kickoffMessageId).toBeNull();
+    expect(result.kickoffError).toBe('invitee_rejected');
+  });
+
+  it('surfaces an unmentionable kickoff target without aborting group creation', async () => {
+    mockCreateChat.mockResolvedValue({ chatId: 'oc_kickoff', invalidBotIds: [], invalidUserIds: [] });
+    mockListChatBotMembers.mockResolvedValue([
+      { larkAppId: OTHER_BOT, openId: 'ou_other_self_scope', mentionable: false },
+    ]);
+
+    const result = await createGroupWithBots({
+      creatorLarkAppId: CREATOR,
+      larkAppIds: [CREATOR, OTHER_BOT],
+      kickoffBotLarkAppId: OTHER_BOT,
+      kickoffPrompt: 'Review PR 562',
+    });
+
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(result.kickoffMessageId).toBeNull();
+    expect(result.kickoffError).toBe('kickoff_bot_not_mentionable');
+  });
+
+  it('surfaces kickoff send failure without aborting group creation', async () => {
+    mockCreateChat.mockResolvedValue({ chatId: 'oc_kickoff', invalidBotIds: [], invalidUserIds: [] });
+    mockListChatBotMembers.mockResolvedValue([
+      { larkAppId: OTHER_BOT, openId: 'ou_other_seen_by_creator', mentionable: true },
+    ]);
+    mockSendMessage.mockRejectedValue(new Error('network down'));
+
+    const result = await createGroupWithBots({
+      creatorLarkAppId: CREATOR,
+      larkAppIds: [CREATOR, OTHER_BOT],
+      kickoffBotLarkAppId: OTHER_BOT,
+      kickoffPrompt: 'Review PR 562',
+    });
+
+    expect(result.chatId).toBe('oc_kickoff');
+    expect(result.kickoffMessageId).toBeNull();
+    expect(result.kickoffError).toBe('network down');
+  });
+
+  it('requires paired kickoff service arguments', async () => {
+    mockCreateChat.mockResolvedValue({ chatId: 'oc_kickoff', invalidBotIds: [], invalidUserIds: [] });
+    const result = await createGroupWithBots({
+      creatorLarkAppId: CREATOR,
+      larkAppIds: [CREATOR, OTHER_BOT],
+      kickoffBotLarkAppId: OTHER_BOT,
+    });
+
+    expect(mockListChatBotMembers).not.toHaveBeenCalled();
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(result.kickoffError).toBe('kickoff_args_must_be_paired');
   });
 
   it('materializes the creator role directly and posts a bootstrap command for peers', async () => {


### PR DESCRIPTION
## 改了什么

给 `botmux create-group` 新增一组可选 kickoff 参数：

- `--kickoff-bot <open_id>`：指定建群后要自动触发的 bot
- `--kickoff-prompt "文本"`：由 creator @ 该 bot 后发送的任务文本

建群成功后，creator 会向新群发送一条顶层 @ 消息，让目标 bot 自动起会话工作（例如 PR review）。kickoff 发送是 best-effort：失败会写入 `kickoffError` 并打印到 stderr，不会把已经建好的群判成失败。

## 行为与边界

- 两个参数必须同时提供且不能为空，否则在建群前失败。
- `--kickoff-bot` 必须能解析到本机 bot、属于本次 `--bot` 列表，且不能是第一个 bot（creator 自己发送的消息不会触发自己）。
- 飞书 bot `open_id` 按应用隔离：CLI 用参数中的 self-view `open_id` 定位目标 bot；建群后 service 再从 creator 视角获取可用于 @ 的 observer-scoped `open_id`，避免跨 app 直接复用错误 ID。
- 目标 bot 邀请失败、不在群中、无法可靠 @ 或发送消息失败时，只返回对应 `kickoffError`，不重复建群。
- 不传 kickoff 参数时，现有 CLI 和 dashboard 行为不变。

## 改动文件

- `src/cli.ts`：参数解析、建群前校验、结果提示。
- `src/cli/create-group-resolver.ts`：纯函数解析并校验 kickoff 目标。
- `src/services/group-creator.ts`：用 creator 视角解析 @ ID 并发送 best-effort kickoff。
- `test/create-group-resolver.test.ts`、`test/group-creator.test.ts`：覆盖正常路径、参数缺失、目标未选中/creator、邀请失败、不可 @、发送失败及返回对象兼容。

## 分支整理记录

本 PR 原分支误从仍处于 open 状态的 PR #489 head 创建，导致 #489 的 6 个 herdr 生命周期提交被一并带入，并非 #489 没有 push。

本次已从最新 `master`（`7790bb818`）重建分支，只保留本 PR 的 create-group kickoff 功能；当前 PR 仅 1 个提交、5 个相关文件，PR #489 的改动全部移除。

## 验证

- `pnpm vitest run test/create-group-resolver.test.ts test/group-creator.test.ts`：45/45 通过。
- `pnpm build`：通过（含 public-domain audit、TypeScript、dashboard bundle、dist audit）。
- 全量 unit：9969/9972 通过；剩余 3 个均为系统时区相关的既有测试，已在干净 `master` 复现，与本 PR 无关。
- GitHub CI：以最新提交为准运行。
