### PR TITLE
feat(relay): 私密 ephemeral /relay 选择卡，隐藏会话元数据

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -2859,13 +2859,23 @@ export async function handleCommand(
           // The picker exposes session metadata — title + source-chat name — to
           // everyone who can see the message. When the bot runs in privateCard
           // mode we hide it: send the picker as an ephemeral card visible only to
-          // the invoker. Feishu ephemeral cards are sent per-user at group top-
-          // level and work in topic groups too (verified live in a 话题群) — they
-          // do NOT require chat-scope; the relay routing rides the button values
-          // regardless of where the picker renders. Gate on group + privateCard;
-          // p2p has no ephemeral option, and an unexpected reject (18053 etc.)
-          // falls back to the visible in-thread reply below.
+          // the invoker.
+          //
+          // Gate on group + privateCard + **chat-scope**. The chat-scope clause
+          // is load-bearing: the ephemeral API (`ephemeral/v1/send`) takes a
+          // `chat_id` only — it has NO thread/root anchor — so a thread-scope
+          // target (话题群 / 话题 inside a 普通群 / new-topic·shared) can't keep the
+          // card in its 话题. A 话题群 rejects with 18053 (→ fall back below), but
+          // a 话题 inside a 普通群 SUCCEEDS and the card escapes to the group top
+          // level. This is the same trap `deliverEphemeralOrReply` (worker-pool)
+          // guards against with a REGRESSION test; PR #164 was the original live
+          // fix. Per 申晗 (2026-07-29): 话题内公开可接受 — so thread-scope pickers
+          // stay on the visible in-thread reply (public card in the 话题), and
+          // ephemeral is scoped to flat 普通群 only, mirroring /card & /close
+          // private cards. p2p has no ephemeral option; an unexpected reject
+          // (18053 etc.) still falls back to the visible reply below.
           const privatePicker = targetChatType === 'group'
+            && targetScope === 'chat'
             && getBot(myAppId).config.privateCard === true;
           const card = buildRelayPickerCard(
             entries, targetChatId, targetAnchor, operatorOpenId, loc, undefined,

--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -2855,8 +2855,40 @@ export async function handleCommand(
           const { collectRelayPickerEntries } = await import('../services/relay-picker.js');
           const entries = await collectRelayPickerEntries(activeSessions, myAppId, targetAnchor, operatorOpenId);
           const { buildRelayPickerCard } = await import('../im/lark/card-builder.js');
-          const card = buildRelayPickerCard(entries, targetChatId, targetAnchor, operatorOpenId, loc, undefined, targetScope, targetChatType);
-          await replyAtInvocation(card, 'interactive');
+          // ── Ephemeral (仅邀请者可见) picker ────────────────────────────────
+          // The picker exposes session metadata — title + source-chat name — to
+          // everyone who can see the message. When the bot runs in privateCard
+          // mode we hide it: send the picker as an ephemeral card visible only to
+          // the invoker. Feishu ephemeral cards are sent per-user at group top-
+          // level and work in topic groups too (verified live in a 话题群) — they
+          // do NOT require chat-scope; the relay routing rides the button values
+          // regardless of where the picker renders. Gate on group + privateCard;
+          // p2p has no ephemeral option, and an unexpected reject (18053 etc.)
+          // falls back to the visible in-thread reply below.
+          const privatePicker = targetChatType === 'group'
+            && getBot(myAppId).config.privateCard === true;
+          const card = buildRelayPickerCard(
+            entries, targetChatId, targetAnchor, operatorOpenId, loc, undefined,
+            targetScope, targetChatType, privatePicker ? 'private' : 'public',
+          );
+          if (privatePicker) {
+            const { sendEphemeralCard } = await import('../im/lark/client.js');
+            try {
+              await sendEphemeralCard(myAppId, targetChatId, operatorOpenId, card);
+            } catch (err) {
+              // Ephemeral unavailable here (18053 topic / permission / network):
+              // fall back to the visible reply so the picker still works — the
+              // privacy win is best-effort, correctness is not.
+              logger.warn(`[${logTag}] /relay ephemeral picker failed (${err instanceof Error ? err.message : err}); sending visible picker`);
+              const visibleCard = buildRelayPickerCard(
+                entries, targetChatId, targetAnchor, operatorOpenId, loc, undefined,
+                targetScope, targetChatType, 'public',
+              );
+              await replyAtInvocation(visibleCard, 'interactive');
+            }
+          } else {
+            await replyAtInvocation(card, 'interactive');
+          }
           break;
         }
         const afterFlag = argsLine.replace(/^--create\s*/i, '').trim();

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -1603,9 +1603,10 @@ export function buildRelayPickerCard(
    *  so the re-render handlers (select / page / search) know they must delete +
    *  resend an ephemeral card instead of returning a body for Lark to patch in
    *  place (ephemeral cards can't be PATCH-updated). Default 'public' preserves
-   *  the legacy visible-to-all picker. Meaningful for group targets (incl. topic
-   *  groups — ephemeral is sent per-user at group top-level); p2p never goes
-   *  ephemeral (see command-handler). */
+   *  the legacy visible-to-all picker. Only ever set 'private' for flat chat-
+   *  scope 普通群 targets: ephemeral has no thread anchor, so command-handler
+   *  gates it on `targetScope === 'chat'` (thread-scope 话题群/话题 stay public
+   *  in-thread — see the gate comment there). p2p never goes ephemeral. */
   visibility: 'private' | 'public' = 'public',
 ): string {
   const searchQuery = state?.searchQuery ?? '';

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -1597,6 +1597,16 @@ export function buildRelayPickerCard(
    *  Authoritative from the /relay command's session chatType. Default 'group'
    *  covers legacy cards rendered before this field existed. */
   targetChatType: 'group' | 'p2p' = 'group',
+  /** When 'private', the card is (or will be) delivered as an ephemeral card
+   *  visible only to the invoker — so the session title / source-chat name never
+   *  leak to other group members. Baked into every button value as `visibility`
+   *  so the re-render handlers (select / page / search) know they must delete +
+   *  resend an ephemeral card instead of returning a body for Lark to patch in
+   *  place (ephemeral cards can't be PATCH-updated). Default 'public' preserves
+   *  the legacy visible-to-all picker. Meaningful for group targets (incl. topic
+   *  groups — ephemeral is sent per-user at group top-level); p2p never goes
+   *  ephemeral (see command-handler). */
+  visibility: 'private' | 'public' = 'public',
 ): string {
   const searchQuery = state?.searchQuery ?? '';
   const requestedPage = state?.page ?? 0;
@@ -1621,6 +1631,7 @@ export function buildRelayPickerCard(
     target_scope: targetScope,
     target_chat_type: targetChatType,
     invoker_open_id: invokerOpenId,
+    visibility,
     search: searchQuery,
     page,
     selected: selectedSessionId ?? '',

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -1171,6 +1171,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     // session's chatType for DM targets. Default 'group' covers legacy cards.
     const targetScope = (value.target_scope as 'thread' | 'chat') ?? 'chat';
     const targetChatType = (value.target_chat_type as 'group' | 'p2p') ?? 'group';
+    const cardVisibility = (value.visibility as 'private' | 'public') ?? 'public';
     const invokerOpenId = value.invoker_open_id as string | undefined;
     if (!targetChatId || !targetRootId || !operatorOpenId) {
       return { toast: { type: 'error', content: t('card.relay.toast_failed', { error: 'missing_value' }, loc) } };
@@ -1233,7 +1234,32 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       },
       targetScope,
       targetChatType,
+      cardVisibility,
     );
+    // ── Private (ephemeral) picker: delete-then-resend ────────────────────
+    // Ephemeral cards CANNOT be PATCH-updated (Feishu legacy interface), so we
+    // can't return a body for the dispatcher to patch in place. Instead delete
+    // the clicked card and resend a fresh ephemeral one carrying the new state
+    // — the same send→interact→delete→resend pattern Feishu documents for
+    // ephemeral flows. Resend FIRST, then delete the old one, so a resend
+    // failure doesn't leave the user with no card at all. The toast keeps the
+    // callback response non-empty (returning {} would make Lark show nothing).
+    if (cardVisibility === 'private') {
+      const { sendEphemeralCard, deleteEphemeralCard } = await import('./client.js');
+      try {
+        await sendEphemeralCard(larkAppId, targetChatId, invokerOpenId ?? operatorOpenId, cardJson);
+        if (cardMessageId) {
+          await deleteEphemeralCard(larkAppId, cardMessageId).catch(() => { /* stale card lingering is cosmetic */ });
+        }
+        // No card body returned — the replacement is already sent. An empty
+        // response is fine here (the new ephemeral card is the user-visible
+        // result); a toast would double up with the freshly-rendered card.
+        return;
+      } catch (err) {
+        logger.warn(`[card-action] relay private picker re-render failed (${err instanceof Error ? err.message : err}); leaving old card in place`);
+        return { toast: { type: 'error', content: t('card.relay.toast_failed', { error: 'ephemeral_refresh_failed' }, loc) } };
+      }
+    }
     // Return an updated card body — event-dispatcher wraps this as
     // { card: { type: 'raw', data: <body> } } so Lark patches the picker
     // in place rather than appending a new message.
@@ -1360,6 +1386,7 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     // field and default to 'group' (their pickers never offered DM targets).
     const targetScope = (value.target_scope as 'thread' | 'chat') ?? 'chat';
     const targetChatType = (value.target_chat_type as 'group' | 'p2p') ?? 'group';
+    const cardVisibility = (value.visibility as 'private' | 'public') ?? 'public';
     const targetAnchor = targetScope === 'chat' ? targetChatId : targetRootId;
     const invokerOpenId = value.invoker_open_id as string | undefined;
     if (!sourceSessionId || !targetChatId || !targetRootId) {
@@ -1485,8 +1512,15 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
       return { toast: { type: 'error', content: t('card.relay.toast_failed', { error: r.error }, loc) } };
     }
     // Best-effort: remove the picker card now that the selection resolved.
+    // Ephemeral (private) pickers need the ephemeral-delete endpoint —
+    // deleteMessage (im/v1/messages) doesn't apply to ephemeral message ids.
     if (cardMessageId && larkAppId) {
-      deleteMessage(larkAppId, cardMessageId).catch(() => { /* leave it */ });
+      if (cardVisibility === 'private') {
+        const { deleteEphemeralCard } = await import('./client.js');
+        deleteEphemeralCard(larkAppId, cardMessageId).catch(() => { /* leave it */ });
+      } else {
+        deleteMessage(larkAppId, cardMessageId).catch(() => { /* leave it */ });
+      }
     }
     return { toast: { type: 'success', content: t('card.relay.toast_success', undefined, loc) } };
   }

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -791,6 +791,34 @@ export async function sendEphemeralCard(
   return messageId ?? '';
 }
 
+/**
+ * Delete a previously-sent ephemeral card (`ephemeral/v1/delete`). Ephemeral
+ * cards CANNOT be PATCH-updated (see {@link sendEphemeralCard}), so the picker's
+ * "in-place refresh" (page / search / select) is implemented as delete-then-
+ * resend; this is the delete half. Best-effort: returns false on any failure
+ * (already gone, network) rather than throwing — a stale ephemeral card lingering
+ * is a cosmetic issue, not a correctness one, and the caller has already sent the
+ * replacement by the time cleanup runs.
+ */
+export async function deleteEphemeralCard(larkAppId: string, messageId: string): Promise<boolean> {
+  const c = getBotClient(larkAppId);
+  try {
+    const res: any = await (c as any).request({
+      method: 'POST',
+      url: '/open-apis/ephemeral/v1/delete',
+      data: { message_id: messageId },
+    });
+    if (res && typeof res.code === 'number' && res.code !== 0) {
+      logger.debug(`Delete ephemeral card ${messageId} returned non-zero code: ${res.code} ${res.msg ?? ''}`);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    logger.debug(`Failed to delete ephemeral card ${messageId}: ${err}`);
+    return false;
+  }
+}
+
 export async function updateMessage(larkAppId: string, messageId: string, cardJson: string): Promise<void> {
   const c = getBotClient(larkAppId);
   let res: any;

--- a/test/card-builder.test.ts
+++ b/test/card-builder.test.ts
@@ -1188,6 +1188,23 @@ describe('buildRelayPickerCard', () => {
     expect(confirmBtn).toMatch(/接力到本单聊|into this DM/);
   });
 
+  it('carries visibility in interactive values (defaults to public, private when passed)', () => {
+    // Default → public (legacy visible-to-all picker).
+    const pub = parse(buildRelayPickerCard(fixtureEntries(2), 'oc_target', 'oc_target', 'ou_invoker_test'));
+    expect(searchInput(pub).behaviors[0].value.visibility).toBe('public');
+    expect(containers(pub)[0].behaviors[0].value.visibility).toBe('public');
+    // Explicit private → carried on every interactive value (search / select /
+    // page / confirm) so the re-render handler knows to delete+resend an
+    // ephemeral card instead of returning a body for in-place patch.
+    const priv = parse(buildRelayPickerCard(
+      fixtureEntries(2), 'oc_target', 'oc_target', 'ou_invoker_test',
+      undefined, { selectedSessionId: 'sess-1' }, 'chat', 'group', 'private',
+    ));
+    expect(searchInput(priv).behaviors[0].value.visibility).toBe('private');
+    expect(containers(priv)[0].behaviors[0].value.visibility).toBe('private');
+    expect(confirmButton(priv)?.behaviors?.[0]?.value?.visibility).toBe('private');
+  });
+
   it('renders "no relayable sessions" notice when entries empty (form still shown)', () => {
     const card = parse(buildRelayPickerCard([], 'oc_target', 'om_target_root', 'ou_invoker_test'));
     const md = card.body.elements.find((e: any) => e.tag === 'markdown');

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -197,7 +197,7 @@ vi.mock('../src/im/lark/card-builder.js', () => ({
   ),
   buildSlashListCard: vi.fn((params: any) => JSON.stringify(params)),
   buildRelayPickerCard: vi.fn(
-    (entries: any[], targetChatId: string, rootMessageId: string, _invokerOpenId?: string, _locale?: any, _state?: any, targetScope?: string, targetChatType?: string) => JSON.stringify({
+    (entries: any[], targetChatId: string, rootMessageId: string, _invokerOpenId?: string, _locale?: any, _state?: any, targetScope?: string, targetChatType?: string, visibility?: string) => JSON.stringify({
       schema: '2.0',
       body: {
         elements: entries.length === 0 ? [
@@ -206,7 +206,7 @@ vi.mock('../src/im/lark/card-builder.js', () => ({
           tag: 'interactive_container',
           behaviors: [{
             type: 'callback',
-            value: { action: 'relay_select', session_id: e.sessionId, target_chat_id: targetChatId, root_id: rootMessageId, target_scope: targetScope ?? 'chat', target_chat_type: targetChatType ?? 'group' },
+            value: { action: 'relay_select', session_id: e.sessionId, target_chat_id: targetChatId, root_id: rootMessageId, target_scope: targetScope ?? 'chat', target_chat_type: targetChatType ?? 'group', visibility: visibility ?? 'public' },
           }],
           elements: [{ tag: 'markdown', content: `**${e.title}**\n${e.chatMode ?? 'group'}\n${e.chatLabel}` }],
         })),
@@ -240,6 +240,10 @@ vi.mock('../src/im/lark/client.js', () => ({
   // Default returns null so picker entries fall back to raw chatId.
   getChatName: vi.fn(async () => null),
   getChatNameAndMode: vi.fn(async () => ({ name: null, mode: 'group' as const })),
+  // privateCard /relay picker: chat-scope 普通群 sends the picker ephemeral
+  // (visible-to-invoker) via this. Default resolves to a fake ephemeral id;
+  // scenarios override with mockRejectedValueOnce to exercise the fallback.
+  sendEphemeralCard: vi.fn(async () => 'eph_picker_msg_id'),
 }));
 
 vi.mock('../src/services/group-creator.js', () => ({
@@ -3914,6 +3918,138 @@ describe('handleCommand', () => {
       expect(containerValue?.target_scope).toBe('thread');
       // 话题群 top-level → anchor = the /relay message id (makeLarkMessage → 'msg_001').
       expect(containerValue?.root_id).toBe('msg_001');
+    });
+
+    // ── privateCard picker gate (PR #654 + 首审/复审修复) ────────────────────
+    // The picker exposes session title + source-chat name. When privateCard is
+    // on, a FLAT 普通群 (chat-scope) sends it as an ephemeral card (visible to the
+    // invoker only). But ephemeral has no thread anchor, so thread-scope targets
+    // must NOT use it (see the gate comment in command-handler + the REGRESSION
+    // in ephemeral-or-reply.test.ts). 申晗 (2026-07-29): 话题内公开可接受.
+
+    // Helper: bot with privateCard on.
+    const withPrivateCard = () => {
+      vi.mocked(getBot).mockImplementation(((id: string = 'app-1') => {
+        const bot = defaultGetBot(id);
+        (bot.config as any).privateCard = true;
+        return bot;
+      }) as any);
+    };
+
+    it('privateCard + flat 普通群 (chat-scope): sends the picker as an ephemeral card, NOT a visible reply', async () => {
+      withPrivateCard();
+      const { sendEphemeralCard } = await import('../src/im/lark/client.js');
+      const ds = makeDaemonSession({ session: makeSession({ ownerOpenId: 'ou_sender', scope: 'chat' }), scope: 'chat' });
+      const otherDs: DaemonSession = {
+        ...makeDaemonSession(),
+        session: makeSession({
+          sessionId: 'sess-other', chatId: 'oc_other', rootMessageId: 'om_other_root',
+          title: 'secret task', ownerOpenId: 'ou_sender',
+        }),
+        chatId: 'oc_other',
+      };
+      const deps = makeDeps(ds);
+      deps.activeSessions.set(sessionKey('om_other_root', LARK_APP_ID), otherDs);
+
+      await handleCommand('/relay', ROOT_ID, makeLarkMessage('/relay'), deps, LARK_APP_ID);
+
+      // Ephemeral send to the invoker in the current chat — never a visible reply.
+      expect(vi.mocked(sendEphemeralCard)).toHaveBeenCalledTimes(1);
+      const [appId, chatId, openId, cardJson] = vi.mocked(sendEphemeralCard).mock.calls[0];
+      expect(appId).toBe(LARK_APP_ID);
+      expect(chatId).toBe(CHAT_ID);
+      expect(openId).toBe('ou_sender');
+      expect(vi.mocked(replyMessage)).not.toHaveBeenCalled();
+      expect(deps.sessionReply).not.toHaveBeenCalled();
+      // The ephemeral card carries visibility='private' baked into its buttons.
+      const card = JSON.parse(cardJson as string);
+      const containerValue = card.body.elements.find((e: any) => e.tag === 'interactive_container')?.behaviors?.[0]?.value;
+      expect(containerValue?.visibility).toBe('private');
+    });
+
+    it('REGRESSION: privateCard + thread-scope (话题群) does NOT go ephemeral — stays a visible in-thread reply (public card)', async () => {
+      // Ephemeral has no thread anchor: a 话题群 rejects with 18053 and a 话题
+      // inside a 普通群 would leak the card to the group top level. So thread-
+      // scope pickers must skip ephemeral entirely (guarded, not fallback).
+      withPrivateCard();
+      const { sendEphemeralCard, getChatNameAndMode } = await import('../src/im/lark/client.js');
+      vi.mocked(getChatNameAndMode).mockResolvedValueOnce({ name: 'Topic Room', mode: 'topic' });
+      const ds = makeDaemonSession({ session: makeSession({ ownerOpenId: 'ou_sender' }) });
+      const otherDs: DaemonSession = {
+        ...makeDaemonSession(),
+        session: makeSession({
+          sessionId: 'sess-other', chatId: 'oc_other', rootMessageId: 'om_other_root',
+          title: 'secret task', ownerOpenId: 'ou_sender',
+        }),
+        chatId: 'oc_other',
+      };
+      const deps = makeDeps(ds);
+      deps.activeSessions.set(sessionKey('om_other_root', LARK_APP_ID), otherDs);
+
+      await handleCommand('/relay', ROOT_ID, makeLarkMessage('/relay'), deps, LARK_APP_ID);
+
+      // Ephemeral must NOT be attempted for a thread-scope target.
+      expect(vi.mocked(sendEphemeralCard)).not.toHaveBeenCalled();
+      // Card goes out as a visible in-thread reply, and is PUBLIC (not private).
+      const [, anchorMsgId, replyContent, msgType, inThread] = vi.mocked(replyMessage).mock.calls[0];
+      expect(anchorMsgId).toBe('msg_001');
+      expect(inThread).toBe(true);
+      expect(msgType).toBe('interactive');
+      const card = JSON.parse(replyContent as string);
+      const containerValue = card.body.elements.find((e: any) => e.tag === 'interactive_container')?.behaviors?.[0]?.value;
+      expect(containerValue?.target_scope).toBe('thread');
+      expect(containerValue?.visibility).toBe('public');
+    });
+
+    it('privateCard + chat-scope: falls back to a visible reply when the ephemeral send fails (e.g. 18053)', async () => {
+      withPrivateCard();
+      const { sendEphemeralCard } = await import('../src/im/lark/client.js');
+      vi.mocked(sendEphemeralCard).mockRejectedValueOnce(new Error('chat can not be thread (code: 18053)'));
+      const ds = makeDaemonSession({ session: makeSession({ ownerOpenId: 'ou_sender', scope: 'chat' }), scope: 'chat' });
+      const otherDs: DaemonSession = {
+        ...makeDaemonSession(),
+        session: makeSession({
+          sessionId: 'sess-other', chatId: 'oc_other', rootMessageId: 'om_other_root',
+          title: 'secret task', ownerOpenId: 'ou_sender',
+        }),
+        chatId: 'oc_other',
+      };
+      const deps = makeDeps(ds);
+      deps.activeSessions.set(sessionKey('om_other_root', LARK_APP_ID), otherDs);
+
+      await handleCommand('/relay', ROOT_ID, makeLarkMessage('/relay'), deps, LARK_APP_ID);
+
+      // Attempted ephemeral, then fell back to the visible reply with a PUBLIC card.
+      expect(vi.mocked(sendEphemeralCard)).toHaveBeenCalledTimes(1);
+      const [, , replyContent, msgType] = vi.mocked(replyMessage).mock.calls[0];
+      expect(msgType).toBe('interactive');
+      const card = JSON.parse(replyContent as string);
+      const containerValue = card.body.elements.find((e: any) => e.tag === 'interactive_container')?.behaviors?.[0]?.value;
+      expect(containerValue?.visibility).toBe('public');
+    });
+
+    it('privateCard OFF + flat 普通群: picker stays a visible reply (no ephemeral)', async () => {
+      // Default bot has no privateCard — the gate must not fire.
+      const { sendEphemeralCard } = await import('../src/im/lark/client.js');
+      const ds = makeDaemonSession({ session: makeSession({ ownerOpenId: 'ou_sender', scope: 'chat' }), scope: 'chat' });
+      const otherDs: DaemonSession = {
+        ...makeDaemonSession(),
+        session: makeSession({
+          sessionId: 'sess-other', chatId: 'oc_other', rootMessageId: 'om_other_root',
+          title: 'other task', ownerOpenId: 'ou_sender',
+        }),
+        chatId: 'oc_other',
+      };
+      const deps = makeDeps(ds);
+      deps.activeSessions.set(sessionKey('om_other_root', LARK_APP_ID), otherDs);
+
+      await handleCommand('/relay', ROOT_ID, makeLarkMessage('/relay'), deps, LARK_APP_ID);
+
+      expect(vi.mocked(sendEphemeralCard)).not.toHaveBeenCalled();
+      const [, , replyContent] = vi.mocked(replyMessage).mock.calls[0];
+      const card = JSON.parse(replyContent as string);
+      const containerValue = card.body.elements.find((e: any) => e.tag === 'interactive_container')?.behaviors?.[0]?.value;
+      expect(containerValue?.visibility).toBe('public');
     });
 
     it('picker refuses upfront when this chat already has an active session for the bot', async () => {


### PR DESCRIPTION
## 结论

`/relay` 选择卡此前是普通群消息，会把**会话标题和来源群名**暴露给所有能看到消息的群成员。本 PR 让开了 `privateCard` 的 bot 在**扁平普通群（chat-scope）** 里把选择卡改为**仅邀请者可见的 ephemeral 卡**，元数据不再泄露。

> ⚠️ **作用域（首审/复审修订）**：ephemeral API（`ephemeral/v1/send`）只接受 `chat_id`、**没有 thread 锚点**，所以对 thread-scope 目标（话题群 / 普通群里的原生话题 / new-topic·shared）无法把卡片留在原话题——话题群会被 18053 拒，普通群里的话题则会让卡片逃到群顶层。这是 `deliverEphemeralOrReply`（worker-pool）已用 REGRESSION 测试锁死、**PR #164** 首次修过的同一个坑。经申晗拍板「**话题内公开可接受**」，本 PR 把 ephemeral **限定在扁平普通群 chat-scope**（与 `/card`、`/close` 私密卡的既定行为一致）；thread-scope 场景继续走可见 in-thread 回复（话题内公开卡）。

## 用户看到什么

| 触发方式 | 旧表现 | 本 PR 后 |
| --- | --- | --- |
| privateCard 开 + **扁平普通群**（chat / chat-topic 顶层）发 `/relay` | 选择卡是普通群消息，全员可见标题+来源群名 | **ephemeral 卡，仅邀请者可见** |
| privateCard 开 + **话题群 / 话题内 / new-topic·shared**（thread-scope）发 `/relay` | 公开卡 | **仍是话题内可见公开卡**（ephemeral 无 thread 锚，不适用；话题内公开可接受） |
| 扁平群 ephemeral 翻页 / 搜索 / 点选 | in-place patch 刷新 | 删旧卡 + 重发新 ephemeral 卡（ephemeral 不支持 patch；先重发再删，失败不会让用户没卡） |
| p2p / ephemeral 发送失败（18053 等） | — | 回退可见回复，功能不受影响 |
| privateCard 关（默认） | 公开卡 | 公开卡（不变） |

## 改了什么

- **command-handler**：私密 picker 门控 = `targetChatType === 'group' && targetScope === 'chat' && privateCard`——**只有扁平普通群 chat-scope** 才用 `sendEphemeralCard`；thread-scope / p2p 走可见 in-thread 回复；ephemeral 异常（18053 等）回退可见公开卡。
- **card-builder**：`buildRelayPickerCard` 新增 `visibility` 参数，烙进每个按钮回调值，供 re-render 判断走 ephemeral 路径。thread-scope 卡恒为 `'public'`。
- **card-handler**：ephemeral 卡不能 PATCH 更新，故（私密卡的）翻页/搜索/点选改为「先重发新 ephemeral 卡、再删旧卡」；确认接力后清理走 ephemeral 删除接口。因 thread-scope 卡恒 public，这些私密分支只会在扁平群 ephemeral 卡上触发。
- **client**：新增 `deleteEphemeralCard`（`ephemeral/v1/delete`）封装。

## 验证

- **build**：`pnpm build` 通过。
- **单测**：6 个相关 test files 共 **406 tests 全绿** —— `command-handler`（29 个 /relay，含新增 4 条门控用例：①chat-scope 走 ephemeral ②REGRESSION 话题群+privateCard 不走 ephemeral、可见公开卡 ③ephemeral 失败回退 ④privateCard 关不误触发）、`card-builder`（131，含 visibility 用例）、`relay-picker`（4）、`ephemeral-or-reply`（既有 REGRESSION 守卫）、`card-integration`、`card-handler-relay-pickup`。
- `git diff --check` 通过。

## 仍未验证

| 剩余检查 | 需要的环境或原因 | 影响范围 |
| --- | --- | --- |
| 截图更新 | 需按**实际群形态**重拍（扁平普通群里 ephemeral「仅对你可见」；话题群里公开卡）——原截图对应旧行为，待作者补 | 不阻塞代码评审 |
| 扁平群 ephemeral 翻页/搜索/点选/确认的完整交互 | 需真机人工点击（switch:here + daemon:restart 后） | 不阻塞代码评审 |
| 全量 CI 测试套件 | 本机 build 环境缺 electron/proxy-agent 依赖，无法本地跑全量；fork PR 不触发 CI | 阻塞发布前 CI，不阻塞代码评审 |

---
> 本 PR 由 @xiaoxueSunn 发起；首审/复审阶段的 P1 修复（门控加 `targetScope === 'chat'` + 补 4 条门控测试）由 review 流程按申晗拍板补入（commit `eee2c634`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
