### PR TITLE
fix(worker): 防止 CoCo 启动竞争导致会话失声

### DIFF
--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -98,6 +98,34 @@ export function isBareShellComm(comm: string | undefined): boolean {
   return BARE_SHELL_COMMS.has(comm.startsWith('.') ? comm.slice(1) : comm);
 }
 
+/**
+ * Let a managed launch wrapper finish its final `exec <cli>` before deciding
+ * that the pane is stuck at an interactive shell.
+ *
+ * A tmux pane can legitimately report the wrapper shell for a few milliseconds
+ * after spawn. Treating that single sample as terminal permanently blocks the
+ * session even though the CLI starts immediately afterward. Non-shell samples
+ * return without delay; only a shell-shaped sample consumes the bounded grace
+ * period.
+ */
+export async function settleLaunchComm(
+  read: () => string | undefined,
+  opts: { timeoutMs?: number; pollMs?: number } = {},
+): Promise<string | undefined> {
+  let comm = read();
+  if (!isBareShellComm(comm)) return comm;
+
+  const timeoutMs = Math.max(0, opts.timeoutMs ?? 2_000);
+  const pollMs = Math.max(1, opts.pollMs ?? 100);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await new Promise<void>((resolve) => setTimeout(resolve, pollMs));
+    comm = read();
+    if (!isBareShellComm(comm)) return comm;
+  }
+  return comm;
+}
+
 /** Classify a confirmed bare-shell launch for diagnostics: 'trampoline' when the
  *  observed leaf shell differs from the shell botmux launched with — the
  *  signature of an rcfile that `exec`-trampolines into another shell (e.g.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7435,7 +7435,10 @@ async function restartCliProcess(
         // intentionally held by the restart gate above. Release its raw-input
         // fence now; other backends keep it until their later markPromptReady().
         if (effectiveBackendType === 'riff' && isPromptReady) releaseRawInputRestartGate();
-        void flushPending();
+        // A local replacement process can exist before its TUI input box does.
+        // Only re-kick a prompt that became ready while the restart fence was
+        // still armed; otherwise markPromptReady() owns the first flush.
+        if (isPromptReady) void flushPending();
       }, 500);
     } catch (err) {
       cliRestartInProgress = false;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -149,7 +149,14 @@ import {
 import { createCliAdapterSync, locateOnPath } from './adapters/cli/registry.js';
 import { buildWrappedLaunch, parseWrapperCli, isTtadkWrapper } from './setup/cli-selection.js';
 import { cliUnavailableMessage } from './setup/cli-availability.js';
-import { findLaunchedCliPid, scheduleWrapperRealCliPid, readComm, isBareShellComm, bareShellLaunchKind } from './core/session-discovery.js';
+import {
+  findLaunchedCliPid,
+  scheduleWrapperRealCliPid,
+  readComm,
+  isBareShellComm,
+  bareShellLaunchKind,
+  settleLaunchComm,
+} from './core/session-discovery.js';
 import { codexRpcEligible, paneRunsRemoteTui, orchestrateCodexRpcInit, rolloutUserTurnMatches, decideStartupDialogAction, shouldQueueInitialPrompt, shouldPreMarkFirstTurn, killAndVerifyPersistentPane, type EngageOutcome } from './codex-rpc-lifecycle.js';
 import { delay } from './utils/timing.js';
 import { claudeJsonlPathForSession, resolveJsonlFromPid, findOpenClaudeSessionIds, syncClaudeResumeTargetToCwd, DEFAULT_CLAUDE_DATA_DIR } from './adapters/cli/claude-code.js';
@@ -4077,7 +4084,7 @@ async function flushPendingInjections(): Promise<void> {
       // path sends first runs the detection.
       if (!bareShellChecked) {
         bareShellChecked = true;
-        if (detectBareShellLaunch()) return;  // finally{} releases the mutex; queue stays
+        if (await detectBareShellLaunch()) return;  // finally{} releases the mutex; queue stays
       }
       const item = pendingInjections.shift()!;
       const cmd = item.command;
@@ -4777,15 +4784,17 @@ function scheduleSubmitFailureNotify(
  * and the pty/herdr backends (which `exec` the CLI directly — getChildPid is the
  * CLI itself, never a shell).
  *
- * Returns true when a bare-shell launch was detected (caller must NOT flush).
+ * Returns true when a persistent bare-shell launch was detected (caller must
+ * NOT flush). A transient wrapper shell gets a bounded chance to exec the CLI.
  */
-function detectBareShellLaunch(): boolean {
+async function detectBareShellLaunch(): Promise<boolean> {
   if (bareShellLaunchBlocked) return true;
   if (lastInitConfig?.adoptMode) return false;       // observing an existing pane, not launching
   if (lastInitConfig?.wrapperCli) return false;      // launcher legitimately wraps the CLI (transient shell shim)
-  const pid = backend?.getChildPid?.();
-  if (!pid) return false;
-  const comm = readComm(pid);
+  const comm = await settleLaunchComm(() => {
+    const pid = backend?.getChildPid?.();
+    return pid ? readComm(pid) : undefined;
+  });
   if (!isBareShellComm(comm)) return false;          // CLI (rust/go/node) is running — healthy launch
 
   // Bare shell is the pane leaf → the CLI never launched. Tier the message on
@@ -4932,7 +4941,7 @@ async function flushPending(): Promise<void> {
     // doesn't get them typed into the bare shell first.
     if (!bareShellChecked) {
       bareShellChecked = true;
-      if (detectBareShellLaunch()) {
+      if (await detectBareShellLaunch()) {
         return;  // finally{} releases the mutex; pendingMessages stay queued, untouched
       }
     }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -922,6 +922,17 @@ let bareShellLaunchBlocked = false;
  *  one-shot so it also covers a reattach onto a pane that degraded to a bare
  *  shell. Reset per spawn in spawnCli. */
 let bareShellChecked = false;
+/** True only while detectBareShellLaunch() is inside its async launch-settle
+ *  window (settleLaunchComm's bounded ≤2s poll for a wrapper's final `exec
+ *  <cli>`). The message/injection flush paths already hold the isFlushing /
+ *  injectionFlushing mutexes across that await, but raw_input (passthrough
+ *  slash commands: /compact, /model, /btw) deliberately bypasses those to
+ *  preserve busy-delivery — so it would otherwise type into a pane whose leaf
+ *  is still the transient shell (or a shell already about to be blocked). This
+ *  latch lets raw_input defer for exactly that window without borrowing the
+ *  general isFlushing mutex (which would wrongly also block busy-delivery when
+ *  no settle is in progress). Reset per spawn in spawnCli. */
+let bareShellCheckInProgress = false;
 /** Ready-gate (Claude-family): holds the first prompt until the SessionStart
  *  hook proves a cjadk-style startup selector is behind us. Claude then needs
  *  fresh post-hook prompt evidence because sibling hooks may still be running.
@@ -4891,10 +4902,20 @@ async function detectBareShellLaunch(): Promise<boolean> {
   if (bareShellLaunchBlocked) return true;
   if (lastInitConfig?.adoptMode) return false;       // observing an existing pane, not launching
   if (lastInitConfig?.wrapperCli) return false;      // launcher legitimately wraps the CLI (transient shell shim)
-  const comm = await settleLaunchComm(() => {
-    const pid = backend?.getChildPid?.();
-    return pid ? readComm(pid) : undefined;
-  });
+  // Hold the raw_input passthrough latch across the bounded settle poll: the
+  // await below yields the event loop for up to 2s, and a concurrent raw_input
+  // IPC handler (which bypasses isFlushing to preserve busy-delivery) must not
+  // type into the pane while its leaf is still the unsettled shell.
+  bareShellCheckInProgress = true;
+  let comm: string | undefined;
+  try {
+    comm = await settleLaunchComm(() => {
+      const pid = backend?.getChildPid?.();
+      return pid ? readComm(pid) : undefined;
+    });
+  } finally {
+    bareShellCheckInProgress = false;
+  }
   if (!isBareShellComm(comm)) return false;          // CLI (rust/go/node) is running — healthy launch
 
   // Bare shell is the pane leaf → the CLI never launched. Tier the message on
@@ -6270,6 +6291,7 @@ async function spawnCli(
   // diagnostic instead of having the prompt typed into it.
   bareShellLaunchBlocked = false;
   bareShellChecked = false;
+  bareShellCheckInProgress = false;
 
   // ── Resume pre-flight check + two-tier fallback ──────────────────────────
   // Tier 1 (adapter probe): adapter.checkResumeTargetExists returns false
@@ -9395,8 +9417,16 @@ process.on('message', async (raw: unknown) => {
       // barrier（shouldDeferUserFlush——/cd 未落地前任何用户输入都不得写入，
       // 否则 passthrough 会执行在旧 cwd 的 CLI 里）时入队。注入排空后由
       // flushPendingInjections 的 finally 补踢 flushPending 送达。
+      // 第四个例外是启动稳定窗口：detectBareShellLaunch() 采到裸 shell 时会
+      // await settleLaunchComm() 最长 2s 等 wrapper 完成 `exec <cli>`——这段
+      // await 让出事件循环，而 IPC handler 不串行（见 raw-input-followup-
+      // atomicity.test.ts），若此刻放行 passthrough 就会打进尚未 exec 的临时
+      // shell。bareShellCheckInProgress 覆盖"检查进行中"、bareShellLaunchBlocked
+      // 覆盖"已确认裸 shell 启动失败"两种状态,一并入队。裸 shell 确认失败后
+      // 这些 pending 不会再被 flush（与 pendingMessages 同款处理），符合预期。
       if (cliRestartInProgress || rawInputRestartGate || sessionRenameInFlight
-        || injectionFlushing || shouldDeferUserFlush(pendingInjections)) {
+        || injectionFlushing || shouldDeferUserFlush(pendingInjections)
+        || bareShellCheckInProgress || bareShellLaunchBlocked) {
         pendingRawInputs.push(msg);
         log(`Deferred passthrough slash command until CLI input gate settles: ${msg.content}`);
       } else {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4177,7 +4177,10 @@ async function flushPendingInjections(): Promise<void> {
       // The detector's settle await can span a restart's tmux jitter window
       // (cliRestartInProgress true, old backend still alive). Re-check the fence
       // before shift()/write so a queued injection never lands in a CLI already
-      // being torn down; the queue is preserved for the replacement generation.
+      // being torn down. The pending injections are then handled by killCli's
+      // restart policy — which drops them (barrier /cd is already durable in
+      // workingDir; non-barrier injects are best-effort and not replayed
+      // cross-process), unlike pendingMessages which killCli preserves.
       if (cliRestartInProgress) return;
       const item = pendingInjections.shift()!;
       const cmd = item.command;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4174,6 +4174,11 @@ async function flushPendingInjections(): Promise<void> {
         bareShellChecked = true;
         if (await detectBareShellLaunch()) return;  // finally{} releases the mutex; queue stays
       }
+      // The detector's settle await can span a restart's tmux jitter window
+      // (cliRestartInProgress true, old backend still alive). Re-check the fence
+      // before shift()/write so a queued injection never lands in a CLI already
+      // being torn down; the queue is preserved for the replacement generation.
+      if (cliRestartInProgress) return;
       const item = pendingInjections.shift()!;
       const cmd = item.command;
       isPromptReady = false;
@@ -4916,6 +4921,15 @@ async function detectBareShellLaunch(): Promise<boolean> {
   } finally {
     bareShellCheckInProgress = false;
   }
+  // A restart can begin while we're suspended in the settle await: tmux staggers
+  // teardown behind a 250–1999ms jitter, so cliRestartInProgress is already true
+  // but the old backend is still alive. Do NOT classify that torn-down pane as a
+  // failed launch — it would set the persistent bareShellLaunchBlocked and emit a
+  // misdiagnosis card for a CLI that's about to be replaced. Return healthy; the
+  // caller's own post-await restart fence keeps the queue intact for the
+  // replacement generation (whose spawnCli resets bareShellChecked and re-runs
+  // this check).
+  if (cliRestartInProgress) return false;
   if (!isBareShellComm(comm)) return false;          // CLI (rust/go/node) is running — healthy launch
 
   // Bare shell is the pane leaf → the CLI never launched. Tier the message on
@@ -5070,6 +5084,14 @@ async function flushPending(): Promise<void> {
         return;  // finally{} releases the mutex; pendingMessages stay queued, untouched
       }
     }
+    // detectBareShellLaunch() awaits a bounded settle poll; a restart can begin
+    // during that yield (tmux staggers teardown behind a 250–1999ms jitter, so
+    // cliRestartInProgress flips true while the old backend is still alive). Do
+    // not write startup commands / rename / user prompts into a CLI already
+    // promised to teardown — re-check the restart fence now, before any shift or
+    // write. The queue is untouched; the replacement generation's markPromptReady
+    // re-invokes flushPending.
+    if (cliRestartInProgress) return;  // finally{} releases the mutex; queue stays
     // One-shot per spawn: type the bot's startup commands (e.g. `/effort
     // ultracode`) into the CLI before the first user prompt drains. Both ready
     // paths funnel through flushPending — the ready-gate settle for Claude-family

--- a/test/raw-input-followup-atomicity.test.ts
+++ b/test/raw-input-followup-atomicity.test.ts
@@ -183,3 +183,52 @@ describe('daemon prompt_ready dispatch', () => {
     expect(region).not.toContain("type: 'message'");
   });
 });
+
+describe('post-settle restart fence', () => {
+  // PR #570 三审阻塞项:detectBareShellLaunch() 的 settle await 会让出事件循环
+  // 最长 2s;tmux restart 的 250–1999ms jitter 期间 cliRestartInProgress 已 true
+  // 而旧 backend 仍存活。两条持锁 flush(message / injection)在 await 返回后只
+  // 复查 backend(jitter 内非 null),不复查 restart fence,会把输入写进即将销毁的
+  // 旧 CLI。改前 detector 同步、入口 restart check 与写入间无让出,故是本次
+  // async 化扩出的第二个窗口。三处 source-level 顺序断言钉死修复。
+
+  it('flushPending re-checks cliRestartInProgress AFTER the awaited detector, BEFORE any write', () => {
+    const flush = caseRegion(workerSrc, 'async function flushPending()', 15000);
+    const detector = flush.indexOf('if (await detectBareShellLaunch())');
+    const fence = flush.indexOf('if (cliRestartInProgress) return;', detector);
+    const startup = flush.indexOf('await runStartupCommands()', detector);
+    const rawShift = flush.indexOf('pendingRawInputs.shift()', detector);
+    const writeInput = flush.indexOf('cliAdapter.writeInput(backend', detector);
+    expect(detector).toBeGreaterThanOrEqual(0);
+    expect(fence).toBeGreaterThan(detector);
+    // Fence must precede every downstream write/shift the settle await exposed.
+    expect(startup).toBeGreaterThan(fence);
+    expect(rawShift).toBeGreaterThan(fence);
+    expect(writeInput).toBeGreaterThan(fence);
+  });
+
+  it('flushPendingInjections re-checks cliRestartInProgress AFTER the awaited detector, BEFORE the shift', () => {
+    const inj = caseRegion(workerSrc, 'async function flushPendingInjections()', 3000);
+    const detector = inj.indexOf('if (await detectBareShellLaunch()) return');
+    const fence = inj.indexOf('if (cliRestartInProgress) return;', detector);
+    const shift = inj.indexOf('pendingInjections.shift()', detector);
+    expect(detector).toBeGreaterThanOrEqual(0);
+    expect(fence).toBeGreaterThan(detector);
+    expect(shift).toBeGreaterThan(fence);
+  });
+
+  it('detectBareShellLaunch skips bare-shell classification when a restart began during settle', () => {
+    const detect = caseRegion(workerSrc, 'async function detectBareShellLaunch()', 2400);
+    const settle = detect.indexOf('await settleLaunchComm(');
+    const restartCheck = detect.indexOf('if (cliRestartInProgress) return false;', settle);
+    const classify = detect.indexOf('isBareShellComm(comm)', restartCheck);
+    const block = detect.indexOf('bareShellLaunchBlocked = true', restartCheck);
+    expect(settle).toBeGreaterThanOrEqual(0);
+    // The restart short-circuit must sit after the await and before the
+    // bare-shell verdict / persistent block, so a torn-down pane isn't
+    // misdiagnosed as a failed launch.
+    expect(restartCheck).toBeGreaterThan(settle);
+    expect(classify).toBeGreaterThan(restartCheck);
+    expect(block).toBeGreaterThan(restartCheck);
+  });
+});

--- a/test/raw-input-followup-atomicity.test.ts
+++ b/test/raw-input-followup-atomicity.test.ts
@@ -60,6 +60,33 @@ describe('worker raw_input handler', () => {
     expect(gate).toContain('injectionFlushing');
     expect(gate).toContain('shouldDeferUserFlush(pendingInjections)');
   });
+
+  it('also defers across the bounded launch-settle window and after a confirmed bare-shell block', () => {
+    // PR #570 二审阻塞项：detectBareShellLaunch() 采到裸 shell 后 await
+    // settleLaunchComm() 让出事件循环最长 2s；IPC handler 不串行，raw_input
+    // 若在此窗口放行会打进尚未 `exec <cli>` 的临时 shell。isFlushing 挡不住它
+    // （raw_input 刻意保留 busy 直送）——须用专用 bareShellCheckInProgress latch
+    // 覆盖"检查进行中"，并用 bareShellLaunchBlocked 覆盖"已确认失败"。
+    const gate = region.slice(
+      region.indexOf('if (cliRestartInProgress'),
+      region.indexOf('pendingRawInputs.push(msg)'),
+    );
+    expect(gate).toContain('bareShellCheckInProgress');
+    expect(gate).toContain('bareShellLaunchBlocked');
+
+    // The latch must be held ACROSS the settle await (set before, cleared in a
+    // finally), otherwise the raw gate's check races the window it guards.
+    const detect = caseRegion(workerSrc, 'async function detectBareShellLaunch()', 1400);
+    const set = detect.indexOf('bareShellCheckInProgress = true');
+    const await_ = detect.indexOf('await settleLaunchComm(', set);
+    const clear = detect.indexOf('bareShellCheckInProgress = false', await_);
+    const finallyIdx = detect.lastIndexOf('finally', clear);
+    expect(set).toBeGreaterThanOrEqual(0);
+    expect(await_).toBeGreaterThan(set);
+    expect(clear).toBeGreaterThan(await_);
+    expect(finallyIdx).toBeGreaterThan(await_);
+    expect(finallyIdx).toBeLessThan(clear);
+  });
 });
 
 describe('worker raw_input delivery', () => {

--- a/test/session-discovery.test.ts
+++ b/test/session-discovery.test.ts
@@ -31,7 +31,13 @@ vi.mock('node:os', () => ({
 
 import { execSync } from 'node:child_process';
 import { readFileSync, readlinkSync, existsSync, readdirSync } from 'node:fs';
-import { discoverAdoptableSessions, validateAdoptTarget, isBareShellComm, bareShellLaunchKind } from '../src/core/session-discovery.js';
+import {
+  discoverAdoptableSessions,
+  validateAdoptTarget,
+  isBareShellComm,
+  bareShellLaunchKind,
+  settleLaunchComm,
+} from '../src/core/session-discovery.js';
 import type { CliId } from '../src/adapters/cli/types.js';
 
 describe('isBareShellComm()', () => {
@@ -66,6 +72,41 @@ describe('bareShellLaunchKind()', () => {
   });
   it('reports stuck (no confident trampoline claim) when the launch shell is unknown', () => {
     expect(bareShellLaunchKind('zsh', '')).toBe('stuck');
+  });
+});
+
+describe('settleLaunchComm()', () => {
+  it('does not classify the launch wrapper as a failed CLI when it execs shortly afterward', async () => {
+    vi.useFakeTimers();
+    try {
+      const reads = ['zsh', 'coco'];
+      const settled = settleLaunchComm(
+        () => reads.shift() ?? 'coco',
+        { timeoutMs: 2_000, pollMs: 100 },
+      );
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(await settled).toBe('coco');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('returns a persistent bare shell after the bounded launch grace period', async () => {
+    vi.useFakeTimers();
+    try {
+      const settled = settleLaunchComm(
+        () => 'zsh',
+        { timeoutMs: 300, pollMs: 100 },
+      );
+
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(await settled).toBe('zsh');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/test/worker-durable-expiry-order.test.ts
+++ b/test/worker-durable-expiry-order.test.ts
@@ -61,6 +61,7 @@ describe('worker durable lease expiry ordering', () => {
       release,
     );
     const wake = restart.indexOf('void flushPending();', riffRawRelease);
+    const guardedWake = restart.indexOf('if (isPromptReady) void flushPending();', riffRawRelease);
 
     expect(restartStart).toBeGreaterThanOrEqual(0);
     expect(restartEnd).toBeGreaterThan(restartStart);
@@ -74,6 +75,12 @@ describe('worker durable lease expiry ordering', () => {
     expect(release).toBeGreaterThan(spawn);
     expect(riffRawRelease).toBeGreaterThan(release);
     expect(wake).toBeGreaterThan(riffRawRelease);
+    // A replacement CoCo/Codex process may exist before its TUI input box
+    // exists. Restart completion must not use type-ahead to flush into that
+    // startup window; only a prompt already observed during the restart fence
+    // needs an explicit wake after the fence drops.
+    expect(guardedWake).toBeGreaterThan(riffRawRelease);
+    expect(wake).toBeGreaterThan(guardedWake);
 
     const promptStart = workerSource.indexOf('function markPromptReady(): void');
     const promptEnd = workerSource.indexOf('\nfunction persistCliSessionId(', promptStart);

--- a/test/worker-durable-expiry-order.test.ts
+++ b/test/worker-durable-expiry-order.test.ts
@@ -60,7 +60,6 @@ describe('worker durable lease expiry ordering', () => {
       "if (effectiveBackendType === 'riff' && isPromptReady) releaseRawInputRestartGate();",
       release,
     );
-    const wake = restart.indexOf('void flushPending();', riffRawRelease);
     const guardedWake = restart.indexOf('if (isPromptReady) void flushPending();', riffRawRelease);
 
     expect(restartStart).toBeGreaterThanOrEqual(0);
@@ -74,13 +73,19 @@ describe('worker durable lease expiry ordering', () => {
     expect(spawn).toBeGreaterThan(kill);
     expect(release).toBeGreaterThan(spawn);
     expect(riffRawRelease).toBeGreaterThan(release);
-    expect(wake).toBeGreaterThan(riffRawRelease);
     // A replacement CoCo/Codex process may exist before its TUI input box
     // exists. Restart completion must not use type-ahead to flush into that
     // startup window; only a prompt already observed during the restart fence
-    // needs an explicit wake after the fence drops.
+    // needs an explicit wake after the fence drops. Assert the wake exists AND
+    // that every flushPending() the restart closure runs is the guarded
+    // `if (isPromptReady)` form — never a bare re-kick that would type-ahead
+    // into the not-yet-ready TUI. Counting both guards against a future edit
+    // reintroducing an unguarded flush anywhere in the closure.
     expect(guardedWake).toBeGreaterThan(riffRawRelease);
-    expect(wake).toBeGreaterThan(guardedWake);
+    const totalFlushes = restart.match(/void flushPending\(\);/g)?.length ?? 0;
+    const guardedFlushes = restart.match(/if \(isPromptReady\) void flushPending\(\);/g)?.length ?? 0;
+    expect(totalFlushes).toBeGreaterThan(0);
+    expect(guardedFlushes).toBe(totalFlushes);
 
     const promptStart = workerSource.indexOf('function markPromptReady(): void');
     const promptEnd = workerSource.indexOf('\nfunction persistCliSessionId(', promptStart);


### PR DESCRIPTION
## 改动说明

- 启动阶段检测到临时 `zsh`/shell wrapper 时，提供最长 2 秒的有界稳定窗口，避免在 wrapper 尚未 `exec coco` 时把会话永久判定为裸 shell 启动失败。
- CLI 重启后仅在输入框已经 ready 时主动 flush；否则由后续 `markPromptReady()` 负责首次投递，避免 Enter 在 CoCo TUI 尚未就绪时丢失。
- 新增启动稳定与重启投递时序回归测试。

## 根因与影响面

根因是 tmux pane 的进程采样和 CoCo TUI ready 存在两个独立竞争窗口。改动位于 worker 共用投递路径，但稳定等待只在采样结果为裸 shell 时发生；重启 flush 继续复用既有 prompt-ready 门禁。已核对最新 `master` 的 worker 改动并无合并冲突。

影响会话：CoCo 及其它通过 managed wrapper 启动、或重启时不支持 type-ahead 的 CLI。普通已就绪会话与非 shell 进程不增加等待。

## 验证

- `pnpm build`：通过（含域名审计、TypeScript 编译、Dashboard bundle、dist 审计）
- `vitest run test/session-discovery.test.ts test/worker-durable-expiry-order.test.ts`：52/52 通过
- 完整 unit suite：9969 通过、15 失败；在未合并的同一 `origin/master` 上复跑失败文件，得到完全相同的 15 个基线失败（Node 22 缺少 `node:sqlite`、临时 ESM 脚本和 Linux 进程扫描环境项），本改动未新增失败
- 真实飞书群聊验证：CoCo 会话可正常接收并回复消息