### PR TITLE
feat(api-only): form C 可视 web 终端 + 嵌套 sandbox pid-ns 降级

### DIFF
--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -251,41 +251,50 @@ export function sandboxEnabled(): boolean {
  */
 let _canUnsharePid: boolean | undefined;
 
+/** Three-state classification of a single bwrap probe run. The distinction is
+ *  load-bearing: only a `clean-nonzero` (bwrap RAN and returned a real verdict)
+ *  is evidence about namespace support; a `timeout`/spawn-error/signal is
+ *  `inconclusive` and must NEVER be treated as such evidence. */
+export type BwrapProbeOutcome = 'success' | 'clean-nonzero' | 'inconclusive';
+
 /**
  * Pure decision for the DUAL pid-ns probe — extracted for unit testing.
  *
  * We must distinguish "this env forbids a fresh /proc mount inside a NEW pid
  * namespace" (the real nested-sandbox condition → safe to drop --unshare-pid)
- * from "bwrap is broken / failing for some other reason" (must NOT degrade).
- * A single --unshare-pid probe cannot tell these apart: a bwrap that fails for
- * ANY reason (e.g. a hostile/fake bwrap that always exits 1, or a --dev-bind
- * that can't work) would look identical to the nested-pid-ns failure.
+ * from "bwrap is broken / the probe couldn't run" (must NOT degrade). Two
+ * probes, each classified into THREE states (success / clean-nonzero /
+ * inconclusive):
+ *   - full = `--unshare-user --unshare-pid --proc /proc …` (real sandbox shape)
+ *   - weak = same MINUS `--unshare-pid`
  *
- * So we run TWO probes and only degrade when the signature is EXACTLY
- * "pid-ns is the problem":
- *   - full = `--unshare-pid --proc /proc …` (what the real sandbox uses)
- *   - weak = same MINUS `--unshare-pid` (drop only the pid namespace)
- * Degrade IFF full FAILED and weak SUCCEEDED — i.e. removing --unshare-pid is
- * precisely what makes bwrap work. If weak ALSO fails, bwrap is broken for a
- * reason dropping pid-ns won't fix → keep full isolation (fail-closed). If full
- * SUCCEEDS, no need to degrade. `canRun===false` (spawn error/timeout/status
- * null) counts as "not a clean success" for that probe.
+ * Degrade IFF `full === 'clean-nonzero' && weak === 'success'` — i.e. bwrap
+ * DEFINITIVELY rejected the run WITH a new pid namespace but ACCEPTED it
+ * WITHOUT one → removing --unshare-pid is precisely the fix (nested signature).
+ * EVERY other combination keeps full isolation (fail-closed):
+ *   - full success → no need to degrade
+ *   - full inconclusive (timeout / spawn error / signal) → NOT evidence of a
+ *     pid-ns restriction, even if weak succeeds → do NOT degrade
+ *   - weak not a clean success (nonzero / inconclusive) → bwrap broken for a
+ *     reason dropping pid-ns won't fix → do NOT degrade
  *
  * Returns whether the host CAN keep --unshare-pid (true = no degrade).
  */
 export function pidNsDualProbeCanUnshare(
-  full: { ranOk: boolean },
-  weak: { ranOk: boolean },
+  full: BwrapProbeOutcome,
+  weak: BwrapProbeOutcome,
 ): boolean {
-  const degrade = !full.ranOk && weak.ranOk;
+  const degrade = full === 'clean-nonzero' && weak === 'success';
   return !degrade;
 }
 
-/** A bwrap probe "ran OK" only when it spawned without error AND exited 0. Any
- *  spawn error (ENOENT), timeout (SIGTERM), or status===null is NOT a clean
- *  success. */
-function probeRanOk(r: ReturnType<typeof spawnSync>): boolean {
-  return !r.error && r.status === 0;
+/** Classify a spawnSync result into the three probe states. A spawn error
+ *  (ENOENT), a timeout/kill (`signal` set, e.g. SIGTERM), or a null exit status
+ *  is `inconclusive` — the probe did not yield a real bwrap verdict. A clean
+ *  numeric exit is `success` (0) or `clean-nonzero` (>0). */
+function classifyProbe(r: ReturnType<typeof spawnSync>): BwrapProbeOutcome {
+  if (r.error || r.signal !== null || r.status === null) return 'inconclusive';
+  return r.status === 0 ? 'success' : 'clean-nonzero';
 }
 
 export function bwrapCanUnsharePid(): boolean {
@@ -295,17 +304,20 @@ export function bwrapCanUnsharePid(): boolean {
   if (!located || !isAbsolute(located)) { _canUnsharePid = true; return true; } // inconclusive → don't degrade
   let executable = located;
   try { executable = realpathSync(located); } catch { /* fall through to probe */ }
-  const base = ['--dev-bind', '/', '/', '--proc', '/proc', '--', '/bin/true'];
-  // FULL: the exact --unshare-pid + fresh --proc combo the real compilation
-  // uses. In a nested pid-ns-restricted sandbox this fails ("Can't mount proc
-  // … Operation not permitted"); on a normal host it succeeds.
-  const full = spawnSync(executable, ['--unshare-pid', ...base], { stdio: 'ignore', timeout: 5_000 });
-  if (probeRanOk(full)) { _canUnsharePid = true; return true; } // full works → never degrade
-  // WEAK: same minus --unshare-pid. Only if THIS succeeds is dropping the pid
-  // namespace the actual fix (nested-sandbox signature). A fake/broken bwrap
-  // that fails everything makes weak fail too → we do NOT degrade (fail-closed).
-  const weak = spawnSync(executable, base, { stdio: 'ignore', timeout: 5_000 });
-  _canUnsharePid = pidNsDualProbeCanUnshare({ ranOk: probeRanOk(full) }, { ranOk: probeRanOk(weak) });
+  // Same SHAPE as the real fs-policy compile (compileToBwrap): --unshare-user
+  // is always present there, and its userns interacts with the proc mount, so
+  // the probe must carry it too or it isn't testing the real condition.
+  const base = ['--dev-bind', '/', '/', '--proc', '/proc', '--unshare-user', '--', '/bin/true'];
+  // FULL: real shape WITH --unshare-pid. Nested pid-ns-restricted sandbox →
+  // clean-nonzero ("Can't mount proc … Operation not permitted"); normal host
+  // → success.
+  const full = classifyProbe(spawnSync(executable, ['--unshare-pid', ...base], { stdio: 'ignore', timeout: 5_000 }));
+  if (full === 'success') { _canUnsharePid = true; return true; } // full works → never degrade
+  // WEAK: same minus --unshare-pid. Only a clean-nonzero full + success weak is
+  // the nested signature; a full timeout/spawn-error (inconclusive) never
+  // degrades even if weak succeeds.
+  const weak = classifyProbe(spawnSync(executable, base, { stdio: 'ignore', timeout: 5_000 }));
+  _canUnsharePid = pidNsDualProbeCanUnshare(full, weak);
   return _canUnsharePid;
 }
 

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -250,6 +250,44 @@ export function sandboxEnabled(): boolean {
  * must not spuriously degrade the normal fleet on an inconclusive probe.
  */
 let _canUnsharePid: boolean | undefined;
+
+/**
+ * Pure decision for the DUAL pid-ns probe — extracted for unit testing.
+ *
+ * We must distinguish "this env forbids a fresh /proc mount inside a NEW pid
+ * namespace" (the real nested-sandbox condition → safe to drop --unshare-pid)
+ * from "bwrap is broken / failing for some other reason" (must NOT degrade).
+ * A single --unshare-pid probe cannot tell these apart: a bwrap that fails for
+ * ANY reason (e.g. a hostile/fake bwrap that always exits 1, or a --dev-bind
+ * that can't work) would look identical to the nested-pid-ns failure.
+ *
+ * So we run TWO probes and only degrade when the signature is EXACTLY
+ * "pid-ns is the problem":
+ *   - full = `--unshare-pid --proc /proc …` (what the real sandbox uses)
+ *   - weak = same MINUS `--unshare-pid` (drop only the pid namespace)
+ * Degrade IFF full FAILED and weak SUCCEEDED — i.e. removing --unshare-pid is
+ * precisely what makes bwrap work. If weak ALSO fails, bwrap is broken for a
+ * reason dropping pid-ns won't fix → keep full isolation (fail-closed). If full
+ * SUCCEEDS, no need to degrade. `canRun===false` (spawn error/timeout/status
+ * null) counts as "not a clean success" for that probe.
+ *
+ * Returns whether the host CAN keep --unshare-pid (true = no degrade).
+ */
+export function pidNsDualProbeCanUnshare(
+  full: { ranOk: boolean },
+  weak: { ranOk: boolean },
+): boolean {
+  const degrade = !full.ranOk && weak.ranOk;
+  return !degrade;
+}
+
+/** A bwrap probe "ran OK" only when it spawned without error AND exited 0. Any
+ *  spawn error (ENOENT), timeout (SIGTERM), or status===null is NOT a clean
+ *  success. */
+function probeRanOk(r: ReturnType<typeof spawnSync>): boolean {
+  return !r.error && r.status === 0;
+}
+
 export function bwrapCanUnsharePid(): boolean {
   if (_canUnsharePid !== undefined) return _canUnsharePid;
   const lookup = spawnSync('sh', ['-c', 'command -v bwrap'], { encoding: 'utf8' });
@@ -257,16 +295,17 @@ export function bwrapCanUnsharePid(): boolean {
   if (!located || !isAbsolute(located)) { _canUnsharePid = true; return true; } // inconclusive → don't degrade
   let executable = located;
   try { executable = realpathSync(located); } catch { /* fall through to probe */ }
-  // Minimal decisive probe: the SAME --unshare-pid + fresh --proc combo the
-  // real compilation uses (fs-policy compileToBwrap). If this fails but a
-  // proc-only mount would succeed, we're in a nested pid-ns-restricted env.
-  const r = spawnSync(executable, [
-    '--dev-bind', '/', '/',
-    '--unshare-pid',
-    '--proc', '/proc',
-    '--', '/bin/true',
-  ], { stdio: 'ignore', timeout: 5_000 });
-  _canUnsharePid = r.status === 0;
+  const base = ['--dev-bind', '/', '/', '--proc', '/proc', '--', '/bin/true'];
+  // FULL: the exact --unshare-pid + fresh --proc combo the real compilation
+  // uses. In a nested pid-ns-restricted sandbox this fails ("Can't mount proc
+  // … Operation not permitted"); on a normal host it succeeds.
+  const full = spawnSync(executable, ['--unshare-pid', ...base], { stdio: 'ignore', timeout: 5_000 });
+  if (probeRanOk(full)) { _canUnsharePid = true; return true; } // full works → never degrade
+  // WEAK: same minus --unshare-pid. Only if THIS succeeds is dropping the pid
+  // namespace the actual fix (nested-sandbox signature). A fake/broken bwrap
+  // that fails everything makes weak fail too → we do NOT degrade (fail-closed).
+  const weak = spawnSync(executable, base, { stdio: 'ignore', timeout: 5_000 });
+  _canUnsharePid = pidNsDualProbeCanUnshare({ ranOk: probeRanOk(full) }, { ranOk: probeRanOk(weak) });
   return _canUnsharePid;
 }
 

--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -234,6 +234,69 @@ export function sandboxEnabled(): boolean {
 }
 
 /**
+ * Whether this host can run bwrap with a NEW PID namespace + a fresh `/proc`
+ * mount — i.e. `bwrap --unshare-pid --proc /proc`. In a NESTED sandbox (e.g.
+ * riff's AIO sandbox) mounting a fresh procfs inside a new pid namespace is
+ * denied by the kernel: `Can't mount proc on /newroot/proc: Operation not
+ * permitted`. When that happens the file sandbox must degrade (drop
+ * --unshare-pid) rather than fail every spawn — but ONLY in a context where
+ * dropping pid isolation cannot leak a sibling bot's secret via
+ * `/proc/<pid>/environ` (see coreOnlyPidNamespaceDegrade below).
+ *
+ * Probed ONCE per process and cached: it shells out to bwrap and the answer is
+ * a fixed property of the host/namespace we booted in. Returns true when the
+ * probe cannot run at all (bwrap missing) — the caller only consults this to
+ * DECIDE A DEGRADE, and a missing bwrap is handled fail-closed elsewhere; we
+ * must not spuriously degrade the normal fleet on an inconclusive probe.
+ */
+let _canUnsharePid: boolean | undefined;
+export function bwrapCanUnsharePid(): boolean {
+  if (_canUnsharePid !== undefined) return _canUnsharePid;
+  const lookup = spawnSync('sh', ['-c', 'command -v bwrap'], { encoding: 'utf8' });
+  const located = lookup.status === 0 ? lookup.stdout.trim() : '';
+  if (!located || !isAbsolute(located)) { _canUnsharePid = true; return true; } // inconclusive → don't degrade
+  let executable = located;
+  try { executable = realpathSync(located); } catch { /* fall through to probe */ }
+  // Minimal decisive probe: the SAME --unshare-pid + fresh --proc combo the
+  // real compilation uses (fs-policy compileToBwrap). If this fails but a
+  // proc-only mount would succeed, we're in a nested pid-ns-restricted env.
+  const r = spawnSync(executable, [
+    '--dev-bind', '/', '/',
+    '--unshare-pid',
+    '--proc', '/proc',
+    '--', '/bin/true',
+  ], { stdio: 'ignore', timeout: 5_000 });
+  _canUnsharePid = r.status === 0;
+  return _canUnsharePid;
+}
+
+/** Test-only: reset the cached pid-ns probe. */
+export function __testOnly_resetPidNamespaceProbe(): void {
+  _canUnsharePid = undefined;
+}
+
+/**
+ * Whether compileToBwrap should DROP `--unshare-pid` for this spawn. Gated on
+ * BOTH conditions, deliberately conservative (security review):
+ *   1. BOTMUX_CORE_ONLY=1 — core-only synthesizes EXACTLY ONE apiOnly bot
+ *      (bot-registry.maybeSynthesizeCoreOnlyConfig), whose worker carries
+ *      LARK_APP_SECRET='' (no-transport). There is NO sibling worker holding a
+ *      secret in env, so exposing the host pid namespace (a fresh --proc in the
+ *      host pid ns enumerates host processes) cannot leak any bot secret via
+ *      /proc/<pid>/environ. On a normal/mixed fleet a sibling transport bot's
+ *      worker DOES carry the plaintext secret in env (worker-pool.ts:2404), so
+ *      --unshare-pid MUST stay — hence this gate never fires there.
+ *   2. The host actually can't unshare-pid (nested sandbox) — otherwise keep
+ *      full isolation; there's no reason to weaken it when it works.
+ * The on-disk credential seal (fs-policy deny masks) is UNCHANGED regardless;
+ * only the pid-namespace defense-in-depth is dropped, and only where it both
+ * (a) can't work and (b) protects nothing.
+ */
+export function coreOnlyPidNamespaceDegrade(): boolean {
+  return process.env.BOTMUX_CORE_ONLY === '1' && !bwrapCanUnsharePid();
+}
+
+/**
  * Whether a LOCAL sandbox engine applies to this backend at all. riff has NO
  * local CLI process to wrap (execution happens in riff's own remote sandbox);
  * without this bypass the worker's fail-safe "backend not sandboxable" hard
@@ -478,7 +541,7 @@ export function prepareDirectSandbox(opts: {
     try { if (statSync(r.path).isFile()) filePaths.add(r.path); } catch { /* absent → dir-shaped mask */ }
   }
 
-  const compiled = compileToBwrap(opts.policy, { symlinks, emptyDir, emptiesDir: empties, filePaths, chdir: opts.chdir });
+  const compiled = compileToBwrap(opts.policy, { symlinks, emptyDir, emptiesDir: empties, filePaths, chdir: opts.chdir, skipPidNamespace: coreOnlyPidNamespaceDegrade() });
   // The shared empty dir + every empty placeholder file are the ro-bind SOURCES
   // for deny masks: real content hidden + read-only. mode 000 additionally makes
   // the mask unlistable for a NON-root uid (a real deny, not a listable "empty");

--- a/src/adapters/cli/fs-policy.ts
+++ b/src/adapters/cli/fs-policy.ts
@@ -900,6 +900,13 @@ export interface CompileBwrapOpts {
   filePaths?: ReadonlySet<string>;
   /** chdir target (the project working dir). */
   chdir: string;
+  /** Drop `--unshare-pid` (keep the fresh `--proc /proc` mount, which works
+   *  without a new pid namespace). Set ONLY in a nested sandbox that can't
+   *  mount proc inside a new pid ns AND where no sibling secret is exposed via
+   *  /proc — see sandbox.coreOnlyPidNamespaceDegrade. The filesystem deny/allow
+   *  masks (the on-disk credential seal) are unaffected; this drops only the
+   *  process-isolation defense-in-depth. Default false = full isolation. */
+  skipPidNamespace?: boolean;
 }
 
 export interface BwrapCompilation {
@@ -1017,7 +1024,18 @@ export function compileToBwrap(policy: FsPolicy, opts: CompileBwrapOpts): BwrapC
   // tmpfs parent becomes unwritable).
   for (const p of remountRo) a.push('--remount-ro', p);
 
-  a.push('--unshare-user', '--unshare-pid', '--unshare-ipc', '--unshare-uts', '--unshare-cgroup-try');
+  // --unshare-pid is the process-isolation half of the sandbox (defense in
+  // depth), NOT the credential seal — that is the FS deny masks above. A NESTED
+  // sandbox can't mount a fresh /proc inside a new pid ns (bwrap: "Can't mount
+  // proc on /newroot/proc: Operation not permitted"), so it is dropped there
+  // via skipPidNamespace. The fresh `--proc /proc` (line above) still mounts
+  // fine WITHOUT a new pid ns. skipPidNamespace is gated (sandbox.coreOnly
+  // PidNamespaceDegrade) to core-only, where no sibling worker holds a secret
+  // in env → dropping pid isolation exposes no /proc/<pid>/environ secret.
+  const unshares = ['--unshare-user'];
+  if (!opts.skipPidNamespace) unshares.push('--unshare-pid');
+  unshares.push('--unshare-ipc', '--unshare-uts', '--unshare-cgroup-try');
+  a.push(...unshares);
   if (!policy.net) a.push('--unshare-net');
   a.push('--die-with-parent', '--new-session', '--chdir', opts.chdir);
   return { args: a, emptyFiles, maskMounts };

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -1126,7 +1126,7 @@ function buildAsyncTriggerLookupResponse(sessionId: string, triggerId?: string):
   const memTriggerId = triggerId || ds?.latestAsyncTriggerId;
   const memResult = ds && memTriggerId ? ds.asyncTriggerResults?.get(memTriggerId) : undefined;
 
-  return resolveAsyncTriggerState({
+  const resolved = resolveAsyncTriggerState({
     sessionId,
     liveActive: !!ds,
     chatId: ds?.chatId ?? stored?.chatId,
@@ -1137,6 +1137,18 @@ function buildAsyncTriggerLookupResponse(sessionId: string, triggerId?: string):
     closedAt: stored?.closedAt,
     requestedTriggerId: triggerId,
   });
+
+  // Form C: attach the read-only web-terminal URL when a LIVE worker terminal
+  // exists (workerPort bound + view capability minted). This lets an async
+  // caller open a live view of the visible CLI TUI while the turn runs. Gated
+  // on the live `ds` — a closed/restored session has no reachable terminal, so
+  // we never advertise a stale URL. buildTerminalUrl carries the ?viewToken=
+  // inline; in core-only the host is frozen to 127.0.0.1 (see index-core-only).
+  if (ds && ds.workerPort && ds.workerViewToken) {
+    resolved.readOnlyUrl = buildTerminalUrl(ds);
+    resolved.viewToken = ds.workerViewToken;
+  }
+  return resolved;
 }
 
 // 看板放置：dashboard 看板视图拖拽卡片后持久化列 + 列内排序位置。

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -1138,13 +1138,18 @@ function buildAsyncTriggerLookupResponse(sessionId: string, triggerId?: string):
     requestedTriggerId: triggerId,
   });
 
-  // Form C: attach the read-only web-terminal URL when a LIVE worker terminal
-  // exists (workerPort bound + view capability minted). This lets an async
-  // caller open a live view of the visible CLI TUI while the turn runs. Gated
-  // on the live `ds` — a closed/restored session has no reachable terminal, so
-  // we never advertise a stale URL. buildTerminalUrl carries the ?viewToken=
-  // inline; in core-only the host is frozen to 127.0.0.1 (see index-core-only).
-  if (ds && ds.workerPort && ds.workerViewToken) {
+  // Form C: attach the read-only web-terminal URL ONLY in core-only mode, and
+  // only when a LIVE worker terminal exists (workerPort bound + view capability
+  // minted). Core-only is the single-tenant loopback path where trigger-result
+  // is a public (no-HMAC) route and riff's in-sandbox runner polls it to open
+  // the visible CLI TUI. Gating on BOTMUX_CORE_ONLY keeps this OFF the normal/
+  // mixed fleet: there trigger-result is HMAC-gated, but we still must not widen
+  // the token surface by minting a terminal read-capability into a poll response
+  // that historically carried none (the dashboard mints view/write tokens only
+  // on explicit /write-link request). buildTerminalUrl carries ?viewToken=
+  // inline; the write token is never included. Closed/restored sessions have no
+  // live worker terminal, so no stale URL is ever advertised.
+  if (process.env.BOTMUX_CORE_ONLY === '1' && ds && ds.workerPort && ds.workerViewToken) {
     resolved.readOnlyUrl = buildTerminalUrl(ds);
     resolved.viewToken = ds.workerViewToken;
   }

--- a/src/index-core-only.ts
+++ b/src/index-core-only.ts
@@ -51,6 +51,18 @@ delete process.env.BOTS_CONFIG;
 // future intentional exposure would be a separate explicit danger switch.)
 process.env.BOTMUX_WORKER_HTTP_HOST = '127.0.0.1';
 delete process.env.BOTMUX_WORKER_HOST; // legacy alias — must not shadow the freeze
+// Freeze the ADVERTISED web-terminal host to loopback too (form C). The line
+// above confines where the worker web server BINDS; this confines the host
+// baked into the read-only terminal URL that buildTerminalUrl() advertises.
+// Without it, config.web.externalHost falls back to getWebExternalHost() →
+// getLocalIp() (a LAN IP like 10.x.x.x), so the URL handed to riff would point
+// at an interface the proxy doesn't even listen on (proxy is 127.0.0.1-only in
+// core-only) — an in-sandbox VNC browser opening that URL would fail to connect.
+// core-only is single-tenant loopback, so the terminal is only ever reached via
+// 127.0.0.1; freeze the advertised host to match the bind. WEB_EXTERNAL_HOST is
+// the env getWebExternalHost() reads first (config.ts:30), so this wins.
+process.env.WEB_EXTERNAL_HOST = '127.0.0.1';
+
 
 // Freeze a DEDICATED state root (codex P1): core-only must never inherit an
 // ambient SESSION_DATA_DIR — a managed turn that spawns `serve --api-only`

--- a/src/services/trigger-types.ts
+++ b/src/services/trigger-types.ts
@@ -131,6 +131,16 @@ export interface TriggerResponse {
     sessionId?: string;
     completedAt?: string;
   };
+  /** Read-only web-terminal URL for the live session's CLI pane, present only
+   *  while a worker web server is up (typically `state:'running'` and at
+   *  `'completed'` before the session closes). Lets an async caller (e.g. riff's
+   *  in-sandbox task-runner) open a live view of the visible CLI TUI — form C.
+   *  Carries the `?viewToken=` read capability inline; knowing it grants read
+   *  only, never terminal input. Omitted when no live worker terminal exists. */
+  readOnlyUrl?: string;
+  /** The bare read capability behind `readOnlyUrl`'s `?viewToken=`, exposed
+   *  separately for callers that build their own URL. Omitted with readOnlyUrl. */
+  viewToken?: string;
 }
 
 export function isRecord(v: unknown): v is Record<string, unknown> {

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -3119,10 +3119,12 @@ describe('core-only public routes + readiness barrier (behavioral)', () => {
   // Form C: trigger-result carries a read-only web-terminal URL while a live
   // worker terminal exists, so an async caller (riff's task-runner) can open
   // the visible CLI TUI in the sandbox browser.
-  it('trigger-result exposes readOnlyUrl + viewToken when a live worker terminal is up', async () => {
+  it('trigger-result exposes readOnlyUrl + viewToken when a live worker terminal is up (core-only)', async () => {
     setIpcAuthSecret(TEST_IPC_SECRET);
     setLarkAppId('local_smoke');
     setCoreOnlyReady();
+    const prevCoreOnly = process.env.BOTMUX_CORE_ONLY;
+    process.env.BOTMUX_CORE_ONLY = '1';
     const findSpy = vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue({
       session: { sessionId: 's-term', chatId: 'http_async_x', larkAppId: 'local_smoke', status: 'open' },
       chatId: 'http_async_x',
@@ -3133,21 +3135,65 @@ describe('core-only public routes + readiness barrier (behavioral)', () => {
       asyncTriggerResults: new Map(),
     } as any);
     handle = await startIpcServer({ port: 0, host: '127.0.0.1', authRequired: true, coreOnlyPublicRoutes: true });
-    const res = await fetch(`http://127.0.0.1:${handle.port}/api/sessions/s-term/trigger-result`);
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(typeof body.readOnlyUrl).toBe('string');
-    // Carries the read capability inline, NOT the write token.
-    expect(body.readOnlyUrl).toContain('viewToken=view-cap-abc');
-    expect(body.readOnlyUrl).not.toContain('write-tok');
-    expect(body.viewToken).toBe('view-cap-abc');
-    findSpy.mockRestore();
+    try {
+      const res = await fetch(`http://127.0.0.1:${handle.port}/api/sessions/s-term/trigger-result`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(typeof body.readOnlyUrl).toBe('string');
+      // Carries the read capability inline, NOT the write token.
+      expect(body.readOnlyUrl).toContain('viewToken=view-cap-abc');
+      expect(body.readOnlyUrl).not.toContain('write-tok');
+      expect(body.viewToken).toBe('view-cap-abc');
+    } finally {
+      if (prevCoreOnly === undefined) delete process.env.BOTMUX_CORE_ONLY;
+      else process.env.BOTMUX_CORE_ONLY = prevCoreOnly;
+      findSpy.mockRestore();
+    }
   });
 
-  it('trigger-result omits readOnlyUrl when the live session has no worker terminal yet', async () => {
+  // codex review concern #1: the readOnlyUrl/viewToken attach must be gated to
+  // core-only. On a normal/mixed fleet trigger-result must NEVER mint a terminal
+  // read-capability into the poll response — even with a live worker terminal —
+  // or an HMAC-authed trigger caller would gain a view token the route never
+  // historically handed out (tokens are minted only on explicit /write-link).
+  it('trigger-result does NOT expose readOnlyUrl on a NON-core-only fleet even with a live worker terminal', async () => {
+    setIpcAuthSecret(TEST_IPC_SECRET);
+    setLarkAppId('local_smoke');
+    const prevCoreOnly = process.env.BOTMUX_CORE_ONLY;
+    delete process.env.BOTMUX_CORE_ONLY; // normal fleet
+    const findSpy = vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue({
+      session: { sessionId: 's-fleet', chatId: 'oc_real_chat', larkAppId: 'local_smoke', status: 'open' },
+      chatId: 'oc_real_chat',
+      larkAppId: 'local_smoke',
+      workerPort: 4321,               // live worker terminal present …
+      workerToken: 'write-tok',
+      workerViewToken: 'view-cap-abc',
+      asyncTriggerResults: new Map(),
+    } as any);
+    // Normal fleet: default server (no coreOnlyPublicRoutes) — trigger-result
+    // is HMAC-gated; authorize with the same unbound token the write-link tests
+    // use so the request reaches the handler.
+    handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+    try {
+      const res = await fetch(`http://127.0.0.1:${handle.port}/api/sessions/s-fleet/trigger-result`, { headers: tokenAuthHeaders() });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // … but NO terminal capability is leaked into the poll response.
+      expect(body.readOnlyUrl).toBeUndefined();
+      expect(body.viewToken).toBeUndefined();
+    } finally {
+      if (prevCoreOnly === undefined) delete process.env.BOTMUX_CORE_ONLY;
+      else process.env.BOTMUX_CORE_ONLY = prevCoreOnly;
+      findSpy.mockRestore();
+    }
+  });
+
+  it('trigger-result omits readOnlyUrl when the live session has no worker terminal yet (core-only)', async () => {
     setIpcAuthSecret(TEST_IPC_SECRET);
     setLarkAppId('local_smoke');
     setCoreOnlyReady();
+    const prevCoreOnly = process.env.BOTMUX_CORE_ONLY;
+    process.env.BOTMUX_CORE_ONLY = '1';
     const findSpy = vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue({
       session: { sessionId: 's-noterm', chatId: 'http_async_y', larkAppId: 'local_smoke', status: 'open' },
       chatId: 'http_async_y',
@@ -3157,11 +3203,16 @@ describe('core-only public routes + readiness barrier (behavioral)', () => {
       asyncTriggerResults: new Map(),
     } as any);
     handle = await startIpcServer({ port: 0, host: '127.0.0.1', authRequired: true, coreOnlyPublicRoutes: true });
-    const res = await fetch(`http://127.0.0.1:${handle.port}/api/sessions/s-noterm/trigger-result`);
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.readOnlyUrl).toBeUndefined();
-    expect(body.viewToken).toBeUndefined();
-    findSpy.mockRestore();
+    try {
+      const res = await fetch(`http://127.0.0.1:${handle.port}/api/sessions/s-noterm/trigger-result`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.readOnlyUrl).toBeUndefined();
+      expect(body.viewToken).toBeUndefined();
+    } finally {
+      if (prevCoreOnly === undefined) delete process.env.BOTMUX_CORE_ONLY;
+      else process.env.BOTMUX_CORE_ONLY = prevCoreOnly;
+      findSpy.mockRestore();
+    }
   });
 });

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -3115,4 +3115,53 @@ describe('core-only public routes + readiness barrier (behavioral)', () => {
     expect(res.status).toBe(200);
     expect((await res.json()).ok).toBe(true);
   });
+
+  // Form C: trigger-result carries a read-only web-terminal URL while a live
+  // worker terminal exists, so an async caller (riff's task-runner) can open
+  // the visible CLI TUI in the sandbox browser.
+  it('trigger-result exposes readOnlyUrl + viewToken when a live worker terminal is up', async () => {
+    setIpcAuthSecret(TEST_IPC_SECRET);
+    setLarkAppId('local_smoke');
+    setCoreOnlyReady();
+    const findSpy = vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue({
+      session: { sessionId: 's-term', chatId: 'http_async_x', larkAppId: 'local_smoke', status: 'open' },
+      chatId: 'http_async_x',
+      larkAppId: 'local_smoke',
+      workerPort: 4321,
+      workerToken: 'write-tok',
+      workerViewToken: 'view-cap-abc',
+      asyncTriggerResults: new Map(),
+    } as any);
+    handle = await startIpcServer({ port: 0, host: '127.0.0.1', authRequired: true, coreOnlyPublicRoutes: true });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/sessions/s-term/trigger-result`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.readOnlyUrl).toBe('string');
+    // Carries the read capability inline, NOT the write token.
+    expect(body.readOnlyUrl).toContain('viewToken=view-cap-abc');
+    expect(body.readOnlyUrl).not.toContain('write-tok');
+    expect(body.viewToken).toBe('view-cap-abc');
+    findSpy.mockRestore();
+  });
+
+  it('trigger-result omits readOnlyUrl when the live session has no worker terminal yet', async () => {
+    setIpcAuthSecret(TEST_IPC_SECRET);
+    setLarkAppId('local_smoke');
+    setCoreOnlyReady();
+    const findSpy = vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue({
+      session: { sessionId: 's-noterm', chatId: 'http_async_y', larkAppId: 'local_smoke', status: 'open' },
+      chatId: 'http_async_y',
+      larkAppId: 'local_smoke',
+      workerPort: null,          // worker web server not up yet
+      workerViewToken: null,
+      asyncTriggerResults: new Map(),
+    } as any);
+    handle = await startIpcServer({ port: 0, host: '127.0.0.1', authRequired: true, coreOnlyPublicRoutes: true });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/sessions/s-noterm/trigger-result`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.readOnlyUrl).toBeUndefined();
+    expect(body.viewToken).toBeUndefined();
+    findSpy.mockRestore();
+  });
 });

--- a/test/fs-policy.test.ts
+++ b/test/fs-policy.test.ts
@@ -591,6 +591,36 @@ describe('compileToBwrap', () => {
     expect(args).toContain('--chdir');
   });
 
+  it('default: emits --unshare-pid (full process isolation) alongside the fresh --proc mount', () => {
+    const p = buildFsPolicy(ctx({ platform: 'linux', homeDir: '/home/u', botHome: '/home/u/.botmux/bots/cli_self', botmuxHome: '/home/u/.botmux', sessionDataDir: '/home/u/.botmux/data', workingDir: '/home/u/proj' }));
+    const { args } = compileToBwrap(p, opts);
+    expect(args).toContain('--unshare-pid');
+    expect(args).toContain('--unshare-user');
+    expect(args).toContain('--proc');
+  });
+
+  it('skipPidNamespace: drops ONLY --unshare-pid, keeps the fresh --proc mount + every other unshare + the FS masks', () => {
+    const p = buildFsPolicy(ctx({
+      platform: 'linux', homeDir: '/home/u', botHome: '/home/u/.botmux/bots/cli_self',
+      botmuxHome: '/home/u/.botmux', sessionDataDir: '/home/u/.botmux/data', workingDir: '/home/u/proj',
+      userPaths: { deny: ['/home/u/proj/secrets'] },
+    }));
+    const { args } = compileToBwrap(p, { ...opts, skipPidNamespace: true });
+    // The nested-sandbox failure was --unshare-pid + fresh --proc; drop ONLY the
+    // pid unshare. Everything else (incl. the fresh proc mount) stays.
+    expect(args).not.toContain('--unshare-pid');
+    expect(args).toContain('--proc');
+    expect(args).toContain('--unshare-user');   // credential-relevant uid map + best-effort environ block
+    expect(args).toContain('--unshare-ipc');
+    expect(args).toContain('--unshare-uts');
+    expect(args).toContain('--unshare-cgroup-try');
+    // The on-disk credential seal (deny mask) is UNAFFECTED by the pid degrade.
+    const mask = args.indexOf('/home/u/proj/secrets');
+    expect(mask).toBeGreaterThan(-1);
+    expect(args[mask - 1]).toBe('/sbx/empty');
+    expect(args[mask - 2]).toBe('--ro-bind');
+  });
+
   it('deny under an exposed tree masks with a READ-ONLY empty-dir bind (not writable tmpfs); unreachable deny is skipped', () => {
     const p = buildFsPolicy(ctx({
       platform: 'linux', homeDir: '/home/u', botHome: '/home/u/.botmux/bots/cli_self',

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect } from 'vitest';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { mkdtempSync, existsSync, writeFileSync, readFileSync, symlinkSync, realpathSync } from 'node:fs';
-import { buildRelayHostEnv, validateRelayRequest, materializeOutboxFile, prepareDirectSandbox } from '../src/adapters/backend/sandbox.js';
+import { buildRelayHostEnv, validateRelayRequest, materializeOutboxFile, prepareDirectSandbox, coreOnlyPidNamespaceDegrade, bwrapCanUnsharePid, __testOnly_resetPidNamespaceProbe } from '../src/adapters/backend/sandbox.js';
 import { createCodexAppAdapter } from '../src/adapters/cli/codex-app.js';
 
 const tmp = () => mkdtempSync(join(tmpdir(), 'sbx-'));
@@ -38,6 +38,45 @@ describe('prepareDirectSandbox platform gate', () => {
       chdir: '/x', home: '/home/u', cliBin: '/usr/bin/true', cliArgs: [],
     });
     expect(r).toBeNull();
+  });
+});
+
+// The pid-namespace degrade (drop --unshare-pid for a nested sandbox that can't
+// mount /proc in a new pid ns) MUST be gated to core-only. On a normal/mixed
+// fleet a sibling transport bot's worker carries LARK_APP_SECRET in its env, so
+// dropping pid isolation would expose it via /proc/<pid>/environ. The gate is
+// BOTMUX_CORE_ONLY=1 && !bwrapCanUnsharePid() — and BOTMUX_CORE_ONLY short-
+// circuits FIRST, so the normal fleet never even runs the probe, never degrades.
+describe('coreOnlyPidNamespaceDegrade gate (credential-safety)', () => {
+  it('is FALSE without BOTMUX_CORE_ONLY, regardless of host pid-ns support (normal fleet keeps --unshare-pid)', () => {
+    const prev = process.env.BOTMUX_CORE_ONLY;
+    delete process.env.BOTMUX_CORE_ONLY;
+    __testOnly_resetPidNamespaceProbe();
+    try {
+      expect(coreOnlyPidNamespaceDegrade()).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.BOTMUX_CORE_ONLY;
+      else process.env.BOTMUX_CORE_ONLY = prev;
+      __testOnly_resetPidNamespaceProbe();
+    }
+  });
+
+  it('under BOTMUX_CORE_ONLY, tracks the host probe: degrade IFF the host cannot unshare-pid', () => {
+    const prev = process.env.BOTMUX_CORE_ONLY;
+    process.env.BOTMUX_CORE_ONLY = '1';
+    __testOnly_resetPidNamespaceProbe();
+    try {
+      // On this (non-nested) host the probe should succeed → NO degrade. In a
+      // nested sandbox the same call returns true. We assert the invariant that
+      // degrade === (core-only AND probe-says-cant): here core-only is on, so
+      // the result must be the negation of the raw probe.
+      const canUnshare = bwrapCanUnsharePid();
+      expect(coreOnlyPidNamespaceDegrade()).toBe(!canUnshare);
+    } finally {
+      if (prev === undefined) delete process.env.BOTMUX_CORE_ONLY;
+      else process.env.BOTMUX_CORE_ONLY = prev;
+      __testOnly_resetPidNamespaceProbe();
+    }
   });
 });
 

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect } from 'vitest';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { mkdtempSync, existsSync, writeFileSync, readFileSync, symlinkSync, realpathSync } from 'node:fs';
-import { buildRelayHostEnv, validateRelayRequest, materializeOutboxFile, prepareDirectSandbox, coreOnlyPidNamespaceDegrade, bwrapCanUnsharePid, __testOnly_resetPidNamespaceProbe } from '../src/adapters/backend/sandbox.js';
+import { buildRelayHostEnv, validateRelayRequest, materializeOutboxFile, prepareDirectSandbox, coreOnlyPidNamespaceDegrade, bwrapCanUnsharePid, pidNsDualProbeCanUnshare, __testOnly_resetPidNamespaceProbe } from '../src/adapters/backend/sandbox.js';
 import { createCodexAppAdapter } from '../src/adapters/cli/codex-app.js';
 
 const tmp = () => mkdtempSync(join(tmpdir(), 'sbx-'));
@@ -77,6 +77,24 @@ describe('coreOnlyPidNamespaceDegrade gate (credential-safety)', () => {
       else process.env.BOTMUX_CORE_ONLY = prev;
       __testOnly_resetPidNamespaceProbe();
     }
+  });
+
+  // codex review concern #2 (P1): a SINGLE --unshare-pid probe treats ANY
+  // bwrap failure as "safe to drop --unshare-pid" — codex reproduced degrade:true
+  // with a fake bwrap that always exits 1. The DUAL probe only degrades when the
+  // signature is exactly "pid-ns is the problem": full (--unshare-pid) fails AND
+  // weak (no --unshare-pid) succeeds. Everything else is fail-closed.
+  describe('pidNsDualProbeCanUnshare (dual full/weak probe, fail-closed)', () => {
+    it('full succeeds → CAN unshare-pid (no degrade), regardless of weak', () => {
+      expect(pidNsDualProbeCanUnshare({ ranOk: true }, { ranOk: true })).toBe(true);
+      expect(pidNsDualProbeCanUnshare({ ranOk: true }, { ranOk: false })).toBe(true);
+    });
+    it('full FAILS but weak SUCCEEDS → nested-sandbox signature → CANNOT unshare-pid (the ONLY degrade case)', () => {
+      expect(pidNsDualProbeCanUnshare({ ranOk: false }, { ranOk: true })).toBe(false);
+    });
+    it('BOTH fail (e.g. fake bwrap always exits 1 — codex repro) → bwrap broken, NOT a pid-ns issue → CAN unshare-pid (fail-closed, no degrade)', () => {
+      expect(pidNsDualProbeCanUnshare({ ranOk: false }, { ranOk: false })).toBe(true);
+    });
   });
 });
 

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -79,21 +79,32 @@ describe('coreOnlyPidNamespaceDegrade gate (credential-safety)', () => {
     }
   });
 
-  // codex review concern #2 (P1): a SINGLE --unshare-pid probe treats ANY
-  // bwrap failure as "safe to drop --unshare-pid" — codex reproduced degrade:true
-  // with a fake bwrap that always exits 1. The DUAL probe only degrades when the
-  // signature is exactly "pid-ns is the problem": full (--unshare-pid) fails AND
-  // weak (no --unshare-pid) succeeds. Everything else is fail-closed.
-  describe('pidNsDualProbeCanUnshare (dual full/weak probe, fail-closed)', () => {
-    it('full succeeds → CAN unshare-pid (no degrade), regardless of weak', () => {
-      expect(pidNsDualProbeCanUnshare({ ranOk: true }, { ranOk: true })).toBe(true);
-      expect(pidNsDualProbeCanUnshare({ ranOk: true }, { ranOk: false })).toBe(true);
+  // codex review concern #2 (P1): a naive probe treats ANY bwrap failure as
+  // "safe to drop --unshare-pid". Three-state classification (success /
+  // clean-nonzero / inconclusive) is load-bearing — a timeout/spawn-error must
+  // NOT be lumped with a clean nonzero exit. Degrade ONLY on the exact nested
+  // signature: full=clean-nonzero (bwrap definitively rejected the pid-ns run)
+  // AND weak=success (accepted it without pid-ns). Everything else fail-closed.
+  describe('pidNsDualProbeCanUnshare (three-state, fail-closed)', () => {
+    it('full success → CAN unshare-pid (no degrade), regardless of weak', () => {
+      expect(pidNsDualProbeCanUnshare('success', 'success')).toBe(true);
+      expect(pidNsDualProbeCanUnshare('success', 'clean-nonzero')).toBe(true);
+      expect(pidNsDualProbeCanUnshare('success', 'inconclusive')).toBe(true);
     });
-    it('full FAILS but weak SUCCEEDS → nested-sandbox signature → CANNOT unshare-pid (the ONLY degrade case)', () => {
-      expect(pidNsDualProbeCanUnshare({ ranOk: false }, { ranOk: true })).toBe(false);
+    it('full clean-nonzero + weak success → nested signature → CANNOT unshare-pid (the ONLY degrade case)', () => {
+      expect(pidNsDualProbeCanUnshare('clean-nonzero', 'success')).toBe(false);
     });
-    it('BOTH fail (e.g. fake bwrap always exits 1 — codex repro) → bwrap broken, NOT a pid-ns issue → CAN unshare-pid (fail-closed, no degrade)', () => {
-      expect(pidNsDualProbeCanUnshare({ ranOk: false }, { ranOk: false })).toBe(true);
+    it('BOTH clean-nonzero (fake bwrap always exits 1 — codex repro) → bwrap broken, NOT pid-ns → CAN unshare-pid (fail-closed)', () => {
+      expect(pidNsDualProbeCanUnshare('clean-nonzero', 'clean-nonzero')).toBe(true);
+    });
+    it('full INCONCLUSIVE (timeout / spawn-error / signal) + weak success → NOT evidence of pid-ns restriction → CAN unshare-pid (the timeout case codex flagged)', () => {
+      expect(pidNsDualProbeCanUnshare('inconclusive', 'success')).toBe(true);
+      expect(pidNsDualProbeCanUnshare('inconclusive', 'clean-nonzero')).toBe(true);
+      expect(pidNsDualProbeCanUnshare('inconclusive', 'inconclusive')).toBe(true);
+    });
+    it('full clean-nonzero + weak NOT clean-success (nonzero/inconclusive) → do NOT degrade', () => {
+      expect(pidNsDualProbeCanUnshare('clean-nonzero', 'clean-nonzero')).toBe(true);
+      expect(pidNsDualProbeCanUnshare('clean-nonzero', 'inconclusive')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
core-only（apiOnly）form C——在 sandbox 内实时看 codex 跑屏——的 daemon 侧两块，合入 master。依赖 #668（已合 master）。两块都随 v3.9.0-canary.13 灰度发布、经 **riff 0.139 真机 E2E 验证全绿零回归**。

## 改了什么 + 为什么

### 1. form C 可视 web 终端（2 个 commit 的第一个）
webTerminal=ON 时 riff launcher 设 `BOTMUX_CORE_CLI=codex`（可视 TUI，非 codex-app 的 app-server），需要把只读终端 URL 交到 riff 手里。两处：
- **index-core-only.ts 冻结 `WEB_EXTERNAL_HOST=127.0.0.1`**：现状 buildTerminalUrl 的 host 走 `getWebExternalHost()`→`getLocalIp()`（LAN IP），而 core-only 的 proxy 只 bind 127.0.0.1 → sandbox 内 VNC 浏览器打这个 URL 连不上。冻结广告 host 与 bind 一致（与既有「冻结 worker HTTP bind host」互补）。
- **trigger-result 附 `readOnlyUrl`+`viewToken`**：`GET /api/sessions/:id/trigger-result` 在有 live worker 终端时（`ds.workerPort && ds.workerViewToken` 门控）带上只读终端 URL。riff runner 本就轮询 trigger-result，turn 一 running 就能拿到 URL 透前端——这才是「实时看屏」。加在 IPC handler 层（`buildAsyncTriggerLookupResponse`），纯 `resolveAsyncTriggerState` 保持无 daemon 依赖；`buildTerminalUrl` 内联 `?viewToken=`，写 token 不下发。

### 2. 嵌套 sandbox pid-ns 降级（第二个 commit）
riff 嵌套 AIO sandbox **不允许在新 PID namespace 里挂 procfs**（`bwrap: Can't mount proc on /newroot/proc: Operation not permitted`）→ fs-policy 沙盒（apiOnly 强制 readIsolation）用的 `--unshare-pid` + fresh `--proc` 失败 → plain codex 崩 4 次。
- `compileToBwrap` 新增 `skipPidNamespace`：为 true 时**只去掉 `--unshare-pid`**，保留 fresh `--proc /proc`（无新 pid-ns 也能挂）+ `--unshare-user` + ipc/uts/cgroup + **全部 FS deny mask 不变**。
- 双门控 `coreOnlyPidNamespaceDegrade()` = `BOTMUX_CORE_ONLY==='1' && !bwrapCanUnsharePid()`（启动一次性探针）。

**安全推理（关键）**：credential 密封分两层——on-disk（FS mask，与 pid-ns 无关）+ env-borne（**兄弟** transport bot 的 worker env 带明文 `LARK_APP_SECRET`，靠 `--unshare-pid`+fresh proc 挡 `/proc/<兄弟pid>/environ`）。故**不能全 fleet 去 --unshare-pid**。但 core-only 只合成**唯一一个** apiOnly bot、其 worker secret 本就空 → 无兄弟凭证可读 → 仅此降级安全。正常/混合 fleet 因 `BOTMUX_CORE_ONLY` 短路**永不降级、永不跑探针**。

## 影响面
- 全部 core-only-gated。正常 fleet：trigger-result 形状不变（readOnlyUrl/viewToken 仅在有 live worker 终端时附加、可选字段老 consumer 忽略）；`WEB_EXTERNAL_HOST` 冻结仅 `BOTMUX_CORE_ONLY` 入口生效；pid-ns 降级双门控短路。
- `serve --api-only` flag 天然满足 gate（cli.ts 显式塞 `BOTMUX_CORE_ONLY=1`、workerForkEnv 不删它 → worker 继承；已用 `/proc/<pid>/environ` 实测 core-only worker present=1、生产 fleet worker present=0）。

## 测试验证
- `pnpm build` 绿（基于最新 master cherry-pick，auto-merge 无冲突）。
- dashboard-ipc(105) + async-trigger-state + api-only-wiring + fs-policy(68) + sandbox 共 **258 单测全绿**，含新增：trigger-result 有/无 worker 终端两态、skipPidNamespace 只删 --unshare-pid 保留 proc+mask、gate 无 BOTMUX_CORE_ONLY 恒 false。
- **riff 0.139 真机 E2E（canary.13）全绿零回归**：serve --api-only→gate 命中→探针降级→plain codex TUI 起（canary.12 的 `Can't mount proc` 消失）→trigger-result completed→readOnlyUrl `http://127.0.0.1:8800/s/<sid>?viewToken=` 带 token 200/去 token 403、VNC 可开。本地也真跑 bwrap 证明降级 argv exit0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)