### PR TITLE
fix(platform): 用目录句柄兼容共享盘凭证路径

### DIFF
--- a/src/platform/secure-host-file.ts
+++ b/src/platform/secure-host-file.ts
@@ -2,13 +2,16 @@
  * Strict host-authority file primitives.
  *
  * Unlike general dotfiles, machine/device credentials must never follow a
- * leaf symlink. Reads pin one inode with O_NOFOLLOW, writes canonicalize only
- * the parent and atomically replace the leaf, and the containing directory
- * must not be writable by group/other users.
+ * leaf symlink. Linux pins the containing directory while operating on the
+ * leaf; other platforms require a non-replaceable ancestor chain. All writes
+ * atomically replace the leaf, and its directory must be owned by the current
+ * user without group/other write access.
  */
+import { randomBytes } from 'node:crypto';
 import {
   closeSync,
   constants,
+  fchmodSync,
   fstatSync,
   fsyncSync,
   lstatSync,
@@ -16,8 +19,10 @@ import {
   openSync,
   readFileSync,
   realpathSync,
+  renameSync,
   statSync,
   unlinkSync,
+  writeFileSync,
 } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
@@ -40,6 +45,16 @@ function assertOwnedByCurrentUser(stats: import('node:fs').Stats, label: string)
   if (process.platform === 'win32' || !process.getuid) return;
   if (stats.uid !== process.getuid()) {
     throw new UnsafeHostAuthorityFileError(`${label} 不属于当前用户`);
+  }
+}
+
+function assertSecureParentStats(stats: import('node:fs').Stats): void {
+  if (!stats.isDirectory()) {
+    throw new UnsafeHostAuthorityFileError('宿主凭证目录不是普通目录');
+  }
+  assertOwnedByCurrentUser(stats, '宿主凭证目录');
+  if (process.platform !== 'win32' && (stats.mode & 0o022) !== 0) {
+    throw new UnsafeHostAuthorityFileError('宿主凭证目录可被组内或其它用户写入');
   }
 }
 
@@ -84,21 +99,74 @@ function assertAncestorChainCannotReplace(canonicalParent: string): void {
   }
 }
 
-/** Create/resolve the parent without ever resolving the final path component. */
-export function secureHostFilePath(filePath: string): string {
+function canonicalSecureHostParent(filePath: string): string {
   const parent = dirname(filePath);
   mkdirSync(parent, { recursive: true, mode: 0o700 });
   const canonicalParent = realpathSync(parent);
   const parentStats = statSync(canonicalParent);
-  if (!parentStats.isDirectory()) {
-    throw new UnsafeHostAuthorityFileError('宿主凭证目录不是普通目录');
-  }
-  assertOwnedByCurrentUser(parentStats, '宿主凭证目录');
-  if (process.platform !== 'win32' && (parentStats.mode & 0o022) !== 0) {
-    throw new UnsafeHostAuthorityFileError('宿主凭证目录可被组内或其它用户写入');
-  }
+  assertSecureParentStats(parentStats);
+  return canonicalParent;
+}
+
+/** Create/resolve the parent without ever resolving the final path component. */
+export function secureHostFilePath(filePath: string): string {
+  const canonicalParent = canonicalSecureHostParent(filePath);
   assertAncestorChainCannotReplace(canonicalParent);
   return join(canonicalParent, basename(filePath));
+}
+
+interface SecureHostParent {
+  path: string;
+  fd?: number;
+}
+
+/**
+ * Linux exposes an opened directory through /proc/self/fd. Keeping that
+ * directory descriptor open makes all leaf operations independent of later
+ * ancestor renames: an untrusted mount-point owner can still cause denial of
+ * service, but cannot redirect a credential write into a directory it reads.
+ *
+ * Other platforms retain the conservative ancestor-chain requirement until
+ * they have an equivalent descriptor-relative primitive.
+ */
+function acquireSecureHostParent(filePath: string): SecureHostParent {
+  const canonicalParent = canonicalSecureHostParent(filePath);
+  if (process.platform !== 'linux') {
+    assertAncestorChainCannotReplace(canonicalParent);
+    return { path: canonicalParent };
+  }
+
+  const fd = openSync(
+    canonicalParent,
+    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+  );
+  try {
+    const openedStats = fstatSync(fd);
+    assertSecureParentStats(openedStats);
+    const anchoredPath = `/proc/self/fd/${fd}`;
+    let anchoredStats: import('node:fs').Stats;
+    try {
+      anchoredStats = statSync(anchoredPath);
+    } catch {
+      // Minimal/chrooted Linux environments may not mount procfs. Preserve
+      // the old fail-closed path validation there.
+      closeSync(fd);
+      assertAncestorChainCannotReplace(canonicalParent);
+      return { path: canonicalParent };
+    }
+    if (!sameInode(openedStats, anchoredStats)) {
+      throw new UnsafeHostAuthorityFileError('宿主凭证目录句柄发生变化');
+    }
+    return { path: anchoredPath, fd };
+  } catch (error) {
+    try { closeSync(fd); } catch { /* best effort */ }
+    throw error;
+  }
+}
+
+function releaseSecureHostParent(parent: SecureHostParent): void {
+  if (parent.fd === undefined) return;
+  closeSync(parent.fd);
 }
 
 function assertSecureFileStats(stats: import('node:fs').Stats, maxBytes: number): void {
@@ -114,15 +182,12 @@ function assertSecureFileStats(stats: import('node:fs').Stats, maxBytes: number)
   }
 }
 
-/** Return null only for a genuinely absent leaf; unsafe shapes fail closed. */
-export function readSecureHostFileSync(filePath: string, maxBytes = 64 * 1024): string | null {
-  try {
-    lstatSync(dirname(filePath));
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
-    throw error;
-  }
-  const resolved = secureHostFilePath(filePath);
+function readSecureHostFileFromParentSync(
+  parent: SecureHostParent,
+  leafName: string,
+  maxBytes: number,
+): string | null {
+  const resolved = join(parent.path, leafName);
   let fd: number;
   try {
     const flags = process.platform === 'win32'
@@ -160,36 +225,111 @@ export function readSecureHostFileSync(filePath: string, maxBytes = 64 * 1024): 
   }
 }
 
+/** Return null only for a genuinely absent leaf; unsafe shapes fail closed. */
+export function readSecureHostFileSync(filePath: string, maxBytes = 64 * 1024): string | null {
+  try {
+    lstatSync(dirname(filePath));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
+  const parent = acquireSecureHostParent(filePath);
+  try {
+    return readSecureHostFileFromParentSync(parent, basename(filePath), maxBytes);
+  } finally {
+    releaseSecureHostParent(parent);
+  }
+}
+
+function writePinnedSecureHostFileSync(
+  parent: SecureHostParent,
+  directoryFd: number,
+  leafName: string,
+  data: string,
+): void {
+  const resolved = join(parent.path, leafName);
+  const tmp = join(
+    parent.path,
+    `${leafName}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`,
+  );
+  let fd: number | undefined;
+  try {
+    fd = openSync(
+      tmp,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+      0o600,
+    );
+    writeFileSync(fd, data, { encoding: 'utf8' });
+    fchmodSync(fd, 0o600);
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+    renameSync(tmp, resolved);
+    fsyncSync(directoryFd);
+  } catch (error) {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch { /* best effort */ }
+    }
+    try { unlinkSync(tmp); } catch { /* best effort */ }
+    throw error;
+  }
+}
+
 /** Strict, durable atomic replace that never follows a leaf symlink. */
 export function writeSecureHostFileSync(filePath: string, data: string): void {
-  const resolved = secureHostFilePath(filePath);
-  let leafExists = false;
+  const parent = acquireSecureHostParent(filePath);
+  const leafName = basename(filePath);
+  const resolved = join(parent.path, leafName);
   try {
-    lstatSync(resolved);
-    leafExists = true;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    let leafExists = false;
+    try {
+      lstatSync(resolved);
+      leafExists = true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+    if (leafExists) {
+      // Pin and validate the existing leaf before replacement. The final
+      // rename never follows a leaf symlink.
+      readSecureHostFileFromParentSync(parent, leafName, 64 * 1024);
+    }
+    if (parent.fd !== undefined) {
+      writePinnedSecureHostFileSync(
+        parent,
+        parent.fd,
+        leafName,
+        data,
+      );
+    } else {
+      atomicWriteFileSync(resolved, data, {
+        mode: 0o600,
+        durable: true,
+        followTargetSymlink: false,
+      });
+    }
+  } finally {
+    releaseSecureHostParent(parent);
   }
-  if (leafExists) {
-    // Pin and validate the existing leaf before replacement. The final rename
-    // never follows a leaf symlink, so a later swap cannot redirect the write.
-    readSecureHostFileSync(resolved);
-  }
-  atomicWriteFileSync(resolved, data, {
-    mode: 0o600,
-    durable: true,
-    followTargetSymlink: false,
-  });
 }
 
 /** Strict durable unlink. Returns false only if the leaf is absent. */
 export function unlinkSecureHostFileSync(filePath: string): boolean {
-  const resolved = secureHostFilePath(filePath);
-  if (readSecureHostFileSync(resolved) === null) return false;
-  unlinkSync(resolved);
-  if (process.platform !== 'win32') {
-    const fd = openSync(dirname(resolved), constants.O_RDONLY);
-    try { fsyncSync(fd); } finally { closeSync(fd); }
+  const parent = acquireSecureHostParent(filePath);
+  const leafName = basename(filePath);
+  const resolved = join(parent.path, leafName);
+  try {
+    if (readSecureHostFileFromParentSync(parent, leafName, 64 * 1024) === null) return false;
+    unlinkSync(resolved);
+    if (process.platform !== 'win32') {
+      if (parent.fd !== undefined) {
+        fsyncSync(parent.fd);
+      } else {
+        const fd = openSync(parent.path, constants.O_RDONLY);
+        try { fsyncSync(fd); } finally { closeSync(fd); }
+      }
+    }
+    return true;
+  } finally {
+    releaseSecureHostParent(parent);
   }
-  return true;
 }

--- a/test/secure-host-file-race.test.ts
+++ b/test/secure-host-file-race.test.ts
@@ -1,0 +1,76 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const fsRace = vi.hoisted(() => ({
+  afterDirectoryOpen: undefined as undefined | (() => void),
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    openSync(
+      path: import('node:fs').PathLike,
+      flags: import('node:fs').OpenMode,
+      mode?: import('node:fs').Mode,
+    ): number {
+      const fd = actual.openSync(path, flags, mode);
+      if (
+        process.platform === 'linux'
+        && typeof flags === 'number'
+        && (flags & actual.constants.O_DIRECTORY) !== 0
+        && fsRace.afterDirectoryOpen
+      ) {
+        const hook = fsRace.afterDirectoryOpen;
+        fsRace.afterDirectoryOpen = undefined;
+        hook();
+      }
+      return fd;
+    },
+  };
+});
+
+import { writeSecureHostFileSync } from '../src/platform/secure-host-file.js';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  fsRace.afterDirectoryOpen = undefined;
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('secure host authority directory pinning', () => {
+  it('does not redirect a Linux write when an ancestor changes after directory open', () => {
+    if (process.platform !== 'linux') return;
+    const root = mkdtempSync(join(tmpdir(), 'botmux-secure-host-race-'));
+    roots.push(root);
+    chmodSync(root, 0o777);
+    const visibleRoot = join(root, 'visible');
+    const movedRoot = join(root, 'moved');
+    const visibleDirectory = join(visibleRoot, '.botmux');
+    const movedFile = join(movedRoot, '.botmux', 'platform.json');
+    const trapFile = join(visibleDirectory, 'platform.json');
+    mkdirSync(visibleDirectory, { recursive: true, mode: 0o700 });
+
+    fsRace.afterDirectoryOpen = () => {
+      renameSync(visibleRoot, movedRoot);
+      mkdirSync(visibleDirectory, { recursive: true, mode: 0o777 });
+      chmodSync(visibleDirectory, 0o777);
+    };
+
+    writeSecureHostFileSync(trapFile, 'secret');
+
+    expect(readFileSync(movedFile, 'utf8')).toBe('secret');
+    expect(existsSync(trapFile)).toBe(false);
+  });
+});

--- a/test/secure-host-file.test.ts
+++ b/test/secure-host-file.test.ts
@@ -69,15 +69,22 @@ describe('secure host authority files', () => {
     expect(() => writeSecureHostFileSync(file, 'secret')).toThrow(/其它用户写入|组内/);
   });
 
-  it('rejects a safe-looking credential directory under a replaceable ancestor', () => {
+  it('pins a safe credential directory under a replaceable ancestor on Linux', () => {
     if (process.platform === 'win32') return;
     const root = tempRoot();
     chmodSync(root, 0o777);
     const dir = join(root, '.botmux');
     mkdirSync(dir, { mode: 0o700 });
+    const file = join(dir, 'device.json');
 
-    expect(() => writeSecureHostFileSync(join(dir, 'device.json'), 'secret'))
-      .toThrow(/祖先目录替换/);
+    if (process.platform === 'linux') {
+      writeSecureHostFileSync(file, 'secret');
+      expect(readSecureHostFileSync(file)).toBe('secret');
+      expect(unlinkSecureHostFileSync(file)).toBe(true);
+      expect(readSecureHostFileSync(file)).toBeNull();
+    } else {
+      expect(() => writeSecureHostFileSync(file, 'secret')).toThrow(/祖先目录替换/);
+    }
   });
 
   it('accepts an owned child under a sticky writable ancestor', () => {


### PR DESCRIPTION
## 背景 / 根因

`v3.4.0` 新增宿主凭证文件的祖先目录防替换校验。企业开发机常把用户 HOME 软链到独立数据盘；当数据盘挂载点由普通管理用户持有（即使模式为 `0755`），旧实现会因为该属主理论上可以替换下级目录而拒绝 `botmux bind`。

旧实现使用规范化后的绝对路径执行临时文件创建与 rename，因此如果继续做路径式 I/O，直接放宽祖先检查会重新引入 TOCTOU 重定向风险。

## 改动

- Linux 打开并校验凭证父目录后，保持目录文件描述符存活，通过 `/proc/self/fd/<fd>` 对叶子文件执行读取、原子替换和删除。
- 打开后的目录再次校验：必须是当前用户所有、不可被 group/other 写入，并核对 procfs 入口与目录句柄仍为同一 inode。
- Linux 原子写继续保持随机独占临时文件、`O_NOFOLLOW`、精确 `0600`、文件 fsync、同目录 rename 与目录 fsync。
- procfs 不可用时回退原有祖先链 fail-closed 校验；macOS / Windows 行为不变。
- 新增祖先目录可替换场景和“目录打开后祖先被替换”竞态回归测试，确认凭证只落到已固定的安全目录，替换出的目录拿不到内容。

## 为什么安全

目录句柄固定的是已经打开并完成属主/权限校验的目录 inode。祖先目录之后即使被重命名或替换，叶子读写仍通过该句柄到达原目录，不再重新沿可变祖先路径解析。攻击者仍可造成拒绝服务，但不能把凭证写入其可读目录。

叶子符号链接拒绝、现有文件 inode 一致性、文件属主、`0600` 和大小限制均保留。

## 影响面

- **公共层**：修改 `secure-host-file`，覆盖 platform binding、device credential、enroll journal 与 isolation marker 的宿主读写。
- **跨平台**：Linux 使用目录句柄兼容数据盘 HOME；无 procfs 的 Linux、macOS 继续使用严格祖先校验；Windows 保持原逻辑。
- **跨 CLI / 后端 / 会话类型**：不改 CLI adapter、PTY/Tmux、话题/群/adopt/restore 路径；仅宿主进程访问权威凭证时生效。
- **兼容性**：普通 root/本人所有的 HOME 行为不变；凭证目录自身仍必须由当前用户持有且不可被组/其他用户写入。

## 实机复现与验证

- 在一台 HOME 软链到本地 ext4 数据盘、挂载点由非 root 用户持有且模式为 `0755` 的 Linux 开发机上，只读复现 `UnsafeHostAuthorityFileError`。
- 用新构建在相同真实 HOME 布局读取一个不存在的探针叶子，返回 `null`，不再触发祖先目录错误；未修改该机器权限、属主或现有绑定。
- 在本机和上述开发机的临时目录验证：打开安全目录后替换祖先，原子写仍进入已固定目录，替换目录没有凭证内容。

## 测试

- `pnpm vitest run test/secure-host-file.test.ts test/secure-host-file-race.test.ts test/atomic-write.test.ts test/platform-binding-clear.test.ts test/platform-bind-ip-family.test.ts test/platform-device.test.ts test/platform-device-enroll.test.ts test/platform-device-isolation.test.ts test/device-isolation-activation-client.test.ts test/device-isolation-daemon.test.ts test/device-isolation-daemon-ipc.test.ts test/platform-device-command.test.ts`：12 files / 74 tests passed。
- `pnpm build`：通过（含 domain audit、TypeScript、dashboard bundle、dist audit）。
- `git diff --check`：通过。
- `pnpm test`：640 files / 9998 tests passed，3 个 scheduler 本地时区断言失败；相同 3 个失败在未修改的 `origin/master` 同环境复现，与本改动无关。
- `pnpm daemon:restart`：46 个进程全部 online。
