### PR TITLE
feat(worker): 只读 web 终端支持 Claude 家族备用屏滚轮滚动

### DIFF
--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -933,6 +933,12 @@ export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, rawBin: 
       : undefined,
     systemHints: [],
     altScreen: false,
+    // Claude & Seed render their transcript in the alternate screen at runtime
+    // (declared altScreen:false only because the FIRST frame is normal-buffer).
+    // Their mouse wheel is a pure transcript scroll, never bound to an action —
+    // safe to let the read-only web terminal scroll via the server-synthesized
+    // restricted wheel path. See CliAdapter.readonlyWheelScroll.
+    readonlyWheelScroll: true,
     // Skills are injected per-session via --plugin-dir (see buildArgs), NOT
     // installed into the global ~/.claude/skills — so they never leak into the
     // user's standalone `claude`. pluginDir is consumed by ensurePluginSkills.

--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -506,6 +506,12 @@ export interface ClaudeFamilyVariant {
   readonly authPaths?: readonly string[];
   /** Opt in only after this concrete fork passes the terminal contract. */
   readonly reliableTurnTerminal?: boolean;
+  /** Opt in to read-only web-terminal wheel scrolling (see
+   *  CliAdapter.readonlyWheelScroll). MUST be set explicitly per variant —
+   *  defaults to off — so a new fork calling this shared factory (e.g. relay)
+   *  does NOT silently inherit a security-sensitive capability. Only variants
+   *  whose alt-screen wheel is a pure scroll (claude-code, seed) enable it. */
+  readonly readonlyWheelScroll?: boolean;
 }
 
 export function createClaudeCodeAdapter(pathOverride?: string): CliAdapter {
@@ -520,6 +526,8 @@ export function createClaudeCodeAdapter(pathOverride?: string): CliAdapter {
     resumeBin: 'claude',
     dataDir: DEFAULT_CLAUDE_DATA_DIR,
     stateJsonPath: join(homedir(), '.claude.json'),
+    // 备用屏滚轮是纯滚动，只读 web 终端可安全走服务端受限滚轮路径。
+    readonlyWheelScroll: true,
     // alias（opus/sonnet/haiku）会被 Claude Code 解析成当前推荐的具体版本；具体 ID 锁版本。
     modelChoices: ['opus', 'sonnet', 'haiku', 'claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001'],
   }, pathOverride ?? 'claude');
@@ -933,12 +941,13 @@ export function createClaudeFamilyAdapter(variant: ClaudeFamilyVariant, rawBin: 
       : undefined,
     systemHints: [],
     altScreen: false,
-    // Claude & Seed render their transcript in the alternate screen at runtime
-    // (declared altScreen:false only because the FIRST frame is normal-buffer).
-    // Their mouse wheel is a pure transcript scroll, never bound to an action —
-    // safe to let the read-only web terminal scroll via the server-synthesized
-    // restricted wheel path. See CliAdapter.readonlyWheelScroll.
-    readonlyWheelScroll: true,
+    // Read-only web-terminal wheel scrolling. Per-variant opt-in (see
+    // ClaudeFamilyVariant.readonlyWheelScroll): claude-code & seed render their
+    // transcript in the alternate screen at runtime and their wheel is a pure
+    // scroll (never bound to an action), so it's safe to let the read-only
+    // viewer scroll via the server-synthesized restricted wheel path. A fork
+    // that reuses this factory without opting in (e.g. relay) stays off.
+    readonlyWheelScroll: variant.readonlyWheelScroll === true,
     // Skills are injected per-session via --plugin-dir (see buildArgs), NOT
     // installed into the global ~/.claude/skills — so they never leak into the
     // user's standalone `claude`. pluginDir is consumed by ensurePluginSkills.

--- a/src/adapters/cli/seed.ts
+++ b/src/adapters/cli/seed.ts
@@ -64,6 +64,8 @@ export function createSeedAdapter(pathOverride?: string): CliAdapter {
     // Seed's model set is gateway-defined, not the
     // Anthropic aliases — skip the setup model prompt; users pick via /model.
     modelChoices: undefined,
+    // 与 Claude Code 同源，备用屏滚轮是纯滚动，只读 web 终端可安全滚动。
+    readonlyWheelScroll: true,
   }, bin);
 }
 

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -349,6 +349,19 @@ export interface CliAdapter {
   /** Whether CLI uses alternate screen buffer */
   readonly altScreen: boolean;
 
+  /** Opt-in: allow the READ-ONLY web terminal (viewToken, no write capability)
+   *  to scroll this CLI's alternate-screen transcript. Alt-screen CLIs keep no
+   *  xterm/tmux scrollback, so the only way to scroll is forwarding SGR
+   *  mouse-wheel events to the CLI — normally forbidden for a view capability,
+   *  since mouse-protocol bytes can also encode clicks/drags an app may bind to
+   *  approvals. When true, the read-only client sends only a restricted
+   *  {type:'scroll',dir,lines} intent and the SERVER synthesizes a pure wheel
+   *  sequence (fixed button 64/65, server-clamped lines, server-owned centre
+   *  coordinate) — the client can never supply raw bytes, a click, or a
+   *  coordinate. Enable ONLY for CLIs where the wheel is purely a scroll and
+   *  never bound to a state-changing action (Claude family). Default: off. */
+  readonly readonlyWheelScroll?: boolean;
+
   /** Curated model candidates surfaced in `botmux setup`. When undefined the
    *  setup flow skips the model prompt for this CLI entirely (e.g. CLIs whose
    *  model is fixed or set via a config file we don't manage). The order is

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4016,6 +4016,34 @@ function exitTmuxScrollMode(): void {
   tmuxScrolledHalfPages = 0;
 }
 
+/**
+ * Server-side synthesis of a restricted mouse-wheel sequence for the READ-ONLY
+ * web terminal (see CliAdapter.readonlyWheelScroll). The read-only client sends
+ * only {dir, lines}; EVERYTHING that could encode a click, drag, release, key,
+ * or arbitrary coordinate is decided HERE, server-side:
+ *   • button is hard-coded to 64 (wheel-up) / 65 (wheel-down) — never a click
+ *   • the coordinate is the server-owned grid CENTRE (never client-supplied,
+ *     never (1,1)) so zone-routed TUIs still accept it
+ *   • line count is clamped to a small positive bound
+ * A view capability therefore cannot forge any event other than a bounded
+ * scroll. Returns '' if the request is malformed so callers forward nothing.
+ */
+function buildReadonlyWheelSequence(dir: unknown, lines: unknown): string {
+  if (dir !== 'up' && dir !== 'down') return '';
+  const n = typeof lines === 'number' && Number.isFinite(lines)
+    ? Math.max(1, Math.min(6, Math.floor(lines)))
+    : 1;
+  const cols = renderCols || PTY_COLS;
+  const rows = renderRows || PTY_ROWS;
+  const col = (cols >> 1) + 1; // grid centre, 1-based; never (1,1)
+  const row = (rows >> 1) + 1;
+  const button = dir === 'up' ? 64 : 65;
+  const coord = `${col};${row}`;
+  let seq = '';
+  for (let i = 0; i < n; i++) seq += `\x1b[<${button};${coord}M`;
+  return seq;
+}
+
 function handleTermAction(key: TermActionKey): void {
   // riff：没有远端终端可驱动——把控制字符 write 进 RiffBackend 会变成一个内容为
   // ANSI 序列的 follow-up 任务（^C 也不会 cancel 任务），必须整体拒绝。
@@ -7929,8 +7957,17 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
       const localTerminalBackend = effectiveBackendType === 'pty'
         || effectiveBackendType === 'tmux'
         || effectiveBackendType === 'zellij';
+      // Read-only wheel scrolling: opt-in per adapter (Claude family). Lets a
+      // viewToken client scroll the CLI's alt-screen transcript WITHOUT gaining
+      // byte-forwarding — the client sends a restricted {type:'scroll'} intent
+      // and the server synthesizes a pure wheel sequence. Off for every other
+      // CLI, so their read-only views still forward zero input. Gated to the
+      // shared relay (PtyBackend / tmux-pipe) path Claude actually runs on;
+      // tmux/zellij attach own their own copy-mode scrolling.
+      const readonlyWheelScroll = cliAdapter?.readonlyWheelScroll === true
+        && !(isTmuxMode && !isPipeMode);
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-      res.end(getTerminalHtml(hasWrite, platformReadonly, loginUrl, forceRemoteScroll, localTerminalBackend));
+      res.end(getTerminalHtml(hasWrite, platformReadonly, loginUrl, forceRemoteScroll, localTerminalBackend, readonlyWheelScroll));
     });
 
     wss = new WebSocketServer({
@@ -8181,6 +8218,19 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
                 else if (msg.data.includes('\x1b[<65;')) herdrWebScrollDirection = 'down';
               }
               backend?.write(msg.data);
+            } else if (msg.type === 'scroll') {
+              // RESTRICTED read-only scroll intent (see readonlyWheelScroll). Unlike
+              // 'input', this is allowed WITHOUT write capability — but the client
+              // supplied only {dir, lines}; the server synthesizes the actual bytes,
+              // so no click/drag/coordinate can be forged. Gated to adapters that
+              // opted in; ignored entirely otherwise.
+              if (cliAdapter?.readonlyWheelScroll !== true) return;
+              const seq = buildReadonlyWheelSequence(msg.dir, msg.lines);
+              if (!seq) return;
+              if (usesHerdrSnapshotWebHistory()) {
+                herdrWebScrollDirection = msg.dir === 'up' ? 'up' : 'down';
+              }
+              backend?.write(seq);
             }
           } catch { /* ignore non-JSON or bad messages */ }
         });
@@ -8212,6 +8262,7 @@ function getTerminalHtml(
   loginUrl = '',
   forceRemoteScroll = false,
   localTerminalBackend = false,
+  readonlyWheelScroll = false,
 ): string {
   const label = sessionId.substring(0, 8);
   return `<!DOCTYPE html>
@@ -8350,6 +8401,7 @@ var hasToken=${hasWrite};
 var platformReadonly=${platformReadonly};
 var remoteScroll=${forceRemoteScroll};
 var localTerminalBackend=${localTerminalBackend};
+var readonlyWheelScroll=${readonlyWheelScroll};
 if(!hasToken){
   if(platformReadonly){var _lb=document.getElementById('login-banner');_lb.classList.add('show');}
   else{var _rb=document.getElementById('readonly-banner');_rb.classList.add('show');_rb.addEventListener('click',function(){_rb.classList.remove('show')});}
@@ -8634,7 +8686,17 @@ if(!${isTmuxMode && !isPipeMode}){
       return;
     }
     if(!hasToken){
-      e.preventDefault();e.stopPropagation();term.scrollLines(e.deltaY>0?3:-3);return;
+      e.preventDefault();e.stopPropagation();
+      // Alt-screen read-only: no local scrollback to move. If the CLI opted into
+      // read-only wheel scrolling, send a RESTRICTED intent (direction + a small
+      // line count only). We never send raw mouse bytes here — the server owns
+      // button/coordinate synthesis, so a view capability can't forge a click.
+      if(readonlyWheelScroll&&ws_&&ws_.readyState===1&&px){
+        var _lines=Math.max(1,Math.min(6,Math.round(Math.abs(px)/33)));
+        ws_.send(JSON.stringify({type:'scroll',dir:px<0?'up':'down',lines:_lines}));
+        return;
+      }
+      term.scrollLines(e.deltaY>0?3:-3);return;
     }
     e.preventDefault();e.stopPropagation();
     _fwdScroll(px,_cellAt(e.clientX,e.clientY)); // report the cell under the pointer

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -822,15 +822,20 @@ const authedClients = new WeakSet<WebSocket>();
 const clientPtys = new Map<WebSocket, pty.IPty>();
 /** Managed-Herdr viewers survive an in-worker /restart while backend changes. */
 const herdrWebBindings = new Map<WebSocket, HerdrWebTerminalBinding>();
-/** Per-WS token bucket bounding read-only {type:'scroll'} throughput. The
- *  client-side clamp (lines≤6) only binds the page; a viewToken holder can
- *  bypass the page and loop scroll messages directly, so the SERVER must cap the
- *  synthesized wheel-tick rate. Mirrors the client's per-gesture ceiling from
- *  #577 (6 ticks / 250ms) but enforced per connection, so multiple viewers can't
- *  stack. WeakMap → state is GC'd when the socket closes. */
-const readonlyScrollBuckets = new WeakMap<WebSocket, { tokens: number; last: number }>();
-const READONLY_SCROLL_MAX_TICKS = 6;      // bucket capacity == #577's per-gesture cap
-const READONLY_SCROLL_WINDOW_MS = 250;    // full refill window
+/** SHARED (session/backend-scoped) idle-reset burst gate for read-only
+ *  {type:'scroll'} intents. The client-side clamp (lines≤6) only binds the page;
+ *  a viewToken holder can bypass it and loop scroll messages, and can open N
+ *  connections. A PER-connection bucket would let N viewers write 6·N ticks at
+ *  once, and a refilling bucket would allow sustained ~24 tick/s — both defeat
+ *  #577's guarantee. So this is a SINGLE counter shared across every viewer,
+ *  mirroring the client's _fwdScroll gesture cap exactly: at most
+ *  READONLY_SCROLL_MAX_TICKS ticks per continuous burst, and the burst only
+ *  resets after a full READONLY_SCROLL_WINDOW_MS of idle (or a direction
+ *  reversal). Continuous flooding — from one socket or many — never exceeds 6
+ *  until everyone goes quiet for the window. */
+const readonlyScrollBurst = { ticks: 0, dir: 0, last: -Infinity };
+const READONLY_SCROLL_MAX_TICKS = 6;      // ticks per continuous burst == #577's per-gesture cap
+const READONLY_SCROLL_WINDOW_MS = 250;    // idle gap that resets the burst
 const writeToken = randomBytes(16).toString('hex');
 // Standalone/test fallback. Production replaces this after init with a stable
 // per-session HMAC derived from the host-only dashboard secret.
@@ -4026,26 +4031,32 @@ function exitTmuxScrollMode(): void {
 }
 
 /**
- * Consume up to `wantTicks` from this WS's read-only-scroll token bucket, and
- * return how many ticks are actually allowed right now. A refilling bucket caps
- * sustained throughput at READONLY_SCROLL_MAX_TICKS per READONLY_SCROLL_WINDOW_MS,
- * per connection — so a viewToken holder looping scroll messages directly
- * (bypassing the page's own clamp) cannot flood the backend, and multiple viewers
- * cannot stack past each socket's own limit. Returns 0 when the bucket is empty.
+ * Admit up to `wantTicks` of read-only scroll into the SHARED idle-reset burst,
+ * returning how many ticks are allowed right now. This is not a refilling bucket
+ * — it faithfully mirrors #577's client _fwdScroll gesture cap, but server-side
+ * and shared across ALL viewers:
+ *   • a full READONLY_SCROLL_WINDOW_MS of idle (no scroll from anyone) resets the
+ *     burst to empty — only THEN can another 6 ticks flow;
+ *   • a direction reversal also resets it (a new gesture);
+ *   • otherwise continuous traffic — from one socket or N sockets interleaved —
+ *     shares the same 6-tick ceiling and cannot exceed it until things go quiet.
+ * So neither multi-connection stacking nor sustained flooding can beat the cap.
+ * Returns 0 when the current burst is already exhausted.
  */
-function consumeReadonlyScrollTokens(ws: WebSocket, wantTicks: number, now: number): number {
+function admitReadonlyScrollTicks(dir: 'up' | 'down', wantTicks: number, now: number): number {
   if (wantTicks <= 0) return 0;
-  const refillRate = READONLY_SCROLL_MAX_TICKS / READONLY_SCROLL_WINDOW_MS; // tokens per ms
-  let bucket = readonlyScrollBuckets.get(ws);
-  if (!bucket) {
-    bucket = { tokens: READONLY_SCROLL_MAX_TICKS, last: now };
-    readonlyScrollBuckets.set(ws, bucket);
+  const dirSign = dir === 'up' ? -1 : 1;
+  const idle = now - readonlyScrollBurst.last >= READONLY_SCROLL_WINDOW_MS;
+  const reversed = readonlyScrollBurst.dir !== 0 && dirSign !== readonlyScrollBurst.dir;
+  if (idle || reversed) {
+    readonlyScrollBurst.ticks = 0; // new gesture
   }
-  const elapsed = Math.max(0, now - bucket.last);
-  bucket.tokens = Math.min(READONLY_SCROLL_MAX_TICKS, bucket.tokens + elapsed * refillRate);
-  bucket.last = now;
-  const granted = Math.min(wantTicks, Math.floor(bucket.tokens));
-  if (granted > 0) bucket.tokens -= granted;
+  readonlyScrollBurst.dir = dirSign;
+  readonlyScrollBurst.last = now;
+  const remaining = READONLY_SCROLL_MAX_TICKS - readonlyScrollBurst.ticks;
+  if (remaining <= 0) return 0;
+  const granted = Math.min(wantTicks, remaining);
+  readonlyScrollBurst.ticks += granted;
   return granted;
 }
 
@@ -8262,15 +8273,18 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
               // so no click/drag/coordinate can be forged. Gated to adapters that
               // opted in; ignored entirely otherwise.
               if (cliAdapter?.readonlyWheelScroll !== true) return;
-              // Rate-limit per WS: the client clamp (lines≤6) only binds the page.
-              // A viewToken holder can loop scroll messages directly, so the SERVER
-              // caps sustained tick throughput (6/250ms, per connection) — this is
-              // the server-side floor that also protects Herdr's expensive path.
+              // Rate-limit: the client clamp (lines≤6) only binds the page. A
+              // viewToken holder can loop scroll messages AND open many WS. So the
+              // SERVER admits ticks through a SHARED idle-reset burst (see
+              // admitReadonlyScrollTicks) — mirroring #577's per-gesture cap across
+              // all viewers: continuous traffic (one socket or many) shares one
+              // 6-tick ceiling and only resets after a full idle window.
+              if (msg.dir !== 'up' && msg.dir !== 'down') return;
               const wantTicks = typeof msg.lines === 'number' && Number.isFinite(msg.lines)
                 ? Math.max(1, Math.min(READONLY_SCROLL_MAX_TICKS, Math.floor(msg.lines)))
                 : 1;
-              const grantedTicks = consumeReadonlyScrollTokens(ws, wantTicks, Date.now());
-              if (grantedTicks <= 0) return; // bucket empty — drop the flood
+              const grantedTicks = admitReadonlyScrollTicks(msg.dir, wantTicks, Date.now());
+              if (grantedTicks <= 0) return; // burst exhausted — drop the flood
               const seq = buildReadonlyWheelSequence(msg.dir, msg.lines, grantedTicks);
               if (!seq) return;
               if (usesHerdrSnapshotWebHistory()) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -822,6 +822,15 @@ const authedClients = new WeakSet<WebSocket>();
 const clientPtys = new Map<WebSocket, pty.IPty>();
 /** Managed-Herdr viewers survive an in-worker /restart while backend changes. */
 const herdrWebBindings = new Map<WebSocket, HerdrWebTerminalBinding>();
+/** Per-WS token bucket bounding read-only {type:'scroll'} throughput. The
+ *  client-side clamp (lines≤6) only binds the page; a viewToken holder can
+ *  bypass the page and loop scroll messages directly, so the SERVER must cap the
+ *  synthesized wheel-tick rate. Mirrors the client's per-gesture ceiling from
+ *  #577 (6 ticks / 250ms) but enforced per connection, so multiple viewers can't
+ *  stack. WeakMap → state is GC'd when the socket closes. */
+const readonlyScrollBuckets = new WeakMap<WebSocket, { tokens: number; last: number }>();
+const READONLY_SCROLL_MAX_TICKS = 6;      // bucket capacity == #577's per-gesture cap
+const READONLY_SCROLL_WINDOW_MS = 250;    // full refill window
 const writeToken = randomBytes(16).toString('hex');
 // Standalone/test fallback. Production replaces this after init with a stable
 // per-session HMAC derived from the host-only dashboard secret.
@@ -4017,6 +4026,30 @@ function exitTmuxScrollMode(): void {
 }
 
 /**
+ * Consume up to `wantTicks` from this WS's read-only-scroll token bucket, and
+ * return how many ticks are actually allowed right now. A refilling bucket caps
+ * sustained throughput at READONLY_SCROLL_MAX_TICKS per READONLY_SCROLL_WINDOW_MS,
+ * per connection — so a viewToken holder looping scroll messages directly
+ * (bypassing the page's own clamp) cannot flood the backend, and multiple viewers
+ * cannot stack past each socket's own limit. Returns 0 when the bucket is empty.
+ */
+function consumeReadonlyScrollTokens(ws: WebSocket, wantTicks: number, now: number): number {
+  if (wantTicks <= 0) return 0;
+  const refillRate = READONLY_SCROLL_MAX_TICKS / READONLY_SCROLL_WINDOW_MS; // tokens per ms
+  let bucket = readonlyScrollBuckets.get(ws);
+  if (!bucket) {
+    bucket = { tokens: READONLY_SCROLL_MAX_TICKS, last: now };
+    readonlyScrollBuckets.set(ws, bucket);
+  }
+  const elapsed = Math.max(0, now - bucket.last);
+  bucket.tokens = Math.min(READONLY_SCROLL_MAX_TICKS, bucket.tokens + elapsed * refillRate);
+  bucket.last = now;
+  const granted = Math.min(wantTicks, Math.floor(bucket.tokens));
+  if (granted > 0) bucket.tokens -= granted;
+  return granted;
+}
+
+/**
  * Server-side synthesis of a restricted mouse-wheel sequence for the READ-ONLY
  * web terminal (see CliAdapter.readonlyWheelScroll). The read-only client sends
  * only {dir, lines}; EVERYTHING that could encode a click, drag, release, key,
@@ -4024,15 +4057,19 @@ function exitTmuxScrollMode(): void {
  *   • button is hard-coded to 64 (wheel-up) / 65 (wheel-down) — never a click
  *   • the coordinate is the server-owned grid CENTRE (never client-supplied,
  *     never (1,1)) so zone-routed TUIs still accept it
- *   • line count is clamped to a small positive bound
+ *   • line count is clamped to a small positive bound, then further shrunk to
+ *     whatever the per-WS rate limiter granted this instant (maxTicks)
  * A view capability therefore cannot forge any event other than a bounded
- * scroll. Returns '' if the request is malformed so callers forward nothing.
+ * scroll. Returns '' if the request is malformed or maxTicks is 0.
  */
-function buildReadonlyWheelSequence(dir: unknown, lines: unknown): string {
+function buildReadonlyWheelSequence(dir: unknown, lines: unknown, maxTicks = READONLY_SCROLL_MAX_TICKS): string {
   if (dir !== 'up' && dir !== 'down') return '';
-  const n = typeof lines === 'number' && Number.isFinite(lines)
-    ? Math.max(1, Math.min(6, Math.floor(lines)))
+  if (maxTicks <= 0) return '';
+  const requested = typeof lines === 'number' && Number.isFinite(lines)
+    ? Math.max(1, Math.min(READONLY_SCROLL_MAX_TICKS, Math.floor(lines)))
     : 1;
+  const n = Math.min(requested, Math.floor(maxTicks));
+  if (n <= 0) return '';
   const cols = renderCols || PTY_COLS;
   const rows = renderRows || PTY_ROWS;
   const col = (cols >> 1) + 1; // grid centre, 1-based; never (1,1)
@@ -8225,7 +8262,16 @@ function startWebServer(host: string, preferredPort?: number): Promise<number> {
               // so no click/drag/coordinate can be forged. Gated to adapters that
               // opted in; ignored entirely otherwise.
               if (cliAdapter?.readonlyWheelScroll !== true) return;
-              const seq = buildReadonlyWheelSequence(msg.dir, msg.lines);
+              // Rate-limit per WS: the client clamp (lines≤6) only binds the page.
+              // A viewToken holder can loop scroll messages directly, so the SERVER
+              // caps sustained tick throughput (6/250ms, per connection) — this is
+              // the server-side floor that also protects Herdr's expensive path.
+              const wantTicks = typeof msg.lines === 'number' && Number.isFinite(msg.lines)
+                ? Math.max(1, Math.min(READONLY_SCROLL_MAX_TICKS, Math.floor(msg.lines)))
+                : 1;
+              const grantedTicks = consumeReadonlyScrollTokens(ws, wantTicks, Date.now());
+              if (grantedTicks <= 0) return; // bucket empty — drop the flood
+              const seq = buildReadonlyWheelSequence(msg.dir, msg.lines, grantedTicks);
               if (!seq) return;
               if (usesHerdrSnapshotWebHistory()) {
                 herdrWebScrollDirection = msg.dir === 'up' ? 'up' : 'down';

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4032,25 +4032,30 @@ function exitTmuxScrollMode(): void {
 
 /**
  * Admit up to `wantTicks` of read-only scroll into the SHARED idle-reset burst,
- * returning how many ticks are allowed right now. This is not a refilling bucket
- * — it faithfully mirrors #577's client _fwdScroll gesture cap, but server-side
- * and shared across ALL viewers:
- *   • a full READONLY_SCROLL_WINDOW_MS of idle (no scroll from anyone) resets the
- *     burst to empty — only THEN can another 6 ticks flow;
- *   • a direction reversal also resets it (a new gesture);
- *   • otherwise continuous traffic — from one socket or N sockets interleaved —
- *     shares the same 6-tick ceiling and cannot exceed it until things go quiet.
- * So neither multi-connection stacking nor sustained flooding can beat the cap.
- * Returns 0 when the current burst is already exhausted.
+ * returning how many ticks are allowed right now. This is not a refilling bucket.
+ * It is INSPIRED by #577's client _fwdScroll gesture cap but is a stricter SECURITY
+ * boundary, because the read-only channel is untrusted:
+ *   • ONLY a full READONLY_SCROLL_WINDOW_MS of idle (no scroll from ANY viewer)
+ *     resets the burst — only THEN can another 6 ticks flow;
+ *   • a direction reversal updates the tracked direction but does NOT reset the
+ *     budget. #577 lets a reversal reopen the burst, but that path has WRITE
+ *     capability; here a viewToken client could otherwise alternate up/down to
+ *     clear ticks on every message and flood without ever idling. So reversal is
+ *     deliberately NOT a reset condition on this path.
+ *   • otherwise continuous traffic — one socket or N interleaved, same direction
+ *     or alternating — shares the same 6-tick ceiling until everyone goes quiet.
+ * So neither multi-connection stacking, sustained flooding, nor direction-flip
+ * abuse can beat the cap. Returns 0 when the current burst is already exhausted.
  */
 function admitReadonlyScrollTicks(dir: 'up' | 'down', wantTicks: number, now: number): number {
   if (wantTicks <= 0) return 0;
   const dirSign = dir === 'up' ? -1 : 1;
   const idle = now - readonlyScrollBurst.last >= READONLY_SCROLL_WINDOW_MS;
-  const reversed = readonlyScrollBurst.dir !== 0 && dirSign !== readonlyScrollBurst.dir;
-  if (idle || reversed) {
-    readonlyScrollBurst.ticks = 0; // new gesture
+  if (idle) {
+    readonlyScrollBurst.ticks = 0; // full idle window → new burst allowed
   }
+  // Track direction for observability only; a reversal must NOT reset the budget
+  // on this untrusted path (see doc above).
   readonlyScrollBurst.dir = dirSign;
   readonlyScrollBurst.last = now;
   const remaining = READONLY_SCROLL_MAX_TICKS - readonlyScrollBurst.ticks;
@@ -4069,7 +4074,7 @@ function admitReadonlyScrollTicks(dir: 'up' | 'down', wantTicks: number, now: nu
  *   • the coordinate is the server-owned grid CENTRE (never client-supplied,
  *     never (1,1)) so zone-routed TUIs still accept it
  *   • line count is clamped to a small positive bound, then further shrunk to
- *     whatever the per-WS rate limiter granted this instant (maxTicks)
+ *     whatever the session-shared burst gate granted this instant (maxTicks)
  * A view capability therefore cannot forge any event other than a bounded
  * scroll. Returns '' if the request is malformed or maxTicks is 0.
  */

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -1990,3 +1990,47 @@ describe('traex/coco sandbox authPaths', () => {
     expect(adapter.authPaths).toEqual(['~/.trae/cli', '~/.cache/coco']);
   });
 });
+
+// ---------------------------------------------------------------------------
+// readonlyWheelScroll — read-only web-terminal wheel capability (security)
+// ---------------------------------------------------------------------------
+
+describe('readonlyWheelScroll capability', () => {
+  // Instantiate the REAL adapters and assert the effective flag, rather than
+  // grepping source — the capability lives in a shared Claude-family factory, so
+  // a source search can't tell claude-code/seed (opted in) apart from relay
+  // (reuses the factory but must NOT inherit it).
+  it('is enabled for claude-code and seed only', () => {
+    expect(createCliAdapterSync('claude-code', '/bin/claude').readonlyWheelScroll).toBe(true);
+    expect(createCliAdapterSync('seed', '/bin/seed').readonlyWheelScroll).toBe(true);
+  });
+
+  it('is NOT inherited by relay, which reuses the Claude-family factory', () => {
+    // relay.ts calls createClaudeFamilyAdapter but does not opt in — the flag must
+    // default off so a fork can't silently gain a security-sensitive capability.
+    expect(createCliAdapterSync('relay', '/bin/relay').readonlyWheelScroll).not.toBe(true);
+  });
+
+  it('is off for every other shipped CLI', () => {
+    const optedIn = new Set<CliId>(['claude-code', 'seed']);
+    const everyCli: CliId[] = [
+      'claude-code', 'seed', 'relay', 'aiden', 'coco', 'codex', 'codex-app',
+      'cursor', 'gemini', 'genius', 'opencode', 'antigravity', 'mtr', 'hermes',
+      'mira', 'mir', 'traex', 'pi', 'copilot', 'oh-my-pi', 'kimi', 'grok',
+      'kiro-cli', 'riff',
+    ];
+    for (const id of everyCli) {
+      let adapter;
+      try {
+        adapter = createCliAdapterSync(id, `/bin/${id}`);
+      } catch {
+        continue; // adapters needing richer runtime setup are covered elsewhere
+      }
+      if (optedIn.has(id)) {
+        expect(adapter.readonlyWheelScroll, `${id} should opt in`).toBe(true);
+      } else {
+        expect(adapter.readonlyWheelScroll, `${id} must NOT enable readonlyWheelScroll`).not.toBe(true);
+      }
+    }
+  });
+});

--- a/test/web-terminal-readonly-scroll.test.ts
+++ b/test/web-terminal-readonly-scroll.test.ts
@@ -132,80 +132,129 @@ describe('read-only web terminal wheel scrolling', () => {
     }
   });
 
-  it('server rate-limits scroll ticks per WS so a direct message flood is bounded', () => {
+  it('shared idle-reset burst: multi-WS cannot stack, sustained flood stays ≤6, reconnect never refreshes', () => {
     const MAX = 6;
     const WINDOW = 250;
-    // Faithful port of consumeReadonlyScrollTokens (WeakMap<ws> → per-connection).
-    const buckets = new Map<object, { tokens: number; last: number }>();
-    function consume(ws: object, wantTicks: number, now: number): number {
+    // Faithful port of admitReadonlyScrollTicks — a SINGLE shared burst counter,
+    // NOT per-connection. Resets only after a full idle window or a direction
+    // reversal, mirroring #577's client _fwdScroll gesture cap.
+    const burst = { ticks: 0, dir: 0, last: -Infinity };
+    function admit(dir: 'up' | 'down', wantTicks: number, now: number): number {
       if (wantTicks <= 0) return 0;
-      const refillRate = MAX / WINDOW;
-      let bucket = buckets.get(ws);
-      if (!bucket) { bucket = { tokens: MAX, last: now }; buckets.set(ws, bucket); }
-      const elapsed = Math.max(0, now - bucket.last);
-      bucket.tokens = Math.min(MAX, bucket.tokens + elapsed * refillRate);
-      bucket.last = now;
-      const granted = Math.min(wantTicks, Math.floor(bucket.tokens));
-      if (granted > 0) bucket.tokens -= granted;
+      const dirSign = dir === 'up' ? -1 : 1;
+      const idle = now - burst.last >= WINDOW;
+      const reversed = burst.dir !== 0 && dirSign !== burst.dir;
+      if (idle || reversed) burst.ticks = 0;
+      burst.dir = dirSign;
+      burst.last = now;
+      const remaining = MAX - burst.ticks;
+      if (remaining <= 0) return 0;
+      const granted = Math.min(wantTicks, remaining);
+      burst.ticks += granted;
       return granted;
     }
 
-    // Attack: a viewToken holder loops {lines:6} 100× at t=0 (same instant).
-    const ws = {};
-    let ticksAtT0 = 0;
-    for (let i = 0; i < 100; i++) ticksAtT0 += consume(ws, 6, 0);
-    // Only the initial bucket (6) is granted — the other 99 messages get nothing.
-    expect(ticksAtT0).toBe(6);
-
-    // After a full window the bucket refills to its cap, not beyond.
-    let ticksAfterWindow = 0;
-    for (let i = 0; i < 100; i++) ticksAfterWindow += consume(ws, 6, WINDOW);
-    expect(ticksAfterWindow).toBe(6);
-
-    // Sustained throughput over 1s of flooding is bounded to ~MAX per window,
-    // NOT the ~100× the attacker attempted. (t=0 burst + 4 refills across 1000ms.)
-    const buckets2 = new Map<object, { tokens: number; last: number }>();
-    function consume2(ws2: object, want: number, now: number): number {
-      if (want <= 0) return 0;
-      const refillRate = MAX / WINDOW;
-      let b = buckets2.get(ws2);
-      if (!b) { b = { tokens: MAX, last: now }; buckets2.set(ws2, b); }
-      const el = Math.max(0, now - b.last);
-      b.tokens = Math.min(MAX, b.tokens + el * refillRate);
-      b.last = now;
-      const g = Math.min(want, Math.floor(b.tokens));
-      if (g > 0) b.tokens -= g;
-      return g;
+    // (1) Multi-connection at the SAME instant cannot stack past 6. Simulate N=10
+    //     sockets each looping {lines:6}; the shared burst caps the total at 6.
+    let totalAtT0 = 0;
+    for (let socket = 0; socket < 10; socket++) {
+      for (let i = 0; i < 100; i++) totalAtT0 += admit('up', 6, 0);
     }
-    const ws2 = {};
-    let total = 0;
-    for (let t = 0; t <= 1000; t += 10) total += consume2(ws2, 6, t); // flood every 10ms
-    // ≈ initial 6 + 1000ms/250ms×6 = 6 + 24 = 30, far below the 606 attempted.
-    expect(total).toBeLessThanOrEqual(30);
-    expect(total).toBeGreaterThanOrEqual(24);
+    expect(totalAtT0).toBe(6); // NOT 6·N — one shared ceiling
 
-    // Two viewers each get their OWN bucket — a second socket cannot borrow the
-    // first's spent tokens, but also proves stacking is per-connection bounded.
-    const a = {}; const b = {};
-    expect(consume(a, 6, 2000)).toBe(6);
-    expect(consume(a, 6, 2000)).toBe(0); // a is now empty at this instant
-    expect(consume(b, 6, 2000)).toBe(6); // b independent, still capped at 6
+    // (2) Sustained flood over 1s from many interleaved sockets. The burst only
+    //     resets on a FULL idle window; continuous traffic never idles, so after
+    //     the first 6 nothing more is admitted for the whole second.
+    const burst2 = { ticks: 0, dir: 0, last: -Infinity };
+    function admit2(dir: 'up' | 'down', want: number, now: number): number {
+      if (want <= 0) return 0;
+      const dirSign = dir === 'up' ? -1 : 1;
+      const idle = now - burst2.last >= WINDOW;
+      const reversed = burst2.dir !== 0 && dirSign !== burst2.dir;
+      if (idle || reversed) burst2.ticks = 0;
+      burst2.dir = dirSign; burst2.last = now;
+      const remaining = MAX - burst2.ticks;
+      if (remaining <= 0) return 0;
+      const g = Math.min(want, remaining); burst2.ticks += g; return g;
+    }
+    let sustained = 0;
+    for (let t = 0; t <= 1000; t += 10) { // flood every 10ms — never idle for 250ms
+      for (let socket = 0; socket < 3; socket++) sustained += admit2('up', 6, t);
+    }
+    expect(sustained).toBe(6); // continuous traffic never resets → still just 6
+
+    // (3) A full idle window (everyone quiet ≥250ms) is required to reopen.
+    const burst3 = { ticks: 0, dir: 0, last: -Infinity };
+    function admit3(dir: 'up' | 'down', want: number, now: number): number {
+      if (want <= 0) return 0;
+      const dirSign = dir === 'up' ? -1 : 1;
+      const idle = now - burst3.last >= WINDOW;
+      const reversed = burst3.dir !== 0 && dirSign !== burst3.dir;
+      if (idle || reversed) burst3.ticks = 0;
+      burst3.dir = dirSign; burst3.last = now;
+      const remaining = MAX - burst3.ticks;
+      if (remaining <= 0) return 0;
+      const g = Math.min(want, remaining); burst3.ticks += g; return g;
+    }
+    expect(admit3('up', 6, 0)).toBe(6);        // first gesture
+    expect(admit3('up', 6, 100)).toBe(0);      // 100ms later — still same burst
+    expect(admit3('up', 6, 200)).toBe(0);      // 200ms — still not idle enough
+    expect(admit3('up', 6, 450)).toBe(6);      // 250ms after last (200) → reset, reopens
+
+    // (4) Reconnect does NOT refresh the budget — the burst is shared/global, not
+    //     tied to a socket. A "new connection" that keeps flooding within the
+    //     window sees the burst already spent.
+    const burst4 = { ticks: 0, dir: 0, last: -Infinity };
+    function admit4(dir: 'up' | 'down', want: number, now: number): number {
+      if (want <= 0) return 0;
+      const dirSign = dir === 'up' ? -1 : 1;
+      const idle = now - burst4.last >= WINDOW;
+      const reversed = burst4.dir !== 0 && dirSign !== burst4.dir;
+      if (idle || reversed) burst4.ticks = 0;
+      burst4.dir = dirSign; burst4.last = now;
+      const remaining = MAX - burst4.ticks;
+      if (remaining <= 0) return 0;
+      const g = Math.min(want, remaining); burst4.ticks += g; return g;
+    }
+    expect(admit4('up', 6, 0)).toBe(6);   // socket #1 spends the burst
+    // socket #1 "closes", socket #2 "opens" and floods 50ms later — no fresh 6.
+    expect(admit4('up', 6, 50)).toBe(0);
+    expect(admit4('up', 6, 100)).toBe(0);
+
+    // (5) Direction reversal starts a new gesture (matches #577 client behaviour).
+    const burst5 = { ticks: 0, dir: 0, last: -Infinity };
+    function admit5(dir: 'up' | 'down', want: number, now: number): number {
+      if (want <= 0) return 0;
+      const dirSign = dir === 'up' ? -1 : 1;
+      const idle = now - burst5.last >= WINDOW;
+      const reversed = burst5.dir !== 0 && dirSign !== burst5.dir;
+      if (idle || reversed) burst5.ticks = 0;
+      burst5.dir = dirSign; burst5.last = now;
+      const remaining = MAX - burst5.ticks;
+      if (remaining <= 0) return 0;
+      const g = Math.min(want, remaining); burst5.ticks += g; return g;
+    }
+    expect(admit5('up', 6, 0)).toBe(6);   // up burst exhausted
+    expect(admit5('up', 6, 10)).toBe(0);  // still up, still spent
+    expect(admit5('down', 6, 20)).toBe(6); // reversed → new gesture reopens
   });
 
-  it('the scroll handler consumes tokens BEFORE writing, and drops on empty bucket', () => {
+  it('the scroll handler admits ticks BEFORE writing, and drops on exhausted burst', () => {
     // Ordering matters: rate-limit gate must run before backend.write.
     const handler = workerSource.slice(
       workerSource.indexOf("} else if (msg.type === 'scroll') {"),
       workerSource.indexOf('backend?.write(seq);') + 'backend?.write(seq);'.length,
     );
-    expect(handler).toContain('const grantedTicks = consumeReadonlyScrollTokens(ws, wantTicks, Date.now());');
+    expect(handler).toContain('const grantedTicks = admitReadonlyScrollTicks(msg.dir, wantTicks, Date.now());');
     expect(handler).toContain('if (grantedTicks <= 0) return;');
     expect(handler).toContain('buildReadonlyWheelSequence(msg.dir, msg.lines, grantedTicks)');
-    // consume must appear before the write.
-    expect(handler.indexOf('consumeReadonlyScrollTokens'))
+    // admit must appear before the write.
+    expect(handler.indexOf('admitReadonlyScrollTicks'))
       .toBeLessThan(handler.indexOf('backend?.write(seq)'));
-    // The bucket is a WeakMap keyed on the WS (auto-GC, per-connection).
-    expect(workerSource).toContain('const readonlyScrollBuckets = new WeakMap<WebSocket');
+    // The burst is a SINGLE shared counter (not per-connection), so multiple
+    // viewers/connections cannot stack past the cap.
+    expect(workerSource).toContain('const readonlyScrollBurst = { ticks: 0, dir: 0, last: -Infinity };');
+    expect(workerSource).not.toContain('new WeakMap<WebSocket, { tokens');
     expect(workerSource).toContain('const READONLY_SCROLL_MAX_TICKS = 6;');
     expect(workerSource).toContain('const READONLY_SCROLL_WINDOW_MS = 250;');
   });

--- a/test/web-terminal-readonly-scroll.test.ts
+++ b/test/web-terminal-readonly-scroll.test.ts
@@ -68,7 +68,7 @@ describe('read-only web terminal wheel scrolling', () => {
     // non-opted-in CLI drops it entirely.
     expect(workerSource).toContain("} else if (msg.type === 'scroll') {");
     expect(workerSource).toContain('if (cliAdapter?.readonlyWheelScroll !== true) return;');
-    expect(workerSource).toContain('const seq = buildReadonlyWheelSequence(msg.dir, msg.lines);');
+    expect(workerSource).toContain('buildReadonlyWheelSequence(msg.dir, msg.lines, grantedTicks)');
     expect(workerSource).toContain('if (!seq) return;');
   });
 
@@ -81,7 +81,8 @@ describe('read-only web terminal wheel scrolling', () => {
       workerSource.indexOf('function handleTermAction'),
     );
     expect(fn).toContain("if (dir !== 'up' && dir !== 'down') return '';");
-    expect(fn).toContain('Math.max(1, Math.min(6, Math.floor(lines)))');
+    expect(fn).toContain('Math.max(1, Math.min(READONLY_SCROLL_MAX_TICKS, Math.floor(lines)))');
+    expect(fn).toContain('const n = Math.min(requested, Math.floor(maxTicks));');
     expect(fn).toContain("const button = dir === 'up' ? 64 : 65;");
     expect(fn).toContain('const col = (cols >> 1) + 1;');
     expect(fn).toContain('const row = (rows >> 1) + 1;');
@@ -91,11 +92,14 @@ describe('read-only web terminal wheel scrolling', () => {
 
   it('buildReadonlyWheelSequence behaves: clamps, fixes button, rejects garbage', () => {
     // Port the pure function and verify its guarantees directly.
-    function build(dir: unknown, lines: unknown, cols = 80, rows = 24): string {
+    function build(dir: unknown, lines: unknown, maxTicks = 6, cols = 80, rows = 24): string {
       if (dir !== 'up' && dir !== 'down') return '';
-      const n = typeof lines === 'number' && Number.isFinite(lines)
+      if (maxTicks <= 0) return '';
+      const requested = typeof lines === 'number' && Number.isFinite(lines)
         ? Math.max(1, Math.min(6, Math.floor(lines)))
         : 1;
+      const n = Math.min(requested, Math.floor(maxTicks));
+      if (n <= 0) return '';
       const col = (cols >> 1) + 1;
       const row = (rows >> 1) + 1;
       const button = dir === 'up' ? 64 : 65;
@@ -112,10 +116,13 @@ describe('read-only web terminal wheel scrolling', () => {
     expect(build('up', 3)).toBe('\x1b[<64;41;13M'.repeat(3));
     expect(build('up', 999)).toBe('\x1b[<64;41;13M'.repeat(6)); // capped
     expect(build('up', 0)).toBe('\x1b[<64;41;13M'); // floored to 1
-    // Garbage direction / non-numeric lines → nothing forwarded.
+    // maxTicks (rate-limiter grant) shrinks further and can zero it out entirely.
+    expect(build('up', 6, 2)).toBe('\x1b[<64;41;13M'.repeat(2));
+    expect(build('up', 6, 0)).toBe(''); // no tokens granted → nothing forwarded
+    // Garbage direction / non-numeric lines → nothing / safe fallback.
     expect(build('left', 3)).toBe('');
     expect(build('click', 3)).toBe('');
-    expect(build('up', 'evil')).toBe('\x1b[<64;41;13M'); // non-number falls back to 1 tick, still pure wheel
+    expect(build('up', 'evil')).toBe('\x1b[<64;41;13M'); // non-number → 1 tick, still pure wheel
     // Never contains a mouse-press (button 0) or release ('m') sequence.
     for (const dir of ['up', 'down'] as const) {
       const s = build(dir, 6);
@@ -123,5 +130,83 @@ describe('read-only web terminal wheel scrolling', () => {
       expect(s).not.toContain('m'); // no SGR release
       expect(s.endsWith('M') || s === '').toBe(true);
     }
+  });
+
+  it('server rate-limits scroll ticks per WS so a direct message flood is bounded', () => {
+    const MAX = 6;
+    const WINDOW = 250;
+    // Faithful port of consumeReadonlyScrollTokens (WeakMap<ws> → per-connection).
+    const buckets = new Map<object, { tokens: number; last: number }>();
+    function consume(ws: object, wantTicks: number, now: number): number {
+      if (wantTicks <= 0) return 0;
+      const refillRate = MAX / WINDOW;
+      let bucket = buckets.get(ws);
+      if (!bucket) { bucket = { tokens: MAX, last: now }; buckets.set(ws, bucket); }
+      const elapsed = Math.max(0, now - bucket.last);
+      bucket.tokens = Math.min(MAX, bucket.tokens + elapsed * refillRate);
+      bucket.last = now;
+      const granted = Math.min(wantTicks, Math.floor(bucket.tokens));
+      if (granted > 0) bucket.tokens -= granted;
+      return granted;
+    }
+
+    // Attack: a viewToken holder loops {lines:6} 100× at t=0 (same instant).
+    const ws = {};
+    let ticksAtT0 = 0;
+    for (let i = 0; i < 100; i++) ticksAtT0 += consume(ws, 6, 0);
+    // Only the initial bucket (6) is granted — the other 99 messages get nothing.
+    expect(ticksAtT0).toBe(6);
+
+    // After a full window the bucket refills to its cap, not beyond.
+    let ticksAfterWindow = 0;
+    for (let i = 0; i < 100; i++) ticksAfterWindow += consume(ws, 6, WINDOW);
+    expect(ticksAfterWindow).toBe(6);
+
+    // Sustained throughput over 1s of flooding is bounded to ~MAX per window,
+    // NOT the ~100× the attacker attempted. (t=0 burst + 4 refills across 1000ms.)
+    const buckets2 = new Map<object, { tokens: number; last: number }>();
+    function consume2(ws2: object, want: number, now: number): number {
+      if (want <= 0) return 0;
+      const refillRate = MAX / WINDOW;
+      let b = buckets2.get(ws2);
+      if (!b) { b = { tokens: MAX, last: now }; buckets2.set(ws2, b); }
+      const el = Math.max(0, now - b.last);
+      b.tokens = Math.min(MAX, b.tokens + el * refillRate);
+      b.last = now;
+      const g = Math.min(want, Math.floor(b.tokens));
+      if (g > 0) b.tokens -= g;
+      return g;
+    }
+    const ws2 = {};
+    let total = 0;
+    for (let t = 0; t <= 1000; t += 10) total += consume2(ws2, 6, t); // flood every 10ms
+    // ≈ initial 6 + 1000ms/250ms×6 = 6 + 24 = 30, far below the 606 attempted.
+    expect(total).toBeLessThanOrEqual(30);
+    expect(total).toBeGreaterThanOrEqual(24);
+
+    // Two viewers each get their OWN bucket — a second socket cannot borrow the
+    // first's spent tokens, but also proves stacking is per-connection bounded.
+    const a = {}; const b = {};
+    expect(consume(a, 6, 2000)).toBe(6);
+    expect(consume(a, 6, 2000)).toBe(0); // a is now empty at this instant
+    expect(consume(b, 6, 2000)).toBe(6); // b independent, still capped at 6
+  });
+
+  it('the scroll handler consumes tokens BEFORE writing, and drops on empty bucket', () => {
+    // Ordering matters: rate-limit gate must run before backend.write.
+    const handler = workerSource.slice(
+      workerSource.indexOf("} else if (msg.type === 'scroll') {"),
+      workerSource.indexOf('backend?.write(seq);') + 'backend?.write(seq);'.length,
+    );
+    expect(handler).toContain('const grantedTicks = consumeReadonlyScrollTokens(ws, wantTicks, Date.now());');
+    expect(handler).toContain('if (grantedTicks <= 0) return;');
+    expect(handler).toContain('buildReadonlyWheelSequence(msg.dir, msg.lines, grantedTicks)');
+    // consume must appear before the write.
+    expect(handler.indexOf('consumeReadonlyScrollTokens'))
+      .toBeLessThan(handler.indexOf('backend?.write(seq)'));
+    // The bucket is a WeakMap keyed on the WS (auto-GC, per-connection).
+    expect(workerSource).toContain('const readonlyScrollBuckets = new WeakMap<WebSocket');
+    expect(workerSource).toContain('const READONLY_SCROLL_MAX_TICKS = 6;');
+    expect(workerSource).toContain('const READONLY_SCROLL_WINDOW_MS = 250;');
   });
 });

--- a/test/web-terminal-readonly-scroll.test.ts
+++ b/test/web-terminal-readonly-scroll.test.ts
@@ -20,20 +20,15 @@ function scriptBlock(startMarker: string): string {
 }
 
 describe('read-only web terminal wheel scrolling', () => {
-  it('exposes readonlyWheelScroll as an opt-in adapter capability, on for Claude only', () => {
+  it('declares readonlyWheelScroll as an opt-in adapter capability', () => {
+    // The capability field exists and is documented as opt-in. The EFFECTIVE
+    // per-adapter value (claude-code/seed on, relay + all others off) is asserted
+    // behaviourally by instantiating the real adapters in cli-adapters.test.ts —
+    // a source grep can't distinguish variants that share the Claude-family
+    // factory (relay reuses it but must NOT inherit the flag).
     expect(adapterTypesSource).toContain('readonly readonlyWheelScroll?: boolean;');
-    // Claude family (claude-code + seed share this adapter) opts in.
-    expect(claudeAdapterSource).toContain('readonlyWheelScroll: true,');
-    // No OTHER shipped adapter turns it on.
-    const others = [
-      'codex', 'gemini', 'opencode', 'cursor', 'grok', 'pi', 'copilot',
-      'kimi', 'aiden', 'coco', 'hermes', 'mira', 'mir', 'traex', 'riff',
-      'genius', 'mtr', 'antigravity', 'kiro-cli', 'oh-my-pi', 'codex-app',
-    ];
-    for (const name of others) {
-      const src = readFileSync(join(process.cwd(), `src/adapters/cli/${name}.ts`), 'utf8');
-      expect(src, `${name} must not enable readonlyWheelScroll`).not.toContain('readonlyWheelScroll');
-    }
+    // Per-variant opt-in, not a hardcoded factory default.
+    expect(claudeAdapterSource).toContain('readonlyWheelScroll: variant.readonlyWheelScroll === true,');
   });
 
   it('only enables the capability on the shared relay path (not tmux/zellij attach)', () => {

--- a/test/web-terminal-readonly-scroll.test.ts
+++ b/test/web-terminal-readonly-scroll.test.ts
@@ -1,0 +1,127 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workerSource = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+const claudeAdapterSource = readFileSync(
+  join(process.cwd(), 'src/adapters/cli/claude-code.ts'),
+  'utf8',
+);
+const adapterTypesSource = readFileSync(
+  join(process.cwd(), 'src/adapters/cli/types.ts'),
+  'utf8',
+);
+
+function scriptBlock(startMarker: string): string {
+  const start = workerSource.indexOf(startMarker);
+  const end = workerSource.indexOf('</script>', start);
+  expect(start).toBeGreaterThan(-1);
+  return workerSource.slice(start, end);
+}
+
+describe('read-only web terminal wheel scrolling', () => {
+  it('exposes readonlyWheelScroll as an opt-in adapter capability, on for Claude only', () => {
+    expect(adapterTypesSource).toContain('readonly readonlyWheelScroll?: boolean;');
+    // Claude family (claude-code + seed share this adapter) opts in.
+    expect(claudeAdapterSource).toContain('readonlyWheelScroll: true,');
+    // No OTHER shipped adapter turns it on.
+    const others = [
+      'codex', 'gemini', 'opencode', 'cursor', 'grok', 'pi', 'copilot',
+      'kimi', 'aiden', 'coco', 'hermes', 'mira', 'mir', 'traex', 'riff',
+      'genius', 'mtr', 'antigravity', 'kiro-cli', 'oh-my-pi', 'codex-app',
+    ];
+    for (const name of others) {
+      const src = readFileSync(join(process.cwd(), `src/adapters/cli/${name}.ts`), 'utf8');
+      expect(src, `${name} must not enable readonlyWheelScroll`).not.toContain('readonlyWheelScroll');
+    }
+  });
+
+  it('only enables the capability on the shared relay path (not tmux/zellij attach)', () => {
+    expect(workerSource).toContain(
+      'const readonlyWheelScroll = cliAdapter?.readonlyWheelScroll === true\n'
+      + '        && !(isTmuxMode && !isPipeMode);',
+    );
+    expect(workerSource).toContain(
+      'getTerminalHtml(hasWrite, platformReadonly, loginUrl, forceRemoteScroll, localTerminalBackend, readonlyWheelScroll)',
+    );
+    expect(workerSource).toContain('var readonlyWheelScroll=${readonlyWheelScroll};');
+  });
+
+  it('read-only client sends a RESTRICTED scroll intent, never raw mouse bytes', () => {
+    const wheelBlock = scriptBlock('// ── Wheel / touch scroll handling ──');
+    // Under !hasToken + alt-screen + capability, the client emits {type:'scroll'}
+    // carrying only a direction and a bounded line count — NOT an SGR byte string.
+    expect(wheelBlock).toContain('if(readonlyWheelScroll&&ws_&&ws_.readyState===1&&px){');
+    expect(wheelBlock).toContain("type:'scroll',dir:px<0?'up':'down',lines:_lines");
+    expect(wheelBlock).toContain('var _lines=Math.max(1,Math.min(6,Math.round(Math.abs(px)/33)));');
+    // The read-only branch must NOT reach _fwdScroll (which forwards raw SGR bytes).
+    const roBranch = wheelBlock.slice(
+      wheelBlock.indexOf('if(!hasToken){', wheelBlock.indexOf('_canScrollLocal(px)')),
+    );
+    const roOnly = roBranch.slice(0, roBranch.indexOf('_fwdScroll(px,_cellAt'));
+    expect(roOnly).not.toContain('_fwdScroll');
+  });
+
+  it('server ignores scroll intent unless the adapter opted in', () => {
+    // The 'scroll' handler is gated on the adapter capability and is NOT behind
+    // authedClients (that is the whole point — read-only is allowed here), but a
+    // non-opted-in CLI drops it entirely.
+    expect(workerSource).toContain("} else if (msg.type === 'scroll') {");
+    expect(workerSource).toContain('if (cliAdapter?.readonlyWheelScroll !== true) return;');
+    expect(workerSource).toContain('const seq = buildReadonlyWheelSequence(msg.dir, msg.lines);');
+    expect(workerSource).toContain('if (!seq) return;');
+  });
+
+  it('server synthesizes the wheel bytes — client cannot supply button/coord/keys', () => {
+    // buildReadonlyWheelSequence hard-codes the button and a server-owned centre
+    // coordinate, and clamps the line count. The client's message never reaches
+    // backend.write() as raw bytes.
+    const fn = workerSource.slice(
+      workerSource.indexOf('function buildReadonlyWheelSequence'),
+      workerSource.indexOf('function handleTermAction'),
+    );
+    expect(fn).toContain("if (dir !== 'up' && dir !== 'down') return '';");
+    expect(fn).toContain('Math.max(1, Math.min(6, Math.floor(lines)))');
+    expect(fn).toContain("const button = dir === 'up' ? 64 : 65;");
+    expect(fn).toContain('const col = (cols >> 1) + 1;');
+    expect(fn).toContain('const row = (rows >> 1) + 1;');
+    // No client-provided coordinate or button is ever interpolated.
+    expect(fn).not.toContain('msg.');
+  });
+
+  it('buildReadonlyWheelSequence behaves: clamps, fixes button, rejects garbage', () => {
+    // Port the pure function and verify its guarantees directly.
+    function build(dir: unknown, lines: unknown, cols = 80, rows = 24): string {
+      if (dir !== 'up' && dir !== 'down') return '';
+      const n = typeof lines === 'number' && Number.isFinite(lines)
+        ? Math.max(1, Math.min(6, Math.floor(lines)))
+        : 1;
+      const col = (cols >> 1) + 1;
+      const row = (rows >> 1) + 1;
+      const button = dir === 'up' ? 64 : 65;
+      const coord = `${col};${row}`;
+      let seq = '';
+      for (let i = 0; i < n; i++) seq += `\x1b[<${button};${coord}M`;
+      return seq;
+    }
+
+    // Direction → fixed wheel button, server-centre coordinate (41;13 for 80x24).
+    expect(build('up', 1)).toBe('\x1b[<64;41;13M');
+    expect(build('down', 1)).toBe('\x1b[<65;41;13M');
+    // Line count clamped to [1,6]; three ticks up.
+    expect(build('up', 3)).toBe('\x1b[<64;41;13M'.repeat(3));
+    expect(build('up', 999)).toBe('\x1b[<64;41;13M'.repeat(6)); // capped
+    expect(build('up', 0)).toBe('\x1b[<64;41;13M'); // floored to 1
+    // Garbage direction / non-numeric lines → nothing forwarded.
+    expect(build('left', 3)).toBe('');
+    expect(build('click', 3)).toBe('');
+    expect(build('up', 'evil')).toBe('\x1b[<64;41;13M'); // non-number falls back to 1 tick, still pure wheel
+    // Never contains a mouse-press (button 0) or release ('m') sequence.
+    for (const dir of ['up', 'down'] as const) {
+      const s = build(dir, 6);
+      expect(s).not.toContain('\x1b[<0;'); // no left-click press
+      expect(s).not.toContain('m'); // no SGR release
+      expect(s.endsWith('M') || s === '').toBe(true);
+    }
+  });
+});

--- a/test/web-terminal-readonly-scroll.test.ts
+++ b/test/web-terminal-readonly-scroll.test.ts
@@ -136,15 +136,14 @@ describe('read-only web terminal wheel scrolling', () => {
     const MAX = 6;
     const WINDOW = 250;
     // Faithful port of admitReadonlyScrollTicks — a SINGLE shared burst counter,
-    // NOT per-connection. Resets only after a full idle window or a direction
-    // reversal, mirroring #577's client _fwdScroll gesture cap.
+    // NOT per-connection. Resets ONLY after a full idle window (direction reversal
+    // does NOT reset it on this untrusted read-only path — see case 5).
     const burst = { ticks: 0, dir: 0, last: -Infinity };
     function admit(dir: 'up' | 'down', wantTicks: number, now: number): number {
       if (wantTicks <= 0) return 0;
       const dirSign = dir === 'up' ? -1 : 1;
       const idle = now - burst.last >= WINDOW;
-      const reversed = burst.dir !== 0 && dirSign !== burst.dir;
-      if (idle || reversed) burst.ticks = 0;
+      if (idle) burst.ticks = 0; // ONLY idle resets (reversal never resets)
       burst.dir = dirSign;
       burst.last = now;
       const remaining = MAX - burst.ticks;
@@ -170,8 +169,7 @@ describe('read-only web terminal wheel scrolling', () => {
       if (want <= 0) return 0;
       const dirSign = dir === 'up' ? -1 : 1;
       const idle = now - burst2.last >= WINDOW;
-      const reversed = burst2.dir !== 0 && dirSign !== burst2.dir;
-      if (idle || reversed) burst2.ticks = 0;
+      if (idle) burst2.ticks = 0; // ONLY idle resets (reversal never resets)
       burst2.dir = dirSign; burst2.last = now;
       const remaining = MAX - burst2.ticks;
       if (remaining <= 0) return 0;
@@ -189,8 +187,7 @@ describe('read-only web terminal wheel scrolling', () => {
       if (want <= 0) return 0;
       const dirSign = dir === 'up' ? -1 : 1;
       const idle = now - burst3.last >= WINDOW;
-      const reversed = burst3.dir !== 0 && dirSign !== burst3.dir;
-      if (idle || reversed) burst3.ticks = 0;
+      if (idle) burst3.ticks = 0; // ONLY idle resets (reversal never resets)
       burst3.dir = dirSign; burst3.last = now;
       const remaining = MAX - burst3.ticks;
       if (remaining <= 0) return 0;
@@ -209,8 +206,7 @@ describe('read-only web terminal wheel scrolling', () => {
       if (want <= 0) return 0;
       const dirSign = dir === 'up' ? -1 : 1;
       const idle = now - burst4.last >= WINDOW;
-      const reversed = burst4.dir !== 0 && dirSign !== burst4.dir;
-      if (idle || reversed) burst4.ticks = 0;
+      if (idle) burst4.ticks = 0; // ONLY idle resets (reversal never resets)
       burst4.dir = dirSign; burst4.last = now;
       const remaining = MAX - burst4.ticks;
       if (remaining <= 0) return 0;
@@ -221,22 +217,49 @@ describe('read-only web terminal wheel scrolling', () => {
     expect(admit4('up', 6, 50)).toBe(0);
     expect(admit4('up', 6, 100)).toBe(0);
 
-    // (5) Direction reversal starts a new gesture (matches #577 client behaviour).
+    // (5) SECURITY: direction reversal must NOT reset the budget on this untrusted
+    //     read-only path. A viewToken client alternating up/down within the window
+    //     stays capped at 6 total — otherwise it could clear ticks every message
+    //     and flood without ever idling. (This intentionally DIVERGES from #577's
+    //     client behaviour, which reopens on reversal but has write capability.)
     const burst5 = { ticks: 0, dir: 0, last: -Infinity };
     function admit5(dir: 'up' | 'down', want: number, now: number): number {
       if (want <= 0) return 0;
       const dirSign = dir === 'up' ? -1 : 1;
       const idle = now - burst5.last >= WINDOW;
-      const reversed = burst5.dir !== 0 && dirSign !== burst5.dir;
-      if (idle || reversed) burst5.ticks = 0;
+      if (idle) burst5.ticks = 0; // ONLY idle resets — reversal does not
       burst5.dir = dirSign; burst5.last = now;
       const remaining = MAX - burst5.ticks;
       if (remaining <= 0) return 0;
       const g = Math.min(want, remaining); burst5.ticks += g; return g;
     }
-    expect(admit5('up', 6, 0)).toBe(6);   // up burst exhausted
-    expect(admit5('up', 6, 10)).toBe(0);  // still up, still spent
-    expect(admit5('down', 6, 20)).toBe(6); // reversed → new gesture reopens
+    expect(admit5('up', 6, 0)).toBe(6);    // up burst exhausted
+    expect(admit5('down', 6, 10)).toBe(0); // reversed within window → still 0
+    expect(admit5('up', 6, 20)).toBe(0);   // flip back → still 0
+    expect(admit5('down', 6, 30)).toBe(0); // keep alternating → still 0
+
+    // (6) Alternating-flood across MANY connections within the window: fill 6 on
+    //     one socket, then interleave up/down from several sockets — total stays 6.
+    const burst6 = { ticks: 0, dir: 0, last: -Infinity };
+    function admit6(dir: 'up' | 'down', want: number, now: number): number {
+      if (want <= 0) return 0;
+      const dirSign = dir === 'up' ? -1 : 1;
+      const idle = now - burst6.last >= WINDOW;
+      if (idle) burst6.ticks = 0;
+      burst6.dir = dirSign; burst6.last = now;
+      const remaining = MAX - burst6.ticks;
+      if (remaining <= 0) return 0;
+      const g = Math.min(want, remaining); burst6.ticks += g; return g;
+    }
+    let altTotal = admit6('up', 6, 0); // socket A fills the burst
+    for (let t = 5; t <= 240; t += 5) { // stay inside the 250ms window
+      const dir = (t / 5) % 2 === 0 ? 'up' : 'down';
+      for (let socket = 0; socket < 4; socket++) altTotal += admit6(dir, 6, t);
+    }
+    expect(altTotal).toBe(6); // alternating + multi-connection cannot beat the cap
+
+    // ...but once EVERYONE is quiet for a full window, the next burst reopens.
+    expect(admit6('up', 6, 240 + WINDOW)).toBe(6);
   });
 
   it('the scroll handler admits ticks BEFORE writing, and drops on exhausted burst', () => {

--- a/test/web-terminal-touch-scroll.test.ts
+++ b/test/web-terminal-touch-scroll.test.ts
@@ -66,7 +66,7 @@ describe('web terminal touch scrolling', () => {
       + "        || effectiveBackendType === 'zellij';",
     );
     expect(workerSource).toContain(
-      'getTerminalHtml(hasWrite, platformReadonly, loginUrl, forceRemoteScroll, localTerminalBackend)',
+      'getTerminalHtml(hasWrite, platformReadonly, loginUrl, forceRemoteScroll, localTerminalBackend',
     );
     expect(workerSource).toContain('var localTerminalBackend=${localTerminalBackend};');
     // Guard the exclusion explicitly: neither Herdr nor Riff may appear in the gate.


### PR DESCRIPTION
> ⚠️ 本 PR **stacked 在 #577 之上**（base = `fix/web-terminal-wheel-smoothness`）,diff 只展示只读滚动这部分。待 #577 合并后把 base 改回 `master`。

## 问题

只读模式（viewToken,无写入权限）下,备用屏 CLI（Claude）**完全滚不动**。

## 根因

Claude 跑在终端**备用屏 + mouse mode**：xterm/tmux 都不留 scrollback,transcript 由 CLI 自己重绘。要滚动只能把 SGR 滚轮事件转发给 CLI。但只读有**两道有意的安全闸**——客户端 `_fwdScroll` 开头 `if(!hasToken)return`、服务端 input handler `if(!authedClients.has(ws))return`——因为 mouse 协议字节里滚轮和「点击/拖拽/释放」同形,CLI 可能把点击绑到审批/危险操作。所以只读视图**一个字节都不许发给 CLI**,备用屏下于是滚不动。

## 方案（不放开字节转发,只加受限意图通道 + 服务端垄断合成与限流）

### 1. 适配器 per-variant opt-in 能力
`CliAdapter.readonlyWheelScroll`(默认关)。**关键**:它是 `ClaudeFamilyVariant` 的**显式 per-variant 字段**,不是共享工厂 `createClaudeFamilyAdapter()` 的硬编码默认值——否则复用该工厂的 fork（如 `relay`）会静默继承。仅 **claude-code、seed** 两个 variant 显式设 `true`;**relay 及其余全部 CLI 关闭**。

### 2. 服务端下发
仅对「开启该能力 且 走 shared relay（PtyBackend / tmux-pipe,Claude 实际路径）」的会话,给只读客户端下发 `readonlyWheelScroll=true`;tmux/zellij 纯 attach 自有 copy-mode 滚动,不涉及。

### 3. 只读客户端发受限意图
备用屏下不再发原始 SGR,改发 `{type:'scroll',dir,lines}`,只带方向 + 限幅行数。

### 4. 服务端垄断字节合成
`buildReadonlyWheelSequence`:`dir` 只认 up/down、`lines` 夹到 [1,6]、button 写死 64/65、坐标用服务端 `renderCols/renderRows` **网格中心**（绝不取客户端坐标、绝不 (1,1)）。`scroll` 分支不经过 `authedClients`（这正是只读要放行的）,但严格 gate 在适配器能力上,未开启的 CLI 整条丢弃。

### 5. 会话级共享 idle-reset burst 限流（防洪泛/叠加）
客户端 `lines≤6` 只绑页面;viewToken 持有者可绕过页面、循环发消息、开多连接。所以服务端加**单一共享**（非 per-connection）idle-reset burst:
- `readonlyScrollBurst` 全 viewer 共享,容量 6 tick
- **只有全体静默满 250ms** 才重置额度;方向反转只更新 dir、**不刷新额度**（#577 客户端反转重开是写权限路径,只读是安全边界不能照搬——否则交替 up/down 可清零额度无限洪泛）
- 连续流量（同向/交替、单连接/多连接交织）共享同一 6-tick 上限;`scroll` 分支先 `admitReadonlyScrollTicks` 扣减、拿 0 直接丢,再把放行数作为 `maxTicks` 收敛合成量

## 安全边界

从「只读零字节」收敛为「只读只能触发受限滚轮」。已封堵的绕过路径：
- **伪造点击/审批**：button/坐标全服务端固定,客户端只能给方向+格数
- **能力越界**：per-variant 显式 opt-in,relay 及其余 CLI 关闭,fork 不自动继承
- **多连接/重连叠加**：共享 burst,非 per-connection,重连不刷新
- **持续洪泛**：连续流量共享 6-tick 上限,唯一重开是全体静默满 250ms
- **反转刷额度**：反转不重置额度

## 影响面

- **跨 CLI**：仅 claude-code + seed 受益;**relay 复用 Claude-family 工厂但确认关闭**;其余 20+ CLI 行为不变
- **跨后端**：仅 shared relay（pty/tmux-pipe）;tmux/zellij attach、Herdr 快照历史路径语义不变（Herdr 下 `herdrWebScrollDirection` 仍正确更新）
- **写入模式**：完全不变,仍走 `_fwdScroll` 原始转发

## 测试

```
$ pnpm vitest run test/web-terminal-readonly-scroll.test.ts   # 8 passed
$ pnpm vitest run test/web-terminal-touch-scroll.test.ts      # 10 passed
$ pnpm vitest run test/cli-adapters.test.ts                   # 304 passed（含新增能力行为测试）
$ pnpm vitest run test/terminal-write-auth.test.ts            # 29 passed（鉴权边界）
```

关键覆盖：
- **adapter 行为测试**（cli-adapters.test.ts,实例化真实 adapter,非源码 grep）：claude-code/seed 断言 `readonlyWheelScroll === true`;**relay 断言 `!== true`（复用工厂不继承）**;sweep 全部 24 个 CliId,opted-in 集合外一律 `!== true`
- **共享 idle-only burst**（readonly-scroll.test.ts,忠实端口 `admitReadonlyScrollTicks`）：多连接 N=10 各刷 100 次总计仅 6（非 6·N）;3 连接交织每 10ms 洪泛 1s 累计仍 6;完整空闲 250ms 才重开;重连不刷新;**反转不重置（交替 up/down 全拿 0）**
- **字节合成**：固定 64/65 + 服务端坐标 + lines 夹取 + maxTicks 收敛;拒绝非法 dir;永不产生点击(button 0)/释放(m)序列
- **handler 顺序**：先 admit 再 write

`npx tsc`:错误数与 master 一致（28 个全在 `src/desktop/`,本机未装 electron 的既有环境限制,与本改动无关）。

> 后续可另开轻量 WS 集成测试专项,用真实 viewToken 连接跑一遍限流/鉴权（Aiden 确认不阻塞本轮）。只读滚动手感建议合并后飞书实测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)