### PR TITLE
fix(dashboard): 会话卡片不显示 bot 头像

### DIFF
--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -8375,6 +8375,11 @@ button.contrast:hover { background: var(--danger-soft); border-color: var(--dang
 /* ── 数字生命球（bot avatar，全站统一）──────────────────────────────────── */
 .orb-avatar {
   position: relative;
+  /* inline-flex 让球在任意容器（含 grid/inline 上下文）都占满自身尺寸——
+     只写 width/height 而不定 display 时，裸 <span> 会退回 inline，宽高被忽略，
+     父级 grid 列量成 0 宽，头像整个塌掉（话题/状态板卡片即如此）。 */
+  display: inline-flex;
+  vertical-align: middle;
   width: 42px;
   height: 42px;
   border-radius: 50%;


### PR DESCRIPTION
## 改了什么

会话控制页「话题 / 状态板」视图里，每张会话卡片本该在 bot 名字旁显示 bot 头像（复用全站统一的 `botAvatarHtml`，和群组管理等页面同一套），但一直是空白。

根因：`.orb-avatar` 基础样式只设了 `width/height`，没设 `display`。裸 `<span>` 默认 `display:inline` 会忽略宽高，内部头像 `<img>` 又是绝对定位不撑开父级，于是头像球塌成 0×0；卡片头部 `.session-card-top` 是 grid，那一列被量成 0 宽，头像整个不可见。其他页面正常是因为那里 `.orb-avatar` 恰好落在 flex 容器里。

修复：给 `.orb-avatar` 补 `display:inline-flex` + `vertical-align:middle`，头像球在任意容器都按自身尺寸占位。

## 为什么

用户反馈 dashboard 会话卡片希望展示 bot 头像而非纯文字。排查发现头像其实已接入、图也正常加载，只是被这个 CSS 缺陷卡住不显示。

## 影响面

- 只动 dashboard 前端 CSS 单文件 `src/dashboard/web/style.css`，不涉及 daemon / core / bot-registry / im 等公共层
- 不涉及跨平台、跨 CLI、跨会话类型逻辑
- `.orb-avatar` 是全站统一头像组件，此修复让所有使用点统一受益；已正常页面本就是 flex 布局，`inline-flex` 不改变其排布

## 验证

- `pnpm dashboard:bundle` 构建通过
- 在真实运行的 dashboard（v3.5.2）上实测：`.orb-avatar` 从 0×0 变为 24×24，卡片正常显示 Claude / botmux / grok 等对应 bot 头像
- 未跑 `pnpm test`（纯 CSS 展示修复，无对应断言）；`tsc` 本地因缺 `proxy-agent` 依赖在无关文件 `src/im/lark/event-dispatcher.ts` 报错，与本改动无关

## 截图与完整说明

before / after / 部署后真实效果截图，以及「如何发现 → 根因 → 修复」完整说明见飞书文档：
https://bytedance.larkoffice.com/docx/Kb3HdXBvuolYknxhNeuclUMXnAg
