### PR TITLE
fix(dashboard): keep version popover above custom scrollbar

### DIFF
--- a/src/dashboard/web/app.tsx
+++ b/src/dashboard/web/app.tsx
@@ -1,5 +1,6 @@
 // Dashboard SPA entry: React chrome + lazy route host + SSE bootstrap.
 import type React from 'react';
+import { createPortal } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import { useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
@@ -578,6 +579,8 @@ function TopbarVersionControl(props: {
   const reconnectTimerRef = useRef<number | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLElement>(null);
+  const [popoverPosition, setPopoverPosition] = useState<{ top: number; left: number } | null>(null);
 
   const clearReconnectTimer = () => {
     if (reconnectTimerRef.current === null) return;
@@ -608,12 +611,39 @@ function TopbarVersionControl(props: {
     if (!open) setRollbackOpen(false);
   }, [open]);
 
+  useEffect(() => {
+    if (!open) {
+      setPopoverPosition(null);
+      return;
+    }
+
+    const updatePopoverPosition = () => {
+      const trigger = triggerRef.current;
+      if (!trigger) return;
+      const rect = trigger.getBoundingClientRect();
+      const maxWidth = Math.min(340, Math.max(0, window.innerWidth - 32));
+      const left = Math.max(16, Math.min(rect.left, window.innerWidth - maxWidth - 16));
+      setPopoverPosition({ top: rect.bottom + 8, left });
+    };
+
+    updatePopoverPosition();
+    window.addEventListener('resize', updatePopoverPosition);
+    // The trigger can move when any ancestor scrolls, not just the window.
+    document.addEventListener('scroll', updatePopoverPosition, true);
+    return () => {
+      window.removeEventListener('resize', updatePopoverPosition);
+      document.removeEventListener('scroll', updatePopoverPosition, true);
+    };
+  }, [open]);
+
   useEffect(() => () => clearReconnectTimer(), []);
 
   useEffect(() => {
     if (!open) return;
     const closeOnPointerDown = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+      const target = event.target as Node;
+      if (rootRef.current?.contains(target) || popoverRef.current?.contains(target)) return;
+      setOpen(false);
     };
     const closeOnEscape = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return;
@@ -818,12 +848,14 @@ function TopbarVersionControl(props: {
               aria-hidden="true"
             >{versionSignal.symbol}</span>}
       </button>
-      {open ? (
+      {open && popoverPosition && typeof document !== 'undefined' ? createPortal((
         <section
+          ref={popoverRef}
           className="dashboard-version-popover"
           role="dialog"
           aria-modal="false"
           aria-labelledby="dashboard-version-title"
+          style={{ top: popoverPosition.top, left: popoverPosition.left }}
         >
           <header className="dashboard-version-popover-head">
             <strong id="dashboard-version-title">{t('update.current')}</strong>
@@ -994,7 +1026,7 @@ function TopbarVersionControl(props: {
             </footer>
           ) : null}
         </section>
-      ) : null}
+      ), document.body) : null}
     </div>
   );
 }

--- a/src/dashboard/web/app.tsx
+++ b/src/dashboard/web/app.tsx
@@ -611,6 +611,21 @@ function TopbarVersionControl(props: {
     if (!open) setRollbackOpen(false);
   }, [open]);
 
+  // A portaled dialog is no longer the next DOM sibling of the trigger. Move
+  // focus into it once after mounting so keyboard users do not skip the whole
+  // dialog when pressing Tab. Do not depend on the actual coordinates: scroll
+  // updates must never steal focus from a user interacting with the popover.
+  useEffect(() => {
+    if (!open || !popoverPosition) return;
+    const frame = window.requestAnimationFrame(() => {
+      const firstFocusable = popoverRef.current?.querySelector<HTMLElement>(
+        'button:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      firstFocusable?.focus();
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [open, popoverPosition !== null]);
+
   useEffect(() => {
     if (!open) {
       setPopoverPosition(null);

--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -8221,7 +8221,8 @@ button.sidebar-create-btn:focus-visible {
 }
 .dashboard-version-control {
   position: relative;
-  z-index: 2;
+  /* Keep the version popover above the app-wide custom scrollbar layer. */
+  z-index: 1600;
   width: max-content;
   margin: -2px 0 0 37px;
 }

--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -8303,9 +8303,8 @@ button.dashboard-version-chip:hover,
   color: var(--fg);
 }
 .dashboard-version-popover {
-  position: absolute;
-  top: calc(100% + 8px);
-  left: 0;
+  position: fixed;
+  z-index: 1601;
   display: flex;
   flex-direction: column;
   width: min(340px, calc(100vw - 32px));
@@ -12923,7 +12922,6 @@ dialog :where(input:not([type=checkbox], [type=radio]), select, textarea) {
   }
   .dashboard-version-control { margin-left: 33px; }
   .dashboard-version-popover {
-    left: -33px;
     width: min(340px, calc(100vw - 24px));
   }
   .topbar-left {

--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -8221,8 +8221,7 @@ button.sidebar-create-btn:focus-visible {
 }
 .dashboard-version-control {
   position: relative;
-  /* Keep the version popover above the app-wide custom scrollbar layer. */
-  z-index: 1600;
+  z-index: 2;
   width: max-content;
   margin: -2px 0 0 37px;
 }

--- a/test/dashboard-version-popover.test.ts
+++ b/test/dashboard-version-popover.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+function dashboardSource(file: string): string {
+  return readFileSync(new URL(`../src/dashboard/web/${file}`, import.meta.url), 'utf8');
+}
+
+describe('dashboard version popover layering regression', () => {
+  it('portals the popover out of the app stacking context and keeps its position tied to the trigger', () => {
+    const app = dashboardSource('app.tsx');
+    const css = dashboardSource('style.css');
+
+    expect(app).toContain("createPortal((");
+    expect(app).toContain('document.body');
+    expect(app).toContain('trigger.getBoundingClientRect()');
+    expect(app).toContain("document.addEventListener('scroll', updatePopoverPosition, true)");
+    expect(app).toContain('popoverRef.current?.contains(target)');
+    expect(css).toMatch(/\.dashboard-version-popover\s*\{[\s\S]*?position:\s*fixed;[\s\S]*?z-index:\s*1601;/);
+  });
+
+  it('clamps the portal horizontally instead of relying on the old topbar offset', () => {
+    const app = dashboardSource('app.tsx');
+    const css = dashboardSource('style.css');
+
+    expect(app).toContain('window.innerWidth - maxWidth - 16');
+    expect(css).not.toMatch(/\.dashboard-version-popover\s*\{[^}]*left:\s*-33px;/s);
+  });
+});

--- a/test/dashboard-version-popover.test.ts
+++ b/test/dashboard-version-popover.test.ts
@@ -15,7 +15,10 @@ describe('dashboard version popover layering regression', () => {
     expect(app).toContain('trigger.getBoundingClientRect()');
     expect(app).toContain("document.addEventListener('scroll', updatePopoverPosition, true)");
     expect(app).toContain('popoverRef.current?.contains(target)');
+    expect(app).toContain('firstFocusable?.focus()');
+    expect(app).toContain('window.requestAnimationFrame');
     expect(css).toMatch(/\.dashboard-version-popover\s*\{[\s\S]*?position:\s*fixed;[\s\S]*?z-index:\s*1601;/);
+    expect(css).toMatch(/\.dashboard-version-control\s*\{[\s\S]*?z-index:\s*2;/);
   });
 
   it('clamps the portal horizontally instead of relying on the old topbar offset', () => {


### PR DESCRIPTION
## Summary

The dashboard version popover can be covered by the app-wide custom scrollbar layer.

The scrollbar layer uses `z-index: 1500`, while `.dashboard-version-control` creates a lower stacking context at `z-index: 2`. When the sidebar has a visible custom scrollbar, its thumb can appear through the version popover.

Raise the version-control stacking context to `z-index: 1600` so the popover remains above the custom scrollbar.

<img width="726" height="542" alt="image" src="https://github.com/user-attachments/assets/23c21a5b-0cf8-4287-a9ea-b31f09092e7e" />

## Validation

- `pnpm dashboard:bundle`
- `git diff --check`