### PR TITLE
fix(cli): 修复 Dashboard 配置未读取 .env

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -83,7 +83,7 @@ import { firstPositional } from './cli/arg-utils.js';
 import { isColdResumeDormant, sessionListDisposition } from './cli/session-list-liveness.js';
 import { dispatchPrimaryMessage, findStdinAliasAttachment, normalizeInteractiveCardInput, sendFileAttachments, sendVideoAttachments, shouldSendAsPureVideo, validateVideoAttachments } from './cli/send-dispatch.js';
 import { dispatchDeferredTopicSend, type DeferredScheduleRunData } from './cli/deferred-topic-send.js';
-import { resolveDaemonExternalHostEnv } from './cli/daemon-lifecycle-env.js';
+import { resolveDaemonEnv } from './cli/daemon-lifecycle-env.js';
 import { buildPm2SpawnCommand } from './cli/pm2-command.js';
 import { callDashboard, type DashboardEndpoint, type DashboardResult } from './cli/dashboard-endpoint.js';
 import { globalInstallUpdateLockTargetIn, installLatestBotmuxSync } from './core/maintenance.js';
@@ -399,7 +399,7 @@ function ecosystemConfig(): string {
   const daemonScript = join(PKG_ROOT, 'dist', 'index-daemon.js');
   const bots = loadBotsJson();
   ensureUniqueBotProcessNames(bots);
-  const externalHostEnv = resolveDaemonExternalHostEnv(
+  const daemonEnv = resolveDaemonEnv(
     process.env,
     existsSync(ENV_FILE) ? readFileSync(ENV_FILE, 'utf-8') : undefined,
   );
@@ -444,7 +444,7 @@ function ecosystemConfig(): string {
     error_file: join(LOG_DIR, `daemon-${i}-error.log`),
     out_file: join(LOG_DIR, `daemon-${i}-out.log`),
     env: {
-      ...externalHostEnv,
+      ...daemonEnv,
       SESSION_DATA_DIR: DATA_DIR,
       BOTMUX_BOT_INDEX: String(i),
       // Native-memory diagnostics. Default off; operator can flip it on
@@ -470,15 +470,13 @@ function ecosystemConfig(): string {
     out_file: join(LOG_DIR, 'dashboard-out.log'),
     merge_logs: true,
     env: {
-      ...externalHostEnv,
+      ...daemonEnv,
       // MUST match the bot daemons' SESSION_DATA_DIR: the dashboard shares
       // pairings/federations/memberships with them via {dataDir}/*.json. Without
       // it the dashboard falls back to an install-relative ../data and reads a
       // DIFFERENT store → /pair「配对码无效」, auto-bind hubsSynced:0,
       // remote-group not_a_member (cross-deployment 拉群 silently broken).
       SESSION_DATA_DIR: DATA_DIR,
-      BOTMUX_DASHBOARD_HOST: process.env.BOTMUX_DASHBOARD_HOST ?? '0.0.0.0',
-      BOTMUX_DASHBOARD_PORT: process.env.BOTMUX_DASHBOARD_PORT ?? '7891',
     },
   });
 

--- a/src/cli/daemon-lifecycle-env.ts
+++ b/src/cli/daemon-lifecycle-env.ts
@@ -1,24 +1,26 @@
 import { parse } from 'dotenv';
 
-const EXTERNAL_HOST_KEYS = [
+const DAEMON_ENV_KEYS = [
   'WEB_EXTERNAL_HOST',
   'BOTMUX_DASHBOARD_EXTERNAL_HOST',
+  'BOTMUX_DASHBOARD_HOST',
+  'BOTMUX_DASHBOARD_PORT',
+  'BOTMUX_DAEMON_IPC_BASE_PORT',
+  'BOTMUX_DASHBOARD_PUBLIC_READONLY',
 ] as const;
 
 /**
- * Pin both PM2 apps to one deterministic external-host snapshot. A lifecycle
- * command launched inside a botmux session inherited its values from the old
- * daemon, so only the persisted .env is authoritative in that context. Empty
- * strings deliberately override PM2's inherited env and mean "auto-detect" in
- * config.ts.
+ * Pin both PM2 apps to one deterministic ~/.botmux/.env snapshot. A restart
+ * launched inside a botmux session inherited its values from the old daemon,
+ * so only the persisted file is authoritative in that context.
  */
-export function resolveDaemonExternalHostEnv(
+export function resolveDaemonEnv(
   inheritedEnv: NodeJS.ProcessEnv,
   envFileText?: string,
-): Record<(typeof EXTERNAL_HOST_KEYS)[number], string> {
+): Record<(typeof DAEMON_ENV_KEYS)[number], string> {
   const fileEnv = envFileText === undefined ? {} : parse(envFileText);
   const sessionOrigin = Boolean(inheritedEnv.BOTMUX_SESSION_ID?.trim());
-  const resolve = (key: (typeof EXTERNAL_HOST_KEYS)[number]): string => {
+  const resolve = (key: (typeof DAEMON_ENV_KEYS)[number]): string => {
     const value = sessionOrigin ? fileEnv[key] : inheritedEnv[key] ?? fileEnv[key];
     return value?.trim() ?? '';
   };
@@ -26,5 +28,9 @@ export function resolveDaemonExternalHostEnv(
   return {
     WEB_EXTERNAL_HOST: resolve('WEB_EXTERNAL_HOST'),
     BOTMUX_DASHBOARD_EXTERNAL_HOST: resolve('BOTMUX_DASHBOARD_EXTERNAL_HOST'),
+    BOTMUX_DASHBOARD_HOST: resolve('BOTMUX_DASHBOARD_HOST') || '0.0.0.0',
+    BOTMUX_DASHBOARD_PORT: resolve('BOTMUX_DASHBOARD_PORT'),
+    BOTMUX_DAEMON_IPC_BASE_PORT: resolve('BOTMUX_DAEMON_IPC_BASE_PORT'),
+    BOTMUX_DASHBOARD_PUBLIC_READONLY: resolve('BOTMUX_DASHBOARD_PUBLIC_READONLY'),
   };
 }

--- a/src/core/maintenance.ts
+++ b/src/core/maintenance.ts
@@ -246,9 +246,15 @@ export function buildRestartLauncher(
 export function detachedRestartEnv(inheritedEnv: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
   const env = { ...inheritedEnv };
   // The dashboard/daemon snapshot may outlive a ~/.botmux/.env edit. Let the
-  // fresh lifecycle CLI resolve these two settings from the file again.
-  delete env.WEB_EXTERNAL_HOST;
-  delete env.BOTMUX_DASHBOARD_EXTERNAL_HOST;
+  // fresh CLI reload these settings from the file.
+  for (const key of [
+    'WEB_EXTERNAL_HOST',
+    'BOTMUX_DASHBOARD_EXTERNAL_HOST',
+    'BOTMUX_DASHBOARD_HOST',
+    'BOTMUX_DASHBOARD_PORT',
+    'BOTMUX_DAEMON_IPC_BASE_PORT',
+    'BOTMUX_DASHBOARD_PUBLIC_READONLY',
+  ]) delete env[key];
   return env;
 }
 

--- a/test/daemon-lifecycle-env.test.ts
+++ b/test/daemon-lifecycle-env.test.ts
@@ -1,53 +1,95 @@
 import { describe, expect, it } from 'vitest';
-import { resolveDaemonExternalHostEnv } from '../src/cli/daemon-lifecycle-env.js';
+import { resolveDaemonEnv } from '../src/cli/daemon-lifecycle-env.js';
 
-describe('resolveDaemonExternalHostEnv()', () => {
-  it('clears inherited host settings when restart comes from a botmux session', () => {
-    expect(resolveDaemonExternalHostEnv({
+describe('resolveDaemonEnv()', () => {
+  it('clears inherited settings when restart comes from a botmux session', () => {
+    expect(resolveDaemonEnv({
       BOTMUX_SESSION_ID: 'session-1',
       WEB_EXTERNAL_HOST: '10.255.64.131',
       BOTMUX_DASHBOARD_EXTERNAL_HOST: '10.255.64.131',
+      BOTMUX_DASHBOARD_HOST: '10.255.64.131',
+      BOTMUX_DASHBOARD_PORT: '9999',
+      BOTMUX_DAEMON_IPC_BASE_PORT: '9998',
+      BOTMUX_DASHBOARD_PUBLIC_READONLY: 'false',
     })).toEqual({
       WEB_EXTERNAL_HOST: '',
       BOTMUX_DASHBOARD_EXTERNAL_HOST: '',
+      BOTMUX_DASHBOARD_HOST: '0.0.0.0',
+      BOTMUX_DASHBOARD_PORT: '',
+      BOTMUX_DAEMON_IPC_BASE_PORT: '',
+      BOTMUX_DASHBOARD_PUBLIC_READONLY: '',
     });
   });
 
-  it('reloads explicit host settings from .env for a session-origin restart', () => {
-    expect(resolveDaemonExternalHostEnv({
+  it('reloads explicit settings from .env for a session-origin restart', () => {
+    expect(resolveDaemonEnv({
       BOTMUX_SESSION_ID: 'session-1',
       WEB_EXTERNAL_HOST: 'stale.example.com',
+      BOTMUX_DASHBOARD_HOST: '0.0.0.0',
+      BOTMUX_DASHBOARD_PORT: '7891',
     }, [
       'WEB_EXTERNAL_HOST=relay.example.com',
       'BOTMUX_DASHBOARD_EXTERNAL_HOST=dashboard.example.com',
+      'BOTMUX_DASHBOARD_HOST=127.0.0.1',
+      'BOTMUX_DASHBOARD_PORT=7991',
+      'BOTMUX_DAEMON_IPC_BASE_PORT=7992',
+      'BOTMUX_DASHBOARD_PUBLIC_READONLY=false',
     ].join('\n'))).toEqual({
       WEB_EXTERNAL_HOST: 'relay.example.com',
       BOTMUX_DASHBOARD_EXTERNAL_HOST: 'dashboard.example.com',
+      BOTMUX_DASHBOARD_HOST: '127.0.0.1',
+      BOTMUX_DASHBOARD_PORT: '7991',
+      BOTMUX_DAEMON_IPC_BASE_PORT: '7992',
+      BOTMUX_DASHBOARD_PUBLIC_READONLY: 'false',
     });
   });
 
   it('keeps ordinary shell overrides ahead of .env', () => {
-    expect(resolveDaemonExternalHostEnv({
+    expect(resolveDaemonEnv({
       WEB_EXTERNAL_HOST: 'shell.example.com',
+      BOTMUX_DASHBOARD_HOST: '127.0.0.2',
+      BOTMUX_DASHBOARD_PORT: '7992',
+      BOTMUX_DAEMON_IPC_BASE_PORT: '7993',
+      BOTMUX_DASHBOARD_PUBLIC_READONLY: 'false',
     }, [
       'WEB_EXTERNAL_HOST=file.example.com',
       'BOTMUX_DASHBOARD_EXTERNAL_HOST=dashboard.example.com',
+      'BOTMUX_DASHBOARD_HOST=127.0.0.1',
+      'BOTMUX_DASHBOARD_PORT=7991',
+      'BOTMUX_DAEMON_IPC_BASE_PORT=7992',
+      'BOTMUX_DASHBOARD_PUBLIC_READONLY=true',
     ].join('\n'))).toEqual({
       WEB_EXTERNAL_HOST: 'shell.example.com',
       BOTMUX_DASHBOARD_EXTERNAL_HOST: 'dashboard.example.com',
+      BOTMUX_DASHBOARD_HOST: '127.0.0.2',
+      BOTMUX_DASHBOARD_PORT: '7992',
+      BOTMUX_DAEMON_IPC_BASE_PORT: '7993',
+      BOTMUX_DASHBOARD_PUBLIC_READONLY: 'false',
     });
   });
 
-  it('lets an ordinary shell explicitly clear persisted host settings', () => {
-    expect(resolveDaemonExternalHostEnv({
+  it('lets an ordinary shell explicitly clear persisted settings', () => {
+    expect(resolveDaemonEnv({
       WEB_EXTERNAL_HOST: '',
       BOTMUX_DASHBOARD_EXTERNAL_HOST: '   ',
+      BOTMUX_DASHBOARD_HOST: '',
+      BOTMUX_DASHBOARD_PORT: '   ',
+      BOTMUX_DAEMON_IPC_BASE_PORT: '',
+      BOTMUX_DASHBOARD_PUBLIC_READONLY: '',
     }, [
       'WEB_EXTERNAL_HOST=file.example.com',
       'BOTMUX_DASHBOARD_EXTERNAL_HOST=dashboard.example.com',
+      'BOTMUX_DASHBOARD_HOST=127.0.0.1',
+      'BOTMUX_DASHBOARD_PORT=7991',
+      'BOTMUX_DAEMON_IPC_BASE_PORT=7992',
+      'BOTMUX_DASHBOARD_PUBLIC_READONLY=false',
     ].join('\n'))).toEqual({
       WEB_EXTERNAL_HOST: '',
       BOTMUX_DASHBOARD_EXTERNAL_HOST: '',
+      BOTMUX_DASHBOARD_HOST: '0.0.0.0',
+      BOTMUX_DASHBOARD_PORT: '',
+      BOTMUX_DAEMON_IPC_BASE_PORT: '',
+      BOTMUX_DASHBOARD_PUBLIC_READONLY: '',
     });
   });
 });

--- a/test/maintenance.test.ts
+++ b/test/maintenance.test.ts
@@ -193,10 +193,14 @@ describe('buildRestartLauncher', () => {
 });
 
 describe('detachedRestartEnv', () => {
-  it('drops runtime host snapshots before launching a managed restart', () => {
+  it('drops runtime env snapshots before launching a managed restart', () => {
     const inherited = {
       WEB_EXTERNAL_HOST: '10.255.64.131',
       BOTMUX_DASHBOARD_EXTERNAL_HOST: '10.255.64.131',
+      BOTMUX_DASHBOARD_HOST: '127.0.0.1',
+      BOTMUX_DASHBOARD_PORT: '7991',
+      BOTMUX_DAEMON_IPC_BASE_PORT: '7992',
+      BOTMUX_DASHBOARD_PUBLIC_READONLY: 'false',
       PATH: '/usr/bin',
     };
 


### PR DESCRIPTION
# fix(cli): 修复 Dashboard 配置未读取 .env

## 背景

Dashboard 由 PM2 直接启动，不经过会加载 `~/.botmux/.env` 的 daemon 入口。

原来的 ecosystem 配置只解析了：

- `WEB_EXTERNAL_HOST`
- `BOTMUX_DASHBOARD_EXTERNAL_HOST`

Dashboard 的绑定地址和端口则直接读取执行 `botmux restart` 时的进程环境。因此即使在 `~/.botmux/.env` 中设置：

```env
BOTMUX_DASHBOARD_HOST=127.0.0.1
```

执行：

```bash
botmux restart --include-pm2
```

后仍可能监听 `0.0.0.0`。

## 改动

扩展现有 `src/cli/daemon-lifecycle-env.ts`，统一解析 PM2 管理的 daemon/Dashboard 所需配置：

- `WEB_EXTERNAL_HOST`
- `BOTMUX_DASHBOARD_EXTERNAL_HOST`
- `BOTMUX_DASHBOARD_HOST`
- `BOTMUX_DASHBOARD_PORT`
- `BOTMUX_DAEMON_IPC_BASE_PORT`
- `BOTMUX_DASHBOARD_PUBLIC_READONLY`

生成 `ecosystem.config.json` 时只读取一次 `~/.botmux/.env`，并将结果同时传给 daemon 和 Dashboard。

managed restart 启动新 CLI 前也会清理继承自旧进程的这些环境变量，避免旧 daemon 的环境快照覆盖刚修改的 `.env`。

配置优先级保持原有语义：

- 普通 shell 执行命令：显式 shell 环境变量优先于 `.env`
- botmux 会话内触发 restart：以持久化 `.env` 为准，避免继承旧 daemon 快照

## 为什么不包含 `BOTMUX_WORKFLOW_RUNS_DIR`

实际调用链检查后，`BOTMUX_WORKFLOW_RUNS_DIR` 只由旧的 workflow archive CLI 使用：

```text
src/cli/workflow-run-archive.ts
```

当前 Dashboard 展示的 workflow v3 runs 使用独立的 `~/.botmux/v3-runs` 路径，并不读取该环境变量；daemon 的 workflow v3 执行路径同样不消费它。

因此，将 `BOTMUX_WORKFLOW_RUNS_DIR` 注入 PM2 env 并不会改变 Dashboard 或 daemon 的行为，反而会把旧 archive CLI 的配置语义混入本次 Dashboard 修复。

本 PR 只处理 PM2 管理进程实际消费的配置。若要让 workflow v3 runs 目录可配置，应单独定义其运行时契约和迁移行为。

## 影响面

涉及：

- CLI 生成 PM2 ecosystem 配置
- daemon/Dashboard managed restart 的环境清理

不涉及：

- CLI adapters
- PTY/Tmux 等会话后端
- workflow run 存储路径
- 飞书消息和卡片处理

## 验证

### 单元测试

```bash
pnpm exec vitest run test/daemon-lifecycle-env.test.ts test/maintenance.test.ts
```

结果：22/22 通过。

### 构建

```bash
pnpm build
```

结果：通过。

### 隔离端到端测试

使用临时 `HOME` 和独立 PM2，真实执行构建后的：

```bash
node dist/cli.js restart --include-pm2
```

验证过程：

1. `.env` 设置 `BOTMUX_DASHBOARD_HOST=0.0.0.0`、端口 `51659`
2. 实际进程监听 `*:51659`，HTTP 返回 200
3. 只修改 `.env` 为 `BOTMUX_DASHBOARD_HOST=127.0.0.1`、端口 `51660`
4. 再次执行 `restart --include-pm2`
5. 旧端口 `51659` 已关闭
6. 新进程只监听 `127.0.0.1:51660`，HTTP 返回 200
7. 生成的 ecosystem 配置同时正确包含 IPC base port、public readonly 和 external host