### PR TITLE
fix(dashboard): Bot 配置页新增机器人后自动刷新

### DIFF
--- a/src/core/dashboard-events.ts
+++ b/src/core/dashboard-events.ts
@@ -11,6 +11,7 @@ export type DashboardEvent =
   | { type: 'schedule.deleted';  body: { id: string } }
   | { type: 'schedule.fired';    body: { id: string; runAt: number; status: 'ok'|'error'; error?: string } }
   | { type: 'schedule.timezone'; body: { timezone: string } }
+  | { type: 'bots.changed';      body: { signature: string } }
   | { type: 'heartbeat';         body: { ts: number } };
 
 export type Subscriber = (event: DashboardEvent) => void;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -17,7 +17,7 @@ import {
   generateToken, parseCookie, buildSetCookie, verifyHmac, cliAuthBind, decideDashboardAuth,
   loadPersistedToken, persistToken, loadDashboardSecret, loadOrCreateDashboardSecret,
 } from './dashboard/auth.js';
-import { DaemonRegistry } from './dashboard/registry.js';
+import { DaemonRegistry, botsRosterSignature } from './dashboard/registry.js';
 import { Aggregator, subscribeDaemon } from './dashboard/aggregator.js';
 import { pickCreatorForGroup } from './dashboard/operator-selector.js';
 import { buildTeamGroupCreatePayload, planGroupCreator } from './dashboard/team-group.js';
@@ -4445,7 +4445,19 @@ const server = createServer(async (req, res) => {
       const hb = setInterval(() => {
         res.write(`event: heartbeat\ndata: ${JSON.stringify({ ts: Date.now() })}\n\n`);
       }, 15_000);
-      res.on('close', () => { off(); clearInterval(hb); });
+      // Push a bots.changed frame whenever the online bot roster actually
+      // changes (bot added / removed / renamed / re-indexed) so the Bot 配置
+      // page can auto-refresh without a manual reload. registry.on fires on
+      // every 15s poll and 30s heartbeat rewrite, so gate on a roster signature
+      // that ignores lastHeartbeat — otherwise we'd spam a frame every poll.
+      let lastRoster = botsRosterSignature(registry.list());
+      const offRoster = registry.on(online => {
+        const sig = botsRosterSignature(online);
+        if (sig === lastRoster) return;
+        lastRoster = sig;
+        res.write(`event: bots.changed\ndata: ${JSON.stringify({ body: { signature: sig } })}\n\n`);
+      });
+      res.on('close', () => { off(); offRoster(); clearInterval(hb); });
       return;
     }
 

--- a/src/dashboard/registry.ts
+++ b/src/dashboard/registry.ts
@@ -31,6 +31,20 @@ const DEFAULT_REFRESH_MS = 15_000;
 
 export type RegistryListener = (online: DaemonInfo[]) => void;
 
+/**
+ * Stable roster fingerprint used to tell a real roster change (bot added /
+ * removed / renamed / re-indexed) apart from the 15s no-op poll and the 30s
+ * heartbeat rewrites. Only fields the dashboard's Bot 配置 list keys off of are
+ * included — a pure heartbeat bump (lastHeartbeat) must NOT change it, or the
+ * `/events` bots.changed emitter would fire every poll. Order-independent.
+ */
+export function botsRosterSignature(online: DaemonInfo[]): string {
+  return [...online]
+    .map(d => `${d.larkAppId}:${d.botName ?? ''}:${d.cliId ?? ''}:${d.botIndex}`)
+    .sort()
+    .join('|');
+}
+
 export interface DaemonRegistryOptions {
   refreshIntervalMs?: number;
 }

--- a/src/dashboard/web/bot-defaults-page.tsx
+++ b/src/dashboard/web/bot-defaults-page.tsx
@@ -3,6 +3,7 @@ import { openBotOnboarding } from './bot-onboarding.js';
 import {
   agentSelectionKey,
   cliIdOf,
+  createRefreshGate,
   displayCliId,
   fallbackCliOptionsState,
   fetchBotDefaults,
@@ -269,9 +270,13 @@ function patchCardPrefsFromBody(bot: BotDefaultsRow, body: any): BotDefaultsRow 
   };
 }
 
-function BotDefaultsPage() {
+export function BotDefaultsPage() {
   const tr = useT();
   const mountedRef = useRef(true);
+  // Latest-wins guard: mount's first refresh() and bots.changed-triggered
+  // refresh()es can overlap, so a slow earlier response must not clobber a
+  // newer roster ("后发先回"). Only the latest in-flight request commits.
+  const refreshGateRef = useRef(createRefreshGate());
   const [bots, setBots] = useState<BotDefaultsRow[]>([]);
   const [cliState, setCliState] = useState<CliOptionsState>(fallbackCliOptionsState);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -285,15 +290,21 @@ function BotDefaultsPage() {
 
   const refresh = useCallback(async (clearProfileRoles = false) => {
     if (clearProfileRoles) setProfileRoleVersion(version => version + 1);
+    const req = refreshGateRef.current.begin();
     setLoading(true);
     try {
       const [nextBots, nextCli] = await Promise.all([fetchBotDefaults(), fetchCliOptions()]);
-      if (!mountedRef.current) return;
+      // Drop a stale response: a newer refresh() started after us (e.g. a
+      // bots.changed fired while this request was in flight) — committing here
+      // would overwrite the fresher roster and re-hide the new bot.
+      if (!mountedRef.current || !req.commit()) return;
       setBots(nextBots.bots);
       setLoadError(nextBots.error);
       setCliState(nextCli);
     } finally {
-      if (mountedRef.current) setLoading(false);
+      // Only the latest request owns the loading flag — an out-of-order earlier
+      // response must not flip loading off while the newest is still pending.
+      if (mountedRef.current && req.commit()) setLoading(false);
     }
   }, []);
 

--- a/src/dashboard/web/bot-defaults-page.tsx
+++ b/src/dashboard/web/bot-defaults-page.tsx
@@ -19,6 +19,7 @@ import {
 } from './bot-defaults.js';
 import { mountReactPage, type PageDisposer } from './react-mount.js';
 import { useT } from './react-hooks.js';
+import { store } from './store.js';
 import {
   CreateActionButton,
   DropdownMenu,
@@ -302,7 +303,14 @@ function BotDefaultsPage() {
     void loadNameMaps().then(() => {
       if (mountedRef.current) setAvatarVersion(value => value + 1);
     });
-    return () => { mountedRef.current = false; };
+    // Auto-refresh the roster when a bot is added / removed / renamed on the
+    // daemon side (SSE bots.changed), so the list stays live without a manual
+    // reload. The bot rows carry their own botName/cliId from /api/bots, so a
+    // plain refresh() is enough to surface a freshly-added bot.
+    const offBots = store.onBotsChanged(() => {
+      if (mountedRef.current) void refresh();
+    });
+    return () => { mountedRef.current = false; offBots(); };
   }, [refresh]);
 
   const filtered = useMemo(() => {

--- a/src/dashboard/web/bot-defaults.ts
+++ b/src/dashboard/web/bot-defaults.ts
@@ -139,6 +139,26 @@ export function modelSuggestionsForOption(opt: CliOption | undefined, cliState: 
   return [];
 }
 
+/**
+ * Latest-wins guard for overlapping async refreshes. The Bot 配置 page fires an
+ * initial refresh on mount and another on every `bots.changed` SSE event; these
+ * can overlap, and a slow earlier `/api/bots` response arriving *after* a newer
+ * one ("后发先回") would otherwise clobber the fresher roster and re-hide a
+ * just-added bot. Each call bumps a monotonic counter and hands back a `commit`
+ * predicate that is only true while this call is still the newest — the caller
+ * gates BOTH its state write and its `loading=false` on it. Kept as a tiny
+ * pure factory so the race is unit-testable without a DOM.
+ */
+export function createRefreshGate(): { begin(): { commit(): boolean } } {
+  let latest = 0;
+  return {
+    begin() {
+      const seq = ++latest;
+      return { commit: () => seq === latest };
+    },
+  };
+}
+
 export async function fetchBotDefaults(): Promise<LoadBotsResult> {
   try {
     const r = await fetch('/api/bots');

--- a/src/dashboard/web/store.ts
+++ b/src/dashboard/web/store.ts
@@ -27,6 +27,10 @@ class Store {
     scheduleTimeZone: this.scheduleTimeZone,
   };
   private listeners = new Set<() => void>();
+  // Bot roster changes don't live in this cache (the Bot 配置 page owns its own
+  // /api/bots fetch), so relay them through a dedicated listener set instead of
+  // bumping the snapshot version. Signature-deduped server-side.
+  private botsListeners = new Set<() => void>();
 
   setScheduleTimeZone(tz: string) {
     if (typeof tz === 'string' && tz && this.scheduleTimeZone !== tz) {
@@ -63,11 +67,17 @@ class Store {
       // Effective schedule timezone changed (settings save → daemon realign) —
       // re-render all schedule times in the new zone without a page reload.
       if (typeof body?.timezone === 'string' && body.timezone) this.scheduleTimeZone = body.timezone;
+    } else if (type === 'bots.changed') {
+      // Bot roster changed (bot added / removed / renamed). Notify subscribers
+      // so the Bot 配置 page re-fetches /api/bots without a manual refresh.
+      for (const fn of this.botsListeners) fn();
+      return; // no snapshot mutation — bots aren't cached here
     } else {
       return; // heartbeat / schedule.fired — no cache mutation
     }
     this.emit();
   }
+  onBotsChanged(fn: () => void) { this.botsListeners.add(fn); return () => this.botsListeners.delete(fn); }
   setOnline(v: boolean) {
     if (this.online !== v) { this.online = v; this.emit(); }
   }
@@ -101,7 +111,7 @@ export async function bootstrap() {
   const types = [
     'session.spawned', 'session.update', 'session.exited',
     'schedule.created', 'schedule.updated', 'schedule.deleted',
-    'schedule.fired', 'schedule.timezone', 'heartbeat',
+    'schedule.fired', 'schedule.timezone', 'bots.changed', 'heartbeat',
   ];
   for (const t of types) {
     es.addEventListener(t, e => {

--- a/test/dashboard-bot-defaults-refresh-race.test.ts
+++ b/test/dashboard-bot-defaults-refresh-race.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { createRefreshGate } from '../src/dashboard/web/bot-defaults.js';
+
+// Deferred promise helper: lets the test resolve two overlapping "requests"
+// in an arbitrary order to reproduce 后发先回 (a slow earlier request that
+// returns AFTER a newer one).
+function defer<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>(r => { resolve = r; });
+  return { promise, resolve };
+}
+
+describe('createRefreshGate (bot-defaults latest-wins)', () => {
+  it('lets a single request commit', async () => {
+    const gate = createRefreshGate();
+    const req = gate.begin();
+    expect(req.commit()).toBe(true);
+  });
+
+  it('invalidates an earlier request once a newer one begins', () => {
+    const gate = createRefreshGate();
+    const first = gate.begin();
+    const second = gate.begin();
+    // second is now newest — first must no longer commit, second may.
+    expect(first.commit()).toBe(false);
+    expect(second.commit()).toBe(true);
+  });
+
+  it('drops the stale (后发先回) response and keeps the newest roster', async () => {
+    const gate = createRefreshGate();
+
+    // Request A = initial mount refresh (returns the OLD single-bot roster).
+    // Request B = bots.changed refresh (returns the NEW two-bot roster).
+    const aResp = defer<string[]>();
+    const bResp = defer<string[]>();
+
+    let committed: string[] | null = null;
+    const runA = (async () => {
+      const req = gate.begin();
+      const roster = await aResp.promise;
+      if (req.commit()) committed = roster;
+    })();
+    const runB = (async () => {
+      const req = gate.begin();
+      const roster = await bResp.promise;
+      if (req.commit()) committed = roster;
+    })();
+
+    // Newest (B) returns FIRST with the fresh roster and commits.
+    bResp.resolve(['botA', 'botB']);
+    await runB;
+    expect(committed).toEqual(['botA', 'botB']);
+
+    // Stale (A) returns LATE with the old roster — must be dropped, not clobber.
+    aResp.resolve(['botA']);
+    await runA;
+    expect(committed).toEqual(['botA', 'botB']);
+  });
+
+  it('commit() re-checks live, so a request invalidated mid-flight cannot flip loading off', () => {
+    const gate = createRefreshGate();
+    const first = gate.begin();
+    expect(first.commit()).toBe(true); // still newest before B starts
+    gate.begin();                      // B begins → first is now stale
+    expect(first.commit()).toBe(false); // both the state write AND loading gate see false
+  });
+});

--- a/test/dashboard-bots-roster-signature.test.ts
+++ b/test/dashboard-bots-roster-signature.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { botsRosterSignature } from '../src/dashboard/registry.js';
+import type { DaemonInfo } from '../src/dashboard/registry.js';
+
+function daemon(over: Partial<DaemonInfo> & { larkAppId: string }): DaemonInfo {
+  return {
+    botName: over.larkAppId,
+    botIndex: 0,
+    ipcPort: 7890,
+    pid: 1,
+    startedAt: 1_000,
+    lastHeartbeat: 1_000,
+    ...over,
+  } as DaemonInfo;
+}
+
+describe('botsRosterSignature', () => {
+  it('is stable across pure heartbeat bumps (no false bots.changed)', () => {
+    const a = [daemon({ larkAppId: 'appA', lastHeartbeat: 1_000 })];
+    const b = [daemon({ larkAppId: 'appA', lastHeartbeat: 99_000 })];
+    expect(botsRosterSignature(a)).toBe(botsRosterSignature(b));
+  });
+
+  it('is order-independent', () => {
+    const a = [daemon({ larkAppId: 'appA', botIndex: 0 }), daemon({ larkAppId: 'appB', botIndex: 1 })];
+    const b = [daemon({ larkAppId: 'appB', botIndex: 1 }), daemon({ larkAppId: 'appA', botIndex: 0 })];
+    expect(botsRosterSignature(a)).toBe(botsRosterSignature(b));
+  });
+
+  it('changes when a new bot is added', () => {
+    const before = [daemon({ larkAppId: 'appA' })];
+    const after = [daemon({ larkAppId: 'appA' }), daemon({ larkAppId: 'appB', botIndex: 1 })];
+    expect(botsRosterSignature(before)).not.toBe(botsRosterSignature(after));
+  });
+
+  it('changes when a bot is removed', () => {
+    const before = [daemon({ larkAppId: 'appA' }), daemon({ larkAppId: 'appB', botIndex: 1 })];
+    const after = [daemon({ larkAppId: 'appA' })];
+    expect(botsRosterSignature(before)).not.toBe(botsRosterSignature(after));
+  });
+
+  it('changes when a bot is renamed', () => {
+    const before = [daemon({ larkAppId: 'appA', botName: 'Old' })];
+    const after = [daemon({ larkAppId: 'appA', botName: 'New' })];
+    expect(botsRosterSignature(before)).not.toBe(botsRosterSignature(after));
+  });
+
+  it('changes when a bot cliId changes', () => {
+    const before = [daemon({ larkAppId: 'appA', cliId: 'claude-code' })];
+    const after = [daemon({ larkAppId: 'appA', cliId: 'codex' })];
+    expect(botsRosterSignature(before)).not.toBe(botsRosterSignature(after));
+  });
+});


### PR DESCRIPTION
## 问题
Dashboard「Bot 配置」页只在挂载时 `fetch('/api/bots')` 一次，无任何 live 更新。新增机器人上线后，用户必须**手动点「刷新」或重载页面**才能看到（issue 复现：新加 bot → 页面不动）。

## 根因
Dashboard 的 SSE `/events` 流只携带 `session.*` / `schedule.*` 事件，**没有任何 bot 名册级事件**。虽然 `DaemonRegistry` 已通过 `fs.watch` + 15s 轮询感知到新 daemon 描述文件并触发 `registry.on(...)`，但这个信号从未推送到浏览器。

## 修复（对齐 sessions 的 live-update 模式）
- `core/dashboard-events.ts`：`DashboardEvent` 联合类型新增 `bots.changed`
- `dashboard/registry.ts`：新增 `botsRosterSignature()` 生成名册指纹（只含 `larkAppId/botName/cliId/botIndex`，**忽略 `lastHeartbeat`**），用于区分真实名册变更与 15s 空轮询 / 30s 心跳重写
- `dashboard.ts` `/events`：订阅 `registry.on`，按 signature 去重后写 `bots.changed` 帧（否则每次轮询都会刷帧）；`res` close 时解绑监听
- `dashboard/web/store.ts`：新增 `onBotsChanged` 监听器集合 + `applySse` 分支；`bootstrap` 事件列表加入 `bots.changed`
- `dashboard/web/bot-defaults-page.tsx`：订阅 `store.onBotsChanged`，收到即 `refresh()`

## 影响面评估
- **仅动 dashboard 层**（core 事件类型 / 聚合注册表 / 前端 store / Bot 配置页），不触碰 CLI 适配器共用基类、后端类型（Pty/Tmux）、IM 平台逻辑 → 跨 CLI / 跨后端 / 跨平台无回归面
- **跨平台**：`registry` 的 `fs.watch` + 轮询在 Linux（daemon 实际运行处）已有测试覆盖
- **向后兼容**：`bots.changed` 是纯增量事件，旧客户端忽略未知事件类型
- **不刷屏**：signature 去重确保只有真实名册变更（增/删/改名/换 CLI）才推帧

## 测试
- 新增 `test/dashboard-bots-roster-signature.test.ts`（6 例）：心跳不变、顺序无关、新增/移除/重命名/换 CLI 触发变更
- 相关套件全绿：`dashboard-{bots-roster-signature,registry,events,aggregator,endpoint}` 共 **40 例通过**
- `tsc --noEmit`：改动文件**零类型错误**（仓库既有 desktop/electron 报错为本机未装 electron 所致，与本改动无关，已确认 clean HEAD 上同样存在）
- `pnpm dashboard:bundle`：前端 esbuild 打包成功

> ⚠️ live 手动验证（飞书里新增 bot 观察 dashboard 自动刷新）尚未在 live daemon 跑，需要时可 `pnpm switch:here && pnpm daemon:restart` 后实测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)