### PR TITLE
fix(terminal): derive stable write token so operate links survive worker restart

### DIFF
--- a/src/core/terminal-write-auth.ts
+++ b/src/core/terminal-write-auth.ts
@@ -64,6 +64,27 @@ export function deriveTerminalViewToken(secret: string, sessionId: string): stri
     .digest('base64url');
 }
 
+/**
+ * Derive a stable WRITE (operate) capability for one session. Mirrors
+ * deriveTerminalViewToken but uses a DISTINCT domain separator so the two
+ * capabilities can never collide — knowing the view token must never yield the
+ * write token (and vice versa) even for the same session+secret.
+ *
+ * Rationale: the write token used to be a per-process `randomBytes(16)`, so an
+ * already-issued 「操作链接」/write link (`?token=`) died the moment its worker
+ * restarted (a silent daemon restart re-forks every worker → new token → old
+ * link 403s). Deriving it from the host-only dashboard secret keeps the operate
+ * link valid across restarts, exactly like the read-only view token. The
+ * host-only secret is masked from sandboxed CLIs, so a sandboxed CLI still
+ * can't mint its own write link.
+ */
+export function deriveTerminalWriteToken(secret: string, sessionId: string): string {
+  return createHmac('sha256', secret)
+    .update('botmux-terminal-write-v1\0')
+    .update(sessionId)
+    .digest('base64url');
+}
+
 export function resolveTerminalWrite(
   { role, tokenMatches, platformBound, platformProxied }: TerminalWriteInput,
 ): { hasWrite: boolean; platformReadonly: boolean } {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -94,6 +94,7 @@ import { loadBotConfigs, type BotConfig } from './bot-registry.js';
 import { readGlobalConfig } from './global-config.js';
 import {
   deriveTerminalViewToken,
+  deriveTerminalWriteToken,
   resolveTerminalAccessForRequest,
   safeTerminalTokenEqual,
   type TerminalAccessDecision,
@@ -823,7 +824,12 @@ const authedClients = new WeakSet<WebSocket>();
 const clientPtys = new Map<WebSocket, pty.IPty>();
 /** Managed-Herdr viewers survive an in-worker /restart while backend changes. */
 const herdrWebBindings = new Map<WebSocket, HerdrWebTerminalBinding>();
-const writeToken = randomBytes(16).toString('hex');
+// Standalone/test fallback. Production replaces this after init with a stable
+// per-session HMAC derived from the host-only dashboard secret, so an
+// already-issued 「操作链接」/write link survives a worker restart (a silent
+// daemon restart re-forks every worker — a per-process random token would 403
+// every previously-issued operate link).
+let writeToken = randomBytes(16).toString('hex');
 // Standalone/test fallback. Production replaces this after init with a stable
 // per-session HMAC derived from the host-only dashboard secret.
 let viewToken = randomBytes(32).toString('base64url');
@@ -838,6 +844,15 @@ const DASHBOARD_SECRET_PATH = join(homedir(), '.botmux', '.dashboard-secret');
 function refreshTerminalViewToken(): void {
   const secret = loadDashboardSecret(DASHBOARD_SECRET_PATH);
   if (secret && sessionId) viewToken = deriveTerminalViewToken(secret, sessionId);
+}
+
+/** Re-derive the stable write (operate) token from the host-only dashboard
+ *  secret so a restarted worker mints the SAME token — keeping already-issued
+ *  「操作链接」/write links valid across restarts. Falls back to the random
+ *  boot token when the secret is unavailable (standalone/test). */
+function refreshTerminalWriteToken(): void {
+  const secret = loadDashboardSecret(DASHBOARD_SECRET_PATH);
+  if (secret && sessionId) writeToken = deriveTerminalWriteToken(secret, sessionId);
 }
 
 /**
@@ -9118,6 +9133,7 @@ process.on('message', async (raw: unknown) => {
       lastInitConfig = msg;
       sessionId = msg.sessionId;
       refreshTerminalViewToken();
+      refreshTerminalWriteToken();
       if (msg.ownerOpenId) process.env.__OWNER_OPEN_ID = msg.ownerOpenId;
       // Pin this worker's i18n locale early so every t() call below resolves
       // against the bot's chosen language without each callsite needing to

--- a/test/terminal-write-auth.test.ts
+++ b/test/terminal-write-auth.test.ts
@@ -17,6 +17,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   deriveTerminalViewToken,
+  deriveTerminalWriteToken,
   resolveTerminalAccess,
   resolveTerminalAccessForRequest,
   resolveTerminalWrite,
@@ -69,6 +70,23 @@ describe('terminal view capability', () => {
       platformBound: false,
       platformProxied: false,
     })).toEqual({ hasRead: true, hasWrite: true, platformReadonly: false });
+  });
+});
+
+describe('terminal write capability', () => {
+  it('is stable for one session, domain-bound to the session, and secret-bound', () => {
+    // Stability across derivations is what keeps an issued operate link valid
+    // after a worker restart re-derives the token.
+    const a = deriveTerminalWriteToken('host-secret', 'session-a');
+    expect(a).toBe(deriveTerminalWriteToken('host-secret', 'session-a'));
+    expect(a).not.toBe(deriveTerminalWriteToken('host-secret', 'session-b'));
+    expect(a).not.toBe(deriveTerminalWriteToken('other-secret', 'session-a'));
+  });
+
+  it('is distinct from the view token for the same session + secret (domain separation)', () => {
+    // Knowing the read-only view token must never yield the write token.
+    expect(deriveTerminalWriteToken('host-secret', 'session-a'))
+      .not.toBe(deriveTerminalViewToken('host-secret', 'session-a'));
   });
 });
 

--- a/test/worker-terminal-read-auth.integration.test.ts
+++ b/test/worker-terminal-read-auth.integration.test.ts
@@ -6,7 +6,7 @@ import { join, resolve } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { WebSocket } from 'ws';
 import type { DaemonToWorker, WorkerToDaemon } from '../src/types.js';
-import { deriveTerminalViewToken } from '../src/core/terminal-write-auth.js';
+import { deriveTerminalViewToken, deriveTerminalWriteToken } from '../src/core/terminal-write-auth.js';
 
 const children = new Set<ChildProcess>();
 const tempDirs = new Set<string>();
@@ -136,6 +136,10 @@ setInterval(() => {}, 1_000);
     const ready = await waitForReady(child, logs);
 
     expect(ready.viewToken).toBe(deriveTerminalViewToken(secret, sessionId));
+    // The operate/write link must also be the stable HMAC (not the random boot
+    // token), so an already-issued 「操作链接」survives a worker restart that
+    // re-runs init → refreshTerminalWriteToken → ready.
+    expect(ready.token).toBe(deriveTerminalWriteToken(secret, sessionId));
     const base = `http://127.0.0.1:${ready.port}`;
 
     const scanner = await fetch(`${base}/`);


### PR DESCRIPTION
## Problem

The web-terminal 「🔑 操作链接」/write link (`http://<host>:<port>/s/<sessionId>?token=...`) starts returning **403 Forbidden** after a while, even though the session is still alive and its read-only 「🖥️ 打开 Web 终端」link opens fine.

## Root cause

The read-only view token was already migrated to a stable per-session HMAC (`deriveTerminalViewToken`), so read links survive restarts. But the write/operate token is still a per-process value minted at worker boot:

```ts
const writeToken = randomBytes(16).toString('hex');
```

A silent daemon restart re-forks every worker, regenerating that token — so every previously-issued write link immediately 403s.

Reproduced on a live session:
- old `?token=…` → **HTTP 403**
- freshly-derived stable viewToken on the same session → **HTTP 200**

i.e. the session is reachable; only the operate token went stale after the worker restart.

## Fix

Derive the write token the same way as the view token — from the host-only dashboard secret — but with a **distinct domain separator** `botmux-terminal-write-v1` so the two capabilities can never collide (knowing the read token must never yield the write token, and vice-versa). A restarted worker re-mints the same operate token, keeping already-issued write links valid.

- Falls back to the random boot token when the secret is unavailable (standalone/test).
- The host-only secret stays masked from sandboxed CLIs, so a sandboxed CLI still cannot mint its own write link.

## Tests

`test/terminal-write-auth.test.ts` adds: write token is stable per session, domain/secret-bound, and distinct from the view token for the same session+secret.

- `npx tsc --noEmit` ✅
- `vitest run` terminal-write-auth (31) + worker read-auth integration (1) all green ✅