### PR TITLE
perf(adopt): 卡片选完会话后只解析目标 pane，不再全量重扫

### DIFF
--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -1027,7 +1027,14 @@ export function validateTmuxAdoptTarget(tmuxTarget: string, expectedPid: number,
       { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], env: tmuxEnv() },
     ).trim();
     panePid = Number(out);
-    if (isNaN(panePid)) return false;
+    // 死/歧义目标下 `tmux display` 打印空 stdout 并以 exit 0 返回（不进 catch），
+    // 于是 `Number('') === 0` 且 `isNaN(0) === false`——必须显式挡掉 0 与负数，否则
+    // hasCliProcess(0, expectedPid, 6) 会从 pid 0 开始 BFS 整棵进程树、每个节点再
+    // fork 一次全量 `ps`（实测 >20s 同步冻结），并且一旦 expectedPid 恰好还活在机器
+    // 上任意位置就误报 alive。这条路径由 daemon 重启时对持久化 adopt 目标的校验触发
+    // （session-manager.ts 的 restore），目标 pane 可能已在两次重启间消失。
+    // 与 discoverAdoptableSessionByTarget 的守卫同源。
+    if (!Number.isInteger(panePid) || panePid <= 0) return false;
   } catch {
     return false;
   }

--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -919,23 +919,45 @@ function resolveAdoptableSessionForPane(
  *
  * `filterCliId` 语义与 `discoverAdoptableSessions` 完全一致，调用方必须原样传入
  * 同一个值 —— 卡片 option 是用户可控输入，丢掉过滤等于允许把 bot 切到别的 CLI。
+ *
+ * ⚠️ `tmux display -t` 是**模糊解析**，且失败时不报错。实测（tmux 3.6a）：
+ *   请求 `nonexist:0.0` → exit 0，stdout 只有分隔符、pane_pid 为空串
+ *   请求 `claude:99.0`（window 索引不存在）→ exit 0，解析到 `claude:2.3`
+ *   请求 `claude:1.99`（pane 索引不存在）→ exit 0，解析到 `claude:1.1`
+ *   请求 `clau:1.3`（会话名前缀）→ exit 0，解析到 `claude:1.3`
+ * 所以既不能靠 exit code 判死活，也不能相信「拿到一个正数 pid」就等于命中了
+ * 请求的那个 pane。这里让同一条 display 连 canonical 地址一起回显，再要求它与
+ * 请求的 target **严格相等**：一次同时挡掉「空 pid」和「静默命中别的 pane」。
+ * 格式串与 `discoverAdoptableSessions` 的 list-panes 完全一致，两边可直接比较。
  */
 export function discoverAdoptableSessionByTarget(
   tmuxTarget: string,
   filterCliId?: CliId,
 ): AdoptableSession | undefined {
+  let canonicalTarget: string;
   let panePid: number;
   try {
     const out = execSync(
-      `tmux display -t ${shellescape(tmuxTarget)} -p '#{pane_pid}'`,
+      `tmux display -t ${shellescape(tmuxTarget)} -p '#{session_name}:#{window_index}.#{pane_index} #{pane_pid}'`,
       { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], env: tmuxEnv() },
     ).trim();
-    panePid = Number(out);
-    if (isNaN(panePid)) return undefined;
+    // 必须按**最后**一个空格切：会话名本身可能含空格（如「AD 智投星:0.0 651511」）。
+    // 与 discoverAdoptableSessions 解析 list-panes 的规则一致。
+    const spaceIdx = out.lastIndexOf(' ');
+    if (spaceIdx === -1) return undefined;
+    canonicalTarget = out.slice(0, spaceIdx);
+    panePid = Number(out.slice(spaceIdx + 1));
   } catch {
     // pane 已经不在了（或 tmux server 没起来）——交给调用方回落全量扫描。
     return undefined;
   }
+  // tmux 解析到了别的 pane（前缀命中 / 索引不存在时回落到活动 pane）→ 当作没找到。
+  if (canonicalTarget !== tmuxTarget) return undefined;
+  // 死目标下 pane_pid 是空串，`Number('') === 0` 且 `isNaN(0) === false`——必须显式
+  // 挡掉 0 与负数，否则 findCliProcess(0, ...) 会从 pid 0 开始遍历整棵进程树，
+  // 每个节点再 fork 一次全量 `ps`，实测 >45s 同步冻结（比它要优化掉的 5.4s 更糟，
+  // 且直接冻住 daemon 事件循环、波及所有 bot）。
+  if (!Number.isInteger(panePid) || panePid <= 0) return undefined;
   return resolveAdoptableSessionForPane(tmuxTarget, panePid, filterCliId);
 }
 

--- a/src/core/session-discovery.ts
+++ b/src/core/session-discovery.ts
@@ -813,7 +813,131 @@ export function excludeOwnedHerdrAdoptTargets(
 }
 
 
+/**
+ * 把单个 tmux pane 解析成一条可 adopt 的会话，解析不出来就返回 undefined。
+ *
+ * 这是 `discoverAdoptableSessions` 每 pane 循环体的原样抽取，目的是让「扫全部
+ * pane」和「只解析某一个 pane」共用同一份判定逻辑 —— 包括 `bmx-*` 跳过、
+ * `filterCliId` 过滤、codex launcher 跟随。两条路径必须永远同构，否则快路径会
+ * 绕开 CLI 过滤，成为把 bot 切到别的 agent 实现的口子。
+ */
+function resolveAdoptableSessionForPane(
+  tmuxTarget: string,
+  panePid: number,
+  filterCliId?: CliId,
+): AdoptableSession | undefined {
+  // 2. Filter out bmx-* sessions
+  const sessionName = tmuxTarget.split(':')[0];
+  if (sessionName?.startsWith('bmx-')) return undefined;
+
+  // 3. Recursively search process tree for known CLI binaries (up to 3 levels)
+  const match = findCliProcess(panePid, 3, filterCliId);
+  if (!match) return undefined;
+
+  // 3b. Filter by CLI type if requested
+  if (filterCliId && match.cliId !== filterCliId) return undefined;
+
+  // npm's `codex` shim can remain as a Node launcher whose argv matches
+  // before generic discovery reaches the native child. Only follow that
+  // launcher: a process whose comm is already `codex` is the selected CLI
+  // itself and may legitimately have another Codex deeper in its tree.
+  // Other CLIs preserve legacy pid selection; their wrapper behavior is
+  // handled by explicit wrapperCli.
+  const cliPid = match.cliId === 'codex' && !match.matchedByComm
+    ? (findLaunchedCliPid(match.pid, 'codex') ?? match.pid)
+    : match.pid;
+
+  // 4. Read CLI working directory (Linux: /proc; macOS: lsof)
+  const cwd = readCwd(cliPid);
+  if (!cwd) return undefined;
+
+  // 5. Try to read CLI session metadata
+  let sessionId: string | undefined;
+  let startedAt: number | undefined;
+  if (match.cliId === 'claude-code') {
+    const meta = readClaudeSessionMeta(cliPid);
+    if (meta) {
+      sessionId = meta.sessionId;
+      startedAt = meta.startedAt;
+    }
+  } else if (match.cliId === 'codex') {
+    // Codex has no per-pid state file — bind via the native process's open
+    // rollout fd. Missing is acceptable: the worker keeps polling cliPid
+    // and attaches when the first post-adopt turn creates/opens the file.
+    const rollout = findCodexRolloutByPid(cliPid);
+    if (rollout) sessionId = rollout.cliSessionId;
+  } else if (match.cliId === 'coco') {
+    // CoCo: probe /proc/<pid>/fd for an open file under the session dir
+    // (session.log / traces.jsonl). events.jsonl itself is opened-written-
+    // closed per event so it's not reliable on its own. Worker-side
+    // re-probes too, so undefined here is acceptable.
+    const cocoSession = findCocoSessionByPid(cliPid);
+    if (cocoSession) sessionId = cocoSession.sessionId;
+  } else if (match.cliId === 'traex') {
+    // TRAE: same open-rollout-fd probe as Codex, with a TRAE-specific
+    // path matcher (~/.trae/cli/sessions/...). Worker-side re-probes by
+    // pid as a fallback, so undefined here is acceptable.
+    const rollout = findTraexRolloutByPid(cliPid);
+    if (rollout) sessionId = rollout.cliSessionId;
+  }
+
+  // 5b. Fall back to the CLI process's own start time for uptime. Without
+  // this only Claude (which has a session JSON with startedAt) shows a real
+  // uptime; every other CLI — cursor/codex/coco/gemini… — rendered "未知".
+  if (startedAt === undefined) {
+    startedAt = readProcessStartTime(cliPid);
+  }
+
+  // 6. Get pane dimensions
+  const dims = getPaneDimensions(tmuxTarget);
+  if (!dims) return undefined;
+
+  return {
+    source: 'tmux',
+    tmuxTarget,
+    panePid,
+    cliPid,
+    cliId: match.cliId,
+    sessionId,
+    cwd,
+    startedAt,
+    paneCols: dims.cols,
+    paneRows: dims.rows,
+  };
+}
+
 // ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * 只解析指定的那一个 tmux pane，不扫全机。
+ *
+ * 用在「用户已经从 /adopt 卡片里选好了目标」这种场景：卡片 option 里带着 tmux
+ * 地址，没必要为了拿到 cwd / 尺寸 / sessionId 再把所有 pane 重扫一遍。全量扫描
+ * 要对每个 pane 走进程树、且树里每个节点都拉一次全量 `ps`，pane 一多就是数秒级
+ * 同步阻塞（本机 31 个 pane 实测 5.4s）；而飞书卡片回调只有 3s 预算，超了用户就
+ * 会看到「目标回调服务超时未响应」。
+ *
+ * `filterCliId` 语义与 `discoverAdoptableSessions` 完全一致，调用方必须原样传入
+ * 同一个值 —— 卡片 option 是用户可控输入，丢掉过滤等于允许把 bot 切到别的 CLI。
+ */
+export function discoverAdoptableSessionByTarget(
+  tmuxTarget: string,
+  filterCliId?: CliId,
+): AdoptableSession | undefined {
+  let panePid: number;
+  try {
+    const out = execSync(
+      `tmux display -t ${shellescape(tmuxTarget)} -p '#{pane_pid}'`,
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], env: tmuxEnv() },
+    ).trim();
+    panePid = Number(out);
+    if (isNaN(panePid)) return undefined;
+  } catch {
+    // pane 已经不在了（或 tmux server 没起来）——交给调用方回落全量扫描。
+    return undefined;
+  }
+  return resolveAdoptableSessionForPane(tmuxTarget, panePid, filterCliId);
+}
 
 /**
  * Scan all tmux panes for running CLI processes that can be adopted by Botmux.
@@ -853,84 +977,9 @@ export function discoverAdoptableSessions(filterCliId?: CliId): AdoptableSession
       const panePid = Number(line.slice(spaceIdx + 1));
       if (isNaN(panePid)) continue;
 
-      // 2. Filter out bmx-* sessions
-      const sessionName = tmuxTarget.split(':')[0];
-      if (sessionName?.startsWith('bmx-')) continue;
-
-      // 3. Recursively search process tree for known CLI binaries (up to 3 levels)
-      const match = findCliProcess(panePid, 3, filterCliId);
-      if (!match) continue;
-
-      // 3b. Filter by CLI type if requested
-      if (filterCliId && match.cliId !== filterCliId) continue;
-
-      // npm's `codex` shim can remain as a Node launcher whose argv matches
-      // before generic discovery reaches the native child. Only follow that
-      // launcher: a process whose comm is already `codex` is the selected CLI
-      // itself and may legitimately have another Codex deeper in its tree.
-      // Other CLIs preserve legacy pid selection; their wrapper behavior is
-      // handled by explicit wrapperCli.
-      const cliPid = match.cliId === 'codex' && !match.matchedByComm
-        ? (findLaunchedCliPid(match.pid, 'codex') ?? match.pid)
-        : match.pid;
-
-      // 4. Read CLI working directory (Linux: /proc; macOS: lsof)
-      const cwd = readCwd(cliPid);
-      if (!cwd) continue;
-
-      // 5. Try to read CLI session metadata
-      let sessionId: string | undefined;
-      let startedAt: number | undefined;
-      if (match.cliId === 'claude-code') {
-        const meta = readClaudeSessionMeta(cliPid);
-        if (meta) {
-          sessionId = meta.sessionId;
-          startedAt = meta.startedAt;
-        }
-      } else if (match.cliId === 'codex') {
-        // Codex has no per-pid state file — bind via the native process's open
-        // rollout fd. Missing is acceptable: the worker keeps polling cliPid
-        // and attaches when the first post-adopt turn creates/opens the file.
-        const rollout = findCodexRolloutByPid(cliPid);
-        if (rollout) sessionId = rollout.cliSessionId;
-      } else if (match.cliId === 'coco') {
-        // CoCo: probe /proc/<pid>/fd for an open file under the session dir
-        // (session.log / traces.jsonl). events.jsonl itself is opened-written-
-        // closed per event so it's not reliable on its own. Worker-side
-        // re-probes too, so undefined here is acceptable.
-        const cocoSession = findCocoSessionByPid(cliPid);
-        if (cocoSession) sessionId = cocoSession.sessionId;
-      } else if (match.cliId === 'traex') {
-        // TRAE: same open-rollout-fd probe as Codex, with a TRAE-specific
-        // path matcher (~/.trae/cli/sessions/...). Worker-side re-probes by
-        // pid as a fallback, so undefined here is acceptable.
-        const rollout = findTraexRolloutByPid(cliPid);
-        if (rollout) sessionId = rollout.cliSessionId;
-      }
-
-      // 5b. Fall back to the CLI process's own start time for uptime. Without
-      // this only Claude (which has a session JSON with startedAt) shows a real
-      // uptime; every other CLI — cursor/codex/coco/gemini… — rendered "未知".
-      if (startedAt === undefined) {
-        startedAt = readProcessStartTime(cliPid);
-      }
-
-      // 6. Get pane dimensions
-      const dims = getPaneDimensions(tmuxTarget);
-      if (!dims) continue;
-
-      results.push({
-        source: 'tmux',
-        tmuxTarget,
-        panePid,
-        cliPid,
-        cliId: match.cliId,
-        sessionId,
-        cwd,
-        startedAt,
-        paneCols: dims.cols,
-        paneRows: dims.rows,
-      });
+      // 2-6 与单 pane 快路径共用同一份判定，见 resolveAdoptableSessionForPane。
+      const session = resolveAdoptableSessionForPane(tmuxTarget, panePid, filterCliId);
+      if (session) results.push(session);
     }
   }
 

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -2646,7 +2646,24 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
         return discoverAdoptableZellijSessions(botCfg.cliId)
           .find(s => s.zellijSession === selected.zellijSession && s.zellijPaneId === selected.zellijPaneId);
       }
-      const { discoverAdoptableSessions, excludeOwnedHerdrAdoptTargets, adoptTargetKey } = await import('../../core/session-discovery.js');
+      const { discoverAdoptableSessions, discoverAdoptableSessionByTarget, excludeOwnedHerdrAdoptTargets, adoptTargetKey } = await import('../../core/session-discovery.js');
+
+      const matchesSelected = (s: import('../../core/session-discovery.js').AdoptableSession) => selected.key
+        ? adoptTargetKey(s) === selected.key
+        : s.tmuxTarget === selected.tmuxTarget && s.cliPid === selected.cliPid;
+
+      // 快路径：卡片 option 里已经带着 tmux 地址，先只解析那一个 pane。
+      // 全量扫描要对每个 pane 走进程树、且树里每个节点都拉一次全量 `ps`，pane 一多
+      // 就是数秒级同步阻塞（31 个 pane 实测 5.4s）。这里是卡片回调，飞书只给 3s
+      // 且**不会重推**，超时用户就看到「目标回调服务超时未响应」；更糟的是同步
+      // execSync 会把事件循环整个冻住，连 2500ms 提前 ACK 的保险丝都发不出去。
+      // 只收窄候选集、判定谓词与全量路径完全一致，没命中就原样回落全量扫描，
+      // 因此不改变任何既有结果，最差只多一次廉价的 tmux display。
+      if (selected.source !== 'herdr' && selected.tmuxTarget) {
+        const fast = discoverAdoptableSessionByTarget(selected.tmuxTarget, botCfg.cliId);
+        if (fast && matchesSelected(fast)) return fast;
+      }
+
       const ownedHerdrTargets = [...activeSessions.values()].flatMap(active => {
         const target = active.session.persistentBackendTarget;
         return active.session.status === 'active'
@@ -2659,9 +2676,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       return excludeOwnedHerdrAdoptTargets(
         discoverAdoptableSessions(botCfg.cliId),
         ownedHerdrTargets,
-      ).find(s => selected.key
-          ? adoptTargetKey(s) === selected.key
-          : s.tmuxTarget === selected.tmuxTarget && s.cliPid === selected.cliPid);
+      ).find(matchesSelected);
     }
     // Discovery scans a live process tree and can transiently miss a pane under
     // load (a racing `ps` snapshot); retry a few times before giving up so a

--- a/test/session-adopt.test.ts
+++ b/test/session-adopt.test.ts
@@ -334,6 +334,8 @@ describe('Adopt card actions', () => {
       // Mock discoverAdoptableSessions to return empty (target gone)
       vi.doMock('../src/core/session-discovery.js', () => ({
         discoverAdoptableSessions: vi.fn(() => []),
+        // 单 pane 快路径同样解析不到（pane 已经没了），card-handler 会回落全量扫描。
+        discoverAdoptableSessionByTarget: vi.fn(() => undefined),
         excludeOwnedHerdrAdoptTargets: vi.fn((sessions: unknown[]) => sessions),
         // card-handler now also pulls adoptTargetKey to disambiguate herdr
         // vs. tmux targets in the dropdown's selected-value. The empty

--- a/test/session-discovery.test.ts
+++ b/test/session-discovery.test.ts
@@ -1090,6 +1090,25 @@ describe('validateAdoptTarget', () => {
     expect(result).toBe(false);
   });
 
+  it('死目标返回空 pane_pid + exit 0 时返回 false，绝不落到 pid 0 的进程树遍历', () => {
+    // 回归（与 discoverAdoptableSessionByTarget 同源）：`tmux display -t` 对死/歧义
+    // 目标不报错，只打印空 pane_pid，`Number('') === 0` 且 `isNaN(0) === false`。
+    // 少了正数校验就会调 hasCliProcess(0, expectedPid, 6)：从 pid 0 BFS 整棵进程树、
+    // 每个节点 fork 一次全量 `ps`（实测 >20s 同步冻结），且一旦 expectedPid 恰好还活在
+    // 机器上任意位置就误报 alive。这条路径由 daemon 重启对持久化 adopt 目标的校验触发。
+    // 注意与上面「pane not found」那条（mock 抛错）不同：这条不抛异常。
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = String(cmd);
+      if (cmdStr.includes('pane_pid')) return '\n';  // 真机对死目标的原样回显：空 pid
+      throw new Error(`unexpected command: ${cmdStr}`);
+    });
+
+    expect(validateAdoptTarget(tmuxTarget('nonexist:0.0', 1001))).toBe(false);
+
+    const cmds = mockExecSync.mock.calls.map(([c]) => String(c));
+    expect(cmds.some(c => c.includes('ps '))).toBe(false);  // 没碰进程树 → 没冻结
+  });
+
   it('should return false when CLI process has exited', () => {
     setupMocks({
       paneLines: 'mysession:0.0 1000\n',

--- a/test/session-discovery.test.ts
+++ b/test/session-discovery.test.ts
@@ -33,6 +33,7 @@ import { execSync } from 'node:child_process';
 import { readFileSync, readlinkSync, existsSync, readdirSync } from 'node:fs';
 import {
   discoverAdoptableSessions,
+  discoverAdoptableSessionByTarget,
   validateAdoptTarget,
   isBareShellComm,
   bareShellLaunchKind,
@@ -193,12 +194,15 @@ function setupMocks(opts: {
     if (displayMatch) {
       const target = displayMatch[1];
 
-      // pane_pid query (for validateAdoptTarget)
+      // pane_pid query (for validateAdoptTarget / discoverAdoptableSessionByTarget)
       if (cmdStr.includes('pane_pid')) {
-        // Extract the target and find matching pane from paneLines
+        // Extract the target and find matching pane from paneLines.
+        // 取 pid 必须按**最后**一个空格切：会话名本身可能含空格
+        // （如「AD 智投星:0.0 651511」），按第一个空格切会把 pid 取成会话名的后半段。
+        // 这与 discoverAdoptableSessions 解析 list-panes 输出的规则一致。
         for (const line of paneLines.split('\n')) {
           if (line.startsWith(target + ' ')) {
-            return line.split(' ')[1] + '\n';
+            return line.slice(line.lastIndexOf(' ') + 1) + '\n';
           }
         }
         throw new Error('pane not found');
@@ -881,6 +885,107 @@ describe('discoverAdoptableSessions', () => {
     expect(results).toHaveLength(1);
     expect(results[0]!.cliId).toBe('traex');
     expect(results[0]!.cwd).toBe('/workspace/trae-proj');
+  });
+});
+
+describe('discoverAdoptableSessionByTarget', () => {
+  // 三个 pane，其中只有一个是我们要解析的目标。全量扫描会把三个都走一遍进程树，
+  // 快路径只碰目标那一个。
+  const threePanes = {
+    paneLines: 'dev:0.0 1000\ndev:0.1 2000\nother:0.0 3000\n',
+    commMap: { 1000: 'zsh', 1001: 'claude', 2000: 'zsh', 2001: 'codex', 3000: 'zsh', 3001: 'claude' },
+    childMap: { 1000: [1001], 2000: [2001], 3000: [3001] },
+    cwdMap: { 1001: '/project/a', 2001: '/project/b', 3001: '/project/c' },
+    dimsMap: { 'dev:0.0': '120 40', 'dev:0.1': '80 24', 'other:0.0': '200 50' },
+    claudeMeta: {
+      1001: JSON.stringify({ sessionId: 'sess-a', cwd: '/project/a', startedAt: 1700000000000 }),
+      3001: JSON.stringify({ sessionId: 'sess-c', cwd: '/project/c', startedAt: 1700000000000 }),
+    },
+  };
+
+  it('解析出的结果与全量扫描中同一 pane 的条目完全一致', () => {
+    // 这条是快路径的核心契约：只收窄候选集，不改判定结果。两者一旦漂移，
+    // /adopt 就会出现「卡片里能选、点了却接管不了」这类难查的偏差。
+    setupMocks(threePanes);
+    const fromFullScan = discoverAdoptableSessions().find(s => s.tmuxTarget === 'dev:0.0');
+
+    setupMocks(threePanes);
+    const fromFastPath = discoverAdoptableSessionByTarget('dev:0.0');
+
+    expect(fromFastPath).toEqual(fromFullScan);
+    expect(fromFastPath).toEqual({
+      source: 'tmux',
+      tmuxTarget: 'dev:0.0',
+      panePid: 1000,
+      cliPid: 1001,
+      cliId: 'claude-code',
+      sessionId: 'sess-a',
+      cwd: '/project/a',
+      startedAt: 1700000000000,
+      paneCols: 120,
+      paneRows: 40,
+    });
+  });
+
+  it('不执行 tmux list-panes —— 这正是它比全量扫描快的原因', () => {
+    setupMocks(threePanes);
+    discoverAdoptableSessionByTarget('dev:0.0');
+
+    const ranListPanes = mockExecSync.mock.calls.some(([cmd]) => String(cmd).includes('list-panes'));
+    expect(ranListPanes).toBe(false);
+  });
+
+  it('只解析目标 pane 的进程树，不碰其它 pane', () => {
+    setupMocks(threePanes);
+    discoverAdoptableSessionByTarget('dev:0.0');
+
+    // 其它两个 pane 的 shell pid 不应该出现在任何一条被执行的命令里
+    const allCmds = mockExecSync.mock.calls.map(([cmd]) => String(cmd)).join('\n');
+    expect(allCmds).not.toContain('2000');
+    expect(allCmds).not.toContain('3000');
+  });
+
+  it('与全量扫描一样跳过 bmx-* 会话（botmux 自己管的 pane）', () => {
+    setupMocks({
+      paneLines: 'bmx-managed:0.0 1000\n',
+      commMap: { 1000: 'zsh', 1001: 'claude' },
+      childMap: { 1000: [1001] },
+      cwdMap: { 1001: '/project/a' },
+      dimsMap: { 'bmx-managed:0.0': '120 40' },
+    });
+
+    expect(discoverAdoptableSessionByTarget('bmx-managed:0.0')).toBeUndefined();
+  });
+
+  it('遵守 filterCliId —— 卡片 option 是用户可控输入，丢掉过滤等于允许切换 CLI 实现', () => {
+    setupMocks(threePanes);
+    // dev:0.1 跑的是 codex，一个 claude-code bot 不该解析得出它
+    expect(discoverAdoptableSessionByTarget('dev:0.1', 'claude-code')).toBeUndefined();
+
+    setupMocks(threePanes);
+    expect(discoverAdoptableSessionByTarget('dev:0.1', 'codex')?.cliId).toBe('codex');
+  });
+
+  it('pane 已经不存在时返回 undefined，由调用方回落全量扫描', () => {
+    setupMocks(threePanes);
+    expect(discoverAdoptableSessionByTarget('gone:9.9')).toBeUndefined();
+  });
+
+  it('会话名含空格时同样能解析（与全量扫描的切分规则一致）', () => {
+    setupMocks({
+      paneLines: 'AD 智投星核心指标:0.0 1000\n',
+      commMap: { 1000: 'fish', 1001: 'claude' },
+      childMap: { 1000: [1001] },
+      cwdMap: { 1001: '/home/user/project' },
+      dimsMap: { 'AD 智投星核心指标:0.0': '210 61' },
+      claudeMeta: {
+        1001: JSON.stringify({ sessionId: 'sess-spaced', cwd: '/home/user/project', startedAt: 1700000000000 }),
+      },
+    });
+
+    const result = discoverAdoptableSessionByTarget('AD 智投星核心指标:0.0');
+    expect(result?.tmuxTarget).toBe('AD 智投星核心指标:0.0');
+    expect(result?.sessionId).toBe('sess-spaced');
   });
 });
 

--- a/test/session-discovery.test.ts
+++ b/test/session-discovery.test.ts
@@ -194,15 +194,21 @@ function setupMocks(opts: {
     if (displayMatch) {
       const target = displayMatch[1];
 
-      // pane_pid query (for validateAdoptTarget / discoverAdoptableSessionByTarget)
+      // pane_pid query. 两种形态：
+      //   validateTmuxAdoptTarget          → 只要 '#{pane_pid}'
+      //   discoverAdoptableSessionByTarget → '#{session_name}:...pane_index} #{pane_pid}'
+      //                                      （连 canonical 地址一起回显，用来核对
+      //                                        tmux 有没有模糊命中别的 pane）
       if (cmdStr.includes('pane_pid')) {
+        const wantsCanonical = cmdStr.includes('session_name');
         // Extract the target and find matching pane from paneLines.
         // 取 pid 必须按**最后**一个空格切：会话名本身可能含空格
         // （如「AD 智投星:0.0 651511」），按第一个空格切会把 pid 取成会话名的后半段。
         // 这与 discoverAdoptableSessions 解析 list-panes 输出的规则一致。
         for (const line of paneLines.split('\n')) {
           if (line.startsWith(target + ' ')) {
-            return line.slice(line.lastIndexOf(' ') + 1) + '\n';
+            // paneLines 的格式与 canonical query 的格式串完全相同，可整行回显。
+            return (wantsCanonical ? line : line.slice(line.lastIndexOf(' ') + 1)) + '\n';
           }
         }
         throw new Error('pane not found');
@@ -969,6 +975,64 @@ describe('discoverAdoptableSessionByTarget', () => {
   it('pane 已经不存在时返回 undefined，由调用方回落全量扫描', () => {
     setupMocks(threePanes);
     expect(discoverAdoptableSessionByTarget('gone:9.9')).toBeUndefined();
+  });
+
+  // ── 死目标 / 模糊命中：tmux display -t 失败时不报错，必须靠回显内容判断 ──
+  //
+  // 真机实测（tmux 3.6a），以下全部 exit 0、stderr 为空：
+  //   nonexist:0.0  → 地址回显为 ':.'、pane_pid 为空串
+  //   claude:99.0   → 解析到 claude:2.3（window 索引不存在 → 回落活动 window）
+  //   claude:1.99   → 解析到 claude:1.1（pane 索引不存在 → 回落活动 pane）
+  //   clau:1.3      → 解析到 claude:1.3（会话名前缀匹配）
+  // 所以既不能靠 exit code 判死活，也不能相信「拿到正数 pid」= 命中了请求的 pane。
+
+  it('死目标返回空 pane_pid + exit 0 时返回 undefined，绝不落到 pid 0 的进程树遍历', () => {
+    // 回归：Number('') === 0 且 isNaN(0) === false。少了正数校验就会调
+    // findCliProcess(0, 3)，从 pid 0 开始 BFS 整棵进程树、每个节点 fork 一次全量
+    // ps，实测 >45s 同步冻结 —— 比它要优化掉的 5.4s 更糟，且直接冻住 daemon
+    // 事件循环。注意这条路径不抛异常，与上面 'gone:9.9' 那条（mock 抛错）不同。
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = String(cmd);
+      if (cmdStr.includes('pane_pid')) return ':. \n';  // 真机对死目标的原样回显
+      throw new Error(`unexpected command: ${cmdStr}`);
+    });
+
+    expect(discoverAdoptableSessionByTarget('nonexist:0.0', 'claude-code')).toBeUndefined();
+
+    const cmds = mockExecSync.mock.calls.map(([c]) => String(c));
+    expect(cmds).toHaveLength(1);                                  // 只问了一次 tmux
+    expect(cmds.some(c => c.includes('ps '))).toBe(false);         // 没碰进程树
+    expect(cmds.some(c => c.includes('list-panes'))).toBe(false);  // 也没回落全量扫描
+  });
+
+  it('tmux 模糊命中别的 pane 时返回 undefined（canonical 地址与请求不符）', () => {
+    // 回归：只补 panePid > 0 挡不住这条 —— 长会话 foobarX 会让短 target foobar
+    // 拿到一个**真实正数** pid。若把请求的 target 原样回填，得到的对象就是
+    // 「地址是用户选的、数据是另一个 pane 的」，端到端可导致接管错误会话。
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const cmdStr = String(cmd);
+      if (cmdStr.includes('pane_pid')) return 'foobarX:0.0 4242\n';
+      throw new Error(`unexpected command: ${cmdStr}`);
+    });
+
+    expect(discoverAdoptableSessionByTarget('foobar:0.0', 'claude-code')).toBeUndefined();
+
+    const cmds = mockExecSync.mock.calls.map(([c]) => String(c));
+    expect(cmds).toHaveLength(1);
+    expect(cmds.some(c => c.includes('ps '))).toBe(false);
+  });
+
+  it('canonical 地址与请求严格相等时才继续解析（含空格会话名也能对上）', () => {
+    // 反向断言上一条不是「无脑返回 undefined」：地址对得上就正常走下去。
+    setupMocks({
+      paneLines: 'AD 智投星核心指标:0.0 1000\n',
+      commMap: { 1000: 'fish', 1001: 'claude' },
+      childMap: { 1000: [1001] },
+      cwdMap: { 1001: '/home/user/project' },
+      dimsMap: { 'AD 智投星核心指标:0.0': '210 61' },
+    });
+
+    expect(discoverAdoptableSessionByTarget('AD 智投星核心指标:0.0')?.cliPid).toBe(1001);
   });
 
   it('会话名含空格时同样能解析（与全量扫描的切分规则一致）', () => {


### PR DESCRIPTION
> **更新**：已按 CR 复审修掉 P1（死 target 冻结 >45s）和 P2（模糊命中错误 pane），head → `ecd7c8cf`，详见[本条回复](https://github.com/deepcoldy/botmux/pull/632#issuecomment-5101480570)。下方数字已同步修正。

## 问题

在 `/adopt` 选择卡里点定某个会话后，`card-handler` 的 `resolveAdoptTarget` 仍会调 `discoverAdoptableSessions()` 把本机**所有** tmux pane 重扫一遍，再 `.find()` 挑出用户刚选的那一个。卡片 option 里其实已经带着 tmux 地址了。

全量扫描要对每个 pane 走进程树，且树里每个节点都拉一次全量 `ps`，pane 一多就是数秒级**同步**阻塞。

而这条路径是飞书卡片回调 —— `card.action.trigger` 只有 3s 预算，且与普通事件不同**不会重推**（见 `event-dispatcher.ts` 里 `CARD_ACTION_ACK_TIMEOUT_MS` 上方的注释）。更糟的是同步 `execSync` 会把 Node 事件循环整个冻住，连 2500ms 提前 ACK 的保险丝都发不出去 —— `setTimeout` 被饿死，用户侧直接看到飞书弹的红色「目标回调服务超时未响应」（错误码 200341）。外层还套了 3 次重试，最坏是 4 遍全量扫描。

线上日志的指纹：`handler exceeded 2500ms` 的告警时间戳比 `Adopt worker forked` **晚 9ms**，而不是点击后 2500ms —— 定时器直到事件循环被放开才补跑。同一份阻塞大概率也是日志里 `[ws] reconnecting` / `no pong within 30s of last ping` 的来源。

## 改动

1. 把 `discoverAdoptableSessions` 每 pane 的循环体原样抽成 `resolveAdoptableSessionForPane`，让「扫全部 pane」和「只解析某一个 pane」共用同一份判定 —— 包括 `bmx-*` 跳过、`filterCliId` 过滤、codex launcher 跟随。两条路径必须永远同构，否则快路径会绕开 CLI 过滤。
2. 新增 `discoverAdoptableSessionByTarget(tmuxTarget, filterCliId)`，只解析目标那一个 pane。
3. `resolveAdoptTarget` 先走快路径。**判定谓词与全量路径完全一致**，没命中就原样回落全量扫描 —— 只收窄候选集、不改判定逻辑，因此不改变任何既有结果。

### `tmux display -t` 的模糊解析（CR 复审后加的防护）

`tmux display -t` 是模糊解析，且解析失败时**不报错**（exit 0、stderr 为空）。真机实测（tmux 3.6a）：

```
请求 nonexist:0.0  → 地址回显 ':.'、pane_pid 为空串
请求 claude:99.0   → 解析到 claude:2.3   ← window 索引不存在，回落活动 window
请求 claude:1.99   → 解析到 claude:1.1   ← pane 索引不存在，回落活动 pane
请求 clau:1.3      → 解析到 claude:1.3   ← 会话名前缀
请求 watc          → 解析到 watch:1.1    ← 前缀 + 省略索引
```

所以既不能靠 exit code 判死活（`Number('') === 0` 且 `isNaN(0) === false`，会落到 `findCliProcess(0, ...)` 从 pid 0 遍历整棵进程树），也不能相信「拿到正数 pid」= 命中了请求的 pane（中间三种都返回**真实正数 pid**，只是属于别的 pane）。

修法是让同一条 display 连 canonical 地址一起回显，再要求它与请求的 target 严格相等 —— 一次同时挡掉两者：

```ts
`tmux display -t ${shellescape(tmuxTarget)} -p '#{session_name}:#{window_index}.#{pane_index} #{pane_pid}'`
...
if (canonicalTarget !== tmuxTarget) return undefined;
if (!Number.isInteger(panePid) || panePid <= 0) return undefined;
```

格式串与 `discoverAdoptableSessions` 的 `list-panes -F` 完全一致，两边可直接字符串比较；按最后一个空格切分，兼容含空格的会话名。

## 实测

本机 31 个 tmux pane / 29 个可 adopt 会话。这台机器同时跑着 20+ 个 live CLI 会话，负载波动大，所以给 5 轮而非单次采样：

```
全量扫描 5 次: 25028 / 11809 / 15030 / 17185 / 28692 ms   中位数 17185
单 pane  5 次:   259 /   623 /   525 /   273 /  1027 ms   中位数   525
中位数提速: 32.7x
```

机器空闲时是 `4948ms → 145ms`。倍数随负载浮动（11x~34x），量级稳定。顺带一提，全量扫描在高负载下能退化到 **28.7 秒**。

死 / 歧义 target（走 canonical 校验直接返回 `undefined`，回落全量扫描 = master 行为）：

```
   23ms  nonexist:0.0    → undefined      （加防护前 >45s 冻结）
   26ms  claude:99.0     → undefined
   25ms  claude:1.99     → undefined
   20ms  clau:1.3        → undefined
   16ms  bmx-fake:0.0    → undefined
  247ms  claude:1.3      → claude:1.3 / pid 45575   ← 真实目标不受影响
```

连跑 5 次死目标：83 / 100 / 107 / 118 / 125 ms，稳定。

## 影响范围评估

- **只有 tmux 来源的 adopt 目标走快路径。** zellij 分支完全未动。herdr 目标的 option 里没有 `tmuxTarget`（`JSON.stringify` 会丢掉 undefined 键），且 herdr 需要 `excludeOwnedHerdrAdoptTargets` 的全局视图，`selected.source !== 'herdr' && selected.tmuxTarget` 两道 guard 都会让它回落全量路径。该函数对非 herdr 条目恒返回 `true`，所以快路径跳过它对 tmux 结果是 no-op。
- **`filterCliId` 原样透传。** 卡片 option 是用户可控输入，快路径若丢掉这个过滤就等于允许把 bot 切到别的 CLI 实现。新增测试专门覆盖：一个 claude-code bot 解析不出跑 codex 的 pane。
- **其它 CLI 的逻辑随循环体整体搬迁，未做语义修改** —— codex launcher 跟随、coco/traex rollout 绑定、claude session meta、`readProcessStartTime` 兜底，全部由既有 49 条 `discoverAdoptableSessions` 测试守住。
- **跨平台**：新增代码只多一条 `tmux display`，无平台相关分支；macOS 的 `ps`/`lsof` 兜底由 `session-discovery.smoke.test.ts` 覆盖。
- 未改任何卡片渲染，无 UI 变化，故无截图。

### 已知遗留（本 PR 不改）

`validateTmuxAdoptTarget`（`session-discovery.ts:950`）用的仍是不带 canonical 校验的 `tmux display -t`，同样有前缀 / 索引模糊命中的性质 —— 这是 master 既有行为，非本 PR 引入。CR 描述的 P2 端到端链路（PID 复用 → `validateAdoptTarget` 二次模糊命中）现在在源头断了（快路径返回 `undefined` 后回落全量扫描，而全量扫描只从 `list-panes` 拿活 pane），但该函数本身建议另开 issue 收掉，不在这个 perf PR 里扩大范围。

## 测试

`session-discovery` 49 → 59，`session-adopt` 11，改动文件隔离跑 **70/70 稳定全过**。

新增 10 条 `discoverAdoptableSessionByTarget` 用例：

- 与全量扫描中同一 pane 的条目**逐字段一致**（快路径的核心契约）
- 不执行 `tmux list-panes`；不触碰其它 pane 的进程树
- 与全量扫描一样跳过 `bmx-*`；遵守 `filterCliId`
- pane 消失时返回 `undefined`，由调用方回落
- 会话名含空格时同样能解析
- **死目标「空 pid + 不抛异常」→ `undefined`**，断言只发一次 tmux 查询、完全不调用 `ps` / `list-panes`
- **canonical 不符（`foobar` → `foobarX 4242`，真实正数 pid）→ `undefined`**，同样不碰进程树
- 反向断言：地址严格相等时正常继续解析，含空格会话名也能对上

顺手修了 `setupMocks` 的一个潜伏 bug：`pane_pid` 分支原本用 `line.split(' ')[1]` 取 pid，会话名含空格时会取成会话名后半段 —— 正是生产代码专门留了回归测试的那个「按第一个空格切」的坑。改为按最后一个空格切。

### 全量套件说明

这台机器 load average 常年 28~54（20+ 个 live CLI 会话），全量套件里那批派生进程 / 超时敏感的用例本身不稳：同一份代码连跑 4 次，失败集合每次都不一样（`codex-app-threads` / `hook-runner` / `workflow-c0-isolation` / `v3-goal-cli` / `whiteboard-cli` / `plugin-init` / `plugin-mcp-gateway` / `skill-injection-mode` / `vc-meeting-im-routing` / `worker-codex-app-missing-dependency` 轮流出现）。已逐个 grep 确认**这些文件没有一个引用 `session-discovery` 或 `card-handler`**。与两位 reviewer 各自观测到的「同款失败在干净 master 上一样出现」一致。
