### PR TITLE
fix(dashboard): 修复启动 Shell 刷新后不回显

### DIFF
--- a/src/dashboard/bot-payload.ts
+++ b/src/dashboard/bot-payload.ts
@@ -77,6 +77,7 @@ export function botDefaultsPayload(bot: DashboardBotDescriptor, j?: any, error?:
     regularGroupMentionMode: (j?.regularGroupMentionMode === 'topic' || j?.regularGroupMentionMode === 'never' || j?.regularGroupMentionMode === 'ambient')
       ? j.regularGroupMentionMode
       : 'always',
+    docSubscribeDefaultMode: j?.docSubscribeDefaultMode === 'all' ? 'all' : 'mention-only',
     substituteMode: j?.substituteMode && typeof j.substituteMode === 'object' ? j.substituteMode : null,
     restrictGrantCommands: j?.restrictGrantCommands === true,
     autoGrantRequestCards: j?.autoGrantRequestCards !== false,
@@ -92,6 +93,7 @@ export function botDefaultsPayload(bot: DashboardBotDescriptor, j?: any, error?:
     startupCommands: typeof j?.startupCommands === 'string' ? j.startupCommands : '',
     customPassthroughCommands: typeof j?.customPassthroughCommands === 'string' ? j.customPassthroughCommands : '',
     canTalkDaemonCommands: typeof j?.canTalkDaemonCommands === 'string' ? j.canTalkDaemonCommands : '',
+    launchShell: typeof j?.launchShell === 'string' ? j.launchShell : '',
     env: typeof j?.env === 'string' ? j.env : '',
     riff: j?.riff && typeof j.riff === 'object' ? j.riff : null,
     skills: j?.skills && typeof j.skills === 'object' ? j.skills : null,

--- a/test/dashboard-bot-payload.test.ts
+++ b/test/dashboard-bot-payload.test.ts
@@ -2,6 +2,26 @@ import { describe, expect, it } from 'vitest';
 import { botDefaultsPayload, botSummaryPayload } from '../src/dashboard/bot-payload.js';
 
 describe('dashboard bot payload helpers', () => {
+  it('keeps every editable Bot Defaults field in the aggregated /api/bots row', () => {
+    const row = botDefaultsPayload(
+      { larkAppId: 'app_contract', botName: 'BotContract', cliId: 'codex', model: 'gpt-5' },
+      {},
+    );
+    const editableFields = [
+      'agentSelectionKey', 'autoGrantRequestCards', 'autoStartOnGroupJoin',
+      'autoStartOnGroupJoinPrompt', 'autoStartOnNewTopic', 'backendType',
+      'botToBotSameDir', 'brandLabel', 'canTalkDaemonCommands', 'codexAppCleanInput',
+      'customPassthroughCommands', 'defaultOncall', 'defaultWorkingDir',
+      'defaultWorkingDirAutoWorktree', 'disableStreamingCard', 'docSubscribeDefaultMode',
+      'env', 'launchShell', 'maxLiveWorkers', 'messageQuotaDefaultLimit', 'model',
+      'overloadAlert', 'p2pMode', 'privateCard', 'regularGroupMentionMode',
+      'regularGroupReplyMode', 'restrictGrantCommands', 'riff', 'sandbox', 'sandboxPaths',
+      'silentTurnReactions', 'skillInjection', 'startupCommands', 'substituteMode',
+      'summaryRange', 'writableTerminalLinkInCard',
+    ];
+    expect(Object.keys(row)).toEqual(expect.arrayContaining(editableFields));
+  });
+
   it('includes authoritative cliId in group roster bot summaries', () => {
     expect(botSummaryPayload({
       larkAppId: 'cli_traex',
@@ -76,6 +96,30 @@ describe('dashboard bot payload helpers', () => {
     })).toMatchObject({
       customPassthroughCommands: '',
       canTalkDaemonCommands: '',
+    });
+  });
+
+  it('projects launchShell so the dashboard preserves it after refresh', () => {
+    const daemon = { larkAppId: 'app_shell', botName: 'BotShell', cliId: 'codex' };
+    expect(botDefaultsPayload(daemon, { launchShell: '/usr/bin/zsh' })).toMatchObject({
+      launchShell: '/usr/bin/zsh',
+    });
+    expect(botDefaultsPayload(daemon, {})).toMatchObject({ launchShell: '' });
+    expect(botDefaultsPayload(daemon, { launchShell: ['zsh'] as any })).toMatchObject({
+      launchShell: '',
+    });
+  });
+
+  it('projects docSubscribeDefaultMode so the dashboard preserves it after refresh', () => {
+    const daemon = { larkAppId: 'app_doc', botName: 'BotDoc', cliId: 'claude-code' };
+    expect(botDefaultsPayload(daemon, { docSubscribeDefaultMode: 'all' })).toMatchObject({
+      docSubscribeDefaultMode: 'all',
+    });
+    expect(botDefaultsPayload(daemon, {})).toMatchObject({
+      docSubscribeDefaultMode: 'mention-only',
+    });
+    expect(botDefaultsPayload(daemon, { docSubscribeDefaultMode: 'invalid' })).toMatchObject({
+      docSubscribeDefaultMode: 'mention-only',
     });
   });
 


### PR DESCRIPTION
## 问题

Bot Defaults 保存 `launchShell` 后配置已经生效，但刷新 Dashboard 时字段变空。

根因是聚合 `/api/bots` 行数据的 `botDefaultsPayload()` 没有投影 `launchShell`，前端刷新后拿不到已保存值。同一路径也遗漏了可编辑字段 `docSubscribeDefaultMode`。

## 修改

- 在 Dashboard bot defaults payload 中补充 `launchShell`，非法类型回退为空字符串
- 补充 `docSubscribeDefaultMode`，非法值回退为 `mention-only`
- 新增可编辑字段完整性契约测试，防止新增配置项时再次漏投影
- 新增两个字段的值与默认值回归测试

## 影响面

仅影响 Dashboard Bot Defaults 聚合接口的返回数据，不修改配置存储、daemon 启动逻辑、CLI 适配器或会话后端。所有 CLI、平台和会话类型共享该修复；已有配置无需迁移。

无视觉样式变化，因此无截图。

## 验证

- `pnpm vitest run test/dashboard-bot-payload.test.ts`：16 tests passed
- `pnpm build`：通过（含 domain audit、TypeScript 编译、Dashboard bundle、dist audit）
