### PR TITLE
fix(lock): 修复 stale-claim owner 并发竞态

### DIFF
--- a/src/utils/file-lock.ts
+++ b/src/utils/file-lock.ts
@@ -36,7 +36,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { basename, dirname, join } from 'node:path';
 import { readLinuxBootIdentity, readProcessStartIdentity } from '../core/session-marker.js';
 import { logger } from './logger.js';
@@ -55,6 +55,23 @@ const MIN_INVALID_HOLDER_STALE_AGE_MS = 1_000;
 const STALE_CLAIM_PREFIX = '.botmux-stale-claim-';
 const STALE_CLAIM_OWNER_SUFFIX = '.owner-';
 const STALE_CLAIM_OWNER_WIDTH = 12;
+const STALE_CLAIM_OWNER_CANDIDATE_SUFFIX = '.candidate-';
+
+/** Deterministic filesystem interleavings for unit tests; never set in runtime code. */
+export interface FileLockTestHooks {
+  afterPinnedHolderFirstStat?: (path: string) => void | Promise<void>;
+  afterPinnedHolderFirstStatSync?: (path: string) => void;
+  beforeStaleClaimOwnerPublish?: (ownerPath: string) => void | Promise<void>;
+  beforeStaleClaimOwnerPublishSync?: (ownerPath: string) => void;
+  beforeStalePublicLockUnlink?: (lockPath: string) => void | Promise<void>;
+  beforeStalePublicLockUnlinkSync?: (lockPath: string) => void;
+}
+
+let fileLockTestHooks: FileLockTestHooks | undefined;
+
+export function __testOnly_setFileLockHooks(hooks?: FileLockTestHooks): void {
+  fileLockTestHooks = hooks;
+}
 
 interface LockHolder {
   pid: number;
@@ -158,26 +175,30 @@ function sameInode(
   return left.dev === right.dev && left.ino === right.ino;
 }
 
-async function releaseOwnedLock(lockPath: string, owned: import('node:fs').Stats): Promise<void> {
+async function releaseOwnedLock(lockPath: string, owned: import('node:fs').Stats): Promise<boolean> {
   try {
     const current = await fsp.lstat(lockPath);
     if (current.isFile() && !current.isSymbolicLink() && sameInode(current, owned)) {
       await fsp.unlink(lockPath);
+      return true;
     }
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
   }
+  return false;
 }
 
-function releaseOwnedLockSync(lockPath: string, owned: import('node:fs').Stats): void {
+function releaseOwnedLockSync(lockPath: string, owned: import('node:fs').Stats): boolean {
   try {
     const current = lstatSync(lockPath);
     if (current.isFile() && !current.isSymbolicLink() && sameInode(current, owned)) {
       unlinkSync(lockPath);
+      return true;
     }
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
   }
+  return false;
 }
 
 function staleClaimPathFor(
@@ -214,46 +235,164 @@ function parseStaleClaimOwnerEpoch(claimPath: string, name: string): number | un
   return Number.isSafeInteger(epoch) ? epoch : undefined;
 }
 
+function staleClaimOwnerCandidatePath(ownerPath: string): string {
+  return `${ownerPath}${STALE_CLAIM_OWNER_CANDIDATE_SUFFIX}${process.pid}-${randomUUID()}`;
+}
+
+function isStaleClaimOwnerCandidate(claimPath: string, name: string): boolean {
+  const prefix = `${basename(claimPath)}${STALE_CLAIM_OWNER_SUFFIX}`;
+  if (!name.startsWith(prefix)) return false;
+  const suffix = name.slice(prefix.length);
+  return new RegExp(
+    `^\\d{${STALE_CLAIM_OWNER_WIDTH}}\\${STALE_CLAIM_OWNER_CANDIDATE_SUFFIX}` +
+    '\\d+-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+  ).test(suffix);
+}
+
 interface PinnedHolderObservation {
   holder: LockHolder | undefined;
   ageMs: number;
   stats: import('node:fs').Stats;
 }
 
-async function readPinnedHolder(path: string): Promise<PinnedHolderObservation> {
+type PinnedHolderMetadataState = 'stable' | 'transient' | 'untrusted';
+
+function pinnedHolderMetadataState(
+  before: import('node:fs').Stats,
+  after: import('node:fs').Stats,
+): PinnedHolderMetadataState {
+  if (!before.isFile() || !after.isFile() || !sameInode(before, after)) return 'untrusted';
+
+  const sizeChanged = before.size !== after.size;
+  const mtimeChanged = before.mtimeMs !== after.mtimeMs;
+  const ctimeChanged = before.ctimeMs !== after.ctimeMs;
+  const linkCountChanged = before.nlink !== after.nlink;
+
+  // Compatibility with an older publisher that exposed the O_EXCL inode
+  // before writing its identity. Never trust either snapshot, but let the
+  // caller retry once the payload has become stable.
+  if (before.size === 0 && (sizeChanged || mtimeChanged || ctimeChanged)) {
+    return 'transient';
+  }
+
+  // Content-relevant metadata changing on a non-empty identity is not a
+  // normal owner lifecycle transition. In particular, a same-size rewrite
+  // followed by mtime restoration still changes ctime and fails closed below.
+  if (sizeChanged || mtimeChanged) return 'untrusted';
+
+  // link(2)/unlink(2) legitimately change ctime and nlink without touching
+  // bytes. This means the pinned inode lost a publication/cleanup race; do not
+  // use the observation, and do not surface it as a business error.
+  if (linkCountChanged) return 'transient';
+  if (ctimeChanged) return 'untrusted';
+  if (before.nlink < 1 || after.nlink < 1) return 'transient';
+  return 'stable';
+}
+
+function pinnedHolderIntegrityError(): Error {
+  return new Error('file-lock stale-claim owner changed while reading');
+}
+
+async function readPinnedHolder(path: string): Promise<PinnedHolderObservation | undefined> {
   const handle = await fsp.open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
   try {
     const before = await handle.stat();
+    if (fileLockTestHooks?.afterPinnedHolderFirstStat) {
+      await fileLockTestHooks.afterPinnedHolderFirstStat(path);
+    }
     const raw = await handle.readFile('utf8');
     const after = await handle.stat();
-    if (!before.isFile() || !sameInode(before, after) || before.size !== after.size ||
-        before.mtimeMs !== after.mtimeMs || before.ctimeMs !== after.ctimeMs) {
-      throw new Error('file-lock stale-claim owner changed while reading');
+    const pinnedState = pinnedHolderMetadataState(before, after);
+    if (pinnedState === 'transient') return undefined;
+    if (pinnedState === 'untrusted') throw pinnedHolderIntegrityError();
+
+    let current: import('node:fs').Stats;
+    try {
+      current = await fsp.lstat(path);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+      throw error;
     }
-    return { holder: parseLockHolder(raw), ageMs: Date.now() - after.mtimeMs, stats: after };
+    if (!current.isFile() || current.isSymbolicLink()) throw pinnedHolderIntegrityError();
+    if (!sameInode(after, current)) return undefined;
+    const pathnameState = pinnedHolderMetadataState(after, current);
+    if (pathnameState === 'transient') return undefined;
+    if (pathnameState === 'untrusted') throw pinnedHolderIntegrityError();
+    return { holder: parseLockHolder(raw), ageMs: Date.now() - current.mtimeMs, stats: current };
   } finally {
     await handle.close();
   }
 }
 
-function readPinnedHolderSync(path: string): PinnedHolderObservation {
+function readPinnedHolderSync(path: string): PinnedHolderObservation | undefined {
   const fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
   try {
     const before = fstatSync(fd);
+    fileLockTestHooks?.afterPinnedHolderFirstStatSync?.(path);
     const raw = readFileSync(fd, 'utf8');
     const after = fstatSync(fd);
-    if (!before.isFile() || !sameInode(before, after) || before.size !== after.size ||
-        before.mtimeMs !== after.mtimeMs || before.ctimeMs !== after.ctimeMs) {
-      throw new Error('file-lock stale-claim owner changed while reading');
+    const pinnedState = pinnedHolderMetadataState(before, after);
+    if (pinnedState === 'transient') return undefined;
+    if (pinnedState === 'untrusted') throw pinnedHolderIntegrityError();
+
+    let current: import('node:fs').Stats;
+    try {
+      current = lstatSync(path);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+      throw error;
     }
-    return { holder: parseLockHolder(raw), ageMs: Date.now() - after.mtimeMs, stats: after };
+    if (!current.isFile() || current.isSymbolicLink()) throw pinnedHolderIntegrityError();
+    if (!sameInode(after, current)) return undefined;
+    const pathnameState = pinnedHolderMetadataState(after, current);
+    if (pathnameState === 'transient') return undefined;
+    if (pathnameState === 'untrusted') throw pinnedHolderIntegrityError();
+    return { holder: parseLockHolder(raw), ageMs: Date.now() - current.mtimeMs, stats: current };
   } finally {
     closeSync(fd);
   }
 }
 
+async function unlinkUnchangedPinnedPath(
+  path: string,
+  pinned: import('node:fs').Stats,
+): Promise<boolean> {
+  let current: import('node:fs').Stats;
+  try {
+    current = await fsp.lstat(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+  if (!current.isFile() || current.isSymbolicLink()) throw pinnedHolderIntegrityError();
+  if (!sameInode(current, pinned)) return false;
+  if (pinnedHolderMetadataState(pinned, current) !== 'stable') return false;
+  await fsp.unlink(path);
+  return true;
+}
+
+function unlinkUnchangedPinnedPathSync(
+  path: string,
+  pinned: import('node:fs').Stats,
+): boolean {
+  let current: import('node:fs').Stats;
+  try {
+    current = lstatSync(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+  if (!current.isFile() || current.isSymbolicLink()) throw pinnedHolderIntegrityError();
+  if (!sameInode(current, pinned)) return false;
+  if (pinnedHolderMetadataState(pinned, current) !== 'stable') return false;
+  unlinkSync(path);
+  return true;
+}
+
 interface StaleClaimOwnership {
   ownerPath: string;
+  candidatePath: string;
+  owned: import('node:fs').Stats;
   handle: import('node:fs/promises').FileHandle;
 }
 
@@ -288,13 +427,14 @@ async function tryAcquireStaleClaimOwnership(
       return undefined;
     }
   } else {
-    let observedOwner: PinnedHolderObservation;
+    let observedOwner: PinnedHolderObservation | undefined;
     try {
       observedOwner = await readPinnedHolder(staleClaimOwnerPath(claimPath, latestEpoch));
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
       throw error;
     }
+    if (!observedOwner) return undefined;
     const staleAge = observedOwner.holder
       ? minStaleAgeMs
       : Math.max(minStaleAgeMs, MIN_INVALID_HOLDER_STALE_AGE_MS);
@@ -309,35 +449,61 @@ async function tryAcquireStaleClaimOwnership(
   }
 
   const ownerPath = staleClaimOwnerPath(claimPath, nextEpoch);
+  const candidatePath = staleClaimOwnerCandidatePath(ownerPath);
   let handle: import('node:fs/promises').FileHandle;
   try {
-    handle = await fsp.open(ownerPath, 'wx');
+    handle = await fsp.open(candidatePath, 'wx');
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'EEXIST' ||
         (error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
     throw error;
   }
+  let owned: import('node:fs').Stats | undefined;
+  const abandonCandidate = async (): Promise<void> => {
+    try { await handle.close(); } catch { /* tolerate */ }
+    if (owned) {
+      try { await releaseOwnedLock(ownerPath, owned); } catch { /* tolerate */ }
+      try { await releaseOwnedLock(candidatePath, owned); } catch { /* tolerate */ }
+    } else {
+      try { await fsp.unlink(candidatePath); } catch { /* tolerate */ }
+    }
+  };
   try {
-    // As with the public lock, publish the identity without an async gap.
     writeFileSync(handle.fd, currentLockHolderPayload());
-    const owner = await handle.stat();
-    const currentClaim = await fsp.lstat(claimPath);
-    if (!owner.isFile() || !sameInode(currentClaim, claim)) {
-      await handle.close();
-      try { await releaseOwnedLock(ownerPath, owner); } catch { /* tolerate */ }
+    owned = await handle.stat();
+    if (!owned.isFile()) throw new Error('file-lock stale-claim owner candidate is not a regular file');
+
+    const currentClaimBeforePublish = await fsp.lstat(claimPath);
+    if (!sameInode(currentClaimBeforePublish, claim)) {
+      await abandonCandidate();
       return undefined;
     }
-    return { ownerPath, handle };
+    if (fileLockTestHooks?.beforeStaleClaimOwnerPublish) {
+      await fileLockTestHooks.beforeStaleClaimOwnerPublish(ownerPath);
+    }
+    // link(2) is an atomic no-overwrite publication: readers can observe
+    // either no epoch pathname or the complete identity, never an empty file.
+    await fsp.link(candidatePath, ownerPath);
+    const publishedOwner = await fsp.lstat(ownerPath);
+    const currentClaim = await fsp.lstat(claimPath);
+    if (!publishedOwner.isFile() || publishedOwner.isSymbolicLink() ||
+        !sameInode(publishedOwner, owned) || !sameInode(currentClaim, claim)) {
+      await abandonCandidate();
+      return undefined;
+    }
+    return { ownerPath, candidatePath, owned, handle };
   } catch (error) {
-    try { await handle.close(); } catch { /* tolerate */ }
-    try { await fsp.unlink(ownerPath); } catch { /* tolerate */ }
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    await abandonCandidate();
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST' ||
+        (error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
     throw error;
   }
 }
 
 interface StaleClaimOwnershipSync {
   ownerPath: string;
+  candidatePath: string;
+  owned: import('node:fs').Stats;
   fd: number;
 }
 
@@ -370,13 +536,14 @@ function tryAcquireStaleClaimOwnershipSync(
       return undefined;
     }
   } else {
-    let observedOwner: PinnedHolderObservation;
+    let observedOwner: PinnedHolderObservation | undefined;
     try {
       observedOwner = readPinnedHolderSync(staleClaimOwnerPath(claimPath, latestEpoch));
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
       throw error;
     }
+    if (!observedOwner) return undefined;
     const staleAge = observedOwner.holder
       ? minStaleAgeMs
       : Math.max(minStaleAgeMs, MIN_INVALID_HOLDER_STALE_AGE_MS);
@@ -391,41 +558,65 @@ function tryAcquireStaleClaimOwnershipSync(
   }
 
   const ownerPath = staleClaimOwnerPath(claimPath, nextEpoch);
+  const candidatePath = staleClaimOwnerCandidatePath(ownerPath);
   let fd: number;
   try {
-    fd = openSync(ownerPath, 'wx');
+    fd = openSync(candidatePath, 'wx');
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'EEXIST' ||
         (error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
     throw error;
   }
+  let owned: import('node:fs').Stats | undefined;
+  const abandonCandidate = (): void => {
+    try { closeSync(fd); } catch { /* tolerate */ }
+    if (owned) {
+      try { releaseOwnedLockSync(ownerPath, owned); } catch { /* tolerate */ }
+      try { releaseOwnedLockSync(candidatePath, owned); } catch { /* tolerate */ }
+    } else {
+      try { unlinkSync(candidatePath); } catch { /* tolerate */ }
+    }
+  };
   try {
     writeFileSync(fd, currentLockHolderPayload());
-    const owner = fstatSync(fd);
-    const currentClaim = lstatSync(claimPath);
-    if (!owner.isFile() || !sameInode(currentClaim, claim)) {
-      closeSync(fd);
-      try { releaseOwnedLockSync(ownerPath, owner); } catch { /* tolerate */ }
+    owned = fstatSync(fd);
+    if (!owned.isFile()) throw new Error('file-lock stale-claim owner candidate is not a regular file');
+
+    const currentClaimBeforePublish = lstatSync(claimPath);
+    if (!sameInode(currentClaimBeforePublish, claim)) {
+      abandonCandidate();
       return undefined;
     }
-    return { ownerPath, fd };
+    fileLockTestHooks?.beforeStaleClaimOwnerPublishSync?.(ownerPath);
+    linkSync(candidatePath, ownerPath);
+    const publishedOwner = lstatSync(ownerPath);
+    const currentClaim = lstatSync(claimPath);
+    if (!publishedOwner.isFile() || publishedOwner.isSymbolicLink() ||
+        !sameInode(publishedOwner, owned) || !sameInode(currentClaim, claim)) {
+      abandonCandidate();
+      return undefined;
+    }
+    return { ownerPath, candidatePath, owned, fd };
   } catch (error) {
-    try { closeSync(fd); } catch { /* tolerate */ }
-    try { unlinkSync(ownerPath); } catch { /* tolerate */ }
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    abandonCandidate();
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST' ||
+        (error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
     throw error;
   }
 }
 
 async function cleanStaleClaimOwnership(claimPath: string, ownership: StaleClaimOwnership): Promise<void> {
   try { await ownership.handle.close(); } catch { /* tolerate */ }
-  try { await fsp.unlink(ownership.ownerPath); } catch { /* tolerate */ }
+  try { await releaseOwnedLock(ownership.ownerPath, ownership.owned); } catch { /* tolerate */ }
+  try { await releaseOwnedLock(ownership.candidatePath, ownership.owned); } catch { /* tolerate */ }
   // Older dead epochs are no longer security-relevant after the claim itself
   // is gone. Clean them best-effort; a loser that was already in flight may
-  // leave another harmless orphan owner file behind.
+  // leave another harmless orphan owner/candidate file behind.
   try {
     const names = await fsp.readdir(dirname(claimPath));
-    await Promise.all(names.filter(name => parseStaleClaimOwnerEpoch(claimPath, name) !== undefined).map(async name => {
+    await Promise.all(names.filter(name =>
+      parseStaleClaimOwnerEpoch(claimPath, name) !== undefined ||
+      isStaleClaimOwnerCandidate(claimPath, name)).map(async name => {
       try { await fsp.unlink(join(dirname(claimPath), name)); } catch { /* tolerate */ }
     }));
   } catch { /* tolerate */ }
@@ -433,10 +624,12 @@ async function cleanStaleClaimOwnership(claimPath: string, ownership: StaleClaim
 
 function cleanStaleClaimOwnershipSync(claimPath: string, ownership: StaleClaimOwnershipSync): void {
   try { closeSync(ownership.fd); } catch { /* tolerate */ }
-  try { unlinkSync(ownership.ownerPath); } catch { /* tolerate */ }
+  try { releaseOwnedLockSync(ownership.ownerPath, ownership.owned); } catch { /* tolerate */ }
+  try { releaseOwnedLockSync(ownership.candidatePath, ownership.owned); } catch { /* tolerate */ }
   try {
     for (const name of readdirSync(dirname(claimPath))) {
-      if (parseStaleClaimOwnerEpoch(claimPath, name) === undefined) continue;
+      if (parseStaleClaimOwnerEpoch(claimPath, name) === undefined &&
+          !isStaleClaimOwnerCandidate(claimPath, name)) continue;
       try { unlinkSync(join(dirname(claimPath), name)); } catch { /* tolerate */ }
     }
   } catch { /* tolerate */ }
@@ -465,10 +658,19 @@ async function resumeStaleBreak(
     }
 
     let current: PinnedHolderObservation | undefined;
+    let publicPathMissing = false;
     try {
       current = await readPinnedHolder(lockPath);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      publicPathMissing = true;
+    }
+    if (!current && !publicPathMissing) {
+      // The pinned inode or its pathname changed during validation. Withdraw
+      // this generation and retry from a fresh public-path observation.
+      await releaseOwnedLock(claimPath, claim);
+      claimRemoved = true;
+      return false;
     }
     if (current && sameInode(current.stats, observed)) {
       const staleAge = current.holder
@@ -483,7 +685,16 @@ async function resumeStaleBreak(
         claimRemoved = true;
         return false;
       }
-      await fsp.unlink(lockPath);
+      if (fileLockTestHooks?.beforeStalePublicLockUnlink) {
+        await fileLockTestHooks.beforeStalePublicLockUnlink(lockPath);
+      }
+      if (!(await unlinkUnchangedPinnedPath(lockPath, current.stats))) {
+        // A late holder publication or pathname replacement won the race.
+        // The pinned bytes are no longer authority to remove the public name.
+        await releaseOwnedLock(claimPath, claim);
+        claimRemoved = true;
+        return false;
+      }
       logger.warn(
         `[file-lock] broke stale lock at ${lockPath} ` +
         `(${current.holder ? `dead/reused pid ${current.holder.pid}` : 'empty/invalid holder'}, age ${current.ageMs}ms)`,
@@ -505,7 +716,8 @@ async function resumeStaleBreak(
       // This owner is returning synchronously and cannot later resume an
       // unlink. Withdraw its epoch so the same process does not look like a
       // permanently-live crashed breaker after a transient I/O error.
-      try { await fsp.unlink(ownership.ownerPath); } catch { /* tolerate */ }
+      try { await releaseOwnedLock(ownership.ownerPath, ownership.owned); } catch { /* tolerate */ }
+      try { await releaseOwnedLock(ownership.candidatePath, ownership.owned); } catch { /* tolerate */ }
     }
   }
 }
@@ -529,10 +741,17 @@ function resumeStaleBreakSync(
     }
 
     let current: PinnedHolderObservation | undefined;
+    let publicPathMissing = false;
     try {
       current = readPinnedHolderSync(lockPath);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      publicPathMissing = true;
+    }
+    if (!current && !publicPathMissing) {
+      releaseOwnedLockSync(claimPath, claim);
+      claimRemoved = true;
+      return false;
     }
     if (current && sameInode(current.stats, observed)) {
       const staleAge = current.holder
@@ -545,7 +764,12 @@ function resumeStaleBreakSync(
         claimRemoved = true;
         return false;
       }
-      unlinkSync(lockPath);
+      fileLockTestHooks?.beforeStalePublicLockUnlinkSync?.(lockPath);
+      if (!unlinkUnchangedPinnedPathSync(lockPath, current.stats)) {
+        releaseOwnedLockSync(claimPath, claim);
+        claimRemoved = true;
+        return false;
+      }
       logger.warn(
         `[file-lock] broke stale lock at ${lockPath} ` +
         `(${current.holder ? `dead/reused pid ${current.holder.pid}` : 'empty/invalid holder'}, age ${current.ageMs}ms)`,
@@ -558,7 +782,8 @@ function resumeStaleBreakSync(
     if (claimRemoved) cleanStaleClaimOwnershipSync(claimPath, ownership);
     else {
       try { closeSync(ownership.fd); } catch { /* tolerate */ }
-      try { unlinkSync(ownership.ownerPath); } catch { /* tolerate */ }
+      try { releaseOwnedLockSync(ownership.ownerPath, ownership.owned); } catch { /* tolerate */ }
+      try { releaseOwnedLockSync(ownership.candidatePath, ownership.owned); } catch { /* tolerate */ }
     }
   }
 }

--- a/src/utils/file-lock.ts
+++ b/src/utils/file-lock.ts
@@ -276,8 +276,13 @@ function pinnedHolderMetadataState(
   }
 
   // Content-relevant metadata changing on a non-empty identity is not a
-  // normal owner lifecycle transition. In particular, a same-size rewrite
-  // followed by mtime restoration still changes ctime and fails closed below.
+  // normal owner lifecycle transition. A size or mtime change fails closed
+  // here. Note we cannot detect a same-size rewrite that also restores mtime
+  // purely from metadata: ctime often does not advance within it at ms
+  // resolution (e.g. ext4), so ctime is not a reliable content-tamper signal.
+  // The legitimate owner protocol never rewrites an epoch in place (O_EXCL
+  // once, then a new epoch pathname), so this residual window is defense in
+  // depth rather than a live hazard.
   if (sizeChanged || mtimeChanged) return 'untrusted';
 
   // link(2)/unlink(2) legitimately change ctime and nlink without touching

--- a/test/file-lock.test.ts
+++ b/test/file-lock.test.ts
@@ -491,15 +491,20 @@ describe('withFileLock', () => {
     expect(lstatSync(lockPath).ino).toBe(staleInode);
   });
 
-  it('fails closed when async owner content changes with the same size and mtime', async () => {
-    const { ownerPath, old } = plantStaleClaimOwner(target, '99999998');
+  // A same-length in-flight rewrite of the owner payload is caught via mtime
+  // moving off the planted age. We deliberately do NOT restore mtime here:
+  // relying on ctime to advance is not portable (ext4's ms-resolution ctime
+  // frequently does not tick within a same-size+same-mtime rewrite, so that
+  // assertion was ~64% flaky on Linux). mtime advancing off `old` is a
+  // deterministic, cross-platform signal for the untrusted fail-closed path.
+  it('fails closed when async owner content is rewritten in flight', async () => {
+    const { ownerPath } = plantStaleClaimOwner(target, '99999998');
     let changed = false;
     __testOnly_setFileLockHooks({
       afterPinnedHolderFirstStat: path => {
         if (path !== ownerPath || changed) return;
         changed = true;
         writeFileSync(ownerPath, '99999997', 'utf8');
-        utimesSync(ownerPath, old, old);
       },
     });
 
@@ -508,15 +513,14 @@ describe('withFileLock', () => {
     expect(changed).toBe(true);
   });
 
-  it('fails closed when sync owner content changes with the same size and mtime', () => {
-    const { ownerPath, old } = plantStaleClaimOwner(target, '99999998');
+  it('fails closed when sync owner content is rewritten in flight', () => {
+    const { ownerPath } = plantStaleClaimOwner(target, '99999998');
     let changed = false;
     __testOnly_setFileLockHooks({
       afterPinnedHolderFirstStatSync: path => {
         if (path !== ownerPath || changed) return;
         changed = true;
         writeFileSync(ownerPath, '99999997', 'utf8');
-        utimesSync(ownerPath, old, old);
       },
     });
 

--- a/test/file-lock.test.ts
+++ b/test/file-lock.test.ts
@@ -18,14 +18,19 @@ import {
   readFileSync,
   readdirSync,
   statSync,
+  unlinkSync,
   utimesSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { readLinuxBootIdentity, readProcessStartIdentity } from '../src/core/session-marker.js';
-import { withFileLock, withFileLockSync } from '../src/utils/file-lock.js';
+import {
+  __testOnly_setFileLockHooks,
+  withFileLock,
+  withFileLockSync,
+} from '../src/utils/file-lock.js';
 
 function staleClaimPathForTest(lockPath: string): string {
   const observed = statSync(lockPath);
@@ -40,6 +45,22 @@ function staleClaimPathForTest(lockPath: string): string {
   return join(dirname(lockPath), `.botmux-stale-claim-${generation}`);
 }
 
+function plantStaleClaimOwner(
+  target: string,
+  ownerPayload: string,
+): { lockPath: string; claimPath: string; ownerPath: string; old: Date } {
+  const lockPath = target + '.lock';
+  writeFileSync(lockPath, '99999999', 'utf8');
+  const old = new Date(Date.now() - 5_000);
+  utimesSync(lockPath, old, old);
+  const claimPath = staleClaimPathForTest(lockPath);
+  linkSync(lockPath, claimPath);
+  const ownerPath = `${claimPath}.owner-000000000000`;
+  writeFileSync(ownerPath, ownerPayload, 'utf8');
+  utimesSync(ownerPath, old, old);
+  return { lockPath, claimPath, ownerPath, old };
+}
+
 describe('withFileLock', () => {
   let target: string;
 
@@ -47,6 +68,10 @@ describe('withFileLock', () => {
     const dir = mkdtempSync(join(tmpdir(), 'botmux-file-lock-'));
     target = join(dir, 'data.json');
     writeFileSync(target, '{}', 'utf-8');
+  });
+
+  afterEach(() => {
+    __testOnly_setFileLockHooks();
   });
 
   it('runs fn and releases the lock', async () => {
@@ -237,6 +262,267 @@ describe('withFileLock', () => {
 
     expect(results.sort((left, right) => left - right)).toEqual(Array.from({ length: 12 }, (_, index) => index));
     expect(maxInFlight).toBe(1);
+  });
+
+  it('retries when an async owner pathname is cleaned after the first pinned stat', async () => {
+    const { lockPath, claimPath, ownerPath } = plantStaleClaimOwner(target, '99999998');
+    let cleaned = false;
+    __testOnly_setFileLockHooks({
+      afterPinnedHolderFirstStat: path => {
+        if (path !== ownerPath || cleaned) return;
+        cleaned = true;
+        unlinkSync(lockPath);
+        unlinkSync(claimPath);
+        unlinkSync(ownerPath);
+      },
+    });
+
+    await expect(withFileLock(target, async () => 'lost-race-retried', { minStaleAgeMs: 0 }))
+      .resolves.toBe('lost-race-retried');
+    expect(cleaned).toBe(true);
+  });
+
+  it('retries when a sync owner pathname is cleaned after the first pinned stat', () => {
+    const { lockPath, claimPath, ownerPath } = plantStaleClaimOwner(target, '99999998');
+    let cleaned = false;
+    __testOnly_setFileLockHooks({
+      afterPinnedHolderFirstStatSync: path => {
+        if (path !== ownerPath || cleaned) return;
+        cleaned = true;
+        unlinkSync(lockPath);
+        unlinkSync(claimPath);
+        unlinkSync(ownerPath);
+      },
+    });
+
+    expect(withFileLockSync(target, () => 'lost-race-retried-sync', { minStaleAgeMs: 0 }))
+      .toBe('lost-race-retried-sync');
+    expect(cleaned).toBe(true);
+  });
+
+  it('retries an async owner observed while its empty payload is being published', async () => {
+    const { ownerPath, old } = plantStaleClaimOwner(target, '');
+    let published = false;
+    __testOnly_setFileLockHooks({
+      afterPinnedHolderFirstStat: path => {
+        if (path !== ownerPath || published) return;
+        published = true;
+        writeFileSync(ownerPath, '99999998', 'utf8');
+        utimesSync(ownerPath, old, old);
+      },
+    });
+
+    await expect(withFileLock(target, async () => 'partial-owner-retried', { minStaleAgeMs: 0 }))
+      .resolves.toBe('partial-owner-retried');
+    expect(published).toBe(true);
+  });
+
+  it('retries a sync owner observed while its empty payload is being published', () => {
+    const { ownerPath, old } = plantStaleClaimOwner(target, '');
+    let published = false;
+    __testOnly_setFileLockHooks({
+      afterPinnedHolderFirstStatSync: path => {
+        if (path !== ownerPath || published) return;
+        published = true;
+        writeFileSync(ownerPath, '99999998', 'utf8');
+        utimesSync(ownerPath, old, old);
+      },
+    });
+
+    expect(withFileLockSync(target, () => 'partial-owner-retried-sync', { minStaleAgeMs: 0 }))
+      .toBe('partial-owner-retried-sync');
+    expect(published).toBe(true);
+  });
+
+  it('publishes a complete async owner payload before making its pathname visible', async () => {
+    const lockPath = target + '.lock';
+    writeFileSync(lockPath, '99999999', 'utf8');
+    const old = new Date(Date.now() - 5_000);
+    utimesSync(lockPath, old, old);
+    let ownerAtPublish: { visible: boolean; payload?: string } | undefined;
+    __testOnly_setFileLockHooks({
+      beforeStaleClaimOwnerPublish: ownerPath => {
+        const visible = existsSync(ownerPath);
+        ownerAtPublish = {
+          visible,
+          ...(visible ? { payload: readFileSync(ownerPath, 'utf8') } : {}),
+        };
+      },
+    });
+
+    await expect(withFileLock(target, async () => 'atomically-published', { minStaleAgeMs: 0 }))
+      .resolves.toBe('atomically-published');
+    expect(ownerAtPublish).toEqual({ visible: false });
+  });
+
+  it('publishes a complete sync owner payload before making its pathname visible', () => {
+    const lockPath = target + '.lock';
+    writeFileSync(lockPath, '99999999', 'utf8');
+    const old = new Date(Date.now() - 5_000);
+    utimesSync(lockPath, old, old);
+    let ownerAtPublish: { visible: boolean; payload?: string } | undefined;
+    __testOnly_setFileLockHooks({
+      beforeStaleClaimOwnerPublishSync: ownerPath => {
+        const visible = existsSync(ownerPath);
+        ownerAtPublish = {
+          visible,
+          ...(visible ? { payload: readFileSync(ownerPath, 'utf8') } : {}),
+        };
+      },
+    });
+
+    expect(withFileLockSync(target, () => 'atomically-published-sync', { minStaleAgeMs: 0 }))
+      .toBe('atomically-published-sync');
+    expect(ownerAtPublish).toEqual({ visible: false });
+  });
+
+  it('cleans an orphaned owner publication candidate after stale recovery', async () => {
+    const lockPath = target + '.lock';
+    writeFileSync(lockPath, '99999999', 'utf8');
+    const old = new Date(Date.now() - 5_000);
+    utimesSync(lockPath, old, old);
+    const claimPath = staleClaimPathForTest(lockPath);
+    const orphanCandidate =
+      `${claimPath}.owner-000000000000.candidate-99999998-550e8400-e29b-41d4-a716-446655440000`;
+    writeFileSync(orphanCandidate, '99999998', 'utf8');
+
+    await expect(withFileLock(target, async () => 'candidate-cleaned', { minStaleAgeMs: 0 }))
+      .resolves.toBe('candidate-cleaned');
+    expect(existsSync(orphanCandidate)).toBe(false);
+  });
+
+  it('does not let an async stale waiter unlink a replacement public lock inode', async () => {
+    const lockPath = target + '.lock';
+    writeFileSync(lockPath, '99999999', 'utf8');
+    const old = new Date(Date.now() - 5_000);
+    utimesSync(lockPath, old, old);
+    let replacement: ReturnType<typeof lstatSync> | undefined;
+    let callbackCalls = 0;
+    __testOnly_setFileLockHooks({
+      beforeStalePublicLockUnlink: path => {
+        if (replacement) return;
+        unlinkSync(path);
+        writeFileSync(path, String(process.pid), 'utf8');
+        replacement = lstatSync(path);
+      },
+    });
+
+    await expect(withFileLock(target, async () => {
+      callbackCalls++;
+      return 'stolen';
+    }, { minStaleAgeMs: 0, maxWaitMs: 150 })).rejects.toThrow(/file-lock timeout/);
+    expect(callbackCalls).toBe(0);
+    expect(readFileSync(lockPath, 'utf8')).toBe(String(process.pid));
+    expect(lstatSync(lockPath).ino).toBe(replacement?.ino);
+  });
+
+  it('does not let a sync stale waiter unlink a replacement public lock inode', () => {
+    const lockPath = target + '.lock';
+    writeFileSync(lockPath, '99999999', 'utf8');
+    const old = new Date(Date.now() - 5_000);
+    utimesSync(lockPath, old, old);
+    let replacement: ReturnType<typeof lstatSync> | undefined;
+    let callbackCalls = 0;
+    __testOnly_setFileLockHooks({
+      beforeStalePublicLockUnlinkSync: path => {
+        if (replacement) return;
+        unlinkSync(path);
+        writeFileSync(path, String(process.pid), 'utf8');
+        replacement = lstatSync(path);
+      },
+    });
+
+    expect(() => withFileLockSync(target, () => {
+      callbackCalls++;
+      return 'stolen-sync';
+    }, { minStaleAgeMs: 0, maxWaitMs: 150 })).toThrow(/file-lock timeout/);
+    expect(callbackCalls).toBe(0);
+    expect(readFileSync(lockPath, 'utf8')).toBe(String(process.pid));
+    expect(lstatSync(lockPath).ino).toBe(replacement?.ino);
+  });
+
+  it('does not steal an async lock that publishes a live holder before stale unlink', async () => {
+    const lockPath = target + '.lock';
+    writeFileSync(lockPath, '99999999', 'utf8');
+    const old = new Date(Date.now() - 5_000);
+    utimesSync(lockPath, old, old);
+    const staleInode = lstatSync(lockPath).ino;
+    let published = false;
+    let callbackCalls = 0;
+    __testOnly_setFileLockHooks({
+      beforeStalePublicLockUnlink: path => {
+        if (published) return;
+        published = true;
+        writeFileSync(path, String(process.pid), 'utf8');
+      },
+    });
+
+    await expect(withFileLock(target, async () => {
+      callbackCalls++;
+      return 'stolen';
+    }, { minStaleAgeMs: 0, maxWaitMs: 150 })).rejects.toThrow(/file-lock timeout/);
+    expect(callbackCalls).toBe(0);
+    expect(readFileSync(lockPath, 'utf8')).toBe(String(process.pid));
+    expect(lstatSync(lockPath).ino).toBe(staleInode);
+  });
+
+  it('does not steal a sync lock that publishes a live holder before stale unlink', () => {
+    const lockPath = target + '.lock';
+    writeFileSync(lockPath, '99999999', 'utf8');
+    const old = new Date(Date.now() - 5_000);
+    utimesSync(lockPath, old, old);
+    const staleInode = lstatSync(lockPath).ino;
+    let published = false;
+    let callbackCalls = 0;
+    __testOnly_setFileLockHooks({
+      beforeStalePublicLockUnlinkSync: path => {
+        if (published) return;
+        published = true;
+        writeFileSync(path, String(process.pid), 'utf8');
+      },
+    });
+
+    expect(() => withFileLockSync(target, () => {
+      callbackCalls++;
+      return 'stolen-sync';
+    }, { minStaleAgeMs: 0, maxWaitMs: 150 })).toThrow(/file-lock timeout/);
+    expect(callbackCalls).toBe(0);
+    expect(readFileSync(lockPath, 'utf8')).toBe(String(process.pid));
+    expect(lstatSync(lockPath).ino).toBe(staleInode);
+  });
+
+  it('fails closed when async owner content changes with the same size and mtime', async () => {
+    const { ownerPath, old } = plantStaleClaimOwner(target, '99999998');
+    let changed = false;
+    __testOnly_setFileLockHooks({
+      afterPinnedHolderFirstStat: path => {
+        if (path !== ownerPath || changed) return;
+        changed = true;
+        writeFileSync(ownerPath, '99999997', 'utf8');
+        utimesSync(ownerPath, old, old);
+      },
+    });
+
+    await expect(withFileLock(target, async () => 'unreachable', { minStaleAgeMs: 0 }))
+      .rejects.toThrow('file-lock stale-claim owner changed while reading');
+    expect(changed).toBe(true);
+  });
+
+  it('fails closed when sync owner content changes with the same size and mtime', () => {
+    const { ownerPath, old } = plantStaleClaimOwner(target, '99999998');
+    let changed = false;
+    __testOnly_setFileLockHooks({
+      afterPinnedHolderFirstStatSync: path => {
+        if (path !== ownerPath || changed) return;
+        changed = true;
+        writeFileSync(ownerPath, '99999997', 'utf8');
+        utimesSync(ownerPath, old, old);
+      },
+    });
+
+    expect(() => withFileLockSync(target, () => 'unreachable-sync', { minStaleAgeMs: 0 }))
+      .toThrow('file-lock stale-claim owner changed while reading');
+    expect(changed).toBe(true);
   });
 
   it('recovers synchronously after a stale-break owner crashes before unlink', () => {


### PR DESCRIPTION
## 问题

在 macOS 26.5.2 / APFS / Node 24.18.0 下重复运行

`elects one stale breaker while concurrent waiters remain serialized`

会概率性失败，固定报错为：

```text
Error: file-lock stale-claim owner changed while reading
```

这不是功能分支回归：master 使用相同的 file-lock 实现。并发 stale-lock 恢复也会走这条公共路径，因此同一竞态可能在 daemon、dashboard、schedule store、sandbox migration、Mira runtime 等调用方中直接抛错。

## 根因与修复

多个 waiter 竞争 stale break 时，winner 清理 owner epoch 会改变 pinned inode 的 `ctime/nlink`。loser 虽仍固定着同一 inode，且 size、mtime、内容均未危险变化，原实现仍将其误判为 owner 被篡改。

- 先写完整 candidate，再通过 hard link 原子发布 owner epoch，消除 `open('wx') → write payload` 的空文件可见窗口
- 将 owner 尚未发布完成、pathname 被清理、仅 `ctime/nlink` 变化识别为 transient/lost race；真实内容或不可信元数据变化仍 fail closed
- stale break 前重新校验 public lock inode 与元数据，避免删除已替换的新锁
- async/sync 保持同一语义，不增加 macOS 特判

## 测试

新增确定性竞态测试，覆盖 owner 清理/发布、public lock 替换和 owner 内容篡改防御：

- `pnpm vitest run --project unit test/file-lock.test.ts`：32 passed
- 现有 12-waiter stale-breaker 用例独立重复 100 次：100/100 passed
- `pnpm test`
- `pnpm build`
