### PR TITLE
fix(pm2): 避免 Homebrew keg-only Node 被误判为 nvm 版本导致 daemon 无法启动

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,7 @@
  *   botmux whiteboard status|enable|disable|current|list|read|update|write — local project whiteboard
  */
 import { execSync, execFileSync, spawnSync, spawn } from 'node:child_process';
-import { existsSync, mkdirSync, copyFileSync, readFileSync, writeFileSync, renameSync, readdirSync, readlinkSync, appendFileSync, statSync, unlinkSync, rmSync, realpathSync } from 'node:fs';
+import { existsSync, mkdirSync, copyFileSync, readFileSync, writeFileSync, renameSync, readdirSync, readlinkSync, symlinkSync, appendFileSync, statSync, unlinkSync, rmSync, realpathSync } from 'node:fs';
 import { underReadIsolation, sendCredFilePath } from './adapters/cli/read-isolation.js';
 import { atomicWriteFileSync } from './utils/atomic-write.js';
 import { join, dirname, basename, resolve } from 'node:path';
@@ -497,6 +497,47 @@ async function cmdServe(args: string[]): Promise<void> {
   });
 }
 
+/**
+ * pm2-safe interpreter path.
+ *
+ * pm2 (>=6, lib/Common.js) treats ANY interpreter path containing the
+ * substring `node@` as an nvm version handle and tries to `nvm install` it —
+ * so a Homebrew keg-only Node (e.g.
+ * `/home/linuxbrew/.linuxbrew/Cellar/node@22/22.23.1/bin/node`) is misread as
+ * version `22/22.23.1/bin/node`, and every `botmux start/restart` dies with
+ * `Version '22/22.23.1/bin/node' not found`.
+ *
+ * We can't just point at a different existing binary: the keg-only formula's
+ * only paths (Cellar/, opt/, and — when it's not the default — bin/) all
+ * contain `node@`. So when process.execPath carries `node@`, we materialize a
+ * stable `@`-free symlink under ~/.botmux and hand pm2 THAT. The symlink still
+ * resolves to the exact Node that launched this CLI (same version → native
+ * modules like node-pty keep working), but its path no longer trips pm2's
+ * nvm heuristic. Non-Homebrew installs keep using process.execPath verbatim.
+ */
+function pm2SafeInterpreter(): string {
+  const exec = process.execPath;
+  if (!exec.includes('node@')) return exec;
+  const link = join(CONFIG_DIR, 'node-interpreter');
+  try {
+    mkdirSync(CONFIG_DIR, { recursive: true });
+    // Refresh the link if missing or pointing at a stale Node (e.g. after a
+    // Homebrew upgrade bumped the patch version under the same install).
+    let current: string | undefined;
+    try { current = readlinkSync(link); } catch { /* not a symlink / absent */ }
+    if (current !== exec) {
+      try { unlinkSync(link); } catch { /* absent */ }
+      symlinkSync(exec, link);
+    }
+    // Sanity: the link must still resolve to a real node. If anything is off,
+    // fall back to the raw path rather than handing pm2 a dangling symlink.
+    if (realpathSync(link) && !link.includes('node@')) return link;
+  } catch {
+    /* fall through to raw execPath */
+  }
+  return exec;
+}
+
 function ecosystemConfig(activationAppId?: string): string {
   const daemonScript = join(PKG_ROOT, 'dist', 'index-daemon.js');
   const bots = loadBotsJson();
@@ -506,12 +547,15 @@ function ecosystemConfig(activationAppId?: string): string {
     existsSync(ENV_FILE) ? readFileSync(ENV_FILE, 'utf-8') : undefined,
   );
 
+  // Node binary every managed process is pinned to (see pm2SafeInterpreter).
+  const interpreter = pm2SafeInterpreter();
+
   const baseApp = {
     script: daemonScript,
     // Pin every managed core process to the Node that invoked this CLI. This
     // keeps GUI/launchd starts independent from PATH and lets Desktop replace
     // an external fleet without also killing unrelated plugin services.
-    interpreter: process.execPath,
+    interpreter,
     cwd: CONFIG_DIR,
     autorestart: true,
     max_restarts: 10,
@@ -604,7 +648,7 @@ function ecosystemConfig(activationAppId?: string): string {
   apps.push({
     name: 'botmux-dashboard',
     script: join(PKG_ROOT, 'dist', 'dashboard.js'),
-    interpreter: process.execPath,
+    interpreter,
     cwd: PKG_ROOT,
     autorestart: true,
     max_restarts: 10,


### PR DESCRIPTION
pm2(>=6, lib/Common.js)会把任何包含子串 `node@` 的 interpreter 路径当作 nvm 版本句柄,尝试 `nvm install <后缀>`。当 botmux 装在 Homebrew keg-only Node 下时,process.execPath 形如 `/home/linuxbrew/.linuxbrew/Cellar/node@22/22.23.1/bin/node`,pm2 会把它误读成版本号 `22/22.23.1/bin/node`,于是每次 `botmux start`/`restart` 都失败:

    [PM2] Installing Node v22/22.23.1/bin/node
    Version '22/22.23.1/bin/node' not found

keg-only formula 没有不带 `@` 的可用路径可交给 pm2(Cellar/、opt/、以及非默认的 bin/ 软链都含 `node@`)。因此本 PR 不改指向别的二进制,而是在 ~/.botmux 下物化一条不带 `@` 的稳定软链(node-interpreter),它解析到的仍是启动本 CLI 的同一个 Node(版本一致 → node-pty 等原生模块照常),再把这条软链作为 pm2 interpreter 传入。execPath 变化时(如 Homebrew 补丁升级)软链会刷新,任何 fs 错误则回退到原始 execPath。非 Homebrew 安装不受影响 —— execPath 原样返回。

## 影响面
仅改 pm2 启动层(src/cli.ts 的 ecosystem 生成)。daemon 每个 bot app 与 dashboard 共用同一安全 interpreter,start/restart/start-bot 三条生成 ecosystem 的路径均覆盖;PTY/Tmux、普通/话题/adopt/restore 会话逻辑及各 CLI 适配器均未改动。Windows 普通路径走 no-op(不触发需权限的 symlink)。

## 验证
- 核对 pm2@6.0.14 源码:`Common.js:470` 的 `node@` 判定 + `resolveNodeInterpreter` 的 `split('@')[1]` 取版本,触发链属实。
- 隔离 HOME + 隔离 PM2_HOME 真启动:用硬链接构造真实 `execPath=.../Cellar/node@22/…/bin/node`,跑实际 pm2@6.0.14,dashboard 成功 online,ecosystem 与 PM2 jlist 里的 interpreter 都是无 `node@` 的 `~/.botmux/node-interpreter`,软链 realpath 回到同一 Node。
- 合并态(落后 master 71 commit,merge-tree 干净只改 `src/cli.ts` +47/-3)`pnpm build` 通过;`pnpm test` 13232 passed / 24 skipped(唯一失败为无关既有 flaky,单文件重跑通过)。