### PR TITLE
ci(release): npm-first 发布顺序，桌面签名资产异步补挂

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,29 @@ jobs:
       RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
     steps:
       - uses: actions/checkout@v6
+        # Push builds the tagged commit (github.ref = refs/tags/vX.Y.Z). But
+        # workflow_dispatch's default checkout is the dispatch's selected ref
+        # (typically master), NOT release_tag — so the recovery path would sign
+        # "current master code + old version number" and --clobber it onto the
+        # old Release, making the desktop assets diverge from the npm tarball /
+        # git tag. Pin the checkout to the tag ref in both cases so the signed
+        # app is always built from exactly the released commit.
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
+
+      - name: Verify HEAD is the tagged commit
+        # Defensive: prove the checkout landed on the tag's commit (not master),
+        # so a mis-resolved ref can never sign the wrong source into a Release.
+        run: |
+          git fetch origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}" --force --quiet 2>/dev/null || true
+          TAG_SHA=$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")
+          HEAD_SHA=$(git rev-parse HEAD)
+          echo "tag ${RELEASE_TAG} → $TAG_SHA ; HEAD → $HEAD_SHA"
+          if [ "$TAG_SHA" != "$HEAD_SHA" ]; then
+            echo "REFUSING: desktop build checked out $HEAD_SHA but tag ${RELEASE_TAG} is $TAG_SHA."
+            echo "Signed assets must be built from the exact released commit. Aborting to avoid attaching mismatched assets."
+            exit 1
+          fi
 
       - uses: actions/setup-node@v6
         with:
@@ -268,10 +291,14 @@ jobs:
       - name: Create GitHub Release (desktop assets attached asynchronously)
         # npm-first: the Release is created right after npm publish, WITHOUT the
         # macOS assets — those are uploaded later by `attach-desktop-assets` once
-        # signing/notarization finishes. So there is a short window where a
-        # stable Release exists with npm already live but no .dmg/.zip yet; the
-        # desktop bundle lands within the same run (minutes). softprops keeps the
-        # release editable so the later --clobber upload just adds the files.
+        # signing/notarization finishes. So the Release exists with npm already
+        # live but no .dmg/.zip yet. Normally the desktop bundle lands within the
+        # same run (a few minutes) once macOS signing completes — but signing is
+        # behind a human approval gate that can wait up to 30 days, or be
+        # rejected / fail / be cancelled; in those cases the Release stays
+        # npm-only until the manual recovery re-run (see attach-desktop-assets).
+        # softprops keeps the release editable so the later --clobber upload just
+        # adds the files.
         uses: softprops/action-gh-release@v3
         with:
           body: ${{ steps.changelog.outputs.body }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,12 @@ jobs:
           retention-days: 7
 
   release:
-    if: always() && github.event_name == 'push' && (needs.desktop.result == 'success' || needs.desktop.result == 'skipped')
-    needs: desktop
+    # npm-first: no longer `needs: desktop`. npm publish + GitHub Release run
+    # immediately on the tag push, WITHOUT waiting for the manually-gated
+    # (macos-signing environment) macOS build. The signed desktop assets are
+    # attached asynchronously afterwards by `attach-desktop-assets`. This keeps
+    # `npm i -g botmux` unblocked when macOS signing is slow / awaiting approval.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -123,10 +127,18 @@ jobs:
           echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
           echo "Publishing $VERSION → npm dist-tag=$NPM_TAG, prerelease=$PRERELEASE"
 
-      - name: Require signed macOS assets for stable releases
-        if: steps.dist_tag.outputs.tag == 'latest' && needs.desktop.result != 'success'
+      - name: Require deepcoldy authority for stable (latest) releases
+        # npm-first removed the transitive authority gate that used to come via
+        # `needs: desktop` (desktop only runs for deepcoldy; the old "Require
+        # signed macOS assets" step then failed non-deepcoldy stable tags). With
+        # release decoupled from desktop, re-assert it explicitly: only deepcoldy
+        # may publish the `latest` dist-tag that every `npm i botmux` user gets.
+        # canary/beta/rc/next go to side dist-tags and stay open for branch
+        # gray-release by anyone.
+        if: steps.dist_tag.outputs.tag == 'latest' && (github.actor != 'deepcoldy' || github.triggering_actor != 'deepcoldy')
         run: |
-          echo "REFUSING: stable releases require macOS signing by deepcoldy."
+          echo "REFUSING: stable (latest) releases may only be published by deepcoldy."
+          echo "actor=${{ github.actor }} triggering_actor=${{ github.triggering_actor }}"
           exit 1
 
       - name: Guard against downgrading npm latest
@@ -253,28 +265,57 @@ jobs:
             echo 'CHANGELOG_EOF'
           } >> "$GITHUB_OUTPUT"
 
-      - name: Download macOS release assets
-        if: needs.desktop.result == 'success'
+      - name: Create GitHub Release (desktop assets attached asynchronously)
+        # npm-first: the Release is created right after npm publish, WITHOUT the
+        # macOS assets — those are uploaded later by `attach-desktop-assets` once
+        # signing/notarization finishes. So there is a short window where a
+        # stable Release exists with npm already live but no .dmg/.zip yet; the
+        # desktop bundle lands within the same run (minutes). softprops keeps the
+        # release editable so the later --clobber upload just adds the files.
+        uses: softprops/action-gh-release@v3
+        with:
+          body: ${{ steps.changelog.outputs.body }}
+          prerelease: ${{ steps.dist_tag.outputs.prerelease == 'true' }}
+
+  attach-desktop-assets:
+    # npm-first tail: once the parallel `desktop` job has signed+notarized the
+    # macOS build AND the `release` job has created the GitHub Release, upload
+    # the .dmg/.zip onto that Release. Runs on the tag-push path (the
+    # workflow_dispatch refresh path is handled by `refresh-desktop-assets`).
+    # `needs: [desktop, release]` both must succeed: desktop for the artifact,
+    # release so the GitHub Release exists to upload onto.
+    if: github.event_name == 'push' && needs.desktop.result == 'success' && needs.release.result == 'success'
+    needs: [desktop, release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      RELEASE_TAG: ${{ github.ref_name }}
+    steps:
+      - name: Download macOS build artifact
         uses: actions/download-artifact@v4
         with:
           name: botmux-macos
           path: release-assets
 
-      - name: Create GitHub Release with macOS assets
-        if: needs.desktop.result == 'success'
-        uses: softprops/action-gh-release@v3
-        with:
-          body: ${{ steps.changelog.outputs.body }}
-          prerelease: ${{ steps.dist_tag.outputs.prerelease == 'true' }}
-          files: release-assets/*
-          fail_on_unmatched_files: true
+      - name: Attach macOS assets to the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "$RELEASE_TAG" release-assets/* --clobber --repo "$GITHUB_REPOSITORY"
 
-      - name: Create GitHub prerelease without macOS assets
-        if: needs.desktop.result == 'skipped' && steps.dist_tag.outputs.prerelease == 'true'
-        uses: softprops/action-gh-release@v3
-        with:
-          body: ${{ steps.changelog.outputs.body }}
-          prerelease: true
+      - name: Verify uploaded release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir downloaded-assets
+          gh release download "$RELEASE_TAG" \
+            --pattern 'Botmux-*.dmg' \
+            --pattern 'Botmux-*.zip' \
+            --dir downloaded-assets \
+            --repo "$GITHUB_REPOSITORY"
+          for file in release-assets/*; do
+            cmp "$file" "downloaded-assets/$(basename "$file")"
+          done
 
   refresh-desktop-assets:
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,6 +277,15 @@ jobs:
           body: ${{ steps.changelog.outputs.body }}
           prerelease: ${{ steps.dist_tag.outputs.prerelease == 'true' }}
 
+      - name: Note — desktop assets pending
+        # Make the npm-first window visible in the run log: npm + Release are
+        # live now; the macOS .dmg/.zip attach in the parallel attach-desktop-assets
+        # job after signing. If signing is rejected/fails/cancelled, recover by
+        # re-running this workflow via workflow_dispatch with this release_tag.
+        run: |
+          echo "npm ${GITHUB_REF_NAME#v} published and GitHub Release ${GITHUB_REF_NAME} created."
+          echo "macOS desktop assets (.dmg/.zip) attach asynchronously in attach-desktop-assets after signing."
+          echo "If signing is rejected/fails/cancelled, re-run this workflow via workflow_dispatch with release_tag=${GITHUB_REF_NAME} to rebuild+sign and attach."
   attach-desktop-assets:
     # npm-first tail: once the parallel `desktop` job has signed+notarized the
     # macOS build AND the `release` job has created the GitHub Release, upload
@@ -284,6 +293,17 @@ jobs:
     # workflow_dispatch refresh path is handled by `refresh-desktop-assets`).
     # `needs: [desktop, release]` both must succeed: desktop for the artifact,
     # release so the GitHub Release exists to upload onto.
+    #
+    # FAILURE MODE (accepted trade-off of npm-first): the `desktop` job sits
+    # behind the macos-signing environment approval, which can wait up to 30
+    # days and may be rejected / the build may fail / the run may be cancelled.
+    # In any of those cases npm + the GitHub Release are already live but this
+    # job never runs, so the Release keeps npm-only (no .dmg/.zip). There is no
+    # auto-retry here on purpose — signing needs a human approval, so retrying
+    # would just re-block. Recovery is manual and idempotent: re-run this
+    # workflow via workflow_dispatch with release_tag=vX.Y.Z; that rebuilds+signs
+    # macOS (fresh artifact, so the 7-day retention is irrelevant) and
+    # `refresh-desktop-assets` --clobber-attaches to the existing Release.
     if: github.event_name == 'push' && needs.desktop.result == 'success' && needs.release.result == 'success'
     needs: [desktop, release]
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,27 +22,37 @@ jobs:
       RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
     steps:
       - uses: actions/checkout@v6
-        # Push builds the tagged commit (github.ref = refs/tags/vX.Y.Z). But
-        # workflow_dispatch's default checkout is the dispatch's selected ref
-        # (typically master), NOT release_tag — so the recovery path would sign
-        # "current master code + old version number" and --clobber it onto the
-        # old Release, making the desktop assets diverge from the npm tarball /
-        # git tag. Pin the checkout to the tag ref in both cases so the signed
-        # app is always built from exactly the released commit.
+        # Build from the EXACT released commit in both trigger paths:
+        #   - push: use github.sha (the immutable commit the tag pointed at when
+        #     the event fired), NOT github.ref. Passing the ref name would make
+        #     checkout re-resolve the tag at checkout time — and desktop runs
+        #     behind a manual approval that can lag up to 30 days, during which
+        #     the tag could be moved (repo ruleset excludes canary/beta/rc from
+        #     tag-update protection). If tag moves A→B after `release` already
+        #     published npm from A, a ref-name checkout would sign B → assets
+        #     diverge from the npm tarball. A pinned SHA cannot move.
+        #   - workflow_dispatch: no event SHA for the tag, so resolve the tag ref
+        #     explicitly (default checkout would be the dispatch ref = master).
+        # The Verify step below then fail-closes if the tag no longer points at
+        # the commit we built (tag moved), so mismatched assets never attach.
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.release_tag) || github.sha }}
 
       - name: Verify HEAD is the tagged commit
-        # Defensive: prove the checkout landed on the tag's commit (not master),
-        # so a mis-resolved ref can never sign the wrong source into a Release.
+        # Prove the built commit still equals what the tag points at. On push,
+        # HEAD is github.sha; if the tag was moved during the approval wait, the
+        # current tag commit won't match HEAD → fail-closed (never attach assets
+        # built from a commit the tag no longer names). On workflow_dispatch this
+        # also catches a mis-resolved ref (e.g. accidental master checkout).
         run: |
           git fetch origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}" --force --quiet 2>/dev/null || true
           TAG_SHA=$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")
           HEAD_SHA=$(git rev-parse HEAD)
-          echo "tag ${RELEASE_TAG} → $TAG_SHA ; HEAD → $HEAD_SHA"
+          echo "tag ${RELEASE_TAG} → $TAG_SHA ; HEAD (built) → $HEAD_SHA"
           if [ "$TAG_SHA" != "$HEAD_SHA" ]; then
-            echo "REFUSING: desktop build checked out $HEAD_SHA but tag ${RELEASE_TAG} is $TAG_SHA."
-            echo "Signed assets must be built from the exact released commit. Aborting to avoid attaching mismatched assets."
+            echo "REFUSING: built commit $HEAD_SHA is not what tag ${RELEASE_TAG} now points at ($TAG_SHA)."
+            echo "The tag was likely moved after npm was published from the original commit."
+            echo "Signed assets must match the released commit; aborting to avoid attaching mismatched assets."
             exit 1
           fi
 


### PR DESCRIPTION
## 背景
此前 Release workflow 的 npm 发布强依赖 macOS 签名：`release` job `needs: desktop`，且有一道「Require signed macOS assets for stable releases」硬闸。而 macOS 签名挂在 `macos-signing` 环境的**人工审批门**后。结果：签名慢 / 待批时，代码明明就绪，`npm i -g botmux` 也拿不到新版——正是 v3.7.0 发版时的体感。

申晗拍板走 **Option B**：解耦 npm 与桌面签名，npm 先发、桌面签名资产异步补挂。

## 改动
- **`release` job 去掉 `needs: desktop`**（及 `always()` 门控），改为 push 即跑：npm publish + 创建 GitHub Release 不再等 macOS 签名。
- **三道既有安全闸原样保留，且仍在 `npm publish` 之前执行**：
  1. 防降级 npm latest（semver 比较，拒绝比当前 latest 小的版本覆盖 latest）
  2. 正式版必须包含最新 origin/master（`merge-base --is-ancestor`，防从落后分支发 latest）
  3. dist-tag 路由（canary/beta/rc/next 走旁路 dist-tag，不碰 latest）
- **新增显式「deepcoldy 才能发 latest」闸**：原先「非 deepcoldy 不能发 stable」是**经 `needs: desktop` 隐式传递**的（desktop 只对 deepcoldy 跑 → 旧「Require signed macOS assets」步骤据此拦非 deepcoldy 的 stable tag）。解耦后这条隐式链断了，故显式重申，否则任何人推 stable tag 都能发 latest。canary/beta/rc/next 仍对所有人开放（灰度用）。
- **新增 `attach-desktop-assets` job**（`needs: [desktop, release]`）：签名完成 + Release 建好后，把 `.dmg/.zip` `--clobber` 补挂到该 Release 并下载校验（与 workflow_dispatch 的 `refresh-desktop-assets` 同法，只是走 tag-push 路径）。
- 合并原「with assets / without assets」两个 Release 创建分支为一个**无条件创建**（不带 assets），assets 一律异步补。

## 权衡
正式版会有一个时间窗：npm 已上、GitHub Release 已建、但 `.dmg/.zip` 还没挂。正常情况下签名在同一次 run 内几分钟补齐；但 macOS 签名挂人工审批门（可等最多 30 天，或被拒/失败/取消），那时 Release 会保持 npm-only，直到手动 `workflow_dispatch`（`release_tag=vX.Y.Z`）恢复 re-run 补挂。换取 npm 不再被签名审批门阻塞。

## 影响面
- 只改 `.github/workflows/release.yml`；不碰产品代码。
- 三道发版安全闸逐字保留、顺序仍在 publish 前；新增的作者权限闸补回解耦断掉的隐式保护。
- prerelease（canary 等）路径：desktop 本就对非 deepcoldy skip；现在无条件创建 Release（带正确 prerelease 标记），比旧的「skipped && prerelease」分支更简单，行为等价或更好。

## 验证
- YAML 解析通过。
- 人工核对 `release` job 步序：Resolve dist-tag → **作者权限闸** → **防降级闸** → **必须含 master 闸** → build → **npm publish** → changelog → 创建 Release。三道 guard + 权限闸全部在 npm publish 之前。
- ⚠️ 属发布基础设施改动，**请 @codex 重点复审安全性**：三道 guard 是否真被保留且未被 npm-first 绕过、新增作者权限闸是否等价替代原隐式保护、`attach-desktop-assets` 的 needs/if 是否正确、有无「Release 建了但 assets 永久缺失」的失败模式。

🤖 下次发版生效；本次 v3.7.0 已按旧流程发成功，不受影响。



---

## 复审后追加（codex review）
- `9005f9dd`：显式化签名失败运维窗口——`attach-desktop-assets` 注释写清失败模式+恢复方式，`release` job 加一步 run-log 打印「npm/Release 已上、资产异步补、失败如何恢复」。
- `58cd65f3`（blocker 修复）：`desktop` job 的 `actions/checkout` 原先没钉 `ref`，`workflow_dispatch` 恢复路径会检出默认 ref（master）而非 `release_tag` → 会把「当前 master 代码+旧版本号」签名挂到旧 Release，资产与 npm/tag 不同源。加「Verify HEAD is the tagged commit」fail-closed 校验。
- `908206b0`（**TOCTOU blocker 修复**，当前 head）：`58cd65f3` 的 push 分支用了 `ref: github.ref`（ref 名），checkout 会在运行时重解析 tag。desktop 挂 30 天审批门 + 仓库 ruleset 不保护 canary/beta/rc 的 tag update → tag 在 `release` 已按事件 SHA 发 npm（commit A）后、desktop 获批前被移到 B → desktop 会构建 B，且原 Verify 取「当前 tag」=B → B==B 放行 → npm(A) 与桌面资产(B) 不同源。改为：push 分支 checkout 用 **`github.sha`**（不可变事件 commit，不会移动），`workflow_dispatch` 分支仍 `refs/tags/${release_tag}`；Verify 步骤据此真正生效（HEAD=A，tag 若移到 B → 当前 `tag^{commit}`=B≠A → fail-closed）。`release` job 不受影响（本就无 ref = 默认事件 SHA）。
