### PR TITLE
feat(lark): 允许已验证的 sibling bot 选择仓库

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -15846,7 +15846,7 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
       // which left a hole once per-chat grants flow through canTalk.
       // canRunDaemonCommand = canOperate ∪（cmd ∈ canTalkDaemonCommands && canTalk）：
       // bot 可通过名单把选定命令（如 /status）降到 canTalk；未配置时与 canOperate 全等。
-      if (!canRunDaemonCommand(larkAppId, chatId, senderOpenId, teamTrustUnionId, cmd, senderUnionId, chatType, isBotSenderType)) {
+      if (!canRunDaemonCommand(larkAppId, chatId, senderOpenId, teamTrustUnionId, cmd, senderUnionId, chatType, isBotSenderType, isBotSenderType)) {
         await sessionReply(anchor, tr('daemon.cmd_allowed_users_only', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
         return;
       }
@@ -16966,7 +16966,7 @@ async function handleThreadReply(
       // (see spawn-path gate above). Denies chat-granted users management commands.
       // canRunDaemonCommand：canTalkDaemonCommands 名单内的命令降到 canTalk，
       // 与 new-topic 路径的统一闸同款（未配置时与 canOperate 全等）。
-      if (!canRunDaemonCommand(larkAppId, effectiveThreadChatId, threadSenderOpenId, threadTeamTrustUnionId, cmd, threadSenderUnionId, ctxChatType, isBotSenderType || isForeignBot)) {
+      if (!canRunDaemonCommand(larkAppId, effectiveThreadChatId, threadSenderOpenId, threadTeamTrustUnionId, cmd, threadSenderUnionId, ctxChatType, isBotSenderType || isForeignBot, isBotSenderType)) {
         sessionReply(anchor, tr('daemon.cmd_allowed_users_only', { cmd }, localeForBot(larkAppId)), 'text', larkAppId);
         return;
       }

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -8,7 +8,7 @@ import { ProxyAgent } from 'proxy-agent';
 import { readFileSync, mkdirSync, existsSync } from 'node:fs';
 import { atomicWriteFileSync } from '../../utils/atomic-write.js';
 import { join } from 'node:path';
-import { getBot, getAllBots, findOncallChat, getOwnerOpenId, type BotState } from '../../bot-registry.js';
+import { getBot, getAllBots, findOncallChat, getOwnerOpenId, loadBotConfigs, type BotState } from '../../bot-registry.js';
 import { config, isVcMeetingAgentGloballyEnabled, vcMeetingAgentGlobalListenerBotAppId } from '../../config.js';
 import { getChatInfo, getChatMode, getCachedChatMode, getUserProfile, listChatMessagesUntil, resolveSiblingBotBySenderOpenId, replyMessage, sendMessage, sendUserMessage, isHumanOpenId, updateMessage } from './client.js';
 import { logger } from '../../utils/logger.js';
@@ -831,10 +831,10 @@ export function isKnownPeerBot(dataDir: string, larkAppId: string, senderOpenId:
 /**
  * Auth-grade local sibling check for the narrow `/repo` exception.
  *
- * Cross-ref proves only "this receiver has seen a bot name -> open_id" and may
- * be stale or name-poisoned. For authorization we additionally require the name
- * to bind to exactly one CURRENTLY configured sibling app, then match the Lark-
- * stamped sender union_id against that exact app's learned own union_id.
+ * Cross-ref proves only "this receiver has seen this sender open_id as some
+ * peer" and may be stale or name-poisoned. For authorization we additionally
+ * require the Lark-stamped sender union_id to match exactly one currently
+ * configured, transport-enabled sibling app's learned own union_id.
  */
 export function isVerifiedLocalSiblingBot(
   dataDir: string,
@@ -846,37 +846,20 @@ export function isVerifiedLocalSiblingBot(
   const unionId = (senderUnionId ?? '').trim();
   if (!openId || !unionId) return false;
 
-  const matchingNames = [...readBotOpenIdCrossRef(dataDir, larkAppId).entries()]
-    .filter(([, peerOpenId]) => peerOpenId === openId)
-    .map(([name]) => name.toLowerCase());
-  if (matchingNames.length === 0) return false;
+  if (!isKnownPeerBot(dataDir, larkAppId, openId)) return false;
 
-  const configuredSiblingAppIds = new Set(
-    getAllBots()
-      .map(b => b.config.larkAppId)
-      .filter(appId => appId && appId !== larkAppId),
-  );
-  if (configuredSiblingAppIds.size === 0) return false;
-
-  let candidateAppId: string | undefined;
+  let matchingConfiguredSiblings = 0;
   try {
-    const infoPath = join(dataDir, 'bots-info.json');
-    if (!existsSync(infoPath)) return false;
-    const entries: Array<{ larkAppId?: unknown; botName?: unknown }> = JSON.parse(readFileSync(infoPath, 'utf-8'));
-    if (!Array.isArray(entries)) return false;
-    for (const entry of entries) {
-      const appId = typeof entry?.larkAppId === 'string' ? entry.larkAppId.trim() : '';
-      const botName = typeof entry?.botName === 'string' ? entry.botName.trim().toLowerCase() : '';
-      if (!appId || !botName || !configuredSiblingAppIds.has(appId)) continue;
-      if (!matchingNames.includes(botName)) continue;
-      if (candidateAppId && candidateAppId !== appId) return false;
-      candidateAppId = appId;
+    for (const cfg of loadBotConfigs()) {
+      const appId = (cfg.larkAppId ?? '').trim();
+      if (!appId || appId === larkAppId || cfg.apiOnly === true) continue;
+      if (getBotUnionId(dataDir, appId) === unionId) matchingConfiguredSiblings += 1;
+      if (matchingConfiguredSiblings > 1) return false;
     }
   } catch {
     return false;
   }
-  if (!candidateAppId) return false;
-  return getBotUnionId(dataDir, candidateAppId) === unionId;
+  return matchingConfiguredSiblings === 1;
 }
 
 /**
@@ -1565,8 +1548,8 @@ export function canOperate(
  * 原样走 canTalk / evaluateTalk，语义不变。canOperate 那段人/bot 通用，不受影响。
  *
  * `/repo` 另有一个更窄的同部署 sibling bot 例外：仅当飞书事件把发送方盖章为 bot，
- * cross-ref 关联到当前仍配置的本机 sibling app，且 sender union_id 精确匹配该 app
- * 已学习的自身 union_id 时放行；不把 sibling 提升为 canOperate，也不把其他 daemon 命令降权。
+ * receiver cross-ref 命中 sender open_id，且 sender union_id 精确匹配当前仍配置的唯一
+ * 本机 sibling app 已学习的自身 union_id 时放行；不把 sibling 提升为 canOperate，也不把其他 daemon 命令降权。
  */
 export function canRunDaemonCommand(
   larkAppId: string,

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -1512,6 +1512,10 @@ export function canOperate(
  * union_id 的情况）；否则「团队拉群里外部 bot 能 talk 却执行不了降权到 canTalk 的命令
  * （如 /status）」——单一 talk 谓词在这道 daemon 命令闸继续分叉。不传（人的路径）→
  * 原样走 canTalk / evaluateTalk，语义不变。canOperate 那段人/bot 通用，不受影响。
+ *
+ * `/repo` 另有一个更窄的同部署 sibling bot 例外：仅当飞书事件把发送方盖章为 bot
+ * 且 cross-ref 命中 isKnownPeerBot 时放行，支持可信编排 bot 先用 `/repo` 绑定工作区；
+ * 不把 sibling 提升为 canOperate，也不把其他 daemon 命令降权。
  */
 export function canRunDaemonCommand(
   larkAppId: string,
@@ -1522,8 +1526,12 @@ export function canRunDaemonCommand(
   memberUnionId?: string | undefined,
   chatType?: 'p2p' | 'group',
   botSender?: boolean,
+  larkStampedBotSender?: boolean,
 ): boolean {
   if (canOperate(larkAppId, chatId, senderOpenId, senderUnionId)) return true;
+  if (cmd === '/repo' && larkStampedBotSender === true && isKnownPeerBot(config.session.dataDir, larkAppId, senderOpenId)) {
+    return true;
+  }
   const list = getBot(larkAppId).config.canTalkDaemonCommands;
   if (!list?.includes(cmd)) return false;
   return botSender

--- a/src/im/lark/event-dispatcher.ts
+++ b/src/im/lark/event-dispatcher.ts
@@ -21,7 +21,7 @@ import { recordObservedBots, listObservedBots } from '../../services/observed-bo
 import { isTeamBot, recordTeamBot } from '../../services/team-bots-store.js';
 import { isTeamGroupChat } from '../../services/team-groups-store.js';
 import { isPlatformTeamBot, isPlatformHallChat, isPlatformTeamMemberChat } from '../../services/platform-team-store.js';
-import { recordBotUnionId, recordBotUnionIdFromMentions } from '../../services/bot-union-ids-store.js';
+import { getBotUnionId, recordBotUnionId, recordBotUnionIdFromMentions } from '../../services/bot-union-ids-store.js';
 import { getDocSubscription, putDocSubscription, removeDocSubscription, listAllDocSubscriptions, type DocSubscription } from '../../services/doc-subs-store.js';
 import { getDocComment, isBotAuthoredReply, hasBotSentinel, commentTriggerAllowed, BOT_REPLY_SENTINEL } from './doc-comment.js';
 import {
@@ -829,6 +829,57 @@ export function isKnownPeerBot(dataDir: string, larkAppId: string, senderOpenId:
 }
 
 /**
+ * Auth-grade local sibling check for the narrow `/repo` exception.
+ *
+ * Cross-ref proves only "this receiver has seen a bot name -> open_id" and may
+ * be stale or name-poisoned. For authorization we additionally require the name
+ * to bind to exactly one CURRENTLY configured sibling app, then match the Lark-
+ * stamped sender union_id against that exact app's learned own union_id.
+ */
+export function isVerifiedLocalSiblingBot(
+  dataDir: string,
+  larkAppId: string,
+  senderOpenId: string | undefined,
+  senderUnionId: string | undefined,
+): boolean {
+  const openId = (senderOpenId ?? '').trim();
+  const unionId = (senderUnionId ?? '').trim();
+  if (!openId || !unionId) return false;
+
+  const matchingNames = [...readBotOpenIdCrossRef(dataDir, larkAppId).entries()]
+    .filter(([, peerOpenId]) => peerOpenId === openId)
+    .map(([name]) => name.toLowerCase());
+  if (matchingNames.length === 0) return false;
+
+  const configuredSiblingAppIds = new Set(
+    getAllBots()
+      .map(b => b.config.larkAppId)
+      .filter(appId => appId && appId !== larkAppId),
+  );
+  if (configuredSiblingAppIds.size === 0) return false;
+
+  let candidateAppId: string | undefined;
+  try {
+    const infoPath = join(dataDir, 'bots-info.json');
+    if (!existsSync(infoPath)) return false;
+    const entries: Array<{ larkAppId?: unknown; botName?: unknown }> = JSON.parse(readFileSync(infoPath, 'utf-8'));
+    if (!Array.isArray(entries)) return false;
+    for (const entry of entries) {
+      const appId = typeof entry?.larkAppId === 'string' ? entry.larkAppId.trim() : '';
+      const botName = typeof entry?.botName === 'string' ? entry.botName.trim().toLowerCase() : '';
+      if (!appId || !botName || !configuredSiblingAppIds.has(appId)) continue;
+      if (!matchingNames.includes(botName)) continue;
+      if (candidateAppId && candidateAppId !== appId) return false;
+      candidateAppId = appId;
+    }
+  } catch {
+    return false;
+  }
+  if (!candidateAppId) return false;
+  return getBotUnionId(dataDir, candidateAppId) === unionId;
+}
+
+/**
  * Should a FOREIGN bot sender be trusted to collaborate (route/spawn a session)
  * WITHOUT `/grant`, because it's a teammate? Two trust sources, both rooted in
  * tenant-stable identity or team-controlled group membership — never a name:
@@ -1513,9 +1564,9 @@ export function canOperate(
  * （如 /status）」——单一 talk 谓词在这道 daemon 命令闸继续分叉。不传（人的路径）→
  * 原样走 canTalk / evaluateTalk，语义不变。canOperate 那段人/bot 通用，不受影响。
  *
- * `/repo` 另有一个更窄的同部署 sibling bot 例外：仅当飞书事件把发送方盖章为 bot
- * 且 cross-ref 命中 isKnownPeerBot 时放行，支持可信编排 bot 先用 `/repo` 绑定工作区；
- * 不把 sibling 提升为 canOperate，也不把其他 daemon 命令降权。
+ * `/repo` 另有一个更窄的同部署 sibling bot 例外：仅当飞书事件把发送方盖章为 bot，
+ * cross-ref 关联到当前仍配置的本机 sibling app，且 sender union_id 精确匹配该 app
+ * 已学习的自身 union_id 时放行；不把 sibling 提升为 canOperate，也不把其他 daemon 命令降权。
  */
 export function canRunDaemonCommand(
   larkAppId: string,
@@ -1529,7 +1580,8 @@ export function canRunDaemonCommand(
   larkStampedBotSender?: boolean,
 ): boolean {
   if (canOperate(larkAppId, chatId, senderOpenId, senderUnionId)) return true;
-  if (cmd === '/repo' && larkStampedBotSender === true && isKnownPeerBot(config.session.dataDir, larkAppId, senderOpenId)) {
+  if (cmd === '/repo' && larkStampedBotSender === true
+    && isVerifiedLocalSiblingBot(config.session.dataDir, larkAppId, senderOpenId, senderUnionId)) {
     return true;
   }
   const list = getBot(larkAppId).config.canTalkDaemonCommands;

--- a/src/im/lark/message-parser.ts
+++ b/src/im/lark/message-parser.ts
@@ -875,12 +875,14 @@ export function extractCardContent(rawContent: string, numberer?: ImgNumberer): 
           }
           const textNodes: string[] = [];
           const buttons: string[] = [];
-          let hasFooterProof = false;
+          let inSignedFooter = false;
           for (const node of paragraph) {
+            if (inSignedFooter) continue;
             if (node.tag === 'text') { if (node.text) textNodes.push(node.text); }
             else if (node.tag === 'a') {
               if (isBotmuxFooterMarkerAnchor(node.href, node.text)) {
-                hasFooterProof = true;
+                inSignedFooter = true;
+                continue;
               }
               // Keep the href so links survive — Format A separates text/href,
               // and dropping href loses real content (规则配置/详情/Trace 链接).
@@ -924,7 +926,17 @@ export function extractCardContent(rawContent: string, numberer?: ImgNumberer): 
             }
           }
           const line = textNodes.join('').trim();
-          if (line && !hasFooterProof) parts.push(line);
+          if (line) {
+            if (inSignedFooter) {
+              const lastBreak = line.lastIndexOf('\n');
+              if (lastBreak >= 0) {
+                const beforeFooter = line.slice(0, lastBreak).trim();
+                if (beforeFooter) parts.push(beforeFooter);
+              }
+            } else {
+              parts.push(line);
+            }
+          }
           if (buttons.length) parts.push(buttons.join(' '));
         }
       } else {

--- a/src/im/lark/message-parser.ts
+++ b/src/im/lark/message-parser.ts
@@ -1246,14 +1246,15 @@ function extractElementText(el: any, parts: string[], imgLabel: (key: string) =>
   const tag = el.tag;
 
   // The public element id alone is not ownership proof: third-party cards may
-  // collide with it. New botmux footers carry all four invariants together.
+  // collide with it. New botmux footers carry the id plus the exact reserved
+  // marker; unexpected large text stays visible rather than being stripped.
   const elementText = el.text?.content ?? el.content;
   if (
     el.element_id === REPLY_CARD_FOOTER_ELEMENT_ID
     && tag === 'markdown'
-    && el.text_size === 'notation_small_v2'
+    && (el.text_size === undefined || el.text_size === 'notation_small_v2')
     && typeof elementText === 'string'
-    && isSignedFormatBFooterLine(elementText)
+    && hasExactMarkerMarkdown(elementText)
   ) {
     return;
   }

--- a/src/im/lark/message-parser.ts
+++ b/src/im/lark/message-parser.ts
@@ -933,6 +933,8 @@ export function extractCardContent(rawContent: string, numberer?: ImgNumberer): 
                 const beforeFooter = line.slice(0, lastBreak).trim();
                 if (beforeFooter) parts.push(beforeFooter);
               }
+              // No newline before the signed marker means the whole paragraph is
+              // footer chrome (brand/usage/recipient). Keep nothing.
             } else {
               parts.push(line);
             }

--- a/test/can-talk-daemon-commands.test.ts
+++ b/test/can-talk-daemon-commands.test.ts
@@ -27,6 +27,7 @@ vi.mock('node-pty', () => ({
 import { parseBotConfigsFromText, registerBot, getBot, __testOnly_resetBotRegistry } from '../src/bot-registry.js';
 import { canRunDaemonCommand, canOperate, canTalk } from '../src/im/lark/event-dispatcher.js';
 import { parseCanTalkDaemonCommandsInput } from '../src/core/passthrough-commands.js';
+import { recordBotUnionId } from '../src/services/bot-union-ids-store.js';
 import { config } from '../src/config.js';
 import { recordTeamBot } from '../src/services/team-bots-store.js';
 
@@ -140,7 +141,17 @@ describe('canRunDaemonCommand /repo trusted same-deployment peer exception', () 
     });
     bot.resolvedAllowedUsers = ['ou_owner'];
     bot.config.chatGrants = { oc_repo: ['ou_granted'] };
+    registerBot({
+      larkAppId: 'repo_sibling',
+      larkAppSecret: 's',
+      cliId: 'codex',
+    });
     writeFileSync(join(tmp, 'bot-openids-repo1.json'), JSON.stringify({ Codex: 'ou_sibling' }));
+    writeFileSync(join(tmp, 'bots-info.json'), JSON.stringify([
+      { larkAppId: 'repo1', botOpenId: 'ou_self', botName: 'Receiver', cliId: 'claude-code' },
+      { larkAppId: 'repo_sibling', botOpenId: 'ou_sibling_self', botName: 'Codex', cliId: 'codex' },
+    ]));
+    recordBotUnionId(tmp, 'repo_sibling', 'on_sibling');
   });
 
   afterEach(() => {
@@ -152,20 +163,54 @@ describe('canRunDaemonCommand /repo trusted same-deployment peer exception', () 
   it('allows a known Lark-stamped sibling bot to run /repo at the shared gate', () => {
     expect(canOperate('repo1', 'oc_repo', 'ou_sibling')).toBe(false);
 
-    expect(repoGate('ou_sibling', '/repo', true)).toBe(true);
+    expect(canRunDaemonCommand('repo1', 'oc_repo', 'ou_sibling', 'on_sibling', '/repo', undefined, 'group', true, true)).toBe(true);
   });
 
   it('does not give the sibling bot general daemon-command authority', () => {
     for (const cmd of ['/cd', '/restart', '/botconfig', '/term']) {
-      expect(repoGate('ou_sibling', cmd, true), cmd).toBe(false);
+      expect(canRunDaemonCommand('repo1', 'oc_repo', 'ou_sibling', 'on_sibling', cmd, undefined, 'group', true, true), cmd).toBe(false);
     }
   });
 
   it('requires the sender to be Lark-stamped as a bot', () => {
-    expect(repoGate('ou_sibling', '/repo', false)).toBe(false);
+    expect(canRunDaemonCommand('repo1', 'oc_repo', 'ou_sibling', 'on_sibling', '/repo', undefined, 'group', false, false)).toBe(false);
     expect(
-      canRunDaemonCommand('repo1', 'oc_repo', 'ou_sibling', undefined, '/repo', undefined, 'group', true, false),
+      canRunDaemonCommand('repo1', 'oc_repo', 'ou_sibling', 'on_sibling', '/repo', undefined, 'group', true, false),
     ).toBe(false);
+  });
+
+  it('requires the sender union_id to match the exact configured sibling app', () => {
+    expect(canRunDaemonCommand('repo1', 'oc_repo', 'ou_sibling', undefined, '/repo', undefined, 'group', true, true)).toBe(false);
+    expect(canRunDaemonCommand('repo1', 'oc_repo', 'ou_sibling', 'on_wrong', '/repo', undefined, 'group', true, true)).toBe(false);
+  });
+
+  it('rejects stale cross-ref and union records for an app that is no longer configured', () => {
+    __testOnly_resetBotRegistry();
+    const bot = registerBot({
+      larkAppId: 'repo1',
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: ['ou_owner'],
+    });
+    bot.resolvedAllowedUsers = ['ou_owner'];
+
+    expect(canRunDaemonCommand('repo1', 'oc_repo', 'ou_sibling', 'on_sibling', '/repo', undefined, 'group', true, true)).toBe(false);
+  });
+
+  it('rejects ambiguous configured sibling name bindings', () => {
+    registerBot({
+      larkAppId: 'repo_sibling_2',
+      larkAppSecret: 's',
+      cliId: 'codex',
+    });
+    recordBotUnionId(tmp, 'repo_sibling_2', 'on_sibling');
+    writeFileSync(join(tmp, 'bots-info.json'), JSON.stringify([
+      { larkAppId: 'repo1', botOpenId: 'ou_self', botName: 'Receiver', cliId: 'claude-code' },
+      { larkAppId: 'repo_sibling', botOpenId: 'ou_sibling_self', botName: 'Codex', cliId: 'codex' },
+      { larkAppId: 'repo_sibling_2', botOpenId: 'ou_sibling_2_self', botName: 'Codex', cliId: 'codex' },
+    ]));
+
+    expect(canRunDaemonCommand('repo1', 'oc_repo', 'ou_sibling', 'on_sibling', '/repo', undefined, 'group', true, true)).toBe(false);
   });
 
   it('keeps /repo denied for human owners only when they are not allowed users, chat grants, and unknown external bots', () => {

--- a/test/can-talk-daemon-commands.test.ts
+++ b/test/can-talk-daemon-commands.test.ts
@@ -123,9 +123,7 @@ describe('canRunDaemonCommand /repo trusted same-deployment peer exception', () 
   let prevDataDir: string;
   let tmp: string;
 
-  const newTopicRoute = (senderOpenId: string, cmd = '/repo', botSender = true) =>
-    canRunDaemonCommand('repo1', 'oc_repo', senderOpenId, undefined, cmd, undefined, 'group', botSender, botSender);
-  const threadReplyRoute = (senderOpenId: string, cmd = '/repo', botSender = true) =>
+  const repoGate = (senderOpenId: string, cmd = '/repo', botSender = true) =>
     canRunDaemonCommand('repo1', 'oc_repo', senderOpenId, undefined, cmd, undefined, 'group', botSender, botSender);
 
   beforeEach(() => {
@@ -151,38 +149,31 @@ describe('canRunDaemonCommand /repo trusted same-deployment peer exception', () 
     __testOnly_resetBotRegistry();
   });
 
-  it('allows a known sibling bot to run /repo through both daemon routes', () => {
+  it('allows a known Lark-stamped sibling bot to run /repo at the shared gate', () => {
     expect(canOperate('repo1', 'oc_repo', 'ou_sibling')).toBe(false);
 
-    expect(newTopicRoute('ou_sibling', '/repo', true)).toBe(true);
-    expect(threadReplyRoute('ou_sibling', '/repo', true)).toBe(true);
+    expect(repoGate('ou_sibling', '/repo', true)).toBe(true);
   });
 
   it('does not give the sibling bot general daemon-command authority', () => {
     for (const cmd of ['/cd', '/restart', '/botconfig', '/term']) {
-      expect(newTopicRoute('ou_sibling', cmd, true), `new-topic ${cmd}`).toBe(false);
-      expect(threadReplyRoute('ou_sibling', cmd, true), `thread-reply ${cmd}`).toBe(false);
+      expect(repoGate('ou_sibling', cmd, true), cmd).toBe(false);
     }
   });
 
   it('requires the sender to be Lark-stamped as a bot', () => {
-    expect(newTopicRoute('ou_sibling', '/repo', false)).toBe(false);
-    expect(threadReplyRoute('ou_sibling', '/repo', false)).toBe(false);
+    expect(repoGate('ou_sibling', '/repo', false)).toBe(false);
     expect(
       canRunDaemonCommand('repo1', 'oc_repo', 'ou_sibling', undefined, '/repo', undefined, 'group', true, false),
     ).toBe(false);
   });
 
   it('keeps /repo denied for human owners only when they are not allowed users, chat grants, and unknown external bots', () => {
-    expect(newTopicRoute('ou_owner', '/repo', false)).toBe(true);
-    expect(threadReplyRoute('ou_owner', '/repo', false)).toBe(true);
+    expect(repoGate('ou_owner', '/repo', false)).toBe(true);
 
-    expect(newTopicRoute('ou_human', '/repo', false)).toBe(false);
-    expect(threadReplyRoute('ou_human', '/repo', false)).toBe(false);
-    expect(newTopicRoute('ou_granted', '/repo', false)).toBe(false);
-    expect(threadReplyRoute('ou_granted', '/repo', false)).toBe(false);
-    expect(newTopicRoute('ou_external_bot', '/repo', true)).toBe(false);
-    expect(threadReplyRoute('ou_external_bot', '/repo', true)).toBe(false);
+    expect(repoGate('ou_human', '/repo', false)).toBe(false);
+    expect(repoGate('ou_granted', '/repo', false)).toBe(false);
+    expect(repoGate('ou_external_bot', '/repo', true)).toBe(false);
   });
 
   it('preserves existing cross-deployment team bot operate semantics', () => {

--- a/test/can-talk-daemon-commands.test.ts
+++ b/test/can-talk-daemon-commands.test.ts
@@ -4,17 +4,31 @@
  * - 闸：canRunDaemonCommand = canOperate ∪ (cmd ∈ 名单 && canTalk)
  * Run: pnpm vitest run test/can-talk-daemon-commands.test.ts
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 vi.mock('@larksuiteoapi/node-sdk', () => {
   class FakeClient { constructor(public opts: Record<string, unknown>) {} }
   return { Client: FakeClient };
 });
 
-import { vi } from 'vitest';
-import { parseBotConfigsFromText, registerBot, getBot } from '../src/bot-registry.js';
+vi.mock('node-pty', () => ({
+  spawn: vi.fn(() => ({
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+  })),
+}));
+
+import { parseBotConfigsFromText, registerBot, getBot, __testOnly_resetBotRegistry } from '../src/bot-registry.js';
 import { canRunDaemonCommand, canOperate, canTalk } from '../src/im/lark/event-dispatcher.js';
 import { parseCanTalkDaemonCommandsInput } from '../src/core/passthrough-commands.js';
+import { config } from '../src/config.js';
+import { recordTeamBot } from '../src/services/team-bots-store.js';
 
 describe('parseCanTalkDaemonCommandsInput (/botconfig input path)', () => {
   it('normalizes and keeps ONLY daemon commands (inverse of passthrough parser)', () => {
@@ -52,6 +66,7 @@ describe('canTalkDaemonCommands parsing', () => {
 
 describe('canRunDaemonCommand gate', () => {
   beforeEach(() => {
+    __testOnly_resetBotRegistry();
     const bot = registerBot({
       larkAppId: 'ct1', larkAppSecret: 's', cliId: 'claude-code',
       allowedUsers: ['ou_owner'],
@@ -96,10 +111,83 @@ describe('canRunDaemonCommand gate', () => {
   it('p2pOpen leg works only when chatType is passed (fail-closed without)', () => {
     const bot = getBot('ct1');
     bot.config.p2pOpen = true;
-    expect(canRunDaemonCommand('ct1', 'p2p_chat', 'ou_p2p_user', undefined, '/status', undefined, 'p2p')).toBe(true);
+    expect(canRunDaemonCommand('ct1', 'p2p_chat', 'ou_p2p_user', undefined, '/status', undefined, 'p2p', false, false)).toBe(true);
     // chatType 省略 → p2pOpen 腿 fail-closed，不放行
     expect(canRunDaemonCommand('ct1', 'p2p_chat', 'ou_p2p_user', undefined, '/status')).toBe(false);
     // p2p 里名单外的命令仍拒
     expect(canRunDaemonCommand('ct1', 'p2p_chat', 'ou_p2p_user', undefined, '/restart', undefined, 'p2p')).toBe(false);
+  });
+});
+
+describe('canRunDaemonCommand /repo trusted same-deployment peer exception', () => {
+  let prevDataDir: string;
+  let tmp: string;
+
+  const newTopicRoute = (senderOpenId: string, cmd = '/repo', botSender = true) =>
+    canRunDaemonCommand('repo1', 'oc_repo', senderOpenId, undefined, cmd, undefined, 'group', botSender, botSender);
+  const threadReplyRoute = (senderOpenId: string, cmd = '/repo', botSender = true) =>
+    canRunDaemonCommand('repo1', 'oc_repo', senderOpenId, undefined, cmd, undefined, 'group', botSender, botSender);
+
+  beforeEach(() => {
+    __testOnly_resetBotRegistry();
+    prevDataDir = config.session.dataDir;
+    tmp = mkdtempSync(join(tmpdir(), 'repo-peer-gate-'));
+    config.session.dataDir = tmp;
+
+    const bot = registerBot({
+      larkAppId: 'repo1',
+      larkAppSecret: 's',
+      cliId: 'claude-code',
+      allowedUsers: ['ou_owner'],
+    });
+    bot.resolvedAllowedUsers = ['ou_owner'];
+    bot.config.chatGrants = { oc_repo: ['ou_granted'] };
+    writeFileSync(join(tmp, 'bot-openids-repo1.json'), JSON.stringify({ Codex: 'ou_sibling' }));
+  });
+
+  afterEach(() => {
+    config.session.dataDir = prevDataDir;
+    rmSync(tmp, { recursive: true, force: true });
+    __testOnly_resetBotRegistry();
+  });
+
+  it('allows a known sibling bot to run /repo through both daemon routes', () => {
+    expect(canOperate('repo1', 'oc_repo', 'ou_sibling')).toBe(false);
+
+    expect(newTopicRoute('ou_sibling', '/repo', true)).toBe(true);
+    expect(threadReplyRoute('ou_sibling', '/repo', true)).toBe(true);
+  });
+
+  it('does not give the sibling bot general daemon-command authority', () => {
+    for (const cmd of ['/cd', '/restart', '/botconfig', '/term']) {
+      expect(newTopicRoute('ou_sibling', cmd, true), `new-topic ${cmd}`).toBe(false);
+      expect(threadReplyRoute('ou_sibling', cmd, true), `thread-reply ${cmd}`).toBe(false);
+    }
+  });
+
+  it('requires the sender to be Lark-stamped as a bot', () => {
+    expect(newTopicRoute('ou_sibling', '/repo', false)).toBe(false);
+    expect(threadReplyRoute('ou_sibling', '/repo', false)).toBe(false);
+    expect(
+      canRunDaemonCommand('repo1', 'oc_repo', 'ou_sibling', undefined, '/repo', undefined, 'group', true, false),
+    ).toBe(false);
+  });
+
+  it('keeps /repo denied for human owners only when they are not allowed users, chat grants, and unknown external bots', () => {
+    expect(newTopicRoute('ou_owner', '/repo', false)).toBe(true);
+    expect(threadReplyRoute('ou_owner', '/repo', false)).toBe(true);
+
+    expect(newTopicRoute('ou_human', '/repo', false)).toBe(false);
+    expect(threadReplyRoute('ou_human', '/repo', false)).toBe(false);
+    expect(newTopicRoute('ou_granted', '/repo', false)).toBe(false);
+    expect(threadReplyRoute('ou_granted', '/repo', false)).toBe(false);
+    expect(newTopicRoute('ou_external_bot', '/repo', true)).toBe(false);
+    expect(threadReplyRoute('ou_external_bot', '/repo', true)).toBe(false);
+  });
+
+  it('preserves existing cross-deployment team bot operate semantics', () => {
+    recordTeamBot(tmp, { unionId: 'on_team_bot', name: 'TeamBot' });
+    expect(canRunDaemonCommand('repo1', 'oc_elsewhere', 'ou_team_bot', 'on_team_bot', '/repo', undefined, 'group', true)).toBe(true);
+    expect(canRunDaemonCommand('repo1', 'oc_elsewhere', 'ou_team_bot', 'on_team_bot', '/restart', undefined, 'group', true)).toBe(true);
   });
 });

--- a/test/can-talk-daemon-commands.test.ts
+++ b/test/can-talk-daemon-commands.test.ts
@@ -122,7 +122,9 @@ describe('canRunDaemonCommand gate', () => {
 
 describe('canRunDaemonCommand /repo trusted same-deployment peer exception', () => {
   let prevDataDir: string;
+  let prevBotsConfig: string | undefined;
   let tmp: string;
+  let botsConfigPath: string;
 
   const repoGate = (senderOpenId: string, cmd = '/repo', botSender = true) =>
     canRunDaemonCommand('repo1', 'oc_repo', senderOpenId, undefined, cmd, undefined, 'group', botSender, botSender);
@@ -130,7 +132,9 @@ describe('canRunDaemonCommand /repo trusted same-deployment peer exception', () 
   beforeEach(() => {
     __testOnly_resetBotRegistry();
     prevDataDir = config.session.dataDir;
+    prevBotsConfig = process.env.BOTS_CONFIG;
     tmp = mkdtempSync(join(tmpdir(), 'repo-peer-gate-'));
+    botsConfigPath = join(tmp, 'bots.json');
     config.session.dataDir = tmp;
 
     const bot = registerBot({
@@ -141,11 +145,11 @@ describe('canRunDaemonCommand /repo trusted same-deployment peer exception', () 
     });
     bot.resolvedAllowedUsers = ['ou_owner'];
     bot.config.chatGrants = { oc_repo: ['ou_granted'] };
-    registerBot({
-      larkAppId: 'repo_sibling',
-      larkAppSecret: 's',
-      cliId: 'codex',
-    });
+    writeFileSync(botsConfigPath, JSON.stringify([
+      { larkAppId: 'repo1', larkAppSecret: 's', cliId: 'claude-code', allowedUsers: ['ou_owner'] },
+      { larkAppId: 'repo_sibling', larkAppSecret: 's', cliId: 'codex' },
+    ]));
+    process.env.BOTS_CONFIG = botsConfigPath;
     writeFileSync(join(tmp, 'bot-openids-repo1.json'), JSON.stringify({ Codex: 'ou_sibling' }));
     writeFileSync(join(tmp, 'bots-info.json'), JSON.stringify([
       { larkAppId: 'repo1', botOpenId: 'ou_self', botName: 'Receiver', cliId: 'claude-code' },
@@ -156,6 +160,8 @@ describe('canRunDaemonCommand /repo trusted same-deployment peer exception', () 
 
   afterEach(() => {
     config.session.dataDir = prevDataDir;
+    if (prevBotsConfig === undefined) delete process.env.BOTS_CONFIG;
+    else process.env.BOTS_CONFIG = prevBotsConfig;
     rmSync(tmp, { recursive: true, force: true });
     __testOnly_resetBotRegistry();
   });
@@ -185,32 +191,63 @@ describe('canRunDaemonCommand /repo trusted same-deployment peer exception', () 
   });
 
   it('rejects stale cross-ref and union records for an app that is no longer configured', () => {
-    __testOnly_resetBotRegistry();
-    const bot = registerBot({
-      larkAppId: 'repo1',
-      larkAppSecret: 's',
-      cliId: 'claude-code',
-      allowedUsers: ['ou_owner'],
-    });
-    bot.resolvedAllowedUsers = ['ou_owner'];
+    writeFileSync(botsConfigPath, JSON.stringify([
+      { larkAppId: 'repo1', larkAppSecret: 's', cliId: 'claude-code', allowedUsers: ['ou_owner'] },
+    ]));
 
     expect(canRunDaemonCommand('repo1', 'oc_repo', 'ou_sibling', 'on_sibling', '/repo', undefined, 'group', true, true)).toBe(false);
   });
 
-  it('rejects ambiguous configured sibling name bindings', () => {
+  it('rejects duplicate configured sibling union matches', () => {
     registerBot({
       larkAppId: 'repo_sibling_2',
       larkAppSecret: 's',
       cliId: 'codex',
     });
     recordBotUnionId(tmp, 'repo_sibling_2', 'on_sibling');
-    writeFileSync(join(tmp, 'bots-info.json'), JSON.stringify([
-      { larkAppId: 'repo1', botOpenId: 'ou_self', botName: 'Receiver', cliId: 'claude-code' },
-      { larkAppId: 'repo_sibling', botOpenId: 'ou_sibling_self', botName: 'Codex', cliId: 'codex' },
-      { larkAppId: 'repo_sibling_2', botOpenId: 'ou_sibling_2_self', botName: 'Codex', cliId: 'codex' },
+    writeFileSync(botsConfigPath, JSON.stringify([
+      { larkAppId: 'repo1', larkAppSecret: 's', cliId: 'claude-code', allowedUsers: ['ou_owner'] },
+      { larkAppId: 'repo_sibling', larkAppSecret: 's', cliId: 'codex' },
+      { larkAppId: 'repo_sibling_2', larkAppSecret: 's', cliId: 'codex' },
     ]));
 
     expect(canRunDaemonCommand('repo1', 'oc_repo', 'ou_sibling', 'on_sibling', '/repo', undefined, 'group', true, true)).toBe(false);
+  });
+
+  it('rejects apiOnly sibling config even when union and cross-ref match', () => {
+    writeFileSync(botsConfigPath, JSON.stringify([
+      { larkAppId: 'repo1', larkAppSecret: 's', cliId: 'claude-code', allowedUsers: ['ou_owner'] },
+      { larkAppId: 'repo_sibling', apiOnly: true, cliId: 'codex' },
+    ]));
+
+    expect(canRunDaemonCommand('repo1', 'oc_repo', 'ou_sibling', 'on_sibling', '/repo', undefined, 'group', true, true)).toBe(false);
+  });
+
+  it('rejects missing or corrupt current config', () => {
+    rmSync(botsConfigPath, { force: true });
+    expect(canRunDaemonCommand('repo1', 'oc_repo', 'ou_sibling', 'on_sibling', '/repo', undefined, 'group', true, true)).toBe(false);
+
+    writeFileSync(botsConfigPath, '{not json');
+    expect(canRunDaemonCommand('repo1', 'oc_repo', 'ou_sibling', 'on_sibling', '/repo', undefined, 'group', true, true)).toBe(false);
+  });
+
+  it('rejects a sibling that exists only in the current daemon registry but not in fresh config', () => {
+    registerBot({
+      larkAppId: 'registry_only_sibling',
+      larkAppSecret: 's',
+      cliId: 'codex',
+    });
+    recordBotUnionId(tmp, 'registry_only_sibling', 'on_registry_only');
+    writeFileSync(join(tmp, 'bot-openids-repo1.json'), JSON.stringify({ Codex: 'ou_registry_only' }));
+    writeFileSync(join(tmp, 'bots-info.json'), JSON.stringify([
+      { larkAppId: 'repo1', botOpenId: 'ou_self', botName: 'Receiver', cliId: 'claude-code' },
+      { larkAppId: 'registry_only_sibling', botOpenId: 'ou_registry_self', botName: 'Codex', cliId: 'codex' },
+    ]));
+    writeFileSync(botsConfigPath, JSON.stringify([
+      { larkAppId: 'repo1', larkAppSecret: 's', cliId: 'claude-code', allowedUsers: ['ou_owner'] },
+    ]));
+
+    expect(canRunDaemonCommand('repo1', 'oc_repo', 'ou_registry_only', 'on_registry_only', '/repo', undefined, 'group', true, true)).toBe(false);
   });
 
   it('keeps /repo denied for human owners only when they are not allowed users, chat grants, and unknown external bots', () => {

--- a/test/daemon-rename-route.test.ts
+++ b/test/daemon-rename-route.test.ts
@@ -187,6 +187,39 @@ function makePeerRepoEventDataWithSplitFooter(
   };
 }
 
+function makePeerRepoEventDataWithV2FooterElement(
+  messageId: string,
+  rootId?: string,
+): any {
+  return {
+    sender: { sender_id: { open_id: PEER, union_id: PEER_UNION }, sender_type: 'app' },
+    message: {
+      message_id: messageId,
+      root_id: rootId,
+      chat_id: CHAT,
+      message_type: 'interactive',
+      content: JSON.stringify({
+        schema: '2.0',
+        body: {
+          elements: [
+            { tag: 'markdown', content: '/repo /data00/home/chenjihong.daryl/botmux/.worktree/peer-bot-repo-permission' },
+            { tag: 'hr' },
+            {
+              element_id: 'botmux_reply_footer',
+              tag: 'markdown',
+              content: '[botmux](https://github.com/deepcoldy/botmux)'
+                + "<font color='grey'> </font>"
+                + '[·](https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1)'
+                + "<font color='grey'> 发送给：</font><at id=ou_owner></at>",
+            },
+          ],
+        },
+      }),
+      create_time: String(Date.now()),
+    },
+  };
+}
+
 function makeCtx(anchor: string, messageId: string): any {
   return {
     chatId: CHAT,
@@ -628,6 +661,26 @@ describe('/repo trusted sibling production routing', () => {
 
     await handleThreadReply(
       makePeerRepoEventDataWithSplitFooter(messageId, rootId),
+      makeCtx(rootId, messageId),
+    );
+
+    const ds = activeSessions.get(sessionKey(rootId, APP));
+    expect(repliedText()).not.toContain('仅 allowedUsers 可执行');
+    expect(mocks.createSession).toHaveBeenCalledTimes(1);
+    expect(ds).toBeTruthy();
+    expect(ds?.ownerOpenId).toBe(PEER);
+    expect(ds?.pendingRepo).toBe(false);
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+    expect(mocks.forkWorker.mock.calls[0]?.[0]).toBe(ds);
+    expect(mocks.forkWorker.mock.calls[0]?.[1]).toBe('');
+  });
+
+  it('thread reply: strips v2 footer element without text_size before /repo command routing', async () => {
+    const rootId = 'om_repo_root_v2_footer';
+    const messageId = 'om_repo_reply_v2_footer';
+
+    await handleThreadReply(
+      makePeerRepoEventDataWithV2FooterElement(messageId, rootId),
       makeCtx(rootId, messageId),
     );
 

--- a/test/daemon-rename-route.test.ts
+++ b/test/daemon-rename-route.test.ts
@@ -21,7 +21,9 @@
  *
  * Run:  pnpm vitest run test/daemon-rename-route.test.ts
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 const mocks = vi.hoisted(() => {
   // Isolate every sessionStore/config read-write under a per-process temp dir
@@ -29,11 +31,13 @@ const mocks = vi.hoisted(() => {
   // and make sure hook events run the local (no-op, nothing configured) path
   // instead of forwarding to a live daemon when the test itself runs inside a
   // botmux session shell.
-  process.env.SESSION_DATA_DIR = `${process.env.TMPDIR ?? '/tmp'}/botmux-rename-route-${process.pid}`;
+  const dataDir = `${process.env.TMPDIR ?? '/tmp'}/botmux-rename-route-${process.pid}`;
+  process.env.SESSION_DATA_DIR = dataDir;
   delete process.env.BOTMUX_SESSION_ID;
   delete process.env.BOTMUX_LARK_APP_ID;
   let seq = 0;
   return {
+    dataDir,
     replyMessage: vi.fn(async () => 'om_reply'),
     sendMessage: vi.fn(async () => 'om_top'),
     getChatMode: vi.fn(async () => 'group' as 'group' | 'topic' | 'p2p'),
@@ -61,6 +65,16 @@ vi.mock('@larksuiteoapi/node-sdk', () => {
   class FakeClient { constructor(public opts: Record<string, unknown>) {} }
   return { Client: FakeClient };
 });
+
+vi.mock('node-pty', () => ({
+  spawn: vi.fn(() => ({
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+  })),
+}));
 
 vi.mock('../src/im/lark/client.js', async () => {
   const actual = await vi.importActual<any>('../src/im/lark/client.js');
@@ -100,6 +114,7 @@ import type { DaemonSession } from '../src/core/types.js';
 const APP = 'rename_route_app';
 const CHAT = 'oc_rename_route_chat';
 const OWNER = 'ou_owner';
+const PEER = 'ou_peer_bot';
 const NOW = new Date().toISOString();
 
 function makeEventData(messageId: string, text: string, rootId?: string): any {
@@ -123,6 +138,12 @@ function makeMentionOnlyEventData(messageId: string, rootId?: string): any {
     name: 'TestBot',
     id: { open_id: 'ou_bot' },
   }];
+  return data;
+}
+
+function makePeerRepoEventData(messageId: string, senderType: 'app' | 'bot', rootId?: string): any {
+  const data = makeEventData(messageId, '/repo', rootId);
+  data.sender = { sender_id: { open_id: PEER }, sender_type: senderType };
   return data;
 }
 
@@ -224,22 +245,40 @@ function repliedText(): string {
     .join('\n');
 }
 
+function crossRefPath(): string {
+  return join(mocks.dataDir, `bot-openids-${APP}.json`);
+}
+
+function seedSiblingCrossRef(): void {
+  mkdirSync(mocks.dataDir, { recursive: true });
+  writeFileSync(crossRefPath(), JSON.stringify({ Codex: PEER }));
+}
+
+function resetRouteTestState(): void {
+  vi.clearAllMocks();
+  mocks.replyMessage.mockResolvedValue('om_reply');
+  mocks.sendMessage.mockResolvedValue('om_top');
+  mocks.getChatMode.mockResolvedValue('group');
+  mocks.getChatNameAndMode.mockResolvedValue({ name: null, mode: 'group' });
+  activeSessions.clear();
+  rmSync(crossRefPath(), { force: true });
+  const bot = registerBot({
+    larkAppId: APP,
+    larkAppSecret: 's',
+    cliId: 'claude-code',
+    allowedUsers: [OWNER],
+    oncallChats: [{ chatId: CHAT, workingDir: '/tmp' }],
+  });
+  bot.resolvedAllowedUsers = [OWNER];
+}
+
 describe('/rename production routing — must not pre-create a session (review P1)', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.replyMessage.mockResolvedValue('om_reply');
-    mocks.sendMessage.mockResolvedValue('om_top');
-    mocks.getChatMode.mockResolvedValue('group');
-    mocks.getChatNameAndMode.mockResolvedValue({ name: null, mode: 'group' });
-    activeSessions.clear();
-    const bot = registerBot({
-      larkAppId: APP,
-      larkAppSecret: 's',
-      cliId: 'claude-code',
-      allowedUsers: [OWNER],
-      oncallChats: [{ chatId: CHAT, workingDir: '/tmp' }],
-    });
-    bot.resolvedAllowedUsers = [OWNER];
+    resetRouteTestState();
+  });
+
+  afterEach(() => {
+    rmSync(crossRefPath(), { force: true });
   });
 
   it('new topic: `/rename Foo` replies no-active-session and creates NOTHING', async () => {
@@ -440,5 +479,54 @@ describe('/rename production routing — must not pre-create a session (review P
     expect(ds.pendingFollowUps).toHaveLength(2);
     expect(ds.session.quoteTargetId).toBe(strangerMessageId);
     expect(ds.session.lastCallerOpenId).toBe('ou_stranger');
+  });
+});
+
+describe('/repo trusted sibling production routing', () => {
+  beforeEach(() => {
+    resetRouteTestState();
+    seedSiblingCrossRef();
+  });
+
+  afterEach(() => {
+    rmSync(crossRefPath(), { force: true });
+  });
+
+  it.each(['app', 'bot'] as const)('new topic: sender_type=%s sibling /repo reaches repo launch path', async (senderType) => {
+    const messageId = `om_repo_new_${senderType}`;
+
+    await handleNewTopic(
+      makePeerRepoEventData(messageId, senderType),
+      makeCtx(messageId, messageId),
+    );
+
+    const ds = activeSessions.get(sessionKey(messageId, APP));
+    expect(repliedText()).not.toContain('仅 allowedUsers 可执行');
+    expect(mocks.createSession).toHaveBeenCalledTimes(1);
+    expect(ds).toBeTruthy();
+    expect(ds?.ownerOpenId).toBe(PEER);
+    expect(ds?.pendingRepo).toBe(false);
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+    expect(mocks.forkWorker.mock.calls[0]?.[0]).toBe(ds);
+  });
+
+  it.each(['app', 'bot'] as const)('thread reply: sender_type=%s sibling /repo reaches repo launch path', async (senderType) => {
+    const rootId = `om_repo_root_${senderType}`;
+    const messageId = `om_repo_reply_${senderType}`;
+
+    await handleThreadReply(
+      makePeerRepoEventData(messageId, senderType, rootId),
+      makeCtx(rootId, messageId),
+    );
+
+    const ds = activeSessions.get(sessionKey(rootId, APP));
+    expect(repliedText()).not.toContain('仅 allowedUsers 可执行');
+    expect(mocks.createSession).toHaveBeenCalledTimes(1);
+    expect(ds).toBeTruthy();
+    expect(ds?.ownerOpenId).toBe(PEER);
+    expect(ds?.session.creatorOpenId).toBe(PEER);
+    expect(ds?.pendingRepo).toBe(false);
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+    expect(mocks.forkWorker.mock.calls[0]?.[0]).toBe(ds);
   });
 });

--- a/test/daemon-rename-route.test.ts
+++ b/test/daemon-rename-route.test.ts
@@ -161,6 +161,32 @@ function makePeerRepoEventData(
   return data;
 }
 
+function makePeerRepoEventDataWithSplitFooter(
+  messageId: string,
+  rootId?: string,
+): any {
+  return {
+    sender: { sender_id: { open_id: PEER, union_id: PEER_UNION }, sender_type: 'app' },
+    message: {
+      message_id: messageId,
+      root_id: rootId,
+      chat_id: CHAT,
+      message_type: 'interactive',
+      content: JSON.stringify({
+        elements: [[
+          { tag: 'text', text: '/repo /data00/home/chenjihong.daryl/botmux/.worktree/peer-bot-repo-permission\n' },
+          { tag: 'a', text: 'botmux', href: 'https://github.com/deepcoldy/botmux' },
+          { tag: 'text', text: "<font color='grey'> </font>" },
+          { tag: 'a', text: '·', href: 'https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1' },
+          { tag: 'text', text: "<font color='grey'> 发送给：</font>" },
+          { tag: 'at', user_name: 'jihong traex' },
+        ]],
+      }),
+      create_time: String(Date.now()),
+    },
+  };
+}
+
 function makeCtx(anchor: string, messageId: string): any {
   return {
     chatId: CHAT,
@@ -594,6 +620,26 @@ describe('/repo trusted sibling production routing', () => {
     expect(ds?.pendingRepo).toBe(false);
     expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
     expect(mocks.forkWorker.mock.calls[0]?.[0]).toBe(ds);
+  });
+
+  it('thread reply: strips live split-font footer before /repo command routing', async () => {
+    const rootId = 'om_repo_root_split_footer';
+    const messageId = 'om_repo_reply_split_footer';
+
+    await handleThreadReply(
+      makePeerRepoEventDataWithSplitFooter(messageId, rootId),
+      makeCtx(rootId, messageId),
+    );
+
+    const ds = activeSessions.get(sessionKey(rootId, APP));
+    expect(repliedText()).not.toContain('仅 allowedUsers 可执行');
+    expect(mocks.createSession).toHaveBeenCalledTimes(1);
+    expect(ds).toBeTruthy();
+    expect(ds?.ownerOpenId).toBe(PEER);
+    expect(ds?.pendingRepo).toBe(false);
+    expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
+    expect(mocks.forkWorker.mock.calls[0]?.[0]).toBe(ds);
+    expect(mocks.forkWorker.mock.calls[0]?.[1]).toBe('');
   });
 
   it('thread reply: rejects stamped sibling /repo when sender union is missing or wrong', async () => {

--- a/test/daemon-rename-route.test.ts
+++ b/test/daemon-rename-route.test.ts
@@ -104,6 +104,7 @@ vi.mock('../src/core/worker-pool.js', async () => {
 
 import { registerBot } from '../src/bot-registry.js';
 import { sessionKey } from '../src/core/types.js';
+import { recordBotUnionId } from '../src/services/bot-union-ids-store.js';
 import {
   __testOnly_activeSessions as activeSessions,
   __testOnly_handleNewTopic as handleNewTopic,
@@ -115,6 +116,7 @@ const APP = 'rename_route_app';
 const CHAT = 'oc_rename_route_chat';
 const OWNER = 'ou_owner';
 const PEER = 'ou_peer_bot';
+const PEER_UNION = 'on_peer_bot';
 const NOW = new Date().toISOString();
 
 function makeEventData(messageId: string, text: string, rootId?: string): any {
@@ -141,9 +143,20 @@ function makeMentionOnlyEventData(messageId: string, rootId?: string): any {
   return data;
 }
 
-function makePeerRepoEventData(messageId: string, senderType: 'app' | 'bot', rootId?: string): any {
+function makePeerRepoEventData(
+  messageId: string,
+  senderType: 'app' | 'bot' | 'user',
+  rootId?: string,
+  senderUnionId: string | null = PEER_UNION,
+): any {
   const data = makeEventData(messageId, '/repo', rootId);
-  data.sender = { sender_id: { open_id: PEER }, sender_type: senderType };
+  data.sender = {
+    sender_id: {
+      open_id: PEER,
+      ...(typeof senderUnionId === 'string' ? { union_id: senderUnionId } : {}),
+    },
+    sender_type: senderType,
+  };
   return data;
 }
 
@@ -249,9 +262,30 @@ function crossRefPath(): string {
   return join(mocks.dataDir, `bot-openids-${APP}.json`);
 }
 
+function botsInfoPath(): string {
+  return join(mocks.dataDir, 'bots-info.json');
+}
+
+function botUnionIdsPath(): string {
+  return join(mocks.dataDir, 'bot-union-ids.json');
+}
+
 function seedSiblingCrossRef(): void {
   mkdirSync(mocks.dataDir, { recursive: true });
   writeFileSync(crossRefPath(), JSON.stringify({ Codex: PEER }));
+}
+
+function seedConfiguredSiblingIdentity(): void {
+  registerBot({
+    larkAppId: 'repo_sibling_route',
+    larkAppSecret: 's',
+    cliId: 'codex',
+  });
+  writeFileSync(botsInfoPath(), JSON.stringify([
+    { larkAppId: APP, botOpenId: 'ou_receiver_self', botName: 'Receiver', cliId: 'claude-code' },
+    { larkAppId: 'repo_sibling_route', botOpenId: 'ou_peer_self', botName: 'Codex', cliId: 'codex' },
+  ]));
+  recordBotUnionId(mocks.dataDir, 'repo_sibling_route', PEER_UNION);
 }
 
 function resetRouteTestState(): void {
@@ -262,6 +296,8 @@ function resetRouteTestState(): void {
   mocks.getChatNameAndMode.mockResolvedValue({ name: null, mode: 'group' });
   activeSessions.clear();
   rmSync(crossRefPath(), { force: true });
+  rmSync(botsInfoPath(), { force: true });
+  rmSync(botUnionIdsPath(), { force: true });
   const bot = registerBot({
     larkAppId: APP,
     larkAppSecret: 's',
@@ -486,10 +522,13 @@ describe('/repo trusted sibling production routing', () => {
   beforeEach(() => {
     resetRouteTestState();
     seedSiblingCrossRef();
+    seedConfiguredSiblingIdentity();
   });
 
   afterEach(() => {
     rmSync(crossRefPath(), { force: true });
+    rmSync(botsInfoPath(), { force: true });
+    rmSync(botUnionIdsPath(), { force: true });
   });
 
   it.each(['app', 'bot'] as const)('new topic: sender_type=%s sibling /repo reaches repo launch path', async (senderType) => {
@@ -510,6 +549,27 @@ describe('/repo trusted sibling production routing', () => {
     expect(mocks.forkWorker.mock.calls[0]?.[0]).toBe(ds);
   });
 
+  it('new topic: rejects stamped sibling /repo when sender union is missing or wrong', async () => {
+    await handleNewTopic(
+      makePeerRepoEventData('om_repo_new_missing_union', 'app', undefined, null),
+      makeCtx('om_repo_new_missing_union', 'om_repo_new_missing_union'),
+    );
+    expect(repliedText()).toContain('仅 allowedUsers 可执行');
+    expect(mocks.createSession).not.toHaveBeenCalled();
+    expect(mocks.forkWorker).not.toHaveBeenCalled();
+
+    resetRouteTestState();
+    seedSiblingCrossRef();
+    seedConfiguredSiblingIdentity();
+    await handleNewTopic(
+      makePeerRepoEventData('om_repo_new_wrong_union', 'bot', undefined, 'on_wrong_peer_bot'),
+      makeCtx('om_repo_new_wrong_union', 'om_repo_new_wrong_union'),
+    );
+    expect(repliedText()).toContain('仅 allowedUsers 可执行');
+    expect(mocks.createSession).not.toHaveBeenCalled();
+    expect(mocks.forkWorker).not.toHaveBeenCalled();
+  });
+
   it.each(['app', 'bot'] as const)('thread reply: sender_type=%s sibling /repo reaches repo launch path', async (senderType) => {
     const rootId = `om_repo_root_${senderType}`;
     const messageId = `om_repo_reply_${senderType}`;
@@ -528,5 +588,56 @@ describe('/repo trusted sibling production routing', () => {
     expect(ds?.pendingRepo).toBe(false);
     expect(mocks.forkWorker).toHaveBeenCalledTimes(1);
     expect(mocks.forkWorker.mock.calls[0]?.[0]).toBe(ds);
+  });
+
+  it('thread reply: rejects stamped sibling /repo when sender union is missing or wrong', async () => {
+    await handleThreadReply(
+      makePeerRepoEventData('om_repo_reply_missing_union', 'app', 'om_repo_root_missing_union', null),
+      makeCtx('om_repo_root_missing_union', 'om_repo_reply_missing_union'),
+    );
+    expect(repliedText()).toContain('仅 allowedUsers 可执行');
+    expect(mocks.createSession).not.toHaveBeenCalled();
+    expect(mocks.forkWorker).not.toHaveBeenCalled();
+
+    resetRouteTestState();
+    seedSiblingCrossRef();
+    seedConfiguredSiblingIdentity();
+    await handleThreadReply(
+      makePeerRepoEventData('om_repo_reply_wrong_union', 'bot', 'om_repo_root_wrong_union', 'on_wrong_peer_bot'),
+      makeCtx('om_repo_root_wrong_union', 'om_repo_reply_wrong_union'),
+    );
+    expect(repliedText()).toContain('仅 allowedUsers 可执行');
+    expect(mocks.createSession).not.toHaveBeenCalled();
+    expect(mocks.forkWorker).not.toHaveBeenCalled();
+  });
+
+  it('thread reply: rejects cross-ref-only /repo when sender is not Lark-stamped as a bot', async () => {
+    await handleThreadReply(
+      makePeerRepoEventData('om_repo_reply_user_stamp', 'user', 'om_repo_root_user_stamp'),
+      makeCtx('om_repo_root_user_stamp', 'om_repo_reply_user_stamp'),
+    );
+
+    expect(repliedText()).toContain('仅 allowedUsers 可执行');
+    expect(mocks.createSession).not.toHaveBeenCalled();
+    expect(mocks.forkWorker).not.toHaveBeenCalled();
+  });
+
+  it('thread reply: rejects stale sibling identity for an app no longer in the current config', async () => {
+    resetRouteTestState();
+    seedSiblingCrossRef();
+    writeFileSync(botsInfoPath(), JSON.stringify([
+      { larkAppId: APP, botOpenId: 'ou_receiver_self', botName: 'Receiver', cliId: 'claude-code' },
+      { larkAppId: 'removed_sibling_app', botOpenId: 'ou_peer_self', botName: 'Codex', cliId: 'codex' },
+    ]));
+    recordBotUnionId(mocks.dataDir, 'removed_sibling_app', PEER_UNION);
+
+    await handleThreadReply(
+      makePeerRepoEventData('om_repo_reply_removed_app', 'bot', 'om_repo_root_removed_app'),
+      makeCtx('om_repo_root_removed_app', 'om_repo_reply_removed_app'),
+    );
+
+    expect(repliedText()).toContain('仅 allowedUsers 可执行');
+    expect(mocks.createSession).not.toHaveBeenCalled();
+    expect(mocks.forkWorker).not.toHaveBeenCalled();
   });
 });

--- a/test/daemon-rename-route.test.ts
+++ b/test/daemon-rename-route.test.ts
@@ -33,6 +33,7 @@ const mocks = vi.hoisted(() => {
   // botmux session shell.
   const dataDir = `${process.env.TMPDIR ?? '/tmp'}/botmux-rename-route-${process.pid}`;
   process.env.SESSION_DATA_DIR = dataDir;
+  process.env.BOTS_CONFIG = `${dataDir}/bots.json`;
   delete process.env.BOTMUX_SESSION_ID;
   delete process.env.BOTMUX_LARK_APP_ID;
   let seq = 0;
@@ -266,6 +267,10 @@ function botsInfoPath(): string {
   return join(mocks.dataDir, 'bots-info.json');
 }
 
+function botsConfigPath(): string {
+  return join(mocks.dataDir, 'bots.json');
+}
+
 function botUnionIdsPath(): string {
   return join(mocks.dataDir, 'bot-union-ids.json');
 }
@@ -276,11 +281,10 @@ function seedSiblingCrossRef(): void {
 }
 
 function seedConfiguredSiblingIdentity(): void {
-  registerBot({
-    larkAppId: 'repo_sibling_route',
-    larkAppSecret: 's',
-    cliId: 'codex',
-  });
+  writeFileSync(botsConfigPath(), JSON.stringify([
+    { larkAppId: APP, larkAppSecret: 's', cliId: 'claude-code', allowedUsers: [OWNER] },
+    { larkAppId: 'repo_sibling_route', larkAppSecret: 's', cliId: 'codex' },
+  ]));
   writeFileSync(botsInfoPath(), JSON.stringify([
     { larkAppId: APP, botOpenId: 'ou_receiver_self', botName: 'Receiver', cliId: 'claude-code' },
     { larkAppId: 'repo_sibling_route', botOpenId: 'ou_peer_self', botName: 'Codex', cliId: 'codex' },
@@ -296,6 +300,7 @@ function resetRouteTestState(): void {
   mocks.getChatNameAndMode.mockResolvedValue({ name: null, mode: 'group' });
   activeSessions.clear();
   rmSync(crossRefPath(), { force: true });
+  rmSync(botsConfigPath(), { force: true });
   rmSync(botsInfoPath(), { force: true });
   rmSync(botUnionIdsPath(), { force: true });
   const bot = registerBot({
@@ -527,6 +532,7 @@ describe('/repo trusted sibling production routing', () => {
 
   afterEach(() => {
     rmSync(crossRefPath(), { force: true });
+    rmSync(botsConfigPath(), { force: true });
     rmSync(botsInfoPath(), { force: true });
     rmSync(botUnionIdsPath(), { force: true });
   });
@@ -625,6 +631,9 @@ describe('/repo trusted sibling production routing', () => {
   it('thread reply: rejects stale sibling identity for an app no longer in the current config', async () => {
     resetRouteTestState();
     seedSiblingCrossRef();
+    writeFileSync(botsConfigPath(), JSON.stringify([
+      { larkAppId: APP, larkAppSecret: 's', cliId: 'claude-code', allowedUsers: [OWNER] },
+    ]));
     writeFileSync(botsInfoPath(), JSON.stringify([
       { larkAppId: APP, botOpenId: 'ou_receiver_self', botName: 'Receiver', cliId: 'claude-code' },
       { larkAppId: 'removed_sibling_app', botOpenId: 'ou_peer_self', botName: 'Codex', cliId: 'codex' },
@@ -634,6 +643,29 @@ describe('/repo trusted sibling production routing', () => {
     await handleThreadReply(
       makePeerRepoEventData('om_repo_reply_removed_app', 'bot', 'om_repo_root_removed_app'),
       makeCtx('om_repo_root_removed_app', 'om_repo_reply_removed_app'),
+    );
+
+    expect(repliedText()).toContain('仅 allowedUsers 可执行');
+    expect(mocks.createSession).not.toHaveBeenCalled();
+    expect(mocks.forkWorker).not.toHaveBeenCalled();
+  });
+
+  it('thread reply: rejects registry-only sibling identity that is absent from current config', async () => {
+    resetRouteTestState();
+    seedSiblingCrossRef();
+    registerBot({ larkAppId: 'registry_only_route', larkAppSecret: 's', cliId: 'codex' });
+    writeFileSync(botsConfigPath(), JSON.stringify([
+      { larkAppId: APP, larkAppSecret: 's', cliId: 'claude-code', allowedUsers: [OWNER] },
+    ]));
+    writeFileSync(botsInfoPath(), JSON.stringify([
+      { larkAppId: APP, botOpenId: 'ou_receiver_self', botName: 'Receiver', cliId: 'claude-code' },
+      { larkAppId: 'registry_only_route', botOpenId: 'ou_peer_self', botName: 'Codex', cliId: 'codex' },
+    ]));
+    recordBotUnionId(mocks.dataDir, 'registry_only_route', PEER_UNION);
+
+    await handleThreadReply(
+      makePeerRepoEventData('om_repo_reply_registry_only', 'bot', 'om_repo_root_registry_only'),
+      makeCtx('om_repo_root_registry_only', 'om_repo_reply_registry_only'),
     );
 
     expect(repliedText()).toContain('仅 allowedUsers 可执行');

--- a/test/daemon-rename-route.test.ts
+++ b/test/daemon-rename-route.test.ts
@@ -22,7 +22,7 @@
  * Run:  pnpm vitest run test/daemon-rename-route.test.ts
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const mocks = vi.hoisted(() => {
@@ -119,6 +119,21 @@ const OWNER = 'ou_owner';
 const PEER = 'ou_peer_bot';
 const PEER_UNION = 'on_peer_bot';
 const NOW = new Date().toISOString();
+const repoFixtureDirs: string[] = [];
+
+function makeRepoFixtureDir(): string {
+  const root = join(mocks.dataDir, 'repo-fixtures');
+  mkdirSync(root, { recursive: true });
+  const dir = mkdtempSync(join(root, 'repo-'));
+  repoFixtureDirs.push(dir);
+  return dir;
+}
+
+function cleanupRepoFixtureDirs(): void {
+  for (const dir of repoFixtureDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
 
 function makeEventData(messageId: string, text: string, rootId?: string): any {
   return {
@@ -165,6 +180,7 @@ function makePeerRepoEventDataWithSplitFooter(
   messageId: string,
   rootId?: string,
 ): any {
+  const repoPath = makeRepoFixtureDir();
   return {
     sender: { sender_id: { open_id: PEER, union_id: PEER_UNION }, sender_type: 'app' },
     message: {
@@ -174,7 +190,7 @@ function makePeerRepoEventDataWithSplitFooter(
       message_type: 'interactive',
       content: JSON.stringify({
         elements: [[
-          { tag: 'text', text: '/repo /data00/home/chenjihong.daryl/botmux/.worktree/peer-bot-repo-permission\n' },
+          { tag: 'text', text: `/repo ${repoPath}\n` },
           { tag: 'a', text: 'botmux', href: 'https://github.com/deepcoldy/botmux' },
           { tag: 'text', text: "<font color='grey'> </font>" },
           { tag: 'a', text: '·', href: 'https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1' },
@@ -191,6 +207,7 @@ function makePeerRepoEventDataWithV2FooterElement(
   messageId: string,
   rootId?: string,
 ): any {
+  const repoPath = makeRepoFixtureDir();
   return {
     sender: { sender_id: { open_id: PEER, union_id: PEER_UNION }, sender_type: 'app' },
     message: {
@@ -202,7 +219,7 @@ function makePeerRepoEventDataWithV2FooterElement(
         schema: '2.0',
         body: {
           elements: [
-            { tag: 'markdown', content: '/repo /data00/home/chenjihong.daryl/botmux/.worktree/peer-bot-repo-permission' },
+            { tag: 'markdown', content: `/repo ${repoPath}` },
             { tag: 'hr' },
             {
               element_id: 'botmux_reply_footer',
@@ -590,6 +607,7 @@ describe('/repo trusted sibling production routing', () => {
   });
 
   afterEach(() => {
+    cleanupRepoFixtureDirs();
     rmSync(crossRefPath(), { force: true });
     rmSync(botsConfigPath(), { force: true });
     rmSync(botsInfoPath(), { force: true });

--- a/test/message-parser.test.ts
+++ b/test/message-parser.test.ts
@@ -726,6 +726,70 @@ describe('Interactive card parsing: botmux footer is stripped from prompt', () =
 // ─── Structural footer strip (brand-agnostic, for per-bot custom brands) ──
 
 describe('Interactive card parsing: footer stripped structurally (custom brand)', () => {
+  it('drops a schema 2.0 footer element without text_size when it carries the exact split-font marker', () => {
+    const card = {
+      schema: '2.0',
+      body: { elements: [
+        { tag: 'markdown', content: '/repo /data00/home/chenjihong.daryl/botmux/.worktree/peer-bot-repo-permission' },
+        { tag: 'hr' },
+        {
+          element_id: 'botmux_reply_footer',
+          tag: 'markdown',
+          content: '[botmux](https://github.com/deepcoldy/botmux)'
+            + "<font color='grey'> </font>"
+            + '[·](https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1)'
+            + "<font color='grey'> 发送给：</font><at id=ou_owner></at>",
+        },
+      ] },
+    };
+
+    const result = parseApiMessage(makeMsg('interactive', card));
+    expect(result.content).toBe('/repo /data00/home/chenjihong.daryl/botmux/.worktree/peer-bot-repo-permission');
+  });
+
+  it.each([
+    {
+      name: 'wrong marker text',
+      footer: {
+        element_id: 'botmux_reply_footer',
+        tag: 'markdown',
+        content: '[footer spec](https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1)',
+      },
+      expected: 'footer spec',
+    },
+    {
+      name: 'wrong marker URL',
+      footer: {
+        element_id: 'botmux_reply_footer',
+        tag: 'markdown',
+        content: '[·](https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1-guide)',
+      },
+      expected: 'reply-card-footer-v1-guide',
+    },
+    {
+      name: 'unexpected text_size',
+      footer: {
+        element_id: 'botmux_reply_footer',
+        tag: 'markdown',
+        text_size: 'normal_v2',
+        content: '[·](https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1)',
+      },
+      expected: 'reply-card-footer-v1',
+    },
+  ])('keeps a schema 2.0 element-id collision with $name', ({ footer, expected }) => {
+    const card = {
+      schema: '2.0',
+      body: { elements: [
+        { tag: 'markdown', content: '正文内容' },
+        footer,
+      ] },
+    };
+
+    const result = parseApiMessage(makeMsg('interactive', card));
+    expect(result.content).toContain('正文内容');
+    expect(result.content).toContain(expected);
+  });
+
   it('drops a footer carrying the complete Botmux structural signature', () => {
     const footer = buildReplyCardFooter({
       brand: 'Acme',

--- a/test/message-parser.test.ts
+++ b/test/message-parser.test.ts
@@ -618,6 +618,37 @@ describe('Interactive card parsing: botmux footer is stripped from prompt', () =
     expect(result.content).toContain('稍后对比');
   });
 
+  it('drops the live split-font signed footer appended after a command', () => {
+    const card = {
+      elements: [[
+        { tag: 'text', text: '/repo /data00/home/chenjihong.daryl/botmux/.worktree/peer-bot-repo-permission\n' },
+        { tag: 'a', text: 'botmux', href: 'https://github.com/deepcoldy/botmux' },
+        { tag: 'text', text: "<font color='grey'> </font>" },
+        { tag: 'a', text: '·', href: 'https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1' },
+        { tag: 'text', text: "<font color='grey'> 发送给：</font>" },
+        { tag: 'at', user_name: 'jihong traex' },
+      ]],
+    };
+    const result = parseApiMessage(makeMsg('interactive', card));
+    expect(result.content).toBe('/repo /data00/home/chenjihong.daryl/botmux/.worktree/peer-bot-repo-permission');
+  });
+
+  it('keeps ordinary links that mention botmux and the marker URL without footer structure', () => {
+    const card = {
+      elements: [[
+        { tag: 'text', text: '正文提到 ' },
+        { tag: 'a', text: 'botmux', href: 'https://github.com/deepcoldy/botmux' },
+        { tag: 'text', text: ' 以及 ' },
+        { tag: 'a', text: 'footer spec', href: 'https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1' },
+        { tag: 'text', text: '，但这不是签名页脚。' },
+      ]],
+    };
+    const result = parseApiMessage(makeMsg('interactive', card));
+    expect(result.content).toContain('botmux(https://github.com/deepcoldy/botmux)');
+    expect(result.content).toContain('footer spec(https://github.com/deepcoldy/bot%6Dux#reply-card-footer-v1)');
+    expect(result.content).toContain('不是签名页脚');
+  });
+
   it('keeps a usage-shaped final line when it belongs to the same body paragraph', () => {
     const card = {
       elements: [[


### PR DESCRIPTION
## 改了什么

- 允许同一 Botmux 配置中经过验证的 sibling bot 在新话题和线程回复里执行 `/repo <path>`，使委派机器人可以先选择目标仓库再启动会话
- 将 sibling 身份校验收紧为多源证据：飞书 `sender_type` 机器人盖章、接收方 cross-reference、fresh bots 配置中的 `union_id` 精确且唯一匹配；缺失、过期、重复、损坏或不一致时全部 fail closed
- 排除当前机器人自身和 `apiOnly` 配置；旧 registry 记录不能替代 fresh config
- 修复飞书回复卡片页脚污染命令正文：兼容 split-font 页脚和 schema 2.0 中缺少 `text_size` 的独立 footer element，并用保留 marker 的严格签名识别避免误删普通链接
- 增加权限 gate、真实 daemon handler 路由和 message parser 回归用例

## 为什么

多机器人委派时，sibling bot 需要在目标机器人上先执行 `/repo` 选择仓库，但原权限模型只允许 owner / `allowedUsers`，导致可信 peer 也无法完成仓库选择。另一方面，不能仅依赖显示名、缓存 registry 或消息里自带的 `union_id` 放权，否则真人或陈旧配置可能伪装成 peer。

真实飞书消息还会把 Botmux 回复卡片页脚带回 `user_card_content`；若页脚残留在 `/repo` 后面，整条消息会被当作普通 worker prompt，而不是 daemon 命令。因此本次同时补齐严格身份校验和页脚剥离，保证只有可信 sibling 的纯净 `/repo` 能进入仓库路由。

## 影响面

- 权限扩展仅限 `/repo`；`/cd` 及其他 owner-only daemon 命令语义不变
- 新话题与线程回复共用同一套 fail-closed 身份约束；cross-reference 认识但没有飞书 bot 盖章的发送方不能借此执行 `/repo`
- sibling 配置必须来自 fresh `bots.json`，且 `union_id` 只能唯一命中一个非自身、非 `apiOnly` bot
- footer 处理只跳过带精确 element ID、markdown tag、允许的 `text_size` 和保留 marker 的独立 element；marker 文本、URL 或 `text_size` 任一不符时保留原正文
- 未改变普通用户授权、session owner、worker prompt 或其他消息处理路径

## 验证

- `corepack pnpm test -- test/message-parser.test.ts`：129 条通过
- `corepack pnpm test -- test/daemon-rename-route.test.ts`：22 条通过
- `corepack pnpm test -- test/can-talk-daemon-commands.test.ts`：23 条通过
- `corepack pnpm exec tsc --noEmit`：通过
- `pnpm build`：通过（含 domain audit、dashboard bundle 和 dist audit）
- `git diff --check`：通过
- 真实飞书线程 smoke：可信 sibling `/repo` 成功创建目标仓库会话且没有 footer prompt 污染；同一 sibling `/cd /tmp` 被拒绝，cwd 未变化
- `pnpm test` 曾得到 12,520 passed / 27 failed / 6 skipped；27 个失败均为宿主环境问题（26 个来自旧 Git 不支持 `git init -b`，1 个来自 tmux wrapper shell）。最终 footer 增量未重新跑全量，因此本 PR 不宣称全量 suite green