### PR TITLE
fix(cli): 修复 list 遇到 Riff 会话崩溃

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3766,16 +3766,34 @@ function sessionBackingInfo(s: SessionData, snapshot?: BackingProbeSnapshot): {
   if (s.backendType === 'pty') {
     return { backendType: 'pty', probe: 'missing', label: 'pty' };
   }
-  // Legacy rows predate backend stamping. Only tmux was externally attachable.
-  const target = sessionPersistentTarget(s)!;
-  const probe = backingProbe(snapshot, target);
-  return {
-    backendType: 'tmux',
-    target,
-    probe,
-    label: probe === 'exists' ? `tmux: ${target.sessionName}` : '-',
-    attachBackend: 'tmux',
-  };
+  if (s.backendType === 'riff') {
+    // Riff runs the CLI on a remote sandbox, not a local multiplexer pane: there
+    // is nothing to probe, attach to, or name as a PersistentBackendTarget
+    // (sessionPersistentTarget returns undefined for it, by design). Surface a
+    // stable label and report the nonexistent local backing as missing — exactly
+    // like pty — so it never slips into the legacy tmux branch and dereferences an
+    // undefined target.
+    return { backendType: 'riff', probe: 'missing', label: 'riff' };
+  }
+  if (s.backendType === undefined) {
+    // Legacy rows predate backend stamping. Only tmux was externally attachable,
+    // so its deterministic target remains the compatibility path.
+    const target = sessionPersistentTarget(s)!;
+    const probe = backingProbe(snapshot, target);
+    return {
+      backendType: 'tmux',
+      target,
+      probe,
+      label: probe === 'exists' ? `tmux: ${target.sessionName}` : '-',
+      attachBackend: 'tmux',
+    };
+  }
+  // Exhaustiveness guard: every BackendType must be classified above. A future
+  // non-suspendable backend added to BackendType will fail to compile here rather
+  // than silently inheriting the legacy tmux target (the Riff crash's root cause).
+  const _exhaustive: never = s.backendType;
+  void _exhaustive;
+  return { probe: 'missing', label: '-' };
 }
 
 function sessionTargetLabel(s: SessionData, snapshot?: BackingProbeSnapshot): string {

--- a/test/cli-list-riff.test.ts
+++ b/test/cli-list-riff.test.ts
@@ -1,0 +1,176 @@
+/**
+ * CLI regression for `botmux list --plain` against active Riff sessions.
+ *
+ * Riff runs the CLI on a remote sandbox, so it has no local multiplexer pane
+ * and `sessionPersistentTarget()` returns undefined for it — by design. A prior
+ * `sessionBackingInfo()` only special-cased tmux/herdr/zellij/zmx and pty, so a
+ * Riff row fell into the legacy tmux branch, force-unwrapped the undefined
+ * target with `!`, and crashed in `backingProbeKey()` reading
+ * `target.backendType` (TypeError). Both `--plain` and the interactive TUI share
+ * that helper, so both list modes crashed.
+ *
+ * These tests run the SOURCE CLI through tsx against a temp data dir with a real
+ * `status: active`, `backendType: 'riff'` session that has no
+ * persistentBackendTarget, and assert the crash is gone and the record is not
+ * mutated by the read-only list command. They fail (nonzero exit + TypeError on
+ * stderr) against the pre-fix cli.ts.
+ *
+ * To keep the target-column assertions honest, the "riff"/"pty" substrings are
+ * kept OUT of every other column (title, session id, working dir), so a matched
+ * substring can only have come from the target label the fix produces.
+ */
+import { spawn } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const CLI_PATH = join(__dirname, '..', 'src', 'cli.ts');
+const APP_ID = 'cli_list_riff_test';
+const tempDirs: string[] = [];
+
+interface StoredSession {
+  sessionId: string;
+  chatId: string;
+  rootMessageId: string;
+  title: string;
+  status: 'active' | 'closed';
+  createdAt: string;
+  workingDir?: string;
+  larkAppId?: string;
+  cliId?: string;
+  backendType?: 'pty' | 'tmux' | 'herdr' | 'zellij' | 'zmx' | 'riff';
+  persistentBackendTarget?: unknown;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeSession(sessionId: string, overrides: Partial<StoredSession> = {}): StoredSession {
+  return {
+    sessionId,
+    chatId: 'oc_list_riff_test',
+    rootMessageId: 'om_list_riff_test',
+    title: sessionId,
+    status: 'active',
+    createdAt: '2026-07-22T00:00:00.000Z',
+    workingDir: '/tmp/session-wd',
+    larkAppId: APP_ID,
+    ...overrides,
+  };
+}
+
+function writeSessions(dataDir: string, sessions: StoredSession[]): string {
+  mkdirSync(dataDir, { recursive: true });
+  const path = join(dataDir, `sessions-${APP_ID}.json`);
+  writeFileSync(path, JSON.stringify(Object.fromEntries(sessions.map(s => [s.sessionId, s]))));
+  return path;
+}
+
+function runList(
+  dataDir: string,
+  homeDir: string,
+  args: string[] = ['--plain'],
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      SESSION_DATA_DIR: dataDir,
+      // Hermetic HOME so the box's real ~/.botmux/bots.json can't flip the
+      // multi-bot column layout under the test (os.homedir() honours $HOME on
+      // POSIX). SESSION_DATA_DIR still wins for the session store regardless.
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+    };
+    const child = spawn(
+      process.execPath,
+      ['--import', 'tsx', CLI_PATH, 'list', ...args],
+      { env, stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => { stdout += chunk; });
+    child.stderr.on('data', (chunk: string) => { stderr += chunk; });
+    child.once('error', reject);
+    child.once('close', status => resolve({ status, stdout, stderr }));
+  });
+}
+
+describe('botmux list — active Riff session', () => {
+  it('renders an active riff session without crashing and leaves the record intact', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-list-riff-data-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'botmux-list-riff-home-'));
+    tempDirs.push(dataDir, homeDir);
+    const session = makeSession('aaaa0001-2222-3333-4444-555566667777', {
+      title: 'remote-task-alpha',
+      cliId: 'riff',
+      backendType: 'riff',
+      // No persistentBackendTarget on purpose: Riff has no local backing pane.
+    });
+    const sessionsPath = writeSessions(dataDir, [session]);
+
+    const result = await runList(dataDir, homeDir);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain('TypeError');
+    expect(result.stderr).not.toContain('backendType');
+    expect(result.stdout).toContain('remote-task-alpha');
+    // 'riff' appears in no other column (id/title/dir), so a match proves the
+    // target column rendered the stable non-persistent label.
+    expect(result.stdout).toContain('riff');
+
+    // list is a READ command: the active record must survive untouched.
+    const stored = JSON.parse(readFileSync(sessionsPath, 'utf8'));
+    expect(stored[session.sessionId]).toBeDefined();
+    expect(stored[session.sessionId].status).toBe('active');
+    expect(stored[session.sessionId].backendType).toBe('riff');
+    expect(stored[session.sessionId].persistentBackendTarget).toBeUndefined();
+  });
+
+  it('lists a mix of riff, pty and legacy (backendType-less) tmux rows without regressing the shared path', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'botmux-list-mix-data-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'botmux-list-mix-home-'));
+    tempDirs.push(dataDir, homeDir);
+    const riff = makeSession('aaaa0001-0000-0000-0000-000000000001', {
+      title: 'row-alpha',
+      cliId: 'riff',
+      backendType: 'riff',
+    });
+    const pty = makeSession('bbbb0002-0000-0000-0000-000000000002', {
+      title: 'row-beta',
+      cliId: 'claude-code',
+      backendType: 'pty',
+    });
+    // No backendType: the legacy compatibility path (deterministic tmux target).
+    const legacy = makeSession('cccc0003-0000-0000-0000-000000000003', {
+      title: 'row-gamma',
+      cliId: 'codex',
+    });
+    const sessionsPath = writeSessions(dataDir, [riff, pty, legacy]);
+
+    const result = await runList(dataDir, homeDir);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain('TypeError');
+    expect(result.stdout).toContain('row-alpha');
+    expect(result.stdout).toContain('row-beta');
+    expect(result.stdout).toContain('row-gamma');
+    // Neither substring appears in any id/title/dir column, so matches can only
+    // come from the riff and pty target labels the shared list path renders —
+    // proving the legacy tmux row (row-gamma) flows through without crashing it.
+    expect(result.stdout).toContain('riff');
+    expect(result.stdout).toContain('pty');
+
+    // None of the three real managed sessions may be pruned or mutated by list.
+    const stored = JSON.parse(readFileSync(sessionsPath, 'utf8'));
+    for (const s of [riff, pty, legacy]) {
+      expect(stored[s.sessionId]).toBeDefined();
+      expect(stored[s.sessionId].status).toBe('active');
+    }
+  });
+});


### PR DESCRIPTION
## 问题

`botmux list` / `botmux list --plain` 遇到**活跃的 Riff 会话**时崩溃：

```
TypeError: Cannot read properties of undefined (reading 'backendType')
  at backingProbeKey (src/cli.ts:3673)
  at backingProbe
  at sessionBackingInfo
  at printSessionTable / formatSessionRow
  at cmdList
```

交互 TUI 与 `--plain` 共用同一段渲染逻辑，两种模式都会崩。

## 根因

Riff 在**远端 sandbox** 运行 CLI，没有本地 multiplexer pane，所以
`sessionPersistentTarget()` 对 `backendType: 'riff'` **正确返回 `undefined`**（Riff 不是本地持久化后端）。

但 `sessionBackingInfo()` 只单独处理了 tmux/herdr/zellij/zmx（suspendable 一族）和 pty，
Riff 落入了本来**只给「`backendType` 未写入的旧 tmux 会话」用的 legacy 分支**。该分支对
`sessionPersistentTarget(s)!` 用了非空断言，随后把实际为 `undefined` 的 target 传给
`backingProbe()`，最终在 `backingProbeKey()` 读 `target.backendType` 时解引用 `undefined` 崩溃。

## 修复

在 `sessionBackingInfo()` 中把 Riff **显式作为非持久后端处理**：

- target 列展示稳定文案 **`riff`**；
- probe 记为 **`missing`**；
- **不**提供 `attachBackend`/`target`（`canAttach` 因此自然为 `false`，不会伪造 attach 入口）；
- 不把 Riff 伪装成 tmux，也不为它构造假的 `PersistentBackendTarget`。

同时收紧语义、并防止将来再犯：

- legacy 兼容分支收紧为**仅 `backendType === undefined`** 的旧会话（原样保留旧 tmux 兼容行为）；
- 分支末尾加 **`never` 穷尽性守卫**——将来往 `BackendType` 新增的、非 suspendable 的后端若漏处理，会**编译报错**，而不是再次静默落入 legacy tmux 分支（本次崩溃的根因模式）。

最小改动：`src/cli.ts` +28/−10，不含无关重构。

## 影响面

- 属于 **CLI list 公共展示路径**，与具体 AI CLI 类型无关；
- 影响**交互 TUI** 与 **`--plain`** 两种列表输出；
- **只改变 Riff 会话的 target 展示**；tmux/herdr/zellij/zmx 的探测/attach/恢复/删除、pty 展示与行为、legacy 旧会话（无 `backendType`）兼容、会话自动清理（prune）、`delete`、daemon 生命周期**均不变**；
- `sessionBackingInfo` / `sessionTargetLabel` / `hasRecoverableBackingSession` / `backingProbeKey` 四个 helper 经确认均为 `cli.ts` 内部函数，**无跨文件消费**（daemon/server 不调用），影响被完全限制在 list 渲染两条路径内。

## 验证

- `pnpm build` 通过（穷尽性守卫能编译 = 所有 `BackendType` 均已被分类）。
- `pnpm test`（unit）：**814 文件全绿 / 13039 测试通过 / 0 失败**。
- 新增 `test/cli-list-riff.test.ts`（跑**源码 CLI** `list --plain`）：
  1. 构造 `status: active`、`backendType: 'riff'`、无 `persistentBackendTarget` 的真实会话记录；
  2. 断言：退出码 `0`、输出含会话标题、target 列含 `riff`、stderr 无 `TypeError`、且会话仍 `active` 未被 list 删除/改坏；
  3. 另覆盖同一份 active 中 **riff + pty + legacy(无 backendType) 混合**，防公共列表逻辑回归。
- **red-on-old**：把修复 stash 掉、仅留新测跑 → 两个用例均 **RED**，且复现出与报告**一模一样**的 `TypeError` 栈（`backingProbeKey` → … → `printSessionTable`）；恢复修复后转绿。
- **构建产物核对**：对 `dist/cli.js` 直接跑 `list --plain`（active riff 记录）→ 退出码 `0`，target 列显示 `riff`：

  ```
  id        │ title             │ ... │ status │ target
  aaaa0001  │ remote-task-alpha │ ... │ idle   │ riff
  共 1 个活跃会话
  ```

### 关于 daemon 部署

`botmux list` 是**用户在 shell 手动执行的独立 CLI 命令，不由 daemon 执行**（已确认相关 helper 均 cli.ts 本地、daemon/server 无调用），因此无需 live daemon 重启来验证——起作用的是 `botmux` 命令解析到的 `dist/cli.js`，本 checkout 的构建产物已按上方核对通过。为避免 review worktree 抢走全局 `botmux` 指向（合并后 worktree 删除会导致全局 shim 失效），本次未从 worktree 执行 `switch:here && daemon:restart`。