### PR TITLE
fix(release): changelog 锚到「上一个已发布 Release」，堵 #593 那类漏 PR 裂缝（发版闸维持 fail-closed）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,61 +153,33 @@ jobs:
             exit 1
           fi
 
-      - name: Guard — stable release must build on the last published release (monotonic) and stay on the master line
-        # 正式版（latest）两条约束同时成立才放行：
-        #
-        # ① 单调下限：被打 tag 的 commit 必须**包含上一个已发布 stable Release 的 tag**
-        #    （作为祖先）。这道下限随每次成功发布单调抬升，天然挡住「给历史旧 commit 新打一个
-        #    高版本 tag」——旧 commit 不含最近发布，直接拒。（codex review 反例：把 v99.0.0
-        #    指到 v3.4.0 的旧 commit，若只看 commit graph 的双向 ancestry 会被误放行，缺后续
-        #    master 改动的旧代码就发成了 latest。用「含上一个已发布 Release」这条下限即可挡死。）
-        #
-        # ② 不分叉：tag 与 origin/master 在同一主线上——tag 是 master 祖先（打完 tag 后 master
-        #    又前进，常见且无害），或 master 是 tag 祖先（tag 在 master 顶端 / 领先几个已合入
-        #    commit）。二者互不为祖先（真从偏离 master 的分支打 tag）才拒。保留原始防护：曾发生
-        #    v2.47.0 从落后 master 175 commit 的分支发到 latest 丢改动。
-        #
-        # 关键收益：**发的是被打 tag 的那个 commit 本身**，不受打完 tag 后又合入 master 的新
-        # commit 影响。旧实现要求 tag「包含最新 master」，把「打完 tag 后 master 又前进」这种
-        # 无害竞态也误判成 fail（曾让 v3.5.1 发版失败、#593 漏进「tag 已打但 Release 没发」的
-        # 裂缝）。下限用「上一个已发布 Release」而非「最新 master」，既修竞态又堵旧-commit-重打。
+      - name: Guard — stable release must contain the latest master
+        # 正式版（latest）只能从「包含最新 master 的 commit」上发：被打 tag 的 commit
+        # 必须把 origin/master 当作祖先——即直接在 master 上打 tag，或在已 rebase 到最新
+        # master 的子分支上打 tag。否则拒绝，防止从落后/分叉的个人分支打出正式版（曾发生
+        # v2.47.0 从落后 master 175 个 commit 的分支发到 latest，丢了一大批 master 改动）。
         # canary/beta/rc/next 走旁路 dist-tag、用于分支灰度，不受此约束。
+        #
+        # 为什么保持 fail-closed、不放宽（codex review 结论）：commit graph 无法区分两种
+        # 形状完全相同的场景——「打完 tag 后 master 才前进」（无害竞态）与「B 已在 master 上
+        # 之后再把 tag 指向历史 A」（真丢改动）。二者的 tag/master/ancestry/版本号全一致，只有
+        # 「tag 创建 vs B 落 master」的墙钟先后能区分，而这不可信地存在于 graph 里。因此在没有
+        # 「tag 创建时 master tip」的可信证明前，放宽这道闸必然引入「把旧 commit 发成 latest」
+        # 的洞。竞态的正确解法是「fetch 最新 master 后在新 HEAD 上重打 tag」（下面的 Fix 提示），
+        # 而 #593 那次真正漏的是 changelog（下一步已把 changelog 锚到「上一个已发布 Release」，
+        # 使失败/无 Release 的 tag 不再截断下一版 changelog）——发版闸本身当时拒得没错。
+        # 注意竞态：若打完 tag 后、本 job fetch 前 master 又前进了，这里会判定 tag 落后而
+        # fail（fail-closed，安全方向）——重新 fetch master 后在新 HEAD 上重打 tag 即可。
         if: steps.dist_tag.outputs.tag == 'latest'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git fetch origin master --quiet
-          git fetch origin --tags --quiet
-          HEAD_SHA=$(git rev-parse --short HEAD)
-          MASTER_SHA=$(git rev-parse --short origin/master)
-
-          # ② 不分叉
-          if git merge-base --is-ancestor HEAD origin/master \
-            || git merge-base --is-ancestor origin/master HEAD; then
-            echo "OK (master line): tagged commit $HEAD_SHA shares the master line (origin/master=$MASTER_SHA)."
-          else
-            echo "REFUSING: tagged commit $HEAD_SHA has diverged from origin/master ($MASTER_SHA)."
-            echo "Stable (latest) releases must be tagged on master, or on a branch fast-forwardable to/from master."
+          if ! git merge-base --is-ancestor origin/master HEAD; then
+            echo "REFUSING: tagged commit $(git rev-parse --short HEAD) does not contain the latest origin/master ($(git rev-parse --short origin/master))."
+            echo "Stable (latest) releases must be tagged on master, or on a branch rebased onto the latest master."
             echo "Fix: rebase/merge onto origin/master then re-tag — or use a -canary/-beta/-rc suffix to publish off-master for testing."
             exit 1
           fi
-
-          # ① 单调下限：含上一个已发布 stable Release
-          PREV_PUBLISHED=$(gh release list --limit 40 \
-            --json tagName,isPrerelease,isDraft,publishedAt \
-            --jq '[.[] | select(.isPrerelease==false and .isDraft==false and .tagName!="'"$GITHUB_REF_NAME"'")]
-                  | sort_by(.publishedAt) | reverse | .[0].tagName // ""' 2>/dev/null || echo "")
-          if [ -z "$PREV_PUBLISHED" ]; then
-            echo "OK (floor): no prior published stable release found — treating $GITHUB_REF_NAME as the first stable release."
-          elif git rev-parse -q --verify "refs/tags/${PREV_PUBLISHED}^{commit}" >/dev/null \
-            && git merge-base --is-ancestor "$PREV_PUBLISHED" HEAD; then
-            echo "OK (floor): tagged commit $HEAD_SHA contains the last published release $PREV_PUBLISHED."
-          else
-            echo "REFUSING: tagged commit $HEAD_SHA does NOT contain the last published release $PREV_PUBLISHED."
-            echo "A stable release must be a descendant of the previous published release (no releasing an older/side commit as latest)."
-            echo "Fix: rebase/merge onto master (which contains $PREV_PUBLISHED) then re-tag — or use a prerelease suffix."
-            exit 1
-          fi
+          echo "OK: tagged commit contains origin/master ($(git rev-parse --short origin/master))."
 
       - run: pnpm build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,24 +153,33 @@ jobs:
             exit 1
           fi
 
-      - name: Guard — stable release must contain the latest master
-        # 正式版（latest）只能从「包含最新 master 的 commit」上发：被打 tag 的 commit
-        # 必须把 origin/master 当作祖先——即直接在 master 上打 tag，或在已 rebase 到最新
-        # master 的子分支上打 tag。否则拒绝，防止从落后/分叉的个人分支打出正式版（曾发生
-        # v2.47.0 从落后 master 175 个 commit 的分支发到 latest，丢了一大批 master 改动）。
+      - name: Guard — stable release must be on the master line (not a diverged branch)
+        # 正式版（latest）只能从 master 主线上的 commit 发：被打 tag 的 commit 必须与
+        # origin/master 处在同一条线上——即 tag 是 master 的祖先（master 后来又前进了，
+        # 常见且无害），或 master 是 tag 的祖先（tag 就在 master 顶端 / 领先 master 几个
+        # 已合入的 commit）。只有当两者「分叉」（互不为祖先，说明 tag 落在一条偏离 master
+        # 的分支上）时才拒绝——防止从落后/分叉的个人分支打出正式版（曾发生 v2.47.0 从落后
+        # master 175 个 commit 的分支发到 latest，丢了一大批 master 改动）。
+        #
+        # 关键：**发的是被打 tag 的那个 commit 本身**，不受打完 tag 后又合入 master 的
+        # 新 commit 影响。旧实现要求 tag 必须「包含最新 master」，于是「打完 tag 后 master
+        # 又前进」这种无害竞态会误判 tag 落后而 fail（曾让 v3.5.1 发版失败、#593 漏进裂缝）。
+        # 现在改为只挡「真分叉」，这条竞态不再阻断发版。
         # canary/beta/rc/next 走旁路 dist-tag、用于分支灰度，不受此约束。
-        # 注意竞态：若打完 tag 后、本 job fetch 前 master 又前进了，这里会判定 tag 落后而
-        # fail（fail-closed，安全方向）——重新 fetch master 后在新 HEAD 上重打 tag 即可。
         if: steps.dist_tag.outputs.tag == 'latest'
         run: |
           git fetch origin master --quiet
-          if ! git merge-base --is-ancestor origin/master HEAD; then
-            echo "REFUSING: tagged commit $(git rev-parse --short HEAD) does not contain the latest origin/master ($(git rev-parse --short origin/master))."
-            echo "Stable (latest) releases must be tagged on master, or on a branch rebased onto the latest master."
+          # tag 在 master 之后（master ⊇ tag）或 tag 在 master 之前/顶端（tag ⊇ master）
+          # 都属于同一主线，放行；只有互不为祖先（分叉）才拒绝。
+          if git merge-base --is-ancestor HEAD origin/master \
+            || git merge-base --is-ancestor origin/master HEAD; then
+            echo "OK: tagged commit $(git rev-parse --short HEAD) is on the master line (origin/master=$(git rev-parse --short origin/master))."
+          else
+            echo "REFUSING: tagged commit $(git rev-parse --short HEAD) has diverged from origin/master ($(git rev-parse --short origin/master))."
+            echo "Stable (latest) releases must be tagged on master, or on a branch rebased onto master (fast-forwardable either direction)."
             echo "Fix: rebase/merge onto origin/master then re-tag — or use a -canary/-beta/-rc suffix to publish off-master for testing."
             exit 1
           fi
-          echo "OK: tagged commit contains origin/master ($(git rev-parse --short origin/master))."
 
       - run: pnpm build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,31 +153,59 @@ jobs:
             exit 1
           fi
 
-      - name: Guard — stable release must be on the master line (not a diverged branch)
-        # 正式版（latest）只能从 master 主线上的 commit 发：被打 tag 的 commit 必须与
-        # origin/master 处在同一条线上——即 tag 是 master 的祖先（master 后来又前进了，
-        # 常见且无害），或 master 是 tag 的祖先（tag 就在 master 顶端 / 领先 master 几个
-        # 已合入的 commit）。只有当两者「分叉」（互不为祖先，说明 tag 落在一条偏离 master
-        # 的分支上）时才拒绝——防止从落后/分叉的个人分支打出正式版（曾发生 v2.47.0 从落后
-        # master 175 个 commit 的分支发到 latest，丢了一大批 master 改动）。
+      - name: Guard — stable release must build on the last published release (monotonic) and stay on the master line
+        # 正式版（latest）两条约束同时成立才放行：
         #
-        # 关键：**发的是被打 tag 的那个 commit 本身**，不受打完 tag 后又合入 master 的
-        # 新 commit 影响。旧实现要求 tag 必须「包含最新 master」，于是「打完 tag 后 master
-        # 又前进」这种无害竞态会误判 tag 落后而 fail（曾让 v3.5.1 发版失败、#593 漏进裂缝）。
-        # 现在改为只挡「真分叉」，这条竞态不再阻断发版。
+        # ① 单调下限：被打 tag 的 commit 必须**包含上一个已发布 stable Release 的 tag**
+        #    （作为祖先）。这道下限随每次成功发布单调抬升，天然挡住「给历史旧 commit 新打一个
+        #    高版本 tag」——旧 commit 不含最近发布，直接拒。（codex review 反例：把 v99.0.0
+        #    指到 v3.4.0 的旧 commit，若只看 commit graph 的双向 ancestry 会被误放行，缺后续
+        #    master 改动的旧代码就发成了 latest。用「含上一个已发布 Release」这条下限即可挡死。）
+        #
+        # ② 不分叉：tag 与 origin/master 在同一主线上——tag 是 master 祖先（打完 tag 后 master
+        #    又前进，常见且无害），或 master 是 tag 祖先（tag 在 master 顶端 / 领先几个已合入
+        #    commit）。二者互不为祖先（真从偏离 master 的分支打 tag）才拒。保留原始防护：曾发生
+        #    v2.47.0 从落后 master 175 commit 的分支发到 latest 丢改动。
+        #
+        # 关键收益：**发的是被打 tag 的那个 commit 本身**，不受打完 tag 后又合入 master 的新
+        # commit 影响。旧实现要求 tag「包含最新 master」，把「打完 tag 后 master 又前进」这种
+        # 无害竞态也误判成 fail（曾让 v3.5.1 发版失败、#593 漏进「tag 已打但 Release 没发」的
+        # 裂缝）。下限用「上一个已发布 Release」而非「最新 master」，既修竞态又堵旧-commit-重打。
         # canary/beta/rc/next 走旁路 dist-tag、用于分支灰度，不受此约束。
         if: steps.dist_tag.outputs.tag == 'latest'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git fetch origin master --quiet
-          # tag 在 master 之后（master ⊇ tag）或 tag 在 master 之前/顶端（tag ⊇ master）
-          # 都属于同一主线，放行；只有互不为祖先（分叉）才拒绝。
+          git fetch origin --tags --quiet
+          HEAD_SHA=$(git rev-parse --short HEAD)
+          MASTER_SHA=$(git rev-parse --short origin/master)
+
+          # ② 不分叉
           if git merge-base --is-ancestor HEAD origin/master \
             || git merge-base --is-ancestor origin/master HEAD; then
-            echo "OK: tagged commit $(git rev-parse --short HEAD) is on the master line (origin/master=$(git rev-parse --short origin/master))."
+            echo "OK (master line): tagged commit $HEAD_SHA shares the master line (origin/master=$MASTER_SHA)."
           else
-            echo "REFUSING: tagged commit $(git rev-parse --short HEAD) has diverged from origin/master ($(git rev-parse --short origin/master))."
-            echo "Stable (latest) releases must be tagged on master, or on a branch rebased onto master (fast-forwardable either direction)."
+            echo "REFUSING: tagged commit $HEAD_SHA has diverged from origin/master ($MASTER_SHA)."
+            echo "Stable (latest) releases must be tagged on master, or on a branch fast-forwardable to/from master."
             echo "Fix: rebase/merge onto origin/master then re-tag — or use a -canary/-beta/-rc suffix to publish off-master for testing."
+            exit 1
+          fi
+
+          # ① 单调下限：含上一个已发布 stable Release
+          PREV_PUBLISHED=$(gh release list --limit 40 \
+            --json tagName,isPrerelease,isDraft,publishedAt \
+            --jq '[.[] | select(.isPrerelease==false and .isDraft==false and .tagName!="'"$GITHUB_REF_NAME"'")]
+                  | sort_by(.publishedAt) | reverse | .[0].tagName // ""' 2>/dev/null || echo "")
+          if [ -z "$PREV_PUBLISHED" ]; then
+            echo "OK (floor): no prior published stable release found — treating $GITHUB_REF_NAME as the first stable release."
+          elif git rev-parse -q --verify "refs/tags/${PREV_PUBLISHED}^{commit}" >/dev/null \
+            && git merge-base --is-ancestor "$PREV_PUBLISHED" HEAD; then
+            echo "OK (floor): tagged commit $HEAD_SHA contains the last published release $PREV_PUBLISHED."
+          else
+            echo "REFUSING: tagged commit $HEAD_SHA does NOT contain the last published release $PREV_PUBLISHED."
+            echo "A stable release must be a descendant of the previous published release (no releasing an older/side commit as latest)."
+            echo "Fix: rebase/merge onto master (which contains $PREV_PUBLISHED) then re-tag — or use a prerelease suffix."
             exit 1
           fi
 
@@ -195,13 +223,29 @@ jobs:
         run: |
           # actions/checkout 默认把 tag 存成轻量指针，需重新 fetch 才能拿到 annotated tag object
           git fetch origin "refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}" --force
-          # 上一个 tag: stable 只跟 stable 比 (词法排序会把 canary 排到 stable 前面,
-          # 不过滤的话 v2.24.4 的 compare 会指向 v2.24.4-canary.X 而不是 v2.24.3)
+          # 上一版锚点：
+          # - prerelease（canary/beta/rc/next）：仍按 v:refname 排序取上一个 tag（灰度链条只关心
+          #   相邻 tag，且 prerelease 常不发 GitHub Release）。stable 只跟 stable 比（词法排序会把
+          #   canary 排到 stable 前面，不过滤的话 v2.24.4 的 compare 会指向 v2.24.4-canary.X）。
+          # - stable（latest）：锚到「上一个**已发布** stable GitHub Release」的 tag，而不是
+          #   git tag 排序的第一个。原因：若某个 stable tag 因签名/npm/权限/guard 失败而**只打了
+          #   tag、没发 Release**（如 v3.5.1），旧逻辑会把它当 PREV_TAG，导致下一版 changelog 从
+          #   那个「隐身版本」起算、漏掉它本该带上的 PR（#593 就是这么漏的）。锚到最近已发布
+          #   Release 后，任何中途没发成的 tag 都不会截断 changelog——它们引入的 PR 会被下一版
+          #   一并带上，保证「覆盖上次发布以来的所有 PR」。取不到已发布 Release 时回退到 tag 排序。
           if [[ "$GITHUB_REF_NAME" == *"-"* ]]; then
             PREV_TAG=$(git tag --sort=-v:refname | grep -Fxv "$GITHUB_REF_NAME" | head -1)
           else
-            PREV_TAG=$(git tag --sort=-v:refname | grep -Fxv "$GITHUB_REF_NAME" | grep -v -e '-' | head -1)
+            PREV_TAG=$(gh release list --limit 40 \
+              --json tagName,isPrerelease,isDraft,publishedAt \
+              --jq '[.[] | select(.isPrerelease==false and .isDraft==false and .tagName!="'"$GITHUB_REF_NAME"'")]
+                    | sort_by(.publishedAt) | reverse | .[0].tagName // ""' 2>/dev/null || echo "")
+            # 回退：无已发布 Release，或该 tag 在本地取不到 commit（异常）→ 用 tag 排序兜底。
+            if [ -z "$PREV_TAG" ] || ! git rev-parse -q --verify "refs/tags/${PREV_TAG}^{commit}" >/dev/null; then
+              PREV_TAG=$(git tag --sort=-v:refname | grep -Fxv "$GITHUB_REF_NAME" | grep -v -e '-' | head -1)
+            fi
           fi
+          echo "changelog range: ${PREV_TAG}..${GITHUB_REF_NAME}"
           TAG_MSG=$(git tag -l --format='%(contents)' "$GITHUB_REF_NAME")
 
           # 区间内每个非 merge commit → 反查所属 PR（gh api，有界：约等于区间 commit 数，


### PR DESCRIPTION
## 背景

v3.5.1 发版 job 失败（`REFUSING: ... does not contain the latest origin/master`）→ 只打 tag 没发 Release → PR #593 卡进「tag 已打但 Release 没发」的裂缝，下一版 changelog 又把它排除。

## 经过 codex 两轮 review 后的最终结论

**发版闸不放宽，维持 fail-closed；只修 changelog 锚点。**

初版尝试放宽发版闸（让 tag 发它自身 commit、不受后续 master 影响），codex 两轮 review 证明不可行：

- **一轮反例**：只看 commit graph 双向 ancestry → 把 v99 指到 v3.4.0 旧 commit 会被放行。
- **二轮更窄反例** `P→A→B`：B 已上 master 后再把高版本 tag 指向历史 A——A 含上个 Release、A 与 B 同主线、版本号更大，「含上一个已发布 Release + 不分叉」两条全过，但发布的 A 漏掉了打 tag 前就在 master 的 B。
- **根因**：commit graph 无法区分「打完 tag 后 master 才前进」（无害竞态）与「B 已在 master 后再 tag 历史 A」（真丢改动）——两者形状完全一致，只有墙钟先后能区分，而这不可信地在 graph 里。没有「tag 创建时 master tip」的可信证明，放宽必然引入「旧 commit 发成 latest」的洞。
- 放宽版还有 **fail-open**：`gh release list ... || echo ""` 失败会把空值当「首个 release」跳过下限。

## 最终改动

1. **发版闸回退为原始 fail-closed**（`is-ancestor origin/master HEAD`），仅补注释说明为何不放宽。竞态的正确解法是 fetch 最新 master 后在新 HEAD 重打 tag（闸的 Fix 提示已写）。
2. **changelog PREV_TAG 锚到「上一个已发布 stable GitHub Release」**（codex 认可方向）：失败/无 Release 的 tag（如 v3.5.1）不再截断下一版 changelog——它引入的 PR 被下一版一并带上，保证「覆盖上次发布以来所有 PR」。取不到已发布 Release 时回退 tag 排序（不劣于原行为）。

→ #593 那类裂缝由 **changelog 侧根治**，发版安全边界**不放松**。

## 影响面

仅 `.github/workflows/release.yml` 的 latest 闸注释 + changelog 锚点；prerelease 链路 / 运行时代码不受影响。YAML 校验通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)