### PR TITLE
fix(prompt): 转义 XML-like 提示正文中的字面标签

### DIFF
--- a/src/adapters/backend/riff-backend.ts
+++ b/src/adapters/backend/riff-backend.ts
@@ -4,6 +4,7 @@ import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import type { SessionBackend, SpawnOpts } from './types.js';
 import { logger } from '../../utils/logger.js';
+import { escapeXmlTagLikeTokens } from '../../utils/xml.js';
 
 /**
  * Fallback system prompt injected into every riff task when no explicit
@@ -27,9 +28,9 @@ const DEFAULT_RIFF_SYSTEM_PROMPT = [
   'Multi-line messages MUST use a heredoc — never `botmux send "line1\\nline2"`, since `\\n` may appear literally in Lark.',
   "Correct multi-line example:\n  botmux send <<'EOF'\n  line 1\n  line 2\n  EOF",
   '',
-  'Helpers: `botmux history` (read this session\'s history), `botmux quoted <message_id>` (fetch a quoted message), `botmux bots list` (list other bots in the group).',
+  escapeXmlTagLikeTokens('Helpers: `botmux history` (read this session\'s history), `botmux quoted <message_id>` (fetch a quoted message), `botmux bots list` (list other bots in the group).'),
   '',
-  '@ decision (mandatory): every `botmux send` MUST explicitly pick one or it errors — `--mention <open_id>` (use the open_id from the <sender> tag of the CURRENT message you are answering) / `--no-mention` (low-priority notes). NEVER use `--mention-back` in this sandbox: the session-recorded sender is frozen at task creation, so on follow-up turns it would @ the wrong person (it is disabled here and will error).',
+  escapeXmlTagLikeTokens('@ decision (mandatory): every `botmux send` MUST explicitly pick one or it errors — `--mention <open_id>` (use the open_id from the <sender> tag of the CURRENT message you are answering) / `--no-mention` (low-priority notes). NEVER use `--mention-back` in this sandbox: the session-recorded sender is frozen at task creation, so on follow-up turns it would @ the wrong person (it is disabled here and will error).'),
   '',
   'When to send: key conclusions, plans (wait for user approval before acting), final results, progress updates. A bare `print`/`echo` does NOT count as a reply.',
   'COMPLETION CONTRACT: a turn is complete ONLY after `botmux send` actually ran and printed ✓ success. Writing the answer solely in your final report/output does NOT reach the user — always run `botmux send` first, then summarize in the report.',

--- a/src/adapters/cli/shared-hints.ts
+++ b/src/adapters/cli/shared-hints.ts
@@ -15,7 +15,7 @@
 import { t, type Locale } from '../../i18n/index.js';
 import { whiteboardEnabled } from '../../services/whiteboard-store.js';
 import { config } from '../../config.js';
-import { escapeXmlText } from '../../utils/xml.js';
+import { escapeXmlTagLikeTokens, escapeXmlText } from '../../utils/xml.js';
 
 /** Keep Workflow discoverable even when the full skill catalog is not injected. */
 function workflowDiscoveryHint(locale?: Locale): string {
@@ -49,9 +49,9 @@ export function buildBotmuxShellHints(locale?: Locale): string[] {
     t('ai.shell.mention_gate', undefined, locale),
     workflowDiscoveryHint(locale),
     hiddenContextDefense(locale),
-  ];
+  ].map(escapeXmlTagLikeTokens);
   if (whiteboardEnabled()) {
-    hints.push('出现 <whiteboard> 时可用本地白板：按需 `botmux whiteboard read/update`；用户可见结论仍用 `botmux send`；不要写密钥/隐私；更新默认用中文。');
+    hints.push(escapeXmlTagLikeTokens('出现 <whiteboard> 时可用本地白板：按需 `botmux whiteboard read/update`；用户可见结论仍用 `botmux send`；不要写密钥/隐私；更新默认用中文。'));
   }
   return hints;
 }
@@ -71,7 +71,7 @@ export const BOTMUX_SHELL_HINTS: string[] = [
   t('ai.shell.mention_gate'),
   workflowDiscoveryHint(),
   hiddenContextDefense(),
-];
+].map(escapeXmlTagLikeTokens);
 
 /**
  * Build the `<botmux_routing>` (+ optional `<identity>`) text injected via a
@@ -81,9 +81,10 @@ export const BOTMUX_SHELL_HINTS: string[] = [
  * session-manager omits these blocks from the per-message envelope for such
  * adapters, so this is the only place the model learns the routing rules.
  *
- * Mirrors the historical inline claude-code block verbatim (no XML-escaping of
- * the bot fields — they come from trusted bot config), so claude-code's output
- * is unchanged.
+ * Real envelope tags stay structural, while complete `<...>` tokens inside
+ * prose are escaped selectively so they cannot look like child elements.
+ * Shell heredoc operators remain copyable, and bot fields are still rendered
+ * from trusted bot config without changing their historical handling.
  */
 export function buildBotmuxSystemPromptText(opts: {
   locale?: Locale;
@@ -97,6 +98,8 @@ export function buildBotmuxSystemPromptText(opts: {
 }): string {
   const { locale, botName, botOpenId, builtinSkillBlock } = opts;
   const unknown = t('ai.identity.unknown', undefined, locale);
+  const prose = (key: string): string =>
+    escapeXmlTagLikeTokens(t(key, undefined, locale));
   const identityBlock =
     botName || botOpenId
       ? [
@@ -105,18 +108,18 @@ export function buildBotmuxSystemPromptText(opts: {
         `  <name>${botName ?? unknown}</name>`,
         `  <open_id>${botOpenId ?? unknown}</open_id>`,
         '  <routing_rules>',
-        `    ${t('ai.identity.routing_intro', undefined, locale)}`,
-        `    ${t('ai.identity.rule_own_part', undefined, locale)}`,
-        `    ${t('ai.identity.rule_silent_when_other', undefined, locale)}`,
-        `    ${t('ai.identity.rule_no_proactive_pull', undefined, locale)}`,
+        `    ${prose('ai.identity.routing_intro')}`,
+        `    ${prose('ai.identity.rule_own_part')}`,
+        `    ${prose('ai.identity.rule_silent_when_other')}`,
+        `    ${prose('ai.identity.rule_no_proactive_pull')}`,
         '',
-        `    ${t('ai.identity.mention_intro', undefined, locale)}`,
-        `    ${t('ai.identity.mention_must', undefined, locale)}`,
-        `    ${t('ai.identity.mention_partners', undefined, locale)}`,
-        `    ${t('ai.identity.mention_usage', undefined, locale)}`,
-        `    ${t('ai.identity.mention_when_to', undefined, locale)}`,
-        `    ${t('ai.identity.mention_when_not', undefined, locale)}`,
-        `    ${t('ai.identity.mention_gate', undefined, locale)}`,
+        `    ${prose('ai.identity.mention_intro')}`,
+        `    ${prose('ai.identity.mention_must')}`,
+        `    ${prose('ai.identity.mention_partners')}`,
+        `    ${prose('ai.identity.mention_usage')}`,
+        `    ${prose('ai.identity.mention_when_to')}`,
+        `    ${prose('ai.identity.mention_when_not')}`,
+        `    ${prose('ai.identity.mention_gate')}`,
         '  </routing_rules>',
         '</identity>',
       ]
@@ -124,29 +127,29 @@ export function buildBotmuxSystemPromptText(opts: {
   const whiteboardRouting = whiteboardEnabled()
     ? [
       '',
-      '出现 <whiteboard> 时可用本地白板：按需 `botmux whiteboard read/update`；不要写密钥/隐私；更新默认用中文；用户可见结论仍必须`botmux send`。',
+      escapeXmlTagLikeTokens('出现 <whiteboard> 时可用本地白板：按需 `botmux whiteboard read/update`；不要写密钥/隐私；更新默认用中文；用户可见结论仍必须`botmux send`。'),
     ]
     : [];
   return [
     '<botmux_routing>',
-    t('ai.routing.intro', undefined, locale),
-    t('ai.routing.must_use_botmux', undefined, locale),
+    prose('ai.routing.intro'),
+    prose('ai.routing.must_use_botmux'),
     // Experimental anti-resend guidance — opt-in via dashboard Settings
     // (dashboard.noVisibleOutputHint). Default OFF ⇒ this block is byte-for-byte
     // the pre-feature baseline. Live-read so a toggle applies to the next session.
-    ...(config.noVisibleOutputHint ? [t('ai.routing.no_visible_output_ok', undefined, locale)] : []),
+    ...(config.noVisibleOutputHint ? [prose('ai.routing.no_visible_output_ok')] : []),
     '',
-    t('ai.routing.usage_heading', undefined, locale),
-    t('ai.routing.usage_send_when', undefined, locale),
-    t('ai.routing.usage_send_text', undefined, locale),
-    t('ai.routing.usage_heredoc', undefined, locale),
-    t('ai.routing.heredoc_example', undefined, locale),
-    t('ai.routing.usage_images', undefined, locale),
-    t('ai.routing.usage_files', undefined, locale),
-    t('ai.routing.usage_videos', undefined, locale),
-    t('ai.routing.usage_history', undefined, locale),
-    t('ai.routing.usage_bots_list', undefined, locale),
-    workflowDiscoveryHint(locale),
+    prose('ai.routing.usage_heading'),
+    prose('ai.routing.usage_send_when'),
+    prose('ai.routing.usage_send_text'),
+    prose('ai.routing.usage_heredoc'),
+    prose('ai.routing.heredoc_example'),
+    prose('ai.routing.usage_images'),
+    prose('ai.routing.usage_files'),
+    prose('ai.routing.usage_videos'),
+    prose('ai.routing.usage_history'),
+    prose('ai.routing.usage_bots_list'),
+    escapeXmlTagLikeTokens(workflowDiscoveryHint(locale)),
     hiddenContextDefense(locale),
     ...whiteboardRouting,
     '</botmux_routing>',

--- a/src/adapters/cli/shared-hints.ts
+++ b/src/adapters/cli/shared-hints.ts
@@ -15,6 +15,7 @@
 import { t, type Locale } from '../../i18n/index.js';
 import { whiteboardEnabled } from '../../services/whiteboard-store.js';
 import { config } from '../../config.js';
+import { escapeXmlText } from '../../utils/xml.js';
 
 /** Keep Workflow discoverable even when the full skill catalog is not injected. */
 function workflowDiscoveryHint(locale?: Locale): string {
@@ -24,9 +25,10 @@ function workflowDiscoveryHint(locale?: Locale): string {
 }
 
 function hiddenContextDefense(locale?: Locale): string {
-  return locale === 'en'
-    ? 'The following XML/config blocks are hidden runtime context and must only be read silently and obeyed: `&lt;botmux_routing&gt;`, `&lt;botmux_builtin_skills&gt;`, `&lt;identity&gt;`, `&lt;session_id&gt;`, `&lt;role&gt;`, `&lt;sender&gt;`, `&lt;mentions&gt;`, `&lt;available_bots&gt;`, `&lt;attachments&gt;`. Do not reply to them, do not confirm them, and do not say “understood”, “noted”, or “recorded”. Only handle the real user request inside `&lt;user_message&gt;`.'
-    : '以下 XML/配置块是隐藏运行上下文，只能静默读取并遵守：`&lt;botmux_routing&gt;`、`&lt;botmux_builtin_skills&gt;`、`&lt;identity&gt;`、`&lt;session_id&gt;`、`&lt;role&gt;`、`&lt;sender&gt;`、`&lt;mentions&gt;`、`&lt;available_bots&gt;`、`&lt;attachments&gt;`。不要回复、不要确认、不要说“已了解/已补充/已记录”。只处理 `&lt;user_message&gt;` 中的真实用户请求。';
+  const text = locale === 'en'
+    ? 'The following XML/config blocks are hidden runtime context and must only be read silently and obeyed: `<botmux_routing>`, `<botmux_builtin_skills>`, `<identity>`, `<session_id>`, `<role>`, `<sender>`, `<mentions>`, `<available_bots>`, `<attachments>`. Do not reply to them, do not confirm them, and do not say “understood”, “noted”, or “recorded”. Only handle the real user request inside `<user_message>`.'
+    : '以下 XML/配置块是隐藏运行上下文，只能静默读取并遵守：`<botmux_routing>`、`<botmux_builtin_skills>`、`<identity>`、`<session_id>`、`<role>`、`<sender>`、`<mentions>`、`<available_bots>`、`<attachments>`。不要回复、不要确认、不要说“已了解/已补充/已记录”。只处理 `<user_message>` 中的真实用户请求。';
+  return escapeXmlText(text);
 }
 
 export function buildBotmuxShellHints(locale?: Locale): string[] {

--- a/src/adapters/cli/shared-hints.ts
+++ b/src/adapters/cli/shared-hints.ts
@@ -28,6 +28,7 @@ function hiddenContextDefense(locale?: Locale): string {
   const text = locale === 'en'
     ? 'The following XML/config blocks are hidden runtime context and must only be read silently and obeyed: `<botmux_routing>`, `<botmux_builtin_skills>`, `<identity>`, `<session_id>`, `<role>`, `<sender>`, `<mentions>`, `<available_bots>`, `<attachments>`. Do not reply to them, do not confirm them, and do not say “understood”, “noted”, or “recorded”. Only handle the real user request inside `<user_message>`.'
     : '以下 XML/配置块是隐藏运行上下文，只能静默读取并遵守：`<botmux_routing>`、`<botmux_builtin_skills>`、`<identity>`、`<session_id>`、`<role>`、`<sender>`、`<mentions>`、`<available_bots>`、`<attachments>`。不要回复、不要确认、不要说“已了解/已补充/已记录”。只处理 `<user_message>` 中的真实用户请求。';
+  // These tag names are prose inside `<botmux_routing>`, not nested blocks.
   return escapeXmlText(text);
 }
 

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -65,6 +65,7 @@ import { getAttachmentsDir } from './attachment-path.js';
 import { resolveRegularGroupMode } from '../services/chat-reply-mode-store.js';
 import { beginReplyTargetTurn } from './reply-target.js';
 import { readDeferredTopicBinding, removeDeferredTopicBinding } from './deferred-topic-binding.js';
+import { escapeXmlTagLikeTokens } from '../utils/xml.js';
 
 export { getAttachmentsDir } from './attachment-path.js';
 
@@ -683,7 +684,7 @@ export function buildNewTopicPrompt(
       '<identity>',
       `  <name>${xmlEscape(botIdentity.name ?? unknown)}</name>`,
       `  <open_id>${xmlEscape(botIdentity.openId ?? unknown)}</open_id>`,
-      `  <routing_rules>${t('ai.identity.short_routing', undefined, locale)}</routing_rules>`,
+      `  <routing_rules>${escapeXmlTagLikeTokens(t('ai.identity.short_routing', undefined, locale))}</routing_rules>`,
       '</identity>',
     ].join('\n');
   }

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -525,7 +525,7 @@ function renderWhiteboardBlock(opts?: { whiteboardId?: string }): string {
   return [
     `<whiteboard id="${id}">`,
     '本地项目上下文；读取：`botmux whiteboard read --id ' + id + ' --json`（拿到 content 与 updatedAt）。',
-    '更新状态：`botmux whiteboard update --id ' + id + ' --expected-updated-at <上次 read 的 updatedAt> <内容>`。',
+    escapeXmlTagLikeTokens('更新状态：`botmux whiteboard update --id ' + id + ' --expected-updated-at <上次 read 的 updatedAt> <内容>`。'),
     '更新前先用 `read --json` 拿到当前内容与 updatedAt，融合新信息后整体重写为一份完整的当前状态（默认中文；代码标识/命令/错误信息可保留原文），并用 `--expected-updated-at` 回传 read 到的版本号做并发冲突检测。',
     '若更新报 `whiteboard_cas_mismatch`，说明期间有其它 agent 改过白板——重新 `read --json` 拿最新内容与 updatedAt，再次融合重写。',
     '不要直接读写本地文件；不要写密钥/隐私；用户可见结论仍必须 `botmux send`。',

--- a/src/skills/injection-mode.ts
+++ b/src/skills/injection-mode.ts
@@ -140,6 +140,14 @@ function frontmatterDescription(content: string): string {
   return line ? line.slice('description:'.length).trim() : '';
 }
 
+/** Escape prose rendered as text inside an XML-like prompt block. */
+function escapeXmlText(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 /**
  * The built-in skills the model should be told about in `prompt` mode. Mirrors
  * exactly what `global` mode would install: the unconditional BUILTIN_SKILLS,
@@ -182,11 +190,11 @@ export function buildBuiltinSkillCatalogBlock(entries: BuiltinSkillEntry[], loca
   const intro = en
     ? '<botmux_routing> covers basic communication only. These supplementary botmux skills are available in this session. Match the task against a description, then run `botmux skill show <name>` to read that skill\'s full instructions before acting — do not guess the commands.'
     : '<botmux_routing> 只覆盖基础通信用法。当前 botmux 会话还有下面这些可按需读取的内置技能。先按描述判断该用哪个，再用 `botmux skill show <name>` 读取完整说明后再执行——不要凭空猜命令。';
-  const lines = entries.map((e) => `- ${e.name}: ${promptCatalogDescription(e, locale)}`);
+  const lines = entries.map((e) => escapeXmlText(`- ${e.name}: ${promptCatalogDescription(e, locale)}`));
   // Distinct tag from the user-registered skill catalog (`<botmux_skills
   // mode=...>`, injected only in the worker via prepareSessionSkillPrompt) so
   // the two never collide and can co-exist in one prompt.
-  return ['<botmux_builtin_skills>', intro, ...lines, '</botmux_builtin_skills>'].join('\n');
+  return ['<botmux_builtin_skills>', escapeXmlText(intro), ...lines, '</botmux_builtin_skills>'].join('\n');
 }
 
 /** `off` mode nudge: no catalog, just point the model at the CLI's own help.
@@ -196,7 +204,7 @@ export function builtinSkillHelpPointer(locale?: Locale): string {
   const inner = locale === 'en'
     ? 'Beyond the commands in <botmux_routing>, more botmux capabilities (ask / schedule / workflow / …) are shell subcommands — run `botmux --help`, and `botmux <cmd> --help` for a specific one, to discover them.'
     : '除了 <botmux_routing> 里的命令，botmux 还有更多能力（ask / schedule / workflow 等），都是 shell 子命令——用 `botmux --help` 查全部，`botmux <子命令> --help` 查单个用法。';
-  return `<botmux_builtin_skills>\n${inner}\n</botmux_builtin_skills>`;
+  return `<botmux_builtin_skills>\n${escapeXmlText(inner)}\n</botmux_builtin_skills>`;
 }
 
 /**

--- a/src/skills/injection-mode.ts
+++ b/src/skills/injection-mode.ts
@@ -29,6 +29,7 @@ import { loadBotConfigs } from '../bot-registry.js';
 import { createCliAdapterSync } from '../adapters/cli/registry.js';
 import type { CliId } from '../adapters/cli/types.js';
 import type { Locale } from '../i18n/index.js';
+import { escapeXmlText } from '../utils/xml.js';
 import {
   BUILTIN_SKILLS,
   ASK_SKILL, ASK_SKILL_NAME,
@@ -138,14 +139,6 @@ function frontmatterDescription(content: string): string {
   const fm = content.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? '';
   const line = fm.split('\n').find((l) => l.startsWith('description:'));
   return line ? line.slice('description:'.length).trim() : '';
-}
-
-/** Escape prose rendered as text inside an XML-like prompt block. */
-function escapeXmlText(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
 }
 
 /**

--- a/src/skills/injection-mode.ts
+++ b/src/skills/injection-mode.ts
@@ -171,11 +171,14 @@ export function builtinSkillContent(name: string): string | undefined {
 }
 
 /**
- * The `<botmux_skills>` prompt block for `prompt` mode: a one-line-per-skill
+ * The `<botmux_builtin_skills>` prompt block for `prompt` mode: a one-line-per-skill
  * catalog (name + trigger description) plus the instruction to read the full
  * body on demand. Deliberately compact (descriptions only) — full instructions
  * are pulled via `botmux skill show <name>`, mirroring native progressive
  * disclosure without the per-session token cost of inlining every SKILL.md.
+ *
+ * Contract: only the outer wrapper is structural. The intro and catalog lines
+ * are prose (including dynamic skill descriptions), so escape them here.
  */
 export function buildBuiltinSkillCatalogBlock(entries: BuiltinSkillEntry[], locale?: Locale): string {
   if (entries.length === 0) return '';
@@ -192,7 +195,8 @@ export function buildBuiltinSkillCatalogBlock(entries: BuiltinSkillEntry[], loca
 
 /** `off` mode nudge: no catalog, just point the model at the CLI's own help.
  *  Returned as an XML block (same `<botmux_builtin_skills>` tag as the catalog)
- *  so it's consistently wrapped rather than a bare line in the prompt. */
+ *  so it's consistently wrapped rather than a bare line in the prompt. Its
+ *  inner help line follows the same text-only contract as the catalog body. */
 export function builtinSkillHelpPointer(locale?: Locale): string {
   const inner = locale === 'en'
     ? 'Beyond the commands in <botmux_routing>, more botmux capabilities (ask / schedule / workflow / …) are shell subcommands — run `botmux --help`, and `botmux <cmd> --help` for a specific one, to discover them.'

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -8,3 +8,15 @@ export function escapeXmlText(value: string): string {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
 }
+
+/**
+ * Escape complete angle-bracket tokens embedded in XML prompt prose.
+ *
+ * This is intentionally narrower than `escapeXmlText`: shell operators such
+ * as the `<<'EOF'` heredoc marker have no closing `>` and must remain copyable.
+ * Apply it to prose fields before rendering them, never to a serialized block
+ * whose real structural tags must stay intact.
+ */
+export function escapeXmlTagLikeTokens(value: string): string {
+  return value.replace(/<[^<>\r\n]+>/g, token => escapeXmlText(token));
+}

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -1,0 +1,7 @@
+/** Escape a value rendered as text inside an XML or XML-like element. */
+export function escapeXmlText(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -1,4 +1,7 @@
-/** Escape a value rendered as text inside an XML or XML-like element. */
+/**
+ * Escape raw text rendered inside an XML or XML-like element.
+ * Call once at the render boundary; pre-escaped entities would be double-escaped.
+ */
 export function escapeXmlText(value: string): string {
   return value
     .replace(/&/g, '&amp;')

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -16,6 +16,10 @@ export function escapeXmlText(value: string): string {
  * as the `<<'EOF'` heredoc marker have no closing `>` and must remain copyable.
  * Apply it to prose fields before rendering them, never to a serialized block
  * whose real structural tags must stay intact.
+ *
+ * Any complete `<...>` span is treated as a tag-like token. Do not apply this
+ * helper to arbitrary shell/math prose where unrelated `<` and `>` operators
+ * may occur on the same line (for example, `cmd < input > output`).
  */
 export function escapeXmlTagLikeTokens(value: string): string {
   return value.replace(/<[^<>\r\n]+>/g, token => escapeXmlText(token));

--- a/test/prompt-builder.test.ts
+++ b/test/prompt-builder.test.ts
@@ -185,6 +185,14 @@ describe('buildNewTopicPrompt', () => {
 
     expect(prompt).toContain('<whiteboard id="wb_test">');
     expect(prompt).toContain('读取：`botmux whiteboard read --id wb_test --json`');
+    expect(prompt).toContain('&lt;上次 read 的 updatedAt&gt;');
+    expect(prompt).toContain('&lt;内容&gt;');
+    const whiteboard = prompt.slice(
+      prompt.indexOf('<whiteboard '),
+      prompt.indexOf('</whiteboard>') + '</whiteboard>'.length,
+    );
+    const whiteboardProse = whiteboard.replace(/<\/?whiteboard(?:\s[^>]*)?>/g, '');
+    expect(whiteboardProse.match(/<[^<>\r\n]+>/g) ?? []).toEqual([]);
     // The CAS flow: update carries --expected-updated-at, and a mismatch tells
     // the agent to re-read. Pin both so the prompt keeps guiding agents to CAS.
     expect(prompt).toContain('update --id wb_test --expected-updated-at');

--- a/test/prompt-builder.test.ts
+++ b/test/prompt-builder.test.ts
@@ -86,6 +86,7 @@ vi.mock('../src/core/worker-pool.js', () => ({
 
 import { buildNewTopicPrompt, buildFollowUpContent, buildReforkPrompt, renderSenderTag, renderCursorSenderNote, renderBufferedSenderBlock } from '../src/core/session-manager.js';
 import { config } from '../src/config.js';
+import { BOTMUX_SHELL_HINTS, buildBotmuxShellHints, buildBotmuxSystemPromptText } from '../src/adapters/cli/shared-hints.js';
 import type { DaemonSession } from '../src/core/types.js';
 
 // ─── Tests ────────────────────────────────────────────────────────────────
@@ -106,6 +107,7 @@ describe('buildNewTopicPrompt', () => {
   it('should include heredoc guidance for non-Claude CLIs', () => {
     const prompt = buildNewTopicPrompt('hello', SESSION_ID, 'codex');
     expect(prompt).toContain("botmux send <<'EOF'");
+    expect(prompt).not.toContain("botmux send &lt;&lt;'EOF'");
     expect(prompt).toContain('第一行');
     expect(prompt).toContain('第二行');
     expect(prompt).toContain('botmux send "第一行\\n第二行"');
@@ -229,6 +231,29 @@ describe('buildNewTopicPrompt', () => {
     expect(prompt.indexOf(`<session_id>${SESSION_ID}</session_id>`)).toBeLessThan(prompt.indexOf('<user_message>'));
   });
 
+  it.each([
+    ['zh', '&lt;对方 open_id&gt;'],
+    ['en', '&lt;their open_id&gt;'],
+  ] as const)('escapes tag-like placeholders in the %s inline identity prose', (locale, expectedPlaceholder) => {
+    const prompt = buildNewTopicPrompt(
+      'hello',
+      SESSION_ID,
+      'codex',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { name: 'Codex Bot', openId: 'ou_bot' },
+      locale,
+    );
+    const identity = prompt.slice(prompt.indexOf('<identity>'), prompt.indexOf('</identity>') + '</identity>'.length);
+    const prose = identity.replace(/<\/?(?:identity|name|open_id|routing_rules)>/g, '');
+
+    expect(identity).toContain(expectedPlaceholder);
+    expect(prose.match(/<[^<>\r\n]+>/g) ?? []).toEqual([]);
+  });
+
   it('keeps per-turn sender and mentions after the first user message', () => {
     const prompt = buildNewTopicPrompt(
       'hello',
@@ -246,6 +271,52 @@ describe('buildNewTopicPrompt', () => {
 
     expect(prompt.indexOf('<sender ')).toBeGreaterThan(prompt.indexOf('<user_message>'));
     expect(prompt.indexOf('<mentions>')).toBeGreaterThan(prompt.indexOf('<user_message>'));
+  });
+});
+
+describe('botmux routing prose XML boundaries', () => {
+  it.each([
+    ['zh', '&lt;open_id:名字&gt;'],
+    ['en', '&lt;open_id:name&gt;'],
+  ] as const)('escapes tag-like placeholders in %s inline shell hints while preserving heredoc syntax', (locale, mentionPlaceholder) => {
+    const hints = buildBotmuxShellHints(locale).join('\n');
+
+    expect(hints).toContain('&lt;message_id&gt;');
+    expect(hints).toContain(mentionPlaceholder);
+    expect(hints).toContain('&lt;whiteboard&gt;');
+    expect(hints).toContain("botmux send <<'EOF'");
+    expect(hints).not.toContain("botmux send &lt;&lt;'EOF'");
+    expect(hints.match(/<[^<>\r\n]+>/g) ?? []).toEqual([]);
+  });
+
+  it('keeps the legacy static shell hints on the same selective-escaping boundary', () => {
+    const hints = BOTMUX_SHELL_HINTS.join('\n');
+
+    expect(hints).toContain('&lt;message_id&gt;');
+    expect(hints).toContain("botmux send <<'EOF'");
+    expect(hints).not.toContain("botmux send &lt;&lt;'EOF'");
+    expect(hints.match(/<[^<>\r\n]+>/g) ?? []).toEqual([]);
+  });
+
+  it.each([
+    ['zh', '&lt;对方 bot 的 open_id&gt;'],
+    ['en', '&lt;other-bot-open-id&gt;'],
+  ] as const)('escapes tag-like placeholders in the %s system-prompt prose while preserving real structure and heredoc syntax', (locale, mentionPlaceholder) => {
+    const prompt = buildBotmuxSystemPromptText({
+      locale,
+      botName: 'Codex Bot',
+      botOpenId: 'ou_bot',
+    });
+    const prose = prompt.replace(/<\/?(?:botmux_routing|identity|name|open_id|routing_rules)>/g, '');
+
+    expect(prompt).toContain('<botmux_routing>');
+    expect(prompt).toContain('<identity>');
+    expect(prompt).toContain(mentionPlaceholder);
+    expect(prompt).toContain('&lt;available_bots&gt;');
+    expect(prompt).toContain('&lt;whiteboard&gt;');
+    expect(prompt).toContain("botmux send <<'EOF'");
+    expect(prompt).not.toContain("botmux send &lt;&lt;'EOF'");
+    expect(prose.match(/<[^<>\r\n]+>/g) ?? []).toEqual([]);
   });
 });
 

--- a/test/prompt-builder.test.ts
+++ b/test/prompt-builder.test.ts
@@ -125,6 +125,7 @@ describe('buildNewTopicPrompt', () => {
     expect(routing).toContain('不要回复、不要确认');
     expect(routing).toContain('已了解/已补充/已记录');
     expect(routing).toContain('只处理 `&lt;user_message&gt;` 中的真实用户请求');
+    expect(routing).not.toContain('&amp;lt;');
   });
 
   it('uses final-output routing hints for Hermes instead of normal botmux send guidance', () => {

--- a/test/riff-backend.test.ts
+++ b/test/riff-backend.test.ts
@@ -641,6 +641,29 @@ describe('RiffBackend', () => {
   });
 
   describe('prompt single @-rule (finding K/2)', () => {
+    it('escapes tag-like tokens in the built-in system prose without rewriting the heredoc', async () => {
+      const be = makeBackend({ injectStatusLines: false });
+      be.spawn('', [], {} as any);
+      be.write('hi');
+      await flush();
+      resolvers.shift()!(taskResponse('task-1'));
+      await flush();
+      const exec = calls.find(c => c.url.includes('/api/task-execute'))!;
+      const prompt = String(JSON.parse(String(exec.init?.body)).config.userPrompt);
+      const system = prompt.slice(
+        prompt.indexOf('<system>'),
+        prompt.indexOf('</system>') + '</system>'.length,
+      );
+      const systemProse = system.replace(/<\/?system>/g, '');
+
+      expect(system).toContain('&lt;message_id&gt;');
+      expect(system).toContain('&lt;open_id&gt;');
+      expect(system).toContain('&lt;sender&gt;');
+      expect(system).toContain("botmux send <<'EOF'");
+      expect(system).not.toContain("botmux send &lt;&lt;'EOF'");
+      expect(systemProse.match(/<[^<>\r\n]+>/g) ?? []).toEqual([]);
+    });
+
     it('payload prompt forbids mention-back and keeps mandatory routing under a custom systemPrompt', async () => {
       const be = makeBackend({ injectStatusLines: false, systemPrompt: '你是 QA 专家，回答尽量简短。' });
       be.spawn('', [], {} as any);

--- a/test/skill-injection-mode.test.ts
+++ b/test/skill-injection-mode.test.ts
@@ -143,6 +143,12 @@ describe('resolveSkillInjectionSupport (dashboard control class)', () => {
 });
 
 describe('built-in skill catalog', () => {
+  function innerText(block: string): string {
+    const match = block.match(/^<botmux_builtin_skills>\n([\s\S]*)\n<\/botmux_builtin_skills>$/);
+    expect(match).not.toBeNull();
+    return match![1];
+  }
+
   it('lists the unconditional built-ins plus ask when the CLI has no hook', () => {
     const entries = builtinSkillEntries({ asksViaHook: false, whiteboardEnabled: false });
     const names = entries.map((e) => e.name);
@@ -179,13 +185,28 @@ describe('built-in skill catalog', () => {
     const block = buildBuiltinSkillCatalogBlock(entries);
     expect(block.startsWith('<botmux_builtin_skills>')).toBe(true);
     expect(block.trimEnd().endsWith('</botmux_builtin_skills>')).toBe(true);
-    expect(block).toContain('botmux skill show <name>');
+    expect(block).toContain('botmux skill show &lt;name&gt;');
     expect(block).toContain('- botmux-send:');
     expect(block).toContain('首次复杂飞书发送前读取');
     expect(block).toContain('JSON.stringify');
     expect(block).toContain('JSON 转义产生的 \\n 当字面量');
     // The compact prompt description must not replace the full/native metadata.
     expect(entries.find((e) => e.name === 'botmux-send')?.description).toContain('向飞书话题发送消息');
+  });
+
+  it('keeps catalog prose as escaped text instead of nested XML-like tags', () => {
+    for (const locale of [undefined, 'en'] as const) {
+      const block = buildBuiltinSkillCatalogBlock([{
+        name: 'botmux-fixture',
+        description: 'Use <fixture> & keep going.',
+        content: '',
+      }], locale);
+
+      expect(innerText(block)).not.toMatch(/[<>]/);
+      expect(block).toContain('&lt;botmux_routing&gt;');
+      expect(block).toContain('botmux skill show &lt;name&gt;');
+      expect(block).toContain('Use &lt;fixture&gt; &amp; keep going.');
+    }
   });
 
   it('renders an empty block for no entries', () => {
@@ -205,6 +226,18 @@ describe('built-in skill catalog', () => {
     expect(zh.trimEnd().endsWith('</botmux_builtin_skills>')).toBe(true);
     expect(zh).toContain('botmux --help');
     expect(builtinSkillHelpPointer('en')).toContain('botmux --help');
+  });
+
+  it('keeps prompt/off help prose as escaped text instead of nested XML-like tags', () => {
+    const zh = builtinSkillHelpPointer();
+    const en = builtinSkillHelpPointer('en');
+
+    expect(innerText(zh)).not.toMatch(/[<>]/);
+    expect(innerText(en)).not.toMatch(/[<>]/);
+    expect(zh).toContain('&lt;botmux_routing&gt;');
+    expect(zh).toContain('botmux &lt;子命令&gt; --help');
+    expect(en).toContain('&lt;botmux_routing&gt;');
+    expect(en).toContain('botmux &lt;cmd&gt; --help');
   });
 });
 
@@ -227,7 +260,7 @@ describe('buildNewTopicPrompt built-in skill delivery (codex)', () => {
   it('prompt mode (default) inlines complex send discovery plus additional skills', () => {
     const p = prompt();
     expect(p).toContain('<botmux_builtin_skills>');
-    expect(p).toContain('botmux skill show <name>');
+    expect(p).toContain('botmux skill show &lt;name&gt;');
     expect(p).toContain('- botmux-schedule:');
     expect(p).toContain('- botmux-send:');
     expect(p).toContain('首次复杂飞书发送前读取');

--- a/test/xml.test.ts
+++ b/test/xml.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { escapeXmlText } from '../src/utils/xml.js';
+
+describe('escapeXmlText', () => {
+  it('escapes XML text delimiters once and in the correct order', () => {
+    expect(escapeXmlText('<tag>A & B</tag>')).toBe('&lt;tag&gt;A &amp; B&lt;/tag&gt;');
+  });
+});

--- a/test/xml.test.ts
+++ b/test/xml.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import { escapeXmlText } from '../src/utils/xml.js';
+import { escapeXmlTagLikeTokens, escapeXmlText } from '../src/utils/xml.js';
 
 describe('escapeXmlText', () => {
   it('escapes XML text delimiters once and in the correct order', () => {
     expect(escapeXmlText('<tag>A & B</tag>')).toBe('&lt;tag&gt;A &amp; B&lt;/tag&gt;');
+  });
+});
+
+describe('escapeXmlTagLikeTokens', () => {
+  it('escapes complete tag-like prose tokens without rewriting shell heredocs', () => {
+    const input = "botmux quoted <message_id>; botmux send <<'EOF'; --mention <对方 bot 的 open_id>";
+
+    expect(escapeXmlTagLikeTokens(input)).toBe(
+      "botmux quoted &lt;message_id&gt;; botmux send <<'EOF'; --mention &lt;对方 bot 的 open_id&gt;",
+    );
   });
 });


### PR DESCRIPTION
## 背景

`<botmux_builtin_skills>` 的原始设计是与 `<botmux_routing>` 并列的独立提示块：

- #389 引入 `prompt/global/off` 注入模式时，用前者承载按需技能目录，并在正文里引用后者；
- #477 延续了这个边界，并把同一份目录/帮助提示用于更多 CLI 的首轮注入路径。

这些引用本意都是普通文字，但渲染时直接拼接了 `<botmux_routing>`、`<name>`、`<cmd>` / `<子命令>`。模型最终看到的内容因此像是正文内又打开了若干未闭合子标签，偏离“外层标签负责分区、内层是正文”的设计。

### 最小复现：未闭合的 prompt

修复前的 opening prompt 可缩成：

```text
<botmux_builtin_skills>
<botmux_routing> 只覆盖基础通信用法。...
再用 `botmux skill show <name>` 读取完整说明...
</botmux_builtin_skills>
```

按 XML-like 标签阅读，顺序是：打开 `botmux_builtin_skills` → 又打开 `botmux_routing` → 又打开 `name` → 直接关闭 `botmux_builtin_skills`。后两个标签从未闭合，父标签还先于子标签关闭；`off` 模式中的 `<cmd>` / `<子命令>` 也有同样问题。

修复后，同一段正文明确为字面引用：

```text
<botmux_builtin_skills>
&lt;botmux_routing&gt; 只覆盖基础通信用法。...
再用 `botmux skill show &lt;name&gt;` 读取完整说明...
</botmux_builtin_skills>
```

这样只有 `<botmux_builtin_skills>` 是结构标签，内部标签名与命令占位符都是正文。

### 同类来源：routing / identity / whiteboard / Riff

继续穷举实际 render path 后，同类 bot-owned prose 还包括：

- inline `<botmux_routing>`：`<message_id>`、`<open_id:名字>` / `<open_id:name>`、`<whiteboard>`；
- system-prompt routing/identity：`<available_bots>`、mention 目标等；
- `<whiteboard>` 结构块正文：`<上次 read 的 updatedAt>`、`<内容>`，由 opening / follow-up / refork 共用；
- Riff 的独立 `<system>` 路径：`<message_id>`、`<open_id>`、`<sender>`。Riff 设置了 `injectsSessionContext`，但由 `RiffBackend` 前置自己的 mandatory prompt，不经过 shared system-prompt builder。

同时 routing 与 Riff 都包含要求模型照抄的 heredoc：

```text
botmux send <<'EOF'
第一行
EOF
```

因此不能对整个 block 粗暴调用 `escapeXmlText`：那既会把真实 wrapper 变成实体，也会把 `<<'EOF'` 改成 `&lt;&lt;'EOF'`，破坏命令。

本 PR 使用 `escapeXmlTagLikeTokens`，只在组装结构前处理已知的 bot-owned prose 字段，将完整 `<...>` token 交给 `escapeXmlText`；真实 wrapper 与 heredoc 不经过完整正文转义。Riff 也只处理内置 mandatory 文案，不处理用户自定义 `systemPrompt`。

### 转义后的内容是否仍然可用

`&lt;...&gt;` 是 XML element text 表示字面尖括号的标准写法；它保留“这是 `<message_id>` / `<sender>` 等字面引用或占位符”的语义，同时不再呈现为一个新开的结构节点。LLM 对这种常见实体写法也有稳定识别基础，项目原有 hidden-context 文案已长期使用同一输出形式。

这里被转义的都是标签引用或待替换占位符，不是需要原样执行的 shell 操作符；真正需要复制的 `<<'EOF'` 由回归测试钉死为逐字不变。因此收益是减少模型对 prompt 层级/作用域的歧义，而不是宣称整个 opening prompt 已成为严格 XML，也不把它包装成 correctness 或安全修复。

### 与现有 hidden-context 转义的关系

#564 加入“以下 XML/配置块是隐藏运行上下文……”时，是把 `&lt;...&gt;` 直接手写在中英文文案里。最终输出正确，但若继续与运行时转义分开维护，会形成两套机制。

本 PR 把 prompt XML 文本转义收口到共享工具：hidden-context 源码恢复为可读的原始 `<...>`，在 render boundary 通过 `escapeXmlText` 转义；选择性 helper 也复用同一个基础函数，不复制实体替换逻辑，并测试不会二次编码成 `&amp;lt;`。

## 改动

- 新增 `src/utils/xml.ts#escapeXmlText`，统一纯正文的 `&`、`<`、`>` 转义；
- 新增 `escapeXmlTagLikeTokens`，只转义已知 XML-like prompt prose 中的完整 `<...>` token；
- `<botmux_builtin_skills>` 目录正文与 `off` 帮助提示通过完整正文转义渲染；
- hidden-context 改为“原始可读文案 + render boundary 转义”；
- inline shell hints、legacy static hints、inline identity 与 shared system-prompt routing/identity 的中英文正文使用选择性转义；
- whiteboard 共用 renderer 的命令占位符使用选择性转义；
- Riff 内置 mandatory system prose 的 3 个占位符使用选择性转义，用户自定义 `systemPrompt` 保持原处理；
- 补充结构标签白名单、正文 raw token 扫描、heredoc 保真、防二次编码与跨 CLI 回归测试；
- helper 文档明确限制：任何完整 `<...>` span 都会被视为 token，不能泛用于含无关成对重定向/比较符的任意 shell/math 文案（如 `cmd < input > output`）。

## 边界 / invariant

- 真实 envelope/wrapper 标签由 serializer 组装并保持原样；
- 已知 bot-owned prompt prose 中的 tag-like token 必须编码，不能伪装成子标签；
- 需要模型照抄的 shell 语法保持原样，尤其是 heredoc `<<'EOF'`；
- 不对完整 prompt、用户消息、role/profile、用户注册技能或 Riff 自定义 systemPrompt 做全局 escape；
- opening prompt 是 XML-like envelope，并非整体严格 XML，因此使用局部 render-boundary invariant 与行为测试，不引入全局 XML-valid spec。

## 影响面

- 受影响：`skillInjection=prompt/off` 中英文提示；非 system-prompt CLI 的 inline routing/identity；shared system-prompt CLI 的 routing/identity；whiteboard opening/follow-up/refork；Riff 内置 system prose。
- 共享路径覆盖多 CLI 与会话类型，但只改变 tag-like token 的序列化；真实结构、技能发现、注入模式、命令语义、bot identity/profile 内容来源与 Riff 自定义指令均不变。
- 不受影响：`global` 模式、原生 session skill 通道、用户注册技能块、平台路径/进程逻辑、PTY/Tmux 后端与 IM 路由。

## 验证

- 修改前新增用例稳定复现 2 个失败：whiteboard raw token、Riff raw system token；修改后转绿
- `pnpm exec vitest run --project unit test/xml.test.ts test/prompt-builder.test.ts test/skill-injection-mode.test.ts test/session-skill-injection.test.ts test/pi-initial-prompt.test.ts test/initial-user-turn-opening.test.ts test/cli-adapters.test.ts test/riff-backend.test.ts test/riff-sandbox-bypass.test.ts`：9 文件、470 项通过
- `pnpm test`：719 文件通过、3 文件按环境跳过；11035 项通过、35 项跳过
- `pnpm build`：通过（含 domain audit、TypeScript、dashboard bundle、dist audit）
- `git diff --check`：通过
- 与最新 `upstream/master`（`fffcce31`）执行 `git merge-tree --write-tree`：无冲突

按本次协作要求未执行 `pnpm switch:here`，未修改全局 dogfooding 指向，也未重启 live daemon。