### PR TITLE
fix(lark): 修复卡片空回调与撤回竞态

### DIFF
--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -339,6 +339,17 @@ function duplicateMultiWorktreeChildNames(repoPaths: string[], projects: Project
   return [...dupes];
 }
 
+function deferRepoCardWithdraw(larkAppId: string | undefined, messageId: string | undefined): void {
+  if (!larkAppId || !messageId) return;
+  // Let the card-action promise resolve so the SDK can send its callback ACK
+  // before the original card disappears. A microtask is too early here: it may
+  // run before the SDK continuation that serializes and writes the ACK frame.
+  setImmediate(() => {
+    void deleteMessage(larkAppId, messageId)
+      .catch(err => logger.debug(`Repo card withdraw (post-callback) failed: ${err}`));
+  });
+}
+
 /**
  * Commit a resolved working directory onto a repo-select session: pin it, then
  * either fork the pending CLI (first selection) or close + recreate the session
@@ -519,8 +530,9 @@ export async function commitRepoSelection(
       markRepoCardConsumed(ds, cardToWithdraw);
       ds.repoCardMessageId = undefined;
 
-      // Hold the claim through confirmation + best-effort card withdraw so a
-      // concurrent in-flight select still sees pendingRepoCommitInFlight.
+      // Hold the claim through confirmation. Card withdrawal is deferred until
+      // after the callback can ACK; stale clicks are blocked by the local
+      // consume mark above rather than by the network request's lifetime.
       try {
         if (!opts?.suppressConfirmReply) {
           // A card click has no turn of its own — anchor the confirmation to the
@@ -533,9 +545,7 @@ export async function commitRepoSelection(
       } catch (e) {
         logger.warn(`[${tag(ds)}] Confirm reply after pending repo commit failed: ${e instanceof Error ? e.message : e}`);
       }
-      if (cardToWithdraw && larkAppId) {
-        try { await deleteMessage(larkAppId, cardToWithdraw); } catch { /* card may already be gone */ }
-      }
+      deferRepoCardWithdraw(larkAppId, cardToWithdraw);
     } finally {
       ds.pendingRepoCommitInFlight = false;
     }
@@ -641,10 +651,9 @@ export async function commitRepoSelection(
       }
     }
     logger.info(`[${tag(ds)}] Repo switched to ${dirPath}, new session created`);
-    // Best-effort withdraw — card already claimed above.
-    if (claimedCard && larkAppId) {
-      try { await deleteMessage(larkAppId, claimedCard); } catch { /* best-effort */ }
-    }
+    // The card was claimed locally above; withdraw it only after this callback
+    // can return its ACK so the delete request cannot race the callback frame.
+    deferRepoCardWithdraw(larkAppId, claimedCard);
   }
 }
 
@@ -2206,7 +2215,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
         }
       } else {
         await sessionReply(rootId, t('card.action.continue_using_current_repo', { cwd: getSessionWorkingDir(ds) }, locDs));
-        if (cardMessageId && larkAppId) deleteMessage(larkAppId, cardMessageId);
+        deferRepoCardWithdraw(larkAppId, cardMessageId);
         ds.repoCardMessageId = undefined;
       }
     }

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -658,7 +658,10 @@ function shapeCardActionResult(result: any): any {
   //   - a raw card body (e.g. toggle_stream) -> wrap as an in-place card patch.
   if (result && (result.toast || result.card)) return result;
   if (result) return { card: { type: 'raw', data: result } };
-  return undefined;
+  // The Lark WS SDK only serializes callback `data` for truthy results. An
+  // empty object therefore means "ACK with no UI update", while undefined
+  // produces a code-only response that the client rejects as an invalid ACK.
+  return {};
 }
 
 function serializeRawCardForPatch(cardData: any): string | undefined {
@@ -703,7 +706,7 @@ async function handleCardActionAckSafe(data: any, larkAppId: string, handlers: E
     .then(shapeCardActionResult)
     .catch(err => {
       logger.error(`Error handling card action: ${err}`);
-      return undefined;
+      return {};
     });
 
   void work.then(result => {

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -236,6 +236,7 @@ function deferred<T>() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(deleteMessage).mockReset().mockResolvedValue(true);
   vi.mocked(getBot).mockImplementation(() => ({
     config: { larkAppId: APP_ID, larkAppSecret: 'secret', cliId: 'claude-code' },
     resolvedAllowedUsers: [],
@@ -253,6 +254,13 @@ beforeEach(() => {
     createdAt: new Date().toISOString(),
     chatType,
   }) as any);
+});
+
+afterEach(async () => {
+  // Repo-card withdrawal deliberately runs in the next macrotask. Drain it
+  // before the following test resets mocks so callbacks cannot leak across
+  // test boundaries and pollute another case's call history.
+  await new Promise<void>(resolve => setImmediate(resolve));
 });
 
 // ─── Tests ────────────────────────────────────────────────────────────────
@@ -480,7 +488,7 @@ describe('repo select card — plain switch', () => {
     expect(forkWorker).toHaveBeenCalledTimes(1);
     expect(ds.pendingRepoCommitInFlight).toBe(false);
     expect(ds.session.sessionId).toBe('uuid-old');
-    expect(deleteMessage).toHaveBeenCalledWith(APP_ID, 'om_card');
+    await vi.waitFor(() => expect(deleteMessage).toHaveBeenCalledWith(APP_ID, 'om_card'));
     expect(ds.repoCardMessageId).toBeUndefined();
   });
 
@@ -509,15 +517,14 @@ describe('repo select card — plain switch', () => {
     expect(ds.workingDir).toBeUndefined();
     expect(ds.session.workingDir).toBeUndefined();
     expect(sessionReply.mock.calls.map(c => c[1]).join()).toContain('已直接开启会话');
-    expect(deleteMessage).toHaveBeenCalledWith(APP_ID, 'om_card');
+    await vi.waitFor(() => expect(deleteMessage).toHaveBeenCalledWith(APP_ID, 'om_card'));
   });
 
-  it('rejects a stale card click while deleteMessage is still pending (local consume mark)', async () => {
-    // Regression: deleteMessage used to be fire-and-forget after claim release.
-    // We now mark the card consumed before network awaits and hold the claim
-    // through best-effort withdraw. A second click on the still-visible card
-    // must never mid-session-switch (killWorker), whether claim is still held
-    // or Feishu withdraw hangs / returns false.
+  it('returns before pending-card withdrawal settles and still rejects stale clicks', async () => {
+    // The callback must complete before the card-withdraw request settles, or
+    // Feishu can observe a missing/late ACK after the original card disappears.
+    // The local consume mark, rather than the network request, keeps stale
+    // clicks from entering the mid-session switch path.
     const ds = makeDs({
       pendingRepo: true,
       pendingPrompt: 'hello world',
@@ -537,9 +544,10 @@ describe('repo select card — plain switch', () => {
     }) as any);
 
     const first = handleCardAction(makeSelectEvent('repo_switch', '/repos/alpha'), deps, APP_ID);
+    const returnedBeforeWithdrawStarted = first.then(() => !vi.mocked(deleteMessage).mock.calls.length);
     await vi.waitFor(() => expect(forkWorker).toHaveBeenCalledTimes(1));
     await vi.waitFor(() => expect(releaseDelete).toBeTruthy());
-    // Consume is local and synchronous before the hung delete.
+    // Consume is local and synchronous before the background delete.
     expect(ds.consumedRepoCardMessageIds).toContain('om_card');
     expect(ds.session.sessionId).toBe('uuid-old');
 
@@ -551,6 +559,7 @@ describe('repo select card — plain switch', () => {
 
     releaseDelete!();
     await first;
+    expect(await returnedBeforeWithdrawStarted).toBe(true);
     expect(ds.pendingRepoCommitInFlight).toBe(false);
     expect(ds.session.sessionId).toBe('uuid-old');
     expect(ds.workingDir).toBe('/repos/alpha');
@@ -563,6 +572,39 @@ describe('repo select card — plain switch', () => {
     expect(createSession).not.toHaveBeenCalled();
     expect(forkWorker).toHaveBeenCalledTimes(1);
     expect(ds.session.sessionId).toBe('uuid-old');
+  });
+
+  it('returns before a mid-session card withdrawal settles', async () => {
+    const ds = makeDs();
+    ds.session.workingDir = '/repos/gamma';
+    const { deps } = makeDeps(ds);
+    let releaseDelete: (() => void) | undefined;
+    vi.mocked(deleteMessage).mockImplementationOnce(() => new Promise<boolean>(res => {
+      releaseDelete = () => res(false);
+    }) as any);
+
+    const action = handleCardAction(makeSelectEvent('repo_switch', '/repos/beta'), deps, APP_ID);
+    const returnedBeforeWithdrawStarted = action.then(() => !vi.mocked(deleteMessage).mock.calls.length);
+    await vi.waitFor(() => expect(releaseDelete).toBeTruthy());
+
+    releaseDelete!();
+    await action;
+    expect(await returnedBeforeWithdrawStarted).toBe(true);
+    expect(ds.workingDir).toBe('/repos/beta');
+    expect(ds.consumedRepoCardMessageIds).toContain('om_card');
+  });
+
+  it('defers current-repo skip-card withdrawal until the action returns', async () => {
+    const ds = makeDs();
+    const { deps } = makeDeps(ds);
+
+    const action = handleCardAction(makeSkipEvent(), deps, APP_ID);
+    const returnedBeforeWithdrawStarted = action.then(() => !vi.mocked(deleteMessage).mock.calls.length);
+
+    await action;
+    expect(await returnedBeforeWithdrawStarted).toBe(true);
+    await vi.waitFor(() => expect(deleteMessage).toHaveBeenCalledWith(APP_ID, 'om_card'));
+    expect(ds.repoCardMessageId).toBeUndefined();
   });
 
   it('keeps the first-spawn session when confirm sessionReply throws (card still marked consumed)', async () => {

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -5391,6 +5391,7 @@ describe('card.action.trigger — ack-safe slow handlers', () => {
     __resetAnchorQueues();
     __resetEventClaimsForTest();
     mockUpdateMessage.mockClear();
+    vi.mocked(logger.error).mockClear();
     setupBotState();
     handlers = makeHandlers();
     startLarkEventDispatcher(MY_APP_ID, 'secret', handlers);
@@ -5406,6 +5407,33 @@ describe('card.action.trigger — ack-safe slow handlers', () => {
     });
 
     expect(result).toEqual({ card: { type: 'raw', data: { type: 'updated-card' } } });
+    expect(mockUpdateMessage).not.toHaveBeenCalled();
+  });
+
+  it('returns a valid empty ACK when a fast card handler has no payload', async () => {
+    handlers.handleCardAction.mockResolvedValue(undefined);
+
+    const result = await capturedHandlers['card.action.trigger']({
+      action: { value: { action: 'repo_switch', root_id: 'root-empty' } },
+      operator: { open_id: USER_OPEN_ID },
+      context: { open_message_id: 'om_empty_card' },
+    });
+
+    expect(result).toEqual({});
+    expect(mockUpdateMessage).not.toHaveBeenCalled();
+  });
+
+  it('still returns a valid empty ACK when a card handler rejects', async () => {
+    handlers.handleCardAction.mockRejectedValue(new Error('handler boom'));
+
+    const result = await capturedHandlers['card.action.trigger']({
+      action: { value: { action: 'repo_switch', root_id: 'root-error' } },
+      operator: { open_id: USER_OPEN_ID },
+      context: { open_message_id: 'om_error_card' },
+    });
+
+    expect(result).toEqual({});
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('handler boom'));
     expect(mockUpdateMessage).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## 改动

- 将 `card.action.trigger` 的空 handler 结果归一为 `{}`，异常兜底也返回合法空 ACK，确保 Lark WS SDK 会写入 callback `data`
- 将仓库选择、直接开始和中途切仓后的卡片撤回延迟到下一 macrotask，避免 `deleteMessage` 抢在 callback ACK 前执行
- 补充空 ACK、异常 ACK、pending / mid-session / skip 撤卡时序及旧卡防重入回归测试

## 原因

`@larksuiteoapi/node-sdk@1.64.0` 仅在回调结果为 truthy 时序列化 `respPayload.data`。仓库选择成功路径返回 `undefined`，最终只回 `{ code: 200 }` 而没有 `data`，飞书客户端会弹出回调错误；同时原流程在返回 callback 前同步撤卡，进一步放大了 ACK 与撤卡的竞态。

空对象会被 SDK 编码为合法的 `e30=` data，语义是“ACK 成功但不更新 UI”。撤卡延后后，原有本地 consumed/claim 标记继续负责拦截旧卡重复点击，不依赖网络撤回完成。

## 影响面

- 仅影响 Lark 卡片动作的 callback 整形，以及 repo 卡片撤回时序
- 显式 toast、原地 card patch、2.5 秒慢处理 ACK 语义不变
- 不影响其他 IM、CLI 类型和 worker backend
- 无卡片 schema / 视觉变化，因此无截图差异

## 验证

- `pnpm exec vitest run --project unit test/event-dispatcher.test.ts test/card-handler-repo-select.test.ts`：279 passed
- `env -u ANTHROPIC_AUTH_TOKEN -u CLAUDE_CODE_MAX_CONTEXT_TOKENS -u CLAUDE_CODE_RESUME_TOKEN_THRESHOLD pnpm test`：9981 passed，23 skipped
- `pnpm build`：通过
- `git diff --check`：通过
