### PR TITLE
refactor(core): 增加机器人级 turn admission/mutation gate

### DIFF
--- a/src/core/bot-turn-mutation-gate.ts
+++ b/src/core/bot-turn-mutation-gate.ts
@@ -1,0 +1,296 @@
+/**
+ * Per-bot admission/drain gate for mutations that replace every live worker
+ * generation (currently read-isolation). JavaScript's single thread makes the
+ * check+increment and close+publish edges atomic, while the waiters cover all
+ * intervening awaits in inbound/HTTP turn preparation.
+ */
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+type GateState = {
+  activeAdmissions: number;
+  mutating: boolean;
+  openWaiters: Array<GateWaiter>;
+  drainWaiters: Array<GateWaiter>;
+};
+
+type GateWaiter = { wake: () => void };
+
+const gates = new Map<string, GateState>();
+type AdmissionLease = { active: boolean; ownerFinished: boolean };
+type MutationLease = { active: boolean };
+const admissionContext = new AsyncLocalStorage<ReadonlyMap<string, AdmissionLease>>();
+const mutationContext = new AsyncLocalStorage<ReadonlyMap<string, MutationLease>>();
+
+function stateFor(larkAppId: string): GateState {
+  let state = gates.get(larkAppId);
+  if (!state) {
+    state = { activeAdmissions: 0, mutating: false, openWaiters: [], drainWaiters: [] };
+    gates.set(larkAppId, state);
+  }
+  return state;
+}
+
+function waitUntilOpen(state: GateState): Promise<void> {
+  return state.mutating
+    ? new Promise(resolve => state.openWaiters.push({ wake: resolve }))
+    : Promise.resolve();
+}
+
+function waitUntilDrained(state: GateState): Promise<void> {
+  return state.activeAdmissions > 0
+    ? new Promise(resolve => state.drainWaiters.push({ wake: resolve }))
+    : Promise.resolve();
+}
+
+function wakeAll(waiters: GateWaiter[]): void {
+  const pending = waiters.splice(0);
+  for (const waiter of pending) waiter.wake();
+}
+
+/** Cancellable condition wait used only by bounded acquisition. Timeout
+ * removes the exact waiter, so it cannot resume later and run a stale shutdown
+ * after its caller already reported refusal. */
+function waitUntilBefore(
+  waiters: GateWaiter[],
+  ready: () => boolean,
+  deadlineMs: number,
+): Promise<boolean> {
+  if (Date.now() >= deadlineMs) return Promise.resolve(false);
+  if (ready()) return Promise.resolve(true);
+  const remaining = deadlineMs - Date.now();
+  if (remaining <= 0) return Promise.resolve(false);
+  return new Promise(resolve => {
+    let settled = false;
+    let timer: NodeJS.Timeout;
+    const waiter: GateWaiter = {
+      wake: () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(Date.now() < deadlineMs);
+      },
+    };
+    waiters.push(waiter);
+    timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      const index = waiters.indexOf(waiter);
+      if (index >= 0) waiters.splice(index, 1);
+      resolve(false);
+    }, remaining);
+  });
+}
+
+export async function withBotTurnAdmission<T>(
+  larkAppId: string,
+  action: () => Promise<T> | T,
+): Promise<T> {
+  // A mutation already owns the bot exclusively. Re-entering an admission
+  // boundary from that mutation must not wait for the gate it owns.
+  const inheritedMutation = mutationContext.getStore()?.get(larkAppId);
+  if (inheritedMutation?.active) return action();
+  const inherited = admissionContext.getStore();
+  // Some admitted event paths delegate to triggerSessionTurn, which is also a
+  // public admission boundary. Treat that nested call as part of the outer
+  // lease; otherwise a mutation that closed the gate while the outer handler
+  // awaited would make the handler wait on itself and deadlock the drain.
+  const inheritedLease = inherited?.get(larkAppId);
+  if (inheritedLease?.active) return action();
+  const state = stateFor(larkAppId);
+  // A mutation may finish and another queued mutation may close the gate again
+  // before this continuation runs, so re-check after every wake.
+  while (state.mutating) await waitUntilOpen(state);
+  state.activeAdmissions++;
+  const lease: AdmissionLease = { active: true, ownerFinished: false };
+  try {
+    const next = new Map(inherited ?? []);
+    next.set(larkAppId, lease);
+    return await admissionContext.run(next, action);
+  } finally {
+    // AsyncLocalStorage descendants can outlive the awaited action when code
+    // starts fire-and-forget work. They retain this object, so revoke it before
+    // decrementing the drain count; a detached continuation must acquire a new
+    // admission instead of impersonating a still-live nested call.
+    // An admitted handler may upgrade itself to a mutation. The upgrade
+    // temporarily releases and later reacquires this exact lease; only the
+    // still-active owner decrements it here.
+    lease.ownerFinished = true;
+    if (lease.active) {
+      lease.active = false;
+      state.activeAdmissions--;
+      if (state.activeAdmissions === 0) {
+        wakeAll(state.drainWaiters);
+      }
+    }
+  }
+}
+
+export async function withBotTurnMutation<T>(
+  larkAppId: string,
+  action: () => Promise<T> | T,
+): Promise<T> {
+  const inheritedMutation = mutationContext.getStore()?.get(larkAppId);
+  if (inheritedMutation?.active) return action();
+  const state = stateFor(larkAppId);
+  const inheritedAdmission = admissionContext.getStore()?.get(larkAppId);
+
+  // Explicit abandon actions are discovered inside already-admitted message
+  // and card handlers. Upgrade that admission instead of nesting and
+  // deadlocking: release only this handler's lease, drain every other turn,
+  // perform the mutation, then atomically reacquire the outer lease before the
+  // gate is reopened. The caller may safely finish delivery/logging under its
+  // original admission after the exclusive state change.
+  const upgrading = inheritedAdmission?.active === true;
+  if (upgrading) {
+    inheritedAdmission.active = false;
+    state.activeAdmissions--;
+    if (state.activeAdmissions === 0) {
+      wakeAll(state.drainWaiters);
+    }
+  }
+
+  while (state.mutating) await waitUntilOpen(state);
+  state.mutating = true;
+  await waitUntilDrained(state);
+  const mutationLease: MutationLease = { active: true };
+  try {
+    const next = new Map(mutationContext.getStore() ?? []);
+    next.set(larkAppId, mutationLease);
+    return await mutationContext.run(next, action);
+  } finally {
+    // Detached descendants retain the AsyncLocalStorage map. Revoke the
+    // mutable lease before reopening the gate so they cannot impersonate the
+    // completed mutation later.
+    mutationLease.active = false;
+    // Reacquire before waking queued admissions/mutations. This keeps the
+    // remainder of an upgraded outer handler inside the admission lifetime and
+    // prevents its finally block from double-decrementing the gate.
+    if (upgrading && !inheritedAdmission.ownerFinished) {
+      state.activeAdmissions++;
+      inheritedAdmission.active = true;
+    }
+    state.mutating = false;
+    wakeAll(state.openWaiters);
+    // Keep the state object stable. Resolved admission waiters resume in later
+    // promise jobs and still hold this object; deleting it here would let a new
+    // caller create a second gate and bypass those about-to-reacquire waiters.
+    // The key space is bounded by configured bot ids.
+  }
+}
+
+export type BoundedBotTurnMutationResult<T> =
+  | { acquired: true; value: T }
+  | { acquired: false; reason: 'timeout' | 'upgrade_conflict' };
+
+/** Acquire one exact mutation lease within a single absolute deadline.
+ *
+ * Unlike Promise.race around `withBotTurnMutation`, this removes a timed-out
+ * waiter and rolls back a gate already closed while admissions were draining.
+ * Therefore `action` can never run after `{ acquired:false }` was returned.
+ *
+ * A same-bot admission may upgrade only when no other mutation already owns
+ * the gate. Returning `upgrade_conflict` leaves that admission untouched; this
+ * keeps the bounded path safe without resuming an admission concurrently with
+ * a mutation it had temporarily released for. */
+export async function tryWithBotTurnMutation<T>(
+  larkAppId: string,
+  acquireTimeoutMs: number,
+  action: () => Promise<T> | T,
+): Promise<BoundedBotTurnMutationResult<T>> {
+  const inheritedMutation = mutationContext.getStore()?.get(larkAppId);
+  if (inheritedMutation?.active) {
+    return { acquired: true, value: await action() };
+  }
+  const state = stateFor(larkAppId);
+  const inheritedAdmission = admissionContext.getStore()?.get(larkAppId);
+  const upgrading = inheritedAdmission?.active === true;
+  if (upgrading && state.mutating) {
+    return { acquired: false, reason: 'upgrade_conflict' };
+  }
+
+  const deadlineMs = Date.now() + Math.max(0, acquireTimeoutMs);
+  if (upgrading) {
+    inheritedAdmission.active = false;
+    state.activeAdmissions--;
+    if (state.activeAdmissions === 0) wakeAll(state.drainWaiters);
+  } else {
+    while (state.mutating) {
+      if (!await waitUntilBefore(state.openWaiters, () => !state.mutating, deadlineMs)) {
+        return { acquired: false, reason: 'timeout' };
+      }
+    }
+  }
+
+  if (Date.now() >= deadlineMs) {
+    if (upgrading && !inheritedAdmission.ownerFinished) {
+      state.activeAdmissions++;
+      inheritedAdmission.active = true;
+    }
+    return { acquired: false, reason: 'timeout' };
+  }
+
+  state.mutating = true;
+  const drained = await waitUntilBefore(
+    state.drainWaiters,
+    () => state.activeAdmissions === 0,
+    deadlineMs,
+  );
+  if (!drained || Date.now() >= deadlineMs) {
+    if (upgrading && !inheritedAdmission.ownerFinished) {
+      state.activeAdmissions++;
+      inheritedAdmission.active = true;
+    }
+    state.mutating = false;
+    wakeAll(state.openWaiters);
+    return { acquired: false, reason: 'timeout' };
+  }
+
+  const mutationLease: MutationLease = { active: true };
+  try {
+    const next = new Map(mutationContext.getStore() ?? []);
+    next.set(larkAppId, mutationLease);
+    if (Date.now() >= deadlineMs) {
+      return { acquired: false, reason: 'timeout' };
+    }
+    const value = await mutationContext.run(next, action);
+    return { acquired: true, value };
+  } finally {
+    mutationLease.active = false;
+    if (upgrading && !inheritedAdmission.ownerFinished) {
+      state.activeAdmissions++;
+      inheritedAdmission.active = true;
+    }
+    state.mutating = false;
+    wakeAll(state.openWaiters);
+  }
+}
+
+/**
+ * Start an independent admission branch from fire-and-forget code. Normal
+ * same-bot nesting is intentionally reentrant and MUST be awaited by its
+ * caller; JavaScript cannot infer whether a returned Promise was floated.
+ * Detached callers clear both contexts and acquire a fresh counted root lease.
+ */
+export function runDetachedBotTurnAdmission<T>(
+  larkAppId: string,
+  action: () => Promise<T> | T,
+): Promise<T> {
+  return admissionContext.run(new Map(), () =>
+    mutationContext.run(new Map(), () => withBotTurnAdmission(larkAppId, action)));
+}
+
+/** Fire-and-forget counterpart for exclusive lifecycle mutations. A detached
+ * mutation inside an admission waits for that admission to drain; one inside a
+ * mutation waits for the parent mutation to reopen the gate. Do not await this
+ * helper from the parent scope whose lease it must wait on. */
+export function runDetachedBotTurnMutation<T>(
+  larkAppId: string,
+  action: () => Promise<T> | T,
+): Promise<T> {
+  return admissionContext.run(new Map(), () =>
+    mutationContext.run(new Map(), () => withBotTurnMutation(larkAppId, action)));
+}
+
+export function __testOnly_resetBotTurnMutationGates(): void {
+  gates.clear();
+}

--- a/src/core/bot-turn-mutation-gate.ts
+++ b/src/core/bot-turn-mutation-gate.ts
@@ -16,7 +16,13 @@ type GateState = {
 type GateWaiter = { wake: () => void };
 
 const gates = new Map<string, GateState>();
-type AdmissionLease = { active: boolean; ownerFinished: boolean };
+type AdmissionLease = {
+  active: boolean;
+  ownerFinished: boolean;
+  pendingUpgrades: number;
+  upgradeLocked: boolean;
+  upgradeWaiters: Array<GateWaiter>;
+};
 type MutationLease = { active: boolean };
 const admissionContext = new AsyncLocalStorage<ReadonlyMap<string, AdmissionLease>>();
 const mutationContext = new AsyncLocalStorage<ReadonlyMap<string, MutationLease>>();
@@ -45,6 +51,88 @@ function waitUntilDrained(state: GateState): Promise<void> {
 function wakeAll(waiters: GateWaiter[]): void {
   const pending = waiters.splice(0);
   for (const waiter of pending) waiter.wake();
+}
+
+function shouldQueueAdmissionUpgrade(lease: AdmissionLease | undefined): lease is AdmissionLease {
+  return lease !== undefined
+    && !lease.ownerFinished
+    && (lease.active || lease.pendingUpgrades > 0);
+}
+
+/** Serialize mutations that inherit the same admission lease. The first
+ * caller keeps the original synchronous close edge; later callers wait on the
+ * lease-local queue instead of snapshotting `active=false` and becoming an
+ * unrelated mutation that would wait for its own outer admission forever. */
+function acquireAdmissionUpgrade(lease: AdmissionLease): Promise<void> | undefined {
+  lease.pendingUpgrades++;
+  if (!lease.upgradeLocked) {
+    lease.upgradeLocked = true;
+    return undefined;
+  }
+  return new Promise(resolve => lease.upgradeWaiters.push({ wake: resolve }));
+}
+
+function releaseAdmissionUpgrade(lease: AdmissionLease): void {
+  lease.pendingUpgrades--;
+  const next = lease.upgradeWaiters.shift();
+  if (next) {
+    // Ownership transfers directly to the next queued mutation. Keep the lock
+    // set until that caller releases it, so sibling actions cannot overlap.
+    next.wake();
+  } else {
+    lease.upgradeLocked = false;
+  }
+}
+
+type BoundedAdmissionUpgradeTicket =
+  | { status: 'acquired' }
+  | { status: 'timed_out' }
+  | {
+    status: 'queued';
+    result: Promise<'acquired' | 'expired_owner' | 'timed_out'>;
+  };
+
+/** Deadline-aware admission-upgrade queue acquisition. A waiter that times
+ * out before ownership transfer is removed from the exact lease-local queue.
+ * If transfer wins the race at an already-expired wall clock, the caller owns
+ * the slot only long enough to release it; its mutation action never runs. */
+function acquireAdmissionUpgradeBefore(
+  lease: AdmissionLease,
+  deadlineMs: number,
+): BoundedAdmissionUpgradeTicket {
+  const remaining = deadlineMs - Date.now();
+  if (remaining <= 0) return { status: 'timed_out' };
+
+  lease.pendingUpgrades++;
+  if (!lease.upgradeLocked) {
+    lease.upgradeLocked = true;
+    return { status: 'acquired' };
+  }
+
+  const result = new Promise<'acquired' | 'expired_owner' | 'timed_out'>(resolve => {
+    let settled = false;
+    let timer: NodeJS.Timeout;
+    const waiter: GateWaiter = {
+      wake: () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(Date.now() < deadlineMs ? 'acquired' : 'expired_owner');
+      },
+    };
+    lease.upgradeWaiters.push(waiter);
+    timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      const index = lease.upgradeWaiters.indexOf(waiter);
+      if (index >= 0) {
+        lease.upgradeWaiters.splice(index, 1);
+        lease.pendingUpgrades--;
+        resolve('timed_out');
+      }
+    }, remaining);
+  });
+  return { status: 'queued', result };
 }
 
 /** Cancellable condition wait used only by bounded acquisition. Timeout
@@ -101,7 +189,13 @@ export async function withBotTurnAdmission<T>(
   // before this continuation runs, so re-check after every wake.
   while (state.mutating) await waitUntilOpen(state);
   state.activeAdmissions++;
-  const lease: AdmissionLease = { active: true, ownerFinished: false };
+  const lease: AdmissionLease = {
+    active: true,
+    ownerFinished: false,
+    pendingUpgrades: 0,
+    upgradeLocked: false,
+    upgradeWaiters: [],
+  };
   try {
     const next = new Map(inherited ?? []);
     next.set(larkAppId, lease);
@@ -125,15 +219,12 @@ export async function withBotTurnAdmission<T>(
   }
 }
 
-export async function withBotTurnMutation<T>(
+async function runBotTurnMutation<T>(
   larkAppId: string,
+  state: GateState,
+  inheritedAdmission: AdmissionLease | undefined,
   action: () => Promise<T> | T,
 ): Promise<T> {
-  const inheritedMutation = mutationContext.getStore()?.get(larkAppId);
-  if (inheritedMutation?.active) return action();
-  const state = stateFor(larkAppId);
-  const inheritedAdmission = admissionContext.getStore()?.get(larkAppId);
-
   // Explicit abandon actions are discovered inside already-admitted message
   // and card handlers. Upgrade that admission instead of nesting and
   // deadlocking: release only this handler's lease, drain every other turn,
@@ -178,6 +269,28 @@ export async function withBotTurnMutation<T>(
   }
 }
 
+export async function withBotTurnMutation<T>(
+  larkAppId: string,
+  action: () => Promise<T> | T,
+): Promise<T> {
+  const inheritedMutation = mutationContext.getStore()?.get(larkAppId);
+  if (inheritedMutation?.active) return action();
+  const state = stateFor(larkAppId);
+  const inheritedAdmission = admissionContext.getStore()?.get(larkAppId);
+
+  if (shouldQueueAdmissionUpgrade(inheritedAdmission)) {
+    const waiting = acquireAdmissionUpgrade(inheritedAdmission);
+    if (waiting) await waiting;
+    try {
+      return await runBotTurnMutation(larkAppId, state, inheritedAdmission, action);
+    } finally {
+      releaseAdmissionUpgrade(inheritedAdmission);
+    }
+  }
+
+  return runBotTurnMutation(larkAppId, state, inheritedAdmission, action);
+}
+
 export type BoundedBotTurnMutationResult<T> =
   | { acquired: true; value: T }
   | { acquired: false; reason: 'timeout' | 'upgrade_conflict' };
@@ -192,23 +305,18 @@ export type BoundedBotTurnMutationResult<T> =
  * the gate. Returning `upgrade_conflict` leaves that admission untouched; this
  * keeps the bounded path safe without resuming an admission concurrently with
  * a mutation it had temporarily released for. */
-export async function tryWithBotTurnMutation<T>(
+async function runBoundedBotTurnMutation<T>(
   larkAppId: string,
-  acquireTimeoutMs: number,
+  state: GateState,
+  inheritedAdmission: AdmissionLease | undefined,
+  deadlineMs: number,
   action: () => Promise<T> | T,
 ): Promise<BoundedBotTurnMutationResult<T>> {
-  const inheritedMutation = mutationContext.getStore()?.get(larkAppId);
-  if (inheritedMutation?.active) {
-    return { acquired: true, value: await action() };
-  }
-  const state = stateFor(larkAppId);
-  const inheritedAdmission = admissionContext.getStore()?.get(larkAppId);
   const upgrading = inheritedAdmission?.active === true;
   if (upgrading && state.mutating) {
     return { acquired: false, reason: 'upgrade_conflict' };
   }
 
-  const deadlineMs = Date.now() + Math.max(0, acquireTimeoutMs);
   if (upgrading) {
     inheritedAdmission.active = false;
     state.activeAdmissions--;
@@ -263,6 +371,56 @@ export async function tryWithBotTurnMutation<T>(
     state.mutating = false;
     wakeAll(state.openWaiters);
   }
+}
+
+export async function tryWithBotTurnMutation<T>(
+  larkAppId: string,
+  acquireTimeoutMs: number,
+  action: () => Promise<T> | T,
+): Promise<BoundedBotTurnMutationResult<T>> {
+  const inheritedMutation = mutationContext.getStore()?.get(larkAppId);
+  if (inheritedMutation?.active) {
+    return { acquired: true, value: await action() };
+  }
+  const state = stateFor(larkAppId);
+  const inheritedAdmission = admissionContext.getStore()?.get(larkAppId);
+  const deadlineMs = Date.now() + Math.max(0, acquireTimeoutMs);
+
+  if (shouldQueueAdmissionUpgrade(inheritedAdmission)) {
+    const ticket = acquireAdmissionUpgradeBefore(inheritedAdmission, deadlineMs);
+    if (ticket.status === 'timed_out') {
+      return { acquired: false, reason: 'timeout' };
+    }
+    if (ticket.status === 'queued') {
+      const result = await ticket.result;
+      if (result === 'timed_out') {
+        return { acquired: false, reason: 'timeout' };
+      }
+      if (result === 'expired_owner') {
+        releaseAdmissionUpgrade(inheritedAdmission);
+        return { acquired: false, reason: 'timeout' };
+      }
+    }
+    try {
+      return await runBoundedBotTurnMutation(
+        larkAppId,
+        state,
+        inheritedAdmission,
+        deadlineMs,
+        action,
+      );
+    } finally {
+      releaseAdmissionUpgrade(inheritedAdmission);
+    }
+  }
+
+  return runBoundedBotTurnMutation(
+    larkAppId,
+    state,
+    inheritedAdmission,
+    deadlineMs,
+    action,
+  );
 }
 
 /**

--- a/test/bot-turn-mutation-gate.test.ts
+++ b/test/bot-turn-mutation-gate.test.ts
@@ -1,0 +1,400 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  __testOnly_resetBotTurnMutationGates,
+  runDetachedBotTurnAdmission,
+  runDetachedBotTurnMutation,
+  tryWithBotTurnMutation,
+  withBotTurnAdmission,
+  withBotTurnMutation,
+} from '../src/core/bot-turn-mutation-gate.js';
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => { resolve = done; });
+  return { promise, resolve };
+}
+
+describe('per-bot turn mutation gate', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    __testOnly_resetBotTurnMutationGates();
+  });
+
+  it('drains an in-flight admission and blocks new turns through the mutation', async () => {
+    const finishFirst = deferred();
+    const finishMutation = deferred();
+    const firstEntered = vi.fn();
+    const mutationEntered = vi.fn();
+    const secondEntered = vi.fn();
+
+    const first = withBotTurnAdmission('app-a', async () => {
+      firstEntered();
+      await finishFirst.promise;
+    });
+    await vi.waitFor(() => expect(firstEntered).toHaveBeenCalledOnce());
+
+    const mutation = withBotTurnMutation('app-a', async () => {
+      mutationEntered();
+      await finishMutation.promise;
+    });
+    await Promise.resolve();
+    expect(mutationEntered).not.toHaveBeenCalled();
+
+    const second = withBotTurnAdmission('app-a', () => { secondEntered(); });
+    await Promise.resolve();
+    expect(secondEntered).not.toHaveBeenCalled();
+
+    finishFirst.resolve();
+    await vi.waitFor(() => expect(mutationEntered).toHaveBeenCalledOnce());
+    expect(secondEntered).not.toHaveBeenCalled();
+
+    finishMutation.resolve();
+    await Promise.all([first, mutation, second]);
+    expect(secondEntered).toHaveBeenCalledOnce();
+  });
+
+  it('does not serialize an unrelated bot', async () => {
+    const finishMutation = deferred();
+    const mutation = withBotTurnMutation('app-a', () => finishMutation.promise);
+    const other = vi.fn();
+    await withBotTurnAdmission('app-b', () => other());
+    expect(other).toHaveBeenCalledOnce();
+    finishMutation.resolve();
+    await mutation;
+  });
+
+  it('keeps woken waiters on the canonical state for the next mutation', async () => {
+    const finishFirstMutation = deferred();
+    const finishQueuedAdmission = deferred();
+    const firstMutation = withBotTurnMutation('app-a', () => finishFirstMutation.promise);
+    const queuedEntered = vi.fn();
+    const queuedAdmission = withBotTurnAdmission('app-a', async () => {
+      queuedEntered();
+      await finishQueuedAdmission.promise;
+    });
+    await Promise.resolve();
+    expect(queuedEntered).not.toHaveBeenCalled();
+
+    finishFirstMutation.resolve();
+    await firstMutation;
+    await vi.waitFor(() => expect(queuedEntered).toHaveBeenCalledOnce());
+
+    const nextMutationEntered = vi.fn();
+    const nextMutation = withBotTurnMutation('app-a', () => nextMutationEntered());
+    await Promise.resolve();
+    expect(nextMutationEntered).not.toHaveBeenCalled();
+
+    finishQueuedAdmission.resolve();
+    await Promise.all([queuedAdmission, nextMutation]);
+    expect(nextMutationEntered).toHaveBeenCalledOnce();
+  });
+
+  it('lets a draining admitted handler enter a nested same-bot boundary', async () => {
+    const enterNested = deferred();
+    const outerEntered = vi.fn();
+    const nestedEntered = vi.fn();
+    const mutationEntered = vi.fn();
+    const outer = withBotTurnAdmission('app-a', async () => {
+      outerEntered();
+      await enterNested.promise;
+      await withBotTurnAdmission('app-a', () => nestedEntered());
+    });
+    await vi.waitFor(() => expect(outerEntered).toHaveBeenCalledOnce());
+
+    const mutation = withBotTurnMutation('app-a', () => mutationEntered());
+    await Promise.resolve();
+    expect(mutationEntered).not.toHaveBeenCalled();
+
+    enterNested.resolve();
+    await Promise.all([outer, mutation]);
+    expect(nestedEntered).toHaveBeenCalledOnce();
+    expect(mutationEntered).toHaveBeenCalledOnce();
+  });
+
+  it('revokes inherited reentrancy for a detached descendant after the outer lease ends', async () => {
+    const releaseDetached = deferred();
+    const finishMutation = deferred();
+    const detachedEntered = vi.fn();
+    let detached!: Promise<void>;
+
+    await withBotTurnAdmission('app-a', async () => {
+      detached = (async () => {
+        await releaseDetached.promise;
+        await withBotTurnAdmission('app-a', () => detachedEntered());
+      })();
+    });
+
+    const mutation = withBotTurnMutation('app-a', () => finishMutation.promise);
+    await Promise.resolve();
+    releaseDetached.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(detachedEntered).not.toHaveBeenCalled();
+
+    finishMutation.resolve();
+    await Promise.all([mutation, detached]);
+    expect(detachedEntered).toHaveBeenCalledOnce();
+  });
+
+  it('upgrades an admitted handler to a mutation without self-deadlock', async () => {
+    const order: string[] = [];
+    await withBotTurnAdmission('app-a', async () => {
+      order.push('admission');
+      await withBotTurnMutation('app-a', async () => {
+        order.push('mutation');
+        await withBotTurnAdmission('app-a', () => order.push('nested-admission'));
+        await withBotTurnMutation('app-a', () => order.push('nested-mutation'));
+      });
+      order.push('after');
+    });
+    expect(order).toEqual([
+      'admission',
+      'mutation',
+      'nested-admission',
+      'nested-mutation',
+      'after',
+    ]);
+  });
+
+  it('upgrades through an awaited nested admission without retaining an ancestor count', async () => {
+    const events: string[] = [];
+    await withBotTurnAdmission('app-a', async () => {
+      await withBotTurnAdmission('app-a', async () => {
+        await withBotTurnMutation('app-a', () => events.push('mutated'));
+      });
+      events.push('outer-finished');
+    });
+    expect(events).toEqual(['mutated', 'outer-finished']);
+  });
+
+  it('an upgraded mutation drains peer admissions and blocks later turns', async () => {
+    const letPeerFinish = deferred();
+    const letCloseFinish = deferred();
+    const startUpgrade = deferred();
+    const events: string[] = [];
+
+    const closer = withBotTurnAdmission('app-a', async () => {
+      events.push('close-admitted');
+      await startUpgrade.promise;
+      await withBotTurnMutation('app-a', async () => {
+        events.push('close-mutating');
+        await letCloseFinish.promise;
+      });
+      events.push('close-after');
+    });
+    const peer = withBotTurnAdmission('app-a', async () => {
+      events.push('peer-admitted');
+      await letPeerFinish.promise;
+      events.push('peer-finished');
+    });
+    await vi.waitFor(() => expect(events).toContain('peer-admitted'));
+
+    startUpgrade.resolve();
+    await Promise.resolve();
+    expect(events).not.toContain('close-mutating');
+
+    letPeerFinish.resolve();
+    await vi.waitFor(() => expect(events).toContain('close-mutating'));
+
+    const later = withBotTurnAdmission('app-a', () => events.push('later-admitted'));
+    await Promise.resolve();
+    expect(events).not.toContain('later-admitted');
+
+    letCloseFinish.resolve();
+    await Promise.all([closer, peer, later]);
+    expect(events.indexOf('peer-finished')).toBeLessThan(events.indexOf('close-mutating'));
+    expect(events.indexOf('close-mutating')).toBeLessThan(events.indexOf('close-after'));
+  });
+
+  it('revokes inherited mutation ownership for detached descendants', async () => {
+    const releaseDetached = deferred();
+    const holdNextMutation = deferred();
+    const detachedEntered = vi.fn();
+    let detached!: Promise<void>;
+
+    await withBotTurnMutation('app-a', async () => {
+      detached = (async () => {
+        await releaseDetached.promise;
+        await withBotTurnAdmission('app-a', () => detachedEntered());
+      })();
+    });
+
+    const nextMutation = withBotTurnMutation('app-a', () => holdNextMutation.promise);
+    await Promise.resolve();
+    releaseDetached.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(detachedEntered).not.toHaveBeenCalled();
+
+    holdNextMutation.resolve();
+    await Promise.all([nextMutation, detached]);
+    expect(detachedEntered).toHaveBeenCalledOnce();
+  });
+
+  it('runs a detached mutation only after its admission parent drains', async () => {
+    const releaseDetachedMutation = deferred();
+    const detachedEntered = vi.fn();
+    let detached!: Promise<void>;
+
+    await withBotTurnAdmission('app-a', () => {
+      detached = runDetachedBotTurnMutation('app-a', async () => {
+        detachedEntered();
+        await releaseDetachedMutation.promise;
+      });
+      expect(detachedEntered).not.toHaveBeenCalled();
+    });
+    await vi.waitFor(() => expect(detachedEntered).toHaveBeenCalledOnce());
+
+    releaseDetachedMutation.resolve();
+    await detached;
+
+    const laterMutation = vi.fn();
+    const laterAdmission = vi.fn();
+    await withBotTurnMutation('app-a', () => laterMutation());
+    await withBotTurnAdmission('app-a', () => laterAdmission());
+    expect(laterMutation).toHaveBeenCalledOnce();
+    expect(laterAdmission).toHaveBeenCalledOnce();
+  });
+
+  it('counts an explicit detached admission begun before its parent returns', async () => {
+    const releaseChild = deferred();
+    const childEntered = vi.fn();
+    let child!: Promise<void>;
+
+    await withBotTurnAdmission('app-a', () => {
+      child = runDetachedBotTurnAdmission('app-a', async () => {
+        childEntered();
+        await releaseChild.promise;
+      });
+    });
+    expect(childEntered).toHaveBeenCalledOnce();
+
+    const mutationEntered = vi.fn();
+    const mutation = withBotTurnMutation('app-a', () => mutationEntered());
+    await Promise.resolve();
+    expect(mutationEntered).not.toHaveBeenCalled();
+
+    releaseChild.resolve();
+    await Promise.all([child, mutation]);
+    expect(mutationEntered).toHaveBeenCalledOnce();
+  });
+
+  it('clears mutation context for an explicit detached mutation', async () => {
+    const releaseChild = deferred();
+    const childEntered = vi.fn();
+    let child!: Promise<void>;
+
+    const parent = withBotTurnMutation('app-a', () => {
+      child = runDetachedBotTurnMutation('app-a', async () => {
+        childEntered();
+        await releaseChild.promise;
+      });
+    });
+    await parent;
+    await vi.waitFor(() => expect(childEntered).toHaveBeenCalledOnce());
+    const admissionEntered = vi.fn();
+    const admission = withBotTurnAdmission('app-a', () => admissionEntered());
+    await Promise.resolve();
+    expect(admissionEntered).not.toHaveBeenCalled();
+
+    releaseChild.resolve();
+    await Promise.all([child, admission]);
+    expect(admissionEntered).toHaveBeenCalledOnce();
+  });
+
+  it('keeps an explicit detached admission behind its mutation parent', async () => {
+    const holdParent = deferred();
+    const detachedEntered = vi.fn();
+    let detached!: Promise<void>;
+    const parent = withBotTurnMutation('app-a', async () => {
+      detached = runDetachedBotTurnAdmission('app-a', () => detachedEntered());
+      await Promise.resolve();
+      expect(detachedEntered).not.toHaveBeenCalled();
+      await holdParent.promise;
+    });
+    await Promise.resolve();
+    holdParent.resolve();
+    await parent;
+    await detached;
+    expect(detachedEntered).toHaveBeenCalledOnce();
+  });
+
+  it('removes a bounded waiter on timeout so its action can never run later', async () => {
+    const releaseOwner = deferred();
+    const ownerEntered = vi.fn();
+    const owner = withBotTurnMutation('app-a', async () => {
+      ownerEntered();
+      await releaseOwner.promise;
+    });
+    await vi.waitFor(() => expect(ownerEntered).toHaveBeenCalledOnce());
+
+    const staleAction = vi.fn();
+    await expect(tryWithBotTurnMutation('app-a', 10, staleAction)).resolves.toEqual({
+      acquired: false,
+      reason: 'timeout',
+    });
+    releaseOwner.resolve();
+    await owner;
+    await new Promise(resolve => setTimeout(resolve, 20));
+    expect(staleAction).not.toHaveBeenCalled();
+
+    const later = vi.fn();
+    await expect(tryWithBotTurnMutation('app-a', 50, later)).resolves.toEqual({
+      acquired: true,
+      value: undefined,
+    });
+    expect(later).toHaveBeenCalledOnce();
+  });
+
+  it('rejects an overdue wake even when owner release runs before the timer callback', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const releaseOwner = deferred();
+    const ownerEntered = vi.fn();
+    const owner = withBotTurnMutation('app-a', async () => {
+      ownerEntered();
+      await releaseOwner.promise;
+    });
+    await Promise.resolve();
+    expect(ownerEntered).toHaveBeenCalledOnce();
+
+    const staleAction = vi.fn();
+    const bounded = tryWithBotTurnMutation('app-a', 10, staleAction);
+    await Promise.resolve();
+    // Advance wall time without running the overdue timer. Releasing the owner
+    // wakes the waiter first; the wake path itself must enforce the deadline.
+    vi.setSystemTime(1_020);
+    releaseOwner.resolve();
+    await owner;
+
+    await expect(bounded).resolves.toEqual({ acquired: false, reason: 'timeout' });
+    expect(staleAction).not.toHaveBeenCalled();
+    await vi.runAllTimersAsync();
+    expect(staleAction).not.toHaveBeenCalled();
+  });
+
+  it('rolls back a closed gate when admissions do not drain before the deadline', async () => {
+    const releaseAdmission = deferred();
+    const heldEntered = vi.fn();
+    const held = withBotTurnAdmission('app-a', async () => {
+      heldEntered();
+      await releaseAdmission.promise;
+    });
+    await vi.waitFor(() => expect(heldEntered).toHaveBeenCalledOnce());
+
+    const mutationAction = vi.fn();
+    const bounded = tryWithBotTurnMutation('app-a', 10, mutationAction);
+    const admittedAfterRollback = vi.fn();
+    const queuedAdmission = withBotTurnAdmission('app-a', admittedAfterRollback);
+
+    await expect(bounded).resolves.toEqual({ acquired: false, reason: 'timeout' });
+    await queuedAdmission;
+    expect(admittedAfterRollback).toHaveBeenCalledOnce();
+    expect(mutationAction).not.toHaveBeenCalled();
+
+    releaseAdmission.resolve();
+    await held;
+    await new Promise(resolve => setTimeout(resolve, 20));
+    expect(mutationAction).not.toHaveBeenCalled();
+  });
+});

--- a/test/bot-turn-mutation-gate.test.ts
+++ b/test/bot-turn-mutation-gate.test.ts
@@ -167,6 +167,194 @@ describe('per-bot turn mutation gate', () => {
     expect(events).toEqual(['mutated', 'outer-finished']);
   });
 
+  it('serializes concurrent mutations that share one admission lease', async () => {
+    const releaseFirst = deferred();
+    const firstEntered = deferred();
+    const events: string[] = [];
+    let activeMutations = 0;
+    let maxActiveMutations = 0;
+
+    const outer = withBotTurnAdmission('app-a', async () => {
+      await Promise.all([
+        withBotTurnMutation('app-a', async () => {
+          activeMutations++;
+          maxActiveMutations = Math.max(maxActiveMutations, activeMutations);
+          events.push('first-start');
+          firstEntered.resolve();
+          await releaseFirst.promise;
+          events.push('first-end');
+          activeMutations--;
+        }),
+        withBotTurnMutation('app-a', () => {
+          activeMutations++;
+          maxActiveMutations = Math.max(maxActiveMutations, activeMutations);
+          events.push('second');
+          activeMutations--;
+        }),
+      ]);
+      events.push('outer-done');
+    });
+
+    await firstEntered.promise;
+    expect(events).toEqual(['first-start']);
+    releaseFirst.resolve();
+    await outer;
+    expect(events).toEqual(['first-start', 'first-end', 'second', 'outer-done']);
+    expect(maxActiveMutations).toBe(1);
+
+    await withBotTurnAdmission('app-a', () => events.push('later-admission'));
+    await withBotTurnMutation('app-a', () => events.push('later-mutation'));
+    expect(events.slice(-2)).toEqual(['later-admission', 'later-mutation']);
+  });
+
+  it('lets a bounded sibling acquire after an earlier same-lease mutation', async () => {
+    const releaseFirst = deferred();
+    const firstEntered = deferred();
+    const boundedAction = vi.fn(() => 'bounded-value');
+
+    const outer = withBotTurnAdmission('app-a', async () => {
+      const first = withBotTurnMutation('app-a', async () => {
+        firstEntered.resolve();
+        await releaseFirst.promise;
+      });
+      const bounded = tryWithBotTurnMutation('app-a', 1_000, boundedAction);
+      const [, result] = await Promise.all([first, bounded]);
+      return result;
+    });
+
+    await firstEntered.promise;
+    expect(boundedAction).not.toHaveBeenCalled();
+    releaseFirst.resolve();
+
+    await expect(outer).resolves.toEqual({ acquired: true, value: 'bounded-value' });
+    expect(boundedAction).toHaveBeenCalledOnce();
+  });
+
+  it('times out a bounded same-lease sibling without running it later', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const releaseFirst = deferred();
+    const firstEntered = deferred();
+    const staleAction = vi.fn();
+    const thirdAction = vi.fn();
+
+    const outer = withBotTurnAdmission('app-a', async () => {
+      const first = withBotTurnMutation('app-a', async () => {
+        firstEntered.resolve();
+        await releaseFirst.promise;
+      });
+      const bounded = tryWithBotTurnMutation('app-a', 10, staleAction);
+      const third = withBotTurnMutation('app-a', thirdAction);
+      const [, result] = await Promise.all([first, bounded, third]);
+      return result;
+    });
+
+    await firstEntered.promise;
+    await vi.advanceTimersByTimeAsync(11);
+    expect(staleAction).not.toHaveBeenCalled();
+    expect(thirdAction).not.toHaveBeenCalled();
+    releaseFirst.resolve();
+
+    await expect(outer).resolves.toEqual({ acquired: false, reason: 'timeout' });
+    await vi.runAllTimersAsync();
+    expect(staleAction).not.toHaveBeenCalled();
+    expect(thirdAction).toHaveBeenCalledOnce();
+
+    const later = vi.fn();
+    await withBotTurnMutation('app-a', later);
+    expect(later).toHaveBeenCalledOnce();
+  });
+
+  it('rejects an overdue same-lease queue handoff before its timer callback', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const releaseFirst = deferred();
+    const firstEntered = deferred();
+    const staleAction = vi.fn();
+
+    const outer = withBotTurnAdmission('app-a', async () => {
+      const first = withBotTurnMutation('app-a', async () => {
+        firstEntered.resolve();
+        await releaseFirst.promise;
+      });
+      const bounded = tryWithBotTurnMutation('app-a', 10, staleAction);
+      const [, result] = await Promise.all([first, bounded]);
+      return result;
+    });
+
+    await firstEntered.promise;
+    // Move wall time past the deadline without running the timer. Direct queue
+    // handoff wins this race, but the expired owner must only release its slot.
+    vi.setSystemTime(1_020);
+    releaseFirst.resolve();
+
+    await expect(outer).resolves.toEqual({ acquired: false, reason: 'timeout' });
+    expect(staleAction).not.toHaveBeenCalled();
+    await vi.runAllTimersAsync();
+    expect(staleAction).not.toHaveBeenCalled();
+
+    const later = vi.fn();
+    await withBotTurnMutation('app-a', later);
+    expect(later).toHaveBeenCalledOnce();
+  });
+
+  it.each(['first', 'second'] as const)(
+    'continues a same-lease mutation queue when the %s action throws',
+    async failingAction => {
+      const events: string[] = [];
+      const error = new Error(`${failingAction}-failed`);
+
+      const results = await withBotTurnAdmission('app-a', () => Promise.allSettled([
+        withBotTurnMutation('app-a', () => {
+          events.push('first');
+          if (failingAction === 'first') throw error;
+          return 'first-value';
+        }),
+        withBotTurnMutation('app-a', () => {
+          events.push('second');
+          if (failingAction === 'second') throw error;
+          return 'second-value';
+        }),
+      ]));
+
+      expect(events).toEqual(['first', 'second']);
+      expect(results[0].status).toBe(failingAction === 'first' ? 'rejected' : 'fulfilled');
+      expect(results[1].status).toBe(failingAction === 'second' ? 'rejected' : 'fulfilled');
+
+      const recovered = vi.fn();
+      await withBotTurnAdmission('app-a', recovered);
+      await withBotTurnMutation('app-a', recovered);
+      expect(recovered).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it('does not restore a ghost admission when a queued upgrade outlives its owner', async () => {
+    const releaseFirst = deferred();
+    const firstEntered = deferred();
+    const events: string[] = [];
+    let first!: Promise<void>;
+    let second!: Promise<void>;
+
+    await withBotTurnAdmission('app-a', () => {
+      first = withBotTurnMutation('app-a', async () => {
+        events.push('first-start');
+        firstEntered.resolve();
+        await releaseFirst.promise;
+        events.push('first-end');
+      });
+      second = withBotTurnMutation('app-a', () => events.push('second'));
+    });
+
+    await firstEntered.promise;
+    releaseFirst.resolve();
+    await Promise.all([first, second]);
+    expect(events).toEqual(['first-start', 'first-end', 'second']);
+
+    const laterMutation = vi.fn();
+    await withBotTurnMutation('app-a', laterMutation);
+    expect(laterMutation).toHaveBeenCalledOnce();
+  });
+
   it('an upgraded mutation drains peer admissions and blocks later turns', async () => {
     const letPeerFinish = deferred();
     const letCloseFinish = deferred();


### PR DESCRIPTION
## 背景

Codex App 生命周期修复与 RIFF 安全关停都需要同一个机器人维度的并发边界：普通 turn 可以并发进入，替换 worker generation 或关停等 mutation 必须先阻止新 turn、等待已进入 turn 排空，再独占执行。现有 master 没有可复用的原语。

## 改动

- 新增每机器人 admission/mutation gate。
- 支持 admission 内升级为 mutation，避免显式关闭路径自锁。
- 支持带绝对截止时间的可取消 mutation 获取；超时 waiter 会从队列移除，动作不会在调用方返回后迟到执行。
- 支持 detached admission/mutation，防止 AsyncLocalStorage 子任务冒用已结束 lease。
- 本 PR 只增加基础模块与测试，不接入运行时路径；后续 Codex App 核心与 RIFF PR 共用该模块。

## 影响范围

纯新增基础模块；当前运行时行为不变。按 larkAppId 隔离，不影响其它机器人。

## 验证

- `git diff --check`：通过
- `pnpm build`：通过
- `pnpm exec vitest run test/bot-turn-mutation-gate.test.ts`：1 个文件、16 项测试全部通过

## 未验证

本 PR 尚未接入 daemon/worker，因此无需 live daemon 或 PM2 验证；运行时接入将在后续独立 PR 中验证。