### PR TITLE
fix(report): 继承自然会话位置并兼容跨机器回传

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,7 +34,7 @@ import { validateWorkingDir } from './core/working-dir.js';
 import { resolveSessionContext } from './core/session-marker.js';
 import { resolveBotmuxDataDir } from './core/data-dir.js';
 import { dashboardSecretPath } from './core/dashboard-secret.js';
-import { acceptedDispatchBotAppIds, activeConversationBotOpenIds, appendDispatchReportProtocol, appendLegacyDispatchReportProtocol, parseDispatchBotSpec, buildDispatchMessages, buildRepoPrimeText, buildReportContent, eligibleAutoMentionAliases, findDispatchRegistryEntry, foldableChatSessionAppIds, offTopicSubBotTopic, resolveReportTarget, resolveSendTarget, threadRootForReachability } from './core/dispatch.js';
+import { acceptedDispatchBotAppIds, activeConversationBotOpenIds, appendDispatchReportProtocol, appendLegacyDispatchReportProtocol, parseDispatchBotSpec, buildDispatchMessages, buildRepoPrimeText, buildReportContent, eligibleAutoMentionAliases, findDispatchRegistryEntry, foldableChatSessionAppIds, offTopicSubBotTopic, resolveReportPlacement, resolveReportRecipient, resolveReportTarget, resolveSendTarget, threadRootForReachability } from './core/dispatch.js';
 import { pickTurnReplyTarget } from './core/reply-target.js';
 import { recordDispatchRegistryEntry } from './core/dispatch-registry.js';
 import { enableAutostart, disableAutostart, autostartStatus, refreshAutostart } from './autostart.js';
@@ -5407,7 +5407,7 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
                                        v2 历史 run 私有静态归档；retire 在维护窗双验后原子迁入 quarantine
   （完整参数见 \`botmux workflow help\` / \`botmux template help\`）
   dispatch --bot <name> [...]          多话题编排：开子话题并把 bot 派进去（详见 \`botmux dispatch --help\`）
-  report [...]                         v3/编排场景向上汇报进度或结果（详见 \`botmux report --help\`）
+  report [...]                         交接 Review / 进展 / 结果并继承会话位置（详见 \`botmux report --help\`）
 
 新建飞书群:
   create-group --bot <name> [--bot ...] [--name "群名"]
@@ -8526,40 +8526,69 @@ async function cmdDispatch(rest: string[]): Promise<void> {
 }
 
 /**
- * `botmux report` — delivery / progress report.
+ * `botmux report` — delivery / progress report, then hand Review/progress/results
+ * back to the stable recipient.
  *
  * Two paths:
  * 1) Platform Issue 领取群：session 有活跃 issue binding → enqueue+write `in_review`
  *    (待验收). This is what kickoff means by 「完成后执行 botmux report」.
- * 2) 多话题协作：dispatched sub-bot reports back to the orchestrator session.
- *    The sub-bot lives in its own sub-topic where the orchestrator has no session;
- *    @-ing the orchestrator there would spawn a fresh context-less one. Instead this
- *    routes INTO the orchestrator's thread (orchestrate-dispatch.json) and @-s it there.
+ * 2) 交接回报：recipient and placement are separate decisions. Registry-backed
+ *    multi-topic dispatches keep their exact orchestrator-session route. Ordinary
+ *    development handoffs inherit the executing turn's visible position with the
+ *    same turn-id gate as `botmux send`, so a later turn cannot reuse a stale
+ *    topic anchor.
  */
 async function cmdReport(rest: string[]): Promise<void> {
   if (rest.includes('--help') || rest.includes('-h')) {
-    console.log(`botmux report — 交付回报（issue 待验收 / 多话题协作回主编排）
+    console.log(`botmux report — 交付回报（issue 待验收 / 交接 Review·进展·结果并保持自然会话位置）
 
 用法:
-  botmux report "子项目X 完成，产出在 …"
-  botmux report --dispatch-root <om_seed> "子项目X 完成，产出在 …"
   botmux report --content-file <path>
+  botmux report --into <om_root> --content-file <path>
+  botmux report --top-level "子项目X 完成，产出在 …"
+  botmux report --dispatch-root <om_seed> "子项目X 完成，产出在 …"
+  botmux report "子项目X 完成，产出在 …" --legacy-dispatch
 
 说明:
   1) 平台 Issue 领取群：本会话绑定了平台 issue 时，把 issue 推到「待验收」(in_review)。
      kickoff 里「完成后执行 botmux report」指的就是这条路径。
-  2) 多话题协作：被 botmux dispatch 派活的子话题里，把回报发回主编排会话并 @ 主 bot
-     （不要在子话题里 @ 主 bot——会另起无上下文会话）。
+  2) 交接 / 协作回报：接收者与消息落点独立解析——接收者仍是原 Reviewer / orchestrator；
+     消息默认依次采用显式 --into / --top-level、dispatch 注册表、legacy dispatch 兼容回退、
+     当前轮次位置，最后才回退到会话默认位置。
+     当前轮次在群顶层就留在群顶层，在话题里就留在原话题；过期轮次的话题目标会被忽略。
+     dispatch 注册表命中时仍回到原主编排会话，并唤醒其已有上下文。
+     legacy / 跨机器 dispatch 没有本机注册表时仍回退群顶层，避免在子话题唤醒无上下文会话。
+
+  代码 Review 交接建议明确写出：首次 Review / 复审、MR、本轮改动、验证、风险，
+  以及希望 Reviewer 采取的动作。
 
 选项:
   --content-file <path>  从文件读取回报内容
+  --into <root_id>       显式发进指定话题（覆盖默认落点）
+  --top-level            显式发到当前群顶层（覆盖默认落点）
   --dispatch-root <id>   dispatch 注入的精确 seed；优先且不命中时 fail closed
+  --legacy-dispatch      legacy / 跨机器 dispatch 自动注入的兼容标记
   --session-id <id>      指定来源会话（默认自动推断）`);
     return;
   }
 
   process.env.SESSION_DATA_DIR ??= resolveDataDir();
   const sessionIdArg = argValue(rest, '--session-id');
+  if (flagPresentButValueMissing(rest, '--into')) {
+    console.error('--into 需要一个 om_ 话题根消息 id。');
+    process.exit(1);
+  }
+  const explicitInto = argValue(rest, '--into')?.trim();
+  if (explicitInto && !/^om_[A-Za-z0-9_-]{1,128}$/.test(explicitInto)) {
+    console.error('--into 必须是有效的 om_ 话题根消息 id。');
+    process.exit(1);
+  }
+  const explicitTopLevel = rest.includes('--top-level');
+  const legacyDispatch = rest.includes('--legacy-dispatch');
+  if (explicitInto && explicitTopLevel) {
+    console.error('--into 与 --top-level 不能同时使用。');
+    process.exit(1);
+  }
   if (flagPresentButValueMissing(rest, '--dispatch-root')) {
     console.error('--dispatch-root 需要一个 om_ 消息 id。');
     process.exit(1);
@@ -8576,7 +8605,7 @@ async function cmdReport(rest: string[]): Promise<void> {
     if (!existsSync(contentFile)) { console.error(`文件不存在: ${contentFile}`); process.exit(1); }
     content = readFileSync(contentFile, 'utf-8');
   } else {
-    const pos = positionals(rest);
+    const pos = positionals(rest, ['--top-level', '--legacy-dispatch']);
     content = pos.length ? pos.join(' ') : await readStdin();
   }
   if (!contentFile) rejectLikelyWindowsStdinMojibake(content);
@@ -8585,11 +8614,21 @@ async function cmdReport(rest: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const sid = sessionIdArg ?? findAncestorSessionId();
+  // The process-tree marker carries the executing turn. Do not revive the
+  // spawn-time BOTMUX_TURN_ID here: it is stale in a long-lived or detached
+  // CLI and could make an old topic target look current.
+  const reportContext = resolveSessionContext(
+    resolveDataDir(),
+    process.env.BOTMUX_SESSION_ID,
+  );
+  const sid = sessionIdArg ?? reportContext?.sessionId;
   if (!sid) {
-    console.error('无法推断 session-id。请在 issue 领取群 / 被 dispatch 派活的会话里运行，或传 --session-id <id>。');
+    console.error('无法推断 session-id。请在当前 Botmux 会话（issue 领取群 / 被 dispatch 派活的会话）里运行，或传 --session-id <id>。');
     process.exit(1);
   }
+  const currentTurnId = reportContext?.sessionId === sid
+    ? reportContext.turnId
+    : undefined;
   const sessions = loadSessions();
   const s = sessions.get(sid);
   if (!s) { console.error(`未找到 session ${sid}`); process.exit(1); }
@@ -8680,34 +8719,60 @@ async function cmdReport(rest: string[]): Promise<void> {
     }
   }
 
-  // Resolve where the report goes + who to @. Same-machine: the dispatch registry
-  // (keyed by this sub-bot's thread root) carries the orchestrator's exact coords.
-  // CROSS-MACHINE: the orchestrator is on another machine, so its registry isn't
-  // on THIS one — resolveReportTarget falls back to this sub-bot's own session
-  // (report top-level into its chat, @ the dispatcher via creatorOpenId). See
-  // resolveReportTarget / Session.creatorOpenId.
+  // Recipient and visible placement are independent. creatorOpenId remains the
+  // stable Reviewer/orchestrator identity; current-turn routing controls where
+  // an ordinary report appears.
+  const reportRecipient = resolveReportRecipient({
+    creatorOpenId: s.creatorOpenId,
+    ownerOpenId: s.ownerOpenId,
+    quoteTargetSenderOpenId: s.quoteTargetSenderOpenId,
+  });
+  const turnReplyTarget = pickTurnReplyTarget(s, currentTurnId);
+  const validatedTurnReplyTarget = currentTurnId
+    && turnReplyTarget?.turnId === currentTurnId
+    ? turnReplyTarget
+    : undefined;
+
+  // Same-machine dispatches retain their exact orchestrator registry route.
+  // A chat-scope target may participate only when it belongs to this executing
+  // turn; historical aliases have no turn id and are intentionally ignored.
   const regPath = join(resolveDataDir(), 'orchestrate-dispatch.json');
   let reg: Record<string, any> = {};
   try { if (existsSync(regPath)) reg = JSON.parse(readFileSync(regPath, 'utf-8')); } catch { /* */ }
   const registryMatch = findDispatchRegistryEntry({
     registry: reg,
     dispatchRootId: explicitDispatchRoot,
+    sessionScope: s.scope ?? 'thread',
     rootMessageId: s.rootMessageId,
-    currentReplyTargetRootId: s.currentReplyTarget?.rootMessageId,
-    replyThreadAliases: s.replyThreadAliases,
+    currentReplyTargetRootId: validatedTurnReplyTarget?.rootMessageId,
+    currentReplyTargetTurnId: validatedTurnReplyTarget?.turnId,
+    currentTurnId,
   });
   if (explicitDispatchRoot && registryMatch?.key !== explicitDispatchRoot) {
     console.error(`精确 dispatch root ${explicitDispatchRoot} 在本机注册表中不存在；为避免串到其他 PM 会话，本次回报已停止。`);
     process.exit(1);
   }
   const entry = registryMatch?.entry as any;
+  const dispatchCoords = resolveReportTarget({
+    registryEntry: entry,
+    sessionChatId: s.chatId,
+  });
+  const registryTarget = registryMatch
+    ? dispatchCoords.orchScope !== 'chat' && dispatchCoords.orchRoot
+      ? { mode: 'thread' as const, rootMessageId: dispatchCoords.orchRoot }
+      : dispatchCoords.orchChatId
+        ? { mode: 'plain' as const, chatId: dispatchCoords.orchChatId }
+        : undefined
+    : undefined;
+  const hasExplicitPlacement = !!explicitInto || explicitTopLevel;
 
   // Same-host dispatches carry the exact source session. Inject the report into
   // that live PM context through its own daemon instead of trying to make the
   // resident app post into the PM's source chat (which may be a P2P the
   // resident app cannot access). The report body remains untrusted envelope
-  // data; only the fixed consolidation instruction is trusted.
-  if (entry?.orchAppId && entry?.orchSessionId) {
+  // data; only the fixed consolidation instruction is trusted. An explicit
+  // visible placement overrides this registry delivery by design.
+  if (!hasExplicitPlacement && entry?.orchAppId && entry?.orchSessionId) {
     const daemon = findDaemon(entry.orchAppId);
     if (!daemon) {
       console.error('主编排 Bot daemon 不在线；回报未发送，可稍后重试同一 botmux report。');
@@ -8758,24 +8823,42 @@ async function cmdReport(rest: string[]): Promise<void> {
       delivery: 'orchestrator-session',
       reportedTo: entry.orchSessionId,
       viaRegistry: true,
+      recipient: {
+        kind: 'orchestrator-session',
+        botAppId: entry.orchAppId,
+        sessionId: entry.orchSessionId,
+        ...(reportRecipient ? { openId: reportRecipient } : {}),
+      },
+      placementSource: 'dispatch-registry',
+      messageTarget: {
+        mode: 'orchestrator-session',
+        sessionId: entry.orchSessionId,
+        botAppId: entry.orchAppId,
+      },
       triggerId: triggerBody.triggerId,
     }));
     return;
   }
 
-  const tgt = resolveReportTarget({
-    registryEntry: entry,
-    sessionChatId: s.chatId,
-    creatorOpenId: s.creatorOpenId,
-    ownerOpenId: s.ownerOpenId,
-    quoteTargetSenderOpenId: s.quoteTargetSenderOpenId,
-  });
-  if (!tgt.orchOpenId || !tgt.orchChatId) {
+  if (!reportRecipient) {
     console.error(
-      '找不到主编排坐标：本会话没记录派活者（creatorOpenId/ownerOpenId 都空）或缺 chatId——大概不是被 botmux dispatch 派活的会话。\n' +
-      '若确需回报，请改用 `botmux send` 或显式 @ 对应的人/ bot。');
+      '找不到 Review / 回报接收者：本会话没有 creatorOpenId、ownerOpenId 或可用的历史发送者。\n' +
+      '若确需交接，请改用 `botmux send --mention <open_id:名字>` 明确指定接收者。');
     process.exit(1);
   }
+  const placement = resolveReportPlacement({
+    into: explicitInto,
+    topLevel: explicitTopLevel,
+    registryTarget,
+    legacyDispatch,
+    chatScope: (s.scope ?? 'thread') === 'chat',
+    chatId: s.chatId,
+    rootMessageId: s.rootMessageId,
+    replyTargetRootId: validatedTurnReplyTarget?.rootMessageId,
+    replyTargetTurnId: validatedTurnReplyTarget?.turnId,
+    replyTargetQuoteOnly: validatedTurnReplyTarget?.quoteOnly,
+    currentTurnId,
+  });
 
   const { registerBot, loadBotConfigs } = await import('./bot-registry.js');
   try { for (const cfg of loadBotConfigs()) registerBot(cfg); } catch { /* */ }
@@ -8783,25 +8866,36 @@ async function cmdReport(rest: string[]): Promise<void> {
   const { sendMessage, replyMessage } = await import('./im/lark/client.js');
   const appId = s.larkAppId!;
 
-  const paras = buildReportContent({ orchOpenId: tgt.orchOpenId, content });
+  const paras = buildReportContent({ orchOpenId: reportRecipient, content });
   const postJson = JSON.stringify({ zh_cn: { title: '', content: paras } });
 
   try {
     let msgId: string;
-    if (tgt.orchScope === 'chat' || !tgt.orchRoot) {
-      // Orchestrator at chat scope, or cross-machine fallback → post top-level
-      // into the chat (the sub-topic's chat = the orchestrator's chat).
-      msgId = await sendMessage(appId, tgt.orchChatId, postJson, 'post');
+    if (placement.target.mode === 'plain') {
+      msgId = await sendMessage(appId, placement.target.chatId, postJson, 'post');
     } else {
-      // Same-machine thread-scope orchestrator → reply into its thread so its
-      // existing context-rich session (anchored on orchRoot) receives the report.
-      msgId = await replyMessage(appId, tgt.orchRoot, postJson, 'post', true);
+      msgId = await replyMessage(
+        appId,
+        placement.target.rootMessageId,
+        postJson,
+        'post',
+        placement.target.mode === 'thread',
+      );
     }
+    const messageTarget = placement.target.mode === 'plain'
+      ? { mode: 'top-level', chatId: placement.target.chatId }
+      : { mode: placement.target.mode, rootMessageId: placement.target.rootMessageId };
     console.log(JSON.stringify({
       success: true,
-      reportedTo: tgt.orchRoot || tgt.orchChatId,
-      orchestrator: tgt.orchOpenId,
+      delivery: 'lark-message',
+      reportedTo: placement.target.mode === 'plain'
+        ? placement.target.chatId
+        : placement.target.rootMessageId,
+      orchestrator: reportRecipient,
+      recipient: { kind: 'mention', openId: reportRecipient },
       viaRegistry: !!registryMatch,
+      placementSource: placement.source,
+      messageTarget,
       messageId: msgId,
     }));
   } catch (err: any) {

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -14,8 +14,9 @@
  * (cli.ts) performs the actual sendMessage + replyMessage.
  */
 
-import type { SessionReplyTarget } from './reply-target.js';
-export { resolveSendTarget } from './reply-target.js';
+import { resolveSendTarget, type SessionReplyTarget } from './reply-target.js';
+
+export { resolveSendTarget };
 
 export interface DispatchBot {
   /** open_id as seen by the orchestrator's app (from <available_bots>). */
@@ -40,11 +41,17 @@ export interface DispatchMessages {
 
 const DISPATCH_ROOT_ID_RE = /^om_[A-Za-z0-9_-]{1,128}$/;
 
-/** Compatibility protocol for legacy/cross-machine `--bot` dispatches. */
+/**
+ * Compatibility protocol for legacy/cross-machine `--bot` dispatches.
+ *
+ * Keep the marker after the positional report text. Older receivers do not know
+ * this boolean flag, but their generic positional parser safely ignores an
+ * unknown trailing flag instead of consuming the report text as its value.
+ */
 export function appendLegacyDispatchReportProtocol(brief: string): string {
   return brief.trimEnd()
     + '\n\n— 完成回报 —\n'
-    + '干完后在本话题运行 `botmux report "子项目完成 + 产出位置/摘要"` '
+    + '干完后在本话题运行 `botmux report "子项目完成 + 产出位置/摘要" --legacy-dispatch` '
     + '把结果回报给主编排会话；不要在本话题 @ 主bot（那会另起一个没有上下文的新会话）。';
 }
 
@@ -344,22 +351,25 @@ export function activeConversationBotOpenIds(input: {
   return openIds;
 }
 
+/** Resolve the stable Review/orchestrator addressee independently of placement. */
+export function resolveReportRecipient(input: {
+  creatorOpenId?: string;
+  ownerOpenId?: string;
+  quoteTargetSenderOpenId?: string;
+}): string | undefined {
+  return [
+    input.creatorOpenId,
+    input.ownerOpenId,
+    input.quoteTargetSenderOpenId,
+  ].find(value => !!value?.trim())?.trim();
+}
+
 /**
- * Resolve where a `botmux report` should go + who to @, so report-back works
- * even when the orchestrator is on a DIFFERENT machine.
+ * Compatibility view of registry coordinates plus recipient.
  *
- * Same-machine: the dispatch registry (orchestrate-dispatch.json) is local, so
- * `registryEntry` carries the orchestrator's exact coords (incl. orchRoot for a
- * thread-scope orchestrator). Cross-machine: the foreign sub-bot's daemon never
- * wrote that registry, so `registryEntry` is undefined — but everything needed
- * for the common case is on the sub-bot's OWN session: the report goes top-level
- * into the chat the sub-topic lives in (= the orchestrator's chat) and @-s the
- * orchestrator (creatorOpenId, captured from the dispatch @). So we fall back to
- * `{ orchChatId: sessionChatId, orchScope: 'chat', orchRoot: '' }`.
- *
- * orchOpenId prefers `creatorOpenId` (stable, set on every session-creation path
- * incl. foreign-bot auto-create), then `ownerOpenId`, then the drifting
- * `quoteTargetSenderOpenId` as a last resort.
+ * `cmdReport` no longer treats these coordinates as the ordinary no-registry
+ * placement. It uses them only to preserve a matching dispatch route; otherwise
+ * {@link resolveReportPlacement} inherits the executing conversation turn.
  */
 export function resolveReportTarget(input: {
   registryEntry?: { orchChatId?: string; orchScope?: string; orchRoot?: string };
@@ -373,7 +383,75 @@ export function resolveReportTarget(input: {
     orchChatId: e?.orchChatId ?? input.sessionChatId,
     orchScope: e?.orchScope ?? 'chat',
     orchRoot: e?.orchRoot ?? '',
-    orchOpenId: input.creatorOpenId ?? input.ownerOpenId ?? input.quoteTargetSenderOpenId,
+    orchOpenId: resolveReportRecipient(input),
+  };
+}
+
+export type ReportPlacementSource =
+  | 'explicit-into'
+  | 'explicit-top-level'
+  | 'dispatch-registry'
+  | 'legacy-dispatch-fallback'
+  | 'current-turn'
+  | 'session-default';
+
+/**
+ * Resolve only the visible placement of a `botmux report`.
+ *
+ * The report recipient is intentionally resolved separately by
+ * {@link resolveReportRecipient}: choosing where the message is shown must never
+ * change who is @-mentioned. Explicit placement wins, a dispatch registry keeps
+ * its existing orchestrator-return semantics, and an explicitly marked legacy
+ * cross-machine dispatch without a local registry keeps the old top-level
+ * compatibility fallback. Ordinary reports reuse the same turn-bound placement
+ * rules as `botmux send`.
+ */
+export function resolveReportPlacement(input: {
+  into?: string;
+  topLevel?: boolean;
+  registryTarget?: SessionReplyTarget;
+  legacyDispatch?: boolean;
+  chatScope: boolean;
+  chatId: string;
+  rootMessageId: string;
+  replyTargetRootId?: string;
+  replyTargetTurnId?: string;
+  replyTargetQuoteOnly?: boolean;
+  currentTurnId?: string;
+}): { target: SessionReplyTarget; source: ReportPlacementSource } {
+  if (input.into) {
+    return {
+      target: { mode: 'thread', rootMessageId: input.into },
+      source: 'explicit-into',
+    };
+  }
+  if (input.topLevel) {
+    return {
+      target: { mode: 'plain', chatId: input.chatId },
+      source: 'explicit-top-level',
+    };
+  }
+  if (input.registryTarget) {
+    return { target: input.registryTarget, source: 'dispatch-registry' };
+  }
+  if (input.legacyDispatch) {
+    return {
+      target: { mode: 'plain', chatId: input.chatId },
+      source: 'legacy-dispatch-fallback',
+    };
+  }
+  return {
+    target: resolveSendTarget({
+      topLevel: false,
+      chatScope: input.chatScope,
+      chatId: input.chatId,
+      rootMessageId: input.rootMessageId,
+      replyTargetRootId: input.replyTargetRootId,
+      replyTargetTurnId: input.replyTargetTurnId,
+      replyTargetQuoteOnly: input.replyTargetQuoteOnly,
+      currentTurnId: input.currentTurnId,
+    }),
+    source: input.currentTurnId ? 'current-turn' : 'session-default',
   };
 }
 
@@ -391,16 +469,19 @@ export interface DispatchRegistryEntry {
  * regular-group chat-scope session folded from a dispatch topic.
  *
  * Folded sessions are keyed by chatId, while the registry is keyed by the seed
- * message id. The seed is retained in currentReplyTarget/replyThreadAliases, so
- * report-back must consult those aliases instead of silently falling back to a
- * context-less top-level message.
+ * message id. Their currentReplyTarget is usable only when it belongs to the
+ * CLI's executing turn. Historical replyThreadAliases deliberately do not
+ * participate: they have no turn id and could route a later ordinary report
+ * back into a stale dispatch.
  */
 export function findDispatchRegistryEntry(input: {
   registry: Record<string, DispatchRegistryEntry>;
   dispatchRootId?: string;
+  sessionScope?: 'thread' | 'chat';
   rootMessageId?: string;
   currentReplyTargetRootId?: string;
-  replyThreadAliases?: Record<string, { createdAt: string; lastUsedAt: string }>;
+  currentReplyTargetTurnId?: string;
+  currentTurnId?: string;
 }): { key: string; entry: DispatchRegistryEntry } | undefined {
   if (input.dispatchRootId) {
     const entry = input.registry[input.dispatchRootId];
@@ -410,11 +491,14 @@ export function findDispatchRegistryEntry(input: {
   const add = (value: string | undefined) => {
     if (value && !ordered.includes(value)) ordered.push(value);
   };
-  add(input.currentReplyTargetRootId);
-  add(input.rootMessageId);
-  const aliases = Object.entries(input.replyThreadAliases ?? {})
-    .sort((a, b) => String(b[1]?.lastUsedAt ?? '').localeCompare(String(a[1]?.lastUsedAt ?? '')));
-  for (const [rootId] of aliases) add(rootId);
+  if (
+    input.currentTurnId
+    && input.currentReplyTargetTurnId === input.currentTurnId
+  ) {
+    add(input.currentReplyTargetRootId);
+  }
+  // Chat-scope rootMessageId is traceability metadata, not a routing anchor.
+  if (input.sessionScope !== 'chat') add(input.rootMessageId);
   for (const key of ordered) {
     const entry = input.registry[key];
     if (entry) return { key, entry };

--- a/test/dispatch.test.ts
+++ b/test/dispatch.test.ts
@@ -29,6 +29,8 @@ import {
   offTopicSubBotTopic,
   foldableChatSessionAppIds,
   recordDispatchInputCommit,
+  resolveReportPlacement,
+  resolveReportRecipient,
   resolveReportTarget,
   resolveSendTarget,
   threadRootForReachability,
@@ -116,9 +118,9 @@ describe('appendDispatchReportProtocol', () => {
     expect(() => appendDispatchReportProtocol('x', 'oc_chat')).toThrow('valid om_ root id');
   });
 
-  it('keeps the root-free compatibility command for legacy cross-machine dispatches', () => {
+  it('trails the marker so older cross-machine receivers keep the positional report text', () => {
     const legacy = appendLegacyDispatchReportProtocol('跨机器任务');
-    expect(legacy).toContain('botmux report "子项目完成 + 产出位置/摘要"');
+    expect(legacy).toContain('botmux report "子项目完成 + 产出位置/摘要" --legacy-dispatch');
     expect(legacy).not.toContain('--dispatch-root');
   });
 });
@@ -549,7 +551,7 @@ describe('resolveReportTarget', () => {
     expect(r).toEqual({ orchChatId: 'oc_orch', orchScope: 'thread', orchRoot: 'om_root', orchOpenId: 'ou_orch' });
   });
 
-  it('CROSS-MACHINE: with no registry entry, derives from the session (chatId + chat-scope)', () => {
+  it('keeps the legacy no-registry coordinate fallback for compatibility callers', () => {
     const r = resolveReportTarget({ registryEntry: undefined, sessionChatId: 'oc_sub', creatorOpenId: 'ou_orch' });
     expect(r).toEqual({ orchChatId: 'oc_sub', orchScope: 'chat', orchRoot: '', orchOpenId: 'ou_orch' });
   });
@@ -561,6 +563,143 @@ describe('resolveReportTarget', () => {
   });
 });
 
+describe('resolveReportRecipient', () => {
+  it('keeps the stable creator as recipient regardless of message placement', () => {
+    expect(resolveReportRecipient({
+      creatorOpenId: 'ou_reviewer',
+      ownerOpenId: 'ou_owner',
+      quoteTargetSenderOpenId: 'ou_latest_sender',
+    })).toBe('ou_reviewer');
+  });
+
+  it('skips empty legacy identity fields', () => {
+    expect(resolveReportRecipient({
+      creatorOpenId: '  ',
+      ownerOpenId: 'ou_owner',
+      quoteTargetSenderOpenId: 'ou_latest_sender',
+    })).toBe('ou_owner');
+  });
+});
+
+describe('resolveReportPlacement', () => {
+  const base = {
+    chatScope: true,
+    chatId: 'oc_task',
+    rootMessageId: 'oc_task',
+    currentTurnId: 'om_turn_current',
+  };
+  const registryTarget = { mode: 'thread' as const, rootMessageId: 'om_orchestrator_topic' };
+
+  it('inherits a group-top-level turn as group top level', () => {
+    expect(resolveReportPlacement(base)).toEqual({
+      target: { mode: 'plain', chatId: 'oc_task' },
+      source: 'current-turn',
+    });
+  });
+
+  it('inherits the matching current turn topic', () => {
+    expect(resolveReportPlacement({
+      ...base,
+      replyTargetRootId: 'om_review_topic',
+      replyTargetTurnId: 'om_turn_current',
+    })).toEqual({
+      target: { mode: 'thread', rootMessageId: 'om_review_topic' },
+      source: 'current-turn',
+    });
+  });
+
+  it('preserves a matching quote-only turn target', () => {
+    expect(resolveReportPlacement({
+      ...base,
+      replyTargetRootId: 'om_quoted_message',
+      replyTargetTurnId: 'om_turn_current',
+      replyTargetQuoteOnly: true,
+    })).toEqual({
+      target: { mode: 'quote', rootMessageId: 'om_quoted_message' },
+      source: 'current-turn',
+    });
+  });
+
+  it('ignores a stale topic target from a different turn', () => {
+    expect(resolveReportPlacement({
+      ...base,
+      replyTargetRootId: 'om_stale_topic',
+      replyTargetTurnId: 'om_turn_old',
+    })).toEqual({
+      target: { mode: 'plain', chatId: 'oc_task' },
+      source: 'current-turn',
+    });
+  });
+
+  it('--into overrides a dispatch registry placement', () => {
+    expect(resolveReportPlacement({
+      ...base,
+      into: 'om_explicit_topic',
+      registryTarget,
+      legacyDispatch: true,
+    })).toEqual({
+      target: { mode: 'thread', rootMessageId: 'om_explicit_topic' },
+      source: 'explicit-into',
+    });
+  });
+
+  it('--top-level overrides a dispatch registry placement', () => {
+    expect(resolveReportPlacement({
+      ...base,
+      topLevel: true,
+      registryTarget,
+      legacyDispatch: true,
+    })).toEqual({
+      target: { mode: 'plain', chatId: 'oc_task' },
+      source: 'explicit-top-level',
+    });
+  });
+
+  it('preserves a dispatch registry placement when there is no explicit override', () => {
+    expect(resolveReportPlacement({
+      ...base,
+      registryTarget,
+    })).toEqual({
+      target: registryTarget,
+      source: 'dispatch-registry',
+    });
+  });
+
+  it('keeps same-machine legacy dispatch on its registry-backed orchestrator route', () => {
+    expect(resolveReportPlacement({
+      ...base,
+      legacyDispatch: true,
+      registryTarget,
+    })).toEqual({
+      target: registryTarget,
+      source: 'dispatch-registry',
+    });
+  });
+
+  it('keeps cross-machine legacy dispatch without a registry on the top-level fallback', () => {
+    expect(resolveReportPlacement({
+      ...base,
+      legacyDispatch: true,
+      replyTargetRootId: 'om_legacy_subtopic',
+      replyTargetTurnId: 'om_turn_current',
+    })).toEqual({
+      target: { mode: 'plain', chatId: 'oc_task' },
+      source: 'legacy-dispatch-fallback',
+    });
+  });
+
+  it('uses the durable session location only when there is no current turn position', () => {
+    expect(resolveReportPlacement({
+      chatScope: false,
+      chatId: 'oc_task',
+      rootMessageId: 'om_session_topic',
+    })).toEqual({
+      target: { mode: 'thread', rootMessageId: 'om_session_topic' },
+      source: 'session-default',
+    });
+  });
+});
+
 describe('findDispatchRegistryEntry', () => {
   const registry = {
     om_seed_old: { orchRoot: 'om_orch_old', orchSessionId: 's_old' },
@@ -568,7 +707,11 @@ describe('findDispatchRegistryEntry', () => {
   };
 
   it('uses the thread root for a normal thread-scoped dispatched session', () => {
-    expect(findDispatchRegistryEntry({ registry, rootMessageId: 'om_seed_new' })).toEqual({
+    expect(findDispatchRegistryEntry({
+      registry,
+      sessionScope: 'thread',
+      rootMessageId: 'om_seed_new',
+    })).toEqual({
       key: 'om_seed_new',
       entry: registry.om_seed_new,
     });
@@ -577,11 +720,11 @@ describe('findDispatchRegistryEntry', () => {
   it('uses currentReplyTarget for a chat-scope session folded from a dispatch topic', () => {
     expect(findDispatchRegistryEntry({
       registry,
+      sessionScope: 'chat',
       rootMessageId: 'oc_group',
       currentReplyTargetRootId: 'om_seed_new',
-      replyThreadAliases: {
-        om_seed_new: { createdAt: '2026-07-14T08:00:00.000Z', lastUsedAt: '2026-07-14T08:01:00.000Z' },
-      },
+      currentReplyTargetTurnId: 'om_turn_current',
+      currentTurnId: 'om_turn_current',
     })).toEqual({ key: 'om_seed_new', entry: registry.om_seed_new });
   });
 
@@ -589,12 +732,11 @@ describe('findDispatchRegistryEntry', () => {
     expect(findDispatchRegistryEntry({
       registry,
       dispatchRootId: 'om_seed_old',
+      sessionScope: 'chat',
       rootMessageId: 'oc_group',
       currentReplyTargetRootId: 'om_seed_new',
-      replyThreadAliases: {
-        om_seed_old: { createdAt: '2026-07-14T07:00:00.000Z', lastUsedAt: '2026-07-14T07:01:00.000Z' },
-        om_seed_new: { createdAt: '2026-07-14T08:00:00.000Z', lastUsedAt: '2026-07-14T08:01:00.000Z' },
-      },
+      currentReplyTargetTurnId: 'om_turn_new',
+      currentTurnId: 'om_turn_new',
     })).toEqual({ key: 'om_seed_old', entry: registry.om_seed_old });
   });
 
@@ -602,20 +744,32 @@ describe('findDispatchRegistryEntry', () => {
     expect(findDispatchRegistryEntry({
       registry,
       dispatchRootId: 'om_seed_missing',
+      sessionScope: 'chat',
       rootMessageId: 'oc_group',
       currentReplyTargetRootId: 'om_seed_new',
+      currentReplyTargetTurnId: 'om_turn_current',
+      currentTurnId: 'om_turn_current',
     })).toBeUndefined();
   });
 
-  it('falls back to the most recently used matching reply-thread alias', () => {
+  it('ignores a stale currentReplyTarget whose turn id does not match', () => {
     expect(findDispatchRegistryEntry({
       registry,
+      sessionScope: 'chat',
       rootMessageId: 'oc_group',
-      replyThreadAliases: {
-        om_seed_old: { createdAt: '2026-07-14T07:00:00.000Z', lastUsedAt: '2026-07-14T07:01:00.000Z' },
-        om_seed_new: { createdAt: '2026-07-14T08:00:00.000Z', lastUsedAt: '2026-07-14T08:01:00.000Z' },
-      },
-    })).toEqual({ key: 'om_seed_new', entry: registry.om_seed_new });
+      currentReplyTargetRootId: 'om_seed_old',
+      currentReplyTargetTurnId: 'om_turn_old',
+      currentTurnId: 'om_turn_new',
+    })).toBeUndefined();
+  });
+
+  it('does not treat a chat-scope trace root as a dispatch route', () => {
+    expect(findDispatchRegistryEntry({
+      registry,
+      sessionScope: 'chat',
+      rootMessageId: 'om_seed_old',
+      currentTurnId: 'om_turn_new',
+    })).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## 背景

`botmux report` 同时承担“唤醒原 Reviewer / orchestrator”和“决定消息可见落点”两项职责。此前在没有 dispatch registry 时固定回退群顶层，导致从话题中发起的普通开发 Review、返工或复审脱离原对话；但 legacy / 跨机器 `--bot` dispatch 又必须保留无 registry 时回到群顶层的兼容行为。

## 根因

report 的接收者与消息落点耦合，且无 registry 的普通 report 和跨机器 legacy dispatch 缺少可区分的路由信号，因此无法同时满足自然会话继承和旧 dispatch 回传语义。

## 改动

- 解耦 report 的接收者解析与消息落点解析。
- 默认落点优先级调整为：显式 `--into` / `--top-level` → dispatch registry → legacy dispatch 顶层回退 → 当前轮次位置 → 会话安全默认。
- 复用 `currentReplyTarget`，并校验其 `turnId` 与当前轮次一致，避免旧话题目标污染新一轮 report。
- 为 legacy / 跨机器 dispatch 注入尾置 `--legacy-dispatch` 标记：本机 registry 命中时仍回原 orchestrator session，无 registry 时保持群顶层兼容回退；尾置形式兼容旧版 parser 对正文的读取。
- 保持显式位置覆盖只改变消息落点，不改变接收者。
- 更新 CLI 帮助和结构化输出，补充 `delivery`、`recipient`、`placementSource` 与 `messageTarget`。
- 补充群顶层、话题、quote-only、过期 turn、显式覆盖、dispatch registry 及跨机器 legacy fallback 的单元测试。

## 用户影响

- 从群顶层发起的普通 Review / 返工继续留在群顶层。
- 从话题发起的普通 Review / 返工继续留在原话题。
- 多话题编排仍按 registry 回到原 orchestrator 会话。
- 跨机器 legacy dispatch 在接收端没有 registry 时仍按旧协议回到群顶层。
- 不新增生命周期状态机、按钮验收或流程门禁。

## 验证

- `pnpm vitest run --project unit test/dispatch.test.ts test/reply-target-fallback.test.ts test/session-marker-resolve.test.ts`：106/106 通过。
- `pnpm exec tsc --noEmit`：通过。
- `pnpm build`：通过，runtime build id `f3fa843a3356`。
- `node dist/cli.js report --help`：通过。
- `git diff --check`：通过。
- 使用已安装 Botmux v2.111.0 做只读兼容探针：尾置 marker 命令保留前置正文并到达 session 校验；未发送消息、未修改安装产物。

## 已知限制

- 未执行真实飞书 E2E，因为真实 report 会产生外部消息；本次以纯函数测试、类型检查和构建验证为主。
- 首次 Review 前的全量测试结果为 11,394 通过、6 失败、6 跳过；6 个失败均来自未修改的 v3 worker/fence Linux 进程发现或恢复测试，单独复跑失败形态不变，与本改动无调用链关系。
- 未修改本机 npm 安装产物，未重启 daemon。
