### PR TITLE
fix(dashboard): 扫码登录飞书弹层 portal 到 body，修复居中被顶到视口下方

### DIFF
--- a/src/dashboard/web/bot-defaults-page.tsx
+++ b/src/dashboard/web/bot-defaults-page.tsx
@@ -1176,10 +1176,14 @@ function FeishuLoginModal(props: { onClose(): void; onSuccess(): void }) {
 
   if (typeof document === 'undefined') return null;
 
-  // Portal 到 body：此弹层内联渲染在头像组件的 DOM 里，而该处位于 .app-shell
-  // （height:100dvh + overflow:hidden 的滚动容器）内部——position:fixed 会被这个
-  // 容器约束、把弹层顶到视口下方，用户得滚动才看得到二维码。挂到 body 顶层后
-  // 与 auth-expired-overlay 一致，稳定居中。
+  // Portal 到 body:此弹层内联渲染在头像组件(位于 .page 页面容器)的 DOM 里。
+  // 祖先 .page 有 `animation: dashboard-page-enter … both`,其关键帧动画 transform
+  // (translateY→none);fill-mode:both 下动画结束后持续「填充」,浏览器把 .page 的
+  // computed transform 算成 identity matrix(而非关键字 none)——「非 none 的 transform」
+  // 会为后代 position:fixed 建立包含块,于是弹层不再相对视口、被约束进 .page 的几何
+  // 范围,顶到视口下方,用户得滚动才看得到二维码(与主题无关,light/dark 均复现;
+  // 注意不是 .app-shell 的 overflow:hidden——overflow 不建立 fixed 包含块)。挂到
+  // body 顶层后逃出任何祖先包含块,与 auth-expired-overlay 一致,稳定居中。
   return createPortal(
     <div
       className="feishu-login-overlay"

--- a/src/dashboard/web/bot-defaults-page.tsx
+++ b/src/dashboard/web/bot-defaults-page.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 import { openBotOnboarding } from './bot-onboarding.js';
 import {
   agentSelectionKey,
@@ -1173,7 +1174,13 @@ function FeishuLoginModal(props: { onClose(): void; onSuccess(): void }) {
     };
   }, [begin, stopTimer]);
 
-  return (
+  if (typeof document === 'undefined') return null;
+
+  // Portal 到 body：此弹层内联渲染在头像组件的 DOM 里，而该处位于 .app-shell
+  // （height:100dvh + overflow:hidden 的滚动容器）内部——position:fixed 会被这个
+  // 容器约束、把弹层顶到视口下方，用户得滚动才看得到二维码。挂到 body 顶层后
+  // 与 auth-expired-overlay 一致，稳定居中。
+  return createPortal(
     <div
       className="feishu-login-overlay"
       onClick={event => {
@@ -1191,7 +1198,8 @@ function FeishuLoginModal(props: { onClose(): void; onSuccess(): void }) {
           <button type="button" className="primary" data-retry hidden={!retry} onClick={() => void begin()}>{tr('feishuLogin.retry')}</button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -10608,6 +10608,11 @@ button.contrast:hover { background: var(--danger-soft); border-color: var(--dang
   position: relative;
   display: grid;
   gap: 12px;
+  /* margin:auto 让 modal 在极矮视口高于视口时,靠 overlay 的 overflow:auto 也能
+     完整滚到顶部。纯 flex 居中(align-items:center)下,超高子元素会上下等量溢出,
+     顶部溢出无法滚回(flexbox 通用行为),标题/关闭按钮够不着;auto margin 在负
+     可用空间下归 0、子元素落到滚动起点,正常视口仍由 auto margin 居中。 */
+  margin: auto;
   width: min(360px, 92vw);
   padding: 18px;
   border-radius: var(--radius-lg);

--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -10600,6 +10600,7 @@ button.contrast:hover { background: var(--danger-soft); border-color: var(--dang
   align-items: center;
   justify-content: center;
   padding: 20px;
+  overflow: auto;
   background: var(--modal-backdrop);
   backdrop-filter: blur(3px);
 }


### PR DESCRIPTION
## 如何发现

用户（孙晓雪）在 dashboard 给 bot 换头像，扫码登录飞书后反馈「黑屏」，需要滚动到很下面才看到二维码。

- 第一张截图：换头像触发「服务器缺少飞书 Web 登录态」→ 弹出「扫码登录飞书」。
- 第二张截图：整页变暗+模糊——这是 `.feishu-login-overlay` 的半透明遮罩，但二维码弹层被顶到视口下方，第一眼看着像黑屏/空遮罩。
- 用户往下滚动后，二维码正常显示（「已经扫码，等待手机确认」），确认功能可用，只是弹层位置错了。

## 用户看到什么

| 触发方式 | 旧表现 | 修复后表现 |
|---|---|---|
| dashboard 改头像/改名缺登录态 → 点「扫码登录飞书」 | 整屏半透明遮罩盖住，像黑屏；二维码被顶到视口下方，要向下滚动才看得到 | 弹层稳定居中，二维码第一眼即见 |

## 根因（经双 reviewer live 复审订正）

`FeishuLoginModal` 直接内联渲染在头像组件（`BotAvatarControl` / `BotProfileIdentity`）的 DOM 里，而该处位于页面容器 `.page` 内部。`.page` 带 `animation: dashboard-page-enter .35s ease both`，关键帧动画 `transform`（`translateY(6px)` → `none`）。**`animation-fill-mode: both` 下动画结束后持续「填充」最终帧，浏览器（Blink）把 `.page` 的 computed `transform` 算成 identity matrix `matrix(1,0,0,1,0,0)`，而不是关键字 `none`——「非 none 的 transform」会为后代 `position:fixed` 建立包含块**，于是弹层不再相对视口、被约束进 `.page` 的几何范围（本地复现 overlay `top=88, height=1954`），modal 被居中到 `y≈881`（视口外）。

> 注：触发者不是 `.app-shell` 的 `overflow:hidden`——`overflow` 不为 `position:fixed` 建立包含块；也与主题无关，light/dark 均复现（`@media (prefers-reduced-motion: reduce)` 下 `.page` 动画被禁用，此时 bug 不出现，可反向印证是该填充式动画所致）。

对照同仓库正常居中的 `auth-expired-overlay`——它渲染在 app 顶层（`.page` 之外），不受此包含块影响。

## 改了什么

- **`bot-defaults-page.tsx`**：`FeishuLoginModal` 改用 `createPortal(node, document.body)`，把弹层挂到 body 顶层，逃出**任何**祖先包含块（与 `auth-expired-overlay` 一致，也是本仓库既有约定——`sessions-page`、`insights-page`、`skills-page` 都这么做）。加 `typeof document === 'undefined'` 守卫兼容 SSR/无 DOM 环境。同时把根因注释订正为准确版本（`.page` 填充式 transform 动画，非 `overflow:hidden`）。
- **`style.css`**：
  - `.feishu-login-overlay` 追加 `overflow: auto`，作为极矮视口下弹层高于视口时的兜底滚动。
  - `.feishu-login-modal` 追加 `margin: auto`。纯 flex 居中（`align-items:center`）下，modal 高于视口时会上下等量溢出，**顶部溢出无法滚回**（flexbox 通用行为），标题/关闭按钮够不着；`margin:auto` 在负可用空间下归 0、子元素落到滚动起点使顶部可达，正常视口仍由 auto margin 居中。这样 `overflow:auto` 兜底才真正生效。

两处 `FeishuLoginModal` 调用点（头像、改名）共用同一组件，一处修复全部生效。

## 影响面

纯 dashboard 前端改动：`.tsx` 仅调整渲染挂载点 + 注释，`.css` 仅两条声明。不涉及 daemon / worker / 任何 CLI 适配器 / 后端逻辑，构建产物只进 dashboard bundle。portal 后经核对：`.feishu-login-*` 专属样式全为纯类名或 `:where()` 列表（不依赖 DOM 位置）、`:root` 主题变量仍继承、z-index 仍生效、backdrop/close/retry 事件语义不变；retry 按钮圆角由 999px→12px 属**向对标的 `auth-expired-dialog` 收敛**（后者本就在 `.page` 外、同为 12px），不是回归。

## 测试验证

- `pnpm build`：✅（domain audit + `tsc --noEmit` + dashboard bundle + dist audit 全过）。
- dashboard 定向 3 文件 / 15 tests：✅；`git diff --check`：✅。
- **Chromium live 复测**（reviewer 用真实构建后的 `style.css`，未注入补丁）：
  - 正常视口 1280×599（dark/light）：overlay = 视口（`top=0,height=599`），modal `top=116.5,height=366`，横纵中心误差 **0px**。
  - 极矮视口 1280×260 滚动起点：modal `top=20`，关闭按钮/标题顶部完整可达（overlay `scrollHeight=406, maxScrollTop=146`）。
  - 滚动到底：retry 按钮 / modal 底部完整可达——`margin:auto` 同时覆盖正/负 free-space 场景。
  - 页面祖先实算 `transform: matrix(1,0,0,1,0,0)`，与订正后的源码注释一致；console 无新增错误。

截图依次为：旧 inline（弹层被顶到视口下方）、portal 后正常视口居中、260px 极矮视口滚动起点顶部可达、滚动终点底部可达。
