### PR TITLE
fix(restore): 机器重启后托管会话不再被误判僵尸清除——missing 一律保留 lazy cold-resume

### DIFF
--- a/src/adapters/backend/tmux-backend.ts
+++ b/src/adapters/backend/tmux-backend.ts
@@ -99,20 +99,19 @@ export class TmuxBackend implements SessionBackend {
    * Tri-state existence probe. `tmux has-session` exits 0 when the session
    * exists and exits 1 (clean status, no signal) when the server answered but
    * the session is absent — INCLUDING "no server running". Both collapse to
-   * 'missing' here. The caller MUST disambiguate before treating 'missing' as a
-   * destructive signal: a single gone pane (server still up) is a true zombie,
-   * but "no server running" means the *whole* server died (e.g. machine reboot)
-   * and every pane vanished at once — those sessions are still resumable from
-   * the CLI transcript on disk. Use `serverState()` to tell the two apart (the
-   * restore path does exactly this). Anything else — a timeout (signal/killed)
-   * or a spawn failure (binary not on PATH → ENOENT, not executable → EACCES;
-   * neither carries a numeric exit status) — means we never got an answer →
-   * 'unknown', so a flaky/unavailable tmux can't be mistaken for a gone session.
+   * 'missing' here. 'missing' is NOT a destructive signal on restore: whether a
+   * single pane died (solo crash) or the whole server is gone (machine reboot),
+   * the CLI transcript on disk is still resumable, so restore keeps the session
+   * active and cold-resumes it on the next message (see restoreActiveSessions).
+   * Anything else — a timeout (signal/killed) or a spawn failure (binary not on
+   * PATH → ENOENT, not executable → EACCES; neither carries a numeric exit
+   * status) — means we never got an answer → 'unknown', so a flaky/unavailable
+   * tmux can't be mistaken for a gone session either.
    *
    * Uses execFileSync (NOT a shell string): running tmux directly keeps a
    * missing/unrunnable binary as ENOENT/EACCES. A shell would instead surface
    * those as its own clean exits 127/126, which this classifier would wrongly
-   * read as 'missing' and then drive a destructive restore-time close.
+   * read as 'missing'.
    */
   static probeSession(name: string): SessionProbe {
     try {
@@ -120,35 +119,6 @@ export class TmuxBackend implements SessionBackend {
       return 'exists';
     } catch (e: any) {
       if (e && typeof e.status === 'number' && !e.signal) return 'missing';
-      return 'unknown';
-    }
-  }
-
-  /**
-   * Tri-state liveness of the tmux SERVER itself (not a specific session).
-   *
-   *   - 'running' — `tmux list-sessions` exited 0, so the server is up with ≥1
-   *                 session. (A tmux server with zero sessions doesn't exist —
-   *                 it self-terminates when its last session closes — so exit 0
-   *                 is an authoritative "server alive".)
-   *   - 'down'    — clean non-zero exit (no signal): "no server running on …".
-   *                 Every pane the server held is gone *at once*.
-   *   - 'unknown' — timeout / signal / spawn failure (ENOENT/EACCES): no answer.
-   *
-   * Why this matters: `probeSession` returns 'missing' BOTH when the server is
-   * up but one session is gone AND when the whole server is down (machine
-   * reboot). Those are very different — a reboot wipes every bmx-* pane
-   * simultaneously, but the CLI transcripts on disk are still resumable. The
-   * restore path uses this to avoid mass-closing every session on the first
-   * boot after a reboot (which would otherwise read each pane as an
-   * authoritative 'missing' zombie and tear it down).
-   */
-  static serverState(): 'running' | 'down' | 'unknown' {
-    try {
-      execFileSync('tmux', ['list-sessions'], { stdio: 'ignore', env: tmuxEnv(), timeout: 3000 });
-      return 'running';
-    } catch (e: any) {
-      if (e && typeof e.status === 'number' && !e.signal) return 'down';
       return 'unknown';
     }
   }

--- a/src/adapters/backend/zellij-backend.ts
+++ b/src/adapters/backend/zellij-backend.ts
@@ -121,22 +121,6 @@ export class ZellijBackend implements SessionBackend {
     return probe.sessions.includes(name) ? 'exists' : 'missing';
   }
 
-  /**
-   * Tri-state liveness of the zellij SERVER (not a specific session). Mirrors
-   * TmuxBackend.serverState — see that doc for why 'missing' must be
-   * disambiguated before driving a destructive restore-time close.
-   *
-   *   - 'running' — list-sessions succeeded with ≥1 live session.
-   *   - 'down'    — list-sessions succeeded with ZERO live sessions, i.e. nothing
-   *                 survives (a machine reboot wipes every session at once).
-   *   - 'unknown' — list-sessions failed/timed out (can't tell).
-   */
-  static serverState(): 'running' | 'down' | 'unknown' {
-    const probe = ZellijBackend.probeLiveSessions();
-    if (!probe.ok) return 'unknown';
-    return probe.sessions.length > 0 ? 'running' : 'down';
-  }
-
   /** Kill + purge a session (so no resurrectable corpse accumulates). */
   static killSession(name: string): void {
     try {

--- a/src/adapters/backend/zmx-backend.ts
+++ b/src/adapters/backend/zmx-backend.ts
@@ -538,14 +538,6 @@ export class ZmxBackend implements SessionBackend {
     return { state: 'compatible', pid: after.pid, clients: after.clients };
   }
 
-  /** ZMX has one daemon per session rather than one shared server. */
-  static serverState(): 'running' | 'down' | 'unknown' {
-    const probe = ZmxBackend.probeSessions();
-    if (!probe.ok) return 'unknown';
-    if (probe.unhealthySessions.some(s => s.startsWith('bmx-'))) return 'unknown';
-    return probe.sessions.some(s => s.startsWith('bmx-')) ? 'running' : 'down';
-  }
-
   static killSession(name: string): void {
     try {
       execFileSync('zmx', ['kill', name, '--force'], {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,7 +82,7 @@ import { scrubClaudeSessionMarkerEnv, scrubSessionCliHomeEnv } from './utils/chi
 import { scheduleTimeZone } from './utils/timezone.js';
 import { expandHomePath, invalidWorkingDirs } from './utils/working-dir.js';
 import { firstPositional } from './cli/arg-utils.js';
-import { isColdResumeDormant, sessionListDisposition } from './cli/session-list-liveness.js';
+import { isColdResumeDormant, isRealManagedSession, sessionListDisposition } from './cli/session-list-liveness.js';
 import {
   attachFrozenManagedZmxSession,
   freezeManagedZmxAttachTarget,
@@ -4173,8 +4173,11 @@ async function cmdList(): Promise<void> {
     const hasPid = !!(s.pid && isProcessAlive(s.pid));
     const hasBackingSession = hasRecoverableBackingSession(s, probeSnapshot);
     const disposition = sessionListDisposition(s, { hasPid, hasBackingSession });
-    if (disposition === 'prune_real') pruned.push(s);
-    else if (disposition === 'prune_scratch') prunedScratch.push(s);
+    // Non-adopt sessions are only ever kept or pruned-as-scratch now: a real
+    // managed session with a missing backing is dormant-recoverable, never
+    // auto-closed by this read command (see sessionListDisposition). Adopt
+    // zombies still reach the `pruned` bucket via the branch above.
+    if (disposition === 'prune_scratch') prunedScratch.push(s);
     else live.push(s);
   }
   const closeNow = async (arr: SessionData[], kind: 'scratch' | 'real'): Promise<number> => {
@@ -4231,7 +4234,6 @@ async function cmdDelete(): Promise<void> {
 
   const sessions = loadSessions();
   const active = [...sessions.values()].filter(s => s.status === 'active');
-  const probeSnapshot = buildBackingProbeSnapshot(active);
 
   if (active.length === 0) {
     console.log('没有活跃会话。');
@@ -4244,18 +4246,22 @@ async function cmdDelete(): Promise<void> {
     toDelete = active;
   } else if (target === 'stopped') {
     toDelete = active.filter(s => {
-      // A deliberately cap-suspended session has neither pid nor backing pane
-      // (that's how its memory is reclaimed) but must cold-resume on the next
-      // message — never a zombie. Mirrors the server-side isSessionStopped guard
-      // and the `list` prune disposition; without it `delete stopped` (which the
-      // overload alert text recommends) would drop a live-but-parked session.
+      // "stopped" = a true zombie the sweep may auto-close. A real managed
+      // session with no live pid is dormant-recoverable, NOT stopped: whether
+      // the CLI merely exited, botmux cap-suspended it, or a host reboot wiped
+      // its backing pane, the on-disk transcript still cold-resumes on the next
+      // message. So a missing backing is NOT a close trigger here — only an
+      // adopted session with a dead external pid, or a disposable scratch that
+      // never became a real CLI session, counts as stopped. Reuses the exact
+      // real-vs-scratch discriminator the server-side isSessionStopped and
+      // `botmux list` prune both use, so the three entry points can't drift.
       if (isColdResumeDormant(s)) return false;
       if (isAdoptedSession(s)) {
         const pid = adoptedCliPid(s);
         return pid ? !isProcessAlive(pid) : !(s.pid && isProcessAlive(s.pid));
       }
       const hasPid = !!(s.pid && isProcessAlive(s.pid));
-      return !hasPid && !hasRecoverableBackingSession(s, probeSnapshot);
+      return !hasPid && !isRealManagedSession(s);
     });
     if (toDelete.length === 0) {
       console.log('没有 stopped 状态的会话。');

--- a/src/cli/session-list-liveness.ts
+++ b/src/cli/session-list-liveness.ts
@@ -5,16 +5,38 @@ export interface SessionListMarkers {
   adoptedFrom?: unknown;
 }
 
-export type SessionListDisposition = 'keep' | 'prune_real' | 'prune_scratch';
+export type SessionListDisposition = 'keep' | 'prune_scratch';
+
+/**
+ * A "real" managed session is one that ever ran a CLI (frozen `cliId`), took a
+ * turn (`lastCliInput`), or adopted a foreign process (`adoptedFrom`). Its CLI
+ * transcript on disk is resumable, so the daemon can always cold-resume it and,
+ * if the transcript is genuinely gone, fall back to a fresh session with a
+ * user-visible notice — never a dead end. A row with none of these markers
+ * never became a real CLI session (an unconfirmed /adopt picker, /help, an
+ * abandoned /relay picker): it is a disposable scratch, safe to prune silently.
+ */
+export function isRealManagedSession(session: SessionListMarkers): boolean {
+  return !!(session.cliId || session.lastCliInput || session.adoptedFrom);
+}
 
 /**
  * Decide whether `botmux list` may auto-prune a non-adopt session whose
  * process/backing-session probes have already been evaluated by the caller.
  *
- * A cap-suspended session deliberately has neither a process PID nor a backing
- * tmux/herdr/zellij/zmx session: that is how its memory is reclaimed. The persisted
- * cold-resume marker is therefore authoritative and must beat the generic
- * zombie heuristic.
+ * The invariant (shared with the server-side `isSessionStopped` sweep): a
+ * missing pid/backing is NEVER, on its own, grounds to permanently close a real
+ * managed session. Whether the CLI process merely exited, the idle-worker
+ * sweeper reclaimed it (cap-suspend), or a whole-host reboot wiped every backing
+ * pane at once, the on-disk transcript is still resumable — so the row is kept
+ * dormant and cold-resumes on the next message. `list` is a READ command and
+ * must not double as a destructive sweep that undoes what restore just kept.
+ *
+ * Only two things are pruned: a deliberate cap-suspension is redundant to keep
+ * distinct here (already `keep` via the marker below), and a disposable scratch
+ * that never became a real CLI session is closed silently. Explicit teardown
+ * (`botmux delete <id>` / `delete stopped` / `/close`) is a separate, intended
+ * path and is unaffected.
  */
 export function sessionListDisposition(
   session: SessionListMarkers,
@@ -22,9 +44,13 @@ export function sessionListDisposition(
 ): SessionListDisposition {
   if (runtime.hasPid || runtime.hasBackingSession) return 'keep';
   if (session.suspendedColdResume === true) return 'keep';
-  return session.cliId || session.lastCliInput || session.adoptedFrom
-    ? 'prune_real'
-    : 'prune_scratch';
+  // A real managed session with neither a live pid nor a surviving backing pane
+  // is dormant, not a zombie: keep it for lazy cold-resume instead of pruning.
+  // This is the host-reboot fix — `restoreActiveSessions` keeps these rows, and
+  // a subsequent `botmux list` must not re-close them (the co-tenant-poisoned
+  // "is the backing gone?" signal is no longer a close trigger anywhere).
+  if (isRealManagedSession(session)) return 'keep';
+  return 'prune_scratch';
 }
 
 export function isColdResumeDormant(session: SessionListMarkers): boolean {

--- a/src/core/persistent-backend.ts
+++ b/src/core/persistent-backend.ts
@@ -274,26 +274,6 @@ export function probePersistentSessions(
 }
 
 /**
- * Tri-state liveness of the backend's multiplexer SERVER itself (not one
- * session). The restore path consults this when a session probes 'missing' to
- * tell apart a true solo zombie (server up, this one pane gone → close) from a
- * machine reboot (server gone, every pane wiped at once → keep for lazy resume,
- * since the CLI transcript on disk is still resumable). See
- * TmuxBackend.serverState for the full rationale.
- *
- * herdr has no cheap server-liveness probe, so it returns 'unknown' →
- * the restore gate falls back to the prior (close-on-missing) behaviour for it.
- */
-export function probePersistentBackendServer(
-  backendType: PersistentBackendType,
-): 'running' | 'down' | 'unknown' {
-  if (backendType === 'tmux') return TmuxBackend.serverState();
-  if (backendType === 'zellij') return ZellijBackend.serverState();
-  if (backendType === 'zmx') return ZmxBackend.serverState();
-  return 'unknown';
-}
-
-/**
  * Kill a backing session. ZMX additionally requires the complete botmux UUID:
  * its public name contains only eight UUID characters, so name-only deletion
  * could destroy a different session after a prefix collision.

--- a/src/core/session-liveness.ts
+++ b/src/core/session-liveness.ts
@@ -1,29 +1,34 @@
 /**
  * Shared "is this session a stopped zombie?" predicate — the same notion the
- * `botmux delete stopped` CLI subcommand uses (dead CLI process + no exact
- * persistent backing), factored out so the host-overload alert's "清僵尸"
- * button can reuse the exact semantics server-side without duplicating (or
- * drifting from) the CLI logic.
+ * `botmux delete stopped` CLI subcommand and the host-overload "清僵尸" button
+ * use, factored out so they can't drift apart.
  *
- * A zombie = a session the store still marks `active`, but whose CLI process is
- * gone and has no recoverable backing target — i.e. nothing is actually
- * running, it's just a stale record holding a slot. Intentionally-suspended sessions are NOT
- * zombies: they're worker-less on purpose and cold-resume on the next message.
- * botmux's own cap-suspend deliberately clears the pid AND destroys the backing
- * CLI/backend (that's how it reclaims memory), so the pid/backend probe alone can't
- * tell such a session apart from a true zombie — it would classify the just-
- * suspended session as stopped and let the sweep permanently close it. The
- * persisted `suspendedColdResume` marker is therefore authoritative and short-
- * circuits to "not stopped", matching the CLI `list` prune guard
- * (session-list-liveness.ts). Callers still gate on `status === 'active'`.
+ * The invariant (shared with `botmux list`'s auto-prune, see
+ * cli/session-list-liveness.ts): a missing pid/backing is NEVER, on its own,
+ * grounds to permanently close a REAL managed session. A real managed session
+ * (one that ever ran a CLI, took a turn, or adopted a process) has a resumable
+ * CLI transcript on disk, so whatever removed its live process — a plain CLI
+ * exit, botmux's own idle-worker cap-suspend, or a whole-host reboot that wiped
+ * every multiplexer pane at once — the next message cold-resumes it (and if the
+ * transcript is genuinely gone, the worker's resume→fresh fallback spawns a
+ * clean session with a user-visible notice). It is dormant, not a zombie.
+ *
+ * A zombie here is therefore only a DISPOSABLE SCRATCH: a row that never became
+ * a real CLI session (an unconfirmed /adopt picker, /help, an abandoned /relay
+ * picker) and now has no live process. Adopted sessions are the one case whose
+ * external pid is authoritative — we never spawned a botmux worker and hold no
+ * transcript of our own, so a dead adopted pid IS a real stop.
+ *
+ * Why we no longer probe the multiplexer backing: botmux shares the default
+ * tmux socket with the operator's own terminal, so a co-tenant reviving the
+ * server made a reboot read as N solo zombies → 239 live sessions mass-closed
+ * after a single reboot. The transcript on disk — not a co-tenant-poisoned
+ * "is the pane alive?" probe — is the authoritative recoverability signal.
+ *
+ * Callers still gate on `status === 'active'`.
  */
-import { execFileSync } from 'node:child_process';
 import type { Session } from '../types.js';
-import {
-  isSuspendableBackendType,
-  probePersistentBackendTarget,
-  resolvePersistentBackendTarget,
-} from './persistent-backend.js';
+import { isRealManagedSession } from '../cli/session-list-liveness.js';
 
 /** Liveness check for an arbitrary pid without signalling it (signal 0). */
 export function isProcessAlive(pid: number): boolean {
@@ -37,17 +42,6 @@ export function isProcessAlive(pid: number): boolean {
   }
 }
 
-/** True when a `bmx-<prefix>` legacy tmux session exists. Best-effort; tmux missing
- *  or any error → treated as "no pane". */
-export function tmuxSessionExists(name: string): boolean {
-  try {
-    execFileSync('tmux', ['has-session', '-t', name], { stdio: 'ignore', timeout: 3000 });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 function adoptedCliPid(s: Session): number | undefined {
   const pid = s.adoptedFrom && typeof s.adoptedFrom === 'object'
     ? (s.adoptedFrom as { originalCliPid?: number }).originalCliPid
@@ -56,49 +50,29 @@ function adoptedCliPid(s: Session): number | undefined {
 }
 
 /**
- * True when a session record is a stopped zombie: no live CLI process and no
- * recoverable backing target. Mirrors cli.ts `delete stopped`. For adopted
- * sessions the original CLI pid is authoritative (we never spawned a botmux
- * worker); for normal sessions, both the recorded worker pid and the exact
- * persisted backend target must be gone. Caller is responsible for the
+ * True when a session record is a stopped zombie: no live process AND it is not
+ * a real managed session that could cold-resume. See the module doc for the
+ * full rationale. For adopted sessions the original CLI pid is authoritative
+ * (we never spawned a botmux worker). Caller is responsible for the
  * `status === 'active'` gate.
  */
 export function isSessionStopped(s: Session): boolean {
-  // botmux cap-suspended a session on purpose: pid cleared + backing CLI/tmux
-  // destroyed, cold-resumes on the next message. The marker beats the generic
-  // zombie heuristic so the "清僵尸" sweep can't permanently close it.
-  if (s.suspendedColdResume === true) return false;
+  // Adopt: the wrapped foreign CLI's own pid is authoritative — we hold no
+  // transcript of our own to resume, so a dead adopted pid IS a real stop.
   const originalPid = adoptedCliPid(s);
   if (originalPid !== undefined) {
     return !isProcessAlive(originalPid);
   }
-  // A live worker pid alone proves the session isn't a zombie — short-circuit
-  // before touching tmux so the (synchronous, up-to-3s) tmux probe only ever
-  // runs for sessions whose pid is already dead. Keeps counts/sweep from
-  // spawning a tmux child per live session and stalling the daemon loop.
+  // A live worker pid alone proves the session isn't a zombie.
   if (s.pid && isProcessAlive(s.pid)) return false;
-
-  // Remote Riff tasks have no local worker/backing process to prove dead.
-  // ZMX likewise owns one independent daemon per session: a missing backing
-  // daemon can mean a normal process/host restart, and the transcript-backed
-  // row remains recoverable by a lazy cold-resume. Neither backend is safe to
-  // permanently close from this local zombie heuristic.
-  if (s.backendType === 'riff' || s.backendType === 'zmx') return false;
-  if (s.backendType === 'pty') return true;
-
-  // Rows created before backend stamping used tmux as their only externally
-  // recoverable backing. Preserve that compatibility probe.
-  if (s.backendType === undefined) {
-    return !tmuxSessionExists(`bmx-${s.sessionId.substring(0, 8)}`);
-  }
-
-  if (!isSuspendableBackendType(s.backendType)) return true;
-  const target = resolvePersistentBackendTarget(
-    s.backendType,
-    s.sessionId,
-    s.persistentBackendTarget,
-  );
-  // Only positive absence is safe to sweep. A transient backend/control-plane
-  // failure must not turn a live persistent CLI into a destructive "zombie".
-  return probePersistentBackendTarget(target) === 'missing';
+  // botmux cap-suspended a session on purpose (pid cleared + backing destroyed
+  // to reclaim memory): the marker beats the heuristic. Subsumed by the
+  // real-managed check below, but kept explicit as the authoritative signal.
+  if (s.suspendedColdResume === true) return false;
+  // No live process. A real managed session is dormant-recoverable (transcript
+  // on disk), NOT a closeable zombie — regardless of backend or whether its
+  // multiplexer pane survived. Only a scratch that never became a real CLI
+  // session is a true stop. This is the host-reboot fix: `restoreActiveSessions`
+  // keeps these rows, and the sweep must not re-close them.
+  return !isRealManagedSession(s);
 }

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -25,7 +25,6 @@ import {
   getSessionPersistentBackendType,
   persistentBackendTargetForSession,
   persistentSessionName,
-  probePersistentBackendServer,
   probePersistentBackendTarget,
   probePersistentSession,
   probePersistentSessions,
@@ -1679,16 +1678,6 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
   for (const [backendType, names] of namesByBackend) {
     probeSnapshots.set(backendType, probePersistentSessions(backendType, names));
   }
-  // Server-liveness is sampled ONCE per backend type (cached): a single
-  // `tmux list-sessions` answers for all of that backend's sessions, and a
-  // consistent snapshot avoids a mid-loop race where an early lazy fork could
-  // flip the answer partway through (the loop itself starts no workers).
-  const serverStateCache = new Map<PersistentBackendType, 'running' | 'down' | 'unknown'>();
-  const backendServerState = (bt: PersistentBackendType) => {
-    let s = serverStateCache.get(bt);
-    if (s === undefined) { s = probePersistentBackendServer(bt); serverStateCache.set(bt, s); }
-    return s;
-  };
   for (const { ds, backendType, backendTarget, backendName } of restoreCandidates) {
     // An earlier candidate's mismatch close can await document cleanup, so
     // revalidate exact ownership and worker state for every row before any
@@ -1702,39 +1691,34 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
       : probeSnapshots.get(backendType)?.get(backendTarget.sessionName) ?? 'unknown';
     if (probe === 'missing') {
       const tag = ds.session.sessionId.substring(0, 8);
-      // Intentionally cold-resume-suspended (idle-worker sweeper killed the
-      // backing session + CLI to reclaim memory over the per-bot live cap). The
-      // 'missing' backing is EXPECTED here, not a zombie — keep the worker-less
-      // active record so the next message cold-resumes from the transcript
-      // (forkWorker(resume=true) clears the marker once the worker is back).
-      if (ds.session.suspendedColdResume) {
-        logger.info(`[${tag}] ${backendType} session was cap-suspended — keeping active for lazy cold-resume`);
-        continue;
-      }
-      // ZMX is not a shared multiplexer server: every session owns an
-      // independent daemon. Another live ZMX session says nothing about this
-      // one, so "missing" cannot safely drive a destructive zombie close.
-      // Preserve the transcript-backed row and cold-resume on the next message.
-      if (backendType === 'zmx') {
-        logger.warn(`[${tag}] zmx backing session "${backendName}" is missing — keeping active for lazy resume`);
-        continue;
-      }
-      // 'missing' is ambiguous: it means EITHER this one pane is gone while the
-      // server runs (a true solo zombie) OR the whole multiplexer server is down
-      // (e.g. machine reboot) and every pane vanished at once. Only the former is
-      // a zombie to close. On a reboot the CLI transcript on disk is still
-      // resumable, so keep the worker-less active record and let it lazily resume
-      // on the next message (exactly like a pty session) instead of mass-closing
-      // every session — the bug that wiped a full dashboard after a host reboot.
-      if (backendServerState(backendType) === 'down') {
-        logger.warn(`[${tag}] ${backendType} server is down (host reboot?) — keeping "${backendName}" active for lazy resume instead of closing`);
-        continue;
-      }
-      // Server is up (or its state is inconclusive) and this specific pane is
-      // gone — a true zombie. Close it (evicts the active record + marks the
-      // store row closed) so the next message starts a clean session.
-      logger.warn(`[${tag}] ${backendType} backing session "${backendName}" is gone — closing zombie active session`);
-      await closeSession(ds.session.sessionId);
+      // A missing backing pane is NEVER an auto-close trigger for a managed
+      // session. Whatever wiped the pane — a host reboot (whole multiplexer
+      // server gone, every pane at once), the idle-worker sweeper reclaiming
+      // memory over the per-bot cap, or a solo CLI crash — the on-disk CLI
+      // transcript is still resumable, so the worker-less active record is kept
+      // and the next message cold-resumes from it (forkWorker(resume=true); if
+      // the transcript is genuinely gone the worker's resume→fresh fallback
+      // spawns a clean session with a user-visible notice — never a dead end).
+      //
+      // This deliberately mirrors pty (no persistent backend → never probed,
+      // never closed) and zmx (per-session daemon → 'missing' always kept). The
+      // only sessions that leave the active set are: a real `/close` (which
+      // marks the store row 'closed' up front, so it is never even in this
+      // `active` restore set), an adopt target that provably exited (handled in
+      // the adopt branch above — those wrap a foreign process with no transcript
+      // of our own), and a CLI-config mismatch (handled below).
+      //
+      // History: an earlier version gated this on `serverState() === 'down'` to
+      // distinguish a whole-server reboot from a solo zombie, then closed the
+      // "solo zombie". But botmux shares the default tmux socket with the
+      // operator's own terminal, so a co-tenant session reviving the server
+      // before restore ran made every reboot read as N solo zombies → 239
+      // active sessions mass-closed after one host reboot. Closing bought only a
+      // tidier dashboard while risking irreversible session loss, so the whole
+      // close-on-missing path was removed. A TTL sweep (evict long-idle active
+      // rows) is the right tool for dashboard tidiness and is intentionally out
+      // of scope here.
+      logger.info(`[${tag}] ${backendType} backing session "${backendName}" is missing — keeping active for lazy cold-resume (transcript is still resumable)`);
       continue;
     }
     if (probe === 'unknown') {

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -2062,9 +2062,12 @@ export function suspendWorker(ds: DaemonSession, reason = 'suspended_idle'): boo
   // cold-resume from the on-disk transcript. forkWorker(resume=true) builds the
   // CLI's `--resume <cliSessionId>` args, so mark this session as having history
   // (the normal `claude_exit` path that sets this never fires on suspend —
-  // process.exit(0) races it). Also persist `suspendedColdResume` so a daemon
-  // restart treats a 'missing' backing session as a deliberate lazy-resume
-  // rather than a zombie to close. See sweepIdleWorkers + restoreActiveSessions.
+  // process.exit(0) races it). Also persist `suspendedColdResume` to record the
+  // deliberate parked state — since the host-reboot fix, restore keeps ANY
+  // managed session with a 'missing' backing for lazy resume, so this marker no
+  // longer gates that decision; it flags "intentionally parked, expect no
+  // worker/pane" for the dormant status label and skips redundant liveness
+  // probes. See sweepIdleWorkers + restoreActiveSessions.
   ds.hasHistory = true;
   ds.session.suspendedColdResume = true;
   sessionStore.updateSessionPid(ds.session.sessionId, null);
@@ -5300,10 +5303,12 @@ function setupWorkerHandlers(
             // periodic usage refresh must be stopped explicitly on this
             // working→idle boundary — the else branch's killWorker already does.
             clearUsageRefreshTimer(ds);
-            // Survive a daemon restart: mark this as a lazy cold-resume so
-            // restore keeps the session active (re-spawns the CLI on the next
-            // message) instead of zombie-closing it when the real bmx-<sid> is
-            // found missing. ds.hasHistory is already true (set at the top of
+            // Survive a daemon restart: mark this as a deliberate lazy
+            // cold-resume. Restore keeps ANY managed session with a 'missing'
+            // backing active regardless (re-spawns the CLI on the next
+            // message) since the host-reboot fix, so this marker records the
+            // parked state (dormant label + skip redundant probes) rather than
+            // gating the keep. ds.hasHistory is already true (set at the top of
             // claude_exit); forkWorker clears suspendedColdResume on re-spawn.
             ds.session.suspendedColdResume = true;
             sessionStore.updateSession(ds.session);

--- a/src/types.ts
+++ b/src/types.ts
@@ -358,10 +358,13 @@ export interface Session {
    * Set true when the idle-worker sweeper suspends this session over the per-bot
    * live cap: the worker AND the backing tmux/herdr/zellij/zmx session (+ CLI) were
    * intentionally killed to reclaim memory, but the session stays `active` and
-   * cold-resumes from its on-disk transcript on the next message. Distinguishes
-   * this deliberate state from a real zombie (pane gone while the server runs):
-   * `restoreActiveSessions` must NOT close a suspended session whose backing
-   * session probes 'missing'. Cleared once a live worker is re-established.
+   * cold-resumes from its on-disk transcript on the next message. Since the
+   * host-reboot fix, NO managed session (suspended or not) is auto-closed just
+   * because its backing probes 'missing' — a resumable transcript is always kept
+   * (see restoreActiveSessions / isSessionStopped). This marker is therefore no
+   * longer a close-guard; it stays as the authoritative "deliberately parked,
+   * expect no worker/pane" signal that drives the `dormant` status label and
+   * skips redundant liveness probes. Cleared once a live worker is re-established.
    */
   suspendedColdResume?: boolean;
   /** CLI used to spawn this session, frozen at creation so bot-level CLI edits only affect new sessions. */

--- a/test/restore-zombie-close.test.ts
+++ b/test/restore-zombie-close.test.ts
@@ -1,21 +1,26 @@
 /**
- * Restore-time zombie-close decision for persistent backends (tmux/zellij/herdr/zmx).
+ * Restore-time close decision for persistent backends (tmux/zellij/herdr/zmx).
  *
  * On daemon restart, restoreActiveSessions() re-registers every persisted active
  * session and then, for persistent backends, probes whether the backing
- * pane/agent survived. PR #98 made a *missing* backing session trigger a
- * permanent closeSession(). The hazard the gate caught: a transient probe
- * failure (herdr server slow-start / list timeout / CLI hiccup) used to fold
- * into the same `false` as "genuinely gone", so one flaky probe could close a
- * still-alive session for good (context lost, pane leaked, store row closed →
- * no lazy recovery).
+ * pane/agent survived. A *missing* backing is NEVER an auto-close trigger: the
+ * CLI transcript on disk is still resumable, so the row is kept worker-less and
+ * cold-resumes on the next message (mirrors pty, which has no backend to probe,
+ * and zmx). This is the fix for the host-reboot mass-close bug — botmux shares
+ * the default tmux socket with the operator's own terminal, so an earlier
+ * serverState()-based gate that tried to tell a solo zombie apart from a reboot
+ * was defeated by a co-tenant reviving the server, closing 239 live sessions
+ * after one reboot. Only three things leave the active set on restore:
  *
- * The fix upgrades the probe to tri-state (exists | missing | unknown). These
- * tests pin the decision boundary:
- *   - missing  → closeSession (Map eviction + store closed), no fork
- *   - unknown  → keep the active record (no close, no fork) for lazy recovery
+ *   - missing  → KEEP the active record (no close, no fork) for lazy cold-resume
+ *   - unknown  → KEEP the active record (no close, no fork) for lazy recovery
  *   - exists   → auto-fork to re-attach, no close
- *   - CLI mismatch → closeSession, so a worker-less old session cannot lazy-resume
+ *   - CLI mismatch → closeSession, so a worker-less old session cannot cold-resume
+ *                    the wrong (config-switched) CLI. Orthogonal to backing state.
+ *
+ * (A real `/close` marks the store row 'closed' up front, so it is never in this
+ * `active` restore set; a provably-exited adopt target is closed in the adopt
+ * branch. Neither is exercised here.)
  *
  * Heavy collaborators are mocked at the module boundary; the session-store runs
  * for real against a temp dir, and the worker-pool mock faithfully reproduces
@@ -38,9 +43,6 @@ const zmxSnapshot = vi.hoisted(() => ({
   sessions: [] as string[],
   unhealthySessions: [] as string[],
 }));
-// Mutable tmux-SERVER liveness the mocked TmuxBackend returns this test run.
-// Default 'running' so a bare 'missing' is read as a solo zombie (server up).
-const server = vi.hoisted(() => ({ state: 'running' as 'running' | 'down' | 'unknown' }));
 const herdrProbe = vi.hoisted(() => ({ result: 'exists' as 'exists' | 'missing' | 'unknown' }));
 // Mutable bot-side wrapperCli for the wrapper-axis mismatch tests.
 const bot = vi.hoisted(() => ({
@@ -160,7 +162,6 @@ vi.mock('../src/adapters/backend/tmux-backend.js', () => ({
     sessionName: vi.fn((id: string) => `bmx-${id.slice(0, 8)}`),
     probeSession: vi.fn(() => probe.result),
     hasSession: vi.fn(() => probe.result === 'exists'),
-    serverState: vi.fn(() => server.state),
     killSession: vi.fn(),
   },
 }));
@@ -186,7 +187,6 @@ vi.mock('../src/adapters/backend/zmx-backend.js', () => ({
       raw: '',
     } : { ok: false }),
     hasSession: vi.fn(() => probe.result === 'exists'),
-    serverState: vi.fn(() => server.state),
     killSession: vi.fn(),
     killManagedSession: vi.fn(),
   },
@@ -230,7 +230,6 @@ beforeEach(() => {
   zmxSnapshot.ok = true;
   zmxSnapshot.sessions = [];
   zmxSnapshot.unhealthySessions = [];
-  server.state = 'running';
   herdrProbe.result = 'exists';
   bot.cliId = 'claude-code';
   bot.wrapperCli = undefined;
@@ -307,7 +306,13 @@ describe('restoreActiveSessions — persistent-backend zombie-close decision', (
     expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('ownership probe unavailable'));
   });
 
-  it('"missing" → closes the zombie (Map eviction + store closed), does not fork', async () => {
+  it('"missing" → keeps the active record for lazy cold-resume, does NOT close', async () => {
+    // A missing backing pane is never an auto-close trigger for a managed
+    // session: whether one pane crashed or the whole server is gone, the CLI
+    // transcript on disk is still resumable, so the worker-less active record is
+    // kept and the next message cold-resumes it. Mirrors pty (never probed) and
+    // zmx (missing always kept). Only a real /close, a provably-exited adopt
+    // target, or a CLI-config mismatch leaves the active set.
     probe.result = 'missing';
     const s = makeActivePersistentSession('om_missing');
     const map = new Map<string, DaemonSession>();
@@ -319,19 +324,24 @@ describe('restoreActiveSessions — persistent-backend zombie-close decision', (
     expect(announceSessionRow).toHaveBeenCalledWith(expect.objectContaining({
       session: expect.objectContaining({ sessionId: s.sessionId }),
     }));
-    expect(closeSession).toHaveBeenCalledWith(s.sessionId);
-    expect([...map.values()].some(v => v.session.sessionId === s.sessionId)).toBe(false);
-    expect(sessionStore.getSession(s.sessionId)!.status).toBe('closed');
+    expect(closeSession).not.toHaveBeenCalled();
+    const ds = map.get(sessionKey('om_missing', 'app_test'));
+    expect(ds).toBeDefined();              // active record retained…
+    expect(ds!.worker).toBeNull();         // …worker-less, cold-resumes on next message
+    expect(sessionStore.getSession(s.sessionId)!.status).toBe('active'); // NOT closed
     expect(forkWorker).not.toHaveBeenCalled();
   });
 
-  it('"missing" + server DOWN (host reboot) → keeps the active record, does NOT close', async () => {
-    // The reboot bug: tmux server is gone, so every bmx-* pane probes 'missing'.
-    // Closing them all wiped a full dashboard. With the server-state gate, a
-    // down server means "keep for lazy resume" (CLI transcript on disk is still
-    // resumable), exactly like a pty session.
+  it('"missing" after a host reboot (server gone) → keeps the active record, does NOT close', async () => {
+    // The reboot bug this whole fix targets: a host reboot wipes the tmux
+    // server, so every bmx-* pane probes 'missing' at once. Because botmux
+    // shares the default tmux socket with the operator's own terminal, a
+    // co-tenant reviving the server before restore ran made the old
+    // serverState() gate read the reboot as N solo zombies → mass-close (239
+    // sessions after one reboot). Now 'missing' is never an auto-close: the
+    // CLI transcript on disk is still resumable, so the row is kept worker-less
+    // and cold-resumes on the next message, exactly like a pty session.
     probe.result = 'missing';
-    server.state = 'down';
     const s = makeActivePersistentSession('om_reboot');
     const map = new Map<string, DaemonSession>();
     wp.registry = map;
@@ -349,7 +359,6 @@ describe('restoreActiveSessions — persistent-backend zombie-close decision', (
 
   it('missing ZMX session stays lazy-recoverable even when another ZMX daemon is running', async () => {
     probe.result = 'missing';
-    server.state = 'running';
     const s = makeActivePersistentSession('om_zmx_missing', 'zmx');
     const map = new Map<string, DaemonSession>();
     wp.registry = map;
@@ -377,13 +386,14 @@ describe('restoreActiveSessions — persistent-backend zombie-close decision', (
     expect(forkWorker).not.toHaveBeenCalled();
   });
 
-  it('CLI mismatch on restore → closes the active record even when the backend server is down', async () => {
+  it('CLI mismatch on restore → closes the active record even though a missing backing is normally kept', async () => {
     // This is the config-switch case: the bot now points at a different CLI,
-    // but an old active session still has its original cliId frozen. If restore
-    // kept it worker-less for lazy resume, the next @mention would resurrect the
-    // old CLI instead of creating a clean session with the current bot config.
+    // but an old active session still has its original cliId frozen. A missing
+    // backing is normally kept for lazy resume, but a mismatch must still close:
+    // otherwise the next @mention would cold-resume the OLD CLI instead of
+    // creating a clean session with the current bot config. Mismatch-close is
+    // orthogonal to whether the backing pane survived.
     probe.result = 'missing';
-    server.state = 'down';
     const s = makeActivePersistentSession('om_cli_mismatch');
     s.cliId = 'codex';
     sessionStore.updateSession(s);
@@ -484,7 +494,6 @@ describe('restoreActiveSessions — persistent-backend zombie-close decision', (
     // A frozen wrapper snapshot that differs from the bot's current wrapper is
     // the same config-switch case as a cliId change and must close too.
     probe.result = 'missing';
-    server.state = 'down';
     const s = makeActivePersistentSession('om_wrapper_mismatch');
     s.wrapperCli = 'aiden x claude';
     s.agentFrozen = true;
@@ -503,7 +512,6 @@ describe('restoreActiveSessions — persistent-backend zombie-close decision', (
 
   it('frozen wrapper matching the bot wrapper → NOT a mismatch, session kept', async () => {
     probe.result = 'missing';
-    server.state = 'down';
     bot.wrapperCli = 'aiden x claude';
     const s = makeActivePersistentSession('om_wrapper_match');
     s.wrapperCli = 'aiden x claude';
@@ -525,7 +533,6 @@ describe('restoreActiveSessions — persistent-backend zombie-close decision', (
     // exactly what the bot is configured for — closing it would be a false
     // positive.
     probe.result = 'missing';
-    server.state = 'down';
     bot.wrapperCli = 'aiden x claude';
     const s = makeActivePersistentSession('om_wrapper_legacy');
     sessionStore.updateSession(s);
@@ -539,9 +546,8 @@ describe('restoreActiveSessions — persistent-backend zombie-close decision', (
     expect(sessionStore.getSession(s.sessionId)!.status).toBe('active');
   });
 
-  it('"missing" + server DOWN → keeps ALL sessions (no mass-close after reboot)', async () => {
+  it('"missing" for every session (host reboot) → keeps ALL of them (no mass-close)', async () => {
     probe.result = 'missing';
-    server.state = 'down';
     const a = makeActivePersistentSession('om_reboot_a');
     const b = makeActivePersistentSession('om_reboot_b');
     const c = makeActivePersistentSession('om_reboot_c');
@@ -559,14 +565,12 @@ describe('restoreActiveSessions — persistent-backend zombie-close decision', (
     expect(forkWorker).not.toHaveBeenCalled();
   });
 
-  it('"missing" + server UP but session was cap-suspended → keeps active for cold-resume (NOT a zombie)', async () => {
+  it('"missing" for a cap-suspended session → keeps active for cold-resume', async () => {
     // The idle-worker sweeper deliberately kills a session's backing pane + CLI
-    // over the per-bot cap. The server stays up (only one pane was killed), so
-    // without the suspend-intent marker this looks exactly like a solo zombie
-    // and would be wrongly closed — losing a session that should lazily
-    // cold-resume on the next message.
+    // over the per-bot cap, leaving suspendedColdResume set. Its backing probes
+    // 'missing' on restart; like every other missing managed backing it is kept
+    // worker-less and cold-resumes from the transcript on the next message.
     probe.result = 'missing';
-    server.state = 'running';
     const s = makeActivePersistentSession('om_cap_suspended');
     s.suspendedColdResume = true;
     sessionStore.updateSession(s);
@@ -580,20 +584,6 @@ describe('restoreActiveSessions — persistent-backend zombie-close decision', (
     expect(ds).toBeDefined();              // active record retained…
     expect(ds!.worker).toBeNull();         // …worker-less, cold-resumes on next message
     expect(sessionStore.getSession(s.sessionId)!.status).toBe('active'); // NOT closed
-    expect(forkWorker).not.toHaveBeenCalled();
-  });
-
-  it('"missing" + server state UNKNOWN → closes (conservative, server may be up)', async () => {
-    probe.result = 'missing';
-    server.state = 'unknown';
-    const s = makeActivePersistentSession('om_missing_unknown_server');
-    const map = new Map<string, DaemonSession>();
-    wp.registry = map;
-
-    await restoreActiveSessions(map);
-
-    expect(closeSession).toHaveBeenCalledWith(s.sessionId);
-    expect(sessionStore.getSession(s.sessionId)!.status).toBe('closed');
     expect(forkWorker).not.toHaveBeenCalled();
   });
 

--- a/test/session-list-liveness.test.ts
+++ b/test/session-list-liveness.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isColdResumeDormant, sessionListDisposition } from '../src/cli/session-list-liveness.js';
+import { isColdResumeDormant, isRealManagedSession, sessionListDisposition } from '../src/cli/session-list-liveness.js';
 
 describe('botmux list session liveness', () => {
   it('keeps a deliberate cold-resume suspension without a pid or backing session', () => {
@@ -9,16 +9,36 @@ describe('botmux list session liveness', () => {
     expect(isColdResumeDormant(session)).toBe(true);
   });
 
-  it('still prunes a real zombie when no suspension marker exists', () => {
+  it('keeps a real managed session with no pid and no backing (host reboot) — dormant, never pruned', () => {
+    // The reboot fix: restoreActiveSessions keeps these rows worker-less, and a
+    // subsequent `botmux list` (a READ command) must not re-close them. Whether
+    // the CLI merely exited or a host reboot wiped the backing pane, the on-disk
+    // transcript still cold-resumes on the next message.
     expect(sessionListDisposition(
       { cliId: 'codex', lastCliInput: 'hello' },
       { hasPid: false, hasBackingSession: false },
-    )).toBe('prune_real');
+    )).toBe('keep');
+    expect(sessionListDisposition(
+      { cliId: 'codex' },
+      { hasPid: false, hasBackingSession: false },
+    )).toBe('keep');
   });
 
-  it('keeps live/backed sessions and distinguishes never-started scratch rows', () => {
+  it('still prunes a never-started scratch row (no real-CLI markers, no pid/backing) silently', () => {
+    expect(sessionListDisposition({}, { hasPid: false, hasBackingSession: false })).toBe('prune_scratch');
+  });
+
+  it('keeps live/backed sessions regardless of the real-vs-scratch markers', () => {
     expect(sessionListDisposition({}, { hasPid: true, hasBackingSession: false })).toBe('keep');
     expect(sessionListDisposition({}, { hasPid: false, hasBackingSession: true })).toBe('keep');
-    expect(sessionListDisposition({}, { hasPid: false, hasBackingSession: false })).toBe('prune_scratch');
+    // A real managed session with a surviving backing pane is kept too.
+    expect(sessionListDisposition({ cliId: 'codex' }, { hasPid: false, hasBackingSession: true })).toBe('keep');
+  });
+
+  it('isRealManagedSession distinguishes transcript-backed rows from disposable scratch', () => {
+    expect(isRealManagedSession({ cliId: 'codex' })).toBe(true);
+    expect(isRealManagedSession({ lastCliInput: 'hi' })).toBe(true);
+    expect(isRealManagedSession({ adoptedFrom: { source: 'tmux' } })).toBe(true);
+    expect(isRealManagedSession({})).toBe(false);
   });
 });

--- a/test/session-liveness.test.ts
+++ b/test/session-liveness.test.ts
@@ -1,82 +1,97 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { isSessionStopped } from '../src/core/session-liveness.js';
 import type { Session } from '../src/types.js';
 
-const persistentProbe = vi.hoisted(() => vi.fn());
-
-vi.mock('../src/core/persistent-backend.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../src/core/persistent-backend.js')>();
-  return {
-    ...actual,
-    probePersistentBackendTarget: persistentProbe,
-  };
-});
-
-// Minimal Session stub — isSessionStopped only reads pid / adoptedFrom /
-// sessionId / backend metadata / suspendedColdResume.
+// Minimal Session stub — isSessionStopped reads pid / adoptedFrom / cliId /
+// lastCliInput / suspendedColdResume. A real managed session always carries a
+// frozen `cliId` (stamped at spawn for every backend, incl. riff/zmx), so the
+// default stub includes one; scratch-row cases clear it explicitly.
 function session(over: Partial<Session>): Session {
-  return { sessionId: '0123456789abcdef', status: 'active', ...over } as Session;
+  return { sessionId: '0123456789abcdef', status: 'active', cliId: 'claude-code', ...over } as Session;
 }
 
-describe('isSessionStopped — botmux-suspended sessions are not zombies', () => {
-  beforeEach(() => {
-    persistentProbe.mockReset();
-  });
-
-  it('treats a cold-resume-suspended session (no pid, tmux destroyed) as NOT stopped', () => {
-    // This is the data-loss guard: botmux cap-suspend clears the pid AND
-    // destroys the backing CLI/tmux, so the generic zombie heuristic would
-    // classify it as stopped and let the "清僵尸" sweep permanently close a
-    // session that should cold-resume on the next message. The persisted
-    // marker must beat the heuristic (mirrors the CLI list prune guard).
+describe('isSessionStopped — real managed sessions are dormant, not zombies', () => {
+  it('treats a cold-resume-suspended session (no pid, backing destroyed) as NOT stopped', () => {
+    // botmux cap-suspend clears the pid AND destroys the backing CLI/tmux to
+    // reclaim memory. It must cold-resume on the next message, never be swept.
     expect(isSessionStopped(session({ suspendedColdResume: true, pid: undefined }))).toBe(false);
   });
 
-  it('still reports a real zombie (dead pid, no marker) as stopped', () => {
-    // pid 1 is init — alive but not ours; use an unused-high pid that is dead.
-    // No suspendedColdResume marker → falls through to the pid/tmux heuristic.
-    // With no pid and no bmx-* tmux pane, it is a stopped zombie.
-    expect(isSessionStopped(session({ suspendedColdResume: undefined, pid: undefined }))).toBe(true);
+  it('treats a real managed session with a dead pid as NOT stopped (dormant, transcript-backed)', () => {
+    // The core of the host-reboot fix: no live pid + no marker, but it DID run a
+    // CLI (cliId frozen), so its transcript on disk cold-resumes on the next
+    // message (resume→fresh fallback if the transcript is gone). Not a zombie.
+    expect(isSessionStopped(session({ suspendedColdResume: undefined, pid: undefined }))).toBe(false);
+  });
+
+  it('treats a never-started scratch row (no cliId/lastCliInput/adopt, dead pid) as stopped', () => {
+    // A row that never became a real CLI session (unconfirmed /adopt picker,
+    // /help, abandoned /relay picker) is a disposable scratch — safe to close.
+    expect(isSessionStopped(session({ cliId: undefined, pid: undefined }))).toBe(true);
+    expect(isSessionStopped(session({ cliId: undefined, lastCliInput: 'x', pid: undefined }))).toBe(false);
   });
 
   it.each([
-    ['exists', false],
-    ['unknown', false],
-    ['missing', true],
-  ] as const)('treats a workerless Herdr %s probe as stopped=%s', (probe, stopped) => {
-    const persistentBackendTarget = {
-      backendType: 'herdr' as const,
-      sessionName: 'botmux',
-      agentName: 'botmux-01234567',
-    };
-    persistentProbe.mockReturnValueOnce(probe);
-
+    ['exists'],
+    ['unknown'],
+    ['missing'],
+  ] as const)('never sweeps a workerless real Herdr row regardless of a %s backing probe', (_probe) => {
+    // A missing backing pane is no longer a close trigger for any backend: the
+    // whole-server-vs-solo-pane ambiguity (defeated by the shared tmux socket)
+    // is gone from the decision. A real Herdr row with a dead pid is dormant.
     expect(isSessionStopped(session({
       backendType: 'herdr',
-      persistentBackendTarget,
-      pid: undefined,
-    }))).toBe(stopped);
-    expect(persistentProbe).toHaveBeenCalledWith(persistentBackendTarget);
-  });
-
-  it.each([
-    'missing',
-    'unknown',
-  ] as const)('keeps a workerless ZMX row recoverable when its backing probe would be %s', (probe) => {
-    persistentProbe.mockReturnValueOnce(probe);
-
-    expect(isSessionStopped(session({
-      backendType: 'zmx',
       persistentBackendTarget: {
-        backendType: 'zmx',
-        sessionName: 'bmx-01234567',
+        backendType: 'herdr',
+        sessionName: 'botmux',
+        agentName: 'botmux-01234567',
       },
       pid: undefined,
     }))).toBe(false);
-    expect(persistentProbe).not.toHaveBeenCalled();
   });
 
-  it('does not call a remote Riff task stopped just because no local tmux pane exists', () => {
+  it('keeps a workerless real ZMX row recoverable (no backing probe needed)', () => {
+    expect(isSessionStopped(session({
+      backendType: 'zmx',
+      persistentBackendTarget: { backendType: 'zmx', sessionName: 'bmx-01234567' },
+      pid: undefined,
+    }))).toBe(false);
+  });
+
+  it('keeps a workerless real tmux row recoverable after its pane vanished (host reboot)', () => {
+    expect(isSessionStopped(session({ backendType: 'tmux', pid: undefined }))).toBe(false);
+  });
+
+  it('keeps a real pty row (no persistent backend) recoverable when its pid is dead', () => {
+    // pty was previously the ONLY backend the sweep unconditionally called
+    // stopped. Under the unified invariant a real pty session with a transcript
+    // cold-resumes exactly like the others — never a dead end.
+    expect(isSessionStopped(session({ backendType: 'pty', pid: undefined }))).toBe(false);
+  });
+
+  it('keeps a legacy (undefined backend) real row recoverable — cannot prove it was ever tmux', () => {
+    expect(isSessionStopped(session({ backendType: undefined, pid: undefined }))).toBe(false);
+  });
+
+  it('does not call a remote Riff task stopped just because no local process exists', () => {
     expect(isSessionStopped(session({ backendType: 'riff', pid: undefined }))).toBe(false);
+  });
+
+  it('reports an adopted session with a dead external pid as stopped (external pid authoritative)', () => {
+    // Adopt wraps a foreign CLI we never spawned and hold no transcript for, so
+    // its own pid — not a botmux transcript — decides. Dead external pid = stop.
+    expect(isSessionStopped(session({
+      cliId: undefined,
+      adoptedFrom: { source: 'tmux', originalCliPid: 999999 } as any,
+      pid: undefined,
+    }))).toBe(true);
+  });
+
+  it('keeps an adopted session alive while its external pid is still running', () => {
+    expect(isSessionStopped(session({
+      cliId: undefined,
+      adoptedFrom: { source: 'tmux', originalCliPid: process.pid } as any,
+      pid: undefined,
+    }))).toBe(false);
   });
 });

--- a/test/session-resume.test.ts
+++ b/test/session-resume.test.ts
@@ -132,7 +132,6 @@ vi.mock('../src/adapters/backend/tmux-backend.js', () => ({
     sessionName: vi.fn((id: string) => `bmx-${id.slice(0, 8)}`),
     hasSession: vi.fn(() => false),
     probeSession: vi.fn(() => 'missing'),
-    serverState: vi.fn(() => 'running'),
   },
 }));
 

--- a/test/tmux-probe.test.ts
+++ b/test/tmux-probe.test.ts
@@ -1,14 +1,16 @@
 /**
  * Unit tests for TmuxBackend.probeSession() — the tri-state existence probe
- * used by restore's zombie-close decision.
+ * used by restore to decide re-attach ('exists') vs keep-for-lazy-cold-resume
+ * ('missing'/'unknown').
  *
  * The hazard these pin: a probe FAILURE (tmux not on PATH, not executable,
- * hung) must classify as 'unknown', never 'missing' — because restore turns
- * 'missing' into a destructive closeSession(). A shell-string `execSync` leaks
- * the shell's own command-not-found / not-executable exit codes (127 / 126) as
- * clean numeric statuses, which a naive "non-zero status ⇒ missing" rule would
- * misread as "session gone". Running the binary directly via execFileSync keeps
- * those failures as ENOENT/EACCES (no numeric status) ⇒ 'unknown'.
+ * hung) must classify as 'unknown', never 'exists' — so a flaky/unavailable
+ * tmux can't be mistaken for a live pane and drive a bogus re-attach. A
+ * shell-string `execSync` leaks the shell's own command-not-found /
+ * not-executable exit codes (127 / 126) as clean numeric statuses, which a
+ * naive "non-zero status ⇒ missing" rule would misread. Running the binary
+ * directly via execFileSync keeps those failures as ENOENT/EACCES (no numeric
+ * status) ⇒ 'unknown'.
  *
  * Both execSync and execFileSync are mocked per scenario so the test pins the
  * intended CLASSIFICATION regardless of which child_process API the impl uses.
@@ -79,29 +81,6 @@ describe('TmuxBackend.probeSession', () => {
   it('hasSession() stays a conservative boolean wrapper (false on unknown)', () => {
     bothThrow({ status: 127, signal: null }, { code: 'ENOENT', status: null, signal: null });
     expect(TmuxBackend.hasSession(NAME)).toBe(false);
-  });
-});
-
-describe('TmuxBackend.serverState', () => {
-  it('returns "running" when list-sessions succeeds (exit 0 ⇒ server up with ≥1 session)', () => {
-    mockedExecFileSync.mockImplementation((() => '') as any);
-    expect(TmuxBackend.serverState()).toBe('running');
-  });
-
-  it('returns "down" on clean non-zero exit ("no server running")', () => {
-    // This is the host-reboot signal: the whole tmux server is gone.
-    mockedExecFileSync.mockImplementation((() => { throw err({ status: 1, signal: null }); }) as any);
-    expect(TmuxBackend.serverState()).toBe('down');
-  });
-
-  it('returns "unknown" when tmux is not found (ENOENT), NOT "down"', () => {
-    mockedExecFileSync.mockImplementation((() => { throw err({ code: 'ENOENT', status: null, signal: null }); }) as any);
-    expect(TmuxBackend.serverState()).toBe('unknown');
-  });
-
-  it('returns "unknown" on timeout (killed by signal), NOT "down"', () => {
-    mockedExecFileSync.mockImplementation((() => { throw err({ signal: 'SIGTERM', status: null, killed: true }); }) as any);
-    expect(TmuxBackend.serverState()).toBe('unknown');
   });
 });
 


### PR DESCRIPTION
## 问题

机器重启后，重启前正活跃的飞书会话**无法自动 resume**——它们被永久 `closeSession` 了，话题从看板消失、下条消息也不再 lazy-resume。

**根因**：默认 tmux 后端的 `bmx-*` 会话与 operator 自己终端**共享默认 tmux socket**。reboot 后 operator 终端在 daemon restore **之前**复活了那个共享 server → 判「整机重启保留」的 `serverState()==='down'` 守卫读成 `'running'` → 每个 `missing` 的 pane 被误判成 solo zombie → `closeSession` 永久关闭。**live 实测：一次 reboot 关掉 239 个活跃会话，仅 1 个 zellij（每会话独立 server）逃过。**

## 修复（方案 B：托管会话 missing 永不作为自动关闭依据）

判断依据不再依赖「共享 server 是否存活」这个被 co-tenant 污染的信号，从根本上消除竞态。凡是**真实托管会话**（曾跑过 CLI —— 有 `cliId`/`lastCliInput`/`adoptedFrom`），其磁盘 CLI transcript 仍可 resume，所以无论其 backing pane 是被单独 crash、被 idle-sweeper 回收（cap-suspend）、还是被整机 reboot 一次性抹掉，都**保留 worker-less active 记录**，交下条消息 cold-resume（`forkWorker(resume=true)`；transcript 真没了则 worker 侧 resume→fresh 兜底新起干净会话 + 用户可见提示，**永不卡死**）。

这条不变量在**四个共享「这会话可关吗」判定的入口**统一落地（避免只改一处、其余入口把刚保住的会话再关掉）：

1. **`restoreActiveSessions`**（daemon 重启）：`missing` → 保留，删掉旧的 `serverState()==='down'` 三段特判。
2. **`botmux list`** auto-prune：real managed 的 `missing` → `keep`（dormant），只有从没成真 CLI 的 disposable scratch 才 `prune_scratch`。
3. **`isSessionStopped`**（过载卡「清僵尸」+ `botmux delete stopped` 共用）：改为「无活进程 **且** 非 real managed」才判 stopped，移除被 co-tenant 污染的 backing 探针。
4. 三处 CLI/服务端入口复用同一纯谓词 **`isRealManagedSession`**（`cli/session-list-liveness.ts`，零依赖 leaf），不再各自实现而分叉。

离开 active 集合的仅剩三种，均与 backing 存活正交：真 `/close`（restore 前已置 `closed`）、adopt 目标已退出（外部 pid 权威，无自有 transcript）、CLI-config mismatch（配置热切，早于探测分支就关）。

## 影响面（多 CLI × 多后端横向排查）

- **跨后端**：
  - tmux / zellij / herdr：行为改变——不再 close-on-missing（这正是修复点）。herdr 之前 `serverState` 返回 `'unknown'` 落到 close 分支，现在同样保留（更安全，其 warm-up 慢启动本就易误杀）。
  - zmx / riff：本就因同款 reboot 歧义在 `isSessionStopped` 里豁免——本 PR 把该原则**扩大到 tmux/zellij/herdr**并统一到共享谓词。
  - **pty / legacy-undefined（backendType 缺失）**：一并纳入统一不变量。⚠️ 这修正了一处 **pre-existing 差异**——旧 `isSessionStopped` 里 `pty → return true` 恒判 stopped，与 `restoreActiveSessions` 从不探测/关闭 pty 的语义本就冲突；legacy 无法证明当年是 tmux 还是 pty，更不该用 `missing` 做破坏性判断。现三者统一为「transcript-backed → recoverable」。**注意：这不是「对齐 pty 旧的 close 行为」，而是把 pty/legacy 收进同一 recoverable 语义。**
- **死代码清理**：移除 `probePersistentBackendServer()` 及 `TmuxBackend`/`ZellijBackend`/`ZmxBackend` 三个 `serverState()`（为被推翻的 reboot-gate 而加，现零调用）；移除 `session-liveness.ts` 里因不再探 backing 而失效的 `tmuxSessionExists` + 3 个 persistent-backend 探针 import。均非接口契约成员，删除安全。
- **layering**：`core/session-liveness.ts → cli/session-list-liveness.ts` 单向边、无环（后者零 import 纯 leaf；core→cli 先例 `core/plugins/pm2.ts`）。
- **跨平台**：纯 Linux daemon 路径逻辑，无平台特异改动。

## 为什么不需要 TTL 回收

dormant 会话**无 worker、无 pane**，仅剩磁盘一行 + dashboard 一行，近零资源占用（申晗确认）。故不引入 TTL。若将来需要 dashboard 整洁，应另按 `lastMessageAt` 做解耦的 dormancy 回收，与本 bug 无关。

## 验证

- `pnpm build` 通过（tsc + dashboard bundle + audit 全绿）。
- `test/restore-zombie-close.test.ts` `missing→close` 断言**翻转**为 `missing→keep`（reboot 全保留 + cap-suspend 保留），删除已失效的 `serverState` 脚手架与「unknown→保守 close」用例。
- `test/session-liveness.test.ts` / `test/session-list-liveness.test.ts`：翻转旧的 close-on-missing 断言；新增 real tmux/pty/legacy/zmx/riff `missing` 全 `keep`、adopt dead-pid=stop / live-pid=keep、`isRealManagedSession` 单测、scratch 仍 `prune_scratch`。
- `test/tmux-probe.test.ts` / `test/session-resume.test.ts`：删除 `serverState` 块 / 死 stub。
- **变异验证有牙**：`isSessionStopped` 塞回 close-on-missing / `sessionListDisposition` 塞回 prune / restore 塞回 closeSession → 相关用例立即变红；移除后干净。
- 全量 `vitest run --project unit`：**12180 passed，0 failed（exit 0）**。
- 与最新 `origin/master`（`4bc7d4e8f`）试合并无冲突（master 仅前进 sandbox.ts，正交）。

净 diff **13 files, +283 / -364**：修复方式是移除被击穿的机器并把判定收敛到单一共享谓词，而非再加守卫。

base=master `fe594fc8b` · head 见最新提交（跨入口洞修复 + 文档同步）
