### PR TITLE
fix(lark): 修复话题操作链接不可见

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -846,13 +846,13 @@ export async function postPrivateSnapshotCard(
  * Deliver the write-enabled session card (the "🔑 获取操作链接" card, which carries
  * a write-token terminal URL + manage buttons) privately to a single operator.
  *
- * Prefers an in-chat "visible-to-you" ephemeral card so the operator never has
- * to leave the conversation. Feishu's ephemeral API only works in plain `group`
- * chats — topic / thread groups reject with {@link LARK_CODE_EPHEMERAL_NOT_GROUP}
- * (18053) and p2p chats are unsupported — and chatType can't distinguish a topic
- * group from a regular one (both record 'group'), so we attempt ephemeral for any
- * non-p2p chat and fall back to a private DM on ANY failure. p2p chats skip the
- * doomed ephemeral attempt and DM directly (the DM lands in that same 1:1 chat).
+ * Prefers an in-chat "visible-to-you" ephemeral card in a flat group so the
+ * operator never has to leave the conversation. Thread-scope sessions and
+ * chat-scope sessions currently folded into a thread go straight to DM:
+ * Feishu may accept their ephemeral message without rendering it in the topic
+ * panel. p2p chats also DM directly (the DM lands in that same 1:1 chat).
+ *
+ * Other group chats attempt ephemeral first and fall back to DM on ANY failure.
  *
  * Both channels are private, so the DM fallback never leaks the write token —
  * unlike the private /card snapshot (which fails closed), here we fail OVER.
@@ -865,7 +865,10 @@ export async function deliverWriteLinkCard(
   cardJson: string,
 ): Promise<'ephemeral' | 'dm' | 'failed'> {
   const who = operatorOpenId.substring(0, 8);
-  if (ds.chatType !== 'p2p') {
+  const replyTarget = ds.currentReplyTarget ?? ds.session.currentReplyTarget;
+  const isThreaded = ds.scope === 'thread'
+    || (!!replyTarget?.rootMessageId && replyTarget.quoteOnly !== true);
+  if (ds.chatType !== 'p2p' && !isThreaded) {
     try {
       await sendEphemeralCard(ds.larkAppId, ds.chatId, operatorOpenId, cardJson);
       logger.info(`[${tag(ds)}] write link delivered via ephemeral card to ${who}…`);

--- a/test/write-link-delivery.test.ts
+++ b/test/write-link-delivery.test.ts
@@ -3,11 +3,10 @@
  * session card ("DM 卡") reaches the operator who clicked 「获取操作链接」.
  *
  * Behaviour under test (方案 A): prefer an in-chat "visible-to-you" ephemeral
- * card, but Feishu's ephemeral API only works in plain `group` chats (topic /
- * thread groups reject with 18053, p2p unsupported). chatType can't tell a topic
- * group from a regular one, so we attempt ephemeral for any non-p2p chat and
- * fall back to a private DM on failure. p2p skips straight to the DM. Both
- * channels are private — the fallback never leaks the write token.
+ * card in flat groups. Thread-scope sessions and chat-scope sessions folded
+ * into a thread use DM because Feishu can accept an ephemeral message without
+ * rendering it in the topic panel. Other group failures fall back to DM, and
+ * p2p skips straight to DM. Both channels are private.
  *
  * Run:  pnpm vitest run test/write-link-delivery.test.ts
  */
@@ -73,8 +72,8 @@ const liveDs = (over: Partial<DaemonSession> = {}) => ds({
 beforeEach(() => {
   vi.clearAllMocks();
   botState.owners = [];
-  sendEphemeralCardMock.mockResolvedValue('eph_msg_id');
-  sendUserMessageMock.mockResolvedValue('dm_msg_id');
+  sendEphemeralCardMock.mockReset().mockResolvedValue('eph_msg_id');
+  sendUserMessageMock.mockReset().mockResolvedValue('dm_msg_id');
 });
 
 describe('deliverWriteLinkCard', () => {
@@ -95,6 +94,27 @@ describe('deliverWriteLinkCard', () => {
 
   it('skips ephemeral entirely for p2p chats and DMs directly', async () => {
     const r = await deliverWriteLinkCard(ds({ chatType: 'p2p' }), OP, CARD);
+    expect(r).toBe('dm');
+    expect(sendEphemeralCardMock).not.toHaveBeenCalled();
+    expect(sendUserMessageMock).toHaveBeenCalledWith('app', OP, CARD, 'interactive');
+  });
+
+  it('DMs a chat-scope session currently folded into a thread', async () => {
+    const r = await deliverWriteLinkCard(ds({
+      scope: 'chat',
+      currentReplyTarget: {
+        rootMessageId: 'om_topic_root',
+        turnId: 'om_user_turn',
+        updatedAt: new Date().toISOString(),
+      },
+    }), OP, CARD);
+    expect(r).toBe('dm');
+    expect(sendEphemeralCardMock).not.toHaveBeenCalled();
+    expect(sendUserMessageMock).toHaveBeenCalledWith('app', OP, CARD, 'interactive');
+  });
+
+  it('DMs a thread-scope session directly', async () => {
+    const r = await deliverWriteLinkCard(ds({ scope: 'thread' }), OP, CARD);
     expect(r).toBe('dm');
     expect(sendEphemeralCardMock).not.toHaveBeenCalled();
     expect(sendUserMessageMock).toHaveBeenCalledWith('app', OP, CARD, 'interactive');
@@ -126,7 +146,7 @@ describe('deliverWriteLinkCardToOwners (botmux term-link backend)', () => {
 
   it('keeps only ou_-prefixed owners, fans out one private card each', async () => {
     botState.owners = ['ou_a', 'ou_b', 'on_union_not_ou']; // last one filtered out
-    const r = await deliverWriteLinkCardToOwners(liveDs({ chatType: 'group' }));
+    const r = await deliverWriteLinkCardToOwners(liveDs({ chatType: 'group', scope: 'chat' }));
     expect(r.ok).toBe(true);
     expect(r).toMatchObject({ delivered: 2, total: 2, channels: ['ephemeral', 'ephemeral'] });
     expect(sendEphemeralCardMock).toHaveBeenCalledTimes(2);
@@ -143,7 +163,7 @@ describe('deliverWriteLinkCardToOwners (botmux term-link backend)', () => {
       .mockRejectedValueOnce(new Error('18053'))
       .mockResolvedValueOnce('eph_ok');
     sendUserMessageMock.mockRejectedValueOnce(new Error('bot not in chat'));
-    const r = await deliverWriteLinkCardToOwners(liveDs({ chatType: 'group' }));
+    const r = await deliverWriteLinkCardToOwners(liveDs({ chatType: 'group', scope: 'chat' }));
     expect(r.ok).toBe(true); // at least one delivered
     expect(r.delivered).toBe(1);
     expect(r.total).toBe(2);
@@ -168,7 +188,7 @@ describe('deliverWritableTerminalCardTo (/term slash command backend)', () => {
   });
 
   it('delivers a token-bearing card to the single operator (ephemeral in a plain group)', async () => {
-    const r = await deliverWritableTerminalCardTo(liveDs({ chatType: 'group' }), 'ou_owner');
+    const r = await deliverWritableTerminalCardTo(liveDs({ chatType: 'group', scope: 'chat' }), 'ou_owner');
     expect(r).toBe('ephemeral');
     expect(sendEphemeralCardMock).toHaveBeenCalledTimes(1);
     const [, , who, card] = sendEphemeralCardMock.mock.calls[0];


### PR DESCRIPTION
## 改了什么

- 话题会话获取操作链接时直接通过私聊 DM 投递
- chat-scope 会话折叠进话题时同样绕过群内 ephemeral 投递
- 普通平铺群继续使用 ephemeral，失败时仍回退私聊
- 补充 thread-scope 和折叠话题场景的回归测试

## 为什么

飞书可能接受话题上下文中的 ephemeral 消息，但不会在话题面板渲染。此前服务端日志显示发送成功，用户侧却看不到操作卡。改为在话题场景使用私聊，可以保持写入 token 仅通过私密通道传输，同时确保用户实际收到。

## 影响面

- 影响 Lark 会话卡的「获取操作链接」、botmux term-link 和 /term 共用投递路径
- thread-scope 与折叠进话题的 chat-scope 改走 DM
- 普通群、p2p 和原有失败回退语义保持兼容

## 验证

- `pnpm vitest run test/write-link-delivery.test.ts test/card-integration.test.ts`：47 个测试通过
- `pnpm build`：通过
- 本地 live daemon 实测：目标会话操作卡成功通过私聊 DM 投递