### PR TITLE
feat(lark): 普通群话题首回合注入话题 hint（按需 botmux history）+ 适配 @types/react@19 解锁 build

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -15364,17 +15364,17 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
     : buildQuoteHint(parsed, scope, anchor, localeForBot(larkAppId));
   const codexAppApplicationContext = vcMeetingApplicationContext(ctx);
   // 普通群「对已有消息发起话题再 @」：入站是话题内回复（root_id 指向另一条更早
-  // 的话题根消息），bot 从未留存该话题历史。首轮拉取整条话题上下文（根 + 本条
-  // @ 之前的全部回复，文本+附件下载到本 bot 附件桶）并前置到 prompt，让 CLI 先
-  // 看到话题完整上下文。best-effort，失败降级（只取根 / 空串）不阻断；coalesced
-  // forward 已自带上下文不再重复拉取。仅首轮 — 后续 handleThreadReply 回合 CLI
-  // 已在首轮拿到话题上下文，不重复拉取。
+  // 的话题根消息），bot 从未留存该话题历史，且正文里没有任何信号表明存在话题根+
+  // 前情。首轮注入一行 hint（非全文），提示 CLI 可用 `botmux history` 按需拉取话题
+  // 历史（对齐 quote hint 的「提示+按需」模式，避免无条件全量预取+下载所有历史附件+
+  // 长话题只取最旧 50 条的问题）。best-effort，metadata 探测失败降级为无 count 的
+  // hint（信号不丢）。coalesced forward 已自带上下文不注入。仅首轮 — 后续
+  // handleThreadReply 回合 CLI 已在首轮拿到该 hint，不重复注入。
   const topicThreadContext = (parsed.rootId && parsed.rootId !== parsed.messageId && !ctx.forwardSeedData)
     ? await buildTopicThreadContext(larkAppId, chatId, parsed.rootId, parsed.messageId, localeForBot(larkAppId))
     : '';
-  // 话题上下文同样前置到 codex-app 结构化 sidecar lane（与 quote hint 一致双 lane
-  // 下发），否则 codex-app（clean input）bot 走 sidecar 时会静默丢掉话题历史，
-  // 正是本 PR 要修的 bug。
+  // 话题 hint 同样前置到 codex-app 结构化 sidecar lane（与 quote hint 一致双 lane
+  // 下发），否则 codex-app（clean input）bot 走 sidecar 时会静默丢掉该 hint。
   const codexAppMessageContext = topicThreadContext + codexAppQuoteContext + (workflowGrillPrompt ?? '');
   const promptContent = topicThreadContext + codexAppQuoteContext + codexAppApplicationContext + content;
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -15362,7 +15362,6 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
   const codexAppQuoteContext = ctx.forwardSeedData
     ? ''
     : buildQuoteHint(parsed, scope, anchor, localeForBot(larkAppId));
-  const codexAppMessageContext = codexAppQuoteContext + (workflowGrillPrompt ?? '');
   const codexAppApplicationContext = vcMeetingApplicationContext(ctx);
   // 普通群「对已有消息发起话题再 @」：入站是话题内回复（root_id 指向另一条更早
   // 的话题根消息），bot 从未留存该话题历史。首轮拉取整条话题上下文（根 + 本条
@@ -15373,6 +15372,10 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
   const topicThreadContext = (parsed.rootId && parsed.rootId !== parsed.messageId && !ctx.forwardSeedData)
     ? await buildTopicThreadContext(larkAppId, chatId, parsed.rootId, parsed.messageId, localeForBot(larkAppId))
     : '';
+  // 话题上下文同样前置到 codex-app 结构化 sidecar lane（与 quote hint 一致双 lane
+  // 下发），否则 codex-app（clean input）bot 走 sidecar 时会静默丢掉话题历史，
+  // 正是本 PR 要修的 bug。
+  const codexAppMessageContext = topicThreadContext + codexAppQuoteContext + (workflowGrillPrompt ?? '');
   const promptContent = topicThreadContext + codexAppQuoteContext + codexAppApplicationContext + content;
 
   // Resolve sender identity for <sender> tag injection. The first call to

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -15365,13 +15365,13 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
   const codexAppApplicationContext = vcMeetingApplicationContext(ctx);
   // 普通群「对已有消息发起话题再 @」：入站是话题内回复（root_id 指向另一条更早
   // 的话题根消息），bot 从未留存该话题历史，且正文里没有任何信号表明存在话题根+
-  // 前情。首轮注入一行 hint（非全文），提示 CLI 可用 `botmux history` 按需拉取话题
-  // 历史（对齐 quote hint 的「提示+按需」模式，避免无条件全量预取+下载所有历史附件+
-  // 长话题只取最旧 50 条的问题）。best-effort，metadata 探测失败降级为无 count 的
-  // hint（信号不丢）。coalesced forward 已自带上下文不注入。仅首轮 — 后续
-  // handleThreadReply 回合 CLI 已在首轮拿到该 hint，不重复注入。
+  // 前情。首轮注入一行 hint（非全文、零网络请求），提示 CLI 可用 `botmux history`
+  // 按需拉取话题历史（对齐 quote hint 的「提示+按需」模式，避免无条件全量预取+
+  // 下载所有历史附件+长话题只取最旧 50 条且把 50 当精确总数的问题）。gate 已证明
+  // 这是话题回复，无需再发网络探测。coalesced forward 已自带上下文不注入。仅首轮
+  // — 后续 handleThreadReply 回合 CLI 已在首轮拿到该 hint，不重复注入。
   const topicThreadContext = (parsed.rootId && parsed.rootId !== parsed.messageId && !ctx.forwardSeedData)
-    ? await buildTopicThreadContext(larkAppId, chatId, parsed.rootId, parsed.messageId, localeForBot(larkAppId))
+    ? buildTopicThreadContext(localeForBot(larkAppId))
     : '';
   // 话题 hint 同样前置到 codex-app 结构化 sidecar lane（与 quote hint 一致双 lane
   // 下发），否则 codex-app（clean input）bot 走 sidecar 时会静默丢掉该 hint。

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -82,6 +82,7 @@ import { createImgNumberer, parseEventMessage, resolveNonsupportMessage, stripLe
 import { expandMergeForward } from './im/lark/merge-forward.js';
 import { bindResourcesToMessage, composeForwardFollowupContent, mergeMessageMentions } from './im/lark/forward-followup-content.js';
 import { buildQuoteHint } from './im/lark/quote-hint.js';
+import { buildTopicThreadContext } from './im/lark/topic-root-context.js';
 import { logger } from './utils/logger.js';
 import { applyAllowedUsersResolve } from './utils/allowed-users-apply.js';
 import { withFileLock, withFileLockSync } from './utils/file-lock.js';
@@ -15363,7 +15364,16 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
     : buildQuoteHint(parsed, scope, anchor, localeForBot(larkAppId));
   const codexAppMessageContext = codexAppQuoteContext + (workflowGrillPrompt ?? '');
   const codexAppApplicationContext = vcMeetingApplicationContext(ctx);
-  const promptContent = codexAppQuoteContext + codexAppApplicationContext + content;
+  // 普通群「对已有消息发起话题再 @」：入站是话题内回复（root_id 指向另一条更早
+  // 的话题根消息），bot 从未留存该话题历史。首轮拉取整条话题上下文（根 + 本条
+  // @ 之前的全部回复，文本+附件下载到本 bot 附件桶）并前置到 prompt，让 CLI 先
+  // 看到话题完整上下文。best-effort，失败降级（只取根 / 空串）不阻断；coalesced
+  // forward 已自带上下文不再重复拉取。仅首轮 — 后续 handleThreadReply 回合 CLI
+  // 已在首轮拿到话题上下文，不重复拉取。
+  const topicThreadContext = (parsed.rootId && parsed.rootId !== parsed.messageId && !ctx.forwardSeedData)
+    ? await buildTopicThreadContext(larkAppId, chatId, parsed.rootId, parsed.messageId, localeForBot(larkAppId))
+    : '';
+  const promptContent = topicThreadContext + codexAppQuoteContext + codexAppApplicationContext + content;
 
   // Resolve sender identity for <sender> tag injection. The first call to
   // resolveSender for an unseen open_id may await contact.v3.user.get with a

--- a/src/dashboard/web/app.tsx
+++ b/src/dashboard/web/app.tsx
@@ -1,4 +1,5 @@
 // Dashboard SPA entry: React chrome + lazy route host + SSE bootstrap.
+import type React from 'react';
 import { createRoot } from 'react-dom/client';
 import { useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
@@ -285,7 +286,7 @@ function getRouteRoot(): HTMLElement {
   return el;
 }
 
-function ThemeMenuSlot(): JSX.Element {
+function ThemeMenuSlot(): React.JSX.Element {
   useEffect(() => {
     initThemeMenu();
   }, []);
@@ -352,7 +353,7 @@ function dashboardStatusSummary(): TopbarStatusSummary {
   };
 }
 
-function TopbarStatusRow(props: { label: string; value: number; hot?: boolean }): JSX.Element {
+function TopbarStatusRow(props: { label: string; value: number; hot?: boolean }): React.JSX.Element {
   return (
     <div className={`topbar-status-row${props.hot ? ' topbar-status-row-hot' : ''}`}>
       <span>{props.label}</span>
@@ -361,7 +362,7 @@ function TopbarStatusRow(props: { label: string; value: number; hot?: boolean })
   );
 }
 
-function TopbarStatusDonut(props: { summary: TopbarStatusSummary }): JSX.Element {
+function TopbarStatusDonut(props: { summary: TopbarStatusSummary }): React.JSX.Element {
   const { attention, idle, working } = props.summary;
   const total = working + attention + idle;
   const background = total === 0
@@ -386,7 +387,7 @@ function closeThemeMenuFromStatus(): void {
   window.dispatchEvent(new Event(CLOSE_THEME_MENU_EVENT));
 }
 
-function TopbarStatusMenu(props: { summary: TopbarStatusSummary; autoOpen?: boolean }): JSX.Element {
+function TopbarStatusMenu(props: { summary: TopbarStatusSummary; autoOpen?: boolean }): React.JSX.Element {
   const { autoOpen = false, summary } = props;
   const [open, setOpen] = useState(false);
   const [autoDismissed, setAutoDismissed] = useState(false);
@@ -479,7 +480,7 @@ function TopbarStatusMenu(props: { summary: TopbarStatusSummary; autoOpen?: bool
   );
 }
 
-function AuthExpiredOverlay(props: { open: boolean; onClose(): void }): JSX.Element | null {
+function AuthExpiredOverlay(props: { open: boolean; onClose(): void }): React.JSX.Element | null {
   if (!props.open) return null;
   return (
     <div
@@ -530,7 +531,7 @@ async function dashboardInstance(): Promise<string> {
 function TopbarVersionControl(props: {
   status: BotmuxUpdateStatus | null;
   onRefresh(): Promise<boolean>;
-}): JSX.Element | null {
+}): React.JSX.Element | null {
   const { status } = props;
   const [open, setOpen] = useState(false);
   const [phase, setPhase] = useState<TopbarUpdatePhase>('idle');
@@ -969,7 +970,7 @@ function TopbarVersionControl(props: {
   );
 }
 
-function DashboardShell(): JSX.Element {
+function DashboardShell(): React.JSX.Element {
   const statusSummary = dashboardStatusSummary();
   const [botOnboardingOpen, setBotOnboardingOpen] = useState(false);
   const [authExpiredOpen, setAuthExpiredOpen] = useState(false);

--- a/src/dashboard/web/bot-onboarding.tsx
+++ b/src/dashboard/web/bot-onboarding.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
 import { DropdownMenu } from './dashboard-components.js';
 import { t } from './ui.js';
@@ -237,7 +238,7 @@ export async function openBotOnboarding(): Promise<void> {
   window.dispatchEvent(new Event(OPEN_BOT_ONBOARDING_EVENT));
 }
 
-function PermissionSummary(props: { job: OnboardingJob }): JSX.Element | null {
+function PermissionSummary(props: { job: OnboardingJob }): React.JSX.Element | null {
   const { job } = props;
   if ((job.status !== 'completed' && job.status !== 'needs_owner') || !job.permission) return null;
   const permission = job.permission;
@@ -274,7 +275,7 @@ function PermissionSummary(props: { job: OnboardingJob }): JSX.Element | null {
   );
 }
 
-function OnboardingMeta(props: { job: OnboardingJob }): JSX.Element | null {
+function OnboardingMeta(props: { job: OnboardingJob }): React.JSX.Element | null {
   const { job } = props;
   if (!job.appId) return null;
   return (
@@ -287,7 +288,7 @@ function OnboardingMeta(props: { job: OnboardingJob }): JSX.Element | null {
   );
 }
 
-function QrCard(props: { dataUrl: string; alt: string; link?: string }): JSX.Element {
+function QrCard(props: { dataUrl: string; alt: string; link?: string }): React.JSX.Element {
   return (
     <div className="qr-card">
       <img className="qr-image" src={props.dataUrl} alt={props.alt} />
@@ -316,7 +317,7 @@ function OnboardingJobView(props: {
   onSubmitOwner(job: OnboardingJob, owner: string, ownerId: string): void;
   onRetry(mode: 'web' | 'compat'): void;
   onClose(): void;
-}): JSX.Element {
+}): React.JSX.Element {
   const { job, ownerError } = props.view;
   return (
     <>
@@ -421,7 +422,7 @@ function OnboardingForm(props: {
   onSessionModeChange(mode: 'reuse' | 'qr'): void;
   onSubmit(event: FormEvent<HTMLFormElement>): void;
   onClose(): void;
-}): JSX.Element {
+}): React.JSX.Element {
   const selectedCli = props.cliState.options.find(option => option.id === props.form.cliId);
   const acceptsModel = selectedCli?.gateway === 'ttadk' && selectedCli.acceptsModel !== false;
   const modelDisabled = selectedCli?.gateway === 'ttadk' && selectedCli.acceptsModel === false;
@@ -586,7 +587,7 @@ function OnboardingForm(props: {
   );
 }
 
-export function BotOnboardingDialog(props: { open: boolean; onClose(): void }): JSX.Element {
+export function BotOnboardingDialog(props: { open: boolean; onClose(): void }): React.JSX.Element {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
   const pollTimerRef = useRef<number | null>(null);
   const loadSeqRef = useRef(0);

--- a/src/dashboard/web/connectors-page.tsx
+++ b/src/dashboard/web/connectors-page.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { CreateActionButton, DropdownMenu, FieldTitle, LoadingState, dropdownLabel } from './dashboard-components.js';
 import { jget, jsend } from './dashboard-api.js';
@@ -130,7 +131,7 @@ function ConnectorDropdown<T extends string>(props: {
   value: T;
   options: Array<{ value: T; label: ReactNode; disabled?: boolean }>;
   onChange(value: T): void;
-}): JSX.Element {
+}): React.JSX.Element {
   return (
     <DropdownMenu
       id={props.id}
@@ -156,7 +157,7 @@ function SearchableGroupPicker(props: {
   emptyLabel: string;
   selectedCountLabel(count: number): string;
   onChange(value: string | string[]): void;
-}): JSX.Element {
+}): React.JSX.Element {
   const rootRef = useRef<HTMLDivElement | null>(null);
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
@@ -290,7 +291,7 @@ function formFromConnector(connector: Connector, groups: GroupOpt[]): CreateForm
   };
 }
 
-function ConnectorsSubNav(props: { active: ConnectorsTab }): JSX.Element {
+function ConnectorsSubNav(props: { active: ConnectorsTab }): React.JSX.Element {
   const tr = useT();
   const isWebhooks = props.active === 'webhooks';
   const isLogs = props.active === 'logs';

--- a/src/dashboard/web/dashboard-components.tsx
+++ b/src/dashboard/web/dashboard-components.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import {
   useCallback,
   useEffect,
@@ -21,7 +22,7 @@ export function dropdownLabel<T extends string>(options: DropdownOption<T>[], va
   return options.find(option => option.value === value)?.label ?? value;
 }
 
-export function Html(props: { html: string; as?: 'span' | 'div' }): JSX.Element {
+export function Html(props: { html: string; as?: 'span' | 'div' }): React.JSX.Element {
   const Tag = props.as ?? 'span';
   return <Tag style={{ display: 'contents' }} dangerouslySetInnerHTML={{ __html: props.html }} />;
 }
@@ -30,7 +31,7 @@ export function LoadingState(props: {
   label: ReactNode;
   className?: string;
   compact?: boolean;
-}): JSX.Element {
+}): React.JSX.Element {
   const className = [
     'page-loading',
     props.compact ? 'page-loading-compact' : '',
@@ -50,7 +51,7 @@ export function SectionHeader(props: {
   count?: ReactNode;
   hint?: ReactNode;
   children?: ReactNode;
-}): JSX.Element {
+}): React.JSX.Element {
   return (
     <div className="sect-head overview-panel-head">
       <h2>{props.title}</h2>
@@ -64,11 +65,11 @@ export function SectionHeader(props: {
 export function HeaderAction(props: {
   href: string;
   children: ReactNode;
-}): JSX.Element {
+}): React.JSX.Element {
   return <a className="sect-head-action" href={props.href}>{props.children}</a>;
 }
 
-export function HeaderControls(props: { children: ReactNode }): JSX.Element {
+export function HeaderControls(props: { children: ReactNode }): React.JSX.Element {
   return <div className="sect-head-controls">{props.children}</div>;
 }
 
@@ -76,7 +77,7 @@ type ActionButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   children: ReactNode;
 };
 
-function ActionGlyph(props: { kind: 'plus' | 'refresh' }): JSX.Element {
+function ActionGlyph(props: { kind: 'plus' | 'refresh' }): React.JSX.Element {
   if (props.kind === 'plus') {
     return (
       <svg className="ui-action-icon" viewBox="0 0 16 16" aria-hidden="true">
@@ -92,7 +93,7 @@ function ActionGlyph(props: { kind: 'plus' | 'refresh' }): JSX.Element {
   );
 }
 
-export function CreateActionButton(props: ActionButtonProps): JSX.Element {
+export function CreateActionButton(props: ActionButtonProps): React.JSX.Element {
   const { children, className, type = 'button', ...buttonProps } = props;
   return (
     <button {...buttonProps} type={type} className={['ui-create-action', className].filter(Boolean).join(' ')}>
@@ -105,7 +106,7 @@ export function CreateActionButton(props: ActionButtonProps): JSX.Element {
 export function RefreshIconButton(props: Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> & {
   label: string;
   busy?: boolean;
-}): JSX.Element {
+}): React.JSX.Element {
   const { label, busy = false, className, type = 'button', ...buttonProps } = props;
   return (
     <button
@@ -138,7 +139,7 @@ export function InfoTip(props: {
   trigger?: ReactNode;
   preventClick?: boolean;
   focusable?: boolean;
-}): JSX.Element {
+}): React.JSX.Element {
   const tipRef = useRef<HTMLSpanElement | null>(null);
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [open, setOpen] = useState(false);
@@ -229,7 +230,7 @@ export function OverflowText(props: {
   popoverClassName?: string;
   showPopover?: boolean;
   durationMs?: number;
-}): JSX.Element {
+}): React.JSX.Element {
   const anchorRef = useRef<HTMLSpanElement | null>(null);
   const [open, setOpen] = useState(false);
   const [overflowing, setOverflowing] = useState(false);
@@ -341,7 +342,7 @@ export function FieldTitle(props: {
   help?: ReactNode;
   helpLabel?: string;
   className?: string;
-}): JSX.Element {
+}): React.JSX.Element {
   return (
     <span className={['ui-field-title', props.className].filter(Boolean).join(' ')}>
       <span className="ui-field-title-text">{props.children}</span>
@@ -354,24 +355,24 @@ export function OverviewList(props: {
   id?: string;
   className?: string;
   children: ReactNode;
-}): JSX.Element {
+}): React.JSX.Element {
   return <ul className={['overview-list', props.className].filter(Boolean).join(' ')} id={props.id}>{props.children}</ul>;
 }
 
 export function OverviewListItem(props: HTMLAttributes<HTMLLIElement> & {
   kind?: 'session' | 'schedule' | 'group';
   children: ReactNode;
-}): JSX.Element {
+}): React.JSX.Element {
   const { kind, className, children, ...rest } = props;
   const kindClass = kind ? `overview-list-item-${kind}` : '';
   return <li {...rest} className={['overview-list-item', kindClass, className].filter(Boolean).join(' ')}>{children}</li>;
 }
 
-export function OverviewListMain(props: { children: ReactNode }): JSX.Element {
+export function OverviewListMain(props: { children: ReactNode }): React.JSX.Element {
   return <div className="overview-list-main">{props.children}</div>;
 }
 
-export function OverviewListTail(props: { children: ReactNode }): JSX.Element {
+export function OverviewListTail(props: { children: ReactNode }): React.JSX.Element {
   return <div className="overview-list-tail">{props.children}</div>;
 }
 
@@ -393,7 +394,7 @@ type DropdownMenuProps<T extends string> = {
   searchEmptyLabel?: ReactNode;
 };
 
-export function DropdownMenu<T extends string>(props: DropdownMenuProps<T>): JSX.Element {
+export function DropdownMenu<T extends string>(props: DropdownMenuProps<T>): React.JSX.Element {
   const detailsRef = useRef<HTMLDetailsElement | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
   const [query, setQuery] = useState('');
@@ -508,6 +509,6 @@ export function DropdownMenu<T extends string>(props: DropdownMenuProps<T>): JSX
   );
 }
 
-export function SortMenu<T extends string>(props: DropdownMenuProps<T>): JSX.Element {
+export function SortMenu<T extends string>(props: DropdownMenuProps<T>): React.JSX.Element {
   return <DropdownMenu {...props} />;
 }

--- a/src/dashboard/web/overview-page.tsx
+++ b/src/dashboard/web/overview-page.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { mountReactPage, type PageDisposer } from './react-mount.js';
 import { useStoreSelector, useT } from './react-hooks.js';
@@ -117,7 +118,7 @@ function MateCard({ card }: { card: BotCard }) {
   const needsYou = card.attention.length > 0;
   const busy = card.busy.length > 0;
   const dotClass = needsYou ? 'warn' : busy ? 'busy' : offline ? 'off' : 'ok';
-  let task: JSX.Element | string;
+  let task: React.JSX.Element | string;
   if (needsYou) {
     const a = [...card.attention].sort((x, y) => attentionWaitSince(x) - attentionWaitSince(y))[0];
     task = <><b>{(stripMentionPrefix(a.title) || a.sessionId).slice(0, 60)}</b>{' · '}{attentionReason(a) ?? ''}</>;

--- a/src/dashboard/web/plugin-page.tsx
+++ b/src/dashboard/web/plugin-page.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import {
   useCallback,
   useEffect,
@@ -169,16 +170,16 @@ async function postServiceAction(pluginId: string, action: PluginServiceAction):
   return normalizePluginManagementPayload(await res.json());
 }
 
-function Tags(props: { values?: readonly string[] }): JSX.Element {
+function Tags(props: { values?: readonly string[] }): React.JSX.Element {
   if (!props.values?.length) return <span className="plugin-muted">-</span>;
   return <>{props.values.map(value => <span className="plugin-chip" key={value}>{value}</span>)}</>;
 }
 
-function InlineCode(props: { children: ReactNode }): JSX.Element {
+function InlineCode(props: { children: ReactNode }): React.JSX.Element {
   return <code className="plugin-inline-code">{props.children}</code>;
 }
 
-function InfoRows(props: { rows: Array<{ label: string; content: ReactNode }> }): JSX.Element {
+function InfoRows(props: { rows: Array<{ label: string; content: ReactNode }> }): React.JSX.Element {
   if (props.rows.length === 0) return <div className="plugin-empty-state">暂无内容</div>;
   return (
     <div className="plugin-info-table">
@@ -192,7 +193,7 @@ function InfoRows(props: { rows: Array<{ label: string; content: ReactNode }> })
   );
 }
 
-function PanelHeading(props: { title: string; description: string }): JSX.Element {
+function PanelHeading(props: { title: string; description: string }): React.JSX.Element {
   return (
     <div className="plugin-tab-panel-head">
       <h3>{props.title}</h3>
@@ -201,7 +202,7 @@ function PanelHeading(props: { title: string; description: string }): JSX.Elemen
   );
 }
 
-function EmptyPanel(props: { children: ReactNode }): JSX.Element {
+function EmptyPanel(props: { children: ReactNode }): React.JSX.Element {
   return <div className="plugin-empty-state">{props.children}</div>;
 }
 
@@ -238,7 +239,7 @@ function serviceStatusClass(report?: PluginServiceReport): string {
   return 'plugin-status-muted';
 }
 
-function ServiceAccessLink(props: { url?: string; health?: boolean }): JSX.Element {
+function ServiceAccessLink(props: { url?: string; health?: boolean }): React.JSX.Element {
   if (!props.url) return <span className="plugin-muted">{props.health ? '无健康检查' : '暂无访问地址'}</span>;
   return (
     <a
@@ -252,7 +253,7 @@ function ServiceAccessLink(props: { url?: string; health?: boolean }): JSX.Eleme
   );
 }
 
-function ServiceDetails(props: { plugin: ManagedPlugin }): JSX.Element {
+function ServiceDetails(props: { plugin: ManagedPlugin }): React.JSX.Element {
   const { plugin } = props;
   if (!plugin.service) return <EmptyPanel>这个插件没有需要单独启动的后台进程。</EmptyPanel>;
   const report = plugin.serviceReport;
@@ -280,7 +281,7 @@ function ServiceActions(props: {
   plugin: ManagedPlugin;
   busy: boolean;
   onAction(action: PluginServiceAction): void;
-}): JSX.Element | null {
+}): React.JSX.Element | null {
   const { plugin } = props;
   if (!plugin.service) return null;
   const report = plugin.serviceReport;
@@ -315,7 +316,7 @@ function ServiceActions(props: {
   );
 }
 
-function DashboardActions(props: { plugin: ManagedPlugin }): JSX.Element | null {
+function DashboardActions(props: { plugin: ManagedPlugin }): React.JSX.Element | null {
   const entries = props.plugin.dashboard ?? [];
   if (entries.length === 0) return null;
   return (
@@ -335,7 +336,7 @@ function PluginActionArea(props: {
   plugin: ManagedPlugin;
   busy: boolean;
   onServiceAction(action: PluginServiceAction): void;
-}): JSX.Element | null {
+}): React.JSX.Element | null {
   const hasService = Boolean(props.plugin.service);
   const hasDashboard = (props.plugin.dashboard?.length ?? 0) > 0;
   if (!hasService && !hasDashboard) return null;
@@ -353,7 +354,7 @@ function PluginActionArea(props: {
   );
 }
 
-function TabPanel(props: { id: string; active: boolean; children: ReactNode }): JSX.Element {
+function TabPanel(props: { id: string; active: boolean; children: ReactNode }): React.JSX.Element {
   return (
     <section
       className={`plugin-tab-panel${props.active ? ' is-active' : ''}`}
@@ -365,7 +366,7 @@ function TabPanel(props: { id: string; active: boolean; children: ReactNode }): 
   );
 }
 
-function SkillsPanel(props: { plugin: ManagedPlugin; active: boolean }): JSX.Element {
+function SkillsPanel(props: { plugin: ManagedPlugin; active: boolean }): React.JSX.Element {
   const skills = props.plugin.contributions?.skills ?? [];
   const rows = skills.map(skill => ({
     label: skill.name || skill.path || 'skill',
@@ -379,7 +380,7 @@ function SkillsPanel(props: { plugin: ManagedPlugin; active: boolean }): JSX.Ele
   );
 }
 
-function McpPanel(props: { plugin: ManagedPlugin; active: boolean }): JSX.Element {
+function McpPanel(props: { plugin: ManagedPlugin; active: boolean }): React.JSX.Element {
   const plugin = props.plugin;
   const server = plugin.contributions?.mcp;
   const serverRows: Array<{ label: string; content: ReactNode }> = server ? [{
@@ -429,7 +430,7 @@ function McpPanel(props: { plugin: ManagedPlugin; active: boolean }): JSX.Elemen
   );
 }
 
-function CliPanel(props: { plugin: ManagedPlugin; active: boolean }): JSX.Element {
+function CliPanel(props: { plugin: ManagedPlugin; active: boolean }): React.JSX.Element {
   const cli = props.plugin.contributions?.cli;
   const rows: Array<{ label: string; content: ReactNode }> = [
     ...(cli?.entry ? [{ label: '入口文件', content: <InlineCode>{cli.entry}</InlineCode> }] : []),
@@ -446,7 +447,7 @@ function CliPanel(props: { plugin: ManagedPlugin; active: boolean }): JSX.Elemen
   );
 }
 
-function DashboardPanel(props: { plugin: ManagedPlugin; active: boolean }): JSX.Element {
+function DashboardPanel(props: { plugin: ManagedPlugin; active: boolean }): React.JSX.Element {
   const rows = (props.plugin.dashboard ?? []).map(entry => ({
     label: entry.id,
     content: (
@@ -464,7 +465,7 @@ function DashboardPanel(props: { plugin: ManagedPlugin; active: boolean }): JSX.
   );
 }
 
-function ServicePanel(props: { plugin: ManagedPlugin; active: boolean }): JSX.Element {
+function ServicePanel(props: { plugin: ManagedPlugin; active: boolean }): React.JSX.Element {
   return (
     <TabPanel id="service" active={props.active}>
       <PanelHeading title="Service" description="插件后台服务的声明、当前状态和访问地址。启动、停止、重启在上方操作区处理。" />
@@ -473,7 +474,7 @@ function ServicePanel(props: { plugin: ManagedPlugin; active: boolean }): JSX.El
   );
 }
 
-function PluginTabs(props: { plugin: ManagedPlugin }): JSX.Element {
+function PluginTabs(props: { plugin: ManagedPlugin }): React.JSX.Element {
   const commands = props.plugin.contributions?.cli?.commands ?? [];
   const tabs = useMemo(() => [
     { id: 'skills', label: 'Skills', count: props.plugin.skillsCount ?? 0, hint: '会话加载' },
@@ -537,7 +538,7 @@ function PluginEnableRow(props: {
   checked: boolean;
   busy: boolean;
   onToggle(scope: string, enabled: boolean): void;
-}): JSX.Element {
+}): React.JSX.Element {
   return (
     <label className="toggle-row plugin-enable-row">
       <span className="plugin-enable-copy">
@@ -563,7 +564,7 @@ function PluginGlobalSetting(props: {
   pendingToggles: PendingToggles;
   busy: boolean;
   onToggle(scope: string, enabled: boolean): void;
-}): JSX.Element {
+}): React.JSX.Element {
   const enabled = pluginEnabledInScope(props.plugin, 'global', props.pendingToggles);
   return (
     <label className="toggle-row plugin-global-setting">
@@ -592,7 +593,7 @@ function PluginBotSettings(props: {
   pendingToggles: PendingToggles;
   busy: boolean;
   onToggle(scope: string, enabled: boolean): void;
-}): JSX.Element {
+}): React.JSX.Element {
   const { plugin, bots, pendingToggles } = props;
   const enabledBotCount = bots.filter(bot => pluginEnabledInScope(plugin, bot.id, pendingToggles)).length;
   return (
@@ -632,7 +633,7 @@ function PluginCapabilitySummary(props: {
   globalEnabled: boolean;
   enabledBotCount: number;
   botCount: number;
-}): JSX.Element {
+}): React.JSX.Element {
   const commands = props.plugin.contributions?.cli?.commands ?? [];
   const capabilities = [
     { label: 'Skills', count: props.plugin.skillsCount ?? 0 },
@@ -662,7 +663,7 @@ function PluginCapabilitySummary(props: {
   );
 }
 
-function FeedbackDialog(props: { feedback: PluginFeedback | null; onClose(): void }): JSX.Element {
+function FeedbackDialog(props: { feedback: PluginFeedback | null; onClose(): void }): React.JSX.Element {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -707,7 +708,7 @@ function PluginCard(props: {
   onToggle(scope: string, enabled: boolean): void;
   onPin(pinned: boolean): void;
   onServiceAction(action: PluginServiceAction): void;
-}): JSX.Element {
+}): React.JSX.Element {
   const { plugin } = props;
   const [expanded, setExpanded] = useState(false);
   const title = plugin.displayName || plugin.id;
@@ -811,7 +812,7 @@ function updateSet<T>(source: ReadonlySet<T>, value: T, present: boolean): Set<T
   return next;
 }
 
-function PluginManagementPage(): JSX.Element {
+function PluginManagementPage(): React.JSX.Element {
   const [payload, setPayload] = useState<PluginManagementPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
@@ -948,7 +949,7 @@ function pluginDashboardApi(pluginId: string) {
   };
 }
 
-function PluginDashboardRoute(props: { hash: string }): JSX.Element {
+function PluginDashboardRoute(props: { hash: string }): React.JSX.Element {
   const [entry, setEntry] = useState<DashboardPluginEntry | null>(null);
   const [Component, setComponent] = useState<PluginDashboardComponent | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -1004,7 +1005,7 @@ function PluginDashboardRoute(props: { hash: string }): JSX.Element {
   );
 }
 
-function PluginRoutePage(): JSX.Element {
+function PluginRoutePage(): React.JSX.Element {
   const hash = location.hash || '#/plugins';
   if (hash === '#/plugins' || hash.startsWith('#/plugins?')) return <PluginManagementPage />;
   return <PluginDashboardRoute hash={hash} />;

--- a/src/dashboard/web/sessions-kanban.tsx
+++ b/src/dashboard/web/sessions-kanban.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import {
   useCallback,
   useEffect,
@@ -322,7 +323,7 @@ function CardActButton(props: {
   icon: string;
   label: string;
   onClick: (button: HTMLButtonElement) => void;
-}): JSX.Element {
+}): React.JSX.Element {
   return (
     <button
       type="button"
@@ -343,7 +344,7 @@ function RenameInput(props: {
   row: any;
   onCancel: () => void;
   onCommit: (row: any, title: string) => void;
-}): JSX.Element {
+}): React.JSX.Element {
   const initial = stripMentionPrefix(props.row.title) || '';
   const [value, setValue] = useState(initial);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -401,7 +402,7 @@ function KanbanCard(props: {
   onCardKeyDown: (row: any, event: KeyboardEvent<HTMLElement>) => void;
   onDragStartCard: (row: any, event: DragEvent<HTMLElement>) => void;
   onEditDone: () => void;
-}): JSX.Element {
+}): React.JSX.Element {
   const { callbacks, row } = props;
   const title = rowTitle(row);
   const botName = botDisplayName(row);
@@ -559,7 +560,7 @@ function ClusterView(props: {
   expanded: boolean;
   onToggleExpanded: () => void;
   onDragStartCluster: (chatId: string, col: SessionKanbanColumn, event: DragEvent<HTMLElement>) => void;
-}): JSX.Element {
+}): React.JSX.Element {
   const item = props.item;
   if (item.type === 'card') return <KanbanCard {...props.cardProps} row={item.row} />;
   const title = chatDisplayTitle(item.rows[0]) ?? item.chatId;
@@ -595,7 +596,7 @@ function ClusterView(props: {
   );
 }
 
-export function SessionsKanbanView(props: SessionsKanbanProps): JSX.Element {
+export function SessionsKanbanView(props: SessionsKanbanProps): React.JSX.Element {
   const [display, setDisplay] = useState<SessionsKanbanProps>(props);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [drag, setDrag] = useState<{ kind: 'card'; id: string } | { kind: 'cluster'; chatId: string; col: SessionKanbanColumn } | null>(null);

--- a/src/dashboard/web/sessions-page.tsx
+++ b/src/dashboard/web/sessions-page.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import {
   Fragment,
   useCallback,
@@ -203,12 +204,12 @@ function windowStorage(): Storage | undefined {
   return typeof window === 'undefined' ? undefined : window.localStorage;
 }
 
-function StatusBadge(props: { status: unknown }): JSX.Element {
+function StatusBadge(props: { status: unknown }): React.JSX.Element {
   const raw = String(props.status ?? 'unknown');
   return <span className={`status status-${cssToken(raw)}`}>{sessionStatusText(raw)}</span>;
 }
 
-function LockChip(props: { row: any }): JSX.Element | null {
+function LockChip(props: { row: any }): React.JSX.Element | null {
   if (!props.row.locked) return null;
   return <span className="session-lock-badge" title={t('sessions.locked')}>{t('sessions.locked')}</span>;
 }
@@ -222,7 +223,7 @@ function IconActionButton(props: {
   kind?: string;
   disabled?: boolean;
   onClick: (button: HTMLButtonElement) => void;
-}): JSX.Element {
+}): React.JSX.Element {
   const className = props.className ?? `card-act${props.kind ? ` ${props.kind}` : ''}`;
   return (
     <button
@@ -242,7 +243,7 @@ function IconActionButton(props: {
   );
 }
 
-function TerminalControls(props: { row: any; url: string | null }): JSX.Element | null {
+function TerminalControls(props: { row: any; url: string | null }): React.JSX.Element | null {
   if (!props.url || !dashboardShellAllowsWebTerminal()) return null;
   const canOpenWritable = shouldOpenWritableTerminal();
   return (
@@ -276,7 +277,7 @@ function TerminalControls(props: { row: any; url: string | null }): JSX.Element 
   );
 }
 
-function ChatScopeLink(props: { row: any; className?: string }): JSX.Element | null {
+function ChatScopeLink(props: { row: any; className?: string }): React.JSX.Element | null {
   const row = props.row;
   if (row.scope !== 'chat' || !row.feishuChatLink) return null;
   return (
@@ -299,7 +300,7 @@ function SortHeader(props: {
   sortKey: string;
   sortDir: 'asc' | 'desc';
   onSort: (key: string) => void;
-}): JSX.Element {
+}): React.JSX.Element {
   const active = props.sortKey === props.sort;
   return (
     <th
@@ -378,7 +379,7 @@ function useDialogVisibility(ref: React.RefObject<HTMLDialogElement | null>, ope
   }, [open, ref]);
 }
 
-function CopyButton(props: { value: string }): JSX.Element {
+function CopyButton(props: { value: string }): React.JSX.Element {
   const [copied, setCopied] = useState(false);
   return (
     <button
@@ -395,7 +396,7 @@ function CopyButton(props: { value: string }): JSX.Element {
   );
 }
 
-function LocateButton(props: { row: any; locateSession: (row: any) => Promise<boolean> }): JSX.Element {
+function LocateButton(props: { row: any; locateSession: (row: any) => Promise<boolean> }): React.JSX.Element {
   const [cooldown, setCooldown] = useState(0);
   const [busy, setBusy] = useState(false);
   useEffect(() => {
@@ -422,7 +423,7 @@ function LocateButton(props: { row: any; locateSession: (row: any) => Promise<bo
 
 // Icon variant of LocateButton for board/list cards: same React-owned busy+30s
 // cooldown, but renders the pin icon via IconActionButton (no imperative DOM writes).
-function LocateIconButton(props: { row: any; onLocate: (row: any) => Promise<boolean> }): JSX.Element {
+function LocateIconButton(props: { row: any; onLocate: (row: any) => Promise<boolean> }): React.JSX.Element {
   const [cooldown, setCooldown] = useState(0);
   const [busy, setBusy] = useState(false);
   useEffect(() => {
@@ -446,7 +447,7 @@ function LocateIconButton(props: { row: any; onLocate: (row: any) => Promise<boo
   );
 }
 
-export function CliFilterGroup(props: { selected: Set<string>; onToggle: (cli: string, checked: boolean) => void }): JSX.Element {
+export function CliFilterGroup(props: { selected: Set<string>; onToggle: (cli: string, checked: boolean) => void }): React.JSX.Element {
   const checked = CLI_FILTER_OPTIONS.filter(cli => props.selected.has(cli)).length;
   const detailsRef = useRef<HTMLDetailsElement>(null);
   const [query, setQuery] = useState('');
@@ -526,7 +527,7 @@ function SessionsFilters(props: {
   filters: FiltersState;
   idleCleanup: IdleCleanupBarProps;
   setFilters: (updater: (prev: FiltersState) => FiltersState) => void;
-}): JSX.Element {
+}): React.JSX.Element {
   const statusOptions = [
     { value: '', label: t('sessions.anyStatus') },
     ...SESSION_STATUS_OPTIONS.map(status => ({ value: status, label: sessionStatusText(status) })),
@@ -659,7 +660,7 @@ function BulkBar(props: {
   onClose: () => void;
   onAddToMonitorRoom: () => void;
   onLock: (locked: boolean) => void;
-}): JSX.Element {
+}): React.JSX.Element {
   const busy = !!props.closeProgress || !!props.lockProgress;
   const lockText = props.lockProgress?.locked ? `${props.lockProgress.done}/${props.lockProgress.total}` : t('sessions.lockSelected');
   const unlockText = props.lockProgress && !props.lockProgress.locked ? `${props.lockProgress.done}/${props.lockProgress.total}` : t('sessions.unlockSelected');
@@ -682,7 +683,7 @@ function BulkBar(props: {
   );
 }
 
-function IdleCleanupBar(props: IdleCleanupBarProps): JSX.Element {
+function IdleCleanupBar(props: IdleCleanupBarProps): React.JSX.Element {
   const [open, setOpen] = useState(false);
   const [draftHours, setDraftHours] = useState<IdleCleanupHours>(props.hours);
   const [popStyle, setPopStyle] = useState<CSSProperties | undefined>();
@@ -852,7 +853,7 @@ function SessionsTable(props: {
   onSelect: (id: string, selected: boolean) => void;
   onSelectAll: (selected: boolean) => void;
   onSort: (key: string) => void;
-}): JSX.Element {
+}): React.JSX.Element {
   const selectAllRef = useRef<HTMLInputElement | null>(null);
   useLayoutEffect(() => {
     if (selectAllRef.current) selectAllRef.current.indeterminate = props.selectAllIndeterminate;
@@ -891,7 +892,7 @@ function SessionsTable(props: {
   };
 
   // 单元格渲染：按列 id 返回对应的 JSX，隐藏列不渲染。
-  function renderCell(row: any, colId: string): JSX.Element | null {
+  function renderCell(row: any, colId: string): React.JSX.Element | null {
     switch (colId) {
       case 'botName':
         return <td data-label={labels.botName}>{botDisplayName(row)}</td>;
@@ -1005,7 +1006,7 @@ function BoardCard(props: {
   onRestart: (row: any, button?: HTMLButtonElement) => void;
   onLock: (row: any, locked: boolean, button?: HTMLButtonElement) => void;
   onClose: (row: any, button?: HTMLButtonElement) => void;
-}): JSX.Element {
+}): React.JSX.Element {
   const row = props.row;
   const title = stripMentionPrefix(row.title) || row.sessionId;
   const botName = botDisplayName(row);
@@ -1095,7 +1096,7 @@ function BoardView(props: {
   onRestart: (row: any, button?: HTMLButtonElement) => void;
   onLock: (row: any, locked: boolean, button?: HTMLButtonElement) => void;
   onClose: (row: any, button?: HTMLButtonElement) => void;
-}): JSX.Element {
+}): React.JSX.Element {
   useEffect(() => {
     if (!props.hidden && !props.animated) props.onAnimated();
   }, [props.animated, props.hidden, props.onAnimated]);
@@ -1215,7 +1216,7 @@ function topicGroupTitle(group: SessionTopicGroup<SessionRow>): string {
   return group.kind === 'chat' ? t('sessions.topic.wholeChat') : t('sessions.topic.singleSession');
 }
 
-export function TopicGroupsView(props: TopicGroupsViewProps): JSX.Element {
+export function TopicGroupsView(props: TopicGroupsViewProps): React.JSX.Element {
   const groups = useMemo(() => groupSessionsByTopic(props.rows), [props.rows]);
   const relationGroups = useMemo(
     () => new Map(groupSessionsByTopic(props.relationRows ?? props.rows).map(group => [group.key, group])),
@@ -1292,7 +1293,7 @@ export function TopicGroupsView(props: TopicGroupsViewProps): JSX.Element {
   );
 }
 
-function HistoryBubble(props: { message: any; ownerOpenId?: string; groupStart: boolean }): JSX.Element {
+function HistoryBubble(props: { message: any; ownerOpenId?: string; groupStart: boolean }): React.JSX.Element {
   const m = props.message;
   const human = m.senderType === 'user';
   const botSender = m.senderType === 'app' || m.senderType === 'bot';
@@ -1315,7 +1316,7 @@ function HistoryBubble(props: { message: any; ownerOpenId?: string; groupStart: 
   );
 }
 
-function HistoryModal(props: { state: HistoryState | null; onClose: () => void }): JSX.Element {
+function HistoryModal(props: { state: HistoryState | null; onClose: () => void }): React.JSX.Element {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
   useDialogVisibility(dialogRef, !!props.state);
   const row = props.state ? store.sessions.get(props.state.sessionId) : null;
@@ -1377,7 +1378,7 @@ function HistoryModal(props: { state: HistoryState | null; onClose: () => void }
   );
 }
 
-function TerminalNameEditor(props: { row: any; onRename: (row: any, title: string) => void }): JSX.Element {
+function TerminalNameEditor(props: { row: any; onRename: (row: any, title: string) => void }): React.JSX.Element {
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState('');
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -1445,7 +1446,7 @@ function TerminalNameEditor(props: { row: any; onRename: (row: any, title: strin
   );
 }
 
-function TerminalModal(props: { state: TerminalState | null; onClose: () => void; onRename: (row: any, title: string) => void }): JSX.Element {
+function TerminalModal(props: { state: TerminalState | null; onClose: () => void; onRename: (row: any, title: string) => void }): React.JSX.Element {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
   useDialogVisibility(dialogRef, !!props.state);
   const row = props.state ? store.sessions.get(props.state.sessionId) : null;
@@ -1517,7 +1518,7 @@ function TerminalModal(props: { state: TerminalState | null; onClose: () => void
 }
 
 
-function InsightReport(props: { report: any }): JSX.Element {
+function InsightReport(props: { report: any }): React.JSX.Element {
   const rep = props.report;
   if (!rep || rep.status !== 'ok') {
     const msg = rep?.error?.message ? String(rep.error.message) : String(rep?.status ?? 'error');
@@ -1591,7 +1592,7 @@ function InsightReport(props: { report: any }): JSX.Element {
   );
 }
 
-function InsightPanel(props: { row: any }): JSX.Element | null {
+function InsightPanel(props: { row: any }): React.JSX.Element | null {
   const [state, setState] = useState<{ loading: boolean; report?: any; error?: string } | null>(null);
   useEffect(() => setState(null), [props.row.sessionId]);
   if (!ui.authed) return null;
@@ -1628,7 +1629,7 @@ function Drawer(props: {
   closeSession: (row: any, button?: HTMLButtonElement) => Promise<boolean>;
   setSessionLocked: (row: any, locked: boolean, button?: HTMLButtonElement) => Promise<boolean>;
   startSession: (row: any, button?: HTMLButtonElement) => Promise<boolean>;
-}): JSX.Element {
+}): React.JSX.Element {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
   useDialogVisibility(dialogRef, !!props.row);
   const row = props.row;
@@ -1700,7 +1701,7 @@ function CreateSessionDialog(props: {
   state: CreateSessionState | null;
   onClose: () => void;
   onSuccess: (body: any) => void;
-}): JSX.Element | null {
+}): React.JSX.Element | null {
   const state = props.state;
   useEffect(() => {
     const dialog = props.dialog;
@@ -2167,7 +2168,7 @@ function CreateSessionDialog(props: {
   );
 }
 
-function SessionsPage(): JSX.Element {
+function SessionsPage(): React.JSX.Element {
   useT();
   const storeRows = useStoreSelector(snapshot => [...snapshot.sessions.values()] as SessionRow[]);
   const [revision, setRevision] = useState(0);

--- a/src/dashboard/web/settings-page.tsx
+++ b/src/dashboard/web/settings-page.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { DropdownMenu, FieldTitle, LoadingState, dropdownLabel } from './dashboard-components.js';
 import { VcConsumerProfilesGate } from './vc-consumer-profiles-section.js';
@@ -893,7 +894,7 @@ function SettingsModule(props: {
   title: string;
   description: string;
   children: ReactNode;
-}): JSX.Element {
+}): React.JSX.Element {
   const cls = ['settings-module', props.className].filter(Boolean).join(' ');
   return (
     <section className={cls}>
@@ -928,7 +929,7 @@ function LarkCliStatus(props: { settings: DashboardSettings['vcMeetingAgent'] })
 function SettingsGroup(props: {
   className?: string;
   children: ReactNode;
-}): JSX.Element {
+}): React.JSX.Element {
   const cls = ['settings-group', props.className].filter(Boolean).join(' ');
   return (
     <section className={cls}>
@@ -944,7 +945,7 @@ function SettingsBlock(props: {
   title: ReactNode;
   titleExtra?: ReactNode;
   children: ReactNode;
-}): JSX.Element {
+}): React.JSX.Element {
   const cls = ['settings-block', props.className].filter(Boolean).join(' ');
   return (
     <section className={cls}>

--- a/src/dashboard/web/skills-page.tsx
+++ b/src/dashboard/web/skills-page.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { FieldTitle, Html, LoadingState, RefreshIconButton, SectionHeader } from './dashboard-components.js';
@@ -130,7 +131,7 @@ function SkillSegmented<T extends string>(props: {
   options: Array<{ value: T; label: ReactNode; help?: ReactNode }>;
   disabled?: boolean;
   onChange(value: T): void;
-}): JSX.Element {
+}): React.JSX.Element {
   const current = props.options.find(option => option.value === props.value);
   return (
     <div className="skills-segmented-control">
@@ -639,7 +640,7 @@ export function RemoveSkillsDialog(props: {
   error: string | null;
   onCancel(): void;
   onConfirm(force: boolean): void;
-}): JSX.Element {
+}): React.JSX.Element {
   const tr = useT();
   const dialogRef = useRef<HTMLDialogElement | null>(null);
   const names = props.names ?? [];
@@ -1471,7 +1472,7 @@ export function SkillMultiPicker(props: {
   skills: SkillRow[];
   busy: boolean;
   onSave(names: string[]): Promise<void>;
-}): JSX.Element {
+}): React.JSX.Element {
   const tr = useT();
   const rootRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);

--- a/src/dashboard/web/v3-components.tsx
+++ b/src/dashboard/web/v3-components.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { SectionHeader } from './dashboard-components.js';
 import { useT } from './react-hooks.js';
@@ -108,7 +109,7 @@ function useV3RunDetail(runId: string): DetailPollState {
   return { view, statusText };
 }
 
-function V3ListPage(): JSX.Element {
+function V3ListPage(): React.JSX.Element {
   const tr = useT();
   const runs = useV3RunsList();
   const headingActions = (
@@ -147,7 +148,7 @@ function V3ListPage(): JSX.Element {
   );
 }
 
-function V3DetailPage(props: { runId: string }): JSX.Element {
+function V3DetailPage(props: { runId: string }): React.JSX.Element {
   const tr = useT();
   const { view, statusText } = useV3RunDetail(props.runId);
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -291,7 +292,7 @@ export function V3CancelButton(props: {
   runStatus: RunView['runStatus'] | undefined;
   busy: boolean;
   onCancel: () => void;
-}): JSX.Element | null {
+}): React.JSX.Element | null {
   const tr = useT();
   if (!ui.authed) return null;
   const terminal = isTerminalRunStatus(props.runStatus);
@@ -313,7 +314,7 @@ export function V3CancelButton(props: {
   );
 }
 
-function V3Legend(): JSX.Element {
+function V3Legend(): React.JSX.Element {
   return (
     <div className="v3r-legend">
       <span className="lg st-pending">待机</span>
@@ -333,7 +334,7 @@ function DagGraph(props: {
   view: RunView | null;
   selectedId: string | null;
   onSelect: (nodeId: string) => void;
-}): JSX.Element {
+}): React.JSX.Element {
   const layout = useMemo(() => props.view ? buildGraphLayout(props.view) : null, [props.view]);
   const topologyKey = layout
     ? `${layout.width}:${layout.height}:${layout.nodes.map(box => box.node.id).join('\u0000')}`
@@ -404,7 +405,7 @@ function DagNode(props: {
   box: ReturnType<typeof buildGraphLayout>['nodes'][number];
   selected: boolean;
   onSelect: (nodeId: string) => void;
-}): JSX.Element {
+}): React.JSX.Element {
   const { box, selected } = props;
   const node = box.node;
   if (node.isLoop) {
@@ -427,7 +428,7 @@ function LoopGraphNode(props: {
   box: ReturnType<typeof buildGraphLayout>['nodes'][number];
   selected: boolean;
   onSelect: (nodeId: string) => void;
-}): JSX.Element {
+}): React.JSX.Element {
   const { box, selected } = props;
   const node = box.node;
   const ls = node.loopState;
@@ -461,7 +462,7 @@ function LoopBudgetDots(props: {
   y: number;
   budget: number;
   maxIterations: number | undefined;
-}): JSX.Element {
+}): React.JSX.Element {
   const ls = props.node.loopState!;
   const cy = props.y + V3_GRAPH.loopHeight - 13;
   const dots = Array.from({ length: props.budget }, (_, idx) => idx + 1);
@@ -494,7 +495,7 @@ function NodePanel(props: {
   instanceId: string | null;
   instancePinned: boolean;
   onInstanceSelect: (nodeId: string) => void;
-}): JSX.Element {
+}): React.JSX.Element {
   const node = props.node;
   const instances = useMemo(
     () => node?.isLoop ? loopInstances(props.view, node.id) : [],
@@ -544,7 +545,7 @@ function NodePanel(props: {
   );
 }
 
-function NodeErrorLine(props: { node: RunNodeView }): JSX.Element {
+function NodeErrorLine(props: { node: RunNodeView }): React.JSX.Element {
   const node = props.node;
   return (
     <p className="v3r-err">
@@ -556,7 +557,7 @@ function NodeErrorLine(props: { node: RunNodeView }): JSX.Element {
   );
 }
 
-function InstanceStrip(props: { node: RunNodeView; auto: boolean }): JSX.Element {
+function InstanceStrip(props: { node: RunNodeView; auto: boolean }): React.JSX.Element {
   const loop = props.node.loop!;
   return (
     <div className="v3r-inst-strip">
@@ -574,7 +575,7 @@ function LoopTimeline(props: {
   instances: RunNodeView[];
   activeInstanceId: string | null;
   onInstanceSelect: (nodeId: string) => void;
-}): JSX.Element {
+}): React.JSX.Element {
   const ls = props.node.loopState;
   if (!ls) return <p className="muted">loop 未开始</p>;
 
@@ -629,7 +630,7 @@ function RoundMiniDag(props: {
   instances: RunNodeView[];
   activeInstanceId: string | null;
   onInstanceSelect: (nodeId: string) => void;
-}): JSX.Element {
+}): React.JSX.Element {
   const instanceByBodyId = useMemo(
     () => new Map(props.instances.map((instance) => [instance.loop!.bodyNodeId, instance])),
     [props.instances],
@@ -680,7 +681,7 @@ function RoundMiniDag(props: {
   );
 }
 
-function TerminalSlot(props: { runId: string; node: RunNodeView | null }): JSX.Element {
+function TerminalSlot(props: { runId: string; node: RunNodeView | null }): React.JSX.Element {
   const ref = useRef<HTMLDivElement | null>(null);
   const renderedSignatureRef = useRef<string | null>(null);
   const signature = props.node ? `${props.runId}|${props.node.id}|${nodeTerminalSignature(props.node)}` : null;
@@ -701,7 +702,7 @@ function TerminalSlot(props: { runId: string; node: RunNodeView | null }): JSX.E
   return <div id="v3-term-slot" className="v3r-term-slot" ref={ref} />;
 }
 
-export function V3RunsPage(): JSX.Element {
+export function V3RunsPage(): React.JSX.Element {
   const runId = v3RunIdFromHash();
   return (
     <section className="page workflows-page v3-page">

--- a/src/dashboard/web/vc-consumer-profiles-section.tsx
+++ b/src/dashboard/web/vc-consumer-profiles-section.tsx
@@ -7,6 +7,7 @@
  * permissionPreset 是 UI 概念：custom 只对「已保存的同 id 预设」可选（服务端
  * 只允许沿用既有 policy），新预设必须先选一个模板档。
  */
+import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { DropdownMenu, FieldTitle, InfoTip, dropdownLabel } from './dashboard-components.js';
 import { useDashboardLocale, useT } from './react-hooks.js';
@@ -83,7 +84,7 @@ function toDto(draft: DraftProfile): VcMeetingConsumerProfileDto {
 /** settings 页挂载门：预设 API 是私有端点，公共只读访客请求必 401——
  * canWrite=false 时完全不挂载编辑器（一次 GET 都不发），只显示提示。 */
 /** 字段标题 + hover 帮助气泡：把配置语义讲清，避免用户对着裸表单猜。 */
-function FieldHead(props: { title: string; help: string }): JSX.Element {
+function FieldHead(props: { title: string; help: string }): React.JSX.Element {
   return (
     <span className="vc-profile-field-head">
       {props.title}
@@ -100,7 +101,7 @@ function VcProfileDialog(props: {
   children: ReactNode;
   onClose(): void;
   className?: string;
-}): JSX.Element {
+}): React.JSX.Element {
   const tr = useT();
   const ref = useRef<HTMLDialogElement | null>(null);
   useEffect(() => {
@@ -742,7 +743,7 @@ function ProfileEditorDialog(props: {
   onUpdate(patch: Partial<DraftProfile>): void;
   onIdChange(value: string): void;
   onRemove(): void;
-}): JSX.Element {
+}): React.JSX.Element {
   const tr = useT();
   const { profile, index } = props;
   return (
@@ -886,7 +887,7 @@ function TemplateDetailsDialog(props: {
   disabled: boolean;
   onClose(): void;
   onUse(): void;
-}): JSX.Element {
+}): React.JSX.Element {
   const tr = useT();
   const template = props.template;
   return (

--- a/src/dashboard/web/webhook-logs-page.tsx
+++ b/src/dashboard/web/webhook-logs-page.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { DropdownMenu, LoadingState, dropdownLabel } from './dashboard-components.js';
 import { jget } from './dashboard-api.js';
@@ -109,7 +110,7 @@ function formatBytes(value: number | undefined): string {
   return `${(value / 1024 / 1024).toFixed(1)} MB`;
 }
 
-function JsonBlock(props: { value: unknown; empty: string; fullHeight?: boolean }): JSX.Element {
+function JsonBlock(props: { value: unknown; empty: string; fullHeight?: boolean }): React.JSX.Element {
   if (props.value === undefined || props.value === null) return <p className="webhook-log-detail-empty">{props.empty}</p>;
   if (typeof props.value === 'object' && !Array.isArray(props.value) && Object.keys(props.value as object).length === 0) {
     return <p className="webhook-log-detail-empty">{props.empty}</p>;
@@ -117,7 +118,7 @@ function JsonBlock(props: { value: unknown; empty: string; fullHeight?: boolean 
   return <pre className={`webhook-log-json${props.fullHeight ? ' full-height' : ''}`}><code>{JSON.stringify(props.value, null, 2)}</code></pre>;
 }
 
-function TargetFacts(props: { value: TriggerLogEntry['target'] }): JSX.Element {
+function TargetFacts(props: { value: TriggerLogEntry['target'] }): React.JSX.Element {
   const items = [
     ['kind', props.value?.kind],
     ['mode', props.value?.mode],
@@ -146,7 +147,7 @@ function LogFilterMenu<T extends string>(props: {
   value: T;
   options: Array<{ value: T; label: ReactNode }>;
   onChange(value: T): void;
-}): JSX.Element {
+}): React.JSX.Element {
   return (
     <DropdownMenu
       id={props.id}
@@ -161,7 +162,7 @@ function LogFilterMenu<T extends string>(props: {
   );
 }
 
-function MetricCard(props: { label: string; value: string | number; tone?: 'ok' | 'error'; hint?: string }): JSX.Element {
+function MetricCard(props: { label: string; value: string | number; tone?: 'ok' | 'error'; hint?: string }): React.JSX.Element {
   return (
     <article className={`card webhook-log-metric${props.tone ? ` ${props.tone}` : ''}`}>
       <span>{props.label}</span>
@@ -171,7 +172,7 @@ function MetricCard(props: { label: string; value: string | number; tone?: 'ok' 
   );
 }
 
-export function WebhookLogsContent(props: { embedded?: boolean } = {}): JSX.Element {
+export function WebhookLogsContent(props: { embedded?: boolean } = {}): React.JSX.Element {
   const tr = useT();
   const mountedRef = useRef(false);
   const logsRef = useRef<TriggerLogEntry[]>([]);

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1070,6 +1070,11 @@ export const messages: Record<string, string> = {
 
   // Quote hint (injected into the CLI prompt)
   'prompt.quote_hint': '[User quoted a message — run `botmux quoted {id}` to view it]',
+  // Topic context — prepended on the first turn of a regular-group topic
+  // whose root is a different (earlier) message the bot never retained.
+  // Replays the whole topic thread (root + prior replies) so the bot sees the
+  // complete context. {count} is the number of prior messages surfaced.
+  'prompt.topic_context': '[Topic context — all prior messages in this topic, {count} total]',
 
   // Markdown / contextual reply card chrome
   'card.you': 'You',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1070,11 +1070,15 @@ export const messages: Record<string, string> = {
 
   // Quote hint (injected into the CLI prompt)
   'prompt.quote_hint': '[User quoted a message — run `botmux quoted {id}` to view it]',
-  // Topic context — prepended on the first turn of a regular-group topic
-  // whose root is a different (earlier) message the bot never retained.
-  // Replays the whole topic thread (root + prior replies) so the bot sees the
-  // complete context. {count} is the number of prior messages surfaced.
-  'prompt.topic_context': '[Topic context — all prior messages in this topic, {count} total]',
+  // Topic context hint — prepended on the first turn of a regular-group topic
+  // whose root is a different (earlier) message the bot never retained. It's a
+  // *hint*, not the transcript: signals that prior topic context exists and
+  // points at `botmux history` for on-demand retrieval (thread-scope by
+  // default). {count} is how many prior messages the topic has.
+  'prompt.topic_context': '[This is a reply inside a topic that already had {count} message(s) before you (the topic root + other replies) which you never retained. Run `botmux history` to read them if you need that context (defaults to this thread; use `--limit` for count, `botmux quoted <message_id>` for a message’s attachments).]',
+  // Countless variant — the metadata probe failed but the gate already proved a
+  // topic root exists, so still emit the hint (never drop the signal).
+  'prompt.topic_context_unknown': '[This is a reply inside a topic that already had prior messages before you (the topic root + possibly other replies) which you never retained. Run `botmux history` to read them if you need that context (defaults to this thread; use `--limit` for count, `botmux quoted <message_id>` for a message’s attachments).]',
 
   // Markdown / contextual reply card chrome
   'card.you': 'You',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1072,13 +1072,10 @@ export const messages: Record<string, string> = {
   'prompt.quote_hint': '[User quoted a message — run `botmux quoted {id}` to view it]',
   // Topic context hint — prepended on the first turn of a regular-group topic
   // whose root is a different (earlier) message the bot never retained. It's a
-  // *hint*, not the transcript: signals that prior topic context exists and
-  // points at `botmux history` for on-demand retrieval (thread-scope by
-  // default). {count} is how many prior messages the topic has.
-  'prompt.topic_context': '[This is a reply inside a topic that already had {count} message(s) before you (the topic root + other replies) which you never retained. Run `botmux history` to read them if you need that context (defaults to this thread; use `--limit` for count, `botmux quoted <message_id>` for a message’s attachments).]',
-  // Countless variant — the metadata probe failed but the gate already proved a
-  // topic root exists, so still emit the hint (never drop the signal).
-  'prompt.topic_context_unknown': '[This is a reply inside a topic that already had prior messages before you (the topic root + possibly other replies) which you never retained. Run `botmux history` to read them if you need that context (defaults to this thread; use `--limit` for count, `botmux quoted <message_id>` for a message’s attachments).]',
+  // *hint*, not the transcript, and carries NO count (zero first-turn network
+  // probe): signals that prior topic context exists and points at
+  // `botmux history` for on-demand retrieval (thread-scope by default).
+  'prompt.topic_context': '[This is a reply inside a topic that already had prior messages before you (the topic root + possibly other replies) which you never retained. Run `botmux history` to read them if you need that context (defaults to this thread; use `--limit` for count, `botmux quoted <message_id>` for a message’s attachments).]',
 
   // Markdown / contextual reply card chrome
   'card.you': 'You',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -1073,11 +1073,15 @@ export const messages: Record<string, string> = {
 
   // Quote hint (injected into the CLI prompt)
   'prompt.quote_hint': '[用户引用了消息 用 botmux quoted {id} 查看]',
-  // Topic context — prepended on the first turn of a 普通群 topic whose root
-  // is a different (earlier) message the bot never retained. Replays the whole
-  // topic thread (root + prior replies) so the bot sees the complete context.
-  // {count} is the number of prior messages surfaced.
-  'prompt.topic_context': '[话题上下文（本话题之前的全部消息，共 {count} 条）]',
+  // Topic context hint — prepended on the first turn of a 普通群 topic whose
+  // root is a different (earlier) message the bot never retained. It's a
+  // *hint*, not the transcript: signals that prior topic context exists and
+  // points at `botmux history` for on-demand retrieval (thread-scope by
+  // default). {count} is how many prior messages the topic has.
+  'prompt.topic_context': '[本条是话题内的回复，此话题在你之前已有 {count} 条消息（话题根 + 其它回复），你没有留存。需要这些前情时用 `botmux history` 查看（默认读本话题；用 `--limit` 控制条数，`botmux quoted <消息id>` 取某条的附件）。]',
+  // Countless variant — the metadata probe failed but the gate already proved a
+  // topic root exists, so still emit the hint (never drop the signal).
+  'prompt.topic_context_unknown': '[本条是话题内的回复，此话题在你之前已有前情消息（话题根 + 可能的其它回复），你没有留存。需要时用 `botmux history` 查看（默认读本话题；用 `--limit` 控制条数，`botmux quoted <消息id>` 取某条的附件）。]',
 
   // Markdown / contextual reply card chrome
   'card.you': '你',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -1075,13 +1075,10 @@ export const messages: Record<string, string> = {
   'prompt.quote_hint': '[用户引用了消息 用 botmux quoted {id} 查看]',
   // Topic context hint — prepended on the first turn of a 普通群 topic whose
   // root is a different (earlier) message the bot never retained. It's a
-  // *hint*, not the transcript: signals that prior topic context exists and
-  // points at `botmux history` for on-demand retrieval (thread-scope by
-  // default). {count} is how many prior messages the topic has.
-  'prompt.topic_context': '[本条是话题内的回复，此话题在你之前已有 {count} 条消息（话题根 + 其它回复），你没有留存。需要这些前情时用 `botmux history` 查看（默认读本话题；用 `--limit` 控制条数，`botmux quoted <消息id>` 取某条的附件）。]',
-  // Countless variant — the metadata probe failed but the gate already proved a
-  // topic root exists, so still emit the hint (never drop the signal).
-  'prompt.topic_context_unknown': '[本条是话题内的回复，此话题在你之前已有前情消息（话题根 + 可能的其它回复），你没有留存。需要时用 `botmux history` 查看（默认读本话题；用 `--limit` 控制条数，`botmux quoted <消息id>` 取某条的附件）。]',
+  // *hint*, not the transcript, and carries NO count (zero first-turn network
+  // probe): signals that prior topic context exists and points at
+  // `botmux history` for on-demand retrieval (thread-scope by default).
+  'prompt.topic_context': '[本条是话题内的回复，此话题在你之前已有前情消息（话题根 + 可能的其它回复），你没有留存。需要这些前情时用 `botmux history` 查看（默认读本话题；用 `--limit` 控制条数，`botmux quoted <消息id>` 取某条的附件）。]',
 
   // Markdown / contextual reply card chrome
   'card.you': '你',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -1073,6 +1073,11 @@ export const messages: Record<string, string> = {
 
   // Quote hint (injected into the CLI prompt)
   'prompt.quote_hint': '[用户引用了消息 用 botmux quoted {id} 查看]',
+  // Topic context — prepended on the first turn of a 普通群 topic whose root
+  // is a different (earlier) message the bot never retained. Replays the whole
+  // topic thread (root + prior replies) so the bot sees the complete context.
+  // {count} is the number of prior messages surfaced.
+  'prompt.topic_context': '[话题上下文（本话题之前的全部消息，共 {count} 条）]',
 
   // Markdown / contextual reply card chrome
   'card.you': '你',

--- a/src/im/lark/topic-root-context.ts
+++ b/src/im/lark/topic-root-context.ts
@@ -1,107 +1,39 @@
 /**
- * Fetch the full history of a 普通群 topic — root + every reply before the
- * current @mention — and render it as a prompt-context block, so the bot sees
- * the *complete* topic context, not just the @-reply text.
+ * Detect a 普通群 topic whose root the bot never retained, and inject a
+ * lightweight *hint* (not the full transcript) telling the CLI it can pull the
+ * topic history on demand via `botmux history`.
  *
  * Why this is needed: a 普通群 topic is often started on an earlier message X
- * (X carries `thread_id` but no `root_id`, arrived as a top-level group
- * message without an @, and was ignored/never retained by the daemon). The
- * @-mention reply carries `root_id=X` + `thread_id` and routes to a session
- * anchored at X — yet without this fetch the bot only ever sees the @-reply.
- * Other humans may also have replied in the topic before the @; those too are
- * invisible unless we replay the thread.
+ * (X carries `thread_id` but no `root_id`, arrived as a top-level group message
+ * without an @, and was ignored/never retained by the daemon). The @-mention
+ * reply carries `root_id=X` + `thread_id` and routes to a session anchored at X
+ * — so on the first turn the bot only sees the @-reply and has no *signal* that
+ * a topic root + prior replies even exist. That missing signal is the real gap
+ * (contrast the quote path: the user's explicit quote already gives the bot a
+ * `botmux quoted` hint).
  *
- * Called only on the first turn (handleNewTopic) when the inbound message is
- * a real-thread reply (`root_id` set and ≠ its own message_id). Subsequent
- * turns already carry the thread in the CLI's conversation history.
+ * Why a hint, not an eager full replay: replaying the whole thread means (1) on
+ * short topics, dumping every message as prompt noise regardless of relevance;
+ * (2) on long topics, `listThreadMessages` caps at the *oldest* 50 (ByCreateTime
+ * Asc + slice), so a late @mention would get the topic's opening and miss the
+ * most-relevant recent messages; (3) downloading every historical image/file to
+ * this bot's bucket up front, most of which won't be used. Instead we mirror the
+ * quote mechanism: emit a one-line hint and let the CLI decide whether to run
+ * `botmux history` (thread-scope by default → walks this very thread, with its
+ * own `--limit` for count control and `botmux quoted` for any attachments).
  *
- * Best-effort throughout: any failure (thread unavailable, withdrawn root, API
- * error) degrades to a root-only fetch, then to '' — the first turn is never
- * blocked, it simply falls back to the old behavior.
+ * Called only on the first turn (handleNewTopic) when the inbound message is a
+ * real-thread reply (`root_id` set and ≠ its own message_id). Subsequent turns
+ * already carry the thread in the CLI's conversation history.
+ *
+ * Best-effort: the count is a single cheap metadata probe (one list call, no
+ * per-message parsing, no card re-resolve, no attachment download). If it fails
+ * we still emit the hint without a count — the gate already proved a root
+ * exists, so the signal must never be lost.
  */
-import { getMessageDetail } from './client.js';
 import { listThreadMessages } from './client.js';
-import {
-  parseApiMessage,
-  extractResources,
-  createImgNumberer,
-  resolveMergedCardContent,
-  type MessageResource,
-} from './message-parser.js';
-import { expandMergeForward } from './merge-forward.js';
-import { downloadResources, formatAttachmentsHint } from '../../core/session-manager.js';
 import { t, type Locale } from '../../i18n/index.js';
 import { logger } from '../../utils/logger.js';
-
-/** Render one raw API message into a { sender, body } pair (body already
- *  includes [图片 N]/[文件 N] placeholders + an <attachments> block). Best-effort
- *  per message: a failure returns null so one bad message can't sink the
- *  whole transcript. */
-async function renderTopicMessage(
-  larkAppId: string,
-  rawMessage: any,
-): Promise<{ sender: string; body: string } | null> {
-  try {
-    const numberer = createImgNumberer();
-    // extractResources BEFORE parseApiMessage so [图片 N]/[文件 N] placeholders
-    // align with the resource list (same contract as parseEventMessage /
-    // renderQuotedMessage — extractTextContent only consults the cache, it does
-    // not create entries for resources that haven't been declared yet).
-    const resources: MessageResource[] = extractResources(
-      rawMessage.msg_type ?? 'text',
-      rawMessage.body?.content ?? '',
-      numberer,
-    );
-    const parsed = parseApiMessage(rawMessage, numberer);
-
-    if (parsed.msgType === 'merge_forward') {
-      const { extraResources } = await expandMergeForward(larkAppId, parsed.messageId, parsed, numberer);
-      resources.push(...extraResources);
-    } else if (parsed.msgType === 'interactive') {
-      // Re-resolve the card via dual im.message.get so the model sees the real
-      // v2 body instead of Lark's "请升级客户端" fallback. Fresh numberer +
-      // full content/resource replacement, matching renderQuotedMessage.
-      const cardNumberer = createImgNumberer();
-      const merged = await resolveMergedCardContent(larkAppId, parsed.messageId, cardNumberer).catch(() => null);
-      if (merged) {
-        parsed.content = merged.text;
-        resources.length = 0;
-        resources.push(...merged.resources);
-      }
-    }
-
-    // Download this message's attachments into this bot's own bucket so a
-    // sandboxed CLI can open them — same as the inbound-message path.
-    const { attachments } = await downloadResources(larkAppId, parsed.messageId, resources);
-
-    const sender = parsed.senderName ?? parsed.senderId ?? '';
-    const text = parsed.content?.trim() ?? '';
-    const attachmentBlock = formatAttachmentsHint(attachments);
-    const body = text + (attachmentBlock ? `\n${attachmentBlock}` : '');
-    if (!body) return null;
-    return { sender: sender || 'unknown', body };
-  } catch (err: any) {
-    logger.debug(`[topic-thread] skip msg=${rawMessage?.message_id?.substring(0, 12)}: ${err?.message ?? err}`);
-    return null;
-  }
-}
-
-/** Render a single root message as a last-resort context block when the full
- *  thread list is unavailable. Mirrors renderTopicMessage but is tolerant of
- *  being called with just a root id. */
-async function renderRootOnly(larkAppId: string, rootId: string, locale?: Locale): Promise<string> {
-  try {
-    const detail = await getMessageDetail(larkAppId, rootId, { userCardContent: false });
-    const rawMessage = detail?.items?.[0];
-    if (!rawMessage) return '';
-    const rendered = await renderTopicMessage(larkAppId, rawMessage);
-    if (!rendered) return '';
-    return `${t('prompt.topic_context', { count: 1 }, locale)}\n${rendered.sender}: ${rendered.body}\n`;
-  } catch (err: any) {
-    logger.warn(`[topic-thread] root-only fallback failed root=${rootId.substring(0, 12)}: ${err?.message ?? err}`);
-    return '';
-  }
-}
 
 export async function buildTopicThreadContext(
   larkAppId: string,
@@ -111,27 +43,22 @@ export async function buildTopicThreadContext(
   locale?: Locale,
 ): Promise<string> {
   if (!rootId) return '';
+  let count = 0;
   try {
-    // listThreadMessages resolves the thread_id from the root, then lists root
-    // + replies in ascending create-time order (with sender names). Up to 50
-    // messages — plenty for a first-turn topic; long threads are capped.
+    // One lightweight metadata list (root + replies, asc). We only read the
+    // *count* for the hint — no per-message render, no card re-resolve, no
+    // attachment download. Capped at the default 50, which is fine as a floor
+    // for a hint; the CLI's own `botmux history --limit` controls the real read.
     const items = await listThreadMessages(larkAppId, chatId, rootId);
     // Exclude the current @-reply: it is the user's prompt for this turn, not
-    // context. (listThreadMessages includes it because it's a thread reply.)
-    const prior = items.filter(m => m?.message_id && m.message_id !== currentMessageId);
-    if (prior.length === 0) {
-      // Thread list empty/unavailable — fall back to fetching just the root.
-      return renderRootOnly(larkAppId, rootId, locale);
-    }
-    const rendered = (await Promise.all(prior.map(m => renderTopicMessage(larkAppId, m))))
-      .filter((r): r is { sender: string; body: string } => r !== null);
-    if (rendered.length === 0) {
-      return renderRootOnly(larkAppId, rootId, locale);
-    }
-    const transcript = rendered.map(r => `${r.sender}: ${r.body}`).join('\n');
-    return `${t('prompt.topic_context', { count: rendered.length }, locale)}\n${transcript}\n`;
+    // prior context. (listThreadMessages includes it — it's a thread reply.)
+    count = items.filter(m => m?.message_id && m.message_id !== currentMessageId).length;
   } catch (err: any) {
-    logger.warn(`[topic-thread] list failed root=${rootId.substring(0, 12)}: ${err?.message ?? err}; trying root-only`);
-    return renderRootOnly(larkAppId, rootId, locale);
+    // Best-effort: we still KNOW a root exists (gate: rootId ≠ messageId), so
+    // fall through to a countless hint rather than dropping the signal entirely.
+    logger.debug(`[topic-thread] count probe failed root=${rootId.substring(0, 12)}: ${err?.message ?? err}`);
   }
+  return count > 0
+    ? `${t('prompt.topic_context', { count }, locale)}\n`
+    : `${t('prompt.topic_context_unknown', undefined, locale)}\n`;
 }

--- a/src/im/lark/topic-root-context.ts
+++ b/src/im/lark/topic-root-context.ts
@@ -1,0 +1,137 @@
+/**
+ * Fetch the full history of a 普通群 topic — root + every reply before the
+ * current @mention — and render it as a prompt-context block, so the bot sees
+ * the *complete* topic context, not just the @-reply text.
+ *
+ * Why this is needed: a 普通群 topic is often started on an earlier message X
+ * (X carries `thread_id` but no `root_id`, arrived as a top-level group
+ * message without an @, and was ignored/never retained by the daemon). The
+ * @-mention reply carries `root_id=X` + `thread_id` and routes to a session
+ * anchored at X — yet without this fetch the bot only ever sees the @-reply.
+ * Other humans may also have replied in the topic before the @; those too are
+ * invisible unless we replay the thread.
+ *
+ * Called only on the first turn (handleNewTopic) when the inbound message is
+ * a real-thread reply (`root_id` set and ≠ its own message_id). Subsequent
+ * turns already carry the thread in the CLI's conversation history.
+ *
+ * Best-effort throughout: any failure (thread unavailable, withdrawn root, API
+ * error) degrades to a root-only fetch, then to '' — the first turn is never
+ * blocked, it simply falls back to the old behavior.
+ */
+import { getMessageDetail } from './client.js';
+import { listThreadMessages } from './client.js';
+import {
+  parseApiMessage,
+  extractResources,
+  createImgNumberer,
+  resolveMergedCardContent,
+  type MessageResource,
+} from './message-parser.js';
+import { expandMergeForward } from './merge-forward.js';
+import { downloadResources, formatAttachmentsHint } from '../../core/session-manager.js';
+import { t, type Locale } from '../../i18n/index.js';
+import { logger } from '../../utils/logger.js';
+
+/** Render one raw API message into a { sender, body } pair (body already
+ *  includes [图片 N]/[文件 N] placeholders + an <attachments> block). Best-effort
+ *  per message: a failure returns null so one bad message can't sink the
+ *  whole transcript. */
+async function renderTopicMessage(
+  larkAppId: string,
+  rawMessage: any,
+): Promise<{ sender: string; body: string } | null> {
+  try {
+    const numberer = createImgNumberer();
+    // extractResources BEFORE parseApiMessage so [图片 N]/[文件 N] placeholders
+    // align with the resource list (same contract as parseEventMessage /
+    // renderQuotedMessage — extractTextContent only consults the cache, it does
+    // not create entries for resources that haven't been declared yet).
+    const resources: MessageResource[] = extractResources(
+      rawMessage.msg_type ?? 'text',
+      rawMessage.body?.content ?? '',
+      numberer,
+    );
+    const parsed = parseApiMessage(rawMessage, numberer);
+
+    if (parsed.msgType === 'merge_forward') {
+      const { extraResources } = await expandMergeForward(larkAppId, parsed.messageId, parsed, numberer);
+      resources.push(...extraResources);
+    } else if (parsed.msgType === 'interactive') {
+      // Re-resolve the card via dual im.message.get so the model sees the real
+      // v2 body instead of Lark's "请升级客户端" fallback. Fresh numberer +
+      // full content/resource replacement, matching renderQuotedMessage.
+      const cardNumberer = createImgNumberer();
+      const merged = await resolveMergedCardContent(larkAppId, parsed.messageId, cardNumberer).catch(() => null);
+      if (merged) {
+        parsed.content = merged.text;
+        resources.length = 0;
+        resources.push(...merged.resources);
+      }
+    }
+
+    // Download this message's attachments into this bot's own bucket so a
+    // sandboxed CLI can open them — same as the inbound-message path.
+    const { attachments } = await downloadResources(larkAppId, parsed.messageId, resources);
+
+    const sender = parsed.senderName ?? parsed.senderId ?? '';
+    const text = parsed.content?.trim() ?? '';
+    const attachmentBlock = formatAttachmentsHint(attachments);
+    const body = text + (attachmentBlock ? `\n${attachmentBlock}` : '');
+    if (!body) return null;
+    return { sender: sender || 'unknown', body };
+  } catch (err: any) {
+    logger.debug(`[topic-thread] skip msg=${rawMessage?.message_id?.substring(0, 12)}: ${err?.message ?? err}`);
+    return null;
+  }
+}
+
+/** Render a single root message as a last-resort context block when the full
+ *  thread list is unavailable. Mirrors renderTopicMessage but is tolerant of
+ *  being called with just a root id. */
+async function renderRootOnly(larkAppId: string, rootId: string, locale?: Locale): Promise<string> {
+  try {
+    const detail = await getMessageDetail(larkAppId, rootId, { userCardContent: false });
+    const rawMessage = detail?.items?.[0];
+    if (!rawMessage) return '';
+    const rendered = await renderTopicMessage(larkAppId, rawMessage);
+    if (!rendered) return '';
+    return `${t('prompt.topic_context', { count: 1 }, locale)}\n${rendered.sender}: ${rendered.body}\n`;
+  } catch (err: any) {
+    logger.warn(`[topic-thread] root-only fallback failed root=${rootId.substring(0, 12)}: ${err?.message ?? err}`);
+    return '';
+  }
+}
+
+export async function buildTopicThreadContext(
+  larkAppId: string,
+  chatId: string,
+  rootId: string,
+  currentMessageId: string,
+  locale?: Locale,
+): Promise<string> {
+  if (!rootId) return '';
+  try {
+    // listThreadMessages resolves the thread_id from the root, then lists root
+    // + replies in ascending create-time order (with sender names). Up to 50
+    // messages — plenty for a first-turn topic; long threads are capped.
+    const items = await listThreadMessages(larkAppId, chatId, rootId);
+    // Exclude the current @-reply: it is the user's prompt for this turn, not
+    // context. (listThreadMessages includes it because it's a thread reply.)
+    const prior = items.filter(m => m?.message_id && m.message_id !== currentMessageId);
+    if (prior.length === 0) {
+      // Thread list empty/unavailable — fall back to fetching just the root.
+      return renderRootOnly(larkAppId, rootId, locale);
+    }
+    const rendered = (await Promise.all(prior.map(m => renderTopicMessage(larkAppId, m))))
+      .filter((r): r is { sender: string; body: string } => r !== null);
+    if (rendered.length === 0) {
+      return renderRootOnly(larkAppId, rootId, locale);
+    }
+    const transcript = rendered.map(r => `${r.sender}: ${r.body}`).join('\n');
+    return `${t('prompt.topic_context', { count: rendered.length }, locale)}\n${transcript}\n`;
+  } catch (err: any) {
+    logger.warn(`[topic-thread] list failed root=${rootId.substring(0, 12)}: ${err?.message ?? err}; trying root-only`);
+    return renderRootOnly(larkAppId, rootId, locale);
+  }
+}

--- a/src/im/lark/topic-root-context.ts
+++ b/src/im/lark/topic-root-context.ts
@@ -1,7 +1,8 @@
 /**
- * Detect a 普通群 topic whose root the bot never retained, and inject a
- * lightweight *hint* (not the full transcript) telling the CLI it can pull the
- * topic history on demand via `botmux history`.
+ * Build a lightweight *hint* (not the topic transcript) telling the CLI that
+ * this first turn is a reply inside a 普通群 topic whose root the bot never
+ * retained — and that it can pull the topic history on demand via
+ * `botmux history`.
  *
  * Why this is needed: a 普通群 topic is often started on an earlier message X
  * (X carries `thread_id` but no `root_id`, arrived as a top-level group message
@@ -12,53 +13,25 @@
  * (contrast the quote path: the user's explicit quote already gives the bot a
  * `botmux quoted` hint).
  *
- * Why a hint, not an eager full replay: replaying the whole thread means (1) on
- * short topics, dumping every message as prompt noise regardless of relevance;
- * (2) on long topics, `listThreadMessages` caps at the *oldest* 50 (ByCreateTime
- * Asc + slice), so a late @mention would get the topic's opening and miss the
- * most-relevant recent messages; (3) downloading every historical image/file to
- * this bot's bucket up front, most of which won't be used. Instead we mirror the
- * quote mechanism: emit a one-line hint and let the CLI decide whether to run
+ * Why a pure hint with ZERO first-turn fetch: the earlier count-probe variant
+ * was neither lightweight nor accurate. `listThreadMessages` first GETs the
+ * root to resolve thread_id, then pulls up to 50 *full* message bodies — and
+ * when thread_id can't be resolved it falls back to paging the *whole chat*
+ * (potentially the entire large-group history) to filter by root_id. On top of
+ * that, the Asc+50 cap means the "count" is only a floor (the oldest 50), so
+ * printing it as an exact total is misleading. Since the daemon gate has
+ * *already* proven this is a topic reply, we don't need a network call at all:
+ * emit the hint unconditionally and let the CLI decide whether to run
  * `botmux history` (thread-scope by default → walks this very thread, with its
  * own `--limit` for count control and `botmux quoted` for any attachments).
  *
  * Called only on the first turn (handleNewTopic) when the inbound message is a
  * real-thread reply (`root_id` set and ≠ its own message_id). Subsequent turns
- * already carry the thread in the CLI's conversation history.
- *
- * Best-effort: the count is a single cheap metadata probe (one list call, no
- * per-message parsing, no card re-resolve, no attachment download). If it fails
- * we still emit the hint without a count — the gate already proved a root
- * exists, so the signal must never be lost.
+ * already carry the thread in the CLI's conversation history. The gate lives at
+ * the call site; this function just renders the localized hint string.
  */
-import { listThreadMessages } from './client.js';
 import { t, type Locale } from '../../i18n/index.js';
-import { logger } from '../../utils/logger.js';
 
-export async function buildTopicThreadContext(
-  larkAppId: string,
-  chatId: string,
-  rootId: string,
-  currentMessageId: string,
-  locale?: Locale,
-): Promise<string> {
-  if (!rootId) return '';
-  let count = 0;
-  try {
-    // One lightweight metadata list (root + replies, asc). We only read the
-    // *count* for the hint — no per-message render, no card re-resolve, no
-    // attachment download. Capped at the default 50, which is fine as a floor
-    // for a hint; the CLI's own `botmux history --limit` controls the real read.
-    const items = await listThreadMessages(larkAppId, chatId, rootId);
-    // Exclude the current @-reply: it is the user's prompt for this turn, not
-    // prior context. (listThreadMessages includes it — it's a thread reply.)
-    count = items.filter(m => m?.message_id && m.message_id !== currentMessageId).length;
-  } catch (err: any) {
-    // Best-effort: we still KNOW a root exists (gate: rootId ≠ messageId), so
-    // fall through to a countless hint rather than dropping the signal entirely.
-    logger.debug(`[topic-thread] count probe failed root=${rootId.substring(0, 12)}: ${err?.message ?? err}`);
-  }
-  return count > 0
-    ? `${t('prompt.topic_context', { count }, locale)}\n`
-    : `${t('prompt.topic_context_unknown', undefined, locale)}\n`;
+export function buildTopicThreadContext(locale?: Locale): string {
+  return `${t('prompt.topic_context', undefined, locale)}\n`;
 }

--- a/test/daemon-codex-app-workflow-wiring.test.ts
+++ b/test/daemon-codex-app-workflow-wiring.test.ts
@@ -21,8 +21,10 @@ describe('daemon Codex App workflow prompt lanes', () => {
 
     expect(block.indexOf('const codexAppVisibleText = content;'))
       .toBeLessThan(block.indexOf('content = workflowGrillPrompt;'));
-    expect(block).toContain("const codexAppMessageContext = codexAppQuoteContext + (workflowGrillPrompt ?? '');");
-    expect(block).toContain('const promptContent = codexAppQuoteContext + codexAppApplicationContext + content;');
+    // 话题上下文 (topicThreadContext) 必须双 lane 下发：既进 legacy promptContent，
+    // 也进 codex-app 结构化 sidecar codexAppMessageContext，否则 codex-app bot 静默丢话题历史。
+    expect(block).toContain("const codexAppMessageContext = topicThreadContext + codexAppQuoteContext + (workflowGrillPrompt ?? '');");
+    expect(block).toContain('const promptContent = topicThreadContext + codexAppQuoteContext + codexAppApplicationContext + content;');
     expect(block).toContain('pendingCodexAppText: codexAppVisibleText');
     expect(block.match(/codexAppText: codexAppVisibleText/g)).toHaveLength(2);
   });

--- a/test/topic-root-context.test.ts
+++ b/test/topic-root-context.test.ts
@@ -1,20 +1,23 @@
 /**
- * Unit tests for buildTopicThreadContext — the first-turn helper that replays
- * the full topic thread (root + prior replies) as a prompt-context block for
- * a 普通群 topic the bot otherwise wouldn't see.
+ * Unit tests for buildTopicThreadContext — the first-turn helper that injects a
+ * lightweight *hint* (not the full transcript) for a 普通群 topic the bot
+ * otherwise wouldn't know exists. The hint points the CLI at `botmux history`
+ * for on-demand retrieval, mirroring the quote-hint pattern.
  *
- * Covers: multi-message transcript, current-message exclusion, per-message
- * rendering (text / image / post / merge_forward / interactive), and the
- * degradation paths (empty thread → root-only fallback; list error →
- * root-only fallback; both fail → '').
+ * Covers: count derivation (current @-reply excluded), the hint wording (points
+ * at `botmux history`, carries the count, contains NO transcript/sender/body),
+ * the no-eager-fetch guarantee (no attachment download / merge_forward /
+ * card re-resolve), and the degradation paths (probe throws → countless hint
+ * still emitted; empty thread → count 0 → countless hint; empty rootId → '').
  *
  * Run:  pnpm vitest run test/topic-root-context.test.ts
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Network / side-effecting dependencies are mocked. message-parser stays real
-// (parseApiMessage / extractResources / createImgNumberer / resolveMergedCardContent
-// are pure or only call the mocked client fns).
+// Only the metadata list is needed now. The old transcript path pulled in
+// getMessageDetail / expandMergeForward / resolveMergedCardContent /
+// downloadResources — we mock them too, purely to ASSERT they are never called
+// (the hint approach must not eagerly fetch or download anything).
 vi.mock('../src/im/lark/client.js', () => ({
   getMessageDetail: vi.fn(),
   listThreadMessages: vi.fn(),
@@ -24,23 +27,15 @@ vi.mock('../src/im/lark/merge-forward.js', () => ({
 }));
 vi.mock('../src/core/session-manager.js', () => ({
   downloadResources: vi.fn(),
-  // Deterministic formatter so assertions don't depend on the real i18n/XML
-  // shape; the real formatAttachmentsHint has its own test coverage.
-  formatAttachmentsHint: vi.fn((atts: any[]) =>
-    Array.isArray(atts) && atts.length
-      ? `<atts>${atts.map(a => a.name).join(',')}</atts>`
-      : '',
-  ),
+  formatAttachmentsHint: vi.fn(() => ''),
 }));
 
 import { buildTopicThreadContext } from '../src/im/lark/topic-root-context.js';
 import { getMessageDetail, listThreadMessages } from '../src/im/lark/client.js';
 import { expandMergeForward } from '../src/im/lark/merge-forward.js';
 import { downloadResources } from '../src/core/session-manager.js';
-import type { LarkMessage } from '../src/types.js';
-import type { MessageResource } from '../src/im/lark/message-parser.js';
 
-function msg(messageId: string, msgType: string, body: unknown, senderName = '张三') {
+function msg(messageId: string, msgType = 'text', body: unknown = { text: 'hi' }, senderName = '张三') {
   return {
     message_id: messageId,
     msg_type: msgType,
@@ -64,129 +59,79 @@ beforeEach(() => {
   downloadResourcesMock.mockReset();
 });
 
-describe('buildTopicThreadContext', () => {
-  it('replays root + prior reply as a transcript and excludes the current @-reply', async () => {
-    // Thread order (asc): root, one human reply, then the current @-reply.
+describe('buildTopicThreadContext (hint mode)', () => {
+  it('emits a hint carrying the prior-message count, excluding the current @-reply', async () => {
+    // Thread (asc): root, one prior reply, then the current @-reply → 2 prior.
     listThreadMessagesMock.mockResolvedValue([
       msg('om_root', 'text', { text: '请帮我分析这段代码' }, '张三'),
       msg('om_reply', 'text', { text: '对，特别是第二段' }, '李四'),
       msg(CURRENT_ID, 'text', { text: '@bot 继续' }, '王五'),
     ]);
-    downloadResourcesMock.mockResolvedValue({ attachments: [], needLogin: false });
 
     const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
-    expect(out).toContain('话题上下文');
-    expect(out).toContain('共 2 条');
-    expect(out).toContain('张三: 请帮我分析这段代码');
-    expect(out).toContain('李四: 对，特别是第二段');
-    // Current @-reply must NOT appear in the context block (it's the prompt).
-    expect(out).not.toContain('继续');
-    expect(expandMergeForwardMock).not.toHaveBeenCalled();
+    expect(out).toContain('话题');
+    expect(out).toContain('2 条');
+    expect(out).toContain('botmux history');
   });
 
-  it('downloads image resources and surfaces the attachment block per message', async () => {
+  it('is a HINT, not a transcript: no message bodies/senders are inlined', async () => {
     listThreadMessagesMock.mockResolvedValue([
-      msg('om_root', 'image', { image_key: 'img_root' }, '张三'),
-      msg(CURRENT_ID, 'text', { text: '@bot' }, '李四'),
+      msg('om_root', 'text', { text: '机密的话题正文内容' }, '张三'),
+      msg('om_reply', 'text', { text: '另一条前情回复' }, '李四'),
+      msg(CURRENT_ID, 'text', { text: '@bot' }, '王五'),
     ]);
-    const attachments = [{ type: 'image', path: '/atts/app_x/om_root/img_root.jpg', name: 'img_root.jpg' }];
-    downloadResourcesMock.mockResolvedValue({ attachments, needLogin: false });
 
     const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
-    expect(out).toContain('[图片 1]');
-    expect(out).toContain('<atts>img_root.jpg</atts>');
-    expect(downloadResourcesMock).toHaveBeenCalledWith('app_x', 'om_root', expect.any(Array));
+    // The transcript content must NOT be replayed into the prompt.
+    expect(out).not.toContain('机密的话题正文内容');
+    expect(out).not.toContain('另一条前情回复');
+    expect(out).not.toContain('张三:');
+    expect(out).not.toContain('李四:');
   });
 
-  it('keeps image and file numbering independent per message (post root)', async () => {
-    const post = {
-      zh_cn: {
-        title: '截图与文档',
-        content: [
-          [{ tag: 'text', text: '图：' }, { tag: 'img', image_key: 'img_aaa' }],
-          [{ tag: 'text', text: '附件：' }, { tag: 'file', file_key: 'file_bbb', file_name: 'spec.pdf' }],
-        ],
-      },
-    };
-    listThreadMessagesMock.mockResolvedValue([
-      msg('om_root', 'post', post, '张三'),
-      msg(CURRENT_ID, 'text', { text: '@bot' }, '李四'),
-    ]);
-    downloadResourcesMock.mockResolvedValue({
-      attachments: [
-        { type: 'image', path: '/a/1.jpg', name: 'img_aaa.jpg' },
-        { type: 'file', path: '/a/2.pdf', name: 'spec.pdf' },
-      ],
-      needLogin: false,
-    });
-
-    const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
-    expect(out).toContain('[图片 1]');
-    expect(out).toContain('[文件 1: spec.pdf]');
-  });
-
-  it('expands a merge_forward root into <forwarded_messages>', async () => {
+  it('never eagerly fetches: no attachment download / merge_forward / card re-resolve / root detail', async () => {
     listThreadMessagesMock.mockResolvedValue([
       msg('om_root', 'merge_forward', {}, '张三'),
-      msg(CURRENT_ID, 'text', { text: '@bot' }, '李四'),
+      msg('om_img', 'image', { image_key: 'img_x' }, '李四'),
+      msg('om_card', 'interactive', { user_dsl: '{}' }, '王五'),
+      msg(CURRENT_ID, 'text', { text: '@bot' }, '赵六'),
     ]);
-    expandMergeForwardMock.mockImplementation(async (_a: string, _m: string, parsed: LarkMessage) => {
-      parsed.msgType = 'merge_forward_expanded';
-      parsed.content = '<forwarded_messages><msg from="A">前情提要</msg></forwarded_messages>';
-      return { extraResources: [{ type: 'image', key: 'img_xyz', name: 'img_xyz.jpg' }] satisfies MessageResource[] };
-    });
-    downloadResourcesMock.mockResolvedValue({ attachments: [{ type: 'image', path: '/a/x.jpg', name: 'img_xyz.jpg' }], needLogin: false });
 
     const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
-    expect(out).toContain('<forwarded_messages>');
-    expect(out).toContain('前情提要');
-    expect(expandMergeForwardMock).toHaveBeenCalledTimes(1);
+    expect(out).toContain('3 条');
+    // The whole point of the hint approach: no eager fetch/download work.
+    expect(downloadResourcesMock).not.toHaveBeenCalled();
+    expect(expandMergeForwardMock).not.toHaveBeenCalled();
+    expect(getMessageDetailMock).not.toHaveBeenCalled();
   });
 
-  it('re-resolves an interactive card root to its real body instead of the upgrade fallback', async () => {
-    const card = {
-      user_dsl: JSON.stringify({
-        header: { title: { tag: 'plain_text', content: '根消息卡片' } },
-        body: { elements: [{ tag: 'markdown', content: 'card body here' }] },
-      }),
-    };
+  it('runs a single metadata probe with the right args (no per-message fan-out)', async () => {
     listThreadMessagesMock.mockResolvedValue([
-      msg('om_root', 'interactive', card, '张三'),
-      msg(CURRENT_ID, 'text', { text: '@bot' }, '李四'),
+      msg('om_root'), msg('om_r1'), msg('om_r2'), msg(CURRENT_ID),
     ]);
-    downloadResourcesMock.mockResolvedValue({ attachments: [], needLogin: false });
-
     const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
-    expect(out).toContain('card body here');
+    expect(listThreadMessagesMock).toHaveBeenCalledTimes(1);
+    expect(listThreadMessagesMock).toHaveBeenCalledWith('app_x', 'oc_chat', 'om_root');
+    expect(out).toContain('3 条');
   });
 
-  it('falls back to root-only when the thread list returns only the current message', async () => {
-    getMessageDetailMock.mockResolvedValue({ items: [msg('om_root', 'text', { text: '孤立的根' }, '张三')] });
-    downloadResourcesMock.mockResolvedValue({ attachments: [], needLogin: false });
+  it('falls back to the countless hint when the list has only the current @-reply', async () => {
     listThreadMessagesMock.mockResolvedValue([msg(CURRENT_ID, 'text', { text: '@bot' }, '王五')]);
-
     const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
-    expect(out).toContain('共 1 条');
-    expect(out).toContain('张三: 孤立的根');
+    // count === 0 → countless variant, but the signal + tool pointer remain.
+    expect(out).toContain('botmux history');
+    expect(out).not.toContain('0 条');
   });
 
-  it('falls back to root-only when listThreadMessages throws', async () => {
+  it('still emits the countless hint when listThreadMessages throws (signal never dropped)', async () => {
     listThreadMessagesMock.mockRejectedValue(new Error('Lark 230002: not in chat'));
-    getMessageDetailMock.mockResolvedValue({ items: [msg('om_root', 'text', { text: '根内容' }, '张三')] });
-    downloadResourcesMock.mockResolvedValue({ attachments: [], needLogin: false });
-
     const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
-    expect(out).toContain('张三: 根内容');
+    expect(out).toContain('话题');
+    expect(out).toContain('botmux history');
+    expect(getMessageDetailMock).not.toHaveBeenCalled();
   });
 
-  it('returns "" (best-effort) when both list and root-only fail', async () => {
-    listThreadMessagesMock.mockRejectedValue(new Error('list down'));
-    getMessageDetailMock.mockRejectedValue(new Error('get down'));
-    const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
-    expect(out).toBe('');
-  });
-
-  it('returns "" for an empty rootId', async () => {
+  it('returns "" for an empty rootId (gate off — nothing to hint about)', async () => {
     const out = await buildTopicThreadContext('app_x', 'oc_chat', '', CURRENT_ID);
     expect(out).toBe('');
     expect(listThreadMessagesMock).not.toHaveBeenCalled();

--- a/test/topic-root-context.test.ts
+++ b/test/topic-root-context.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for buildTopicThreadContext — the first-turn helper that replays
+ * the full topic thread (root + prior replies) as a prompt-context block for
+ * a 普通群 topic the bot otherwise wouldn't see.
+ *
+ * Covers: multi-message transcript, current-message exclusion, per-message
+ * rendering (text / image / post / merge_forward / interactive), and the
+ * degradation paths (empty thread → root-only fallback; list error →
+ * root-only fallback; both fail → '').
+ *
+ * Run:  pnpm vitest run test/topic-root-context.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Network / side-effecting dependencies are mocked. message-parser stays real
+// (parseApiMessage / extractResources / createImgNumberer / resolveMergedCardContent
+// are pure or only call the mocked client fns).
+vi.mock('../src/im/lark/client.js', () => ({
+  getMessageDetail: vi.fn(),
+  listThreadMessages: vi.fn(),
+}));
+vi.mock('../src/im/lark/merge-forward.js', () => ({
+  expandMergeForward: vi.fn(),
+}));
+vi.mock('../src/core/session-manager.js', () => ({
+  downloadResources: vi.fn(),
+  // Deterministic formatter so assertions don't depend on the real i18n/XML
+  // shape; the real formatAttachmentsHint has its own test coverage.
+  formatAttachmentsHint: vi.fn((atts: any[]) =>
+    Array.isArray(atts) && atts.length
+      ? `<atts>${atts.map(a => a.name).join(',')}</atts>`
+      : '',
+  ),
+}));
+
+import { buildTopicThreadContext } from '../src/im/lark/topic-root-context.js';
+import { getMessageDetail, listThreadMessages } from '../src/im/lark/client.js';
+import { expandMergeForward } from '../src/im/lark/merge-forward.js';
+import { downloadResources } from '../src/core/session-manager.js';
+import type { LarkMessage } from '../src/types.js';
+import type { MessageResource } from '../src/im/lark/message-parser.js';
+
+function msg(messageId: string, msgType: string, body: unknown, senderName = '张三') {
+  return {
+    message_id: messageId,
+    msg_type: msgType,
+    create_time: '1700000000000',
+    sender: { id: 'ou_' + messageId, sender_type: 'user', sender_name: senderName },
+    body: { content: typeof body === 'string' ? body : JSON.stringify(body) },
+  };
+}
+
+const CURRENT_ID = 'om_current';
+
+const getMessageDetailMock = getMessageDetail as unknown as ReturnType<typeof vi.fn>;
+const listThreadMessagesMock = listThreadMessages as unknown as ReturnType<typeof vi.fn>;
+const expandMergeForwardMock = expandMergeForward as unknown as ReturnType<typeof vi.fn>;
+const downloadResourcesMock = downloadResources as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  getMessageDetailMock.mockReset();
+  listThreadMessagesMock.mockReset();
+  expandMergeForwardMock.mockReset();
+  downloadResourcesMock.mockReset();
+});
+
+describe('buildTopicThreadContext', () => {
+  it('replays root + prior reply as a transcript and excludes the current @-reply', async () => {
+    // Thread order (asc): root, one human reply, then the current @-reply.
+    listThreadMessagesMock.mockResolvedValue([
+      msg('om_root', 'text', { text: '请帮我分析这段代码' }, '张三'),
+      msg('om_reply', 'text', { text: '对，特别是第二段' }, '李四'),
+      msg(CURRENT_ID, 'text', { text: '@bot 继续' }, '王五'),
+    ]);
+    downloadResourcesMock.mockResolvedValue({ attachments: [], needLogin: false });
+
+    const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
+    expect(out).toContain('话题上下文');
+    expect(out).toContain('共 2 条');
+    expect(out).toContain('张三: 请帮我分析这段代码');
+    expect(out).toContain('李四: 对，特别是第二段');
+    // Current @-reply must NOT appear in the context block (it's the prompt).
+    expect(out).not.toContain('继续');
+    expect(expandMergeForwardMock).not.toHaveBeenCalled();
+  });
+
+  it('downloads image resources and surfaces the attachment block per message', async () => {
+    listThreadMessagesMock.mockResolvedValue([
+      msg('om_root', 'image', { image_key: 'img_root' }, '张三'),
+      msg(CURRENT_ID, 'text', { text: '@bot' }, '李四'),
+    ]);
+    const attachments = [{ type: 'image', path: '/atts/app_x/om_root/img_root.jpg', name: 'img_root.jpg' }];
+    downloadResourcesMock.mockResolvedValue({ attachments, needLogin: false });
+
+    const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
+    expect(out).toContain('[图片 1]');
+    expect(out).toContain('<atts>img_root.jpg</atts>');
+    expect(downloadResourcesMock).toHaveBeenCalledWith('app_x', 'om_root', expect.any(Array));
+  });
+
+  it('keeps image and file numbering independent per message (post root)', async () => {
+    const post = {
+      zh_cn: {
+        title: '截图与文档',
+        content: [
+          [{ tag: 'text', text: '图：' }, { tag: 'img', image_key: 'img_aaa' }],
+          [{ tag: 'text', text: '附件：' }, { tag: 'file', file_key: 'file_bbb', file_name: 'spec.pdf' }],
+        ],
+      },
+    };
+    listThreadMessagesMock.mockResolvedValue([
+      msg('om_root', 'post', post, '张三'),
+      msg(CURRENT_ID, 'text', { text: '@bot' }, '李四'),
+    ]);
+    downloadResourcesMock.mockResolvedValue({
+      attachments: [
+        { type: 'image', path: '/a/1.jpg', name: 'img_aaa.jpg' },
+        { type: 'file', path: '/a/2.pdf', name: 'spec.pdf' },
+      ],
+      needLogin: false,
+    });
+
+    const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
+    expect(out).toContain('[图片 1]');
+    expect(out).toContain('[文件 1: spec.pdf]');
+  });
+
+  it('expands a merge_forward root into <forwarded_messages>', async () => {
+    listThreadMessagesMock.mockResolvedValue([
+      msg('om_root', 'merge_forward', {}, '张三'),
+      msg(CURRENT_ID, 'text', { text: '@bot' }, '李四'),
+    ]);
+    expandMergeForwardMock.mockImplementation(async (_a: string, _m: string, parsed: LarkMessage) => {
+      parsed.msgType = 'merge_forward_expanded';
+      parsed.content = '<forwarded_messages><msg from="A">前情提要</msg></forwarded_messages>';
+      return { extraResources: [{ type: 'image', key: 'img_xyz', name: 'img_xyz.jpg' }] satisfies MessageResource[] };
+    });
+    downloadResourcesMock.mockResolvedValue({ attachments: [{ type: 'image', path: '/a/x.jpg', name: 'img_xyz.jpg' }], needLogin: false });
+
+    const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
+    expect(out).toContain('<forwarded_messages>');
+    expect(out).toContain('前情提要');
+    expect(expandMergeForwardMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-resolves an interactive card root to its real body instead of the upgrade fallback', async () => {
+    const card = {
+      user_dsl: JSON.stringify({
+        header: { title: { tag: 'plain_text', content: '根消息卡片' } },
+        body: { elements: [{ tag: 'markdown', content: 'card body here' }] },
+      }),
+    };
+    listThreadMessagesMock.mockResolvedValue([
+      msg('om_root', 'interactive', card, '张三'),
+      msg(CURRENT_ID, 'text', { text: '@bot' }, '李四'),
+    ]);
+    downloadResourcesMock.mockResolvedValue({ attachments: [], needLogin: false });
+
+    const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
+    expect(out).toContain('card body here');
+  });
+
+  it('falls back to root-only when the thread list returns only the current message', async () => {
+    getMessageDetailMock.mockResolvedValue({ items: [msg('om_root', 'text', { text: '孤立的根' }, '张三')] });
+    downloadResourcesMock.mockResolvedValue({ attachments: [], needLogin: false });
+    listThreadMessagesMock.mockResolvedValue([msg(CURRENT_ID, 'text', { text: '@bot' }, '王五')]);
+
+    const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
+    expect(out).toContain('共 1 条');
+    expect(out).toContain('张三: 孤立的根');
+  });
+
+  it('falls back to root-only when listThreadMessages throws', async () => {
+    listThreadMessagesMock.mockRejectedValue(new Error('Lark 230002: not in chat'));
+    getMessageDetailMock.mockResolvedValue({ items: [msg('om_root', 'text', { text: '根内容' }, '张三')] });
+    downloadResourcesMock.mockResolvedValue({ attachments: [], needLogin: false });
+
+    const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
+    expect(out).toContain('张三: 根内容');
+  });
+
+  it('returns "" (best-effort) when both list and root-only fail', async () => {
+    listThreadMessagesMock.mockRejectedValue(new Error('list down'));
+    getMessageDetailMock.mockRejectedValue(new Error('get down'));
+    const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
+    expect(out).toBe('');
+  });
+
+  it('returns "" for an empty rootId', async () => {
+    const out = await buildTopicThreadContext('app_x', 'oc_chat', '', CURRENT_ID);
+    expect(out).toBe('');
+    expect(listThreadMessagesMock).not.toHaveBeenCalled();
+  });
+});

--- a/test/topic-root-context.test.ts
+++ b/test/topic-root-context.test.ts
@@ -1,23 +1,21 @@
 /**
  * Unit tests for buildTopicThreadContext — the first-turn helper that injects a
- * lightweight *hint* (not the full transcript) for a 普通群 topic the bot
- * otherwise wouldn't know exists. The hint points the CLI at `botmux history`
- * for on-demand retrieval, mirroring the quote-hint pattern.
+ * lightweight *hint* (not the full transcript, and with ZERO network fetch) for
+ * a 普通群 topic the bot otherwise wouldn't know exists. The hint points the CLI
+ * at `botmux history` for on-demand retrieval, mirroring the quote-hint pattern.
  *
- * Covers: count derivation (current @-reply excluded), the hint wording (points
- * at `botmux history`, carries the count, contains NO transcript/sender/body),
- * the no-eager-fetch guarantee (no attachment download / merge_forward /
- * card re-resolve), and the degradation paths (probe throws → countless hint
- * still emitted; empty thread → count 0 → countless hint; empty rootId → '').
+ * The function is now pure + synchronous: it takes only a locale and renders the
+ * localized hint. It performs no Lark API calls at all — the daemon gate already
+ * proved this is a topic reply, so there's nothing to probe. These tests lock
+ * that contract: the hint wording is right, it carries no transcript, and NONE
+ * of the (previously used) network helpers are ever invoked.
  *
  * Run:  pnpm vitest run test/topic-root-context.test.ts
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Only the metadata list is needed now. The old transcript path pulled in
-// getMessageDetail / expandMergeForward / resolveMergedCardContent /
-// downloadResources — we mock them too, purely to ASSERT they are never called
-// (the hint approach must not eagerly fetch or download anything).
+// Mock the (previously used) network / side-effecting deps purely to ASSERT
+// they are never called — the hint approach must do zero first-turn fetch.
 vi.mock('../src/im/lark/client.js', () => ({
   getMessageDetail: vi.fn(),
   listThreadMessages: vi.fn(),
@@ -35,18 +33,6 @@ import { getMessageDetail, listThreadMessages } from '../src/im/lark/client.js';
 import { expandMergeForward } from '../src/im/lark/merge-forward.js';
 import { downloadResources } from '../src/core/session-manager.js';
 
-function msg(messageId: string, msgType = 'text', body: unknown = { text: 'hi' }, senderName = '张三') {
-  return {
-    message_id: messageId,
-    msg_type: msgType,
-    create_time: '1700000000000',
-    sender: { id: 'ou_' + messageId, sender_type: 'user', sender_name: senderName },
-    body: { content: typeof body === 'string' ? body : JSON.stringify(body) },
-  };
-}
-
-const CURRENT_ID = 'om_current';
-
 const getMessageDetailMock = getMessageDetail as unknown as ReturnType<typeof vi.fn>;
 const listThreadMessagesMock = listThreadMessages as unknown as ReturnType<typeof vi.fn>;
 const expandMergeForwardMock = expandMergeForward as unknown as ReturnType<typeof vi.fn>;
@@ -59,81 +45,37 @@ beforeEach(() => {
   downloadResourcesMock.mockReset();
 });
 
-describe('buildTopicThreadContext (hint mode)', () => {
-  it('emits a hint carrying the prior-message count, excluding the current @-reply', async () => {
-    // Thread (asc): root, one prior reply, then the current @-reply → 2 prior.
-    listThreadMessagesMock.mockResolvedValue([
-      msg('om_root', 'text', { text: '请帮我分析这段代码' }, '张三'),
-      msg('om_reply', 'text', { text: '对，特别是第二段' }, '李四'),
-      msg(CURRENT_ID, 'text', { text: '@bot 继续' }, '王五'),
-    ]);
-
-    const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
-    expect(out).toContain('话题');
-    expect(out).toContain('2 条');
-    expect(out).toContain('botmux history');
-  });
-
-  it('is a HINT, not a transcript: no message bodies/senders are inlined', async () => {
-    listThreadMessagesMock.mockResolvedValue([
-      msg('om_root', 'text', { text: '机密的话题正文内容' }, '张三'),
-      msg('om_reply', 'text', { text: '另一条前情回复' }, '李四'),
-      msg(CURRENT_ID, 'text', { text: '@bot' }, '王五'),
-    ]);
-
-    const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
-    // The transcript content must NOT be replayed into the prompt.
-    expect(out).not.toContain('机密的话题正文内容');
-    expect(out).not.toContain('另一条前情回复');
-    expect(out).not.toContain('张三:');
-    expect(out).not.toContain('李四:');
-  });
-
-  it('never eagerly fetches: no attachment download / merge_forward / card re-resolve / root detail', async () => {
-    listThreadMessagesMock.mockResolvedValue([
-      msg('om_root', 'merge_forward', {}, '张三'),
-      msg('om_img', 'image', { image_key: 'img_x' }, '李四'),
-      msg('om_card', 'interactive', { user_dsl: '{}' }, '王五'),
-      msg(CURRENT_ID, 'text', { text: '@bot' }, '赵六'),
-    ]);
-
-    const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
-    expect(out).toContain('3 条');
-    // The whole point of the hint approach: no eager fetch/download work.
-    expect(downloadResourcesMock).not.toHaveBeenCalled();
-    expect(expandMergeForwardMock).not.toHaveBeenCalled();
-    expect(getMessageDetailMock).not.toHaveBeenCalled();
-  });
-
-  it('runs a single metadata probe with the right args (no per-message fan-out)', async () => {
-    listThreadMessagesMock.mockResolvedValue([
-      msg('om_root'), msg('om_r1'), msg('om_r2'), msg(CURRENT_ID),
-    ]);
-    const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
-    expect(listThreadMessagesMock).toHaveBeenCalledTimes(1);
-    expect(listThreadMessagesMock).toHaveBeenCalledWith('app_x', 'oc_chat', 'om_root');
-    expect(out).toContain('3 条');
-  });
-
-  it('falls back to the countless hint when the list has only the current @-reply', async () => {
-    listThreadMessagesMock.mockResolvedValue([msg(CURRENT_ID, 'text', { text: '@bot' }, '王五')]);
-    const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
-    // count === 0 → countless variant, but the signal + tool pointer remain.
-    expect(out).toContain('botmux history');
-    expect(out).not.toContain('0 条');
-  });
-
-  it('still emits the countless hint when listThreadMessages throws (signal never dropped)', async () => {
-    listThreadMessagesMock.mockRejectedValue(new Error('Lark 230002: not in chat'));
-    const out = await buildTopicThreadContext('app_x', 'oc_chat', 'om_root', CURRENT_ID);
+describe('buildTopicThreadContext (hint mode, zero-fetch)', () => {
+  it('emits a hint that points the CLI at botmux history', () => {
+    const out = buildTopicThreadContext();
     expect(out).toContain('话题');
     expect(out).toContain('botmux history');
-    expect(getMessageDetailMock).not.toHaveBeenCalled();
+    expect(out.endsWith('\n')).toBe(true);
   });
 
-  it('returns "" for an empty rootId (gate off — nothing to hint about)', async () => {
-    const out = await buildTopicThreadContext('app_x', 'oc_chat', '', CURRENT_ID);
-    expect(out).toBe('');
+  it('is a HINT, not a transcript: carries no count and no message bodies/senders', () => {
+    const out = buildTopicThreadContext();
+    // No exact count is claimed (the old {count} floor-count is gone).
+    expect(out).not.toMatch(/\d+\s*条/);
+    expect(out).not.toContain(':'); // no "sender: body" transcript lines
+  });
+
+  it('performs ZERO first-turn network fetch (the core of the P2 fix)', () => {
+    buildTopicThreadContext();
     expect(listThreadMessagesMock).not.toHaveBeenCalled();
+    expect(getMessageDetailMock).not.toHaveBeenCalled();
+    expect(expandMergeForwardMock).not.toHaveBeenCalled();
+    expect(downloadResourcesMock).not.toHaveBeenCalled();
+  });
+
+  it('is synchronous (returns a string, not a Promise)', () => {
+    const out = buildTopicThreadContext();
+    expect(typeof out).toBe('string');
+  });
+
+  it('renders the English hint under an en locale', () => {
+    const out = buildTopicThreadContext('en');
+    expect(out).toContain('botmux history');
+    expect(out.toLowerCase()).toContain('topic');
   });
 });


### PR DESCRIPTION
## 背景

飞书普通群里，用户对一条已有消息 X「发起话题」、话题内 @bot。Lark 给 @ 回复带上 `root_id=X` + `thread_id`，daemon 把会话锚到 X、`handleNewTopic` 开新会话。但 X 以及话题里 @ 之前的其它回复都是更早的群消息（无 @ 被忽略、未留存），bot 首轮只看到 @ 回复正文，**既看不到话题上下文，也没有任何信号表明存在话题根 + 前情** —— 很可能直接答偏，也想不到该去查历史。

代码佐证：`event-dispatcher.ts` 注释明确话题根消息带 `thread_id` 无 `root_id`、后续回复才带 `root_id` 走 real-thread 分支；`handleNewTopic` 首轮拼 prompt 时只含当前回复。

对照 quote 机制：用户主动引用某条消息时，daemon 会注入一行 `[用户引用了消息 用 botmux quoted <id> 查看]` hint，让 bot 按需自取 —— topic-root 场景缺的正是这个「信号」。

## 改动

### feat：普通群话题首回合注入话题 hint（主改动，零网络请求）

- 新增 `src/im/lark/topic-root-context.ts`：`buildTopicThreadContext(locale)` 是一个**纯同步、零 Lark API 调用**的函数，返回一行 hint —— 提示 CLI「本条是话题内回复，此话题在你之前已有前情消息，需要时用 `botmux history` 查看（默认读本话题，`--limit` 控条数，`botmux quoted <id>` 取附件）」。不预取、不下载、不渲染 transcript。
- `daemon.ts` `handleNewTopic`：仅当入站是话题内回复（`parsed.rootId && parsed.rootId !== parsed.messageId && !ctx.forwardSeedData`，对齐 event-dispatcher 的 real-thread 路由）才注入。hint **双 lane 下发**：既进 legacy `promptContent`，也进 codex-app 结构化 sidecar `codexAppMessageContext`（否则 codex-app clean-input bot 走 sidecar 会静默丢掉 hint）。仅首轮 —— 后续 `handleThreadReply` 回合 CLI 已在首轮拿到 hint。
- i18n 新增 `prompt.topic_context`（无 count 文案）。

**为什么是 hint 而非全量注入**（经 review 讨论定型）：全量拉取整条话题历史存在三个问题 —— ① 短话题把全部消息当噪音塞进 prompt；② 长话题 `listThreadMessages` 按 `ByCreateTimeAsc + slice(50)` 只取**最旧 50 条**，用户很晚才 @ 时恰恰看不到离 @ 最近（最相关）的讨论，且把 50 当精确总数是误导；③ 首轮无条件下载所有历史图片/文件落盘，多数用不上。且 `listThreadMessages` 解不到 `thread_id` 时会 fallback 翻整个大群历史。既然 daemon gate 已证明这是话题回复，首轮无需任何网络请求 —— 注入一行 hint、让 CLI 按需走 `botmux history` 即可，与现有 quote 机制的「提示 + 按需」模式一致。

### fix：dashboard 构建适配 `@types/react@19`（顺带解锁 build）

`@types/react@19` 移除了全局 JSX 命名空间，dashboard 下 13 个 `.tsx` 仍用全局 `JSX.Element`，导致 `tsc` TS2503、`pnpm build` 失败（master 上同样炸）。每个受影响文件补 `import type React from 'react';`，把 122 处 `JSX.Element` → `React.JSX.Element`。仅类型引用调整，运行时产物不变。

## 影响范围评估

- **跨 CLI**：hint 一次性拼好，双 lane 覆盖 legacy prompt 与 codex-app 结构化 sidecar；无逐适配器改动。
- **跨后端**：PtyBackend / TmuxBackend 接收同一 prompt。
- **跨 IM**：话题为飞书独有，仅 lark 路径。
- **跨会话类型**：话题群新话题（根即入站，`rootId` 空/==msg 不触发）；普通群仅 real-thread 回复触发；adopt/restore 不走 handleNewTopic；coalesced forward 已自带上下文，gate 跳过；v3 workflow 独立路径不覆盖。
- **公共层**：动 `daemon.ts` + 新增 im/lark helper + i18n；helper 纯同步零副作用，回归面极低。

## 测试验证

- `pnpm build` ✅
- `test/topic-root-context.test.ts` 5 项 ✅（hint 指向 `botmux history` / 无 count / 无 transcript / **断言 `listThreadMessages`·`getMessageDetail`·`expandMergeForward`·`downloadResources` 全部未被调用**（zero-fetch 锁）/ 同步返回 string / en locale 渲染英文）
- `test/daemon-codex-app-workflow-wiring.test.ts` 2 项 ✅（双 lane 契约锁）
- 全量 `pnpm test`：731 files passed / 1 skipped，唯一失败 `group-join-shared-routing` 为 `beforeAll` 10s hook 超时的既有 flake（单跑 5/5 绿、与本改动零关联；双审均独立复现同一 flake）。

## 提交记录

- `4cb30197` fix(dashboard): 迁移 JSX.Element 至 React.JSX.Element 适配 @types/react@19
- `1f186e6c` feat(lark): 普通群话题首回合补全话题上下文（初版：全量 transcript）
- `8afd466e` fix(lark): 话题上下文补进 codex-app sidecar lane（P2：双 lane 下发）
- `76da00a5` refactor(lark): 话题上下文补全改为轻量 hint（按需 botmux history）
- `9597cf2c` refactor(lark): 话题 hint 删除首轮网络探测（零 fetch）

> 说明：初版为「全量 transcript + 下载附件 + count」，经 review 讨论逐步收敛为**零 fetch 的一行 hint**。commit 历史保留了演进过程，最终行为以上文「改动」一节为准。

## Review

- Claude 首审 + Codex 复审双审收敛，代码层面均 APPROVE。
- 未合码，等 owner 最终确认。
