### PR TITLE
feat(lark): 新增仅发起人可见卡（采纳后转全群可见）

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5353,6 +5353,7 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
        --video-covers <path>           视频封面图片（可重复，按顺序对应 --videos）
        --card-file <path>              直接发送飞书/Lark interactive 卡片 JSON
        --card-json <json>              直接发送飞书/Lark interactive 卡片 JSON 字符串
+       --owner-only                    发仅发起人可见卡（含「采纳→转全群可见」按钮）；仅普通群聊可用
        --mention <open_id:name>        @提及（可重复）
        --mention-back                  @回本轮触发消息的发送者（open_id 自动取自会话）
        --no-mention                    明确声明本条不@任何人
@@ -7038,6 +7039,11 @@ async function cmdSend(rest: string[]): Promise<void> {
   // @ hard-gate: every reply must explicitly choose one of these.
   const mentionBack = rest.includes('--mention-back');
   const noMention = rest.includes('--no-mention');
+  // --owner-only: send a card only the session owner can see (ephemeral), with an
+  // 采纳 button that publishes the same content to the whole group on click. Only
+  // works in flat 普通群 (chat scope); topic/thread/p2p reject (ephemeral has no
+  // thread anchor) → refuse with a clear hint rather than leaking a visible card.
+  const ownerOnly = rest.includes('--owner-only');
   // --attention[=kind]: raise a hand — post this message AND light the dashboard
   // needs-you column for this session. Parsed specially (not argValue) so a bare
   // `--attention "我卡住了"` doesn't eat the message as the flag value.
@@ -7137,6 +7143,65 @@ async function cmdSend(rest: string[]): Promise<void> {
     }
   }
   if (!contentFile && !customCardRequested) rejectLikelyWindowsStdinMojibake(content);
+
+  // ─── --owner-only: 仅发起人可见卡（采纳后转全群可见）────────────────────────
+  // 自包含分支：直接发 ephemeral 卡后返回，不走下方可见发送 / mention footer /
+  // quote chain 机制（ephemeral 无 thread anchor，也不 quote）。
+  if (ownerOnly) {
+    if (asVoice || images.length > 0 || files.length > 0 || videoAttachments.length > 0) {
+      console.error('botmux send: --owner-only 暂不支持语音 / 图片 / 文件 / 视频，只支持正文或 --card-json 卡片内容');
+      process.exit(2);
+    }
+    if (sendTopLevel || sendInto || overrideChatId || mentionBack || mentionArgs.length > 0) {
+      console.error('botmux send: --owner-only 不与 --top-level / --into / --chat / --mention / --mention-back 混用（卡片仅发起人可见）');
+      process.exit(2);
+    }
+    // ephemeral 只在 flat 普通群 + chat scope 生效（见 client.ts sendEphemeralCard）。
+    if (s.chatType !== 'group' || s.scope !== 'chat') {
+      console.error('botmux send: --owner-only 仅普通群聊可用；话题群 / 单聊不支持仅发起人可见卡');
+      process.exit(2);
+    }
+    const ownerModule = await import('./bot-registry.js');
+    const ownerOpenId = ownerModule.getOwnerOpenId(s.larkAppId!);
+    if (!ownerOpenId) {
+      console.error('botmux send: --owner-only 需要已配置 owner open_id');
+      process.exit(2);
+    }
+    // 内容 elements：--card-json 用其 elements；否则把正文包成 markdown 元素。
+    let contentElements: Array<Record<string, unknown>>;
+    if (customCard) {
+      const els = (customCard as { elements?: unknown }).elements;
+      if (!Array.isArray(els) || els.length === 0) {
+        console.error('botmux send: --owner-only 的 --card-json 必须含非空 elements');
+        process.exit(2);
+      }
+      contentElements = els as Array<Record<string, unknown>>;
+    } else {
+      if (!content.trim()) { console.error('botmux send: --owner-only 没有内容可发送'); process.exit(2); }
+      contentElements = [{ tag: 'markdown', content }];
+    }
+    const nonce = randomBytes(16).toString('hex');
+    const { buildOwnerPublishEphemeralCard, buildOwnerPublishPublicCard } = await import('./im/lark/owner-publish-card.js');
+    const { registerOwnerPublish } = await import('./im/lark/owner-publish-pending.js');
+    const { sendEphemeralCard } = await import('./im/lark/client.js');
+    const { localeForBot } = await import('./i18n/index.js');
+    const loc = localeForBot(s.larkAppId);
+    // 先登记待发布 payload（公开卡 = 原样内容，无按钮），再发私密卡。
+    registerOwnerPublish(nonce, {
+      ownerOpenId,
+      chatId: s.chatId,
+      publishCardJson: buildOwnerPublishPublicCard(contentElements),
+    });
+    const ephemeralCard = buildOwnerPublishEphemeralCard(contentElements, nonce, loc);
+    try {
+      const messageId = await sendEphemeralCard(s.larkAppId!, s.chatId, ownerOpenId, ephemeralCard);
+      console.log(`✓ 已发送仅你可见卡 ${messageId || '(no id)'}｜点「采纳」后转为所有人可见`);
+    } catch (err) {
+      console.error(`botmux send: 发送仅发起人可见卡失败：${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
+    return;
+  }
 
   const managedPayloadError = managedVcSendPayloadError({
     managed: !!vcMeetingManagedSendOrigin,

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -116,6 +116,15 @@ export const messages: Record<string, string> = {
   'card.grant.result_expiry': 'Expires at: {time}',
   'card.grant.result_quota': 'Message quota: {n}',
 
+  // Owner-only card (publish to everyone on acceptance)
+  'card.owner_publish.only_you': '👁 Only visible to you',
+  'card.owner_publish.accept': 'Accept (make visible to everyone)',
+  'card.owner_publish.toast_stale': 'This card has expired',
+  'card.owner_publish.toast_owner_only': 'Only the sender can accept',
+  'card.owner_publish.toast_already': 'Already accepted, or the card has expired',
+  'card.owner_publish.toast_published': 'Now visible to everyone',
+  'card.owner_publish.toast_publish_failed': 'Publish failed, please retry',
+
   // Message quota exhausted
   'quota.exhausted_notify': '⚠️ {at} has used up their message quota ({limit}/{limit}); talk access has been revoked. Ask the owner to /grant again to continue.',
 

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -119,6 +119,15 @@ export const messages: Record<string, string> = {
   'card.grant.result_expiry': '有效至：{time}',
   'card.grant.result_quota': '消息额度：{n} 条',
 
+  // 仅发起人可见卡（采纳后转全群可见）
+  'card.owner_publish.only_you': '👁 仅对你可见',
+  'card.owner_publish.accept': '采纳（转为所有人可见）',
+  'card.owner_publish.toast_stale': '该卡片已失效',
+  'card.owner_publish.toast_owner_only': '仅发起人可采纳',
+  'card.owner_publish.toast_already': '已采纳过，或该卡片已失效',
+  'card.owner_publish.toast_published': '已转为所有人可见',
+  'card.owner_publish.toast_publish_failed': '发布失败，请稍后重试',
+
   // 消息额度用尽
   'quota.exhausted_notify': '⚠️ {at} 的消息额度已用尽（{limit}/{limit}），已收回与我的对话授权。如需继续，请联系 owner 重新 /grant。',
 

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -76,6 +76,11 @@ import {
   type V3DistillationCardHandlerDeps,
 } from './v3-distillation-card-handler.js';
 import { handleAskCardAction, isAskCardAction } from './ask-card.js';
+import {
+  handleOwnerPublishAction,
+  isOwnerPublishAction,
+  type OwnerPublishActionValue,
+} from './owner-publish-card.js';
 import { createCliAdapterSync } from '../../adapters/cli/registry.js';
 import { buildClosedSessionCard } from '../../core/closed-session-card.js';
 import { ttadkConfigModelChoices } from '../../setup/cli-selection.js';
@@ -915,6 +920,17 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
   // Use the receiving bot's allowedUsers — the operator open_id in card actions
   // is scoped to the app that received the callback.
   const operatorOpenId = data?.operator?.open_id;
+  // ─── 仅发起人可见卡「采纳（转为所有人可见）」动作 ────────────────────────────
+  // 不绑 session，必须在 session 解析前处理。owner 强闸门 + nonce 一次性核销；
+  // 采纳后删私密卡 + 向全群重发公开卡。cardMessageId 是私密卡 id，用于删除。
+  if (isOwnerPublishAction(value?.action) && larkAppId) {
+    return handleOwnerPublishAction(
+      value as OwnerPublishActionValue,
+      operatorOpenId,
+      cardMessageId,
+      larkAppId,
+    );
+  }
   // ─── 机器过载告警卡动作（overload_clean_stopped / overload_suspend_idle / noop）──
   // 不绑 session。owner 强闸门 + nonce 一次性核销（每按钮各一次，防重复点/超时重投/旧卡）。
   // 点完不替换成死卡：重建同一张卡，把点过的按钮标 done+数量并 disabled，另一个仍可点。

--- a/src/im/lark/owner-publish-card.ts
+++ b/src/im/lark/owner-publish-card.ts
@@ -1,0 +1,153 @@
+/**
+ * 「仅发起人可见 → 采纳后转全群可见」卡片 —— card-handler 的 owner-publish 分支。
+ *
+ * 由 `botmux send --owner-only` 发出：bot 用 `sendEphemeralCard` 发一张只有发起人
+ * 看得到的卡（顶部标「仅对你可见」），卡底带一个「采纳（转为所有人可见）」按钮。
+ * 发起人点击后，删掉这张私密卡，把同样的内容以全群可见的普通卡重发到群里。
+ *
+ * 约束：ephemeral 卡只在 flat 普通群（chat scope）生效，话题群 / 单聊会被飞书拒
+ * （18053），所以本功能只在普通群聊可用（见 client.ts 的 sendEphemeralCard 说明与
+ * command-handler.ts 里 relay picker 的同款注释）。
+ *
+ * 设计对齐 v3-gate-card-handler / ask-card：owner 强闸门 + nonce 一次性核销 +
+ * 点击回调里同步返回终态（这里是删私密卡 + 全群重发），不依赖异步 PATCH。
+ */
+import { logger } from '../../utils/logger.js';
+import { t, localeForBot, type Locale } from '../../i18n/index.js';
+import { getOwnerOpenId } from '../../bot-registry.js';
+import { sendMessage, deleteEphemeralCard } from './client.js';
+import { claimOwnerPublish, registerOwnerPublish } from './owner-publish-pending.js';
+
+/** 采纳（转为所有人可见）按钮动作。 */
+export const OWNER_PUBLISH_ACTION = 'owner_publish';
+
+export function isOwnerPublishAction(action: unknown): boolean {
+  return action === OWNER_PUBLISH_ACTION;
+}
+
+/**
+ * 把发起人提供的内容卡包成「仅发起人可见 + 采纳按钮」卡。
+ *
+ * `contentElements` 是要展示（也是采纳后原样发到群里）的卡片 elements；
+ * `nonce` 由调用方生成并登记到 owner-publish-pending。这里在内容之下追加一行
+ * 「仅对你可见」note 和采纳按钮。采纳后发到群里的卡见 buildOwnerPublishPublicCard。
+ */
+export function buildOwnerPublishEphemeralCard(
+  contentElements: Array<Record<string, unknown>>,
+  nonce: string,
+  locale?: Locale,
+): string {
+  const elements: Array<Record<string, unknown>> = [
+    ...contentElements,
+    { tag: 'hr' },
+    {
+      tag: 'note',
+      elements: [
+        { tag: 'plain_text', content: t('card.owner_publish.only_you', undefined, locale) },
+      ],
+    },
+    {
+      tag: 'action',
+      actions: [
+        {
+          tag: 'button',
+          text: { tag: 'plain_text', content: t('card.owner_publish.accept', undefined, locale) },
+          type: 'primary',
+          value: { action: OWNER_PUBLISH_ACTION, nonce },
+        },
+      ],
+    },
+  ];
+  return JSON.stringify({
+    config: { wide_screen_mode: true },
+    elements,
+  });
+}
+
+/** 采纳后发到全群的公开卡：原样内容，无采纳按钮、无「仅对你可见」标注。 */
+/** 采纳后发到全群的公开卡：原样内容，无采纳按钮、无「仅对你可见」标注。
+ *
+ * ⚠️ 安全契约：`contentElements` 必须来自已过 `findDisallowedCardCallback` 校验的
+ * 卡片（当前唯一调用方 cli.ts `--owner-only` 用 `normalizeInteractiveCardInput`
+ * 归一后的 customCard，或纯文本 markdown 元素）。这些 elements 会原样发到全群，
+ * 若含未校验的 callback button，`stampBotmuxCallbackMarkers` 会把它标成 botmux
+ * 自己的 callback。切勿新增绕过 normalize 直接塞 elements 的旁路。 */
+export function buildOwnerPublishPublicCard(
+  contentElements: Array<Record<string, unknown>>,
+): string {
+  return JSON.stringify({
+    config: { wide_screen_mode: true },
+    elements: contentElements,
+  });
+}
+
+export interface OwnerPublishActionValue {
+  action?: string;
+  nonce?: string;
+}
+
+export interface OwnerPublishCardHandlerDeps {
+  /** 向全群发公开卡。默认 = 真实 sendMessage。 */
+  sendMessage?: typeof sendMessage;
+  /** 删掉私密卡。默认 = 真实 deleteEphemeralCard。 */
+  deleteEphemeralCard?: typeof deleteEphemeralCard;
+}
+
+/**
+ * 处理「采纳（转为所有人可见）」点击。
+ *
+ * 流程：owner 强闸门 → nonce 一次性核销（拿到待发布 payload）→ 删私密卡 +
+ * 向全群发公开卡。返回 Lark 卡片回调响应（`{ toast }`）。
+ *
+ * `cardMessageId` 是被点击的私密卡的 message_id（来自 data.context.open_message_id），
+ * 用于删除该私密卡。
+ */
+export async function handleOwnerPublishAction(
+  value: OwnerPublishActionValue,
+  operatorOpenId: string | undefined,
+  cardMessageId: string | undefined,
+  larkAppId: string,
+  deps: OwnerPublishCardHandlerDeps = {},
+): Promise<{ toast: { type: string; content: string } }> {
+  const locale = localeForBot(larkAppId);
+  const send = deps.sendMessage ?? sendMessage;
+  const delEphemeral = deps.deleteEphemeralCard ?? deleteEphemeralCard;
+
+  const nonce = value.nonce;
+  if (!nonce) {
+    return { toast: { type: 'warning', content: t('card.owner_publish.toast_stale', undefined, locale) } };
+  }
+
+  // owner 强闸门：只有发起人本人能采纳。虽然私密卡本就只对 owner 可见，仍做服务端
+  // 校验（对齐 grant/overload 卡），不信任卡片来源。
+  const owner = getOwnerOpenId(larkAppId);
+  if (!operatorOpenId || operatorOpenId !== owner) {
+    logger.info(`owner_publish blocked for non-owner: ${operatorOpenId}`);
+    return { toast: { type: 'error', content: t('card.owner_publish.toast_owner_only', undefined, locale) } };
+  }
+
+  // nonce 一次性核销：拿到待发布 payload。重复点 / 旧卡 / 重启后 → null。
+  const entry = claimOwnerPublish(nonce);
+  if (!entry) {
+    return { toast: { type: 'info', content: t('card.owner_publish.toast_already', undefined, locale) } };
+  }
+
+  // 先发公开卡（correctness 优先）；成功后再删私密卡（best-effort，删失败只是残留一张
+  // 仅 owner 可见的私密卡，不影响正确性）。发失败则回滚 nonce 让 owner 可重试
+  // ——私密卡还在，按钮仍指向同一 nonce。
+  try {
+    await send(larkAppId, entry.chatId, entry.publishCardJson, 'interactive');
+  } catch (err) {
+    logger.warn(`owner_publish send-to-group failed: ${err instanceof Error ? err.message : String(err)}`);
+    registerOwnerPublish(nonce, {
+      ownerOpenId: entry.ownerOpenId,
+      chatId: entry.chatId,
+      publishCardJson: entry.publishCardJson,
+    });
+    return { toast: { type: 'error', content: t('card.owner_publish.toast_publish_failed', undefined, locale) } };
+  }
+  if (cardMessageId) {
+    await delEphemeral(larkAppId, cardMessageId).catch(() => { /* 残留私密卡只是观感问题 */ });
+  }
+  return { toast: { type: 'success', content: t('card.owner_publish.toast_published', undefined, locale) } };
+}

--- a/src/im/lark/owner-publish-pending.ts
+++ b/src/im/lark/owner-publish-pending.ts
@@ -1,0 +1,74 @@
+/**
+ * One-shot pending store for "仅发起人可见 → 采纳后转全群可见" cards. When the
+ * bot sends an owner-only (ephemeral) card via `botmux send --owner-only`, the
+ * card carries a fresh nonce in its 采纳 button `value`; the daemon that sent it
+ * remembers the payload here — the owner open_id, the target chat, and the final
+ * card JSON to publish to the whole group on acceptance.
+ *
+ * The publish payload lives here rather than on the button `value` because a
+ * card action `value` is a small `Record<string,string>` (size-limited by
+ * Feishu); a full card JSON wouldn't fit reliably.
+ *
+ * When the owner clicks 采纳, the handler validates the nonce is still live and
+ * the operator is the owner, then burns it — so a re-delivered callback, a
+ * double-tap, or a click on a stale card (from before a daemon restart) can't
+ * publish twice.
+ *
+ * Pure in-memory, per daemon process (the sending daemon is the one that
+ * validates, since it sent the card). Daemon restart clears it → old owner-only
+ * cards expire naturally, which is the desired behaviour (the ephemeral card is
+ * only visible to the owner anyway, so a stale one lingering is harmless).
+ */
+const NONCE_TTL_MS = 24 * 60 * 60_000; // 24h: an owner-only card older than this is stale.
+
+interface PendingPublish {
+  at: number;
+  /** Only this open_id may accept (转为所有人可见). */
+  ownerOpenId: string;
+  /** The group the ephemeral card was sent into; the published card goes here. */
+  chatId: string;
+  /** The final card JSON to send to the whole group on acceptance. */
+  publishCardJson: string;
+}
+
+const pending = new Map<string, PendingPublish>();
+let lastPrunedAt = 0;
+const PRUNE_INTERVAL_MS = 60_000;
+
+function prune(now: number): void {
+  if (now - lastPrunedAt < PRUNE_INTERVAL_MS) return;
+  lastPrunedAt = now;
+  for (const [k, e] of pending) {
+    if (now - e.at >= NONCE_TTL_MS) pending.delete(k);
+  }
+}
+
+/** Register a freshly-issued owner-only card (called when the card is sent). */
+export function registerOwnerPublish(
+  nonce: string,
+  entry: { ownerOpenId: string; chatId: string; publishCardJson: string },
+): void {
+  if (!nonce) return;
+  const now = Date.now();
+  prune(now);
+  pending.set(nonce, { at: now, ...entry });
+}
+
+/**
+ * Try to claim `nonce` for publishing. Returns the pending payload exactly once:
+ * the first successful claim burns the nonce, so a double-tap / re-delivered
+ * callback / stale card can't publish twice. Unknown or expired nonce → null.
+ */
+export function claimOwnerPublish(nonce: string): PendingPublish | null {
+  if (!nonce) return null;
+  const now = Date.now();
+  prune(now);
+  const e = pending.get(nonce);
+  if (!e) return null;
+  if (now - e.at >= NONCE_TTL_MS) { pending.delete(nonce); return null; }
+  pending.delete(nonce); // one-shot: burn on claim
+  return e;
+}
+
+export function _resetOwnerPublishForTest(): void { pending.clear(); lastPrunedAt = 0; }
+export function _ownerPublishCountForTest(): number { return pending.size; }

--- a/test/owner-publish-card.test.ts
+++ b/test/owner-publish-card.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/bot-registry.js', async () => {
+  const actual = await vi.importActual<typeof import('../src/bot-registry.js')>('../src/bot-registry.js');
+  return { ...actual, getOwnerOpenId: vi.fn(() => 'ou_owner') };
+});
+
+import {
+  OWNER_PUBLISH_ACTION,
+  buildOwnerPublishEphemeralCard,
+  buildOwnerPublishPublicCard,
+  handleOwnerPublishAction,
+} from '../src/im/lark/owner-publish-card.js';
+import {
+  _ownerPublishCountForTest,
+  _resetOwnerPublishForTest,
+  claimOwnerPublish,
+  registerOwnerPublish,
+} from '../src/im/lark/owner-publish-pending.js';
+
+const APP = 'cli_a';
+const CHAT = 'oc_group';
+const ELEMENTS = [{ tag: 'markdown', content: '答案：xxx' }];
+
+function register(nonce: string): void {
+  registerOwnerPublish(nonce, {
+    ownerOpenId: 'ou_owner',
+    chatId: CHAT,
+    publishCardJson: buildOwnerPublishPublicCard(ELEMENTS),
+  });
+}
+
+beforeEach(() => {
+  _resetOwnerPublishForTest();
+});
+
+describe('owner-publish card', () => {
+  it('ephemeral card carries the 采纳 button with action+nonce; public card has neither button nor 「仅对你可见」', () => {
+    const ephemeral = JSON.parse(buildOwnerPublishEphemeralCard(ELEMENTS, 'n1'));
+    const buttons = ephemeral.elements.flatMap((e: any) => e.actions ?? []);
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0].value).toEqual({ action: OWNER_PUBLISH_ACTION, nonce: 'n1' });
+
+    const pub = JSON.parse(buildOwnerPublishPublicCard(ELEMENTS));
+    expect(pub.elements.some((e: any) => e.actions)).toBe(false);
+    expect(JSON.stringify(pub)).not.toContain('仅对你可见');
+  });
+
+  it('non-owner click is blocked (never publishes, nonce stays live)', async () => {
+    register('n1');
+    const sendMessage = vi.fn(async () => 'om_pub');
+    const deleteEphemeralCard = vi.fn(async () => true);
+    const res = await handleOwnerPublishAction(
+      { action: OWNER_PUBLISH_ACTION, nonce: 'n1' },
+      'ou_intruder', 'om_eph', APP,
+      { sendMessage, deleteEphemeralCard },
+    );
+    expect(res.toast.type).toBe('error');
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(_ownerPublishCountForTest()).toBe(1); // still claimable
+  });
+
+  it('owner click publishes to the group then deletes the ephemeral card', async () => {
+    register('n1');
+    const sendMessage = vi.fn(async () => 'om_pub');
+    const deleteEphemeralCard = vi.fn(async () => true);
+    const res = await handleOwnerPublishAction(
+      { action: OWNER_PUBLISH_ACTION, nonce: 'n1' },
+      'ou_owner', 'om_eph', APP,
+      { sendMessage, deleteEphemeralCard },
+    );
+    expect(res.toast.type).toBe('success');
+    expect(sendMessage).toHaveBeenCalledWith(APP, CHAT, buildOwnerPublishPublicCard(ELEMENTS), 'interactive');
+    expect(deleteEphemeralCard).toHaveBeenCalledWith(APP, 'om_eph');
+    expect(_ownerPublishCountForTest()).toBe(0); // burned
+  });
+
+  it('double-tap does not publish twice (nonce is one-shot)', async () => {
+    register('n1');
+    const sendMessage = vi.fn(async () => 'om_pub');
+    const deleteEphemeralCard = vi.fn(async () => true);
+    const deps = { sendMessage, deleteEphemeralCard };
+    await handleOwnerPublishAction({ action: OWNER_PUBLISH_ACTION, nonce: 'n1' }, 'ou_owner', 'om_eph', APP, deps);
+    const second = await handleOwnerPublishAction({ action: OWNER_PUBLISH_ACTION, nonce: 'n1' }, 'ou_owner', 'om_eph', APP, deps);
+    expect(second.toast.type).toBe('info');
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('unknown / missing nonce → stale-ish toast, no publish', async () => {
+    const sendMessage = vi.fn(async () => 'om_pub');
+    const deleteEphemeralCard = vi.fn(async () => true);
+    const missing = await handleOwnerPublishAction({ action: OWNER_PUBLISH_ACTION }, 'ou_owner', 'om_eph', APP, { sendMessage, deleteEphemeralCard });
+    expect(missing.toast.type).toBe('warning');
+    const unknown = await handleOwnerPublishAction({ action: OWNER_PUBLISH_ACTION, nonce: 'nope' }, 'ou_owner', 'om_eph', APP, { sendMessage, deleteEphemeralCard });
+    expect(unknown.toast.type).toBe('info');
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('publish failure rolls back the nonce so the owner can retry; ephemeral card is kept', async () => {
+    register('n1');
+    const sendMessage = vi.fn(async () => { throw new Error('network'); });
+    const deleteEphemeralCard = vi.fn(async () => true);
+    const res = await handleOwnerPublishAction(
+      { action: OWNER_PUBLISH_ACTION, nonce: 'n1' },
+      'ou_owner', 'om_eph', APP,
+      { sendMessage, deleteEphemeralCard },
+    );
+    expect(res.toast.type).toBe('error');
+    expect(deleteEphemeralCard).not.toHaveBeenCalled(); // ephemeral stays so owner still sees it
+    expect(_ownerPublishCountForTest()).toBe(1); // rolled back → retryable
+  });
+
+  it('claimOwnerPublish returns the payload exactly once', () => {
+    register('n1');
+    expect(claimOwnerPublish('n1')?.chatId).toBe(CHAT);
+    expect(claimOwnerPublish('n1')).toBeNull();
+  });
+});


### PR DESCRIPTION
## 改了什么

新增 `botmux send --owner-only`：发一张只有发起人可见的 ephemeral 卡，卡底带「采纳（转为所有人可见）」按钮；发起人点击后删掉私密卡，把同样内容以全群可见的普通卡重发到群里。

| 文件 | 改动 |
|---|---|
| `im/lark/owner-publish-pending.ts`（新） | nonce → 待发布 payload 的一次性内存 store（仿 `overload-nonce`），daemon 重启自然过期 |
| `im/lark/owner-publish-card.ts`（新） | 仅可见卡 / 公开卡构建 + 采纳回调（owner 强闸门 + nonce 一次性核销 + 先发公开卡再删私密卡，发失败回滚 nonce 可重试） |
| `im/lark/card-handler.ts` | session 解析前挂上采纳按钮回调分支（仿 grant 卡） |
| `im/lark/client.ts` | 补 `deleteEphemeralCard`（ephemeral 不能 PATCH，替换靠 delete-then-resend） |
| `cli.ts` | `send --owner-only` 分支：话题群 / 单聊（飞书 18053）报错拒绝，只普通群聊可用；不与语音 / 附件 / mention / top-level / into 混用 |
| `i18n/zh.ts`、`i18n/en.ts` | 新增 `card.owner_publish.*` 文案 |

## 为什么

需要「机器人回复先仅对发起人可见、确认无误后再一键转全群公开」的能力。

## 影响面

- 只加新分支 / 新文件，不改既有卡片 / 会话 / CLI 行为。
- ephemeral 只在 flat 普通群（chat scope）可用；话题群 / 话题 / 单聊 **fail-closed 报错**（ephemeral API 无 thread anchor，话题群飞书返回 18053，且「普通群里的话题」会让卡逃逸到群顶层——所以限定 flat 普通群，和 `deliverEphemeralOrReply` / relay picker 的既有约束一致）。
- 采纳回调走 owner 强闸门 + nonce 一次性核销，重复点 / 旧卡 / daemon 重启后均不重复发布。

## 验证

- `pnpm exec tsc --noEmit` 干净、`pnpm build` 通过。
- 新增单测 7 个：非 owner 拦截 / nonce 一次性 / 采纳发公开卡+删私密卡 / 双击不重复发 / 发失败回滚可重试 / 未知 nonce / 卡片结构。跑 `owner-publish-card` + `ask-card` + `grant-gates` 共 **43 passed**。
- ⏳ 待补：飞书真机走一遍「发私密卡 → 点采纳 → 转全群」（需部署到 live daemon 手测），合并前补截图。

🤖 Generated with [Claude Code](https://claude.com/claude-code)