### PR TITLE
fix(card): 完成后撤回执行状态卡

### DIFF
--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -1172,6 +1172,7 @@ export function persistStreamCardState(ds: DaemonSession): void {
   if (
     s.streamCardId === cardId &&
     s.streamCardNonce === ds.streamCardNonce &&
+    s.streamCardTurnId === ds.streamCardTurnId &&
     s.displayMode === ds.displayMode &&
     s.currentImageKey === ds.currentImageKey &&
     s.currentTurnTitle === ds.currentTurnTitle &&
@@ -1184,6 +1185,7 @@ export function persistStreamCardState(ds: DaemonSession): void {
   ) return;
   s.streamCardId = cardId;
   s.streamCardNonce = ds.streamCardNonce;
+  s.streamCardTurnId = ds.streamCardTurnId;
   s.displayMode = ds.displayMode;
   s.currentImageKey = ds.currentImageKey;
   s.currentTurnTitle = ds.currentTurnTitle;
@@ -1395,6 +1397,7 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
         adoptedFrom: adopted,
         streamCardId: session.streamCardId,
         streamCardNonce: session.streamCardNonce,
+        streamCardTurnId: session.streamCardTurnId,
         displayMode: session.displayMode === 'screenshot' || session.displayMode === 'hidden'
           ? session.displayMode
           : (session.streamExpanded ? 'screenshot' : 'hidden'),
@@ -1517,6 +1520,7 @@ export async function restoreActiveSessions(activeSessions: Map<string, DaemonSe
       // letting the next update create a new card.
       streamCardId: session.streamCardId,
       streamCardNonce: session.streamCardNonce,
+      streamCardTurnId: session.streamCardTurnId,
       displayMode: session.displayMode ?? (session.streamExpanded ? 'screenshot' : 'hidden'),
       currentImageKey: session.currentImageKey,
       currentTurnTitle: session.currentTurnTitle,
@@ -1982,6 +1986,7 @@ export async function resumeSession(
     ownerOpenId: session.ownerOpenId,
     streamCardId: session.streamCardId,
     streamCardNonce: session.streamCardNonce,
+    streamCardTurnId: session.streamCardTurnId,
     displayMode: session.displayMode ?? (session.streamExpanded ? 'screenshot' : 'hidden'),
     currentImageKey: session.currentImageKey,
     currentTurnTitle: session.currentTurnTitle,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -153,7 +153,21 @@ export interface DaemonSession {
   ownerOpenId?: string;          // topic creator's open_id — receives write-enabled terminal link via DM
   streamCardId?: string;         // message_id of the streaming card in group (PATCHed with live output)
   streamCardNonce?: string;       // unique nonce for the current streaming card — embedded in button values to distinguish old vs current card
+  streamCardTurnId?: string;      // exact turn represented by streamCardId; persisted for restart-safe completion recall
   streamCardPending?: boolean;    // true when a new turn started, next screen_update creates a new card
+  /** Two-phase completion evidence keyed by turn: the status card is recalled
+   *  only after both a completed terminal and a successful result delivery.
+   *  In-memory only; bounded and pruned by worker-pool. */
+  streamCardCompletionTurns?: Map<string, {
+    terminalCompleted?: true;
+    resultDelivered?: true;
+    recallAttempts?: number;
+    recallTimer?: NodeJS.Timeout;
+    updatedAt: number;
+  }>;
+  /** Suppresses trailing idle updates from recreating a card that completion
+   *  recall just withdrew. Cleared when the daemon begins the next turn. */
+  recalledStreamCardTurnId?: string;
   pendingLocalCliButtonRefresh?: boolean; // true when cli_session_id arrived while the streaming card POST was in flight
   pendingRiffUrlCardRefresh?: boolean; // true when riff_access_url arrived while the streaming card POST was in flight
   /** Set on sessions restored after a daemon restart: suppresses the automatic

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1014,6 +1014,111 @@ export function recallFrozenCards(ds: DaemonSession): void {
   logger.info(`[${tag(ds)}] Recalled ${targets.length} previous streaming card(s)`);
 }
 
+const COMPLETED_CARD_RECALL_BACKOFF_MS = [1_000, 3_000, 10_000] as const;
+const COMPLETED_CARD_TURN_TTL_MS = 30 * 60_000;
+const COMPLETED_CARD_TURN_MAX = 32;
+
+function pruneStreamCardCompletionTurns(ds: DaemonSession): void {
+  const states = ds.streamCardCompletionTurns;
+  if (!states) return;
+  const cutoff = Date.now() - COMPLETED_CARD_TURN_TTL_MS;
+  for (const [turnId, state] of states) {
+    if (!state.recallTimer && state.updatedAt < cutoff) states.delete(turnId);
+  }
+  if (states.size <= COMPLETED_CARD_TURN_MAX) return;
+  [...states.entries()]
+    .filter(([, state]) => !state.recallTimer)
+    .sort((a, b) => a[1].updatedAt - b[1].updatedAt)
+    .slice(0, states.size - COMPLETED_CARD_TURN_MAX)
+    .forEach(([turnId]) => states.delete(turnId));
+}
+
+function streamCardCompletionState(ds: DaemonSession, turnId: string) {
+  const states = ds.streamCardCompletionTurns ??= new Map();
+  const state = states.get(turnId) ?? { updatedAt: Date.now() };
+  state.updatedAt = Date.now();
+  states.set(turnId, state);
+  pruneStreamCardCompletionTurns(ds);
+  return state;
+}
+
+/**
+ * 撤回已完成轮次的状态卡。终态与结果送达可能以任意顺序到达，因此先按 turn
+ * 汇合两份证据；真正删除前再次校验卡片身份和新轮次状态，避免晚到事件误删新卡。
+ */
+function scheduleCompletedStreamCardRecall(ds: DaemonSession, turnId: string): void {
+  const state = ds.streamCardCompletionTurns?.get(turnId);
+  if (!state?.terminalCompleted || !state.resultDelivered || state.recallTimer) return;
+  if (!ds.streamCardId || ds.streamCardId === CARD_POSTING_SENTINEL) return;
+  if (ds.streamCardTurnId !== turnId || ds.streamCardPending || ds.session.status !== 'active') return;
+
+  const cardId = ds.streamCardId;
+  const attempt = state.recallAttempts ?? 0;
+  const delayMs = COMPLETED_CARD_RECALL_BACKOFF_MS[attempt];
+  if (delayMs === undefined) return;
+  state.recallTimer = setTimeout(async () => {
+    state.recallTimer = undefined;
+    if (ds.streamCardId !== cardId
+      || ds.streamCardTurnId !== turnId
+      || ds.streamCardPending
+      || ds.session.status !== 'active') {
+      return;
+    }
+
+    let recalled = false;
+    try {
+      recalled = await deleteMessage(ds.larkAppId, cardId);
+    } catch (err) {
+      logger.debug(`[${tag(ds)}] Failed to recall completed streaming card: ${err}`);
+    }
+    if (!recalled) {
+      state.recallAttempts = attempt + 1;
+      state.updatedAt = Date.now();
+      scheduleCompletedStreamCardRecall(ds, turnId);
+      return;
+    }
+
+    ds.streamCardId = undefined;
+    ds.streamCardNonce = undefined;
+    ds.streamCardTurnId = undefined;
+    ds.currentImageKey = undefined;
+    ds.recalledStreamCardTurnId = turnId;
+    clearUsageRefreshTimer(ds);
+    if (ds.pendingCardId === cardId) {
+      ds.pendingCardId = undefined;
+      ds.pendingCardJson = undefined;
+    }
+    if (ds.frozenCards) {
+      for (const [nonce, frozen] of ds.frozenCards) {
+        if (frozen.messageId === cardId) ds.frozenCards.delete(nonce);
+      }
+      saveFrozenCards(ds.session.sessionId, ds.frozenCards);
+    }
+    ds.streamCardCompletionTurns?.delete(turnId);
+    persistStreamCardState(ds);
+    logger.info(`[${tag(ds)}] Recalled completed streaming card for turn ${turnId.substring(0, 12)}`);
+  }, delayMs);
+}
+
+function bindStreamCardToTurn(ds: DaemonSession, turnId: string | undefined): void {
+  if (!turnId) return;
+  ds.streamCardTurnId = turnId;
+  if (ds.recalledStreamCardTurnId !== turnId) ds.recalledStreamCardTurnId = undefined;
+  scheduleCompletedStreamCardRecall(ds, turnId);
+}
+
+function markStreamCardTerminalCompleted(ds: DaemonSession, turnId: string): void {
+  const state = streamCardCompletionState(ds, turnId);
+  state.terminalCompleted = true;
+  scheduleCompletedStreamCardRecall(ds, turnId);
+}
+
+function markStreamCardResultDelivered(ds: DaemonSession, turnId: string): void {
+  const state = streamCardCompletionState(ds, turnId);
+  state.resultDelivered = true;
+  scheduleCompletedStreamCardRecall(ds, turnId);
+}
+
 /**
  * Force-post a fresh streaming card for `ds`, bypassing the per-bot
  * `disableStreamingCard` opt-out. Backs the `/card` command: a user can
@@ -1049,6 +1154,7 @@ export async function postFreshStreamingCard(
   // together so a failed /card leaves no orphaned nonce/pending state).
   const prevCardId = ds.streamCardId;
   const prevNonce = ds.streamCardNonce;
+  const prevTurnId = ds.streamCardTurnId;
   const prevPending = ds.streamCardPending;
 
   ds.streamCardNonce = randomBytes(4).toString('hex');
@@ -1074,6 +1180,7 @@ export async function postFreshStreamingCard(
   ds.streamCardId = CARD_POSTING_SENTINEL;
   try {
     ds.streamCardId = await sessionReply(sessionAnchorId(ds), cardJson, 'interactive', ds.larkAppId, ds.currentReplyTarget?.turnId);
+    bindStreamCardToTurn(ds, ds.currentReplyTarget?.turnId);
     // This card is now the live one for the current turn. Clear the new-turn
     // pending flag so the next screen_update PATCHes it instead of POSTing a
     // duplicate (the gate above only suppresses cards when disabled+unforced;
@@ -1092,6 +1199,7 @@ export async function postFreshStreamingCard(
   } catch (err) {
     ds.streamCardId = prevCardId;
     ds.streamCardNonce = prevNonce;
+    ds.streamCardTurnId = prevTurnId;
     ds.streamCardPending = prevPending;
     flushPendingLocalCliOpenReadinessPatch(ds);
     flushPendingRiffUrlPatch(ds);
@@ -1482,6 +1590,7 @@ function flushCardPatch(ds: DaemonSession): void {
         if (ds.streamCardId === cardId) {
           logger.warn(`[${tag(ds)}] Stream card withdrawn, clearing reference`);
           ds.streamCardId = undefined;
+          ds.streamCardTurnId = undefined;
           persistStreamCardState(ds);
         } else {
           logger.debug(`[${tag(ds)}] Stale card ${cardId.substring(0, 12)} withdrawn (current: ${ds.streamCardId?.substring(0, 12) ?? 'none'})`);
@@ -3221,6 +3330,7 @@ export async function transferSession(
   // lives in another chat entirely (the source card was just frozen above).
   ds.session.streamCardId = undefined;
   ds.session.streamCardNonce = undefined;
+  ds.session.streamCardTurnId = undefined;
   ds.session.currentImageKey = undefined;
 
   // Mirror onto runtime DaemonSession.
@@ -3229,6 +3339,7 @@ export async function transferSession(
   ds.scope = targetScope;
   ds.streamCardId = undefined;
   ds.streamCardNonce = undefined;
+  ds.streamCardTurnId = undefined;
   ds.currentImageKey = undefined;
 
   sessionStore.updateSession(ds.session);
@@ -4320,6 +4431,11 @@ function setupWorkerHandlers(
           break;
         }
 
+        if (!ds.streamCardId && msg.turnId && ds.recalledStreamCardTurnId === msg.turnId) {
+          logger.debug(`[${t}] Completed turn card already recalled — skipping trailing ready card`);
+          break;
+        }
+
         // If a previous streaming card survived (e.g. daemon restart), try to
         // PATCH it with the new "starting" state instead of POSTing a fresh card.
         // ds.streamCardPending forces a new card (e.g. mid-session repo switch
@@ -4362,6 +4478,7 @@ function setupWorkerHandlers(
             );
             await updateMessage(ds.larkAppId, restoredCardId, streamCardJson);
             if (!ownsLifecycleMutation()) break;
+            bindStreamCardToTurn(ds, ds.streamCardTurnId ?? msg.turnId ?? ds.currentReplyTarget?.turnId);
             // Worker IPC handlers may run while the direct restore PATCH is in
             // flight. Re-queue readiness after it completes so an older
             // not-ready payload can never overwrite the cli_session_id PATCH.
@@ -4387,6 +4504,7 @@ function setupWorkerHandlers(
             // PATCH failed (withdrawn, expired, etc.) — fall through to POST a fresh card.
             logger.info(`[${t}] Failed to reuse existing streaming card (${err instanceof Error ? err.message : err}), posting new one`);
             ds.streamCardId = undefined;
+            ds.streamCardTurnId = undefined;
             persistStreamCardState(ds);
           }
         }
@@ -4436,6 +4554,7 @@ function setupWorkerHandlers(
             break;
           }
           ds.streamCardId = postedCardId;
+          bindStreamCardToTurn(ds, msg.turnId ?? ds.currentReplyTarget?.turnId);
           // This card IS the current turn's live card — clear the new-turn flag
           // so subsequent screen_updates PATCH it (starting → working) instead of
           // POSTing a second card. Without this, a re-fork that happens while
@@ -4469,6 +4588,7 @@ function setupWorkerHandlers(
           logger.warn(`[${t}] Failed to send streaming card, falling back to static card: ${err}`);
           // Clear sentinel so screen_updates can create a streaming card later
           ds.streamCardId = undefined;
+          ds.streamCardTurnId = undefined;
           clearPendingLocalCliOpenReadinessPatch(ds);
           persistStreamCardState(ds);
           // Fallback: send static session card
@@ -4725,6 +4845,10 @@ function setupWorkerHandlers(
         const turnTitle = ds.currentTurnTitle || ds.session.title || getCliDisplayName(effectiveCliId);
         const mode: DisplayMode = ds.displayMode ?? 'hidden';
 
+        // Completion recall may win a race with the worker's trailing idle
+        // redraw. Do not recreate the just-withdrawn card for the same turn.
+        if (!ds.streamCardId && msg.turnId && ds.recalledStreamCardTurnId === msg.turnId) break;
+
         if (ds.streamCardPending || !ds.streamCardId) {
           // If a POST is already in-flight, drop this update — it will be
           // picked up by subsequent screen_updates once the card ID lands.
@@ -4766,6 +4890,7 @@ function setupWorkerHandlers(
                 return;
               }
               ds.streamCardId = msgId;
+              bindStreamCardToTurn(ds, msg.turnId ?? ds.currentReplyTarget?.turnId);
               persistStreamCardState(ds);
               // New card live — recall any cards parked by previous turns
               // (user message, bot @mention, adopt-bridge new turn, etc.).
@@ -4791,10 +4916,15 @@ function setupWorkerHandlers(
               }
               logger.debug(`[${t}] Failed to create streaming card: ${err}`);
               ds.streamCardId = undefined;
+              ds.streamCardTurnId = undefined;
               clearPendingLocalCliOpenReadinessPatch(ds);
               persistStreamCardState(ds);
             });
         } else {
+          if (!ds.streamCardTurnId) {
+            bindStreamCardToTurn(ds, msg.turnId ?? ds.currentReplyTarget?.turnId);
+            persistStreamCardState(ds);
+          }
           // Same turn — PATCH only on status change. Image PATCHes go through
           // the screenshot_uploaded path; text is no longer a card body mode.
           const statusChanged = prevStatus !== ds.lastScreenStatus;
@@ -5453,6 +5583,7 @@ function setupWorkerHandlers(
       }
 
       case 'explicit_reply_observed': {
+        markStreamCardResultDelivered(ds, msg.turnId);
         if (msg.turnId.startsWith('mlrp_turn_')) {
           markMessageListenerRunPreviewReplied(msg.turnId, {
             sessionId: ds.session.sessionId,
@@ -5537,6 +5668,7 @@ function setupWorkerHandlers(
         } catch (err: any) {
           logger.error(`[${t}] Failed to settle deferred schedule turn ${msg.turnId.substring(0, 8)}: ${err.message}`);
         }
+        if (msg.status === 'completed') markStreamCardTerminalCompleted(ds, msg.turnId);
         break;
       }
 
@@ -5891,6 +6023,7 @@ function deliverFinalOutput(
   if (waitPromise) {
     waitPromise.resolve(msg.content);
     ds.lastBridgeEmittedUuid = finalOutputDedupeKey(ds, msg);
+    markStreamCardResultDelivered(ds, msg.turnId);
     logger.info(`[${t}] Intercepted final_output for Wait Mode HTTP request (turn ${msg.turnId.substring(0, 8)})`);
     return;
   }
@@ -5907,6 +6040,7 @@ function deliverFinalOutput(
     // Stamp the owning bot for cross-bot isolation.
     asyncTriggerStore.recordCompleted(ds.session.sessionId, msg.turnId, msg.content, completedAt, ds.larkAppId, msg.usage);
     ds.lastBridgeEmittedUuid = finalOutputDedupeKey(ds, msg);
+    markStreamCardResultDelivered(ds, msg.turnId);
     logger.info(`[${t}] Captured final_output for Async HTTP request (turn ${msg.turnId.substring(0, 8)})`);
     return;
   }
@@ -5954,6 +6088,7 @@ function deliverFinalOutput(
         // reaction must never retry and duplicate the document comment.
         consumeDocCommentTurn(ds, msg.turnId);
         ds.lastBridgeEmittedUuid = finalOutputDedupeKey(ds, msg);
+        markStreamCardResultDelivered(ds, msg.turnId);
         if (docTurn.reactionId && docTurn.replyId) {
           try {
             await removeCommentReaction(ds.larkAppId,
@@ -6192,6 +6327,7 @@ function deliverFinalOutput(
       if (preparedListenerReply?.kind === 'succeeded' && preparedListenerReply.messageId) {
         recordPrimaryOutput(preparedListenerReply.messageId);
         ds.lastBridgeEmittedUuid = finalOutputDedupeKey(ds, msg);
+        markStreamCardResultDelivered(ds, msg.turnId);
         logger.info(
           `[${t}] VC listener fallback replayed existing provider result `
           + `(turn ${msg.turnId.substring(0, 8)})`,
@@ -6237,6 +6373,7 @@ function deliverFinalOutput(
         finishVcMeetingImReply(config.session.dataDir, preparedListenerReply.ref, messageId);
       }
       ds.lastBridgeEmittedUuid = finalOutputDedupeKey(ds, msg);
+      markStreamCardResultDelivered(ds, msg.turnId);
       logger.info(`[${t}] Bridge final_output forwarded (turn ${msg.turnId.substring(0, 8)}, ${msg.content.length} chars, kind=${msg.kind ?? 'bridge'}, attempt ${attempt + 1})`);
     } catch (err: any) {
       if (!stillCurrent()) return;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -3957,6 +3957,7 @@ function beginNewTurn(ds: DaemonSession, title: string): void {
   // in. A new turn returns to the config default (noCardChats / disableStreamingCard).
   // Use `/card on` to persistently restore cards for the chat.
   ds.streamingCardForced = undefined;
+  ds.recalledStreamCardTurnId = undefined;
   const previousUsageLimit = ds.usageLimit;
   const previousStatus = ds.lastScreenStatus === 'limited' && previousUsageLimit ? 'limited' : 'idle';
   if (ds.streamCardId && workerHasInitialized(ds)) {
@@ -17562,6 +17563,7 @@ async function handleThreadReply(
     parkStreamCard(ds);
     ds.streamCardId = undefined;
     ds.streamCardNonce = undefined;
+    ds.streamCardTurnId = undefined;
     // This is a new turn even though the worker is currently down. Force the
     // first screen_update from the re-forked worker to POST a fresh card and
     // drop any persisted screenshot from the previous turn. Otherwise a stale
@@ -18014,6 +18016,7 @@ async function handleDocComment(ctx: DocCommentContext): Promise<boolean> {
       parkStreamCard(ds);
       ds.streamCardId = undefined;
       ds.streamCardNonce = undefined;
+      ds.streamCardTurnId = undefined;
       ds.streamCardPending = true;
       ds.currentImageKey = undefined;
       persistStreamCardState(ds);

--- a/src/types.ts
+++ b/src/types.ts
@@ -337,6 +337,9 @@ export interface Session {
    *  (rather than a fresh POST) after daemon restart. */
   streamCardId?: string;
   streamCardNonce?: string;
+  /** Exact turn represented by streamCardId. Completion recall uses this
+   *  binding so a late terminal cannot withdraw a newer turn's card. */
+  streamCardTurnId?: string;
   /** Legacy field kept for migrating sessions persisted before displayMode was added. */
   streamExpanded?: boolean;
   /** Card body display mode — 'hidden' | 'screenshot'. */

--- a/test/bridge-final-output-retry.test.ts
+++ b/test/bridge-final-output-retry.test.ts
@@ -16,13 +16,14 @@ const updateMessageMock = vi.fn(async () => {});
 const addReactionMock = vi.fn(async () => 'reaction_id');
 const replyToDocCommentMock = vi.fn(async () => {});
 const removeCommentReactionMock = vi.fn(async () => {});
+const deleteMessageMock = vi.fn(async () => true);
 const updateSessionMock = vi.fn();
 vi.mock('../src/im/lark/client.js', () => ({
   updateMessage: (...args: any[]) => updateMessageMock(...args),
   addReaction: (...args: any[]) => addReactionMock(...args),
   removeReaction: vi.fn(async () => {}),
   sendUserMessage: vi.fn(async () => {}),
-  deleteMessage: vi.fn(async () => {}),
+  deleteMessage: (...args: any[]) => deleteMessageMock(...args),
   getChatInfo: vi.fn(),
   MessageWithdrawnError: class MessageWithdrawnError extends Error {
     constructor(id: string) { super(`withdrawn: ${id}`); this.name = 'MessageWithdrawnError'; }
@@ -2074,5 +2075,182 @@ describe('Worker turn_terminal routing', () => {
       turnId: 'om_replacement',
     });
     expect(onCliExit).not.toHaveBeenCalled();
+  });
+});
+
+describe('Completed streaming-card recall', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  function makeCardDs(turnId = 'turn-1'): DaemonSession {
+    const ds = makeDs();
+    ds.streamCardId = 'om_status_card';
+    ds.streamCardNonce = 'nonce-1';
+    ds.streamCardTurnId = turnId;
+    ds.lastScreenStatus = 'idle';
+    return ds;
+  }
+
+  it('recalls the exact status card after fallback output is delivered and the turn completes', async () => {
+    const sessionReply = vi.fn(async () => 'om_final_reply');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const ds = makeCardDs();
+    __testOnly_setupWorkerHandlers(ds, ds.worker as any);
+
+    (ds.worker as any).emit('message', {
+      ...finalOutputMsg(),
+      sessionId: ds.session.sessionId,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    (ds.worker as any).emit('message', {
+      type: 'turn_terminal',
+      sessionId: ds.session.sessionId,
+      turnId: 'turn-1',
+      status: 'completed',
+    } satisfies Extract<WorkerToDaemon, { type: 'turn_terminal' }>);
+    await Promise.resolve();
+
+    expect(deleteMessageMock).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(deleteMessageMock).toHaveBeenCalledWith('app_test', 'om_status_card');
+    expect(ds.streamCardId).toBeUndefined();
+    expect(ds.streamCardNonce).toBeUndefined();
+    expect(ds.streamCardTurnId).toBeUndefined();
+    expect(ds.recalledStreamCardTurnId).toBe('turn-1');
+
+    // A trailing idle redraw from the completed worker must not recreate the
+    // status card after the withdraw succeeds.
+    (ds.worker as any).emit('message', {
+      type: 'screen_update',
+      content: 'idle after completed turn',
+      status: 'idle',
+      turnId: 'turn-1',
+    } satisfies Extract<WorkerToDaemon, { type: 'screen_update' }>);
+    await Promise.resolve();
+    expect(sessionReply).toHaveBeenCalledTimes(1);
+  });
+
+  it('also recalls after a successful explicit botmux send and completed terminal', async () => {
+    initWorkerPool({
+      sessionReply: vi.fn(async () => 'unused'),
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const ds = makeCardDs('turn-explicit');
+    __testOnly_setupWorkerHandlers(ds, ds.worker as any);
+
+    (ds.worker as any).emit('message', {
+      type: 'explicit_reply_observed',
+      turnId: 'turn-explicit',
+      messageId: 'om_explicit_reply',
+    } satisfies Extract<WorkerToDaemon, { type: 'explicit_reply_observed' }>);
+    (ds.worker as any).emit('message', {
+      type: 'turn_terminal',
+      sessionId: ds.session.sessionId,
+      turnId: 'turn-explicit',
+      status: 'completed',
+    } satisfies Extract<WorkerToDaemon, { type: 'turn_terminal' }>);
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(deleteMessageMock).toHaveBeenCalledWith('app_test', 'om_status_card');
+  });
+
+  it('keeps the card when the turn fails or no result was delivered', async () => {
+    initWorkerPool({
+      sessionReply: vi.fn(async () => 'om_final_reply'),
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const failed = makeCardDs('turn-failed');
+    __testOnly_setupWorkerHandlers(failed, failed.worker as any);
+    (failed.worker as any).emit('message', {
+      type: 'explicit_reply_observed', turnId: 'turn-failed', messageId: 'om_reply',
+    } satisfies Extract<WorkerToDaemon, { type: 'explicit_reply_observed' }>);
+    (failed.worker as any).emit('message', {
+      type: 'turn_terminal', sessionId: failed.session.sessionId,
+      turnId: 'turn-failed', status: 'failed', errorCode: 'cli_failed',
+    } satisfies Extract<WorkerToDaemon, { type: 'turn_terminal' }>);
+
+    const noResult = makeCardDs('turn-no-result');
+    __testOnly_setupWorkerHandlers(noResult, noResult.worker as any);
+    (noResult.worker as any).emit('message', {
+      type: 'turn_terminal', sessionId: noResult.session.sessionId,
+      turnId: 'turn-no-result', status: 'completed',
+    } satisfies Extract<WorkerToDaemon, { type: 'turn_terminal' }>);
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    expect(deleteMessageMock).not.toHaveBeenCalled();
+    expect(failed.streamCardId).toBe('om_status_card');
+    expect(noResult.streamCardId).toBe('om_status_card');
+  });
+
+  it('does not withdraw the old card after a newer turn starts during the grace period', async () => {
+    initWorkerPool({
+      sessionReply: vi.fn(async () => 'unused'),
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const ds = makeCardDs('turn-old');
+    __testOnly_setupWorkerHandlers(ds, ds.worker as any);
+    (ds.worker as any).emit('message', {
+      type: 'explicit_reply_observed', turnId: 'turn-old', messageId: 'om_reply',
+    } satisfies Extract<WorkerToDaemon, { type: 'explicit_reply_observed' }>);
+    (ds.worker as any).emit('message', {
+      type: 'turn_terminal', sessionId: ds.session.sessionId,
+      turnId: 'turn-old', status: 'completed',
+    } satisfies Extract<WorkerToDaemon, { type: 'turn_terminal' }>);
+    await Promise.resolve();
+
+    ds.streamCardPending = true;
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(deleteMessageMock).not.toHaveBeenCalled();
+    expect(ds.streamCardId).toBe('om_status_card');
+  });
+
+  it('retains the card when Lark rejects every recall attempt', async () => {
+    deleteMessageMock
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+    initWorkerPool({
+      sessionReply: vi.fn(async () => 'unused'),
+      getSessionWorkingDir: () => '/tmp',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const ds = makeCardDs('turn-recall-fails');
+    __testOnly_setupWorkerHandlers(ds, ds.worker as any);
+    (ds.worker as any).emit('message', {
+      type: 'explicit_reply_observed', turnId: 'turn-recall-fails', messageId: 'om_reply',
+    } satisfies Extract<WorkerToDaemon, { type: 'explicit_reply_observed' }>);
+    (ds.worker as any).emit('message', {
+      type: 'turn_terminal', sessionId: ds.session.sessionId,
+      turnId: 'turn-recall-fails', status: 'completed',
+    } satisfies Extract<WorkerToDaemon, { type: 'turn_terminal' }>);
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(14_000);
+
+    expect(deleteMessageMock).toHaveBeenCalledTimes(3);
+    expect(ds.streamCardId).toBe('om_status_card');
+    expect(ds.recalledStreamCardTurnId).toBeUndefined();
   });
 });


### PR DESCRIPTION
## 背景

执行结果已经发出后，状态卡仍停留在“工作中 / 等待输入”，容易让用户误以为任务没有真正结束。状态卡应是执行期的临时反馈，成功终态由最终回复承接。

## 改动

- 将状态卡与准确的 `turnId` 绑定并持久化，daemon 重启后仍能安全判断卡片归属
- 汇合“turn completed”和“结果成功送达”两份证据，满足后延迟撤回状态卡
- 覆盖显式 `botmux send`、bridge fallback、文档评论及 HTTP 结果交付路径
- 撤回前复核卡片 ID、turn 和新轮次状态，避免晚到终态误删下一轮卡片
- 撤回失败最多重试 3 次；任务失败、取消、无结果或发送失败时继续保留卡片
- 抑制完成后的尾部 idle / ready 更新重新创建已撤回卡片

## 影响面

- 修改公共飞书 streaming-card 生命周期，适用于所有 CLI 和普通/自动开工会话
- 不改变 CLI 的完成判定；Codex 继续以现有 `task_complete` 为真实终态，压缩检查点不会触发撤回
- silent / receiver / card-off 会话没有活动状态卡，不会新增消息副作用
- type-ahead、新轮次已开始、worker 换代和跨 chat transfer 都通过 turn/card 双重校验保持隔离

## 验证

- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run test/bridge-final-output-retry.test.ts`：55 条通过
- `NODE_NO_WARNINGS=1 pnpm test`：781 个测试文件通过，12,343 条通过，35 条按环境跳过
- `pnpm build`
- `git diff --check`

## UI 说明

终态效果是最终回复成功出现约 1 秒后，执行状态卡从会话中撤回；失败或未成功送达时卡片保持可见。撤回后的终态没有可保留的静态卡片截图。