### PR TITLE
fix(pi): 修复长首轮 prompt 投递

### DIFF
--- a/src/adapters/cli/pi-initial-prompt-extension.ts
+++ b/src/adapters/cli/pi-initial-prompt-extension.ts
@@ -1,0 +1,52 @@
+import { readFile } from 'node:fs/promises';
+
+export const PI_INITIAL_PROMPT_COMMAND_NAME = 'botmux-initial-prompt';
+export const PI_INITIAL_PROMPT_COMMAND = `/${PI_INITIAL_PROMPT_COMMAND_NAME}`;
+export const PI_INITIAL_PROMPT_FILE_ENV = 'BOTMUX_PI_INITIAL_PROMPT_FILE';
+
+interface PiExtensionCommandContext {
+  isIdle(): boolean;
+  ui: {
+    notify(message: string, level: 'info' | 'warning' | 'error'): void;
+  };
+}
+
+interface PiExtensionApi {
+  registerCommand(name: string, options: {
+    description: string;
+    handler(args: string, ctx: PiExtensionCommandContext): Promise<void> | void;
+  }): void;
+  sendUserMessage(content: string, options?: { deliverAs: 'followUp' }): void;
+}
+
+/**
+ * Pi expands @file only for launch argv, not for text entered into its TUI.
+ * Deferred first prompts therefore use this short, one-shot command: the
+ * extension reads the worker-selected file (never a user-supplied path) and
+ * submits its full contents through Pi's native user-message API as one turn.
+ */
+export default function registerBotmuxInitialPromptExtension(pi: PiExtensionApi): void {
+  pi.registerCommand(PI_INITIAL_PROMPT_COMMAND_NAME, {
+    description: 'Deliver the Botmux initial prompt',
+    handler: async (_args, ctx) => {
+      const filePath = process.env[PI_INITIAL_PROMPT_FILE_ENV];
+      if (!filePath) {
+        ctx.ui.notify('Botmux initial prompt is no longer available.', 'error');
+        return;
+      }
+
+      try {
+        const prompt = await readFile(filePath, 'utf8');
+        if (ctx.isIdle()) pi.sendUserMessage(prompt);
+        else pi.sendUserMessage(prompt, { deliverAs: 'followUp' });
+        // One-shot within this Pi process. Keep the file itself until the worker
+        // ends the session so an owned process restart can safely replay a
+        // command that was written but not yet consumed.
+        delete process.env[PI_INITIAL_PROMPT_FILE_ENV];
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        ctx.ui.notify(`Failed to load Botmux initial prompt: ${detail}`, 'error');
+      }
+    },
+  });
+}

--- a/src/adapters/cli/pi-initial-prompt.ts
+++ b/src/adapters/cli/pi-initial-prompt.ts
@@ -1,5 +1,10 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  PI_INITIAL_PROMPT_COMMAND,
+  PI_INITIAL_PROMPT_FILE_ENV,
+} from './pi-initial-prompt-extension.js';
 
 export const PI_INITIAL_PROMPT_ARG_BYTE_LIMIT = 4096;
 
@@ -14,19 +19,40 @@ export function piInitialPromptNeedsFile(prompt: string | undefined): boolean {
   return !!prompt && Buffer.byteLength(prompt, 'utf8') > PI_INITIAL_PROMPT_ARG_BYTE_LIMIT;
 }
 
-export function piInitialPromptDir(sessionDataDir: string): string {
+export function piInitialPromptRootDir(sessionDataDir: string): string {
   return join(sessionDataDir, 'pi-initial-prompts');
 }
 
+export function piInitialPromptDir(sessionDataDir: string, sessionId: string): string {
+  return join(piInitialPromptRootDir(sessionDataDir), safeSessionFileStem(sessionId));
+}
+
 export function piInitialPromptFilePath(sessionDataDir: string, sessionId: string): string {
-  return join(piInitialPromptDir(sessionDataDir), `${safeSessionFileStem(sessionId)}.prompt.md`);
+  return join(piInitialPromptDir(sessionDataDir, sessionId), 'initial.prompt.md');
+}
+
+function piInitialPromptExtensionPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const compiled = resolve(here, 'pi-initial-prompt-extension.js');
+  if (existsSync(compiled)) return compiled;
+  return resolve(here, 'pi-initial-prompt-extension.ts');
 }
 
 export function preparePiInitialPromptArg(opts: {
   prompt: string;
   sessionId: string;
   sessionDataDir?: string;
-}): { initialPromptArg: string; filePath?: string; readonlyRoot?: string } {
+}): {
+  initialPromptArg: string;
+  filePath?: string;
+  readonlyRoot?: string;
+  cleanupDir?: string;
+  deferredInput?: {
+    content: string;
+    additionalArgs: string[];
+    env: Record<string, string>;
+  };
+} {
   if (!piInitialPromptNeedsFile(opts.prompt)) {
     return { initialPromptArg: opts.prompt };
   }
@@ -36,13 +62,19 @@ export function preparePiInitialPromptArg(opts: {
     throw new Error('Pi long initial prompt requires SESSION_DATA_DIR for @file delivery; refusing TUI paste fallback');
   }
 
-  const dir = piInitialPromptDir(sessionDataDir);
-  mkdirSync(dir, { recursive: true });
+  const dir = piInitialPromptDir(sessionDataDir, opts.sessionId);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
   const filePath = piInitialPromptFilePath(sessionDataDir, opts.sessionId);
   writeFileSync(filePath, opts.prompt, { encoding: 'utf8', mode: 0o600 });
   return {
     initialPromptArg: `@${filePath}`,
     filePath,
     readonlyRoot: dir,
+    cleanupDir: dir,
+    deferredInput: {
+      content: PI_INITIAL_PROMPT_COMMAND,
+      additionalArgs: ['--extension', piInitialPromptExtensionPath()],
+      env: { [PI_INITIAL_PROMPT_FILE_ENV]: filePath },
+    },
   };
 }

--- a/src/adapters/cli/pi-initial-prompt.ts
+++ b/src/adapters/cli/pi-initial-prompt.ts
@@ -1,0 +1,48 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const PI_INITIAL_PROMPT_ARG_BYTE_LIMIT = 4096;
+
+const SAFE_SESSION_ID = /^[A-Za-z0-9._-]+$/;
+
+function safeSessionFileStem(sessionId: string): string {
+  if (SAFE_SESSION_ID.test(sessionId) && !/^\.+$/.test(sessionId)) return sessionId;
+  return sessionId.replace(/[^A-Za-z0-9._-]/g, '_').replace(/^\.+$/, '_');
+}
+
+export function piInitialPromptNeedsFile(prompt: string | undefined): boolean {
+  return !!prompt && Buffer.byteLength(prompt, 'utf8') > PI_INITIAL_PROMPT_ARG_BYTE_LIMIT;
+}
+
+export function piInitialPromptDir(sessionDataDir: string): string {
+  return join(sessionDataDir, 'pi-initial-prompts');
+}
+
+export function piInitialPromptFilePath(sessionDataDir: string, sessionId: string): string {
+  return join(piInitialPromptDir(sessionDataDir), `${safeSessionFileStem(sessionId)}.prompt.md`);
+}
+
+export function preparePiInitialPromptArg(opts: {
+  prompt: string;
+  sessionId: string;
+  sessionDataDir?: string;
+}): { initialPromptArg: string; filePath?: string; readonlyRoot?: string } {
+  if (!piInitialPromptNeedsFile(opts.prompt)) {
+    return { initialPromptArg: opts.prompt };
+  }
+
+  const sessionDataDir = opts.sessionDataDir?.trim();
+  if (!sessionDataDir) {
+    throw new Error('Pi long initial prompt requires SESSION_DATA_DIR for @file delivery; refusing TUI paste fallback');
+  }
+
+  const dir = piInitialPromptDir(sessionDataDir);
+  mkdirSync(dir, { recursive: true });
+  const filePath = piInitialPromptFilePath(sessionDataDir, opts.sessionId);
+  writeFileSync(filePath, opts.prompt, { encoding: 'utf8', mode: 0o600 });
+  return {
+    initialPromptArg: `@${filePath}`,
+    filePath,
+    readonlyRoot: dir,
+  };
+}

--- a/src/adapters/cli/pi.ts
+++ b/src/adapters/cli/pi.ts
@@ -37,6 +37,8 @@ export function createPiAdapter(pathOverride?: string): CliAdapter {
         initialPrompt: prepared.initialPromptArg,
         readonlyRoots: prepared.readonlyRoot ? [prepared.readonlyRoot] : undefined,
         cleanupPaths: prepared.filePath ? [prepared.filePath] : undefined,
+        cleanupDirs: prepared.cleanupDir ? [prepared.cleanupDir] : undefined,
+        deferredInput: prepared.deferredInput,
       };
     },
 

--- a/src/adapters/cli/pi.ts
+++ b/src/adapters/cli/pi.ts
@@ -1,5 +1,6 @@
 import { resolveCommand } from './registry.js';
 import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
+import { preparePiInitialPromptArg } from './pi-initial-prompt.js';
 import type { CliAdapter, PtyHandle } from './types.js';
 
 import { delay } from '../../utils/timing.js';
@@ -26,11 +27,20 @@ export function createPiAdapter(pathOverride?: string): CliAdapter {
       return `pi --session-id ${sessionId}`;
     },
 
+    prepareInitialPromptArg({ initialPrompt, sessionId, sessionDataDir }) {
+      const prepared = preparePiInitialPromptArg({
+        prompt: initialPrompt,
+        sessionId,
+        sessionDataDir,
+      });
+      return {
+        initialPrompt: prepared.initialPromptArg,
+        readonlyRoots: prepared.readonlyRoot ? [prepared.readonlyRoot] : undefined,
+        cleanupPaths: prepared.filePath ? [prepared.filePath] : undefined,
+      };
+    },
+
     passesInitialPromptViaArgs: true,
-    // tmux reports "command too long" around ~12KB total launch argv on some
-    // deployments, well below OS ARG_MAX. Keep short Pi prompts on argv (legacy
-    // behavior) but route long first messages/cards through writeInput instead.
-    maxInitialPromptArgBytes: 4096,
 
     async writeInput(pty: PtyHandle, content: string) {
       if (pty.pasteText && pty.sendSpecialKeys) {

--- a/src/adapters/cli/read-isolation.ts
+++ b/src/adapters/cli/read-isolation.ts
@@ -317,6 +317,10 @@ export function buildV2DenyPaths(ctx: V2IsolationContext): string[] {
       `${sd}/frozen-cards`,            // conversation content (all bots')
       `${sd}/turn-sends`,              // CLI only APPENDS markers here — read-deny is safe
       `${sd}/crash-diagnostics`,
+      // Long Pi first prompts may contain the full hidden routing/identity
+      // context. Deny the shared root, then the worker carves back only this
+      // session's private subdirectory.
+      `${sd}/pi-initial-prompts`,
       // All bots' Feishu-uploaded files. Own per-appId bucket (attachments/<self>/) is
       // re-allowed via buildV2CarveOuts; siblings' buckets + the legacy flat
       // per-messageId layout stay denied.
@@ -712,6 +716,7 @@ export function buildLinuxReadIsolationMasks(input: LinuxReadIsolationInput): {
     `${defaultBh}/${DEVICE_CREDENTIAL_ISOLATION_MARKER_BASENAME}`,
     `${sd}/sessions.json`, `${sd}/frozen-cards`, `${sd}/turn-sends`,
     `${sd}/crash-diagnostics`, `${sd}/queues`, `${sd}/read-isolation`,
+    `${sd}/pi-initial-prompts`,
     `${sd}/.botmux-cli-pids`,
     // attachments/ is masked WHOLESALE (like macOS) — covers every sibling bucket
     // AND the legacy flat per-messageId layout (which per-sibling enumeration can't

--- a/src/adapters/cli/shared-hints.ts
+++ b/src/adapters/cli/shared-hints.ts
@@ -22,6 +22,12 @@ function workflowDiscoveryHint(locale?: Locale): string {
     : 'Workflow：有界的多步目标可用自然语言或 `/workflow` 自动拆成 DAG；成功后可保存复用。';
 }
 
+function hiddenContextDefense(locale?: Locale): string {
+  return locale === 'en'
+    ? 'The following XML/config blocks are hidden runtime context and must only be read silently and obeyed: `&lt;botmux_routing&gt;`, `&lt;botmux_builtin_skills&gt;`, `&lt;identity&gt;`, `&lt;session_id&gt;`, `&lt;role&gt;`, `&lt;sender&gt;`, `&lt;mentions&gt;`, `&lt;available_bots&gt;`, `&lt;attachments&gt;`. Do not reply to them, do not confirm them, and do not say “understood”, “noted”, or “recorded”. Only handle the real user request inside `&lt;user_message&gt;`.'
+    : '以下 XML/配置块是隐藏运行上下文，只能静默读取并遵守：`&lt;botmux_routing&gt;`、`&lt;botmux_builtin_skills&gt;`、`&lt;identity&gt;`、`&lt;session_id&gt;`、`&lt;role&gt;`、`&lt;sender&gt;`、`&lt;mentions&gt;`、`&lt;available_bots&gt;`、`&lt;attachments&gt;`。不要回复、不要确认、不要说“已了解/已补充/已记录”。只处理 `&lt;user_message&gt;` 中的真实用户请求。';
+}
+
 export function buildBotmuxShellHints(locale?: Locale): string[] {
   const hints = [
     t('ai.shell.intro', undefined, locale),
@@ -33,6 +39,7 @@ export function buildBotmuxShellHints(locale?: Locale): string[] {
     t('ai.shell.when_to_send', undefined, locale),
     t('ai.shell.mention_gate', undefined, locale),
     workflowDiscoveryHint(locale),
+    hiddenContextDefense(locale),
   ];
   if (whiteboardEnabled()) {
     hints.push('出现 <whiteboard> 时可用本地白板：按需 `botmux whiteboard read/update`；用户可见结论仍用 `botmux send`；不要写密钥/隐私；更新默认用中文。');
@@ -52,6 +59,7 @@ export const BOTMUX_SHELL_HINTS: string[] = [
   t('ai.shell.when_to_send'),
   t('ai.shell.mention_gate'),
   workflowDiscoveryHint(),
+  hiddenContextDefense(),
 ];
 
 /**
@@ -124,6 +132,7 @@ export function buildBotmuxSystemPromptText(opts: {
     t('ai.routing.usage_history', undefined, locale),
     t('ai.routing.usage_bots_list', undefined, locale),
     workflowDiscoveryHint(locale),
+    hiddenContextDefense(locale),
     ...whiteboardRouting,
     '</botmux_routing>',
     ...identityBlock,

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -119,7 +119,19 @@ export interface CliAdapter {
     initialPrompt: string;
     sessionId: string;
     sessionDataDir?: string;
-  }): { initialPrompt: string; readonlyRoots?: string[]; cleanupPaths?: string[] };
+  }): {
+    initialPrompt: string;
+    readonlyRoots?: string[];
+    cleanupPaths?: string[];
+    cleanupDirs?: string[];
+    /** Safe, short TUI input used only when worker policy must defer this
+     * prepared argv prompt (startup commands, durable cold-start, etc.). */
+    deferredInput?: {
+      content: string;
+      additionalArgs?: string[];
+      env?: Record<string, string>;
+    };
+  };
 
   /** When true, the adapter passes the initial prompt via CLI args (e.g. -i).
    *  The worker skips queuing the prompt for stdin write unless another

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -112,6 +112,15 @@ export interface CliAdapter {
     remoteThreadId?: string;
   }): string[];
 
+  /** Adapter-specific chance to rewrite the first prompt before buildArgs sees
+   *  it. Used for CLIs that support file positional args for long prompts: the
+   *  worker can still treat the prompt as args-baked and skip stdin fallback. */
+  prepareInitialPromptArg?(opts: {
+    initialPrompt: string;
+    sessionId: string;
+    sessionDataDir?: string;
+  }): { initialPrompt: string; readonlyRoots?: string[]; cleanupPaths?: string[] };
+
   /** When true, the adapter passes the initial prompt via CLI args (e.g. -i).
    *  The worker skips queuing the prompt for stdin write unless another
    *  defer condition routes it through the post-start input queue. */

--- a/src/core/inflight-input-tracker.ts
+++ b/src/core/inflight-input-tracker.ts
@@ -24,6 +24,7 @@ import type { CodexAppTurnInput, VcMeetingImTurnOrigin } from '../types.js';
 
 export type InflightItem = {
   content: string;
+  logicalContent?: string;
   turnId?: string;
   dispatchAttempt?: number;
   vcMeetingImTurnOrigin?: VcMeetingImTurnOrigin;

--- a/src/utils/child-env.ts
+++ b/src/utils/child-env.ts
@@ -107,6 +107,8 @@ export const BOTMUX_INJECTED_ENV_KEYS = [
   'BOTMUX_OWNER_OPEN_ID',
   'BOTMUX_TURN_ID',
   'BOTMUX_DISPATCH_ATTEMPT',
+  // Pi deferred long-first-prompt extension reads one exact per-session file.
+  'BOTMUX_PI_INITIAL_PROMPT_FILE',
   // Loopback port of the owning daemon's agent-facing IPC. Read-isolated CLIs
   // (whose daemon discovery dir is Seatbelt-denied) need it to reach the
   // session-scoped, capability-gated routes (v3 workflow relay, vc-agent).

--- a/src/utils/pending-input-queue.ts
+++ b/src/utils/pending-input-queue.ts
@@ -2,6 +2,10 @@ import type { CodexAppTurnInput, VcMeetingImTurnOrigin } from '../types.js';
 
 export interface PendingCliInput {
   content: string;
+  /** The real user turn represented by `content` when delivery uses a short
+   * adapter command. Transcript bridges fingerprint this value, while the PTY
+   * receives `content`. */
+  logicalContent?: string;
   turnId?: string;
   dispatchAttempt?: number;
   vcMeetingImTurnOrigin?: VcMeetingImTurnOrigin;
@@ -21,7 +25,8 @@ export function mergeQueuedCliInput(
   // would drop or mis-attach the sidecar.
   if (tail.dispatchAttempt !== undefined || next.dispatchAttempt !== undefined
     || tail.vcMeetingImTurnOrigin || next.vcMeetingImTurnOrigin
-    || tail.codexAppInput || next.codexAppInput) return false;
+    || tail.codexAppInput || next.codexAppInput
+    || tail.logicalContent || next.logicalContent) return false;
   tail.content = `${tail.content}\n\n${next.content}`;
   tail.turnId = next.turnId ?? tail.turnId;
   return true;
@@ -71,6 +76,34 @@ export function shouldDeferInitialPromptForArgLimit(opts: {
   const limit = opts.maxInitialPromptArgBytes;
   if (typeof limit !== 'number' || !Number.isFinite(limit) || limit < 0) return false;
   return Buffer.byteLength(opts.prompt, 'utf8') > limit;
+}
+
+/** Resolve the physical first-prompt transport after worker defer policy is
+ * known. A transformed argv prompt can provide a short deferred command while
+ * retaining the original text for bridge attribution. Other adapters keep the
+ * legacy behavior: argv when not deferred, original text in the queue when
+ * deferred. */
+export function resolveInitialPromptDelivery(opts: {
+  originalPrompt?: string;
+  preparedArg?: string;
+  preparedDeferredContent?: string;
+  defer: boolean;
+}): {
+  argvPrompt?: string;
+  queuedContent?: string;
+  logicalContent?: string;
+} {
+  if (!opts.originalPrompt) return {};
+  if (!opts.defer) {
+    return { argvPrompt: opts.preparedArg ?? opts.originalPrompt };
+  }
+  const queuedContent = opts.preparedDeferredContent ?? opts.originalPrompt;
+  return {
+    queuedContent,
+    ...(queuedContent !== opts.originalPrompt
+      ? { logicalContent: opts.originalPrompt }
+      : {}),
+  };
 }
 
 /** Once either side of a queue boundary is durable, stop this batch and wait

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -13,7 +13,7 @@
  *   7. On 'restart', kills CLI and re-spawns with --resume
  */
 import { randomBytes } from 'node:crypto';
-import { mkdirSync, writeFileSync, unlinkSync, existsSync, statSync, lstatSync, readdirSync, readlinkSync, readFileSync, realpathSync, copyFileSync, watch as fsWatch, createWriteStream, openSync, closeSync, fstatSync, constants as fsConstants, type FSWatcher, type WriteStream } from 'node:fs';
+import { mkdirSync, writeFileSync, unlinkSync, rmdirSync, existsSync, statSync, lstatSync, readdirSync, readlinkSync, readFileSync, realpathSync, copyFileSync, watch as fsWatch, createWriteStream, openSync, closeSync, fstatSync, constants as fsConstants, type FSWatcher, type WriteStream } from 'node:fs';
 import { atomicWriteFileSync } from './utils/atomic-write.js';
 import { join, basename, dirname } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
@@ -54,6 +54,7 @@ import {
   mergeQueuedCliInput,
   pendingInputMayFlush,
   pendingInputAllowsTypeAhead,
+  resolveInitialPromptDelivery,
   shouldDeferArgsBakedDurablePrompt,
   shouldDeferInitialPromptForArgLimit,
   shouldStopPendingBatch,
@@ -265,6 +266,10 @@ let remoteThreadId: string | undefined;
 let rpcDialogDismissTimer: ReturnType<typeof setTimeout> | null = null;
 let rpcEnginePidMarker: string | null = null;
 const piInitialPromptCleanupPaths: string[] = [];
+const piInitialPromptCleanupDirs: string[] = [];
+let piInitialPromptReadonlyRoots: string[] = [];
+let piInitialPromptAdditionalArgs: string[] = [];
+let piInitialPromptEnv: Record<string, string> = {};
 
 function cleanupPiInitialPromptFiles(): void {
   while (piInitialPromptCleanupPaths.length > 0) {
@@ -272,6 +277,16 @@ function cleanupPiInitialPromptFiles(): void {
     if (!p) continue;
     try { unlinkSync(p); } catch { /* best effort */ }
   }
+  while (piInitialPromptCleanupDirs.length > 0) {
+    const dir = piInitialPromptCleanupDirs.pop();
+    if (!dir) continue;
+    // Non-recursive on purpose: remove only an empty session-owned directory,
+    // never a shared root or a path that unexpectedly gained other content.
+    try { rmdirSync(dir); } catch { /* best effort */ }
+  }
+  piInitialPromptReadonlyRoots = [];
+  piInitialPromptAdditionalArgs = [];
+  piInitialPromptEnv = {};
 }
 
 function stopCodexRpcEngine(): void {
@@ -765,6 +780,8 @@ let reattachIdleProbeTimer: ReturnType<typeof setTimeout> | null = null;
 let lastSpawnEffectiveResume = false;
 let lastSpawnEffectiveCliSessionId: string | undefined;
 let lastSpawnDeferInitialPrompt = false;
+let lastSpawnQueuedInitialPrompt: string | undefined;
+let lastSpawnQueuedInitialPromptLogicalContent: string | undefined;
 let idleDetector: IdleDetector | null = null;
 let isTmuxMode = false;
 /** True once a crash diagnostic tmux shell (bmx-diag-<sid>) is live. */
@@ -5026,6 +5043,7 @@ async function flushPending(): Promise<void> {
       // resend (Codex delta P1-1).
       if (!codexRpcEngine) inflightInputs.onWrite(item);
       const msg = item.content;
+      const logicalMsg = item.logicalContent ?? msg;
       currentBotmuxTurnId = item.turnId;
       currentBotmuxDispatchAttempt = item.dispatchAttempt;
       currentVcMeetingImTurnOrigin = item.vcMeetingImTurnOrigin;
@@ -5042,13 +5060,13 @@ async function flushPending(): Promise<void> {
       let bridgeTurnId: string | undefined;
       if (claudeBridgeActive) {
         try { bridgeIngest(); } catch { /* best-effort */ }
-        bridgeTurnId = bridgeMarkPendingTurn(msg, item.turnId, item.dispatchAttempt);
+        bridgeTurnId = bridgeMarkPendingTurn(logicalMsg, item.turnId, item.dispatchAttempt);
       } else if (codexBridgeActive) {
         // Codex mark works even before the rollout path is known: the
         // queue is path-agnostic, and the late-attach below will start
         // ingest from offset 0 so the user_message that lands shortly
         // after still fingerprint-matches this turn.
-        codexBridgeMarkPendingTurn(msg, item.turnId, item.dispatchAttempt);
+        codexBridgeMarkPendingTurn(logicalMsg, item.turnId, item.dispatchAttempt);
       }
       if (durableWrite
         && cliAdapter.reliableTurnTerminal === true
@@ -5104,7 +5122,7 @@ async function flushPending(): Promise<void> {
         // do. Otherwise surface it as a submit failure so the message isn't
         // silently lost.
         if (backend) scheduleSubmitFailureNotify(
-          msg,
+          logicalMsg,
           undefined,
           '会话 JSONL',
           bridgeTurnId,
@@ -5130,7 +5148,7 @@ async function flushPending(): Promise<void> {
       // nag that the submit wasn't confirmed.
       if (result && result.submitted === false && backend) {
         scheduleSubmitFailureNotify(
-          msg,
+          logicalMsg,
           result.recheck,
           '会话 JSONL',
           bridgeTurnId,
@@ -6303,6 +6321,11 @@ async function spawnCli(
   // string limits (tmux "command too long") while preserving short argv prompts.
   let preparedInitialPrompt: string | undefined;
   let promptArgPreparationChanged = false;
+  let preparedDeferredInput: {
+    content: string;
+    additionalArgs?: string[];
+    env?: Record<string, string>;
+  } | undefined;
   if (cfg.prompt) {
     const prepared = cliAdapter.prepareInitialPromptArg?.({
       initialPrompt: cfg.prompt,
@@ -6310,11 +6333,17 @@ async function spawnCli(
       sessionDataDir: process.env.SESSION_DATA_DIR,
     });
     if (prepared?.readonlyRoots?.length) {
-      cfg.skillReadonlyRoots = [...(cfg.skillReadonlyRoots ?? []), ...prepared.readonlyRoots];
+      piInitialPromptReadonlyRoots = [
+        ...new Set([...piInitialPromptReadonlyRoots, ...prepared.readonlyRoots]),
+      ];
     }
     if (prepared?.cleanupPaths?.length) {
       piInitialPromptCleanupPaths.push(...prepared.cleanupPaths);
     }
+    if (prepared?.cleanupDirs?.length) {
+      piInitialPromptCleanupDirs.push(...prepared.cleanupDirs);
+    }
+    preparedDeferredInput = prepared?.deferredInput;
     preparedInitialPrompt = prepared?.initialPrompt ?? cfg.prompt;
     promptArgPreparationChanged = preparedInitialPrompt !== cfg.prompt;
   }
@@ -6332,7 +6361,19 @@ async function spawnCli(
       prompt: cfg.prompt,
       maxInitialPromptArgBytes: cliAdapter.maxInitialPromptArgBytes,
     }));
-  if (deferInitialPrompt) preparedInitialPrompt = undefined;
+  const initialPromptDelivery = resolveInitialPromptDelivery({
+    originalPrompt: cfg.prompt,
+    preparedArg: preparedInitialPrompt,
+    preparedDeferredContent: preparedDeferredInput?.content,
+    defer: deferInitialPrompt,
+  });
+  preparedInitialPrompt = initialPromptDelivery.argvPrompt;
+  lastSpawnQueuedInitialPrompt = initialPromptDelivery.queuedContent;
+  lastSpawnQueuedInitialPromptLogicalContent = initialPromptDelivery.logicalContent;
+  if (deferInitialPrompt && preparedDeferredInput) {
+    piInitialPromptAdditionalArgs = [...(preparedDeferredInput.additionalArgs ?? [])];
+    piInitialPromptEnv = { ...(preparedDeferredInput.env ?? {}) };
+  }
   lastSpawnDeferInitialPrompt = deferInitialPrompt;
   kiroSessionIdCaptureArmed = cfg.cliId === 'kiro-cli' && !effectiveCliSessionId && !willReattachPersistent;
   kiroSessionIdCaptureBuffer = '';
@@ -6430,6 +6471,12 @@ async function spawnCli(
     remoteWsUrl,
     remoteThreadId,
   });
+  // Pi's deferred long-first-prompt command is implemented by a session-scoped
+  // extension. Keep its launch args across owned process restarts while the
+  // queued/in-flight command may still need replay.
+  if (piInitialPromptAdditionalArgs.length > 0) {
+    args.unshift(...piInitialPromptAdditionalArgs);
+  }
 
   // Extra args from env (CLI_DISABLE_DEFAULT_ARGS is removed — adapters own their defaults)
   const extra = (process.env.CLI_EXTRA_ARGS ?? '').trim();
@@ -6555,6 +6602,9 @@ async function spawnCli(
   // passthrough whitelist (BOTMUX_INJECTED_ENV_KEYS) so the tmux backend forwards
   // them past the server's global env.
   if (cliAdapter.spawnEnv) Object.assign(childEnv, cliAdapter.spawnEnv);
+  if (Object.keys(piInitialPromptEnv).length > 0) {
+    Object.assign(childEnv, piInitialPromptEnv);
+  }
 
   // v2 read isolation: point the CLI at its PER-BOT config dir (set AFTER spawnEnv
   // so it overrides any adapter default). claude → CLAUDE_CONFIG_DIR, codex →
@@ -6650,6 +6700,9 @@ async function spawnCli(
           cliId: cliAdapter.id,
           resolvedBin: canonical(cliAdapter.resolvedBin),
         }),
+        // buildV2DenyPaths masks the shared pi-initial-prompts root. Re-open
+        // only this session's private child directory for Pi's @file/extension.
+        ...piInitialPromptReadonlyRoots.map(canonical),
       ];
       finalDenyPaths = carve.finalDenyPaths.map(canonical);
       traverseDirs = carve.traverseDirs.map(canonical);
@@ -6885,6 +6938,7 @@ async function spawnCli(
           extraExecPaths: cliAdapter.sandboxExtraExecPaths?.(),
           readonlyRoots: [
             ...(cfg.skillReadonlyRoots ?? []),
+            ...piInitialPromptReadonlyRoots,
             ...(readIsoLinuxMasks?.ownReadOnlyPaths ?? []),
           ],
           mcpGatewaySocketPath: sessionMcpGatewayHost?.socketPath,
@@ -7585,7 +7639,7 @@ function killCli(opts: { preservePending?: boolean } = {}): void {
   currentCliCredentialIsolated = false;
   stopSessionMcpGatewayHost();
   stopCodexRpcEngine();
-  cleanupPiInitialPromptFiles();
+  if (!opts.preservePending) cleanupPiInitialPromptFiles();
   destroyCrashDiagnosticTerminal('killCli');
   idleDetector?.dispose();
   idleDetector = null;
@@ -9070,7 +9124,10 @@ process.on('message', async (raw: unknown) => {
           deferInitialPrompt,
         })) {
           pendingMessages.push({
-            content: msg.prompt,
+            content: lastSpawnQueuedInitialPrompt ?? msg.prompt,
+            ...(lastSpawnQueuedInitialPromptLogicalContent
+              ? { logicalContent: lastSpawnQueuedInitialPromptLogicalContent }
+              : {}),
             turnId: msg.turnId,
             dispatchAttempt: msg.dispatchAttempt,
             vcMeetingImTurnOrigin: msg.vcMeetingImTurnOrigin,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -264,6 +264,15 @@ let remoteWsUrl: string | undefined;
 let remoteThreadId: string | undefined;
 let rpcDialogDismissTimer: ReturnType<typeof setTimeout> | null = null;
 let rpcEnginePidMarker: string | null = null;
+const piInitialPromptCleanupPaths: string[] = [];
+
+function cleanupPiInitialPromptFiles(): void {
+  while (piInitialPromptCleanupPaths.length > 0) {
+    const p = piInitialPromptCleanupPaths.pop();
+    if (!p) continue;
+    try { unlinkSync(p); } catch { /* best effort */ }
+  }
+}
 
 function stopCodexRpcEngine(): void {
   const engine = codexRpcEngine;
@@ -755,6 +764,7 @@ let reattachIdleProbeTimer: ReturnType<typeof setTimeout> | null = null;
  *  adapter's hermesBridgeAttach reads the correct mode. */
 let lastSpawnEffectiveResume = false;
 let lastSpawnEffectiveCliSessionId: string | undefined;
+let lastSpawnDeferInitialPrompt = false;
 let idleDetector: IdleDetector | null = null;
 let isTmuxMode = false;
 /** True once a crash diagnostic tmux shell (bmx-diag-<sid>) is live. */
@@ -6291,6 +6301,23 @@ async function spawnCli(
   // baking it into args would drop the message that triggered the resume.
   // Finally, defer adapter-declared over-limit prompts to avoid backend command
   // string limits (tmux "command too long") while preserving short argv prompts.
+  let preparedInitialPrompt: string | undefined;
+  let promptArgPreparationChanged = false;
+  if (cfg.prompt) {
+    const prepared = cliAdapter.prepareInitialPromptArg?.({
+      initialPrompt: cfg.prompt,
+      sessionId: effectiveAdapterSessionId,
+      sessionDataDir: process.env.SESSION_DATA_DIR,
+    });
+    if (prepared?.readonlyRoots?.length) {
+      cfg.skillReadonlyRoots = [...(cfg.skillReadonlyRoots ?? []), ...prepared.readonlyRoots];
+    }
+    if (prepared?.cleanupPaths?.length) {
+      piInitialPromptCleanupPaths.push(...prepared.cleanupPaths);
+    }
+    preparedInitialPrompt = prepared?.initialPrompt ?? cfg.prompt;
+    promptArgPreparationChanged = preparedInitialPrompt !== cfg.prompt;
+  }
   const deferInitialPrompt = shouldDeferInitialPromptForStartup({
     hasStartupCommands: !!cfg.startupCommands?.length,
     adoptMode: cfg.adoptMode === true,
@@ -6300,11 +6327,13 @@ async function spawnCli(
     adoptMode: cfg.adoptMode === true,
     dispatchAttempt: cfg.dispatchAttempt,
   }) || (effectiveResume && cliAdapter.initialPromptArgsIgnoredOnResume === true)
-    || shouldDeferInitialPromptForArgLimit({
+    || (!promptArgPreparationChanged && shouldDeferInitialPromptForArgLimit({
       passesInitialPromptViaArgs: cliAdapter.passesInitialPromptViaArgs === true,
       prompt: cfg.prompt,
       maxInitialPromptArgBytes: cliAdapter.maxInitialPromptArgBytes,
-    });
+    }));
+  if (deferInitialPrompt) preparedInitialPrompt = undefined;
+  lastSpawnDeferInitialPrompt = deferInitialPrompt;
   kiroSessionIdCaptureArmed = cfg.cliId === 'kiro-cli' && !effectiveCliSessionId && !willReattachPersistent;
   kiroSessionIdCaptureBuffer = '';
   // Per-bot local read isolation: assemble the Seatbelt profile context (the gate
@@ -6386,7 +6415,7 @@ async function spawnCli(
     resume: effectiveResume,
     workingDir: cfg.workingDir,
     resumeSessionId: effectiveCliSessionId,
-    initialPrompt: deferInitialPrompt ? undefined : (cfg.prompt || undefined),
+    initialPrompt: preparedInitialPrompt,
     botName: cfg.botName,
     botOpenId: cfg.botOpenId,
     larkAppId: cfg.larkAppId,
@@ -7556,6 +7585,7 @@ function killCli(opts: { preservePending?: boolean } = {}): void {
   currentCliCredentialIsolated = false;
   stopSessionMcpGatewayHost();
   stopCodexRpcEngine();
+  cleanupPiInitialPromptFiles();
   destroyCrashDiagnosticTerminal('killCli');
   idleDetector?.dispose();
   idleDetector = null;
@@ -9015,20 +9045,7 @@ process.on('message', async (raw: unknown) => {
         // Tier-1/Tier-2 fresh demotion, which clears the flag). Adopt spawns
         // return from spawnCli before that write — exclude them explicitly so
         // the stale module-level value can't leak in.
-        const deferInitialPrompt = shouldDeferInitialPromptForStartup({
-          hasStartupCommands: !!msg.startupCommands?.length,
-          adoptMode: msg.adoptMode === true,
-          passesInitialPromptViaArgs: cliAdapter?.passesInitialPromptViaArgs === true,
-        }) || shouldDeferArgsBakedDurablePrompt({
-          passesInitialPromptViaArgs: cliAdapter?.passesInitialPromptViaArgs === true,
-          adoptMode: msg.adoptMode === true,
-          dispatchAttempt: msg.dispatchAttempt,
-        }) || (msg.adoptMode !== true && lastSpawnEffectiveResume && cliAdapter?.initialPromptArgsIgnoredOnResume === true)
-          || shouldDeferInitialPromptForArgLimit({
-            passesInitialPromptViaArgs: cliAdapter?.passesInitialPromptViaArgs === true,
-            prompt: msg.prompt,
-            maxInitialPromptArgBytes: cliAdapter?.maxInitialPromptArgBytes,
-          });
+        const deferInitialPrompt = lastSpawnDeferInitialPrompt;
         if (msg.prompt && cliAdapter?.passesInitialPromptViaArgs && !deferInitialPrompt && codexBridgeFallbackActive()) {
           // Args-baked first prompts (notably Pi) never pass through the normal
           // 'message' IPC path, so the structured bridge would otherwise see the
@@ -9502,6 +9519,7 @@ process.on('message', async (raw: unknown) => {
 // ─── Cleanup ─────────────────────────────────────────────────────────────────
 
 function cleanup(): void {
+  cleanupPiInitialPromptFiles();
   stopSessionMcpGatewayHost();
   if (tmuxRestartTimer) {
     clearTimeout(tmuxRestartTimer);

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -773,7 +773,7 @@ describe('pi buildArgs', () => {
     expect(args).not.toContain('--tools');
     expect(args.at(-1)).toBe('hello pi');
     expect(adapter.passesInitialPromptViaArgs).toBe(true);
-    expect(adapter.maxInitialPromptArgBytes).toBe(4096);
+    expect(adapter.maxInitialPromptArgBytes).toBeUndefined();
     expect(adapter.altScreen).toBe(true);
   });
 });

--- a/test/inflight-input-tracker.test.ts
+++ b/test/inflight-input-tracker.test.ts
@@ -41,6 +41,21 @@ describe('InflightInputTracker', () => {
     expect(t.takeCarryOver()).toEqual([{ content: '<legacy />', turnId: 'om_1', codexAppInput }]);
   });
 
+  it('preserves logical content for a deferred transport command across crash replay', () => {
+    const t = new InflightInputTracker();
+    t.onWrite({
+      content: '/botmux-initial-prompt',
+      logicalContent: 'full original prompt',
+      turnId: 'om_1',
+    });
+    expect(t.onCliExit()).toBe(1);
+    expect(t.takeCarryOver()).toEqual([{
+      content: '/botmux-initial-prompt',
+      logicalContent: 'full original prompt',
+      turnId: 'om_1',
+    }]);
+  });
+
   it('completed turn: idle clears in-flight, a later crash re-queues nothing', () => {
     const t = new InflightInputTracker();
     t.onWrite(item('hello'));

--- a/test/initial-prompt-arg-limit.test.ts
+++ b/test/initial-prompt-arg-limit.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
 import { createPiAdapter } from '../src/adapters/cli/pi.js';
-import type { PtyHandle } from '../src/adapters/cli/types.js';
 import { shouldQueueInitialPrompt } from '../src/codex-rpc-lifecycle.js';
 import { shouldDeferInitialPromptForArgLimit } from '../src/utils/pending-input-queue.js';
 
@@ -41,45 +43,44 @@ describe('initial prompt argv byte-limit fallback', () => {
     })).toBe(false);
   });
 
-  it('routes over-limit Pi first prompts out of spawn args and into the worker queue exactly once', async () => {
+  it('routes long Pi first prompts through @file argv instead of the worker queue', () => {
     const adapter = createPiAdapter('/bin/pi');
-    const prompt = '长卡片'.repeat(2500); // > 10KB UTF-8, above Pi's tmux-safe argv budget.
+    const prompt = '长卡片'.repeat(2500); // > 10KB UTF-8, above Pi's old tmux-safe argv budget.
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-pi-limit-'));
+    try {
+      const prepared = adapter.prepareInitialPromptArg!({
+        initialPrompt: prompt,
+        sessionId: 'sess-pi-long',
+        sessionDataDir: dataDir,
+      });
+      const deferInitialPrompt = shouldDeferInitialPromptForArgLimit({
+        passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
+        prompt: prepared.initialPrompt,
+        maxInitialPromptArgBytes: adapter.maxInitialPromptArgBytes,
+      });
+      const args = adapter.buildArgs({
+        sessionId: 'sess-pi-long',
+        resume: false,
+        initialPrompt: deferInitialPrompt ? undefined : prepared.initialPrompt,
+      });
+      const shouldQueue = shouldQueueInitialPrompt({
+        hasPrompt: true,
+        rpcEngineActive: false,
+        queuePrompt: false,
+        passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
+        deferInitialPrompt,
+      });
 
-    const deferInitialPrompt = shouldDeferInitialPromptForArgLimit({
-      passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
-      prompt,
-      maxInitialPromptArgBytes: adapter.maxInitialPromptArgBytes,
-    });
-    const args = adapter.buildArgs({
-      sessionId: 'sess-pi-long',
-      resume: false,
-      initialPrompt: deferInitialPrompt ? undefined : prompt,
-    });
-    const shouldQueue = shouldQueueInitialPrompt({
-      hasPrompt: true,
-      rpcEngineActive: false,
-      queuePrompt: false,
-      passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
-      deferInitialPrompt,
-    });
-
-    expect(adapter.maxInitialPromptArgBytes).toBe(4096);
-    expect(Buffer.byteLength(prompt, 'utf8')).toBeGreaterThan(10_000);
-    expect(deferInitialPrompt).toBe(true);
-    expect(args).toEqual(['--session-id', 'sess-pi-long']);
-    expect(args).not.toContain(prompt);
-    expect(shouldQueue).toBe(true);
-
-    const pty = {
-      write: vi.fn(),
-      pasteText: vi.fn(),
-      sendSpecialKeys: vi.fn(),
-    } satisfies PtyHandle;
-    if (shouldQueue) await adapter.writeInput(pty, prompt);
-
-    expect(pty.pasteText).toHaveBeenCalledTimes(1);
-    expect(pty.pasteText).toHaveBeenCalledWith(prompt);
-    expect(pty.sendSpecialKeys).toHaveBeenCalledTimes(1);
-    expect(pty.sendSpecialKeys).toHaveBeenCalledWith('Enter');
+      expect(adapter.maxInitialPromptArgBytes).toBeUndefined();
+      expect(Buffer.byteLength(prompt, 'utf8')).toBeGreaterThan(10_000);
+      expect(prepared.initialPrompt).toMatch(/^@.+\.prompt\.md$/);
+      expect(readFileSync(prepared.cleanupPaths![0]!, 'utf-8')).toBe(prompt);
+      expect(deferInitialPrompt).toBe(false);
+      expect(args).toEqual(['--session-id', 'sess-pi-long', prepared.initialPrompt]);
+      expect(args).not.toContain(prompt);
+      expect(shouldQueue).toBe(false);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/initial-prompt-arg-limit.test.ts
+++ b/test/initial-prompt-arg-limit.test.ts
@@ -4,7 +4,11 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { createPiAdapter } from '../src/adapters/cli/pi.js';
 import { shouldQueueInitialPrompt } from '../src/codex-rpc-lifecycle.js';
-import { shouldDeferInitialPromptForArgLimit } from '../src/utils/pending-input-queue.js';
+import {
+  resolveInitialPromptDelivery,
+  shouldDeferInitialPromptForArgLimit,
+} from '../src/utils/pending-input-queue.js';
+import { PI_INITIAL_PROMPT_COMMAND } from '../src/adapters/cli/pi-initial-prompt-extension.js';
 
 process.env.BOTMUX_TIME_SCALE ??= '0.01';
 
@@ -82,5 +86,32 @@ describe('initial prompt argv byte-limit fallback', () => {
     } finally {
       rmSync(dataDir, { recursive: true, force: true });
     }
+  });
+
+  it('uses Pi native message delivery instead of TUI-pasting a transformed long prompt when deferred', () => {
+    const original = 'x'.repeat(10_000);
+    const preparedArg = '@/data/pi-initial-prompts/session/initial.prompt.md';
+    expect(resolveInitialPromptDelivery({
+      originalPrompt: original,
+      preparedArg,
+      preparedDeferredContent: PI_INITIAL_PROMPT_COMMAND,
+      defer: true,
+    })).toEqual({
+      queuedContent: PI_INITIAL_PROMPT_COMMAND,
+      logicalContent: original,
+    });
+  });
+
+  it('preserves legacy argv and deferred queue behavior without an adapter command', () => {
+    expect(resolveInitialPromptDelivery({
+      originalPrompt: 'hello',
+      preparedArg: 'prepared',
+      defer: false,
+    })).toEqual({ argvPrompt: 'prepared' });
+    expect(resolveInitialPromptDelivery({
+      originalPrompt: 'hello',
+      preparedArg: 'prepared',
+      defer: true,
+    })).toEqual({ queuedContent: 'hello' });
   });
 });

--- a/test/pi-initial-prompt.test.ts
+++ b/test/pi-initial-prompt.test.ts
@@ -1,0 +1,102 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { shouldQueueInitialPrompt } from '../src/codex-rpc-lifecycle.js';
+import { createPiAdapter } from '../src/adapters/cli/pi.js';
+import {
+  PI_INITIAL_PROMPT_ARG_BYTE_LIMIT,
+  preparePiInitialPromptArg,
+} from '../src/adapters/cli/pi-initial-prompt.js';
+
+function longBotmuxPrompt(): string {
+  return [
+    '<botmux_routing>',
+    '- botmux-goal-ask: ask the user before choosing a goal',
+    '- botmux-orchestrate: coordinate bounded multi-step work',
+    '- botmux-ask: ask for approval through cards',
+    '</botmux_routing>',
+    '<botmux_builtin_skills>',
+    '- botmux-goal-ask: ...',
+    '- botmux-orchestrate: ...',
+    '- botmux-ask: ...',
+    '</botmux_builtin_skills>',
+    '<identity>',
+    '  <name>DW Agent (Pi)</name>',
+    '  <routing_rules>hidden launch rules</routing_rules>',
+    '</identity>',
+    '<user_message>',
+    '请修复 Pi 长首轮 prompt 被拆成多轮 user message 的问题。',
+    '</user_message>',
+    'x'.repeat(PI_INITIAL_PROMPT_ARG_BYTE_LIMIT + 1),
+  ].join('\n');
+}
+
+describe('Pi initial prompt @file delivery', () => {
+  it('keeps short first prompts as the positional message', () => {
+    const result = preparePiInitialPromptArg({
+      prompt: '<user_message>hello Pi</user_message>',
+      sessionId: 'sess-short',
+      sessionDataDir: '/tmp/botmux-data',
+    });
+
+    expect(result.initialPromptArg).toBe('<user_message>hello Pi</user_message>');
+    expect(result.filePath).toBeUndefined();
+    expect(result.readonlyRoot).toBeUndefined();
+  });
+
+  it('writes long first prompts to a session-lifetime UTF-8 file and passes @file', () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-pi-prompt-'));
+    try {
+      const prompt = longBotmuxPrompt();
+      const result = preparePiInitialPromptArg({
+        prompt,
+        sessionId: 'sess-long',
+        sessionDataDir: dataDir,
+      });
+
+      expect(result.initialPromptArg).toBe(`@${result.filePath}`);
+      expect(result.filePath).toMatch(/pi-initial-prompts\/sess-long\.prompt\.md$/);
+      expect(result.readonlyRoot).toBe(dirname(result.filePath!));
+      expect(readFileSync(result.filePath!, 'utf-8')).toBe(prompt);
+      expect(result.initialPromptArg).toContain('@');
+
+      const adapterPrepared = createPiAdapter('pi').prepareInitialPromptArg!({
+        initialPrompt: prompt,
+        sessionId: 'sess-long-adapter',
+        sessionDataDir: dataDir,
+      });
+      expect(adapterPrepared.initialPrompt).toMatch(/^@.+\.prompt\.md$/);
+      expect(adapterPrepared.readonlyRoots).toEqual([dirname(adapterPrepared.cleanupPaths![0]!)]);
+      expect(adapterPrepared.cleanupPaths).toHaveLength(1);
+
+      const args = createPiAdapter('pi').buildArgs({
+        sessionId: 'sess-long-adapter',
+        initialPrompt: adapterPrepared.initialPrompt,
+      });
+      expect(args).toEqual(['--session-id', 'sess-long-adapter', adapterPrepared.initialPrompt]);
+
+      expect(Buffer.byteLength(prompt, 'utf8')).toBeGreaterThan(PI_INITIAL_PROMPT_ARG_BYTE_LIMIT);
+      expect(Buffer.byteLength(adapterPrepared.initialPrompt, 'utf8')).toBeLessThan(prompt.length);
+
+      // Worker wiring must treat the prepared @file path as args-baked input, so
+      // the first turn is not queued for writeInput/TUI paste fallback after spawn.
+      expect(shouldQueueInitialPrompt({
+        hasPrompt: true,
+        rpcEngineActive: false,
+        queuePrompt: false,
+        passesInitialPromptViaArgs: true,
+        deferInitialPrompt: false,
+      })).toBe(false);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when a long prompt has no session data directory for the prompt file', () => {
+    expect(() => preparePiInitialPromptArg({
+      prompt: longBotmuxPrompt(),
+      sessionId: 'sess-no-dir',
+    })).toThrow(/SESSION_DATA_DIR/);
+  });
+});

--- a/test/pi-initial-prompt.test.ts
+++ b/test/pi-initial-prompt.test.ts
@@ -1,6 +1,6 @@
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, relative } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { shouldQueueInitialPrompt } from '../src/codex-rpc-lifecycle.js';
 import { createPiAdapter } from '../src/adapters/cli/pi.js';
@@ -8,6 +8,11 @@ import {
   PI_INITIAL_PROMPT_ARG_BYTE_LIMIT,
   preparePiInitialPromptArg,
 } from '../src/adapters/cli/pi-initial-prompt.js';
+import registerBotmuxInitialPromptExtension, {
+  PI_INITIAL_PROMPT_COMMAND,
+  PI_INITIAL_PROMPT_COMMAND_NAME,
+  PI_INITIAL_PROMPT_FILE_ENV,
+} from '../src/adapters/cli/pi-initial-prompt-extension.js';
 
 function longBotmuxPrompt(): string {
   return [
@@ -56,10 +61,19 @@ describe('Pi initial prompt @file delivery', () => {
       });
 
       expect(result.initialPromptArg).toBe(`@${result.filePath}`);
-      expect(result.filePath).toMatch(/pi-initial-prompts\/sess-long\.prompt\.md$/);
+      expect(result.filePath).toMatch(/pi-initial-prompts\/sess-long\/initial\.prompt\.md$/);
       expect(result.readonlyRoot).toBe(dirname(result.filePath!));
+      expect(result.cleanupDir).toBe(result.readonlyRoot);
       expect(readFileSync(result.filePath!, 'utf-8')).toBe(prompt);
       expect(result.initialPromptArg).toContain('@');
+      expect(result.deferredInput?.content).toBe(PI_INITIAL_PROMPT_COMMAND);
+      expect(result.deferredInput?.additionalArgs).toEqual([
+        '--extension',
+        expect.stringMatching(/pi-initial-prompt-extension\.(?:js|ts)$/),
+      ]);
+      expect(result.deferredInput?.env).toEqual({
+        [PI_INITIAL_PROMPT_FILE_ENV]: result.filePath,
+      });
 
       const adapterPrepared = createPiAdapter('pi').prepareInitialPromptArg!({
         initialPrompt: prompt,
@@ -69,6 +83,8 @@ describe('Pi initial prompt @file delivery', () => {
       expect(adapterPrepared.initialPrompt).toMatch(/^@.+\.prompt\.md$/);
       expect(adapterPrepared.readonlyRoots).toEqual([dirname(adapterPrepared.cleanupPaths![0]!)]);
       expect(adapterPrepared.cleanupPaths).toHaveLength(1);
+      expect(adapterPrepared.cleanupDirs).toEqual(adapterPrepared.readonlyRoots);
+      expect(adapterPrepared.deferredInput?.content).toBe(PI_INITIAL_PROMPT_COMMAND);
 
       const args = createPiAdapter('pi').buildArgs({
         sessionId: 'sess-long-adapter',
@@ -93,10 +109,70 @@ describe('Pi initial prompt @file delivery', () => {
     }
   });
 
+  it('uses a distinct readonly directory for every session', () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-pi-isolation-'));
+    try {
+      const first = preparePiInitialPromptArg({
+        prompt: longBotmuxPrompt(),
+        sessionId: 'session-a',
+        sessionDataDir: dataDir,
+      });
+      const second = preparePiInitialPromptArg({
+        prompt: longBotmuxPrompt(),
+        sessionId: 'session-b',
+        sessionDataDir: dataDir,
+      });
+
+      expect(first.readonlyRoot).not.toBe(second.readonlyRoot);
+      expect(relative(first.readonlyRoot!, second.filePath!).startsWith('..')).toBe(true);
+      expect(relative(second.readonlyRoot!, first.filePath!).startsWith('..')).toBe(true);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it('fails closed when a long prompt has no session data directory for the prompt file', () => {
     expect(() => preparePiInitialPromptArg({
       prompt: longBotmuxPrompt(),
       sessionId: 'sess-no-dir',
     })).toThrow(/SESSION_DATA_DIR/);
+  });
+});
+
+describe('Pi deferred initial prompt extension', () => {
+  it('loads the worker-selected file and submits it as one native user message', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-pi-extension-'));
+    const filePath = join(dataDir, 'initial.prompt.md');
+    const prompt = longBotmuxPrompt();
+    writeFileSync(filePath, prompt);
+    const previous = process.env[PI_INITIAL_PROMPT_FILE_ENV];
+    process.env[PI_INITIAL_PROMPT_FILE_ENV] = filePath;
+    try {
+      let commandName: string | undefined;
+      let handler: ((args: string, ctx: any) => Promise<void> | void) | undefined;
+      const sent: Array<{ content: string; options?: { deliverAs: 'followUp' } }> = [];
+      registerBotmuxInitialPromptExtension({
+        registerCommand(name, options) {
+          commandName = name;
+          handler = options.handler;
+        },
+        sendUserMessage(content, options) {
+          sent.push({ content, options });
+        },
+      });
+
+      expect(commandName).toBe(PI_INITIAL_PROMPT_COMMAND_NAME);
+      await handler!('', {
+        isIdle: () => true,
+        ui: { notify: () => undefined },
+      });
+
+      expect(sent).toEqual([{ content: prompt, options: undefined }]);
+      expect(process.env[PI_INITIAL_PROMPT_FILE_ENV]).toBeUndefined();
+    } finally {
+      if (previous === undefined) delete process.env[PI_INITIAL_PROMPT_FILE_ENV];
+      else process.env[PI_INITIAL_PROMPT_FILE_ENV] = previous;
+      rmSync(dataDir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/prompt-builder.test.ts
+++ b/test/prompt-builder.test.ts
@@ -113,6 +113,19 @@ describe('buildNewTopicPrompt', () => {
     expect(prompt).toContain('--content-file');
   });
 
+  it('tells non-injecting CLIs to silently obey hidden launch context and answer only user_message', () => {
+    const prompt = buildNewTopicPrompt('hello', SESSION_ID, 'codex');
+    const routing = prompt.slice(prompt.indexOf('<botmux_routing>'), prompt.indexOf('</botmux_routing>'));
+
+    expect(routing).toContain('隐藏运行上下文');
+    expect(routing).toContain('&lt;botmux_builtin_skills&gt;');
+    expect(routing).toContain('&lt;identity&gt;');
+    expect(routing).toContain('&lt;available_bots&gt;');
+    expect(routing).toContain('不要回复、不要确认');
+    expect(routing).toContain('已了解/已补充/已记录');
+    expect(routing).toContain('只处理 `&lt;user_message&gt;` 中的真实用户请求');
+  });
+
   it('uses final-output routing hints for Hermes instead of normal botmux send guidance', () => {
     const prompt = buildNewTopicPrompt('hello', SESSION_ID, 'hermes');
     expect(prompt).toContain('普通文字回复请直接写在 assistant final');

--- a/test/read-isolation.test.ts
+++ b/test/read-isolation.test.ts
@@ -214,6 +214,7 @@ describe('v2 HYBRID model (buildV2DenyPaths)', () => {
     expect(d).toContain('/Users/bot/.botmux/data/queues');        // all bots' inbound message content
     expect(d).toContain('/Users/bot/.botmux/data/read-isolation'); // profiles enumerate sibling sessions
     expect(d).toContain('/Users/bot/.botmux/data/.botmux-cli-pids'); // live cross-session tuples
+    expect(d).toContain('/Users/bot/.botmux/data/pi-initial-prompts'); // hidden first-turn context
     // schedules.json is a read-modify-write store — denying the read makes a
     // sandboxed `botmux schedule` load an empty map then overwrite the shared
     // file, wiping every bot's tasks. Deliberately NOT denied (accept the minor
@@ -757,7 +758,8 @@ describe('Linux read isolation (buildLinuxReadIsolationMasks)', () => {
     for (const p of ['/Users/bot/.claude', '/Users/bot/.codex', '/Users/bot/.ssh',
       '/Users/bot/.botmux/bots.json', '/Users/bot/.botmux/feishu-session.json',
       '/Users/bot/.botmux/.dashboard-secret', '/Users/bot/.botmux/data/frozen-cards',
-      '/Users/bot/.botmux/data/queues']) expect(r.hidePaths).toContain(p);
+      '/Users/bot/.botmux/data/queues',
+      '/Users/bot/.botmux/data/pi-initial-prompts']) expect(r.hidePaths).toContain(p);
     // per-sibling (enumerated — no regex on bwrap)
     for (const p of ['/Users/bot/.botmux/bots/cli_other1', '/Users/bot/.lark-cli-bots/cli_other2',
       '/Users/bot/.botmux/data/sessions-cli_other1.json', '/Users/bot/.botmux/data/identities-cli_other2.json',
@@ -886,6 +888,14 @@ describe('worker capability carve-out ordering', () => {
     expect(allowAt).toBeGreaterThan(denyAt);
     expect(writeDenyAt).toBeGreaterThan(allowAt);
     expect(profileAt).toBeGreaterThan(writeDenyAt);
+  });
+
+  it('carves back only the prepared Pi session prompt directory after masking the shared root', () => {
+    expect(source).toContain('...piInitialPromptReadonlyRoots.map(canonical),');
+    expect(source).toContain('...piInitialPromptReadonlyRoots,');
+    expect(source).not.toContain(
+      'cfg.skillReadonlyRoots = [...(cfg.skillReadonlyRoots ?? []), ...prepared.readonlyRoots]',
+    );
   });
 
   it('enforces the mandatory credential gate before adopt and wraps wrapperCli from the outside', () => {

--- a/test/startup-commands.test.ts
+++ b/test/startup-commands.test.ts
@@ -103,6 +103,7 @@ describe('worker.ts startup-commands wiring', () => {
     // adapter-level preparation may also rewrite long prompts to safe argv tokens.
     expect(src).toContain('cliAdapter.prepareInitialPromptArg?.({');
     expect(src).toContain('promptArgPreparationChanged = preparedInitialPrompt !== cfg.prompt;');
+    expect(src).toContain('resolveInitialPromptDelivery({');
     expect(src).toContain('initialPrompt: preparedInitialPrompt,');
     expect(src).toContain('shouldDeferInitialPromptForArgLimit({');
     expect(src).toContain('maxInitialPromptArgBytes: cliAdapter.maxInitialPromptArgBytes,');
@@ -111,5 +112,9 @@ describe('worker.ts startup-commands wiring', () => {
     expect(src).toContain('shouldQueueInitialPrompt({');
     expect(src).toContain('passesInitialPromptViaArgs: cliAdapter?.passesInitialPromptViaArgs === true,');
     expect(src).toContain('deferInitialPrompt,');
+    expect(src).toContain('content: lastSpawnQueuedInitialPrompt ?? msg.prompt,');
+    expect(src).toContain('logicalContent: lastSpawnQueuedInitialPromptLogicalContent');
+    expect(src).toContain('args.unshift(...piInitialPromptAdditionalArgs);');
+    expect(src).toContain('Object.assign(childEnv, piInitialPromptEnv);');
   });
 });

--- a/test/startup-commands.test.ts
+++ b/test/startup-commands.test.ts
@@ -99,11 +99,15 @@ describe('worker.ts startup-commands wiring', () => {
   });
 
   it('defers args-baked initial prompts for startup commands and adapter argv byte limits', () => {
-    // buildArgs gets undefined (not baked) and the init handler queues it instead.
-    expect(src).toContain('initialPrompt: deferInitialPrompt ? undefined : (cfg.prompt || undefined)');
+    // buildArgs gets undefined (not baked) and the init handler queues it instead;
+    // adapter-level preparation may also rewrite long prompts to safe argv tokens.
+    expect(src).toContain('cliAdapter.prepareInitialPromptArg?.({');
+    expect(src).toContain('promptArgPreparationChanged = preparedInitialPrompt !== cfg.prompt;');
+    expect(src).toContain('initialPrompt: preparedInitialPrompt,');
     expect(src).toContain('shouldDeferInitialPromptForArgLimit({');
     expect(src).toContain('maxInitialPromptArgBytes: cliAdapter.maxInitialPromptArgBytes,');
-    expect(src).toContain('maxInitialPromptArgBytes: cliAdapter?.maxInitialPromptArgBytes,');
+    expect(src).toContain('lastSpawnDeferInitialPrompt = deferInitialPrompt;');
+    expect(src).toContain('const deferInitialPrompt = lastSpawnDeferInitialPrompt;');
     expect(src).toContain('shouldQueueInitialPrompt({');
     expect(src).toContain('passesInitialPromptViaArgs: cliAdapter?.passesInitialPromptViaArgs === true,');
     expect(src).toContain('deferInitialPrompt,');

--- a/test/worker-queue-merge.test.ts
+++ b/test/worker-queue-merge.test.ts
@@ -44,6 +44,20 @@ describe('mergeQueuedCliInput', () => {
     expect(ordinaryTail).toEqual([{ content: 'human turn', turnId: 'im-1' }]);
   });
 
+  it('never merges a transport command that represents different logical content', () => {
+    const deferred = [{
+      content: '/botmux-initial-prompt',
+      logicalContent: 'full original prompt',
+      turnId: 't1',
+    }];
+    expect(mergeQueuedCliInput(deferred, { content: 'next', turnId: 't2' })).toBe(false);
+    expect(mergeQueuedCliInput([{ content: 'ordinary', turnId: 't1' }], {
+      content: '/botmux-initial-prompt',
+      logicalContent: 'full original prompt',
+      turnId: 't2',
+    })).toBe(false);
+  });
+
   it('never merges queued explicit meeting IM turns or batches them on one live origin', () => {
     const pending = [{ content: 'human A', turnId: 'im-1', vcMeetingImTurnOrigin: imOrigin }];
     expect(mergeQueuedCliInput(pending, {


### PR DESCRIPTION
## 改动
- Pi 首轮长 prompt 超过 4096 bytes 时不再回退到 TUI paste，而是写入 session 数据目录下的 UTF-8 prompt 文件，并以 `@/path/to/*.prompt.md` positional 参数启动 Pi。
- 保留短 prompt 直接作为 positional message 的行为；长 prompt 缺少 `SESSION_DATA_DIR` 时 fail closed，避免退回 paste 导致上下文刷屏。
- worker 在 `buildArgs()` 前执行 adapter 级首轮 prompt 预处理，并把 prompt 文件目录加入 Linux sandbox readonly roots；session 清理时 best-effort 删除生成文件。
- 在 botmux routing/system prompt 中补充隐藏运行上下文防线：静默读取 XML/配置块，不回复/确认/记录，只处理 `<user_message>`。
- 增加 focused 回归测试覆盖 Pi `@file` 投递、adapter args、no TUI queue fallback、短 prompt 行为和 routing 防御文案。

## 为什么
Pi TUI 在长多行首轮 prompt 通过 paste + Enter 投递时会把 botmux 启动上下文拆成多轮 user message，模型会把 `botmux_routing`、`identity`、builtin skills 等隐藏上下文碎片误判为真实请求并连续回复“已了解/已补充”。Pi 支持 `pi [options] [@files...] [messages...]`，因此长 prompt 用 `@file` 可以保持单个完整初始 user turn。

## 影响面
- 主要影响 Pi adapter 和 worker 首轮启动参数构造。
- 短 prompt 行为保持不变；其它 CLI 未接入新的 `prepareInitialPromptArg` hook，启动方式不变。
- Linux sandbox 下新增只读暴露 Pi prompt 文件目录，避免 `.botmux` 隐藏策略遮住 `@file`。
- prompt 防御同时影响 inline routing 和 injectsSessionContext CLIs 的 system prompt 文案，只增加“隐藏上下文静默遵守”约束。

## 验证
- `pnpm vitest run --project unit test/pi-initial-prompt.test.ts test/startup-commands.test.ts test/prompt-builder.test.ts`：69 passed
- `pnpm build`：通过
- 已执行 `pnpm switch:here && pnpm daemon:restart`，用当前 checkout 部署 live daemon 后在飞书 @Pi 做长 prompt 回归验证：Pi 返回唯一 marker `pi-long-prompt-single-turn-ok-20260723`，未出现“已了解/已补充”等隐藏上下文确认噪音。
- 检查 Pi session jsonl：`user_turn_count = 1`，首轮 user turn 约 38863 bytes，包含完整 prompt；没有单独以 `- botmux-*` / `<identity>` / `<routing_rules>` 开头的碎片 user turn。

## 备注
- 完整 `pnpm test` 在当前 macOS 环境仍有与本改动无关的既有/环境型失败（例如部分测试里 `rmSync` 对目录、git clone hardlink、端口竞争、v3 distillation 环境凭据隔离测试）。本 PR 相关 focused 回归和 build 均已通过。
- live daemon / 全局 shim 当前曾为验证切到本 checkout；合并/测试结束后需切回 canonical checkout。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
