### PR TITLE
fix(pm2): 给 pm2 jlist 输出捕获加 maxBuffer，修大 fleet 下 start-bot ENOBUFS

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -330,6 +330,13 @@ function pm2Capture(args: string[], home: string = PM2_HOME, timeoutMs = 10_000)
     env: pm2Env(home),
     shell: pm2.shell ?? false,
     timeout: timeoutMs,
+    // `pm2 jlist` serializes EVERY process's full env + metadata, so its stdout
+    // grows ~linearly with the bot count. Node's default spawnSync maxBuffer is
+    // 1 MiB — a box with ~30+ bots blows past it and spawnSync fails with
+    // ENOBUFS, which surfaced as `start-bot` (dashboard "bring one bot online")
+    // dying before it could launch anything. Lift the cap well above any real
+    // fleet size. (ps/git captures elsewhere already do the same.)
+    maxBuffer: 64 * 1024 * 1024,
   });
   if (r.status !== 0) {
     const detail = r.error?.message

--- a/src/core/plugins/pm2.ts
+++ b/src/core/plugins/pm2.ts
@@ -56,6 +56,10 @@ export function capturePluginPm2(args: string[], opts: { timeoutMs?: number; env
     env: pm2Env(opts.env),
     shell: pm2.shell ?? false,
     timeout: opts.timeoutMs ?? 10_000,
+    // `pm2 jlist` output scales with the process count (full env per process);
+    // Node's 1 MiB default spawnSync buffer overflows to ENOBUFS on large
+    // fleets. Match cli.ts pm2Capture — lift the cap far above any real size.
+    maxBuffer: 64 * 1024 * 1024,
   });
   if (result.status !== 0) {
     const detail = result.error?.message


### PR DESCRIPTION
## 背景
机器上 bot 数量较多时（实测 46 个 pm2 进程），**dashboard/CLI 新建 bot 无法自动上线**：`botmux start-bot <appId>` 在第一步 `pm2 jlist` 就抛 `spawnSync … ENOBUFS`，还没开始拉起进程就失败。live 复现于生产 box（申晗手动 dashboard 扫码建 bot，写进 bots.json 但没起进程）。

## 根因
`pm2 jlist` 把**每个进程的完整 env + 元数据**序列化进 stdout，体积随 bot 数近似线性增长；本机 jlist 已达 **~1.6 MB**。而捕获它的两处 `spawnSync` 都没设 `maxBuffer`，用 Node 默认 **1 MiB** 上限 → 超限即 `ENOBUFS`。阈值约 30 个进程，本机早已越过。

- `src/cli.ts` `pm2Capture`（start-bot / status / inspect 都走它）
- `src/core/plugins/pm2.ts` `capturePluginPm2`（plugin service-manager 读 jlist，同样的潜在 bug）

既有 bot 不受影响——daemon 冷启动 / restart 走**批量 pm2 start**路径；只有**单条 start-bot** 读 jlist 时中招，故表现为「老 bot 正常、新建 bot 起不来」。

## 改动
两处捕获 jlist 的 spawnSync 都加 `maxBuffer: 64 * 1024 * 1024`，远高于任何真实 fleet 规模。与仓库其它大输出捕获一致（`ps -axww` 32 MiB、session-discovery 16 MiB、cli-runtime-update 2 MiB）。

## 影响面
- 纯扩容性修复，不改 pm2 命令语义 / 输出解析 / 控制流；只放宽捕获缓冲上限。
- 跨平台无关（纯 Node child_process 选项）。
- 两处都是 jlist 读取路径，其它 `runPm2`（stdio inherit，不缓冲）不受影响、无需改。

## 验证
- **复现**：默认 maxBuffer 跑 `pm2 jlist`（1.6 MB）→ ENOBUFS；加 64 MiB → 正常读全量。
- **修后**（生产 box 实测）：`node dist/cli.js start-bot <卡住的 appId> --json` → `{"ok":true,"state":"started","processName":"botmux-45"}`，该 bot 真正上线（pm2 online, pid 存在）。
- `pnpm build` 绿；`bot-live-control` / `plugin-pm2-env` / `pm2-command` **15/15** 全过。

🤖 与 PR #629 无关，独立修复。
