### PR TITLE
fix(lark): 卡片扁平化剔除 botmux 回调按钮(🔊 语音总结等),发送侧统一打标长期防腐

### DIFF
--- a/src/im/lark/callback-button-marker.ts
+++ b/src/im/lark/callback-button-marker.ts
@@ -1,0 +1,96 @@
+/**
+ * botmux callback-button ownership marker.
+ *
+ * WHY: botmux reply/session/config cards carry callback buttons (🔊 语音总结 /
+ * 关闭会话 / 重启 / 配置 …). When another bot reads such a card (history /
+ * cross-bot relay / quote), a plain-text flattening renders them as
+ * `[🔊 语音总结]` chrome it can never click — prompt pollution. The parser
+ * strips any button it can PROVE is botmux's own callback; proof must not
+ * depend on a hand-maintained action wordlist, because every new botmux
+ * button added later would silently leak again until someone updates the list.
+ *
+ * HOW: every card botmux sends is stamped at the single egress choke point
+ * (client.ts send/reply/ephemeral/update — all interactive traffic flows
+ * through those four). Each `tag:'button'` gets a `__bm_cb:1` marker on its
+ * callback payload — both real payload shapes: legacy top-level `value` and
+ * v2 `behaviors:[{type:'callback', value}]`. Jump buttons (open_url) are left
+ * unmarked so their URLs keep surfacing in flattened text.
+ *
+ * The marker round-trips to card-handler on click as an unknown key and is
+ * ignored there; it is additive only. Cards sent by older botmux builds have
+ * no marker — the parser's legacy action wordlist covers those.
+ */
+
+export const BOTMUX_CALLBACK_MARKER_KEY = '__bm_cb';
+
+/** True when a button payload object carries the botmux callback marker. */
+function markPayload(value: unknown): void {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    (value as Record<string, unknown>)[BOTMUX_CALLBACK_MARKER_KEY] = 1;
+  }
+}
+
+function stampElement(el: unknown): void {
+  if (!el || typeof el !== 'object') return;
+  if (Array.isArray(el)) {
+    for (const child of el) stampElement(child);
+    return;
+  }
+  const node = el as Record<string, unknown>;
+  if (node.tag === 'button') {
+    // Do NOT stamp open_url jump buttons: their link is real, followable
+    // content and must keep surfacing in flattened text. A button whose
+    // behaviors are callback-only (or legacy top-level value) gets stamped.
+    const hasOpenUrl = (Array.isArray(node.behaviors)
+      && node.behaviors.some((b: any) => b?.type === 'open_url'))
+      || typeof node.url === 'string' && (node.url as string).length > 0
+      || !!(node.multi_url && typeof node.multi_url === 'object'
+        && Object.values(node.multi_url as Record<string, unknown>).some(v => typeof v === 'string' && v));
+    if (!hasOpenUrl) {
+      markPayload(node.value);
+      if (Array.isArray(node.behaviors)) {
+        for (const b of node.behaviors as any[]) {
+          if (b && typeof b === 'object' && b.type === 'callback') markPayload(b.value);
+        }
+      }
+    }
+  }
+  for (const value of Object.values(node)) {
+    if (value && typeof value === 'object') stampElement(value);
+  }
+}
+
+/**
+ * Stamp every callback button in an interactive card's JSON. Idempotent and
+ * total: on any JSON anomaly the input string is returned unchanged (a stamp
+ * failure must never block an outbound message). Non-interactive content
+ * should not be passed here at all (callers gate on msgType === 'interactive'),
+ * but a non-card JSON body is tolerated harmlessly.
+ */
+export function stampBotmuxCallbackMarkers(cardJson: string): string {
+  let card: unknown;
+  try {
+    card = JSON.parse(cardJson);
+  } catch {
+    return cardJson;
+  }
+  stampElement(card);
+  try {
+    return JSON.stringify(card);
+  } catch {
+    return cardJson;
+  }
+}
+
+/** True when `el` is a button stamped by stampBotmuxCallbackMarkers. */
+export function hasBotmuxCallbackMarker(el: any): boolean {
+  if (!el || typeof el !== 'object') return false;
+  const marked = (v: unknown): boolean =>
+    !!v && typeof v === 'object' && !Array.isArray(v)
+    && (v as Record<string, unknown>)[BOTMUX_CALLBACK_MARKER_KEY] === 1;
+  if (marked(el.value)) return true;
+  if (Array.isArray(el.behaviors)) {
+    return el.behaviors.some((b: any) => b?.type === 'callback' && marked(b.value));
+  }
+  return false;
+}

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -527,7 +527,17 @@ export async function sendUserMessage(
 ): Promise<string> {
   assertLarkTransport(larkAppId, 'sendUserMessage');
   const c = getBotClient(larkAppId);
-  const body = msgType === 'text' ? JSON.stringify({ text: content }) : content;
+  // Stamp callback-button ownership markers on interactive DMs too: this is the
+  // FIFTH card egress surface (config / write-link / substitute / overload / …
+  // cards all DM their callback buttons through here). Without it a peer bot
+  // reading such a DM via history flattens the buttons into its prompt, and —
+  // worse — a future botmux DM button with a new action would leak past the
+  // parser's legacy wordlist. Shared `body` feeds BOTH branches below (plain
+  // create + deadline request), so one stamp covers both. Same total-function
+  // contract as send/reply/ephemeral/update: any JSON anomaly returns unchanged.
+  const body = msgType === 'text'
+    ? JSON.stringify({ text: content })
+    : msgType === 'interactive' ? stampBotmuxCallbackMarkers(content) : content;
   const data = {
     receive_id: openId,
     msg_type: msgType as any,

--- a/src/im/lark/client.ts
+++ b/src/im/lark/client.ts
@@ -14,6 +14,7 @@ import { getBotCapability } from '../../services/bot-profile-store.js';
 import { resolveTeamRoleFile } from '../../core/role-resolver.js';
 import { type Brand, larkHosts, normalizeBrand, sdkDomain } from './lark-hosts.js';
 import { canonicalMobileKey, isMobileEntry, normalizeMobileEntry } from '../../setup/bot-config-editor.js';
+import { stampBotmuxCallbackMarkers } from './callback-button-marker.js';
 
 type LarkRequestParams = Record<string, string | number | boolean | undefined>;
 
@@ -230,7 +231,9 @@ export async function sendMessage(
 ): Promise<string> {
   assertLarkTransport(larkAppId, 'sendMessage');
   const c = getBotClient(larkAppId);
-  const body = msgType === 'text' ? JSON.stringify({ text: content }) : content;
+  const body = msgType === 'text'
+    ? JSON.stringify({ text: content })
+    : msgType === 'interactive' ? stampBotmuxCallbackMarkers(content) : content;
 
   let res: any;
   try {
@@ -291,7 +294,9 @@ export async function replyMessage(
 ): Promise<string> {
   assertLarkTransport(larkAppId, 'replyMessage');
   const c = getBotClient(larkAppId);
-  const body = msgType === 'text' ? JSON.stringify({ text: content }) : content;
+  const body = msgType === 'text'
+    ? JSON.stringify({ text: content })
+    : msgType === 'interactive' ? stampBotmuxCallbackMarkers(content) : content;
 
   let res: any;
   try {
@@ -814,7 +819,7 @@ export async function sendEphemeralCard(
   const c = getBotClient(larkAppId);
   let card: unknown;
   try {
-    card = JSON.parse(cardJson);
+    card = JSON.parse(stampBotmuxCallbackMarkers(cardJson));
   } catch (err) {
     throw new Error(`Invalid ephemeral card JSON: ${err}`);
   }
@@ -867,7 +872,7 @@ export async function updateMessage(larkAppId: string, messageId: string, cardJs
   try {
     res = await c.im.v1.message.patch({
       path: { message_id: messageId },
-      data: { content: cardJson },
+      data: { content: stampBotmuxCallbackMarkers(cardJson) },
     });
   } catch (err: any) {
     if (getLarkErrorCode(err) === LARK_CODE_MESSAGE_WITHDRAWN) {

--- a/src/im/lark/message-parser.ts
+++ b/src/im/lark/message-parser.ts
@@ -4,6 +4,7 @@ import { logger } from '../../utils/logger.js';
 import {
   REPLY_CARD_FOOTER_ELEMENT_ID,
 } from './reply-card-footer-signature.js';
+import { hasBotmuxCallbackMarker } from './callback-button-marker.js';
 
 // Event data structure from WSClient im.message.receive_v1
 // sender is at data top-level, NOT inside data.message
@@ -811,6 +812,7 @@ export function extractCardContent(rawContent: string, numberer?: ImgNumberer): 
               // Same jump-URL policy as Format B: simple cards reach history
               // via the Format A list view WITHOUT a resolve pass, so dropping
               // the URL here would lose button links on that main path.
+              if (isBotmuxCallbackButton(node)) continue;
               const btnText = typeof node.text === 'string' ? node.text : node.text?.content;
               if (btnText) {
                 const url = buttonOpenUrl(node);
@@ -1026,6 +1028,58 @@ function firstNonEmptyString(...candidates: unknown[]): string | undefined {
   return undefined;
 }
 
+/** botmux's own card control buttons (🔊 语音总结 / 关闭会话 / 重启 / 配置 …) are
+ *  pure callbacks back into the daemon: when another bot reads the card
+ *  (history / cross-bot relay / quote), rendering them as `[🔊 语音总结]`
+ *  pollutes the receiving prompt with affordances it can never click, so
+ *  drop them structurally — same rationale as the botmux grey-footer strip
+ *  in extractElementText.
+ *
+ *  Primary detection is the egress-stamped ownership marker
+ *  (callback-button-marker.ts). This wordlist is the LEGACY fallback for
+ *  cards sent by pre-marker builds (chat history is long-lived), covering
+ *  every action dispatched by card-handler as of the fix — it is frozen;
+ *  new botmux buttons rely on the marker, not on growing this list.
+ *  Third-party cards' buttons (Argos 确认/创建群组…) stay: they carry no
+ *  marker and their `value` never uses botmux's action vocabulary. */
+const BOTMUX_INTERNAL_CARD_ACTIONS: ReadonlySet<string> = new Set([
+  // session / reply card controls (card-handler's actionType dispatch)
+  'close', 'disconnect', 'export_text', 'get_write_link', 'open_local_cli',
+  'open_local_terminal', 'refresh_screenshot', 'restart', 'resume',
+  'retry_last_task', 'takeover', 'term_action', 'toggle_display',
+  'toggle_stream', 'tui_keys', 'tui_text_input', 'voice_summary',
+  // pendingRepo gates
+  'repo_manual_submit', 'repo_worktree_submit', 'skip_repo',
+  'worktree_toggle_mode',
+  // config / grant / relay cards
+  'config_toggle', 'config_set', 'config_quota', 'config_text_open',
+  'config_text_save', 'grant_chat', 'grant_global', 'grant_deny',
+  'relay_search', 'relay_page', 'relay_select', 'relay_confirm',
+  // host-overload alert + codex notifier cards
+  'overload_noop', 'overload_clean_stopped', 'overload_suspend_idle',
+  'codex_notifier_continue', 'codex_notifier_open_app',
+]);
+
+/** True when the button is one of botmux's own callback buttons. Primary
+ *  signal: the egress-stamped ownership marker (see
+ *  callback-button-marker.ts) — future-proof against any new botmux action
+ *  name. Legacy fallback: cards sent by pre-marker builds are still
+ *  recognized via the internal action wordlist, in EITHER of the two real
+ *  payload shapes — legacy top-level `value.action` (session/config cards)
+ *  or v2 `behaviors:[{type:'callback', value.action}]` (reply-card voice
+ *  button inside column_set). A button that somehow carries BOTH a botmux
+ *  signal AND an open_url jump target is kept, since a real link is always
+ *  worth surfacing. */
+function isBotmuxCallbackButton(el: any): boolean {
+  if (buttonOpenUrl(el)) return false;
+  if (hasBotmuxCallbackMarker(el)) return true;
+  let action: unknown = el?.value?.action;
+  if (typeof action !== 'string' && Array.isArray(el?.behaviors)) {
+    action = el.behaviors.find((b: any) => b?.type === 'callback')?.value?.action;
+  }
+  return typeof action === 'string' && BOTMUX_INTERNAL_CARD_ACTIONS.has(action);
+}
+
 /** Resolve a card button's jump target across schema generations: v1 `url` /
  *  `multi_url`, v2 `behaviors: [{type:'open_url', default_url, pc_url, …}]`.
  *  Returns undefined for callback-only buttons (they have no followable URL). */
@@ -1121,7 +1175,9 @@ function extractElementText(el: any, parts: string[], imgLabel: (key: string) =>
   // Jump buttons carry their target as v1 `url`/`multi_url` or v2 `behaviors`
   // open_url; keep it so the reader can actually follow the link (e.g. Argos
   // [分析报告] → the report URL). Callback buttons have no URL and stay bare.
+  // botmux's own callback buttons (🔊 语音总结 …) are dropped entirely.
   if (tag === 'button') {
+    if (isBotmuxCallbackButton(el)) return;
     const btnText = typeof el.text === 'string' ? el.text : el.text?.content;
     if (btnText) {
       const url = buttonOpenUrl(el);

--- a/test/message-parser.test.ts
+++ b/test/message-parser.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from 'vitest';
 import { parseApiMessage, extractResources, parseEventMessage, stripLeadingMentions, createImgNumberer, cardContentHasUpgradeFallback, isPureCardUpgradeFallback, mergeCardText, wrapResolvedCardText, mentionOpenId, CARD_EMBEDDED_PLACEHOLDER } from '../src/im/lark/message-parser.js';
 import { buildMarkdownCard, buildReplyCardFooter } from '../src/im/lark/md-card.js';
+import { stampBotmuxCallbackMarkers, hasBotmuxCallbackMarker, BOTMUX_CALLBACK_MARKER_KEY } from '../src/im/lark/callback-button-marker.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
@@ -801,6 +802,217 @@ describe('Interactive card parsing: footer stripped structurally (custom brand)'
     };
     const result = parseApiMessage(makeMsg('interactive', card));
     expect(result.content).toContain('报警时间 17:45');
+  });
+});
+
+// ─── botmux internal callback buttons are stripped from flattened text ────
+
+describe('botmux internal callback buttons (🔊 语音总结 …) dropped from prompt', () => {
+  // botmux reply/session cards carry callback buttons whose only affordance is
+  // a callback into the sender bot's daemon. Flattening them as `[🔊 语音总结]`
+  // leaks unusable chrome into peer bots' prompts (history / cross-bot relay /
+  // quote) — the receiving bot can never click them. They are identified
+  // structurally by `value.action` from botmux's internal vocabulary + no
+  // jump URL; third-party and valueless buttons stay.
+  it('Format B: drops the production voice-summary button (column_set + behaviors callback), keeps the reply body', () => {
+    // Exact shape the cli.ts reply path builds: the button lives inside a
+    // column_set's auto-width column and carries its action under
+    // behaviors:[{type:'callback', value}] — NOT top-level value.
+    const card = {
+      body: { elements: [
+        { tag: 'markdown', content: '这是机器人的回复内容' },
+        { tag: 'hr' },
+        { tag: 'column_set', flex_mode: 'none', columns: [
+          { tag: 'column', width: 'weighted', weight: 1, vertical_align: 'center',
+            elements: [{ tag: 'markdown', text_size: 'notation_small_v2', content: ' ' }] },
+          { tag: 'column', width: 'auto', vertical_align: 'center', elements: [{
+            tag: 'button',
+            text: { tag: 'plain_text', content: '🔊 语音总结' },
+            type: 'default',
+            behaviors: [{
+              type: 'callback',
+              value: { action: 'voice_summary', session_id: 's1', root_id: 'om_1', lark_app_id: 'cli_a1', chat_id: 'oc_1' },
+            }],
+          }] },
+        ] },
+      ] },
+    };
+    const result = parseApiMessage(makeMsg('interactive', card));
+    expect(result.content).toContain('这是机器人的回复内容');
+    expect(result.content).not.toContain('语音总结');
+  });
+
+  it('Format B: drops session-card controls (关闭会话/重启), keeps third-party callbacks', () => {
+    const card = {
+      body: { elements: [
+        { tag: 'action', actions: [
+          { tag: 'button', text: { tag: 'plain_text', content: '❌ 关闭会话' },
+            value: { action: 'close', session_id: 's1' } },
+          { tag: 'button', text: { tag: 'plain_text', content: '🔄 重启' },
+            value: { action: 'restart', session_id: 's1' } },
+          // Third-party card button with its own callback vocabulary — kept.
+          { tag: 'button', text: { tag: 'plain_text', content: '确认' },
+            value: { action: 'ack_alarm', rule_id: 'r1' } },
+          // Button with no value at all — always kept.
+          { tag: 'button', text: { tag: 'plain_text', content: '🖥️ 打开终端' } },
+        ] },
+      ] },
+    };
+    const result = parseApiMessage(makeMsg('interactive', card));
+    expect(result.content).not.toContain('关闭会话');
+    expect(result.content).not.toContain('重启');
+    expect(result.content).toContain('[确认]');
+    expect(result.content).toContain('[🖥️ 打开终端]');
+  });
+
+  it('Format B: real buildReplyCardFooter + real voice button — neither chrome leaks', () => {
+    // End-to-end sanity with the REAL builders: footer signature strip (master)
+    // and callback-button strip (this change) must jointly leave only the body.
+    const footer = buildReplyCardFooter({ recipientOpenIds: ['ou_55cda5a6c00f49eef42043a7746499b4'] })!;
+    const card = {
+      body: { elements: [
+        { tag: 'markdown', content: '修复已完成，详见上面。' },
+        { tag: 'hr' },
+        { tag: 'column_set', flex_mode: 'none', columns: [
+          { tag: 'column', width: 'weighted', weight: 1, vertical_align: 'center',
+            elements: [footer.element] },
+          { tag: 'column', width: 'auto', vertical_align: 'center', elements: [{
+            tag: 'button',
+            text: { tag: 'plain_text', content: '🔊 语音总结' },
+            type: 'default',
+            behaviors: [{
+              type: 'callback',
+              value: { action: 'voice_summary', session_id: 's1', root_id: 'om_1', lark_app_id: 'cli_a1', chat_id: 'oc_1' },
+            }],
+          }] },
+        ] },
+      ] },
+    };
+    const result = parseApiMessage(makeMsg('interactive', card));
+    expect(result.content).toContain('修复已完成，详见上面。');
+    expect(result.content).not.toContain('语音总结');
+    expect(result.content).not.toContain('发送给');
+    expect(result.content).not.toContain('botmux');
+  });
+
+  it('Format B: a jump-URL button is kept even under a botmux action name', () => {
+    // A real link always wins over the cleanup heuristic — the open_url
+    // behavior means the reader can actually follow it.
+    const card = {
+      body: { elements: [
+        { tag: 'button', text: { tag: 'plain_text', content: '分析报告' },
+          value: { action: 'voice_summary', session_id: 's1' },
+          behaviors: [{ type: 'open_url', default_url: 'https://example.com/report' }] },
+      ] },
+    };
+    const result = parseApiMessage(makeMsg('interactive', card));
+    expect(result.content).toContain('[分析报告](https://example.com/report)');
+  });
+
+  it('Format A: drops the voice-summary button while keeping bare buttons', () => {
+    // Format A is the API simplified list view; nodes keep `value` when the
+    // card supplies it, so the same structural filter applies.
+    const card = {
+      title: '回复',
+      elements: [[
+        { tag: 'text', text: '回复正文' },
+        { tag: 'button', text: '🔊 语音总结',
+          value: { action: 'voice_summary', session_id: 's1' } },
+        { tag: 'button', text: 'Option A', type: 'primary' },
+      ]],
+    };
+    const result = parseApiMessage(makeMsg('interactive', card));
+    expect(result.content).toContain('回复正文');
+    expect(result.content).not.toContain('语音总结');
+    expect(result.content).toContain('[Option A]');
+  });
+
+  it('marker path: a stamped button is dropped even with an UNKNOWN action (future-proof)', () => {
+    // The egress stamp (`__bm_cb`) is the long-term contract: a future botmux
+    // button with an action the legacy wordlist has never heard of must still
+    // be stripped, WITHOUT anyone updating the wordlist.
+    const card = {
+      body: { elements: [
+        { tag: 'button', text: { tag: 'plain_text', content: '🆕 未来按钮' },
+          value: { action: 'some_future_action', __bm_cb: 1 } },
+      ] },
+    };
+    const result = parseApiMessage(makeMsg('interactive', card));
+    expect(result.content).not.toContain('未来按钮');
+  });
+
+  it('roundtrip: every callback button in a real egress-stamped card vanishes, jump URL stays', () => {
+    // Full pipeline: stampBotmuxCallbackMarkers (what client.ts applies on
+    // send/reply/ephemeral/update) → parseApiMessage (what the peer bot sees).
+    // A custom-brand bot with a session card and a voice-reply card must leak
+    // zero callback chrome while its genuine jump button survives.
+    const sessionCard = JSON.stringify({
+      body: { elements: [
+        { tag: 'markdown', content: '会话正文' },
+        { tag: 'action', actions: [
+          { tag: 'button', text: { tag: 'plain_text', content: '❌ 关闭会话' },
+            type: 'danger', value: { action: 'close', session_id: 's1' } },
+          { tag: 'button', text: { tag: 'plain_text', content: '🆕 某未来功能' },
+            value: { action: 'totally_new_action', session_id: 's1' } },
+          { tag: 'button', text: { tag: 'plain_text', content: '📄 打开报告' },
+            behaviors: [{ type: 'open_url', default_url: 'https://example.com/report' }] },
+        ] },
+      ] },
+    });
+    const stamped = stampBotmuxCallbackMarkers(sessionCard);
+    const result = parseApiMessage(makeMsg('interactive', stamped));
+    expect(result.content).toContain('会话正文');
+    expect(result.content).not.toContain('关闭会话');
+    expect(result.content).not.toContain('某未来功能');   // unknown action — marker wins
+    expect(result.content).toContain('[📄 打开报告](https://example.com/report)');
+    // sanity: the stamp actually fired (not passing by accident)
+    expect(stamped).toContain('__bm_cb');
+  });
+});
+
+// ─── stampBotmuxCallbackMarkers: egress stamp unit behavior ───────────────
+
+describe('stampBotmuxCallbackMarkers (egress choke-point stamp)', () => {
+  it('stamps legacy top-level value and v2 behaviors callback, skips jump buttons', () => {
+    const card = JSON.stringify({
+      body: { elements: [
+        { tag: 'button', text: { tag: 'plain_text', content: 'A' }, value: { action: 'close', session_id: 's' } },
+        { tag: 'button', text: { tag: 'plain_text', content: 'B' },
+          behaviors: [{ type: 'callback', value: { action: 'voice_summary' } }] },
+        { tag: 'button', text: { tag: 'plain_text', content: 'C' }, value: { action: 'cfg' },
+          behaviors: [{ type: 'open_url', default_url: 'https://example.com' }] },
+      ] },
+    });
+    const out = JSON.parse(stampBotmuxCallbackMarkers(card));
+    const [a, b, c] = out.body.elements;
+    expect(a.value[BOTMUX_CALLBACK_MARKER_KEY]).toBe(1);
+    expect(b.behaviors[0].value[BOTMUX_CALLBACK_MARKER_KEY]).toBe(1);
+    // jump button untouched: its value must stay marker-free
+    expect(c.value[BOTMUX_CALLBACK_MARKER_KEY]).toBeUndefined();
+    expect(hasBotmuxCallbackMarker(a)).toBe(true);
+    expect(hasBotmuxCallbackMarker(b)).toBe(true);
+    expect(hasBotmuxCallbackMarker(c)).toBe(false);
+  });
+
+  it('reaches buttons nested in column_set / i18n sections', () => {
+    const card = JSON.stringify({
+      body: { elements: [{ tag: 'column_set', columns: [
+        { tag: 'column', elements: [{ tag: 'button', text: { tag: 'plain_text', content: 'X' },
+          behaviors: [{ type: 'callback', value: { action: 'voice_summary' } }] }] },
+      ] }] },
+      i18n_elements: { zh_cn: [{ tag: 'button', text: { tag: 'plain_text', content: 'Y' }, value: { action: 'close' } }] },
+    });
+    const out = JSON.parse(stampBotmuxCallbackMarkers(card));
+    const nested = out.body.elements[0].columns[0].elements[0];
+    expect(nested.behaviors[0].value[BOTMUX_CALLBACK_MARKER_KEY]).toBe(1);
+    expect(out.i18n_elements.zh_cn[0].value[BOTMUX_CALLBACK_MARKER_KEY]).toBe(1);
+  });
+
+  it('is idempotent and tolerates non-JSON input unchanged', () => {
+    const card = JSON.stringify({ body: { elements: [{ tag: 'button', text: { tag: 'plain_text', content: 'A' }, value: { action: 'close' } }] } });
+    const once = stampBotmuxCallbackMarkers(card);
+    expect(stampBotmuxCallbackMarkers(once)).toBe(once);
+    expect(stampBotmuxCallbackMarkers('not-json{')).toBe('not-json{');
   });
 });
 

--- a/test/send-user-message-egress-stamp.test.ts
+++ b/test/send-user-message-egress-stamp.test.ts
@@ -1,0 +1,142 @@
+/**
+ * sendUserMessage egress stamping: the FIFTH card egress surface.
+ *
+ * sendUserMessage DMs interactive cards (config / write-link / substitute /
+ * overload / …) whose callback buttons must carry the `__bm_cb` ownership
+ * marker, exactly like the other four egress choke points (sendMessage /
+ * replyMessage / sendEphemeralCard / updateMessage). Without it a peer bot
+ * reading such a DM via history flattens the buttons into its prompt, and a
+ * FUTURE botmux DM button with an action the parser's legacy wordlist has
+ * never heard of would leak unstripped.
+ *
+ * These assert the REAL client egress path (SDK mocked at the boundary,
+ * capturing the exact `data.content` posted to Lark), plus a full
+ * send -> flatten roundtrip proving an unknown-action button is dropped.
+ *
+ * Run: pnpm vitest run test/send-user-message-egress-stamp.test.ts
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+vi.mock('@larksuiteoapi/node-sdk', () => {
+  class FakeClient { constructor(public opts: Record<string, unknown>) {} }
+  return { Client: FakeClient };
+});
+
+import { registerBot, getBot } from '../src/bot-registry.js';
+import { sendUserMessage } from '../src/im/lark/client.js';
+import { parseApiMessage } from '../src/im/lark/message-parser.js';
+import { BOTMUX_CALLBACK_MARKER_KEY } from '../src/im/lark/callback-button-marker.js';
+
+/** Register a bot whose SDK create/request handlers capture the posted body. */
+function setupCapture(appId: string) {
+  registerBot({ larkAppId: appId, larkAppSecret: 's', cliId: 'claude-code' });
+  const calls: Array<{ via: 'create' | 'request'; content: string }> = [];
+  getBot(appId).client = {
+    im: { v1: { message: {
+      create: async (args: any) => {
+        calls.push({ via: 'create', content: args?.data?.content });
+        return { code: 0, data: { message_id: 'om_dm' } };
+      },
+    } } },
+    // The deadline (requestOptions) branch goes through c.request(...).
+    request: async (args: any) => {
+      calls.push({ via: 'request', content: args?.data?.content });
+      return { code: 0, data: { message_id: 'om_dm' } };
+    },
+  } as any;
+  return calls;
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('sendUserMessage egress: interactive DMs are stamped', () => {
+  it('stamps a callback button on the plain create path', async () => {
+    const calls = setupCapture('dm1');
+    const card = JSON.stringify({
+      body: { elements: [
+        { tag: 'markdown', content: '配置' },
+        { tag: 'action', actions: [
+          { tag: 'button', text: { tag: 'plain_text', content: '⚙️ 配置' },
+            value: { action: 'config_toggle', field: 'sandbox' } },
+        ] },
+      ] },
+    });
+    await sendUserMessage('dm1', 'ou_owner', card, 'interactive');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].via).toBe('create');
+    const posted = JSON.parse(calls[0].content);
+    const btn = posted.body.elements[1].actions[0];
+    expect(btn.value[BOTMUX_CALLBACK_MARKER_KEY]).toBe(1);
+  });
+
+  it('stamps on the deadline (requestOptions) path too — shared body', async () => {
+    const calls = setupCapture('dm2');
+    const card = JSON.stringify({
+      body: { elements: [
+        { tag: 'button', text: { tag: 'plain_text', content: '🔊 语音总结' },
+          behaviors: [{ type: 'callback', value: { action: 'voice_summary', session_id: 's1' } }] },
+      ] },
+    });
+    // Passing requestOptions routes through c.request(...) rather than create.
+    await sendUserMessage('dm2', 'ou_owner', card, 'interactive', undefined, {});
+    expect(calls).toHaveLength(1);
+    expect(calls[0].via).toBe('request');
+    const posted = JSON.parse(calls[0].content);
+    expect(posted.body.elements[0].behaviors[0].value[BOTMUX_CALLBACK_MARKER_KEY]).toBe(1);
+  });
+
+  it('leaves text DMs and non-interactive bodies untouched', async () => {
+    const calls = setupCapture('dm3');
+    await sendUserMessage('dm3', 'ou_owner', 'hello', 'text');
+    // text: wrapped as {text}, never stamped
+    expect(JSON.parse(calls[0].content)).toEqual({ text: 'hello' });
+    // a non-interactive structured body (e.g. 'post') passes through verbatim
+    const postBody = JSON.stringify({ post: { zh_cn: { title: 't' } } });
+    await sendUserMessage('dm3', 'ou_owner', postBody, 'post');
+    expect(calls[1].content).toBe(postBody);
+    expect(calls[1].content).not.toContain(BOTMUX_CALLBACK_MARKER_KEY);
+  });
+
+  it('does NOT stamp a jump-URL button (real link stays followable)', async () => {
+    const calls = setupCapture('dm4');
+    const card = JSON.stringify({
+      body: { elements: [
+        { tag: 'button', text: { tag: 'plain_text', content: '📄 打开报告' },
+          behaviors: [{ type: 'open_url', default_url: 'https://example.com/report' }] },
+      ] },
+    });
+    await sendUserMessage('dm4', 'ou_owner', card, 'interactive');
+    const posted = JSON.parse(calls[0].content);
+    // open_url button has no callback value to mark; stays marker-free
+    expect(JSON.stringify(posted)).not.toContain(BOTMUX_CALLBACK_MARKER_KEY);
+  });
+});
+
+describe('sendUserMessage egress: unknown-action DM button roundtrip (future-proof)', () => {
+  it('an UNKNOWN future DM action, stamped on send, is dropped on flatten', async () => {
+    // This is the exact leak codex reproduced: pre-fix, an interactive DM whose
+    // button action is NOT in the parser wordlist flattened to
+    // `[Future DM Callback]`. With egress stamping, the marker rides along and
+    // the parser drops it WITHOUT anyone touching the wordlist.
+    const calls = setupCapture('dm5');
+    const card = JSON.stringify({
+      body: { elements: [
+        { tag: 'markdown', content: 'DM 正文' },
+        { tag: 'button', text: { tag: 'plain_text', content: 'Future DM Callback' },
+          value: { action: 'totally_new_dm_action', session_id: 's1' } },
+      ] },
+    });
+    await sendUserMessage('dm5', 'ou_owner', card, 'interactive');
+    const stampedOnWire = calls[0].content;
+    expect(stampedOnWire).toContain(BOTMUX_CALLBACK_MARKER_KEY); // sanity: stamp fired
+
+    // What a peer bot sees when it reads this DM back as a card.
+    const flattened = parseApiMessage({
+      message_id: 'om_dm', msg_type: 'interactive', create_time: '1',
+      sender: { id: 'ou_bot', sender_type: 'app' },
+      body: { content: stampedOnWire },
+    } as any).content;
+    expect(flattened).toContain('DM 正文');
+    expect(flattened).not.toContain('Future DM Callback');
+  });
+});


### PR DESCRIPTION
## 问题

回复卡片底部的「🔊 语音总结」等 botmux 回调按钮，`message-parser` 扁平化卡片时被渲染成 `[🔊 语音总结]` 混进正文。别的 bot 通过 history / 跨 bot 接力 / 引用读到这张卡片时，这些永远点不到的 chrome 直接进了对端 prompt（Bot at Bot 场景尤其扎眼，申晗实测截图实证）。同类泄漏还包括 `关闭会话/重启/配置…` 全部回调按钮。

## 方案（三层）

1. **发送侧打标（根治）**：新增 `callback-button-marker.ts`，在 `client.ts` **全部 5 个**卡片出站收口（`sendMessage`/`replyMessage`/`sendEphemeralCard`/`updateMessage`/`sendUserMessage`）给所有 callback 按钮注入 `__bm_cb:1` 归属标记；跳转 URL 按钮不打（链接是真实可点内容）。未来新增任何 botmux 按钮出站自动带标，**零维护**——解决「词表会被后人漏更新导致重新泄漏」的腐烂隐患。
   > 注：初版只覆盖前 4 个收口，PR 描述曾误写「已核实全仓无第二家卡片出站面」——首审(Claude) + 复审(codex) 双双证伪：`sendUserMessage`（config / write-link / substitute / overload 等私信卡）是第 5 个出站面，初版漏打标。已在 follow-up commit 补齐，5 个收口现在行为一致。
2. **解析侧按标剔除**：扁平化按钮产出处（Format A/B 两路）先查标记，命中即丢弃，词表里根本不存在的新 action 同样剔除。
3. **词表兜底旧卡**：无标记的老卡片（聊天历史长期存活）按 `card-handler` 全量派发动作词表（冻结不增长）识别剔除。第三方卡片按钮（Argos 确认/创建群组）、无 payload 的按钮、带 URL 的跳转按钮一律保留。

**避过的坑**：生产语音按钮的 action 不在顶层 `value`，而在 v2 `behaviors:[{type:'callback', value}]` 里且套在 `column_set` 中（session 卡按钮才是顶层 `value:`）——两种形状打标/解析都认，测试照抄 `cli.ts` 生产真实 payload。

## 影响面

- 出站层：callback button 的 value 里多一个无害键，点击回填 `card-handler` 只读已知键不受影响；所有 CLI/后端/会话类型共用同一出站收口，行为一致。
- 解析层：只影响卡片→文本扁平化（history/跨 bot 接力/引用/合并转发），卡片本身的按钮渲染与回调派发不受影响。

## 测试

- `pnpm build` ✅
- `test/message-parser.test.ts` **106/106**（新增 8 条：生产 column_set/behaviors 真实形状、标记+未知 action 未来防腐、打标→解析 roundtrip 全链路、跳转 URL 优先保留、Format A、真实 `buildReplyCardFooter` 整合、stamping 单元 3 条）
- **`test/send-user-message-egress-stamp.test.ts` 5/5**（follow-up 新增，SDK 边界 mock 抓真实 posted `data.content`）：create 路径 + deadline(requestOptions) 路径各断言 callback 按钮被打标；text/post 非交互 body 原样不动、jump-URL 按钮不打标；未知 action 的 send→flatten roundtrip（复现「未来私信按钮」泄漏，证明打标后解析侧无需动词表即 drop）
- 消费侧回归 `card-json-export / quoted-render / card-builder / card-integration / merge-forward / event-dispatcher` 合计 **554 绿**；follow-up 另跑 `cli-send-dispatch / command-handler / settings-card-c4 / quoted-render / merge-forward` 合计 **426 绿**
- mutation 双向有牙：摘掉打标 → 3 条测试红；摘掉解析标记检查 → 2 条测试红；摘掉 `sendUserMessage` 打标 → 3 条 egress 测试红（2 条负向仍绿）

## 遗留（非阻塞 P3）

`BOTMUX_INTERNAL_CARD_ACTIONS` 词表里 `config_set` / `config_quota` / `relay_select` / `relay_page` / `relay_search` 挂在 `select_static`（下拉）而非 `button` 上，`isBotmuxCallbackButton` 只在 `tag==='button'` 分支跑 → 这几条是死条目。今天无害（这类卡也走已打标的 `sendUserMessage` DM），双审都判非阻塞，留作后续。
