### PR TITLE
feat(trigger): codex-app per-turn token usage → trigger-result（PR B / 拆自 #638）

### DIFF
--- a/docs-site/docs/en/api-task-trigger.md
+++ b/docs-site/docs/en/api-task-trigger.md
@@ -155,7 +155,7 @@ GET /api/sessions/:sessionId/trigger-result
 ```
 
 About `usage` (this turn's token usage, four mutually-exclusive buckets):
-- Present only for **codex / codex-app tasks** and only when the turn's usage was captured; **omitted entirely** for other CLIs or when not captured.
+- Present only for **codex-app tasks** and only when the turn's usage was captured; **omitted entirely** for other CLIs (including plain codex) or when not captured.
 - **omit ≠ 0**: no usage means no `usage` field, not four zeros — treat "field absent = unknown", don't read a missing field as a real 0.
 - Buckets: `inputTokens` (fresh input, cache read/write already subtracted), `outputTokens`, `cacheReadTokens`, `cacheCreateTokens`, all per-turn deltas (not session totals).
 - **Survives restart**: after a daemon restart, re-querying a completed session restores `usage` alongside `output` from disk.

--- a/docs-site/docs/en/api-task-trigger.md
+++ b/docs-site/docs/en/api-task-trigger.md
@@ -135,11 +135,11 @@ GET /api/sessions/:sessionId/trigger-result
 | `state` | Meaning | What to do | Key fields |
 |---------|---------|-----------|-----------|
 | `running` | still running | keep polling | — |
-| `completed` | final output ready | terminal; read `output.content` | `output.content`, `finishedAt` |
+| `completed` | final output ready | terminal; read `output.content` (codex-app also brings `usage`) | `output.content`, `finishedAt`, `usage?` |
 | `failed` | session terminated with no captured output (soft terminal) | see below | `errorCode:"no_output"`, `error`, `finishedAt` |
 | `not_found` | no such session (never existed / invalid id) | see two physical forms below | `errorCode:"session_not_found"` |
 
-`completed` example:
+`completed` example (`usage` present only for codex-app, and only when captured):
 
 ```json
 {
@@ -147,11 +147,19 @@ GET /api/sessions/:sessionId/trigger-result
   "state": "completed",
   "triggerId": "trg_87e7b415-...",
   "output": { "content": "ASYNC_DEMO_OK" },
+  "usage": { "inputTokens": 60, "outputTokens": 30, "cacheReadTokens": 40, "cacheCreateTokens": 0 },
   "finishedAt": "2026-07-24T08:43:17.126Z",
   "target": { "kind": "turn", "sessionId": "2eed60c4-...", "chatId": "http_async_..." },
   "async": { "status": "completed", "sessionId": "2eed60c4-...", "completedAt": "..." }
 }
 ```
+
+About `usage` (this turn's token usage, four mutually-exclusive buckets):
+- Present only for **codex / codex-app tasks** and only when the turn's usage was captured; **omitted entirely** for other CLIs or when not captured.
+- **omit ≠ 0**: no usage means no `usage` field, not four zeros — treat "field absent = unknown", don't read a missing field as a real 0.
+- Buckets: `inputTokens` (fresh input, cache read/write already subtracted), `outputTokens`, `cacheReadTokens`, `cacheCreateTokens`, all per-turn deltas (not session totals).
+- **Survives restart**: after a daemon restart, re-querying a completed session restores `usage` alongside `output` from disk.
+
 
 ### `failed` is a soft terminal — don't kill immediately
 

--- a/docs-site/docs/zh/api-task-trigger.md
+++ b/docs-site/docs/zh/api-task-trigger.md
@@ -155,7 +155,7 @@ GET /api/sessions/:sessionId/trigger-result
 ```
 
 关于 `usage`（本轮 token 用量，四桶互斥）：
-- **仅 codex / codex-app 任务**、且本轮成功采集到用量时出现；其它 CLI 或未采集到时**整段省略**。
+- **仅 codex-app 任务**、且本轮成功采集到用量时出现；其它 CLI（含纯 codex）或未采集到时**整段省略**。
 - **omit ≠ 0**：拿不到用量就没有 `usage` 字段，而不是四个 0——请按"字段缺失=未知"处理，不要把缺失当成真实 0 用量。
 - 四桶：`inputTokens`（纯新增输入，已扣除缓存读/写）、`outputTokens`、`cacheReadTokens`、`cacheCreateTokens`，均为本轮增量（非会话累计）。
 - **随重启持久化**：daemon 重启后再查该已完成会话，`usage` 与 `output` 一并从磁盘恢复。

--- a/docs-site/docs/zh/api-task-trigger.md
+++ b/docs-site/docs/zh/api-task-trigger.md
@@ -135,11 +135,11 @@ GET /api/sessions/:sessionId/trigger-result
 | `state` | 含义 | 你该做什么 | 关键字段 |
 |---------|------|-----------|---------|
 | `running` | 任务还在跑 | 继续轮询 | — |
-| `completed` | 有最终产出 | 落终态，读 `output.content` | `output.content`、`finishedAt` |
+| `completed` | 有最终产出 | 落终态，读 `output.content`（codex-app 还会带 `usage`） | `output.content`、`finishedAt`、`usage?` |
 | `failed` | 会话已终止但没捕获到产出（软终态） | 见下方说明 | `errorCode:"no_output"`、`error`、`finishedAt` |
 | `not_found` | 查无此会话（从未存在/非法 id） | 见下方两种物理表现 | `errorCode:"session_not_found"` |
 
-`completed` 响应示例：
+`completed` 响应示例（`usage` 仅 codex-app、且成功采集到时出现）：
 
 ```json
 {
@@ -147,11 +147,19 @@ GET /api/sessions/:sessionId/trigger-result
   "state": "completed",
   "triggerId": "trg_87e7b415-...",
   "output": { "content": "ASYNC_DEMO_OK" },
+  "usage": { "inputTokens": 60, "outputTokens": 30, "cacheReadTokens": 40, "cacheCreateTokens": 0 },
   "finishedAt": "2026-07-24T08:43:17.126Z",
   "target": { "kind": "turn", "sessionId": "2eed60c4-...", "chatId": "http_async_..." },
   "async": { "status": "completed", "sessionId": "2eed60c4-...", "completedAt": "..." }
 }
 ```
+
+关于 `usage`（本轮 token 用量，四桶互斥）：
+- **仅 codex / codex-app 任务**、且本轮成功采集到用量时出现；其它 CLI 或未采集到时**整段省略**。
+- **omit ≠ 0**：拿不到用量就没有 `usage` 字段，而不是四个 0——请按"字段缺失=未知"处理，不要把缺失当成真实 0 用量。
+- 四桶：`inputTokens`（纯新增输入，已扣除缓存读/写）、`outputTokens`、`cacheReadTokens`、`cacheCreateTokens`，均为本轮增量（非会话累计）。
+- **随重启持久化**：daemon 重启后再查该已完成会话，`usage` 与 `output` 一并从磁盘恢复。
+
 
 ### `failed` 是软终态，不要立即判死
 

--- a/src/codex-app-runner.ts
+++ b/src/codex-app-runner.ts
@@ -22,7 +22,7 @@ import {
 } from './services/codex-app-runner-protocol.js';
 import {
   TurnTokenUsageAccumulator,
-  parseCodexTokenBreakdown,
+  parseTokenUsagePair,
 } from './services/codex-app-token-usage.js';
 
 type JsonObject = Record<string, any>;
@@ -357,15 +357,16 @@ function handleNotification(msg: JsonObject): void {
     const turnId = typeof params.turnId === 'string' ? params.turnId : undefined;
     if (turnId) {
       const usage = (params.tokenUsage ?? {}) as JsonObject;
-      const total = parseCodexTokenBreakdown(usage.total);
-      const last = parseCodexTokenBreakdown(usage.last);
+      const parsed = parseTokenUsagePair(usage.total, usage.last);
       const acc = getOrCreateUsageAccumulator(turnId);
-      if (total && last) {
-        acc.update(total, last);
+      if (parsed) {
+        acc.update(parsed.total, parsed.last);
       } else {
         // Malformed usage for a KNOWN turn: poison it (sticky). Silently skipping
         // would let a later valid notification rebuild a fresh baseline and report
-        // only the last completion — a plausible-looking undercount.
+        // only the last completion — a plausible-looking undercount. This also
+        // covers asymmetric cacheWrite presence (total has it, last omits it or
+        // vice-versa), where a 0-default would misattribute cache-create tokens.
         acc.poison('malformed tokenUsage notification');
       }
     } else {

--- a/src/codex-app-runner.ts
+++ b/src/codex-app-runner.ts
@@ -282,6 +282,22 @@ const usageAccumulators = new Map<string, TurnTokenUsageAccumulator>();
  *  that never emit a final marker. */
 const MAX_USAGE_ACCUMULATORS = 8;
 
+/** Get (or create, with bounded pruning) the usage accumulator for a turn. */
+function getOrCreateUsageAccumulator(turnId: string): TurnTokenUsageAccumulator {
+  let acc = usageAccumulators.get(turnId);
+  if (!acc) {
+    // Bounded pruning: a turn that never emits a final marker (crash/interrupt)
+    // would otherwise leak its accumulator. Evict the oldest insertion at the cap.
+    if (usageAccumulators.size >= MAX_USAGE_ACCUMULATORS) {
+      const oldest = usageAccumulators.keys().next().value;
+      if (oldest !== undefined) usageAccumulators.delete(oldest);
+    }
+    acc = new TurnTokenUsageAccumulator();
+    usageAccumulators.set(turnId, acc);
+  }
+  return acc;
+}
+
 function detectedCodexVersion(): CodexVersion | undefined {
   if (codexVersionChecked) return codexVersion;
   codexVersionChecked = true;
@@ -339,23 +355,19 @@ function handleNotification(msg: JsonObject): void {
   if (msg.method === 'thread/tokenUsage/updated') {
     const params = (msg.params ?? {}) as JsonObject;
     const turnId = typeof params.turnId === 'string' ? params.turnId : undefined;
-    const usage = (params.tokenUsage ?? {}) as JsonObject;
-    const total = parseCodexTokenBreakdown(usage.total);
-    const last = parseCodexTokenBreakdown(usage.last);
-    if (turnId && total && last) {
-      let acc = usageAccumulators.get(turnId);
-      if (!acc) {
-        // Bounded pruning: a turn that never emits a final marker (crash/interrupt)
-        // would otherwise leak its accumulator. Only one turn is active at a time,
-        // so a tiny cap suffices — evict the oldest insertion when exceeded.
-        if (usageAccumulators.size >= MAX_USAGE_ACCUMULATORS) {
-          const oldest = usageAccumulators.keys().next().value;
-          if (oldest !== undefined) usageAccumulators.delete(oldest);
-        }
-        acc = new TurnTokenUsageAccumulator();
-        usageAccumulators.set(turnId, acc);
+    if (turnId) {
+      const usage = (params.tokenUsage ?? {}) as JsonObject;
+      const total = parseCodexTokenBreakdown(usage.total);
+      const last = parseCodexTokenBreakdown(usage.last);
+      const acc = getOrCreateUsageAccumulator(turnId);
+      if (total && last) {
+        acc.update(total, last);
+      } else {
+        // Malformed usage for a KNOWN turn: poison it (sticky). Silently skipping
+        // would let a later valid notification rebuild a fresh baseline and report
+        // only the last completion — a plausible-looking undercount.
+        acc.poison('malformed tokenUsage notification');
       }
-      acc.update(total, last);
     }
   }
   controller?.handleNotification(msg);

--- a/src/codex-app-runner.ts
+++ b/src/codex-app-runner.ts
@@ -20,6 +20,10 @@ import {
   decodeCodexAppRunnerInput,
   type CodexAppRunnerInput,
 } from './services/codex-app-runner-protocol.js';
+import {
+  TurnTokenUsageAccumulator,
+  parseCodexTokenBreakdown,
+} from './services/codex-app-token-usage.js';
 
 type JsonObject = Record<string, any>;
 
@@ -269,6 +273,12 @@ let codexVersion: CodexVersion | undefined;
 let cleanVersionWarningShown = false;
 let controller: CodexAppTurnController;
 
+/** Per-turn token accumulators keyed by codex appTurnId. Fed by
+ *  thread/tokenUsage/updated notifications; drained (and deleted) when the
+ *  matching turn's final marker is emitted. Bounded by turn lifetime — a turn
+ *  that never finalizes leaves at most one stale entry, cleared on next final. */
+const usageAccumulators = new Map<string, TurnTokenUsageAccumulator>();
+
 function detectedCodexVersion(): CodexVersion | undefined {
   if (codexVersionChecked) return codexVersion;
   codexVersionChecked = true;
@@ -320,6 +330,21 @@ function handleServerRequest(msg: JsonObject): boolean {
 }
 
 function handleNotification(msg: JsonObject): void {
+  // Per-turn token usage rides on thread/tokenUsage/updated (NOT turn/completed).
+  // Feed the accumulator for the matching appTurnId; the controller ignores this
+  // method, so we handle it here and still delegate for everything else.
+  if (msg.method === 'thread/tokenUsage/updated') {
+    const params = (msg.params ?? {}) as JsonObject;
+    const turnId = typeof params.turnId === 'string' ? params.turnId : undefined;
+    const usage = (params.tokenUsage ?? {}) as JsonObject;
+    const total = parseCodexTokenBreakdown(usage.total);
+    const last = parseCodexTokenBreakdown(usage.last);
+    if (turnId && total && last) {
+      let acc = usageAccumulators.get(turnId);
+      if (!acc) { acc = new TurnTokenUsageAccumulator(); usageAccumulators.set(turnId, acc); }
+      acc.update(total, last);
+    }
+  }
   controller?.handleNotification(msg);
 }
 
@@ -453,7 +478,12 @@ controller = new CodexAppTurnController({
   onDiagnostic: writeLine,
   onLifecycle: event => emitMarker('lifecycle', event),
   onFinal: marker => {
-    emitMarker('final', marker);
+    // Attach this turn's token usage (if the accumulator saw coherent totals)
+    // and drain its accumulator. Omitted when no usage was observed — never zeros.
+    const acc = marker.appTurnId ? usageAccumulators.get(marker.appTurnId) : undefined;
+    const usage = acc?.result() ?? undefined;
+    if (marker.appTurnId) usageAccumulators.delete(marker.appTurnId);
+    emitMarker('final', usage ? { ...marker, usage } : marker);
     writeLine();
   },
   onPrompt: prompt,

--- a/src/codex-app-runner.ts
+++ b/src/codex-app-runner.ts
@@ -278,6 +278,9 @@ let controller: CodexAppTurnController;
  *  matching turn's final marker is emitted. Bounded by turn lifetime — a turn
  *  that never finalizes leaves at most one stale entry, cleared on next final. */
 const usageAccumulators = new Map<string, TurnTokenUsageAccumulator>();
+/** Only one turn is active at a time; a small cap bounds leakage from turns
+ *  that never emit a final marker. */
+const MAX_USAGE_ACCUMULATORS = 8;
 
 function detectedCodexVersion(): CodexVersion | undefined {
   if (codexVersionChecked) return codexVersion;
@@ -341,7 +344,17 @@ function handleNotification(msg: JsonObject): void {
     const last = parseCodexTokenBreakdown(usage.last);
     if (turnId && total && last) {
       let acc = usageAccumulators.get(turnId);
-      if (!acc) { acc = new TurnTokenUsageAccumulator(); usageAccumulators.set(turnId, acc); }
+      if (!acc) {
+        // Bounded pruning: a turn that never emits a final marker (crash/interrupt)
+        // would otherwise leak its accumulator. Only one turn is active at a time,
+        // so a tiny cap suffices — evict the oldest insertion when exceeded.
+        if (usageAccumulators.size >= MAX_USAGE_ACCUMULATORS) {
+          const oldest = usageAccumulators.keys().next().value;
+          if (oldest !== undefined) usageAccumulators.delete(oldest);
+        }
+        acc = new TurnTokenUsageAccumulator();
+        usageAccumulators.set(turnId, acc);
+      }
       acc.update(total, last);
     }
   }
@@ -482,6 +495,11 @@ controller = new CodexAppTurnController({
     // and drain its accumulator. Omitted when no usage was observed — never zeros.
     const acc = marker.appTurnId ? usageAccumulators.get(marker.appTurnId) : undefined;
     const usage = acc?.result() ?? undefined;
+    // Surface a protocol anomaly rather than silently omitting usage — a
+    // regression/negative-baseline should be visible in the runner log.
+    if (acc?.warning && !usage) {
+      writeLine(`[codex-app] token usage dropped for turn ${marker.appTurnId ?? '?'}: ${acc.warning}`);
+    }
     if (marker.appTurnId) usageAccumulators.delete(marker.appTurnId);
     emitMarker('final', usage ? { ...marker, usage } : marker);
     writeLine();

--- a/src/codex-app-runner.ts
+++ b/src/codex-app-runner.ts
@@ -368,6 +368,10 @@ function handleNotification(msg: JsonObject): void {
         // only the last completion — a plausible-looking undercount.
         acc.poison('malformed tokenUsage notification');
       }
+    } else {
+      // No turnId to attribute usage to — can't fold it into any turn. Surface a
+      // protocol warning rather than dropping it entirely silently.
+      writeLine('[codex-app] tokenUsage notification without turnId (ignored)');
     }
   }
   controller?.handleNotification(msg);

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -905,7 +905,7 @@ function buildAsyncTriggerLookupResponse(sessionId: string, triggerId?: string):
     sessionId,
     liveActive: !!ds,
     chatId: ds?.chatId ?? stored?.chatId,
-    memResult: memResult ? { status: memResult.status, content: memResult.content, completedAt: memResult.completedAt } : undefined,
+    memResult: memResult ? { status: memResult.status, content: memResult.content, completedAt: memResult.completedAt, usage: memResult.usage } : undefined,
     memTriggerId: memResult ? memTriggerId : undefined,
     persisted,
     storedStatus: stored ? (stored.status === 'closed' ? 'closed' : 'open') : undefined,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -222,6 +222,7 @@ export interface DaemonSession {
     createdAt: number;
     completedAt?: number;
     content?: string;
+    usage?: { inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheCreateTokens: number };
   }>;
   latestAsyncTriggerId?: string;
   /** Stable turn ids whose automatic transcript fallback is capture/discard.

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -4152,10 +4152,11 @@ function deliverFinalOutput(
     asyncResult.status = 'completed';
     asyncResult.content = msg.content;
     asyncResult.completedAt = completedAt;
+    if (msg.usage) asyncResult.usage = msg.usage;
     // Durably persist the outcome so trigger-result can rebuild `completed`
-    // (with content) after a daemon restart drops the in-memory Map. Stamp the
-    // owning bot for cross-bot isolation.
-    asyncTriggerStore.recordCompleted(ds.session.sessionId, msg.turnId, msg.content, completedAt, ds.larkAppId);
+    // (with content + usage) after a daemon restart drops the in-memory Map.
+    // Stamp the owning bot for cross-bot isolation.
+    asyncTriggerStore.recordCompleted(ds.session.sessionId, msg.turnId, msg.content, completedAt, ds.larkAppId, msg.usage);
     ds.lastBridgeEmittedUuid = finalOutputDedupeKey(ds, msg);
     logger.info(`[${t}] Captured final_output for Async HTTP request (turn ${msg.turnId.substring(0, 8)})`);
     return;

--- a/src/services/async-trigger-state.ts
+++ b/src/services/async-trigger-state.ts
@@ -62,6 +62,13 @@ export function decideAsyncOwnership(inp: OwnershipInputs): OwnershipDecision {
 }
 
 
+export interface TurnUsageBuckets {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+}
+
 export interface AsyncStateInputs {
   sessionId: string;
   /** Whether a live DaemonSession is currently registered for this id. */
@@ -69,13 +76,13 @@ export interface AsyncStateInputs {
   /** chatId from the live session or the stored record, if known. */
   chatId?: string;
   /** In-memory async result for the resolved trigger, if the session is live. */
-  memResult?: { status: 'pending' | 'completed'; content?: string; completedAt?: number };
+  memResult?: { status: 'pending' | 'completed'; content?: string; completedAt?: number; usage?: TurnUsageBuckets };
   /** triggerId the in-memory result is keyed under (latest or explicit). */
   memTriggerId?: string;
   /** Durable persisted result (survives restart), if any. */
   persisted?: {
     triggerId: string;
-    result: { status: 'pending' | 'completed'; content?: string; completedAt?: number };
+    result: { status: 'pending' | 'completed'; content?: string; completedAt?: number; usage?: TurnUsageBuckets };
   };
   /** On-disk session record status: 'open' (active), 'closed', or absent. */
   storedStatus?: 'open' | 'closed';
@@ -112,10 +119,10 @@ export function resolveAsyncTriggerState(inp: AsyncStateInputs): TriggerResponse
 
   const completed =
     (inp.memResult?.status === 'completed' && inp.memTriggerId
-      ? { triggerId: inp.memTriggerId, content: inp.memResult.content, completedAt: inp.memResult.completedAt }
+      ? { triggerId: inp.memTriggerId, content: inp.memResult.content, completedAt: inp.memResult.completedAt, usage: inp.memResult.usage }
       : undefined) ??
     (inp.persisted?.result.status === 'completed'
-      ? { triggerId: inp.persisted.triggerId, content: inp.persisted.result.content, completedAt: inp.persisted.result.completedAt }
+      ? { triggerId: inp.persisted.triggerId, content: inp.persisted.result.content, completedAt: inp.persisted.result.completedAt, usage: inp.persisted.result.usage }
       : undefined);
 
   if (completed) {
@@ -127,6 +134,7 @@ export function resolveAsyncTriggerState(inp: AsyncStateInputs): TriggerResponse
       action: 'completed',
       target: { kind: 'turn', sessionId, chatId },
       output: completed.content !== undefined ? { content: completed.content } : undefined,
+      ...(completed.usage ? { usage: completed.usage } : {}),
       finishedAt,
       async: { status: 'completed', sessionId, completedAt: finishedAt },
       message: 'async trigger completed',

--- a/src/services/async-trigger-store.ts
+++ b/src/services/async-trigger-store.ts
@@ -31,6 +31,14 @@ export interface PersistedAsyncTriggerResult {
   createdAt: number;
   completedAt?: number;
   content?: string;
+  /** Per-turn token usage captured at completion (codex-app). Optional — omitted
+   *  when the turn produced no coherent usage. */
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreateTokens: number;
+  };
 }
 
 /** On-disk shape: { ownerLarkAppId, latestTriggerId, results }. ownerLarkAppId
@@ -96,8 +104,15 @@ export function recordPending(sessionId: string, triggerId: string, createdAt: n
 }
 
 /** Mark an async trigger completed with its captured final output.
- *  `ownerLarkAppId` is REQUIRED (see recordPending). */
-export function recordCompleted(sessionId: string, triggerId: string, content: string, completedAt: number, ownerLarkAppId: string): void {
+ *  `ownerLarkAppId` is REQUIRED (see recordPending). `usage` optional per-turn tokens. */
+export function recordCompleted(
+  sessionId: string,
+  triggerId: string,
+  content: string,
+  completedAt: number,
+  ownerLarkAppId: string,
+  usage?: PersistedAsyncTriggerResult['usage'],
+): void {
   const file = load(sessionId);
   if (ownerLarkAppId) file.ownerLarkAppId = ownerLarkAppId;
   const prev = file.results[triggerId];
@@ -106,6 +121,7 @@ export function recordCompleted(sessionId: string, triggerId: string, content: s
     createdAt: prev?.createdAt ?? completedAt,
     completedAt,
     content,
+    ...(usage ? { usage } : {}),
   };
   if (!file.latestTriggerId) file.latestTriggerId = triggerId;
   save(sessionId, file);

--- a/src/services/codex-app-runner-protocol.ts
+++ b/src/services/codex-app-runner-protocol.ts
@@ -155,15 +155,17 @@ export function normalizeAppRunnerFinalMarker(payload: unknown): CodexAppFinalMa
   };
 }
 
-/** Accept the four-bucket usage only when all fields are finite numbers, else
- *  drop it (the daemon then omits usage rather than persisting partial data). */
+/** Accept the four-bucket usage only when every field is a non-negative integer
+ *  (a token count), else drop it (daemon omits usage rather than persisting a
+ *  negative/fractional/partial value that a compromised or buggy runner sent). */
 function normalizeFinalUsage(raw: unknown): CodexAppFinalMarker['usage'] | undefined {
   if (!isRecord(raw)) return undefined;
   const keys = ['inputTokens', 'outputTokens', 'cacheReadTokens', 'cacheCreateTokens'] as const;
   const out = {} as NonNullable<CodexAppFinalMarker['usage']>;
   for (const k of keys) {
-    if (typeof raw[k] !== 'number' || !Number.isFinite(raw[k])) return undefined;
-    out[k] = raw[k] as number;
+    const v = raw[k];
+    if (typeof v !== 'number' || !Number.isInteger(v) || v < 0) return undefined;
+    out[k] = v;
   }
   return out;
 }

--- a/src/services/codex-app-runner-protocol.ts
+++ b/src/services/codex-app-runner-protocol.ts
@@ -22,6 +22,15 @@ export interface CodexAppFinalMarker {
   replyTurnId?: string;
   /** Pre-steer Codex App and Mira markers used one id for both domains. */
   legacyTurnId?: string;
+  /** Per-turn token usage (four mutually-exclusive buckets), when the turn's
+   *  thread/tokenUsage/updated notifications yielded a coherent total. Omitted
+   *  when no usage was observed / a protocol anomaly was detected. */
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreateTokens: number;
+  };
 }
 
 interface CodexAppLifecycleBase {
@@ -142,7 +151,21 @@ export function normalizeAppRunnerFinalMarker(payload: unknown): CodexAppFinalMa
     appTurnId: optionalNonEmptyString(payload.appTurnId),
     replyTurnId: optionalNonEmptyString(payload.replyTurnId),
     legacyTurnId: optionalNonEmptyString(payload.turnId),
+    usage: normalizeFinalUsage(payload.usage),
   };
+}
+
+/** Accept the four-bucket usage only when all fields are finite numbers, else
+ *  drop it (the daemon then omits usage rather than persisting partial data). */
+function normalizeFinalUsage(raw: unknown): CodexAppFinalMarker['usage'] | undefined {
+  if (!isRecord(raw)) return undefined;
+  const keys = ['inputTokens', 'outputTokens', 'cacheReadTokens', 'cacheCreateTokens'] as const;
+  const out = {} as NonNullable<CodexAppFinalMarker['usage']>;
+  for (const k of keys) {
+    if (typeof raw[k] !== 'number' || !Number.isFinite(raw[k])) return undefined;
+    out[k] = raw[k] as number;
+  }
+  return out;
 }
 
 export function normalizeCodexAppLifecycleEvent(payload: unknown): CodexAppLifecycleEvent | undefined {

--- a/src/services/codex-app-token-usage.ts
+++ b/src/services/codex-app-token-usage.ts
@@ -44,21 +44,32 @@ function isFiniteNum(v: unknown): v is number {
   return typeof v === 'number' && Number.isFinite(v);
 }
 
-/** Validate a raw notification payload's breakdown into a typed one, or null. */
+/** Token counts are non-negative integers; a negative or fractional value is a
+ *  protocol violation, not a real count. */
+function isTokenCount(v: unknown): v is number {
+  return isFiniteNum(v) && Number.isInteger(v) && v >= 0;
+}
+
+/** Validate a raw notification payload's breakdown into a typed one, or null.
+ *  0.145 fields are REQUIRED except `cacheWriteInputTokens` (added later, so a
+ *  compat default of 0 is honest for it only). Any other missing/non-numeric
+ *  field returns null — defaulting them to 0 would misreport a protocol gap as a
+ *  real 0. */
 export function parseCodexTokenBreakdown(raw: unknown): CodexTokenBreakdown | null {
   if (!raw || typeof raw !== 'object') return null;
   const r = raw as Record<string, unknown>;
-  const keys: (keyof CodexTokenBreakdown)[] = [
-    'totalTokens', 'inputTokens', 'cachedInputTokens',
-    'cacheWriteInputTokens', 'outputTokens', 'reasoningOutputTokens',
+  const required: (keyof CodexTokenBreakdown)[] = [
+    'totalTokens', 'inputTokens', 'cachedInputTokens', 'outputTokens', 'reasoningOutputTokens',
   ];
   const out = {} as CodexTokenBreakdown;
-  for (const k of keys) {
-    // Missing fields default to 0 (older/partial payloads); present-but-nonnumeric is invalid.
-    if (r[k] === undefined) { out[k] = 0; continue; }
-    if (!isFiniteNum(r[k])) return null;
+  for (const k of required) {
+    if (!isTokenCount(r[k])) return null; // required non-negative integer; else protocol gap
     out[k] = r[k] as number;
   }
+  // cacheWriteInputTokens: back-compat optional; absent → 0, present must be a token count.
+  if (r.cacheWriteInputTokens === undefined) out.cacheWriteInputTokens = 0;
+  else if (!isTokenCount(r.cacheWriteInputTokens)) return null;
+  else out.cacheWriteInputTokens = r.cacheWriteInputTokens as number;
   return out;
 }
 
@@ -88,10 +99,18 @@ export class TurnTokenUsageAccumulator {
     if (this.baseline === null) {
       // baseline = total - last, per field. This lets a mid-session / resumed
       // turn measure only its own tokens without knowing prior session totals.
-      this.baseline = subtract(total, last);
+      // A negative field means total < last — impossible if `last` is a subset
+      // of the cumulative `total`; treat as a protocol anomaly and fail closed
+      // rather than derive a bogus baseline that inflates the turn.
+      const baseline = subtract(total, last);
+      if (!allNonNegative(baseline)) {
+        this.protocolWarning = 'tokenUsage baseline (total-last) went negative';
+        return;
+      }
+      this.baseline = baseline;
     }
-    // total must be monotonic non-decreasing vs the last seen; a regression is a
-    // protocol anomaly → fail closed (stop trusting usage for this turn).
+    // total must be monotonic non-decreasing vs the last seen ACROSS ALL FIELDS;
+    // a regression in any field is a protocol anomaly → fail closed.
     if (this.latestTotal && !isGreaterOrEqual(total, this.latestTotal)) {
       this.protocolWarning = 'tokenUsage.total regressed';
       return;
@@ -124,9 +143,14 @@ function subtract(a: CodexTokenBreakdown, b: CodexTokenBreakdown): CodexTokenBre
 }
 
 function isGreaterOrEqual(a: CodexTokenBreakdown, b: CodexTokenBreakdown): boolean {
+  // Every cumulative field must be monotonic — a regression in ANY (including
+  // cacheRead/cacheWrite/reasoning) is a protocol anomaly, not just total/in/out.
   return a.totalTokens >= b.totalTokens
     && a.inputTokens >= b.inputTokens
-    && a.outputTokens >= b.outputTokens;
+    && a.cachedInputTokens >= b.cachedInputTokens
+    && a.cacheWriteInputTokens >= b.cacheWriteInputTokens
+    && a.outputTokens >= b.outputTokens
+    && a.reasoningOutputTokens >= b.reasoningOutputTokens;
 }
 
 function allNonNegative(d: CodexTokenBreakdown): boolean {

--- a/src/services/codex-app-token-usage.ts
+++ b/src/services/codex-app-token-usage.ts
@@ -54,7 +54,13 @@ function isTokenCount(v: unknown): v is number {
  *  0.145 fields are REQUIRED except `cacheWriteInputTokens` (added later, so a
  *  compat default of 0 is honest for it only). Any other missing/non-numeric
  *  field returns null — defaulting them to 0 would misreport a protocol gap as a
- *  real 0. */
+ *  real 0.
+ *
+ *  NOTE: when `total` and `last` are consumed together (the accumulator), prefer
+ *  `parseTokenUsagePair` — it additionally enforces that the back-compat
+ *  cacheWrite default is only honored when BOTH sides omit the field. A lone
+ *  breakdown parsed here cannot see its counterpart, so a `cacheWrite=0` default
+ *  here is provisional until the pair check confirms symmetry. */
 export function parseCodexTokenBreakdown(raw: unknown): CodexTokenBreakdown | null {
   if (!raw || typeof raw !== 'object') return null;
   const r = raw as Record<string, unknown>;
@@ -71,6 +77,35 @@ export function parseCodexTokenBreakdown(raw: unknown): CodexTokenBreakdown | nu
   else if (!isTokenCount(r.cacheWriteInputTokens)) return null;
   else out.cacheWriteInputTokens = r.cacheWriteInputTokens as number;
   return out;
+}
+
+/** True when a raw breakdown object carries `cacheWriteInputTokens` on the wire
+ *  (vs. omitting it — the pre-cacheWrite codex versions the compat default is
+ *  meant for). */
+function hasCacheWriteField(raw: unknown): boolean {
+  return !!raw && typeof raw === 'object'
+    && (raw as Record<string, unknown>).cacheWriteInputTokens !== undefined;
+}
+
+/** Parse the `{ total, last }` pair from one notification, enforcing the
+ *  cross-breakdown invariant the single parser can't see: the back-compat
+ *  `cacheWriteInputTokens → 0` default is honest ONLY when BOTH breakdowns omit
+ *  the field (a genuinely old codex). If exactly one side carries it, the two
+ *  disagree (version skew / corruption): silently defaulting the missing side to
+ *  0 would misattribute real cache-create tokens into fresh input AND poison the
+ *  baseline for later completions with a plausible-looking undercount. Return
+ *  null so the caller poisons the turn instead of emitting corrupt buckets. */
+export function parseTokenUsagePair(
+  rawTotal: unknown,
+  rawLast: unknown,
+): { total: CodexTokenBreakdown; last: CodexTokenBreakdown } | null {
+  const total = parseCodexTokenBreakdown(rawTotal);
+  const last = parseCodexTokenBreakdown(rawLast);
+  if (!total || !last) return null;
+  // Asymmetric cacheWrite presence ⇒ the 0-default on the missing side is a
+  // guess, not a fact. Refuse rather than fabricate a wrong split.
+  if (hasCacheWriteField(rawTotal) !== hasCacheWriteField(rawLast)) return null;
+  return { total, last };
 }
 
 /** Map a cumulative-delta codex breakdown to riff's four mutually-exclusive
@@ -128,12 +163,23 @@ export class TurnTokenUsageAccumulator {
   }
 
   /** The turn's usage so far as four buckets, or null if no usage seen / a
-   *  protocol anomaly was detected / the bucket split is incoherent. */
+   *  protocol anomaly was detected / the bucket split is incoherent. When usage
+   *  is dropped for an incoherent delta or bucket split (as opposed to simply
+   *  never having seen a notification), a warning is recorded so the caller can
+   *  surface the omission rather than dropping it silently. */
   result(): TurnTokenUsage | null {
     if (this.protocolWarning || !this.baseline || !this.latestTotal) return null;
     const delta = subtract(this.latestTotal, this.baseline);
-    if (!allNonNegative(delta)) return null;
-    return toFourBucket(delta);
+    if (!allNonNegative(delta)) {
+      this.protocolWarning = 'tokenUsage delta (latestTotal-baseline) went negative';
+      return null;
+    }
+    const buckets = toFourBucket(delta);
+    if (!buckets) {
+      this.protocolWarning = 'tokenUsage bucket split incoherent (cache buckets exceed input)';
+      return null;
+    }
+    return buckets;
   }
 
   /** Non-null when the accumulator gave up on usage for a protocol reason. */

--- a/src/services/codex-app-token-usage.ts
+++ b/src/services/codex-app-token-usage.ts
@@ -1,0 +1,135 @@
+/**
+ * Per-turn token-usage accumulator for the codex app-server protocol.
+ *
+ * codex emits token usage via `thread/tokenUsage/updated` notifications, NOT on
+ * `turn/completed` (whose Turn object carries no usage). A single codex turn can
+ * produce MANY upstream completions (tool-call loops), so the notification's
+ * `tokenUsage.last` is only the LAST completion's usage — never the whole turn.
+ * The authoritative per-turn figure is a delta of the cumulative `total`:
+ *
+ *   - on the first notification for a turn, derive baseline = total - last
+ *     (per field), so a resumed session needs no prior session-total knowledge;
+ *   - the turn's usage so far = latestTotal - baseline (per field);
+ *   - later notifications only advance latestTotal (total-delta is idempotent
+ *     against duplicate notifications — never sum `last`, never overwrite).
+ *
+ * Fail-closed: if `total` regresses or any derived field goes negative, the
+ * usage is dropped (returns null) and the caller logs a protocol warning rather
+ * than reporting corrupt numbers.
+ *
+ * Ref: codex protocol TokenUsageInfo::append_last_usage (total += last; last =
+ * this completion) and app-server ThreadTokenUsageUpdatedNotification /
+ * TokenUsageBreakdown (0.145 generated types).
+ */
+
+/** codex TokenUsageBreakdown (0.145). All numbers; cumulative on `total`. */
+export interface CodexTokenBreakdown {
+  totalTokens: number;
+  inputTokens: number;
+  cachedInputTokens: number;
+  cacheWriteInputTokens: number;
+  outputTokens: number;
+  reasoningOutputTokens: number;
+}
+
+/** riff-facing four-bucket usage (mutually exclusive input buckets). */
+export interface TurnTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+}
+
+function isFiniteNum(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v);
+}
+
+/** Validate a raw notification payload's breakdown into a typed one, or null. */
+export function parseCodexTokenBreakdown(raw: unknown): CodexTokenBreakdown | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const keys: (keyof CodexTokenBreakdown)[] = [
+    'totalTokens', 'inputTokens', 'cachedInputTokens',
+    'cacheWriteInputTokens', 'outputTokens', 'reasoningOutputTokens',
+  ];
+  const out = {} as CodexTokenBreakdown;
+  for (const k of keys) {
+    // Missing fields default to 0 (older/partial payloads); present-but-nonnumeric is invalid.
+    if (r[k] === undefined) { out[k] = 0; continue; }
+    if (!isFiniteNum(r[k])) return null;
+    out[k] = r[k] as number;
+  }
+  return out;
+}
+
+/** Map a cumulative-delta codex breakdown to riff's four mutually-exclusive
+ *  buckets. codex `inputTokens` INCLUDES cached-read + cache-write, so the
+ *  fresh-input bucket subtracts both. Returns null if the split is incoherent
+ *  (buckets exceed input) — caller drops usage + warns rather than emit garbage. */
+export function toFourBucket(d: CodexTokenBreakdown): TurnTokenUsage | null {
+  const cacheReadTokens = d.cachedInputTokens;
+  const cacheCreateTokens = d.cacheWriteInputTokens;
+  const outputTokens = d.outputTokens; // reasoningOutputTokens is a subset — never add
+  const inputTokens = d.inputTokens - cacheReadTokens - cacheCreateTokens;
+  if (cacheReadTokens < 0 || cacheCreateTokens < 0 || outputTokens < 0 || inputTokens < 0) return null;
+  return { inputTokens, outputTokens, cacheReadTokens, cacheCreateTokens };
+}
+
+/** Accumulates per-turn usage from `thread/tokenUsage/updated` notifications for
+ *  ONE appTurnId, using the total-delta algorithm. */
+export class TurnTokenUsageAccumulator {
+  private baseline: CodexTokenBreakdown | null = null;
+  private latestTotal: CodexTokenBreakdown | null = null;
+  private protocolWarning: string | undefined;
+
+  /** Feed a notification's `tokenUsage` = { total, last, ... }. `total` is
+   *  cumulative; `last` is the most recent completion's usage. */
+  update(total: CodexTokenBreakdown, last: CodexTokenBreakdown): void {
+    if (this.baseline === null) {
+      // baseline = total - last, per field. This lets a mid-session / resumed
+      // turn measure only its own tokens without knowing prior session totals.
+      this.baseline = subtract(total, last);
+    }
+    // total must be monotonic non-decreasing vs the last seen; a regression is a
+    // protocol anomaly → fail closed (stop trusting usage for this turn).
+    if (this.latestTotal && !isGreaterOrEqual(total, this.latestTotal)) {
+      this.protocolWarning = 'tokenUsage.total regressed';
+      return;
+    }
+    this.latestTotal = total;
+  }
+
+  /** The turn's usage so far as four buckets, or null if no usage seen / a
+   *  protocol anomaly was detected / the bucket split is incoherent. */
+  result(): TurnTokenUsage | null {
+    if (this.protocolWarning || !this.baseline || !this.latestTotal) return null;
+    const delta = subtract(this.latestTotal, this.baseline);
+    if (!allNonNegative(delta)) return null;
+    return toFourBucket(delta);
+  }
+
+  /** Non-null when the accumulator gave up on usage for a protocol reason. */
+  get warning(): string | undefined { return this.protocolWarning; }
+}
+
+function subtract(a: CodexTokenBreakdown, b: CodexTokenBreakdown): CodexTokenBreakdown {
+  return {
+    totalTokens: a.totalTokens - b.totalTokens,
+    inputTokens: a.inputTokens - b.inputTokens,
+    cachedInputTokens: a.cachedInputTokens - b.cachedInputTokens,
+    cacheWriteInputTokens: a.cacheWriteInputTokens - b.cacheWriteInputTokens,
+    outputTokens: a.outputTokens - b.outputTokens,
+    reasoningOutputTokens: a.reasoningOutputTokens - b.reasoningOutputTokens,
+  };
+}
+
+function isGreaterOrEqual(a: CodexTokenBreakdown, b: CodexTokenBreakdown): boolean {
+  return a.totalTokens >= b.totalTokens
+    && a.inputTokens >= b.inputTokens
+    && a.outputTokens >= b.outputTokens;
+}
+
+function allNonNegative(d: CodexTokenBreakdown): boolean {
+  return d.totalTokens >= 0 && d.inputTokens >= 0 && d.cachedInputTokens >= 0
+    && d.cacheWriteInputTokens >= 0 && d.outputTokens >= 0 && d.reasoningOutputTokens >= 0;
+}

--- a/src/services/codex-app-token-usage.ts
+++ b/src/services/codex-app-token-usage.ts
@@ -118,6 +118,15 @@ export class TurnTokenUsageAccumulator {
     this.latestTotal = total;
   }
 
+  /** Mark this turn's usage as unusable (sticky). Called when a notification for
+   *  the turn arrives but its breakdown is malformed: skipping it silently would
+   *  let a LATER valid notification rebuild a fresh baseline and report only the
+   *  last completion — a plausible-looking undercount. Poisoning makes result()
+   *  omit + warn instead. */
+  poison(reason: string): void {
+    if (!this.protocolWarning) this.protocolWarning = reason;
+  }
+
   /** The turn's usage so far as four buckets, or null if no usage seen / a
    *  protocol anomaly was detected / the bucket split is incoherent. */
   result(): TurnTokenUsage | null {

--- a/src/services/trigger-types.ts
+++ b/src/services/trigger-types.ts
@@ -117,6 +117,15 @@ export interface TriggerResponse {
   output?: {
     content: string;
   };
+  /** Per-turn token usage for a completed async turn (codex-app). Present on
+   *  `state:'completed'` when captured; omitted otherwise. Field names mirror the
+   *  caller's TaskTokenUsage. */
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreateTokens: number;
+  };
   async?: {
     status: TriggerAsyncStatus;
     sessionId?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -745,6 +745,14 @@ export type WorkerToDaemon =
       // which mixes presentation with payload).
       kind?: 'bridge' | 'local-turn' | 'local-turn-headless';
       userText?: string;
+      /** Per-turn token usage (codex-app). Daemon persists it with the async
+       *  trigger result so trigger-result's completed state can report it. */
+      usage?: {
+        inputTokens: number;
+        outputTokens: number;
+        cacheReadTokens: number;
+        cacheCreateTokens: number;
+      };
     }
   | {
       type: 'turn_terminal';

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4970,6 +4970,7 @@ function handleCodexAppMarker(body: string): void {
         lastUuid: identity.lastUuid,
         turnId: identity.turnId,
         ...(dispatchAttempt !== undefined ? { dispatchAttempt } : {}),
+        ...(marker.usage ? { usage: marker.usage } : {}),
       });
       emitTurnTerminal(identity.turnId, 'completed', undefined, dispatchAttempt);
       return;

--- a/test/async-trigger-state.test.ts
+++ b/test/async-trigger-state.test.ts
@@ -82,6 +82,28 @@ describe('resolveAsyncTriggerState — completed', () => {
     expect(r.triggerId).toBe('trg_a');
   });
 
+  it('emits per-turn usage from the completed result (mem and persisted), omits when absent', () => {
+    const usage = { inputTokens: 60, outputTokens: 30, cacheReadTokens: 40, cacheCreateTokens: 0 };
+    const fromMem = resolveAsyncTriggerState({
+      sessionId: 's1', liveActive: true, storedStatus: 'open', memTriggerId: 'trg_a',
+      memResult: { status: 'completed', content: 'x', completedAt: 1, usage },
+    });
+    expect(fromMem.usage).toEqual(usage);
+
+    const fromDisk = resolveAsyncTriggerState({
+      sessionId: 's1', liveActive: false, storedStatus: 'closed',
+      persisted: { triggerId: 'trg_a', result: { status: 'completed', content: 'x', completedAt: 1, usage } },
+    });
+    expect(fromDisk.usage).toEqual(usage);
+
+    const noUsage = resolveAsyncTriggerState({
+      sessionId: 's1', liveActive: true, storedStatus: 'open', memTriggerId: 'trg_a',
+      memResult: { status: 'completed', content: 'x', completedAt: 1 },
+    });
+    expect(noUsage.state).toBe('completed');
+    expect(noUsage.usage).toBeUndefined();
+  });
+
   it('rebuilt from durable result after restart (no live session)', () => {
     // Simulates daemon restart: no live ds, in-memory Map gone, but the
     // session record is closed and the durable result says completed.

--- a/test/async-trigger-store.test.ts
+++ b/test/async-trigger-store.test.ts
@@ -113,6 +113,17 @@ describe('owner stamping (cross-bot isolation)', () => {
     expect(lookup('sess1')?.ownerLarkAppId).toBe('cli_botA');
   });
 
+  it('persists per-turn usage and returns it on lookup (survives reload)', () => {
+    const usage = { inputTokens: 60, outputTokens: 30, cacheReadTokens: 40, cacheCreateTokens: 0 };
+    recordCompleted('sess1', 'trg_a', 'done', 5000, 'cli_botA', usage);
+    expect(lookup('sess1')?.result.usage).toEqual(usage);
+  });
+
+  it('omits usage when none is recorded', () => {
+    recordCompleted('sess1', 'trg_a', 'done', 5000, 'cli_botA');
+    expect(lookup('sess1')?.result.usage).toBeUndefined();
+  });
+
   it('owner persists across pending → completed', () => {
     recordPending('sess1', 'trg_a', 1000, 'cli_botA');
     recordCompleted('sess1', 'trg_a', 'x', 5000, ''); // no owner on completion (legacy-unstamped)

--- a/test/async-usage-glue.test.ts
+++ b/test/async-usage-glue.test.ts
@@ -8,7 +8,7 @@
  * Run: pnpm vitest run test/async-usage-glue.test.ts
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -77,5 +77,24 @@ describe('final_output → durable usage persistence (memory + disk + restart)',
 
     expect(ds.asyncTriggerResults.get('trg_b').usage).toBeUndefined();
     expect(asyncTriggerStore.lookup('sess-glue-2', 'trg_b')?.result.usage).toBeUndefined();
+  });
+});
+
+describe('trigger-result wrapper wires usage from both mem and persisted (source lock)', () => {
+  // The trigger-result composition (buildAsyncTriggerLookupResponse) is module
+  // private and behind the daemon registry, so unit-testing it live needs a heavy
+  // harness. Lock the two spreads that carry usage into resolveAsyncTriggerState —
+  // deleting either (live memResult.usage OR persisted result.usage) fails here,
+  // guarding the exact hop codex flagged. resolveAsyncTriggerState's own mem+disk
+  // usage emission is covered in async-trigger-state.test.ts.
+  it('passes memResult.usage (live path) into the resolver', () => {
+    const src = readFileSync(new URL('../src/core/dashboard-ipc-server.ts', import.meta.url), 'utf8');
+    const call = src.indexOf('resolveAsyncTriggerState({');
+    expect(call).toBeGreaterThan(0);
+    const body = src.slice(call, src.indexOf('});', call));
+    // live in-memory result must forward usage
+    expect(body).toMatch(/memResult\?\.usage|usage: memResult\.usage/);
+    // persisted result is passed whole (its `result.usage` reaches the resolver)
+    expect(body).toContain('persisted');
   });
 });

--- a/test/async-usage-glue.test.ts
+++ b/test/async-usage-glue.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Glue test: the daemon's final_output handler persists per-turn usage all the
+ * way into the durable async-trigger store (memory + disk), and it survives a
+ * "restart" (a fresh store lookup with no in-memory Map). This is the hop the
+ * unit tests can't cover — deleting the `msg.usage` spread at the recording site
+ * makes this go red.
+ *
+ * Run: pnpm vitest run test/async-usage-glue.test.ts
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+let tempDir: string;
+
+// Real async-trigger-store, but its dataDir points at a temp dir so we assert
+// actual on-disk persistence. config is the only dep the async branch needs.
+vi.mock('../src/config.js', () => ({
+  config: {
+    web: { externalHost: 'localhost' },
+    session: { get dataDir() { return tempDir; } },
+    daemon: { backendType: 'tmux', cliId: 'claude-code' },
+  },
+}));
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import * as asyncTriggerStore from '../src/services/async-trigger-store.js';
+import { __testOnly_deliverFinalOutput } from '../src/core/worker-pool.js';
+
+const USAGE = { inputTokens: 60, outputTokens: 30, cacheReadTokens: 40, cacheCreateTokens: 0 };
+
+function armedDs(sessionId: string, turnId: string): any {
+  // Minimal DaemonSession shape the async branch of deliverFinalOutput reads.
+  return {
+    session: { sessionId },
+    larkAppId: 'cli_test',
+    asyncTriggerResults: new Map([[turnId, { status: 'pending', createdAt: 1 }]]),
+  };
+}
+
+function finalMsg(turnId: string, withUsage: boolean): any {
+  return {
+    type: 'final_output',
+    content: 'ASYNC_OK',
+    lastUuid: turnId,
+    turnId,
+    ...(withUsage ? { usage: USAGE } : {}),
+  };
+}
+
+beforeEach(() => { tempDir = mkdtempSync(join(tmpdir(), 'async-usage-glue-')); });
+afterEach(() => { rmSync(tempDir, { recursive: true, force: true }); });
+
+describe('final_output → durable usage persistence (memory + disk + restart)', () => {
+  it('persists usage into the async store and it survives a fresh (restart) lookup', () => {
+    const ds = armedDs('sess-glue-1', 'trg_a');
+    asyncTriggerStore.recordPending('sess-glue-1', 'trg_a', 1, 'cli_test');
+
+    __testOnly_deliverFinalOutput(ds, finalMsg('trg_a', true), 'tag', 0);
+
+    // in-memory result carries usage
+    expect(ds.asyncTriggerResults.get('trg_a').usage).toEqual(USAGE);
+    // durable store (fresh read = post-restart, no in-memory Map) carries usage
+    expect(asyncTriggerStore.lookup('sess-glue-1', 'trg_a')?.result.usage).toEqual(USAGE);
+    expect(asyncTriggerStore.lookup('sess-glue-1', 'trg_a')?.result.status).toBe('completed');
+  });
+
+  it('omits usage end-to-end when the final marker had none (never fabricates zeros)', () => {
+    const ds = armedDs('sess-glue-2', 'trg_b');
+    asyncTriggerStore.recordPending('sess-glue-2', 'trg_b', 1, 'cli_test');
+
+    __testOnly_deliverFinalOutput(ds, finalMsg('trg_b', false), 'tag', 0);
+
+    expect(ds.asyncTriggerResults.get('trg_b').usage).toBeUndefined();
+    expect(asyncTriggerStore.lookup('sess-glue-2', 'trg_b')?.result.usage).toBeUndefined();
+  });
+});

--- a/test/codex-app-runner-protocol.test.ts
+++ b/test/codex-app-runner-protocol.test.ts
@@ -129,6 +129,12 @@ describe('app runner final marker normalization', () => {
     // not an object
     expect(normalizeAppRunnerFinalMarker({ content: 'done', usage: 42 }).usage).toBeUndefined();
   });
+
+  it('drops usage with a negative or fractional token count (boundary at the marker layer)', () => {
+    const base = { inputTokens: 10, outputTokens: 5, cacheReadTokens: 2, cacheCreateTokens: 0 };
+    expect(normalizeAppRunnerFinalMarker({ content: 'done', usage: { ...base, inputTokens: -1 } }).usage).toBeUndefined();
+    expect(normalizeAppRunnerFinalMarker({ content: 'done', usage: { ...base, outputTokens: 2.5 } }).usage).toBeUndefined();
+  });
 });
 
 describe('Codex App lifecycle event normalization', () => {

--- a/test/codex-app-runner-protocol.test.ts
+++ b/test/codex-app-runner-protocol.test.ts
@@ -115,6 +115,20 @@ describe('app runner final marker normalization', () => {
     expect(normalizeAppRunnerFinalMarker({ content: 42, appTurnId: 'x' })).toBeUndefined();
     expect(normalizeAppRunnerFinalMarker(null)).toBeUndefined();
   });
+
+  it('passes through a well-formed usage object', () => {
+    const usage = { inputTokens: 60, outputTokens: 30, cacheReadTokens: 40, cacheCreateTokens: 0 };
+    expect(normalizeAppRunnerFinalMarker({ content: 'done', usage }).usage).toEqual(usage);
+  });
+
+  it('drops a malformed usage object (missing/non-numeric field) rather than persist partial', () => {
+    // missing cacheCreateTokens
+    expect(normalizeAppRunnerFinalMarker({ content: 'done', usage: { inputTokens: 1, outputTokens: 1, cacheReadTokens: 1 } }).usage).toBeUndefined();
+    // non-numeric
+    expect(normalizeAppRunnerFinalMarker({ content: 'done', usage: { inputTokens: 'x', outputTokens: 1, cacheReadTokens: 1, cacheCreateTokens: 1 } }).usage).toBeUndefined();
+    // not an object
+    expect(normalizeAppRunnerFinalMarker({ content: 'done', usage: 42 }).usage).toBeUndefined();
+  });
 });
 
 describe('Codex App lifecycle event normalization', () => {

--- a/test/codex-app-runner.integration.test.ts
+++ b/test/codex-app-runner.integration.test.ts
@@ -434,4 +434,32 @@ describe('codex-app-runner app-server protocol integration', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it('folds thread/tokenUsage/updated into the final marker usage (four buckets)', async () => {
+    // Real runner + fake app-server emitting a token-usage notification; assert
+    // the emitted final marker carries the per-turn four-bucket usage.
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-codex-usage-'));
+    const fakeCodex = join(dir, 'fake-codex');
+    const logPath = join(dir, 'requests.jsonl');
+    copyFileSync(FAKE_SERVER_FIXTURE, fakeCodex);
+    chmodSync(fakeCodex, 0o755);
+    let stdout = '';
+    const child = spawn(process.execPath, [
+      '--import', 'tsx', RUNNER_PATH, '--session-id', 'usage-int', '--codex-bin', fakeCodex, '--cwd', dir,
+    ], { cwd: resolve('.'), env: { ...process.env, FAKE_CODEX_LOG: logPath, FAKE_CODEX_VERSION: '0.144.6', FAKE_CODEX_BEHAVIOR: 'success', FAKE_TOKEN_USAGE: '1' }, stdio: ['pipe', 'pipe', 'pipe'] });
+    liveChildren.add(child);
+    child.stdout.on('data', c => { stdout += c.toString('utf8'); });
+    const harness: Harness = { child, get stdout() { return stdout; }, get stderr() { return ''; } };
+    try {
+      await waitForOutput(harness, o => o.includes('Codex App connected.'));
+      child.stdin.write(`${CONTROL_PREFIX}${encodeRunnerInput('hi', { text: 'hi' })}\r`);
+      await waitForOutput(harness, o => FINAL_MARKER.test(o));
+      const final = decodeFinalMarker(harness.stdout);
+      // input=100 total incl cache; cached=40 → fresh input 60, output 30, cacheRead 40.
+      expect(final.usage).toEqual({ inputTokens: 60, outputTokens: 30, cacheReadTokens: 40, cacheCreateTokens: 0 });
+    } finally {
+      await stopChild(child);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/codex-app-runner.integration.test.ts
+++ b/test/codex-app-runner.integration.test.ts
@@ -462,4 +462,31 @@ describe('codex-app-runner app-server protocol integration', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it('omits usage when a malformed tokenUsage notification poisons the turn (sticky)', async () => {
+    // malformed-then-valid same turn: the runner must NOT report only the later
+    // completion. Final marker usage is omitted.
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-codex-poison-'));
+    const fakeCodex = join(dir, 'fake-codex');
+    const logPath = join(dir, 'requests.jsonl');
+    copyFileSync(FAKE_SERVER_FIXTURE, fakeCodex);
+    chmodSync(fakeCodex, 0o755);
+    let stdout = '';
+    const child = spawn(process.execPath, [
+      '--import', 'tsx', RUNNER_PATH, '--session-id', 'usage-poison', '--codex-bin', fakeCodex, '--cwd', dir,
+    ], { cwd: resolve('.'), env: { ...process.env, FAKE_CODEX_LOG: logPath, FAKE_CODEX_VERSION: '0.144.6', FAKE_CODEX_BEHAVIOR: 'success', FAKE_TOKEN_USAGE_POISON: '1' }, stdio: ['pipe', 'pipe', 'pipe'] });
+    liveChildren.add(child);
+    child.stdout.on('data', c => { stdout += c.toString('utf8'); });
+    const harness: Harness = { child, get stdout() { return stdout; }, get stderr() { return ''; } };
+    try {
+      await waitForOutput(harness, o => o.includes('Codex App connected.'));
+      child.stdin.write(`${CONTROL_PREFIX}${encodeRunnerInput('hi', { text: 'hi' })}\r`);
+      await waitForOutput(harness, o => FINAL_MARKER.test(o));
+      const final = decodeFinalMarker(harness.stdout);
+      expect(final.usage).toBeUndefined();
+    } finally {
+      await stopChild(child);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/codex-app-runner.integration.test.ts
+++ b/test/codex-app-runner.integration.test.ts
@@ -489,4 +489,33 @@ describe('codex-app-runner app-server protocol integration', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it('omits usage when asymmetric cacheWrite poisons the turn, even after a later valid packet (codex P1)', async () => {
+    // First packet: total carries cacheWriteInputTokens but last omits it. A
+    // 0-default on the missing side would misattribute cache-create into fresh
+    // input; the runner must poison. A subsequent symmetric packet must not
+    // resurrect a plausible-looking wrong split → final marker usage OMITTED.
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-codex-asym-'));
+    const fakeCodex = join(dir, 'fake-codex');
+    const logPath = join(dir, 'requests.jsonl');
+    copyFileSync(FAKE_SERVER_FIXTURE, fakeCodex);
+    chmodSync(fakeCodex, 0o755);
+    let stdout = '';
+    const child = spawn(process.execPath, [
+      '--import', 'tsx', RUNNER_PATH, '--session-id', 'usage-asym', '--codex-bin', fakeCodex, '--cwd', dir,
+    ], { cwd: resolve('.'), env: { ...process.env, FAKE_CODEX_LOG: logPath, FAKE_CODEX_VERSION: '0.144.6', FAKE_CODEX_BEHAVIOR: 'success', FAKE_TOKEN_USAGE_ASYM: '1' }, stdio: ['pipe', 'pipe', 'pipe'] });
+    liveChildren.add(child);
+    child.stdout.on('data', c => { stdout += c.toString('utf8'); });
+    const harness: Harness = { child, get stdout() { return stdout; }, get stderr() { return ''; } };
+    try {
+      await waitForOutput(harness, o => o.includes('Codex App connected.'));
+      child.stdin.write(`${CONTROL_PREFIX}${encodeRunnerInput('hi', { text: 'hi' })}\r`);
+      await waitForOutput(harness, o => FINAL_MARKER.test(o));
+      const final = decodeFinalMarker(harness.stdout);
+      expect(final.usage).toBeUndefined();
+    } finally {
+      await stopChild(child);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/codex-app-token-usage.test.ts
+++ b/test/codex-app-token-usage.test.ts
@@ -38,11 +38,17 @@ describe('toFourBucket', () => {
 });
 
 describe('parseCodexTokenBreakdown', () => {
-  it('defaults missing fields to 0', () => {
-    expect(parseCodexTokenBreakdown({ totalTokens: 5, inputTokens: 5 })).toMatchObject({ totalTokens: 5, inputTokens: 5, outputTokens: 0 });
+  it('parses a complete breakdown', () => {
+    expect(parseCodexTokenBreakdown({ totalTokens: 5, inputTokens: 5, cachedInputTokens: 0, cacheWriteInputTokens: 0, outputTokens: 3, reasoningOutputTokens: 1 }))
+      .toMatchObject({ totalTokens: 5, inputTokens: 5, outputTokens: 3 });
   });
   it('rejects non-numeric present fields', () => {
     expect(parseCodexTokenBreakdown({ totalTokens: 'x' })).toBeNull();
+  });
+  it('rejects negative or fractional token counts (protocol boundary)', () => {
+    const full = { totalTokens: 5, inputTokens: 5, cachedInputTokens: 0, cacheWriteInputTokens: 0, outputTokens: 3, reasoningOutputTokens: 1 };
+    expect(parseCodexTokenBreakdown({ ...full, inputTokens: -1 })).toBeNull();
+    expect(parseCodexTokenBreakdown({ ...full, outputTokens: 1.5 })).toBeNull();
   });
   it('rejects non-object', () => {
     expect(parseCodexTokenBreakdown(null)).toBeNull();
@@ -97,5 +103,43 @@ describe('TurnTokenUsageAccumulator — total-delta', () => {
 
   it('no notifications → null (caller omits usage, never writes zeros)', () => {
     expect(new TurnTokenUsageAccumulator().result()).toBeNull();
+  });
+
+  it('fail-closed: negative baseline (total < last) → null + warning (not inflated turn)', () => {
+    // codex review repro: total.input=50 but last.input=100 → baseline would be
+    // -50 and the turn would wrongly read input=100. Must reject.
+    const acc = new TurnTokenUsageAccumulator();
+    acc.update(bd({ totalTokens: 50, inputTokens: 50, outputTokens: 20 }), bd({ totalTokens: 100, inputTokens: 100, outputTokens: 40 }));
+    expect(acc.result()).toBeNull();
+    expect(acc.warning).toBeTruthy();
+  });
+
+  it('fail-closed: a regression in a NON-total field (cacheRead) is caught', () => {
+    const acc = new TurnTokenUsageAccumulator();
+    acc.update(
+      bd({ totalTokens: 200, inputTokens: 150, cachedInputTokens: 50, outputTokens: 50 }),
+      bd({ totalTokens: 100, inputTokens: 80, cachedInputTokens: 20, outputTokens: 20 }),
+    );
+    // total/input/output all advance, but cachedInputTokens regresses 50→10
+    acc.update(
+      bd({ totalTokens: 260, inputTokens: 200, cachedInputTokens: 10, outputTokens: 60 }),
+      bd({ totalTokens: 60, inputTokens: 50, cachedInputTokens: 0, outputTokens: 10 }),
+    );
+    expect(acc.result()).toBeNull();
+    expect(acc.warning).toBeTruthy();
+  });
+});
+
+describe('parseCodexTokenBreakdown — required fields', () => {
+  const full = { totalTokens: 1, inputTokens: 1, cachedInputTokens: 0, cacheWriteInputTokens: 0, outputTokens: 1, reasoningOutputTokens: 0 };
+  it('rejects a missing REQUIRED field (not defaulted to 0)', () => {
+    for (const k of ['totalTokens', 'inputTokens', 'cachedInputTokens', 'outputTokens', 'reasoningOutputTokens']) {
+      const { [k]: _omit, ...partial } = full as Record<string, number>;
+      expect(parseCodexTokenBreakdown(partial)).toBeNull();
+    }
+  });
+  it('accepts a missing cacheWriteInputTokens (back-compat → 0)', () => {
+    const { cacheWriteInputTokens: _omit, ...compat } = full;
+    expect(parseCodexTokenBreakdown(compat)?.cacheWriteInputTokens).toBe(0);
   });
 });

--- a/test/codex-app-token-usage.test.ts
+++ b/test/codex-app-token-usage.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from 'vitest';
 import {
   TurnTokenUsageAccumulator,
   parseCodexTokenBreakdown,
+  parseTokenUsagePair,
   toFourBucket,
   type CodexTokenBreakdown,
 } from '../src/services/codex-app-token-usage.js';
@@ -152,5 +153,73 @@ describe('parseCodexTokenBreakdown — required fields', () => {
   it('accepts a missing cacheWriteInputTokens (back-compat → 0)', () => {
     const { cacheWriteInputTokens: _omit, ...compat } = full;
     expect(parseCodexTokenBreakdown(compat)?.cacheWriteInputTokens).toBe(0);
+  });
+});
+
+describe('parseTokenUsagePair — cacheWrite symmetry (codex P1)', () => {
+  const total = { totalTokens: 130, inputTokens: 100, cachedInputTokens: 40, cacheWriteInputTokens: 40, outputTokens: 30, reasoningOutputTokens: 10 };
+  const last = { totalTokens: 130, inputTokens: 100, cachedInputTokens: 40, cacheWriteInputTokens: 40, outputTokens: 30, reasoningOutputTokens: 10 };
+
+  it('parses a well-formed pair (both carry cacheWrite)', () => {
+    const p = parseTokenUsagePair(total, last);
+    expect(p?.total.cacheWriteInputTokens).toBe(40);
+    expect(p?.last.cacheWriteInputTokens).toBe(40);
+  });
+
+  it('accepts a pair where BOTH omit cacheWrite (genuine old codex → 0/0)', () => {
+    const { cacheWriteInputTokens: _t, ...totalOld } = total;
+    const { cacheWriteInputTokens: _l, ...lastOld } = last;
+    const p = parseTokenUsagePair(totalOld, lastOld);
+    expect(p?.total.cacheWriteInputTokens).toBe(0);
+    expect(p?.last.cacheWriteInputTokens).toBe(0);
+  });
+
+  it('REJECTS asymmetric cacheWrite: total has it, last omits it (would misattribute cache-create)', () => {
+    const { cacheWriteInputTokens: _l, ...lastNoCW } = last;
+    expect(parseTokenUsagePair(total, lastNoCW)).toBeNull();
+  });
+
+  it('REJECTS asymmetric cacheWrite the other way: last has it, total omits it', () => {
+    const { cacheWriteInputTokens: _t, ...totalNoCW } = total;
+    expect(parseTokenUsagePair(totalNoCW, last)).toBeNull();
+  });
+
+  it('returns null when either breakdown is itself malformed', () => {
+    expect(parseTokenUsagePair({ totalTokens: 'x' }, last)).toBeNull();
+    expect(parseTokenUsagePair(total, null)).toBeNull();
+  });
+});
+
+describe('TurnTokenUsageAccumulator — asymmetric-cacheWrite poison (codex P1 end-to-end)', () => {
+  it('asymmetric first packet → poison; a later VALID packet cannot resurrect (omit, not miscount)', () => {
+    // First notification for the turn: total carries cacheWrite=40, last omits it.
+    // parseTokenUsagePair refuses → runner poisons the turn. A subsequent coherent
+    // packet must NOT rebuild a baseline and report a plausible-looking wrong split.
+    const acc = new TurnTokenUsageAccumulator();
+    const total1 = { totalTokens: 130, inputTokens: 100, cachedInputTokens: 40, cacheWriteInputTokens: 40, outputTokens: 30, reasoningOutputTokens: 10 };
+    const last1NoCW = { totalTokens: 130, inputTokens: 100, cachedInputTokens: 40, outputTokens: 30, reasoningOutputTokens: 10 };
+    const parsed1 = parseTokenUsagePair(total1, last1NoCW);
+    expect(parsed1).toBeNull();
+    acc.poison('malformed tokenUsage notification'); // what the runner does on null
+
+    // later valid packet (both sides symmetric)
+    const parsed2 = parseTokenUsagePair(
+      { totalTokens: 200, inputTokens: 150, cachedInputTokens: 40, cacheWriteInputTokens: 40, outputTokens: 60, reasoningOutputTokens: 10 },
+      { totalTokens: 70, inputTokens: 50, cachedInputTokens: 0, cacheWriteInputTokens: 0, outputTokens: 30, reasoningOutputTokens: 0 },
+    );
+    if (parsed2) acc.update(parsed2.total, parsed2.last);
+    expect(acc.result()).toBeNull();
+    expect(acc.warning).toBeTruthy();
+  });
+});
+
+describe('TurnTokenUsageAccumulator — warning on incoherent omit (codex non-blocking)', () => {
+  it('records a warning when the bucket split is incoherent (not silent)', () => {
+    // baseline=0, latestTotal has cache buckets exceeding input → toFourBucket null.
+    const acc = new TurnTokenUsageAccumulator();
+    const bad = bd({ totalTokens: 100, inputTokens: 50, cachedInputTokens: 40, cacheWriteInputTokens: 60, outputTokens: 20 });
+    acc.update(bad, bad); // baseline = 0 → delta = bad; toFourBucket returns null (40+60 > 50)
+    expect(acc.result()).toBeNull();
+    expect(acc.warning).toBe('tokenUsage bucket split incoherent (cache buckets exceed input)');
   });
 });

--- a/test/codex-app-token-usage.test.ts
+++ b/test/codex-app-token-usage.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for the per-turn codex token-usage accumulator — the total-delta
+ * algorithm that turns cumulative `thread/tokenUsage/updated` notifications into
+ * a single turn's four-bucket usage.
+ *
+ * Run: pnpm vitest run test/codex-app-token-usage.test.ts
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  TurnTokenUsageAccumulator,
+  parseCodexTokenBreakdown,
+  toFourBucket,
+  type CodexTokenBreakdown,
+} from '../src/services/codex-app-token-usage.js';
+
+function bd(p: Partial<CodexTokenBreakdown>): CodexTokenBreakdown {
+  return {
+    totalTokens: 0, inputTokens: 0, cachedInputTokens: 0,
+    cacheWriteInputTokens: 0, outputTokens: 0, reasoningOutputTokens: 0, ...p,
+  };
+}
+
+describe('toFourBucket', () => {
+  it('splits codex input into fresh/cacheRead/cacheCreate and keeps output', () => {
+    // Official example: input=100 total (incl cache), cached=40, cacheWrite=60.
+    const u = toFourBucket(bd({ inputTokens: 100, cachedInputTokens: 40, cacheWriteInputTokens: 60, outputTokens: 20, reasoningOutputTokens: 8 }));
+    expect(u).toEqual({ inputTokens: 0, outputTokens: 20, cacheReadTokens: 40, cacheCreateTokens: 60 });
+  });
+
+  it('does NOT add reasoningOutputTokens to output (it is a subset)', () => {
+    const u = toFourBucket(bd({ inputTokens: 10, outputTokens: 30, reasoningOutputTokens: 25 }));
+    expect(u?.outputTokens).toBe(30);
+  });
+
+  it('returns null when buckets exceed input (incoherent split)', () => {
+    expect(toFourBucket(bd({ inputTokens: 50, cachedInputTokens: 40, cacheWriteInputTokens: 60 }))).toBeNull();
+  });
+});
+
+describe('parseCodexTokenBreakdown', () => {
+  it('defaults missing fields to 0', () => {
+    expect(parseCodexTokenBreakdown({ totalTokens: 5, inputTokens: 5 })).toMatchObject({ totalTokens: 5, inputTokens: 5, outputTokens: 0 });
+  });
+  it('rejects non-numeric present fields', () => {
+    expect(parseCodexTokenBreakdown({ totalTokens: 'x' })).toBeNull();
+  });
+  it('rejects non-object', () => {
+    expect(parseCodexTokenBreakdown(null)).toBeNull();
+  });
+});
+
+describe('TurnTokenUsageAccumulator — total-delta', () => {
+  it('single completion: baseline = total - last, turn = latestTotal - baseline', () => {
+    const acc = new TurnTokenUsageAccumulator();
+    // first (only) completion of this turn: total jumped by `last`
+    acc.update(bd({ totalTokens: 130, inputTokens: 100, cachedInputTokens: 40, cacheWriteInputTokens: 0, outputTokens: 30 }),
+               bd({ totalTokens: 130, inputTokens: 100, cachedInputTokens: 40, cacheWriteInputTokens: 0, outputTokens: 30 }));
+    // baseline = 0 → whole total is this turn
+    expect(acc.result()).toEqual({ inputTokens: 60, outputTokens: 30, cacheReadTokens: 40, cacheCreateTokens: 0 });
+  });
+
+  it('mid-session turn: prior session total excluded via baseline', () => {
+    const acc = new TurnTokenUsageAccumulator();
+    // session already had 1000 total; this turn's first completion added 130 (last)
+    acc.update(bd({ totalTokens: 1130, inputTokens: 900, outputTokens: 230 }),
+               bd({ totalTokens: 130, inputTokens: 100, outputTokens: 30 }));
+    // baseline = 1130-130 = 1000 total / 800 input / 200 output → turn = last so far
+    expect(acc.result()).toEqual({ inputTokens: 100, outputTokens: 30, cacheReadTokens: 0, cacheCreateTokens: 0 });
+  });
+
+  it('multiple completions in one turn accumulate via total, not last-sum', () => {
+    const acc = new TurnTokenUsageAccumulator();
+    // completion 1: session base 1000, +130
+    acc.update(bd({ totalTokens: 1130, inputTokens: 900, outputTokens: 230 }), bd({ totalTokens: 130, inputTokens: 100, outputTokens: 30 }));
+    // completion 2 (tool loop): total advances to 1300; last is only completion-2's usage
+    acc.update(bd({ totalTokens: 1300, inputTokens: 1040, outputTokens: 260 }), bd({ totalTokens: 170, inputTokens: 140, outputTokens: 30 }));
+    // turn = 1300-baseline(1000) → input 1040-800=240, output 260-200=60
+    expect(acc.result()).toEqual({ inputTokens: 240, outputTokens: 60, cacheReadTokens: 0, cacheCreateTokens: 0 });
+  });
+
+  it('idempotent against a duplicated notification (same total)', () => {
+    const acc = new TurnTokenUsageAccumulator();
+    const total = bd({ totalTokens: 1130, inputTokens: 900, outputTokens: 230 });
+    const last = bd({ totalTokens: 130, inputTokens: 100, outputTokens: 30 });
+    acc.update(total, last);
+    acc.update(total, last); // duplicate delivery
+    expect(acc.result()).toEqual({ inputTokens: 100, outputTokens: 30, cacheReadTokens: 0, cacheCreateTokens: 0 });
+  });
+
+  it('fail-closed: total regression → null + warning', () => {
+    const acc = new TurnTokenUsageAccumulator();
+    acc.update(bd({ totalTokens: 1130, inputTokens: 900, outputTokens: 230 }), bd({ totalTokens: 130, inputTokens: 100, outputTokens: 30 }));
+    acc.update(bd({ totalTokens: 1000, inputTokens: 800, outputTokens: 200 }), bd({ totalTokens: 10, inputTokens: 8, outputTokens: 2 }));
+    expect(acc.result()).toBeNull();
+    expect(acc.warning).toBeTruthy();
+  });
+
+  it('no notifications → null (caller omits usage, never writes zeros)', () => {
+    expect(new TurnTokenUsageAccumulator().result()).toBeNull();
+  });
+});

--- a/test/codex-app-token-usage.test.ts
+++ b/test/codex-app-token-usage.test.ts
@@ -105,6 +105,17 @@ describe('TurnTokenUsageAccumulator — total-delta', () => {
     expect(new TurnTokenUsageAccumulator().result()).toBeNull();
   });
 
+  it('poison() is sticky: a later valid update cannot resurrect usage', () => {
+    // Models malformed-then-valid within one turn: the runner poisons on the
+    // malformed notification; a subsequent valid one must NOT rebuild a baseline
+    // and report only that completion (a plausible-looking undercount).
+    const acc = new TurnTokenUsageAccumulator();
+    acc.poison('malformed tokenUsage notification');
+    acc.update(bd({ totalTokens: 130, inputTokens: 100, outputTokens: 30 }), bd({ totalTokens: 130, inputTokens: 100, outputTokens: 30 }));
+    expect(acc.result()).toBeNull();
+    expect(acc.warning).toBeTruthy();
+  });
+
   it('fail-closed: negative baseline (total < last) → null + warning (not inflated turn)', () => {
     // codex review repro: total.input=50 but last.input=100 → baseline would be
     // -50 and the turn would wrongly read input=100. Must reject.

--- a/test/fixtures/fake-codex-app-server.mjs
+++ b/test/fixtures/fake-codex-app-server.mjs
@@ -130,6 +130,26 @@ function emitTurnCompletion(threadId, turnId, outputSchema) {
       },
     });
   }
+  // Opt-in: ASYMMETRIC cacheWrite first (total has it, last omits it), then a
+  // valid symmetric packet, same turn. The asymmetry must poison the turn (a
+  // 0-default on the missing side would misattribute cache-create into fresh
+  // input); the later valid packet must NOT resurrect usage. Final marker OMITs.
+  if (process.env.FAKE_TOKEN_USAGE_ASYM === '1') {
+    notify('thread/tokenUsage/updated', {
+      threadId, turnId,
+      tokenUsage: {
+        total: { totalTokens: 130, inputTokens: 100, cachedInputTokens: 40, cacheWriteInputTokens: 40, outputTokens: 30, reasoningOutputTokens: 10 },
+        last: { totalTokens: 130, inputTokens: 100, cachedInputTokens: 40, /* cacheWrite MISSING */ outputTokens: 30, reasoningOutputTokens: 10 },
+      },
+    });
+    notify('thread/tokenUsage/updated', {
+      threadId, turnId,
+      tokenUsage: {
+        total: { totalTokens: 200, inputTokens: 150, cachedInputTokens: 40, cacheWriteInputTokens: 40, outputTokens: 60, reasoningOutputTokens: 10 },
+        last: { totalTokens: 70, inputTokens: 50, cachedInputTokens: 0, cacheWriteInputTokens: 0, outputTokens: 30, reasoningOutputTokens: 0 },
+      },
+    });
+  }
   notify('turn/completed', { threadId, turn: { id: turnId, status: 'completed' } });
 }
 

--- a/test/fixtures/fake-codex-app-server.mjs
+++ b/test/fixtures/fake-codex-app-server.mjs
@@ -115,6 +115,21 @@ function emitTurnCompletion(threadId, turnId, outputSchema) {
       },
     });
   }
+  // Opt-in: a MALFORMED usage notification first, then a valid one, same turn.
+  // Exercises the runner's sticky-poison path — usage must end up OMITTED.
+  if (process.env.FAKE_TOKEN_USAGE_POISON === '1') {
+    notify('thread/tokenUsage/updated', {
+      threadId, turnId,
+      tokenUsage: { total: { totalTokens: 'bad' }, last: {} }, // malformed → poison
+    });
+    notify('thread/tokenUsage/updated', {
+      threadId, turnId,
+      tokenUsage: {
+        total: { totalTokens: 130, inputTokens: 100, cachedInputTokens: 40, cacheWriteInputTokens: 0, outputTokens: 30, reasoningOutputTokens: 10 },
+        last: { totalTokens: 130, inputTokens: 100, cachedInputTokens: 40, cacheWriteInputTokens: 0, outputTokens: 30, reasoningOutputTokens: 10 },
+      },
+    });
+  }
   notify('turn/completed', { threadId, turn: { id: turnId, status: 'completed' } });
 }
 

--- a/test/fixtures/fake-codex-app-server.mjs
+++ b/test/fixtures/fake-codex-app-server.mjs
@@ -101,6 +101,20 @@ function emitTurnCompletion(threadId, turnId, outputSchema) {
       text: answer,
     },
   });
+  // Opt-in: emit a token-usage notification (as the real app-server does) so the
+  // runner's per-turn accumulator has something to fold. cumulative `total`,
+  // last-completion `last`. input includes cache read+write per codex semantics.
+  if (process.env.FAKE_TOKEN_USAGE === '1') {
+    notify('thread/tokenUsage/updated', {
+      threadId,
+      turnId,
+      tokenUsage: {
+        total: { totalTokens: 130, inputTokens: 100, cachedInputTokens: 40, cacheWriteInputTokens: 0, outputTokens: 30, reasoningOutputTokens: 10 },
+        last: { totalTokens: 130, inputTokens: 100, cachedInputTokens: 40, cacheWriteInputTokens: 0, outputTokens: 30, reasoningOutputTokens: 10 },
+        modelContextWindow: 272000,
+      },
+    });
+  }
   notify('turn/completed', { threadId, turn: { id: turnId, status: 'completed' } });
 }
 


### PR DESCRIPTION
## 背景

拆自 #638（superseded）的 per-trigger usage 块。异步任务完成后，`trigger-result` 的 `completed` 态带上**这一轮真实消耗的 token**（四桶：input/output/cacheRead/cacheCreate），供 riff 任务详情展示。**仅 codex-app**（走 app-server 结构化协议、有 thread/tokenUsage/updated 通知）。

契约与算法按 codex 用 Codex 0.145 生成类型 + 官方 `append_last_usage` 源码交底实现。

## 为什么不是"取 last"

token 来自独立通知 `thread/tokenUsage/updated`（`turn/completed` 的 Turn 无 usage）。一个 codex turn 有多次 completion，`tokenUsage.last` 只是最后一次的量。**本轮**用 total-delta：首条 `baseline=total-last`，之后 `本轮=latestTotal-baseline`（逐字段）；重复通知幂等。

## fail-closed（codex 三轮 review 加固）

- 负 baseline（total<last）、**全字段**单调性回退、缺必填字段、负数/小数 token → 一律拒绝、usage omit（不写 0）。
- 首条 malformed 对该 turn **sticky poison**：后续 valid 通知不能重建 baseline 造成少算。
- **cacheWrite 非对称缺失守卫（第三轮 P1）**：`parseTokenUsagePair` 强制 total/last 的 `cacheWriteInputTokens` presence 对称——只有两边同时缺失才兼容为 0（真·老版本 codex），只缺一边即返 null → runner poison 该 turn（否则 0-default 会把 cache-create 误算进 fresh input，且后续 valid 包沿错误 baseline 少算）。
- runner 读 warning 落 log（异常不静默）；`result()` 因 delta 负值 / bucket-split 不一致 omit 时也写 warning（不再静默）；usage map 有界清理（未 finalize 的 turn 不泄漏）。
- worker→daemon 层 normalizeFinalUsage 同样要求非负整数（防篡改穿透到磁盘）。

## 传递链
runner（按 appTurnId 累加 + onFinal 附四桶）→ CodexAppFinalMarker.usage（严格 normalize）→ worker final_output.usage → daemon 内存+持久化（recordCompleted）→ trigger-result completed 输出 usage（内存/磁盘任一）。`TriggerResponse.usage`（对齐 riff TaskTokenUsage），仅 completed；**omit≠0**；随重启持久化。

## 影响范围
仅 codex-app async 完成路径新增**可选** usage；不改其它字段；老会话/无通知照旧。不含 model/effort（PR A 已合）、不含 awaiting_input（PR C，申晗暂缓）。

## 测试（106 测绿）
- codex-app-token-usage 25：total-delta / 四桶 / mid-session baseline / 多 completion / 幂等 / 负 baseline / 全字段回退 / 负数小数 parse / **sticky poison** / omit / **parseTokenUsagePair 两向非对称拒绝 + 两边同缺兼容 0** / **非对称首包 poison→later-valid 不复活→omit** / **bucket-split 不一致写 warning**。
- normalizer valid/malformed/negative/fractional。
- async-usage-glue：真 deliverFinalOutput 穿内存+磁盘+restart；dashboard-ipc source-lock（删 memResult.usage spread 即红）。
- integration（真 runner + fake app-server）：折叠 tokenUsage→final 四桶；**malformed→valid 同 turn poison → omit**；**asymmetric cacheWrite→valid 同 turn poison → omit（FAKE_TOKEN_USAGE_ASYM）**。
- mutation 验证有牙：禁用 pair 对称 guard，恰好 3 个 P1 测试转红。
- `pnpm build` + docs-site build 绿。双语文档 completed 补 usage/omit≠0/重启持久化/codex-app only。

最终 SHA：e6d52c0f（第三轮 P1 修复：cacheWrite 非对称缺失守卫 + incoherent omit warning）。

## 拆分链
#585 已合（async 四态）· PR A #639 已合（model/effort）· **本 PR B**（usage）· PR C（awaiting_input，暂缓）· #638 superseded。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
