### PR TITLE
feat(claude-code): 自动确认运行中 /effort 切档的 Yes/No 框

### DIFF
--- a/src/utils/effort-confirm-dialog.ts
+++ b/src/utils/effort-confirm-dialog.ts
@@ -1,0 +1,82 @@
+import { stripAnsiForLog } from './crash-log.js';
+
+export type EffortConfirmAction = 'pass' | 'confirm';
+
+/**
+ * Auto-confirm Claude Code's mid-session "Change effort level?" dialog.
+ *
+ * When botmux passes a fully-qualified `/effort <level>` command through to
+ * Claude Code *during* a session, the client shows a Yes/No confirmation
+ * ("This conversation is cached… Switching to <level> means the full history
+ * gets re-read"). The user already expressed the target level when they typed
+ * the command, so the second confirmation is pure friction — and because this
+ * native slash dialog fires no hook (unlike AskUserQuestion) and is not caught
+ * by any screen detector, an un-answered dialog silently parks the session on a
+ * green "awaiting input" card with no way to answer from Feishu.
+ *
+ * This guard is *armed* only by botmux's own `/effort <level>` passthrough, so
+ * it never inspects arbitrary screens. While armed it watches PTY chunks for
+ * the effort dialog's distinctive title plus a rendered confirm option; on a
+ * match it reports `confirm` (the caller presses Enter on the default "Yes"
+ * row) and disarms. The caller also disarms on a timeout, so a `/effort` that
+ * needs no confirmation (e.g. first use in a fresh session) leaves no residue.
+ *
+ * Bare `/effort` (no level) opens a level *picker*, not a Yes/No confirm — the
+ * target is unknown, so it is intentionally NOT armed here.
+ */
+export class EffortConfirmDialogGuard {
+  private armed = false;
+  private tail = '';
+
+  /** Arm after a `/effort <level>` passthrough is written to the CLI. */
+  arm(): void {
+    this.armed = true;
+    this.tail = '';
+  }
+
+  /** Whether the guard is currently watching for the confirm dialog. */
+  isArmed(): boolean {
+    return this.armed;
+  }
+
+  /** Stop watching (fired dialog, timed out, or CLI respawn). */
+  disarm(): void {
+    this.armed = false;
+    this.tail = '';
+  }
+
+  reset(): void {
+    this.disarm();
+  }
+
+  inspect(data: string): EffortConfirmAction {
+    if (!this.armed) return 'pass';
+
+    const plain = stripAnsiForLog(data).replace(/\s+/g, '').toLowerCase();
+    this.tail = (this.tail + plain).slice(-4_096);
+
+    // Match structurally, and only *after* the most recent title, so stale
+    // scrollback (e.g. an earlier assistant answer containing "yes") before a
+    // half-drawn title can never be mistaken for the rendered options. The
+    // dialog's numbered rows collapse to `1.yes…` / `2.no…` once ANSI cursor
+    // moves and whitespace are stripped; requiring BOTH confirms the choices
+    // have actually rendered before we press Enter.
+    const titleAt = this.tail.lastIndexOf('changeeffortlevel');
+    if (titleAt < 0) return 'pass';
+    const afterTitle = this.tail.slice(titleAt);
+    const hasYesRow = /1\.yes/.test(afterTitle);
+    const hasNoRow = /2\.no/.test(afterTitle);
+    if (!hasYesRow || !hasNoRow) return 'pass';
+
+    // One-shot: disarm so a later composer redraw can't inherit menu words.
+    this.disarm();
+    return 'confirm';
+  }
+}
+
+/** True for `/effort <level>` (a confirmable switch), false for bare `/effort`
+ *  (a level picker), a multi-token line, or any other command. Anchored to a
+ *  single argument so only the confirm-dialog form arms the guard. */
+export function isEffortLevelCommand(content: string): boolean {
+  return /^\s*\/effort\s+\S+\s*$/.test(content);
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -55,6 +55,7 @@ import { canStartInjectionFlush, shouldDeferUserFlush, shouldFlushInjectionsFirs
 import { decideRestartFollowup, settleDurableTurnForRestart } from './core/restart-followup-policy.js';
 import { stripAnsiForLog, tailChars } from './utils/crash-log.js';
 import { CodexUpdateDialogGuard } from './utils/codex-update-dialog.js';
+import { EffortConfirmDialogGuard, isEffortLevelCommand } from './utils/effort-confirm-dialog.js';
 import { installStdioEpipeGuard, isIgnorableStreamError } from './utils/stdio-epipe-guard.js';
 import {
   mergeQueuedCliInput,
@@ -1612,6 +1613,10 @@ async function deliverRawInput(msg: Extract<DaemonToWorker, { type: 'raw_input' 
     isPromptReady = false;
     idleDetector?.reset();
     log(`Passthrough slash command: ${msg.content}`);
+    // A mid-session `/effort <level>` opens a Yes/No "Change effort level?"
+    // confirm dialog; arm the guard so onPtyData can auto-accept it. Bare
+    // `/effort` opens a level picker (unknown target) and is left alone.
+    if (isEffortLevelCommand(msg.content)) armEffortConfirm();
   } catch (err: any) {
     // Do not send another queued command against a backend whose write failed.
     isPromptReady = false;
@@ -4828,6 +4833,34 @@ async function driveCocoPicker(navKeys: string[], needsReviewSubmit: boolean, co
 const TRUST_DIALOG_PATTERN = /Yes, I trust this folder|Yes, continue/;
 let trustHandled = false;
 const codexUpdateDialogGuard = new CodexUpdateDialogGuard();
+// Auto-confirm Claude Code's mid-session "Change effort level?" Yes/No dialog.
+// Armed only by botmux's own `/effort <level>` passthrough (see deliverRawInput)
+// and disarmed on match, timeout, or CLI respawn — never inspects idle screens.
+const effortConfirmGuard = new EffortConfirmDialogGuard();
+let effortConfirmTimer: ReturnType<typeof setTimeout> | null = null;
+// The dialog appears within a second of the command landing; keep the arm
+// window short so a later, unrelated screen can never be mistaken for it.
+const EFFORT_CONFIRM_WINDOW_MS = 8_000;
+
+function disarmEffortConfirm(): void {
+  if (effortConfirmTimer) {
+    clearTimeout(effortConfirmTimer);
+    effortConfirmTimer = null;
+  }
+  effortConfirmGuard.disarm();
+}
+
+/** Arm the effort-confirm guard for a bounded window after a `/effort <level>`
+ *  passthrough. Only claude-code sessions we drive show this dialog. */
+function armEffortConfirm(): void {
+  if (lastInitConfig?.cliId !== 'claude-code' || lastInitConfig.adoptMode) return;
+  disarmEffortConfirm();
+  effortConfirmGuard.arm();
+  effortConfirmTimer = setTimeout(() => {
+    effortConfirmTimer = null;
+    effortConfirmGuard.disarm();
+  }, EFFORT_CONFIRM_WINDOW_MS);
+}
 
 /**
  * Aiden refuses the Codex `-c check_for_update_on_startup=false` override.
@@ -5156,6 +5189,20 @@ function onPtyData(data: string): void {
       }
       return;
     }
+  }
+
+  // Effort-switch confirm auto-accept. Armed only by our own `/effort <level>`
+  // passthrough, so this never fires on an ordinary screen. The dialog's
+  // default row is "Yes", so Enter confirms — mirroring the trust dialog.
+  if (effortConfirmGuard.isArmed() && effortConfirmGuard.inspect(data) === 'confirm') {
+    disarmEffortConfirm();
+    log('Effort-switch confirm dialog detected, auto-accepting...');
+    if (backend && 'sendSpecialKeys' in backend) {
+      (backend as any).sendSpecialKeys('Enter');
+    } else {
+      backend?.write('\r');
+    }
+    return;
   }
 
   // Track last PTY output time for the ready-gate quiescence settle (see
@@ -8572,6 +8619,7 @@ function killCli(opts: { preservePending?: boolean } = {}): void {
   altBufferActive = false;
   trustHandled = false;
   codexUpdateDialogGuard.reset();
+  disarmEffortConfirm();
   appRunnerControlDecoder.reset();
 }
 

--- a/test/effort-confirm-dialog.test.ts
+++ b/test/effort-confirm-dialog.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EffortConfirmDialogGuard,
+  isEffortLevelCommand,
+} from '../src/utils/effort-confirm-dialog.js';
+
+describe('isEffortLevelCommand', () => {
+  it('matches /effort with a single explicit level', () => {
+    expect(isEffortLevelCommand('/effort max')).toBe(true);
+    expect(isEffortLevelCommand('/effort ultracode')).toBe(true);
+    expect(isEffortLevelCommand('  /effort high  ')).toBe(true);
+  });
+
+  it('does not match bare /effort (opens a picker, unknown target)', () => {
+    expect(isEffortLevelCommand('/effort')).toBe(false);
+    expect(isEffortLevelCommand('/effort   ')).toBe(false);
+  });
+
+  it('does not match a multi-token line (anchored to one argument)', () => {
+    expect(isEffortLevelCommand('/effort max please')).toBe(false);
+    expect(isEffortLevelCommand('/effort max now')).toBe(false);
+  });
+
+  it('does not match other commands', () => {
+    expect(isEffortLevelCommand('/model opus')).toBe(false);
+    expect(isEffortLevelCommand('/fast')).toBe(false);
+    expect(isEffortLevelCommand('effort max')).toBe(false);
+    expect(isEffortLevelCommand('please /effort max')).toBe(false);
+  });
+});
+
+describe('EffortConfirmDialogGuard', () => {
+  it('passes on every chunk until it is armed', () => {
+    const guard = new EffortConfirmDialogGuard();
+    expect(guard.isArmed()).toBe(false);
+    expect(
+      guard.inspect('Change effort level?\n❯ 1. Yes, switch to max\n  2. No, go back'),
+    ).toBe('pass');
+  });
+
+  it('confirms the fully-rendered effort dialog through ANSI', () => {
+    const guard = new EffortConfirmDialogGuard();
+    guard.arm();
+    const dialog =
+      '\x1b[2J\x1b[1;1HChange effort level?\x1b[3;1HYour next response will be slower'
+      + '\x1b[5;1H\x1b[7m❯ 1. Yes, switch to max\x1b[6;1H  2. No, go back';
+    expect(guard.inspect(dialog)).toBe('confirm');
+  });
+
+  it('detects the dialog split across PTY chunks', () => {
+    const guard = new EffortConfirmDialogGuard();
+    guard.arm();
+    // Title first, then the two option rows in a later redraw chunk.
+    expect(guard.inspect('\x1b[1;1HChange effort level?')).toBe('pass');
+    expect(guard.inspect('\x1b[5;1H❯ 1. Yes, switch to ultracode\x1b[6;1H  2. No, go back')).toBe(
+      'confirm',
+    );
+  });
+
+  it('requires BOTH numbered rows: title + only "1. Yes" is not enough', () => {
+    const guard = new EffortConfirmDialogGuard();
+    guard.arm();
+    expect(guard.inspect('Change effort level?\n❯ 1. Yes, switch to max')).toBe('pass');
+    expect(guard.isArmed()).toBe(true);
+  });
+
+  // Reviewer's reproduction: stale scrollback containing "yes" BEFORE a
+  // half-drawn title must never be read as the rendered confirm option.
+  it('does not confirm when "yes" is stale scrollback preceding the title', () => {
+    const guard = new EffortConfirmDialogGuard();
+    guard.arm();
+    expect(guard.inspect('Earlier assistant answer: yes, that works\n')).toBe('pass');
+    expect(guard.inspect('\x1b[1;1HChange effort level?')).toBe('pass');
+    expect(guard.isArmed()).toBe(true);
+  });
+
+  it('only matches options AFTER the most recent title', () => {
+    const guard = new EffortConfirmDialogGuard();
+    guard.arm();
+    // "1. Yes / 2. No" appear as prior prose, THEN a bare title redraw — the
+    // options are before the title, so they must not count.
+    expect(guard.inspect('checklist: 1. yes path 2. no path\n')).toBe('pass');
+    expect(guard.inspect('Change effort level?')).toBe('pass');
+    expect(guard.isArmed()).toBe(true);
+  });
+
+  it('is one-shot: disarms after confirming so a redraw cannot re-fire', () => {
+    const guard = new EffortConfirmDialogGuard();
+    guard.arm();
+    const dialog = 'Change effort level?\n❯ 1. Yes, switch to max\n  2. No, go back';
+    expect(guard.inspect(dialog)).toBe('confirm');
+    expect(guard.isArmed()).toBe(false);
+    expect(guard.inspect(dialog)).toBe('pass');
+  });
+
+  it('does not mistake an ordinary composer screen for the dialog', () => {
+    const guard = new EffortConfirmDialogGuard();
+    guard.arm();
+    expect(guard.inspect('❯ yes, please write the tests for @file')).toBe('pass');
+    expect(guard.isArmed()).toBe(true);
+  });
+
+  it('disarm and reset stop it watching', () => {
+    const guard = new EffortConfirmDialogGuard();
+    guard.arm();
+    guard.disarm();
+    expect(guard.isArmed()).toBe(false);
+    expect(
+      guard.inspect('Change effort level?\n❯ 1. Yes, switch to max\n  2. No, go back'),
+    ).toBe('pass');
+
+    guard.arm();
+    guard.reset();
+    expect(guard.isArmed()).toBe(false);
+  });
+});


### PR DESCRIPTION
## 现象

在飞书里对一个 Claude Code bot 发 `/effort <档位>`(如 `/effort max`)切换思考等级时,会话会卡住:飞书卡片停在绿色「等待输入」,但既没显示要选什么,也没有作答入口,切档无法完成。

根因:会话运行中透传 `/effort <档位>` 时,Claude Code 客户端会弹一个原生的 Yes/No 确认框(「Change effort level? / This conversation is cached… Switching to X means the full history gets re-read」),因为切档会作废已缓存的对话、需重读历史。而 botmux 判定「等待输入」只看 `isPromptReady`(屏幕静默 + 出现 `❯`),无法区分「空 composer 等你打字」和「阻塞选择框等你按键」——确认框静止后正好命中 idle 判据,被渲染成「等待输入」绿卡。用户在飞书发文字会被敲进那个框,但框要的是方向键/回车,于是卡死。

> 注:启动时设 effort(`startupCommands` 里的 `/effort <arg>`)不弹框(无缓存);此框只在**会话中途切换**时出现。

## 为什么不走 ask-hook / 截屏

- Claude Code 的原生 slash 确认框**不触发任何 hook**(官方 hook 文档确认:`/model` 切换不触发 hook;`Notification` matcher 枚举无 slash-picker;`Elicitation` 仅 MCP)。botmux 只注册了 `PreToolUse(matcher=AskUserQuestion)`,ask-hook 只接工具调用型提问,接不住原生框。
- 通用 LLM 扫屏(旧 `ScreenAnalyzer`)已于 2026-07-26 作为死代码删除,成本高、脆弱。
- **命令感知**:这条 `/effort` 是 botmux 自己透传的,它在敲入那一刻就知道预期会弹确认框。据此只在这个窄窗口内识别,不猜任意屏幕。

## 改动

新增 `EffortConfirmDialogGuard`(仿现有 `CodexUpdateDialogGuard` / trust-dialog auto-accept):

- `deliverRawInput` 透传 `/effort <档位>` 后 `armEffortConfirm()`;
- 只对 `cliId==='claude-code'` 且非 adopt 会话武装,8 秒窗口过期自动解除;
- `onPtyData` 里 guard 命中确认框时替按 `Enter`(默认高亮行即 Yes),一次性(命中即 disarm);
- `killCli` 清理定时器与状态。

**误判防护**(review 轮1 指出并修复):matcher 只在最近一次标题 `changeeffortlevel` **之后**匹配,且要求结构化的 `1.Yes` 与 `2.No` **同时**出现,旧滚屏里的裸 `yes` 不再参与命中;命令正则锚定为单参数 `/^\s*\/effort\s+\S+\s*$/`(裸 `/effort` 弹的是档位列表、目标未知,不武装)。

下游发卡/回传按键管线未改动(复用既有 `tui_keys` → `handleTuiKeys`)。

## 测试

- `effort-confirm` 单测 13 例全绿,含 review 复现的反例:「旧文本含 yes + 后续只有半绘标题 → 必须 `pass`」、「选项在标题之前 → `pass`」、「只有 1.Yes 无 2.No → `pass`」。
- 相关回归(trust-dialog / codex-update-dialog / effort)全绿。
- `tsc --noEmit`:本改动涉及文件 0 错(仓库既有 electron/proxy-agent 可选依赖缺失报错与本改动无关)。
- 真机验证:部署到 claude-code bot 后,会话中 `/effort high`、`/effort xhigh` 均直接切好、不再停在确认框。

## Review

两轮 code review(轮1 发现真 bug:matcher 过宽会误按 Enter,已按建议修复;轮2 独立重跑 44/44 测试 + tsc + 重放攻击,通过)。

## 未验证 / 边界

- 只覆盖 botmux 主动透传 `/effort <档位>` 触发的框;模型自己中途弹的框不在本 PR 范围。
- `/model`(动态模型列表,选项 botmux 不预知)未处理,是后续独立工作。
- Claude Code 的 `/effort <档位>` 会把该档位持久化为新会话默认(写 `~/.claude/settings.json` 的 `effortLevel`)——这是 Claude Code 自身行为,与本改动无关,本 PR 不处理(已与需求方确认接受)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
