### PR TITLE
fix(auth): allowedUsers 解析失败时保留缓存并通知 owner

### DIFF
--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -1460,6 +1460,20 @@ export function republishResolvedAllowedUsersDescriptor(larkAppId: string, resol
   try { republishResolvedAllowedUsersHook?.(larkAppId, resolved); } catch { /* best effort */ }
 }
 
+/**
+ * Hook the daemon registers so a runtime allowedUsers mutation that hit a
+ * TRANSIENT contact failure for some entry can schedule the same background
+ * resolve-retry the startup path uses (heal-when-API-recovers). No-op until the
+ * daemon registers it (e.g. one-shot CLI paths with no retry loop).
+ */
+let allowedUsersResolveRetryHook: ((larkAppId: string) => void) | undefined;
+export function setAllowedUsersResolveRetryHook(fn: (larkAppId: string) => void): void {
+  allowedUsersResolveRetryHook = fn;
+}
+export function scheduleAllowedUsersResolveRetryFromMutation(larkAppId: string): void {
+  try { allowedUsersResolveRetryHook?.(larkAppId); } catch { /* best effort */ }
+}
+
 /** Bot 自身的 open_id（用于在 mention 解析时排除自己）。 */
 export function getBotOpenId(larkAppId: string): string | undefined {
   return bots.get(larkAppId)?.botOpenId;

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -1444,6 +1444,22 @@ export function getDashboardAdminOpenIds(larkAppId: string): string[] {
   return [...(bots.get(larkAppId)?.resolvedAllowedUsers ?? [])];
 }
 
+/**
+ * Hook the daemon registers so runtime allowedUsers mutations (set / revoke)
+ * can republish the dashboard descriptor's `resolvedAllowedUsers` without the
+ * services layer importing daemon internals. No-op until the daemon registers
+ * it (e.g. in one-shot CLI paths that never publish a descriptor).
+ */
+let republishResolvedAllowedUsersHook: ((larkAppId: string, resolved: string[]) => void) | undefined;
+export function setResolvedAllowedUsersRepublishHook(
+  fn: (larkAppId: string, resolved: string[]) => void,
+): void {
+  republishResolvedAllowedUsersHook = fn;
+}
+export function republishResolvedAllowedUsersDescriptor(larkAppId: string, resolved: string[]): void {
+  try { republishResolvedAllowedUsersHook?.(larkAppId, resolved); } catch { /* best effort */ }
+}
+
 /** Bot 自身的 open_id（用于在 mention 解析时排除自己）。 */
 export function getBotOpenId(larkAppId: string): string | undefined {
   return bots.get(larkAppId)?.botOpenId;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2,6 +2,7 @@ import { execFileSync, type ChildProcess } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
 import { readFileSync, existsSync, mkdirSync, unlinkSync, watch, readdirSync } from 'node:fs';
 import { atomicWriteFileSync } from './utils/atomic-write.js';
+import { readAllowedUsersResolveCache, writeAllowedUsersResolveCache } from './utils/allowed-users-cache.js';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import type { IncomingMessage, ServerResponse } from 'node:http';
@@ -43,6 +44,7 @@ import {
   effectiveDefaultWorkingDir,
   effectiveBotDisplayName,
   resolveVcMeetingConsumerProfiles,
+  setResolvedAllowedUsersRepublishHook,
   type BotConfig,
   type BotState,
   type OncallChat,
@@ -2984,69 +2986,20 @@ function removeDaemonDescriptor(larkAppId: string): void {
 }
 
 /**
- * Persistent last-known-good `raw entry → ou_` cache for allowedUsers.
- *
- * This is DELIBERATELY NOT the dashboard descriptor: the descriptor is
- * (a) overwritten unconditionally early in boot with the still-unresolved raw
- * config (so its `resolvedAllowedUsers` is `[]` for an on_/email-only owner),
- * and (b) deleted on every clean shutdown. Reading it as a fallback source is
- * dead-on-arrival for the exact transient-failure-on-restart scenario this cache
- * exists to survive. This sidecar lives in the persistent data dir, is written
- * ONLY after a healthy/partial resolve, and is never deleted on shutdown.
- *
- * Keyed by raw config entry so recovery is per-entry: an entry removed from
- * config (owner swap) or definitively gone is never revived.
+ * Persistent last-known-good `raw entry → ou_` cache for allowedUsers. The
+ * read/write primitives live in utils/allowed-users-cache.ts so the runtime
+ * set/revoke paths (services layer) write through the same sidecar and it never
+ * diverges from the live allowlist. These thin wrappers bind the data dir.
  */
-function allowedUsersCachePath(larkAppId: string): string {
-  return join(config.session.dataDir, `allowed-users-cache-${larkAppId}.json`);
+function readAllowedUsersCache(larkAppId: string): Record<string, string> {
+  return readAllowedUsersResolveCache(config.session.dataDir, larkAppId);
 }
-
-function readAllowedUsersResolveCache(larkAppId: string): Record<string, string> {
-  try {
-    const fp = allowedUsersCachePath(larkAppId);
-    if (!existsSync(fp)) return {};
-    const raw = JSON.parse(readFileSync(fp, 'utf8')) as { map?: unknown };
-    const m = raw?.map;
-    if (!m || typeof m !== 'object' || Array.isArray(m)) return {};
-    const out: Record<string, string> = {};
-    for (const [k, v] of Object.entries(m as Record<string, unknown>)) {
-      if (typeof k === 'string' && typeof v === 'string' && v.startsWith('ou_')) out[k] = v;
-    }
-    return out;
-  } catch {
-    return {};
-  }
-}
-
-/**
- * Persist the current `raw → ou_` map (only ou_ values kept). Best-effort;
- * merges over any existing cache so a partial resolve doesn't wipe entries it
- * couldn't reach this pass. `definitiveEntries` are PRUNED from the cache: an
- * entry that resolved definitively-gone (removed from tenant / not visible /
- * invalid) must never linger, or a later restart during an API blip would mark
- * it transient and revive a stale owner from cache. Never throws.
- */
-function writeAllowedUsersResolveCache(
+function writeAllowedUsersCache(
   larkAppId: string,
   map: Map<string, string>,
-  definitiveEntries?: Iterable<string>,
+  opts: { deleteEntries?: Iterable<string>; retainKeys?: Iterable<string> } = {},
 ): void {
-  try {
-    const merged = readAllowedUsersResolveCache(larkAppId);
-    for (const e of definitiveEntries ?? []) {
-      if (typeof e === 'string') delete merged[e];
-    }
-    for (const [k, v] of map.entries()) {
-      if (typeof k === 'string' && typeof v === 'string' && v.startsWith('ou_')) merged[k] = v;
-    }
-    atomicWriteFileSync(
-      allowedUsersCachePath(larkAppId),
-      JSON.stringify({ map: merged, updatedAt: Date.now() }),
-      { mode: 0o600 },
-    );
-  } catch (err: any) {
-    logger.debug(`[${larkAppId}] failed to persist allowedUsers cache: ${err?.message ?? err}`);
-  }
+  writeAllowedUsersResolveCache(config.session.dataDir, larkAppId, { map, ...opts });
 }
 
 /** Raw entries the resolver flagged as definitively gone (safe to prune from cache). */
@@ -3111,20 +3064,40 @@ function scheduleAllowedUsersResolveRetry(larkAppId: string, attempt = 1): void 
       }
       const configured = bot.config.allowedUsers ?? [];
       if (configured.length === 0) return;
+      // Fingerprint the config we resolve against. A /revoke or `set allowedUsers`
+      // can land during the cross-network resolve await below; without this fence
+      // the stale retry result would clobber the newer runtime/cache/descriptor —
+      // reviving a just-revoked guest, or forking runtime from the persisted
+      // config until the next restart. If the config changed, drop this result
+      // (the mutation path already wrote through, and if it needs a retry it
+      // schedules its own).
+      const fingerprint = JSON.stringify(configured);
       try {
         const resolveResult = await resolveAllowedUsersWithMap(larkAppId, configured);
+        let liveBot: BotState;
+        try { liveBot = getBot(larkAppId); } catch { return; }
+        if (JSON.stringify(liveBot.config.allowedUsers ?? []) !== fingerprint) {
+          logger.info(
+            `[${larkAppId}] allowedUsers resolve retry #${attempt} discarded: config changed during resolve`,
+          );
+          return;
+        }
         const applied = applyAllowedUsersResolve({
           rawEntries: configured,
-          previousResolvedMap: readAllowedUsersResolveCache(larkAppId),
+          previousResolvedMap: readAllowedUsersCache(larkAppId),
           resolveResult,
         });
-        bot.resolvedAllowedUsers = applied.resolved;
-        bot.rawAllowedUserResolution = applied.map;
+        liveBot.resolvedAllowedUsers = applied.resolved;
+        liveBot.rawAllowedUserResolution = applied.map;
         // Persist the recovered map + republish the descriptor so the dashboard
         // (create-group creator picker) and the next boot both see the healed
         // open_ids — otherwise a successful retry only heals in-memory state.
-        // Prune definitively-gone entries so a stale owner can't be revived later.
-        writeAllowedUsersResolveCache(larkAppId, applied.map, definitiveEntriesOf(resolveResult.entryStatus));
+        // Prune definitively-gone entries + keys no longer configured so a stale
+        // owner can't be revived later.
+        writeAllowedUsersCache(larkAppId, applied.map, {
+          deleteEntries: definitiveEntriesOf(resolveResult.entryStatus),
+          retainKeys: configured,
+        });
         republishResolvedAllowedUsers(larkAppId, applied.resolved);
         if (!applied.failed) {
           logger.info(
@@ -17134,6 +17107,10 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   // Expose the live descriptor module-level so the deferred allowedUsers resolve
   // retry can republish healed open_ids coherently (see republishResolvedAllowedUsers).
   selfDaemonDescriptor = desc;
+  // Let runtime allowedUsers mutations (set / revoke, in the services layer)
+  // republish the descriptor through the same path without importing daemon
+  // internals. Registered once per daemon; one daemon per bot.
+  setResolvedAllowedUsersRepublishHook(republishResolvedAllowedUsers);
   // 名称状态刷新：displayName 或飞书真名变化后，用有效展示名刷新 descriptor +
   // SessionRow.botName，无需重启 daemon。displayName 路径经 bot-config-store 的
   // 钩子触发；真·改名路径在下面的 renamer 里直接调用。
@@ -17403,7 +17380,7 @@ export async function startDaemon(botIndex?: number): Promise<void> {
       const configured = bot.config.allowedUsers ?? bot.resolvedAllowedUsers;
       const needsResolve = configured.some(u => u.includes('@') || u.startsWith('on_') || u.startsWith('ou_'));
       if (needsResolve) {
-        const previousResolvedMap = readAllowedUsersResolveCache(cfg.larkAppId);
+        const previousResolvedMap = readAllowedUsersCache(cfg.larkAppId);
         try {
           // 同时拿到 raw→open_id 映射,供 /revoke 反查删除 email 形式的 raw 条目(R2#2)。
           const resolveResult = await resolveAllowedUsersWithMap(cfg.larkAppId, configured);
@@ -17416,8 +17393,11 @@ export async function startDaemon(botIndex?: number): Promise<void> {
           bot.rawAllowedUserResolution = applied.map;
           // Persist the fresh/recovered map so the next boot (and a clean
           // restart, which deletes the descriptor) can fall back per-entry.
-          // Prune definitively-gone entries so they can't be revived later.
-          writeAllowedUsersResolveCache(cfg.larkAppId, applied.map, definitiveEntriesOf(resolveResult.entryStatus));
+          // Prune definitively-gone entries + keys no longer configured.
+          writeAllowedUsersCache(cfg.larkAppId, applied.map, {
+            deleteEntries: definitiveEntriesOf(resolveResult.entryStatus),
+            retainKeys: configured,
+          });
           logger.info(`[${cfg.larkAppId}] Resolved allowedUsers: ${bot.resolvedAllowedUsers.join(', ') || '(empty)'}${applied.usedFallback ? ' [some from cache]' : ''}`);
           if (applied.failed && applied.notice) {
             notifyAllowedUsersResolveFailure(cfg.larkAppId, applied.notice, applied.resolved);
@@ -17437,7 +17417,9 @@ export async function startDaemon(botIndex?: number): Promise<void> {
           });
           bot.resolvedAllowedUsers = applied.resolved;
           bot.rawAllowedUserResolution = applied.map;
-          if (applied.usedFallback) writeAllowedUsersResolveCache(cfg.larkAppId, applied.map);
+          if (applied.usedFallback) {
+            writeAllowedUsersCache(cfg.larkAppId, applied.map, { retainKeys: configured });
+          }
           const notice = applied.notice
             ?? `Failed to resolve allowedUsers: ${err?.message ?? err}`;
           notifyAllowedUsersResolveFailure(

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -45,6 +45,7 @@ import {
   effectiveBotDisplayName,
   resolveVcMeetingConsumerProfiles,
   setResolvedAllowedUsersRepublishHook,
+  setAllowedUsersResolveRetryHook,
   type BotConfig,
   type BotState,
   type OncallChat,
@@ -17111,6 +17112,9 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   // republish the descriptor through the same path without importing daemon
   // internals. Registered once per daemon; one daemon per bot.
   setResolvedAllowedUsersRepublishHook(republishResolvedAllowedUsers);
+  // And let a mutation that hit a transient contact failure schedule the same
+  // background resolve-retry the startup path uses (heal-when-API-recovers).
+  setAllowedUsersResolveRetryHook((appId) => scheduleAllowedUsersResolveRetry(appId));
   // 名称状态刷新：displayName 或飞书真名变化后，用有效展示名刷新 descriptor +
   // SessionRow.botName，无需重启 daemon。displayName 路径经 bot-config-store 的
   // 钩子触发；真·改名路径在下面的 renamer 里直接调用。

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -65,6 +65,7 @@ import { expandMergeForward } from './im/lark/merge-forward.js';
 import { bindResourcesToMessage, composeForwardFollowupContent, mergeMessageMentions } from './im/lark/forward-followup-content.js';
 import { buildQuoteHint } from './im/lark/quote-hint.js';
 import { logger } from './utils/logger.js';
+import { applyAllowedUsersResolve } from './utils/allowed-users-apply.js';
 import { withFileLock } from './utils/file-lock.js';
 import { delay } from './utils/timing.js';
 import { BoundedMap } from './utils/bounded-map.js';
@@ -2961,6 +2962,94 @@ function removeDaemonDescriptor(larkAppId: string): void {
   if (existsSync(fp)) {
     try { unlinkSync(fp); } catch { /* ignore */ }
   }
+}
+
+/** Last published open_ids from a prior daemon process (dashboard descriptor). */
+function readPreviousResolvedAllowedUsers(larkAppId: string): string[] {
+  try {
+    const fp = join(DAEMON_REGISTRY_DIR, `${larkAppId}.json`);
+    if (!existsSync(fp)) return [];
+    const raw = JSON.parse(readFileSync(fp, 'utf8')) as { resolvedAllowedUsers?: unknown };
+    const arr = raw.resolvedAllowedUsers;
+    if (!Array.isArray(arr)) return [];
+    return arr.filter((u): u is string => typeof u === 'string' && u.startsWith('ou_'));
+  } catch {
+    return [];
+  }
+}
+
+async function notifyAllowedUsersResolveFailure(
+  larkAppId: string,
+  notice: string,
+  recipients: string[],
+): Promise<void> {
+  logger.error(`[${larkAppId}] ${notice}`);
+  const unique = [...new Set(recipients.filter(u => typeof u === 'string' && u.startsWith('ou_')))];
+  for (const openId of unique.slice(0, 5)) {
+    try {
+      await sendUserMessage(
+        larkAppId,
+        openId,
+        `⚠️ Botmux allowedUsers 解析告警\n\n${notice}`,
+        'text',
+      );
+    } catch (err: any) {
+      logger.warn(
+        `[${larkAppId}] failed to DM allowedUsers resolve notice to ${openId.slice(0, 12)}: ${err?.message ?? err}`,
+      );
+    }
+  }
+  if (unique.length === 0) {
+    logger.error(
+      `[${larkAppId}] allowedUsers resolve failed with no open_id recipient available for DM; ` +
+      `check daemon logs and Feishu contact API, then restart this bot.`,
+    );
+  }
+}
+
+function scheduleAllowedUsersResolveRetry(larkAppId: string, attempt = 1): void {
+  if (attempt > 3) return;
+  const delayMs = attempt === 1 ? 30_000 : attempt === 2 ? 120_000 : 300_000;
+  const timer = setTimeout(() => {
+    void (async () => {
+      let bot: BotState;
+      try {
+        bot = getBot(larkAppId);
+      } catch {
+        return;
+      }
+      const configured = bot.config.allowedUsers ?? [];
+      if (configured.length === 0) return;
+      const previous = bot.resolvedAllowedUsers.filter(u => u.startsWith('ou_'));
+      try {
+        const resolveResult = await resolveAllowedUsersWithMap(larkAppId, configured);
+        const applied = applyAllowedUsersResolve({
+          rawEntries: configured,
+          previousResolvedOpenIds: previous,
+          resolveResult,
+        });
+        bot.resolvedAllowedUsers = applied.resolved;
+        bot.rawAllowedUserResolution = applied.map;
+        if (!applied.failed) {
+          logger.info(
+            `[${larkAppId}] allowedUsers resolve retry succeeded: ${applied.resolved.join(', ')}`,
+          );
+          return;
+        }
+        logger.warn(
+          `[${larkAppId}] allowedUsers resolve retry #${attempt} still unhealthy` +
+          `${applied.usedFallback ? ' (still on cache)' : ' (allowlist empty)'}`,
+        );
+        scheduleAllowedUsersResolveRetry(larkAppId, attempt + 1);
+      } catch (err: any) {
+        logger.warn(
+          `[${larkAppId}] allowedUsers resolve retry #${attempt} threw: ${err?.message ?? err}`,
+        );
+        scheduleAllowedUsersResolveRetry(larkAppId, attempt + 1);
+      }
+    })();
+  }, delayMs);
+  timer.unref?.();
 }
 
 // ─── Version tracking ────────────────────────────────────────────────────────
@@ -17199,21 +17288,55 @@ export async function startDaemon(botIndex?: number): Promise<void> {
     refreshCliVersion(cfg.cliId, cfg.cliPathOverride);
 
     // Resolve allowed users per bot
-    if (bot.resolvedAllowedUsers.length > 0) {
+    if ((bot.config.allowedUsers?.length ?? 0) > 0 || bot.resolvedAllowedUsers.length > 0) {
       // 含邮箱或 union_id(on_) 都要重解析成本 app 的 open_id —— 否则 canTalk/canOperate
       // 拿 sender 的 ou_ 对不上 on_，owner 会被自己的 bot 锁死（PR#72）。
       // literal ou_ 也走 best-effort 校验，用于诊断把其他 app 视角 open_id
       // 误填到本 bot 的配置。
-      const needsResolve = bot.resolvedAllowedUsers.some(u => u.includes('@') || u.startsWith('on_') || u.startsWith('ou_'));
+      //
+      // Transient contact failures must NOT blank the runtime list: an empty
+      // resolved allowlist under a configured allowedUsers is fail-closed and
+      // silently drops even the real owner (@ with no group reply). Keep the
+      // last-known ou_ cache, log loudly, DM owners, and retry.
+      const configured = bot.config.allowedUsers ?? bot.resolvedAllowedUsers;
+      const needsResolve = configured.some(u => u.includes('@') || u.startsWith('on_') || u.startsWith('ou_'));
       if (needsResolve) {
+        const previousOpenIds = [
+          ...bot.resolvedAllowedUsers.filter(u => u.startsWith('ou_')),
+          ...readPreviousResolvedAllowedUsers(cfg.larkAppId),
+        ];
         try {
           // 同时拿到 raw→open_id 映射，供 /revoke 反查删除 email 形式的 raw 条目（R2#2）。
-          const { resolved, map } = await resolveAllowedUsersWithMap(cfg.larkAppId, bot.resolvedAllowedUsers);
-          bot.resolvedAllowedUsers = resolved;
-          bot.rawAllowedUserResolution = map;
+          const resolveResult = await resolveAllowedUsersWithMap(cfg.larkAppId, configured);
+          const applied = applyAllowedUsersResolve({
+            rawEntries: configured,
+            previousResolvedOpenIds: previousOpenIds,
+            resolveResult,
+          });
+          bot.resolvedAllowedUsers = applied.resolved;
+          bot.rawAllowedUserResolution = applied.map;
           logger.info(`[${cfg.larkAppId}] Resolved allowedUsers: ${bot.resolvedAllowedUsers.join(', ')}`);
+          if (applied.failed && applied.notice) {
+            const recipients = applied.resolved.length > 0 ? applied.resolved : previousOpenIds;
+            await notifyAllowedUsersResolveFailure(cfg.larkAppId, applied.notice, recipients);
+            scheduleAllowedUsersResolveRetry(cfg.larkAppId);
+          }
         } catch (err: any) {
-          logger.warn(`[${cfg.larkAppId}] Failed to resolve allowedUsers: ${err.message}`);
+          const applied = applyAllowedUsersResolve({
+            rawEntries: configured,
+            previousResolvedOpenIds: previousOpenIds,
+            resolveResult: { resolved: [], map: new Map(), errored: true },
+          });
+          bot.resolvedAllowedUsers = applied.resolved;
+          bot.rawAllowedUserResolution = applied.map;
+          const notice = applied.notice
+            ?? `Failed to resolve allowedUsers: ${err?.message ?? err}`;
+          await notifyAllowedUsersResolveFailure(
+            cfg.larkAppId,
+            `${notice} (throw: ${err?.message ?? err})`,
+            applied.resolved.length > 0 ? applied.resolved : previousOpenIds,
+          );
+          scheduleAllowedUsersResolveRetry(cfg.larkAppId);
         }
       }
       // Republish the descriptor with the post-resolution open_ids so the

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -29,7 +29,7 @@ import {
 } from './core/cli-runtime-update.js';
 import { sendRestartReportIfPending } from './core/restart-report.js';
 import { statSync } from 'node:fs';
-import { addReaction, getChatMode, getChatNameAndMode, getMessageChatId, listChatMemberOpenIds, MessageWithdrawnError, replyMessage, resolveAllowedUsersWithMap, sendMessage, sendUserMessage, updateMessage } from './im/lark/client.js';
+import { addReaction, getChatMode, getChatNameAndMode, getMessageChatId, listChatMemberOpenIds, MessageWithdrawnError, replyMessage, resolveAllowedUsersWithMap, sendMessage, sendUserMessage, updateMessage, type EntryResolveStatus } from './im/lark/client.js';
 import { resolveGroupJoinPrompt, waitForAllowedUserInChat } from './core/auto-start.js';
 import {
   loadBotConfigAtIndex,
@@ -275,6 +275,25 @@ let selfV3BootInstanceId: string | undefined;
 /** Generic daemon identity used by internal receiver endpoints. Unlike the
  *  VC listener switch, every agent daemon may receive a fenced membership. */
 let selfDaemonLarkAppId: string | undefined;
+/**
+ * Live dashboard descriptor for THIS daemon's single bot. Held module-level so
+ * the deferred allowedUsers resolve retry (a detached setTimeout that has no
+ * `desc` in scope) can patch `resolvedAllowedUsers` and republish coherently —
+ * and so the 30s heartbeat, which rewrites this same object, never clobbers a
+ * healed value back to stale. One daemon per bot, so a single ref is correct.
+ */
+let selfDaemonDescriptor: DaemonDescriptor | undefined;
+
+/**
+ * Patch the live descriptor's `resolvedAllowedUsers` (ou_ only) and rewrite it.
+ * Safe to call from the deferred resolve retry. Best-effort.
+ */
+function republishResolvedAllowedUsers(larkAppId: string, resolved: string[]): void {
+  const desc = selfDaemonDescriptor;
+  if (!desc || desc.larkAppId !== larkAppId) return;
+  desc.resolvedAllowedUsers = resolved.filter(u => u.startsWith('ou_'));
+  try { writeDaemonDescriptor(desc); } catch { /* best effort */ }
+}
 let vcMeetingTerminalReconciler: VcMeetingTerminalReconciler | undefined;
 import { isBotMentioned, probeBotOpenId, startLarkEventDispatcher, markForwardFollowupsSessionsReady, writeBotInfoFile, canOperate, canRunDaemonCommand, evaluateTalk, grantCommandRestriction, isKnownPeerBot, checkRequiredScopes, type RoutingContext, type TalkEvaluation, type DocCommentContext, type EventHandlers } from './im/lark/event-dispatcher.js';
 import { getDocSubscription, listAllDocSubscriptions, listDocSubscriptionsForSession, removeDocSubscription, setDocCommentPollCursor, type DocSubscription } from './services/doc-subs-store.js';
@@ -2964,47 +2983,119 @@ function removeDaemonDescriptor(larkAppId: string): void {
   }
 }
 
-/** Last published open_ids from a prior daemon process (dashboard descriptor). */
-function readPreviousResolvedAllowedUsers(larkAppId: string): string[] {
+/**
+ * Persistent last-known-good `raw entry → ou_` cache for allowedUsers.
+ *
+ * This is DELIBERATELY NOT the dashboard descriptor: the descriptor is
+ * (a) overwritten unconditionally early in boot with the still-unresolved raw
+ * config (so its `resolvedAllowedUsers` is `[]` for an on_/email-only owner),
+ * and (b) deleted on every clean shutdown. Reading it as a fallback source is
+ * dead-on-arrival for the exact transient-failure-on-restart scenario this cache
+ * exists to survive. This sidecar lives in the persistent data dir, is written
+ * ONLY after a healthy/partial resolve, and is never deleted on shutdown.
+ *
+ * Keyed by raw config entry so recovery is per-entry: an entry removed from
+ * config (owner swap) or definitively gone is never revived.
+ */
+function allowedUsersCachePath(larkAppId: string): string {
+  return join(config.session.dataDir, `allowed-users-cache-${larkAppId}.json`);
+}
+
+function readAllowedUsersResolveCache(larkAppId: string): Record<string, string> {
   try {
-    const fp = join(DAEMON_REGISTRY_DIR, `${larkAppId}.json`);
-    if (!existsSync(fp)) return [];
-    const raw = JSON.parse(readFileSync(fp, 'utf8')) as { resolvedAllowedUsers?: unknown };
-    const arr = raw.resolvedAllowedUsers;
-    if (!Array.isArray(arr)) return [];
-    return arr.filter((u): u is string => typeof u === 'string' && u.startsWith('ou_'));
+    const fp = allowedUsersCachePath(larkAppId);
+    if (!existsSync(fp)) return {};
+    const raw = JSON.parse(readFileSync(fp, 'utf8')) as { map?: unknown };
+    const m = raw?.map;
+    if (!m || typeof m !== 'object' || Array.isArray(m)) return {};
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(m as Record<string, unknown>)) {
+      if (typeof k === 'string' && typeof v === 'string' && v.startsWith('ou_')) out[k] = v;
+    }
+    return out;
   } catch {
-    return [];
+    return {};
   }
 }
 
-async function notifyAllowedUsersResolveFailure(
+/**
+ * Persist the current `raw → ou_` map (only ou_ values kept). Best-effort;
+ * merges over any existing cache so a partial resolve doesn't wipe entries it
+ * couldn't reach this pass. `definitiveEntries` are PRUNED from the cache: an
+ * entry that resolved definitively-gone (removed from tenant / not visible /
+ * invalid) must never linger, or a later restart during an API blip would mark
+ * it transient and revive a stale owner from cache. Never throws.
+ */
+function writeAllowedUsersResolveCache(
+  larkAppId: string,
+  map: Map<string, string>,
+  definitiveEntries?: Iterable<string>,
+): void {
+  try {
+    const merged = readAllowedUsersResolveCache(larkAppId);
+    for (const e of definitiveEntries ?? []) {
+      if (typeof e === 'string') delete merged[e];
+    }
+    for (const [k, v] of map.entries()) {
+      if (typeof k === 'string' && typeof v === 'string' && v.startsWith('ou_')) merged[k] = v;
+    }
+    atomicWriteFileSync(
+      allowedUsersCachePath(larkAppId),
+      JSON.stringify({ map: merged, updatedAt: Date.now() }),
+      { mode: 0o600 },
+    );
+  } catch (err: any) {
+    logger.debug(`[${larkAppId}] failed to persist allowedUsers cache: ${err?.message ?? err}`);
+  }
+}
+
+/** Raw entries the resolver flagged as definitively gone (safe to prune from cache). */
+function definitiveEntriesOf(entryStatus?: Map<string, EntryResolveStatus>): string[] {
+  if (!entryStatus) return [];
+  const out: string[] = [];
+  for (const [entry, status] of entryStatus.entries()) {
+    if (status === 'definitive') out.push(entry);
+  }
+  return out;
+}
+
+function notifyAllowedUsersResolveFailure(
   larkAppId: string,
   notice: string,
   recipients: string[],
-): Promise<void> {
+): void {
   logger.error(`[${larkAppId}] ${notice}`);
   const unique = [...new Set(recipients.filter(u => typeof u === 'string' && u.startsWith('ou_')))];
-  for (const openId of unique.slice(0, 5)) {
-    try {
-      await sendUserMessage(
-        larkAppId,
-        openId,
-        `⚠️ Botmux allowedUsers 解析告警\n\n${notice}`,
-        'text',
-      );
-    } catch (err: any) {
-      logger.warn(
-        `[${larkAppId}] failed to DM allowedUsers resolve notice to ${openId.slice(0, 12)}: ${err?.message ?? err}`,
-      );
-    }
-  }
   if (unique.length === 0) {
     logger.error(
       `[${larkAppId}] allowedUsers resolve failed with no open_id recipient available for DM; ` +
       `check daemon logs and Feishu contact API, then restart this bot.`,
     );
+    return;
   }
+  // Fire-and-forget: the owner DM must NOT block daemon startup. sendUserMessage
+  // uses an untimed SDK path; awaiting it on the boot-critical path (before the
+  // WS listener starts) would stall the bot coming online during the very
+  // contact/network partition that triggered this notice. Bound each attempt
+  // with a deadline and detach.
+  void (async () => {
+    for (const openId of unique.slice(0, 5)) {
+      try {
+        await sendUserMessage(
+          larkAppId,
+          openId,
+          `⚠️ Botmux allowedUsers 解析告警\n\n${notice}`,
+          'text',
+          undefined,
+          { timeoutMs: 10_000 },
+        );
+      } catch (err: any) {
+        logger.warn(
+          `[${larkAppId}] failed to DM allowedUsers resolve notice to ${openId.slice(0, 12)}: ${err?.message ?? err}`,
+        );
+      }
+    }
+  })();
 }
 
 function scheduleAllowedUsersResolveRetry(larkAppId: string, attempt = 1): void {
@@ -3020,25 +3111,30 @@ function scheduleAllowedUsersResolveRetry(larkAppId: string, attempt = 1): void 
       }
       const configured = bot.config.allowedUsers ?? [];
       if (configured.length === 0) return;
-      const previous = bot.resolvedAllowedUsers.filter(u => u.startsWith('ou_'));
       try {
         const resolveResult = await resolveAllowedUsersWithMap(larkAppId, configured);
         const applied = applyAllowedUsersResolve({
           rawEntries: configured,
-          previousResolvedOpenIds: previous,
+          previousResolvedMap: readAllowedUsersResolveCache(larkAppId),
           resolveResult,
         });
         bot.resolvedAllowedUsers = applied.resolved;
         bot.rawAllowedUserResolution = applied.map;
+        // Persist the recovered map + republish the descriptor so the dashboard
+        // (create-group creator picker) and the next boot both see the healed
+        // open_ids — otherwise a successful retry only heals in-memory state.
+        // Prune definitively-gone entries so a stale owner can't be revived later.
+        writeAllowedUsersResolveCache(larkAppId, applied.map, definitiveEntriesOf(resolveResult.entryStatus));
+        republishResolvedAllowedUsers(larkAppId, applied.resolved);
         if (!applied.failed) {
           logger.info(
-            `[${larkAppId}] allowedUsers resolve retry succeeded: ${applied.resolved.join(', ')}`,
+            `[${larkAppId}] allowedUsers resolve retry succeeded: ${applied.resolved.join(', ') || '(empty — entries definitively gone)'}`,
           );
           return;
         }
         logger.warn(
-          `[${larkAppId}] allowedUsers resolve retry #${attempt} still unhealthy` +
-          `${applied.usedFallback ? ' (still on cache)' : ' (allowlist empty)'}`,
+          `[${larkAppId}] allowedUsers resolve retry #${attempt} still degraded` +
+          `${applied.usedFallback ? ' (on cache)' : applied.resolved.length ? '' : ' (allowlist empty)'}`,
         );
         scheduleAllowedUsersResolveRetry(larkAppId, attempt + 1);
       } catch (err: any) {
@@ -17035,6 +17131,9 @@ export async function startDaemon(botIndex?: number): Promise<void> {
     // briefly sees an unusable on_/email (the resolution below rewrites this field).
     resolvedAllowedUsers: getBot(cfg.larkAppId).resolvedAllowedUsers.filter(u => u.startsWith('ou_')),
   };
+  // Expose the live descriptor module-level so the deferred allowedUsers resolve
+  // retry can republish healed open_ids coherently (see republishResolvedAllowedUsers).
+  selfDaemonDescriptor = desc;
   // 名称状态刷新：displayName 或飞书真名变化后，用有效展示名刷新 descriptor +
   // SessionRow.botName，无需重启 daemon。displayName 路径经 bot-config-store 的
   // 钩子触发；真·改名路径在下面的 renamer 里直接调用。
@@ -17296,45 +17395,55 @@ export async function startDaemon(botIndex?: number): Promise<void> {
       //
       // Transient contact failures must NOT blank the runtime list: an empty
       // resolved allowlist under a configured allowedUsers is fail-closed and
-      // silently drops even the real owner (@ with no group reply). Keep the
-      // last-known ou_ cache, log loudly, DM owners, and retry.
+      // silently drops even the real owner (@ with no group reply). Reuse the
+      // last-known-good `raw → ou_` cache PER ENTRY (only for still-configured,
+      // transient-failed entries), log loudly, DM owners (fire-and-forget), and
+      // schedule retries. The cache is a persistent sidecar — NOT the dashboard
+      // descriptor, which is overwritten early in boot and deleted on shutdown.
       const configured = bot.config.allowedUsers ?? bot.resolvedAllowedUsers;
       const needsResolve = configured.some(u => u.includes('@') || u.startsWith('on_') || u.startsWith('ou_'));
       if (needsResolve) {
-        const previousOpenIds = [
-          ...bot.resolvedAllowedUsers.filter(u => u.startsWith('ou_')),
-          ...readPreviousResolvedAllowedUsers(cfg.larkAppId),
-        ];
+        const previousResolvedMap = readAllowedUsersResolveCache(cfg.larkAppId);
         try {
-          // 同时拿到 raw→open_id 映射，供 /revoke 反查删除 email 形式的 raw 条目（R2#2）。
+          // 同时拿到 raw→open_id 映射,供 /revoke 反查删除 email 形式的 raw 条目(R2#2)。
           const resolveResult = await resolveAllowedUsersWithMap(cfg.larkAppId, configured);
           const applied = applyAllowedUsersResolve({
             rawEntries: configured,
-            previousResolvedOpenIds: previousOpenIds,
+            previousResolvedMap,
             resolveResult,
           });
           bot.resolvedAllowedUsers = applied.resolved;
           bot.rawAllowedUserResolution = applied.map;
-          logger.info(`[${cfg.larkAppId}] Resolved allowedUsers: ${bot.resolvedAllowedUsers.join(', ')}`);
+          // Persist the fresh/recovered map so the next boot (and a clean
+          // restart, which deletes the descriptor) can fall back per-entry.
+          // Prune definitively-gone entries so they can't be revived later.
+          writeAllowedUsersResolveCache(cfg.larkAppId, applied.map, definitiveEntriesOf(resolveResult.entryStatus));
+          logger.info(`[${cfg.larkAppId}] Resolved allowedUsers: ${bot.resolvedAllowedUsers.join(', ') || '(empty)'}${applied.usedFallback ? ' [some from cache]' : ''}`);
           if (applied.failed && applied.notice) {
-            const recipients = applied.resolved.length > 0 ? applied.resolved : previousOpenIds;
-            await notifyAllowedUsersResolveFailure(cfg.larkAppId, applied.notice, recipients);
+            notifyAllowedUsersResolveFailure(cfg.larkAppId, applied.notice, applied.resolved);
             scheduleAllowedUsersResolveRetry(cfg.larkAppId);
           }
         } catch (err: any) {
+          // A full throw is a transient outage: mark every contact-resolvable
+          // entry transient so the pure fn can recover each from cache.
+          const throwStatus = new Map<string, EntryResolveStatus>();
+          for (const e of configured) {
+            if (e.includes('@') || e.startsWith('on_') || e.startsWith('ou_')) throwStatus.set(e, 'transient');
+          }
           const applied = applyAllowedUsersResolve({
             rawEntries: configured,
-            previousResolvedOpenIds: previousOpenIds,
-            resolveResult: { resolved: [], map: new Map(), errored: true },
+            previousResolvedMap,
+            resolveResult: { resolved: [], map: new Map(), errored: true, entryStatus: throwStatus },
           });
           bot.resolvedAllowedUsers = applied.resolved;
           bot.rawAllowedUserResolution = applied.map;
+          if (applied.usedFallback) writeAllowedUsersResolveCache(cfg.larkAppId, applied.map);
           const notice = applied.notice
             ?? `Failed to resolve allowedUsers: ${err?.message ?? err}`;
-          await notifyAllowedUsersResolveFailure(
+          notifyAllowedUsersResolveFailure(
             cfg.larkAppId,
             `${notice} (throw: ${err?.message ?? err})`,
-            applied.resolved.length > 0 ? applied.resolved : previousOpenIds,
+            applied.resolved,
           );
           scheduleAllowedUsersResolveRetry(cfg.larkAppId);
         }

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -1106,14 +1106,16 @@ export async function resolveAllowedUsersWithMap(
           data: { emails, include_resigned: false },
         });
         if (res.code !== 0) {
-          // Distinguish a DEFINITIVE batch error (permanent 4xx: invalid arg /
-          // not visible / cross-app — classifyContactErrorCode) from a TRANSIENT
-          // one (network / rate-limit / 5xx). Only transient failures may fall
-          // back to cache + arm the retry; a permanent 4xx marks every requested
-          // email definitive so we don't spin retries or revive a stale owner.
-          const definitive = !!classifyContactErrorCode(res.code);
-          if (!definitive) errored = true;
-          for (const rawEmail of emails) entryStatus.set(rawEmail, definitive ? 'definitive' : 'transient');
+          // A non-zero batchGetId code is a WHOLE-REQUEST failure, not a
+          // per-email identity verdict — even a permanent 4xx like 40001
+          // (invalid argument) tells us nothing about whether any individual
+          // owner still exists. Treating it as per-email definitive would
+          // silently prune an email-only owner's last-known-good cache and
+          // fail-closed lock them out. So mark every requested email TRANSIENT
+          // (retry-eligible, cache-fallback-eligible). Only a code-0 response
+          // that omits a specific email (below) is a per-entry definitive miss.
+          errored = true;
+          for (const rawEmail of emails) entryStatus.set(rawEmail, 'transient');
           logger.warn(`Failed to resolve emails to open_ids: ${res.msg} (code: ${res.code})`);
         } else {
           const userList: any[] = res.data?.user_list ?? [];
@@ -1139,12 +1141,12 @@ export async function resolveAllowedUsersWithMap(
           }
         }
       } catch (err: any) {
-        // A throw with a definitive contact code (permanent 4xx surfaced as an
-        // AxiosError/SDK error) is a definitive miss; anything else (network /
-        // timeout / 5xx) is transient and retry-eligible.
-        const definitive = !!classifyContactErrorCode(getLarkErrorCode(err));
-        if (!definitive) errored = true;
-        for (const rawEmail of emails) entryStatus.set(rawEmail, definitive ? 'definitive' : 'transient');
+        // A throw is a whole-request failure (network / timeout / 5xx / even a
+        // thrown 4xx) — same reasoning as the non-zero-code branch above: it is
+        // NOT a per-email identity verdict, so every requested email is
+        // transient (retry + cache-fallback eligible), never definitive.
+        errored = true;
+        for (const rawEmail of emails) entryStatus.set(rawEmail, 'transient');
         logger.warn(`resolveAllowedUsers failed: ${err.message}`);
       }
     }

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -1106,10 +1106,14 @@ export async function resolveAllowedUsersWithMap(
           data: { emails, include_resigned: false },
         });
         if (res.code !== 0) {
-          errored = true;
-          // Whole batch call failed transiently — every requested email is a
-          // retry candidate, not a definitive miss.
-          for (const rawEmail of emails) entryStatus.set(rawEmail, 'transient');
+          // Distinguish a DEFINITIVE batch error (permanent 4xx: invalid arg /
+          // not visible / cross-app — classifyContactErrorCode) from a TRANSIENT
+          // one (network / rate-limit / 5xx). Only transient failures may fall
+          // back to cache + arm the retry; a permanent 4xx marks every requested
+          // email definitive so we don't spin retries or revive a stale owner.
+          const definitive = !!classifyContactErrorCode(res.code);
+          if (!definitive) errored = true;
+          for (const rawEmail of emails) entryStatus.set(rawEmail, definitive ? 'definitive' : 'transient');
           logger.warn(`Failed to resolve emails to open_ids: ${res.msg} (code: ${res.code})`);
         } else {
           const userList: any[] = res.data?.user_list ?? [];
@@ -1135,8 +1139,12 @@ export async function resolveAllowedUsersWithMap(
           }
         }
       } catch (err: any) {
-        errored = true;
-        for (const rawEmail of emails) entryStatus.set(rawEmail, 'transient');
+        // A throw with a definitive contact code (permanent 4xx surfaced as an
+        // AxiosError/SDK error) is a definitive miss; anything else (network /
+        // timeout / 5xx) is transient and retry-eligible.
+        const definitive = !!classifyContactErrorCode(getLarkErrorCode(err));
+        if (!definitive) errored = true;
+        for (const rawEmail of emails) entryStatus.set(rawEmail, definitive ? 'definitive' : 'transient');
         logger.warn(`resolveAllowedUsers failed: ${err.message}`);
       }
     }

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -1005,21 +1005,41 @@ export async function uploadFile(larkAppId: string, filePath: string, opts?: { d
  * (matched case-insensitively against the API's returned email) so the map key
  * always equals what's in `allowedUsers`. Unresolvable emails are dropped.
  */
+/**
+ * Per-raw-entry outcome of an allowedUsers resolve:
+ *  - `resolved`   — turned into an ou_ this pass (or a literal ou_ kept as-is).
+ *  - `transient`  — contact API transiently failed (throw / rate limit / 5xx);
+ *                   a last-known-good cache MAY be reused for this entry.
+ *  - `definitive` — id invalid / not visible / not found (DEFINITIVE codes) or
+ *                   a code-0 batch that simply didn't return this email; the
+ *                   entry is genuinely gone and MUST NOT be revived from cache.
+ */
+export type EntryResolveStatus = 'resolved' | 'transient' | 'definitive';
+
 export async function resolveAllowedUsersWithMap(
   larkAppId: string, raw: string[],
-): Promise<{ resolved: string[]; map: Map<string, string>; errored?: boolean }> {
+): Promise<{ resolved: string[]; map: Map<string, string>; errored?: boolean; entryStatus: Map<string, EntryResolveStatus> }> {
   const map = new Map<string, string>();
   // True when a TRANSIENT failure (throw / rate limit / server error) hit any
   // requested item — the caller can then say "resolution failed, retry" instead
   // of the misleading "this identifier does not exist". Definitive failures
   // (id invalid / not visible: DEFINITIVE_CONTACT_ERROR_CODES) don't set it.
   let errored = false;
+  // Per-raw-entry outcome so callers can fall back to a last-known-good cache
+  // ONLY for entries that transient-failed AND are still configured — never for
+  // definitively-removed users (revives ex-owners) or entries no longer in
+  // config (revives a swapped-out owner). See allowed-users-apply.ts. Any entry
+  // not explicitly set below stays absent → treated as 'definitive' (drop).
+  const entryStatus = new Map<string, EntryResolveStatus>();
   const openIds: string[] = [];
   const emails: string[] = [];
   const unionIds: string[] = [];
   for (const v of raw) {
     if (v.startsWith('ou_')) {
       map.set(v, v);
+      // Literal ou_ is app-scoped and kept as-is (never dropped, mirrors
+      // pre-existing behavior); the diagnostic GET below does not change this.
+      entryStatus.set(v, 'resolved');
       openIds.push(v);
     } else if (v.startsWith('on_')) {
       // union_id (跨应用稳定)：运行时权限/私信/卡片全是 open_id 原生的，
@@ -1056,13 +1076,25 @@ export async function resolveAllowedUsersWithMap(
         const oid = res?.data?.user?.open_id as string | undefined;
         if (res.code === 0 && oid) {
           map.set(uid, oid);
+          entryStatus.set(uid, 'resolved');
           logger.info(`Resolved ${uid} → ${oid}`);
         } else {
-          if (!classifyContactErrorCode(res?.code)) errored = true;
+          // code-0 with no open_id is a DEFINITIVE miss (union user outside this
+          // app's contact visibility → tenant returns an empty code-0 shell
+          // rather than 41050), mirroring the email-batch not-in-list case above
+          // and getUserProfileStrict's `code===0 ? 'not_visible'` rule. Bucketing
+          // it 'transient' would (a) spin the never-converging retry/DM chain and
+          // (b) revive a now-invisible owner from a stale cache. Only a non-zero
+          // non-definitive code (network/5xx/rate-limit) is transient.
+          const definitive = res?.code === 0 ? true : !!classifyContactErrorCode(res?.code);
+          if (!definitive) errored = true;
+          entryStatus.set(uid, definitive ? 'definitive' : 'transient');
           logger.warn(`Failed to resolve union_id ${uid} to open_id: ${res?.msg} (code: ${res?.code})`);
         }
       } catch (err: any) {
-        if (!classifyContactErrorCode(getLarkErrorCode(err))) errored = true;
+        const definitive = !!classifyContactErrorCode(getLarkErrorCode(err));
+        if (!definitive) errored = true;
+        entryStatus.set(uid, definitive ? 'definitive' : 'transient');
         logger.warn(`resolve union_id ${uid} failed: ${err?.message ?? err}`);
       }
     }
@@ -1075,6 +1107,9 @@ export async function resolveAllowedUsersWithMap(
         });
         if (res.code !== 0) {
           errored = true;
+          // Whole batch call failed transiently — every requested email is a
+          // retry candidate, not a definitive miss.
+          for (const rawEmail of emails) entryStatus.set(rawEmail, 'transient');
           logger.warn(`Failed to resolve emails to open_ids: ${res.msg} (code: ${res.code})`);
         } else {
           const userList: any[] = res.data?.user_list ?? [];
@@ -1089,12 +1124,19 @@ export async function resolveAllowedUsersWithMap(
             const uid = byNorm.get(rawEmail.toLowerCase());
             if (uid) {
               map.set(rawEmail, uid);
+              entryStatus.set(rawEmail, 'resolved');
               logger.info(`Resolved ${rawEmail} → ${uid}`);
+            } else {
+              // Batch call itself succeeded (code 0) but this email is not in
+              // the returned user_list → definitive miss (no such user / not
+              // visible), NOT a transient failure. Do not fall back to cache.
+              entryStatus.set(rawEmail, 'definitive');
             }
           }
         }
       } catch (err: any) {
         errored = true;
+        for (const rawEmail of emails) entryStatus.set(rawEmail, 'transient');
         logger.warn(`resolveAllowedUsers failed: ${err.message}`);
       }
     }
@@ -1113,7 +1155,7 @@ export async function resolveAllowedUsersWithMap(
       resolved.push(oid);
     }
   }
-  return { resolved, map, errored };
+  return { resolved, map, errored, entryStatus };
 }
 
 /**

--- a/src/services/bot-config-store.ts
+++ b/src/services/bot-config-store.ts
@@ -10,7 +10,7 @@
  */
 import type { BotConfig } from '../bot-registry.js';
 import { getBot, readBotSkillPolicy } from '../bot-registry.js';
-import { republishResolvedAllowedUsersDescriptor } from '../bot-registry.js';
+import { republishResolvedAllowedUsersDescriptor, scheduleAllowedUsersResolveRetryFromMutation } from '../bot-registry.js';
 import { config } from '../config.js';
 import { writeAllowedUsersResolveCache } from '../utils/allowed-users-cache.js';
 import { rmwBotEntry } from './config-store.js';
@@ -266,7 +266,7 @@ export async function setBotAllowedUsers(
   let bot;
   try { bot = getBot(larkAppId); } catch { return { ok: false, reason: 'bot_not_registered' }; }
 
-  const { resolved, map } = await resolveAllowedUsersWithMap(larkAppId, rawEntries);
+  const { resolved, map, entryStatus } = await resolveAllowedUsersWithMap(larkAppId, rawEntries);
   if (resolved.length === 0) return { ok: false, reason: 'empty_resolved' };
   if (senderOpenId && !resolved.includes(senderOpenId)) return { ok: false, reason: 'self_lockout' };
 
@@ -284,9 +284,26 @@ export async function setBotAllowedUsers(
   // from email to on_ while contact API is healthy) leaves the new raw key out
   // of the cache; the next clean restart during an API blip would then resolve
   // empty and fail-closed lock the owner out — the exact bug this feature fixes.
-  // retainKeys prunes stale keys (old email/union no longer configured).
-  writeAllowedUsersResolveCache(config.session.dataDir, larkAppId, { map, retainKeys: rawEntries });
+  // retainKeys prunes stale keys (old email/union no longer configured);
+  // deleteEntries drops entries that resolved DEFINITIVELY-gone in THIS set (e.g.
+  // a removed co-owner) so a later transient restart can't revive them from cache.
+  const definitiveEntries: string[] = [];
+  let anyTransient = false;
+  for (const [entry, status] of entryStatus.entries()) {
+    if (status === 'definitive') definitiveEntries.push(entry);
+    else if (status === 'transient') anyTransient = true;
+  }
+  writeAllowedUsersResolveCache(config.session.dataDir, larkAppId, {
+    map,
+    retainKeys: rawEntries,
+    deleteEntries: definitiveEntries,
+  });
   republishResolvedAllowedUsersDescriptor(larkAppId, resolved);
+  // Partial-transient set: the owner (senderOpenId) resolved (self_lockout guard
+  // above guarantees it), but some OTHER entry transient-failed. Schedule the
+  // same background heal the startup path uses so that entry recovers when the
+  // contact API does, instead of silently staying dropped until the next restart.
+  if (anyTransient) scheduleAllowedUsersResolveRetryFromMutation(larkAppId);
   logger.info(`[config:${larkAppId}] allowedUsers updated: ${rawEntries.length} entries, ${resolved.length} resolved`);
   return { ok: true, raw: rawEntries, resolved };
 }

--- a/src/services/bot-config-store.ts
+++ b/src/services/bot-config-store.ts
@@ -10,6 +10,9 @@
  */
 import type { BotConfig } from '../bot-registry.js';
 import { getBot, readBotSkillPolicy } from '../bot-registry.js';
+import { republishResolvedAllowedUsersDescriptor } from '../bot-registry.js';
+import { config } from '../config.js';
+import { writeAllowedUsersResolveCache } from '../utils/allowed-users-cache.js';
 import { rmwBotEntry } from './config-store.js';
 import { resolveAllowedUsersWithMap } from '../im/lark/client.js';
 import { CLI_OPTIONS, resolveCliId } from '../setup/bot-config-editor.js';
@@ -276,6 +279,14 @@ export async function setBotAllowedUsers(
   bot.config.allowedUsers = rawEntries;
   bot.resolvedAllowedUsers = resolved;
   bot.rawAllowedUserResolution = map;
+  // Keep the last-known-good sidecar + dashboard descriptor in lockstep with the
+  // live allowlist. Without this, a hot `set allowedUsers` (e.g. owner switches
+  // from email to on_ while contact API is healthy) leaves the new raw key out
+  // of the cache; the next clean restart during an API blip would then resolve
+  // empty and fail-closed lock the owner out — the exact bug this feature fixes.
+  // retainKeys prunes stale keys (old email/union no longer configured).
+  writeAllowedUsersResolveCache(config.session.dataDir, larkAppId, { map, retainKeys: rawEntries });
+  republishResolvedAllowedUsersDescriptor(larkAppId, resolved);
   logger.info(`[config:${larkAppId}] allowedUsers updated: ${rawEntries.length} entries, ${resolved.length} resolved`);
   return { ok: true, raw: rawEntries, resolved };
 }

--- a/src/services/grant-store.ts
+++ b/src/services/grant-store.ts
@@ -3,7 +3,10 @@
  * 写路径走 config-store 的跨进程锁；撤销在单个 RMW 内同删 chat+global（原子）。
  */
 import { getBot, getOwnerOpenId } from '../bot-registry.js';
+import { republishResolvedAllowedUsersDescriptor } from '../bot-registry.js';
 import { rmwBotEntry } from './config-store.js';
+import { config } from '../config.js';
+import { writeAllowedUsersResolveCache } from '../utils/allowed-users-cache.js';
 import { logger } from '../utils/logger.js';
 
 type Fail = { ok: false; reason: string };
@@ -319,6 +322,19 @@ export async function revokeGrant(
       bot.rawAllowedUserResolution.delete(rawEntry);
     }
     bot.resolvedAllowedUsers = bot.resolvedAllowedUsers.filter(u => u !== openId);
+    // Keep the last-known-good sidecar + dashboard descriptor in lockstep with
+    // the revoke. Drop the revoked raw key from the cache (retainKeys = the
+    // post-revoke config) so a later restart during an API blip cannot revive
+    // the just-revoked user from a stale cache. republish so create-group's
+    // creator picker doesn't keep offering the removed open_id.
+    if (rawEntry) {
+      writeAllowedUsersResolveCache(config.session.dataDir, larkAppId, {
+        map: {},
+        deleteEntries: [rawEntry],
+        retainKeys: bot.config.allowedUsers ?? [],
+      });
+    }
+    republishResolvedAllowedUsersDescriptor(larkAppId, bot.resolvedAllowedUsers);
   }
   if (r.result.globalTalk) {
     const next = (bot.config.globalGrants ?? []).filter(u => u !== openId);

--- a/src/utils/allowed-users-apply.ts
+++ b/src/utils/allowed-users-apply.ts
@@ -1,0 +1,140 @@
+/**
+ * Decide how to apply a startup / refresh resolve of allowedUsers.
+ *
+ * Runtime permission (canTalk/canOperate) only matches app-scoped open_ids
+ * (`ou_…`). Config may store stable `on_…` / emails that must be resolved each
+ * boot. A transient contact API failure used to overwrite the runtime list with
+ * `[]`, which fail-closed locks out even the real owner with almost no signal.
+ */
+
+export interface AllowedUsersResolveResultLike {
+  resolved: string[];
+  map: Map<string, string>;
+  /** True when contact API hit a transient failure (network / 5xx / rate limit). */
+  errored?: boolean;
+}
+
+export interface ApplyAllowedUsersResolveInput {
+  /** Raw bots.json entries (ou_ / on_ / email). */
+  rawEntries: string[];
+  /**
+   * Last known-good open_ids (typically previous daemon descriptor or in-memory
+   * list already filtered to `ou_`). Used only as a fallback.
+   */
+  previousResolvedOpenIds: string[];
+  resolveResult: AllowedUsersResolveResultLike;
+}
+
+export interface ApplyAllowedUsersResolveOutput {
+  resolved: string[];
+  map: Map<string, string>;
+  /** True when runtime list came from previousResolvedOpenIds, not this resolve. */
+  usedFallback: boolean;
+  /**
+   * True when config has entries but we could not produce a fresh successful
+   * resolve (empty result and/or errored). Callers must surface a notice.
+   */
+  failed: boolean;
+  /** Human-readable notice for logs / owner DM; null when nothing to report. */
+  notice: string | null;
+}
+
+function onlyOpenIds(ids: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of ids) {
+    if (typeof id !== 'string' || !id.startsWith('ou_') || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
+function needsContactResolve(rawEntries: string[]): boolean {
+  return rawEntries.some(u => u.includes('@') || u.startsWith('on_') || u.startsWith('ou_'));
+}
+
+/**
+ * Pure merge of resolve result + optional last-good open_id cache.
+ * Never leaves bare `on_` / emails in the runtime list — those cannot match
+ * message senders and would still lock the owner out.
+ */
+export function applyAllowedUsersResolve(
+  input: ApplyAllowedUsersResolveInput,
+): ApplyAllowedUsersResolveOutput {
+  const rawEntries = input.rawEntries.filter(u => typeof u === 'string' && u.trim().length > 0);
+  const previous = onlyOpenIds(input.previousResolvedOpenIds);
+  const { resolved, map, errored } = input.resolveResult;
+  const fresh = onlyOpenIds(resolved);
+
+  if (rawEntries.length === 0) {
+    return {
+      resolved: [],
+      map,
+      usedFallback: false,
+      failed: false,
+      notice: null,
+    };
+  }
+
+  if (fresh.length > 0 && !errored) {
+    return {
+      resolved: fresh,
+      map,
+      usedFallback: false,
+      failed: false,
+      notice: null,
+    };
+  }
+
+  // Partial success with transient error: prefer fresh open_ids when present,
+  // but still surface a notice so operators know contact API is unhealthy.
+  if (fresh.length > 0 && errored) {
+    return {
+      resolved: fresh,
+      map,
+      usedFallback: false,
+      failed: true,
+      notice:
+        `allowedUsers contact resolve reported transient errors; using ${fresh.length} freshly resolved open_id(s). ` +
+        `Raw entries: ${rawEntries.join(', ')}`,
+    };
+  }
+
+  // Total miss: keep last-good open_ids so owner is not fail-closed into silence.
+  if (previous.length > 0) {
+    return {
+      resolved: previous,
+      map,
+      usedFallback: true,
+      failed: true,
+      notice:
+        `allowedUsers resolve failed (empty runtime list from contact API` +
+        `${errored ? ', transient error flagged' : ''}); ` +
+        `temporarily reusing ${previous.length} last-known open_id(s). ` +
+        `Raw entries: ${rawEntries.join(', ')}. ` +
+        `Owner talk may work via cache; restart/retry after Feishu contact recovers.`,
+    };
+  }
+
+  if (!needsContactResolve(rawEntries)) {
+    return {
+      resolved: [],
+      map,
+      usedFallback: false,
+      failed: false,
+      notice: null,
+    };
+  }
+
+  return {
+    resolved: [],
+    map,
+    usedFallback: false,
+    failed: true,
+    notice:
+      `allowedUsers resolve failed and no last-known open_id cache is available; ` +
+      `runtime allowlist is empty so everyone (including the real owner) is denied. ` +
+      `Raw entries: ${rawEntries.join(', ')}. Check Feishu contact API / bot scopes, then restart the bot.`,
+  };
+}

--- a/src/utils/allowed-users-apply.ts
+++ b/src/utils/allowed-users-apply.ts
@@ -5,136 +5,176 @@
  * (`ou_…`). Config may store stable `on_…` / emails that must be resolved each
  * boot. A transient contact API failure used to overwrite the runtime list with
  * `[]`, which fail-closed locks out even the real owner with almost no signal.
+ *
+ * This module merges the fresh resolve with a last-known-good `raw → ou_` cache,
+ * but ONLY per-entry and ONLY when that entry both (a) transient-failed this
+ * pass and (b) is still present in the current raw config. That guards against
+ * two revival hazards a bare `ou_[]` fallback list would create:
+ *   - config swaps owner `on_old → on_new`, contact API blips → `ou_old` would
+ *     be resurrected from cache even though the operator removed it;
+ *   - an owner is definitively removed from the tenant (errored=false,
+ *     resolved=[]) → they would be revived indefinitely.
+ * The cache is keyed by raw entry, so an entry no longer in config, or one that
+ * resolved definitively-gone, is never reused.
  */
+
+import type { EntryResolveStatus } from '../im/lark/client.js';
 
 export interface AllowedUsersResolveResultLike {
   resolved: string[];
   map: Map<string, string>;
   /** True when contact API hit a transient failure (network / 5xx / rate limit). */
   errored?: boolean;
+  /**
+   * Per-raw-entry outcome. Entries absent from the map are treated as
+   * `definitive` (safest: never revived from cache).
+   */
+  entryStatus?: Map<string, EntryResolveStatus>;
 }
 
 export interface ApplyAllowedUsersResolveInput {
   /** Raw bots.json entries (ou_ / on_ / email). */
   rawEntries: string[];
   /**
-   * Last known-good open_ids (typically previous daemon descriptor or in-memory
-   * list already filtered to `ou_`). Used only as a fallback.
+   * Last known-good `raw entry → ou_` mapping (persisted sidecar from a prior
+   * healthy resolve). Used only as a per-entry fallback for still-configured,
+   * transient-failed entries. A plain `raw → ou_` object (JSON-friendly).
    */
-  previousResolvedOpenIds: string[];
+  previousResolvedMap: Record<string, string>;
   resolveResult: AllowedUsersResolveResultLike;
 }
 
 export interface ApplyAllowedUsersResolveOutput {
+  /** Runtime allowlist: `ou_` only, deduped, config order preserved. */
   resolved: string[];
+  /**
+   * `raw → ou_` map consistent with `resolved` (includes both freshly resolved
+   * and cache-recovered entries). Callers persist/assign this as the source of
+   * truth so `/revoke` reverse-lookup and the sidecar stay coherent.
+   */
   map: Map<string, string>;
-  /** True when runtime list came from previousResolvedOpenIds, not this resolve. */
+  /** True when any runtime entry came from the cache, not this resolve. */
   usedFallback: boolean;
   /**
-   * True when config has entries but we could not produce a fresh successful
-   * resolve (empty result and/or errored). Callers must surface a notice.
+   * True when config has entries but we could not produce a clean successful
+   * resolve (some entry transient-failed and/or the runtime list is degraded).
+   * Callers must surface a notice + schedule a retry.
    */
   failed: boolean;
   /** Human-readable notice for logs / owner DM; null when nothing to report. */
   notice: string | null;
 }
 
-function onlyOpenIds(ids: string[]): string[] {
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const id of ids) {
-    if (typeof id !== 'string' || !id.startsWith('ou_') || seen.has(id)) continue;
-    seen.add(id);
-    out.push(id);
-  }
-  return out;
-}
-
+/** Config entries that require a contact resolve (email / union / literal ou_). */
 function needsContactResolve(rawEntries: string[]): boolean {
   return rawEntries.some(u => u.includes('@') || u.startsWith('on_') || u.startsWith('ou_'));
 }
 
+function entryStatusOf(
+  status: Map<string, EntryResolveStatus> | undefined,
+  entry: string,
+): EntryResolveStatus {
+  // Absent → definitive: never revive an entry the resolver did not explicitly
+  // flag as transient. Safer to drop than to resurrect a stale grant.
+  return status?.get(entry) ?? 'definitive';
+}
+
 /**
- * Pure merge of resolve result + optional last-good open_id cache.
+ * Pure merge of a fresh resolve result + a last-known-good `raw → ou_` cache.
+ *
+ * Walk raw config in order. For each entry:
+ *   - fresh `ou_` from this resolve → use it (authoritative);
+ *   - else if this entry transient-failed AND has a cached `ou_` → reuse cache
+ *     (marks usedFallback + failed);
+ *   - else (definitive miss / no cache / non-resolvable literal) → drop it.
  * Never leaves bare `on_` / emails in the runtime list — those cannot match
- * message senders and would still lock the owner out.
+ * message senders and would still lock the owner out. Output `map` mirrors the
+ * chosen `resolved` set so downstream `/revoke` + sidecar stay consistent.
  */
 export function applyAllowedUsersResolve(
   input: ApplyAllowedUsersResolveInput,
 ): ApplyAllowedUsersResolveOutput {
   const rawEntries = input.rawEntries.filter(u => typeof u === 'string' && u.trim().length > 0);
-  const previous = onlyOpenIds(input.previousResolvedOpenIds);
-  const { resolved, map, errored } = input.resolveResult;
-  const fresh = onlyOpenIds(resolved);
+  const prevMap = input.previousResolvedMap ?? {};
+  const { map: freshMap, errored, entryStatus } = input.resolveResult;
 
   if (rawEntries.length === 0) {
-    return {
-      resolved: [],
-      map,
-      usedFallback: false,
-      failed: false,
-      notice: null,
-    };
+    return { resolved: [], map: new Map(), usedFallback: false, failed: false, notice: null };
   }
 
-  if (fresh.length > 0 && !errored) {
-    return {
-      resolved: fresh,
-      map,
-      usedFallback: false,
-      failed: false,
-      notice: null,
-    };
-  }
+  const outMap = new Map<string, string>();
+  const resolved: string[] = [];
+  const seen = new Set<string>();
+  let usedFallback = false;
+  let transientMissWithoutCache = false;
+  const recoveredEntries: string[] = [];
 
-  // Partial success with transient error: prefer fresh open_ids when present,
-  // but still surface a notice so operators know contact API is unhealthy.
-  if (fresh.length > 0 && errored) {
-    return {
-      resolved: fresh,
-      map,
-      usedFallback: false,
-      failed: true,
-      notice:
-        `allowedUsers contact resolve reported transient errors; using ${fresh.length} freshly resolved open_id(s). ` +
-        `Raw entries: ${rawEntries.join(', ')}`,
-    };
-  }
-
-  // Total miss: keep last-good open_ids so owner is not fail-closed into silence.
-  if (previous.length > 0) {
-    return {
-      resolved: previous,
-      map,
-      usedFallback: true,
-      failed: true,
-      notice:
-        `allowedUsers resolve failed (empty runtime list from contact API` +
-        `${errored ? ', transient error flagged' : ''}); ` +
-        `temporarily reusing ${previous.length} last-known open_id(s). ` +
-        `Raw entries: ${rawEntries.join(', ')}. ` +
-        `Owner talk may work via cache; restart/retry after Feishu contact recovers.`,
-    };
-  }
-
-  if (!needsContactResolve(rawEntries)) {
-    return {
-      resolved: [],
-      map,
-      usedFallback: false,
-      failed: false,
-      notice: null,
-    };
-  }
-
-  return {
-    resolved: [],
-    map,
-    usedFallback: false,
-    failed: true,
-    notice:
-      `allowedUsers resolve failed and no last-known open_id cache is available; ` +
-      `runtime allowlist is empty so everyone (including the real owner) is denied. ` +
-      `Raw entries: ${rawEntries.join(', ')}. Check Feishu contact API / bot scopes, then restart the bot.`,
+  const push = (rawEntry: string, oid: string) => {
+    if (!oid.startsWith('ou_')) return;
+    outMap.set(rawEntry, oid);
+    if (!seen.has(oid)) {
+      seen.add(oid);
+      resolved.push(oid);
+    }
   };
+
+  for (const entry of rawEntries) {
+    const fresh = freshMap.get(entry);
+    if (fresh && fresh.startsWith('ou_')) {
+      push(entry, fresh);
+      continue;
+    }
+    // No fresh ou_. Only reuse cache if this entry TRANSIENT-failed this pass —
+    // a definitive miss (removed / invalid / swapped out) must not be revived.
+    if (entryStatusOf(entryStatus, entry) === 'transient') {
+      const cached = prevMap[entry];
+      if (typeof cached === 'string' && cached.startsWith('ou_')) {
+        push(entry, cached);
+        usedFallback = true;
+        recoveredEntries.push(entry);
+      } else {
+        transientMissWithoutCache = true;
+      }
+    }
+    // definitive / resolved-without-ou_ / non-resolvable literal → drop entry.
+  }
+
+  // A resolve is "healthy" only when nothing transient-failed. Definitive
+  // drops (removed owners) are expected and do NOT mark failed — the config
+  // is simply reflecting reality; there is nothing to retry.
+  const anyTransient = rawEntries.some(e => entryStatusOf(entryStatus, e) === 'transient');
+  const failed = !!errored || anyTransient;
+
+  if (!failed) {
+    // Clean pass. resolved may still be empty here if config holds only
+    // definitively-gone / non-resolvable entries — that is a legitimate empty
+    // allowlist, not a fallback situation. Non-resolvable-only configs (no
+    // contact entries) also land here with no notice.
+    return { resolved, map: outMap, usedFallback: false, failed: false, notice: null };
+  }
+
+  // Degraded pass (something transient-failed). Build an operator-facing notice.
+  let notice: string;
+  if (resolved.length > 0 && usedFallback) {
+    notice =
+      `allowedUsers resolve degraded: contact API transiently failed for ` +
+      `${recoveredEntries.length} entr${recoveredEntries.length === 1 ? 'y' : 'ies'} ` +
+      `(${recoveredEntries.join(', ')}); reused last-known ou_ from cache so owner talk keeps working. ` +
+      `Retrying automatically; restart after Feishu contact recovers if needed.`;
+  } else if (resolved.length > 0) {
+    notice =
+      `allowedUsers resolve degraded: some entries transiently failed but ` +
+      `${resolved.length} open_id(s) resolved/recovered. Raw entries: ${rawEntries.join(', ')}. Retrying.`;
+  } else if (transientMissWithoutCache || needsContactResolve(rawEntries)) {
+    notice =
+      `allowedUsers resolve failed: contact API unavailable and no last-known ou_ cache for the ` +
+      `affected entr${recoveredEntries.length === 1 ? 'y' : 'ies'}; runtime allowlist is empty so ` +
+      `everyone (including the real owner) is denied. Raw entries: ${rawEntries.join(', ')}. ` +
+      `Check Feishu contact API / bot scopes; retrying automatically.`;
+  } else {
+    notice =
+      `allowedUsers resolve degraded; runtime allowlist is empty. Raw entries: ${rawEntries.join(', ')}.`;
+  }
+
+  return { resolved, map: outMap, usedFallback, failed: true, notice };
 }

--- a/src/utils/allowed-users-cache.ts
+++ b/src/utils/allowed-users-cache.ts
@@ -1,0 +1,105 @@
+/**
+ * Persistent last-known-good `raw entry → ou_` cache for allowedUsers.
+ *
+ * This is DELIBERATELY NOT the dashboard descriptor: that descriptor is
+ * (a) overwritten unconditionally early in daemon boot with the still-unresolved
+ * raw config (so its `resolvedAllowedUsers` is `[]` for an on_/email-only owner),
+ * and (b) deleted on every clean shutdown. Reading it as a fallback source is
+ * dead-on-arrival for the transient-failure-on-restart scenario this cache
+ * exists to survive. This sidecar lives in the persistent data dir, is written
+ * whenever a healthy/partial resolve or a hot config/grant mutation produces a
+ * fresh `raw → ou_` mapping, and is never deleted on shutdown.
+ *
+ * Keyed by raw config entry so recovery is per-entry: an entry removed from
+ * config (owner swap / revoke) or definitively gone is never revived. Both the
+ * daemon startup/retry path and the runtime set/revoke paths write through here
+ * so the cache never diverges from the live allowlist.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { atomicWriteFileSync } from './atomic-write.js';
+import { logger } from './logger.js';
+
+export function allowedUsersCachePath(dataDir: string, larkAppId: string): string {
+  return join(dataDir, `allowed-users-cache-${larkAppId}.json`);
+}
+
+/** Read the persisted `raw → ou_` cache (ou_ values only). `{}` on any error. */
+export function readAllowedUsersResolveCache(dataDir: string, larkAppId: string): Record<string, string> {
+  try {
+    const fp = allowedUsersCachePath(dataDir, larkAppId);
+    if (!existsSync(fp)) return {};
+    const raw = JSON.parse(readFileSync(fp, 'utf8')) as { map?: unknown };
+    const m = raw?.map;
+    if (!m || typeof m !== 'object' || Array.isArray(m)) return {};
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(m as Record<string, unknown>)) {
+      if (typeof k === 'string' && typeof v === 'string' && v.startsWith('ou_')) out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+export interface WriteAllowedUsersCacheOpts {
+  /**
+   * Fresh `raw → ou_` pairs to upsert (only ou_ values are kept). Callers pass
+   * the resolve/mutation result map.
+   */
+  map: Map<string, string> | Record<string, string>;
+  /**
+   * Entries to delete from the cache regardless of `map` — e.g. definitively-gone
+   * ids (removed from tenant) or a raw entry just revoked. Pruned so a later
+   * restart during an API blip can't mark them transient and revive a stale owner.
+   */
+  deleteEntries?: Iterable<string>;
+  /**
+   * When provided, the cache is pruned to ONLY these raw keys (plus whatever
+   * `map` upserts). Pass the current raw allowedUsers config so keys no longer
+   * configured (owner swap) never linger. Omit to merge without pruning.
+   */
+  retainKeys?: Iterable<string>;
+}
+
+/**
+ * Persist the `raw → ou_` cache. Merges `map` over the existing cache, deletes
+ * `deleteEntries`, and — when `retainKeys` is given — drops every key not in
+ * that set. Best-effort; never throws.
+ */
+export function writeAllowedUsersResolveCache(
+  dataDir: string,
+  larkAppId: string,
+  opts: WriteAllowedUsersCacheOpts,
+): void {
+  try {
+    let merged = readAllowedUsersResolveCache(dataDir, larkAppId);
+
+    if (opts.retainKeys) {
+      const keep = new Set<string>();
+      for (const k of opts.retainKeys) if (typeof k === 'string') keep.add(k);
+      const pruned: Record<string, string> = {};
+      for (const [k, v] of Object.entries(merged)) if (keep.has(k)) pruned[k] = v;
+      merged = pruned;
+    }
+
+    for (const e of opts.deleteEntries ?? []) {
+      if (typeof e === 'string') delete merged[e];
+    }
+
+    const entries: Iterable<[string, string]> = opts.map instanceof Map
+      ? opts.map.entries()
+      : Object.entries(opts.map);
+    for (const [k, v] of entries) {
+      if (typeof k === 'string' && typeof v === 'string' && v.startsWith('ou_')) merged[k] = v;
+    }
+
+    atomicWriteFileSync(
+      allowedUsersCachePath(dataDir, larkAppId),
+      JSON.stringify({ map: merged, updatedAt: Date.now() }),
+      { mode: 0o600 },
+    );
+  } catch (err: any) {
+    logger.debug(`[${larkAppId}] failed to persist allowedUsers cache: ${err?.message ?? err}`);
+  }
+}

--- a/test/allowed-users-apply.test.ts
+++ b/test/allowed-users-apply.test.ts
@@ -1,87 +1,182 @@
 import { describe, expect, it } from 'vitest';
 import { applyAllowedUsersResolve } from '../src/utils/allowed-users-apply.js';
+import type { EntryResolveStatus } from '../src/im/lark/client.js';
+
+/** Build a resolveResult from a raw→ou_ map + per-entry status. */
+function result(
+  freshPairs: Array<[string, string]>,
+  status: Array<[string, EntryResolveStatus]>,
+  errored = false,
+) {
+  return {
+    resolved: freshPairs.map(([, oid]) => oid),
+    map: new Map(freshPairs),
+    errored,
+    entryStatus: new Map(status),
+  };
+}
 
 describe('applyAllowedUsersResolve', () => {
-  it('uses a fresh successful resolve', () => {
-    const map = new Map([['on_owner', 'ou_owner']]);
+  it('uses a fresh successful resolve (no fallback, no notice)', () => {
     const out = applyAllowedUsersResolve({
       rawEntries: ['on_owner'],
-      previousResolvedOpenIds: ['ou_stale'],
-      resolveResult: { resolved: ['ou_owner'], map },
+      previousResolvedMap: { on_owner: 'ou_stale' },
+      resolveResult: result([['on_owner', 'ou_owner']], [['on_owner', 'resolved']]),
     });
 
     expect(out.resolved).toEqual(['ou_owner']);
+    expect(out.map.get('on_owner')).toBe('ou_owner');
     expect(out.usedFallback).toBe(false);
     expect(out.failed).toBe(false);
     expect(out.notice).toBeNull();
   });
 
-  it('falls back to last-known open_ids when resolve returns empty (transient lockout)', () => {
+  it('per-entry: recovers ONLY the transient-failed, still-configured entry from cache', () => {
+    // on_a resolved fresh; on_b transient-failed → recovered from cache.
+    const out = applyAllowedUsersResolve({
+      rawEntries: ['on_a', 'on_b'],
+      previousResolvedMap: { on_a: 'ou_a_stale', on_b: 'ou_b_cached' },
+      resolveResult: result(
+        [['on_a', 'ou_a']],
+        [['on_a', 'resolved'], ['on_b', 'transient']],
+        true,
+      ),
+    });
+
+    // Fresh ou_a (authoritative, not the stale cache) + cached ou_b.
+    expect(out.resolved).toEqual(['ou_a', 'ou_b_cached']);
+    expect(out.map.get('on_a')).toBe('ou_a');
+    expect(out.map.get('on_b')).toBe('ou_b_cached');
+    expect(out.usedFallback).toBe(true);
+    expect(out.failed).toBe(true);
+    expect(out.notice).toContain('on_b');
+  });
+
+  it('total transient failure with cache: keeps every configured entry from cache (owner not locked out)', () => {
     const out = applyAllowedUsersResolve({
       rawEntries: ['on_928c2db360e48084f1ff72ebe161b1d6'],
-      previousResolvedOpenIds: ['ou_8a744395b1a13034de3e5e8ba6ba9715'],
-      resolveResult: { resolved: [], map: new Map(), errored: true },
+      previousResolvedMap: { on_928c2db360e48084f1ff72ebe161b1d6: 'ou_8a744395b1a13034de3e5e8ba6ba9715' },
+      resolveResult: result([], [['on_928c2db360e48084f1ff72ebe161b1d6', 'transient']], true),
     });
 
     expect(out.resolved).toEqual(['ou_8a744395b1a13034de3e5e8ba6ba9715']);
     expect(out.usedFallback).toBe(true);
     expect(out.failed).toBe(true);
-    expect(out.notice).toContain('reusing');
-    expect(out.notice).toContain('on_928c2db360e48084f1ff72ebe161b1d6');
+    // map/resolved consistency: /revoke reverse-lookup must still work.
+    expect(out.map.get('on_928c2db360e48084f1ff72ebe161b1d6')).toBe('ou_8a744395b1a13034de3e5e8ba6ba9715');
   });
 
-  it('reports hard failure with empty list when there is no cache', () => {
+  it('MUST NOT revive a definitively-removed owner even if cache still has them', () => {
+    // errored=false + entry marked definitive (removed from tenant / not visible).
     const out = applyAllowedUsersResolve({
-      rawEntries: ['on_owner'],
-      previousResolvedOpenIds: ['on_not_an_open_id', ''],
-      resolveResult: { resolved: [], map: new Map(), errored: true },
+      rawEntries: ['on_fired_owner'],
+      previousResolvedMap: { on_fired_owner: 'ou_fired' },
+      resolveResult: result([], [['on_fired_owner', 'definitive']], false),
     });
 
     expect(out.resolved).toEqual([]);
     expect(out.usedFallback).toBe(false);
-    expect(out.failed).toBe(true);
-    expect(out.notice).toContain('runtime allowlist is empty');
-  });
-
-  it('keeps empty config as a non-failure open path', () => {
-    const out = applyAllowedUsersResolve({
-      rawEntries: [],
-      previousResolvedOpenIds: ['ou_stale'],
-      resolveResult: { resolved: [], map: new Map() },
-    });
-
-    expect(out.resolved).toEqual([]);
+    // Definitive removal is not a failure — reflects reality, nothing to retry.
     expect(out.failed).toBe(false);
     expect(out.notice).toBeNull();
   });
 
-  it('never leaves bare on_ entries in the runtime list after a failed resolve', () => {
+  it('MUST NOT revive an owner that was swapped out of config (on_old → on_new)', () => {
+    // Config now only has on_new; on_new transient-fails; cache still holds on_old.
+    // on_old is NOT in rawEntries, so it can never be recovered.
+    const out = applyAllowedUsersResolve({
+      rawEntries: ['on_new'],
+      previousResolvedMap: { on_old: 'ou_old', on_new: 'ou_new_cached' },
+      resolveResult: result([], [['on_new', 'transient']], true),
+    });
+
+    expect(out.resolved).toEqual(['ou_new_cached']);
+    expect(out.resolved).not.toContain('ou_old');
+    expect(out.map.has('on_old')).toBe(false);
+  });
+
+  it('transient failure with NO cache: empty list + hard-failure notice', () => {
     const out = applyAllowedUsersResolve({
       rawEntries: ['on_owner'],
-      // Memory still holds the pre-resolve raw list — must not be reused as-is.
-      previousResolvedOpenIds: ['on_owner'],
-      resolveResult: { resolved: [], map: new Map(), errored: true },
+      previousResolvedMap: {},
+      resolveResult: result([], [['on_owner', 'transient']], true),
     });
 
     expect(out.resolved).toEqual([]);
-    expect(out.resolved.every(id => id.startsWith('ou_'))).toBe(true);
-    expect(out.failed).toBe(true);
-  });
-
-  it('surfaces notice when fresh resolve partially succeeds with errored=true', () => {
-    const out = applyAllowedUsersResolve({
-      rawEntries: ['on_a', 'on_b'],
-      previousResolvedOpenIds: [],
-      resolveResult: {
-        resolved: ['ou_a'],
-        map: new Map([['on_a', 'ou_a']]),
-        errored: true,
-      },
-    });
-
-    expect(out.resolved).toEqual(['ou_a']);
     expect(out.usedFallback).toBe(false);
     expect(out.failed).toBe(true);
-    expect(out.notice).toContain('transient errors');
+    expect(out.notice).toContain('no last-known ou_ cache');
+  });
+
+  it('empty config is a non-failure open path', () => {
+    const out = applyAllowedUsersResolve({
+      rawEntries: [],
+      previousResolvedMap: { on_x: 'ou_stale' },
+      resolveResult: result([], []),
+    });
+
+    expect(out.resolved).toEqual([]);
+    expect(out.map.size).toBe(0);
+    expect(out.failed).toBe(false);
+    expect(out.notice).toBeNull();
+  });
+
+  it('never leaves bare on_ / email in the runtime list', () => {
+    const out = applyAllowedUsersResolve({
+      rawEntries: ['on_owner'],
+      // Even if a malformed cache somehow held a non-ou_ value, it is filtered.
+      previousResolvedMap: { on_owner: 'on_not_an_open_id' },
+      resolveResult: result([], [['on_owner', 'transient']], true),
+    });
+
+    expect(out.resolved.every(id => id.startsWith('ou_'))).toBe(true);
+    expect(out.resolved).toEqual([]);
+  });
+
+  it('literal ou_ resolved fresh is kept; output map is self-consistent', () => {
+    const out = applyAllowedUsersResolve({
+      rawEntries: ['ou_literal', 'on_owner'],
+      previousResolvedMap: {},
+      resolveResult: result(
+        [['ou_literal', 'ou_literal'], ['on_owner', 'ou_owner']],
+        [['ou_literal', 'resolved'], ['on_owner', 'resolved']],
+      ),
+    });
+
+    expect(out.resolved).toEqual(['ou_literal', 'ou_owner']);
+    expect(out.usedFallback).toBe(false);
+    expect(out.failed).toBe(false);
+  });
+
+  it('dedupes when the same person is configured twice (union + email) and preserves order', () => {
+    const out = applyAllowedUsersResolve({
+      rawEntries: ['on_owner', 'owner@corp.com'],
+      previousResolvedMap: {},
+      resolveResult: result(
+        [['on_owner', 'ou_owner'], ['owner@corp.com', 'ou_owner']],
+        [['on_owner', 'resolved'], ['owner@corp.com', 'resolved']],
+      ),
+    });
+
+    expect(out.resolved).toEqual(['ou_owner']);
+    // Both raw keys still map to the ou_ for /revoke reverse-lookup.
+    expect(out.map.get('on_owner')).toBe('ou_owner');
+    expect(out.map.get('owner@corp.com')).toBe('ou_owner');
+  });
+
+  it('definitive miss for one entry + fresh for another: drops removed, keeps live, not failed', () => {
+    const out = applyAllowedUsersResolve({
+      rawEntries: ['on_gone', 'on_live'],
+      previousResolvedMap: { on_gone: 'ou_gone_cached' },
+      resolveResult: result(
+        [['on_live', 'ou_live']],
+        [['on_gone', 'definitive'], ['on_live', 'resolved']],
+      ),
+    });
+
+    expect(out.resolved).toEqual(['ou_live']);
+    expect(out.resolved).not.toContain('ou_gone_cached');
+    expect(out.usedFallback).toBe(false);
+    expect(out.failed).toBe(false);
   });
 });

--- a/test/allowed-users-apply.test.ts
+++ b/test/allowed-users-apply.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { applyAllowedUsersResolve } from '../src/utils/allowed-users-apply.js';
+
+describe('applyAllowedUsersResolve', () => {
+  it('uses a fresh successful resolve', () => {
+    const map = new Map([['on_owner', 'ou_owner']]);
+    const out = applyAllowedUsersResolve({
+      rawEntries: ['on_owner'],
+      previousResolvedOpenIds: ['ou_stale'],
+      resolveResult: { resolved: ['ou_owner'], map },
+    });
+
+    expect(out.resolved).toEqual(['ou_owner']);
+    expect(out.usedFallback).toBe(false);
+    expect(out.failed).toBe(false);
+    expect(out.notice).toBeNull();
+  });
+
+  it('falls back to last-known open_ids when resolve returns empty (transient lockout)', () => {
+    const out = applyAllowedUsersResolve({
+      rawEntries: ['on_928c2db360e48084f1ff72ebe161b1d6'],
+      previousResolvedOpenIds: ['ou_8a744395b1a13034de3e5e8ba6ba9715'],
+      resolveResult: { resolved: [], map: new Map(), errored: true },
+    });
+
+    expect(out.resolved).toEqual(['ou_8a744395b1a13034de3e5e8ba6ba9715']);
+    expect(out.usedFallback).toBe(true);
+    expect(out.failed).toBe(true);
+    expect(out.notice).toContain('reusing');
+    expect(out.notice).toContain('on_928c2db360e48084f1ff72ebe161b1d6');
+  });
+
+  it('reports hard failure with empty list when there is no cache', () => {
+    const out = applyAllowedUsersResolve({
+      rawEntries: ['on_owner'],
+      previousResolvedOpenIds: ['on_not_an_open_id', ''],
+      resolveResult: { resolved: [], map: new Map(), errored: true },
+    });
+
+    expect(out.resolved).toEqual([]);
+    expect(out.usedFallback).toBe(false);
+    expect(out.failed).toBe(true);
+    expect(out.notice).toContain('runtime allowlist is empty');
+  });
+
+  it('keeps empty config as a non-failure open path', () => {
+    const out = applyAllowedUsersResolve({
+      rawEntries: [],
+      previousResolvedOpenIds: ['ou_stale'],
+      resolveResult: { resolved: [], map: new Map() },
+    });
+
+    expect(out.resolved).toEqual([]);
+    expect(out.failed).toBe(false);
+    expect(out.notice).toBeNull();
+  });
+
+  it('never leaves bare on_ entries in the runtime list after a failed resolve', () => {
+    const out = applyAllowedUsersResolve({
+      rawEntries: ['on_owner'],
+      // Memory still holds the pre-resolve raw list — must not be reused as-is.
+      previousResolvedOpenIds: ['on_owner'],
+      resolveResult: { resolved: [], map: new Map(), errored: true },
+    });
+
+    expect(out.resolved).toEqual([]);
+    expect(out.resolved.every(id => id.startsWith('ou_'))).toBe(true);
+    expect(out.failed).toBe(true);
+  });
+
+  it('surfaces notice when fresh resolve partially succeeds with errored=true', () => {
+    const out = applyAllowedUsersResolve({
+      rawEntries: ['on_a', 'on_b'],
+      previousResolvedOpenIds: [],
+      resolveResult: {
+        resolved: ['ou_a'],
+        map: new Map([['on_a', 'ou_a']]),
+        errored: true,
+      },
+    });
+
+    expect(out.resolved).toEqual(['ou_a']);
+    expect(out.usedFallback).toBe(false);
+    expect(out.failed).toBe(true);
+    expect(out.notice).toContain('transient errors');
+  });
+});

--- a/test/allowed-users-cache.test.ts
+++ b/test/allowed-users-cache.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  allowedUsersCachePath,
+  readAllowedUsersResolveCache,
+  writeAllowedUsersResolveCache,
+} from '../src/utils/allowed-users-cache.js';
+
+const APP = 'app-cache-test';
+let dir: string;
+
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'auc-')); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+describe('allowed-users-cache sidecar', () => {
+  it('returns {} when the file does not exist', () => {
+    expect(readAllowedUsersResolveCache(dir, APP)).toEqual({});
+    expect(existsSync(allowedUsersCachePath(dir, APP))).toBe(false);
+  });
+
+  it('round-trips a raw→ou_ map (only ou_ values kept)', () => {
+    writeAllowedUsersResolveCache(dir, APP, {
+      map: new Map([['on_owner', 'ou_owner'], ['bad', 'on_not_ou'], ['email@x', 'ou_x']]),
+    });
+    expect(readAllowedUsersResolveCache(dir, APP)).toEqual({ on_owner: 'ou_owner', 'email@x': 'ou_x' });
+  });
+
+  it('merges over existing cache by default (no pruning)', () => {
+    writeAllowedUsersResolveCache(dir, APP, { map: { on_a: 'ou_a' } });
+    writeAllowedUsersResolveCache(dir, APP, { map: { on_b: 'ou_b' } });
+    expect(readAllowedUsersResolveCache(dir, APP)).toEqual({ on_a: 'ou_a', on_b: 'ou_b' });
+  });
+
+  it('deleteEntries removes keys even if not in map (definitive prune / revoke)', () => {
+    writeAllowedUsersResolveCache(dir, APP, { map: { on_a: 'ou_a', on_gone: 'ou_gone' } });
+    writeAllowedUsersResolveCache(dir, APP, { map: {}, deleteEntries: ['on_gone'] });
+    expect(readAllowedUsersResolveCache(dir, APP)).toEqual({ on_a: 'ou_a' });
+  });
+
+  it('retainKeys prunes every key not in the current config (owner swap)', () => {
+    writeAllowedUsersResolveCache(dir, APP, { map: { on_old: 'ou_old', on_keep: 'ou_keep' } });
+    // Config now only has on_keep + a freshly resolved on_new.
+    writeAllowedUsersResolveCache(dir, APP, {
+      map: { on_new: 'ou_new' },
+      retainKeys: ['on_keep', 'on_new'],
+    });
+    expect(readAllowedUsersResolveCache(dir, APP)).toEqual({ on_keep: 'ou_keep', on_new: 'ou_new' });
+    // on_old (no longer configured) is gone → cannot be revived on a later blip.
+  });
+
+  it('retainKeys + upsert: new map entries survive even if not in retain set', () => {
+    // map upserts are applied AFTER retain pruning, so a freshly resolved key
+    // that the caller forgot to list in retainKeys is still written.
+    writeAllowedUsersResolveCache(dir, APP, { map: { on_a: 'ou_a' } });
+    writeAllowedUsersResolveCache(dir, APP, { map: { on_b: 'ou_b' }, retainKeys: [] });
+    expect(readAllowedUsersResolveCache(dir, APP)).toEqual({ on_b: 'ou_b' });
+  });
+
+  it('tolerates a corrupt cache file (returns {})', () => {
+    // Write then corrupt by writing a non-JSON payload via a malformed map.
+    writeAllowedUsersResolveCache(dir, APP, { map: { on_a: 'ou_a' } });
+    // A second write with a Record works; simulate corruption by reading a
+    // path that holds invalid JSON is covered by the try/catch → {}.
+    expect(readAllowedUsersResolveCache(dir, APP)).toEqual({ on_a: 'ou_a' });
+  });
+});

--- a/test/allowed-users-cache.test.ts
+++ b/test/allowed-users-cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -59,10 +59,14 @@ describe('allowed-users-cache sidecar', () => {
   });
 
   it('tolerates a corrupt cache file (returns {})', () => {
-    // Write then corrupt by writing a non-JSON payload via a malformed map.
-    writeAllowedUsersResolveCache(dir, APP, { map: { on_a: 'ou_a' } });
-    // A second write with a Record works; simulate corruption by reading a
-    // path that holds invalid JSON is covered by the try/catch → {}.
-    expect(readAllowedUsersResolveCache(dir, APP)).toEqual({ on_a: 'ou_a' });
+    // Actually write malformed JSON to the cache path and confirm the reader
+    // swallows it rather than throwing.
+    writeFileSync(allowedUsersCachePath(dir, APP), '{ this is : not json', 'utf8');
+    expect(readAllowedUsersResolveCache(dir, APP)).toEqual({});
+  });
+
+  it('tolerates a valid-JSON file whose map field is the wrong shape (returns {})', () => {
+    writeFileSync(allowedUsersCachePath(dir, APP), JSON.stringify({ map: ['not', 'an', 'object'] }), 'utf8');
+    expect(readAllowedUsersResolveCache(dir, APP)).toEqual({});
   });
 });

--- a/test/bot-config-store.test.ts
+++ b/test/bot-config-store.test.ts
@@ -25,14 +25,16 @@ vi.mock('../src/im/lark/client.js', () => ({
   resolveAllowedUsersWithMap: async (_appId: string, raw: string[]) => {
     const map = new Map<string, string>();
     const resolved: string[] = [];
+    const entryStatus = new Map<string, 'resolved' | 'transient' | 'definitive'>();
     for (const v of raw) {
       let id: string | undefined;
       if (v.startsWith('ou_')) id = v;
       else if (v.startsWith('on_')) id = 'ou_' + v.slice(3);
       else if (v.includes('@')) id = 'ou_' + v.split('@')[0];
-      if (id) { resolved.push(id); map.set(v, id); }
+      if (id) { resolved.push(id); map.set(v, id); entryStatus.set(v, 'resolved'); }
+      else entryStatus.set(v, 'definitive');
     }
-    return { resolved, map };
+    return { resolved, map, entryStatus };
   },
 }));
 
@@ -50,8 +52,11 @@ describe('bot-config store', () => {
     const dir = mkdtempSync(join(tmpdir(), 'botmux-cfgstore-'));
     configPath = join(dir, 'bots.json');
     process.env.BOTS_CONFIG = configPath;
+    // Isolate the allowedUsers sidecar (setBotAllowedUsers writes it) into the
+    // same tmp dir so tests don't pollute the real ~/.botmux/data.
+    process.env.SESSION_DATA_DIR = dir;
   });
-  afterEach(() => { delete process.env.BOTS_CONFIG; });
+  afterEach(() => { delete process.env.BOTS_CONFIG; delete process.env.SESSION_DATA_DIR; });
 
   function writeConfig(entry: Record<string, unknown> = {}) {
     writeFileSync(configPath, JSON.stringify([{

--- a/test/grant-command.test.ts
+++ b/test/grant-command.test.ts
@@ -450,6 +450,7 @@ describe('tryHandleGrantCommand two bots co-addressed (@Claude @Codex /grant)', 
     const dir = mkdtempSync(join(tmpdir(), 'botmux-grant-co-'));
     configPath = join(dir, 'bots.json');
     process.env.BOTS_CONFIG = configPath;
+    process.env.SESSION_DATA_DIR = dir; // isolate allowedUsers sidecar (revokeGrant writes it)
     writeFileSync(configPath, JSON.stringify([
       { larkAppId: 'bco', larkAppSecret: 's', cliId: 'claude-code', allowedUsers: ['ou_owner'] },
     ], null, 2), 'utf-8');
@@ -458,7 +459,7 @@ describe('tryHandleGrantCommand two bots co-addressed (@Claude @Codex /grant)', 
     bot.botOpenId = 'ou_bot';
     bot.resolvedAllowedUsers = ['ou_owner'];
   });
-  afterEach(() => { delete process.env.BOTS_CONFIG; vi.restoreAllMocks(); });
+  afterEach(() => { delete process.env.BOTS_CONFIG; delete process.env.SESSION_DATA_DIR; vi.restoreAllMocks(); });
 
   it('owner: does NOT grant the other bot — no per-target card, no chatGrants entry', async () => {
     const handled = await tryHandleGrantCommand('bco', coAddressedMsg(), 'ou_owner');
@@ -482,6 +483,7 @@ describe('tryHandleGrantCommand whole-chat grant (@bot /grant, no target)', () =
     const dir = mkdtempSync(join(tmpdir(), 'botmux-grant-cmd-'));
     configPath = join(dir, 'bots.json');
     process.env.BOTS_CONFIG = configPath;
+    process.env.SESSION_DATA_DIR = dir; // isolate allowedUsers sidecar (revokeGrant writes it)
     writeFileSync(configPath, JSON.stringify([
       { larkAppId: 'b2', larkAppSecret: 's', cliId: 'claude-code', allowedUsers: ['ou_owner'] },
     ], null, 2), 'utf-8');
@@ -490,7 +492,7 @@ describe('tryHandleGrantCommand whole-chat grant (@bot /grant, no target)', () =
     bot.botOpenId = 'ou_bot';
     bot.resolvedAllowedUsers = ['ou_owner'];
   });
-  afterEach(() => { delete process.env.BOTS_CONFIG; vi.restoreAllMocks(); });
+  afterEach(() => { delete process.env.BOTS_CONFIG; delete process.env.SESSION_DATA_DIR; vi.restoreAllMocks(); });
 
   // only the bot is @mentioned, no human target → whole-chat grant
   const bareMsg = (text: string, chatId = 'oc_room') => ({

--- a/test/grant-store.test.ts
+++ b/test/grant-store.test.ts
@@ -31,8 +31,9 @@ beforeEach(() => {
   const dir = mkdtempSync(join(tmpdir(), 'botmux-grant-store-'));
   configPath = join(dir, 'bots.json');
   process.env.BOTS_CONFIG = configPath;
+  process.env.SESSION_DATA_DIR = dir; // isolate allowedUsers sidecar (revokeGrant writes it)
 });
-afterEach(() => { delete process.env.BOTS_CONFIG; vi.restoreAllMocks(); });
+afterEach(() => { delete process.env.BOTS_CONFIG; delete process.env.SESSION_DATA_DIR; vi.restoreAllMocks(); });
 
 describe('grant-store', () => {
   it('addChatGrant persists & syncs in-memory; only affects given chat', async () => {

--- a/test/resolve-allowed-users-union.test.ts
+++ b/test/resolve-allowed-users-union.test.ts
@@ -87,3 +87,77 @@ describe('resolveAllowedUsersWithMap — on_ union_id entries (PR#72 lockout fix
     warn.mockRestore();
   });
 });
+
+// PR #590 fix: per-entry resolve status drives the last-known-good cache
+// fallback. Only 'transient' entries may be recovered from cache; 'definitive'
+// misses (removed / not-visible / invalid) must NOT be, or a stale owner gets
+// revived. errored must stay in lockstep with 'transient'.
+describe('resolveAllowedUsersWithMap — entryStatus classification (PR#590)', () => {
+  it('union_id resolved → resolved; errored stays false', async () => {
+    stubClient(async ({ path }: any) =>
+      ({ code: 0, data: { user: { open_id: 'ou_ok', union_id: path.user_id, name: 'X' } } }));
+    const { entryStatus, errored } = await resolveAllowedUsersWithMap(APP, ['on_ok']);
+    expect(entryStatus.get('on_ok')).toBe('resolved');
+    expect(errored).toBeFalsy();
+  });
+
+  it('union_id code-0 with NO open_id → definitive (NOT transient); does not flag errored', async () => {
+    // Union user outside this app's contact visibility → tenant returns a code-0
+    // empty shell rather than 41050. Must be definitive so the never-converging
+    // retry chain is not armed and a stale cached ou_ is not revived.
+    stubClient(async ({ path }: any) => ({ code: 0, data: { user: { union_id: path.user_id } } }));
+    const { entryStatus, errored, resolved } = await resolveAllowedUsersWithMap(APP, ['on_ghost']);
+    expect(entryStatus.get('on_ghost')).toBe('definitive');
+    expect(errored).toBeFalsy();
+    expect(resolved).toEqual([]);
+  });
+
+  it('union_id definitive contact code (41050 not_visible) → definitive; not errored', async () => {
+    stubClient(async () => ({ code: 41050, msg: 'not visible' }));
+    const { entryStatus, errored } = await resolveAllowedUsersWithMap(APP, ['on_hidden']);
+    expect(entryStatus.get('on_hidden')).toBe('definitive');
+    expect(errored).toBeFalsy();
+  });
+
+  it('union_id transient failure (throw) → transient + errored', async () => {
+    stubClient(async () => { throw new Error('ECONNRESET'); });
+    const { entryStatus, errored } = await resolveAllowedUsersWithMap(APP, ['on_flaky']);
+    expect(entryStatus.get('on_flaky')).toBe('transient');
+    expect(errored).toBe(true);
+  });
+
+  it('union_id non-definitive non-zero code (server error) → transient + errored', async () => {
+    stubClient(async () => ({ code: 500, msg: 'internal' }));
+    const { entryStatus, errored } = await resolveAllowedUsersWithMap(APP, ['on_5xx']);
+    expect(entryStatus.get('on_5xx')).toBe('transient');
+    expect(errored).toBe(true);
+  });
+
+  it('literal ou_ is always resolved (never dropped/transient)', async () => {
+    stubClient(async () => ({ code: 0, data: { user: {} } }));
+    const { entryStatus } = await resolveAllowedUsersWithMap(APP, ['ou_literal']);
+    expect(entryStatus.get('ou_literal')).toBe('resolved');
+  });
+
+  it('email not returned by a code-0 batch → definitive (not transient)', async () => {
+    stubClient(
+      async () => ({ code: 0, data: { user: {} } }),
+      async () => ({ code: 0, data: { user_list: [] } }), // batch OK but empty
+    );
+    const { entryStatus, errored } = await resolveAllowedUsersWithMap(APP, ['ghost@corp.com']);
+    expect(entryStatus.get('ghost@corp.com')).toBe('definitive');
+    expect(errored).toBeFalsy();
+  });
+
+  it('email batch call fails (code!=0) → transient + errored for every requested email', async () => {
+    stubClient(
+      async () => ({ code: 0, data: { user: {} } }),
+      async () => ({ code: 500, msg: 'batch down' }),
+    );
+    const { entryStatus, errored } = await resolveAllowedUsersWithMap(APP, ['a@corp.com', 'b@corp.com']);
+    expect(entryStatus.get('a@corp.com')).toBe('transient');
+    expect(entryStatus.get('b@corp.com')).toBe('transient');
+    expect(errored).toBe(true);
+  });
+});
+

--- a/test/resolve-allowed-users-union.test.ts
+++ b/test/resolve-allowed-users-union.test.ts
@@ -159,5 +159,36 @@ describe('resolveAllowedUsersWithMap — entryStatus classification (PR#590)', (
     expect(entryStatus.get('b@corp.com')).toBe('transient');
     expect(errored).toBe(true);
   });
-});
 
+  it('email batch permanent 4xx (40001 invalid arg) → definitive, NOT transient; does not flag errored', async () => {
+    // codex delta finding: a permanent 4xx must not spin retries or revive a
+    // cached owner. classifyContactErrorCode(40001)==='invalid_id' → definitive.
+    stubClient(
+      async () => ({ code: 0, data: { user: {} } }),
+      async () => ({ code: 40001, msg: 'invalid argument' }),
+    );
+    const { entryStatus, errored } = await resolveAllowedUsersWithMap(APP, ['bad@corp.com']);
+    expect(entryStatus.get('bad@corp.com')).toBe('definitive');
+    expect(errored).toBeFalsy();
+  });
+
+  it('email batch throw with definitive code → definitive; plain network throw → transient', async () => {
+    // Definitive: thrown SDK error carrying code 41050.
+    stubClient(
+      async () => ({ code: 0, data: { user: {} } }),
+      async () => { const e: any = new Error('not visible'); e.response = { data: { code: 41050 } }; throw e; },
+    );
+    const def = await resolveAllowedUsersWithMap(APP, ['hidden@corp.com']);
+    expect(def.entryStatus.get('hidden@corp.com')).toBe('definitive');
+    expect(def.errored).toBeFalsy();
+
+    // Transient: plain network throw, no contact code.
+    stubClient(
+      async () => ({ code: 0, data: { user: {} } }),
+      async () => { throw new Error('ECONNRESET'); },
+    );
+    const tr = await resolveAllowedUsersWithMap(APP, ['flaky@corp.com']);
+    expect(tr.entryStatus.get('flaky@corp.com')).toBe('transient');
+    expect(tr.errored).toBe(true);
+  });
+});

--- a/test/resolve-allowed-users-union.test.ts
+++ b/test/resolve-allowed-users-union.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { resolveAllowedUsersWithMap } from '../src/im/lark/client.js';
+import { applyAllowedUsersResolve } from '../src/utils/allowed-users-apply.js';
 import { registerBot } from '../src/bot-registry.js';
 import { logger } from '../src/utils/logger.js';
 
@@ -160,35 +161,86 @@ describe('resolveAllowedUsersWithMap — entryStatus classification (PR#590)', (
     expect(errored).toBe(true);
   });
 
-  it('email batch permanent 4xx (40001 invalid arg) → definitive, NOT transient; does not flag errored', async () => {
-    // codex delta finding: a permanent 4xx must not spin retries or revive a
-    // cached owner. classifyContactErrorCode(40001)==='invalid_id' → definitive.
+  it('email batch permanent 4xx (40001) is a WHOLE-REQUEST error → transient, NOT per-email definitive', async () => {
+    // codex 2nd delta: 40001 is an invalid-argument error for the whole batch
+    // request, not a per-email identity verdict. Marking each email definitive
+    // would silently prune an email-only owner's LKG cache and lock them out.
+    // Must be transient so fallback + retry + DM all fire.
     stubClient(
       async () => ({ code: 0, data: { user: {} } }),
       async () => ({ code: 40001, msg: 'invalid argument' }),
     );
-    const { entryStatus, errored } = await resolveAllowedUsersWithMap(APP, ['bad@corp.com']);
-    expect(entryStatus.get('bad@corp.com')).toBe('definitive');
-    expect(errored).toBeFalsy();
+    const { entryStatus, errored, resolved } = await resolveAllowedUsersWithMap(APP, ['owner@corp.com']);
+    expect(entryStatus.get('owner@corp.com')).toBe('transient');
+    expect(errored).toBe(true);
+    expect(resolved).toEqual([]); // no cache in this stub → empty, but retry-eligible
   });
 
-  it('email batch throw with definitive code → definitive; plain network throw → transient', async () => {
-    // Definitive: thrown SDK error carrying code 41050.
+  it('email batch throw (any error, incl thrown 4xx) → transient for every requested email', async () => {
+    // A throw is a whole-request failure — same reasoning as a non-zero code.
     stubClient(
       async () => ({ code: 0, data: { user: {} } }),
       async () => { const e: any = new Error('not visible'); e.response = { data: { code: 41050 } }; throw e; },
     );
-    const def = await resolveAllowedUsersWithMap(APP, ['hidden@corp.com']);
-    expect(def.entryStatus.get('hidden@corp.com')).toBe('definitive');
-    expect(def.errored).toBeFalsy();
+    const thrown4xx = await resolveAllowedUsersWithMap(APP, ['hidden@corp.com']);
+    expect(thrown4xx.entryStatus.get('hidden@corp.com')).toBe('transient');
+    expect(thrown4xx.errored).toBe(true);
 
-    // Transient: plain network throw, no contact code.
     stubClient(
       async () => ({ code: 0, data: { user: {} } }),
       async () => { throw new Error('ECONNRESET'); },
     );
-    const tr = await resolveAllowedUsersWithMap(APP, ['flaky@corp.com']);
-    expect(tr.entryStatus.get('flaky@corp.com')).toBe('transient');
-    expect(tr.errored).toBe(true);
+    const network = await resolveAllowedUsersWithMap(APP, ['flaky@corp.com']);
+    expect(network.entryStatus.get('flaky@corp.com')).toBe('transient');
+    expect(network.errored).toBe(true);
+  });
+});
+
+// End-to-end: resolver → applyAllowedUsersResolve → cache decision, for the exact
+// scenario codex flagged — an email-only owner + a batch-wide error (incl 40001)
+// must NOT be locked out. The whole-request error is transient, so the pure fn
+// recovers the owner from the last-known-good cache and never prunes it.
+describe('resolve → apply end-to-end: email-only owner + batch error keeps owner (PR#590)', () => {
+  it('batch 40001 with a cached owner → owner recovered from cache, marked failed (retry), not pruned', async () => {
+    stubClient(
+      async () => ({ code: 0, data: { user: {} } }),
+      async () => ({ code: 40001, msg: 'invalid argument' }),
+    );
+    const resolveResult = await resolveAllowedUsersWithMap(APP, ['owner@corp.com']);
+    // resolver: whole-request failure → transient, errored, nothing resolved.
+    expect(resolveResult.entryStatus.get('owner@corp.com')).toBe('transient');
+    expect(resolveResult.errored).toBe(true);
+    expect(resolveResult.resolved).toEqual([]);
+
+    const applied = applyAllowedUsersResolve({
+      rawEntries: ['owner@corp.com'],
+      previousResolvedMap: { 'owner@corp.com': 'ou_owner' }, // last-known-good
+      resolveResult,
+    });
+    // owner kept alive from cache; flagged failed so a retry is armed; the cache
+    // key is NOT in the definitive set, so a caller pruning definitives keeps it.
+    expect(applied.resolved).toEqual(['ou_owner']);
+    expect(applied.usedFallback).toBe(true);
+    expect(applied.failed).toBe(true);
+    expect(applied.map.get('owner@corp.com')).toBe('ou_owner');
+    const definitives = [...resolveResult.entryStatus.entries()]
+      .filter(([, s]) => s === 'definitive').map(([e]) => e);
+    expect(definitives).toEqual([]); // nothing to prune → cached owner survives
+  });
+
+  it('batch 40001 with NO cache → empty runtime but failed=true so fallback/DM/retry still fire', async () => {
+    stubClient(
+      async () => ({ code: 0, data: { user: {} } }),
+      async () => ({ code: 40001, msg: 'invalid argument' }),
+    );
+    const resolveResult = await resolveAllowedUsersWithMap(APP, ['owner@corp.com']);
+    const applied = applyAllowedUsersResolve({
+      rawEntries: ['owner@corp.com'],
+      previousResolvedMap: {},
+      resolveResult,
+    });
+    expect(applied.resolved).toEqual([]);
+    expect(applied.failed).toBe(true); // NOT a silent success — owner-lockout is surfaced + retried
+    expect(applied.notice).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- On daemon startup, if resolving `allowedUsers` (`on_` / email → `ou_`) fails or returns empty, **do not** wipe the runtime allowlist.
- Reuse last-known `ou_` open_ids from the previous daemon descriptor when available (keeps owner talkable).
- Surface a visible failure signal: `logger.error` + best-effort DM to owner open_ids, plus scheduled resolve retries (30s / 2m / 5m).

## PR Doc
https://bytedance.larkoffice.com/docx/YrwydSBOloCARTxQ1E6cGQxEnvb

## Why
A Feishu contact `ECONNRESET` during Seed 0717 restart left `Resolved allowedUsers:` empty. Config still had the owner `on_…`, but fail-closed runtime matching denied everyone — including the owner — so real `@` mentions were silently dropped.

## Test plan
- [x] `vitest run --project unit test/allowed-users-apply.test.ts test/resolve-allowed-users-union.test.ts` (10 passed)
- [ ] Restart a bot with `allowedUsers: [on_…]` while contact API is healthy → fresh resolve, no DM
- [ ] Simulate empty resolve with a prior descriptor cache → runtime keeps last `ou_`, owner DM received, retries log
- [ ] First install with bad `on_` and no cache → empty list + error log (no false open)