### PR TITLE
fix(traex): 提交确认改用 history.jsonl 修 type-ahead 误报

### DIFF
--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -8,7 +8,7 @@ import {
   traexHistoryMatchDelta,
   traexHistorySize,
   findTraexRolloutSetByPid,
-  type TraexHistorySidFilter,
+  traexHistorySidIsOwned,
 } from '../../services/traex-transcript.js';
 import { discoverRolloutSessions } from '../../services/resumable-session-discovery.js';
 import { delay } from '../../utils/timing.js';
@@ -76,26 +76,26 @@ function withDb<T>(fn: (db: DatabaseSyncLike) => T): T | null {
   }
 }
 
-/** Build the ownership filter for the shared global history.jsonl. When the
- * TRAE pid is known, only accept a same-text history line whose session id is
- * one THIS pid currently holds open — so a concurrent sibling pane's identical
- * text (same TRAE_HOME) can't hand us its foreign session id. The open-rollout
- * set is re-fetched on EVERY match attempt (not snapshotted): a just-started
- * session's owned rollout fd can appear slightly after its history line, and a
- * snapshot would permanently reject it. When the pid is unknown or its rollout
- * set can't be enumerated, fall back to accept-first — preserving single-pane /
- * no-pid submit-confirmation semantics; the worker-side attach gate is the
- * backstop there. Mirrors codex.ts writeInput's acceptSid. */
-function buildHistorySidFilter(cliPid: number | undefined): TraexHistorySidFilter | undefined {
-  if (!cliPid) return undefined;
-  return (sid) => {
-    if (!sid) return false;
-    const owned = findTraexRolloutSetByPid(cliPid);
-    // set unavailable (enumeration failed) → don't block the submit
-    // confirmation; the worker attach gate re-checks ownership.
-    if (!owned) return true;
-    return owned.has(sid.toLowerCase());
-  };
+/** Decide whether a session id surfaced by the history text match is safe to
+ * RETURN to the worker as a candidate for persist / bridge attach.
+ *
+ * Two separable facts: the text match confirms the SUBMIT (a full-content match
+ * in the global submit log — this is ownership-INDEPENDENT and must never be
+ * gated, or a foreign-first line / unknown pid would re-introduce the false
+ * "submission couldn't be confirmed" warning this fix removes). The reported
+ * session id is a weaker signal: history.jsonl is shared by every TRAE pane
+ * under one TRAE_HOME, so a sibling pane's identical text (e.g. a bare "继续" in
+ * adopt mode, which carries no unique <session_id>) can surface a FOREIGN id.
+ *
+ * So we ALWAYS confirm the submit on a text match, but only attach the id when
+ * THIS pid provably holds that rollout open (fail closed on unknown pid /
+ * unavailable enumeration / non-member). The open-rollout set is re-fetched per
+ * call, not snapshotted. TRAE additionally has a worker-side gate
+ * (traexHistorySidOwnedByCurrentPid) whose pid resolution is richer than
+ * pty.cliPid, so the authoritative persist/attach decision still lands there. */
+function traexSidOwnedByPid(cliPid: number | undefined, sid: string | undefined): boolean {
+  if (!cliPid || !sid) return false;
+  return traexHistorySidIsOwned(sid, findTraexRolloutSetByPid(cliPid));
 }
 
 
@@ -265,14 +265,24 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
       const historyPath = traeHistoryPath();
       const baseByte = traexHistorySize(historyPath);
 
-      // Ownership filter for the shared-TRAE_HOME history.jsonl (see
-      // buildHistorySidFilter). Accept-first when the pid is unknown.
       const cliPid = typeof pty.cliPid === 'number' && Number.isInteger(pty.cliPid) && pty.cliPid > 0
         ? pty.cliPid
         : undefined;
-      const acceptSid = buildHistorySidFilter(cliPid);
 
-      const matchNow = () => traexHistoryMatchDelta(historyPath, baseByte, content, acceptSid);
+      // The text match confirms the SUBMIT (a full-content match in the global
+      // submit log). The reported session id is a SEPARATE, weaker signal:
+      // history.jsonl is shared by every TRAE pane under one TRAE_HOME, so a
+      // sibling pane's identical text can surface a foreign id. Only return the
+      // id when THIS pid provably owns that rollout — otherwise confirm the
+      // submit WITHOUT an id so the worker never persists/attaches an unverified
+      // one. traexHistoryMatchDelta is called with no ownership filter: we do
+      // NOT want a foreign-first line to mask our own submit confirmation; we
+      // gate on ownership only for the returned id.
+      const confirmResult = (sid?: string) =>
+        sid && traexSidOwnedByPid(cliPid, sid)
+          ? { submitted: true as const, cliSessionId: sid }
+          : { submitted: true as const };
+      const matchNow = () => traexHistoryMatchDelta(historyPath, baseByte, content);
 
       try {
         if (pty.pasteText) pty.pasteText(content);
@@ -285,28 +295,18 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
 
       for (let attempt = 0; attempt < 3; attempt++) {
         const match = matchNow();
-        if (match.found) {
-          return match.cliSessionId
-            ? { submitted: true, cliSessionId: match.cliSessionId }
-            : { submitted: true };
-        }
+        if (match.found) return confirmResult(match.cliSessionId);
         await delay(800);
         if (!trySendEnter()) return { submitted: false };
       }
       const finalMatch = matchNow();
-      if (finalMatch.found) {
-        return finalMatch.cliSessionId
-          ? { submitted: true, cliSessionId: finalMatch.cliSessionId }
-          : { submitted: true };
-      }
+      if (finalMatch.found) return confirmResult(finalMatch.cliSessionId);
       // In-band budget exhausted. Hand the worker a recheck closure: a slow or
       // busy TRAE may still append our history line after the retries gave up,
       // and the worker re-scans on a delay before warning the user.
       const recheck = () => {
         const late = matchNow();
-        return late.found
-          ? { submitted: true, cliSessionId: late.cliSessionId }
-          : false;
+        return late.found ? confirmResult(late.cliSessionId) : false;
       };
       return { submitted: false, recheck };
     },

--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -76,27 +76,12 @@ function withDb<T>(fn: (db: DatabaseSyncLike) => T): T | null {
   }
 }
 
-/** Decide whether a session id surfaced by the history text match is safe to
- * RETURN to the worker as a candidate for persist / bridge attach.
- *
- * Two separable facts: the text match confirms the SUBMIT (a full-content match
- * in the global submit log — this is ownership-INDEPENDENT and must never be
- * gated, or a foreign-first line / unknown pid would re-introduce the false
- * "submission couldn't be confirmed" warning this fix removes). The reported
- * session id is a weaker signal: history.jsonl is shared by every TRAE pane
- * under one TRAE_HOME, so a sibling pane's identical text (e.g. a bare "继续" in
- * adopt mode, which carries no unique <session_id>) can surface a FOREIGN id.
- *
- * So we ALWAYS confirm the submit on a text match, but only attach the id when
- * THIS pid provably holds that rollout open (fail closed on unknown pid /
- * unavailable enumeration / non-member). The open-rollout set is re-fetched per
- * call, not snapshotted. TRAE additionally has a worker-side gate
- * (traexHistorySidOwnedByCurrentPid) whose pid resolution is richer than
- * pty.cliPid, so the authoritative persist/attach decision still lands there. */
-function traexSidOwnedByPid(cliPid: number | undefined, sid: string | undefined): boolean {
-  if (!cliPid || !sid) return false;
-  return traexHistorySidIsOwned(sid, findTraexRolloutSetByPid(cliPid));
-}
+/** Adapter-side session-id ownership uses findTraexRolloutSetByPid +
+ * traexHistorySidIsOwned directly in writeInput (kept as raw three-state so the
+ * enumeration-unavailable case can fast-degrade). The authoritative persist /
+ * bridge-attach decision additionally re-checks worker-side via
+ * traexHistorySidOwnedByCurrentPid, whose pid resolution is richer than
+ * pty.cliPid (and covers the sandbox bwrap-supervisor case). */
 
 
 /** Scan threads backwards for the most recent thread whose first_user_message
@@ -277,23 +262,20 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
       //  - SESSION ID: history.jsonl is shared by every TRAE pane under one
       //    TRAE_HOME, so a sibling's identical text can surface a foreign id.
       //    Return the id ONLY when this pid provably owns that rollout.
-      // When a pid is enumerable, PREFER the owned scan: ownedMatch() passes an
-      // ownership filter so a foreign-first line is skipped and scanning
-      // continues to our own line (Codex's foreign-first→owned-later case). Only
-      // if no owned line is found do we fall back to the unfiltered any-text scan
-      // to confirm the submit without an id. Without a pid, there's nothing to
-      // own, so we just confirm the submit.
-      const ownedFilter = (sid: string | undefined): boolean => traexSidOwnedByPid(cliPid, sid);
-      const ownedMatch = () => cliPid
-        ? traexHistoryMatchDelta(historyPath, baseByte, content, ownedFilter)
-        : { found: false as const };
+      //
+      // The three states of findTraexRolloutSetByPid are kept DISTINCT (not
+      // flattened through a boolean helper) because they drive different waits:
+      //   • undefined  → fd enumeration unavailable (no pid / not on Linux /
+      //     proc unreadable): we can never prove ownership, so there is no point
+      //     polling for an owned line — confirm the submit on any-text at once.
+      //   • Set (maybe empty) → enumeration works; an owned line may simply not
+      //     be on disk yet. KEEP polling for it and do NOT let a foreign-first
+      //     any-text hit end the loop early (a sibling's identical line can land
+      //     on poll N while our owned line appears on poll N+k — returning
+      //     no-SID on the first foreign sighting would permanently drop our id).
+      const ownedMatch = (owned: Set<string> | undefined) =>
+        traexHistoryMatchDelta(historyPath, baseByte, content, (sid) => traexHistorySidIsOwned(sid ?? '', owned));
       const anyMatch = () => traexHistoryMatchDelta(historyPath, baseByte, content);
-      // A confirmed submit: prefer the owned sid, else confirm without one.
-      const resolveConfirmed = () => {
-        const owned = ownedMatch();
-        if (owned.found && owned.cliSessionId) return { submitted: true as const, cliSessionId: owned.cliSessionId };
-        return anyMatch().found ? { submitted: true as const } : null;
-      };
 
       try {
         if (pty.pasteText) pty.pasteText(content);
@@ -304,18 +286,45 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
       await delay(200);
       if (!trySendEnter()) return { submitted: false };
 
+      // `sawAnyText` remembers that the submit is proven (an any-text line
+      // exists) even while we keep polling for the OWNED line. Once set, no
+      // further Enter is needed — the message is in TRAE's log — so the loop only
+      // waits for the owned rollout to surface.
+      let sawAnyText = false;
+      // Prefer an owned id whenever enumeration is possible. Returns a final
+      // result to return now, or null to keep waiting. `final` relaxes the
+      // owned-wait: at budget end / on the worker recheck, confirm on any-text.
+      const resolve = (final: boolean) => {
+        const owned = cliPid ? findTraexRolloutSetByPid(cliPid) : undefined;
+        if (owned !== undefined) {
+          const m = ownedMatch(owned);
+          if (m.found && m.cliSessionId) return { submitted: true as const, cliSessionId: m.cliSessionId };
+          // Enumeration works but no owned line yet. Note submit evidence but
+          // keep waiting for the owned id — unless the budget is spent.
+          if (anyMatch().found) sawAnyText = true;
+          return final && sawAnyText ? { submitted: true as const } : null;
+        }
+        // Enumeration unavailable — can't prove ownership, so confirm the submit
+        // on any-text as soon as it appears (no owned line to wait for).
+        if (anyMatch().found) return { submitted: true as const };
+        return null;
+      };
+
       for (let attempt = 0; attempt < 3; attempt++) {
-        const confirmed = resolveConfirmed();
+        const confirmed = resolve(false);
         if (confirmed) return confirmed;
         await delay(800);
-        if (!trySendEnter()) return { submitted: false };
+        // Only re-Enter while the submit is still unproven; once any-text is
+        // seen the message is committed and we're merely waiting for the owned
+        // rollout fd, so another Enter would risk a duplicate submit.
+        if (!sawAnyText && !trySendEnter()) return { submitted: false };
       }
-      const finalConfirmed = resolveConfirmed();
+      const finalConfirmed = resolve(true);
       if (finalConfirmed) return finalConfirmed;
       // In-band budget exhausted. Hand the worker a recheck closure: a slow or
       // busy TRAE may still append our history line after the retries gave up,
       // and the worker re-scans on a delay before warning the user.
-      const recheck = () => resolveConfirmed() ?? false;
+      const recheck = () => resolve(true) ?? false;
       return { submitted: false, recheck };
     },
 

--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -3,8 +3,13 @@ import { createRequire } from 'node:module';
 import { resolveCommand } from './registry.js';
 import { BOTMUX_SHELL_HINTS } from './shared-hints.js';
 import type { CliAdapter, PtyHandle } from './types.js';
-import { traeStateDbPath, traeSessionsRoot } from '../../services/traex-paths.js';
-import { traexRolloutHasUserInputSince } from '../../services/traex-transcript.js';
+import { traeStateDbPath, traeSessionsRoot, traeHistoryPath } from '../../services/traex-paths.js';
+import {
+  traexHistoryMatchDelta,
+  traexHistorySize,
+  findTraexRolloutSetByPid,
+  type TraexHistorySidFilter,
+} from '../../services/traex-transcript.js';
 import { discoverRolloutSessions } from '../../services/resumable-session-discovery.js';
 import { delay } from '../../utils/timing.js';
 
@@ -71,70 +76,28 @@ function withDb<T>(fn: (db: DatabaseSyncLike) => T): T | null {
   }
 }
 
-interface ThreadSnapshot {
-  id: string;
-  updatedAtMs: number;
-  rolloutPath: string;
-  rolloutOffset: number;
+/** Build the ownership filter for the shared global history.jsonl. When the
+ * TRAE pid is known, only accept a same-text history line whose session id is
+ * one THIS pid currently holds open — so a concurrent sibling pane's identical
+ * text (same TRAE_HOME) can't hand us its foreign session id. The open-rollout
+ * set is re-fetched on EVERY match attempt (not snapshotted): a just-started
+ * session's owned rollout fd can appear slightly after its history line, and a
+ * snapshot would permanently reject it. When the pid is unknown or its rollout
+ * set can't be enumerated, fall back to accept-first — preserving single-pane /
+ * no-pid submit-confirmation semantics; the worker-side attach gate is the
+ * backstop there. Mirrors codex.ts writeInput's acceptSid. */
+function buildHistorySidFilter(cliPid: number | undefined): TraexHistorySidFilter | undefined {
+  if (!cliPid) return undefined;
+  return (sid) => {
+    if (!sid) return false;
+    const owned = findTraexRolloutSetByPid(cliPid);
+    // set unavailable (enumeration failed) → don't block the submit
+    // confirmation; the worker attach gate re-checks ownership.
+    if (!owned) return true;
+    return owned.has(sid.toLowerCase());
+  };
 }
 
-interface SubmitSnapshot {
-  newestUpdatedAtMs: number;
-  byId: Map<string, ThreadSnapshot>;
-}
-
-function currentFileSize(path: string): number {
-  if (!path || !existsSync(path)) return 0;
-  try { return statSync(path).size; } catch { return 0; }
-}
-
-/** Snapshot recent SQLite thread rows and each rollout's complete byte size
- * before touching the PTY. The DB is an index; the rollout delta below is the
- * actual submit proof. `null` means verification is unavailable and callers
- * must fail closed before writing any bytes. */
-function snapRecentThreads(): SubmitSnapshot | null {
-  return withDb((db) => {
-    const rows = db.prepare(
-      'SELECT id, COALESCE(updated_at_ms, 0) AS updatedAtMs, rollout_path AS rolloutPath ' +
-      'FROM threads ORDER BY updated_at_ms DESC LIMIT 64',
-    ).all() as Array<Omit<ThreadSnapshot, 'rolloutOffset'>>;
-    const byId = new Map<string, ThreadSnapshot>();
-    let newestUpdatedAtMs = 0;
-    for (const row of rows) {
-      if (!row.id || !row.rolloutPath) continue;
-      newestUpdatedAtMs = Math.max(newestUpdatedAtMs, Number(row.updatedAtMs) || 0);
-      byId.set(row.id, {
-        id: row.id,
-        updatedAtMs: Number(row.updatedAtMs) || 0,
-        rolloutPath: row.rolloutPath,
-        rolloutOffset: currentFileSize(row.rolloutPath),
-      });
-    }
-    return { newestUpdatedAtMs, byId };
-  });
-}
-
-/** Resolve the session whose rollout gained this exact role=user record.
- * Works for the first prompt, later prompts in the same thread, and a freshly
- * rotated thread. Sibling processes can update SQLite concurrently, but their
- * rollout delta cannot match our full prompt accidentally. */
-function detectSubmittedThread(before: SubmitSnapshot, expectedText: string): { found: boolean; cliSessionId?: string } {
-  return withDb((db) => {
-    const rows = db.prepare(
-      'SELECT id, COALESCE(updated_at_ms, 0) AS updatedAtMs, rollout_path AS rolloutPath ' +
-      'FROM threads WHERE COALESCE(updated_at_ms, 0) >= ? ORDER BY updated_at_ms DESC LIMIT 64',
-    ).all(before.newestUpdatedAtMs) as Array<Omit<ThreadSnapshot, 'rolloutOffset'>>;
-    for (const r of rows) {
-      if (!r.id || !r.rolloutPath) continue;
-      const prior = before.byId.get(r.id);
-      const fromOffset = prior?.rolloutPath === r.rolloutPath ? prior.rolloutOffset : 0;
-      if (traexRolloutHasUserInputSince(r.rolloutPath, fromOffset, expectedText)) {
-        return { found: true, cliSessionId: r.id };
-      }
-    }
-    return { found: false };
-  }) ?? { found: false };
-}
 
 /** Scan threads backwards for the most recent thread whose first_user_message
  *  references the botmux session id. Used by buildArgs(resume) and
@@ -287,17 +250,29 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
         }
       };
 
-      // Reliable delivery requires an attributable submit. Refuse before the
-      // paste if the SQLite session/path index cannot be read; writing first
-      // and discovering that verification is unavailable would make replay
-      // ambiguous and could execute the same action twice.
-      const beforeSnap = snapRecentThreads();
-      if (!beforeSnap) {
-        return {
-          submitted: false,
-          failureReason: 'TRAE SQLite 提交验证不可用，已在写入前安全拒绝。',
-        };
-      }
+      // Submit confirmation polls the global submit log history.jsonl, NOT the
+      // per-session rollout. TRAE is a type-ahead CLI: a message pasted while a
+      // turn is running is PARKED in TRAE's queue and only written to the
+      // rollout when the running turn dequeues it — which can exceed the
+      // worker's confirmation deadline and fire a false "submission couldn't be
+      // confirmed" warning even though TRAE received it. history.jsonl is
+      // written at SUBMIT time (verified empirically on traecli 0.200.19: a
+      // mid-turn follow-up appears here in ~1s while the rollout lags past 20s),
+      // so it confirms parked submits immediately. This mirrors the codex
+      // adapter, which polls its identically-shaped history.jsonl for the same
+      // reason. history.jsonl is created lazily on the first submit, so an
+      // absent file just means baseByte=0 and the first appended line matches.
+      const historyPath = traeHistoryPath();
+      const baseByte = traexHistorySize(historyPath);
+
+      // Ownership filter for the shared-TRAE_HOME history.jsonl (see
+      // buildHistorySidFilter). Accept-first when the pid is unknown.
+      const cliPid = typeof pty.cliPid === 'number' && Number.isInteger(pty.cliPid) && pty.cliPid > 0
+        ? pty.cliPid
+        : undefined;
+      const acceptSid = buildHistorySidFilter(cliPid);
+
+      const matchNow = () => traexHistoryMatchDelta(historyPath, baseByte, content, acceptSid);
 
       try {
         if (pty.pasteText) pty.pasteText(content);
@@ -309,7 +284,7 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
       if (!trySendEnter()) return { submitted: false };
 
       for (let attempt = 0; attempt < 3; attempt++) {
-        const match = detectSubmittedThread(beforeSnap, content);
+        const match = matchNow();
         if (match.found) {
           return match.cliSessionId
             ? { submitted: true, cliSessionId: match.cliSessionId }
@@ -318,14 +293,17 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
         await delay(800);
         if (!trySendEnter()) return { submitted: false };
       }
-      const finalMatch = detectSubmittedThread(beforeSnap, content);
+      const finalMatch = matchNow();
       if (finalMatch.found) {
         return finalMatch.cliSessionId
           ? { submitted: true, cliSessionId: finalMatch.cliSessionId }
           : { submitted: true };
       }
+      // In-band budget exhausted. Hand the worker a recheck closure: a slow or
+      // busy TRAE may still append our history line after the retries gave up,
+      // and the worker re-scans on a delay before warning the user.
       const recheck = () => {
-        const late = detectSubmittedThread(beforeSnap, content);
+        const late = matchNow();
         return late.found
           ? { submitted: true, cliSessionId: late.cliSessionId }
           : false;

--- a/src/adapters/cli/traex.ts
+++ b/src/adapters/cli/traex.ts
@@ -269,20 +269,31 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
         ? pty.cliPid
         : undefined;
 
-      // The text match confirms the SUBMIT (a full-content match in the global
-      // submit log). The reported session id is a SEPARATE, weaker signal:
-      // history.jsonl is shared by every TRAE pane under one TRAE_HOME, so a
-      // sibling pane's identical text can surface a foreign id. Only return the
-      // id when THIS pid provably owns that rollout — otherwise confirm the
-      // submit WITHOUT an id so the worker never persists/attaches an unverified
-      // one. traexHistoryMatchDelta is called with no ownership filter: we do
-      // NOT want a foreign-first line to mask our own submit confirmation; we
-      // gate on ownership only for the returned id.
-      const confirmResult = (sid?: string) =>
-        sid && traexSidOwnedByPid(cliPid, sid)
-          ? { submitted: true as const, cliSessionId: sid }
-          : { submitted: true as const };
-      const matchNow = () => traexHistoryMatchDelta(historyPath, baseByte, content);
+      // Two separable facts, matched with two different scans:
+      //  - SUBMIT confirmation: any full-content match in the global submit log,
+      //    ownership-INDEPENDENT (a foreign-first line or unknown pid must never
+      //    suppress it, or the false "submission couldn't be confirmed" warning
+      //    this fix removes would come back).
+      //  - SESSION ID: history.jsonl is shared by every TRAE pane under one
+      //    TRAE_HOME, so a sibling's identical text can surface a foreign id.
+      //    Return the id ONLY when this pid provably owns that rollout.
+      // When a pid is enumerable, PREFER the owned scan: ownedMatch() passes an
+      // ownership filter so a foreign-first line is skipped and scanning
+      // continues to our own line (Codex's foreign-first→owned-later case). Only
+      // if no owned line is found do we fall back to the unfiltered any-text scan
+      // to confirm the submit without an id. Without a pid, there's nothing to
+      // own, so we just confirm the submit.
+      const ownedFilter = (sid: string | undefined): boolean => traexSidOwnedByPid(cliPid, sid);
+      const ownedMatch = () => cliPid
+        ? traexHistoryMatchDelta(historyPath, baseByte, content, ownedFilter)
+        : { found: false as const };
+      const anyMatch = () => traexHistoryMatchDelta(historyPath, baseByte, content);
+      // A confirmed submit: prefer the owned sid, else confirm without one.
+      const resolveConfirmed = () => {
+        const owned = ownedMatch();
+        if (owned.found && owned.cliSessionId) return { submitted: true as const, cliSessionId: owned.cliSessionId };
+        return anyMatch().found ? { submitted: true as const } : null;
+      };
 
       try {
         if (pty.pasteText) pty.pasteText(content);
@@ -294,20 +305,17 @@ export function createTraexAdapter(pathOverride?: string): CliAdapter {
       if (!trySendEnter()) return { submitted: false };
 
       for (let attempt = 0; attempt < 3; attempt++) {
-        const match = matchNow();
-        if (match.found) return confirmResult(match.cliSessionId);
+        const confirmed = resolveConfirmed();
+        if (confirmed) return confirmed;
         await delay(800);
         if (!trySendEnter()) return { submitted: false };
       }
-      const finalMatch = matchNow();
-      if (finalMatch.found) return confirmResult(finalMatch.cliSessionId);
+      const finalConfirmed = resolveConfirmed();
+      if (finalConfirmed) return finalConfirmed;
       // In-band budget exhausted. Hand the worker a recheck closure: a slow or
       // busy TRAE may still append our history line after the retries gave up,
       // and the worker re-scans on a delay before warning the user.
-      const recheck = () => {
-        const late = matchNow();
-        return late.found ? confirmResult(late.cliSessionId) : false;
-      };
+      const recheck = () => resolveConfirmed() ?? false;
       return { submitted: false, recheck };
     },
 

--- a/src/services/traex-paths.ts
+++ b/src/services/traex-paths.ts
@@ -15,10 +15,25 @@ export function traeHome(): string {
 }
 
 /** SQLite database holding the `threads` table (one row per interactive
- *  session). Used as the submit-verification source of truth because traex
- *  (unlike codex) does not write a flat history.jsonl. */
+ *  session). Used to reverse-map a botmux session id to a TRAE-native session
+ *  UUID (buildArgs/buildResumeCommand) and as the session/path index for
+ *  rollout-based transcript bridging. */
 export function traeStateDbPath(): string {
   return join(traeHome(), 'cli', 'state_5.sqlite');
+}
+
+/** Global submit log — TRAE appends one JSON line (`{session_id, ts, text}`,
+ *  byte-identical to Codex's format) here on every successful user submit
+ *  across all sessions, AT SUBMIT TIME. This is the authoritative submit-
+ *  confirmation source: unlike the per-session rollout JSONL, a message parked
+ *  by TRAE's type-ahead queue while a turn is running is written here
+ *  immediately, whereas the rollout only records it once the running turn
+ *  dequeues it (which can exceed the worker's submit-confirmation deadline and
+ *  fire a false "submission couldn't be confirmed" warning). Shared by every
+ *  TRAE pane under one TRAE_HOME, so a match needs a pid-ownership filter to
+ *  avoid attributing a sibling pane's identical text — mirrors codexHistoryPath. */
+export function traeHistoryPath(): string {
+  return join(traeHome(), 'cli', 'history.jsonl');
 }
 
 /** Per-session rollout JSONL files live under dates here, e.g.

--- a/src/services/traex-transcript.ts
+++ b/src/services/traex-transcript.ts
@@ -165,6 +165,81 @@ export function traexRolloutHasUserInputSince(
   );
 }
 
+// -- history.jsonl submit-confirmation (submit-time truth) ------------------
+//
+// TRAE writes ~/.trae/cli/history.jsonl at SUBMIT time — one JSON line
+// {session_id, ts, text} per successful user submit, byte-identical to Codex's
+// format. This is the correct submit-confirmation source: a type-ahead message
+// parked while a turn runs is logged here immediately, whereas the per-session
+// rollout only records it when the running turn dequeues it (which can exceed
+// the worker's confirmation deadline → false "submission couldn't be confirmed"
+// warning). Because history.jsonl is a single global file shared by every TRAE
+// pane under one TRAE_HOME, a same-text line may be written by a concurrent
+// sibling pane; callers pass an `acceptSid` ownership filter to skip a foreign
+// pane's line. Mirrors the codex.ts writeInput verification path exactly.
+
+export interface TraexHistoryMatch {
+  found: boolean;
+  cliSessionId?: string;
+}
+
+/** Optional ownership filter for a shared-history match: accept a same-text
+ *  line only when its session id is one the owning pid actually holds open.
+ *  Re-evaluated on every call so a lazily-opened owned rollout fd that appears
+ *  AFTER its history line can still be accepted on a later poll. */
+export type TraexHistorySidFilter = (cliSessionId: string | undefined) => boolean;
+
+function readTraexHistorySid(parsed: unknown): string | undefined {
+  return parsed && typeof parsed === 'object' && typeof (parsed as any).session_id === 'string'
+    ? (parsed as any).session_id
+    : undefined;
+}
+
+/** Scan the byte delta appended to history.jsonl since `fromByte` for a line
+ *  whose decoded `text` exactly matches `expectedText` (newline-normalised).
+ *  Never parses a non-newline-terminated tail, so a half-written line can't
+ *  manufacture a false match — a later poll sees the completed entry. */
+export function traexHistoryMatchDelta(
+  path: string,
+  fromByte: number,
+  expectedText: string,
+  acceptSid?: TraexHistorySidFilter,
+): TraexHistoryMatch {
+  if (!existsSync(path)) return { found: false };
+  let size: number;
+  try { size = statSync(path).size; } catch { return { found: false }; }
+  if (size <= fromByte) return { found: false };
+  const len = size - fromByte;
+  const buf = Buffer.alloc(len);
+  const fd = openSync(path, 'r');
+  try { readSync(fd, buf, 0, len, fromByte); } finally { closeSync(fd); }
+  const delta = buf.toString('utf8');
+  // Drop a trailing partial line (no newline yet) — it may still be mid-write.
+  const lines = delta.endsWith('\n') ? delta.split('\n') : delta.split('\n').slice(0, -1);
+  const expected = normaliseInputText(expectedText);
+  for (const line of lines) {
+    if (line.length === 0) continue;
+    let parsed: any;
+    try { parsed = JSON.parse(line); } catch { continue; }
+    if (typeof parsed?.text !== 'string') continue;
+    if (normaliseInputText(parsed.text) !== expected) continue;
+    const cliSessionId = readTraexHistorySid(parsed);
+    // Skip a same-text line owned by a DIFFERENT pane (shared-TRAE_HOME
+    // collision). Keep scanning — the owned line may be later in this delta
+    // or arrive on a later poll.
+    if (acceptSid && !acceptSid(cliSessionId)) continue;
+    return { found: true, cliSessionId };
+  }
+  return { found: false };
+}
+
+/** Current byte size of history.jsonl (0 when absent), captured before a paste
+ *  so the confirmation scan only considers lines this submit appends. */
+export function traexHistorySize(path: string): number {
+  if (!path || !existsSync(path)) return 0;
+  try { return statSync(path).size; } catch { return 0; }
+}
+
 function matchTraexRolloutPath(target: string): { path: string; cliSessionId: string } | undefined {
   if (!target.endsWith('.jsonl')) return undefined;
   // Accept both the default layout (~/.trae/cli/sessions/...) and any
@@ -180,41 +255,65 @@ function matchTraexRolloutPath(target: string): { path: string; cliSessionId: st
   return { path: target, cliSessionId: sid };
 }
 
+/** Enumerate the file paths a pid holds open (Linux /proc, else lsof). Shared
+ *  by findTraexRolloutByPid (single) and findTraexRolloutSetByPid (ownership
+ *  set) so both derive from one source. Returns undefined when enumeration is
+ *  unavailable — callers treat that as "cannot prove ownership". */
+function traexProcessOpenTargets(pid: number): string[] | undefined {
+  if (!Number.isInteger(pid) || pid <= 0) return undefined;
+  if (IS_LINUX) {
+    const fdDir = `/proc/${pid}/fd`;
+    if (!existsSync(fdDir)) return undefined;
+    let entries: string[];
+    try { entries = readdirSync(fdDir); } catch { return undefined; }
+    const targets: string[] = [];
+    for (const fd of entries) {
+      try { targets.push(readlinkSync(join(fdDir, fd))); } catch { continue; }
+    }
+    return targets;
+  }
+  let out: string;
+  try {
+    out = execSync(`lsof -p ${pid} -Fn`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+  } catch {
+    return undefined;
+  }
+  const targets: string[] = [];
+  for (const line of out.split('\n')) {
+    if (line.startsWith('n/')) targets.push(line.slice(1));
+  }
+  return targets;
+}
+
 /** Find the rollout file an externally-running TRAE process has open.
  *  Same /proc/<pid>/fd strategy as findCodexRolloutByPid, but with a
  *  TRAE-specific path matcher so we never bind to a sibling Codex pane. */
 export function findTraexRolloutByPid(pid: number): { path: string; cliSessionId: string } | undefined {
-  if (!Number.isInteger(pid) || pid <= 0) return undefined;
-  if (IS_LINUX) {
-    const fdDir = `/proc/${pid}/fd`;
-    if (existsSync(fdDir)) {
-      let entries: string[];
-      try { entries = readdirSync(fdDir); } catch { return undefined; }
-      for (const fd of entries) {
-        let target: string;
-        try { target = readlinkSync(join(fdDir, fd)); } catch { continue; }
-        const hit = matchTraexRolloutPath(target);
-        if (hit) return hit;
-      }
-      return undefined;
-    }
-  }
-  let out: string;
-  try {
-    out = execSync(`lsof -p ${pid} -Fn`, {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-  } catch {
-    return undefined;
-  }
-  for (const line of out.split('\n')) {
-    if (!line.startsWith('n/')) continue;
-    const target = line.slice(1);
+  const targets = traexProcessOpenTargets(pid);
+  if (!targets) return undefined;
+  for (const target of targets) {
     const hit = matchTraexRolloutPath(target);
     if (hit) return hit;
   }
   return undefined;
+}
+
+/** Lowercased set of TRAE session ids whose rollout the pid holds open. The
+ *  ownership gate for a shared-history.jsonl submit match: only a sid this pid
+ *  actually owns is safe to accept, so a concurrent sibling pane's identical
+ *  text can't hand back a foreign session id. Empty Set = pid holds no TRAE
+ *  rollout; undefined = fd enumeration unavailable (caller must fail open on
+ *  the ownership check but the worker's attach gate re-verifies). Mirrors
+ *  findCodexRolloutSetByPid. */
+export function findTraexRolloutSetByPid(pid: number): Set<string> | undefined {
+  const targets = traexProcessOpenTargets(pid);
+  if (!targets) return undefined;
+  const set = new Set<string>();
+  for (const target of targets) {
+    const hit = matchTraexRolloutPath(target);
+    if (hit) set.add(hit.cliSessionId.toLowerCase());
+  }
+  return set;
 }
 
 /** Locate the rollout file for a given TRAE session UUID. Filename shape is

--- a/src/services/traex-transcript.ts
+++ b/src/services/traex-transcript.ts
@@ -302,8 +302,8 @@ export function findTraexRolloutByPid(pid: number): { path: string; cliSessionId
  *  ownership gate for a shared-history.jsonl submit match: only a sid this pid
  *  actually owns is safe to accept, so a concurrent sibling pane's identical
  *  text can't hand back a foreign session id. Empty Set = pid holds no TRAE
- *  rollout; undefined = fd enumeration unavailable (caller must fail open on
- *  the ownership check but the worker's attach gate re-verifies). Mirrors
+ *  rollout; undefined = fd enumeration unavailable (callers must treat undefined
+ *  as "cannot prove ownership" — fail closed, do not bind). Mirrors
  *  findCodexRolloutSetByPid. */
 export function findTraexRolloutSetByPid(pid: number): Set<string> | undefined {
   const targets = traexProcessOpenTargets(pid);
@@ -315,6 +315,22 @@ export function findTraexRolloutSetByPid(pid: number): Set<string> | undefined {
   }
   return set;
 }
+
+/** Pure ownership decision: is `cliSessionId` one of the rollouts the observed
+ *  pid holds open? `ownedRollouts` is the lowercased sid set from
+ *  findTraexRolloutSetByPid (undefined when fd enumeration was unavailable).
+ *  FAIL CLOSED — a missing set or a non-member id returns false so the caller
+ *  never binds the bridge (or persists a resume id) it can't prove the pid owns.
+ *  Extracted so the exact predicate the worker's persist/attach gates use is
+ *  unit-testable without a live pid. Mirrors codexHistorySidIsOwned. */
+export function traexHistorySidIsOwned(
+  cliSessionId: string,
+  ownedRollouts: Set<string> | undefined,
+): boolean {
+  if (!ownedRollouts) return false;
+  return ownedRollouts.has(cliSessionId.toLowerCase());
+}
+
 
 /** Locate the rollout file for a given TRAE session UUID. Filename shape is
  *  identical to Codex: `rollout-<ts>-<sid>.jsonl`, so a suffix match over the

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1183,6 +1183,11 @@ let lastSpawnEffectiveCliSessionId: string | undefined;
 let lastSpawnDeferInitialPrompt = false;
 let lastSpawnQueuedInitialPrompt: string | undefined;
 let lastSpawnQueuedInitialPromptLogicalContent: string | undefined;
+// True when this session runs under an outer bwrap supervisor (file sandbox OR
+// Linux credential-only bwrap) — both make getChildPid() the supervisor, not the
+// CLI leaf. credentialOnlyBwrap needs host probes so it can't be recomputed from
+// cfg at gate-check time; capture the spawn-time verdict for currentTraexObservedPid.
+let lastSpawnOuterBwrapActive = false;
 /**
  * True only when {@link shouldArmSpawnArgvInitialPromptBusy} says so: argv-
  * baked first prompt + SessionStart ready (Grok-class). First markPromptReady
@@ -3658,18 +3663,21 @@ function codexBridgeStartTimer(): void {
           cwd: lastInitConfig?.workingDir,
           pid: codexAdoptPendingPid,
         });
-        // Codex defense-in-depth: resolveFileBridgePath resolves sessionId-first,
-        // so a pending sid that is actually a shared-CODEX_HOME sibling's would
-        // resolve to that foreign rollout. Only attach when the resolved rollout's
-        // sid is one the observed pid actually holds open. This poller re-runs
-        // every 1s, so a lazily-opened owned fd is picked up on a later tick.
-        // Skip the gate only when we have no pid to prove ownership with (keeps
-        // the sid/pid resolution working for non-adopt / pid-less flows).
-        const attachOk = !(structuredBridgeIsCodex() && lastInitConfig?.adoptMode && path && currentCodexObservedPid())
-          || (() => {
-            const sid = codexSessionIdFromRolloutPath(path!);
-            return !!sid && codexHistorySidOwnedByCurrentPid(sid);
-          })();
+        // Codex/TRAE defense-in-depth: resolveFileBridgePath resolves
+        // sessionId-first, so a pending sid that is actually a shared-home
+        // sibling's (CODEX_HOME / TRAE_HOME) would resolve to that foreign
+        // rollout. Only attach when the resolved rollout's sid is one the
+        // observed pid actually holds open. This poller re-runs every 1s, so a
+        // lazily-opened owned fd is picked up on a later tick. Skip the gate
+        // only when we have no pid to prove ownership with (keeps the sid/pid
+        // resolution working for non-adopt / pid-less flows).
+        const codexAttachGated = structuredBridgeIsCodex() && lastInitConfig?.adoptMode && path && currentCodexObservedPid();
+        const traexAttachGated = structuredBridgeIsTraex() && lastInitConfig?.adoptMode && path && currentTraexObservedPid();
+        const attachOk = codexAttachGated
+          ? (() => { const sid = codexSessionIdFromRolloutPath(path!); return !!sid && codexHistorySidOwnedByCurrentPid(sid); })()
+          : traexAttachGated
+            ? (() => { const sid = codexSessionIdFromRolloutPath(path!); return !!sid && traexHistorySidOwnedByCurrentPid(sid); })()
+            : true;
         if (path && attachOk) {
           if (codexAdoptPendingPid && (lastInitConfig?.cliId === 'codex' || lastInitConfig?.cliId === 'traex')) {
             const discoveredSessionId = codexSessionIdFromRolloutPath(path);
@@ -3935,15 +3943,32 @@ function codexHistorySidOwnedByCurrentPid(cliSessionId: string): boolean {
   return owned;
 }
 
+/** Resolve the pid that actually holds a TRAE rollout open, given a candidate
+ *  that may be a bwrap supervisor. Under the file sandbox, botmux launches
+ *  `bwrap --unshare-pid -- traex`, so the tmux pane leaf / getChildPid() is the
+ *  bwrap process — its /proc/<pid>/fd holds no rollout, and the ownership gate
+ *  would always fail. The real traex leaf is host-visible across the pid ns
+ *  (ps -A ppid links), so a comm-based BFS descends to it. Outside the sandbox
+ *  (or if traex hasn't been forked yet) the candidate already is the leaf, so
+ *  we return it unchanged — fail closed to the launcher pid rather than guess. */
+function resolveTraexOwnershipPid(candidatePid: number, sandbox: boolean): number {
+  if (!sandbox || !candidatePid) return candidatePid;
+  return findLaunchedCliPid(candidatePid, 'traex') ?? candidatePid;
+}
+
 /** TRAE counterpart of currentCodexObservedPid: the pid of the TRAE process
  *  this worker observes (spawned child or adopted pane). Same resolution order
  *  — the wired backend.cliPid first, then the live pane child pid, then the
  *  adopt-pending pid (which is populated for TRAE too, see the codex/traex
- *  branch around line 3674). */
+ *  branch around line 3674). backend.cliPid is already sandbox-resolved at wire
+ *  time; the getChildPid() fallback is not, so descend it here too (no-op
+ *  outside the sandbox / when already a leaf). */
 function currentTraexObservedPid(): number | undefined {
-  return (backend as { cliPid?: number } | null)?.cliPid
-    ?? backend?.getChildPid?.()
-    ?? codexAdoptPendingPid;
+  const wired = (backend as { cliPid?: number } | null)?.cliPid;
+  if (wired) return wired;
+  const child = backend?.getChildPid?.();
+  if (child) return resolveTraexOwnershipPid(child, lastSpawnOuterBwrapActive);
+  return codexAdoptPendingPid;
 }
 
 /** Ownership gate for binding a TRAE session id that came from the GLOBAL
@@ -4136,6 +4161,19 @@ function codexBridgeNotifyCliSessionId(cliSessionId: string): void {
   if (structuredBridgeIsCodex() && lastInitConfig?.adoptMode && currentCodexObservedPid()) {
     if (!codexHistorySidOwnedByCurrentPid(cliSessionId)) {
       log(`Codex initial-attach refused for unverified session ${cliSessionId}; keeping poller armed on pid ${currentCodexObservedPid()}`);
+      codexBridgePendingSessionId = undefined;
+      codexBridgeStartTimer();
+      return;
+    }
+  }
+  // TRAE INITIAL attach: same shared-history.jsonl hazard as codex above. The
+  // TRAE adapter only returns an owned sid, but keep a defense-in-depth gate so
+  // a foreign sid from any other path can't first-attach the bridge in adopt
+  // mode. Fail closed identically: keep the poller armed on the adopt pid rather
+  // than pinning an unverified sid (which would wedge the bridge).
+  if (structuredBridgeIsTraex() && lastInitConfig?.adoptMode && currentTraexObservedPid()) {
+    if (!traexHistorySidOwnedByCurrentPid(cliSessionId)) {
+      log(`TRAE initial-attach refused for unverified session ${cliSessionId}; keeping poller armed on pid ${currentTraexObservedPid()}`);
       codexBridgePendingSessionId = undefined;
       codexBridgeStartTimer();
       return;
@@ -9615,6 +9653,36 @@ async function spawnCli(
   if (cliPid) startWrapperRealPidResolve(cliPid);
   if (cliPid) observeCursorCliSessionId(cliPid);
 
+  // File sandbox / Linux credential-only bwrap launches `bwrap --unshare-pid --
+  // traex`, so the pane leaf (getChildPid) is the bwrap SUPERVISOR — its
+  // /proc/<pid>/fd holds no rollout and the TRAE ownership gate can never admit
+  // a session id (fresh sandbox TRAE then never captures its SID, the bridge
+  // never attaches, and because reliableTurnTerminal disables screen-idle the
+  // durable turn can wedge — it does NOT self-heal). The real traex leaf is
+  // host-visible across the pid ns (ps -A ppid links), so BFS-descend to it and
+  // rewire backend.cliPid. Bounded retry (not one-shot): bwrap may not have
+  // forked traex yet at spawn. Reuses scheduleWrapperRealCliPid's stale-backend
+  // guard so a mid-retry worker restart can't rewire the new session. Gated on
+  // outerBwrapActive — sandboxRequested OR the Linux credential-only bwrap path,
+  // both of which produce an outer supervisor pid. */
+  const outerBwrapActive = sandboxRequested || credentialOnlyBwrap;
+  lastSpawnOuterBwrapActive = outerBwrapActive;
+  const startTraexSandboxPidResolve = (launcherPid: number): void => {
+    if (cfg.cliId !== 'traex' || !outerBwrapActive) return;
+    scheduleWrapperRealCliPid(launcherPid, {
+      findRealPid: (lp) => findLaunchedCliPid(lp, 'traex'),
+      getBackend: () => backend,
+      getChildPid: () => backend?.getChildPid?.(),
+      applyRealPid: (realPid) => {
+        log(`TRAE sandbox: resolved real traex leaf pid ${realPid} under bwrap supervisor ${launcherPid}; rewiring ownership pid`);
+        (backend as TmuxBackend | PtyBackend | ZellijBackend | ZmxBackend).cliPid = realPid;
+        (backend as TmuxBackend | PtyBackend | ZellijBackend | ZmxBackend).cliCwd = cfg.workingDir;
+        publishLocalProcessAttestation(realPid);
+      },
+      schedule: (fn, ms) => { setTimeout(fn, ms); },
+    });
+  };
+
   // Wire pid + cwd so adapters' writeInput can bind submits to this process:
   //   - claude-code: ~/.claude/sessions/<pid>.json
   //   - grok: findGrokSessionByPid → preferSessionId against shared
@@ -9622,16 +9690,24 @@ async function spawnCli(
   //   - traex: findTraexRolloutSetByPid → ownership gate for the shared global
   //     history.jsonl (concurrent same-TRAE_HOME panes must not cross-claim a
   //     sibling's session id from an identical-text submit). getChildPid() is
-  //     the tmux/pty pane leaf = the traex process (traex has no launcher
-  //     indirection; a rare wrapperCli+traex combo isn't rewired here, so its
-  //     unowned pid just fails closed — no wrong id, only lost id capture).
+  //     normally the traex process itself, EXCEPT under the file sandbox: bwrap
+  //     runs `--unshare-pid -- traex`, so the pane leaf is the bwrap supervisor
+  //     and /proc/<bwrap>/fd holds no rollout. resolveTraexOwnershipPid() BFS-
+  //     descends to the real traex leaf (host-visible across the pid ns via
+  //     `ps -A` ppid links) so the ownership gate can actually admit the id;
+  //     it fails closed to the launcher pid when no leaf is found yet (the async
+  //     retry below re-resolves once bwrap has forked traex).
   // Claude's sessionId is set ONCE at process start (2.1.123); a `--resume`
   // lookup will surface here, but in-pane `/clear` won't. The pinned
   // claudeJsonlPath above is still the initial guess; the resolver corrects
   // it on first write when Claude was started with `--resume`.
   if (cliPid && (claudeDataDir || cfg.cliId === 'grok' || cfg.cliId === 'traex')) {
-    (backend as TmuxBackend | PtyBackend | ZellijBackend | ZmxBackend).cliPid = cliPid;
+    // TRAE under outer bwrap: best-effort immediate resolve (leaf may already be
+    // forked), then a bounded retry below covers the not-yet-forked case.
+    const wiredPid = cfg.cliId === 'traex' ? resolveTraexOwnershipPid(cliPid, outerBwrapActive) : cliPid;
+    (backend as TmuxBackend | PtyBackend | ZellijBackend | ZmxBackend).cliPid = wiredPid;
     (backend as TmuxBackend | PtyBackend | ZellijBackend | ZmxBackend).cliCwd = cfg.workingDir;
+    if (cfg.cliId === 'traex' && outerBwrapActive) startTraexSandboxPidResolve(cliPid);
   }
 
   // Async pid fallback: tmux/pty resolve the CLI pid synchronously above, but
@@ -9660,8 +9736,10 @@ async function spawnCli(
           }
         }
         if (claudeDataDir || cfg.cliId === 'grok' || cfg.cliId === 'traex') {
-          (backend as TmuxBackend | PtyBackend | ZellijBackend | ZmxBackend).cliPid = pid;
+          const wiredPid = cfg.cliId === 'traex' ? resolveTraexOwnershipPid(pid, outerBwrapActive) : pid;
+          (backend as TmuxBackend | PtyBackend | ZellijBackend | ZmxBackend).cliPid = wiredPid;
           (backend as TmuxBackend | PtyBackend | ZellijBackend | ZmxBackend).cliCwd = cfg.workingDir;
+          if (cfg.cliId === 'traex' && outerBwrapActive) startTraexSandboxPidResolve(pid);
         }
         // wrapperCli under a late-pid backend (zellij): `pid` here is still the
         // LAUNCHER. Kick the descendant resolver so the bridge gets the real CLI

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -132,7 +132,7 @@ import {
 import { buildBotmuxLarkNativeSessionTitle } from './core/session-title.js';
 import { drainCodexRollout, findCodexRolloutBySessionId, findCodexRolloutByPid, findCodexRolloutSetByPid, codexHistorySidIsOwned, splitCodexEventsByCutoff, extractLastCodexTurn, codexSessionIdFromRolloutPath, scanCodexThreadSettings, type CodexBridgeEvent, type CodexDrainResult } from './services/codex-transcript.js';
 import { CodexServiceTierTracker, resolveCodexServiceTierSnapshot } from './services/codex-service-tier.js';
-import { drainTraexRollout, findTraexRolloutBySessionId, findTraexRolloutByPid } from './services/traex-transcript.js';
+import { drainTraexRollout, findTraexRolloutBySessionId, findTraexRolloutByPid, findTraexRolloutSetByPid, traexHistorySidIsOwned } from './services/traex-transcript.js';
 import { parseTraexUserInputQuestions } from './services/traex-user-input.js';
 import { cocoEventsPathForSession, drainCocoEvents, findCocoSessionByPid } from './services/coco-transcript.js';
 import { currentHermesStateOffset, drainHermesStateDb, resolveHermesStateDbPath } from './services/hermes-transcript.js';
@@ -3935,6 +3935,37 @@ function codexHistorySidOwnedByCurrentPid(cliSessionId: string): boolean {
   return owned;
 }
 
+/** TRAE counterpart of currentCodexObservedPid: the pid of the TRAE process
+ *  this worker observes (spawned child or adopted pane). Same resolution order
+ *  — the wired backend.cliPid first, then the live pane child pid, then the
+ *  adopt-pending pid (which is populated for TRAE too, see the codex/traex
+ *  branch around line 3674). */
+function currentTraexObservedPid(): number | undefined {
+  return (backend as { cliPid?: number } | null)?.cliPid
+    ?? backend?.getChildPid?.()
+    ?? codexAdoptPendingPid;
+}
+
+/** Ownership gate for binding a TRAE session id that came from the GLOBAL
+ *  history.jsonl (shared by every TRAE pane under one TRAE_HOME). A concurrent
+ *  sibling pane submitting identical text — e.g. a bare "继续" in adopt mode,
+ *  which carries no unique <session_id> — can make writeInput's history match
+ *  surface a FOREIGN session id. Before persisting it (resume target) or
+ *  (re-)attaching the transcript bridge, require the id to be one THIS pid
+ *  actually holds open. FAIL CLOSED: unavailable fd enumeration (undefined set)
+ *  or a non-member id → false, so the caller keeps its current binding. Mirrors
+ *  codexHistorySidOwnedByCurrentPid; the pure decision lives in
+ *  traexHistorySidIsOwned for unit testing without a live pid. */
+function traexHistorySidOwnedByCurrentPid(cliSessionId: string): boolean {
+  const pid = currentTraexObservedPid();
+  const ownedRollouts = pid ? findTraexRolloutSetByPid(pid) : undefined;
+  const owned = traexHistorySidIsOwned(cliSessionId, ownedRollouts);
+  if (!owned) {
+    log(`TRAE session id ${cliSessionId} not owned by pid ${pid ?? '?'} (open rollouts: ${ownedRollouts ? [...ownedRollouts].join(',') || 'none' : 'unknown'})`);
+  }
+  return owned;
+}
+
 /** Called from flushPending after writeInput first returns a cliSessionId.
  *  Tries to locate the rollout file immediately; if it's not on disk yet,
  *  remembers the sid so the 1s poller can keep retrying. */
@@ -3990,6 +4021,15 @@ function codexBridgeNotifyCliSessionId(cliSessionId: string): void {
     if (structuredBridgeIsTraex()) {
       const currentSid = codexSessionIdFromRolloutPath(codexBridgeRolloutPath);
       if (currentSid && currentSid.toLowerCase() === cliSessionId.toLowerCase()) return;
+      // Ownership gate: the reported id came from the GLOBAL history.jsonl, so a
+      // sibling pane's identical text (e.g. a bare adopt-mode reply with no
+      // unique <session_id>) could surface a foreign id. Only rotate the bridge
+      // to a rollout THIS pid holds open; otherwise keep the current binding
+      // (fail closed on unknown/unowned). Mirrors the codex branch above.
+      if (!traexHistorySidOwnedByCurrentPid(cliSessionId)) {
+        log(`Keeping current TRAE bridge ${currentSid ?? '?'} — refusing history-only re-attach to ${cliSessionId}`);
+        return;
+      }
       const next = resolveFileBridgePath('traex', { sessionId: cliSessionId });
       // Close any terminal already committed to the retired rollout before
       // switching. A durable turn is a worker HOL barrier, so a legitimate
@@ -9579,11 +9619,17 @@ async function spawnCli(
   //   - claude-code: ~/.claude/sessions/<pid>.json
   //   - grok: findGrokSessionByPid → preferSessionId against shared
   //     prompt_history (concurrent same-cwd workers must not cross-claim)
+  //   - traex: findTraexRolloutSetByPid → ownership gate for the shared global
+  //     history.jsonl (concurrent same-TRAE_HOME panes must not cross-claim a
+  //     sibling's session id from an identical-text submit). getChildPid() is
+  //     the tmux/pty pane leaf = the traex process (traex has no launcher
+  //     indirection; a rare wrapperCli+traex combo isn't rewired here, so its
+  //     unowned pid just fails closed — no wrong id, only lost id capture).
   // Claude's sessionId is set ONCE at process start (2.1.123); a `--resume`
   // lookup will surface here, but in-pane `/clear` won't. The pinned
   // claudeJsonlPath above is still the initial guess; the resolver corrects
   // it on first write when Claude was started with `--resume`.
-  if (cliPid && (claudeDataDir || cfg.cliId === 'grok')) {
+  if (cliPid && (claudeDataDir || cfg.cliId === 'grok' || cfg.cliId === 'traex')) {
     (backend as TmuxBackend | PtyBackend | ZellijBackend | ZmxBackend).cliPid = cliPid;
     (backend as TmuxBackend | PtyBackend | ZellijBackend | ZmxBackend).cliCwd = cfg.workingDir;
   }
@@ -9613,7 +9659,7 @@ async function spawnCli(
             log(`Failed to write CLI PID marker (async): ${err.message}`);
           }
         }
-        if (claudeDataDir || cfg.cliId === 'grok') {
+        if (claudeDataDir || cfg.cliId === 'grok' || cfg.cliId === 'traex') {
           (backend as TmuxBackend | PtyBackend | ZellijBackend | ZmxBackend).cliPid = pid;
           (backend as TmuxBackend | PtyBackend | ZellijBackend | ZmxBackend).cliCwd = cfg.workingDir;
         }

--- a/test/find-launched-cli-pid.test.ts
+++ b/test/find-launched-cli-pid.test.ts
@@ -59,6 +59,24 @@ describe('findLaunchedCliPid()', () => {
     expect(findLaunchedCliPid(1, 'codex', 6, { childrenOf: (pid) => t[pid] ?? [], commOf: (pid) => c[pid] })).toBe(2);
   });
 
+  it('descends bwrap --unshare-pid supervisor → intermediate → traex leaf (sandbox)', () => {
+    // Empirically observed shape: node-pty/tmux launches `bwrap`, which forks an
+    // intermediate then execs traex in a new pid ns. getChildPid() returns the
+    // bwrap supervisor (500); the real traex leaf (502) holds the rollout fd and
+    // is host-visible via ps -A ppid links. The BFS must reach it.
+    const t: Record<number, number[]> = { 500: [501], 501: [502], 502: [] };
+    const c: Record<number, string> = { 500: 'bwrap', 501: 'bwrap', 502: 'traex' };
+    expect(findLaunchedCliPid(500, 'traex', 6, { childrenOf: (pid) => t[pid] ?? [], commOf: (pid) => c[pid] })).toBe(502);
+  });
+
+  it('returns null when bwrap has not yet exec\'d traex (bounded retry re-runs)', () => {
+    // At spawn, bwrap may not have forked the leaf yet — findLaunchedCliPid
+    // returns null and the caller's bounded retry re-runs on a later tick.
+    const t: Record<number, number[]> = { 500: [501], 501: [] };
+    const c: Record<number, string> = { 500: 'bwrap', 501: 'bwrap' };
+    expect(findLaunchedCliPid(500, 'traex', 6, { childrenOf: (pid) => t[pid] ?? [], commOf: (pid) => c[pid] })).toBeNull();
+  });
+
   it('terminates on cycles in the reported tree (seen guard)', () => {
     const cyc: Record<number, number[]> = { 1: [2], 2: [1] }; // 2 points back to 1
     const c: Record<number, string> = { 1: 'node', 2: 'sh' };

--- a/test/traex-adapter-submit.test.ts
+++ b/test/traex-adapter-submit.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { appendFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { spawn, type ChildProcess } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createTraexAdapter } from '../src/adapters/cli/traex.js';
@@ -8,10 +9,19 @@ import type { PtyHandle } from '../src/adapters/cli/types.js';
 // TRAE submit verification polls the global submit log history.jsonl (written
 // at SUBMIT time), NOT the per-session rollout. This mirrors the codex adapter
 // and is the fix for the false "submission couldn't be confirmed" warning that
-// fired when a type-ahead follow-up was parked mid-turn: the rollout only gets
-// a parked message when the running turn dequeues it (can exceed the worker's
-// deadline), while history.jsonl gets it immediately. These tests drive a PTY
-// whose Enter appends the pasted text to history.jsonl, exactly as TRAE does.
+// fired when a type-ahead follow-up was parked mid-turn.
+//
+// history.jsonl is a GLOBAL file shared by every TRAE pane under one TRAE_HOME,
+// so a sibling pane's identical text (e.g. a bare adopt-mode reply with no
+// unique <session_id>) can surface a FOREIGN session id. The adapter therefore
+// separates two facts:
+//   - the text match CONFIRMS the submit (ownership-independent — always);
+//   - the reported session id is only RETURNED when this pid provably holds
+//     that rollout open (fail closed otherwise), so persist/attach never binds
+//     an unverified id.
+// These tests drive a PTY whose Enter appends the pasted text to history.jsonl,
+// and — for the ownership path — hold the matching rollout file open in a real
+// child process so /proc/<pid>/fd resolves.
 
 const SID_1 = '00000000-0000-7000-8000-000000000001';
 const SID_2 = '00000000-0000-7000-8000-000000000002';
@@ -19,6 +29,7 @@ let traeHome: string;
 let historyPath: string;
 let previousTraeHome: string | undefined;
 let previousScale: string | undefined;
+const holders: ChildProcess[] = [];
 
 function historyLine(sid: string, text: string): string {
   return `${JSON.stringify({ session_id: sid, ts: 1785900000, text })}\n`;
@@ -29,9 +40,24 @@ function seedHistory(sid: string, text: string): void {
   appendFileSync(historyPath, historyLine(sid, text));
 }
 
+/** Create the rollout file for `sid` and hold it open in a real child process,
+ *  returning that pid. findTraexRolloutSetByPid(pid) then sees the rollout via
+ *  /proc/<pid>/fd, so the adapter's ownership gate admits the sid. */
+function spawnRolloutHolder(sid: string): number {
+  const dir = join(traeHome, 'cli', 'sessions', '2026', '08', '05');
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `rollout-2026-08-05T00-00-00-${sid}.jsonl`);
+  writeFileSync(path, historyLine(sid, 'rollout seed'));
+  // `tail -f` keeps an fd open on the file until we kill it.
+  const child = spawn('tail', ['-f', path], { stdio: 'ignore' });
+  holders.push(child);
+  return child.pid!;
+}
+
 /** A PTY whose first Enter appends the pasted text to history.jsonl under the
- *  given session id — the submit-time write TRAE performs. */
-function ptyThatCommits(sid: string): PtyHandle & {
+ *  given session id — the submit-time write TRAE performs. Optional cliPid wires
+ *  the adapter's ownership gate. */
+function ptyThatCommits(sid: string, cliPid?: number): PtyHandle & {
   pasteText: ReturnType<typeof vi.fn>;
   sendSpecialKeys: ReturnType<typeof vi.fn>;
 } {
@@ -39,6 +65,7 @@ function ptyThatCommits(sid: string): PtyHandle & {
   let committed = false;
   return {
     write: vi.fn(),
+    cliPid,
     pasteText: vi.fn((text: string) => { pasted = text; }),
     sendSpecialKeys: vi.fn((key: string) => {
       if (key === 'Enter' && !committed) {
@@ -50,16 +77,11 @@ function ptyThatCommits(sid: string): PtyHandle & {
   };
 }
 
-/** A PTY that never writes the submit to history.jsonl (stuck in composer). */
-function ptyThatNeverCommits(): PtyHandle & {
+function ptyThatNeverCommits(cliPid?: number): PtyHandle & {
   pasteText: ReturnType<typeof vi.fn>;
   sendSpecialKeys: ReturnType<typeof vi.fn>;
 } {
-  return {
-    write: vi.fn(),
-    pasteText: vi.fn(),
-    sendSpecialKeys: vi.fn(),
-  };
+  return { write: vi.fn(), cliPid, pasteText: vi.fn(), sendSpecialKeys: vi.fn() };
 }
 
 describe.sequential('TRAE adapter submit verification (history.jsonl)', () => {
@@ -73,6 +95,7 @@ describe.sequential('TRAE adapter submit verification (history.jsonl)', () => {
   });
 
   afterEach(() => {
+    while (holders.length) { try { holders.pop()!.kill('SIGKILL'); } catch { /* ignore */ } }
     if (previousTraeHome === undefined) delete process.env.TRAE_HOME;
     else process.env.TRAE_HOME = previousTraeHome;
     if (previousScale === undefined) delete process.env.BOTMUX_TIME_SCALE;
@@ -80,16 +103,19 @@ describe.sequential('TRAE adapter submit verification (history.jsonl)', () => {
     rmSync(traeHome, { recursive: true, force: true });
   });
 
+  // ── Submit confirmation (ownership-INDEPENDENT — the original bug fix) ──
+
   it('confirms the first submit even when history.jsonl does not exist yet (lazy-created)', async () => {
     // No history file on disk — TRAE creates it on the first submit. baseByte=0
     // and the appended line matches, so the submit is confirmed (unlike the old
-    // SQLite path, which failed closed before writing).
+    // SQLite path, which failed closed before writing). No cliPid → no id, but
+    // the submit is still confirmed (never a false submit_unconfirmed).
     const adapter = createTraexAdapter('/bin/traex');
     const pty = ptyThatCommits(SID_1);
 
     const result = await adapter.writeInput(pty, 'the very first prompt');
 
-    expect(result).toEqual({ submitted: true, cliSessionId: SID_1 });
+    expect(result).toEqual({ submitted: true });
     expect(pty.pasteText).toHaveBeenCalledWith('the very first prompt');
     expect(pty.sendSpecialKeys).toHaveBeenCalledWith('Enter');
   });
@@ -101,25 +127,16 @@ describe.sequential('TRAE adapter submit verification (history.jsonl)', () => {
 
     const result = await adapter.writeInput(pty, 'a different second prompt');
 
-    expect(result).toEqual({ submitted: true, cliSessionId: SID_1 });
+    expect(result).toEqual({ submitted: true });
     // baseByte was captured after the seeded line, so only the new submit counts.
     expect(pty.sendSpecialKeys).toHaveBeenCalledTimes(1);
-  });
-
-  it('returns the new native session id when a submit rotates to a fresh session', async () => {
-    seedHistory(SID_1, 'old session prompt');
-    const adapter = createTraexAdapter('/bin/traex');
-    const pty = ptyThatCommits(SID_2);
-
-    const result = await adapter.writeInput(pty, 'first prompt after session rotation');
-
-    expect(result).toEqual({ submitted: true, cliSessionId: SID_2 });
   });
 
   it('confirms a mid-turn type-ahead follow-up (the false-warning regression)', async () => {
     // Simulates the reported bug: a follow-up sent while a turn is running. TRAE
     // parks it but writes history.jsonl immediately, so writeInput confirms it
-    // in-band instead of returning { submitted: false } → false warning.
+    // in-band instead of returning { submitted: false } → false warning. Submit
+    // confirmation must NOT depend on pid ownership.
     seedHistory(SID_1, '<botmux_routing>opening turn</botmux_routing>');
     const adapter = createTraexAdapter('/bin/traex');
     const followUp = `<session_id>bm</session_id>\n\n<user_message>\nfollow-up while busy\n</user_message>`;
@@ -127,7 +144,7 @@ describe.sequential('TRAE adapter submit verification (history.jsonl)', () => {
 
     const result = await adapter.writeInput(pty, followUp);
 
-    expect(result).toEqual({ submitted: true, cliSessionId: SID_1 });
+    expect(result).toEqual({ submitted: true });
   });
 
   it('returns submitted:false + recheck when the submit never reaches history.jsonl', async () => {
@@ -139,10 +156,54 @@ describe.sequential('TRAE adapter submit verification (history.jsonl)', () => {
 
     expect(result).toMatchObject({ submitted: false });
     expect(typeof (result as any).recheck).toBe('function');
-    // A recheck once the file finally records it flips to confirmed.
+    // A recheck once the file finally records it flips to confirmed (no owning
+    // pid → confirmed without an id).
     appendFileSync(historyPath, historyLine(SID_1, 'stuck in composer'));
     const late = await (result as any).recheck();
-    expect(late).toEqual({ submitted: true, cliSessionId: SID_1 });
+    expect(late).toEqual({ submitted: true });
+  });
+
+  // ── Session-id ownership (only RETURN a pid-owned id) ──
+
+  it('returns the session id when THIS pid provably owns the rollout', async () => {
+    const ownedPid = spawnRolloutHolder(SID_1);
+    // Give tail a beat to open the fd.
+    await new Promise(r => setTimeout(r, 150));
+    const adapter = createTraexAdapter('/bin/traex');
+    const pty = ptyThatCommits(SID_1, ownedPid);
+
+    const result = await adapter.writeInput(pty, 'owned submit');
+
+    expect(result).toEqual({ submitted: true, cliSessionId: SID_1 });
+  });
+
+  it('confirms the submit but WITHHOLDS a foreign sibling id the pid does not own', async () => {
+    // The classic collision: our pid owns SID_1's rollout, but a sibling pane
+    // wrote the SAME text first under SID_2. The history match may surface
+    // SID_2; ownership gating must refuse to return it (would misbind resume /
+    // bridge to a foreign session) while still confirming our submit.
+    const ownedPid = spawnRolloutHolder(SID_1);
+    await new Promise(r => setTimeout(r, 150));
+    const adapter = createTraexAdapter('/bin/traex');
+    // PTY commits the text under the FOREIGN SID_2 (sibling won the race).
+    const pty = ptyThatCommits(SID_2, ownedPid);
+
+    const result = await adapter.writeInput(pty, 'duplicate text across panes');
+
+    expect(result).toEqual({ submitted: true });
+    expect((result as any).cliSessionId).toBeUndefined();
+  });
+
+  it('withholds the id when fd enumeration is unavailable (pid not running)', async () => {
+    // A pid that isn't a live rollout holder → findTraexRolloutSetByPid returns
+    // an empty set (or undefined); either way, fail closed on the id but still
+    // confirm the submit.
+    const adapter = createTraexAdapter('/bin/traex');
+    const pty = ptyThatCommits(SID_1, 2 ** 22); // almost-certainly-dead pid
+
+    const result = await adapter.writeInput(pty, 'no owner submit');
+
+    expect(result).toEqual({ submitted: true });
   });
 
   it('keeps the botmux-ask fallback skill for non-RPC TraeX sessions', () => {

--- a/test/traex-adapter-submit.test.ts
+++ b/test/traex-adapter-submit.test.ts
@@ -1,81 +1,37 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { DatabaseSync } from 'node:sqlite';
-import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { appendFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { createTraexAdapter } from '../src/adapters/cli/traex.js';
 import type { PtyHandle } from '../src/adapters/cli/types.js';
+
+// TRAE submit verification polls the global submit log history.jsonl (written
+// at SUBMIT time), NOT the per-session rollout. This mirrors the codex adapter
+// and is the fix for the false "submission couldn't be confirmed" warning that
+// fired when a type-ahead follow-up was parked mid-turn: the rollout only gets
+// a parked message when the running turn dequeues it (can exceed the worker's
+// deadline), while history.jsonl gets it immediately. These tests drive a PTY
+// whose Enter appends the pasted text to history.jsonl, exactly as TRAE does.
 
 const SID_1 = '00000000-0000-7000-8000-000000000001';
 const SID_2 = '00000000-0000-7000-8000-000000000002';
 let traeHome: string;
-let dbPath: string;
+let historyPath: string;
 let previousTraeHome: string | undefined;
 let previousScale: string | undefined;
 
-function rolloutPath(sid: string): string {
-  return join(traeHome, 'cli', 'sessions', '2000', '01', '01', `rollout-2000-01-01T00-00-00-${sid}.jsonl`);
+function historyLine(sid: string, text: string): string {
+  return `${JSON.stringify({ session_id: sid, ts: 1785900000, text })}\n`;
 }
 
-function userLine(text: string): string {
-  return `${JSON.stringify({
-    timestamp: new Date().toISOString(),
-    type: 'response_item',
-    payload: {
-      type: 'message',
-      role: 'user',
-      content: [{ type: 'input_text', text }],
-    },
-  })}\n`;
+function seedHistory(sid: string, text: string): void {
+  mkdirSync(join(traeHome, 'cli'), { recursive: true });
+  appendFileSync(historyPath, historyLine(sid, text));
 }
 
-function openDb(): DatabaseSync {
-  return new DatabaseSync(dbPath);
-}
-
-function createStateDb(): void {
-  mkdirSync(dirname(dbPath), { recursive: true });
-  const db = openDb();
-  try {
-    db.exec(`
-      CREATE TABLE threads (
-        id TEXT PRIMARY KEY,
-        rollout_path TEXT NOT NULL,
-        created_at INTEGER NOT NULL,
-        updated_at_ms INTEGER,
-        first_user_message TEXT NOT NULL DEFAULT ''
-      )
-    `);
-  } finally {
-    db.close();
-  }
-}
-
-function insertThread(sid: string, text: string, updatedAtMs: number): void {
-  const path = rolloutPath(sid);
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, userLine(text));
-  const db = openDb();
-  try {
-    db.prepare(
-      'INSERT INTO threads (id, rollout_path, created_at, updated_at_ms, first_user_message) VALUES (?, ?, ?, ?, ?)',
-    ).run(sid, path, updatedAtMs, updatedAtMs, text);
-  } finally {
-    db.close();
-  }
-}
-
-function appendThreadUser(sid: string, text: string, updatedAtMs: number): void {
-  appendFileSync(rolloutPath(sid), userLine(text));
-  const db = openDb();
-  try {
-    db.prepare('UPDATE threads SET updated_at_ms = ? WHERE id = ?').run(updatedAtMs, sid);
-  } finally {
-    db.close();
-  }
-}
-
-function ptyThatCommits(onEnter: (text: string) => void): PtyHandle & {
+/** A PTY whose first Enter appends the pasted text to history.jsonl under the
+ *  given session id — the submit-time write TRAE performs. */
+function ptyThatCommits(sid: string): PtyHandle & {
   pasteText: ReturnType<typeof vi.fn>;
   sendSpecialKeys: ReturnType<typeof vi.fn>;
 } {
@@ -87,18 +43,31 @@ function ptyThatCommits(onEnter: (text: string) => void): PtyHandle & {
     sendSpecialKeys: vi.fn((key: string) => {
       if (key === 'Enter' && !committed) {
         committed = true;
-        onEnter(pasted);
+        mkdirSync(join(traeHome, 'cli'), { recursive: true });
+        appendFileSync(historyPath, historyLine(sid, pasted));
       }
     }),
   };
 }
 
-describe.sequential('TRAE adapter submit verification', () => {
+/** A PTY that never writes the submit to history.jsonl (stuck in composer). */
+function ptyThatNeverCommits(): PtyHandle & {
+  pasteText: ReturnType<typeof vi.fn>;
+  sendSpecialKeys: ReturnType<typeof vi.fn>;
+} {
+  return {
+    write: vi.fn(),
+    pasteText: vi.fn(),
+    sendSpecialKeys: vi.fn(),
+  };
+}
+
+describe.sequential('TRAE adapter submit verification (history.jsonl)', () => {
   beforeEach(() => {
     previousTraeHome = process.env.TRAE_HOME;
     previousScale = process.env.BOTMUX_TIME_SCALE;
     traeHome = mkdtempSync(join(tmpdir(), 'traex-adapter-'));
-    dbPath = join(traeHome, 'cli', 'state_5.sqlite');
+    historyPath = join(traeHome, 'cli', 'history.jsonl');
     process.env.TRAE_HOME = traeHome;
     process.env.BOTMUX_TIME_SCALE = '0.01';
   });
@@ -111,41 +80,69 @@ describe.sequential('TRAE adapter submit verification', () => {
     rmSync(traeHome, { recursive: true, force: true });
   });
 
-  it('fails closed before PTY write when the SQLite session index is unavailable', async () => {
+  it('confirms the first submit even when history.jsonl does not exist yet (lazy-created)', async () => {
+    // No history file on disk — TRAE creates it on the first submit. baseByte=0
+    // and the appended line matches, so the submit is confirmed (unlike the old
+    // SQLite path, which failed closed before writing).
     const adapter = createTraexAdapter('/bin/traex');
-    const pty = ptyThatCommits(() => { throw new Error('must not submit'); });
+    const pty = ptyThatCommits(SID_1);
 
-    const result = await adapter.writeInput(pty, 'do not write without proof');
+    const result = await adapter.writeInput(pty, 'the very first prompt');
 
-    expect(result).toEqual(expect.objectContaining({
-      submitted: false,
-      failureReason: expect.stringContaining('SQLite'),
-    }));
-    expect(pty.pasteText).not.toHaveBeenCalled();
-    expect(pty.sendSpecialKeys).not.toHaveBeenCalled();
+    expect(result).toEqual({ submitted: true, cliSessionId: SID_1 });
+    expect(pty.pasteText).toHaveBeenCalledWith('the very first prompt');
+    expect(pty.sendSpecialKeys).toHaveBeenCalledWith('Enter');
   });
 
-  it('confirms a later turn from the same rollout delta, not first_user_message', async () => {
-    createStateDb();
-    insertThread(SID_1, 'the immutable first prompt', 1_000);
+  it('confirms a later turn from the history.jsonl delta, ignoring earlier lines', async () => {
+    seedHistory(SID_1, 'the immutable first prompt');
     const adapter = createTraexAdapter('/bin/traex');
-    const pty = ptyThatCommits(text => appendThreadUser(SID_1, text, 2_000));
+    const pty = ptyThatCommits(SID_1);
 
     const result = await adapter.writeInput(pty, 'a different second prompt');
 
     expect(result).toEqual({ submitted: true, cliSessionId: SID_1 });
+    // baseByte was captured after the seeded line, so only the new submit counts.
     expect(pty.sendSpecialKeys).toHaveBeenCalledTimes(1);
   });
 
-  it('returns the new native session id when a submit rotates to a fresh rollout', async () => {
-    createStateDb();
-    insertThread(SID_1, 'old session prompt', 1_000);
+  it('returns the new native session id when a submit rotates to a fresh session', async () => {
+    seedHistory(SID_1, 'old session prompt');
     const adapter = createTraexAdapter('/bin/traex');
-    const pty = ptyThatCommits(text => insertThread(SID_2, text, 2_000));
+    const pty = ptyThatCommits(SID_2);
 
     const result = await adapter.writeInput(pty, 'first prompt after session rotation');
 
     expect(result).toEqual({ submitted: true, cliSessionId: SID_2 });
+  });
+
+  it('confirms a mid-turn type-ahead follow-up (the false-warning regression)', async () => {
+    // Simulates the reported bug: a follow-up sent while a turn is running. TRAE
+    // parks it but writes history.jsonl immediately, so writeInput confirms it
+    // in-band instead of returning { submitted: false } → false warning.
+    seedHistory(SID_1, '<botmux_routing>opening turn</botmux_routing>');
+    const adapter = createTraexAdapter('/bin/traex');
+    const followUp = `<session_id>bm</session_id>\n\n<user_message>\nfollow-up while busy\n</user_message>`;
+    const pty = ptyThatCommits(SID_1);
+
+    const result = await adapter.writeInput(pty, followUp);
+
+    expect(result).toEqual({ submitted: true, cliSessionId: SID_1 });
+  });
+
+  it('returns submitted:false + recheck when the submit never reaches history.jsonl', async () => {
+    seedHistory(SID_1, 'prior turn');
+    const adapter = createTraexAdapter('/bin/traex');
+    const pty = ptyThatNeverCommits();
+
+    const result = await adapter.writeInput(pty, 'stuck in composer');
+
+    expect(result).toMatchObject({ submitted: false });
+    expect(typeof (result as any).recheck).toBe('function');
+    // A recheck once the file finally records it flips to confirmed.
+    appendFileSync(historyPath, historyLine(SID_1, 'stuck in composer'));
+    const late = await (result as any).recheck();
+    expect(late).toEqual({ submitted: true, cliSessionId: SID_1 });
   });
 
   it('keeps the botmux-ask fallback skill for non-RPC TraeX sessions', () => {

--- a/test/traex-adapter-submit.test.ts
+++ b/test/traex-adapter-submit.test.ts
@@ -84,6 +84,32 @@ function ptyThatNeverCommits(cliPid?: number): PtyHandle & {
   return { write: vi.fn(), cliPid, pasteText: vi.fn(), sendSpecialKeys: vi.fn() };
 }
 
+/** A PTY whose Enter appends the SAME pasted text TWICE — first under a foreign
+ *  sibling's session id, THEN under the owned one. Models the shared-history
+ *  collision where a sibling pane's identical text lands first in history.jsonl
+ *  but our own owned line follows. The adapter must skip the foreign line and
+ *  return the owned id. */
+function ptyForeignThenOwned(foreignSid: string, ownedSid: string, cliPid?: number): PtyHandle & {
+  pasteText: ReturnType<typeof vi.fn>;
+  sendSpecialKeys: ReturnType<typeof vi.fn>;
+} {
+  let pasted = '';
+  let committed = false;
+  return {
+    write: vi.fn(),
+    cliPid,
+    pasteText: vi.fn((text: string) => { pasted = text; }),
+    sendSpecialKeys: vi.fn((key: string) => {
+      if (key === 'Enter' && !committed) {
+        committed = true;
+        mkdirSync(join(traeHome, 'cli'), { recursive: true });
+        appendFileSync(historyPath, historyLine(foreignSid, pasted));  // sibling first
+        appendFileSync(historyPath, historyLine(ownedSid, pasted));    // ours next
+      }
+    }),
+  };
+}
+
 describe.sequential('TRAE adapter submit verification (history.jsonl)', () => {
   beforeEach(() => {
     previousTraeHome = process.env.TRAE_HOME;
@@ -192,6 +218,21 @@ describe.sequential('TRAE adapter submit verification (history.jsonl)', () => {
 
     expect(result).toEqual({ submitted: true });
     expect((result as any).cliSessionId).toBeUndefined();
+  });
+
+  it('returns the OWNED id when a foreign sibling line is written first, ours later', async () => {
+    // Codex regression: an unfiltered matcher returns at the FIRST matching line,
+    // so a foreign-first line would mask our owned line and drop the id even
+    // though we own a later one. With an enumerable pid, the owned scan skips the
+    // foreign line and keeps scanning to ours — returning SID_1, not undefined.
+    const ownedPid = spawnRolloutHolder(SID_1);
+    await new Promise(r => setTimeout(r, 150));
+    const adapter = createTraexAdapter('/bin/traex');
+    const pty = ptyForeignThenOwned(SID_2, SID_1, ownedPid);
+
+    const result = await adapter.writeInput(pty, 'duplicate text foreign-first');
+
+    expect(result).toEqual({ submitted: true, cliSessionId: SID_1 });
   });
 
   it('withholds the id when fd enumeration is unavailable (pid not running)', async () => {

--- a/test/traex-adapter-submit.test.ts
+++ b/test/traex-adapter-submit.test.ts
@@ -85,10 +85,10 @@ function ptyThatNeverCommits(cliPid?: number): PtyHandle & {
 }
 
 /** A PTY whose Enter appends the SAME pasted text TWICE — first under a foreign
- *  sibling's session id, THEN under the owned one. Models the shared-history
- *  collision where a sibling pane's identical text lands first in history.jsonl
- *  but our own owned line follows. The adapter must skip the foreign line and
- *  return the owned id. */
+ *  sibling's session id, THEN under the owned one (both in the same callback, so
+ *  both are present by the adapter's first probe). The adapter must skip the
+ *  foreign line and return the owned id. See ptyForeignNowOwnedLater for the
+ *  harder async-timing variant. */
 function ptyForeignThenOwned(foreignSid: string, ownedSid: string, cliPid?: number): PtyHandle & {
   pasteText: ReturnType<typeof vi.fn>;
   sendSpecialKeys: ReturnType<typeof vi.fn>;
@@ -105,6 +105,36 @@ function ptyForeignThenOwned(foreignSid: string, ownedSid: string, cliPid?: numb
         mkdirSync(join(traeHome, 'cli'), { recursive: true });
         appendFileSync(historyPath, historyLine(foreignSid, pasted));  // sibling first
         appendFileSync(historyPath, historyLine(ownedSid, pasted));    // ours next
+      }
+    }),
+  };
+}
+
+/** The hard async-timing variant: on Enter the FOREIGN line lands immediately,
+ *  but the OWNED line is written by a timer strictly AFTER the adapter's first
+ *  poll (delayMs). This reproduces Codex's reproduction — a matcher that settles
+ *  on the first any-text sighting would return {submitted:true} with no id at
+ *  ~200ms and never re-scan for the owned line. The adapter must keep polling
+ *  (enumeration available) until the owned line surfaces, then return ownedSid. */
+function ptyForeignNowOwnedLater(
+  foreignSid: string, ownedSid: string, cliPid: number, delayMs: number,
+): PtyHandle & { pasteText: ReturnType<typeof vi.fn>; sendSpecialKeys: ReturnType<typeof vi.fn>; timers: NodeJS.Timeout[] } {
+  let pasted = '';
+  let committed = false;
+  const timers: NodeJS.Timeout[] = [];
+  return {
+    write: vi.fn(),
+    cliPid,
+    timers,
+    pasteText: vi.fn((text: string) => { pasted = text; }),
+    sendSpecialKeys: vi.fn((key: string) => {
+      if (key === 'Enter' && !committed) {
+        committed = true;
+        mkdirSync(join(traeHome, 'cli'), { recursive: true });
+        appendFileSync(historyPath, historyLine(foreignSid, pasted));  // foreign lands now
+        timers.push(setTimeout(() => {
+          appendFileSync(historyPath, historyLine(ownedSid, pasted));   // owned lands later
+        }, delayMs));
       }
     }),
   };
@@ -231,6 +261,26 @@ describe.sequential('TRAE adapter submit verification (history.jsonl)', () => {
     const pty = ptyForeignThenOwned(SID_2, SID_1, ownedPid);
 
     const result = await adapter.writeInput(pty, 'duplicate text foreign-first');
+
+    expect(result).toEqual({ submitted: true, cliSessionId: SID_1 });
+  });
+
+  it('keeps polling past a foreign-first sighting until the OWNED line lands later (async timing)', async () => {
+    // Codex's timing reproduction: on Enter the foreign line lands immediately,
+    // the owned line ~400ms later — strictly after the adapter's first probe. A
+    // matcher that settled on the first any-text sighting would return
+    // {submitted:true} with NO id at ~200ms and never re-scan. Enumeration is
+    // available (real owning pid), so the adapter must keep polling until the
+    // owned line surfaces and return SID_1. Run at REAL time (no BOTMUX_TIME_SCALE)
+    // so the 200ms+800ms cadence spans the 400ms owned-line timer.
+    delete process.env.BOTMUX_TIME_SCALE;
+    const ownedPid = spawnRolloutHolder(SID_1);
+    await new Promise(r => setTimeout(r, 150));
+    const adapter = createTraexAdapter('/bin/traex');
+    const pty = ptyForeignNowOwnedLater(SID_2, SID_1, ownedPid, 400);
+
+    const result = await adapter.writeInput(pty, 'duplicate text owned-later');
+    for (const t of pty.timers) clearTimeout(t);
 
     expect(result).toEqual({ submitted: true, cliSessionId: SID_1 });
   });

--- a/test/traex-transcript.test.ts
+++ b/test/traex-transcript.test.ts
@@ -6,6 +6,8 @@ import { CodexBridgeQueue } from '../src/services/codex-bridge-queue.js';
 import {
   drainTraexRollout,
   traexRolloutHasUserInputSince,
+  traexHistoryMatchDelta,
+  traexHistorySize,
 } from '../src/services/traex-transcript.js';
 
 const SID = '00000000-0000-7000-8000-000000000001';
@@ -183,5 +185,87 @@ describe('traexRolloutHasUserInputSince', () => {
     expect(traexRolloutHasUserInputSince(path, baseline, 'same thread, later prompt')).toBe(true);
     expect(traexRolloutHasUserInputSince(path, baseline, 'same thread, old prompt')).toBe(false);
     expect(traexRolloutHasUserInputSince(path, baseline, 'same thread')).toBe(false);
+  });
+});
+
+describe('traexHistoryMatchDelta (submit-time history.jsonl verification)', () => {
+  let histPath: string;
+
+  function histLine(sessionId: string, text: string): string {
+    return `${JSON.stringify({ session_id: sessionId, ts: 1785900000, text })}\n`;
+  }
+
+  beforeEach(() => {
+    histPath = join(dir, 'history.jsonl');
+  });
+
+  it('confirms a submit appended after baseByte and returns its session_id', () => {
+    const base = histLine('aaaa1111-0000-7000-8000-000000000001', 'earlier turn');
+    writeFileSync(histPath, base);
+    const baseByte = Buffer.byteLength(base);
+    // The follow-up botmux would paste while a turn is running: parked by TRAE
+    // but written to history.jsonl immediately at submit time.
+    appendFileSync(histPath, histLine('bbbb2222-0000-7000-8000-000000000002', '<session_id>x</session_id>\n\n<user_message>\nfollow-up while busy\n</user_message>'));
+
+    const match = traexHistoryMatchDelta(histPath, baseByte, '<session_id>x</session_id>\n\n<user_message>\nfollow-up while busy\n</user_message>');
+    expect(match.found).toBe(true);
+    expect(match.cliSessionId).toBe('bbbb2222-0000-7000-8000-000000000002');
+  });
+
+  it('never matches a line at or before baseByte (only the new submit)', () => {
+    const base = histLine('aaaa1111-0000-7000-8000-000000000001', 'earlier turn');
+    writeFileSync(histPath, base);
+    const baseByte = Buffer.byteLength(base);
+    expect(traexHistoryMatchDelta(histPath, baseByte, 'earlier turn').found).toBe(false);
+  });
+
+  it('returns not-found when the file is absent (lazy-created on first submit)', () => {
+    expect(traexHistoryMatchDelta(join(dir, 'nope.jsonl'), 0, 'anything').found).toBe(false);
+  });
+
+  it('normalises CRLF/CR so a paste round-tripped through TRAE still matches', () => {
+    writeFileSync(histPath, '');
+    appendFileSync(histPath, histLine('cccc3333-0000-7000-8000-000000000003', 'line one\nline two'));
+    // Expected text arrives with CRLF from the caller; the stored text is LF.
+    const match = traexHistoryMatchDelta(histPath, 0, 'line one\r\nline two');
+    expect(match.found).toBe(true);
+    expect(match.cliSessionId).toBe('cccc3333-0000-7000-8000-000000000003');
+  });
+
+  it('ignores a trailing partial (non-newline-terminated) line until it completes', () => {
+    writeFileSync(histPath, '');
+    // Half-written line — no trailing newline. Must NOT match yet.
+    const partial = JSON.stringify({ session_id: 'dddd4444-0000-7000-8000-000000000004', ts: 1785900001, text: 'mid write' });
+    writeFileSync(histPath, partial);
+    expect(traexHistoryMatchDelta(histPath, 0, 'mid write').found).toBe(false);
+    // Completed with a newline on a later poll — now it matches.
+    writeFileSync(histPath, partial + '\n');
+    expect(traexHistoryMatchDelta(histPath, 0, 'mid write').found).toBe(true);
+  });
+
+  it('with an ownership filter, skips a sibling pane\'s identical text and accepts only the owned session', () => {
+    writeFileSync(histPath, '');
+    const foreignSid = 'ffff0000-0000-7000-8000-00000000000f';
+    const ownedSid = '11110000-0000-7000-8000-000000000011';
+    // Same exact text submitted by two panes sharing one TRAE_HOME; the
+    // sibling's line lands first.
+    appendFileSync(histPath, histLine(foreignSid, 'duplicate text'));
+    appendFileSync(histPath, histLine(ownedSid, 'duplicate text'));
+
+    const acceptOwned = (sid: string | undefined) => sid?.toLowerCase() === ownedSid.toLowerCase();
+    const match = traexHistoryMatchDelta(histPath, 0, 'duplicate text', acceptOwned);
+    expect(match.found).toBe(true);
+    expect(match.cliSessionId).toBe(ownedSid);
+
+    // If the ONLY line is a foreign pane's, the owned filter rejects it.
+    writeFileSync(histPath, histLine(foreignSid, 'only foreign'));
+    expect(traexHistoryMatchDelta(histPath, 0, 'only foreign', acceptOwned).found).toBe(false);
+  });
+
+  it('traexHistorySize returns 0 for an absent file and the byte size otherwise', () => {
+    expect(traexHistorySize(join(dir, 'absent.jsonl'))).toBe(0);
+    const body = histLine('eeee5555-0000-7000-8000-000000000055', 'sized');
+    writeFileSync(histPath, body);
+    expect(traexHistorySize(histPath)).toBe(Buffer.byteLength(body));
   });
 });

--- a/test/traex-transcript.test.ts
+++ b/test/traex-transcript.test.ts
@@ -8,6 +8,7 @@ import {
   traexRolloutHasUserInputSince,
   traexHistoryMatchDelta,
   traexHistorySize,
+  traexHistorySidIsOwned,
 } from '../src/services/traex-transcript.js';
 
 const SID = '00000000-0000-7000-8000-000000000001';
@@ -267,5 +268,29 @@ describe('traexHistoryMatchDelta (submit-time history.jsonl verification)', () =
     const body = histLine('eeee5555-0000-7000-8000-000000000055', 'sized');
     writeFileSync(histPath, body);
     expect(traexHistorySize(histPath)).toBe(Buffer.byteLength(body));
+  });
+});
+
+describe('traexHistorySidIsOwned (ownership gate predicate)', () => {
+  const OWNED = 'aaaa1111-0000-7000-8000-000000000001';
+  const FOREIGN = 'ffff0000-0000-7000-8000-00000000000f';
+
+  it('accepts an id present in the owned set (case-insensitive)', () => {
+    const owned = new Set([OWNED.toLowerCase()]);
+    expect(traexHistorySidIsOwned(OWNED, owned)).toBe(true);
+    expect(traexHistorySidIsOwned(OWNED.toUpperCase(), owned)).toBe(true);
+  });
+
+  it('rejects an id NOT in the owned set (foreign sibling pane)', () => {
+    const owned = new Set([OWNED.toLowerCase()]);
+    expect(traexHistorySidIsOwned(FOREIGN, owned)).toBe(false);
+  });
+
+  it('fails closed when the set is undefined (fd enumeration unavailable)', () => {
+    expect(traexHistorySidIsOwned(OWNED, undefined)).toBe(false);
+  });
+
+  it('fails closed on an empty set (pid holds no TRAE rollout)', () => {
+    expect(traexHistorySidIsOwned(OWNED, new Set())).toBe(false);
   });
 });

--- a/test/traex-worker-bridge-wiring.test.ts
+++ b/test/traex-worker-bridge-wiring.test.ts
@@ -90,6 +90,53 @@ describe('TRAE worker structured-bridge wiring', () => {
     expect(matches.length).toBeGreaterThanOrEqual(2);
   });
 
+  it('gates the TRAE INITIAL bridge attach on pid-fd ownership (adopt mode)', () => {
+    // The initial-attach path (no prior rollout bound) must refuse a foreign
+    // shared-history sid, mirroring the codex initial-attach gate. Fail closed:
+    // keep the poller armed rather than pinning an unverified sid.
+    expect(workerSource).toContain('TRAE initial-attach refused for unverified session');
+    const idx = workerSource.indexOf('TRAE initial-attach refused');
+    const ctx = workerSource.slice(workerSource.lastIndexOf('if (structuredBridgeIsTraex()', idx), idx + 200);
+    expect(ctx).toContain("lastInitConfig?.adoptMode && currentTraexObservedPid()");
+    expect(ctx).toContain('traexHistorySidOwnedByCurrentPid(cliSessionId)');
+  });
+
+  it('gates the TRAE adopt poller attach on resolved-rollout ownership', () => {
+    // The 1s poller resolves a pending sid to a rollout path (sessionId-first),
+    // so a shared-TRAE_HOME sibling sid would resolve to a foreign rollout.
+    // attachOk must verify the resolved rollout's sid is pid-owned before
+    // attaching (and before it persists the discovered sid for traex).
+    expect(workerSource).toContain('traexAttachGated');
+    const idx = workerSource.indexOf('const codexAttachGated');
+    const ctx = workerSource.slice(idx, idx + 700);
+    expect(ctx).toContain("structuredBridgeIsTraex() && lastInitConfig?.adoptMode");
+    expect(ctx).toContain('traexHistorySidOwnedByCurrentPid(sid)');
+  });
+
+  it('resolves the real traex leaf under an outer bwrap supervisor (sandbox pid)', () => {
+    // Under the file sandbox / credential-only bwrap, getChildPid() is the bwrap
+    // supervisor, not traex. resolveTraexOwnershipPid BFS-descends to the leaf so
+    // the ownership gate can admit the id; gated on outerBwrapActive (sandbox OR
+    // credential-only bwrap, since both produce an outer supervisor).
+    const start = workerSource.indexOf('function resolveTraexOwnershipPid');
+    const body = workerSource.slice(start, workerSource.indexOf('\n}\n', start));
+    expect(body).toContain("findLaunchedCliPid(candidatePid, 'traex')");
+    expect(workerSource).toContain('const outerBwrapActive = sandboxRequested || credentialOnlyBwrap;');
+  });
+
+  it('drives the sandbox leaf resolver as a BOUNDED RETRY (leaf may not be forked yet)', () => {
+    // One-shot resolution loses the common case where bwrap has not exec'd traex
+    // at wire time. startTraexSandboxPidResolve reuses scheduleWrapperRealCliPid
+    // (the same bounded-retry + stale-backend guard as the wrapperCli resolver),
+    // and both the sync and zellij-async wiring sites kick it.
+    const start = workerSource.indexOf('const startTraexSandboxPidResolve');
+    const body = workerSource.slice(start, start + 900);
+    expect(body).toContain('scheduleWrapperRealCliPid(launcherPid');
+    expect(body).toContain("findLaunchedCliPid(lp, 'traex')");
+    const kicks = workerSource.match(/if \(cfg\.cliId === 'traex' && outerBwrapActive\) startTraexSandboxPidResolve\(/g) ?? [];
+    expect(kicks.length).toBeGreaterThanOrEqual(2);
+  });
+
 
   it('follows the adopted TRAE pid so direct local /new rotation is observable', () => {
     expect(workerSource).toContain('maybeFollowTraexSessionRotationViaPid();');

--- a/test/traex-worker-bridge-wiring.test.ts
+++ b/test/traex-worker-bridge-wiring.test.ts
@@ -42,6 +42,55 @@ describe('TRAE worker structured-bridge wiring', () => {
     expect(traex).toContain('codexBridgePendingSessionId = cliSessionId;');
   });
 
+  it('gates the history-derived TRAE re-attach on pid-fd ownership (foreign sibling id refused)', () => {
+    // history.jsonl is a global file shared by every TRAE pane under one
+    // TRAE_HOME; a sibling pane's identical text (e.g. a bare adopt-mode reply
+    // with no unique <session_id>) can surface a foreign id. The rotation branch
+    // must refuse to re-attach the bridge to an id THIS pid does not own, and
+    // the ownership check must run BEFORE the bridge is detached/re-attached.
+    const start = workerSource.indexOf('function codexBridgeNotifyCliSessionId');
+    const end = workerSource.indexOf('function maybeFollowGrokSessionRotationViaPid', start);
+    const notify = workerSource.slice(start, end);
+    const traexStart = notify.indexOf('if (structuredBridgeIsTraex())');
+    const traex = notify.slice(traexStart, notify.indexOf('// Grok', traexStart));
+
+    expect(traex).toContain('traexHistorySidOwnedByCurrentPid(cliSessionId)');
+    // Gate must precede the detach/re-attach so an unowned id keeps the binding.
+    expect(traex.indexOf('traexHistorySidOwnedByCurrentPid(cliSessionId)'))
+      .toBeLessThan(traex.indexOf('codexBridgeDetachFile();'));
+    expect(traex).toContain('refusing history-only re-attach');
+  });
+
+  it('resolves the observed TRAE pid from backend.cliPid → child pid → adopt-pending pid', () => {
+    const start = workerSource.indexOf('function currentTraexObservedPid');
+    const end = workerSource.indexOf('\n}\n', start);
+    const body = workerSource.slice(start, end);
+
+    expect(body).toContain('.cliPid');
+    expect(body).toContain('backend?.getChildPid?.()');
+    expect(body).toContain('codexAdoptPendingPid');
+  });
+
+  it('gates the ownership decision through the pure fail-closed predicate', () => {
+    const start = workerSource.indexOf('function traexHistorySidOwnedByCurrentPid');
+    const end = workerSource.indexOf('\n}\n', start);
+    const body = workerSource.slice(start, end);
+
+    expect(body).toContain('currentTraexObservedPid()');
+    expect(body).toContain('findTraexRolloutSetByPid(pid)');
+    expect(body).toContain('traexHistorySidIsOwned(cliSessionId, ownedRollouts)');
+  });
+
+  it('wires fresh-managed TRAE cliPid so writeInput can prove submit ownership', () => {
+    // Without this, backend.cliPid is unset for a normal TRAE PTY/tmux session
+    // and the ownership gate can never admit the session id (only adopt mode,
+    // via adoptCliPid, would). Both the sync and async(zellij) wiring sites must
+    // include traex alongside grok.
+    const matches = workerSource.match(/claudeDataDir \|\| cfg\.cliId === 'grok' \|\| cfg\.cliId === 'traex'/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+
   it('follows the adopted TRAE pid so direct local /new rotation is observable', () => {
     expect(workerSource).toContain('maybeFollowTraexSessionRotationViaPid();');
     const start = workerSource.indexOf('function maybeFollowTraexSessionRotationViaPid');


### PR DESCRIPTION
## 问题

TRAE 用户经常遇到 `⚠️ 刚才那条消息发给 TRAE 后没能确认提交（重试 Enter 后等了 20s 仍未在会话 JSONL 里看到新记录）。可能卡在输入框里——请去 Web 终端看一下，手动按 Enter 或重发。` —— 但实际上 TRAE 已收到并会处理。

## 根因

TRAE 是 Codex 家族的 type-ahead CLI：**忙碌中发的追问会被 TRAE 暂存进队列，只在上一轮出队时才写入 per-session rollout JSONL**。但 `traex` 适配器的 `writeInput` 之前**轮询 rollout** 来确认提交，导致被暂存的追问在上一轮结束前查不到——超过 worker 的 20s 确认死线（`SUBMIT_DEFERRED_RECHECK_MS`）就误报。

**选错了验证文件**：适配器旧注释称「没有全局 history.jsonl」，但 `~/.trae/cli/history.jsonl` 真实存在且**在提交时刻即写入**（格式与 Codex 完全一致：`{session_id, ts, text}`）。Codex 适配器正是靠这个文件确认提交、绕开同一个坑——所以 Codex 免疫，TRAE 中招。

截图里报错的 preview 开头是 `<session_id>…`，正是**追问（follow-up）**而非新话题首条，与该场景完全吻合。

「经常而非每次」：worker 的仲裁器（`decideSubmitConfirmationAction`）在 20s 内若检测到 PTY 输出/transcript/`botmux send` 活动就会压掉告警——长任务持续刷屏时被掩盖，安静窗口才暴露，因而间歇性。

## 改动（仅限 TRAE，不动共用 Codex 逻辑）

- `traex.ts`：`writeInput` 弃用 SQLite rollout 快照，改为轮询 `history.jsonl` 的 byte-delta（`traexHistoryMatchDelta`），非换行结尾的半写行不参与匹配。
- `history.jsonl` 是同一 `TRAE_HOME` 下所有 pane 共享的全局文件，加 **Codex 同款 pid 所有权过滤**（`findTraexRolloutSetByPid`，走 `/proc/<pid>/fd`）：只接受本 pid 持有的 session，防并发 sibling pane 发相同文本抢答返回错误 `session_id`；pid 未知时 accept-first，保持单 pane 语义。
- 删除旧「SQLite 索引不可用即写前拒绝」分支：`history.jsonl` 首次提交才懒创建，`baseByte=0` 时首行天然匹配。
- `traex-paths.ts`：新增 `traeHistoryPath()`。

## 影响面

- **跨 CLI**：未触碰 `codex.ts` 或 `codex-transcript` 的共用导出（`splitCodexEventsByCutoff` 等），Codex/CoCo 等其它 Codex 家族适配器不受影响。
- **跨后端**：`writeInput` 经 `PtyHandle` 抽象，PTY/tmux 后端一致；`cliPid` 缺失时回退 accept-first。
- **会话类型**：仅影响 traex 适配器的提交确认路径。

## 验证

- **真机复现根因**：用 traecli 0.200.19 跑 PTY 复现——忙碌中追问 **+1.0s** 落 `history.jsonl`，rollout 到 **+20s 死线仍无**，旧路径必误报。
- **对照 Codex**：同款脚本跑真 codex——追问 **+1.0s** 落 `history.jsonl`，全程 20s 内确认，证实选对文件即免疫。
- **修复后 adapter 级 PTY 实证**（直接驱动编译后的 `writeInput`）：忙碌中追问 **1.0s 返回 `{submitted:true}`** 且 `session_id` 正确（修前为 `{submitted:false, recheck}` → 20s 后误报）。
- **单测**：`traex-transcript` 新增 7 例（提交时确认／delta／CRLF 归一／半写行安全／所有权过滤 sibling 与仅 foreign 拒绝／size），`traex-adapter-submit` 重写 6 例（旧用例 mock 的是已移除的 SQLite 路径），含忙碌中 type-ahead 追问回归。
- `pnpm build` 绿；两测试文件隔离与全量 `vitest --project unit` 均绿（另有 2 个与本改动无关的并发 flaky suite，隔离复跑全绿）。