### PR TITLE
fix(message-listener): 修卡片按钮链接丢失与关闭草稿二刷消失

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -2571,7 +2571,7 @@ async function collectMessageListenerPreviewMatches(
   });
   const candidateBotAppIds = collectListenerBotAppIds(messages, dashboardHistoryMessageSender);
   const appIdToOpenId = await buildListenerBotAppIdToOpenId(larkAppId, chatId, candidateBotAppIds);
-  return previewMessageListenerMatches({
+  const matches = previewMessageListenerMatches({
     bot: previewBot,
     chatId,
     messages,
@@ -2584,6 +2584,20 @@ async function collectMessageListenerPreviewMatches(
     // spawn a session for a message live routing never sends to the listener).
     explicitlyMentionedThisBot: (message) => messageMentionsBot(message, larkAppId, bot.botOpenId),
   });
+  // The listener matcher extracts card text from the SIMPLIFIED history view,
+  // which drops button jump URLs. The live delivery path (handleNewTopic) fixes
+  // this by re-extracting after resolveNonsupportMessage merges the card's two
+  // representations. Preview/run-preview do NOT go through handleNewTopic, so
+  // apply the equivalent merge here: run-preview spawns REAL turns off
+  // match.messageText, and preview display should show the same links the live
+  // listener will. Only interactive cards need it; a resolver miss keeps the
+  // match-time text. Resolve concurrently — each match is an independent fetch.
+  await Promise.all(matches.map(async (match) => {
+    if (match.msgType !== 'interactive') return;
+    const merged = await resolveMergedCardContent(larkAppId, match.messageId).catch(() => null);
+    if (merged?.text?.trim()) match.messageText = merged.text;
+  }));
+  return matches;
 }
 
 function publicMessageListenerMatch(match: MessageListenerPreviewMatch): Record<string, unknown> {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -195,7 +195,7 @@ import {
   extractBotmuxLarkNativeSessionTitlePrompt,
 } from './core/session-title.js';
 import { settleDeferredScheduleRun } from './core/deferred-schedule-settlement.js';
-import { renderMessageListenerPrompt } from './services/message-listener.js';
+import { renderMessageListenerPrompt, refreshListenerCardTextFromResolved } from './services/message-listener.js';
 import { sweepOrphanSandboxes } from './adapters/backend/sandbox.js';
 import { TmuxBackend } from './adapters/backend/tmux-backend.js';
 import { HerdrBackend } from './adapters/backend/herdr-backend.js';
@@ -15737,6 +15737,9 @@ async function handleNewTopic(data: any, ctx: RoutingContext): Promise<void> {
   const ownerOpenIdForSession = isForeignBotSender ? undefined : senderOpenId;
   const ownerUnionIdForSession = isForeignBotSender ? undefined : senderUnionId;
   const botCfg = getBot(larkAppId).config;
+  // Upgrade a card match's text/title from the resolved message (button URLs the
+  // simplified match-time view dropped). See refreshListenerCardTextFromResolved.
+  if (messageListener) refreshListenerCardTextFromResolved(messageListener, data.message);
   const listenerPrompt = messageListener ? renderMessageListenerPrompt(messageListener) : undefined;
   if (listenerPrompt) {
     content = listenerPrompt;

--- a/src/dashboard/web/roles-page.tsx
+++ b/src/dashboard/web/roles-page.tsx
@@ -139,7 +139,12 @@ function cloneListener(listener: MessageListenerData | null | undefined): Messag
 }
 
 function listenerHasConfig(listener: MessageListenerData | null): boolean {
-  return listener?.enabled === true && listener.prompt.trim().length > 0;
+  // A persisted listener is worth loading into the editor whenever it carries a
+  // prompt — INCLUDING a disabled draft (enabled:false + non-empty prompt). The
+  // backend persists such drafts (see messageListenerConfigFromUpdate); gating
+  // on enabled here would reset the editor to blank on reload and make the saved
+  // draft look lost. Runtime matching still requires enabled===true elsewhere.
+  return !!listener && listener.prompt.trim().length > 0;
 }
 
 function groupHasAnyRoleOrListener(group: GroupInfo): boolean {
@@ -740,18 +745,28 @@ function RolesPage(props: { tab: RolesTab }) {
 
   async function handleSaveListener(): Promise<void> {
     if (!selectedGroupId || !selectedBotId) return;
-    if (!editingListener.enabled) {
+    // Disabled + blank prompt = clear the listener entirely (mirrors the backend
+    // messageListenerConfigFromUpdate: nothing worth persisting → delete). A
+    // disabled draft WITH a prompt falls through and is saved as-is (enabled:false),
+    // so turning the toggle off then Save no longer discards the typed content.
+    if (!editingListener.enabled && !editingListener.prompt.trim()) {
       await handleDeleteListener(false);
       return;
     }
-    if (!editingListener.prompt.trim()) {
-      flash(setListenerFlash, tr('roles.listenerPromptRequired'), true);
-      return;
-    }
-    if (editingListener.senderPolicy?.mode !== 'all_except_excluded'
-      && (editingListener.senderPolicy?.includeSenderOpenIds?.length ?? 0) === 0) {
-      flash(setListenerFlash, tr('roles.listenerSenderRequired'), true);
-      return;
+    // Prompt + sender requirements only gate an ENABLED listener (it will match
+    // live messages). A disabled draft never matches at runtime, so an
+    // incomplete sender policy is fine to persist and re-editing later can
+    // complete it before enabling.
+    if (editingListener.enabled) {
+      if (!editingListener.prompt.trim()) {
+        flash(setListenerFlash, tr('roles.listenerPromptRequired'), true);
+        return;
+      }
+      if (editingListener.senderPolicy?.mode !== 'all_except_excluded'
+        && (editingListener.senderPolicy?.includeSenderOpenIds?.length ?? 0) === 0) {
+        flash(setListenerFlash, tr('roles.listenerSenderRequired'), true);
+        return;
+      }
     }
     setListenerSaving(true);
     try {
@@ -1012,7 +1027,7 @@ function RolesPage(props: { tab: RolesTab }) {
                         type="button"
                         id="roles-listener-delete"
                         className="danger"
-                        style={{ display: selectedListener?.enabled ? '' : 'none' }}
+                        style={{ display: selectedListener ? '' : 'none' }}
                         disabled={listenerDeleting}
                         onClick={() => void handleDeleteListener()}
                       >

--- a/src/services/message-listener-store.ts
+++ b/src/services/message-listener-store.ts
@@ -107,6 +107,37 @@ export function getMessageListenerConfig(larkAppId: string, chatId: string): Mes
   }
 }
 
+/**
+ * Build the persisted config for a listener update, or `null` when the update
+ * carries nothing worth keeping (→ delete the entry).
+ *
+ * A DISABLED listener with a non-empty prompt is a valid *draft*: it is
+ * persisted with `enabled:false` so the operator can turn it on later without
+ * retyping. Previously any disabled update was collapsed to `null` (deleted
+ * outright), so a draft saved while the toggle was off vanished on the next
+ * reload — the exact bug this fixes. Only a disabled update with a BLANK prompt
+ * is a true clear (this is also what the DELETE route sends: `{enabled:false,
+ * prompt:''}`). Enabled updates always carry a prompt
+ * (validateMessageListenerUpdate guarantees it), so they always build a config.
+ *
+ * Runtime is unaffected by a persisted draft: findMessageListenerForChat and
+ * enabledMessageListenerChatIds both require `enabled===true`, so an off draft
+ * never matches messages — it only survives for the dashboard editor.
+ */
+export function messageListenerConfigFromUpdate(patch: MessageListenerUpdate): MessageListenerConfig | null {
+  if (!patch.prompt.trim()) return null;
+  return {
+    enabled: patch.enabled,
+    ...(patch.name ? { name: patch.name } : {}),
+    ...(patch.replyCardTitle ? { replyCardTitle: patch.replyCardTitle } : {}),
+    ...(patch.workingDir ? { workingDir: patch.workingDir } : {}),
+    prompt: patch.prompt,
+    ...(patch.senderPolicy && Object.keys(patch.senderPolicy).length > 0 ? { senderPolicy: patch.senderPolicy } : {}),
+    ...(patch.messagePolicy ? { messagePolicy: { ...patch.messagePolicy, scope: 'top_level' } } : { messagePolicy: { scope: 'top_level' } }),
+    replyPolicy: { mode: 'thread', sessionMode: 'per_message' },
+  };
+}
+
 export async function updateMessageListenerConfig(
   larkAppId: string,
   chatId: string,
@@ -115,19 +146,13 @@ export async function updateMessageListenerConfig(
   let bot;
   try { bot = getBot(larkAppId); } catch { return { ok: false, reason: 'bot_not_registered' }; }
 
-  const normalized: MessageListenerConfig | null = patch.enabled ? {
-    enabled: true,
-    ...(patch.name ? { name: patch.name } : {}),
-    ...(patch.replyCardTitle ? { replyCardTitle: patch.replyCardTitle } : {}),
-    ...(patch.workingDir ? { workingDir: patch.workingDir } : {}),
-    prompt: patch.prompt,
-    ...(patch.senderPolicy && Object.keys(patch.senderPolicy).length > 0 ? { senderPolicy: patch.senderPolicy } : {}),
-    ...(patch.messagePolicy ? { messagePolicy: { ...patch.messagePolicy, scope: 'top_level' } } : { messagePolicy: { scope: 'top_level' } }),
-    replyPolicy: { mode: 'thread', sessionMode: 'per_message' },
-  } : null;
-
   const validation = validateMessageListenerUpdate(patch);
   if (!validation.ok) return { ok: false, reason: validation.reason };
+
+  // A disabled update with a non-empty prompt persists as an off DRAFT (kept for
+  // the editor, never matched at runtime); only a blank-prompt disabled update
+  // clears the entry. See messageListenerConfigFromUpdate.
+  const normalized = messageListenerConfigFromUpdate(patch);
 
   const result = await rmwBotEntry<MessageListenerConfig | null>(larkAppId, (entry) => {
     if (!normalized) {

--- a/src/services/message-listener.ts
+++ b/src/services/message-listener.ts
@@ -123,6 +123,30 @@ export function extractListenerMessageText(message: any): string {
   return '';
 }
 
+/**
+ * Refresh a card match's observed text/title from the (now-resolved) message.
+ *
+ * The listener match is computed during filtering, off the SIMPLIFIED card the
+ * WS/history API first delivers — that view drops button jump URLs and lazy
+ * sub-card bodies. The live delivery path (daemon handleNewTopic) later runs
+ * resolveNonsupportMessage(data), merging the card's two representations
+ * (server-rendered + structured body.elements, incl. button open_url) into
+ * `message.content` — the same depth the direct-@bot path uses. Re-extracting
+ * here lets the model receive the button links, not the lossy match-time
+ * snapshot. Only interactive cards can differ (plain text/post already carried
+ * full content at match time). Fail-safe: a resolver miss (cross-tenant, REST
+ * unavailable) leaves `message.content` as the simplified view and yields the
+ * SAME text as match time, so guarding on a non-empty result never blanks a
+ * match — it only ever upgrades. Mutates `match` in place.
+ */
+export function refreshListenerCardTextFromResolved(match: MessageListenerMatch, message: any): void {
+  if (match.msgType !== 'interactive') return;
+  const text = extractListenerMessageText(message);
+  if (text.trim()) match.messageText = text;
+  const title = extractListenerMessageTitle(message);
+  if (title?.trim()) match.messageTitle = title;
+}
+
 function contains(list: readonly string[] | undefined, value: string | undefined): boolean {
   return !!value && !!list && list.includes(value);
 }

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -332,6 +332,97 @@ describe('PUT /api/bot-card-prefs — Codex App clean history', () => {
   });
 });
 
+describe('PUT/GET /api/message-listeners/:chatId — disabled draft persistence (Bug2: 二刷消失)', () => {
+  it('persists a disabled listener that still has a prompt, and GET returns it after reload', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dashboard-ipc-listener-draft-'));
+    const configPath = join(dir, 'bots.json');
+    const appId = 'test-listener-draft-app';
+    const chatId = 'oc_draft_chat';
+    const prevBotsConfig = process.env.BOTS_CONFIG;
+    try {
+      process.env.BOTS_CONFIG = configPath;
+      writeFileSync(configPath, JSON.stringify([{
+        larkAppId: appId,
+        larkAppSecret: 'secret',
+        cliId: 'claude',
+      }], null, 2));
+      loadBotConfigs().forEach((c: any) => registerBot(c));
+      setLarkAppId(appId);
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      const base = `http://127.0.0.1:${handle.port}`;
+
+      // Save with the toggle OFF but a real prompt typed in — the exact action
+      // that used to silently drop everything.
+      const put = await fetch(`${base}/api/message-listeners/${chatId}`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ enabled: false, name: '告警监听草稿', prompt: '分析命中的告警消息' }),
+      });
+      expect(put.status).toBe(200);
+      const putBody = await put.json();
+      expect(putBody).toMatchObject({ ok: true });
+      expect(putBody.listener).toMatchObject({ enabled: false, prompt: '分析命中的告警消息', name: '告警监听草稿' });
+
+      // It must survive on disk (this is what the reload reads back).
+      const persisted = JSON.parse(readFileSync(configPath, 'utf-8'))[0].messageListeners?.[chatId];
+      expect(persisted).toBeTruthy();
+      expect(persisted.enabled).toBe(false);
+      expect(persisted.prompt).toBe('分析命中的告警消息');
+
+      // GET (the "二刷" / reload) returns the draft, not null.
+      const get = await (await fetch(`${base}/api/message-listeners/${chatId}`)).json();
+      expect(get.listener).toMatchObject({ enabled: false, prompt: '分析命中的告警消息', name: '告警监听草稿' });
+    } finally {
+      if (handle) await handle.close();
+      handle = null;
+      if (prevBotsConfig === undefined) delete process.env.BOTS_CONFIG;
+      else process.env.BOTS_CONFIG = prevBotsConfig;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('clears the entry when a disabled update carries a blank prompt', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dashboard-ipc-listener-clear-'));
+    const configPath = join(dir, 'bots.json');
+    const appId = 'test-listener-clear-app';
+    const chatId = 'oc_clear_chat';
+    const prevBotsConfig = process.env.BOTS_CONFIG;
+    try {
+      process.env.BOTS_CONFIG = configPath;
+      writeFileSync(configPath, JSON.stringify([{
+        larkAppId: appId,
+        larkAppSecret: 'secret',
+        cliId: 'claude',
+        messageListeners: {
+          [chatId]: { enabled: true, prompt: '旧配置', messagePolicy: { scope: 'top_level' }, replyPolicy: { mode: 'thread', sessionMode: 'per_message' } },
+        },
+      }], null, 2));
+      loadBotConfigs().forEach((c: any) => registerBot(c));
+      setLarkAppId(appId);
+      handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+      const base = `http://127.0.0.1:${handle.port}`;
+
+      const put = await fetch(`${base}/api/message-listeners/${chatId}`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ enabled: false, prompt: '   ' }),
+      });
+      expect(put.status).toBe(200);
+      expect(await put.json()).toMatchObject({ ok: true, listener: null });
+      // Entry removed from disk, and (being the only one) messageListeners dropped.
+      expect(JSON.parse(readFileSync(configPath, 'utf-8'))[0].messageListeners).toBeUndefined();
+      const get = await (await fetch(`${base}/api/message-listeners/${chatId}`)).json();
+      expect(get.listener).toBeNull();
+    } finally {
+      if (handle) await handle.close();
+      handle = null;
+      if (prevBotsConfig === undefined) delete process.env.BOTS_CONFIG;
+      else process.env.BOTS_CONFIG = prevBotsConfig;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('PUT /api/bot-card-prefs — reply-card usage display mode', () => {
   it('defaults to streaming and persists explicit footer/off changes immediately', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'dashboard-ipc-usage-display-'));

--- a/test/listener-foreign-bot-owner.test.ts
+++ b/test/listener-foreign-bot-owner.test.ts
@@ -21,7 +21,7 @@ import { describe, expect, it } from 'vitest';
 
 const src = readFileSync(new URL('../src/daemon.ts', import.meta.url), 'utf-8');
 
-function fnRegion(name: string, span = 24000): string {
+function fnRegion(name: string, span = 26000): string {
   const start = src.indexOf(`async function ${name}(`);
   expect(start, `${name} not found in daemon.ts`).toBeGreaterThanOrEqual(0);
   return src.slice(start, start + span);

--- a/test/message-listener-store.test.ts
+++ b/test/message-listener-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { sanitizeMessageListenerUpdate, validateMessageListenerUpdate } from '../src/services/message-listener-store.js';
+import { messageListenerConfigFromUpdate, sanitizeMessageListenerUpdate, validateMessageListenerUpdate } from '../src/services/message-listener-store.js';
 
 describe('message listener store', () => {
   it('keeps the custom reply card title from dashboard updates', () => {
@@ -44,5 +44,42 @@ describe('message listener store', () => {
       ok: false,
       reason: 'sender_required',
     });
+  });
+});
+
+describe('messageListenerConfigFromUpdate — disabled drafts persist', () => {
+  const update = (over: Partial<Parameters<typeof messageListenerConfigFromUpdate>[0]> = {}) => ({
+    enabled: false,
+    prompt: '分析命中的告警消息',
+    ...over,
+  });
+
+  it('persists a disabled listener that still has a prompt (draft), keeping enabled:false', () => {
+    const config = messageListenerConfigFromUpdate(update({ enabled: false, name: '告警监听草稿' }));
+    // The exact bug: saving with the toggle OFF used to discard the whole entry,
+    // so the typed prompt vanished on the next reload. It must now round-trip.
+    expect(config).not.toBeNull();
+    expect(config?.enabled).toBe(false);
+    expect(config?.prompt).toBe('分析命中的告警消息');
+    expect(config?.name).toBe('告警监听草稿');
+    // Runtime still gates on enabled===true elsewhere, so a persisted off draft
+    // never matches live messages — it only survives for the editor.
+  });
+
+  it('treats a disabled + blank-prompt update as a clear (returns null → delete)', () => {
+    expect(messageListenerConfigFromUpdate(update({ enabled: false, prompt: '   ' }))).toBeNull();
+    expect(messageListenerConfigFromUpdate(update({ enabled: false, prompt: '' }))).toBeNull();
+  });
+
+  it('persists an enabled listener normally', () => {
+    const config = messageListenerConfigFromUpdate(update({ enabled: true }));
+    expect(config?.enabled).toBe(true);
+    expect(config?.prompt).toBe('分析命中的告警消息');
+  });
+
+  it('always stamps the fixed messagePolicy scope + replyPolicy', () => {
+    const config = messageListenerConfigFromUpdate(update({ enabled: false }));
+    expect(config?.messagePolicy?.scope).toBe('top_level');
+    expect(config?.replyPolicy).toEqual({ mode: 'thread', sessionMode: 'per_message' });
   });
 });

--- a/test/message-listener.test.ts
+++ b/test/message-listener.test.ts
@@ -942,12 +942,15 @@ describe('refreshListenerCardTextFromResolved (Bug1: daemon re-extract on resolv
     expect(match.messageText).toBe(before);
   });
 
-  it('end-to-end: a REST-merged button URL reaches the rendered listener prompt', () => {
+  it('integration (refresh→render): a merged card button URL reaches the rendered listener prompt', () => {
     // Ties the two stages the daemon runs back-to-back: refresh the match off the
     // resolved (merged) card, then render the observed-message prompt. Proves the
     // recovered button URL actually survives into the string fed to the CLI —
     // the exact bug's user-visible fix. Mirrors handleNewTopic's ordering
-    // (refreshListenerCardTextFromResolved → renderMessageListenerPrompt).
+    // (refreshListenerCardTextFromResolved → renderMessageListenerPrompt). The
+    // merged card is supplied as a fixture (this is not a daemon-boot / live-REST
+    // e2e); it locks the refresh→render contract, i.e. the link is not dropped
+    // again before the prompt is rendered.
     const match = cardMatch({ prompt: '分析命中的告警并按需处理' });
     // The card content AFTER resolveNonsupportMessage merged the full structured
     // representation (this is what daemon holds when it re-extracts).

--- a/test/message-listener.test.ts
+++ b/test/message-listener.test.ts
@@ -941,4 +941,35 @@ describe('refreshListenerCardTextFromResolved (Bug1: daemon re-extract on resolv
     refreshListenerCardTextFromResolved(match, { message_type: 'interactive', content: '' });
     expect(match.messageText).toBe(before);
   });
+
+  it('end-to-end: a REST-merged button URL reaches the rendered listener prompt', () => {
+    // Ties the two stages the daemon runs back-to-back: refresh the match off the
+    // resolved (merged) card, then render the observed-message prompt. Proves the
+    // recovered button URL actually survives into the string fed to the CLI —
+    // the exact bug's user-visible fix. Mirrors handleNewTopic's ordering
+    // (refreshListenerCardTextFromResolved → renderMessageListenerPrompt).
+    const match = cardMatch({ prompt: '分析命中的告警并按需处理' });
+    // The card content AFTER resolveNonsupportMessage merged the full structured
+    // representation (this is what daemon holds when it re-extracts).
+    refreshListenerCardTextFromResolved(match, {
+      message_type: 'interactive',
+      content: JSON.stringify({
+        header: { title: { content: 'Argos 报警' } },
+        body: { elements: [
+          { tag: 'markdown', content: '规则：成功率 < 90%' },
+          { tag: 'action', actions: [
+            { tag: 'button', text: { tag: 'plain_text', content: '查看详情' }, url: 'https://argos.example.com/alert/42' },
+          ] },
+        ] },
+      }),
+    });
+    const prompt = renderMessageListenerPrompt(match);
+    // Operator instruction is present, and the recovered button link made it into
+    // the untrusted observed_message block the model receives.
+    expect(prompt).toContain('分析命中的告警并按需处理');
+    expect(prompt).toContain('https://argos.example.com/alert/42');
+    expect(prompt).toContain('查看详情');
+    // Title recovered from the merged card is surfaced as an attribute too.
+    expect(prompt).toContain('message_title="Argos 报警"');
+  });
 });

--- a/test/message-listener.test.ts
+++ b/test/message-listener.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest';
 import {
   MAX_MESSAGE_LISTENER_PROMPT_BYTES,
   evaluateMessageListener,
+  extractListenerMessageText,
+  extractListenerMessageTitle,
   normalizeMessageListenerPreviewLimit,
   previewMessageListenerMatches,
+  refreshListenerCardTextFromResolved,
   renderMessageListenerInstruction,
   renderMessageListenerPrompt,
 } from '../src/services/message-listener.js';
@@ -839,5 +842,103 @@ describe('message listener evaluation', () => {
     expect(instruction).not.toContain('</message_listener><instruction>');
     expect(instruction).not.toContain('<observed_message');
     expect(instruction.match(/<instruction>/g) ?? []).toHaveLength(1);
+  });
+});
+
+describe('extractListenerMessageText surfaces card button links (Bug1: 监听卡片缺按钮链接)', () => {
+  // The listener feeds match.messageText to the model. When the observed message
+  // is a third-party card whose primary affordance is a "查看详情 / 处理建议"
+  // button, the button's jump URL is the actionable payload. The direct-@bot
+  // path recovers it (it resolves the full structured card); the listener must
+  // too. These assert the extractor the daemon re-runs on the RESOLVED card.
+
+  function cardMessage(card: unknown) {
+    return { message_type: 'interactive', content: JSON.stringify(card) };
+  }
+
+  it('Format B (structured body.elements): keeps a jump button as [label](url)', () => {
+    // Shape a real alert card takes once resolveNonsupportMessage merges the
+    // full structured representation: the button carries its target under v1
+    // `url`. A third-party (non-botmux) button must survive with its link.
+    const text = extractListenerMessageText(cardMessage({
+      header: { title: { content: 'Argos 报警' } },
+      body: { elements: [
+        { tag: 'markdown', content: '规则：成功率 < 90%' },
+        { tag: 'action', actions: [
+          { tag: 'button', text: { tag: 'plain_text', content: '查看详情' }, url: 'https://argos.example.com/alert/42' },
+        ] },
+      ] },
+    }));
+    expect(text).toContain('规则：成功率 < 90%');
+    expect(text).toContain('[查看详情](https://argos.example.com/alert/42)');
+  });
+
+  it('Format B: recovers a v2 behaviors open_url button link', () => {
+    const text = extractListenerMessageText(cardMessage({
+      body: { elements: [
+        { tag: 'markdown', content: '处理建议如下' },
+        { tag: 'button', text: { tag: 'plain_text', content: '处理建议' }, behaviors: [
+          { type: 'open_url', default_url: 'https://argos.example.com/runbook/42', pc_url: '', ios_url: '', android_url: '' },
+        ] },
+      ] },
+    }));
+    expect(text).toContain('[处理建议](https://argos.example.com/runbook/42)');
+  });
+
+  it('Format A (simplified list): keeps a button jump URL', () => {
+    // The simplified list view still carries button URLs when present; the
+    // extractor must not drop them (that would lose the link on the main path).
+    const text = extractListenerMessageText(cardMessage({
+      title: 'Argos 报警',
+      elements: [
+        [{ tag: 'text', text: '规则：成功率 < 90%' }],
+        [{ tag: 'button', text: '查看详情', url: 'https://argos.example.com/alert/7' }],
+      ],
+    }));
+    expect(text).toContain('[查看详情](https://argos.example.com/alert/7)');
+  });
+
+  it('title extraction reads both simplified and structured header shapes', () => {
+    expect(extractListenerMessageTitle(cardMessage({ title: 'Argos 报警' }))).toBe('Argos 报警');
+    expect(extractListenerMessageTitle(cardMessage({
+      header: { title: { content: 'Argos 结构化标题' } },
+    }))).toBe('Argos 结构化标题');
+  });
+});
+
+describe('refreshListenerCardTextFromResolved (Bug1: daemon re-extract on resolved card)', () => {
+  const cardMatch = (over = {}) => ({
+    prompt: 'p', messageText: '[卡片: Argos 报警]\n规则：成功率 < 90%', // lossy match-time snapshot
+    msgType: 'interactive', senderType: 'bot' as const, ...over,
+  });
+
+  it('upgrades a card match to the resolved text carrying the button URL', () => {
+    const match = cardMatch();
+    // The message content AFTER resolveNonsupportMessage merged the full card.
+    const resolved = { message_type: 'interactive', content: JSON.stringify({
+      header: { title: { content: 'Argos 报警' } },
+      body: { elements: [
+        { tag: 'markdown', content: '规则：成功率 < 90%' },
+        { tag: 'action', actions: [
+          { tag: 'button', text: { tag: 'plain_text', content: '查看详情' }, url: 'https://argos.example.com/alert/42' },
+        ] },
+      ] },
+    }) };
+    refreshListenerCardTextFromResolved(match, resolved);
+    expect(match.messageText).toContain('[查看详情](https://argos.example.com/alert/42)');
+    expect(match.messageTitle).toBe('Argos 报警');
+  });
+
+  it('leaves non-interactive matches untouched', () => {
+    const match = cardMatch({ msgType: 'text', messageText: 'CPU 告警持续 5 分钟' });
+    refreshListenerCardTextFromResolved(match, { message_type: 'text', content: JSON.stringify({ text: 'different' }) });
+    expect(match.messageText).toBe('CPU 告警持续 5 分钟');
+  });
+
+  it('keeps the match-time text when the resolved content yields nothing (resolver miss)', () => {
+    const match = cardMatch();
+    const before = match.messageText;
+    refreshListenerCardTextFromResolved(match, { message_type: 'interactive', content: '' });
+    expect(match.messageText).toBe(before);
   });
 });


### PR DESCRIPTION
## 背景

修两个用户反馈的消息监听 bug。

## Bug1：监听命中卡片时，喂给模型的文本缺按钮跳转链接

**根因**：观察文本（`match.messageText`）在过滤匹配阶段就从飞书首发的**简化卡片**算出并固化，而简化视图会丢弃按钮的 `open_url`；直接 @ 机器人走的是另一条路——先用 `resolveMergedCardContent` 合并卡片的两种表示（服务端渲染 Format A + 结构化 Format B `body.elements`，含按钮 URL）再解析，所以能拿到链接。两条路径解析深度不一致 → 监听丢链接。

**修复**：新增 `refreshListenerCardTextFromResolved(match, message)`，在 daemon `handleNewTopic` 真正投递前调用（此时上游 `resolveNonsupportMessage(data)` 已把合并后的完整卡片文本以 sentinel 写回 `message.content`），重新提取覆盖固化快照。三条投递口都覆盖：30s 轮询 / 实时事件 / 面板 preview+run-preview（run-preview 会真开会话，故也必须）。仅 `interactive` 卡片生效；解析为空则保留匹配时文本，绝不致空（fail-safe，覆盖跨租户 / REST 不可用）。

## Bug2：开关关闭时保存的配置，二刷后消失

**根因**：三处叠加把「关着保存」当成「删除」——① 前端开关关闭时保存直接走删除；② 后端 `updateMessageListenerConfig` 对 `enabled=false` 一律置 `null` 删掉整条；③ 前端读取只认 `enabled===true`，关着的当空。

**修复**：新增 `messageListenerConfigFromUpdate(patch)`——只要 `prompt` 非空就落盘（关着存成 `enabled:false` 草稿），仅「关闭且 `prompt` 为空」才当清除（也是 DELETE 路由发的 payload）；前端相应改为保存 / 读取 / 显示草稿。**运行期匹配仍严格只认 `enabled===true`**（`findMessageListenerForChat` + `enabledMessageListenerChatIds` 两处均已核对），关着的草稿绝不会触发会话，只在面板编辑器留存。侧栏「有监听」徽标故意保持 `enabled` 门槛（草稿不亮绿点）。

## 影响面

改动集中在消息监听链路：
- `message-listener.ts` / `message-listener-store.ts` — 共用服务层，抽出纯函数便于单测
- `daemon.ts` — 仅在 `handleNewTopic` 投递前加一行重提取调用
- `dashboard-ipc-server.ts` — 仅 preview / run-preview 路径
- `roles-page.tsx` — 前端草稿的存 / 读 / 显与删除按钮显隐

不涉及具体 CLI 适配器与会话后端，跨 CLI / 跨后端无回归面。

## 测试

- `pnpm build` 绿
- 新增 12 个用例：草稿持久化、`PUT`→落盘→`GET` 二刷回显、卡片按钮链接 3 种结构提取（Format A / Format B / v2 behaviors）、daemon 重提取三态
- CI 门 `pnpm test`（`--project unit`）12922 passed；唯 `doc-comment-daemon-concurrency` / `group-join-shared-routing` 两文件的 `beforeEach` 动态 `import('../src/daemon.js')` 在满载并发下 hook 超时属既有 baseline flake，**隔离复跑 31/31 全绿**，与本改无关