### PR TITLE
fix(repo): 避免默认目录模式扫描用户主目录

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -205,20 +205,19 @@ export { validateWorkingDir };
  *   1. Build candidate absolute paths — absolute / `~` taken as-is; relative or
  *      bare names resolved against each scan dir, then the daemon cwd (mirrors
  *      how the card's project list is rooted).
- *   2. Prefer a candidate matching a scanned git project (carries a branch label).
- *   3. For a bare name, also match a scanned project by basename (covers projects
- *      nested deeper than the scan-dir top level).
- *   4. Fall back to any existing directory — lenient like `/cd`, whose trust model
- *      is "owner explicitly chose a dir"; the CLI already runs with full FS access.
+ *   2. Return the first directly existing candidate, describing its git ref
+ *      without scanning unrelated roots. This is lenient like `/cd`, whose trust
+ *      model is "owner explicitly chose a dir"; the CLI already runs with full
+ *      FS access.
+ *   3. Only for a bare name that did not directly resolve, scan projects and
+ *      match by basename (covers projects nested deeper than the scan-dir top
+ *      level).
  * Returns null when nothing resolves to an existing directory.
  */
 export function resolveRepoSelection(
   repoArg: string,
   scanDirs: string[],
 ): { path: string; displayName: string } | null {
-  const existingScanDirs = scanDirs.filter((d) => existsSync(d));
-  const projects = existingScanDirs.length > 0 ? scanMultipleProjects(existingScanDirs) : [];
-
   const isExplicitPath =
     repoArg.startsWith('/') ||
     repoArg.startsWith('~') ||
@@ -233,18 +232,9 @@ export function resolveRepoSelection(
     candidates.push(resolve(expandHome(repoArg))); // daemon-cwd fallback (matches /cd)
   }
 
-  // 1) Exact scanned-project match — preferred, gives the "name (branch)" label.
-  for (const cand of candidates) {
-    const proj = projects.find((p) => resolve(p.path) === cand);
-    if (proj) return { path: proj.path, displayName: `${proj.name} (${proj.branch})` };
-  }
-  // 2) Bare name → match a scanned project by basename.
-  if (!isExplicitPath) {
-    const byName = projects.find((p) => p.name === repoArg);
-    if (byName) return { path: byName.path, displayName: `${byName.name} (${byName.branch})` };
-  }
-  // 3) Lenient fallback: any existing directory. Label it with a git ref when
-  //    it's a repo (covers explicit paths outside the scan roots), else basename.
+  // Direct candidates must win before any recursive scan. Besides avoiding
+  // unnecessary traversal (especially a legacy HOME fallback), describing just
+  // the selected directory preserves the same "name (branch)" label for repos.
   for (const cand of candidates) {
     try {
       if (!statSync(cand).isDirectory()) continue;
@@ -256,6 +246,17 @@ export function resolveRepoSelection(
       ? { path: cand, displayName: `${desc.name} (${desc.branch})` }
       : { path: cand, displayName: basename(cand) };
   }
+
+  // Explicit and relative paths have no basename-search semantics: when their
+  // concrete candidates do not exist, a recursive project scan cannot resolve
+  // them. Bare names alone may refer to a repo nested below a scan root.
+  if (isExplicitPath) return null;
+
+  const existingScanDirs = scanDirs.filter((d) => existsSync(d));
+  const projects = existingScanDirs.length > 0 ? scanMultipleProjects(existingScanDirs) : [];
+  const byName = projects.find((p) => p.name === repoArg);
+  if (byName) return { path: byName.path, displayName: `${byName.name} (${byName.branch})` };
+
   return null;
 }
 

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -222,9 +222,13 @@ export function getProjectScanDirs(ds?: DaemonSession): string[] {
   if (ds?.larkAppId) {
     const bot = getBot(ds.larkAppId);
     const dirs = new Set<string>();
-    const workingDirs = bot.config.workingDirs?.length
-      ? bot.config.workingDirs
-      : parseWorkingDirList(bot.config.workingDir ?? '~');
+    const configuredMultiDirs = parseWorkingDirList(bot.config.workingDirs);
+    const configuredLegacyDirs = parseWorkingDirList(bot.config.workingDir);
+    const workingDirs = configuredMultiDirs.length > 0
+      ? configuredMultiDirs
+      : configuredLegacyDirs.length > 0
+        ? configuredLegacyDirs
+        : [effectiveDefaultWorkingDir(bot.config) ?? '~'];
     for (const wd of workingDirs) {
       dirs.add(expandHome(wd));
     }
@@ -235,7 +239,14 @@ export function getProjectScanDirs(ds?: DaemonSession): string[] {
   }
   // Fallback to global config
   const dirs = new Set<string>();
-  for (const wd of config.daemon.workingDirs) {
+  const configuredMultiDirs = parseWorkingDirList(config.daemon.workingDirs);
+  const configuredLegacyDirs = parseWorkingDirList(config.daemon.workingDir);
+  const workingDirs = configuredMultiDirs.length > 0
+    ? configuredMultiDirs
+    : configuredLegacyDirs.length > 0
+      ? configuredLegacyDirs
+      : ['~'];
+  for (const wd of workingDirs) {
     dirs.add(expandHome(wd));
   }
   if (ds?.workingDir) {

--- a/src/services/project-scanner.ts
+++ b/src/services/project-scanner.ts
@@ -37,14 +37,22 @@ export interface ProjectScanOptions {
 }
 
 /**
- * Describe a single directory as a project: its basename + current git ref,
- * or null if the directory isn't a git repo/worktree. Used by `/repo <path>`
- * to label an explicitly given path that may sit outside the scanned roots
- * (the card's project list, by contrast, only covers the scan dirs).
+ * Describe a single directory as a project: the main worktree basename +
+ * current git ref, or null if the directory isn't a git repo/worktree. Using
+ * the main worktree name preserves the picker label for an explicitly selected
+ * linked worktree without recursively scanning the configured roots first.
  */
 export function describeProjectDir(dir: string): { name: string; branch: string } | null {
   if (!isValidGitMarker(dir)) return null;
-  return { name: basename(dir), branch: getGitRef(dir) };
+  const worktreeList = runGit('worktree list --porcelain', dir);
+  const mainWorktree = worktreeList
+    ?.split('\n')
+    .find(line => line.startsWith('worktree '))
+    ?.slice('worktree '.length);
+  return {
+    name: mainWorktree ? basename(mainWorktree) : basename(dir),
+    branch: getGitRef(dir),
+  };
 }
 
 /** `rev-parse --abbrev-ref HEAD` returns the literal string `HEAD` when

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -484,7 +484,7 @@ import { existsSync, statSync, readFileSync, mkdirSync, mkdtempSync, rmSync, wri
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { codexHome } from '../src/services/codex-paths.js';
-import { scanMultipleProjects } from '../src/services/project-scanner.js';
+import { scanMultipleProjects, describeProjectDir } from '../src/services/project-scanner.js';
 import { readGlobalConfig, repoPickerScanOptions } from '../src/global-config.js';
 import { createRepoWorktree, pushWorktreeBranch } from '../src/services/git-worktree.js';
 import { discoverAdoptableSessions } from '../src/core/session-discovery.js';
@@ -2025,14 +2025,13 @@ describe('handleCommand', () => {
 
     it('should resolve a first-level project name and switch repo (mid-session)', async () => {
       vi.mocked(existsSync).mockReturnValue(true);
-      vi.mocked(scanMultipleProjects).mockReturnValue([
-        { name: 'payments', path: '/home/testuser/payments', branch: 'main' },
-      ]);
+      vi.mocked(describeProjectDir).mockReturnValueOnce({ name: 'payments', branch: 'main' });
       const ds = makeDaemonSession({ pendingRepo: false, repoCardMessageId: 'om_card' });
       const deps = makeDeps(ds);
 
       await handleCommand('/repo', ROOT_ID, makeLarkMessage('/repo payments'), deps, LARK_APP_ID);
 
+      expect(scanMultipleProjects).not.toHaveBeenCalled();
       expect(ds.workingDir).toBe('/home/testuser/payments');
       expect(sessionStore.createSession).toHaveBeenCalledWith(
         CHAT_ID, ROOT_ID, 'payments (main)', 'group', undefined,

--- a/test/repo-selection.test.ts
+++ b/test/repo-selection.test.ts
@@ -3,12 +3,13 @@
  * which lets a user skip the Lark repo-selection card by naming a path
  * (absolute/relative) or a first-level project name under a scan dir.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { execSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, rmSync, realpathSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { resolveRepoSelection } from '../src/core/command-handler.js';
+import { logger } from '../src/utils/logger.js';
 
 function gitInit(dir: string, branch = 'main'): void {
   execSync(`git init -q -b ${branch} "${dir}"`, { stdio: 'pipe' });
@@ -42,6 +43,20 @@ describe('resolveRepoSelection', () => {
     expect(r).not.toBeNull();
     expect(realpathSync(r!.path)).toBe(repo);
     expect(r!.displayName).toBe('botmux (main)');
+  });
+
+  it('does not scan unrelated roots when a candidate directory exists directly', () => {
+    const direct = join(scanDir, 'tmp');
+    mkdirSync(direct);
+    const scanLog = vi.spyOn(logger, 'info').mockImplementation(() => {});
+
+    try {
+      const r = resolveRepoSelection('tmp', [scanDir]);
+      expect(r).toEqual({ path: direct, displayName: 'tmp' });
+      expect(scanLog).not.toHaveBeenCalledWith(expect.stringContaining('Scanned '));
+    } finally {
+      scanLog.mockRestore();
+    }
   });
 
   it('resolves an absolute path to an existing git repo', () => {
@@ -87,6 +102,17 @@ describe('resolveRepoSelection', () => {
     expect(r).not.toBeNull();
     expect(realpathSync(r!.path)).toBe(repo);
     expect(r!.displayName).toBe('app (main)');
+  });
+
+  it('still scans for a nested project matched by basename', () => {
+    const repo = join(scanDir, 'teams', 'platform', 'deep-app');
+    mkdirSync(repo, { recursive: true });
+    gitInit(repo, 'main');
+
+    const r = resolveRepoSelection('deep-app', [scanDir]);
+    expect(r).not.toBeNull();
+    expect(realpathSync(r!.path)).toBe(repo);
+    expect(r!.displayName).toBe('deep-app (main)');
   });
 
   it('falls back to a plain (non-git) directory with a basename label', () => {

--- a/test/session-manager-scan.test.ts
+++ b/test/session-manager-scan.test.ts
@@ -13,6 +13,10 @@ const mockGetBot = vi.fn();
 vi.mock('../src/bot-registry.js', () => ({
   getBot: (id: string) => mockGetBot(id),
   getAllBots: () => [],
+  effectiveDefaultWorkingDir: (cfg: any) =>
+    cfg?.defaultWorkingDir
+    || (cfg?.defaultOncall?.enabled ? cfg.defaultOncall.workingDir : undefined)
+    || undefined,
 }));
 
 vi.mock('../src/config.js', () => ({
@@ -43,6 +47,39 @@ describe('getProjectScanDir (single)', () => {
 });
 
 describe('getProjectScanDirs (multi)', () => {
+  it('uses defaultWorkingDir instead of implicitly scanning HOME', () => {
+    mockGetBot.mockReturnValue({ config: { defaultWorkingDir: '~/Code' } });
+    expect(getProjectScanDirs({ larkAppId: 'a1' } as any)).toEqual([`${HOME}/Code`]);
+  });
+
+  it('keeps workingDirs → workingDir → effective default priority', () => {
+    mockGetBot.mockReturnValue({
+      config: {
+        workingDirs: ['/repos/one', '/repos/two'],
+        workingDir: '/legacy/root',
+        defaultWorkingDir: '/default/root',
+      },
+    });
+    expect(getProjectScanDirs({ larkAppId: 'a1' } as any)).toEqual(['/repos/one', '/repos/two']);
+
+    mockGetBot.mockReturnValue({
+      config: {
+        workingDir: '/legacy/root',
+        defaultWorkingDir: '/default/root',
+      },
+    });
+    expect(getProjectScanDirs({ larkAppId: 'a1' } as any)).toEqual(['/legacy/root']);
+  });
+
+  it('uses the enabled defaultOncall dir as the effective default', () => {
+    mockGetBot.mockReturnValue({
+      config: {
+        defaultOncall: { enabled: true, workingDir: '/oncall/root' },
+      },
+    });
+    expect(getProjectScanDirs({ larkAppId: 'a1' } as any)).toEqual(['/oncall/root']);
+  });
+
   it('scans each configured workingDir from itself, not the parent', () => {
     mockGetBot.mockReturnValue({ config: { workingDir: '/repos/foo' } });
     expect(getProjectScanDirs({ larkAppId: 'a1' } as any)).toEqual(['/repos/foo']);
@@ -63,6 +100,14 @@ describe('getProjectScanDirs (multi)', () => {
     const dirs = getProjectScanDirs({ larkAppId: 'a1', workingDir: '/repos/baz' } as any);
     expect(dirs).toContain('/repos/baz');
     expect(dirs).not.toContain('/repos'); // never the parent
+  });
+
+  it('deduplicates the session workingDir after home expansion', () => {
+    mockGetBot.mockReturnValue({ config: { defaultWorkingDir: '~/Code' } });
+    expect(getProjectScanDirs({
+      larkAppId: 'a1',
+      workingDir: `${HOME}/Code`,
+    } as any)).toEqual([`${HOME}/Code`]);
   });
 
   it('falls back to global config workingDirs rooted at themselves (no bot)', () => {


### PR DESCRIPTION
## 背景与根因

普通新会话已经会用 `defaultWorkingDir` 启动，但 repo 扫描走的是另一套目录解析逻辑。仅配置 `defaultWorkingDir`、没有 legacy `workingDirs/workingDir` 时，旧逻辑会：

1. 因 `workingDirs/workingDir` 为空，把基础扫描根回退为 `~`；
2. 再把 session 的实际 `workingDir`（可能来自 `defaultWorkingDir`、oncall 或 peer inherit）额外加入。

例如 bot 只配置 `defaultWorkingDir: ~/Code`，session 也在 `~/Code` 时，旧扫描根实际是：

```text
[~, ~/Code]
```

因此正确目录虽然已经在 roots 中，HOME 仍被隐式加入。与此同时，`resolveRepoSelection()` 会在解析直接候选路径前先调用 `scanMultipleProjects()` 扫描全部 roots。结果 `/repo tmp` 即使能直接命中 `~/Code/tmp`，也会先递归扫描 HOME，包括 macOS 的 `Library/Containers`、Desktop、Documents、Downloads 等目录，并由 daemon Node 在 worker/CLI 启动前触发 TCC 权限弹窗。

根因是扫描根和解析顺序错误，不是 scanner 的权限错误处理。

## 改动

- repo scan root 统一为 `workingDirs → workingDir → effectiveDefaultWorkingDir → ~`；`effectiveDefaultWorkingDir` 继续复用现有的 `defaultWorkingDir` / enabled `defaultOncall` 语义。
- session `workingDir` 仍追加到 roots，并在展开 `~` 后去重。仅配置 `defaultWorkingDir` 时不再隐式加入 HOME。
- `/repo <arg>` 先解析显式路径和各 root 下可直接命中的目录，只读取目标目录自身的 Git 信息。
- 只有 bare name 没有直接候选、需要深层 basename 搜索时，才递归扫描项目。
- linked worktree 通过目标目录的 `git worktree list` 保留主仓显示名，无需为标签扫描其它 roots。

## 保持行为与影响面

- bare `/repo` picker 仍会主动扫描项目，但只扫描修正后的 roots。
- `/repo <数字>` 继续使用上次 picker 缓存；嵌套 repo 的 basename 搜索仍可用。
- 普通话题/群会话的启动目录和权限语义不变；oncall、peer inherit、`/cd` 产生的 session 目录仍会进入扫描范围。
- 修复位于 daemon 公共路径，对所有 CLI、PTY/Tmux、macOS/Linux 生效；没有 macOS 特判，也没有吞权限错误。

## 验证

- 扫描根、resolver、scanner 定向测试：59 passed
- `/repo` 命令层：205 passed
- repo 选择卡与 card builder：178 passed
- `pnpm build`：通过
- `git diff --check`：通过
- `pnpm test`：10,847 passed / 35 skipped；1 个未改动的 `file-lock` 并发用例在本机失败，单独运行可复现