### PR TITLE
fix(overload): 跨 bot 聚合降压会话

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -69,6 +69,7 @@ import * as scheduler from './scheduler.js';
 import { listActiveSessions, findActiveBySessionId, closeSession, getActiveSessionsRegistry, transferSession, deliverWriteLinkCardToOwners, forkWorker, suspendWorker, killWorker } from './worker-pool.js';
 import { listOnlineDaemons } from '../utils/daemon-discovery.js';
 import { isSessionStopped } from './session-liveness.js';
+import { isSuspendableBackendType } from './persistent-backend.js';
 import { getChatMode, replyMessage, sendMessage, resolveUnionIdFromOpenId, listThreadMessages, listChatMessages, listChatBotMembers, getUserProfile, getUserProfileStrict, resolveAllowedUsersWithMap, type ChatBotMember } from '../im/lark/client.js';
 import { parseApiMessage, cardContentHasUpgradeFallback, resolveMergedCardContent } from '../im/lark/message-parser.js';
 import { resumeSession, spawnDashboardSession, activateQueuedSession, closeCliMismatchedSessionsForBot, suspendActiveSessionsForBot } from './session-manager.js';
@@ -649,11 +650,10 @@ ipcRoute('POST', '/api/sessions/:sessionId/suspend', (_req, res, params) => {
 
 /**
  * Count host-overload降压 candidates for THIS daemon's scope, so the alert card
- * can show "僵尸 N / 闲置 M" before the owner clicks. `stopped` counts zombies
- * from the SHARED session store (same answer on every daemon — the card handler
- * only takes it from one), `idle` counts THIS daemon's own idle live workers
- * (owning-daemon-authoritative — the handler sums across daemons). Mirrors the
- * exact classification the sweep uses so the preview matches what a click does.
+ * can show "僵尸 N / 闲置 M" before the owner clicks. Both counts are local to
+ * THIS daemon: its session store is bot-scoped, and live workers only exist in
+ * their owning process. The card handler sums every daemon's response. Mirrors
+ * the exact classification the sweep uses so the preview matches a click.
  */
 ipcRoute('GET', '/api/host-overload/counts', (_req, res) => {
   const stopped = sessionStore.listSessions().filter(s => s.status === 'active' && isSessionStopped(s)).length;
@@ -661,6 +661,7 @@ ipcRoute('GET', '/api/host-overload/counts', (_req, res) => {
   for (const ds of listActiveSessions()) {
     if (!ds.worker || ds.worker.killed) continue;
     if (ds.adoptedFrom || ds.initConfig?.adoptMode) continue;
+    if (!isSuspendableBackendType(ds.initConfig?.backendType)) continue;
     if (ds.lastScreenStatus !== 'idle') continue;
     idle++;
   }
@@ -671,8 +672,8 @@ ipcRoute('GET', '/api/host-overload/counts', (_req, res) => {
  * Bulk host-overload降压 sweep, driven by the overload-alert card buttons.
  * `mode`:
  *   - `clean_stopped`: close stopped zombie sessions (dead CLI + no tmux) from
- *     the SHARED session store — machine-wide, so a single daemon's sweep is
- *     enough (the alert-owning daemon calls this once, no fan-out needed).
+ *     THIS daemon's bot-scoped session store. The card handler fans this mode
+ *     out to every online daemon.
  *   - `suspend_idle`: suspend THIS daemon's own idle (non-busy, suspendable,
  *     non-adopt) live workers. Live workers only exist in their owning daemon's
  *     process, so the card handler fans this mode out to every online daemon.
@@ -690,10 +691,8 @@ ipcRoute('POST', '/api/host-overload/sweep', async (req, res) => {
     for (const s of stopped) {
       try {
         const r = await closeSession(s.sessionId);
-        // Only count sessions this call actually closed. A shared-store session
-        // already closed by another daemon's concurrent sweep returns
-        // alreadyClosed=true — counting it would inflate `affected` by the
-        // number of daemons that raced on the same zombie.
+        // Only count sessions this call actually closed. A concurrent action in
+        // this daemon may already have closed the same record.
         if (r.ok && !r.alreadyClosed) affected++;
       } catch (err) {
         logger.warn(`[overload-sweep] close failed for ${s.sessionId.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`);
@@ -710,6 +709,7 @@ ipcRoute('POST', '/api/host-overload/sweep', async (req, res) => {
     for (const ds of listActiveSessions()) {
       if (!ds.worker || ds.worker.killed) continue;             // no live worker
       if (ds.adoptedFrom || ds.initConfig?.adoptMode) continue;  // never suspend adopt
+      if (!isSuspendableBackendType(ds.initConfig?.backendType)) continue;
       if (ds.lastScreenStatus !== 'idle') continue;              // never cut an in-flight reply
       try {
         if (suspendWorker(ds, 'host_overload_suspend')) affected++;

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -756,13 +756,9 @@ export async function runAutoWorktreeCommit(deps: {
 /**
  * Drive a host-overload降压 sweep across daemons.
  *
- * `suspend_idle` fans out to EVERY online daemon and sums the affected counts —
- * live workers only exist in their owning daemon's process, so each must sweep
- * its own. `clean_stopped` operates on the SHARED, machine-wide session store,
- * so ONE daemon does the whole job: it tries daemons in order until the first
- * one succeeds (not a fixed `daemons[0]`, so a single flaky descriptor doesn't
- * sink the action while healthy siblings sit idle). Fanning clean_stopped out
- * would make siblings race the same zombies and double-count them.
+ * Both modes fan out to EVERY online daemon and sum the affected counts. Each
+ * daemon owns one bot-scoped session store and its own live workers, so neither
+ * stopped sessions nor idle workers can be swept through a sibling daemon.
  *
  * Throws when there are no online daemons, or when every attempt failed — so
  * the caller rolls back the nonce instead of burning the button on an action
@@ -789,32 +785,21 @@ async function sweepHostOverload(mode: 'clean_stopped' | 'suspend_idle'): Promis
     }
   };
 
-  if (mode === 'clean_stopped') {
-    // Machine-wide (shared store): try daemons in order, stop at the first
-    // success. Only if EVERY daemon failed do we throw (→ nonce rollback).
-    for (const d of daemons) {
-      const n = await postSweep(d);
-      if (n !== null) return n;
-    }
-    throw new Error(`sweep clean_stopped reached no daemon (${daemons.length} failed)`);
-  }
-
-  // suspend_idle: fan out to all daemons and sum. Throw only if not one acked.
+  // Fan out to all daemons and sum. Throw only if not one daemon acked.
   let affected = 0;
   let ok = 0;
   const results = await Promise.all(daemons.map(postSweep));
   for (const n of results) {
     if (n !== null) { affected += n; ok++; }
   }
-  if (ok === 0) throw new Error(`sweep suspend_idle reached no daemon (${daemons.length} failed)`);
+  if (ok === 0) throw new Error(`sweep ${mode} reached no daemon (${daemons.length} failed)`);
   return affected;
 }
 
 /**
- * Machine-wide counts for the overload alert preview. `stopped` (zombies) reads
- * the SHARED session store, so every daemon returns the same number → take the
- * max (any one authoritative). `idle` live workers are per-owning-daemon → sum.
- * Best-effort: an unreachable daemon just contributes 0.
+ * Machine-wide counts for the overload alert preview. Each daemon reports its
+ * bot-scoped stopped sessions and its own live workers, so both fields must be
+ * summed. Best-effort: an unreachable daemon just contributes 0.
  */
 export async function countHostOverload(): Promise<{ stopped: number; idle: number }> {
   const daemons = listOnlineDaemons();
@@ -825,7 +810,7 @@ export async function countHostOverload(): Promise<{ stopped: number; idle: numb
       const res = await fetchDaemonIpc(d.ipcPort, '/api/host-overload/counts', { method: 'GET' });
       const body: any = await res.json().catch(() => ({}));
       if (res.ok && body?.ok) {
-        if (typeof body.stopped === 'number') stopped = Math.max(stopped, body.stopped);
+        if (typeof body.stopped === 'number') stopped += body.stopped;
         if (typeof body.idle === 'number') idle += body.idle;
       }
     } catch { /* unreachable daemon contributes 0 */ }

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -760,9 +760,15 @@ export async function runAutoWorktreeCommit(deps: {
  * daemon owns one bot-scoped session store and its own live workers, so neither
  * stopped sessions nor idle workers can be swept through a sibling daemon.
  *
- * Throws when there are no online daemons, or when every attempt failed — so
- * the caller rolls back the nonce instead of burning the button on an action
- * that never ran. A partial success (≥1 daemon ok) returns normally.
+ * Fail-closed on partial failure: if ANY discovered daemon doesn't ACK, throw —
+ * the caller then rolls back the nonce (releaseOverloadNonce) so the owner can
+ * retry, instead of burning the button on a card that reports「已清理 0」while
+ * the daemon that actually held the zombies never ran. Both sweeps are
+ * idempotent (an already-closed session leaves the stopped set; an already-
+ * suspended worker leaves the idle set), so a retry only re-hits whatever
+ * failed. Reporting a partial count as a completed action would resurrect the
+ * exact "显示 0、实际没清" symptom this fix exists to kill — just triggered by
+ * "the daemon holding the zombies failed" instead of "the first daemon had none".
  */
 async function sweepHostOverload(mode: 'clean_stopped' | 'suspend_idle'): Promise<number> {
   const daemons = listOnlineDaemons();
@@ -785,15 +791,15 @@ async function sweepHostOverload(mode: 'clean_stopped' | 'suspend_idle'): Promis
     }
   };
 
-  // Fan out to all daemons and sum. Throw only if not one daemon acked.
-  let affected = 0;
-  let ok = 0;
+  // Fan out to all daemons and sum. Fail the whole action if ANY didn't ACK, so
+  // the caller keeps the button retriable rather than reporting a partial sweep
+  // as complete.
   const results = await Promise.all(daemons.map(postSweep));
-  for (const n of results) {
-    if (n !== null) { affected += n; ok++; }
+  const failed = results.filter(n => n === null).length;
+  if (failed > 0) {
+    throw new Error(`sweep ${mode}: ${failed}/${daemons.length} daemon(s) did not ack — retriable`);
   }
-  if (ok === 0) throw new Error(`sweep ${mode} reached no daemon (${daemons.length} failed)`);
-  return affected;
+  return results.reduce((sum: number, n) => sum + (n ?? 0), 0);
 }
 
 /**

--- a/test/card-handler-overload.test.ts
+++ b/test/card-handler-overload.test.ts
@@ -28,6 +28,7 @@ import {
 } from '../src/core/host-overload-alert.js';
 import {
   _resetOverloadNoncesForTest,
+  claimOverloadNonce,
   registerOverloadNonce,
 } from '../src/im/lark/overload-nonce.js';
 
@@ -39,6 +40,13 @@ const daemons = [
 function response(body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function errorResponse(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
     headers: { 'content-type': 'application/json' },
   });
 }
@@ -104,5 +112,62 @@ describe('host-overload card actions across bot-scoped daemons', () => {
     expect(sweepCalls.map(([port]) => port).sort()).toEqual([7101, 7102]);
     expect(JSON.stringify(result)).toContain('✓ 已清理 5 个僵尸');
     expect(JSON.stringify(result)).toContain('僵尸会话 0 个');
+  });
+
+  // Regression: a partial fan-out failure must NOT be reported as a completed
+  // sweep. Field scenario — daemon A holds no zombies and acks 0, daemon B holds
+  // 5 but its request fails (500 / network reject). If we treat `ok >= 1` as
+  // success we'd burn the button to "✓ 已清理 0 个僵尸" (disabled) while B's 5
+  // zombies survive, and the one-shot nonce + 15min re-alert gate leave the owner
+  // no retry — the very "显示 0、实际没清" symptom this PR exists to kill.
+  it('fails the whole action (retriable) when any discovered daemon does not ack', async () => {
+    fetchDaemonIpcMock.mockImplementation(async (port: number, path: string) => {
+      if (path === '/api/host-overload/sweep') {
+        if (port === 7101) return response({ ok: true, affected: 0 });
+        return errorResponse(500, { ok: false, error: 'boom' }); // daemon B (holds the zombies) fails
+      }
+      if (path === '/api/host-overload/counts') {
+        return response({ ok: true, stopped: port === 7101 ? 0 : 5, idle: 0 });
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    const state: OverloadCardState = {
+      nonce: 'nonce-partial-fail',
+      load15: 30,
+      cpu: 10,
+      mem: 0.95,
+      reasons: ['load', 'memory'],
+      stopped: 5,
+      idle: 0,
+      cleanedN: -1,
+      suspendedN: -1,
+    };
+    registerOverloadNonce(state.nonce);
+
+    const result = await handleCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: {
+        value: {
+          action: OVERLOAD_ACTION_CLEAN_STOPPED,
+          st: JSON.stringify(state),
+        },
+      },
+    }, {
+      activeSessions: new Map(),
+      sessionReply: vi.fn(async () => 'om_reply'),
+      lastRepoScan: new Map(),
+    } as any, 'cli_alert');
+
+    // Both daemons were attempted (fan-out still happens).
+    const sweepCalls = fetchDaemonIpcMock.mock.calls.filter(([, path]) => path === '/api/host-overload/sweep');
+    expect(sweepCalls.map(([port]) => port).sort()).toEqual([7101, 7102]);
+
+    // Must surface as a failure toast, NOT a completed card.
+    expect(JSON.stringify(result)).not.toContain('✓ 已清理');
+    expect(result?.toast?.type).toBe('error');
+
+    // The nonce must be released so the owner can click the button again.
+    expect(claimOverloadNonce(state.nonce, OVERLOAD_ACTION_CLEAN_STOPPED)).toBe(true);
   });
 });

--- a/test/card-handler-overload.test.ts
+++ b/test/card-handler-overload.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { listOnlineDaemonsMock, fetchDaemonIpcMock } = vi.hoisted(() => ({
+  listOnlineDaemonsMock: vi.fn(),
+  fetchDaemonIpcMock: vi.fn(),
+}));
+
+vi.mock('../src/utils/daemon-discovery.js', () => ({
+  listOnlineDaemons: (...args: any[]) => listOnlineDaemonsMock(...args),
+}));
+
+vi.mock('../src/core/daemon-ipc-auth.js', () => ({
+  fetchDaemonIpc: (...args: any[]) => fetchDaemonIpcMock(...args),
+}));
+
+vi.mock('../src/bot-registry.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/bot-registry.js')>('../src/bot-registry.js');
+  return { ...actual, getOwnerOpenId: vi.fn(() => 'ou_owner') };
+});
+
+import {
+  countHostOverload,
+  handleCardAction,
+} from '../src/im/lark/card-handler.js';
+import {
+  OVERLOAD_ACTION_CLEAN_STOPPED,
+  type OverloadCardState,
+} from '../src/core/host-overload-alert.js';
+import {
+  _resetOverloadNoncesForTest,
+  registerOverloadNonce,
+} from '../src/im/lark/overload-nonce.js';
+
+const daemons = [
+  { larkAppId: 'cli_a', ipcPort: 7101 },
+  { larkAppId: 'cli_b', ipcPort: 7102 },
+];
+
+function response(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  _resetOverloadNoncesForTest();
+  listOnlineDaemonsMock.mockReset();
+  fetchDaemonIpcMock.mockReset();
+  listOnlineDaemonsMock.mockReturnValue(daemons);
+});
+
+describe('host-overload card actions across bot-scoped daemons', () => {
+  it('sums stopped and idle candidates from every daemon', async () => {
+    fetchDaemonIpcMock.mockImplementation(async (port: number, path: string) => {
+      expect(path).toBe('/api/host-overload/counts');
+      return response(port === 7101
+        ? { ok: true, stopped: 2, idle: 4 }
+        : { ok: true, stopped: 3, idle: 5 });
+    });
+
+    await expect(countHostOverload()).resolves.toEqual({ stopped: 5, idle: 9 });
+  });
+
+  it('cleans every daemon and reports the summed affected count', async () => {
+    fetchDaemonIpcMock.mockImplementation(async (port: number, path: string) => {
+      if (path === '/api/host-overload/sweep') {
+        return response({ ok: true, affected: port === 7101 ? 0 : 5 });
+      }
+      if (path === '/api/host-overload/counts') {
+        return response({ ok: true, stopped: 0, idle: port === 7101 ? 4 : 5 });
+      }
+      throw new Error(`unexpected path: ${path}`);
+    });
+
+    const state: OverloadCardState = {
+      nonce: 'nonce-clean-all',
+      load15: 30,
+      cpu: 10,
+      mem: 0.95,
+      reasons: ['load', 'memory'],
+      stopped: 5,
+      idle: 9,
+      cleanedN: -1,
+      suspendedN: -1,
+    };
+    registerOverloadNonce(state.nonce);
+
+    const result = await handleCardAction({
+      operator: { open_id: 'ou_owner' },
+      action: {
+        value: {
+          action: OVERLOAD_ACTION_CLEAN_STOPPED,
+          st: JSON.stringify(state),
+        },
+      },
+    }, {
+      activeSessions: new Map(),
+      sessionReply: vi.fn(async () => 'om_reply'),
+      lastRepoScan: new Map(),
+    } as any, 'cli_alert');
+
+    const sweepCalls = fetchDaemonIpcMock.mock.calls.filter(([, path]) => path === '/api/host-overload/sweep');
+    expect(sweepCalls.map(([port]) => port).sort()).toEqual([7101, 7102]);
+    expect(JSON.stringify(result)).toContain('✓ 已清理 5 个僵尸');
+    expect(JSON.stringify(result)).toContain('僵尸会话 0 个');
+  });
+});


### PR DESCRIPTION
## 问题

机器过载告警卡把 session store 当成了整机共享数据：

- 僵尸数跨 daemon 取 `max`
- `clean_stopped` 在第一个成功响应的 daemon 上立即返回

实际 session store 按 `larkAppId` 分区。于是卡片可能显示另一个 bot 的僵尸数，但点击后只扫到一个没有僵尸的 daemon，结果显示“已清理 0 个”。

## 修复

- 僵尸数和闲置数都汇总所有在线 daemon
- `clean_stopped` 与 `suspend_idle` 都 fan-out 到所有 daemon，并汇总 `affected`
- 闲置候选只统计实际支持挂起的 backend，使预览与 sweep 条件一致
- 增加跨 daemon 回归测试，覆盖“第一个 daemon 返回 0、第二个持有僵尸”的现场场景

## 验证

- `pnpm exec vitest run --project unit test/card-handler-overload.test.ts test/host-overload-alert.test.ts test/session-liveness.test.ts test/dashboard-ipc.test.ts test/idle-worker-sweeper.test.ts test/worker-suspend.test.ts`（6 files / 150 tests passed）
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `git diff --check`

## 现场验证

部署后四个 daemon 均收到 `clean_stopped`：持有僵尸的 daemon 关闭 5/5，其余为 0/0；卡片刷新为“僵尸会话 0 个 / 已清理 5 个僵尸”。
