### PR TITLE
feat(lark): 新增 /invite 元命令，@bot /invite @群外bot 拉其进群

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -3400,6 +3400,7 @@ export async function handleCommand(
           t('help.grant', undefined, loc),
           t('help.revoke', undefined, loc),
           t('help.vc_auth', undefined, loc),
+          t('help.invite', undefined, loc),
           '',
           t('help.heading_config', undefined, loc),
           t('help.config_get', undefined, loc),

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -130,6 +130,17 @@ export const messages: Record<string, string> = {
   'cmd.revoke.multi_would_open': '⚠️ {name} — skipped: last global allowed user / owner, revoking would open the bot to everyone',
   'cmd.revoke.multi_failed': '⚠️ {name} — revoke failed: {reason}',
 
+  // /invite (pull an out-of-chat bot into this chat, owner only)
+  'cmd.invite.owner_only': '⚠️ Only the owner can use /invite.',
+  'cmd.invite.p2p': '⚠️ Bots cannot be added in a DM — use /invite inside a group chat.',
+  'cmd.invite.usage': 'Usage: @me /invite @bot-to-add (multiple allowed), or @me /invite --app cli_xxx',
+  'cmd.invite.header': '🤝 /invite results:',
+  'cmd.invite.ok': '✅ Added to the chat: {names}',
+  'cmd.invite.already': '⏭️ Already in the chat (skipped): {names}',
+  'cmd.invite.unresolved': '⚠️ Could not resolve (not in this deployment\'s roster — use --app cli_xxx): {names}',
+  'cmd.invite.ambiguous_item': '⚠️ The name "{name}" matches multiple bots ({apps}) — use --app to pick one.',
+  'cmd.invite.failed_item': '❌ Failed to add: {name} — {reason}',
+
   // ─── Adopt card ──────────────────────────────────────────────────────────
   'card.adopt.title': '📡 Choose a CLI session to adopt',
   'card.adopt.placeholder_select': 'Pick a CLI session',
@@ -540,6 +551,7 @@ export const messages: Record<string, string> = {
   'help.grant': '@bot /grant @someone   - Let them talk in this chat (you can @ several at once); /grant (no target) opens the whole chat to talk',
   'help.revoke': '@bot /revoke @someone  - Revoke their talk access (you can @ several at once); /revoke (no target) revokes the whole-chat grant',
   'help.vc_auth': '/vc-auth @someone     - Temporarily trust an in-meeting instruction source; /vc-auth revoke @someone revokes; /vc-auth list shows current grants',
+  'help.invite': '@bot /invite @bot   - Pull an out-of-chat bot into this chat (multiple allowed; --app cli_xxx adds by app id)',
   'help.heading_config': '⚙️ Edit config remotely (owner only; written + hot-applied, no restart):',
   'help.config_get': '/botconfig get  - Show this bot\'s current operational config',
   'help.config_set': '/botconfig set <field> <value>  - Change model/cli/lang/toggles; /botconfig help for all fields',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -133,6 +133,17 @@ export const messages: Record<string, string> = {
   'cmd.revoke.multi_would_open': '⚠️ {name} —— 跳过：ta 是最后的全局授权用户 / owner，撤销会让机器人对所有人开放',
   'cmd.revoke.multi_failed': '⚠️ {name} —— 撤销失败：{reason}',
 
+  // /invite（把群外 bot 拉进本群，owner 专用）
+  'cmd.invite.owner_only': '⚠️ 仅 owner 可以使用 /invite。',
+  'cmd.invite.p2p': '⚠️ 私聊里不能拉机器人，请在群里使用 /invite。',
+  'cmd.invite.usage': '用法：@我 /invite @要拉进群的机器人（可多个），或 @我 /invite --app cli_xxx',
+  'cmd.invite.header': '🤝 /invite 结果：',
+  'cmd.invite.ok': '✅ 已拉进群：{names}',
+  'cmd.invite.already': '⏭️ 已在群内（跳过）：{names}',
+  'cmd.invite.unresolved': '⚠️ 无法解析（不在本部署花名册，可用 --app cli_xxx 直接指定）：{names}',
+  'cmd.invite.ambiguous_item': '⚠️ 名字「{name}」对应多个机器人（{apps}），请改用 --app 指定。',
+  'cmd.invite.failed_item': '❌ 拉入失败：{name} —— {reason}',
+
   // ─── Adopt card ──────────────────────────────────────────────────────────
   'card.adopt.title': '📡 选择要接入的 CLI 会话',
   'card.adopt.placeholder_select': '选择 CLI 会话',
@@ -543,6 +554,7 @@ export const messages: Record<string, string> = {
   'help.grant': '@机器人 /grant @某人   - 授权对方在本群对话（可一次 @ 多人/多 bot）；/grant（不带人）授权本群所有成员对话',
   'help.revoke': '@机器人 /revoke @某人  - 撤销对方本群对话权（可一次 @ 多人/多 bot）；/revoke（不带人）撤销整群授权',
   'help.vc_auth': '/vc-auth @成员     - 会议监听中临时授权本场指令源；/vc-auth revoke @成员 撤销；/vc-auth list 查看',
+  'help.invite': '@机器人 /invite @bot  - 把不在群里的 bot 拉进本群（可一次多个；--app cli_xxx 可直接指定 app）',
   'help.heading_config': '⚙️ 远程改配置（owner 专用，写盘即热更新、无需重启）：',
   'help.config_get': '/botconfig get  - 查看本机器人当前运营配置',
   'help.config_set': '/botconfig set <字段> <值>  - 改 model/cli/lang/开关等；/botconfig help 看全部字段',

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -38,6 +38,7 @@ import {
 import { automateOpenPlatformSetup } from '../../setup/open-platform-automation.js';
 import { type Brand, larkHosts, normalizeBrand, sdkDomain } from './lark-hosts.js';
 import { tryHandleGrantCommand } from './grant-command.js';
+import { tryHandleInviteCommand } from './invite-command.js';
 import { tryHandleReplyModeCommand } from './reply-mode-command.js';
 import { tryHandleSubstituteCommand } from './substitute-command.js';
 import { buildGrantCard } from './card-builder.js';
@@ -2439,6 +2440,12 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
       // /grant、/revoke — 群内授权元命令。在路由/spawn 之前拦截（仅 owner，需明确 @ 本 bot），
       // 否则会被当成 prompt 喂给 CLI 会话。
       if (await tryHandleGrantCommand(larkAppId, message, senderOpenId)) {
+        return;
+      }
+
+      // /invite — 把群外 bot 拉进本群的元命令。与 /grant 同款拦截模型（仅 owner，
+      // 需明确 @ 本 bot），防止进路由/spawn，也防多 bot 重复执行拉人。
+      if (await tryHandleInviteCommand(larkAppId, message, senderOpenId)) {
         return;
       }
 

--- a/src/im/lark/grant-command.ts
+++ b/src/im/lark/grant-command.ts
@@ -6,15 +6,23 @@
  */
 import { getOwnerOpenId, getBotOpenId, getBot } from '../../bot-registry.js';
 import { isBotMentioned, extractMessageTextForRouting } from './event-dispatcher.js';
-import { stripLeadingMentions, mentionOpenId } from './message-parser.js';
+import { stripLeadingMentions } from './message-parser.js';
 import { buildGrantCard } from './card-builder.js';
 import { openPendingMulti } from './grant-pending.js';
 import { revokeGrant, addAllowedChatGroup, removeAllowedChatGroup } from '../../services/grant-store.js';
 import { replyMessage } from './client.js';
 import { localeForBot, t } from '../../i18n/index.js';
 import { logger } from '../../utils/logger.js';
+import {
+  parseTargetsAfterCommand, isCommandTargetOnly, stripAllMentions,
+} from './mention-targets.js';
 
-/** 从 mention 列表取所有非本 bot 的【授权目标】（可以是真人，也可以是另一个 bot——
+export { stripAllMentions };
+
+/** /grant|/revoke 的命令词匹配（带 \b 边界）。共享解析器见 mention-targets.ts。 */
+const GRANT_CMD_PATTERN = /\/(?:grant|revoke)\b/i;
+
+/** 取所有非本 bot 的【授权目标】（可以是真人，也可以是另一个 bot——
  *  授权 bot 走同一条路，命中后写本群 chatGrants，放行其在本群拉起 chat-scope 会话）。
  *  按 open_id 去重、保持 @ 顺序，支持一次 /grant @a @b、/revoke @a @b 批量处置。
  *
@@ -22,99 +30,15 @@ import { logger } from '../../utils/logger.js';
  *  （`@OperatorBot /grant @Grantee`），不是 grantee。否则 owner 一条 `@Claude @Codex /grant`
  *  把两个操作 bot 都前导 @ 了，每个 daemon 会把「另一个 bot」当成目标 → 两 bot 互相授权
  *  （实测 bug）。位置过滤仅在能拿到位置信息（text 形态的 key / post 的节点序）时生效；
- *  纯 mentions 的合成消息（无 content.text）退回历史「全部非本 bot」行为。 */
+ *  纯 mentions 的合成消息（无 content.text）退回历史「全部非本 bot」行为。
+ *  实现在 mention-targets.ts（与 /invite 共享）。 */
 export function parseGrantTargets(message: any, botOpenId: string | undefined): Array<{ openId: string; name: string }> {
-  let content: any;
-  try { content = JSON.parse(message?.content ?? '{}'); } catch { content = undefined; }
-
-  // text 形态：@ 落在 content.text 里，每个 mention 带 key 占位符可定位其位置 → 按命令词位置过滤。
-  if (content && typeof content.text === 'string') {
-    return parseTextTargetsAfterCommand(content.text, message?.mentions ?? [], botOpenId);
-  }
-  // post（富文本）形态：@ 落在 inline `at` 节点（message.mentions 常为空、偶有填充，统一走节点序）→
-  // 按命令词节点位置过滤，不被「message.mentions 是否填充」左右。
-  const inner = content?.zh_cn ?? content?.en_us ?? content;
-  if (Array.isArray(inner?.content)) {
-    return parsePostAtMentions(message, botOpenId);
-  }
-
-  // 合成消息（仅 mentions、无 content 结构，多见于单测/旧调用）：无位置信息，退回全部非本 bot。
-  const seen = new Set<string>();
-  const out: Array<{ openId: string; name: string }> = [];
-  for (const x of (message?.mentions ?? [])) {
-    const oid = mentionOpenId(x);
-    if (!oid || oid === botOpenId || seen.has(oid)) continue;
-    seen.add(oid);
-    out.push({ openId: oid, name: x.name ?? oid });
-  }
-  return out;
-}
-
-/** text 形态：只取「命令词之后」的非本 bot mention。用 mention 的 key 占位符定位其在 text 里的
- *  位置；`key(?!\d)` 边界规避 @_user_1 / @_user_10 前缀歧义（与 isGrantTargetOnly 同款）。
- *  定位不到 key（异常形态）时保守退回「视为目标」，与历史行为一致，不漏真实 grantee。 */
-function parseTextTargetsAfterCommand(
-  text: string, mentions: any[], botOpenId: string | undefined,
-): Array<{ openId: string; name: string }> {
-  const cmdIdx = text.search(/\/(?:grant|revoke)\b/i);
-  const seen = new Set<string>();
-  const out: Array<{ openId: string; name: string }> = [];
-  for (const m of mentions) {
-    const oid = mentionOpenId(m);
-    if (!oid || oid === botOpenId || seen.has(oid)) continue;
-    const key = m?.key;
-    if (cmdIdx >= 0 && typeof key === 'string' && key.length > 0) {
-      const km = new RegExp(`${escapeRe(key)}(?!\\d)`).exec(text);
-      if (km && km.index <= cmdIdx) continue;   // 命令词之前 = 操作 bot 点名，剔除
-    }
-    seen.add(oid);
-    out.push({ openId: oid, name: m.name ?? oid });
-  }
-  return out;
-}
-
-/** 从 post inline `at` 节点取非本 bot 的目标（user_name 兜 name），按 user_id 去重、保持顺序。
- *  同 text 形态：只收「命令词文本节点之后」的 `at` 节点（前导 @ 是操作 bot 点名，剔除）。 */
-function parsePostAtMentions(message: any, botOpenId: string | undefined): Array<{ openId: string; name: string }> {
-  const seen = new Set<string>();
-  const out: Array<{ openId: string; name: string }> = [];
-  let content: any;
-  try { content = JSON.parse(message?.content ?? '{}'); } catch { return out; }
-  const inner = content?.zh_cn ?? content?.en_us ?? content;
-  if (!Array.isArray(inner?.content)) return out;
-  // 先定位命令词文本节点的序号，再只收其后的 at 节点。
-  let seq = 0, cmdSeq = -1;
-  const ats: Array<{ oid: string; name: string; seq: number }> = [];
-  for (const para of inner.content) {
-    if (!Array.isArray(para)) continue;
-    for (const node of para) {
-      if (cmdSeq < 0 && node?.tag === 'text' && /\/(?:grant|revoke)\b/i.test(node.text ?? '')) cmdSeq = seq;
-      if (node?.tag === 'at' && node.user_id) ats.push({ oid: node.user_id, name: node.user_name ?? node.user_id, seq });
-      seq++;
-    }
-  }
-  for (const a of ats) {
-    if (a.oid === botOpenId || seen.has(a.oid)) continue;
-    if (cmdSeq >= 0 && a.seq <= cmdSeq) continue;   // 命令词之前 = 操作 bot 点名，剔除
-    seen.add(a.oid);
-    out.push({ openId: a.oid, name: a.name });
-  }
-  return out;
+  return parseTargetsAfterCommand(message, botOpenId, GRANT_CMD_PATTERN);
 }
 
 /** 取第一个非本 bot 的目标（单目标场景的便捷封装）。 */
 export function parseGrantTarget(message: any, botOpenId: string | undefined): { openId: string; name: string } | undefined {
   return parseGrantTargets(message, botOpenId)[0];
-}
-
-/** 把文本里所有 `@<name>` mention token 去掉（split/join，防正则注入），归一空白后 trim。 */
-export function stripAllMentions(text: string, mentions: any[]): string {
-  let s = text;
-  for (const m of mentions ?? []) {
-    const name = m?.name;
-    if (typeof name === 'string' && name.length) s = s.split(`@${name}`).join(' ');
-  }
-  return s.replace(/\s+/g, ' ').trim();
 }
 
 /**
@@ -133,50 +57,14 @@ export function parseGrantQuota(text: string, mentions: any[]): { ok: true; quot
   return { ok: true, quota: n };
 }
 
-function escapeRe(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 /**
  * 本 bot 是否「只是作为 /grant、/revoke 的目标」被 @（@ 出现在命令词之后），
  * 而不是被前导 @ 点名执行命令的操作 bot。命中（仅目标）返回 true，调用方应静默放手——
  * 否则异主目标 bot 会误回 owner_only、同主目标 bot 会把自己剔空后误开整群授权。
- *
- * text 与 post（富文本）两种消息形态都覆盖，二者入口都能命中 /grant（见 event-dispatcher
- * 的 extractMessageTextForRouting / isBotMentioned），所以 guard 必须同时兜住：
- *  - text：{"text":"@_user_1 /grant @_user_2"}，@ 是占位符 key；用「key 后不接数字」的
- *    边界锁定整 token，规避 @_user_1 / @_user_10 这类 key 前缀歧义。
- *  - post：@ 是独立的 `at` 节点（不在 text 里、mentions 可能为空），按文档节点顺序比较
- *    本 bot 的 `at` 节点与含命令词的 text 节点的先后。
+ * 实现细节（text/post 双形态、key 前缀歧义规避）见 mention-targets.ts。
  */
 export function isGrantTargetOnly(message: any, botOpenId: string | undefined): boolean {
-  if (!botOpenId) return false;
-  let content: any;
-  try { content = JSON.parse(message?.content ?? '{}'); } catch { return false; }
-
-  if (typeof content?.text === 'string') {
-    const key = (message?.mentions ?? []).find((m: any) => mentionOpenId(m) === botOpenId)?.key;
-    if (!key) return false;
-    const cmdIdx = content.text.search(/\/(?:grant|revoke)\b/i);
-    const keyMatch = new RegExp(`${escapeRe(key)}(?!\\d)`).exec(content.text);
-    const myIdx = keyMatch ? keyMatch.index : -1;
-    return cmdIdx >= 0 && myIdx > cmdIdx;
-  }
-
-  const inner = content?.zh_cn ?? content?.en_us ?? content;
-  if (Array.isArray(inner?.content)) {
-    let seq = 0, cmdSeq = -1, mySeq = -1;
-    for (const para of inner.content) {
-      if (!Array.isArray(para)) continue;
-      for (const node of para) {
-        if (cmdSeq < 0 && node?.tag === 'text' && /\/(?:grant|revoke)\b/i.test(node.text ?? '')) cmdSeq = seq;
-        if (mySeq < 0 && node?.tag === 'at' && node.user_id === botOpenId) mySeq = seq;
-        seq++;
-      }
-    }
-    return cmdSeq >= 0 && mySeq > cmdSeq;
-  }
-  return false;
+  return isCommandTargetOnly(message, botOpenId, GRANT_CMD_PATTERN);
 }
 
 /** 返回 true 表示已拦截（不再进入路由/spawn）。 */

--- a/src/im/lark/grant-command.ts
+++ b/src/im/lark/grant-command.ts
@@ -66,10 +66,11 @@ export function parseGrantQuota(text: string, mentions: any[]): { ok: true; quot
  * 本 bot 是否「只是作为 /grant、/revoke 的目标」被 @（@ 出现在命令词之后），
  * 而不是被前导 @ 点名执行命令的操作 bot。命中（仅目标）返回 true，调用方应静默放手——
  * 否则异主目标 bot 会误回 owner_only、同主目标 bot 会把自己剔空后误开整群授权。
- * 实现细节（text/post 双形态、key 前缀歧义规避）见 mention-targets.ts。
+ * 实现细节（text/post 双形态、key 前缀歧义规避、open_id + app_id 双判据）见 mention-targets.ts。
+ * botAppId（本 bot larkAppId）让 guard 也认 app_id 形态的本 bot @（协作 bot 常以 app_id 被 @）。
  */
-export function isGrantTargetOnly(message: any, botOpenId: string | undefined): boolean {
-  return isCommandTargetOnly(message, botOpenId, GRANT_CMD_PATTERN);
+export function isGrantTargetOnly(message: any, botOpenId: string | undefined, botAppId?: string): boolean {
+  return isCommandTargetOnly(message, botOpenId, GRANT_CMD_PATTERN, botAppId);
 }
 
 /** 返回 true 表示已拦截（不再进入路由/spawn）。 */
@@ -89,7 +90,7 @@ export async function tryHandleGrantCommand(
   // 常见于 owner 用 `/grant @bot` 授权另一个 bot 在本群协作）→ 这条命令是发给前导 @ 的
   // 操作 bot 的，本 bot 的 daemon 必须放手：既不能回 owner_only（异主 bot 会误报「仅 owner
   // 可使用 /grant」），也不能把自己从 targets 剔空后误判成裸 /grant 给整群开授权。
-  if (isGrantTargetOnly(message, getBotOpenId(larkAppId))) {
+  if (isGrantTargetOnly(message, getBotOpenId(larkAppId), larkAppId)) {
     logger.debug(`[grant:${larkAppId}] ignoring /grant|/revoke where this bot is only a target`);
     return true;  // 拦截（不喂 CLI），但不回复、不改授权——命令属于操作 bot
   }

--- a/src/im/lark/grant-command.ts
+++ b/src/im/lark/grant-command.ts
@@ -33,7 +33,12 @@ const GRANT_CMD_PATTERN = /\/(?:grant|revoke)\b/i;
  *  纯 mentions 的合成消息（无 content.text）退回历史「全部非本 bot」行为。
  *  实现在 mention-targets.ts（与 /invite 共享）。 */
 export function parseGrantTargets(message: any, botOpenId: string | undefined): Array<{ openId: string; name: string }> {
-  return parseTargetsAfterCommand(message, botOpenId, GRANT_CMD_PATTERN);
+  // /grant 只接受 open_id 主体（授权对象是人 / 群内 bot）。共享解析器现在也收
+  // app_id-only 的 mention（/invite 拉群外 bot 用），但那种目标对授权无意义且过去
+  // 就被 mentionOpenId 直接 drop——过滤掉 openId 为空的项，保持 grant 行为 byte-parity。
+  return parseTargetsAfterCommand(message, botOpenId, GRANT_CMD_PATTERN)
+    .filter(t => t.openId)
+    .map(t => ({ openId: t.openId, name: t.name }));
 }
 
 /** 取第一个非本 bot 的目标（单目标场景的便捷封装）。 */

--- a/src/im/lark/grant-command.ts
+++ b/src/im/lark/grant-command.ts
@@ -41,6 +41,17 @@ export function parseGrantTargets(message: any, botOpenId: string | undefined): 
     .map(t => ({ openId: t.openId, name: t.name }));
 }
 
+/**
+ * 命令词之后是否存在**任何**目标 mention（含 app_id-only 的群外/协作 bot）。
+ * parseGrantTargets 会把 app_id-only 目标 .filter 掉，于是 `@OperatorBot /grant
+ * @OtherBot(app_id-only)` 在 operator daemon 里 targets 会变空 → 若据此走裸 /grant
+ * 整群授权分支 = 提权（owner 本意是授权某个 bot，却误对全群开放 talk）。用未过滤的
+ * raw 解析识别「指了目标但都不可按 open_id 授权」，让 handler fail closed 回 usage。
+ */
+export function hasAnyTargetMention(message: any, botOpenId: string | undefined): boolean {
+  return parseTargetsAfterCommand(message, botOpenId, GRANT_CMD_PATTERN).length > 0;
+}
+
 /** 取第一个非本 bot 的目标（单目标场景的便捷封装）。 */
 export function parseGrantTarget(message: any, botOpenId: string | undefined): { openId: string; name: string } | undefined {
   return parseGrantTargets(message, botOpenId)[0];
@@ -118,6 +129,14 @@ export async function tryHandleGrantCommand(
     if (!chatId) {
       await replyMessage(larkAppId, messageId, t(isGrant ? 'cmd.grant.usage' : 'cmd.revoke.usage', undefined, loc))
         .catch(err => logger.debug(`grant usage reply failed: ${err}`));
+      return true;
+    }
+    // fail closed：命令后其实**有**目标 mention，只是都是 app_id-only（群外/协作 bot，
+    // 被 parseGrantTargets .filter 掉）→ owner 本意是授权某个 bot，绝不能退化成「对全群
+    // 开放 talk」的整群授权（operator daemon 视角的提权）。回 usage，明确不按 app_id 授权。
+    if (hasAnyTargetMention(message, getBotOpenId(larkAppId))) {
+      await replyMessage(larkAppId, messageId, t(isGrant ? 'cmd.grant.usage' : 'cmd.revoke.usage', undefined, loc))
+        .catch(err => logger.debug(`grant app-id-target guard reply failed: ${err}`));
       return true;
     }
     // 无 @目标时只接受"整群"意图：精确 `/grant`（空尾巴）或 `/grant all`。带其它 token

--- a/src/im/lark/invite-command.ts
+++ b/src/im/lark/invite-command.ts
@@ -125,8 +125,9 @@ export async function tryHandleInviteCommand(
       .catch(err => logger.debug(`invite ${key} reply failed: ${err}`));
 
   // 本 bot 只是作为 /invite 的【目标】被 @（`@OperatorBot /invite @ThisBot`）→ 命令属于
-  // 前导 @ 的操作 bot，本 bot 必须静默放手（同 /grant 的 target-only 守卫）。
-  if (isCommandTargetOnly(message, myOpenId, INVITE_CMD_PATTERN)) {
+  // 前导 @ 的操作 bot，本 bot 必须静默放手（同 /grant 的 target-only 守卫）。传 larkAppId
+  // 让 guard 也认 app_id 形态的本 bot @（群外/协作 bot 常以 app_id 被 @，只认 open_id 会漏判）。
+  if (isCommandTargetOnly(message, myOpenId, INVITE_CMD_PATTERN, larkAppId)) {
     logger.debug(`[invite:${larkAppId}] ignoring /invite where this bot is only a target`);
     return true;
   }

--- a/src/im/lark/invite-command.ts
+++ b/src/im/lark/invite-command.ts
@@ -1,0 +1,238 @@
+/**
+ * 拉 bot 进群元命令：`@bot /invite @目标bot [@目标bot2 ...]`，也支持
+ * `@bot /invite --app cli_xxx（可多个）` 直接按 app_id 拉任意飞书应用。
+ *
+ * 与 /grant 同款拦截模型（在 dispatcher 路由/spawn 之前处理，见 event-dispatcher）：
+ *  - 必须明确 @ 本 bot 才执行（多 bot 群防重复处理）——执行方（inviter）必须本身
+ *    在群内，飞书要求 inviter 是群成员，本 bot 处理这条消息天然满足；
+ *  - 仅 owner 可用（对齐 /grant 的权限模型）；
+ *  - 命令词之后的 @ 才是目标（共享 mention-targets.ts 的位置解析）。
+ *
+ * 目标 mention → larkAppId 的解析不走群成员表（目标恰恰不在群里），改查
+ * 部署级共享花名册 bots-info.json（每个 daemon 启动时 merge 写入），按显示名
+ * 唯一匹配（大小写不敏感，与 /group 的 knownBotNames 判定同款）；重名 / 查无
+ * 时按目标报错，并提示用 --app 直通。已在群内的目标（live 群 bot 成员表能
+ * 对上的）跳过并报「已在群内」，幂等。
+ *
+ * 拉人走 services/groups-store.ts 的 addBotToChat（proxy=本 bot），与 /group、
+ * dashboard groups 面板、vc-agent 共用同一封装；批量失败时回退逐个拉（镜像
+ * group-creator 的批处理回退）。
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getOwnerOpenId, getBotOpenId } from '../../bot-registry.js';
+import { config } from '../../config.js';
+import { isBotMentioned, extractMessageTextForRouting } from './event-dispatcher.js';
+import { stripLeadingMentions } from './message-parser.js';
+import { addBotToChat } from '../../services/groups-store.js';
+import { listChatBotMembers, replyMessage } from './client.js';
+import type { ChatBotMember } from './client.js';
+import { localeForBot, t } from '../../i18n/index.js';
+import { logger } from '../../utils/logger.js';
+import { parseTargetsAfterCommand, isCommandTargetOnly, stripAllMentions } from './mention-targets.js';
+
+const INVITE_CMD_PATTERN = /\/invite\b/i;
+
+/** app_id 的合法形状（飞书自建/商店应用均为 cli_ 前缀）。 */
+const APP_ID_PATTERN = /^cli_[A-Za-z0-9]+$/;
+
+/** 飞书 chatMembers.create 的 id_list 上限很小（实测 >5 即 400，见 group-creator），按 5 一批。 */
+const INVITE_BATCH_SIZE = 5;
+
+interface BotsInfoEntry { larkAppId: string; botName: string | null }
+
+/** 读部署共享花名册 bots-info.json；文件缺失/损坏按空花名册处理（名字解析全部走不通，提示 --app）。 */
+export function readBotsInfoEntries(): BotsInfoEntry[] {
+  try {
+    const p = join(config.session.dataDir, 'bots-info.json');
+    if (!existsSync(p)) return [];
+    const raw = JSON.parse(readFileSync(p, 'utf-8'));
+    if (!Array.isArray(raw)) return [];
+    return raw.filter((e: any) => typeof e?.larkAppId === 'string' && e.larkAppId);
+  } catch {
+    return [];
+  }
+}
+
+interface ParsedInviteArgs {
+  /** --app 指定的 app_id（按出现顺序、去重）。 */
+  appIds: string[];
+  /** --app 后跟的非法 token（非 cli_ 形状）。 */
+  badAppTokens: string[];
+  /** 剥掉 /invite、所有 @、所有 --app x 之后的残余文本（应为空，否则 usage）。 */
+  leftover: string;
+}
+
+/** 从已 stripLeadingMentions 的命令文本解析 --app 参数。 */
+export function parseInviteArgs(text: string, mentions: any[]): ParsedInviteArgs {
+  // 先剥 mention 显示名（避免 @名字 里的空格干扰 token 切分），再去命令词。
+  const body = stripAllMentions(text, mentions).replace(INVITE_CMD_PATTERN, ' ');
+  const appIds: string[] = [];
+  const badAppTokens: string[] = [];
+  const leftoverTokens: string[] = [];
+  const tokens = body.split(/\s+/).filter(Boolean);
+  for (let i = 0; i < tokens.length; i++) {
+    const tok = tokens[i];
+    const inline = /^--app=(\S+)$/.exec(tok);
+    if (inline) {
+      (APP_ID_PATTERN.test(inline[1]) ? appIds : badAppTokens).push(inline[1]);
+      continue;
+    }
+    if (tok === '--app') {
+      const next = tokens[++i];
+      if (next === undefined) { badAppTokens.push(''); continue; }
+      (APP_ID_PATTERN.test(next) ? appIds : badAppTokens).push(next);
+      continue;
+    }
+    leftoverTokens.push(tok);
+  }
+  return { appIds: [...new Set(appIds)], badAppTokens, leftover: leftoverTokens.join(' ') };
+}
+
+/** 批量拉人；整批全失败且 >1 个时回退逐个拉（镜像 group-creator 的批处理回退）。 */
+async function addBotsResilient(larkAppId: string, chatId: string, ids: string[]) {
+  let results: { id: string; ok: boolean; error?: string }[] = [];
+  for (let i = 0; i < ids.length; i += INVITE_BATCH_SIZE) {
+    const batch = ids.slice(i, i + INVITE_BATCH_SIZE);
+    let r = await addBotToChat(larkAppId, chatId, batch);
+    if (batch.length > 1 && r.every(x => !x.ok)) {
+      // 整批失败可能是单个坏 id 拖累全批 → 逐个隔离重试，让好 id 落进去。
+      const perId: typeof r = [];
+      for (const id of batch) perId.push(...await addBotToChat(larkAppId, chatId, [id]));
+      r = perId;
+    }
+    results.push(...r);
+  }
+  return results;
+}
+
+/** 返回 true 表示已拦截（不再进入路由/spawn）。 */
+export async function tryHandleInviteCommand(
+  larkAppId: string, message: any, senderOpenId: string | undefined,
+): Promise<boolean> {
+  const rawText = extractMessageTextForRouting(message);
+  if (!rawText) return false;
+  // 先 strip 掉开头的 @<mention>（含本 bot），否则 `@bot /invite @x` 匹配不到命令词。
+  const text = stripLeadingMentions(rawText.trim(), message?.mentions ?? []);
+  if (!/^\/invite(\s|$)/i.test(text)) return false;
+
+  const myOpenId = getBotOpenId(larkAppId);
+  const messageId = message.message_id;
+  const chatId = message.chat_id;
+  const loc = localeForBot(larkAppId);
+  const reply = (key: string, params?: Record<string, string | number>) =>
+    replyMessage(larkAppId, messageId, t(key, params, loc))
+      .catch(err => logger.debug(`invite ${key} reply failed: ${err}`));
+
+  // 本 bot 只是作为 /invite 的【目标】被 @（`@OperatorBot /invite @ThisBot`）→ 命令属于
+  // 前导 @ 的操作 bot，本 bot 必须静默放手（同 /grant 的 target-only 守卫）。
+  if (isCommandTargetOnly(message, myOpenId, INVITE_CMD_PATTERN)) {
+    logger.debug(`[invite:${larkAppId}] ignoring /invite where this bot is only a target`);
+    return true;
+  }
+
+  // 私聊拉不了成员。必须在 isBotMentioned 选举门之前：DM 里没有群成员表、用户
+  // @ 不出本 bot，放选举门后面这条提示永远不可达，用户只会看到沉默。
+  if (message?.chat_type === 'p2p') {
+    await reply('cmd.invite.p2p');
+    return true;
+  }
+
+  // 多 bot 群：必须明确 @ 当前 bot 才由本 daemon 处理；否则吞掉（不喂 CLI）。
+  if (!isBotMentioned(larkAppId, message, senderOpenId)) return true;
+
+  // owner 强闸门（对齐 /grant）。
+  const owner = getOwnerOpenId(larkAppId);
+  if (!senderOpenId || senderOpenId !== owner) {
+    await reply('cmd.invite.owner_only');
+    return true;
+  }
+
+  if (!chatId) {
+    await reply('cmd.invite.usage');
+    return true;
+  }
+
+  const mentionTargets = parseTargetsAfterCommand(message, myOpenId, INVITE_CMD_PATTERN);
+  const args = parseInviteArgs(text, message?.mentions ?? []);
+  if (args.badAppTokens.length > 0 || args.leftover) {
+    await reply('cmd.invite.usage');
+    return true;
+  }
+  if (mentionTargets.length === 0 && args.appIds.length === 0) {
+    await reply('cmd.invite.usage');
+    return true;
+  }
+
+  // live 群 bot 成员表：already-in-chat 判定的权威源。拿不到就降级为空表——
+  // 飞书 API 自身对重复拉人也是幂等报错，不至于出错事（与 /group 对 listChatBotMembers
+  // 的容错一致）。
+  let roster: ChatBotMember[] = [];
+  try {
+    roster = await listChatBotMembers(larkAppId, chatId);
+  } catch (e: any) {
+    logger.warn(`[invite:${larkAppId}] failed to list chat bot members (already-in-chat detection degraded): ${e?.message ?? e}`);
+  }
+  const rosterOpenIds = new Set(roster.map(m => m.openId));
+  const rosterAppIds = new Set(roster.map(m => m.larkAppId).filter(Boolean));
+  const rosterNameById = new Map(roster.filter(m => m.larkAppId).map(m => [m.larkAppId, m.displayName || m.name || m.larkAppId]));
+
+  const botsInfo = readBotsInfoEntries();
+  const byLowerName = new Map<string, BotsInfoEntry[]>();
+  for (const e of botsInfo) {
+    const k = e.botName?.toLowerCase();
+    if (!k) continue;
+    (byLowerName.get(k) ?? byLowerName.set(k, []).get(k)!).push(e);
+  }
+  const nameOf = (appId: string) =>
+    botsInfo.find(e => e.larkAppId === appId)?.botName ?? rosterNameById.get(appId) ?? appId;
+
+  const toInvite: string[] = [];
+  const already: string[] = [];
+  const unresolved: string[] = [];
+  const ambiguous: string[] = [];
+
+  for (const tgt of mentionTargets) {
+    if (rosterOpenIds.has(tgt.openId)) { already.push(tgt.name); continue; }
+    const candidates = tgt.name ? (byLowerName.get(tgt.name.toLowerCase()) ?? []) : [];
+    if (candidates.length === 1) {
+      const appId = candidates[0].larkAppId;
+      if (appId === larkAppId || rosterAppIds.has(appId)) already.push(tgt.name);
+      else if (!toInvite.includes(appId)) toInvite.push(appId);
+    } else if (candidates.length > 1) {
+      ambiguous.push(t('cmd.invite.ambiguous_item', { name: tgt.name, apps: candidates.map(c => c.larkAppId).join('、') }, loc));
+    } else {
+      unresolved.push(tgt.name || tgt.openId);
+    }
+  }
+  for (const appId of args.appIds) {
+    if (appId === larkAppId || rosterAppIds.has(appId)) already.push(nameOf(appId));
+    else if (!toInvite.includes(appId)) toInvite.push(appId);
+  }
+
+  const added: string[] = [];
+  const failed: string[] = [];
+  if (toInvite.length > 0) {
+    const results = await addBotsResilient(larkAppId, chatId, toInvite);
+    for (const r of results) {
+      if (r.ok) added.push(nameOf(r.id));
+      else failed.push(t('cmd.invite.failed_item', { name: nameOf(r.id), reason: r.error ?? 'unknown' }, loc));
+    }
+  }
+
+  const sections: string[] = [];
+  if (added.length) sections.push(t('cmd.invite.ok', { names: added.join('、') }, loc));
+  if (already.length) sections.push(t('cmd.invite.already', { names: [...new Set(already)].join('、') }, loc));
+  if (unresolved.length) sections.push(t('cmd.invite.unresolved', { names: [...new Set(unresolved)].join('、') }, loc));
+  if (ambiguous.length) sections.push(...ambiguous);
+  if (failed.length) sections.push(...failed);
+  const body = sections.join('\n') || t('cmd.invite.usage', undefined, loc);
+  await replyMessage(larkAppId, messageId,
+    toInvite.length > 0 || already.length > 0 ? t('cmd.invite.header', undefined, loc) + '\n' + body : body,
+  ).catch(err => logger.debug(`invite result reply failed: ${err}`));
+  logger.info(
+    `[invite:${larkAppId}] chat=${chatId} added=[${added}] already=[${already}] ` +
+    `unresolved=[${unresolved}] ambiguous=${ambiguous.length} failed=[${failed}]`,
+  );
+  return true;
+}

--- a/src/im/lark/invite-command.ts
+++ b/src/im/lark/invite-command.ts
@@ -193,7 +193,16 @@ export async function tryHandleInviteCommand(
   const ambiguous: string[] = [];
 
   for (const tgt of mentionTargets) {
-    if (rosterOpenIds.has(tgt.openId)) { already.push(tgt.name); continue; }
+    // 已在群内：open_id 命中 live 成员表即跳过（app_id 形态目标无 open_id，靠下方 appId 分支的 rosterAppIds 判定）。
+    if (tgt.openId && rosterOpenIds.has(tgt.openId)) { already.push(tgt.name); continue; }
+    // 目标 mention 自带 app_id（飞书对「群外 bot」的 @ 形态）→ app_id 就是待拉 id，
+    // 直接用，跳过名字→花名册解析（更可靠，规避重名/查无）。
+    if (tgt.appId) {
+      if (tgt.appId === larkAppId || rosterAppIds.has(tgt.appId)) already.push(tgt.name);
+      else if (!toInvite.includes(tgt.appId)) toInvite.push(tgt.appId);
+      continue;
+    }
+    // 仅有 open_id（无 app_id）：按显示名查部署花名册解析出 app_id。
     const candidates = tgt.name ? (byLowerName.get(tgt.name.toLowerCase()) ?? []) : [];
     if (candidates.length === 1) {
       const appId = candidates[0].larkAppId;

--- a/src/im/lark/mention-targets.ts
+++ b/src/im/lark/mention-targets.ts
@@ -13,12 +13,21 @@
  * 从 grant-command.ts 提炼泛化（2026-07 /invite 落地时）；grant 的对外导出
  * （parseGrantTargets / isGrantTargetOnly / stripAllMentions）保持原样委托到这里。
  */
-import { mentionOpenId } from './message-parser.js';
+import { mentionOpenId, mentionIdentity } from './message-parser.js';
 
 /** 命令正则必须带 `\b` 边界、不带 g 标志（exec/index 语义依赖）。 */
 export type CommandPattern = RegExp;
 
-export interface MentionTarget { openId: string; name: string }
+/**
+ * `openId`：mention 的 open_id（可能为空——飞书用 `{id_type:'app_id', id:'cli_xxx'}`
+ * 形态标识**群外 bot**，此时无 open_id，见 message-parser 的 mentionOpenId 注释）。
+ * `appId`：mention 的 app_id（仅 app_id 形态 mention 才有）。
+ * 二者至少有一个非空该 target 才被收录（/invite 拉群外 bot 主场景恰恰只有 appId）。
+ * /grant 只消费 openId（授权对象必须是 open_id 主体），app_id-only 目标由
+ * parseGrantTargets 过滤掉——grant 行为与历史 byte-parity（app_id 形态过去被
+ * mentionOpenId 直接 drop，本就不在 grant 目标里）。
+ */
+export interface MentionTarget { openId: string; name: string; appId?: string }
 
 /**
  * 从 mention 列表取「cmdPattern 匹配的命令词之后」出现的所有非本 bot @，按
@@ -45,10 +54,11 @@ export function parseTargetsAfterCommand(
   const seen = new Set<string>();
   const out: MentionTarget[] = [];
   for (const x of (message?.mentions ?? [])) {
-    const oid = mentionOpenId(x);
-    if (!oid || oid === botOpenId || seen.has(oid)) continue;
-    seen.add(oid);
-    out.push({ openId: oid, name: x.name ?? oid });
+    const { openId: oid, appId } = mentionIdentity(x);
+    const dedup = oid || appId;                 // app_id 形态无 open_id，用 appId 去重
+    if (!dedup || oid === botOpenId || appId === botOpenId || seen.has(dedup)) continue;
+    seen.add(dedup);
+    out.push({ openId: oid ?? '', name: x.name ?? oid ?? appId ?? '', appId });
   }
   return out;
 }
@@ -63,15 +73,16 @@ function parseTextTargetsAfterCommand(
   const seen = new Set<string>();
   const out: MentionTarget[] = [];
   for (const m of mentions) {
-    const oid = mentionOpenId(m);
-    if (!oid || oid === botOpenId || seen.has(oid)) continue;
+    const { openId: oid, appId } = mentionIdentity(m);
+    const dedup = oid || appId;                 // app_id 形态（群外 bot）无 open_id，用 appId 去重
+    if (!dedup || oid === botOpenId || appId === botOpenId || seen.has(dedup)) continue;
     const key = m?.key;
     if (cmdIdx >= 0 && typeof key === 'string' && key.length > 0) {
       const km = new RegExp(`${escapeRe(key)}(?!\\d)`).exec(text);
       if (km && km.index <= cmdIdx) continue;   // 命令词之前 = 操作 bot 点名，剔除
     }
-    seen.add(oid);
-    out.push({ openId: oid, name: m.name ?? oid });
+    seen.add(dedup);
+    out.push({ openId: oid ?? '', name: m.name ?? oid ?? appId ?? '', appId });
   }
   return out;
 }
@@ -87,20 +98,23 @@ function parsePostAtMentions(message: any, botOpenId: string | undefined, cmdPat
   if (!Array.isArray(inner?.content)) return out;
   // 先定位命令词文本节点的序号，再只收其后的 at 节点。
   let seq = 0, cmdSeq = -1;
-  const ats: Array<{ oid: string; name: string; seq: number }> = [];
+  const ats: Array<{ id: string; name: string; seq: number }> = [];
   for (const para of inner.content) {
     if (!Array.isArray(para)) continue;
     for (const node of para) {
       if (cmdSeq < 0 && node?.tag === 'text' && cmdPattern.test(node.text ?? '')) cmdSeq = seq;
-      if (node?.tag === 'at' && node.user_id) ats.push({ oid: node.user_id, name: node.user_name ?? node.user_id, seq });
+      if (node?.tag === 'at' && node.user_id) ats.push({ id: node.user_id, name: node.user_name ?? node.user_id, seq });
       seq++;
     }
   }
   for (const a of ats) {
-    if (a.oid === botOpenId || seen.has(a.oid)) continue;
+    if (a.id === botOpenId || seen.has(a.id)) continue;
     if (cmdSeq >= 0 && a.seq <= cmdSeq) continue;   // 命令词之前 = 操作 bot 点名，剔除
-    seen.add(a.oid);
-    out.push({ openId: a.oid, name: a.name });
+    seen.add(a.id);
+    // 群外 bot 的 at 节点 user_id 是 `cli_` 前缀 app_id（open_id 恒为 `ou_`，不冲突）→
+    // 归到 appId 让 /invite 直接拿去拉人；否则按 open_id（/grant、群内 bot）。
+    const isAppId = /^cli_/.test(a.id);
+    out.push(isAppId ? { openId: '', name: a.name, appId: a.id } : { openId: a.id, name: a.name });
   }
   return out;
 }

--- a/src/im/lark/mention-targets.ts
+++ b/src/im/lark/mention-targets.ts
@@ -1,0 +1,161 @@
+/**
+ * 「@执行bot /<cmd> @目标…」形态元命令的共享 mention 解析。
+ *
+ * `/grant`、`/invite` 这类命令的同一种 mention 语义：
+ *  - 命令词**之前**的 @ 是「点名让哪个 bot 执行」——不是目标（多 bot 群里
+ *    owner 常同时 @ 多个操作 bot，位置过滤走错会把操作 bot 当目标，实测踩过：
+ *    两 bot 互相 grant）；
+ *  - 命令词**之后**的 @ 才是目标；排除执行 bot 自身；
+ *  - text 形态（content.text 里是 key 占位符）与 post 富文本形态（inline at
+ *    节点、message.mentions 常为空）都要支持；位置信息缺失的合成消息退回
+ *    「全部非本 bot mention」的历史宽松行为。
+ *
+ * 从 grant-command.ts 提炼泛化（2026-07 /invite 落地时）；grant 的对外导出
+ * （parseGrantTargets / isGrantTargetOnly / stripAllMentions）保持原样委托到这里。
+ */
+import { mentionOpenId } from './message-parser.js';
+
+/** 命令正则必须带 `\b` 边界、不带 g 标志（exec/index 语义依赖）。 */
+export type CommandPattern = RegExp;
+
+export interface MentionTarget { openId: string; name: string }
+
+/**
+ * 从 mention 列表取「cmdPattern 匹配的命令词之后」出现的所有非本 bot @，按
+ * open_id 去重、保持 @ 顺序（支持一次命令带多目标）。
+ */
+export function parseTargetsAfterCommand(
+  message: any, botOpenId: string | undefined, cmdPattern: CommandPattern,
+): MentionTarget[] {
+  let content: any;
+  try { content = JSON.parse(message?.content ?? '{}'); } catch { content = undefined; }
+
+  // text 形态：@ 落在 content.text 里，每个 mention 带 key 占位符可定位其位置 → 按命令词位置过滤。
+  if (content && typeof content.text === 'string') {
+    return parseTextTargetsAfterCommand(content.text, message?.mentions ?? [], botOpenId, cmdPattern);
+  }
+  // post（富文本）形态：@ 落在 inline `at` 节点（message.mentions 常为空、偶有填充，统一走节点序）→
+  // 按命令词节点位置过滤，不被「message.mentions 是否填充」左右。
+  const inner = content?.zh_cn ?? content?.en_us ?? content;
+  if (Array.isArray(inner?.content)) {
+    return parsePostAtMentions(message, botOpenId, cmdPattern);
+  }
+
+  // 合成消息（仅 mentions、无 content 结构，多见于单测/旧调用）：无位置信息，退回全部非本 bot。
+  const seen = new Set<string>();
+  const out: MentionTarget[] = [];
+  for (const x of (message?.mentions ?? [])) {
+    const oid = mentionOpenId(x);
+    if (!oid || oid === botOpenId || seen.has(oid)) continue;
+    seen.add(oid);
+    out.push({ openId: oid, name: x.name ?? oid });
+  }
+  return out;
+}
+
+/** text 形态：只取「命令词之后」的非本 bot mention。用 mention 的 key 占位符定位其在 text 里的
+ *  位置；`key(?!\d)` 边界规避 @_user_1 / @_user_10 前缀歧义（与 isCommandTargetOnly 同款）。
+ *  定位不到 key（异常形态）时保守退回「视为目标」，与历史行为一致，不漏真实 target。 */
+function parseTextTargetsAfterCommand(
+  text: string, mentions: any[], botOpenId: string | undefined, cmdPattern: CommandPattern,
+): MentionTarget[] {
+  const cmdIdx = text.search(cmdPattern);
+  const seen = new Set<string>();
+  const out: MentionTarget[] = [];
+  for (const m of mentions) {
+    const oid = mentionOpenId(m);
+    if (!oid || oid === botOpenId || seen.has(oid)) continue;
+    const key = m?.key;
+    if (cmdIdx >= 0 && typeof key === 'string' && key.length > 0) {
+      const km = new RegExp(`${escapeRe(key)}(?!\\d)`).exec(text);
+      if (km && km.index <= cmdIdx) continue;   // 命令词之前 = 操作 bot 点名，剔除
+    }
+    seen.add(oid);
+    out.push({ openId: oid, name: m.name ?? oid });
+  }
+  return out;
+}
+
+/** 从 post inline `at` 节点取非本 bot 的目标（user_name 兜 name），按 user_id 去重、保持顺序。
+ *  同 text 形态：只收「命令词文本节点之后」的 `at` 节点（前导 @ 是操作 bot 点名，剔除）。 */
+function parsePostAtMentions(message: any, botOpenId: string | undefined, cmdPattern: CommandPattern): MentionTarget[] {
+  const seen = new Set<string>();
+  const out: MentionTarget[] = [];
+  let content: any;
+  try { content = JSON.parse(message?.content ?? '{}'); } catch { return out; }
+  const inner = content?.zh_cn ?? content?.en_us ?? content;
+  if (!Array.isArray(inner?.content)) return out;
+  // 先定位命令词文本节点的序号，再只收其后的 at 节点。
+  let seq = 0, cmdSeq = -1;
+  const ats: Array<{ oid: string; name: string; seq: number }> = [];
+  for (const para of inner.content) {
+    if (!Array.isArray(para)) continue;
+    for (const node of para) {
+      if (cmdSeq < 0 && node?.tag === 'text' && cmdPattern.test(node.text ?? '')) cmdSeq = seq;
+      if (node?.tag === 'at' && node.user_id) ats.push({ oid: node.user_id, name: node.user_name ?? node.user_id, seq });
+      seq++;
+    }
+  }
+  for (const a of ats) {
+    if (a.oid === botOpenId || seen.has(a.oid)) continue;
+    if (cmdSeq >= 0 && a.seq <= cmdSeq) continue;   // 命令词之前 = 操作 bot 点名，剔除
+    seen.add(a.oid);
+    out.push({ openId: a.oid, name: a.name });
+  }
+  return out;
+}
+
+/**
+ * 本 bot 是否「只是作为命令的目标」被 @（@ 出现在命令词之后），而不是被前导 @
+ * 点名执行命令的操作 bot。命中（仅目标）返回 true，调用方应静默放手——否则
+ * 目标 bot 会误回 owner_only / 把自己剔空后误执行。
+ *
+ * text 与 post（富文本）两种消息形态都覆盖（同 parseTargetsAfterCommand）：
+ *  - text：{"text":"@_user_1 /cmd @_user_2"}，@ 是占位符 key；用「key 后不接数字」
+ *    的边界锁定整 token，规避 @_user_1 / @_user_10 这类 key 前缀歧义。
+ *  - post：@ 是独立的 `at` 节点（不在 text 里、mentions 可能为空），按文档节点
+ *    顺序比较本 bot 的 `at` 节点与含命令词的 text 节点的先后。
+ */
+export function isCommandTargetOnly(message: any, botOpenId: string | undefined, cmdPattern: CommandPattern): boolean {
+  if (!botOpenId) return false;
+  let content: any;
+  try { content = JSON.parse(message?.content ?? '{}'); } catch { return false; }
+
+  if (typeof content?.text === 'string') {
+    const key = (message?.mentions ?? []).find((m: any) => mentionOpenId(m) === botOpenId)?.key;
+    if (!key) return false;
+    const cmdIdx = content.text.search(cmdPattern);
+    const keyMatch = new RegExp(`${escapeRe(key)}(?!\\d)`).exec(content.text);
+    const myIdx = keyMatch ? keyMatch.index : -1;
+    return cmdIdx >= 0 && myIdx > cmdIdx;
+  }
+
+  const inner = content?.zh_cn ?? content?.en_us ?? content;
+  if (Array.isArray(inner?.content)) {
+    let seq = 0, cmdSeq = -1, mySeq = -1;
+    for (const para of inner.content) {
+      if (!Array.isArray(para)) continue;
+      for (const node of para) {
+        if (cmdSeq < 0 && node?.tag === 'text' && cmdPattern.test(node.text ?? '')) cmdSeq = seq;
+        if (mySeq < 0 && node?.tag === 'at' && node.user_id === botOpenId) mySeq = seq;
+        seq++;
+      }
+    }
+    return cmdSeq >= 0 && mySeq > cmdSeq;
+  }
+  return false;
+}
+
+/** 把文本里所有 `@<name>` mention token 去掉（split/join，防正则注入），归一空白后 trim。 */
+export function stripAllMentions(text: string, mentions: any[]): string {
+  let s = text;
+  for (const m of mentions ?? []) {
+    const name = m?.name;
+    if (typeof name === 'string' && name.length) s = s.split(`@${name}`).join(' ');
+  }
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+export function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/im/lark/mention-targets.ts
+++ b/src/im/lark/mention-targets.ts
@@ -13,7 +13,7 @@
  * 从 grant-command.ts 提炼泛化（2026-07 /invite 落地时）；grant 的对外导出
  * （parseGrantTargets / isGrantTargetOnly / stripAllMentions）保持原样委托到这里。
  */
-import { mentionOpenId, mentionIdentity } from './message-parser.js';
+import { mentionIdentity } from './message-parser.js';
 
 /** 命令正则必须带 `\b` 边界、不带 g 标志（exec/index 语义依赖）。 */
 export type CommandPattern = RegExp;
@@ -124,19 +124,32 @@ function parsePostAtMentions(message: any, botOpenId: string | undefined, cmdPat
  * 点名执行命令的操作 bot。命中（仅目标）返回 true，调用方应静默放手——否则
  * 目标 bot 会误回 owner_only / 把自己剔空后误执行。
  *
+ * 本 bot 的身份判据要**同时**认 open_id 与 app_id：飞书对「群外 / 协作 bot」的 @
+ * 常以 `{id_type:'app_id', id:'cli_xxx'}` 形态下发（无 open_id），只认 open_id 会
+ * 漏判 `@OperatorBot /cmd @ThisBot(app_id 形态)` → guard 不命中 → 目标 bot 误回
+ * owner_only / 已在群（实测 blocker，2026-07 /invite app_id 支持）。botAppId 即本
+ * bot 的 larkAppId（app_id 形态自我识别用）。
+ *
  * text 与 post（富文本）两种消息形态都覆盖（同 parseTargetsAfterCommand）：
  *  - text：{"text":"@_user_1 /cmd @_user_2"}，@ 是占位符 key；用「key 后不接数字」
  *    的边界锁定整 token，规避 @_user_1 / @_user_10 这类 key 前缀歧义。
  *  - post：@ 是独立的 `at` 节点（不在 text 里、mentions 可能为空），按文档节点
  *    顺序比较本 bot 的 `at` 节点与含命令词的 text 节点的先后。
  */
-export function isCommandTargetOnly(message: any, botOpenId: string | undefined, cmdPattern: CommandPattern): boolean {
-  if (!botOpenId) return false;
+export function isCommandTargetOnly(
+  message: any, botOpenId: string | undefined, cmdPattern: CommandPattern, botAppId?: string,
+): boolean {
+  if (!botOpenId && !botAppId) return false;
+  /** 该 mention 是否指向本 bot（open_id 或 app_id 任一命中）。 */
+  const isMe = (m: any): boolean => {
+    const { openId, appId } = mentionIdentity(m);
+    return (!!botOpenId && openId === botOpenId) || (!!botAppId && appId === botAppId);
+  };
   let content: any;
   try { content = JSON.parse(message?.content ?? '{}'); } catch { return false; }
 
   if (typeof content?.text === 'string') {
-    const key = (message?.mentions ?? []).find((m: any) => mentionOpenId(m) === botOpenId)?.key;
+    const key = (message?.mentions ?? []).find(isMe)?.key;
     if (!key) return false;
     const cmdIdx = content.text.search(cmdPattern);
     const keyMatch = new RegExp(`${escapeRe(key)}(?!\\d)`).exec(content.text);
@@ -151,7 +164,8 @@ export function isCommandTargetOnly(message: any, botOpenId: string | undefined,
       if (!Array.isArray(para)) continue;
       for (const node of para) {
         if (cmdSeq < 0 && node?.tag === 'text' && cmdPattern.test(node.text ?? '')) cmdSeq = seq;
-        if (mySeq < 0 && node?.tag === 'at' && node.user_id === botOpenId) mySeq = seq;
+        // post at 节点：user_id 可能是本 bot 的 open_id（群内）或 app_id（cli_ 前缀，群外形态）。
+        if (mySeq < 0 && node?.tag === 'at' && node.user_id && (node.user_id === botOpenId || node.user_id === botAppId)) mySeq = seq;
         seq++;
       }
     }

--- a/test/grant-command.test.ts
+++ b/test/grant-command.test.ts
@@ -444,6 +444,28 @@ describe('tryHandleGrantCommand bot-as-target (@operator /grant @thisBot)', () =
     expect(replyMock).not.toHaveBeenCalled();
     expect(getBot('btb').config.allowedChatGroups ?? []).toEqual([]);   // 整群授权绝不被误开
   });
+
+  // OPERATOR 视角（codex delta-3）：本 bot 是**前导** operator（命令前），尾部目标是**别的**
+  // app_id-only bot。parseGrantTargets 的 .filter 会把 app_id-only 目标剔空 → targets 空 →
+  // 若据此走裸 /grant 整群授权 = 提权（owner 本意授权某 bot，误对全群开放 talk）。必须 fail
+  // closed：hasAnyTargetMention 识别「命令后有目标只是不可按 open_id 授权」→ 回 usage、不开整群。
+  it('owner sender, this bot is OPERATOR + tail target is another app_id-only bot → fail closed, whole-chat NOT opened', async () => {
+    const opWithAppIdTarget = {
+      message_id: 'om_opa', chat_id: 'oc_1',
+      content: JSON.stringify({ text: '@_user_1 /grant @_user_2' }),
+      mentions: [
+        { key: '@_user_1', id: { open_id: 'ou_bot' }, name: 'Codex' },          // 本 bot = 前导 operator
+        { key: '@_user_2', id: 'cli_other', id_type: 'app_id', name: 'Other' }, // 别的 bot，app_id-only，尾部目标
+      ],
+    };
+    const handled = await tryHandleGrantCommand('btb', opWithAppIdTarget, 'ou_owner');
+    expect(handled).toBe(true);
+    expect(getBot('btb').config.allowedChatGroups ?? []).toEqual([]);   // 绝不因目标被剔空而误开整群
+    // 且不是静默：应回 usage 明确「不按 app_id 授权」，不能与真正裸 /grant 等价。
+    const [, , content, msgType] = replyMock.mock.calls.at(-1) ?? [];
+    expect(msgType ?? 'text').not.toBe('interactive');   // 不是授权卡
+    expect(String(content ?? '')).not.toContain('已授权本群所有成员');   // 绝不是整群授权回执
+  });
 });
 
 describe('tryHandleGrantCommand two bots co-addressed (@Claude @Codex /grant)', () => {

--- a/test/grant-command.test.ts
+++ b/test/grant-command.test.ts
@@ -426,6 +426,24 @@ describe('tryHandleGrantCommand bot-as-target (@operator /grant @thisBot)', () =
     const [, , , msgType] = replyMock.mock.calls.at(-1)!;
     expect(msgType).toBe('interactive');                         // card still pops for the operator
   });
+
+  // 本 bot 以 **app_id 形态**（larkAppId=btb）作为目标出现在命令词后。这是协作 bot 被 @
+  // 的常见形态。修复前 guard 只认 open_id → 漏判 → parseGrantTargets 的 .filter(openId)
+  // 把 app_id-only 自身剔空 → targets 空 → 误走整群授权分支（提权，codex 警告的失败模式）。
+  it('owner sender, this bot @ed as app_id after /grant → silent, whole-chat NOT opened', async () => {
+    const appIdTargetMsg = {
+      message_id: 'om_aid', chat_id: 'oc_1',
+      content: JSON.stringify({ text: '@_user_1 /grant @_user_2' }),
+      mentions: [
+        { key: '@_user_1', id: { open_id: 'ou_op' }, name: 'Claude' },      // 操作 bot（前导 @）
+        { key: '@_user_2', id: 'btb', id_type: 'app_id', name: 'Codex' },   // 本 bot，app_id 形态目标
+      ],
+    };
+    const handled = await tryHandleGrantCommand('btb', appIdTargetMsg, 'ou_owner');
+    expect(handled).toBe(true);
+    expect(replyMock).not.toHaveBeenCalled();
+    expect(getBot('btb').config.allowedChatGroups ?? []).toEqual([]);   // 整群授权绝不被误开
+  });
 });
 
 describe('tryHandleGrantCommand two bots co-addressed (@Claude @Codex /grant)', () => {

--- a/test/invite-command.test.ts
+++ b/test/invite-command.test.ts
@@ -300,3 +300,86 @@ describe('tryHandleInviteCommand — 解析与拉人', () => {
     expect(addBotMock).toHaveBeenCalledWith('b1', 'oc_1', ['cli_codex']);
   });
 });
+
+// 回归锁（codex blocker）：飞书对「群外 bot」的 @ 是 app_id 形态
+// （{id_type:'app_id', id:'cli_xxx'} 或 object {app_id:'cli_xxx'}），
+// 过去 mentionOpenId 直接 drop → 目标空 → 误回 usage 不拉人。这些用例在修复前必挂。
+describe('tryHandleInviteCommand — app_id 形态目标（群外 bot 主场景）', () => {
+  it('text form, target mention as app_id OBJECT (WS shape, no open_id) → invited by app_id directly', async () => {
+    writeBotsInfo([]);   // 花名册为空也应能拉（app_id 自带，不依赖名字解析）
+    const msg = inviteMessage({
+      text: '@_user_1 /invite @_user_2',
+      mentions: [
+        { key: '@_user_1', id: { open_id: ME }, name: 'Claude' },
+        { key: '@_user_2', id: { app_id: 'cli_codex' }, name: 'Codex' },
+      ],
+    });
+    expect(await tryHandleInviteCommand('b1', msg, OWNER)).toBe(true);
+    expect(addBotMock).toHaveBeenCalledWith('b1', 'oc_1', ['cli_codex']);
+    expect(String(replyMock.mock.calls.at(-1)![2])).toContain('已拉进群');
+  });
+
+  it('text form, target mention as app_id STRING (REST shape) → invited by app_id directly', async () => {
+    writeBotsInfo([]);
+    const msg = inviteMessage({
+      text: '@_user_1 /invite @_user_2',
+      mentions: [
+        { key: '@_user_1', id: { open_id: ME }, name: 'Claude' },
+        { key: '@_user_2', id: 'cli_codex', id_type: 'app_id', name: 'Codex' },
+      ],
+    });
+    expect(await tryHandleInviteCommand('b1', msg, OWNER)).toBe(true);
+    expect(addBotMock).toHaveBeenCalledWith('b1', 'oc_1', ['cli_codex']);
+  });
+
+  it('post form, target at-node carries cli_ app_id in user_id → invited directly', async () => {
+    writeBotsInfo([]);
+    const postMsg = {
+      message_id: 'om_post2', chat_id: 'oc_1',
+      content: JSON.stringify({ zh_cn: { content: [[
+        { tag: 'at', user_id: ME, user_name: 'Claude' },
+        { tag: 'text', text: ' /invite ' },
+        { tag: 'at', user_id: 'cli_codex', user_name: 'Codex' },
+      ]] } }),
+      mentions: [],
+    };
+    expect(await tryHandleInviteCommand('b1', postMsg, OWNER)).toBe(true);
+    expect(addBotMock).toHaveBeenCalledWith('b1', 'oc_1', ['cli_codex']);
+  });
+
+  it('app_id target already in chat (roster app_id match) is skipped, not re-invited', async () => {
+    writeBotsInfo([]);
+    rosterMock.mockImplementation(async () => [
+      { larkAppId: 'cli_codex', openId: 'ou_codex_scoped', name: 'Codex', displayName: 'Codex' },
+    ]);
+    const msg = inviteMessage({
+      text: '@_user_1 /invite @_user_2',
+      mentions: [
+        { key: '@_user_1', id: { open_id: ME }, name: 'Claude' },
+        { key: '@_user_2', id: { app_id: 'cli_codex' }, name: 'Codex' },
+      ],
+    });
+    expect(await tryHandleInviteCommand('b1', msg, OWNER)).toBe(true);
+    expect(addBotMock).not.toHaveBeenCalled();
+    expect(String(replyMock.mock.calls.at(-1)![2])).toContain('已在群内');
+  });
+
+  it('target-only guard still fires when THIS bot is @ed as app_id after /invite', async () => {
+    // 本 bot 被以 app_id 形态 @ 在 /invite 之后 = 本 bot 是 invitee → 静默放手。
+    // b1 的 larkAppId 即 "b1"，用它当本 bot 的 app_id 形态 mention。
+    const msg = inviteMessage({
+      text: '@_user_1 /invite @_user_2',
+      mentions: [
+        { key: '@_user_1', id: { open_id: 'ou_opbot' }, name: 'OpBot' },
+        { key: '@_user_2', id: 'b1', id_type: 'app_id', name: 'Claude' },
+      ],
+    });
+    // isCommandTargetOnly 用 open_id 判据；app_id 形态的本 bot @ 不会命中 target-only，
+    // 但仍必须不把「自己」误当拉取目标 → toInvite 不含 b1（rosterAppIds/larkAppId 自排除）。
+    expect(await tryHandleInviteCommand('b1', msg, OWNER)).toBe(true);
+    // 关键断言：绝不把本 bot 自己的 app_id 拉进群。
+    for (const call of addBotMock.mock.calls) {
+      expect(call[2]).not.toContain('b1');
+    }
+  });
+});

--- a/test/invite-command.test.ts
+++ b/test/invite-command.test.ts
@@ -1,0 +1,302 @@
+/**
+ * invite-command：`@bot /invite @目标bot` / `--app cli_xxx` 拉群外 bot 进本群。
+ * 覆盖：参数解析纯函数、花名册读取、target-only 守卫、owner 闸门、名字→appId
+ * 解析（唯一/未解析/歧义）、已在群内幂等、批量失败逐个回退。
+ * Run: pnpm vitest run test/invite-command.test.ts
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@larksuiteoapi/node-sdk', () => {
+  class FakeClient { constructor(public opts: Record<string, unknown>) {} }
+  return { Client: FakeClient };
+});
+
+// 拦截回执与拉人 API，避免真实 Lark 调用。
+const replyMock = vi.fn(async () => 'om_reply');
+const rosterMock = vi.fn(async (_app: string, _chat: string) => [] as any[]);
+const addBotMock = vi.fn(async (_app: string, _chat: string, ids: string[]) =>
+  ids.map(id => ({ id, ok: true })) as { id: string; ok: boolean; error?: string }[]);
+vi.mock('../src/im/lark/client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/im/lark/client.js')>();
+  return {
+    ...actual,
+    replyMessage: (...a: any[]) => replyMock(...a),
+    listChatBotMembers: (...a: any[]) => rosterMock(...a),
+  };
+});
+vi.mock('../src/services/groups-store.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/services/groups-store.js')>();
+  return { ...actual, addBotToChat: (...a: any[]) => addBotMock(...a) };
+});
+
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { tryHandleInviteCommand, parseInviteArgs, readBotsInfoEntries } from '../src/im/lark/invite-command.js';
+import { registerBot } from '../src/bot-registry.js';
+import { config } from '../src/config.js';
+
+const OWNER = 'ou_owner';
+const ME = 'ou_bot';
+
+/** text 形态：`@_user_1`（=本 bot，前导操作方点名）+ `/invite` + 尾部目标。 */
+function inviteMessage(overrides: {
+  text?: string; mentions?: any[]; chatType?: string; chatId?: string;
+} = {}) {
+  return {
+    message_id: 'om_inv', chat_id: overrides.chatId ?? 'oc_1',
+    ...(overrides.chatType ? { chat_type: overrides.chatType } : {}),
+    content: JSON.stringify({ text: overrides.text ?? '@_user_1 /invite @_user_2' }),
+    mentions: overrides.mentions ?? [
+      { key: '@_user_1', id: { open_id: ME }, name: 'Claude' },
+      { key: '@_user_2', id: { open_id: 'ou_codex' }, name: 'Codex' },
+    ],
+  };
+}
+
+let tmpDir: string;
+function writeBotsInfo(entries: Array<{ larkAppId: string; botName: string | null }>) {
+  writeFileSync(join(tmpDir, 'bots-info.json'), JSON.stringify(entries));
+}
+
+beforeEach(() => {
+  replyMock.mockClear();
+  rosterMock.mockClear();
+  addBotMock.mockClear();
+  rosterMock.mockImplementation(async () => []);
+  addBotMock.mockImplementation(async (_a, _c, ids: string[]) => ids.map(id => ({ id, ok: true })));
+  const bot = registerBot({ larkAppId: 'b1', larkAppSecret: 's', cliId: 'claude-code', allowedUsers: [OWNER] });
+  bot.botOpenId = ME;
+  bot.resolvedAllowedUsers = [OWNER];
+  tmpDir = mkdtempSync(join(tmpdir(), 'invite-cmd-'));
+  config.session.dataDir = tmpDir;
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.SESSION_DATA_DIR;
+});
+
+describe('parseInviteArgs', () => {
+  it('parses --app with space and = forms, deduped', () => {
+    expect(parseInviteArgs('/invite --app cli_a --app=cli_b --app cli_a', [])).toEqual({
+      appIds: ['cli_a', 'cli_b'], badAppTokens: [], leftover: '',
+    });
+  });
+  it('flags non-cli_ tokens after --app', () => {
+    const r = parseInviteArgs('/invite --app not_an_app', []);
+    expect(r.appIds).toEqual([]);
+    expect(r.badAppTokens).toEqual(['not_an_app']);
+  });
+  it('flags dangling --app', () => {
+    expect(parseInviteArgs('/invite --app', []).badAppTokens.length).toBe(1);
+  });
+  it('captures leftover garbage tokens', () => {
+    expect(parseInviteArgs('/invite 乱七八糟', []).leftover).toBe('乱七八糟');
+  });
+  it('strips mention display names before tokenizing', () => {
+    const r = parseInviteArgs('/invite @张 三 --app cli_a', [{ name: '张 三' }]);
+    expect(r.appIds).toEqual(['cli_a']);
+    expect(r.leftover).toBe('');
+  });
+});
+
+describe('readBotsInfoEntries', () => {
+  it('returns [] when file missing', () => {
+    expect(readBotsInfoEntries()).toEqual([]);
+  });
+  it('parses entries with larkAppId', () => {
+    writeBotsInfo([{ larkAppId: 'cli_codex', botName: 'Codex' }]);
+    expect(readBotsInfoEntries()).toEqual([{ larkAppId: 'cli_codex', botName: 'Codex' }]);
+  });
+});
+
+describe('tryHandleInviteCommand — 拦截与闸门', () => {
+  it('unrelated message is not intercepted', async () => {
+    const msg = inviteMessage({ text: '@_user_1 帮我看下代码' });
+    expect(await tryHandleInviteCommand('b1', msg, OWNER)).toBe(false);
+  });
+
+  it('non-owner: replies owner_only, never calls addBotToChat', async () => {
+    writeBotsInfo([{ larkAppId: 'cli_codex', botName: 'Codex' }]);
+    expect(await tryHandleInviteCommand('b1', inviteMessage(), 'ou_intruder')).toBe(true);
+    expect(addBotMock).not.toHaveBeenCalled();
+    expect(replyMock).toHaveBeenCalled();
+    expect(String(replyMock.mock.calls.at(-1)![2])).toContain('owner');
+  });
+
+  it('another bot addressed (I am not mentioned): intercepted but fully silent', async () => {
+    const msg = inviteMessage({ mentions: [
+      { key: '@_user_1', id: { open_id: 'ou_otherbot' }, name: 'CoCo' },
+      { key: '@_user_2', id: { open_id: 'ou_codex' }, name: 'Codex' },
+    ] });
+    expect(await tryHandleInviteCommand('b1', msg, OWNER)).toBe(true);
+    expect(replyMock).not.toHaveBeenCalled();
+    expect(addBotMock).not.toHaveBeenCalled();
+  });
+
+  it('target-only guard: I am @ed AFTER /invite → silent (I am the invitee, not the operator)', async () => {
+    const msg = inviteMessage({
+      text: '@_user_1 /invite @_user_2',
+      mentions: [
+        { key: '@_user_1', id: { open_id: 'ou_opbot' }, name: 'OpBot' },
+        { key: '@_user_2', id: { open_id: ME }, name: 'Claude' },
+      ],
+    });
+    expect(await tryHandleInviteCommand('b1', msg, OWNER)).toBe(true);
+    expect(replyMock).not.toHaveBeenCalled();
+    expect(addBotMock).not.toHaveBeenCalled();
+  });
+
+  it('p2p chat: refuses with p2p reply', async () => {
+    expect(await tryHandleInviteCommand('b1', inviteMessage({ chatType: 'p2p' }), OWNER)).toBe(true);
+    expect(addBotMock).not.toHaveBeenCalled();
+    expect(String(replyMock.mock.calls.at(-1)![2])).toContain('私聊');
+  });
+
+  it('p2p without any @ (real DM form): still gets the p2p reply, not silence', async () => {
+    const msg = { message_id: 'om_dm', chat_id: 'oc_dm', chat_type: 'p2p', content: JSON.stringify({ text: '/invite @Codex' }), mentions: [] };
+    expect(await tryHandleInviteCommand('b1', msg, OWNER)).toBe(true);
+    expect(addBotMock).not.toHaveBeenCalled();
+    expect(String(replyMock.mock.calls.at(-1)![2])).toContain('私聊');
+  });
+
+  it('no targets at all → usage reply, no API call', async () => {
+    const msg = inviteMessage({ text: '@_user_1 /invite', mentions: [
+      { key: '@_user_1', id: { open_id: ME }, name: 'Claude' },
+    ] });
+    expect(await tryHandleInviteCommand('b1', msg, OWNER)).toBe(true);
+    expect(addBotMock).not.toHaveBeenCalled();
+    expect(String(replyMock.mock.calls.at(-1)![2])).toContain('用法');
+  });
+
+  it('bad --app token → usage reply', async () => {
+    const msg = inviteMessage({ text: '@_user_1 /invite --app oops', mentions: [
+      { key: '@_user_1', id: { open_id: ME }, name: 'Claude' },
+    ] });
+    expect(await tryHandleInviteCommand('b1', msg, OWNER)).toBe(true);
+    expect(addBotMock).not.toHaveBeenCalled();
+    expect(String(replyMock.mock.calls.at(-1)![2])).toContain('用法');
+  });
+});
+
+describe('tryHandleInviteCommand — 解析与拉人', () => {
+  it('happy path: unique roster name resolves and is added', async () => {
+    writeBotsInfo([{ larkAppId: 'cli_codex', botName: 'Codex' }]);
+    expect(await tryHandleInviteCommand('b1', inviteMessage(), OWNER)).toBe(true);
+    expect(addBotMock).toHaveBeenCalledWith('b1', 'oc_1', ['cli_codex']);
+    const out = String(replyMock.mock.calls.at(-1)![2]);
+    expect(out).toContain('已拉进群');
+    expect(out).toContain('Codex');
+  });
+
+  it('already-in-chat target (live roster openId match) is skipped', async () => {
+    writeBotsInfo([{ larkAppId: 'cli_codex', botName: 'Codex' }]);
+    rosterMock.mockImplementation(async () => [
+      { larkAppId: 'cli_codex', openId: 'ou_codex', name: 'Codex', displayName: 'Codex' },
+    ]);
+    expect(await tryHandleInviteCommand('b1', inviteMessage(), OWNER)).toBe(true);
+    expect(addBotMock).not.toHaveBeenCalled();
+    expect(String(replyMock.mock.calls.at(-1)![2])).toContain('已在群内');
+  });
+
+  it('name not in bots-info → unresolved with --app hint, no add', async () => {
+    writeBotsInfo([{ larkAppId: 'cli_gemini', botName: 'Gemini' }]);
+    expect(await tryHandleInviteCommand('b1', inviteMessage(), OWNER)).toBe(true);
+    expect(addBotMock).not.toHaveBeenCalled();
+    const out = String(replyMock.mock.calls.at(-1)![2]);
+    expect(out).toContain('无法解析');
+    expect(out).toContain('Codex');
+    expect(out).toContain('--app');
+  });
+
+  it('duplicate display name → ambiguous with candidate app ids, no add', async () => {
+    writeBotsInfo([
+      { larkAppId: 'cli_dup1', botName: 'Codex' },
+      { larkAppId: 'cli_dup2', botName: 'Codex' },
+    ]);
+    expect(await tryHandleInviteCommand('b1', inviteMessage(), OWNER)).toBe(true);
+    expect(addBotMock).not.toHaveBeenCalled();
+    const out = String(replyMock.mock.calls.at(-1)![2]);
+    expect(out).toContain('多个机器人');
+    expect(out).toContain('cli_dup1');
+    expect(out).toContain('cli_dup2');
+  });
+
+  it('--app bypasses name resolution (also works for bots outside the roster)', async () => {
+    writeBotsInfo([]);
+    const msg = inviteMessage({ text: '@_user_1 /invite --app cli_ext', mentions: [
+      { key: '@_user_1', id: { open_id: ME }, name: 'Claude' },
+    ] });
+    expect(await tryHandleInviteCommand('b1', msg, OWNER)).toBe(true);
+    expect(addBotMock).toHaveBeenCalledWith('b1', 'oc_1', ['cli_ext']);
+    expect(String(replyMock.mock.calls.at(-1)![2])).toContain('已拉进群');
+  });
+
+  it('mixed batch: resolvable added, already-in-chat skipped, unresolved reported — only resolvable hits the API', async () => {
+    writeBotsInfo([{ larkAppId: 'cli_codex', botName: 'Codex' }]);
+    rosterMock.mockImplementation(async () => [
+      { larkAppId: 'b1', openId: ME, name: 'Claude', displayName: 'Claude' },
+      { larkAppId: 'cli_gemini', openId: 'ou_gemini', name: 'Gemini', displayName: 'Gemini' },
+    ]);
+    const msg = inviteMessage({
+      text: '@_user_1 /invite @_user_2 @_user_3 @_user_4',
+      mentions: [
+        { key: '@_user_1', id: { open_id: ME }, name: 'Claude' },
+        { key: '@_user_2', id: { open_id: 'ou_codex' }, name: 'Codex' },
+        { key: '@_user_3', id: { open_id: 'ou_gemini' }, name: 'Gemini' },
+        { key: '@_user_4', id: { open_id: 'ou_ghost' }, name: 'Ghost' },
+      ],
+    });
+    expect(await tryHandleInviteCommand('b1', msg, OWNER)).toBe(true);
+    expect(addBotMock).toHaveBeenCalledWith('b1', 'oc_1', ['cli_codex']);
+    const out = String(replyMock.mock.calls.at(-1)![2]);
+    expect(out).toContain('Codex');
+    expect(out).toContain('已在群内');
+    expect(out).toContain('Gemini');
+    expect(out).toContain('无法解析');
+    expect(out).toContain('Ghost');
+  });
+
+  it('whole-batch failure falls back to per-id invites and reports individual results', async () => {
+    writeBotsInfo([
+      { larkAppId: 'cli_codex', botName: 'Codex' },
+      { larkAppId: 'cli_gemini', botName: 'Gemini' },
+    ]);
+    addBotMock
+      .mockImplementationOnce(async (_a, _c, ids: string[]) => ids.map(id => ({ id, ok: false, error: 'batch boom' })))
+      .mockImplementation(async (_a, _c, ids: string[]) =>
+        ids.map(id => ({ id, ok: id !== 'cli_gemini', ...(id === 'cli_gemini' ? { error: 'invalid_id' } : {}) })));
+    const msg = inviteMessage({
+      text: '@_user_1 /invite @_user_2 @_user_3',
+      mentions: [
+        { key: '@_user_1', id: { open_id: ME }, name: 'Claude' },
+        { key: '@_user_2', id: { open_id: 'ou_codex' }, name: 'Codex' },
+        { key: '@_user_3', id: { open_id: 'ou_gemini' }, name: 'Gemini' },
+      ],
+    });
+    expect(await tryHandleInviteCommand('b1', msg, OWNER)).toBe(true);
+    // 1 次批量（全失败）+ 2 次逐个 = 3 次调用
+    expect(addBotMock).toHaveBeenCalledTimes(3);
+    const out = String(replyMock.mock.calls.at(-1)![2]);
+    expect(out).toContain('已拉进群');
+    expect(out).toContain('Codex');
+    expect(out).toContain('拉入失败');
+    expect(out).toContain('Gemini');
+  });
+
+  it('post (rich-text) form: operator at-node + invite text node + target at-node', async () => {
+    writeBotsInfo([{ larkAppId: 'cli_codex', botName: 'Codex' }]);
+    const postMsg = {
+      message_id: 'om_post', chat_id: 'oc_1',
+      content: JSON.stringify({ zh_cn: { content: [[
+        { tag: 'at', user_id: ME, user_name: 'Claude' },
+        { tag: 'text', text: ' /invite ' },
+        { tag: 'at', user_id: 'ou_codex', user_name: 'Codex' },
+      ]] } }),
+      mentions: [],
+    };
+    expect(await tryHandleInviteCommand('b1', postMsg, OWNER)).toBe(true);
+    expect(addBotMock).toHaveBeenCalledWith('b1', 'oc_1', ['cli_codex']);
+  });
+});

--- a/test/invite-command.test.ts
+++ b/test/invite-command.test.ts
@@ -33,6 +33,7 @@ import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { tryHandleInviteCommand, parseInviteArgs, readBotsInfoEntries } from '../src/im/lark/invite-command.js';
+import { isCommandTargetOnly } from '../src/im/lark/mention-targets.js';
 import { registerBot } from '../src/bot-registry.js';
 import { config } from '../src/config.js';
 
@@ -364,9 +365,9 @@ describe('tryHandleInviteCommand — app_id 形态目标（群外 bot 主场景�
     expect(String(replyMock.mock.calls.at(-1)![2])).toContain('已在群内');
   });
 
-  it('target-only guard still fires when THIS bot is @ed as app_id after /invite', async () => {
-    // 本 bot 被以 app_id 形态 @ 在 /invite 之后 = 本 bot 是 invitee → 静默放手。
-    // b1 的 larkAppId 即 "b1"，用它当本 bot 的 app_id 形态 mention。
+  it('target-only guard fires when THIS bot is @ed as app_id after /invite (SAME owner) → fully silent', async () => {
+    // `@OpBot /invite @ThisBot`，本 bot 以 app_id 形态(larkAppId=b1)被 @ 在命令词之后
+    // = 本 bot 是 invitee，命令属于前导 @ 的 OpBot → 必须静默放手：既不拉人也不回复。
     const msg = inviteMessage({
       text: '@_user_1 /invite @_user_2',
       mentions: [
@@ -374,12 +375,72 @@ describe('tryHandleInviteCommand — app_id 形态目标（群外 bot 主场景�
         { key: '@_user_2', id: 'b1', id_type: 'app_id', name: 'Claude' },
       ],
     });
-    // isCommandTargetOnly 用 open_id 判据；app_id 形态的本 bot @ 不会命中 target-only，
-    // 但仍必须不把「自己」误当拉取目标 → toInvite 不含 b1（rosterAppIds/larkAppId 自排除）。
     expect(await tryHandleInviteCommand('b1', msg, OWNER)).toBe(true);
-    // 关键断言：绝不把本 bot 自己的 app_id 拉进群。
-    for (const call of addBotMock.mock.calls) {
-      expect(call[2]).not.toContain('b1');
-    }
+    // 行为断言（不是只看拉人 API）：target-only 必须两者都不调用，否则会多回一条「已在群内」。
+    expect(addBotMock).not.toHaveBeenCalled();
+    expect(replyMock).not.toHaveBeenCalled();
+  });
+
+  it('target-only guard fires when THIS bot is @ed as app_id after /invite (CROSS owner) → no owner_only leak', async () => {
+    // 命令属于别的 daemon 的 owner；本 bot 是 app_id 形态的 invitee。修复前 guard 漏判 →
+    // 走到 owner 闸门对陌生 sender 误回 owner_only（异主泄漏）。契约=静默放手。
+    const msg = inviteMessage({
+      text: '@_user_1 /invite @_user_2',
+      mentions: [
+        { key: '@_user_1', id: { open_id: 'ou_opbot' }, name: 'OpBot' },
+        { key: '@_user_2', id: 'b1', id_type: 'app_id', name: 'Claude' },
+      ],
+    });
+    expect(await tryHandleInviteCommand('b1', msg, 'ou_not_my_owner')).toBe(true);
+    expect(addBotMock).not.toHaveBeenCalled();
+    expect(replyMock).not.toHaveBeenCalled();   // 不泄漏 owner_only
+  });
+
+  it('target-only guard fires for post form when THIS bot at-node (cli_ app_id) is after /invite', async () => {
+    const postMsg = {
+      message_id: 'om_post3', chat_id: 'oc_1',
+      content: JSON.stringify({ zh_cn: { content: [[
+        { tag: 'at', user_id: 'ou_opbot', user_name: 'OpBot' },
+        { tag: 'text', text: ' /invite ' },
+        { tag: 'at', user_id: 'b1', user_name: 'Claude' },   // 本 bot 以 app_id 形态被 @ 在命令后
+      ]] } }),
+      mentions: [],
+    };
+    expect(await tryHandleInviteCommand('b1', postMsg, OWNER)).toBe(true);
+    expect(addBotMock).not.toHaveBeenCalled();
+    expect(replyMock).not.toHaveBeenCalled();
+  });
+});
+
+// isCommandTargetOnly 单元级：直接锁 guard 机制识别 app_id 形态本 bot（text + post）。
+// handler 级的 post 用例在修复前靠 isBotMentioned 选举门也会静默（同 end-behavior），
+// 无法单独证明 guard 有牙；这里直接断言 guard 返回值，修复前 post/text 两支都必挂。
+describe('isCommandTargetOnly — app_id 形态本 bot 识别', () => {
+  const INVITE = /\/invite\b/i;
+  const APPID = 'cli_me';
+
+  it('text: bot @ed as app_id AFTER cmd → true (needs botAppId arg)', () => {
+    const msg = { content: JSON.stringify({ text: '@_user_1 /invite @_user_2' }), mentions: [
+      { key: '@_user_1', id: { open_id: 'ou_op' }, name: 'Op' },
+      { key: '@_user_2', id: APPID, id_type: 'app_id', name: 'Me' },
+    ] };
+    expect(isCommandTargetOnly(msg, 'ou_me', INVITE, APPID)).toBe(true);
+  });
+
+  it('post: bot at-node app_id AFTER cmd → true (needs botAppId arg)', () => {
+    const msg = { content: JSON.stringify({ zh_cn: { content: [[
+      { tag: 'at', user_id: 'ou_op', user_name: 'Op' },
+      { tag: 'text', text: ' /invite ' },
+      { tag: 'at', user_id: APPID, user_name: 'Me' },
+    ]] } }), mentions: [] };
+    expect(isCommandTargetOnly(msg, 'ou_me', INVITE, APPID)).toBe(true);
+  });
+
+  it('text: bot @ed as app_id BEFORE cmd (operator role) → false (not target-only)', () => {
+    const msg = { content: JSON.stringify({ text: '@_user_1 /invite @_user_2' }), mentions: [
+      { key: '@_user_1', id: APPID, id_type: 'app_id', name: 'Me' },
+      { key: '@_user_2', id: { open_id: 'ou_target' }, name: 'T' },
+    ] };
+    expect(isCommandTargetOnly(msg, 'ou_me', INVITE, APPID)).toBe(false);
   });
 });


### PR DESCRIPTION
## 改了什么

新增 daemon 元命令 `/invite`：在群里 `@bot /invite @目标bot`（可多个）把**不在群里的**机器人拉进本群；`@bot /invite --app cli_xxx` 可按 app_id 直接拉任意飞书应用（不限 botmux 花名册）。

- **拦截模型完全对齐 /grant**（申晗指定）：dispatcher 路由/spawn 之前拦截；必须明确 @ 本 bot 才执行（多 bot 群防重复拉人）；仅 owner 可用；私聊显式拒绝并提示 DM 不可达原因（p2p 检查放在选举门之前，否则 DM 里永远静默）
- **目标解析**：命令词**之后**的 @ 才算目标（共享解析器）。目标 bot 不在群里，所以不走群成员表，改查部署级花名册 `bots-info.json` 显示名唯一匹配（大小写不敏感，与 /group 同款）；查无 → 按目标报错并提示 `--app`；一个名字对应多个 app → 列出候选 app_id 引导 `--app` 消歧
- **幂等/健壮**：live 群 bot 成员表能对上的目标跳过（已在群内）；拉人复用 `addBotToChat`（/group、dashboard、vc-agent 同款封装）；按 5 个一批、整批失败回退逐个隔离重试（镜像 group-creator），逐目标汇报「已拉/已在群/无法解析/歧义/失败」
- **重构**：把 grant-command 的 mention 位置解析（text/post 双形态、target-only 守卫、stripAllMentions）提炼为共享模块 `mention-targets.ts`，grant 导出签名与行为不变

## CLI 冲突核查（为何用 /invite 这个名字）

实机 grep 本机 6 个 CLI 的二进制/产物均无 `/invite` 内置 slash 命令：claude-code 2.1.220（12 处 invite 字样全是 MIME/protobuf/文案）、codex 0.145.0、gemini-cli、opencode（5 处命中全是 API 路径与 Discord 链接）、cursor-agent、kimi 全为 0。aider / qwen-code（gemini fork）/ Copilot CLI 凭公开命令集判断同样没有。注意点：用户 CLI 侧自定义命令（如 `~/.claude/commands/invite.md`）会被本命令抢占——与所有 daemon 命令行为一致。

## 影响面评估

- **跨 CLI**：无关。daemon 层元命令，不进 worker/适配器；已核实无 CLI 有同名内置命令
- **跨后端 / 会话类型**：拦截发生在路由决策**之前**，对 PtyBackend/TmuxBackend、话题/群/adopt/restore、sandbox、v3 workflow 均零侵入；p2p 显式拒绝
- **公共层**：event-dispatcher 新增 1 import + 1 拦截调用（/grant 之后，仅对 `/invite` 开头的消息生效）；grant-command 纯提炼重构（既有 43 测试全绿锁行为）；i18n 双语言补齐；/help 增加一行

## 测试验证

- `pnpm build` ✅
- 新增 `test/invite-command.test.ts` 23 用例全绿（隔离单跑）：参数解析、花名册读取、target-only 守卫、owner 闸门、未@本bot 静默、p2p（含无@真实 DM 形态）、usage、唯一/未解析/歧义、已在群幂等、混合批次只拉可解析项、整批失败逐个回退、post 富文本形态
- `test/grant-command.test.ts` 43 用例全绿（回归锁）
- 全套 11298 passed（唯一 FAIL=test/group-join-shared-routing beforeAll 10s 超时：**干净基线 stash 全套复跑同款失败**，属环境性 flake，与本次无关；该文件隔离单跑 5/5 绿）

## 待人工验证（live）

需 `pnpm switch:here && pnpm daemon:restart` 后在飞书实测（⚠️ 全 fleet 会跑本 checkout，测完切回 canonical）：`@执行bot /invite @群外bot` 拉人、`--app` 拉任意 app、重名/未解析/已在群提示、非 owner 被挡、另一个群内 bot 不误动作。