### PR TITLE
fix(config): Dashboard 链接跟随 listen host 而非误报 LAN IP

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -21,16 +21,37 @@ function nonBlankHost(value: string | undefined): string | undefined {
   return value?.trim() || undefined;
 }
 
+/** A wildcard/any-address bind is not itself a reachable destination, so a link
+ *  advertising it must be resolved to a concrete IP. A specific bind host (e.g.
+ *  127.0.0.1, a LAN IP) IS reachable and should be advertised verbatim. Blank
+ *  hosts are normalized away by callers (nonBlankHost) before they reach here,
+ *  so an empty string is also treated as a wildcard for the raw-config path in
+ *  dashboard.ts's loopback gate. */
+export function isWildcardBindHost(host: string): boolean {
+  return host === '0.0.0.0' || host === '::' || host === '';
+}
+
 const configuredWebExternalHost = nonBlankHost(process.env.WEB_EXTERNAL_HOST);
 const configuredDashboardExternalHost =
   nonBlankHost(process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST) ?? configuredWebExternalHost;
+const configuredDashboardBindHost = nonBlankHost(process.env.BOTMUX_DASHBOARD_HOST);
 
 export function getWebExternalHost(): string {
   return configuredWebExternalHost ?? getLocalIp();
 }
 
 export function getDashboardExternalHost(): string {
-  return configuredDashboardExternalHost ?? getLocalIp();
+  // Priority: explicit external host → the actual listen host (when it's a
+  // concrete, reachable address) → autodetected LAN IP. Advertising the bind
+  // host keeps the printed/DM'd link consistent with where the dashboard is
+  // actually listening: a 127.0.0.1 bind must link to 127.0.0.1, not a LAN IP
+  // nothing is listening on. Only a wildcard bind (0.0.0.0/::) — which isn't a
+  // reachable destination — falls through to autodetect.
+  if (configuredDashboardExternalHost) return configuredDashboardExternalHost;
+  if (configuredDashboardBindHost && !isWildcardBindHost(configuredDashboardBindHost)) {
+    return configuredDashboardBindHost;
+  }
+  return getLocalIp();
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,12 +21,8 @@ function nonBlankHost(value: string | undefined): string | undefined {
   return value?.trim() || undefined;
 }
 
-/** A wildcard/any-address bind is not itself a reachable destination, so a link
- *  advertising it must be resolved to a concrete IP. A specific bind host (e.g.
- *  127.0.0.1, a LAN IP) IS reachable and should be advertised verbatim. Blank
- *  hosts are normalized away by callers (nonBlankHost) before they reach here,
- *  so an empty string is also treated as a wildcard for the raw-config path in
- *  dashboard.ts's loopback gate. */
+/** A wildcard bind (0.0.0.0 / :: / '') isn't a reachable address, so a link must
+ *  resolve it to a concrete IP; a specific host is advertised verbatim. */
 export function isWildcardBindHost(host: string): boolean {
   return host === '0.0.0.0' || host === '::' || host === '';
 }
@@ -41,12 +37,8 @@ export function getWebExternalHost(): string {
 }
 
 export function getDashboardExternalHost(): string {
-  // Priority: explicit external host → the actual listen host (when it's a
-  // concrete, reachable address) → autodetected LAN IP. Advertising the bind
-  // host keeps the printed/DM'd link consistent with where the dashboard is
-  // actually listening: a 127.0.0.1 bind must link to 127.0.0.1, not a LAN IP
-  // nothing is listening on. Only a wildcard bind (0.0.0.0/::) — which isn't a
-  // reachable destination — falls through to autodetect.
+  // Explicit external host → the actual (non-wildcard) listen host → LAN IP.
+  // A 127.0.0.1 bind must link to 127.0.0.1, not a LAN IP nothing listens on.
   if (configuredDashboardExternalHost) return configuredDashboardExternalHost;
   if (configuredDashboardBindHost && !isWildcardBindHost(configuredDashboardBindHost)) {
     return configuredDashboardBindHost;

--- a/src/core/dashboard-url.ts
+++ b/src/core/dashboard-url.ts
@@ -17,6 +17,16 @@ export interface DashboardUrls {
 }
 
 /**
+ * Format a host for use inside a URL. An IPv6 literal (contains ':', e.g. `::1`)
+ * must be wrapped in brackets or `http://::1:7891/` is an invalid URL. IPv4,
+ * hostnames, and already-bracketed literals pass through unchanged.
+ */
+export function formatUrlHost(host: string): string {
+  if (host.includes(':') && !host.startsWith('[')) return `[${host}]`;
+  return host;
+}
+
+/**
  * Builds the dashboard URL(s) for a token.
  *
  * When 远程访问 is enabled AND this machine is bound to the central platform, the
@@ -37,7 +47,7 @@ export interface DashboardUrls {
  * dashboard link being the one place that always stays local.
  */
 export function buildDashboardUrls(opts: { host: string; port: number | string; token?: string }): DashboardUrls {
-  const localOrigin = `http://${opts.host}:${opts.port}`;
+  const localOrigin = `http://${formatUrlHost(String(opts.host))}:${opts.port}`;
   // 对外基址：中心平台优先（远程访问开 + 已绑定），否则自建反代基址 BOTMUX_PUBLIC_URL。
   const platformBase = isRemoteAccessEnabled() ? platformMachineBaseUrl() : null;
   const remoteBase = platformBase ?? publicReverseProxyBaseUrl();

--- a/src/core/plugins/runtime.ts
+++ b/src/core/plugins/runtime.ts
@@ -32,6 +32,9 @@ export interface PluginServiceDefinition {
     killTimeoutMs?: number;
     watchDelayMs?: number;
   };
+  /** Build the plugin's advertised URLs. `host` is already URL-ready — an IPv6
+   *  literal arrives bracketed (`[::1]`) — so interpolate it straight into a URL
+   *  (`http://${host}:${port}/`) without re-formatting. */
   urls?(ctx: { host: string; env: Record<string, string>; port?: number }): {
     openUrl?: string;
     healthUrl?: string;

--- a/src/core/plugins/service-manager.ts
+++ b/src/core/plugins/service-manager.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, rmSync } from 'node:fs';
 import { dirname, isAbsolute, resolve } from 'node:path';
 import { config } from '../../config.js';
+import { formatUrlHost } from '../dashboard-url.js';
 import { atomicWriteFileSync } from '../../utils/atomic-write.js';
 import { withFileLock, withFileLockSync } from '../../utils/file-lock.js';
 import { readPluginRegistry } from '../../services/plugin-registry-store.js';
@@ -229,24 +230,35 @@ function isLoopbackHost(hostname: string): boolean {
   return hostname === '127.0.0.1' || hostname === 'localhost' || hostname === '::1' || hostname === '[::1]';
 }
 
-function rewriteLoopbackServiceUrl(rawUrl: string | undefined): string | undefined {
+/** The dashboard external host, formatted so it can be interpolated straight into
+ *  a URL: an IPv6 literal (e.g. `::1`) comes back bracketed (`[::1]`). This is the
+ *  URL-ready form the plugin `urls()` contract receives and every openUrl uses; a
+ *  raw `::1` would produce the invalid `http://::1:port/`. */
+function urlReadyDashboardHost(): string {
+  return formatUrlHost(config.dashboard.externalHost);
+}
+
+export function rewriteLoopbackServiceUrl(rawUrl: string | undefined): string | undefined {
   if (!rawUrl) return undefined;
   try {
     const url = new URL(rawUrl);
-    if (isLoopbackHost(url.hostname)) url.hostname = config.dashboard.externalHost;
+    // The WHATWG hostname setter silently drops a bare IPv6 literal (`::1`), so
+    // pass the bracketed form or the loopback rewrite would no-op.
+    if (isLoopbackHost(url.hostname)) url.hostname = urlReadyDashboardHost();
     return url.toString();
   } catch {
     return rawUrl;
   }
 }
 
-function serviceUrls(record: InstalledPluginRecord, definition: PluginServiceDefinition): Pick<PluginServiceState, 'port' | 'openUrl' | 'healthUrl'> {
+export function serviceUrls(record: InstalledPluginRecord, definition: PluginServiceDefinition): Pick<PluginServiceState, 'port' | 'openUrl' | 'healthUrl'> {
   const env = definitionEnv(record, definition);
   const port = definition.port ?? (env.PORT ? Number(env.PORT) : undefined);
-  const urls = definition.urls?.({ host: config.dashboard.externalHost, env, ...(Number.isFinite(port) ? { port } : {}) }) ?? {};
+  const host = urlReadyDashboardHost();
+  const urls = definition.urls?.({ host, env, ...(Number.isFinite(port) ? { port } : {}) }) ?? {};
   return {
     ...(Number.isFinite(port) ? { port } : {}),
-    ...(urls.openUrl ? { openUrl: rewriteLoopbackServiceUrl(urls.openUrl) } : Number.isFinite(port) ? { openUrl: `http://${config.dashboard.externalHost}:${port}/` } : {}),
+    ...(urls.openUrl ? { openUrl: rewriteLoopbackServiceUrl(urls.openUrl) } : Number.isFinite(port) ? { openUrl: `http://${host}:${port}/` } : {}),
     ...(urls.healthUrl ? { healthUrl: rewriteLoopbackServiceUrl(urls.healthUrl) } : {}),
   };
 }

--- a/src/core/terminal-url.ts
+++ b/src/core/terminal-url.ts
@@ -1,4 +1,5 @@
 import { config } from '../config.js';
+import { formatUrlHost } from './dashboard-url.js';
 import { platformMachineBaseUrl, publicReverseProxyBaseUrl } from '../platform/binding.js';
 import { isRemoteAccessEnabled } from '../global-config.js';
 
@@ -110,8 +111,8 @@ export function buildTerminalUrl(ds: TerminalUrlSession, opts: { write?: boolean
     }
   }
   const base = proxyReady
-    ? `http://${config.web.externalHost}:${getTerminalAdvertisedPort()}/s/${ds.session.sessionId}`
-    : `http://${config.web.externalHost}:${ds.workerPort ?? ds.session.webPort}`;
+    ? `http://${formatUrlHost(config.web.externalHost)}:${getTerminalAdvertisedPort()}/s/${ds.session.sessionId}`
+    : `http://${formatUrlHost(config.web.externalHost)}:${ds.workerPort ?? ds.session.webPort}`;
   return opts.write
     ? withCapability(base, 'token', ds.workerToken)
     : withCapability(base, 'viewToken', ds.workerViewToken);

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -11,7 +11,7 @@ import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { randomBytes } from 'node:crypto';
 import { logger } from './utils/logger.js';
-import { config } from './config.js';
+import { config, isWildcardBindHost } from './config.js';
 import { listenWithProbe } from './utils/listen-with-probe.js';
 import {
   generateToken, parseCookie, buildSetCookie, verifyHmac, cliAuthBind, decideDashboardAuth,
@@ -245,10 +245,6 @@ let activeToken: string | null = loadPersistedToken(TOKEN_PATH);
 let boundDashboardPort = config.dashboard.port;
 
 const SECRET = loadOrCreateSecret();
-
-function isWildcardBindHost(host: string): boolean {
-  return host === '0.0.0.0' || host === '::' || host === '';
-}
 
 function tcpPortAvailable(host: string, port: number): Promise<boolean> {
   return new Promise((resolve) => {

--- a/src/dashboard/federation-spoke-api.ts
+++ b/src/dashboard/federation-spoke-api.ts
@@ -17,6 +17,7 @@ import { readFileSync, mkdirSync, existsSync, unlinkSync } from 'node:fs';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { join, dirname } from 'node:path';
 import { config } from '../config.js';
+import { formatUrlHost } from '../core/dashboard-url.js';
 import { jsonRes } from './http.js';
 import { buildTeamRoster, type LiveBot } from '../services/team-roster.js';
 import { buildFederatedRoster } from '../services/federation-roster.js';
@@ -498,7 +499,7 @@ export async function handleFederationSpokeApi(
   if (path === '/api/team/local' && method === 'GET') {
     ensureDefaultTeam(dataDir);
     const me = getDeploymentIdentity(dataDir);
-    const suggestedHubUrl = `http://${config.dashboard.externalHost}:${config.dashboard.port}`;
+    const suggestedHubUrl = `http://${formatUrlHost(config.dashboard.externalHost)}:${config.dashboard.port}`;
     jsonRes(res, 200, { ok: true, deployment: me, suggestedHubUrl, ...buildFederatedRoster(dataDir, DEFAULT_TEAM_ID, botConfigOrder(), undefined, live) });
     return true;
   }
@@ -507,7 +508,7 @@ export async function handleFederationSpokeApi(
   if (path === '/api/team/hosted' && method === 'GET') {
     ensureDefaultTeam(dataDir);
     const me = getDeploymentIdentity(dataDir);
-    const suggestedHubUrl = `http://${config.dashboard.externalHost}:${config.dashboard.port}`;
+    const suggestedHubUrl = `http://${formatUrlHost(config.dashboard.externalHost)}:${config.dashboard.port}`;
     const teams = listTeams(dataDir).map(t => ({
       teamId: t.id, name: t.name, isDefault: t.id === DEFAULT_TEAM_ID,
       // dashboard 团队页发起过的协作群 —— 看板团队筛选的白名单之一
@@ -579,7 +580,7 @@ export async function handleFederationSpokeApi(
     // Issue a delegationToken to the hub + tell it our callback URL, so the hub
     // can delegate 拉群 back to us (hub→spoke) when it has no local creator.
     const delegationToken = randomBytes(24).toString('base64url');
-    const callbackUrl = `http://${config.dashboard.externalHost}:${config.dashboard.port}`;
+    const callbackUrl = `http://${formatUrlHost(config.dashboard.externalHost)}:${config.dashboard.port}`;
     let hubRes: Response;
     try {
       hubRes = await fetchWithTimeout(fetcher, `${hubUrl}/api/federation/join`, {

--- a/src/im/lark/sessions-card.ts
+++ b/src/im/lark/sessions-card.ts
@@ -24,6 +24,7 @@ import { composeEntries, sortByStatus, paginate, composeDetail } from '../../das
 import type { DaemonClient } from '../../dashboard/daemon-internal-client.js';
 import type { SessionRow } from '../../core/dashboard-rows.js';
 import { config } from '../../config.js';
+import { formatUrlHost } from '../../core/dashboard-url.js';
 import { type Locale, t } from '../../i18n/index.js';
 
 import { terminalMultiUrl } from './card-builder.js';
@@ -592,7 +593,7 @@ function mapResumeDisabledReason(reasonKey: string | undefined): string | undefi
  *  rejected here even if the raw row still has a port value. */
 export function buildSessionTerminalUrl(row: SessionRow): string | null {
   if (row.status === 'closed') return null;
-  const host = config.web.externalHost;
+  const host = formatUrlHost(config.web.externalHost);
   if (typeof row.proxyPort === 'number' && row.proxyPort > 0) {
     return `http://${host}:${row.proxyPort}/s/${encodeURIComponent(row.sessionId)}`;
   }

--- a/src/im/lark/v3-blocked-card.ts
+++ b/src/im/lark/v3-blocked-card.ts
@@ -9,6 +9,7 @@
  */
 
 import { config } from '../../config.js';
+import { formatUrlHost } from '../../core/dashboard-url.js';
 
 export const V3_BLOCKED_RETRY_ACTION = 'v3_blocked_retry';
 /** 运行时 human-ask 选项按钮的 action（与「重试」同卡不同 namespace）。 */
@@ -75,7 +76,7 @@ export function v3BlockedCardNonce(runId: string, nodeId: string, attemptId: str
 }
 
 function v3RunDetailUrl(runId: string): string {
-  return `http://${config.dashboard.externalHost}:${config.dashboard.port}/#/v3/${encodeURIComponent(runId)}`;
+  return `http://${formatUrlHost(config.dashboard.externalHost)}:${config.dashboard.port}/#/v3/${encodeURIComponent(runId)}`;
 }
 
 export function buildV3BlockedCard(input: V3BlockedCardInput): string {

--- a/src/im/lark/v3-gate-card.ts
+++ b/src/im/lark/v3-gate-card.ts
@@ -9,6 +9,7 @@
  */
 
 import { config } from '../../config.js';
+import { formatUrlHost } from '../../core/dashboard-url.js';
 import { DEFAULT_HUMAN_GATE_OPTIONS } from '../../workflows/v3/dag.js';
 import { splitV3HostGatePrompt } from '../../workflows/v3/host-bindings.js';
 
@@ -56,7 +57,7 @@ export function v3GateCardNonce(runId: string, waitId: string): string {
 
 /** v3 run 在 dashboard 的详情页 URL（跟 v0.2 的 #/workflows 对称，走 #/v3）。 */
 export function v3RunDetailUrl(runId: string): string {
-  return `http://${config.dashboard.externalHost}:${config.dashboard.port}/#/v3/${encodeURIComponent(runId)}`;
+  return `http://${formatUrlHost(config.dashboard.externalHost)}:${config.dashboard.port}/#/v3/${encodeURIComponent(runId)}`;
 }
 
 export function buildV3GateCard(input: V3GateCardInput): string {

--- a/src/im/lark/v3-loop-grant-card.ts
+++ b/src/im/lark/v3-loop-grant-card.ts
@@ -10,6 +10,7 @@
  */
 
 import { config } from '../../config.js';
+import { formatUrlHost } from '../../core/dashboard-url.js';
 
 export const V3_LOOP_GRANT_ACTION = 'v3_loop_grant';
 
@@ -51,7 +52,7 @@ export function v3LoopGrantCardNonce(runId: string, loopId: string, iteration: n
 }
 
 function v3RunDetailUrl(runId: string): string {
-  return `http://${config.dashboard.externalHost}:${config.dashboard.port}/#/v3/${encodeURIComponent(runId)}`;
+  return `http://${formatUrlHost(config.dashboard.externalHost)}:${config.dashboard.port}/#/v3/${encodeURIComponent(runId)}`;
 }
 
 export function buildV3LoopGrantCard(input: V3LoopGrantCardInput): string {

--- a/src/im/lark/v3-progress-card.ts
+++ b/src/im/lark/v3-progress-card.ts
@@ -9,6 +9,7 @@
  */
 
 import { config } from '../../config.js';
+import { formatUrlHost } from '../../core/dashboard-url.js';
 import type { V3ProgressView } from '../../workflows/v3/progress-projection.js';
 import type { V3RunSaveActionValue } from './v3-run-save-card.js';
 
@@ -27,7 +28,7 @@ export interface V3ProgressCardOptions {
 const MAX_INLINE_IDS = 5;
 
 export function v3ProgressRunDetailUrl(runId: string): string {
-  return `http://${config.dashboard.externalHost}:${config.dashboard.port}/#/v3/${encodeURIComponent(runId)}`;
+  return `http://${formatUrlHost(config.dashboard.externalHost)}:${config.dashboard.port}/#/v3/${encodeURIComponent(runId)}`;
 }
 
 /** Render one complete Feishu card body from the safe v3 progress projection. */

--- a/src/im/lark/v3-revisit-grant-card.ts
+++ b/src/im/lark/v3-revisit-grant-card.ts
@@ -15,6 +15,7 @@
  */
 
 import { config } from '../../config.js';
+import { formatUrlHost } from '../../core/dashboard-url.js';
 
 export const V3_REVISIT_GRANT_ACTION = 'v3_revisit_grant';
 
@@ -58,7 +59,7 @@ export function v3RevisitGrantCardNonce(runId: string, sourceNodeId: string, att
 }
 
 function v3RunDetailUrl(runId: string): string {
-  return `http://${config.dashboard.externalHost}:${config.dashboard.port}/#/v3/${encodeURIComponent(runId)}`;
+  return `http://${formatUrlHost(config.dashboard.externalHost)}:${config.dashboard.port}/#/v3/${encodeURIComponent(runId)}`;
 }
 
 export function buildV3RevisitGrantCard(input: V3RevisitGrantCardInput): string {

--- a/test/dashboard-url.test.ts
+++ b/test/dashboard-url.test.ts
@@ -11,7 +11,7 @@ vi.mock('../src/platform/binding.js', () => ({
   publicReverseProxyBaseUrl: vi.fn(() => null),
 }));
 
-import { buildDashboardUrl, buildDashboardUrls } from '../src/core/dashboard-url.js';
+import { buildDashboardUrl, buildDashboardUrls, formatUrlHost } from '../src/core/dashboard-url.js';
 import { isRemoteAccessEnabled } from '../src/global-config.js';
 import { platformMachineBaseUrl, publicReverseProxyBaseUrl } from '../src/platform/binding.js';
 
@@ -132,5 +132,36 @@ describe('buildDashboardUrls', () => {
       url: 'https://botmux.example.com/?t=abc',
       localUrl: 'http://1.2.3.4:7891/?t=abc',
     });
+  });
+
+  it('brackets an IPv6 literal host so the URL is valid', () => {
+    const { url } = buildDashboardUrls({ host: '::1', port: 7891, token: 'abc' });
+    expect(url).toBe('http://[::1]:7891/?t=abc');
+    expect(() => new URL(url)).not.toThrow();
+  });
+});
+
+describe('formatUrlHost', () => {
+  it('brackets a bare IPv6 literal', () => {
+    expect(formatUrlHost('::1')).toBe('[::1]');
+    expect(formatUrlHost('fe80::1')).toBe('[fe80::1]');
+    expect(formatUrlHost('::ffff:1.2.3.4')).toBe('[::ffff:1.2.3.4]');
+    expect(formatUrlHost('FE80::1')).toBe('[FE80::1]');
+  });
+
+  it('leaves IPv4, hostnames, and already-bracketed literals unchanged', () => {
+    expect(formatUrlHost('127.0.0.1')).toBe('127.0.0.1');
+    expect(formatUrlHost('dash.example.com')).toBe('dash.example.com');
+    expect(formatUrlHost('[::1]')).toBe('[::1]');
+  });
+
+  // The invariant every host→URL exit site shares (dashboard link, v3 cards,
+  // federation, web terminal): a formatted host interpolated into a URL must
+  // always parse. Guards copy-paste exits that forget to wrap.
+  it('any formatted host interpolates into a parseable URL', () => {
+    for (const host of ['::1', 'fe80::1', '::ffff:1.2.3.4', '127.0.0.1', 'dash.example.com']) {
+      const h = formatUrlHost(host);
+      expect(() => new URL(`http://${h}:7891/#/v3/run-1`)).not.toThrow();
+    }
   });
 });

--- a/test/plugin-service-url-host.test.ts
+++ b/test/plugin-service-url-host.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Only the dashboard external host matters for URL shape; a getter lets each
+// test flip it. formatUrlHost stays REAL so the IPv6-bracketing fix is exercised
+// end-to-end through serviceUrls, not stubbed away.
+let dashboardExternalHost = '10.0.12.34';
+vi.mock('../src/config.js', () => ({
+  config: {
+    dashboard: {
+      get externalHost() {
+        return dashboardExternalHost;
+      },
+      port: 7891,
+    },
+  },
+}));
+
+import { serviceUrls, rewriteLoopbackServiceUrl } from '../src/core/plugins/service-manager.js';
+import type { InstalledPluginRecord } from '../src/core/plugins/types.js';
+import type { PluginServiceDefinition } from '../src/core/plugins/runtime.js';
+
+function fakeRecord(): InstalledPluginRecord {
+  return {
+    id: 'demo-plugin',
+    packageName: '@acme/demo-plugin',
+    version: '1.0.0',
+    source: { type: 'npm', spec: '@acme/demo-plugin@1.0.0' },
+    manifest: { schemaVersion: 1, id: 'demo-plugin' },
+    installedAt: '2026-07-29T00:00:00Z',
+  } as InstalledPluginRecord;
+}
+
+describe('plugin serviceUrls IPv6-safe host', () => {
+  afterEach(() => {
+    dashboardExternalHost = '10.0.12.34';
+  });
+
+  // Class 1: default openUrl (no urls() defined) — the `http://${host}:${port}/`
+  // exit that produced the invalid `http://::1:8080/` before the fix.
+  it('default openUrl brackets an IPv6 external host into a valid URL', () => {
+    dashboardExternalHost = '::1';
+    const def: PluginServiceDefinition = { port: 8080, pm2: { script: 'server.js' } };
+    const { openUrl } = serviceUrls(fakeRecord(), def);
+    expect(openUrl).toBe('http://[::1]:8080/');
+    expect(() => new URL(openUrl!)).not.toThrow();
+  });
+
+  it('default openUrl leaves IPv4 unchanged', () => {
+    dashboardExternalHost = '10.0.12.34';
+    const def: PluginServiceDefinition = { port: 8080, pm2: { script: 'server.js' } };
+    expect(serviceUrls(fakeRecord(), def).openUrl).toBe('http://10.0.12.34:8080/');
+  });
+
+  // Class 2: custom urls() — the contract now hands a URL-ready host, so a plugin
+  // interpolating it straight into a URL still gets a valid IPv6 URL.
+  it('custom urls() receives a URL-ready (bracketed) IPv6 host', () => {
+    dashboardExternalHost = '::1';
+    let seenHost = '';
+    const def: PluginServiceDefinition = {
+      port: 8080,
+      pm2: { script: 'server.js' },
+      urls: ({ host, port }) => {
+        seenHost = host;
+        return { openUrl: `http://${host}:${port}/app`, healthUrl: `http://${host}:${port}/healthz` };
+      },
+    };
+    const { openUrl, healthUrl } = serviceUrls(fakeRecord(), def);
+    expect(seenHost).toBe('[::1]');
+    expect(openUrl).toBe('http://[::1]:8080/app');
+    expect(healthUrl).toBe('http://[::1]:8080/healthz');
+    expect(() => new URL(openUrl!)).not.toThrow();
+    expect(() => new URL(healthUrl!)).not.toThrow();
+  });
+
+  // Class 3: loopback rewrite — a plugin advertising a 127.0.0.1/localhost URL
+  // gets its host rewritten to the external host, and the WHATWG hostname setter
+  // must receive the bracketed IPv6 or it silently no-ops.
+  it('rewrites a loopback URL to a bracketed IPv6 external host', () => {
+    dashboardExternalHost = '::1';
+    expect(rewriteLoopbackServiceUrl('http://127.0.0.1:8080/app')).toBe('http://[::1]:8080/app');
+    expect(rewriteLoopbackServiceUrl('http://localhost:8080/app')).toBe('http://[::1]:8080/app');
+  });
+
+  it('rewrites a loopback URL to an IPv4 external host', () => {
+    dashboardExternalHost = '192.168.31.88';
+    expect(rewriteLoopbackServiceUrl('http://127.0.0.1:8080/app')).toBe('http://192.168.31.88:8080/app');
+  });
+
+  it('leaves a non-loopback URL untouched', () => {
+    dashboardExternalHost = '::1';
+    expect(rewriteLoopbackServiceUrl('http://example.com:8080/app')).toBe('http://example.com:8080/app');
+  });
+});

--- a/test/web-external-host.test.ts
+++ b/test/web-external-host.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 describe('web external host', () => {
   const originalWebExternalHost = process.env.WEB_EXTERNAL_HOST;
   const originalDashboardExternalHost = process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST;
+  const originalDashboardHost = process.env.BOTMUX_DASHBOARD_HOST;
 
   afterEach(() => {
     vi.resetModules();
@@ -12,6 +13,8 @@ describe('web external host', () => {
     else process.env.WEB_EXTERNAL_HOST = originalWebExternalHost;
     if (originalDashboardExternalHost === undefined) delete process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST;
     else process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST = originalDashboardExternalHost;
+    if (originalDashboardHost === undefined) delete process.env.BOTMUX_DASHBOARD_HOST;
+    else process.env.BOTMUX_DASHBOARD_HOST = originalDashboardHost;
   });
 
   it('re-resolves the LAN IP when WEB_EXTERNAL_HOST is not configured', async () => {
@@ -95,5 +98,80 @@ describe('web external host', () => {
 
     const { config } = await import('../src/config.js');
     expect(config.dashboard.externalHost).toBe('terminal.example.com');
+  });
+
+  it('advertises a concrete BOTMUX_DASHBOARD_HOST bind instead of the LAN IP', async () => {
+    // The reported bug: bind 127.0.0.1 but the printed link showed the LAN IP.
+    delete process.env.WEB_EXTERNAL_HOST;
+    delete process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST;
+    process.env.BOTMUX_DASHBOARD_HOST = '127.0.0.1';
+
+    vi.doMock('node:os', async (importOriginal) => ({
+      ...(await importOriginal<typeof import('node:os')>()),
+      networkInterfaces: vi.fn(() => ({
+        en0: [{ family: 'IPv4', internal: false, address: '10.0.12.34' }],
+      })),
+    }));
+    vi.doMock('../src/setup/ensure-tmux.js', () => ({
+      probeTmuxFunctional: () => ({ ok: false }),
+    }));
+
+    const { config } = await import('../src/config.js');
+    expect(config.dashboard.externalHost).toBe('127.0.0.1');
+    // The web terminal host is independent — it still autodetects the LAN IP.
+    expect(config.web.externalHost).toBe('10.0.12.34');
+  });
+
+  it('autodetects the LAN IP for a wildcard dashboard bind', async () => {
+    delete process.env.WEB_EXTERNAL_HOST;
+    delete process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST;
+    process.env.BOTMUX_DASHBOARD_HOST = '0.0.0.0';
+
+    vi.doMock('node:os', async (importOriginal) => ({
+      ...(await importOriginal<typeof import('node:os')>()),
+      networkInterfaces: vi.fn(() => ({
+        en0: [{ family: 'IPv4', internal: false, address: '10.0.12.34' }],
+      })),
+    }));
+    vi.doMock('../src/setup/ensure-tmux.js', () => ({
+      probeTmuxFunctional: () => ({ ok: false }),
+    }));
+
+    const { config } = await import('../src/config.js');
+    expect(config.dashboard.externalHost).toBe('10.0.12.34');
+  });
+
+  it('autodetects the LAN IP for an IPv6 wildcard or blank dashboard bind', async () => {
+    delete process.env.WEB_EXTERNAL_HOST;
+    delete process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST;
+
+    vi.doMock('node:os', async (importOriginal) => ({
+      ...(await importOriginal<typeof import('node:os')>()),
+      networkInterfaces: vi.fn(() => ({
+        en0: [{ family: 'IPv4', internal: false, address: '10.0.12.34' }],
+      })),
+    }));
+    vi.doMock('../src/setup/ensure-tmux.js', () => ({
+      probeTmuxFunctional: () => ({ ok: false }),
+    }));
+
+    for (const bind of ['::', '', '   ']) {
+      vi.resetModules();
+      process.env.BOTMUX_DASHBOARD_HOST = bind;
+      const { config } = await import('../src/config.js');
+      expect(config.dashboard.externalHost).toBe('10.0.12.34');
+    }
+  });
+
+  it('lets an explicit external host win over the bind host', async () => {
+    delete process.env.WEB_EXTERNAL_HOST;
+    process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST = 'dash.example.com';
+    process.env.BOTMUX_DASHBOARD_HOST = '127.0.0.1';
+    vi.doMock('../src/setup/ensure-tmux.js', () => ({
+      probeTmuxFunctional: () => ({ ok: false }),
+    }));
+
+    const { config } = await import('../src/config.js');
+    expect(config.dashboard.externalHost).toBe('dash.example.com');
   });
 });

--- a/test/web-external-host.test.ts
+++ b/test/web-external-host.test.ts
@@ -83,10 +83,10 @@ describe('web external host', () => {
   it('returns a concrete IPv6 bind raw (URL layer brackets it)', async () => {
     setEnv({ BOTMUX_DASHBOARD_HOST: '::1' });
     const config = await loadConfig(() => '10.0.12.34');
+    // config layer stays raw; bracketing for the URL is formatUrlHost's job and
+    // is covered hermetically in dashboard-url.test.ts (this suite doesn't mock
+    // the platform-binding / remote-access state buildDashboardUrl reads).
     expect(config.dashboard.externalHost).toBe('::1');
-    const { buildDashboardUrl } = await import('../src/core/dashboard-url.js');
-    expect(buildDashboardUrl({ host: config.dashboard.externalHost, port: 7891 }))
-      .toBe('http://[::1]:7891/');
   });
 
   it('autodetects the LAN IP for wildcard or blank dashboard binds', async () => {

--- a/test/web-external-host.test.ts
+++ b/test/web-external-host.test.ts
@@ -1,177 +1,105 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 describe('web external host', () => {
-  const originalWebExternalHost = process.env.WEB_EXTERNAL_HOST;
-  const originalDashboardExternalHost = process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST;
-  const originalDashboardHost = process.env.BOTMUX_DASHBOARD_HOST;
+  const original = {
+    WEB_EXTERNAL_HOST: process.env.WEB_EXTERNAL_HOST,
+    BOTMUX_DASHBOARD_EXTERNAL_HOST: process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST,
+    BOTMUX_DASHBOARD_HOST: process.env.BOTMUX_DASHBOARD_HOST,
+  };
 
   afterEach(() => {
     vi.resetModules();
     vi.doUnmock('node:os');
     vi.doUnmock('../src/setup/ensure-tmux.js');
-    if (originalWebExternalHost === undefined) delete process.env.WEB_EXTERNAL_HOST;
-    else process.env.WEB_EXTERNAL_HOST = originalWebExternalHost;
-    if (originalDashboardExternalHost === undefined) delete process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST;
-    else process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST = originalDashboardExternalHost;
-    if (originalDashboardHost === undefined) delete process.env.BOTMUX_DASHBOARD_HOST;
-    else process.env.BOTMUX_DASHBOARD_HOST = originalDashboardHost;
+    for (const [k, v] of Object.entries(original)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
   });
 
-  it('re-resolves the LAN IP when WEB_EXTERNAL_HOST is not configured', async () => {
-    delete process.env.WEB_EXTERNAL_HOST;
-    let interfaces: Record<string, any[]> = {
-      en0: [{ family: 'IPv4', internal: false, address: '10.0.12.34' }],
-    };
-
+  /** Fresh config with node:os / ensure-tmux mocked. `lanIp` is read lazily each
+   *  access, so a test can flip it and re-read config.*.externalHost. */
+  async function loadConfig(lanIp: () => string) {
+    vi.resetModules();
     vi.doMock('node:os', async (importOriginal) => ({
       ...(await importOriginal<typeof import('node:os')>()),
-      networkInterfaces: vi.fn(() => interfaces),
+      networkInterfaces: vi.fn(() => ({
+        en0: [{ family: 'IPv4', internal: false, address: lanIp() }],
+      })),
     }));
     vi.doMock('../src/setup/ensure-tmux.js', () => ({
       probeTmuxFunctional: () => ({ ok: false }),
     }));
+    return (await import('../src/config.js')).config;
+  }
 
-    const { config } = await import('../src/config.js');
+  const setEnv = (env: Record<string, string | undefined>) => {
+    for (const k of Object.keys(original)) delete process.env[k];
+    for (const [k, v] of Object.entries(env)) if (v !== undefined) process.env[k] = v;
+  };
+
+  it('re-resolves the LAN IP when WEB_EXTERNAL_HOST is not configured', async () => {
+    setEnv({});
+    let lan = '10.0.12.34';
+    const config = await loadConfig(() => lan);
     expect(config.web.externalHost).toBe('10.0.12.34');
-
-    interfaces = {
-      en0: [{ family: 'IPv4', internal: false, address: '192.168.31.88' }],
-    };
+    lan = '192.168.31.88';
     expect(config.web.externalHost).toBe('192.168.31.88');
   });
 
   it('keeps an explicit WEB_EXTERNAL_HOST fixed', async () => {
-    process.env.WEB_EXTERNAL_HOST = 'terminal.example.com';
-    let interfaces: Record<string, any[]> = {
-      en0: [{ family: 'IPv4', internal: false, address: '10.0.12.34' }],
-    };
-
-    vi.doMock('node:os', async (importOriginal) => ({
-      ...(await importOriginal<typeof import('node:os')>()),
-      networkInterfaces: vi.fn(() => interfaces),
-    }));
-    vi.doMock('../src/setup/ensure-tmux.js', () => ({
-      probeTmuxFunctional: () => ({ ok: false }),
-    }));
-
-    const { config } = await import('../src/config.js');
+    setEnv({ WEB_EXTERNAL_HOST: 'terminal.example.com' });
+    let lan = '10.0.12.34';
+    const config = await loadConfig(() => lan);
     expect(config.web.externalHost).toBe('terminal.example.com');
-
-    interfaces = {
-      en0: [{ family: 'IPv4', internal: false, address: '192.168.31.88' }],
-    };
+    lan = '192.168.31.88';
     expect(config.web.externalHost).toBe('terminal.example.com');
   });
 
   it('treats blank host settings as unset', async () => {
-    process.env.WEB_EXTERNAL_HOST = '   ';
-    process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST = '';
-    let interfaces: Record<string, any[]> = {
-      en0: [{ family: 'IPv4', internal: false, address: '10.0.12.34' }],
-    };
-
-    vi.doMock('node:os', async (importOriginal) => ({
-      ...(await importOriginal<typeof import('node:os')>()),
-      networkInterfaces: vi.fn(() => interfaces),
-    }));
-    vi.doMock('../src/setup/ensure-tmux.js', () => ({
-      probeTmuxFunctional: () => ({ ok: false }),
-    }));
-
-    const { config } = await import('../src/config.js');
+    setEnv({ WEB_EXTERNAL_HOST: '   ', BOTMUX_DASHBOARD_EXTERNAL_HOST: '' });
+    let lan = '10.0.12.34';
+    const config = await loadConfig(() => lan);
     expect(config.web.externalHost).toBe('10.0.12.34');
     expect(config.dashboard.externalHost).toBe('10.0.12.34');
-
-    interfaces = {
-      en0: [{ family: 'IPv4', internal: false, address: '192.168.31.88' }],
-    };
+    lan = '192.168.31.88';
     expect(config.web.externalHost).toBe('192.168.31.88');
     expect(config.dashboard.externalHost).toBe('192.168.31.88');
   });
 
-  it('falls back to WEB_EXTERNAL_HOST when the dashboard host is blank', async () => {
-    process.env.WEB_EXTERNAL_HOST = 'terminal.example.com';
-    process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST = ' ';
-    vi.doMock('../src/setup/ensure-tmux.js', () => ({
-      probeTmuxFunctional: () => ({ ok: false }),
-    }));
-
-    const { config } = await import('../src/config.js');
+  it('falls back to WEB_EXTERNAL_HOST when the dashboard external host is blank', async () => {
+    setEnv({ WEB_EXTERNAL_HOST: 'terminal.example.com', BOTMUX_DASHBOARD_EXTERNAL_HOST: ' ' });
+    const config = await loadConfig(() => '10.0.12.34');
     expect(config.dashboard.externalHost).toBe('terminal.example.com');
   });
 
   it('advertises a concrete BOTMUX_DASHBOARD_HOST bind instead of the LAN IP', async () => {
-    // The reported bug: bind 127.0.0.1 but the printed link showed the LAN IP.
-    delete process.env.WEB_EXTERNAL_HOST;
-    delete process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST;
-    process.env.BOTMUX_DASHBOARD_HOST = '127.0.0.1';
-
-    vi.doMock('node:os', async (importOriginal) => ({
-      ...(await importOriginal<typeof import('node:os')>()),
-      networkInterfaces: vi.fn(() => ({
-        en0: [{ family: 'IPv4', internal: false, address: '10.0.12.34' }],
-      })),
-    }));
-    vi.doMock('../src/setup/ensure-tmux.js', () => ({
-      probeTmuxFunctional: () => ({ ok: false }),
-    }));
-
-    const { config } = await import('../src/config.js');
+    setEnv({ BOTMUX_DASHBOARD_HOST: '127.0.0.1' });
+    const config = await loadConfig(() => '10.0.12.34');
     expect(config.dashboard.externalHost).toBe('127.0.0.1');
-    // The web terminal host is independent — it still autodetects the LAN IP.
     expect(config.web.externalHost).toBe('10.0.12.34');
   });
 
-  it('autodetects the LAN IP for a wildcard dashboard bind', async () => {
-    delete process.env.WEB_EXTERNAL_HOST;
-    delete process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST;
-    process.env.BOTMUX_DASHBOARD_HOST = '0.0.0.0';
-
-    vi.doMock('node:os', async (importOriginal) => ({
-      ...(await importOriginal<typeof import('node:os')>()),
-      networkInterfaces: vi.fn(() => ({
-        en0: [{ family: 'IPv4', internal: false, address: '10.0.12.34' }],
-      })),
-    }));
-    vi.doMock('../src/setup/ensure-tmux.js', () => ({
-      probeTmuxFunctional: () => ({ ok: false }),
-    }));
-
-    const { config } = await import('../src/config.js');
-    expect(config.dashboard.externalHost).toBe('10.0.12.34');
+  it('returns a concrete IPv6 bind raw (URL layer brackets it)', async () => {
+    setEnv({ BOTMUX_DASHBOARD_HOST: '::1' });
+    const config = await loadConfig(() => '10.0.12.34');
+    expect(config.dashboard.externalHost).toBe('::1');
+    const { buildDashboardUrl } = await import('../src/core/dashboard-url.js');
+    expect(buildDashboardUrl({ host: config.dashboard.externalHost, port: 7891 }))
+      .toBe('http://[::1]:7891/');
   });
 
-  it('autodetects the LAN IP for an IPv6 wildcard or blank dashboard bind', async () => {
-    delete process.env.WEB_EXTERNAL_HOST;
-    delete process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST;
-
-    vi.doMock('node:os', async (importOriginal) => ({
-      ...(await importOriginal<typeof import('node:os')>()),
-      networkInterfaces: vi.fn(() => ({
-        en0: [{ family: 'IPv4', internal: false, address: '10.0.12.34' }],
-      })),
-    }));
-    vi.doMock('../src/setup/ensure-tmux.js', () => ({
-      probeTmuxFunctional: () => ({ ok: false }),
-    }));
-
-    for (const bind of ['::', '', '   ']) {
-      vi.resetModules();
-      process.env.BOTMUX_DASHBOARD_HOST = bind;
-      const { config } = await import('../src/config.js');
+  it('autodetects the LAN IP for wildcard or blank dashboard binds', async () => {
+    for (const bind of ['0.0.0.0', '::', '', '   ']) {
+      setEnv({ BOTMUX_DASHBOARD_HOST: bind });
+      const config = await loadConfig(() => '10.0.12.34');
       expect(config.dashboard.externalHost).toBe('10.0.12.34');
     }
   });
 
   it('lets an explicit external host win over the bind host', async () => {
-    delete process.env.WEB_EXTERNAL_HOST;
-    process.env.BOTMUX_DASHBOARD_EXTERNAL_HOST = 'dash.example.com';
-    process.env.BOTMUX_DASHBOARD_HOST = '127.0.0.1';
-    vi.doMock('../src/setup/ensure-tmux.js', () => ({
-      probeTmuxFunctional: () => ({ ok: false }),
-    }));
-
-    const { config } = await import('../src/config.js');
+    setEnv({ BOTMUX_DASHBOARD_EXTERNAL_HOST: 'dash.example.com', BOTMUX_DASHBOARD_HOST: '127.0.0.1' });
+    const config = await loadConfig(() => '10.0.12.34');
     expect(config.dashboard.externalHost).toBe('dash.example.com');
   });
 });


### PR DESCRIPTION
问题：~/.botmux/.env 里 BOTMUX_DASHBOARD_HOST=127.0.0.1 时，restart 后打印/DM 的 Dashboard 链接仍是 getLocalIp() 探测出的 LAN IP，指向一个根本没在监听的地址。

根因：getDashboardExternalHost() 的回退链只有
BOTMUX_DASHBOARD_EXTERNAL_HOST ?? WEB_EXTERNAL_HOST ?? getLocalIp()， 从不参考实际监听地址 BOTMUX_DASHBOARD_HOST。

修复：未显式配置对外 host 时，优先广告具体的 listen host（127.0.0.1 / LAN IP 等可达地址原样使用）；仅当 bind 为通配 0.0.0.0/:: 这种非可达地址时才回退 LAN IP 自动探测。顺带把 dashboard.ts 里重复的 isWildcardBindHost 收敛到 config.ts。

影响面：只动 config.ts 的 dashboard externalHost 解析 + dashboard.ts 去重导入； web.externalHost（web 终端）不受影响，仍走各自逻辑。所有经由
config.dashboard.externalHost 的出口（restart 提示、restart-report DM、v3 卡片、 federation、plugin service）一并受益。

测试：pnpm build 绿；新增 web-external-host.test.ts 3 例（具体 bind 广告自身 / 通配 bind 回退 LAN IP / 显式 external host 优先）；dashboard-url、terminal-url、 federation-spoke-api 回归全绿（73 passed）。