### PR TITLE
fix(ask): 发卡瞬时失败不再作废 ask + 拉长默认超时，修原生 picker 卡死

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9503,8 +9503,14 @@ export async function runHook(
     routeRoot = adopt.rootMessageId;
   }
 
-  // 解析 timeoutMs：默认 1 小时，可由 BOTMUX_ASK_TIMEOUT_MS 覆盖
-  const DEFAULT_TIMEOUT_MS = 3_600_000;
+  // 解析 timeoutMs：默认 ~24h，可由 BOTMUX_ASK_TIMEOUT_MS 覆盖。
+  // 为什么这么长：ask 超时不是良性兜底——broker settle 成 `timedOut` 会让 hook
+  // 落到 passthrough，Claude 转而渲染原生 picker，而此后飞书回调已无通道把答案
+  // 送回（picker 挂死、答案不生效）。所以默认值对齐 hook 安装侧的进程超时上限
+  // （settings.json 里的 86400s），让 broker 不会 *早于* hook 进程本身超时；
+  // 既避免"人回复慢→picker 卡死"，又保留一个有限的进程级兜底（永不超时会让一次
+  // CLI turn 无限阻塞，是更糟的失败）。
+  const DEFAULT_TIMEOUT_MS = 86_400_000; // 24h — 对齐 hook 安装侧 timeout:86400s
   let timeoutMs = DEFAULT_TIMEOUT_MS;
   const timeoutEnv = env.BOTMUX_ASK_TIMEOUT_MS;
   if (timeoutEnv) {

--- a/src/im/lark/ask-card.ts
+++ b/src/im/lark/ask-card.ts
@@ -20,6 +20,34 @@ export const ASK_TOGGLE_ACTION = 'ask_toggle';
 
 const MAX_BUTTONS_PER_ACTION_ROW = 4;
 
+/** Card-dispatch retry policy. A transient Feishu failure (5xx / network /
+ *  timeout) must NOT collapse the ask into `invalidated` — that unblocks the
+ *  CLI hook into passthrough, Claude renders its native picker, and the answer
+ *  channel is gone even though the card may well have posted. We retry with a
+ *  stable idempotency uuid (Feishu returns the original message_id for repeats
+ *  within a 1h TTL), so a partial success (card delivered, response errored)
+ *  recovers the real messageId instead of discarding the ask. */
+const CARD_DISPATCH_MAX_ATTEMPTS = 3;
+const CARD_DISPATCH_BASE_DELAY_MS = 400;
+
+/** Extract an HTTP-ish status from an SDK/Axios error across SDK versions. */
+function errorStatus(err: unknown): number | undefined {
+  const e = err as any;
+  return e?.response?.status ?? e?.response?.statusCode ?? e?.status ?? e?.statusCode;
+}
+
+/** Retry only when a retry could plausibly help: network errors (no status),
+ *  429, and 5xx. A definitive 4xx (e.g. 400 invalid_message_id, 403) will fail
+ *  identically on retry, so surface it immediately. */
+function isTransientDispatchError(err: unknown): boolean {
+  const status = errorStatus(err);
+  if (status === undefined) return true; // network / timeout / no HTTP response
+  if (status === 429) return true;
+  return status >= 500 && status <= 599;
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
 export interface AskCardActionData {
   operator?: { open_id?: string };
   action?: {
@@ -50,10 +78,34 @@ export function createLarkAskCardDispatcher(
       // 所以这里要按前缀判断是否真的能 reply.
       const canReplyToRoot =
         typeof ask.rootMessageId === 'string' && ask.rootMessageId.startsWith('om_');
-      const messageId = canReplyToRoot
-        ? await reply(ask.larkAppId, ask.rootMessageId!, cardJson, 'interactive', true)
-        : await send(ask.larkAppId, ask.chatId, cardJson, 'interactive');
-      return { messageId };
+      // Stable idempotency token: repeated attempts for the same ask dedupe on
+      // the Feishu server (1h TTL) so a retry after a partial success returns
+      // the ORIGINAL message_id instead of posting a duplicate card.
+      const uuid = `ask-${ask.askId}`;
+      let lastErr: unknown;
+      for (let attempt = 1; attempt <= CARD_DISPATCH_MAX_ATTEMPTS; attempt++) {
+        try {
+          const messageId = canReplyToRoot
+            ? await reply(ask.larkAppId, ask.rootMessageId!, cardJson, 'interactive', true, uuid)
+            : await send(ask.larkAppId, ask.chatId, cardJson, 'interactive', uuid);
+          return { messageId };
+        } catch (err) {
+          lastErr = err;
+          // A definitive (non-transient) error will fail identically on retry —
+          // surface it now so the ask is invalidated promptly (e.g. the chat is
+          // gone). Transient errors get a bounded, backed-off retry.
+          if (!isTransientDispatchError(err) || attempt === CARD_DISPATCH_MAX_ATTEMPTS) {
+            throw err;
+          }
+          logger.warn(
+            `[ask:${ask.askId}] card dispatch attempt ${attempt}/${CARD_DISPATCH_MAX_ATTEMPTS} ` +
+            `failed (transient, retrying): ${err instanceof Error ? err.message : String(err)}`,
+          );
+          await sleep(CARD_DISPATCH_BASE_DELAY_MS * attempt);
+        }
+      }
+      // Unreachable (loop either returns or throws), but satisfies the type checker.
+      throw lastErr;
     },
     async onSettle(ask, result) {
       if (!ask.cardMessageId) return;

--- a/test/ask-card.test.ts
+++ b/test/ask-card.test.ts
@@ -638,7 +638,9 @@ describe('createLarkAskCardDispatcher', () => {
     const dispatcher = createLarkAskCardDispatcher({ replyMessage: reply as any, sendMessage: send as any });
 
     await expect(dispatcher.send(makePending())).resolves.toEqual({ messageId: 'om_reply' });
-    expect(reply).toHaveBeenCalledWith('cli_ask', 'om_root', expect.any(String), 'interactive', true);
+    // A stable idempotency uuid (`ask-<askId>`) is passed so retries dedupe on
+    // the Feishu server instead of posting a duplicate card.
+    expect(reply).toHaveBeenCalledWith('cli_ask', 'om_root', expect.any(String), 'interactive', true, 'ask-ask-1');
     expect(send).not.toHaveBeenCalled();
   });
 
@@ -649,7 +651,7 @@ describe('createLarkAskCardDispatcher', () => {
     const ask = makePending({ rootMessageId: null, cardMessageId: 'om_card' });
 
     await expect(dispatcher.send(ask)).resolves.toEqual({ messageId: 'om_send' });
-    expect(send).toHaveBeenCalledWith('cli_ask', 'oc_chat', expect.any(String), 'interactive');
+    expect(send).toHaveBeenCalledWith('cli_ask', 'oc_chat', expect.any(String), 'interactive', 'ask-ask-1');
 
     await dispatcher.onSettle?.(ask, {
       kind: 'timedOut',
@@ -659,5 +661,54 @@ describe('createLarkAskCardDispatcher', () => {
       timedOut: true,
     });
     expect(update).toHaveBeenCalledWith('cli_ask', 'om_card', expect.stringContaining('超时'));
+  });
+
+  // ── Dispatch resilience: a transient Feishu failure must NOT bubble out of
+  //    send() (which would invalidate the ask → hook passthrough → stuck native
+  //    picker). It retries with the same idempotency uuid and recovers. ──────
+  it('retries a transient 500 and recovers the messageId (idempotent uuid reused)', async () => {
+    const err500 = Object.assign(new Error('Request failed with status code 500'), {
+      response: { status: 500 },
+    });
+    const reply = vi
+      .fn()
+      .mockRejectedValueOnce(err500) // partial-success shape: card may have posted, response errored
+      .mockResolvedValueOnce('om_reply');
+    const dispatcher = createLarkAskCardDispatcher({ replyMessage: reply as any });
+
+    await expect(dispatcher.send(makePending())).resolves.toEqual({ messageId: 'om_reply' });
+    expect(reply).toHaveBeenCalledTimes(2);
+    // Same idempotency uuid on both attempts → Feishu dedupes, no duplicate card.
+    expect(reply.mock.calls[0]![5]).toBe('ask-ask-1');
+    expect(reply.mock.calls[1]![5]).toBe('ask-ask-1');
+  });
+
+  it('retries a network error (no HTTP status) then succeeds', async () => {
+    const netErr = Object.assign(new Error('ECONNRESET'), { code: 'ECONNRESET' });
+    const send = vi.fn().mockRejectedValueOnce(netErr).mockResolvedValueOnce('om_send');
+    const dispatcher = createLarkAskCardDispatcher({ sendMessage: send as any });
+
+    await expect(
+      dispatcher.send(makePending({ rootMessageId: null })),
+    ).resolves.toEqual({ messageId: 'om_send' });
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT retry a definitive 4xx — throws immediately so a dead chat invalidates promptly', async () => {
+    const err400 = Object.assign(new Error('invalid message_id'), { response: { status: 400 } });
+    const reply = vi.fn().mockRejectedValue(err400);
+    const dispatcher = createLarkAskCardDispatcher({ replyMessage: reply as any });
+
+    await expect(dispatcher.send(makePending())).rejects.toBe(err400);
+    expect(reply).toHaveBeenCalledTimes(1); // no retry on a permanent error
+  });
+
+  it('gives up after the attempt cap and rethrows the last transient error', async () => {
+    const err503 = Object.assign(new Error('unavailable'), { response: { status: 503 } });
+    const reply = vi.fn().mockRejectedValue(err503);
+    const dispatcher = createLarkAskCardDispatcher({ replyMessage: reply as any });
+
+    await expect(dispatcher.send(makePending())).rejects.toBe(err503);
+    expect(reply).toHaveBeenCalledTimes(3); // CARD_DISPATCH_MAX_ATTEMPTS
   });
 });

--- a/test/cmd-hook.test.ts
+++ b/test/cmd-hook.test.ts
@@ -182,6 +182,21 @@ describe('runHook', () => {
     });
   });
 
+  describe('ask timeoutMs 默认值（防止过早超时退化成原生 picker）', () => {
+    // ask 超时不是良性兜底：broker settle 成 timedOut → hook passthrough →
+    // Claude 渲染原生 picker，此后飞书回调无通道送回答案。默认值必须足够长
+    // （对齐 hook 安装侧 86400s 进程超时），避免"人回复慢→picker 卡死"。
+    it('未设 BOTMUX_ASK_TIMEOUT_MS → body.timeoutMs 默认 24h', async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      const captureStub = async (body: Record<string, unknown>) => {
+        capturedBody = body;
+        return { kind: 'answered' as const, answers: [['继续']], by: 'ou_u', comment: null, timedOut: false };
+      };
+      await runHook(claudeAskPayload, FULL_ENV, captureStub, 'claude-code');
+      expect(capturedBody?.timeoutMs).toBe(86_400_000);
+    });
+  });
+
   describe('env 缺失 + adopt 路由返回 null → passthrough', () => {
     // Codex 钉桩：祖先里有非 adopt PID、daemon 全 404（resolver 返回 null）时，
     // 必须既不调用 postAsk、stdout 又为空——确保"真·非 botmux 会话"完全不受影响。
@@ -259,7 +274,7 @@ describe('runHook', () => {
       expect(capturedBody?.timeoutMs).toBe(7_200_000);
     });
 
-    it('无效值 → 使用默认 3600000', async () => {
+    it('无效值 → 回退到默认（24h，对齐 hook 进程超时上限）', async () => {
       let capturedBody: Record<string, unknown> | undefined;
       const captureStub = async (body: Record<string, unknown>): Promise<AskResult> => {
         capturedBody = body;
@@ -267,7 +282,7 @@ describe('runHook', () => {
       };
       const env = { ...FULL_ENV, BOTMUX_ASK_TIMEOUT_MS: 'not_a_number' };
       await runHook(claudeAskPayload, env, captureStub, 'claude-code');
-      expect(capturedBody?.timeoutMs).toBe(3_600_000);
+      expect(capturedBody?.timeoutMs).toBe(86_400_000);
     });
   });
 


### PR DESCRIPTION
## 问题

飞书 AskUserQuestion 卡片答完、CLI 却仍挂在原生选择器、答案不生效(卡片报"此 ask 已失效")。

根因:`runHook`(cli.ts)只有 `result.kind==='answered'` 才回 directive;其余任何结局(`timedOut` / `invalidated` / postAsk 抛错)一律 `passthrough` → Claude 转而渲染**原生 picker**,而此后飞书回调已无阻塞的 hook 通道把答案送回 → picker 挂死。

其中一个高频触发:ask-broker 发卡是 fire-and-forget,发卡 Promise 一旦 reject 就立即 `settle(kind:'invalidated')`(`ask-broker.ts` card-dispatch `.catch`)。但**飞书 API 抛错 ≠ 卡片没投出**——500/超时常是 partial success(卡片已送达、仅响应报错),此时 ask 被误作废,而群里那张卡仍可点、却喂不回答案。生产 daemon 日志有反复的飞书 500 佐证此路径。

## 改动(对准共性:减少非 answered 的 settle)

1. **`src/im/lark/ask-card.ts`——发卡有界重试 + 幂等 uuid**:`createLarkAskCardDispatcher.send` 改为最多 3 次退避重试,传稳定幂等 uuid `ask-<askId>`(飞书对 1h TTL 内重复请求返回原 message_id → 重试不会重复发卡,partial success 能拿回真实 message_id 而非作废整个 ask)。仅对瞬时错误(无 HTTP status 的网络错 / 429 / 5xx)重试;确定性 4xx(如 400 invalid_message_id、403)立即抛出,让死群尽快作废。
2. **`src/cli.ts`——runHook 默认超时 1h → 24h**(`DEFAULT_TIMEOUT_MS=86_400_000`,对齐 hook 安装侧 `settings.json` 里的 `timeout:86400`s 进程上限):避免"人回复慢→超时→passthrough→picker 卡死";保留有限进程级兜底(永不超时会让一次 CLI turn 无限阻塞,是更糟的失败)。`BOTMUX_ASK_TIMEOUT_MS` 覆盖不变。

## 影响面

仅 ask 卡投递 + 超时默认;不动会话/CLI/后端逻辑。仅 claude 家族走 hook directive 受益;coco 仍走 native picker 按键驱动(daemon 独立分支,`daemon.ts` 的 `coco_drive_picker`)不受影响。发卡 dispatcher 唯一 caller 是 `daemon.ts` 的 `setAskCardDispatcher(createLarkAskCardDispatcher())` + `ask-broker.ts` 的 `.send(snapshot(ask))`,改动收敛。幂等 uuid `ask-<randomUUID>` 长 40 字符 < 飞书 50 限;对 interactive 消息类型生效。

## 验证

- `pnpm build` 通过
- 隔离跑 `test/ask-card.test.ts` + `test/cmd-hook.test.ts` 全绿(新增 4 例发卡韧性:瞬时 500 重试恢复 / 网络错重试 / 确定 4xx 不重试立即抛 / 超上限重抛;+ 幂等 uuid 断言 + 超时默认 24h/override 断言;顺带把 pre-existing"无效值→3600000"用例改为 86400000)
- `pnpm test` 全量:唯一非通过为已知墙钟计时 flake(hook-runner 类)+ 无浏览器/CLI 环境的 e2e baseline(coco/codex/multi-bot),隔离复跑绿,与本改动零耦合

## 已知未覆盖(独立 follow-up)

"弹卡后重启 daemon"场景:broker 纯内存无持久化,重启即丢 pending ask → hook fetch reject → passthrough → picker。需 broker 持久化/重启重连,是更大的独立一步,不在本 PR 范围。
