### PR TITLE
fix(worker): 修 iOS 三方输入法在 WebShell 无法输入 / 语音纠错重复

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9292,6 +9292,82 @@ function _showReadonlyToast(){
 }
 document.getElementById('terminal').addEventListener('contextmenu',function(e){e.preventDefault()});
 
+// ── iOS third-party IME fix (keyCode=229 + composed insertText dead-path) ──
+// Some iOS third-party keyboards (Doubao/豆包 for every char, WeChat/微信 for
+// spaces & trailing single chars) deliver text as: keydown(keyCode=229) →
+// input(inputType=insertText, composed=true) with NO composition events. xterm
+// 5.x drops these:
+//   • _inputEvent bails because its guard is (!ev.composed || !_keyDownSeen) —
+//     here composed=true AND a 229 keydown set _keyDownSeen, so both are false.
+//   • the only fallback (CompositionHelper._handleAnyTextareaChanges) uses a
+//     setTimeout + String.replace(oldValue,'') diff that miscomputes under fast
+//     consecutive input, so characters are silently lost.
+//
+// Voice-input correction (Doubao 语音) exposes a SECOND bug: one physical
+// Backspace fires MANY deleteContentBackward events in the textarea (it wants to
+// delete a whole run), but xterm emits only ONE \x7f per Backspace keydown — so
+// the terminal deletes 1 char while the textarea deleted N, leaving N-1 stale
+// chars that reappear when Doubao then re-inserts the corrected sentence
+// (the "everything repeats" symptom). We must forward EACH delete event.
+//
+// Diagnosed from real-device iOS event traces. Upstream: xterm.js #5835 / #5836.
+//
+// Strategy — take over ONLY these dead/lossy paths, nothing else:
+//   1. attachCustomKeyEventHandler returns false to CLAIM a key so xterm skips
+//      it (no broken 229 fallback; no single-\x7f Backspace) — this is also what
+//      prevents double-emit. We claim: keydown 229 (not composing), AND
+//      Backspace ONLY WHEN the textarea is non-empty (an IME edit is pending).
+//      An empty textarea means a normal terminal Backspace (delete the CLI line)
+//      → we DON'T claim it, so xterm sends its standard \x7f. This is critical:
+//      claiming an empty-textarea Backspace would swallow it (no input event).
+//   2. our textarea 'input' listener forwards each event: insertText → the data,
+//      each delete* → one \x7f, so N textarea deletes become N terminal deletes.
+//   3. composition input (WeChat Chinese) is untouched — it already works — so
+//      we never interfere while _composing is true.
+// term.input(data,true) routes through onData like real typing (NOT paste — it
+// must not bracketed-paste-wrap per-char input nor clear the textarea), so the
+// readonly gating in onData still applies.
+if(hasToken && !/[?&]imefix=0\\b/.test(location.search)){(function(){
+  var _claim=false;     // current key is claimed (229 dead-path or IME Backspace)
+  var _composing=false; // a real composition (compositionstart..end) is active
+  var _ta=term.textarea;
+  try{
+    term.attachCustomKeyEventHandler(function(e){
+      if(e.type==='keydown'&&!_composing){
+        if(e.keyCode===229){ _claim=true; return false; }
+        // Backspace: claim ONLY when an IME edit is pending (textarea non-empty),
+        // so one physical backspace's N delete events all reach the terminal.
+        // Empty textarea → normal terminal backspace, let xterm send its \x7f.
+        if(e.keyCode===8 && _ta && _ta.value.length>0){ _claim=true; return false; }
+      }
+      return true;
+    });
+  }catch(_e){}
+  if(_ta){
+    // compositionstart/end bound the reliable path; never take over inside it.
+    _ta.addEventListener('compositionstart',function(){_composing=true;_claim=false;},{capture:true,passive:true});
+    _ta.addEventListener('compositionend',function(){_composing=false;_claim=false;},{capture:true,passive:true});
+    // A single claimed keydown can fire MULTIPLE input events, e.g. the
+    // consecutive-space→。 conversion (delete THEN insertText) or a voice-input
+    // correction (many deletes). So DON'T clear _claim per-input — forward every
+    // input in this cycle and only close the cycle on keyup / compositionstart.
+    _ta.addEventListener('input',function(e){
+      if(!_claim||_composing)return;   // only inside a claimed cycle
+      var it=e.inputType||'';
+      if(it.indexOf('delete')===0){
+        // Each textarea delete → one terminal backspace, so N deletes (whole-run
+        // erase) map 1:1 instead of collapsing to a single \x7f.
+        try{term.input('\\x7f',true)}catch(_e){}
+        return;
+      }
+      // insertText / insertReplacementText etc. carrying the final char(s)
+      if(e.data){try{term.input(e.data,true)}catch(_e){}}
+    },{capture:true,passive:true});
+    // Close the cycle on keyup (the claimed keydown's matching keyup).
+    _ta.addEventListener('keyup',function(){_claim=false;},{capture:true,passive:true});
+  }
+})();}
+
 // ── WebSocket ──
 var ws_=null,el=document.getElementById('status');
 term.onData(function(d){

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9333,7 +9333,13 @@ if(hasToken && !/[?&]imefix=0\\b/.test(location.search)){(function(){
   var _ta=term.textarea;
   try{
     term.attachCustomKeyEventHandler(function(e){
-      if(e.type==='keydown'&&!_composing){
+      if(e.type==='keydown'){
+        // Reset at the start of every keydown: iOS IME synthetic keys often fire
+        // NO keyup, so _claim could otherwise stay stuck on from a prior cycle.
+        // Clearing here (before deciding to claim) guarantees a fresh state each
+        // physical key, closing the "stuck-open → double-emit" window.
+        _claim=false;
+        if(_composing) return true;
         if(e.keyCode===229){ _claim=true; return false; }
         // Backspace: claim ONLY when an IME edit is pending (textarea non-empty),
         // so one physical backspace's N delete events all reach the terminal.
@@ -9347,6 +9353,9 @@ if(hasToken && !/[?&]imefix=0\\b/.test(location.search)){(function(){
     // compositionstart/end bound the reliable path; never take over inside it.
     _ta.addEventListener('compositionstart',function(){_composing=true;_claim=false;},{capture:true,passive:true});
     _ta.addEventListener('compositionend',function(){_composing=false;_claim=false;},{capture:true,passive:true});
+    // Blur also closes the cycle — another guard against a stuck-open _claim when
+    // the matching keyup never arrives (the textarea can lose focus instead).
+    _ta.addEventListener('blur',function(){_claim=false;},{capture:true,passive:true});
     // A single claimed keydown can fire MULTIPLE input events, e.g. the
     // consecutive-space→。 conversion (delete THEN insertText) or a voice-input
     // correction (many deletes). So DON'T clear _claim per-input — forward every
@@ -9360,8 +9369,13 @@ if(hasToken && !/[?&]imefix=0\\b/.test(location.search)){(function(){
         try{term.input('\\x7f',true)}catch(_e){}
         return;
       }
-      // insertText / insertReplacementText etc. carrying the final char(s)
-      if(e.data){try{term.input(e.data,true)}catch(_e){}}
+      // insertText / insertReplacementText etc. carrying the final char(s).
+      // Only forward composed input (what IMEs emit — every real Doubao/WeChat
+      // insert is composed=true). A composed=false insertText is one xterm's own
+      // _inputEvent WILL emit (its guard passes when !composed), so forwarding it
+      // here too — should _claim ever be stuck open — would double-emit. Gating on
+      // composed makes the two paths mutually exclusive and closes that window.
+      if(e.data&&e.composed){try{term.input(e.data,true)}catch(_e){}}
     },{capture:true,passive:true});
     // Close the cycle on keyup (the claimed keydown's matching keyup).
     _ta.addEventListener('keyup',function(){_claim=false;},{capture:true,passive:true});

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9369,13 +9369,23 @@ if(hasToken && !/[?&]imefix=0\\b/.test(location.search)){(function(){
         try{term.input('\\x7f',true)}catch(_e){}
         return;
       }
-      // insertText / insertReplacementText etc. carrying the final char(s).
-      // Only forward composed input (what IMEs emit — every real Doubao/WeChat
-      // insert is composed=true). A composed=false insertText is one xterm's own
-      // _inputEvent WILL emit (its guard passes when !composed), so forwarding it
-      // here too — should _claim ever be stuck open — would double-emit. Gating on
-      // composed makes the two paths mutually exclusive and closes that window.
-      if(e.data&&e.composed){try{term.input(e.data,true)}catch(_e){}}
+      // Forward ONLY inputType==='insertText' — the exact dead path the target
+      // Doubao/WeChat traces take (keydown 229 → insertText, composed=true, no
+      // composition events). This is a strict WHITELIST, not a composed filter:
+      //   • e.composed is a shadow-DOM-crossing flag, NOT an "is-IME" marker —
+      //     EVERY trusted InputEvent (paste, replacement, drop…) is composed=true.
+      //     So gating on composed alone still swallows non-insertText paths.
+      //   • insertFromPaste: xterm's own paste handler already sent the text
+      //     (stopPropagation but NOT preventDefault), then the default paste
+      //     inserts into the textarea and fires insertFromPaste — forwarding it
+      //     here too would DOUBLE the paste.
+      //   • insertReplacementText: WebKit correction runs ㅎ→하→한 as a REPLACE
+      //     stream; appending each token yields "ㅎ하한" instead of "한".
+      // insertText remains gated on composed too: a composed=false insertText is
+      // one xterm's _inputEvent WILL emit itself (its guard passes when
+      // !composed), so — should _claim ever be stuck open — forwarding it here
+      // would double-emit. Whitelist + composed = mutually exclusive with xterm.
+      if(e.data&&e.composed&&it==='insertText'){try{term.input(e.data,true)}catch(_e){}}
     },{capture:true,passive:true});
     // Close the cycle on keyup (the claimed keydown's matching keyup).
     _ta.addEventListener('keyup',function(){_claim=false;},{capture:true,passive:true});

--- a/test/web-terminal-ime.test.ts
+++ b/test/web-terminal-ime.test.ts
@@ -52,12 +52,14 @@ describe('web terminal iOS IME fix', () => {
     expect(block).toContain("_ta.addEventListener('blur',function(){_claim=false;}");
   });
 
-  it('forwards inserted text ONLY when composed (mutually exclusive with xterm’s own _inputEvent)', () => {
+  it('forwards inserted text ONLY for inputType===insertText AND composed (whitelist, not just composed)', () => {
     const block = imeBlock();
-    // A composed=false insertText is one xterm's _inputEvent will emit itself
-    // (its guard passes when !composed); gating our forward on e.composed keeps
-    // the two paths from both firing = the double-emit fix.
-    expect(block).toContain('if(e.data&&e.composed){try{term.input(e.data,true)}catch(_e){}}');
+    // composed is a shadow-DOM flag true for EVERY trusted InputEvent, so gating
+    // on composed alone would still swallow insertFromPaste / insertReplacementText.
+    // The whitelist restricts us to the exact dead path the target traces take.
+    expect(block).toContain("if(e.data&&e.composed&&it==='insertText'){try{term.input(e.data,true)}catch(_e){}}");
+    // the composed-only and unconditional forms are both regressions
+    expect(block).not.toContain('if(e.data&&e.composed){try{term.input(e.data,true)}catch(_e){}}');
     expect(block).not.toContain('if(e.data){try{term.input(e.data,true)}catch(_e){}}');
   });
 
@@ -84,5 +86,195 @@ describe('web terminal iOS IME fix', () => {
   it('is gated behind hasToken and an ?imefix=0 escape hatch', () => {
     const block = imeBlock();
     expect(block).toContain('if(hasToken && !/[?&]imefix=0');
+  });
+});
+
+// ── Executable behavioural tests ────────────────────────────────────────────
+// The source-level asserts above lock statement SHAPE; these run the real IIFE
+// in a stub DOM and assert BEHAVIOUR, so a shape that "looks right" but emits
+// twice is caught. We model xterm's own emitters (verified against @xterm/xterm
+// 5.5.0 lib/xterm.js):
+//   • _inputEvent(e): emits iff e.data && e.inputType==='insertText' &&
+//     (!e.composed || !_keyDownSeen)   — nothing else, delete* never emits.
+//   • paste: handlePasteEvent does stopPropagation but NOT preventDefault, so
+//     xterm sends the text once AND the browser's default paste then fires an
+//     input(insertFromPaste, composed=true) into the textarea.
+// A regression that forwards a non-insertText composed event shows up as
+// total emits > the single intended copy.
+function buildImeRig() {
+  const start = workerSource.indexOf('if(hasToken && !/[?&]imefix=0');
+  const end = workerSource.indexOf('})();}', start) + '})();}'.length;
+  // The block lives in a template literal: \\x7f → \x7f, \\b → \b at emit time.
+  const emitted = workerSource.slice(start, end).replace(/\\\\/g, '\\');
+
+  const listeners: Record<string, Array<(e: any) => void>> = {};
+  const textarea = {
+    value: 'abc',
+    addEventListener(type: string, fn: (e: any) => void) {
+      (listeners[type] = listeners[type] || []).push(fn);
+    },
+  };
+  const ours: string[] = [];
+  let keyDownSeen = false;
+  let handler: ((e: any) => boolean) | null = null;
+  const term = {
+    textarea,
+    attachCustomKeyEventHandler(fn: (e: any) => boolean) {
+      handler = fn;
+    },
+    input(d: string) {
+      ours.push(d);
+    },
+  };
+  // eslint-disable-next-line no-new-func
+  new Function('term', 'location', 'hasToken', emitted)(term, { search: '?tok=1' }, true);
+
+  const fire = (type: string, ev: any) => (listeners[type] || []).forEach((fn) => fn(ev));
+  // xterm's own _inputEvent emit rule (5.5.0):
+  const xtermInputEmits = (ev: any) =>
+    !!(ev.data && ev.inputType === 'insertText' && (!ev.composed || !keyDownSeen));
+
+  let xtermEmits = 0;
+  return {
+    setTextarea(v: string) {
+      textarea.value = v;
+    },
+    keydown(keyCode: number) {
+      keyDownSeen = true;
+      handler?.({ type: 'keydown', keyCode });
+    },
+    keyup() {
+      keyDownSeen = false;
+      fire('keyup', {});
+    },
+    compositionstart() {
+      fire('compositionstart', {});
+    },
+    compositionend() {
+      fire('compositionend', {});
+    },
+    blur() {
+      fire('blur', {});
+    },
+    input(ev: any) {
+      // Count what xterm's own input handler would emit for this event first…
+      if (xtermInputEmits(ev)) xtermEmits += 1;
+      // …then deliver to the patch's capture-phase listener.
+      fire('input', ev);
+    },
+    xtermPaste() {
+      // xterm's paste handler sends the text once (independent of _inputEvent).
+      xtermEmits += 1;
+    },
+    get ours() {
+      return ours;
+    },
+    get total() {
+      return xtermEmits + ours.length;
+    },
+  };
+}
+
+describe('web terminal iOS IME fix — behaviour (exactly-once, no double-emit)', () => {
+  it('豆包 single char: keydown229 → insertText forwards exactly once', () => {
+    const rig = buildImeRig();
+    rig.setTextarea('你');
+    rig.keydown(229);
+    rig.input({ inputType: 'insertText', data: '你', composed: true });
+    expect(rig.ours).toEqual(['你']);
+    expect(rig.total).toBe(1);
+  });
+
+  it('space→。 conversion (delete THEN insertText) in one claimed cycle', () => {
+    const rig = buildImeRig();
+    rig.setTextarea('。');
+    rig.keydown(229);
+    rig.input({ inputType: 'deleteContentBackward', composed: true });
+    rig.input({ inputType: 'insertText', data: '。', composed: true });
+    expect(rig.ours).toEqual(['\x7f', '。']);
+    expect(rig.total).toBe(2);
+  });
+
+  it('voice correction: one Backspace → N deletes map 1:1 to N terminal backspaces', () => {
+    const rig = buildImeRig();
+    rig.setTextarea('整段文字');
+    rig.keydown(8);
+    rig.input({ inputType: 'deleteContentBackward', composed: true });
+    rig.input({ inputType: 'deleteContentBackward', composed: true });
+    rig.input({ inputType: 'deleteContentBackward', composed: true });
+    expect(rig.ours).toEqual(['\x7f', '\x7f', '\x7f']);
+  });
+
+  it('WeChat composition is never taken over (patch stays silent, xterm owns it)', () => {
+    const rig = buildImeRig();
+    rig.compositionstart();
+    rig.setTextarea('ni');
+    rig.keydown(229);
+    rig.input({ inputType: 'insertCompositionText', data: 'ni', composed: true });
+    rig.compositionend();
+    expect(rig.ours).toEqual([]);
+  });
+
+  it('empty-textarea Backspace is NOT claimed (normal terminal backspace flows to xterm)', () => {
+    const rig = buildImeRig();
+    rig.setTextarea('');
+    rig.keydown(8);
+    // No IME input event follows a plain terminal backspace; patch stays silent
+    // and xterm emits its own \x7f (modelled outside this rig).
+    expect(rig.ours).toEqual([]);
+  });
+
+  // ── The two sequences Codex's delta review flagged ──
+  it('REGRESSION (Codex #1): stuck claim + iOS paste must NOT double (insertFromPaste is not insertText)', () => {
+    const rig = buildImeRig();
+    rig.setTextarea('x');
+    rig.keydown(229); // claim; iOS omits the matching keyup → _claim stays open
+    rig.xtermPaste(); // xterm's paste handler already sent the pasted text once
+    // default paste (not preventDefault'd) then inserts into the textarea:
+    rig.input({ inputType: 'insertFromPaste', data: 'hello', composed: true });
+    expect(rig.ours).toEqual([]); // patch must NOT re-forward the paste
+    expect(rig.total).toBe(1); // exactly one copy reaches the terminal
+  });
+
+  it('REGRESSION (Codex #2): WebKit replacement ㅎ→하→한 must not append (insertReplacementText is not insertText)', () => {
+    const rig = buildImeRig();
+    rig.setTextarea('한');
+    rig.keydown(229);
+    rig.input({ inputType: 'insertReplacementText', data: 'ㅎ', composed: true });
+    rig.input({ inputType: 'insertReplacementText', data: '하', composed: true });
+    rig.input({ inputType: 'insertReplacementText', data: '한', composed: true });
+    // We do NOT own replacement semantics, so we forward nothing and let xterm's
+    // own path handle it — critically we must not turn '한' into 'ㅎ하한'.
+    expect(rig.ours.join('')).not.toBe('ㅎ하한');
+    expect(rig.ours).toEqual([]);
+  });
+
+  it('REGRESSION (original P3): stuck claim + composed=false insertText stays single (xterm owns it)', () => {
+    const rig = buildImeRig();
+    rig.setTextarea('x');
+    rig.keydown(229); // claim, no keyup
+    // A composed=false insertText is one xterm's _inputEvent emits itself.
+    rig.input({ inputType: 'insertText', data: 'Z', composed: false });
+    expect(rig.ours).toEqual([]); // patch must not also forward it
+    expect(rig.total).toBe(1);
+  });
+
+  it('a new keydown resets _claim so a later composed=false insertText is not double-forwarded', () => {
+    const rig = buildImeRig();
+    rig.setTextarea('x');
+    rig.keydown(229); // claim, no keyup
+    rig.keydown(65); // new key resets _claim at keydown start
+    rig.input({ inputType: 'insertText', data: 'A', composed: false });
+    expect(rig.ours).toEqual([]);
+    expect(rig.total).toBe(1);
+  });
+
+  it('blur resets _claim (guards against a stuck-open claim when keyup never arrives)', () => {
+    const rig = buildImeRig();
+    rig.setTextarea('x');
+    rig.keydown(229);
+    rig.blur();
+    rig.input({ inputType: 'insertFromPaste', data: 'zzz', composed: true });
+    expect(rig.ours).toEqual([]);
   });
 });

--- a/test/web-terminal-ime.test.ts
+++ b/test/web-terminal-ime.test.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Source-level regression guard for the iOS third-party IME fix injected into
+// the web terminal page (getTerminalHtml in src/worker.ts). That block is a
+// string of browser JS, so — like web-terminal-touch-scroll.test.ts — we assert
+// on its source rather than execute a DOM. These assertions lock the two
+// double-emit hardening invariants a Codex review flagged (composed gate +
+// _claim reset on keydown/blur, not just keyup) so a future edit can't silently
+// regress them, plus the core dead-path takeover behaviour.
+const workerSource = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+
+function imeBlock(): string {
+  const start = workerSource.indexOf('// ── iOS third-party IME fix');
+  const end = workerSource.indexOf('})();}', start);
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  // include the closing IIFE
+  return workerSource.slice(start, end + '})();}'.length);
+}
+
+describe('web terminal iOS IME fix', () => {
+  it('claims the keyCode=229 dead path (returns false so xterm skips its broken fallback)', () => {
+    const block = imeBlock();
+    expect(block).toContain('if(e.keyCode===229){ _claim=true; return false; }');
+  });
+
+  it('claims Backspace ONLY when the textarea is non-empty (empty = normal terminal backspace)', () => {
+    const block = imeBlock();
+    // The non-empty guard is what keeps a plain shell-line backspace flowing to
+    // xterm (which sends its standard \x7f) instead of being swallowed.
+    expect(block).toContain('if(e.keyCode===8 && _ta && _ta.value.length>0){ _claim=true; return false; }');
+  });
+
+  it('resets _claim at the START of every keydown (iOS IME keys often fire no keyup)', () => {
+    const block = imeBlock();
+    // Must reset before deciding to claim, so a stuck-open _claim from a prior
+    // cycle (missing keyup) cannot leak into the next key.
+    const keydownIdx = block.indexOf("if(e.type==='keydown'){");
+    const resetIdx = block.indexOf('_claim=false;', keydownIdx);
+    const claim229Idx = block.indexOf('if(e.keyCode===229)', keydownIdx);
+    expect(keydownIdx).toBeGreaterThan(-1);
+    expect(resetIdx).toBeGreaterThan(keydownIdx);
+    // reset happens before the claim decision
+    expect(resetIdx).toBeLessThan(claim229Idx);
+  });
+
+  it('also closes the cycle on keyup AND blur (belt-and-suspenders against stuck-open _claim)', () => {
+    const block = imeBlock();
+    expect(block).toContain("_ta.addEventListener('keyup',function(){_claim=false;}");
+    expect(block).toContain("_ta.addEventListener('blur',function(){_claim=false;}");
+  });
+
+  it('forwards inserted text ONLY when composed (mutually exclusive with xterm’s own _inputEvent)', () => {
+    const block = imeBlock();
+    // A composed=false insertText is one xterm's _inputEvent will emit itself
+    // (its guard passes when !composed); gating our forward on e.composed keeps
+    // the two paths from both firing = the double-emit fix.
+    expect(block).toContain('if(e.data&&e.composed){try{term.input(e.data,true)}catch(_e){}}');
+    expect(block).not.toContain('if(e.data){try{term.input(e.data,true)}catch(_e){}}');
+  });
+
+  it('maps each textarea delete to one terminal backspace (whole-run erase stays 1:1)', () => {
+    const block = imeBlock();
+    expect(block).toContain("if(it.indexOf('delete')===0){");
+    expect(block).toContain("term.input('\\\\x7f',true)");
+  });
+
+  it('never takes over while a real composition is active (WeChat Chinese stays on xterm)', () => {
+    const block = imeBlock();
+    expect(block).toContain("_ta.addEventListener('compositionstart',function(){_composing=true;_claim=false;}");
+    expect(block).toContain("_ta.addEventListener('compositionend',function(){_composing=false;_claim=false;}");
+    // the input handler bails while composing
+    expect(block).toContain('if(!_claim||_composing)return;');
+  });
+
+  it('uses term.input (not term.paste) so per-char input is not bracketed-paste-wrapped', () => {
+    const block = imeBlock();
+    expect(block).toContain('term.input(e.data,true)');
+    expect(block).not.toContain('term.paste(e.data)');
+  });
+
+  it('is gated behind hasToken and an ?imefix=0 escape hatch', () => {
+    const block = imeBlock();
+    expect(block).toContain('if(hasToken && !/[?&]imefix=0');
+  });
+});


### PR DESCRIPTION
## 背景 / 问题

WebShell 交互终端页（`worker.ts` 的 `getTerminalHtml`）用原生 xterm.js 5.x（CDN 加载）。iOS 上第三方输入法（**豆包**、**微信** 等）在 xterm 隐藏 `textarea` 上产生的事件序列，命中 xterm 两处缺陷，导致：

- **豆包几乎无法输入**、**微信空格/句尾单字丢失或延迟**
- **豆包语音输入纠错时整段文字重复**

自带输入法正常，故此前一直没暴露。

## 根因（两处，均有 iOS 26.5.2 真机 trace 佐证）

### 1) keyCode=229 + composed insertText 死路
字符走 `keydown(keyCode=229)` → `input(inputType=insertText, composed=true)`，**无** composition 事件。
- xterm 的 `_inputEvent` 守卫 `(!ev.composed || !_keyDownSeen)`：此处 `composed=true` 且 229 keydown 已置 `_keyDownSeen` → 恒为假 → **不发送**。
- 唯一兜底 `CompositionHelper._handleAnyTextareaChanges` 用 `setTimeout` + `String.replace(oldValue,'')` 算差量，连续快打时算错 → **丢字**。

豆包每个字/词/标点全走此路（几乎打不上）；微信空格与句尾单字走此路（延迟/丢）。

### 2) 语音纠错重复
一次物理退格，iOS 三方输入法在 `textarea` 里**连发 N 个 `deleteContentBackward`**（意图删整行），但 xterm 对一个 Backspace keydown 只发 **1 个 `\x7f`** → 终端删 1 字、textarea 删 N 字，残留 N-1 字；随后输入法重插整句 → 旧内容没删干净 + 新整句叠加 = **整段重复**。

## 修复（仅接管这两条死/损路，其余一律不碰）

- `attachCustomKeyEventHandler` 认领：`keydown` 229（非 composing）；以及 **Backspace 但仅当 `textarea` 非空**（有 IME 编辑待定）时——空 `textarea` 是正常终端退格，放行给 xterm 发标准 `\x7f`，**避免吞掉 shell 命令行退格**这一致命回归。
- 认领后 `return false`，xterm 跳过其缺陷兜底 / 单发退格 → **杜绝双发**。
- `textarea` `'input'` 监听逐事件转发：`insertText` → 原样 `term.input(data,true)`；每个 `delete*` → 一个 `\x7f`，使 N 次删除 **1:1** 映射到终端 N 次删除。
- composition 输入（微信中文本来就可靠）在 `_composing` 期间**完全不接管**。
- 用 `term.input(data,true)`（**非** `paste`：不做括号粘贴包装、不清空 textarea），走既有 `onData` → 沿用现有 WS 发送与只读门控。
- **逃生阀**：URL 加 `?imefix=0` 可临时关闭修复回到原生 xterm 行为，便于对比排查。

## 影响面

- **仅改** `worker.ts` 的 `getTerminalHtml` 浏览器端 JS（用户实际使用的交互终端页）。
- 不碰服务端、其它 CLI 适配器、后端（PtyBackend/TmuxBackend…）、其它终端页（`debug-terminal`、`v3-terminal`）。
- 纯浏览器行为改动，跨平台无关（daemon 运行的 Linux 不受影响）。
- 桌面 IME 走 composition，`_composing` 期间不接管，不受影响。

## 测试与验证

- ✅ `pnpm build` 通过；运行期 JS 语法解析通过（`new Function`）。
- ✅ 基于两段真机 trace（豆包/微信 iOS 26.5.2 Safari/Chrome）**字节级离线模拟 5 场景全过**：逐字输入、连续空格转句号（删+插）、语音纠错整段删除、composition 期间零误发、英文/Enter/方向键不误领。
- ✅ **真机复测（用户 iOS 实测）**：豆包/微信打字正常、语音纠错重复消失、shell 命令行退格正常。
- ✅ `pnpm test`：11167 passed，6 failed 均为本机沙箱**预存环境性失败**（`v3-worker-fence` / `v3-goal-cli` / `v3-cancel-runtime`，依赖 git 远程 ref / tmux server）；`git stash` 后在纯净分支复现同样失败，**与本改动无关**。

## 上游

对应 xterm.js issue #5835 / PR #5836（同类根因）。本 PR 是 botmux 侧的 hook 层修复，与 CDN xterm 版本解耦，无需等上游发版。

🤖 Generated with [Claude Code](https://claude.com/claude-code)