### PR TITLE
fix(core): 修 botmux send 因 PID 复用串到别的 bot 旧会话

### DIFF
--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -12,7 +12,7 @@ import * as sessionStore from '../services/session-store.js';
 import * as messageQueue from '../services/message-queue.js';
 import { downloadMessageResource, listChatBotMembers, UserTokenMissingError } from '../im/lark/client.js';
 import { logger } from '../utils/logger.js';
-import { forkWorker, sendWorkerInput, forkAdoptWorker, adoptSandboxBlocked, killStalePids, getCurrentCliVersion, restoreUsageLimitRuntimeState, setActiveSessionSafe, isRelayableRealSession, closeSession, getActiveSessionsRegistry, suspendWorker } from './worker-pool.js';
+import { forkWorker, sendWorkerInput, forkAdoptWorker, adoptSandboxBlocked, killStalePids, sweepDeadPidMarkers, getCurrentCliVersion, restoreUsageLimitRuntimeState, setActiveSessionSafe, isRelayableRealSession, closeSession, getActiveSessionsRegistry, suspendWorker } from './worker-pool.js';
 import { createCliAdapterSync } from '../adapters/cli/registry.js';
 import { buildBotmuxShellHints } from '../adapters/cli/shared-hints.js';
 import {
@@ -1208,6 +1208,12 @@ export async function staggeredRecoveryFork(
 export async function restoreActiveSessions(activeSessions: Map<string, DaemonSession>): Promise<void> {
   const sessions = sessionStore.listSessions();
   const active = sessions.filter(s => s.status === 'active');
+
+  // Sweep dead CLI-pid markers regardless of whether we have sessions to restore:
+  // the landmine files (recycled-PID misroute source) accumulate across every
+  // daemon run, and a run with zero active sessions is still a fresh start that
+  // should clean up after prior crashes/SIGKILLs.
+  sweepDeadPidMarkers();
 
   if (active.length === 0) {
     logger.info('No active sessions to restore');

--- a/src/core/session-marker.ts
+++ b/src/core/session-marker.ts
@@ -130,15 +130,6 @@ function parseIdentityBoundSessionMarker(raw: string): IdentityBoundSessionMarke
   }
 }
 
-export function parseSessionMarker(raw: string): AncestorSessionContext {
-  const parsed = parseIdentityBoundSessionMarker(raw);
-  return {
-    sessionId: parsed.sessionId,
-    ...(parsed.turnId ? { turnId: parsed.turnId } : {}),
-    ...(parsed.dispatchAttempt !== undefined ? { dispatchAttempt: parsed.dispatchAttempt } : {}),
-  };
-}
-
 /**
  * Strong marker lookup for authority-bearing commands. Unlike the legacy
  * read/reply resolver, this requires the worker's JSON procStart binding and
@@ -195,12 +186,55 @@ export function findAuthenticatedAncestorSessionContext(
 }
 
 /**
+ * Is a process-tree marker safe to treat as THIS process's session origin?
+ *
+ * Two ways a marker lies, both seen in production:
+ *  - Recycled PID: the file was written by a since-exited process, and the kernel
+ *    later handed the same PID number to an unrelated process now sitting in our
+ *    ancestry. When the marker carries a procStart birth-stamp we can prove this
+ *    directly (the live process's start ≠ the recorded one).
+ *  - Stale/foreign session: a legacy marker (written before procStart existed) on
+ *    a reused PID names a DIFFERENT session than `BOTMUX_SESSION_ID`. That env var
+ *    is injected at spawn, never mutates, and is inherited across every reparent,
+ *    so it is ground truth for the session this process belongs to; a marker that
+ *    disagrees with it is not ours and cannot be verified any other way.
+ *
+ * This exact pair leaked a PR review across bots: a June legacy marker (no
+ * procStart) on a recycled low PID routed a `botmux send` into a different bot's
+ * long-closed session. The recycled process was alive, so liveness alone said
+ * nothing — only the birth-stamp mismatch OR the env disagreement exposes it.
+ */
+function isTrustworthyAncestorMarker(
+  pid: number,
+  marker: IdentityBoundSessionMarker,
+  envSessionId: string | undefined,
+): boolean {
+  if (marker.procStart && readProcessStartIdentity(pid) !== marker.procStart) return false;
+  if (envSessionId && marker.sessionId !== envSessionId) return false;
+  return true;
+}
+
+/**
  * Walk the process tree looking for a CLI-pid marker written by the botmux
  * worker. Legacy markers contain just the session id; new markers are JSON and
  * also carry the current inbound turn id so long-lived CLI processes can route
  * `botmux send` to the correct topic alias on the 2nd/Nth turn.
+ *
+ * A matched marker is honored only when `isTrustworthyAncestorMarker` clears it
+ * against `envSessionId` (the caller threads in the inherited BOTMUX_SESSION_ID;
+ * resolveSessionContext and the v3 relay client both pass it explicitly). When
+ * omitted, only the procStart birth-stamp check applies — the function never
+ * reads the ambient global env itself, so it stays pure and its callers decide
+ * what "ground truth" is. An untrustworthy marker — empty, a recycled PID, or a
+ * different session than the authoritative env — is skipped and the walk keeps
+ * climbing; a genuine ancestor marker may sit higher, and if none does the caller
+ * falls back to the env id.
  */
-export function findAncestorSessionContext(dataDir: string, startPid: number = process.ppid): AncestorSessionContext | null {
+export function findAncestorSessionContext(
+  dataDir: string,
+  startPid: number = process.ppid,
+  envSessionId?: string,
+): AncestorSessionContext | null {
   const markersDir = join(dataDir, '.botmux-cli-pids');
   if (!existsSync(markersDir)) return null;
 
@@ -208,7 +242,17 @@ export function findAncestorSessionContext(dataDir: string, startPid: number = p
   for (let depth = 0; depth < 8 && pid > 1; depth++) {
     const markerPath = join(markersDir, String(pid));
     if (existsSync(markerPath)) {
-      try { return parseSessionMarker(readFileSync(markerPath, 'utf-8')); } catch { return { sessionId: '' }; }
+      let marker: IdentityBoundSessionMarker;
+      try { marker = parseIdentityBoundSessionMarker(readFileSync(markerPath, 'utf-8')); }
+      catch { return { sessionId: '' }; }
+      if (marker.sessionId && isTrustworthyAncestorMarker(pid, marker, envSessionId)) {
+        return {
+          sessionId: marker.sessionId,
+          ...(marker.turnId ? { turnId: marker.turnId } : {}),
+          ...(marker.dispatchAttempt !== undefined ? { dispatchAttempt: marker.dispatchAttempt } : {}),
+        };
+      }
+      // Marker present but not ours: keep climbing (see doc comment above).
     }
     const parent = readParentPid(pid);
     if (!parent) break;
@@ -240,7 +284,9 @@ export function resolveSessionContext(
   envSessionId: string | undefined,
   startPid: number = process.ppid,
 ): AncestorSessionContext | null {
-  const fromMarker = findAncestorSessionContext(dataDir, startPid);
+  // Pass envSessionId as ground truth so the walk rejects a recycled-PID marker
+  // that names a different (stale/foreign) session than the one we belong to.
+  const fromMarker = findAncestorSessionContext(dataDir, startPid, envSessionId);
   // A live process-tree marker is the primary source whenever it is visible.
   // Per-session capability snapshots may survive SIGKILL or a later config
   // change that disables read isolation; they are only a fallback for the

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -4939,6 +4939,60 @@ export function killStalePids(activeSessions_: Session[]): void {
   cleanupPersistentBackendSessions('herdr', activeSessions_);
 }
 
+/**
+ * Sweep dead CLI-pid marker files out of `.botmux-cli-pids/`. Each marker is
+ * named for the PID that wrote it; when that PID is gone the file is a landmine —
+ * the kernel eventually recycles the number onto an unrelated process, and a
+ * `botmux send` climbing its ancestry can then read a since-exited session's
+ * marker and route the message into the WRONG bot's session. (Fix A already
+ * rejects such a marker at read time by verifying procStart / the env session
+ * id; this GC removes the file so the collision can't even be attempted, and
+ * keeps the directory from growing without bound — graceful worker exit unlinks
+ * its own marker, but SIGKILL / crash / force-kill do not.)
+ *
+ * Cross-daemon safe: with many daemons sharing one data dir, a DEAD pid cannot
+ * belong to any live daemon's session, so unlinking its marker never races a
+ * peer. A live pid's marker is always left untouched. The tiny window where a
+ * PID is recycled between the liveness probe and unlink is benign — the new
+ * owner rewrites its marker on the next turn, and Fix A makes a briefly-missing
+ * marker fall back to the correct env id, never to a wrong session.
+ *
+ * `isPidAlive` is injectable so tests are deterministic regardless of what PIDs
+ * the host has actually allocated (picking a "surely-dead" literal is unsafe —
+ * it can be below pid_max and collide with a live process on a busy runner).
+ * Production uses `process.kill(pid, 0)`: a signal-0 probe that never kills.
+ * Conservative on every ambiguity — only a definitively-dead PID is swept.
+ */
+export function defaultPidLiveness(pid: number): boolean {
+  try {
+    process.kill(pid, 0); // signal 0 = liveness probe, never kills
+    return true;          // alive → owned by some (possibly peer) daemon
+  } catch (err: any) {
+    if (err?.code === 'ESRCH') return false; // no such process → dead
+    return true; // EPERM (alive, not ours) or unknown error → keep, never guess
+  }
+}
+
+export function sweepDeadPidMarkers(
+  dataDir: string = config.session.dataDir,
+  isPidAlive: (pid: number) => boolean = defaultPidLiveness,
+): number {
+  const markersDir = join(dataDir, '.botmux-cli-pids');
+  let entries: string[];
+  try { entries = readdirSync(markersDir); }
+  catch { return 0; } // dir absent (fresh install) → nothing to sweep
+  let removed = 0;
+  for (const name of entries) {
+    const pid = Number(name);
+    if (!Number.isInteger(pid) || pid <= 1) continue; // ignore non-pid files
+    if (isPidAlive(pid)) continue;                    // keep live (incl. peer daemons)
+    try { unlinkSync(join(markersDir, name)); removed++; }
+    catch { /* raced with another sweeper or the owner — fine */ }
+  }
+  if (removed > 0) logger.info(`Swept ${removed} dead CLI-pid marker(s) from ${markersDir}`);
+  return removed;
+}
+
 function cleanupPersistentBackendSessions(backendType: 'tmux' | 'herdr', activeSessions_: Session[]): void {
   const anyBackend = getAllBots().some(b => (b.config.backendType ?? config.daemon.backendType) === backendType)
     || config.daemon.backendType === backendType;

--- a/src/workflows/v3/session-relay-client.ts
+++ b/src/workflows/v3/session-relay-client.ts
@@ -54,7 +54,7 @@ export function readWorkflowSessionRelayContext(options: {
   const sessionId = options.env.BOTMUX_SESSION_ID?.trim();
   if (!sessionId) return null;
   const findMarker = options.findMarker ?? findAncestorSessionContext;
-  const marker = findMarker(options.dataDir, options.startPid ?? process.ppid);
+  const marker = findMarker(options.dataDir, options.startPid ?? process.ppid, sessionId);
   if (marker?.sessionId) return null;
   const readClaim = options.readClaim ?? readManagedOriginCapability;
   const relayDir = options.env.BOTMUX_SEND_RELAY?.trim();

--- a/test/dashboard-create-session.test.ts
+++ b/test/dashboard-create-session.test.ts
@@ -51,6 +51,7 @@ vi.mock('../src/core/worker-pool.js', () => ({
   forkAdoptWorker: vi.fn(),
   adoptSandboxBlocked: vi.fn((botCfg, session) => botCfg?.sandbox === true || botCfg?.readIsolation === true || session?.sandbox === true || process.env.BOTMUX_SANDBOX === '1'),
   killStalePids: vi.fn(),
+  sweepDeadPidMarkers: vi.fn(),
   getCurrentCliVersion: vi.fn(() => 'test-cli-v1'),
   restoreUsageLimitRuntimeState: vi.fn(),
   setActiveSessionSafe: vi.fn(async (map: Map<string, any>, k: string, ds: any) => { map.set(k, ds); }),

--- a/test/prompt-builder.test.ts
+++ b/test/prompt-builder.test.ts
@@ -78,6 +78,7 @@ vi.mock('../src/services/whiteboard-store.js', () => ({
 vi.mock('../src/core/worker-pool.js', () => ({
   forkWorker: vi.fn(),
   killStalePids: vi.fn(),
+  sweepDeadPidMarkers: vi.fn(),
   getActiveSessionsRegistry: vi.fn(() => undefined),
   getCurrentCliVersion: vi.fn(() => '1.0.0'),
 }));

--- a/test/restore-zombie-close.test.ts
+++ b/test/restore-zombie-close.test.ts
@@ -75,6 +75,7 @@ vi.mock('../src/core/worker-pool.js', () => ({
   adoptSandboxBlocked: vi.fn((botCfg: any, session?: any) =>
     botCfg?.sandbox === true || botCfg?.readIsolation === true || session?.sandbox === true || process.env.BOTMUX_SANDBOX === '1'),
   killStalePids: vi.fn(),
+  sweepDeadPidMarkers: vi.fn(),
   getActiveSessionsRegistry: vi.fn(() => wp.registry ?? undefined),
   getCurrentCliVersion: vi.fn(() => '1.0.0-test'),
   restoreUsageLimitRuntimeState: vi.fn(),

--- a/test/scheduler-silent-execute.test.ts
+++ b/test/scheduler-silent-execute.test.ts
@@ -65,6 +65,7 @@ vi.mock('../src/core/worker-pool.js', () => ({
   forkAdoptWorker: vi.fn(),
   adoptSandboxBlocked: vi.fn((botCfg, session) => botCfg?.sandbox === true || botCfg?.readIsolation === true || session?.sandbox === true || process.env.BOTMUX_SANDBOX === '1'),
   killStalePids: vi.fn(),
+  sweepDeadPidMarkers: vi.fn(),
   getCurrentCliVersion: vi.fn(() => 'test-cli-v1'),
   restoreUsageLimitRuntimeState: vi.fn(),
   setActiveSessionSafe: vi.fn(async (map: Map<string, any>, k: string, ds: any) => { map.set(k, ds); }),

--- a/test/session-marker-resolve.test.ts
+++ b/test/session-marker-resolve.test.ts
@@ -31,31 +31,83 @@ describe('resolveSessionContext()', () => {
     );
   }
 
+  // A genuine worker marker always names the SAME session as the injected
+  // BOTMUX_SESSION_ID (both are written per-spawn for one session); the marker's
+  // only edge is carrying the fresh per-turn turnId/dispatchAttempt the env lacks.
   it('prefers the marker (with its fresh turnId) over the env when ancestry resolves', () => {
-    writeMarker(process.pid, JSON.stringify({ sessionId: 'marker-sid', turnId: 'turn-9' }));
+    writeMarker(process.pid, JSON.stringify({ sessionId: 'env-sid', turnId: 'turn-9' }));
     const ctx = resolveSessionContext(dir, 'env-sid', process.pid);
-    expect(ctx).toEqual({ sessionId: 'marker-sid', turnId: 'turn-9' });
+    expect(ctx).toEqual({ sessionId: 'env-sid', turnId: 'turn-9' });
   });
 
   it('parses a positive integer dispatchAttempt from the marker', () => {
     writeMarker(process.pid, JSON.stringify({
-      sessionId: 'marker-sid',
+      sessionId: 'env-sid',
       turnId: 'turn-9',
       dispatchAttempt: 2,
     }));
     const ctx = resolveSessionContext(dir, 'env-sid', process.pid);
-    expect(ctx).toEqual({ sessionId: 'marker-sid', turnId: 'turn-9', dispatchAttempt: 2 });
+    expect(ctx).toEqual({ sessionId: 'env-sid', turnId: 'turn-9', dispatchAttempt: 2 });
   });
 
   it.each([0, -1, 1.5, '2', Number.MAX_SAFE_INTEGER + 1])(
     'ignores an invalid marker dispatchAttempt (%s)',
     (dispatchAttempt) => {
-      writeMarker(process.pid, JSON.stringify({ sessionId: 'marker-sid', dispatchAttempt }));
+      writeMarker(process.pid, JSON.stringify({ sessionId: 'env-sid', dispatchAttempt }));
       const ctx = resolveSessionContext(dir, 'env-sid', process.pid);
-      expect(ctx?.sessionId).toBe('marker-sid');
+      expect(ctx?.sessionId).toBe('env-sid');
       expect(ctx?.dispatchAttempt).toBeUndefined();
     },
   );
+
+  // ── Recycled-PID misroute guard (the cross-bot leak these fixes address) ──
+  // The kernel recycles PID numbers; a since-exited session's marker file left on
+  // a reused PID must never route THIS process's send into that stale session.
+  it('rejects a legacy marker whose session differs from env (the cross-bot leak) → env fallback', () => {
+    // Reproduces the incident: a June legacy marker (no procStart) on a recycled
+    // low PID named a DIFFERENT bot's long-closed session. The marker walk must
+    // skip it and fall back to the authoritative inherited env session id.
+    writeMarker(process.pid, JSON.stringify({ sessionId: 'stale-other-bot-sid', turnId: null }));
+    const ctx = resolveSessionContext(dir, 'env-sid', process.pid);
+    expect(ctx).toEqual({ sessionId: 'env-sid' });
+  });
+
+  it('rejects a marker whose procStart ≠ the live process (recycled PID with a birth-stamp)', () => {
+    // A newer marker carries procStart; if it disagrees with the live process the
+    // PID was recycled onto us — skip even when it happens to match the env sid.
+    writeMarker(process.pid, JSON.stringify({
+      sessionId: 'env-sid', turnId: 'turn-x', procStart: '1', // 1 tick ≠ any real start
+    }));
+    const ctx = resolveSessionContext(dir, 'env-sid', process.pid);
+    expect(ctx).toEqual({ sessionId: 'env-sid' }); // env fallback, marker's turnId dropped
+  });
+
+  it('honors a marker whose procStart MATCHES the live process (genuine ancestor)', () => {
+    const liveStart = readProcessStartIdentity(process.pid);
+    expect(liveStart).toBeTruthy();
+    writeMarker(process.pid, JSON.stringify({
+      sessionId: 'env-sid', turnId: 'turn-live', procStart: liveStart,
+    }));
+    const ctx = resolveSessionContext(dir, 'env-sid', process.pid);
+    expect(ctx).toEqual({ sessionId: 'env-sid', turnId: 'turn-live' });
+  });
+
+  it('honors a live legacy marker (no procStart) that matches env — zero regression for old-format sessions', () => {
+    // 700+ live sessions in the fleet still carry pre-procStart markers. As long
+    // as the sid matches the inherited env, they stay fully trusted.
+    writeMarker(process.pid, JSON.stringify({ sessionId: 'env-sid', turnId: 'turn-legacy' }));
+    const ctx = resolveSessionContext(dir, 'env-sid', process.pid);
+    expect(ctx).toEqual({ sessionId: 'env-sid', turnId: 'turn-legacy' });
+  });
+
+  it('trusts a live legacy marker when no env is available to contradict it', () => {
+    // host-command-context passes envSessionId=undefined ("am I in a session?").
+    // With nothing to disprove and a live PID, the marker is honored as before.
+    writeMarker(process.pid, JSON.stringify({ sessionId: 'only-marker-sid', turnId: 't' }));
+    const ctx = resolveSessionContext(dir, undefined, process.pid);
+    expect(ctx).toEqual({ sessionId: 'only-marker-sid', turnId: 't' });
+  });
+
 
   it('falls back to BOTMUX_SESSION_ID when the marker walk finds nothing (detached/backgrounded)', () => {
     // No markers dir at all → ancestry walk returns null, the detached case.
@@ -94,9 +146,12 @@ describe('resolveSessionContext()', () => {
     });
   });
 
-  it('does not mix a marker with another session capability', () => {
+  it('rejects a foreign-session marker and uses this session’s own capability snapshot instead', () => {
+    // marker names a DIFFERENT session than env → recycled-PID collision. It must
+    // be skipped, and resolution must land on env-sid's own capability snapshot,
+    // never blending the foreign marker's fields in.
     writeMarker(process.pid, JSON.stringify({
-      sessionId: 'marker-sid',
+      sessionId: 'foreign-sid',
       turnId: 'turn-marker',
       dispatchAttempt: 1,
     }));
@@ -106,9 +161,9 @@ describe('resolveSessionContext()', () => {
       dispatchAttempt: 2,
     });
     expect(resolveSessionContext(dir, 'env-sid', process.pid)).toEqual({
-      sessionId: 'marker-sid',
-      turnId: 'turn-marker',
-      dispatchAttempt: 1,
+      sessionId: 'env-sid',
+      turnId: 'turn-protected',
+      dispatchAttempt: 2,
     });
   });
 

--- a/test/session-resume.test.ts
+++ b/test/session-resume.test.ts
@@ -52,6 +52,7 @@ vi.mock('../src/core/worker-pool.js', () => ({
   adoptSandboxBlocked: vi.fn((botCfg: any, session?: any) =>
     botCfg?.sandbox === true || botCfg?.readIsolation === true || session?.sandbox === true || process.env.BOTMUX_SANDBOX === '1'),
   killStalePids: vi.fn(),
+  sweepDeadPidMarkers: vi.fn(),
   getCurrentCliVersion: vi.fn(() => '1.0.0-test'),
   restoreUsageLimitRuntimeState: vi.fn(),
   // Faithful: mirror the real setActiveSessionSafe — if a DIFFERENT entry

--- a/test/sweep-dead-pid-markers.test.ts
+++ b/test/sweep-dead-pid-markers.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit tests for sweepDeadPidMarkers (worker-pool.ts) — the daemon-startup GC
+ * that removes dead CLI-pid marker files from `.botmux-cli-pids/`.
+ *
+ * Why it exists: marker files are named for the PID that wrote them. When that
+ * PID exits the file lingers, and the kernel eventually recycles the number onto
+ * an unrelated process; a `botmux send` climbing its ancestry then reads a
+ * since-exited session's marker and routes into the WRONG bot's session (a real
+ * cross-bot leak). Fix A rejects such a marker at read time; this sweep removes
+ * the file so the collision can't be attempted and the dir can't grow unbounded
+ * (graceful exit unlinks its own marker, but SIGKILL/crash/force-kill do not).
+ *
+ * Cross-daemon safety contract asserted here: only DEAD-pid markers are removed;
+ * a live pid's marker (possibly owned by a peer daemon sharing the data dir) is
+ * always kept.
+ *
+ * Run:  pnpm vitest run test/sweep-dead-pid-markers.test.ts
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// worker-pool.ts pulls in backends / lark client / registry on import; mock the
+// heavy side-effect modules so we can import the pure fs sweep in isolation.
+vi.mock('../src/adapters/backend/tmux-backend.js', () => ({
+  TmuxBackend: { sessionName: (id: string) => `bmx-${id.slice(0, 8)}`, killSession: vi.fn(), listBotmuxSessions: vi.fn(() => []) },
+}));
+vi.mock('../src/adapters/backend/herdr-backend.js', () => ({
+  HerdrBackend: { sessionName: (id: string) => `bmx-${id.slice(0, 8)}`, killSession: vi.fn(), killAgent: vi.fn(), listBotmuxSessions: vi.fn(() => []) },
+}));
+vi.mock('../src/adapters/backend/zellij-backend.js', () => ({
+  ZellijBackend: { sessionName: (id: string) => `bmx-${id.slice(0, 8)}`, killSession: vi.fn() },
+}));
+vi.mock('../src/bot-registry.js', () => ({
+  getBot: vi.fn(() => ({ resolvedAllowedUsers: [], config: {} })),
+  getAllBots: vi.fn(() => []),
+  resolveBrandLabel: vi.fn(() => undefined),
+}));
+vi.mock('../src/im/lark/client.js', () => ({
+  updateMessage: vi.fn(), deleteMessage: vi.fn(), sendEphemeralCard: vi.fn(),
+  sendUserMessage: vi.fn(), addReaction: vi.fn(), removeReaction: vi.fn(),
+  getMessageChatId: vi.fn(), MessageWithdrawnError: class extends Error {},
+}));
+vi.mock('../src/services/frozen-card-store.js', () => ({
+  loadFrozenCards: vi.fn(() => new Map()), saveFrozenCards: vi.fn(),
+}));
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+import { sweepDeadPidMarkers, defaultPidLiveness } from '../src/core/worker-pool.js';
+
+// Liveness is INJECTED so the test never depends on which PIDs the host has
+// actually allocated. Picking a "surely-dead" literal is unsafe — any value
+// below pid_max (4_194_303 on Linux) can collide with a live process on a busy
+// runner and flake. Here `LIVE`/`DEAD` are pure labels backed by a fixed set.
+const LIVE = 111;
+const DEAD = 222;
+const alive = new Set([LIVE]);
+const fakeLiveness = (pid: number) => alive.has(pid);
+
+describe('sweepDeadPidMarkers()', () => {
+  let dir: string;
+  let markersDir: string;
+  const marker = (pid: number | string) => join(markersDir, String(pid));
+  const write = (pid: number | string, body = JSON.stringify({ sessionId: 's' })) => {
+    writeFileSync(marker(pid), body);
+  };
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'sweep-'));
+    markersDir = join(dir, '.botmux-cli-pids');
+    mkdirSync(markersDir, { recursive: true });
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('removes a marker whose PID is dead', () => {
+    write(DEAD);
+    expect(sweepDeadPidMarkers(dir, fakeLiveness)).toBe(1);
+    expect(existsSync(marker(DEAD))).toBe(false);
+  });
+
+  it('keeps a marker whose PID is alive (never touches a peer daemon’s live session)', () => {
+    write(LIVE);
+    expect(sweepDeadPidMarkers(dir, fakeLiveness)).toBe(0);
+    expect(existsSync(marker(LIVE))).toBe(true);
+  });
+
+  it('sweeps only the dead ones in a mixed directory', () => {
+    write(LIVE);
+    write(DEAD);
+    write(DEAD + 1);
+    expect(sweepDeadPidMarkers(dir, fakeLiveness)).toBe(2);
+    expect(existsSync(marker(LIVE))).toBe(true);
+    expect(existsSync(marker(DEAD))).toBe(false);
+    expect(existsSync(marker(DEAD + 1))).toBe(false);
+  });
+
+  it('ignores non-PID entries (never deletes stray files)', () => {
+    writeFileSync(marker('not-a-pid'), 'x');
+    writeFileSync(marker('0'), 'x');   // pid 0/1 are not real CLI markers
+    writeFileSync(marker('1'), 'x');
+    // Guard: even if the fake probe were asked, non-pid names must be skipped
+    // before liveness is ever consulted.
+    expect(sweepDeadPidMarkers(dir, () => false)).toBe(0);
+    expect(existsSync(marker('not-a-pid'))).toBe(true);
+    expect(existsSync(marker('0'))).toBe(true);
+    expect(existsSync(marker('1'))).toBe(true);
+  });
+
+  it('returns 0 and does not throw when the markers dir is absent (fresh install)', () => {
+    rmSync(markersDir, { recursive: true, force: true });
+    expect(sweepDeadPidMarkers(dir, fakeLiveness)).toBe(0);
+  });
+
+  it('is a no-op on an empty markers dir', () => {
+    expect(sweepDeadPidMarkers(dir, fakeLiveness)).toBe(0);
+  });
+});
+
+describe('defaultPidLiveness()', () => {
+  it('reports this live process as alive', () => {
+    expect(defaultPidLiveness(process.pid)).toBe(true);
+  });
+
+  it('reports a PID above pid_max as dead (cannot exist)', () => {
+    // 2^22 + 1 exceeds Linux pid_max default; process.kill → ESRCH → dead.
+    expect(defaultPidLiveness(4_194_305)).toBe(false);
+  });
+
+  it('treats an EPERM probe (alive but not ours to signal) conservatively as alive', () => {
+    // Force the EPERM branch deterministically — on a root runner process.kill(1,0)
+    // succeeds, so a bare pid-1 assertion would never actually exercise it. Stub
+    // process.kill to throw EPERM and confirm the probe keeps the PID (never
+    // reports a live-but-unsignalable process as dead → sweep won't delete it).
+    const realKill = process.kill;
+    try {
+      (process as any).kill = () => { const e: any = new Error('operation not permitted'); e.code = 'EPERM'; throw e; };
+      expect(defaultPidLiveness(1234)).toBe(true);
+    } finally {
+      process.kill = realKill;
+    }
+  });
+
+  it('treats an unknown probe error conservatively as alive (never guesses dead)', () => {
+    const realKill = process.kill;
+    try {
+      (process as any).kill = () => { const e: any = new Error('weird'); e.code = 'EIO'; throw e; };
+      expect(defaultPidLiveness(1234)).toBe(true);
+    } finally {
+      process.kill = realKill;
+    }
+  });
+});


### PR DESCRIPTION
## 问题(生产真实事故)

一条 PR review 的 `botmux send` 被发进了**另一个 bot 的旧会话**、以那个 bot 的身份发到它的旧群里(申晗在飞书里看到「别的机器人发到别的群」并追问)。

逐条对线上真实状态坐实,根因是进程树 PID-marker 的两个缺陷叠加:

1. **marker 从不 GC**:`~/.botmux/data/.botmux-cli-pids/<pid>` 文件在写它的进程退出后不清理。优雅退出会 `unlink` 自己的(`worker.ts:8527`),但 **SIGKILL / 崩溃 / 强杀 全绕过**。线上实测 **1419 个 marker 里 1190 个是死进程**留下的。
2. **发送路径解析器不校验存活**:`botmux send` 等走的 `findAncestorSessionContext` 只按「这个 pid 的 marker 文件存在」就返回它的 sessionId,**不核对该 marker 是不是当前活进程写的**。而授权类命令走的 `findAuthenticatedAncestorSessionContext` 是**会**核对 procStart 的——就差这一道。

当内核把某个死会话的 pid 号**复用**给一条 send 的祖先进程时,walk 撞到那条残留 marker,就把消息路由进它记录的旧会话(旧 bot、旧群),并继承了旧会话的 quote 目标。

**铁证**:泄漏消息落在 `turn-sends/2edd79c1.jsonl`,而 session `2edd79c1` 属于**另一个 bot** `cli_a9f66d03`、另一个群(6/15 已 closed);当前会话正确身份是 env `BOTMUX_SESSION_ID=c750b6ac` / bot `cli_a96331`。`2edd79c1` 在磁盘上只由 pid `181627` 命中——它已 DEAD、6/15 遗留的无 procStart 老格式 marker。

## 改动

### Fix A — 读取时校验(立即止血)`src/core/session-marker.ts`
`findAncestorSessionContext` 命中 marker 后必须通过新增的 `isTrustworthyAncestorMarker` 才采信:
- marker 带 `procStart` 时,必须等于活进程的 procStart(直接证伪 PID 复用);
- 传入 `envSessionId`(继承的 `BOTMUX_SESSION_ID`,spawn 注入、永不变、跨 reparent 继承,是本进程所属会话的 ground truth)时,`marker.sessionId` 必须与之相等,否则判定是别的会话、不可信。

不可信的 marker 被跳过、walk 继续上爬;都不可信则回落到正确的 env sessionId。函数不再自己读全局 env(保持纯函数),由 `resolveSessionContext` 与 v3 relay client 显式传入。删掉因此不再被引用的 `parseSessionMarker`。

> 关键判断:为什么不能只靠「活着就信」?本次泄漏的 181627 **是活进程**(pid 被复用),且是无 procStart 的老 marker——只有「sid 与 env 不符」能识破它。线上还有 700+ 活会话是同样的无 procStart 老格式,只要 sid 与 env 相符就必须继续采信(零回归)。

### Fix B — 启动时 GC(清历史地雷)`src/core/worker-pool.ts`
新增 `sweepDeadPidMarkers`,daemon 启动(`restoreActiveSessions`)时清掉 pid 已死的 marker 文件。**跨 daemon 安全**:47 个 daemon 共享一个 data dir,死 pid 不可能属于任何存活 daemon 的会话,删它绝不误伤 peer;活 pid 的 marker 一律保留。

## 影响面评估

动的是核心共享路径 `core/session-marker.ts`(喂给 `botmux send`、MCP gateway、hooks、vc-agent、v3 relay),逐一核对:
- **cli.ts** 的所有 send/schedule/role 等 callers 走它自己的**本地** `findAncestorSessionContext` wrapper → `resolveSessionContext`(已显式传 `BOTMUX_SESSION_ID`)。cli.ts 只 import `resolveSessionContext`,不直接用核心原语。
- **host-command-context** 传 `envSessionId=undefined`(探测「是否在会话内」)→ 无 env 可反驳时,活进程的 legacy marker 仍被采信,行为不变(新增用例覆盖)。
- **v3 relay client** 现显式传 `sessionId`;它只关心「有没有活 marker」,foreign/stale marker 被拒→返回 null→relay 照常走,语义正确。
- **零回归 for 老格式会话**:700+ 活会话仍是无 procStart 老 marker,sid 与 env 相符即照常采信。
- Fix B 仅 Linux/macOS 进程模型;pid 存活探测用 `process.kill(pid,0)`,与 `killStalePids` 同一惯用法。

## 测试(mutation 验证有牙,非只看全绿)

`test/session-marker-resolve.test.ts`(20 tests):
- **复现事故**:异会话 legacy marker → env 回落;procStart 不符 → 拒;procStart 相符 → 采信;活 legacy marker 匹配 env → 零回归;无 env 时活 marker 仍采信;foreign marker + 本会话 capability → 用 capability 不混用。
- mutation:把 `isTrustworthyAncestorMarker` 改成恒 `true` → **3 用例 FAIL**,恢复全绿。

`test/sweep-dead-pid-markers.test.ts`(6 tests):死 pid 删 / 活 pid(peer)留 / 混合只删死的 / 非 pid 文件不碰 / 目录缺失或空不抛。
- mutation:删存活门槛(删所有)或删 unlink(不删) → **各 2 用例 FAIL**。

其它:
- 定向回归 **126 passed**(marker / v3-relay / sweep / dispatch / read-isolation / reap-orphan / kill-worker)。
- `pnpm build` 干净;`git merge-tree --write-tree` 对 master exit 0 零冲突。
- 全量测试见下方评论(跑完补)。

## 部署说明

Fix A 是纯读取逻辑、`pnpm build` 即生效;Fix B 在 daemon 启动时跑一次。需要 `pnpm switch:here && pnpm daemon:restart` 上 live 才会真正开始清扫历史死 marker + 关闭串台窗口。**未经申晗确认不合码 / 不部署。**
