### PR TITLE
fix(worker): web 终端备用屏鼠标滚轮连续滚动不丝滑

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7913,8 +7913,16 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
       // normal buffer until resize causes a redraw. Preserve that mode so
       // scroll gestures continue to target the CLI's own transcript.
       const forceRemoteScroll = effectiveBackendType === 'herdr' && cliAdapter?.altScreen === true;
+      // The wheel burst cap throttles Herdr's EXPENSIVE forwarding path (each
+      // forwarded wheel → pane send-text + snapshot re-render). That cost is a
+      // property of the BACKEND, not of the adapter's declared altScreen: a
+      // Herdr session with an altScreen:false CLI (Claude/Codex) that enters the
+      // alternate buffer at runtime (vim/less, or the CLI's own alt-screen)
+      // still forwards via _fwdScroll and must stay capped. So gate the cap on
+      // the backend itself, independent of forceRemoteScroll.
+      const herdrBackend = effectiveBackendType === 'herdr';
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-      res.end(getTerminalHtml(hasWrite, platformReadonly, loginUrl, forceRemoteScroll));
+      res.end(getTerminalHtml(hasWrite, platformReadonly, loginUrl, forceRemoteScroll, herdrBackend));
     });
 
     wss = new WebSocketServer({
@@ -8195,6 +8203,7 @@ function getTerminalHtml(
   platformReadonly = false,
   loginUrl = '',
   forceRemoteScroll = false,
+  herdrBackend = false,
 ): string {
   const label = sessionId.substring(0, 8);
   return `<!DOCTYPE html>
@@ -8332,6 +8341,7 @@ if(isTouch){document.body.classList.add('touch');}
 var hasToken=${hasWrite};
 var platformReadonly=${platformReadonly};
 var remoteScroll=${forceRemoteScroll};
+var herdrBackend=${herdrBackend};
 if(!hasToken){
   if(platformReadonly){var _lb=document.getElementById('login-banner');_lb.classList.add('show');}
   else{var _rb=document.getElementById('readonly-banner');_rb.classList.add('show');_rb.addEventListener('click',function(){_rb.classList.remove('show')});}
@@ -8539,14 +8549,19 @@ window.addEventListener('resize',onViewportResize);
 // cap the whole continuous burst — not each browser event — then require an idle
 // gap (or direction reversal) before loading the next history chunk.
 //
-// The burst ceiling exists ONLY to throttle Herdr's EXPENSIVE remote history-chunk
-// loading (remoteScroll): each forwarded wheel there can trigger a network round
-// trip + snapshot re-render, so a fast spin must not fire hundreds of them. A local
-// PTY/tmux CLI (Claude Code etc.) repaints its own alt-screen cheaply, so capping it
-// at 6 ticks is what froze a continuous wheel spin after ~2 notches — the "not smooth
-// / stuck" symptom. Gate the cap on remoteScroll: unlimited ticks for local CLIs.
+// The burst ceiling exists ONLY to throttle Herdr's EXPENSIVE forwarding path:
+// on a Herdr backend each forwarded wheel triggers a pane send-text + snapshot
+// re-render, so a fast spin must not fire hundreds of them. That cost is a
+// property of the BACKEND, not of the adapter's declared altScreen — a Herdr
+// session running an altScreen:false CLI (Claude/Codex) that enters the
+// alternate buffer at runtime (vim/less, the CLI's own alt-screen) still hits
+// this path and must stay capped. A local PTY/tmux CLI repaints its own
+// alt-screen cheaply, so capping it at 6 ticks is what froze a continuous wheel
+// spin after ~2 notches — the "not smooth / stuck" symptom. Gate the cap on
+// herdrBackend (NOT remoteScroll, which also encodes altScreen): unlimited ticks
+// for every local backend, capped only for Herdr.
 var _scrollAccum=0,_scrollBurstTicks=0,_scrollBurstDir=0,_scrollBurstT=0;
-var _SCROLL_STEP=33;var _SCROLL_BURST_MAX=remoteScroll?6:Infinity;var _SCROLL_BURST_IDLE_MS=250;
+var _SCROLL_STEP=33;var _SCROLL_BURST_MAX=herdrBackend?6:Infinity;var _SCROLL_BURST_IDLE_MS=250;
 function _endScrollBurst(){
   clearTimeout(_scrollBurstT);_scrollBurstT=0;
   _scrollAccum=0;_scrollBurstTicks=0;_scrollBurstDir=0;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7913,16 +7913,24 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
       // normal buffer until resize causes a redraw. Preserve that mode so
       // scroll gestures continue to target the CLI's own transcript.
       const forceRemoteScroll = effectiveBackendType === 'herdr' && cliAdapter?.altScreen === true;
-      // The wheel burst cap throttles Herdr's EXPENSIVE forwarding path (each
-      // forwarded wheel → pane send-text + snapshot re-render). That cost is a
-      // property of the BACKEND, not of the adapter's declared altScreen: a
-      // Herdr session with an altScreen:false CLI (Claude/Codex) that enters the
-      // alternate buffer at runtime (vim/less, or the CLI's own alt-screen)
-      // still forwards via _fwdScroll and must stay capped. So gate the cap on
-      // the backend itself, independent of forceRemoteScroll.
-      const herdrBackend = effectiveBackendType === 'herdr';
+      // The wheel burst cap throttles backends where a forwarded wheel is
+      // EXPENSIVE or has no local terminal to drive:
+      //   • Herdr — each forwarded wheel → pane send-text + snapshot re-render.
+      //   • Riff  — has NO drivable terminal; writes become remote task/follow-up
+      //             creations (handleTermAction even rejects ANSI to Riff), so an
+      //             uncapped spin would flood remote task creation.
+      // This is a BACKEND property, independent of the adapter's declared
+      // altScreen: an altScreen:false CLI (Claude/Codex) that enters the
+      // alternate buffer at runtime (vim/less, or the CLI's own alt-screen) still
+      // forwards via _fwdScroll and must inherit its backend's cap. So gate the
+      // cap on a POSITIVE allowlist of cheap, locally-drivable terminal backends
+      // (pty/tmux/zellij); every other backend — Herdr, Riff, and any future one
+      // — stays safely capped by default.
+      const localTerminalBackend = effectiveBackendType === 'pty'
+        || effectiveBackendType === 'tmux'
+        || effectiveBackendType === 'zellij';
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-      res.end(getTerminalHtml(hasWrite, platformReadonly, loginUrl, forceRemoteScroll, herdrBackend));
+      res.end(getTerminalHtml(hasWrite, platformReadonly, loginUrl, forceRemoteScroll, localTerminalBackend));
     });
 
     wss = new WebSocketServer({
@@ -8203,7 +8211,7 @@ function getTerminalHtml(
   platformReadonly = false,
   loginUrl = '',
   forceRemoteScroll = false,
-  herdrBackend = false,
+  localTerminalBackend = false,
 ): string {
   const label = sessionId.substring(0, 8);
   return `<!DOCTYPE html>
@@ -8341,7 +8349,7 @@ if(isTouch){document.body.classList.add('touch');}
 var hasToken=${hasWrite};
 var platformReadonly=${platformReadonly};
 var remoteScroll=${forceRemoteScroll};
-var herdrBackend=${herdrBackend};
+var localTerminalBackend=${localTerminalBackend};
 if(!hasToken){
   if(platformReadonly){var _lb=document.getElementById('login-banner');_lb.classList.add('show');}
   else{var _rb=document.getElementById('readonly-banner');_rb.classList.add('show');_rb.addEventListener('click',function(){_rb.classList.remove('show')});}
@@ -8549,19 +8557,20 @@ window.addEventListener('resize',onViewportResize);
 // cap the whole continuous burst — not each browser event — then require an idle
 // gap (or direction reversal) before loading the next history chunk.
 //
-// The burst ceiling exists ONLY to throttle Herdr's EXPENSIVE forwarding path:
-// on a Herdr backend each forwarded wheel triggers a pane send-text + snapshot
-// re-render, so a fast spin must not fire hundreds of them. That cost is a
-// property of the BACKEND, not of the adapter's declared altScreen — a Herdr
-// session running an altScreen:false CLI (Claude/Codex) that enters the
-// alternate buffer at runtime (vim/less, the CLI's own alt-screen) still hits
-// this path and must stay capped. A local PTY/tmux CLI repaints its own
-// alt-screen cheaply, so capping it at 6 ticks is what froze a continuous wheel
-// spin after ~2 notches — the "not smooth / stuck" symptom. Gate the cap on
-// herdrBackend (NOT remoteScroll, which also encodes altScreen): unlimited ticks
-// for every local backend, capped only for Herdr.
+// The burst ceiling throttles backends where a forwarded wheel is EXPENSIVE or
+// has no local terminal to drive: Herdr (each tick → pane send-text + snapshot
+// re-render) and Riff (no drivable terminal — writes become remote task/follow-up
+// creations, so an uncapped spin would flood remote task creation). That cost is
+// a BACKEND property, not the adapter's declared altScreen — an altScreen:false
+// CLI (Claude/Codex) that enters the alternate buffer at runtime (vim/less, the
+// CLI's own alt-screen) still hits this path and inherits its backend's cap. A
+// local PTY/tmux/zellij backend repaints its own alt-screen cheaply, so capping
+// it at 6 ticks is what froze a continuous wheel spin after ~2 notches — the
+// "not smooth / stuck" symptom. Gate the release on a POSITIVE allowlist of
+// cheap local terminal backends (localTerminalBackend); every other backend —
+// Herdr, Riff, and any future one — stays safely capped by default.
 var _scrollAccum=0,_scrollBurstTicks=0,_scrollBurstDir=0,_scrollBurstT=0;
-var _SCROLL_STEP=33;var _SCROLL_BURST_MAX=herdrBackend?6:Infinity;var _SCROLL_BURST_IDLE_MS=250;
+var _SCROLL_STEP=33;var _SCROLL_BURST_MAX=localTerminalBackend?Infinity:6;var _SCROLL_BURST_IDLE_MS=250;
 function _endScrollBurst(){
   clearTimeout(_scrollBurstT);_scrollBurstT=0;
   _scrollAccum=0;_scrollBurstTicks=0;_scrollBurstDir=0;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8538,8 +8538,15 @@ window.addEventListener('resize',onViewportResize);
 // A high-resolution trackpad emits dozens of wheel events for one gesture, so
 // cap the whole continuous burst — not each browser event — then require an idle
 // gap (or direction reversal) before loading the next history chunk.
+//
+// The burst ceiling exists ONLY to throttle Herdr's EXPENSIVE remote history-chunk
+// loading (remoteScroll): each forwarded wheel there can trigger a network round
+// trip + snapshot re-render, so a fast spin must not fire hundreds of them. A local
+// PTY/tmux CLI (Claude Code etc.) repaints its own alt-screen cheaply, so capping it
+// at 6 ticks is what froze a continuous wheel spin after ~2 notches — the "not smooth
+// / stuck" symptom. Gate the cap on remoteScroll: unlimited ticks for local CLIs.
 var _scrollAccum=0,_scrollBurstTicks=0,_scrollBurstDir=0,_scrollBurstT=0;
-var _SCROLL_STEP=33;var _SCROLL_BURST_MAX=6;var _SCROLL_BURST_IDLE_MS=250;
+var _SCROLL_STEP=33;var _SCROLL_BURST_MAX=remoteScroll?6:Infinity;var _SCROLL_BURST_IDLE_MS=250;
 function _endScrollBurst(){
   clearTimeout(_scrollBurstT);_scrollBurstT=0;
   _scrollAccum=0;_scrollBurstTicks=0;_scrollBurstDir=0;

--- a/test/web-terminal-touch-scroll.test.ts
+++ b/test/web-terminal-touch-scroll.test.ts
@@ -42,7 +42,7 @@ describe('web terminal touch scrolling', () => {
   it('bounds remote scroll ticks per gesture instead of per browser event', () => {
     const wheelBlock = scriptBlock('// ── Wheel / touch scroll handling ──');
 
-    expect(wheelBlock).toContain('var _SCROLL_BURST_MAX=6');
+    expect(wheelBlock).toContain('var _SCROLL_BURST_MAX=remoteScroll?6:Infinity');
     expect(wheelBlock).toContain('_scrollBurstTicks<_SCROLL_BURST_MAX');
     expect(wheelBlock).toContain('setTimeout(_endScrollBurst,_SCROLL_BURST_IDLE_MS)');
     expect(wheelBlock).toContain('if(_scrollBurstTicks>=_SCROLL_BURST_MAX)_scrollAccum=0');

--- a/test/web-terminal-touch-scroll.test.ts
+++ b/test/web-terminal-touch-scroll.test.ts
@@ -39,38 +39,65 @@ describe('web terminal touch scrolling', () => {
       .toBeLessThan(wheelBlock.indexOf('_fwdScroll(px,_cellAt'));
   });
 
-  it('caps the burst on the Herdr backend, not on remoteScroll/altScreen', () => {
+  it('caps the burst on non-local backends, not on remoteScroll/altScreen', () => {
     const wheelBlock = scriptBlock('// ── Wheel / touch scroll handling ──');
 
-    // Cap gated on herdrBackend (the expensive send-text+snapshot path), NOT on
-    // remoteScroll — which also encodes altScreen and would leave a Herdr session
-    // running an altScreen:false CLI (Claude/Codex) uncapped once it enters the
-    // alternate buffer at runtime.
-    expect(wheelBlock).toContain('var _SCROLL_BURST_MAX=herdrBackend?6:Infinity');
+    // Cap gated on localTerminalBackend (a positive allowlist of cheap, locally-
+    // drivable backends), NOT on remoteScroll — which also encodes altScreen and
+    // would leave a Herdr session running an altScreen:false CLI (Claude/Codex)
+    // uncapped once it enters the alternate buffer at runtime. Herdr AND Riff
+    // (no drivable terminal → remote task floods) must stay capped.
+    expect(wheelBlock).toContain('var _SCROLL_BURST_MAX=localTerminalBackend?Infinity:6');
     expect(wheelBlock).not.toContain('_SCROLL_BURST_MAX=remoteScroll');
+    expect(wheelBlock).not.toContain('_SCROLL_BURST_MAX=herdrBackend');
     expect(wheelBlock).toContain('_scrollBurstTicks<_SCROLL_BURST_MAX');
     expect(wheelBlock).toContain('setTimeout(_endScrollBurst,_SCROLL_BURST_IDLE_MS)');
     expect(wheelBlock).toContain('if(_scrollBurstTicks>=_SCROLL_BURST_MAX)_scrollAccum=0');
   });
 
-  it('derives herdrBackend from the backend alone, independent of altScreen', () => {
-    // forceRemoteScroll still requires altScreen; herdrBackend must NOT — the cap
-    // has to hold for a runtime alt-buffer under an altScreen:false Herdr CLI.
+  it('derives localTerminalBackend as a positive pty/tmux/zellij allowlist', () => {
+    // forceRemoteScroll still requires altScreen; the cap gate must NOT — it has
+    // to hold for a runtime alt-buffer under any non-local backend. Herdr and Riff
+    // are deliberately EXCLUDED (expensive / no drivable terminal), so a new or
+    // unknown backend defaults to safely capped.
     expect(workerSource).toContain(
-      "const herdrBackend = effectiveBackendType === 'herdr';",
+      "const localTerminalBackend = effectiveBackendType === 'pty'\n"
+      + "        || effectiveBackendType === 'tmux'\n"
+      + "        || effectiveBackendType === 'zellij';",
     );
     expect(workerSource).toContain(
-      'getTerminalHtml(hasWrite, platformReadonly, loginUrl, forceRemoteScroll, herdrBackend)',
+      'getTerminalHtml(hasWrite, platformReadonly, loginUrl, forceRemoteScroll, localTerminalBackend)',
     );
-    expect(workerSource).toContain('var herdrBackend=${herdrBackend};');
+    expect(workerSource).toContain('var localTerminalBackend=${localTerminalBackend};');
+    // Guard the exclusion explicitly: neither Herdr nor Riff may appear in the gate.
+    const gate = workerSource.slice(
+      workerSource.indexOf('const localTerminalBackend ='),
+      workerSource.indexOf('res.writeHead', workerSource.indexOf('const localTerminalBackend =')),
+    );
+    expect(gate).not.toContain("=== 'herdr'");
+    expect(gate).not.toContain("=== 'riff'");
   });
 
-  it('forwards wheel ticks proportionally when uncapped, and caps Herdr', () => {
-    // Extract the real burst-accumulation loop from the source so the test moves
-    // when the algorithm moves, then run it for both backends.
-    function runSpin(herdrBackend: boolean, notches: number, pxPerNotch: number) {
+  it('forwards wheel ticks proportionally when uncapped, and caps non-local backends', () => {
+    // Pull the cap EXPRESSION straight from the generated client JS so the test
+    // fails if the gate changes, then evaluate it per backend rather than
+    // re-hardcoding "6 : Infinity".
+    const wheelBlock = scriptBlock('// ── Wheel / touch scroll handling ──');
+    const capExpr = /_SCROLL_BURST_MAX=([^;]+);/.exec(wheelBlock)?.[1];
+    expect(capExpr).toBe('localTerminalBackend?Infinity:6');
+    const capFor = (localTerminalBackend: boolean): number =>
+      // eslint-disable-next-line no-new-func
+      Function('localTerminalBackend', `return ${capExpr}`)(localTerminalBackend);
+
+    // Which backends count as local (cheap) is decided by the server-side gate.
+    const localBackend: Record<string, boolean> = {
+      pty: true, tmux: true, zellij: true, herdr: false, riff: false,
+    };
+
+    // Replays the same burst-accumulation loop the client runs, parameterised by
+    // the cap the gate above yields for each backend.
+    function runSpin(cap: number, notches: number, pxPerNotch: number) {
       const _SCROLL_STEP = 33;
-      const _SCROLL_BURST_MAX = herdrBackend ? 6 : Infinity;
       let _scrollAccum = 0;
       let _scrollBurstTicks = 0;
       let _scrollBurstDir = 0;
@@ -80,28 +107,33 @@ describe('web terminal touch scrolling', () => {
         const dir = px < 0 ? -1 : 1;
         if (_scrollBurstDir && dir !== _scrollBurstDir) { _scrollAccum = 0; _scrollBurstTicks = 0; }
         _scrollBurstDir = dir;
-        if (_scrollBurstTicks >= _SCROLL_BURST_MAX) continue;
+        if (_scrollBurstTicks >= cap) continue;
         _scrollAccum += px;
         let n = 0;
-        while (Math.abs(_scrollAccum) >= _SCROLL_STEP && n < 6 && _scrollBurstTicks < _SCROLL_BURST_MAX) {
+        while (Math.abs(_scrollAccum) >= _SCROLL_STEP && n < 6 && _scrollBurstTicks < cap) {
           const up = _scrollAccum < 0;
           _scrollAccum += up ? _SCROLL_STEP : -_SCROLL_STEP;
           n++; _scrollBurstTicks++; emitted++;
         }
-        if (_scrollBurstTicks >= _SCROLL_BURST_MAX) _scrollAccum = 0;
+        if (_scrollBurstTicks >= cap) _scrollAccum = 0;
       }
       return emitted;
     }
 
-    // Local PTY/tmux (herdrBackend=false): 40 notches @100px scale with distance,
-    // never freeze. Old cap of 6 would have frozen it after ~2 notches.
-    const local = runSpin(false, 40, 100);
-    expect(local).toBe(Math.floor((40 * 100) / 33)); // 121
-    expect(local).toBeGreaterThan(100);
+    // Local pty/tmux/zellij: 40 notches @100px scale with distance, never freeze.
+    // The old cap of 6 would have frozen them after ~2 notches.
+    for (const be of ['pty', 'tmux', 'zellij']) {
+      const emitted = runSpin(capFor(localBackend[be]), 40, 100);
+      expect(emitted, `${be} should scroll proportionally`).toBe(Math.floor((40 * 100) / 33)); // 121
+      expect(emitted).toBeGreaterThan(100);
+    }
 
-    // Herdr backend: still capped at 6 no matter how long the spin.
-    expect(runSpin(true, 40, 100)).toBe(6);
-    expect(runSpin(true, 2, 100)).toBe(6); // reaches cap within the first notches
+    // Herdr AND Riff: still capped at 6 no matter how long the spin — Riff would
+    // otherwise flood remote task creation.
+    for (const be of ['herdr', 'riff']) {
+      expect(runSpin(capFor(localBackend[be]), 40, 100), `${be} must stay capped`).toBe(6);
+      expect(runSpin(capFor(localBackend[be]), 2, 100)).toBe(6); // reaches cap within first notches
+    }
   });
 
   it('uses local scrollback before requesting another remote history chunk', () => {

--- a/test/web-terminal-touch-scroll.test.ts
+++ b/test/web-terminal-touch-scroll.test.ts
@@ -39,13 +39,69 @@ describe('web terminal touch scrolling', () => {
       .toBeLessThan(wheelBlock.indexOf('_fwdScroll(px,_cellAt'));
   });
 
-  it('bounds remote scroll ticks per gesture instead of per browser event', () => {
+  it('caps the burst on the Herdr backend, not on remoteScroll/altScreen', () => {
     const wheelBlock = scriptBlock('// ── Wheel / touch scroll handling ──');
 
-    expect(wheelBlock).toContain('var _SCROLL_BURST_MAX=remoteScroll?6:Infinity');
+    // Cap gated on herdrBackend (the expensive send-text+snapshot path), NOT on
+    // remoteScroll — which also encodes altScreen and would leave a Herdr session
+    // running an altScreen:false CLI (Claude/Codex) uncapped once it enters the
+    // alternate buffer at runtime.
+    expect(wheelBlock).toContain('var _SCROLL_BURST_MAX=herdrBackend?6:Infinity');
+    expect(wheelBlock).not.toContain('_SCROLL_BURST_MAX=remoteScroll');
     expect(wheelBlock).toContain('_scrollBurstTicks<_SCROLL_BURST_MAX');
     expect(wheelBlock).toContain('setTimeout(_endScrollBurst,_SCROLL_BURST_IDLE_MS)');
     expect(wheelBlock).toContain('if(_scrollBurstTicks>=_SCROLL_BURST_MAX)_scrollAccum=0');
+  });
+
+  it('derives herdrBackend from the backend alone, independent of altScreen', () => {
+    // forceRemoteScroll still requires altScreen; herdrBackend must NOT — the cap
+    // has to hold for a runtime alt-buffer under an altScreen:false Herdr CLI.
+    expect(workerSource).toContain(
+      "const herdrBackend = effectiveBackendType === 'herdr';",
+    );
+    expect(workerSource).toContain(
+      'getTerminalHtml(hasWrite, platformReadonly, loginUrl, forceRemoteScroll, herdrBackend)',
+    );
+    expect(workerSource).toContain('var herdrBackend=${herdrBackend};');
+  });
+
+  it('forwards wheel ticks proportionally when uncapped, and caps Herdr', () => {
+    // Extract the real burst-accumulation loop from the source so the test moves
+    // when the algorithm moves, then run it for both backends.
+    function runSpin(herdrBackend: boolean, notches: number, pxPerNotch: number) {
+      const _SCROLL_STEP = 33;
+      const _SCROLL_BURST_MAX = herdrBackend ? 6 : Infinity;
+      let _scrollAccum = 0;
+      let _scrollBurstTicks = 0;
+      let _scrollBurstDir = 0;
+      let emitted = 0;
+      for (let i = 0; i < notches; i++) {
+        const px = pxPerNotch; // steady downward spin
+        const dir = px < 0 ? -1 : 1;
+        if (_scrollBurstDir && dir !== _scrollBurstDir) { _scrollAccum = 0; _scrollBurstTicks = 0; }
+        _scrollBurstDir = dir;
+        if (_scrollBurstTicks >= _SCROLL_BURST_MAX) continue;
+        _scrollAccum += px;
+        let n = 0;
+        while (Math.abs(_scrollAccum) >= _SCROLL_STEP && n < 6 && _scrollBurstTicks < _SCROLL_BURST_MAX) {
+          const up = _scrollAccum < 0;
+          _scrollAccum += up ? _SCROLL_STEP : -_SCROLL_STEP;
+          n++; _scrollBurstTicks++; emitted++;
+        }
+        if (_scrollBurstTicks >= _SCROLL_BURST_MAX) _scrollAccum = 0;
+      }
+      return emitted;
+    }
+
+    // Local PTY/tmux (herdrBackend=false): 40 notches @100px scale with distance,
+    // never freeze. Old cap of 6 would have frozen it after ~2 notches.
+    const local = runSpin(false, 40, 100);
+    expect(local).toBe(Math.floor((40 * 100) / 33)); // 121
+    expect(local).toBeGreaterThan(100);
+
+    // Herdr backend: still capped at 6 no matter how long the spin.
+    expect(runSpin(true, 40, 100)).toBe(6);
+    expect(runSpin(true, 2, 100)).toBe(6); // reaches cap within the first notches
   });
 
   it('uses local scrollback before requesting another remote history chunk', () => {


### PR DESCRIPTION
## 问题

网页终端里，运行在终端**备用屏**（alternate screen）的 CLI（如 Claude Code）鼠标滚轮上下滚动不丝滑——连续转两三格后就"卡住"，需要停顿一下才能继续。

## 根因

备用屏 CLI 在 xterm/tmux 里都不保留 scrollback，整个 transcript 由 CLI 自己在固定网格内重绘。所以网页端把滚轮事件通过 `_fwdScroll` 转成 SGR mouse-wheel 事件转发给 CLI 自行滚动重绘。

`_fwdScroll` 里有一段**整段手势封顶** `_SCROLL_BURST_MAX=6`（配合 250ms 空闲重置）。这段节流本是给转发代价高/无本地终端可驱动的后端设计的，却被**无差别套用到所有备用屏转发**，包括本地廉价重绘的 CLI：

- 一格滚轮 ≈ 100px，`_SCROLL_STEP=33px/tick`，即约 3 tick/格
- 封顶 6 tick ≈ 只能连续滚约 **2 格** 就冻结，必须等 250ms 空闲重置

## 修复

按**后端**决定是否放开封顶——用一个**正向白名单**，只有可廉价本地驱动的终端后端（pty/tmux/zellij）才放开：

```ts
const localTerminalBackend = effectiveBackendType === 'pty'
  || effectiveBackendType === 'tmux'
  || effectiveBackendType === 'zellij';
// 客户端 JS：
var _SCROLL_BURST_MAX = localTerminalBackend ? Infinity : 6;
```

- **本地终端后端（pty/tmux/zellij）**：放开为 `Infinity`,滚轮 tick 数与滚动距离成正比,不再冻结
- **Herdr**：每个转发 wheel → `pane send-text + snapshot` 重渲染,昂贵,**保持封顶 6**
- **Riff**：没有可驱动终端,`RiffBackend.write()` 会把输入创建成远端 task/follow-up（`handleTermAction` 甚至拒绝向 Riff 写 ANSI 控制字符）,**保持封顶 6**,避免远端任务洪泛
- **未来任何新增/未知后端**：不在白名单即默认封顶 6（fail-safe）

单个浏览器 wheel 事件内的 `n<6` 上限**保留**,防止单次超大 delta 一口气灌爆;手势方向反转 / 空闲重置逻辑不变。`remoteScroll`（= backend 是 Herdr && altScreen===true）只保留原本的本地 scrollback / 远端滚动路由职责,不再参与封顶判定。

## 影响面评估

- **改动位置**：仅 `getTerminalHtml` 生成的客户端 JS 字符串 + 其上游 gate 计算,位于备用屏滚轮/触摸转发路径
- **跨 CLI**：备用屏 CLI（Claude / Codex / OpenCode 等）在本地终端后端上均受益;普通屏 CLI 走 xterm 原生 scrollback（`_canScrollLocal` 分支），本次不涉及
- **跨后端**：pty/tmux/zellij 放开;Herdr、Riff 及未知后端保持封顶——行为不变、无洪泛风险
- **altScreen 解耦**：封顶按后端判定,与适配器声明的 altScreen 无关——altScreen:false 的 CLI（Claude/Codex）运行时进入 alternate buffer（vim/less 或 CLI 自身 alt-screen）时,仍继承其后端的封顶策略
- **跨平台**：纯客户端逻辑,macOS / Linux 一致
- **tmux/zellij 纯 attach 模式（gate）**：不接线滚轮转发,不受影响

## 测试验证

```
$ pnpm vitest run test/web-terminal-touch-scroll.test.ts
 ✓ test/web-terminal-touch-scroll.test.ts (10 tests)
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

关键测试（在既有 8 个基础上新增 2 个）：
- 断言封顶 gate 在 `localTerminalBackend`（正向 pty/tmux/zellij 白名单），并显式 guard gate 内不出现 `'herdr'`/`'riff'`
- 行为测试**从生成的客户端 JS 里正则抽取 cap 表达式**（`localTerminalBackend?Infinity:6`）再按后端 eval 求值（表达式一变测试即挂）：
  - pty / tmux / zellij 各跑 40 格 @100px → **121 tick**（与距离成正比,不冻结）
  - **Herdr 和 Riff** 同样 40 格 → **仍封顶 6**,2 格内即达顶

`npx tsc`：错误数与 master 完全一致（28 个,全部在 `src/desktop/`,因本机未装 electron,属既有环境限制,与本改动无关）。

> 注：本机 daemon 跑的是全局 npm 安装版而非本 checkout,且滚轮丝滑度是主观手感,建议 reviewer 合并后在飞书 web 终端实测确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)