### PR TITLE
refactor(plugins): 内联 Dashboard URL host 格式化

### DIFF
--- a/src/core/plugins/service-manager.ts
+++ b/src/core/plugins/service-manager.ts
@@ -230,21 +230,15 @@ function isLoopbackHost(hostname: string): boolean {
   return hostname === '127.0.0.1' || hostname === 'localhost' || hostname === '::1' || hostname === '[::1]';
 }
 
-/** The dashboard external host, formatted so it can be interpolated straight into
- *  a URL: an IPv6 literal (e.g. `::1`) comes back bracketed (`[::1]`). This is the
- *  URL-ready form the plugin `urls()` contract receives and every openUrl uses; a
- *  raw `::1` would produce the invalid `http://::1:port/`. */
-function urlReadyDashboardHost(): string {
-  return formatUrlHost(config.dashboard.externalHost);
-}
-
 export function rewriteLoopbackServiceUrl(rawUrl: string | undefined): string | undefined {
   if (!rawUrl) return undefined;
   try {
     const url = new URL(rawUrl);
     // The WHATWG hostname setter silently drops a bare IPv6 literal (`::1`), so
     // pass the bracketed form or the loopback rewrite would no-op.
-    if (isLoopbackHost(url.hostname)) url.hostname = urlReadyDashboardHost();
+    if (isLoopbackHost(url.hostname)) {
+      url.hostname = formatUrlHost(config.dashboard.externalHost);
+    }
     return url.toString();
   } catch {
     return rawUrl;
@@ -254,7 +248,7 @@ export function rewriteLoopbackServiceUrl(rawUrl: string | undefined): string | 
 export function serviceUrls(record: InstalledPluginRecord, definition: PluginServiceDefinition): Pick<PluginServiceState, 'port' | 'openUrl' | 'healthUrl'> {
   const env = definitionEnv(record, definition);
   const port = definition.port ?? (env.PORT ? Number(env.PORT) : undefined);
-  const host = urlReadyDashboardHost();
+  const host = formatUrlHost(config.dashboard.externalHost);
   const urls = definition.urls?.({ host, env, ...(Number.isFinite(port) ? { port } : {}) }) ?? {};
   return {
     ...(Number.isFinite(port) ? { port } : {}),


### PR DESCRIPTION
## 改了什么

删除 `service-manager.ts` 中只包装一行调用的 `urlReadyDashboardHost()`，在两个使用点直接调用 `formatUrlHost(config.dashboard.externalHost)`。

`PluginServiceDefinition.urls()` 的 URL-ready host 契约仍保留在 `runtime.ts` 类型注释中，IPv6 bracket 行为不变。

## 为什么单独开这个 PR

PR #667 已于 `2026-07-30 01:59 UTC` 合入 master；随后合入其 fork 源分支的 stacked PR 只更新了 fork branch，无法倒推已经完成的 master merge。因此把同一个单提交清理作为 #667 的 follow-up 提交到 master。

## 影响面

仅做 plugin service URL 构造路径的等价重构：

- 默认 `openUrl`
- 自定义 `urls({ host })`
- loopback URL hostname rewrite

不影响其它 CLI、后端或会话类型。

## 实际验证

- `pnpm exec vitest run test/plugin-service-url-host.test.ts test/plugin-service-lifecycle-guard.test.ts test/plugin-service-link-watch.test.ts test/plugin-service-restart-lifecycle.test.ts --reporter=dot`：23 passed
- `pnpm build`：通过
- `pnpm daemon:restart`：全部进程 online
