### PR TITLE
fix(claude): read-isolation 首帧预置 hasCompletedOnboarding（修干净环境首启卡引导）

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1137,6 +1137,18 @@ function seedAndTrustClaudeState(statePath: string, workingDir: string, log: (m:
       } catch { data = {}; }
     }
     if (!data.projects || typeof data.projects !== 'object') data.projects = {};
+    // Onboarding gate: Claude Code holds the FIRST launch on a one-time
+    // theme/onboarding selection until `hasCompletedOnboarding:true` is on the
+    // top level of .claude.json. The seed above copies it from the host's
+    // global ~/.claude.json — but a CLEAN environment (fresh sandbox, e.g.
+    // core-only in riff, or any box that never ran Claude globally) has no
+    // global file to copy it from, so the redirected CLAUDE_CONFIG_DIR session
+    // would stick on that first-frame selection until a human clears it once.
+    // Force it here (idempotent, top-level) so a headless/programmatic first
+    // launch never blocks on interactive onboarding — same intent as the
+    // per-cwd trust-dialog acceptance below. If the seed/global already set it,
+    // this is a no-op.
+    data.hasCompletedOnboarding = true;
     let canonical = workingDir;
     try { canonical = realpathSync(workingDir); } catch { /* cwd may not exist yet */ }
     const entry = data.projects[canonical] && typeof data.projects[canonical] === 'object'


### PR DESCRIPTION
## 改了什么

`src/worker.ts` 的 `seedAndTrustClaudeState`（read-isolation 冷启前 provision BOT_HOME 的 `.claude.json` 那处）新增一行：显式 `data.hasCompletedOnboarding = true`。

## 为什么

core-only / read-isolation 的 claude 会话**首次冷启**会卡在 Claude Code 的一次性引导（主题 / onboarding 选择），直到 `.claude.json` 顶层有 `hasCompletedOnboarding:true`。

`seedAndTrustClaudeState` 原本：
- 从宿主**全局** `~/.claude.json` 拷顶层字段来带过 onboarding「seen」标记；
- 已显式设 `projects.<cwd>.hasTrustDialogAccepted=true`（信任弹窗那道已关）。

问题：onboarding 标记是「靠拷全局」的。**干净环境**（全新沙箱，如 riff 的 core-only；或任何从未全局跑过 claude 的机器）宿主没有全局 `~/.claude.json` 可拷 → 标记带不过来 → 重定向 `CLAUDE_CONFIG_DIR` 的会话首帧卡在主题选择，需人工点一次才落盘（riff 在沙箱里实测到）。信任弹窗因为是显式写的所以关了，onboarding 门漏了。

## 影响面

- 仅作用于走 **read-isolation 重定向 `CLAUDE_CONFIG_DIR`** 的 claude 家族会话（core-only 强制 `readIsolation=true`，必经此路径；普通 sandbox/read-isolation 的 claude 也受益）。
- **不动**非隔离路径的共享全局 `~/.claude.json` 写入（`ensureClaudeFolderTrust` 未改——它写共享状态、且宿主通常已全局 onboarded，不是本 bug 的触发面；避免无谓地碰共享热状态文件）。
- 幂等：若 seed/全局已设 `hasCompletedOnboarding` 则为 no-op；merge 语义保留 `.claude.json` 已有的其它 key。
- 跨 CLI：只碰 claude 家族的 state 文件，不影响其它 20+ CLI（codex 分支走 `else`，未动）。

## 测试验证

- `pnpm build` 通过。
- `claude-folder-trust` + `seed-adapter` **16/16 绿**（确认没扰动 sibling 的 `ensureClaudeFolderTrust` / seed 布局）。
- 功能 smoke（复刻 seed 逻辑，三格）：
  - 干净环境（riff 场景，无全局无既有 state）→ `hasCompletedOnboarding:true` ✅ + cwd trusted ✅
  - 既有 state merge → 保留 `numStartups`/`oauthAccount`/其它 project，不 clobber ✅
  - 全局 seed → onboarding 带过、账号带过、其它 projects 不泄漏 ✅
- ⚠️ **首帧行为需 riff 真机验**：unit 无法证明真实 Claude Code 引导门被清；建议出 canary 让 riff 在干净沙箱确认首启直接进会话、不卡主题选择。

## 说明

`seedAndTrustClaudeState` 是 `worker.ts` 私有函数、无法直接单测（worker.ts 是 worker 进程入口，import 会触发副作用），故用功能 smoke 兜底 + 复用已有 `claude-folder-trust` 回归确认 sibling 未受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
