### PR TITLE
fix(sandbox): macOS 安全基线放行 iokit-open，修复沙箱内浏览器 SIGSEGV

### DIFF
--- a/src/adapters/cli/fs-policy.ts
+++ b/src/adapters/cli/fs-policy.ts
@@ -493,7 +493,7 @@ const SEATBELT_BASE_PROFILE = '/System/Library/Sandbox/Profiles/bsd.sb';
  * Compile the policy to a macOS Seatbelt profile. `(deny default)` + Apple's
  * bsd.sb base makes it deny-by-default for BOTH files and other operations,
  * then we re-allow the non-file operation classes the CLI needs (process/mach/
- * ipc/sysctl/signal, network gated on policy.net) and the three file tiers
+ * ipc/sysctl/signal/iokit-open, network gated on policy.net) and the three file tiers
  * emitted shallow→deep (Seatbelt applies the LAST matching rule → deepest rule
  * wins, matching accessForPath()).
  */
@@ -510,6 +510,21 @@ export function compileToSeatbelt(policy: FsPolicy): string {
     '(allow ipc*)',
     '(allow sysctl*)',
     '(allow file-ioctl)',
+    // IOKit user clients. bsd.sb carries NO iokit rule, so `(deny default)` denies
+    // every IOServiceOpen — and the frameworks that need one (CoreGraphics /
+    // IOSurface / IOPMrootDomain power monitoring) often do NOT check the failure:
+    // the process dies with a bare SIGSEGV inside IOKit, no sandbox diagnostic at
+    // all. Reproduced with `chrome-headless-shell` (the binary behind an agent's
+    // puppeteer/playwright screenshots): SEGV_ACCERR before first paint, every run.
+    // NOT a claim that IOKit is security-irrelevant — opening user clients is real
+    // kernel attack surface. It is an explicit COMPATIBILITY TRADE-OFF, of a piece
+    // with the wholesale mach*/ipc*/sysctl* grants above: this sandbox's threat
+    // model is the file isolation enforced by the tiers below (cross-bot reads and
+    // credentials), not kernel-surface reduction. A per-user-client-class allow-list
+    // would be tighter, but the required set drifts with macOS/silicon/toolchain and
+    // every miss fails as that same silent crash. Tighten it behind an opt-in tier
+    // if a deployment ever needs the kernel surface closed too.
+    '(allow iokit-open)',
     ...(policy.net ? ['(allow network*)', '(allow system-socket)'] : []),
   ];
   for (const r of policy.rules) {

--- a/test/fs-policy-seatbelt.e2e.test.ts
+++ b/test/fs-policy-seatbelt.e2e.test.ts
@@ -9,7 +9,7 @@
  * the fix (import Apple's bsd.sb base) must keep working across OS updates.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { execFileSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, realpathSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
 import { join, dirname } from 'node:path';
@@ -18,9 +18,14 @@ import { buildFsPolicy, compileToSeatbelt } from '../src/adapters/cli/fs-policy.
 const darwin = process.platform === 'darwin'
   && spawnSync('sh', ['-c', 'command -v sandbox-exec'], { stdio: 'ignore' }).status === 0;
 const d = darwin ? describe : describe.skip;
+// The IOKit probe needs a C toolchain. Decided at collection time so a runner
+// without clang reports SKIPPED — never a green test that silently proved nothing.
+const clangAvailable = darwin
+  && spawnSync('sh', ['-c', 'command -v clang'], { stdio: 'ignore' }).status === 0;
+const iokitIt = clangAvailable ? it : it.skip;
 
 d('Seatbelt three-tier enforcement (real sandbox-exec)', () => {
-  let S: string, profile: string;
+  let S: string, profile: string, policyForProfile: ReturnType<typeof buildFsPolicy>;
   const canonical = (p: string) => { try { return realpathSync(p); } catch { return p; } };
 
   beforeAll(() => {
@@ -43,6 +48,7 @@ d('Seatbelt three-tier enforcement (real sandbox-exec)', () => {
       net: true, writeRegexes: [],
     });
     policy.rules = policy.rules.filter(r => r.access === 'deny' || (() => { try { return require('node:fs').existsSync(r.path); } catch { return false; } })());
+    policyForProfile = policy;
     profile = join(S, 'p.sb');
     writeFileSync(profile, compileToSeatbelt(policy));
   });
@@ -75,5 +81,57 @@ d('Seatbelt three-tier enforcement (real sandbox-exec)', () => {
   it('processes bootstrap under deny-read-default (bsd.sb base): node runs + writes rw', () => {
     expect(allowed('node', '-e', 'process.exit(0)')).toBe(true);
     expect(allowed('node', '-e', `require('fs').writeFileSync(${JSON.stringify(join(S, 'proj/n.txt'))},'ok')`)).toBe(true);
+  });
+
+  /**
+   * `(deny default)` + bsd.sb (which carries NO iokit rule) denies every
+   * IOServiceOpen. The frameworks that need one mostly don't check the failure —
+   * Chromium dies with a bare SIGSEGV inside IOKit, no sandbox diagnostic — so the
+   * grant has to be asserted at the kernel level, not just as profile text.
+   * The probe calls IORegisterForSystemPower (the exact user client Chromium's
+   * power monitor opens) and reports MACH_PORT_NULL as DENIED.
+   */
+  iokitIt('iokit-open is granted (IOServiceOpen works; stripping the grant denies it)', () => {
+    const src = join(S, 'proj/iokit-probe.c');
+    const bin = join(S, 'proj/iokit-probe');
+    writeFileSync(src, [
+      '#include <IOKit/pwr_mgt/IOPMLib.h>',
+      '#include <stdio.h>',
+      'static void cb(void *r, io_service_t s, natural_t t, void *a) { (void)r;(void)s;(void)t;(void)a; }',
+      'int main(void) {',
+      '  IONotificationPortRef np = NULL; io_object_t note = 0;',
+      '  io_connect_t port = IORegisterForSystemPower(NULL, &np, cb, &note);',
+      '  printf("%s\\n", port == MACH_PORT_NULL ? "DENIED" : "OK");',
+      '  return 0;',
+      '}',
+    ].join('\n'));
+    // A compile failure must FAIL, not silently pass: this test is the only
+    // kernel-level proof, and a green "toolchain missing" would be worse than a
+    // red build (the whole bug class here is silent).
+    const cc = spawnSync('clang', ['-framework', 'IOKit', '-framework', 'CoreFoundation', '-o', bin, src], { encoding: 'utf8' });
+    expect(cc.status, `clang failed to build the IOKit probe: ${cc.stderr}`).toBe(0);
+
+    // The probe reports on STDOUT, so the verdict never depends on how a given
+    // macOS surfaces the refusal (exit code vs signal). Anything that stops the
+    // probe from running (spawn error, crash before print) yields neither
+    // OK nor DENIED and fails the assertion — with the details attached.
+    const verdict = (...argv: string[]) => {
+      const r = spawnSync(argv[0], argv.slice(1), { encoding: 'utf8' });
+      const why = `spawn ${argv.join(' ')} → status=${r.status} signal=${r.signal} err=${r.error?.message} stderr=${r.stderr}`;
+      expect(r.error, why).toBeUndefined();
+      expect(['OK', 'DENIED'], why).toContain((r.stdout ?? '').trim());
+      return r.stdout.trim();
+    };
+
+    expect(verdict(bin)).toBe('OK');                                  // sanity: unsandboxed
+    expect(verdict('sandbox-exec', '-f', profile, bin)).toBe('OK');    // the grant works
+
+    // Negative control: the SAME profile minus that one line → the open is refused.
+    const stripped = join(S, 'p-no-iokit.sb');
+    const text = compileToSeatbelt(policyForProfile);
+    const withoutGrant = text.replace(/^\(allow iokit-open\)\r?\n/m, '');
+    expect(withoutGrant).not.toContain('(allow iokit-open)'); // the strip actually happened
+    writeFileSync(stripped, withoutGrant);
+    expect(verdict('sandbox-exec', '-f', stripped, bin)).toBe('DENIED');
   });
 });

--- a/test/fs-policy.test.ts
+++ b/test/fs-policy.test.ts
@@ -432,9 +432,17 @@ describe('compileToSeatbelt', () => {
     expect(prof).toContain('(allow network*)'); // net defaults true
   });
 
+  // Regression: bsd.sb carries no iokit rule, so without this grant `(deny default)`
+  // kills every IOServiceOpen — Chromium (headless screenshots) SIGSEGVs inside
+  // IOKit with no sandbox diagnostic. See the e2e for the live proof.
+  it('grants iokit-open (bsd.sb has none; missing it SIGSEGVs Chromium)', () => {
+    expect(compileToSeatbelt(policy())).toContain('(allow iokit-open)');
+  });
+
   it('omits network grants when net is disabled', () => {
     const prof = compileToSeatbelt(buildFsPolicy(ctx({ net: false })));
     expect(prof).not.toContain('(allow network*)');
+    expect(prof).toContain('(allow iokit-open)'); // not gated on net
   });
 
   it('deeper rules are emitted later (last-match wins)', () => {


### PR DESCRIPTION
## 问题

`compileToSeatbelt()`（`src/adapters/cli/fs-policy.ts`）用 `(deny default)` + Apple `bsd.sb` 基座，然后重新放行少量非文件操作类（`process*` / `signal` / `mach*` / `ipc*` / `sysctl*` / `file-ioctl`，`network*` 由 `policy.net` 控制）。

**`bsd.sb` 里没有任何 iokit 规则**（`grep -c iokit /System/Library/Sandbox/Profiles/bsd.sb` → 0），所以沙箱内**每一次 `IOServiceOpen` 都被默认拒绝**。

坏就坏在失败形态：需要 IOKit user client 的框架（CoreGraphics / IOSurface / IOPMrootDomain 电源监控）大多不检查返回值，拿到 `MACH_PORT_NULL` 后直接解引用 —— 进程在 IOKit 里 **裸 SIGSEGV，没有任何沙箱诊断信息**。表现是「浏览器在沙箱里一跑就崩，日志里什么都没有」。

这条在生产里真实咬到过：一个开了沙箱的 bot 所有 puppeteer/playwright 截图全部 SIGSEGV，排查过程中先后误判成 WindowServer 问题、二进制版本问题、甚至跨机器问题，最后靠把 HTML 发给另一台没开沙箱的机器代渲染才交付。

## 改动

在非文件操作类里加一条 `(allow iokit-open)`。

## 本地验证

环境：macOS 26.5.2 (25F84) / Apple M4 / arm64，`chrome-headless-shell` 150.0.7871.24。
**profile 由产品代码本身生成**（`buildFsPolicy()` + `compileToSeatbelt()`），不是手写的等价物。

| profile | 结果 |
|-|-|
| 改动前 | `rc=139`，`Received signal 11 SEGV_ACCERR`，首帧之前就死 |
| 改动后 | `rc=0`，正常出图 |
| 完全不沙箱（基线） | `rc=0` |

沙箱内截图与**完全不沙箱**的截图 **md5 逐字节相同**（`87ec88a5213c7602b3a3fbe975552483`）—— 这条 grant 不改变渲染行为，只是不再被杀。开 / 关 GPU 都验过。

只需要 `iokit-open`：`iokit-get-properties` / `iokit-set-properties` 不加也能跑通。

## 为什么不按 user-client-class 白名单收紧

我做了 bisect：在这台机器上，只放行 `(iokit-user-client-class "RootDomainUserClient")` 一个类就足够让 `chrome-headless-shell` 跑通（崩的其实是 Chromium 的电源监控 `IORegisterForSystemPower`）。

**但不建议按类白名单**，理由是这个集合会漂移而失败无声：

- Intel / Apple Silicon 的 GPU、编解码、显示相关 user-client 类不同；
- VideoToolbox 硬件编解码、CoreGraphics / IOSurface 的路径随是否启用硬件加速、显示环境、系统版本变化；
- agent 会跑的其它工具（ffmpeg、node-canvas、sharp…）各有各的类；
- 一旦漏掉，失败形态还是本 PR 开头那个**无诊断的 SIGSEGV**，维护成本极高。

同时需要说清楚这是**显式的兼容性取舍，不是「IOKit 没有安全价值」**：打开 user client 确实是真实的内核攻击面。但它不会把被 `file-read*` 拒掉的文件变得可读 —— 跨 bot 目录、`.ssh`、`.aws`、Keychain 仍然由文件规则挡住；新增的是「驱动漏洞 → 内核执行」这条本地利用链，而当前 profile 本来就整体放行了 `mach*` / `ipc*` / `sysctl*`，本就不是面向任意恶意 native binary 的强系统调用沙箱。本沙箱声明的边界是**文件隔离**（跨 bot 读 + 凭证）。

如果将来有部署确实需要连内核面一起关，建议做成显式的「能力档位」（默认兼容档全放、高风险档最小白名单），而不是把某台机器上观测到的单一 class 当成全局默认。代码注释里写明了这一点。

## 测试

`test/fs-policy.test.ts`
- 断言 profile 含 `(allow iokit-open)`
- 断言它不受 `net` 开关影响

`test/fs-policy-seatbelt.e2e.test.ts` — **内核级验证**，不只是断言 profile 文本：
- 用 `clang` 编译一个调用 `IORegisterForSystemPower` 的探针（Chromium 电源监控打开的正是这个 user client），探针把 `OK` / `DENIED` 打到 stdout
- 在真 profile 下 → `OK`；在**剥掉这一行的同一份 profile** 下 → `DENIED`（negative control）
- 结论走 stdout 而不是退出码，避免依赖不同 macOS 用退出码还是信号表达拒绝
- 缺 `clang` 时整条用例报 **skipped 而不是绿灯**（collection time 判定）；`clang` 在但 SDK/framework 编译失败则直接 fail 并带上 stderr —— 本 PR 修的就是「静默失败」这一类问题，测试自己不能再静默通过

**mutation 验证**（不是只看全绿）：
- 删掉 src 里那一行 → 3 个用例失败（2 个 unit + 1 个 e2e），恢复后全绿
- 把 negative control 改成「不剥离」→ 该用例失败

```
Test Files  2 passed (2)
     Tests  52 passed (52)
```

相关 sandbox 测试无回归：`sandbox.test.ts` / `fs-policy-bwrap.e2e.test.ts` / `sandbox-mask-manifest` / `riff-sandbox-bypass` / `plugin-mcp-sandbox` / `sandbox-migration` / `sandbox-paths-normalize` 全绿，`tsc --noEmit` 干净。

## 影响面

- 仅 macOS Seatbelt 路径。Linux `compileToBwrap()` 是 mount namespace 模型，没有对应的 `iokit-open` operation，也没有 `bsd.sb` 的 deny-default 副作用，**无需同步改动**（Linux 侧的硬件加速属于 `/dev/dri`、VA-API 等设备节点暴露，是独立设计，不应在本 PR 顺带做）。
- `read-isolation.ts` 里的 legacy `buildSeatbeltProfile()` 用的是 `(allow default)`，本来就不受影响。

## Review

改动经 codex 两轮定向 review：
1. 第一轮唯一阻断项是 e2e 在缺 clang 时测试体内 `return`（报告仍显示通过 = 假绿灯），另有两条低优先级建议（negative control 的字符串剥离锚定整行并验证剥离生效、不要只比较退出码）；
2. 修完复验，确认三条均已实质修复、本轮修复未引入新的静默通过路径，**无阻断合入问题**；按其建议进一步收敛了注释措辞（避免被读成「IOKit 不属于安全边界」）并给 spawn helper 补了诊断输出。

安全面结论（codex）：不存在 `IOServiceOpen → 绕过 file-read* 读到被 deny 的文件 / 别的 bot 凭证` 这样的直接路径，文件与凭证边界不被削弱；新增的是内核/驱动漏洞利用面，属于上面说明的显式取舍。
