### PR TITLE
chore(setup): 移除未使用的 im:message.*_msg:get_as_user 权限申请

### DIFF
--- a/src/setup/lark-scopes.json
+++ b/src/setup/lark-scopes.json
@@ -255,8 +255,6 @@
       "im:chat:read",
       "im:chat:update",
       "im:message",
-      "im:message.group_msg:get_as_user",
-      "im:message.p2p_msg:get_as_user",
       "im:message.pins:read",
       "im:message.pins:write_only",
       "im:message.reactions:read",


### PR DESCRIPTION
## 改了什么

从 `src/setup/lark-scopes.json` 的 **user** scope 清单里删掉两条权限申请：

- `im:message.group_msg:get_as_user`
- `im:message.p2p_msg:get_as_user`

## 为什么

这两个 scope 是**死权限**——botmux 从未走过需要它们的调用路径。

它们管的是「**以 `user_access_token` 身份**读消息正文」（`im.v1.message.get`，p2p→单聊 / group→群聊，已对飞书官方文档核实）。而 botmux 的实际链路是：

- **读消息正文**（`getMessageDetail` / `listChatMessages` / `listThreadMessages` 等）一律走 `larkGet(getBotClient())`，即 **tenant/app token**，靠 `im:message` + `im:message.group_msg`（均保留）满足；
- 全仓**唯一**用 user token 碰消息的是 `downloadWithUserToken`（下载图片/文件附件），需要的是 `im:resource` + `im:message:readonly`，也不是这俩；
- `/login` OAuth 仅申请 `im:message:readonly` / `im:resource` / `offline_access`，本就没请求这俩 `get_as_user`。

全仓搜索 `get_as_user` 仅命中被删的这两行，无任何 TS/JS 代码、测试或 `BOTMUX_REQUIRED_SCOPES` 引用。

## 影响面

- 仅改「推荐导入的 scope 清单」——新用户 setup 时少申请这俩权限。**纯静态 JSON，不触碰任何运行时代码路径**，跨平台 / 跨 CLI / 跨后端 / 跨会话类型均无影响。
- 已在开放平台授权过的老 app 不会被自动撤销（想彻底清需去后台手删）。

## 测试验证

- `pnpm build` ✅ 绿
- `test/setup-verify-permissions.test.ts` + `test/dashboard-bot-onboarding.test.ts` 共 **75 测试全过** ✅
- JSON 合法性：user scope 数 130 → 128 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)