### PR TITLE
fix(opencode): 大段输入改用粘贴提交

### DIFF
--- a/src/adapters/cli/opencode.ts
+++ b/src/adapters/cli/opencode.ts
@@ -20,6 +20,7 @@ import { delay } from '../../utils/timing.js';
  */
 
 const OPENCODE_SESSION_ID_RE = /^ses_[0-9A-Za-z]+$/;
+const OPENCODE_PASTE_THRESHOLD = 150;
 
 function isOpenCodeSessionId(value: string | undefined): value is string {
   return typeof value === 'string' && OPENCODE_SESSION_ID_RE.test(value);
@@ -253,7 +254,11 @@ export function createOpenCodeAdapter(pathOverride?: string): CliAdapter {
 
       try {
         if (pty.sendText && pty.sendSpecialKeys) {
-          pty.sendText(content);
+          if (!isSlashCommand && pty.pasteText && (content.length > OPENCODE_PASTE_THRESHOLD || content.includes('\n'))) {
+            pty.pasteText(content);
+          } else {
+            pty.sendText(content);
+          }
           await delay(200);
           pty.sendSpecialKeys('Enter');
         } else {

--- a/test/opencode-resume.test.ts
+++ b/test/opencode-resume.test.ts
@@ -231,11 +231,22 @@ describe('opencode writeInput DB verification', () => {
 
   it('skips verification for slash commands (TUI command palette, no user row)', async () => {
     openDb().close();
-    const pty = stubPty();
+    const events: string[] = [];
+    const pty: PtyHandle & { enters: number } = {
+      enters: 0,
+      write(_data: string) {},
+      sendText(text: string) { events.push(`text:${text}`); },
+      pasteText(text: string) { events.push(`paste:${text}`); },
+      sendSpecialKeys(...keys: string[]) {
+        events.push(`key:${keys.join('+')}`);
+        pty.enters++;
+      },
+    };
     const adapter = createOpenCodeAdapter();
     const result = await adapter.writeInput(pty, '/help');
     expect(result).toBeUndefined();
     expect(pty.enters).toBe(1);  // 无重试 Enter，避免误触面板
+    expect(events).toEqual(['text:/help', 'key:Enter']);
   });
 
   it('stays blind (undefined) when the DB is missing', async () => {
@@ -243,5 +254,30 @@ describe('opencode writeInput DB verification', () => {
     const adapter = createOpenCodeAdapter();
     const result = await adapter.writeInput(pty, 'no db yet');
     expect(result).toBeUndefined();
+  });
+
+  it('pastes multi-line prompts so OpenCode can use its bracketed-paste path', async () => {
+    const db = openDb();
+    seedSession(db, { id: 'ses_target' });
+    const content = `<botmux_routing>\n${'hint\n'.repeat(200)}</botmux_routing>\n\n<user_message>\nhello\n</user_message>`;
+    const events: string[] = [];
+    const pty: PtyHandle & { enters: number } = {
+      enters: 0,
+      write(_data: string) {},
+      sendText(text: string) { events.push(`text:${text.length}`); },
+      pasteText(text: string) { events.push(`paste:${text.length}`); },
+      sendSpecialKeys(...keys: string[]) {
+        events.push(`key:${keys.join('+')}`);
+        pty.enters++;
+        if (pty.enters === 1) seedUserPart(db, 'ses_target', content, Date.now());
+      },
+    };
+
+    const adapter = createOpenCodeAdapter();
+    const result = await adapter.writeInput(pty, content);
+    db.close();
+
+    expect(result).toMatchObject({ submitted: true, cliSessionId: 'ses_target' });
+    expect(events).toEqual([`paste:${content.length}`, 'key:Enter']);
   });
 });

--- a/test/write-input.test.ts
+++ b/test/write-input.test.ts
@@ -19,9 +19,11 @@
  *   message in the input box. Submit is verified via CoCo's platform-specific
  *   history.jsonl.
  * - CoCo (raw PTY): same explicit \x1b[200~...\x1b[201~ wrap as claude-code.
- * - Other adapters (Aiden/Codex/Gemini/OpenCode): use plain sendText + Enter
+ * - Other adapters (Aiden/Codex/Gemini): use plain sendText + Enter
  *   in tmux, or write(content) + \r in raw mode. The whole content (including
  *   newlines) is sent in one sendText call — those CLIs tolerate raw LF.
+ * - OpenCode: short single-line prompts use sendText + Enter; multiline or
+ *   large prompts use pasteText + Enter so OpenTUI receives bracketed paste.
  *
  * Run:  pnpm vitest run test/write-input.test.ts
  */
@@ -157,17 +159,18 @@ function makeRawPty(opts?: { confirmCodexSubmit?: boolean; codexSessionId?: stri
 type AdapterEntry = [string, CliAdapter];
 
 /** Adapters that use plain sendText+Enter (tmux) / write+CR (raw) — Aiden,
- *  Gemini, Genius, OpenCode, MTR, Hermes. (Codex moved to PASTE_BUFFER_ADAPTERS; its
+ *  Gemini, Genius, MTR, Hermes. (Codex moved to PASTE_BUFFER_ADAPTERS; its
  *  TUI treats every literal \n as Enter, so a multi-line burst fragmented into
  *  per-line submits / "Queued follow-up inputs" — bracketed paste fixes it.) */
 const PLAIN_ADAPTERS: AdapterEntry[] = [
   ['aiden', createAidenAdapter('/bin/aiden')],
   ['gemini', createGeminiAdapter('/bin/gemini')],
   ['genius', createGeniusAdapter('/bin/genius')],
-  ['opencode', createOpenCodeAdapter('/bin/opencode')],
   ['mtr', createMtrAdapter('/bin/mtr')],
   ['hermes', createHermesAdapter('/bin/hermes')],
 ];
+
+const OPENCODE_ADAPTER: AdapterEntry = ['opencode', createOpenCodeAdapter('/bin/opencode')];
 
 /** Node runner adapters use a one-line base64 control protocol so multiline
  *  content cannot be split by terminal Enter semantics. */
@@ -202,6 +205,7 @@ const ALL_ADAPTERS: AdapterEntry[] = [
   ...HUMAN_TYPING_ADAPTERS,
   ...PASTE_BUFFER_ADAPTERS,
   ...PLAIN_ADAPTERS,
+  OPENCODE_ADAPTER,
   ...APP_RUNNER_ADAPTERS,
 ];
 
@@ -216,7 +220,7 @@ function decodeRunnerLine(line: string, prefix: string): any {
 // =========================================================================
 
 describe('writeInput: single-line, tmux mode', () => {
-  it.each([...HUMAN_TYPING_ADAPTERS, ...PLAIN_ADAPTERS])('%s: sendText + Enter, no pasteText', async (_name, adapter) => {
+  it.each([...HUMAN_TYPING_ADAPTERS, ...PLAIN_ADAPTERS, OPENCODE_ADAPTER])('%s: sendText + Enter, no pasteText', async (_name, adapter) => {
     const pty = makeTmuxPty();
     await adapter.writeInput(pty, 'hello world');
     expect(pty.sendText).toHaveBeenCalledWith('hello world');
@@ -243,7 +247,7 @@ describe('writeInput: single-line, tmux mode', () => {
 });
 
 describe('writeInput: single-line, non-tmux mode', () => {
-  it.each(PLAIN_ADAPTERS)('%s: write(content) + CR', async (_name, adapter) => {
+  it.each([...PLAIN_ADAPTERS, OPENCODE_ADAPTER])('%s: write(content) + CR', async (_name, adapter) => {
     const pty = makeRawPty();
     await adapter.writeInput(pty, 'hello world');
     const allWritten = pty.write.mock.calls.map(c => c[0]).join('');
@@ -273,9 +277,11 @@ describe('writeInput: single-line, non-tmux mode', () => {
 // 2. Multiline content
 //    - Claude Code / CoCo / Codex: bracketed paste (pasteText) with the whole
 //      string — the embedded \n stay content, only the trailing Enter submits.
-//    - PLAIN adapters (Aiden/Gemini/OpenCode/MTR/Hermes): sendText with the
+//    - PLAIN adapters (Aiden/Gemini/MTR/Hermes): sendText with the
 //      whole string (including \n) — those CLIs treat literal LF as a newline,
 //      not a submit, so only the trailing Enter submits.
+//    - OpenCode: pasteText for multiline/large prompts so its TUI receives
+//      bracketed paste rather than slow literal key replay.
 // =========================================================================
 
 const MULTILINE = 'first line\n\nSession ID: abc-123';
@@ -285,6 +291,44 @@ describe('writeInput: multiline, tmux mode', () => {
     const pty = makeTmuxPty();
     await adapter.writeInput(pty, MULTILINE);
     expect(pty.sendText).toHaveBeenCalledWith(MULTILINE);
+    expect(pty.sendSpecialKeys).toHaveBeenCalledWith('Enter');
+    expect(pty.pasteText).not.toHaveBeenCalled();
+  });
+
+  it('opencode: short single-line input uses sendText + Enter', async () => {
+    const [, adapter] = OPENCODE_ADAPTER;
+    const pty = makeTmuxPty();
+    await adapter.writeInput(pty, 'hello world');
+    expect(pty.sendText).toHaveBeenCalledWith('hello world');
+    expect(pty.sendSpecialKeys).toHaveBeenCalledWith('Enter');
+    expect(pty.pasteText).not.toHaveBeenCalled();
+  });
+
+  it('opencode: long single-line input uses pasteText + Enter', async () => {
+    const [, adapter] = OPENCODE_ADAPTER;
+    const input = 'x'.repeat(151);
+    const pty = makeTmuxPty();
+    await adapter.writeInput(pty, input);
+    expect(pty.pasteText).toHaveBeenCalledWith(input);
+    expect(pty.sendSpecialKeys).toHaveBeenCalledWith('Enter');
+    expect(pty.sendText).not.toHaveBeenCalled();
+  });
+
+  it('opencode: multiline input uses pasteText + Enter', async () => {
+    const [, adapter] = OPENCODE_ADAPTER;
+    const pty = makeTmuxPty();
+    await adapter.writeInput(pty, MULTILINE);
+    expect(pty.pasteText).toHaveBeenCalledWith(MULTILINE);
+    expect(pty.sendSpecialKeys).toHaveBeenCalledWith('Enter');
+    expect(pty.sendText).not.toHaveBeenCalled();
+  });
+
+  it('opencode: slash commands keep sendText even when long or multiline', async () => {
+    const [, adapter] = OPENCODE_ADAPTER;
+    const input = `/help\n${'x'.repeat(151)}`;
+    const pty = makeTmuxPty();
+    await adapter.writeInput(pty, input);
+    expect(pty.sendText).toHaveBeenCalledWith(input);
     expect(pty.sendSpecialKeys).toHaveBeenCalledWith('Enter');
     expect(pty.pasteText).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
# fix(opencode): 大段输入改用粘贴提交

## 变更

- OpenCode adapter 对多行或超过 150 字符的普通输入改用 `pasteText()`，让 tmux 以 bracketed paste 方式提交大段首轮 prompt。
- slash command 仍保持 `sendText() + Enter`，避免影响 OpenCode 命令面板。
- 补充 OpenCode adapter 回归测试，覆盖大段 prompt 走 paste、slash command 仍走 text。

## 背景

OpenCode 首轮 botmux prompt 会包含 routing、identity、session、sender、skills 等上下文，实际写入 CLI 的内容可能远大于用户消息本身。

此前 OpenCode adapter 统一使用 `tmux send-keys -l` 字面输入整段内容。对于几 KB 的首轮 prompt，OpenCode TUI 会像收到大量键盘输入一样慢慢处理，导致用户体感“短消息发给 OpenCode 后几分钟才开始处理”。

OpenCode 自身对 bracketed paste 有大段输入快路径，因此 botmux 在可用时应走 `pasteText()`，而不是把大段 prompt 当逐字按键输入。

## 验证

- `BOTMUX_TIME_SCALE=0.01 pnpm test -- test/opencode-resume.test.ts`
  - 16 tests passed
- `pnpm build`
  - `audit:domains` passed
  - `tsc` passed
  - dashboard bundle passed
  - dist audit passed
- `git diff --check`
  - passed
- 手动 live daemon 验证
  - 将当前 checkout 部署到 live daemon 后，OpenCode 首轮短消息不再长时间卡住。
