### PR TITLE
feat(group): 支持原生话题群与 Bot 群消息

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4448,8 +4448,110 @@ async function postSessionCliIpc(
 
 async function cmdChat(argv: string[]): Promise<void> {
   const sub = argv[0] ?? '';
+  if (sub === 'send') {
+    assertTurnTransportOrExit('chat send');
+    const rest = argv.slice(1);
+    if (rest.includes('--help') || rest.includes('-h')) {
+      console.log(`
+botmux chat send — 用指定 Bot 身份向已知飞书群发送顶层 Markdown 卡片
+
+用法:
+  botmux chat send --bot <name|larkAppId> --chat-id <oc_xxx>
+                   --markdown-file <path> [--idempotency-key <key>]
+
+说明:
+  - 不依赖 Botmux Session，适合安装器和已有群的失败恢复。
+  - --bot 必须是该群成员；消息使用该 Bot 的飞书身份发送。
+  - --idempotency-key 最长 50 字节，飞书会在有效期内去重。
+`);
+      return;
+    }
+    const botRef = argValue(rest, '--bot');
+    const chatId = argValue(rest, '--chat-id');
+    const markdownFile = argValue(rest, '--markdown-file');
+    const idempotencyKey = argValue(rest, '--idempotency-key');
+    if (!botRef || !chatId || !markdownFile) {
+      console.error('用法: botmux chat send --bot <name|larkAppId> --chat-id <oc_xxx> --markdown-file <path> [--idempotency-key <key>]');
+      process.exitCode = 2;
+      return;
+    }
+    if (!/^oc_[A-Za-z0-9]+$/.test(chatId)) {
+      console.error(`非法 --chat-id: ${chatId}`);
+      process.exitCode = 2;
+      return;
+    }
+    if (!existsSync(markdownFile)) {
+      console.error(`Markdown 文件不存在: ${markdownFile}`);
+      process.exitCode = 1;
+      return;
+    }
+    const markdown = readFileSync(markdownFile, 'utf-8');
+    if (!markdown.trim()) {
+      console.error('Markdown 文件内容不能为空。');
+      process.exitCode = 2;
+      return;
+    }
+    if (Buffer.byteLength(markdown, 'utf-8') > 256 * 1024) {
+      console.error('Markdown 文件超过 256 KiB。');
+      process.exitCode = 2;
+      return;
+    }
+    if (idempotencyKey && Buffer.byteLength(idempotencyKey, 'utf-8') > 50) {
+      console.error('--idempotency-key 最长 50 字节。');
+      process.exitCode = 2;
+      return;
+    }
+
+    const { registerBot, loadBotConfigs } = await import('./bot-registry.js');
+    const fullConfigs = loadBotConfigs();
+    const dataDir = resolveDataDir();
+    const botInfoPath = join(dataDir, 'bots-info.json');
+    let botInfoEntries: Array<{ larkAppId: string; botName: string | null }> = [];
+    try {
+      if (existsSync(botInfoPath)) botInfoEntries = JSON.parse(readFileSync(botInfoPath, 'utf-8'));
+    } catch { /* invalid bots-info is equivalent to no display-name hints */ }
+    const { resolveBotRefs } = await import('./cli/create-group-resolver.js');
+    const resolved = resolveBotRefs(
+      [botRef],
+      fullConfigs.map(c => ({ larkAppId: c.larkAppId, cliId: c.cliId })),
+      botInfoEntries,
+    );
+    if (resolved.ambiguousWarnings.length > 0) {
+      console.error(`--bot 引用有歧义: ${resolved.ambiguousWarnings.join(' ')}`);
+      process.exitCode = 2;
+      return;
+    }
+    if (resolved.invalid.length > 0 || resolved.larkAppIds.length !== 1) {
+      console.error(`无法解析 --bot ${botRef}`);
+      process.exitCode = 2;
+      return;
+    }
+    const larkAppId = resolved.larkAppIds[0];
+    const cfg = fullConfigs.find(c => c.larkAppId === larkAppId);
+    if (!cfg) {
+      console.error(`未找到 Bot 配置: ${larkAppId}`);
+      process.exitCode = 1;
+      return;
+    }
+    registerBot(cfg);
+    const { sendBotMarkdownToChat } = await import('./services/chat-sender.js');
+    try {
+      const result = await sendBotMarkdownToChat({
+        larkAppId,
+        chatId,
+        markdown,
+        idempotencyKey,
+        brand: cfg.brandLabel,
+      });
+      console.log(JSON.stringify({ ok: true, identity: 'bot', larkAppId, chatId, ...result }));
+    } catch (err: any) {
+      console.error(`Bot 群消息发送失败: ${err?.message ?? err}`);
+      process.exitCode = 1;
+    }
+    return;
+  }
   if (sub !== 'rename') {
-    console.error('用法: botmux chat rename <新群名称> [--proactive]');
+    console.error('用法: botmux chat rename <新群名称> [--proactive] | botmux chat send --help');
     process.exitCode = 2;
     return;
   }
@@ -5333,6 +5435,8 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
 飞书消息（在 CLI 会话内自动推断 session）:
   chat rename <新群名称>               修改当前会话所在群的名称
        --proactive                    标记为 AI 主动改名（应用 10 分钟防抖）
+  chat send --bot <name> --chat-id <oc_xxx> --markdown-file <path>
+                                       用指定 Bot 身份向已知群发送顶层 Markdown 卡片；不依赖 Session
   send [content]                       发消息到当前话题（支持 stdin / --content-file）
        --images <path>                 内联图片（可重复）
        --files <path>                  附件（可重复）
@@ -5396,7 +5500,7 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
   report [...]                         v3/编排场景向上汇报进度或结果（详见 \`botmux report --help\`）
 
 新建飞书群:
-  create-group --bot <name> [--bot ...] [--name "群名"]
+  create-group --bot <name> [--bot ...] [--name "群名"] [--topic]
                                        用指定 bot 起新群；详见 \`botmux create-group --help\`
 
 精确群对话授权（talk-only）:
@@ -8725,7 +8829,7 @@ async function cmdCreateGroup(rest: string[]): Promise<void> {
 botmux create-group — 用一组机器人新建飞书群
 
 用法:
-  botmux create-group --bot <name|larkAppId> [--bot ...] [--name "群名"]
+  botmux create-group --bot <name|larkAppId> [--bot ...] [--name "群名"] [--topic]
                       [--working-dir <path>]
                       [--kickoff-bot <open_id> --kickoff-prompt "文本"]
                       [--json-status]
@@ -8736,6 +8840,7 @@ botmux create-group — 用一组机器人新建飞书群
                   bots.json 中第一个。重名 → 取 bots.json 中第一个匹配，stderr 打 warning。
                   重复 ref → 自动去重保留首次顺序。
   --name <群名>   可选；不传则用飞书默认无名群。
+  --topic         可选；在 chat.create 时直接创建原生话题群，不再先建普通群后二次更新。
   --working-dir <path>
                  可选；创建成功后，把新群为所有成功入群的 bot 绑定到该目录（等价于逐个 /oncall bind），
                  下次在群里开新话题时直接使用该目录，跳过仓库选择卡片。也可写作 --cwd / --dir。
@@ -8772,6 +8877,7 @@ botmux create-group — 用一组机器人新建飞书群
 
   const botRefs = argValues(rest, '--bot');
   const name = argValue(rest, '--name');
+  const topic = rest.includes('--topic');
   const workingDirArg = argValue(rest, '--working-dir', '--cwd', '--dir');
   const kickoffBot = argValue(rest, '--kickoff-bot');
   const kickoffPrompt = argValue(rest, '--kickoff-prompt');
@@ -8890,6 +8996,7 @@ botmux create-group — 用一组机器人新建飞书群
       creatorLarkAppId,
       larkAppIds: resolved.larkAppIds,
       name: name?.trim() || undefined,
+      groupMessageType: topic ? 'thread' : undefined,
       userOpenIds: targetOpenId ? [targetOpenId] : [],
       transferOwnerTo: targetOpenId,
       notifyOwnerOpenId: targetOpenId,

--- a/src/services/chat-sender.ts
+++ b/src/services/chat-sender.ts
@@ -1,0 +1,28 @@
+import { sendMessage } from '../im/lark/client.js';
+import { buildMarkdownCard } from '../im/lark/md-card.js';
+
+export interface SendBotMarkdownToChatOpts {
+  larkAppId: string;
+  chatId: string;
+  markdown: string;
+  idempotencyKey?: string;
+  brand?: string;
+}
+
+/** Send a top-level Markdown card to a known chat using a configured Bot
+ * identity. This intentionally has no Session dependency so installers and
+ * recovery scripts can finish onboarding an already-created group without
+ * impersonating a user or creating a duplicate group. */
+export async function sendBotMarkdownToChat(
+  opts: SendBotMarkdownToChatOpts,
+): Promise<{ messageId: string }> {
+  const card = buildMarkdownCard(opts.markdown, undefined, opts.brand);
+  const messageId = await sendMessage(
+    opts.larkAppId,
+    opts.chatId,
+    card,
+    'interactive',
+    opts.idempotencyKey,
+  );
+  return { messageId };
+}

--- a/src/services/group-creator.ts
+++ b/src/services/group-creator.ts
@@ -31,6 +31,9 @@ export interface CreateGroupOpts {
    *  (Lark rejects self-invite). May be empty (creator-only chat). */
   larkAppIds: string[];
   name?: string;
+  /** Native Feishu group message mode. `thread` creates a topic group in the
+   * initial chat.create call, avoiding a separate user-authenticated update. */
+  groupMessageType?: 'chat' | 'thread';
   userOpenIds?: string[];
   /** Users to add by union_id (tenant-stable) — used to pull bot OWNERS into a
    *  federated group regardless of which bot they paired through (open_id is
@@ -143,6 +146,7 @@ export async function createGroupWithBots(opts: CreateGroupOpts): Promise<Create
     name: opts.name,
     botIds: [],
     userIds: opts.userOpenIds ?? [],
+    groupMessageType: opts.groupMessageType,
   });
   opts.onChatCreated?.(r.chatId);
   for (let i = 0; i < otherBots.length; i += BOT_BATCH) {

--- a/src/services/groups-store.ts
+++ b/src/services/groups-store.ts
@@ -179,7 +179,12 @@ function classifyRenameChatError(code: unknown): 'permission_denied' | 'lark_api
  */
 export async function createChat(
   creatorLarkAppId: string,
-  opts: { name?: string; botIds: string[]; userIds?: string[] },
+  opts: {
+    name?: string;
+    botIds: string[];
+    userIds?: string[];
+    groupMessageType?: 'chat' | 'thread';
+  },
 ): Promise<{ chatId: string; invalidBotIds: string[]; invalidUserIds: string[] }> {
   const client = getBotClient(creatorLarkAppId);
   // Filter out the creator from bot_id_list — Lark errors if the inviter
@@ -188,6 +193,7 @@ export async function createChat(
   const userIds = (opts.userIds ?? []).filter(Boolean);
   const data: Record<string, unknown> = {};
   if (opts.name) data.name = opts.name;
+  if (opts.groupMessageType) data.group_message_type = opts.groupMessageType;
   if (otherBots.length > 0) data.bot_id_list = otherBots;
   if (userIds.length > 0) data.user_id_list = userIds;
   const params: Record<string, unknown> = {};

--- a/test/api-only-cli-gate.behavior.test.ts
+++ b/test/api-only-cli-gate.behavior.test.ts
@@ -79,6 +79,11 @@ d('root-dispatch transport gate — behavioral, tamper-resistant (built CLI)', (
       expect(code, `${cmd} honest exit`).toBe(2);
       expect(out, `${cmd} msg`).toMatch(/unavailable|no Feishu|HTTP control-API/);
     }
+    const chatSend = runCli(['chat', 'send'], {
+      BOTMUX_SESSION_ID: VIRTUAL_SID, BOTMUX_CHAT_ID: 'http_async_behaviorzero', BOTMUX_LARK_APP_ID: 'cli_test_bot',
+    });
+    expect(chatSend.code, 'chat send honest exit').toBe(2);
+    expect(chatSend.out, 'chat send msg').toMatch(/unavailable|no Feishu|HTTP control-API/);
   });
 
   it('TAMPERED env (env -u all BOTMUX_*) with a --session-id target: still refused', () => {

--- a/test/chat-sender.test.ts
+++ b/test/chat-sender.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSendMessage = vi.fn();
+const mockBuildMarkdownCard = vi.fn();
+
+vi.mock('../src/im/lark/client.js', () => ({
+  sendMessage: (...args: unknown[]) => mockSendMessage(...args),
+}));
+
+vi.mock('../src/im/lark/md-card.js', () => ({
+  buildMarkdownCard: (...args: unknown[]) => mockBuildMarkdownCard(...args),
+}));
+
+import { sendBotMarkdownToChat } from '../src/services/chat-sender.js';
+
+describe('sendBotMarkdownToChat', () => {
+  beforeEach(() => {
+    mockSendMessage.mockReset();
+    mockBuildMarkdownCard.mockReset();
+  });
+
+  it('sends an interactive markdown card through the selected bot identity', async () => {
+    mockBuildMarkdownCard.mockReturnValue('{"schema":"2.0"}');
+    mockSendMessage.mockResolvedValue('om_welcome');
+
+    await expect(sendBotMarkdownToChat({
+      larkAppId: 'cli_claude',
+      chatId: 'oc_work_group',
+      markdown: '# Welcome',
+      idempotencyKey: 'welcome-123',
+      brand: 'Claude',
+    })).resolves.toEqual({ messageId: 'om_welcome' });
+
+    expect(mockBuildMarkdownCard).toHaveBeenCalledWith('# Welcome', undefined, 'Claude');
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      'cli_claude',
+      'oc_work_group',
+      '{"schema":"2.0"}',
+      'interactive',
+      'welcome-123',
+    );
+  });
+});

--- a/test/cli-root-help.test.ts
+++ b/test/cli-root-help.test.ts
@@ -35,6 +35,11 @@ describe('botmux root help workflow surface', () => {
       expect(stdout).toContain('template archive-runs [--commit|--verify <archive>|--retire <archive> --ack-daemon-stopped]');
       expect(stdout).toContain('v2 历史 run 私有静态归档');
       expect(stdout).toContain('原子迁入 quarantine');
+      expect(stdout).toContain('create-group --bot <name> [--bot ...] [--name "群名"]');
+      expect(stdout).toContain('botmux create-group --help');
+      expect(stdout).toContain('chat rename <新群名称>');
+      expect(stdout).toContain('chat send --bot <name> --chat-id <oc_xxx> --markdown-file <path>');
+      expect(stdout).toContain('[--topic]');
       expect(stdout).not.toContain('template <run|resume|cancel|ls|tail|validate|show>');
       expect(stdout).not.toContain('v2 执行兼容面');
       expect(stdout).not.toContain('workflow <run|resume|cancel|ls|tail|validate|show>');

--- a/test/group-creator.test.ts
+++ b/test/group-creator.test.ts
@@ -87,6 +87,18 @@ describe('createGroupWithBots', () => {
     );
   });
 
+  it('passes native topic mode to chat.create', async () => {
+    mockCreateChat.mockResolvedValue({ chatId: 'oc_topic', invalidBotIds: [], invalidUserIds: [] });
+    await createGroupWithBots({
+      creatorLarkAppId: CREATOR,
+      larkAppIds: [CREATOR, OTHER_BOT],
+      groupMessageType: 'thread',
+    });
+    expect(mockCreateChat).toHaveBeenCalledWith(CREATOR, expect.objectContaining({
+      groupMessageType: 'thread',
+    }));
+  });
+
   it('pulls bot owners into the chat by union_id; reports invalidOwnerUnionIds', async () => {
     mockCreateChat.mockResolvedValue({ chatId: 'oc_fed', invalidBotIds: [], invalidUserIds: [] });
     mockAddUsersByUnionId.mockResolvedValue({ invalidUserIds: ['on_gone'] });

--- a/test/groups-store.test.ts
+++ b/test/groups-store.test.ts
@@ -185,6 +185,20 @@ describe('groups-store wrappers', () => {
     expect(callArgs.data.bot_id_list).toEqual(['cli_other']);
   });
 
+  it('createChat creates a native topic group when groupMessageType is thread', async () => {
+    chatCreateStub.mockResolvedValueOnce({
+      code: 0,
+      data: { chat_id: 'oc_topic', invalid_bot_id_list: [] },
+    });
+    await createChat('cli_creator', {
+      name: 'topic team',
+      botIds: ['cli_creator'],
+      groupMessageType: 'thread',
+    });
+    const callArgs = chatCreateStub.mock.calls[0][0];
+    expect(callArgs.data.group_message_type).toBe('thread');
+  });
+
   it('createChat omits bot_id_list when only creator is in the bot list', async () => {
     chatCreateStub.mockResolvedValueOnce({
       code: 0,


### PR DESCRIPTION
## 改动

- `botmux create-group --topic` 在 `chat.create` 请求中直接传 `group_message_type=thread`，避免先建普通群再用用户权限更新。
- 新增 `botmux chat send --bot <name|appId> --chat-id <oc_xxx> --markdown-file <path> [--idempotency-key <key>]`，允许安装器/恢复脚本用已配置 Bot 身份向已有群发送顶层 Markdown 卡片，无需 Session。
- 保留 create-group 的 chatId 提前输出与部分失败恢复契约；chat send 仍受 apiOnly/虚拟会话 transport gate 约束。

## 影响面

- 仅扩展飞书群创建请求的可选字段，默认 create-group 行为不变。
- 新消息命令复用既有 `buildMarkdownCard` 与 `sendMessage`，不改变普通 Session 回复路径。
- 无跨 CLI、PTY/Tmux、其它 IM 路径变化。

## 验证

- `pnpm build`
- `pnpm vitest run --project unit test/groups-store.test.ts test/group-creator.test.ts test/chat-sender.test.ts test/cli-root-help.test.ts test/api-only-cli-gate.behavior.test.ts`（64 tests passed）
- `pnpm test`：本改动相关测试全绿；全量仅有仓库既有的 Node 24 环境差异：`session-discovery.smoke.test.ts` 期望 comm=`node`，当前内核返回 `MainThread`。