### PR TITLE
fix(dashboard): Web 详情未登录时支持一键登录

### DIFF
--- a/src/core/dashboard-url.ts
+++ b/src/core/dashboard-url.ts
@@ -1,4 +1,8 @@
-import { platformMachineBaseUrl, publicReverseProxyBaseUrl } from '../platform/binding.js';
+import {
+  platformMachineBaseUrl,
+  publicReverseProxyBaseUrl,
+  readPlatformBinding,
+} from '../platform/binding.js';
 import { isRemoteAccessEnabled } from '../global-config.js';
 
 export interface DashboardUrls {
@@ -62,4 +66,27 @@ export function buildDashboardUrls(opts: { host: string; port: number | string; 
 /** Convenience: just the primary dashboard URL (see {@link buildDashboardUrls}). */
 export function buildDashboardUrl(opts: { host: string; port: number | string; token?: string }): string {
   return buildDashboardUrls(opts).url;
+}
+
+/**
+ * Build the platform owner-login URL advertised by an unauthenticated
+ * Dashboard response. The SPA replaces only the hash-route `next` value, so
+ * the server never exposes the Dashboard token or machine tunnel credential.
+ */
+export function buildPlatformDashboardLoginUrl(): string | undefined {
+  if (!isRemoteAccessEnabled()) return undefined;
+  const binding = readPlatformBinding();
+  const machineId = binding?.machineId.trim();
+  if (!binding || !machineId) return undefined;
+  try {
+    const platform = new URL(binding.platformUrl);
+    if (!['http:', 'https:'].includes(platform.protocol) || platform.username || platform.password) {
+      return undefined;
+    }
+    const loginUrl = new URL(`/open/${encodeURIComponent(machineId)}`, platform);
+    loginUrl.searchParams.set('next', '/#/');
+    return loginUrl.toString();
+  } catch {
+    return undefined;
+  }
 }

--- a/src/core/dashboard-url.ts
+++ b/src/core/dashboard-url.ts
@@ -52,9 +52,7 @@ export function formatUrlHost(host: string): string {
  */
 export function buildDashboardUrls(opts: { host: string; port: number | string; token?: string }): DashboardUrls {
   const localOrigin = `http://${formatUrlHost(String(opts.host))}:${opts.port}`;
-  // 对外基址：中心平台优先（远程访问开 + 已绑定），否则自建反代基址 BOTMUX_PUBLIC_URL。
-  const platformBase = isRemoteAccessEnabled() ? platformMachineBaseUrl() : null;
-  const remoteBase = platformBase ?? publicReverseProxyBaseUrl();
+  const remoteBase = remotePublicBase();
   const primaryOrigin = remoteBase ?? localOrigin;
   const suffix = opts.token ? `/?t=${opts.token}` : '/';
   return {
@@ -66,6 +64,43 @@ export function buildDashboardUrls(opts: { host: string; port: number | string; 
 /** Convenience: just the primary dashboard URL (see {@link buildDashboardUrls}). */
 export function buildDashboardUrl(opts: { host: string; port: number | string; token?: string }): string {
   return buildDashboardUrls(opts).url;
+}
+
+/**
+ * The remote public base for dashboard-family links, or null when neither the
+ * central platform (远程访问 on + bound) nor a self-hosted reverse proxy
+ * (`BOTMUX_PUBLIC_URL`) applies — callers then fall back to local `host:port`.
+ * Single source for the platform/public flip shared by {@link buildDashboardUrls}
+ * and {@link buildV3RunDetailUrl}, so dashboard links and v3 card deep-links
+ * flip to the platform together under the one 远程访问 switch.
+ *
+ * 对外基址：中心平台优先（远程访问开 + 已绑定），否则自建反代基址 BOTMUX_PUBLIC_URL。
+ */
+function remotePublicBase(): string | null {
+  const platformBase = isRemoteAccessEnabled() ? platformMachineBaseUrl() : null;
+  return platformBase ?? publicReverseProxyBaseUrl();
+}
+
+/**
+ * Build the token-free deep link to a v3 run detail page (`…/#/v3/<runId>`),
+ * applying the same 远程访问 flip as {@link buildDashboardUrls}: central-platform
+ * machine subdomain first (远程访问 on + bound), then a self-hosted reverse proxy
+ * (`BOTMUX_PUBLIC_URL`), else the local `http://<externalHost>:<port>` form.
+ *
+ * Workflow / gate / blocked cards advertise this as「Web 详情（需登录）」. Routing it
+ * through the platform base is what lets a REMOTE recipient actually reach the
+ * SPA: the page then hits the same-origin management API, gets a 401 carrying
+ * `X-Botmux-Login-Url`, and offers the one-click platform owner login (see
+ * {@link buildPlatformDashboardLoginUrl}). The prior local-only form was
+ * unreachable off-LAN, so that login flow could never trigger for remote users.
+ *
+ * No token is appended: v3 run projections stay behind the dashboard auth gate
+ * and are reached only after the owner login sets the cookie. `runId` is
+ * URL-encoded.
+ */
+export function buildV3RunDetailUrl(runId: string, opts: { host: string; port: number | string }): string {
+  const origin = remotePublicBase() ?? `http://${formatUrlHost(String(opts.host))}:${opts.port}`;
+  return `${origin}/#/v3/${encodeURIComponent(runId)}`;
 }
 
 /**

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -66,7 +66,11 @@ import { checkCliAvailability } from './setup/cli-availability.js';
 import { invalidWorkingDirs } from './utils/working-dir.js';
 import { invalidateGlobalConfigCache, mergeDashboardConfig, mergeGlobalConfig, readGlobalConfig, type MaintenanceConfig, type RepoPickerMode, type WhiteboardConfig } from './global-config.js';
 import { hostLocalTimeZone, scheduleTimeZone } from './utils/timezone.js';
-import { buildDashboardUrls, type DashboardUrls } from './core/dashboard-url.js';
+import {
+  buildDashboardUrls,
+  buildPlatformDashboardLoginUrl,
+  type DashboardUrls,
+} from './core/dashboard-url.js';
 import { resolveBotmuxDataDir } from './core/data-dir.js';
 import { dashboardSecretPath } from './core/dashboard-secret.js';
 import { getGitRepoInfo } from './core/session-row-enrichment.js';
@@ -2706,7 +2710,12 @@ const server = createServer(async (req, res) => {
     const authed = !!presentedToken && presentedToken === activeToken && !!activeToken;
 
     if (decision.kind === 'deny401') {
-      res.writeHead(401, { 'content-type': 'text/html; charset=utf-8' });
+      const loginUrl = buildPlatformDashboardLoginUrl();
+      res.writeHead(401, {
+        'content-type': 'text/html; charset=utf-8',
+        'cache-control': 'no-store',
+        ...(loginUrl ? { 'x-botmux-login-url': loginUrl } : {}),
+      });
       res.end('<h1>Token expired</h1><p>Run <code>botmux dashboard</code> to get a fresh URL.</p>');
       return;
     }

--- a/src/dashboard/web/app.tsx
+++ b/src/dashboard/web/app.tsx
@@ -36,6 +36,7 @@ import {
   dashboardClientShellRedirect,
   readDashboardClientShell,
 } from './client-shell.js';
+import { dashboardLoginHref } from './auth-login.js';
 
 type OwnerAvatar = { avatarUrl: string; name?: string };
 type TopbarAttentionNotice = { count: number; time: string; bot: string; reason: string };
@@ -169,6 +170,7 @@ const routeState = createDashboardRouteState();
 const OWNER_AVATAR_KEY = 'botmux.ownerAvatar.v1';
 const BUSY_STATUSES = new Set(['working', 'analyzing', 'active', 'starting']);
 const AUTH_EXPIRED_EVENT = 'botmux:auth-expired';
+let authLoginBaseUrl: string | undefined;
 
 function icon(children: ReactNode): ReactNode {
   return <svg viewBox="0 0 16 16" aria-hidden="true">{children}</svg>;
@@ -480,8 +482,13 @@ function TopbarStatusMenu(props: { summary: TopbarStatusSummary; autoOpen?: bool
   );
 }
 
-function AuthExpiredOverlay(props: { open: boolean; onClose(): void }): React.JSX.Element | null {
+function AuthExpiredOverlay(props: {
+  open: boolean;
+  loginUrl?: string;
+  onClose(): void;
+}): React.JSX.Element | null {
   if (!props.open) return null;
+  const canLogin = !!props.loginUrl;
   return (
     <div
       id="auth-expired-overlay"
@@ -490,9 +497,31 @@ function AuthExpiredOverlay(props: { open: boolean; onClose(): void }): React.JS
       onClick={event => { if (event.target === event.currentTarget) props.onClose(); }}
     >
       <div className="auth-expired-dialog" role="dialog" aria-modal="true" aria-labelledby="auth-expired-title">
-        <h2 id="auth-expired-title">访问链接已失效</h2>
-        <p>当前链接/访问已失效，请使用最新授权链接重新进入（运行 botmux dashboard 获取）。</p>
-        <button id="auth-expired-dismiss" type="button" className="primary" onClick={props.onClose}>知道了</button>
+        <h2 id="auth-expired-title">{canLogin ? '登录 Dashboard' : '访问链接已失效'}</h2>
+        <p>{canLogin
+          ? '当前浏览器尚未登录。点击后将通过 Botmux 平台校验机器 owner 权限，并返回当前页面；无权限账号仍会被拒绝。'
+          : '当前链接/访问已失效，请使用最新授权链接重新进入（运行 botmux dashboard 获取）。'}</p>
+        <div className="auth-expired-actions">
+          {props.loginUrl ? (
+            <a
+              id="dashboard-one-click-login"
+              className="auth-login-link primary"
+              href={props.loginUrl}
+              target="_top"
+              rel="noopener"
+            >
+              一键登录
+            </a>
+          ) : null}
+          <button
+            id="auth-expired-dismiss"
+            type="button"
+            className={canLogin ? 'secondary' : 'primary'}
+            onClick={props.onClose}
+          >
+            {canLogin ? '暂不登录' : '知道了'}
+          </button>
+        </div>
       </div>
     </div>
   );
@@ -1128,7 +1157,11 @@ function DashboardShell(): React.JSX.Element {
           </div>
         </div>
       </div>
-      <AuthExpiredOverlay open={authExpiredOpen} onClose={closeAuthExpired} />
+      <AuthExpiredOverlay
+        open={authExpiredOpen}
+        loginUrl={dashboardLoginHref(authLoginBaseUrl, location.hash)}
+        onClose={closeAuthExpired}
+      />
     </>
   );
 }
@@ -1144,7 +1177,11 @@ function setLocale(locale: DashboardLocale): void {
 
 // ── Auth-expiry overlay ──────────────────────────────────────────────────────
 let expiredShown = false;
-export function showAuthExpiredOverlay(): void {
+export function showAuthExpiredOverlay(loginUrl?: string): void {
+  const hasLoginUrl = !!dashboardLoginHref(loginUrl, location.hash);
+  const loginUrlChanged = hasLoginUrl && authLoginBaseUrl !== loginUrl;
+  if (hasLoginUrl) authLoginBaseUrl = loginUrl;
+  if (expiredShown && loginUrlChanged) renderShell();
   if (expiredShown) return;
   expiredShown = true;
   window.dispatchEvent(new Event(AUTH_EXPIRED_EVENT));
@@ -1174,9 +1211,10 @@ window.fetch = async function patchedFetch(
 ): ReturnType<typeof fetch> {
   const res = await origFetch(...args);
   if (res.status === 401) {
+    const loginUrl = res.headers.get('x-botmux-login-url') ?? undefined;
     const method = (args[1]?.method ?? 'GET').toUpperCase();
     const isRead = method === 'GET' || method === 'HEAD';
-    if (isRead && !publicReadOnly) showAuthExpiredOverlay();
+    if (loginUrl || (isRead && !publicReadOnly)) showAuthExpiredOverlay(loginUrl);
     else showReadOnlyToast();
   }
   return res;

--- a/src/dashboard/web/auth-login.ts
+++ b/src/dashboard/web/auth-login.ts
@@ -1,0 +1,18 @@
+/** Build the platform SSO jump while preserving only the current SPA hash. */
+export function dashboardLoginHref(
+  platformLoginUrl: string | undefined,
+  hash: string,
+): string | undefined {
+  if (!platformLoginUrl) return undefined;
+  try {
+    const url = new URL(platformLoginUrl);
+    if (!['http:', 'https:'].includes(url.protocol) || url.username || url.password) return undefined;
+    const route = hash.startsWith('#/') && hash.length <= 4_096 && !/[\u0000-\u001f\u007f]/.test(hash)
+      ? hash
+      : '#/';
+    url.searchParams.set('next', `/${route}`);
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}

--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -4208,6 +4208,30 @@ td code,
   justify-self: center;
 }
 
+.auth-expired-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+}
+
+.auth-login-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  padding: 0 18px;
+  border-radius: var(--radius-lg);
+  background: var(--accent);
+  color: var(--on-accent);
+  font-size: 13px;
+  text-decoration: none;
+}
+
+.auth-login-link:hover {
+  filter: brightness(.96);
+}
+
 .checkbox-row {
   display: flex;
   flex-wrap: wrap;

--- a/src/im/lark/v3-blocked-card.ts
+++ b/src/im/lark/v3-blocked-card.ts
@@ -9,7 +9,7 @@
  */
 
 import { config } from '../../config.js';
-import { formatUrlHost } from '../../core/dashboard-url.js';
+import { buildV3RunDetailUrl } from '../../core/dashboard-url.js';
 
 export const V3_BLOCKED_RETRY_ACTION = 'v3_blocked_retry';
 /** 运行时 human-ask 选项按钮的 action（与「重试」同卡不同 namespace）。 */
@@ -76,7 +76,7 @@ export function v3BlockedCardNonce(runId: string, nodeId: string, attemptId: str
 }
 
 function v3RunDetailUrl(runId: string): string {
-  return `http://${formatUrlHost(config.dashboard.externalHost)}:${config.dashboard.port}/#/v3/${encodeURIComponent(runId)}`;
+  return buildV3RunDetailUrl(runId, { host: config.dashboard.externalHost, port: config.dashboard.port });
 }
 
 export function buildV3BlockedCard(input: V3BlockedCardInput): string {

--- a/src/im/lark/v3-gate-card.ts
+++ b/src/im/lark/v3-gate-card.ts
@@ -9,7 +9,7 @@
  */
 
 import { config } from '../../config.js';
-import { formatUrlHost } from '../../core/dashboard-url.js';
+import { buildV3RunDetailUrl } from '../../core/dashboard-url.js';
 import { DEFAULT_HUMAN_GATE_OPTIONS } from '../../workflows/v3/dag.js';
 import { splitV3HostGatePrompt } from '../../workflows/v3/host-bindings.js';
 
@@ -55,9 +55,11 @@ export function v3GateCardNonce(runId: string, waitId: string): string {
   return `v3gate:${runId}:${waitId}`;
 }
 
-/** v3 run 在 dashboard 的详情页 URL（跟 v0.2 的 #/workflows 对称，走 #/v3）。 */
+/** v3 run 在 dashboard 的详情页 URL（跟 v0.2 的 #/workflows 对称，走 #/v3）。
+ *  远程访问开+已绑定时走平台子域，否则 BOTMUX_PUBLIC_URL / 本地——详见
+ *  {@link buildV3RunDetailUrl}，让远程用户点卡片够得着 SPA 才能触发一键登录。 */
 export function v3RunDetailUrl(runId: string): string {
-  return `http://${formatUrlHost(config.dashboard.externalHost)}:${config.dashboard.port}/#/v3/${encodeURIComponent(runId)}`;
+  return buildV3RunDetailUrl(runId, { host: config.dashboard.externalHost, port: config.dashboard.port });
 }
 
 export function buildV3GateCard(input: V3GateCardInput): string {

--- a/src/im/lark/v3-loop-grant-card.ts
+++ b/src/im/lark/v3-loop-grant-card.ts
@@ -10,7 +10,7 @@
  */
 
 import { config } from '../../config.js';
-import { formatUrlHost } from '../../core/dashboard-url.js';
+import { buildV3RunDetailUrl } from '../../core/dashboard-url.js';
 
 export const V3_LOOP_GRANT_ACTION = 'v3_loop_grant';
 
@@ -52,7 +52,7 @@ export function v3LoopGrantCardNonce(runId: string, loopId: string, iteration: n
 }
 
 function v3RunDetailUrl(runId: string): string {
-  return `http://${formatUrlHost(config.dashboard.externalHost)}:${config.dashboard.port}/#/v3/${encodeURIComponent(runId)}`;
+  return buildV3RunDetailUrl(runId, { host: config.dashboard.externalHost, port: config.dashboard.port });
 }
 
 export function buildV3LoopGrantCard(input: V3LoopGrantCardInput): string {

--- a/src/im/lark/v3-progress-card.ts
+++ b/src/im/lark/v3-progress-card.ts
@@ -9,7 +9,7 @@
  */
 
 import { config } from '../../config.js';
-import { formatUrlHost } from '../../core/dashboard-url.js';
+import { buildV3RunDetailUrl } from '../../core/dashboard-url.js';
 import type { V3ProgressView } from '../../workflows/v3/progress-projection.js';
 import type { V3RunSaveActionValue } from './v3-run-save-card.js';
 
@@ -28,7 +28,7 @@ export interface V3ProgressCardOptions {
 const MAX_INLINE_IDS = 5;
 
 export function v3ProgressRunDetailUrl(runId: string): string {
-  return `http://${formatUrlHost(config.dashboard.externalHost)}:${config.dashboard.port}/#/v3/${encodeURIComponent(runId)}`;
+  return buildV3RunDetailUrl(runId, { host: config.dashboard.externalHost, port: config.dashboard.port });
 }
 
 /** Render one complete Feishu card body from the safe v3 progress projection. */

--- a/src/im/lark/v3-revisit-grant-card.ts
+++ b/src/im/lark/v3-revisit-grant-card.ts
@@ -15,7 +15,7 @@
  */
 
 import { config } from '../../config.js';
-import { formatUrlHost } from '../../core/dashboard-url.js';
+import { buildV3RunDetailUrl } from '../../core/dashboard-url.js';
 
 export const V3_REVISIT_GRANT_ACTION = 'v3_revisit_grant';
 
@@ -59,7 +59,7 @@ export function v3RevisitGrantCardNonce(runId: string, sourceNodeId: string, att
 }
 
 function v3RunDetailUrl(runId: string): string {
-  return `http://${formatUrlHost(config.dashboard.externalHost)}:${config.dashboard.port}/#/v3/${encodeURIComponent(runId)}`;
+  return buildV3RunDetailUrl(runId, { host: config.dashboard.externalHost, port: config.dashboard.port });
 }
 
 export function buildV3RevisitGrantCard(input: V3RevisitGrantCardInput): string {

--- a/test/dashboard-login-ui.test.ts
+++ b/test/dashboard-login-ui.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+import { dashboardLoginHref } from '../src/dashboard/web/auth-login.js';
+
+describe('dashboardLoginHref', () => {
+  it('preserves the current workflow hash in the platform SSO jump', () => {
+    expect(dashboardLoginHref(
+      'https://platform.example/open/m-1?next=%2F%23%2F',
+      '#/workflows/run-1',
+    )).toBe(
+      'https://platform.example/open/m-1?next=%2F%23%2Fworkflows%2Frun-1',
+    );
+  });
+
+  it('falls back to the dashboard root for malformed or missing hashes', () => {
+    const base = 'https://platform.example/open/m-1?next=%2F%23%2F';
+    expect(dashboardLoginHref(base, '')).toBe(base);
+    expect(dashboardLoginHref(base, '#evil')).toBe(base);
+  });
+
+  it('rejects missing, non-http, and malformed platform login URLs', () => {
+    expect(dashboardLoginHref(undefined, '#/workflows/run-1')).toBeUndefined();
+    expect(dashboardLoginHref('javascript:alert(1)', '#/workflows/run-1')).toBeUndefined();
+    expect(dashboardLoginHref('not a url', '#/workflows/run-1')).toBeUndefined();
+  });
+});
+
+describe('Dashboard one-click login wiring', () => {
+  it('advertises the token-free login URL on 401 and renders it in the existing overlay', () => {
+    const server = readFileSync(new URL('../src/dashboard.ts', import.meta.url), 'utf8');
+    const app = readFileSync(new URL('../src/dashboard/web/app.tsx', import.meta.url), 'utf8');
+    expect(server).toContain("'x-botmux-login-url': loginUrl");
+    expect(server).toContain("'cache-control': 'no-store'");
+    expect(app).toContain("res.headers.get('x-botmux-login-url')");
+    expect(app).toContain('id="dashboard-one-click-login"');
+    expect(app).toContain('一键登录');
+  });
+});

--- a/test/dashboard-url.test.ts
+++ b/test/dashboard-url.test.ts
@@ -9,21 +9,35 @@ vi.mock('../src/global-config.js', () => ({
 vi.mock('../src/platform/binding.js', () => ({
   platformMachineBaseUrl: vi.fn(() => null),
   publicReverseProxyBaseUrl: vi.fn(() => null),
+  readPlatformBinding: vi.fn(() => null),
 }));
 
-import { buildDashboardUrl, buildDashboardUrls, formatUrlHost } from '../src/core/dashboard-url.js';
+import {
+  buildDashboardUrl,
+  buildDashboardUrls,
+  buildPlatformDashboardLoginUrl,
+  formatUrlHost,
+} from '../src/core/dashboard-url.js';
 import { isRemoteAccessEnabled } from '../src/global-config.js';
-import { platformMachineBaseUrl, publicReverseProxyBaseUrl } from '../src/platform/binding.js';
+import {
+  platformMachineBaseUrl,
+  publicReverseProxyBaseUrl,
+  readPlatformBinding,
+} from '../src/platform/binding.js';
 
 const setRemote = (on: boolean) => vi.mocked(isRemoteAccessEnabled).mockReturnValue(on);
 const setPlatform = (base: string | null) => vi.mocked(platformMachineBaseUrl).mockReturnValue(base);
 const setPublic = (base: string | null) => vi.mocked(publicReverseProxyBaseUrl).mockReturnValue(base);
+const setBinding = (binding: ReturnType<typeof readPlatformBinding>) => (
+  vi.mocked(readPlatformBinding).mockReturnValue(binding)
+);
 
 describe('buildDashboardUrl', () => {
   beforeEach(() => {
     setRemote(false);
     setPlatform(null);
     setPublic(null);
+    setBinding(null);
   });
 
   it('builds a local host:port URL with token when remote access is off', () => {
@@ -163,5 +177,41 @@ describe('formatUrlHost', () => {
       const h = formatUrlHost(host);
       expect(() => new URL(`http://${h}:7891/#/v3/run-1`)).not.toThrow();
     }
+  });
+});
+
+describe('buildPlatformDashboardLoginUrl', () => {
+  beforeEach(() => {
+    setRemote(false);
+    setBinding(null);
+  });
+
+  it('builds a token-free platform owner-login URL with a safe root fallback', () => {
+    setRemote(true);
+    setBinding({
+      platformUrl: 'https://platform.example',
+      machineId: 'm-1',
+      machineToken: 'machine-secret',
+    });
+    expect(buildPlatformDashboardLoginUrl()).toBe(
+      'https://platform.example/open/m-1?next=%2F%23%2F',
+    );
+    expect(buildPlatformDashboardLoginUrl()).not.toContain('machine-secret');
+  });
+
+  it('is unavailable unless remote access and a platform binding are both present', () => {
+    setBinding({ platformUrl: 'https://platform.example', machineId: 'm-1', machineToken: 'secret' });
+    expect(buildPlatformDashboardLoginUrl()).toBeUndefined();
+    setRemote(true);
+    setBinding(null);
+    expect(buildPlatformDashboardLoginUrl()).toBeUndefined();
+  });
+
+  it('rejects a non-http platform binding and safely encodes the machine id path segment', () => {
+    setRemote(true);
+    setBinding({ platformUrl: 'file:///tmp/platform', machineId: 'm/1', machineToken: 'secret' });
+    expect(buildPlatformDashboardLoginUrl()).toBeUndefined();
+    setBinding({ platformUrl: 'https://platform.example/base', machineId: 'm/1', machineToken: 'secret' });
+    expect(buildPlatformDashboardLoginUrl()).toContain('/open/m%2F1?');
   });
 });

--- a/test/dashboard-url.test.ts
+++ b/test/dashboard-url.test.ts
@@ -16,6 +16,7 @@ import {
   buildDashboardUrl,
   buildDashboardUrls,
   buildPlatformDashboardLoginUrl,
+  buildV3RunDetailUrl,
   formatUrlHost,
 } from '../src/core/dashboard-url.js';
 import { isRemoteAccessEnabled } from '../src/global-config.js';
@@ -213,5 +214,74 @@ describe('buildPlatformDashboardLoginUrl', () => {
     expect(buildPlatformDashboardLoginUrl()).toBeUndefined();
     setBinding({ platformUrl: 'https://platform.example/base', machineId: 'm/1', machineToken: 'secret' });
     expect(buildPlatformDashboardLoginUrl()).toContain('/open/m%2F1?');
+  });
+});
+
+describe('buildV3RunDetailUrl', () => {
+  // Mirrors the buildDashboardUrls flip so a REMOTE recipient tapping a v3
+  // card's「Web 详情」can actually reach the SPA (→ 401 → one-click login),
+  // instead of the old always-LAN link that was unreachable off-LAN.
+  beforeEach(() => {
+    setRemote(false);
+    setPlatform(null);
+    setPublic(null);
+  });
+
+  const opts = { host: '1.2.3.4', port: 7891 };
+
+  it('stays local host:port when remote access is off', () => {
+    expect(buildV3RunDetailUrl('run-1', opts)).toBe('http://1.2.3.4:7891/#/v3/run-1');
+  });
+
+  it('stays local when remote access is on but the host is not bound', () => {
+    setRemote(true);
+    setPlatform(null);
+    expect(buildV3RunDetailUrl('run-1', opts)).toBe('http://1.2.3.4:7891/#/v3/run-1');
+  });
+
+  it('stays local when bound but remote access is off (switch gates it)', () => {
+    setRemote(false);
+    setPlatform('https://m-deadbeef.botmux.example');
+    expect(buildV3RunDetailUrl('run-1', opts)).toBe('http://1.2.3.4:7891/#/v3/run-1');
+  });
+
+  it('routes through the platform machine subdomain when remote access is on and bound', () => {
+    setRemote(true);
+    setPlatform('https://m-deadbeef.botmux.example');
+    expect(buildV3RunDetailUrl('run-1', opts)).toBe(
+      'https://m-deadbeef.botmux.example/#/v3/run-1',
+    );
+  });
+
+  it('routes through BOTMUX_PUBLIC_URL when set and no platform (self-hosted nginx)', () => {
+    setPublic('https://botmux.example.com');
+    expect(buildV3RunDetailUrl('run-1', opts)).toBe('https://botmux.example.com/#/v3/run-1');
+  });
+
+  it('lets the platform subdomain win over BOTMUX_PUBLIC_URL when both apply', () => {
+    setRemote(true);
+    setPlatform('https://m-deadbeef.botmux.example');
+    setPublic('https://botmux.example.com');
+    expect(buildV3RunDetailUrl('run-1', opts)).toBe(
+      'https://m-deadbeef.botmux.example/#/v3/run-1',
+    );
+  });
+
+  it('never appends a token and URL-encodes the runId (both local and platform)', () => {
+    expect(buildV3RunDetailUrl('run with space', opts)).toBe(
+      'http://1.2.3.4:7891/#/v3/run%20with%20space',
+    );
+    setRemote(true);
+    setPlatform('https://m-deadbeef.botmux.example');
+    const url = buildV3RunDetailUrl('run with space', opts);
+    expect(url).toBe('https://m-deadbeef.botmux.example/#/v3/run%20with%20space');
+    expect(url).not.toContain('?t=');
+    expect(url).not.toContain('token');
+  });
+
+  it('brackets an IPv6 literal host in the local form', () => {
+    expect(buildV3RunDetailUrl('run-1', { host: '::1', port: 7891 })).toBe(
+      'http://[::1]:7891/#/v3/run-1',
+    );
   });
 });


### PR DESCRIPTION
## 背景

Workflow 卡片的「Web 详情（需登录）」会打开 token-free Dashboard 深链。匿名用户能加载 SPA，但管理 API 返回 401，现有弹层只能提示运行 `botmux dashboard`，无法在页面内完成登录。

## 改动

- 保留 Workflow 卡片原有 `multi_url`、文案和 action；不修改「打开 Web 终端」链路。
- Dashboard 401 在远程访问开启且机器已绑定平台时，附加 token-free `X-Botmux-Login-Url`，并设置 `Cache-Control: no-store`。
- 复用现有未登录弹层，增加「一键登录」按钮；点击后走平台 `/open/<machineId>` owner 登录，并只把当前 SPA hash 写入 `next`，登录后回到原 Workflow 路由。
- 未绑定平台或关闭远程访问时，保持原 `botmux dashboard` 授权链接提示。

## 安全边界

- 不开放任何 Dashboard / v3 Workflow API，原 401 权限门保持不变。
- 响应和页面均不包含 Dashboard token 或 machine token。
- 平台地址只接受 HTTP(S) 且拒绝带 userinfo 的 URL；machine ID 作为 path segment 编码。
- 前端只保留 `location.hash`，不会把可能含 `?t=` 的 `location.search` 转发给平台。
- 最终权限仍由平台现有 machine owner gate 判定；无权限用户不会获得 Dashboard 登录态。

## 验证

- `pnpm vitest run test/dashboard-url.test.ts test/dashboard-auth.test.ts test/dashboard-login-ui.test.ts test/v3-progress-card.test.ts test/v3-gate-card.test.ts test/v3-blocked-card.test.ts test/v3-loop-grant-card.test.ts test/v3-revisit-grant-card.test.ts`（140 passed）
- Web 终端与卡片补充回归（52 passed）
- `pnpm build`
- `pnpm test`：12,329 passed；`codex-app-threads` 的既有超时用例在全量负载下偶发失败，单文件重跑 11/11 passed
- 本机匿名 API 实测返回 401 + token-free 登录 header；Playwright 实测弹层按钮精确保留 Workflow hash，点击进入飞书 OAuth
