### PR TITLE
fix: auto-suspend oversized bot sessions

### DIFF
--- a/src/bot-registry.ts
+++ b/src/bot-registry.ts
@@ -1129,6 +1129,14 @@ export interface BotConfig {
    */
   maxLiveWorkers?: number;
   /**
+   * Optional per-session RSS guard, in MiB. When set, this bot's daemon samples
+   * live sessions periodically and suspends idle, resumable sessions whose
+   * worker+CLI process tree exceeds this size. Missing means disabled. This is
+   * deliberately separate from maxLiveWorkers: it catches one runaway CLI even
+   * when the live-session count is still under the cap.
+   */
+  maxSessionRssMiB?: number;
+  /**
    * When true, THIS bot's daemon watches host load/memory and DMs the bot owner
    * when the machine crosses into (and back out of) an overloaded state — a
    * heads-up that botmux session cold-starts may time out and false-die. Host
@@ -2504,6 +2512,10 @@ export function parseBotConfigsFromText(jsonText: string): BotConfig[] {
       maxLiveWorkers: typeof entry.maxLiveWorkers === 'number'
         && Number.isInteger(entry.maxLiveWorkers) && entry.maxLiveWorkers > 0
         ? entry.maxLiveWorkers
+        : undefined,
+      maxSessionRssMiB: typeof entry.maxSessionRssMiB === 'number'
+        && Number.isInteger(entry.maxSessionRssMiB) && entry.maxSessionRssMiB > 0
+        ? entry.maxSessionRssMiB
         : undefined,
       // Only explicit true persisted (undefined = off), same as restrictGrantCommands.
       overloadAlert: entry.overloadAlert === true || undefined,

--- a/src/core/session-rss-guard.ts
+++ b/src/core/session-rss-guard.ts
@@ -1,0 +1,127 @@
+import { sampleProcfs } from './resource-monitor/procfs.js';
+import type { ProcessResourceSample } from './resource-monitor/types.js';
+import type { DaemonSession } from './types.js';
+import { isSuspendableBackendType } from './persistent-backend.js';
+import { suspendWorker } from './worker-pool.js';
+import { readProcessStartIdentity } from './session-marker.js';
+import { logger } from '../utils/logger.js';
+
+export interface SessionRssGuardOptions {
+  /** Positive MiB threshold. Missing or <= 0 disables the guard. */
+  maxSessionRssMiB?: number;
+  processes?: ProcessResourceSample[];
+  suspend?: typeof suspendWorker;
+  processStart?: (pid: number) => string | undefined;
+}
+
+export interface SessionRssGuardResult {
+  sessionId: string;
+  rssBytes: number;
+  thresholdBytes: number;
+  pids: number[];
+}
+
+function collectChildren(processes: ProcessResourceSample[]): Map<number, number[]> {
+  const children = new Map<number, number[]>();
+  for (const proc of processes) {
+    const arr = children.get(proc.ppid) ?? [];
+    arr.push(proc.pid);
+    children.set(proc.ppid, arr);
+  }
+  return children;
+}
+
+function collectSubtree(rootPid: number | undefined, children: Map<number, number[]>): Set<number> {
+  const out = new Set<number>();
+  if (!rootPid || rootPid <= 0) return out;
+  const stack = [rootPid];
+  while (stack.length) {
+    const pid = stack.pop();
+    if (!pid || out.has(pid)) continue;
+    out.add(pid);
+    for (const child of children.get(pid) ?? []) stack.push(child);
+  }
+  return out;
+}
+
+function liveAttestedCliPid(ds: DaemonSession, processStart: (pid: number) => string | undefined): number | undefined {
+  const attestation = ds.localProcessAttestation;
+  if (!attestation?.cliPid) return undefined;
+  if (attestation.workerGeneration !== undefined && ds.workerGeneration !== undefined && attestation.workerGeneration !== ds.workerGeneration) {
+    return undefined;
+  }
+  if (attestation.cliProcStart && processStart(attestation.cliPid) !== attestation.cliProcStart) {
+    return undefined;
+  }
+  return attestation.cliPid;
+}
+
+function sessionProcessPids(
+  ds: DaemonSession,
+  children: Map<number, number[]>,
+  processStart: (pid: number) => string | undefined,
+): Set<number> {
+  const pids = new Set<number>();
+  for (const pid of collectSubtree(ds.worker?.pid, children)) pids.add(pid);
+  const cliPid = liveAttestedCliPid(ds, processStart);
+  for (const pid of collectSubtree(cliPid, children)) pids.add(pid);
+  return pids;
+}
+
+function sumRss(pids: Set<number>, byPid: Map<number, ProcessResourceSample>): number {
+  let total = 0;
+  for (const pid of pids) total += byPid.get(pid)?.rssBytes ?? 0;
+  return total;
+}
+
+function eligibleForAutoSuspend(ds: DaemonSession): boolean {
+  if (!ds.worker || ds.worker.killed) return false;
+  if (ds.adoptedFrom || ds.initConfig?.adoptMode) return false;
+  if (!isSuspendableBackendType(ds.initConfig?.backendType)) return false;
+  return ds.lastScreenStatus === 'idle';
+}
+
+/**
+ * Suspend idle, resumable sessions whose worker+CLI footprint exceeds the
+ * per-bot RSS threshold. This is a last-ditch guard for one runaway CLI; the
+ * count-based maxLiveWorkers sweeper still handles ordinary resident-session
+ * pressure.
+ */
+export function sweepOversizedSessions(
+  activeSessions: Map<string, DaemonSession>,
+  opts: SessionRssGuardOptions = {},
+): SessionRssGuardResult[] {
+  const thresholdMiB = opts.maxSessionRssMiB;
+  if (!Number.isInteger(thresholdMiB) || !thresholdMiB || thresholdMiB <= 0) return [];
+  const thresholdBytes = thresholdMiB * 1024 * 1024;
+  const processes = opts.processes ?? sampleProcfs().processes;
+  if (processes.length === 0) return [];
+
+  const byPid = new Map(processes.map(proc => [proc.pid, proc]));
+  const children = collectChildren(processes);
+  const processStart = opts.processStart ?? readProcessStartIdentity;
+  const suspend = opts.suspend ?? suspendWorker;
+  const suspended: SessionRssGuardResult[] = [];
+
+  for (const ds of activeSessions.values()) {
+    if (!eligibleForAutoSuspend(ds)) continue;
+    const pids = sessionProcessPids(ds, children, processStart);
+    if (pids.size === 0) continue;
+    const rssBytes = sumRss(pids, byPid);
+    if (rssBytes < thresholdBytes) continue;
+    try {
+      if (suspend(ds, 'session_rss_guard')) {
+        suspended.push({
+          sessionId: ds.session.sessionId,
+          rssBytes,
+          thresholdBytes,
+          pids: [...pids].sort((a, b) => a - b),
+        });
+      }
+    } catch (err) {
+      logger.warn(`[session-rss-guard] suspend failed for ${ds.session.sessionId.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  return suspended;
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -199,6 +199,7 @@ import { HerdrBackend } from './adapters/backend/herdr-backend.js';
 import { ZellijBackend } from './adapters/backend/zellij-backend.js';
 import { ZmxBackend } from './adapters/backend/zmx-backend.js';
 import { sweepIdleWorkers, DEFAULT_MAX_LIVE_WORKERS } from './core/idle-worker-sweeper.js';
+import { sweepOversizedSessions } from './core/session-rss-guard.js';
 import {
   getSessionPersistentBackendType,
   killPersistentBackendTarget,
@@ -18621,6 +18622,18 @@ export async function startDaemon(botIndex?: number): Promise<void> {
       );
     }
   };
+  const enforceSessionRssGuard = (source: 'periodic'): void => {
+    const maxSessionRssMiB = getBot(cfg.larkAppId).config.maxSessionRssMiB;
+    const suspended = sweepOversizedSessions(activeSessions, { maxSessionRssMiB });
+    for (const item of suspended) {
+      logger.warn(
+        `[session-rss-guard] suspended session ${item.sessionId.slice(0, 8)} `
+        + `rss=${Math.round(item.rssBytes / 1024 / 1024)}MiB `
+        + `threshold=${Math.round(item.thresholdBytes / 1024 / 1024)}MiB `
+        + `pids=${item.pids.join(',')} source=${source}`,
+      );
+    }
+  };
   // Initialise worker pool with daemon callbacks
   initWorkerPool({
     sessionReply,
@@ -19160,6 +19173,7 @@ export async function startDaemon(botIndex?: number): Promise<void> {
     // Dashboard config edits need no restart; the timer also backstops any
     // missed lifecycle edge. Normal new/resumed sessions enforce immediately.
     enforceLiveSessionCap('periodic');
+    enforceSessionRssGuard('periodic');
   }, 60_000);
   idleWorkerSweepTimer.unref?.();
 

--- a/src/dashboard/bot-payload.ts
+++ b/src/dashboard/bot-payload.ts
@@ -87,6 +87,7 @@ export function botDefaultsPayload(bot: DashboardBotDescriptor, j?: any, error?:
     skillInjectionDefault: (j?.skillInjectionDefault === 'global' || j?.skillInjectionDefault === 'off') ? j.skillInjectionDefault : 'prompt',
     skillInjectionSupport: (j?.skillInjectionSupport === 'dynamic' || j?.skillInjectionSupport === 'global') ? j.skillInjectionSupport : 'none',
     maxLiveWorkers: typeof j?.maxLiveWorkers === 'number' ? j.maxLiveWorkers : null,
+    maxSessionRssMiB: typeof j?.maxSessionRssMiB === 'number' ? j.maxSessionRssMiB : null,
     logicalSessionCount: typeof j?.logicalSessionCount === 'number' ? j.logicalSessionCount : 0,
     residentSessionCount: typeof j?.residentSessionCount === 'number' ? j.residentSessionCount : 0,
     dormantSessionCount: typeof j?.dormantSessionCount === 'number' ? j.dormantSessionCount : 0,

--- a/src/dashboard/web/bot-defaults.ts
+++ b/src/dashboard/web/bot-defaults.ts
@@ -76,6 +76,7 @@ export type BotDefaultsRow = {
   substituteMode?: BotSubstituteMode | null;
   docSubscribeDefaultMode?: string;
   maxLiveWorkers?: number | null;
+  maxSessionRssMiB?: number | null;
   logicalSessionCount?: number;
   residentSessionCount?: number;
   dormantSessionCount?: number;

--- a/src/services/bot-config-store.ts
+++ b/src/services/bot-config-store.ts
@@ -85,6 +85,7 @@ export const CONFIG_FIELDS: readonly ConfigFieldSpec[] = [
   { key: 'restrictGrantCommands', configKey: 'restrictGrantCommands', kind: 'boolean', effect: 'immediate', clearable: false, hint: '被授权人仅能纯对话、拦截斜杠命令 on|off' },
   { key: 'p2pMode', configKey: 'p2pMode', kind: 'enum', effect: 'immediate', clearable: true, enumValues: ['thread', 'chat'], hint: '私聊单聊模式 thread|chat；默认 chat=扁平连续会话，thread=每条 DM 独立会话（chat/unset 回默认）' },
   { key: 'maxLiveWorkers', configKey: 'maxLiveWorkers', kind: 'number', effect: 'immediate', clearable: true, hint: '最大常驻会话数；超过后最久未用的会话自动休眠（退出后台进程和 CLI、回收内存，下条消息冷恢复）；unset=默认 30' },
+  { key: 'maxSessionRssMiB', configKey: 'maxSessionRssMiB', kind: 'number', effect: 'immediate', clearable: true, hint: '单会话 RSS 自动休眠阈值(MiB)；超过后仅休眠 idle 且可恢复的会话，防止单个 CLI 吃爆整机；unset=关闭' },
   { key: 'customPassthroughCommands', configKey: 'customPassthroughCommands', kind: 'stringList', effect: 'immediate', clearable: true, hint: '额外放行透传给 CLI 的 slash 命令（逗号/空格分隔，如 /goal /export）；unset 回仅内置白名单' },
   { key: 'canTalkDaemonCommands', configKey: 'canTalkDaemonCommands', kind: 'stringList', effect: 'immediate', clearable: true, parseList: parseCanTalkDaemonCommandsInput, hint: '把列出的 daemon 命令权限从 canOperate（仅管理员）降到 canTalk（对话放行即可用），如 /status /help；仅认 daemon 命令，透传命令无效；unset 回全部仅管理员' },
   { key: 'startupCommands', configKey: 'startupCommands', kind: 'stringList', effect: 'next-session', clearable: true, parseList: parseStartupCommandsInput, hint: '开会话后、首条消息前自动发给 CLI 的命令（逗号/换行分隔，可带参数，如 /effort ultracode）；unset 回不发' },

--- a/test/bot-config-store.test.ts
+++ b/test/bot-config-store.test.ts
@@ -464,6 +464,24 @@ describe('bot-config store', () => {
     expect(registry.getBot('app_default').config.maxLiveWorkers).toBeUndefined();
   });
 
+  it('number field (maxSessionRssMiB) round-trips and clears on null', async () => {
+    const { registry, store } = await loaded();
+    const spec = store.findConfigField('maxSessionRssMiB')!;
+    expect(spec.kind).toBe('number');
+    expect(spec.effect).toBe('immediate');
+
+    const r1 = await store.applyConfigField('app_default', spec, 4096);
+    expect(r1.ok).toBe(true);
+    if (r1.ok) { expect(r1.oldText).toBe('∅'); expect(r1.newText).toBe('4096'); }
+    expect(readConfig().maxSessionRssMiB).toBe(4096);
+    expect(registry.getBot('app_default').config.maxSessionRssMiB).toBe(4096);
+
+    const r2 = await store.applyConfigField('app_default', spec, null);
+    expect(r2.ok).toBe(true);
+    expect(readConfig().maxSessionRssMiB).toBeUndefined();
+    expect(registry.getBot('app_default').config.maxSessionRssMiB).toBeUndefined();
+  });
+
   it('coerceConfigValue(number) accepts positive integers and rejects junk/≤0/fractions', async () => {
     const { store } = await loaded();
     const spec = store.findConfigField('maxLiveWorkers')!;

--- a/test/bot-registry.test.ts
+++ b/test/bot-registry.test.ts
@@ -178,6 +178,22 @@ describe('parseBotConfigsFromText — brand', () => {
     }
   });
 
+  it('keeps a positive-integer maxSessionRssMiB guard threshold', () => {
+    const [cfg] = mod.parseBotConfigsFromText(JSON.stringify([
+      { larkAppId: 'a', larkAppSecret: 's', maxSessionRssMiB: 4096 },
+    ]));
+    expect(cfg.maxSessionRssMiB).toBe(4096);
+  });
+
+  it('drops invalid maxSessionRssMiB values to undefined', () => {
+    for (const bad of [0, -2, 1.5, '4096', null] as const) {
+      const [cfg] = mod.parseBotConfigsFromText(JSON.stringify([
+        { larkAppId: 'a', larkAppSecret: 's', maxSessionRssMiB: bad },
+      ]));
+      expect(cfg.maxSessionRssMiB).toBeUndefined();
+    }
+  });
+
   it('keeps a trimmed displayName and drops blank/non-string values', () => {
     const [cfg] = mod.parseBotConfigsFromText(JSON.stringify([
       { larkAppId: 'a', larkAppSecret: 's', displayName: '  小助手  ' },

--- a/test/dashboard-bot-payload.test.ts
+++ b/test/dashboard-bot-payload.test.ts
@@ -13,7 +13,7 @@ describe('dashboard bot payload helpers', () => {
       'botToBotSameDir', 'brandLabel', 'canTalkDaemonCommands', 'codexAppCleanInput',
       'customPassthroughCommands', 'defaultOncall', 'defaultWorkingDir',
       'defaultWorkingDirAutoWorktree', 'disableStreamingCard', 'docSubscribeDefaultMode',
-      'env', 'launchShell', 'maxLiveWorkers', 'messageQuotaDefaultLimit', 'model',
+      'env', 'launchShell', 'maxLiveWorkers', 'maxSessionRssMiB', 'messageQuotaDefaultLimit', 'model',
       'overloadAlert', 'p2pMode', 'privateCard', 'regularGroupMentionMode',
       'regularGroupReplyMode', 'restrictGrantCommands', 'riff', 'sandbox', 'sandboxPaths',
       'silentTurnReactions', 'skillInjection', 'startupCommands', 'substituteMode',

--- a/test/session-rss-guard.test.ts
+++ b/test/session-rss-guard.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from 'vitest';
+import { sweepOversizedSessions } from '../src/core/session-rss-guard.js';
+import type { ProcessResourceSample } from '../src/core/resource-monitor/types.js';
+
+vi.mock('../src/services/session-store.js', () => ({
+  registerSessionBridgeSendMarkerCleanupFence: vi.fn(),
+  cleanupSessionBridgeSendMarkers: vi.fn(),
+  cleanupSessionBridgeSendMarkersNow: vi.fn(),
+  updateSessionPid: vi.fn(),
+  updateSession: vi.fn(),
+}));
+vi.mock('../src/core/dashboard-events.js', () => ({
+  dashboardEventBus: { publish: vi.fn() },
+}));
+vi.mock('../src/utils/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+vi.mock('../src/bot-registry.js', () => ({
+  getBot: vi.fn(() => ({ config: {} })),
+}));
+
+const MiB = 1024 * 1024;
+
+function proc(pid: number, ppid: number, rssMiB: number, startTicks = pid * 10): ProcessResourceSample {
+  return {
+    pid,
+    ppid,
+    rssBytes: rssMiB * MiB,
+    cpuTicks: 0,
+    startTicks,
+    cmd: `p${pid}`,
+  };
+}
+
+function ds(sessionId: string, opts: Record<string, unknown> = {}) {
+  return {
+    session: { sessionId, status: 'active' },
+    worker: { pid: 100, killed: false },
+    workerGeneration: 1,
+    initConfig: { backendType: 'tmux' },
+    lastScreenStatus: 'idle',
+    larkAppId: 'app',
+    ...opts,
+  } as any;
+}
+
+describe('sweepOversizedSessions', () => {
+  it('does nothing when the guard threshold is unset', () => {
+    const suspend = vi.fn();
+    const active = new Map<string, any>([
+      ['s1', ds('s1')],
+    ]);
+
+    expect(sweepOversizedSessions(active, {
+      processes: [proc(100, 1, 100), proc(101, 100, 900)],
+      suspend,
+    })).toEqual([]);
+    expect(suspend).not.toHaveBeenCalled();
+  });
+
+  it('suspends an idle resumable session over the RSS threshold', () => {
+    const suspend = vi.fn(() => true);
+    const active = new Map<string, any>([
+      ['s1', ds('s1')],
+    ]);
+
+    const res = sweepOversizedSessions(active, {
+      maxSessionRssMiB: 512,
+      processes: [proc(100, 1, 120), proc(101, 100, 450)],
+      suspend,
+    });
+
+    expect(res).toEqual([{
+      sessionId: 's1',
+      rssBytes: 570 * MiB,
+      thresholdBytes: 512 * MiB,
+      pids: [100, 101],
+    }]);
+    expect(suspend).toHaveBeenCalledWith(active.get('s1'), 'session_rss_guard');
+  });
+
+  it('skips busy, adopted, and non-resumable sessions', () => {
+    const suspend = vi.fn(() => true);
+    const active = new Map<string, any>([
+      ['busy', ds('busy', { worker: { pid: 100, killed: false }, lastScreenStatus: 'working' })],
+      ['adopt', ds('adopt', { worker: { pid: 200, killed: false }, adoptedFrom: { tmuxTarget: 'user:0.1' } })],
+      ['pty', ds('pty', { worker: { pid: 300, killed: false }, initConfig: { backendType: 'pty' } })],
+    ]);
+
+    const res = sweepOversizedSessions(active, {
+      maxSessionRssMiB: 128,
+      processes: [
+        proc(100, 1, 300),
+        proc(200, 1, 300),
+        proc(300, 1, 300),
+      ],
+      suspend,
+    });
+
+    expect(res).toEqual([]);
+    expect(suspend).not.toHaveBeenCalled();
+  });
+
+  it('includes a trusted attested CLI pid outside the worker subtree', () => {
+    const suspend = vi.fn(() => true);
+    const active = new Map<string, any>([
+      ['s1', ds('s1', {
+        worker: { pid: 100, killed: false },
+        localProcessAttestation: {
+          workerGeneration: 1,
+          backendType: 'tmux',
+          credentialIsolated: false,
+          cliPid: 500,
+          cliProcStart: '5000',
+        },
+      })],
+    ]);
+
+    const res = sweepOversizedSessions(active, {
+      maxSessionRssMiB: 512,
+      processes: [
+        proc(100, 1, 80),
+        proc(500, 1, 350, 5000),
+        proc(501, 500, 220),
+      ],
+      suspend,
+      processStart: (pid) => pid === 500 ? '5000' : String(pid * 10),
+    });
+
+    expect(res.map(x => ({ sessionId: x.sessionId, pids: x.pids, rssMiB: x.rssBytes / MiB }))).toEqual([
+      { sessionId: 's1', pids: [100, 500, 501], rssMiB: 650 },
+    ]);
+  });
+
+  it('ignores a stale attested CLI pid when procStart no longer matches', () => {
+    const suspend = vi.fn(() => true);
+    const active = new Map<string, any>([
+      ['s1', ds('s1', {
+        worker: { pid: 100, killed: false },
+        localProcessAttestation: {
+          workerGeneration: 1,
+          backendType: 'tmux',
+          credentialIsolated: false,
+          cliPid: 500,
+          cliProcStart: 'old-start',
+        },
+      })],
+    ]);
+
+    const res = sweepOversizedSessions(active, {
+      maxSessionRssMiB: 512,
+      processes: [
+        proc(100, 1, 80),
+        proc(500, 1, 600, 5000),
+      ],
+      suspend,
+      processStart: () => 'new-start',
+    });
+
+    expect(res).toEqual([]);
+    expect(suspend).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add an opt-in per-bot `maxSessionRssMiB` guard for runaway session memory
- periodically suspend idle, resumable sessions whose worker+CLI process tree exceeds the configured RSS budget
- expose the field through bot config parsing, `/config`, and dashboard bot payloads

## Verification
- `pnpm exec tsc --noEmit`
- `pnpm vitest run --project unit test/session-rss-guard.test.ts test/bot-registry.test.ts test/bot-config-store.test.ts test/dashboard-bot-payload.test.ts test/idle-worker-sweeper.test.ts test/api-only-cli-gate.behavior.test.ts test/worker-terminal-read-auth.integration.test.ts`
- `pnpm build`

Note: `pnpm test` was first run before rebuilding `dist/`, causing the built-CLI gate test to read stale artifacts. After `pnpm build`, the previously failing built-CLI tests passed when rerun.