### PR TITLE
fix(token-usage): 修复超长 Codex transcript 冷恢复用量丢失

### DIFF
--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -1,7 +1,6 @@
 /**
  * Session cost calculator — computes token usage from JSONL logs.
  */
-import { createHash } from 'node:crypto';
 import { closeSync, constants, existsSync, fstatSync, openSync, readFileSync, readSync, statSync, type Stats } from 'node:fs';
 import { logger } from '../utils/logger.js';
 import type { CliId } from '../adapters/cli/types.js';
@@ -224,20 +223,15 @@ type UsageKind = 'claude' | 'codex' | 'coco' | 'pi' | 'generic';
 
 interface UsageSourceRecord {
   offset: number;
-  byteLength: number;
-  sha256: string;
 }
 
 const CODEX_USAGE_SOURCE_RECORD_MAX_BYTES = 64 * 1024;
 
 function sourceRecordForLine(line: string, lineStart: number | undefined): UsageSourceRecord | null {
   if (lineStart === undefined || lineStart < 0) return null;
-  const raw = Buffer.from(line, 'utf8');
-  if (raw.length > CODEX_USAGE_SOURCE_RECORD_MAX_BYTES) return null;
+  if (Buffer.byteLength(line, 'utf8') > CODEX_USAGE_SOURCE_RECORD_MAX_BYTES) return null;
   return {
     offset: lineStart,
-    byteLength: raw.length,
-    sha256: createHash('sha256').update(raw).digest('hex'),
   };
 }
 
@@ -496,8 +490,9 @@ function finalizeTokenUsage(aggregate: TokenUsageAggregate): SessionTokenUsage |
 // Dashboard row composition calls into this on every /api/sessions render and
 // on worker status transitions. Transcripts can be tens of MB, so the reader
 // (a) short-circuits on unchanged stat, (b) reparses a changing file at most
-// once per throttle interval, and (c) for append-only JSONL folds only the
-// newly appended bytes instead of rereading the whole file.
+// once per throttle interval, (c) folds non-Codex append-only JSONL from the
+// durable frontier, and (d) for Codex changes replays the bounded tracked
+// source interval or falls back to a normal rebuild / oversized tail rebuild.
 
 type CachedUsageKind = UsageKind | 'aiden';
 
@@ -507,7 +502,6 @@ interface UsageFileCacheEntry {
   size: number;
   dev: number;
   ino: number;
-  frontierFingerprint: string | null;
   canReadIncrementally: boolean;
   /** Durable parse frontier: byte offset just past the last complete line.
    *  <= 0 ⇒ the next change forces a full reparse. */
@@ -532,7 +526,7 @@ export const MAX_USAGE_TRANSCRIPT_BYTES = 64 * 1024 * 1024;
  *  Keep this tight: it is a synchronous dashboard read path, and real 150MiB+
  *  rollouts have many token_count snapshots in the last 4MiB. */
 export const CODEX_USAGE_TRANSCRIPT_TAIL_BYTES = 4 * 1024 * 1024;
-export const USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES = 64;
+const CODEX_USAGE_REPLAY_BYTES = 4 * 1024 * 1024;
 
 /** Aiden checkpoint paths move as the session progresses (latest.json points
  *  at a new checkpoint id per turn), so positive hits expire quickly too. */
@@ -617,15 +611,6 @@ function ensureUsageFileCacheCapacity(key: string): void {
   }
 }
 
-function usageFileFingerprintFromFd(fd: number, st: Stats, offset: number): string | null {
-  if (offset <= 0) return null;
-  const len = Math.min(USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES, offset);
-  const start = offset - len;
-  const probe = readFdProbe(fd, start, len);
-  if (!probe || probe.length !== len) return null;
-  return `${st.dev}:${st.ino}:${start}:${probe.toString('base64')}`;
-}
-
 function canReuseUsageCache(
   cached: UsageFileCacheEntry,
   st: Stats,
@@ -635,78 +620,30 @@ function canReuseUsageCache(
   return cached.dev === st.dev && cached.ino === st.ino;
 }
 
-function mergeCodexIndependentMetrics(
-  next: TokenUsageAggregate,
-  previous?: TokenUsageAggregate,
-  sourceValid?: {
-    latestCodexUsage: boolean;
-    latestContextUsage: boolean;
-    model: boolean;
-  },
-): TokenUsageAggregate {
-  if (!previous) return next;
-  const inheritModel = !next.model && !!previous.model && !!sourceValid?.model;
-  const inheritCodexUsage = !next.latestCodexUsage && !!previous.latestCodexUsage && !!sourceValid?.latestCodexUsage;
-  const inheritContextUsage = !next.latestContextUsage && !!previous.latestContextUsage && !!sourceValid?.latestContextUsage;
-  return {
-    ...next,
-    model: next.model || (inheritModel ? previous.model : ''),
-    modelSource: next.model ? next.modelSource : (inheritModel ? previous.modelSource : null),
-    latestCodexUsage: next.latestCodexUsage ?? (inheritCodexUsage ? previous.latestCodexUsage : null),
-    latestCodexUsageSource: next.latestCodexUsage ? next.latestCodexUsageSource : (inheritCodexUsage ? previous.latestCodexUsageSource : null),
-    latestContextUsage: next.latestContextUsage ?? (inheritContextUsage ? previous.latestContextUsage : null),
-    latestContextUsageSource: next.latestContextUsage ? next.latestContextUsageSource : (inheritContextUsage ? previous.latestContextUsageSource : null),
-  };
-}
-
-function sourceRecordKey(source: UsageSourceRecord): string {
-  return `${source.offset}:${source.byteLength}:${source.sha256}`;
-}
-
-function validateSourceRecord(fd: number, source: UsageSourceRecord | null | undefined, cache: Map<string, boolean>): boolean {
-  if (!source) return false;
-  if (source.byteLength <= 0 || source.byteLength > CODEX_USAGE_SOURCE_RECORD_MAX_BYTES) return false;
-  const key = sourceRecordKey(source);
-  const cached = cache.get(key);
-  if (cached !== undefined) return cached;
-  const raw = readFdProbe(fd, source.offset, source.byteLength);
-  let valid = raw !== null && raw.length === source.byteLength;
-  if (valid && raw) valid = createHash('sha256').update(raw).digest('hex') === source.sha256;
-  if (valid) {
-    const terminator = readFdProbe(fd, source.offset + source.byteLength, 1);
-    valid = !!terminator && terminator.length === 1 && terminator[0] === 0x0a;
-  }
-  cache.set(key, valid);
-  return valid;
-}
-
-function validateCodexSourceRecords(
-  fd: number,
-  previous?: TokenUsageAggregate,
-): { latestCodexUsage: boolean; latestContextUsage: boolean; model: boolean } {
-  const cache = new Map<string, boolean>();
-  return {
-    latestCodexUsage: validateSourceRecord(fd, previous?.latestCodexUsageSource, cache),
-    latestContextUsage: validateSourceRecord(fd, previous?.latestContextUsageSource, cache),
-    model: validateSourceRecord(fd, previous?.modelSource, cache),
-  };
-}
-
-function canReuseCodexAggregate(
+function earliestCodexReplaySourceOffset(
   previous: TokenUsageAggregate | undefined,
-  sourceValid: { latestCodexUsage: boolean; latestContextUsage: boolean; model: boolean } | undefined,
-): boolean {
-  if (!previous || !sourceValid) return false;
-  if (previous.latestCodexUsage && !sourceValid.latestCodexUsage) return false;
-  if (previous.latestContextUsage && !sourceValid.latestContextUsage) return false;
-  if (previous.model && !sourceValid.model) return false;
-  return true;
+): number | null {
+  if (!previous) return null;
+  const offsets: number[] = [];
+  if (previous.latestCodexUsage) {
+    if (!previous.latestCodexUsageSource) return null;
+    offsets.push(previous.latestCodexUsageSource.offset);
+  }
+  if (previous.latestContextUsage) {
+    if (!previous.latestContextUsageSource) return null;
+    offsets.push(previous.latestContextUsageSource.offset);
+  }
+  if (previous.model) {
+    if (!previous.modelSource) return null;
+    offsets.push(previous.modelSource.offset);
+  }
+  return offsets.length > 0 ? Math.min(...offsets) : null;
 }
 
 function cacheUsageRead(
   key: string,
   st: Stats,
-  entry: Omit<UsageFileCacheEntry, 'mtimeMs' | 'ctimeMs' | 'size' | 'dev' | 'ino' | 'frontierFingerprint'>,
+  entry: Omit<UsageFileCacheEntry, 'mtimeMs' | 'ctimeMs' | 'size' | 'dev' | 'ino'>,
 ): void {
   ensureUsageFileCacheCapacity(key);
   usageFileCache.set(key, {
@@ -716,25 +653,6 @@ function cacheUsageRead(
     size: st.size,
     dev: st.dev,
     ino: st.ino,
-    frontierFingerprint: null,
-  });
-}
-
-function cacheUsageReadWithFrontierFingerprint(
-  key: string,
-  st: Stats,
-  entry: Omit<UsageFileCacheEntry, 'mtimeMs' | 'ctimeMs' | 'size' | 'dev' | 'ino' | 'frontierFingerprint'>,
-  frontierFingerprint: string | null,
-): void {
-  ensureUsageFileCacheCapacity(key);
-  usageFileCache.set(key, {
-    ...entry,
-    mtimeMs: st.mtimeMs,
-    ctimeMs: st.ctimeMs,
-    size: st.size,
-    dev: st.dev,
-    ino: st.ino,
-    frontierFingerprint,
   });
 }
 
@@ -775,32 +693,33 @@ function readCodexTokenAggregateCached(
   let baseOffset: number;
   let dropInitialResidualLine = false;
   const previousAgg = cached?.previewAgg ? cloneAggregate(cached.previewAgg) : undefined;
-  // The frontier fingerprint only proves the durable cursor still points at
-  // the same byte frontier. Cached Codex metrics are inherited only after each
-  // metric's own source JSONL record passes validation below.
-  const cursorContinuityValid = !!cached
+  const sameOpenFileAsCache = !!cached
     && cached.dev === fdStat.dev
-    && cached.ino === fdStat.ino
-    && cached.frontierFingerprint !== null
-    && usageFileFingerprintFromFd(fd, fdStat, cached.offset) === cached.frontierFingerprint;
-  const canInheritCachedMetrics = cursorContinuityValid
-    ? validateCodexSourceRecords(fd, previousAgg)
-    : undefined;
-  const canReuseCachedAggregate = canReuseCodexAggregate(previousAgg, canInheritCachedMetrics);
-  const canReuseCachedOffset = !!cached
-    && cursorContinuityValid
-    && canReuseCachedAggregate
+    && cached.ino === fdStat.ino;
+  const canConsiderReplay = !!cached
+    && sameOpenFileAsCache
     && cached.canReadIncrementally
     && cached.offset > 0
     && fdStat.size >= cached.offset;
-  const reuseCachedOffset = canReuseCachedOffset
-    && fdStat.size - cached.offset <= CODEX_USAGE_TRANSCRIPT_TAIL_BYTES;
   const oversized = fdStat.size > MAX_USAGE_TRANSCRIPT_BYTES;
+  const candidateReplayBaseOffset = canConsiderReplay
+    ? earliestCodexReplaySourceOffset(previousAgg)
+    : null;
+  const candidateReplaySpan = candidateReplayBaseOffset === null
+    ? Number.POSITIVE_INFINITY
+    : fdStat.size - candidateReplayBaseOffset;
+  const replayBaseOffset = candidateReplaySpan <= CODEX_USAGE_REPLAY_BYTES
+    && candidateReplayBaseOffset !== null
+    && isJsonlLineBoundaryFd(fd, candidateReplayBaseOffset)
+    ? candidateReplayBaseOffset
+    : null;
+  const replaySpan = replayBaseOffset === null ? Number.POSITIVE_INFINITY : fdStat.size - replayBaseOffset;
+  const reuseTrackedReplay = replayBaseOffset !== null && replaySpan <= CODEX_USAGE_REPLAY_BYTES;
 
-  if (reuseCachedOffset) {
-    state = cloneAggregate(cached.state);
-    seenMessageIds = new Set(cached.seenMessageIds);
-    baseOffset = cached.offset;
+  if (reuseTrackedReplay) {
+    state = newTokenUsageAggregate();
+    seenMessageIds = new Set();
+    baseOffset = replayBaseOffset;
   } else {
     state = newTokenUsageAggregate();
     seenMessageIds = new Set();
@@ -839,7 +758,6 @@ function readCodexTokenAggregateCached(
   }
 
   const nextOffset = pendingTailIsInitialResidualLine ? baseOffset : baseOffset + completeBytes;
-  const nextFingerprint = usageFileFingerprintFromFd(fd, fdStat, nextOffset);
   let endStat: Stats;
   try {
     endStat = fstatSync(fd);
@@ -891,34 +809,32 @@ function readCodexTokenAggregateCached(
     // has arrived yet. Cache safe stat/throttle metadata only; the stored
     // offset is not a reusable durable cursor, so any later change reboots from
     // a bounded tail instead of turning that suffix into a fake complete line.
-    const merged = mergeCodexIndependentMetrics(previewAgg, previousAgg, canInheritCachedMetrics);
-    const mergedResult = finalizeTokenUsage(merged);
-    cacheUsageReadWithFrontierFingerprint(key, fdStat, {
+    const result = finalizeTokenUsage(previewAgg);
+    cacheUsageRead(key, fdStat, {
       offset: nextOffset,
       state,
       seenMessageIds,
-      previewAgg: merged,
-      result: mergedResult,
+      previewAgg,
+      result,
       parsedAtMs: now,
       canReadIncrementally: false,
-    }, nextFingerprint);
+    });
     closeSync(fd);
-    return { agg: merged, result: mergedResult };
+    return { agg: previewAgg, result };
   }
-  const merged = mergeCodexIndependentMetrics(previewAgg, previousAgg, canInheritCachedMetrics);
-  const mergedResult = finalizeTokenUsage(merged);
-  const canReadIncrementally = reuseCachedOffset || aggregateHasCodexUsage(previewAgg);
-  cacheUsageReadWithFrontierFingerprint(key, fdStat, {
+  const result = finalizeTokenUsage(previewAgg);
+  const canReadIncrementally = aggregateHasCodexUsage(previewAgg);
+  cacheUsageRead(key, fdStat, {
     offset: nextOffset,
     state,
     seenMessageIds,
-    previewAgg: merged,
-    result: mergedResult,
+    previewAgg,
+    result,
     parsedAtMs: now,
     canReadIncrementally,
-  }, nextFingerprint);
+  });
   closeSync(fd);
-  return { agg: merged, result: mergedResult };
+  return { agg: previewAgg, result };
 }
 
 function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, opts?: { fresh?: boolean }): UsageReadResult | null {

--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -527,14 +527,13 @@ export const MAX_USAGE_TRANSCRIPT_BYTES = 64 * 1024 * 1024;
  *  snapshot in the last 4MiB, so this window is the common-case fast path. */
 export const CODEX_USAGE_TRANSCRIPT_TAIL_BYTES = 4 * 1024 * 1024;
 const CODEX_USAGE_REPLAY_BYTES = 4 * 1024 * 1024;
-/** When a single huge turn (e.g. one giant tool output) pushes the latest
- *  token_count snapshot out of the first tail window, widen the window one
- *  step at a time and re-scan until both the cumulative and context metrics
- *  are recovered. This keeps the card showing the TRUE latest usage instead of
- *  collapsing to null. Bounded so the synchronous dashboard read never walks an
- *  unbounded prefix: past this budget we stop widening and fail closed (yield
- *  whatever the bounded window found, without inheriting a possibly-stale value
- *  across an unverifiable generation boundary). */
+/** When the last tail window is missing a metric (a single huge turn can push
+ *  the newest token_count snapshot — or the model line — out of it), do ONE
+ *  bounded widen to this size and re-scan that whole window. It is the width of
+ *  the single widened pass, NOT a cumulative ladder: the worst-case synchronous
+ *  dashboard read is `tail + this`, and past it we fail closed (yield whatever
+ *  the widened window found, never inheriting a possibly-stale value across an
+ *  unverifiable generation boundary). */
 export const CODEX_USAGE_MAX_BACKSCAN_BYTES = 32 * 1024 * 1024;
 
 /** Aiden checkpoint paths move as the session progresses (latest.json points
@@ -608,9 +607,12 @@ function aggregateHasCodexUsage(agg: TokenUsageAggregate): boolean {
   return !!agg.latestCodexUsage || !!agg.latestContextUsage;
 }
 
-/** Both independent Codex metrics recovered. Used to decide when a widening
- *  back-scan can stop: they may live on different lines, so a window that only
- *  caught one is not yet complete. */
+/** The two cumulative-usage metrics recovered. Used to decide when the bounded
+ *  widen can stop: cumulative and context can sit on different lines, so a
+ *  window that caught only one is not complete. Model is handled separately
+ *  (see the model back-fill below) — it is a stable session-level attribute, so
+ *  gating the (bounded) widen on it would force a re-scan for every rollout that
+ *  simply never re-emits a model line inside the tail window. */
 function aggregateHasAllCodexMetrics(agg: TokenUsageAggregate): boolean {
   return !!agg.latestCodexUsage && !!agg.latestContextUsage;
 }
@@ -811,33 +813,54 @@ function readCodexTokenAggregateCached(
     }
     ({ state, seenMessageIds, scanned, completeBytes, previewAgg, pendingTailIsInitialResidualLine } = win);
   } else {
-    // Oversized cold/bounded read: start at the last tail window and widen it
-    // one step at a time until BOTH independent metrics are recovered (they can
-    // sit on different lines) — or we hit the file head or the back-scan budget.
-    // This recovers the true latest usage even when a single >4MiB turn pushed
-    // the newest snapshot out of the first window, instead of collapsing to null.
-    let win: WindowScan | null = null;
-    let step = 0;
-    for (;;) {
-      const windowBytes = CODEX_USAGE_TRANSCRIPT_TAIL_BYTES * (step + 1);
-      baseOffset = Math.max(0, fdStat.size - windowBytes);
-      const attempt = scanFromWindow(baseOffset, false);
-      if (!attempt) {
-        closeSync(fd);
-        usageFileCache.delete(key);
-        return null;
+    // Oversized cold/bounded read. Fast path: scan the last tail window. If the
+    // three independent metrics (cumulative / context / model) are not all on
+    // that window — a single >4MiB turn can push the newest snapshot, or the
+    // model line, out of it — do ONE bounded widen to the back-scan budget and
+    // re-scan that whole window. A single widened pass (not a 4/8/.../32 ladder)
+    // keeps the worst-case synchronous read at tail + budget instead of their
+    // sum, while still recovering the true latest usage. Each pass scans from a
+    // fresh state; Codex token_count is cumulative (latest wins), so re-folding
+    // older lines first and letting the newest snapshot overwrite last is exact.
+    baseOffset = Math.max(0, fdStat.size - CODEX_USAGE_TRANSCRIPT_TAIL_BYTES);
+    let win = scanFromWindow(baseOffset, false);
+    if (!win) {
+      closeSync(fd);
+      usageFileCache.delete(key);
+      return null;
+    }
+    if (!aggregateHasAllCodexMetrics(win.previewAgg) && baseOffset > 0) {
+      const widenedBaseOffset = Math.max(0, fdStat.size - CODEX_USAGE_MAX_BACKSCAN_BYTES);
+      if (widenedBaseOffset < baseOffset) {
+        const widened = scanFromWindow(widenedBaseOffset, false);
+        if (!widened) {
+          closeSync(fd);
+          usageFileCache.delete(key);
+          return null;
+        }
+        baseOffset = widenedBaseOffset;
+        win = widened;
       }
-      win = attempt;
-      if (
-        aggregateHasAllCodexMetrics(attempt.previewAgg)
-        || baseOffset === 0
-        || windowBytes >= CODEX_USAGE_MAX_BACKSCAN_BYTES
-      ) {
-        break;
-      }
-      step += 1;
     }
     ({ state, seenMessageIds, scanned, completeBytes, previewAgg, pendingTailIsInitialResidualLine } = win);
+  }
+
+  // Model back-fill: the model rides on turn_context/session_meta lines and is
+  // a stable session-level attribute, but a bounded window may not re-include
+  // one (a long final turn can push the last model line out of it). A fresh
+  // per-window scan would then ship an empty model to the ledger ("unknown").
+  // Carry the model forward from the SAME open file's cached read (dev+ino) —
+  // model only, never the usage numbers, and only to fill an empty value, so a
+  // genuine in-window model always wins and no stale token counts are inherited.
+  if (
+    oversized
+    && !reuseTrackedReplay
+    && !previewAgg.model
+    && sameOpenFileAsCache
+    && previousAgg?.model
+  ) {
+    if (previewAgg === state) previewAgg = cloneAggregate(state);
+    previewAgg.model = previousAgg.model;
   }
 
   const nextOffset = pendingTailIsInitialResidualLine ? baseOffset : baseOffset + completeBytes;

--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -458,6 +458,10 @@ type CachedUsageKind = UsageKind | 'aiden';
 interface UsageFileCacheEntry {
   mtimeMs: number;
   size: number;
+  dev: number;
+  ino: number;
+  frontierFingerprint: string | null;
+  canReadIncrementally: boolean;
   /** Durable parse frontier: byte offset just past the last complete line.
    *  <= 0 ⇒ the next change forces a full reparse. */
   offset: number;
@@ -481,6 +485,7 @@ export const MAX_USAGE_TRANSCRIPT_BYTES = 64 * 1024 * 1024;
  *  Keep this tight: it is a synchronous dashboard read path, and real 150MiB+
  *  rollouts have many token_count snapshots in the last 4MiB. */
 export const CODEX_USAGE_TRANSCRIPT_TAIL_BYTES = 4 * 1024 * 1024;
+export const USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES = 64;
 
 /** Aiden checkpoint paths move as the session progresses (latest.json points
  *  at a new checkpoint id per turn), so positive hits expire quickly too. */
@@ -528,19 +533,25 @@ function openRegularUsageFile(path: string): number | null {
   }
 }
 
-function isJsonlLineBoundary(path: string, offset: number): boolean {
-  if (offset <= 0) return true;
+function readFileProbe(path: string, offset: number, length: number): Buffer | null {
+  if (length <= 0) return Buffer.alloc(0);
   const fd = openRegularUsageFile(path);
-  if (fd === null) return false;
+  if (fd === null) return null;
   try {
-    const buf = Buffer.alloc(1);
-    const read = readSync(fd, buf, 0, 1, offset - 1);
-    return read === 1 && buf[0] === 0x0a;
+    const buf = Buffer.alloc(length);
+    const read = readSync(fd, buf, 0, length, offset);
+    return buf.subarray(0, read);
   } catch {
-    return false;
+    return null;
   } finally {
     closeSync(fd);
   }
+}
+
+function isJsonlLineBoundary(path: string, offset: number): boolean {
+  if (offset <= 0) return true;
+  const probe = readFileProbe(path, offset - 1, 1);
+  return !!probe && probe.length === 1 && probe[0] === 0x0a;
 }
 
 function aggregateHasCodexUsage(agg: TokenUsageAggregate): boolean {
@@ -559,6 +570,71 @@ function ensureUsageFileCacheCapacity(key: string): void {
   }
 }
 
+function usageFileFingerprint(path: string, st: Stats, offset: number): string | null {
+  if (offset <= 0) return null;
+  const len = Math.min(USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES, offset);
+  const start = offset - len;
+  const probe = readFileProbe(path, start, len);
+  if (!probe || probe.length !== len) return null;
+  return `${st.dev}:${st.ino}:${start}:${probe.toString('base64')}`;
+}
+
+function isSameUsageFileGeneration(
+  cached: UsageFileCacheEntry,
+  st: Stats,
+  path: string,
+): boolean {
+  if (cached.dev !== st.dev || cached.ino !== st.ino) return false;
+  if (cached.frontierFingerprint === null) return false;
+  return usageFileFingerprint(path, st, cached.offset) === cached.frontierFingerprint;
+}
+
+function canReuseUsageCache(
+  cached: UsageFileCacheEntry,
+  st: Stats,
+  path: string,
+  opts: { validateFingerprint?: boolean } = {},
+): boolean {
+  if (!cached.canReadIncrementally) return false;
+  if (st.size < cached.offset) return false;
+  if (cached.dev !== st.dev || cached.ino !== st.ino) return false;
+  if (!opts.validateFingerprint) return true;
+  return isSameUsageFileGeneration(cached, st, path);
+}
+
+function mergeCodexIndependentMetrics(
+  next: TokenUsageAggregate,
+  previous?: TokenUsageAggregate,
+): TokenUsageAggregate {
+  if (!previous) return next;
+  return {
+    ...next,
+    model: next.model || previous.model,
+    latestCodexUsage: next.latestCodexUsage ?? previous.latestCodexUsage,
+    latestContextUsage: next.latestContextUsage ?? previous.latestContextUsage,
+  };
+}
+
+function cacheUsageRead(
+  key: string,
+  path: string,
+  st: Stats,
+  entry: Omit<UsageFileCacheEntry, 'mtimeMs' | 'size' | 'dev' | 'ino' | 'frontierFingerprint'>,
+  opts: { captureFingerprint?: boolean } = {},
+): void {
+  ensureUsageFileCacheCapacity(key);
+  usageFileCache.set(key, {
+    ...entry,
+    mtimeMs: st.mtimeMs,
+    size: st.size,
+    dev: st.dev,
+    ino: st.ino,
+    frontierFingerprint: opts.captureFingerprint
+      ? usageFileFingerprint(path, st, entry.offset)
+      : null,
+  });
+}
+
 function readOversizedCodexTokenAggregateCached(
   key: string,
   path: string,
@@ -570,7 +646,13 @@ function readOversizedCodexTokenAggregateCached(
   let seenMessageIds: Set<string>;
   let baseOffset: number;
   let dropInitialResidualLine = false;
-  const canReuseCachedOffset = !!cached && cached.offset > 0 && st.size >= cached.offset;
+  const sameGeneration = !!cached && isSameUsageFileGeneration(cached, st, path);
+  const canInheritCachedMetrics = sameGeneration;
+  const canReuseCachedOffset = !!cached
+    && sameGeneration
+    && cached.canReadIncrementally
+    && cached.offset > 0
+    && st.size >= cached.offset;
   const reuseCachedOffset = canReuseCachedOffset
     && st.size - cached.offset <= CODEX_USAGE_TRANSCRIPT_TAIL_BYTES;
 
@@ -614,32 +696,37 @@ function readOversizedCodexTokenAggregateCached(
     foldUsageText('codex', previewAgg, new Set(seenMessageIds), tailText);
   }
 
-  const result = finalizeTokenUsage(previewAgg);
   if (pendingTailIsInitialResidualLine) {
     // The bounded window starts in the middle of a JSONL record and no newline
-    // has arrived yet. Do not persist `baseOffset`: if the writer later appends
-    // only '\n', that residual suffix would otherwise become a fake complete
-    // line on the incremental path.
-    return cached && !reuseCachedOffset
-      ? { agg: cached.previewAgg, result: cached.result }
-      : { agg: previewAgg, result };
+    // has arrived yet. Cache safe stat/throttle metadata only; the stored
+    // offset is not a reusable durable cursor, so any later change reboots from
+    // a bounded tail instead of turning that suffix into a fake complete line.
+    const merged = mergeCodexIndependentMetrics(previewAgg, canInheritCachedMetrics ? cached?.previewAgg : undefined);
+    const mergedResult = finalizeTokenUsage(merged);
+    cacheUsageRead(key, path, st, {
+      offset: baseOffset,
+      state,
+      seenMessageIds,
+      previewAgg: merged,
+      result: mergedResult,
+      parsedAtMs: now,
+      canReadIncrementally: false,
+    }, { captureFingerprint: true });
+    return { agg: merged, result: mergedResult };
   }
-  if (!aggregateHasCodexUsage(previewAgg) && cached && !reuseCachedOffset) {
-    return { agg: cached.previewAgg, result: cached.result };
-  }
-
-  ensureUsageFileCacheCapacity(key);
-  usageFileCache.set(key, {
-    mtimeMs: st.mtimeMs,
-    size: st.size,
+  const merged = mergeCodexIndependentMetrics(previewAgg, canInheritCachedMetrics ? cached?.previewAgg : undefined);
+  const mergedResult = finalizeTokenUsage(merged);
+  const canReadIncrementally = reuseCachedOffset || aggregateHasCodexUsage(previewAgg);
+  cacheUsageRead(key, path, st, {
     offset: baseOffset + completeBytes,
     state,
     seenMessageIds,
-    previewAgg,
-    result,
+    previewAgg: merged,
+    result: mergedResult,
     parsedAtMs: now,
-  });
-  return { agg: previewAgg, result };
+    canReadIncrementally,
+  }, { captureFingerprint: true });
+  return { agg: merged, result: mergedResult };
 }
 
 function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, opts?: { fresh?: boolean }): UsageReadResult | null {
@@ -664,7 +751,7 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, op
 
   const now = Date.now();
   const cached = usageFileCache.get(key);
-  if (cached) {
+  if (cached && cached.dev === st.dev && cached.ino === st.ino) {
     const unchanged = cached.mtimeMs === st.mtimeMs && cached.size === st.size;
     const throttled = !opts?.fresh && now - cached.parsedAtMs < USAGE_REPARSE_MIN_INTERVAL_MS;
     if (unchanged || throttled) {
@@ -694,16 +781,14 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, op
     // Checkpoints are rewritten whole — nothing incremental to exploit.
     const result = readTokenUsageFromAidenCheckpoint(path);
     const blank = newTokenUsageAggregate();
-    ensureUsageFileCacheCapacity(key);
-    usageFileCache.set(key, {
-      mtimeMs: st.mtimeMs,
-      size: st.size,
+    cacheUsageRead(key, path, st, {
       offset: -1,
       state: blank,
       seenMessageIds: new Set(),
       previewAgg: blank,
       result,
       parsedAtMs: now,
+      canReadIncrementally: false,
     });
     return { agg: blank, result };
   }
@@ -711,7 +796,9 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, op
   let state: TokenUsageAggregate;
   let seenMessageIds: Set<string>;
   let baseOffset: number;
-  if (cached && cached.offset > 0 && st.size >= cached.offset) {
+  if (cached && cached.offset > 0 && canReuseUsageCache(cached, st, path, {
+    validateFingerprint: kind === 'codex',
+  })) {
     // Append-only growth: continue folding from the durable frontier.
     state = cached.state;
     seenMessageIds = cached.seenMessageIds;
@@ -747,17 +834,15 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, op
   }
 
   const result = finalizeTokenUsage(previewAgg);
-  ensureUsageFileCacheCapacity(key);
-  usageFileCache.set(key, {
-    mtimeMs: st.mtimeMs,
-    size: st.size,
+  cacheUsageRead(key, path, st, {
     offset: baseOffset + completeBytes,
     state,
     seenMessageIds,
     previewAgg,
     result,
     parsedAtMs: now,
-  });
+    canReadIncrementally: true,
+  }, { captureFingerprint: kind === 'codex' });
   return { agg: previewAgg, result };
 }
 

--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -813,15 +813,21 @@ function readCodexTokenAggregateCached(
     }
     ({ state, seenMessageIds, scanned, completeBytes, previewAgg, pendingTailIsInitialResidualLine } = win);
   } else {
-    // Oversized cold/bounded read. Fast path: scan the last tail window. If the
-    // three independent metrics (cumulative / context / model) are not all on
-    // that window — a single >4MiB turn can push the newest snapshot, or the
-    // model line, out of it — do ONE bounded widen to the back-scan budget and
-    // re-scan that whole window. A single widened pass (not a 4/8/.../32 ladder)
-    // keeps the worst-case synchronous read at tail + budget instead of their
-    // sum, while still recovering the true latest usage. Each pass scans from a
-    // fresh state; Codex token_count is cumulative (latest wins), so re-folding
-    // older lines first and letting the newest snapshot overwrite last is exact.
+    // Oversized cold/bounded read. Fast path: scan the last tail window. Widen
+    // ONCE to the back-scan budget and re-scan that whole window when the fast
+    // path is incomplete — either the two usage metrics (cumulative/context)
+    // are not both present, or this session is KNOWN to carry a model (the
+    // cached read had one) but the fast window has none. A single >4MiB turn can
+    // push the newest token_count — or a just-switched model line — out of the
+    // tail window; the widen recovers the true latest of all of them. A single
+    // widened pass (not a 4/8/.../32 ladder) keeps the worst-case synchronous
+    // read at tail + budget, not their sum. Each pass scans from a fresh state;
+    // Codex token_count/model are latest-wins, so re-folding older lines first
+    // and letting the newest overwrite last is exact. Model is NOT inherited
+    // from cache: a widen that still finds none fails closed to empty rather
+    // than risk shipping a stale model (which mis-prices the ledger) after an
+    // append-only model switch.
+    const cachedHadModel = sameOpenFileAsCache && !!previousAgg?.model;
     baseOffset = Math.max(0, fdStat.size - CODEX_USAGE_TRANSCRIPT_TAIL_BYTES);
     let win = scanFromWindow(baseOffset, false);
     if (!win) {
@@ -829,7 +835,9 @@ function readCodexTokenAggregateCached(
       usageFileCache.delete(key);
       return null;
     }
-    if (!aggregateHasAllCodexMetrics(win.previewAgg) && baseOffset > 0) {
+    const fastPathIncomplete = !aggregateHasAllCodexMetrics(win.previewAgg)
+      || (cachedHadModel && !win.previewAgg.model);
+    if (fastPathIncomplete && baseOffset > 0) {
       const widenedBaseOffset = Math.max(0, fdStat.size - CODEX_USAGE_MAX_BACKSCAN_BYTES);
       if (widenedBaseOffset < baseOffset) {
         const widened = scanFromWindow(widenedBaseOffset, false);
@@ -843,24 +851,6 @@ function readCodexTokenAggregateCached(
       }
     }
     ({ state, seenMessageIds, scanned, completeBytes, previewAgg, pendingTailIsInitialResidualLine } = win);
-  }
-
-  // Model back-fill: the model rides on turn_context/session_meta lines and is
-  // a stable session-level attribute, but a bounded window may not re-include
-  // one (a long final turn can push the last model line out of it). A fresh
-  // per-window scan would then ship an empty model to the ledger ("unknown").
-  // Carry the model forward from the SAME open file's cached read (dev+ino) —
-  // model only, never the usage numbers, and only to fill an empty value, so a
-  // genuine in-window model always wins and no stale token counts are inherited.
-  if (
-    oversized
-    && !reuseTrackedReplay
-    && !previewAgg.model
-    && sameOpenFileAsCache
-    && previousAgg?.model
-  ) {
-    if (previewAgg === state) previewAgg = cloneAggregate(state);
-    previewAgg.model = previousAgg.model;
   }
 
   const nextOffset = pendingTailIsInitialResidualLine ? baseOffset : baseOffset + completeBytes;

--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -1,6 +1,7 @@
 /**
  * Session cost calculator — computes token usage from JSONL logs.
  */
+import { createHash } from 'node:crypto';
 import { closeSync, constants, existsSync, fstatSync, openSync, readFileSync, readSync, statSync, type Stats } from 'node:fs';
 import { logger } from '../utils/logger.js';
 import type { CliId } from '../adapters/cli/types.js';
@@ -10,7 +11,7 @@ import {
   cachedTranscriptPathLookup,
   resolveSessionTranscriptPath,
 } from '../services/transcript-resolver.js';
-import { scanJsonlFromOffset } from '../services/jsonl-cursor.js';
+import { scanJsonlFromFd, scanJsonlFromOffset } from '../services/jsonl-cursor.js';
 import {
   isMeaningfulQueuedCommand,
   isMeaningfulUserEvent,
@@ -207,6 +208,9 @@ interface TokenUsageAggregate {
   turns: number;
   latestCodexUsage: SessionTokenUsage | null;
   latestContextUsage: SessionContextUsage | null;
+  latestCodexUsageSource: UsageSourceRecord | null;
+  latestContextUsageSource: UsageSourceRecord | null;
+  modelSource: UsageSourceRecord | null;
   /** Prompt-side (input + cache) and output tokens accumulated for the CURRENT
    *  user turn — reset when a new user message is seen (Claude). Lets the card
    *  show a small "this turn" delta alongside the large cumulative total. */
@@ -217,6 +221,27 @@ interface TokenUsageAggregate {
 /** Per-CLI transcript dialect. Each kind only counts the events that dialect
  *  defines as billable turns — no cross-CLI guessing on usage-shaped lines. */
 type UsageKind = 'claude' | 'codex' | 'coco' | 'pi' | 'generic';
+
+interface UsageSourceRecord {
+  offset: number;
+  byteLength: number;
+  sha256: string;
+}
+
+const CODEX_USAGE_SOURCE_RECORD_MAX_BYTES = 64 * 1024;
+
+function sourceRecordForLine(line: string, lineStart: number | undefined): UsageSourceRecord | null {
+  if (lineStart === undefined || lineStart < 0) return null;
+  const raw = Buffer.from(line, 'utf8');
+  if (raw.length > CODEX_USAGE_SOURCE_RECORD_MAX_BYTES) return null;
+  return {
+    offset: lineStart,
+    byteLength: raw.length,
+    sha256: createHash('sha256').update(raw).digest('hex'),
+  };
+}
+
+type UsageSourceRecordGetter = () => UsageSourceRecord | null;
 
 function usageKindForCli(cliId: SessionTokenUsageQuery['cliId']): UsageKind {
   switch (cliId) {
@@ -251,6 +276,9 @@ function newTokenUsageAggregate(): TokenUsageAggregate {
     turns: 0,
     latestCodexUsage: null,
     latestContextUsage: null,
+    latestCodexUsageSource: null,
+    latestContextUsageSource: null,
+    modelSource: null,
     turnInputTokens: 0,
     turnOutputTokens: 0,
   };
@@ -314,17 +342,29 @@ function foldClaudeLine(agg: TokenUsageAggregate, seenMessageIds: Set<string>, e
 /** Codex rollouts report cumulative totals via event_msg/token_count; only
  *  the latest snapshot counts. The active model rides on turn_context /
  *  session_meta payloads (latest wins — sessions can switch models). */
-function foldCodexLine(agg: TokenUsageAggregate, entry: any): void {
+function foldCodexLine(agg: TokenUsageAggregate, entry: any, getSource: UsageSourceRecordGetter): void {
   const contextUsage = extractCodexContextUsage(entry);
-  if (contextUsage) agg.latestContextUsage = contextUsage;
+  let source: UsageSourceRecord | null | undefined;
+  const sourceForTrackedMetric = () => {
+    source ??= getSource();
+    return source;
+  };
+  if (contextUsage) {
+    agg.latestContextUsage = contextUsage;
+    agg.latestContextUsageSource = sourceForTrackedMetric();
+  }
 
   const codexUsage = extractCodexTokenCountUsage(entry);
   if (codexUsage) {
     agg.latestCodexUsage = codexUsage;
+    agg.latestCodexUsageSource = sourceForTrackedMetric();
     return;
   }
   const m = entry?.payload?.model ?? entry?.payload?.collaboration_mode?.settings?.model;
-  if (typeof m === 'string' && m) agg.model = m;
+  if (typeof m === 'string' && m) {
+    agg.model = m;
+    agg.modelSource = sourceForTrackedMetric();
+  }
 }
 
 /** CoCo events: only assistant messages with response_meta.usage count; the
@@ -390,12 +430,18 @@ function foldGenericLine(agg: TokenUsageAggregate, seenMessageIds: Set<string>, 
   agg.turns++;
 }
 
-function foldUsageLine(kind: UsageKind, agg: TokenUsageAggregate, seenMessageIds: Set<string>, entry: any): void {
+function foldUsageLine(
+  kind: UsageKind,
+  agg: TokenUsageAggregate,
+  seenMessageIds: Set<string>,
+  entry: any,
+  getSource?: UsageSourceRecordGetter,
+): void {
   switch (kind) {
     case 'claude':
       return foldClaudeLine(agg, seenMessageIds, entry);
     case 'codex':
-      return foldCodexLine(agg, entry);
+      return foldCodexLine(agg, entry, getSource ?? (() => null));
     case 'coco':
       return foldCocoLine(agg, entry);
     case 'pi':
@@ -414,7 +460,7 @@ function readTokenUsageAggregate(path: string, kind: UsageKind): TokenUsageAggre
   try {
     let scanError: unknown = null;
     const scanned = scanJsonlFromOffset(path, 0, {
-      onLine: (line) => foldUsageJsonLine(kind, agg, seenMessageIds, line),
+      onLine: (line, lineStart) => foldUsageJsonLine(kind, agg, seenMessageIds, line, lineStart),
       onError: (error) => { scanError = error; },
     });
     if (!scanned) throw scanError instanceof Error ? scanError : new Error('scan failed');
@@ -457,6 +503,7 @@ type CachedUsageKind = UsageKind | 'aiden';
 
 interface UsageFileCacheEntry {
   mtimeMs: number;
+  ctimeMs: number;
   size: number;
   dev: number;
   ino: number;
@@ -511,46 +558,46 @@ function foldUsageText(kind: UsageKind, agg: TokenUsageAggregate, seenMessageIds
   }
 }
 
-function foldUsageJsonLine(kind: UsageKind, agg: TokenUsageAggregate, seenMessageIds: Set<string>, line: string): void {
+function foldUsageJsonLine(
+  kind: UsageKind,
+  agg: TokenUsageAggregate,
+  seenMessageIds: Set<string>,
+  line: string,
+  lineStart?: number,
+): void {
   if (!line.trim()) return;
   try {
-    foldUsageLine(kind, agg, seenMessageIds, JSON.parse(line));
+    const entry = JSON.parse(line);
+    if (kind !== 'codex') {
+      foldUsageLine(kind, agg, seenMessageIds, entry);
+      return;
+    }
+    let sourceCalculated = false;
+    let source: UsageSourceRecord | null = null;
+    foldUsageLine(kind, agg, seenMessageIds, entry, () => {
+      if (!sourceCalculated) {
+        source = sourceRecordForLine(line, lineStart);
+        sourceCalculated = true;
+      }
+      return source;
+    });
   } catch { /* skip malformed lines */ }
 }
 
-function openRegularUsageFile(path: string): number | null {
-  let fd: number | null = null;
-  try {
-    fd = openSync(path, constants.O_RDONLY | (constants.O_NONBLOCK ?? 0));
-    if (!fstatSync(fd).isFile()) {
-      closeSync(fd);
-      return null;
-    }
-    return fd;
-  } catch {
-    if (fd !== null) closeSync(fd);
-    return null;
-  }
-}
-
-function readFileProbe(path: string, offset: number, length: number): Buffer | null {
+function readFdProbe(fd: number, offset: number, length: number): Buffer | null {
   if (length <= 0) return Buffer.alloc(0);
-  const fd = openRegularUsageFile(path);
-  if (fd === null) return null;
   try {
     const buf = Buffer.alloc(length);
     const read = readSync(fd, buf, 0, length, offset);
     return buf.subarray(0, read);
   } catch {
     return null;
-  } finally {
-    closeSync(fd);
   }
 }
 
-function isJsonlLineBoundary(path: string, offset: number): boolean {
+function isJsonlLineBoundaryFd(fd: number, offset: number): boolean {
   if (offset <= 0) return true;
-  const probe = readFileProbe(path, offset - 1, 1);
+  const probe = readFdProbe(fd, offset - 1, 1);
   return !!probe && probe.length === 1 && probe[0] === 0x0a;
 }
 
@@ -570,119 +617,214 @@ function ensureUsageFileCacheCapacity(key: string): void {
   }
 }
 
-function usageFileFingerprint(path: string, st: Stats, offset: number): string | null {
+function usageFileFingerprintFromFd(fd: number, st: Stats, offset: number): string | null {
   if (offset <= 0) return null;
   const len = Math.min(USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES, offset);
   const start = offset - len;
-  const probe = readFileProbe(path, start, len);
+  const probe = readFdProbe(fd, start, len);
   if (!probe || probe.length !== len) return null;
   return `${st.dev}:${st.ino}:${start}:${probe.toString('base64')}`;
-}
-
-function isSameUsageFileGeneration(
-  cached: UsageFileCacheEntry,
-  st: Stats,
-  path: string,
-): boolean {
-  if (cached.dev !== st.dev || cached.ino !== st.ino) return false;
-  if (cached.frontierFingerprint === null) return false;
-  return usageFileFingerprint(path, st, cached.offset) === cached.frontierFingerprint;
 }
 
 function canReuseUsageCache(
   cached: UsageFileCacheEntry,
   st: Stats,
-  path: string,
-  opts: { validateFingerprint?: boolean } = {},
 ): boolean {
   if (!cached.canReadIncrementally) return false;
   if (st.size < cached.offset) return false;
-  if (cached.dev !== st.dev || cached.ino !== st.ino) return false;
-  if (!opts.validateFingerprint) return true;
-  return isSameUsageFileGeneration(cached, st, path);
+  return cached.dev === st.dev && cached.ino === st.ino;
 }
 
 function mergeCodexIndependentMetrics(
   next: TokenUsageAggregate,
   previous?: TokenUsageAggregate,
+  sourceValid?: {
+    latestCodexUsage: boolean;
+    latestContextUsage: boolean;
+    model: boolean;
+  },
 ): TokenUsageAggregate {
   if (!previous) return next;
+  const inheritModel = !next.model && !!previous.model && !!sourceValid?.model;
+  const inheritCodexUsage = !next.latestCodexUsage && !!previous.latestCodexUsage && !!sourceValid?.latestCodexUsage;
+  const inheritContextUsage = !next.latestContextUsage && !!previous.latestContextUsage && !!sourceValid?.latestContextUsage;
   return {
     ...next,
-    model: next.model || previous.model,
-    latestCodexUsage: next.latestCodexUsage ?? previous.latestCodexUsage,
-    latestContextUsage: next.latestContextUsage ?? previous.latestContextUsage,
+    model: next.model || (inheritModel ? previous.model : ''),
+    modelSource: next.model ? next.modelSource : (inheritModel ? previous.modelSource : null),
+    latestCodexUsage: next.latestCodexUsage ?? (inheritCodexUsage ? previous.latestCodexUsage : null),
+    latestCodexUsageSource: next.latestCodexUsage ? next.latestCodexUsageSource : (inheritCodexUsage ? previous.latestCodexUsageSource : null),
+    latestContextUsage: next.latestContextUsage ?? (inheritContextUsage ? previous.latestContextUsage : null),
+    latestContextUsageSource: next.latestContextUsage ? next.latestContextUsageSource : (inheritContextUsage ? previous.latestContextUsageSource : null),
   };
+}
+
+function sourceRecordKey(source: UsageSourceRecord): string {
+  return `${source.offset}:${source.byteLength}:${source.sha256}`;
+}
+
+function validateSourceRecord(fd: number, source: UsageSourceRecord | null | undefined, cache: Map<string, boolean>): boolean {
+  if (!source) return false;
+  if (source.byteLength <= 0 || source.byteLength > CODEX_USAGE_SOURCE_RECORD_MAX_BYTES) return false;
+  const key = sourceRecordKey(source);
+  const cached = cache.get(key);
+  if (cached !== undefined) return cached;
+  const raw = readFdProbe(fd, source.offset, source.byteLength);
+  let valid = raw !== null && raw.length === source.byteLength;
+  if (valid && raw) valid = createHash('sha256').update(raw).digest('hex') === source.sha256;
+  if (valid) {
+    const terminator = readFdProbe(fd, source.offset + source.byteLength, 1);
+    valid = !!terminator && terminator.length === 1 && terminator[0] === 0x0a;
+  }
+  cache.set(key, valid);
+  return valid;
+}
+
+function validateCodexSourceRecords(
+  fd: number,
+  previous?: TokenUsageAggregate,
+): { latestCodexUsage: boolean; latestContextUsage: boolean; model: boolean } {
+  const cache = new Map<string, boolean>();
+  return {
+    latestCodexUsage: validateSourceRecord(fd, previous?.latestCodexUsageSource, cache),
+    latestContextUsage: validateSourceRecord(fd, previous?.latestContextUsageSource, cache),
+    model: validateSourceRecord(fd, previous?.modelSource, cache),
+  };
+}
+
+function canReuseCodexAggregate(
+  previous: TokenUsageAggregate | undefined,
+  sourceValid: { latestCodexUsage: boolean; latestContextUsage: boolean; model: boolean } | undefined,
+): boolean {
+  if (!previous || !sourceValid) return false;
+  if (previous.latestCodexUsage && !sourceValid.latestCodexUsage) return false;
+  if (previous.latestContextUsage && !sourceValid.latestContextUsage) return false;
+  if (previous.model && !sourceValid.model) return false;
+  return true;
 }
 
 function cacheUsageRead(
   key: string,
-  path: string,
   st: Stats,
-  entry: Omit<UsageFileCacheEntry, 'mtimeMs' | 'size' | 'dev' | 'ino' | 'frontierFingerprint'>,
-  opts: { captureFingerprint?: boolean } = {},
+  entry: Omit<UsageFileCacheEntry, 'mtimeMs' | 'ctimeMs' | 'size' | 'dev' | 'ino' | 'frontierFingerprint'>,
 ): void {
   ensureUsageFileCacheCapacity(key);
   usageFileCache.set(key, {
     ...entry,
     mtimeMs: st.mtimeMs,
+    ctimeMs: st.ctimeMs,
     size: st.size,
     dev: st.dev,
     ino: st.ino,
-    frontierFingerprint: opts.captureFingerprint
-      ? usageFileFingerprint(path, st, entry.offset)
-      : null,
+    frontierFingerprint: null,
   });
 }
 
-function readOversizedCodexTokenAggregateCached(
+function cacheUsageReadWithFrontierFingerprint(
+  key: string,
+  st: Stats,
+  entry: Omit<UsageFileCacheEntry, 'mtimeMs' | 'ctimeMs' | 'size' | 'dev' | 'ino' | 'frontierFingerprint'>,
+  frontierFingerprint: string | null,
+): void {
+  ensureUsageFileCacheCapacity(key);
+  usageFileCache.set(key, {
+    ...entry,
+    mtimeMs: st.mtimeMs,
+    ctimeMs: st.ctimeMs,
+    size: st.size,
+    dev: st.dev,
+    ino: st.ino,
+    frontierFingerprint,
+  });
+}
+
+function readCodexTokenAggregateCached(
   key: string,
   path: string,
   st: Stats,
   cached: UsageFileCacheEntry | undefined,
   now: number,
+  retryOnRace = true,
 ): UsageReadResult | null {
+  let fd: number | null = null;
+  let fdStat: Stats;
+  try {
+    fd = openSync(path, constants.O_RDONLY | (constants.O_NONBLOCK ?? 0));
+    fdStat = fstatSync(fd);
+    if (!fdStat.isFile()) {
+      closeSync(fd);
+      usageFileCache.delete(key);
+      return { agg: newTokenUsageAggregate(), result: null };
+    }
+  } catch (error) {
+    if (fd !== null) closeSync(fd);
+    logger.error(`Failed to open Codex transcript ${path}: ${error instanceof Error ? error.message : String(error)}`);
+    usageFileCache.delete(key);
+    return null;
+  }
+  if (fdStat.dev !== st.dev || fdStat.ino !== st.ino || fdStat.size !== st.size) {
+    closeSync(fd);
+    usageFileCache.delete(key);
+    if (retryOnRace) {
+      return readCodexTokenAggregateCached(key, path, fdStat, undefined, now, false);
+    }
+    return { agg: newTokenUsageAggregate(), result: null };
+  }
   let state: TokenUsageAggregate;
   let seenMessageIds: Set<string>;
   let baseOffset: number;
   let dropInitialResidualLine = false;
-  const sameGeneration = !!cached && isSameUsageFileGeneration(cached, st, path);
-  const canInheritCachedMetrics = sameGeneration;
+  const previousAgg = cached?.previewAgg ? cloneAggregate(cached.previewAgg) : undefined;
+  // The frontier fingerprint only proves the durable cursor still points at
+  // the same byte frontier. Cached Codex metrics are inherited only after each
+  // metric's own source JSONL record passes validation below.
+  const cursorContinuityValid = !!cached
+    && cached.dev === fdStat.dev
+    && cached.ino === fdStat.ino
+    && cached.frontierFingerprint !== null
+    && usageFileFingerprintFromFd(fd, fdStat, cached.offset) === cached.frontierFingerprint;
+  const canInheritCachedMetrics = cursorContinuityValid
+    ? validateCodexSourceRecords(fd, previousAgg)
+    : undefined;
+  const canReuseCachedAggregate = canReuseCodexAggregate(previousAgg, canInheritCachedMetrics);
   const canReuseCachedOffset = !!cached
-    && sameGeneration
+    && cursorContinuityValid
+    && canReuseCachedAggregate
     && cached.canReadIncrementally
     && cached.offset > 0
-    && st.size >= cached.offset;
+    && fdStat.size >= cached.offset;
   const reuseCachedOffset = canReuseCachedOffset
-    && st.size - cached.offset <= CODEX_USAGE_TRANSCRIPT_TAIL_BYTES;
+    && fdStat.size - cached.offset <= CODEX_USAGE_TRANSCRIPT_TAIL_BYTES;
+  const oversized = fdStat.size > MAX_USAGE_TRANSCRIPT_BYTES;
 
   if (reuseCachedOffset) {
-    state = cached.state;
-    seenMessageIds = cached.seenMessageIds;
+    state = cloneAggregate(cached.state);
+    seenMessageIds = new Set(cached.seenMessageIds);
     baseOffset = cached.offset;
   } else {
     state = newTokenUsageAggregate();
     seenMessageIds = new Set();
-    baseOffset = Math.max(0, st.size - CODEX_USAGE_TRANSCRIPT_TAIL_BYTES);
-    dropInitialResidualLine = !isJsonlLineBoundary(path, baseOffset);
+    baseOffset = oversized ? Math.max(0, fdStat.size - CODEX_USAGE_TRANSCRIPT_TAIL_BYTES) : 0;
+    dropInitialResidualLine = oversized && !isJsonlLineBoundaryFd(fd, baseOffset);
   }
 
   let scanError: unknown = null;
   let droppedInitialResidualLine = false;
-  const scanned = scanJsonlFromOffset(path, baseOffset, {
-    endOffset: st.size,
-    onLine: (line) => {
+  const scanned = scanJsonlFromFd(fd, baseOffset, {
+    endOffset: fdStat.size,
+    onLine: (line, lineStart) => {
       if (dropInitialResidualLine) {
         dropInitialResidualLine = false;
         droppedInitialResidualLine = true;
         return;
       }
-      foldUsageJsonLine('codex', state, seenMessageIds, line);
+      foldUsageJsonLine('codex', state, seenMessageIds, line, lineStart);
     },
     onError: (error) => { scanError = error; },
   });
   if (!scanned) {
-    logger.error(`Failed to read oversized Codex transcript tail ${path}: ${scanError instanceof Error ? scanError.message : String(scanError)}`);
+    logger.error(`Failed to read Codex transcript slice ${path}: ${scanError instanceof Error ? scanError.message : String(scanError)}`);
+    closeSync(fd);
     usageFileCache.delete(key);
     return null;
   }
@@ -696,36 +838,86 @@ function readOversizedCodexTokenAggregateCached(
     foldUsageText('codex', previewAgg, new Set(seenMessageIds), tailText);
   }
 
+  const nextOffset = pendingTailIsInitialResidualLine ? baseOffset : baseOffset + completeBytes;
+  const nextFingerprint = usageFileFingerprintFromFd(fd, fdStat, nextOffset);
+  let endStat: Stats;
+  try {
+    endStat = fstatSync(fd);
+  } catch {
+    closeSync(fd);
+    usageFileCache.delete(key);
+    return { agg: newTokenUsageAggregate(), result: null };
+  }
+  if (
+    endStat.dev !== fdStat.dev
+    || endStat.ino !== fdStat.ino
+    || endStat.size !== fdStat.size
+    || endStat.mtimeMs !== fdStat.mtimeMs
+    || endStat.ctimeMs !== fdStat.ctimeMs
+  ) {
+    closeSync(fd);
+    usageFileCache.delete(key);
+    if (retryOnRace) {
+      return readCodexTokenAggregateCached(key, path, endStat, undefined, now, false);
+    }
+    return { agg: newTokenUsageAggregate(), result: null };
+  }
+
+  let pathStat: Stats;
+  try {
+    pathStat = statSync(path);
+  } catch {
+    closeSync(fd);
+    usageFileCache.delete(key);
+    return { agg: newTokenUsageAggregate(), result: null };
+  }
+  if (
+    pathStat.dev !== fdStat.dev
+    || pathStat.ino !== fdStat.ino
+    || pathStat.size !== fdStat.size
+    || pathStat.mtimeMs !== fdStat.mtimeMs
+    || pathStat.ctimeMs !== fdStat.ctimeMs
+  ) {
+    closeSync(fd);
+    usageFileCache.delete(key);
+    if (retryOnRace) {
+      return readCodexTokenAggregateCached(key, path, pathStat, undefined, now, false);
+    }
+    return { agg: newTokenUsageAggregate(), result: null };
+  }
+
   if (pendingTailIsInitialResidualLine) {
     // The bounded window starts in the middle of a JSONL record and no newline
     // has arrived yet. Cache safe stat/throttle metadata only; the stored
     // offset is not a reusable durable cursor, so any later change reboots from
     // a bounded tail instead of turning that suffix into a fake complete line.
-    const merged = mergeCodexIndependentMetrics(previewAgg, canInheritCachedMetrics ? cached?.previewAgg : undefined);
+    const merged = mergeCodexIndependentMetrics(previewAgg, previousAgg, canInheritCachedMetrics);
     const mergedResult = finalizeTokenUsage(merged);
-    cacheUsageRead(key, path, st, {
-      offset: baseOffset,
+    cacheUsageReadWithFrontierFingerprint(key, fdStat, {
+      offset: nextOffset,
       state,
       seenMessageIds,
       previewAgg: merged,
       result: mergedResult,
       parsedAtMs: now,
       canReadIncrementally: false,
-    }, { captureFingerprint: true });
+    }, nextFingerprint);
+    closeSync(fd);
     return { agg: merged, result: mergedResult };
   }
-  const merged = mergeCodexIndependentMetrics(previewAgg, canInheritCachedMetrics ? cached?.previewAgg : undefined);
+  const merged = mergeCodexIndependentMetrics(previewAgg, previousAgg, canInheritCachedMetrics);
   const mergedResult = finalizeTokenUsage(merged);
   const canReadIncrementally = reuseCachedOffset || aggregateHasCodexUsage(previewAgg);
-  cacheUsageRead(key, path, st, {
-    offset: baseOffset + completeBytes,
+  cacheUsageReadWithFrontierFingerprint(key, fdStat, {
+    offset: nextOffset,
     state,
     seenMessageIds,
     previewAgg: merged,
     result: mergedResult,
     parsedAtMs: now,
     canReadIncrementally,
-  }, { captureFingerprint: true });
+  }, nextFingerprint);
+  closeSync(fd);
   return { agg: merged, result: mergedResult };
 }
 
@@ -739,8 +931,11 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, op
   }
 
   if (!st) {
-    // Unstat-able (file gone, or mocked fs in unit tests): parse directly, uncached.
     usageFileCache.delete(key);
+    if (kind === 'codex') {
+      return { agg: newTokenUsageAggregate(), result: null };
+    }
+    // Unstat-able (file gone, or mocked fs in unit tests): parse directly, uncached.
     if (kind === 'aiden') {
       const result = readTokenUsageFromAidenCheckpoint(path);
       return result ? { agg: newTokenUsageAggregate(), result } : null;
@@ -752,15 +947,15 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, op
   const now = Date.now();
   const cached = usageFileCache.get(key);
   if (cached && cached.dev === st.dev && cached.ino === st.ino) {
-    const unchanged = cached.mtimeMs === st.mtimeMs && cached.size === st.size;
+    const unchanged = cached.mtimeMs === st.mtimeMs && cached.ctimeMs === st.ctimeMs && cached.size === st.size;
     const throttled = !opts?.fresh && now - cached.parsedAtMs < USAGE_REPARSE_MIN_INTERVAL_MS;
     if (unchanged || throttled) {
       return { agg: cached.previewAgg, result: cached.result };
     }
   }
 
-  if (st.size > MAX_USAGE_TRANSCRIPT_BYTES && kind === 'codex') {
-    return readOversizedCodexTokenAggregateCached(key, path, st, cached, now);
+  if (kind === 'codex') {
+    return readCodexTokenAggregateCached(key, path, st, cached, now);
   }
 
   if (st.size > MAX_USAGE_TRANSCRIPT_BYTES) {
@@ -781,7 +976,7 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, op
     // Checkpoints are rewritten whole — nothing incremental to exploit.
     const result = readTokenUsageFromAidenCheckpoint(path);
     const blank = newTokenUsageAggregate();
-    cacheUsageRead(key, path, st, {
+    cacheUsageRead(key, st, {
       offset: -1,
       state: blank,
       seenMessageIds: new Set(),
@@ -796,9 +991,7 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, op
   let state: TokenUsageAggregate;
   let seenMessageIds: Set<string>;
   let baseOffset: number;
-  if (cached && cached.offset > 0 && canReuseUsageCache(cached, st, path, {
-    validateFingerprint: kind === 'codex',
-  })) {
+  if (cached && cached.offset > 0 && canReuseUsageCache(cached, st)) {
     // Append-only growth: continue folding from the durable frontier.
     state = cached.state;
     seenMessageIds = cached.seenMessageIds;
@@ -812,7 +1005,7 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, op
   let scanError: unknown = null;
   const scanned = scanJsonlFromOffset(path, baseOffset, {
     endOffset: st.size,
-    onLine: (line) => foldUsageJsonLine(kind, state, seenMessageIds, line),
+    onLine: (line, lineStart) => foldUsageJsonLine(kind, state, seenMessageIds, line, lineStart),
     onError: (error) => { scanError = error; },
   });
   if (!scanned) {
@@ -834,7 +1027,7 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, op
   }
 
   const result = finalizeTokenUsage(previewAgg);
-  cacheUsageRead(key, path, st, {
+  cacheUsageRead(key, st, {
     offset: baseOffset + completeBytes,
     state,
     seenMessageIds,
@@ -842,7 +1035,7 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, op
     result,
     parsedAtMs: now,
     canReadIncrementally: true,
-  }, { captureFingerprint: kind === 'codex' });
+  });
   return { agg: previewAgg, result };
 }
 

--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -1,7 +1,7 @@
 /**
  * Session cost calculator — computes token usage from JSONL logs.
  */
-import { existsSync, readFileSync, statSync, type Stats } from 'node:fs';
+import { closeSync, constants, existsSync, fstatSync, openSync, readFileSync, readSync, statSync, type Stats } from 'node:fs';
 import { logger } from '../utils/logger.js';
 import type { CliId } from '../adapters/cli/types.js';
 import { findAidenLatestCheckpointByBotmuxSessionId, findAidenLatestCheckpointBySessionId } from '../services/aiden-checkpoints.js';
@@ -476,6 +476,11 @@ const USAGE_REPARSE_MIN_INTERVAL_MS = 15_000;
 /** Token usage is advisory. Never let dashboard row rendering synchronously
  *  scan pathological multi-GB transcripts. */
 export const MAX_USAGE_TRANSCRIPT_BYTES = 64 * 1024 * 1024;
+/** Codex token_count events are cumulative snapshots, so an oversized cold
+ *  restore only needs a bounded tail window to recover the latest usage card.
+ *  Keep this tight: it is a synchronous dashboard read path, and real 150MiB+
+ *  rollouts have many token_count snapshots in the last 4MiB. */
+export const CODEX_USAGE_TRANSCRIPT_TAIL_BYTES = 4 * 1024 * 1024;
 
 /** Aiden checkpoint paths move as the session progresses (latest.json points
  *  at a new checkpoint id per turn), so positive hits expire quickly too. */
@@ -508,9 +513,133 @@ function foldUsageJsonLine(kind: UsageKind, agg: TokenUsageAggregate, seenMessag
   } catch { /* skip malformed lines */ }
 }
 
+function openRegularUsageFile(path: string): number | null {
+  let fd: number | null = null;
+  try {
+    fd = openSync(path, constants.O_RDONLY | (constants.O_NONBLOCK ?? 0));
+    if (!fstatSync(fd).isFile()) {
+      closeSync(fd);
+      return null;
+    }
+    return fd;
+  } catch {
+    if (fd !== null) closeSync(fd);
+    return null;
+  }
+}
+
+function isJsonlLineBoundary(path: string, offset: number): boolean {
+  if (offset <= 0) return true;
+  const fd = openRegularUsageFile(path);
+  if (fd === null) return false;
+  try {
+    const buf = Buffer.alloc(1);
+    const read = readSync(fd, buf, 0, 1, offset - 1);
+    return read === 1 && buf[0] === 0x0a;
+  } catch {
+    return false;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function aggregateHasCodexUsage(agg: TokenUsageAggregate): boolean {
+  return !!agg.latestCodexUsage || !!agg.latestContextUsage;
+}
+
 interface UsageReadResult {
   agg: TokenUsageAggregate;
   result: SessionTokenUsage | null;
+}
+
+function ensureUsageFileCacheCapacity(key: string): void {
+  if (usageFileCache.size >= USAGE_FILE_CACHE_MAX_ENTRIES && !usageFileCache.has(key)) {
+    const oldest = usageFileCache.keys().next().value;
+    if (oldest !== undefined) usageFileCache.delete(oldest);
+  }
+}
+
+function readOversizedCodexTokenAggregateCached(
+  key: string,
+  path: string,
+  st: Stats,
+  cached: UsageFileCacheEntry | undefined,
+  now: number,
+): UsageReadResult | null {
+  let state: TokenUsageAggregate;
+  let seenMessageIds: Set<string>;
+  let baseOffset: number;
+  let dropInitialResidualLine = false;
+  const canReuseCachedOffset = !!cached && cached.offset > 0 && st.size >= cached.offset;
+  const reuseCachedOffset = canReuseCachedOffset
+    && st.size - cached.offset <= CODEX_USAGE_TRANSCRIPT_TAIL_BYTES;
+
+  if (reuseCachedOffset) {
+    state = cached.state;
+    seenMessageIds = cached.seenMessageIds;
+    baseOffset = cached.offset;
+  } else {
+    state = newTokenUsageAggregate();
+    seenMessageIds = new Set();
+    baseOffset = Math.max(0, st.size - CODEX_USAGE_TRANSCRIPT_TAIL_BYTES);
+    dropInitialResidualLine = !isJsonlLineBoundary(path, baseOffset);
+  }
+
+  let scanError: unknown = null;
+  let droppedInitialResidualLine = false;
+  const scanned = scanJsonlFromOffset(path, baseOffset, {
+    endOffset: st.size,
+    onLine: (line) => {
+      if (dropInitialResidualLine) {
+        dropInitialResidualLine = false;
+        droppedInitialResidualLine = true;
+        return;
+      }
+      foldUsageJsonLine('codex', state, seenMessageIds, line);
+    },
+    onError: (error) => { scanError = error; },
+  });
+  if (!scanned) {
+    logger.error(`Failed to read oversized Codex transcript tail ${path}: ${scanError instanceof Error ? scanError.message : String(scanError)}`);
+    usageFileCache.delete(key);
+    return null;
+  }
+  const completeBytes = scanned.newOffset - baseOffset;
+
+  let previewAgg = state;
+  const tailText = scanned.pendingTail.trim();
+  const pendingTailIsInitialResidualLine = dropInitialResidualLine && !droppedInitialResidualLine;
+  if (tailText && !pendingTailIsInitialResidualLine) {
+    previewAgg = cloneAggregate(state);
+    foldUsageText('codex', previewAgg, new Set(seenMessageIds), tailText);
+  }
+
+  const result = finalizeTokenUsage(previewAgg);
+  if (pendingTailIsInitialResidualLine) {
+    // The bounded window starts in the middle of a JSONL record and no newline
+    // has arrived yet. Do not persist `baseOffset`: if the writer later appends
+    // only '\n', that residual suffix would otherwise become a fake complete
+    // line on the incremental path.
+    return cached && !reuseCachedOffset
+      ? { agg: cached.previewAgg, result: cached.result }
+      : { agg: previewAgg, result };
+  }
+  if (!aggregateHasCodexUsage(previewAgg) && cached && !reuseCachedOffset) {
+    return { agg: cached.previewAgg, result: cached.result };
+  }
+
+  ensureUsageFileCacheCapacity(key);
+  usageFileCache.set(key, {
+    mtimeMs: st.mtimeMs,
+    size: st.size,
+    offset: baseOffset + completeBytes,
+    state,
+    seenMessageIds,
+    previewAgg,
+    result,
+    parsedAtMs: now,
+  });
+  return { agg: previewAgg, result };
 }
 
 function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, opts?: { fresh?: boolean }): UsageReadResult | null {
@@ -543,6 +672,10 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, op
     }
   }
 
+  if (st.size > MAX_USAGE_TRANSCRIPT_BYTES && kind === 'codex') {
+    return readOversizedCodexTokenAggregateCached(key, path, st, cached, now);
+  }
+
   if (st.size > MAX_USAGE_TRANSCRIPT_BYTES) {
     // Warn once per transcript, not per observed size: an actively-growing
     // oversized file would otherwise re-warn and leak a Set entry every reparse.
@@ -557,15 +690,11 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, op
     return { agg: newTokenUsageAggregate(), result: null };
   }
 
-  if (usageFileCache.size >= USAGE_FILE_CACHE_MAX_ENTRIES && !usageFileCache.has(key)) {
-    const oldest = usageFileCache.keys().next().value;
-    if (oldest !== undefined) usageFileCache.delete(oldest);
-  }
-
   if (kind === 'aiden') {
     // Checkpoints are rewritten whole — nothing incremental to exploit.
     const result = readTokenUsageFromAidenCheckpoint(path);
     const blank = newTokenUsageAggregate();
+    ensureUsageFileCacheCapacity(key);
     usageFileCache.set(key, {
       mtimeMs: st.mtimeMs,
       size: st.size,
@@ -618,6 +747,7 @@ function readSessionTokenAggregateCached(path: string, kind: CachedUsageKind, op
   }
 
   const result = finalizeTokenUsage(previewAgg);
+  ensureUsageFileCacheCapacity(key);
   usageFileCache.set(key, {
     mtimeMs: st.mtimeMs,
     size: st.size,

--- a/src/core/cost-calculator.ts
+++ b/src/core/cost-calculator.ts
@@ -10,7 +10,7 @@ import {
   cachedTranscriptPathLookup,
   resolveSessionTranscriptPath,
 } from '../services/transcript-resolver.js';
-import { scanJsonlFromFd, scanJsonlFromOffset } from '../services/jsonl-cursor.js';
+import { scanJsonlFromFd, scanJsonlFromOffset, type JsonlCursor } from '../services/jsonl-cursor.js';
 import {
   isMeaningfulQueuedCommand,
   isMeaningfulUserEvent,
@@ -522,11 +522,20 @@ const USAGE_REPARSE_MIN_INTERVAL_MS = 15_000;
  *  scan pathological multi-GB transcripts. */
 export const MAX_USAGE_TRANSCRIPT_BYTES = 64 * 1024 * 1024;
 /** Codex token_count events are cumulative snapshots, so an oversized cold
- *  restore only needs a bounded tail window to recover the latest usage card.
- *  Keep this tight: it is a synchronous dashboard read path, and real 150MiB+
- *  rollouts have many token_count snapshots in the last 4MiB. */
+ *  restore starts from a bounded tail window and recovers the latest usage
+ *  card from it. Real 150MiB+ rollouts almost always carry a token_count
+ *  snapshot in the last 4MiB, so this window is the common-case fast path. */
 export const CODEX_USAGE_TRANSCRIPT_TAIL_BYTES = 4 * 1024 * 1024;
 const CODEX_USAGE_REPLAY_BYTES = 4 * 1024 * 1024;
+/** When a single huge turn (e.g. one giant tool output) pushes the latest
+ *  token_count snapshot out of the first tail window, widen the window one
+ *  step at a time and re-scan until both the cumulative and context metrics
+ *  are recovered. This keeps the card showing the TRUE latest usage instead of
+ *  collapsing to null. Bounded so the synchronous dashboard read never walks an
+ *  unbounded prefix: past this budget we stop widening and fail closed (yield
+ *  whatever the bounded window found, without inheriting a possibly-stale value
+ *  across an unverifiable generation boundary). */
+export const CODEX_USAGE_MAX_BACKSCAN_BYTES = 32 * 1024 * 1024;
 
 /** Aiden checkpoint paths move as the session progresses (latest.json points
  *  at a new checkpoint id per turn), so positive hits expire quickly too. */
@@ -597,6 +606,13 @@ function isJsonlLineBoundaryFd(fd: number, offset: number): boolean {
 
 function aggregateHasCodexUsage(agg: TokenUsageAggregate): boolean {
   return !!agg.latestCodexUsage || !!agg.latestContextUsage;
+}
+
+/** Both independent Codex metrics recovered. Used to decide when a widening
+ *  back-scan can stop: they may live on different lines, so a window that only
+ *  caught one is not yet complete. */
+function aggregateHasAllCodexMetrics(agg: TokenUsageAggregate): boolean {
+  return !!agg.latestCodexUsage && !!agg.latestContextUsage;
 }
 
 interface UsageReadResult {
@@ -690,8 +706,7 @@ function readCodexTokenAggregateCached(
   }
   let state: TokenUsageAggregate;
   let seenMessageIds: Set<string>;
-  let baseOffset: number;
-  let dropInitialResidualLine = false;
+  let baseOffset = 0;
   const previousAgg = cached?.previewAgg ? cloneAggregate(cached.previewAgg) : undefined;
   const sameOpenFileAsCache = !!cached
     && cached.dev === fdStat.dev
@@ -716,45 +731,113 @@ function readCodexTokenAggregateCached(
   const replaySpan = replayBaseOffset === null ? Number.POSITIVE_INFINITY : fdStat.size - replayBaseOffset;
   const reuseTrackedReplay = replayBaseOffset !== null && replaySpan <= CODEX_USAGE_REPLAY_BYTES;
 
+  // Scan one [from, size) window into a fresh aggregate. Codex token_count is a
+  // cumulative snapshot (latest wins), so a wider window that re-includes older
+  // lines re-folds them first and the newest snapshot still overwrites last —
+  // scanning from a fresh state each time keeps that correctness without any
+  // double counting. Returns null only on read failure.
+  interface WindowScan {
+    state: TokenUsageAggregate;
+    seenMessageIds: Set<string>;
+    scanned: JsonlCursor;
+    completeBytes: number;
+    previewAgg: TokenUsageAggregate;
+    pendingTailIsInitialResidualLine: boolean;
+  }
+  const scanFromWindow = (from: number, knownLineBoundary: boolean): WindowScan | null => {
+    const windowState = newTokenUsageAggregate();
+    const windowSeen = new Set<string>();
+    // Replay/full-file reads start on a proven line boundary (offset 0, or an
+    // offset already validated by isJsonlLineBoundaryFd), so they need no extra
+    // probe. Only a widened bounded-tail window lands at an arbitrary byte and
+    // must drop the partial leading record.
+    let dropResidual = !knownLineBoundary && from > 0 && !isJsonlLineBoundaryFd(fd, from);
+    let droppedResidual = false;
+    let windowScanError: unknown = null;
+    const windowScanned = scanJsonlFromFd(fd, from, {
+      endOffset: fdStat.size,
+      onLine: (line, lineStart) => {
+        if (dropResidual) {
+          dropResidual = false;
+          droppedResidual = true;
+          return;
+        }
+        foldUsageJsonLine('codex', windowState, windowSeen, line, lineStart);
+      },
+      onError: (error) => { windowScanError = error; },
+    });
+    if (!windowScanned) {
+      logger.error(`Failed to read Codex transcript slice ${path}: ${windowScanError instanceof Error ? windowScanError.message : String(windowScanError)}`);
+      return null;
+    }
+    let windowPreview = windowState;
+    const windowTail = windowScanned.pendingTail.trim();
+    const residualTailPending = dropResidual && !droppedResidual;
+    if (windowTail && !residualTailPending) {
+      windowPreview = cloneAggregate(windowState);
+      foldUsageText('codex', windowPreview, new Set(windowSeen), windowTail);
+    }
+    return {
+      state: windowState,
+      seenMessageIds: windowSeen,
+      scanned: windowScanned,
+      completeBytes: windowScanned.newOffset - from,
+      previewAgg: windowPreview,
+      pendingTailIsInitialResidualLine: residualTailPending,
+    };
+  };
+
+  let scanned: JsonlCursor;
+  let completeBytes: number;
+  let previewAgg: TokenUsageAggregate;
+  let pendingTailIsInitialResidualLine: boolean;
+
   if (reuseTrackedReplay) {
-    state = newTokenUsageAggregate();
-    seenMessageIds = new Set();
     baseOffset = replayBaseOffset;
+    const win = scanFromWindow(baseOffset, true);
+    if (!win) {
+      closeSync(fd);
+      usageFileCache.delete(key);
+      return null;
+    }
+    ({ state, seenMessageIds, scanned, completeBytes, previewAgg, pendingTailIsInitialResidualLine } = win);
+  } else if (!oversized) {
+    baseOffset = 0;
+    const win = scanFromWindow(baseOffset, true);
+    if (!win) {
+      closeSync(fd);
+      usageFileCache.delete(key);
+      return null;
+    }
+    ({ state, seenMessageIds, scanned, completeBytes, previewAgg, pendingTailIsInitialResidualLine } = win);
   } else {
-    state = newTokenUsageAggregate();
-    seenMessageIds = new Set();
-    baseOffset = oversized ? Math.max(0, fdStat.size - CODEX_USAGE_TRANSCRIPT_TAIL_BYTES) : 0;
-    dropInitialResidualLine = oversized && !isJsonlLineBoundaryFd(fd, baseOffset);
-  }
-
-  let scanError: unknown = null;
-  let droppedInitialResidualLine = false;
-  const scanned = scanJsonlFromFd(fd, baseOffset, {
-    endOffset: fdStat.size,
-    onLine: (line, lineStart) => {
-      if (dropInitialResidualLine) {
-        dropInitialResidualLine = false;
-        droppedInitialResidualLine = true;
-        return;
+    // Oversized cold/bounded read: start at the last tail window and widen it
+    // one step at a time until BOTH independent metrics are recovered (they can
+    // sit on different lines) — or we hit the file head or the back-scan budget.
+    // This recovers the true latest usage even when a single >4MiB turn pushed
+    // the newest snapshot out of the first window, instead of collapsing to null.
+    let win: WindowScan | null = null;
+    let step = 0;
+    for (;;) {
+      const windowBytes = CODEX_USAGE_TRANSCRIPT_TAIL_BYTES * (step + 1);
+      baseOffset = Math.max(0, fdStat.size - windowBytes);
+      const attempt = scanFromWindow(baseOffset, false);
+      if (!attempt) {
+        closeSync(fd);
+        usageFileCache.delete(key);
+        return null;
       }
-      foldUsageJsonLine('codex', state, seenMessageIds, line, lineStart);
-    },
-    onError: (error) => { scanError = error; },
-  });
-  if (!scanned) {
-    logger.error(`Failed to read Codex transcript slice ${path}: ${scanError instanceof Error ? scanError.message : String(scanError)}`);
-    closeSync(fd);
-    usageFileCache.delete(key);
-    return null;
-  }
-  const completeBytes = scanned.newOffset - baseOffset;
-
-  let previewAgg = state;
-  const tailText = scanned.pendingTail.trim();
-  const pendingTailIsInitialResidualLine = dropInitialResidualLine && !droppedInitialResidualLine;
-  if (tailText && !pendingTailIsInitialResidualLine) {
-    previewAgg = cloneAggregate(state);
-    foldUsageText('codex', previewAgg, new Set(seenMessageIds), tailText);
+      win = attempt;
+      if (
+        aggregateHasAllCodexMetrics(attempt.previewAgg)
+        || baseOffset === 0
+        || windowBytes >= CODEX_USAGE_MAX_BACKSCAN_BYTES
+      ) {
+        break;
+      }
+      step += 1;
+    }
+    ({ state, seenMessageIds, scanned, completeBytes, previewAgg, pendingTailIsInitialResidualLine } = win);
   }
 
   const nextOffset = pendingTailIsInitialResidualLine ? baseOffset : baseOffset + completeBytes;

--- a/src/services/jsonl-cursor.ts
+++ b/src/services/jsonl-cursor.ts
@@ -7,7 +7,6 @@ import {
   readSync,
   statSync,
 } from 'node:fs';
-import { StringDecoder } from 'node:string_decoder';
 
 export interface JsonlCursor {
   newOffset: number;
@@ -35,8 +34,7 @@ export function scanJsonlFromOffset(path: string, fromOffset: number, opts: Json
   let fd: number | null = null;
   let nextReadOffset = Math.max(0, fromOffset);
   let lineStartOffset = nextReadOffset;
-  let carry = '';
-  const decoder = new StringDecoder('utf8');
+  let carry = Buffer.alloc(0);
   const buf = Buffer.alloc(chunkSize);
 
   try {
@@ -55,27 +53,23 @@ export function scanJsonlFromOffset(path: string, fromOffset: number, opts: Json
       if (bytesRead <= 0) break;
       nextReadOffset += bytesRead;
 
-      const decoded = decoder.write(buf.subarray(0, bytesRead));
-      const text = carry + decoded;
+      const chunk = Buffer.from(buf.subarray(0, bytesRead));
+      const bytes = carry.length > 0 ? Buffer.concat([carry, chunk]) : chunk;
       let searchFrom = 0;
-      let currentLineStart = lineStartOffset;
-      // carry never contains '\n', so newlines can only appear at or after
-      // carry.length — starting there avoids re-scanning a growing carry on
-      // every chunk when a single record spans many chunks.
-      let nl = text.indexOf('\n', carry.length);
+      const currentBufferStartOffset = lineStartOffset;
+      let nl = bytes.indexOf(0x0a, carry.length);
       while (nl >= 0) {
-        const line = text.slice(searchFrom, nl);
-        opts.onLine?.(line, currentLineStart);
-        currentLineStart += Buffer.byteLength(line, 'utf8') + 1;
+        const line = bytes.subarray(searchFrom, nl);
+        opts.onLine?.(line.toString('utf8'), currentBufferStartOffset + searchFrom);
         searchFrom = nl + 1;
-        nl = text.indexOf('\n', searchFrom);
+        nl = bytes.indexOf(0x0a, searchFrom);
       }
-      carry = text.slice(searchFrom);
-      lineStartOffset = currentLineStart;
+      carry = Buffer.from(bytes.subarray(searchFrom));
+      lineStartOffset = currentBufferStartOffset + searchFrom;
     }
     return {
       newOffset: lineStartOffset,
-      pendingTail: carry + decoder.end(),
+      pendingTail: carry.toString('utf8'),
     };
   } catch (error) {
     opts.onError?.(error);

--- a/src/services/jsonl-cursor.ts
+++ b/src/services/jsonl-cursor.ts
@@ -23,28 +23,16 @@ export interface JsonlScanOptions {
 const TAIL_PROBE_BYTES = 64 * 1024;
 const JSONL_SCAN_CHUNK_BYTES = 64 * 1024;
 
-/**
- * Scan an append-only JSONL file from `fromOffset` using bounded-memory chunked
- * reads. Calls `onLine` for each COMPLETE line, and returns the durable byte
- * frontier plus any trailing partial line text left after the last newline.
- */
-export function scanJsonlFromOffset(path: string, fromOffset: number, opts: JsonlScanOptions = {}): JsonlCursor | null {
+function scanJsonlFromOpenFd(fd: number, fromOffset: number, opts: JsonlScanOptions = {}): JsonlCursor | null {
   const endOffset = opts.endOffset;
   const chunkSize = Math.max(1, opts.chunkSize ?? JSONL_SCAN_CHUNK_BYTES);
-  let fd: number | null = null;
   let nextReadOffset = Math.max(0, fromOffset);
   let lineStartOffset = nextReadOffset;
-  let carry = Buffer.alloc(0);
+  let lineBuffers: Buffer[] = [];
+  let lineBytes = 0;
   const buf = Buffer.alloc(chunkSize);
 
   try {
-    // O_NONBLOCK prevents an untrusted transcript path swapped to a FIFO from
-    // hanging the daemon. Validate the opened fd (rather than only the path)
-    // so directories/devices and the stat→open replacement window fail closed.
-    fd = openSync(path, constants.O_RDONLY | (constants.O_NONBLOCK ?? 0));
-    if (!fstatSync(fd).isFile()) {
-      throw new Error(`JSONL source is not a regular file: ${path}`);
-    }
     while (true) {
       const remaining = endOffset === undefined ? chunkSize : endOffset - nextReadOffset;
       if (remaining <= 0) break;
@@ -53,24 +41,66 @@ export function scanJsonlFromOffset(path: string, fromOffset: number, opts: Json
       if (bytesRead <= 0) break;
       nextReadOffset += bytesRead;
 
-      const chunk = Buffer.from(buf.subarray(0, bytesRead));
-      const bytes = carry.length > 0 ? Buffer.concat([carry, chunk]) : chunk;
       let searchFrom = 0;
-      const currentBufferStartOffset = lineStartOffset;
-      let nl = bytes.indexOf(0x0a, carry.length);
+      let nl = buf.subarray(0, bytesRead).indexOf(0x0a);
       while (nl >= 0) {
-        const line = bytes.subarray(searchFrom, nl);
-        opts.onLine?.(line.toString('utf8'), currentBufferStartOffset + searchFrom);
+        const segment = Buffer.from(buf.subarray(searchFrom, nl));
+        if (segment.length > 0) {
+          lineBuffers.push(segment);
+          lineBytes += segment.length;
+        }
+        const line = lineBuffers.length === 1
+          ? lineBuffers[0]
+          : Buffer.concat(lineBuffers, lineBytes);
+        opts.onLine?.(line.toString('utf8'), lineStartOffset);
         searchFrom = nl + 1;
-        nl = bytes.indexOf(0x0a, searchFrom);
+        lineStartOffset += lineBytes + 1;
+        lineBuffers = [];
+        lineBytes = 0;
+        nl = buf.subarray(searchFrom, bytesRead).indexOf(0x0a);
+        if (nl >= 0) nl += searchFrom;
       }
-      carry = Buffer.from(bytes.subarray(searchFrom));
-      lineStartOffset = currentBufferStartOffset + searchFrom;
+      if (searchFrom < bytesRead) {
+        const segment = Buffer.from(buf.subarray(searchFrom, bytesRead));
+        lineBuffers.push(segment);
+        lineBytes += segment.length;
+      }
     }
     return {
       newOffset: lineStartOffset,
-      pendingTail: carry.toString('utf8'),
+      pendingTail: lineBuffers.length === 0
+        ? ''
+        : (lineBuffers.length === 1 ? lineBuffers[0] : Buffer.concat(lineBuffers, lineBytes)).toString('utf8'),
     };
+  } catch (error) {
+    opts.onError?.(error);
+    return null;
+  }
+}
+
+/** Scan a JSONL stream from a caller-owned regular file descriptor. The fd is
+ *  never closed here; ownership stays with the caller. */
+export function scanJsonlFromFd(fd: number, fromOffset: number, opts: JsonlScanOptions = {}): JsonlCursor | null {
+  return scanJsonlFromOpenFd(fd, fromOffset, opts);
+}
+
+/**
+ * Scan an append-only JSONL file from `fromOffset` using chunked reads. Calls
+ * `onLine` for each COMPLETE line, and returns the durable byte frontier plus
+ * any trailing partial line text left after the last newline. One logical line
+ * is accumulated linearly, so memory remains proportional to that line length.
+ */
+export function scanJsonlFromOffset(path: string, fromOffset: number, opts: JsonlScanOptions = {}): JsonlCursor | null {
+  let fd: number | null = null;
+  try {
+    // O_NONBLOCK prevents an untrusted transcript path swapped to a FIFO from
+    // hanging the daemon. Validate the opened fd (rather than only the path)
+    // so directories/devices and the stat→open replacement window fail closed.
+    fd = openSync(path, constants.O_RDONLY | (constants.O_NONBLOCK ?? 0));
+    if (!fstatSync(fd).isFile()) {
+      throw new Error(`JSONL source is not a regular file: ${path}`);
+    }
+    return scanJsonlFromOpenFd(fd, fromOffset, opts);
   } catch (error) {
     opts.onError?.(error);
     return null;

--- a/test/cost-calculator-cache.test.ts
+++ b/test/cost-calculator-cache.test.ts
@@ -12,10 +12,11 @@ vi.mock('node:fs', async (importOriginal) => {
   return {
     ...original,
     readFileSync: vi.fn(original.readFileSync),
+    readSync: vi.fn(original.readSync),
   };
 });
 
-import { mkdtempSync, writeFileSync, appendFileSync, rmSync, readFileSync, truncateSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, appendFileSync, rmSync, readFileSync, readSync, statSync, truncateSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -23,12 +24,20 @@ vi.mock('../src/utils/logger.js', () => ({
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 
+vi.mock('../src/services/codex-transcript.js', () => ({
+  findCodexRolloutBySessionId: vi.fn(),
+  findCodexSessionIdByBotmuxSessionId: vi.fn(),
+}));
+
 import {
+  CODEX_USAGE_TRANSCRIPT_TAIL_BYTES,
   MAX_USAGE_TRANSCRIPT_BYTES,
+  getSessionUsageSnapshot,
   readSessionTokenUsageFile,
   __resetSessionUsageCachesForTest,
 } from '../src/core/cost-calculator.js';
 import { logger } from '../src/utils/logger.js';
+import { findCodexRolloutBySessionId } from '../src/services/codex-transcript.js';
 
 function claudeLine(id: string | null, input: number, output: number): string {
   return JSON.stringify({
@@ -41,14 +50,63 @@ function claudeLine(id: string | null, input: number, output: number): string {
   });
 }
 
-function codexCountLine(input: number, output: number, cacheRead = 0): string {
+function codexCountLine(
+  input: number,
+  output: number,
+  cacheRead = 0,
+  context?: { used: number; window: number },
+): string {
   return JSON.stringify({
     type: 'event_msg',
     payload: {
       type: 'token_count',
-      info: { total_token_usage: { input_tokens: input, output_tokens: output, cached_input_tokens: cacheRead } },
+      info: {
+        total_token_usage: { input_tokens: input, output_tokens: output, cached_input_tokens: cacheRead },
+        ...(context
+          ? {
+              last_token_usage: { total_tokens: context.used, input_tokens: context.used - output, output_tokens: output },
+              model_context_window: context.window,
+            }
+          : {}),
+      },
     },
   });
+}
+
+function codexModelLine(model: string): string {
+  return JSON.stringify({ type: 'turn_context', payload: { model } });
+}
+
+function writeSparsePrefix(path: string, size: number, lastByte: string): void {
+  writeFileSync(path, '');
+  truncateSync(path, size - 1);
+  appendFileSync(path, lastByte);
+}
+
+function codexSnapshotAtTail(path: string, line: string): { baseOffset: number; finalSize: number } {
+  const finalSize = MAX_USAGE_TRANSCRIPT_BYTES + CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 1;
+  const baseOffset = finalSize - CODEX_USAGE_TRANSCRIPT_TAIL_BYTES;
+  const lineBytes = Buffer.byteLength(line);
+  expect(lineBytes).toBeLessThan(CODEX_USAGE_TRANSCRIPT_TAIL_BYTES);
+  truncateSync(path, baseOffset - 1);
+  appendFileSync(path, '\n');
+  appendFileSync(path, line);
+  appendFileSync(path, Buffer.alloc(CODEX_USAGE_TRANSCRIPT_TAIL_BYTES - lineBytes, 0x20));
+  return { baseOffset, finalSize };
+}
+
+function expectBoundedTailRead(baseOffset: number): void {
+  const calls = vi.mocked(readSync).mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  const positions = calls.map((call) => Number(call[4])).filter(Number.isFinite);
+  expect(Math.min(...positions)).toBe(baseOffset - 1);
+  expect(calls.some((call) => Number(call[3]) === 1 && Number(call[4]) === baseOffset - 1)).toBe(true);
+  const requestedBytes = calls.reduce((sum, call) => sum + Number(call[3]), 0);
+  expect(requestedBytes).toBeLessThanOrEqual(CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 1);
+}
+
+function fileSize(path: string): number {
+  return statSync(path).size;
 }
 
 let dir: string;
@@ -60,7 +118,9 @@ beforeEach(() => {
   now = 1_000_000_000;
   vi.spyOn(Date, 'now').mockImplementation(() => now);
   vi.mocked(readFileSync).mockClear();
+  vi.mocked(readSync).mockClear();
   vi.mocked(logger.warn).mockClear();
+  vi.mocked(findCodexRolloutBySessionId).mockReset();
 });
 
 afterEach(() => {
@@ -199,6 +259,172 @@ describe('readSessionTokenUsageFile caching', () => {
     });
   });
 
+  it('cold reads an oversized Codex transcript from a bounded tail window', () => {
+    const p = join(dir, 'oversized-codex.jsonl');
+    writeFileSync(p, '');
+    truncateSync(p, MAX_USAGE_TRANSCRIPT_BYTES + 1);
+    appendFileSync(p, [
+      '',
+      codexModelLine('gpt-5.5-codex'),
+      codexCountLine(3_739_570, 23_299, 3_563_008, { used: 160_240, window: 258_400 }),
+      '',
+    ].join('\n'));
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toEqual({
+      context: { usedTokens: 160_240, windowTokens: 258_400, percentUsed: 62 },
+      tokens: {
+        in: 3_739_570,
+        out: 23_299,
+        inputTokens: 176_562,
+        outputTokens: 23_299,
+        cacheReadTokens: 3_563_008,
+        cacheCreateTokens: 0,
+        model: 'gpt-5.5-codex',
+        turns: 0,
+      },
+      turnTokens: null,
+    });
+    expect(readFileSync).not.toHaveBeenCalled();
+    expectBoundedTailRead(fileSize(p) - CODEX_USAGE_TRANSCRIPT_TAIL_BYTES);
+  });
+
+  it('keeps the first Codex tail record when the bounded start is on a line boundary', () => {
+    const p = join(dir, 'codex-tail-line-boundary.jsonl');
+    const firstTailLine = `${codexCountLine(400, 50, 25, { used: 120, window: 1_000 })}\n`;
+    const paddingBytes = CODEX_USAGE_TRANSCRIPT_TAIL_BYTES - Buffer.byteLength(firstTailLine);
+    expect(paddingBytes).toBeGreaterThan(0);
+    writeSparsePrefix(p, MAX_USAGE_TRANSCRIPT_BYTES + 1, '\n');
+    appendFileSync(p, firstTailLine);
+    appendFileSync(p, Buffer.alloc(paddingBytes, 0x20));
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 120, windowTokens: 1_000, percentUsed: 12 },
+      tokens: { in: 400, out: 50, inputTokens: 375, cacheReadTokens: 25 },
+      turnTokens: null,
+    });
+  });
+
+  it('drops the first Codex tail record when the bounded start is inside a line', () => {
+    const p = join(dir, 'codex-tail-mid-line.jsonl');
+    const residualLine = `${codexCountLine(999_999, 999, 0, { used: 999, window: 1_000 })}\n`;
+    const paddingBytes = CODEX_USAGE_TRANSCRIPT_TAIL_BYTES - Buffer.byteLength(residualLine);
+    expect(paddingBytes).toBeGreaterThan(0);
+    writeSparsePrefix(p, MAX_USAGE_TRANSCRIPT_BYTES + 1, 'x');
+    appendFileSync(p, residualLine);
+    appendFileSync(p, Buffer.alloc(paddingBytes, 0x20));
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toEqual({ context: null, tokens: null, turnTokens: null });
+  });
+
+  it('does not turn an unterminated initial residual tail into a Codex snapshot after only a newline append', () => {
+    const p = join(dir, 'codex-tail-unterminated-residual.jsonl');
+    const residualJson = codexCountLine(999_999, 999, 0, { used: 999, window: 1_000 });
+    const paddingBytes = CODEX_USAGE_TRANSCRIPT_TAIL_BYTES - Buffer.byteLength(residualJson);
+    expect(paddingBytes).toBeGreaterThan(0);
+    writeSparsePrefix(p, MAX_USAGE_TRANSCRIPT_BYTES + 1, 'x');
+    appendFileSync(p, residualJson);
+    appendFileSync(p, Buffer.alloc(paddingBytes, 0x20));
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toEqual({ context: null, tokens: null, turnTokens: null });
+
+    appendFileSync(p, '\n');
+    now += 20_000;
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toEqual({ context: null, tokens: null, turnTokens: null });
+  });
+
+  it('re-bootstraps oversized Codex transcripts when the unread cache delta exceeds the tail budget', () => {
+    const p = join(dir, 'codex-cache-large-delta.jsonl');
+    writeFileSync(p, `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 30 },
+      tokens: { in: 100, out: 10 },
+    });
+
+    vi.mocked(readSync).mockClear();
+    const latestLine = `${codexCountLine(500, 60, 200, { used: 240, window: 1_000 })}\n`;
+    const { baseOffset } = codexSnapshotAtTail(p, latestLine);
+    now += 20_000;
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 240, windowTokens: 1_000, percentUsed: 24 },
+      tokens: { in: 500, out: 60, inputTokens: 300, cacheReadTokens: 200 },
+    });
+    expectBoundedTailRead(baseOffset);
+  });
+
+  it('continues incrementally after an oversized Codex cold tail bootstrap when the append is small', () => {
+    const p = join(dir, 'codex-small-append-after-tail.jsonl');
+    writeSparsePrefix(p, MAX_USAGE_TRANSCRIPT_BYTES + 1, '\n');
+    appendFileSync(p, `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 30 },
+      tokens: { in: 100, out: 10 },
+    });
+
+    vi.mocked(readSync).mockClear();
+    const appended = `${codexCountLine(150, 20, 50, { used: 70, window: 1_000 })}\n`;
+    appendFileSync(p, appended);
+    now += 20_000;
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 70, windowTokens: 1_000, percentUsed: 7 },
+      tokens: { in: 150, out: 20, inputTokens: 100, cacheReadTokens: 50 },
+    });
+    const requestedBytes = vi.mocked(readSync).mock.calls.reduce((sum, call) => sum + Number(call[3]), 0);
+    expect(requestedBytes).toBeLessThanOrEqual(Buffer.byteLength(appended));
+  });
+
   it('skips oversized transcripts instead of scanning them from byte zero', () => {
     const p = join(dir, 'oversized.jsonl');
     writeFileSync(p, '');
@@ -232,6 +458,26 @@ describe('readSessionTokenUsageFile caching', () => {
     expect(readSessionTokenUsageFile(p, 'coco', { fresh: true })).toBeNull();
 
     expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not evict unrelated cached entries for a new non-Codex oversized transcript', () => {
+    const firstPath = join(dir, 'cached-0.jsonl');
+    writeFileSync(firstPath, `${claudeLine('msg_0', 1, 1)}\n`);
+    const first = readSessionTokenUsageFile(firstPath, 'claude');
+    expect(first).toMatchObject({ turns: 1, inputTokens: 1 });
+
+    for (let i = 1; i < 512; i++) {
+      const p = join(dir, `cached-${i}.jsonl`);
+      writeFileSync(p, `${claudeLine(`msg_${i}`, i + 1, 1)}\n`);
+      expect(readSessionTokenUsageFile(p, 'claude')).toMatchObject({ turns: 1 });
+    }
+
+    const oversized = join(dir, 'new-oversized-coco.jsonl');
+    writeFileSync(oversized, '');
+    truncateSync(oversized, MAX_USAGE_TRANSCRIPT_BYTES + 1);
+    expect(readSessionTokenUsageFile(oversized, 'coco')).toBeNull();
+
+    expect(readSessionTokenUsageFile(firstPath, 'claude')).toBe(first);
   });
 
   it('returns null and drops the cache entry when the file disappears', () => {

--- a/test/cost-calculator-cache.test.ts
+++ b/test/cost-calculator-cache.test.ts
@@ -7,13 +7,6 @@
  * Run:  pnpm vitest run test/cost-calculator-cache.test.ts
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-vi.mock('node:crypto', async (importOriginal) => {
-  const original = await importOriginal<typeof import('node:crypto')>();
-  return {
-    ...original,
-    createHash: vi.fn(original.createHash),
-  };
-});
 vi.mock('node:fs', async (importOriginal) => {
   const original = await importOriginal<typeof import('node:fs')>();
   return {
@@ -26,7 +19,6 @@ vi.mock('node:fs', async (importOriginal) => {
   };
 });
 
-import { createHash } from 'node:crypto';
 import { closeSync, constants, fstatSync, mkdtempSync, openSync, writeFileSync, appendFileSync, rmSync, readFileSync, readSync, renameSync, statSync, truncateSync, utimesSync, writeSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -43,13 +35,14 @@ vi.mock('../src/services/codex-transcript.js', () => ({
 import {
   CODEX_USAGE_TRANSCRIPT_TAIL_BYTES,
   MAX_USAGE_TRANSCRIPT_BYTES,
-  USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES,
   getSessionUsageSnapshot,
   readSessionTokenUsageFile,
   __resetSessionUsageCachesForTest,
 } from '../src/core/cost-calculator.js';
 import { logger } from '../src/utils/logger.js';
 import { findCodexRolloutBySessionId } from '../src/services/codex-transcript.js';
+
+const TEST_FRONTIER_BYTES = 64;
 
 function claudeLine(id: string | null, input: number, output: number): string {
   return JSON.stringify({
@@ -153,22 +146,39 @@ function expectBoundedTailRead(baseOffset: number): void {
   expect(calls.some((call) => Number(call[3]) === 1 && Number(call[4]) === baseOffset - 1)).toBe(true);
   const requestedBytes = calls.reduce((sum, call) => sum + Number(call[3]), 0);
   expect(requestedBytes).toBeLessThanOrEqual(
-    CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 1 + USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES,
+    CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 1,
   );
 }
 
-function expectLargeDeltaBoundedTailRead(baseOffset: number, sourceValidationBytes: number): void {
+function expectLargeDeltaBoundedTailRead(baseOffset: number): void {
   const calls = vi.mocked(readSync).mock.calls;
   expect(calls.length).toBeGreaterThan(0);
   expect(calls.some((call) => Number(call[3]) === 1 && Number(call[4]) === baseOffset - 1)).toBe(true);
   const requestedBytes = calls.reduce((sum, call) => sum + Number(call[3]), 0);
   expect(requestedBytes).toBeLessThanOrEqual(
-    sourceValidationBytes
-    + USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES
-    + 1
-    + CODEX_USAGE_TRANSCRIPT_TAIL_BYTES
-    + USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES,
+    1
+    + CODEX_USAGE_TRANSCRIPT_TAIL_BYTES,
   );
+}
+
+function expectCodexTrackedReplayRead(replayOffset: number, replayBytes: number): void {
+  const calls = vi.mocked(readSync).mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  const requestedBytes = calls.reduce((sum, call) => sum + Number(call[3]), 0);
+  if (replayOffset > 0) {
+    expect(calls.some((call) => Number(call[3]) === 1 && Number(call[4]) === replayOffset - 1)).toBe(true);
+  }
+  const positions = calls.map((call) => Number(call[4])).filter(Number.isFinite);
+  expect(Math.min(...positions)).toBe(replayOffset > 0 ? replayOffset - 1 : replayOffset);
+  expect(calls.some((call) => Number(call[4]) === replayOffset && Number(call[3]) > 1)).toBe(true);
+  expect(requestedBytes).toBeLessThanOrEqual(
+    (replayOffset > 0 ? 1 : 0)
+    + replayBytes,
+  );
+}
+
+function requestedBytes(): number {
+  return vi.mocked(readSync).mock.calls.reduce((sum, call) => sum + Number(call[3]), 0);
 }
 
 function fileSize(path: string): number {
@@ -208,7 +218,6 @@ beforeEach(() => {
   now = 1_000_000_000;
   vi.spyOn(Date, 'now').mockImplementation(() => now);
   vi.mocked(fstatSync).mockClear();
-  vi.mocked(createHash).mockClear();
   vi.mocked(openSync).mockClear();
   vi.mocked(readFileSync).mockClear();
   vi.mocked(readSync).mockClear();
@@ -407,13 +416,7 @@ describe('readSessionTokenUsageFile caching', () => {
       },
       turnTokens: null,
     });
-    const requestedBytes = vi.mocked(readSync).mock.calls.reduce((sum, call) => sum + Number(call[3]), 0);
-    expect(requestedBytes).toBeLessThanOrEqual(
-      Buffer.byteLength(initialLine)
-      + USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES
-      + Buffer.byteLength(appended)
-      + USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES,
-    );
+    expectCodexTrackedReplayRead(0, fileSize(p));
   });
 
   it('cold reads an oversized Codex transcript from a bounded tail window', () => {
@@ -451,7 +454,7 @@ describe('readSessionTokenUsageFile caching', () => {
     expectBoundedTailRead(fileSize(p) - CODEX_USAGE_TRANSCRIPT_TAIL_BYTES);
   });
 
-  it('hashes Codex source records only for lines that update tracked metrics', () => {
+  it('ignores non-metric Codex lines while tracking metric source records', () => {
     const p = join(dir, 'codex-lazy-source-hash.jsonl');
     writeFileSync(p, [
       JSON.stringify({ type: 'event_msg', payload: { type: 'notice', message: 'ignored' } }),
@@ -466,9 +469,6 @@ describe('readSessionTokenUsageFile caching', () => {
       inputTokens: 80,
       cacheReadTokens: 20,
     });
-    expect(createHash).toHaveBeenCalledTimes(1);
-
-    vi.mocked(createHash).mockClear();
     const ignoredOnly = join(dir, 'codex-ignored-only.jsonl');
     writeFileSync(ignoredOnly, [
       JSON.stringify({ type: 'event_msg', payload: { type: 'notice', message: 'ignored' } }),
@@ -477,7 +477,6 @@ describe('readSessionTokenUsageFile caching', () => {
     ].join('\n'));
 
     expect(readSessionTokenUsageFile(ignoredOnly, 'codex', { fresh: true })).toBeNull();
-    expect(createHash).not.toHaveBeenCalled();
   });
 
   it('keeps the first Codex tail record when the bounded start is on a line boundary', () => {
@@ -556,7 +555,7 @@ describe('readSessionTokenUsageFile caching', () => {
     })).toEqual({ context: null, tokens: null, turnTokens: null });
   });
 
-  it('caches a no-snapshot Codex tail over an existing snapshot without enabling incremental reuse', () => {
+  it('does not inherit cached Codex metrics when a large tail has no snapshot', () => {
     const p = join(dir, 'codex-large-delta-no-snapshot.jsonl');
     writeOversizedCodexSnapshot(p, `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
     vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
@@ -577,10 +576,7 @@ describe('readSessionTokenUsageFile caching', () => {
       sessionId: 'botmux-sid',
       cliSessionId: 'codex-sid',
       fresh: true,
-    })).toMatchObject({
-      context: { usedTokens: 30 },
-      tokens: { in: 100, out: 10 },
-    });
+    })).toEqual({ context: null, tokens: null, turnTokens: null });
 
     vi.mocked(readSync).mockClear();
     expect(getSessionUsageSnapshot({
@@ -588,14 +584,11 @@ describe('readSessionTokenUsageFile caching', () => {
       sessionId: 'botmux-sid',
       cliSessionId: 'codex-sid',
       fresh: true,
-    })).toMatchObject({
-      context: { usedTokens: 30 },
-      tokens: { in: 100, out: 10 },
-    });
+    })).toEqual({ context: null, tokens: null, turnTokens: null });
     expect(vi.mocked(readSync)).not.toHaveBeenCalled();
   });
 
-  it('preserves cached cumulative tokens when a large Codex tail only has context', () => {
+  it('drops cached cumulative tokens when a large Codex tail only has context', () => {
     const p = join(dir, 'codex-context-only-large-delta.jsonl');
     writeOversizedCodexSnapshot(p, `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
     vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
@@ -619,15 +612,12 @@ describe('readSessionTokenUsageFile caching', () => {
       fresh: true,
     })).toMatchObject({
       context: { usedTokens: 240, windowTokens: 1_000, percentUsed: 24 },
-      tokens: { in: 100, out: 10, inputTokens: 80, cacheReadTokens: 20 },
+      tokens: null,
     });
-    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({
-      in: 100,
-      out: 10,
-    });
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toBeNull();
   });
 
-  it('preserves cached context when a large Codex tail only has cumulative tokens', () => {
+  it('drops cached context when a large Codex tail only has cumulative tokens', () => {
     const p = join(dir, 'codex-cumulative-only-large-delta.jsonl');
     writeOversizedCodexSnapshot(p, `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
     vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
@@ -650,7 +640,7 @@ describe('readSessionTokenUsageFile caching', () => {
       cliSessionId: 'codex-sid',
       fresh: true,
     })).toMatchObject({
-      context: { usedTokens: 30, windowTokens: 1_000, percentUsed: 3 },
+      context: null,
       tokens: { in: 500, out: 60, inputTokens: 300, cacheReadTokens: 200 },
     });
   });
@@ -713,7 +703,7 @@ describe('readSessionTokenUsageFile caching', () => {
       context: { usedTokens: 240, windowTokens: 1_000, percentUsed: 24 },
       tokens: { in: 500, out: 60, inputTokens: 300, cacheReadTokens: 200 },
     });
-    expectLargeDeltaBoundedTailRead(baseOffset, Buffer.byteLength(initialLine));
+    expectLargeDeltaBoundedTailRead(baseOffset);
   });
 
   it('continues incrementally after an oversized Codex cold tail bootstrap when the append is small', () => {
@@ -746,13 +736,8 @@ describe('readSessionTokenUsageFile caching', () => {
       context: { usedTokens: 70, windowTokens: 1_000, percentUsed: 7 },
       tokens: { in: 150, out: 20, inputTokens: 100, cacheReadTokens: 50 },
     });
-    const requestedBytes = vi.mocked(readSync).mock.calls.reduce((sum, call) => sum + Number(call[3]), 0);
-    expect(requestedBytes).toBeLessThanOrEqual(
-      Buffer.byteLength(initialLine)
-      + USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES
-      + Buffer.byteLength(appended)
-      + USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES,
-    );
+    const replayOffset = fileSize(p) - Buffer.byteLength(initialLine) - Buffer.byteLength(appended);
+    expectCodexTrackedReplayRead(replayOffset, fileSize(p) - replayOffset);
   });
 
   it('rebuilds Codex usage when a same-size transcript is rename-replaced', () => {
@@ -911,7 +896,7 @@ describe('readSessionTokenUsageFile caching', () => {
     let replaced = false;
     vi.mocked(readSync).mockImplementation((fd, buffer, offset, length, position) => {
       const bytesRead = (realReadSync as typeof readSync)(fd, buffer, offset, length, position);
-      if (!replaced && length === USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES) {
+      if (!replaced && length > 1) {
         renameSync(replacement, p);
         replaced = true;
       }
@@ -989,8 +974,8 @@ describe('readSessionTokenUsageFile caching', () => {
     const p = join(dir, 'codex-source-front-rewrite-same-size.jsonl');
     const oldLine = `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`;
     const newLine = oldLine.replace('"input_tokens":100', '"input_tokens":999');
-    expect(Buffer.from(newLine).subarray(-USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES).equals(
-      Buffer.from(oldLine).subarray(-USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES),
+    expect(Buffer.from(newLine).subarray(-TEST_FRONTIER_BYTES).equals(
+      Buffer.from(oldLine).subarray(-TEST_FRONTIER_BYTES),
     )).toBe(true);
     const { finalSize } = writeOversizedCodexSnapshot(p, oldLine);
     const firstStat = statSync(p);
@@ -1010,13 +995,113 @@ describe('readSessionTokenUsageFile caching', () => {
     });
   });
 
+  it('replays the scanned Codex interval when a later metric is written between an unchanged source and frontier', () => {
+    const p = join(dir, 'codex-middle-rewrite-between-source-and-frontier.jsonl');
+    const oldModelLine = codexModelLine('old-model');
+    const oldTokenLine = codexCountLine(100, 10, 20, { used: 30, window: 1_000 });
+    const newTokenLine = codexCountLine(999, 11, 30, { used: 240, window: 1_000 });
+    const newModelLine = codexModelLine('new-model');
+    const oldTokenOffset = Buffer.byteLength(`${oldModelLine}\n`, 'utf8');
+    const newTokenOffset = Buffer.byteLength(`${oldModelLine}\n${oldTokenLine}\n`, 'utf8');
+    const newModelOffset = newTokenOffset + Buffer.byteLength(`${newTokenLine}\n`, 'utf8');
+    const inertLineFor = (line: string) => {
+      const prefix = '{"x":"';
+      const suffix = '"}';
+      const targetBytes = Buffer.byteLength(line, 'utf8');
+      const fixedBytes = Buffer.byteLength(prefix + suffix, 'utf8');
+      expect(targetBytes).toBeGreaterThan(fixedBytes);
+      return prefix + 'x'.repeat(targetBytes - fixedBytes) + suffix;
+    };
+    const inertTokenLine = inertLineFor(newTokenLine);
+    const inertModelLine = inertLineFor(newModelLine);
+    expect(Buffer.byteLength(inertTokenLine)).toBe(Buffer.byteLength(newTokenLine));
+    expect(Buffer.byteLength(inertModelLine)).toBe(Buffer.byteLength(newModelLine));
+    writeFileSync(p, [
+      oldModelLine,
+      oldTokenLine,
+      inertTokenLine,
+      inertModelLine,
+      JSON.stringify({ type: 'event_msg', payload: { type: 'notice', padding: 'stable-tail'.repeat(32) } }),
+      '',
+    ].join('\n'));
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+    const firstStat = statSync(p);
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 30, windowTokens: 1_000, percentUsed: 3 },
+      tokens: {
+        in: 100,
+        out: 10,
+        model: 'old-model',
+      },
+      turnTokens: null,
+    });
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({
+      in: 100,
+      out: 10,
+      model: 'old-model',
+    });
+
+    const oldSource = readBytesAt(p, oldTokenOffset, Buffer.byteLength(oldTokenLine));
+    const oldFrontier = readBytesAt(
+      p,
+      fileSize(p) - TEST_FRONTIER_BYTES,
+      TEST_FRONTIER_BYTES,
+    );
+    sleepSync(5);
+    writeBytesAt(p, newTokenOffset, newTokenLine);
+    writeBytesAt(p, newModelOffset, newModelLine);
+    const secondStat = statSync(p);
+    expect(secondStat.ino).toBe(firstStat.ino);
+    expect(secondStat.size).toBe(firstStat.size);
+    expect(secondStat.ctimeMs).toBeGreaterThanOrEqual(firstStat.ctimeMs);
+    expect(readBytesAt(p, oldTokenOffset, Buffer.byteLength(oldTokenLine))).toEqual(oldSource);
+    expect(readBytesAt(
+      p,
+      fileSize(p) - TEST_FRONTIER_BYTES,
+      TEST_FRONTIER_BYTES,
+    )).toEqual(oldFrontier);
+    now += 20_000;
+
+    vi.mocked(readSync).mockClear();
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 240, windowTokens: 1_000, percentUsed: 24 },
+      tokens: {
+        in: 999,
+        out: 11,
+        inputTokens: 969,
+        cacheReadTokens: 30,
+        model: 'new-model',
+      },
+      turnTokens: null,
+    });
+    expectCodexTrackedReplayRead(0, fileSize(p));
+    vi.mocked(readSync).mockClear();
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({
+      in: 999,
+      out: 11,
+      inputTokens: 969,
+      cacheReadTokens: 30,
+      model: 'new-model',
+    });
+  });
+
   it('does not return stale Codex usage when a front-rewritten source record grows slightly but keeps its frontier', () => {
     const p = join(dir, 'codex-source-front-rewrite-grow.jsonl');
     const oldLine = `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`;
     const newLine = oldLine.replace('"input_tokens":100', '"input_tokens":999');
     expect(Buffer.byteLength(newLine)).toBe(Buffer.byteLength(oldLine));
-    expect(Buffer.from(newLine).subarray(-USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES).equals(
-      Buffer.from(oldLine).subarray(-USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES),
+    expect(Buffer.from(newLine).subarray(-TEST_FRONTIER_BYTES).equals(
+      Buffer.from(oldLine).subarray(-TEST_FRONTIER_BYTES),
     )).toBe(true);
     const finalSize = MAX_USAGE_TRANSCRIPT_BYTES + CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 1;
     const leadBytes = 512;
@@ -1025,11 +1110,11 @@ describe('readSessionTokenUsageFile caching', () => {
     const firstStat = statSync(p);
     expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({ in: 100, out: 10 });
 
-    const frontierOffset = lineOffset + Buffer.byteLength(oldLine) - USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES;
-    const oldFrontier = readBytesAt(p, frontierOffset, USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES);
+    const frontierOffset = lineOffset + Buffer.byteLength(oldLine) - TEST_FRONTIER_BYTES;
+    const oldFrontier = readBytesAt(p, frontierOffset, TEST_FRONTIER_BYTES);
     writeBytesAt(p, lineOffset, newLine);
     appendFileSync(p, Buffer.alloc(128, 0x20));
-    expect(readBytesAt(p, frontierOffset, USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES)).toEqual(oldFrontier);
+    expect(readBytesAt(p, frontierOffset, TEST_FRONTIER_BYTES)).toEqual(oldFrontier);
     const secondStat = statSync(p);
     expect(secondStat.ino).toBe(firstStat.ino);
     now += 20_000;
@@ -1040,6 +1125,107 @@ describe('readSessionTokenUsageFile caching', () => {
       inputTokens: 979,
       cacheReadTokens: 20,
     });
+  });
+
+  it('replays a tracked Codex interval when a middle rewrite is followed by a small append', () => {
+    const p = join(dir, 'codex-middle-rewrite-small-append.jsonl');
+    const oldTokenLine = codexCountLine(100, 10, 20, { used: 30, window: 1_000 });
+    const newTokenLine = codexCountLine(999, 11, 30, { used: 240, window: 1_000 });
+    const inertLine = '{"x":"' + 'x'.repeat(Buffer.byteLength(newTokenLine) - Buffer.byteLength('{"x":""}')) + '"}';
+    expect(Buffer.byteLength(inertLine)).toBe(Buffer.byteLength(newTokenLine));
+    writeFileSync(p, [
+      oldTokenLine,
+      inertLine,
+      JSON.stringify({ type: 'event_msg', payload: { type: 'notice', padding: 'stable-tail'.repeat(32) } }),
+      '',
+    ].join('\n'));
+    const firstStat = statSync(p);
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({ in: 100, out: 10 });
+
+    const oldFrontier = readBytesAt(
+      p,
+      fileSize(p) - TEST_FRONTIER_BYTES,
+      TEST_FRONTIER_BYTES,
+    );
+    sleepSync(5);
+    const newTokenOffset = Buffer.byteLength(`${oldTokenLine}\n`, 'utf8');
+    writeBytesAt(p, newTokenOffset, newTokenLine);
+    const appended = `${codexModelLine('new-model')}\n`;
+    appendFileSync(p, appended);
+    const secondStat = statSync(p);
+    expect(secondStat.ino).toBe(firstStat.ino);
+    expect(secondStat.size).toBe(firstStat.size + Buffer.byteLength(appended));
+    expect(readBytesAt(
+      p,
+      fileSize(p) - Buffer.byteLength(appended) - TEST_FRONTIER_BYTES,
+      TEST_FRONTIER_BYTES,
+    )).toEqual(oldFrontier);
+    now += 20_000;
+
+    vi.mocked(readSync).mockClear();
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({
+      in: 999,
+      out: 11,
+      inputTokens: 969,
+      cacheReadTokens: 30,
+      model: 'new-model',
+    });
+    expectCodexTrackedReplayRead(0, fileSize(p));
+  });
+
+  it('falls back to a normal rebuild when the tracked replay boundary is rejected', () => {
+    const p = join(dir, 'codex-normal-boundary-rejected.jsonl');
+    const prefixLine = JSON.stringify({ type: 'event_msg', payload: { type: 'notice', message: 'prefix' } });
+    const oldTokenLine = codexCountLine(100, 10, 20, { used: 30, window: 1_000 });
+    const newTokenLine = codexCountLine(999, 11, 30, { used: 240, window: 1_000 });
+    const oldSourceOffset = Buffer.byteLength(`${prefixLine}\n`, 'utf8');
+    writeFileSync(p, `${prefixLine}\n${oldTokenLine}\n`);
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({ in: 100, out: 10 });
+
+    vi.mocked(readSync).mockClear();
+    writeBytesAt(p, oldSourceOffset - 1, ' ');
+    appendFileSync(p, `\n${newTokenLine}\n`);
+    now += 20_000;
+
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({
+      in: 999,
+      out: 11,
+      inputTokens: 969,
+      cacheReadTokens: 30,
+    });
+    expect(requestedBytes()).toBe(fileSize(p) + 1);
+  });
+
+  it('falls back to an oversized tail rebuild when the tracked replay boundary is rejected', () => {
+    const p = join(dir, 'codex-oversized-boundary-rejected.jsonl');
+    const prefixLine = JSON.stringify({ type: 'event_msg', payload: { type: 'notice', padding: 'p'.repeat(1024) } });
+    const oldTokenLine = `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`;
+    const newTokenLine = codexCountLine(999, 11, 30, { used: 240, window: 1_000 });
+    const finalSize = MAX_USAGE_TRANSCRIPT_BYTES + CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 1;
+    const baseOffset = finalSize - CODEX_USAGE_TRANSCRIPT_TAIL_BYTES;
+    const oldSourceOffset = baseOffset + Buffer.byteLength(`${prefixLine}\n`, 'utf8');
+    writeFileSync(p, '');
+    truncateSync(p, baseOffset - 1);
+    appendFileSync(p, `\n${prefixLine}\n${oldTokenLine}`);
+    appendFileSync(p, Buffer.alloc(finalSize - fileSize(p), 0x20));
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({ in: 100, out: 10 });
+
+    vi.mocked(readSync).mockClear();
+    writeBytesAt(p, oldSourceOffset - 1, ' ');
+    appendFileSync(p, `\n${newTokenLine}\n`);
+    const tailBaseOffset = fileSize(p) - CODEX_USAGE_TRANSCRIPT_TAIL_BYTES;
+    expect(fileSize(p) - oldSourceOffset).toBeLessThanOrEqual(CODEX_USAGE_TRANSCRIPT_TAIL_BYTES);
+    now += 20_000;
+
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({
+      in: 999,
+      out: 11,
+      inputTokens: 969,
+      cacheReadTokens: 30,
+    });
+    expect(vi.mocked(readSync).mock.calls.some((call) => Number(call[3]) === 1 && Number(call[4]) === oldSourceOffset - 1)).toBe(true);
+    expect(vi.mocked(readSync).mock.calls.some((call) => Number(call[3]) === 1 && Number(call[4]) === tailBaseOffset - 1)).toBe(true);
+    expect(requestedBytes()).toBe(CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 2);
   });
 
   it('rebuilds Codex usage when the same inode is rewritten and grows slightly', () => {

--- a/test/cost-calculator-cache.test.ts
+++ b/test/cost-calculator-cache.test.ts
@@ -587,9 +587,10 @@ describe('readSessionTokenUsageFile caching', () => {
     });
   });
 
-  it('widens the back-scan across several windows to recover a snapshot far from the tail', () => {
-    // Snapshot sits ~10MiB from EOF (past 2 tail windows), buried behind a big
-    // non-snapshot burst. The reader must widen past the first windows to find it.
+  it('widens the back-scan to recover a snapshot past the fast-path tail window', () => {
+    // Snapshot sits ~10MiB from EOF (outside the 4MiB fast-path window) behind a
+    // big non-snapshot burst. The fast path misses, so the reader does one
+    // bounded widen to the back-scan budget and recovers it.
     const p = join(dir, 'codex-backscan-multi-window.jsonl');
     const snapshot = `${codexCountLine(321, 32, 100, { used: 210, window: 1_000 })}\n`;
     const finalSize = MAX_USAGE_TRANSCRIPT_BYTES + 12 * 1024 * 1024;
@@ -610,6 +611,50 @@ describe('readSessionTokenUsageFile caching', () => {
     })).toMatchObject({
       context: { usedTokens: 210, windowTokens: 1_000, percentUsed: 21 },
       tokens: { in: 321, out: 32, inputTokens: 221, cacheReadTokens: 100 },
+    });
+  });
+
+  it('carries the model forward when a large tail window recovers usage but no model line', () => {
+    // Model rides on turn_context lines and is a stable session attribute. Warm
+    // read captures model; a later >4MiB burst + a new tail token_count (with NO
+    // model line) must recover the usage AND keep the model, not ship "" to the
+    // ledger. (Regression for the widen dropping model — usage-only back-fill.)
+    const p = join(dir, 'codex-model-carry-forward.jsonl');
+    const finalSize = MAX_USAGE_TRANSCRIPT_BYTES + CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 1;
+    const baseOffset = finalSize - CODEX_USAGE_TRANSCRIPT_TAIL_BYTES;
+    writeFileSync(p, '');
+    truncateSync(p, baseOffset - 1);
+    appendFileSync(p, '\n');
+    appendFileSync(p, `${codexModelLine('gpt-5-codex')}\n`);
+    appendFileSync(p, `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
+    appendFileSync(p, Buffer.alloc(finalSize - fileSize(p), 0x20));
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({ tokens: { in: 100, out: 10, model: 'gpt-5-codex' } });
+
+    // >4MiB non-snapshot burst then a new token_count with NO model line.
+    let appended = 0;
+    let i = 0;
+    while (appended < CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 8192) {
+      const line = `${JSON.stringify({ type: 'event_msg', payload: { type: 'agent_message', text: `t${i++}` } })}\n`;
+      appendFileSync(p, line);
+      appended += Buffer.byteLength(line);
+    }
+    appendFileSync(p, `${codexCountLine(500, 60, 200, { used: 240, window: 1_000 })}\n`);
+    now += 20_000;
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 240, windowTokens: 1_000, percentUsed: 24 },
+      tokens: { in: 500, out: 60, model: 'gpt-5-codex' },
     });
   });
 
@@ -642,6 +687,13 @@ describe('readSessionTokenUsageFile caching', () => {
       ...vi.mocked(readSync).mock.calls.map((call) => Number(call[4])).filter(Number.isFinite),
     );
     expect(minReadPos).toBeGreaterThan(snapshotOffset);
+    // Worst-case synchronous read is a single fast-path tail window plus ONE
+    // bounded widen — NOT a 4/8/.../32 ladder (which would total 144MiB). Pin
+    // the ceiling so a future change cannot silently reintroduce cumulative
+    // re-scans. Chunk/probe overhead is tiny next to the multi-MiB windows.
+    expect(requestedBytes()).toBeLessThanOrEqual(
+      CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + CODEX_USAGE_MAX_BACKSCAN_BYTES + 64 * 1024,
+    );
   });
 
   it('does not inherit warm Codex usage across a burst that exceeds the back-scan budget', () => {

--- a/test/cost-calculator-cache.test.ts
+++ b/test/cost-calculator-cache.test.ts
@@ -33,6 +33,7 @@ vi.mock('../src/services/codex-transcript.js', () => ({
 }));
 
 import {
+  CODEX_USAGE_MAX_BACKSCAN_BYTES,
   CODEX_USAGE_TRANSCRIPT_TAIL_BYTES,
   MAX_USAGE_TRANSCRIPT_BYTES,
   getSessionUsageSnapshot,
@@ -555,7 +556,7 @@ describe('readSessionTokenUsageFile caching', () => {
     })).toEqual({ context: null, tokens: null, turnTokens: null });
   });
 
-  it('does not inherit cached Codex metrics when a large tail has no snapshot', () => {
+  it('recovers usage by widening the back-scan when a large Codex tail has no snapshot', () => {
     const p = join(dir, 'codex-large-delta-no-snapshot.jsonl');
     writeOversizedCodexSnapshot(p, `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
     vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
@@ -569,6 +570,10 @@ describe('readSessionTokenUsageFile caching', () => {
       tokens: { in: 100, out: 10 },
     });
 
+    // A single >4MiB non-snapshot burst (e.g. one huge tool output) pushes the
+    // only token_count snapshot out of the first tail window. Rather than
+    // collapsing the usage card to null, the reader widens the back-scan until
+    // it recovers the true latest usage from the earlier snapshot.
     appendLargeCodexDelta(p, JSON.stringify({ type: 'event_msg', payload: { type: 'notice' } }));
     now += 20_000;
     expect(getSessionUsageSnapshot({
@@ -576,7 +581,53 @@ describe('readSessionTokenUsageFile caching', () => {
       sessionId: 'botmux-sid',
       cliSessionId: 'codex-sid',
       fresh: true,
-    })).toEqual({ context: null, tokens: null, turnTokens: null });
+    })).toMatchObject({
+      context: { usedTokens: 30, windowTokens: 1_000, percentUsed: 3 },
+      tokens: { in: 100, out: 10 },
+    });
+  });
+
+  it('widens the back-scan across several windows to recover a snapshot far from the tail', () => {
+    // Snapshot sits ~10MiB from EOF (past 2 tail windows), buried behind a big
+    // non-snapshot burst. The reader must widen past the first windows to find it.
+    const p = join(dir, 'codex-backscan-multi-window.jsonl');
+    const snapshot = `${codexCountLine(321, 32, 100, { used: 210, window: 1_000 })}\n`;
+    const finalSize = MAX_USAGE_TRANSCRIPT_BYTES + 12 * 1024 * 1024;
+    const snapshotOffset = finalSize - 10 * 1024 * 1024;
+    writeFileSync(p, '');
+    truncateSync(p, snapshotOffset - 1);
+    appendFileSync(p, '\n');
+    appendFileSync(p, snapshot);
+    appendFileSync(p, Buffer.alloc(finalSize - fileSize(p), 0x20));
+    expect(fileSize(p)).toBe(finalSize);
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 210, windowTokens: 1_000, percentUsed: 21 },
+      tokens: { in: 321, out: 32, inputTokens: 221, cacheReadTokens: 100 },
+    });
+  });
+
+  it('bounds the back-scan and does not walk the whole file when no snapshot is within budget', () => {
+    // The only snapshot is further from EOF than the back-scan budget. The read
+    // must stop widening at CODEX_USAGE_MAX_BACKSCAN_BYTES (never scanning back
+    // to the snapshot) and, with no cached value to fall back to, yield null.
+    const p = join(dir, 'codex-backscan-budget-exceeded.jsonl');
+    const snapshot = `${codexCountLine(777, 70, 50, { used: 300, window: 1_000 })}\n`;
+    const finalSize = MAX_USAGE_TRANSCRIPT_BYTES + CODEX_USAGE_MAX_BACKSCAN_BYTES + 8 * 1024 * 1024;
+    const snapshotOffset = finalSize - CODEX_USAGE_MAX_BACKSCAN_BYTES - 4 * 1024 * 1024;
+    writeFileSync(p, '');
+    truncateSync(p, snapshotOffset - 1);
+    appendFileSync(p, '\n');
+    appendFileSync(p, snapshot);
+    appendFileSync(p, Buffer.alloc(finalSize - fileSize(p), 0x20));
+    expect(fileSize(p)).toBe(finalSize);
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
 
     vi.mocked(readSync).mockClear();
     expect(getSessionUsageSnapshot({
@@ -585,10 +636,49 @@ describe('readSessionTokenUsageFile caching', () => {
       cliSessionId: 'codex-sid',
       fresh: true,
     })).toEqual({ context: null, tokens: null, turnTokens: null });
-    expect(vi.mocked(readSync)).not.toHaveBeenCalled();
+    // Never reads at or before the snapshot: the deepest read stays within the
+    // bounded back-scan budget from EOF.
+    const minReadPos = Math.min(
+      ...vi.mocked(readSync).mock.calls.map((call) => Number(call[4])).filter(Number.isFinite),
+    );
+    expect(minReadPos).toBeGreaterThan(snapshotOffset);
   });
 
-  it('drops cached cumulative tokens when a large Codex tail only has context', () => {
+  it('does not inherit warm Codex usage across a burst that exceeds the back-scan budget', () => {
+    // Warm cache holds in=555. A later burst larger than the whole back-scan
+    // budget leaves no snapshot reachable within budget. We must NOT resurrect
+    // the stale value across what could be a rewritten generation — the bounded
+    // rebuild yields null rather than a possibly-invalid inherited value. (This
+    // is the fail-closed boundary; the common warm case is recovered by the
+    // back-scan itself, exercised in the widening tests above.)
+    const p = join(dir, 'codex-backscan-budget-no-inherit.jsonl');
+    writeOversizedCodexSnapshot(p, `${codexCountLine(555, 55, 30, { used: 400, window: 1_000 })}\n`);
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({ tokens: { in: 555, out: 55 } });
+
+    let appended = 0;
+    let i = 0;
+    while (appended < CODEX_USAGE_MAX_BACKSCAN_BYTES + 8 * 1024 * 1024) {
+      const line = `${JSON.stringify({ type: 'event_msg', payload: { type: 'agent_message', text: `t${i++}` } })}\n`;
+      appendFileSync(p, line);
+      appended += Buffer.byteLength(line);
+    }
+    now += 20_000;
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toEqual({ context: null, tokens: null, turnTokens: null });
+  });
+
+  it('recovers earlier cumulative tokens by widening the back-scan when a large Codex tail only has context', () => {
     const p = join(dir, 'codex-context-only-large-delta.jsonl');
     writeOversizedCodexSnapshot(p, `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
     vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
@@ -605,6 +695,9 @@ describe('readSessionTokenUsageFile caching', () => {
     appendLargeCodexDelta(p, codexContextLine(240, 1_000));
     now += 20_000;
 
+    // The tail window only carries the new context snapshot; the cumulative
+    // metric lives on the earlier line, so the reader widens the back-scan and
+    // keeps the true latest of BOTH instead of dropping cumulative tokens.
     expect(getSessionUsageSnapshot({
       cliId: 'codex',
       sessionId: 'botmux-sid',
@@ -612,12 +705,11 @@ describe('readSessionTokenUsageFile caching', () => {
       fresh: true,
     })).toMatchObject({
       context: { usedTokens: 240, windowTokens: 1_000, percentUsed: 24 },
-      tokens: null,
+      tokens: { in: 100, out: 10 },
     });
-    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toBeNull();
   });
 
-  it('drops cached context when a large Codex tail only has cumulative tokens', () => {
+  it('recovers earlier context by widening the back-scan when a large Codex tail only has cumulative tokens', () => {
     const p = join(dir, 'codex-cumulative-only-large-delta.jsonl');
     writeOversizedCodexSnapshot(p, `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
     vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
@@ -634,13 +726,16 @@ describe('readSessionTokenUsageFile caching', () => {
     appendLargeCodexDelta(p, codexCountLine(500, 60, 200));
     now += 20_000;
 
+    // The tail window only carries the new cumulative snapshot; the context
+    // metric lives on the earlier line, so the reader widens the back-scan and
+    // recovers the true latest of BOTH metrics instead of dropping context.
     expect(getSessionUsageSnapshot({
       cliId: 'codex',
       sessionId: 'botmux-sid',
       cliSessionId: 'codex-sid',
       fresh: true,
     })).toMatchObject({
-      context: null,
+      context: { usedTokens: 30, windowTokens: 1_000, percentUsed: 3 },
       tokens: { in: 500, out: 60, inputTokens: 300, cacheReadTokens: 200 },
     });
   });

--- a/test/cost-calculator-cache.test.ts
+++ b/test/cost-calculator-cache.test.ts
@@ -614,12 +614,13 @@ describe('readSessionTokenUsageFile caching', () => {
     });
   });
 
-  it('carries the model forward when a large tail window recovers usage but no model line', () => {
-    // Model rides on turn_context lines and is a stable session attribute. Warm
-    // read captures model; a later >4MiB burst + a new tail token_count (with NO
-    // model line) must recover the usage AND keep the model, not ship "" to the
-    // ledger. (Regression for the widen dropping model — usage-only back-fill.)
-    const p = join(dir, 'codex-model-carry-forward.jsonl');
+  it('widens to recover the model when the cached read had one but the tail window does not', () => {
+    // Model rides on turn_context lines. Warm read captured a model, so the
+    // session is known to carry one; when a >4MiB burst pushes it (and the last
+    // model line) out of the fast tail window, the widen must re-scan far enough
+    // to recover the model — not ship "" to the ledger, and not inherit it
+    // blindly (see the model-switch test for why inheritance is wrong).
+    const p = join(dir, 'codex-model-widen-recover.jsonl');
     const finalSize = MAX_USAGE_TRANSCRIPT_BYTES + CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 1;
     const baseOffset = finalSize - CODEX_USAGE_TRANSCRIPT_TAIL_BYTES;
     writeFileSync(p, '');
@@ -655,6 +656,49 @@ describe('readSessionTokenUsageFile caching', () => {
     })).toMatchObject({
       context: { usedTokens: 240, windowTokens: 1_000, percentUsed: 24 },
       tokens: { in: 500, out: 60, model: 'gpt-5-codex' },
+    });
+  });
+
+  it('recovers the SWITCHED model (not the stale one) when a burst pushes it out of the tail window', () => {
+    // Append-only model switch: old-model → new-model, then a >4MiB burst pushes
+    // new-model out of the fast tail window, then EOF token_count with no model.
+    // The widen must recover new-model (latest wins); inheriting the cached
+    // old-model would mis-price the ledger — worse than "unknown".
+    const p = join(dir, 'codex-model-switch.jsonl');
+    const finalSize = MAX_USAGE_TRANSCRIPT_BYTES + CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 1;
+    const baseOffset = finalSize - CODEX_USAGE_TRANSCRIPT_TAIL_BYTES;
+    writeFileSync(p, '');
+    truncateSync(p, baseOffset - 1);
+    appendFileSync(p, '\n');
+    appendFileSync(p, `${codexModelLine('old-model')}\n`);
+    appendFileSync(p, `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
+    appendFileSync(p, Buffer.alloc(finalSize - fileSize(p), 0x20));
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({ tokens: { in: 100, out: 10, model: 'old-model' } });
+
+    appendFileSync(p, `${codexModelLine('new-model')}\n`);
+    let appended = 0;
+    let i = 0;
+    while (appended < CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 8192) {
+      const line = `${JSON.stringify({ type: 'event_msg', payload: { type: 'agent_message', text: `t${i++}` } })}\n`;
+      appendFileSync(p, line);
+      appended += Buffer.byteLength(line);
+    }
+    appendFileSync(p, `${codexCountLine(500, 60, 200, { used: 240, window: 1_000 })}\n`);
+    now += 20_000;
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      tokens: { in: 500, out: 60, model: 'new-model' },
     });
   });
 

--- a/test/cost-calculator-cache.test.ts
+++ b/test/cost-calculator-cache.test.ts
@@ -7,6 +7,13 @@
  * Run:  pnpm vitest run test/cost-calculator-cache.test.ts
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+vi.mock('node:crypto', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:crypto')>();
+  return {
+    ...original,
+    createHash: vi.fn(original.createHash),
+  };
+});
 vi.mock('node:fs', async (importOriginal) => {
   const original = await importOriginal<typeof import('node:fs')>();
   return {
@@ -15,10 +22,12 @@ vi.mock('node:fs', async (importOriginal) => {
     openSync: vi.fn(original.openSync),
     readFileSync: vi.fn(original.readFileSync),
     readSync: vi.fn(original.readSync),
+    statSync: vi.fn(original.statSync),
   };
 });
 
-import { constants, fstatSync, mkdtempSync, openSync, writeFileSync, appendFileSync, rmSync, readFileSync, readSync, renameSync, statSync, truncateSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { closeSync, constants, fstatSync, mkdtempSync, openSync, writeFileSync, appendFileSync, rmSync, readFileSync, readSync, renameSync, statSync, truncateSync, utimesSync, writeSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -110,6 +119,18 @@ function codexSnapshotAtTailSize(path: string, line: string, finalSize: number):
   return { baseOffset, finalSize };
 }
 
+function codexSnapshotInsideTail(path: string, line: string, leadBytes: number, finalSize: number): { lineOffset: number; finalSize: number } {
+  const baseOffset = finalSize - CODEX_USAGE_TRANSCRIPT_TAIL_BYTES;
+  const lineOffset = baseOffset + leadBytes;
+  const lineBytes = Buffer.byteLength(line);
+  expect(lineBytes + leadBytes).toBeLessThan(CODEX_USAGE_TRANSCRIPT_TAIL_BYTES);
+  truncateSync(path, lineOffset - 1);
+  appendFileSync(path, '\n');
+  appendFileSync(path, line);
+  appendFileSync(path, Buffer.alloc(finalSize - lineOffset - lineBytes, 0x20));
+  return { lineOffset, finalSize };
+}
+
 function codexSnapshotAtTail(path: string, line: string): { baseOffset: number; finalSize: number } {
   return codexSnapshotAtTailSize(path, line, MAX_USAGE_TRANSCRIPT_BYTES + CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 1);
 }
@@ -136,13 +157,14 @@ function expectBoundedTailRead(baseOffset: number): void {
   );
 }
 
-function expectLargeDeltaBoundedTailRead(baseOffset: number): void {
+function expectLargeDeltaBoundedTailRead(baseOffset: number, sourceValidationBytes: number): void {
   const calls = vi.mocked(readSync).mock.calls;
   expect(calls.length).toBeGreaterThan(0);
   expect(calls.some((call) => Number(call[3]) === 1 && Number(call[4]) === baseOffset - 1)).toBe(true);
   const requestedBytes = calls.reduce((sum, call) => sum + Number(call[3]), 0);
   expect(requestedBytes).toBeLessThanOrEqual(
-    USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES
+    sourceValidationBytes
+    + USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES
     + 1
     + CODEX_USAGE_TRANSCRIPT_TAIL_BYTES
     + USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES,
@@ -151,6 +173,30 @@ function expectLargeDeltaBoundedTailRead(baseOffset: number): void {
 
 function fileSize(path: string): number {
   return statSync(path).size;
+}
+
+function readBytesAt(path: string, offset: number, length: number): Buffer {
+  const fd = openSync(path, 'r');
+  try {
+    const buf = Buffer.alloc(length);
+    const read = readSync(fd, buf, 0, length, offset);
+    return Buffer.from(buf.subarray(0, read));
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function writeBytesAt(path: string, offset: number, content: string): void {
+  const fd = openSync(path, 'r+');
+  try {
+    writeSync(fd, Buffer.from(content), 0, Buffer.byteLength(content), offset);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
 let dir: string;
@@ -162,9 +208,11 @@ beforeEach(() => {
   now = 1_000_000_000;
   vi.spyOn(Date, 'now').mockImplementation(() => now);
   vi.mocked(fstatSync).mockClear();
+  vi.mocked(createHash).mockClear();
   vi.mocked(openSync).mockClear();
   vi.mocked(readFileSync).mockClear();
   vi.mocked(readSync).mockClear();
+  vi.mocked(statSync).mockClear();
   vi.mocked(logger.warn).mockClear();
   vi.mocked(findCodexRolloutBySessionId).mockReset();
 });
@@ -324,6 +372,50 @@ describe('readSessionTokenUsageFile caching', () => {
     });
   });
 
+  it('keeps normal-size Codex appends incremental instead of rereading from byte zero', () => {
+    const p = join(dir, 'codex-normal-size-incremental.jsonl');
+    const initialLine = `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`;
+    writeFileSync(p, initialLine);
+    appendFileSync(p, `${'x'.repeat(2 * 1024 * 1024)}\n`);
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({
+      in: 100,
+      out: 10,
+    });
+
+    vi.mocked(readSync).mockClear();
+    const appended = `${codexCountLine(150, 20, 50, { used: 70, window: 1_000 })}\n`;
+    appendFileSync(p, appended);
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+    now += 20_000;
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toEqual({
+      context: { usedTokens: 70, windowTokens: 1_000, percentUsed: 7 },
+      tokens: {
+        in: 150,
+        out: 20,
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadTokens: 50,
+        cacheCreateTokens: 0,
+        model: '',
+        turns: 0,
+      },
+      turnTokens: null,
+    });
+    const requestedBytes = vi.mocked(readSync).mock.calls.reduce((sum, call) => sum + Number(call[3]), 0);
+    expect(requestedBytes).toBeLessThanOrEqual(
+      Buffer.byteLength(initialLine)
+      + USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES
+      + Buffer.byteLength(appended)
+      + USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES,
+    );
+  });
+
   it('cold reads an oversized Codex transcript from a bounded tail window', () => {
     const p = join(dir, 'oversized-codex.jsonl');
     writeFileSync(p, '');
@@ -357,6 +449,35 @@ describe('readSessionTokenUsageFile caching', () => {
     });
     expect(readFileSync).not.toHaveBeenCalled();
     expectBoundedTailRead(fileSize(p) - CODEX_USAGE_TRANSCRIPT_TAIL_BYTES);
+  });
+
+  it('hashes Codex source records only for lines that update tracked metrics', () => {
+    const p = join(dir, 'codex-lazy-source-hash.jsonl');
+    writeFileSync(p, [
+      JSON.stringify({ type: 'event_msg', payload: { type: 'notice', message: 'ignored' } }),
+      JSON.stringify({ type: 'event_msg', payload: { type: 'other', info: { total_token_usage: { input_tokens: 1 } } } }),
+      codexCountLine(100, 10, 20, { used: 30, window: 1_000 }),
+      '',
+    ].join('\n'));
+
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({
+      in: 100,
+      out: 10,
+      inputTokens: 80,
+      cacheReadTokens: 20,
+    });
+    expect(createHash).toHaveBeenCalledTimes(1);
+
+    vi.mocked(createHash).mockClear();
+    const ignoredOnly = join(dir, 'codex-ignored-only.jsonl');
+    writeFileSync(ignoredOnly, [
+      JSON.stringify({ type: 'event_msg', payload: { type: 'notice', message: 'ignored' } }),
+      JSON.stringify({ type: 'session_meta', payload: { cwd: dir } }),
+      '',
+    ].join('\n'));
+
+    expect(readSessionTokenUsageFile(ignoredOnly, 'codex', { fresh: true })).toBeNull();
+    expect(createHash).not.toHaveBeenCalled();
   });
 
   it('keeps the first Codex tail record when the bounded start is on a line boundary', () => {
@@ -565,7 +686,8 @@ describe('readSessionTokenUsageFile caching', () => {
 
   it('re-bootstraps oversized Codex transcripts when the unread cache delta exceeds the tail budget', () => {
     const p = join(dir, 'codex-cache-large-delta.jsonl');
-    writeOversizedCodexSnapshot(p, `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
+    const initialLine = `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`;
+    writeOversizedCodexSnapshot(p, initialLine);
     vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
     expect(getSessionUsageSnapshot({
       cliId: 'codex',
@@ -591,13 +713,14 @@ describe('readSessionTokenUsageFile caching', () => {
       context: { usedTokens: 240, windowTokens: 1_000, percentUsed: 24 },
       tokens: { in: 500, out: 60, inputTokens: 300, cacheReadTokens: 200 },
     });
-    expectLargeDeltaBoundedTailRead(baseOffset);
+    expectLargeDeltaBoundedTailRead(baseOffset, Buffer.byteLength(initialLine));
   });
 
   it('continues incrementally after an oversized Codex cold tail bootstrap when the append is small', () => {
     const p = join(dir, 'codex-small-append-after-tail.jsonl');
+    const initialLine = `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`;
     writeSparsePrefix(p, MAX_USAGE_TRANSCRIPT_BYTES + 1, '\n');
-    appendFileSync(p, `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
+    appendFileSync(p, initialLine);
     vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
     expect(getSessionUsageSnapshot({
       cliId: 'codex',
@@ -625,7 +748,8 @@ describe('readSessionTokenUsageFile caching', () => {
     });
     const requestedBytes = vi.mocked(readSync).mock.calls.reduce((sum, call) => sum + Number(call[3]), 0);
     expect(requestedBytes).toBeLessThanOrEqual(
-      USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES
+      Buffer.byteLength(initialLine)
+      + USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES
       + Buffer.byteLength(appended)
       + USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES,
     );
@@ -648,6 +772,36 @@ describe('readSessionTokenUsageFile caching', () => {
       out: 90,
       inputTokens: 699,
       cacheReadTokens: 300,
+    });
+  });
+
+  it('does not use unchanged cache when ctime changes after same-size rewrite with restored mtime', () => {
+    const p = join(dir, 'codex-ctime-same-size-rewrite.jsonl');
+    const oldLine = `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`;
+    const newLine = oldLine.replace('"input_tokens":100', '"input_tokens":999');
+    expect(Buffer.byteLength(newLine)).toBe(Buffer.byteLength(oldLine));
+    writeFileSync(p, oldLine);
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({ in: 100, out: 10 });
+    const firstStat = statSync(p);
+
+    let secondStat = firstStat;
+    for (let attempt = 0; attempt < 10 && secondStat.ctimeMs === firstStat.ctimeMs; attempt++) {
+      sleepSync(10);
+      writeFileSync(p, oldLine);
+      writeFileSync(p, newLine);
+      utimesSync(p, firstStat.atime, firstStat.mtime);
+      secondStat = statSync(p);
+    }
+    expect(secondStat.ino).toBe(firstStat.ino);
+    expect(secondStat.size).toBe(firstStat.size);
+    expect(secondStat.ctimeMs).not.toBe(firstStat.ctimeMs);
+    now += 20_000;
+
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({
+      in: 999,
+      out: 10,
+      inputTokens: 979,
+      cacheReadTokens: 20,
     });
   });
 
@@ -730,6 +884,86 @@ describe('readSessionTokenUsageFile caching', () => {
     });
   });
 
+  it('does not merge cached cumulative tokens when the path is replaced between generation validation and scan', () => {
+    const p = join(dir, 'codex-toctou-replace-before-scan.jsonl');
+    writeOversizedCodexSnapshot(
+      p,
+      `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`,
+    );
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 30 },
+      tokens: { in: 100, out: 10 },
+    });
+
+    appendLargeCodexDelta(p, JSON.stringify({ type: 'event_msg', payload: { type: 'notice' } }));
+    const replacement = join(dir, 'codex-toctou-replace-before-scan-new.jsonl');
+    writeFileSync(replacement, '');
+    codexSnapshotAtTailSize(replacement, `${codexContextLine(240, 1_000)}\n`, fileSize(p));
+
+    now += 20_000;
+    const realReadSync = vi.mocked(readSync).getMockImplementation()!;
+    let replaced = false;
+    vi.mocked(readSync).mockImplementation((fd, buffer, offset, length, position) => {
+      const bytesRead = (realReadSync as typeof readSync)(fd, buffer, offset, length, position);
+      if (!replaced && length === USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES) {
+        renameSync(replacement, p);
+        replaced = true;
+      }
+      return bytesRead;
+    });
+
+    const snapshot = getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    });
+    expect(snapshot.tokens).toBeNull();
+    expect(snapshot.turnTokens).toBeNull();
+    if (snapshot.context) {
+      expect(snapshot.context).toEqual({ usedTokens: 240, windowTokens: 1_000, percentUsed: 24 });
+    }
+    expect(replaced).toBe(true);
+  });
+
+  it('does not inherit a cached Codex metric when its source line terminator is overwritten', () => {
+    const p = join(dir, 'codex-source-terminator-overwrite.jsonl');
+    const line = `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`;
+    const { baseOffset } = writeOversizedCodexSnapshot(p, line);
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 30 },
+      tokens: { in: 100, out: 10 },
+    });
+
+    writeBytesAt(p, baseOffset + Buffer.byteLength(line) - 1, 'x');
+    appendLargeCodexDelta(p, codexContextLine(240, 1_000));
+    now += 20_000;
+
+    const snapshot = getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    });
+    expect(snapshot).toMatchObject({
+      context: { usedTokens: 240, windowTokens: 1_000, percentUsed: 24 },
+      tokens: null,
+      turnTokens: null,
+    });
+  });
+
   it('rebuilds Codex usage when the same inode is rewritten to the same size', () => {
     const p = join(dir, 'codex-same-inode-same-size.jsonl');
     const firstLine = `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`;
@@ -748,6 +982,63 @@ describe('readSessionTokenUsageFile caching', () => {
       out: 70,
       inputTokens: 477,
       cacheReadTokens: 300,
+    });
+  });
+
+  it('rebuilds Codex usage when only the front of the cached source record changes and its frontier stays unchanged', () => {
+    const p = join(dir, 'codex-source-front-rewrite-same-size.jsonl');
+    const oldLine = `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`;
+    const newLine = oldLine.replace('"input_tokens":100', '"input_tokens":999');
+    expect(Buffer.from(newLine).subarray(-USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES).equals(
+      Buffer.from(oldLine).subarray(-USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES),
+    )).toBe(true);
+    const { finalSize } = writeOversizedCodexSnapshot(p, oldLine);
+    const firstStat = statSync(p);
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({ in: 100, out: 10 });
+
+    codexSnapshotAtTail(p, newLine);
+    truncateSync(p, finalSize);
+    const secondStat = statSync(p);
+    expect(secondStat.ino).toBe(firstStat.ino);
+    now += 20_000;
+
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({
+      in: 999,
+      out: 10,
+      inputTokens: 979,
+      cacheReadTokens: 20,
+    });
+  });
+
+  it('does not return stale Codex usage when a front-rewritten source record grows slightly but keeps its frontier', () => {
+    const p = join(dir, 'codex-source-front-rewrite-grow.jsonl');
+    const oldLine = `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`;
+    const newLine = oldLine.replace('"input_tokens":100', '"input_tokens":999');
+    expect(Buffer.byteLength(newLine)).toBe(Buffer.byteLength(oldLine));
+    expect(Buffer.from(newLine).subarray(-USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES).equals(
+      Buffer.from(oldLine).subarray(-USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES),
+    )).toBe(true);
+    const finalSize = MAX_USAGE_TRANSCRIPT_BYTES + CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 1;
+    const leadBytes = 512;
+    writeFileSync(p, '');
+    const { lineOffset } = codexSnapshotInsideTail(p, oldLine, leadBytes, finalSize);
+    const firstStat = statSync(p);
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({ in: 100, out: 10 });
+
+    const frontierOffset = lineOffset + Buffer.byteLength(oldLine) - USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES;
+    const oldFrontier = readBytesAt(p, frontierOffset, USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES);
+    writeBytesAt(p, lineOffset, newLine);
+    appendFileSync(p, Buffer.alloc(128, 0x20));
+    expect(readBytesAt(p, frontierOffset, USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES)).toEqual(oldFrontier);
+    const secondStat = statSync(p);
+    expect(secondStat.ino).toBe(firstStat.ino);
+    now += 20_000;
+
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({
+      in: 999,
+      out: 10,
+      inputTokens: 979,
+      cacheReadTokens: 20,
     });
   });
 
@@ -800,6 +1091,52 @@ describe('readSessionTokenUsageFile caching', () => {
     expect(vi.mocked(openSync).mock.calls.some(([, flags]) => {
       return typeof flags === 'number' && (flags & constants.O_NONBLOCK) === constants.O_NONBLOCK;
     })).toBe(true);
+  });
+
+  it('fails closed when the final fd stability check cannot fstat the open transcript', () => {
+    const p = join(dir, 'codex-final-fstat-fail.jsonl');
+    writeOversizedCodexSnapshot(p, `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+    const realFstatSync = vi.mocked(fstatSync).getMockImplementation()!;
+    let calls = 0;
+    vi.mocked(fstatSync).mockImplementation((fd) => {
+      calls++;
+      if (calls === 2) throw new Error('fstat boom');
+      return realFstatSync(fd);
+    });
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toEqual({ context: null, tokens: null, turnTokens: null });
+    expect(calls).toBeGreaterThanOrEqual(2);
+  });
+
+  it('fails closed instead of falling back to a path scan when the initial Codex stat fails', () => {
+    const p = join(dir, 'codex-initial-stat-fails.jsonl');
+    writeFileSync(p, '');
+    truncateSync(p, MAX_USAGE_TRANSCRIPT_BYTES + 128 * 1024);
+    appendFileSync(p, `\n${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
+
+    const realStatSync = vi.mocked(statSync).getMockImplementation()!;
+    vi.mocked(statSync).mockImplementation((pathLike, options) => {
+      if (pathLike === p) throw new Error('stat boom');
+      return realStatSync(pathLike, options as any);
+    });
+
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toBeNull();
+    expect(openSync).not.toHaveBeenCalled();
+    expect(readSync).not.toHaveBeenCalled();
+
+    vi.mocked(statSync).mockImplementation(realStatSync);
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({
+      in: 100,
+      out: 10,
+      inputTokens: 80,
+      cacheReadTokens: 20,
+    });
   });
 
   it('skips oversized transcripts instead of scanning them from byte zero', () => {

--- a/test/cost-calculator-cache.test.ts
+++ b/test/cost-calculator-cache.test.ts
@@ -11,12 +11,14 @@ vi.mock('node:fs', async (importOriginal) => {
   const original = await importOriginal<typeof import('node:fs')>();
   return {
     ...original,
+    fstatSync: vi.fn(original.fstatSync),
+    openSync: vi.fn(original.openSync),
     readFileSync: vi.fn(original.readFileSync),
     readSync: vi.fn(original.readSync),
   };
 });
 
-import { mkdtempSync, writeFileSync, appendFileSync, rmSync, readFileSync, readSync, statSync, truncateSync } from 'node:fs';
+import { constants, fstatSync, mkdtempSync, openSync, writeFileSync, appendFileSync, rmSync, readFileSync, readSync, renameSync, statSync, truncateSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -32,6 +34,7 @@ vi.mock('../src/services/codex-transcript.js', () => ({
 import {
   CODEX_USAGE_TRANSCRIPT_TAIL_BYTES,
   MAX_USAGE_TRANSCRIPT_BYTES,
+  USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES,
   getSessionUsageSnapshot,
   readSessionTokenUsageFile,
   __resetSessionUsageCachesForTest,
@@ -77,14 +80,26 @@ function codexModelLine(model: string): string {
   return JSON.stringify({ type: 'turn_context', payload: { model } });
 }
 
+function codexContextLine(used: number, window: number): string {
+  return JSON.stringify({
+    type: 'event_msg',
+    payload: {
+      type: 'token_count',
+      info: {
+        last_token_usage: { total_tokens: used, input_tokens: used - 1, output_tokens: 1 },
+        model_context_window: window,
+      },
+    },
+  });
+}
+
 function writeSparsePrefix(path: string, size: number, lastByte: string): void {
   writeFileSync(path, '');
   truncateSync(path, size - 1);
   appendFileSync(path, lastByte);
 }
 
-function codexSnapshotAtTail(path: string, line: string): { baseOffset: number; finalSize: number } {
-  const finalSize = MAX_USAGE_TRANSCRIPT_BYTES + CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 1;
+function codexSnapshotAtTailSize(path: string, line: string, finalSize: number): { baseOffset: number; finalSize: number } {
   const baseOffset = finalSize - CODEX_USAGE_TRANSCRIPT_TAIL_BYTES;
   const lineBytes = Buffer.byteLength(line);
   expect(lineBytes).toBeLessThan(CODEX_USAGE_TRANSCRIPT_TAIL_BYTES);
@@ -95,6 +110,20 @@ function codexSnapshotAtTail(path: string, line: string): { baseOffset: number; 
   return { baseOffset, finalSize };
 }
 
+function codexSnapshotAtTail(path: string, line: string): { baseOffset: number; finalSize: number } {
+  return codexSnapshotAtTailSize(path, line, MAX_USAGE_TRANSCRIPT_BYTES + CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 1);
+}
+
+function writeOversizedCodexSnapshot(path: string, line: string): { baseOffset: number; finalSize: number } {
+  writeFileSync(path, '');
+  return codexSnapshotAtTail(path, line);
+}
+
+function appendLargeCodexDelta(path: string, line: string): void {
+  appendFileSync(path, Buffer.alloc(CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 128, 0x20));
+  appendFileSync(path, `\n${line}\n`);
+}
+
 function expectBoundedTailRead(baseOffset: number): void {
   const calls = vi.mocked(readSync).mock.calls;
   expect(calls.length).toBeGreaterThan(0);
@@ -102,7 +131,22 @@ function expectBoundedTailRead(baseOffset: number): void {
   expect(Math.min(...positions)).toBe(baseOffset - 1);
   expect(calls.some((call) => Number(call[3]) === 1 && Number(call[4]) === baseOffset - 1)).toBe(true);
   const requestedBytes = calls.reduce((sum, call) => sum + Number(call[3]), 0);
-  expect(requestedBytes).toBeLessThanOrEqual(CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 1);
+  expect(requestedBytes).toBeLessThanOrEqual(
+    CODEX_USAGE_TRANSCRIPT_TAIL_BYTES + 1 + USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES,
+  );
+}
+
+function expectLargeDeltaBoundedTailRead(baseOffset: number): void {
+  const calls = vi.mocked(readSync).mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  expect(calls.some((call) => Number(call[3]) === 1 && Number(call[4]) === baseOffset - 1)).toBe(true);
+  const requestedBytes = calls.reduce((sum, call) => sum + Number(call[3]), 0);
+  expect(requestedBytes).toBeLessThanOrEqual(
+    USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES
+    + 1
+    + CODEX_USAGE_TRANSCRIPT_TAIL_BYTES
+    + USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES,
+  );
 }
 
 function fileSize(path: string): number {
@@ -117,6 +161,8 @@ beforeEach(() => {
   __resetSessionUsageCachesForTest();
   now = 1_000_000_000;
   vi.spyOn(Date, 'now').mockImplementation(() => now);
+  vi.mocked(fstatSync).mockClear();
+  vi.mocked(openSync).mockClear();
   vi.mocked(readFileSync).mockClear();
   vi.mocked(readSync).mockClear();
   vi.mocked(logger.warn).mockClear();
@@ -169,6 +215,25 @@ describe('readSessionTokenUsageFile caching', () => {
     const second = readSessionTokenUsageFile(p, 'claude');
 
     expect(second).toMatchObject({ inputTokens: 300, outputTokens: 30, turns: 2 });
+  });
+
+  it('does not add a frontier fingerprint store probe to non-Codex incremental cache writes', () => {
+    const p = join(dir, 'claude-no-fingerprint-probe.jsonl');
+    writeFileSync(p, `${claudeLine('msg_a', 100, 10)}\n`);
+    readSessionTokenUsageFile(p, 'claude');
+
+    vi.mocked(readSync).mockClear();
+    const appended = `${claudeLine('msg_b', 200, 20)}\n`;
+    appendFileSync(p, appended);
+    now += 20_000;
+
+    expect(readSessionTokenUsageFile(p, 'claude', { fresh: true })).toMatchObject({
+      inputTokens: 300,
+      outputTokens: 30,
+      turns: 2,
+    });
+    const requestedBytes = vi.mocked(readSync).mock.calls.reduce((sum, call) => sum + Number(call[3]), 0);
+    expect(requestedBytes).toBe(Buffer.byteLength(appended));
   });
 
   it('throttles reparsing of a file that keeps changing', () => {
@@ -351,6 +416,15 @@ describe('readSessionTokenUsageFile caching', () => {
       fresh: true,
     })).toEqual({ context: null, tokens: null, turnTokens: null });
 
+    vi.mocked(readSync).mockClear();
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toEqual({ context: null, tokens: null, turnTokens: null });
+    expect(vi.mocked(readSync)).not.toHaveBeenCalled();
+
     appendFileSync(p, '\n');
     now += 20_000;
     expect(getSessionUsageSnapshot({
@@ -361,9 +435,137 @@ describe('readSessionTokenUsageFile caching', () => {
     })).toEqual({ context: null, tokens: null, turnTokens: null });
   });
 
+  it('caches a no-snapshot Codex tail over an existing snapshot without enabling incremental reuse', () => {
+    const p = join(dir, 'codex-large-delta-no-snapshot.jsonl');
+    writeOversizedCodexSnapshot(p, `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 30 },
+      tokens: { in: 100, out: 10 },
+    });
+
+    appendLargeCodexDelta(p, JSON.stringify({ type: 'event_msg', payload: { type: 'notice' } }));
+    now += 20_000;
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 30 },
+      tokens: { in: 100, out: 10 },
+    });
+
+    vi.mocked(readSync).mockClear();
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 30 },
+      tokens: { in: 100, out: 10 },
+    });
+    expect(vi.mocked(readSync)).not.toHaveBeenCalled();
+  });
+
+  it('preserves cached cumulative tokens when a large Codex tail only has context', () => {
+    const p = join(dir, 'codex-context-only-large-delta.jsonl');
+    writeOversizedCodexSnapshot(p, `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 30 },
+      tokens: { in: 100, out: 10 },
+    });
+
+    appendLargeCodexDelta(p, codexContextLine(240, 1_000));
+    now += 20_000;
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 240, windowTokens: 1_000, percentUsed: 24 },
+      tokens: { in: 100, out: 10, inputTokens: 80, cacheReadTokens: 20 },
+    });
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({
+      in: 100,
+      out: 10,
+    });
+  });
+
+  it('preserves cached context when a large Codex tail only has cumulative tokens', () => {
+    const p = join(dir, 'codex-cumulative-only-large-delta.jsonl');
+    writeOversizedCodexSnapshot(p, `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 30, windowTokens: 1_000, percentUsed: 3 },
+      tokens: { in: 100, out: 10 },
+    });
+
+    appendLargeCodexDelta(p, codexCountLine(500, 60, 200));
+    now += 20_000;
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 30, windowTokens: 1_000, percentUsed: 3 },
+      tokens: { in: 500, out: 60, inputTokens: 300, cacheReadTokens: 200 },
+    });
+  });
+
+  it('does not inherit Codex metrics from an offset-zero cache after the file becomes oversized', () => {
+    const p = join(dir, 'codex-offset-zero-to-oversized.jsonl');
+    writeFileSync(p, codexCountLine(100, 10, 20, { used: 30, window: 1_000 }));
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 30 },
+      tokens: { in: 100, out: 10 },
+    });
+
+    writeOversizedCodexSnapshot(p, `${codexContextLine(240, 1_000)}\n`);
+    now += 20_000;
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toEqual({
+      context: { usedTokens: 240, windowTokens: 1_000, percentUsed: 24 },
+      tokens: null,
+      turnTokens: null,
+    });
+  });
+
   it('re-bootstraps oversized Codex transcripts when the unread cache delta exceeds the tail budget', () => {
     const p = join(dir, 'codex-cache-large-delta.jsonl');
-    writeFileSync(p, `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
+    writeOversizedCodexSnapshot(p, `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`);
     vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
     expect(getSessionUsageSnapshot({
       cliId: 'codex',
@@ -376,8 +578,8 @@ describe('readSessionTokenUsageFile caching', () => {
     });
 
     vi.mocked(readSync).mockClear();
-    const latestLine = `${codexCountLine(500, 60, 200, { used: 240, window: 1_000 })}\n`;
-    const { baseOffset } = codexSnapshotAtTail(p, latestLine);
+    appendLargeCodexDelta(p, codexCountLine(500, 60, 200, { used: 240, window: 1_000 }));
+    const baseOffset = fileSize(p) - CODEX_USAGE_TRANSCRIPT_TAIL_BYTES;
     now += 20_000;
 
     expect(getSessionUsageSnapshot({
@@ -389,7 +591,7 @@ describe('readSessionTokenUsageFile caching', () => {
       context: { usedTokens: 240, windowTokens: 1_000, percentUsed: 24 },
       tokens: { in: 500, out: 60, inputTokens: 300, cacheReadTokens: 200 },
     });
-    expectBoundedTailRead(baseOffset);
+    expectLargeDeltaBoundedTailRead(baseOffset);
   });
 
   it('continues incrementally after an oversized Codex cold tail bootstrap when the append is small', () => {
@@ -422,7 +624,182 @@ describe('readSessionTokenUsageFile caching', () => {
       tokens: { in: 150, out: 20, inputTokens: 100, cacheReadTokens: 50 },
     });
     const requestedBytes = vi.mocked(readSync).mock.calls.reduce((sum, call) => sum + Number(call[3]), 0);
-    expect(requestedBytes).toBeLessThanOrEqual(Buffer.byteLength(appended));
+    expect(requestedBytes).toBeLessThanOrEqual(
+      USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES
+      + Buffer.byteLength(appended)
+      + USAGE_TRANSCRIPT_FRONTIER_FINGERPRINT_BYTES,
+    );
+  });
+
+  it('rebuilds Codex usage when a same-size transcript is rename-replaced', () => {
+    const p = join(dir, 'codex-rename-replace.jsonl');
+    const firstLine = `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`;
+    const { finalSize } = writeOversizedCodexSnapshot(p, firstLine);
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({ in: 100, out: 10 });
+
+    const replacement = join(dir, 'codex-rename-replace-new.jsonl');
+    writeOversizedCodexSnapshot(replacement, `${codexCountLine(999, 90, 300, { used: 400, window: 1_000 })}\n`);
+    truncateSync(replacement, finalSize);
+    renameSync(replacement, p);
+    now += 20_000;
+
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({
+      in: 999,
+      out: 90,
+      inputTokens: 699,
+      cacheReadTokens: 300,
+    });
+  });
+
+  it('does not inherit old cumulative tokens when a replacement Codex generation only has context', () => {
+    const p = join(dir, 'codex-replace-context-only.jsonl');
+    const { finalSize } = writeOversizedCodexSnapshot(
+      p,
+      `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`,
+    );
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 30 },
+      tokens: { in: 100, out: 10 },
+    });
+
+    const replacement = join(dir, 'codex-replace-context-only-new.jsonl');
+    writeOversizedCodexSnapshot(replacement, `${codexContextLine(240, 1_000)}\n`);
+    truncateSync(replacement, finalSize);
+    renameSync(replacement, p);
+    now += 20_000;
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toEqual({
+      context: { usedTokens: 240, windowTokens: 1_000, percentUsed: 24 },
+      tokens: null,
+      turnTokens: null,
+    });
+  });
+
+  it('does not inherit old context when a replacement Codex generation only has cumulative tokens', () => {
+    const p = join(dir, 'codex-replace-cumulative-only.jsonl');
+    const { finalSize } = writeOversizedCodexSnapshot(
+      p,
+      `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`,
+    );
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 30 },
+      tokens: { in: 100, out: 10 },
+    });
+
+    const replacement = join(dir, 'codex-replace-cumulative-only-new.jsonl');
+    writeOversizedCodexSnapshot(replacement, `${codexCountLine(500, 60, 200)}\n`);
+    truncateSync(replacement, finalSize);
+    renameSync(replacement, p);
+    now += 20_000;
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toEqual({
+      context: null,
+      tokens: {
+        in: 500,
+        out: 60,
+        inputTokens: 300,
+        outputTokens: 60,
+        cacheReadTokens: 200,
+        cacheCreateTokens: 0,
+        model: '',
+        turns: 0,
+      },
+      turnTokens: null,
+    });
+  });
+
+  it('rebuilds Codex usage when the same inode is rewritten to the same size', () => {
+    const p = join(dir, 'codex-same-inode-same-size.jsonl');
+    const firstLine = `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`;
+    const { finalSize } = writeOversizedCodexSnapshot(p, firstLine);
+    const firstStat = statSync(p);
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({ in: 100, out: 10 });
+
+    codexSnapshotAtTail(p, `${codexCountLine(777, 70, 300, { used: 400, window: 1_000 })}\n`);
+    truncateSync(p, finalSize);
+    const secondStat = statSync(p);
+    expect(secondStat.ino).toBe(firstStat.ino);
+    now += 20_000;
+
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({
+      in: 777,
+      out: 70,
+      inputTokens: 477,
+      cacheReadTokens: 300,
+    });
+  });
+
+  it('rebuilds Codex usage when the same inode is rewritten and grows slightly', () => {
+    const p = join(dir, 'codex-same-inode-grows.jsonl');
+    const firstLine = `${codexCountLine(100, 10, 20, { used: 30, window: 1_000 })}\n`;
+    const { finalSize } = writeOversizedCodexSnapshot(p, firstLine);
+    const firstStat = statSync(p);
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({ in: 100, out: 10 });
+
+    codexSnapshotAtTailSize(p, `${codexCountLine(888, 80, 300, { used: 400, window: 1_000 })}\n`, finalSize + 128);
+    const secondStat = statSync(p);
+    expect(secondStat.ino).toBe(firstStat.ino);
+    now += 20_000;
+
+    expect(readSessionTokenUsageFile(p, 'codex', { fresh: true })).toMatchObject({
+      in: 888,
+      out: 80,
+      inputTokens: 588,
+      cacheReadTokens: 300,
+    });
+  });
+
+  it('uses nonblocking regular-file checks for the Codex tail boundary probe and fails closed on non-regular fds', () => {
+    const p = join(dir, 'codex-boundary-probe-fail-closed.jsonl');
+    const firstTailLine = `${codexCountLine(400, 50, 25, { used: 120, window: 1_000 })}\n`;
+    writeOversizedCodexSnapshot(p, firstTailLine);
+    vi.mocked(findCodexRolloutBySessionId).mockReturnValue(p);
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toMatchObject({
+      context: { usedTokens: 120, windowTokens: 1_000, percentUsed: 12 },
+      tokens: { in: 400, out: 50, inputTokens: 375, cacheReadTokens: 25 },
+      turnTokens: null,
+    });
+
+    __resetSessionUsageCachesForTest();
+    vi.mocked(fstatSync).mockImplementationOnce(() => ({ isFile: () => false }) as any);
+
+    expect(getSessionUsageSnapshot({
+      cliId: 'codex',
+      sessionId: 'botmux-sid',
+      cliSessionId: 'codex-sid',
+      fresh: true,
+    })).toEqual({ context: null, tokens: null, turnTokens: null });
+    expect(vi.mocked(openSync).mock.calls.some(([, flags]) => {
+      return typeof flags === 'number' && (flags & constants.O_NONBLOCK) === constants.O_NONBLOCK;
+    })).toBe(true);
   });
 
   it('skips oversized transcripts instead of scanning them from byte zero', () => {

--- a/test/cost-calculator.test.ts
+++ b/test/cost-calculator.test.ts
@@ -17,14 +17,40 @@ vi.mock('node:os', async (importOriginal) => ({
 // Mock fs so we never touch real disk
 vi.mock('node:fs', async (importOriginal) => {
   const original = await importOriginal<typeof import('node:fs')>();
+  const readFileSyncMock = vi.fn(() => '');
+  const fdContent = new Map<number, string>();
+  let nextFd = 10_000;
+  const statsForContent = (content: string) => ({
+    dev: 1,
+    ino: 1,
+    size: Buffer.byteLength(content, 'utf8'),
+    mtimeMs: 1,
+    ctimeMs: 1,
+    isFile: () => true,
+  });
   return {
     ...original,
+    closeSync: vi.fn((fd: number) => { fdContent.delete(fd); }),
     existsSync: vi.fn(() => false),
+    fstatSync: vi.fn((fd: number) => statsForContent(fdContent.get(fd) ?? '')),
     lstatSync: vi.fn(() => ({
       isFile: () => true,
       mtimeMs: 0,
     })),
-    readFileSync: vi.fn(() => ''),
+    openSync: vi.fn((path: string) => {
+      const fd = nextFd++;
+      fdContent.set(fd, String(readFileSyncMock(path, 'utf-8') ?? ''));
+      return fd;
+    }),
+    readFileSync: readFileSyncMock,
+    readSync: vi.fn((fd: number, buffer: Buffer, offset: number, length: number, position: number | null) => {
+      const content = Buffer.from(fdContent.get(fd) ?? '', 'utf8');
+      const start = Math.max(0, position ?? 0);
+      const slice = content.subarray(start, start + length);
+      slice.copy(buffer, offset);
+      return slice.length;
+    }),
+    statSync: vi.fn((path: string) => statsForContent(String(readFileSyncMock(path, 'utf-8') ?? ''))),
   };
 });
 

--- a/test/jsonl-cursor.test.ts
+++ b/test/jsonl-cursor.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -132,5 +132,51 @@ describe('scanJsonlFromOffset', () => {
       newOffset: Buffer.byteLength(text + nextLine, 'utf8'),
       pendingTail: '',
     });
+  });
+
+  it('does not repeatedly concatenate an accumulated long line on every chunk', () => {
+    const longLine = 'x'.repeat(256 * 1024);
+    const secondLine = '{"type":"complete"}';
+    const text = `${longLine}\n${secondLine}\n`;
+    writeFileSync(path, text, 'utf8');
+
+    const concatSpy = vi.spyOn(Buffer, 'concat');
+    try {
+      const lines: Array<{ line: string; lineStart: number }> = [];
+      const cursor = scanJsonlFromOffset(path, 0, {
+        chunkSize: 1024,
+        onLine: (line, lineStart) => lines.push({ line, lineStart }),
+      });
+
+      expect(lines).toEqual([
+        { line: longLine, lineStart: 0 },
+        { line: secondLine, lineStart: Buffer.byteLength(`${longLine}\n`, 'utf8') },
+      ]);
+      expect(cursor).toEqual({
+        newOffset: Buffer.byteLength(text, 'utf8'),
+        pendingTail: '',
+      });
+      expect(concatSpy.mock.calls.length).toBeLessThanOrEqual(1);
+
+      concatSpy.mockClear();
+      const appended = '{"type":"next"}\n';
+      appendFileSync(path, appended, 'utf8');
+      const followUpLines: Array<{ line: string; lineStart: number }> = [];
+      const followUpCursor = scanJsonlFromOffset(path, cursor!.newOffset, {
+        chunkSize: 3,
+        onLine: (line, lineStart) => followUpLines.push({ line, lineStart }),
+      });
+      expect(followUpLines).toEqual([{
+        line: '{"type":"next"}',
+        lineStart: Buffer.byteLength(text, 'utf8'),
+      }]);
+      expect(followUpCursor).toEqual({
+        newOffset: Buffer.byteLength(text + appended, 'utf8'),
+        pendingTail: '',
+      });
+      expect(concatSpy.mock.calls.length).toBeLessThanOrEqual(1);
+    } finally {
+      concatSpy.mockRestore();
+    }
   });
 });

--- a/test/jsonl-cursor.test.ts
+++ b/test/jsonl-cursor.test.ts
@@ -92,4 +92,45 @@ describe('scanJsonlFromOffset', () => {
       pendingTail: '',
     });
   });
+
+  it('keeps durable byte offsets correct when starting inside a UTF-8 codepoint', () => {
+    const prefix = '中';
+    const firstLine = 'broken-prefix\n';
+    const appendedLine = '{"type":"event_msg"}\n';
+    const text = prefix + firstLine + appendedLine;
+    writeFileSync(path, text, 'utf8');
+
+    const lines: Array<{ line: string; lineStart: number }> = [];
+    const cursor = scanJsonlFromOffset(path, 1, {
+      chunkSize: 2,
+      onLine: (line, lineStart) => lines.push({ line, lineStart }),
+    });
+
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toEqual({
+      line: '{"type":"event_msg"}',
+      lineStart: Buffer.byteLength(prefix + firstLine, 'utf8'),
+    });
+    expect(cursor).toEqual({
+      newOffset: Buffer.byteLength(text, 'utf8'),
+      pendingTail: '',
+    });
+
+    const nextLine = '{"type":"token_count"}\n';
+    appendFileSync(path, nextLine, 'utf8');
+    const followUpLines: Array<{ line: string; lineStart: number }> = [];
+    const followUpCursor = scanJsonlFromOffset(path, cursor!.newOffset, {
+      chunkSize: 3,
+      onLine: (line, lineStart) => followUpLines.push({ line, lineStart }),
+    });
+
+    expect(followUpLines).toEqual([{
+      line: '{"type":"token_count"}',
+      lineStart: Buffer.byteLength(text, 'utf8'),
+    }]);
+    expect(followUpCursor).toEqual({
+      newOffset: Buffer.byteLength(text + nextLine, 'utf8'),
+      pendingTail: '',
+    });
+  });
 });


### PR DESCRIPTION
## 改了什么

- Codex/TraeX transcript 的 token usage 缓存统一走 safe regular-file fd 读取路径；normal 小文件、oversized 冷尾扫和后续变化都复用同一套 fd 稳定性校验。
- oversized Codex/TraeX 冷恢复保持严格有界尾扫：只读 4 MiB tail 加 1 byte boundary probe；latest token_count wins，恢复 context 与 cumulative token snapshot，保持 turnTokens=null。
- Codex fresh 变化后不再用 64-byte frontier 或 delta-only cached.state 证明旧值有效；改为从旧非空 cumulative/context/model 的最早可追溯 source offset 到 current end 做 bounded tracked replay。
- 若 source 缺失、source offset 非 JSONL boundary 或 replay span 超过 4 MiB：normal 从 0 rebuild（最多 64 MiB），oversized 从 current 4 MiB tail rebuild；未覆盖旧指标不继承。
- 删除不再参与正确性证明的 production frontier fingerprint 字段/helper/capture/export、source SHA/hash validation 与旧 merge helper；source record 收窄为 offset，64 KiB guard 改用 Buffer.byteLength。
- JSONL cursor 仍按 chunk 读取、按 logical line 线性累积分片，只在完整行或 pending tail materialize 时拼接，避免超长无换行记录 O(n^2) 同步复制。
- 收窄非 Codex 影响面：Claude/CoCo/Pi/generic oversized 行为保持 fail-safe；非 Codex cache 写入不新增 probe。

## 为什么

- 旧实现对大于 64 MiB 的 Codex transcript 冷读直接跳过，导致 daemon 重启或冷恢复后超长会话卡片丢失 context 与 cumulative usage。
- Codex/TraeX 的 token_count 是累积快照，最新快照同时包含累计 token 与 context；真实大样本最后 4 MiB 内已有足够 token_count，无需全文件扫描。
- 仅校验旧 source 行或 64-byte frontier 不能证明 source 到 durable frontier 之间的已扫描区间未变化；同 inode 等长原位改写可能插入更晚 token_count，让旧 cache stale。
- tracked replay 是确定性证明：用同一 safe regular-file fd 从可追溯 source offset 重放到 current end；若不能在有界窗口内证明，就重建或 tail rebuild，避免继承未覆盖旧值。
- 删除 frontier/hash 死路径可避免额外 64-byte IO，也消除未来把采样/旧 source hash 误用为完整 generation 证明的入口。

## 影响面

- 生产代码影响：`src/core/cost-calculator.ts`、`src/services/jsonl-cursor.ts`。
- 测试影响：`test/cost-calculator-cache.test.ts`、`test/cost-calculator.test.ts`、`test/jsonl-cursor.test.ts`。
- Codex/TraeX：normal 小文件仍支持有界 tracked replay；oversized 冷读/超限变化仍限制在 current 4 MiB tail；cache 继承只来自本轮 replay/rebuild 真实解析结果。
- 非 Codex：Claude/CoCo/Pi/generic oversized 行为保持 fail-safe；Aiden/Claude/CoCo/Pi/generic cache 写入不新增 64-byte probe。
- 共享 JSONL cursor：修复 byte offset 与超长行线性累积；`scanJsonlFromFd` 不关闭 caller-owned fd，path 版只负责 open/fstat/close。
- 未改 Usage Ledger、Worker、卡片渲染、resolver、live daemon 或全局配置。

## 验证

- 通过：`rtk pnpm vitest run --project unit test/cost-calculator-cache.test.ts`
  - 44/44 passed。
- 通过：`rtk pnpm vitest run --project unit test/cost-calculator-cache.test.ts test/cost-calculator.test.ts test/jsonl-cursor.test.ts test/coco-transcript.test.ts`
  - 4 files passed；119/119 passed（cache 44、cost 53、jsonl 9、CoCo 13）。
- 通过：`rtk git diff --check`。
- 通过：`rtk pnpm build`
  - domain audit clean；tsc/build-dashboard/audit-dist completed；本地 build id `e96302f4166c`。
- tracked replay / fallback IO 预算已由测试固化：
  - unchanged-stat 快路径 0 readSync。
  - cold normal / normal full rebuild：read <= fileSize（<=64 MiB）。
  - cold/rebuild oversized：1 byte boundary + 4 MiB scan。
  - tracked replay：`(offset > 0 ? 1 byte boundary : 0) + replaySpan`，replaySpan <=4 MiB，支持多 chunk。
  - boundary-rejection fallback：normal 精确 `fileSize + 1`；oversized 精确 `4 MiB + 2`。
- 真实大文件 smoke：`/home/chenjihong.daryl/.codex/sessions/2026/07/19/rollout-2026-07-19T18-40-47-019f79f6-d730-7dc2-993e-26cb0815083d.jsonl`
  - 本轮文件持续增长，当前 fileSize=179,807,385 bytes；target readSync calls=65；requested=4,194,305 bytes（4 MiB + 1 boundary）；bounded=true。
  - 恢复 context=214,421/258,400=83%；tokens in=1,820,860,890，out=3,540,121，inputTokens=45,723,866，cacheRead=1,775,137,024，cacheCreate=0，model=gpt-5.6-sol，turnTokens=null。
- 64 MiB 单行 JSONL smoke 保持此前结论：Buffer.concat=1 次；concatBytes=67,108,864；newOffset=67,108,865；pendingTail=""，O(n^2) blocker 已消除。
- 全量 `pnpm test` 未在本提交后宣称通过；当前稳定可复现环境基线仍为 Git 2.20.1 不支持 `git init -b` 导致 26 条 worktree/repo 相关测试失败，另有 tmux wrapper 1 条失败。负载期额外无关异常已单独复跑 287/287 通过；CI 状态以后续 GitHub checks 为准。