### PR TITLE
docs(readme): 按骨架重写 README（zh+en，精简 + registry 事实源 CLI 清单）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -36,7 +36,7 @@ A daemon watches Lark messages and spawns an isolated session process for each n
 
 ## 5-Minute Setup
 
-> About 5 minutes: a single Lark QR scan in `botmux setup` creates the app, configures all permissions, and publishes a version in one flow (`--no-open-platform-auto` skips the automation for manual app creation).
+> About 5 minutes: a single Lark QR scan in `botmux setup` creates the app, configures all permissions, and publishes a version in one flow (add `--no-open-platform-auto` to only create the app and skip the permission + publish automation, which you then complete manually; creating the app manually / pasting credentials is a separate option inside setup).
 
 ```bash
 npm install -g botmux        # requires Node >= 22
@@ -56,7 +56,7 @@ Then DM the bot, or run `botmux dashboard` to create a group, and start chatting
 - **[Scheduled tasks](https://deepcoldy.github.io/botmux/en/schedule) & [external triggers](https://deepcoldy.github.io/botmux/en/webhook)** — configure recurring tasks in natural language (alert analysis / group summaries); trigger programmatically from external systems via [Webhook](https://deepcoldy.github.io/botmux/en/webhook) or the [task-trigger API](https://deepcoldy.github.io/botmux/en/api-task-trigger).
 - **[On-call mode](https://deepcoldy.github.io/botmux/en/oncall) & [voice summary](https://deepcoldy.github.io/botmux/en/voice)** — pull it into an on-call group and any member's @ triggers a probe in the project dir; once TTS is configured, each card footer gains a 🔊 voice-summary button that makes the model "speak plainly".
 
-More: [Roles & teams](https://deepcoldy.github.io/botmux/en/roles) · [File sandbox](https://deepcoldy.github.io/botmux/en/sandbox) · [Dashboard](https://deepcoldy.github.io/botmux/en/dashboard) · [tmux persistence](https://deepcoldy.github.io/botmux/en/tmux) · [VC meeting agent](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg).
+More: [Roles & teams](https://deepcoldy.github.io/botmux/en/roles) · [File sandbox](https://deepcoldy.github.io/botmux/en/sandbox) · [Dashboard](https://deepcoldy.github.io/botmux/en/dashboard) · [tmux persistence](https://deepcoldy.github.io/botmux/en/tmux) · [VC meeting agent (showcase)](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg).
 
 ## Supported CLIs & Agents
 
@@ -64,30 +64,29 @@ Switch with `cliId` in `bots.json`. **20+ adapters**, spanning local CLIs (proce
 
 `claude-code` · `codex` · `gemini` · `cursor` · `opencode` · `antigravity` · `copilot` · `grok` · `kimi` · `kiro-cli` · `aiden` · `coco` (TRAE) · `hermes` · `mira` · `riff` (cloud agent) …
 
-The full list and integration methods (including wrapper / gateway setups) are authoritative in [CLI Adapters](https://deepcoldy.github.io/botmux/en/adapters).
+The current full set of `cliId`s is authoritative in [`src/adapters/cli/registry.ts`](https://github.com/deepcoldy/botmux/blob/master/src/adapters/cli/registry.ts); per-CLI config and wrapper / gateway setups are in [CLI Adapters](https://deepcoldy.github.io/botmux/en/adapters).
 
 ## Design Philosophy: Bridge the CLI Directly, No SDK Wrapper
 
-botmux doesn't reimplement memory, context management, tool calls, or permission systems — the CLIs iterate on all of that themselves. botmux bridges the complete CLI process and rides that evolution: **every CLI upgrade benefits botmux with zero adaptation**. You keep talking in plain language; the daemon wraps context into structured prompts behind the scenes before feeding the CLI.
+botmux doesn't reimplement memory, context management, tool calls, or permission systems — **most native CLI capabilities don't need reimplementing, and CLI upgrades usually benefit botmux directly** (when interfaces / params / output formats / resume semantics change, an adapter may still need to catch up). You keep talking in plain language; the daemon wraps context into structured prompts behind the scenes before feeding the CLI. An Agent-SDK-based approach is the inverse: capabilities depend on what the SDK exposes and on your own integration.
 
-Compared with approaches that rebuild everything on an Agent SDK:
+The table below compares only **verifiable integration boundaries** — it does not claim what other approaches "necessarily lack":
 
-| Dimension | botmux | Agent-SDK-based approach |
+| Integration boundary | botmux | Agent-SDK-based approach |
 |------|--------|--------------------------|
-| Architecture | Bridges the complete CLI process | Rebuilt on an SDK |
-| CLI capabilities | Full runtime (hooks / memory / plan mode / MCP / `/` commands) | A subset of the SDK API; missing features hand-built |
-| CLI upgrades | Benefit automatically, zero adaptation | Must track SDK version changes |
-| Memory / context | Reuses the CLI's built-in, improves as the CLI iterates | Must be self-built, duplicating native CLI capabilities |
-| Multi-CLI | 20+ CLIs / agents, switch in one line | Usually bound to a single SDK |
-| Multi-bot | Multi-bot @mention routing in one group | Usually single-bot |
-| Direct terminal | `tmux attach` into the real process, same as local dev | Usually can't operate the underlying terminal |
+| What's bridged | The full CLI process (its built-in hooks / memory / plan mode / MCP / `/` commands) | Whatever the SDK exposes |
+| CLI upgrades | Mostly benefit directly; adapter catches up when interfaces / resume change | Depends on SDK version and integration |
+| Memory / context | Reuses the CLI's built-in | Depends on the SDK / self-built |
+| Multi-CLI / agent | 20+ adapters, switch in one line | Depends on SDK coverage |
+| Multi-bot | Multi-bot @mention routing in one group | Depends on the implementation |
+| Direct terminal | Local CLIs can `tmux attach` into the real process | Depends on the implementation |
 
 ## Docs · Community · Contributing
 
 - 📖 **Full docs** (commands / config / best practices / troubleshooting): **<https://deepcoldy.github.io/botmux/en/>**
 - ✨ **Showcase** (illustrated + video): [*Create a really useful Feishu assistant in 5 minutes*](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg)
 - ❓ **FAQ / troubleshooting**: [FAQ](https://deepcoldy.github.io/botmux/en/faq) · [Common Pitfalls](https://deepcoldy.github.io/botmux/en/pitfalls)
-- 💬 **Community**: find the internal / external "Botmux" chat-group cards at the bottom of the [showcase doc](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg).
+- 💬 **Community**: the [About & Resources](https://deepcoldy.github.io/botmux/en/about) page has QR entries to join the internal / external "Botmux" chat groups.
 - 🤝 **Contributing**: issues / PRs welcome. To add an adapter, see [CLI Adapters](https://deepcoldy.github.io/botmux/en/adapters).
 - 📄 **License**: [MIT](LICENSE)
 

--- a/README.en.md
+++ b/README.en.md
@@ -1,458 +1,93 @@
 # botmux
 
 <p align="center">
-  <img src="cover.svg" alt="botmux cover" width="800">
+  <img src="cover.svg" alt="botmux" width="760">
 </p>
 
 <p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License MIT"></a>
-  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg" alt="Node.js >= 22">
-  <a href="https://www.npmjs.com/package/botmux"><img src="https://img.shields.io/npm/v/botmux.svg" alt="npm version"></a>
-  <a href="https://github.com/deepcoldy/botmux"><img src="https://img.shields.io/github/stars/deepcoldy/botmux?style=social" alt="GitHub Stars"></a>
+  <a href="https://www.npmjs.com/package/botmux"><img src="https://img.shields.io/npm/v/botmux.svg" alt="npm"></a>
+  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg" alt="Node >= 22">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT"></a>
+  <a href="https://github.com/deepcoldy/botmux"><img src="https://img.shields.io/github/stars/deepcoldy/botmux.svg?style=social" alt="Stars"></a>
+</p>
+
+<p align="center"><b>Drive your AI coding CLI from Lark (Feishu).</b> One message starts a session, each session runs its own isolated CLI process, streamed back in real time — synced across phone, desktop, and terminal.</p>
+
+<p align="center">
+  <a href="https://deepcoldy.github.io/botmux/en/"><b>📖 Docs</b></a> ·
+  <a href="#5-minute-setup"><b>🚀 Quickstart</b></a> ·
+  <a href="https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg"><b>✨ Showcase</b></a> ·
+  <a href="README.md">中文</a>
 </p>
 
 <p align="center">
-  <a href="#design-philosophy">Design</a> &middot;
-  <a href="#key-advantages">Advantages</a> &middot;
-  <a href="#5-minute-setup">Quick Start</a> &middot;
-  <a href="https://deepcoldy.github.io/botmux/en/"><b>📖 Docs</b></a>
+  <img src="gif/fold&unfold.gif" width="640" alt="Lark streaming card relaying CLI output in real time">
 </p>
 
-[中文](README.md) | English
-
-**Plug any AI coding CLI into Feishu/Lark — every DM, group or topic gets its own CLI session, with live-streaming cards, a web terminal, and zero glue code.**
-
-> 📖 **Full docs** (commands / config / best practices / troubleshooting): **<https://deepcoldy.github.io/botmux/en/>** — this README only covers why and how to get started fast.
-
-| Lark Streaming Cards | Web Terminal | tmux Session Management | Multi-Bot Collaboration |
-|:-:|:-:|:-:|:-:|
-| <img src="gif/fold&unfold.gif" width="220" /> | <img src="gif/web_terminal.gif" width="220" /> | <img src="gif/tmux.gif" width="220" /> | <img src="docs/setup/multi-bot-collab.png" width="220" /> |
-
-<details>
-<summary>Full demo video</summary>
-
-[Demo Video](https://github.com/user-attachments/assets/3ba4c681-0a7e-4a03-89c8-b8d26b544a65)
-</details>
-
 ---
 
-## Why botmux?
+A daemon watches Lark messages and spawns an isolated AI coding CLI process for each new session, streaming the CLI's output back as live Lark cards and offering an interactive web terminal. It **doesn't reimplement agent capabilities** — it bridges the CLIs you already use directly (`botmux` ships **24 built-in adapters**, see [Supported CLIs](#supported-clis)).
 
-### Design Philosophy
+## What it solves
 
-Core philosophy: **Bridge CLIs, don't rebuild them**. botmux doesn't reimplement Agent capabilities — it bridges existing AI coding CLIs (Claude Code, Codex, Cursor, Gemini, OpenCode, Antigravity, GitHub Copilot, Kimi Code, Grok Build, Kiro) directly. Memory, context management, tool use, permission systems — these capabilities are evolving rapidly within the CLIs themselves. botmux rides on top of that evolution rather than rebuilding in parallel. Every CLI upgrade benefits botmux automatically with zero adaptation.
-
-### Key Advantages
-
-Compared to OpenClaw-style approaches built on Agent SDKs:
-
-| Feature | botmux | OpenClaw-style |
-|---------|--------|---------------|
-| Architecture | Bridges full CLI processes directly | Rebuilds on Agent SDK |
-| CLI Capabilities | Full runtime (hooks, memory, plan mode, skills, `/` commands) | SDK API subset, missing features must be reimplemented |
-| CLI Upgrades | Zero-adaptation automatic benefit | Must track SDK version changes |
-| Memory / Context | Reuses CLI's built-in memory system, improves as the CLI evolves | Must build custom memory system, duplicating CLI-native capabilities |
-| Multi-CLI Support | Many CLIs, switch with one config (Claude Code / Codex / Cursor / Gemini / OpenCode / Antigravity / GitHub Copilot / Kimi Code / Grok Build / Kiro, …) | Tied to a single SDK, cannot switch CLIs |
-| Web Terminal | Interactive full terminal, mobile shortcut toolbar, phone/desktop/Lark tri-screen sync | Usually web chat UI or read-only output |
-| Multi-Bot Collaboration | Multiple bots in same group via @mention routing, isolated processes, different CLIs sparring | Usually single bot |
-| Multi-Topic Collaboration | A lead bot auto-splits the task, opens multiple topics, and dispatches several bots to work in parallel (coder + reviewer), with a Lark task list as the shared progress board | Usually manual one-by-one assignment, no unified progress board |
-| Terminal Access | tmux attach directly into the CLI process, same as local dev experience | No direct terminal access |
-| Installation | `npm install -g botmux`, 5-min Lark setup | Easy to install, but more configuration needed |
-
----
-
-## Prerequisites
-
-- **Node.js** >= 22
-- **AI coding CLI / local agent app** installed and authenticated (`claude`, `codex`, `coco`, `cursor-agent`, `gemini`, `genius`, `opencode`, `hermes`, `seed` (Seed CLI, a Claude Code fork), `relay` (Relay CLI, the new release of Seed), `pi`, `omp` (oh-my-pi, a Pi fork), `copilot` (GitHub Copilot CLI), `traex` (TRAE CLI), `mircli` (Mir CLI), `agy` (Antigravity), `kimi` (Kimi Code), `grok` (Grok Build), or `kiro-cli` (Kiro) in PATH)
-  - **CoCo requires `0.120.32+`**: type-ahead (sending a new message while a turn is still running, parked in CoCo's own message queue) relies on 0.120.32+ behavior; earlier versions may drop or serialize input while busy — upgrade before use
-- **tmux** >= 3.x (optional — auto-enabled when installed for persistent CLI sessions)
-- **CJK fonts** (only needed for screenshot rendering of Chinese text / emoji):
-  - macOS: ships with PingFang / Hiragino, no action needed
-  - Debian/Ubuntu: daemon will background-install `fonts-noto-cjk fonts-noto-color-emoji` on first boot if missing (requires passwordless sudo or running as root; restart the daemon after install)
-  - Other Linux distros: install Noto CJK + Noto Color Emoji manually (package names vary)
+- **The agent can't reach you, and you can't drive it from your phone** — the CLI runs on a dev box, you're on your phone. botmux pushes every turn as a Lark card so you can view / follow up / interrupt anywhere, and open a writable web terminal to operate it directly.
+- **The CLI is blind to your Lark context** — pull a bot into a topic group / on-call group and one @ runs it right in your local repo; a session can be moved to another group with `/relay`, keeping its full context.
+- **A single agent isn't enough** — put several bots backed by different CLIs in one group, @ whoever should act, and have Claude Code and Codex review the same MR — each analyzing independently and pushing back when they disagree.
 
 ## 5-Minute Setup
 
-> 💡 **TL;DR**: `npm i -g botmux` → `botmux setup`; for Feishu tenants, **one QR scan** creates a working bot → `botmux start`. The same Web session names the app (`botmux-N` by default, customizable), creates it, reads AppID/AppSecret, imports permissions, configures the redirect URL, and creates + submits a publish version. Pass `--no-open-platform-auto` to skip permission/publish automation after app creation.
-
-### 1. Install botmux
+> Scanning to create the app + granting permissions takes about 5 minutes. ByteDance-internal users: see [one-command setup](https://deepcoldy.github.io/botmux/en/quickstart).
 
 ```bash
-npm install -g botmux
-# or: pnpm add -g botmux
-# or: bun add -g botmux
+npm install -g botmux        # requires Node >= 22
+botmux setup                 # scan to create a bot → pick a CLI → pick a working dir → scan to grant permissions
+botmux start                 # start the daemon (botmux autostart enable for auto-start on boot)
 ```
 
-Manual and scheduled updates keep using the npm, pnpm, or Bun global location that owns the running botmux install. Unknown install layouts are never silently updated with npm.
+Then DM the bot, or run `botmux dashboard` to create a group, and start chatting. Full steps (screenshots, internal one-command setup, proxy config) are in the **[5-Minute Quickstart](https://deepcoldy.github.io/botmux/en/quickstart)**.
 
-> Requires **Node.js ≥ 22**, with at least one AI coding CLI installed and authenticated (`claude` / `codex` / `cursor-agent` / `gemini` / `opencode` / `coco` / `agy` / `kimi` / `grok` / `kiro-cli` on your PATH). Installing **tmux** too is recommended (enables session persistence automatically).
+## Core Scenarios
 
-### 2. Create the App & Configure (`botmux setup`)
+- **[Live streaming cards](https://deepcoldy.github.io/botmux/en/cards)** — one live-updating card per turn, relaying the terminal screen verbatim as a screenshot; one tap to show/hide output, scroll, or restart/close/adopt the session.
+- **[Multi-bot collaboration](https://deepcoldy.github.io/botmux/en/multi-bot)** — multi-bot @mention routing in one group; different CLIs mean different models and natural diversity — have them critique each other on design reviews, code reviews, tech-stack choices.
+- **[Multi-topic orchestration](https://deepcoldy.github.io/botmux/en/multi-topic)** — hand an orchestrator a big task and it seeds topics in the group, spins up an isolated session per bot to run a pipeline, and the Lark task board shows every subtask's progress at a glance.
+- **[Interactive web terminal](https://deepcoldy.github.io/botmux/en/web-terminal)** — not just viewing output: drive the CLI directly from a browser / phone, with a floating shortcut bar on mobile (Esc, Ctrl+C, arrow keys).
+- **[Adopt & relay sessions](https://deepcoldy.github.io/botmux/en/adopt)** — running halfway in local tmux, `/adopt` it from your phone; `/relay` moves the whole session (same process, same memory) into a team group to continue.
+- **[Scheduled tasks & Webhook](https://deepcoldy.github.io/botmux/en/schedule)** — configure recurring tasks in natural language (alert analysis / group summaries), or trigger programmatically from external systems via [Webhook / API](https://deepcoldy.github.io/botmux/en/webhook).
+- **[On-call mode & voice summary](https://deepcoldy.github.io/botmux/en/oncall)** — pull it into an on-call group and any member's @ triggers a probe in the project dir; a one-tap 🔊 voice summary on every card footer makes the model "speak plainly".
 
-Run `botmux setup` — every choice is an interactive picker (↑/↓ to move, type to filter, ⏎ to confirm, Esc to cancel; non-interactive terminals fall back to numbered input):
+More: [Roles & teams](https://deepcoldy.github.io/botmux/en/roles) · [File sandbox](https://deepcoldy.github.io/botmux/en/sandbox) · [Dashboard](https://deepcoldy.github.io/botmux/en/dashboard) · [tmux persistence](https://deepcoldy.github.io/botmux/en/tmux) · [VC meeting agent](https://deepcoldy.github.io/botmux/en/voice).
 
-1. **Action**: a fresh install goes straight into the create flow; with an existing config, first pick "add / reconfigure / edit / remove bot".
-2. **App source** — pick one of three:
-   - **One-scan app creation (recommended)**: enter a bot name or leave it blank for `botmux-0`, `botmux-1`, etc. After Feishu Web QR login, botmux uploads its default icon, creates a custom app, reads AppID/AppSecret, then reuses that session for permissions and publishing. If Web creation is unavailable or the account is on Lark international, the user can explicitly choose the official `@larksuiteoapi/node-sdk` compatibility mode; it may require an additional scan and the platform chooses the app name.
-   - **Pick an existing app**: reuse (or QR-login to get) a Feishu web session, list the apps you previously created on the Open Platform, and have the **AppID/AppSecret fetched automatically** — no digging through the console when re-configuring on a new machine (Feishu tenants only).
-   - **Enter AppID/Secret manually** — see "Create the app manually" folded below.
-3. **Pick the CLI**: choose the CLI to bridge (searchable — type `cla` to filter Claude).
-4. **Working dir for new topics** — pick one of two modes:
-   - **Fixed default dir (recommended)**: new topics start straight in the given directory with **no card** (persisted as `defaultWorkingDir`; change later via `/config` or `botmux setup edit`). Pick this if you want the bot to just work in one directory.
-   - **Repo-select card**: each new topic pops a card listing scanned git repos to choose from — good when you hop between repos. The follow-up question asks for the **repo scan root(s)** — usually the **parent directory** of your git projects (e.g. `~/projects`, comma-separated for multiple); the card scans **downward** for git repos (up to 3 levels). Avoid `~` (too many folders to traverse).
+## Supported CLIs
 
-After app creation, setup reuses the same Web session to import permissions, configure `http://127.0.0.1:9768/callback`, and create + submit a publish version, so the Feishu primary path **has no second QR code**. Another scan is possible only after the user explicitly selects SDK compatibility mode. Automation failures still print the manual steps without affecting the saved bot config.
+Switch with `cliId` in `bots.json`; processes are fully isolated. **24 built-in adapters**:
 
-> ✅ **Both Feishu (feishu.cn) and Lark international (larksuite.com) tenants are supported.** Feishu uses the one-scan Web flow; explicitly selected SDK compatibility mode auto-detects and remembers Lark international tenants. The manual paste path asks once. Each bot connects to its own brand's domain, so one machine can run Feishu and Lark bots side by side, with login credentials isolated per app.
+`claude-code` · `codex` · `codex-app` · `gemini` · `cursor` · `opencode` · `antigravity` · `copilot` · `grok` · `kimi` · `kiro-cli` · `pi` · `oh-my-pi` · `aiden` · `coco` · `traex` · `mtr` · `hermes` · `mira` · `mir` · `genius` · `seed` · `relay` · `riff` (cloud agent)
 
-At the end, setup validates credentials with a `tenant_access_token` call (only writing `bots.json` on success) and writes the full scope JSON to `~/.botmux/lark-scopes.json` for reference.
+See [CLI Adapters](https://deepcoldy.github.io/botmux/en/adapters).
 
-<details>
-<summary><b>Scripted (non-TUI) setup</b> — field-level subcommands for coding agents / automation, independent of the interactive question order</summary>
+## Design Philosophy: Bridge the CLI Directly, No SDK Wrapper
 
-```bash
-botmux setup list --json                     # list bots (secret masked)
-botmux setup add --create-app \
-  --app-name "Engineering Assistant" \
-  --allowed-users alice@example.com          # first use scans once; later valid sessions skip it
-botmux setup add --create-app --switch-account \
-  --allowed-users alice@example.com          # explicitly rescan and replace the local session
-botmux setup configure botmux-1              # retry Open Platform setup after a partial add
-botmux setup add \
-  --app-id cli_xxx --app-secret xxx \
-  --allowed-users alice@example.com \
-  --cli codex --working-dir ~/projects       # add (credentials still validated before writing)
-botmux setup edit botmux-0 --cli claude-code \
-  --default-working-dir /data/proj           # per-field edits; pass - to clear a field
-botmux setup remove botmux-1 --yes           # non-interactive removal requires --yes
-botmux setup help                            # full flag reference
-```
+botmux doesn't reimplement memory, context management, tool calls, or permission systems — the CLIs iterate on all of that themselves. botmux bridges the complete CLI process and rides that evolution: **every CLI upgrade benefits botmux with zero adaptation**. You keep talking in plain language; the daemon wraps context into structured prompts behind the scenes before feeding the CLI.
 
-- `--working-dir` is the repo-select card's scan root; `--default-working-dir` is the fixed default dir (new topics start there directly, no card) — the same two modes as the TUI question.
-- `--create-app` reuses a valid session and reports the confirmed account/tenant on stderr; the first use scans once. `--switch-account` explicitly rescans and replaces the local session. `--json` never opens an unexpected QR when no valid cache exists unless `--switch-account` is passed.
-- Successful JSON reports `openPlatform.status` as `ready`, `ready_with_warnings`, `manual`, or `skipped`. If the app and local config were created but critical Feishu permissions/events/callback setup failed, the command exits non-zero with `partial: true`, does not auto-start the new bot, and returns a usable `botmux setup configure <bot>` continuation command. Session failures automatically add `--switch-account`; manual Lark setup omits a deterministic retry command instead of sending agents into a loop. The partial bot remains in `bots.json` for recovery, so a fleet-wide `botmux start/restart` can still spawn it; configure it successfully before restarting the fleet.
-- Existing-credential mode skips Open Platform automation unless `--open-platform-auto` is passed. `--compatibility-mode` must be selected explicitly, may need another scan, and does not support `--app-name`.
-- If you previously scripted setup by piping numbered answers into the TUI, migrate to these subcommands: whenever the question sequence changes (this release adds the working-dir mode question), piped answers silently shift.
+Compared with approaches that rebuild everything on an Agent SDK:
 
-</details>
+| Dimension | botmux | Agent-SDK-based approach |
+|------|--------|--------------------------|
+| Architecture | Bridges the complete CLI process | Rebuilt on an SDK |
+| CLI capabilities | Full runtime (hooks / memory / plan mode / MCP / `/` commands) | A subset of the SDK API; missing features hand-built |
+| CLI upgrades | Benefit automatically, zero adaptation | Must track SDK version changes |
+| Memory / context | Reuses the CLI's built-in, improves as the CLI iterates | Must be self-built, duplicating native CLI capabilities |
+| Multi-CLI | 24 switchable in one line | Usually bound to a single SDK |
+| Multi-bot | Multi-bot @mention routing in one group | Usually single-bot |
+| Direct terminal | `tmux attach` into the real process, same as local dev | Usually can't operate the underlying terminal |
 
-### 3. Start
+## Docs · Community · Contributing
 
-```bash
-botmux start
-```
+- 📖 **Full docs** (commands / config / best practices / troubleshooting): **<https://deepcoldy.github.io/botmux/en/>**
+- ✨ **Showcase** (illustrated + video): [*Create a really useful Feishu assistant in 5 minutes*](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg)
+- ❓ **FAQ / troubleshooting**: [FAQ](https://deepcoldy.github.io/botmux/en/faq) · [Common Pitfalls](https://deepcoldy.github.io/botmux/en/pitfalls)
+- 🤝 **Contributing**: issues / PRs welcome. To add a CLI adapter, see [CLI Adapters](https://deepcoldy.github.io/botmux/en/adapters).
+- 📄 **License**: [MIT](LICENSE)
 
-> `start` re-validates credentials before forking workers; missing scopes only WARN, they don't block the daemon. If you later need to verify the event subscription, Lark requires the daemon to be running so it can detect the WebSocket connection.
-
-### 4. Create a Group and Start Chatting
-
-1. Create a **topic-enabled group** in Lark
-2. Open group settings → Group Bots → add the bot you just created
-3. Send a message in the group — the bot responds automatically
-
-![Add bot to group](docs/setup/add-bot-to-group.png)
-
-### 5. Enable Boot-time Autostart (recommended)
-
-After confirming the bot can send/receive messages, run:
-
-```bash
-botmux autostart enable
-```
-
-<details>
-<summary><b>Manual Open Platform config: create app / permissions / redirect / publish (fallback)</b> —— handled automatically by botmux setup with the same login session; expand only if auto-config failed or you want to verify manually</summary>
-
-<br>
-
-**Create the app manually**: go to the [Lark Open Platform](https://open.larkoffice.com/app), create a "Custom App", copy **App ID / App Secret** from "Credentials & Basic Info", and pick "Enter AppID/Secret manually" at `botmux setup`'s "App source" step to paste them back.
-
-![Create App](docs/setup/create-app.png)
-
-**Add permissions**: run the copy-to-clipboard command setup printed, then go to "Permissions & Scopes" → "Batch Import/Export" and paste. Submit for review — visibility "only me" auto-approves.
-
-![Permissions](docs/setup/permissions.png)
-
-The full JSON lives at `~/.botmux/lark-scopes.json` (also tracked in-repo at [src/setup/lark-scopes.json](src/setup/lark-scopes.json), kept in sync with the internal wiki, covers ~290 tenant + user scopes).
-
-```bash
-# macOS (local)
-cat ~/.botmux/lark-scopes.json | pbcopy
-# Linux desktop (local X server)
-cat ~/.botmux/lark-scopes.json | xclip -selection clipboard
-# SSH / headless: just cat — selecting in your local terminal copies to your local clipboard
-cat ~/.botmux/lark-scopes.json
-# SSH via OSC 52 — write to local clipboard through terminal (iTerm2 / kitty / WezTerm / Alacritty / tmux 1.5+)
-base64 -w0 < ~/.botmux/lark-scopes.json | awk 'BEGIN{printf "\033]52;c;"}{printf "%s",$0}END{printf "\a"}'
-```
-
-**Add redirect URL (optional)**: if you plan to use `/login` inside Lark to let botmux act on your behalf for docs / calendar / wiki / sheets, add a redirect URL under "Security Settings" → "Redirect URL": `http://127.0.0.1:9768/callback`. Skip this if you only need bot messaging.
-
-**Publish**: go to "Version Management & Release", click "Create Version" and publish. Set availability to "Visible to me only" for automatic approval.
-
-![Publish](docs/setup/publish.png)
-
-</details>
-
-<details>
-<summary><b>Troubleshoot — bot not receiving messages</b></summary>
-
-<br>
-
-botmux enables the bot capability, long-connection event mode, and baseline event subscriptions automatically, so normally you don't touch this. If the bot **receives no messages at all** (not even DMs) after following the steps above, verify these two:
-
-- **Event subscription**: Open Platform → your app → Events & Callbacks → should subscribe to `im.message.receive_v1` + `card.action.trigger` (subscribed by default; add manually if missing). The delivery method must be "Receive events via long connection" (WebSocket), with the botmux daemon running.
-- **Bot capability**: Open Platform → your app → Features → Bot should be enabled (on by default); name/avatar are editable.
-
-Then restart the daemon: `botmux restart`.
-
-</details>
-
----
-
-## Features
-
-### Streaming Cards
-
-Each conversation turn gets a live-updating Feishu card — your main window for sensing and driving the CLI from phone/Lark:
-
-- **Live terminal screenshot streamed to the card** (rendered headlessly via xterm into a PNG, faithfully reproducing the CLI's TUI); one-tap "show/hide output", "export text", "page up/down"
-- **Live status**: Starting → Analyzing → Working / Executing → Idle; marks "limit reached · retryable" when quota runs out
-- **Act right from the card**: open (writable) terminal, 🔑 get write link, restart / close / take over the session, re-send last task
-- **One new card per turn**, the previous one frozen as an archive; after `/relay` moves a session to another group, the old card auto-freezes as an archive
-- **Closing leaves a resumable card** (with the CLI's native resume command) — click back in anytime
-
-
-### Web Terminal (Interactive)
-
-Each session exposes a web terminal at `http://<WEB_EXTERNAL_HOST>:<port>`.
-
-- When `WEB_EXTERNAL_HOST` is unset or blank, start/restart auto-detects the current non-loopback IPv4 address. To pin a proxy, NAT address, or hostname, set it explicitly in `~/.botmux/.env`. Restarts launched from a botmux session, the Dashboard, or auto-update treat that file as authoritative so the old daemon address cannot leak into the new processes.
-- **Read-only link** — shown on the streaming card in the group thread
-- **Write-enabled link** — sent via DM on demand (click "Get Write Link" on the card)
-
-On mobile/tablet, a floating shortcut toolbar provides Esc, Ctrl+C, Tab, arrow keys and other control keys missing from virtual keyboards — full CLI control from your phone.
-
-### Multi-Bot Collaboration
-
-Run multiple Lark bots on a single machine, each mapped to a different CLI. In the same group chat, messages are routed via @mention — each bot gets its own isolated CLI process. In a 1:1 group (you + one bot) it responds automatically without @; multi-person groups require @ by default (the per-bot "Group @ policy" can relax this inside owned topics or group-wide). In a regular (non-topic) group, `@<bot1> @<bot2> /t xxx` spawns one independent thread per mentioned bot anchored at the same message. Send `@<bot1> @<bot2> /introduce` once so they register each other's open_id; afterwards each bot can explicitly @-mention the others from within its own session (commands: [📖 Docs · Slash Commands](https://deepcoldy.github.io/botmux/en/slash-commands)).
-
-### Multi-Topic Collaboration
-
-The next level up from "Multi-Bot Collaboration": a lead bot (the **orchestrator**) splits one large task into multiple **sub-projects**, **automatically opens several topics** in the group, dispatches a team of bots into each topic to drive it in parallel (commonly "one writes the code + one reviews"), uses a single **Lark task list** as the shared progress board everyone reads from, and finally collects the results and aggregates them. A single regular group becomes a parallel workbench, and you can see overall progress at a glance from the Lark task panel.
-
-**How it runs** — the `botmux-orchestrate` skill walks the orchestrator through the full flow:
-
-> Split into sub-projects → propose a "sub-project ↔ bot" assignment → send it to you for **a single approval** (confirmable via card) → create the Lark task list → open each topic and dispatch → collect the reports → aggregate
-
-Under the hood, dispatching is done by `botmux dispatch`: it seeds a topic in the group and @-mentions the chosen bots, spawning an independent session for each. For local bots, pass stable app identities. The command establishes and reads back a receiver-scoped, bidirectional, talk-only `chatGrant` before sending, then waits for the target session to acknowledge the task. A brand-new “cold” group therefore does not depend on historical `/introduce` or peer caches.
-
-```bash
-botmux dispatch --title "Implement login module" \
-  --bot-app "cli_xxx:coder" --bot-app "cli_yyy:reviewer" \
-  --brief-file /tmp/brief.md
-```
-
-- `--bot-app <larkAppId[:role]>` — recommended for local bots; performs exact receiver-scoped conversation authorization and real session acceptance checks. It grants no management permission and cannot be combined with `--repo`; resident bots should use their configured default working directory.
-- `--bot <open_id[:name[:role]]>` — compatibility path for external/legacy bots; the caller owns open-id scoping, authorization, and acceptance checks.
-- `--repo <dir>` — only for the legacy `--bot` path when operate trust already exists; presets each sub-bot's working directory (absolute path, must exist on the sub-bot's machine).
-- `--standby` — **must be paired with `--repo`** (and cannot be combined with `--into`): sends `/repo` once to bring the bot up in the given directory on standby without a brief; activate it later with `--into ... --brief(-file)`.
-- `--into <topic root>` — return to an existing topic and append one message (activate standby bots / add coordination); still requires a bot target, and outside standby mode must carry `--brief` or `--brief-file`.
-
-When a sub-bot finishes, it reports progress/completion back with `botmux report` from inside its own sub-topic. A local-only `--bot-app` dispatch automatically injects `botmux report --dispatch-root <seed>` into each immutable task turn, so the report is delivered to the exact PM session recorded for that seed even if the same chat-scoped resident session later receives another dispatch. Legacy or mixed `--bot` dispatches keep the root-free cross-machine compatibility fallback. The orchestrator then aggregates the collected reports.
-
-**Collaboration boundaries:**
-
-- **Same deployment does not imply management trust** — `--bot-app` only installs receiver-scoped, talk-only `chatGrant` entries for that group. It does not touch `allowedUsers` and cannot run operate-level commands such as `/repo`. Management commands require an explicit allowedUsers / team / oncall operate trust path. `/introduce` only handles discovery / registering open_id and **grants no permissions**.
-- Sub-bots must already be in the group and @-mentionable (i.e. have the `im:message.group_at_msg.include_bot` permission).
-- A single topic can hold multiple bots, and they @-mention each other to collaborate within the topic (e.g. the coder @-mentions the reviewer once the code is done).
-
-### Tmux Persistence
-
-When tmux is installed, botmux automatically uses it. CLI processes persist inside tmux sessions — all features work unchanged.
-
-**Key benefit: daemon restarts don't interrupt the CLI.** During `botmux restart`, the worker process exits but the tmux session (and the CLI inside it) keeps running. The next incoming message triggers a re-attach — no `--resume` context reload needed.
-
-```bash
-# Interactive session picker — select and attach to tmux (see § CLI Commands)
-botmux list
-
-# Or manually attach (session name = bmx-<first 8 chars of session ID>)
-tmux attach -t bmx-<first-8-chars-of-session-id>
-# Ctrl+B, D to detach — CLI keeps running
-
-# Force pure pty mode (disable tmux)
-BACKEND_TYPE=pty botmux start
-```
-
-**Lifecycle:**
-
-| Event | tmux session | CLI process |
-|-------|-------------|-------------|
-| `botmux restart` | Survives | Survives (re-attaches on next message) |
-| `/close` or close button | Destroyed | Terminated (SIGHUP) |
-| CLI exits / crashes | Closes with it | Already exited (auto-restart creates new session) |
-
-### Session Adopt
-
-Seamlessly connect Botmux to CLI processes already running in tmux — monitor and interact from your phone via Lark.
-
-```
-/adopt              # Selection card: ① take over a running session ② resume a past session from disk
-/adopt 0:2.0        # Directly adopt a tmux pane (or pass a past session id to resume-import it)
-```
-
-- **Import past sessions** — The card's second filter lists this host's past sessions for the CLI (claude-code / seed / codex / traex / antigravity / genius); pick one to rebuild it as a standard Botmux session via `--resume` in its original working dir — no live process required, no need to move it into tmux first
-- **Shared mode** — After adopting, iTerm2 and Lark stay in sync: streaming card shows real-time terminal output, Lark chat input is forwarded directly to the terminal
-- **One-click takeover** — Click the "Takeover" button on the streaming card to rebuild the session with `--resume` and convert to a standard Botmux session
-- **Safe disconnect** — Click "Disconnect" to detach Botmux without affecting the original CLI
-
-### Scheduled Tasks
-
-Three schedule types (once / interval / cron) with Chinese/English natural
-language, executed inside the original thread (no new topic per run).
-
-**Two ways to create**:
-- **Slash command** (quick): `/schedule 每日17:50 check AI news`
-- **Conversation** (flexible): just tell the agent "add a reminder for every day at 9:00 to check deploys" — the `botmux-schedule` Skill fires automatically.
-
-Supported formats: Chinese NL (`每日17:50` / `30分钟后` / `明天9:00`),
-English duration (`30m`), interval (`every 2h`), cron (`0 9 * * *`),
-ISO timestamp (`2026-05-01T10:00`).
-
-### Lark integration (Skill + CLI)
-
-When a CLI spawns inside a botmux session it automatically gets
-`~/.botmux/bin` on PATH plus a set of ready-to-use Skills:
-
-- `botmux send` — send a message to the current thread (text, images, files, interactive card JSON, @mention)
-- `botmux history` — fetch session history (topic groups → in-thread, regular groups → whole chat)
-- `botmux quoted <message_id>` — when the user @ed the bot via Lark's quote-reply UI, fetch the quoted message on demand
-- `botmux bots list` — discover bots + their `open_id`s
-- `botmux schedule` — manage scheduled tasks
-- `botmux-workflow` — orchestrate bounded multi-step work with natural language or `/workflow`, then save successful runs for reuse
-
-These capabilities are wired via `--append-system-prompt` and Skill
-descriptions, so the agent picks them up automatically. Compared to
-Anthropic's official Telegram channel — which exposes each action as an
-MCP tool — the Skill + CLI combo skips the MCP handshake on every CLI
-launch, doesn't burn tool-list tokens, and works across every CLI that
-can read a system prompt and shell out (Claude Code / Codex / Cursor /
-Gemini / OpenCode / Antigravity / GitHub Copilot), with no MCP protocol support required.
-
-### Dashboard
-
-> `botmux dashboard` issues a one-time-token URL — manage every daemon/bot from the browser.
-
-- One-click locate back to the Feishu thread / open Web Terminal / multi-select batch close
-- Add a bot with the same one-scan Feishu flow: optional stable name, AI CLI and working-directory choices, fail-closed administrator confirmation, and an explicit compatibility fallback
-- Create a new group with auto owner-transfer + @-mention notification
-- Disband or leave a chat (associated sessions auto-closed)
-- **Standalone Codex completion notifications (experimental, off by default)**: while macOS is locked, the selected Bot privately sends the final Codex App/CLI reply, including Codex App Side Chats. Regular App threads can be opened on the Mac running BotMux or adopted into Feishu; ephemeral Side Chats are result-only. Choose the Bot and notification timing under Settings → Experimental ([design and maintenance notes](docs/design/codex-notifier.md))
-- **Session Insights** (owner-only, read-only): parse each session's transcript to view action spans / work timeline / context curve / failure aggregates + diagnostic suggestions; send `/insight` in chat for the current session's summary card
-- **Workflows console**:
-  - v3 Run List and Run Detail show the DAG, node states, decisions, and attempt terminal logs, and stop polling at terminal state
-  - **Cancel v3 runs directly from the dashboard**; trusted Lark cards in the bound topic handle `humanGate`, retry, and grant decisions
-  - Create, run, save, and reuse workflows in Lark with natural language or `/workflow`; the v2 Dashboard/Catalog has been retired
-
-<img src="docs/dashboard.png" alt="botmux dashboard" width="800" />
-
----
-
-## Usage
-
-### Workflow
-
-1. Send a message in a Lark topic group to create a new thread; or in a regular group send `/t <prompt>` to force-open a new topic
-2. The bot shows a repo selection card — pick a project or click "Start directly" (a bot bound via `/oncall bind` skips this step; binding is per-bot)
-3. The CLI spawns in the selected directory
-4. A live streaming card appears in the thread, showing real-time terminal output with markdown rendering
-5. Each reply creates a new streaming card for that turn; previous cards freeze at their last state
-6. Click "Get Write Link" on the card to receive a write-enabled terminal URL via DM
-7. The CLI replies in the thread via the `botmux send` command (wired through the `botmux-send` Skill)
-
----
-
-### Multi-step Workflow (v3)
-
-- Say “research three competitors and write a report” or “chain A/B/C and run it automatically.” The bot lightly confirms Workflow intent, clarifies the goal, builds a bounded DAG, and executes it.
-- Use `/workflow <goal>` for an explicit start, and `/workflow list|show|cancel` to inspect or cancel runs.
-- Save a successful run with `/workflow save last weekly-report`, then reuse it with `/workflow run weekly-report region=sg`; only missing required parameters are requested.
-- The v2 runtime is retired. Legacy definitions and run history retain only offline `botmux template migrate-v3` / `archive-runs` migration and archive tooling.
-
----
-
-### One Headless Goal (local CLI)
-
-`botmux goal run` executes one real goal without starting the daemon. It is useful for local scripts, CI, and human-triggered automation. It follows the existing v3 ephemeral-worker, sandbox/enforcement, journal, worker-fence, and manifest-validation path. Its trust boundary is the same as a local operator running botmux directly; it is not a remote-execution API.
-
-```bash
-botmux goal run "inspect the repository and write release notes" \
-  --bot my-codex \
-  --working-dir ~/projects/app \
-  --run-id release-notes-2026-07-22 \
-  --timeout 900 \
-  --json
-```
-
-The goal may also come from `--goal-file <path>` or `--stdin`. `--timeout` is in seconds. SIGINT, SIGTERM, and timeouts converge the journal to a durable `cancelled` terminal before the CLI exits.
-
-In `--json` mode stdout contains exactly one terminal JSON document (`schemaVersion: "botmux.goal-run-result/v1"`); logs go to stderr. Exit codes are a stable machine contract: `0` succeeded, `10` failed, `11` blocked, `12` cancelled, `13` run-id/active-driver conflict, and `14` usage or startup error. Failures also carry structured `error.code` and `error.message` values.
-
-`--run-id` is the idempotency key. An existing terminal result is replayed without spawning a worker; a live driver is rejected with exit `13`; after a driver is killed with `kill -9`, retrying the same request and run id resumes from the v3 journal/worker fence as a new attempt rather than overwriting the old attempt. A different goal, bot, working directory, or timeout cannot reuse the run id.
-
-The JSON `artifacts` list contains only relative paths and metadata accepted by the existing manifest validator. `runDirectory.stability` is always `informative-only`: the directory is useful for local diagnosis but its private layout is not an API. When usage/cost data is unavailable, the field is omitted rather than fabricated as zero.
-
-This first slice is a local single-process CLI contract only. It does not provide a daemon/remote Host API, event stream, or cross-host fencing; those require a separate RFC and security review.
-
----
-
-### Per-Bot Environment Variables (run a bot on GLM / a third-party provider)
-
-Each `bots.json` entry can define its own `env` object, injected into **that bot's CLI process**. Typical use: run one bot on a GLM Coding Plan / third-party Anthropic·OpenAI-compatible provider while another keeps using official Claude — just point the former at the provider's endpoint and key:
-
-```json
-{
-  "cliId": "claude-code",
-  "workingDir": "~/projects",
-  "env": {
-    "ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
-    "ANTHROPIC_AUTH_TOKEN": "your GLM Coding Plan key"
-  }
-}
-```
-
-> For GLM in China use `https://open.bigmodel.cn/api/anthropic`. For an OpenAI-protocol CLI like Codex, set `OPENAI_BASE_URL` / `OPENAI_API_KEY` (the provider's OpenAI-compatible endpoint) instead of `ANTHROPIC_*`. Also handy for `HTTPS_PROXY` or CLI feature flags.
-
-Notes:
-
-- `env` accepts valid env-var names with string/number/boolean values; botmux-reserved keys (`BOTMUX_`, `LARK_APP_`, …) are ignored, so config can't hijack session routing or creds.
-- Injected **per session** into the CLI process (effective from the next session). On the tmux/zellij backends it goes in via each pane's `/usr/bin/env` prefix, **never the shared server env**, so one bot's provider config can't leak into another's.
-- Also editable in the dashboard ("Bot defaults → Environment variables", owner-authenticated) or via `/config set env '{...}'`.
-- Not a secret vault: values live in `bots.json` and the process environment in plaintext, visible to local diagnostic tools.
-
----
-
-## 📖 Documentation
-
-The full reference — commands, config, best practices, troubleshooting — lives in the docs site; not duplicated here —
-
-### 👉 https://deepcoldy.github.io/botmux/en/
-
-| Topic | Docs |
-|-------|------|
-| Slash commands / CLI commands / agent-facing subcommands | [Commands](https://deepcoldy.github.io/botmux/en/slash-commands) |
-| `bots.json` fields / env vars / file locations | [Configuration](https://deepcoldy.github.io/botmux/en/bots-json) |
-| Multi-CLI adapters (incl. wrapper / gateway integration) | [Adapters](https://deepcoldy.github.io/botmux/en/adapters) |
-| Scenario-based best practices (Oncall / alerting-ops / solo dev / team) | [Best Practices](https://deepcoldy.github.io/botmux/en/best-practices) |
-| Common pitfalls / FAQ | [Pitfalls](https://deepcoldy.github.io/botmux/en/pitfalls) · [FAQ](https://deepcoldy.github.io/botmux/en/faq) |
-| Features: scheduled tasks / Oncall / Dashboard / multi-bot / session relay | [Schedule](https://deepcoldy.github.io/botmux/en/schedule) · [Oncall](https://deepcoldy.github.io/botmux/en/oncall) · [Dashboard](https://deepcoldy.github.io/botmux/en/dashboard) · [Multi-bot](https://deepcoldy.github.io/botmux/en/multi-bot) · [Relay](https://deepcoldy.github.io/botmux/en/relay) |
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md).
-
-## License
-
-[MIT](LICENSE)
+<p align="center">If it's useful, drop a ⭐ Star → <a href="https://github.com/deepcoldy/botmux">deepcoldy/botmux</a></p>

--- a/README.en.md
+++ b/README.en.md
@@ -26,7 +26,7 @@
 
 ---
 
-A daemon watches Lark messages and spawns an isolated AI coding CLI process for each new session, streaming the CLI's output back as live Lark cards and offering an interactive web terminal. It **doesn't reimplement agent capabilities** — it bridges the CLIs you already use directly (`botmux` ships **24 built-in adapters**, see [Supported CLIs](#supported-clis)).
+A daemon watches Lark messages and spawns an isolated session process for each new session, streaming the AI coding CLI / agent's output back as live Lark cards and offering an interactive web terminal. It **doesn't reimplement agent capabilities** — it bridges the tools you already use directly (**20+ CLI / agent adapters**, see [Supported CLIs & Agents](#supported-clis--agents)).
 
 ## What it solves
 
@@ -36,15 +36,15 @@ A daemon watches Lark messages and spawns an isolated AI coding CLI process for 
 
 ## 5-Minute Setup
 
-> Scanning to create the app + granting permissions takes about 5 minutes. ByteDance-internal users: see [one-command setup](https://deepcoldy.github.io/botmux/en/quickstart).
+> About 5 minutes: a single Lark QR scan in `botmux setup` creates the app, configures all permissions, and publishes a version in one flow (`--no-open-platform-auto` skips the automation for manual app creation).
 
 ```bash
 npm install -g botmux        # requires Node >= 22
-botmux setup                 # scan to create a bot → pick a CLI → pick a working dir → scan to grant permissions
+botmux setup                 # one scan to create the app → pick a CLI → pick a working dir (permissions + publish auto-configured)
 botmux start                 # start the daemon (botmux autostart enable for auto-start on boot)
 ```
 
-Then DM the bot, or run `botmux dashboard` to create a group, and start chatting. Full steps (screenshots, internal one-command setup, proxy config) are in the **[5-Minute Quickstart](https://deepcoldy.github.io/botmux/en/quickstart)**.
+Then DM the bot, or run `botmux dashboard` to create a group, and start chatting. Full steps (Lark international, `--no-open-platform-auto` manual app creation, troubleshooting) are in the **[5-Minute Quickstart](https://deepcoldy.github.io/botmux/en/quickstart)**.
 
 ## Core Scenarios
 
@@ -53,18 +53,18 @@ Then DM the bot, or run `botmux dashboard` to create a group, and start chatting
 - **[Multi-topic orchestration](https://deepcoldy.github.io/botmux/en/multi-topic)** — hand an orchestrator a big task and it seeds topics in the group, spins up an isolated session per bot to run a pipeline, and the Lark task board shows every subtask's progress at a glance.
 - **[Interactive web terminal](https://deepcoldy.github.io/botmux/en/web-terminal)** — not just viewing output: drive the CLI directly from a browser / phone, with a floating shortcut bar on mobile (Esc, Ctrl+C, arrow keys).
 - **[Adopt & relay sessions](https://deepcoldy.github.io/botmux/en/adopt)** — running halfway in local tmux, `/adopt` it from your phone; `/relay` moves the whole session (same process, same memory) into a team group to continue.
-- **[Scheduled tasks & Webhook](https://deepcoldy.github.io/botmux/en/schedule)** — configure recurring tasks in natural language (alert analysis / group summaries), or trigger programmatically from external systems via [Webhook / API](https://deepcoldy.github.io/botmux/en/webhook).
-- **[On-call mode & voice summary](https://deepcoldy.github.io/botmux/en/oncall)** — pull it into an on-call group and any member's @ triggers a probe in the project dir; a one-tap 🔊 voice summary on every card footer makes the model "speak plainly".
+- **[Scheduled tasks](https://deepcoldy.github.io/botmux/en/schedule) & [external triggers](https://deepcoldy.github.io/botmux/en/webhook)** — configure recurring tasks in natural language (alert analysis / group summaries); trigger programmatically from external systems via [Webhook](https://deepcoldy.github.io/botmux/en/webhook) or the [task-trigger API](https://deepcoldy.github.io/botmux/en/api-task-trigger).
+- **[On-call mode](https://deepcoldy.github.io/botmux/en/oncall) & [voice summary](https://deepcoldy.github.io/botmux/en/voice)** — pull it into an on-call group and any member's @ triggers a probe in the project dir; once TTS is configured, each card footer gains a 🔊 voice-summary button that makes the model "speak plainly".
 
-More: [Roles & teams](https://deepcoldy.github.io/botmux/en/roles) · [File sandbox](https://deepcoldy.github.io/botmux/en/sandbox) · [Dashboard](https://deepcoldy.github.io/botmux/en/dashboard) · [tmux persistence](https://deepcoldy.github.io/botmux/en/tmux) · [VC meeting agent](https://deepcoldy.github.io/botmux/en/voice).
+More: [Roles & teams](https://deepcoldy.github.io/botmux/en/roles) · [File sandbox](https://deepcoldy.github.io/botmux/en/sandbox) · [Dashboard](https://deepcoldy.github.io/botmux/en/dashboard) · [tmux persistence](https://deepcoldy.github.io/botmux/en/tmux) · [VC meeting agent](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg).
 
-## Supported CLIs
+## Supported CLIs & Agents
 
-Switch with `cliId` in `bots.json`; processes are fully isolated. **24 built-in adapters**:
+Switch with `cliId` in `bots.json`. **20+ adapters**, spanning local CLIs (process-isolated, reachable via `tmux attach`) and API / cloud agents (e.g. Mira, riff — reached over API / remote, not a local process). Representative ones:
 
-`claude-code` · `codex` · `codex-app` · `gemini` · `cursor` · `opencode` · `antigravity` · `copilot` · `grok` · `kimi` · `kiro-cli` · `pi` · `oh-my-pi` · `aiden` · `coco` · `traex` · `mtr` · `hermes` · `mira` · `mir` · `genius` · `seed` · `relay` · `riff` (cloud agent)
+`claude-code` · `codex` · `gemini` · `cursor` · `opencode` · `antigravity` · `copilot` · `grok` · `kimi` · `kiro-cli` · `aiden` · `coco` (TRAE) · `hermes` · `mira` · `riff` (cloud agent) …
 
-See [CLI Adapters](https://deepcoldy.github.io/botmux/en/adapters).
+The full list and integration methods (including wrapper / gateway setups) are authoritative in [CLI Adapters](https://deepcoldy.github.io/botmux/en/adapters).
 
 ## Design Philosophy: Bridge the CLI Directly, No SDK Wrapper
 
@@ -78,7 +78,7 @@ Compared with approaches that rebuild everything on an Agent SDK:
 | CLI capabilities | Full runtime (hooks / memory / plan mode / MCP / `/` commands) | A subset of the SDK API; missing features hand-built |
 | CLI upgrades | Benefit automatically, zero adaptation | Must track SDK version changes |
 | Memory / context | Reuses the CLI's built-in, improves as the CLI iterates | Must be self-built, duplicating native CLI capabilities |
-| Multi-CLI | 24 switchable in one line | Usually bound to a single SDK |
+| Multi-CLI | 20+ CLIs / agents, switch in one line | Usually bound to a single SDK |
 | Multi-bot | Multi-bot @mention routing in one group | Usually single-bot |
 | Direct terminal | `tmux attach` into the real process, same as local dev | Usually can't operate the underlying terminal |
 
@@ -87,7 +87,8 @@ Compared with approaches that rebuild everything on an Agent SDK:
 - 📖 **Full docs** (commands / config / best practices / troubleshooting): **<https://deepcoldy.github.io/botmux/en/>**
 - ✨ **Showcase** (illustrated + video): [*Create a really useful Feishu assistant in 5 minutes*](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg)
 - ❓ **FAQ / troubleshooting**: [FAQ](https://deepcoldy.github.io/botmux/en/faq) · [Common Pitfalls](https://deepcoldy.github.io/botmux/en/pitfalls)
-- 🤝 **Contributing**: issues / PRs welcome. To add a CLI adapter, see [CLI Adapters](https://deepcoldy.github.io/botmux/en/adapters).
+- 💬 **Community**: find the internal / external "Botmux" chat-group cards at the bottom of the [showcase doc](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg).
+- 🤝 **Contributing**: issues / PRs welcome. To add an adapter, see [CLI Adapters](https://deepcoldy.github.io/botmux/en/adapters).
 - 📄 **License**: [MIT](LICENSE)
 
 <p align="center">If it's useful, drop a ⭐ Star → <a href="https://github.com/deepcoldy/botmux">deepcoldy/botmux</a></p>

--- a/README.en.md
+++ b/README.en.md
@@ -44,7 +44,7 @@ botmux setup                 # one scan to create the app → pick a CLI → pic
 botmux start                 # start the daemon (botmux autostart enable for auto-start on boot)
 ```
 
-Then DM the bot, or run `botmux dashboard` to create a group, and start chatting. Full steps (Lark international, `--no-open-platform-auto` manual app creation, troubleshooting) are in the **[5-Minute Quickstart](https://deepcoldy.github.io/botmux/en/quickstart)**.
+Then DM the bot, or run `botmux dashboard` to create a group, and start chatting. Full steps (Lark international, manual permission / publish setup after `--no-open-platform-auto`, troubleshooting) are in the **[5-Minute Quickstart](https://deepcoldy.github.io/botmux/en/quickstart)**.
 
 ## Core Scenarios
 

--- a/README.md
+++ b/README.md
@@ -1,459 +1,93 @@
 # botmux
 
 <p align="center">
-  <img src="cover.svg" alt="botmux cover" width="800">
+  <img src="cover.svg" alt="botmux" width="760">
 </p>
 
 <p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License MIT"></a>
-  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg" alt="Node.js >= 22">
-  <a href="https://www.npmjs.com/package/botmux"><img src="https://img.shields.io/npm/v/botmux.svg" alt="npm version"></a>
-  <a href="https://github.com/deepcoldy/botmux"><img src="https://img.shields.io/github/stars/deepcoldy/botmux.svg?style=social" alt="GitHub Stars"></a>
+  <a href="https://www.npmjs.com/package/botmux"><img src="https://img.shields.io/npm/v/botmux.svg" alt="npm"></a>
+  <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg" alt="Node >= 22">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT"></a>
+  <a href="https://github.com/deepcoldy/botmux"><img src="https://img.shields.io/github/stars/deepcoldy/botmux.svg?style=social" alt="Stars"></a>
+</p>
+
+<p align="center"><b>在飞书里遥控你的 AI 编程 CLI。</b>一条消息启动一个会话，每个会话一个独立 CLI 进程，实时流式回传——手机、电脑、终端三端同步。</p>
+
+<p align="center">
+  <a href="https://deepcoldy.github.io/botmux/"><b>📖 文档</b></a> ·
+  <a href="#5-分钟接入"><b>🚀 快速接入</b></a> ·
+  <a href="https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg"><b>✨ 效果展示</b></a> ·
+  <a href="README.en.md">English</a>
 </p>
 
 <p align="center">
-  <a href="#设计理念">设计理念</a> · <a href="#核心优势">核心优势</a> · <a href="#5-分钟快速接入">快速接入</a> · <a href="https://deepcoldy.github.io/botmux/"><b>📖 文档</b></a> · <a href="https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg"><b>✨ 效果展示</b></a>
-</p>
-
-<p align="center">
-  中文 | <a href="README.en.md">English</a>
+  <img src="gif/fold&unfold.gif" width="640" alt="飞书流式卡片实时回传 CLI 输出">
 </p>
 
 ---
 
-**飞书 + AI 编程 CLI——私聊 / 群聊 / 话题，每个会话一个独立 CLI 进程，实时流式回传。** Daemon 监听飞书消息，为每个新会话自动启动独立 CLI 进程（Claude Code / Codex / Cursor / Gemini / OpenCode / Antigravity / GitHub Copilot / Kimi Code / Grok Build / Kiro），提供实时流式卡片和可交互 Web 终端。
+Daemon 监听飞书消息，为每个新会话自动 spawn 一个独立的 AI 编程 CLI 进程，把 CLI 的输出实时流式回传成飞书卡片，并提供可交互的 Web 终端。它**不重造 Agent 能力**，而是直接桥接你已经在用的 CLI（`botmux` 内置 **24 种适配器**，见 [支持的 CLI](#支持的-cli)）。
 
-> ✨ **先看效果**：[**《5 分钟创建一个真正好用的飞书助理》**](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg) —— 飞书图文 + 视频演示：AI 消息提醒 / 多端同步跨端操作 / 多 Bot 协作 / 多话题并行编排 / 语音总结 + 飞书会议 / Oncall 与个人替身。
+## 它解决什么
 
-> 📖 **完整文档**（命令 / 配置 / 最佳实践 / 排错）：**<https://deepcoldy.github.io/botmux/>** ——本 README 只讲为什么用它和怎么快速上手。
+- **Agent 收不到通知、手机控不了** — CLI 跑在开发机上，人在手机上。botmux 把每轮输出推成飞书卡片，随时随地查看 / 追问 / 打断，还能开可写 Web 终端直接操作。
+- **CLI 不感知飞书上下文** — 把机器人拉进话题群 / oncall 群，@ 一句就在你本机的代码库里开跑；会话可以用 `/relay` 原样搬到另一个群，上下文一点不丢。
+- **单个 Agent 不够用** — 同一个群里放多个不同 CLI 的机器人，@ 谁谁干活，让 Claude Code 和 Codex 一起 review 同一个 MR、各自独立分析、观点不同自动互怼。
 
-## 演示
+## 5 分钟接入
 
-| 飞书流式卡片 | Web 终端 | tmux 会话管理 | 多机器人协作 |
-|:-:|:-:|:-:|:-:|
-| <img src="gif/fold&unfold.gif" width="220" /> | <img src="gif/web_terminal.gif" width="220" /> | <img src="gif/tmux.gif" width="220" /> | <img src="docs/setup/multi-bot-collab.png" width="220" /> |
-
-<details>
-<summary>完整演示视频</summary>
-
-[演示视频](https://github.com/user-attachments/assets/3ba4c681-0a7e-4a03-89c8-b8d26b544a65)
-</details>
-
----
-
-## 为什么选择 botmux
-
-### 设计理念
-
-**不做 SDK wrapper，直接桥接 CLI。**
-
-botmux 不重新实现 Agent 能力，而是直接桥接已有的 AI 编程 CLI（Claude Code、Codex、Cursor、Gemini、OpenCode、Antigravity、GitHub Copilot、Kimi Code、Kiro）。记忆、上下文管理、工具调用、权限体系——这些能力 CLI 本身都在快速迭代，botmux 选择站在这个进化之上，而不是平行重造一套。CLI 的每次升级，botmux 零适配自动受益。
-
-### 核心优势
-
-与 OpenClaw 等基于 Agent SDK 构建的方案相比：
-
-| 特性 | botmux | OpenClaw 类方案 |
-|------|--------|----------------|
-| 底层架构 | 直接桥接完整 CLI 进程 | 基于 Agent SDK 重新构建 |
-| CLI 能力 | 完整运行时（hooks、memory、plan mode、Skill、`/` 命令） | SDK API 子集，需手动实现缺失功能 |
-| CLI 升级 | 零适配自动受益 | 需要跟进 SDK 版本变更 |
-| 记忆 / 上下文 | 直接复用 CLI 内建的记忆系统，随 CLI 迭代自动增强 | 需自建记忆系统，与 CLI 原生能力重复 |
-| 多 CLI 支持 | 多种 CLI 一键切换（Claude Code / Codex / Cursor / Gemini / OpenCode / Antigravity / GitHub Copilot / Kimi Code / Grok Build / Kiro 等） | 绑定单一 SDK，无法切换 CLI |
-| Web 终端 | 可交互的完整终端，移动端快捷键工具栏，手机/电脑/飞书三端同步 | 通常仅 Web 聊天界面或只读输出 |
-| 多机器人协作 | 多 bot 同群 @mention 路由，独立进程隔离，不同 CLI 赛博斗蛐蛐 | 通常单机器人 |
-| 多话题协作模式 | 主 bot 自动拆任务、开多话题、派多 bot 并行协作（coder+reviewer），飞书任务清单当共享进度板 | 通常需人工逐个分派、无统一进度板 |
-| 终端直连 | tmux attach 直接进入 CLI 进程，和本地开发体验一致 | 无法直接操作底层终端 |
-| 安装部署 | `npm install -g botmux`，5 分钟飞书配置即可使用 | 安装简单，但配置项较多 |
-
----
-
-## 功能特性
-
-### Skill 管理
-
-botmux 可以管理 CLI 无关的自定义 Skill Registry，并按 bot 配置在会话启动时优先披露指定 skill；未配置时完全保持 Claude / Codex 等 CLI 自己的默认 skill 行为。安装、bot 级策略、Claude scoped plugin 和 Codex prompt delivery 说明见 [Skill 管理](docs/setup/skills.md)。
-
-### 实时流式卡片
-
-每轮对话一张实时更新的飞书卡片，是你在手机/飞书上感知并操控 CLI 的主窗口：
-
-- **终端画面实时截图刷新到卡片**（xterm 无头渲染成图，原样还原 CLI 的 TUI）；可一键「显示 / 隐藏输出」「导出文字」「上下翻屏」
-- **状态实时指示**：启动中 → 正在分析 → 工作中 / 执行中 → 等待输入；额度用满会标「限额已达 · 可重试」
-- **卡片上直接操作**：打开（可写）终端、🔑 取操作链接、重启 / 关闭 / 接管会话、重发上一条任务
-- **每轮一张新卡片**，上一轮冻结存档；会话用 `/relay` 搬到别的群后，原卡片自动冻结为存档
-- **关闭给「可恢复」卡片**（附 CLI 原生 resume 命令），随时点回来继续
-
-### Web 终端（可交互）
-
-每个会话提供一个 Web 终端，地址为 `http://<WEB_EXTERNAL_HOST>:<端口>`。
-
-- `WEB_EXTERNAL_HOST` 未配置或留空时，启动/重启会自动探测当前非回环 IPv4；如需固定代理、NAT 地址或域名，请在 `~/.botmux/.env` 中显式设置。由 botmux 会话、Dashboard 或自动升级触发的重启均以该文件为准，避免旧 daemon 地址被带入新进程。
-- **只读链接** — 展示在群话题的流式卡片上，随时查看进度
-- **可操作链接** — 按需获取（点击卡片上的「🔑 获取操作链接」通过私聊发送），可直接在浏览器中操作 CLI
-- 移动端/平板提供悬浮快捷键工具栏（Esc、Ctrl+C、Tab、方向键等），手机上也能流畅操作
-
-### 多机器人协作
-
-同一台机器上可运行多个飞书机器人，每个机器人可对应不同的 CLI。同一群聊中通过 @mention 路由消息，仅「你 + 1 个机器人」的 1v1 群无需 @ 自动响应，多人群默认必须 @（可通过「群聊 @ 策略」配置话题内免 @ / 全群免 @）；多机器人时 `@<bot1> @<bot2> /t xxx` 可让每个被 @ 的机器人在同一条消息上各自独立开新话题。先发一次 `@<bot1> @<bot2> /introduce` 让它们互相登记 open_id，之后各 bot 就能在自己的会话里显式 @mention 对方协作（命令详见 [📖 文档 · 斜杠命令](https://deepcoldy.github.io/botmux/slash-commands)）。
-
-### 多话题协作模式
-
-「多机器人协作」的升级版：主 bot（**编排者**）把一个大任务拆成多个**子项目**，在群里**自动开多条话题**，每条话题派一组 bot 并行推进（常见「一个写代码 + 一个 review」），用一张**飞书任务清单**当所有人共享的进度板，最后由主 bot 收齐汇总。一个普通群就是一个并行工作台，你在飞书任务面板一眼看完成度。
-
-**怎么跑** —— `botmux-orchestrate` skill 教编排者走完整流程：
-
-> 拆子项目 → 提一版「子项目 ↔ bot」分配 → 发给你**一次审批**（可用卡片确认） → 建飞书任务清单 → 逐个开话题派活 → 收齐回报 → 汇总
-
-底层派活靠 `botmux dispatch`：在群里种一条话题、把指定 bot @ 进去各起独立会话。同机 Bot 推荐传稳定 App 身份；命令会先在每个 receiver 视角建立并回读该群的双向 talk-only `chatGrant`，再发任务并等待目标 session 确认接单，因此新建“冷群”不依赖历史 `/introduce` / peer 缓存。
+> 扫码建应用 + 配权限走一遍，约 5 分钟。字节内部同学见 [一行命令接入](https://deepcoldy.github.io/botmux/quickstart)。
 
 ```bash
-botmux dispatch --title "实现登录模块" \
-  --bot-app "cli_xxx:coder" --bot-app "cli_yyy:reviewer" \
-  --brief-file /tmp/brief.md
+npm install -g botmux        # 需要 Node >= 22
+botmux setup                 # 扫码建机器人 → 选 CLI → 选工作目录 → 扫码配权限
+botmux start                 # 启动 daemon（botmux autostart enable 设开机自启）
 ```
 
-- `--bot-app <larkAppId[:角色]>` —— 同机 Bot 的推荐入口；自动完成 receiver-scoped 精确对话授权与实际接单确认。它不授管理命令权，不能与 `--repo` 同用，驻守 Bot 应使用自身默认工作目录。
-- `--bot <open_id[:名字[:角色]]>` —— 兼容外部/旧链路的原始 open_id 入口；调用方自行保证 receiver 作用域、权限与接单状态。
-- `--repo <目录>` —— 只适用于已经具备 operate 信任的旧 `--bot` 链路；预设子 bot 工作目录（绝对路径，需在子 bot 所在机器上存在）。
-- `--standby` —— **必须配 `--repo`**（且不能与 `--into` 同用）：只发一次 `/repo` 把 bot 拉起到指定目录待命、不派简报，之后用 `--into ... --brief(-file)` 激活派活。
-- `--into <话题root>` —— 回到已有话题追加一条（激活待命的 bot / 追加协调）；仍需指定 bot，且非 standby 时必须带 `--brief` 或 `--brief-file`。
+然后私聊机器人、或 `botmux dashboard` 拉个群，直接开聊。完整步骤（含截图、内部一键接入、代理配置）见 **[5 分钟快速接入](https://deepcoldy.github.io/botmux/quickstart)**。
 
-子 Bot 完成后运行 `botmux report`。纯同机 `--bot-app` 派单会在每一轮任务中自动注入带精确 seed 的 `botmux report --dispatch-root <seed>` 命令，把回报直接注入 dispatch 时登记的原 PM session；即使同一 chat-scope 会话后来又收到新派单，也不会串到新 seed。legacy / mixed `--bot` 仍保留无精确 seed 的跨机兼容回退。
+## 核心场景
 
-**协作边界**：
+- **[实时流式卡片](https://deepcoldy.github.io/botmux/cards)** — 每轮对话一张实时刷新的卡片，终端画面原样截图回传；一键显示/隐藏输出、翻屏、重启/关闭/接管会话。
+- **[多机器人协作](https://deepcoldy.github.io/botmux/multi-bot)** — 同群多 bot @mention 路由，不同 CLI 背后不同模型，天然多样性；方案评审 / 代码 review / 技术选型让它们互相挑刺。
+- **[多话题并行编排](https://deepcoldy.github.io/botmux/multi-topic)** — 给编排者一个大任务，它自动在群里种话题、拉各 bot 起独立会话跑流水线，飞书任务面板一眼看完所有子任务进度。
+- **[可交互 Web 终端](https://deepcoldy.github.io/botmux/web-terminal)** — 不只是看输出，浏览器 / 手机直接操作 CLI，移动端带悬浮快捷键栏（Esc、Ctrl+C、方向键）。
+- **[会话接入 & 接力](https://deepcoldy.github.io/botmux/adopt)** — 本地 tmux 里跑到一半，手机 `/adopt` 接管；`/relay` 把整个会话（原进程、原记忆）搬进团队群继续。
+- **[定时任务 & Webhook](https://deepcoldy.github.io/botmux/schedule)** — 自然语言配周期任务（报警分析 / 群总结），或用 [Webhook / API](https://deepcoldy.github.io/botmux/webhook) 从外部系统编程式触发。
+- **[Oncall 模式 & 语音总结](https://deepcoldy.github.io/botmux/oncall)** — 拉进 oncall 群，任何成员 @ 即在项目目录排查；每张卡片页脚一键 🔊 语音总结，让模型「说人话」。
 
-- **同部署不等于隐式管理互信** —— `--bot-app` 只在目标群建立双方 receiver-scoped 的 talk-only `chatGrant`，不碰 `allowedUsers`，跑不了 `/repo` 等 operate 级命令。需要管理命令时必须另有明确的 allowedUsers / team / oncall operate 信任；`/introduce` 只负责发现 / 登记 open_id，**不授予任何权限**。
-- 子 bot 须已在群里、可被 @（具备 `im:message.group_at_msg.include_bot` 权限）。
-- 一条话题可放多个 bot，它们在话题内互相 @ 协作（如 coder 写完 @ reviewer 审）。
+更多：[角色与团队](https://deepcoldy.github.io/botmux/roles) · [文件沙盒](https://deepcoldy.github.io/botmux/sandbox) · [Dashboard 管控面](https://deepcoldy.github.io/botmux/dashboard) · [tmux 会话常驻](https://deepcoldy.github.io/botmux/tmux) · [飞书会议智能体](https://deepcoldy.github.io/botmux/voice)。
 
-### Tmux 会话常驻
+## 支持的 CLI
 
-安装 tmux 后自动启用。CLI 进程常驻在 tmux session 内，所有功能不受影响。
+`bots.json` 里用 `cliId` 一键切换，进程完全隔离。内置 **24 种适配器**：
 
-**核心收益：Daemon 重启不中断 CLI。** `botmux restart` 时 worker 进程退出，但 tmux session（及其中的 CLI 进程）保持运行。下次收到消息时 worker 自动 re-attach，无需 `--resume` 重载上下文。
+`claude-code` · `codex` · `codex-app` · `gemini` · `cursor` · `opencode` · `antigravity` · `copilot` · `grok` · `kimi` · `kiro-cli` · `pi` · `oh-my-pi` · `aiden` · `coco` · `traex` · `mtr` · `hermes` · `mira` · `mir` · `genius` · `seed` · `relay` · `riff`（云 agent）
 
-| 事件 | tmux session | CLI 进程 |
-|------|-------------|---------|
-| `botmux restart` | 存活 | 存活（下次消息 re-attach） |
-| `/close` 或关闭按钮 | 销毁 | 终止（SIGHUP） |
-| CLI 自行退出 / 崩溃 | 随之关闭 | 已退出（自动重启用新 session） |
+详见 [多 CLI 适配器](https://deepcoldy.github.io/botmux/adapters)。
 
-```bash
-# 交互式会话列表 — 选择后直接 attach 到 tmux（见 § CLI 命令）
-botmux list
+## 设计理念：直接桥接 CLI，不做 SDK wrapper
 
-# 也可以手动 attach（会话名 = bmx-<sessionId 前 8 位>）
-tmux attach -t bmx-<session-id-前8位>
-# Ctrl+B, D 退出 attach，不影响 CLI 继续运行
+botmux 不重新实现记忆、上下文管理、工具调用、权限体系——这些能力 CLI 本身都在快速迭代。botmux 直接桥接完整的 CLI 进程，站在这个进化之上：**CLI 每次升级，botmux 零适配自动受益**。用户照常发人话，daemon 在后台把上下文封装成结构化 prompt 再喂给 CLI。
 
-# 强制降级到纯 pty 模式（不使用 tmux）
-BACKEND_TYPE=pty botmux start
-```
+与基于 Agent SDK 重造一套的方案相比：
 
-### 会话接入（Adopt）
+| 维度 | botmux | 基于 Agent SDK 的方案 |
+|------|--------|----------------------|
+| 底层架构 | 直接桥接完整 CLI 进程 | 基于 SDK 重新构建 |
+| CLI 能力 | 完整运行时（hooks / memory / plan mode / MCP / `/` 命令） | SDK API 子集，缺失功能需手动补 |
+| CLI 升级 | 零适配自动受益 | 需跟进 SDK 版本变更 |
+| 记忆 / 上下文 | 直接复用 CLI 内建，随 CLI 迭代增强 | 需自建，与 CLI 原生能力重复 |
+| 多 CLI | 24 种一键切换 | 通常绑定单一 SDK |
+| 多机器人 | 同群多 bot @mention 路由 | 通常单机器人 |
+| 终端直连 | `tmux attach` 进真进程，与本地开发一致 | 通常无法直接操作底层终端 |
 
-将已在 tmux 中运行的 CLI 进程无缝接入 Botmux，在手机上通过飞书查看进度和交互。
+## 文档 · 社区 · 贡献
 
-```
-/adopt              # 弹出选择卡片：① 接管运行中的会话 ② 从磁盘 resume 导入历史会话
-/adopt 0:2.0        # 直接接入指定 tmux pane（或传历史会话 id 直接 resume 导入）
-```
+- 📖 **完整文档**（命令 / 配置 / 最佳实践 / 排错）：**<https://deepcoldy.github.io/botmux/>**
+- ✨ **效果展示**（图文 + 视频演示）：[《5 分钟创建一个真正好用的飞书助理》](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg)
+- ❓ **常见问题 / 排错**：[FAQ](https://deepcoldy.github.io/botmux/faq) · [常见踩坑](https://deepcoldy.github.io/botmux/pitfalls)
+- 🤝 **贡献**：欢迎 issue / PR。新增 CLI 适配器见 [多 CLI 适配器](https://deepcoldy.github.io/botmux/adapters)。
+- 📄 **License**：[MIT](LICENSE)
 
-- **历史会话导入** — 卡片第二栏列出本机该 CLI 的历史会话（claude-code / seed / codex / traex / antigravity / genius），选中即以 `--resume` 在原工作目录重建为标准 Botmux 会话，无需进程仍在运行、也不用先迁进 tmux
-- **共享模式** — Botmux 接入后，iTerm2 和飞书双向同步：流式卡片实时显示终端输出，飞书聊天框输入直接透传到终端
-- **一键接管** — 点击流式卡片上的「🔄 接管」按钮，Botmux 以 `--resume` 重建会话，转为标准 Botmux 会话
-- **安全断开** — 点击「⏏ 断开」，Botmux 退出观察，原 CLI 不受影响
-
-### 定时任务
-
-支持三种调度类型 + 中文自然语言，支持原话题延续（到点在同一话题内继续，不另开 thread）。
-
-**两种创建方式**：
-- **斜杠命令**（快捷）：`/schedule 每日17:50 帮我看看AI圈有什么新闻`
-- **对话触发**（灵活）：直接跟 agent 说「帮我加个每天 18:00 检查部署的定时任务」，自动触发 `botmux-schedule` Skill
-
-支持的调度格式：
-- 中文自然语言：`每日17:50` / `每周一10:00` / `30分钟后` / `明天9:00`
-- 英文 duration/interval：`30m` / `2h` / `every 30m` / `every 2h`
-- Cron 表达式：`0 9 * * *`
-- ISO 时间戳：`2026-05-01T10:00`
-
-### 与飞书话题的交互（Skill + CLI）
-
-CLI 进入 botmux 会话时自动获得 `~/.botmux/bin` 在 PATH 中，以及一组开箱即用的 Skill：
-
-- `botmux send` — 向当前话题发消息（支持文本、图片、文件、interactive 卡片 JSON、@mention）
-- `botmux history` — 读取当前会话历史消息（话题/thread 会话拉话题内，普通群 chat-scope 会话拉整群）
-- `botmux quoted <message_id>` — 用户用引用 UI @ 机器人时，按需读取被引用的那条消息
-- `botmux bots list` — 查询当前群聊的机器人及 open_id
-- `botmux schedule` — 增删改查定时任务
-- `botmux-workflow` — 用自然语言或 `/workflow` 编排有界多步任务；成功 run 可保存为 Saved Workflow 并复用
-
-这些能力通过 `--append-system-prompt` 注入和 Skill 描述自动引导 agent 使用。Skill + CLI 的组合相比 Anthropic 官方 Telegram channel 那套 MCP 方案：CLI 启动不用做 MCP 握手、不占用工具列表 token，且对 Claude Code / Codex / Cursor / Gemini / OpenCode / Antigravity / GitHub Copilot 通用 —— 只要 CLI 能读 system prompt 跑 shell 命令就行，不依赖任何 MCP 协议支持。
-
-### Dashboard 管控面
-
-> 命令行 `botmux dashboard` 出一次性 token URL，浏览器里跨所有 daemon/机器人管控
-
-- 一键定位回飞书话题 / 跳 Web 终端 / 多选批量关闭会话
-- 添加机器人对齐 Feishu 单次扫码主路径：名称可选且全程冻结，支持 AI CLI / 工作目录选择、管理员 fail-closed 补填与显式兼容模式
-- 拉新群、自动转让群主、@ 提醒
-- 解散群聊、bot 退群（关联会话自动清理）
-- **Codex 独立任务完成通知（实验性、默认关闭）**：macOS 锁屏时由所选 Bot 私聊同步 Codex App/CLI 最终回复，也覆盖 Codex App Side Chat；普通 App 会话可通过飞书回调请求运行 BotMux 的 Mac 打开原会话，或在飞书中接管继续处理，临时 Side Chat 只同步结果。在「设置 → 实验性配置」选择 Bot 与通知时机（[设计与维护说明](docs/design/codex-notifier.md)）
-- **会话洞察**（owner-only，只读）：解析各会话 transcript，看动作 span / 工作时序 / 上下文曲线 / 失败聚合 + 诊断建议；聊天里发 `/insight` 可取当前会话摘要卡
-- **Workflows 管控面**：
-  - v3 Run List 与 Run Detail 展示 DAG、节点状态、决策记录和 attempt 终端日志，到 terminal 自动停轮询
-  - **Dashboard 内可直接 cancel v3 run**；humanGate / retry / grant 继续通过绑定话题里的可信飞书卡片处理
-  - 新流程统一在飞书用自然语言或 `/workflow` 创建、运行、保存和复用；v2 Dashboard/Catalog 已下线
-
-<img src="docs/dashboard.png" alt="botmux dashboard" width="800" />
-
----
-
-## 前置要求
-
-- **Node.js** >= 22
-- **AI 编程 CLI / 本地 Agent 应用** 已安装并完成认证（`claude`、`codex`、`coco`、`cursor-agent`、`gemini`、`genius`、`opencode`、`hermes`、`seed`（Seed CLI，Claude Code 衍生）、`relay`（Relay CLI，Seed 新版）、`pi`、`omp`（oh-my-pi，Pi 衍生）、`copilot`（GitHub Copilot CLI）、`traex`（TRAE CLI）、`mircli`（Mir CLI）、`agy`（Antigravity）、`kimi`（Kimi Code）、`grok`（Grok Build）或 `kiro-cli`（Kiro）在 PATH 中）
-  - **CoCo 最低版本 `0.120.32`**：type-ahead（会话忙时即可发新消息，由 CoCo 自己的消息队列接住）依赖 0.120.32+ 的行为；更早版本忙时输入可能丢失或串行，请升级后再用
-- **tmux** >= 3.x（可选，安装后自动启用会话常驻）
-- **CJK 字体**（用于截图渲染中文/emoji）：
-  - macOS 自带 PingFang/Hiragino，无需配置
-  - Debian/Ubuntu：daemon 启动时若检测到缺字体会后台 `apt-get install fonts-noto-cjk fonts-noto-color-emoji`（需免密 sudo 或以 root 运行；装完重启 daemon 生效）
-  - 其他 Linux 发行版请手动安装 Noto CJK + Noto Color Emoji（包名视发行版而定）
-
-## 5 分钟快速接入
-
-> 💡 **TL;DR**：`npm i -g botmux` → `botmux setup`，飞书租户**扫一次码**就能建好一个可用机器人 → `botmux start`。这次扫码拿到的 Web 登录态会连续完成：按 `botmux-N`（可自定义）命名并创建应用、读取 AppID/AppSecret、导入权限、配置重定向 URL、创建并提交发布版本。整个开放平台配置都由 setup 默认完成；加 `--no-open-platform-auto` 可跳过应用创建后的权限/发版自动配置。
-
-### 1. 安装 botmux
-
-```bash
-npm install -g botmux
-# 或：pnpm add -g botmux
-# 或：bun add -g botmux
-```
-
-botmux 的手动/定时更新会识别当前全局安装归属，并继续使用同一个 npm、pnpm 或 Bun 安装位置；无法安全识别的安装方式不会自动回退到 npm。
-
-> 要求 **Node.js ≥ 22**，且本地已装好并登录至少一种 AI 编程 CLI（`claude` / `codex` / `cursor-agent` / `gemini` / `opencode` / `coco` / `agy` / `grok` / `kiro-cli` 等在 PATH 中）。推荐顺手装 **tmux**（装了自动启用会话常驻）。
-
-### 2. 创建应用并配置（`botmux setup`）
-
-跑 `botmux setup`，全程交互式选择（↑/↓ 选择、输入即搜索、⏎ 确认、Esc 取消；非交互终端自动回退为序号输入）：
-
-1. **操作**：首次安装直接进入创建流程；已有配置时先选「添加新机器人 / 重新配置 / 编辑现有机器人 / 删除机器人」。
-2. **飞书应用来源**：三选一——
-   - **一次扫码创建新应用（推荐）**：可填写机器人名称；留空自动使用 `botmux-0`、`botmux-1`……。首次扫码拿到 Web 登录态后，botmux 自动上传默认图标、创建企业自建应用、读取 AppID/AppSecret，并复用同一登录态继续配置权限与发版；后续添加会先显示当前账号与企业供确认，有效期内免扫码。Web 自动创建不可用或使用 Lark 国际版时，可由用户明确选择 `@larksuiteoapi/node-sdk` 兼容模式；兼容模式可能需要额外扫码，且应用名称由平台决定。
-   - **选择已有应用**：复用（或扫码获取）飞书 Web 登录态，列出你在开放平台创建过的应用，选中后**自动读取 AppID/AppSecret**——换机器重配、复用旧应用不用再去后台翻 Secret（仅飞书租户）。
-   - **手动输入 AppID/Secret**：见文末折叠的「手动创建应用」。
-3. **选择 CLI**：选本次要接入的 CLI（可搜索，如输入 `cla` 过滤出 Claude）。
-4. **新话题工作目录**：二选一——
-   - **固定默认目录（推荐）**：新话题直接在指定目录启动、**不弹卡片**（落 `defaultWorkingDir` 字段，之后可用 `/config` 或 `botmux setup edit` 修改）。想让机器人"直接进目录干活"选这个。
-   - **仓库选择卡片**：新话题先弹卡片，从扫描到的 git 仓库里选一个再启动，适合经常在多个仓库间切换。下一问填**仓库扫描根目录**，通常是 git 项目的**父级目录**（如 `~/projects`，支持逗号分隔多个），卡片从该目录**向下**查找 git 仓库（最多 3 层）；尽量别填 `~`（要遍历太多文件夹）。
-
-应用创建后会直接复用同一份 Web 登录态，自动导入权限、配置 `http://127.0.0.1:9768/callback` 重定向 URL、创建并提交发布版本。Feishu 主路径是**首次最多扫码一次、后续有效期内免扫**；缓存账号/企业会在创建前展示并用同一份 cookie 再次比对，登录态失效时先提示，不会静默弹码。只有用户主动「更换账号」或明确选择 SDK 兼容模式时才会重新扫码。
-
-> ✅ **飞书 (feishu.cn) 与 Lark 国际版 (larksuite.com) 均支持**。飞书走单次 Web 扫码；用户明确选择 SDK 兼容模式后，会自动识别并记住 Lark 国际版租户。手动粘 AppID/Secret 时会让你选一次租户类型。每个机器人按所属版本独立连对应域名，同一台机器可同时跑飞书 + Lark 机器人，登录凭证按应用隔离、互不干扰。
-
-setup 末尾会用 `tenant_access_token` 校验凭证（通过才落盘 `bots.json`），并把完整权限 JSON 写到 `~/.botmux/lark-scopes.json` 备查。
-
-<details>
-<summary><b>脚本化（非 TUI）setup</b> —— 给 coding agent / 自动化脚本用的字段级子命令，不依赖交互问答顺序</summary>
-
-```bash
-botmux setup list --json                     # 列出机器人（secret 脱敏）
-botmux setup add --create-app \
-  --app-name 研发助手 \
-  --allowed-users alice@example.com          # 首次扫码；后续有效登录态下免扫
-botmux setup add --create-app --switch-account \
-  --allowed-users alice@example.com          # 明确更换账号并覆盖本机登录态
-botmux setup configure botmux-1              # partial 后重跑开放平台配置并上线
-botmux setup add \
-  --app-id cli_xxx --app-secret xxx \
-  --allowed-users alice@example.com \
-  --cli codex --working-dir ~/projects       # 添加（写盘前照样校验凭证）
-botmux setup edit botmux-0 --cli claude-code \
-  --default-working-dir /data/proj           # 按字段修改；值传 - 清空
-botmux setup remove botmux-1 --yes           # 非交互删除必须 --yes
-botmux setup help                            # 完整 flag 列表
-```
-
-- `--working-dir` 是仓库选择卡片的扫描根；`--default-working-dir` 是固定默认目录（新话题直接启动、不弹卡），对应 TUI 里工作目录模式的两个选项。
-- `--create-app` 默认先复用并在 stderr 显示已确认的账号/企业；无缓存时首次扫码。`--switch-account` 强制重新扫码并覆盖本机登录态。`--json` 不会在缺少有效缓存时自行弹码，需显式加 `--switch-account`。
-- 成功 JSON 会把 `openPlatform.status` 明确标成 `ready` / `ready_with_warnings` / `manual` / `skipped`。应用和本地配置已创建、但 Feishu 权限/事件/回调等关键配置失败时，命令返回非零退出码与 `partial: true`，不会自动启动新 Bot，并给出可继续执行的 `botmux setup configure <bot>` 命令；会话失效时命令自动带 `--switch-account`，Lark 手工配置则不会给出无效的循环重试。partial Bot 仍保留在 `bots.json` 以便重试，整组 `botmux start/restart` 仍会启动它，建议先 configure 成功再重启 fleet。
-- 已有凭证模式的开放平台自动配置默认跳过，需要时显式加 `--open-platform-auto`。`--compatibility-mode` 必须显式选择，可能需要额外扫码且不支持 `--app-name`。
-- 以前对交互问答「管道喂数字」的脚本请迁移到这些子命令：问答序列一变（本版本就新增了工作目录模式一问），喂数字会静默错位。
-
-</details>
-
-### 3. 启动
-
-```bash
-botmux start
-```
-
-> start 前再校验一次凭证；权限未配齐不会阻塞 daemon，只 WARN。如果之后需要确认事件订阅，飞书后台会要求 daemon 已在跑才能识别长连接。
-
-### 4. 建群开聊
-
-1. 飞书中创建一个**话题群**
-2. 进入群设置 → 群机器人 → 添加刚创建的机器人
-3. 在群里发消息，机器人自动响应
-
-![添加机器人到群](docs/setup/add-bot-to-group.png)
-
-### 5. 开机自启（推荐）
-
-确认机器人能正常收发消息之后，跑一次：
-
-```bash
-botmux autostart enable
-```
-
-<details>
-<summary><b>手动配置开放平台：建应用 / 权限 / 重定向 / 发版（备用）</b> —— 默认由 botmux setup 使用同一次登录态自动完成，仅在自动配置失败、或想手动核对时展开</summary>
-
-<br>
-
-**手动创建应用**：去 [飞书开放平台](https://open.larkoffice.com/app) 建「企业自建应用」，在「凭证与基础信息」复制 **App ID / App Secret**，在 `botmux setup` 的「飞书应用来源」步骤选「手动输入 AppID/Secret」粘贴回来。
-
-![创建应用](docs/setup/create-app.png)
-
-**添加权限**：按 terminal 提示的一键复制命令把权限 JSON 复制到剪贴板，进入「权限管理」→「批量导入/导出权限」粘贴 → 提交审批。可用性范围选「仅自己可见」会自动通过：
-
-![权限管理](docs/setup/permissions.png)
-
-完整 JSON 已经写到 `~/.botmux/lark-scopes.json`，源仓库版本在 [src/setup/lark-scopes.json](src/setup/lark-scopes.json)（与本仓库内部 wiki 文档同步，覆盖 tenant + user 双套域 ≈ 290 项）。
-
-```bash
-# macOS 本地
-cat ~/.botmux/lark-scopes.json | pbcopy
-# Linux 桌面 (本地有 X 服务器)
-cat ~/.botmux/lark-scopes.json | xclip -selection clipboard
-# SSH / 无 DISPLAY：直接 cat, 在本地 terminal 鼠标选中即写本地剪贴板
-cat ~/.botmux/lark-scopes.json
-# SSH 上 OSC 52 直接写本地剪贴板 (iTerm2 / kitty / WezTerm / Alacritty / tmux 1.5+)
-base64 -w0 < ~/.botmux/lark-scopes.json | awk 'BEGIN{printf "\033]52;c;"}{printf "%s",$0}END{printf "\a"}'
-```
-
-**添加重定向 URL（按需）**：如果之后要在飞书里 `/login` 让 botmux 以你的身份调云文档/日历/Wiki 等 API，进入「安全设置」→「重定向 URL」填入 `http://127.0.0.1:9768/callback`。只用 bot 收发消息的话这一步可以跳过。
-
-**发版**：进入「版本管理与发布」，点击「创建版本」并发布。可用性范围选择「仅自己可见」即可自动通过审核。
-
-![发版](docs/setup/publish.png)
-
-</details>
-
-<details>
-<summary><b>机器人收不到消息时的自查</b></summary>
-
-<br>
-
-botmux 会自动开启机器人能力、长连接事件模式并订阅基础事件，正常情况下不用动。如果按上面步骤走完 bot **完全收不到任何消息**（连私聊都不回），分别确认这两项：
-
-- **事件订阅**：开放平台 → 你的应用 → 事件与回调 → 应当订阅 `im.message.receive_v1` + `card.action.trigger`（默认已订阅，如缺失就手动添加）。订阅方式必须是「使用长连接接收事件」(WebSocket)，且 botmux daemon 已经在跑。
-- **机器人能力**：开放平台 → 你的应用 → 应用功能 → 机器人 应当已开通（默认开通），名字/头像可以改。
-
-确认后重启 daemon：`botmux restart`。
-
-</details>
-
----
-
-## 使用指南
-
-### 使用流程
-
-1. 在飞书话题群中发送消息创建新话题；或在普通群中发 `/t <prompt>` 主动开新话题；也可在 Dashboard 为单个 bot 开启普通群回复开话题
-2. 机器人弹出仓库选择卡片 — 选择项目或点击「直接开启会话」（被 `/oncall bind` 绑过的 bot 会跳过此步；绑定按 bot 计）
-3. CLI 在所选目录下启动
-4. 话题中出现实时流式卡片，展示终端输出并支持 Markdown 渲染
-5. 每次回复创建新的流式卡片，上一轮卡片冻结在最后状态
-6. 点击卡片上的「🔑 获取操作链接」通过私聊获取可写终端链接
-7. CLI 通过 `botmux send` 命令在话题中回复（由 `botmux-send` Skill 自动引导）
-
----
-
-### 多步 Workflow（v3）
-
-- 直接用自然语言说“调研三家竞品并出报告”“把 A/B/C 串起来自动做”，bot 会先轻确认是否切换到 Workflow，再澄清、编排并执行有界 DAG。
-- 明确要编排时可发 `/workflow <目标>`；查看/取消 run 用 `/workflow list|show|cancel`。
-- 成功 run 可用 `/workflow save last 周报` 固化；之后 `/workflow run 周报 region=sg` 复用，缺少的必填参数会单独补问。
-- v2 runtime 已下线。旧定义与历史 run 只保留 `botmux template migrate-v3` / `archive-runs` 离线迁移归档入口。
-
----
-
-### 单个 Headless Goal（本机 CLI）
-
-`botmux goal run` 在不启动 daemon 的情况下运行一个真实 goal，适合本机脚本、CI 和人工触发的自动化。它走现有 v3 ephemeral worker、沙箱/enforcement、journal、worker fence 和 manifest 校验路径；信任边界与操作者在本机直接运行 botmux 相同，不是远程执行 API。
-
-```bash
-botmux goal run "检查仓库并生成发布说明" \
-  --bot my-codex \
-  --working-dir ~/projects/app \
-  --run-id release-notes-2026-07-22 \
-  --timeout 900 \
-  --json
-```
-
-Goal 也可来自 `--goal-file <path>` 或 `--stdin`。`--timeout` 的单位是秒；SIGINT、SIGTERM 和超时都会先把 run 折算为 durable `cancelled` 终态，再退出。
-
-`--json` 模式只向 stdout 写一份终态 JSON（`schemaVersion: "botmux.goal-run-result/v1"`），日志走 stderr。退出码是稳定的机器合同：`0` succeeded、`10` failed、`11` blocked、`12` cancelled、`13` runId/活动 driver 冲突、`14` 参数或启动错误。失败同样返回结构化 `error.code` / `error.message`。
-
-`--run-id` 是幂等键：已有终态会原样重放且不启动 worker；活动 driver 仍存活时拒绝并返回 `13`；driver 被 `kill -9` 后，用同一请求和 runId 重试会根据 v3 journal/worker fence 接续为新 attempt，不覆盖旧 attempt。不同 goal、bot、工作目录或 timeout 不能复用同一 runId。
-
-JSON 中的 `artifacts` 只包含经既有 manifest validator 验证的相对路径和摘要。`runDirectory.stability` 固定为 `informative-only`：该目录供本机诊断，不属于稳定 API，消费方不应读取其私有布局。采集不到 usage/cost 时字段会省略，不会伪造零值。
-
-当前入口仅提供本机单进程 CLI 合同，不提供 daemon/远程 Host API、事件流或跨机器 fencing；这些能力需要独立 RFC 和安全评审。
-
----
-
-### Bot 级环境变量（接入 GLM / 第三方服务商）
-
-每个 `bots.json` 条目都可以配置独立的 `env` 对象，注入到**该 bot 的 CLI 进程**。典型用途：让某个 bot 跑 GLM Coding Plan / 第三方 Anthropic·OpenAI 兼容服务商，另一个 bot 仍跑官方 Claude——只需给前者填上服务商的端点和 key：
-
-```json
-{
-  "cliId": "claude-code",
-  "workingDir": "~/projects",
-  "env": {
-    "ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
-    "ANTHROPIC_AUTH_TOKEN": "你的 GLM Coding Plan key"
-  }
-}
-```
-
-> GLM 国内站把 `ANTHROPIC_BASE_URL` 换成 `https://open.bigmodel.cn/api/anthropic`。给 Codex 这类 OpenAI 协议 CLI 接入时，填 `OPENAI_BASE_URL` / `OPENAI_API_KEY`（指向服务商的 OpenAI 兼容端点）而非 `ANTHROPIC_*`。也可用于设 `HTTPS_PROXY`、CLI 专属开关等。
-
-要点：
-
-- `env` 只接受合法环境变量名，值支持字符串、数字、布尔值；`BOTMUX_` / `LARK_APP_` 等 botmux 保留键会被忽略（防止串改会话路由/凭证）。
-- 按**会话**注入到 CLI 进程（下个新会话起效）。tmux/zellij 后端经每个 pane 的 `/usr/bin/env` 注入，**不写入共享 server 全局 env**，所以一个 bot 的服务商配置不会串到别的 bot。
-- 也可在 dashboard 的「机器人默认设置 → 环境变量」里填写（owner 鉴权），或用 `/config set env '{...}'`。
-- 不要把它当成安全密钥库：值以明文存在 `bots.json` 与进程环境中，可能被本机诊断工具看到。
-
----
-
-## 📖 完整文档
-
-命令、配置、最佳实践、排错的完整内容都在文档站，这里不再重复 ——
-
-### 👉 https://deepcoldy.github.io/botmux/
-
-| 主题 | 文档 |
-|------|------|
-| 斜杠命令 / CLI 命令 / 会话内子命令 | [命令参考](https://deepcoldy.github.io/botmux/slash-commands) |
-| `bots.json` 字段 / 环境变量 / 文件位置 | [配置参考](https://deepcoldy.github.io/botmux/bots-json) |
-| 多 CLI 适配器（含 wrapper / 网关接入） | [适配器](https://deepcoldy.github.io/botmux/adapters) |
-| 按场景的最佳实践（Oncall / 报警运维 / 个人研发 / 多人协作） | [最佳实践](https://deepcoldy.github.io/botmux/best-practices) |
-| 常见踩坑 / FAQ 排错 | [踩坑](https://deepcoldy.github.io/botmux/pitfalls) · [FAQ](https://deepcoldy.github.io/botmux/faq) |
-| 功能详解：定时任务 / Oncall / Dashboard / 多机器人协作 / 会话接力 | [定时](https://deepcoldy.github.io/botmux/schedule) · [Oncall](https://deepcoldy.github.io/botmux/oncall) · [Dashboard](https://deepcoldy.github.io/botmux/dashboard) · [多 bot](https://deepcoldy.github.io/botmux/multi-bot) · [接力](https://deepcoldy.github.io/botmux/relay) |
-
-## 贡献
-
-参见 [CONTRIBUTING.md](CONTRIBUTING.md)。
-
-## 许可证
-
-[MIT](LICENSE)
+<p align="center">好用的话，顺手点个 ⭐ Star 吧 → <a href="https://github.com/deepcoldy/botmux">deepcoldy/botmux</a></p>

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ botmux setup                 # 一次扫码建应用 → 选 CLI → 选工作�
 botmux start                 # 启动 daemon（botmux autostart enable 设开机自启）
 ```
 
-然后私聊机器人、或 `botmux dashboard` 拉个群，直接开聊。完整步骤（含 Lark 国际版、`--no-open-platform-auto` 手动建应用、排查）见 **[5 分钟快速接入](https://deepcoldy.github.io/botmux/quickstart)**。
+然后私聊机器人、或 `botmux dashboard` 拉个群，直接开聊。完整步骤（含 Lark 国际版、`--no-open-platform-auto` 后手动配置权限 / 发版、排查）见 **[5 分钟快速接入](https://deepcoldy.github.io/botmux/quickstart)**。
 
 ## 核心场景
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ---
 
-Daemon 监听飞书消息，为每个新会话自动 spawn 一个独立的 AI 编程 CLI 进程，把 CLI 的输出实时流式回传成飞书卡片，并提供可交互的 Web 终端。它**不重造 Agent 能力**，而是直接桥接你已经在用的 CLI（`botmux` 内置 **24 种适配器**，见 [支持的 CLI](#支持的-cli)）。
+Daemon 监听飞书消息，为每个新会话自动 spawn 一个独立的会话进程，把 AI 编程 CLI / Agent 的输出实时流式回传成飞书卡片，并提供可交互的 Web 终端。它**不重造 Agent 能力**，而是直接桥接你已经在用的工具（**20+ CLI / Agent 适配器**，见 [支持的 CLI / Agent](#支持的-cli--agent)）。
 
 ## 它解决什么
 
@@ -36,15 +36,15 @@ Daemon 监听飞书消息，为每个新会话自动 spawn 一个独立的 AI �
 
 ## 5 分钟接入
 
-> 扫码建应用 + 配权限走一遍，约 5 分钟。字节内部同学见 [一行命令接入](https://deepcoldy.github.io/botmux/quickstart)。
+> 约 5 分钟：`botmux setup` 一次飞书扫码就连续建好应用、配全权限、发版（`--no-open-platform-auto` 可跳过自动配置改手动建应用）。
 
 ```bash
 npm install -g botmux        # 需要 Node >= 22
-botmux setup                 # 扫码建机器人 → 选 CLI → 选工作目录 → 扫码配权限
+botmux setup                 # 一次扫码建应用 → 选 CLI → 选工作目录（自动配权限 + 发版）
 botmux start                 # 启动 daemon（botmux autostart enable 设开机自启）
 ```
 
-然后私聊机器人、或 `botmux dashboard` 拉个群，直接开聊。完整步骤（含截图、内部一键接入、代理配置）见 **[5 分钟快速接入](https://deepcoldy.github.io/botmux/quickstart)**。
+然后私聊机器人、或 `botmux dashboard` 拉个群，直接开聊。完整步骤（含 Lark 国际版、`--no-open-platform-auto` 手动建应用、排查）见 **[5 分钟快速接入](https://deepcoldy.github.io/botmux/quickstart)**。
 
 ## 核心场景
 
@@ -53,18 +53,18 @@ botmux start                 # 启动 daemon（botmux autostart enable 设开机
 - **[多话题并行编排](https://deepcoldy.github.io/botmux/multi-topic)** — 给编排者一个大任务，它自动在群里种话题、拉各 bot 起独立会话跑流水线，飞书任务面板一眼看完所有子任务进度。
 - **[可交互 Web 终端](https://deepcoldy.github.io/botmux/web-terminal)** — 不只是看输出，浏览器 / 手机直接操作 CLI，移动端带悬浮快捷键栏（Esc、Ctrl+C、方向键）。
 - **[会话接入 & 接力](https://deepcoldy.github.io/botmux/adopt)** — 本地 tmux 里跑到一半，手机 `/adopt` 接管；`/relay` 把整个会话（原进程、原记忆）搬进团队群继续。
-- **[定时任务 & Webhook](https://deepcoldy.github.io/botmux/schedule)** — 自然语言配周期任务（报警分析 / 群总结），或用 [Webhook / API](https://deepcoldy.github.io/botmux/webhook) 从外部系统编程式触发。
-- **[Oncall 模式 & 语音总结](https://deepcoldy.github.io/botmux/oncall)** — 拉进 oncall 群，任何成员 @ 即在项目目录排查；每张卡片页脚一键 🔊 语音总结，让模型「说人话」。
+- **[定时任务](https://deepcoldy.github.io/botmux/schedule) & [外部触发](https://deepcoldy.github.io/botmux/webhook)** — 自然语言配周期任务（报警分析 / 群总结）；从外部系统编程式触发用 [Webhook](https://deepcoldy.github.io/botmux/webhook) 或 [API 任务触发](https://deepcoldy.github.io/botmux/api-task-trigger)。
+- **[Oncall 模式](https://deepcoldy.github.io/botmux/oncall) & [语音总结](https://deepcoldy.github.io/botmux/voice)** — 拉进 oncall 群，任何成员 @ 即在项目目录排查；配好 TTS 后每张卡片页脚会多一个 🔊 语音总结按钮，让模型「说人话」。
 
-更多：[角色与团队](https://deepcoldy.github.io/botmux/roles) · [文件沙盒](https://deepcoldy.github.io/botmux/sandbox) · [Dashboard 管控面](https://deepcoldy.github.io/botmux/dashboard) · [tmux 会话常驻](https://deepcoldy.github.io/botmux/tmux) · [飞书会议智能体](https://deepcoldy.github.io/botmux/voice)。
+更多：[角色与团队](https://deepcoldy.github.io/botmux/roles) · [文件沙盒](https://deepcoldy.github.io/botmux/sandbox) · [Dashboard 管控面](https://deepcoldy.github.io/botmux/dashboard) · [tmux 会话常驻](https://deepcoldy.github.io/botmux/tmux) · [飞书会议智能体](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg)。
 
-## 支持的 CLI
+## 支持的 CLI / Agent
 
-`bots.json` 里用 `cliId` 一键切换，进程完全隔离。内置 **24 种适配器**：
+`bots.json` 里用 `cliId` 一键切换。**20+ 适配器**，覆盖本地 CLI（进程隔离，`tmux attach` 可直连）和 API / 云 Agent（如 Mira、riff——通过 API / 远端接入，非本地进程）。代表项：
 
-`claude-code` · `codex` · `codex-app` · `gemini` · `cursor` · `opencode` · `antigravity` · `copilot` · `grok` · `kimi` · `kiro-cli` · `pi` · `oh-my-pi` · `aiden` · `coco` · `traex` · `mtr` · `hermes` · `mira` · `mir` · `genius` · `seed` · `relay` · `riff`（云 agent）
+`claude-code` · `codex` · `gemini` · `cursor` · `opencode` · `antigravity` · `copilot` · `grok` · `kimi` · `kiro-cli` · `aiden` · `coco`(TRAE) · `hermes` · `mira` · `riff`(云 Agent) …
 
-详见 [多 CLI 适配器](https://deepcoldy.github.io/botmux/adapters)。
+完整清单与接入方式（含套 wrapper / 网关）以 [多 CLI 适配器](https://deepcoldy.github.io/botmux/adapters) 为准。
 
 ## 设计理念：直接桥接 CLI，不做 SDK wrapper
 
@@ -78,7 +78,7 @@ botmux 不重新实现记忆、上下文管理、工具调用、权限体系—�
 | CLI 能力 | 完整运行时（hooks / memory / plan mode / MCP / `/` 命令） | SDK API 子集，缺失功能需手动补 |
 | CLI 升级 | 零适配自动受益 | 需跟进 SDK 版本变更 |
 | 记忆 / 上下文 | 直接复用 CLI 内建，随 CLI 迭代增强 | 需自建，与 CLI 原生能力重复 |
-| 多 CLI | 24 种一键切换 | 通常绑定单一 SDK |
+| 多 CLI | 20+ CLI / Agent 一键切换 | 通常绑定单一 SDK |
 | 多机器人 | 同群多 bot @mention 路由 | 通常单机器人 |
 | 终端直连 | `tmux attach` 进真进程，与本地开发一致 | 通常无法直接操作底层终端 |
 
@@ -87,7 +87,8 @@ botmux 不重新实现记忆、上下文管理、工具调用、权限体系—�
 - 📖 **完整文档**（命令 / 配置 / 最佳实践 / 排错）：**<https://deepcoldy.github.io/botmux/>**
 - ✨ **效果展示**（图文 + 视频演示）：[《5 分钟创建一个真正好用的飞书助理》](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg)
 - ❓ **常见问题 / 排错**：[FAQ](https://deepcoldy.github.io/botmux/faq) · [常见踩坑](https://deepcoldy.github.io/botmux/pitfalls)
-- 🤝 **贡献**：欢迎 issue / PR。新增 CLI 适配器见 [多 CLI 适配器](https://deepcoldy.github.io/botmux/adapters)。
+- 💬 **交流群**：见 [效果展示文档](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg) 底部的内部 / 外部「Botmux 交流群」群卡片。
+- 🤝 **贡献**：欢迎 issue / PR。新增适配器见 [多 CLI 适配器](https://deepcoldy.github.io/botmux/adapters)。
 - 📄 **License**：[MIT](LICENSE)
 
 <p align="center">好用的话，顺手点个 ⭐ Star 吧 → <a href="https://github.com/deepcoldy/botmux">deepcoldy/botmux</a></p>

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Daemon 监听飞书消息，为每个新会话自动 spawn 一个独立的会话
 
 ## 5 分钟接入
 
-> 约 5 分钟：`botmux setup` 一次飞书扫码就连续建好应用、配全权限、发版（`--no-open-platform-auto` 可跳过自动配置改手动建应用）。
+> 约 5 分钟：`botmux setup` 一次飞书扫码就连续建好应用、配全权限、发版（加 `--no-open-platform-auto` 则只建应用、跳过权限与发版的自动配置，之后需手动完成；手动创建 / 粘贴凭证是 setup 里的另一个选项）。
 
 ```bash
 npm install -g botmux        # 需要 Node >= 22
@@ -56,7 +56,7 @@ botmux start                 # 启动 daemon（botmux autostart enable 设开机
 - **[定时任务](https://deepcoldy.github.io/botmux/schedule) & [外部触发](https://deepcoldy.github.io/botmux/webhook)** — 自然语言配周期任务（报警分析 / 群总结）；从外部系统编程式触发用 [Webhook](https://deepcoldy.github.io/botmux/webhook) 或 [API 任务触发](https://deepcoldy.github.io/botmux/api-task-trigger)。
 - **[Oncall 模式](https://deepcoldy.github.io/botmux/oncall) & [语音总结](https://deepcoldy.github.io/botmux/voice)** — 拉进 oncall 群，任何成员 @ 即在项目目录排查；配好 TTS 后每张卡片页脚会多一个 🔊 语音总结按钮，让模型「说人话」。
 
-更多：[角色与团队](https://deepcoldy.github.io/botmux/roles) · [文件沙盒](https://deepcoldy.github.io/botmux/sandbox) · [Dashboard 管控面](https://deepcoldy.github.io/botmux/dashboard) · [tmux 会话常驻](https://deepcoldy.github.io/botmux/tmux) · [飞书会议智能体](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg)。
+更多：[角色与团队](https://deepcoldy.github.io/botmux/roles) · [文件沙盒](https://deepcoldy.github.io/botmux/sandbox) · [Dashboard 管控面](https://deepcoldy.github.io/botmux/dashboard) · [tmux 会话常驻](https://deepcoldy.github.io/botmux/tmux) · [飞书会议智能体（效果展示）](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg)。
 
 ## 支持的 CLI / Agent
 
@@ -64,30 +64,29 @@ botmux start                 # 启动 daemon（botmux autostart enable 设开机
 
 `claude-code` · `codex` · `gemini` · `cursor` · `opencode` · `antigravity` · `copilot` · `grok` · `kimi` · `kiro-cli` · `aiden` · `coco`(TRAE) · `hermes` · `mira` · `riff`(云 Agent) …
 
-完整清单与接入方式（含套 wrapper / 网关）以 [多 CLI 适配器](https://deepcoldy.github.io/botmux/adapters) 为准。
+当前完整 `cliId` 以 [`src/adapters/cli/registry.ts`](https://github.com/deepcoldy/botmux/blob/master/src/adapters/cli/registry.ts) 为准；各 CLI 的配置与套 wrapper / 网关方法见 [多 CLI 适配器](https://deepcoldy.github.io/botmux/adapters)。
 
 ## 设计理念：直接桥接 CLI，不做 SDK wrapper
 
-botmux 不重新实现记忆、上下文管理、工具调用、权限体系——这些能力 CLI 本身都在快速迭代。botmux 直接桥接完整的 CLI 进程，站在这个进化之上：**CLI 每次升级，botmux 零适配自动受益**。用户照常发人话，daemon 在后台把上下文封装成结构化 prompt 再喂给 CLI。
+botmux 不重新实现记忆、上下文管理、工具调用、权限体系——**多数 CLI 原生能力无需 botmux 重造，CLI 升级通常直接受益**（接口 / 参数 / 输出格式 / resume 语义有变时，adapter 仍可能要跟进）。用户照常发人话，daemon 在后台把上下文封装成结构化 prompt 再喂给 CLI。基于 Agent SDK 的方案则相反：能力取决于 SDK 暴露的接口面与你自己的集成实现。
 
-与基于 Agent SDK 重造一套的方案相比：
+下表只对比**可核验的集成边界**，不对其它方案下「必然缺失」的结论：
 
-| 维度 | botmux | 基于 Agent SDK 的方案 |
+| 集成边界 | botmux | 基于 Agent SDK 的方案 |
 |------|--------|----------------------|
-| 底层架构 | 直接桥接完整 CLI 进程 | 基于 SDK 重新构建 |
-| CLI 能力 | 完整运行时（hooks / memory / plan mode / MCP / `/` 命令） | SDK API 子集，缺失功能需手动补 |
-| CLI 升级 | 零适配自动受益 | 需跟进 SDK 版本变更 |
-| 记忆 / 上下文 | 直接复用 CLI 内建，随 CLI 迭代增强 | 需自建，与 CLI 原生能力重复 |
-| 多 CLI | 20+ CLI / Agent 一键切换 | 通常绑定单一 SDK |
-| 多机器人 | 同群多 bot @mention 路由 | 通常单机器人 |
-| 终端直连 | `tmux attach` 进真进程，与本地开发一致 | 通常无法直接操作底层终端 |
+| 桥接对象 | 完整 CLI 进程（含 hooks / memory / plan mode / MCP / `/` 命令等 CLI 自带运行时） | SDK 暴露的接口面 |
+| CLI 升级 | 多数直接受益；接口 / resume 有变时 adapter 跟进 | 取决于 SDK 版本与集成实现 |
+| 记忆 / 上下文 | 直接复用 CLI 内建 | 取决于 SDK / 自建 |
+| 多 CLI / Agent | 20+ 适配器一键切换 | 取决于 SDK 覆盖面 |
+| 多机器人 | 同群多 bot @mention 路由 | 取决于实现 |
+| 终端直连 | 本地 CLI 可 `tmux attach` 进真进程 | 取决于实现 |
 
 ## 文档 · 社区 · 贡献
 
 - 📖 **完整文档**（命令 / 配置 / 最佳实践 / 排错）：**<https://deepcoldy.github.io/botmux/>**
 - ✨ **效果展示**（图文 + 视频演示）：[《5 分钟创建一个真正好用的飞书助理》](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg)
 - ❓ **常见问题 / 排错**：[FAQ](https://deepcoldy.github.io/botmux/faq) · [常见踩坑](https://deepcoldy.github.io/botmux/pitfalls)
-- 💬 **交流群**：见 [效果展示文档](https://bytedance.larkoffice.com/wiki/UBOXwH01CixfxfkqxUpcKgvQnsg) 底部的内部 / 外部「Botmux 交流群」群卡片。
+- 💬 **交流群**：[关于 & 资源](https://deepcoldy.github.io/botmux/about) 页有内部 / 外部「Botmux 交流群」的扫码入群入口。
 - 🤝 **贡献**：欢迎 issue / PR。新增适配器见 [多 CLI 适配器](https://deepcoldy.github.io/botmux/adapters)。
 - 📄 **License**：[MIT](LICENSE)
 


### PR DESCRIPTION
## 目标

旧 README 459 行、11 张内嵌图、功能全文铺开 +「使用指南」塞进 Workflow/Goal/env 细节，偏长杂乱、显旧。按 @codex 拍板的骨架与约束重写（zh + en 同批）。

## 骨架（codex 定）

Hero（一句话定位 + 4 badge + 文档/Quickstart/Showcase CTA + 1 张主 demo gif）→ 3 个用户痛点/结果 → 3 条命令、5 分钟 Quickstart → 7 个核心场景（每条一句价值 + 深链文档）→ 支持的 CLI → 直接桥接 CLI 的设计理念 + 中性对比表 → 文档/社区/贡献/License/Star。

## 约束落地

- **不写「30 秒」**——扫码建应用客观是 5 分钟路径，标题即「5 分钟接入」。
- **行数**：zh 93 + en 93 = 186 行，落在 codex 的 180-220 区间。**只留 1 张主 demo gif**，细节全部深链文档站，删掉所有 setup 内嵌截图。
- **CLI 清单以 registry 为事实源（24 个 adapter）**，不再手工写会漂移的名单：`claude-code · codex · codex-app · gemini · cursor · opencode · antigravity · copilot · grok · kimi · kiro-cli · pi · oh-my-pi · aiden · coco · traex · mtr · hermes · mira · mir · genius · seed · relay · riff`。
- **README.en.md 同批对齐**（同结构、深链走 `/en/`）。

## 验证

- 自锚点（`#5-分钟接入`/`#支持的-cli`、`#5-minute-setup`/`#supported-clis`）与各 header 的 GFM slug 匹配。
- 深链的 17 个文档站页（quickstart/cards/multi-bot/multi-topic/web-terminal/adopt/schedule/webhook/oncall/roles/sandbox/dashboard/tmux/voice/adapters/faq/pitfalls）在 master docs-site 均存在。
- 保留的资产（cover.svg、gif/fold&unfold.gif）存在。

diff：+111 / −842。@codex 请 review。未经你 review 通过不合。

🤖 Generated with [Riff](https://riff.dev)
