### PR TITLE
fix(claude): 加固跨目录恢复的软链边界

### DIFF
--- a/src/adapters/cli/claude-code.ts
+++ b/src/adapters/cli/claude-code.ts
@@ -1,6 +1,24 @@
-import { copyFileSync, existsSync, mkdirSync, statSync, openSync, readSync, closeSync, readFileSync, readdirSync, readlinkSync, realpathSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
+import {
+  closeSync,
+  constants as fsConstants,
+  existsSync,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  readlinkSync,
+  realpathSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeSync,
+} from 'node:fs';
 import { homedir } from 'node:os';
-import { basename, dirname, join } from 'node:path';
+import { basename, dirname, isAbsolute, join, relative, sep } from 'node:path';
 import { resolveCommand } from './registry.js';
 import { sessionReadyHookCommand } from '../hook-command.js';
 import type { CliAdapter, CliId, PtyHandle } from './types.js';
@@ -86,6 +104,174 @@ export interface ClaudeResumeTargetSyncResult {
   copied: boolean;
 }
 
+const SESSION_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const RESUME_COPY_BUFFER_BYTES = 64 * 1024;
+
+interface ClaudeResumeCandidate {
+  path: string;
+  mtimeMs: number;
+  ctimeMs: number;
+  size: number;
+  dev: number;
+  ino: number;
+}
+
+function isStrictDescendant(root: string, path: string): boolean {
+  const rel = relative(root, path);
+  return rel.length > 0 && rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel);
+}
+
+function lstatIfPresent(path: string): import('node:fs').Stats | undefined {
+  try {
+    return lstatSync(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw error;
+  }
+}
+
+function assertSafeResumeTargetLeaf(targetPath: string, projectsRootReal: string): void {
+  const targetStats = lstatIfPresent(targetPath);
+  if (!targetStats) return;
+  if (targetStats.isSymbolicLink() || !targetStats.isFile()) {
+    throw new Error(`unsafe Claude resume target (expected a regular file): ${targetPath}`);
+  }
+  const targetReal = realpathSync(targetPath);
+  if (!isStrictDescendant(projectsRootReal, targetReal)) {
+    throw new Error(`unsafe Claude resume target outside projects root: ${targetPath}`);
+  }
+}
+
+function writeAllSync(fd: number, buffer: Buffer, length: number): void {
+  let offset = 0;
+  while (offset < length) {
+    const written = writeSync(fd, buffer, offset, length - offset);
+    if (written <= 0) throw new Error('short write while syncing Claude resume transcript');
+    offset += written;
+  }
+}
+
+/**
+ * Copy a scanned regular source into a same-directory private temp file, then
+ * atomically replace the target leaf. Source and temp descriptors are pinned
+ * with O_NOFOLLOW + inode checks so a child-planted symlink cannot redirect
+ * the privileged worker between scan and copy.
+ */
+function atomicCopyClaudeResumeTranscript(
+  source: ClaudeResumeCandidate,
+  targetPath: string,
+  projectsRootReal: string,
+): void {
+  const targetDir = dirname(targetPath);
+  mkdirSync(targetDir, { recursive: true });
+  const targetDirStats = lstatSync(targetDir);
+  if (targetDirStats.isSymbolicLink() || !targetDirStats.isDirectory()) {
+    throw new Error(`unsafe Claude resume target directory: ${targetDir}`);
+  }
+  const targetDirReal = realpathSync(targetDir);
+  if (!isStrictDescendant(projectsRootReal, targetDirReal)) {
+    throw new Error(`unsafe Claude resume target directory outside projects root: ${targetDir}`);
+  }
+
+  const resolvedTargetPath = join(targetDirReal, basename(targetPath));
+  assertSafeResumeTargetLeaf(resolvedTargetPath, projectsRootReal);
+
+  const tempPath = join(
+    targetDirReal,
+    `.${basename(targetPath)}.${process.pid}.${randomBytes(8).toString('hex')}.tmp`,
+  );
+  const noFollow = process.platform === 'win32' ? 0 : (fsConstants.O_NOFOLLOW ?? 0);
+  let sourceFd: number | undefined;
+  let tempFd: number | undefined;
+  try {
+    const rescanned = lstatSync(source.path);
+    if (
+      rescanned.isSymbolicLink()
+      || !rescanned.isFile()
+      || rescanned.dev !== source.dev
+      || rescanned.ino !== source.ino
+      || rescanned.size !== source.size
+      || rescanned.mtimeMs !== source.mtimeMs
+      || rescanned.ctimeMs !== source.ctimeMs
+    ) {
+      throw new Error(`unsafe Claude resume source changed after scan: ${source.path}`);
+    }
+    const sourceReal = realpathSync(source.path);
+    if (!isStrictDescendant(projectsRootReal, sourceReal)) {
+      throw new Error(`unsafe Claude resume source outside projects root: ${source.path}`);
+    }
+
+    sourceFd = openSync(source.path, fsConstants.O_RDONLY | noFollow);
+    const openedSource = fstatSync(sourceFd);
+    if (
+      !openedSource.isFile()
+      || openedSource.dev !== source.dev
+      || openedSource.ino !== source.ino
+    ) {
+      throw new Error(`unsafe Claude resume source raced while opening: ${source.path}`);
+    }
+
+    tempFd = openSync(
+      tempPath,
+      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | noFollow,
+      0o600,
+    );
+    const buffer = Buffer.allocUnsafe(RESUME_COPY_BUFFER_BYTES);
+    let copiedBytes = 0;
+    while (true) {
+      const count = readSync(sourceFd, buffer, 0, buffer.length, null);
+      if (count === 0) break;
+      writeAllSync(tempFd, buffer, count);
+      copiedBytes += count;
+    }
+
+    const sourceAfterCopy = fstatSync(sourceFd);
+    if (
+      sourceAfterCopy.dev !== openedSource.dev
+      || sourceAfterCopy.ino !== openedSource.ino
+      || sourceAfterCopy.size !== openedSource.size
+      || sourceAfterCopy.mtimeMs !== openedSource.mtimeMs
+      || sourceAfterCopy.ctimeMs !== openedSource.ctimeMs
+      || copiedBytes !== openedSource.size
+    ) {
+      throw new Error(`Claude resume source changed while copying: ${source.path}`);
+    }
+    const tempStats = fstatSync(tempFd);
+    if (!tempStats.isFile() || tempStats.nlink !== 1 || tempStats.size !== copiedBytes) {
+      throw new Error(`unsafe Claude resume temporary copy: ${tempPath}`);
+    }
+
+    closeSync(sourceFd);
+    sourceFd = undefined;
+    closeSync(tempFd);
+    tempFd = undefined;
+
+    // Re-check immediately before rename. rename replaces a raced leaf symlink
+    // itself instead of following it, so the destination can never write
+    // through to the symlink target.
+    assertSafeResumeTargetLeaf(resolvedTargetPath, projectsRootReal);
+    const tempPathStats = lstatSync(tempPath);
+    if (
+      tempPathStats.isSymbolicLink()
+      || !tempPathStats.isFile()
+      || tempPathStats.dev !== tempStats.dev
+      || tempPathStats.ino !== tempStats.ino
+    ) {
+      throw new Error(`unsafe Claude resume temporary path changed before rename: ${tempPath}`);
+    }
+    renameSync(tempPath, resolvedTargetPath);
+  } catch (error) {
+    if (sourceFd !== undefined) {
+      try { closeSync(sourceFd); } catch { /* best effort */ }
+    }
+    if (tempFd !== undefined) {
+      try { closeSync(tempFd); } catch { /* best effort */ }
+    }
+    try { unlinkSync(tempPath); } catch { /* absent or already renamed */ }
+    throw error;
+  }
+}
+
 /**
  * Claude stores a session transcript under the hash of the cwd where that
  * session last ran. Botmux's `/cd` deliberately keeps the logical session id,
@@ -98,24 +284,65 @@ export interface ClaudeResumeTargetSyncResult {
  * directory. Copies are retained in older project directories because they are
  * useful native Claude history; choosing the newest candidate on every resume
  * prevents a later `/cd` back to an earlier cwd from reviving a stale branch.
+ *
+ * The Claude data root is writable by the sandboxed CLI while this helper runs
+ * in the unsandboxed worker. Treat every scanned leaf as hostile: UUID-gate the
+ * filename, reject symlink/non-regular source and target entries, enforce
+ * realpath containment, and atomically replace the target via a private temp
+ * inode so copy cannot read or write through a child-planted symlink.
  */
 export function syncClaudeResumeTargetToCwd(
   sessionId: string,
   cwd: string,
   dataDir: string = DEFAULT_CLAUDE_DATA_DIR,
 ): ClaudeResumeTargetSyncResult {
+  if (!SESSION_UUID_RE.test(sessionId)) {
+    throw new Error(`invalid Claude resume session id: ${sessionId}`);
+  }
   const targetPath = claudeJsonlPathForSession(sessionId, cwd, dataDir);
   const projectsDir = join(dataDir, 'projects');
   if (!existsSync(projectsDir)) return { targetPath, copied: false };
 
-  const candidates: Array<{ path: string; mtimeMs: number; size: number }> = [];
+  const dataDirStats = lstatSync(dataDir);
+  if (dataDirStats.isSymbolicLink() || !dataDirStats.isDirectory()) {
+    throw new Error(`unsafe Claude data root: ${dataDir}`);
+  }
+  const dataRootReal = realpathSync(dataDir);
+  const projectsDirStats = lstatSync(projectsDir);
+  if (projectsDirStats.isSymbolicLink() || !projectsDirStats.isDirectory()) {
+    throw new Error(`unsafe Claude projects root: ${projectsDir}`);
+  }
+  const projectsRootReal = realpathSync(projectsDir);
+  if (dirname(projectsRootReal) !== dataRootReal) {
+    throw new Error(`unsafe Claude projects root outside data root: ${projectsDir}`);
+  }
+  assertSafeResumeTargetLeaf(targetPath, projectsRootReal);
+
+  const candidates: ClaudeResumeCandidate[] = [];
   for (const entry of readdirSync(projectsDir, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
-    const path = join(projectsDir, entry.name, `${sessionId}.jsonl`);
-    if (!existsSync(path)) continue;
+    const bucketDir = join(projectsDir, entry.name);
+    let bucketReal: string;
     try {
-      const stat = statSync(path);
-      if (stat.isFile()) candidates.push({ path, mtimeMs: stat.mtimeMs, size: stat.size });
+      const bucketStats = lstatSync(bucketDir);
+      if (bucketStats.isSymbolicLink() || !bucketStats.isDirectory()) continue;
+      bucketReal = realpathSync(bucketDir);
+      if (!isStrictDescendant(projectsRootReal, bucketReal)) continue;
+    } catch { continue; }
+    const path = join(projectsDir, entry.name, `${sessionId}.jsonl`);
+    try {
+      const stat = lstatSync(path);
+      if (stat.isSymbolicLink() || !stat.isFile()) continue;
+      const candidateReal = realpathSync(path);
+      if (!isStrictDescendant(projectsRootReal, candidateReal)) continue;
+      candidates.push({
+        path,
+        mtimeMs: stat.mtimeMs,
+        ctimeMs: stat.ctimeMs,
+        size: stat.size,
+        dev: stat.dev,
+        ino: stat.ino,
+      });
     } catch { /* candidate disappeared while scanning */ }
   }
   if (candidates.length === 0) return { targetPath, copied: false };
@@ -124,8 +351,7 @@ export function syncClaudeResumeTargetToCwd(
   const newest = candidates[0];
   if (newest.path === targetPath) return { targetPath, sourcePath: newest.path, copied: false };
 
-  mkdirSync(dirname(targetPath), { recursive: true });
-  copyFileSync(newest.path, targetPath);
+  atomicCopyClaudeResumeTranscript(newest, targetPath, projectsRootReal);
   return { targetPath, sourcePath: newest.path, copied: true };
 }
 
@@ -183,8 +409,6 @@ function makeSubmitFingerprint(content: string, len = 30): string | undefined {
   const collapsed = normaliseForFingerprint(content);
   return collapsed.length > 0 ? collapsed.substring(0, len) : undefined;
 }
-
-const SESSION_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /** Returns the absolute path to Claude Code's per-process session state file.
  *  Claude writes `{pid, sessionId, cwd, procStart, status, updatedAt, ...}`

--- a/test/claude-code-cwd.test.ts
+++ b/test/claude-code-cwd.test.ts
@@ -12,7 +12,19 @@
  * Run:  pnpm vitest run test/claude-code-cwd.test.ts
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, mkdirSync, readFileSync, symlinkSync, rmSync, realpathSync, utimesSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
 import { join } from 'node:path';
 import { claudeJsonlPathForSession, syncClaudeResumeTargetToCwd } from '../src/adapters/cli/claude-code.js';
@@ -79,7 +91,8 @@ describe('syncClaudeResumeTargetToCwd', () => {
     mkdirSync(newCwd);
     const source = claudeJsonlPathForSession(SID, oldCwd, dataDir);
     mkdirSync(join(source, '..'), { recursive: true });
-    writeFileSync(source, '{"turn":"old-context"}\n');
+    const content = `${'{"turn":"old-context"}\n'.repeat(8_000)}`;
+    writeFileSync(source, content);
 
     const result = syncClaudeResumeTargetToCwd(SID, newCwd, dataDir);
 
@@ -88,7 +101,7 @@ describe('syncClaudeResumeTargetToCwd', () => {
       sourcePath: source,
       copied: true,
     });
-    expect(readFileSync(result.targetPath, 'utf8')).toBe('{"turn":"old-context"}\n');
+    expect(readFileSync(result.targetPath, 'utf8')).toBe(content);
   });
 
   it('refreshes a stale target from the newest cwd copy', () => {
@@ -112,6 +125,8 @@ describe('syncClaudeResumeTargetToCwd', () => {
     expect(result.copied).toBe(true);
     expect(result.sourcePath).toBe(source);
     expect(readFileSync(target, 'utf8')).toBe('newest-context');
+    expect(lstatSync(target).isFile()).toBe(true);
+    expect(readdirSync(join(target, '..')).filter(name => name.endsWith('.tmp'))).toEqual([]);
   });
 
   it('keeps the target untouched when it is already the newest copy', () => {
@@ -134,5 +149,87 @@ describe('syncClaudeResumeTargetToCwd', () => {
 
     expect(result).toEqual({ targetPath: target, sourcePath: target, copied: false });
     expect(readFileSync(target, 'utf8')).toBe('current-context');
+  });
+
+  it('拒绝跟随 sibling 桶里的 source 软链读取 dataDir 外文件', () => {
+    const dataDir = join(tmpRoot, 'claude-data');
+    const newCwd = join(tmpRoot, 'new-project');
+    mkdirSync(newCwd);
+    const outside = join(tmpRoot, 'outside-secret.jsonl');
+    writeFileSync(outside, 'host-secret\n');
+    const hostileBucket = join(dataDir, 'projects', 'hostile-bucket');
+    mkdirSync(hostileBucket, { recursive: true });
+    symlinkSync(outside, join(hostileBucket, `${SID}.jsonl`));
+
+    const result = syncClaudeResumeTargetToCwd(SID, newCwd, dataDir);
+
+    expect(result).toEqual({
+      targetPath: claudeJsonlPathForSession(SID, newCwd, dataDir),
+      copied: false,
+    });
+    expect(existsSync(result.targetPath)).toBe(false);
+    expect(readFileSync(outside, 'utf8')).toBe('host-secret\n');
+  });
+
+  it('拒绝 target 软链，避免把 transcript 写穿到 dataDir 外文件', () => {
+    const dataDir = join(tmpRoot, 'claude-data');
+    const oldCwd = join(tmpRoot, 'old-project');
+    const newCwd = join(tmpRoot, 'new-project');
+    mkdirSync(oldCwd);
+    mkdirSync(newCwd);
+    const source = claudeJsonlPathForSession(SID, oldCwd, dataDir);
+    const target = claudeJsonlPathForSession(SID, newCwd, dataDir);
+    mkdirSync(join(source, '..'), { recursive: true });
+    mkdirSync(join(target, '..'), { recursive: true });
+    const outside = join(tmpRoot, 'outside-config.json');
+    writeFileSync(outside, 'must-not-change\n');
+    writeFileSync(source, 'transcript\n');
+    const now = Date.now() / 1000;
+    utimesSync(outside, now - 60, now - 60);
+    utimesSync(source, now, now);
+    symlinkSync(outside, target);
+
+    expect(() => syncClaudeResumeTargetToCwd(SID, newCwd, dataDir))
+      .toThrow(/unsafe Claude resume target/);
+    expect(lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(readFileSync(outside, 'utf8')).toBe('must-not-change\n');
+  });
+
+  it('拒绝 dangling target 软链，不在 dataDir 外创建目标文件', () => {
+    const dataDir = join(tmpRoot, 'claude-data');
+    const oldCwd = join(tmpRoot, 'old-project');
+    const newCwd = join(tmpRoot, 'new-project');
+    mkdirSync(oldCwd);
+    mkdirSync(newCwd);
+    const source = claudeJsonlPathForSession(SID, oldCwd, dataDir);
+    const target = claudeJsonlPathForSession(SID, newCwd, dataDir);
+    mkdirSync(join(source, '..'), { recursive: true });
+    mkdirSync(join(target, '..'), { recursive: true });
+    writeFileSync(source, 'transcript\n');
+    const outside = join(tmpRoot, 'outside-created-by-write-through.jsonl');
+    symlinkSync(outside, target);
+
+    expect(() => syncClaudeResumeTargetToCwd(SID, newCwd, dataDir))
+      .toThrow(/unsafe Claude resume target/);
+    expect(existsSync(outside)).toBe(false);
+  });
+
+  it('拒绝整个 projects 根目录被替换为指向 dataDir 外的软链', () => {
+    const dataDir = join(tmpRoot, 'claude-data');
+    const outsideProjects = join(tmpRoot, 'outside-projects');
+    mkdirSync(dataDir);
+    mkdirSync(outsideProjects);
+    symlinkSync(outsideProjects, join(dataDir, 'projects'));
+
+    expect(() => syncClaudeResumeTargetToCwd(SID, realDir, dataDir))
+      .toThrow(/unsafe Claude projects root/);
+  });
+
+  it('拒绝非 UUID session id，避免把路径片段插入跨桶扫描', () => {
+    const dataDir = join(tmpRoot, 'claude-data');
+    mkdirSync(join(dataDir, 'projects'), { recursive: true });
+
+    expect(() => syncClaudeResumeTargetToCwd('../../outside', realDir, dataDir))
+      .toThrow(/invalid Claude resume session id/);
   });
 });


### PR DESCRIPTION
## 背景

`syncClaudeResumeTargetToCwd` 在 Claude-family 冷恢复、且 cwd 已变化时，会从 sibling project 桶挑最新 `<session-id>.jsonl` 并复制到当前 cwd 桶。沙盒内 CLI 可以写自己的 `claudeDataDir`，而同步函数运行在沙盒外 worker；原实现使用 `statSync + copyFileSync`，两端都会跟随软链：

- source 是软链时，会把 `claudeDataDir` 外文件读入 transcript（读穿）；
- target 是软链时，会把 transcript 覆写到 `claudeDataDir` 外文件（写穿）。

这是复审已关闭的 #506 时发现的 master 独立问题；#506 的 cwd 恢复主问题已由 master 现有同步逻辑解决，本 PR 只移植其安全增量，不引入第二套 rescue/move 逻辑。

## 漏洞链路图

```mermaid
flowchart LR
  subgraph Sandbox["沙盒内：Claude dataDir 可写"]
    S["旧 cwd 桶<br/>source 软链"]
    T["新 cwd 桶<br/>target 软链"]
  end

  H1["dataDir 外文件<br/>secret"]
  H2["dataDir 外文件<br/>config"]
  W["沙盒外 worker<br/>syncClaudeResumeTargetToCwd"]
  C["目标 transcript"]

  H1 -. "软链指向" .-> S
  S -->|"stat/copy 跟随：读穿"| W
  W -->|"把外部内容复制进桶"| C
  W -->|"copy 跟随：写穿"| T
  T -. "软链指向并覆写" .-> H2
```

## 修复方案

```mermaid
flowchart LR
  I["session id / 候选路径"] --> U["UUID gate"]
  U --> L["lstat：拒绝软链和非普通文件"]
  L --> R["realpath：限制在 projects root"]
  R --> O["O_NOFOLLOW 打开并核对 inode"]
  O --> P["同目录私有临时文件<br/>0600 + O_EXCL"]
  P --> A["rename 原子替换 target leaf"]
  L -->|"不安全"| X["拒绝同步；不碰外部文件"]
  R -->|"越界"| X
```

具体包括：

- 对 session id 做 UUID gate，阻断路径片段进入跨桶扫描；
- source、target、projects root 和桶目录全部改为 `lstat`/类型检查，并做 realpath 包含性验证；
- POSIX 上以 `O_NOFOLLOW` 打开 source，结合 `dev/ino/size/mtime/ctime` 校验扫描、打开、复制期间的对象一致性；
- 先写同目录 `0600 + O_EXCL` 私有临时 inode，完整校验后 `rename` 原子替换 target leaf；即使 target leaf 在末刻被换成软链，rename 也替换软链本身，不会写穿其指向；
- 保持 master 既有 COPY/保留旧桶语义，不加入另一套 MOVE/rescue；sidecar 迁移属于独立功能增量，不和本安全修复捆绑。

## 影响面

- **模块 / CLI**：只修改 `claude-code` 适配器的 transcript 同步 helper；影响所有显式提供 `claudeDataDir` 的 Claude-family 适配器（Claude Code、Seed/Genius 等）。其他 CLI 不走此路径。
- **会话路径**：只在 `resume && !willReattachPersistent && claudeDataDir` 的冷恢复路径触发；持久 pane 重连、全新会话、riff 远端会话不受影响。
- **后端 / 沙盒**：PTY/Tmux 最终复用同一 worker gate；重点封住“沙盒内可写 dataDir、沙盒外 worker 执行同步”的权限边界。非沙盒路径也获得相同防护。
- **平台**：Linux/macOS 使用 `O_NOFOLLOW`；Windows 保留兼容分支，并仍有 lstat、realpath、inode 与原子替换校验。daemon 生产路径（Linux）已编译和测试。
- **兼容行为**：普通 transcript 仍 COPY 到新 cwd，旧桶仍保留；直接把 `dataDir` 或 `projects` 根本身做成软链的配置会在冷同步时 fail closed，由后续既有 resume probe/fallback 决定是否恢复。

## 实际验证

- `pnpm build`：通过
- `pnpm exec vitest run test/command-handler.test.ts test/cli-adapters.test.ts test/seed-adapter.test.ts test/claude-code-cwd.test.ts`：4 files / **525 tests passed**
  - 覆盖正常跨 cwd 多 buffer copy、旧 target 刷新、最新 target 不动；
  - 新增 source 软链读穿、target 软链写穿、dangling target、projects root 软链、非 UUID 拒绝；
  - 验证 target 为普通文件且无临时文件残留。
- `pnpm test`：**10651 passed / 5 skipped / 4 failed**；4 个失败均在本 PR 未触及的 fs-policy root-mode 与 scheduler 时区断言。对精确 `origin/master@e13ec929` 的干净 worktree 复跑对应 3 个文件，得到相同 **4 failures**，确认为基线/环境失败。
- `pnpm daemon:restart`：成功，全部进程恢复 online。
