### PR TITLE
fix(session): 让 delete 与 daemon 关闭状态对齐

### DIFF
--- a/docs-site/docs/en/cli-commands.md
+++ b/docs-site/docs/en/cli-commands.md
@@ -17,6 +17,13 @@ Manage the daemon and sessions from the terminal.
 | `botmux delete stopped` | Clean up zombie sessions whose processes have exited |
 | `botmux dashboard` | Print a Web Dashboard URL once (refreshes the token each time) |
 
+When the daemon is online, `botmux delete` first asks the owning daemon to run
+the same lifecycle teardown as `/close`: evict the in-memory active session,
+persist the closed state, and clean up the worker, backend, and subscriptions.
+The local fallback is used only when the owning daemon is confirmed offline. If
+an online daemon rejects the request or IPC fails, the command fails without a
+local hard kill.
+
 ## Auto-Start on Boot
 
 ```bash

--- a/docs-site/docs/zh/cli-commands.md
+++ b/docs-site/docs/zh/cli-commands.md
@@ -17,6 +17,11 @@
 | `botmux delete stopped` | 清理进程已退出的僵尸会话 |
 | `botmux dashboard` | 输出一次 Web Dashboard URL（每次刷 token） |
 
+daemon 在线时，`botmux delete` 会先请求会话所属 daemon 执行与 `/close`
+一致的生命周期收口：移除内存中的活跃会话、持久化关闭状态，并回收
+worker、后端与订阅。仅当所属 daemon 确认不在线时才使用本地收口；在线
+daemon 拒绝或 IPC 连接失败时命令返回失败，不会继续本地强杀。
+
 ## 开机自启
 
 ```bash

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3225,6 +3225,80 @@ function adoptedCliPid(s: SessionData): number | undefined {
   return typeof pid === 'number' && pid > 0 ? pid : undefined;
 }
 
+type SessionDeleteCloseResult =
+  | { ok: true; via: 'daemon' | 'offline' }
+  | { ok: false; error: string };
+
+/** Offline-only fallback for `botmux delete`. When the owning daemon is live,
+ *  it must own the whole close transition so its activeSessions registry,
+ *  persistent row, lifecycle hooks, subscriptions, and backend teardown stay
+ *  coherent. This legacy local path is safe only when there is no daemon
+ *  process whose in-memory state could be stranded. */
+function closeSessionOffline(s: SessionData): void {
+  const originalPid = adoptedCliPid(s);
+  // Adopted sessions own only the botmux worker/viewer, never the user's CLI.
+  if (s.pid && s.pid !== originalPid && isProcessAlive(s.pid)) {
+    killProcess(s.pid);
+  }
+
+  // Adopted panes belong to the user. Ordinary bmx-* sessions are botmux-owned
+  // and still need direct cleanup when no daemon exists to run killWorker().
+  if (!isAdoptedSession(s)) {
+    const tmuxName = `bmx-${s.sessionId.substring(0, 8)}`;
+    try {
+      execSync(`tmux kill-session -t '${tmuxName}' 2>/dev/null`, {
+        stdio: 'ignore',
+        env: tmuxEnv(),
+      });
+    } catch { /* no tmux session */ }
+  }
+
+  s.status = 'closed';
+  s.closedAt = new Date().toISOString();
+  saveSession(s);
+}
+
+/** Close through the owning daemon whenever it is online. The IPC request is
+ *  deliberately sent BEFORE any local kill: deleting the current bmx-* tmux
+ *  first would terminate this very CLI before it can evict daemon memory.
+ *
+ *  Trusted host callers use the dashboard HMAC. A sandboxed/read-isolated CLI
+ *  can only authorize the exact current session with its rotating per-turn
+ *  capability, so `delete <other-id>` remains fail-closed. */
+async function closeSessionForDelete(
+  s: SessionData,
+  online = listOnlineDaemons(),
+): Promise<SessionDeleteCloseResult> {
+  const daemon = s.larkAppId
+    ? online.find(d => d.larkAppId === s.larkAppId)
+    : online.length === 1 ? online[0] : undefined;
+  const isCurrentSession = process.env.BOTMUX_SESSION_ID === s.sessionId;
+  const injectedPort = isCurrentSession
+    ? resolveDaemonIpcPort(undefined, process.env.BOTMUX_DAEMON_IPC_PORT)
+    : undefined;
+  const ipcPort = daemon?.ipcPort ?? injectedPort;
+
+  if (!s.larkAppId && online.length > 1 && !ipcPort) {
+    return { ok: false, error: '会话缺少 larkAppId，多 daemon 下无法判定归属' };
+  }
+
+  if (ipcPort) {
+    try {
+      const res = await postSessionCliIpc(ipcPort, s.sessionId, 'close', {});
+      const body: any = await res.json().catch(() => ({}));
+      if (res.ok && body?.ok) return { ok: true, via: 'daemon' };
+      return { ok: false, error: body?.error ?? `HTTP ${res.status}` };
+    } catch (err: any) {
+      // A fresh daemon descriptor means there may still be authoritative
+      // in-memory state. Never fall back to a partial local kill in this case.
+      return { ok: false, error: `连接 daemon 失败: ${err?.message ?? err}` };
+    }
+  }
+
+  closeSessionOffline(s);
+  return { ok: true, via: 'offline' };
+}
+
 function adoptTargetLabel(s: SessionData): string {
   if (!isAdoptedSession(s)) return '';
   const a = s.adoptedFrom;
@@ -3440,26 +3514,16 @@ function interactiveSessionPicker(active: SessionData[]): Promise<void> {
       process.stdout.write('\x1b[?1049l'); // leave alt screen
     }
 
-    function deleteSession(idx: number): void {
+    let deleteInFlight = false;
+
+    async function deleteSession(idx: number): Promise<void> {
       const r = rows[idx];
       const s = r.session;
-
-      // Kill botmux's worker process. For adopted sessions, never kill the
-      // user's original CLI pid if an old record stored it in `pid`.
-      const originalPid = adoptedCliPid(s);
-      if (s.pid && s.pid !== originalPid && isProcessAlive(s.pid)) {
-        killProcess(s.pid);
+      const result = await closeSessionForDelete(s);
+      if (!result.ok) {
+        flashMsg = `\x1b[31m✗ 删除失败: ${result.error}\x1b[0m`;
+        return;
       }
-
-      // Kill only botmux-owned tmux sessions. Adopted panes belong to the user.
-      if (!r.isAdopt && r.hasTmux) {
-        try { execSync(`tmux kill-session -t '${r.tmuxName}' 2>/dev/null`, { stdio: 'ignore', env: tmuxEnv() }); } catch { /* */ }
-      }
-
-      // Mark closed & persist
-      s.status = 'closed';
-      s.closedAt = new Date().toISOString();
-      saveSession(s);
 
       // Remove from active list and TUI rows
       const activeIdx = active.indexOf(s);
@@ -3467,15 +3531,20 @@ function interactiveSessionPicker(active: SessionData[]): Promise<void> {
       rows.splice(idx, 1);
 
       if (cursor >= rows.length) cursor = Math.max(0, rows.length - 1);
-      flashMsg = `\x1b[32m✓ 已删除 ${s.sessionId.substring(0, 8)}\x1b[0m`;
+      flashMsg = result.via === 'daemon'
+        ? `\x1b[32m✓ 已删除 ${s.sessionId.substring(0, 8)}\x1b[0m`
+        : `\x1b[33m✓ 已离线删除 ${s.sessionId.substring(0, 8)}\x1b[0m`;
     }
 
-    process.stdin.on('data', (key: string) => {
+    process.stdin.on('data', async (key: string) => {
+      if (deleteInFlight) return;
       // Delete confirmation mode
       if (confirmDelete) {
         confirmDelete = false;
         if (key === 'y' || key === 'Y') {
-          deleteSession(cursor);
+          deleteInFlight = true;
+          try { await deleteSession(cursor); }
+          finally { deleteInFlight = false; }
         } else {
           flashMsg = '\x1b[2m取消删除\x1b[0m';
         }
@@ -3613,7 +3682,7 @@ async function cmdList(): Promise<void> {
   await interactiveSessionPicker(live);
 }
 
-function cmdDelete(): void {
+async function cmdDelete(): Promise<void> {
   const target = process.argv[3];
   if (!target) {
     console.error('用法: botmux delete <session-id|all>');
@@ -3663,33 +3732,30 @@ function cmdDelete(): void {
     }
   }
 
-  for (const s of toDelete) {
-    const originalPid = adoptedCliPid(s);
-
-    // Kill botmux's worker process if running. For adopted sessions, never
-    // kill the user's original CLI pid.
-    if (s.pid && s.pid !== originalPid && isProcessAlive(s.pid)) {
-      killProcess(s.pid);
-      console.log(`  killed pid ${s.pid}`);
-    }
-
-    // Kill associated botmux-owned tmux session if it exists. Adopted panes
-    // belong to the user and must be left untouched.
-    const tmuxName = `bmx-${s.sessionId.substring(0, 8)}`;
-    if (!isAdoptedSession(s)) {
-      try {
-        execSync(`tmux kill-session -t '${tmuxName}' 2>/dev/null`, { stdio: 'ignore', env: tmuxEnv() });
-        console.log(`  killed tmux ${tmuxName}`);
-      } catch { /* no tmux session */ }
-    }
-
-    // Mark session as closed
-    s.status = 'closed';
-    s.closedAt = new Date().toISOString();
-    saveSession(s);
-    console.log(`✓ ${s.sessionId.substring(0, 8)} ${s.title}`);
+  // A self-delete may tear down the process running this loop. Put it last so
+  // `delete all` still closes every other target before the current session.
+  const currentSessionId = process.env.BOTMUX_SESSION_ID;
+  if (currentSessionId && toDelete.length > 1) {
+    toDelete.sort((a, b) => Number(a.sessionId === currentSessionId) - Number(b.sessionId === currentSessionId));
   }
-  console.log(`\n已关闭 ${toDelete.length} 个会话`);
+
+  const online = listOnlineDaemons();
+  let closed = 0;
+  let offline = 0;
+  let failed = 0;
+  for (const s of toDelete) {
+    const result = await closeSessionForDelete(s, online);
+    if (!result.ok) {
+      console.error(`✗ ${s.sessionId.substring(0, 8)} ${s.title}: ${result.error}`);
+      failed++;
+      continue;
+    }
+    closed++;
+    if (result.via === 'offline') offline++;
+    console.log(`✓ ${s.sessionId.substring(0, 8)} ${s.title}${result.via === 'offline' ? '（daemon 离线，本地收口）' : ''}`);
+  }
+  console.log(`\n已关闭 ${closed} 个会话${offline ? `（${offline} 个离线收口）` : ''}${failed ? `，${failed} 个失败` : ''}`);
+  if (failed > 0) process.exitCode = 1;
 }
 
 /**
@@ -3796,14 +3862,14 @@ async function cmdSuspend(): Promise<void> {
   if (failed > 0) process.exitCode = 1;
 }
 
-/** 会话级 CLI IPC（slash/cd）的 POST：与 postAsk 同款双路径——能读 host secret
+/** 会话级 CLI IPC（slash/cd/close）的 POST：与 postAsk 同款双路径——能读 host secret
  *  （非隔离进程）走 trusted-host HMAC 签名；读不到（沙箱 BOTMUX_SEND_RELAY /
  *  macOS 读隔离 carve-out）改带本会话当前轮换的 origin capability，由 daemon
  *  handler 与活跃记录比对。两条路都不读 bots.json。 */
 async function postSessionCliIpc(
   ipcPort: number,
   sessionId: string,
-  route: 'slash' | 'cd',
+  route: 'slash' | 'cd' | 'close',
   payload: Record<string, unknown>,
 ): Promise<Response> {
   const requestBody: Record<string, unknown> = { ...payload };
@@ -9041,7 +9107,7 @@ switch (command) {
   case 'ls':      await cmdList(); break;
   case 'delete':
   case 'del':
-  case 'rm':      cmdDelete(); break;
+  case 'rm':      await cmdDelete(); break;
   case 'resume':  await cmdResume(); break;
   case 'suspend': await cmdSuspend(); break;
   case 'slash':   await cmdSlash(); break;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3269,18 +3269,20 @@ async function closeSessionForDelete(
   s: SessionData,
   online = listOnlineDaemons(),
 ): Promise<SessionDeleteCloseResult> {
+  // Legacy sessions without larkAppId live in sessions.json. A per-bot daemon
+  // writes only its own sessions-<appId>.json and silently no-ops on close
+  // (sessionStore.closeSession only touches the current file), so routing a
+  // legacy session to it yields "200 OK" with no actual state change. Keep
+  // these on the offline fallback, whose saveSession() persists to the legacy
+  // file correctly.
   const daemon = s.larkAppId
     ? online.find(d => d.larkAppId === s.larkAppId)
-    : online.length === 1 ? online[0] : undefined;
+    : undefined;
   const isCurrentSession = process.env.BOTMUX_SESSION_ID === s.sessionId;
   const injectedPort = isCurrentSession
     ? resolveDaemonIpcPort(undefined, process.env.BOTMUX_DAEMON_IPC_PORT)
     : undefined;
   const ipcPort = daemon?.ipcPort ?? injectedPort;
-
-  if (!s.larkAppId && online.length > 1 && !ipcPort) {
-    return { ok: false, error: '会话缺少 larkAppId，多 daemon 下无法判定归属' };
-  }
 
   if (ipcPort) {
     try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3272,12 +3272,20 @@ async function closeSessionForDelete(
   // Legacy sessions without larkAppId live in sessions.json. A per-bot daemon
   // writes only its own sessions-<appId>.json and silently no-ops on close
   // (sessionStore.closeSession only touches the current file), so routing a
-  // legacy session to it yields "200 OK" with no actual state change. Keep
-  // these on the offline fallback, whose saveSession() persists to the legacy
-  // file correctly.
-  const daemon = s.larkAppId
-    ? online.find(d => d.larkAppId === s.larkAppId)
-    : undefined;
+  // legacy session to it yields "200 OK" with no actual state change. This must
+  // hold on BOTH ways a daemon port is discovered — the descriptor lookup AND
+  // the injected-port current-session fallback below — so gate the whole daemon
+  // path on larkAppId with one authoritative guard. A live daemon-spawned
+  // session always carries larkAppId, so this never diverts the legitimate
+  // sandboxed current-session close (which reaches its daemon via the injected
+  // port); it only keeps larkAppId-less legacy records on the offline fallback,
+  // whose saveSession() persists to the legacy file correctly.
+  if (!s.larkAppId) {
+    closeSessionOffline(s);
+    return { ok: true, via: 'offline' };
+  }
+
+  const daemon = online.find(d => d.larkAppId === s.larkAppId);
   const isCurrentSession = process.env.BOTMUX_SESSION_ID === s.sessionId;
   const injectedPort = isCurrentSession
     ? resolveDaemonIpcPort(undefined, process.env.BOTMUX_DAEMON_IPC_PORT)

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -243,11 +243,12 @@ function routeHasNarrowUntrustedAuth(method: string, pathname: string): boolean 
   // forge readiness or an ask for that session.
   if (method === 'POST' && pathname === '/api/session-ready') return true;
   if (method === 'POST' && pathname === '/api/asks') return true;
-  // botmux slash / botmux cd（角色切换）：合法调用方是会话内的 CLI 自身，沙箱 /
-  // 读隔离下读不到 host secret。两个 handler 内验证该会话的 rotating per-turn
+  // botmux slash / botmux cd（角色切换）/ botmux delete（关闭自身）：合法调用方
+  // 是会话内的 CLI 自身，沙箱 / 读隔离下读不到 host secret。handler 内验证
+  // 该会话的 rotating per-turn
   // capability 并绑定到 URL 里的 sessionId（同 /api/asks 姿势）——capability 只
   // 证明「我是这个会话当前这一轮的 CLI」，选不了别的会话。
-  if (method === 'POST' && /^\/api\/sessions\/[^/]+\/(?:slash|cd)$/.test(pathname)) return true;
+  if (method === 'POST' && /^\/api\/sessions\/[^/]+\/(?:slash|cd|close)$/.test(pathname)) return true;
   if (method === 'POST' && pathname === '/api/hooks/emit') return true;
   if (method === 'POST' && pathname === '/api/attention') return true;
   // Workflow v3 mutations carry their own domain-separated full-envelope
@@ -358,7 +359,15 @@ ipcRoute('GET', '/api/sessions/:sessionId', (_req, res, params) => {
   jsonRes(res, 404, { error: 'not_found' });
 });
 
-ipcRoute('POST', '/api/sessions/:sessionId/close', async (_req, res, params) => {
+/** Canonical daemon-side close used by the dashboard and `botmux delete`.
+ *  Host callers authenticate with HMAC; a read-isolated CLI may close only its
+ *  exact live session with the rotating per-turn capability. */
+ipcRoute('POST', '/api/sessions/:sessionId/close', async (req, res, params) => {
+  const body = await readJsonBody<Record<string, unknown>>(req)
+    .catch(() => ({} as Record<string, unknown>));
+  const ds = findActiveBySessionId(params.sessionId);
+  const auth = sessionCliIpcAuth(req, ds, params.sessionId, body);
+  if (!auth.ok) return jsonRes(res, 403, { ok: false, error: auth.error });
   const r = await closeSession(params.sessionId);
   jsonRes(res, 200, r);
 });

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1482,9 +1482,55 @@ export async function closeSession(
     // crash/limited turn may never have reached an idle edge).
     recordUsageForDaemonSession(ds);
     killWorker(ds);
+    // Commit the daemon-visible close barrier before any network await below.
+    // `botmux delete` may be running inside the session being destroyed; once
+    // its worker/backing pane exits, a new IM message must not find this stale
+    // entry and resurrect the old logical session while doc cleanup is pending.
+    activeSessionsRegistry?.delete(activeSessionKey(ds));
+    killedLive = true;
+  }
+
+  // Persistence is part of the same no-await barrier as Map eviction. If the
+  // daemon crashes during best-effort doc cleanup, restart recovery must not
+  // restore a session that was already explicitly closed.
+  const stored = sessionStore.getSession(sessionId);
+  const wasOpen = !!stored && stored.status !== 'closed';
+  if (wasOpen) sessionStore.closeSession(sessionId);
+
+  if (ds) {
+    if (!ds.exitEventEmitted) {
+      ds.exitEventEmitted = true;
+      dashboardEventBus.publish({
+        type: 'session.exited',
+        body: { sessionId, reason: 'dashboard_close' },
+      });
+      emitSessionLifecycleHook(ds, 'session.exit', { reason: 'dashboard_close' });
+    }
+  }
+
+  // Preserve the existing externally-visible event order: exit first, then
+  // the final persisted-row update. Persistence itself was already committed
+  // above as part of the close barrier.
+  if (wasOpen) {
+    const after = sessionStore.getSession(sessionId);
+    dashboardEventBus.publish({
+      type: 'session.update',
+      body: {
+        sessionId,
+        patch: {
+          status: 'closed',
+          closedAt: after?.closedAt ? Date.parse(after.closedAt) : Date.now(),
+          tokenUsage: after ? composeRowFromClosed(after).tokenUsage : null,
+        },
+      },
+    });
+  }
+
+  if (ds) {
     // 文档入口清理：会话关闭即删除其绑定。只有旧
     // /subscribe-lark-doc 记录需要调飞书逐文件退订 API；
-    // /watch-comment 仅依赖应用级评论事件，删本地监听表即可。
+    // /watch-comment 仅依赖应用级评论事件，删本地监听表即可。此段允许 await，
+    // 因为上面的内存 + 持久化关闭屏障已经提交。
     try {
       const anchor = sessionAnchorId(ds);
       const subs = listDocSubscriptionsForSession(config.session.dataDir, ds.larkAppId, anchor);
@@ -1498,35 +1544,6 @@ export async function closeSession(
     } catch (err: any) {
       logger.warn(`[doc-comment] cleanup on close failed for ${sessionId.slice(0, 8)}: ${err?.message ?? err}`);
     }
-    activeSessionsRegistry?.delete(activeSessionKey(ds));
-    killedLive = true;
-    if (!ds.exitEventEmitted) {
-      ds.exitEventEmitted = true;
-      dashboardEventBus.publish({
-        type: 'session.exited',
-        body: { sessionId, reason: 'dashboard_close' },
-      });
-      emitSessionLifecycleHook(ds, 'session.exit', { reason: 'dashboard_close' });
-    }
-  }
-
-  // Persistence path — load → mark closed → save (delegated to sessionStore).
-  const stored = sessionStore.getSession(sessionId);
-  const wasOpen = !!stored && stored.status !== 'closed';
-  if (wasOpen) {
-    sessionStore.closeSession(sessionId);
-    const after = sessionStore.getSession(sessionId);
-    dashboardEventBus.publish({
-      type: 'session.update',
-      body: {
-        sessionId,
-        patch: {
-          status: 'closed',
-          closedAt: after?.closedAt ? Date.parse(after.closedAt) : Date.now(),
-          tokenUsage: after ? composeRowFromClosed(after).tokenUsage : null,
-        },
-      },
-    });
   }
 
   // alreadyClosed = nothing happened on either path.

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -294,8 +294,13 @@ describe('POST /api/sessions/:sessionId/rename', () => {
 
 describe('POST /api/sessions/:sessionId/close', () => {
   it('returns 200 with ok=true even when session does not exist (idempotent)', async () => {
-    handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
-    const res = await fetch(`http://127.0.0.1:${handle.port}/api/sessions/nonexistent/close`, { method: 'POST' });
+    setIpcAuthSecret(TEST_IPC_SECRET);
+    handle = await startIpcServer({ port: 0, host: '127.0.0.1', authRequired: true });
+    const path = '/api/sessions/nonexistent/close';
+    const res = await fetch(`http://127.0.0.1:${handle.port}${path}`, {
+      method: 'POST',
+      headers: trustedHostHeaders('POST', path, handle.port),
+    });
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);

--- a/test/ipc-close-route.test.ts
+++ b/test/ipc-close-route.test.ts
@@ -1,0 +1,140 @@
+// POST /api/sessions/:sessionId/close route-level authorization matrix.
+// Trusted host callers retain dashboard/admin behavior; an untrusted in-session
+// caller may only close the exact live session whose rotating capability it owns.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  setIpcAuthSecret,
+  startIpcServer,
+  type IpcServerHandle,
+} from '../src/core/dashboard-ipc-server.js';
+import { daemonIpcAuthHeaders } from '../src/core/daemon-ipc-auth.js';
+import * as workerPool from '../src/core/worker-pool.js';
+
+const CAP = 'c0ffee12'.repeat(8);
+const HOST_SECRET = 'test-ipc-close-host-secret';
+let handle: IpcServerHandle | null = null;
+
+afterEach(async () => {
+  if (handle) await handle.close();
+  handle = null;
+  setIpcAuthSecret(null);
+  vi.restoreAllMocks();
+});
+
+async function postClose(sessionId: string, opts: {
+  auth?: 'capability' | 'signed' | 'none';
+  authRequired?: boolean;
+  capability?: string;
+} = {}): Promise<Response> {
+  if (!handle) {
+    if (opts.authRequired) setIpcAuthSecret(HOST_SECRET);
+    handle = await startIpcServer({
+      port: 0,
+      host: '127.0.0.1',
+      ...(opts.authRequired ? { authRequired: true } : {}),
+    });
+  }
+  const auth = opts.auth ?? 'capability';
+  const path = `/api/sessions/${sessionId}/close`;
+  const body: Record<string, unknown> = {};
+  if (auth === 'capability') body.originCapability = opts.capability ?? CAP;
+  const headers: HeadersInit = auth === 'signed'
+    ? daemonIpcAuthHeaders({
+      secret: HOST_SECRET,
+      port: handle.port,
+      method: 'POST',
+      path,
+      headers: { 'content-type': 'application/json' },
+    })
+    : { 'content-type': 'application/json' };
+  return fetch(`http://127.0.0.1:${handle.port}${path}`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/sessions/:sessionId/close', () => {
+  it('accepts the exact live session capability and delegates to canonical closeSession', async () => {
+    vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue({
+      session: { sessionId: 's-close' },
+      managedTurnOrigin: { capability: CAP },
+      larkAppId: 'app-1',
+    } as any);
+    const closeSpy = vi.spyOn(workerPool, 'closeSession')
+      .mockResolvedValue({ ok: true, alreadyClosed: false });
+
+    const res = await postClose('s-close', { authRequired: true });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, alreadyClosed: false });
+    expect(closeSpy).toHaveBeenCalledWith('s-close');
+  });
+
+  it('rejects a missing or stale capability without closing anything', async () => {
+    vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue({
+      session: { sessionId: 's-close-denied' },
+      managedTurnOrigin: { capability: CAP },
+      larkAppId: 'app-1',
+    } as any);
+    const closeSpy = vi.spyOn(workerPool, 'closeSession')
+      .mockResolvedValue({ ok: true, alreadyClosed: false });
+
+    const missing = await postClose('s-close-denied', {
+      auth: 'none',
+      authRequired: true,
+    });
+    expect(missing.status).toBe(403);
+    expect(await missing.json()).toMatchObject({ ok: false, error: 'origin_unproven' });
+
+    const stale = await postClose('s-close-denied', {
+      capability: 'bad0'.repeat(16),
+    });
+    expect(stale.status).toBe(403);
+    expect(await stale.json()).toMatchObject({ ok: false, error: 'origin_unproven' });
+    expect(closeSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not reveal whether an unproven target session exists', async () => {
+    vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue(undefined);
+    const closeSpy = vi.spyOn(workerPool, 'closeSession')
+      .mockResolvedValue({ ok: true, alreadyClosed: true });
+
+    const res = await postClose('missing', { authRequired: true });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ ok: false, error: 'origin_unproven' });
+    expect(closeSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps trusted-host close idempotent for an already missing session', async () => {
+    vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue(undefined);
+    const closeSpy = vi.spyOn(workerPool, 'closeSession')
+      .mockResolvedValue({ ok: true, alreadyClosed: true });
+
+    const res = await postClose('missing', {
+      auth: 'signed',
+      authRequired: true,
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, alreadyClosed: true });
+    expect(closeSpy).toHaveBeenCalledWith('missing');
+  });
+
+  it('denies receiver-session self-close through the ordinary capability aperture', async () => {
+    vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue({
+      session: { sessionId: 's-receiver', vcMeetingReceiver: { meetingId: 'm' } },
+      managedTurnOrigin: { capability: CAP },
+      larkAppId: 'app-1',
+    } as any);
+    const closeSpy = vi.spyOn(workerPool, 'closeSession')
+      .mockResolvedValue({ ok: true, alreadyClosed: false });
+
+    const res = await postClose('s-receiver', { authRequired: true });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ ok: false, error: 'managed_action_required' });
+    expect(closeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/test/session-delete-cli.test.ts
+++ b/test/session-delete-cli.test.ts
@@ -64,6 +64,13 @@ function writeSessions(dataDir: string, sessions: StoredSession[]): string {
   return path;
 }
 
+function writeLegacySessions(dataDir: string, sessions: StoredSession[]): string {
+  mkdirSync(dataDir, { recursive: true });
+  const path = join(dataDir, 'sessions.json');
+  writeFileSync(path, JSON.stringify(Object.fromEntries(sessions.map(s => [s.sessionId, s]))));
+  return path;
+}
+
 function writeDaemonDescriptor(dataDir: string, port: number): void {
   const dir = join(dataDir, 'dashboard-daemons');
   mkdirSync(dir, { recursive: true });
@@ -266,6 +273,49 @@ describe('botmux delete — daemon-first close', () => {
         `/api/sessions/${other.sessionId}/close`,
         `/api/sessions/${self.sessionId}/close`,
       ]);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close(err => err ? reject(err) : resolve());
+      });
+    }
+  });
+
+  it('closes a legacy session (no larkAppId) locally even when a daemon is online', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-delete-legacy-data-'));
+    tempDirs.push(dataDir);
+    // Legacy session has no larkAppId and lives in sessions.json, not the
+    // per-bot file. A per-bot daemon cannot persist its close.
+    const session = makeSession('sess-delete-legacy', { larkAppId: undefined });
+    const sessionsPath = writeLegacySessions(dataDir, [session]);
+
+    const seen: string[] = [];
+    const server = createServer(async (req, res) => {
+      seen.push(req.url ?? '');
+      await readRequestBody(req);
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{"ok":true,"alreadyClosed":false}');
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+
+    try {
+      const port = (server.address() as AddressInfo).port;
+      writeDaemonDescriptor(dataDir, port);
+      const result = await runDelete(dataDir, [session.sessionId], {
+        BOTMUX_SESSION_ID: undefined,
+        BOTMUX_LARK_APP_ID: undefined,
+        BOTMUX_SEND_RELAY: undefined,
+        BOTMUX_DAEMON_IPC_PORT: undefined,
+      });
+
+      // CLI must not route the legacy session to the daemon: the daemon writes
+      // only its own sessions-<appId>.json and would return "200 OK" without
+      // actually closing the legacy row.
+      expect(seen).toEqual([]);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('daemon 离线，本地收口');
+      const stored = JSON.parse(readFileSync(sessionsPath, 'utf8'));
+      expect(stored[session.sessionId].status).toBe('closed');
+      expect(stored[session.sessionId].closedAt).toBeTruthy();
     } finally {
       await new Promise<void>((resolve, reject) => {
         server.close(err => err ? reject(err) : resolve());

--- a/test/session-delete-cli.test.ts
+++ b/test/session-delete-cli.test.ts
@@ -1,0 +1,275 @@
+/**
+ * CLI boundary regression for `botmux delete` daemon-first close semantics.
+ *
+ * Runs the source CLI through tsx against a tiny fake daemon. The daemon route
+ * itself is covered separately; these tests prove the CLI never kills/persists
+ * locally while a live owner daemon is authoritative, carries the current
+ * session capability, and retains an offline fallback.
+ */
+import { spawn } from 'node:child_process';
+import { createServer, type IncomingMessage } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { RELAY_ORIGIN_CAPABILITY_BASENAME } from '../src/core/managed-origin-capability.js';
+
+const CLI_PATH = join(__dirname, '..', 'src', 'cli.ts');
+const APP_ID = 'cli_delete_test';
+const CAPABILITY = 'ab'.repeat(32);
+const tempDirs: string[] = [];
+
+interface StoredSession {
+  sessionId: string;
+  chatId: string;
+  rootMessageId: string;
+  title: string;
+  status: 'active' | 'closed';
+  createdAt: string;
+  closedAt?: string;
+  larkAppId?: string;
+  adoptedFrom?: { source: 'tmux'; tmuxTarget: string; cwd: string };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeSession(sessionId: string, overrides: Partial<StoredSession> = {}): StoredSession {
+  return {
+    sessionId,
+    chatId: 'oc_delete_test',
+    rootMessageId: 'om_delete_test',
+    title: sessionId,
+    status: 'active',
+    createdAt: '2026-07-22T00:00:00.000Z',
+    larkAppId: APP_ID,
+    ...overrides,
+  };
+}
+
+function writeSessions(dataDir: string, sessions: StoredSession[]): string {
+  mkdirSync(dataDir, { recursive: true });
+  const path = join(dataDir, `sessions-${APP_ID}.json`);
+  writeFileSync(path, JSON.stringify(Object.fromEntries(sessions.map(s => [s.sessionId, s]))));
+  return path;
+}
+
+function writeDaemonDescriptor(dataDir: string, port: number): void {
+  const dir = join(dataDir, 'dashboard-daemons');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${APP_ID}.json`), JSON.stringify({
+    larkAppId: APP_ID,
+    ipcPort: port,
+    lastHeartbeat: Date.now(),
+  }));
+}
+
+function writeRelayCapability(relayDir: string): void {
+  mkdirSync(relayDir, { recursive: true });
+  writeFileSync(
+    join(relayDir, RELAY_ORIGIN_CAPABILITY_BASENAME),
+    JSON.stringify({ token: CAPABILITY, turnId: 'turn-delete', dispatchAttempt: 3 }),
+  );
+}
+
+function runDelete(
+  dataDir: string,
+  args: string[],
+  envOverrides: Record<string, string | undefined> = {},
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      SESSION_DATA_DIR: dataDir,
+      ...envOverrides,
+    };
+    for (const [key, value] of Object.entries(env)) {
+      if (value === undefined) delete env[key];
+    }
+    const child = spawn(
+      process.execPath,
+      ['--import', 'tsx', CLI_PATH, 'delete', ...args],
+      { env, stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => { stdout += chunk; });
+    child.stderr.on('data', (chunk: string) => { stderr += chunk; });
+    child.once('error', reject);
+    child.once('close', status => resolve({ status, stdout, stderr }));
+  });
+}
+
+function readRequestBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+  return new Promise((resolve) => {
+    let raw = '';
+    req.setEncoding('utf8');
+    req.on('data', chunk => { raw += chunk; });
+    req.on('end', () => {
+      try { resolve(raw ? JSON.parse(raw) : {}); }
+      catch { resolve({}); }
+    });
+  });
+}
+
+describe('botmux delete — daemon-first close', () => {
+  it('delegates a current-session close to the daemon with its rotating capability', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-delete-data-'));
+    const relayDir = mkdtempSync(join(tmpdir(), 'botmux-delete-relay-'));
+    tempDirs.push(dataDir, relayDir);
+    const session = makeSession('sess-delete-current');
+    const sessionsPath = writeSessions(dataDir, [session]);
+    writeRelayCapability(relayDir);
+
+    let requestUrl = '';
+    let requestBody: Record<string, unknown> = {};
+    const server = createServer(async (req, res) => {
+      requestUrl = req.url ?? '';
+      requestBody = await readRequestBody(req);
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{"ok":true,"alreadyClosed":false}');
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+
+    try {
+      const port = (server.address() as AddressInfo).port;
+      writeDaemonDescriptor(dataDir, port);
+      const result = await runDelete(dataDir, [session.sessionId], {
+        BOTMUX_SESSION_ID: session.sessionId,
+        BOTMUX_LARK_APP_ID: APP_ID,
+        BOTMUX_SEND_RELAY: relayDir,
+        BOTMUX_DAEMON_IPC_PORT: String(port),
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('已关闭 1 个会话');
+      expect(requestUrl).toBe(`/api/sessions/${session.sessionId}/close`);
+      expect(requestBody).toMatchObject({
+        originCapability: CAPABILITY,
+        originTurnId: 'turn-delete',
+        originDispatchAttempt: 3,
+      });
+      // The fake daemon deliberately does not persist. Staying active proves
+      // the CLI did not run the legacy local fallback after an IPC success.
+      const stored = JSON.parse(readFileSync(sessionsPath, 'utf8'));
+      expect(stored[session.sessionId].status).toBe('active');
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close(err => err ? reject(err) : resolve());
+      });
+    }
+  });
+
+  it('fails closed when a discovered daemon rejects the close', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-delete-data-'));
+    const relayDir = mkdtempSync(join(tmpdir(), 'botmux-delete-relay-'));
+    tempDirs.push(dataDir, relayDir);
+    const session = makeSession('sess-delete-rejected');
+    const sessionsPath = writeSessions(dataDir, [session]);
+    writeRelayCapability(relayDir);
+
+    const server = createServer(async (req, res) => {
+      await readRequestBody(req);
+      res.writeHead(403, { 'content-type': 'application/json' });
+      res.end('{"ok":false,"error":"origin_unproven"}');
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+
+    try {
+      const port = (server.address() as AddressInfo).port;
+      writeDaemonDescriptor(dataDir, port);
+      const result = await runDelete(dataDir, [session.sessionId], {
+        BOTMUX_SESSION_ID: session.sessionId,
+        BOTMUX_LARK_APP_ID: APP_ID,
+        BOTMUX_SEND_RELAY: relayDir,
+        BOTMUX_DAEMON_IPC_PORT: String(port),
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('origin_unproven');
+      expect(result.stdout).toContain('0 个会话');
+      const stored = JSON.parse(readFileSync(sessionsPath, 'utf8'));
+      expect(stored[session.sessionId].status).toBe('active');
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close(err => err ? reject(err) : resolve());
+      });
+    }
+  });
+
+  it('uses the legacy local close only when no daemon is online', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-delete-data-'));
+    tempDirs.push(dataDir);
+    const session = makeSession('sess-delete-offline', {
+      adoptedFrom: { source: 'tmux', tmuxTarget: 'user:1.0', cwd: '/repo' },
+    });
+    const sessionsPath = writeSessions(dataDir, [session]);
+
+    const result = await runDelete(dataDir, [session.sessionId], {
+      BOTMUX_SESSION_ID: undefined,
+      BOTMUX_LARK_APP_ID: undefined,
+      BOTMUX_SEND_RELAY: undefined,
+      BOTMUX_DAEMON_IPC_PORT: undefined,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('daemon 离线，本地收口');
+    const stored = JSON.parse(readFileSync(sessionsPath, 'utf8'));
+    expect(stored[session.sessionId].status).toBe('closed');
+    expect(stored[session.sessionId].closedAt).toBeTruthy();
+  });
+
+  it('orders the current session last for delete all', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-delete-data-'));
+    const fakeHome = mkdtempSync(join(tmpdir(), 'botmux-delete-home-'));
+    tempDirs.push(dataDir, fakeHome);
+    const self = makeSession('sess-delete-self');
+    const other = makeSession('sess-delete-other');
+    writeSessions(dataDir, [self, other]);
+    mkdirSync(join(fakeHome, '.botmux'), { recursive: true });
+    writeFileSync(join(fakeHome, '.botmux', '.dashboard-secret'), 'delete-test-secret');
+
+    const seen: string[] = [];
+    const server = createServer(async (req, res) => {
+      seen.push(req.url ?? '');
+      await readRequestBody(req);
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{"ok":true,"alreadyClosed":false}');
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+
+    try {
+      const port = (server.address() as AddressInfo).port;
+      writeDaemonDescriptor(dataDir, port);
+      const result = await runDelete(dataDir, ['all'], {
+        HOME: fakeHome,
+        BOTMUX_SESSION_ID: self.sessionId,
+        BOTMUX_LARK_APP_ID: APP_ID,
+        BOTMUX_SEND_RELAY: undefined,
+        BOTMUX_DAEMON_IPC_PORT: String(port),
+      });
+
+      expect(result.status).toBe(0);
+      expect(seen).toEqual([
+        `/api/sessions/${other.sessionId}/close`,
+        `/api/sessions/${self.sessionId}/close`,
+      ]);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close(err => err ? reject(err) : resolve());
+      });
+    }
+  });
+});

--- a/test/session-delete-cli.test.ts
+++ b/test/session-delete-cli.test.ts
@@ -322,4 +322,47 @@ describe('botmux delete — daemon-first close', () => {
       });
     }
   });
+
+  it('closes a legacy current session locally even with an injected daemon port', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-delete-legacy-cur-data-'));
+    tempDirs.push(dataDir);
+    // A larkAppId-less session that is ALSO the current session: the injected
+    // BOTMUX_DAEMON_IPC_PORT reaches a daemon even with no online descriptor.
+    // The daemon still writes only its own sessions-<appId>.json and would
+    // no-op the legacy close, so the larkAppId guard must divert this to the
+    // offline path too — the injected port is not a second door around it.
+    const session = makeSession('sess-delete-legacy-cur', { larkAppId: undefined });
+    const sessionsPath = writeLegacySessions(dataDir, [session]);
+
+    const seen: string[] = [];
+    const server = createServer(async (req, res) => {
+      seen.push(req.url ?? '');
+      await readRequestBody(req);
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{"ok":true,"alreadyClosed":false}');
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+
+    try {
+      const port = (server.address() as AddressInfo).port;
+      const result = await runDelete(dataDir, [session.sessionId], {
+        BOTMUX_SESSION_ID: session.sessionId,
+        BOTMUX_LARK_APP_ID: undefined,
+        BOTMUX_SEND_RELAY: undefined,
+        BOTMUX_DAEMON_IPC_PORT: String(port),
+      });
+
+      // Injected port must not route a legacy session to the daemon.
+      expect(seen).toEqual([]);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('daemon 离线，本地收口');
+      const stored = JSON.parse(readFileSync(sessionsPath, 'utf8'));
+      expect(stored[session.sessionId].status).toBe('closed');
+      expect(stored[session.sessionId].closedAt).toBeTruthy();
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close(err => err ? reject(err) : resolve());
+      });
+    }
+  });
 });

--- a/test/session-delete-close-barrier.test.ts
+++ b/test/session-delete-close-barrier.test.ts
@@ -1,0 +1,88 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { config } from '../src/config.js';
+import * as docComment from '../src/im/lark/doc-comment.js';
+import * as workerPool from '../src/core/worker-pool.js';
+import { activeSessionKey } from '../src/core/types.js';
+import * as docSubsStore from '../src/services/doc-subs-store.js';
+import * as sessionStore from '../src/services/session-store.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  workerPool.setActiveSessionsRegistry(new Map());
+  sessionStore.init();
+  vi.restoreAllMocks();
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('daemon close barrier used by botmux delete', () => {
+  it('evicts activeSessions and persists closed before awaited doc cleanup', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-delete-barrier-'));
+    tempDirs.push(dataDir);
+    const previousDataDir = config.session.dataDir;
+    config.session.dataDir = dataDir;
+    sessionStore.init('app-delete-barrier');
+
+    let releaseCleanup!: () => void;
+    const cleanupGate = new Promise<void>(resolve => { releaseCleanup = resolve; });
+    vi.spyOn(docSubsStore, 'listDocSubscriptionsForSession').mockReturnValue([{
+      fileToken: 'doc-delete-barrier',
+      fileType: 'docx',
+      managedBy: 'subscribe-lark-doc',
+    }] as any);
+    vi.spyOn(docSubsStore, 'removeDocSubscription').mockImplementation(() => true);
+    vi.spyOn(docComment, 'unsubscribeDocFile').mockImplementation(() => cleanupGate);
+
+    try {
+      const session = sessionStore.createSession(
+        'oc_delete_barrier',
+        'om_delete_barrier',
+        'delete barrier',
+        'group',
+      );
+      session.larkAppId = 'app-delete-barrier';
+      sessionStore.updateSession(session);
+      const ds = {
+        session,
+        worker: null,
+        workerPort: null,
+        workerToken: null,
+        workerViewToken: null,
+        larkAppId: 'app-delete-barrier',
+        chatId: session.chatId,
+        chatType: 'group',
+        scope: 'thread',
+        spawnedAt: Date.now(),
+        cliVersion: 'test',
+        lastMessageAt: Date.now(),
+        hasHistory: true,
+        adoptedFrom: { source: 'tmux', tmuxTarget: 'user:1.0', cwd: '/repo' },
+      } as any;
+      const active = new Map([[activeSessionKey(ds), ds]]);
+      workerPool.setActiveSessionsRegistry(active);
+
+      const pending = workerPool.closeSession(session.sessionId);
+
+      // closeSession has reached the first await (unsubscribeDocFile), but the
+      // logical close barrier must already be fully visible.
+      expect(active.has(activeSessionKey(ds))).toBe(false);
+      expect(sessionStore.getSession(session.sessionId)?.status).toBe('closed');
+
+      releaseCleanup();
+      await expect(pending).resolves.toEqual({ ok: true, alreadyClosed: false });
+      expect(docSubsStore.removeDocSubscription).toHaveBeenCalledWith(
+        dataDir,
+        'app-delete-barrier',
+        'doc-delete-barrier',
+      );
+    } finally {
+      releaseCleanup();
+      config.session.dataDir = previousDataDir;
+    }
+  });
+});


### PR DESCRIPTION
## 背景

`botmux delete` 原先只在 CLI 侧直接终止进程/tmux 并写入关闭状态，不会同步移除 daemon 内存中的 `activeSessions` 条目。删除当前会话时，如果先 kill 再通知 daemon，执行命令的 CLI 本身会随 backing session 一起退出，IPC 没有机会发出。

## 方案

- daemon 在线时，`botmux delete` 先调用已有的 `POST /api/sessions/:sessionId/close`，由 daemon 统一执行 worker/backend 回收、`activeSessions` 删除、持久化关闭、订阅清理和生命周期事件。
- 宿主终端调用继续使用 dashboard HMAC；读隔离/沙箱内的 CLI 只能用当前轮换 capability 关闭它自己所属的精确会话。
- 已发现在线 daemon 时，IPC 拒绝或连接失败会 fail closed，不再退回本地强杀；只在所属 daemon 不在线时保留原本的本地收口。
- `delete all` 将当前会话放到最后，避免自删除提前终止批处理。TUI 删除也走同一条路径。
- daemon close 先同步提交内存删除 + 持久化关闭屏障，再等待文档退订，避免异步清理期间的会话复活或崩溃恢复。

本 PR 不新增 `botmux session close-self` 命令或新 IPC 路由。

## 验证

- `corepack pnpm build` 通过。
- TypeScript `tsc --noEmit` 通过。
- 定向回归：8 个测试文件，170/170 通过，覆盖 CLI daemon-first、在线失败 fail-closed、离线收口、自删除排序、IPC 鉴权矩阵和 close barrier。
- 全量单测：9928/9960 通过，32 项失败均已完成环境/基线归因：
  - 25 项因系统 Git 2.20 不支持 `git init -b` 失败；使用 Git 2.31 对对应的 3 个文件复跑为 31/31 通过。
  - 剩余 7 项为当前 shell/`/proc` PID namespace 的进程发现与超时用例；已在未修改的 `origin/master` (`ec4d3407`) 临时工作树上按相同签名复现 7/7。
