### PR TITLE
fix(sandbox): 沙盒 bot 的任何 botmux 子命令都因 bots.json 不可读而死（#668 回归）

### DIFF
--- a/src/adapters/cli/read-isolation.ts
+++ b/src/adapters/cli/read-isolation.ts
@@ -20,6 +20,7 @@
  * plaintext). See the design doc for the two-layer rationale.
  */
 
+import { statSync } from 'node:fs';
 import {
   DEVICE_AUTHORITY_DIRECTORY,
   DEVICE_CREDENTIAL_FILE,
@@ -379,23 +380,29 @@ function dedupe(xs: string[]): string[] {
 
 /**
  * True when this process is a CLI the worker spawned for a bot under READ
- * ISOLATION (the sandbox). The worker injects BOTH of these and writes that
- * bot's own credential to `<BOT_HOME>/send-cred.json` — see
- * {@link sendCredFilePath}.
+ * ISOLATION (the sandbox), where `~/.botmux/bots.json` is denied ON PURPOSE (it
+ * holds every sibling bot's app secret).
  *
- * Why this predicate exists: inside the sandbox `~/.botmux/bots.json` is denied
- * ON PURPOSE (it holds every sibling bot's secret). Seatbelt allows the METADATA
- * read but denies the CONTENT read, so `existsSync()` says yes and the following
- * `readFileSync()` fails with EPERM/EACCES. Callers must be able to tell that
- * EXPECTED state apart from a genuine unreadable-config fault: under isolation
- * the correct answer is "disk has nothing for you, use send-cred.json"; outside
- * it, an unreadable bots.json must stay fatal (degrading there would silently
- * boot a zero-bot process — no bot answers and nothing says why).
+ * The signal is the EXISTENCE of this bot's own `<BOT_HOME>/send-cred.json`.
+ * The worker writes that file host-side and ONLY for a sandboxed session
+ * (`if (sandboxRequested && SESSION_DATA_DIR)`), so its presence is decided by
+ * the host, not by the sandboxed process's environment.
  *
- * Deliberately requires BOTH markers: a half-configured environment is not
- * isolation, and treating it as such would widen the swallow to cases the
- * sandbox never produces.
+ * ⚠️ Do NOT weaken this back to an env-only check. `BOTMUX_LARK_APP_ID` and
+ * `SESSION_DATA_DIR` are injected into EVERY worker-spawned CLI (worker.ts
+ * `childEnv.BOTMUX_LARK_APP_ID = cfg.larkAppId`, ungated), sandboxed or not — an
+ * env-only predicate matches ordinary bots too and would silently downgrade a
+ * genuine "bots.json is unreadable" fault into "there are no bots" on a normal
+ * host. (Caught in review, 2026-08-03.) The env vars stay in the check only to
+ * locate the file.
  */
 export function underReadIsolation(): boolean {
-  return !!process.env.SESSION_DATA_DIR && !!process.env.BOTMUX_LARK_APP_ID;
+  const sessionDataDir = process.env.SESSION_DATA_DIR;
+  const appId = process.env.BOTMUX_LARK_APP_ID;
+  if (!sessionDataDir || !appId) return false;
+  try {
+    return statSync(sendCredFilePath(sessionDataDir, appId)).isFile();
+  } catch {
+    return false; // absent or unreadable → not a sandboxed session we can vouch for
+  }
 }

--- a/src/adapters/cli/read-isolation.ts
+++ b/src/adapters/cli/read-isolation.ts
@@ -306,7 +306,18 @@ export function buildSeatbeltProfile(
 
 // A marker records which confinement capabilities are attached to the live
 // process. Credential-only panes must cold-spawn when a full sandbox is enabled.
-export const ISOLATION_PANE_MARKER_VERSION = 7;
+//
+// BUMP THIS whenever the START-TIME contract of an isolated CLI changes in a way
+// a still-running process cannot satisfy — a warm reattach preserves the live
+// process untouched, so anything the reattach path relies on but the old process
+// lacks makes reattach unsafe.
+//   · 7 → 8 (2026-08-03): isolated CLIs now MUST carry the host-injected
+//     BOTMUX_READ_ISOLATION / BOTMUX_API_ONLY env (bots.json EPERM fix). Panes
+//     spawned by v3.8.0 have a v7 marker but a process with NEITHER key, so
+//     `botmux` inside them still dies on the denied bots.json read. Reattaching
+//     them would leave the regression unfixed after a plain `daemon:restart`;
+//     the bump forces a cold respawn that injects the markers.
+export const ISOLATION_PANE_MARKER_VERSION = 8;
 
 export type IsolationCapability = 'credential' | 'read' | 'write';
 

--- a/src/adapters/cli/read-isolation.ts
+++ b/src/adapters/cli/read-isolation.ts
@@ -376,3 +376,26 @@ export function isolatedPaneReattachSafe(
 function dedupe(xs: string[]): string[] {
   return Array.from(new Set(xs));
 }
+
+/**
+ * True when this process is a CLI the worker spawned for a bot under READ
+ * ISOLATION (the sandbox). The worker injects BOTH of these and writes that
+ * bot's own credential to `<BOT_HOME>/send-cred.json` — see
+ * {@link sendCredFilePath}.
+ *
+ * Why this predicate exists: inside the sandbox `~/.botmux/bots.json` is denied
+ * ON PURPOSE (it holds every sibling bot's secret). Seatbelt allows the METADATA
+ * read but denies the CONTENT read, so `existsSync()` says yes and the following
+ * `readFileSync()` fails with EPERM/EACCES. Callers must be able to tell that
+ * EXPECTED state apart from a genuine unreadable-config fault: under isolation
+ * the correct answer is "disk has nothing for you, use send-cred.json"; outside
+ * it, an unreadable bots.json must stay fatal (degrading there would silently
+ * boot a zero-bot process — no bot answers and nothing says why).
+ *
+ * Deliberately requires BOTH markers: a half-configured environment is not
+ * isolation, and treating it as such would widen the swallow to cases the
+ * sandbox never produces.
+ */
+export function underReadIsolation(): boolean {
+  return !!process.env.SESSION_DATA_DIR && !!process.env.BOTMUX_LARK_APP_ID;
+}

--- a/src/adapters/cli/read-isolation.ts
+++ b/src/adapters/cli/read-isolation.ts
@@ -20,7 +20,6 @@
  * plaintext). See the design doc for the two-layer rationale.
  */
 
-import { statSync } from 'node:fs';
 import {
   DEVICE_AUTHORITY_DIRECTORY,
   DEVICE_CREDENTIAL_FILE,
@@ -381,28 +380,27 @@ function dedupe(xs: string[]): string[] {
 /**
  * True when this process is a CLI the worker spawned for a bot under READ
  * ISOLATION (the sandbox), where `~/.botmux/bots.json` is denied ON PURPOSE (it
- * holds every sibling bot's app secret).
+ * holds every sibling bot's app secret). Callers use it to tell that EXPECTED
+ * denial apart from a genuine unreadable-config fault.
  *
- * The signal is the EXISTENCE of this bot's own `<BOT_HOME>/send-cred.json`.
- * The worker writes that file host-side and ONLY for a sandboxed session
- * (`if (sandboxRequested && SESSION_DATA_DIR)`), so its presence is decided by
- * the host, not by the sandboxed process's environment.
+ * The signal is `BOTMUX_READ_ISOLATION`, which the worker sets (and otherwise
+ * explicitly DELETES) on the child env, gated on `sandboxRequested`. It has to
+ * come from the host; two CLI-side guesses were tried and are both wrong:
  *
- * ⚠️ Do NOT weaken this back to an env-only check. `BOTMUX_LARK_APP_ID` and
- * `SESSION_DATA_DIR` are injected into EVERY worker-spawned CLI (worker.ts
- * `childEnv.BOTMUX_LARK_APP_ID = cfg.larkAppId`, ungated), sandboxed or not — an
- * env-only predicate matches ordinary bots too and would silently downgrade a
- * genuine "bots.json is unreadable" fault into "there are no bots" on a normal
- * host. (Caught in review, 2026-08-03.) The env vars stay in the check only to
- * locate the file.
+ *   · `SESSION_DATA_DIR` + `BOTMUX_LARK_APP_ID` — injected for EVERY
+ *     worker-spawned CLI, sandboxed or not. Matches ordinary bots, so a real
+ *     "bots.json is unreadable" fault would be silently downgraded to "there are
+ *     no bots" on a normal host.
+ *   · existence of `<BOT_HOME>/send-cred.json` — wrong in BOTH directions: a
+ *     no-transport (apiOnly) bot has its own copy denied by fs-policy
+ *     (`push([`${ctx.botHome}/send-cred.json`], 'deny', 'mandatory')` in the
+ *     `!larkTransport` branch), so a genuinely sandboxed bot reads as
+ *     not-isolated; and the file is never cleaned up, so flipping a bot from
+ *     `sandbox: true` back to `false` leaves a stale one behind that makes an
+ *     ordinary CLI look isolated.
+ *
+ * (Both caught in review, 2026-08-03. Do not "simplify" this back to either.)
  */
 export function underReadIsolation(): boolean {
-  const sessionDataDir = process.env.SESSION_DATA_DIR;
-  const appId = process.env.BOTMUX_LARK_APP_ID;
-  if (!sessionDataDir || !appId) return false;
-  try {
-    return statSync(sendCredFilePath(sessionDataDir, appId)).isFile();
-  } catch {
-    return false; // absent or unreadable → not a sandboxed session we can vouch for
-  }
+  return process.env.BOTMUX_READ_ISOLATION === '1';
 }

--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -2,6 +2,7 @@ import * as Lark from '@larksuiteoapi/node-sdk';
 import { readFileSync, existsSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { homedir } from 'node:os';
+import { underReadIsolation } from './adapters/cli/read-isolation.js';
 import type { BackendType } from './adapters/backend/types.js';
 import type { RiffBackendConfig } from './adapters/backend/riff-backend.js';
 import type { CliId } from './adapters/cli/types.js';
@@ -2163,7 +2164,27 @@ export function isManagedActivationStartingAtIndex(
 }
 
 function parseBotConfigFile(filePath: string): BotConfig[] {
-  const raw = readFileSync(filePath, 'utf-8');
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, 'utf-8');
+  } catch (err: any) {
+    // A sandboxed CLI is denied bots.json ON PURPOSE (it holds every sibling's
+    // secret). Seatbelt allows the METADATA read but denies the CONTENT read, so
+    // resolveBotConfigPath()'s existsSync() passes and we land here with
+    // EPERM/EACCES — the "no config file" branch that would have degraded
+    // gracefully is never reached. Callers then die with a raw
+    // `EPERM … open '~/.botmux/bots.json'`, which is why EVERY botmux subcommand
+    // (not just send) breaks inside the sandbox.
+    //
+    // Under isolation the bot's identity comes from registerSelfFromCredFile()
+    // instead, so "disk gave us nothing" is the correct, complete answer here.
+    //
+    // Outside isolation an unreadable bots.json is a REAL fault and must still
+    // throw: swallowing it would silently boot a zero-bot process (no bots
+    // respond, no error anywhere) — strictly worse than crashing loudly.
+    if ((err?.code === 'EPERM' || err?.code === 'EACCES') && underReadIsolation()) return [];
+    throw err;
+  }
   try {
     return parseBotConfigsFromText(raw);
   } catch (err: any) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@
  */
 import { execSync, execFileSync, spawnSync, spawn } from 'node:child_process';
 import { existsSync, mkdirSync, copyFileSync, readFileSync, writeFileSync, renameSync, readdirSync, readlinkSync, appendFileSync, statSync, unlinkSync, rmSync, realpathSync } from 'node:fs';
-import { underReadIsolation } from './adapters/cli/read-isolation.js';
+import { underReadIsolation, sendCredFilePath } from './adapters/cli/read-isolation.js';
 import { atomicWriteFileSync } from './utils/atomic-write.js';
 import { join, dirname, basename, resolve } from 'node:path';
 import { homedir } from 'node:os';
@@ -6544,6 +6544,24 @@ async function relaySend(
  *  with a clear message. Reads bots.json best-effort; an apiOnly bot runs
  *  non-isolated (no Feishu secret to protect), so bots.json is readable here. */
 function currentBotIsApiOnly(larkAppId: string): boolean {
+  // Under read isolation bots.json is denied ON PURPOSE, so loadBotsJson() below
+  // can only ever answer "no bots at all". Letting that stand would silently turn
+  // this check into a no-op for EVERY sandboxed bot — including the apiOnly ones
+  // it exists to catch — and managedOriginHasNoTransport() (which advertises
+  // itself as tamper-resistant) delegates its verdict here.
+  //
+  // The worker already hands this bot its OWN config through the designed private
+  // channel: <BOT_HOME>/send-cred.json, written host-side, carrying apiOnly. Take
+  // the verdict from there instead of degrading it away. Only valid for our own
+  // appId — a sandboxed bot cannot see (and must not answer for) its siblings.
+  // Absent key = not apiOnly: JSON.stringify drops `apiOnly: undefined`, which is
+  // exactly what the worker writes for a normal transport-enabled bot.
+  if (underReadIsolation() && process.env.BOTMUX_LARK_APP_ID === larkAppId) {
+    try {
+      const credPath = sendCredFilePath(process.env.SESSION_DATA_DIR as string, larkAppId);
+      return JSON.parse(readFileSync(credPath, 'utf-8'))?.apiOnly === true;
+    } catch { /* no/unreadable cred file → fall through to the bots.json view */ }
+  }
   try {
     return loadBotsJson().some((b: any) => b?.larkAppId === larkAppId && b?.apiOnly === true);
   } catch {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6545,6 +6545,11 @@ function currentBotIsApiOnly(larkAppId: string): boolean {
     // apiOnly (JSON.stringify drops `apiOnly: undefined`, which is exactly what
     // the worker writes for a normal transport-enabled bot).
     if (process.env.BOTMUX_LARK_APP_ID !== larkAppId) return false; // can't see siblings
+    // Host-owned verdict first: a no-transport bot's own send-cred.json is denied
+    // by fs-policy (`!larkTransport` branch denies <BOT_HOME>/send-cred.json), so
+    // for exactly the bots this gate exists to catch the file read below cannot
+    // succeed. The worker therefore also states it in the env.
+    if (process.env.BOTMUX_API_ONLY === '1') return true;
     try {
       const credPath = sendCredFilePath(process.env.SESSION_DATA_DIR as string, larkAppId);
       return JSON.parse(readFileSync(credPath, 'utf-8'))?.apiOnly === true;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -364,35 +364,16 @@ function pm2Capture(args: string[], home: string = PM2_HOME, timeoutMs = 10_000)
 }
 
 function loadBotsJson(): any[] {
+  // NOTE: this stays FATAL on a read error, deliberately. Several callers treat
+  // an empty list as "nothing references this" and go on to delete things
+  // (plugin dematerialize / uninstall dependency check) — degrading the read to
+  // [] would turn a denied read into silent destructive action. Anything that
+  // must survive an unreadable bots.json has to opt out explicitly, the way
+  // allBotAppIds() and currentBotIsApiOnly() do.
   if (existsSync(BOTS_JSON_FILE)) {
-    let raw: string;
     try {
-      raw = readFileSync(BOTS_JSON_FILE, 'utf-8');
+      return parseBotConfigsJson(readFileSync(BOTS_JSON_FILE, 'utf-8'), BOTS_JSON_FILE);
     } catch (err: any) {
-      // Separate "cannot READ it" from "read it, it's malformed" — they need
-      // opposite handling and conflating them is what broke every sandboxed bot.
-      //
-      // A sandboxed CLI is denied bots.json on purpose (sibling secrets). Seatbelt
-      // permits the metadata read, so existsSync() above passes and we land here
-      // with EPERM/EACCES. Under isolation that is the DESIGNED state: identity
-      // comes from <BOT_HOME>/send-cred.json via registerSelfFromCredFile(), so
-      // "no bots from disk" is the correct and complete answer.
-      //
-      // NOTE for future edits: exiting here is NOT catchable by callers.
-      // currentBotIsApiOnly() wraps this call in try/catch and documents itself as
-      // "never throws" — literally true and completely useless, because
-      // process.exit() is not an exception. This ran on the ROOT dispatch gate
-      // (managedOriginHasNoTransport), so it killed EVERY botmux subcommand inside
-      // the sandbox, not just send. Introduced by #668, found 2026-08-03.
-      if ((err?.code === 'EPERM' || err?.code === 'EACCES') && underReadIsolation()) return [];
-      // Outside isolation an unreadable bots.json is a real fault: stay fatal.
-      console.error(`❌ ${err?.message ?? String(err)}`);
-      process.exit(1);
-    }
-    try {
-      return parseBotConfigsJson(raw, BOTS_JSON_FILE);
-    } catch (err: any) {
-      // Malformed content is always fatal, isolation or not.
       console.error(`❌ ${err?.message ?? String(err)}`);
       process.exit(1);
     }
@@ -6556,11 +6537,24 @@ function currentBotIsApiOnly(larkAppId: string): boolean {
   // appId — a sandboxed bot cannot see (and must not answer for) its siblings.
   // Absent key = not apiOnly: JSON.stringify drops `apiOnly: undefined`, which is
   // exactly what the worker writes for a normal transport-enabled bot.
-  if (underReadIsolation() && process.env.BOTMUX_LARK_APP_ID === larkAppId) {
+  if (underReadIsolation()) {
+    // bots.json is denied in here and loadBotsJson() is FATAL on that — never
+    // reach it from the root dispatch gate. This bot's own apiOnly comes from the
+    // designed private channel instead: <BOT_HOME>/send-cred.json, written
+    // host-side by the worker, carrying apiOnly (worker.ts). Absent key = not
+    // apiOnly (JSON.stringify drops `apiOnly: undefined`, which is exactly what
+    // the worker writes for a normal transport-enabled bot).
+    if (process.env.BOTMUX_LARK_APP_ID !== larkAppId) return false; // can't see siblings
     try {
       const credPath = sendCredFilePath(process.env.SESSION_DATA_DIR as string, larkAppId);
       return JSON.parse(readFileSync(credPath, 'utf-8'))?.apiOnly === true;
-    } catch { /* no/unreadable cred file → fall through to the bots.json view */ }
+    } catch {
+      // No readable cred file: we cannot tell. Say "not apiOnly" rather than
+      // crash — the transport boundary still fail-closes downstream
+      // (getBotClient throws for apiOnly, and an apiOnly bot has no secret to
+      // talk to Feishu with in the first place).
+      return false;
+    }
   }
   try {
     return loadBotsJson().some((b: any) => b?.larkAppId === larkAppId && b?.apiOnly === true);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@
  */
 import { execSync, execFileSync, spawnSync, spawn } from 'node:child_process';
 import { existsSync, mkdirSync, copyFileSync, readFileSync, writeFileSync, renameSync, readdirSync, readlinkSync, appendFileSync, statSync, unlinkSync, rmSync, realpathSync } from 'node:fs';
+import { underReadIsolation } from './adapters/cli/read-isolation.js';
 import { atomicWriteFileSync } from './utils/atomic-write.js';
 import { join, dirname, basename, resolve } from 'node:path';
 import { homedir } from 'node:os';
@@ -364,9 +365,34 @@ function pm2Capture(args: string[], home: string = PM2_HOME, timeoutMs = 10_000)
 
 function loadBotsJson(): any[] {
   if (existsSync(BOTS_JSON_FILE)) {
+    let raw: string;
     try {
-      return parseBotConfigsJson(readFileSync(BOTS_JSON_FILE, 'utf-8'), BOTS_JSON_FILE);
+      raw = readFileSync(BOTS_JSON_FILE, 'utf-8');
     } catch (err: any) {
+      // Separate "cannot READ it" from "read it, it's malformed" — they need
+      // opposite handling and conflating them is what broke every sandboxed bot.
+      //
+      // A sandboxed CLI is denied bots.json on purpose (sibling secrets). Seatbelt
+      // permits the metadata read, so existsSync() above passes and we land here
+      // with EPERM/EACCES. Under isolation that is the DESIGNED state: identity
+      // comes from <BOT_HOME>/send-cred.json via registerSelfFromCredFile(), so
+      // "no bots from disk" is the correct and complete answer.
+      //
+      // NOTE for future edits: exiting here is NOT catchable by callers.
+      // currentBotIsApiOnly() wraps this call in try/catch and documents itself as
+      // "never throws" — literally true and completely useless, because
+      // process.exit() is not an exception. This ran on the ROOT dispatch gate
+      // (managedOriginHasNoTransport), so it killed EVERY botmux subcommand inside
+      // the sandbox, not just send. Introduced by #668, found 2026-08-03.
+      if ((err?.code === 'EPERM' || err?.code === 'EACCES') && underReadIsolation()) return [];
+      // Outside isolation an unreadable bots.json is a real fault: stay fatal.
+      console.error(`❌ ${err?.message ?? String(err)}`);
+      process.exit(1);
+    }
+    try {
+      return parseBotConfigsJson(raw, BOTS_JSON_FILE);
+    } catch (err: any) {
+      // Malformed content is always fatal, isolation or not.
       console.error(`❌ ${err?.message ?? String(err)}`);
       process.exit(1);
     }

--- a/src/utils/child-env.ts
+++ b/src/utils/child-env.ts
@@ -175,6 +175,15 @@ export const BOTMUX_INJECTED_ENV_KEYS = [
   // Resolved display footer for sandboxed `botmux send`; avoids reading the
   // credential-bearing bots.json from inside the child.
   'BOTMUX_BRAND_LABEL',
+  // Read-isolation marker + host-owned apiOnly verdict. Both are decided by the
+  // worker (gated on sandboxRequested / cfg.apiOnly) and MUST reach the child:
+  // inside the sandbox bots.json is denied, so the CLI has no other way to tell
+  // "denied because I'm sandboxed (expected)" from "unreadable (real fault)", nor
+  // to know its own apiOnly (a no-transport bot's send-cred.json is denied too).
+  // Being on this list also means tmuxEnv()/scrubTmuxServerGlobalEnv() strip them
+  // when unset — so a stale value cannot leak into a NON-sandboxed pane.
+  'BOTMUX_READ_ISOLATION',
+  'BOTMUX_API_ONLY',
   // Per-bot display preference for Context / Token usage
   // ('streaming' | 'footer' | 'off'). Injected explicitly so sandboxed offline
   // fallback cannot drift to the default when bots.json is unreadable.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8498,6 +8498,28 @@ async function spawnCli(
   if (cfg.chatType) childEnv.BOTMUX_CHAT_TYPE = cfg.chatType;
   else delete childEnv.BOTMUX_CHAT_TYPE;
   childEnv.BOTMUX_LARK_APP_ID = cfg.larkAppId;
+  // Explicit, HOST-DECIDED read-isolation marker. The CLI needs to tell
+  // "bots.json is denied because I'm sandboxed (expected)" from "bots.json is
+  // unreadable (real fault)" — see underReadIsolation() in read-isolation.ts.
+  // It cannot be inferred CLI-side:
+  //   · env like BOTMUX_LARK_APP_ID / SESSION_DATA_DIR is injected for EVERY bot,
+  //     sandboxed or not;
+  //   · the presence of <BOT_HOME>/send-cred.json does not work either — a
+  //     no-transport (apiOnly) bot has its OWN copy denied by fs-policy
+  //     (`push([`${ctx.botHome}/send-cred.json`], 'deny', 'mandatory')`), and a
+  //     stale file survives flipping a bot from sandbox:true back to false.
+  // Always assign or DELETE, never leave it to chance: a stale value inherited
+  // from an rcfile / tmux environment must not make an unsandboxed CLI believe
+  // it is isolated (same reasoning as chatBotDiscovery below).
+  if (sandboxRequested) childEnv.BOTMUX_READ_ISOLATION = '1';
+  else delete childEnv.BOTMUX_READ_ISOLATION;
+  // Host-owned apiOnly verdict. Needed because a no-transport bot's OWN
+  // send-cred.json is denied by fs-policy (the `!larkTransport` branch), so the
+  // sandboxed CLI cannot read its apiOnly flag from disk and would otherwise have
+  // to assume "not apiOnly". Forging this can only make a turn MORE restricted,
+  // never less. Mirrors what the riff path already does via mergedEnv.
+  if (cfg.apiOnly) childEnv.BOTMUX_API_ONLY = '1';
+  else delete childEnv.BOTMUX_API_ONLY;
   childEnv.BOTMUX_ROOT_MESSAGE_ID = cfg.rootMessageId;
   // This bot's resolved brandLabel template, injected so a SANDBOXED `botmux
   // send` renders the role-name footer without reading bots.json (deny-by-

--- a/test/bot-registry.test.ts
+++ b/test/bot-registry.test.ts
@@ -1646,7 +1646,23 @@ describe('loadBotConfigs when bots.json exists but is unreadable', () => {
   it('degrades to an empty list under read isolation (identity comes from send-cred.json)', () => {
     process.env.SESSION_DATA_DIR = '/h/.botmux/data';
     process.env.BOTMUX_LARK_APP_ID = 'cli_sandboxed';
+    // Isolation is proven by the HOST-written send-cred.json, not by env alone —
+    // the worker injects those two vars for ordinary bots too.
+    vi.mocked(fs.statSync).mockImplementation(((p: any) =>
+      String(p).endsWith('/bots/cli_sandboxed/send-cred.json')
+        ? ({ isFile: () => true } as any)
+        : ({ mtimeMs: 0, isFile: () => false } as any)) as never);
     expect(mod.loadBotConfigs()).toEqual([]);
+  });
+
+  it('does NOT degrade for an ordinary worker CLI (same env vars, no cred file)', () => {
+    // The regression this guards: an env-only isolation check matches every
+    // worker-spawned CLI, so a genuinely unreadable bots.json on a normal host
+    // would silently become "there are no bots".
+    process.env.SESSION_DATA_DIR = '/h/.botmux/data';
+    process.env.BOTMUX_LARK_APP_ID = 'cli_plain';
+    vi.mocked(fs.statSync).mockImplementation((() => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); }) as never);
+    expect(() => mod.loadBotConfigs()).toThrow(/EPERM/);
   });
 
   it('still throws OUTSIDE read isolation — an unreadable bots.json is a real fault there', () => {

--- a/test/bot-registry.test.ts
+++ b/test/bot-registry.test.ts
@@ -1644,14 +1644,7 @@ describe('loadBotConfigs when bots.json exists but is unreadable', () => {
   });
 
   it('degrades to an empty list under read isolation (identity comes from send-cred.json)', () => {
-    process.env.SESSION_DATA_DIR = '/h/.botmux/data';
-    process.env.BOTMUX_LARK_APP_ID = 'cli_sandboxed';
-    // Isolation is proven by the HOST-written send-cred.json, not by env alone —
-    // the worker injects those two vars for ordinary bots too.
-    vi.mocked(fs.statSync).mockImplementation(((p: any) =>
-      String(p).endsWith('/bots/cli_sandboxed/send-cred.json')
-        ? ({ isFile: () => true } as any)
-        : ({ mtimeMs: 0, isFile: () => false } as any)) as never);
+    process.env.BOTMUX_READ_ISOLATION = '1';
     expect(mod.loadBotConfigs()).toEqual([]);
   });
 
@@ -1659,9 +1652,9 @@ describe('loadBotConfigs when bots.json exists but is unreadable', () => {
     // The regression this guards: an env-only isolation check matches every
     // worker-spawned CLI, so a genuinely unreadable bots.json on a normal host
     // would silently become "there are no bots".
+    delete process.env.BOTMUX_READ_ISOLATION;
     process.env.SESSION_DATA_DIR = '/h/.botmux/data';
     process.env.BOTMUX_LARK_APP_ID = 'cli_plain';
-    vi.mocked(fs.statSync).mockImplementation((() => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); }) as never);
     expect(() => mod.loadBotConfigs()).toThrow(/EPERM/);
   });
 
@@ -1674,14 +1667,14 @@ describe('loadBotConfigs when bots.json exists but is unreadable', () => {
   });
 
   it('still throws when only ONE isolation marker is present (half-configured is not isolation)', () => {
+    delete process.env.BOTMUX_READ_ISOLATION;
     process.env.SESSION_DATA_DIR = '/h/.botmux/data';
     delete process.env.BOTMUX_LARK_APP_ID;
     expect(() => mod.loadBotConfigs()).toThrow(/EPERM/);
   });
 
   it('still throws for a NON-permission read error even under isolation (only EPERM/EACCES are expected)', () => {
-    process.env.SESSION_DATA_DIR = '/h/.botmux/data';
-    process.env.BOTMUX_LARK_APP_ID = 'cli_sandboxed';
+    process.env.BOTMUX_READ_ISOLATION = '1';
     vi.mocked(fs.readFileSync).mockImplementation(() => {
       throw Object.assign(new Error('EIO: i/o error'), { code: 'EIO' });
     });

--- a/test/bot-registry.test.ts
+++ b/test/bot-registry.test.ts
@@ -1608,3 +1608,67 @@ describe('vcMeetingAgentConfigActive — apiOnly bots never attend VC meetings',
       .toBeUndefined();
   });
 });
+
+// ─── bots.json unreadable (sandbox read isolation) ────────────────────────
+
+/**
+ * Regression (2026-08-03, fleet P0): every botmux subcommand died inside a
+ * sandboxed bot with `EPERM: operation not permitted, open '~/.botmux/bots.json'`.
+ *
+ * Shape of the bug: Seatbelt allows the METADATA read but denies the CONTENT
+ * read, so resolveBotConfigPath()'s existsSync() passes (the graceful "no config
+ * file" branch is never taken) and parseBotConfigFile()'s readFileSync throws.
+ * The isolated bot's own identity comes from send-cred.json, so disk returning
+ * nothing is the correct answer there — but ONLY there.
+ */
+describe('loadBotConfigs when bots.json exists but is unreadable', () => {
+  let mod: Awaited<ReturnType<typeof freshImport>>;
+  let fs: typeof import('node:fs');
+  const savedEnv = { ...process.env };
+
+  const eperm = () => Object.assign(new Error("EPERM: operation not permitted, open '/h/.botmux/bots.json'"), { code: 'EPERM' });
+
+  beforeEach(async () => {
+    delete process.env.BOTS_CONFIG;      // force the ~/.botmux/bots.json branch
+    delete process.env.BOTMUX_CORE_ONLY; // not the synthesized core-only path
+    mod = await freshImport();
+    fs = await import('node:fs');
+    vi.mocked(fs.existsSync).mockReturnValue(true);       // metadata read allowed
+    vi.mocked(fs.readFileSync).mockImplementation(() => { throw eperm(); }); // content denied
+  });
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.readFileSync).mockReturnValue('' as never);
+  });
+
+  it('degrades to an empty list under read isolation (identity comes from send-cred.json)', () => {
+    process.env.SESSION_DATA_DIR = '/h/.botmux/data';
+    process.env.BOTMUX_LARK_APP_ID = 'cli_sandboxed';
+    expect(mod.loadBotConfigs()).toEqual([]);
+  });
+
+  it('still throws OUTSIDE read isolation — an unreadable bots.json is a real fault there', () => {
+    delete process.env.SESSION_DATA_DIR;
+    delete process.env.BOTMUX_LARK_APP_ID;
+    // Swallowing here would silently boot a zero-bot process: no bot answers and
+    // nothing anywhere says why. Crashing loudly is the correct behaviour.
+    expect(() => mod.loadBotConfigs()).toThrow(/EPERM/);
+  });
+
+  it('still throws when only ONE isolation marker is present (half-configured is not isolation)', () => {
+    process.env.SESSION_DATA_DIR = '/h/.botmux/data';
+    delete process.env.BOTMUX_LARK_APP_ID;
+    expect(() => mod.loadBotConfigs()).toThrow(/EPERM/);
+  });
+
+  it('still throws for a NON-permission read error even under isolation (only EPERM/EACCES are expected)', () => {
+    process.env.SESSION_DATA_DIR = '/h/.botmux/data';
+    process.env.BOTMUX_LARK_APP_ID = 'cli_sandboxed';
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      throw Object.assign(new Error('EIO: i/o error'), { code: 'EIO' });
+    });
+    expect(() => mod.loadBotConfigs()).toThrow(/EIO/);
+  });
+});

--- a/test/child-env.test.ts
+++ b/test/child-env.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import {
+  BOTMUX_INJECTED_ENV_KEYS,
   CLAUDE_SESSION_MARKER_ENV_KEYS,
   redactChildEnv,
   scrubClaudeSessionMarkerEnv,
@@ -183,5 +184,22 @@ describe('session CLI home scrub call sites', () => {
     expect(fn.slice(0, fn.indexOf('\n}'))).toContain('scrubClaudeSessionMarkerEnv(');
     expect(read('index-daemon.ts')).toContain('scrubClaudeSessionMarkerEnv(process.env)');
     expect(read('worker.ts')).toContain('scrubClaudeSessionMarkerEnv(process.env)');
+  });
+});
+
+// ─── read-isolation markers must reach the child ──────────────────────────
+
+/**
+ * Regression guard (2026-08-03): the sandbox bots.json fix hinges on the worker
+ * telling the CLI it is isolated. buildBotmuxEnvAssignments() forwards ONLY the
+ * keys in BOTMUX_INJECTED_ENV_KEYS, so leaving these out silently strips them on
+ * the tmux backend — the fix would compile, pass every unit test, and do nothing
+ * on a real machine. (Three review rounds did not catch this; the allowlist is
+ * the kind of coupling that is invisible from the call site.)
+ */
+describe('BOTMUX_INJECTED_ENV_KEYS carries the read-isolation markers', () => {
+  it('includes BOTMUX_READ_ISOLATION and BOTMUX_API_ONLY', () => {
+    expect(BOTMUX_INJECTED_ENV_KEYS).toContain('BOTMUX_READ_ISOLATION');
+    expect(BOTMUX_INJECTED_ENV_KEYS).toContain('BOTMUX_API_ONLY');
   });
 });

--- a/test/read-isolation.test.ts
+++ b/test/read-isolation.test.ts
@@ -9,6 +9,7 @@ import {
   buildCredentialIsolationRules,
   isolatedPaneReattachSafe,
   isolationPaneMarkerContent,
+  ISOLATION_PANE_MARKER_VERSION,
   botHomePath,
   buildCliExecutableReadCarveOuts,
   sendCredFilePath,
@@ -186,15 +187,56 @@ describe('isolatedPaneReattachSafe', () => {
     expect(isolatedPaneReattachSafe(JSON.stringify({ version: 1, bootId: 'old' }))).toBe(false);
     expect(isolatedPaneReattachSafe(JSON.stringify({ version: 2, bootId: 'old-mcp-policy' }))).toBe(false);
     expect(isolatedPaneReattachSafe(JSON.stringify({ version: 5, bootId: 'pre-device-policy' }))).toBe(false);
-    expect(isolatedPaneReattachSafe(JSON.stringify({ version: 7, bootId: 'missing-capabilities' }))).toBe(false);
     expect(isolatedPaneReattachSafe(JSON.stringify({
-      version: 7, bootId: 'unknown-capability', capabilities: ['credential', 'network'],
+      version: ISOLATION_PANE_MARKER_VERSION, bootId: 'missing-capabilities',
+    }))).toBe(false);
+    expect(isolatedPaneReattachSafe(JSON.stringify({
+      version: ISOLATION_PANE_MARKER_VERSION, bootId: 'unknown-capability', capabilities: ['credential', 'network'],
     }))).toBe(false);
     // No / blank marker → pane was NOT spawned isolated → unsafe (kill + cold-spawn).
     expect(isolatedPaneReattachSafe(null)).toBe(false);
     expect(isolatedPaneReattachSafe(undefined)).toBe(false);
     expect(isolatedPaneReattachSafe('')).toBe(false);
     expect(isolatedPaneReattachSafe('   ')).toBe(false);
+  });
+});
+
+// ─── cold-start migration: START-TIME env contract (bots.json EPERM fix) ──────
+
+/**
+ * Regression guard (2026-08-03). The bots.json-EPERM fix injects a NEW start-time
+ * env contract (BOTMUX_READ_ISOLATION / BOTMUX_API_ONLY) that only reaches a CLI
+ * at spawn. A warm reattach preserves the live process untouched, so a pane that
+ * was spawned by v3.8.0 — v7 marker, full capabilities, but a process carrying
+ * NEITHER env key — would be judged reattach-safe and keep crashing on the denied
+ * bots.json read after a plain `daemon:restart`. The marker version is the ONLY
+ * lever that turns such a pane from "warm reattach (keep old process)" into
+ * "kill + cold-spawn (inject the markers)". So bumping it past 7 is load-bearing,
+ * not cosmetic. If someone reverts the bump, this test goes red.
+ */
+describe('isolatedPaneReattachSafe — start-time contract bump forces cold respawn', () => {
+  // Exactly the shape codex reproduced: a v3.8.0 sandbox pane's marker.
+  const legacyV7Full = JSON.stringify({
+    version: 7,
+    bootId: 'old-v3.8-pane',
+    capabilities: ['credential', 'read', 'write'],
+  });
+
+  it('rejects a v7 pane even with FULL valid capabilities (its process lacks the new env markers)', () => {
+    expect(isolatedPaneReattachSafe(legacyV7Full, ['read', 'write'])).toBe(false);
+    expect(isolatedPaneReattachSafe(legacyV7Full, ['credential', 'read', 'write'])).toBe(false);
+  });
+
+  it('accepts a pane stamped with the current version (cold-spawned under the new contract)', () => {
+    const current = isolationPaneMarkerContent('fresh-boot', ['credential', 'read', 'write']);
+    expect(isolatedPaneReattachSafe(current, ['read', 'write'])).toBe(true);
+  });
+
+  it('has moved the version past 7 — the release that shipped without the env contract', () => {
+    // Pins the intent: v7 was the last version whose isolated processes could
+    // lack BOTMUX_READ_ISOLATION. Anything ≥ 8 is fine; reverting to ≤ 7 would
+    // silently warm-reattach those broken panes.
+    expect(ISOLATION_PANE_MARKER_VERSION).toBeGreaterThan(7);
   });
 });
 

--- a/test/read-isolation.test.ts
+++ b/test/read-isolation.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   evaluateReadIsolationGate,
   evaluateCredentialOnlyIsolationGate,
@@ -280,49 +282,81 @@ describe('CLI protected capability wiring', () => {
 // ─── underReadIsolation ───────────────────────────────────────────────────
 
 /**
- * Regression guard (2026-08-03 fleet P0, introduced by #668): callers use this
- * predicate to decide whether an UNREADABLE ~/.botmux/bots.json is the expected
- * sandbox state (degrade to "no bots") or a genuine fault (stay fatal). Getting
- * it wrong in either direction is bad: too narrow → every sandboxed bot's CLI
- * dies on the root dispatch gate; too wide → a real unreadable config silently
- * boots a zero-bot process.
+ * Regression guard (2026-08-03 fleet P0, introduced by #668). Callers use this to
+ * decide whether an UNREADABLE ~/.botmux/bots.json is the expected sandbox state
+ * (degrade) or a real fault (stay fatal). Wrong in either direction is bad:
+ * too narrow → every sandboxed bot's CLI dies on the root dispatch gate;
+ * too wide → a genuine unreadable config silently becomes "there are no bots".
+ *
+ * The predicate must key off the HOST-written send-cred.json, not env alone:
+ * BOTMUX_LARK_APP_ID / SESSION_DATA_DIR are injected for every worker-spawned
+ * CLI, sandboxed or not.
  */
 describe('underReadIsolation', () => {
   const saved = { ...process.env };
-  afterEach(() => { process.env = { ...saved }; });
+  let tmp: string;
 
-  it('is true only when BOTH worker-injected markers are present', async () => {
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'botmux-iso-'));
+    mkdirSync(join(tmp, 'data'), { recursive: true });
+  });
+  afterEach(() => {
+    process.env = { ...saved };
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const writeCred = (appId: string) => {
+    const dir = join(tmp, 'bots', appId);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'send-cred.json'), '{"larkAppId":"' + appId + '"}');
+  };
+
+  it('is true when the host-written send-cred.json exists for this bot', async () => {
     const { underReadIsolation } = await import('../src/adapters/cli/read-isolation.js');
-    process.env.SESSION_DATA_DIR = '/h/.botmux/data';
+    writeCred('cli_sandboxed');
+    process.env.SESSION_DATA_DIR = join(tmp, 'data');
     process.env.BOTMUX_LARK_APP_ID = 'cli_sandboxed';
     expect(underReadIsolation()).toBe(true);
   });
 
-  it('is false when only SESSION_DATA_DIR is set (half-configured is not isolation)', async () => {
+  it('is FALSE for an ordinary worker-spawned CLI: both env vars set, no cred file', async () => {
+    // This is the case that matters most — the worker injects BOTMUX_LARK_APP_ID
+    // and SESSION_DATA_DIR for NON-sandboxed bots too. An env-only predicate would
+    // wrongly report isolation here and swallow real config faults.
     const { underReadIsolation } = await import('../src/adapters/cli/read-isolation.js');
-    process.env.SESSION_DATA_DIR = '/h/.botmux/data';
-    delete process.env.BOTMUX_LARK_APP_ID;
+    process.env.SESSION_DATA_DIR = join(tmp, 'data');
+    process.env.BOTMUX_LARK_APP_ID = 'cli_plain';
     expect(underReadIsolation()).toBe(false);
   });
 
-  it('is false when only BOTMUX_LARK_APP_ID is set', async () => {
+  it('is false when the cred file belongs to a DIFFERENT bot', async () => {
     const { underReadIsolation } = await import('../src/adapters/cli/read-isolation.js');
+    writeCred('cli_someone_else');
+    process.env.SESSION_DATA_DIR = join(tmp, 'data');
+    process.env.BOTMUX_LARK_APP_ID = 'cli_me';
+    expect(underReadIsolation()).toBe(false);
+  });
+
+  it('is false when SESSION_DATA_DIR is missing even though the file exists', async () => {
+    const { underReadIsolation } = await import('../src/adapters/cli/read-isolation.js');
+    writeCred('cli_sandboxed');
     delete process.env.SESSION_DATA_DIR;
     process.env.BOTMUX_LARK_APP_ID = 'cli_sandboxed';
     expect(underReadIsolation()).toBe(false);
   });
 
-  it('is false on a plain host with neither marker', async () => {
+  it('is false on a bare host with neither marker', async () => {
     const { underReadIsolation } = await import('../src/adapters/cli/read-isolation.js');
     delete process.env.SESSION_DATA_DIR;
     delete process.env.BOTMUX_LARK_APP_ID;
     expect(underReadIsolation()).toBe(false);
   });
 
-  it('treats an empty-string marker as absent (not isolation)', async () => {
+  it('is false when the cred path is a directory, not a file', async () => {
     const { underReadIsolation } = await import('../src/adapters/cli/read-isolation.js');
-    process.env.SESSION_DATA_DIR = '';
-    process.env.BOTMUX_LARK_APP_ID = 'cli_sandboxed';
+    mkdirSync(join(tmp, 'bots', 'cli_odd', 'send-cred.json'), { recursive: true });
+    process.env.SESSION_DATA_DIR = join(tmp, 'data');
+    process.env.BOTMUX_LARK_APP_ID = 'cli_odd';
     expect(underReadIsolation()).toBe(false);
   });
 });

--- a/test/read-isolation.test.ts
+++ b/test/read-isolation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import {
   evaluateReadIsolationGate,
@@ -274,5 +274,55 @@ describe('CLI protected capability wiring', () => {
     expect(vcSource).toContain(
       'const liveOrigin = resolveSessionContext(config.session.dataDir, receiverSessionId);',
     );
+  });
+});
+
+// ─── underReadIsolation ───────────────────────────────────────────────────
+
+/**
+ * Regression guard (2026-08-03 fleet P0, introduced by #668): callers use this
+ * predicate to decide whether an UNREADABLE ~/.botmux/bots.json is the expected
+ * sandbox state (degrade to "no bots") or a genuine fault (stay fatal). Getting
+ * it wrong in either direction is bad: too narrow → every sandboxed bot's CLI
+ * dies on the root dispatch gate; too wide → a real unreadable config silently
+ * boots a zero-bot process.
+ */
+describe('underReadIsolation', () => {
+  const saved = { ...process.env };
+  afterEach(() => { process.env = { ...saved }; });
+
+  it('is true only when BOTH worker-injected markers are present', async () => {
+    const { underReadIsolation } = await import('../src/adapters/cli/read-isolation.js');
+    process.env.SESSION_DATA_DIR = '/h/.botmux/data';
+    process.env.BOTMUX_LARK_APP_ID = 'cli_sandboxed';
+    expect(underReadIsolation()).toBe(true);
+  });
+
+  it('is false when only SESSION_DATA_DIR is set (half-configured is not isolation)', async () => {
+    const { underReadIsolation } = await import('../src/adapters/cli/read-isolation.js');
+    process.env.SESSION_DATA_DIR = '/h/.botmux/data';
+    delete process.env.BOTMUX_LARK_APP_ID;
+    expect(underReadIsolation()).toBe(false);
+  });
+
+  it('is false when only BOTMUX_LARK_APP_ID is set', async () => {
+    const { underReadIsolation } = await import('../src/adapters/cli/read-isolation.js');
+    delete process.env.SESSION_DATA_DIR;
+    process.env.BOTMUX_LARK_APP_ID = 'cli_sandboxed';
+    expect(underReadIsolation()).toBe(false);
+  });
+
+  it('is false on a plain host with neither marker', async () => {
+    const { underReadIsolation } = await import('../src/adapters/cli/read-isolation.js');
+    delete process.env.SESSION_DATA_DIR;
+    delete process.env.BOTMUX_LARK_APP_ID;
+    expect(underReadIsolation()).toBe(false);
+  });
+
+  it('treats an empty-string marker as absent (not isolation)', async () => {
+    const { underReadIsolation } = await import('../src/adapters/cli/read-isolation.js');
+    process.env.SESSION_DATA_DIR = '';
+    process.env.BOTMUX_LARK_APP_ID = 'cli_sandboxed';
+    expect(underReadIsolation()).toBe(false);
   });
 });

--- a/test/read-isolation.test.ts
+++ b/test/read-isolation.test.ts
@@ -1,7 +1,5 @@
-import { describe, it, expect, afterEach, beforeEach } from 'vitest';
-import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
 import {
   evaluateReadIsolationGate,
   evaluateCredentialOnlyIsolationGate,
@@ -282,81 +280,44 @@ describe('CLI protected capability wiring', () => {
 // ─── underReadIsolation ───────────────────────────────────────────────────
 
 /**
- * Regression guard (2026-08-03 fleet P0, introduced by #668). Callers use this to
- * decide whether an UNREADABLE ~/.botmux/bots.json is the expected sandbox state
- * (degrade) or a real fault (stay fatal). Wrong in either direction is bad:
- * too narrow → every sandboxed bot's CLI dies on the root dispatch gate;
- * too wide → a genuine unreadable config silently becomes "there are no bots".
- *
- * The predicate must key off the HOST-written send-cred.json, not env alone:
- * BOTMUX_LARK_APP_ID / SESSION_DATA_DIR are injected for every worker-spawned
- * CLI, sandboxed or not.
+ * Regression guard (2026-08-03 fleet P0, introduced by #668). Two earlier
+ * versions of this predicate were wrong and both are pinned here as negative
+ * cases, so a future "simplification" back to either one fails loudly.
  */
 describe('underReadIsolation', () => {
   const saved = { ...process.env };
-  let tmp: string;
+  afterEach(() => { process.env = { ...saved }; });
 
-  beforeEach(() => {
-    tmp = mkdtempSync(join(tmpdir(), 'botmux-iso-'));
-    mkdirSync(join(tmp, 'data'), { recursive: true });
-  });
-  afterEach(() => {
-    process.env = { ...saved };
-    rmSync(tmp, { recursive: true, force: true });
-  });
+  const load = async () => (await import('../src/adapters/cli/read-isolation.js')).underReadIsolation;
 
-  const writeCred = (appId: string) => {
-    const dir = join(tmp, 'bots', appId);
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(join(dir, 'send-cred.json'), '{"larkAppId":"' + appId + '"}');
-  };
-
-  it('is true when the host-written send-cred.json exists for this bot', async () => {
-    const { underReadIsolation } = await import('../src/adapters/cli/read-isolation.js');
-    writeCred('cli_sandboxed');
-    process.env.SESSION_DATA_DIR = join(tmp, 'data');
-    process.env.BOTMUX_LARK_APP_ID = 'cli_sandboxed';
+  it('is true when the worker marked the child as sandboxed', async () => {
+    const underReadIsolation = await load();
+    process.env.BOTMUX_READ_ISOLATION = '1';
     expect(underReadIsolation()).toBe(true);
   });
 
-  it('is FALSE for an ordinary worker-spawned CLI: both env vars set, no cred file', async () => {
-    // This is the case that matters most — the worker injects BOTMUX_LARK_APP_ID
-    // and SESSION_DATA_DIR for NON-sandboxed bots too. An env-only predicate would
-    // wrongly report isolation here and swallow real config faults.
-    const { underReadIsolation } = await import('../src/adapters/cli/read-isolation.js');
-    process.env.SESSION_DATA_DIR = join(tmp, 'data');
+  it('is false on a plain host', async () => {
+    const underReadIsolation = await load();
+    delete process.env.BOTMUX_READ_ISOLATION;
+    expect(underReadIsolation()).toBe(false);
+  });
+
+  it('does NOT infer isolation from SESSION_DATA_DIR + BOTMUX_LARK_APP_ID', async () => {
+    // Rejected v1: the worker injects both of those for EVERY bot it spawns,
+    // sandboxed or not, so this shape is an ordinary CLI. Treating it as isolated
+    // would swallow a real unreadable-bots.json fault on a normal host.
+    const underReadIsolation = await load();
+    delete process.env.BOTMUX_READ_ISOLATION;
+    process.env.SESSION_DATA_DIR = '/h/.botmux/data';
     process.env.BOTMUX_LARK_APP_ID = 'cli_plain';
     expect(underReadIsolation()).toBe(false);
   });
 
-  it('is false when the cred file belongs to a DIFFERENT bot', async () => {
-    const { underReadIsolation } = await import('../src/adapters/cli/read-isolation.js');
-    writeCred('cli_someone_else');
-    process.env.SESSION_DATA_DIR = join(tmp, 'data');
-    process.env.BOTMUX_LARK_APP_ID = 'cli_me';
-    expect(underReadIsolation()).toBe(false);
-  });
-
-  it('is false when SESSION_DATA_DIR is missing even though the file exists', async () => {
-    const { underReadIsolation } = await import('../src/adapters/cli/read-isolation.js');
-    writeCred('cli_sandboxed');
-    delete process.env.SESSION_DATA_DIR;
-    process.env.BOTMUX_LARK_APP_ID = 'cli_sandboxed';
-    expect(underReadIsolation()).toBe(false);
-  });
-
-  it('is false on a bare host with neither marker', async () => {
-    const { underReadIsolation } = await import('../src/adapters/cli/read-isolation.js');
-    delete process.env.SESSION_DATA_DIR;
-    delete process.env.BOTMUX_LARK_APP_ID;
-    expect(underReadIsolation()).toBe(false);
-  });
-
-  it('is false when the cred path is a directory, not a file', async () => {
-    const { underReadIsolation } = await import('../src/adapters/cli/read-isolation.js');
-    mkdirSync(join(tmp, 'bots', 'cli_odd', 'send-cred.json'), { recursive: true });
-    process.env.SESSION_DATA_DIR = join(tmp, 'data');
-    process.env.BOTMUX_LARK_APP_ID = 'cli_odd';
-    expect(underReadIsolation()).toBe(false);
+  it('only accepts the exact marker value "1"', async () => {
+    const underReadIsolation = await load();
+    for (const v of ['0', 'true', 'yes', '']) {
+      process.env.BOTMUX_READ_ISOLATION = v;
+      expect(underReadIsolation()).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## 症状

沙盒（read isolation）bot 里执行**任何** `botmux` 子命令都立即退出：

```
❌ EPERM: operation not permitted, open '~/.botmux/bots.json'
```

不只是 `send` —— `history` / `schedule list` / 角色切换全挂，等于沙盒 bot 的对外通道完全不可用。我们机队五台机器升到 v3.8.0 后全中；受影响面按沙盒 bot 数量，其中一台 6 个 bot 里 5 个是沙盒。

## 根因

`git bisect` 定位到 **#668**（`76c033f3`，core-only / API-only bot 模式）。

它把 `currentBotIsApiOnly()` 挂到了**根 dispatch 闸** `managedOriginHasNoTransport()` 上 —— 每条子命令开跑前都过一次。调用链最终落到 `cli.ts` 的 `loadBotsJson()`：

```js
if (existsSync(BOTS_JSON_FILE)) {          // stat 放行 → 进来
  try { return parseBotConfigsJson(readFileSync(BOTS_JSON_FILE, 'utf-8'), BOTS_JSON_FILE) }
  catch (err) { console.error(`❌ ${err?.message}`); process.exit(1) }   // ← 退进程
}
```

两个关键点：

1. 沙盒里 `bots.json` 被拒是**设计如此**（它装着所有兄弟 bot 的 app secret）。Seatbelt **放行元数据读、拒绝内容读**，所以 `existsSync()` 为真，那条优雅的 "no bot configuration found" 分支永远走不到，直接撞上 `readFileSync` 的 EPERM。
2. `loadBotsJson()` 在失败时 **`process.exit(1)`，不是抛异常**。#668 其实写了防御 —— `currentBotIsApiOnly()` 外面包了 `try/catch` 并在文档注释里写 "Read-only + never throws"。那句话字面上成立：它不 throw，它 exit。`process.exit()` 捕不住，所以那层防御完全失效。

> 这个雷之前有人踩过并就地绕开了：`cli.ts` 的 `allBotAppIds()` 注释里写着 "sandboxed sessions … must never touch bots.json — it is denied and **`loadBotsJson()` process.exit(1)s on the read error**"，那处自己内联了一个 sandbox-safe 读。#668 新增调用方时没有这个上下文。这说明"每个调用方自己记得绕开"的模式不可靠。

## 复现（不需要真沙盒）

`chmod 000` 造出的就是「stat 放行 / open 拒绝」同一形状：

```bash
TMPH=$(mktemp -d); mkdir -p $TMPH/.botmux/data
printf '[{"larkAppId":"cli_x","larkAppSecret":"s","cliId":"claude-code"}]' > $TMPH/.botmux/bots.json
chmod 000 $TMPH/.botmux/bots.json

env -i HOME=$TMPH PATH=$(dirname $(command -v node)):/usr/bin:/bin \
  SESSION_DATA_DIR=$TMPH/.botmux/data BOTMUX_LARK_APP_ID=cli_x \
  BOTMUX_SESSION_ID=deadbeef BOTMUX_CHAT_ID=oc_x BOTMUX_READ_ISOLATION=1 \
  node dist/cli.js send --no-mention probe

# 修复前: ❌ EACCES: permission denied, open '…/bots.json'
# 修复后: 未找到 session deadbeef      ← 与 #668 之前的版本逐字一致
```

bisect 就是用这个判据跑的（输出里有没有 `bots.json`），每轮只 `npx tsc`。

## 改了什么

**1. 新增 `BOTMUX_READ_ISOLATION` 标记（`worker.ts` → `read-isolation.ts`）**

CLI 需要能区分「bots.json 被拒是因为我在沙盒里（预期）」和「bots.json 读不了（真故障）」。这个信号**必须由宿主给**，CLI 侧推不出来 —— 我们试错了两版：

| 版本 | 判据 | 为什么错 |
|---|---|---|
| v1 | `SESSION_DATA_DIR` + `BOTMUX_LARK_APP_ID` | `childEnv.BOTMUX_LARK_APP_ID` **不受 sandbox 门控**，每个 worker 拉起的 CLI 都有 → 误命中普通 bot，会把真实的配置故障静默降级成"没有 bot" |
| v2 | `<BOT_HOME>/send-cred.json` 是否存在 | 两向都错：`fs-policy.ts` 的 `!larkTransport` 分支把 **no-transport(apiOnly) bot 自己的** cred 文件也 deny 了；且该文件从不清理，`sandbox:true→false` 后残留会让普通 CLI 误判成隔离 |
| **v3** | **`BOTMUX_READ_ISOLATION`**，worker gated on `sandboxRequested` 注入、非沙盒时显式 `delete` | 本版 |

三版演进都写进了代码注释，避免后来者"简化"回去。

**2. `loadBotsJson()` 保持 fail-fast，不做中央吞咽**

它有二十多个调用方，其中 `cli.ts` 的插件 dematerialize / uninstall 依赖检查会把 `[]` 读成"没有任何 bot 引用它"→ **删除仍在使用的插件**。把"读不到"降级成"空"在那里等于把拒绝读变成静默的破坏性动作。需要在沙盒里存活的调用方必须**显式退出**这套。

**3. `currentBotIsApiOnly()` 在读隔离下不碰 `loadBotsJson()`**

改为：`BOTMUX_API_ONLY`（宿主注入）→ `send-cred.json` 的 `apiOnly` → false。同时给**本地沙盒**路径补上 `BOTMUX_API_ONLY` 注入（riff 路径早就有）—— 没有它，no-transport bot 的 cred 文件被 deny、沙盒里读不出自己的 apiOnly，那个自称 tamper-resistant 的闸会对整类 bot 空转。伪造这个标记只会让本轮更受限，不会更宽松。

**4. `bot-registry.ts` `parseBotConfigFile()`**：同形状的第二条路径（send 路径会走 `loadBotConfigs`），加同款守卫。

**5. 两个标记加进 `BOTMUX_INJECTED_ENV_KEYS`**

`buildBotmuxEnvAssignments()` **只转发这个白名单里的 key**。不加的话 tmux backend 会把标记直接丢掉 —— 编译过、全量单测过、手工探针过（探针手动传 env，绕过了注入链路），但真机上沙盒 bot 依旧崩、**症状和修之前一模一样**，极易被误判成"修复方向错了"。加进白名单同时拿到 `scrubTmuxServerGlobalEnv()` 的清理语义，陈旧值不会漏进非沙盒 pane。

## 验证

干净 `env -i` 环境下的对照矩阵：

| 场景 | 结果 |
|---|---|
| 沙盒 + 非 apiOnly | 越过 bots.json，走到 session 查找 ✅ |
| 沙盒 + apiOnly（cred 可读） | 无 transport 闸正常拦截 ✅ |
| 沙盒 + apiOnly（cred 被 deny） | 无 transport 闸正常拦截 ✅ |
| 普通 bot（同样 env、无 marker） | 仍然硬失败 ✅ |
| 正常可读的 `bots.json` | 与 #668 之前逐字一致 ✅ |

- 单测：全量 unit 通过（余下失败为满载 flaky，逐个单跑全过）
- 新增回归测试均做了**变异验证**（删掉守卫 / `&&` 改 `||` / 从白名单移除 key → 对应用例变红）
- **真机验证**：已部署到一台机器，其沙盒 bot 通过 `botmux send` 发出消息（不是 lark-cli 绕道），`botmux schedule list` 正常，`bots.json` 仍 EPERM（符合设计）

## 备注

`process.exit()` 在库函数里做错误处理，会让调用方的 `try/catch` 变成安慰剂 —— #668 里那句 "never throws" 的注释就是被这一点坑的。这个 PR 没有系统性改造 `loadBotsJson()` 的其它调用方，但在函数上写明了为什么它必须保持 fail-fast、以及要豁免该怎么做。
