### PR TITLE
fix(sandbox): 只读暴露 traex/coco 迁移标记，修 goal-mode 启动卡首运行迁移弹窗

### DIFF
--- a/src/adapters/cli/coco.ts
+++ b/src/adapters/cli/coco.ts
@@ -119,12 +119,19 @@ export function createCocoAdapter(pathOverride?: string): CliAdapter {
   let cachedBin: string | undefined;
   return {
     id: 'coco',
-    // ~/.trae/cli kept REAL (shared with traex): login + shared Trae state incl.
-    // the codex-style SQLite DBs (fcntl locks don't work unless the dir is bound
-    // real). ~/.cache/coco kept REAL too: the transcript bridge reads events.jsonl
-    // at the REAL ~/.cache/coco/sessions/<sid>/ path (see coco-transcript.ts) —
-    // without the rw bind the CLI's writes would be invisible to the daemon.
-    authPaths: ['~/.trae/cli', '~/.cache/coco'],
+    // ~/.trae kept REAL (whole dir, shared with traex): login + shared Trae state
+    // incl. the codex-style SQLite DBs under cli/ (fcntl locks don't work unless
+    // the dir is bound real). Coco runs the SAME traecli binary as traex, so it
+    // reads the same first-run state at the ~/.trae ROOT — the coco legacy-
+    // migration done-markers (.coco-migrated / .coco-migration-skip-all),
+    // traecli.toml, installation_id. Binding only cli/ hid those while the
+    // migration SOURCE (~/.cache/coco, bound rw below) stayed visible, so a
+    // sandboxed goal-mode pane wedged on the interactive "Legacy TRAE CLI data
+    // detected" prompt with no human at the PTY (same failure as traex.ts).
+    // ~/.cache/coco kept REAL too: the transcript bridge reads events.jsonl at the
+    // REAL ~/.cache/coco/sessions/<sid>/ path (see coco-transcript.ts) — without
+    // the rw bind the CLI's writes would be invisible to the daemon.
+    authPaths: ['~/.trae', '~/.cache/coco'],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, model, disableCliBypass }) {

--- a/src/adapters/cli/coco.ts
+++ b/src/adapters/cli/coco.ts
@@ -5,6 +5,7 @@ import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
 import { cocoCacheRoot } from '../../services/coco-paths.js';
 import { delay, scaleMs } from '../../utils/timing.js';
 import { installCocoAskPlugin } from '../coco-ask-plugin.js';
+import { TRAE_MIGRATION_DONE_MARKERS } from './traex.js';
 import type { CliAdapter, PtyHandle } from './types.js';
 
 /** Global submit log — CoCo appends one JSON line here on every successful
@@ -119,19 +120,18 @@ export function createCocoAdapter(pathOverride?: string): CliAdapter {
   let cachedBin: string | undefined;
   return {
     id: 'coco',
-    // ~/.trae kept REAL (whole dir, shared with traex): login + shared Trae state
-    // incl. the codex-style SQLite DBs under cli/ (fcntl locks don't work unless
-    // the dir is bound real). Coco runs the SAME traecli binary as traex, so it
-    // reads the same first-run state at the ~/.trae ROOT — the coco legacy-
-    // migration done-markers (.coco-migrated / .coco-migration-skip-all),
-    // traecli.toml, installation_id. Binding only cli/ hid those while the
-    // migration SOURCE (~/.cache/coco, bound rw below) stayed visible, so a
-    // sandboxed goal-mode pane wedged on the interactive "Legacy TRAE CLI data
-    // detected" prompt with no human at the PTY (same failure as traex.ts).
-    // ~/.cache/coco kept REAL too: the transcript bridge reads events.jsonl at the
-    // REAL ~/.cache/coco/sessions/<sid>/ path (see coco-transcript.ts) — without
-    // the rw bind the CLI's writes would be invisible to the daemon.
-    authPaths: ['~/.trae', '~/.cache/coco'],
+    // ~/.trae/cli kept REAL (shared with traex): login + shared Trae state incl.
+    // the codex-style SQLite DBs (fcntl locks don't work unless the dir is bound
+    // real). ~/.cache/coco kept REAL too: the transcript bridge reads events.jsonl
+    // at the REAL ~/.cache/coco/sessions/<sid>/ path (see coco-transcript.ts) —
+    // without the rw bind the CLI's writes would be invisible to the daemon.
+    // NOT widened to the whole ~/.trae (that root holds hooks/plugins/skills/
+    // traecli.toml, and authPaths are readWrite → a chat-driven sandbox could
+    // mutate shared hook/plugin code). Coco runs the SAME traecli binary as traex,
+    // so it hits the same first-run migration prompt; the done-markers it needs
+    // are exposed READ-ONLY via sandboxReadonlyPaths() below.
+    authPaths: ['~/.trae/cli', '~/.cache/coco'],
+    sandboxReadonlyPaths: () => [...TRAE_MIGRATION_DONE_MARKERS],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, model, disableCliBypass }) {

--- a/src/adapters/cli/read-isolation.ts
+++ b/src/adapters/cli/read-isolation.ts
@@ -307,17 +307,23 @@ export function buildSeatbeltProfile(
 // A marker records which confinement capabilities are attached to the live
 // process. Credential-only panes must cold-spawn when a full sandbox is enabled.
 //
-// BUMP THIS whenever the START-TIME contract of an isolated CLI changes in a way
-// a still-running process cannot satisfy — a warm reattach preserves the live
-// process untouched, so anything the reattach path relies on but the old process
-// lacks makes reattach unsafe.
-//   · 7 → 8 (2026-08-03): isolated CLIs now MUST carry the host-injected
-//     BOTMUX_READ_ISOLATION / BOTMUX_API_ONLY env (bots.json EPERM fix). Panes
-//     spawned by v3.8.0 have a v7 marker but a process with NEITHER key, so
-//     `botmux` inside them still dies on the denied bots.json read. Reattaching
-//     them would leave the regression unfixed after a plain `daemon:restart`;
-//     the bump forces a cold respawn that injects the markers.
-export const ISOLATION_PANE_MARKER_VERSION = 8;
+// BUMP THIS whenever the START-TIME sandbox contract of an isolated CLI changes
+// in a way a still-running process cannot satisfy — warm reattach preserves the
+// live process + its original bwrap mounts/env untouched, so a new mount/env the
+// reattach path relies on but the old process lacks makes reattach unsafe.
+//   · 7 → 8 (#709): isolated CLIs must carry host-injected BOTMUX_READ_ISOLATION
+//     / BOTMUX_API_ONLY env (bots.json EPERM fix). Panes spawned by v3.8.0 have a
+//     v7 marker but a process with NEITHER key, so `botmux` inside them dies on
+//     the denied bots.json read; reattaching leaves the regression unfixed after
+//     a plain `daemon:restart`.
+//   · 8 → 9 (#714): traex/coco now bind ~/.trae migration done-markers read-only
+//     (sandboxReadonlyPaths) so goal-mode stops wedging on the TRAE first-run
+//     migration prompt. That is a new spawn-time mount; a pane predating it warm-
+//     reattaches with the old mount set and still wedges, so it must cold-spawn.
+// #709 (→8) merged first; this PR (#714) rebased on top and takes 9. Numbers stay
+// strictly monotonic — a pane at any intermediate version must be rejected so it
+// cold-spawns under the current contract rather than bypassing a migration.
+export const ISOLATION_PANE_MARKER_VERSION = 9;
 
 export type IsolationCapability = 'credential' | 'read' | 'write';
 

--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -179,28 +179,46 @@ function goalEnvConfigArgs(env: NodeJS.ProcessEnv = process.env): string[] {
   return args;
 }
 
+/**
+ * First-run "Legacy TRAE CLI data detected → migrate?" done-markers at the
+ * ~/.trae ROOT. traecli treats a marker's mere EXISTENCE (content/mode
+ * irrelevant — verified with a 0-byte `chmod 444` file) as "migration already
+ * done" and skips the interactive prompt. Under the file sandbox the migration
+ * SOURCE ~/.cache/coco is visible (baseline rw bind) but ~/.trae root is not, so
+ * without these the TUI wedges on a prompt no human can answer in goal mode.
+ *
+ * Exposed READ-ONLY (via sandboxReadonlyPaths → fs-policy readonlyRoots), NOT by
+ * widening authPaths to the whole ~/.trae: that root also holds hooks/ plugins/
+ * skills/ traecli.toml and authPaths compile to readWrite, which would let a
+ * chat-driven sandbox mutate shared hook/plugin code other bots execute.
+ *
+ *  · .coco-rollouts-migrated  → gates the "recent SESSIONS" prompt (the wedge)
+ *  · .coco-migrated           → gates the config-migration prompt (defence in depth)
+ * Both are dirt-cheap read-only single-file binds; missing ones are dropped by
+ * the worker's existence filter (keepExisting), so a host without them is fine.
+ */
+export const TRAE_MIGRATION_DONE_MARKERS = [
+  '~/.trae/.coco-rollouts-migrated',
+  '~/.trae/.coco-migrated',
+] as const;
+
 export function createTraexAdapter(pathOverride?: string): CliAdapter {
   const rawBin = pathOverride ?? 'traex';
   let cachedBin: string | undefined;
   return {
     id: 'traex',
-    // Whole ~/.trae kept REAL (not just ~/.trae/cli): traex is codex-based and
-    // keeps the same SQLite state/log DBs under cli/ (state_*.sqlite /
-    // logs_*.sqlite) — under the deny-by-default file sandbox a path not in
-    // authPaths doesn't exist, so the DBs are unreachable / lack the fcntl locks
-    // SQLite needs (same failure as codex.ts). It ALSO reads first-run state at
-    // the ~/.trae ROOT: the coco legacy-migration done-markers (`.coco-migrated`,
-    // `.coco-migration-skip-all`), traecli.toml, installation_id. Binding only
-    // cli/ hid those, so a sandboxed goal-mode pane saw the migration SOURCE
-    // (~/.cache/coco, which IS bound) but not the done-marker → the TUI popped an
-    // interactive "Legacy TRAE CLI data detected" migration prompt and WEDGED
-    // (no human at the PTY to answer). Binding the whole dir mirrors codex.ts's
-    // `~/.codex` and matches where TRAE actually reads startup state.
-    // No secret exposure: traecli.toml carries model/hooks/marketplaces/projects,
-    // not API keys (the model_provider credential lives outside ~/.trae); and
-    // ~/.trae is already global-shared across traex bots, so this widens no
-    // cross-bot boundary.
-    authPaths: ['~/.trae'],
+    // Whole ~/.trae/cli kept REAL: traex is codex-based and keeps the same SQLite
+    // state/log DBs there (state_*.sqlite / logs_*.sqlite) — under the deny-by-
+    // default file sandbox a path not in authPaths doesn't exist, so the DBs are
+    // unreachable / lack the fcntl locks SQLite needs (same failure as codex.ts).
+    // NOTE: we deliberately do NOT widen this to the whole ~/.trae — that root
+    // holds hooks/ plugins/ skills/ traecli.toml, and authPaths compile to
+    // readWrite (fs-policy `push(authPaths,'readWrite')`), so a chat-driven
+    // sandbox could mutate shared hook/plugin CODE that later bots (or the user's
+    // own non-sandboxed traecli) execute. The first-run migration markers that
+    // must be visible are exposed READ-ONLY via sandboxReadonlyPaths() instead.
+    authPaths: ['~/.trae/cli'],
+    sandboxReadonlyPaths: () => [...TRAE_MIGRATION_DONE_MARKERS],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, resumeSessionId, workingDir, model, disableCliBypass, bypassHookTrust, remoteWsUrl, remoteThreadId }) {

--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -184,11 +184,23 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
   let cachedBin: string | undefined;
   return {
     id: 'traex',
-    // Whole ~/.trae/cli kept REAL: traex is codex-based and keeps the same SQLite
-    // state/log DBs there (state_*.sqlite / logs_*.sqlite) — under the deny-by-
-    // default file sandbox a path not in authPaths doesn't exist, so the DBs are
-    // unreachable / lack the fcntl locks SQLite needs (same failure as codex.ts).
-    authPaths: ['~/.trae/cli'],
+    // Whole ~/.trae kept REAL (not just ~/.trae/cli): traex is codex-based and
+    // keeps the same SQLite state/log DBs under cli/ (state_*.sqlite /
+    // logs_*.sqlite) — under the deny-by-default file sandbox a path not in
+    // authPaths doesn't exist, so the DBs are unreachable / lack the fcntl locks
+    // SQLite needs (same failure as codex.ts). It ALSO reads first-run state at
+    // the ~/.trae ROOT: the coco legacy-migration done-markers (`.coco-migrated`,
+    // `.coco-migration-skip-all`), traecli.toml, installation_id. Binding only
+    // cli/ hid those, so a sandboxed goal-mode pane saw the migration SOURCE
+    // (~/.cache/coco, which IS bound) but not the done-marker → the TUI popped an
+    // interactive "Legacy TRAE CLI data detected" migration prompt and WEDGED
+    // (no human at the PTY to answer). Binding the whole dir mirrors codex.ts's
+    // `~/.codex` and matches where TRAE actually reads startup state.
+    // No secret exposure: traecli.toml carries model/hooks/marketplaces/projects,
+    // not API keys (the model_provider credential lives outside ~/.trae); and
+    // ~/.trae is already global-shared across traex bots, so this widens no
+    // cross-bot boundary.
+    authPaths: ['~/.trae'],
     get resolvedBin(): string { return (cachedBin ??= resolveCommand(rawBin)); },
 
     buildArgs({ sessionId, resume, resumeSessionId, workingDir, model, disableCliBypass, bypassHookTrust, remoteWsUrl, remoteThreadId }) {

--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -194,8 +194,13 @@ function goalEnvConfigArgs(env: NodeJS.ProcessEnv = process.env): string[] {
  *
  *  · .coco-rollouts-migrated  → gates the "recent SESSIONS" prompt (the wedge)
  *  · .coco-migrated           → gates the config-migration prompt (defence in depth)
- * Both are dirt-cheap read-only single-file binds; missing ones are dropped by
- * the worker's existence filter (keepExisting), so a host without them is fine.
+ * Both are dirt-cheap read-only single-file binds; a marker absent on this host is
+ * dropped by the worker's existence filter (keepExisting) so it can't cause a bind
+ * FAILURE — but note that is not the same as "goal-mode is fine": if the migration
+ * SOURCE (~/.cache/coco) exists while the marker is genuinely missing, the prompt
+ * legitimately fires. In practice the markers are written host-side once migration
+ * has run (the normal fleet state); this bind just makes that host truth visible
+ * through the sandbox instead of hidden behind the ~/.trae/cli-only carve-out.
  */
 export const TRAE_MIGRATION_DONE_MARKERS = [
   '~/.trae/.coco-rollouts-migrated',

--- a/src/adapters/cli/types.ts
+++ b/src/adapters/cli/types.ts
@@ -422,6 +422,17 @@ export interface CliAdapter {
    *  Missing/empty → no extra re-expose. */
   sandboxExtraExecPaths?(): readonly string[];
 
+  /** Absolute paths (files or dirs) this adapter needs visible READ-ONLY inside
+   *  the file sandbox — distinct from `authPaths`, which are bound READ-WRITE.
+   *  Use this for host state the CLI only READS (e.g. traex/coco's first-run
+   *  migration done-markers at the ~/.trae root): exposing them read-only lets
+   *  the CLI see them without widening the writable surface to sibling
+   *  hook/plugin/skill code. Wired into the fs-policy `readonlyRoots` channel
+   *  (→ readOnly rule). `~`-expanded + existence-filtered by the worker, so
+   *  listing a path absent on this host is a no-op. Missing/empty → nothing extra
+   *  exposed. Return ONLY paths safe to reveal read-only (never credentials). */
+  sandboxReadonlyPaths?(): readonly string[];
+
   /** Extra env merged into the spawned child's environment. Used by Claude-family
    *  forks to point the CLI at its data root (e.g. Seed's `CLAUDE_CONFIG_DIR`).
    *  Keys placed here are also forwarded through the tmux backend (see

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8928,6 +8928,11 @@ async function spawnCli(
       readonlyRoots: keepExisting([
         ...(cfg.skillReadonlyRoots ?? []),
         ...piInitialPromptReadonlyRoots,
+        // Adapter-declared read-only host paths (e.g. traex/coco first-run
+        // migration done-markers at ~/.trae root). Exposed read-only so the CLI
+        // sees them without widening the read-WRITE authPaths surface. `~`-expanded
+        // here; keepExisting drops any absent on this host.
+        ...[...(cliAdapter.sandboxReadonlyPaths?.() ?? [])].map(expandTildeLexical),
       ]),
       botmuxInstallRoot,
       outbox,

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -2103,16 +2103,26 @@ describe('kiro-cli buildArgs', () => {
 });
 
 describe('traex/coco sandbox authPaths', () => {
-  it('traex keeps the whole ~/.trae/cli real in the sandbox (codex-based, same SQLite lock hazard)', () => {
+  it('traex keeps the whole ~/.trae real in the sandbox (SQLite state + first-run migration markers)', () => {
     // traex keeps codex-style state_*.sqlite / logs_*.sqlite + rollout sessions
-    // under ~/.trae/cli; the daemon bridge reads them at the REAL path, and the
-    // overlayfs home lacks the fcntl locks SQLite needs (see codex.ts).
+    // under ~/.trae/cli (fresh-tmpfs sandbox lacks the fcntl locks SQLite needs;
+    // see codex.ts), AND reads first-run state at the ~/.trae ROOT: the coco
+    // legacy-migration done-markers (.coco-migrated / .coco-migration-skip-all),
+    // traecli.toml, installation_id. Binding only cli/ hid those, so a sandboxed
+    // goal-mode pane saw the migration SOURCE (~/.cache/coco, bound) but not the
+    // done-marker → the TUI wedged on an interactive "Legacy TRAE CLI data
+    // detected" prompt with no human at the PTY. Whole-dir bind mirrors codex.ts's
+    // ~/.codex. Regression guard: narrowing back to ~/.trae/cli reintroduces the
+    // wedge.
     const adapter = createTraexAdapter('/bin/traex');
-    expect(adapter.authPaths).toEqual(['~/.trae/cli']);
+    expect(adapter.authPaths).toEqual(['~/.trae']);
   });
 
-  it('coco keeps ~/.trae/cli (shared trae state/SQLite) AND ~/.cache/coco (transcripts the bridge reads) real', () => {
+  it('coco keeps the whole ~/.trae (shared trae state/SQLite + migration markers) AND ~/.cache/coco (transcripts the bridge reads) real', () => {
+    // Coco runs the same traecli binary as traex, so it needs the same ~/.trae
+    // ROOT state (migration done-markers etc.) visible or it wedges on the coco
+    // migration prompt; ~/.cache/coco stays bound for the transcript bridge.
     const adapter = createCocoAdapter('/bin/coco');
-    expect(adapter.authPaths).toEqual(['~/.trae/cli', '~/.cache/coco']);
+    expect(adapter.authPaths).toEqual(['~/.trae', '~/.cache/coco']);
   });
 });

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -2103,26 +2103,29 @@ describe('kiro-cli buildArgs', () => {
 });
 
 describe('traex/coco sandbox authPaths', () => {
-  it('traex keeps the whole ~/.trae real in the sandbox (SQLite state + first-run migration markers)', () => {
-    // traex keeps codex-style state_*.sqlite / logs_*.sqlite + rollout sessions
-    // under ~/.trae/cli (fresh-tmpfs sandbox lacks the fcntl locks SQLite needs;
-    // see codex.ts), AND reads first-run state at the ~/.trae ROOT: the coco
-    // legacy-migration done-markers (.coco-migrated / .coco-migration-skip-all),
-    // traecli.toml, installation_id. Binding only cli/ hid those, so a sandboxed
-    // goal-mode pane saw the migration SOURCE (~/.cache/coco, bound) but not the
-    // done-marker → the TUI wedged on an interactive "Legacy TRAE CLI data
-    // detected" prompt with no human at the PTY. Whole-dir bind mirrors codex.ts's
-    // ~/.codex. Regression guard: narrowing back to ~/.trae/cli reintroduces the
-    // wedge.
+  it('traex keeps ~/.trae/cli real (RW SQLite state) and exposes migration markers READ-ONLY (not the whole ~/.trae)', () => {
+    // authPaths (readWrite) stays scoped to cli/ — widening to the whole ~/.trae
+    // would give a chat-driven sandbox RW to sibling hooks/plugins/skills/config
+    // that other bots execute. The first-run "Legacy TRAE CLI data detected"
+    // migration prompt (which wedges goal-mode's human-less PTY) is instead
+    // silenced by exposing the done-markers READ-ONLY via sandboxReadonlyPaths.
     const adapter = createTraexAdapter('/bin/traex');
-    expect(adapter.authPaths).toEqual(['~/.trae']);
+    expect(adapter.authPaths).toEqual(['~/.trae/cli']);
+    expect(adapter.sandboxReadonlyPaths?.()).toEqual([
+      '~/.trae/.coco-rollouts-migrated',
+      '~/.trae/.coco-migrated',
+    ]);
   });
 
-  it('coco keeps the whole ~/.trae (shared trae state/SQLite + migration markers) AND ~/.cache/coco (transcripts the bridge reads) real', () => {
-    // Coco runs the same traecli binary as traex, so it needs the same ~/.trae
-    // ROOT state (migration done-markers etc.) visible or it wedges on the coco
-    // migration prompt; ~/.cache/coco stays bound for the transcript bridge.
+  it('coco keeps ~/.trae/cli + ~/.cache/coco real (RW) and exposes the same migration markers READ-ONLY', () => {
+    // Coco runs the same traecli binary as traex → same migration prompt; markers
+    // exposed read-only, authPaths NOT widened past cli/ (+ the coco cache the
+    // transcript bridge reads).
     const adapter = createCocoAdapter('/bin/coco');
-    expect(adapter.authPaths).toEqual(['~/.trae', '~/.cache/coco']);
+    expect(adapter.authPaths).toEqual(['~/.trae/cli', '~/.cache/coco']);
+    expect(adapter.sandboxReadonlyPaths?.()).toEqual([
+      '~/.trae/.coco-rollouts-migrated',
+      '~/.trae/.coco-migrated',
+    ]);
   });
 });

--- a/test/fs-policy.test.ts
+++ b/test/fs-policy.test.ts
@@ -118,6 +118,30 @@ describe('buildFsPolicy', () => {
     expect(accessForPath(p.rules, '/Users/u/other-project/secret').access).toBe('none');
   });
 
+  it('readonlyRoots (traex/coco migration markers) expose the marker READ-ONLY without making sibling ~/.trae code writable', () => {
+    // Regression for the traex/coco goal-mode wedge: the first-run migration
+    // prompt is silenced by making ~/.trae/.coco-rollouts-migrated visible, but
+    // via the readOnly channel — NOT by widening authPaths to the whole ~/.trae
+    // (that root holds hooks/plugins/skills/traecli.toml, which authPaths would
+    // bind readWrite and let a chat-driven sandbox mutate code other bots run).
+    const p = buildFsPolicy(ctx({
+      platform: 'linux', homeDir: '/home/u', botHome: '/home/u/.botmux/bots/cli_self',
+      botmuxHome: '/home/u/.botmux', sessionDataDir: '/home/u/.botmux/data', workingDir: '/home/u/proj',
+      authPaths: ['/home/u/.trae/cli'],
+      readonlyRoots: ['/home/u/.trae/.coco-rollouts-migrated', '/home/u/.trae/.coco-migrated'],
+    }));
+    // markers visible read-only (mere existence gates the traecli prompt)
+    expect(accessForPath(p.rules, '/home/u/.trae/.coco-rollouts-migrated').access).toBe('readOnly');
+    expect(accessForPath(p.rules, '/home/u/.trae/.coco-migrated').access).toBe('readOnly');
+    // cli/ stays readWrite (SQLite state/log DBs)
+    expect(accessForPath(p.rules, '/home/u/.trae/cli/state_x.sqlite').access).toBe('readWrite');
+    // sibling executable/config surface stays UNwritable (deny-by-default 'none')
+    expect(accessForPath(p.rules, '/home/u/.trae/hooks/hooks.json').access).toBe('none');
+    expect(accessForPath(p.rules, '/home/u/.trae/plugins/p/hooks.json').access).toBe('none');
+    expect(accessForPath(p.rules, '/home/u/.trae/skills/s/skill.md').access).toBe('none');
+    expect(accessForPath(p.rules, '/home/u/.trae/traecli.toml').access).toBe('none');
+  });
+
   it('language toolchains under $HOME are readable so python/perl/rust/go/etc. run; their credential files stay denied', () => {
     const p = buildFsPolicy(ctx({ platform: 'linux', homeDir: '/home/u', botHome: '/home/u/.botmux/bots/cli_self', botmuxHome: '/home/u/.botmux', sessionDataDir: '/home/u/.botmux/data', workingDir: '/home/u/proj' }));
     // toolchains runnable (readOnly)

--- a/test/read-isolation.test.ts
+++ b/test/read-isolation.test.ts
@@ -201,6 +201,7 @@ describe('isolatedPaneReattachSafe', () => {
   });
 });
 
+<<<<<<< HEAD
 // ─── cold-start migration: START-TIME env contract (bots.json EPERM fix) ──────
 
 /**
@@ -237,6 +238,39 @@ describe('isolatedPaneReattachSafe — start-time contract bump forces cold resp
     // lack BOTMUX_READ_ISOLATION. Anything ≥ 8 is fine; reverting to ≤ 7 would
     // silently warm-reattach those broken panes.
     expect(ISOLATION_PANE_MARKER_VERSION).toBeGreaterThan(7);
+  });
+});
+
+// ─── #714: new spawn-time sandbox mount (traex/coco migration markers) ────────
+
+/**
+ * Regression guard. #714 adds a new spawn-time bwrap mount (traex/coco's
+ * read-only migration done-markers via sandboxReadonlyPaths). A warm reattach
+ * keeps the live process + its ORIGINAL mount set, so a pane spawned before this
+ * change would reattach without the marker mount and keep wedging on the TRAE
+ * migration prompt. The marker version is the only lever that turns such a pane
+ * into kill + cold-spawn, so bumping past the pre-#714 versions is load-bearing.
+ *
+ * Ordering note: #709 took 8 (env contract); #714 takes 9. Both prior versions
+ * must be rejected. If the merge order flips, rebase so this stays monotonic.
+ */
+describe('isolatedPaneReattachSafe — #714 mount contract forces cold respawn of pre-9 panes', () => {
+  const full = ['credential', 'read', 'write'] as const;
+  for (const v of [7, 8]) {
+    it(`rejects a v${v} pane even with full capabilities (its bwrap lacks the marker mount)`, () => {
+      const marker = JSON.stringify({ version: v, bootId: `pre-714-v${v}`, capabilities: [...full] });
+      expect(isolatedPaneReattachSafe(marker, ['read', 'write'])).toBe(false);
+    });
+  }
+
+  it('accepts a pane stamped with the current version', () => {
+    expect(isolatedPaneReattachSafe(isolationPaneMarkerContent('fresh', [...full]), ['read', 'write'])).toBe(true);
+  });
+
+  it('has moved the version past 8 (the #709 env-contract version)', () => {
+    // Reverting below 9 would silently warm-reattach panes that predate the
+    // migration-marker mount. ≥ 9 is required.
+    expect(ISOLATION_PANE_MARKER_VERSION).toBeGreaterThan(8);
   });
 });
 

--- a/test/read-isolation.test.ts
+++ b/test/read-isolation.test.ts
@@ -201,7 +201,6 @@ describe('isolatedPaneReattachSafe', () => {
   });
 });
 
-<<<<<<< HEAD
 // ─── cold-start migration: START-TIME env contract (bots.json EPERM fix) ──────
 
 /**
@@ -318,6 +317,16 @@ describe('worker capability carve-out ordering', () => {
     expect(source).not.toContain(
       'cfg.skillReadonlyRoots = [...(cfg.skillReadonlyRoots ?? []), ...prepared.readonlyRoots]',
     );
+  });
+
+  it('wires adapter sandboxReadonlyPaths() into the readonlyRoots channel (traex/coco migration markers)', () => {
+    // Guards a call-site blind spot: the adapter test only checks the method's
+    // RETURN value and the fs-policy test hand-feeds readonlyRoots, so if this
+    // spread were deleted the markers would silently stop reaching the sandbox
+    // and BOTH of those tests would stay green (goal-mode traex would wedge again
+    // on the migration prompt). Assert the worker actually threads the method
+    // output into readonlyRoots.
+    expect(source).toContain('...[...(cliAdapter.sandboxReadonlyPaths?.() ?? [])].map(expandTildeLexical),');
   });
 
   it('enforces the mandatory credential gate before adopt and wraps wrapperCli from the outside', () => {


### PR DESCRIPTION
## 症状
沙盒(`sandbox:true`)的 **traex / coco** bot 在 goal-mode 冷启动后卡死在交互弹窗：

```
Legacy TRAE CLI data detected
Would you like to migrate detected data to the new TRAE CLI storage?
  Migrate recent sessions from /root/.cache/coco/sessions to /root/.trae…
```

goal-mode pane 背后没有真人在 PTY，弹窗永远等不到答复 → 会话 wedge，bot 跑不起来。（申晗 2026-08-03 拿 Traex 实测撞到。）

## 根因（子代理真机 node-pty 复现确认）
traecli 判断迁移是否完成读 `~/.trae` **根目录**下的 done-marker。沙盒 `authPaths` 只 bind `~/.trae/cli` 子目录 → 迁移 SOURCE `~/.cache/coco`（baseline rw bind）可见，但 done-marker（根目录）不可见 → traecli 判"待迁移" → 弹窗。coco 与 traex 是同一 traecli 二进制（软链），同坑。

精确事实（纠正初版 PR 的误判）：
- 门控 **session 迁移弹窗**（本次 wedge）的是 `.coco-rollouts-migrated`，**不是** `.coco-migrated`（后者门控 config 迁移）
- traecli 只看 marker **是否存在**（0 字节 + `chmod 444` 即可），内容/可写性无关
- `DISABLE_ACTIVE_MIGRATION` 是 QUIC/OpenSSL 传输参数（RFC 9000），与迁移无关；env / `-c disable_active_migration` 均无效

## 改法（v2：codex 复审后收窄）
初版把 `authPaths` 扩到整个 `~/.trae` —— codex 正确指出 `authPaths` 编译成 **readWrite**（`fs-policy.ts:533`），会把 `~/.trae` 根下 hooks//plugins/（command hook，后续 CoCo 会话都加载）/skills//traecli.toml 全部 RW 暴露给受聊天输入驱动的沙盒 = 跨 bot / 出沙盒完整性边界扩大；且 codex.ts 的 `~/.codex` 整目录 bind 类比不成立（codex 有 `supportsReadIsolation`，沙盒下宿主根被丢弃；traex/coco 没有）。

**收窄为只读暴露 marker，不碰 authPaths 的 RW 面**：
- 新增 adapter 可选方法 `sandboxReadonlyPaths()`（`types.ts`，镜像 `sandboxExtraExecPaths`），worker 接进 fs-policy 的 `readonlyRoots` 通道（→ readOnly 规则 + 存在性过滤）
- traex/coco 的 `authPaths` **还原**成 `~/.trae/cli`（+ coco 的 `~/.cache/coco`），改由 `sandboxReadonlyPaths()` 只读暴露两个 marker：`.coco-rollouts-migrated`（本次）+ `.coco-migrated`（纵深）
- 策略级验证：marker→readOnly、`cli/`→readWrite、hooks//plugins//traecli.toml→none（**不可写**）

## P1b：marker version bump（存量 pane 冷启动迁移）
`sandboxReadonlyPaths` 是新的 spawn-time bwrap mount；warm reattach 保留旧进程+旧 mount，存量 v3.8 pane 会 reattach 且仍缺 marker mount、继续卡。bump `ISOLATION_PANE_MARKER_VERSION` → 强制冷启动。**与 #709 排序**：#709(→8 env 契约) 与 #714(→9 mount 契约) 独立；本 PR 取 9 假设 #709 先合占 8，顺序反了则后合者 rebase 保持单调（注释已写明）。

## 验证
- build 绿；cli-adapters 313 + fs-policy 66(+1) + read-isolation(+#714 块) + sandbox 16 + child-env = **444 全绿**
- 变异有牙：marker 9→8 → #714 reattach 块红；authPaths 改回 `~/.trae` → fs-policy「sibling 不可写」断言红
- **真机 live**：部署后触发沙盒 Traex 冷启动，bwrap cmdline 实测含 `--ro-bind /root/.trae/.coco-rollouts-migrated` + `.coco-migrated`（只读）、`--bind /root/.trae/cli`（RW），**无**整目录 `~/.trae` / hooks / plugins bind；之前每次都卡弹窗的 pane 现在冷启动到正常 `❯` 提示，wedge 消失。测完已恢复 daemon 到原 checkout。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>