### PR TITLE
fix(aiden): aiden x codex 不再重复透传 --dangerously-bypass-hook-trust（启动即挂）

### DIFF
--- a/src/setup/cli-selection.ts
+++ b/src/setup/cli-selection.ts
@@ -235,7 +235,9 @@ export function parseWrapperCli(wrapperCli: string): string[] {
 
 /** wrapper 前缀首 token 是否为 aiden 网关（`aiden x <cli>`）。aiden 会拦截底层 CLI
  *  的 config 透传参数——`aiden x claude` 拒收 `--settings`、`aiden x codex` 自 1.8.38
- *  起直接报错拒收 `-c`——故转发前要剥掉 botmux 注入的那部分（见 {@link stripWrapperUnsafeArgs}）。 */
+ *  起直接报错拒收 `-c`；此外 aiden 自身已注入 codex 的 `--dangerously-bypass-hook-trust`，
+ *  botmux 再透传一份会让 codex 收到两次而报错——故转发前要剥掉这几项 botmux 注入的参数
+ *  （见 {@link stripWrapperUnsafeArgs}）。 */
 function isAidenWrapper(tokens: ReadonlyArray<string>): boolean {
   return tokens[0] === 'aiden';
 }
@@ -278,6 +280,11 @@ export function stripSettingsArgs(args: ReadonlyArray<string>): string[] {
  *   - `--settings <v>` / `--settings=<v>`（claude 携带 hook/bypass，aiden x claude 历来就剥）
  *   - botmux 自己注入的 Codex `-c`（session 环境，以及关闭启动更新选择器）；
  *     aiden 1.8.38+ 会直接报错拒收 `aiden x codex` 透传的 `-c`/`--config`。
+ *   - `--dangerously-bypass-hook-trust`（codex 家族的 hook-trust 绕过 flag）：aiden 网关
+ *     自身已管理底层 codex 的 hook-trust，botmux 再透传一份会让 codex 收到两次 →
+ *     `error: the argument '--dangerously-bypass-hook-trust' cannot be used multiple times`
+ *     直接启动失败。故经 aiden 网关时一律剥掉这份冗余副本（bare flag，无值）；aiden x claude
+ *     路径底层 claude 从不注入此 flag，剥除是 no-op。
  * 这些参数承载的 session 环境已在进程级 env（BOTMUX_SESSION_ID 等）注入、并被 wrapper
  * 子进程继承（见 worker.ts childEnv），故剥掉只是去掉一条冗余的 belt-and-suspenders
  * 通道，不丢功能。关闭启动更新的覆盖在 aiden 路径无法传递（launcher 本身禁止 config）；
@@ -301,6 +308,9 @@ export function stripWrapperUnsafeArgs(args: ReadonlyArray<string>): string[] {
   for (let i = 0; i < afterSettings.length; i++) {
     const a = afterSettings[i]!;
     if (a === '-c' && isBotmuxCodexConfigValue(afterSettings[i + 1])) { i++; continue; }
+    // aiden 网关自身已管理底层 codex 的 hook-trust；再透传 botmux 注入的这份
+    // 会让 codex 收到两次 → clap 报 "cannot be used multiple times" 启动失败。
+    if (a === '--dangerously-bypass-hook-trust') continue;
     out.push(a);
   }
   return out;

--- a/test/cli-selection.test.ts
+++ b/test/cli-selection.test.ts
@@ -245,6 +245,18 @@ describe('stripWrapperUnsafeArgs', () => {
     ])).toEqual(['--session-id', 'x', '--model', 'm']);
   });
 
+  // Regression: aiden's own launcher injects codex's --dangerously-bypass-hook-trust,
+  // so botmux passing it too made codex's clap see it twice → "cannot be used multiple
+  // times" and spawn aborted. Strip botmux's redundant copy for aiden wrappers.
+  it('strips the codex --dangerously-bypass-hook-trust flag (aiden injects its own)', () => {
+    expect(stripWrapperUnsafeArgs([
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--dangerously-bypass-hook-trust',
+      '--no-alt-screen',
+      '--model', 'm',
+    ])).toEqual(['--dangerously-bypass-approvals-and-sandbox', '--no-alt-screen', '--model', 'm']);
+  });
+
   it('leaves args untouched when nothing is unsafe', () => {
     expect(stripWrapperUnsafeArgs(['resume', 'cid', '--model', 'm'])).toEqual(['resume', 'cid', '--model', 'm']);
   });
@@ -307,6 +319,33 @@ describe('buildWrappedLaunch', () => {
   it('does not strip a user-supplied -c that is not a botmux override (aiden x codex)', () => {
     const out = buildWrappedLaunch('aiden x codex', ['-c', 'model_reasoning_effort="high"', '--model', 'm']);
     expect(out.args).toEqual(['x', 'codex', '-c', 'model_reasoning_effort="high"', '--model', 'm']);
+  });
+
+  // Regression: aiden's launcher injects codex's --dangerously-bypass-hook-trust itself,
+  // so botmux's copy (codex.ts buildArgs, gated by bypassCodexHookTrust) reaching the
+  // launcher made codex see the flag twice → `error: the argument
+  // '--dangerously-bypass-hook-trust' cannot be used multiple times` and spawn aborted.
+  // The approval/sandbox bypass is a distinct flag aiden does NOT inject → kept.
+  it('strips the codex --dangerously-bypass-hook-trust for aiden x codex (aiden injects its own)', () => {
+    const out = buildWrappedLaunch('aiden x codex', [
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--dangerously-bypass-hook-trust',
+      '--no-alt-screen',
+      '-c',
+      'shell_environment_policy.set.BOTMUX_SESSION_ID="sess-4"',
+      '-C',
+      '/repo',
+    ]);
+    expect(out.bin).toBe('aiden');
+    expect(out.args).toEqual([
+      'x',
+      'codex',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--no-alt-screen',
+      '-C',
+      '/repo',
+    ]);
+    expect(out.args).not.toContain('--dangerously-bypass-hook-trust');
   });
 
   // Regression (only reproduces on cjadk codex): cjadk's `code` subcommand defines


### PR DESCRIPTION
## 问题

`aiden x codex` 会话启动即挂，报：

```
error: the argument '--dangerously-bypass-hook-trust' cannot be used multiple times
```

## 根因

- `aiden x codex` 是 wrapperCli，底层 `cliId=codex`。codex 适配器 `buildArgs` 会注入 `--dangerously-bypass-hook-trust`（受全局开关「自动信任 Codex Hook」`bypassCodexHookTrust` 控制，默认开）。
- **aiden 网关自身也会**给底层 codex 注入同一个 flag。
- 转发时走 `stripWrapperUnsafeArgs`，它只剥了 aiden 拒收的 `--settings`（claude 侧）和 botmux 注入的 codex `-c` override，**没剥这个 flag** → codex 收到两份 → clap 报错、进程直接退出。

botmux 全仓只在 `codex.ts:190` 注入这一份（`traex.ts` 那份走的是 traex，不经 aiden），第二份确定来自 aiden launcher。

## 修法

在同一个 choke point `stripWrapperUnsafeArgs`（就是当初剥 aiden 拒收 `-c` 的地方）对 aiden 网关额外剥掉 botmux 注入的这份 `--dangerously-bypass-hook-trust`（aiden 自己那份保留，语义不变）。保持 codex 适配器 wrapper-无关；一处改动同时覆盖 `buildWrappedLaunch` 的三个调用点：spawn、reproduce-command、本地终端。

## 影响面

- **只作用于 aiden 网关**（`buildWrappedLaunch` 里 cjadk 走 rewrite、ttadk 走自己分支、plain 原样透传，都不进此函数）。
- `aiden x claude`：底层 claude-code 从不注入此 flag → 剥除是 no-op。
- 直连 codex / cjadk codex / ttadk / traex：不走这条路径，仍是单份 flag，无回归。
- 关掉「自动信任 Codex Hook」或受限 bot（`disableCliBypass`）：codex 侧本就不注入，剥除是空操作。

## 验证

- `pnpm build` 绿
- `test/cli-selection.test.ts` 73 项全过（新增 2 项回归：`stripWrapperUnsafeArgs` 单元 + `buildWrappedLaunch` 端到端）
- 已用 `git stash` 验证：去掉本修复，新增 2 项回归必挂 → 确实守住了这个 bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)