### PR TITLE
fix(dashboard): 为复制操作增加降级兜底

### DIFF
--- a/src/dashboard/web/clipboard.ts
+++ b/src/dashboard/web/clipboard.ts
@@ -1,0 +1,41 @@
+export async function copyText(text: string, promptLabel?: string): Promise<boolean> {
+  try {
+    if (typeof navigator !== 'undefined' && typeof navigator.clipboard?.writeText === 'function') {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Fall through to the legacy path for denied/unsupported async clipboard.
+  }
+  if (copyTextLegacy(text)) return true;
+  if (promptLabel && typeof window !== 'undefined' && typeof window.prompt === 'function') {
+    window.prompt(promptLabel, text);
+  }
+  return false;
+}
+
+function copyTextLegacy(text: string): boolean {
+  if (
+    typeof document === 'undefined'
+    || !document.body
+    || typeof document.createElement !== 'function'
+    || typeof document.execCommand !== 'function'
+  ) {
+    return false;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.cssText = 'position:fixed;top:0;left:0;width:1px;height:1px;opacity:0';
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  try {
+    return document.execCommand('copy');
+  } catch {
+    return false;
+  } finally {
+    textarea.remove();
+  }
+}

--- a/src/dashboard/web/connectors-page.tsx
+++ b/src/dashboard/web/connectors-page.tsx
@@ -4,6 +4,7 @@ import { jget, jsend } from './dashboard-api.js';
 import { mountReactPage, type PageDisposer } from './react-mount.js';
 import { useT } from './react-hooks.js';
 import { WebhookLogsContent } from './webhook-logs-page.js';
+import { copyText } from './clipboard.js';
 
 interface Connector {
   id: string;
@@ -621,12 +622,14 @@ function ConnectorsPage(props: { tab: ConnectorsTab }) {
   }
 
   function copyConnectorUrl(connector: Connector): void {
-    void navigator.clipboard?.writeText(webhookUrl(connector.id));
-    setCopiedId(connector.id);
-    if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
-    copyTimerRef.current = setTimeout(() => {
-      if (mountedRef.current) setCopiedId(null);
-    }, 1200);
+    void copyText(webhookUrl(connector.id), tr('connectors.copy')).then(copied => {
+      if (!copied || !mountedRef.current) return;
+      setCopiedId(connector.id);
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => {
+        if (mountedRef.current) setCopiedId(null);
+      }, 1200);
+    });
   }
 
   return (

--- a/src/dashboard/web/groups-page.tsx
+++ b/src/dashboard/web/groups-page.tsx
@@ -12,6 +12,7 @@ import {
 import { mountReactPage, type PageDisposer } from './react-mount.js';
 import { useT } from './react-hooks.js';
 import { botOrbStyle, chatAvatarUrlFor } from './ui.js';
+import { copyText } from './clipboard.js';
 import {
   CreateActionButton,
   DropdownMenu,
@@ -368,9 +369,11 @@ function CreateDialog(props: {
             type="button"
             data-copy={chatId}
             onClick={() => {
-              void navigator.clipboard.writeText(chatId);
-              setCopied(true);
-              props.setTimer(() => setCopied(false), 800);
+              void copyText(chatId, tr('sessions.copy')).then(didCopy => {
+                if (!didCopy) return;
+                setCopied(true);
+                props.setTimer(() => setCopied(false), 800);
+              });
             }}
           >
             {copied ? tr('sessions.copied') : tr('sessions.copy')}

--- a/src/dashboard/web/sessions-page.tsx
+++ b/src/dashboard/web/sessions-page.tsx
@@ -23,6 +23,7 @@ import {
 } from '../session-cleanup.js';
 import { mountReactPage, type PageDisposer } from './react-mount.js';
 import { useStoreSelector, useT } from './react-hooks.js';
+import { copyText } from './clipboard.js';
 import {
   KANBAN_TEAM_STORAGE_KEY,
   normalizeHiddenTableColumns,
@@ -385,9 +386,11 @@ function CopyButton(props: { value: string }): JSX.Element {
       type="button"
       data-copy={props.value}
       onClick={() => {
-        void navigator.clipboard.writeText(props.value);
-        setCopied(true);
-        window.setTimeout(() => setCopied(false), 800);
+        void copyText(props.value, t('sessions.copy')).then(didCopy => {
+          if (!didCopy) return;
+          setCopied(true);
+          window.setTimeout(() => setCopied(false), 800);
+        });
       }}
     >
       {copied ? t('sessions.copied') : t('sessions.copy')}

--- a/src/dashboard/web/sessions.ts
+++ b/src/dashboard/web/sessions.ts
@@ -7,6 +7,7 @@ import {
 } from './ui.js';
 import { CLI_OPTIONS } from '../../setup/bot-config-editor.js';
 import { sessionTerminalHref } from './session-terminal.js';
+import { copyText } from './clipboard.js';
 
 export function tokenCount(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
@@ -302,17 +303,12 @@ export async function copySpawnCommand(s: any, btn?: HTMLButtonElement): Promise
       if (r.status !== 401) alert(`${t('sessions.copyCommandFail')}: ${body?.error ?? r.status}`);
       return;
     }
-    try {
-      await navigator.clipboard.writeText(body.command);
+    if (await copyText(body.command, t('sessions.copyCommand'))) {
       if (btn) {
         const prev = btn.textContent;
         btn.textContent = t('sessions.copyCommandDone');
         setTimeout(() => { if (prev !== null) btn.textContent = prev; }, 1500);
       }
-    } catch {
-      // Clipboard API unavailable (non-secure context) — fall back to a prompt
-      // so the user can still select + copy the command manually.
-      window.prompt(t('sessions.copyCommand'), body.command);
     }
   } catch (e) {
     alert(`${t('sessions.copyCommandFail')}: ${e}`);

--- a/src/dashboard/web/webhook-logs-page.tsx
+++ b/src/dashboard/web/webhook-logs-page.tsx
@@ -3,6 +3,7 @@ import { DropdownMenu, LoadingState, dropdownLabel } from './dashboard-component
 import { jget } from './dashboard-api.js';
 import { mountReactPage, type PageDisposer } from './react-mount.js';
 import { useT } from './react-hooks.js';
+import { copyText } from './clipboard.js';
 
 type LogStatus = '' | 'ok' | 'error';
 type TimeWindow = '24h' | '7d' | '30d' | 'all';
@@ -260,7 +261,8 @@ export function WebhookLogsContent(props: { embedded?: boolean } = {}): JSX.Elem
 
   async function copySelected(): Promise<void> {
     if (!selected) return;
-    await navigator.clipboard?.writeText(JSON.stringify(selected, null, 2));
+    const didCopy = await copyText(JSON.stringify(selected, null, 2), tr('webhookLogs.copyJson'));
+    if (!didCopy) return;
     setCopied(true);
     setTimeout(() => mountedRef.current && setCopied(false), 1200);
   }

--- a/test/dashboard-clipboard.test.ts
+++ b/test/dashboard-clipboard.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { copyText } from '../src/dashboard/web/clipboard.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('dashboard clipboard helper', () => {
+  it('copies via textarea when navigator.clipboard is unavailable', async () => {
+    const prompt = vi.fn();
+    const execCommand = vi.fn(() => true);
+    const textarea = {
+      value: '',
+      style: { cssText: '' },
+      setAttribute: vi.fn(),
+      focus: vi.fn(),
+      select: vi.fn(),
+      remove: vi.fn(),
+    };
+    const appendChild = vi.fn();
+    vi.stubGlobal('navigator', {});
+    vi.stubGlobal('window', { prompt });
+    vi.stubGlobal('document', {
+      body: { appendChild },
+      createElement: vi.fn(() => textarea),
+      execCommand,
+    });
+
+    await expect(copyText('{"ok":true}', '复制')).resolves.toBe(true);
+
+    expect(textarea.value).toBe('{"ok":true}');
+    expect(appendChild).toHaveBeenCalledWith(textarea);
+    expect(textarea.select).toHaveBeenCalled();
+    expect(execCommand).toHaveBeenCalledWith('copy');
+    expect(textarea.remove).toHaveBeenCalled();
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  it('falls back to prompt when direct copy is unavailable', async () => {
+    const prompt = vi.fn();
+    vi.stubGlobal('navigator', {});
+    vi.stubGlobal('window', { prompt });
+
+    await expect(copyText('{"ok":true}', '复制')).resolves.toBe(false);
+
+    expect(prompt).toHaveBeenCalledWith('复制', '{"ok":true}');
+  });
+});


### PR DESCRIPTION
## 改动内容

- 新增 dashboard 侧 `copyText` 统一复制工具，优先使用 `navigator.clipboard.writeText`，失败或不可用时降级到隐藏 textarea + `document.execCommand('copy')`，最后再用 prompt 让用户手动复制。
- 将连接器 Webhook URL、群组 chat id、会话复制按钮、spawn command、Webhook 日志 JSON 复制等入口统一接入 `copyText`。
- 新增 `test/dashboard-clipboard.test.ts`，覆盖 Clipboard API 不可用时的 textarea 降级和 prompt 兜底路径。

## 为什么

部分 dashboard 访问场景可能不是安全上下文（例如，在开发机上启动 dashboard，在本地使用 ip 地址访问链接），或浏览器 Clipboard API 被禁用/拒绝，原先直接调用 `navigator.clipboard.writeText` 会导致复制失败且没有可靠兜底。统一封装后，各复制入口在受限环境下仍能尽量完成复制或给出手动复制方式。

## 影响面

- 影响 dashboard web 前端复制行为，涉及连接器、群组、会话列表/命令复制、Webhook 日志页面。
- 不涉及 daemon、Worker、CLI 适配器、PTY/Tmux 后端、飞书消息路由等公共运行链路。
- 对支持 Clipboard API 的正常浏览器路径行为保持不变；受影响的是 Clipboard API 不可用或调用失败的浏览器/访问上下文。
- 无视觉样式调整，仅复制交互行为变化；不附截图。

## 测试验证

- `pnpm test -- test/dashboard-clipboard.test.ts`
  - 结果：1 个测试文件通过，2 个用例通过。
- `pnpm build`
  - 结果：通过，包含 domain audit、tsc、dashboard bundle、build audit。