### PR TITLE
fix(test): 修复 CI build 恒红——sandbox 测试按运行时 bwrap 能力门控 + 更新 grant 陈旧断言

### DIFF
--- a/test/card-handler-grant-partial.test.ts
+++ b/test/card-handler-grant-partial.test.ts
@@ -76,10 +76,10 @@ describe('card-handler 部分授权失败', () => {
     };
   }
 
-  it('部分成功：失败 target 的 pending 被清（不再永久 throttle），owner 收到失败清单，成功 bot 仍登记+撤卡', async () => {
+  it('部分成功：失败 target 的 pending 被清（不再永久 throttle），owner 收到失败清单，成功 bot 仍登记，原卡就地更新为终态（不撤卡）', async () => {
     const { pending, handler } = await fresh();
     const nonce = pending.openPendingMulti('h1', 'oc_1', ['ou_ok', 'ou_fail']);
-    await handler.handleCardAction(multiAction(['ou_ok', 'ou_fail'], ['好机器人', '坏目标'], nonce), deps, 'h1');
+    const res = await handler.handleCardAction(multiAction(['ou_ok', 'ou_fail'], ['好机器人', '坏目标'], nonce), deps, 'h1');
 
     // 失败 target 的 pending 必须清掉：checkNonce/isThrottled 都不再挡它（同步发生，扣 pending 在落库阶段）
     expect(pending.checkNonce('h1', 'oc_1', 'ou_fail', nonce)).toBe(false);
@@ -87,7 +87,11 @@ describe('card-handler 部分授权失败', () => {
     // 成功 target 也清了
     expect(pending.checkNonce('h1', 'oc_1', 'ou_ok', nonce)).toBe(false);
 
-    await flushBackground();   // 通知 + 失败清单文字 + 撤卡走后台 fire-and-forget
+    // 授权成功就地 patch 原卡为终态（绿头 update_multi），同步返回该 body——不再撤卡（见 2d1faa4c）
+    expect(res?.config?.update_multi).toBe(true);
+    expect(res?.header?.template).toBe('green');
+
+    await flushBackground();   // 失败清单文字走后台 fire-and-forget
 
     // owner 收到失败清单（含失败目标名），且不是静默
     const partialReply = replyMock.mock.calls.find(c => typeof c[2] === 'string' && String(c[2]).includes('坏目标'));
@@ -98,8 +102,8 @@ describe('card-handler 部分授权失败', () => {
     const [, , , entries] = recordObservedMock.mock.calls.at(-1)!;
     expect(entries).toEqual([{ openId: 'ou_ok', name: '好机器人' }]);
 
-    // 卡仍撤回
-    expect(deleteMock).toHaveBeenCalledWith('h1', 'om_card');
+    // 原卡就地更新即完成，不再撤回（2d1faa4c：不发通知卡 + 不撤原卡）
+    expect(deleteMock).not.toHaveBeenCalled();
   });
 
   it('全部失败：保留 pending（owner 可点原卡重试）+ toast 报错，不撤卡', async () => {

--- a/test/plugin-mcp-sandbox.test.ts
+++ b/test/plugin-mcp-sandbox.test.ts
@@ -13,7 +13,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { prepareDirectSandbox } from '../src/adapters/backend/sandbox.js';
+import { prepareDirectSandbox, probeHostCredentialIsolationMechanism } from '../src/adapters/backend/sandbox.js';
 import { buildFsPolicy } from '../src/adapters/cli/fs-policy.js';
 import { installLocalPlugin } from '../src/core/plugins/install.js';
 import { ensureGatewayEntry } from '../src/core/plugins/mcp/gateway-installer.js';
@@ -35,13 +35,20 @@ import {
 
 const builtCli = resolve('dist/cli.js');
 
+// bwrap being installed is not enough: unprivileged user-namespace creation is
+// disabled on many CI runners (GitHub Actions), where bwrap dies with
+// "setting up uid map: Permission denied". Gate on the SAME runtime probe the
+// worker uses so these real-sandbox specs skip (not fail) where the kernel
+// won't let bwrap establish namespaces, while still running on capable hosts.
+const bwrapUsable = probeHostCredentialIsolationMechanism().mechanism === 'bwrap';
+
 function codexForwardedEnvKeys(configPath: string): string[] {
   const match = readFileSync(configPath, 'utf8').match(/^env_vars = (\[[^\n]+])$/m);
   if (!match) throw new Error('generated Codex Gateway entry has no env_vars');
   return JSON.parse(match[1]) as string[];
 }
 
-describe.skipIf(process.platform !== 'linux' || !existsSync(builtCli))('plugin MCP Gateway sandbox integration', () => {
+describe.skipIf(process.platform !== 'linux' || !existsSync(builtCli) || !bwrapUsable)('plugin MCP Gateway sandbox integration', () => {
   let root: string;
   let home: string;
   let dataDir: string;

--- a/test/v3-distillation-runner.test.ts
+++ b/test/v3-distillation-runner.test.ts
@@ -12,6 +12,7 @@ import {
 import { spawn } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { probeHostCredentialIsolationMechanism } from '../src/adapters/backend/sandbox.js';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -32,6 +33,14 @@ import type { BotSnapshot } from '../src/workflows/v3/contract.js';
 
 const roots: string[] = [];
 const originalAnthropicApiKey = process.env.ANTHROPIC_API_KEY;
+
+// The PID-namespace spec below launches a REAL bwrap-wrapped helper. bwrap
+// being installed is not enough — unprivileged user-namespace creation is
+// disabled on many CI runners (GitHub Actions), where bwrap dies with "setting
+// up uid map: Permission denied" and the helper never writes its pid. Gate on
+// the SAME runtime probe the worker uses so the spec skips (not fails) there,
+// while still exercising the real namespace collapse on capable hosts.
+const bwrapUsable = probeHostCredentialIsolationMechanism().mechanism === 'bwrap';
 
 // Hermeticity guard. runV3DistillationModel reads process.env for provider
 // selection whenever the bot does NOT own provider config (botOwnsProviderConfiguration
@@ -378,7 +387,7 @@ describe('runV3DistillationModel', () => {
     expect(readdirSync(dirs.scratchParent)).toEqual([]);
   });
 
-  it.skipIf(process.platform !== 'linux')(
+  it.skipIf(process.platform !== 'linux' || !bwrapUsable)(
     'collapses the PID namespace before cleaning scratch',
     async () => {
     const dirs = fixture();


### PR DESCRIPTION
## 背景

`master` 的 CI `build` job（跑 `pnpm test`）**长期失败**（最近多次 run 均红）。排查后确认 3 个失败测试文件**与被测代码/依赖无关**，是测试自身的环境门控/陈旧断言问题：

## 问题 1：sandbox 测试环境门控不足（2 个文件）

`test/plugin-mcp-sandbox.test.ts`、`test/v3-distillation-runner.test.ts` 里跑**真实 bwrap** 的用例，skip 判断只看 `process.platform === 'linux'`（+ 有无 `dist/cli.js`）。但 **GitHub Actions runner 禁用了非特权 user namespace**，bwrap 一起就死：

```
bwrap: setting up uid map: Permission denied
```

于是用例不 skip、反而 fail（`plugin-mcp-sandbox` ×3、`v3-distillation-runner` PID namespace 用例 ×1）。

**修法**：复用 worker 生产同款运行时探针 `probeHostCredentialIsolationMechanism()`（内部实跑一次 `--unshare-user … -- /bin/true`）判断 bwrap 是否**真的可用**，无能力的 runner 上 skip、有能力的主机照常真跑。与仓库里 `test/fs-policy-bwrap.e2e.test.ts` 既有的 `bwrapUsable` 门控是同一思路（DRY：直接用生产探针，不另造一份）。

## 问题 2：`card-handler-grant-partial` 陈旧断言（1 个文件）

「部分成功」用例断言 `expect(deleteMock).toHaveBeenCalledWith('h1', 'om_card')`（撤回原卡）。但 **2d1faa4c**（2026-07-31，`fix(grant): 授权成功就地更新原卡(正文@被授权人),不再发通知卡+撤回原卡`）已把行为改成**就地 patch 原卡为终态、不再撤卡**。断言未同步 → **自那以后恒 fail**。

**修法**：改为断言 `handleCardAction` 返回就地更新的终态卡（`config.update_multi === true` + `header.template === 'green'`）、且 `deleteMock` 未被调用——对齐同文件「全部失败」用例已有的 `expect(deleteMock).not.toHaveBeenCalled()` 风格。

## 验证

| 场景 | 结果 |
|---|---|
| 本机（bwrap 可用） | 3 文件 **38 测试全绿**，sandbox 用例**真跑未 skip** |
| 模拟 runner（PATH 塞入失败的 bwrap stub） | `plugin-mcp-sandbox` 整块 skip、`v3-distillation` PID 用例 skip，**0 失败** = CI 应得的绿 |
| `tsc --noEmit` | 干净 |
| 相邻套件 `card-handler-grant` / `sandbox` / `fs-policy-bwrap` | **47 测试全绿** |

## 影响面

**纯测试文件改动**，不动任何 `src` 运行时逻辑；跨平台 / 跨 CLI / 跨后端均无影响。

## 关联

修复本 PR 后，CI `build` 将转绿，同时也会解除 #699（Dependabot 安全修复）等其它 PR 因 master 既有 CI 红而误判失败的问题。建议本 PR 先行合入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)