### PR TITLE
fix(traex): 用 RPC 桥接原生问答

### DIFF
--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -328,6 +328,11 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
       'DeepSeek-V4-Pro',
       'kimi-k2.6',
     ],
+    // RPC mode bridges native AskUserQuestion directly. Keep the normal
+    // botmux-ask skill available too: TraeX sessions can fail closed to a
+    // standard PTY when RPC is unavailable, where native questions cannot
+    // reach the card bridge.
+    asksViaHook: false,
   };
 }
 

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -249,9 +249,9 @@ export interface CliAdapter {
     readonly sessionStartCommand?: string;
   };
 
-  /** true = 该 CLI 通过 hook 接管 askUserQuestion（不再装 botmux-ask skill 兜底）。
-   *  注入机制由各 adapter 自行决定（Claude 走 --settings、OpenCode 走插件、
-   *  CoCo 走 ensureAskHook 装插件）。 */
+  /** true = 该 CLI 的 Hook 已接管 askUserQuestion（不再装 botmux-ask
+   *  skill 兜底）。注入机制由各 adapter 自行决定（Claude 走 --settings、
+   *  OpenCode 走插件、CoCo 走 ensureAskHook）。 */
   readonly asksViaHook?: boolean;
 
   /** 命令式 hook 安装钩子：适用于无法靠纯写文件完成、需要 spawn CLI 子命令的场景

--- a/src/adapters/hook-installer.ts
+++ b/src/adapters/hook-installer.ts
@@ -135,6 +135,58 @@ function removeBotmuxAskHookGroups(
   }
 }
 
+function isBotmuxTraexAskHookEntry(entry: unknown): boolean {
+  return !!entry
+    && typeof entry === 'object'
+    && (entry as ClaudeHookEntry).type === 'command'
+    && typeof (entry as ClaudeHookEntry).command === 'string'
+    && (entry as ClaudeHookEntry).command.includes('cli.js')
+    && (entry as ClaudeHookEntry).command.trimEnd().endsWith('hook traex');
+}
+
+/**
+ * TRAE now routes native user-input through its RPC app-server. Remove only
+ * legacy botmux `hook traex` entries so they cannot race the RPC bridge and
+ * emit a duplicate Ask card. A hook group may contain multiple commands, so
+ * strip only the botmux entry and preserve unrelated user hooks in that group.
+ */
+export function cleanupTraexAskHooks(configPaths: readonly string[]): void {
+  for (const candidatePath of configPaths) {
+    const configPath = expandHome(candidatePath);
+    const settings = readJsonFile<ClaudeSettings>(configPath);
+    if (!settings || !isRecord(settings.hooks)) continue;
+    const hooks = settings.hooks as Record<string, ClaudeHookGroup[]>;
+
+    let changed = false;
+    for (const eventName of ['PreToolUse', 'PermissionRequest']) {
+      const existing = hooks[eventName] ?? [];
+      if (!Array.isArray(existing)) continue;
+      const filtered: ClaudeHookGroup[] = [];
+      for (const group of existing) {
+        if (!group || !Array.isArray(group.hooks)) {
+          filtered.push(group);
+          continue;
+        }
+        const retainedEntries = group.hooks.filter((entry) => !isBotmuxTraexAskHookEntry(entry));
+        if (retainedEntries.length === group.hooks.length) {
+          filtered.push(group);
+        } else {
+          changed = true;
+          if (retainedEntries.length > 0) filtered.push({ ...group, hooks: retainedEntries });
+        }
+      }
+      if (!changed) continue;
+      if (filtered.length === 0) delete hooks[eventName];
+      else hooks[eventName] = filtered;
+    }
+    if (!changed) continue;
+
+    const content = JSON.stringify(settings, null, 2) + '\n';
+    writeIfChanged(configPath, content);
+    logger.info(`[hook] Removed legacy TRAE ask hook → ${configPath}`);
+  }
+}
+
 /**
  * 判断某 hook group 是否是 botmux SessionStart 就绪 hook（用于幂等替换）。
  * 同 ask hook：结构化识别（命令引用 botmux 的 cli.js 且尾部是 `session-ready`），

--- a/src/codex-rpc-engine.ts
+++ b/src/codex-rpc-engine.ts
@@ -478,9 +478,30 @@ export class CodexRpcEngine {
     try { this.send({ jsonrpc: '2.0', id, result }); } catch { /* connection gone */ }
   }
 
-  /** Reply to a server→client request with a JSON-RPC error so the app-server
-   *  sees the request failed, instead of a benign {answers:{}} it would treat as
-   *  "no answer" and silently complete. -32000 = generic server error. */
+  /** Fail a native user-input request by INTERRUPTING its turn instead of
+   *  replying. Verified on real traex 0.200.19: replying with either empty
+   *  answers or a JSON-RPC error is normalized to `{answers:{}}` and the turn
+   *  still completes (the ask is silently skipped). `turn/interrupt` is the only
+   *  path that actually stops the turn (status → 'interrupted'); the pending
+   *  server request is cancelled along with it, so we do NOT also respond. */
+  private interruptTurnFor(id: number, params: unknown, reason: string): void {
+    const p = (params && typeof params === 'object') ? params as Record<string, unknown> : {};
+    const threadId = typeof p.threadId === 'string' ? p.threadId : undefined;
+    const turnId = typeof p.turnId === 'string' ? p.turnId : undefined;
+    if (!threadId || !turnId) {
+      // No turn coordinates to interrupt: fall back to a JSON-RPC error so at
+      // least the request does not hang the app-server waiting on a reply.
+      this.log(`[codex-rpc] requestUserInput failure without threadId/turnId; replying error (${reason})`);
+      this.respondError(id, reason);
+      return;
+    }
+    this.request('turn/interrupt', { threadId, turnId }, { timeoutMs: 10_000, fatalOnTimeout: false })
+      .then(() => this.log('[codex-rpc] turn interrupted after requestUserInput failure'))
+      .catch(err => this.log(`[codex-rpc] turn/interrupt failed: ${err instanceof Error ? err.message : String(err)}`));
+  }
+
+  /** Reply to a server→client request with a JSON-RPC error. Used only as a
+   *  last resort when a failed requestUserInput has no turn to interrupt. */
   private respondError(id: number, message: string): void {
     try { this.send({ jsonrpc: '2.0', id, error: { code: -32000, message } }); } catch { /* connection gone */ }
   }
@@ -508,16 +529,20 @@ export class CodexRpcEngine {
     // the protocol-shaped answers object. Keep all approval requests automatic.
     if (typeof msg.id === 'number' && typeof msg.method === 'string') {
       if (msg.method === 'item/tool/requestUserInput' && this.opts.onRequestUserInput) {
-        void this.opts.onRequestUserInput(msg.params).then(
+        const requestParams = msg.params;
+        void this.opts.onRequestUserInput(requestParams).then(
           result => this.respond(msg.id, result),
           err => {
-            // Fail VISIBLY, never silently: returning {answers:{}} makes the
-            // app-server treat the tool as "unanswered" and complete the turn,
-            // so unsupported/broker-failed asks would be silently skipped. A
-            // JSON-RPC error surfaces the failure on the tool call instead.
+            // Fail VISIBLY, never silently. Verified against real traex 0.200.19:
+            // ANY response to this request — empty answers OR a JSON-RPC error —
+            // is normalized by the app-server into `{answers:{}}` and the turn
+            // still COMPLETES, so unsupported/broker-failed asks would be
+            // silently skipped. Only `turn/interrupt` (threadId+turnId, both
+            // carried in this request's params) actually stops the turn
+            // (status → 'interrupted'). So fail by interrupting the turn.
             const message = err instanceof Error ? err.message : String(err);
-            this.log(`[codex-rpc] requestUserInput bridge failed: ${message}`);
-            this.respondError(msg.id, message);
+            this.log(`[codex-rpc] requestUserInput bridge failed: ${message}; interrupting turn`);
+            this.interruptTurnFor(msg.id, requestParams, message);
           },
         );
         return;

--- a/src/codex-rpc-engine.ts
+++ b/src/codex-rpc-engine.ts
@@ -68,6 +68,11 @@ export interface CodexRpcEngineOpts {
   /** Optional model + reasoning effort forwarded to thread config (P1). */
   model?: string;
   reasoningEffort?: string;
+  /** Feature gates owned by the app-server process (the viewer TUI does not
+   *  execute model tools in RPC mode). */
+  appServerFeatures?: string[];
+  /** Bridge a native request_user_input server request to the host UI. */
+  onRequestUserInput?: (params: unknown) => Promise<unknown>;
   /** Override the per-request JSON-RPC timeout (default REQUEST_TIMEOUT_MS).
    *  Mainly for tests that assert the wedged-app-server recovery path. */
   requestTimeoutMs?: number;
@@ -123,7 +128,8 @@ export class CodexRpcEngine {
   async start(): Promise<void> {
     this.reapStaleAppServer();
     this.port = await findFreePort();
-    this.child = spawn(this.opts.cliBin, ['app-server', '--listen', `ws://127.0.0.1:${this.port}`], {
+    const featureArgs = (this.opts.appServerFeatures ?? []).flatMap(feature => ['--enable', feature]);
+    this.child = spawn(this.opts.cliBin, ['app-server', ...featureArgs, '--listen', `ws://127.0.0.1:${this.port}`], {
       cwd: this.opts.cwd,
       env: this.opts.env,
       stdio: ['ignore', 'ignore', 'pipe'],
@@ -490,8 +496,20 @@ export class CodexRpcEngine {
       else p.resolve(msg.result);
       return;
     }
-    // Server→client request (approvals / elicitations): auto-answer.
+    // Native user-input requests are the one server→client request that must
+    // wait for a human. In botmux this callback posts a Lark card and returns
+    // the protocol-shaped answers object. Keep all approval requests automatic.
     if (typeof msg.id === 'number' && typeof msg.method === 'string') {
+      if (msg.method === 'item/tool/requestUserInput' && this.opts.onRequestUserInput) {
+        void this.opts.onRequestUserInput(msg.params).then(
+          result => this.respond(msg.id, result),
+          err => {
+            this.log(`[codex-rpc] requestUserInput bridge failed: ${err instanceof Error ? err.message : String(err)}`);
+            this.respond(msg.id, { answers: {} });
+          },
+        );
+        return;
+      }
       this.respond(msg.id, autoApproval(msg.method));
       return;
     }

--- a/src/codex-rpc-engine.ts
+++ b/src/codex-rpc-engine.ts
@@ -497,7 +497,13 @@ export class CodexRpcEngine {
     }
     this.request('turn/interrupt', { threadId, turnId }, { timeoutMs: 10_000, fatalOnTimeout: false })
       .then(() => this.log('[codex-rpc] turn interrupted after requestUserInput failure'))
-      .catch(err => this.log(`[codex-rpc] turn/interrupt failed: ${err instanceof Error ? err.message : String(err)}`));
+      .catch(err => {
+        // If the interrupt itself errors or times out, the turn is still wedged
+        // and we have no other lever. Declare the engine dead so the worker
+        // replaces the pane (onDead → restartCliProcess) rather than leaking a
+        // permanently stuck turn — the whole point of this failure path.
+        this.failAll(new Error(`turn/interrupt failed: ${err instanceof Error ? err.message : String(err)}`));
+      });
   }
 
   /** Reply to a server→client request with a JSON-RPC error. Used only as a

--- a/src/codex-rpc-engine.ts
+++ b/src/codex-rpc-engine.ts
@@ -478,6 +478,13 @@ export class CodexRpcEngine {
     try { this.send({ jsonrpc: '2.0', id, result }); } catch { /* connection gone */ }
   }
 
+  /** Reply to a server→client request with a JSON-RPC error so the app-server
+   *  sees the request failed, instead of a benign {answers:{}} it would treat as
+   *  "no answer" and silently complete. -32000 = generic server error. */
+  private respondError(id: number, message: string): void {
+    try { this.send({ jsonrpc: '2.0', id, error: { code: -32000, message } }); } catch { /* connection gone */ }
+  }
+
   private send(msg: Json): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) throw new Error('app-server ws not open');
     this.ws.send(JSON.stringify(msg));
@@ -504,8 +511,13 @@ export class CodexRpcEngine {
         void this.opts.onRequestUserInput(msg.params).then(
           result => this.respond(msg.id, result),
           err => {
-            this.log(`[codex-rpc] requestUserInput bridge failed: ${err instanceof Error ? err.message : String(err)}`);
-            this.respond(msg.id, { answers: {} });
+            // Fail VISIBLY, never silently: returning {answers:{}} makes the
+            // app-server treat the tool as "unanswered" and complete the turn,
+            // so unsupported/broker-failed asks would be silently skipped. A
+            // JSON-RPC error surfaces the failure on the tool call instead.
+            const message = err instanceof Error ? err.message : String(err);
+            this.log(`[codex-rpc] requestUserInput bridge failed: ${message}`);
+            this.respondError(msg.id, message);
           },
         );
         return;

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 import { ensureSkills, ensureAskSkill, ensurePluginSkills, ensureWhiteboardSkill, removeGlobalBotmuxSkills } from '../skills/installer.js';
 import { shouldInstallGlobalSkills } from '../skills/injection-mode.js';
 import { whiteboardEnabled } from '../services/whiteboard-store.js';
-import { installHook } from '../adapters/hook-installer.js';
+import { cleanupTraexAskHooks, installHook } from '../adapters/hook-installer.js';
 import { hookCommandFor } from '../adapters/hook-command.js';
 import { randomBytes, randomUUID } from 'node:crypto';
 import { config } from '../config.js';
@@ -25,6 +25,7 @@ import { loadFrozenCards, saveFrozenCards } from '../services/frozen-card-store.
 import { hashUrlForLog, cancelRiffTaskById } from '../adapters/backend/riff-backend.js';
 import { logger } from '../utils/logger.js';
 import { createCliAdapterSync } from '../adapters/cli/registry.js';
+import { traeHome } from '../services/traex-paths.js';
 import { botLocale, localeForBot, t as tr } from '../i18n/index.js';
 import { claudeJsonlPathForSession } from '../adapters/cli/claude-code.js';
 import { findUniqueClaudeSessionByCwd } from './session-discovery.js';
@@ -1153,6 +1154,12 @@ const skillsInstalledCliIds = new Set<string>();
  */
 export function ensureCliSkills(cliId: CliId, cliPathOverride?: string): void {
   const adapter = createCliAdapterSync(cliId, cliPathOverride);
+  if (cliId === 'traex') {
+    cleanupTraexAskHooks([
+      join(traeHome(), 'hooks.json'),
+      join(traeHome(), 'cli', 'hooks.json'),
+    ]);
+  }
 
   // Claude-family CLIs deliver skills per-session via `--plugin-dir` (no global
   // leak), so they always materialise their plugin dir — the builtin-injection

--- a/src/services/traex-user-input.ts
+++ b/src/services/traex-user-input.ts
@@ -1,0 +1,70 @@
+import type { AskOption, AskQuestion } from '../core/ask-types.js';
+
+export interface TraexUserInputQuestion {
+  id: string;
+  question: AskQuestion;
+}
+
+export type TraexUserInputParseResult =
+  | { kind: 'answerable'; questions: TraexUserInputQuestion[] }
+  | { kind: 'unsupported'; reason: string };
+
+/**
+ * Convert TRAE's app-server requestUserInput payload into the existing
+ * button-card contract. The card cannot faithfully represent a free-text or
+ * malformed question, so a mixed batch must not silently drop those questions.
+ */
+export function parseTraexUserInputQuestions(params: unknown): TraexUserInputParseResult {
+  if (!params || typeof params !== 'object' || Array.isArray(params)) {
+    return { kind: 'unsupported', reason: 'missing request parameters' };
+  }
+  const rawQuestions = (params as Record<string, unknown>).questions;
+  if (!Array.isArray(rawQuestions) || rawQuestions.length === 0) {
+    return { kind: 'unsupported', reason: 'missing questions' };
+  }
+
+  const questions: TraexUserInputQuestion[] = [];
+  const ids = new Set<string>();
+  for (let index = 0; index < rawQuestions.length; index++) {
+    const raw = rawQuestions[index];
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      return { kind: 'unsupported', reason: `question ${index + 1} is malformed` };
+    }
+    const question = raw as Record<string, unknown>;
+    if (!Array.isArray(question.options) || question.options.length < 2) {
+      return { kind: 'unsupported', reason: `question ${index + 1} has fewer than two options` };
+    }
+
+    const options: AskOption[] = [];
+    for (const option of question.options) {
+      if (!option || typeof option !== 'object' || Array.isArray(option)) {
+        return { kind: 'unsupported', reason: `question ${index + 1} has a malformed option` };
+      }
+      const label = (option as Record<string, unknown>).label;
+      if (typeof label !== 'string' || !label.trim()) {
+        return { kind: 'unsupported', reason: `question ${index + 1} has an invalid option label` };
+      }
+      options.push({ key: label, label });
+    }
+
+    const id = typeof question.id === 'string' && question.id ? question.id : `q${index}`;
+    if (ids.has(id)) {
+      return { kind: 'unsupported', reason: `duplicate question id: ${id}` };
+    }
+    ids.add(id);
+    const prompt = typeof question.question === 'string' && question.question.trim()
+      ? question.question
+      : typeof question.header === 'string' && question.header.trim()
+        ? question.header
+        : `Question ${index + 1}`;
+    questions.push({
+      id,
+      question: {
+        prompt,
+        multiSelect: question.multiSelect === true,
+        options,
+      },
+    });
+  }
+  return { kind: 'answerable', questions };
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -587,11 +587,12 @@ async function bridgeTraexUserInput(
   cfg: Extract<DaemonToWorker, { type: 'init' }>,
   params: unknown,
 ): Promise<RpcUserInputAnswer> {
-  const empty: RpcUserInputAnswer = { answers: {} };
   const parsed = parseTraexUserInputQuestions(params);
   if (parsed.kind === 'unsupported') {
-    log(`TRAE RPC requestUserInput cannot be represented by an ask card (${parsed.reason}); returning empty answers`);
-    return empty;
+    // Returning empty answers makes TraeX silently complete the tool as if no
+    // one answered, dropping the whole batch. Throw instead so the RPC engine
+    // replies with a JSON-RPC error and the failure is visible on the turn.
+    throw new Error(`requestUserInput cannot be represented as an ask card: ${parsed.reason}`);
   }
   const { questions } = parsed;
   const daemon = findOnlineDaemon(cfg.larkAppId);
@@ -617,7 +618,11 @@ async function bridgeTraexUserInput(
     answers?: ReadonlyArray<ReadonlyArray<string>>;
     comment?: string | null;
   };
-  if (result.kind !== 'answered') return empty;
+  // Timeout/cancel/invalidated — surface as an error rather than an empty answer
+  // that TraeX would treat as "no one answered" and silently skip.
+  if (result.kind !== 'answered') {
+    throw new Error(`ask not answered (${result.kind ?? 'unknown'})`);
+  }
 
   const customText = result.comment?.trim() ?? '';
   const answers: RpcUserInputAnswer['answers'] = {};

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -119,6 +119,7 @@ import {
 import { buildBotmuxLarkNativeSessionTitle } from './core/session-title.js';
 import { drainCodexRollout, findCodexRolloutBySessionId, findCodexRolloutByPid, splitCodexEventsByCutoff, extractLastCodexTurn, codexSessionIdFromRolloutPath, type CodexBridgeEvent } from './services/codex-transcript.js';
 import { drainTraexRollout, findTraexRolloutBySessionId, findTraexRolloutByPid } from './services/traex-transcript.js';
+import { parseTraexUserInputQuestions } from './services/traex-user-input.js';
 import { cocoEventsPathForSession, drainCocoEvents, findCocoSessionByPid } from './services/coco-transcript.js';
 import { currentHermesStateOffset, drainHermesStateDb, resolveHermesStateDbPath } from './services/hermes-transcript.js';
 import { filterHermesEventsForBotmuxSession } from './services/hermes-session-filter.js';
@@ -235,7 +236,8 @@ import {
   type HookInstallConfig,
 } from './adapters/hook-installer.js';
 import { hookCommandFor } from './adapters/hook-command.js';
-import { parseDaemonIpcPort } from './utils/daemon-discovery.js';
+import { findOnlineDaemon, parseDaemonIpcPort } from './utils/daemon-discovery.js';
+import { fetchDaemonIpc } from './core/daemon-ipc-auth.js';
 import { withCodexAppContext } from './utils/codex-app-context.js';
 import { resolveCodexAppFinalTurnIdentity } from './adapters/cli/codex-app-turn.js';
 import { RunnerControlDecoder } from './adapters/cli/runner-control-channel.js';
@@ -576,6 +578,57 @@ async function prepareCodexNativeTitleGeneration(
   if (threadId) await captureCodexResumeTitleBaseline(threadId, engine);
 }
 
+type RpcUserInputAnswer = { answers: Record<string, { answers: string[] }> };
+
+/** Bridge TRAE app-server's native request_user_input request to botmux's
+ * existing Lark ask broker. The app-server owns tool execution in RPC mode, so
+ * returning this response resumes the same turn without terminal key driving. */
+async function bridgeTraexUserInput(
+  cfg: Extract<DaemonToWorker, { type: 'init' }>,
+  params: unknown,
+): Promise<RpcUserInputAnswer> {
+  const empty: RpcUserInputAnswer = { answers: {} };
+  const parsed = parseTraexUserInputQuestions(params);
+  if (parsed.kind === 'unsupported') {
+    log(`TRAE RPC requestUserInput cannot be represented by an ask card (${parsed.reason}); returning empty answers`);
+    return empty;
+  }
+  const { questions } = parsed;
+  const daemon = findOnlineDaemon(cfg.larkAppId);
+  if (!daemon) throw new Error(`daemon not found for larkAppId=${cfg.larkAppId}`);
+
+  const response = await fetchDaemonIpc(daemon.ipcPort, '/api/asks', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      sessionId: cfg.sessionId,
+      chatId: cfg.chatId,
+      larkAppId: cfg.larkAppId,
+      rootMessageId: cfg.rootMessageId || null,
+      questions: questions.map(entry => entry.question),
+      timeoutMs: 3_600_000,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`ask broker HTTP ${response.status}: ${(await response.text()).slice(0, 200)}`);
+  }
+  const result = await response.json() as {
+    kind?: string;
+    answers?: ReadonlyArray<ReadonlyArray<string>>;
+    comment?: string | null;
+  };
+  if (result.kind !== 'answered') return empty;
+
+  const customText = result.comment?.trim() ?? '';
+  const answers: RpcUserInputAnswer['answers'] = {};
+  questions.forEach((entry, index) => {
+    const selected = result.answers?.[index] ?? [];
+    const values = selected.length > 0 ? [...selected] : customText ? [customText] : [];
+    if (values.length > 0) answers[entry.id] = { answers: values };
+  });
+  return { answers };
+}
+
 /** Stand up (or re-establish) the per-session codex app-server + botmux-owned
  *  thread and point remote{WsUrl,ThreadId} at it, so the next spawnCli launches
  *  `codex --remote <ws> resume <thread>` and input flows over JSON-RPC. Fully
@@ -601,7 +654,17 @@ async function engageCodexRpc(cfg: Extract<DaemonToWorker, { type: 'init' }>): P
     const engineEnv: NodeJS.ProcessEnv = { ...redactChildEnv(process.env) };
     engineEnv.PATH = `${join(homedir(), '.botmux', 'bin')}:${engineEnv.PATH ?? ''}`;
     engineEnv.BOTMUX_SESSION_ID = cfg.sessionId;
+    // In Codex/TraeX RPC mode the app-server, not the remote viewer TUI, runs
+    // model shell tools. Give that process the same non-secret route binding as
+    // spawnCli so `botmux ask` can post into the current Lark thread.
+    engineEnv.BOTMUX_CHAT_ID = cfg.chatId;
+    if (cfg.chatType) engineEnv.BOTMUX_CHAT_TYPE = cfg.chatType;
+    else delete engineEnv.BOTMUX_CHAT_TYPE;
     engineEnv.BOTMUX_LARK_APP_ID = cfg.larkAppId;
+    engineEnv.BOTMUX_ROOT_MESSAGE_ID = cfg.rootMessageId;
+    engineEnv.BOTMUX_SESSION_SCOPE = cfg.rootMessageId?.startsWith('om_') ? 'thread' : 'chat';
+    if (cfg.ownerOpenId) engineEnv.BOTMUX_OWNER_OPEN_ID = cfg.ownerOpenId;
+    else delete engineEnv.BOTMUX_OWNER_OPEN_ID;
     // The app-server owns model execution in RPC mode. Its MCP gateway child
     // must inherit the trusted host socket just like a native CLI process does.
     if (sessionMcpGatewayHost) {
@@ -619,6 +682,10 @@ async function engageCodexRpc(cfg: Extract<DaemonToWorker, { type: 'init' }>): P
     engine = new CodexRpcEngine({
       cliBin, cwd: cfg.workingDir, env: engineEnv, sessionId: cfg.sessionId,
       model: cfg.model, log: (m: string) => log(m),
+      appServerFeatures: cfg.cliId === 'traex' ? ['default_mode_request_user_input'] : undefined,
+      onRequestUserInput: cfg.cliId === 'traex'
+        ? (params: unknown) => bridgeTraexUserInput(cfg, params)
+        : undefined,
       onDead: () => {
         if (codexRpcEngine === engine) {
           log('Codex RPC app-server died; replacing the tmux session and re-engaging the thread');

--- a/test/codex-rpc-engine.test.ts
+++ b/test/codex-rpc-engine.test.ts
@@ -107,6 +107,23 @@ describe('CodexRpcEngine — happy-path lifecycle against a fake app-server', ()
     });
     engine.stop();
   }, 20_000);
+
+  it('replies with a JSON-RPC error (not empty answers) when the input bridge rejects', async () => {
+    // The blocker fix: an unsupported/broker-failed ask must fail VISIBLY. When
+    // onRequestUserInput rejects, the engine must send a JSON-RPC error so the
+    // app-server sees the tool failed — not {answers:{}} it would silently skip.
+    const engine = makeEngine({
+      env: { ...process.env, FAKE_REQUEST_USER_INPUT: '1' },
+      appServerFeatures: ['default_mode_request_user_input'],
+      onRequestUserInput: async () => { throw new Error('cannot represent as ask card'); },
+    });
+    await engine.start();
+    await engine.startThread();
+    // The fixture turns our error response into a turn-level error, so the turn
+    // rejects instead of resolving as an unanswered success.
+    await expect(engine.sendTurn('ask me')).rejects.toThrow(/user-input request failed/);
+    engine.stop();
+  }, 20_000);
 });
 
 describe('CodexRpcEngine — failure/recovery paths', () => {

--- a/test/codex-rpc-engine.test.ts
+++ b/test/codex-rpc-engine.test.ts
@@ -108,20 +108,29 @@ describe('CodexRpcEngine — happy-path lifecycle against a fake app-server', ()
     engine.stop();
   }, 20_000);
 
-  it('replies with a JSON-RPC error (not empty answers) when the input bridge rejects', async () => {
-    // The blocker fix: an unsupported/broker-failed ask must fail VISIBLY. When
-    // onRequestUserInput rejects, the engine must send a JSON-RPC error so the
-    // app-server sees the tool failed — not {answers:{}} it would silently skip.
+  it('interrupts the turn (not a benign reply) when the input bridge rejects', async () => {
+    // The blocker fix. Verified against real traex 0.200.19: replying to
+    // requestUserInput with empty answers OR a JSON-RPC error is normalized to
+    // {answers:{}} and the turn still COMPLETES, silently skipping the ask. Only
+    // `turn/interrupt` actually stops the turn. So on bridge rejection the engine
+    // must send turn/interrupt — asserted here via the engine log + the fixture
+    // resolving turn/start as an interrupted turn rather than a completed one.
+    const logs: string[] = [];
     const engine = makeEngine({
       env: { ...process.env, FAKE_REQUEST_USER_INPUT: '1' },
       appServerFeatures: ['default_mode_request_user_input'],
+      log: (m: string) => logs.push(m),
       onRequestUserInput: async () => { throw new Error('cannot represent as ask card'); },
     });
     await engine.start();
     await engine.startThread();
-    // The fixture turns our error response into a turn-level error, so the turn
-    // rejects instead of resolving as an unanswered success.
-    await expect(engine.sendTurn('ask me')).rejects.toThrow(/user-input request failed/);
+    // turn/start resolves (interrupted), so sendTurn does not throw here; the
+    // point is that the turn was stopped, not silently completed.
+    await engine.sendTurn('ask me');
+    // Give the async interrupt round-trip a moment to log its result.
+    await new Promise(resolve => setTimeout(resolve, 200));
+    expect(logs.some(l => l.includes('interrupting turn'))).toBe(true);
+    expect(logs.some(l => l.includes('turn interrupted after requestUserInput failure'))).toBe(true);
     engine.stop();
   }, 20_000);
 });

--- a/test/codex-rpc-engine.test.ts
+++ b/test/codex-rpc-engine.test.ts
@@ -133,6 +133,28 @@ describe('CodexRpcEngine — happy-path lifecycle against a fake app-server', ()
     expect(logs.some(l => l.includes('turn interrupted after requestUserInput failure'))).toBe(true);
     engine.stop();
   }, 20_000);
+
+  it('declares the engine dead when turn/interrupt itself fails (no permanently wedged turn)', async () => {
+    // The interrupt is the last lever we have on bridge failure. If it errors or
+    // times out, the turn stays stuck — so the engine must fire onDead so the
+    // worker restarts the pane, rather than only logging and leaking the hang.
+    let deadCount = 0;
+    const engine = makeEngine({
+      sessionId: 'interrupt-fail',
+      env: { ...process.env, FAKE_REQUEST_USER_INPUT: '1', FAKE_INTERRUPT_ERROR: '1' },
+      appServerFeatures: ['default_mode_request_user_input'],
+      onRequestUserInput: async () => { throw new Error('cannot represent as ask card'); },
+      onDead: () => { deadCount++; },
+    });
+    await engine.start();
+    await engine.startThread();
+    // failAll rejects the still-pending turn/start, so sendTurn rejects here —
+    // that is the visible failure, not a silent hang. We only care that onDead fired.
+    await engine.sendTurn('ask me').catch(() => {});
+    await new Promise(resolve => setTimeout(resolve, 300));
+    expect(deadCount).toBe(1);
+    engine.stop();
+  }, 20_000);
 });
 
 describe('CodexRpcEngine — failure/recovery paths', () => {

--- a/test/codex-rpc-engine.test.ts
+++ b/test/codex-rpc-engine.test.ts
@@ -84,6 +84,29 @@ describe('CodexRpcEngine — happy-path lifecycle against a fake app-server', ()
     expect(tid).toBe('thread-persisted-42');
     engine.stop();
   }, 20_000);
+
+  it('bridges requestUserInput server requests to the host callback', async () => {
+    let received: unknown;
+    let resolveReceived!: () => void;
+    const receivedPromise = new Promise<void>(resolve => { resolveReceived = resolve; });
+    const engine = makeEngine({
+      env: { ...process.env, FAKE_REQUEST_USER_INPUT: '1' },
+      appServerFeatures: ['default_mode_request_user_input'],
+      onRequestUserInput: async params => {
+        received = params;
+        resolveReceived();
+        return { answers: { choice: { answers: ['Yes'] } } };
+      },
+    });
+    await engine.start();
+    await engine.startThread();
+    await engine.sendTurn('ask me');
+    await receivedPromise;
+    expect(received).toMatchObject({
+      questions: [{ id: 'choice', question: 'Continue?' }],
+    });
+    engine.stop();
+  }, 20_000);
 });
 
 describe('CodexRpcEngine — failure/recovery paths', () => {

--- a/test/fixtures/fake-codex-rpc-server.mjs
+++ b/test/fixtures/fake-codex-rpc-server.mjs
@@ -32,15 +32,18 @@ wss.on('connection', (ws) => {
     let msg; try { msg = JSON.parse(data.toString()); } catch { return; }
     if (REQUEST_USER_INPUT && msg.id === 900 && (msg.result !== undefined || msg.error !== undefined)) {
       if (!pendingTurnReply) return;
-      // Distinguish the three client behaviors so the engine test can assert
-      // which one happened: a JSON-RPC error (fail-visible), a "Yes" answer, or
-      // anything else (including the old empty {answers:{}}).
-      const outcome = msg.error !== undefined
-        ? { error: { message: `user-input request failed: ${msg.error?.message ?? 'error'}` } }
-        : msg.result?.answers?.choice?.answers?.[0] === 'Yes'
-          ? { result: { accepted: true } }
-          : { error: { message: 'missing user-input answer' } };
-      ws.send(JSON.stringify({ jsonrpc: '2.0', id: pendingTurnReply, ...outcome }));
+      // Real traex 0.200.19 normalizes ANY reply to requestUserInput (empty
+      // answers OR a JSON-RPC error) into {answers:{}} and COMPLETES the turn.
+      // Model that: a direct reply always completes the turn. Only an explicit
+      // `turn/interrupt` (below) ends it as interrupted. This keeps the fixture
+      // faithful to the verified product behavior instead of inventing an
+      // "error bubbles up" semantics that traex does not implement.
+      const accepted = msg.result?.answers?.choice?.answers?.[0] === 'Yes';
+      ws.send(JSON.stringify({
+        jsonrpc: '2.0',
+        id: pendingTurnReply,
+        result: { accepted, status: 'completed' },
+      }));
       pendingTurnReply = undefined;
       return;
     }
@@ -59,6 +62,21 @@ wss.on('connection', (ws) => {
           updatedAt: threadReadAttempt > UPDATED_DELAY_READS ? UPDATED_AFTER : UPDATED_BEFORE,
         } });
       case 'thread/name/set': currentThreadName = msg.params?.name; return reply({});
+      case 'turn/interrupt': {
+        // Verified real behavior: interrupt ends the in-flight turn as
+        // 'interrupted' and acks with {}. Resolve the pending turn/start as an
+        // interrupted turn so the engine test can assert the turn stopped
+        // instead of silently completing.
+        if (pendingTurnReply) {
+          ws.send(JSON.stringify({
+            jsonrpc: '2.0',
+            id: pendingTurnReply,
+            result: { turn: { status: 'interrupted' } },
+          }));
+          pendingTurnReply = undefined;
+        }
+        return reply({});
+      }
       case 'turn/start': {
         if (HANG_TURN) return;
         if (REQUEST_USER_INPUT) {
@@ -68,6 +86,9 @@ wss.on('connection', (ws) => {
             id: 900,
             method: 'item/tool/requestUserInput',
             params: {
+              threadId: msg.params?.threadId ?? 'thread-fake-1',
+              turnId: 'turn-fake-1',
+              itemId: 'item-fake-1',
               questions: [{
                 id: 'choice', header: 'Test', question: 'Continue?', multiSelect: false,
                 options: [{ label: 'Yes', description: '' }, { label: 'No', description: '' }],

--- a/test/fixtures/fake-codex-rpc-server.mjs
+++ b/test/fixtures/fake-codex-rpc-server.mjs
@@ -63,6 +63,16 @@ wss.on('connection', (ws) => {
         } });
       case 'thread/name/set': currentThreadName = msg.params?.name; return reply({});
       case 'turn/interrupt': {
+        // FAKE_INTERRUPT_ERROR=1 models an interrupt that itself fails: the
+        // app-server rejects turn/interrupt with a JSON-RPC error. The engine
+        // then has no lever left and must declare itself dead (onDead) rather
+        // than leaking a wedged turn.
+        if (process.env.FAKE_INTERRUPT_ERROR === '1') {
+          return ws.send(JSON.stringify({
+            jsonrpc: '2.0', id: msg.id,
+            error: { code: -32000, message: 'interrupt failed' },
+          }));
+        }
         // Verified real behavior: interrupt ends the in-flight turn as
         // 'interrupted' and acks with {}. Resolve the pending turn/start as an
         // interrupted turn so the engine test can assert the turn stopped

--- a/test/fixtures/fake-codex-rpc-server.mjs
+++ b/test/fixtures/fake-codex-rpc-server.mjs
@@ -19,6 +19,7 @@ const UPDATED_BEFORE = Number(process.env.FAKE_UPDATED_BEFORE ?? '100');
 const UPDATED_AFTER = Number(process.env.FAKE_UPDATED_AFTER ?? '101');
 let threadReadAttempt = 0;
 let currentThreadName;
+const REQUEST_USER_INPUT = process.env.FAKE_REQUEST_USER_INPUT === '1';
 
 const httpServer = createServer((req, res) => {
   if (req.url === '/readyz') { res.writeHead(200); res.end('ok'); return; }
@@ -26,8 +27,20 @@ const httpServer = createServer((req, res) => {
 });
 const wss = new WebSocketServer({ server: httpServer });
 wss.on('connection', (ws) => {
+  let pendingTurnReply;
   ws.on('message', (data) => {
     let msg; try { msg = JSON.parse(data.toString()); } catch { return; }
+    if (REQUEST_USER_INPUT && msg.id === 900 && msg.result !== undefined) {
+      if (!pendingTurnReply) return;
+      const accepted = msg.result?.answers?.choice?.answers?.[0] === 'Yes';
+      ws.send(JSON.stringify({
+        jsonrpc: '2.0',
+        id: pendingTurnReply,
+        ...(accepted ? { result: { accepted: true } } : { error: { message: 'missing user-input answer' } }),
+      }));
+      pendingTurnReply = undefined;
+      return;
+    }
     if (typeof msg.id !== 'number' || typeof msg.method !== 'string') return;
     const reply = (result) => ws.send(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result }));
     switch (msg.method) {
@@ -43,7 +56,25 @@ wss.on('connection', (ws) => {
           updatedAt: threadReadAttempt > UPDATED_DELAY_READS ? UPDATED_AFTER : UPDATED_BEFORE,
         } });
       case 'thread/name/set': currentThreadName = msg.params?.name; return reply({});
-      case 'turn/start': if (HANG_TURN) return; return reply({ accepted: true });
+      case 'turn/start': {
+        if (HANG_TURN) return;
+        if (REQUEST_USER_INPUT) {
+          pendingTurnReply = msg.id;
+          ws.send(JSON.stringify({
+            jsonrpc: '2.0',
+            id: 900,
+            method: 'item/tool/requestUserInput',
+            params: {
+              questions: [{
+                id: 'choice', header: 'Test', question: 'Continue?', multiSelect: false,
+                options: [{ label: 'Yes', description: '' }, { label: 'No', description: '' }],
+              }],
+            },
+          }));
+          return;
+        }
+        return reply({ accepted: true });
+      }
       default: return reply({});
     }
   });

--- a/test/fixtures/fake-codex-rpc-server.mjs
+++ b/test/fixtures/fake-codex-rpc-server.mjs
@@ -30,14 +30,17 @@ wss.on('connection', (ws) => {
   let pendingTurnReply;
   ws.on('message', (data) => {
     let msg; try { msg = JSON.parse(data.toString()); } catch { return; }
-    if (REQUEST_USER_INPUT && msg.id === 900 && msg.result !== undefined) {
+    if (REQUEST_USER_INPUT && msg.id === 900 && (msg.result !== undefined || msg.error !== undefined)) {
       if (!pendingTurnReply) return;
-      const accepted = msg.result?.answers?.choice?.answers?.[0] === 'Yes';
-      ws.send(JSON.stringify({
-        jsonrpc: '2.0',
-        id: pendingTurnReply,
-        ...(accepted ? { result: { accepted: true } } : { error: { message: 'missing user-input answer' } }),
-      }));
+      // Distinguish the three client behaviors so the engine test can assert
+      // which one happened: a JSON-RPC error (fail-visible), a "Yes" answer, or
+      // anything else (including the old empty {answers:{}}).
+      const outcome = msg.error !== undefined
+        ? { error: { message: `user-input request failed: ${msg.error?.message ?? 'error'}` } }
+        : msg.result?.answers?.choice?.answers?.[0] === 'Yes'
+          ? { result: { accepted: true } }
+          : { error: { message: 'missing user-input answer' } };
+      ws.send(JSON.stringify({ jsonrpc: '2.0', id: pendingTurnReply, ...outcome }));
       pendingTurnReply = undefined;
       return;
     }

--- a/test/hook-installer.test.ts
+++ b/test/hook-installer.test.ts
@@ -11,6 +11,7 @@ import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'n
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
+  cleanupTraexAskHooks,
   hasInstalledSessionReadyHook,
   installHook,
 } from '../src/adapters/hook-installer.js';
@@ -343,5 +344,71 @@ describe('installHook — opencode-plugin', () => {
     const afterSecond = readFileSync(configPath, 'utf-8');
 
     expect(afterSecond).toBe(afterFirst);
+  });
+});
+
+// ─── TRAE legacy hook cleanup ────────────────────────────────────────────────
+
+describe('cleanupTraexAskHooks', () => {
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    configPath = join(tmpDir, '.trae', 'hooks.json');
+  });
+
+  it('removes only legacy botmux TraeX ask hooks and preserves unrelated hooks', () => {
+    const existing = {
+      version: 1,
+      hooks: {
+        UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'era-cli ... UserPromptSubmit' }] }],
+        PostToolUse: [{ matcher: '*', hooks: [{ type: 'command', command: 'era-cli ... PostToolUse' }] }],
+        Stop: [{ hooks: [{ type: 'command', command: 'era-cli ... Stop' }] }],
+        PreToolUse: [
+          {
+            matcher: '^(AskUserQuestion|request_user_input)$',
+            hooks: [
+              { type: 'command', command: '/repo/dist/cli.js hook traex' },
+              { type: 'command', command: 'era-cli ... PreToolUse' },
+            ],
+          },
+        ],
+        PermissionRequest: [
+          { hooks: [{ type: 'command', command: '/opt/botmux/dist/cli.js hook traex' }] },
+        ],
+      },
+    };
+    mkdirSync(join(tmpDir, '.trae'), { recursive: true });
+    writeFileSync(configPath, JSON.stringify(existing, null, 2) + '\n', 'utf-8');
+
+    cleanupTraexAskHooks([configPath]);
+
+    const settings = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(settings.version).toBe(1);
+    expect(settings.hooks.UserPromptSubmit[0].hooks[0].command).toContain('UserPromptSubmit');
+    expect(settings.hooks.PostToolUse[0].hooks[0].command).toContain('PostToolUse');
+    expect(settings.hooks.Stop[0].hooks[0].command).toContain('Stop');
+    expect(settings.hooks.PreToolUse).toEqual([
+      {
+        matcher: '^(AskUserQuestion|request_user_input)$',
+        hooks: [{ type: 'command', command: 'era-cli ... PreToolUse' }],
+      },
+    ]);
+    expect(settings.hooks.PermissionRequest).toBeUndefined();
+  });
+
+  it('ignores malformed hook groups instead of blocking daemon startup', () => {
+    const existing = {
+      hooks: {
+        PreToolUse: 'not-an-array',
+        PermissionRequest: [{ hooks: [null, { type: 'command', command: 'not-botmux' }] }],
+      },
+    };
+    mkdirSync(join(tmpDir, '.trae'), { recursive: true });
+    writeFileSync(configPath, JSON.stringify(existing, null, 2) + '\n', 'utf-8');
+
+    expect(() => cleanupTraexAskHooks([configPath])).not.toThrow();
+    expect(JSON.parse(readFileSync(configPath, 'utf-8'))).toEqual(existing);
   });
 });

--- a/test/traex-adapter-submit.test.ts
+++ b/test/traex-adapter-submit.test.ts
@@ -147,4 +147,11 @@ describe.sequential('TRAE adapter submit verification', () => {
 
     expect(result).toEqual({ submitted: true, cliSessionId: SID_2 });
   });
+
+  it('keeps the botmux-ask fallback skill for non-RPC TraeX sessions', () => {
+    const adapter = createTraexAdapter('/bin/traex');
+
+    expect(adapter.asksViaHook).toBe(false);
+    expect(adapter.hookInstall).toBeUndefined();
+  });
 });

--- a/test/traex-user-input.test.ts
+++ b/test/traex-user-input.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { parseTraexUserInputQuestions } from '../src/services/traex-user-input.js';
+
+describe('parseTraexUserInputQuestions', () => {
+  it('preserves every answerable question and its stable id', () => {
+    const result = parseTraexUserInputQuestions({
+      questions: [
+        {
+          id: 'environment',
+          question: 'Choose an environment',
+          multiSelect: true,
+          options: [{ label: 'staging' }, { label: 'production' }],
+        },
+        {
+          id: 'notify',
+          header: 'Notification',
+          question: 'Choose a notification channel',
+          multiSelect: false,
+          options: [{ label: 'Lark' }, { label: 'Email' }],
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      kind: 'answerable',
+      questions: [
+        {
+          id: 'environment',
+          question: {
+            prompt: 'Choose an environment',
+            multiSelect: true,
+            options: [{ key: 'staging', label: 'staging' }, { key: 'production', label: 'production' }],
+          },
+        },
+        {
+          id: 'notify',
+          question: {
+            prompt: 'Choose a notification channel',
+            multiSelect: false,
+            options: [{ key: 'Lark', label: 'Lark' }, { key: 'Email', label: 'Email' }],
+          },
+        },
+      ],
+    });
+  });
+
+  it('rejects an entire mixed batch when one question cannot be represented as buttons', () => {
+    const result = parseTraexUserInputQuestions({
+      questions: [
+        {
+          id: 'choice',
+          question: 'Continue?',
+          multiSelect: false,
+          options: [{ label: 'Yes' }, { label: 'No' }],
+        },
+        {
+          id: 'free_text',
+          question: 'Explain why',
+          multiSelect: false,
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      kind: 'unsupported',
+      reason: 'question 2 has fewer than two options',
+    });
+  });
+
+  it('rejects duplicated question ids instead of overwriting an answer', () => {
+    const result = parseTraexUserInputQuestions({
+      questions: [
+        { id: 'choice', question: 'One?', multiSelect: false, options: [{ label: 'A' }, { label: 'B' }] },
+        { id: 'choice', question: 'Two?', multiSelect: false, options: [{ label: 'C' }, { label: 'D' }] },
+      ],
+    });
+
+    expect(result).toEqual({
+      kind: 'unsupported',
+      reason: 'duplicate question id: choice',
+    });
+  });
+});

--- a/test/traex-worker-bridge-wiring.test.ts
+++ b/test/traex-worker-bridge-wiring.test.ts
@@ -4,6 +4,20 @@ import { describe, expect, it } from 'vitest';
 const workerSource = readFileSync(new URL('../src/worker.ts', import.meta.url), 'utf8');
 
 describe('TRAE worker structured-bridge wiring', () => {
+  it('gives the RPC app-server the non-secret Lark route required by botmux ask', () => {
+    const start = workerSource.indexOf('async function engageCodexRpc');
+    const end = workerSource.indexOf('engine = new CodexRpcEngine', start);
+    const envSetup = workerSource.slice(start, end);
+
+    expect(envSetup).toContain('engineEnv.BOTMUX_SESSION_ID = cfg.sessionId;');
+    expect(envSetup).toContain('engineEnv.BOTMUX_CHAT_ID = cfg.chatId;');
+    expect(envSetup).toContain('engineEnv.BOTMUX_LARK_APP_ID = cfg.larkAppId;');
+    expect(envSetup).toContain('engineEnv.BOTMUX_ROOT_MESSAGE_ID = cfg.rootMessageId;');
+    expect(envSetup).toContain("engineEnv.BOTMUX_SESSION_SCOPE = cfg.rootMessageId?.startsWith('om_') ? 'thread' : 'chat';");
+    expect(envSetup).toContain('engineEnv.BOTMUX_OWNER_OPEN_ID = cfg.ownerOpenId;');
+    expect(envSetup).not.toContain('BOTMUX_LARK_APP_SECRET');
+  });
+
   it('dispatches TRAE rollouts to the dedicated task_complete reader', () => {
     const start = workerSource.indexOf('function structuredBridgeIngestPath');
     const end = workerSource.indexOf('\n}\n', start);


### PR DESCRIPTION
## 问题

TraeX 0.200.19 的原生 `request_user_input` / `AskUserQuestion` 不会经过通用 `PreToolUse` / `PostToolUse` hook；并且该版本不支持通过 `updatedInput` 直接回填答案。因此原 PR 的 Hook + directive 路径无法可靠把问答桥接到飞书，真实会话会卡在 TUI。

## 修复

改为使用 TraeX app-server 的 JSON-RPC 协议：

1. `CodexRpcEngine` 支持为 app-server 添加 feature flag，并把 `item/tool/requestUserInput` server request 交给宿主回调处理。
2. TraeX RPC 会话启用 `default_mode_request_user_input`；worker 将可表达的多选/单选题转发到既有 `/api/asks` → 飞书 AskBroker。
3. 用户点选后，结果按原 `question.id` 组织为 `ToolRequestUserInputResponse`，通过同一 RPC request 返回，恢复原来的 TraeX turn，不再需要 TUI 键盘回填。
4. 删除旧的 TraeX Hook 适配器/安装路径；启动时仅清理 botmux 自己遗留的 `hook traex` 命令，且不删除同一 group 内的用户 hook。
5. 非 RPC TraeX 会话仍保留 `botmux-ask` skill 兜底；含自由文本或其他无法完整表达为按钮卡的混合题组整批拒绝，避免静默漏答。

## 真实验证

已在飞书真实链路完成闭环：

- 新 TraeX RPC 会话触发原生 `request_user_input`；
- 飞书出现 Ask 卡，选择“继续”；
- 结束卡显示“问题1：继续”；
- 同一 TraeX turn 随后继续执行，未卡在 TUI。

## 自审与影响面

- TraeX 专属逻辑只在 `cliId === 'traex'` 时启用 request-user-input feature 和回调；Codex 的默认 approval 自动响应逻辑不变。
- RPC 不可用时仍 fail-closed 回到既有 PTY 路径，且保留 skill 兜底。
- 遗留 Hook 清理只匹配 botmux 的 `cli.js hook traex` entry；无关 hook 和同组用户 entry 均保留。
- 已 rebase 到当前 `upstream/master`，并保留上游刚合入的 Codex 原生标题同步逻辑。

## 验证

- `pnpm exec vitest run --project unit test/codex-rpc-engine.test.ts test/traex-user-input.test.ts test/traex-adapter-submit.test.ts test/traex-worker-bridge-wiring.test.ts test/hook-installer.test.ts test/codex-rpc-lifecycle.test.ts test/codex-app-threads.test.ts`：104 passed
- `pnpm exec tsc --noEmit`：通过
- `pnpm build`：通过
- `pnpm test`：10,019 passed / 5 failed / 23 skipped；5 个失败均为 `v3-distillation-runner` 环境问题，并已在干净 `upstream/master` worktree 复现，和本 PR 无关。