### PR TITLE
fix(mcp): 修复空数据目录污染项目路径

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9071,7 +9071,9 @@ switch (command) {
       process.exitCode = 2;
       break;
     }
-    process.env.SESSION_DATA_DIR ??= resolveDataDir();
+    if (!process.env.SESSION_DATA_DIR?.trim()) {
+      process.env.SESSION_DATA_DIR = resolveDataDir();
+    }
     const { runMcpGateway } = await import('./core/plugins/mcp/gateway.js');
     await runMcpGateway();
     break;

--- a/src/core/plugins/mcp/gateway.ts
+++ b/src/core/plugins/mcp/gateway.ts
@@ -35,7 +35,7 @@ import {
   type ClientCapabilities,
   type ServerCapabilities,
 } from '@modelcontextprotocol/sdk/types.js';
-import { config } from '../../../config.js';
+import { resolveBotmuxDataDir } from '../../data-dir.js';
 import { readGlobalConfig } from '../../../global-config.js';
 import { readPluginRegistry } from '../../../services/plugin-registry-store.js';
 import { atomicWriteFileSync } from '../../../utils/atomic-write.js';
@@ -151,7 +151,7 @@ function gatewayPluginIds(env: NodeJS.ProcessEnv = process.env): string[] {
 }
 
 function gatewayDataDir(env: NodeJS.ProcessEnv): string {
-  return env.SESSION_DATA_DIR?.trim() || config.session.dataDir;
+  return resolveBotmuxDataDir({ env });
 }
 
 function gatewayDescriptors(pluginIds: readonly string[]): GatewayDescriptor[] {

--- a/test/plugin-mcp-gateway.test.ts
+++ b/test/plugin-mcp-gateway.test.ts
@@ -73,12 +73,17 @@ describe('plugin MCP Gateway', () => {
     };
   }
 
-  async function connectMcpServe(sessionId: string): Promise<Client> {
+  async function connectMcpServe(
+    sessionId: string,
+    options: { dataDir?: string; cwd?: string } = {},
+  ): Promise<Client> {
+    const env = mcpServeEnvironment(sessionId);
+    if (options.dataDir !== undefined) env.SESSION_DATA_DIR = options.dataDir;
     const transport = new StdioClientTransport({
       command: process.execPath,
-      args: ['--import', 'tsx', resolve('src/cli.ts'), 'mcp', 'serve'],
-      cwd: resolve('.'),
-      env: mcpServeEnvironment(sessionId),
+      args: ['--import', import.meta.resolve('tsx'), resolve('src/cli.ts'), 'mcp', 'serve'],
+      cwd: options.cwd ?? resolve('.'),
+      env,
       stderr: 'pipe',
     });
     const client = new Client({ name: 'mcp-serve-test', version: '1.0.0' });
@@ -261,6 +266,20 @@ describe('plugin MCP Gateway', () => {
     } finally {
       await client.close();
       rmSync(resolve('data', 'mcp-gateway', `${sessionId}.json`), { force: true });
+    }
+  });
+
+  it('treats an empty SESSION_DATA_DIR as missing instead of writing into cwd', async () => {
+    const sessionId = 'mcp-serve-empty-data-dir';
+    const diagnostics = join(home, '.botmux', 'data', 'mcp-gateway', `${sessionId}.json`);
+    const cwdDiagnostics = join(home, 'mcp-gateway', `${sessionId}.json`);
+    const client = await connectMcpServe(sessionId, { dataDir: '', cwd: home });
+    try {
+      expect((await client.listTools()).tools).toEqual([]);
+      await vi.waitFor(() => expect(existsSync(diagnostics)).toBe(true));
+      expect(existsSync(cwdDiagnostics)).toBe(false);
+    } finally {
+      await client.close();
     }
   });
 


### PR DESCRIPTION
## 改了什么

- `botmux mcp serve` 启动时将空白 `SESSION_DATA_DIR` 视为未配置，并回退到标准数据目录。
- MCP Gateway 统一复用 `resolveBotmuxDataDir`，避免直接调用 Gateway 时再次产生相对路径。
- 增加空字符串环境变量的集成回归测试，验证诊断文件写入 `~/.botmux/data/mcp-gateway`，而不是当前项目目录。

## 为什么

Claude Code 的全局 botmux MCP 配置会把缺失的 `SESSION_DATA_DIR` 展开为空字符串。原实现使用 `??=`，不会覆盖空字符串；Gateway 随后执行相对路径拼接，导致普通 Claude Code 会话在项目 cwd 下创建 `mcp-gateway/standalone.json`。

## 影响面

- 影响公共 Plugin MCP Gateway 路径，覆盖 Claude Code 和 Codex。
- 不改变插件选择、MCP 协议、后端或会话恢复逻辑。
- 显式自定义数据目录和 `~/.botmux/.data-dir` breadcrumb 行为保持不变。
- 复用现有跨平台数据目录解析器，macOS/Linux 使用同一逻辑。

## 验证

- `node node_modules/vitest/vitest.mjs run --project unit test/plugin-mcp-gateway.test.ts`：17/17 通过。
- `node node_modules/vitest/vitest.mjs run --project unit`：通过；2 个既有 sandbox 测试跳过。
- `pnpm build`：通过。
- 使用构建产物和全局 `~/.botmux/bin/botmux` 分别复现 `SESSION_DATA_DIR=""`：诊断文件均写入 `.botmux/data/mcp-gateway/standalone.json`，cwd 未生成 `mcp-gateway`。
