### PR TITLE
fix(lark): 修 1V1 群拉新 bot 后 @ 新 bot 时老 bot 跟回(chatStatsCache 陈旧窗口)

### DIFF
--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -765,10 +765,12 @@ export async function getGroupStats(larkAppId: string, chatId: string): Promise<
 
 /**
  * Drop the cached group stats for one chat — called when a membership-change
- * event arrives, so the 1v1 relax gate sees fresh counts on the very next
- * message instead of coasting on stale numbers for up to CHAT_CACHE_TTL.
- * Without this, "拉了新 bot 进 1V1 群" 后最多 5 分钟内老 bot 仍把群当成 solo,
- * 对不 @ 自己的消息继续应答。TTL 继续保留,作为事件未订阅（老应用）时的兜底。
+ * event that is VISIBLE to this app arrives (user add/delete broadcast, or our
+ * own bot being added/removed), so the 1v1 relax gate sees fresh counts on the
+ * very next message instead of coasting on stale numbers for up to
+ * CHAT_CACHE_TTL. TTL 继续保留,作为事件未订阅（老应用）时的兜底。
+ * 注意跨进程边界:「别的 bot 进群/离群」事件只推给当事 bot 自己的 app,
+ * 一 bot 一 daemon 部署下此函数够不到兄弟进程的缓存(见 handler 处注释)。
  */
 export function invalidateChatStats(larkAppId: string, chatId: string): void {
   if (chatStatsCache.delete(`${larkAppId}:${chatId}`)) {

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -776,29 +776,6 @@ export function invalidateChatStats(larkAppId: string, chatId: string): void {
   }
 }
 
-/**
- * Invalidate group stats for the chat across EVERY locally-hosted bot.
- *
- * 飞书 `im.chat.member.bot.added/deleted_v1` 只推给「进群/被移出的那个 bot 自己
- * 的 app」,同群其他存量 bot 收不到——单 bot 失效对「拉了另一个 bot 进群」无效。
- * 但本 daemon 单进程托管全 fleet 且 chatStatsCache 是进程级共享的:任一本地
- * bot 收到自己的 bot.added/deleted 事件时,顺势清掉该群在所有本地 bot app
- * 视角下的缓存条目,fleet 内互相失效即告成立。
- *
- * 边界:拉进群的是【非本 daemon 的第三方 bot】时没有任何事件信号可达,该方向
- * 只能靠 relax 末条款的 mentionsAnotherMember 守卫 + TTL 兜底(见 relax 注释)。
- */
-export function invalidateChatStatsForAllLocalBots(chatId: string): void {
-  let cleared = 0;
-  for (const b of getAllBots()) {
-    const appId = b?.config?.larkAppId;
-    if (appId && chatStatsCache.delete(`${appId}:${chatId}`)) cleared++;
-  }
-  if (cleared > 0) {
-    logger.debug(`[group-stats] invalidated cached stats for ${chatId} across ${cleared} local bot(s): bot membership changed`);
-  }
-}
-
 /** Test-only: clear the group-stats cache between cases. */
 export function __resetChatStatsForTest(): void {
   chatStatsCache.clear();
@@ -3016,13 +2993,14 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
       const chatIdForKey: string | undefined = data?.chat_id;
       const operatorForKey: string | undefined = data?.operator_id?.open_id;
       const eventKey = `im.chat.member.bot.added_v1:${larkAppId}:${eventIdForKey(data) ?? `${chatIdForKey ?? 'unknown'}:${operatorForKey ?? 'unknown'}`}`;
-      // 飞书只把 bot.added 推给「进群的那个 bot 自己的 app」——同群存量 bot 无
-      // 事件可收。因此这里必须扇出到 fleet 全 bot 视角对群缓存（缓存进程级共享）：
-      // 收到的是自己 fleet 内某个 bot 的进群,就把该群在所有本地 bot app 下的
-      // group-stats 条目一起清掉,让 1v1 放行在下一条消息就用 fresh 人数。
-      // 非 fleet 三方 bot 进群永远拿不到此事件,那方向靠 relax 末条款的
-      // mentionsAnotherMember 守卫 + TTL 兜底,不靠这里。
-      if (chatIdForKey) invalidateChatStatsForAllLocalBots(chatIdForKey);
+      // 飞书只把 bot.added 推给「进群的那个 bot 自己的 app」(官方文档语義,
+      // codex 复审证实),且生产是 PM2「一 bot 一 daemon 进程」(daemon.ts
+      // "Load the assigned bot (one daemon per bot)")——同群其他 bot 的缓存在
+      // 别的进程,这里够不到,只能清自己的 key。覆盖增量其实很小:新添进群
+      // 时本 bot 此前若恰有该群条目（曾被移出又拉回),避免带着上轮陈旧数放行。
+      // 「拉了别的 bot 进群→存量 bot 陈旧」方向无事件信号,靠 relax 末条款的
+      // mentionsAnotherMember 守卫 + TTL 兜底。
+      if (chatIdForKey) invalidateChatStats(larkAppId, chatIdForKey);
       scheduleAckSafeEvent(eventKey, async () => {
       try {
         const chatId: string | undefined = data?.chat_id;
@@ -3035,13 +3013,14 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
       }
       }, 'bot-added event');
     },
-    // bot 被移出群（只推给被移出的 bot 自己的 app）=> 同样扇出失效 fleet 全视角。
-    // user.added/deleted_v1 则推给群内已订阅的所有 bot app,每个 bot 自己的 WS
-    // 都收到,只清自己那条即可。纯本地 map 删除,同步处理、即时 ACK,不进
-    // scheduleAckSafeEvent 的 work 队列;去重也不必要——失效是幂等的。
+    // bot.deleted 同样只推给被移出的 bot 自己的 app——清自己的 key 即可(语义
+    // 同 bot.added:进程边界上够不到兄弟 daemon;「别的 bot 离群→存量 bot
+    // 陈旧」靠①守卫+TTL)。user.added/deleted_v1 推给群内已订阅的所有 bot
+    // app,每个 bot 自己的 WS 都收到,各自清自己那条。纯本地 map 删除,同步
+    // 处理、即时 ACK,不进 work 队列;去重也不必要——失效是幂等的。
     'im.chat.member.bot.deleted_v1': (data: any) => {
       const chatId: string | undefined = data?.chat_id;
-      if (chatId) invalidateChatStatsForAllLocalBots(chatId);
+      if (chatId) invalidateChatStats(larkAppId, chatId);
     },
     'im.chat.member.user.added_v1': (data: any) => {
       const chatId: string | undefined = data?.chat_id;

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -776,6 +776,29 @@ export function invalidateChatStats(larkAppId: string, chatId: string): void {
   }
 }
 
+/**
+ * Invalidate group stats for the chat across EVERY locally-hosted bot.
+ *
+ * 飞书 `im.chat.member.bot.added/deleted_v1` 只推给「进群/被移出的那个 bot 自己
+ * 的 app」,同群其他存量 bot 收不到——单 bot 失效对「拉了另一个 bot 进群」无效。
+ * 但本 daemon 单进程托管全 fleet 且 chatStatsCache 是进程级共享的:任一本地
+ * bot 收到自己的 bot.added/deleted 事件时,顺势清掉该群在所有本地 bot app
+ * 视角下的缓存条目,fleet 内互相失效即告成立。
+ *
+ * 边界:拉进群的是【非本 daemon 的第三方 bot】时没有任何事件信号可达,该方向
+ * 只能靠 relax 末条款的 mentionsAnotherMember 守卫 + TTL 兜底(见 relax 注释)。
+ */
+export function invalidateChatStatsForAllLocalBots(chatId: string): void {
+  let cleared = 0;
+  for (const b of getAllBots()) {
+    const appId = b?.config?.larkAppId;
+    if (appId && chatStatsCache.delete(`${appId}:${chatId}`)) cleared++;
+  }
+  if (cleared > 0) {
+    logger.debug(`[group-stats] invalidated cached stats for ${chatId} across ${cleared} local bot(s): bot membership changed`);
+  }
+}
+
 /** Test-only: clear the group-stats cache between cases. */
 export function __resetChatStatsForTest(): void {
   chatStatsCache.clear();
@@ -2993,9 +3016,13 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
       const chatIdForKey: string | undefined = data?.chat_id;
       const operatorForKey: string | undefined = data?.operator_id?.open_id;
       const eventKey = `im.chat.member.bot.added_v1:${larkAppId}:${eventIdForKey(data) ?? `${chatIdForKey ?? 'unknown'}:${operatorForKey ?? 'unknown'}`}`;
-      // 无论是本 bot 还是别的 bot 被拉进群，bot_count 都变了——先同步失效
-      // group-stats 缓存,让 1v1 放行在下一条消息就用新鲜人数,不等 TTL。
-      if (chatIdForKey) invalidateChatStats(larkAppId, chatIdForKey);
+      // 飞书只把 bot.added 推给「进群的那个 bot 自己的 app」——同群存量 bot 无
+      // 事件可收。因此这里必须扇出到 fleet 全 bot 视角对群缓存（缓存进程级共享）：
+      // 收到的是自己 fleet 内某个 bot 的进群,就把该群在所有本地 bot app 下的
+      // group-stats 条目一起清掉,让 1v1 放行在下一条消息就用 fresh 人数。
+      // 非 fleet 三方 bot 进群永远拿不到此事件,那方向靠 relax 末条款的
+      // mentionsAnotherMember 守卫 + TTL 兜底,不靠这里。
+      if (chatIdForKey) invalidateChatStatsForAllLocalBots(chatIdForKey);
       scheduleAckSafeEvent(eventKey, async () => {
       try {
         const chatId: string | undefined = data?.chat_id;
@@ -3008,14 +3035,13 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
       }
       }, 'bot-added event');
     },
-    // 成员数变化的其余事件同样只做一件事：失效 group-stats 缓存（见
-    // invalidateChatStats 注释）。纯本地 map 删除,同步处理、即时 ACK,
-    // 不进 scheduleAckSafeEvent 的 work 队列;去重也不必要——失效是幂等的,
-    // 重推只是多删一次不存在的 key。bot.deleted 早已在基线订阅列表里,
-    // user.added/deleted 属尽力而为的可选订阅（老应用可能没订阅,靠 TTL 兜底）。
+    // bot 被移出群（只推给被移出的 bot 自己的 app）=> 同样扇出失效 fleet 全视角。
+    // user.added/deleted_v1 则推给群内已订阅的所有 bot app,每个 bot 自己的 WS
+    // 都收到,只清自己那条即可。纯本地 map 删除,同步处理、即时 ACK,不进
+    // scheduleAckSafeEvent 的 work 队列;去重也不必要——失效是幂等的。
     'im.chat.member.bot.deleted_v1': (data: any) => {
       const chatId: string | undefined = data?.chat_id;
-      if (chatId) invalidateChatStats(larkAppId, chatId);
+      if (chatId) invalidateChatStatsForAllLocalBots(chatId);
     },
     'im.chat.member.user.added_v1': (data: any) => {
       const chatId: string | undefined = data?.chat_id;

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -763,6 +763,24 @@ export async function getGroupStats(larkAppId: string, chatId: string): Promise<
   }
 }
 
+/**
+ * Drop the cached group stats for one chat — called when a membership-change
+ * event arrives, so the 1v1 relax gate sees fresh counts on the very next
+ * message instead of coasting on stale numbers for up to CHAT_CACHE_TTL.
+ * Without this, "拉了新 bot 进 1V1 群" 后最多 5 分钟内老 bot 仍把群当成 solo,
+ * 对不 @ 自己的消息继续应答。TTL 继续保留,作为事件未订阅（老应用）时的兜底。
+ */
+export function invalidateChatStats(larkAppId: string, chatId: string): void {
+  if (chatStatsCache.delete(`${larkAppId}:${chatId}`)) {
+    logger.debug(`[group-stats] invalidated cached stats for ${chatId} (${larkAppId}): membership changed`);
+  }
+}
+
+/** Test-only: clear the group-stats cache between cases. */
+export function __resetChatStatsForTest(): void {
+  chatStatsCache.clear();
+}
+
 // ─── Cross-bot open_id mapping ──────────────────────────────────────────
 //
 // Lark open_id is per-app scoped: Bot A sees a different open_id for Bot B
@@ -1419,7 +1437,13 @@ export async function checkGroupMessageAccess(
   // No @mention — only allow if sender is the sole human in the group
   // AND this is the only bot in the chat. With multiple bots, require @mention
   // to disambiguate.
-  if (isAllowed) {
+  //
+  // 若消息 @ 了别的具体成员（mentionsAnotherMember），群必然不是 1人1bot——
+  // 只有群成员能被 @，多出的那个 @ 本身就是人数变化的证据。上游可能还抱着
+  // 陈旧缓存 {1,1}（刚拉了新 bot 的 TTL 窗口），这会直接跳过人数查询落到
+  // 'ignore'，挡住「用户 @ 新 bot、老 bot 跟着回复」。群聊 @ 策略 never/ambient
+  // 在调用方（relax 条款）已先行结算，这里不受影响。
+  if (isAllowed && !mentionsAnotherMember(larkAppId, message)) {
     const { userCount, botCount } = await getGroupStats(larkAppId, chatId);
     logger.debug(`Group user count: ${userCount}, bot count: ${botCount}`);
     if (userCount <= 1 && botCount <= 1) {
@@ -2764,8 +2788,16 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
       //   !ownsSession (group)    → require @mention + allowlist
       //   p2p                     → allowlist only
       if (chatType === 'group') {
+        const mentionMode = resolveGroupMentionMode(larkAppId);
+        // 消息里 @ 了别的具体成员,就已经证明群不是 1人1bot（只有群成员能被 @）——
+        // 此刻末条 solo 放行必然不成立,而 stats 只被末条消费,直接跳过这次（可能
+        // 昂贵的）人数查询。这在「刚拉了新 bot、用户 @ 新 bot」窗口里尤为重要：
+        // 拦截老 bot 的同时不再为它反复刷新陈旧缓存。
+        const mentionsOther = mentionsAnotherMember(larkAppId, message);
         let stats: { userCount: number; botCount: number } | null = null;
-        if (ownsSession && !replyRootId) stats = await getGroupStats(larkAppId, chatId);
+        if (ownsSession && !replyRootId && !mentionsOther && mentionMode !== 'never') {
+          stats = await getGroupStats(larkAppId, chatId);
+        }
         // replyRootId means this turn has already been explicitly addressed
         // to the bot by shared-topic logic (possibly from inside an existing
         // Lark thread). Do not re-run the generic group @ gate, which would
@@ -2790,8 +2822,8 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
         //     treat it as a hand-off and stay quiet.
         // Both gated on isAllowed so restricted groups still only react to
         // permitted senders. (The shared fold-back's replyRootId is already
-        // handled by the first clause.)
-        const mentionMode = resolveGroupMentionMode(larkAppId);
+        // handled by the first clause. `mentionMode` 已在块首解析,用于 stats
+        // 惰性获取。)
         // 话题群 owned-topic 免@续话不再无条件放行（#336 引入的默认行为回归：
         // 多人群里旁人不 @ 也会触发 bot）。现在与普通群共用同一套「群聊 @ 策略」:
         // 默认 'always' 在多人群里必须 @，想要话题内免@续话就把 mentionMode 配成
@@ -2800,12 +2832,16 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
         // 注：pairedForwardSeed 仅在 never/ambient 模式下产生，且 ambient redirect
         // 已在配对前排除，故 isAllowed=true 时下方 never/ambient 条款必然放行；
         // 不在此单独加 clause，以免 isAllowed=false 时绕过权限检查。
+        // 末条 solo 放行另有 `!mentionsOther` 守卫：消息 @ 了别的具体成员时,
+        // 群必然不是 1人1bot（只有群成员能被 @），且是指给别人的——拦住「刚拉新 bot、
+        // 缓存仍是陈旧 {1,1} 时老 bot 跟着回复」的误放行。never 条款在前已短路,
+        // 故该守卫不影响「群聊 @ 策略」配置的 never 语义。
         const relax = (!!replyRootId && isAllowed)
           || (!!substituteTrigger && isAllowed)
           || (isAllowed && mentionMode === 'never')
-          || (isAllowed && mentionMode === 'ambient' && !mentionsAnotherMember(larkAppId, message))
-          || (isAllowed && mentionMode === 'topic' && ownsSession && !!message.thread_id && !mentionsAnotherMember(larkAppId, message))
-          || (ownsSession && isAllowed && !!stats && stats.userCount <= 1 && stats.botCount <= 1);
+          || (isAllowed && mentionMode === 'ambient' && !mentionsOther)
+          || (isAllowed && mentionMode === 'topic' && ownsSession && !!message.thread_id && !mentionsOther)
+          || (ownsSession && isAllowed && !!stats && !mentionsOther && stats.userCount <= 1 && stats.botCount <= 1);
         if (!relax) {
           const access = await checkGroupMessageAccess(larkAppId, message, chatId, senderOpenId, humanSenderUnionId);
           if (access === 'not_allowed') {
@@ -2957,6 +2993,9 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
       const chatIdForKey: string | undefined = data?.chat_id;
       const operatorForKey: string | undefined = data?.operator_id?.open_id;
       const eventKey = `im.chat.member.bot.added_v1:${larkAppId}:${eventIdForKey(data) ?? `${chatIdForKey ?? 'unknown'}:${operatorForKey ?? 'unknown'}`}`;
+      // 无论是本 bot 还是别的 bot 被拉进群，bot_count 都变了——先同步失效
+      // group-stats 缓存,让 1v1 放行在下一条消息就用新鲜人数,不等 TTL。
+      if (chatIdForKey) invalidateChatStats(larkAppId, chatIdForKey);
       scheduleAckSafeEvent(eventKey, async () => {
       try {
         const chatId: string | undefined = data?.chat_id;
@@ -2968,6 +3007,23 @@ export function startLarkEventDispatcher(larkAppId: string, larkAppSecret: strin
         logger.error(`Error handling bot-added event: ${err}`);
       }
       }, 'bot-added event');
+    },
+    // 成员数变化的其余事件同样只做一件事：失效 group-stats 缓存（见
+    // invalidateChatStats 注释）。纯本地 map 删除,同步处理、即时 ACK,
+    // 不进 scheduleAckSafeEvent 的 work 队列;去重也不必要——失效是幂等的,
+    // 重推只是多删一次不存在的 key。bot.deleted 早已在基线订阅列表里,
+    // user.added/deleted 属尽力而为的可选订阅（老应用可能没订阅,靠 TTL 兜底）。
+    'im.chat.member.bot.deleted_v1': (data: any) => {
+      const chatId: string | undefined = data?.chat_id;
+      if (chatId) invalidateChatStats(larkAppId, chatId);
+    },
+    'im.chat.member.user.added_v1': (data: any) => {
+      const chatId: string | undefined = data?.chat_id;
+      if (chatId) invalidateChatStats(larkAppId, chatId);
+    },
+    'im.chat.member.user.deleted_v1': (data: any) => {
+      const chatId: string | undefined = data?.chat_id;
+      if (chatId) invalidateChatStats(larkAppId, chatId);
     },
     // 文档评论入口（/watch-comment / /subscribe-lark-doc）。notice 事件主要覆盖 @Bot
     // 通知；普通评论由 daemon 应用身份轮询补齐，不依赖逐文件 subscribe API。

--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -29,6 +29,19 @@ export const BOT_BASELINE_APP_EVENTS = [
   'im.message.reaction.deleted_v1',
 ] as const;
 
+/**
+ * Best-effort app events: subscribed alongside the baseline but NEVER part of
+ * the fail-closed verification (missingBaselineEvents / MANAGED_VERIFIED_EVENT_COUNT).
+ * Used for enhancements that degrade gracefully when unsubscribed — membership
+ * change events only drive chatStatsCache invalidation, whose 5-min TTL is the
+ * documented fallback. Some tenants cannot grant the underlying member-read
+ * scopes for user events; hard-requiring them would block bot onboarding.
+ */
+export const BOT_OPTIONAL_APP_EVENTS = [
+  'im.chat.member.user.added_v1',
+  'im.chat.member.user.deleted_v1',
+] as const;
+
 /** 缺了它 daemon 完全收不到消息——回读确认失败时整个自动配置 fail-closed。 */
 export const BOT_CRITICAL_APP_EVENTS = ['im.message.receive_v1'] as const;
 
@@ -762,7 +775,7 @@ export async function automateOpenPlatformSetup(
     eventWarnings.push(`读取当前事件订阅失败: ${safeErrorMessage(err)}`);
   }
   const hasEvent = (name: string) => Boolean(eventState?.events.includes(name));
-  const wantedAppEvents = [...BOT_BASELINE_APP_EVENTS, ...VC_MEETING_APP_EVENTS];
+  const wantedAppEvents = [...BOT_BASELINE_APP_EVENTS, ...BOT_OPTIONAL_APP_EVENTS, ...VC_MEETING_APP_EVENTS];
   const missingAppEvents = wantedAppEvents.filter(name => !hasEvent(name));
   const missingUserEvents = VC_MEETING_USER_EVENTS.filter(name => !hasEvent(name));
   if (missingAppEvents.length > 0 || missingUserEvents.length > 0) {
@@ -775,7 +788,8 @@ export async function automateOpenPlatformSetup(
         try {
           await addEvents([name], [], eventMode);
         } catch (err: any) {
-          eventWarnings.push(`订阅事件 ${name} 失败: ${safeErrorMessage(err)}`);
+          const optional = (BOT_OPTIONAL_APP_EVENTS as readonly string[]).includes(name) ? '（可选事件, 不影响核心功能）' : '';
+          eventWarnings.push(`订阅事件 ${name} 失败${optional}: ${safeErrorMessage(err)}`);
         }
       }
       for (const name of missingUserEvents) {

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -134,7 +134,7 @@ vi.mock('@larksuiteoapi/node-sdk', () => {
 // ─── Imports (must be after mocks) ──────────────────────────────────────────
 
 import { __resetAnchorQueues } from '../src/utils/anchor-serializer.js';
-import { __resetEventClaimsForTest, __resetChatStatsForTest, canOperate, canTalk, decideRouting, ensureBotOpenId, getGroupStats, isBotMentioned, mentionsAnotherMember, markForwardFollowupsSessionsReady, startLarkEventDispatcher, writeBotInfoFile, type EventHandlers } from '../src/im/lark/event-dispatcher.js';
+import { __resetEventClaimsForTest, __resetChatStatsForTest, canOperate, canTalk, decideRouting, ensureBotOpenId, isBotMentioned, mentionsAnotherMember, markForwardFollowupsSessionsReady, startLarkEventDispatcher, writeBotInfoFile, type EventHandlers } from '../src/im/lark/event-dispatcher.js';
 import {
   VC_BOT_MEETING_ACTIVITY_EVENT,
   VC_BOT_MEETING_ENDED_EVENT,
@@ -6562,12 +6562,12 @@ describe('1v1 陈旧缓存守门 — 拉新 bot 后 @ 新 bot 时老 bot 不跟�
   // 守卫)+②(成员变更事件驱动 invalidateChatStats)共同把窗口压到事件投递秒级,
   // 且①只影响 never 之外的策略——never 语义由前序条款先行结算,必须原样保留。
   //
-  // ②的投递边界（codex 复审证实,见 PR #691 review）:im.chat.member.bot.added/
-  // deleted_v1 只推给「进群/被移出的那个 bot 自己的 app」,存量 bot 无事件可收;
-  // 因此 bot 事件的处理按 fleet 扇出——单 daemon 进程级共享缓存,任一本地 bot
-  // 收到自己的事件就清同群所有本地 bot 的条目。user.added/deleted_v1 则广播给
-  // 群内所有已订阅 bot,各自清自己那条。非 fleet 三方 bot 进群无任何信号,
-  // 靠①守卫 + TTL 兜底。
+  // ②的投递+部署边界（codex 两轮复审证实,见 PR #691 review）:
+  // im.chat.member.bot.added/deleted_v1 只推给「进群/被移出的那个 bot 自己的
+  // app」,且生产是 PM2 一 bot 一 daemon 进程、chatStatsCache 进程内——bot 事件
+  // 只能清自己的 key(覆盖「本 bot 被移出又拉回」类自身残留)。user.added/
+  // deleted_v1 广播给群内所有已订阅 bot,各自清自己那条。「别的 bot 进群/离群
+  // →本 bot 陈旧」无事件信号且跨进程,靠①守卫 + TTL 兜底。
   let handlers: ReturnType<typeof makeHandlers>;
 
   const CHAT = 'chat-stale-1v1';
@@ -6656,17 +6656,12 @@ describe('1v1 陈旧缓存守门 — 拉新 bot 后 @ 新 bot 时老 bot 不跟�
   it.each([
     'im.chat.member.bot.added_v1',
     'im.chat.member.bot.deleted_v1',
-  ] as const)('② %s 扇出失效:fleet 某 bot 收到自己的事件后,同群本地全 bot 条目一并失效', async (eventName) => {
-    // 真实投递语义:bot.added/deleted 只推给「进群/被移出的那个 bot 自己的 app」,
-    // 存量 bot 永远收不到。修复靠单 daemon 进程级共享缓存:任一本地 bot 收到自己
-    // 的事件,就按 getAllBots() 枚举把该群在所有本地 bot app 下的条目一起清掉。
-    // 单测里用已捕获 handler 触发,等效于 fleet 内任一 bot 的 dispatcher 收事件——
-    // 扇出路径不依赖 handler 闭包的 larkAppId,而是纯枚举,这就是被测对象。
-    mockGetAllBots.mockReturnValue([
-      { config: { larkAppId: MY_APP_ID } },
-      { config: { larkAppId: OTHER_BOT_APP_ID } },
-    ] as any);
-    startStaleOwnedGroup(); // 首次判定后缓存 MY_APP_ID 视角的 {1,1}
+  ] as const)('② %s 只清本 bot 自己的 key(生产=一 bot 一 daemon,够不到兄弟进程)', async (eventName) => {
+    // 真实投递+部署语义(codex 两轮复审证实):bot.added/deleted 只推给当事 bot
+    // 自己的 app;且生产 PM2 一 bot 一 daemon 进程,chatStatsCache 进程内——
+    // 事件到达时只能清自己的 key。覆盖增量=本 bot 被移出又拉回等「自己的条目
+    // 跨上轮残留」场景;「别的 bot 进群→本 bot 陈旧」方向无事件,靠①+TTL。
+    startStaleOwnedGroup(); // 首次判定后缓存本 bot 视角的 {1,1}
 
     await capturedHandlers['im.message.receive_v1'](makeUserMessageEvent({
       senderOpenId: USER_OPEN_ID,
@@ -6679,19 +6674,9 @@ describe('1v1 陈旧缓存守门 — 拉新 bot 后 @ 新 bot 时老 bot 不跟�
     expect(handlers.handleThreadReply).toHaveBeenCalledTimes(1);
     expect(mockGetChatInfo).toHaveBeenCalledTimes(1);
 
-    // 也给同群另一个本地 bot app(OTHER_BOT_APP_ID)塞一条 {1,1} 陈旧条目——
-    // 这是「同群存量 bot」在缓存里的实际存在形式,扇出必须连它一起清掉。
-    await getGroupStats(OTHER_BOT_APP_ID, CHAT);
-    expect(mockGetChatInfo).toHaveBeenCalledTimes(2);
-
     capturedHandlers[eventName]({ chat_id: CHAT, operator_id: { open_id: USER_OPEN_ID } });
-    // 飞书侧真实人数变化(新 bot 进群 / 某 bot 离开,现在同群另一 bot 视角):
+    // 飞书侧人数变化(以本 bot 被拉回后真实形态为例):
     mockGetChatInfo.mockResolvedValue({ userCount: 1, botCount: 2 });
-
-    // 扇出牙齿①:另一 bot app 的条目也必须被清——若失效退化成只清自己的 key,
-    // 这次读取会命中 B 的陈旧缓存、不发查询(总次数停在 3 而非 4)。
-    await getGroupStats(OTHER_BOT_APP_ID, CHAT);
-    expect(mockGetChatInfo).toHaveBeenCalledTimes(3);
 
     await capturedHandlers['im.message.receive_v1'](makeUserMessageEvent({
       senderOpenId: USER_OPEN_ID,
@@ -6702,11 +6687,10 @@ describe('1v1 陈旧缓存守门 — 拉新 bot 后 @ 新 bot 时老 bot 不跟�
     }));
     await flushEventWork();
 
-    // 扇出牙齿②:本 bot 条目同样被清→重查→{1,2}→不再按 solo 放行;
-    // 失效退化成 no-op 时这里会命中陈旧 {1,1} 继续回复。
+    // 失效→重查→{1,2}→不再按 solo 放行;失效退化成 no-op 会命中陈旧 {1,1} 续放。
     expect(handlers.handleThreadReply).toHaveBeenCalledTimes(1);
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
-    expect(mockGetChatInfo).toHaveBeenCalledTimes(4);
+    expect(mockGetChatInfo).toHaveBeenCalledTimes(2);
   });
 
   it.each([
@@ -6745,10 +6729,6 @@ describe('1v1 陈旧缓存守门 — 拉新 bot 后 @ 新 bot 时老 bot 不跟�
   });
 
   it('② 发在别的群的成员事件不误伤本群缓存（按 larkAppId:chatId 精确失效）', async () => {
-    mockGetAllBots.mockReturnValue([
-      { config: { larkAppId: MY_APP_ID } },
-      { config: { larkAppId: OTHER_BOT_APP_ID } },
-    ] as any);
     startStaleOwnedGroup();
 
     await capturedHandlers['im.message.receive_v1'](makeUserMessageEvent({

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -6559,8 +6559,10 @@ describe('1v1 陈旧缓存守门 — 拉新 bot 后 @ 新 bot 时老 bot 不跟�
   // 复现并钉住生产投诉:原 1人1bot 群被拉进第二个 bot 后,旧 bot 的
   // group-stats 缓存仍是 {1,1}（TTL 5min 内）。此刻用户 @ 新 bot,
   // 旧 bot 误按 solo 放行 → 跟着回复。修复①(solo 判定加 mentionsAnotherMember
-  // 守卫)+②(成员变更事件驱动 invalidateChatStats)共同把窗口压到事件投递秒级,
-  // 且①只影响 never 之外的策略——never 语义由前序条款先行结算,必须原样保留。
+  // 守卫)在消息到达当下立即拦死该投诉路径;②(成员变更事件驱动
+  // invalidateChatStats)只负责把「有人进/出群、本 bot 被移出又拉回」这些
+  // 事件可见方向的纯文本窗口也压到秒级——别的 bot 进群方向无事件(见下),
+  // 靠①+TTL。①只影响 never 之外的策略:never 语义由前序条款先行结算。
   //
   // ②的投递+部署边界（codex 两轮复审证实,见 PR #691 review）:
   // im.chat.member.bot.added/deleted_v1 只推给「进群/被移出的那个 bot 自己的

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -134,7 +134,7 @@ vi.mock('@larksuiteoapi/node-sdk', () => {
 // ─── Imports (must be after mocks) ──────────────────────────────────────────
 
 import { __resetAnchorQueues } from '../src/utils/anchor-serializer.js';
-import { __resetEventClaimsForTest, canOperate, canTalk, decideRouting, ensureBotOpenId, isBotMentioned, mentionsAnotherMember, markForwardFollowupsSessionsReady, startLarkEventDispatcher, writeBotInfoFile, type EventHandlers } from '../src/im/lark/event-dispatcher.js';
+import { __resetEventClaimsForTest, __resetChatStatsForTest, canOperate, canTalk, decideRouting, ensureBotOpenId, isBotMentioned, mentionsAnotherMember, markForwardFollowupsSessionsReady, startLarkEventDispatcher, writeBotInfoFile, type EventHandlers } from '../src/im/lark/event-dispatcher.js';
 import {
   VC_BOT_MEETING_ACTIVITY_EVENT,
   VC_BOT_MEETING_ENDED_EVENT,
@@ -6552,5 +6552,203 @@ describe('startLarkEventDispatcher — 长连接死后自愈 (reconnect-exhauste
     expect(ws.start).toHaveBeenCalledTimes(1);
 
     vi.useRealTimers();
+  });
+});
+
+describe('1v1 陈旧缓存守门 — 拉新 bot 后 @ 新 bot 时老 bot 不跟回', () => {
+  // 复现并钉住生产投诉:原 1人1bot 群被拉进第二个 bot 后,旧 bot 的
+  // group-stats 缓存仍是 {1,1}（TTL 5min 内）。此刻用户 @ 新 bot,
+  // 旧 bot 误按 solo 放行 → 跟着回复。修复①(solo 判定加 mentionsAnotherMember
+  // 守卫)+②(成员变更事件驱动 invalidateChatStats)共同把窗口压到事件投递秒级,
+  // 且①只影响 never 之外的策略——never 语义由前序条款先行结算,必须原样保留。
+  let handlers: ReturnType<typeof makeHandlers>;
+
+  const CHAT = 'chat-stale-1v1';
+
+  function startStaleOwnedGroup(mentionMode?: 'always' | 'topic' | 'never' | 'ambient') {
+    setupBotState({ allowedUsers: [USER_OPEN_ID], ...(mentionMode ? { regularGroupMentionMode: mentionMode } : {}) });
+    mockGetChatMode.mockResolvedValue('group');
+    // 陈旧现场:真实群已是 1人2bot,但这些调用方拿到的还是 TTL 内的老值。
+    mockGetChatInfo.mockResolvedValue({ userCount: 1, botCount: 1 });
+    handlers.resolveReplyThreadAlias.mockReturnValue(null);
+    handlers.isSessionOwner.mockImplementation((anchor: string) => anchor === CHAT);
+    startLarkEventDispatcher(MY_APP_ID, 'secret', handlers);
+  }
+
+  function atOtherBotEvent(messageId: string, senderOpenId = USER_OPEN_ID) {
+    return makeUserMessageEvent({
+      senderOpenId,
+      content: JSON.stringify({ text: '@BotB 帮我看一下这个问题' }),
+      mentions: [{ key: '@_bot_b', name: 'BotB', id: { open_id: OTHER_BOT_OPEN_ID } }],
+      messageId,
+      chatId: CHAT,
+      chatType: 'group',
+    });
+  }
+
+  beforeEach(() => {
+    capturedHandlers = {};
+    __resetAnchorQueues();
+    __resetEventClaimsForTest();
+    __resetChatStatsForTest();
+    _resetGrantPending();
+    handlers = makeHandlers();
+    mockFindOncallChat.mockReturnValue(undefined);
+    // 本组用例必须亲自摆出陈旧 {1,1};beforeEach 全局默认 {3,1} 不能泄漏进来。
+    mockGetChatInfo.mockReset();
+  });
+
+  it('① 默认 always + 陈旧 {1,1}:@ 别的 bot 时老 bot 静默（ownsSession 也不会触发 solo 放行）', async () => {
+    startStaleOwnedGroup();
+    await capturedHandlers['im.message.receive_v1'](atOtherBotEvent('msg-at-newbot-1'));
+    await flushEventWork();
+
+    expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+    // @ 了别人时 solo 不可能成立,连人数查询都该省掉(顺带避免顺手刷新陈旧缓存)。
+    expect(mockGetChatInfo).not.toHaveBeenCalled();
+  });
+
+  it('① 无会话路径（checkGroupMessageAccess）:@ 别的 bot 同样不被陈旧 {1,1} 误放行', async () => {
+    startStaleOwnedGroup();
+    handlers.isSessionOwner.mockReturnValue(false); // 老 bot 在此群还没有会话
+
+    // 第一条纯文本:真·1v1 时代的老 bot 会直接开工（此调用把 {1,1} 写入缓存）。
+    await capturedHandlers['im.message.receive_v1'](makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'hi bot' }),
+      messageId: 'msg-plain-opens-1',
+      chatId: CHAT,
+      chatType: 'group',
+    }));
+    await flushEventWork();
+    expect(handlers.handleNewTopic).toHaveBeenCalledTimes(1);
+
+    // 拉了新 bot 之后(CLI 侧这里仍是同一老缓存 key),用户 @ 新 bot:
+    await capturedHandlers['im.message.receive_v1'](atOtherBotEvent('msg-at-newbot-2'));
+    await flushEventWork();
+    expect(handlers.handleNewTopic).toHaveBeenCalledTimes(1); // 没有第二次放行
+    expect(handlers.handleThreadReply).not.toHaveBeenCalled();
+    // @ 了别人时连人数查询都省掉——getChatInfo 全程只在第一条真·solo 消息时调过一次。
+    expect(mockGetChatInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it('① 遵循 dashboard「群聊 @ 策略」:never 模式下 @ 别的 bot 依旧应答', async () => {
+    startStaleOwnedGroup('never');
+    await capturedHandlers['im.message.receive_v1'](atOtherBotEvent('msg-at-newbot-never'));
+    await flushEventWork();
+
+    expect(handlers.handleThreadReply).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      anchor: CHAT,
+      larkAppId: MY_APP_ID,
+    }));
+    // never 语义不依赖人数:根本不发起 stats 查询。
+    expect(mockGetChatInfo).not.toHaveBeenCalled();
+  });
+
+  it('② bot.added 事件让陈旧 {1,1} 立刻失效:下一条纯文本消息按新鲜人数判定', async () => {
+    startStaleOwnedGroup(); // 首次判定后缓存 {1,1}(模拟拉新 bot 前的热缓存)
+
+    await capturedHandlers['im.message.receive_v1'](makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'continue please' }),
+      messageId: 'msg-before-add',
+      chatId: CHAT,
+      chatType: 'group',
+    }));
+    await flushEventWork();
+    expect(handlers.handleThreadReply).toHaveBeenCalledTimes(1); // 真·1v1 时代放行
+    expect(mockGetChatInfo).toHaveBeenCalledTimes(1);
+
+    // 用户把第二个 bot 拉进群 —— 事件到达老 bot 的 dispatcher:
+    capturedHandlers['im.chat.member.bot.added_v1']({
+      chat_id: CHAT,
+      operator_id: { open_id: USER_OPEN_ID },
+    });
+    // 飞书侧真实人数变化:
+    mockGetChatInfo.mockResolvedValue({ userCount: 1, botCount: 2 });
+
+    await capturedHandlers['im.message.receive_v1'](makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'another plain message' }),
+      messageId: 'msg-after-add',
+      chatId: CHAT,
+      chatType: 'group',
+    }));
+    await flushEventWork();
+
+    // 失效→重查→{1,2}→不再按 solo 放行;没有失效的话会命中陈旧 {1,1} 继续回复。
+    expect(handlers.handleThreadReply).toHaveBeenCalledTimes(1);
+    expect(handlers.handleNewTopic).not.toHaveBeenCalled();
+    expect(mockGetChatInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    'im.chat.member.bot.deleted_v1',
+    'im.chat.member.user.added_v1',
+    'im.chat.member.user.deleted_v1',
+  ] as const)('② %s 事件同样失效 group-stats 缓存', async (eventName) => {
+    // fresh 值只需满足「非 solo」来证明判定用了新数,不必模拟各事件的真实增减方向。
+    const freshStats = { userCount: 2, botCount: 1 };
+    startStaleOwnedGroup();
+
+    await capturedHandlers['im.message.receive_v1'](makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'seed the cache' }),
+      messageId: `msg-seed-${eventName}`,
+      chatId: CHAT,
+      chatType: 'group',
+    }));
+    await flushEventWork();
+    expect(handlers.handleThreadReply).toHaveBeenCalledTimes(1);
+
+    expect(capturedHandlers[eventName]).toBeTypeOf('function');
+    capturedHandlers[eventName]({ chat_id: CHAT, operator_id: { open_id: USER_OPEN_ID } });
+    mockGetChatInfo.mockResolvedValue(freshStats);
+
+    await capturedHandlers['im.message.receive_v1'](makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'post-change plain text' }),
+      messageId: `msg-post-${eventName}`,
+      chatId: CHAT,
+      chatType: 'group',
+    }));
+    await flushEventWork();
+
+    expect(handlers.handleThreadReply).toHaveBeenCalledTimes(1);
+    expect(mockGetChatInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it('② 发在别的群的成员事件不误伤本群缓存（按 larkAppId:chatId 精确失效）', async () => {
+    startStaleOwnedGroup();
+
+    await capturedHandlers['im.message.receive_v1'](makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'seed' }),
+      messageId: 'msg-seed-otherchat',
+      chatId: CHAT,
+      chatType: 'group',
+    }));
+    await flushEventWork();
+    expect(handlers.handleThreadReply).toHaveBeenCalledTimes(1);
+
+    // 别的群加了 bot —— 只清那个群的缓存:
+    capturedHandlers['im.chat.member.bot.added_v1']({
+      chat_id: 'chat-unrelated',
+      operator_id: { open_id: USER_OPEN_ID },
+    });
+
+    await capturedHandlers['im.message.receive_v1'](makeUserMessageEvent({
+      senderOpenId: USER_OPEN_ID,
+      content: JSON.stringify({ text: 'still 1v1 here' }),
+      messageId: 'msg-after-otherchat',
+      chatId: CHAT,
+      chatType: 'group',
+    }));
+    await flushEventWork();
+
+    // 本群缓存命中(没有多余重查),仍按 1v1 放行。
+    expect(handlers.handleThreadReply).toHaveBeenCalledTimes(2);
+    expect(mockGetChatInfo).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/event-dispatcher.test.ts
+++ b/test/event-dispatcher.test.ts
@@ -134,7 +134,7 @@ vi.mock('@larksuiteoapi/node-sdk', () => {
 // ─── Imports (must be after mocks) ──────────────────────────────────────────
 
 import { __resetAnchorQueues } from '../src/utils/anchor-serializer.js';
-import { __resetEventClaimsForTest, __resetChatStatsForTest, canOperate, canTalk, decideRouting, ensureBotOpenId, isBotMentioned, mentionsAnotherMember, markForwardFollowupsSessionsReady, startLarkEventDispatcher, writeBotInfoFile, type EventHandlers } from '../src/im/lark/event-dispatcher.js';
+import { __resetEventClaimsForTest, __resetChatStatsForTest, canOperate, canTalk, decideRouting, ensureBotOpenId, getGroupStats, isBotMentioned, mentionsAnotherMember, markForwardFollowupsSessionsReady, startLarkEventDispatcher, writeBotInfoFile, type EventHandlers } from '../src/im/lark/event-dispatcher.js';
 import {
   VC_BOT_MEETING_ACTIVITY_EVENT,
   VC_BOT_MEETING_ENDED_EVENT,
@@ -6561,6 +6561,13 @@ describe('1v1 陈旧缓存守门 — 拉新 bot 后 @ 新 bot 时老 bot 不跟�
   // 旧 bot 误按 solo 放行 → 跟着回复。修复①(solo 判定加 mentionsAnotherMember
   // 守卫)+②(成员变更事件驱动 invalidateChatStats)共同把窗口压到事件投递秒级,
   // 且①只影响 never 之外的策略——never 语义由前序条款先行结算,必须原样保留。
+  //
+  // ②的投递边界（codex 复审证实,见 PR #691 review）:im.chat.member.bot.added/
+  // deleted_v1 只推给「进群/被移出的那个 bot 自己的 app」,存量 bot 无事件可收;
+  // 因此 bot 事件的处理按 fleet 扇出——单 daemon 进程级共享缓存,任一本地 bot
+  // 收到自己的事件就清同群所有本地 bot 的条目。user.added/deleted_v1 则广播给
+  // 群内所有已订阅 bot,各自清自己那条。非 fleet 三方 bot 进群无任何信号,
+  // 靠①守卫 + TTL 兜底。
   let handlers: ReturnType<typeof makeHandlers>;
 
   const CHAT = 'chat-stale-1v1';
@@ -6646,48 +6653,66 @@ describe('1v1 陈旧缓存守门 — 拉新 bot 后 @ 新 bot 时老 bot 不跟�
     expect(mockGetChatInfo).not.toHaveBeenCalled();
   });
 
-  it('② bot.added 事件让陈旧 {1,1} 立刻失效:下一条纯文本消息按新鲜人数判定', async () => {
-    startStaleOwnedGroup(); // 首次判定后缓存 {1,1}(模拟拉新 bot 前的热缓存)
+  it.each([
+    'im.chat.member.bot.added_v1',
+    'im.chat.member.bot.deleted_v1',
+  ] as const)('② %s 扇出失效:fleet 某 bot 收到自己的事件后,同群本地全 bot 条目一并失效', async (eventName) => {
+    // 真实投递语义:bot.added/deleted 只推给「进群/被移出的那个 bot 自己的 app」,
+    // 存量 bot 永远收不到。修复靠单 daemon 进程级共享缓存:任一本地 bot 收到自己
+    // 的事件,就按 getAllBots() 枚举把该群在所有本地 bot app 下的条目一起清掉。
+    // 单测里用已捕获 handler 触发,等效于 fleet 内任一 bot 的 dispatcher 收事件——
+    // 扇出路径不依赖 handler 闭包的 larkAppId,而是纯枚举,这就是被测对象。
+    mockGetAllBots.mockReturnValue([
+      { config: { larkAppId: MY_APP_ID } },
+      { config: { larkAppId: OTHER_BOT_APP_ID } },
+    ] as any);
+    startStaleOwnedGroup(); // 首次判定后缓存 MY_APP_ID 视角的 {1,1}
 
     await capturedHandlers['im.message.receive_v1'](makeUserMessageEvent({
       senderOpenId: USER_OPEN_ID,
-      content: JSON.stringify({ text: 'continue please' }),
-      messageId: 'msg-before-add',
+      content: JSON.stringify({ text: 'seed the cache' }),
+      messageId: `msg-seed-${eventName}`,
       chatId: CHAT,
       chatType: 'group',
     }));
     await flushEventWork();
-    expect(handlers.handleThreadReply).toHaveBeenCalledTimes(1); // 真·1v1 时代放行
+    expect(handlers.handleThreadReply).toHaveBeenCalledTimes(1);
     expect(mockGetChatInfo).toHaveBeenCalledTimes(1);
 
-    // 用户把第二个 bot 拉进群 —— 事件到达老 bot 的 dispatcher:
-    capturedHandlers['im.chat.member.bot.added_v1']({
-      chat_id: CHAT,
-      operator_id: { open_id: USER_OPEN_ID },
-    });
-    // 飞书侧真实人数变化:
+    // 也给同群另一个本地 bot app(OTHER_BOT_APP_ID)塞一条 {1,1} 陈旧条目——
+    // 这是「同群存量 bot」在缓存里的实际存在形式,扇出必须连它一起清掉。
+    await getGroupStats(OTHER_BOT_APP_ID, CHAT);
+    expect(mockGetChatInfo).toHaveBeenCalledTimes(2);
+
+    capturedHandlers[eventName]({ chat_id: CHAT, operator_id: { open_id: USER_OPEN_ID } });
+    // 飞书侧真实人数变化(新 bot 进群 / 某 bot 离开,现在同群另一 bot 视角):
     mockGetChatInfo.mockResolvedValue({ userCount: 1, botCount: 2 });
+
+    // 扇出牙齿①:另一 bot app 的条目也必须被清——若失效退化成只清自己的 key,
+    // 这次读取会命中 B 的陈旧缓存、不发查询(总次数停在 3 而非 4)。
+    await getGroupStats(OTHER_BOT_APP_ID, CHAT);
+    expect(mockGetChatInfo).toHaveBeenCalledTimes(3);
 
     await capturedHandlers['im.message.receive_v1'](makeUserMessageEvent({
       senderOpenId: USER_OPEN_ID,
-      content: JSON.stringify({ text: 'another plain message' }),
-      messageId: 'msg-after-add',
+      content: JSON.stringify({ text: 'post-change plain text' }),
+      messageId: `msg-post-${eventName}`,
       chatId: CHAT,
       chatType: 'group',
     }));
     await flushEventWork();
 
-    // 失效→重查→{1,2}→不再按 solo 放行;没有失效的话会命中陈旧 {1,1} 继续回复。
+    // 扇出牙齿②:本 bot 条目同样被清→重查→{1,2}→不再按 solo 放行;
+    // 失效退化成 no-op 时这里会命中陈旧 {1,1} 继续回复。
     expect(handlers.handleThreadReply).toHaveBeenCalledTimes(1);
     expect(handlers.handleNewTopic).not.toHaveBeenCalled();
-    expect(mockGetChatInfo).toHaveBeenCalledTimes(2);
+    expect(mockGetChatInfo).toHaveBeenCalledTimes(4);
   });
 
   it.each([
-    'im.chat.member.bot.deleted_v1',
     'im.chat.member.user.added_v1',
     'im.chat.member.user.deleted_v1',
-  ] as const)('② %s 事件同样失效 group-stats 缓存', async (eventName) => {
+  ] as const)('② %s(广播给群内所有已订阅 bot)失效自己那条缓存', async (eventName) => {
     // fresh 值只需满足「非 solo」来证明判定用了新数,不必模拟各事件的真实增减方向。
     const freshStats = { userCount: 2, botCount: 1 };
     startStaleOwnedGroup();
@@ -6720,6 +6745,10 @@ describe('1v1 陈旧缓存守门 — 拉新 bot 后 @ 新 bot 时老 bot 不跟�
   });
 
   it('② 发在别的群的成员事件不误伤本群缓存（按 larkAppId:chatId 精确失效）', async () => {
+    mockGetAllBots.mockReturnValue([
+      { config: { larkAppId: MY_APP_ID } },
+      { config: { larkAppId: OTHER_BOT_APP_ID } },
+    ] as any);
     startStaleOwnedGroup();
 
     await capturedHandlers['im.message.receive_v1'](makeUserMessageEvent({

--- a/test/setup-open-platform-automation.test.ts
+++ b/test/setup-open-platform-automation.test.ts
@@ -1102,6 +1102,8 @@ describe('automateOpenPlatformSetup', () => {
           'drive.notice.comment_add_v1',
           'im.message.reaction.created_v1',
           'im.message.reaction.deleted_v1',
+          'im.chat.member.user.added_v1',
+          'im.chat.member.user.deleted_v1',
           'vc.bot.meeting_invited_v1',
           'vc.bot.meeting_activity_v1',
           'vc.bot.meeting_ended_v1',
@@ -1129,8 +1131,8 @@ describe('automateOpenPlatformSetup', () => {
       expect(result.message).toContain('im.message.receive_v1');
       expect(result.eventWarning).toBeTruthy();
     }
-    // 批量失败后逐个重试过:baseline 6 + VC app 3 + VC user 1 = 批量 1 次 + 单个 10 次
-    expect(sub.updateBodies.filter(body => Array.isArray(body.appEvents)).length).toBe(11);
+    // 批量失败后逐个重试过:baseline 6 + 可选 user 事件 2 + VC app 3 + VC user 1 = 批量 1 次 + 单个 12 次
+    expect(sub.updateBodies.filter(body => Array.isArray(body.appEvents)).length).toBe(13);
     // 核心事件缺失时不再继续发版,避免发布一个收不到消息的版本
     expect(calls.some(u => u.includes('/publish/commit/'))).toBe(false);
   });
@@ -1188,7 +1190,7 @@ describe('automateOpenPlatformSetup', () => {
     expect(calls.some(u => u.includes('/publish/commit/'))).toBe(true);
     if (result.ok) {
       expect(result.missingVcEvents).toEqual(vcEvents);
-      expect(result.subscribedEventCount).toBe(7); // 6 baseline 事件 + 1 回调
+      expect(result.subscribedEventCount).toBe(9); // 6 baseline 事件 + 2 可选 user 事件 + 1 回调
       expect(result.eventWarning).toContain('VC 会议事件未确认订阅');
       // VC listener 保存门必须拦下这种结果(dashboard 两条分支都走这个门)
       expect(vcListenerEventGateError(result)).toContain('vc.bot.meeting_invited_v1');


### PR DESCRIPTION
## 问题

原 1人1bot 群被拉进第二个 bot 后，真实人数立刻是 `{1,2}`，但老 bot 的 `chatStatsCache` 在 TTL（5min）内仍缓存 `{1,1}`。此刻用户 @ 新 bot，老 bot 经两条 solo 判定路径（`relax` 末条款 / `checkGroupMessageAccess`）误把群当成 1v1，**跟着回复**。

这正是「刚拉了 bot 立刻 @ 测试」必踩的窗口——用户最反感的也是这条。

## 修复（两层互不依赖）

### ① 本地守门（零配置、立即生效，修复用户投诉场景）

消息里 @ 了**别的具体成员**，就意味着该成员在群里（只有群成员能被 @）——**群必非 1人1bot**，根本不用查缓存。

- 给 `relax` 末条款和 `checkGroupMessageAccess` 的 solo 分支加 `!mentionsAnotherMember(larkAppId, message)` 守卫（复用 ambient 模式现成的 redirect 判定）
- stats 获取改条件化（`ownsSession && !replyRootId && !mentionsOther && mentionMode !== 'never'`）：@ 了别人或 never 模式时**连人数 API 查询都省掉**
- **尊重 dashboard「群聊 @ 策略」**：never 在前序条款短路、语义原样保留（专用 pin 测试护住）；ambient/topic 本就有同款 redirect 守卫；唯一行为增量是 always 的「1v1 免@豁免」补上 redirect 识别

### ② 成员变更事件驱动缓存失效（压缩纯文本残留窗口；边界经 codex 两轮复审校准）

> 此处两度修订：**bot.added/deleted 只推给当事 bot 自己的 app（官方文档），且生产是 PM2 一 bot 一 daemon 进程**——bot 事件只能清自己的 key。「别的 bot 进群/离群 → 本 bot 陈旧」无事件信号且跨进程，靠 ① 守卫 + TTL 兜底（跨进程 IPC 广播可作后续增强）。

- 新增 `invalidateChatStats(larkAppId, chatId)`
- `im.chat.member.bot.added_v1` / `bot.deleted_v1`：清本 bot 自己的 key（覆盖「本 bot 被移出又拉回」等自身残留场景）。bot.deleted 顺带补注册了 handler（基线订阅列表早就有、却没有处理器）
- `im.chat.member.user.added_v1` / `deleted_v1`：**广播给群内已订阅的所有 bot app**，各自清自己那条——这是②的主要有效方向（「有人被拉进 1V1 群」秒级失效）。进新设 `BOT_OPTIONAL_APP_EVENTS` 可选订阅——**刻意不进 baseline**（部分租户授不了成员读取权限，放进去会让建 bot fail-closed）；老应用没订阅则仅靠 TTL
- TTL 保留作最后兜底不变

## 测试验证

- `pnpm build` ✅
- `test/event-dispatcher.test.ts` 256/256（+6 新用例；bot 事件用例最终按「自身 key 失效」真实部署语义编写）
- `test/setup-open-platform-automation.test.ts` 39/39（更新 3 处断言）
- 全套 `pnpm test` 11282 passed（唯一文件级失败 = `group-join-shared-routing` beforeAll 10s 超时，与 master 一致的环境 flake，单跑 5/5 绿，codex 独立复现同结论）
- **变异测试 7 杀**：
  - 同时拆 relax 守卫+stats 跳取 → FAIL
  - 拆 `checkGroupMessageAccess` 守卫 → FAIL
  - 守卫错放 never 条款（违反 never 语义）→ FAIL
  - 删 bot.added 失效 → FAIL
  - 删 bot.deleted 失效 → FAIL
  - 删 user.added handler → FAIL
  - 单拆 relax 守卫或 stats 跳取任一 **不** FAIL——有意 defense-in-depth 双保险

## 影响面（CLAUDE.md 要求项）

| 维度 | 评估 |
|---|---|
| 跨平台 | 纯 Lark 事件层逻辑，无平台相关 |
| 跨 CLI | 没碰 `adapters/` / worker |
| 跨会话类型 | 话题群已有「@别人 inside owned topic 后退」用例保持绿；p2p 不触；never/ambient/topic 语义原样 |
| 行为增量 | always 模式下「@了别人 + 陈旧 1v1 缓存」从可能放行 → 必静默（修复投诉场景）；有成员加入后 1v1 判定秒级刷新（原 ≤5min） |

## 待真机确认

live 部署需 `pnpm switch:here && pnpm daemon:restart`（会影响全 fleet 所有 bot），待批准。真机补记：user member 事件对老应用未订阅时仅 TTL 兜底（与代码注释一致）。