### PR TITLE
perf(dashboard): 缓存群矩阵并提供轻量元数据

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -2251,7 +2251,12 @@ ipcRoute('PUT', '/api/roles/:chatId', async (req, res, p) => {
   try {
     if (hasContentField) writeRoleFile(cachedLarkAppId, p.chatId, content);
     if (injectMode !== undefined) writeRoleInjectMode(cachedLarkAppId, p.chatId, injectMode);
-    jsonRes(res, 200, { ok: true });
+    // `changed` reflects whether the role FILE (→ hasRole in the groups matrix)
+    // was written. An injectMode-only PUT touches just the .meta.json sidecar and
+    // leaves hasRole untouched, so it reports changed:false — the dashboard uses
+    // this to avoid needlessly busting its 30s groups-matrix snapshot on the
+    // common inject-mode toggle.
+    jsonRes(res, 200, { ok: true, changed: hasContentField });
   } catch (e) {
     jsonRes(res, 500, { ok: false, error: String(e) });
   }
@@ -2262,7 +2267,9 @@ ipcRoute('DELETE', '/api/roles/:chatId', async (_req, res, p) => {
   if (!isValidRoleChatId(p.chatId)) return jsonRes(res, 400, { ok: false, error: 'invalid_chat_id' });
   const existed = deleteRoleFile(cachedLarkAppId, p.chatId);
   deleteRoleInjectMode(cachedLarkAppId, p.chatId);
-  jsonRes(res, 200, { ok: true, existed });
+  // `changed` mirrors `existed`: a DELETE that removed nothing didn't flip
+  // hasRole, so the dashboard skips invalidating its groups-matrix snapshot.
+  jsonRes(res, 200, { ok: true, existed, changed: existed });
 });
 
 // ─── Role profile management (dashboard) ──────────────────────────────────

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -25,6 +25,7 @@ import {
   compactGroupsMatrix,
   createGroupsMatrixSnapshot,
   enrichSessionsWithGroupNames,
+  roleWriteShouldInvalidate,
   type GroupsMatrix,
 } from './dashboard/groups-matrix-snapshot.js';
 import {
@@ -3993,14 +3994,25 @@ const server = createServer(async (req, res) => {
           headers: { 'content-type': 'application/json' },
           body: raw,
         });
+        const upstreamText = await upstream.text();
+        let upstreamJson: any = null;
+        try { upstreamJson = JSON.parse(upstreamText); } catch { /* leave null */ }
+        // 写角色会翻转群矩阵里的 hasRole → 失效快照，避免 roles 页「已配置」
+        // 徽标最多陈旧 30s（对齐 oncall bind/unbind、建群/加 bot 的失效）。
+        if (roleWriteShouldInvalidate(upstream.ok, upstreamJson)) groupsMatrixSnapshot.invalidate();
         res.writeHead(upstream.status, { 'content-type': 'application/json' });
-        res.end(await upstream.text());
+        res.end(upstreamText);
         return;
       }
       if (req.method === 'DELETE') {
         const upstream = await proxyToDaemon(larkAppId, `/api/roles/${encodeURIComponent(chatId)}`, { method: 'DELETE' });
+        const upstreamText = await upstream.text();
+        let upstreamJson: any = null;
+        try { upstreamJson = JSON.parse(upstreamText); } catch { /* leave null */ }
+        // 删角色会把 hasRole 翻回 false — 失效快照让徽标立即刷新，不等 30s TTL。
+        if (roleWriteShouldInvalidate(upstream.ok, upstreamJson)) groupsMatrixSnapshot.invalidate();
         res.writeHead(upstream.status, { 'content-type': 'application/json' });
-        res.end(await upstream.text());
+        res.end(upstreamText);
         return;
       }
     }
@@ -4085,8 +4097,15 @@ const server = createServer(async (req, res) => {
         headers: { 'content-type': 'application/json' },
         body: raw,
       });
+      const upstreamText = await upstream.text();
+      let upstreamJson: any = null;
+      try { upstreamJson = JSON.parse(upstreamText); } catch { /* leave null */ }
+      // 只有真正改写了角色文件（changed:true）才失效缓存：preview、被拒
+      // （chat_role_exists）、missing_entry 都不动 hasRole，跟着失效只会白白
+      // 打穿 30s 快照、把 PR 的 fan-out 优化抵消掉（判定在 roleWriteShouldInvalidate）。
+      if (roleWriteShouldInvalidate(upstream.ok, upstreamJson)) groupsMatrixSnapshot.invalidate();
       res.writeHead(upstream.status, { 'content-type': 'application/json' });
-      res.end(await upstream.text());
+      res.end(upstreamText);
       return;
     }
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -22,6 +22,12 @@ import { DaemonRegistry, botsRosterSignature } from './dashboard/registry.js';
 import { Aggregator, subscribeDaemon } from './dashboard/aggregator.js';
 import { createSessionPresentationCoordinator } from './dashboard/session-presentation.js';
 import {
+  compactGroupsMatrix,
+  createGroupsMatrixSnapshot,
+  enrichSessionsWithGroupNames,
+  type GroupsMatrix,
+} from './dashboard/groups-matrix-snapshot.js';
+import {
   parseDashboardAskAnswerRequest,
   proxyDashboardAskAnswer,
 } from './dashboard/desktop-asks.js';
@@ -299,6 +305,16 @@ mkdirSync(REGISTRY_DIR, { recursive: true });
 const registry = new DaemonRegistry(REGISTRY_DIR);
 const aggregator = new Aggregator();
 const sessionPresentation = createSessionPresentationCoordinator(aggregator, getGitRepoInfo);
+const groupsMatrixSnapshot = createGroupsMatrixSnapshot(buildGroupsMatrix, {
+  onRefreshError: error => logger.warn(`[dashboard] groups matrix refresh failed: ${String(error)}`),
+});
+let groupsRosterSignature = botsRosterSignature(registry.list());
+registry.on((online) => {
+  const next = botsRosterSignature(online);
+  if (next === groupsRosterSignature) return;
+  groupsRosterSignature = next;
+  groupsMatrixSnapshot.invalidate();
+});
 
 // Keep Git-derived fields in the central read-model so REST snapshots and SSE
 // share one row shape. Idle/limited turn boundaries force a branch refresh
@@ -1097,6 +1113,7 @@ const groupsActionDeps: GroupsActionDeps = {
   proxyToDaemon,
   closeSessionsMatching,
   fetch: fetchDaemonUrl,
+  invalidateGroups: () => groupsMatrixSnapshot.invalidate(),
 };
 
 // ─── PR2 C8: Route B internal API (`/__daemon/*`) ───────────────────────────
@@ -1118,7 +1135,7 @@ const daemonInternalApi = createDaemonInternalApi({
   getSessions: () => aggregator.getSessions(),
   getSchedules: () => aggregator.getSchedules(),
   resolveDashboardSettings,
-  buildGroupsMatrix,
+  buildGroupsMatrix: () => groupsMatrixSnapshot.get(),
   settingsApplierDeps: settingsWriteApplierDeps,
   groupsActionDeps,
   proxyToDaemon,
@@ -1985,6 +2002,7 @@ async function createTeamGroup(args: { name: string; larkAppIds: string[]; userO
     if (!upstream.ok || !parsed?.ok || typeof parsed.chatId !== 'string') {
       return { ok: false, error: parsed?.error ?? `group_create_http_${upstream.status}` };
     }
+    groupsMatrixSnapshot.invalidate();
     return {
       ok: true,
       chatId: parsed.chatId,
@@ -2022,6 +2040,7 @@ async function transferTeamGroupOwner(args: {
         transferError: parsed?.error ?? `owner_transfer_http_${upstream.status}`,
       };
     }
+    groupsMatrixSnapshot.invalidate();
     return {
       ownerTransferredTo: parsed.ownerTransferredTo ?? null,
       transferError: parsed.transferError ?? null,
@@ -2079,6 +2098,7 @@ async function createLifecycleGroupForWebhook(
   if (!upstream.ok || !parsed?.ok || typeof parsed.chatId !== 'string') {
     throw new Error(parsed?.error ?? `group_create_http_${upstream.status}`);
   }
+  groupsMatrixSnapshot.invalidate();
   return { chatId: parsed.chatId, creatorLarkAppId: parsed.creator ?? pick.creatorLarkAppId };
 }
 
@@ -2088,7 +2108,7 @@ async function createLifecycleGroupForWebhook(
  * always returns the raw (unscrubbed) view — the browser route applies its
  * `redactGroupsForPublic` scrub on top when the caller is unauthed.
  */
-async function buildGroupsMatrix(): Promise<{ chats: any[]; bots: any[] }> {
+async function buildGroupsMatrix(): Promise<GroupsMatrix> {
   const out = new Map<string, any>();
   const cliIds = configuredCliIds();
   const onlineBots = [...registry.list()]
@@ -2684,12 +2704,13 @@ const server = createServer(async (req, res) => {
       // raw appId as botName — resolve through the live registry so consumers
       // (dashboard, HD2D office tab) always see the human-facing name.
       const names = new Map([...registry.list()].map(d => [d.larkAppId, d.botName] as const));
-      const sessions = aggregator.getSessions().map(s => {
+      groupsMatrixSnapshot.warm();
+      const sessions = enrichSessionsWithGroupNames(aggregator.getSessions().map(s => {
         const n = names.get(s.larkAppId);
         return n && n !== s.larkAppId && (!s.botName || s.botName === s.larkAppId)
           ? { ...s, botName: n }
           : s;
-      });
+      }), groupsMatrixSnapshot.peekPresentation());
       return jsonRes(res, 200, {
         sessions: authed ? sessions : redactSessionsForPublic(sessions),
       });
@@ -3925,7 +3946,12 @@ const server = createServer(async (req, res) => {
       // route and the Route B `/__daemon/groups-matrix` endpoint return the
       // same matrix shape. Public-read carve-out: oncall bindings carry
       // workingDir (repo/customer paths) so we scrub when unauthed.
-      const matrix = await buildGroupsMatrix();
+      const matrix = await groupsMatrixSnapshot.get({
+        force: authed && url.searchParams.get('refresh') === '1',
+      });
+      if (url.searchParams.get('view') === 'compact') {
+        return jsonRes(res, 200, compactGroupsMatrix(matrix));
+      }
       return jsonRes(res, 200, {
         chats: authed ? matrix.chats : redactGroupsForPublic(matrix.chats),
         bots: matrix.bots,
@@ -4817,6 +4843,7 @@ const server = createServer(async (req, res) => {
           upstreamJson.autoInvitedOpenId = autoInvited;
         }
       }
+      if (upstream.ok && upstreamJson?.ok) groupsMatrixSnapshot.invalidate();
       res.writeHead(upstream.status, { 'content-type': 'application/json' });
       res.end(upstreamJson ? JSON.stringify(upstreamJson) : upstreamText);
       return;
@@ -4900,6 +4927,7 @@ const server = createServer(async (req, res) => {
         if (!groupUpstream.ok || !groupResp?.ok || typeof groupResp.chatId !== 'string') {
           return jsonRes(res, 502, { ok: false, error: groupResp?.error ?? `group_create_http_${groupUpstream.status}` });
         }
+        groupsMatrixSnapshot.invalidate();
       } catch {
         return jsonRes(res, 502, { ok: false, error: 'group_create_proxy_failed' });
       }

--- a/src/dashboard/daemon-internal-api.ts
+++ b/src/dashboard/daemon-internal-api.ts
@@ -36,6 +36,7 @@ import {
   type GroupsActionDeps,
   type HandlerResult,
 } from './groups-action-helpers.js';
+import { roleWriteShouldInvalidate } from './groups-matrix-snapshot.js';
 import {
   applySettingsWrite,
   type ResolvedDashboardSettingsView,
@@ -458,7 +459,10 @@ const ROUTES: RouteDef[] = [
           body: ctx.bodyRaw.length > 0 ? ctx.bodyRaw : '{}',
         },
       );
-      return { status: upstream.status, body: await readUpstream(upstream) };
+      const body = await readUpstream(upstream);
+      // 写角色翻转 hasRole → 失效群矩阵快照（对齐同文件的 oncall bind/unbind）。
+      if (roleWriteShouldInvalidate(upstream.ok, body)) deps.groupsActionDeps.invalidateGroups?.();
+      return { status: upstream.status, body };
     },
   },
   {
@@ -472,7 +476,10 @@ const ROUTES: RouteDef[] = [
         `/api/roles/${encodeURIComponent(chatId)}`,
         { method: 'DELETE' },
       );
-      return { status: upstream.status, body: await readUpstream(upstream) };
+      const body = await readUpstream(upstream);
+      // 删角色把 hasRole 翻回 false → 同样失效快照。
+      if (roleWriteShouldInvalidate(upstream.ok, body)) deps.groupsActionDeps.invalidateGroups?.();
+      return { status: upstream.status, body };
     },
   },
 

--- a/src/dashboard/groups-action-helpers.ts
+++ b/src/dashboard/groups-action-helpers.ts
@@ -32,6 +32,8 @@ export interface GroupsActionDeps {
   closeSessionsMatching: (predicate: (s: SessionLikeForClose) => boolean) => Promise<unknown[]>;
   /** Override for tests; defaults to global fetch in production. */
   fetch?: typeof fetch;
+  /** Drop the central read snapshot after a successful membership/config mutation. */
+  invalidateGroups?: () => void;
 }
 
 export interface HandlerResult {
@@ -83,6 +85,7 @@ export async function addBotsToGroup(
     { method: 'POST', headers: { 'content-type': 'application/json' }, body: bodyRaw },
   );
   const { text, json } = await parseUpstream(upstream);
+  if (upstream.ok && json?.ok !== false) deps.invalidateGroups?.();
   return { status: upstream.status, body: json ?? text };
 }
 
@@ -111,6 +114,7 @@ export async function disbandGroup(
 
   let closedSessions: unknown[] = [];
   if (json?.ok) {
+    deps.invalidateGroups?.();
     closedSessions = await deps.closeSessionsMatching(s => s.chatId === chatId);
   }
   return { status: upstream.status, body: { ...(json ?? {}), closedSessions } };
@@ -165,6 +169,7 @@ export async function leaveGroup(
       closedSessions,
     };
   }));
+  if (result.some(item => item.ok)) deps.invalidateGroups?.();
   return ok({ result });
 }
 
@@ -184,6 +189,7 @@ export async function bindOncall(
     { method: 'PUT', headers: { 'content-type': 'application/json' }, body: bodyRaw || '{}' },
   );
   const { text, json } = await parseUpstream(upstream);
+  if (upstream.ok && json?.ok !== false) deps.invalidateGroups?.();
   return { status: upstream.status, body: json ?? text };
 }
 
@@ -200,5 +206,6 @@ export async function unbindOncall(
     appId, `/api/oncall/${encodeURIComponent(chatId)}`, { method: 'DELETE' },
   );
   const { text, json } = await parseUpstream(upstream);
+  if (upstream.ok && json?.ok !== false) deps.invalidateGroups?.();
   return { status: upstream.status, body: json ?? text };
 }

--- a/src/dashboard/groups-matrix-snapshot.ts
+++ b/src/dashboard/groups-matrix-snapshot.ts
@@ -44,6 +44,33 @@ function optionalTrimmedString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+/**
+ * Decide whether a role write (PUT/DELETE `/api/roles/:chatId`, or
+ * `POST /api/role-profiles/:id/apply`) actually mutated the `hasRole` matrix
+ * and should therefore invalidate the groups snapshot.
+ *
+ * `hasRole` (per bot × chat) feeds the roles-page「已配置/未配置」badge and the
+ * groups card, so a stale snapshot leaves the badge wrong for up to the 30s TTL
+ * — and the refresh button can't fix it (it hits `/api/groups` without
+ * `refresh=1`). We invalidate on every successful write, mirroring the oncall
+ * bind/unbind path, with one exception: responses that explicitly report
+ * `changed: false` (the `apply` route's `preview` mode, and no-op/refused
+ * applies) did NOT touch any role file, so invalidating there would just punch
+ * through the cache on the common preview click and undo the fan-out savings
+ * this snapshot exists to provide.
+ */
+export function roleWriteShouldInvalidate(upstreamOk: boolean, body: unknown): boolean {
+  if (!upstreamOk) return false;
+  if (body && typeof body === "object" && !Array.isArray(body)) {
+    const rec = body as Record<string, unknown>;
+    if (rec.ok === false) return false;
+    // `apply` reports changed:false for preview / already-applied / missing;
+    // PUT/DELETE omit the field entirely (undefined !== false) → still invalidate.
+    if (rec.changed === false) return false;
+  }
+  return true;
+}
+
 export function compactGroupsMatrix(matrix: GroupsMatrix): CompactGroupsSnapshot {
   return {
     chats: matrix.chats.flatMap((chat) => {

--- a/src/dashboard/groups-matrix-snapshot.ts
+++ b/src/dashboard/groups-matrix-snapshot.ts
@@ -52,24 +52,30 @@ function optionalTrimmedString(value: unknown): string | undefined {
  * `hasRole` (per bot × chat) feeds the roles-page「已配置/未配置」badge and the
  * groups card, so a stale snapshot leaves the badge wrong for up to the 30s TTL
  * — and the refresh button can't fix it (it hits `/api/groups` without
- * `refresh=1`). We invalidate on every successful write, mirroring the oncall
- * bind/unbind path, with one exception: responses that explicitly report
- * `changed: false` (the `apply` route's `preview` mode, and no-op/refused
- * applies) did NOT touch any role file, so invalidating there would just punch
- * through the cache on the common preview click and undo the fan-out savings
- * this snapshot exists to provide.
+ * `refresh=1`). We invalidate on every successful write EXCEPT when the daemon
+ * reports `changed: false`, which means the role FILE was not touched:
+ *   - `apply` preview mode, and no-op / refused applies;
+ *   - an injectMode-only PUT (writes just the `.meta.json` sidecar — `hasRole`
+ *     is unchanged, so the common inject-mode toggle must not bust the cache);
+ *   - a DELETE that removed nothing (`existed:false`).
+ * Invalidating in those cases would punch through the 30s snapshot and undo the
+ * fan-out savings this cache exists to provide. Responses that omit `changed`
+ * entirely (e.g. a proxied text body we can't parse) still invalidate — a
+ * successful write we can't introspect should refresh rather than stay stale.
  */
 export function roleWriteShouldInvalidate(upstreamOk: boolean, body: unknown): boolean {
   if (!upstreamOk) return false;
   if (body && typeof body === "object" && !Array.isArray(body)) {
     const rec = body as Record<string, unknown>;
     if (rec.ok === false) return false;
-    // `apply` reports changed:false for preview / already-applied / missing;
-    // PUT/DELETE omit the field entirely (undefined !== false) → still invalidate.
+    // changed:false = daemon confirmed the role file was untouched (preview /
+    // injectMode-only / delete-not-found). Absent field (undefined !== false)
+    // → still invalidate, keeping the fail-safe "refresh when unsure" default.
     if (rec.changed === false) return false;
   }
   return true;
 }
+
 
 export function compactGroupsMatrix(matrix: GroupsMatrix): CompactGroupsSnapshot {
   return {

--- a/src/dashboard/groups-matrix-snapshot.ts
+++ b/src/dashboard/groups-matrix-snapshot.ts
@@ -1,0 +1,141 @@
+export interface GroupMatrixChat {
+  chatId: string;
+  name?: string;
+  avatar?: string;
+  [key: string]: unknown;
+}
+
+export interface GroupsMatrix {
+  chats: GroupMatrixChat[];
+  bots: unknown[];
+}
+
+export interface GroupPresentation {
+  chatId: string;
+  name?: string;
+  avatar?: string;
+}
+
+export interface CompactGroupsSnapshot {
+  chats: GroupPresentation[];
+}
+
+interface CachedMatrix {
+  matrix: GroupsMatrix;
+  presentationByChatId: ReadonlyMap<string, GroupPresentation>;
+  validUntil: number;
+}
+
+export interface GroupsMatrixSnapshotOptions {
+  ttlMs?: number;
+  retryMs?: number;
+  now?: () => number;
+  onRefreshError?: (error: unknown) => void;
+}
+
+export interface GroupsMatrixSnapshot {
+  get: (options?: { force?: boolean }) => Promise<GroupsMatrix>;
+  warm: () => void;
+  invalidate: () => void;
+  peekPresentation: () => ReadonlyMap<string, GroupPresentation>;
+}
+
+function optionalTrimmedString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function compactGroupsMatrix(matrix: GroupsMatrix): CompactGroupsSnapshot {
+  return {
+    chats: matrix.chats.flatMap((chat) => {
+      const chatId = optionalTrimmedString(chat.chatId);
+      if (!chatId) return [];
+      return [
+        {
+          chatId,
+          ...(optionalTrimmedString(chat.name) ? { name: optionalTrimmedString(chat.name) } : {}),
+          ...(optionalTrimmedString(chat.avatar)
+            ? { avatar: optionalTrimmedString(chat.avatar) }
+            : {}),
+        },
+      ];
+    }),
+  };
+}
+
+function presentationMap(matrix: GroupsMatrix): ReadonlyMap<string, GroupPresentation> {
+  return new Map(compactGroupsMatrix(matrix).chats.map((chat) => [chat.chatId, chat]));
+}
+
+export function enrichSessionsWithGroupNames<T extends Record<string, unknown>>(
+  sessions: readonly T[],
+  presentationByChatId: ReadonlyMap<string, GroupPresentation>,
+): T[] {
+  if (presentationByChatId.size === 0) return [...sessions];
+  return sessions.map((session) => {
+    if (session.chatType !== "group" || optionalTrimmedString(session.chatDisplayName))
+      return session;
+    const chatId = optionalTrimmedString(session.chatId);
+    const name = chatId ? presentationByChatId.get(chatId)?.name : undefined;
+    return name ? { ...session, chatDisplayName: name } : session;
+  });
+}
+
+export function createGroupsMatrixSnapshot(
+  build: () => Promise<GroupsMatrix>,
+  options: GroupsMatrixSnapshotOptions = {},
+): GroupsMatrixSnapshot {
+  const ttlMs = options.ttlMs ?? 30_000;
+  const retryMs = options.retryMs ?? 5_000;
+  const now = options.now ?? Date.now;
+  let cached: CachedMatrix | null = null;
+  let inFlight: Promise<GroupsMatrix> | null = null;
+  let generation = 0;
+  let inFlightGeneration = 0;
+
+  const get = async (getOptions: { force?: boolean } = {}): Promise<GroupsMatrix> => {
+    if (!getOptions.force && cached && cached.validUntil > now()) return cached.matrix;
+    if (inFlight) {
+      if (inFlightGeneration === generation) return inFlight;
+      await inFlight;
+      return get(getOptions);
+    }
+
+    const startedGeneration = generation;
+    inFlightGeneration = startedGeneration;
+    inFlight = build()
+      .then((matrix) => {
+        cached = {
+          matrix,
+          presentationByChatId: presentationMap(matrix),
+          validUntil: startedGeneration === generation ? now() + ttlMs : 0,
+        };
+        return matrix;
+      })
+      .catch((error: unknown) => {
+        options.onRefreshError?.(error);
+        if (!cached) throw error;
+        cached.validUntil = now() + retryMs;
+        return cached.matrix;
+      })
+      .finally(() => {
+        inFlight = null;
+      });
+    return inFlight;
+  };
+
+  return {
+    get,
+    warm() {
+      void get().catch(() => {
+        // Cold-cache enrichment is best-effort; the authoritative session list remains available.
+      });
+    },
+    invalidate() {
+      generation += 1;
+      if (cached) cached.validUntil = 0;
+    },
+    peekPresentation() {
+      return cached?.presentationByChatId ?? new Map();
+    },
+  };
+}

--- a/src/dashboard/web/groups-api.ts
+++ b/src/dashboard/web/groups-api.ts
@@ -63,7 +63,7 @@ export async function fetchGroupsSnapshot(options: FetchGroupsSnapshotOptions = 
   const seq = ++requestSeq;
   latestRequestSeq = seq;
   const request = (async () => {
-    const r = await fetch('/api/groups');
+    const r = await fetch(options.force ? '/api/groups?refresh=1' : '/api/groups');
     const body = await r.json().catch(() => ({}));
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     const snapshot = normalizeGroupsSnapshot(body);

--- a/test/daemon-internal-api.test.ts
+++ b/test/daemon-internal-api.test.ts
@@ -35,6 +35,7 @@ function makeDeps(over: Partial<DaemonInternalApiDeps> = {}): DaemonInternalApiD
     proxyToDaemon: vi.fn(async () => makeUpstream(200, { ok: true })),
     closeSessionsMatching: vi.fn(async () => []),
     fetch: vi.fn(async () => makeUpstream(200, { inChat: true })),
+    invalidateGroups: vi.fn(),
   };
   const settingsApplierDeps = {
     readGlobalConfig: vi.fn(() => ({})),
@@ -538,6 +539,8 @@ describe('dispatch: groups write', () => {
       '/api/roles/oc_x',
       expect.objectContaining({ method: 'GET' }),
     );
+    // Reads never mutate hasRole → must not bust the 30s snapshot.
+    expect(deps.groupsActionDeps.invalidateGroups).not.toHaveBeenCalled();
   });
 
   it('PUT /groups/:id/roles/:appId proxies role body to internal /api/roles/:chatId PUT', async () => {
@@ -552,6 +555,20 @@ describe('dispatch: groups write', () => {
       '/api/roles/oc_x',
       expect.objectContaining({ method: 'PUT', body }),
     );
+    // Writing a role flips hasRole → snapshot must be invalidated so the
+    // roles-page badge / groups card don't stay stale for up to 30s.
+    expect(deps.groupsActionDeps.invalidateGroups).toHaveBeenCalledOnce();
+  });
+
+  it('PUT /groups/:id/roles/:appId does NOT invalidate when the daemon write fails', async () => {
+    const proxySpy = vi.fn(async () => makeUpstream(500, { ok: false, error: 'disk_full' }));
+    const deps = makeDeps({ proxyToDaemon: proxySpy });
+    const api = createDaemonInternalApi(deps);
+    const r = await api.dispatchForTest(
+      'PUT', url('/__daemon/groups/oc_x/roles/cli_owner'), JSON.stringify({ content: 'x' }),
+    );
+    expect(r.status).toBe(500);
+    expect(deps.groupsActionDeps.invalidateGroups).not.toHaveBeenCalled();
   });
 
   it('DELETE /groups/:id/roles/:appId proxies to internal /api/roles/:chatId DELETE', async () => {
@@ -565,6 +582,8 @@ describe('dispatch: groups write', () => {
       '/api/roles/oc_x',
       expect.objectContaining({ method: 'DELETE' }),
     );
+    // Deleting a role flips hasRole back to false → same invalidation.
+    expect(deps.groupsActionDeps.invalidateGroups).toHaveBeenCalledOnce();
   });
 });
 

--- a/test/dashboard-groups-matrix-snapshot.test.ts
+++ b/test/dashboard-groups-matrix-snapshot.test.ts
@@ -115,26 +115,34 @@ describe("groups presentation projection", () => {
 
 describe("roleWriteShouldInvalidate", () => {
   // ── invalidate: a role file was actually written / deleted ──────────────
-  it("invalidates on a PUT/DELETE style success that omits `changed`", () => {
-    // Daemon role PUT returns {ok:true}; DELETE returns {ok:true,existed}.
-    // Neither carries `changed`, so undefined !== false → invalidate.
-    expect(roleWriteShouldInvalidate(true, { ok: true })).toBe(true);
-    expect(roleWriteShouldInvalidate(true, { ok: true, existed: true })).toBe(true);
-  });
-
-  it("invalidates when apply reports a real write (changed:true)", () => {
+  it("invalidates when the daemon reports a real role-file write (changed:true)", () => {
+    // PUT with content → {ok:true,changed:true}; DELETE that removed a file →
+    // {ok:true,existed:true,changed:true}; apply real write → {ok:true,changed:true}.
+    expect(roleWriteShouldInvalidate(true, { ok: true, changed: true })).toBe(true);
+    expect(roleWriteShouldInvalidate(true, { ok: true, existed: true, changed: true })).toBe(true);
     expect(roleWriteShouldInvalidate(true, { ok: true, changed: true, byteLength: 42 })).toBe(true);
   });
 
-  it("invalidates even when the body is not JSON (defensive default)", () => {
-    // proxied text bodies parse to a string; a successful write we can't
-    // inspect should still refresh the badge rather than leave it stale.
+  it("invalidates a success that omits `changed` (fail-safe: refresh when unsure)", () => {
+    // A proxied text body we can't introspect, or any writer that doesn't emit
+    // `changed`, should still refresh the badge rather than leave it stale.
+    expect(roleWriteShouldInvalidate(true, { ok: true })).toBe(true);
     expect(roleWriteShouldInvalidate(true, "OK")).toBe(true);
     expect(roleWriteShouldInvalidate(true, null)).toBe(true);
   });
 
   // ── do NOT invalidate: nothing changed → busting the cache would just
-  //    punch through the 30s snapshot on the common preview click ─────────
+  //    punch through the 30s snapshot on a common no-op ─────────────────────
+  it("does not invalidate an injectMode-only PUT (changed:false, hasRole untouched)", () => {
+    // saveInjectMode() sends {injectMode} with no content → daemon writes only
+    // the .meta.json sidecar and reports changed:false.
+    expect(roleWriteShouldInvalidate(true, { ok: true, changed: false })).toBe(false);
+  });
+
+  it("does not invalidate a DELETE that removed nothing (existed/changed:false)", () => {
+    expect(roleWriteShouldInvalidate(true, { ok: true, existed: false, changed: false })).toBe(false);
+  });
+
   it("does not invalidate on apply preview (ok:true but changed:false)", () => {
     expect(
       roleWriteShouldInvalidate(true, { ok: true, preview: true, changed: false, wouldOverwrite: true }),
@@ -152,6 +160,6 @@ describe("roleWriteShouldInvalidate", () => {
   it("does not invalidate when the HTTP call failed (e.g. 409 chat_role_exists / 500)", () => {
     // upstream.ok is false for 4xx/5xx — never invalidate regardless of body.
     expect(roleWriteShouldInvalidate(false, { ok: false, error: "chat_role_exists" })).toBe(false);
-    expect(roleWriteShouldInvalidate(false, { ok: true })).toBe(false);
+    expect(roleWriteShouldInvalidate(false, { ok: true, changed: true })).toBe(false);
   });
 });

--- a/test/dashboard-groups-matrix-snapshot.test.ts
+++ b/test/dashboard-groups-matrix-snapshot.test.ts
@@ -4,6 +4,7 @@ import {
   compactGroupsMatrix,
   createGroupsMatrixSnapshot,
   enrichSessionsWithGroupNames,
+  roleWriteShouldInvalidate,
   type GroupsMatrix,
 } from "../src/dashboard/groups-matrix-snapshot.js";
 
@@ -109,5 +110,48 @@ describe("groups presentation projection", () => {
       { sessionId: "g2", chatId: "oc_release", chatType: "group", chatDisplayName: "Pinned name" },
       { sessionId: "p1", chatId: "oc_dm", chatType: "p2p", chatDisplayName: "Alice" },
     ]);
+  });
+});
+
+describe("roleWriteShouldInvalidate", () => {
+  // ── invalidate: a role file was actually written / deleted ──────────────
+  it("invalidates on a PUT/DELETE style success that omits `changed`", () => {
+    // Daemon role PUT returns {ok:true}; DELETE returns {ok:true,existed}.
+    // Neither carries `changed`, so undefined !== false → invalidate.
+    expect(roleWriteShouldInvalidate(true, { ok: true })).toBe(true);
+    expect(roleWriteShouldInvalidate(true, { ok: true, existed: true })).toBe(true);
+  });
+
+  it("invalidates when apply reports a real write (changed:true)", () => {
+    expect(roleWriteShouldInvalidate(true, { ok: true, changed: true, byteLength: 42 })).toBe(true);
+  });
+
+  it("invalidates even when the body is not JSON (defensive default)", () => {
+    // proxied text bodies parse to a string; a successful write we can't
+    // inspect should still refresh the badge rather than leave it stale.
+    expect(roleWriteShouldInvalidate(true, "OK")).toBe(true);
+    expect(roleWriteShouldInvalidate(true, null)).toBe(true);
+  });
+
+  // ── do NOT invalidate: nothing changed → busting the cache would just
+  //    punch through the 30s snapshot on the common preview click ─────────
+  it("does not invalidate on apply preview (ok:true but changed:false)", () => {
+    expect(
+      roleWriteShouldInvalidate(true, { ok: true, preview: true, changed: false, wouldOverwrite: true }),
+    ).toBe(false);
+  });
+
+  it("does not invalidate when apply is a no-op / missing entry (changed:false)", () => {
+    expect(roleWriteShouldInvalidate(true, { ok: false, error: "missing_entry", changed: false })).toBe(false);
+  });
+
+  it("does not invalidate on an application-level failure (ok:false)", () => {
+    expect(roleWriteShouldInvalidate(true, { ok: false, error: "content_required" })).toBe(false);
+  });
+
+  it("does not invalidate when the HTTP call failed (e.g. 409 chat_role_exists / 500)", () => {
+    // upstream.ok is false for 4xx/5xx — never invalidate regardless of body.
+    expect(roleWriteShouldInvalidate(false, { ok: false, error: "chat_role_exists" })).toBe(false);
+    expect(roleWriteShouldInvalidate(false, { ok: true })).toBe(false);
   });
 });

--- a/test/dashboard-groups-matrix-snapshot.test.ts
+++ b/test/dashboard-groups-matrix-snapshot.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  compactGroupsMatrix,
+  createGroupsMatrixSnapshot,
+  enrichSessionsWithGroupNames,
+  type GroupsMatrix,
+} from "../src/dashboard/groups-matrix-snapshot.js";
+
+function matrix(name = "Release room"): GroupsMatrix {
+  return {
+    chats: [
+      {
+        chatId: "oc_release",
+        name,
+        avatar: "https://example.com/release.png",
+        ownerId: "ou_owner",
+        memberBots: [{ larkAppId: "cli_a", inChat: true }],
+      },
+    ],
+    bots: [{ larkAppId: "cli_a", botName: "Codex" }],
+  };
+}
+
+describe("groups matrix snapshot", () => {
+  it("coalesces concurrent builds and reuses the value within the TTL", async () => {
+    let resolveBuild!: (value: GroupsMatrix) => void;
+    const build = vi.fn(
+      () =>
+        new Promise<GroupsMatrix>((resolve) => {
+          resolveBuild = resolve;
+        }),
+    );
+    const snapshot = createGroupsMatrixSnapshot(build);
+
+    const first = snapshot.get();
+    const second = snapshot.get();
+    expect(build).toHaveBeenCalledTimes(1);
+    resolveBuild(matrix());
+    await expect(Promise.all([first, second])).resolves.toEqual([matrix(), matrix()]);
+    await snapshot.get();
+    expect(build).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes after invalidation and when force is requested", async () => {
+    const build = vi
+      .fn()
+      .mockResolvedValueOnce(matrix("First"))
+      .mockResolvedValueOnce(matrix("Second"))
+      .mockResolvedValueOnce(matrix("Third"));
+    const snapshot = createGroupsMatrixSnapshot(build);
+
+    await snapshot.get();
+    snapshot.invalidate();
+    await expect(snapshot.get()).resolves.toEqual(matrix("Second"));
+    await expect(snapshot.get({ force: true })).resolves.toEqual(matrix("Third"));
+    expect(build).toHaveBeenCalledTimes(3);
+  });
+
+  it("serves the last successful snapshot when a refresh fails", async () => {
+    const onRefreshError = vi.fn();
+    const build = vi
+      .fn()
+      .mockResolvedValueOnce(matrix())
+      .mockRejectedValueOnce(new Error("daemon unavailable"));
+    const snapshot = createGroupsMatrixSnapshot(build, { onRefreshError });
+
+    await snapshot.get();
+    snapshot.invalidate();
+    await expect(snapshot.get()).resolves.toEqual(matrix());
+    expect(onRefreshError).toHaveBeenCalledOnce();
+  });
+});
+
+describe("groups presentation projection", () => {
+  it("returns only the chat presentation allowlist", () => {
+    expect(compactGroupsMatrix(matrix())).toEqual({
+      chats: [
+        {
+          chatId: "oc_release",
+          name: "Release room",
+          avatar: "https://example.com/release.png",
+        },
+      ],
+    });
+  });
+
+  it("fills missing group names without changing p2p or existing names", () => {
+    const presentation = new Map([
+      ["oc_release", { chatId: "oc_release", name: "Release room" }],
+      ["oc_dm", { chatId: "oc_dm", name: "Wrong p2p name" }],
+    ]);
+    const sessions = enrichSessionsWithGroupNames(
+      [
+        { sessionId: "g1", chatId: "oc_release", chatType: "group" },
+        {
+          sessionId: "g2",
+          chatId: "oc_release",
+          chatType: "group",
+          chatDisplayName: "Pinned name",
+        },
+        { sessionId: "p1", chatId: "oc_dm", chatType: "p2p", chatDisplayName: "Alice" },
+      ],
+      presentation,
+    );
+
+    expect(sessions).toEqual([
+      { sessionId: "g1", chatId: "oc_release", chatType: "group", chatDisplayName: "Release room" },
+      { sessionId: "g2", chatId: "oc_release", chatType: "group", chatDisplayName: "Pinned name" },
+      { sessionId: "p1", chatId: "oc_dm", chatType: "p2p", chatDisplayName: "Alice" },
+    ]);
+  });
+});

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -2547,4 +2547,54 @@ describe('role profile IPC routes', () => {
       rmSync(dataDir, { recursive: true, force: true });
     }
   });
+
+  it('reports `changed` so the dashboard only invalidates on real hasRole mutations', async () => {
+    // The groups-matrix snapshot keys off `changed` to avoid busting its 30s
+    // cache on no-op writes. A content PUT / real DELETE flip hasRole
+    // (changed:true); an injectMode-only PUT and a delete-not-found do NOT
+    // (changed:false) — otherwise the common inject-mode toggle would punch
+    // through the cache and re-fan-out across every daemon.
+    const prevDataDir = process.env.SESSION_DATA_DIR;
+    const prevConfigDataDir = config.session.dataDir;
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-role-changed-ipc-'));
+    config.session.dataDir = dataDir;
+    setLarkAppId('cli_profile');
+    try {
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      const base = `http://127.0.0.1:${handle.port}`;
+
+      // Content PUT writes the role file → changed:true.
+      const putContent = await fetch(`${base}/api/roles/oc_changed`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ content: '# Role\nhello' }),
+      });
+      expect(putContent.status).toBe(200);
+      expect(await putContent.json()).toMatchObject({ ok: true, changed: true });
+
+      // injectMode-only PUT touches just the .meta.json sidecar → changed:false.
+      const putMode = await fetch(`${base}/api/roles/oc_changed`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ injectMode: 'once' }),
+      });
+      expect(putMode.status).toBe(200);
+      expect(await putMode.json()).toMatchObject({ ok: true, changed: false });
+
+      // DELETE that removed the existing file → changed:true.
+      const delExisting = await fetch(`${base}/api/roles/oc_changed`, { method: 'DELETE' });
+      expect(delExisting.status).toBe(200);
+      expect(await delExisting.json()).toMatchObject({ ok: true, existed: true, changed: true });
+
+      // DELETE with nothing to remove → changed:false.
+      const delMissing = await fetch(`${base}/api/roles/oc_changed`, { method: 'DELETE' });
+      expect(delMissing.status).toBe(200);
+      expect(await delMissing.json()).toMatchObject({ ok: true, existed: false, changed: false });
+    } finally {
+      if (prevDataDir === undefined) delete process.env.SESSION_DATA_DIR;
+      else process.env.SESSION_DATA_DIR = prevDataDir;
+      config.session.dataDir = prevConfigDataDir;
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/groups-action-helpers.test.ts
+++ b/test/groups-action-helpers.test.ts
@@ -32,6 +32,7 @@ function makeDeps(over: Partial<GroupsActionDeps> = {}): GroupsActionDeps {
     proxyToDaemon: vi.fn(async () => makeRes(200, { ok: true })),
     closeSessionsMatching: vi.fn(async () => []),
     fetch: vi.fn(async () => makeRes(200, { inChat: true })),
+    invalidateGroups: vi.fn(),
     ...over,
   };
 }
@@ -52,6 +53,7 @@ describe('addBotsToGroup', () => {
     expect(r.body).toEqual({ ok: true, added: ['cli_x'] });
     // membership probe + add-bots
     expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(deps.invalidateGroups).toHaveBeenCalledOnce();
   });
 
   it('returns no_proxy_bot when no online daemon is in chat', async () => {
@@ -63,6 +65,7 @@ describe('addBotsToGroup', () => {
     const r = await addBotsToGroup('oc_demo', '{}', deps);
     expect(r.status).toBe(200);
     expect(r.body).toEqual({ ok: false, error: 'no_proxy_bot' });
+    expect(deps.invalidateGroups).not.toHaveBeenCalled();
   });
 
   it('returns bad_json when body is not valid JSON', async () => {
@@ -101,6 +104,7 @@ describe('disbandGroup', () => {
     expect(r.status).toBe(200);
     expect(r.body).toEqual({ ok: true, closedSessions: closedReturn });
     expect(deps.closeSessionsMatching).toHaveBeenCalledOnce();
+    expect(deps.invalidateGroups).toHaveBeenCalledOnce();
   });
 
   it('returns larkAppId_required when body lacks the field', async () => {
@@ -119,6 +123,7 @@ describe('disbandGroup', () => {
     expect(r.status).toBe(500);
     expect(r.body).toEqual({ ok: false, error: 'lark_denied', closedSessions: [] });
     expect(deps.closeSessionsMatching).not.toHaveBeenCalled();
+    expect(deps.invalidateGroups).not.toHaveBeenCalled();
   });
 });
 
@@ -174,6 +179,7 @@ describe('leaveGroup', () => {
 
     // Cascade close called only for cli_a (the only successful leave).
     expect(closedSpy).toHaveBeenCalledOnce();
+    expect(deps.invalidateGroups).toHaveBeenCalledOnce();
   });
 
   it('returns larkAppIds_required when body lacks the array or it is empty', async () => {
@@ -230,6 +236,7 @@ describe('bindOncall', () => {
     expect(call[1]).toBe('/api/oncall/oc_demo');
     expect((call[2] as RequestInit).method).toBe('PUT');
     expect((call[2] as RequestInit).body).toBe('{"workingDir":"/repo/x"}');
+    expect(deps.invalidateGroups).toHaveBeenCalledOnce();
   });
 
   it('uses "{}" body when raw body is empty', async () => {
@@ -251,5 +258,6 @@ describe('unbindOncall', () => {
     expect(call[0]).toBe('cli_owner');
     expect(call[1]).toBe('/api/oncall/oc_demo');
     expect((call[2] as RequestInit).method).toBe('DELETE');
+    expect(deps.invalidateGroups).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## 背景

Dashboard 的群元数据读取目前每次都会 fan-out 到全部在线 daemon；每个 daemon 再翻页读取飞书群列表，中央 Dashboard 随后为每个群补齐全部 Bot 的 `memberBots`。这使群列表请求同时承担大量飞书请求、矩阵构造和网络传输开销。

在 devbox 的实际数据上：

- 964 个群、47 个在线 Bot
- 完整 `GET /api/groups` 约 6.51 MB、约 3.9 秒
- 一次刷新至少需要 64 次飞书分页请求
- 完整矩阵包含 45,308 条 `memberBots`，真实在群关系为 2,634 条
- 仅 `chatId/name/avatar` 的展示投影约 264 KB

这也会让只需要群名/头像的客户端被迫下载完整管理矩阵。

## 改动

- 为中央群矩阵增加 30 秒内存快照：
  - 并发刷新 single-flight 合并
  - TTL 内复用成功结果
  - 刷新失败时短暂沿用最近成功快照
  - 群创建、加 Bot、退群、解散、oncall 变更、群主转移及 Bot roster 变化后主动失效
- `GET /api/groups?view=compact` 仅返回群展示字段 `chatId/name/avatar`
- `GET /api/groups?refresh=1` 支持已认证 Dashboard 手动强制刷新；公开只读请求不能绕过缓存
- `GET /api/sessions` 从现有快照补全群聊 `chatDisplayName`
  - 冷缓存仅后台预热，不阻塞会话热路径
  - 不修改持久化 Session，不批量产生 SSE 更新事件
  - 不覆盖 p2p 名称或已有群名
- 默认 `GET /api/groups` 响应结构保持不变，Dashboard 群管理页和内部 `groups-matrix/overview-snapshot` 继续使用完整矩阵
- Dashboard 前端的“强制刷新”会显式请求服务端刷新，而不只是绕过浏览器侧 3 秒缓存

## 影响面

- 改动位于中央 Dashboard 聚合/展示层，不涉及各 CLI adapter、PTY/Tmux backend 或 Session 持久化格式
- 所有 CLI、群会话和历史会话共用相同展示投影
- compact 接口只暴露原公开群接口已有的名称和头像字段
- 默认完整接口保持兼容；旧客户端仍可继续调用原接口，新客户端可选择轻量视图

## 验证

- `pnpm build`：通过（含 TypeScript、Dashboard bundle、dist audit）
- `pnpm vitest run test/dashboard-groups-matrix-snapshot.test.ts test/groups-action-helpers.test.ts test/daemon-internal-api.test.ts test/dashboard-public-redact.test.ts`：4 files / 144 tests 通过
- 配套 desktop 客户端：
  - node / cli / web 三套 TypeScript 配置通过
  - Dashboard bridge 相关 3 files / 16 tests 通过
- 尝试执行 `pnpm test` 全量单测；当前 Codex 运行环境没有系统级 `node` / `npm`，导致 `codex-app-threads` 的隔离子进程报 `env: node: No such file or directory`，`plugin-init` 的 npm fixture 报 `spawnSync npm ENOENT`。本 PR 相关测试及正式构建均已通过。