### PR TITLE
fix(cli): bots list 在读隔离下从 send-cred 注册自身，避免静默返回空花名册

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8838,8 +8838,14 @@ async function cmdBots(sub: string, rest: string[]): Promise<void> {
   }
 
   const sessionIdArg = argValue(rest, '--session-id');
-  // 与 history/quoted 同一前奏：本地会话解析 + riff sandbox env 合成会话兜底
-  //（远端沙箱无 sessions.json/bots.json 时 `botmux bots list` 照常可用）。
+  // 与 history/quoted 同一前奏：先从本 bot 自己的 send-cred 文件注册，让 Lark client
+  // 在**不读被 deny 的 bots.json** 的前提下可用，再做会话解析 + riff sandbox env
+  // 合成会话兜底。漏掉 registerSelfFromCredFile() 时读隔离 bot 的
+  // `botmux bots list` 会在 getBotClient() 上抛 "Bot not registered"，
+  // listChatBotMembers() 把它降级成 legacy discovery（configured 行同样来自
+  // bots.json）→ 返回 `total: 0`。**失败形态是静默的**：沙盒 bot 拿到空花名册会
+  // 按"只 @ mentionable 的"判定群里没人可 @，多 bot 协作直接不发生且不报错。
+  await registerSelfFromCredFile();
   const { sid, larkAppId: resolvedAppId, session: s } = await resolveSessionAppId(sessionIdArg);
 
   const appId = resolvedAppId;

--- a/test/bots-list-cred-registration.test.ts
+++ b/test/bots-list-cred-registration.test.ts
@@ -87,6 +87,11 @@ describe('botmux bots list under read isolation', () => {
       HOME: home,
       SESSION_DATA_DIR: dataDir,
       BOTMUX_LARK_APP_ID: APP_ID,
+      // Pin the members/bots discovery path ON. Without this the child inherits
+      // the flag from the parent/CI env; if it happens to be 'false', the code
+      // skips listChatBotsViaMembersBots() entirely — so the pre-fix version
+      // never reaches getBotClient() and this regression would falsely pass.
+      BOTMUX_LARK_LIST_BOTS_API_ENABLED: 'true',
     });
 
     const combined = `${stdout}\n${stderr}`;

--- a/test/bots-list-cred-registration.test.ts
+++ b/test/bots-list-cred-registration.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression: `botmux bots list` must register the calling bot from its own
+ * send-cred file before touching the Lark client, exactly like cmdSend /
+ * cmdHistory / cmdQuoted do.
+ *
+ * Under read isolation bots.json is Seatbelt-denied, so the bot registry starts
+ * empty and getBotClient() throws `Bot not registered: <appId>`. listChatBotMembers()
+ * swallows that into a legacy-discovery fallback whose `configured` rows also come
+ * from bots.json — so the command answered `total: 0` instead of erroring. The
+ * failure mode is SILENT: a sandboxed bot reads an empty roster as "nobody here to
+ * @-mention" and multi-bot collaboration simply never happens.
+ *
+ * The assertion is deliberately negative (no `Bot not registered`) rather than an
+ * exact roster: with a throwaway app secret the API call fails either way, so
+ * this stays offline-safe while still failing when the registration is missing.
+ */
+import { spawn } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const CLI_PATH = join(__dirname, '..', 'src', 'cli.ts');
+const APP_ID = 'cli_isolated_roster';
+const SESSION_ID = '11111111-2222-3333-4444-555555555555';
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function runCli(args: string[], env: NodeJS.ProcessEnv) {
+  return new Promise<{ status: number | null; stdout: string; stderr: string }>((resolve, reject) => {
+    const child = spawn(process.execPath, ['--import', 'tsx', CLI_PATH, ...args], {
+      env: { ...process.env, ...env, BOTMUX_WORKFLOW: '' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', c => { stdout += c; });
+    child.stderr.on('data', c => { stderr += c; });
+    child.once('error', reject);
+    child.once('close', status => resolve({ status, stdout, stderr }));
+  });
+}
+
+/** Read-isolated layout: per-bot session file + send-cred inside BOT_HOME, NO bots.json. */
+function seedIsolatedBot(): { home: string; dataDir: string } {
+  const root = mkdtempSync(join(tmpdir(), 'botmux-bots-list-cred-'));
+  tempDirs.push(root);
+  const home = join(root, 'home');
+  const dataDir = join(home, '.botmux', 'data');
+  const botHome = join(home, '.botmux', 'bots', APP_ID);
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(botHome, { recursive: true });
+
+  writeFileSync(join(dataDir, `sessions-${APP_ID}.json`), JSON.stringify({
+    [SESSION_ID]: {
+      sessionId: SESSION_ID,
+      chatId: 'oc_isolated_roster_chat',
+      chatType: 'group',
+      rootMessageId: '',
+      sessionScope: 'chat',
+      title: 'roster regression',
+      status: 'active',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      larkAppId: APP_ID,
+    },
+  }));
+
+  // The only credential source available to an isolated bot.
+  writeFileSync(join(botHome, 'send-cred.json'), JSON.stringify({
+    larkAppSecret: 'throwaway-secret-for-registration-only',
+    brand: 'feishu',
+  }));
+
+  return { home, dataDir };
+}
+
+describe('botmux bots list under read isolation', () => {
+  it('registers self from send-cred instead of failing with "Bot not registered"', async () => {
+    const { home, dataDir } = seedIsolatedBot();
+
+    const { stdout, stderr } = await runCli(['bots', 'list', '--session-id', SESSION_ID], {
+      HOME: home,
+      SESSION_DATA_DIR: dataDir,
+      BOTMUX_LARK_APP_ID: APP_ID,
+    });
+
+    const combined = `${stdout}\n${stderr}`;
+    expect(combined).not.toContain('Bot not registered');
+    // Still answers with a well-formed roster payload for the right session.
+    const payload = JSON.parse(stdout);
+    expect(payload.sessionId).toBe(SESSION_ID);
+    expect(Array.isArray(payload.bots)).toBe(true);
+  }, 30_000);
+});


### PR DESCRIPTION
## 问题

`cmdBots()`（`src/cli.ts`）的注释写着「与 history/quoted 同一前奏」，但实际漏了那一步：

| 命令 | `registerSelfFromCredFile()` |
|-|-|
| `botmux send` | ✅ cli.ts:5633 |
| `botmux history` | ✅ cli.ts:5788 |
| `botmux quoted` | ✅ cli.ts:6338 |
| `botmux bots list` | ❌ 缺失 |

读隔离（`sandbox: true` / `readIsolation: true`）下 `bots.json` 被 Seatbelt deny，bot registry 起来是空的，于是：

`getBotClient()` 抛 `Bot not registered: <appId>` → `listChatBotMembers()` 把它降级成 legacy bot discovery（而 legacy 的 `configured` 行同样来自 `bots.json`）→ 命令返回 `total: 0`，**不报错**。

## 为什么值得修

**失败形态是静默的**，这比「少一个命令可用」严重：沙盒 bot 拿到空花名册后，会按「只 @ `mentionable: true` 的」规则老实判定"这个群里没有可以 @ 的 bot"，于是**多 bot 协作直接不发生，且不产生任何错误**。

真机实测（dev-beta，群里 8 个 bot）：

```
# 沙盒 + 读隔离的 bot
$ botmux bots list
[WARN] members/bots failed for cli_xxx in oc_xxx; falling back to legacy bot discovery: Bot not registered: cli_xxx
{"sessionId":"...","chatId":"oc_...","bots":[],"total":0}

# 同一个群、非沙盒 bot
$ botmux bots list
... "total": 8
```

那次协作里沙盒 bot 全程只能靠对端在消息正文里硬塞 open_id 才 @ 得到人。

同族前案就在代码注释里：`registerSelfFromCredFile` 上方原文是「Missing this was why a sandboxed isolated bot's `botmux quoted` failed "Bot not registered"」—— 当时补了 send / history / quoted 三处，`bots list` 漏网。

## 改动

1. `cmdBots()` 在会话解析前 `await registerSelfFromCredFile()`，并把注释改成描述实际行为 + 记录这个静默失败链。
2. 新增 `test/bots-list-cred-registration.test.ts`：按读隔离布局（per-bot `sessions-<appId>.json` + BOT_HOME 里的 `send-cred.json`，**无** `bots.json`）跑真实 CLI。

断言刻意取**反向**（输出里不出现 `Bot not registered`）而不是断言具体花名册内容：一次性 app secret 下 API 调用无论如何都会失败，这样测试离线可跑、又能在缺修复时失败。

**已做变异验证**（不是只看测试变绿）：抠掉这一行后测试失败，并复现生产里同一条 WARN：

```
[WARN] members/bots failed for cli_isolated_roster in oc_isolated_roster_chat;
       falling back to legacy bot discovery: Bot not registered: cli_isolated_roster
```

## 刻意不做

- **不动 `bots-info.json` 那条 catch 兜底。** 排查中一度以为它是死代码，核实后否掉了：daemon 会原子写它（`im/lark/event-dispatcher.ts` 的 upsert、以及启动时探测 bot open_id 落盘），`fs-policy` 也按 readOnly 给沙盒放行。本次只补注册这一步。
- 不把这段前奏抽成共用 helper。四处调用点各自的上下文不同（riff 合成会话、`--session-id` 解析时机），抽取的收益不足以抵掉改动面。

## 验证

- `npx tsc --noEmit` 通过
- `test/bots-list-cred-registration.test.ts` + `test/bots-list-output.test.ts` 全过
- 变异测试：移除修复 → 新测试失败（见上）
