### PR TITLE
fix(skills): agentbuddy 快速失败杀整进程组(修 shim 孙进程漏杀仍挂起)

### DIFF
--- a/src/services/skill-registry-store.ts
+++ b/src/services/skill-registry-store.ts
@@ -1131,7 +1131,11 @@ async function runAgentbuddyCliAsync(args: string[], cwd: string, failCode: stri
   return new Promise<void>((resolve, reject) => {
     let child: ReturnType<typeof spawn>;
     try {
-      child = spawn(bin, [...prefixArgs, ...args], { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+      // detached → own process group, so we can SIGKILL the WHOLE tree. The
+      // configured command is usually a shim (`npx agentbuddy@latest …`), so the
+      // real agentbuddy is a grandchild; killing only the direct child would
+      // leave it alive holding the pipes and polling the auth server.
+      child = spawn(bin, [...prefixArgs, ...args], { cwd, stdio: ['ignore', 'pipe', 'pipe'], detached: true });
     } catch (err: any) {
       reject(err?.code === 'ENOENT' ? new Error('agentbuddy_not_found') : err);
       return;
@@ -1139,7 +1143,12 @@ async function runAgentbuddyCliAsync(args: string[], cwd: string, failCode: stri
     let out = '';
     let settled = false;
     let killedForLogin = false;
-    const timer = setTimeout(() => { if (!settled) { killedForLogin = false; child.kill('SIGKILL'); } }, agentbuddyTimeoutMs());
+    let timedOut = false;
+    const killTree = () => {
+      try { if (child.pid) process.kill(-child.pid, 'SIGKILL'); } catch { /* group gone */ }
+      try { child.kill('SIGKILL'); } catch { /* already dead */ }
+    };
+    const timer = setTimeout(() => { if (!settled) { timedOut = true; killTree(); } }, agentbuddyTimeoutMs());
     const finish = (fn: () => void) => { if (settled) return; settled = true; clearTimeout(timer); fn(); };
     const onData = (chunk: Buffer) => {
       out += chunk.toString('utf-8');
@@ -1147,18 +1156,20 @@ async function runAgentbuddyCliAsync(args: string[], cwd: string, failCode: stri
       // server, not stdin, so it would otherwise hang until the timeout.
       if (!killedForLogin && isAgentbuddyLoginPrompt(out)) {
         killedForLogin = true;
-        child.kill('SIGKILL');
+        killTree();
       }
     };
     child.stdout?.on('data', onData);
     child.stderr?.on('data', onData);
     child.on('error', (err: any) => finish(() => reject(err?.code === 'ENOENT' ? new Error('agentbuddy_not_found') : err)));
-    child.on('close', (code) => finish(() => {
+    // Settle on 'exit' (direct child terminated), NOT 'close' (all stdio EOF):
+    // a killed shim can leave a grandchild holding the pipes so 'close' never
+    // fires. Detecting login → killTree → 'exit' → reject login_required.
+    child.on('exit', (code) => finish(() => {
       if (killedForLogin || isAgentbuddyLoginPrompt(out)) { reject(new Error('agentbuddy_login_required')); return; }
+      if (timedOut) { reject(new Error(`${failCode}: timed out after ${agentbuddyTimeoutMs()}ms`)); return; }
       if (code === 0) { resolve(); return; }
-      const trimmed = out.trim();
-      if (child.killed) { reject(new Error(`${failCode}: timed out after ${agentbuddyTimeoutMs()}ms`)); return; }
-      reject(new Error(`${failCode}: ${trimmed || `exit ${code}`}`));
+      reject(new Error(`${failCode}: ${out.trim() || `exit ${code}`}`));
     }));
   });
 }

--- a/test/skill-agentbuddy-install.test.ts
+++ b/test/skill-agentbuddy-install.test.ts
@@ -217,6 +217,24 @@ describe('agentbuddy skill install', () => {
     expect(readSkillRegistry().skills.deploy).toBeUndefined();
   });
 
+  it('fails fast even when a shim grandchild (npx-style) holds the pipes open', async () => {
+    // Reproduces the real deploy shape: BOTMUX_AGENTBUDDY_CMD is a shim
+    // (`npx agentbuddy@latest …`) whose grandchild is the real CLI. Killing only
+    // the direct child leaves the grandchild alive holding stdout/stderr, so
+    // 'close' never fires — the runner must kill the whole process group and
+    // settle on 'exit'. The shim runs the login-hang fake WITHOUT exec, so node
+    // is a true grandchild that would outlive a direct-child-only kill.
+    const shim = join(mkdtempSync(join(tmpdir(), 'botmux-ab-shim-')), 'shim.sh');
+    writeFileSync(shim, `#!/bin/bash\nnode ${fakeBin} "$@"\n`, { mode: 0o755 });
+    vi.stubEnv('BOTMUX_AGENTBUDDY_CMD', shim);
+    vi.stubEnv('FAKE_AB_LOGIN_HANG', '1');
+    vi.stubEnv('BOTMUX_AGENTBUDDY_TIMEOUT_MS', '30000');
+    const started = performance.now();
+    await expect(installAgentbuddySkillAsync({ group: 'g/h', skill: 'deploy' })).rejects.toThrow(/agentbuddy_login_required/);
+    expect(performance.now() - started).toBeLessThan(8000);
+    expect(readSkillRegistry().skills.deploy).toBeUndefined();
+  });
+
   it('serializes concurrent same-identifier installs (no staging clobber)', async () => {
     vi.stubEnv('FAKE_AB_DELAY_MS', '150'); // hold the staging so the two would overlap unlocked
     const opts = { group: 'g/h', skill: 'deploy' };


### PR DESCRIPTION
## 背景
#663 给 agentbuddy 安装加了「检测到登录提示就快速失败」，但对**真实部署**无效——我随后 live 实测（部署机 agentbuddy logout 后）发现仍会挂到超时。

## 根因
`BOTMUX_AGENTBUDDY_CMD` 在部署机通常是 shim（`npx agentbuddy@latest …`），真正的 agentbuddy 是**孙进程**。#663 只 `child.kill()` 杀直接子进程（npx/shim），孙进程存活并继续持有 stdout/stderr 管道 → `'close'` 事件永不触发 → Promise 照样挂到超时。#663 的单测用单进程 fake CLI，漏掉了这个进程树维度（我的疏忽，已补测）。

## 修复
- spawn 加 `detached: true` 拿独立进程组；检测到登录提示 / 超时时 `process.kill(-pid, 'SIGKILL')` 杀**整组**（含孙进程），兜底再 kill 直接子。
- 结算监听 `'exit'`（直接子退出即触发）而非 `'close'`（需所有 stdio EOF，被存活孙进程阻塞）。
- 新增回归测试：经不 exec 的 shim 起 fake CLI（node 成真孙进程），断言 <8s fast-fail 且不写 registry——旧的直接子 kill 会挂到此测试超时。

## 验证
真机（部署机 agentbuddy 已 logout）：原命令 **7s 内** `agentbuddy_login_required` 失败，进程树无残留孤儿。`tsc` + 全套 skill/dashboard 测试（17+63）+ bundle 绿。

（承接 #663。）