### PR TITLE
fix(dashboard): 修复定时任务编辑状态回填异常

### DIFF
--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -1849,6 +1849,7 @@ ipcRoute('POST', '/api/sessions/:sessionId/locate', async (_req, res, params) =>
 export interface ScheduleRow {
   id: string;
   name: string;
+  schedule: string;
   parsed: ParsedSchedule;
   prompt: string;
   workingDir: string;
@@ -1875,6 +1876,7 @@ function composeScheduleRow(t: ScheduledTask): ScheduleRow {
   return {
     id: t.id,
     name: t.name,
+    schedule: t.schedule,
     parsed: t.parsed,
     prompt: t.prompt,
     workingDir: t.workingDir,

--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -802,9 +802,13 @@ export function updateTask(
   if (!task) return { ok: false, error: 'not_found' };
 
   const patch: Record<string, unknown> = {};
+  const eventPatch: Record<string, unknown> = {};
   if (updates.name !== undefined) patch.name = updates.name;
   if (updates.prompt !== undefined) patch.prompt = updates.prompt;
-  if (updates.silent !== undefined) patch.silent = updates.silent === true ? true : undefined;
+  if (updates.silent !== undefined) {
+    patch.silent = updates.silent === true ? true : undefined;
+    eventPatch.silent = updates.silent === true;
+  }
 
   const legacyPosition = updates.deliver === 'new-topic'
     ? 'new-topic'
@@ -844,7 +848,7 @@ export function updateTask(
   scheduleStore.updateTask(id, patch);
   dashboardEventBus.publish({
     type: 'schedule.updated',
-    body: { id, patch },
+    body: { id, patch: { ...patch, ...eventPatch } },
   });
   return { ok: true };
 }

--- a/test/dashboard-ipc.test.ts
+++ b/test/dashboard-ipc.test.ts
@@ -1652,6 +1652,34 @@ describe('GET /api/schedules', () => {
     const body = await res.json();
     expect(Array.isArray(body.schedules)).toBe(true);
   });
+
+  it('includes raw schedule so the edit form can prefill the schedule field', async () => {
+    setLarkAppId('cli_ipc_test_bot001');
+    const add = scheduler.addTask({
+      name: 'AI 工作环境巡检',
+      schedule: '10 0,12 * * *',
+      prompt: '执行一次巡检',
+      workingDir: '/tmp',
+      chatId: 'oc_schedule',
+      larkAppId: 'cli_ipc_test_bot001',
+      executionPosition: 'topic',
+      rootMessageId: 'om_schedule_root',
+      chatType: 'topic_group',
+    });
+    handle = await startIpcServer({ port: 0, host: '127.0.0.1' });
+
+    const res = await fetch(`http://127.0.0.1:${handle.port}/api/schedules`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const row = body.schedules.find((s: any) => s.id === add.id);
+
+    expect(row).toMatchObject({
+      id: add.id,
+      name: 'AI 工作环境巡检',
+      schedule: '10 0,12 * * *',
+      parsed: { display: '10 0,12 * * *' },
+    });
+  });
 });
 
 describe('POST /api/schedules execution position', () => {

--- a/test/scheduler-toggle-delivery.test.ts
+++ b/test/scheduler-toggle-delivery.test.ts
@@ -119,3 +119,18 @@ describe('scheduler.toggleDelivery', () => {
     expect(publish).not.toHaveBeenCalled();
   });
 });
+
+describe('scheduler.updateTask', () => {
+  it('publishes silent:false when disabling silent so dashboard caches clear stale true', async () => {
+    const { updateTask } = await import('../src/core/scheduler.js');
+    const id = seed('origin', { silent: true });
+
+    expect(updateTask(id, { silent: false })).toEqual({ ok: true });
+
+    expect(store.get(id)!.silent).toBeUndefined();
+    expect(publish).toHaveBeenCalledWith({
+      type: 'schedule.updated',
+      body: { id, patch: { silent: false } },
+    });
+  });
+});


### PR DESCRIPTION
## 改了什么

- 在 dashboard schedule 行数据中补回原始 `schedule` 字段，让编辑弹窗的「调度规则」输入框能正确回填。
- 将 schedule 更新时的持久化 patch 与 dashboard 事件 patch 分离：关闭静默时，持久化仍按既有兼容逻辑清理 `silent` 字段，但 `schedule.updated` 事件显式发送 `silent:false`。
- 补充回归测试，覆盖：
  - `GET /api/schedules` 返回的行数据包含原始 `schedule`。
  - 从 `silent:true` 切到 `false` 时，dashboard cache 能收到可序列化的 `silent:false`。

## 为什么

定时任务编辑弹窗依赖 `editing.schedule` 初始化「调度规则」输入框，但后端返回给 dashboard 的 schedule row 只有 `parsed.display`，没有原始 `schedule` 字段，导致弹窗里该输入框为空。

另一个同链路问题是：`silent:false` 在持久化层会被规范化为字段缺失。之前同一个 patch 直接发给 dashboard，经过 SSE/JSON 后 `silent: undefined` 被丢弃，前端 cache 无法清掉旧的 `silent:true`，表现为编辑保存后静默状态仍显示开启。

## 影响面

- 仅影响 dashboard 定时任务编辑页的数据回填和编辑后的实时状态同步。
- 不改变 `schedules.json` 的持久化格式。
- 不影响任务实际调度、执行位置或静默执行语义。

## 验证

- `pnpm vitest run test/scheduler-toggle-delivery.test.ts` 通过。
- `pnpm vitest run test/dashboard-ipc.test.ts -- -t "includes raw schedule"` 通过。
- `pnpm build` 通过。
- live dashboard API 临时任务验证通过：`silent:true -> false -> true` 均能在 dashboard 聚合列表即时反映；临时任务已删除。
- 已用当前 checkout 重启 live botmux，并确认 `botmux-0/1/2` 与 `botmux-dashboard` 全部 online。
