### PR TITLE
fix(codex): 回写结构化回合失败状态

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -749,6 +749,7 @@ export const messages: Record<string, string> = {
   'worker.start_failed': '⚠️ The {cliName} session failed to start: {reason}\nCheck the Agent/backend settings in Dashboard and the installation environment on the daemon host, then resend your message to retry.',
   'worker.start_exited_early': 'The worker exited before becoming ready (exit code: {code}); see the Botmux logs for details.',
   'worker.empty_final_completed': '⚠️ {cliName} reported this turn as completed, but botmux captured no final text from the terminal transcript and saw no tracked reply for this turn. If you already replied via a redirected send (--top-level / --into / --override-chat), you can ignore this. Otherwise open the web terminal to inspect the last output, or resend a message to continue the session.',
+  'worker.empty_final_failed': '⚠️ The {cliName} turn failed without producing a result that could be sent. Open the web terminal to inspect the last error, or resend the message to continue the session.',
 
   // ─── CLI setup wizard / pm2 lifecycle (no per-bot context) ───────────────
   'setup.lark_create_app': 'First create a Lark app at: https://open.feishu.cn/app',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -752,6 +752,7 @@ export const messages: Record<string, string> = {
   'worker.start_failed': '⚠️ {cliName} 会话启动失败：{reason}\n请检查 Dashboard 的 Agent / 后端配置和 daemon 所在机器的安装环境，修复后重发消息即可重试。',
   'worker.start_exited_early': 'worker 在就绪前退出（exit code: {code}）；详细错误可查看 Botmux 日志。',
   'worker.empty_final_completed': '⚠️ {cliName} 已报告本轮处理完成，但 botmux 没有从终端记录里捕获到最终文本，也没有追踪到本轮的回复。若你已经通过改道发送（--top-level / --into / --override-chat）回复过，可忽略本提示；否则请打开 Web 终端查看最后输出，或直接重发消息让会话继续。',
+  'worker.empty_final_failed': '⚠️ {cliName} 本轮执行失败，且没有生成可发送的结论。请打开 Web 终端查看最后错误，或直接重发消息让会话继续。',
 
   // ─── CLI setup wizard / pm2 lifecycle (no per-bot context) ───────────────
   'setup.lark_create_app': '请先在飞书开放平台创建应用: https://open.feishu.cn/app',

--- a/src/services/bridge-fallback-gate.ts
+++ b/src/services/bridge-fallback-gate.ts
@@ -200,3 +200,17 @@ export function shouldEmitEmptyCompletedBridgeFallback(
   if ((turn.finalText ?? '').trim().length > 0) return false;
   return !shouldSuppressBridgeEmit(turn, nextBoundaryMs, markers, adoptMode);
 }
+
+/** 结构化失败回合没有显式回复时补发可见结果；限流由调用方改用专用卡片。 */
+export function shouldEmitFailedBridgeFallback(
+  turn: BridgeGateInput,
+  nextBoundaryMs: number | undefined,
+  markers: readonly BridgeSendMarker[],
+  adoptMode: boolean,
+): boolean {
+  if (adoptMode) return false;
+  if (turn.isLocal) return false;
+  if (turn.terminalStatus !== 'failed') return false;
+  if ((turn.finalText ?? '').trim().length > 0) return false;
+  return !shouldSuppressBridgeEmit(turn, nextBoundaryMs, markers, adoptMode);
+}

--- a/src/services/codex-transcript.ts
+++ b/src/services/codex-transcript.ts
@@ -4,14 +4,18 @@
  * Codex stores each session's full transcript at
  *   ~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-<ts>-<cliSessionId>.jsonl
  * and creates the file lazily on the first user submit. Inside, the bridge
- * fallback only cares about two `response_item.payload.type === 'message'`
+ * fallback primarily cares about two `response_item.payload.type === 'message'`
  * shapes:
  *
  *   - role=user             → the user's prompt text (input_text content)
  *   - role=assistant +
  *     phase=final_answer    → the model's final reply (output_text content)
  *
- * Why these and not `event_msg`:
+ * 同时读取失败的 `event_msg.payload.type === 'task_complete'`。Codex 失败
+ * 时可能没有最终回复；若忽略该终态，Lark 回合会一直卡在队列里，限流或错误
+ * 状态也无法同步到群内。
+ *
+ * 其余 `event_msg` 仍忽略：
  *   - `response_item` is the canonical transcript record; `event_msg` is a
  *     UI-event stream that can carry the same final text via two channels
  *     (`agent_message phase=final_answer` AND `task_complete.last_agent_message`).
@@ -123,6 +127,28 @@ export interface CodexBridgeEvent {
    *  transcript user timestamp. Used by bridges whose committed user
    *  timestamp can lag behind in-turn delivery markers. */
   preserveMarkTimeMs?: boolean;
+}
+
+export const CODEX_RATE_LIMIT_ERROR_CODE = 'codex_rate_limited';
+export const CODEX_TASK_FAILED_ERROR_CODE = 'codex_task_failed';
+
+function codexTaskFailureCode(error: unknown): string {
+  if (!error || typeof error !== 'object') return CODEX_TASK_FAILED_ERROR_CODE;
+  const value = error as any;
+  const status = value.codex_error_info
+    ?.response_too_many_failed_attempts
+    ?.http_status_code;
+  const message = typeof value.message === 'string' ? value.message : '';
+  if (status === 429 || /\b429\b.*too many requests|too many requests.*\b429\b/i.test(message)) {
+    return CODEX_RATE_LIMIT_ERROR_CODE;
+  }
+  return CODEX_TASK_FAILED_ERROR_CODE;
+}
+
+export function isCodexRateLimitEvent(event: CodexBridgeEvent): boolean {
+  return event.kind === 'assistant_final'
+    && event.terminalStatus === 'failed'
+    && event.terminalErrorCode === CODEX_RATE_LIMIT_ERROR_CODE;
 }
 
 /** Extract the last completed user/assistant turn from a Codex / CoCo bridge
@@ -324,11 +350,22 @@ export function drainCodexRollout(path: string, fromOffset: number): CodexDrainR
     cursor += lineByteLen;
     let obj: any;
     try { obj = JSON.parse(line); } catch { continue; }
-    if (obj?.type !== 'response_item') continue;
     const p = obj.payload;
-    if (!p || typeof p !== 'object' || p.type !== 'message') continue;
+    if (!p || typeof p !== 'object') continue;
     const ts = typeof obj.timestamp === 'string' ? Date.parse(obj.timestamp) : NaN;
     const timestampMs = Number.isFinite(ts) ? ts : Date.now();
+    if (obj?.type === 'event_msg' && p.type === 'task_complete' && p.error) {
+      events.push({
+        uuid: `${path}:${lineStart}`,
+        timestampMs,
+        kind: 'assistant_final',
+        text: '',
+        terminalStatus: 'failed',
+        terminalErrorCode: codexTaskFailureCode(p.error),
+      });
+      continue;
+    }
+    if (obj?.type !== 'response_item' || p.type !== 'message') continue;
     if (p.role === 'user') {
       const text = joinTextBlocks(p.content, 'input_text');
       if (!text) continue;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -37,7 +37,7 @@ import { killPersistentBackendTarget, killPersistentSession, probePersistentBack
 import { readProcessStartIdentity } from './core/session-marker.js';
 import { drainTranscript, joinAssistantText, trailingAssistantText, findJsonlContainingFingerprint, findJsonlsContainingExactContent, findLatestJsonl, extractLastAssistantTurn, stringifyUserContent, extractTurnStartText, splitTranscriptEventsByCutoff, isTranscriptRateLimitEvent, apiErrorMessageText, type TranscriptEvent } from './services/claude-transcript.js';
 import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint } from './services/bridge-turn-queue.js';
-import { shouldEmitEmptyCompletedBridgeFallback, shouldSuppressBridgeEmit, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
+import { shouldEmitEmptyCompletedBridgeFallback, shouldEmitFailedBridgeFallback, shouldSuppressBridgeEmit, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
 import {
   decideHardTimeoutAction,
   decideSettleMarkReady,
@@ -119,7 +119,7 @@ import {
   setCodexAppThreadName,
 } from './services/codex-app-threads.js';
 import { buildBotmuxLarkNativeSessionTitle } from './core/session-title.js';
-import { drainCodexRollout, findCodexRolloutBySessionId, findCodexRolloutByPid, splitCodexEventsByCutoff, extractLastCodexTurn, codexSessionIdFromRolloutPath, type CodexBridgeEvent } from './services/codex-transcript.js';
+import { CODEX_RATE_LIMIT_ERROR_CODE, drainCodexRollout, findCodexRolloutBySessionId, findCodexRolloutByPid, splitCodexEventsByCutoff, extractLastCodexTurn, codexSessionIdFromRolloutPath, isCodexRateLimitEvent, type CodexBridgeEvent } from './services/codex-transcript.js';
 import { drainTraexRollout, findTraexRolloutBySessionId, findTraexRolloutByPid } from './services/traex-transcript.js';
 import { parseTraexUserInputQuestions } from './services/traex-user-input.js';
 import { cocoEventsPathForSession, drainCocoEvents, findCocoSessionByPid } from './services/coco-transcript.js';
@@ -2030,10 +2030,9 @@ const bridgeSecondaryPaths = new Map<string, number>(); // path → offset
 let bridgeOffset = 0;
 let bridgePendingTail = '';
 const bridgeQueue = new BridgeTurnQueue();
-/** uuids of Claude transcript rate-limit records we've already turned into a
- *  `limited` emit. drainTranscript re-reads from offset 0 on truncation /
- *  rotation and emitReadyTurns re-drains from 0, so the same rate_limit record
- *  can resurface; keying on the record's stable uuid makes the emit idempotent. */
+/** uuids of structured transcript rate-limit records already turned into a
+ *  `limited` emit. Transcript readers may re-read from offset 0 on truncation
+ *  or rotation, so the stable record uuid keeps the emit idempotent. */
 const emittedRateLimitUuids = new Set<string>();
 let bridgeWatcher: FSWatcher | null = null;
 let bridgeFallbackTimer: NodeJS.Timeout | null = null;
@@ -2136,6 +2135,10 @@ function formatHeadlessLocalTurnContent(assistantText: string): string | null {
 
 function emptyCompletedBridgeFallbackContent(): string {
   return t('worker.empty_final_completed', { cliName: cliName() });
+}
+
+function failedBridgeFallbackContent(): string {
+  return t('worker.empty_final_failed', { cliName: cliName() });
 }
 
 // ─── Bridge fallback marker (non-adopt) ────────────────────────────────────
@@ -3820,6 +3823,7 @@ function codexBridgeIngest(opts: { signalIdle?: boolean } = {}): void {
   codexBridgePendingTail = result.pendingTail;
   if (result.events.length > 0) lastStructuredBridgeActivityAtMs = Date.now();
   codexBridgeQueue.ingest(result.events);
+  maybeEmitCodexStructuredRateLimit(result.events);
   // Transcript-driven idle: an `assistant_final` event is the CLI declaring
   // end-of-turn, far more reliable than the screen-pattern heuristic
   // (CoCo's status bar varies by --yolo flag, version, theme; codex has
@@ -3828,6 +3832,26 @@ function codexBridgeIngest(opts: { signalIdle?: boolean } = {}): void {
   // converge. Idempotent — IdleDetector.fireIdle no-ops while already idle.
   if (opts.signalIdle !== false && result.events.some(e => e.kind === 'assistant_final')) {
     idleDetector?.fireIdle();
+  }
+}
+
+/** 将 Codex 的结构化 429 终态同步为限流卡片，避免回合静默结束。 */
+function maybeEmitCodexStructuredRateLimit(events: readonly CodexBridgeEvent[]): void {
+  for (const ev of events) {
+    if (!isCodexRateLimitEvent(ev) || emittedRateLimitUuids.has(ev.uuid)) continue;
+    emittedRateLimitUuids.add(ev.uuid);
+    const usageLimit = structuredRateLimitState('429 Too Many Requests');
+    usageLimitTracker.noteStructuredLimit();
+    send({
+      type: 'screen_update',
+      content: currentUsageLimitSnapshot(),
+      status: 'limited',
+      usageLimit,
+      turnId: currentBotmuxTurnId,
+      dispatchAttempt: currentBotmuxDispatchAttempt,
+    });
+    log(`Structured rate-limit detected in Codex transcript (uuid=${ev.uuid.substring(0, 8)}, retryLabel=${usageLimit.retryLabel}) → emitted limited state.`);
+    return;
   }
 }
 
@@ -3912,6 +3936,9 @@ function emitReadyCodexTurns(): void {
       ? turn.finalText
       : shouldEmitEmptyCompletedBridgeFallback(gateInput, nextBoundaryMs, markers, adoptMode)
         ? emptyCompletedBridgeFallbackContent()
+        : turn.terminalErrorCode !== CODEX_RATE_LIMIT_ERROR_CODE
+          && shouldEmitFailedBridgeFallback(gateInput, nextBoundaryMs, markers, adoptMode)
+          ? failedBridgeFallbackContent()
         : '';
     if (!content) continue;
     if (shouldSuppressBridgeEmit(gateInput, nextBoundaryMs, markers, adoptMode)) {

--- a/test/bridge-fallback-gate.test.ts
+++ b/test/bridge-fallback-gate.test.ts
@@ -4,6 +4,7 @@ import {
   buildBridgeSendMarkerContent,
   buildBridgeSendPreviewText,
   shouldEmitEmptyCompletedBridgeFallback,
+  shouldEmitFailedBridgeFallback,
   shouldSuppressBridgeEmit,
   type BridgeSendMarker,
 } from '../src/services/bridge-fallback-gate.js';
@@ -313,6 +314,44 @@ describe('shouldEmitEmptyCompletedBridgeFallback', () => {
       undefined,
       [],
       false,
+    )).toBe(false);
+  });
+});
+
+describe('shouldEmitFailedBridgeFallback', () => {
+  it('emits a visible diagnostic for an empty failed turn without a send marker', () => {
+    expect(shouldEmitFailedBridgeFallback(
+      { ...turn(100), finalText: '', terminalStatus: 'failed' },
+      undefined,
+      [],
+      false,
+    )).toBe(true);
+  });
+
+  it('does not duplicate an explicit reply or affect completed, local, or adopt turns', () => {
+    expect(shouldEmitFailedBridgeFallback(
+      { ...turn(100), finalText: '', terminalStatus: 'failed' },
+      200,
+      [markerForContent(150, 'failure already reported')],
+      false,
+    )).toBe(false);
+    expect(shouldEmitFailedBridgeFallback(
+      { ...turn(100), finalText: '', terminalStatus: 'completed' },
+      undefined,
+      [],
+      false,
+    )).toBe(false);
+    expect(shouldEmitFailedBridgeFallback(
+      { ...turn(100, true), finalText: '', terminalStatus: 'failed' },
+      undefined,
+      [],
+      false,
+    )).toBe(false);
+    expect(shouldEmitFailedBridgeFallback(
+      { ...turn(100), finalText: '', terminalStatus: 'failed' },
+      undefined,
+      [],
+      true,
     )).toBe(false);
   });
 });

--- a/test/codex-transcript.test.ts
+++ b/test/codex-transcript.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, writeFileSync, appendFileSync, rmSync, statSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { drainCodexRollout, codexSessionIdFromRolloutPath, findCodexRolloutBySessionId, findCodexSessionIdByBotmuxSessionId, splitCodexEventsByCutoff, extractLastCodexTurn, type CodexBridgeEvent } from '../src/services/codex-transcript.js';
+import { CODEX_RATE_LIMIT_ERROR_CODE, CODEX_TASK_FAILED_ERROR_CODE, drainCodexRollout, codexSessionIdFromRolloutPath, findCodexRolloutBySessionId, findCodexSessionIdByBotmuxSessionId, isCodexRateLimitEvent, splitCodexEventsByCutoff, extractLastCodexTurn, type CodexBridgeEvent } from '../src/services/codex-transcript.js';
 
 let dir: string;
 let path: string;
@@ -267,7 +267,7 @@ describe('drainCodexRollout', () => {
     expect(r.events[0].text).toBe('done');
   });
 
-  it('skips reasoning / function_call / function_call_output / event_msg', () => {
+  it('skips reasoning / function_call / function_call_output / successful event_msg', () => {
     writeFileSync(path,
       ev({ type: 'response_item', payload: { type: 'reasoning' } }) +
       ev({ type: 'response_item', payload: { type: 'function_call', name: 'shell' } }) +
@@ -278,6 +278,55 @@ describe('drainCodexRollout', () => {
     expect(r.events).toHaveLength(1);
     expect(r.events[0].kind).toBe('user');
     expect(r.events[0].text).toBe('actual prompt');
+  });
+
+  it('turns a structured 429 task failure into an empty failed terminal', () => {
+    writeFileSync(path,
+      ev(userResponseItem('retryable prompt')) +
+      ev({
+        timestamp: '2026-04-29T07:00:02.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'task_complete',
+          last_agent_message: null,
+          error: {
+            message: 'exceeded retry limit, last status: 429 Too Many Requests',
+            codex_error_info: {
+              response_too_many_failed_attempts: { http_status_code: 429 },
+            },
+          },
+        },
+      }));
+
+    const result = drainCodexRollout(path, 0);
+    expect(result.events).toHaveLength(2);
+    expect(result.events[1]).toMatchObject({
+      kind: 'assistant_final',
+      text: '',
+      terminalStatus: 'failed',
+      terminalErrorCode: CODEX_RATE_LIMIT_ERROR_CODE,
+    });
+    expect(isCodexRateLimitEvent(result.events[1])).toBe(true);
+  });
+
+  it('settles a non-rate task failure without classifying it as limited', () => {
+    writeFileSync(path, ev({
+      timestamp: '2026-04-29T07:00:02.000Z',
+      type: 'event_msg',
+      payload: {
+        type: 'task_complete',
+        error: { message: 'connection closed unexpectedly' },
+      },
+    }));
+
+    const result = drainCodexRollout(path, 0);
+    expect(result.events[0]).toMatchObject({
+      kind: 'assistant_final',
+      text: '',
+      terminalStatus: 'failed',
+      terminalErrorCode: CODEX_TASK_FAILED_ERROR_CODE,
+    });
+    expect(isCodexRateLimitEvent(result.events[0])).toBe(false);
   });
 
   it('skips messages with no input_text/output_text content', () => {


### PR DESCRIPTION
## 背景

Codex 结构化回合可能以 `event_msg/task_complete` 结束，同时携带错误且没有 `last_agent_message`。旧逻辑只从 `response_item` 提取最终回复，因此限流或任务失败后不会形成终态，飞书卡片会一直停留在“工作中”。

## 改动

- 将失败的 `task_complete` 解析为结构化失败终态
- 对 429 限流复用已有的额度受限状态和重试提示
- 对无正文的普通任务失败补充兜底结论
- 通过现有发送标记继续避免重复回写
- 增加 Codex transcript 与 bridge fallback 的回归用例

## 影响面

- 主要影响 Codex JSONL transcript 和 worker 的结构化回合收尾
- 公共 bridge fallback 仅新增“失败且无最终正文”场景，正常完成、已有最终回复及显式 `botmux send` 路径不变
- 不改变 PTY/Tmux、路径、进程或平台相关逻辑
- 普通飞书群/话题会话生效；local/adopt 会话仍按现有规则排除辅助回写
- 卡片继续复用现有限流 UI，没有新增界面

## 验证

- `pnpm exec vitest run test/codex-transcript.test.ts test/codex-bridge-queue.test.ts test/bridge-fallback-gate.test.ts test/traex-worker-bridge-wiring.test.ts test/cli-usage-limit.test.ts test/card-builder.test.ts test/bridge-final-output-retry.test.ts`
  - 7 个测试文件、311 个用例全部通过
- `pnpm build`
  - 构建、domain audit 和 dist audit 通过
- `git diff --check`
  - 通过
- 使用本次事故 transcript 回放，能够识别 2 条结构化 429 失败事件
- 开发机热修后 daemon、机器人进程和 dashboard 均恢复在线；本次遗漏结论已在原群补发并读回确认

未主动制造新的上游 429，以免影响正在运行的会话。