### PR TITLE
fix(lark): 私聊 chat 模式下话题内回复不再漏到 DM 顶层

### DIFF
--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -2465,6 +2465,15 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
       };
       let routingSource = decision.source;
       let replyRootId: string | undefined;
+      // 私聊 chat 模式：会话是扁平连续的(整段 DM 一个 chat-scope 会话),但如果这条
+      // 消息本身是在某个已存在的话题里回复的(root_id+thread_id),可见回复必须落回
+      // 那个话题里,而不是漏到 DM 顶层。decideRouting 已把 scope 折成 chat(会话扁平
+      // 语义不变),这里只补 replyRootId 让 sendReply 用 reply_in_thread 锚回话题根。
+      // 群聊侧的同类保留由 maybeFold / alias 分支处理(它们 gate chatType==='group',
+      // 私聊走不到),故私聊必须在此单独补。仅 p2p:群顶层消息不该被强行塞进话题。
+      if (routing.scope === 'chat' && chatType === 'p2p' && message.root_id && message.thread_id) {
+        replyRootId = message.root_id;
+      }
       const explicitlyMentionedThisBot = isBotMentioned(larkAppId, message, senderOpenId);
       // Cheap in-memory gate FIRST: skip the getChatMode roundtrip and the
       // per-chat toggle disk read entirely for bots that never configured a

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -4307,6 +4307,80 @@ describe('im.message.receive_v1 — regular group thread replies preference', ()
   });
 });
 
+describe('im.message.receive_v1 — p2p chat-mode topic reply anchoring', () => {
+  let handlers: ReturnType<typeof makeHandlers>;
+
+  beforeEach(() => {
+    capturedHandlers = {};
+    setupBotState({ p2pMode: 'chat', allowedUsers: [USER_OPEN_ID] });
+    handlers = makeHandlers();
+    mockFindOncallChat.mockReturnValue(undefined);
+    mockGetChatMode.mockResolvedValue('p2p');
+    startLarkEventDispatcher(MY_APP_ID, 'secret', handlers);
+  });
+
+  it('a DM reply inside an existing topic stays chat-scope but anchors the visible reply back to the topic root (no leak to DM top level)', async () => {
+    // Regression: p2pMode default flipped to 'chat' makes the whole DM one flat
+    // chat-scope session. A message that is itself a reply INSIDE a native topic
+    // (root_id + thread_id) must keep the session flat (chat-scope, anchored on
+    // chatId) BUT thread its visible reply under that topic root via replyRootId
+    // — otherwise the reply leaks to the DM top level. The group-side
+    // replyRootId preservation is gated chatType==='group', so p2p needs its own.
+    const reply = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'follow up inside this DM topic' }),
+      rootId: 'dm-topic-root',
+      threadId: 'omt_dm_topic',
+      messageId: 'msg-dm-in-topic',
+      chatId: 'oc_dm_chat',
+      chatType: 'p2p',
+    });
+    // Bot owns the flat DM chat-scope session (keyed on chatId).
+    handlers.isSessionOwner.mockImplementation((anchor: string) => anchor === 'oc_dm_chat');
+
+    await capturedHandlers['im.message.receive_v1'](reply);
+    await flushEventWork();
+
+    // Session stays flat chat-scope on the DM chatId...
+    // ...and the visible reply is anchored back to the topic root (replyRootId).
+    const call = handlers.handleThreadReply.mock.calls.find(c => c[0] === reply)
+      ?? handlers.handleNewTopic.mock.calls.find(c => c[0] === reply);
+    expect(call).toBeTruthy();
+    expect(call![1]).toEqual(expect.objectContaining({
+      scope: 'chat',
+      anchor: 'oc_dm_chat',
+      replyRootId: 'dm-topic-root',
+      larkAppId: MY_APP_ID,
+    }));
+  });
+
+  it('a top-level DM message (no thread) stays flat with no replyRootId', async () => {
+    // The fix must NOT invent a replyRootId for ordinary top-level DM messages —
+    // only real topic replies (root_id + thread_id) get the thread anchor.
+    const top = makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'plain DM message' }),
+      messageId: 'msg-dm-top',
+      chatId: 'oc_dm_chat2',
+      chatType: 'p2p',
+    });
+    handlers.isSessionOwner.mockReturnValue(false);
+
+    await capturedHandlers['im.message.receive_v1'](top);
+    await flushEventWork();
+
+    const call = handlers.handleNewTopic.mock.calls.find(c => c[0] === top)
+      ?? handlers.handleThreadReply.mock.calls.find(c => c[0] === top);
+    expect(call).toBeTruthy();
+    expect(call![1]).toEqual(expect.objectContaining({
+      scope: 'chat',
+      anchor: 'oc_dm_chat2',
+      larkAppId: MY_APP_ID,
+    }));
+    expect(call![1].replyRootId).toBeUndefined();
+  });
+});
+
 describe('im.message.receive_v1 — regular group reply mode (tri-state: chat | new-topic | shared)', () => {
   let handlers: ReturnType<typeof makeHandlers>;
 


### PR DESCRIPTION
## 概述

修复 #631 引入的回归:**私聊(1:1 DM)里在已存在话题内回复,可见回复漏到 DM 顶层**(而非留在话题里)。申晗实测发现并要求修复。

## 根因

#631 把私聊 `p2pMode` 默认从 `thread` 翻转为 `chat`(整段 DM 共用一个扁平连续会话)。`decideRoutingWithSource` 的 p2p chat 分支排在 `real-thread`(`root_id+thread_id`)判断**之前**——所以当用户在某个已存在话题里回复时:
- 会话**正确地**保持扁平 chat-scope(chat 语义要求如此);
- 但可见回复丢了话题锚点 → 漏到 DM 顶层。

关键:所有把可见回复 `replyRootId` 锚回话题根的逻辑(`maybeFoldMentionedRegularGroupThreadToChat` / alias 折叠分支)都 gate 了 `chatType === 'group'`,**私聊一条都走不到**。

实证(decideRouting 在话题内回复 root_id+thread_id):
- 改前(master 6dcca31b,DM 默认 thread):`{scope:thread, anchor:topic-root}` 留话题 ✅
- #631 后(DM 默认 chat):`{scope:chat, anchor:chatId}` 无 replyRootId → 漏顶层 ❌

## 修法

dispatch 层在 `routing.scope==='chat' && chatType==='p2p' && root_id && thread_id` 时,补 `replyRootId = root_id`。会话仍扁平连续(chat 语义不变),但可见回复经 `reply_in_thread` 落回那个话题里,不再漏顶层。**仅 p2p** —— 群顶层消息不该被强行塞进话题;群侧话题回复的锚点保留本就由 maybeFold/alias 处理(实测群 4 模式 × 拥有/未拥有话题会话全部正确保留锚点,不受本 PR 影响)。

## 影响面
- 仅 `im/lark/event-dispatcher.ts` 的 human dispatch 路径,+9 行,新增一个 p2p-only 条件。
- 不碰群路由、不碰 CLI 适配器/后端/worker。
- 群聊话题回复锚点保留逻辑完全不变(已实证)。

## 验证
- 新增 2 条 handler 级回归:①DM 话题内回复 → `{scope:chat, anchor:chatId, replyRootId:topic-root}`(会话扁平+回复锚回话题);②普通顶层 DM → 不虚构 replyRootId。
- `pnpm vitest run test/event-dispatcher.test.ts` → 248/248 ✅
- 命中面 4 文件(event-dispatcher / relay-target-routing / command-handler / reply-mode-command)→ 481/481 ✅
- `tsc --noEmit` ✅ / `pnpm build` ✅
