### PR TITLE
fix(dashboard): 修复消息监听「发送者过滤」列表在矮视口塌缩滚不动

### DIFF
--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -7429,7 +7429,13 @@ dialog.onboarding-dialog::backdrop {
 .roles-listener-members {
   display: flex;
   flex-direction: column;
-  min-height: 0;
+  /* Do not let this box shrink: it is a flex child of the listener editor and
+     the whole form (.roles-editor-form) is the scroll container. With the old
+     `min-height:0` it collapsed to ~0 on shorter viewports (≲800px tall) and,
+     combined with `overflow:hidden`, clipped the member rows entirely — the
+     picker looked empty and the wheel had nothing to reveal. Keeping its full
+     content height lets the form overflow and scroll normally. */
+  flex-shrink: 0;
   border: 1px solid var(--border-soft);
   border-radius: var(--radius-lg);
   overflow: hidden;


### PR DESCRIPTION
## 问题
消息监听配置页(角色管理 → 按群组 → 选群选 Bot → 「消息监听」页签)底部的「发送者过滤」成员/机器人列表,在浏览器视口高度偏矮(≲800px)时**看着是空的、鼠标滚轮也滚不到**。申晗 live 实测撞到,一度误以为是「没有可选项」。

## 根因
`.roles-listener-members`(列表框)是监听编辑器 flex 列布局里的可收缩子元素,带 `min-height:0` + `overflow:hidden`。矮视口下 flex 算法把它压成 ~2px 高,叠加 `overflow:hidden` 直接把成员行裁掉——列表没高度,滚轮滚过去也无内容可露。外层 `.roles-editor-form`(overflow-y:auto)本应是滚动容器,但框本身塌缩就露不出行。

## 修复
`min-height:0` → `flex-shrink:0`,不让该框被压缩,滚动交给外层表单容器。一行 CSS。

## 影响面
- 纯前端 CSS(`src/dashboard/web/style.css` 一处 `.roles-listener-members` 规则),不碰任何 TS/后端/其它 CLI/会话类型。
- dashboard 静态资源热更(`dashboard:bundle`)即生效,无需重启 daemon。
- 不影响高视口下的表现(高视口本就不塌缩)。

## 验证
agent-browser 真实浏览器 @ 1280×720 视口(同 bot 同群 live 复现):
- 修前:`.roles-listener-members` clientHeight = **2px**,成员行排在 y≈900(屏幕外),滚轮无效。
- 修后:框高 **2px→329px**,外层表单可滚范围 **320→647px**,申晗/施亚晖两行成员都能滚到并可见。
- 顺带验证完整流程:点某行「监听」→ 红字「至少选择一个发送者」消失 → 保存按钮从禁用变可点。

> 临时 workaround(无需改代码):浏览器 Ctrl+-(⌘-)缩小到 80%/67%,视口等效变高,列表框即撑开。