### PR TITLE
fix(claude): 等待并行 SessionStart hook 完成

### DIFF
--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -625,10 +625,9 @@ export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, rawBin: 
       // settings.json（见下方 hookInstall.sessionStartCommand）。原因有二：
       //   1. wrapperCli=`aiden x claude` 会剥掉本 --settings（aiden 硬拒），进程级那份它拿
       //      不到；全局是它唯一能读到就绪 hook 的渠道。
-      //   2. 若进程级和全局**同时**注入 SessionStart，Claude 会等两条 hook 都退出才渲染输入框，
-      //      但 worker 在第一条 hook 发来的信号就放行首条 prompt → 首条 prompt 抢在输入框渲染前
-      //      落地 → 触发 Claude 的 paste-burst 启发式 → 多行里的软换行 `\` 被当字面量保留。
-      //      单一来源（全局）消除这个竞态，恢复原先单 hook 的时序。
+      //   2. 避免重复执行同一 botmux hook。项目级的其它 SessionStart hook 仍会按
+      //      Claude 语义并行执行；worker 把本 hook 当 selector 边界，并等待 hook 后
+      //      新 prompt 证据，所以慢项目 hook 不会让首条消息提前落地。
       // 全局即足够：Claude（含 cjadk / aiden 等启动器跑的真 claude）默认读 ~/.claude/settings.json，
       // 与 askUserQuestion hook 同源同渠道，比进程级更稳（还覆盖 adopt / 剥 --settings 的场景）。
       const inlineSettings: Record<string, unknown> = {};
@@ -922,9 +921,9 @@ export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, rawBin: 
 
     completionPattern: COMPLETION_RE,
     readyPattern: /❯/,
-    // Claude 家族在 spawn 时注入 SessionStart hook（见 buildArgs），回调
-    // `botmux session-ready` 给出「真就绪」信号。worker 据此武装 ready-gate：
-    // 收到信号前不投首条 prompt，绕开 cjadk 启动选择器吞首条消息的 bug。
+    // Claude 家族在 spawn 时注入 SessionStart hook，回调
+    // `botmux session-ready` 给出启动 selector 边界。worker 收到后清掉旧
+    // readyPattern 证据，并等待新 prompt 再投首条消息。
     injectsReadyHook: true,
     defaultPassthroughCommands: variant.id === 'claude-code' ? ['/goal'] : undefined,
     // Seed shares most of this adapter but has not been verified to expose the

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7928,10 +7928,9 @@ async function cmdHook(cliId: string): Promise<void> {
 
 // ─── botmux session-ready ─────────────────────────────────────────────────────
 //
-// Claude 家族（claude/seed）的 SessionStart hook 客户端。Claude 在 TUI 输入框
-// 真正渲染就绪时（startup / resume / clear / compact）触发本命令；它通知 daemon
-// 「CLI 真就绪」，放行 worker 端被 ready-gate 门控的首条 prompt——绕开 cjadk 之类
-// 自定义 launcher 启动选择器的 ❯ 误命中 readyPattern、把首条消息整条吞掉的 bug。
+// Claude 家族（claude/seed）的 SessionStart hook 客户端。它通知 daemon 已越过
+// 外层 startup selector；worker 随即清除 selector 留下的旧 ❯ 证据，再等待所有
+// 并行 hook 完成后新渲染的输入框，避免 cjadk 选择器误吞首条消息。
 //
 // 会话归属只靠 hook 子进程继承的 env（worker spawn 时设的 BOTMUX_SESSION_ID /
 // BOTMUX_LARK_APP_ID）。任何失败（env 缺失=adopt/非 botmux 会话、daemon 不可达）
@@ -9118,7 +9117,7 @@ switch (command) {
   }
   case 'session-ready': {
     // `botmux session-ready` — Claude 家族 SessionStart hook 客户端，通知 daemon
-    // 「CLI 真就绪」，放行被门控的首条 prompt。
+    // 已越过外层 selector；worker 再等待 hook 后的新 prompt 证据。
     await cmdSessionReady();
     break;
   }

--- a/src/core/session-ready-handshake.ts
+++ b/src/core/session-ready-handshake.ts
@@ -1,0 +1,46 @@
+type PendingAck = {
+  resolve: (acknowledged: boolean) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+const pendingAcks = new Map<string, PendingAck>();
+
+/**
+ * Register the daemon side of a SessionStart worker acknowledgement before the
+ * IPC message is sent. The timeout is deliberately fail-open: older or
+ * overloaded workers must not leave Claude's SessionStart hook stuck forever.
+ */
+export function waitForSessionReadyAck(requestId: string, timeoutMs: number): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    const previous = pendingAcks.get(requestId);
+    if (previous) {
+      clearTimeout(previous.timer);
+      previous.resolve(false);
+    }
+    const timer = setTimeout(() => {
+      pendingAcks.delete(requestId);
+      resolve(false);
+    }, timeoutMs);
+    pendingAcks.set(requestId, { resolve, timer });
+  });
+}
+
+/** Resolve a live acknowledgement. Unknown/duplicate ids are harmless. */
+export function acknowledgeSessionReady(requestId: string): boolean {
+  const pending = pendingAcks.get(requestId);
+  if (!pending) return false;
+  pendingAcks.delete(requestId);
+  clearTimeout(pending.timer);
+  pending.resolve(true);
+  return true;
+}
+
+/** Fail a waiter immediately when forwarding to the worker itself failed. */
+export function cancelSessionReadyAck(requestId: string): boolean {
+  const pending = pendingAcks.get(requestId);
+  if (!pending) return false;
+  pendingAcks.delete(requestId);
+  clearTimeout(pending.timer);
+  pending.resolve(false);
+  return true;
+}

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -94,6 +94,7 @@ import { isLocalCliOpenEnabled, isLocalCliOpenReady } from '../services/local-cl
 import { isSilentScheduledTurn } from './silent-schedule-turns.js';
 import { writeDeferredTopicBinding } from './deferred-topic-binding.js';
 import { deferWorkerSpawnDuringDeviceIsolation } from './device-isolation-activation.js';
+import { acknowledgeSessionReady } from './session-ready-handshake.js';
 
 type WindowsForkOptions = ForkOptions & { windowsHide?: boolean };
 
@@ -2359,6 +2360,14 @@ function setupWorkerHandlers(
   worker.on('message', async (msg: WorkerToDaemon) => {
     const effectiveCliId = sessionCliId(ds, botCfg);
     switch (msg.type) {
+      case 'session_ready_ack': {
+        if (ds.worker !== worker) {
+          logger.warn(`[${t}] Ignored session_ready_ack from stale worker generation`);
+          break;
+        }
+        acknowledgeSessionReady(msg.requestId);
+        break;
+      }
       case 'local_process_attestation': {
         // This message arrives over the private parent<->worker IPC channel;
         // unlike .botmux-cli-pids it cannot be forged or deleted by the CLI.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,5 +1,5 @@
 import { execFileSync, type ChildProcess } from 'node:child_process';
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { readFileSync, existsSync, mkdirSync, unlinkSync, watch, readdirSync } from 'node:fs';
 import { atomicWriteFileSync } from './utils/atomic-write.js';
 import { join, dirname } from 'node:path';
@@ -106,6 +106,10 @@ import {
 } from './core/worker-pool.js';
 import { ipcRoute, isTrustedHostIpcRequest, jsonRes, readJsonBody, setBotName, setLarkAppId, startIpcServer, setBotRenamer, setBotAvatarChanger } from './core/dashboard-ipc-server.js';
 import { setDeviceIsolationDaemonIdentity } from './core/device-isolation-daemon.js';
+import {
+  cancelSessionReadyAck,
+  waitForSessionReadyAck,
+} from './core/session-ready-handshake.js';
 import { loadOrCreateDashboardSecret } from './dashboard/auth.js';
 import { daemonIpcAuthHeaders, loadDaemonIpcSecret } from './core/daemon-ipc-auth.js';
 import {
@@ -4276,11 +4280,18 @@ ipcRoute('POST', '/api/session-ready', async (req, res) => {
     }
   }
   if (ds?.worker) {
+    const requestId = randomUUID();
+    const ack = waitForSessionReadyAck(requestId, 2_000);
     try {
-      ds.worker.send({ type: 'session_ready', source } as DaemonToWorker);
+      ds.worker.send({ type: 'session_ready', source, requestId } as DaemonToWorker);
       logger.info(`[${sessionId.slice(0, 8)}] session-ready signal forwarded to worker (source=${source ?? '?'})`);
     } catch (err) {
+      cancelSessionReadyAck(requestId);
       logger.warn(`session-ready forward failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    const acknowledged = await ack;
+    if (!acknowledged) {
+      logger.warn(`[${sessionId.slice(0, 8)}] session-ready worker ACK timed out; allowing hook to continue`);
     }
   }
   return jsonRes(res, 200, { ok: true });

--- a/src/types.ts
+++ b/src/types.ts
@@ -586,10 +586,11 @@ export type DaemonToWorker =
   | { type: 'set_locale'; locale: 'zh' | 'en' }
   | { type: 'term_action'; key: TermActionKey }
   | { type: 'refresh_screen' }
-  // Claude-family「真就绪」信号：CLI 的 SessionStart hook 经 `botmux session-ready`
-  // 调到 daemon，daemon 转发给本会话 worker，放行被 ready-gate 门控的首条 prompt
-  // （绕开 cjadk 启动选择器吞首条消息）。source = SessionStart 的 startup/resume/… 。
-  | { type: 'session_ready'; source?: string };
+  // Claude-family SessionStart 信号：CLI hook 经 `botmux session-ready` 调到
+  // daemon。requestId 让 daemon 等到 worker 已清掉启动选择器留下的旧 prompt
+  // 证据再回复 hook，避免 Claude 在 worker 重置前继续渲染真正输入框。
+  // source = SessionStart 的 startup/resume/… 。
+  | { type: 'session_ready'; source?: string; requestId?: string };
 
 /** Messages sent from Worker to Daemon */
 export type WorkerToDaemon =
@@ -606,6 +607,9 @@ export type WorkerToDaemon =
   | { type: 'cli_session_id'; cliSessionId: string; turnId?: string; dispatchAttempt?: number }
   | { type: 'claude_exit'; code: number | null; signal: string | null; logTail?: string; canParkDiagnostic?: boolean; turnId?: string; dispatchAttempt?: number }
   | { type: 'prompt_ready' }
+  /** Worker 已处理 SessionStart 信号并建立 post-hook prompt evidence fence。
+   *  daemon 收到后才结束 `botmux session-ready` HTTP 请求。 */
+  | { type: 'session_ready_ack'; requestId: string }
   | { type: 'screen_update'; content: string; status: ScreenStatus; usageLimit?: CliUsageLimitState; turnId?: string; dispatchAttempt?: number }
   | { type: 'error'; message: string; turnId?: string; dispatchAttempt?: number }
   | { type: 'bridge_source_session'; bridge: 'hermes'; sourceSessionId: string }

--- a/src/utils/idle-detector.ts
+++ b/src/utils/idle-detector.ts
@@ -1,5 +1,7 @@
 import type { CliAdapter } from '../adapters/cli/types.js';
 
+export type IdleEvidenceSource = 'screen' | 'external';
+
 /** Spinner frames — animate while CLI is working.
  *  Includes Claude Code symbols, Ink dots braille chars (Gemini),
  *  and OpenCode progress bar chars (■⬝). */
@@ -15,7 +17,7 @@ export class IdleDetector {
   private lastSpinnerAt = 0;
   private quiescenceTimer: ReturnType<typeof setTimeout> | null = null;
   private isIdle = false;
-  private idleCallback: (() => void) | null = null;
+  private idleCallback: ((source: IdleEvidenceSource) => void) | null = null;
   private completionPattern: RegExp | undefined;
   private readyPattern: RegExp | undefined;
   private readySeen = false;
@@ -25,7 +27,7 @@ export class IdleDetector {
     this.readyPattern = cli.readyPattern;
   }
 
-  onIdle(cb: () => void): void {
+  onIdle(cb: (source: IdleEvidenceSource) => void): void {
     this.idleCallback = cb;
   }
 
@@ -68,7 +70,7 @@ export class IdleDetector {
       this.clearTimer();
       this.quiescenceTimer = setTimeout(() => {
         this.quiescenceTimer = null;
-        if (!this.isIdle) this.markIdle();
+        if (!this.isIdle) this.markIdle('screen');
       }, 500);
       return;
     }
@@ -89,6 +91,20 @@ export class IdleDetector {
     this.clearTimer();
   }
 
+  /**
+   * Drop prompt evidence observed before a SessionStart boundary. Unlike the
+   * ordinary per-turn reset, this does not synthesize a recent spinner: once
+   * Claude finishes the remaining parallel hooks, its newly rendered prompt
+   * should need only the normal quiescence window.
+   */
+  resetReadyEvidence(): void {
+    this.isIdle = false;
+    this.outputTail = '';
+    this.readySeen = false;
+    this.lastSpinnerAt = 0;
+    this.clearTimer();
+  }
+
   /** External idle source — lets transcript-driven detectors (Claude jsonl
    *  Stop, Codex rollout assistant_final, CoCo events.jsonl finish_reason
    *  stop) push idle without waiting for screen-pattern + quiescence to
@@ -96,7 +112,7 @@ export class IdleDetector {
    *  for the next turn — same lifecycle as the internal markIdle path. */
   fireIdle(): void {
     if (this.isIdle) return;
-    this.markIdle();
+    this.markIdle('external');
   }
 
   dispose(): void {
@@ -115,14 +131,14 @@ export class IdleDetector {
       );
       return;
     }
-    this.markIdle();
+    this.markIdle('screen');
   }
 
-  private markIdle(): void {
+  private markIdle(source: IdleEvidenceSource): void {
     this.isIdle = true;
     this.outputTail = '';
     this.clearTimer();
-    this.idleCallback?.();
+    this.idleCallback?.(source);
   }
 
   private clearTimer(): void {

--- a/src/utils/input-gate.ts
+++ b/src/utils/input-gate.ts
@@ -33,6 +33,31 @@ export function shouldWriteNow(state: {
   return state.supportsTypeAhead && !state.awaitingFirstPrompt;
 }
 
+/**
+ * Claude runs every matching SessionStart hook in parallel and waits for all of
+ * them before it renders the real input prompt. Botmux's own hook can therefore
+ * finish while a slower project hook is still running. During the first prompt,
+ * treat the signal as an outer-selector boundary only and wait for fresh prompt
+ * evidence emitted after that boundary.
+ *
+ * Other ready-integrated CLIs (notably Hermes) emit their signal only once their
+ * prompt is usable, so their established authoritative-signal behavior stays
+ * unchanged.
+ */
+export function shouldWaitForPostSessionStartPromptEvidence(state: {
+  isClaudeFamily: boolean;
+  hasReadyPattern: boolean;
+  awaitingFirstPrompt: boolean;
+  isPromptReady: boolean;
+  alreadyWaiting: boolean;
+}): boolean {
+  return state.isClaudeFamily
+    && state.hasReadyPattern
+    && state.awaitingFirstPrompt
+    && !state.isPromptReady
+    && !state.alreadyWaiting;
+}
+
 export function shouldReleaseFirstPromptTimeout(state: {
   /** Adapter wants the soft timeout to wait for a real readyPattern. */
   deferFirstPromptTimeoutUntilReady: boolean;
@@ -49,13 +74,14 @@ export function shouldReleaseFirstPromptTimeout(state: {
 }
 
 /**
- * After the ready-gate releases (real SessionStart signal OR the timeout
+ * After the ready-gate releases (SessionStart/direct-ready signal OR the timeout
  * fallback), the worker settles for PTY quiescence and then decides whether to
  * mark the prompt ready (which flushes for ALL adapters) vs. just calling
  * flushPending() (which only flushes for type-ahead adapters). Marking ready is
  * correct when ANY of these hold:
- *   - promptReadyAfterSettle         — the real SessionStart/BOTMUX_READY_COMMAND
- *                                      signal fired (authoritative: input box exists).
+ *   - promptReadyAfterSettle         — an authoritative direct ready command
+ *                                      fired (Hermes). Claude passes false here
+ *                                      and waits for post-hook PTY evidence.
  *   - promptReadyDetectedDuringSettle — the idle detector fired during the
  *                                      settle (a readyPattern/idle proved readiness).
  *   - readyPatternSeenDuringHold      — a readyPattern fired WHILE the gate was

--- a/src/utils/ready-gate.ts
+++ b/src/utils/ready-gate.ts
@@ -1,6 +1,6 @@
 /**
  * Ready-gate state machine — holds the FIRST prompt for Claude-family CLIs until
- * a SessionStart hook fires a "真就绪" (true-ready) signal.
+ * a SessionStart hook proves the outer startup selector has been passed.
  *
  * Why this exists: a custom launcher (e.g. `cjadk claude`) shows an interactive
  * model/session selector at startup whose cursor is `❯` (U+276F). That glyph
@@ -10,11 +10,11 @@
  * trailing Enter mis-selects a menu item). The selector clears before Claude's
  * real input box renders, so the message is silently lost.
  *
- * Claude Code's `SessionStart` hook fires within ~3ms of the real input box
- * rendering, and crucially does NOT fire while the launcher is still on its
- * selector — so it's an unambiguous "the CLI is genuinely ready" signal. This
- * gate suspends the first flush until that signal (or a fallback timeout) so the
- * selector can never eat the first message.
+ * Claude Code's `SessionStart` hook crucially does NOT fire while the launcher
+ * is still on its selector. Claude can run multiple matching hooks in parallel,
+ * though, and renders the real prompt only after all finish. This gate therefore
+ * establishes the anti-selector boundary; the worker separately waits for fresh
+ * post-signal prompt evidence before it flushes Claude input.
  *
  * Lifecycle (recreated per CLI spawn in the worker):
  *   - `arm()`        — call at spawn when the adapter injects the SessionStart

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -45,7 +45,13 @@ import { readProcessStartIdentity } from './core/session-marker.js';
 import { drainTranscript, joinAssistantText, trailingAssistantText, findJsonlContainingFingerprint, findJsonlsContainingExactContent, findLatestJsonl, extractLastAssistantTurn, stringifyUserContent, extractTurnStartText, splitTranscriptEventsByCutoff, type TranscriptEvent } from './services/claude-transcript.js';
 import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint } from './services/bridge-turn-queue.js';
 import { shouldSuppressBridgeEmit, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
-import { decideHardTimeoutAction, decideSettleMarkReady, shouldReleaseFirstPromptTimeout, shouldWriteNow } from './utils/input-gate.js';
+import {
+  decideHardTimeoutAction,
+  decideSettleMarkReady,
+  shouldReleaseFirstPromptTimeout,
+  shouldWaitForPostSessionStartPromptEvidence,
+  shouldWriteNow,
+} from './utils/input-gate.js';
 import { canStartInjectionFlush, shouldDeferUserFlush, shouldFlushInjectionsFirst, type PendingInjection } from './core/inject-queue-policy.js';
 import { stripAnsiForLog, tailChars } from './utils/crash-log.js';
 import { CodexUpdateDialogGuard } from './utils/codex-update-dialog.js';
@@ -883,17 +889,16 @@ let bareShellLaunchBlocked = false;
  *  shell. Reset per spawn in spawnCli. */
 let bareShellChecked = false;
 /** Ready-gate (Claude-family): holds the first prompt until the SessionStart
- *  hook fires a true-ready signal, so a cjadk-style startup selector's ❯ (which
- *  falsely matches readyPattern) can't eat the first message. Recreated + armed
- *  per spawn in spawnCli; disarmed on signal or fallback timeout. */
+ *  hook proves a cjadk-style startup selector is behind us. Claude then needs
+ *  fresh post-hook prompt evidence because sibling hooks may still be running.
+ *  Recreated + armed per spawn; disarmed on signal or fallback timeout. */
 let readyGate = new ReadyGate();
 /** Fallback timer: if the SessionStart signal never arrives (hook injection
  *  failed / old CLI / launcher didn't pass --settings / adopt) release the gate
  *  and fall back to readyPattern + quiescence. */
 let readySignalTimer: ReturnType<typeof setTimeout> | null = null;
 /** How long the ready-gate waits for the SessionStart signal before falling
- *  back. The real signal lands within ~ms of the input box rendering, so this is
- *  pure insurance against a missing/failed hook — generous but bounded. */
+ *  back. This is insurance against a missing/failed hook — generous but bounded. */
 const READY_SIGNAL_TIMEOUT_MS = 45_000;
 /** Soft fallback for CLIs that never emit an idle/ready signal during startup.
  *  Legacy adapters release queued first input here. Adapters that opt into
@@ -906,13 +911,13 @@ const FIRST_PROMPT_HARD_TIMEOUT_MS = 90_000;
 /** Epoch ms of the most recent PTY output — used to settle for quiescence
  *  before the first flush (see settleThenFlush). */
 let lastPtyOutputAtMs = 0;
-/** After the SessionStart signal fires, the input box has appeared but Ink's
- *  startup render isn't fully drained yet — typing immediately trips Claude's
+/** After the SessionStart signal fires, Ink's startup rendering or sibling
+ *  hooks may still be active — typing immediately can trip Claude's
  *  paste-burst heuristic and the `\` soft-newline markers (claude-code
  *  writeInput) get kept literally. This is pronounced under wrapperCli launchers
  *  (e.g. `aiden x claude`) whose Claude renders more at startup. So we wait for
- *  the PTY to fall quiet for SETTLE_MS before the first flush — the signal still
- *  gates readiness (anti-selector), the settle just lets the render drain. */
+ *  PTY quiescence, while Claude additionally requires fresh prompt evidence
+ *  after the SessionStart boundary. */
 const READY_FLUSH_SETTLE_MS = 1_000;
 /** Upper bound on the settle so a chatty startup (spinners, periodic redraw)
  *  can't stall the first prompt indefinitely. */
@@ -935,12 +940,19 @@ let promptReadyDetectedDuringSettle = false;
  *  spawn that renders ❯ but never fires BOTMUX_READY_COMMAND waits the full
  *  hard timeout (and previously never delivered at all). */
 let readyPatternSeenDuringHold = false;
+/** Claude's SessionStart hooks run in parallel. Its botmux hook proves the
+ * startup selector is behind us, but sibling project hooks may still be
+ * running. Hold type-ahead until a fresh PTY prompt is observed after the
+ * SessionStart signal. */
+let awaitingPostSessionStartPromptEvidence = false;
+/** Scoped marker set only by IdleDetector's screen-driven callback. */
+let postSessionStartPromptEvidenceInFlight = false;
 
 /** Wait until the PTY has been quiet for READY_FLUSH_SETTLE_MS (Ink render
  *  drained), capped at READY_FLUSH_SETTLE_CAP_MS, then flush the held prompt.
- *  A real SessionStart/BOTMUX_READY_COMMAND signal is itself authoritative
- *  prompt readiness; the timeout fallback only opens the gate and lets the
- *  regular readyPattern/idle path prove readiness later. */
+ *  An authoritative direct ready command (Hermes) can mark prompt readiness;
+ *  Claude's SessionStart only opens the anti-selector boundary and its regular
+ *  readyPattern/idle path must prove readiness afterward. */
 function settleThenFlush(startedAtMs: number, promptReadyAfterSettle: boolean): void {
   readyFlushSettleTimer = null;
   const now = Date.now();
@@ -4528,6 +4540,15 @@ function releaseRawInputRestartGate(): void {
   log('Replacement CLI prompt ready — releasing deferred passthrough commands');
 }
 
+function markPromptReadyFromPty(): void {
+  postSessionStartPromptEvidenceInFlight = true;
+  try {
+    markPromptReady();
+  } finally {
+    postSessionStartPromptEvidenceInFlight = false;
+  }
+}
+
 function markPromptReady(): void {
   if (isPromptReady) return;  // guard against duplicate calls
   stopBusyPatternIdleProbe();
@@ -4545,6 +4566,14 @@ function markPromptReady(): void {
     readyPatternSeenDuringHold = true;
     log('Idle detected but holding for SessionStart ready signal (startup selector guard)');
     return;
+  }
+  if (awaitingPostSessionStartPromptEvidence) {
+    if (!postSessionStartPromptEvidenceInFlight) {
+      log('Ignoring non-PTY ready source while waiting for post-SessionStart prompt evidence');
+      return;
+    }
+    awaitingPostSessionStartPromptEvidence = false;
+    log('Fresh prompt evidence observed after SessionStart hooks');
   }
   if (isSettlingFirstFlush) {
     promptReadyDetectedDuringSettle = true;
@@ -4575,6 +4604,7 @@ function markPromptReady(): void {
   maybeEmitWorkflowTranscriptOutput();
   if (awaitingFirstPrompt) {
     awaitingFirstPrompt = false;
+    awaitingPostSessionStartPromptEvidence = false;
     renderer?.markNewTurn();  // exclude history replay from streaming card
   }
   send({ type: 'prompt_ready' });
@@ -4909,6 +4939,10 @@ async function flushPending(): Promise<void> {
   // after Ink's startup render has drained (else paste-burst keeps `\` literal).
   if (isSettlingFirstFlush) {
     log(`Holding ${pendingMessages.length} pending message(s) until ready-gate settle completes`);
+    return;
+  }
+  if (awaitingPostSessionStartPromptEvidence) {
+    log(`Holding ${pendingMessages.length} pending message(s) until post-SessionStart prompt evidence`);
     return;
   }
   // Type-ahead adapters flush even while the CLI is busy; others wait for
@@ -7334,6 +7368,7 @@ async function spawnCli(
   isSettlingFirstFlush = false;
   promptReadyDetectedDuringSettle = false;
   readyPatternSeenDuringHold = false;
+  awaitingPostSessionStartPromptEvidence = false;
   // Reset quiescence baseline so the settle measures silence from THIS spawn.
   lastPtyOutputAtMs = Date.now();
   const readyHookAvailable = effectiveReadyHookInstall
@@ -7384,7 +7419,7 @@ async function spawnCli(
   // quiescence, repeatedly triggering markPromptReady() and duplicate cards.
   if (effectiveBackendType !== 'riff') {
     idleDetector = new IdleDetector(cliAdapter);
-    idleDetector.onIdle(async () => {
+    idleDetector.onIdle(async (evidenceSource) => {
       log('Prompt detected (idle)');
       // Bridge drain MUST run before markPromptReady() — the latter calls
       // flushPending() which can immediately fire the next queued message
@@ -7396,7 +7431,11 @@ async function spawnCli(
       if (codexBridgeFallbackActive()) {
         try { codexBridgeDrainAndMaybeEmit(); } catch (err: any) { log(`Codex bridge emit error: ${err.message}`); }
       }
-      markPromptReady();
+      if (evidenceSource === 'screen') {
+        markPromptReadyFromPty();
+      } else {
+        markPromptReady();
+      }
     });
   }
 
@@ -7546,6 +7585,7 @@ async function spawnCli(
     }
 
     awaitingFirstPrompt = false;
+    awaitingPostSessionStartPromptEvidence = false;
     renderer?.markNewTurn();
     log(forced
       ? `WARN First prompt hard timeout — ${cliName()} readyPattern did not arrive; forcing queued message flush`
@@ -7603,6 +7643,7 @@ function killCli(opts: { preservePending?: boolean } = {}): void {
   isSettlingFirstFlush = false;
   promptReadyDetectedDuringSettle = false;
   readyPatternSeenDuringHold = false;
+  awaitingPostSessionStartPromptEvidence = false;
   stopScreenAnalyzer();
   stopScreenUpdates();
   backend?.kill();
@@ -9418,23 +9459,42 @@ process.on('message', async (raw: unknown) => {
     }
 
     case 'session_ready': {
-      // Claude-family SessionStart hook fired (via `botmux session-ready` →
-      // daemon). The CLI's input box is genuinely rendered — release the
-      // ready-gate and deliver any held first prompt. Idempotent: a later
-      // duplicate (clear/compact source) is a no-op.
+      // Claude-family SessionStart hooks run in parallel. This signal proves
+      // the startup selector is behind us, but a slower project hook can still
+      // be running and Claude does not render its real prompt until ALL hooks
+      // finish. Clear selector-era evidence and require a fresh PTY prompt after
+      // the signal. Hermes keeps its authoritative ready-command behavior.
       log(`SessionStart ready signal received (source=${msg.source ?? '?'})`);
+      const waitForPostHookPrompt = shouldWaitForPostSessionStartPromptEvidence({
+        isClaudeFamily: !!cliAdapter?.claudeDataDir,
+        hasReadyPattern: !!cliAdapter?.readyPattern,
+        awaitingFirstPrompt,
+        isPromptReady,
+        alreadyWaiting: awaitingPostSessionStartPromptEvidence,
+      });
+      if (waitForPostHookPrompt) {
+        awaitingPostSessionStartPromptEvidence = true;
+        promptReadyDetectedDuringSettle = false;
+        readyPatternSeenDuringHold = false;
+        idleDetector?.resetReadyEvidence();
+        lastPtyOutputAtMs = Date.now();
+        log('SessionStart boundary recorded — waiting for fresh post-hook prompt evidence');
+      }
       // 先记下 gate 是否已被 45s fallback 释放：ReadyGate.receive() 是一次性
       // 语义，fallback 抢先后 releaseReadyGate 会整块跳过迟到的真信号。
       const lateAfterFallback = readyGate.isArmed && readyGate.isReceived;
-      releaseReadyGate('SessionStart hook', { promptReadyAfterSettle: true });
+      releaseReadyGate('SessionStart hook', { promptReadyAfterSettle: !waitForPostHookPrompt });
       // 冷启动超过 READY_SIGNAL_TIMEOUT_MS 的 CLI（Hermes 常态是 2-3 分钟）恰好
       // 总落在 fallback 之后：fallback 只开闸不投递（非 type-ahead 的
       // flushPending 是 no-op），真信号依然是权威就绪，这里直接兑现。仅限首轮
       // （awaitingFirstPrompt）——首条 prompt 交付后 clear/compact 来源的
       // SessionStart 保持原有 no-op 语义，绝不在会话中途误标就绪。
-      if (lateAfterFallback && awaitingFirstPrompt && !isPromptReady) {
+      if (lateAfterFallback && awaitingFirstPrompt && !isPromptReady && !waitForPostHookPrompt) {
         log('Late ready signal after timeout fallback — marking prompt ready now');
         markPromptReady();
+      }
+      if (msg.requestId) {
+        send({ type: 'session_ready_ack', requestId: msg.requestId });
       }
       break;
     }

--- a/test/idle-detector.test.ts
+++ b/test/idle-detector.test.ts
@@ -430,6 +430,50 @@ describe('IdleDetector: reset()', () => {
   });
 });
 
+describe('IdleDetector: resetReadyEvidence()', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('drops a selector-era prompt and waits for a newly rendered prompt', () => {
+    const detector = new IdleDetector(makeCli({ readyPattern: /❯/ }));
+    const cb = vi.fn();
+    detector.onIdle(cb);
+
+    detector.feed('startup selector ❯');
+    vi.advanceTimersByTime(1_000);
+    detector.resetReadyEvidence();
+
+    // The old quiescence timer and readySeen flag were both discarded.
+    vi.advanceTimersByTime(10_000);
+    expect(cb).not.toHaveBeenCalled();
+
+    detector.feed('real Claude prompt ❯');
+    vi.advanceTimersByTime(1_999);
+    expect(cb).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(cb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('distinguishes screen evidence from an external idle source', () => {
+    const screenDetector = new IdleDetector(makeCli({ readyPattern: /❯/ }));
+    const screenCb = vi.fn();
+    screenDetector.onIdle(screenCb);
+    screenDetector.feed('real prompt ❯');
+    vi.advanceTimersByTime(2_000);
+    expect(screenCb).toHaveBeenCalledWith('screen');
+
+    const externalDetector = new IdleDetector(makeCli());
+    const externalCb = vi.fn();
+    externalDetector.onIdle(externalCb);
+    externalDetector.fireIdle();
+    expect(externalCb).toHaveBeenCalledWith('external');
+
+    screenDetector.dispose();
+    externalDetector.dispose();
+  });
+});
+
 // ─── dispose() ────────────────────────────────────────────────────────────
 
 describe('IdleDetector: dispose()', () => {

--- a/test/input-gate.test.ts
+++ b/test/input-gate.test.ts
@@ -13,7 +13,13 @@
  * Run: pnpm vitest run test/input-gate.test.ts
  */
 import { describe, it, expect } from 'vitest';
-import { decideHardTimeoutAction, decideSettleMarkReady, shouldReleaseFirstPromptTimeout, shouldWriteNow } from '../src/utils/input-gate.js';
+import {
+  decideHardTimeoutAction,
+  decideSettleMarkReady,
+  shouldReleaseFirstPromptTimeout,
+  shouldWaitForPostSessionStartPromptEvidence,
+  shouldWriteNow,
+} from '../src/utils/input-gate.js';
 
 const base = {
   isPromptReady: false,
@@ -84,8 +90,51 @@ describe('shouldReleaseFirstPromptTimeout', () => {
   });
 });
 
+describe('shouldWaitForPostSessionStartPromptEvidence', () => {
+  const sessionStartBase = {
+    isClaudeFamily: true,
+    hasReadyPattern: true,
+    awaitingFirstPrompt: true,
+    isPromptReady: false,
+    alreadyWaiting: false,
+  };
+
+  it('requires fresh prompt evidence for a Claude-family first prompt', () => {
+    expect(shouldWaitForPostSessionStartPromptEvidence(sessionStartBase)).toBe(true);
+  });
+
+  it('keeps Hermes and other non-Claude ready signals authoritative', () => {
+    expect(shouldWaitForPostSessionStartPromptEvidence({
+      ...sessionStartBase,
+      isClaudeFamily: false,
+    })).toBe(false);
+  });
+
+  it('does not create an unprovable fence without a readyPattern', () => {
+    expect(shouldWaitForPostSessionStartPromptEvidence({
+      ...sessionStartBase,
+      hasReadyPattern: false,
+    })).toBe(false);
+  });
+
+  it('ignores duplicate and mid-session SessionStart signals', () => {
+    expect(shouldWaitForPostSessionStartPromptEvidence({
+      ...sessionStartBase,
+      alreadyWaiting: true,
+    })).toBe(false);
+    expect(shouldWaitForPostSessionStartPromptEvidence({
+      ...sessionStartBase,
+      awaitingFirstPrompt: false,
+    })).toBe(false);
+    expect(shouldWaitForPostSessionStartPromptEvidence({
+      ...sessionStartBase,
+      isPromptReady: true,
+    })).toBe(false);
+  });
+});
+
 describe('decideSettleMarkReady', () => {
-  it('marks ready when the real SessionStart signal fired (promptReadyAfterSettle)', () => {
+  it('marks ready when an authoritative direct ready signal fired', () => {
     expect(decideSettleMarkReady({
       promptReadyAfterSettle: true,
       promptReadyDetectedDuringSettle: false,

--- a/test/session-ready-handshake.test.ts
+++ b/test/session-ready-handshake.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  acknowledgeSessionReady,
+  cancelSessionReadyAck,
+  waitForSessionReadyAck,
+} from '../src/core/session-ready-handshake.js';
+
+describe('SessionStart worker acknowledgement', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('resolves true when the worker acknowledges the request', async () => {
+    const pending = waitForSessionReadyAck('request-1', 2_000);
+    expect(acknowledgeSessionReady('request-1')).toBe(true);
+    await expect(pending).resolves.toBe(true);
+    expect(acknowledgeSessionReady('request-1')).toBe(false);
+  });
+
+  it('fails open after a bounded timeout', async () => {
+    const pending = waitForSessionReadyAck('request-2', 2_000);
+    vi.advanceTimersByTime(2_000);
+    await expect(pending).resolves.toBe(false);
+    expect(acknowledgeSessionReady('request-2')).toBe(false);
+  });
+
+  it('can be cancelled immediately when IPC forwarding fails', async () => {
+    const pending = waitForSessionReadyAck('request-3', 2_000);
+    expect(cancelSessionReadyAck('request-3')).toBe(true);
+    await expect(pending).resolves.toBe(false);
+    expect(cancelSessionReadyAck('request-3')).toBe(false);
+  });
+});

--- a/test/worker-pipe-initial-screen-order.test.ts
+++ b/test/worker-pipe-initial-screen-order.test.ts
@@ -70,23 +70,47 @@ describe('worker pipe initial screen ordering', () => {
     expect(hardTimerIdx).toBeGreaterThan(fallbackStart);
   });
 
-  it('treats an explicit session-ready signal as prompt-ready after settle', () => {
+  it('treats Claude SessionStart as a boundary and waits for fresh prompt evidence', () => {
     const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
     const settleStart = source.indexOf('function settleThenFlush');
     const markIdx = source.indexOf('markPromptReady();', settleStart);
     const flushIdx = source.indexOf('void flushPending();', settleStart);
     const sessionReadyCase = source.indexOf("case 'session_ready'");
+    const waitDecisionIdx = source.indexOf(
+      'const waitForPostHookPrompt = shouldWaitForPostSessionStartPromptEvidence({',
+      sessionReadyCase,
+    );
+    const resetEvidenceIdx = source.indexOf('idleDetector?.resetReadyEvidence();', waitDecisionIdx);
+    const ptyReadyIdx = source.indexOf('markPromptReadyFromPty();');
+    const screenEvidenceGuardIdx = source.indexOf("if (evidenceSource === 'screen')");
     const signalReleaseIdx = source.indexOf(
-      "releaseReadyGate('SessionStart hook', { promptReadyAfterSettle: true });",
+      "releaseReadyGate('SessionStart hook', { promptReadyAfterSettle: !waitForPostHookPrompt });",
       sessionReadyCase,
     );
     const timeoutReleaseIdx = source.indexOf("releaseReadyGate('signal timeout fallback');");
+    const flushStart = source.indexOf('async function flushPending');
+    const postHookFlushGuardIdx = source.indexOf(
+      'if (awaitingPostSessionStartPromptEvidence)',
+      flushStart,
+    );
+    const ackIdx = source.indexOf(
+      "send({ type: 'session_ready_ack', requestId: msg.requestId });",
+      sessionReadyCase,
+    );
 
     expect(settleStart).toBeGreaterThan(-1);
     expect(markIdx).toBeGreaterThan(settleStart);
     expect(flushIdx).toBeGreaterThan(markIdx);
     expect(sessionReadyCase).toBeGreaterThan(-1);
+    expect(waitDecisionIdx).toBeGreaterThan(sessionReadyCase);
+    expect(resetEvidenceIdx).toBeGreaterThan(waitDecisionIdx);
+    expect(ptyReadyIdx).toBeGreaterThan(-1);
+    expect(screenEvidenceGuardIdx).toBeGreaterThan(-1);
+    expect(ptyReadyIdx).toBeGreaterThan(screenEvidenceGuardIdx);
     expect(signalReleaseIdx).toBeGreaterThan(sessionReadyCase);
+    expect(postHookFlushGuardIdx).toBeGreaterThan(flushStart);
+    expect(postHookFlushGuardIdx).toBeLessThan(source.indexOf('isFlushing = true;', flushStart));
+    expect(ackIdx).toBeGreaterThan(signalReleaseIdx);
     // Timeout fallback must stay conservative: it opens the gate but does not
     // force prompt-ready for a CLI whose true ready signal never arrived.
     expect(timeoutReleaseIdx).toBeGreaterThan(-1);
@@ -153,15 +177,16 @@ describe('worker pipe initial screen ordering', () => {
     // ReadyGate.receive() is one-shot: once the 45s fallback fires, a later
     // releaseReadyGate from the real signal is skipped entirely. A CLI whose
     // cold start exceeds READY_SIGNAL_TIMEOUT_MS (Hermes: 2-3 min) would then
-    // never take the authoritative markPromptReady path. The session_ready
-    // case must detect the late arrival (gate armed + already received) and
-    // mark prompt-ready directly — but only during the first-prompt phase
-    // (awaitingFirstPrompt), so clear/compact SessionStart fires mid-session
-    // stay no-ops.
+    // never take the authoritative markPromptReady path. The session_ready case
+    // must detect the late arrival (gate armed + already received) and mark
+    // prompt-ready directly for authoritative non-Claude signals. Claude waits
+    // for post-hook prompt evidence instead. Both paths are limited to the
+    // first-prompt phase, so clear/compact SessionStart stays a no-op.
     const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
     const sessionReadyCase = source.indexOf("case 'session_ready'");
     const lateCheckIdx = source.indexOf('readyGate.isArmed && readyGate.isReceived', sessionReadyCase);
     const lateGuardIdx = source.indexOf('awaitingFirstPrompt && !isPromptReady', sessionReadyCase);
+    const claudeGuardIdx = source.indexOf('&& !waitForPostHookPrompt', lateGuardIdx);
     const lateMarkIdx = source.indexOf('markPromptReady();', lateGuardIdx);
     const caseEnd = source.indexOf('case ', sessionReadyCase + 1);
 
@@ -169,6 +194,8 @@ describe('worker pipe initial screen ordering', () => {
     expect(lateCheckIdx).toBeGreaterThan(sessionReadyCase);
     expect(lateCheckIdx).toBeLessThan(caseEnd);
     expect(lateGuardIdx).toBeGreaterThan(lateCheckIdx);
+    expect(claudeGuardIdx).toBeGreaterThan(lateGuardIdx);
+    expect(claudeGuardIdx).toBeLessThan(lateMarkIdx);
     expect(lateMarkIdx).toBeGreaterThan(lateGuardIdx);
     expect(lateMarkIdx).toBeLessThan(caseEnd);
   });


### PR DESCRIPTION
## 背景

这是 PR #515 合入后的时序加固。

最初怀疑项目级 `.claude/settings.json` 会覆盖 `CLAUDE_CONFIG_DIR` 中的 SessionStart hook。根据 Claude 官方语义和 Claude Code 2.1.218 实测，用户级与项目级 hooks 会合并、并行执行；两边的 marker 都能落盘，因此“项目 settings 存在就忽略 botmux hook”并不成立。

真正的问题是：Claude 会并行启动所有匹配的 SessionStart hooks，并在它们全部结束后才继续初始化。botmux 自己的 hook 若先结束，旧逻辑会把该信号直接视为输入框已可用；此时较慢的项目 hook 仍在运行，首条消息可能提前写入。

实测时序（一个快速用户级 hook + 一个 `sleep 3` 的项目级 hook）：

- botmux/用户级 hook：约 1.56s 完成
- 项目级 hook：约 4.56s 完成
- Claude `--init-only`：约 5.11s 返回

## 修改

- 将 Claude SessionStart 信号改为“两阶段”语义：
  1. 信号只证明已经越过外层 startup selector；
  2. 清除 selector 阶段留下的旧 `❯`/idle 证据，等待信号之后新出现的 screen prompt evidence，才放行首条消息。
- daemon → worker 增加有界 ACK 握手：daemon 在 worker 已建立上述 fence 后才回复 `botmux session-ready` HTTP 请求，避免 Claude 在 worker 重置证据前继续渲染真正输入框。
- ACK 最长等待 2 秒并 fail-open，旧 worker 或瞬时过载不会永久卡住 Claude hook。
- 区分 screen idle 与 transcript/external idle；只有新 screen evidence 能解除 Claude 的 post-SessionStart fence。
- 保留 90 秒 first-prompt hard fallback，避免 readyPattern 变化造成永久等待。
- Hermes 等非 Claude ready-integrated CLI 仍把自身 direct ready command 视为权威信号，行为不变。

## 影响面

- CLI：仅 Claude family（`claudeDataDir` 标记，包括 Claude Code/同族变体）启用 post-hook prompt fence；其他 CLI 不启用。
- 后端/会话：只影响 fresh ready-gated spawn。adopt 和 persistent reattach 仍不 arm gate；PTY/tmux 等共享同一 worker 状态机。
- 平台：daemon/worker IPC 与 IdleDetector 均为跨平台逻辑；不新增 Linux/macOS 专属路径。
- sandbox/read-isolation：沿用 PR #515 的 capability preflight 和鉴权；本 PR 不改变 capability 授权语义。

## 验证

- `pnpm vitest run test/idle-detector.test.ts test/input-gate.test.ts test/session-ready-handshake.test.ts test/worker-pipe-initial-screen-order.test.ts test/session-rename-worker.test.ts test/worker-durable-expiry-order.test.ts test/ready-gate.test.ts test/session-ready-cli.test.ts test/claude-settings-hook.test.ts`
  - 9 files / 112 tests 全部通过
- `pnpm build`
  - 通过（domain audit、tsc、dashboard bundle、dist audit 均通过）
- `pnpm test`
  - 638 files / 9,985 tests 通过
  - 仅 3 个 scheduler 本地时区测试失败；在独立的未修改 `origin/master` worktree 上复现完全相同的 3 个失败，确认是现有基线，与本 PR 无关
- `pnpm daemon:restart`
  - 46 个 daemon/dashboard 进程均恢复 online
