### PR TITLE
fix(relay): 修接力确认因 worker 退出卡死而假超时 + 失败改可见消息

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -286,7 +286,31 @@ const WORKER_SIGKILL_BACKSTOP_MS = 7_000;
 const CLOSE_FENCE_WARN_MS = 8_000;
 // Peer relay waits 5s for the whole transfer request. Tmux observer detach has
 // its own 3s command timeout, so this fence leaves headroom for routing/fork.
+// This tight default is load-bearing ONLY for the cross-daemon `/relay --create`
+// peer path (dashboard-ipc-server migrate-to-chat), whose transfer must finish
+// inside the leader's 5s HTTP abort — otherwise the peer commits the move after
+// the leader already reported failure (split-brain; see the busy-refuse comment
+// in transferSession). In-process callers have no such ceiling.
 const TRANSFER_DETACH_FENCE_MS = 3_500;
+// In-process picker relay (card-handler relay_confirm) runs with no HTTP abort
+// above it — its card ACK already degrades to a background "处理中" toast at 2.5s
+// and the real result is delivered as a visible message. So it can afford a
+// larger fence as a last-resort safety net. The COMMON hang, however, is not a
+// slow teardown — it's the worker ACKing the detach in ~9ms but then wedging in
+// node-pty's native process-exit teardown (a still-open web-terminal client PTY
+// blocks `process.exit()` in the reader-thread join; the JS event loop is
+// already stopped so the worker cannot self-rescue). We handle that below by
+// force-killing the worker once its ACK proves the observer already detached, so
+// this fence only bounds the pathological "no ACK at all" case.
+export const TRANSFER_DETACH_FENCE_PICKER_MS = 8_000;
+// Grace after the worker's transfer_detached ACK before the daemon force-kills
+// it. The ACK proves killCli({preserveSandbox:true}) already ran — backend
+// detached, CLI/tmux/sandbox left intact for the replacement — so the ACKed
+// worker process is disposable. Give it a brief window to exit cleanly on its
+// own; if node-pty's exit teardown wedges it (the real bug), SIGKILL it rather
+// than stranding the transfer behind the full fence. Short because a healthy
+// worker exits within a few ms of the ACK.
+const TRANSFER_DETACH_POST_ACK_KILL_MS = 300;
 const TRANSFER_FORCE_EXIT_MS = 500;
 const WORKER_REDACTED_ENV_KEYS = ['GITHUB_TOKEN', 'GH_TOKEN'] as const;
 
@@ -1920,14 +1944,32 @@ export async function detachWorkerForTransfer(
   const maybeFinish = (): void => {
     if (acked && exited) finish(true);
   };
+  // Once the worker ACKs, its observer is already detached (killCli ran); the
+  // process itself is disposable. A healthy worker exits within a few ms, but a
+  // web-terminal client PTY makes node-pty's process.exit() teardown wedge the
+  // process for the whole fence (JS loop already stopped → it can't self-kill).
+  // So on ACK, arm a short grace timer, then SIGKILL — turning an 8s stall into
+  // a ~300ms one. Cleared if the worker exits on its own first.
+  let postAckKillTimer: ReturnType<typeof setTimeout> | undefined;
+  const armPostAckKill = (): void => {
+    if (postAckKillTimer || exited) return;
+    postAckKillTimer = setTimeout(() => {
+      if (exited) return;
+      logger.info(`[${tag(ds)}] Detach ACK received but worker still alive after ${TRANSFER_DETACH_POST_ACK_KILL_MS}ms (node-pty exit wedge); SIGKILL`);
+      try { w.kill('SIGKILL'); } catch { /* already gone */ }
+    }, TRANSFER_DETACH_POST_ACK_KILL_MS);
+    postAckKillTimer.unref?.();
+  };
   const onMessage = (raw: unknown): void => {
     const msg = raw as Partial<WorkerToDaemon>;
     if (msg.type !== 'transfer_detached' || msg.requestId !== requestId) return;
     acked = true;
+    armPostAckKill();
     maybeFinish();
   };
   const onExit = (): void => {
     exited = true;
+    if (postAckKillTimer) { clearTimeout(postAckKillTimer); postAckKillTimer = undefined; }
     maybeFinish();
   };
   w.on('message', onMessage);
@@ -1940,6 +1982,7 @@ export async function detachWorkerForTransfer(
   void sendWorkerIpc(w, { type: 'detach_for_transfer', requestId })
     .catch(() => finish(false));
   const completed = await completion;
+  if (postAckKillTimer) { clearTimeout(postAckKillTimer); postAckKillTimer = undefined; }
 
   // A timed-out detach request may still be queued in Node's IPC channel and
   // arrive later. Never hand new input back to that uncertain worker. SIGKILL
@@ -3376,6 +3419,14 @@ export async function transferSession(
     detachWorkerImpl?: (
       ds: DaemonSession,
     ) => boolean | void | Promise<boolean | void>;
+    /** Detach-fence budget (ms) for the observer teardown handshake. Defaults
+     *  to the tight TRANSFER_DETACH_FENCE_MS, which the cross-daemon peer path
+     *  needs to stay inside the leader's 5s HTTP abort. In-process callers with
+     *  no HTTP ceiling (the picker relay_confirm) pass a larger value
+     *  (TRANSFER_DETACH_FENCE_PICKER_MS) so a slightly-slow-but-clean teardown
+     *  is not misclassified as a failure. Ignored when detachWorkerImpl is set
+     *  (test doubles don't observe a real fence). */
+    detachTimeoutMs?: number;
   },
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   // Depth defense — unreachable per TS narrowing above, but guards against
@@ -3489,7 +3540,13 @@ export async function transferSession(
   }
 
   const fkw = opts?.forkWorkerImpl ?? forkWorker;
-  const detach = opts?.detachWorkerImpl ?? detachWorkerForTransfer;
+  // The default detach observes a real fence and takes a per-call timeout; a
+  // test double only takes `ds`. Bind the requested fence onto the real impl
+  // only — a test double never observes a fence, so the budget is irrelevant
+  // (and its narrower signature wouldn't accept it).
+  const detachTimeoutMs = opts?.detachTimeoutMs ?? TRANSFER_DETACH_FENCE_MS;
+  const detach = opts?.detachWorkerImpl
+    ?? ((d: DaemonSession) => detachWorkerForTransfer(d, { timeoutMs: detachTimeoutMs }));
   const transferGate = beginTransferInputGate(ds);
   if (!transferGate) return { ok: false, error: 'worker_busy' };
   let uncertainRetiringWorker: ChildProcess | undefined;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -226,6 +226,15 @@ export const messages: Record<string, string> = {
   'card.relay.toast_not_started_yet': '⚠️ The session has not picked a repo yet, so the CLI never started. Pick a repo in the source chat first.',
   'card.relay.toast_same_chat': 'That session is already at the target location (same topic/chat) — nothing to relay.',
   'card.relay.toast_failed': 'Relay failed: {error}',
+  // Copy used when a relay-confirm failure is delivered as a visible message
+  // (not a toast): confirm processing waits on the detach fence (up to 8s),
+  // which necessarily exceeds the card ACK window (2.5s), after which a toast
+  // can no longer be surfaced and is dropped — only a message reaches the user.
+  // transferSession never commits the routing rewrite on any !ok path, so the
+  // session always stays put; the copy therefore stresses "not lost, retry".
+  'card.relay.fail_timeout': '⚠️ Relay timed out before completing. The session is still where it was — nothing was lost; its Lark history and AI memory remain in the source. Wait a moment, then click "Confirm relay" again to retry.',
+  'card.relay.fail_worker_busy': '⚠️ Relay did not complete: the session is mid-turn. It is still where it was and was not lost — wait for it to go idle, then click "Confirm relay" again.',
+  'card.relay.fail_generic': '⚠️ Relay did not complete ({error}). The session is still where it was — nothing was lost; its Lark history and AI memory remain in the source. Please click "Confirm relay" again to retry.',
   'card.relay.toast_target_has_session': 'This chat already has an active session for the bot. Please /close it first, then relay.',
   'cmd.relay.target_has_session_msg': '⚠️ This bot already has an active session "{title}" in this chat. Please /close it first, then relay a new one in.',
   'card.relay.toast_success': '✅ Relayed into this chat',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -229,6 +229,13 @@ export const messages: Record<string, string> = {
   'card.relay.toast_not_started_yet': '⚠️ 会话还没选仓库、CLI 没起来，无法接力。请先回原会话把仓库选了。',
   'card.relay.toast_same_chat': '该会话已在目标位置（同一话题/群），无需接力。',
   'card.relay.toast_failed': '接力失败：{error}',
+  // 接力确认失败后走可见消息（而非 toast）时用的文案：确认处理要等 detach 死线
+  // （最长 8s），必然超过卡片 ACK 窗口（2.5s），此时 toast 已无法补发、会被丢弃，
+  // 只能靠消息把失败告诉用户。transferSession 在任何 !ok 路径都不提交路由改写，
+  // 会话必然仍在原处，因此文案统一强调「未丢失、可重试」。
+  'card.relay.fail_timeout': '⚠️ 接力超时未完成。会话仍在原处、未丢失——飞书消息历史和 AI 记忆都还在源会话里。请稍等片刻，再点一次「确认接力」重试。',
+  'card.relay.fail_worker_busy': '⚠️ 接力未完成：会话正在处理中（mid-turn）。会话仍在原处、未丢失，请等它空闲后再点一次「确认接力」重试。',
+  'card.relay.fail_generic': '⚠️ 接力未完成（{error}）。会话仍在原处、未丢失——飞书消息历史和 AI 记忆都还在源会话里。请稍后再点一次「确认接力」重试。',
   'card.relay.toast_target_has_session': '本群已有该机器人的活跃会话，请先 /close 它再接力',
   'cmd.relay.target_has_session_msg': '⚠️ 本群已有该机器人的活跃会话「{title}」。请先用 /close 关掉那个会话，再接力新的过来。',
   'card.relay.toast_success': '✅ 已接力到本群',

--- a/src/im/lark/card-handler.ts
+++ b/src/im/lark/card-handler.ts
@@ -1593,34 +1593,52 @@ export async function handleCardAction(data: CardActionData, deps: CardHandlerDe
     } catch (err: any) {
       return { toast: { type: 'error', content: t('card.relay.toast_failed', { error: err?.message ?? 'send_m1_failed' }, loc) } };
     }
-    const { transferSession } = await import('../../core/worker-pool.js');
+    const { transferSession, TRANSFER_DETACH_FENCE_PICKER_MS } = await import('../../core/worker-pool.js');
     // chat-scope → anchor on the M1 id (audit-only); thread-scope → anchor on
     // the 话题 root (targetAnchor) so future replies in the 话题 route here.
+    // In-process picker relay has no HTTP abort above it (unlike the cross-daemon
+    // /relay --create peer path), so give the observer-detach fence generous
+    // headroom — a clean-but-slightly-slow worker teardown (~3.5s observed) must
+    // not be misclassified as worker_detach_timeout.
     const r = targetScope === 'thread'
-      ? await transferSession(sourceDs.session.sessionId, targetChatId, targetAnchor, targetChatType, 'thread')
-      : await transferSession(sourceDs.session.sessionId, targetChatId, m1MessageId, targetChatType, 'chat');
+      ? await transferSession(sourceDs.session.sessionId, targetChatId, targetAnchor, targetChatType, 'thread', { detachTimeoutMs: TRANSFER_DETACH_FENCE_PICKER_MS })
+      : await transferSession(sourceDs.session.sessionId, targetChatId, m1MessageId, targetChatType, 'chat', { detachTimeoutMs: TRANSFER_DETACH_FENCE_PICKER_MS });
     if (!r.ok) {
       // Best-effort: orphan M1 cleanup so a failed transfer doesn't leave a
       // misleading "已接力" message in the target chat (王皓's "明明失败了
       // 却返回成功了" complaint). Race-condition fallback only — the
       // pre-flight checks above should catch the common cases first.
       deleteMessage(larkAppId, m1MessageId).catch(() => { /* leave it */ });
-      if (r.error === 'target_chat_has_session') {
-        // Lost the race vs the pre-flight check — still surface as a message.
-        const errText = t('cmd.relay.target_has_session_msg', { title: '' }, loc);
-        sendMessage(larkAppId, targetChatId, errText, 'text').catch(() => undefined);
-        return;
+      // Deliver the failure as a VISIBLE message, never a toast. The confirm
+      // handler awaits the detach fence (up to TRANSFER_DETACH_FENCE_PICKER_MS
+      // = 8s), which always exceeds the 2.5s card-ACK window — once the generic
+      // "后台处理中" ACK has gone out, a toast can no longer be surfaced and is
+      // silently dropped (only a `not shown to user` log line remained; this is
+      // exactly the failure 申晗 hit — a false-timeout relay whose error the
+      // user never saw). transferSession never commits the routing rewrite on
+      // ANY !ok path, so the source session is always still intact; the copy
+      // reassures the user it was not lost and points at a concrete retry (the
+      // picker card + its 确认 button survive — we only delete them on success
+      // below). Land the notice where the user is looking, mirroring the M1
+      // delivery target: thread-scope → reply_in_thread into the 话题;
+      // chat-scope → a top-level message in the target chat.
+      const failText =
+        r.error === 'worker_detach_timeout' ? t('card.relay.fail_timeout', undefined, loc)
+        : r.error === 'worker_busy' ? t('card.relay.fail_worker_busy', undefined, loc)
+        : r.error === 'target_chat_has_session' ? t('cmd.relay.target_has_session_msg', { title: '' }, loc)
+        : r.error === 'adopt_not_relayable' ? t('card.relay.toast_adopt_not_relayable', undefined, loc)
+        : r.error === 'not_started_yet' ? t('card.relay.toast_not_started_yet', undefined, loc)
+        : t('card.relay.fail_generic', { error: r.error }, loc);
+      try {
+        if (targetScope === 'thread') {
+          await replyMessage(larkAppId, targetAnchor, failText, 'text', /*replyInThread*/ true);
+        } else {
+          await sendMessage(larkAppId, targetChatId, failText, 'text');
+        }
+      } catch (e) {
+        logger.warn(`[card-action] relay failure notice send failed (${e instanceof Error ? e.message : e}); relay error was: ${r.error}`);
       }
-      if (r.error === 'adopt_not_relayable') {
-        return { toast: { type: 'error', content: t('card.relay.toast_adopt_not_relayable', undefined, loc) } };
-      }
-      if (r.error === 'worker_busy') {
-        return { toast: { type: 'error', content: t('card.relay.toast_worker_busy', undefined, loc) } };
-      }
-      if (r.error === 'not_started_yet') {
-        return { toast: { type: 'error', content: t('card.relay.toast_not_started_yet', undefined, loc) } };
-      }
-      return { toast: { type: 'error', content: t('card.relay.toast_failed', { error: r.error }, loc) } };
+      return;
     }
     // Best-effort: remove the picker card now that the selection resolved.
     // Ephemeral (private) pickers need the ephemeral-delete endpoint —

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12905,6 +12905,13 @@ process.on('message', async (raw: unknown) => {
       killCli({ preserveSandbox: true });
       cleanup();
       await flushTransferDetachAck(msg.requestId);
+      // NOTE: process.exit(0) can wedge in node-pty's native teardown when a
+      // web-terminal client PTY was attached (the reader-thread join blocks and
+      // the JS event loop is already stopped, so this process cannot self-kill
+      // via a timer). killCli() above already detached the observer and the ACK
+      // just flushed, so the daemon force-kills this now-disposable process
+      // shortly after the ACK (see detachWorkerForTransfer's post-ACK kill).
+      // We still request a clean exit; the daemon SIGKILL is the hard backstop.
       process.exit(0);
     }
 

--- a/test/card-handler-relay-pickup.test.ts
+++ b/test/card-handler-relay-pickup.test.ts
@@ -49,6 +49,10 @@ vi.mock('../src/core/worker-pool.js', async (importOriginal) => {
 
 import { handleCardAction } from '../src/im/lark/card-handler.js';
 import { sessionKey } from '../src/core/types.js';
+// Real constant (the worker-pool mock spreads ...actual, so this is the live
+// value). The picker relay path passes it as transferSession's detach-fence
+// budget — generous because the in-process picker has no HTTP abort above it.
+import { TRANSFER_DETACH_FENCE_PICKER_MS } from '../src/core/worker-pool.js';
 import type { DaemonSession } from '../src/core/types.js';
 import type { Session } from '../src/types.js';
 
@@ -217,7 +221,7 @@ describe('relay_confirm button click', () => {
     expect(m1Payload).toContain('Friendly Source Chat Name');
     expect(m1Payload).not.toContain('oc_source');
 
-    expect(transferSessionMock).toHaveBeenCalledWith('sess-source-1', 'oc_target', 'om_M1', 'group', 'chat');
+    expect(transferSessionMock).toHaveBeenCalledWith('sess-source-1', 'oc_target', 'om_M1', 'group', 'chat', { detachTimeoutMs: TRANSFER_DETACH_FENCE_PICKER_MS });
     expect(deleteMessageMock).toHaveBeenCalledWith(LARK_APP_ID, 'om_picker_card');
     expect(r?.toast?.type).toBe('success');
   });
@@ -238,7 +242,7 @@ describe('relay_confirm button click', () => {
     expect(replyMessageMock).toHaveBeenCalledWith(LARK_APP_ID, 'om_topic_root', expect.any(String), 'text', true);
     expect(sendMessageMock).not.toHaveBeenCalled();
     // Session anchors on the 话题 root (NOT the M1 id), scope 'thread'.
-    expect(transferSessionMock).toHaveBeenCalledWith('sess-source-1', 'oc_target', 'om_topic_root', 'group', 'thread');
+    expect(transferSessionMock).toHaveBeenCalledWith('sess-source-1', 'oc_target', 'om_topic_root', 'group', 'thread', { detachTimeoutMs: TRANSFER_DETACH_FENCE_PICKER_MS });
     expect(r?.toast?.type).toBe('success');
   });
 
@@ -259,7 +263,7 @@ describe('relay_confirm button click', () => {
     expect(sendMessageMock.mock.calls[0][1]).toBe('oc_dm');
     expect(sendMessageMock.mock.calls[0][2]).toContain('直接发消息继续对话');
     // chatType flips to p2p; flat DM anchors chat-scope on the M1 id (audit-only).
-    expect(transferSessionMock).toHaveBeenCalledWith('sess-source-1', 'oc_dm', 'om_M1', 'p2p', 'chat');
+    expect(transferSessionMock).toHaveBeenCalledWith('sess-source-1', 'oc_dm', 'om_M1', 'p2p', 'chat', { detachTimeoutMs: TRANSFER_DETACH_FENCE_PICKER_MS });
     expect(r?.toast?.type).toBe('success');
   });
 
@@ -276,7 +280,7 @@ describe('relay_confirm button click', () => {
 
     expect(replyMessageMock).toHaveBeenCalledWith(LARK_APP_ID, 'om_dm_topic_root', expect.stringContaining('直接发消息继续对话'), 'text', true);
     expect(sendMessageMock).not.toHaveBeenCalled();
-    expect(transferSessionMock).toHaveBeenCalledWith('sess-source-1', 'oc_dm', 'om_dm_topic_root', 'p2p', 'thread');
+    expect(transferSessionMock).toHaveBeenCalledWith('sess-source-1', 'oc_dm', 'om_dm_topic_root', 'p2p', 'thread', { detachTimeoutMs: TRANSFER_DETACH_FENCE_PICKER_MS });
     expect(r?.toast?.type).toBe('success');
   });
 
@@ -305,7 +309,7 @@ describe('relay_confirm button click', () => {
       LARK_APP_ID,
     );
 
-    expect(transferSessionMock).toHaveBeenCalledWith('sess-source-1', 'oc_target', 'om_topic_root', 'group', 'thread');
+    expect(transferSessionMock).toHaveBeenCalledWith('sess-source-1', 'oc_target', 'om_topic_root', 'group', 'thread', { detachTimeoutMs: TRANSFER_DETACH_FENCE_PICKER_MS });
   });
 
   it('falls back to chatId in the M1 body when getChatName returns null', async () => {
@@ -320,7 +324,7 @@ describe('relay_confirm button click', () => {
     expect(m1Payload).toContain('oc_source');
   });
 
-  it('returns a friendly toast when transferSession reports adopt_not_relayable', async () => {
+  it('sends a VISIBLE message (not a toast) when transferSession reports adopt_not_relayable', async () => {
     const ds = makeDs();
     const map = new Map<string, DaemonSession>();
     map.set(sessionKey('om_source_root', LARK_APP_ID), ds);
@@ -329,9 +333,15 @@ describe('relay_confirm button click', () => {
 
     const r = await handleCardAction(actionData({ sessionId: 'sess-source-1' }), deps(map), LARK_APP_ID);
 
-    expect(r?.toast?.type).toBe('error');
-    expect(r?.toast?.content).toContain('/adopt');
-    expect(r?.toast?.content).not.toMatch(/adopt_not_relayable/);
+    // No toast — the confirm handler awaits the detach fence and always exceeds
+    // the 2.5s card-ACK window, so a toast would be dropped. Deliver a message.
+    expect(r).toBeUndefined();
+    // chat-scope target (actionData default) → sendMessage into the target chat.
+    // First call is the M1 announce; the failure notice is the last call.
+    const lastSend = sendMessageMock.mock.calls.at(-1)!;
+    expect(lastSend[1]).toBe('oc_target');
+    expect(lastSend[2]).toContain('/adopt');
+    expect(lastSend[2]).not.toMatch(/adopt_not_relayable/);
   });
 
   // Helper to construct a DaemonSession with explicit chatId / scope / worker —
@@ -461,7 +471,7 @@ describe('relay_confirm button click', () => {
     expect(deleteMessageMock).toHaveBeenCalledWith(LARK_APP_ID, 'om_M1');
   });
 
-  it('returns a friendly toast when transferSession reports worker_busy', async () => {
+  it('sends a VISIBLE message (not a toast) when transferSession reports worker_busy', async () => {
     const ds = makeDs();
     const map = new Map<string, DaemonSession>();
     map.set(sessionKey('om_source_root', LARK_APP_ID), ds);
@@ -470,13 +480,16 @@ describe('relay_confirm button click', () => {
 
     const r = await handleCardAction(actionData({ sessionId: 'sess-source-1' }), deps(map), LARK_APP_ID);
 
-    expect(r?.toast?.type).toBe('error');
-    // Specific toast string, not the raw error code via toast_failed.
-    expect(r?.toast?.content).not.toMatch(/worker_busy/);
-    expect(r?.toast?.content).toMatch(/正在处理|mid-turn|wait/i);
+    expect(r).toBeUndefined();
+    const lastSend = sendMessageMock.mock.calls.at(-1)!;
+    expect(lastSend[1]).toBe('oc_target');
+    // Human copy: not the raw error code; reassures the session is not lost.
+    expect(lastSend[2]).not.toMatch(/worker_busy/);
+    expect(lastSend[2]).toMatch(/正在处理|mid-turn/i);
+    expect(lastSend[2]).toMatch(/未丢失|not lost|still where/i);
   });
 
-  it('returns a friendly toast when transferSession reports not_started_yet', async () => {
+  it('sends a VISIBLE message (not a toast) when transferSession reports not_started_yet', async () => {
     const ds = makeDs();
     const map = new Map<string, DaemonSession>();
     map.set(sessionKey('om_source_root', LARK_APP_ID), ds);
@@ -485,8 +498,61 @@ describe('relay_confirm button click', () => {
 
     const r = await handleCardAction(actionData({ sessionId: 'sess-source-1' }), deps(map), LARK_APP_ID);
 
-    expect(r?.toast?.type).toBe('error');
-    expect(r?.toast?.content).not.toMatch(/not_started_yet/);
-    expect(r?.toast?.content).toMatch(/选仓库|pick a repo/i);
+    expect(r).toBeUndefined();
+    const lastSend = sendMessageMock.mock.calls.at(-1)!;
+    expect(lastSend[2]).not.toMatch(/not_started_yet/);
+    expect(lastSend[2]).toMatch(/选仓库|pick a repo/i);
+  });
+
+  // The exact bug 申晗 hit: transfer false-times-out (worker took ~3.5s to
+  // exit cleanly). Pre-fix this returned a toast that the ACK window dropped,
+  // leaving only a `not shown to user` log line — the user saw nothing and the
+  // follow-up spawned a fresh repo picker. Now it lands a visible message that
+  // says the session is intact and to retry.
+  it('sends a VISIBLE, reassuring message when transferSession reports worker_detach_timeout (the false-timeout bug)', async () => {
+    const ds = makeDs();
+    const map = new Map<string, DaemonSession>();
+    map.set(sessionKey('om_source_root', LARK_APP_ID), ds);
+
+    transferSessionMock.mockResolvedValueOnce({ ok: false, error: 'worker_detach_timeout' as any });
+
+    const r = await handleCardAction(actionData({ sessionId: 'sess-source-1' }), deps(map), LARK_APP_ID);
+
+    // Never a toast (it would be swallowed after the ACK window).
+    expect(r).toBeUndefined();
+    const lastSend = sendMessageMock.mock.calls.at(-1)!;
+    expect(lastSend[1]).toBe('oc_target');
+    expect(lastSend[2]).not.toMatch(/worker_detach_timeout/);
+    // "会话仍在原处、未丢失" + a concrete retry instruction.
+    expect(lastSend[2]).toMatch(/超时|timed out/i);
+    expect(lastSend[2]).toMatch(/未丢失|not lost|still where/i);
+    expect(lastSend[2]).toMatch(/重试|retry|再点/i);
+    // Orphan M1 cleaned up so no misleading "已接力" lingers.
+    expect(deleteMessageMock).toHaveBeenCalledWith(LARK_APP_ID, 'om_M1');
+  });
+
+  // Thread-scope failure lands the notice reply_in_thread into the 话题 (the
+  // invocation spot), mirroring the M1 delivery — not a top-level sendMessage.
+  it('thread-scope failure: notice goes reply_in_thread into the 话题 root', async () => {
+    const ds = makeDs();
+    const map = new Map<string, DaemonSession>();
+    map.set(sessionKey('om_source_root', LARK_APP_ID), ds);
+
+    transferSessionMock.mockResolvedValueOnce({ ok: false, error: 'worker_detach_timeout' as any });
+
+    const r = await handleCardAction(
+      actionData({ sessionId: 'sess-source-1', target_chat_id: 'oc_target', root_id: 'om_topic_root', target_scope: 'thread' }),
+      deps(map),
+      LARK_APP_ID,
+    );
+
+    expect(r).toBeUndefined();
+    // Last replyMessage call = the failure notice into the 话题 root, replyInThread=true.
+    const lastReply = replyMessageMock.mock.calls.at(-1)!;
+    expect(lastReply[0]).toBe(LARK_APP_ID);
+    expect(lastReply[1]).toBe('om_topic_root');
+    expect(lastReply[3]).toBe('text');
+    expect(lastReply[4]).toBe(true);
+    expect(lastReply[2]).toMatch(/超时|timed out/i);
   });
 });

--- a/test/transfer-session.test.ts
+++ b/test/transfer-session.test.ts
@@ -575,6 +575,58 @@ describe('transferSession', () => {
     expect(ds.session.rootMessageId).toBe('om_source_root');
   });
 
+  it('force-kills a worker that ACKs the detach but never self-exits (node-pty exit wedge), completing the transfer', async () => {
+    // The production bug: the worker runs killCli + sends transfer_detached in
+    // ~9ms, then process.exit(0) wedges in node-pty's native teardown (an open
+    // web-terminal client PTY blocks the reader-thread join; the JS loop is
+    // already stopped so the worker cannot self-kill). The daemon must not sit
+    // out the whole fence waiting for an exit that never comes on its own — once
+    // the ACK proves the observer detached, it force-kills the disposable
+    // process. Here the worker ACKs but ONLY exits when SIGKILLed by the daemon.
+    let oldWorker: any;
+    const send = vi.fn((
+      message: { type: string; requestId?: string },
+      callback?: (error: Error | null) => void,
+    ) => {
+      callback?.(null);
+      // ACK the detach on the next tick, but deliberately do NOT emit 'exit' —
+      // simulate the wedged process.exit(0). Only the daemon's SIGKILL ends it.
+      if (message.type === 'detach_for_transfer') {
+        queueMicrotask(() => oldWorker.emit('message', {
+          type: 'transfer_detached',
+          requestId: message.requestId,
+        }));
+      }
+    });
+    const kill = vi.fn((signal: NodeJS.Signals) => {
+      oldWorker.signalCode = signal;
+      oldWorker.emit('exit', null, signal);
+      return true;
+    });
+    oldWorker = Object.assign(new EventEmitter(), {
+      killed: false,
+      connected: true,
+      exitCode: null,
+      signalCode: null,
+      send,
+      kill,
+    }) as any;
+    const ds = makeDs({ worker: oldWorker, lastScreenStatus: 'idle' });
+    registry.set(sessionKey('om_source_root', 'cli_app_test'), ds);
+
+    // No manual exit emission — the daemon's post-ACK kill is the ONLY thing
+    // that can end this worker. If the fix regressed, this would hang until the
+    // full fence and return false.
+    const completed = await detachWorkerForTransfer(ds);
+
+    expect(completed).toBe(true);
+    expect(kill).toHaveBeenCalledWith('SIGKILL');
+    expect(ds.worker).toBeNull();
+    // Source routing untouched by the detach itself (transferSession rewrites it).
+    expect(ds.chatId).toBe('oc_source');
+    expect(ds.session.rootMessageId).toBe('om_source_root');
+  });
+
   it('keeps detach timeout bounded when the child IPC send callback never fires', async () => {
     const send = vi.fn(() => undefined);
     let oldWorker: any;


### PR DESCRIPTION
## 问题

飞书 `/relay` 选完会话点「确认接力」后，接力**静默失败**：会话没搬走，后续在目标群发的消息被当作全新会话、弹出仓库选择框。用户端看不到任何失败提示。

## 根因

worker 收到 `detach_for_transfer` 后，`killCli` + `cleanup` + 发 `transfer_detached` ACK **仅耗时 ~9ms** 即调用 `process.exit(0)`。但进程随后卡在 **node-pty 的原生退出清理**里：会话开过 web 终端时，node-pty 的后台读线程 join 会阻塞 `process.exit()`，而此时 JS 事件循环已停，worker 无法自救（timer 也不会再触发）。

daemon 侧 `detachWorkerForTransfer` 的完成判定要求「收到 ACK」**且**「进程退出」两者：ACK 9ms 就到了，但「退出」要等到 daemon 的 detach 死线 SIGKILL 才发生 → 判定为 `worker_detach_timeout`，`transferSession` 返回失败、路由从不提交（会话留在原处）。

叠加第二个问题：失败仅通过 toast 返回，而确认处理必然超过卡片 ACK 窗口（2.5s），toast 在 ACK 之后无法补发被丢弃 → 用户完全看不到错误，只留一行日志。

## 修复

1. **daemon 侧**（`worker-pool.ts` `detachWorkerForTransfer`）：`transfer_detached` ACK 已证明 observer 摘除完成（CLI / tmux / sandbox 完好保留给替身 worker），ACK 后这个进程即可丢弃。收到 ACK 后给 **300ms 宽限**，worker 仍未自退则由 daemon `SIGKILL` 它，把最长 8s 的干等收敛到 ~300ms。新增常量 `TRANSFER_DETACH_POST_ACK_KILL_MS=300`。worker 自己正常退出时照旧走 clean exit（宽限 timer 清掉，不会误杀）。
2. **卡片回复**（`card-handler.ts` `relay_confirm`）：所有失败改为发**可见消息**（不再依赖 toast，因为该操作必然超 ACK 窗口）。落点镜像 M1：话题群 `reply_in_thread` 进话题，普通群/单聊发顶层。文案统一说明「会话仍在原处、未丢失、请重试」（`transferSession` 任何失败路径都不提交路由，会话必留原处）。
3. **detach 死线阈值**：保留 in-process picker 的更宽死线（8s）作为「ACK 都收不到」极端情况的兜底；阈值 per-call 传入，跨 daemon `/relay --create` 峰值路径仍用 3.5s，守住对端 5s HTTP abort，避免脑裂。

## 测试

- **新增 regression**：worker 只发 ACK、故意永不自退，仅 daemon `SIGKILL` 能终结它 → 断言接力成功 + `kill('SIGKILL')` 被调用；实测 ~300ms 通过。
- `transfer-session` 62 例 + `card-handler-relay-pickup` 26 例；连同 `command-handler` / `migrate-to-chat-endpoint` / `transfer-passthrough-gate` / `fork-session` 共 **338 例全过**。
- `pnpm build` 绿；i18n zh/en 新 key parity 一致。
- **真机验证**（飞书实测）：接力全程 ~340ms 成功——`detach requested` → `Detach ACK received but worker still alive after 300ms; SIGKILL`（+308ms）→ `transferred 源群 → 目标群`（+338ms）→ worker 就绪。无 `hard-retiring` / `fence failed`，目标群不再弹仓库框，后续消息正常续上迁移过来的会话。

## 影响面

- 改动集中在 detach / transfer 路径与 `relay_confirm` 卡片回复；不影响其它 CLI / 后端的正常运行。
- daemon 侧改动对所有走 `transferSession` 的入口生效（picker `relay_confirm`、`/relay --create` leader、dashboard IPC `migrate-to-chat`）——「ACK 后快速回收」对三者都是正向收益，且 ACK 语义未变，healthy worker 的 clean-exit 路径不受影响。