### PR TITLE
fix(desktop): 修复 dashboard v2 兼容误判

### DIFF
--- a/src/desktop/main/dashboard-compat.ts
+++ b/src/desktop/main/dashboard-compat.ts
@@ -1,6 +1,6 @@
 import type { DashboardLocateResult } from '../shared/types.js';
 
-const supportedDashboardProtocolVersion = 1;
+const supportedDashboardProtocolVersion = 2;
 const defaultCompatTimeoutMs = 3000;
 const cliUpgradeHint = '请升级或切换全局 botmux CLI 后重启运行时；源码开发可执行 pnpm switch:here && botmux restart。也可以先在外部浏览器打开控制台。';
 

--- a/test/desktop/desktop-dashboard-compat.test.ts
+++ b/test/desktop/desktop-dashboard-compat.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it, vi } from 'vitest';
 
 describe('desktop dashboard compat validation', () => {
+  it('accepts the current runtime compat manifest', async () => {
+    const { buildCompatManifest } = await import('../../src/dashboard/compat.js');
+    const { validateDashboardCompat } = await import('../../src/desktop/main/dashboard-compat.js');
+    const fetch = vi.fn().mockResolvedValue(response(200, buildCompatManifest({
+      runtimeVersion: '3.6.0',
+      machineId: null,
+    })));
+
+    await expect(validateDashboardCompat('http://127.0.0.1:7891/', { fetch }))
+      .resolves.toEqual({ ok: true });
+  });
+
   it('accepts the supported desktop compat manifest', async () => {
     const { validateDashboardCompat } = await import('../../src/desktop/main/dashboard-compat.js');
     const fetch = vi.fn().mockResolvedValue(response(200, {
@@ -92,7 +104,7 @@ describe('desktop dashboard compat validation', () => {
       schemaVersion: 1,
       product: 'botmux',
       runtimeVersion: '3.0.0',
-      dashboardProtocolVersion: 2,
+      dashboardProtocolVersion: 3,
       desktopShell: { supported: true },
       features: ['desktop-shell'],
       routes: ['#/'],


### PR DESCRIPTION
## 改动内容

- 将 Desktop 支持的 dashboard 协议上限从 v1 同步到 v2。
- 增加当前 runtime compat manifest 与 Desktop 校验器之间的契约回归测试。
- 保留对 v1 manifest 的兼容，并继续拒绝未来未支持的 v3 协议。

## 根因与影响

3.6.0 runtime 已将 dashboard compat manifest 升级为 v2，同时保留 v1 字段；Desktop 仍硬编码只支持 v1，导致 App 与 CLI 同为 3.6.0 时，切换控制台页面仍被误判为 incompatible。

修复后 Desktop 可以正常嵌入当前 v2 dashboard；旧 v1 runtime 行为不变，未来更高协议仍会安全降级。

## 验证

- `pnpm exec vitest run test/desktop/desktop-dashboard-compat.test.ts test/desktop/dashboard-compat.test.ts test/desktop/desktop-ipc-runtime-monitor.test.ts`：27/27 通过
- `pnpm build`：通过
- 完整本地 Desktop 构建、安装和签名验证：通过
- `pnpm desktop:smoke`：7/7 通过，确认 runtime 3.6.0 / dashboard protocol v2