### PR TITLE
fix(adopt): pendingRepo 期拒绝接管并给一键关闭卡

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -15,7 +15,7 @@ import { scanProjects, scanMultipleProjects, describeProjectDir } from '../servi
 import { createRepoWorktree, pushWorktreeBranch } from '../services/git-worktree.js';
 import { worktreeSlugFromContextAI } from '../services/worktree-slug-ai.js';
 import { resolvePairedSpawnBackendType } from './persistent-backend.js';
-import { buildRepoSelectCard, buildAdoptSelectCard, buildCodexAppThreadSelectCard, buildSlashListCard, getCliDisplayName, buildConfigCard } from '../im/lark/card-builder.js';
+import { buildRepoSelectCard, buildAdoptSelectCard, buildCodexAppThreadSelectCard, buildSlashListCard, getCliDisplayName, buildConfigCard, buildAdoptBlockedCard } from '../im/lark/card-builder.js';
 import { handleDashboardCommand } from './dashboard-command/index.js';
 import { createCliAdapterSync } from '../adapters/cli/registry.js';
 import type { CliId, ResumableSession } from '../adapters/cli/types.js';
@@ -3484,6 +3484,39 @@ function isZellijTarget(t: AdoptableSession | ZellijAdoptableSession): t is Zell
   return 'zellijPaneId' in t;
 }
 
+/**
+ * Refuse a takeover (`/adopt`, Codex App thread, disk resume import) while the
+ * session is still on the first-spawn repo-select gate (`pendingRepo`).
+ *
+ * Adopt/import attaches to an already-running CLI, so it cannot double as a way
+ * to finish that gate — the two states are mutually exclusive by design. Rather
+ * than migrate the pending placeholder in place (which used to leave a
+ * contradictory `adopt` + "待选仓库" session, and risked folding botmux
+ * envelopes into the external CLI), we post a card that explains the refusal
+ * and offers a one-tap "close session". After the user closes it, a fresh
+ * `/adopt` runs as a clean first message (which never enters pendingRepo).
+ *
+ * Returns true when the takeover was blocked (caller must return immediately).
+ * Note pendingRepo is in-memory only, so this can never wrongly fire on a
+ * daemon-restored session.
+ */
+async function blockTakeoverWhilePendingRepo(
+  ds: DaemonSession,
+  sessionReply: (rid: string, content: string, msgType?: string) => Promise<string>,
+): Promise<boolean> {
+  if (!ds.pendingRepo) return false;
+  const loc = localeForBot(ds.larkAppId);
+  const card = buildAdoptBlockedCard(
+    sessionAnchorId(ds),
+    ds.session.sessionId,
+    getBot(ds.larkAppId).config.cliId,
+    loc,
+  );
+  await sessionReply(sessionAnchorId(ds), card, 'interactive');
+  logger.info(`[${tag(ds)}] Takeover refused: session still on pendingRepo gate — posted close-session card`);
+  return true;
+}
+
 export async function startCodexAppThreadSession(
   thread: CodexAppThreadSummary,
   ds: DaemonSession,
@@ -3494,6 +3527,8 @@ export async function startCodexAppThreadSession(
     deps.sessionReply(rid, content, msgType, larkAppId);
   const loc: Locale = localeForBot(ds.larkAppId ?? larkAppId);
   const title = codexAppThreadTitle(thread);
+
+  if (await blockTakeoverWhilePendingRepo(ds, sessionReply)) return;
 
   ds.adoptedFrom = undefined;
   ds.workingDir = thread.cwd;
@@ -3550,6 +3585,10 @@ export async function startAdoptSession(
     await sessionReply(sessionAnchorId(ds), t('cmd.adopt.sandbox_blocked', undefined, loc));
     return;
   }
+
+  // A session still on the repo-select gate can't be adopted in place — refuse
+  // and offer a one-tap close so the user retires it and re-adopts cleanly.
+  if (await blockTakeoverWhilePendingRepo(ds, sessionReply)) return;
 
   const valid = zellij
     ? validateZellijAdoptTarget(target.zellijSession, target.zellijPaneId, target.cliPid, target.cliId)
@@ -3638,6 +3677,8 @@ export async function startResumeImportSession(
     deps.sessionReply(rid, content, msgType, larkAppId);
   const loc: Locale = localeForBot(ds.larkAppId ?? larkAppId);
   const project = target.cwd.split('/').pop() || target.cwd;
+
+  if (await blockTakeoverWhilePendingRepo(ds, sessionReply)) return;
 
   ds.workingDir = target.cwd;
   ds.session.workingDir = target.cwd;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -362,6 +362,8 @@ export const messages: Record<string, string> = {
   'cmd.adopt.pane_not_found': 'tmux pane not found: {pane}',
   'cmd.adopt.target_exited': '⚠️ Target CLI session has exited.',
   'cmd.adopt.sandbox_blocked': '🛡️ This bot has the file sandbox enabled and cannot /adopt an already-running CLI (a sandbox can only be applied at spawn time, never retro-fitted around a live process). Just send a message to cold-start a new, sandboxed CLI session instead.',
+  'card.adopt_blocked.title': '⚠️ Cannot adopt: close the current session first',
+  'card.adopt_blocked.body': 'This topic is still waiting for you to pick a repository, so it cannot /adopt an already-running CLI directly.\n\nTap "Close session" below to end the pending repo-select session, then run /adopt again to attach your CLI (your original CLI is left untouched).',
   'cmd.adopt.success': '📡 Adopted {cliName} · {project} ({pane})',
   'cmd.adopt.resume_success': '↩️ Resumed {cliName} session · {project} — “{title}”',
   'cmd.adopt.resume_not_found': '⚠️ That past session no longer exists or is already in use ({id})',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -365,6 +365,8 @@ export const messages: Record<string, string> = {
   'cmd.adopt.pane_not_found': '未找到 tmux pane {pane}',
   'cmd.adopt.target_exited': '⚠️ 目标 CLI 会话已退出',
   'cmd.adopt.sandbox_blocked': '🛡️ 本机器人已开启文件沙盒，无法 /adopt 已在运行的 CLI（沙盒只能在启动时套用，无法事后包裹活进程）。直接发消息会以沙盒方式冷启动一个新 CLI 会话。',
+  'card.adopt_blocked.title': '⚠️ 无法接入：请先关闭当前会话',
+  'card.adopt_blocked.body': '本话题正在等待你选择仓库，无法直接 /adopt 接管已在运行的 CLI。\n\n请点下方「关闭会话」结束当前的选仓会话，然后重新 /adopt 接管你的 CLI（原 CLI 不受影响）。',
   'cmd.adopt.success': '📡 已接入 {cliName} · {project} ({pane})',
   'cmd.adopt.resume_success': '↩️ 已恢复 {cliName} 历史会话 · {project} —「{title}」',
   'cmd.adopt.resume_not_found': '⚠️ 该历史会话已不存在或已被占用（{id}）',

--- a/src/im/lark/card-builder.ts
+++ b/src/im/lark/card-builder.ts
@@ -1414,6 +1414,43 @@ export function buildQuotaExhaustedCard(targetOpenId: string, limit: number, loc
   return JSON.stringify(card);
 }
 
+/**
+ * Reject card for `/adopt` (and Codex App / resume import) attempted while the
+ * session is still on the first-spawn repo-select gate (`pendingRepo`). Adopt
+ * attaches to an already-running CLI, so it cannot double as a way to finish
+ * that gate: the two states are mutually exclusive by design. Rather than fold
+ * the buffered repo-card messages into the takeover (complex + leaks botmux
+ * envelopes into the external CLI), we refuse and offer a one-tap "close
+ * session" so the user can retire the pending session and re-issue `/adopt`
+ * cleanly. The close button reuses the shared `action: 'close'` handler; the
+ * resulting closed card honours privateCard on its own.
+ */
+export function buildAdoptBlockedCard(rootId: string, sessionId: string, cliId: CliId | undefined, locale?: Locale): string {
+  const actionBase = { root_id: rootId, session_id: sessionId, cli_id: cliId ?? 'claude-code' };
+  const card = {
+    config: { wide_screen_mode: true },
+    header: {
+      title: { tag: 'plain_text', content: t('card.adopt_blocked.title', undefined, locale) },
+      template: 'orange',
+    },
+    elements: [
+      { tag: 'markdown', content: t('card.adopt_blocked.body', undefined, locale) },
+      {
+        tag: 'action',
+        actions: [
+          {
+            tag: 'button',
+            text: { tag: 'plain_text', content: t('card.btn.close_session', undefined, locale) },
+            type: 'danger',
+            value: { action: 'close', ...actionBase },
+          },
+        ],
+      },
+    ],
+  };
+  return JSON.stringify(card);
+}
+
 /** 授权处置后的终态卡（无按钮，防重复点击）。 */
 function formatGrantExpiry(expiresAt: number, locale?: Locale): string {
   return new Date(expiresAt).toLocaleString(locale === 'en' ? 'en-US' : 'zh-CN', { hour12: false });

--- a/test/card-builder.test.ts
+++ b/test/card-builder.test.ts
@@ -17,6 +17,7 @@ import {
   buildSessionClosedCard,
   buildRelayPickerCard,
   buildAdoptSelectCard,
+  buildAdoptBlockedCard,
   buildPrivateSnapshotCard,
   buildConfigCard,
   getCliDisplayName,
@@ -82,6 +83,26 @@ describe('buildAdoptSelectCard', () => {
     const option = card.elements[1].actions[0].options[0].text.content;
     expect(option).toContain('Pi · herdr · collie:w3:p1');
     expect(option).not.toContain('· botmux ·');
+  });
+});
+
+describe('buildAdoptBlockedCard', () => {
+  it('carries a close-session button bound to the session and a repo-select explanation', () => {
+    const card = parse(buildAdoptBlockedCard('om_root', 'sess-123', 'codex', 'en'));
+    const actions = allActions(card);
+    const closeBtn = actions.find((a: any) => a.value?.action === 'close');
+    expect(closeBtn).toBeDefined();
+    expect(closeBtn.type).toBe('danger');
+    expect(closeBtn.value).toMatchObject({ action: 'close', root_id: 'om_root', session_id: 'sess-123', cli_id: 'codex' });
+    // Body must explain the refusal (waiting on repo selection) so the tap is understood.
+    const body = card.elements.map((e: any) => e.content ?? '').join(' ');
+    expect(body.toLowerCase()).toContain('repository');
+  });
+
+  it('defaults cli_id to claude-code when unknown', () => {
+    const card = parse(buildAdoptBlockedCard('om_root', 'sess-9', undefined, 'en'));
+    const closeBtn = allActions(card).find((a: any) => a.value?.action === 'close');
+    expect(closeBtn.value.cli_id).toBe('claude-code');
   });
 });
 

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -194,6 +194,13 @@ vi.mock('../src/im/lark/card-builder.js', () => ({
   buildRepoSelectCard: vi.fn(() => '{"card":"json"}'),
   buildAdoptSelectCard: vi.fn(() => '{"card":"adopt-select"}'),
   buildCodexAppThreadSelectCard: vi.fn(() => '{"card":"codex-app-thread-select"}'),
+  buildAdoptBlockedCard: vi.fn((rootId: string, sessionId: string, cliId?: string) => JSON.stringify({
+    header: { title: { content: '⚠️ adopt blocked' } },
+    elements: [
+      { tag: 'markdown', content: 'waiting for repository selection' },
+      { tag: 'action', actions: [{ tag: 'button', type: 'danger', value: { action: 'close', root_id: rootId, session_id: sessionId, cli_id: cliId ?? 'claude-code' } }] },
+    ],
+  })),
   buildSessionClosedCard: vi.fn(
     (sid: string) =>
       `{"header":{"title":{"content":"🛑 会话已关闭"}},"action":"resume","cmd":"botmux resume ${sid.substring(0, 12)}"}`,
@@ -461,7 +468,7 @@ vi.mock('../src/services/card-mode-store.js', () => ({
 
 // ─── Imports (after mocks) ──────────────────────────────────────────────────
 
-import { DAEMON_COMMANDS, SESSIONLESS_DAEMON_COMMANDS, PASSTHROUGH_COMMANDS, resolvePassthroughCommands, resolveAdapterDefaultPassthroughCommands, handleCommand, handleCardCommand, handleTermLinkCommand, parseSlashCommandInvocation, parseForceTopicInvocation } from '../src/core/command-handler.js';
+import { DAEMON_COMMANDS, SESSIONLESS_DAEMON_COMMANDS, PASSTHROUGH_COMMANDS, resolvePassthroughCommands, resolveAdapterDefaultPassthroughCommands, handleCommand, handleCardCommand, handleTermLinkCommand, parseSlashCommandInvocation, parseForceTopicInvocation, startAdoptSession } from '../src/core/command-handler.js';
 import { setCardMode } from '../src/services/card-mode-store.js';
 import { writeRoleFile, deleteRoleFile, writeTeamRoleFile, deleteTeamRoleFile, resolveRole, resolveRoleFile } from '../src/core/role-resolver.js';
 import { setBotCapability, clearBotCapability } from '../src/services/bot-profile-store.js';
@@ -475,7 +482,7 @@ import { sessionKey } from '../src/core/types.js';
 import { setTerminalProxyPort } from '../src/core/terminal-url.js';
 import type { DaemonSession } from '../src/core/types.js';
 import type { LarkMessage, Session } from '../src/types.js';
-import { killWorker, suspendWorker, forkWorker, getCurrentCliVersion, deliverEphemeralOrReply, deliverWritableTerminalCardTo, requestSessionRestart } from '../src/core/worker-pool.js';
+import { killWorker, suspendWorker, forkWorker, forkAdoptWorker, getCurrentCliVersion, deliverEphemeralOrReply, deliverWritableTerminalCardTo, requestSessionRestart } from '../src/core/worker-pool.js';
 import { dashboardEventBus, type DashboardEvent } from '../src/core/dashboard-events.js';
 import { getOwnerOpenId } from '../src/bot-registry.js';
 import { canOperate } from '../src/im/lark/event-dispatcher.js';
@@ -3086,6 +3093,45 @@ describe('handleCommand', () => {
   // ─── /adopt ─────────────────────────────────────────────────────────────
 
   describe('/adopt', () => {
+    it('refuses adopt while the session is still on the pendingRepo gate and posts a close-session card', async () => {
+      const ds = makeDaemonSession({
+        pendingRepo: true,
+        pendingPrompt: 'buffered while picking repo',
+        pendingFollowUps: ['second buffered line'],
+        repoCardMessageId: 'om_repo_card',
+      });
+      const deps = makeDeps(ds);
+      const target = {
+        source: 'tmux' as const,
+        tmuxTarget: '0:1.0',
+        cliPid: 4242,
+        sessionId: 'host-cli',
+        cliId: 'claude-code' as const,
+        cwd: '/repo',
+        paneCols: 80,
+        paneRows: 24,
+      };
+
+      await startAdoptSession(target, ds, deps, LARK_APP_ID);
+
+      // Refused: no takeover, no state mutation — the pending gate is untouched
+      // so the session can still finish via /repo (or the card's close button).
+      expect(forkAdoptWorker).not.toHaveBeenCalled();
+      expect(ds.adoptedFrom).toBeUndefined();
+      expect(ds.pendingRepo).toBe(true);
+      expect(ds.pendingPrompt).toBe('buffered while picking repo');
+      expect(ds.pendingFollowUps).toEqual(['second buffered line']);
+
+      // Posted an interactive card carrying a close-session button bound to this session.
+      const replyArgs = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls.at(-1)!;
+      expect(replyArgs[2]).toBe('interactive');
+      const card = JSON.parse(replyArgs[1] as string);
+      const buttons = card.elements.flatMap((el: any) => el.actions ?? []);
+      const closeBtn = buttons.find((b: any) => b.value?.action === 'close');
+      expect(closeBtn).toBeDefined();
+      expect(closeBtn.value.session_id).toBe(ds.session.sessionId);
+    });
+
     it('should refuse re-adopt and prompt 断开 when ds.adoptedFrom is already set', async () => {
       const ds = makeDaemonSession({
         adoptedFrom: {

--- a/test/session-adopt.test.ts
+++ b/test/session-adopt.test.ts
@@ -35,6 +35,10 @@ vi.mock('../src/im/lark/card-builder.js', () => ({
   ),
   buildAdoptSelectCard: vi.fn(() => JSON.stringify({ type: 'adopt_select' })),
   buildCodexAppThreadSelectCard: vi.fn(() => JSON.stringify({ type: 'codex_app_thread_select' })),
+  buildAdoptBlockedCard: vi.fn((rootId: string, sessionId: string, cliId?: string) => JSON.stringify({
+    type: 'adopt_blocked',
+    elements: [{ tag: 'action', actions: [{ tag: 'button', value: { action: 'close', root_id: rootId, session_id: sessionId, cli_id: cliId ?? 'claude-code' } }] }],
+  })),
   getCliDisplayName: vi.fn(() => 'Claude'),
 }));
 
@@ -421,6 +425,41 @@ describe('Adopt card actions', () => {
       expect(sessionStore.updateSession).toHaveBeenCalledWith(ds.session);
       expect(forkWorker).toHaveBeenCalledWith(ds, '', true);
       expect(deleteMessage).toHaveBeenCalledWith(APP_ID, 'om_card_msg');
+    });
+
+    it('refuses a Codex App thread takeover while the session is still on the pendingRepo gate', async () => {
+      vi.mocked(getBot).mockReturnValue({
+        config: {
+          larkAppId: APP_ID,
+          larkAppSecret: 'secret',
+          cliId: 'codex-app',
+          cliPathOverride: '/opt/codex',
+        },
+        resolvedAllowedUsers: [],
+        botOpenId: 'ou_bot',
+      } as any);
+      vi.mocked(listCodexAppThreads).mockResolvedValueOnce([
+        {
+          threadId: 'thread-1',
+          name: 'Existing Codex App thread',
+          preview: 'preview',
+          cwd: '/repo/codex-app',
+          updatedAtMs: 1780000000000,
+        },
+      ]);
+      const ds = makeDaemonSession({ pendingRepo: true, pendingPrompt: 'buffered' });
+      const sessions = new Map<string, DaemonSession>();
+      sessions.set(sessionKey(ROOT_ID, APP_ID), ds);
+      const deps = makeDeps(sessions);
+
+      await handleCardAction(makeCodexAppThreadSelectEvent(ROOT_ID, JSON.stringify({ threadId: 'thread-1' })), deps, APP_ID);
+      await flush();
+
+      // Refused: no takeover, pending gate untouched.
+      expect(forkWorker).not.toHaveBeenCalled();
+      expect(ds.adoptedFrom).toBeUndefined();
+      expect(ds.pendingRepo).toBe(true);
+      expect(ds.session.cliSessionId).not.toBe('thread-1');
     });
 
     it('should return early when rootId is missing', async () => {


### PR DESCRIPTION
## 改了什么

会话仍在「待选仓库」挂起态（`pendingRepo`）时直接 `/adopt`（或 Codex App thread 接管 / 磁盘 resume import），旧逻辑只写 `adoptedFrom` 就 fork bridge worker，**不清 `pendingRepo`**。后果：后续消息继续命中 daemon 的选仓缓冲分支，形成「CLI 已接入，但消息仍提示先选仓库」的死循环；dashboard 也同时显示 `adopt` 与「待选仓库」两个自相矛盾的标签。

adopt 接管的是**已在运行的 CLI**，本就不能兼作「选仓完成」的第二条路径——两态互斥。因此本 PR 不做原地状态迁移，而是**直接拒绝 + 引导一键关闭**：

- 新增 `buildAdoptBlockedCard`：卡片标题写明拒绝原因（本话题正在等你选仓库，无法直接 adopt），并带一个 danger 按钮「关闭会话」，**复用现成的 `action: 'close'` 处理器**（关闭后由其自身逻辑处理 privateCard / 关闭卡）。
- 三个**交互式**接管入口（`startAdoptSession` / `startCodexAppThreadSession` / `startResumeImportSession`）顶部共用 `blockTakeoverWhilePendingRepo` 守卫：命中 `pendingRepo` 即发卡并 `return`，**不做任何状态修改**。（Codex-notifier 私聊「继续处理」卡回调是另一条路径，见下方「已知限制」。）
- 用户点「关闭会话」→ 退掉选仓会话 → 再 `/adopt` 走干净的首条消息路径（首条 `/adopt` 本就不进 `pendingRepo`，畅通）。

## 为什么这么改（而不是把缓冲消息折进接管）

评审阶段先实现过「接管时清 `pendingRepo` + 把选仓期缓冲消息折进接管首轮」，但这条路：
1. 复杂——要给 21 个 pending 字段做清理 + 快照/回滚，还要处理 bridge 裸化；
2. 有一处提示泄漏——外部 adopt 的 bridge 模式下，缓冲的第 2+ 条 follow-up 里 `<attachments>` XML 与 `open_id` 会原样进入用户自己的外部 CLI，违反 bridge「外部 CLI 永远看不到 botmux 信封」的契约。

按 owner 决策，去掉整套折叠逻辑，改为「拒绝 + 一键关闭」：adopt 接管的本就是用户自己在敲的 CLI，关掉选仓会话后重发一句即可，代价小；而死循环 + dashboard 双标这两个真实 bug 被彻底堵死。实现从 ~430 行降到 **~190 行（含测试）**，且不再有任何提示泄漏面。

## 影响面评估

- **共用路径**：仅在 `core/command-handler` 三个 takeover 入口顶部各加一句守卫 + 一个共用 helper；`im/lark/card-builder` 加一个纯函数 card builder；两条 i18n 文案。无状态迁移、无回滚机制、无前端改动。
- **CLI**：外部 tmux / Herdr / Zellij adopt 共用 `startAdoptSession`；Codex App thread selector / 磁盘 resume import 分别走各自入口，这三类交互入口被守卫覆盖。普通 botmux-owned CLI 路径不变。Codex-notifier 私聊「继续处理」卡回调不在覆盖范围（见「已知限制」）。
- **后端/会话类型**：`pendingRepo` 只存在内存、不落盘，守卫不会误伤 daemon 重启恢复的会话。thread/chat scope 均覆盖。
- **平台**：无平台专属路径、shell 或文件系统行为变化。

## 实际验证

- `pnpm build`：通过（tsc、dashboard bundle、dist audit 全绿）
- 定向回归：`pnpm vitest run test/card-builder.test.ts test/command-handler.test.ts test/session-adopt.test.ts` → **3 files / 360 tests passed**
- 新增测试单独隔离跑亦通过：
  - `startAdoptSession`：pendingRepo 期 `/adopt` 被拒（不 fork、状态不变、发出带 close 按钮的卡）
  - Codex App thread 接管：pendingRepo 期被拒（不 fork、gate 未消费）
  - `buildAdoptBlockedCard` 单测：close 按钮绑定正确 session_id、cli_id 缺省兜底 claude-code
- `git merge-tree` 对当前 master（含 #660）零冲突。

## 已知限制（pre-existing，不在本 PR 范围）

本 PR 的守卫覆盖三类**交互式**接管入口：`/adopt`（直接指定 pane / 选择卡）、Codex App thread 选择卡、磁盘 resume import。

**不覆盖** Codex-notifier 私聊「任务完成 → 在飞书中继续处理」卡回调（`daemon.ts` 的 `adoptCodexNotifierEvent`）：该路径在调用 `startCodexAppThreadSession` 之前会自行 inline 清掉 `pendingRepo`，故新守卫必然 no-op。默认 `p2pMode=chat` 下它复用同一 DM 的会话，因此在「选仓卡未完成 + 已 buffer 一条待提交 prompt」的组合下存在两个 **pre-existing** 问题：① 待提交 prompt 被静默丢弃；② 迟到的 auto-worktree 完成 / 旧选仓卡二次点击可能 kill 掉刚接管的会话。

这两条 race **在 master 上已存在**（本 PR 未改动 `daemon.ts` / `card-handler.ts`，与其 byte-identical），不是本 PR 引入。按 owner 决策，notifier 路径的收口另开 follow-up PR 处理（验收两项：notifier 遇 pendingRepo 不再静默丢待提交 prompt；迟到 auto-worktree 与旧 repo 卡不再替换刚接管的会话）。

## 说明

本 PR 分支历史已按 owner 决策重写为单 commit `ae84d2c`（此前的「清状态/折叠消息」两版方案已废弃）。

