### PR TITLE
fix(cli): BOTMUX_PUBLIC_URL 纳入 daemon env 白名单，会话内重启不再丢反代域名

### DIFF
--- a/docs-site/docs/en/env.md
+++ b/docs-site/docs/en/env.md
@@ -29,6 +29,7 @@ Most configuration goes through `bots.json` / the dashboard — you **usually do
 | `BOTMUX_DASHBOARD_HOST` | `0.0.0.0` | Dashboard HTTP bind address |
 | `BOTMUX_DASHBOARD_PORT` | `7891` | Dashboard HTTP port |
 | `BOTMUX_DASHBOARD_EXTERNAL_HOST` | `WEB_EXTERNAL_HOST` or auto-detect | Host used in URLs the CLI prints |
+| `BOTMUX_PUBLIC_URL` | _(unset)_ | Self-hosted reverse-proxy base (`scheme://host[:port]`). Set it when you don't use the central platform but front the dashboard with your own nginx etc. on a single public/intranet domain; dashboard and card terminal links then emit `<base>/…` and `<base>/s/<sessionId>` through the dashboard front door, with no per-bot port. Unset falls back to the local `host:port`. Must be written into `~/.botmux/.env` (a restart launched from inside a session reads only the file, it does not inherit the shell) |
 | `BOTMUX_DAEMON_IPC_BASE_PORT` | `7892` | Each daemon's IPC port = base + botIndex |
 | `BOTMUX_WORKFLOW_RUNS_DIR` | `~/.botmux/workflow-runs` | Workflow run storage directory |
 

--- a/docs-site/docs/zh/env.md
+++ b/docs-site/docs/zh/env.md
@@ -29,6 +29,7 @@
 | `BOTMUX_DASHBOARD_HOST` | `0.0.0.0` | dashboard HTTP 绑定地址 |
 | `BOTMUX_DASHBOARD_PORT` | `7891` | dashboard HTTP 端口 |
 | `BOTMUX_DASHBOARD_EXTERNAL_HOST` | `WEB_EXTERNAL_HOST` 或自动探测 | CLI 输出 URL 用的 host |
+| `BOTMUX_PUBLIC_URL` | _(未设置)_ | 自建反代对外基址（`scheme://host[:port]`）。没接中心平台、但自己用 nginx 等把 dashboard 反代到单一公网/内网域名时设它，dashboard / 卡片终端链接改吐 `<基址>/…`、`<基址>/s/<sessionId>`，走 dashboard 前门、无需 per-bot 端口。未设回退本地 `host:port`。必须写在 `~/.botmux/.env`（会话内发起的重启只读文件、不继承 shell） |
 | `BOTMUX_DAEMON_IPC_BASE_PORT` | `7892` | 每个 daemon 的 IPC 端口 = base + botIndex |
 | `BOTMUX_WORKFLOW_RUNS_DIR` | `~/.botmux/workflow-runs` | workflow run 存储目录 |
 

--- a/src/cli/daemon-lifecycle-env.ts
+++ b/src/cli/daemon-lifecycle-env.ts
@@ -7,6 +7,12 @@ const DAEMON_ENV_KEYS = [
   'BOTMUX_DASHBOARD_PORT',
   'BOTMUX_DAEMON_IPC_BASE_PORT',
   'BOTMUX_DASHBOARD_PUBLIC_READONLY',
+  // Self-hosted reverse-proxy base for terminal/dashboard links
+  // (publicReverseProxyBaseUrl). Left out of this list it only survived as
+  // long as every restart came from a shell that exported it — one restart
+  // from a bot session (whose pane wrapper unsets BOTMUX_*) silently demoted
+  // all web-terminal links back to raw ip:port.
+  'BOTMUX_PUBLIC_URL',
 ] as const;
 
 /**
@@ -32,5 +38,6 @@ export function resolveDaemonEnv(
     BOTMUX_DASHBOARD_PORT: resolve('BOTMUX_DASHBOARD_PORT'),
     BOTMUX_DAEMON_IPC_BASE_PORT: resolve('BOTMUX_DAEMON_IPC_BASE_PORT'),
     BOTMUX_DASHBOARD_PUBLIC_READONLY: resolve('BOTMUX_DASHBOARD_PUBLIC_READONLY'),
+    BOTMUX_PUBLIC_URL: resolve('BOTMUX_PUBLIC_URL'),
   };
 }

--- a/src/cli/daemon-lifecycle-env.ts
+++ b/src/cli/daemon-lifecycle-env.ts
@@ -1,5 +1,10 @@
 import { parse } from 'dotenv';
 
+// Keys baked into the PM2 env block (see ecosystemConfig in cli.ts). This list
+// MUST stay mirrored by detachedRestartEnv() in src/core/maintenance.ts: any key
+// added here also has to be stripped there, or a detached restart (dashboard
+// update/restart, maintenance auto-update) reuses the stale baked value instead
+// of reloading it from ~/.botmux/.env.
 const DAEMON_ENV_KEYS = [
   'WEB_EXTERNAL_HOST',
   'BOTMUX_DASHBOARD_EXTERNAL_HOST',

--- a/src/core/maintenance.ts
+++ b/src/core/maintenance.ts
@@ -247,6 +247,11 @@ export function detachedRestartEnv(inheritedEnv: NodeJS.ProcessEnv = process.env
   const env = { ...inheritedEnv };
   // The dashboard/daemon snapshot may outlive a ~/.botmux/.env edit. Let the
   // fresh CLI reload these settings from the file.
+  //
+  // This list MUST mirror DAEMON_ENV_KEYS in src/cli/daemon-lifecycle-env.ts:
+  // every key baked into the PM2 env block there has to be stripped here, or a
+  // detached restart (dashboard update/restart, maintenance auto-update) keeps
+  // the stale baked value instead of reloading from the file. Keep them in sync.
   for (const key of [
     'WEB_EXTERNAL_HOST',
     'BOTMUX_DASHBOARD_EXTERNAL_HOST',
@@ -254,6 +259,7 @@ export function detachedRestartEnv(inheritedEnv: NodeJS.ProcessEnv = process.env
     'BOTMUX_DASHBOARD_PORT',
     'BOTMUX_DAEMON_IPC_BASE_PORT',
     'BOTMUX_DASHBOARD_PUBLIC_READONLY',
+    'BOTMUX_PUBLIC_URL',
   ]) delete env[key];
   return env;
 }

--- a/test/daemon-lifecycle-env.test.ts
+++ b/test/daemon-lifecycle-env.test.ts
@@ -11,6 +11,7 @@ describe('resolveDaemonEnv()', () => {
       BOTMUX_DASHBOARD_PORT: '9999',
       BOTMUX_DAEMON_IPC_BASE_PORT: '9998',
       BOTMUX_DASHBOARD_PUBLIC_READONLY: 'false',
+      BOTMUX_PUBLIC_URL: 'http://stale.proxy.example.com',
     })).toEqual({
       WEB_EXTERNAL_HOST: '',
       BOTMUX_DASHBOARD_EXTERNAL_HOST: '',
@@ -18,6 +19,7 @@ describe('resolveDaemonEnv()', () => {
       BOTMUX_DASHBOARD_PORT: '',
       BOTMUX_DAEMON_IPC_BASE_PORT: '',
       BOTMUX_DASHBOARD_PUBLIC_READONLY: '',
+      BOTMUX_PUBLIC_URL: '',
     });
   });
 
@@ -34,6 +36,10 @@ describe('resolveDaemonEnv()', () => {
       'BOTMUX_DASHBOARD_PORT=7991',
       'BOTMUX_DAEMON_IPC_BASE_PORT=7992',
       'BOTMUX_DASHBOARD_PUBLIC_READONLY=false',
+      // The regression this pins: a bot session's pane wrapper unsets BOTMUX_*,
+      // so a self-upgrade restart from inside a session has NO inherited value —
+      // only the .env snapshot can keep web-terminal links on the proxy domain.
+      'BOTMUX_PUBLIC_URL=http://botmux.example.com',
     ].join('\n'))).toEqual({
       WEB_EXTERNAL_HOST: 'relay.example.com',
       BOTMUX_DASHBOARD_EXTERNAL_HOST: 'dashboard.example.com',
@@ -41,6 +47,7 @@ describe('resolveDaemonEnv()', () => {
       BOTMUX_DASHBOARD_PORT: '7991',
       BOTMUX_DAEMON_IPC_BASE_PORT: '7992',
       BOTMUX_DASHBOARD_PUBLIC_READONLY: 'false',
+      BOTMUX_PUBLIC_URL: 'http://botmux.example.com',
     });
   });
 
@@ -51,6 +58,7 @@ describe('resolveDaemonEnv()', () => {
       BOTMUX_DASHBOARD_PORT: '7992',
       BOTMUX_DAEMON_IPC_BASE_PORT: '7993',
       BOTMUX_DASHBOARD_PUBLIC_READONLY: 'false',
+      BOTMUX_PUBLIC_URL: 'http://shell.proxy.example.com',
     }, [
       'WEB_EXTERNAL_HOST=file.example.com',
       'BOTMUX_DASHBOARD_EXTERNAL_HOST=dashboard.example.com',
@@ -58,6 +66,7 @@ describe('resolveDaemonEnv()', () => {
       'BOTMUX_DASHBOARD_PORT=7991',
       'BOTMUX_DAEMON_IPC_BASE_PORT=7992',
       'BOTMUX_DASHBOARD_PUBLIC_READONLY=true',
+      'BOTMUX_PUBLIC_URL=http://file.proxy.example.com',
     ].join('\n'))).toEqual({
       WEB_EXTERNAL_HOST: 'shell.example.com',
       BOTMUX_DASHBOARD_EXTERNAL_HOST: 'dashboard.example.com',
@@ -65,6 +74,7 @@ describe('resolveDaemonEnv()', () => {
       BOTMUX_DASHBOARD_PORT: '7992',
       BOTMUX_DAEMON_IPC_BASE_PORT: '7993',
       BOTMUX_DASHBOARD_PUBLIC_READONLY: 'false',
+      BOTMUX_PUBLIC_URL: 'http://shell.proxy.example.com',
     });
   });
 
@@ -76,6 +86,7 @@ describe('resolveDaemonEnv()', () => {
       BOTMUX_DASHBOARD_PORT: '   ',
       BOTMUX_DAEMON_IPC_BASE_PORT: '',
       BOTMUX_DASHBOARD_PUBLIC_READONLY: '',
+      BOTMUX_PUBLIC_URL: '',
     }, [
       'WEB_EXTERNAL_HOST=file.example.com',
       'BOTMUX_DASHBOARD_EXTERNAL_HOST=dashboard.example.com',
@@ -83,6 +94,7 @@ describe('resolveDaemonEnv()', () => {
       'BOTMUX_DASHBOARD_PORT=7991',
       'BOTMUX_DAEMON_IPC_BASE_PORT=7992',
       'BOTMUX_DASHBOARD_PUBLIC_READONLY=false',
+      'BOTMUX_PUBLIC_URL=http://file.proxy.example.com',
     ].join('\n'))).toEqual({
       WEB_EXTERNAL_HOST: '',
       BOTMUX_DASHBOARD_EXTERNAL_HOST: '',
@@ -90,6 +102,7 @@ describe('resolveDaemonEnv()', () => {
       BOTMUX_DASHBOARD_PORT: '',
       BOTMUX_DAEMON_IPC_BASE_PORT: '',
       BOTMUX_DASHBOARD_PUBLIC_READONLY: '',
+      BOTMUX_PUBLIC_URL: '',
     });
   });
 });

--- a/test/maintenance.test.ts
+++ b/test/maintenance.test.ts
@@ -201,6 +201,10 @@ describe('detachedRestartEnv', () => {
       BOTMUX_DASHBOARD_PORT: '7991',
       BOTMUX_DAEMON_IPC_BASE_PORT: '7992',
       BOTMUX_DASHBOARD_PUBLIC_READONLY: 'false',
+      // Mirrors DAEMON_ENV_KEYS: a baked BOTMUX_PUBLIC_URL must be stripped too,
+      // else a detached restart keeps the stale proxy base instead of reloading
+      // it from ~/.botmux/.env.
+      BOTMUX_PUBLIC_URL: 'http://stale.proxy.example.com',
       PATH: '/usr/bin',
     };
 


### PR DESCRIPTION
## 问题

`BOTMUX_PUBLIC_URL`（自建反代对外基址，`publicReverseProxyBaseUrl()` 消费）此前只活在调用方 shell 环境里，不在 `resolveDaemonEnv` 的 `DAEMON_ENV_KEYS` 白名单中。

bot 会话的 pane wrapper 会 unset 全部 `BOTMUX_*`，所以从会话内发起的一次 `pm2 delete+start`（自我升级的常规动作）就把它从 pm2 存档里扫掉——web terminal / dashboard 链接全部退化成裸 `IP:Port`。2026-07-27 dev-beta 机器实机复现（三个 daemon 中恰好只有执行过会话内 delete+start 的那个丢失）。

## 修复

`BOTMUX_PUBLIC_URL` 加入 `DAEMON_ENV_KEYS`——复用该模块既有的「`~/.botmux/.env` 持久快照；session 内发起的重启只信文件」机制（注释原话即为此场景设计），任何来源的重启都不再依赖调用方 shell。

空串安全：`publicReverseProxyBaseUrl()` 对空串返回 null 回退本地 host:port，与其余白名单键行为一致。

## 测试

```
test/daemon-lifecycle-env.test.ts  4 passed
（覆盖：会话内重启从 .env 恢复、普通 shell 覆盖优先、显式空串清除）
```

codex 定向 review：空串消费链、tmux 清洗互不影响、sessionOrigin 语义、dashboard/terminal-url 消费路径——无 payload。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
