### PR TITLE
feat(im): 实时事件 <sender> 名字兜底走 message.get(with_sender_name)

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -14584,7 +14584,7 @@ async function startInitialPassthroughSession(args: {
   const botCfg = getBot(larkAppId).config;
   refreshCliVersion(botCfg.cliId, botCfg.cliPathOverride);
   const directChatSender = chatType === 'p2p'
-    ? await resolveSender(larkAppId, senderOpenId, parsed.senderType)
+    ? await resolveSender(larkAppId, senderOpenId, parsed.senderType, { messageId })
     : undefined;
   // Group cold-start passthroughs only need a stable caller identity while the
   // repo picker is pending. Avoid adding a contact lookup to every /goal start;
@@ -14967,7 +14967,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
         setDirectChatDisplayNameFromSender(
           session,
           chatType,
-          await resolveSender(larkAppId, senderOpenId, parsed.senderType),
+          await resolveSender(larkAppId, senderOpenId, parsed.senderType, { messageId }),
         );
       }
       session.larkAppId = larkAppId;
@@ -15054,7 +15054,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
     parsed.content,
     parsed.mentions,
   );
-  const newTopicSender = await resolveSender(larkAppId, senderOpenId, parsed.senderType);
+  const newTopicSender = await resolveSender(larkAppId, senderOpenId, parsed.senderType, { messageId });
 
   refreshCliVersion(botCfg.cliId, botCfg.cliPathOverride);
 
@@ -15540,7 +15540,9 @@ async function handleThreadReply(data: any, ctx: RoutingContext): Promise<void> 
       larkAppId,
       senderOpenIdForPrefix,
       parsed.senderType,
-      isForeignBot ? { type: 'bot', name: foreignBotName !== 'Bot' ? foreignBotName : undefined } : undefined,
+      isForeignBot
+        ? { type: 'bot', name: foreignBotName !== 'Bot' ? foreignBotName : undefined, messageId: parsed.messageId }
+        : { messageId: parsed.messageId },
     );
     return threadSenderCached;
   };

--- a/src/im/lark/identity-cache.ts
+++ b/src/im/lark/identity-cache.ts
@@ -23,7 +23,7 @@ import { join, dirname } from 'node:path';
 import { getBotClient } from '../../bot-registry.js';
 import { config } from '../../config.js';
 import { logger } from '../../utils/logger.js';
-import { larkGet } from './client.js';
+import { larkGet, getMessageDetail } from './client.js';
 
 export type IdentityType = 'user' | 'bot' | 'app' | 'unknown';
 
@@ -31,7 +31,7 @@ export interface IdentityRecord {
   openId: string;
   type: IdentityType;
   name?: string;
-  source: 'sender' | 'mention' | 'contact_api' | 'bot_cross_ref' | 'bot_info';
+  source: 'sender' | 'mention' | 'contact_api' | 'message_api' | 'bot_cross_ref' | 'bot_info';
   updatedAt: number;
 }
 
@@ -245,6 +245,46 @@ async function fetchUserName(larkAppId: string, openId: string): Promise<void> {
   }
 }
 
+/**
+ * Best-effort name resolution via `im.v1.messages.get` with `with_sender_name=true`.
+ * Unlike the contact API this covers BOTH user and bot senders and does NOT
+ * require `contact:user.base:readonly` — the server returns the display name
+ * for whoever sent the given message. Used as a last-resort fallback in the
+ * live-event path, where the event itself carries only open_id.
+ *
+ * Best-effort: any failure (network, permission, message not found, name
+ * absent) degrades silently to `undefined`. Wrapped in the same short budget
+ * as the contact path so a slow API can't stall prompt injection. On success
+ * the name is written to the cache keyed by the resolved sender's open_id, so
+ * later messages from the same sender hit the cache without a re-fetch.
+ */
+export async function resolveNameViaMessage(
+  larkAppId: string,
+  openId: string,
+  messageId: string,
+  type: 'user' | 'bot',
+): Promise<string | undefined> {
+  if (!openId || !messageId) return undefined;
+  try {
+    const detail = await withTimeout(
+      getMessageDetail(larkAppId, messageId, { userCardContent: false }),
+      RESOLVE_BUDGET_MS,
+    );
+    const sender = detail?.items?.[0]?.sender;
+    const name: unknown = sender?.sender_name;
+    if (typeof name === 'string' && name.trim()) {
+      const trimmed = name.trim();
+      recordIdentity(larkAppId, { openId, name: trimmed, type, source: 'message_api' });
+      return trimmed;
+    }
+  } catch (err: any) {
+    logger.debug(
+      `[identity] message.get sender_name for ${openId.substring(0, 12)} via ${messageId.substring(0, 12)} failed: ${err?.message ?? err}`,
+    );
+  }
+  return undefined;
+}
+
 function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const t = setTimeout(() => reject(new Error('identity-resolve-timeout')), ms);
@@ -270,12 +310,21 @@ export interface ResolvedSender {
  * lookups, and best-effort resolve the display name. Caller-supplied hints
  * (e.g. a known foreign-bot display name from `bot-openids-${appId}.json`)
  * win over cache.
+ *
+ * Name resolution order (each step only runs if the prior didn't yield a name):
+ *   1. hint / cache — free, in-memory.
+ *   2. contact API — users only; needs `contact:user.base:readonly`.
+ *   3. message.get(`with_sender_name=true`) — fallback when `messageId` is
+ *      supplied and steps 1–2 came up empty. Covers users AND bots, and works
+ *      without the contact scope (the server names whoever sent that message).
+ *      This is what lets the live-event `<sender>` tag carry a name even when
+ *      contact is unavailable / out of visible range / the sender is a bot.
  */
 export async function resolveSender(
   larkAppId: string,
   openId: string | undefined,
   senderType: string | undefined,
-  hint?: { name?: string; type?: 'user' | 'bot' },
+  hint?: { name?: string; type?: 'user' | 'bot'; messageId?: string },
 ): Promise<ResolvedSender | undefined> {
   if (!openId) return undefined;
 
@@ -293,6 +342,12 @@ export async function resolveSender(
   let name = hint?.name ?? getIdentity(larkAppId, openId)?.name;
   if (!name && type === 'user') {
     name = await resolveName(larkAppId, openId);
+  }
+  // Last-resort fallback: server-side sender_name via message.get. Covers the
+  // gap the contact API can't (bots, missing scope, out-of-range users) but
+  // only when the caller knows which message this sender is attached to.
+  if (!name && hint?.messageId) {
+    name = await resolveNameViaMessage(larkAppId, openId, hint.messageId, type);
   }
   return { openId, type, name };
 }

--- a/test/identity-cache-message-fallback.test.ts
+++ b/test/identity-cache-message-fallback.test.ts
@@ -1,0 +1,97 @@
+/**
+ * resolveSender's message.get fallback (B 方案).
+ *
+ * The live-event path only carries a sender open_id, so `<sender>` tag names
+ * come from best-effort resolution. Order: cache/hint → contact API (users
+ * only, needs scope) → message.get(with_sender_name=true) as last resort. The
+ * message fallback covers what contact can't: bots, missing/out-of-range
+ * contact scope. It only fires when a `messageId` hint is supplied AND the
+ * earlier steps produced no name, so the happy path (cache hit) never pays an
+ * extra API round-trip.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getMessageDetail = vi.fn();
+const larkGet = vi.fn();
+
+vi.mock('../src/im/lark/client.js', () => ({
+  getMessageDetail: (...a: unknown[]) => getMessageDetail(...a),
+  larkGet: (...a: unknown[]) => larkGet(...a),
+}));
+
+vi.mock('../src/bot-registry.js', () => ({
+  getBotClient: () => ({}),
+}));
+
+vi.mock('../src/config.js', () => ({
+  config: { session: { dataDir: '/tmp/botmux-identity-test' } },
+}));
+
+import { resolveSender } from '../src/im/lark/identity-cache.js';
+
+const APP = 'cli_identity_test';
+
+describe('resolveSender message.get fallback', () => {
+  beforeEach(() => {
+    getMessageDetail.mockReset();
+    larkGet.mockReset();
+    // contact API miss by default so the fallback path is exercised for users.
+    larkGet.mockResolvedValue({ code: 0, data: { user: {} } });
+  });
+
+  it('resolves a bot sender name via message.get when contact cannot (bots skip contact)', async () => {
+    getMessageDetail.mockResolvedValue({
+      items: [{ sender: { sender_name: 'Premium(Claude)' } }],
+    });
+    const s = await resolveSender(APP, 'ou_bot_1', 'app', { messageId: 'om_1' });
+    expect(s).toMatchObject({ openId: 'ou_bot_1', type: 'bot', name: 'Premium(Claude)' });
+    // Bots never hit the contact API; only the message fallback ran.
+    expect(larkGet).not.toHaveBeenCalled();
+    expect(getMessageDetail).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to message.get for a user when contact yields no name', async () => {
+    getMessageDetail.mockResolvedValue({
+      items: [{ sender: { sender_name: '杨志发' } }],
+    });
+    const s = await resolveSender(APP, 'ou_user_1', 'user', { messageId: 'om_2' });
+    expect(s).toMatchObject({ type: 'user', name: '杨志发' });
+    expect(getMessageDetail).toHaveBeenCalledOnce();
+  });
+
+  it('caches the resolved name so a later resolve needs no second fetch', async () => {
+    getMessageDetail.mockResolvedValue({
+      items: [{ sender: { sender_name: '杨志发' } }],
+    });
+    await resolveSender(APP, 'ou_user_cache', 'user', { messageId: 'om_3' });
+    getMessageDetail.mockClear();
+    const s2 = await resolveSender(APP, 'ou_user_cache', 'user', { messageId: 'om_3b' });
+    expect(s2?.name).toBe('杨志发');
+    expect(getMessageDetail).not.toHaveBeenCalled();
+  });
+
+  it('does not call message.get when no messageId hint is supplied', async () => {
+    const s = await resolveSender(APP, 'ou_no_hint', 'app');
+    expect(s).toMatchObject({ type: 'bot', name: undefined });
+    expect(getMessageDetail).not.toHaveBeenCalled();
+  });
+
+  it('does not call message.get when a name is already known via hint', async () => {
+    const s = await resolveSender(APP, 'ou_hinted', 'app', { name: 'KnownBot', messageId: 'om_4' });
+    expect(s?.name).toBe('KnownBot');
+    expect(getMessageDetail).not.toHaveBeenCalled();
+  });
+
+  it('degrades silently to undefined name when message.get has no sender_name', async () => {
+    getMessageDetail.mockResolvedValue({ items: [{ sender: {} }] });
+    const s = await resolveSender(APP, 'ou_blank', 'app', { messageId: 'om_5' });
+    expect(s).toMatchObject({ type: 'bot', name: undefined });
+    expect(getMessageDetail).toHaveBeenCalledOnce();
+  });
+
+  it('degrades silently when message.get throws', async () => {
+    getMessageDetail.mockRejectedValue(new Error('boom'));
+    const s = await resolveSender(APP, 'ou_err', 'app', { messageId: 'om_6' });
+    expect(s).toMatchObject({ type: 'bot', name: undefined });
+  });
+});

--- a/test/identity-cache-message-fallback.test.ts
+++ b/test/identity-cache-message-fallback.test.ts
@@ -5,14 +5,29 @@
  * come from best-effort resolution. Order: cache/hint → contact API (users
  * only, needs scope) → message.get(with_sender_name=true) as last resort. The
  * message fallback covers what contact can't: bots, missing/out-of-range
- * contact scope. It only fires when a `messageId` hint is supplied AND the
- * earlier steps produced no name, so the happy path (cache hit) never pays an
- * extra API round-trip.
+ * contact scope, AND a contact lookup that hangs/times out. It only fires when
+ * a `messageId` hint is supplied AND the earlier steps produced no name, so the
+ * happy path (cache hit) never pays an extra API round-trip.
+ *
+ * Each step keeps its own `RESOLVE_BUDGET_MS` timeout on purpose: a *single*
+ * shared deadline would let a hung contact lookup consume the whole budget and
+ * starve the message.get fallback — which is exactly the "contact 首查超时"
+ * case the PR exists to cover. The ~1.6s worst case (both APIs slow) is an
+ * accepted, non-blocking tradeoff; losing fallback coverage is not.
+ *
+ * Each test runs against a unique on-disk cache dir (mkdtemp) so a real flush
+ * can't leak an `identities-*.json` file into the next run and silently short-
+ * circuit the "fallback actually fires" / "cache hit skips fetch" assertions.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const getMessageDetail = vi.fn();
 const larkGet = vi.fn();
+// Mutable so beforeEach can repoint the identity cache at a fresh temp dir.
+const mockConfig = vi.hoisted(() => ({ session: { dataDir: '' } }));
 
 vi.mock('../src/im/lark/client.js', () => ({
   getMessageDetail: (...a: unknown[]) => getMessageDetail(...a),
@@ -24,19 +39,32 @@ vi.mock('../src/bot-registry.js', () => ({
 }));
 
 vi.mock('../src/config.js', () => ({
-  config: { session: { dataDir: '/tmp/botmux-identity-test' } },
+  config: mockConfig,
 }));
 
-import { resolveSender } from '../src/im/lark/identity-cache.js';
+import { resolveSender, flushIdentityCacheSync } from '../src/im/lark/identity-cache.js';
 
 const APP = 'cli_identity_test';
 
 describe('resolveSender message.get fallback', () => {
+  let dataDir: string;
+
   beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'botmux-identity-test-'));
+    mockConfig.session.dataDir = dataDir;
     getMessageDetail.mockReset();
     larkGet.mockReset();
     // contact API miss by default so the fallback path is exercised for users.
     larkGet.mockResolvedValue({ code: 0, data: { user: {} } });
+  });
+
+  afterEach(() => {
+    // Restore real timers (only the contact-timeout test swaps them in) and
+    // clear the module-level flush debounce so it can't fire into the next
+    // test's dir.
+    vi.useRealTimers();
+    flushIdentityCacheSync();
+    rmSync(dataDir, { recursive: true, force: true });
   });
 
   it('resolves a bot sender name via message.get when contact cannot (bots skip contact)', async () => {
@@ -93,5 +121,26 @@ describe('resolveSender message.get fallback', () => {
     getMessageDetail.mockRejectedValue(new Error('boom'));
     const s = await resolveSender(APP, 'ou_err', 'app', { messageId: 'om_6' });
     expect(s).toMatchObject({ type: 'bot', name: undefined });
+  });
+
+  it('still falls back to message.get after a hung contact lookup times out (PR core case)', async () => {
+    vi.useFakeTimers();
+    // contact.v3.user.get never settles → its per-step withTimeout must trip at
+    // RESOLVE_BUDGET_MS. The message.get fallback MUST still run afterwards; a
+    // shared/total deadline that let contact eat the whole budget would starve
+    // it, silently dropping the exact "contact 首查超时" case the PR targets.
+    larkGet.mockImplementation(() => new Promise(() => {}));
+    getMessageDetail.mockResolvedValue({
+      items: [{ sender: { sender_name: '杨志发' } }],
+    });
+
+    const p = resolveSender(APP, 'ou_slow_contact', 'user', { messageId: 'om_slow' });
+    // Trip the contact-step timeout (RESOLVE_BUDGET_MS = 800ms).
+    await vi.advanceTimersByTimeAsync(800);
+    const s = await p;
+
+    expect(larkGet).toHaveBeenCalled();
+    expect(getMessageDetail).toHaveBeenCalledOnce();
+    expect(s).toMatchObject({ type: 'user', name: '杨志发' });
   });
 });


### PR DESCRIPTION
## 背景 / 为什么 #480 对这个问题没用

用户（杨志发）反馈：升级后 codex 收到的 prompt 里 \`<sender type=\"user\" open_id=\"...\" />\` 少了 \`name\` 属性。

排查发现 botmux 有两条独立的「发送者名字」链路：

1. **实时事件路径 `receive_v1`** —— 就是注入进 CLI prompt 的 `<sender>`。名字只靠 `identity-cache` 的 `contact.v3.user.get` 现补，**contact 缺权限 / 可见范围不含发送人 / 首次查询超时 / 发送方是 bot** 时就降级成没有 `name`。
2. **API 读消息路径**（history / quoted / 合并转发 / dashboard 历史）—— PR #480 加了 `with_sender_name=true` 的就是这条。

#480 的描述里已写明「实时事件路径 receive_v1 不带 sender_name，不受影响」。所以它优化的是事后读历史的名字，用户看到的是消息进来那一刻的 `<sender>`，两条路径不重叠 → 没起作用。

## 改了什么

在 `resolveSender` 增加**最后一层兜底**（B 方案，只在名字缺失时才查）：

- `src/im/lark/identity-cache.ts`：新增 `resolveNameViaMessage`，当 hint / cache / contact API 都没拿到名字、且调用方带了 `messageId` 时，用 `getMessageDetail(with_sender_name=true)`（复用 #480 已改好的调用，套同一 `RESOLVE_BUDGET_MS` 预算）反查一次 `items[0].sender.sender_name`。它**同时覆盖 user 和 bot**，且**不依赖 contact scope**（服务端直接返回这条消息发送方的显示名）。解析到的名字写回 identity 缓存，后续同发送方命中缓存不再请求。`IdentityRecord.source` 增加 `'message_api'`。
- `src/daemon.ts`：4 个 `<sender>` 注入点（p2p 冷启动 / p2p 命令 / 新话题 / 话题回复）把入站 `messageId` 透给 `resolveSender`；订阅、定时等无入站消息的调用点不传，行为不变。

名字优先级：**hint > cache > contact API > message.get 兜底**，纯增量，不带 messageId 时与改动前完全一致。

## 影响面

仅 **Lark 实时事件的 `<sender>` 名字解析链路**。跨 CLI / 跨后端无涉（改动都在 Lark identity-cache 与 daemon 注入点，且是纯增量兜底）。

## 测试验证

- 新增 \`test/identity-cache-message-fallback.test.ts\`，**7 例全绿**：bot 兜底、user contact miss 后兜底、缓存命中不再请求、无 messageId 不请求、hint 已有名字不请求、无 sender_name / 抛错静默降级。
- 回归 \`message-parser\` / \`merge-forward\` / \`dashboard-history-senders\` 共 **86 例全绿**。
- \`pnpm build\`：改动文件 tsc 无报错（\`src/desktop\` 的 electron 报错在干净 master 上同样存在，与本 PR 无关）。
- ⚠️ **live 实测待补**：此 checkout 的 desktop 依赖缺失导致完整 build 失败、dist 未刷新，未在飞书实测。建议在干净构建环境 \`switch:here && daemon:restart\` 后，让 contact 缺权限的 bot 发一条消息验证 prompt 里 \`<sender>\` 带上了 name。

🤖 Generated with [Claude Code](https://claude.com/claude-code)