### PR TITLE
fix(adopt): 防止 Codex 多 rollout 误绑 / 共享 history 跨进程误绑 / 输入拼接

### DIFF
--- a/src/adapters/backend/tmux-pipe-backend.ts
+++ b/src/adapters/backend/tmux-pipe-backend.ts
@@ -686,6 +686,30 @@ export class TmuxPipeBackend implements SessionBackend {
     return this.captureWithBounds('');
   }
 
+  captureInputState(): {
+    viewport: string;
+    cursor: { x: number; y: number };
+  } | null {
+    if (this.exited) return null;
+    const cursor = this.getCursorPosition();
+    if (!cursor) return null;
+    try {
+      const viewport = execFileSync(
+        'tmux', ['capture-pane', '-p', '-t', this.paneTarget],
+        {
+          encoding: 'utf-8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+          timeout: 2000,
+          maxBuffer: 16 * 1024 * 1024,
+          env: tmuxEnv(),
+        },
+      );
+      return { viewport, cursor };
+    } catch {
+      return null;
+    }
+  }
+
   private captureWithBounds(bounds: string, opts?: { restoreCursor?: boolean }): string {
     if (this.exited) return '';
     try {

--- a/src/adapters/backend/types.ts
+++ b/src/adapters/backend/types.ts
@@ -116,6 +116,15 @@ export interface SessionBackend {
    */
   settleCurrentScreen?(): Promise<boolean>;
   captureViewport?(): string;
+  /**
+   * Plain current viewport plus the real terminal cursor. Adopt-mode input
+   * guards use this to detect an unsubmitted local composer draft before a
+   * remote message is written into the same TUI.
+   */
+  captureInputState?(): {
+    viewport: string;
+    cursor: { x: number; y: number };
+  } | null;
   getPaneSize?(): { cols: number; rows: number } | null;
   /**
    * Remote sandbox access URL — backends that run on a remote sandbox (e.g.

--- a/src/adapters/cli/codex.ts
+++ b/src/adapters/cli/codex.ts
@@ -4,6 +4,7 @@ import { resolveCommand } from './registry.js';
 import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
 import type { CliAdapter, PtyHandle } from './types.js';
 import { codexHistoryPath, codexHome, codexSessionsRoot } from '../../services/codex-paths.js';
+import { findCodexRolloutSetByPid } from '../../services/codex-transcript.js';
 import { discoverRolloutSessions } from '../../services/resumable-session-discovery.js';
 import { delay, scaleMs } from '../../utils/timing.js';
 
@@ -35,7 +36,19 @@ function historyTextMatches(actual: string, expected: string): boolean {
   return actual === expected || normaliseHistoryText(actual) === normaliseHistoryText(expected);
 }
 
-function matchHistoryDelta(path: string, fromByte: number, expectedText: string): HistoryMatch {
+/** Optional ownership filter for a history match. `history.jsonl` is a single
+ *  global file shared by every Codex pane under one CODEX_HOME, so a concurrent
+ *  sibling pane submitting identical text can land its line first. When a filter
+ *  is supplied, a same-text line is only accepted if `acceptSid(sid)` is true —
+ *  a foreign sibling's line is skipped and scanning continues for the owned one.
+ *  The filter is re-evaluated on every call (not snapshotted) so a lazily-opened
+ *  owned rollout fd that appears AFTER its history line can still be accepted on
+ *  a later poll. */
+type HistorySidFilter = (cliSessionId: string | undefined) => boolean;
+
+function matchHistoryDelta(
+  path: string, fromByte: number, expectedText: string, acceptSid?: HistorySidFilter,
+): HistoryMatch {
   if (!existsSync(path)) return { found: false };
   let size: number;
   try { size = statSync(path).size; } catch { return { found: false }; }
@@ -54,7 +67,12 @@ function matchHistoryDelta(path: string, fromByte: number, expectedText: string)
     try {
       const parsed = JSON.parse(line);
       if (typeof parsed?.text === 'string' && historyTextMatches(parsed.text, expectedText)) {
-        return { found: true, cliSessionId: readCliSessionId(parsed) };
+        const cliSessionId = readCliSessionId(parsed);
+        // Skip a same-text line owned by a DIFFERENT pane (shared-CODEX_HOME
+        // collision). Keep scanning — the owned line may be later in this delta
+        // or arrive on a subsequent poll.
+        if (acceptSid && !acceptSid(cliSessionId)) continue;
+        return { found: true, cliSessionId };
       }
     } catch {
       // Ignore partial/non-JSON lines. A later poll will see the completed
@@ -65,11 +83,11 @@ function matchHistoryDelta(path: string, fromByte: number, expectedText: string)
 }
 
 async function waitForHistoryAppend(
-  path: string, fromByte: number, expectedText: string, timeoutMs: number,
+  path: string, fromByte: number, expectedText: string, timeoutMs: number, acceptSid?: HistorySidFilter,
 ): Promise<HistoryMatch> {
   const deadline = Date.now() + scaleMs(timeoutMs);
   while (Date.now() < deadline) {
-    const match = matchHistoryDelta(path, fromByte, expectedText);
+    const match = matchHistoryDelta(path, fromByte, expectedText, acceptSid);
     if (match.found) return match;
     await delay(100);
   }
@@ -296,6 +314,31 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
       const historyPath = codexHistoryPath();
       const baseByte = currentFileSize(historyPath);
 
+      // Ownership filter for the shared global history.jsonl. When we know the
+      // Codex PID, only accept a same-text history line whose session id is one
+      // THIS pid currently holds open — so a concurrent sibling pane's identical
+      // text (same CODEX_HOME) can't hand us its foreign session id. Re-fetch the
+      // open-rollout set on EVERY match attempt (not once at baseByte): the owned
+      // rollout fd for a just-started session can appear slightly after its
+      // history line, and a snapshot would permanently reject it. When the pid is
+      // unknown (no PtyHandle.cliPid) or its rollout set can't be read, fall back
+      // to accept-first — preserving the original submit-confirmation semantics
+      // for single-pane sessions and no-pid callers; the worker-side attach gate
+      // is the backstop there.
+      const cliPid = typeof pty.cliPid === 'number' && Number.isInteger(pty.cliPid) && pty.cliPid > 0
+        ? pty.cliPid
+        : undefined;
+      const acceptSid: HistorySidFilter | undefined = cliPid
+        ? (sid) => {
+            if (!sid) return false;
+            const owned = findCodexRolloutSetByPid(cliPid);
+            // set unavailable (enumeration failed) → don't block the submit
+            // confirmation; the worker attach gate re-checks ownership.
+            if (!owned) return true;
+            return owned.has(sid.toLowerCase());
+          }
+        : undefined;
+
       try {
         if (pty.pasteText) {
           // tmux mode: load-buffer + paste-buffer -d -p. The `-p` flag emits
@@ -313,7 +356,7 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
       if (!trySendEnter()) return { submitted: false };
 
       for (let attempt = 0; attempt < 3; attempt++) {
-        const match = await waitForHistoryAppend(historyPath, baseByte, content, 800);
+        const match = await waitForHistoryAppend(historyPath, baseByte, content, 800, acceptSid);
         if (match.found) {
           return match.cliSessionId
             ? { submitted: true, cliSessionId: match.cliSessionId }
@@ -321,7 +364,7 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
         }
         if (!trySendEnter()) return { submitted: false };
       }
-      const match = await waitForHistoryAppend(historyPath, baseByte, content, 800);
+      const match = await waitForHistoryAppend(historyPath, baseByte, content, 800, acceptSid);
       if (match.found) {
         return match.cliSessionId
           ? { submitted: true, cliSessionId: match.cliSessionId }
@@ -332,7 +375,7 @@ export function createCodexAdapter(pathOverride?: string): CliAdapter {
       // initial prompt) may still append our marker after the retries gave
       // up, and the worker re-scans on a delay before warning the user.
       const recheck = () => {
-        const late = matchHistoryDelta(historyPath, baseByte, content);
+        const late = matchHistoryDelta(historyPath, baseByte, content, acceptSid);
         return late.found
           ? { submitted: true, cliSessionId: late.cliSessionId }
           : false;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1184,6 +1184,7 @@ export const messages: Record<string, string> = {
   'trigger.external_event_clean': 'External event',
 
   // Worker-side submit / notify messages
+  'worker.codex_composer_conflict': 'The adopted Codex terminal already has an unsubmitted local draft. botmux left that draft untouched and did not append the Lark message. Submit or clear the local draft, then resend the Lark message.',
   'worker.submit_impossible': '⚠️ Your last message was not safely written to {cliName}.\nReason: {reason}\nAddress the reason above and verify the terminal state before trying again.\nStart: {preview}',
   'worker.submit_unconfirmed': '⚠️ Your last message was sent to {cliName} but submission couldn’t be confirmed (after retrying Enter and waiting {secs}s, no new entry showed up in {transcriptLabel}). It may be stuck in the input box — check the Web terminal and press Enter manually or resend.\nStart: {preview}',
   'worker.submit_unconfirmed_zmx': '⚠️ Your last message could not be confirmed as written to {cliName} after {secs}s. Do not resend it blindly; run botmux list locally, enter the ZMX session, and inspect its composer.\nStart: {preview}',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -1187,6 +1187,7 @@ export const messages: Record<string, string> = {
   'trigger.external_event_clean': '外部事件触发',
 
   // Worker-side submit / notify messages
+  'worker.codex_composer_conflict': '已 adopt 的 Codex 终端输入框里已有未提交的本地草稿。botmux 保留了草稿，没有把这条飞书消息拼到后面。请先提交或清空本地草稿，再重发飞书消息。',
   'worker.submit_impossible': '⚠️ 刚才那条消息没有安全写入 {cliName}。\n原因：{reason}\n请处理上述原因并确认终端状态后再试。\n开头：{preview}',
   'worker.submit_unconfirmed': '⚠️ 刚才那条消息发给 {cliName} 后没能确认提交（重试 Enter 后等了 {secs}s 仍未在{transcriptLabel}里看到新记录）。可能卡在输入框里——请去 Web 终端看一下，手动按 Enter 或重发。\n开头：{preview}',
   'worker.submit_unconfirmed_zmx': '⚠️ 刚才那条消息没能确认写入 {cliName}（等待 {secs}s 后仍无提交证据）。不要直接重发；请在本机运行 botmux list 进入该 ZMX 会话检查输入框。\n开头：{preview}',

--- a/src/services/codex-composer-state.ts
+++ b/src/services/codex-composer-state.ts
@@ -13,6 +13,14 @@ export type CodexComposerState = 'empty' | 'draft' | 'unknown';
  * right; a multi-line draft moves it below the marker row. This lets botmux
  * distinguish the placeholder from user-authored text without depending on
  * the placeholder copy, color, or locale.
+ *
+ * KNOWN LIMITATION (fail-open, accepted): the signal is cursor position alone.
+ * A single-line draft whose cursor the user moved back to the very start
+ * (`cursor.x` at the empty-composer column) is indistinguishable from an empty
+ * composer and reports 'empty' — the Lark message would still be appended. A
+ * truly fail-closed detector would need composer content evidence (ANSI style
+ * runs / a stronger Codex state probe), not just the cursor. This guard only
+ * covers the common case where the cursor is still at/after the draft it typed.
  */
 export function detectCodexComposerState(
   input: CodexComposerInputState | null | undefined,
@@ -33,6 +41,16 @@ export function detectCodexComposerState(
     const line = lines[row] ?? '';
     const marker = /^(\s*)›/.exec(line);
     if (!marker) continue;
+    // NOTE on Codex's update picker (`› 1. Update now` / `› 2. Skip`): we do
+    // NOT special-case it. The adapter's readyPattern excludes it so a queued
+    // message can't auto-select a menu item, but here the only consequence of
+    // treating a picker row as a composer is the state we return, and BOTH
+    // outcomes are safe: a picker is never something a Lark message should be
+    // injected into, so classifying it as 'draft' (refuse) is fine, and 'empty'
+    // merely falls through to the normal write. Adding a `\d+.` exclusion here
+    // would instead turn a legitimate numbered draft (e.g. `› 1. 买牛奶`) into
+    // 'unknown' → the message gets appended and clobbers the draft: the exact
+    // fail-open bug this guard exists to prevent. So the bare marker stays.
 
     if (row < cursor.y) return 'draft';
     const emptyCursorX = marker[1]!.length + 2; // visible `› ` prefix

--- a/src/services/codex-composer-state.ts
+++ b/src/services/codex-composer-state.ts
@@ -1,0 +1,43 @@
+export interface CodexComposerInputState {
+  viewport: string;
+  cursor: { x: number; y: number };
+}
+
+export type CodexComposerState = 'empty' | 'draft' | 'unknown';
+
+/**
+ * Infer whether the cursor is inside a non-empty Codex composer.
+ *
+ * Codex leaves the cursor immediately after the `› ` marker while its empty
+ * placeholder is visible. A real single-line draft moves the cursor to the
+ * right; a multi-line draft moves it below the marker row. This lets botmux
+ * distinguish the placeholder from user-authored text without depending on
+ * the placeholder copy, color, or locale.
+ */
+export function detectCodexComposerState(
+  input: CodexComposerInputState | null | undefined,
+): CodexComposerState {
+  if (!input) return 'unknown';
+  const { cursor } = input;
+  if (!Number.isInteger(cursor.x) || !Number.isInteger(cursor.y) || cursor.x < 0 || cursor.y < 0) {
+    return 'unknown';
+  }
+
+  const lines = input.viewport.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+  if (cursor.y >= lines.length) return 'unknown';
+
+  // Codex keeps the composer compact. Limit the backward scan so an old user
+  // prompt higher in the viewport cannot be mistaken for the live composer.
+  const firstCandidateRow = Math.max(0, cursor.y - 12);
+  for (let row = cursor.y; row >= firstCandidateRow; row -= 1) {
+    const line = lines[row] ?? '';
+    const marker = /^(\s*)›/.exec(line);
+    if (!marker) continue;
+
+    if (row < cursor.y) return 'draft';
+    const emptyCursorX = marker[1]!.length + 2; // visible `› ` prefix
+    return cursor.x > emptyCursorX ? 'draft' : 'empty';
+  }
+
+  return 'unknown';
+}

--- a/src/services/codex-transcript.ts
+++ b/src/services/codex-transcript.ts
@@ -67,30 +67,31 @@ export function codexSessionIdFromRolloutPath(path: string): string | undefined 
   return m ? m[1] : undefined;
 }
 
-/** Find the rollout file an externally-running Codex process has open. The
- *  Codex process keeps fd open on its current rollout for the entire
- *  lifetime of the session, so this is the authoritative way to bind a
- *  Codex pid to its sessionId — far more reliable than scanning
- *  `~/.codex/sessions` by mtime (which would race with sibling Codex panes
- *  in the same project).
+type CodexRolloutRef = { path: string; cliSessionId: string };
+
+/** Find the rollout file an externally-running Codex process has open. A
+ *  single open rollout is authoritative for that pid. Multiple open rollouts
+ *  are ambiguous: current Codex versions can keep parent and sibling-agent
+ *  transcripts open in the same process, so choosing the first fd can bind
+ *  an adopted pane to the wrong conversation.
  *
  *  Linux: `/proc/<pid>/fd/*` fast path.
  *  macOS / BSD: `lsof -p <pid> -Fn` 兜底（同 session-discovery 里的 readCwd）。
  *  两种平台都用 `codexSessionIdFromRolloutPath` 提取 sid。 */
-export function findCodexRolloutByPid(pid: number): { path: string; cliSessionId: string } | undefined {
+export function findCodexRolloutByPid(pid: number): CodexRolloutRef | undefined {
   if (!Number.isInteger(pid) || pid <= 0) return undefined;
   if (IS_LINUX) {
     const fdDir = `/proc/${pid}/fd`;
     if (existsSync(fdDir)) {
       let entries: string[];
       try { entries = readdirSync(fdDir); } catch { return undefined; }
+      const targets: string[] = [];
       for (const fd of entries) {
         let target: string;
         try { target = readlinkSync(join(fdDir, fd)); } catch { continue; }
-        const hit = matchCodexRolloutPath(target);
-        if (hit) return hit;
+        targets.push(target);
       }
-      return undefined;
+      return findSingleCodexRollout(targets);
     }
     // /proc 不可读时落到下面的 lsof 兜底（极少见，但兜一下）
   }
@@ -105,16 +106,23 @@ export function findCodexRolloutByPid(pid: number): { path: string; cliSessionId
   } catch {
     return undefined;
   }
-  for (const line of out.split('\n')) {
-    if (!line.startsWith('n/')) continue;
-    const target = line.slice(1);
-    const hit = matchCodexRolloutPath(target);
-    if (hit) return hit;
-  }
-  return undefined;
+  return findSingleCodexRollout(out.split('\n').flatMap(line =>
+    line.startsWith('n/') ? [line.slice(1)] : [],
+  ));
 }
 
-function matchCodexRolloutPath(target: string): { path: string; cliSessionId: string } | undefined {
+function findSingleCodexRollout(targets: Iterable<string>): CodexRolloutRef | undefined {
+  let found: CodexRolloutRef | undefined;
+  for (const target of targets) {
+    const hit = matchCodexRolloutPath(target);
+    if (!hit) continue;
+    if (found && found.path !== hit.path) return undefined;
+    found = hit;
+  }
+  return found;
+}
+
+function matchCodexRolloutPath(target: string): CodexRolloutRef | undefined {
   if (!target.endsWith('.jsonl')) return undefined;
   if (!target.includes('/.codex/sessions/')) return undefined;
   const sid = codexSessionIdFromRolloutPath(target);

--- a/src/services/codex-transcript.ts
+++ b/src/services/codex-transcript.ts
@@ -161,7 +161,17 @@ function findSingleCodexRollout(targets: Iterable<string>): CodexRolloutRef | un
 
 function matchCodexRolloutPath(target: string): CodexRolloutRef | undefined {
   if (!target.endsWith('.jsonl')) return undefined;
-  if (!target.includes('/.codex/sessions/')) return undefined;
+  // The rollout lives under `<CODEX_HOME>/sessions/<YYYY>/<MM>/<DD>/`. CODEX_HOME
+  // defaults to ~/.codex but can be a custom / per-bot-isolated root, and an
+  // ADOPTED external Codex may have started under a CODEX_HOME the worker never
+  // inherited — so anchoring on the literal `/.codex/sessions/` (or on the
+  // worker's own codexSessionsRoot()) would make that rollout invisible. Once fd
+  // ownership is a hard gate for bridge attach, an invisible rollout means the
+  // legitimate session can never pass the gate. The path already came from the
+  // target PID's open fds (that IS the ownership proof), so anchor only on the
+  // env-independent structural shape: a `sessions/` path segment plus the
+  // distinctive `rollout-<ts>-<uuid>.jsonl` filename (validated below).
+  if (!/(^|\/)sessions\//.test(target)) return undefined;
   const sid = codexSessionIdFromRolloutPath(target);
   if (!sid) return undefined;
   return { path: target, cliSessionId: sid };

--- a/src/services/codex-transcript.ts
+++ b/src/services/codex-transcript.ts
@@ -69,16 +69,16 @@ export function codexSessionIdFromRolloutPath(path: string): string | undefined 
 
 type CodexRolloutRef = { path: string; cliSessionId: string };
 
-/** Find the rollout file an externally-running Codex process has open. A
- *  single open rollout is authoritative for that pid. Multiple open rollouts
- *  are ambiguous: current Codex versions can keep parent and sibling-agent
- *  transcripts open in the same process, so choosing the first fd can bind
- *  an adopted pane to the wrong conversation.
+/** Enumerate the filesystem paths a process currently has open, normalised to
+ *  a plain string[] regardless of platform. Returns undefined only when the
+ *  enumeration itself is unavailable (unreadable /proc, lsof failed); an empty
+ *  array means "readable, but no matching fds". Both `findCodexRolloutByPid`
+ *  and `findCodexRolloutSetByPid` derive from THIS single source so their
+ *  Linux `/proc` and macOS/BSD `lsof` normalisation can never drift apart.
  *
  *  Linux: `/proc/<pid>/fd/*` fast path.
- *  macOS / BSD: `lsof -p <pid> -Fn` 兜底（同 session-discovery 里的 readCwd）。
- *  两种平台都用 `codexSessionIdFromRolloutPath` 提取 sid。 */
-export function findCodexRolloutByPid(pid: number): CodexRolloutRef | undefined {
+ *  macOS / BSD: `lsof -p <pid> -Fn` 兜底（同 session-discovery 里的 readCwd）。 */
+function codexProcessOpenTargets(pid: number): string[] | undefined {
   if (!Number.isInteger(pid) || pid <= 0) return undefined;
   if (IS_LINUX) {
     const fdDir = `/proc/${pid}/fd`;
@@ -91,7 +91,7 @@ export function findCodexRolloutByPid(pid: number): CodexRolloutRef | undefined 
         try { target = readlinkSync(join(fdDir, fd)); } catch { continue; }
         targets.push(target);
       }
-      return findSingleCodexRollout(targets);
+      return targets;
     }
     // /proc 不可读时落到下面的 lsof 兜底（极少见，但兜一下）
   }
@@ -106,9 +106,46 @@ export function findCodexRolloutByPid(pid: number): CodexRolloutRef | undefined 
   } catch {
     return undefined;
   }
-  return findSingleCodexRollout(out.split('\n').flatMap(line =>
+  return out.split('\n').flatMap(line =>
     line.startsWith('n/') ? [line.slice(1)] : [],
-  ));
+  );
+}
+
+/** Find the rollout file an externally-running Codex process has open. A
+ *  single open rollout is authoritative for that pid. Multiple open rollouts
+ *  are ambiguous: current Codex versions can keep parent and sibling-agent
+ *  transcripts open in the same process, so choosing the first fd can bind
+ *  an adopted pane to the wrong conversation.
+ *
+ *  两种平台都用 `codexSessionIdFromRolloutPath` 提取 sid。 */
+export function findCodexRolloutByPid(pid: number): CodexRolloutRef | undefined {
+  const targets = codexProcessOpenTargets(pid);
+  if (!targets) return undefined;
+  return findSingleCodexRollout(targets);
+}
+
+/** Enumerate ALL rollouts a Codex pid currently has open, keyed by lowercased
+ *  sessionId. Unlike `findCodexRolloutByPid`, this does NOT collapse the
+ *  parent+sibling multi-rollout case to `undefined` — it returns every match so
+ *  a caller can test membership (`historySid ∈ set`).
+ *
+ *  This is the ownership gate for post-submit rollout re-attach: `history.jsonl`
+ *  is a single global file shared by every Codex pane under one CODEX_HOME, so a
+ *  concurrent sibling pane submitting identical text can make writeInput return
+ *  the WRONG session id. Only a sid this exact pid actually holds open is safe to
+ *  re-attach to; a foreign sid (another pane's) is rejected, leaving the current
+ *  binding untouched. Returns an empty Set when the pid holds no rollout, and
+ *  undefined only when the fd enumeration itself is unavailable — callers must
+ *  treat undefined as "cannot prove ownership" (fail closed: do not re-attach). */
+export function findCodexRolloutSetByPid(pid: number): Set<string> | undefined {
+  const targets = codexProcessOpenTargets(pid);
+  if (!targets) return undefined;
+  const set = new Set<string>();
+  for (const target of targets) {
+    const hit = matchCodexRolloutPath(target);
+    if (hit) set.add(hit.cliSessionId.toLowerCase());
+  }
+  return set;
 }
 
 function findSingleCodexRollout(targets: Iterable<string>): CodexRolloutRef | undefined {

--- a/src/services/codex-transcript.ts
+++ b/src/services/codex-transcript.ts
@@ -148,6 +148,21 @@ export function findCodexRolloutSetByPid(pid: number): Set<string> | undefined {
   return set;
 }
 
+/** Pure ownership decision: is `cliSessionId` one of the rollouts the observed
+ *  pid holds open? `ownedRollouts` is the lowercased sid set from
+ *  findCodexRolloutSetByPid (undefined when fd enumeration was unavailable).
+ *  FAIL CLOSED — a missing set or a non-member id returns false so the caller
+ *  never binds the bridge to a session it can't prove the pid owns. Extracted so
+ *  the exact predicate the worker's attach entry points use is unit-testable
+ *  without a live pid. */
+export function codexHistorySidIsOwned(
+  cliSessionId: string,
+  ownedRollouts: Set<string> | undefined,
+): boolean {
+  if (!ownedRollouts) return false;
+  return ownedRollouts.has(cliSessionId.toLowerCase());
+}
+
 function findSingleCodexRollout(targets: Iterable<string>): CodexRolloutRef | undefined {
   let found: CodexRolloutRef | undefined;
   for (const target of targets) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -130,7 +130,7 @@ import {
   setCodexAppThreadName,
 } from './services/codex-app-threads.js';
 import { buildBotmuxLarkNativeSessionTitle } from './core/session-title.js';
-import { drainCodexRollout, findCodexRolloutBySessionId, findCodexRolloutByPid, splitCodexEventsByCutoff, extractLastCodexTurn, codexSessionIdFromRolloutPath, scanCodexThreadSettings, type CodexBridgeEvent, type CodexDrainResult } from './services/codex-transcript.js';
+import { drainCodexRollout, findCodexRolloutBySessionId, findCodexRolloutByPid, findCodexRolloutSetByPid, splitCodexEventsByCutoff, extractLastCodexTurn, codexSessionIdFromRolloutPath, scanCodexThreadSettings, type CodexBridgeEvent, type CodexDrainResult } from './services/codex-transcript.js';
 import { CodexServiceTierTracker, resolveCodexServiceTierSnapshot } from './services/codex-service-tier.js';
 import { drainTraexRollout, findTraexRolloutBySessionId, findTraexRolloutByPid } from './services/traex-transcript.js';
 import { parseTraexUserInputQuestions } from './services/traex-user-input.js';
@@ -3885,22 +3885,48 @@ function codexBridgeNotifyCliSessionId(cliSessionId: string): void {
   if (codexBridgeRolloutPath) {
     // A Codex process can keep its parent and sibling-agent rollouts open at
     // the same time. Pre-submit pid discovery therefore may have attached an
-    // adopted pane to an unverified sibling transcript. writeInput returns the
-    // authoritative visible-session id; switch immediately instead of keeping
-    // the first attachment forever. Do not drain the old path because it has
-    // just been proven to belong to a different conversation.
+    // adopted pane to an unverified sibling transcript. writeInput returns a
+    // visible-session id, but that id comes from the GLOBAL history.jsonl
+    // (one file shared by every Codex pane under a CODEX_HOME): a concurrent
+    // sibling pane submitting identical text can make writeInput return the
+    // WRONG (foreign) session id. So the reported id is only a CANDIDATE —
+    // gate the re-attach on pid fd ownership below.
+    //
+    // Not draining the retired rollout before detach is safe here (NOT because
+    // "the old path is proven foreign" — Codex /new · /clear · /resume are
+    // legitimate same-process rotations): prepareAdoptWrite() ran
+    // codexBridgeIngest() before this turn's mark+write, codexBridgeDetachFile()
+    // preserves codexBridgeQueue (already-ingested terminals survive the
+    // re-attach), and a rotated-away rollout is quiescent before the next prompt
+    // is submitted — so there is no post-ingest window in which a legitimate
+    // terminal is appended to the old path and lost.
     if (structuredBridgeIsCodex()) {
       const currentSid = codexSessionIdFromRolloutPath(codexBridgeRolloutPath);
       if (currentSid?.toLowerCase() === cliSessionId.toLowerCase()) return;
+      // Ownership gate: only re-attach to a session id THIS pid actually holds
+      // open. This admits the real parent+sibling multi-rollout case (the id is
+      // in the pid's fd set) while rejecting a foreign id contributed by another
+      // pane's identical-text history line. findCodexRolloutByPid can't serve as
+      // the gate — it collapses the multi-rollout case to undefined, which is
+      // exactly the case we must ALLOW. Fail closed: if fd enumeration is
+      // unavailable (undefined) or the id is foreign, keep the current binding.
+      const pid = (backend as { cliPid?: number } | null)?.cliPid
+        ?? backend?.getChildPid?.()
+        ?? codexAdoptPendingPid;
+      const ownedRollouts = pid ? findCodexRolloutSetByPid(pid) : undefined;
+      if (!ownedRollouts || !ownedRollouts.has(cliSessionId.toLowerCase())) {
+        log(`Codex session id ${cliSessionId} not owned by pid ${pid ?? '?'} (open rollouts: ${ownedRollouts ? [...ownedRollouts].join(',') || 'none' : 'unknown'}); keeping current bridge ${currentSid ?? '?'} — refusing history-only re-attach`);
+        return;
+      }
       const next = resolveFileBridgePath('codex', { sessionId: cliSessionId });
       if (next && next !== codexBridgeRolloutPath) {
         const attachMode = lastInitConfig?.adoptMode ? 'split-live' : 'fresh-empty';
-        log(`Codex session binding corrected ${currentSid ?? '?'} → ${cliSessionId}; re-attaching bridge to ${next}`);
+        log(`Codex session binding corrected ${currentSid ?? '?'} → ${cliSessionId} (pid ${pid} owns it); re-attaching bridge to ${next}`);
         codexBridgeDetachFile();
         codexBridgePendingSessionId = undefined;
         codexBridgeAttach(next, attachMode);
       } else if (!next) {
-        log(`Codex session binding corrected ${currentSid ?? '?'} → ${cliSessionId}; waiting for rollout`);
+        log(`Codex session binding corrected ${currentSid ?? '?'} → ${cliSessionId} (pid ${pid} owns it); waiting for rollout`);
         codexBridgeDetachFile();
         codexBridgePendingSessionId = cliSessionId;
         codexBridgeStartTimer();

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -130,7 +130,7 @@ import {
   setCodexAppThreadName,
 } from './services/codex-app-threads.js';
 import { buildBotmuxLarkNativeSessionTitle } from './core/session-title.js';
-import { drainCodexRollout, findCodexRolloutBySessionId, findCodexRolloutByPid, findCodexRolloutSetByPid, splitCodexEventsByCutoff, extractLastCodexTurn, codexSessionIdFromRolloutPath, scanCodexThreadSettings, type CodexBridgeEvent, type CodexDrainResult } from './services/codex-transcript.js';
+import { drainCodexRollout, findCodexRolloutBySessionId, findCodexRolloutByPid, findCodexRolloutSetByPid, codexHistorySidIsOwned, splitCodexEventsByCutoff, extractLastCodexTurn, codexSessionIdFromRolloutPath, scanCodexThreadSettings, type CodexBridgeEvent, type CodexDrainResult } from './services/codex-transcript.js';
 import { CodexServiceTierTracker, resolveCodexServiceTierSnapshot } from './services/codex-service-tier.js';
 import { drainTraexRollout, findTraexRolloutBySessionId, findTraexRolloutByPid } from './services/traex-transcript.js';
 import { parseTraexUserInputQuestions } from './services/traex-user-input.js';
@@ -3889,9 +3889,6 @@ function codexBridgeDetachFile(): void {
   codexBridgeBaselineDone = false;
 }
 
-/** Called from flushPending after writeInput first returns a cliSessionId.
- *  Tries to locate the rollout file immediately; if it's not on disk yet,
- *  remembers the sid so the 1s poller can keep retrying. */
 /** Resolve the pid of the Codex process this worker observes (spawned child or
  *  adopted pane), mirroring the grok/traex pid-follow resolution order. */
 function currentCodexObservedPid(): number | undefined {
@@ -3909,17 +3906,26 @@ function currentCodexObservedPid(): number | undefined {
  *  collapse the legitimate parent+sibling multi-rollout case to undefined the
  *  way findCodexRolloutByPid does), so membership admits the authoritative id
  *  and rejects a foreign one. FAIL CLOSED: an unavailable fd enumeration
- *  (undefined) or a non-member id returns false → caller must not bind. */
+ *  (undefined) or a non-member id returns false → caller must not bind.
+ *
+ *  The pure decision (sid ∈ owned set) lives in codexHistorySidIsOwned so it can
+ *  be unit-tested without spawning a worker; this wrapper only supplies the live
+ *  pid + fd-set. BOTH production attach entry points (the notify re-attach branch
+ *  AND the initial-attach guard) call this one wrapper — there is no parallel
+ *  decision copy that could drift. */
 function codexHistorySidOwnedByCurrentPid(cliSessionId: string): boolean {
   const pid = currentCodexObservedPid();
   const ownedRollouts = pid ? findCodexRolloutSetByPid(pid) : undefined;
-  if (!ownedRollouts || !ownedRollouts.has(cliSessionId.toLowerCase())) {
+  const owned = codexHistorySidIsOwned(cliSessionId, ownedRollouts);
+  if (!owned) {
     log(`Codex session id ${cliSessionId} not owned by pid ${pid ?? '?'} (open rollouts: ${ownedRollouts ? [...ownedRollouts].join(',') || 'none' : 'unknown'})`);
-    return false;
   }
-  return true;
+  return owned;
 }
 
+/** Called from flushPending after writeInput first returns a cliSessionId.
+ *  Tries to locate the rollout file immediately; if it's not on disk yet,
+ *  remembers the sid so the 1s poller can keep retrying. */
 function codexBridgeNotifyCliSessionId(cliSessionId: string): void {
   if (!codexBridgeFallbackActive()) return;
   if (codexBridgeRolloutPath) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -123,6 +123,7 @@ import {
   type PidFollowResult,
 } from './services/bridge-rotation-policy.js';
 import { CodexBridgeQueue } from './services/codex-bridge-queue.js';
+import { detectCodexComposerState } from './services/codex-composer-state.js';
 import {
   generateCodexAppThreadTitle,
   readCodexAppThreadMetadata,
@@ -3882,6 +3883,30 @@ function codexBridgeDetachFile(): void {
 function codexBridgeNotifyCliSessionId(cliSessionId: string): void {
   if (!codexBridgeFallbackActive()) return;
   if (codexBridgeRolloutPath) {
+    // A Codex process can keep its parent and sibling-agent rollouts open at
+    // the same time. Pre-submit pid discovery therefore may have attached an
+    // adopted pane to an unverified sibling transcript. writeInput returns the
+    // authoritative visible-session id; switch immediately instead of keeping
+    // the first attachment forever. Do not drain the old path because it has
+    // just been proven to belong to a different conversation.
+    if (structuredBridgeIsCodex()) {
+      const currentSid = codexSessionIdFromRolloutPath(codexBridgeRolloutPath);
+      if (currentSid?.toLowerCase() === cliSessionId.toLowerCase()) return;
+      const next = resolveFileBridgePath('codex', { sessionId: cliSessionId });
+      if (next && next !== codexBridgeRolloutPath) {
+        const attachMode = lastInitConfig?.adoptMode ? 'split-live' : 'fresh-empty';
+        log(`Codex session binding corrected ${currentSid ?? '?'} → ${cliSessionId}; re-attaching bridge to ${next}`);
+        codexBridgeDetachFile();
+        codexBridgePendingSessionId = undefined;
+        codexBridgeAttach(next, attachMode);
+      } else if (!next) {
+        log(`Codex session binding corrected ${currentSid ?? '?'} → ${cliSessionId}; waiting for rollout`);
+        codexBridgeDetachFile();
+        codexBridgePendingSessionId = cliSessionId;
+        codexBridgeStartTimer();
+      }
+      return;
+    }
     // Already attached — first-attach-wins for most CLIs. Exceptions: TRAE
     // and Grok can rotate their native session in the same process.
     if (structuredBridgeIsTraex()) {
@@ -5615,6 +5640,13 @@ function adapterInputHandle(target: SessionBackend): PtyHandle {
   return target instanceof ZmxBackend
     ? strictInputHandle(target)
     : target;
+}
+
+function codexAdoptComposerConflict(target: SessionBackend): string | undefined {
+  if (lastInitConfig?.cliId !== 'codex' || !lastInitConfig.adoptMode) return undefined;
+  const state = detectCodexComposerState(target.captureInputState?.());
+  if (state !== 'draft') return undefined;
+  return t('worker.codex_composer_conflict');
 }
 
 let ambiguousSubmissionWriteTail: Promise<void> = Promise.resolve();
@@ -11871,6 +11903,21 @@ process.on('message', async (raw: unknown) => {
             const submissionBackend = backend;
             const submissionAdapter = cliAdapter;
             let recoveryFailureReason: string | undefined;
+            const composerConflict = codexAdoptComposerConflict(submissionBackend);
+            if (composerConflict) {
+              log('Refused Codex adopt input because the local composer contains an unsubmitted draft');
+              scheduleSubmitFailureNotify(
+                content,
+                undefined,
+                'submit history',
+                undefined,
+                composerConflict,
+                turnSeq,
+                msg,
+                'failed',
+              );
+              return;
+            }
             try {
               const transaction = await runAmbiguousSubmissionTransaction(
                 submissionBackend,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3646,7 +3646,19 @@ function codexBridgeStartTimer(): void {
           cwd: lastInitConfig?.workingDir,
           pid: codexAdoptPendingPid,
         });
-        if (path) {
+        // Codex defense-in-depth: resolveFileBridgePath resolves sessionId-first,
+        // so a pending sid that is actually a shared-CODEX_HOME sibling's would
+        // resolve to that foreign rollout. Only attach when the resolved rollout's
+        // sid is one the observed pid actually holds open. This poller re-runs
+        // every 1s, so a lazily-opened owned fd is picked up on a later tick.
+        // Skip the gate only when we have no pid to prove ownership with (keeps
+        // the sid/pid resolution working for non-adopt / pid-less flows).
+        const attachOk = !(structuredBridgeIsCodex() && lastInitConfig?.adoptMode && path && currentCodexObservedPid())
+          || (() => {
+            const sid = codexSessionIdFromRolloutPath(path!);
+            return !!sid && codexHistorySidOwnedByCurrentPid(sid);
+          })();
+        if (path && attachOk) {
           if (codexAdoptPendingPid && (lastInitConfig?.cliId === 'codex' || lastInitConfig?.cliId === 'traex')) {
             const discoveredSessionId = codexSessionIdFromRolloutPath(path);
             if (discoveredSessionId) persistCliSessionId(discoveredSessionId);
@@ -3880,6 +3892,34 @@ function codexBridgeDetachFile(): void {
 /** Called from flushPending after writeInput first returns a cliSessionId.
  *  Tries to locate the rollout file immediately; if it's not on disk yet,
  *  remembers the sid so the 1s poller can keep retrying. */
+/** Resolve the pid of the Codex process this worker observes (spawned child or
+ *  adopted pane), mirroring the grok/traex pid-follow resolution order. */
+function currentCodexObservedPid(): number | undefined {
+  return (backend as { cliPid?: number } | null)?.cliPid
+    ?? backend?.getChildPid?.()
+    ?? codexAdoptPendingPid;
+}
+
+/** Ownership gate for binding a Codex bridge to a session id that came from the
+ *  GLOBAL history.jsonl. That file is shared by every Codex pane under one
+ *  CODEX_HOME, so a concurrent sibling pane submitting identical text can make
+ *  writeInput's history match return a FOREIGN session id. Before attaching (or
+ *  re-attaching) to such an id we require it to be one THIS pid actually holds
+ *  open. findCodexRolloutSetByPid returns every open rollout (it does NOT
+ *  collapse the legitimate parent+sibling multi-rollout case to undefined the
+ *  way findCodexRolloutByPid does), so membership admits the authoritative id
+ *  and rejects a foreign one. FAIL CLOSED: an unavailable fd enumeration
+ *  (undefined) or a non-member id returns false → caller must not bind. */
+function codexHistorySidOwnedByCurrentPid(cliSessionId: string): boolean {
+  const pid = currentCodexObservedPid();
+  const ownedRollouts = pid ? findCodexRolloutSetByPid(pid) : undefined;
+  if (!ownedRollouts || !ownedRollouts.has(cliSessionId.toLowerCase())) {
+    log(`Codex session id ${cliSessionId} not owned by pid ${pid ?? '?'} (open rollouts: ${ownedRollouts ? [...ownedRollouts].join(',') || 'none' : 'unknown'})`);
+    return false;
+  }
+  return true;
+}
+
 function codexBridgeNotifyCliSessionId(cliSessionId: string): void {
   if (!codexBridgeFallbackActive()) return;
   if (codexBridgeRolloutPath) {
@@ -3904,20 +3944,14 @@ function codexBridgeNotifyCliSessionId(cliSessionId: string): void {
       const currentSid = codexSessionIdFromRolloutPath(codexBridgeRolloutPath);
       if (currentSid?.toLowerCase() === cliSessionId.toLowerCase()) return;
       // Ownership gate: only re-attach to a session id THIS pid actually holds
-      // open. This admits the real parent+sibling multi-rollout case (the id is
-      // in the pid's fd set) while rejecting a foreign id contributed by another
-      // pane's identical-text history line. findCodexRolloutByPid can't serve as
-      // the gate — it collapses the multi-rollout case to undefined, which is
-      // exactly the case we must ALLOW. Fail closed: if fd enumeration is
-      // unavailable (undefined) or the id is foreign, keep the current binding.
-      const pid = (backend as { cliPid?: number } | null)?.cliPid
-        ?? backend?.getChildPid?.()
-        ?? codexAdoptPendingPid;
-      const ownedRollouts = pid ? findCodexRolloutSetByPid(pid) : undefined;
-      if (!ownedRollouts || !ownedRollouts.has(cliSessionId.toLowerCase())) {
-        log(`Codex session id ${cliSessionId} not owned by pid ${pid ?? '?'} (open rollouts: ${ownedRollouts ? [...ownedRollouts].join(',') || 'none' : 'unknown'}); keeping current bridge ${currentSid ?? '?'} — refusing history-only re-attach`);
+      // open (admits the real parent+sibling multi-rollout case, rejects a
+      // foreign id from another pane's identical-text history line). Fail
+      // closed: keep the current binding when unowned/unknown.
+      if (!codexHistorySidOwnedByCurrentPid(cliSessionId)) {
+        log(`Keeping current Codex bridge ${currentSid ?? '?'} — refusing history-only re-attach to ${cliSessionId}`);
         return;
       }
+      const pid = currentCodexObservedPid();
       const next = resolveFileBridgePath('codex', { sessionId: cliSessionId });
       if (next && next !== codexBridgeRolloutPath) {
         const attachMode = lastInitConfig?.adoptMode ? 'split-live' : 'fresh-empty';
@@ -4029,6 +4063,25 @@ function codexBridgeNotifyCliSessionId(cliSessionId: string): void {
       codexBridgeStartTimer();
     }
     return;
+  }
+  // Codex INITIAL attach (no prior rollout bound). The multi-fd adopt case
+  // reaches here with codexBridgeRolloutPath still unset: findCodexRolloutByPid
+  // returned undefined (ambiguous parent+sibling), so the adopt block armed the
+  // poller instead of attaching. The cliSessionId is normally already
+  // source-filtered by the codex adapter (writeInput only returns an owned sid),
+  // but keep a defense-in-depth ownership gate here too so a sid from any other
+  // path can't first-attach the shared-history foreign session. Fail closed:
+  // when the sid isn't provably owned, DON'T pin it as pending (that would wedge
+  // the bridge — the poller's pid fallback stays ambiguous→undefined forever and
+  // the owned line never re-triggers this callback). Keep the adopt pid pending
+  // so the poller can bind once a uniquely-owned rollout appears.
+  if (structuredBridgeIsCodex() && lastInitConfig?.adoptMode && currentCodexObservedPid()) {
+    if (!codexHistorySidOwnedByCurrentPid(cliSessionId)) {
+      log(`Codex initial-attach refused for unverified session ${cliSessionId}; keeping poller armed on pid ${currentCodexObservedPid()}`);
+      codexBridgePendingSessionId = undefined;
+      codexBridgeStartTimer();
+      return;
+    }
   }
   const path = resolveFileBridgePath(lastInitConfig?.cliId, {
     sessionId: cliSessionId,

--- a/test/codex-adapter-history-ownership.test.ts
+++ b/test/codex-adapter-history-ownership.test.ts
@@ -30,6 +30,11 @@ let prevCodexHome: string | undefined;
 let prevScale: string | undefined;
 let ownerChild: ChildProcessWithoutNullStreams;
 let rolloutB: string;
+/** Deferred timers scheduled by a test's onEnter. writeInput retries Enter, so
+ *  onEnter can fire several times; track every timer and clear them in afterEach
+ *  so none survives to append to an already-removed home dir (→ uncaught ENOENT
+ *  that poisons later tests / fails CI). */
+let pendingTimers: ReturnType<typeof setTimeout>[] = [];
 
 /** A rollout file under `<CODEX_HOME>/sessions/YYYY/MM/DD/rollout-<ts>-<sid>.jsonl`. */
 function rolloutPath(root: string, sid: string): string {
@@ -82,6 +87,8 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+  for (const t of pendingTimers) clearTimeout(t);
+  pendingTimers = [];
   if (ownerChild && !ownerChild.killed) ownerChild.kill('SIGKILL');
   if (home) rmSync(home, { recursive: true, force: true });
   if (prevScale === undefined) delete process.env.BOTMUX_TIME_SCALE; else process.env.BOTMUX_TIME_SCALE = prevScale;
@@ -110,9 +117,18 @@ describe('codex writeInput history ownership filter', () => {
     expect((result as any).cliSessionId).toBe(SID_B);
   });
 
-  it('works under a custom CODEX_HOME (no /.codex/ segment in the path)', async () => {
-    // home is already a custom mkdtemp root (not ~/.codex); assert the ownership
-    // probe still recognizes B's rollout by its structural /sessions/ shape.
+  it('recognizes rollouts under a custom CODEX_HOME (env-independent path shape), when worker + Codex share that home', async () => {
+    // SCOPE: this proves the ownership probe recognizes B's rollout by its
+    // structural `/sessions/rollout-…` shape even when the home is a custom
+    // mkdtemp root (no `/.codex/` segment) — home here is BOTH the worker's
+    // CODEX_HOME (via process.env, set in beforeEach) and the child's.
+    //
+    // It does NOT cover an ADOPTED external Codex whose CODEX_HOME differs from
+    // the worker's: the worker scrubs inherited CODEX_HOME and the adapter reads
+    // the worker's own codexHistoryPath()/sessions root, while the adopt init
+    // message carries no external CODEX_HOME (only adoptCwd). That cross-home
+    // adopt was never plumbed (true on master too) — a pre-existing limitation,
+    // out of scope for this fix. See the note in matchCodexRolloutPath.
     const historyPath = join(home, 'history.jsonl');
     const adapter = createCodexAdapter();
     let appended = false;
@@ -131,9 +147,16 @@ describe('codex writeInput history ownership filter', () => {
     const historyPath = join(home, 'history.jsonl');
     const adapter = createCodexAdapter();
     // On submit only A appears; B's line arrives shortly after (separate tick).
+    // writeInput retries Enter, so guard the deferred B-append one-shot and track
+    // the timer so afterEach can clear it (no append into a removed home dir).
+    let scheduledB = false;
     const onEnter = () => {
       appendFileSync(historyPath, historyLine(SID_A, 'ping'));
-      setTimeout(() => appendFileSync(historyPath, historyLine(SID_B, 'ping')), 20);
+      if (scheduledB) return;
+      scheduledB = true;
+      pendingTimers.push(setTimeout(() => {
+        try { appendFileSync(historyPath, historyLine(SID_B, 'ping')); } catch { /* home may be gone if test already resolved */ }
+      }, 20));
     };
 
     const result = await adapter.writeInput!(fakePty(ownerChild.pid!, onEnter), 'ping');

--- a/test/codex-adapter-history-ownership.test.ts
+++ b/test/codex-adapter-history-ownership.test.ts
@@ -1,0 +1,155 @@
+/**
+ * codex writeInput history-ownership filter (shared CODEX_HOME collision).
+ *
+ * history.jsonl is ONE global file shared by every Codex pane under a CODEX_HOME.
+ * When two panes submit identical text, both append a same-text line; scanning
+ * the delta and taking the FIRST match can hand pane B pane A's session id. That
+ * poisoned id then drives the worker's bridge attach → B's replies are lost or
+ * A's transcript is posted into B's thread.
+ *
+ * The adapter now filters the history match by pid ownership: it only accepts a
+ * same-text line whose session id is one THIS pid actually holds open
+ * (findCodexRolloutSetByPid), so B's writeInput returns B even when A's identical
+ * line landed first. These tests spawn a REAL subprocess holding B's rollout fd
+ * (so the ownership probe has a live pid to enumerate) and assert the RESULT is
+ * B — not merely "not A", which a permanently-wedged bridge would also satisfy.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { createCodexAdapter } from '../src/adapters/cli/codex.js';
+import type { PtyHandle } from '../src/adapters/cli/types.js';
+
+const SID_A = '019dd80d-d922-7a11-8339-0208d8c5b4ec'; // foreign sibling pane
+const SID_B = '019dd80d-d922-7a11-8339-0208d8c5b4ee'; // this pane (owned)
+
+let home: string;
+let prevCodexHome: string | undefined;
+let prevScale: string | undefined;
+let ownerChild: ChildProcessWithoutNullStreams;
+let rolloutB: string;
+
+/** A rollout file under `<CODEX_HOME>/sessions/YYYY/MM/DD/rollout-<ts>-<sid>.jsonl`. */
+function rolloutPath(root: string, sid: string): string {
+  const dir = join(root, 'sessions', '2026', '05', '15');
+  mkdirSync(dir, { recursive: true });
+  return join(dir, `rollout-2026-05-15T07-04-39-${sid}.jsonl`);
+}
+
+/** A global history.jsonl line: Codex writes `{session_id, text, ...}` per submit. */
+function historyLine(sid: string, text: string): string {
+  return `${JSON.stringify({ session_id: sid, text, ts: 0 })}\n`;
+}
+
+/** A PtyHandle whose paste is a no-op but whose Enter triggers `onEnter`, so a
+ *  test can append the history line(s) AFTER writeInput captured its baseByte —
+ *  matching production (Codex writes the history line in response to submit, so
+ *  the line always lands after baseByte). */
+function fakePty(cliPid: number | undefined, onEnter?: () => void): PtyHandle {
+  return {
+    write() {},
+    pasteText() {},
+    sendSpecialKeys() { onEnter?.(); },
+    ...(cliPid !== undefined ? { cliPid } : {}),
+  } as unknown as PtyHandle;
+}
+
+beforeEach(async () => {
+  prevScale = process.env.BOTMUX_TIME_SCALE;
+  process.env.BOTMUX_TIME_SCALE = '0.01'; // collapse the ~0.5–3s submit waits
+  prevCodexHome = process.env.CODEX_HOME;
+  home = mkdtempSync(join(tmpdir(), 'bmx-codex-hist-'));
+  process.env.CODEX_HOME = home;
+
+  // B's rollout exists and is held open by a live process → ownership probe of
+  // that pid enumerates SID_B (not SID_A).
+  rolloutB = rolloutPath(home, SID_B);
+  writeFileSync(rolloutB, '');
+  writeFileSync(join(home, 'history.jsonl'), '');
+
+  ownerChild = spawn(
+    process.execPath,
+    ['-e', `require('fs').openSync(${JSON.stringify(rolloutB)}, 'a'); process.stdout.write('ready\\n'); setTimeout(()=>{}, 60000);`],
+    { stdio: ['ignore', 'pipe', 'pipe'] },
+  ) as ChildProcessWithoutNullStreams;
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('owner child not ready')), 5000);
+    ownerChild.stdout.once('data', (b: Buffer) => { if (b.toString().includes('ready')) { clearTimeout(timer); resolve(); } });
+    ownerChild.once('error', reject);
+  });
+});
+
+afterEach(() => {
+  if (ownerChild && !ownerChild.killed) ownerChild.kill('SIGKILL');
+  if (home) rmSync(home, { recursive: true, force: true });
+  if (prevScale === undefined) delete process.env.BOTMUX_TIME_SCALE; else process.env.BOTMUX_TIME_SCALE = prevScale;
+  if (prevCodexHome === undefined) delete process.env.CODEX_HOME; else process.env.CODEX_HOME = prevCodexHome;
+});
+
+describe('codex writeInput history ownership filter', () => {
+  it('returns the OWNED session id (B), not the foreign sibling line (A) that landed first', async () => {
+    const historyPath = join(home, 'history.jsonl');
+    const adapter = createCodexAdapter();
+    // On submit (Enter), the shared history gains A's identical-text line FIRST
+    // (a concurrent sibling pane), then B's own line — both AFTER baseByte, as in
+    // production where Codex writes the line in response to the submit.
+    let appended = false;
+    const onEnter = () => {
+      if (appended) return;
+      appended = true;
+      appendFileSync(historyPath, historyLine(SID_A, '继续'));
+      appendFileSync(historyPath, historyLine(SID_B, '继续'));
+    };
+
+    const result = await adapter.writeInput!(fakePty(ownerChild.pid!, onEnter), '继续');
+    expect(result).toBeDefined();
+    expect((result as any).submitted).toBe(true);
+    // The heart of the fix: B's writeInput binds to B, never to A.
+    expect((result as any).cliSessionId).toBe(SID_B);
+  });
+
+  it('works under a custom CODEX_HOME (no /.codex/ segment in the path)', async () => {
+    // home is already a custom mkdtemp root (not ~/.codex); assert the ownership
+    // probe still recognizes B's rollout by its structural /sessions/ shape.
+    const historyPath = join(home, 'history.jsonl');
+    const adapter = createCodexAdapter();
+    let appended = false;
+    const onEnter = () => {
+      if (appended) return;
+      appended = true;
+      appendFileSync(historyPath, historyLine(SID_A, 'hello'));
+      appendFileSync(historyPath, historyLine(SID_B, 'hello'));
+    };
+
+    const result = await adapter.writeInput!(fakePty(ownerChild.pid!, onEnter), 'hello');
+    expect((result as any)?.cliSessionId).toBe(SID_B);
+  });
+
+  it('does not wedge when ONLY the foreign line exists yet — waits, then binds B once B lands', async () => {
+    const historyPath = join(home, 'history.jsonl');
+    const adapter = createCodexAdapter();
+    // On submit only A appears; B's line arrives shortly after (separate tick).
+    const onEnter = () => {
+      appendFileSync(historyPath, historyLine(SID_A, 'ping'));
+      setTimeout(() => appendFileSync(historyPath, historyLine(SID_B, 'ping')), 20);
+    };
+
+    const result = await adapter.writeInput!(fakePty(ownerChild.pid!, onEnter), 'ping');
+    // Must NOT have taken A; must eventually bind B (not a permanent no-match).
+    expect((result as any)?.cliSessionId).toBe(SID_B);
+  });
+
+  it('with NO pid, preserves accept-first semantics (single-pane / pid-less callers unchanged)', async () => {
+    const historyPath = join(home, 'history.jsonl');
+    const adapter = createCodexAdapter();
+    // Only a foreign-looking line exists; without a pid there is no ownership
+    // signal, so the original submit-confirmation behavior (accept the match)
+    // is preserved — the worker-side attach gate is the backstop there.
+    const onEnter = () => { appendFileSync(historyPath, historyLine(SID_A, 'noping')); };
+
+    const result = await adapter.writeInput!(fakePty(undefined, onEnter), 'noping');
+    expect((result as any)?.cliSessionId).toBe(SID_A);
+  });
+});

--- a/test/codex-coco-pid-discovery.smoke.test.ts
+++ b/test/codex-coco-pid-discovery.smoke.test.ts
@@ -26,6 +26,9 @@ let codexSiblingRollout: string;
 let cocoSessionLog: string;
 let child: ChildProcessWithoutNullStreams;
 let ambiguousChild: ChildProcessWithoutNullStreams;
+let customHomeChild: ChildProcessWithoutNullStreams;
+let customHomeRollout: string;
+const CUSTOM_HOME_SID = '019dd80d-d922-7a11-8339-0208d8c5b4ea';
 
 beforeAll(async () => {
   dir = mkdtempSync(join(tmpdir(), 'bmx-pid-disc-'));
@@ -93,11 +96,37 @@ beforeAll(async () => {
     });
     ambiguousChild.once('error', reject);
   });
+
+  // Custom CODEX_HOME: rollout path has NO `/.codex/` segment. Verifies the
+  // ownership probe recognizes it by the structural `/sessions/rollout-…` shape
+  // (an adopted external Codex may run under a CODEX_HOME the worker never
+  // inherited; the fd already comes from the pid, so the path anchor must be
+  // env-independent). `customhome` deliberately omits `.codex`.
+  const customHomeDir = join(dir, 'customhome', 'sessions', '2026', '05', '15');
+  mkdirSync(customHomeDir, { recursive: true });
+  customHomeRollout = join(customHomeDir, `rollout-2026-05-15T07-04-41-${CUSTOM_HOME_SID}.jsonl`);
+  writeFileSync(customHomeRollout, '');
+  customHomeChild = spawn(
+    process.execPath,
+    ['-e', `require('fs').openSync(${JSON.stringify(customHomeRollout)}, 'a'); process.stdout.write('ready\\n'); setTimeout(() => {}, 60000);`],
+    { stdio: ['ignore', 'pipe', 'pipe'] },
+  ) as ChildProcessWithoutNullStreams;
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('custom-home child not ready in 5s')), 5000);
+    customHomeChild.stdout.once('data', (buf: Buffer) => {
+      if (buf.toString().includes('ready')) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    customHomeChild.once('error', reject);
+  });
 });
 
 afterAll(() => {
   if (child && !child.killed) child.kill('SIGKILL');
   if (ambiguousChild && !ambiguousChild.killed) ambiguousChild.kill('SIGKILL');
+  if (customHomeChild && !customHomeChild.killed) customHomeChild.kill('SIGKILL');
   if (dir) rmSync(dir, { recursive: true, force: true });
 });
 
@@ -162,6 +191,15 @@ describe('findCodexRolloutSetByPid', () => {
     expect(findCodexRolloutSetByPid(0)).toBeUndefined();
     expect(findCodexRolloutSetByPid(-1)).toBeUndefined();
     expect(findCodexRolloutSetByPid(1.5 as any)).toBeUndefined();
+  });
+
+  it('recognizes a rollout under a custom CODEX_HOME with no /.codex/ segment', () => {
+    // Env-independent structural anchor: the path came from the pid's fd, so it
+    // must be recognized by its `/sessions/rollout-<ts>-<uuid>.jsonl` shape even
+    // when CODEX_HOME is a custom/isolated root the worker never inherited.
+    const set = findCodexRolloutSetByPid(customHomeChild.pid!);
+    expect(set).toBeDefined();
+    expect(set!.has(CUSTOM_HOME_SID.toLowerCase())).toBe(true);
   });
 });
 

--- a/test/codex-coco-pid-discovery.smoke.test.ts
+++ b/test/codex-coco-pid-discovery.smoke.test.ts
@@ -13,7 +13,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-import { findCodexRolloutByPid } from '../src/services/codex-transcript.js';
+import { findCodexRolloutByPid, findCodexRolloutSetByPid } from '../src/services/codex-transcript.js';
 import { findCocoSessionByPid } from '../src/services/coco-transcript.js';
 
 const CODEX_SID = '019dd80d-d922-7a11-8339-0208d8c5b4ec';
@@ -123,6 +123,45 @@ describe('findCodexRolloutByPid', () => {
     expect(findCodexRolloutByPid(0)).toBeUndefined();
     expect(findCodexRolloutByPid(-1)).toBeUndefined();
     expect(findCodexRolloutByPid(1.5 as any)).toBeUndefined();
+  });
+});
+
+// findCodexRolloutSetByPid is the ownership gate for post-submit rollout
+// re-attach: it must NOT collapse the parent+sibling multi-rollout case to
+// undefined (that's the case the bridge must ALLOW), and it must let a caller
+// prove a history-derived sid is foreign (not in this pid's fd set) so a
+// shared-CODEX_HOME sibling's identical-text history line can't hijack the
+// binding. Same real-subprocess strategy as above so macOS lsof stays covered.
+describe('findCodexRolloutSetByPid', () => {
+  it('returns the single sid a one-rollout process holds', () => {
+    const set = findCodexRolloutSetByPid(child.pid!);
+    expect(set).toBeDefined();
+    expect(set!.has(CODEX_SID.toLowerCase())).toBe(true);
+    expect(set!.size).toBe(1);
+  });
+
+  it('returns BOTH sids for the parent+sibling multi-rollout process (does not collapse to undefined)', () => {
+    const set = findCodexRolloutSetByPid(ambiguousChild.pid!);
+    expect(set).toBeDefined();
+    // The exact case findCodexRolloutByPid refuses to guess — here we must see
+    // every open rollout so `historySid ∈ set` can admit the authoritative one.
+    expect(set!.has(CODEX_SID.toLowerCase())).toBe(true);
+    expect(set!.has(CODEX_SIBLING_SID.toLowerCase())).toBe(true);
+    expect(set!.size).toBe(2);
+  });
+
+  it('does not contain a foreign sid (shared-CODEX_HOME poison is rejectable)', () => {
+    const foreignSid = '019dd80d-d922-7a11-8339-0208d8c5b4ff';
+    const set = findCodexRolloutSetByPid(child.pid!);
+    expect(set).toBeDefined();
+    expect(set!.has(foreignSid.toLowerCase())).toBe(false);
+  });
+
+  it('returns undefined (fail-closed) for a non-existent or invalid pid', () => {
+    expect(findCodexRolloutSetByPid(2_000_000)).toBeUndefined();
+    expect(findCodexRolloutSetByPid(0)).toBeUndefined();
+    expect(findCodexRolloutSetByPid(-1)).toBeUndefined();
+    expect(findCodexRolloutSetByPid(1.5 as any)).toBeUndefined();
   });
 });
 

--- a/test/codex-coco-pid-discovery.smoke.test.ts
+++ b/test/codex-coco-pid-discovery.smoke.test.ts
@@ -17,12 +17,15 @@ import { findCodexRolloutByPid } from '../src/services/codex-transcript.js';
 import { findCocoSessionByPid } from '../src/services/coco-transcript.js';
 
 const CODEX_SID = '019dd80d-d922-7a11-8339-0208d8c5b4ec';
+const CODEX_SIBLING_SID = '019dd80d-d922-7a11-8339-0208d8c5b4ee';
 const COCO_SID = '8db7d911-96f3-4764-a310-e42ae4cb626f';
 
 let dir: string;
 let codexRollout: string;
+let codexSiblingRollout: string;
 let cocoSessionLog: string;
 let child: ChildProcessWithoutNullStreams;
+let ambiguousChild: ChildProcessWithoutNullStreams;
 
 beforeAll(async () => {
   dir = mkdtempSync(join(tmpdir(), 'bmx-pid-disc-'));
@@ -31,7 +34,9 @@ beforeAll(async () => {
   const codexDir = join(dir, '.codex', 'sessions', '2026', '05', '15');
   mkdirSync(codexDir, { recursive: true });
   codexRollout = join(codexDir, `rollout-2026-05-15T07-04-39-${CODEX_SID}.jsonl`);
+  codexSiblingRollout = join(codexDir, `rollout-2026-05-15T07-04-40-${CODEX_SIBLING_SID}.jsonl`);
   writeFileSync(codexRollout, '');
+  writeFileSync(codexSiblingRollout, '');
   // 伪 CoCo 会话目录：路径里必须含 `/.cache/coco/sessions/<uuid>/`。session.log
   // 模拟 CoCo 长持有的 fd（events.jsonl 是 open-write-close，不靠谱）。
   const cocoDir = join(dir, '.cache', 'coco', 'sessions', COCO_SID);
@@ -63,10 +68,36 @@ beforeAll(async () => {
     });
     child.once('error', reject);
   });
+
+  ambiguousChild = spawn(
+    process.execPath,
+    [
+      '-e',
+      `
+        const fs = require('fs');
+        fs.openSync(${JSON.stringify(codexRollout)}, 'a');
+        fs.openSync(${JSON.stringify(codexSiblingRollout)}, 'a');
+        process.stdout.write('ready\\n');
+        setTimeout(() => {}, 60000);
+      `,
+    ],
+    { stdio: ['ignore', 'pipe', 'pipe'] },
+  ) as ChildProcessWithoutNullStreams;
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('ambiguous child not ready in 5s')), 5000);
+    ambiguousChild.stdout.once('data', (buf: Buffer) => {
+      if (buf.toString().includes('ready')) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    ambiguousChild.once('error', reject);
+  });
 });
 
 afterAll(() => {
   if (child && !child.killed) child.kill('SIGKILL');
+  if (ambiguousChild && !ambiguousChild.killed) ambiguousChild.kill('SIGKILL');
   if (dir) rmSync(dir, { recursive: true, force: true });
 });
 
@@ -78,6 +109,10 @@ describe('findCodexRolloutByPid', () => {
     // macOS lsof 会把 tmp 路径解析成 /private/tmp/... —— 用文件名 anchor
     // 而不是完整路径比较。
     expect(hit!.path.endsWith(`rollout-2026-05-15T07-04-39-${CODEX_SID}.jsonl`)).toBe(true);
+  });
+
+  it('does not guess when one process holds multiple rollout files', () => {
+    expect(findCodexRolloutByPid(ambiguousChild.pid!)).toBeUndefined();
   });
 
   it('returns undefined for a non-existent pid', () => {

--- a/test/codex-composer-guard-wiring.test.ts
+++ b/test/codex-composer-guard-wiring.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('Codex adopt composer collision guard wiring', () => {
+  it('checks the adopted pane before bridge attribution and terminal input', () => {
+    const worker = readFileSync(join(repoRoot, 'src/worker.ts'), 'utf8');
+    const adoptBranch = worker.indexOf('const composerConflict = codexAdoptComposerConflict(submissionBackend);');
+    const bridgePreparation = worker.indexOf('prepareAdoptWrite,', adoptBranch);
+    const adapterWrite = worker.indexOf('submissionAdapter.writeInput(', adoptBranch);
+
+    expect(adoptBranch).toBeGreaterThan(0);
+    expect(bridgePreparation).toBeGreaterThan(adoptBranch);
+    expect(adapterWrite).toBeGreaterThan(adoptBranch);
+    expect(worker.slice(adoptBranch, bridgePreparation)).toContain('scheduleSubmitFailureNotify(');
+    expect(worker.slice(adoptBranch, bridgePreparation)).toContain('return;');
+  });
+
+  it('gets a plain viewport and real cursor from the adopted tmux pane', () => {
+    const backend = readFileSync(join(repoRoot, 'src/adapters/backend/tmux-pipe-backend.ts'), 'utf8');
+    const method = backend.indexOf('captureInputState():');
+    const nextMethod = backend.indexOf('private captureWithBounds(', method);
+    const body = backend.slice(method, nextMethod);
+
+    expect(method).toBeGreaterThan(0);
+    expect(body).toContain('this.getCursorPosition()');
+    expect(body).toContain("'tmux', ['capture-pane', '-p', '-t', this.paneTarget]");
+    expect(body).toContain('return { viewport, cursor };');
+  });
+});

--- a/test/codex-composer-state.test.ts
+++ b/test/codex-composer-state.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { detectCodexComposerState } from '../src/services/codex-composer-state.js';
+
+describe('detectCodexComposerState', () => {
+  it('detects the single-line draft that caused a Lark message to be prefixed', () => {
+    const viewport = [
+      '  Tip: Use /fast for faster inference.',
+      '',
+      '› 帮我查一下最新的 botmux 在',
+      '',
+      '  gpt-5.6-sol high · Context 12% used',
+    ].join('\n');
+
+    expect(detectCodexComposerState({
+      viewport,
+      cursor: { x: 24, y: 2 },
+    })).toBe('draft');
+  });
+
+  it('treats an empty Codex placeholder as an empty composer', () => {
+    const viewport = [
+      '  Tip: Use /fast for faster inference.',
+      '',
+      '› Write tests for @filename',
+      '',
+      '  gpt-5.6-sol high · Context 12% used',
+    ].join('\n');
+
+    expect(detectCodexComposerState({
+      viewport,
+      cursor: { x: 2, y: 2 },
+    })).toBe('empty');
+  });
+
+  it('detects a multi-line draft even when the cursor is on an empty continuation line', () => {
+    const viewport = [
+      '› LINE_ONE',
+      '',
+      '',
+      '  gpt-5.6-sol high · Context 12% used',
+    ].join('\n');
+
+    expect(detectCodexComposerState({
+      viewport,
+      cursor: { x: 2, y: 1 },
+    })).toBe('draft');
+  });
+
+  it('returns unknown when the current viewport does not expose a composer marker', () => {
+    expect(detectCodexComposerState({
+      viewport: 'Working...\nRunning command',
+      cursor: { x: 0, y: 1 },
+    })).toBe('unknown');
+  });
+});

--- a/test/codex-transcript.test.ts
+++ b/test/codex-transcript.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, writeFileSync, appendFileSync, rmSync, statSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { drainCodexRollout, codexSessionIdFromRolloutPath, findCodexRolloutBySessionId, findCodexSessionIdByBotmuxSessionId, splitCodexEventsByCutoff, extractLastCodexTurn, scanCodexThreadSettings, type CodexBridgeEvent } from '../src/services/codex-transcript.js';
+import { drainCodexRollout, codexSessionIdFromRolloutPath, findCodexRolloutBySessionId, findCodexSessionIdByBotmuxSessionId, codexHistorySidIsOwned, splitCodexEventsByCutoff, extractLastCodexTurn, scanCodexThreadSettings, type CodexBridgeEvent } from '../src/services/codex-transcript.js';
 
 let dir: string;
 let path: string;
@@ -99,6 +99,42 @@ describe('findCodexRolloutBySessionId', () => {
       else process.env.CODEX_HOME = prevCodexHome;
       rmSync(codexHome, { recursive: true, force: true });
     }
+  });
+});
+
+describe('codexHistorySidIsOwned (pure attach-ownership decision)', () => {
+  // This is the exact predicate BOTH worker attach entry points (notify
+  // re-attach + initial-attach guard) consult via codexHistorySidOwnedByCurrentPid.
+  // Testing it directly proves "owned B is selected, foreign A is rejected"
+  // without a live worker — and without a parallel copy of the decision.
+  const OWNED = 'aaaaaaaa-aaaa-7aaa-8aaa-aaaaaaaaaaaa';
+  const SIBLING = 'bbbbbbbb-bbbb-7bbb-8bbb-bbbbbbbbbbbb';
+  const FOREIGN = 'cccccccc-cccc-7ccc-8ccc-cccccccccccc';
+
+  it('accepts an owned sid (single-rollout pid)', () => {
+    expect(codexHistorySidIsOwned(OWNED, new Set([OWNED]))).toBe(true);
+  });
+
+  it('accepts EITHER owned sid in the parent+sibling multi-rollout case', () => {
+    const owned = new Set([OWNED, SIBLING]);
+    expect(codexHistorySidIsOwned(OWNED, owned)).toBe(true);
+    expect(codexHistorySidIsOwned(SIBLING, owned)).toBe(true);
+  });
+
+  it('rejects a foreign sid (shared-CODEX_HOME sibling pane collision)', () => {
+    expect(codexHistorySidIsOwned(FOREIGN, new Set([OWNED, SIBLING]))).toBe(false);
+  });
+
+  it('is case-insensitive on the sid', () => {
+    expect(codexHistorySidIsOwned(OWNED.toUpperCase(), new Set([OWNED]))).toBe(true);
+  });
+
+  it('fails closed when the owned set is unavailable (fd enumeration failed)', () => {
+    expect(codexHistorySidIsOwned(OWNED, undefined)).toBe(false);
+  });
+
+  it('fails closed against an empty owned set (pid holds no rollout yet)', () => {
+    expect(codexHistorySidIsOwned(OWNED, new Set())).toBe(false);
   });
 });
 

--- a/test/codex-worker-bridge-wiring.test.ts
+++ b/test/codex-worker-bridge-wiring.test.ts
@@ -3,6 +3,13 @@ import { describe, expect, it } from 'vitest';
 
 const workerSource = readFileSync(new URL('../src/worker.ts', import.meta.url), 'utf8');
 
+// NB: this file only asserts the WIRING shape of codexBridgeNotifyCliSessionId
+// (a module-state-heavy worker-internal function that isn't unit-testable
+// end-to-end without spawning a real worker). The behavioral guarantee behind
+// the ownership gate — a foreign, shared-CODEX_HOME history sid is NOT in the
+// pid's fd set and therefore cannot hijack the binding, while a real
+// parent+sibling sid IS — is exercised against real subprocesses in
+// codex-coco-pid-discovery.smoke.test.ts (findCodexRolloutSetByPid).
 describe('Codex worker structured-bridge wiring', () => {
   it('reattaches an incorrectly discovered rollout after writeInput verifies the session id', () => {
     const start = workerSource.indexOf('function codexBridgeNotifyCliSessionId');
@@ -17,5 +24,27 @@ describe('Codex worker structured-bridge wiring', () => {
     expect(codex.indexOf('codexBridgeDetachFile();')).toBeLessThan(codex.indexOf('codexBridgeAttach(next, attachMode);'));
     expect(codex).toContain("lastInitConfig?.adoptMode ? 'split-live' : 'fresh-empty'");
     expect(codex).toContain('codexBridgePendingSessionId = cliSessionId;');
+  });
+
+  it('gates the re-attach on pid rollout-fd ownership before detaching (rejects a foreign history sid)', () => {
+    const start = workerSource.indexOf('function codexBridgeNotifyCliSessionId');
+    const end = workerSource.indexOf('// Already attached — first-attach-wins for most CLIs.', start);
+    const codex = workerSource.slice(start, end);
+
+    const gate = codex.indexOf('findCodexRolloutSetByPid(');
+    const detach = codex.indexOf('codexBridgeDetachFile();');
+    const resolveNext = codex.indexOf("resolveFileBridgePath('codex'");
+
+    // The ownership check must exist AND run before both the path resolution and
+    // the detach, so a foreign sid returns early with the binding intact.
+    expect(gate).toBeGreaterThan(0);
+    expect(gate).toBeLessThan(resolveNext);
+    expect(gate).toBeLessThan(detach);
+    // Must use the fd-SET accessor, not the ambiguity-collapsing single one
+    // (which returns undefined for the parent+sibling case we must ALLOW).
+    expect(codex).not.toContain('findCodexRolloutByPid(pid)?.cliSessionId === cliSessionId');
+    // Membership test + fail-closed early return when unowned/unknown.
+    expect(codex).toContain('.has(cliSessionId.toLowerCase())');
+    expect(codex).toContain('refusing history-only re-attach');
   });
 });

--- a/test/codex-worker-bridge-wiring.test.ts
+++ b/test/codex-worker-bridge-wiring.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const workerSource = readFileSync(new URL('../src/worker.ts', import.meta.url), 'utf8');
+
+describe('Codex worker structured-bridge wiring', () => {
+  it('reattaches an incorrectly discovered rollout after writeInput verifies the session id', () => {
+    const start = workerSource.indexOf('function codexBridgeNotifyCliSessionId');
+    const end = workerSource.indexOf('// Already attached — first-attach-wins for most CLIs.', start);
+    const notify = workerSource.slice(start, end);
+    const codexStart = notify.indexOf('if (structuredBridgeIsCodex())');
+    const codex = notify.slice(codexStart);
+
+    expect(codexStart).toBeGreaterThanOrEqual(0);
+    expect(codex).toContain('codexSessionIdFromRolloutPath(codexBridgeRolloutPath)');
+    expect(codex).toContain("resolveFileBridgePath('codex', { sessionId: cliSessionId })");
+    expect(codex.indexOf('codexBridgeDetachFile();')).toBeLessThan(codex.indexOf('codexBridgeAttach(next, attachMode);'));
+    expect(codex).toContain("lastInitConfig?.adoptMode ? 'split-live' : 'fresh-empty'");
+    expect(codex).toContain('codexBridgePendingSessionId = cliSessionId;');
+  });
+});

--- a/test/codex-worker-bridge-wiring.test.ts
+++ b/test/codex-worker-bridge-wiring.test.ts
@@ -31,7 +31,7 @@ describe('Codex worker structured-bridge wiring', () => {
     const end = workerSource.indexOf('// Already attached — first-attach-wins for most CLIs.', start);
     const codex = workerSource.slice(start, end);
 
-    const gate = codex.indexOf('findCodexRolloutSetByPid(');
+    const gate = codex.indexOf('codexHistorySidOwnedByCurrentPid(cliSessionId)');
     const detach = codex.indexOf('codexBridgeDetachFile();');
     const resolveNext = codex.indexOf("resolveFileBridgePath('codex'");
 
@@ -40,11 +40,32 @@ describe('Codex worker structured-bridge wiring', () => {
     expect(gate).toBeGreaterThan(0);
     expect(gate).toBeLessThan(resolveNext);
     expect(gate).toBeLessThan(detach);
-    // Must use the fd-SET accessor, not the ambiguity-collapsing single one
-    // (which returns undefined for the parent+sibling case we must ALLOW).
-    expect(codex).not.toContain('findCodexRolloutByPid(pid)?.cliSessionId === cliSessionId');
-    // Membership test + fail-closed early return when unowned/unknown.
-    expect(codex).toContain('.has(cliSessionId.toLowerCase())');
     expect(codex).toContain('refusing history-only re-attach');
+
+    // The ownership helper must use the fd-SET accessor (not the ambiguity-
+    // collapsing single one, which returns undefined for the parent+sibling
+    // case we must ALLOW) and fail closed on an unavailable set.
+    const helperStart = workerSource.indexOf('function codexHistorySidOwnedByCurrentPid');
+    expect(helperStart).toBeGreaterThan(0);
+    const helper = workerSource.slice(helperStart, workerSource.indexOf('\n}', helperStart));
+    expect(helper).toContain('findCodexRolloutSetByPid(');
+    expect(helper).toContain('.has(cliSessionId.toLowerCase())');
+    expect(helper).not.toContain('findCodexRolloutByPid(');
+  });
+
+  it('also gates the INITIAL attach (unattached multi-fd adopt), not just re-attach', () => {
+    // The multi-fd adopt case starts unattached (findCodexRolloutByPid → undefined),
+    // so a foreign history sid would otherwise reach the generic initial-attach
+    // tail with no ownership check. Assert the codex initial-attach guard exists
+    // and that a rejected sid does NOT get pinned as pending (which would wedge
+    // the bridge — poller pid-fallback stays ambiguous forever).
+    const marker = "Codex INITIAL attach";
+    const guardIdx = workerSource.indexOf(marker);
+    expect(guardIdx).toBeGreaterThan(0);
+    const guard = workerSource.slice(guardIdx, guardIdx + 1400);
+    expect(guard).toContain('codexHistorySidOwnedByCurrentPid(cliSessionId)');
+    // On refusal, clear pending (do not pin the foreign sid) + keep polling.
+    expect(guard).toContain('codexBridgePendingSessionId = undefined;');
+    expect(guard).toContain('codexBridgeStartTimer();');
   });
 });

--- a/test/codex-worker-bridge-wiring.test.ts
+++ b/test/codex-worker-bridge-wiring.test.ts
@@ -44,12 +44,13 @@ describe('Codex worker structured-bridge wiring', () => {
 
     // The ownership helper must use the fd-SET accessor (not the ambiguity-
     // collapsing single one, which returns undefined for the parent+sibling
-    // case we must ALLOW) and fail closed on an unavailable set.
+    // case we must ALLOW) and delegate the pure membership decision to
+    // codexHistorySidIsOwned (unit-tested in codex-transcript.test.ts).
     const helperStart = workerSource.indexOf('function codexHistorySidOwnedByCurrentPid');
     expect(helperStart).toBeGreaterThan(0);
     const helper = workerSource.slice(helperStart, workerSource.indexOf('\n}', helperStart));
     expect(helper).toContain('findCodexRolloutSetByPid(');
-    expect(helper).toContain('.has(cliSessionId.toLowerCase())');
+    expect(helper).toContain('codexHistorySidIsOwned(');
     expect(helper).not.toContain('findCodexRolloutByPid(');
   });
 


### PR DESCRIPTION
## 修复背景

Codex `/adopt` 有两类真实缺陷：

1. **多 rollout 误绑**：一个 Codex 进程可能同时持有父会话与 sibling agent 的多个 rollout fd。旧实现按 PID 找到第一个 rollout 就绑定，可能让 `/adopt` 桥接到错误会话。
2. **本地草稿被拼接**：被 adopt 的 Codex 输入框里若已有本地未提交草稿，飞书消息会继续粘贴到草稿后面，导致实际提交内容被错误拼接。

审查（Claude 首审 + codex 多轮复审）过程中，还发现并修复了修复本身引入的一处**跨进程误绑回归**：Codex 的 `history.jsonl` 是同一 `CODEX_HOME` 下**所有 pane 共用的单一全局文件**。两个 pane 并发提交相同文本时，`writeInput` 扫 history delta 取第一条同文行，可能拿到**另一个 pane 的会话 id**，进而驱动 bridge 绑到错误会话（回复丢失 / 对方 transcript 发到本话题）。

## 修复内容

**多 rollout 歧义**
- PID 同时关联多个不同 rollout 时不再猜测，`findCodexRolloutByPid` 返回歧义状态（`undefined`），等待更可靠证据。
- 新增 `findCodexRolloutSetByPid`：枚举该 PID 打开的**全部** rollout（返回 sid 集合），与单结果版本共用同一份 `codexProcessOpenTargets` 归一化（Linux `/proc` 与 macOS/BSD `lsof` 双平台一致）。

**共享 history 跨进程误绑（核心）**
- **候选筛选前移到 history 匹配源头**：Codex 适配器 `writeInput` 扫 history delta 时，仅接受 `sid ∈ findCodexRolloutSetByPid(pty.cliPid)` 的同文行，跳过外来 pane 的同文行、继续等待本 PID 拥有的行。owned set **每轮 poll/recheck 重取**（不快照），兼容"rollout fd 比 history 行稍晚可见"。无 `pty.cliPid` 时保持原 accept-first 语义。
- **worker 侧双入口 defense-in-depth**：提取纯判据 `codexHistorySidIsOwned(sid, ownedSet)`，由 worker `codexHistorySidOwnedByCurrentPid`（供 live pid + fd-set）在 **re-attach 门与 initial-attach 门两处**共用，unknown / foreign 一律 fail-closed；initial-attach 拒绝时不 pin 外来 sid，保 PID poller 避免 wedge。
- **路径判据 env 无关**：`matchCodexRolloutPath` 去掉硬编码 `/.codex/sessions/`，改用结构形态（`/sessions/` 段 + `rollout-<ts>-<uuid>.jsonl` 文件名）——fd 来自目标 PID 本身即所有权证据。

**输入前草稿守卫**
- 为 tmux pipe backend 增加当前 viewport + 真实 cursor 的只读快照能力（`captureInputState`，可选接口）。
- 仅在 Codex + adopt 模式下按 cursor 位置检测非空 composer；发现本地草稿时拒绝写入飞书消息，保留草稿并返回中英文可操作提示。

## 影响面

- **Codex**：仅影响 adopt 模式的 rollout 选择、重绑定、输入前守卫；所有权门限定 `cliId === 'codex'`。
- **其他 CLI**：不进入 Codex 专属判断（`findCodexRolloutByPid` 歧义→undefined 的 5 个 adopt 外消费者都把 undefined 当"继续轮询"兜底，更保守）。
- **平台**：fd 枚举 Linux `/proc` 与 macOS/BSD `lsof` 共用归一化。
- **后端**：`captureInputState` 为可选接口，当前仅 TmuxPipeBackend 实现。

## 验证

- `pnpm build`：通过，domain / dist audit 均通过。
- 定向测试：`codex-adapter-history-ownership`（真子进程持 rollout fd + 共享 history，断言最终绑 owned B 而非首落盘的外来 A；含"只有 A 时不 wedge、B 落盘后绑 B"、无 pid accept-first、共享 custom home 路径识别）、`codex-transcript`（纯 `codexHistorySidIsOwned` 选 B / 拒 A / fail-closed）、`codex-coco-pid-discovery` smoke（`findCodexRolloutSetByPid` 单/多 rollout + 自定义 CODEX_HOME 路径识别，真子进程覆盖 macOS lsof）、`codex-composer-state` / `codex-composer-guard-wiring` / `codex-worker-bridge-wiring`（双入口门接线）。
- 相关回归：codex-transcript / bridge-queue / bridge-rotation / bridge-fallback / session-discovery / adopt-route / submit-confirmation / bridge-input / write-input-all-cli e2e 全绿，`Errors 0` 无 timer 泄漏 / ENOENT。
- CI：build + CodeQL / Analyze 共 **5/5 pass**。

## 已知边界（非本 PR 引入，未扩范围）

- composer 光标移回草稿开头（cursor 停在 `› ` 后起始列）仍可能漏检——启发式仅靠 cursor 位置，真 fail-closed 需 ANSI/样式等更强证据；已在源码注释标注。
- 外部被 adopt 的 Codex 若以与 worker 不同的 `CODEX_HOME` 启动，端到端 adopt 仍是既有限制（worker 会 scrub 继承的 `CODEX_HOME`，adopt init 不携带外部 `CODEX_HOME`，master 亦然）。本 PR 仅保证**共享同一 custom home 时**的路径识别 env 无关；跨-home plumbing（PID 枚举提供 sid→path/root）属未来工作。
