### PR TITLE
fix(core): 修 dashboard 改 per-bot env 后 /restart 不生效（live-worker 仍用旧快照）

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -66,7 +66,7 @@ import { readGlobalConfig } from '../global-config.js';
 import { normalizeChatReplyMode, setChatReplyMode, type ChatReplyMode } from '../services/chat-reply-mode-store.js';
 import * as chatFirstSeenStore from '../services/chat-first-seen-store.js';
 import * as scheduler from './scheduler.js';
-import { listActiveSessions, findActiveBySessionId, closeSession, getActiveSessionsRegistry, transferSession, deliverWriteLinkCardToOwners, forkWorker, suspendWorker, killWorker } from './worker-pool.js';
+import { listActiveSessions, findActiveBySessionId, closeSession, getActiveSessionsRegistry, transferSession, deliverWriteLinkCardToOwners, forkWorker, suspendWorker, killWorker, latestPerBotEnvForRestart } from './worker-pool.js';
 import { listOnlineDaemons } from '../utils/daemon-discovery.js';
 import { isSessionStopped } from './session-liveness.js';
 import { isSuspendableBackendType } from './persistent-backend.js';
@@ -605,8 +605,9 @@ ipcRoute('POST', '/api/sessions/:sessionId/restart', (_req, res, params) => {
   const cliId = ds.session.cliId ?? 'unknown';
   if (ds.worker && !ds.worker.killed) {
     // Live worker → in-place CLI restart (kills the CLI, respawns with --resume).
+    // 捎带最新 per-bot env：dashboard 改完 env 后重启才真正生效（与 /restart 同逻辑）。
     try {
-      ds.worker.send({ type: 'restart' } as DaemonToWorker);
+      ds.worker.send({ type: 'restart', env: latestPerBotEnvForRestart(ds) } as DaemonToWorker);
     } catch (err) {
       return jsonRes(res, 502, { ok: false, error: String(err) });
     }
@@ -894,7 +895,7 @@ ipcRoute('POST', '/api/sessions/:sessionId/cd', async (req, res, params) => {
     // 与 worker 侧一致（下次 forkWorker 用它重建 init 消息）。
     if (ds.initConfig) ds.initConfig.workingDir = v.resolvedPath;
     try {
-      ds.worker.send({ type: 'restart', updateWorkingDir: v.resolvedPath } as DaemonToWorker);
+      ds.worker.send({ type: 'restart', updateWorkingDir: v.resolvedPath, env: latestPerBotEnvForRestart(ds) } as DaemonToWorker);
     } catch {
       // send() 抛异常：worker 进程实际上已经不可达（管道已断），但 above 的
       // repinSessionWorkingDir 已经把记录改成了新目录——绝不能留下「记录新、

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1460,6 +1460,24 @@ function destroyLivePaneBeforeRestart(ds: DaemonSession): void {
   }
 }
 
+/**
+ * Live-worker /restart 携带的最新 per-bot env（bots.json `env`）。worker 收到
+ * restart 时在 respawn 前全量覆盖 lastInitConfig.env —— 否则 live-worker 重启
+ * 一直用 fork 时刻的旧快照，dashboard 改完 env（如切 provider 的
+ * ANTHROPIC_BASE_URL/TOKEN）后 /restart 并不会生效（只有 refork 路径生效）。
+ * 三分态返回：对象 = 最新 env；null = 明确清空（dashboard 已删）；
+ * undefined = 取不到（bot 已注销等异常），让 worker 保持快照不动（=旧行为）。
+ * 只热更 env 一个字段：sandbox/backendType 是刻意 freeze-once 的设计（见
+ * forkWorker init 注释），cliId 换 CLI 会踩 resume transcript 对齐，均不带。
+ */
+export function latestPerBotEnvForRestart(ds: DaemonSession): Record<string, string> | null | undefined {
+  try {
+    return getBot(ds.larkAppId).config.env ?? null;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Join or start one correlated physical restart for a session. */
 export function requestSessionRestart(
   ds: DaemonSession,
@@ -1467,7 +1485,7 @@ export function requestSessionRestart(
 ): { attemptId: string; joined: boolean } {
   return restartCoordinator.request(ds.session.sessionId, observer, attemptId => {
     if (ds.worker && !ds.worker.killed) {
-      ds.worker.send({ type: 'restart', attemptId } as DaemonToWorker);
+      ds.worker.send({ type: 'restart', attemptId, env: latestPerBotEnvForRestart(ds) } as DaemonToWorker);
       return;
     }
     // No live worker but the persistent pane may still be alive (e.g. after a
@@ -3634,10 +3652,12 @@ function setupWorkerHandlers(
           break;
         }
 
-        // Auto-restart CLI within the same worker
+        // Auto-restart CLI within the same worker. 捎带最新 per-bot env：崩溃
+        // 往往正是旧 env 配的错（如过期 token / 失效 proxy），用户改完 env 后
+        // 下一轮 auto-restart 直接用新值恢复，不必再手工 /close。
         if (ds.worker && !ds.worker.killed) {
           logger.info(`[${t}] Auto-restarting ${getCliDisplayName(effectiveCliId)}...`);
-          ds.worker.send({ type: 'restart' } as DaemonToWorker);
+          ds.worker.send({ type: 'restart', env: latestPerBotEnvForRestart(ds) } as DaemonToWorker);
         }
         break;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -624,8 +624,13 @@ export type DaemonToWorker =
   /** Kill the CLI and respawn it with --resume. `updateWorkingDir`（可选）
    *  用于角色切换的 cwd-move respawn：respawn 前把 worker 侧 lastInitConfig
    *  收敛到新目录，让 CLI 在新 cwd 冷启动（新 CLAUDE.md/记忆索引开场注入）
-   *  同时 --resume 续回对话上下文。`attemptId` 关联手工 restart 的完成回执。 */
-  | { type: 'restart'; attemptId?: string; updateWorkingDir?: string }
+   *  同时 --resume 续回对话上下文。`attemptId` 关联手工 restart 的完成回执。
+   *  `env`（可选）携 daemon 侧最新的 per-bot env（bots.json `env`）：worker
+   *  在 respawn 前全量覆盖 lastInitConfig.env，使 dashboard 改完 env 后
+   *  /restart 真正生效（否则 live-worker restart 一直用 fork 时刻的旧快照）。
+   *  三分态：undefined = 不携带（旧 daemon / 兜底，worker 保持快照不动）；
+   *  null = 明确清空（dashboard 清除了 env，worker 移除快照）。 */
+  | { type: 'restart'; attemptId?: string; updateWorkingDir?: string; env?: Record<string, string> | null }
   /** Lease watchdog fencing: only the exact still-running durable attempt may
    * tear down/restart the CLI. A late command after terminal/current-turn
    * advance is ignored worker-side. */

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -10552,6 +10552,16 @@ process.on('message', async (raw: unknown) => {
       if (msg.updateWorkingDir && lastInitConfig) {
         lastInitConfig.workingDir = msg.updateWorkingDir;
       }
+      // per-bot env 热更：daemon 发 restart 时捎带 bots.json `env` 的最新值
+      // （live-worker restart 不 refork，没有 init 重发这条通道），respawn 前
+      // 全量覆盖 lastInitConfig.env —— spawnCli 的 sanitizePerBotEnv(cfg.env)
+      // 每次 spawn 都重跑，覆盖即在重启出的 CLI 上生效。undefined=不携带（旧
+      // daemon / 兜底）保持快照；null=dashboard 已清空 → 移除快照。与上面的
+      // cwd merge 一样放在合并守卫之前：被合并的重复 restart 也应带走 env
+      // 更新，pending 的 respawn 展开 {...lastInitConfig} 时自然拿到新值。
+      if (msg.env !== undefined && lastInitConfig) {
+        lastInitConfig.env = msg.env === null ? undefined : msg.env;
+      }
       // restart 合并：已有一轮 restart 在飞（teardown 进行中，或 tmux jitter
       // 定时器未触发）时不叠加第二轮——叠加会 clearTimeout 吃掉首轮 teardown、
       // 把重启预算无故烧到 tier-2 强制 FRESH（丢上下文），非 tmux 路径还会

--- a/test/crash-loop-diagnostic.test.ts
+++ b/test/crash-loop-diagnostic.test.ts
@@ -180,7 +180,8 @@ describe("crash-loop diagnostic terminal (daemon 'claude_exit' handler)", () => 
 
     // First 3 auto-restart in place; the 4th asks the worker to park a
     // diagnostic shell (deferred park) and keeps it alive (no close).
-    expect(worker.send).toHaveBeenCalledWith({ type: 'restart' });
+    // auto-restart 捎带最新 per-bot env（本 fixture 的 mock getBot 无 env → null）。
+    expect(worker.send).toHaveBeenCalledWith({ type: 'restart', env: null });
     expect(worker.send).toHaveBeenCalledWith({ type: 'park_diagnostic' });
     expect(worker.send).not.toHaveBeenCalledWith({ type: 'close' });
     // Survives daemon restart: lazy cold-resume + idle, restart counter reset.

--- a/test/restart-live-worker-env.test.ts
+++ b/test/restart-live-worker-env.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Regression tests for "dashboard 改 per-bot env 后 /restart 不生效":
+ *
+ *  背景 — dashboard 保存 env（PUT /api/bot-env → applyConfigField）只写
+ *  bots.json + 同步 daemon 内存 bot registry，没有任何 IPC 会推给活着的
+ *  worker。而 live-worker /restart 只在 worker 进程内用 fork 时刻的
+ *  lastInitConfig 快照 respawn CLI（lastInitConfig 只在 init 时赋值一次），
+ *  导致改完 env 后 /restart 出来的 CLI 仍是旧 env；只有 refork（新会话 /
+ *  /close 后重发 / daemon 重启）才生效——与文档「当前运行中的会话需
+ *  /restart 重启才换新值」的承诺不符。
+ *
+ *  修复 — daemon 发 restart IPC 时捎带 daemon 侧最新 bots.json `env`
+ *  （latestPerBotEnvForRestart，三分态：对象=最新 / null=已清空 / undefined=
+ *  取不到保持旧行为）；worker 在 respawn 前全量覆盖 lastInitConfig.env，
+ *  spawnCli 的 sanitizePerBotEnv(cfg.env) 每次 spawn 都重跑即生效。
+ *
+ *  覆盖：
+ *  1. latestPerBotEnvForRestart 纯函数三分态（最新 / 清空 / 取不到兜底）。
+ *  2. daemon behavioral：requestSessionRestart live-worker 分支把 env 放进
+ *     发给 worker 的 restart 消息体（含 attemptId）。
+ *  3. 其余三个 restart IPC 生产者（dashboard 重启按钮 / dashboard cwd-move /
+ *     崩溃 auto-restart）同样捎带 env——respawn 即该用最新 env，语义一致。
+ *  4. worker wiring（source pin，worker.ts 是进程入口不可 import，同
+ *     restart-worker-null-reattach.test.ts 的做法）：env merge 在合并守卫
+ *     之前（被合并的重复 restart 也要带走 env 更新）且含 null→清除语义。
+ *
+ * Run:  pnpm vitest run test/restart-live-worker-env.test.ts
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../src/utils/logger.js', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const getBotMock = vi.fn();
+vi.mock('../src/bot-registry.js', async (importOriginal) => ({
+  ...(await importOriginal() as object),
+  getBot: (...args: unknown[]) => getBotMock(...args),
+}));
+
+import { readFileSync } from 'node:fs';
+import {
+  latestPerBotEnvForRestart,
+  requestSessionRestart,
+  __testOnly_resetRestartCoordinator,
+} from '../src/core/worker-pool.js';
+
+const workerSource = readFileSync(new URL('../src/worker.ts', import.meta.url), 'utf8');
+const workerPoolSource = readFileSync(new URL('../src/core/worker-pool.ts', import.meta.url), 'utf8');
+const dashboardIpcSource = readFileSync(new URL('../src/core/dashboard-ipc-server.ts', import.meta.url), 'utf8');
+
+let sessionCounter = 0;
+
+function makeDs(envWorker?: { killed?: boolean }) {
+  const send = vi.fn();
+  const ds: any = {
+    session: {
+      sessionId: `env-restart-${++sessionCounter}`,
+      backendType: 'pty',
+    },
+    larkAppId: 'cli_app1',
+    hasHistory: true,
+    worker: envWorker ? { killed: envWorker.killed ?? false, send } : { killed: false, send },
+  };
+  return { ds, send };
+}
+
+function observer() {
+  return { source: 'slash' as const, notify: vi.fn(async () => {}) };
+}
+
+beforeEach(() => {
+  getBotMock.mockReset();
+  __testOnly_resetRestartCoordinator();
+});
+
+afterEach(() => {
+  __testOnly_resetRestartCoordinator();
+});
+
+// ─── 1. latestPerBotEnvForRestart 纯函数三分态 ──────────────────────────────
+
+describe('latestPerBotEnvForRestart (daemon-side env snapshot carrier)', () => {
+  it('returns the LIVE bots.json env object when configured', () => {
+    getBotMock.mockReturnValue({ config: { env: { ANTHROPIC_BASE_URL: 'https://glm' } } });
+    const { ds } = makeDs();
+    expect(latestPerBotEnvForRestart(ds)).toEqual({ ANTHROPIC_BASE_URL: 'https://glm' });
+    expect(getBotMock).toHaveBeenCalledWith('cli_app1');
+  });
+
+  it('returns null when the config has no env (worker must clear its snapshot)', () => {
+    getBotMock.mockReturnValue({ config: {} });
+    const { ds } = makeDs();
+    expect(latestPerBotEnvForRestart(ds)).toBeNull();
+  });
+
+  it('returns null for an EMPTY env object too (dashboard cleared every key)', () => {
+    getBotMock.mockReturnValue({ config: { env: {} } });
+    const { ds } = makeDs();
+    // {} ?? null → {} is truthy, so this is {} — worker 全量覆盖为空对象，
+    // 等价于清空（sanitizePerBotEnv({}) → 无 key 可注入）。
+    expect(latestPerBotEnvForRestart(ds)).toEqual({});
+  });
+
+  it('falls back to undefined when the bot is gone (keep old-snapshot behavior)', () => {
+    getBotMock.mockImplementation(() => { throw new Error('Bot not registered'); });
+    const { ds } = makeDs();
+    expect(latestPerBotEnvForRestart(ds)).toBeUndefined();
+  });
+});
+
+// ─── 2. daemon behavioral：live-worker restart 消息带 env ────────────────────
+
+describe('requestSessionRestart live-worker branch carries env (behavioral)', () => {
+  it('sends {type:restart, attemptId, env} with the latest bots.json env', () => {
+    getBotMock.mockReturnValue({ config: { env: { HTTPS_PROXY: 'http://p:7890' } } });
+    const { ds, send } = makeDs();
+    const r = requestSessionRestart(ds, observer());
+
+    expect(r.joined).toBe(false);
+    expect(send).toHaveBeenCalledTimes(1);
+    const msg = send.mock.calls[0][0];
+    expect(msg.type).toBe('restart');
+    expect(typeof msg.attemptId).toBe('string');
+    expect(msg.attemptId).toBe(r.attemptId);
+    expect(msg.env).toEqual({ HTTPS_PROXY: 'http://p:7890' });
+  });
+
+  it('sends env:null when no per-bot env is configured (worker clears snapshot)', () => {
+    getBotMock.mockReturnValue({ config: {} });
+    const { ds, send } = makeDs();
+    requestSessionRestart(ds, observer());
+    expect(send.mock.calls[0][0].env).toBeNull();
+  });
+
+  it('sends env:undefined when bot lookup fails (= legacy message, no env key)', () => {
+    getBotMock.mockImplementation(() => { throw new Error('gone'); });
+    const { ds, send } = makeDs();
+    requestSessionRestart(ds, observer());
+    expect(send.mock.calls[0][0].env).toBeUndefined();
+  });
+
+  it('a joined second request does NOT resend the restart message', () => {
+    // restartCoordinator 合并重复触发：第二条只 join，env 以第一条为准（同一
+    // 物理重启），pending respawn 展开 {...lastInitConfig} 时拿到第一次捎带
+    // 的 env（worker 侧在合并守卫前 merge，第二条带的新值也会生效）。
+    getBotMock.mockReturnValue({ config: { env: { A: '1' } } });
+    const { ds, send } = makeDs();
+    const first = requestSessionRestart(ds, observer());
+    const second = requestSessionRestart(ds, observer());
+    expect(second.joined).toBe(true);
+    expect(second.attemptId).toBe(first.attemptId);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── 3. 全部四个 restart IPC 生产者均捎带 env（wiring） ─────────────────────
+
+describe('every daemon-side restart IPC producer carries env (source wiring)', () => {
+  it('worker-pool.ts: every {type:restart} send includes env', () => {
+    const sends = workerPoolSource.match(/ds\.worker\.send\(\{ type: 'restart'[^}]*\}/g) ?? [];
+    expect(sends.length).toBeGreaterThanOrEqual(2); // requestSessionRestart + auto-restart
+    for (const s of sends) {
+      expect(s, `missing env in: ${s}`).toContain('env: latestPerBotEnvForRestart(ds)');
+    }
+  });
+
+  it('dashboard-ipc-server.ts: every {type:restart} send includes env', () => {
+    const sends = dashboardIpcSource.match(/ds\.worker\.send\(\{ type: 'restart'[^}]*\}/g) ?? [];
+    expect(sends.length).toBe(2); // dashboard restart 按钮 + cwd-move
+    for (const s of sends) {
+      expect(s, `missing env in: ${s}`).toContain('env: latestPerBotEnvForRestart(ds)');
+    }
+  });
+
+  it('the restart message type declares the three-state env field', () => {
+    const typesSource = readFileSync(new URL('../src/types.ts', import.meta.url), 'utf8');
+    const restartLine = typesSource.indexOf("| { type: 'restart';");
+    expect(restartLine).toBeGreaterThanOrEqual(0);
+    const line = typesSource.slice(restartLine, typesSource.indexOf('}', restartLine));
+    expect(line).toContain('env?: Record<string, string> | null');
+  });
+});
+
+// ─── 4. worker wiring：respawn 前 merge env（合并守卫之前 + null 清除语义） ──
+
+describe('worker restart case merges env into lastInitConfig (source pin)', () => {
+  function restartCaseBranch(): string {
+    const start = workerSource.indexOf("case 'restart': {");
+    const end = workerSource.indexOf("case 'expire_durable_turn':", start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    return workerSource.slice(start, end);
+  }
+
+  it('full-replaces lastInitConfig.env with null→clear three-state semantics', () => {
+    const branch = restartCaseBranch();
+    expect(branch).toContain('if (msg.env !== undefined && lastInitConfig)');
+    expect(branch).toContain('lastInitConfig.env = msg.env === null ? undefined : msg.env;');
+  });
+
+  it('the env merge sits BEFORE the in-flight merge guard (coalesced restarts still take the update)', () => {
+    const branch = restartCaseBranch();
+    const envMerge = branch.indexOf('if (msg.env !== undefined && lastInitConfig)');
+    const guard = branch.indexOf('if (cliRestartInProgress || tmuxRestartTimer)');
+    expect(envMerge).toBeGreaterThanOrEqual(0);
+    expect(guard).toBeGreaterThan(envMerge);
+  });
+
+  it('spawnCli re-derives the inject set from cfg.env on every spawn (no cached copy)', () => {
+    const spawnCfg = workerSource.indexOf('const perBotInjectEnv = sanitizePerBotEnv(cfg.env);');
+    expect(spawnCfg).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/test/restart-worker-null-reattach.test.ts
+++ b/test/restart-worker-null-reattach.test.ts
@@ -72,8 +72,9 @@ describe('P1 requestSessionRestart wiring', () => {
     expect(fn).toBeGreaterThanOrEqual(0);
     const body = workerPoolSource.slice(fn, workerPoolSource.indexOf('\n}', fn) + 2);
 
-    // Live-worker branch still sends the in-worker restart IPC (unchanged).
-    expect(body).toContain("ds.worker.send({ type: 'restart', attemptId }");
+    // Live-worker branch still sends the in-worker restart IPC — now also
+    // carrying the latest per-bot env (dashboard edits apply on /restart).
+    expect(body).toContain("ds.worker.send({ type: 'restart', attemptId, env: latestPerBotEnvForRestart(ds) }");
 
     // No-worker branch: pane teardown MUST precede forkWorker.
     const destroy = body.indexOf('destroyLivePaneBeforeRestart(ds)');


### PR DESCRIPTION
## 改了什么

dashboard 改完「环境变量」后 `/restart`，重启出来的 CLI 之前一直用**旧 env**——这条修复让它真正生效。

**根因链**：dashboard 保存 env（`PUT /api/bot-env` → `applyConfigField`）只写 `bots.json` + 同步 daemon 内存 bot registry，**没有任何 IPC 会推给活着的 worker**；而 live-worker `/restart` 只在 worker 进程内用 fork 时刻的 `lastInitConfig` 快照 respawn CLI（`lastInitConfig` 只在收到 `init` 时被赋值一次）→ 改完 env 后 `/restart` 无效，只有 refork（新会话 / `/close` 后重发 / daemon 重启）才生效。这与 `bot-config-store.ts` 对外承诺「next-session 字段…当前运行中的会话需 `/restart` 重启才换新值」**不符**（本次调查还同源确认了 `/restart` 命令与流式卡「重启」按钮走同一入口 `requestSessionRestart`，行为一致）。

**修复（最小增量，只热更 env 一个字段）**：
- `src/types.ts`：`restart` IPC 新增可选 `env`（**三分态**：`undefined`=旧 daemon 不携带→保持快照；`null`=明确清空；对象=全量替换）。
- `src/core/worker-pool.ts`：新增 `latestPerBotEnvForRestart()`；`requestSessionRestart`（/restart 命令 + 流式卡重启按钮的合并入口）与**崩溃 auto-restart** 两个 daemon 侧生产者发送时捎带最新 env。
- `src/worker.ts`：`case 'restart'` 在合并守卫**之前**全量覆盖 `lastInitConfig.env`——被合并的重复 restart 也要带走 env 更新，pending respawn 展开 `{...lastInitConfig}` 自然拿到新值；`spawnCli` 的 `sanitizePerBotEnv(cfg.env)` 每次 spawn 重跑，覆盖即生效。
- `src/core/dashboard-ipc-server.ts`：**dashboard「重启」按钮** 与 **cwd-move respawn** 两个生产者同样捎带（至此 4 个 restart IPC 生产者语义一致：凡 respawn 即用最新 env）。

**为什么只热更 env**：`sandbox`/`backendType` 是刻意 freeze-once 的设计（热更会把历史会话 retroactively sandbox / strand 持久 pane）；`cliId` 换 CLI 会踩 resume transcript 对齐；`model`/`startupCommands` 是同型 gap（worker 都用 `lastInitConfig` 快照），本 PR 描述点名、留 follow-up，不扩面。

**兼容性**：新旧 daemon/worker 任意组合安全——旧 worker 忽略未知 `env` 字段（行为=现状）；旧 daemon 不携带 `env`（worker 三分态语义=保持快照）。

## 影响面

- `restart` IPC 消息协议 = 向后兼容的字段追加。
- 4 个 daemon 侧 restart 生产者全部改带 env；跨 CLI 适配器无感知（env 注入在 `spawnCli` 公共层，`sanitizePerBotEnv` 每次 spawn 重跑）。
- PTY / tmux 后端走同一条 `spawnCli` 无差异（tmux 仍走 per-pane `/usr/bin/env` 前缀，不进 tmux server 全局 env）。
- adopt 会话两端本就硬拒绝 restart，无影响。
- 存量连锁更新：`restart-worker-null-reattach.test.ts`、`crash-loop-diagnostic.test.ts` 的精确消息断言随新消息形状更新（两测试本意即 pin 该两条 send 接线）。

## 实际测试验证

- ✅ `pnpm build` 绿。
- ✅ 新增 `test/restart-live-worker-env.test.ts` **14 例全绿**：纯函数三分态（最新/清空/注销兜底）+ daemon 行为（消息体携 `env`/`null`/`undefined`，coordinator 合并不重发）+ 4 个生产者 wiring + worker merge 顺序与 null 清除语义。
- ✅ **mutation 验证 3/3 全命中**（测试有牙）：去掉 daemon env 捎带→3 FAIL；去掉 worker merge→2 FAIL；merge 移到合并守卫后→1 FAIL。
- ✅ restart 相关存量测试 **294/294**（command-handler / card-integration / restart-coordinator / followup-policy / worker-restart-race / null-reattach）。
- ✅ `pnpm test` 全套 **11287/11292 绿**（残留 `listen-with-probe` 端口探测 flake：多轮随机挂不同用例，OS 端口竞争，与本改动无关；crash-loop 的合法连锁已随形状更新复绿）。
