### PR TITLE
fix(dashboard): 平台绑定时自动初始化面板 token

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -15,7 +15,8 @@ import { config } from './config.js';
 import { listenWithProbe } from './utils/listen-with-probe.js';
 import {
   generateToken, parseCookie, buildSetCookie, verifyHmac, cliAuthBind, decideDashboardAuth,
-  loadPersistedToken, persistToken, loadDashboardSecret, loadOrCreateDashboardSecret,
+  loadPersistedToken, loadOrCreatePersistedToken, persistToken,
+  loadDashboardSecret, loadOrCreateDashboardSecret,
 } from './dashboard/auth.js';
 import { DaemonRegistry, botsRosterSignature } from './dashboard/registry.js';
 import { Aggregator, subscribeDaemon } from './dashboard/aggregator.js';
@@ -232,8 +233,9 @@ function loadOrCreateSecret(): string {
 }
 
 // The active dashboard token is persisted to disk so a previously-issued
-// dashboard URL survives `botmux restart`; only `botmux dashboard` (the
-// /__cli/rotate endpoint) rotates it and thereby invalidates the old link.
+// dashboard URL survives `botmux restart`. A platform-bound dashboard creates
+// the first token on startup; only `botmux dashboard` (the /__cli/rotate
+// endpoint) replaces it and thereby invalidates the old link.
 // The start/restart hint reads it via the non-rotating /__cli/current endpoint
 // so it can show the live link without invalidating it.
 let activeToken: string | null = loadPersistedToken(TOKEN_PATH);
@@ -5189,6 +5191,10 @@ function startPlatformTunnelIfBound(): void {
   try {
     const binding = readPlatformBinding();
     if (!binding) return;
+    if (!activeToken) {
+      activeToken = loadOrCreatePersistedToken(TOKEN_PATH);
+      logger.info('[platform-tunnel] 已初始化 dashboard token');
+    }
     const version = readBotmuxVersion();
     platformTunnel = startPlatformTunnelClient({
       binding,

--- a/src/dashboard/auth.ts
+++ b/src/dashboard/auth.ts
@@ -172,6 +172,15 @@ export function persistToken(tokenPath: string, token: string): void {
   chmodSync(tokenPath, 0o600);
 }
 
+/** Load the active token, creating and persisting the first one when absent. */
+export function loadOrCreatePersistedToken(tokenPath: string): string {
+  const existing = loadPersistedToken(tokenPath);
+  if (existing) return existing;
+  const token = generateToken();
+  persistToken(tokenPath, token);
+  return token;
+}
+
 /** Extract `botmux_dashboard_token` value from a Cookie header. */
 export function parseCookie(header: string | undefined): string | undefined {
   if (!header) return undefined;

--- a/test/dashboard-auth.test.ts
+++ b/test/dashboard-auth.test.ts
@@ -9,7 +9,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   verifyHmac, generateToken, parseCookie, decideDashboardAuth,
-  loadPersistedToken, persistToken, loadDashboardSecret, loadOrCreateDashboardSecret,
+  loadPersistedToken, loadOrCreatePersistedToken, persistToken,
+  loadDashboardSecret, loadOrCreateDashboardSecret,
 } from '../src/dashboard/auth.js';
 
 const SECRET = 'a'.repeat(43); // base64url 32 bytes
@@ -81,6 +82,19 @@ describe('token persistence (survives restart, rotates only on `botmux dashboard
     const tok = generateToken();
     persistToken(tokenPath, tok);
     expect(loadPersistedToken(tokenPath)).toBe(tok);
+  });
+
+  it('loadOrCreatePersistedToken creates and persists a missing token', () => {
+    const tok = loadOrCreatePersistedToken(tokenPath);
+    expect(tok).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(loadPersistedToken(tokenPath)).toBe(tok);
+    expect(statSync(tokenPath).mode & 0o777).toBe(0o600);
+  });
+
+  it('loadOrCreatePersistedToken reuses an existing token without rotating it', () => {
+    persistToken(tokenPath, 'existing-token');
+    expect(loadOrCreatePersistedToken(tokenPath)).toBe('existing-token');
+    expect(loadPersistedToken(tokenPath)).toBe('existing-token');
   });
 
   it('persisted token survives a simulated restart (same file, new process)', () => {


### PR DESCRIPTION
## 背景

平台已绑定但本机尚未生成 `~/.botmux/.dashboard-token` 时，平台隧道会注册空 token。此后 Dashboard 的一键升级请求会在进入 npm 更新逻辑前被鉴权拦截，用户只能先手动启动一次 `botmux dashboard` 来初始化 token。

## 改动

- 平台绑定存在且 token 缺失时，在启动平台隧道前生成并持久化初始 token
- 已有 token 继续复用，不发生轮换
- 未绑定平台的机器保持原行为，不主动创建 token
- `/__cli/current` 仍为只读探针，`/api/update/*` 鉴权规则不变

## 验证

- `pnpm exec vitest run test/dashboard-auth.test.ts --project unit`：55 passed
- `pnpm exec vitest run --project unit`：722 files passed，1 file skipped；11094 tests passed，6 skipped
- `pnpm build`：通过
- `git diff --check`：通过

无 UI 改动，无需截图。
