### PR TITLE
fix(bridge): 无回复 sentinel 改为末行终止符匹配

### DIFF
--- a/src/services/bridge-fallback-gate.ts
+++ b/src/services/bridge-fallback-gate.ts
@@ -8,10 +8,14 @@
  * disk and threads them through here.
  *
  * Rules:
- *   - Non-adopt + exact no-reply sentinel: suppress. Botmux-aware models use
- *     this explicit protocol when a turn genuinely needs no chat response.
- *     Exact matching is intentional: prose such as "I should stay silent"
- *     is still a normal final answer and must not be guessed away.
+ *   - Non-adopt + no-reply sentinel terminator: suppress the whole turn.
+ *     Botmux-aware models use this explicit protocol when a turn genuinely
+ *     needs no chat response. The signal is the LAST non-empty line of the
+ *     final being exactly `BOTMUX_NO_REPLY` — models almost always explain
+ *     the silence first and then append the token on its own line, so a
+ *     full-string exact match leaked the literal token into Lark. A token
+ *     that only appears inline (mid-sentence, or with prose after it) is
+ *     still a normal answer and is NOT guessed away. See isBridgeNoReplyFinal.
  *   - Adopt mode never suppresses: in /adopt the model in the adopted
  *     session is unaware of botmux, so transcript drain is the ONLY
  *     channel from model to Lark. There's no `botmux send` to compete
@@ -42,7 +46,28 @@ const MATERIAL_FINAL_MIN_EXTRA_CHARS = 120;
 export const BRIDGE_NO_REPLY_SENTINEL = 'BOTMUX_NO_REPLY';
 
 export function isBridgeNoReplyFinal(finalText: string | undefined): boolean {
-  return finalText?.trim() === BRIDGE_NO_REPLY_SENTINEL;
+  if (finalText === undefined) return false;
+  // Suppress the whole turn when the model's final ENDS WITH a standalone
+  // no-reply sentinel line. We look at the LAST non-empty line only:
+  //   - pure `BOTMUX_NO_REPLY`                       → suppress
+  //   - `<prose>\n\nBOTMUX_NO_REPLY`                 → suppress the whole turn
+  //   - a final whose last non-empty line is prose   → NOT a no-reply signal
+  //     (the token inline in a sentence, or followed by more prose, still posts)
+  // Full-string exact match was too brittle: botmux-aware models almost always
+  // explain the silence first ("...no reply needed.") and then append the token
+  // on its own line, which exact match let leak the literal token into Lark.
+  // Trade-off (accepted): a genuine answer that happens to end with a bare
+  // sentinel line is dropped WHOLE — the product wants a fully silent no-reply
+  // turn over the safer strip-and-forward. The last-non-empty-line rule (not a
+  // substring / endsWith test) keeps that risk to finals the model deliberately
+  // terminated with the sentinel.
+  const lines = finalText.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (line.length === 0) continue;
+    return line === BRIDGE_NO_REPLY_SENTINEL;
+  }
+  return false;
 }
 
 export interface BridgeSendMarker {

--- a/test/bridge-fallback-gate.test.ts
+++ b/test/bridge-fallback-gate.test.ts
@@ -28,9 +28,31 @@ describe('shouldSuppressBridgeEmit', () => {
     )).toBe(true);
   });
 
-  it('non-adopt: prose about staying silent is not guessed away', () => {
+  it('non-adopt: prose then a standalone sentinel LINE suppresses the whole turn', () => {
+    // The real-world shape: the model explains the silence, then appends the
+    // token on its own trailing line. Full-string exact match let this leak.
+    expect(shouldSuppressBridgeEmit(
+      { ...turn(100), finalText: `Codex acknowledged and is reviewing. Nothing for me to do — no reply needed.\n\n${BRIDGE_NO_REPLY_SENTINEL}` },
+      undefined,
+      [],
+      false,
+    )).toBe(true);
+  });
+
+  it('non-adopt: token inline in a prose sentence is not guessed away', () => {
+    // Last non-empty line is a full sentence (token mid-line), not a bare
+    // sentinel — a normal answer that merely mentions the token.
     expect(shouldSuppressBridgeEmit(
       { ...turn(100), finalText: `I will stay silent instead of replying. ${BRIDGE_NO_REPLY_SENTINEL}` },
+      undefined,
+      [],
+      false,
+    )).toBe(false);
+  });
+
+  it('non-adopt: sentinel followed by more prose still posts (not a terminator)', () => {
+    expect(shouldSuppressBridgeEmit(
+      { ...turn(100), finalText: `${BRIDGE_NO_REPLY_SENTINEL}\n\nActually, here is the answer you asked for.` },
       undefined,
       [],
       false,


### PR DESCRIPTION
## 背景

#554 引入无回复回合静默协议:模型判断本轮无需回复时,final 只输出 `BOTMUX_NO_REPLY`,worker 侧 gate 静默吞掉兜底转发。合并并上线后,申晗在生产复现漏网 case(截图见群):

模型的 final 实际是
```
Codex acknowledged and is reviewing. Nothing for me to do — no reply needed.

BOTMUX_NO_REPLY
```
即**先解释一句「无需回复」,再把 token 另起一行附在结尾**。而原 gate 是 `final.trim() === "BOTMUX_NO_REPLY"` 精确全等,要求整条 final 只有这一个 token → 不命中 → 整条(含字面量 token)被兜底原样转发到飞书,**泄漏 sentinel**。

根因:精确全等对真实模型行为太脆。botmux-aware 模型极难做到「只输出一个词」,几乎总要先解释再补 token。

## 改动

`isBridgeNoReplyFinal` 从「整条精确全等」改为「**final 的最后一个非空行**精确等于 `BOTMUX_NO_REPLY`」:

| final 形态 | 行为 |
|---|---|
| 纯 `BOTMUX_NO_REPLY` | 静默吞掉(不变) |
| `<解释>\n\nBOTMUX_NO_REPLY`(结尾独立行) | **整条 turn 静默吞掉**(新) |
| token 出现在句中(`… BOTMUX_NO_REPLY now.`) | 照常转发 |
| token 之后还有正文 | 照常转发 |

## 取舍(已与仓库 owner 申晗确认,选激进方案 B)

命中即**整条 turn 丢弃**,彻底静音无回复回合。风险=真答复若恰好以独立 sentinel 行结尾,会被整条丢掉且用户看不到;产品明确选择接受此风险以换取完全静音(而非更保守的「剥掉 token 行、转发剩余正文」方案 A)。用「末行匹配」而非 `substring`/`endsWith`,把误吞限定在模型主动以 sentinel 收尾的 final。

提示词(i18n)保持不变——仍要求模型「final 只输出该 token」,gate 改动纯粹是模型不听话时的防御。

## 影响范围

- 只改共享 `bridge-fallback-gate.ts` 的 `isBridgeNoReplyFinal`,波及所有走 transcript 兜底的非 adopt 会话,共用同一 gate(`shouldSuppressBridgeEmit`)的自动回投路径有三条:Claude 家族 `emitReadyTurns`、结构化 bridge `emitReadyCodexTurns`、以及 Codex App/Mira/Mir 的 `handleCodexAppMarker`(新旧两个协议分支)。多行 final 的组装保留换行,与末行匹配假设一致。
- **与 #553 空完成兜底组合正确**:sentinel 终止的 final 非空,`shouldEmitEmptyCompletedBridgeFallback` 返回 false,不会触发「已完成但无文本」诊断卡。
- adopt 模式不解释 sentinel(不变)。

## 测试

- `test/bridge-fallback-gate.test.ts` 新增/改写:末行终止符 suppress、prose+空行+token 行 suppress、句中 token 照发、token 后接正文照发。
- 目标 6 文件(bridge-fallback-gate / cli-adapters / prompt-builder / bridge-final-output-retry / codex-bridge-queue / claude-turn-terminal-contract):**480 passed**。
- 额外对抗 11 条(CRLF、尾部标点、大小写、trailing 空行、undefined/空、#553 组合、adopt):全过。
- `pnpm build`:通过。

由 origin/master `3c0d64de` 切出,单文件逻辑改动 + 测试。
