### PR TITLE
fix(skills): agentbuddy 下载凭证过期时快速失败而非卡处理中

### DIFF
--- a/src/dashboard/web/skills-page.tsx
+++ b/src/dashboard/web/skills-page.tsx
@@ -949,6 +949,7 @@ function SkillsPage() {
       return tr('skills.gitNeedsAuth');
     }
     if (msg.startsWith('agentbuddy_not_found')) return tr('skills.agentbuddyNotFound');
+    if (msg.startsWith('agentbuddy_login_required')) return tr('skills.agentbuddyNeedsLogin');
     if (msg.startsWith('agentbuddy_command_failed')) {
       return /login|credential|unauthor|not logged|401|403/i.test(msg)
         ? tr('skills.agentbuddyNeedsLogin')

--- a/src/services/skill-registry-store.ts
+++ b/src/services/skill-registry-store.ts
@@ -1,5 +1,5 @@
 import { closeSync, cpSync, existsSync, lstatSync, mkdirSync, mkdtempSync, openSync, readFileSync, readSync, readdirSync, realpathSync, rmSync, statSync } from 'node:fs';
-import { execFile, execFileSync } from 'node:child_process';
+import { execFile, execFileSync, spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { promisify } from 'node:util';
@@ -977,19 +977,38 @@ function agentbuddyInstallArgs(opts: AgentbuddySource): string[] {
   return [...args, ...flags];
 }
 
+/** agentbuddy uses a SEPARATE download/AI credential from the SSO login cache:
+ *  `whoami`/`login` can report "logged in" while the download cred is expired.
+ *  In that case `skill add` doesn't fail — it prints a device-login URL and
+ *  polls the auth server for authorization (NOT stdin), so on a headless daemon
+ *  it hangs until our timeout. `--strict` only checks the login cache, not this.
+ *  Detect the interactive-auth prompt in the child's output and treat it as a
+ *  fast, actionable failure ("run agentbuddy login on the host") instead of a
+ *  minutes-long "processing" hang. */
+const AGENTBUDDY_LOGIN_PROMPT_RE = /No valid credentials|Waiting for authorization|\/auth\/api\/v1\/(lark|ai)\/login|open this URL|Verification code:/i;
+
+function isAgentbuddyLoginPrompt(text: string): boolean {
+  return AGENTBUDDY_LOGIN_PROMPT_RE.test(text);
+}
+
 function runAgentbuddyCli(args: string[], cwd: string, failCode: string): void {
   const { bin, prefixArgs } = agentbuddyCommand();
   try {
-    execFileSync(bin, [...prefixArgs, ...args], {
+    const out = execFileSync(bin, [...prefixArgs, ...args], {
       cwd,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
       timeout: agentbuddyTimeoutMs(),
     });
+    // Sync path can't kill mid-stream; if agentbuddy somehow printed a login
+    // prompt yet still exited 0, surface the actionable error anyway.
+    if (isAgentbuddyLoginPrompt(out)) throw new Error('agentbuddy_login_required');
   } catch (err: any) {
+    if (err?.message === 'agentbuddy_login_required') throw err;
     if (err?.code === 'ENOENT') throw new Error('agentbuddy_not_found');
     const stderr = Buffer.isBuffer(err?.stderr) ? err.stderr.toString('utf-8').trim() : String(err?.stderr ?? '').trim();
     const stdout = Buffer.isBuffer(err?.stdout) ? err.stdout.toString('utf-8').trim() : String(err?.stdout ?? '').trim();
+    if (isAgentbuddyLoginPrompt(`${stdout}\n${stderr}`)) throw new Error('agentbuddy_login_required');
     throw new Error(`${failCode}: ${stderr || stdout || err?.message || String(err)}`);
   }
 }
@@ -1109,14 +1128,39 @@ function registerAgentbuddyStaging(
 
 async function runAgentbuddyCliAsync(args: string[], cwd: string, failCode: string): Promise<void> {
   const { bin, prefixArgs } = agentbuddyCommand();
-  try {
-    await execFileAsync(bin, [...prefixArgs, ...args], { cwd, encoding: 'utf-8', timeout: agentbuddyTimeoutMs() });
-  } catch (err: any) {
-    if (err?.code === 'ENOENT') throw new Error('agentbuddy_not_found');
-    const stderr = Buffer.isBuffer(err?.stderr) ? err.stderr.toString('utf-8').trim() : String(err?.stderr ?? '').trim();
-    const stdout = Buffer.isBuffer(err?.stdout) ? err.stdout.toString('utf-8').trim() : String(err?.stdout ?? '').trim();
-    throw new Error(`${failCode}: ${stderr || stdout || err?.message || String(err)}`);
-  }
+  return new Promise<void>((resolve, reject) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(bin, [...prefixArgs, ...args], { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch (err: any) {
+      reject(err?.code === 'ENOENT' ? new Error('agentbuddy_not_found') : err);
+      return;
+    }
+    let out = '';
+    let settled = false;
+    let killedForLogin = false;
+    const timer = setTimeout(() => { if (!settled) { killedForLogin = false; child.kill('SIGKILL'); } }, agentbuddyTimeoutMs());
+    const finish = (fn: () => void) => { if (settled) return; settled = true; clearTimeout(timer); fn(); };
+    const onData = (chunk: Buffer) => {
+      out += chunk.toString('utf-8');
+      // Kill the moment the interactive-auth prompt appears — it polls the auth
+      // server, not stdin, so it would otherwise hang until the timeout.
+      if (!killedForLogin && isAgentbuddyLoginPrompt(out)) {
+        killedForLogin = true;
+        child.kill('SIGKILL');
+      }
+    };
+    child.stdout?.on('data', onData);
+    child.stderr?.on('data', onData);
+    child.on('error', (err: any) => finish(() => reject(err?.code === 'ENOENT' ? new Error('agentbuddy_not_found') : err)));
+    child.on('close', (code) => finish(() => {
+      if (killedForLogin || isAgentbuddyLoginPrompt(out)) { reject(new Error('agentbuddy_login_required')); return; }
+      if (code === 0) { resolve(); return; }
+      const trimmed = out.trim();
+      if (child.killed) { reject(new Error(`${failCode}: timed out after ${agentbuddyTimeoutMs()}ms`)); return; }
+      reject(new Error(`${failCode}: ${trimmed || `exit ${code}`}`));
+    }));
+  });
 }
 
 export function installAgentbuddySkill(opts: AgentbuddySource, requireSkillName?: string): SkillPackage[] {

--- a/test/skill-agentbuddy-install.test.ts
+++ b/test/skill-agentbuddy-install.test.ts
@@ -29,6 +29,14 @@ const { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, readdirSync 
 const { join } = require('node:path');
 if (process.env.FAKE_AB_FAIL === '1') { process.stderr.write('needs login\\n'); process.exit(1); }
 if (process.env.FAKE_AB_EMPTY === '1') { process.exit(0); }
+// Simulate an expired download credential: print the interactive-auth prompt,
+// then poll "forever" (never touch stdin) — mirrors real agentbuddy so the
+// wrapper must detect the prompt and kill, not wait out the timeout.
+if (process.env.FAKE_AB_LOGIN_HANG === '1') {
+  process.stdout.write('[INFO] Downloading...\\nNo valid credentials. Logging in...\\n\\n  To login, open this URL in any browser:\\n  https://host/auth/api/v1/lark/login?session=X\\n\\n  Waiting for authorization...\\n');
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 60000);
+  process.exit(0);
+}
 const argv = process.argv.slice(2);
 const TEL_START = '<!-- @telemetry:start -->';
 const TEL_END = '<!-- @telemetry:end -->';
@@ -90,6 +98,7 @@ describe('agentbuddy skill install', () => {
     vi.stubEnv('BOTMUX_AGENTBUDDY_CMD', `node ${fakeBin}`);
     vi.stubEnv('FAKE_AB_FAIL', '');
     vi.stubEnv('FAKE_AB_EMPTY', '');
+    vi.stubEnv('FAKE_AB_LOGIN_HANG', '');
     vi.stubEnv('FAKE_AB_TELEMETRY', '');
     vi.stubEnv('FAKE_AB_SCRUB_NOOP', '');
     vi.stubEnv('FAKE_AB_DELAY_MS', '');
@@ -195,6 +204,17 @@ describe('agentbuddy skill install', () => {
   it('errors when the CLI produces no skill', () => {
     vi.stubEnv('FAKE_AB_EMPTY', '1');
     expect(() => installAgentbuddySkill({ group: 'g/h', skill: 'deploy' })).toThrow(/agentbuddy_no_skill_produced/);
+  });
+
+  it('fails fast (no timeout hang) when the download credential is expired and agentbuddy drops to interactive login', async () => {
+    vi.stubEnv('FAKE_AB_LOGIN_HANG', '1');
+    // Big timeout: if we waited it out the test would take 30s. The prompt
+    // detector must kill the child and reject almost immediately.
+    vi.stubEnv('BOTMUX_AGENTBUDDY_TIMEOUT_MS', '30000');
+    const started = performance.now();
+    await expect(installAgentbuddySkillAsync({ group: 'g/h', skill: 'deploy' })).rejects.toThrow(/agentbuddy_login_required/);
+    expect(performance.now() - started).toBeLessThan(5000);
+    expect(readSkillRegistry().skills.deploy).toBeUndefined();
   });
 
   it('serializes concurrent same-identifier installs (no staging clobber)', async () => {


### PR DESCRIPTION
## 现象
dashboard 安装 agentbuddy skill 一直「处理中」，直到 180s 超时才失败（申晗 live 实测复现）。

## 根因
agentbuddy 下载 skill 用的凭证（get-jwt 的 `ai/login`）与 SSO 登录缓存是**两套独立凭证**。`whoami` / `login` 报「已登录 / Already logged in」时，下载凭证仍可能过期。此时 `skill add` **不报错**，而是打印设备登录 URL 并轮询授权服务器（不读 stdin）——headless daemon 无法应答，于是挂到超时。此前加的 `--strict` 只检查登录缓存、不检查下载凭证，兜不住这条路径。

## 修复
- `runAgentbuddyCliAsync`（dashboard job 走的路径）改用 `spawn` 流式读取子进程输出，一旦匹配到交互式登录提示（`No valid credentials` / `Waiting for authorization` / `auth/api/v1/{lark,ai}/login` / `Verification code` 等）立即 `SIGKILL` 并以 `agentbuddy_login_required` **快速失败**。
- sync 路径（CLI）做等价的事后判定。
- dashboard `mapInstallError` 把 `agentbuddy_login_required` 映射到「请在部署机 `agentbuddy login`」的可操作提示（复用 `agentbuddyNeedsLogin` 文案），不再显示原始技术错误或卡住。

## 运维侧
部署机遇到该情况重跑一次 `agentbuddy login` 刷新下载凭证即可（已在 live 上验证：刷新后原命令立即安装成功）。

## 测试
- built dist 对真实形态登录提示 **45ms 内 reject**（原 180s 挂起）。
- 新增回归测试：模拟凭证过期（打印登录提示后长睡），断言 <5s fail-fast 且不写 registry。
- `tsc` + 全套 skill/dashboard 测试 + bundle 绿。

（本 fix 承接已合并的 #432 agentbuddy 安装能力。）