### PR TITLE
fix(claude): managed 模式 fingerprint-mismatch 的 user 行绑 durable mark（修 core-only claude 永久 running）

### DIFF
--- a/src/services/bridge-turn-queue.ts
+++ b/src/services/bridge-turn-queue.ts
@@ -107,48 +107,38 @@ export function makeFingerprint(message: string, len = 30): string | undefined {
   return collapsed.substring(0, len);
 }
 
+/** Minimum overlap (normalised chars) required for a truncation-proof match.
+ *  Long enough that an unrelated short local prompt ("pwd", "ls -la") can't
+ *  accidentally be a substring of a marked prompt, short enough that a terse
+ *  real instruction still proves. */
+const TRUNCATION_MATCH_MIN_CHARS = 16;
+
+/** Capability-agnostic proof that a recorded transcript user line is THIS
+ *  turn's user event even though its head-substring fingerprint didn't match.
+ *
+ *  claude-code TRUNCATES the leading envelope lines (`<user_message>` +
+ *  `<botmux_task …>`) when persisting the user turn, so the head fingerprint is
+ *  gone — but the surviving TAIL is a contiguous suffix of what we sent. We
+ *  prove belonging by content, NOT by session type (apiOnly/adopt): the
+ *  recorded normalised text must be a non-trivial contiguous SUBSTRING of the
+ *  mark's full normalised content. Unrelated local terminal input (`pwd`) is
+ *  not a substring of the marked API/Lark prompt, so it can never spoof this
+ *  and steal the durable mark (the write-terminal race codex flagged, PR #724)
+ *  — regardless of whether the session can mint a Web Terminal write token.
+ *
+ *  `recordedNorm` and `markContentNorm` are both already normaliseForFingerprint'd.
+ *  Guards: require a real mark content, a recorded line of at least
+ *  TRUNCATION_MATCH_MIN_CHARS, and containment. */
+export function isTruncatedMatch(recordedNorm: string, markContentNorm?: string): boolean {
+  if (!markContentNorm || markContentNorm.length === 0) return false;
+  if (recordedNorm.length < TRUNCATION_MATCH_MIN_CHARS) return false;
+  return markContentNorm.includes(recordedNorm);
+}
+
 export class BridgeTurnQueue {
   private seen = new Set<string>();
   private queue: BridgePendingTurn[] = [];
   private collecting: BridgePendingTurn | null = null;
-  /** Whether local-terminal turn synthesis is allowed. TRUE only in adopt mode,
-   *  where a human types directly in the pane and those turns must surface to
-   *  Lark. Default false; the worker flips it on only for adopt spawns (mirrors
-   *  CodexBridgeQueue.setLocalTurns). NOTE this is NOT "no local input possible"
-   *  — a normal managed session can still receive Web Terminal write input (see
-   *  truncationFallbackEnabled). */
-  private localTurnsEnabled = false;
-
-  /** Whether to BIND a fingerprint-mismatched user event to the earliest
-   *  pending durable mark instead of leaving it unmatched. Enabled ONLY for a
-   *  session where local terminal WRITE is impossible — a strict no-transport
-   *  core-only / HTTP-virtual (apiOnly) session. There, claude-code truncates
-   *  the leading envelope lines (`<user_message>` + `<botmux_task …>`) when
-   *  persisting the user turn, so the head-substring fingerprint can never match
-   *  the recorded line — yet the line is unambiguously this turn's user event
-   *  (nothing else can write to that pane).
-   *
-   *  MUST NOT key on adoptMode: a NORMAL managed (non-adopt) session can still
-   *  mint a Web Terminal write token (`/api/sessions/:id/write-link` +
-   *  `writableTerminalLinkInCard`; the worker WS then writes `type:'input'`
-   *  straight to the backend). A human-typed local turn there would STEAL the
-   *  API/Lark durable mark and complete the trigger with the wrong output — the
-   *  regression codex caught in PR #724. So a managed writable session keeps the
-   *  old mismatch→local behavior; only strict no-write apiOnly enables this. */
-  private truncationFallbackEnabled = false;
-
-  /** Toggle adopt-mode local-turn synthesis. Called once at spawn: true for an
-   *  /adopt of a human's live pane, false (default) for every managed spawn. */
-  setLocalTurns(enabled: boolean): void {
-    this.localTurnsEnabled = enabled;
-  }
-
-  /** Toggle the truncation-fallback bind. Enable ONLY when local terminal write
-   *  is impossible for this session (strict no-transport apiOnly core-only /
-   *  HTTP-virtual). See the field doc for why adoptMode is the wrong boundary. */
-  setTruncationFallback(enabled: boolean): void {
-    this.truncationFallbackEnabled = enabled;
-  }
 
   /** Register events as historical — their uuids are now considered seen
    *  but no attribution happens. Used at attach time to baseline. */
@@ -381,29 +371,26 @@ export class BridgeTurnQueue {
           next.markTimeMs = eventTimeMs;
           this.collecting = next;
           consumedNext = true;
-        } else if (this.truncationFallbackEnabled) {
-          // STRICT no-write session (apiOnly core-only / HTTP-virtual): local
-          // terminal write is impossible, so this user event MUST belong to the
-          // earliest pending durable turn even though the fingerprint (a prefix
-          // of what we marked) didn't match. claude-code TRUNCATES the leading
-          // envelope lines (`<user_message>` + `<botmux_task …>`) when persisting
-          // the user turn, so a head-substring fingerprint can never match the
-          // recorded line — yet it is unambiguously this turn's user event
-          // (nothing else can write to that pane). Bind it rather than leaving
-          // the durable mark to expire with no final_output.
-          //
-          // Gated on truncationFallbackEnabled, NOT adoptMode: a normal managed
-          // session can mint a Web Terminal write token, so a human-typed local
-          // turn there must NOT steal the durable mark (codex PR #724 P1) — that
-          // case keeps the mismatch→local-synth path below.
+        } else if (isTruncatedMatch(userText, next.contentNormalized)) {
+          // TRUNCATION-PROOF bind (capability-agnostic — see isTruncatedMatch).
+          // The head-substring fingerprint didn't match because claude-code
+          // TRUNCATES the leading envelope lines (`<user_message>` +
+          // `<botmux_task …>`) when persisting the user turn. But the recorded
+          // line is PROVABLY this turn's user event: its normalised text is a
+          // non-trivial contiguous substring of the FULL marked content
+          // (`contentNormalized`), i.e. exactly the surviving tail of what we
+          // sent. This does NOT guess from session type (apiOnly/adopt) —
+          // unrelated local terminal input like `pwd` is not a substring of the
+          // marked API/Lark prompt, so it can never steal the durable mark
+          // (the write-terminal race codex flagged on PR #724).
           next.started = true;
           if (!next.sourceJsonlPath) next.sourceJsonlPath = sourceJsonlPath;
           next.markTimeMs = eventTimeMs;
           this.collecting = next;
           consumedNext = true;
         }
-        // Non-truncation-fallback mismatch falls through to local-turn synthesis
-        // (adopt, or normal managed with a writable terminal).
+        // Otherwise (no fingerprint match, not a provable truncation) falls
+        // through to local-turn synthesis below (adopt) or is skipped (managed).
       } else {
         // Legacy mark() with no fingerprint — start on the next turn-start.
         next.started = true;
@@ -414,17 +401,16 @@ export class BridgeTurnQueue {
       }
     }
     if (!consumedNext) {
-      if (this.truncationFallbackEnabled) {
-        // STRICT no-write session (apiOnly): local input is impossible, so a
-        // user event with no pending mark to bind (mark not yet created, or
-        // already consumed) must NOT be synthesised as a local turn. Skip it;
-        // a real pending mark, if any, binds the next meaningful user event.
-        return;
-      }
-      // Adopt OR normal managed with a writable Web Terminal: this is (or may
-      // be) real local-terminal input. Synthesise a started turn ahead of any
-      // unstarted Lark turn so chronological order matches transcript order at
-      // emit time — and so it does NOT steal the pending durable mark.
+      // The user event neither fingerprint-matched nor proved a truncation of a
+      // pending durable mark. Treat it as local-terminal input: synthesise a
+      // started local turn ahead of any unstarted turn so chronological order
+      // matches transcript order at emit time. This is SAFE regardless of
+      // session type — it never steals a pending durable mark (the mark stays
+      // unstarted, to be bound by its real user line). Restoring the original
+      // pre-PR behavior here (no session-type gate) is what keeps codex's
+      // requirement: a genuine local turn on a normal managed writable terminal
+      // still emits and is not silently dropped. The mark-stealing bug lived in
+      // the fingerprint-MISMATCH bind above, now gated on the truncation proof.
       const localTurn: BridgePendingTurn = {
         turnId: `local-${uuid}`,
         started: true,

--- a/src/services/bridge-turn-queue.ts
+++ b/src/services/bridge-turn-queue.ts
@@ -111,6 +111,21 @@ export class BridgeTurnQueue {
   private seen = new Set<string>();
   private queue: BridgePendingTurn[] = [];
   private collecting: BridgePendingTurn | null = null;
+  /** Whether local-terminal turn synthesis is allowed. TRUE only in adopt mode,
+   *  where a human types directly in the pane and those turns must surface to
+   *  Lark. In MANAGED mode (normal Lark-driven or core-only/apiOnly triggers)
+   *  there is NO local input: every user event in the transcript belongs to a
+   *  pending durable turn we marked. Synthesising a local turn there is always
+   *  wrong — it steals the transcript line from the pending mark, which then
+   *  expires with no final_output. Default false; the worker flips it on only
+   *  for adopt spawns (mirrors CodexBridgeQueue.setLocalTurns). */
+  private localTurnsEnabled = false;
+
+  /** Toggle adopt-mode local-turn synthesis. Called once at spawn: true for an
+   *  /adopt of a human's live pane, false (default) for every managed spawn. */
+  setLocalTurns(enabled: boolean): void {
+    this.localTurnsEnabled = enabled;
+  }
 
   /** Register events as historical — their uuids are now considered seen
    *  but no attribution happens. Used at attach time to baseline. */
@@ -343,8 +358,24 @@ export class BridgeTurnQueue {
           next.markTimeMs = eventTimeMs;
           this.collecting = next;
           consumedNext = true;
+        } else if (!this.localTurnsEnabled) {
+          // MANAGED mode (no adopt): there is no local-terminal input, so this
+          // user event MUST belong to the earliest pending durable turn even
+          // though the fingerprint (a prefix of what we marked) didn't match.
+          // claude-code is known to TRUNCATE the leading envelope lines
+          // (`<user_message>` + `<botmux_task …>`) when persisting the user turn
+          // to its transcript, so a head-substring fingerprint can never match
+          // the recorded line — yet it is unambiguously this turn's user event
+          // (only one turn is ever in flight per pane in managed mode). Bind it
+          // rather than synthesising a local turn that would steal the line and
+          // leave the durable mark to expire with no final_output.
+          next.started = true;
+          if (!next.sourceJsonlPath) next.sourceJsonlPath = sourceJsonlPath;
+          next.markTimeMs = eventTimeMs;
+          this.collecting = next;
+          consumedNext = true;
         }
-        // Mismatch falls through to local-turn synthesis below.
+        // Adopt-mode mismatch falls through to local-turn synthesis below.
       } else {
         // Legacy mark() with no fingerprint — start on the next turn-start.
         next.started = true;
@@ -355,6 +386,14 @@ export class BridgeTurnQueue {
       }
     }
     if (!consumedNext) {
+      if (!this.localTurnsEnabled) {
+        // MANAGED mode: no local input exists. A user event with no pending
+        // turn to bind (e.g. the mark hasn't been created yet, or was already
+        // consumed) must NOT become a synthetic local turn — that only applies
+        // to adopt, where a human types directly in the pane. Skip it; a real
+        // pending mark, if any, will bind the next meaningful user event.
+        return;
+      }
       // Local-terminal input (or a queued_command whose prompt didn't
       // match any pending Lark fingerprint). Synthesise a started turn
       // ahead of any unstarted Lark turn so chronological order matches

--- a/src/services/bridge-turn-queue.ts
+++ b/src/services/bridge-turn-queue.ts
@@ -107,10 +107,10 @@ export function makeFingerprint(message: string, len = 30): string | undefined {
   return collapsed.substring(0, len);
 }
 
-/** Minimum overlap (normalised chars) required for a truncation-proof match.
- *  Long enough that an unrelated short local prompt ("pwd", "ls -la") can't
- *  accidentally be a substring of a marked prompt, short enough that a terse
- *  real instruction still proves. */
+/** Minimum tail length (normalised chars) required for a truncation-proof
+ *  match. A non-trivial length floor so a very short surviving tail can't
+ *  coincide with an unrelated short local prompt. This is a length gate, NOT a
+ *  uniqueness/entropy claim — the actual proof is the SUFFIX anchor below. */
 const TRUNCATION_MATCH_MIN_CHARS = 16;
 
 /** Capability-agnostic proof that a recorded transcript user line is THIS
@@ -118,21 +118,31 @@ const TRUNCATION_MATCH_MIN_CHARS = 16;
  *
  *  claude-code TRUNCATES the leading envelope lines (`<user_message>` +
  *  `<botmux_task …>`) when persisting the user turn, so the head fingerprint is
- *  gone — but the surviving TAIL is a contiguous suffix of what we sent. We
- *  prove belonging by content, NOT by session type (apiOnly/adopt): the
- *  recorded normalised text must be a non-trivial contiguous SUBSTRING of the
- *  mark's full normalised content. Unrelated local terminal input (`pwd`) is
- *  not a substring of the marked API/Lark prompt, so it can never spoof this
- *  and steal the durable mark (the write-terminal race codex flagged, PR #724)
- *  — regardless of whether the session can mint a Web Terminal write token.
+ *  gone — but the surviving text is exactly the TAIL of what we sent, i.e. a
+ *  contiguous SUFFIX of the mark's full normalised content. We anchor the proof
+ *  to that observed invariant with `endsWith`, NOT a loose `includes`: an
+ *  interior substring (a command like `run pnpm test --project unit`, or the
+ *  bare closing tags `</botmux_task> </user_message>`) that happens to appear
+ *  in the middle of the task body is NOT a suffix, so a Web Terminal operator
+ *  typing such a phrase can't spoof this and steal the pending durable mark
+ *  (the interior-substring false-match codex demonstrated on PR #724). Length
+ *  (16) is a floor, not the proof — the suffix anchor is. Proof is by CONTENT
+ *  shape, not session type (apiOnly/adopt), so it holds regardless of whether
+ *  the session can mint a Web Terminal write token.
  *
  *  `recordedNorm` and `markContentNorm` are both already normaliseForFingerprint'd.
- *  Guards: require a real mark content, a recorded line of at least
- *  TRUNCATION_MATCH_MIN_CHARS, and containment. */
+ *  Guards: require a real mark content, a recorded tail of at least
+ *  TRUNCATION_MATCH_MIN_CHARS, and a strict suffix match.
+ *
+ *  NOTE: if a future claude-code build stops truncating at the head (recorded
+ *  line no longer a suffix of what we sent), this correctly returns false and
+ *  the turn falls back to local-synth — never a wrong-mark bind. Re-proving a
+ *  non-suffix truncation would need a truncation-surviving turn nonce/closing
+ *  marker, not a relaxed substring test. */
 export function isTruncatedMatch(recordedNorm: string, markContentNorm?: string): boolean {
   if (!markContentNorm || markContentNorm.length === 0) return false;
   if (recordedNorm.length < TRUNCATION_MATCH_MIN_CHARS) return false;
-  return markContentNorm.includes(recordedNorm);
+  return markContentNorm.endsWith(recordedNorm);
 }
 
 export class BridgeTurnQueue {

--- a/src/services/bridge-turn-queue.ts
+++ b/src/services/bridge-turn-queue.ts
@@ -113,18 +113,41 @@ export class BridgeTurnQueue {
   private collecting: BridgePendingTurn | null = null;
   /** Whether local-terminal turn synthesis is allowed. TRUE only in adopt mode,
    *  where a human types directly in the pane and those turns must surface to
-   *  Lark. In MANAGED mode (normal Lark-driven or core-only/apiOnly triggers)
-   *  there is NO local input: every user event in the transcript belongs to a
-   *  pending durable turn we marked. Synthesising a local turn there is always
-   *  wrong — it steals the transcript line from the pending mark, which then
-   *  expires with no final_output. Default false; the worker flips it on only
-   *  for adopt spawns (mirrors CodexBridgeQueue.setLocalTurns). */
+   *  Lark. Default false; the worker flips it on only for adopt spawns (mirrors
+   *  CodexBridgeQueue.setLocalTurns). NOTE this is NOT "no local input possible"
+   *  — a normal managed session can still receive Web Terminal write input (see
+   *  truncationFallbackEnabled). */
   private localTurnsEnabled = false;
+
+  /** Whether to BIND a fingerprint-mismatched user event to the earliest
+   *  pending durable mark instead of leaving it unmatched. Enabled ONLY for a
+   *  session where local terminal WRITE is impossible — a strict no-transport
+   *  core-only / HTTP-virtual (apiOnly) session. There, claude-code truncates
+   *  the leading envelope lines (`<user_message>` + `<botmux_task …>`) when
+   *  persisting the user turn, so the head-substring fingerprint can never match
+   *  the recorded line — yet the line is unambiguously this turn's user event
+   *  (nothing else can write to that pane).
+   *
+   *  MUST NOT key on adoptMode: a NORMAL managed (non-adopt) session can still
+   *  mint a Web Terminal write token (`/api/sessions/:id/write-link` +
+   *  `writableTerminalLinkInCard`; the worker WS then writes `type:'input'`
+   *  straight to the backend). A human-typed local turn there would STEAL the
+   *  API/Lark durable mark and complete the trigger with the wrong output — the
+   *  regression codex caught in PR #724. So a managed writable session keeps the
+   *  old mismatch→local behavior; only strict no-write apiOnly enables this. */
+  private truncationFallbackEnabled = false;
 
   /** Toggle adopt-mode local-turn synthesis. Called once at spawn: true for an
    *  /adopt of a human's live pane, false (default) for every managed spawn. */
   setLocalTurns(enabled: boolean): void {
     this.localTurnsEnabled = enabled;
+  }
+
+  /** Toggle the truncation-fallback bind. Enable ONLY when local terminal write
+   *  is impossible for this session (strict no-transport apiOnly core-only /
+   *  HTTP-virtual). See the field doc for why adoptMode is the wrong boundary. */
+  setTruncationFallback(enabled: boolean): void {
+    this.truncationFallbackEnabled = enabled;
   }
 
   /** Register events as historical — their uuids are now considered seen
@@ -358,24 +381,29 @@ export class BridgeTurnQueue {
           next.markTimeMs = eventTimeMs;
           this.collecting = next;
           consumedNext = true;
-        } else if (!this.localTurnsEnabled) {
-          // MANAGED mode (no adopt): there is no local-terminal input, so this
-          // user event MUST belong to the earliest pending durable turn even
-          // though the fingerprint (a prefix of what we marked) didn't match.
-          // claude-code is known to TRUNCATE the leading envelope lines
-          // (`<user_message>` + `<botmux_task …>`) when persisting the user turn
-          // to its transcript, so a head-substring fingerprint can never match
-          // the recorded line — yet it is unambiguously this turn's user event
-          // (only one turn is ever in flight per pane in managed mode). Bind it
-          // rather than synthesising a local turn that would steal the line and
-          // leave the durable mark to expire with no final_output.
+        } else if (this.truncationFallbackEnabled) {
+          // STRICT no-write session (apiOnly core-only / HTTP-virtual): local
+          // terminal write is impossible, so this user event MUST belong to the
+          // earliest pending durable turn even though the fingerprint (a prefix
+          // of what we marked) didn't match. claude-code TRUNCATES the leading
+          // envelope lines (`<user_message>` + `<botmux_task …>`) when persisting
+          // the user turn, so a head-substring fingerprint can never match the
+          // recorded line — yet it is unambiguously this turn's user event
+          // (nothing else can write to that pane). Bind it rather than leaving
+          // the durable mark to expire with no final_output.
+          //
+          // Gated on truncationFallbackEnabled, NOT adoptMode: a normal managed
+          // session can mint a Web Terminal write token, so a human-typed local
+          // turn there must NOT steal the durable mark (codex PR #724 P1) — that
+          // case keeps the mismatch→local-synth path below.
           next.started = true;
           if (!next.sourceJsonlPath) next.sourceJsonlPath = sourceJsonlPath;
           next.markTimeMs = eventTimeMs;
           this.collecting = next;
           consumedNext = true;
         }
-        // Adopt-mode mismatch falls through to local-turn synthesis below.
+        // Non-truncation-fallback mismatch falls through to local-turn synthesis
+        // (adopt, or normal managed with a writable terminal).
       } else {
         // Legacy mark() with no fingerprint — start on the next turn-start.
         next.started = true;
@@ -386,18 +414,17 @@ export class BridgeTurnQueue {
       }
     }
     if (!consumedNext) {
-      if (!this.localTurnsEnabled) {
-        // MANAGED mode: no local input exists. A user event with no pending
-        // turn to bind (e.g. the mark hasn't been created yet, or was already
-        // consumed) must NOT become a synthetic local turn — that only applies
-        // to adopt, where a human types directly in the pane. Skip it; a real
-        // pending mark, if any, will bind the next meaningful user event.
+      if (this.truncationFallbackEnabled) {
+        // STRICT no-write session (apiOnly): local input is impossible, so a
+        // user event with no pending mark to bind (mark not yet created, or
+        // already consumed) must NOT be synthesised as a local turn. Skip it;
+        // a real pending mark, if any, binds the next meaningful user event.
         return;
       }
-      // Local-terminal input (or a queued_command whose prompt didn't
-      // match any pending Lark fingerprint). Synthesise a started turn
-      // ahead of any unstarted Lark turn so chronological order matches
-      // transcript order at emit time.
+      // Adopt OR normal managed with a writable Web Terminal: this is (or may
+      // be) real local-terminal input. Synthesise a started turn ahead of any
+      // unstarted Lark turn so chronological order matches transcript order at
+      // emit time — and so it does NOT steal the pending durable mark.
       const localTurn: BridgePendingTurn = {
         turnId: `local-${uuid}`,
         started: true,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -11477,24 +11477,6 @@ process.on('message', async (raw: unknown) => {
       const initStartedAtMs = Date.now();
       if (lastInitConfig) return;  // already initialized
       lastInitConfig = msg;
-      // Claude bridge turn-attribution flags, set once per spawn:
-      //  • setLocalTurns(adopt): synthesise local turns for a human typing in
-      //    an ADOPTED pane. Managed spawns leave it off.
-      //  • setTruncationFallback(no-transport): bind a fingerprint-mismatched
-      //    user event to the earliest pending durable mark — ONLY for a strict
-      //    no-write session (apiOnly core-only OR http_async_/http_wait_ virtual
-      //    chat), where local terminal write is impossible so the mismatch can
-      //    only be claude-code's truncated-envelope user line. A NORMAL managed
-      //    session can mint a Web Terminal write token, so it must NOT bind
-      //    (would steal the durable mark — codex PR #724 P1); it keeps
-      //    mismatch→local-synth. Mirrors the no-transport predicate used for the
-      //    credential boundary below.
-      bridgeQueue.setLocalTurns(msg.adoptMode === true);
-      bridgeQueue.setTruncationFallback(
-        msg.apiOnly === true
-        || msg.chatId?.startsWith('http_async_') === true
-        || msg.chatId?.startsWith('http_wait_') === true,
-      );
       activeRestartAttemptId = msg.restartAttemptId;
       sessionId = msg.sessionId;
       refreshTerminalViewToken();

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -11477,12 +11477,24 @@ process.on('message', async (raw: unknown) => {
       const initStartedAtMs = Date.now();
       if (lastInitConfig) return;  // already initialized
       lastInitConfig = msg;
-      // Claude bridge local-turn synthesis is adopt-only: a human typing in an
-      // adopted pane produces local turns that must reach Lark. In managed mode
-      // (normal Lark triggers OR core-only/apiOnly) there is no local input, so
-      // every transcript user event belongs to a pending durable mark — see
-      // BridgeTurnQueue.setLocalTurns. Mirrors codexBridgeQueue.setLocalTurns.
+      // Claude bridge turn-attribution flags, set once per spawn:
+      //  • setLocalTurns(adopt): synthesise local turns for a human typing in
+      //    an ADOPTED pane. Managed spawns leave it off.
+      //  • setTruncationFallback(no-transport): bind a fingerprint-mismatched
+      //    user event to the earliest pending durable mark — ONLY for a strict
+      //    no-write session (apiOnly core-only OR http_async_/http_wait_ virtual
+      //    chat), where local terminal write is impossible so the mismatch can
+      //    only be claude-code's truncated-envelope user line. A NORMAL managed
+      //    session can mint a Web Terminal write token, so it must NOT bind
+      //    (would steal the durable mark — codex PR #724 P1); it keeps
+      //    mismatch→local-synth. Mirrors the no-transport predicate used for the
+      //    credential boundary below.
       bridgeQueue.setLocalTurns(msg.adoptMode === true);
+      bridgeQueue.setTruncationFallback(
+        msg.apiOnly === true
+        || msg.chatId?.startsWith('http_async_') === true
+        || msg.chatId?.startsWith('http_wait_') === true,
+      );
       activeRestartAttemptId = msg.restartAttemptId;
       sessionId = msg.sessionId;
       refreshTerminalViewToken();

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -11477,6 +11477,12 @@ process.on('message', async (raw: unknown) => {
       const initStartedAtMs = Date.now();
       if (lastInitConfig) return;  // already initialized
       lastInitConfig = msg;
+      // Claude bridge local-turn synthesis is adopt-only: a human typing in an
+      // adopted pane produces local turns that must reach Lark. In managed mode
+      // (normal Lark triggers OR core-only/apiOnly) there is no local input, so
+      // every transcript user event belongs to a pending durable mark — see
+      // BridgeTurnQueue.setLocalTurns. Mirrors codexBridgeQueue.setLocalTurns.
+      bridgeQueue.setLocalTurns(msg.adoptMode === true);
       activeRestartAttemptId = msg.restartAttemptId;
       sessionId = msg.sessionId;
       refreshTerminalViewToken();

--- a/test/bridge-turn-queue.test.ts
+++ b/test/bridge-turn-queue.test.ts
@@ -928,10 +928,15 @@ describe('BridgeTurnQueue', () => {
   // no adopt) there is no local input, so the next meaningful user event MUST
   // bind the pending durable mark rather than synthesise a local turn that
   // steals the line and leaves the mark to expire with no final_output.
-  describe('managed mode (no local turns): fingerprint-mismatched user binds the pending durable mark', () => {
+  // Truncation-fallback (STRICT no-write apiOnly / core-only / HTTP-virtual):
+  // claude-code TRUNCATES the leading envelope lines when persisting the user
+  // turn, so a head-substring fingerprint can never match. Since local terminal
+  // write is impossible for these sessions, the mismatched user event is
+  // unambiguously the pending durable turn — bind it (not local-synth).
+  describe('truncation-fallback (no-write apiOnly): mismatched user binds the pending durable mark', () => {
     it('binds the pending mark even when the transcript user line does NOT contain the fingerprint', () => {
       const q = new BridgeTurnQueue();
-      // default: setLocalTurns NOT called → managed mode
+      q.setTruncationFallback(true); // strict no-write session
       const fp = makeFingerprint('<user_message>\n<botmux_task trusted="true">\nDo the thing');
       q.mark('t1', fp, 100, undefined, 7); // durable trigger (dispatchAttempt)
       // claude wrote only the truncated tail — no <botmux_task> prefix, so the
@@ -945,8 +950,9 @@ describe('BridgeTurnQueue', () => {
       expect(q.size()).toBe(0);
     });
 
-    it('does NOT synthesise a local turn on a mismatched user event in managed mode', () => {
+    it('does NOT synthesise a local turn on a mismatched user event (no-write session)', () => {
       const q = new BridgeTurnQueue();
+      q.setTruncationFallback(true);
       const fp = makeFingerprint('a prompt whose head claude will drop');
       q.mark('t1', fp);
       q.ingest([user('u1', 'totally different recorded text'), assistant('a1', 'reply')]);
@@ -958,16 +964,57 @@ describe('BridgeTurnQueue', () => {
       expect(ready[0].assistantUuids).toEqual(['a1']);
     });
 
-    it('managed mode: a stray USER event with NO pending mark does not start a local turn', () => {
+    it('no-write session: a stray USER event with NO pending mark does not start a local turn', () => {
       const q = new BridgeTurnQueue();
+      q.setTruncationFallback(true);
       // No mark() — a stray user line (e.g. mark not yet created) must not be
-      // synthesised as a local turn in managed mode. (An orphan assistant
-      // continuation after a restart IS still recovered via the headless path —
-      // that is deliberate and not exercised here.)
+      // synthesised as a local turn. (An orphan assistant continuation after a
+      // restart IS still recovered via the headless path — not exercised here.)
       q.ingest([user('u1', 'orphan user line')]);
       expect(q.peek().some(t => t.isLocal)).toBe(false);
       expect(q.peek()).toHaveLength(0);
       expect(q.drainEmittable()).toEqual([]);
+    });
+  });
+
+  // codex PR #724 P1 regression: adoptMode=false is NOT "no local input". A
+  // NORMAL managed session (truncationFallback OFF — it can mint a Web Terminal
+  // write token) must keep the mismatch→local-synth path: a human-typed local
+  // turn there must NOT steal the API/Lark durable mark.
+  describe('normal managed + writable terminal (truncationFallback OFF): local input does NOT steal the durable mark', () => {
+    it('a Web Terminal local turn does NOT consume the pending API durable mark', () => {
+      const q = new BridgeTurnQueue();
+      // Neither flag set → normal managed. Local write IS possible here.
+      const fp = makeFingerprint('trusted API prompt');
+      q.mark('api-trigger', fp, 100, undefined, 9); // durable API trigger
+      // Human typed in the Web Terminal while the API turn was pending:
+      q.ingest([user('web-u', 'pwd'), assistant('web-a', '/tmp')]);
+      // The local turn is synthesised (not bound to api-trigger); the durable
+      // mark stays pending, unstolen.
+      const apiMark = q.peek().find(t => t.turnId === 'api-trigger');
+      expect(apiMark?.started).toBe(false);
+      const ready = q.drainEmittable();
+      expect(ready).toHaveLength(1);
+      expect(ready[0].isLocal).toBe(true);
+      expect(ready[0].turnId).not.toBe('api-trigger');
+      expect(ready[0].assistantUuids).toEqual(['web-a']);
+      // When the REAL API user line lands, api-trigger binds normally.
+      q.ingest([user('api-u', 'trusted API prompt — full'), assistant('api-a', 'API reply')]);
+      const next = q.drainEmittable();
+      expect(next).toHaveLength(1);
+      expect(next[0].turnId).toBe('api-trigger');
+      expect(next[0].dispatchAttempt).toBe(9);
+      expect(next[0].assistantUuids).toEqual(['api-a']);
+    });
+
+    it('normal managed: a no-pending-mark local turn is emitted (not silently dropped)', () => {
+      const q = new BridgeTurnQueue();
+      // No mark; local human input with no pending Lark/API turn.
+      q.ingest([user('web-u', 'ls'), assistant('web-a', 'file listing')]);
+      const ready = q.drainEmittable();
+      expect(ready).toHaveLength(1);
+      expect(ready[0].isLocal).toBe(true);
+      expect(ready[0].assistantUuids).toEqual(['web-a']);
     });
   });
 });

--- a/test/bridge-turn-queue.test.ts
+++ b/test/bridge-turn-queue.test.ts
@@ -13,7 +13,7 @@
  *     yet (e.g. Claude is still in tool-use mid-turn)
  */
 import { describe, it, expect } from 'vitest';
-import { BridgeTurnQueue, makeFingerprint } from '../src/services/bridge-turn-queue.js';
+import { BridgeTurnQueue, makeFingerprint, isTruncatedMatch } from '../src/services/bridge-turn-queue.js';
 import { shouldSuppressBridgeEmit, type BridgeSendMarker } from '../src/services/bridge-fallback-gate.js';
 import type { TranscriptEvent } from '../src/services/claude-transcript.js';
 
@@ -122,7 +122,6 @@ describe('BridgeTurnQueue', () => {
 
   it('local-terminal turn before any Lark message: emitted as isLocal turn (not dropped)', () => {
     const q = new BridgeTurnQueue();
-    q.setLocalTurns(true); // adopt mode: a human types in the pane
     // Local user types in the original pane — no pending turn yet
     q.ingest([user('local-u1'), assistant('local-a1', 'local reply')]);
     // Then a Lark message arrives
@@ -141,7 +140,6 @@ describe('BridgeTurnQueue', () => {
 
   it('local turn between two Lark turns: local emits separately, neither Lark turn is polluted', () => {
     const q = new BridgeTurnQueue();
-    q.setLocalTurns(true); // adopt mode: a human types in the pane
     q.mark('t1');
     q.ingest([user('u1'), assistant('a1', 'lark1')]);
     // After t1 is started+collected but not yet emitted, local user types
@@ -360,7 +358,6 @@ describe('BridgeTurnQueue', () => {
 
   it('fingerprint match: only the matching user event starts the Lark turn; non-match becomes a local turn', () => {
     const q = new BridgeTurnQueue();
-    q.setLocalTurns(true); // adopt mode: local `ls -la` is a real human turn
     const fp = makeFingerprint('please review the new patch');
     q.mark('t1', fp);
     // Local user types something else first — synthesised as a local turn
@@ -381,7 +378,6 @@ describe('BridgeTurnQueue', () => {
 
   it('fingerprint mismatch: local user with different content creates a local turn but does NOT start the Lark turn', () => {
     const q = new BridgeTurnQueue();
-    q.setLocalTurns(true); // adopt mode: distinct local input must not steal the Lark mark
     const fp = makeFingerprint('lark-specific question');
     q.mark('t1', fp);
     // Local user types — content does not match fingerprint
@@ -564,7 +560,6 @@ describe('BridgeTurnQueue', () => {
   describe('local-terminal turn forwarding', () => {
     it('marks the synthesised turn as isLocal and captures userUuid', () => {
       const q = new BridgeTurnQueue();
-      q.setLocalTurns(true);
       q.ingest([user('local-u1', 'pwd'), assistant('local-a1', '/tmp')]);
       const ready = q.drainEmittable();
       expect(ready).toHaveLength(1);
@@ -582,7 +577,6 @@ describe('BridgeTurnQueue', () => {
 
     it('empty local turn (no assistant text yet) is dropped on the next user event', () => {
       const q = new BridgeTurnQueue();
-      q.setLocalTurns(true);
       // First local prompt — Claude crashed / cancelled before responding.
       q.ingest([user('local-u1', 'first')]);
       // Queue now has a started local turn with no assistant uuids.
@@ -600,7 +594,6 @@ describe('BridgeTurnQueue', () => {
 
     it('an empty Lark turn (no fingerprint match yet) is NOT dropped by a local turn arriving', () => {
       const q = new BridgeTurnQueue();
-      q.setLocalTurns(true);
       q.mark('t1', makeFingerprint('lark question'));
       // Local input arrives first — must not consume / drop the unstarted Lark turn.
       q.ingest([user('local-u', 'something else'), assistant('local-a', 'local reply')]);
@@ -620,7 +613,6 @@ describe('BridgeTurnQueue', () => {
 
     it('back-to-back local turns each emit independently with their own uuids', () => {
       const q = new BridgeTurnQueue();
-      q.setLocalTurns(true);
       q.ingest([
         user('local-u1', 'first'),
         assistant('local-a1', 'first reply'),
@@ -644,7 +636,6 @@ describe('BridgeTurnQueue', () => {
       // text. The empty-collecting drop now applies to Lark turns too, so
       // the abandoned turn is removed and the next turn emits cleanly.
       const q = new BridgeTurnQueue();
-      q.setLocalTurns(true);
       q.mark('t1');
       q.ingest([user('u1')]);  // t1 started, model went silent
       q.ingest([user('local-u'), assistant('local-a', 'local reply')]);
@@ -757,7 +748,6 @@ describe('BridgeTurnQueue', () => {
 
     it('queued_command prompt mismatch falls through to local turn synthesised from attachment.prompt', () => {
       const q = new BridgeTurnQueue();
-      q.setLocalTurns(true); // adopt mode: the type-ahead prompt is real human input
       q.mark('t1', makeFingerprint('lark-specific question'));
       // User typed something else directly in the pane while Claude was busy
       // — it landed in the type-ahead queue and now dequeues as a
@@ -921,85 +911,71 @@ describe('BridgeTurnQueue', () => {
     });
   });
 
-  // Regression for the core-only / managed-mode completion bug: claude-code
-  // TRUNCATES the leading envelope lines (`<user_message>` + `<botmux_task …>`)
-  // when persisting the user turn to its transcript, so a head-substring
-  // fingerprint can NEVER match the recorded line. In MANAGED mode (default —
-  // no adopt) there is no local input, so the next meaningful user event MUST
-  // bind the pending durable mark rather than synthesise a local turn that
-  // steals the line and leaves the mark to expire with no final_output.
-  // Truncation-fallback (STRICT no-write apiOnly / core-only / HTTP-virtual):
-  // claude-code TRUNCATES the leading envelope lines when persisting the user
-  // turn, so a head-substring fingerprint can never match. Since local terminal
-  // write is impossible for these sessions, the mismatched user event is
-  // unambiguously the pending durable turn — bind it (not local-synth).
-  describe('truncation-fallback (no-write apiOnly): mismatched user binds the pending durable mark', () => {
-    it('binds the pending mark even when the transcript user line does NOT contain the fingerprint', () => {
-      const q = new BridgeTurnQueue();
-      q.setTruncationFallback(true); // strict no-write session
-      const fp = makeFingerprint('<user_message>\n<botmux_task trusted="true">\nDo the thing');
-      q.mark('t1', fp, 100, undefined, 7); // durable trigger (dispatchAttempt)
-      // claude wrote only the truncated tail — no <botmux_task> prefix, so the
-      // head fingerprint is absent from the recorded line.
-      q.ingest([user('u1', 'Do the thing\n</botmux_task>\n</user_message>'), assistant('a1', 'CC_DONE')]);
-      const ready = q.drainEmittable();
-      expect(ready).toHaveLength(1);
-      expect(ready[0].turnId).toBe('t1');       // bound to the durable mark, NOT local-*
-      expect(ready[0].isLocal).toBeFalsy();
-      expect(ready[0].assistantUuids).toEqual(['a1']);
-      expect(q.size()).toBe(0);
+  // Truncation-proof bind (codex PR #724): claude-code TRUNCATES the leading
+  // envelope lines (`<user_message>` + `<botmux_task …>`) when persisting the
+  // user turn, so the head-substring fingerprint never matches. We bind the
+  // pending durable mark ONLY when the recorded line is a PROVABLE truncation
+  // (its normalised text is a contiguous substring of the mark's full
+  // contentNormalized) — capability-agnostic, so an unrelated local terminal
+  // turn cannot steal the mark regardless of write-token access.
+  describe('isTruncatedMatch (content proof)', () => {
+    const full = makeFingerprintFull('<user_message> <botmux_task trusted="true"> Please run the migration and report results </botmux_task> </user_message>');
+    it('accepts the surviving tail of the marked content', () => {
+      expect(isTruncatedMatch('Please run the migration and report results </botmux_task> </user_message>', full)).toBe(true);
     });
-
-    it('does NOT synthesise a local turn on a mismatched user event (no-write session)', () => {
-      const q = new BridgeTurnQueue();
-      q.setTruncationFallback(true);
-      const fp = makeFingerprint('a prompt whose head claude will drop');
-      q.mark('t1', fp);
-      q.ingest([user('u1', 'totally different recorded text'), assistant('a1', 'reply')]);
-      // No local-* turn is ever created; the mark is bound instead.
-      expect(q.peek().some(t => t.isLocal)).toBe(false);
-      const ready = q.drainEmittable();
-      expect(ready).toHaveLength(1);
-      expect(ready[0].turnId).toBe('t1');
-      expect(ready[0].assistantUuids).toEqual(['a1']);
+    it('rejects unrelated short local input (pwd / ls)', () => {
+      expect(isTruncatedMatch('pwd', full)).toBe(false);
+      expect(isTruncatedMatch('ls -la', full)).toBe(false);
     });
-
-    it('no-write session: a stray USER event with NO pending mark does not start a local turn', () => {
-      const q = new BridgeTurnQueue();
-      q.setTruncationFallback(true);
-      // No mark() — a stray user line (e.g. mark not yet created) must not be
-      // synthesised as a local turn. (An orphan assistant continuation after a
-      // restart IS still recovered via the headless path — not exercised here.)
-      q.ingest([user('u1', 'orphan user line')]);
-      expect(q.peek().some(t => t.isLocal)).toBe(false);
-      expect(q.peek()).toHaveLength(0);
-      expect(q.drainEmittable()).toEqual([]);
+    it('rejects when there is no mark content', () => {
+      expect(isTruncatedMatch('anything at all here', undefined)).toBe(false);
+      expect(isTruncatedMatch('anything at all here', '')).toBe(false);
+    });
+    it('rejects a too-short recorded line even if it is a substring', () => {
+      expect(isTruncatedMatch('run', full)).toBe(false); // below TRUNCATION_MATCH_MIN_CHARS
+    });
+    it('rejects text that is NOT a substring of the mark', () => {
+      expect(isTruncatedMatch('a completely different instruction entirely', full)).toBe(false);
     });
   });
 
-  // codex PR #724 P1 regression: adoptMode=false is NOT "no local input". A
-  // NORMAL managed session (truncationFallback OFF — it can mint a Web Terminal
-  // write token) must keep the mismatch→local-synth path: a human-typed local
-  // turn there must NOT steal the API/Lark durable mark.
-  describe('normal managed + writable terminal (truncationFallback OFF): local input does NOT steal the durable mark', () => {
-    it('a Web Terminal local turn does NOT consume the pending API durable mark', () => {
+  describe('truncation-proof bind in the queue (durable mark, mismatched head)', () => {
+    it('binds the durable mark when the recorded line is a provable truncation of the marked content', () => {
       const q = new BridgeTurnQueue();
-      // Neither flag set → normal managed. Local write IS possible here.
-      const fp = makeFingerprint('trusted API prompt');
-      q.mark('api-trigger', fp, 100, undefined, 9); // durable API trigger
-      // Human typed in the Web Terminal while the API turn was pending:
+      const marked = '<user_message>\n<botmux_task trusted="true">\nDo the migration and report</botmux_task>\n</user_message>';
+      const fp = makeFingerprint(marked);
+      const norm = makeFingerprintFull(marked);
+      q.mark('t1', fp, 100, norm, 7); // durable trigger with contentNormalized
+      // claude persisted only the truncated tail (head envelope dropped):
+      q.ingest([user('u1', 'Do the migration and report</botmux_task>\n</user_message>'), assistant('a1', 'CC_DONE')]);
+      const ready = q.drainEmittable();
+      expect(ready).toHaveLength(1);
+      expect(ready[0].turnId).toBe('t1');
+      expect(ready[0].isLocal).toBeFalsy();
+      expect(ready[0].dispatchAttempt).toBe(7);
+      expect(ready[0].assistantUuids).toEqual(['a1']);
+    });
+
+    // codex PR #724 P1: a Web Terminal local turn (capability exists on ANY
+    // session, incl. apiOnly/core-only via write-link) must NOT steal the
+    // durable mark. The content proof makes this hold WITHOUT keying on session
+    // type — `pwd` is not a substring of the marked prompt.
+    it('does NOT let an unrelated Web Terminal local turn steal the durable mark', () => {
+      const q = new BridgeTurnQueue();
+      const marked = 'trusted API prompt: analyse the failing test and propose a fix';
+      const fp = makeFingerprint(marked);
+      const norm = makeFingerprintFull(marked);
+      q.mark('api-trigger', fp, 100, norm, 9);
+      // Human typed `pwd` in the Web Terminal while api-trigger was pending:
       q.ingest([user('web-u', 'pwd'), assistant('web-a', '/tmp')]);
-      // The local turn is synthesised (not bound to api-trigger); the durable
-      // mark stays pending, unstolen.
       const apiMark = q.peek().find(t => t.turnId === 'api-trigger');
-      expect(apiMark?.started).toBe(false);
+      expect(apiMark?.started).toBe(false); // NOT stolen
       const ready = q.drainEmittable();
       expect(ready).toHaveLength(1);
       expect(ready[0].isLocal).toBe(true);
       expect(ready[0].turnId).not.toBe('api-trigger');
-      expect(ready[0].assistantUuids).toEqual(['web-a']);
-      // When the REAL API user line lands, api-trigger binds normally.
-      q.ingest([user('api-u', 'trusted API prompt — full'), assistant('api-a', 'API reply')]);
+      // The real API user line binds it afterwards.
+      q.ingest([user('api-u', 'trusted API prompt: analyse the failing test and propose a fix'), assistant('api-a', 'API reply')]);
       const next = q.drainEmittable();
       expect(next).toHaveLength(1);
       expect(next[0].turnId).toBe('api-trigger');
@@ -1007,14 +983,21 @@ describe('BridgeTurnQueue', () => {
       expect(next[0].assistantUuids).toEqual(['api-a']);
     });
 
-    it('normal managed: a no-pending-mark local turn is emitted (not silently dropped)', () => {
+    it('no truncation proof + no fingerprint match → synth local (not silently dropped)', () => {
       const q = new BridgeTurnQueue();
-      // No mark; local human input with no pending Lark/API turn.
-      q.ingest([user('web-u', 'ls'), assistant('web-a', 'file listing')]);
+      q.mark('t1', makeFingerprint('some API prompt'), 100, makeFingerprintFull('some API prompt'));
+      q.ingest([user('web-u', 'unrelated local command output here'), assistant('web-a', 'result')]);
       const ready = q.drainEmittable();
       expect(ready).toHaveLength(1);
-      expect(ready[0].isLocal).toBe(true);
-      expect(ready[0].assistantUuids).toEqual(['web-a']);
+      expect(ready[0].isLocal).toBe(true); // emitted, not dropped
+      const t1 = q.peek().find(t => t.turnId === 't1');
+      expect(t1?.started).toBe(false); // mark untouched
     });
   });
 });
+
+/** Local helper: full normalised content (what the worker stores as
+ *  contentNormalized), distinct from the 30-char makeFingerprint. */
+function makeFingerprintFull(message: string): string {
+  return message.replace(/\s+/g, ' ').trim();
+}

--- a/test/bridge-turn-queue.test.ts
+++ b/test/bridge-turn-queue.test.ts
@@ -937,6 +937,21 @@ describe('BridgeTurnQueue', () => {
     it('rejects text that is NOT a substring of the mark', () => {
       expect(isTruncatedMatch('a completely different instruction entirely', full)).toBe(false);
     });
+    // codex PR #724 review 4851322948 (P1): an INTERIOR ≥16-char substring must
+    // be false. A Web Terminal operator typing a command/phrase that appears in
+    // the MIDDLE of the marked task body is not the surviving truncation tail,
+    // so it must not prove belonging (the old `includes` accepted these and let
+    // the local turn steal the pending durable mark).
+    it('rejects an interior command substring (codex repro: run pnpm test --project unit)', () => {
+      const marked = makeFingerprintFull('<user_message> <botmux_task trusted="true"> Please investigate the failure; run pnpm test --project unit and report results </botmux_task> </user_message>');
+      // Both are ≥16-char substrings that appear INTERIOR to the mark, not as a
+      // suffix. The old `includes` accepted them (letting a local turn steal the
+      // durable mark); the `endsWith` anchor must reject both.
+      expect(isTruncatedMatch('run pnpm test --project unit', marked)).toBe(false);
+      expect(isTruncatedMatch('investigate the failure', marked)).toBe(false);
+      // Sanity: the genuine surviving tail (a real suffix, ≥16) still proves true.
+      expect(isTruncatedMatch('run pnpm test --project unit and report results </botmux_task> </user_message>', marked)).toBe(true);
+    });
   });
 
   describe('truncation-proof bind in the queue (durable mark, mismatched head)', () => {
@@ -980,6 +995,35 @@ describe('BridgeTurnQueue', () => {
       expect(next).toHaveLength(1);
       expect(next[0].turnId).toBe('api-trigger');
       expect(next[0].dispatchAttempt).toBe(9);
+      expect(next[0].assistantUuids).toEqual(['api-a']);
+    });
+
+    // codex PR #724 review 4851322948 (P1): the SHARP repro — an operator types
+    // a command that appears verbatim in the MIDDLE of the marked task body.
+    // Under the old `includes` this ≥16-char interior substring proved true and
+    // stole the pending durable mark. The `endsWith` anchor rejects it (not a
+    // suffix), so it synthesises a local turn and the durable mark survives to
+    // be bound by its real (truncated-tail) user line.
+    it('does NOT let an interior-command local turn steal the durable mark (endsWith anchor)', () => {
+      const q = new BridgeTurnQueue();
+      const marked = '<user_message>\n<botmux_task trusted="true">\nInvestigate the failure; run pnpm test --project unit and report results</botmux_task>\n</user_message>';
+      const fp = makeFingerprint(marked);
+      const norm = makeFingerprintFull(marked);
+      q.mark('api-trigger', fp, 100, norm, 11);
+      // Operator types the exact command that lives INTERIOR to the marked body:
+      q.ingest([user('web-u', 'run pnpm test --project unit'), assistant('web-a', 'FAIL: 2 tests')]);
+      const apiMark = q.peek().find(t => t.turnId === 'api-trigger');
+      expect(apiMark?.started).toBe(false); // interior substring must NOT steal
+      const ready = q.drainEmittable();
+      expect(ready).toHaveLength(1);
+      expect(ready[0].isLocal).toBe(true);
+      expect(ready[0].turnId).not.toBe('api-trigger');
+      // The real durable turn's truncated tail (a genuine suffix) binds it after.
+      q.ingest([user('api-u', 'run pnpm test --project unit and report results</botmux_task>\n</user_message>'), assistant('api-a', 'API reply')]);
+      const next = q.drainEmittable();
+      expect(next).toHaveLength(1);
+      expect(next[0].turnId).toBe('api-trigger');
+      expect(next[0].dispatchAttempt).toBe(11);
       expect(next[0].assistantUuids).toEqual(['api-a']);
     });
 

--- a/test/bridge-turn-queue.test.ts
+++ b/test/bridge-turn-queue.test.ts
@@ -122,6 +122,7 @@ describe('BridgeTurnQueue', () => {
 
   it('local-terminal turn before any Lark message: emitted as isLocal turn (not dropped)', () => {
     const q = new BridgeTurnQueue();
+    q.setLocalTurns(true); // adopt mode: a human types in the pane
     // Local user types in the original pane — no pending turn yet
     q.ingest([user('local-u1'), assistant('local-a1', 'local reply')]);
     // Then a Lark message arrives
@@ -140,6 +141,7 @@ describe('BridgeTurnQueue', () => {
 
   it('local turn between two Lark turns: local emits separately, neither Lark turn is polluted', () => {
     const q = new BridgeTurnQueue();
+    q.setLocalTurns(true); // adopt mode: a human types in the pane
     q.mark('t1');
     q.ingest([user('u1'), assistant('a1', 'lark1')]);
     // After t1 is started+collected but not yet emitted, local user types
@@ -358,6 +360,7 @@ describe('BridgeTurnQueue', () => {
 
   it('fingerprint match: only the matching user event starts the Lark turn; non-match becomes a local turn', () => {
     const q = new BridgeTurnQueue();
+    q.setLocalTurns(true); // adopt mode: local `ls -la` is a real human turn
     const fp = makeFingerprint('please review the new patch');
     q.mark('t1', fp);
     // Local user types something else first — synthesised as a local turn
@@ -378,6 +381,7 @@ describe('BridgeTurnQueue', () => {
 
   it('fingerprint mismatch: local user with different content creates a local turn but does NOT start the Lark turn', () => {
     const q = new BridgeTurnQueue();
+    q.setLocalTurns(true); // adopt mode: distinct local input must not steal the Lark mark
     const fp = makeFingerprint('lark-specific question');
     q.mark('t1', fp);
     // Local user types — content does not match fingerprint
@@ -560,6 +564,7 @@ describe('BridgeTurnQueue', () => {
   describe('local-terminal turn forwarding', () => {
     it('marks the synthesised turn as isLocal and captures userUuid', () => {
       const q = new BridgeTurnQueue();
+      q.setLocalTurns(true);
       q.ingest([user('local-u1', 'pwd'), assistant('local-a1', '/tmp')]);
       const ready = q.drainEmittable();
       expect(ready).toHaveLength(1);
@@ -577,6 +582,7 @@ describe('BridgeTurnQueue', () => {
 
     it('empty local turn (no assistant text yet) is dropped on the next user event', () => {
       const q = new BridgeTurnQueue();
+      q.setLocalTurns(true);
       // First local prompt — Claude crashed / cancelled before responding.
       q.ingest([user('local-u1', 'first')]);
       // Queue now has a started local turn with no assistant uuids.
@@ -594,6 +600,7 @@ describe('BridgeTurnQueue', () => {
 
     it('an empty Lark turn (no fingerprint match yet) is NOT dropped by a local turn arriving', () => {
       const q = new BridgeTurnQueue();
+      q.setLocalTurns(true);
       q.mark('t1', makeFingerprint('lark question'));
       // Local input arrives first — must not consume / drop the unstarted Lark turn.
       q.ingest([user('local-u', 'something else'), assistant('local-a', 'local reply')]);
@@ -613,6 +620,7 @@ describe('BridgeTurnQueue', () => {
 
     it('back-to-back local turns each emit independently with their own uuids', () => {
       const q = new BridgeTurnQueue();
+      q.setLocalTurns(true);
       q.ingest([
         user('local-u1', 'first'),
         assistant('local-a1', 'first reply'),
@@ -636,6 +644,7 @@ describe('BridgeTurnQueue', () => {
       // text. The empty-collecting drop now applies to Lark turns too, so
       // the abandoned turn is removed and the next turn emits cleanly.
       const q = new BridgeTurnQueue();
+      q.setLocalTurns(true);
       q.mark('t1');
       q.ingest([user('u1')]);  // t1 started, model went silent
       q.ingest([user('local-u'), assistant('local-a', 'local reply')]);
@@ -748,6 +757,7 @@ describe('BridgeTurnQueue', () => {
 
     it('queued_command prompt mismatch falls through to local turn synthesised from attachment.prompt', () => {
       const q = new BridgeTurnQueue();
+      q.setLocalTurns(true); // adopt mode: the type-ahead prompt is real human input
       q.mark('t1', makeFingerprint('lark-specific question'));
       // User typed something else directly in the pane while Claude was busy
       // — it landed in the type-ahead queue and now dequeues as a
@@ -908,6 +918,56 @@ describe('BridgeTurnQueue', () => {
           false,
         ),
       ).toBe(true);
+    });
+  });
+
+  // Regression for the core-only / managed-mode completion bug: claude-code
+  // TRUNCATES the leading envelope lines (`<user_message>` + `<botmux_task …>`)
+  // when persisting the user turn to its transcript, so a head-substring
+  // fingerprint can NEVER match the recorded line. In MANAGED mode (default —
+  // no adopt) there is no local input, so the next meaningful user event MUST
+  // bind the pending durable mark rather than synthesise a local turn that
+  // steals the line and leaves the mark to expire with no final_output.
+  describe('managed mode (no local turns): fingerprint-mismatched user binds the pending durable mark', () => {
+    it('binds the pending mark even when the transcript user line does NOT contain the fingerprint', () => {
+      const q = new BridgeTurnQueue();
+      // default: setLocalTurns NOT called → managed mode
+      const fp = makeFingerprint('<user_message>\n<botmux_task trusted="true">\nDo the thing');
+      q.mark('t1', fp, 100, undefined, 7); // durable trigger (dispatchAttempt)
+      // claude wrote only the truncated tail — no <botmux_task> prefix, so the
+      // head fingerprint is absent from the recorded line.
+      q.ingest([user('u1', 'Do the thing\n</botmux_task>\n</user_message>'), assistant('a1', 'CC_DONE')]);
+      const ready = q.drainEmittable();
+      expect(ready).toHaveLength(1);
+      expect(ready[0].turnId).toBe('t1');       // bound to the durable mark, NOT local-*
+      expect(ready[0].isLocal).toBeFalsy();
+      expect(ready[0].assistantUuids).toEqual(['a1']);
+      expect(q.size()).toBe(0);
+    });
+
+    it('does NOT synthesise a local turn on a mismatched user event in managed mode', () => {
+      const q = new BridgeTurnQueue();
+      const fp = makeFingerprint('a prompt whose head claude will drop');
+      q.mark('t1', fp);
+      q.ingest([user('u1', 'totally different recorded text'), assistant('a1', 'reply')]);
+      // No local-* turn is ever created; the mark is bound instead.
+      expect(q.peek().some(t => t.isLocal)).toBe(false);
+      const ready = q.drainEmittable();
+      expect(ready).toHaveLength(1);
+      expect(ready[0].turnId).toBe('t1');
+      expect(ready[0].assistantUuids).toEqual(['a1']);
+    });
+
+    it('managed mode: a stray USER event with NO pending mark does not start a local turn', () => {
+      const q = new BridgeTurnQueue();
+      // No mark() — a stray user line (e.g. mark not yet created) must not be
+      // synthesised as a local turn in managed mode. (An orphan assistant
+      // continuation after a restart IS still recovered via the headless path —
+      // that is deliberate and not exercised here.)
+      q.ingest([user('u1', 'orphan user line')]);
+      expect(q.peek().some(t => t.isLocal)).toBe(false);
+      expect(q.peek()).toHaveLength(0);
+      expect(q.drainEmittable()).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## 问题
core-only（apiOnly）跑 `BOTMUX_CORE_CLI=claude-code` 时，若 SessionStart ready-gate 走 45s 超时 fallback（riff 嵌套 sandbox 稳定触发），首 prompt flush 后 `GET /api/sessions/:id/trigger-result` **永远 `running`、不翻 completed**，riff 客户端 poll 到 idle 超时。对比 codex 场景正常。

riff 逐行日志定位（感谢）：
- claude `BridgeTurnQueue` 在 fingerprint mismatch 时**无条件**合成 local-typed turn。
- claude-code 落盘 user 行时**截掉开头** `<user_message>` + `<botmux_task trusted="true">` 两行（只留尾部 `</botmux_external_event></user_message>`）→ head-substring fingerprint 永不匹配。
- 那条 user 行 fall through 成 local turn（`local-4e…`），其 fallback 按 local-typed 被 suppressed；原始 trigger mark 从没匹配到任何 user 行，120s 后 `Bridge mark expired` 丢弃 → 无 final_output → 永久 running。

## 根因
claude 的 `BridgeTurnQueue` **缺了 `CodexBridgeQueue` 已有的 adopt-only 门控**。local-turn 合成只在 adopt（真人在 pane 敲字）才合理；managed 模式（普通 Lark 触发 OR core-only/apiOnly）没有本地输入，每条 transcript user 事件都属于某个 pending durable mark，合成 local 永远错——它偷走了 mark 该绑的行。修 codex 完成检测（PR #707）时给了 codex 这道闸，claude queue 没同步 = **parity gap**。

## 修法
- `BridgeTurnQueue` 加 `setLocalTurns(enabled)` + `localTurnsEnabled`（默认 false = managed，镜像 `CodexBridgeQueue`）。
- `handleTurnStart`：fingerprint mismatch 时——**managed 模式绑定最早的 pending durable mark**（无本地输入，下一条 meaningful user 行必是此 turn，不靠 head fingerprint）；**adopt 模式**才 fall through 合成 local。managed 下无 pending mark 的 stray user 也不合成 local（headless 助手续写的 restart 恢复路径保留不动）。
- `worker.ts` init：`bridgeQueue.setLocalTurns(msg.adoptMode === true)`（单一权威点，镜像 codex 的默认 false + adopt 置 true）。

## 影响面
- 仅 claude 家族 bridge（`BridgeTurnQueue`）；codex/traex/grok 各自 queue 不受影响。
- **adopt 模式行为不变**（真人本地输入仍合成 local turn）——50 个既有 adopt 测试加显式 `setLocalTurns(true)` opt-in 后全绿。
- managed 模式（含正常 fleet 的 Lark 触发）：mismatch 现绑 durable mark。正常 fleet fingerprint 通常能匹配，此路径只在 claude 截头/信号迟到等边缘触发，绑定比合成 local 更正确。

## 测试
- `pnpm build` 绿；`bridge-turn-queue`(53：50 adopt + 3 新 managed 回归) + `claude-transcript` + `claude-turn-terminal-contract` 共 **154 单测全绿**。
- 新 managed 回归钉死 riff 场景：截头 user 行仍绑 durable mark（非 `local-*`）、mismatch 不合成 local、stray user 跳过。
- ⚠️ **本地无法复现 45s ready-gate 超时路径**（隔离环境 SessionStart 秒到、从不超时）。队列层截头场景已单测钉死；完整链路的超时触发由 **riff 嵌套 sandbox 真机验证**（其环境稳定触发超时）——canary 出后 riff 复验 trigger-result 是否 completed。

## 备注
Bug B（每轮 ~45s ready-gate 空等，SessionStart 信号迟到 ~1.2s 输给 fallback）是**独立延迟问题，本 PR 不含**，下一轮单独做（apiOnly 免 signal-gate 但保留 PTY-quiescence settle）。本 PR 是正确性修复（让任务*能*完成），Bug B 是延迟优化（让它*变快*）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)