### PR TITLE
fix(token-usage): 修复 Pi 会话 token 入账

### DIFF
--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -153,7 +153,7 @@ interface TokenUsageAggregate {
 
 /** Per-CLI transcript dialect. Each kind only counts the events that dialect
  *  defines as billable turns — no cross-CLI guessing on usage-shaped lines. */
-type UsageKind = 'claude' | 'codex' | 'coco' | 'generic';
+type UsageKind = 'claude' | 'codex' | 'coco' | 'pi' | 'generic';
 
 function usageKindForCli(cliId: SessionTokenUsageQuery['cliId']): UsageKind {
   switch (cliId) {
@@ -171,6 +171,8 @@ function usageKindForCli(cliId: SessionTokenUsageQuery['cliId']): UsageKind {
       return 'codex';
     case 'coco':
       return 'coco';
+    case 'pi':
+      return 'pi';
     default:
       return 'generic';
   }
@@ -231,6 +233,24 @@ function foldCocoLine(agg: TokenUsageAggregate, entry: any): void {
   agg.turns++;
 }
 
+function foldPiLine(agg: TokenUsageAggregate, seenMessageIds: Set<string>, entry: any): void {
+  if (entry?.type !== 'message' || entry?.message?.role !== 'assistant') return;
+  const msg = entry.message;
+  const u = msg.usage;
+  if (!u || typeof u !== 'object') return;
+  const messageId = typeof msg.id === 'string' ? msg.id : '';
+  if (messageId) {
+    if (seenMessageIds.has(messageId)) return;
+    seenMessageIds.add(messageId);
+  }
+  agg.inputTokens += num(u.input);
+  agg.outputTokens += num(u.output);
+  agg.cacheReadTokens += num(u.cacheRead);
+  agg.cacheCreateTokens += num(u.cacheWrite);
+  if (!agg.model && typeof msg.model === 'string') agg.model = msg.model;
+  agg.turns++;
+}
+
 /** Cursor / TraeX / Antigravity: transcripts whose exact dialect is not yet
  *  pinned down — keep the tolerant multi-shape extraction for them. */
 function foldGenericLine(agg: TokenUsageAggregate, seenMessageIds: Set<string>, entry: any): void {
@@ -263,6 +283,8 @@ function foldUsageLine(kind: UsageKind, agg: TokenUsageAggregate, seenMessageIds
       return foldCodexLine(agg, entry);
     case 'coco':
       return foldCocoLine(agg, entry);
+    case 'pi':
+      return foldPiLine(agg, seenMessageIds, entry);
     case 'generic':
       return foldGenericLine(agg, seenMessageIds, entry);
   }

--- a/src/services/transcript-resolver.ts
+++ b/src/services/transcript-resolver.ts
@@ -8,8 +8,9 @@ import { findCodexRolloutBySessionId, findCodexSessionIdByBotmuxSessionId } from
 import { cocoEventsPathForSession } from './coco-transcript.js';
 import { findCursorTranscriptByChatId } from './cursor-transcript.js';
 import { findTraexRolloutBySessionId } from './traex-transcript.js';
+import { findPiTranscriptBySessionId } from './pi-transcript.js';
 
-export type TranscriptKind = 'claude' | 'codex' | 'coco' | 'cursor' | 'traex' | 'antigravity';
+export type TranscriptKind = 'claude' | 'codex' | 'coco' | 'cursor' | 'traex' | 'pi' | 'antigravity';
 
 export interface TranscriptPathQuery {
   cliId?: CliId | 'unknown';
@@ -130,6 +131,10 @@ export function resolveSessionTranscriptPath(q: TranscriptPathQuery): ResolvedTr
     case 'traex': {
       const path = cachedTranscriptPathLookup(`traex:${sid}`, null, () => findTraexRolloutBySessionId(sid) ?? null, { retryMiss: q.fresh });
       return path ? { path, kind: 'traex' } : null;
+    }
+    case 'pi': {
+      const path = cachedTranscriptPathLookup(`pi:${sid}:${q.cwd ?? ''}`, null, () => findPiTranscriptBySessionId(sid, q.cwd) ?? null, { retryMiss: q.fresh });
+      return path ? { path, kind: 'pi' } : null;
     }
     case 'antigravity': {
       // Validate the CLI session id before interpolating it into a path (every

--- a/test/cost-calculator.test.ts
+++ b/test/cost-calculator.test.ts
@@ -43,6 +43,10 @@ vi.mock('../src/services/traex-transcript.js', () => ({
   findTraexRolloutBySessionId: vi.fn(() => undefined),
 }));
 
+vi.mock('../src/services/pi-transcript.js', () => ({
+  findPiTranscriptBySessionId: vi.fn(() => undefined),
+}));
+
 vi.mock('../src/services/aiden-checkpoints.js', () => ({
   findAidenLatestCheckpointBySessionId: vi.fn(() => undefined),
   findAidenLatestCheckpointByBotmuxSessionId: vi.fn(() => undefined),
@@ -78,6 +82,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { findAidenLatestCheckpointByBotmuxSessionId, findAidenLatestCheckpointBySessionId } from '../src/services/aiden-checkpoints.js';
 import { findCodexRolloutBySessionId, findCodexSessionIdByBotmuxSessionId } from '../src/services/codex-transcript.js';
 import { findTraexRolloutBySessionId } from '../src/services/traex-transcript.js';
+import { findPiTranscriptBySessionId } from '../src/services/pi-transcript.js';
 import {
   getSessionJsonlPath,
   getSessionCost,
@@ -128,6 +133,8 @@ beforeEach(() => {
   vi.mocked(findCodexSessionIdByBotmuxSessionId).mockReturnValue(undefined);
   vi.mocked(findTraexRolloutBySessionId).mockReset();
   vi.mocked(findTraexRolloutBySessionId).mockReturnValue(undefined);
+  vi.mocked(findPiTranscriptBySessionId).mockReset();
+  vi.mocked(findPiTranscriptBySessionId).mockReturnValue(undefined);
   vi.mocked(findAidenLatestCheckpointBySessionId).mockReset();
   vi.mocked(findAidenLatestCheckpointBySessionId).mockReturnValue(undefined);
   vi.mocked(findAidenLatestCheckpointByBotmuxSessionId).mockReset();
@@ -568,6 +575,42 @@ describe('getSessionTokenUsage', () => {
       cacheCreateTokens: 5,
     });
     expect(usage!.inputTokens + usage!.cacheReadTokens + usage!.cacheCreateTokens).toBe(usage!.in);
+  });
+
+  it('reports Pi transcript usage in uncached and cache buckets', () => {
+    vi.mocked(findPiTranscriptBySessionId).mockReturnValue('/home/testuser/.pi/agent/sessions/--tmp/2026-08-03_pi-sid.jsonl');
+    setupJsonl(JSON.stringify({
+      type: 'message',
+      message: {
+        id: 'pi-msg-1',
+        role: 'assistant',
+        model: 'claude-sonnet-4-20250514',
+        usage: {
+          input: 100,
+          output: 20,
+          cacheRead: 30,
+          cacheWrite: 10,
+          totalTokens: 160,
+        },
+      },
+    }));
+
+    expect(getSessionTokenUsage({
+      cliId: 'pi',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'pi-sid',
+      cwd: '/tmp',
+    })).toEqual({
+      in: 140,
+      out: 20,
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 30,
+      cacheCreateTokens: 10,
+      turns: 1,
+      model: 'claude-sonnet-4-20250514',
+    });
+    expect(findPiTranscriptBySessionId).toHaveBeenCalledWith('pi-sid', '/tmp');
   });
 
   it('reports CoCo nested response_meta usage without counting agent_end duplicates', () => {


### PR DESCRIPTION
## Summary
- 为 Pi session 接入 transcript resolver，并通过独立 dialect 读取 assistant message 的 `input`、`output`、`cacheRead` 与 `cacheWrite`。
- 将 Pi usage 映射为 ledger 的未缓存输入、输出、缓存命中和缓存创建 bucket，避免影响其它 CLI 的 generic 解析。
- 增加 Pi token usage 回归测试，并以真实 Pi 会话验证 ledger 已正常写入。

## 影响范围
- 公共 usage resolver / calculator 新增 Pi 专用分支；Claude、Codex、CoCo 和 generic 分支未修改。
- Pi session 的 Dashboard、流式卡和 usage ledger 从后续快照开始显示用量；历史未写入记录无法回补。

## Test plan
- [x] `pnpm vitest run test/cost-calculator.test.ts test/cost-calculator-cache.test.ts test/usage-ledger.test.ts`（89/89）
- [x] `pnpm build`
- [x] `pnpm switch:here && pnpm daemon:restart`
- [x] 真实 Pi session `6ffe0522…` 已写入两条 usage ledger 增量；累计值与 transcript 手工汇总一致
- [x] Codex 独立 review：可合入，无可复现问题

🤖 Generated with [Claude Code](https://claude.com/claude-code)