### PR TITLE
fix(hermes): 冷启动首条消息不再白等 45s ready-gate

### DIFF
--- a/src/adapters/cli/hermes.ts
+++ b/src/adapters/cli/hermes.ts
@@ -61,12 +61,25 @@ export function createHermesAdapter(pathOverride?: string): CliAdapter {
     readyPattern: /❯/,
     completionPattern: undefined,
     systemHints: BOTMUX_SHELL_HINTS,
-    // Hermes emits an explicit BOTMUX_READY_COMMAND once prompt_toolkit's real
-    // input composer has rendered.  Arm Botmux's ready-gate so the first queued
-    // Lark prompt waits for that true-ready signal instead of relying on the
-    // screen-level ❯ marker alone.  Do not opt into type-ahead: before the first
-    // prompt Hermes can silently drop input typed during TUI initialization.
-    injectsReadyHook: true,
+    // Do NOT arm Botmux's ready-gate for Hermes. #353 set injectsReadyHook here
+    // on the premise that Hermes shell-executes BOTMUX_READY_COMMAND once its
+    // prompt_toolkit composer renders — a cross-repo contract the shipped Hermes
+    // never honored: `grep BOTMUX_READY_COMMAND` across hermes-agent 0.18.x is
+    // empty, and Hermes exposes no composer-ready hook at all (its shell-hooks
+    // fire only at turn boundaries — on_session_start emits from
+    // conversation_loop AFTER the first prompt is already submitted, too late to
+    // gate the first prompt on). So the signal never arrives and the gate always
+    // falls through its 45s READY_SIGNAL_TIMEOUT_MS, delaying the FIRST cold-start
+    // message by ~45s even though the real ❯ composer is up in ~3.6s.
+    //
+    // Empirically the ❯ readyPattern above IS the earliest reliable readiness
+    // signal: a PTY probe of the real binary shows the fully-chromed input box
+    // (border + status bar + "/help for commands") at ~3.6s, and Hermes has NO
+    // cjadk-style startup selector that would make ❯ a false positive. So we rely
+    // on the IdleDetector's ❯ match + deferFirstPromptTimeoutUntilReady (queue
+    // the first message until the real ❯ appears, 90s hard cap). Do NOT opt into
+    // type-ahead: before the first prompt Hermes can silently drop input typed
+    // during TUI initialization (see #342).
     deferFirstPromptTimeoutUntilReady: true,
     altScreen: false,
   };

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1301,13 +1301,15 @@ let isSettlingFirstFlush = false;
  *  later markPromptReady call would return early with the first prompt stranded. */
 let promptReadyDetectedDuringSettle = false;
 /** While the ready-gate is holding, the IdleDetector may still fire on a real
- *  readyPattern (e.g. Hermes's ❯) — proving the input box exists — but
+ *  readyPattern (e.g. grok's ❯) — proving the input box exists — but
  *  markPromptReady() returns early because the gate is armed. Record that the
  *  pattern was seen so the gate's timeout-fallback settle can mark the prompt
  *  ready immediately instead of delivering into a !isPromptReady state that
- *  flushPending() rejects for non-type-ahead adapters. Without this, a Hermes
- *  spawn that renders ❯ but never fires BOTMUX_READY_COMMAND waits the full
- *  hard timeout (and previously never delivered at all). */
+ *  flushPending() rejects for non-type-ahead adapters. Without this, a ready-
+ *  gated spawn that renders ❯ but never fires its SessionStart signal waits the
+ *  full hard timeout (and previously never delivered at all). (Hermes used to be
+ *  the example here; it no longer arms the gate — see hermes.ts — because the
+ *  shipped binary never emitted BOTMUX_READY_COMMAND.) */
 let readyPatternSeenDuringHold = false;
 /** Claude's SessionStart hooks run in parallel. Its botmux hook proves the
  * startup selector is behind us, but sibling project hooks may still be
@@ -8209,7 +8211,11 @@ async function spawnCli(
   lastPtyOutputAtMs = Date.now();
   const readyHookAvailable = effectiveReadyHookInstall
     ? hasInstalledSessionReadyHook(effectiveReadyHookInstall)
-    : true; // Hermes emits BOTMUX_READY_COMMAND directly instead of a config hook.
+    : true; // No config-file hook to verify → assume a direct ready-command
+            // integration (env-injected BOTMUX_READY_COMMAND). No current adapter
+            // takes this branch: claude-code and grok both ship a hookInstall
+            // config. (Hermes formerly did, on a BOTMUX_READY_COMMAND contract the
+            // shipped binary never honored — it no longer sets injectsReadyHook.)
   const isolatedReadyTransportRequired = sandboxRequested || credentialBoundaryActive;
   const readyPortAvailable = !isolatedReadyTransportRequired
     || parseDaemonIpcPort(childEnv.BOTMUX_DAEMON_IPC_PORT) !== undefined;

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -1060,8 +1060,15 @@ describe('hermes buildArgs', () => {
     expect(adapter.passesInitialPromptViaArgs).toBeFalsy();
   });
 
-  it('uses explicit ready signal gate without type-ahead', () => {
-    expect(adapter.injectsReadyHook).toBe(true);
+  it('relies on ❯ readyPattern without ready-gate or type-ahead', () => {
+    // #353 armed the ready-gate via injectsReadyHook on the premise that Hermes
+    // shell-executes BOTMUX_READY_COMMAND at composer-ready. The shipped Hermes
+    // never honored that contract (no composer-ready hook exists), so the gate
+    // always fell through its 45s timeout, delaying the first cold-start message.
+    // Hermes must NOT arm the gate; its ❯ readyPattern (input box up in ~3.6s) is
+    // the earliest reliable readiness signal.
+    expect(adapter.injectsReadyHook).toBeFalsy();
+    expect(adapter.readyPattern?.source).toBe('❯');
     expect(adapter.deferFirstPromptTimeoutUntilReady).toBe(true);
     expect(adapter.supportsTypeAhead).toBeFalsy();
   });

--- a/test/tmux-backend-env.test.ts
+++ b/test/tmux-backend-env.test.ts
@@ -123,7 +123,7 @@ describe('buildBotmuxEnvAssignments()', () => {
     expect(out).not.toContain('PATH=/usr/bin');
   });
 
-  it('forwards BOTMUX_READY_COMMAND so Hermes can release the first-prompt ready gate', () => {
+  it('forwards BOTMUX_READY_COMMAND so ready-hook CLIs can release the first-prompt ready gate', () => {
     const out = buildBotmuxEnvAssignments({
       BOTMUX: '1',
       BOTMUX_READY_COMMAND: '"/usr/local/bin/node" "/opt/botmux/dist/cli.js" session-ready',

--- a/test/worker-pipe-initial-screen-order.test.ts
+++ b/test/worker-pipe-initial-screen-order.test.ts
@@ -174,10 +174,13 @@ describe('worker pipe initial screen ordering', () => {
   });
 
   it('forces the first prompt for non-type-ahead adapters at the hard timeout', () => {
-    // THE HERMES FIX (hard-timeout path): previously the hard cap only logged
-    // "forcing queued message flush" and flushed for type-ahead adapters only;
-    // non-type-ahead adapters (Hermes) never delivered. The release must now
-    // route non-type-ahead adapters to markPromptReady() (which then flushes).
+    // Hard-timeout path (originally "THE HERMES FIX"): previously the hard cap
+    // only logged "forcing queued message flush" and flushed for type-ahead
+    // adapters only; non-type-ahead adapters never delivered. The release must
+    // now route non-type-ahead adapters to markPromptReady() (which then
+    // flushes). (Hermes drove this originally; it no longer arms the gate — see
+    // hermes.ts — but the mechanism still guards any non-type-ahead ready-gated
+    // adapter.)
     const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
     const fallbackStart = source.indexOf('const releaseFirstPromptTimeout =');
     const decideIdx = source.indexOf("decideHardTimeoutAction(cliAdapter?.supportsTypeAhead === true)", fallbackStart);
@@ -194,13 +197,14 @@ describe('worker pipe initial screen ordering', () => {
 
   it('honors a true ready signal that arrives AFTER the timeout fallback (slow cold start)', () => {
     // ReadyGate.receive() is one-shot: once the 45s fallback fires, a later
-    // releaseReadyGate from the real signal is skipped entirely. A CLI whose
-    // cold start exceeds READY_SIGNAL_TIMEOUT_MS (Hermes: 2-3 min) would then
-    // never take the authoritative markPromptReady path. The session_ready case
-    // must detect the late arrival (gate armed + already received) and mark
-    // prompt-ready directly for authoritative non-Claude signals. Claude waits
-    // for post-hook prompt evidence instead. Both paths are limited to the
-    // first-prompt phase, so clear/compact SessionStart stays a no-op.
+    // releaseReadyGate from the real signal is skipped entirely. A ready-gated
+    // CLI whose cold start exceeds READY_SIGNAL_TIMEOUT_MS would then never take
+    // the authoritative markPromptReady path. The session_ready case must detect
+    // the late arrival (gate armed + already received) and mark prompt-ready
+    // directly for authoritative non-Claude signals. Claude waits for post-hook
+    // prompt evidence instead. Both paths are limited to the first-prompt phase,
+    // so clear/compact SessionStart stays a no-op. (Hermes drove this originally
+    // via its 2-3 min cold start; it no longer arms the gate — see hermes.ts.)
     const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
     const sessionReadyCase = source.indexOf("case 'session_ready'");
     const lateCheckIdx = source.indexOf('readyGate.isArmed && readyGate.isReceived', sessionReadyCase);


### PR DESCRIPTION
## 问题

Hermes 冷启动**首条消息延迟 ≈45s**。

## 根因

PR #353 给 hermes 适配器设了 `injectsReadyHook: true`,前提假设是「Hermes 会在 prompt_toolkit composer 渲染后 shell 执行 `BOTMUX_READY_COMMAND`」——这是一个跨仓库契约,当时注释写「由作者侧 Hermes 实现保证」。

**但线上 Hermes Agent v0.18.2 里 `BOTMUX_READY_COMMAND` 出现 0 次**,契约从未被兑现,`session-ready` 信号永远不会发出。于是:

- worker spawn 时 `readyGate.arm()` 扣住首条 prompt,等 `session_ready` IPC;
- 等不到 → 只能靠 `READY_SIGNAL_TIMEOUT_MS`(45s)的 fallback 才放行;
- 而真实 `❯` 输入框其实 ~3.6s 就已经出现了。

**线上日志实证**(修复前,fresh 会话):
```
08:49:39.962  Spawning fresh CLI: hermes ...
08:49:39.962  Ready gate armed — holding first prompt until SessionStart ready signal
08:49:46.344  Prompt detected (idle)          ← 真 ❯ 已出现(~6s)但被扣住
08:49:46.371  Idle detected but holding for SessionStart ready signal (startup selector guard)
08:50:24.963  Ready gate released (signal timeout fallback)   ← spawn + 正好 45s
08:50:24.963  Hermes is ready for input
```
全程**没有** `SessionStart ready signal received`——信号根本没来过。

## 为什么不用 Hermes 的原生 hook?

深挖 Hermes v0.18.2 源码确认:**它没有任何 composer-ready hook 可用**。

- Hermes 确有 shell-hooks 系统(`--accept-hooks`,botmux 已在传),支持 `on_session_start` / `pre/post_tool_call` / `pre/post_llm_call` 等 20+ 回合级事件。
- 但**没有 TUI-composer-ready 事件**。最接近的 `on_session_start` 的实际 emit 点在 `agent/conversation_loop.py`——首个回合开始处理、build system prompt 时才 fire,即**用户已经把首条 prompt 提交进去之后**。用它当 ready-gate 门控是鸡生蛋(gate 需要在投递首条 prompt 之前拿到信号)。
- 所有 `invoke_hook` 调用点(turn_finalizer / conversation_loop / turn_context)都在回合边界,无一在首次输入前 fire。
- `--pass-session-id` 只把 id 塞进 system prompt,不提前写 DB;`sessions` 表落行也在首回合 → poll DB 同样太晚。

**∴ 屏幕上的 `❯` 输入框恰恰就是 Hermes 最早/最可靠的启动成功信号。** PTY 探针实测真实二进制:带完整边框 + 状态栏(`es1_orange_o48 | ctx | YOLO`)+ `/help for commands` 的真输入框 **3.64s 就出现**,且 Hermes **没有 cjadk 式的启动选择器**会让 `❯` 误命中。

## 改动

hermes 适配器去掉 `injectsReadyHook`,回到 `❯` readyPattern 检测路径:
- 保留 `deferFirstPromptTimeoutUntilReady`:首条消息排队至真 `❯` 出现才投递,90s 硬顶兜底;
- **不**开 type-ahead:#342 担心的「打进未就绪 TUI 静默吞消息」风险仍被挡住;
- 不再武装 ready-gate → 无 45s 死等。

## 影响面评估

- **只动 hermes 单个适配器** + 相关陈旧注释;**不改 worker 共用逻辑**(`worker.ts` diff 纯注释)。
- 另两个 `injectsReadyHook: true` 的适配器不受影响:
  - `claude-code` — 有真 SessionStart hook(`hookInstall` 写 settings.json);
  - `grok` — 有真 `grok-hooks` 配置(`hookInstall` 写 `botmux-session-ready.json`)。
  - 二者都走 `hookInstall` 配置校验分支,不走 Hermes 那条「无 hookInstall、靠 env 契约」的分支。
- `BOTMUX_READY_COMMAND` env 透传机制(`child-env` 白名单 + tmux 后端)**保留**,claude-code / grok 仍在用。

## 测试验证

**`pnpm build`** 绿。

**单测**(376 passed):
```
npx vitest run test/cli-adapters.test.ts test/worker-pipe-initial-screen-order.test.ts test/tmux-backend-env.test.ts
→ Test Files 3 passed (3) | Tests 376 passed (376)
```
- 更新 hermes 断言:`injectsReadyHook` falsy + `readyPattern.source === '❯'`;
- grok 的 `injectsReadyHook: true` 断言**不变**(验证未误伤)。

**线上冷启动实测**(bot idx44,`pnpm switch:here && pnpm daemon:restart` 后 `tmux kill-session` 强制 fresh spawn):
```
10:46:41.096  Spawning fresh CLI: hermes --resume ... --yolo --accept-hooks --pass-session-id
10:46:49.321  Prompt detected (idle)
10:46:49.348  Hermes is ready for input
```
**spawn → ready = ~8.2s**,全程**无** `Ready gate armed` / `holding for SessionStart` / `signal timeout fallback`。

对比:
| | 修复前 | 修复后 |
|---|---|---|
| 冷启动 spawn → ready | **45.0s**(定时器 fallback) | **~8.2s**(❯ 检测) |

45s 死等被彻底消除。