### PR TITLE
fix(routing): 修复同机 sibling bot 首次直连误弹授权卡（cross-ref 冷启动竞态）

### DIFF
--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -1678,6 +1678,95 @@ export async function resolveCurrentChatBotOpenIdsByLarkAppIds(
   return { ok: true, mappings };
 }
 
+/**
+ * A resolved same-deployment sibling identity: the receiver-scoped open_id
+ * `senderOpenId`, proven to belong to a locally-configured bot whose stable
+ * `larkAppId` and unique `botName` are returned so the caller can persist the
+ * receiver's cross-ref (botName → receiver-scoped open_id).
+ */
+export type SiblingBotResolution =
+  | { ok: true; larkAppId: string; botName: string; senderOpenId: string }
+  | { ok: false; reason: string };
+
+/**
+ * Resolve a foreign-bot SENDER open_id (receiver-scoped) to a same-deployment
+ * sibling, using only live authorization-grade signals — never the possibly
+ * stale/uninitialized cross-ref or observed stores. This closes the cold-start
+ * window where a same-machine sibling @s a receiver whose cross-ref has not yet
+ * learned that sibling's receiver-scoped open_id (Lark open_id is per-app).
+ *
+ * Identity is accepted only when all signals agree, mirroring
+ * {@link resolveCurrentChatBotOpenIdsByLarkAppIds}:
+ *  1. the receiver's live `/members/bots` row carries `bot_id === senderOpenId`;
+ *  2. exactly one locally-configured bot (other than the receiver) has that
+ *     exact `bot_name` in bots-info.json — a unique name binding;
+ *  3. that candidate app independently confirms `is_in_chat` and binds to
+ *     exactly one live row for its name (the strict resolver's own re-check).
+ *
+ * Fails closed (returns `{ ok: false }`) on any API error, ambiguity, or name
+ * collision, so the caller falls back to the `/grant` request card. Never
+ * authorizes a genuine external bot: an external sender's open_id has no
+ * locally-configured app of the same unique name, so step 2 fails.
+ */
+export async function resolveSiblingBotBySenderOpenId(
+  receiverLarkAppId: string,
+  chatId: string,
+  senderOpenId: string | undefined,
+): Promise<SiblingBotResolution> {
+  if (!senderOpenId) return { ok: false, reason: 'no_sender_open_id' };
+
+  const timeoutMs = config.chatBotDiscovery?.listBotsApiTimeoutMs ?? 3_000;
+  const live = await listChatBotsViaMembersBots(receiverLarkAppId, chatId, timeoutMs);
+  if (!live.ok) return { ok: false, reason: `live_membership_unavailable: ${live.reason}` };
+
+  // 1. The sender must appear in the receiver's live bot roster by open_id.
+  const liveRow = live.items.find(item => item.botId === senderOpenId);
+  if (!liveRow) return { ok: false, reason: 'sender_not_in_live_roster' };
+  const botName = liveRow.botName;
+
+  // 2. Exactly one locally-configured sibling (≠ receiver) must claim that
+  //    exact name. Read the controlled config fresh — a sibling appended after
+  //    this process started must still be recognized (auth boundary).
+  let candidateAppIds: string[] = [];
+  try {
+    const raw = JSON.parse(readFileSync(join(config.session.dataDir, 'bots-info.json'), 'utf-8'));
+    if (!Array.isArray(raw)) throw new Error('bots-info.json must contain an array');
+    const namesByAppId = new Map<string, string[]>();
+    for (const entry of raw) {
+      const appId = typeof entry?.larkAppId === 'string' ? entry.larkAppId.trim() : '';
+      const name = typeof entry?.botName === 'string' ? entry.botName.trim() : '';
+      if (!appId || !name) continue;
+      const names = namesByAppId.get(appId);
+      if (names) names.push(name);
+      else namesByAppId.set(appId, [name]);
+    }
+    for (const [appId, names] of namesByAppId) {
+      if (appId === receiverLarkAppId) continue;
+      // Require a unique name binding for the app — an app with multiple names
+      // is ambiguous and must not shortcut vetting.
+      if (names.length === 1 && names[0] === botName) candidateAppIds.push(appId);
+    }
+  } catch (err: any) {
+    return { ok: false, reason: `bots_info_unavailable: ${err?.message ?? String(err)}` };
+  }
+  if (candidateAppIds.length !== 1) {
+    return { ok: false, reason: candidateAppIds.length === 0 ? 'no_sibling_with_name' : 'ambiguous_sibling_name' };
+  }
+  const candidateAppId = candidateAppIds[0];
+
+  // 3. Delegate the strict re-check (is_in_chat + unique name + unique live
+  //    row) to the auth-grade resolver, then require it to bind back to exactly
+  //    the sender's open_id.
+  const resolved = await resolveCurrentChatBotOpenIdsByLarkAppIds(receiverLarkAppId, chatId, [candidateAppId]);
+  if (!resolved.ok) return { ok: false, reason: `strict_resolve_failed: ${resolved.error}` };
+  const mapping = resolved.mappings.find(m => m.larkAppId === candidateAppId);
+  if (!mapping || mapping.subjectOpenId !== senderOpenId) {
+    return { ok: false, reason: 'strict_resolve_open_id_mismatch' };
+  }
+
+  return { ok: true, larkAppId: candidateAppId, botName, senderOpenId };
+}
+
 // `/members/bots` returns the observer-scoped mention handle (`bot_id`) and
 // display name only. Bind botmux identity only when a configured bot has already
 // been proven to be in this chat and the name match is unique, OR the item's

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -10,7 +10,7 @@ import { atomicWriteFileSync } from '../../utils/atomic-write.js';
 import { join } from 'node:path';
 import { getBot, getAllBots, findOncallChat, getOwnerOpenId, type BotState } from '../../bot-registry.js';
 import { config, isVcMeetingAgentGloballyEnabled, vcMeetingAgentGlobalListenerBotAppId } from '../../config.js';
-import { getChatInfo, getChatMode, getCachedChatMode, listChatBotMembers, replyMessage, sendMessage, sendUserMessage, isHumanOpenId, updateMessage } from './client.js';
+import { getChatInfo, getChatMode, getCachedChatMode, listChatBotMembers, resolveSiblingBotBySenderOpenId, replyMessage, sendMessage, sendUserMessage, isHumanOpenId, updateMessage } from './client.js';
 import { logger } from '../../utils/logger.js';
 import { BoundedMap } from '../../utils/bounded-map.js';
 import { serializeByAnchor } from '../../utils/anchor-serializer.js';
@@ -2303,8 +2303,32 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
               && !isTrustedTeamBotSender(config.session.dataDir, chatId, senderUnionId)
               && !hasChatGrant(larkAppId, chatId, senderOpenId)
               && !hasGlobalGrant(larkAppId, senderOpenId)) {
-            await maybeSendGrantRequestCard(larkAppId, message, chatId, senderOpenId, data);
-            return;
+            // Cold-start self-heal: the cross-ref (bot-openids-<appId>.json) is
+            // learned lazily from observed mentions[], so the FIRST bot→bot
+            // direct @ from a same-deployment sibling can arrive before the
+            // receiver has learned that sibling's receiver-scoped open_id
+            // (Lark open_id is per-app). That raced a real sibling into this
+            // "unknown external bot" branch and mis-fired a /grant card
+            // (regression from ec146a49). Before deciding unknown, confirm the
+            // sender against the group's LIVE `/members/bots` roster: accept
+            // only when it binds to exactly one locally-configured sibling of
+            // the same unique name that independently confirms is_in_chat.
+            // Fails closed to the grant card on any API error / ambiguity /
+            // genuine external bot — never a name-only shortcut.
+            const sibling = await resolveSiblingBotBySenderOpenId(larkAppId, chatId, senderOpenId)
+              .catch((err): { ok: false; reason: string } => ({ ok: false, reason: `resolve_threw: ${err?.message ?? String(err)}` }));
+            if (sibling.ok) {
+              // Persist the newly-proven mapping so subsequent @s from this
+              // sibling hit isKnownPeerBot directly (no live API roundtrip).
+              updateBotOpenIdCrossRef(config.session.dataDir, larkAppId, [
+                { name: sibling.botName, id: { open_id: sibling.senderOpenId } },
+              ]);
+              logger.info(`Lazy sibling cross-ref backfill: ${sibling.botName} → ${senderOpenId?.substring(0, 12)} (was cold; skipping /grant)`);
+            } else {
+              logger.info(`Foreign bot @mention not a known sibling (${sibling.reason}); sending grant request card`);
+              await maybeSendGrantRequestCard(larkAppId, message, chatId, senderOpenId, data);
+              return;
+            }
           }
         }
         logger.info(`Bot-to-bot @mention detected (scope=${ctx.scope}): routing to handleThreadReply`);

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -60,6 +60,8 @@ vi.mock('../src/bot-registry.js', () => ({
 }));
 
 const mockListChatBotMembers = vi.fn(async () => [] as Array<{ openId: string; name: string }>);
+const mockResolveSiblingBot = vi.fn(async () => ({ ok: false, reason: 'default_no_sibling' } as
+  { ok: true; larkAppId: string; botName: string; senderOpenId: string } | { ok: false; reason: string }));
 const mockGetChatMode = vi.fn(async () => 'topic' as 'group' | 'topic' | 'p2p');
 const mockGetCachedChatMode = vi.fn(() => undefined as 'group' | 'topic' | 'p2p' | undefined);
 const mockGetChatInfo = vi.fn(async () => ({ userCount: 1, botCount: 1 }));
@@ -77,6 +79,7 @@ vi.mock('../src/im/lark/client.js', () => ({
   getChatMode: (...args: any[]) => mockGetChatMode(...args),
   getCachedChatMode: (...args: any[]) => mockGetCachedChatMode(...args),
   listChatBotMembers: (...args: any[]) => mockListChatBotMembers(...args),
+  resolveSiblingBotBySenderOpenId: (...args: any[]) => mockResolveSiblingBot(...args),
   replyMessage: (...args: any[]) => mockReplyMessage(...args),
   updateMessage: (...args: any[]) => mockUpdateMessage(...args),
   getMessageDetail: (...args: any[]) => mockGetMessageDetail(...args),
@@ -1435,6 +1438,8 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
     __resetEventClaimsForTest();
     _resetGrantPending();
     mockReplyMessage.mockClear();
+    mockResolveSiblingBot.mockReset();
+    mockResolveSiblingBot.mockResolvedValue({ ok: false, reason: 'default_no_sibling' });
     mockGetOwnerOpenId.mockReset();
     mockGetOwnerOpenId.mockReturnValue(undefined);
     mockGetCachedChatMode.mockReset();
@@ -1656,6 +1661,118 @@ describe('im.message.receive_v1 — bot-to-bot @mention routing', () => {
       expect.stringContaining(OTHER_BOT_OPEN_ID),
       'interactive',
     );
+  });
+
+  it('routes a cold same-deployment sibling (cross-ref not yet learned) after live /members/bots self-heal, and backfills the cross-ref', async () => {
+    // Regression for ec146a49: a same-machine sibling's FIRST direct @ can
+    // arrive before the receiver has learned that sibling's receiver-scoped
+    // open_id (Lark open_id is per-app), so isKnownPeerBot is momentarily
+    // false and it raced into the "unknown external bot" grant-card branch.
+    // The live /members/bots resolver confirms it's a locally-configured
+    // sibling → route through, no grant card, and persist the mapping.
+    setupBotState({ allowedUsers: ['ou_owner'], autoGrantRequestCards: true });
+    mockGetOwnerOpenId.mockReturnValue('ou_owner');
+    // Cold cross-ref (bot-openids-*.json empty); bots-info.json knows the
+    // sibling name so the backfill write validates and persists.
+    mockReadFileSync.mockImplementation((path: any) =>
+      String(path).includes('bots-info.json')
+        ? JSON.stringify([{ larkAppId: 'app-sibling', botOpenId: null, botName: 'SiblingBot' }])
+        : '{}');
+    mockResolveSiblingBot.mockResolvedValue({
+      ok: true, larkAppId: 'app-sibling', botName: 'SiblingBot', senderOpenId: OTHER_BOT_OPEN_ID,
+    });
+    handlers.isSessionOwner.mockImplementation((anchor: string) => anchor === 'root-cold-sibling-topic');
+    const event = makeBotMessageEvent({
+      senderOpenId: OTHER_BOT_OPEN_ID,
+      senderType: 'bot',
+      chatId: 'chat-cold-sibling-topic',
+      rootId: 'root-cold-sibling-topic',
+      threadId: 'root-cold-sibling-topic',
+      messageId: 'msg-cold-sibling-topic',
+      content: JSON.stringify({
+        zh_cn: { content: [[{ tag: 'at', user_id: MY_OPEN_ID }]] },
+      }),
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(mockResolveSiblingBot).toHaveBeenCalledWith(MY_APP_ID, 'chat-cold-sibling-topic', OTHER_BOT_OPEN_ID);
+    expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
+      scope: 'thread',
+      anchor: 'root-cold-sibling-topic',
+      larkAppId: MY_APP_ID,
+    }));
+    expect(mockReplyMessage).not.toHaveBeenCalled();
+    // Cross-ref backfilled so subsequent @s skip the live roundtrip.
+    expect(mockWriteFileSync).toHaveBeenCalled();
+  });
+
+  it('still sends the grant card for a genuine external bot the live resolver rejects', async () => {
+    // Negative control: the resolver fails closed (no locally-configured
+    // sibling of that unique name / API error / name collision), so the
+    // /grant card path is preserved for real external bots.
+    setupBotState({ allowedUsers: ['ou_owner'], autoGrantRequestCards: true });
+    mockGetOwnerOpenId.mockReturnValue('ou_owner');
+    mockReadFileSync.mockReturnValue('{}');
+    mockResolveSiblingBot.mockResolvedValue({ ok: false, reason: 'no_sibling_with_name' });
+    handlers.isSessionOwner.mockImplementation((anchor: string) => anchor === 'root-real-external-topic');
+    const event = makeBotMessageEvent({
+      senderOpenId: OTHER_BOT_OPEN_ID,
+      senderType: 'bot',
+      chatId: 'chat-real-external-topic',
+      rootId: 'root-real-external-topic',
+      threadId: 'root-real-external-topic',
+      messageId: 'msg-real-external-topic',
+      content: JSON.stringify({
+        zh_cn: { content: [[{ tag: 'at', user_id: MY_OPEN_ID }]] },
+      }),
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(mockResolveSiblingBot).toHaveBeenCalledWith(MY_APP_ID, 'chat-real-external-topic', OTHER_BOT_OPEN_ID);
+    expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+    expect(mockReplyMessage).toHaveBeenCalledWith(
+      MY_APP_ID,
+      'msg-real-external-topic',
+      expect.stringContaining(OTHER_BOT_OPEN_ID),
+      'interactive',
+    );
+  });
+
+  it('does NOT consult the live resolver when the bot is already a known peer (no wasted API roundtrip)', async () => {
+    // Fast path: an already-learned sibling (cross-ref hit) routes straight
+    // through without the live /members/bots call.
+    setupBotState({ allowedUsers: ['ou_owner'], autoGrantRequestCards: true });
+    mockGetOwnerOpenId.mockReturnValue('ou_owner');
+    // Cross-ref already contains the sibling → isKnownPeerBot true.
+    mockReadFileSync.mockReturnValue(JSON.stringify({ SiblingBot: OTHER_BOT_OPEN_ID }));
+    handlers.isSessionOwner.mockImplementation((anchor: string) => anchor === 'root-known-peer-topic');
+    const event = makeBotMessageEvent({
+      senderOpenId: OTHER_BOT_OPEN_ID,
+      senderType: 'bot',
+      chatId: 'chat-known-peer-topic',
+      rootId: 'root-known-peer-topic',
+      threadId: 'root-known-peer-topic',
+      messageId: 'msg-known-peer-topic',
+      content: JSON.stringify({
+        zh_cn: { content: [[{ tag: 'at', user_id: MY_OPEN_ID }]] },
+      }),
+    });
+
+    await capturedHandlers['im.message.receive_v1'](event);
+    await flushEventWork();
+
+    expect(mockResolveSiblingBot).not.toHaveBeenCalled();
+    expect(handlers.handleThreadReply).toHaveBeenCalledWith(event, expect.objectContaining({
+      scope: 'thread',
+      anchor: 'root-known-peer-topic',
+      larkAppId: MY_APP_ID,
+    }));
+    expect(mockReplyMessage).not.toHaveBeenCalled();
   });
 
   it('routes a chat-granted bot through an owned native topic', async () => {

--- a/test/list-chat-bot-members.test.ts
+++ b/test/list-chat-bot-members.test.ts
@@ -655,3 +655,123 @@ describe('listChatBotMembers', () => {
     expect(claude).toMatchObject({ openId: 'ou_obs_claude', mentionSource: 'observed' });
   });
 });
+
+describe('resolveSiblingBotBySenderOpenId', () => {
+  afterEach(async () => {
+    if (state.dataDir) {
+      rmSync(state.dataDir, { recursive: true, force: true });
+      state.dataDir = '';
+    }
+    state.listBotsApiItems = undefined;
+    state.listBotsApiError = undefined;
+    state.listBotsApiCode = 0;
+    state.listBotsApiCalls = 0;
+    state.botConfigs = [
+      { larkAppId: 'cli_self', larkAppSecret: 's1', cliId: 'codex' },
+      { larkAppId: 'cli_peer', larkAppSecret: 's2', cliId: 'codex' },
+    ];
+    state.inChatByAppId = {};
+    state.inChatErrorByAppId = {};
+    state.inChatCodeByAppId = {};
+    state.inChatCalls = [];
+    const { __testOnly_resetAllBotClients } = await import('../src/im/lark/client.js');
+    __testOnly_resetAllBotClients();
+  });
+
+  it('resolves a cold sibling by its receiver-scoped sender open_id (unique name + is_in_chat)', async () => {
+    state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-sibling-'));
+    state.listBotsApiItems = [{ bot_id: 'ou_peer_seen_by_receiver', bot_name: 'BotPeer' }];
+    writeFileSync(join(state.dataDir, 'bots-info.json'), JSON.stringify([
+      { larkAppId: 'cli_self', botOpenId: 'ou_self', botName: 'BotSelf' },
+      { larkAppId: 'cli_peer', botOpenId: 'ou_peer_seen_by_peer', botName: 'BotPeer' },
+    ]));
+    // Cross-ref cold on purpose (not consulted by the resolver).
+    writeFileSync(join(state.dataDir, 'bot-openids-cli_self.json'), JSON.stringify({}));
+
+    const { resolveSiblingBotBySenderOpenId } = await import('../src/im/lark/client.js');
+    await expect(resolveSiblingBotBySenderOpenId('cli_self', 'oc_chat', 'ou_peer_seen_by_receiver'))
+      .resolves.toEqual({ ok: true, larkAppId: 'cli_peer', botName: 'BotPeer', senderOpenId: 'ou_peer_seen_by_receiver' });
+    expect(state.inChatCalls).toEqual(['cli_peer']);
+  });
+
+  it('fails closed for a genuine external sender not backed by any local sibling of that name', async () => {
+    state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-sibling-'));
+    // Live roster shows a stranger bot whose name matches no configured sibling.
+    state.listBotsApiItems = [{ bot_id: 'ou_stranger', bot_name: 'StrangerBot' }];
+    writeFileSync(join(state.dataDir, 'bots-info.json'), JSON.stringify([
+      { larkAppId: 'cli_self', botOpenId: 'ou_self', botName: 'BotSelf' },
+      { larkAppId: 'cli_peer', botOpenId: 'ou_peer', botName: 'BotPeer' },
+    ]));
+
+    const { resolveSiblingBotBySenderOpenId } = await import('../src/im/lark/client.js');
+    const res = await resolveSiblingBotBySenderOpenId('cli_self', 'oc_chat', 'ou_stranger');
+    expect(res.ok).toBe(false);
+  });
+
+  it('fails closed when the sender open_id is absent from the live roster', async () => {
+    state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-sibling-'));
+    state.listBotsApiItems = [{ bot_id: 'ou_peer_seen_by_receiver', bot_name: 'BotPeer' }];
+    writeFileSync(join(state.dataDir, 'bots-info.json'), JSON.stringify([
+      { larkAppId: 'cli_self', botOpenId: 'ou_self', botName: 'BotSelf' },
+      { larkAppId: 'cli_peer', botOpenId: 'ou_peer', botName: 'BotPeer' },
+    ]));
+
+    const { resolveSiblingBotBySenderOpenId } = await import('../src/im/lark/client.js');
+    const res = await resolveSiblingBotBySenderOpenId('cli_self', 'oc_chat', 'ou_not_in_roster');
+    expect(res).toEqual({ ok: false, reason: 'sender_not_in_live_roster' });
+  });
+
+  it('fails closed when two configured siblings share the roster name (anti-impersonation)', async () => {
+    state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-sibling-'));
+    state.botConfigs = [
+      { larkAppId: 'cli_self', larkAppSecret: 's1', cliId: 'codex' },
+      { larkAppId: 'cli_peer', larkAppSecret: 's2', cliId: 'codex' },
+      { larkAppId: 'cli_peer2', larkAppSecret: 's3', cliId: 'codex' },
+    ];
+    state.listBotsApiItems = [{ bot_id: 'ou_peer_seen_by_receiver', bot_name: 'BotPeer' }];
+    writeFileSync(join(state.dataDir, 'bots-info.json'), JSON.stringify([
+      { larkAppId: 'cli_self', botOpenId: 'ou_self', botName: 'BotSelf' },
+      { larkAppId: 'cli_peer', botOpenId: 'ou_peer', botName: 'BotPeer' },
+      { larkAppId: 'cli_peer2', botOpenId: 'ou_peer2', botName: 'BotPeer' },
+    ]));
+
+    const { resolveSiblingBotBySenderOpenId } = await import('../src/im/lark/client.js');
+    const res = await resolveSiblingBotBySenderOpenId('cli_self', 'oc_chat', 'ou_peer_seen_by_receiver');
+    expect(res).toEqual({ ok: false, reason: 'ambiguous_sibling_name' });
+  });
+
+  it('fails closed when the live /members/bots call errors', async () => {
+    state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-sibling-'));
+    state.listBotsApiError = new Error('gateway unavailable');
+    writeFileSync(join(state.dataDir, 'bots-info.json'), JSON.stringify([
+      { larkAppId: 'cli_peer', botOpenId: 'ou_peer', botName: 'BotPeer' },
+    ]));
+
+    const { resolveSiblingBotBySenderOpenId } = await import('../src/im/lark/client.js');
+    const res = await resolveSiblingBotBySenderOpenId('cli_self', 'oc_chat', 'ou_peer_seen_by_receiver');
+    expect(res.ok).toBe(false);
+    expect((res as { reason: string }).reason).toContain('live_membership_unavailable');
+  });
+
+  it('returns no_sender_open_id when the sender open_id is missing', async () => {
+    state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-sibling-'));
+    const { resolveSiblingBotBySenderOpenId } = await import('../src/im/lark/client.js');
+    await expect(resolveSiblingBotBySenderOpenId('cli_self', 'oc_chat', undefined))
+      .resolves.toEqual({ ok: false, reason: 'no_sender_open_id' });
+    expect(state.listBotsApiCalls).toBe(0);
+  });
+
+  it('fails closed when the matched sibling is not actually in the chat', async () => {
+    state.dataDir = mkdtempSync(join(tmpdir(), 'botmux-sibling-'));
+    state.listBotsApiItems = [{ bot_id: 'ou_peer_seen_by_receiver', bot_name: 'BotPeer' }];
+    state.inChatByAppId = { cli_peer: false };
+    writeFileSync(join(state.dataDir, 'bots-info.json'), JSON.stringify([
+      { larkAppId: 'cli_self', botOpenId: 'ou_self', botName: 'BotSelf' },
+      { larkAppId: 'cli_peer', botOpenId: 'ou_peer', botName: 'BotPeer' },
+    ]));
+
+    const { resolveSiblingBotBySenderOpenId } = await import('../src/im/lark/client.js');
+    const res = await resolveSiblingBotBySenderOpenId('cli_self', 'oc_chat', 'ou_peer_seen_by_receiver');
+    expect(res.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## 问题

`ec146a49`（#572，onboarding/MOSA 大 PR）顺带改了 `src/im/lark/event-dispatcher.ts` 的 foreign-bot 授权门：把门控从「chat/new-topic 等入口」扩大到**所有 scope（含 native topic）**，并删除了 `ownsSession` 豁免。

副作用：同机 sibling bot **首次 bot→bot 直连**时，接收侧的 cross-ref（`bot-openids-<appId>.json`）尚未从 `mentions[]` 学到对方的 receiver-scoped open_id（飞书 open_id 按接收应用隔离），于是被误判为「未知外部 bot」而误弹 `/grant` 授权卡。真正回归点是 `ec146a49`（2026-07-24 进入 master），同机 bot 识别能力本身是 `d5a36005` 引入的。

## 修复

不恢复 `ownsSession` 豁免（那会让真实外部 bot 借已有话题绕权限），而是在判 unknown、发授权卡**之前**补一次 live sibling 身份确认：

1. **`src/im/lark/client.ts` 新增 `resolveSiblingBotBySenderOpenId(receiverAppId, chatId, senderOpenId)`**
   - 用当前群 **live `/members/bots`** roster，仅当 sender open_id 命中「唯一同名本机配置 sibling」且该 app 独立 `is_in_chat` 确认时才认；
   - 内部复用 auth-grade `resolveCurrentChatBotOpenIdsByLarkAppIds` 做严格再校验（要求回绑到正是 sender 的 open_id）；
   - 任何 API 失败/歧义/同名冲突/真外部 bot 一律 **fail-closed** 回授权卡，绝不认自报名字（防同名冒名蹭权）。

2. **`src/im/lark/event-dispatcher.ts` foreign-bot gate**（受限态那道）
   - 命中 sibling → `updateBotOpenIdCrossRef` 回填 cross-ref（后续同一对 bot 直接命中 `isKnownPeerBot`，且**同条消息**下游 daemon `evaluateTalk` 的 peer 腿也随之放行）再 route；
   - 未命中 → 维持原授权卡逻辑。

## 影响面

- 仅收窄「配了 allowlist 的受限态 + foreign-bot @mention」这一门，**未动** oncall / grant / team-peer / open-mode 其它腿。
- 真实外部 bot 授权语义不变（负向用例覆盖）。
- 已有 native-topic 授权卡回归测试仍绿（resolver 默认 fail-closed）。
- 跨 CLI/backend/平台：改动集中在 `im/lark/` 公共层，逻辑与具体 CLI/backend 无关；`/members/bots` + `is_in_chat` 均为已有能力，仅新增只读调用。

## 测试

- `pnpm build` 绿。
- 新增 `test/event-dispatcher.test.ts` 4 例：冷 sibling 自愈+回填、真外部 bot 仍弹卡、known-peer 不走 live、granted-bot 不走 live。
- 新增 `test/list-chat-bot-members.test.ts` 7 例：resolver 正向、真外部 fail-closed、roster 缺失、同名歧义、API 失败、空 open_id、不在群。
- 定向套件全通：`event-dispatcher`(236) / `list-chat-bot-members`(32) / `exact-chat-grant` / `peer-bot-operate` / `team-peer-trust` / `grant-gates` / `bot-routing` / `grant-card`。
- 注：`v3-worker-fence` / `v3-distillation-runner` / `v3-cancel-runtime` 11 例在本沙盒 fail，已确认在干净 `master`（stash 后）上**同样 fail**，属 PID/进程扫描环境相关的既有失败，与本改动无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)