### PR TITLE
fix(adopt): 收口 Codex-notifier 接管绕过 pendingRepo 守卫的两处 race

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4581,8 +4581,10 @@ async function adoptCodexNotifierEvent(
     // 卡在「正在创建/提交」。因此丢弃一旦发布即为终态——用「取消并请重发」的显式
     // 语义告知用户,而非假装能恢复。
     // 判断是否有「已收下但尚未真正送达 CLI」的用户输入会被下面的 clear 抹掉
-    // (见 notifierAdoptWouldDropInput,覆盖选仓挂起期缓冲 + 选仓刚提交的启动窗
-    // 两个窗口,都不拿 pendingRepo 当前置)。有则记录已丢弃,如实告知用户。
+    // (见 notifierAdoptWouldDropInput:repo-select 镜像字段只在 pendingRepo===true
+    // 计入——立即启动路径也播种这些字段但已 fork 送达,不能误判;pendingRawInput/
+    // pendingFollowUpInput 独立于 pendingRepo,覆盖选仓刚提交等 prompt_ready 的启动窗)。
+    // 有则记录已丢弃,如实告知用户。
     bufferedInputDropped = notifierAdoptWouldDropInput(ds);
     clearPendingRepoStateForNotifierAdopt(ds);
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4365,6 +4365,42 @@ async function deliverCodexNotifierEvent(
   }
 }
 
+/**
+ * Fully retire an in-memory repo-select placeholder when the Codex-notifier
+ * 「继续处理」callback takes over the DM session. The legacy inline clear only
+ * reset six fields and left `repoCardMessageId`, `pendingFollowUps`,
+ * `pendingRepoCommitInFlight`, `worktreeCreating`, attachments, mentions, raw
+ * input, etc. behind — a stale repo-card click or a late auto-worktree
+ * completion could then act on the just-adopted session. Clear the whole
+ * pending-repo surface so no residue survives the takeover. Buffered user input
+ * is dropped here — the drop is terminal (never rolled back, since concurrent
+ * background tasks may already have observed pendingRepo=false); the caller
+ * tells the user their input was cancelled on both the success and failure card.
+ */
+function clearPendingRepoStateForNotifierAdopt(ds: DaemonSession): void {
+  ds.pendingRepo = false;
+  ds.pendingRepoCommitInFlight = false;
+  ds.worktreeCreating = false;
+  ds.repoCardMessageId = undefined;
+  ds.pendingPrompt = undefined;
+  ds.pendingTurnId = undefined;
+  ds.pendingRawInput = undefined;
+  ds.pendingRawTurnId = undefined;
+  ds.pendingFollowUpInput = undefined;
+  ds.pendingAttachments = undefined;
+  ds.pendingMentions = undefined;
+  ds.pendingSubstituteTrigger = undefined;
+  ds.pendingSubstituteControlCard = undefined;
+  ds.pendingSender = undefined;
+  ds.pendingFollowUps = undefined;
+  ds.pendingFollowUpTurnId = undefined;
+  ds.pendingCodexAppText = undefined;
+  ds.pendingCodexAppApplicationContext = undefined;
+  ds.pendingCodexAppMessageContext = undefined;
+  ds.pendingCodexAppFollowUps = undefined;
+  ds.pendingCodexAppFollowUpContexts = undefined;
+}
+
 async function adoptCodexNotifierEvent(
   larkAppId: string,
   event: CodexTaskCompletedEvent,
@@ -4426,7 +4462,15 @@ async function adoptCodexNotifierEvent(
     }
   }
 
+  let bufferedInputDropped = false;
   if (ds.session.cliSessionId !== event.threadId || !ds.worker || ds.worker.killed) {
+    // Do the two throwable, deadline-sensitive steps FIRST, before mutating any
+    // session/pending state: the dynamic import and the 2.2s AbortSignal check.
+    // If either fails here nothing has been touched, so no rollback is needed
+    // and the buffered repo-select input is left intact for a retry.
+    const { startCodexAppThreadSession } = await import('./core/command-handler.js');
+    signal.throwIfAborted();
+
     // 接管原生 Codex App 线程时固定为纯 codex-app 启动，不能继承通知 Bot 的
     // wrapper/model；这些配置针对普通 CLI，会错误包装 app-server runner。
     ds.session.cliId = 'codex-app';
@@ -4435,12 +4479,29 @@ async function adoptCodexNotifierEvent(
     delete ds.session.model;
     ds.session.agentFrozen = true;
     sessionStore.updateSession(ds.session);
-    ds.pendingRepo = false;
-    ds.pendingPrompt = undefined;
-    ds.pendingTurnId = undefined;
-    ds.pendingCodexAppText = undefined;
-    ds.pendingCodexAppApplicationContext = undefined;
-    ds.pendingCodexAppMessageContext = undefined;
+
+    // 默认 flat DM(p2pMode=chat)下这条按钮回调复用同一私聊的现有会话。若该会话
+    // 恰好停在「待选仓库」挂起态且已缓冲一条尚未提交的输入，接管会消费掉
+    // pendingRepo(#669 的守卫要求接管前 pendingRepo 必须为 false)。旧逻辑只清了
+    // 部分字段并静默丢弃缓冲输入。这里完整清空全部 pending 状态(否则残留的
+    // repoCardMessageId/pendingFollowUps/worktreeCreating 等会让旧选仓卡二次点击、
+    // 迟到 auto-worktree 完成误操作已接管会话——见 runAutoWorktreeCommit 的
+    // pendingRepo 护栏),并记录「缓冲输入已丢弃」以便如实告知用户。
+    //
+    // 不做 pending 快照回滚:clear 之后 startCodexAppThreadSession 的 async guard
+    // 会让出微任务,迟到 auto-worktree / 正在 prepare 的 commit 可能已观察到
+    // pendingRepo=false 而正常结束并在 finally 清掉 in-flight 标志;此时若把
+    // pendingRepo=true/worktreeCreating=true 快照复活,后台任务已不在,会话会永久
+    // 卡在「正在创建/提交」。因此丢弃一旦发布即为终态——用「取消并请重发」的显式
+    // 语义告知用户,而非假装能恢复。
+    bufferedInputDropped = ds.pendingRepo === true && (
+      (ds.pendingPrompt?.trim().length ?? 0) > 0
+      || (ds.pendingFollowUps?.length ?? 0) > 0
+      || (ds.pendingAttachments?.length ?? 0) > 0
+      || (ds.pendingRawInput?.trim().length ?? 0) > 0
+      || (ds.pendingCodexAppText?.trim().length ?? 0) > 0
+    );
+    clearPendingRepoStateForNotifierAdopt(ds);
 
     // 完成事件已经携带恢复所需的原生 threadId/cwd。按钮回调不再额外启动一次
     // app-server 做非必要的元数据刷新，避免子进程把飞书回调拖过截止时间。
@@ -4452,28 +4513,40 @@ async function adoptCodexNotifierEvent(
       status: event.status,
     };
 
-    const { startCodexAppThreadSession } = await import('./core/command-handler.js');
-    signal.throwIfAborted();
-    await startCodexNotifierAdoptionSession(
-      startCodexAppThreadSession,
-      target,
-      ds,
-      {
-        activeSessions,
-        sessionReply,
-        getActiveCount,
-        lastRepoScan,
-      },
-      larkAppId,
-      cardMessageId,
-    );
+    try {
+      await startCodexNotifierAdoptionSession(
+        startCodexAppThreadSession,
+        target,
+        ds,
+        {
+          activeSessions,
+          sessionReply,
+          getActiveCount,
+          lastRepoScan,
+        },
+        larkAppId,
+        cardMessageId,
+      );
+    } catch (err) {
+      // 接管失败/超时:pending 已清空且不回滚(见上)。若曾丢弃过缓冲输入,把「已取消、
+      // 请重发」前置到抛给外层的错误里——外层用它渲染失败卡,用户就不会以为原消息还
+      // 在队列里等着(否则失败卡只说"接管失败请重试",缓冲却已没了=静默丢失)。
+      if (bufferedInputDropped) {
+        const detail = err instanceof Error ? err.message : String(err);
+        throw new Error(`你在选择仓库前输入的消息已取消，请在接管成功后重新发送。（接管未完成：${detail}）`);
+      }
+      throw err;
+    }
   }
 
+  const baseAdoptNotice = scope === 'chat'
+    ? '现在可以直接在当前私聊继续发送指令；需要操作终端时，请点击会话卡内的「获取操作链接」。'
+    : '请在本卡片的话题中继续发送指令；需要操作终端时，请点击话题会话卡内的「获取操作链接」。';
   return buildCodexNotifierResultCard(
     '已接管 Codex App 任务',
-    scope === 'chat'
-      ? '现在可以直接在当前私聊继续发送指令；需要操作终端时，请点击会话卡内的「获取操作链接」。'
-      : '请在本卡片的话题中继续发送指令；需要操作终端时，请点击话题会话卡内的「获取操作链接」。',
+    bufferedInputDropped
+      ? `⚠️ 你在选择仓库前输入的消息未随本次接管发送，请重新发送一次。\n\n${baseAdoptNotice}`
+      : baseAdoptNotice,
     'green',
   );
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4366,16 +4366,64 @@ async function deliverCodexNotifierEvent(
 }
 
 /**
+ * P1 revalidation for the Codex-notifier「继续处理」takeover. After the dynamic
+ * import + AbortSignal await inside adoptCodexNotifierEvent, a concurrent path may
+ * have moved the ground: a `/relay` transfer opened its input gate (the starter
+ * would then fail-closed with a bare `return` our no-op sessionReply swallows,
+ * and the outer handler would render a bogus green「已接管」over a half-rewritten
+ * session), or the session was /close'd / swapped / re-created under this key.
+ * Returns true when the takeover MUST abort before mutating any state — so the
+ * caller can throw with zero side effects and no buffered input dropped.
+ */
+function notifierAdoptStaleOrTransferring(
+  ds: DaemonSession,
+  sessions: Map<string, DaemonSession>,
+  activeKey: string,
+  genSessionId: string,
+): boolean {
+  return (
+    sessions.get(activeKey) !== ds
+    || ds.session.sessionId !== genSessionId
+    || ds.session.status !== 'active'
+    || isSessionTransferring(ds)
+  );
+}
+
+/**
+ * P2 predicate: would clearPendingRepoStateForNotifierAdopt drop user input that
+ * was accepted but not yet delivered to the CLI? Covers BOTH windows, neither of
+ * which may gate on pendingRepo:
+ *  (1) repo-select pending (pendingRepo=true): buffered in pendingPrompt /
+ *      pendingFollowUps / pendingAttachments / pendingRawInput / pendingCodexAppText.
+ *  (2) just-committed launch window (pendingRepo=false): commitRepoSelection has
+ *      already set pendingRepo=false and forked the worker, but pendingRawInput /
+ *      pendingFollowUpInput still wait on the new worker's prompt_ready to send.
+ *      A takeover here must NOT silently drop them just because pendingRepo=false.
+ */
+function notifierAdoptWouldDropInput(ds: DaemonSession): boolean {
+  return (
+    (ds.pendingPrompt?.trim().length ?? 0) > 0
+    || (ds.pendingFollowUps?.length ?? 0) > 0
+    || (ds.pendingAttachments?.length ?? 0) > 0
+    || (ds.pendingRawInput?.trim().length ?? 0) > 0
+    || (ds.pendingCodexAppText?.trim().length ?? 0) > 0
+    || (ds.pendingFollowUpInput?.cliInput?.trim().length ?? 0) > 0
+  );
+}
+
+/**
  * Fully retire an in-memory repo-select placeholder when the Codex-notifier
  * 「继续处理」callback takes over the DM session. The legacy inline clear only
  * reset six fields and left `repoCardMessageId`, `pendingFollowUps`,
  * `pendingRepoCommitInFlight`, `worktreeCreating`, attachments, mentions, raw
  * input, etc. behind — a stale repo-card click or a late auto-worktree
  * completion could then act on the just-adopted session. Clear the whole
- * pending-repo surface so no residue survives the takeover. Buffered user input
- * is dropped here — the drop is terminal (never rolled back, since concurrent
- * background tasks may already have observed pendingRepo=false); the caller
- * tells the user their input was cancelled on both the success and failure card.
+ * pending-repo surface so no residue survives the takeover. Buffered/undelivered
+ * user input (repo-select buffer AND the pendingRawInput/pendingFollowUpInput a
+ * just-committed session is still waiting to send on prompt_ready) is dropped
+ * here — the drop is terminal (never rolled back, since concurrent background
+ * tasks may already have observed pendingRepo=false); the caller tells the user
+ * their input was cancelled on both the success and failure card.
  */
 function clearPendingRepoStateForNotifierAdopt(ds: DaemonSession): void {
   ds.pendingRepo = false;
@@ -4463,6 +4511,10 @@ async function adoptCodexNotifierEvent(
   }
 
   let bufferedInputDropped = false;
+  // Snapshot the session identity BEFORE the throwable/deadline-bound awaits
+  // below. If the session is closed, swapped, or re-created under this active
+  // key while we await, the post-await revalidation must detect the drift.
+  const adoptGenSessionId = ds.session.sessionId;
   if (ds.session.cliSessionId !== event.threadId || !ds.worker || ds.worker.killed) {
     // Do the two throwable, deadline-sensitive steps FIRST, before mutating any
     // session/pending state: the dynamic import and the 2.2s AbortSignal check.
@@ -4470,6 +4522,14 @@ async function adoptCodexNotifierEvent(
     // and the buffered repo-select input is left intact for a retry.
     const { startCodexAppThreadSession } = await import('./core/command-handler.js');
     signal.throwIfAborted();
+
+    // Re-validate AFTER the awaits and BEFORE mutating anything (see
+    // notifierAdoptStaleOrTransferring): a concurrent /relay transfer or a
+    // /close/swap/re-create under this key must fail the takeover explicitly
+    // rather than half-rewrite the session and report a bogus green success.
+    if (notifierAdoptStaleOrTransferring(ds, activeSessions, activeKey, adoptGenSessionId)) {
+      throw new Error('该会话正在转移或已变更，无法接管；请稍后在完成通知卡上重试');
+    }
 
     // 接管原生 Codex App 线程时固定为纯 codex-app 启动，不能继承通知 Bot 的
     // wrapper/model；这些配置针对普通 CLI，会错误包装 app-server runner。
@@ -4494,13 +4554,10 @@ async function adoptCodexNotifierEvent(
     // pendingRepo=true/worktreeCreating=true 快照复活,后台任务已不在,会话会永久
     // 卡在「正在创建/提交」。因此丢弃一旦发布即为终态——用「取消并请重发」的显式
     // 语义告知用户,而非假装能恢复。
-    bufferedInputDropped = ds.pendingRepo === true && (
-      (ds.pendingPrompt?.trim().length ?? 0) > 0
-      || (ds.pendingFollowUps?.length ?? 0) > 0
-      || (ds.pendingAttachments?.length ?? 0) > 0
-      || (ds.pendingRawInput?.trim().length ?? 0) > 0
-      || (ds.pendingCodexAppText?.trim().length ?? 0) > 0
-    );
+    // 判断是否有「已收下但尚未真正送达 CLI」的用户输入会被下面的 clear 抹掉
+    // (见 notifierAdoptWouldDropInput,覆盖选仓挂起期缓冲 + 选仓刚提交的启动窗
+    // 两个窗口,都不拿 pendingRepo 当前置)。有则记录已丢弃,如实告知用户。
+    bufferedInputDropped = notifierAdoptWouldDropInput(ds);
     clearPendingRepoStateForNotifierAdopt(ds);
 
     // 完成事件已经携带恢复所需的原生 threadId/cwd。按钮回调不再额外启动一次
@@ -4528,12 +4585,12 @@ async function adoptCodexNotifierEvent(
         cardMessageId,
       );
     } catch (err) {
-      // 接管失败/超时:pending 已清空且不回滚(见上)。若曾丢弃过缓冲输入,把「已取消、
+      // 接管失败/超时:pending 已清空且不回滚(见上)。若曾丢弃过缓冲/未送达输入,把「已取消、
       // 请重发」前置到抛给外层的错误里——外层用它渲染失败卡,用户就不会以为原消息还
       // 在队列里等着(否则失败卡只说"接管失败请重试",缓冲却已没了=静默丢失)。
       if (bufferedInputDropped) {
         const detail = err instanceof Error ? err.message : String(err);
-        throw new Error(`你在选择仓库前输入的消息已取消，请在接管成功后重新发送。（接管未完成：${detail}）`);
+        throw new Error(`你此前发送但尚未送达的消息已取消，请在接管成功后重新发送。（接管未完成：${detail}）`);
       }
       throw err;
     }
@@ -4545,11 +4602,15 @@ async function adoptCodexNotifierEvent(
   return buildCodexNotifierResultCard(
     '已接管 Codex App 任务',
     bufferedInputDropped
-      ? `⚠️ 你在选择仓库前输入的消息未随本次接管发送，请重新发送一次。\n\n${baseAdoptNotice}`
+      ? `⚠️ 你此前发送但尚未送达的消息未随本次接管发送，请重新发送一次。\n\n${baseAdoptNotice}`
       : baseAdoptNotice,
     'green',
   );
 }
+
+export const __testOnly_notifierAdoptStaleOrTransferring = notifierAdoptStaleOrTransferring;
+export const __testOnly_notifierAdoptWouldDropInput = notifierAdoptWouldDropInput;
+export const __testOnly_clearPendingRepoStateForNotifierAdopt = clearPendingRepoStateForNotifierAdopt;
 
 const handleCodexNotifierCardAction = createCodexNotifierCardActionHandler({
   getExpectedOwnerOpenId: larkAppId =>

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4391,24 +4391,39 @@ function notifierAdoptStaleOrTransferring(
 
 /**
  * P2 predicate: would clearPendingRepoStateForNotifierAdopt drop user input that
- * was accepted but not yet delivered to the CLI? Covers BOTH windows, neither of
- * which may gate on pendingRepo:
- *  (1) repo-select pending (pendingRepo=true): buffered in pendingPrompt /
- *      pendingFollowUps / pendingAttachments / pendingRawInput / pendingCodexAppText.
- *  (2) just-committed launch window (pendingRepo=false): commitRepoSelection has
- *      already set pendingRepo=false and forked the worker, but pendingRawInput /
- *      pendingFollowUpInput still wait on the new worker's prompt_ready to send.
- *      A takeover here must NOT silently drop them just because pendingRepo=false.
+ * was accepted but not yet delivered to the CLI? Two DISTINCT windows with
+ * different gating — do NOT collapse them:
+ *
+ *  (1) repo-select pending buffer — ONLY meaningful while pendingRepo===true.
+ *      pendingPrompt / pendingCodexAppText / pendingAttachments / pendingFollowUps
+ *      are the message stashed for the deferred post-repo-selection fork. But the
+ *      pinned/defaultWorkingDir immediate-launch path (daemon.ts ~16031/17325)
+ *      ALSO seeds these same mirror fields, then forks and clears only
+ *      pendingTurnId (~16097/17387) — leaving pendingPrompt/etc behind on an
+ *      already-delivered session with pendingRepo=false. Gating on pendingRepo
+ *      here is what stops us from warning "message not delivered, resend" about
+ *      a prompt the worker already ran (which would make the user re-run a
+ *      non-idempotent command).
+ *
+ *  (2) just-committed launch window — INDEPENDENT of pendingRepo. commitRepoSelection
+ *      set pendingRepo=false and forked, but pendingRawInput / pendingFollowUpInput
+ *      still wait on the new worker's prompt_ready to actually send. These are the
+ *      only fields that legitimately represent undelivered input while
+ *      pendingRepo=false, so they are checked unconditionally. (The immediate-launch
+ *      path never populates them — it forks with the prompt as a direct argument.)
  */
 function notifierAdoptWouldDropInput(ds: DaemonSession): boolean {
-  return (
+  const repoSelectBuffered = ds.pendingRepo === true && (
     (ds.pendingPrompt?.trim().length ?? 0) > 0
     || (ds.pendingFollowUps?.length ?? 0) > 0
     || (ds.pendingAttachments?.length ?? 0) > 0
-    || (ds.pendingRawInput?.trim().length ?? 0) > 0
     || (ds.pendingCodexAppText?.trim().length ?? 0) > 0
-    || (ds.pendingFollowUpInput?.cliInput?.trim().length ?? 0) > 0
   );
+  // Undelivered regardless of pendingRepo (awaiting prompt_ready on a forked worker).
+  const undeliveredLaunchInput =
+    (ds.pendingRawInput?.trim().length ?? 0) > 0
+    || (ds.pendingFollowUpInput?.cliInput?.trim().length ?? 0) > 0;
+  return repoSelectBuffered || undeliveredLaunchInput;
 }
 
 /**
@@ -4508,6 +4523,17 @@ async function adoptCodexNotifierEvent(
       await closeSessionHelper(session.sessionId);
       throw new Error('通知所在会话路由被一条待处理的持久会话占用');
     }
+  }
+
+  // Transfer guard OUTSIDE the launch branch. If the session is already on the
+  // target thread with a live worker, the branch below is skipped entirely —
+  // but a concurrent /relay could still be moving this session's routing away.
+  // Returning a green「已接管，可继续」while the route is migrating is a lie.
+  // Fail-closed here first (a freshly-created ds has no transfer gate, so this
+  // is a no-op for the new-session path); the launch branch keeps its own
+  // post-await revalidation for the drift that can open during its awaits.
+  if (isSessionTransferring(ds)) {
+    throw new Error('该会话正在转移，暂时无法接管；请转移完成后在完成通知卡上重试');
   }
 
   let bufferedInputDropped = false;
@@ -4611,6 +4637,7 @@ async function adoptCodexNotifierEvent(
 export const __testOnly_notifierAdoptStaleOrTransferring = notifierAdoptStaleOrTransferring;
 export const __testOnly_notifierAdoptWouldDropInput = notifierAdoptWouldDropInput;
 export const __testOnly_clearPendingRepoStateForNotifierAdopt = clearPendingRepoStateForNotifierAdopt;
+export const __testOnly_adoptCodexNotifierEvent = adoptCodexNotifierEvent;
 
 const handleCodexNotifierCardAction = createCodexNotifierCardActionHandler({
   getExpectedOwnerOpenId: larkAppId =>

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -765,6 +765,18 @@ export async function runAutoWorktreeCommit(deps: {
     const wt = await maybeCreateDefaultWorktree(larkAppId, baseDir, {
       isBotDefaultDir: true, title, prompt, locale: localeForBot(larkAppId), notify,
     });
+    // The pendingRepo placeholder can legitimately be consumed WHILE this
+    // up-to-30s build runs — e.g. the Codex-notifier「继续处理」callback adopts
+    // the same DM session and clears pendingRepo before we get here. If we now
+    // funneled into commitRepoSelection, its mid-session branch would kill the
+    // freshly-adopted worker and replace it with a botmux-owned worktree
+    // session. Bail on the late result instead: the takeover already owns the
+    // session. (commitRepoSelection also re-checks pendingRepo under its claim,
+    // but that check runs after an await — fence here before any mutation.)
+    if (!ds.pendingRepo) {
+      logger.info(`[${tag(ds)}] auto-worktree completion ignored — pendingRepo already consumed (session taken over)`);
+      return;
+    }
     // Commit even on fallback (wt.dir === baseDir) — the session must still start.
     // commitRepoSelection has its own /close + generation guards and, for a
     // pendingRepo session, folds any messages buffered during creation (pendingPrompt

--- a/test/card-handler-repo-select.test.ts
+++ b/test/card-handler-repo-select.test.ts
@@ -120,6 +120,10 @@ vi.mock('../src/services/worktree-slug-ai.js', () => ({
   }),
 }));
 
+vi.mock('../src/services/default-worktree.js', () => ({
+  maybeCreateDefaultWorktree: vi.fn(async (_appId: string, baseDir: string) => ({ dir: `${baseDir}-wt` })),
+}));
+
 vi.mock('@larksuiteoapi/node-sdk', () => ({
   Client: class { constructor() {} },
   WSClient: class { start() {} },
@@ -129,12 +133,13 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
 
 // ─── Imports ──────────────────────────────────────────────────────────────
 
-import { handleCardAction, type CardHandlerDeps } from '../src/im/lark/card-handler.js';
+import { handleCardAction, runAutoWorktreeCommit, type CardHandlerDeps } from '../src/im/lark/card-handler.js';
 import { forkWorker, killWorker, teardownAuthoritativePersistentBackingBeforeClose, deliverEphemeralOrReply, deliverWriteLinkCard } from '../src/core/worker-pool.js';
 import { buildNewTopicCliInput, getAvailableBots, getSessionWorkingDir } from '../src/core/session-manager.js';
 import { getBot } from '../src/bot-registry.js';
 import { createSession, closeSession, updateSession } from '../src/services/session-store.js';
 import { createRepoWorktree, pushWorktreeBranch, removeRepoWorktree } from '../src/services/git-worktree.js';
+import { maybeCreateDefaultWorktree } from '../src/services/default-worktree.js';
 import { applyConfigField } from '../src/services/bot-config-store.js';
 import { deleteMessage } from '../src/im/lark/client.js';
 import { canOperate } from '../src/im/lark/event-dispatcher.js';
@@ -927,6 +932,37 @@ describe('repo select card — plain switch', () => {
 });
 
 describe('repo select card — worktree open', () => {
+  it('runAutoWorktreeCommit bails when pendingRepo was consumed mid-build (e.g. notifier adopt)', async () => {
+    // A takeover (Codex-notifier「继续处理」, etc.) can consume pendingRepo while
+    // the up-to-30s worktree build runs. The late completion must NOT funnel into
+    // commitRepoSelection and kill+replace the just-adopted session.
+    const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: { killed: false } as any });
+    const { deps } = makeDeps(ds);
+    const d = deferred<{ dir: string }>();
+    vi.mocked(maybeCreateDefaultWorktree).mockReturnValueOnce(d.promise as any);
+
+    const run = runAutoWorktreeCommit({
+      ds,
+      anchor: ROOT_ID,
+      larkAppId: APP_ID,
+      baseDir: '/repos/alpha',
+      activeSessions: deps.activeSessions,
+      notify: vi.fn(),
+    });
+    await vi.waitFor(() => expect(ds.worktreeCreating).toBe(true));
+
+    // Simulate the takeover consuming pendingRepo while git runs.
+    ds.pendingRepo = false;
+    d.resolve({ dir: '/repos/alpha-wt' });
+    await run;
+
+    // Guard fired: no commit, no fork/kill, workingDir untouched.
+    expect(forkWorker).not.toHaveBeenCalled();
+    expect(killWorker).not.toHaveBeenCalled();
+    expect(ds.workingDir).toBeUndefined();
+    expect(ds.worktreeCreating).toBe(false);
+  });
+
   it('double click starts ONE background creation and commits once', async () => {
     const ds = makeDs({ pendingRepo: true, pendingPrompt: 'hi', worker: null });
     const { deps, sessionReply } = makeDeps(ds);

--- a/test/codex-notifier-adopt-race.test.ts
+++ b/test/codex-notifier-adopt-race.test.ts
@@ -1,0 +1,167 @@
+/**
+ * PR #686 follow-up — the two pre-existing races the Codex-notifier「继续处理」
+ * takeover exposed, isolated to their pure decision helpers so they can be
+ * exercised without standing up the whole daemon:
+ *
+ *  P1 · notifierAdoptStaleOrTransferring — after the dynamic import + AbortSignal
+ *       await, a concurrent /relay transfer (or /close/swap/re-create) must abort
+ *       the takeover BEFORE any mutation, so the outer handler never renders a
+ *       bogus green「已接管」over a half-rewritten / relayed session.
+ *
+ *  P2 · notifierAdoptWouldDropInput — the "would clear drop undelivered input?"
+ *       predicate must NOT gate on pendingRepo: input buffered in the just-
+ *       committed launch window (pendingRepo=false, pendingRawInput/
+ *       pendingFollowUpInput still waiting on prompt_ready) is just as real as
+ *       the repo-select pending buffer.
+ *
+ * Run: pnpm vitest run test/codex-notifier-adopt-race.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  transferring: new WeakSet<object>(),
+}));
+
+vi.mock('@larksuiteoapi/node-sdk', () => {
+  class FakeClient { constructor(public opts: Record<string, unknown>) {} }
+  return { Client: FakeClient, WSClient: class { start() {} } };
+});
+
+// isSessionTransferring is the only worker-pool behaviour these pure helpers
+// depend on. Back it by a test-controlled WeakSet keyed on the session object so
+// a test can flip a ds "into transfer" without a real relay gate.
+vi.mock('../src/core/worker-pool.js', async () => {
+  const actual = await vi.importActual<any>('../src/core/worker-pool.js');
+  return {
+    ...actual,
+    isSessionTransferring: (ds: any) => mocks.transferring.has(ds),
+  };
+});
+
+import {
+  __testOnly_notifierAdoptStaleOrTransferring as staleOrTransferring,
+  __testOnly_notifierAdoptWouldDropInput as wouldDropInput,
+  __testOnly_clearPendingRepoStateForNotifierAdopt as clearForAdopt,
+} from '../src/daemon.js';
+import type { DaemonSession } from '../src/core/types.js';
+
+const KEY = 'oc_dm:cli_app';
+
+function makeDs(overrides: Partial<DaemonSession> = {}): DaemonSession {
+  return {
+    session: {
+      sessionId: 'sid-1',
+      status: 'active',
+      cliSessionId: undefined,
+    },
+    worker: null,
+    larkAppId: 'cli_app',
+    chatId: 'oc_dm',
+    ...overrides,
+  } as unknown as DaemonSession;
+}
+
+describe('P1 · notifierAdoptStaleOrTransferring', () => {
+  beforeEach(() => {
+    // Fresh transfer set per test (WeakSet has no clear()).
+    mocks.transferring = new WeakSet();
+  });
+
+  it('healthy, still-mapped, non-transferring session → proceed (false)', () => {
+    const ds = makeDs();
+    const sessions = new Map([[KEY, ds]]);
+    expect(staleOrTransferring(ds, sessions, KEY, 'sid-1')).toBe(false);
+  });
+
+  it('session swapped out of the active map → abort (true)', () => {
+    const ds = makeDs();
+    const other = makeDs({ session: { sessionId: 'sid-2', status: 'active' } as any });
+    const sessions = new Map([[KEY, other]]); // key now points elsewhere
+    expect(staleOrTransferring(ds, sessions, KEY, 'sid-1')).toBe(true);
+  });
+
+  it('active-map entry removed (/close) → abort (true)', () => {
+    const ds = makeDs();
+    const sessions = new Map<string, DaemonSession>(); // key gone
+    expect(staleOrTransferring(ds, sessions, KEY, 'sid-1')).toBe(true);
+  });
+
+  it('session identity drifted (re-created under the same key) → abort (true)', () => {
+    const ds = makeDs();
+    const sessions = new Map([[KEY, ds]]);
+    ds.session.sessionId = 'sid-DIFFERENT';
+    expect(staleOrTransferring(ds, sessions, KEY, 'sid-1')).toBe(true);
+  });
+
+  it('session no longer active (closed) → abort (true)', () => {
+    const ds = makeDs({ session: { sessionId: 'sid-1', status: 'closed' } as any });
+    const sessions = new Map([[KEY, ds]]);
+    expect(staleOrTransferring(ds, sessions, KEY, 'sid-1')).toBe(true);
+  });
+
+  it('a /relay transfer opened its gate on this session → abort (true)', () => {
+    const ds = makeDs();
+    const sessions = new Map([[KEY, ds]]);
+    mocks.transferring.add(ds); // relay in progress
+    expect(staleOrTransferring(ds, sessions, KEY, 'sid-1')).toBe(true);
+  });
+});
+
+describe('P2 · notifierAdoptWouldDropInput', () => {
+  it('nothing pending → false', () => {
+    expect(wouldDropInput(makeDs())).toBe(false);
+  });
+
+  it('repo-select pending buffer (pendingRepo=true) → true', () => {
+    expect(wouldDropInput(makeDs({ pendingRepo: true, pendingPrompt: 'hello' } as any))).toBe(true);
+  });
+
+  it('pendingRawInput in the launch window with pendingRepo ALREADY false → true (the P2 window)', () => {
+    // commitRepoSelection has set pendingRepo=false and forked; pendingRawInput
+    // still awaits the new worker's prompt_ready. The old predicate gated on
+    // pendingRepo===true and would MISS this — silently dropping the raw input.
+    const ds = makeDs({ pendingRepo: false, pendingRawInput: '/status' } as any);
+    expect(wouldDropInput(ds)).toBe(true);
+  });
+
+  it('pendingFollowUpInput staged for prompt_ready with pendingRepo false → true', () => {
+    const ds = makeDs({
+      pendingRepo: false,
+      pendingFollowUpInput: { userPrompt: 'go', cliInput: 'wrapped go' },
+    } as any);
+    expect(wouldDropInput(ds)).toBe(true);
+  });
+
+  it('whitespace-only buffers do not count as droppable input', () => {
+    const ds = makeDs({ pendingRepo: false, pendingRawInput: '   ', pendingPrompt: '  ' } as any);
+    expect(wouldDropInput(ds)).toBe(false);
+  });
+
+  it('mention/context-only pending (no submittable text) → false', () => {
+    // pendingMentions / codexApp*Context are not submittable input on their own.
+    const ds = makeDs({
+      pendingRepo: true,
+      pendingMentions: [{ openId: 'ou_x' }],
+      pendingCodexAppApplicationContext: { some: 'ctx' },
+    } as any);
+    expect(wouldDropInput(ds)).toBe(false);
+  });
+});
+
+describe('P2 · clear actually removes what the predicate flagged', () => {
+  it('the launch-window fields the predicate now covers are all cleared', () => {
+    const ds = makeDs({
+      pendingRepo: false,
+      pendingRawInput: '/status',
+      pendingFollowUpInput: { userPrompt: 'go', cliInput: 'wrapped go' },
+      pendingPrompt: 'hi',
+    } as any);
+    expect(wouldDropInput(ds)).toBe(true);
+    clearForAdopt(ds);
+    // Everything the predicate reads is now gone → a second check is false.
+    expect(wouldDropInput(ds)).toBe(false);
+    expect(ds.pendingRawInput).toBeUndefined();
+    expect(ds.pendingFollowUpInput).toBeUndefined();
+    expect(ds.pendingRepo).toBe(false);
+  });
+});

--- a/test/codex-notifier-adopt-race.test.ts
+++ b/test/codex-notifier-adopt-race.test.ts
@@ -9,10 +9,12 @@
  *       bogus green「已接管」over a half-rewritten / relayed session.
  *
  *  P2 · notifierAdoptWouldDropInput — the "would clear drop undelivered input?"
- *       predicate must NOT gate on pendingRepo: input buffered in the just-
- *       committed launch window (pendingRepo=false, pendingRawInput/
- *       pendingFollowUpInput still waiting on prompt_ready) is just as real as
- *       the repo-select pending buffer.
+ *       predicate splits by state semantics: repo-select mirror fields
+ *       (pendingPrompt/etc) count ONLY while pendingRepo===true (the immediate-
+ *       launch path also seeds them but has already forked/delivered), while
+ *       pendingRawInput/pendingFollowUpInput are checked independently of
+ *       pendingRepo — they are the real just-committed launch window still
+ *       waiting on prompt_ready.
  *
  * Run: pnpm vitest run test/codex-notifier-adopt-race.test.ts
  */

--- a/test/codex-notifier-adopt-race.test.ts
+++ b/test/codex-notifier-adopt-race.test.ts
@@ -38,11 +38,36 @@ vi.mock('../src/core/worker-pool.js', async () => {
   };
 });
 
+// The integration test drives adoptCodexNotifierEvent through its real control
+// flow; stub the one network hop (message→chat lookup) and the bot config read.
+vi.mock('../src/im/lark/client.js', async () => {
+  const actual = await vi.importActual<any>('../src/im/lark/client.js');
+  return {
+    ...actual,
+    getMessageChatId: vi.fn(async () => 'oc_dm'),
+  };
+});
+
+vi.mock('../src/bot-registry.js', async () => {
+  const actual = await vi.importActual<any>('../src/bot-registry.js');
+  return {
+    ...actual,
+    getBot: vi.fn(() => ({
+      config: { larkAppId: 'cli_app', cliId: 'codex-app', p2pMode: 'chat', cliPathOverride: undefined },
+      botName: 'TestBot',
+      botOpenId: 'ou_bot',
+    })),
+  };
+});
+
 import {
   __testOnly_notifierAdoptStaleOrTransferring as staleOrTransferring,
   __testOnly_notifierAdoptWouldDropInput as wouldDropInput,
   __testOnly_clearPendingRepoStateForNotifierAdopt as clearForAdopt,
+  __testOnly_adoptCodexNotifierEvent as adoptEvent,
+  __testOnly_activeSessions as activeSessions,
 } from '../src/daemon.js';
+import { sessionKey } from '../src/core/types.js';
 import type { DaemonSession } from '../src/core/types.js';
 
 const KEY = 'oc_dm:cli_app';
@@ -146,6 +171,39 @@ describe('P2 · notifierAdoptWouldDropInput', () => {
     } as any);
     expect(wouldDropInput(ds)).toBe(false);
   });
+
+  // ─── P2 regression: the immediate-launch (pinned/defaultWorkingDir) path ───
+  // seeds pendingPrompt/pendingCodexAppText/pendingAttachments as MIRROR fields,
+  // forks, and clears only pendingTurnId — leaving those fields on an already-
+  // delivered session with pendingRepo=false. Flagging them would wrongly warn
+  // "message not delivered, resend" → user re-runs a possibly non-idempotent
+  // command. So repo-select mirror fields must ONLY count when pendingRepo===true.
+  it('pinned launch residue: pendingPrompt with pendingRepo=false → false (already delivered)', () => {
+    const ds = makeDs({ pendingRepo: false, pendingPrompt: 'already ran' } as any);
+    expect(wouldDropInput(ds)).toBe(false);
+  });
+
+  it('pinned launch residue: pendingCodexAppText with pendingRepo=false → false', () => {
+    const ds = makeDs({ pendingRepo: false, pendingCodexAppText: 'ran visible text' } as any);
+    expect(wouldDropInput(ds)).toBe(false);
+  });
+
+  it('pinned launch residue: pendingAttachments with pendingRepo=false → false', () => {
+    const ds = makeDs({ pendingRepo: false, pendingAttachments: [{ key: 'img_1' }] } as any);
+    expect(wouldDropInput(ds)).toBe(false);
+  });
+
+  it('pinned launch residue: pendingFollowUps with pendingRepo=false → false', () => {
+    const ds = makeDs({ pendingRepo: false, pendingFollowUps: ['a', 'b'] } as any);
+    expect(wouldDropInput(ds)).toBe(false);
+  });
+
+  it('raw/follow-up stay independent: pendingRawInput true even alongside pendingRepo=false residue', () => {
+    // The launch window that IS real: raw input still awaiting prompt_ready,
+    // coexisting with an already-delivered pendingPrompt mirror. raw wins → true.
+    const ds = makeDs({ pendingRepo: false, pendingPrompt: 'delivered', pendingRawInput: '/status' } as any);
+    expect(wouldDropInput(ds)).toBe(true);
+  });
 });
 
 describe('P2 · clear actually removes what the predicate flagged', () => {
@@ -163,5 +221,60 @@ describe('P2 · clear actually removes what the predicate flagged', () => {
     expect(ds.pendingRawInput).toBeUndefined();
     expect(ds.pendingFollowUpInput).toBeUndefined();
     expect(ds.pendingRepo).toBe(false);
+  });
+});
+
+// ─── P2#2 integration: guard placement OUTSIDE the launch branch ────────────
+// A pure-helper test cannot prove WHERE the transfer guard sits. Drive the real
+// adoptCodexNotifierEvent control flow with a session that is ALREADY on the
+// target thread with a live worker (so the launch/re-fork branch is skipped
+// entirely). Only an out-of-branch guard can still catch an in-flight transfer.
+describe('P2#2 · adoptCodexNotifierEvent transfer guard (integration)', () => {
+  const EVENT = {
+    eventId: 'e'.repeat(64),
+    type: 'codex_task_completed',
+    source: 'codex-app',
+    threadId: 'thread-live',
+    nativeTurnId: 'nt-1',
+    status: 'completed',
+    cwd: '/repos/live',
+    title: 'Live task',
+    finalPreview: 'done',
+  } as any;
+
+  function liveAdoptedDs(): DaemonSession {
+    // Same thread as EVENT + a live worker → the `cliSessionId !== threadId ||
+    // !worker || worker.killed` launch branch is FALSE (skipped).
+    return makeDs({
+      session: { sessionId: 'sid-live', status: 'active', cliSessionId: 'thread-live' } as any,
+      worker: { killed: false } as any,
+      workingDir: '/repos/live',
+    });
+  }
+
+  beforeEach(() => {
+    mocks.transferring = new WeakSet();
+    activeSessions.clear();
+  });
+
+  it('same-thread live worker + /relay transferring → throws, NOT a green success card', async () => {
+    const ds = liveAdoptedDs();
+    activeSessions.set(sessionKey('oc_dm', 'cli_app'), ds);
+    mocks.transferring.add(ds); // relay in progress on this exact session
+
+    const ctrl = new AbortController();
+    await expect(
+      adoptEvent('cli_app', EVENT, 'om_card', 'ou_owner', ctrl.signal, Date.now() + 2200),
+    ).rejects.toThrow(/转移/); // "该会话正在转移，暂时无法接管…"
+  });
+
+  it('same-thread live worker + NOT transferring → returns the green adopt card (idempotent re-click)', async () => {
+    const ds = liveAdoptedDs();
+    activeSessions.set(sessionKey('oc_dm', 'cli_app'), ds);
+    // no transfer gate → the out-of-branch guard is a no-op
+
+    const ctrl = new AbortController();
+    const card = await adoptEvent('cli_app', EVENT, 'om_card', 'ou_owner', ctrl.signal, Date.now() + 2200);
+    expect(JSON.stringify(card)).toContain('已接管');
   });
 });


### PR DESCRIPTION
## 背景

#669 给三条**交互式**接管入口（`/adopt` direct+selector、Codex App thread selector、磁盘 resume import）加了 `blockTakeoverWhilePendingRepo` 守卫：会话仍在「待选仓库」挂起态时接管会被拒绝并给一键关闭卡。但 review 中 @codex 指出还有**第 4 条**接管路径绕过守卫——Codex-notifier 私聊「任务完成 → 在飞书中继续处理」卡回调（`adoptCodexNotifierEvent`）。它在调 `startCodexAppThreadSession` **之前**先 inline 清掉 `pendingRepo`，所以新守卫必然 no-op。

默认 flat DM（`p2pMode=chat`）下这条回调复用同一私聊的现有会话，由此暴露多个 **pre-existing**（master 既有，非 #669 引入）race。本 PR 是 #669 约定的 follow-up。经 @codex 两轮复审逐步收敛，最终收口 4 处 correctness 问题。

## 改了什么（最终版，含两轮复审后的修正）

### 1. 迟到 auto-worktree 不再替换刚接管的会话
`runAutoWorktreeCommit`：在 `maybeCreateDefaultWorktree` 的 await 之后、`commitRepoSelection` 之前加 `if (!ds.pendingRepo) return` 护栏——后台 worktree（可长达 30s）在会话被接管消费掉 `pendingRepo` 后才完成时，不再进 `commitRepoSelection` 的 mid-session 分支 kill 掉刚接管的 worker。对所有消费 `pendingRepo` 的接管路径生效。

### 2. notifier 接管完整清理 pending，旧选仓卡二次点击失效
`clearPendingRepoStateForNotifierAdopt` 完整清空全部 pending-repo 状态（旧 inline 清理只动 6 字段，残留 `repoCardMessageId`/`pendingFollowUps`/`worktreeCreating` 等）。`repoCardMessageId=undefined` 让旧选仓卡 fail closed。

### 3. transfer race：接管不再误报成功 + 不污染 session
rebase 到最新 master 后（#458 ZMX 在 `startCodexAppThreadSession` 入口新增 `isSessionTransferring` fence，命中只 `return`），若同一会话正在 `/relay` 转移，notifier 接管会先改写 session 再调 starter，starter 命中 fence 只 return、提示被 no-op sessionReply 吞掉，外层却渲染绿色「已接管」而 session 已被改一半。修两处（@codex 二审后定稿）：
- **分支外 early guard**：进入函数拿到 ds 后、启动 if 分支**外**先 `isSessionTransferring(ds)` fail-closed——覆盖「已是同 thread + live worker、启动分支被跳过」但正在转移的路径（新建 ds 无 transfer gate，对新会话 no-op）。
- **分支内 await 后二次校验** `notifierAdoptStaleOrTransferring`：动态 import + `signal.throwIfAborted()` 之后、任何 mutation 之前，校验 `activeSessions.get(activeKey)===ds` + session identity/status 未变 + `!isSessionTransferring`。命中抛明确失败;因在 clear 之前，pending 完好、零副作用可重试。

### 4. 不静默丢「未送达」输入，且不误警告「已送达」输入
`notifierAdoptWouldDropInput` 谓词按状态语义拆两类（@codex 二审后收窄）：
- **repo-select 镜像字段**（`pendingPrompt`/`pendingCodexAppText`/`pendingAttachments`/`pendingFollowUps`）**只在 `pendingRepo===true`** 计入。因为 pinned/defaultWorkingDir 立即启动路径（`~16031/17325`）也播种这些镜像字段，fork 后只清 `pendingTurnId`（`~16097/17387`），残留字段在 `pendingRepo=false` 的**已送达**会话上——若无条件计入会误警告「消息未送达请重发」→ 非幂等指令重跑。
- **`pendingRawInput` / `pendingFollowUpInput`** 独立于 `pendingRepo` 判断——它们是唯一在 `pendingRepo=false` 仍代表**真未送达**的字段（commitRepoSelection 已 fork、等新 worker `prompt_ready` 才发；立即启动路径从不播种它们）。

成功卡带 warning、失败卡把「已取消、请重发」前置进抛出的 Error（外层据此渲染），成功/失败两路径都如实告知，无静默丢失、无额外网络 await、无假回滚（clear 后不回滚——回滚已被并发 auto-worktree 观察过的 `pendingRepo` 会让会话永久卡「正在创建/提交」）。

## 影响面

- **daemon.ts**：仅 `adoptCodexNotifierEvent` 的接管控制流 + pending 清理 + 结果卡文案；新增 3 个 daemon-local helper（`notifierAdoptStaleOrTransferring` / `notifierAdoptWouldDropInput` / `clearPendingRepoStateForNotifierAdopt`）。
- **card-handler.ts**：`runAutoWorktreeCommit` 加一句 `!ds.pendingRepo` 护栏,对所有走 auto-worktree 的会话生效。
- 不改产品行为：notifier「继续处理」仍照常 resume 目标线程;只是不再静默丢/误警告输入、不再误杀会话、不再误报成功。

## 验证

- `pnpm build` 通过
- 相关回归 8 files / 350 tests 全绿（新增 `test/codex-notifier-adopt-race.test.ts` 20 tests + `card-handler-repo-select` 55 + `codex-notifier*` + `command-handler` + `transfer-passthrough-gate`）
- 新测试 **mutation 双证有牙**：退回过宽谓词 → P2#1 的 4 条 pinned-launch-residue 反例变红;去掉分支外 transfer guard → P2#2 集成测试（同 thread live worker + transferring → 抛错）变红;退回 `pendingRepo===true` 前置 → P2 启动窗测试红;去掉 `isSessionTransferring` → P1 relay 测试红。
- 已 rebase 到最新 master（`f770b8e69`），`git merge-tree --write-tree origin/master HEAD` 无冲突，PR `MERGEABLE`
- CI `build` 红项已与 master 对照确认为 baseline（`card-handler-grant-partial` + `plugin-mcp-sandbox` bwrap + `v3-distillation-runner`，在纯 master `f770b8e69` 及 master 自己的 CI run 上同样失败），非本 PR 引入。

## 已知覆盖边界

`adoptCodexNotifierEvent` 现经 `__testOnly_adoptCodexNotifierEvent` 导出并有一条穿过其真实控制流的 P2#2 集成测试。非阻塞 P3：auto-worktree guard 命中前 worktree 可能已建好并发过「已创建」提示 → 孤儿目录可另开 follow-up。
