### PR TITLE
fix(platform): 支持 BOTMUX_SKIP_HOST_AUTH_CHECK 跳过宿主凭证祖先链检查

### DIFF
--- a/src/platform/secure-host-file.ts
+++ b/src/platform/secure-host-file.ts
@@ -44,6 +44,20 @@ function assertOwnedByCurrentUser(stats: import('node:fs').Stats, label: string)
 }
 
 /**
+ * Escape hatch for trusted-but-awkward shared hosts (e.g. corporate devboxes)
+ * where some ancestor like `/data00` is owned by an unrelated service account
+ * and owner-writable (`0755`), yet the physical machine is trusted and the
+ * user cannot chmod that level. `BOTMUX_SKIP_HOST_AUTH_CHECK=1` skips ONLY the
+ * ancestor-chain replaceability walk below; the direct credential-dir/leaf
+ * checks (owner, exact 0600, no group/other write) still apply.
+ */
+function ancestorChainCheckDisabled(): boolean {
+  return process.env.BOTMUX_SKIP_HOST_AUTH_CHECK === '1';
+}
+
+let warnedAncestorChainSkipped = false;
+
+/**
  * A 0700 credential directory is still replaceable when one of its ancestors
  * is writable by another user. Walk the canonical chain so later path-based
  * open/rename operations cannot be redirected by renaming the whole directory.
@@ -54,6 +68,16 @@ function assertOwnedByCurrentUser(stats: import('node:fs').Stats, label: string)
  */
 function assertAncestorChainCannotReplace(canonicalParent: string): void {
   if (process.platform === 'win32' || !process.getuid) return;
+  if (ancestorChainCheckDisabled()) {
+    if (!warnedAncestorChainSkipped) {
+      warnedAncestorChainSkipped = true;
+      console.error(
+        '[secure-host-file] BOTMUX_SKIP_HOST_AUTH_CHECK=1 已跳过宿主凭证祖先链检查；'
+        + '仅在本机物理环境可信（如共享 devbox 上某级父目录归属服务账号）时使用。',
+      );
+    }
+    return;
+  }
   const uid = process.getuid();
   const trustedOwner = (owner: number) => owner === uid || owner === 0;
   let childPath = canonicalParent;
@@ -75,7 +99,11 @@ function assertAncestorChainCannotReplace(canonicalParent: string): void {
         && trustedOwner(ancestorStats.uid)
         && trustedOwner(childStats.uid);
       if (!stickyProtectsChild) {
-        throw new UnsafeHostAuthorityFileError('宿主凭证目录可被不可信祖先目录替换');
+        throw new UnsafeHostAuthorityFileError(
+          '宿主凭证目录可被不可信祖先目录替换'
+          + `（祖先 ${ancestorPath} 可被非本人账号写入）；`
+          + '若本机物理环境可信，可设 BOTMUX_SKIP_HOST_AUTH_CHECK=1 跳过祖先链检查',
+        );
       }
     }
 

--- a/test/secure-host-file.test.ts
+++ b/test/secure-host-file.test.ts
@@ -80,6 +80,29 @@ describe('secure host authority files', () => {
       .toThrow(/祖先目录替换/);
   });
 
+  it('BOTMUX_SKIP_HOST_AUTH_CHECK=1 bypasses only the ancestor-chain walk', () => {
+    if (process.platform === 'win32') return;
+    const root = tempRoot();
+    chmodSync(root, 0o777);
+    const dir = join(root, '.botmux');
+    mkdirSync(dir, { mode: 0o700 });
+    const file = join(dir, 'device.json');
+
+    const prev = process.env.BOTMUX_SKIP_HOST_AUTH_CHECK;
+    process.env.BOTMUX_SKIP_HOST_AUTH_CHECK = '1';
+    try {
+      writeSecureHostFileSync(file, 'secret');
+      expect(readSecureHostFileSync(file)).toBe('secret');
+      // The direct leaf/dir checks stay enforced even with the escape hatch on:
+      // a group/other-writable credential dir must still fail closed.
+      chmodSync(dir, 0o720);
+      expect(() => writeSecureHostFileSync(file, 'again')).toThrow(/其它用户写入|组内/);
+    } finally {
+      if (prev === undefined) delete process.env.BOTMUX_SKIP_HOST_AUTH_CHECK;
+      else process.env.BOTMUX_SKIP_HOST_AUTH_CHECK = prev;
+    }
+  });
+
   it('accepts an owned child under a sticky writable ancestor', () => {
     if (process.platform === 'win32') return;
     const root = tempRoot();


### PR DESCRIPTION
共享 devbox（如 BOE）上 ~/.botmux 的某级祖先目录常归属无关服务账号且 owner 可写（0755），会触发 secure-host-file 的祖先链可替换检查 UnsafeHostAuthorityFileError，导致 botmux bind / 读绑定 / device.json 全部报错，且用户无权 chmod 该级目录、删除重建 .botmux 也无效。

改动：
- assertAncestorChainCannotReplace 支持 BOTMUX_SKIP_HOST_AUTH_CHECK=1， 设置后仅跳过「祖先链可替换」这一条遍历，每进程打一次 stderr 警告； .botmux 本身的直接校验（owner 属主、严格 0600、无组/其他写、拒绝 符号链接）全部保留，不降级凭证文件安全性。
- 抛错信息补充具体罪魁祖先路径 + 逃生阀提示，该提示挂在 error.message 上，自动传播到三个出口：读绑定 [platform-binding] 拒绝读取、botmux bind 写崩溃栈、device.json 相关错误（binding.ts / device.ts 均透传 message）。

影响面：改的是 binding + device 两条凭证路径共用的底层原语，但默认（不设环境变量）行为与原来完全一致，仅新增显式 opt-out 分支；Windows 分支在函数首行即 return，不受影响。

验证：pnpm build 通过；vitest run test/secure-host-file.test.ts 6 passed （含新增用例：验证逃生阀开启后可写读，同时确认组/其他可写目录仍 fail-closed）。