### PR TITLE
ci(release): 发版后给本版本 PR 自动留「Released in vX.Y.Z」评论

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # pull-requests: write —— 发版后给本版本包含的 PR 逐条留「Released in vX.Y.Z」
+      # 评论(见下方 Comment "Released in" 步骤)。GitHub 原生那个侧栏 released 徽标
+      # 判定用的是 PR 分支的原始 head commit,squash 合并会把它变成孤儿 commit → 徽标
+      # 永远不显示(即便 squash 出的新 commit 能从 tag 到达也不行)。此权限用于发一条
+      # 可见的时间线评论作为 squash 兼容的替代。
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -287,6 +293,13 @@ jobs:
           done
           SECTIONS=$(node .github/scripts/changelog-sections.mjs < "$RAW")
 
+          # 复用上面已算好的 PR 列表(不再多打一次 API),抽出本版本包含的**去重** PR
+          # 号,持久化到 $RUNNER_TEMP,交给后面的「Comment "Released in"」步骤逐个留言。
+          # 从 $RAW 里 type=='pr' 的行取第 2 列(PR number),排序去重。可能为空(纯直推
+          # commit、无关联 PR)——那样评论步骤自然什么都不做。
+          awk -F'\t' '$1=="pr"{print $2}' "$RAW" | sort -un > "$RUNNER_TEMP/released_prs.txt"
+          echo "PRs in this release: $(paste -sd' ' "$RUNNER_TEMP/released_prs.txt")"
+
           {
             echo 'body<<CHANGELOG_EOF'
             # TAG_MSG 后必须空一行再接自动段落：分隔线 '---' 紧贴正文末行会被 markdown
@@ -313,6 +326,53 @@ jobs:
         with:
           body: ${{ steps.changelog.outputs.body }}
           prerelease: ${{ steps.dist_tag.outputs.prerelease == 'true' }}
+
+      - name: Comment "Released in" on included PRs
+        # squash 兼容的「已发布」标记:GitHub 原生侧栏 released 徽标只认 PR 分支的原始
+        # head commit,squash 会把它变成孤儿 commit → 徽标永不显示。这里改为在本版本
+        # 包含的每个 PR 上留一条**可见、可点**的时间线评论作为等效替代。PR 列表来自上面
+        # changelog 步骤已算好的 released_prs.txt(不额外打 API 拉取)。
+        #
+        # 只在 stable(latest)发版时评论:canary/beta/rc/next 是分支灰度,常不从 master
+        # 出、也不是用户装到的正式版;若也评论,PR 会先被刷「Released in v3.7.0-canary.0」
+        # 再来一条「v3.7.0」,既噪又易误导。对齐原生徽标只关心正式 Release 的语义。
+        if: steps.dist_tag.outputs.tag == 'latest'
+        # 设计要点:
+        # - fail-soft:npm + Release 此时已经发布,评论失败绝不能让本 job 失败 →
+        #   continue-on-error + 每个 PR 内部 || true,单个 PR 评论失败不影响其它。
+        # - 幂等:workflow 重跑(如签名恢复 re-run)时不重复刷评论——先查该 PR 是否已
+        #   有带本版本隐藏标记 `<!-- released-in:vX.Y.Z -->` 的评论,有就跳过。
+        # - 只在有 PR 时动作;纯直推(released_prs.txt 为空)自然 no-op。
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          PR_FILE="$RUNNER_TEMP/released_prs.txt"
+          if [ ! -s "$PR_FILE" ]; then
+            echo "No PRs associated with this release; nothing to comment."
+            exit 0
+          fi
+          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}"
+          MARKER="<!-- released-in:${RELEASE_TAG} -->"
+          # 从 FD 3 读 PR 列表(而非 stdin),避免循环体内的 gh 子进程吃掉 stdin 里剩余的
+          # PR 行导致漏评论。
+          while read -r pr <&3; do
+            [ -n "$pr" ] || continue
+            # 幂等检查:该 PR 是否已有本版本的「已发布」评论
+            if gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" \
+                 --jq '.[].body' 2>/dev/null | grep -qF "$MARKER"; then
+              echo "PR #${pr}: already has released-in ${RELEASE_TAG} comment, skipping."
+              continue
+            fi
+            BODY="${MARKER}
+          🚀 Released in [**${RELEASE_TAG}**](${RELEASE_URL})"
+            if gh pr comment "$pr" --repo "$GITHUB_REPOSITORY" --body "$BODY" 2>/dev/null; then
+              echo "PR #${pr}: commented released-in ${RELEASE_TAG}."
+            else
+              echo "PR #${pr}: comment failed (non-fatal), continuing." >&2
+            fi
+          done 3< "$PR_FILE"
 
       - name: Note — desktop assets pending
         # Make the npm-first window visible in the run log: npm + Release are


### PR DESCRIPTION
## 背景 / 为什么

GitHub 原生侧栏那个「released in vX.Y.Z」徽标,判定用的是 **PR 分支的原始 head commit** 能否从 tag 回溯 —— 而 **squash 合并**会把 PR 压成一个全新 commit,原始 head commit 变成**孤儿**(即便 squash 出的新 commit 能从 tag 到达,GitHub 也不认)→ 用 squash 的 PR **永远不显示该徽标**。

实测 v3.7.1 佐证:
| PR | 合并方式 | 原生徽标 |
|---|---|---|
| #650 #631 | merge commit | ✅ 显示 |
| #645 #646 #629 | squash | ❌ 不显示 |

(release notes 里能提到 #645 等,是 CI 从 commit message 的 `(#N)` 文本抓的,与徽标是两套独立机制。)

申晗希望**保持 squash 的线性历史**,又能在 PR 上看到「进了哪个版本」。原生二者互斥,故用**发版后自动评论**作为 squash 兼容的等效替代。

## 改了什么

发版后给本版本包含的每个 PR 留一条**可见可点**的时间线评论:

> 🚀 Released in [**v3.7.1**](release 链接)

## 实现(复用现有机制,不新增 API 扫描)

- **PR 列表复用**:直接取 changelog 步骤**已算好**的 `$RAW`(`type==pr` 行)去重,写到 `released_prs.txt` 交给新步骤——**不再多打一次** `/commits/{sha}/pulls`
- **只在 stable(latest)评论**:`if: steps.dist_tag.outputs.tag == 'latest'`,与同 job 已有 3 处 guard 用法一致。canary/beta/rc/next 是灰度,若也评论会先刷 `-canary` 再刷正式版、既噪又误导,且对齐原生徽标只关心正式 Release 的语义
- **fail-soft**:npm + Release 此时**已发布**,评论失败绝不能让 job 失败 → `continue-on-error: true` + 单 PR 内部容错
- **幂等**:workflow 重跑(如签名恢复 re-run)不重复刷——靠隐藏标记 `<!-- released-in:vX.Y.Z -->` 先查后发
- **FD 3 读列表**:用 `while read <&3 … done 3< file` 而非 stdin,避免循环内 `gh` 子进程吃掉后续 PR 行导致漏评论
- 纯直推(列表为空)自然 no-op
- 新增 `pull-requests: write` 权限(原 job 仅 `contents: write`)

## 实际验证

- `python3 yaml.safe_load` 解析通过;`if` guard 与同 job 已有 3 处 `dist_tag == 'latest'` 用法一致
- **bash 端到端模拟**(mock gh):PR 抽取去重 ✅ / 幂等跳过已评论的 PR ✅ / FD3 隔离——即便 mock 的 `gh pr comment` 尝试读 stdin 也**无 LEAK**、不漏 PR:
  ```
  PR #629: commented.
  PR #645: already has comment, skipping (idempotent).
  PR #650: commented.
  ```
- 去重样例:`645` 出现两次(merge-commit 多子 commit 场景)→ 收敛为一条

## 影响面

- **纯改 `release.yml` 的 `release` job**,只在 **stable tag-push** 时多跑一步评论
- 不动 npm publish / Release 创建 / 桌面资产 / #651 的 dist-tag 回滚 workflow
- 不涉及运行时代码,无跨平台/CLI/后端影响

⚠️ 生效范围:合入后**下一个 stable 版本**起自动评论;历史 PR 不追溯(可后续手动补一次性脚本,若需要)。