### PR TITLE
fix(reaction): 修复 Grok card-off 假 DONE / 卡 GoGoGo

### DIFF
--- a/src/adapters/cli/grok.ts
+++ b/src/adapters/cli/grok.ts
@@ -313,7 +313,10 @@ export function createGrokAdapter(pathOverride?: string): CliAdapter {
     // Busy markers verified on 0.2.93: "⠧ Waiting for response…" spinner
     // during the model phase, and the "Ctrl+c:cancel" shortcut-bar entry
     // through model AND tool phases (idle bar shows Shift+Tab:mode /
-    // Ctrl+x:shortcuts only).
+    // Ctrl+x:shortcuts only). Kept for reattach / first-prompt-timeout
+    // probes — post-submit busy-absent probing is disabled for
+    // reliableTurnTerminal CLIs (worker) because these markers often lag
+    // several seconds after submit and were flipping card-off DONE early.
     busyPattern: /Waiting for response|Ctrl\+c:\s*cancel/i,
     // Routing/identity ride on --rules (injectsSessionContext); no inline hints.
     systemHints: [],

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -4667,12 +4667,18 @@ function setupWorkerHandlers(
             source: 'screen_update',
             content: msg.content,
           });
-          // Usage ledger + turn reactions: idle/limited edges are turn
-          // boundaries. Append the token delta, and flip this turn's pending ✋
-          // reactions to ✅ (best-effort, never blocks the status pipeline).
+          // Usage ledger: any settle-to-idle/limited edge records the delta.
+          // Turn reactions are stricter — only flip ✋→✅ after a real busy
+          // period (working/analyzing). Cold-start starting→idle (or the first
+          // prompt-ready before the turn has gone working) must NOT DONE a
+          // message that is still about to be / just being processed. Grok
+          // card-off sessions hit this when the ready-gate settle fired idle
+          // ~seconds after GoGoGo while the CLI was still running the prompt.
           if (ds.lastScreenStatus === 'idle' || ds.lastScreenStatus === 'limited') {
             recordUsageForDaemonSession(ds);
-            void finishTurnReactions(ds);
+            if (prevStatus === 'working' || prevStatus === 'analyzing') {
+              void finishTurnReactions(ds);
+            }
           }
           if (
             ds.lastScreenStatus === 'idle'
@@ -5790,7 +5796,8 @@ function shouldDropMismatchedHermesFinalOutput(
 /**
  * Turn-end half of the two-phase turn reactions (auto-on for card-off sessions,
  * i.e. streaming card disabled). The 冲! "received" reactions are added per-message at the daemon
- * acceptance point (`noteTurnReceived`); when the worker next returns to idle we
+ * acceptance point (`noteTurnReceived`); the screen_update handler calls this
+ * only on working|analyzing → idle|limited (not cold-start starting→idle), to
  * flip every pending ✋ on this session to ✅ DONE and clear the list. When
  * silentTurnReactions is enabled after a ✋ has already landed, we only remove
  * that received reaction and do not add DONE. Binding the start to the message

--- a/src/utils/pending-input-queue.ts
+++ b/src/utils/pending-input-queue.ts
@@ -148,6 +148,56 @@ export function resolveInitialPromptDelivery(opts: {
   };
 }
 
+/**
+ * Whether this spawn baked a non-empty first prompt into argv (not the write
+ * queue). Shared base for both Grok pre-exec busy arming and the card-off
+ * "seed working before first idle" path for quiescence argv adapters.
+ *
+ * Riff has passesInitialPromptViaArgs=false → false (queue-after-spawn).
+ */
+export function shouldTrackArgvBakedFirstPrompt(opts: {
+  passesInitialPromptViaArgs: boolean;
+  preparedInitialPrompt?: string | null;
+  queuedInitialPrompt?: string | null;
+}): boolean {
+  if (!opts.passesInitialPromptViaArgs) return false;
+  if (!opts.preparedInitialPrompt?.trim()) return false;
+  if (opts.queuedInitialPrompt) return false;
+  return true;
+}
+
+/**
+ * Whether markPromptReady must treat the first post-spawn ready as
+ * "pre-execution SessionStart" (report working, keep busy) rather than true
+ * end-of-turn idle.
+ *
+ * Strict conditions (PR #633 review):
+ *  - adapter actually bakes the first prompt into argv (`passesInitialPromptViaArgs`)
+ *  - an argv prompt exists and was NOT deferred to the write queue
+ *  - SessionStart ready exists (`injectsReadyHook`) so first ready ≠ completion
+ *  - turn terminal is authoritative (`reliableTurnTerminal`) so a later
+ *    assistant_final/fireIdle will produce a real idle edge
+ *
+ * Riff (and any queue-after-spawn adapter) has passesInitialPromptViaArgs=false
+ * — must return false, or the first markPromptReady would clear isPromptReady
+ * and leave the post-spawn queue flush never firing.
+ * Gemini/Pi/MTR/OpenCode pass prompt via argv but use quiescence as the sole
+ * idle signal — first ready IS completion; must return false or they stick
+ * (use {@link shouldTrackArgvBakedFirstPrompt} + seed working→idle instead).
+ */
+export function shouldArmSpawnArgvInitialPromptBusy(opts: {
+  passesInitialPromptViaArgs: boolean;
+  preparedInitialPrompt?: string | null;
+  queuedInitialPrompt?: string | null;
+  injectsReadyHook: boolean;
+  reliableTurnTerminal: boolean;
+}): boolean {
+  if (!shouldTrackArgvBakedFirstPrompt(opts)) return false;
+  if (!opts.injectsReadyHook) return false;
+  if (!opts.reliableTurnTerminal) return false;
+  return true;
+}
+
 /** Once either side of a queue boundary is durable, stop this batch and wait
  *  for the next reliable idle edge before writing the following turn. */
 export function shouldStopPendingBatch(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -64,6 +64,8 @@ import {
   pendingInputMayFlush,
   pendingInputAllowsTypeAhead,
   resolveInitialPromptDelivery,
+  shouldArmSpawnArgvInitialPromptBusy,
+  shouldTrackArgvBakedFirstPrompt,
   shouldDeferArgsBakedDurablePrompt,
   shouldDeferInitialPromptForArgLimit,
   shouldStopPendingBatch,
@@ -1167,6 +1169,19 @@ let lastSpawnEffectiveCliSessionId: string | undefined;
 let lastSpawnDeferInitialPrompt = false;
 let lastSpawnQueuedInitialPrompt: string | undefined;
 let lastSpawnQueuedInitialPromptLogicalContent: string | undefined;
+/**
+ * True only when {@link shouldArmSpawnArgvInitialPromptBusy} says so: argv-
+ * baked first prompt + SessionStart ready (Grok-class). First markPromptReady
+ * then reports working (not idle). Cleared on first consume. Must stay false
+ * for Riff/queue-after-spawn and for quiescence-only argv adapters.
+ */
+let spawnArgvInitialPromptBusy = false;
+/**
+ * True when spawn baked first prompt into argv (any such adapter, incl. Pi /
+ * Gemini). Card-off reactions need a working→idle edge: Grok uses the busy
+ * arm above; quiescence argv adapters seed working then idle at first ready.
+ */
+let spawnArgvNeedsWorkingSeed = false;
 let idleDetector: IdleDetector | null = null;
 let isTmuxMode = false;
 /** True once a crash diagnostic tmux shell (bmx-diag-<sid>) is live. */
@@ -5881,6 +5896,31 @@ function markPromptReadyFromPty(observedBackend: SessionBackend): void {
   }
 }
 
+/**
+ * Push a coarse screen status to the daemon without waiting for the 2s sampler.
+ * Used so card-off reactions see working→idle even on short turns.
+ *
+ * @param force - When true, send `status` as-is and skip classifyScreenUsageLimit.
+ *   Synthetic "working" seeds for card-off reactions MUST force: if the first
+ *   screen already shows a rate-limit banner, classify would rewrite working→
+ *   limited and the seed collapses to limited→limited (no working edge →
+ *   finishTurnReactions never runs). Review: PR #633 third round.
+ */
+function publishScreenStatus(status: 'working' | 'idle', opts?: { force?: boolean }): void {
+  if (!renderer) return;
+  const { content } = renderer.snapshot();
+  const statusPayload = opts?.force
+    ? { status }
+    : classifyScreenUsageLimit(content, status);
+  send({
+    type: 'screen_update',
+    content,
+    ...statusPayload,
+    turnId: currentBotmuxTurnId,
+    dispatchAttempt: currentBotmuxDispatchAttempt,
+  });
+}
+
 function markPromptReady(): void {
   // Only screen readiness plus a non-shell pane leaf may release a launch that
   // was previously blocked. Transcript/task callbacks can arrive while the
@@ -5988,14 +6028,48 @@ function markPromptReady(): void {
       log('prompt-ready with no backend installed — deferring restart success receipt');
     }
   }
-  // Send immediate idle snapshot so Lark card reflects idle status.
-  // BUT: skip when messages are pending — flushPending() will immediately
-  // make the CLI busy, so the idle state is transient and shouldn't appear
-  // in the card.  This avoids a false "就绪" flash on daemon restart
-  // (where the initial prompt is queued before the CLI becomes idle).
-  if (renderer && pendingMessages.length === 0 && pendingRawInputs.length === 0 && pendingSessionRename === null && !isFlushing) {
-    const { content } = renderer.snapshot();
-    send({ type: 'screen_update', content, ...classifyScreenUsageLimit(content, 'idle'), turnId: currentBotmuxTurnId, dispatchAttempt: currentBotmuxDispatchAttempt });
+  // Send an immediate status snapshot so Lark card / card-off reactions track
+  // real work. Skip pure idle when:
+  //  - messages are pending — flushPending() will immediately make the CLI
+  //    busy (avoids a false "就绪" flash on daemon restart);
+  //  - Grok-class argv+SessionStart arming: first ready is pre-execution, so
+  //    park as working until assistant_final/fireIdle;
+  //  - quiescence argv CLIs (Pi/Gemini/MTR/OpenCode): first ready IS turn end
+  //    — seed working then idle so card-off gets working→idle (review P2).
+  const hasPendingWork =
+    pendingMessages.length > 0
+    || pendingRawInputs.length > 0
+    || pendingSessionRename !== null
+    || isFlushing;
+  if (renderer && !hasPendingWork) {
+    if (spawnArgvInitialPromptBusy) {
+      spawnArgvInitialPromptBusy = false;
+      spawnArgvNeedsWorkingSeed = false;
+      // Stay non-ready so the next genuine end-of-turn idle is a real edge.
+      isPromptReady = false;
+      idleDetector?.reset();
+      // force: rate-limit banner must not rewrite synthetic working → limited
+      publishScreenStatus('working', { force: true });
+      log('Spawn argv initial prompt still in flight — reporting working (not idle) so turn reactions can settle later');
+    } else if (spawnArgvNeedsWorkingSeed) {
+      // First ready = true completion for quiescence argv adapters. Seed a
+      // working edge before idle/limited so daemon finishTurnReactions (gated
+      // on working→idle|limited) still flips card-off GoGoGo on cold-start
+      // one-shots — including when the terminal already shows a rate-limit
+      // banner (classify would otherwise collapse both seeds to limited).
+      spawnArgvNeedsWorkingSeed = false;
+      publishScreenStatus('working', { force: true });
+      // Second tick may classify to limited when the banner is visible — that
+      // is fine: gate allows working→limited.
+      publishScreenStatus('idle');
+      log('Argv-baked first prompt completed — seeded working→idle for card-off reactions');
+    } else {
+      publishScreenStatus('idle');
+    }
+  } else if (hasPendingWork) {
+    // Queued path will flip busy via flushPending; drop argv seed flags.
+    spawnArgvInitialPromptBusy = false;
+    spawnArgvNeedsWorkingSeed = false;
   }
   // barrier 注入必须先于本次 pending 用户消息落地（现存发送方均 barrier=false，
   // 该分支目前不触发；机制保留见 pendingInjections 声明处注释）。跳过本次
@@ -6446,6 +6520,11 @@ async function flushPending(): Promise<void> {
   if (isPromptReady) {
     isPromptReady = false;
     idleDetector?.reset();
+    // Immediate working for card-off reaction settle (PR #633 P2): the screen
+    // sampler is 2s — without this a short turn can complete before any
+    // working status is observed, leaving idle→idle and GoGoGo uncleared.
+    // force: same rate-limit rewrite trap as argv seed (review third round).
+    publishScreenStatus('working', { force: true });
   }
 
   try {
@@ -6636,7 +6715,16 @@ async function flushPending(): Promise<void> {
         if (recoveryFailureReason) {
           result = { ...result, submitted: false };
         }
-        scheduleBusyPatternIdleProbe(`${cliName()} post-submit`);
+        // Transcript-backed CLIs (Grok/Codex/… reliableTurnTerminal) own idle via
+        // assistant_final → fireIdle. Their busyPattern is often missing for
+        // several seconds after submit (or never matches the current TUI chrome),
+        // so a post-submit "busy marker absent" probe falsely marks prompt ready
+        // and the card-off DONE reaction lands while the turn is still running
+        // (seen live on Grok: GoGoGo → +7s post-submit probe → DONE, then
+        // deferred recheck still saw active PTY output).
+        if (cliAdapter.reliableTurnTerminal !== true) {
+          scheduleBusyPatternIdleProbe(`${cliName()} post-submit`);
+        }
       } catch (err: any) {
         recoveryFailureReason = err instanceof SubmissionWriteError
           ? err.recoveryFailureReason
@@ -6844,7 +6932,11 @@ function sendToPty(
     flushPending();  // fire-and-forget async; no-op if already flushing
   } else {
     if (!mergedQueued) log(`Queued message (${pendingMessages.length} pending): "${content.substring(0, 80)}" — ${cliName()} ${awaitingFirstPrompt ? 'still booting' : 'is busy'}`);
-    scheduleBusyPatternIdleProbe(`${cliName()} queued-message`);
+    // Same false-idle trap as post-submit (see flushPending): do not let
+    // "busy marker absent" declare ready for transcript-backed CLIs.
+    if (cliAdapter?.reliableTurnTerminal !== true) {
+      scheduleBusyPatternIdleProbe(`${cliName()} queued-message`);
+    }
   }
   return true;
 }
@@ -8187,6 +8279,21 @@ async function spawnCli(
   preparedInitialPrompt = initialPromptDelivery.argvPrompt;
   lastSpawnQueuedInitialPrompt = initialPromptDelivery.queuedContent;
   lastSpawnQueuedInitialPromptLogicalContent = initialPromptDelivery.logicalContent;
+  // Argv-baked first prompt tracking (PR #633 P2 / second-round review):
+  //  - needsWorkingSeed: any argv CLI (Pi/Gemini/MTR/OpenCode/Grok) so card-off
+  //    reactions can form working→idle (seeded at first ready or Grok arm).
+  //  - busy arm: only Grok-class SessionStart (first ready ≠ turn end).
+  const argvBakedOpts = {
+    passesInitialPromptViaArgs: cliAdapter.passesInitialPromptViaArgs === true,
+    preparedInitialPrompt,
+    queuedInitialPrompt: lastSpawnQueuedInitialPrompt,
+  };
+  spawnArgvNeedsWorkingSeed = shouldTrackArgvBakedFirstPrompt(argvBakedOpts);
+  spawnArgvInitialPromptBusy = shouldArmSpawnArgvInitialPromptBusy({
+    ...argvBakedOpts,
+    injectsReadyHook: cliAdapter.injectsReadyHook === true,
+    reliableTurnTerminal: cliAdapter.reliableTurnTerminal === true,
+  });
   if (deferInitialPrompt && preparedDeferredInput) {
     piInitialPromptAdditionalArgs = [...(preparedDeferredInput.additionalArgs ?? [])];
     piInitialPromptEnv = { ...(preparedDeferredInput.env ?? {}) };

--- a/test/initial-prompt-arg-limit.test.ts
+++ b/test/initial-prompt-arg-limit.test.ts
@@ -3,14 +3,89 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { createPiAdapter } from '../src/adapters/cli/pi.js';
+import { createGrokAdapter } from '../src/adapters/cli/grok.js';
+import { createRiffAdapter } from '../src/adapters/cli/riff.js';
+import { createGeminiAdapter } from '../src/adapters/cli/gemini.js';
 import { shouldQueueInitialPrompt } from '../src/codex-rpc-lifecycle.js';
 import {
   resolveInitialPromptDelivery,
+  shouldArmSpawnArgvInitialPromptBusy,
+  shouldTrackArgvBakedFirstPrompt,
   shouldDeferInitialPromptForArgLimit,
 } from '../src/utils/pending-input-queue.js';
 import { PI_INITIAL_PROMPT_COMMAND } from '../src/adapters/cli/pi-initial-prompt-extension.js';
 
 process.env.BOTMUX_TIME_SCALE ??= '0.01';
+
+describe('shouldArmSpawnArgvInitialPromptBusy (PR #633 CR)', () => {
+  it('arms only for Grok-class argv + SessionStart + reliable terminal', () => {
+    const grok = createGrokAdapter('/bin/grok');
+    expect(shouldArmSpawnArgvInitialPromptBusy({
+      passesInitialPromptViaArgs: grok.passesInitialPromptViaArgs === true,
+      preparedInitialPrompt: 'review this MR',
+      queuedInitialPrompt: undefined,
+      injectsReadyHook: grok.injectsReadyHook === true,
+      reliableTurnTerminal: grok.reliableTurnTerminal === true,
+    })).toBe(true);
+  });
+
+  it('does not arm for Riff (prompt is queue-after-spawn, not argv)', () => {
+    const riff = createRiffAdapter();
+    // Reviewer regression: preparedInitialPrompt non-empty alone must NOT arm —
+    // Riff ignores prompt in buildArgs and queues after spawnCli returns.
+    expect(riff.passesInitialPromptViaArgs).toBeFalsy();
+    expect(shouldArmSpawnArgvInitialPromptBusy({
+      passesInitialPromptViaArgs: riff.passesInitialPromptViaArgs === true,
+      preparedInitialPrompt: 'hello from feishu',
+      queuedInitialPrompt: undefined,
+      injectsReadyHook: riff.injectsReadyHook === true,
+      reliableTurnTerminal: riff.reliableTurnTerminal === true,
+    })).toBe(false);
+  });
+
+  it('does not arm for quiescence-only argv adapters (Pi / Gemini) but still tracks argv seed', () => {
+    for (const adapter of [createPiAdapter('/bin/pi'), createGeminiAdapter('/bin/gemini')]) {
+      expect(adapter.passesInitialPromptViaArgs).toBe(true);
+      expect(adapter.injectsReadyHook).toBeFalsy();
+      const base = {
+        passesInitialPromptViaArgs: adapter.passesInitialPromptViaArgs === true,
+        preparedInitialPrompt: 'do something',
+        queuedInitialPrompt: undefined as string | undefined,
+      };
+      // Track seed so markPromptReady can publish working→idle for card-off.
+      expect(shouldTrackArgvBakedFirstPrompt(base)).toBe(true);
+      // Must NOT hold busy across first ready (first ready IS turn end).
+      expect(shouldArmSpawnArgvInitialPromptBusy({
+        ...base,
+        injectsReadyHook: adapter.injectsReadyHook === true,
+        reliableTurnTerminal: adapter.reliableTurnTerminal === true,
+      })).toBe(false);
+    }
+  });
+
+  it('does not arm when the first prompt was deferred to the write queue', () => {
+    expect(shouldArmSpawnArgvInitialPromptBusy({
+      passesInitialPromptViaArgs: true,
+      preparedInitialPrompt: 'argv-form',
+      queuedInitialPrompt: 'queued command',
+      injectsReadyHook: true,
+      reliableTurnTerminal: true,
+    })).toBe(false);
+  });
+
+  it('Riff post-spawn queue path: shouldQueueInitialPrompt is true when prompt exists', () => {
+    // Behavioral pin: riff does not bake prompt into argv, so the worker must
+    // queue + flush once after spawn (isPromptReady stays true for that flush).
+    const riff = createRiffAdapter();
+    expect(shouldQueueInitialPrompt({
+      hasPrompt: true,
+      rpcEngineActive: false,
+      queuePrompt: false,
+      passesInitialPromptViaArgs: riff.passesInitialPromptViaArgs === true,
+      deferInitialPrompt: false,
+    })).toBe(true);
+  });
+});
 
 describe('initial prompt argv byte-limit fallback', () => {
   it('does not defer when the adapter does not pass initial prompts via args', () => {

--- a/test/turn-reactions.test.ts
+++ b/test/turn-reactions.test.ts
@@ -11,8 +11,9 @@
  *
  * Run:  pnpm vitest run test/turn-reactions.test.ts
  */
+import { EventEmitter } from 'node:events';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mkdtempSync } from 'fs';
+import { mkdtempSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -43,13 +44,21 @@ vi.mock('../src/im/lark/client.js', async () => {
 
 import { registerBot } from '../src/bot-registry.js';
 import { noteTurnReceived } from '../src/daemon.js';
-import { __testOnly_finishTurnReactions as finishTurnReactions } from '../src/core/worker-pool.js';
+import {
+  initWorkerPool,
+  __testOnly_finishTurnReactions as finishTurnReactions,
+  __testOnly_setupWorkerHandlers,
+} from '../src/core/worker-pool.js';
 import type { DaemonSession } from '../src/core/types.js';
 
 const APP = 'reaction_app';
 
 function makeDs(over: Partial<DaemonSession> = {}): DaemonSession {
-  const session: any = { sessionId: 'sess-' + Math.random().toString(36).slice(2), chatId: 'oc_x', rootMessageId: 'om_root' };
+  // status:'active' is required by the screen_update handler's ownsLifecycleMutation
+  // guard (added with the ZMX lifecycle-ownership work). Without it every
+  // screen_update breaks before lastScreenStatus updates, so the behavioral
+  // working→idle / working→limited flip tests below never see a real edge.
+  const session: any = { sessionId: 'sess-' + Math.random().toString(36).slice(2), chatId: 'oc_x', rootMessageId: 'om_root', status: 'active' };
   return { session, larkAppId: APP, chatId: 'oc_x', scope: 'chat', ...over } as unknown as DaemonSession;
 }
 
@@ -324,3 +333,180 @@ describe('two-phase turn reactions', () => {
     expect(mocks.addReaction).not.toHaveBeenCalledWith(APP, 'om_a', 'DONE');
   });
 });
+
+/**
+ * Source-level pin: the screen_update handler must only flip ✋→✅ after a real
+ * busy period (working/analyzing → idle|limited). Cold-start starting→idle
+ * (ready-gate settle before the turn has gone working) must leave GoGoGo alone
+ * — otherwise card-off Grok sessions DONE a message while the CLI is still
+ * chewing the first prompt.
+ */
+describe('turn reaction idle edge gate (source)', () => {
+  it('finishTurnReactions is gated on prevStatus working|analyzing', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/core/worker-pool.ts'),
+      'utf8',
+    );
+    // Anchor on the screen_update reaction comment — "// Usage ledger" alone
+    // also appears on the kill/close path and would pick the wrong block.
+    const blockStart = source.indexOf('// Usage ledger + turn reactions') >= 0
+      ? source.indexOf('// Usage ledger + turn reactions')
+      : source.indexOf('// Usage ledger: any settle-to-idle');
+    expect(blockStart).toBeGreaterThan(-1);
+    const block = source.slice(blockStart, blockStart + 900);
+    expect(block).toContain("prevStatus === 'working' || prevStatus === 'analyzing'");
+    expect(block).toContain('void finishTurnReactions(ds)');
+    // Must NOT call finishTurnReactions on every idle/limited edge unconditionally.
+    expect(block).not.toMatch(
+      /if \(ds\.lastScreenStatus === 'idle' \|\| ds\.lastScreenStatus === 'limited'\) \{\s*recordUsageForDaemonSession\(ds\);\s*void finishTurnReactions\(ds\);/,
+    );
+  });
+});
+
+/**
+ * Behavioral pin for PR #633 review P2: card-off finishTurnReactions requires a
+ * working→idle edge. Argv cold-start (Pi/Gemini) must seed working before idle
+ * (worker side); daemon-side, bare undefined→idle must NOT flip, while the
+ * seeded working→idle sequence must.
+ */
+describe('turn reaction screen_update behavioral gate', () => {
+  function makeFakeWorker() {
+    const worker = new EventEmitter() as any;
+    worker.killed = false;
+    worker.send = vi.fn();
+    worker.kill = vi.fn();
+    worker.pid = 4242;
+    worker.stdout = new EventEmitter();
+    worker.stderr = new EventEmitter();
+    return worker;
+  }
+
+  async function flush(): Promise<void> {
+    await new Promise(resolve => setTimeout(resolve, 0));
+    // finishTurnReactions is fire-and-forget void; wait a tick for awaits
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.SESSION_DATA_DIR = mkdtempSync(join(tmpdir(), 'botmux-react-behav-'));
+    mocks.addReaction.mockImplementation(async (_app: string, msgId: string) => `rid_${msgId}`);
+    mocks.removeReaction.mockResolvedValue(undefined);
+    registerWith(true);
+    initWorkerPool({
+      sessionReply: vi.fn(async () => 'om_reply'),
+      getSessionWorkingDir: () => '/repo',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+  });
+
+  it('undefined→idle alone does not DONE pending GoGoGo (gate)', async () => {
+    const worker = makeFakeWorker();
+    const ds = makeDs({
+      worker,
+      workerPort: 9999,
+      lastScreenStatus: undefined,
+      pendingAckReactions: [{ messageId: 'om_a', reactionId: 'rid_om_a' }],
+    });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    worker.emit('message', { type: 'screen_update', content: 'done?', status: 'idle' });
+    await flush();
+
+    expect(mocks.removeReaction).not.toHaveBeenCalled();
+    expect(mocks.addReaction).not.toHaveBeenCalledWith(APP, 'om_a', 'DONE');
+    expect(ds.pendingAckReactions?.map(a => a.messageId)).toEqual(['om_a']);
+  });
+
+  it('working→idle flips pending GoGoGo to DONE (argv seed / flushPending path)', async () => {
+    const worker = makeFakeWorker();
+    const ds = makeDs({
+      worker,
+      workerPort: 9999,
+      lastScreenStatus: undefined,
+      pendingAckReactions: [{ messageId: 'om_a', reactionId: 'rid_om_a' }],
+    });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    // Mirrors markPromptReady seeding working then idle for quiescence argv CLIs.
+    worker.emit('message', { type: 'screen_update', content: 'busy', status: 'working' });
+    await flush();
+    worker.emit('message', { type: 'screen_update', content: 'ready', status: 'idle' });
+    await flush();
+
+    expect(mocks.removeReaction).toHaveBeenCalledWith(APP, 'om_a', 'rid_om_a');
+    expect(mocks.addReaction).toHaveBeenCalledWith(APP, 'om_a', 'DONE');
+    expect(ds.pendingAckReactions).toEqual([]);
+  });
+
+  it('working→limited flips DONE (rate-limit banner on settle; synthetic working must not be rewritten)', async () => {
+    // Review third round: if both seeds classify to limited, gate never sees
+    // working. Forced synthetic working + limited settle must still DONE.
+    const worker = makeFakeWorker();
+    const ds = makeDs({
+      worker,
+      workerPort: 9999,
+      lastScreenStatus: undefined,
+      pendingAckReactions: [{ messageId: 'om_a', reactionId: 'rid_om_a' }],
+    });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    worker.emit('message', {
+      type: 'screen_update',
+      content: 'Rate limit exceeded. Try again at 10:36 PM.',
+      status: 'working',
+    });
+    await flush();
+    worker.emit('message', {
+      type: 'screen_update',
+      content: 'Rate limit exceeded. Try again at 10:36 PM.',
+      status: 'limited',
+      usageLimit: {
+        limited: true,
+        kind: 'rate',
+        retryAtMs: Date.now() + 60_000,
+        retryLabel: '10:36 PM',
+        retryReady: false,
+      },
+    });
+    await flush();
+
+    expect(mocks.removeReaction).toHaveBeenCalledWith(APP, 'om_a', 'rid_om_a');
+    expect(mocks.addReaction).toHaveBeenCalledWith(APP, 'om_a', 'DONE');
+    expect(ds.pendingAckReactions).toEqual([]);
+  });
+
+  it('limited→limited alone does not DONE (no working edge)', async () => {
+    const worker = makeFakeWorker();
+    const ds = makeDs({
+      worker,
+      workerPort: 9999,
+      lastScreenStatus: undefined,
+      pendingAckReactions: [{ messageId: 'om_a', reactionId: 'rid_om_a' }],
+    });
+    __testOnly_setupWorkerHandlers(ds, worker);
+
+    const limitedMsg = {
+      type: 'screen_update' as const,
+      content: 'Rate limit exceeded. Try again at 10:36 PM.',
+      status: 'limited' as const,
+      usageLimit: {
+        limited: true as const,
+        kind: 'rate' as const,
+        retryAtMs: Date.now() + 60_000,
+        retryLabel: '10:36 PM',
+        retryReady: false,
+      },
+    };
+    worker.emit('message', limitedMsg);
+    await flush();
+    worker.emit('message', limitedMsg);
+    await flush();
+
+    expect(mocks.addReaction).not.toHaveBeenCalledWith(APP, 'om_a', 'DONE');
+    expect(ds.pendingAckReactions?.map(a => a.messageId)).toEqual(['om_a']);
+  });
+});
+
+

--- a/test/worker-argv-reaction-status.integration.test.ts
+++ b/test/worker-argv-reaction-status.integration.test.ts
@@ -1,0 +1,112 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { DaemonToWorker, WorkerToDaemon } from '../src/types.js';
+
+const children = new Set<ChildProcess>();
+const tempDirs = new Set<string>();
+
+async function stopChild(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise<void>(resolvePromise => child.once('exit', () => resolvePromise()));
+  child.kill('SIGKILL');
+  await Promise.race([
+    exited,
+    new Promise<void>(resolvePromise => setTimeout(resolvePromise, 2_000)),
+  ]);
+}
+
+afterEach(async () => {
+  await Promise.all([...children].map(stopChild));
+  children.clear();
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.clear();
+});
+
+async function waitForScreenUpdates(
+  child: ChildProcess,
+  messages: WorkerToDaemon[],
+  count: number,
+  logs: string[],
+): Promise<Array<Extract<WorkerToDaemon, { type: 'screen_update' }>>> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const updates = messages.filter(
+      (message): message is Extract<WorkerToDaemon, { type: 'screen_update' }> =>
+        message.type === 'screen_update',
+    );
+    if (updates.length >= count) return updates;
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(`worker exited before ${count} screen updates\n${logs.join('')}`);
+    }
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 25));
+  }
+  throw new Error(
+    `timed out waiting for ${count} screen updates: ${JSON.stringify(messages)}\n${logs.join('')}`,
+  );
+}
+
+describe('worker argv reaction status', () => {
+  it('forces the synthetic working seed before classifying a limited settle', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-worker-argv-reaction-'));
+    tempDirs.add(root);
+    const dataDir = join(root, 'session');
+    mkdirSync(dataDir, { recursive: true });
+
+    // A single rate-limit render followed by quiescence reaches the natural
+    // argv first-turn completion path in ~3s. The worker must emit raw working
+    // first, then classify the real idle settle as limited. If the synthetic
+    // tick is classified too, both updates collapse to limited and card-off
+    // GoGoGo never sees the busy edge required to flip DONE.
+    const fakeGemini = join(root, 'fake-gemini');
+    writeFileSync(fakeGemini, `#!/usr/bin/env node
+process.stdout.write('Rate limit exceeded. Try again at 10:36 PM.\\n');
+setInterval(() => {}, 1_000);
+`);
+    chmodSync(fakeGemini, 0o755);
+
+    const messages: WorkerToDaemon[] = [];
+    const logs: string[] = [];
+    const child = spawn(process.execPath, ['--import', 'tsx', resolve('src/worker.ts')], {
+      cwd: resolve('.'),
+      env: {
+        ...process.env,
+        HOME: root,
+        SESSION_DATA_DIR: dataDir,
+        BOTMUX_SESSION_ID: 'sid-worker-argv-reaction',
+        LARK_APP_ID: 'app_test',
+        LARK_APP_SECRET: 'secret',
+      },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    children.add(child);
+    child.on('message', raw => messages.push(raw as WorkerToDaemon));
+    child.stdout?.on('data', chunk => logs.push(chunk.toString()));
+    child.stderr?.on('data', chunk => logs.push(chunk.toString()));
+
+    child.send({
+      type: 'init',
+      sessionId: 'sid-worker-argv-reaction',
+      chatId: 'oc_test',
+      rootMessageId: 'om_root',
+      workingDir: dataDir,
+      cliId: 'gemini',
+      cliPathOverride: fakeGemini,
+      backendType: 'pty',
+      prompt: 'hello from argv',
+      larkAppId: 'app_test',
+      larkAppSecret: 'secret',
+      turnId: 'om_turn',
+    } satisfies DaemonToWorker);
+
+    const updates = await waitForScreenUpdates(child, messages, 2, logs);
+    expect(updates.slice(0, 2).map(message => message.status)).toEqual([
+      'working',
+      'limited',
+    ]);
+    expect(updates[0]?.usageLimit).toBeUndefined();
+    expect(updates[1]?.usageLimit?.limited).toBe(true);
+  }, 15_000);
+});

--- a/test/worker-pipe-initial-screen-order.test.ts
+++ b/test/worker-pipe-initial-screen-order.test.ts
@@ -61,31 +61,57 @@ describe('worker pipe initial screen ordering', () => {
     expect(captureIdx).toBeGreaterThan(idleIdx);
   });
 
-  it('runs a busy-pattern idle probe after each submitted input', () => {
+  it('cold-start argv prompts seed working for card-off; Grok holds busy, quiescence seeds idle', () => {
+    // Grok: argv + SessionStart → hold working until assistant_final.
+    // Pi/Gemini: argv but first ready IS turn end → seed working then idle.
+    // Arming is centralized (not bare preparedInitialPrompt) so Riff is safe.
     const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+    expect(source).toContain('shouldArmSpawnArgvInitialPromptBusy');
+    expect(source).toContain('shouldTrackArgvBakedFirstPrompt');
+    expect(source).toContain('spawnArgvNeedsWorkingSeed');
+    expect(source).toContain('Spawn argv initial prompt still in flight — reporting working');
+    expect(source).toContain('Argv-baked first prompt completed — seeded working→idle');
+    expect(source).toContain("publishScreenStatus('working', { force: true })");
+    // Synthetic working must not be rewritten by classifyScreenUsageLimit
+    // (rate-limit banner would otherwise collapse seed to limited→limited).
+    expect(source).toContain('opts?.force');
+    // Short-turn fix: flushPending publishes working immediately on submit.
+    expect(source).toContain("// Immediate working for card-off reaction settle");
+  });
+
+  it('runs a busy-pattern idle probe after each submitted input — except reliableTurnTerminal CLIs', () => {
+    const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+    // Attribution and ZMX's recovery journal now wrap the adapter call inside
+    // flushPending. Anchor the literal write there, then confirm the probe is
+    // gated behind `reliableTurnTerminal !== true` (Grok/Codex own idle via
+    // assistant_final; a post-submit "busy absent" probe was flipping card-off
+    // DONE mid-turn because their busy markers lag after submit).
     const flushStart = source.indexOf('async function flushPending(): Promise<void>');
     const flushEnd = source.indexOf('function sendToPty(', flushStart);
     const flush = source.slice(flushStart, flushEnd);
-    // Attribution and ZMX's recovery journal now wrap the adapter call. Anchor
-    // the literal write inside flushPending, then preserve the probe ordering.
     const writeIdx = flush.indexOf('() => targetAdapter.writeInput(');
-    const probeIdx = flush.indexOf('scheduleBusyPatternIdleProbe(`${cliName()} post-submit`);');
+    const gateIdx = flush.indexOf('if (cliAdapter.reliableTurnTerminal !== true) {', writeIdx);
+    const probeIdx = flush.indexOf('scheduleBusyPatternIdleProbe(`${cliName()} post-submit`);', writeIdx);
     const helperIdx = source.indexOf('function scheduleBusyPatternIdleProbe(source: string): void');
 
     expect(helperIdx).toBeGreaterThan(-1);
     expect(writeIdx).toBeGreaterThan(-1);
-    expect(probeIdx).toBeGreaterThan(writeIdx);
+    expect(gateIdx).toBeGreaterThan(writeIdx);
+    expect(probeIdx).toBeGreaterThan(gateIdx);
+    expect(probeIdx).toBeLessThan(gateIdx + 250);
   });
 
-  it('rechecks busy-pattern adapters when a Lark message is queued while busy', () => {
+  it('rechecks busy-pattern adapters when a Lark message is queued while busy — except reliableTurnTerminal', () => {
     const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
     const queueLogIdx = source.indexOf('Queued message (${pendingMessages.length} pending)');
-    const queuedProbeIdx = source.indexOf('scheduleBusyPatternIdleProbe(`${cliName()} queued-message`);');
+    const gateIdx = source.indexOf('if (cliAdapter?.reliableTurnTerminal !== true) {', queueLogIdx);
+    const queuedProbeIdx = source.indexOf('scheduleBusyPatternIdleProbe(`${cliName()} queued-message`);', queueLogIdx);
     const helperIdx = source.indexOf('function scheduleBusyPatternIdleProbe(source: string): void');
 
     expect(helperIdx).toBeGreaterThan(-1);
     expect(queueLogIdx).toBeGreaterThan(-1);
-    expect(queuedProbeIdx).toBeGreaterThan(queueLogIdx);
+    expect(gateIdx).toBeGreaterThan(queueLogIdx);
+    expect(queuedProbeIdx).toBeGreaterThan(gateIdx);
   });
 
   it('rechecks busy-pattern adapters after first prompt timeout fallback unlocks startup', () => {


### PR DESCRIPTION
## 改了什么

- `reliableTurnTerminal` CLI（Grok/Codex 等）跳过 post-submit / queued 的 **busy-absent idle probe**，避免提交后几秒误判空闲、过早 DONE。
- card-off 进度 reaction 仅在 **`working|analyzing → idle|limited`** 时 ✋→✅，避免冷启动 settle 的假 idle。
- argv 冷启动首 prompt 第一次 ready 上报 **working**（非 idle），保证真实结束时有 working→idle 边，避免一直卡在 GoGoGo。

## 为什么

Grok 配了 `busyPattern`，提交后 UI busy 标记常滞后，post-submit probe 会假 idle 并提前 DONE；Codex 无 `busyPattern`，不走该路径。叠加上一轮「只允许 working→idle 才 DONE」后，argv 冷启动又会出现「永远 GoGoGo」（从未进入 working）。

## 影响面

- **CLI**：有 `busyPattern` 且 card-off 的会话（尤其 Grok）；Codex 无 busyPattern，行为基本不变。
- **模块**：`worker.ts`、`worker-pool.ts`、`adapters/cli/grok.ts`（注释）。
- **会话类型**：card-off / 无流式卡片的进度 reaction；开着流式卡片的不受影响。

## 测试验证

```bash
pnpm vitest run test/turn-reactions.test.ts test/worker-pipe-initial-screen-order.test.ts
# 36 passed
pnpm switch:here && pnpm daemon:restart
# 飞书 Grok 实测：GoGoGo → 任务结束 → DONE，中途不再秒切 DONE
```