### PR TITLE
fix(worker): 普通消息缺少提交确认时自动重试

### DIFF
--- a/src/core/input-turn-dedupe.ts
+++ b/src/core/input-turn-dedupe.ts
@@ -1,0 +1,54 @@
+export type InputTurnState = 'inflight' | 'committed';
+
+/**
+ * Worker-local idempotency fence for daemon retries.
+ *
+ * A retry can arrive while the first IPC handler is still committing the same
+ * turn. Keep that distinct from a committed duplicate: inflight duplicates are
+ * ignored and wait for the original ACK, while committed duplicates re-ACK
+ * without entering the CLI input queue again.
+ */
+export class InputTurnDeduper {
+  private readonly states = new Map<string, InputTurnState>();
+
+  constructor(private readonly maxCommitted = 256) {}
+
+  begin(turnId: string): 'new' | InputTurnState {
+    const current = this.states.get(turnId);
+    if (current) return current;
+    this.states.set(turnId, 'inflight');
+    return 'new';
+  }
+
+  commit(turnId: string): void {
+    // ACKs for adopt / durable-dispatch turns share the same worker helper but
+    // are outside this ordinary-IM fence. Do not let those unrelated turn IDs
+    // evict committed ordinary messages from the bounded replay window.
+    if (!this.states.has(turnId)) return;
+    this.states.delete(turnId);
+    this.states.set(turnId, 'committed');
+    this.pruneCommitted();
+  }
+
+  release(turnId: string): void {
+    if (this.states.get(turnId) === 'inflight') this.states.delete(turnId);
+  }
+
+  state(turnId: string): InputTurnState | undefined {
+    return this.states.get(turnId);
+  }
+
+  private pruneCommitted(): void {
+    let committed = 0;
+    for (const state of this.states.values()) {
+      if (state === 'committed') committed += 1;
+    }
+    if (committed <= this.maxCommitted) return;
+    for (const [turnId, state] of this.states) {
+      if (state !== 'committed') continue;
+      this.states.delete(turnId);
+      committed -= 1;
+      if (committed <= this.maxCommitted) break;
+    }
+  }
+}

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -2860,6 +2860,220 @@ const transferInputGates = new WeakMap<DaemonSession, TransferInputGate>();
 // cannot forge an option that bypasses the transfer gate.
 const transferReplacementForkBypass = new WeakSet<DaemonSession>();
 
+const ORDINARY_IM_RECEIPT_TIMEOUT_MS = 2_000;
+const ORDINARY_IM_MAX_ATTEMPTS = 2;
+
+type OrdinaryImDelivery = {
+  key: string;
+  ds: DaemonSession;
+  worker: ChildProcess;
+  workerGeneration: number;
+  message: Extract<DaemonToWorker, { type: 'message' | 'init' }>;
+  turnId: string;
+  attempt: number;
+  timer?: ReturnType<typeof setTimeout>;
+};
+
+/** Exact ordinary-IM turns awaiting the worker's synchronous receipt ACK. The
+ * daemon event has already been claimed by Lark dedup at this point, so losing
+ * this in-memory delivery without retry would permanently drop the message. */
+const pendingOrdinaryImDeliveries = new Map<string, OrdinaryImDelivery>();
+
+function ordinaryImDeliveryKey(ds: DaemonSession, turnId: string, workerGeneration: number): string {
+  return `${ds.session.sessionId}:${workerGeneration}:${turnId}`;
+}
+
+function clearOrdinaryImDelivery(record: OrdinaryImDelivery): void {
+  if (record.timer) clearTimeout(record.timer);
+  record.timer = undefined;
+  if (pendingOrdinaryImDeliveries.get(record.key) === record) {
+    pendingOrdinaryImDeliveries.delete(record.key);
+  }
+}
+
+function clearOrdinaryImDeliveryTimer(record: OrdinaryImDelivery): void {
+  if (record.timer) clearTimeout(record.timer);
+  record.timer = undefined;
+}
+
+function failOrdinaryImDelivery(record: OrdinaryImDelivery, reason: string): void {
+  if (pendingOrdinaryImDeliveries.get(record.key) !== record) return;
+  clearOrdinaryImDelivery(record);
+  logger.error(
+    `[${tag(record.ds)}] Ordinary IM worker delivery failed `
+    + `turn=${record.turnId.substring(0, 16)} generation=${record.workerGeneration} `
+    + `attempts=${record.attempt} reason=${reason}`,
+  );
+  if (record.ds.session.vcMeetingReceiver || isSilentScheduledTurn(record.ds, record.turnId)) return;
+  const loc = botLocale(getBot(record.ds.larkAppId).config);
+  void requireCallbacks().sessionReply(
+    sessionAnchorId(record.ds),
+    tr('worker.input_delivery_failed', { turnId: record.turnId.substring(0, 16) }, loc),
+    'text',
+    record.ds.larkAppId,
+    record.turnId,
+  ).catch(err => logger.error(
+    `[${tag(record.ds)}] Failed to report ordinary IM worker delivery failure: `
+    + `${err instanceof Error ? err.message : String(err)}`,
+  ));
+}
+
+function retryOrFailOrdinaryImDelivery(record: OrdinaryImDelivery, reason: string): void {
+  if (pendingOrdinaryImDeliveries.get(record.key) !== record) return;
+  if (
+    record.attempt < ORDINARY_IM_MAX_ATTEMPTS
+    && record.ds.worker === record.worker
+    && !record.worker.killed
+    && record.ds.workerGeneration === record.workerGeneration
+    && record.ds.session.workerGeneration === record.workerGeneration
+  ) {
+    logger.warn(
+      `[${tag(record.ds)}] Ordinary IM input missing worker receipt; retrying exact turn `
+      + `${record.turnId.substring(0, 16)} on generation ${record.workerGeneration} `
+      + `(reason=${reason})`,
+    );
+    sendOrdinaryImDeliveryAttempt(record);
+    return;
+  }
+  failOrdinaryImDelivery(record, reason);
+}
+
+function sendOrdinaryImDeliveryAttempt(record: OrdinaryImDelivery): boolean {
+  if (pendingOrdinaryImDeliveries.get(record.key) !== record) return false;
+  if (
+    record.ds.worker !== record.worker
+    || record.worker.killed
+    || record.ds.workerGeneration !== record.workerGeneration
+    || record.ds.session.workerGeneration !== record.workerGeneration
+  ) {
+    failOrdinaryImDelivery(record, 'worker_generation_changed');
+    return false;
+  }
+
+  if (record.timer) clearTimeout(record.timer);
+  record.timer = undefined;
+  const attempt = ++record.attempt;
+  try {
+    record.worker.send(record.message, (err) => {
+      if (pendingOrdinaryImDeliveries.get(record.key) !== record || record.attempt !== attempt) return;
+      if (err) {
+        retryOrFailOrdinaryImDelivery(record, `ipc_callback:${err.message}`);
+        return;
+      }
+      logger.info(
+        `[${tag(record.ds)}] Ordinary IM input enqueued to worker IPC `
+        + `turn=${record.turnId.substring(0, 16)} generation=${record.workerGeneration} attempt=${attempt}`,
+      );
+    });
+  } catch (err) {
+    queueMicrotask(() => retryOrFailOrdinaryImDelivery(
+      record,
+      `ipc_throw:${err instanceof Error ? err.message : String(err)}`,
+    ));
+    return true;
+  }
+
+  // The worker ACKs synchronously when its IPC handler claims the exact turn.
+  // Slow CLI startup/processing therefore does not extend this transport-only
+  // timeout; the later committed ACK retains input-queue semantics.
+  if (pendingOrdinaryImDeliveries.get(record.key) === record) {
+    record.timer = setTimeout(() => {
+      retryOrFailOrdinaryImDelivery(record, 'receipt_timeout');
+    }, ORDINARY_IM_RECEIPT_TIMEOUT_MS);
+    record.timer.unref?.();
+  }
+  return true;
+}
+
+function sendOrdinaryImDeliveryTracked(
+  ds: DaemonSession,
+  message: Extract<DaemonToWorker, { type: 'message' | 'init' }>,
+): boolean {
+  const turnId = message.turnId;
+  const worker = ds.worker;
+  const workerGeneration = ds.workerGeneration;
+  if (!turnId || !worker || worker.killed || !Number.isSafeInteger(workerGeneration) || (workerGeneration ?? 0) <= 0) {
+    return false;
+  }
+  const key = ordinaryImDeliveryKey(ds, turnId, workerGeneration!);
+  if (pendingOrdinaryImDeliveries.has(key)) return true;
+  const record: OrdinaryImDelivery = {
+    key,
+    ds,
+    worker,
+    workerGeneration: workerGeneration!,
+    message,
+    turnId,
+    attempt: 0,
+  };
+  pendingOrdinaryImDeliveries.set(key, record);
+  return sendOrdinaryImDeliveryAttempt(record);
+}
+
+function shouldTrackOrdinaryImDelivery(
+  ds: DaemonSession,
+  message: Extract<DaemonToWorker, { type: 'message' | 'init' }>,
+): boolean {
+  return !!message.turnId?.startsWith('om_')
+    && message.dispatchAttempt === undefined
+    && (message.type !== 'init' || (!!message.prompt && !message.adoptMode))
+    && !ds.adoptedFrom
+    && !ds.session.vcMeetingReceiver
+    && Number.isSafeInteger(ds.workerGeneration)
+    && (ds.workerGeneration ?? 0) > 0
+    && ds.session.workerGeneration === ds.workerGeneration;
+}
+
+function acknowledgeOrdinaryImDeliveryReceipt(
+  ds: DaemonSession,
+  turnId: string,
+  workerGeneration: number,
+): void {
+  const key = ordinaryImDeliveryKey(ds, turnId, workerGeneration);
+  const record = pendingOrdinaryImDeliveries.get(key);
+  if (!record) return;
+  clearOrdinaryImDeliveryTimer(record);
+  logger.info(
+    `[${tag(ds)}] Ordinary IM input received by worker `
+    + `turn=${turnId.substring(0, 16)} generation=${workerGeneration} attempt=${record.attempt}`,
+  );
+}
+
+function completeOrdinaryImDelivery(
+  ds: DaemonSession,
+  turnId: string,
+  workerGeneration: number,
+): void {
+  const key = ordinaryImDeliveryKey(ds, turnId, workerGeneration);
+  const record = pendingOrdinaryImDeliveries.get(key);
+  if (record) clearOrdinaryImDelivery(record);
+}
+
+function rejectOrdinaryImDelivery(
+  ds: DaemonSession,
+  turnId: string,
+  workerGeneration: number,
+  reason: string,
+): void {
+  const key = ordinaryImDeliveryKey(ds, turnId, workerGeneration);
+  const record = pendingOrdinaryImDeliveries.get(key);
+  if (!record) return;
+  retryOrFailOrdinaryImDelivery(record, `worker_rejected:${reason}`);
+}
+
+function abandonOrdinaryImDeliveriesForWorker(worker: ChildProcess): void {
+  for (const record of pendingOrdinaryImDeliveries.values()) {
+    if (record.worker === worker) clearOrdinaryImDelivery(record);
+  }
+}
+
+export function __testOnly_resetOrdinaryImDeliveries(): void {
+  for (const record of pendingOrdinaryImDeliveries.values()) {
+    if (record.timer) clearTimeout(record.timer);
+  }
+  pendingOrdinaryImDeliveries.clear();
+}
+
 export function isSessionTransferring(ds: DaemonSession): boolean {
   return transferInputGates.has(ds);
 }
@@ -3029,7 +3243,20 @@ function releaseTransferInputGate(
     while (gate.messages.length > 0) {
       const message = gate.messages[0];
       try {
-        worker.send(message);
+        if (
+          message.type === 'message'
+          && shouldTrackOrdinaryImDelivery(ds, message)
+        ) {
+          // The transfer gate owns buffering/order; once a replacement
+          // generation exists, ordinary IM delivery returns to the same exact
+          // receipt protocol as steady-state input. The watchdog remains valid
+          // after the gate itself settles.
+          if (!sendOrdinaryImDeliveryTracked(ds, message)) {
+            throw new Error('replacement worker rejected tracked IM delivery');
+          }
+        } else {
+          worker.send(message);
+        }
         gate.messages.shift();
       } catch (err) {
         gate.needsWorker = true;
@@ -3802,6 +4029,9 @@ export function sendWorkerInput(
       ? { vcMeetingImTurnOrigin }
       : {}),
   };
+  if (!transferGate && shouldTrackOrdinaryImDelivery(ds, message)) {
+    return sendOrdinaryImDeliveryTracked(ds, message);
+  }
   return sendWorkerSessionInput(ds, message);
 }
 
@@ -4264,7 +4494,6 @@ export function forkWorker(
       sessionStore.updateSession(ds.session);
     }
   }
-  worker.send(initMsg);
   ds.initConfig = initMsg;
 
   // Stamp cliId on the persisted session so the dashboard can show a CLI badge
@@ -4292,6 +4521,11 @@ export function forkWorker(
   setupWorkerHandlers(ds, worker, startupState, workerGeneration);
 
   ds.worker = worker;
+  if (shouldTrackOrdinaryImDelivery(ds, initMsg)) {
+    sendOrdinaryImDeliveryTracked(ds, initMsg);
+  } else {
+    worker.send(initMsg);
+  }
   ds.spawnedAt = Date.now();
   ds.cliVersion = getCurrentCliVersion(runtimeInstallationKey({
     cliId: agentCfg.cliId,
@@ -4594,6 +4828,30 @@ function setupWorkerHandlers(
         sessionStore.updateSession(ds.session);
         break;
       }
+      case 'turn_input_received': {
+        if (
+          ds.worker !== worker
+          || ds.workerGeneration !== workerGeneration
+          || ds.session.workerGeneration !== workerGeneration
+        ) {
+          logger.warn(`[${t}] Ignored turn_input_received from stale worker generation`);
+          break;
+        }
+        acknowledgeOrdinaryImDeliveryReceipt(ds, msg.turnId, workerGeneration);
+        break;
+      }
+      case 'turn_input_rejected': {
+        if (
+          ds.worker !== worker
+          || ds.workerGeneration !== workerGeneration
+          || ds.session.workerGeneration !== workerGeneration
+        ) {
+          logger.warn(`[${t}] Ignored turn_input_rejected from stale worker generation`);
+          break;
+        }
+        rejectOrdinaryImDelivery(ds, msg.turnId, workerGeneration, msg.reason);
+        break;
+      }
       case 'turn_input_committed': {
         // Bind the receipt to the exact live worker generation. A late ACK
         // from a replaced worker cannot make the replacement appear to have
@@ -4606,6 +4864,9 @@ function setupWorkerHandlers(
           logger.warn(`[${t}] Ignored turn_input_committed from stale worker generation`);
           break;
         }
+        // Compatibility/fallback: a commit also proves receipt if the earlier
+        // receipt ACK was delayed or dropped on the reverse IPC channel.
+        completeOrdinaryImDelivery(ds, msg.turnId, workerGeneration);
         if (recordDispatchInputCommit(ds.session, msg.turnId, workerGeneration)) {
           sessionStore.updateSession(ds.session);
           if (msg.turnId.startsWith('mlrp_turn_')) {
@@ -6165,6 +6426,7 @@ function setupWorkerHandlers(
   });
 
   worker.on('exit', (code, signal) => {
+    abandonOrdinaryImDeliveriesForWorker(worker);
     const transferRetirement = transferRetiringWorkers.has(worker);
     transferRetiringWorkers.delete(worker);
     clearLifecycleRetirement(ds, worker);

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -798,6 +798,7 @@ export const messages: Record<string, string> = {
   'worker.crash_diagnostic_terminal': 'The web terminal, where available, preserves the last startup output. Fix the issue, then send a new message to retry.',
   'worker.crash_recent_output': 'Recent terminal output:',
   'worker.start_failed': '⚠️ The {cliName} session failed to start: {reason}\nCheck the Agent/backend settings in Dashboard and the installation environment on the daemon host, then resend your message to retry.',
+  'worker.input_delivery_failed': '⚠️ The Worker could not receive this message. Botmux retried on the same Worker but delivery still did not complete; it stopped before a cross-process retry to avoid duplicate execution. Please resend the message.\nturn: {turnId}',
   'worker.start_exited_early': 'The worker exited before becoming ready (exit code: {code}); see the Botmux logs for details.',
   'worker.tui_submit_failed': '⚠️ The TUI answer could not be confirmed as delivered to {cliName}. The CLI may still be waiting for input; open the local terminal or send a new message to recover.',
   'worker.raw_input_failed': '⚠️ The slash command could not be confirmed as delivered to {cliName}, so the follow-up text in the same message was not submitted. Check the terminal state, then resend.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -801,6 +801,7 @@ export const messages: Record<string, string> = {
   'worker.crash_diagnostic_terminal': 'Web 终端（若可用）保留了最后一次启动输出，可打开查看；修复问题后发新消息会重新启动。',
   'worker.crash_recent_output': '最近终端输出：',
   'worker.start_failed': '⚠️ {cliName} 会话启动失败：{reason}\n请检查 Dashboard 的 Agent / 后端配置和 daemon 所在机器的安装环境，修复后重发消息即可重试。',
+  'worker.input_delivery_failed': '⚠️ Worker 未能接收这条消息。Botmux 已在同一 Worker 上自动重试，但仍未完成接收；为避免跨进程重复执行，没有继续重投。请重发本条消息。\nturn: {turnId}',
   'worker.start_exited_early': 'worker 在就绪前退出（exit code: {code}）；详细错误可查看 Botmux 日志。',
   'worker.tui_submit_failed': '⚠️ TUI 答案未能确认送达 {cliName}。CLI 可能仍在等待输入；请打开本机终端处理，或发送一条新消息解除并继续。',
   'worker.raw_input_failed': '⚠️ Slash 命令未能确认送达 {cliName}，同一条消息中紧随其后的正文没有继续提交。请检查当前终端状态后重发。',

--- a/src/types.ts
+++ b/src/types.ts
@@ -736,6 +736,14 @@ export type WorkerToDaemon =
    * CLI input queue. The daemon persists a root-bound receipt only after this
    * acknowledgement; IPC arrival alone is not acceptance. */
   | { type: 'turn_input_committed'; turnId: string }
+  /** Transport-only receipt for ordinary Lark IM delivery. Emitted
+   * synchronously when the live worker's IPC handler claims the exact turn,
+   * before slow startup work; input-queue ownership is acknowledged separately
+   * by turn_input_committed. */
+  | { type: 'turn_input_received'; turnId: string }
+  /** The worker received an ordinary turn but could not place it into its CLI
+   * input queue. This is safe to retry within the same worker generation. */
+  | { type: 'turn_input_rejected'; turnId: string; reason: string }
   /** Transfer-only completion fence. Emitted after the old worker has detached
    * its backend observer and disarmed sandbox teardown, immediately before it
    * exits. The daemon also waits for that child exit before forking replacement. */

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -113,6 +113,7 @@ import {
 import { readPlatformBinding } from './platform/binding.js';
 import { loadDashboardSecret, loadPersistedToken } from './dashboard/auth.js';
 import { InflightInputTracker } from './core/inflight-input-tracker.js';
+import { InputTurnDeduper } from './core/input-turn-dedupe.js';
 import {
   shouldRunQuietRotation,
   evaluatePidResolverPullback,
@@ -1334,6 +1335,10 @@ function cliName(): string {
 let isPromptReady = false;
 /** Mutex for async flushPending — prevents concurrent flush loops. */
 let isFlushing = false;
+/** An init prompt exists but spawn/RPC policy has not yet established whether
+ * it is argv-baked, RPC-owned, or queued. Concurrent follow-ups may enter the
+ * queue during async init, but must not flush ahead of this first turn. */
+let initialInputOwnershipPending = false;
 /** True from the moment an owned CLI restart begins until the replacement
  * backend has been synchronously installed. Async backends (notably Riff)
  * keep the old backend object alive while destroySession() awaits remote
@@ -1651,6 +1656,13 @@ const freshnessInputQueue = new CodexRunnerFreshnessInputQueue<
   state => { codexRunnerFreshness = state; },
 );
 const pendingMessages = freshnessInputQueue.normal;
+/** Ordinary Lark IM turns may be retransmitted by the daemon when the exact
+ * receipt ACK times out. Fence those retries before any renderer / adapter side
+ * effects so one Lark message can enter the CLI input queue at most once per
+ * worker generation. Durable receiver attempts already have their own lease
+ * protocol and adopt writes have an ambiguity journal, so this gate stays on
+ * non-adopt `om_` turns without dispatchAttempt. */
+const ordinaryImTurnDedupe = new InputTurnDeduper(256);
 /** Correlation ids that this worker actually wrote into the owned Codex App
  * runner. Runner lifecycle/final markers may route only to ids in this bounded
  * local set; model/user display bytes cannot add entries. */
@@ -6726,6 +6738,7 @@ async function flushPending(): Promise<void> {
   // old CLI. Never let a new flush (including one triggered by the old
   // backend's idle/task-done callback) write across that restart boundary.
   if (cliRestartInProgress) return;
+  if (initialInputOwnershipPending) return;
   if (shouldHoldCodexRunnerInput(codexRunnerFreshness)) return;
   if (isFlushing) return;  // while loop in active flush will pick up new messages
   if (!backend || !cliAdapter) return;
@@ -7160,7 +7173,6 @@ function sendToPty(
     vcMeetingImTurnOrigin?: VcMeetingImTurnOrigin;
   } = {},
 ): boolean {
-  if (!cliAdapter) return false;
   const next: PendingCliInput = {
     content,
     turnId,
@@ -7179,6 +7191,7 @@ function sendToPty(
     log(`Queued message while CLI backend is restarting (${pendingMessages.length} pending)`);
     return true;
   }
+  if (!cliAdapter) return false;
   const supportsTypeAhead = pendingInputAllowsTypeAhead(
     cliAdapter.supportsTypeAhead === true,
     durableTurnInFlight,
@@ -11723,7 +11736,24 @@ function send(msg: WorkerToDaemon): void {
 }
 
 function acknowledgeTurnInputCommitted(turnId?: string): void {
-  if (turnId) send({ type: 'turn_input_committed', turnId });
+  if (!turnId) return;
+  ordinaryImTurnDedupe.commit(turnId);
+  send({ type: 'turn_input_committed', turnId });
+}
+
+function acknowledgeTurnInputReceived(turnId?: string): void {
+  if (turnId) send({ type: 'turn_input_received', turnId });
+}
+
+function receiveOrdinaryImTurn(turnId: string): 'new' | 'inflight' | 'committed' {
+  const state = ordinaryImTurnDedupe.begin(turnId);
+  acknowledgeTurnInputReceived(turnId);
+  return state;
+}
+
+function rejectOrdinaryImTurn(turnId: string, reason: string): void {
+  ordinaryImTurnDedupe.release(turnId);
+  send({ type: 'turn_input_rejected', turnId, reason });
 }
 
 function publishLocalProcessAttestation(cliPid?: number): void {
@@ -11823,8 +11853,43 @@ process.on('message', async (raw: unknown) => {
   switch (msg.type) {
     case 'init': {
       const initStartedAtMs = Date.now();
-      if (lastInitConfig) return;  // already initialized
+      const ordinaryImTurnId = !msg.adoptMode
+        && msg.dispatchAttempt === undefined
+        && !!msg.prompt
+        && msg.turnId?.startsWith('om_')
+        ? msg.turnId
+        : undefined;
+      if (lastInitConfig) {
+        // Only an exact retry of this generation's init may be acknowledged.
+        // A different init is still rejected as an invalid re-initialization.
+        if (ordinaryImTurnId && lastInitConfig.turnId === ordinaryImTurnId) {
+          const duplicateState = receiveOrdinaryImTurn(ordinaryImTurnId);
+          if (duplicateState === 'committed') {
+            log(`Re-ACKing committed duplicate init turn ${ordinaryImTurnId.substring(0, 16)}`);
+            acknowledgeTurnInputCommitted(ordinaryImTurnId);
+          } else {
+            log(`Re-ACKing received duplicate init turn ${ordinaryImTurnId.substring(0, 16)}`);
+          }
+        }
+        return;
+      }
+      if (ordinaryImTurnId) {
+        const duplicateState = receiveOrdinaryImTurn(ordinaryImTurnId);
+        // Receipt is the daemon ↔ worker transport boundary. Publish it before
+        // startup work can await a slow backend, plugin gateway, or Codex
+        // metadata read. The later committed ACK keeps its existing meaning.
+        if (duplicateState === 'committed') {
+          log(`Re-ACKing committed duplicate init turn ${ordinaryImTurnId.substring(0, 16)}`);
+          acknowledgeTurnInputCommitted(ordinaryImTurnId);
+          break;
+        }
+        if (duplicateState === 'inflight') {
+          log(`Re-ACKing received duplicate init turn ${ordinaryImTurnId.substring(0, 16)}`);
+          break;
+        }
+      }
       lastInitConfig = msg;
+      initialInputOwnershipPending = !!msg.prompt;
       activeRestartAttemptId = msg.restartAttemptId;
       sessionId = msg.sessionId;
       refreshTerminalViewToken();
@@ -11979,7 +12044,10 @@ process.on('message', async (raw: unknown) => {
           passesInitialPromptViaArgs: cliAdapter?.passesInitialPromptViaArgs === true,
           deferInitialPrompt,
         })) {
-          pendingMessages.push({
+          // Follow-up IPC handlers can run while this async init is awaiting
+          // backend startup. They queue safely behind !backend above, but the
+          // original init prompt must remain first in logical turn order.
+          pendingMessages.unshift({
             content: lastSpawnQueuedInitialPrompt ?? msg.prompt,
             ...(lastSpawnQueuedInitialPromptLogicalContent
               ? { logicalContent: lastSpawnQueuedInitialPromptLogicalContent }
@@ -11995,6 +12063,10 @@ process.on('message', async (raw: unknown) => {
           // it into argv or the RPC engine already accepted it.
           initialInputCommitted = true;
         }
+        // The first turn is now either at queue head or already owned by the
+        // argv/RPC startup path. Only now may an early idle edge drain
+        // follow-ups that arrived while init was awaiting slow startup work.
+        initialInputOwnershipPending = false;
         if (initialInputCommitted) acknowledgeTurnInputCommitted(msg.turnId);
 
         // A backend may become prompt-ready before spawnCli() returns. The
@@ -12021,6 +12093,7 @@ process.on('message', async (raw: unknown) => {
           dispatchAttempt: currentBotmuxDispatchAttempt,
         });
       } catch (err: any) {
+        initialInputOwnershipPending = false;
         await sendFatalWorkerErrorAndExit(err);
         return;
       }
@@ -12029,6 +12102,25 @@ process.on('message', async (raw: unknown) => {
 
     case 'message': {
       const messageAdoptMode = lastInitConfig?.adoptMode === true;
+      const ordinaryImTurnId = !messageAdoptMode
+        && msg.dispatchAttempt === undefined
+        && msg.turnId?.startsWith('om_')
+        ? msg.turnId
+        : undefined;
+      if (ordinaryImTurnId) {
+        const duplicateState = receiveOrdinaryImTurn(ordinaryImTurnId);
+        // ACK process ownership synchronously, before crash recovery or any
+        // other awaited work. Actual queue ownership remains committed below.
+        if (duplicateState === 'committed') {
+          log(`Re-ACKing committed duplicate IM turn ${ordinaryImTurnId.substring(0, 16)}`);
+          acknowledgeTurnInputCommitted(ordinaryImTurnId);
+          break;
+        }
+        if (duplicateState === 'inflight') {
+          log(`Re-ACKing received duplicate IM turn ${ordinaryImTurnId.substring(0, 16)}`);
+          break;
+        }
+      }
       // Adopt IPC handlers can overlap. Delay their turn baseline until the
       // submission mutex is held so a queued message cannot steal attribution
       // from the write/verification already in flight.
@@ -12080,6 +12172,7 @@ process.on('message', async (raw: unknown) => {
           await spawnCli(restartCfg);
           await prepareCodexNativeTitleGeneration(restartCfg, codexRpcEngine);
         } catch (err) {
+          if (ordinaryImTurnId) ordinaryImTurnDedupe.release(ordinaryImTurnId);
           // Pass the message's own attempt (not the stale currentBotmux* from a
           // prior IM turn) so a durable delivery relaunch failure carries the
           // right attribution for the daemon's receipt/lease gate.
@@ -12334,6 +12427,7 @@ process.on('message', async (raw: unknown) => {
           vcMeetingImTurnOrigin: msg.vcMeetingImTurnOrigin,
         });
         if (inputCommitted) acknowledgeTurnInputCommitted(msg.turnId);
+        else if (ordinaryImTurnId) rejectOrdinaryImTurn(ordinaryImTurnId, 'cli_input_unavailable');
       }
       break;
     }

--- a/test/input-turn-dedupe.test.ts
+++ b/test/input-turn-dedupe.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { InputTurnDeduper } from '../src/core/input-turn-dedupe.js';
+
+describe('InputTurnDeduper', () => {
+  it('distinguishes inflight retries from committed duplicates', () => {
+    const dedupe = new InputTurnDeduper();
+
+    expect(dedupe.begin('om_turn')).toBe('new');
+    expect(dedupe.begin('om_turn')).toBe('inflight');
+
+    dedupe.commit('om_turn');
+    expect(dedupe.begin('om_turn')).toBe('committed');
+  });
+
+  it('releases an uncommitted turn so a retry can own it', () => {
+    const dedupe = new InputTurnDeduper();
+
+    expect(dedupe.begin('om_turn')).toBe('new');
+    dedupe.release('om_turn');
+
+    expect(dedupe.begin('om_turn')).toBe('new');
+  });
+
+  it('does not retain commits for turns that did not enter this fence', () => {
+    const dedupe = new InputTurnDeduper();
+
+    dedupe.commit('durable_turn');
+
+    expect(dedupe.state('durable_turn')).toBeUndefined();
+  });
+
+  it('keeps inflight turns while pruning old committed turns', () => {
+    const dedupe = new InputTurnDeduper(2);
+    dedupe.begin('om_inflight');
+    for (const turnId of ['om_1', 'om_2', 'om_3']) {
+      dedupe.begin(turnId);
+      dedupe.commit(turnId);
+    }
+
+    expect(dedupe.state('om_inflight')).toBe('inflight');
+    expect(dedupe.state('om_1')).toBeUndefined();
+    expect(dedupe.state('om_2')).toBe('committed');
+    expect(dedupe.state('om_3')).toBe('committed');
+  });
+});

--- a/test/session-lifecycle-start.test.ts
+++ b/test/session-lifecycle-start.test.ts
@@ -136,7 +136,13 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
 }));
 
 import { __testOnly_resetSessionLifecycleHooks } from '../src/services/session-lifecycle-hooks.js';
-import { forkAdoptWorker, forkWorker, initWorkerPool, sendWorkerInput } from '../src/core/worker-pool.js';
+import {
+  __testOnly_resetOrdinaryImDeliveries,
+  forkAdoptWorker,
+  forkWorker,
+  initWorkerPool,
+  sendWorkerInput,
+} from '../src/core/worker-pool.js';
 import type { DaemonSession } from '../src/core/types.js';
 import * as sessionStore from '../src/services/session-store.js';
 import { getBot } from '../src/bot-registry.js';
@@ -202,7 +208,9 @@ function defaultBot(overrides: Record<string, unknown> = {}) {
 }
 
 beforeEach(() => {
+  vi.useRealTimers();
   vi.clearAllMocks();
+  __testOnly_resetOrdinaryImDeliveries();
   vi.mocked(getBot).mockImplementation(() => defaultBot());
   __testOnly_resetSessionLifecycleHooks();
   forkMock.mockImplementation(() => makeFakeWorker());
@@ -211,6 +219,225 @@ beforeEach(() => {
     getSessionWorkingDir: () => '/repo',
     getActiveCount: () => 1,
     closeSession: vi.fn(),
+  });
+});
+
+describe('ordinary IM worker receipt acknowledgement', () => {
+  it('clears the watchdog when the exact live worker generation receives the turn', async () => {
+    vi.useFakeTimers();
+    const sessionReply = vi.fn(async () => 'om_reply');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/repo',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const ds = makeDs();
+    forkWorker(ds, 'hello', false);
+    const worker = forkMock.mock.results.at(-1)!.value;
+
+    expect(sendWorkerInput(ds, 'business turn', 'om_business')).toBe(true);
+    worker.emit('message', { type: 'turn_input_received', turnId: 'om_business' });
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    const businessSends = vi.mocked(worker.send).mock.calls
+      .map(call => call[0])
+      .filter(message => message?.type === 'message' && message?.turnId === 'om_business');
+    expect(businessSends).toHaveLength(1);
+    expect(sessionReply).not.toHaveBeenCalled();
+  });
+
+  it('retries the exact turn once and reports a visible failure when no receipt ACK arrives', async () => {
+    vi.useFakeTimers();
+    const sessionReply = vi.fn(async () => 'om_failure');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/repo',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const ds = makeDs();
+    forkWorker(ds, 'hello', false);
+    const worker = forkMock.mock.results.at(-1)!.value;
+
+    expect(sendWorkerInput(ds, 'business turn', 'om_business')).toBe(true);
+    await vi.advanceTimersByTimeAsync(2_000);
+    let businessSends = vi.mocked(worker.send).mock.calls
+      .map(call => call[0])
+      .filter(message => message?.type === 'message' && message?.turnId === 'om_business');
+    expect(businessSends).toHaveLength(2);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    await Promise.resolve();
+    expect(sessionReply).toHaveBeenCalledWith(
+      'om_root',
+      expect.stringContaining('Worker 未能接收'),
+      'text',
+      'app_test',
+      'om_business',
+    );
+    businessSends = vi.mocked(worker.send).mock.calls
+      .map(call => call[0])
+      .filter(message => message?.type === 'message' && message?.turnId === 'om_business');
+    expect(businessSends).toHaveLength(2);
+  });
+
+  it('retries immediately when the parent IPC callback rejects the enqueue', async () => {
+    vi.useFakeTimers();
+    const sessionReply = vi.fn(async () => 'om_failure');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/repo',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const ds = makeDs();
+    forkWorker(ds, 'hello', false);
+    const worker = forkMock.mock.results.at(-1)!.value;
+    vi.mocked(worker.send).mockImplementation((message: any, callback?: (err?: Error | null) => void) => {
+      if (message?.type === 'message') callback?.(new Error('channel closed'));
+    });
+
+    expect(sendWorkerInput(ds, 'business turn', 'om_business')).toBe(true);
+    await vi.runAllTicks();
+
+    const businessSends = vi.mocked(worker.send).mock.calls
+      .map(call => call[0])
+      .filter(message => message?.type === 'message' && message?.turnId === 'om_business');
+    expect(businessSends).toHaveLength(2);
+    expect(sessionReply).toHaveBeenCalledWith(
+      'om_root',
+      expect.stringContaining('Worker 未能接收'),
+      'text',
+      'app_test',
+      'om_business',
+    );
+  });
+
+  it('retries a turn that the worker received but could not enqueue', async () => {
+    vi.useFakeTimers();
+    const sessionReply = vi.fn(async () => 'om_failure');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/repo',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const ds = makeDs();
+    forkWorker(ds, 'hello', false);
+    const worker = forkMock.mock.results.at(-1)!.value;
+
+    expect(sendWorkerInput(ds, 'business turn', 'om_business')).toBe(true);
+    worker.emit('message', { type: 'turn_input_received', turnId: 'om_business' });
+    worker.emit('message', {
+      type: 'turn_input_rejected',
+      turnId: 'om_business',
+      reason: 'cli_input_unavailable',
+    });
+    let businessSends = vi.mocked(worker.send).mock.calls
+      .map(call => call[0])
+      .filter(message => message?.type === 'message' && message?.turnId === 'om_business');
+    expect(businessSends).toHaveLength(2);
+
+    worker.emit('message', { type: 'turn_input_received', turnId: 'om_business' });
+    worker.emit('message', {
+      type: 'turn_input_rejected',
+      turnId: 'om_business',
+      reason: 'cli_input_unavailable',
+    });
+    await Promise.resolve();
+
+    expect(sessionReply).toHaveBeenCalledWith(
+      'om_root',
+      expect.stringContaining('Worker 未能接收'),
+      'text',
+      'app_test',
+      'om_business',
+    );
+    businessSends = vi.mocked(worker.send).mock.calls
+      .map(call => call[0])
+      .filter(message => message?.type === 'message' && message?.turnId === 'om_business');
+    expect(businessSends).toHaveLength(2);
+  });
+
+  it('ignores a stale worker ACK and fails the original generation visibly', async () => {
+    vi.useFakeTimers();
+    const sessionReply = vi.fn(async () => 'om_failure');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/repo',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const ds = makeDs();
+    forkWorker(ds, 'first', false);
+    const firstWorker = forkMock.mock.results.at(-1)!.value;
+    expect(sendWorkerInput(ds, 'business turn', 'om_business')).toBe(true);
+
+    forkWorker(ds, 'replacement', { resume: true });
+    firstWorker.emit('message', { type: 'turn_input_received', turnId: 'om_business' });
+    await vi.advanceTimersByTimeAsync(2_000);
+    await Promise.resolve();
+
+    expect(sessionReply).toHaveBeenCalledWith(
+      'om_root',
+      expect.stringContaining('Worker 未能接收'),
+      'text',
+      'app_test',
+      'om_business',
+    );
+  });
+
+  it('tracks a cold-start init turn and retries when the worker never receives it', async () => {
+    vi.useFakeTimers();
+    const sessionReply = vi.fn(async () => 'om_failure');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/repo',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const ds = makeDs();
+
+    forkWorker(ds, 'cold start', 'om_kickoff');
+    const worker = forkMock.mock.results.at(-1)!.value;
+    await vi.advanceTimersByTimeAsync(4_000);
+    await Promise.resolve();
+
+    const initSends = vi.mocked(worker.send).mock.calls
+      .map(call => call[0])
+      .filter(message => message?.type === 'init' && message?.turnId === 'om_kickoff');
+    expect(initSends).toHaveLength(2);
+    expect(sessionReply).toHaveBeenCalledWith(
+      'om_root',
+      expect.stringContaining('Worker 未能接收'),
+      'text',
+      'app_test',
+      'om_kickoff',
+    );
+  });
+
+  it('does not mistake slow startup for delivery failure after init is received', async () => {
+    vi.useFakeTimers();
+    const sessionReply = vi.fn(async () => 'om_failure');
+    initWorkerPool({
+      sessionReply,
+      getSessionWorkingDir: () => '/repo',
+      getActiveCount: () => 1,
+      closeSession: vi.fn(),
+    });
+    const ds = makeDs();
+
+    forkWorker(ds, 'cold start', 'om_kickoff');
+    const worker = forkMock.mock.results.at(-1)!.value;
+    worker.emit('message', { type: 'turn_input_received', turnId: 'om_kickoff' });
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    const initSends = vi.mocked(worker.send).mock.calls
+      .map(call => call[0])
+      .filter(message => message?.type === 'init' && message?.turnId === 'om_kickoff');
+    expect(initSends).toHaveLength(1);
+    expect(sessionReply).not.toHaveBeenCalled();
   });
 });
 

--- a/test/transfer-session.test.ts
+++ b/test/transfer-session.test.ts
@@ -440,6 +440,8 @@ describe('transferSession', () => {
     const replacementFork = vi.fn((...args: Parameters<typeof forkWorker>) => {
       lifecycle.push('replacement:fork');
       ds.worker = replacementWorker;
+      ds.workerGeneration = 2;
+      ds.session.workerGeneration = 2;
       return forkWorkerSpy(...args);
     });
     const moving = transferSession(
@@ -466,6 +468,11 @@ describe('transferSession', () => {
       'arrived during transfer',
       'turn-late',
       { dispatchAttempt: 7 },
+    )).toBe(true);
+    expect(sendWorkerInput(
+      ds,
+      'ordinary message during transfer',
+      'om_transfer_late',
     )).toBe(true);
     const rawDuringTransfer = {
       type: 'raw_input' as const,
@@ -504,6 +511,7 @@ describe('transferSession', () => {
       'old:exit',
       'replacement:fork',
       'replacement:message',
+      'replacement:message',
       'replacement:raw_input',
     ]);
     expect(replacementFork).toHaveBeenCalledWith(ds, '', true);
@@ -513,7 +521,16 @@ describe('transferSession', () => {
       turnId: 'turn-late',
       dispatchAttempt: 7,
     }));
-    expect(replacementSend).toHaveBeenNthCalledWith(2, rawDuringTransfer);
+    expect(replacementSend).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        type: 'message',
+        content: 'ordinary message during transfer',
+        turnId: 'om_transfer_late',
+      }),
+      expect.any(Function),
+    );
+    expect(replacementSend).toHaveBeenNthCalledWith(3, rawDuringTransfer);
   });
 
   it('fails safe on detach timeout using hard retirement without ordinary close cleanup', async () => {

--- a/test/worker-ordinary-im-init-concurrency.integration.test.ts
+++ b/test/worker-ordinary-im-init-concurrency.integration.test.ts
@@ -1,0 +1,190 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { DaemonToWorker, WorkerToDaemon } from '../src/types.js';
+
+const children = new Set<ChildProcess>();
+const tempDirs = new Set<string>();
+
+async function waitFor(
+  predicate: () => boolean,
+  logs: string[],
+  timeoutMs = 8_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 25));
+  }
+  throw new Error(`worker condition timed out\n${logs.join('')}`);
+}
+
+afterEach(() => {
+  for (const child of children) {
+    if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+  }
+  children.clear();
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.clear();
+});
+
+describe('ordinary IM during real worker init', () => {
+  it('queues a concurrent follow-up instead of rejecting it before cliAdapter is ready', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-worker-init-concurrency-'));
+    tempDirs.add(root);
+    const dataDir = join(root, 'session');
+    mkdirSync(dataDir, { recursive: true });
+    const fakePi = join(root, 'fake-pi');
+    writeFileSync(fakePi, `#!/usr/bin/env node
+setTimeout(() => process.stdout.write('Ready\\n'), 500);
+setInterval(() => {}, 1_000);
+`);
+    chmodSync(fakePi, 0o755);
+
+    const messages: WorkerToDaemon[] = [];
+    const logs: string[] = [];
+    const child = spawn(process.execPath, ['--import', 'tsx', resolve('src/worker.ts')], {
+      cwd: resolve('.'),
+      env: {
+        ...process.env,
+        HOME: root,
+        SESSION_DATA_DIR: dataDir,
+        BOTMUX_SESSION_ID: 'sid-worker-init-concurrency',
+        LARK_APP_ID: 'app_test',
+        LARK_APP_SECRET: 'secret',
+      },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    children.add(child);
+    child.on('message', raw => messages.push(raw as WorkerToDaemon));
+    child.stdout?.on('data', chunk => logs.push(chunk.toString()));
+    child.stderr?.on('data', chunk => logs.push(chunk.toString()));
+
+    child.send({
+      type: 'init',
+      sessionId: 'sid-worker-init-concurrency',
+      chatId: 'oc_test',
+      rootMessageId: 'om_root',
+      workingDir: dataDir,
+      cliId: 'pi',
+      cliPathOverride: fakePi,
+      backendType: 'pty',
+      prompt: 'initial turn',
+      larkAppId: 'app_test',
+      larkAppSecret: 'secret',
+      turnId: 'om_initial',
+    } satisfies DaemonToWorker);
+    child.send({
+      type: 'message',
+      content: 'follow-up during init',
+      turnId: 'om_followup',
+    } satisfies DaemonToWorker);
+
+    await waitFor(() => messages.some(message =>
+      message.type === 'turn_input_committed' && message.turnId === 'om_followup'), logs);
+    await waitFor(() => messages.some(message =>
+      message.type === 'turn_input_committed' && message.turnId === 'om_initial'), logs);
+
+    expect(messages).toEqual(expect.arrayContaining([
+      { type: 'turn_input_received', turnId: 'om_initial' },
+      { type: 'turn_input_received', turnId: 'om_followup' },
+      { type: 'turn_input_committed', turnId: 'om_initial' },
+      { type: 'turn_input_committed', turnId: 'om_followup' },
+    ]));
+    expect(messages).not.toContainEqual(expect.objectContaining({
+      type: 'turn_input_rejected',
+      turnId: 'om_followup',
+    }));
+  }, 15_000);
+
+  it('holds a non-argv follow-up until the initial prompt owns the queue head', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'botmux-worker-init-order-'));
+    tempDirs.add(root);
+    const dataDir = join(root, 'session');
+    mkdirSync(dataDir, { recursive: true });
+    const inputLog = join(root, 'stdin.log');
+    const fakeCodex = join(root, 'fake-codex');
+    writeFileSync(fakeCodex, `#!/usr/bin/env node
+const fs = require('node:fs');
+if (process.argv.includes('app-server')) {
+  setInterval(() => {}, 1_000);
+} else {
+  let initialTurnCompleted = false;
+  let observedInput = '';
+  setTimeout(() => process.stdout.write('›\\n'), 200);
+  process.stdin.on('data', chunk => {
+    fs.appendFileSync(process.env.FAKE_INPUT_LOG, chunk);
+    observedInput += chunk.toString();
+    if (!initialTurnCompleted && observedInput.includes('INITIAL_ORDER_MARKER')) {
+      initialTurnCompleted = true;
+      setTimeout(() => process.stdout.write('›\\n'), 50);
+    }
+  });
+  setInterval(() => {}, 1_000);
+}
+`);
+    chmodSync(fakeCodex, 0o755);
+
+    const messages: WorkerToDaemon[] = [];
+    const logs: string[] = [];
+    const child = spawn(process.execPath, ['--import', 'tsx', resolve('src/worker.ts')], {
+      cwd: resolve('.'),
+      env: {
+        ...process.env,
+        HOME: root,
+        SESSION_DATA_DIR: dataDir,
+        BOTMUX_SESSION_ID: 'sid-worker-init-order',
+        // Keep the real 7s title-metadata await that opens the race window,
+        // but collapse Codex's unrelated history.jsonl submit polling so this
+        // ordering probe stays deterministic under full-suite contention.
+        BOTMUX_TIME_SCALE: '0.05',
+        LARK_APP_ID: 'app_test',
+        LARK_APP_SECRET: 'secret',
+      },
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    });
+    children.add(child);
+    child.on('message', raw => messages.push(raw as WorkerToDaemon));
+    child.stdout?.on('data', chunk => logs.push(chunk.toString()));
+    child.stderr?.on('data', chunk => logs.push(chunk.toString()));
+
+    child.send({
+      type: 'init',
+      sessionId: 'sid-worker-init-order',
+      chatId: 'oc_test',
+      rootMessageId: 'om_root',
+      workingDir: dataDir,
+      cliId: 'codex',
+      cliPathOverride: fakeCodex,
+      backendType: 'pty',
+      prompt: 'INITIAL_ORDER_MARKER',
+      resume: true,
+      cliSessionId: 'thread-existing',
+      nativeSessionTitle: 'Existing title',
+      env: { FAKE_INPUT_LOG: inputLog },
+      larkAppId: 'app_test',
+      larkAppSecret: 'secret',
+      turnId: 'om_initial_order',
+    } satisfies DaemonToWorker);
+    child.send({
+      type: 'message',
+      content: 'FOLLOWUP_ORDER_MARKER',
+      turnId: 'om_followup_order',
+    } satisfies DaemonToWorker);
+
+    await waitFor(() => {
+      if (!existsSync(inputLog)) return false;
+      const input = readFileSync(inputLog, 'utf8');
+      return input.includes('INITIAL_ORDER_MARKER') && input.includes('FOLLOWUP_ORDER_MARKER');
+    }, logs, 14_000);
+
+    const input = readFileSync(inputLog, 'utf8');
+    expect(input.indexOf('INITIAL_ORDER_MARKER')).toBeLessThan(input.indexOf('FOLLOWUP_ORDER_MARKER'));
+    expect(messages).not.toContainEqual(expect.objectContaining({
+      type: 'turn_input_rejected',
+      turnId: 'om_followup_order',
+    }));
+  }, 20_000);
+});

--- a/test/worker-ordinary-im-receipt-wiring.test.ts
+++ b/test/worker-ordinary-im-receipt-wiring.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const workerSource = readFileSync(new URL('../src/worker.ts', import.meta.url), 'utf8');
+
+function caseRegion(name: 'init' | 'message', next: 'message' | 'raw_input'): string {
+  const start = workerSource.indexOf(`case '${name}': {`);
+  const end = workerSource.indexOf(`case '${next}':`, start + 1);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return workerSource.slice(start, end);
+}
+
+describe('ordinary IM worker receipt wiring', () => {
+  it('claims and ACKs init before any slow startup await', () => {
+    const init = caseRegion('init', 'message');
+    const receipt = init.indexOf('receiveOrdinaryImTurn(ordinaryImTurnId)');
+    const firstStartupAwait = Math.min(
+      ...[
+        init.indexOf('await startWebServer('),
+        init.indexOf('await orchestrateCodexRpcInit('),
+        init.indexOf('await spawnCli('),
+      ].filter(index => index >= 0),
+    );
+
+    expect(receipt).toBeGreaterThanOrEqual(0);
+    expect(receipt).toBeLessThan(firstStartupAwait);
+  });
+
+  it('claims and ACKs a steady-state turn before crash recovery awaits', () => {
+    const message = caseRegion('message', 'raw_input');
+    const receipt = message.indexOf('receiveOrdinaryImTurn(ordinaryImTurnId)');
+    const crashRestart = message.indexOf('await spawnCli(restartCfg)');
+
+    expect(receipt).toBeGreaterThanOrEqual(0);
+    expect(crashRestart).toBeGreaterThan(receipt);
+  });
+
+  it('queues pre-adapter follow-ups and preserves the init prompt at the head', () => {
+    const sendToPtyStart = workerSource.indexOf('function sendToPty(');
+    const sendToPtyEnd = workerSource.indexOf('// ─── Screen Update Timer', sendToPtyStart);
+    const sendToPty = workerSource.slice(sendToPtyStart, sendToPtyEnd);
+    const backendQueue = sendToPty.indexOf('if (cliRestartInProgress || !backend)');
+    const adapterReject = sendToPty.indexOf('if (!cliAdapter) return false;');
+    const init = caseRegion('init', 'message');
+    const flushStart = workerSource.indexOf('async function flushPending()');
+    const flushEnd = workerSource.indexOf('\nfunction sendToPty(', flushStart);
+    const flush = workerSource.slice(flushStart, flushEnd);
+
+    expect(backendQueue).toBeGreaterThanOrEqual(0);
+    expect(adapterReject).toBeGreaterThan(backendQueue);
+    expect(init).toContain('pendingMessages.unshift({');
+    expect(flush).toContain('if (initialInputOwnershipPending) return;');
+    expect(init.indexOf('initialInputOwnershipPending = !!msg.prompt;'))
+      .toBeLessThan(init.indexOf('await startWebServer('));
+    expect(init.indexOf('initialInputOwnershipPending = false;'))
+      .toBeGreaterThan(init.indexOf('pendingMessages.unshift({'));
+  });
+});


### PR DESCRIPTION
> [!IMPORTANT]
> 普通飞书消息现在使用两阶段 ACK：Worker receipt 负责 daemon → Worker 传输确认，原有 commit 继续表示 Agent 输入队列已接收。稳态消息、transfer 回放和首轮 init 共用同一套 generation fence 与重试协议。当前 head 为 `77d0e465`，已修复两轮 review 的 4 项 blocking；PR 仍为 Changes requested，等待复审，未合并。真实 daemon 故障注入尚未执行。

## 如何发现

> @孙晓雪：「最近 botmux 总是漏我的消息 怎么回事？我刚刚发了两次 他没收到？」

用户随后要求继续定位：[飞书原始消息](https://applink.feishu.cn/client/chat/open?openChatId=oc_4d3c639ba350e35594bda6daf9b597b9&openMessageId=om_x100b68315b2218a0deda52c7e97ddfc)。现场截图、两次消息的日志时序和完整代码路径收录在[事故说明文档](https://bytedance.larkoffice.com/docx/IW9ndargwofSALxDQsAcGihUnBe)。

定位确认：第一条消息已通过飞书接收、权限检查和事件去重，也进入了 daemon 的普通消息处理；Codex transcript 与 Worker 日志中都没有这条消息。第二条消息沿相同入口进入 Worker 并写入 PTY。由此排除了飞书未送达、@ 解析、事件去重、模型不回复和 Worker 重启，故障位于 daemon 向 Worker 交接输入的边界。

上一轮 review 继续发现：原实现只覆盖稳态 `message`，没有覆盖 transfer 回放和首轮 `init.prompt`；同时把 2 秒 watchdog 绑在 commit 上，慢冷重启会先误报失败、随后真实执行。

## 用户看到什么

| 触发方式 | 旧表现 | 修复后表现 |
| --- | --- | --- |
| 稳态普通消息未到达 Worker | 飞书事件已被认领，但 Agent 没收到；无重试、无提示 | 2 秒内无 Worker receipt 时，在同一 generation 重试一次 |
| 新话题首条消息或 worker-null 冷启动的 `init.prompt` 未到达 Worker | 首轮走裸 `worker.send(initMsg)`，仍可能静默丢失 | init turn 使用同一 receipt watchdog 和 turn ID 去重 |
| transfer 期间缓冲的普通消息回放失败 | replacement 回放后立即移出 buffer，没有 ACK 或重试 | 回放到 replacement generation 时进入同一 tracked sender |
| crash-diagnostic 冷重启超过 4 秒 | 先提示「请重发」，原消息随后仍执行；人工重发可能执行两次 | Worker 在任何慢启动 await 前回 receipt；慢启动只延迟 commit，不触发传输失败 |
| Worker 收到消息但无法进入 CLI 输入队列 | receipt 若直接结束追踪，可能再次静默丢失 | Worker 回 `turn_input_rejected`；同代安全重试，第二次仍拒绝才提示失败 |

## 根因

原路径调用 `ChildProcess.send()` 后立即返回 `true`。这个返回值只表示执行了发送调用，不表示 Worker 已处理该 IPC。飞书事件此前已经被去重模块认领，这段内存交接一旦丢失，事件不会再次进入。

首版修复又把「IPC 已到 Worker」和「已进入 Agent 输入队列」合成一个 ACK。两者的超时属性不同：IPC receipt 应同步返回；commit 可能受冷启动、插件准备和 Codex 元数据读取影响。用 2 秒 commit 超时判断传输失败，会把正常慢启动当成丢消息。

## 改了什么

- 新增 `turn_input_received`。Worker 的 IPC handler 在认领普通 `om_` turn 后同步发送，任何启动或恢复 await 都在其后。
- 保留 `turn_input_committed` 的原语义。durable dispatch 仍只以 commit 作为输入队列权威状态，不使用 receipt。
- daemon 的 2 秒 watchdog 只等待 receipt；同一 Worker generation 最多发送两次，不跨进程重投。
- Worker 在任何 renderer、adapter 或 PTY 副作用前按 turn ID 去重：`inflight` 重复包只补 receipt，`committed` 重复包补 receipt 与 commit，不再次写入 CLI。
- `init.prompt` 在安装 Worker handler、绑定 generation 后通过同一 tracked sender 发送；重复 init 只接受相同 turn ID。
- transfer gate 仍负责冻结顺序；replacement generation 建立后，普通 `message` 回放交给 tracked sender，raw/control 输入保持原协议。
- 新增 `turn_input_rejected`。Worker 明确无法入队时释放本地 inflight fence，daemon 用原 payload 做同代安全重试。
- init 并发窗口内，`sendToPty` 在检查 `cliAdapter` 前先按 `!backend` 将 follow-up 放入现有输入队列；init prompt 使用 `unshift` 保持在 follow-up 之前。
- 新增首轮输入归属栅栏：init 在任何异步等待前关闭 `flushPending`，等首轮 prompt 已占据队首或已由 argv/RPC 接管后再放行，避免早到的 prompt-ready 把 follow-up 先写入 PTY。
- Worker 退出时清理该 generation 的内存记录；stale generation 的 receipt、reject 和 commit 都不能确认新 Worker。

不做跨 Worker 自动重投。旧 Worker 是否已执行但来不及回 ACK 无法可靠判断，跨进程重投可能让外部写操作执行两次。

## 架构判断

两阶段 ACK 复用仓库已有的 Worker generation、transfer gate 和 durable commit 边界，没有为三条入口分别建立特殊超时：

- receipt 的权威所有者是当前 Worker IPC handler，只回答「该 generation 已收到 turn」。
- commit 的权威所有者仍是 Worker 输入队列，只回答「Agent 已接收 turn」。
- transfer gate 只拥有转移期间的顺序和缓冲；回放完成后恢复普通投递协议。
- adopt 的 ambiguity journal、durable dispatch 的 lease/receipt、VC receiver 与 silent schedule 的既有规则未改变。

## 观察到的修复结果

- rebase 到最新 `origin/master`（`1854ee3b`）后，组合回归：8 个文件，503/503 通过。
- focused 覆盖 receipt 超时、IPC callback 失败、Worker reject、stale generation、init 首轮、10 秒慢启动、transfer 回放和 Worker ACK 顺序。新增两条真实 Worker 探针：一条验证 init 与并发 follow-up 均 received + committed；另一条使用非 argv-baked Codex PTY，在保留真实 7 秒标题元数据等待的条件下捕获 stdin，断言首轮 prompt 先于 follow-up 写入。顺序探针 3 轮连续通过。
- `pnpm build`、TypeScript、domain audit、dist audit 和 `git diff --check` 均通过。
- 最新全量：807 个文件通过、2 个文件失败、3 个文件跳过；12,950 项通过、2 项失败、35 项跳过。失败为 `codex-app-threads` 的 100ms 启动时序和 adopted Pi 的 4 秒视口时序，均不在本 PR 改动面；两个失败文件随后隔离复跑 14/14 通过。本 PR 新增的真实 PTY 顺序探针已在全量争用下通过。

## 仍未验证什么

| 剩余检查 | 需要的环境或原因 | 影响范围 |
| --- | --- | --- |
| 真实 daemon 下分别阻断稳态、init 和 transfer receipt | 会干扰当前正在使用的 Bot，PR 阶段未重启或注入故障 | 只阻塞发布，不阻塞 PR 审核 |
| GitHub review 与 CI | fork PR 暂无 checks，上一轮 review 状态仍为 Changes requested | 阻塞合并 |


