### PR TITLE
fix(codex): transcript 兜底改用 task_complete 作 turn 终止边界（修 codex 0.146 完成链失效）

### DIFF
--- a/src/services/codex-transcript.ts
+++ b/src/services/codex-transcript.ts
@@ -3,24 +3,33 @@
  *
  * Codex stores each session's full transcript at
  *   ~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-<ts>-<cliSessionId>.jsonl
- * and creates the file lazily on the first user submit. Inside, the bridge
- * fallback only cares about two `response_item.payload.type === 'message'`
- * shapes:
+ * and creates the file lazily on the first user submit. The bridge fallback
+ * cares about exactly two records:
  *
- *   - role=user             → the user's prompt text (input_text content)
- *   - role=assistant +
- *     phase=final_answer    → the model's final reply (output_text content)
+ *   - user turn-start: `response_item.payload` message role=user
+ *     (input_text content). Stable across every codex version.
+ *   - turn terminal: `event_msg.payload` `task_complete`, which carries the
+ *     final visible text in `last_agent_message` (may be empty) and fires
+ *     exactly ONCE per turn.
  *
- * Why these and not `event_msg`:
- *   - `response_item` is the canonical transcript record; `event_msg` is a
- *     UI-event stream that can carry the same final text via two channels
- *     (`agent_message phase=final_answer` AND `task_complete.last_agent_message`).
- *     Picking `response_item` keeps the reader to a single source of truth
- *     and avoids any chance of double-emit if both paths are present.
- *   - Skipping role=developer (system instructions), phase=commentary
- *     (mid-turn status), reasoning, and function_call* keeps the bridge
- *     focused on what the user actually said and what the model finally
- *     answered — same scope as the Claude bridge.
+ * Why task_complete and NOT the assistant `response_item` message:
+ *   - Codex USED to tag the final assistant message `phase:'final_answer'`,
+ *     which older readers keyed on. Newer codex (observed >=0.146, and
+ *     model-provider dependent) DROPPED that field: the final assistant
+ *     message and every mid-turn assistant message are now byte-identically
+ *     `phase:undefined`, so no assistant `response_item` is a safe boundary —
+ *     keying on one would close the turn on the first mid-turn preamble and
+ *     truncate (or, if a stale second final is buffered, double-emit).
+ *   - `task_complete` is present in every observed schema (0.139 / 0.145 /
+ *     0.146), fires once per turn, and dedups codex's THREE representations of
+ *     one answer (event_msg agent_message / response_item message / event_msg
+ *     task_complete) down to a single emit — no cross-source dedup needed.
+ *   - A cancelled turn writes `turn_aborted` (no task_complete); we surface it
+ *     as an `ambiguous` terminal so the durable delivery is released instead
+ *     of wedging as "running" forever.
+ *
+ * This mirrors the traex reader (traex-transcript.ts), which adopted the same
+ * task_complete boundary earlier for the identical no-reliable-phase reason.
  *
  * Pure I/O. Attribution belongs in CodexBridgeQueue.
  */
@@ -365,6 +374,17 @@ function joinTextBlocks(content: unknown, kind: 'input_text' | 'output_text'): s
   return parts.join('');
 }
 
+/** Normalise a `turn_aborted.reason` into a stable, bounded error code for the
+ *  durable-delivery terminal outcome. Mirrors the traex reader. */
+function codexAbortErrorCode(reason: unknown): string {
+  const normalized = (typeof reason === 'string' ? reason : 'unknown')
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 64) || 'unknown';
+  return `codex_turn_aborted:${normalized}`;
+}
+
 /** Increment-read the rollout from `fromOffset`. Mirrors the byte-offset
  *  contract of claude-transcript.drainTranscript so callers can swap them
  *  out and reuse the existing fs.watch / poll wakeup machinery. */
@@ -402,23 +422,62 @@ export function drainCodexRollout(path: string, fromOffset: number): CodexDrainR
     cursor += lineByteLen;
     let obj: any;
     try { obj = JSON.parse(line); } catch { continue; }
-    if (obj?.type !== 'response_item') continue;
-    const p = obj.payload;
-    if (!p || typeof p !== 'object' || p.type !== 'message') continue;
+    const p = obj?.payload;
+    if (!p || typeof p !== 'object') continue;
     const ts = typeof obj.timestamp === 'string' ? Date.parse(obj.timestamp) : NaN;
     const timestampMs = Number.isFinite(ts) ? ts : Date.now();
-    if (p.role === 'user') {
+    // User turn-start: response_item message role=user. Stable across every
+    // codex version, and the ONLY event the RPC rollout-match probe reads
+    // (codex-rpc-lifecycle.rolloutUserTurnMatches), so it must stay a
+    // response_item user message.
+    if (obj.type === 'response_item' && p.type === 'message' && p.role === 'user') {
       const text = joinTextBlocks(p.content, 'input_text');
       if (!text) continue;
       events.push({ uuid: `${path}:${lineStart}`, timestampMs, kind: 'user', text });
-    } else if (p.role === 'assistant' && p.phase === 'final_answer') {
-      const text = joinTextBlocks(p.content, 'output_text');
-      if (!text) continue;
-      events.push({ uuid: `${path}:${lineStart}`, timestampMs, kind: 'assistant_final', text });
+      continue;
     }
-    // Skip role=developer (instructions), phase=commentary (mid-turn
-    // status), and any reasoning / function_call* events — see file
-    // header for rationale.
+    // Turn terminal: event_msg `task_complete` carries the final visible text
+    // in `last_agent_message` (may be empty) and fires exactly ONCE per turn.
+    // This is the SOLE assistant_final source. Codex assistant `response_item`
+    // messages are NOT a safe boundary: the `phase:'final_answer'` marker was
+    // dropped (>=0.146), and mid-turn assistant messages are byte-identical to
+    // the final one (both phase:undefined) — keying on them would close a turn
+    // on the first mid-turn preamble and truncate/duplicate. Taking only
+    // task_complete also dedups codex's triple representation of one answer
+    // (event_msg agent_message / response_item message / event_msg
+    // task_complete). Mirrors the traex reader. See file header.
+    if (obj.type === 'event_msg'
+      && p.type === 'task_complete'
+      && typeof p.turn_id === 'string'
+      && p.turn_id.length > 0) {
+      events.push({
+        uuid: `${path}:${lineStart}`,
+        timestampMs,
+        kind: 'assistant_final',
+        text: typeof p.last_agent_message === 'string' ? p.last_agent_message : '',
+      });
+      continue;
+    }
+    // A cancelled turn writes `turn_aborted` (turn_id, reason) and NO
+    // task_complete. Side effects may already have run, so release the durable
+    // delivery as `ambiguous` rather than wedge the turn as running forever.
+    if (obj.type === 'event_msg'
+      && p.type === 'turn_aborted'
+      && typeof p.turn_id === 'string'
+      && p.turn_id.length > 0) {
+      events.push({
+        uuid: `${path}:${lineStart}`,
+        timestampMs,
+        kind: 'assistant_final',
+        text: '',
+        terminalStatus: 'ambiguous',
+        terminalErrorCode: codexAbortErrorCode(p.reason),
+      });
+      continue;
+    }
+    // Everything else is skipped: role=developer/system instructions,
+    // reasoning, function_call*, and every assistant `response_item` message
+    // (mid-turn OR final) — the turn boundary comes only from task_complete.
   }
   return { events, newOffset, pendingTail };
 }

--- a/test/codex-transcript.test.ts
+++ b/test/codex-transcript.test.ts
@@ -24,13 +24,32 @@ function userResponseItem(text: string, ts = '2026-04-29T07:00:00.000Z') {
 }
 
 function assistantFinalResponseItem(text: string, ts = '2026-04-29T07:00:01.000Z') {
+  // The turn terminal is now event_msg/task_complete, NOT the assistant
+  // response_item. Codex >=0.146 dropped phase:'final_answer', so this helper
+  // emits the task_complete record that actually closes the turn. `text`
+  // becomes last_agent_message. Kept named "assistantFinal…" so existing
+  // call sites read naturally.
+  return {
+    timestamp: ts,
+    type: 'event_msg',
+    payload: {
+      type: 'task_complete',
+      turn_id: `turn-${ts}`,
+      last_agent_message: text,
+    },
+  };
+}
+
+/** An assistant `response_item` message — mid-turn OR final, both phase-less in
+ *  codex >=0.146. The reader must NOT treat any of these as a turn boundary. */
+function assistantMessageResponseItem(text: string, phase?: string, ts = '2026-04-29T07:00:01.000Z') {
   return {
     timestamp: ts,
     type: 'response_item',
     payload: {
       type: 'message',
       role: 'assistant',
-      phase: 'final_answer',
+      ...(phase !== undefined ? { phase } : {}),
       content: [{ type: 'output_text', text }],
     },
   };
@@ -224,7 +243,7 @@ describe('drainCodexRollout', () => {
     expect(r.newOffset).toBe(0);
   });
 
-  it('extracts user + assistant_final from response_item', () => {
+  it('extracts user (response_item) + assistant_final (task_complete)', () => {
     writeFileSync(path,
       ev(userResponseItem('hello there')) +
       ev(assistantFinalResponseItem('hi back')));
@@ -249,30 +268,84 @@ describe('drainCodexRollout', () => {
     expect(r.events[0].text).toBe('real user prompt');
   });
 
-  it('skips assistant phase=commentary (mid-turn status)', () => {
+  // Regression for the codex >=0.146 phase-drift bug: mid-turn AND final
+  // assistant response_item messages are both phase-less and must NOT be a
+  // turn boundary. Only task_complete closes the turn. Keying on a phase-less
+  // assistant message would close the turn on the first mid-turn preamble
+  // ("I'll run the commands…") and truncate the real answer.
+  it('never treats an assistant response_item message as terminal (mid-turn preamble + phase-less final)', () => {
     writeFileSync(path,
-      ev({
-        type: 'response_item',
-        payload: {
-          type: 'message',
-          role: 'assistant',
-          phase: 'commentary',
-          content: [{ type: 'output_text', text: 'thinking…' }],
-        },
-      }) +
-      ev(assistantFinalResponseItem('done')));
+      ev(userResponseItem('do two things')) +
+      ev(assistantMessageResponseItem("I'll run the commands.")) +   // mid-turn preamble, phase:undefined
+      ev(assistantMessageResponseItem('step1 step2 DONE')) +          // final answer, ALSO phase:undefined (0.146)
+      ev(assistantFinalResponseItem('step1 step2 DONE')));            // the real terminal
     const r = drainCodexRollout(path, 0);
-    expect(r.events).toHaveLength(1);
-    expect(r.events[0].kind).toBe('assistant_final');
-    expect(r.events[0].text).toBe('done');
+    // Exactly one user + one assistant_final (from task_complete). Neither
+    // assistant response_item produced an event.
+    expect(r.events).toHaveLength(2);
+    expect(r.events[0].kind).toBe('user');
+    expect(r.events[1].kind).toBe('assistant_final');
+    expect(r.events[1].text).toBe('step1 step2 DONE');
   });
 
-  it('skips reasoning / function_call / function_call_output / event_msg', () => {
+  // Old codex (0.139 / 0.145) still tags the final message phase:'final_answer'
+  // AND emits task_complete. We take ONLY task_complete → exactly one
+  // assistant_final, no double-close (the queue would buffer a stray second
+  // final and could mis-close a later turn).
+  it('old-codex final_answer response_item + task_complete → single assistant_final', () => {
+    writeFileSync(path,
+      ev(userResponseItem('hi')) +
+      ev(assistantMessageResponseItem('legacy final', 'final_answer')) +  // old phase-tagged final
+      ev(assistantFinalResponseItem('legacy final')));                    // task_complete for same turn
+    const r = drainCodexRollout(path, 0);
+    const finals = r.events.filter(e => e.kind === 'assistant_final');
+    expect(finals).toHaveLength(1);
+    expect(finals[0].text).toBe('legacy final');
+  });
+
+  // A task_complete with empty last_agent_message still closes the turn (a
+  // silent successful turn must release its durable delivery).
+  it('empty last_agent_message still yields an assistant_final', () => {
+    writeFileSync(path,
+      ev(userResponseItem('go')) +
+      ev({ timestamp: '2026-04-29T07:00:02.000Z', type: 'event_msg', payload: { type: 'task_complete', turn_id: 't1', last_agent_message: '' } }));
+    const r = drainCodexRollout(path, 0);
+    expect(r.events).toHaveLength(2);
+    expect(r.events[1].kind).toBe('assistant_final');
+    expect(r.events[1].text).toBe('');
+  });
+
+  // task_complete without a turn_id is a malformed/partial record — ignored
+  // (belt-and-suspenders on top of the newline-completeness guard).
+  it('task_complete without turn_id is ignored', () => {
+    writeFileSync(path,
+      ev(userResponseItem('go')) +
+      ev({ timestamp: '2026-04-29T07:00:02.000Z', type: 'event_msg', payload: { type: 'task_complete', last_agent_message: 'no turn id' } }));
+    const r = drainCodexRollout(path, 0);
+    expect(r.events).toHaveLength(1);
+    expect(r.events[0].kind).toBe('user');
+  });
+
+  // A cancelled turn writes turn_aborted (no task_complete) → ambiguous
+  // terminal so the durable delivery releases instead of wedging as running.
+  it('turn_aborted yields an ambiguous assistant_final', () => {
+    writeFileSync(path,
+      ev(userResponseItem('go')) +
+      ev({ timestamp: '2026-04-29T07:00:02.000Z', type: 'event_msg', payload: { type: 'turn_aborted', turn_id: 't1', reason: 'user interrupt' } }));
+    const r = drainCodexRollout(path, 0);
+    expect(r.events).toHaveLength(2);
+    expect(r.events[1].kind).toBe('assistant_final');
+    expect(r.events[1].terminalStatus).toBe('ambiguous');
+    expect(r.events[1].terminalErrorCode).toBe('codex_turn_aborted:user_interrupt');
+  });
+
+  it('skips reasoning / function_call / function_call_output / non-terminal event_msg', () => {
     writeFileSync(path,
       ev({ type: 'response_item', payload: { type: 'reasoning' } }) +
       ev({ type: 'response_item', payload: { type: 'function_call', name: 'shell' } }) +
       ev({ type: 'response_item', payload: { type: 'function_call_output' } }) +
-      ev({ type: 'event_msg', payload: { type: 'task_complete', last_agent_message: 'not picked up' } }) +
+      ev({ type: 'event_msg', payload: { type: 'token_count', total: 42 } }) +
+      ev({ type: 'event_msg', payload: { type: 'agent_message', message: 'mid-turn chatter' } }) +
       ev(userResponseItem('actual prompt')));
     const r = drainCodexRollout(path, 0);
     expect(r.events).toHaveLength(1);


### PR DESCRIPTION
## 改了什么
codex-transcript.ts 的 rollout 解析器：判定「模型答完了」（产出 `assistant_final` 事件）的依据，从 `response_item` 的 `phase==='final_answer'` 改为 `event_msg` 的 `task_complete`（用 `last_agent_message` 作最终文本、top-level `timestamp` 作时间戳），删掉失效的 phase 分支；顺带把 `turn_aborted`（取消场景）映射为 `ambiguous` 终止。

## 为什么
codex 新版（实测 0.146.0，且与 model provider 相关）**去掉了** 最终 assistant `response_item` 上的 `phase:'final_answer'` 字段。解析器靠这个字段扫 `assistant_final` → 驱动 worker `final_output` → 解析 async trigger-result。字段没了之后：
- 新版 codex 的最终答复扫不到 → turn 永不闭合 → trigger-result **永久 running**。
- 更糟：中途预告 assistant message 和最终 message 现在都是 `phase:undefined`、无法区分，若「phase 缺失就当 final」会在第一句中途预告就闭合 → **输出截断**（这是我一度写错、又推翻的方案）。

`task_complete` 在三个实测 codex 版本（0.139 / 0.145 / 0.146）里都在、每轮恰一次、带最终文本 → 单一来源、天然免去重（codex 一个答复有 event_msg agent_message / response_item message / event_msg task_complete 三种表示，只取 task_complete 一次）。完全对齐 traex-transcript.ts 的既有实现（traex 早前因同样「assistant message 无可靠 phase」的原因就采用了 task_complete 边界）。

## 影响面
- **影响所有 codex 会话**的 transcript 兜底完成链（不止 apiOnly）。普通 fleet 里被掩盖，是因为模型平时主动调 `botmux send` 推消息、不依赖兜底；apiOnly / core-only 下 `botmux send` 被禁，transcript 成唯一完成通道，才暴露成任务永不完成。**值得单独 review + 考虑 backport 现役 fleet**。
- 仅 codex：`drainCodexRollout` 由 `structuredBridgeIsCodex()` 门控（worker.ts），traex/grok/cursor 各自 drainer 不受影响。`extractLastCodexTurn`（adopt 前导卡）source-agnostic、RPC rollout-match probe 只读 user 事件 → 均不受删 phase 分支影响。

## 测试验证
- `pnpm build` 绿（基于最新 master cherry-pick，auto-merge 无冲突）。
- `codex-transcript`(33) + `codex-bridge-queue`(41) 共 **74 单测全绿**，含新增回归：中途/phase-less 最终 assistant message 都不当 final、老版 phase+task_complete 只 emit 一次、空 last_agent_message 仍闭合、无 turn_id 忽略、turn_aborted→ambiguous。
- **riff 0.139 真机 E2E 已验证**（canary.13）：多步 turn trigger-result 5s 到 completed、output 完整不截断不 double（修前永久 running）。

已随 v3.9.0-canary.13 灰度发布并经 riff 真机验证；本 PR 将其合入 master 以进入正式版。

🤖 Generated with [Claude Code](https://claude.com/claude-code)