### PR TITLE
fix(ask): AskUserQuestion 卡片扛住 daemon 重启（存盘 restore + hook 重连接回）

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9558,6 +9558,10 @@ async function cmdAsk(sub: string, rest: string[]): Promise<void> {
     options,
     prompt,
     timeoutMs,
+    // Explicit `botmux ask buttons` has no reconnecting claimant (the CLI exits
+    // on daemon restart), so mark it non-hook: the broker won't persist/handoff
+    // it and can never confuse it with a hook ask's card (codex P1-4/P1-3).
+    originKind: 'explicit',
     ...(liveAskOrigin?.turnId ? { originTurnId: liveAskOrigin.turnId } : {}),
     ...(liveAskOrigin?.dispatchAttempt !== undefined
       ? { originDispatchAttempt: liveAskOrigin.dispatchAttempt }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -120,6 +120,7 @@ import {
   readWorkflowSessionRelayContext,
 } from './workflows/v3/session-relay-client.js';
 import { fetchDaemonIpc, loadDaemonIpcSecret } from './core/daemon-ipc-auth.js';
+import { isRetryableAskHttpStatus } from './core/ask-types.js';
 import { readManagedOriginCapability } from './core/managed-origin-capability.js';
 import { rejectLikelyWindowsStdinMojibake, decodeStdinBytes } from './cli/stdin-encoding.js';
 import {
@@ -9462,7 +9463,8 @@ async function postAsk(body: Record<string, unknown>): Promise<import('./core/as
     // Only transient server states are retryable. A deterministic 4xx (bad
     // body, capability denied, unsupported chat) will fail identically forever;
     // 502/503/504 mean the daemon is up but not ready (startup window) → retry.
-    const retryable = res.status === 502 || res.status === 503 || res.status === 504;
+    // Shared pure classifier (unit-tested directly — codex P1-3 seam).
+    const retryable = isRetryableAskHttpStatus(res.status);
     throw mkErr(`botmux ask: daemon HTTP ${res.status}: ${errBody}`, retryable);
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9696,8 +9696,14 @@ export async function runHook(
     routeRoot = adopt.rootMessageId;
   }
 
-  // 解析 timeoutMs：默认 1 小时，可由 BOTMUX_ASK_TIMEOUT_MS 覆盖
-  const DEFAULT_TIMEOUT_MS = 3_600_000;
+  // 解析 timeoutMs：默认 ~24h，可由 BOTMUX_ASK_TIMEOUT_MS 覆盖。
+  // 为什么这么长：ask 超时不是良性兜底——broker settle 成 `timedOut` 会让 hook
+  // 落到 passthrough，Claude 转而渲染原生 picker，而此后飞书回调已无通道把答案
+  // 送回（picker 挂死、答案不生效）。所以默认值对齐 hook 安装侧的进程超时上限
+  // （settings.json 里的 86400s），让 broker 不会 *早于* hook 进程本身超时；
+  // 既避免"人回复慢→picker 卡死"，又保留一个有限的进程级兜底（永不超时会让一次
+  // CLI turn 无限阻塞，是更糟的失败）。
+  const DEFAULT_TIMEOUT_MS = 86_400_000; // 24h — 对齐 hook 安装侧 timeout:86400s
   let timeoutMs = DEFAULT_TIMEOUT_MS;
   const timeoutEnv = env.BOTMUX_ASK_TIMEOUT_MS;
   if (timeoutEnv) {
@@ -9716,12 +9722,39 @@ export async function runHook(
     timeoutMs,
   };
 
-  let result: import('./core/ask-types.js').AskResult;
-  try {
-    result = await postAskFn(body);
-  } catch {
-    // 任何失败（daemon 不可达、HTTP 错误等）→ passthrough 放行
-    return { stdout: adapter.passthrough(payload) };
+  // Post the ask, RETRYING across a daemon restart. The daemon holds pending
+  // asks in memory only, so a restart between "card posted" and "user clicked"
+  // drops the ask; historically postAskFn then threw (daemon unreachable) and
+  // we fell straight to passthrough → the CLI rendered its native picker with no
+  // way to receive the answer. Instead: while the daemon is unreachable (and
+  // only then — an answered/timedOut/invalidated result returns normally), keep
+  // reconnecting until the ask's own deadline. The daemon restores the pending
+  // ask from disk on boot and re-attaches this reconnecting request to it by a
+  // stable key, so the SAME card resolves through the normal hook directive.
+  // Blocking here keeps Claude spinning; the native picker never renders.
+  const deadline = Date.now() + timeoutMs;
+  let result: import('./core/ask-types.js').AskResult | undefined;
+  let attempt = 0;
+  while (true) {
+    try {
+      result = await postAskFn(body);
+      break;
+    } catch (err) {
+      // exitCode 3 = daemon unreachable / transport error (see postAsk). That is
+      // the restart-in-progress case → retry. Anything else (or a non-coded
+      // throw) is not something a retry fixes → passthrough as before.
+      const code = (err as { exitCode?: number } | undefined)?.exitCode;
+      if (code !== 3 || Date.now() >= deadline) {
+        return { stdout: adapter.passthrough(payload) };
+      }
+      attempt++;
+      // Backoff: quick first reconnects (daemon usually returns in a few
+      // seconds), capped at 5s. Never sleep past the deadline.
+      const backoff = Math.min(5_000, 500 * attempt);
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) return { stdout: adapter.passthrough(payload) };
+      await new Promise((r) => setTimeout(r, Math.min(backoff, remaining)));
+    }
   }
 
   if (result.kind === 'answered') {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { createInterface } from 'node:readline';
 import { createRequire } from 'node:module';
-import { randomBytes } from 'node:crypto';
+import { randomBytes, randomUUID } from 'node:crypto';
 import { validateWorkingDir } from './core/working-dir.js';
 import { resolveSessionContext } from './core/session-marker.js';
 import { resolveBotmuxDataDir } from './core/data-dir.js';
@@ -9402,20 +9402,24 @@ botmux create-group — 用一组机器人新建飞书群
 
 /**
  * postAsk: 找到 daemon → POST /api/asks → 返回 AskResult。
- * 连接失败 / HTTP 错误时抛出带 exitCode 属性的 Error：
- *   - exitCode=3：daemon 不可达或 HTTP 错误
+ * 连接失败 / HTTP 错误时抛出带 `exitCode` + `retryable` 属性的 Error：
+ *   - exitCode=3：daemon 不可达或 HTTP 错误（保持向后兼容）
+ *   - retryable=true：仅当 daemon 不可达 / 网络失败 / 明确的 transient HTTP
+ *     (502/503/504，含 daemon 启动尚未就绪) 时。这些正是"daemon 重启中"的信号,
+ *     runHook 会重连重试。确定性 4xx（bad body / capability 拒绝 / unsupported)
+ *     与非 JSON 是 retryable=false —— 重试 24h 也不会变,应立即 passthrough。
  */
 async function postAsk(body: Record<string, unknown>): Promise<import('./core/ask-types.js').AskResult> {
   type AskResult = import('./core/ask-types.js').AskResult;
+  type AskError = Error & { exitCode: number; retryable: boolean };
+  const mkErr = (message: string, retryable: boolean): AskError =>
+    Object.assign(new Error(message), { exitCode: 3, retryable });
 
   const larkAppId = body.larkAppId as string;
   const daemon = findDaemon(larkAppId);
   if (!daemon) {
-    const err = new Error(
-      `botmux ask: 找不到 daemon (larkAppId=${larkAppId})。daemon 已停？exit 3.`,
-    ) as Error & { exitCode: number };
-    err.exitCode = 3;
-    throw err;
+    // No daemon record → it's (re)starting or momentarily gone → retryable.
+    throw mkErr(`botmux ask: 找不到 daemon (larkAppId=${larkAppId})。daemon 已停？exit 3.`, true);
   }
 
   let res: Response;
@@ -9447,28 +9451,26 @@ async function postAsk(body: Record<string, unknown>): Promise<import('./core/as
       ? await fetchDaemonIpc(daemon.ipcPort, '/api/asks', init, hostSecret)
       : await fetch(`http://127.0.0.1:${daemon.ipcPort}/api/asks`, init);
   } catch (fetchErr) {
+    // Socket refused / reset / timeout → daemon is down or restarting → retryable.
     const msg = fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
-    const err = new Error(
-      `botmux ask: 无法连接 daemon (port=${daemon.ipcPort}): ${msg}`,
-    ) as Error & { exitCode: number };
-    err.exitCode = 3;
-    throw err;
+    throw mkErr(`botmux ask: 无法连接 daemon (port=${daemon.ipcPort}): ${msg}`, true);
   }
 
   if (!res.ok) {
     let errBody = '';
     try { errBody = (await res.text()).slice(0, 200); } catch { /* */ }
-    const err = new Error(`botmux ask: daemon HTTP ${res.status}: ${errBody}`) as Error & { exitCode: number };
-    err.exitCode = 3;
-    throw err;
+    // Only transient server states are retryable. A deterministic 4xx (bad
+    // body, capability denied, unsupported chat) will fail identically forever;
+    // 502/503/504 mean the daemon is up but not ready (startup window) → retry.
+    const retryable = res.status === 502 || res.status === 503 || res.status === 504;
+    throw mkErr(`botmux ask: daemon HTTP ${res.status}: ${errBody}`, retryable);
   }
 
   try {
     return (await res.json()) as AskResult;
   } catch (jsonErr) {
-    const err = new Error(`botmux ask: daemon 返回非 JSON: ${jsonErr}`) as Error & { exitCode: number };
-    err.exitCode = 3;
-    throw err;
+    // A malformed body is not something a retry fixes.
+    throw mkErr(`botmux ask: daemon 返回非 JSON: ${jsonErr}`, false);
   }
 }
 
@@ -9713,6 +9715,12 @@ export async function runHook(
     }
   }
 
+  // Per-invocation identity: generated ONCE here (outside the retry loop) and
+  // reused across every reconnect POST, so a re-POST after a daemon restart
+  // re-attaches to the same restored ask instead of posting a duplicate card.
+  // originKind='hook' namespaces it away from an explicit `botmux ask buttons`.
+  const requestId = randomUUID();
+
   const body: Record<string, unknown> = {
     sessionId: routeSessionId,
     chatId: routeChatId,
@@ -9720,6 +9728,8 @@ export async function runHook(
     rootMessageId: routeRoot,
     questions: parsed.questions,
     timeoutMs,
+    requestId,
+    originKind: 'hook',
   };
 
   // Post the ask, RETRYING across a daemon restart. The daemon holds pending
@@ -9740,11 +9750,14 @@ export async function runHook(
       result = await postAskFn(body);
       break;
     } catch (err) {
-      // exitCode 3 = daemon unreachable / transport error (see postAsk). That is
-      // the restart-in-progress case → retry. Anything else (or a non-coded
-      // throw) is not something a retry fixes → passthrough as before.
-      const code = (err as { exitCode?: number } | undefined)?.exitCode;
-      if (code !== 3 || Date.now() >= deadline) {
+      // Retry ONLY genuinely transient failures (daemon unreachable / network /
+      // 502-503-504 startup-not-ready — see postAsk's `retryable`). That is the
+      // restart-in-progress case. A deterministic error (4xx bad body /
+      // capability / unsupported, non-JSON) has retryable=false → passthrough
+      // immediately rather than spin for 24h. A non-coded throw is also treated
+      // as non-retryable.
+      const retryable = (err as { retryable?: boolean } | undefined)?.retryable === true;
+      if (!retryable || Date.now() >= deadline) {
         return { stdout: adapter.passthrough(payload) };
       }
       attempt++;

--- a/src/core/ask-api.ts
+++ b/src/core/ask-api.ts
@@ -16,6 +16,13 @@ export interface AskApiBody {
   questions: AskQuestion[];
   /** Already in milliseconds. CLI side converts from `--timeout` seconds. */
   timeoutMs: number;
+  /** Per-invocation identity (hook generates once, reuses across reconnect
+   *  retries) so a re-POST after a daemon restart re-attaches to the same ask.
+   *  Optional — legacy callers omit it and the broker synthesizes one. */
+  requestId?: string;
+  /** Caller kind ('hook' | 'explicit' | …) namespacing the identity so an
+   *  explicit `botmux ask` can't re-claim a hook ask's card. Optional. */
+  originKind?: string;
 }
 
 export type AskApiBodyError =
@@ -33,7 +40,9 @@ export type AskApiBodyError =
   | 'duplicate_option_key'
   | 'bad_questions'
   | 'bad_question_shape'
-  | 'bad_multiSelect';
+  | 'bad_multiSelect'
+  | 'bad_requestId'
+  | 'bad_originKind';
 
 /** 校验单个 option 对象，返回解析后的 AskOption 或错误码。 */
 function parseOption(o: unknown): AskOption | AskApiBodyError {
@@ -91,6 +100,22 @@ export function parseAskBody(raw: unknown): AskApiBody | { error: AskApiBodyErro
   ) {
     return { error: 'bad_timeoutMs' };
   }
+  // Optional invocation identity. When present, must be a sane short string
+  // (used verbatim as a persistence filename segment after sanitization).
+  let requestId: string | undefined;
+  if (r.requestId !== undefined) {
+    if (typeof r.requestId !== 'string' || !r.requestId.trim() || r.requestId.length > 128) {
+      return { error: 'bad_requestId' };
+    }
+    requestId = r.requestId;
+  }
+  let originKind: string | undefined;
+  if (r.originKind !== undefined) {
+    if (typeof r.originKind !== 'string' || !r.originKind.trim() || r.originKind.length > 32) {
+      return { error: 'bad_originKind' };
+    }
+    originKind = r.originKind;
+  }
 
   let questions: AskQuestion[];
 
@@ -128,5 +153,7 @@ export function parseAskBody(raw: unknown): AskApiBody | { error: AskApiBodyErro
     rootMessageId: r.rootMessageId as string | null,
     questions,
     timeoutMs: r.timeoutMs,
+    ...(requestId !== undefined ? { requestId } : {}),
+    ...(originKind !== undefined ? { originKind } : {}),
   };
 }

--- a/src/core/ask-broker.ts
+++ b/src/core/ask-broker.ts
@@ -12,10 +12,8 @@ import { randomUUID } from 'node:crypto';
 
 import { logger } from '../utils/logger.js';
 import {
-  computeAskKey,
-  listPersistedAsks,
-  persistAsk,
-  removePersistedAsk,
+  askKeyFor,
+  type AskPersistStore,
   type PersistedAsk,
 } from './ask-persist-store.js';
 import type {
@@ -27,10 +25,14 @@ import type {
 } from './ask-types.js';
 
 interface InternalPending extends Omit<PendingAsk, 'selections'> {
-  /** Stable cross-restart identity (sessionId + questions hash). Used to
-   *  re-attach a reconnecting hook to its own restored ask, and as the
-   *  persistence filename key. */
+  /** Stable cross-restart identity = `${originKind}.${requestId}` (see
+   *  ask-persist-store). Re-attaches a reconnecting hook to its own restored
+   *  ask, and is the persistence filename key. */
   askKey: string;
+  /** Per-invocation id (hook generates once, reuses across reconnect retries). */
+  requestId: string;
+  /** Caller kind ('hook' | 'explicit' | …) namespacing the identity. */
+  originKind: string;
   /** Waiter Promise resolver. Absent on a dormant (restored, unclaimed) ask —
    *  a click can still settle its card, but there is no CLI turn to resolve
    *  until a reconnecting hook re-attaches one. */
@@ -41,12 +43,22 @@ interface InternalPending extends Omit<PendingAsk, 'selections'> {
   /**
    * Restored from disk after a daemon restart but not yet re-claimed by a
    * reconnecting hook: the card is still live in Feishu, but there is no waiter
-   * Promise to resolve. A click on a dormant ask records selections/settles the
-   * card, and the answer is delivered when the hook re-registers (which flips
-   * dormant → active by attaching a fresh resolve). No timeout runs while
-   * dormant except the absolute-deadline sweep.
+   * Promise to resolve. Two dormant sub-cases:
+   *  - awaiting a click: a click records selections and produces a terminal
+   *    result that is stashed in `answeredResult` (NOT delivered/deleted yet).
+   *  - already answered while dormant: `answeredResult` is set; the record is
+   *    kept until the reconnecting hook claims it.
+   * Re-attach (hook re-register with the same key) flips dormant → active: if an
+   * answer is already stashed it is delivered immediately (0 new card); else a
+   * fresh waiter + deadline timer are installed.
    */
   dormant?: boolean;
+  /**
+   * A terminal result that arrived while the ask was dormant (user clicked
+   * before the hook reconnected). Held here — the durable handoff — so the
+   * reconnecting hook can claim it. Delivered + cleared on re-attach.
+   */
+  answeredResult?: AskResult;
   /**
    * 按问题序号（questionIndex）累积的勾选 key 集合。
    * 单选问题（multiSelect:false）Set 内最多保留 1 个 key。
@@ -57,6 +69,18 @@ interface InternalPending extends Omit<PendingAsk, 'selections'> {
 
 const pending = new Map<string, InternalPending>();
 let dispatcher: AskCardDispatcher | null = null;
+
+/** Injected durable store (codex P1-4: no global-dataDir reads from the broker).
+ *  Wired once at daemon bootstrap via setAskPersistStore; null → persistence is
+ *  a no-op (unit tests that don't exercise restart-resume需要绑定各自 temp
+ *  store，绝不回落到全局目录). */
+let persistStore: AskPersistStore | null = null;
+
+/** Wire the durable persist store. Called once at daemon bootstrap with the
+ *  real dir; tests inject a temp store (and only clean their own sentinel dir). */
+export function setAskPersistStore(store: AskPersistStore | null): void {
+  persistStore = store;
+}
 
 /** Optional actor context for the talk check. Card-click paths (toggle/submit)
  *  omit it — Lark card-action callbacks carry no sender union / bot flag, so the
@@ -131,16 +155,22 @@ export function registerAsk(input: CreateAskInput): Promise<AskResult> {
     throw new Error('ask-broker: cardDispatcher not wired — daemon bootstrap bug');
   }
 
-  const askKey = computeAskKey(input.sessionId, input.questions);
+  // Invocation identity: prefer the caller-supplied requestId (hook generates it
+  // once and reuses it across reconnect retries) so a re-POST after a restart
+  // re-attaches. Legacy/explicit callers without one get a synthesized id — they
+  // simply won't cross-restart-resume, which is the pre-existing behaviour.
+  const requestId = input.requestId ?? randomUUID();
+  const originKind = input.originKind ?? 'hook';
+  const askKey = askKeyFor(originKind, requestId);
 
-  // Re-attach path: a hook reconnecting after a daemon restart re-POSTs the
-  // same ask. If we restored a dormant entry with this key (card still live in
-  // Feishu), attach a fresh waiter + timeout to it instead of posting a second
-  // card. The user's click — whenever it lands — resolves this new Promise, so
-  // the answer flows back through the normal hook directive.
+  // Re-attach path: a hook reconnecting after a daemon restart re-POSTs the same
+  // ask (same requestId). If a dormant entry with this key exists (card still
+  // live in Feishu), attach to it instead of posting a second card — and if the
+  // user already answered while it was dormant, deliver that stashed answer
+  // immediately (codex P1-1).
   const existing = findDormantByKey(askKey);
   if (existing) {
-    return reattachDormantAsk(existing, input);
+    return reattachDormantAsk(existing);
   }
 
   const askId = randomUUID();
@@ -170,6 +200,8 @@ export function registerAsk(input: CreateAskInput): Promise<AskResult> {
     const ask: InternalPending = {
       askId,
       askKey,
+      requestId,
+      originKind,
       nonce,
       larkAppId: input.larkAppId,
       chatId: input.chatId,
@@ -186,58 +218,95 @@ export function registerAsk(input: CreateAskInput): Promise<AskResult> {
     };
     pending.set(askId, ask);
     // Persist immediately so a restart before the card even lands still leaves a
-    // resumable record (its cardMessageId fills in once dispatch resolves).
+    // resumable record (its cardMessageId fills in once dispatch resolves; until
+    // then restore/re-attach re-sends the card — codex P1-2).
     persistFromInternal(ask);
     logger.info?.(`ask-broker: registered + persisted ask ${askId} (key=${askKey}, session=${input.sessionId})`);
 
-    // Card dispatch is async — store the messageId once it lands.
-    void dispatcher!
-      .send(snapshot(ask))
-      .then(({ messageId }) => {
-        const cur = pending.get(askId);
-        if (cur && !cur.settled) {
-          cur.cardMessageId = messageId;
-          // Re-persist so a restart after the card lands can patch the exact
-          // card on settle and knows it was already delivered.
-          persistFromInternal(cur);
-        }
-      })
-      .catch((err) => {
-        const msg = err instanceof Error ? err.message : String(err);
-        logger.warn?.(`ask-broker: ${askId} card dispatch failed: ${msg}`);
-        settle(askId, {
-          kind: 'invalidated',
-          reason: `card dispatch failed: ${msg}`,
-          selected: null,
-          by: null,
-          comment: null,
-          timedOut: false,
-        });
-      });
+    // Card dispatch is async — the dispatcher dedupes by requestId so a re-send
+    // (restore/re-attach after a restart in this window) can't double-post.
+    void sendCardForAsk(ask);
   });
 }
 
-/** Find a dormant (restored-but-unclaimed) ask by its stable key. Only dormant
- *  entries are re-attachable — an active ask with a live waiter must never be
- *  hijacked by a second registration. */
+/** Dispatch (or idempotently re-dispatch) the card for an ask and record its
+ *  messageId. The dispatcher uses the ask's requestId as the Feishu idempotency
+ *  uuid, so a re-send after a restart (when a prior send may have partially
+ *  succeeded) returns the original message_id rather than posting a duplicate
+ *  (codex P1-2). On a hard dispatch failure the ask is invalidated. */
+function sendCardForAsk(ask: InternalPending): void {
+  void dispatcher!
+    .send(snapshot(ask))
+    .then(({ messageId }) => {
+      const cur = pending.get(ask.askId);
+      if (cur && !cur.settled) {
+        cur.cardMessageId = messageId;
+        // Re-persist so a later restart knows the card is delivered (and can
+        // patch the exact card on settle).
+        persistFromInternal(cur);
+      }
+    })
+    .catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn?.(`ask-broker: ${ask.askId} card dispatch failed: ${msg}`);
+      settle(ask.askId, {
+        kind: 'invalidated',
+        reason: `card dispatch failed: ${msg}`,
+        selected: null,
+        by: null,
+        comment: null,
+        timedOut: false,
+      });
+    });
+}
+
+/** Find a re-attachable ask by its stable key. Re-attachable = a dormant entry
+ *  (restored after a restart), whether still awaiting a click OR already carrying
+ *  a stashed answer (settled-while-dormant — the durable handoff). An ACTIVE ask
+ *  with a live waiter is never matched: it must not be hijacked by a second
+ *  registration. */
 function findDormantByKey(askKey: string): InternalPending | undefined {
   for (const ask of pending.values()) {
-    if (ask.askKey === askKey && ask.dormant && !ask.settled) return ask;
+    if (ask.askKey !== askKey || !ask.dormant) continue;
+    // dormant + awaiting click (not settled), OR dormant + stashed answer.
+    if (!ask.settled || ask.answeredResult) return ask;
   }
   return undefined;
 }
 
-/** Re-attach a reconnecting hook to a restored dormant ask: keep its card,
- *  nonce, and accumulated selections, but install a fresh waiter Promise and
- *  a timeout re-armed to the ORIGINAL absolute deadline. Flips dormant → active. */
-function reattachDormantAsk(ask: InternalPending, input: CreateAskInput): Promise<AskResult> {
+/**
+ * Re-attach a reconnecting hook to a restored dormant ask. Flips dormant →
+ * active. Two cases:
+ *  - answer already stashed (user clicked before the hook reconnected): resolve
+ *    immediately with the durable-handoff result, mark settled, and remove the
+ *    persisted record (codex P1-1). No new card, no new timer.
+ *  - still awaiting a click: install a fresh waiter + timeout re-armed to the
+ *    ORIGINAL absolute deadline; if the card was never confirmed sent, re-send
+ *    it (idempotent by requestId) so the user has exactly one live card.
+ */
+function reattachDormantAsk(ask: InternalPending): Promise<AskResult> {
+  // Case 1: durable handoff — answer arrived while dormant.
+  if (ask.answeredResult) {
+    const result = ask.answeredResult;
+    ask.dormant = false;
+    ask.settled = true;
+    ask.settledAt = Date.now();
+    clearTimeout(ask.timeoutHandle);
+    persistStore?.remove(ask.askKey); // claimed → durable record no longer needed
+    gcSettled();
+    logger.info?.(
+      `ask-broker: re-attach delivered stashed answer for ask ${ask.askId} (key=${ask.askKey})`,
+    );
+    return Promise.resolve(result);
+  }
+
+  // Case 2: still awaiting a click.
   return new Promise<AskResult>((resolve) => {
     ask.dormant = false;
     ask.resolve = resolve;
-    // Replace the dormant-phase deadline timer (armed by restorePersistedAsks)
-    // rather than leaking it — settle is idempotent, but two live timers is
-    // sloppy. Re-arm to the surviving absolute deadline (not a fresh full
-    // timeout — the clock kept running while the daemon was down).
+    // Replace the dormant-phase deadline timer rather than leaking it. Re-arm to
+    // the surviving absolute deadline (not a fresh full timeout — the clock kept
+    // running while the daemon was down).
     clearTimeout(ask.timeoutHandle);
     const remaining = Math.max(0, ask.deadlineAt - Date.now());
     ask.timeoutHandle = setTimeout(() => {
@@ -248,20 +317,26 @@ function reattachDormantAsk(ask: InternalPending, input: CreateAskInput): Promis
     ask.timeoutHandle.unref?.();
     logger.info?.(
       `ask-broker: re-attached hook to restored ask ${ask.askId} (key=${ask.askKey}, ` +
-      `${Math.round(remaining / 1000)}s left)`,
+      `${Math.round(remaining / 1000)}s left, card=${ask.cardMessageId ? 'live' : 'MISSING→resend'})`,
     );
-    // sessionId/chatId are identity-stable across the reconnect; input is only
-    // used for the key match, which already succeeded. Nothing else to copy.
-    void input;
+    // Card was never confirmed sent before the restart — send it now so the user
+    // has a card to click (idempotent by requestId; a partial-success prior send
+    // returns the same message_id).
+    if (!ask.cardMessageId) sendCardForAsk(ask);
   });
 }
 
 /** Build the persisted projection from a live internal ask and write it. */
 function persistFromInternal(ask: InternalPending): void {
-  if (ask.settled) return;
+  if (!persistStore) return;
+  // A settled ask with a stashed answer is a durable handoff that must be KEPT
+  // until claimed; a settled ask without one has nothing left to resume.
+  if (ask.settled && !ask.answeredResult) return;
   const persisted: PersistedAsk = {
-    v: 1,
+    v: 2,
     askKey: ask.askKey,
+    requestId: ask.requestId,
+    originKind: ask.originKind,
     askId: ask.askId,
     nonce: ask.nonce,
     larkAppId: ask.larkAppId,
@@ -274,8 +349,9 @@ function persistFromInternal(ask: InternalPending): void {
     deadlineAt: ask.deadlineAt,
     cardMessageId: ask.cardMessageId,
     selections: ask.questions.map((_, i) => [...(ask.selections.get(i) ?? new Set<string>())]),
+    ...(ask.answeredResult ? { answeredResult: ask.answeredResult } : {}),
   };
-  persistAsk(persisted);
+  persistStore.put(persisted);
 }
 
 /**
@@ -516,7 +592,11 @@ export function invalidateAll(reason: string): number {
  */
 export function restorePersistedAsks(now: number = Date.now(), larkAppId?: string): number {
   let restored = 0;
-  for (const p of listPersistedAsks(now)) {
+  if (!persistStore) {
+    logger.info?.('ask-broker: restore sweep skipped — no persist store wired');
+    return 0;
+  }
+  for (const p of persistStore.list(now)) {
     // One bot per daemon process: only restore asks this daemon can actually
     // serve (its own bot's sessions). Another bot's daemon owns the rest.
     if (larkAppId && p.larkAppId !== larkAppId) continue;
@@ -540,6 +620,8 @@ export function restorePersistedAsks(now: number = Date.now(), larkAppId?: strin
     const ask: InternalPending = {
       askId: p.askId,
       askKey: p.askKey,
+      requestId: p.requestId,
+      originKind: p.originKind,
       nonce: p.nonce,
       larkAppId: p.larkAppId,
       chatId: p.chatId,
@@ -552,6 +634,9 @@ export function restorePersistedAsks(now: number = Date.now(), larkAppId?: strin
       cardMessageId: p.cardMessageId,
       settled: false,
       dormant: true,
+      // Carry a stashed answer forward (user answered before restart): the
+      // reconnecting hook claims it via reattachDormantAsk.
+      ...(p.answeredResult ? { answeredResult: p.answeredResult } : {}),
       // No resolve yet — attached when the reconnecting hook re-registers.
       timeoutHandle,
       selections,
@@ -560,7 +645,7 @@ export function restorePersistedAsks(now: number = Date.now(), larkAppId?: strin
     restored++;
     logger.info?.(
       `ask-broker: restored pending ask ${p.askId} (key=${p.askKey}, session=${p.sessionId}, ` +
-      `dormant, ${Math.round((p.deadlineAt - now) / 1000)}s left) — awaiting hook re-attach`,
+      `dormant${p.answeredResult ? '+answered' : ''}, ${Math.round((p.deadlineAt - now) / 1000)}s left) — awaiting hook re-attach`,
     );
   }
   // Always log the boot sweep outcome (even 0) so a live restart test can
@@ -579,18 +664,37 @@ export function restorePersistedAsks(now: number = Date.now(), larkAppId?: strin
 function settle(askId: string, result: AskResult): void {
   const ask = pending.get(askId);
   if (!ask || ask.settled) return;
+
+  // Durable handoff (codex P1-1): a dormant ask (restored after a restart, no
+  // waiter yet) that receives an ANSWER must NOT drop it into the void. Stash
+  // the terminal result and KEEP the persisted record so the reconnecting hook
+  // can claim it (reattachDormantAsk delivers + removes). Only answered results
+  // are worth stashing — a dormant ask that timed out / was invalidated has no
+  // consumer to hand off to, so it settles+cleans normally.
+  if (ask.dormant && !ask.resolve && result.kind === 'answered') {
+    ask.settled = true;
+    ask.settledAt = Date.now();
+    ask.answeredResult = result;
+    clearTimeout(ask.timeoutHandle);
+    persistFromInternal(ask); // re-persist WITH answeredResult (not removed)
+    logger.info?.(`ask-broker: stashed answer for dormant ask ${askId} (key=${ask.askKey}) — awaiting hook claim`);
+    // Still notify the card layer so the Feishu card flips to its settled view.
+    notifyOnSettle(ask, result);
+    return;
+  }
+
   ask.settled = true;
   ask.settledAt = Date.now();
   clearTimeout(ask.timeoutHandle);
   // The durable record's job is done the moment the ask leaves the pending
-  // state — drop it so a later restart doesn't resurrect a settled ask.
-  removePersistedAsk(ask.askKey);
+  // state (delivered to a live waiter, or a terminal non-answer) — drop it so a
+  // later restart doesn't resurrect a settled ask.
+  persistStore?.remove(ask.askKey);
   // Reap older settled entries opportunistically — keeps the map bounded
   // without paying for a dedicated GC timer.
   gcSettled();
 
-  // A dormant (restored, not-yet-reclaimed) ask has no waiter Promise — a click
-  // can still settle its card, but there is nothing to resolve. Guard the call.
+  // A dormant ask has no waiter Promise — guard the call.
   try {
     ask.resolve?.(result);
   } catch (err) {
@@ -599,25 +703,35 @@ function settle(askId: string, result: AskResult): void {
     );
   }
 
-  if (dispatcher?.onSettle) {
-    try {
-      void Promise.resolve(dispatcher.onSettle(snapshot(ask), result)).catch((err) => {
-        logger.warn?.(
-          `ask-broker: ${askId} onSettle failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      });
-    } catch (err) {
+  notifyOnSettle(ask, result);
+}
+
+/** Notify the IM-side dispatcher's onSettle hook (best-effort — never blocks
+ *  broker state). Shared by the normal settle path and the dormant-answer stash. */
+function notifyOnSettle(ask: InternalPending, result: AskResult): void {
+  if (!dispatcher?.onSettle) return;
+  try {
+    void Promise.resolve(dispatcher.onSettle(snapshot(ask), result)).catch((err) => {
       logger.warn?.(
-        `ask-broker: ${askId} onSettle threw: ${err instanceof Error ? err.message : String(err)}`,
+        `ask-broker: ${ask.askId} onSettle failed: ${err instanceof Error ? err.message : String(err)}`,
       );
-    }
+    });
+  } catch (err) {
+    logger.warn?.(
+      `ask-broker: ${ask.askId} onSettle threw: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 }
 
 /** Strip broker-internal fields before handing a snapshot to the IM-side
- *  dispatcher. Keeps the dispatcher contract narrow. */
+ *  dispatcher. Keeps the dispatcher contract narrow (PendingAsk only). */
 function snapshot(ask: InternalPending): PendingAsk {
-  const { resolve: _r, timeoutHandle: _t, settledAt: _sat, selections: _sel, ...rest } = ask;
+  const {
+    // Runtime-only / broker-internal fields excluded from the IM contract:
+    resolve: _r, timeoutHandle: _t, settledAt: _sat, selections: _sel,
+    askKey: _ak, requestId: _rid, originKind: _ok, dormant: _dm, answeredResult: _ar,
+    ...rest
+  } = ask;
   return {
     ...rest,
     selections: ask.questions.map((_, i) => [...(ask.selections.get(i) ?? new Set<string>())]),
@@ -625,10 +739,14 @@ function snapshot(ask: InternalPending): PendingAsk {
 }
 
 /** Drop settled entries that have aged past the retention window. Cheap O(n)
- *  walk — n is tiny in practice (≤ a few dozen pending+recent asks). */
+ *  walk — n is tiny in practice (≤ a few dozen pending+recent asks). A dormant
+ *  ask holding a stashed answer (durable handoff, awaiting the hook's claim) is
+ *  NEVER reaped from memory here — it lives until claimed or its deadline; on
+ *  disk it survives regardless, and a restart re-hydrates it. */
 function gcSettled(): void {
   const cutoff = Date.now() - SETTLED_RETENTION_MS;
   for (const [id, ask] of pending) {
+    if (ask.dormant && ask.answeredResult) continue; // unclaimed handoff — keep
     if (ask.settled && ask.settledAt !== undefined && ask.settledAt < cutoff) {
       pending.delete(id);
     }
@@ -716,4 +834,8 @@ export function _resetForTest(): void {
   pending.clear();
   dispatcher = null;
   canTalkChecker = null;
+  // Detach the injected store — never delete files here (codex P1-4: a helper
+  // reaping a shared dataDir could wipe a LIVE pending ask). Tests own their
+  // temp dir's cleanup via their own teardown.
+  persistStore = null;
 }

--- a/src/core/ask-broker.ts
+++ b/src/core/ask-broker.ts
@@ -13,7 +13,8 @@ import { randomUUID } from 'node:crypto';
 import { logger } from '../utils/logger.js';
 import {
   askKeyFor,
-  dispatchUuidFor,
+  dispatchUuidForKey,
+  HANDOFF_RETENTION_MS,
   type AskPersistStore,
   type PersistedAsk,
 } from './ask-persist-store.js';
@@ -24,6 +25,7 @@ import type {
   CreateAskInput,
   PendingAsk,
 } from './ask-types.js';
+import { AskDispatchError } from './ask-types.js';
 
 /** Origins for which restart-resume + durable handoff are enabled. Only a
  *  caller that has a reconnecting claimant after a daemon restart may persist:
@@ -66,6 +68,10 @@ interface InternalPending extends Omit<PendingAsk, 'selections'> {
   /** Durable handoff: a terminal result that arrived while dormant, held until
    *  the reconnecting hook claims it. */
   answeredResult?: AskResult;
+  /** Absolute-expiry timer for an unclaimed handoff stash (codex P1-4). Armed on
+   *  stash + on restore-of-a-stashed-answer; fires at answeredAt + retention to
+   *  reap memory + disk together. Cleared when the hook claims the stash. */
+  handoffExpiryHandle?: NodeJS.Timeout;
   /**
    * 按问题序号（questionIndex）累积的勾选 key 集合。
    */
@@ -81,10 +87,23 @@ let dispatcher: AskCardDispatcher | null = null;
  *  store，绝不回落到全局目录). */
 let persistStore: AskPersistStore | null = null;
 
+/** Effective handoff-retention window. Defaults to the durable-store constant;
+ *  a test may shrink it via `_setHandoffRetentionForTest` so the absolute-expiry
+ *  reaper (codex P1-4) can be exercised with real timers instead of a 24h wait
+ *  or fake-timer gymnastics around the async dispatch loop. */
+let handoffRetentionMs: number = HANDOFF_RETENTION_MS;
+
 /** Wire the durable persist store. Called once at daemon bootstrap with the
  *  real dir; tests inject a temp store (and only clean their own sentinel dir). */
 export function setAskPersistStore(store: AskPersistStore | null): void {
   persistStore = store;
+}
+
+/** Shrink the handoff-retention window — for tests only, so the absolute-expiry
+ *  reaper (codex P1-4) can be verified with a short real timer. Restored to the
+ *  default by `_resetForTest`. */
+export function _setHandoffRetentionForTest(ms: number): void {
+  handoffRetentionMs = ms;
 }
 
 /** Optional actor context for the talk check. Card-click paths (toggle/submit)
@@ -161,7 +180,19 @@ export function registerAsk(input: CreateAskInput): Promise<AskResult> {
   }
 
   const originKind = input.originKind ?? 'hook';
-  const resumable = RESUMABLE_ORIGINS.has(originKind) && input.requestId !== undefined;
+  // Resumability is gated by TWO independent facts (codex P1-4):
+  //  1. the origin has a reconnecting claimant (only 'hook' re-POSTs after a
+  //     restart; an explicit `botmux ask buttons` process exits), AND
+  //  2. the issuing session's backend actually SURVIVES a daemon restart —
+  //     computed by the daemon from the authenticated session's frozen backend
+  //     (tmux/herdr/zellij/zmx), NOT trusted from the client. A PTY-backed hook
+  //     dies with the daemon, so persisting it would orphan a record no one can
+  //     ever re-claim. Undefined backend signal → false (fail closed).
+  // A caller-supplied requestId is still required (it's the re-attach identity).
+  const resumable =
+    RESUMABLE_ORIGINS.has(originKind) &&
+    input.requestId !== undefined &&
+    input.backendSurvivesRestart === true;
   // Invocation identity: prefer the caller-supplied requestId (hook generates it
   // once and reuses it across reconnect retries). A caller without one (explicit
   // `botmux ask buttons`) gets a synthesized id and is NOT resumable — it has no
@@ -172,25 +203,41 @@ export function registerAsk(input: CreateAskInput): Promise<AskResult> {
   // lands on a different key and can't reclaim this ask (codex P1-3).
   const askKey = askKeyFor(input.larkAppId, input.sessionId, originKind, requestId);
 
-  // Same-requestId replay — covers ALL states of an existing entry with this key
-  // (codex P1-1). Only join if the FULL immutable identity also matches (defence
-  // in depth on top of the scoped key). Otherwise fall through to a new ask.
+  // Same-key handling — covers ALL states of an existing entry with this key
+  // (codex P1-1). The scoped key already pins (app/session/origin/request); here
+  // we additionally require the FULL immutable identity (chat/root/questions) to
+  // match before joining/replaying/re-attaching.
   const existing = findByKey(askKey);
-  if (existing && sameIdentity(existing, input)) {
-    // active (still awaiting a click): add another waiter → both callers get the
-    // one result; no second ask, no second card.
-    if (!existing.settled && !existing.dormant) {
-      logger.info?.(`ask-broker: active replay joined ask ${existing.askId} (key=${askKey})`);
-      return new Promise<AskResult>((resolve) => { existing.waiters.push(resolve); });
-    }
-    // recent-terminal (settled, still retained): return the same terminal result.
-    if (existing.settled && existing.terminalResult && !existing.dormant) {
-      logger.info?.(`ask-broker: replay returned retained terminal result for ${existing.askId}`);
-      return Promise.resolve(existing.terminalResult);
-    }
-    // dormant (restored after restart): re-attach (handoff or fresh waiter).
-    if (existing.dormant) {
-      return reattachByRequest(existing);
+  if (existing) {
+    if (sameIdentity(existing, input)) {
+      // active (still awaiting a click): add another waiter → both callers get the
+      // one result; no second ask, no second card.
+      if (!existing.settled && !existing.dormant) {
+        logger.info?.(`ask-broker: active replay joined ask ${existing.askId} (key=${askKey})`);
+        return new Promise<AskResult>((resolve) => { existing.waiters.push(resolve); });
+      }
+      // recent-terminal (settled, still retained): return the same terminal result.
+      if (existing.settled && existing.terminalResult && !existing.dormant) {
+        logger.info?.(`ask-broker: replay returned retained terminal result for ${existing.askId}`);
+        return Promise.resolve(existing.terminalResult);
+      }
+      // dormant (restored after restart): re-attach (handoff or fresh waiter).
+      if (existing.dormant) {
+        return reattachByRequest(existing);
+      }
+    } else {
+      // Same key, DIFFERENT immutable identity (crafted / stale-but-mutated
+      // re-POST). FAIL CLOSED (codex P1-2): never fall through to a second ask —
+      // that would post an ambiguous second card and a click could resolve
+      // either. The caller gets a terminal `invalidated` and no card is sent.
+      logger.warn?.(
+        `ask-broker: identity mismatch on key ${askKey} (existing ask ${existing.askId}) — rejecting re-register`,
+      );
+      return Promise.resolve<AskResult>({
+        kind: 'invalidated',
+        reason: 'ask identity mismatch (same key, different question set / chat)',
+        selected: null, by: null, comment: null, timedOut: false,
+      });
     }
   }
 
@@ -253,34 +300,87 @@ function sameIdentity(ask: InternalPending, input: CreateAskInput): boolean {
   );
 }
 
-/** Stable shape string for question-set equality (prompt + multiSelect + option
- *  keys, order-sensitive). Two different question sets must not re-attach. */
+/** Stable shape string for question-set equality (prompt + multiSelect + each
+ *  option's key AND label, order-sensitive). Two question sets that would render
+ *  a DIFFERENT card to the user — including a relabelled option whose key is
+ *  unchanged — must not re-attach/replay (codex P1-2). */
 function questionsShape(qs: PendingAsk['questions']): string {
-  return JSON.stringify(qs.map((q) => ({ p: q.prompt, m: !!q.multiSelect, o: q.options.map((o) => o.key) })));
+  return JSON.stringify(
+    qs.map((q) => ({
+      p: q.prompt,
+      m: !!q.multiSelect,
+      o: q.options.map((o) => [o.key, o.label]),
+    })),
+  );
 }
 
+/** Max card (re-)dispatch attempts on transient failures before giving up and
+ *  invalidating. Small: a card send is a single Feishu POST; if a handful of
+ *  attempts across a few seconds all fail transiently, the chat is unreachable
+ *  and waiting longer won't help. */
+const CARD_DISPATCH_MAX_ATTEMPTS = 4;
+/** Base backoff between transient re-sends (linear: base × attempt, capped). */
+const CARD_DISPATCH_BACKOFF_MS = 500;
+const CARD_DISPATCH_BACKOFF_CAP_MS = 4_000;
+
 /** Dispatch (or idempotently re-dispatch) the card and record its messageId. The
- *  dispatcher gets a stable `dispatchUuid` (from requestId) so a re-send after a
- *  restart returns the original message_id instead of posting a duplicate
- *  (codex P1-1/P1-2). On a hard dispatch failure the ask is invalidated. */
+ *  dispatcher gets a stable `dispatchUuid` (derived from the scoped key) so any
+ *  re-send — a bounded transient retry here, or a restart re-attach — returns the
+ *  ORIGINAL message_id instead of posting a duplicate (codex P1-1/P1-3).
+ *
+ *  Retry policy (codex P1-3 partial-success): a `retryable` AskDispatchError
+ *  (5xx/429/network) is retried up to CARD_DISPATCH_MAX_ATTEMPTS with linear
+ *  backoff, reusing the SAME uuid — so a send that landed server-side before the
+ *  socket broke converges to one logical card. A non-retryable error
+ *  (deterministic 4xx / withdrawn) — or a plain untyped throw (fail closed) —
+ *  invalidates immediately. */
 function sendCardForAsk(ask: InternalPending): void {
-  void dispatcher!
-    .send(snapshot(ask))
-    .then(({ messageId }) => {
-      const cur = pending.get(ask.askId);
-      if (cur && !cur.settled) {
-        cur.cardMessageId = messageId;
-        if (cur.resumable) persistFromInternal(cur);
+  void (async () => {
+    for (let attempt = 1; attempt <= CARD_DISPATCH_MAX_ATTEMPTS; attempt++) {
+      // Bail if the ask settled out from under us (timeout / invalidate / a click
+      // on a restored dormant card) — nothing left to dispatch.
+      const live = pending.get(ask.askId);
+      if (!live || live.settled) return;
+      try {
+        const { messageId } = await dispatcher!.send(snapshot(ask));
+        const cur = pending.get(ask.askId);
+        if (cur && !cur.settled) {
+          cur.cardMessageId = messageId;
+          if (cur.resumable) persistFromInternal(cur);
+        }
+        return; // sent (or server-deduped to the original) — done
+      } catch (err) {
+        const retryable = err instanceof AskDispatchError && err.retryable;
+        const msg = err instanceof Error ? err.message : String(err);
+        if (retryable && attempt < CARD_DISPATCH_MAX_ATTEMPTS) {
+          const backoff = Math.min(CARD_DISPATCH_BACKOFF_MS * attempt, CARD_DISPATCH_BACKOFF_CAP_MS);
+          logger.warn?.(
+            `ask-broker: ${ask.askId} card dispatch attempt ${attempt} failed (transient): ${msg} — retrying in ${backoff}ms`,
+          );
+          await sleep(backoff);
+          continue;
+        }
+        // Deterministic failure, exhausted retries, or an untyped throw (fail
+        // closed): invalidate so the blocked CLI unblocks instead of hanging.
+        logger.warn?.(
+          `ask-broker: ${ask.askId} card dispatch failed (${retryable ? 'transient, retries exhausted' : 'not retryable'}): ${msg}`,
+        );
+        settle(ask.askId, {
+          kind: 'invalidated', reason: `card dispatch failed: ${msg}`,
+          selected: null, by: null, comment: null, timedOut: false,
+        });
+        return;
       }
-    })
-    .catch((err) => {
-      const msg = err instanceof Error ? err.message : String(err);
-      logger.warn?.(`ask-broker: ${ask.askId} card dispatch failed: ${msg}`);
-      settle(ask.askId, {
-        kind: 'invalidated', reason: `card dispatch failed: ${msg}`,
-        selected: null, by: null, comment: null, timedOut: false,
-      });
-    });
+    }
+  })();
+}
+
+/** Promise-based sleep whose timer never keeps the process alive (unref). */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const h = setTimeout(resolve, ms);
+    h.unref?.();
+  });
 }
 
 /** Find an entry by its scoped stable key (any state). */
@@ -304,6 +404,7 @@ function reattachByRequest(ask: InternalPending): Promise<AskResult> {
     ask.settledAt = Date.now();
     ask.terminalResult = result;
     clearTimeout(ask.timeoutHandle);
+    clearTimeout(ask.handoffExpiryHandle); // claimed → cancel the unclaimed-stash reaper
     persistStore?.remove(ask.askKey); // claimed → durable record no longer needed
     gcSettled();
     logger.info?.(`ask-broker: re-attach delivered stashed answer for ask ${ask.askId} (key=${ask.askKey})`);
@@ -611,13 +712,20 @@ export function restorePersistedAsks(now: number = Date.now(), larkAppId?: strin
     for (let i = 0; i < p.questions.length; i++) {
       selections.set(i, new Set<string>(p.selections?.[i] ?? []));
     }
+    const hasStashedAnswer = p.answeredResult !== undefined;
+    // A stashed-answer restore is already terminal (settled), awaiting only the
+    // hook's claim — it must NOT arm a deadline timer (there's nothing left to
+    // time out). A still-awaiting-click restore arms the ORIGINAL absolute
+    // deadline so it can't linger forever if the CLI never returns.
     const remaining = Math.max(0, p.deadlineAt - now);
-    const timeoutHandle = setTimeout(() => {
-      settle(p.askId, {
-        kind: 'timedOut', selected: null, by: null, comment: null, timedOut: true,
-      });
-    }, remaining);
-    timeoutHandle.unref?.();
+    const timeoutHandle = hasStashedAnswer
+      ? undefined
+      : setTimeout(() => {
+          settle(p.askId, {
+            kind: 'timedOut', selected: null, by: null, comment: null, timedOut: true,
+          });
+        }, remaining);
+    timeoutHandle?.unref?.();
 
     const ask: InternalPending = {
       askId: p.askId,
@@ -635,16 +743,27 @@ export function restorePersistedAsks(now: number = Date.now(), larkAppId?: strin
       createdAt: p.createdAt,
       deadlineAt: p.deadlineAt,
       cardMessageId: p.cardMessageId,
-      settled: false,
+      // A stashed-answer restore is terminal-but-unclaimed: settled=true so
+      // gcSettled/other paths treat it as done, dormant=true so a hook re-POST
+      // routes to reattachByRequest to CLAIM it.
+      settled: hasStashedAnswer,
+      settledAt: hasStashedAnswer ? (p.answeredAt ?? now) : undefined,
       dormant: true,
       waiters: [], // attached when the reconnecting hook re-registers
       // Carry a stashed answer forward (user answered before restart): the
       // reconnecting hook claims it via reattachByRequest.
       ...(p.answeredResult ? { answeredResult: p.answeredResult, terminalResult: p.answeredResult } : {}),
-      timeoutHandle,
+      // timeoutHandle is only meaningful for the awaiting-click case; a stashed
+      // restore uses a no-op cleared handle so clearTimeout calls stay safe.
+      timeoutHandle: timeoutHandle ?? setTimeout(() => {}, 0),
       selections,
     };
+    if (timeoutHandle === undefined) { clearTimeout(ask.timeoutHandle); }
     pending.set(p.askId, ask);
+    // Re-arm the absolute handoff-expiry reaper for a restored stash (codex
+    // P1-4): a SECOND restart before the hook claims must still reap memory +
+    // disk at the ORIGINAL answeredAt + retention, not restart the clock.
+    if (hasStashedAnswer) armHandoffExpiry(ask);
     restored++;
     logger.info?.(
       `ask-broker: restored pending ask ${p.askId} (key=${p.askKey}, session=${p.sessionId}, ` +
@@ -681,6 +800,11 @@ function settle(askId: string, result: AskResult): void {
     ask.terminalResult = result;
     clearTimeout(ask.timeoutHandle);
     persistFromInternal(ask); // re-persist WITH answeredResult + answeredAt (kept until claimed)
+    // Arm the absolute handoff-expiry timer (codex P1-4): if the reconnecting
+    // hook never claims this stash (CLI gone for good), reap memory + disk
+    // TOGETHER at answeredAt + HANDOFF_RETENTION_MS — not just on the next boot
+    // list() sweep, which a long-running daemon never performs.
+    armHandoffExpiry(ask);
     logger.info?.(`ask-broker: stashed answer for dormant ask ${askId} (key=${ask.askKey}) — awaiting hook claim`);
     // Still notify the card layer so the Feishu card flips to its settled view.
     notifyOnSettle(ask, result);
@@ -747,9 +871,10 @@ function snapshot(ask: InternalPending): PendingAsk {
     ...rest,
     selections: ask.questions.map((_, i) => [...(ask.selections.get(i) ?? new Set<string>())]),
     // Resumable asks carry a stable dedupe token so a re-send (after restart)
-    // is idempotent on the Feishu side. Non-resumable asks (explicit / one-shot)
-    // don't re-send, so they don't need it.
-    ...(ask.resumable ? { dispatchUuid: dispatchUuidFor(ask.requestId) } : {}),
+    // is idempotent on the Feishu side. Derived from the SCOPED key (not the
+    // bare requestId) so a second session reusing the same requestId can't alias
+    // this card's uuid (codex P1-1). Non-resumable asks don't re-send.
+    ...(ask.resumable ? { dispatchUuid: dispatchUuidForKey(ask.askKey) } : {}),
   };
 }
 
@@ -766,6 +891,36 @@ function gcSettled(): void {
       pending.delete(id);
     }
   }
+}
+
+/**
+ * Arm an absolute-expiry timer for an unclaimed handoff stash (codex P1-4). A
+ * stashed answer is kept until the reconnecting hook claims it — but if the CLI
+ * is gone for good, nothing would ever remove it from a long-running daemon's
+ * memory (gcSettled deliberately skips unclaimed handoffs) OR from disk (the
+ * disk reap only runs in list() at boot). This timer closes both: at
+ * `answeredAt + HANDOFF_RETENTION_MS` it deletes the in-memory entry AND the
+ * persisted record TOGETHER, so memory and disk never diverge.
+ *
+ * Idempotent: clears any prior handle first (re-arming on a second restore is
+ * fine). The timer is unref'd so it never keeps the process alive.
+ */
+function armHandoffExpiry(ask: InternalPending): void {
+  clearTimeout(ask.handoffExpiryHandle);
+  const stashedAt = ask.settledAt ?? Date.now();
+  const fireIn = Math.max(0, stashedAt + handoffRetentionMs - Date.now());
+  ask.handoffExpiryHandle = setTimeout(() => {
+    // Only reap if STILL an unclaimed stash (a claim clears this handle, but
+    // guard against a late fire racing a claim).
+    const cur = pending.get(ask.askId);
+    if (!cur || !cur.dormant || !cur.answeredResult) return;
+    pending.delete(cur.askId);
+    persistStore?.remove(cur.askKey);
+    logger.info?.(
+      `ask-broker: handoff stash expired unclaimed for ask ${cur.askId} (key=${cur.askKey}) — reaped memory + disk`,
+    );
+  }, fireIn);
+  ask.handoffExpiryHandle.unref?.();
 }
 
 // ---- diagnostics for tests ---------------------------------------------------
@@ -845,10 +1000,14 @@ export function _allAskIds(): string[] {
 /** Reset broker state — for tests only. Does NOT resolve outstanding promises,
  *  so tests must not call this while real CLI processes might be waiting. */
 export function _resetForTest(): void {
-  for (const ask of pending.values()) clearTimeout(ask.timeoutHandle);
+  for (const ask of pending.values()) {
+    clearTimeout(ask.timeoutHandle);
+    clearTimeout(ask.handoffExpiryHandle);
+  }
   pending.clear();
   dispatcher = null;
   canTalkChecker = null;
+  handoffRetentionMs = HANDOFF_RETENTION_MS; // restore default retention
   // Detach the injected store — never delete files here (codex P1-4: a helper
   // reaping a shared dataDir could wipe a LIVE pending ask). Tests own their
   // temp dir's cleanup via their own teardown.

--- a/src/core/ask-broker.ts
+++ b/src/core/ask-broker.ts
@@ -188,6 +188,7 @@ export function registerAsk(input: CreateAskInput): Promise<AskResult> {
     // Persist immediately so a restart before the card even lands still leaves a
     // resumable record (its cardMessageId fills in once dispatch resolves).
     persistFromInternal(ask);
+    logger.info?.(`ask-broker: registered + persisted ask ${askId} (key=${askKey}, session=${input.sessionId})`);
 
     // Card dispatch is async — store the messageId once it lands.
     void dispatcher!
@@ -557,10 +558,17 @@ export function restorePersistedAsks(now: number = Date.now(), larkAppId?: strin
     };
     pending.set(p.askId, ask);
     restored++;
+    logger.info?.(
+      `ask-broker: restored pending ask ${p.askId} (key=${p.askKey}, session=${p.sessionId}, ` +
+      `dormant, ${Math.round((p.deadlineAt - now) / 1000)}s left) — awaiting hook re-attach`,
+    );
   }
-  if (restored > 0) {
-    logger.info?.(`ask-broker: restored ${restored} pending ask(s) from disk (dormant, awaiting hook re-attach)`);
-  }
+  // Always log the boot sweep outcome (even 0) so a live restart test can
+  // confirm the restore path ran, not just infer it from behaviour.
+  logger.info?.(
+    `ask-broker: restore sweep complete — ${restored} pending ask(s) restored` +
+    (larkAppId ? ` for ${larkAppId}` : ''),
+  );
   return restored;
 }
 

--- a/src/core/ask-broker.ts
+++ b/src/core/ask-broker.ts
@@ -11,6 +11,13 @@
 import { randomUUID } from 'node:crypto';
 
 import { logger } from '../utils/logger.js';
+import {
+  computeAskKey,
+  listPersistedAsks,
+  persistAsk,
+  removePersistedAsk,
+  type PersistedAsk,
+} from './ask-persist-store.js';
 import type {
   AskCardDispatcher,
   AskClickOutcome,
@@ -20,10 +27,26 @@ import type {
 } from './ask-types.js';
 
 interface InternalPending extends Omit<PendingAsk, 'selections'> {
-  resolve: (result: AskResult) => void;
+  /** Stable cross-restart identity (sessionId + questions hash). Used to
+   *  re-attach a reconnecting hook to its own restored ask, and as the
+   *  persistence filename key. */
+  askKey: string;
+  /** Waiter Promise resolver. Absent on a dormant (restored, unclaimed) ask —
+   *  a click can still settle its card, but there is no CLI turn to resolve
+   *  until a reconnecting hook re-attaches one. */
+  resolve?: (result: AskResult) => void;
   timeoutHandle: NodeJS.Timeout;
   /** epoch ms when settle ran; undefined while still pending. */
   settledAt?: number;
+  /**
+   * Restored from disk after a daemon restart but not yet re-claimed by a
+   * reconnecting hook: the card is still live in Feishu, but there is no waiter
+   * Promise to resolve. A click on a dormant ask records selections/settles the
+   * card, and the answer is delivered when the hook re-registers (which flips
+   * dormant → active by attaching a fresh resolve). No timeout runs while
+   * dormant except the absolute-deadline sweep.
+   */
+  dormant?: boolean;
   /**
    * 按问题序号（questionIndex）累积的勾选 key 集合。
    * 单选问题（multiSelect:false）Set 内最多保留 1 个 key。
@@ -108,6 +131,18 @@ export function registerAsk(input: CreateAskInput): Promise<AskResult> {
     throw new Error('ask-broker: cardDispatcher not wired — daemon bootstrap bug');
   }
 
+  const askKey = computeAskKey(input.sessionId, input.questions);
+
+  // Re-attach path: a hook reconnecting after a daemon restart re-POSTs the
+  // same ask. If we restored a dormant entry with this key (card still live in
+  // Feishu), attach a fresh waiter + timeout to it instead of posting a second
+  // card. The user's click — whenever it lands — resolves this new Promise, so
+  // the answer flows back through the normal hook directive.
+  const existing = findDormantByKey(askKey);
+  if (existing) {
+    return reattachDormantAsk(existing, input);
+  }
+
   const askId = randomUUID();
   const nonce = randomUUID().slice(0, 8);
   const createdAt = Date.now();
@@ -134,6 +169,7 @@ export function registerAsk(input: CreateAskInput): Promise<AskResult> {
 
     const ask: InternalPending = {
       askId,
+      askKey,
       nonce,
       larkAppId: input.larkAppId,
       chatId: input.chatId,
@@ -149,13 +185,21 @@ export function registerAsk(input: CreateAskInput): Promise<AskResult> {
       selections,
     };
     pending.set(askId, ask);
+    // Persist immediately so a restart before the card even lands still leaves a
+    // resumable record (its cardMessageId fills in once dispatch resolves).
+    persistFromInternal(ask);
 
     // Card dispatch is async — store the messageId once it lands.
     void dispatcher!
       .send(snapshot(ask))
       .then(({ messageId }) => {
         const cur = pending.get(askId);
-        if (cur && !cur.settled) cur.cardMessageId = messageId;
+        if (cur && !cur.settled) {
+          cur.cardMessageId = messageId;
+          // Re-persist so a restart after the card lands can patch the exact
+          // card on settle and knows it was already delivered.
+          persistFromInternal(cur);
+        }
       })
       .catch((err) => {
         const msg = err instanceof Error ? err.message : String(err);
@@ -170,6 +214,67 @@ export function registerAsk(input: CreateAskInput): Promise<AskResult> {
         });
       });
   });
+}
+
+/** Find a dormant (restored-but-unclaimed) ask by its stable key. Only dormant
+ *  entries are re-attachable — an active ask with a live waiter must never be
+ *  hijacked by a second registration. */
+function findDormantByKey(askKey: string): InternalPending | undefined {
+  for (const ask of pending.values()) {
+    if (ask.askKey === askKey && ask.dormant && !ask.settled) return ask;
+  }
+  return undefined;
+}
+
+/** Re-attach a reconnecting hook to a restored dormant ask: keep its card,
+ *  nonce, and accumulated selections, but install a fresh waiter Promise and
+ *  a timeout re-armed to the ORIGINAL absolute deadline. Flips dormant → active. */
+function reattachDormantAsk(ask: InternalPending, input: CreateAskInput): Promise<AskResult> {
+  return new Promise<AskResult>((resolve) => {
+    ask.dormant = false;
+    ask.resolve = resolve;
+    // Replace the dormant-phase deadline timer (armed by restorePersistedAsks)
+    // rather than leaking it — settle is idempotent, but two live timers is
+    // sloppy. Re-arm to the surviving absolute deadline (not a fresh full
+    // timeout — the clock kept running while the daemon was down).
+    clearTimeout(ask.timeoutHandle);
+    const remaining = Math.max(0, ask.deadlineAt - Date.now());
+    ask.timeoutHandle = setTimeout(() => {
+      settle(ask.askId, {
+        kind: 'timedOut', selected: null, by: null, comment: null, timedOut: true,
+      });
+    }, remaining);
+    ask.timeoutHandle.unref?.();
+    logger.info?.(
+      `ask-broker: re-attached hook to restored ask ${ask.askId} (key=${ask.askKey}, ` +
+      `${Math.round(remaining / 1000)}s left)`,
+    );
+    // sessionId/chatId are identity-stable across the reconnect; input is only
+    // used for the key match, which already succeeded. Nothing else to copy.
+    void input;
+  });
+}
+
+/** Build the persisted projection from a live internal ask and write it. */
+function persistFromInternal(ask: InternalPending): void {
+  if (ask.settled) return;
+  const persisted: PersistedAsk = {
+    v: 1,
+    askKey: ask.askKey,
+    askId: ask.askId,
+    nonce: ask.nonce,
+    larkAppId: ask.larkAppId,
+    chatId: ask.chatId,
+    rootMessageId: ask.rootMessageId,
+    sessionId: ask.sessionId,
+    chatType: ask.chatType,
+    questions: ask.questions,
+    createdAt: ask.createdAt,
+    deadlineAt: ask.deadlineAt,
+    cardMessageId: ask.cardMessageId,
+    selections: ask.questions.map((_, i) => [...(ask.selections.get(i) ?? new Set<string>())]),
+  };
+  persistAsk(persisted);
 }
 
 /**
@@ -215,6 +320,10 @@ export function toggleAsk(args: {
     sel.clear();
     sel.add(args.key);
   }
+
+  // Persist the updated checkbox state so a restart mid-multi-select keeps the
+  // boxes the user already ticked (best-effort; never blocks the toggle).
+  persistFromInternal(ask);
 
   return 'toggled';
 }
@@ -393,6 +502,68 @@ export function invalidateAll(reason: string): number {
   return ids.length;
 }
 
+/**
+ * Restore pending asks from disk after a daemon restart. Each becomes a DORMANT
+ * entry: its card is still live in Feishu (we do NOT re-post — cardMessageId is
+ * preserved), so a click can settle it, but there is no waiter Promise until the
+ * surviving CLI hook reconnects and re-registers (findDormantByKey →
+ * reattachDormantAsk installs a fresh resolve). Each dormant ask arms a timer to
+ * its ORIGINAL absolute deadline so it can't linger forever if the CLI never
+ * comes back. Called once during daemon bootstrap. Returns the count restored.
+ *
+ * Idempotent-ish: an askKey already present (e.g. re-invoked) is skipped.
+ */
+export function restorePersistedAsks(now: number = Date.now(), larkAppId?: string): number {
+  let restored = 0;
+  for (const p of listPersistedAsks(now)) {
+    // One bot per daemon process: only restore asks this daemon can actually
+    // serve (its own bot's sessions). Another bot's daemon owns the rest.
+    if (larkAppId && p.larkAppId !== larkAppId) continue;
+    // Skip if this key is already live (defensive — boot runs once).
+    let dup = false;
+    for (const a of pending.values()) if (a.askKey === p.askKey && !a.settled) { dup = true; break; }
+    if (dup) continue;
+
+    const selections = new Map<number, Set<string>>();
+    for (let i = 0; i < p.questions.length; i++) {
+      selections.set(i, new Set<string>(p.selections?.[i] ?? []));
+    }
+    const remaining = Math.max(0, p.deadlineAt - now);
+    const timeoutHandle = setTimeout(() => {
+      settle(p.askId, {
+        kind: 'timedOut', selected: null, by: null, comment: null, timedOut: true,
+      });
+    }, remaining);
+    timeoutHandle.unref?.();
+
+    const ask: InternalPending = {
+      askId: p.askId,
+      askKey: p.askKey,
+      nonce: p.nonce,
+      larkAppId: p.larkAppId,
+      chatId: p.chatId,
+      rootMessageId: p.rootMessageId,
+      sessionId: p.sessionId,
+      chatType: p.chatType,
+      questions: p.questions,
+      createdAt: p.createdAt,
+      deadlineAt: p.deadlineAt,
+      cardMessageId: p.cardMessageId,
+      settled: false,
+      dormant: true,
+      // No resolve yet — attached when the reconnecting hook re-registers.
+      timeoutHandle,
+      selections,
+    };
+    pending.set(p.askId, ask);
+    restored++;
+  }
+  if (restored > 0) {
+    logger.info?.(`ask-broker: restored ${restored} pending ask(s) from disk (dormant, awaiting hook re-attach)`);
+  }
+  return restored;
+}
+
 /** Internal — settle an ask exactly once and notify the dispatcher's onSettle
  *  hook (best-effort, never blocks broker state transitions). The settled
  *  entry stays in the map for `SETTLED_RETENTION_MS` so late race-losers get
@@ -403,12 +574,17 @@ function settle(askId: string, result: AskResult): void {
   ask.settled = true;
   ask.settledAt = Date.now();
   clearTimeout(ask.timeoutHandle);
+  // The durable record's job is done the moment the ask leaves the pending
+  // state — drop it so a later restart doesn't resurrect a settled ask.
+  removePersistedAsk(ask.askKey);
   // Reap older settled entries opportunistically — keeps the map bounded
   // without paying for a dedicated GC timer.
   gcSettled();
 
+  // A dormant (restored, not-yet-reclaimed) ask has no waiter Promise — a click
+  // can still settle its card, but there is nothing to resolve. Guard the call.
   try {
-    ask.resolve(result);
+    ask.resolve?.(result);
   } catch (err) {
     logger.warn?.(
       `ask-broker: ${askId} resolve threw: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/core/ask-broker.ts
+++ b/src/core/ask-broker.ts
@@ -870,11 +870,13 @@ function snapshot(ask: InternalPending): PendingAsk {
   return {
     ...rest,
     selections: ask.questions.map((_, i) => [...(ask.selections.get(i) ?? new Set<string>())]),
-    // Resumable asks carry a stable dedupe token so a re-send (after restart)
-    // is idempotent on the Feishu side. Derived from the SCOPED key (not the
-    // bare requestId) so a second session reusing the same requestId can't alias
-    // this card's uuid (codex P1-1). Non-resumable asks don't re-send.
-    ...(ask.resumable ? { dispatchUuid: dispatchUuidForKey(ask.askKey) } : {}),
+    // EVERY ask carries a scoped dedupe token (codex P1-1): the broker's bounded
+    // retry re-sends the card, and a re-send without a uuid posts a DUPLICATE on
+    // the Feishu side. The uuid is the card's dedupe identity for THIS broker
+    // lifetime — derived from the scoped askKey, independent of persistence.
+    // `resumable` gates only cross-restart persistence, NOT intra-process
+    // dispatch idempotency, so explicit / PTY asks (which also retry) dedupe too.
+    dispatchUuid: dispatchUuidForKey(ask.askKey),
   };
 }
 

--- a/src/core/ask-broker.ts
+++ b/src/core/ask-broker.ts
@@ -13,6 +13,7 @@ import { randomUUID } from 'node:crypto';
 import { logger } from '../utils/logger.js';
 import {
   askKeyFor,
+  dispatchUuidFor,
   type AskPersistStore,
   type PersistedAsk,
 } from './ask-persist-store.js';
@@ -24,45 +25,49 @@ import type {
   PendingAsk,
 } from './ask-types.js';
 
+/** Origins for which restart-resume + durable handoff are enabled. Only a
+ *  caller that has a reconnecting claimant after a daemon restart may persist:
+ *  the hook process survives in the CLI's tmux/persistent-backend session and
+ *  re-POSTs with the same requestId. An explicit `botmux ask buttons` CLI exits
+ *  on restart (no claimant) and a PTY-backend hook doesn't survive, so those
+ *  must NOT persist/handoff — else they leave orphan records (codex P1-4). */
+const RESUMABLE_ORIGINS = new Set(['hook']);
+
 interface InternalPending extends Omit<PendingAsk, 'selections'> {
-  /** Stable cross-restart identity = `${originKind}.${requestId}` (see
-   *  ask-persist-store). Re-attaches a reconnecting hook to its own restored
-   *  ask, and is the persistence filename key. */
+  /** Stable identity = larkAppId.sessionId.originKind.requestId (see
+   *  ask-persist-store.askKeyFor). NOT a bearer secret — scoped to the
+   *  authenticated session so another session can't reclaim by reusing a
+   *  requestId (codex P1-3). */
   askKey: string;
   /** Per-invocation id (hook generates once, reuses across reconnect retries). */
   requestId: string;
   /** Caller kind ('hook' | 'explicit' | …) namespacing the identity. */
   originKind: string;
-  /** Waiter Promise resolver. Absent on a dormant (restored, unclaimed) ask —
-   *  a click can still settle its card, but there is no CLI turn to resolve
-   *  until a reconnecting hook re-attaches one. */
-  resolve?: (result: AskResult) => void;
+  /** Whether this ask is eligible for persistence + restart resume (its origin
+   *  has a reconnecting claimant). */
+  resumable: boolean;
+  /** Waiter Promise resolvers. Normally one; an active same-requestId replay
+   *  (client reset mid-POST → re-POST) JOINS the same ask and adds another
+   *  waiter here so all callers get the one result — no second ask/card
+   *  (codex P1-1 active-replay). */
+  waiters: Array<(result: AskResult) => void>;
   timeoutHandle: NodeJS.Timeout;
   /** epoch ms when settle ran; undefined while still pending. */
   settledAt?: number;
+  /** Terminal result, retained briefly after settle so a same-requestId replay
+   *  in the ambiguous window gets the identical answer instead of a stale/new
+   *  ask (codex P1-1). */
+  terminalResult?: AskResult;
   /**
-   * Restored from disk after a daemon restart but not yet re-claimed by a
-   * reconnecting hook: the card is still live in Feishu, but there is no waiter
-   * Promise to resolve. Two dormant sub-cases:
-   *  - awaiting a click: a click records selections and produces a terminal
-   *    result that is stashed in `answeredResult` (NOT delivered/deleted yet).
-   *  - already answered while dormant: `answeredResult` is set; the record is
-   *    kept until the reconnecting hook claims it.
-   * Re-attach (hook re-register with the same key) flips dormant → active: if an
-   * answer is already stashed it is delivered immediately (0 new card); else a
-   * fresh waiter + deadline timer are installed.
+   * Restored from disk after a daemon restart, not yet re-claimed. See
+   * reattachByRequest for the two sub-cases (awaiting click / stashed answer).
    */
   dormant?: boolean;
-  /**
-   * A terminal result that arrived while the ask was dormant (user clicked
-   * before the hook reconnected). Held here — the durable handoff — so the
-   * reconnecting hook can claim it. Delivered + cleared on re-attach.
-   */
+  /** Durable handoff: a terminal result that arrived while dormant, held until
+   *  the reconnecting hook claims it. */
   answeredResult?: AskResult;
   /**
    * 按问题序号（questionIndex）累积的勾选 key 集合。
-   * 单选问题（multiSelect:false）Set 内最多保留 1 个 key。
-   * 多选问题（multiSelect:true）Set 内可保留任意个 key。
    */
   selections: Map<number, Set<string>>;
 }
@@ -155,22 +160,38 @@ export function registerAsk(input: CreateAskInput): Promise<AskResult> {
     throw new Error('ask-broker: cardDispatcher not wired — daemon bootstrap bug');
   }
 
-  // Invocation identity: prefer the caller-supplied requestId (hook generates it
-  // once and reuses it across reconnect retries) so a re-POST after a restart
-  // re-attaches. Legacy/explicit callers without one get a synthesized id — they
-  // simply won't cross-restart-resume, which is the pre-existing behaviour.
-  const requestId = input.requestId ?? randomUUID();
   const originKind = input.originKind ?? 'hook';
-  const askKey = askKeyFor(originKind, requestId);
+  const resumable = RESUMABLE_ORIGINS.has(originKind) && input.requestId !== undefined;
+  // Invocation identity: prefer the caller-supplied requestId (hook generates it
+  // once and reuses it across reconnect retries). A caller without one (explicit
+  // `botmux ask buttons`) gets a synthesized id and is NOT resumable — it has no
+  // reconnecting claimant, so persisting/handing off would orphan (codex P1-4).
+  const requestId = input.requestId ?? randomUUID();
+  // Identity is SCOPED to the authenticated (larkAppId, sessionId): a requestId
+  // is an idempotency id, never a bearer secret — a different session reusing it
+  // lands on a different key and can't reclaim this ask (codex P1-3).
+  const askKey = askKeyFor(input.larkAppId, input.sessionId, originKind, requestId);
 
-  // Re-attach path: a hook reconnecting after a daemon restart re-POSTs the same
-  // ask (same requestId). If a dormant entry with this key exists (card still
-  // live in Feishu), attach to it instead of posting a second card — and if the
-  // user already answered while it was dormant, deliver that stashed answer
-  // immediately (codex P1-1).
-  const existing = findDormantByKey(askKey);
-  if (existing) {
-    return reattachDormantAsk(existing);
+  // Same-requestId replay — covers ALL states of an existing entry with this key
+  // (codex P1-1). Only join if the FULL immutable identity also matches (defence
+  // in depth on top of the scoped key). Otherwise fall through to a new ask.
+  const existing = findByKey(askKey);
+  if (existing && sameIdentity(existing, input)) {
+    // active (still awaiting a click): add another waiter → both callers get the
+    // one result; no second ask, no second card.
+    if (!existing.settled && !existing.dormant) {
+      logger.info?.(`ask-broker: active replay joined ask ${existing.askId} (key=${askKey})`);
+      return new Promise<AskResult>((resolve) => { existing.waiters.push(resolve); });
+    }
+    // recent-terminal (settled, still retained): return the same terminal result.
+    if (existing.settled && existing.terminalResult && !existing.dormant) {
+      logger.info?.(`ask-broker: replay returned retained terminal result for ${existing.askId}`);
+      return Promise.resolve(existing.terminalResult);
+    }
+    // dormant (restored after restart): re-attach (handoff or fresh waiter).
+    if (existing.dormant) {
+      return reattachByRequest(existing);
+    }
   }
 
   const askId = randomUUID();
@@ -180,28 +201,19 @@ export function registerAsk(input: CreateAskInput): Promise<AskResult> {
 
   return new Promise<AskResult>((resolve) => {
     const timeoutHandle = setTimeout(() => {
-      settle(askId, {
-        kind: 'timedOut',
-        selected: null,
-        by: null,
-        comment: null,
-        timedOut: true,
-      });
+      settle(askId, { kind: 'timedOut', selected: null, by: null, comment: null, timedOut: true });
     }, input.timeoutMs);
-    // Don't keep the event loop alive just because an ask is pending.
     timeoutHandle.unref?.();
 
-    // 为每个问题初始化空的勾选集合
     const selections = new Map<number, Set<string>>();
-    for (let i = 0; i < input.questions.length; i++) {
-      selections.set(i, new Set<string>());
-    }
+    for (let i = 0; i < input.questions.length; i++) selections.set(i, new Set<string>());
 
     const ask: InternalPending = {
       askId,
       askKey,
       requestId,
       originKind,
+      resumable,
       nonce,
       larkAppId: input.larkAppId,
       chatId: input.chatId,
@@ -212,28 +224,45 @@ export function registerAsk(input: CreateAskInput): Promise<AskResult> {
       createdAt,
       deadlineAt,
       settled: false,
-      resolve,
+      waiters: [resolve],
       timeoutHandle,
       selections,
     };
     pending.set(askId, ask);
-    // Persist immediately so a restart before the card even lands still leaves a
-    // resumable record (its cardMessageId fills in once dispatch resolves; until
-    // then restore/re-attach re-sends the card — codex P1-2).
-    persistFromInternal(ask);
-    logger.info?.(`ask-broker: registered + persisted ask ${askId} (key=${askKey}, session=${input.sessionId})`);
-
-    // Card dispatch is async — the dispatcher dedupes by requestId so a re-send
-    // (restore/re-attach after a restart in this window) can't double-post.
+    // Persist ONLY resumable origins (codex P1-4). A restart before the card
+    // lands still leaves a resumable record; restore/re-attach re-sends.
+    if (resumable) {
+      persistFromInternal(ask);
+      logger.info?.(`ask-broker: registered + persisted ask ${askId} (key=${askKey}, session=${input.sessionId})`);
+    }
     void sendCardForAsk(ask);
   });
 }
 
-/** Dispatch (or idempotently re-dispatch) the card for an ask and record its
- *  messageId. The dispatcher uses the ask's requestId as the Feishu idempotency
- *  uuid, so a re-send after a restart (when a prior send may have partially
- *  succeeded) returns the original message_id rather than posting a duplicate
- *  (codex P1-2). On a hard dispatch failure the ask is invalidated. */
+/** Immutable-identity equality: a reattach/replay must match the ORIGINAL ask on
+ *  every caller-independent field, not just the (already-scoped) key. Guards
+ *  against a stale/crafted requestId landing on a mismatched ask (codex P1-3). */
+function sameIdentity(ask: InternalPending, input: CreateAskInput): boolean {
+  return (
+    ask.larkAppId === input.larkAppId &&
+    ask.sessionId === input.sessionId &&
+    ask.chatId === input.chatId &&
+    ask.rootMessageId === input.rootMessageId &&
+    ask.originKind === (input.originKind ?? 'hook') &&
+    questionsShape(ask.questions) === questionsShape(input.questions)
+  );
+}
+
+/** Stable shape string for question-set equality (prompt + multiSelect + option
+ *  keys, order-sensitive). Two different question sets must not re-attach. */
+function questionsShape(qs: PendingAsk['questions']): string {
+  return JSON.stringify(qs.map((q) => ({ p: q.prompt, m: !!q.multiSelect, o: q.options.map((o) => o.key) })));
+}
+
+/** Dispatch (or idempotently re-dispatch) the card and record its messageId. The
+ *  dispatcher gets a stable `dispatchUuid` (from requestId) so a re-send after a
+ *  restart returns the original message_id instead of posting a duplicate
+ *  (codex P1-1/P1-2). On a hard dispatch failure the ask is invalidated. */
 function sendCardForAsk(ask: InternalPending): void {
   void dispatcher!
     .send(snapshot(ask))
@@ -241,94 +270,67 @@ function sendCardForAsk(ask: InternalPending): void {
       const cur = pending.get(ask.askId);
       if (cur && !cur.settled) {
         cur.cardMessageId = messageId;
-        // Re-persist so a later restart knows the card is delivered (and can
-        // patch the exact card on settle).
-        persistFromInternal(cur);
+        if (cur.resumable) persistFromInternal(cur);
       }
     })
     .catch((err) => {
       const msg = err instanceof Error ? err.message : String(err);
       logger.warn?.(`ask-broker: ${ask.askId} card dispatch failed: ${msg}`);
       settle(ask.askId, {
-        kind: 'invalidated',
-        reason: `card dispatch failed: ${msg}`,
-        selected: null,
-        by: null,
-        comment: null,
-        timedOut: false,
+        kind: 'invalidated', reason: `card dispatch failed: ${msg}`,
+        selected: null, by: null, comment: null, timedOut: false,
       });
     });
 }
 
-/** Find a re-attachable ask by its stable key. Re-attachable = a dormant entry
- *  (restored after a restart), whether still awaiting a click OR already carrying
- *  a stashed answer (settled-while-dormant — the durable handoff). An ACTIVE ask
- *  with a live waiter is never matched: it must not be hijacked by a second
- *  registration. */
-function findDormantByKey(askKey: string): InternalPending | undefined {
-  for (const ask of pending.values()) {
-    if (ask.askKey !== askKey || !ask.dormant) continue;
-    // dormant + awaiting click (not settled), OR dormant + stashed answer.
-    if (!ask.settled || ask.answeredResult) return ask;
-  }
+/** Find an entry by its scoped stable key (any state). */
+function findByKey(askKey: string): InternalPending | undefined {
+  for (const ask of pending.values()) if (ask.askKey === askKey) return ask;
   return undefined;
 }
 
 /**
- * Re-attach a reconnecting hook to a restored dormant ask. Flips dormant →
- * active. Two cases:
- *  - answer already stashed (user clicked before the hook reconnected): resolve
- *    immediately with the durable-handoff result, mark settled, and remove the
- *    persisted record (codex P1-1). No new card, no new timer.
- *  - still awaiting a click: install a fresh waiter + timeout re-armed to the
- *    ORIGINAL absolute deadline; if the card was never confirmed sent, re-send
- *    it (idempotent by requestId) so the user has exactly one live card.
+ * Re-attach a reconnecting hook to a restored DORMANT ask. Two cases:
+ *  - answer already stashed (click → reattach): deliver the durable-handoff
+ *    result immediately, settle, remove the persisted record. No new card/timer.
+ *  - still awaiting a click: install a waiter + timeout re-armed to the ORIGINAL
+ *    absolute deadline; re-send the card if it was never confirmed sent.
  */
-function reattachDormantAsk(ask: InternalPending): Promise<AskResult> {
-  // Case 1: durable handoff — answer arrived while dormant.
+function reattachByRequest(ask: InternalPending): Promise<AskResult> {
   if (ask.answeredResult) {
     const result = ask.answeredResult;
     ask.dormant = false;
     ask.settled = true;
     ask.settledAt = Date.now();
+    ask.terminalResult = result;
     clearTimeout(ask.timeoutHandle);
     persistStore?.remove(ask.askKey); // claimed → durable record no longer needed
     gcSettled();
-    logger.info?.(
-      `ask-broker: re-attach delivered stashed answer for ask ${ask.askId} (key=${ask.askKey})`,
-    );
+    logger.info?.(`ask-broker: re-attach delivered stashed answer for ask ${ask.askId} (key=${ask.askKey})`);
     return Promise.resolve(result);
   }
 
-  // Case 2: still awaiting a click.
   return new Promise<AskResult>((resolve) => {
     ask.dormant = false;
-    ask.resolve = resolve;
-    // Replace the dormant-phase deadline timer rather than leaking it. Re-arm to
-    // the surviving absolute deadline (not a fresh full timeout — the clock kept
-    // running while the daemon was down).
+    ask.waiters.push(resolve);
     clearTimeout(ask.timeoutHandle);
     const remaining = Math.max(0, ask.deadlineAt - Date.now());
     ask.timeoutHandle = setTimeout(() => {
-      settle(ask.askId, {
-        kind: 'timedOut', selected: null, by: null, comment: null, timedOut: true,
-      });
+      settle(ask.askId, { kind: 'timedOut', selected: null, by: null, comment: null, timedOut: true });
     }, remaining);
     ask.timeoutHandle.unref?.();
     logger.info?.(
       `ask-broker: re-attached hook to restored ask ${ask.askId} (key=${ask.askKey}, ` +
       `${Math.round(remaining / 1000)}s left, card=${ask.cardMessageId ? 'live' : 'MISSING→resend'})`,
     );
-    // Card was never confirmed sent before the restart — send it now so the user
-    // has a card to click (idempotent by requestId; a partial-success prior send
-    // returns the same message_id).
     if (!ask.cardMessageId) sendCardForAsk(ask);
   });
 }
 
-/** Build the persisted projection from a live internal ask and write it. */
+/** Build the persisted projection from a live internal ask and write it. Only
+ *  called for resumable asks. */
 function persistFromInternal(ask: InternalPending): void {
-  if (!persistStore) return;
+  if (!persistStore || !ask.resumable) return;
   // A settled ask with a stashed answer is a durable handoff that must be KEPT
   // until claimed; a settled ask without one has nothing left to resume.
   if (ask.settled && !ask.answeredResult) return;
@@ -349,7 +351,7 @@ function persistFromInternal(ask: InternalPending): void {
     deadlineAt: ask.deadlineAt,
     cardMessageId: ask.cardMessageId,
     selections: ask.questions.map((_, i) => [...(ask.selections.get(i) ?? new Set<string>())]),
-    ...(ask.answeredResult ? { answeredResult: ask.answeredResult } : {}),
+    ...(ask.answeredResult ? { answeredResult: ask.answeredResult, answeredAt: ask.settledAt ?? Date.now() } : {}),
   };
   persistStore.put(persisted);
 }
@@ -622,6 +624,7 @@ export function restorePersistedAsks(now: number = Date.now(), larkAppId?: strin
       askKey: p.askKey,
       requestId: p.requestId,
       originKind: p.originKind,
+      resumable: true, // only resumable origins were ever persisted
       nonce: p.nonce,
       larkAppId: p.larkAppId,
       chatId: p.chatId,
@@ -634,10 +637,10 @@ export function restorePersistedAsks(now: number = Date.now(), larkAppId?: strin
       cardMessageId: p.cardMessageId,
       settled: false,
       dormant: true,
+      waiters: [], // attached when the reconnecting hook re-registers
       // Carry a stashed answer forward (user answered before restart): the
-      // reconnecting hook claims it via reattachDormantAsk.
-      ...(p.answeredResult ? { answeredResult: p.answeredResult } : {}),
-      // No resolve yet — attached when the reconnecting hook re-registers.
+      // reconnecting hook claims it via reattachByRequest.
+      ...(p.answeredResult ? { answeredResult: p.answeredResult, terminalResult: p.answeredResult } : {}),
       timeoutHandle,
       selections,
     };
@@ -671,12 +674,13 @@ function settle(askId: string, result: AskResult): void {
   // can claim it (reattachDormantAsk delivers + removes). Only answered results
   // are worth stashing — a dormant ask that timed out / was invalidated has no
   // consumer to hand off to, so it settles+cleans normally.
-  if (ask.dormant && !ask.resolve && result.kind === 'answered') {
+  if (ask.dormant && ask.waiters.length === 0 && result.kind === 'answered') {
     ask.settled = true;
     ask.settledAt = Date.now();
     ask.answeredResult = result;
+    ask.terminalResult = result;
     clearTimeout(ask.timeoutHandle);
-    persistFromInternal(ask); // re-persist WITH answeredResult (not removed)
+    persistFromInternal(ask); // re-persist WITH answeredResult + answeredAt (kept until claimed)
     logger.info?.(`ask-broker: stashed answer for dormant ask ${askId} (key=${ask.askKey}) — awaiting hook claim`);
     // Still notify the card layer so the Feishu card flips to its settled view.
     notifyOnSettle(ask, result);
@@ -685,22 +689,28 @@ function settle(askId: string, result: AskResult): void {
 
   ask.settled = true;
   ask.settledAt = Date.now();
+  ask.terminalResult = result; // retained for a same-requestId replay in the ambiguous window
   clearTimeout(ask.timeoutHandle);
   // The durable record's job is done the moment the ask leaves the pending
-  // state (delivered to a live waiter, or a terminal non-answer) — drop it so a
+  // state (delivered to live waiters, or a terminal non-answer) — drop it so a
   // later restart doesn't resurrect a settled ask.
   persistStore?.remove(ask.askKey);
   // Reap older settled entries opportunistically — keeps the map bounded
   // without paying for a dedicated GC timer.
   gcSettled();
 
-  // A dormant ask has no waiter Promise — guard the call.
-  try {
-    ask.resolve?.(result);
-  } catch (err) {
-    logger.warn?.(
-      `ask-broker: ${askId} resolve threw: ${err instanceof Error ? err.message : String(err)}`,
-    );
+  // Resolve every waiter (normally one; >1 when a same-requestId active replay
+  // joined). A dormant ask has no waiters — the loop simply no-ops.
+  const waiters = ask.waiters;
+  ask.waiters = [];
+  for (const w of waiters) {
+    try {
+      w(result);
+    } catch (err) {
+      logger.warn?.(
+        `ask-broker: ${askId} waiter threw: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   notifyOnSettle(ask, result);
@@ -728,13 +738,18 @@ function notifyOnSettle(ask: InternalPending, result: AskResult): void {
 function snapshot(ask: InternalPending): PendingAsk {
   const {
     // Runtime-only / broker-internal fields excluded from the IM contract:
-    resolve: _r, timeoutHandle: _t, settledAt: _sat, selections: _sel,
-    askKey: _ak, requestId: _rid, originKind: _ok, dormant: _dm, answeredResult: _ar,
+    waiters: _w, timeoutHandle: _t, settledAt: _sat, selections: _sel,
+    askKey: _ak, requestId: _rid, originKind: _ok, resumable: _rs,
+    dormant: _dm, answeredResult: _ar, terminalResult: _tr,
     ...rest
   } = ask;
   return {
     ...rest,
     selections: ask.questions.map((_, i) => [...(ask.selections.get(i) ?? new Set<string>())]),
+    // Resumable asks carry a stable dedupe token so a re-send (after restart)
+    // is idempotent on the Feishu side. Non-resumable asks (explicit / one-shot)
+    // don't re-send, so they don't need it.
+    ...(ask.resumable ? { dispatchUuid: dispatchUuidFor(ask.requestId) } : {}),
   };
 }
 

--- a/src/core/ask-persist-store.ts
+++ b/src/core/ask-persist-store.ts
@@ -1,5 +1,5 @@
 /**
- * ask-persist-store — file-backed pending `botmux ask` state.
+ * ask-persist-store — file-backed pending `botmux ask` state (injectable).
  *
  * Why this exists: the ask broker's pending registry is an in-memory Map, so a
  * daemon restart between "card posted" and "user clicked" loses the ask. The
@@ -9,49 +9,63 @@
  * the answer. (See the AskUserQuestion picker-desync investigation.)
  *
  * This module owns the durable projection of each pending ask under
- * `<dataDir>/asks/<askKey>.json`. The broker persists on create, removes on
- * settle, and on boot re-hydrates them as "dormant" asks (card still live in
- * Feishu, but no waiter yet). When the surviving CLI hook reconnects and
- * re-POSTs the same ask, the broker matches it by `askKey` and re-attaches a
- * fresh waiter Promise + timeout to the dormant entry — so the answer flows back
- * through the normal hook directive, no native picker, no keystroke driving.
+ * `<storeDir>/<askKey>.json`. The broker persists on create, updates on card /
+ * selection / terminal-answer change, and removes once the answer is CLAIMED by
+ * the reconnecting hook. On boot the broker re-hydrates them as "dormant" asks
+ * (card still live in Feishu, no waiter yet).
+ *
+ * DEPENDENCY INJECTION (codex P1-4): the store is created with an explicit
+ * directory rather than reading `config.session.dataDir` at call time. Tests
+ * inject a temp dir and delete only their own sentinel-guarded directory; the
+ * broker never bulk-cleans a shared/global dataDir (a test helper doing that
+ * could delete a LIVE pending ask). Production wires the real dir once at
+ * daemon bootstrap.
  *
  * Design mirrors `workflows/v3/gate-wait-store.ts` (also "survive restart"):
- * atomic writes, fsync durability, a `listPersistedAsks` restore scan. Kept
- * bot-agnostic and pure file IO so it's testable without the daemon.
+ * atomic writes, fsync durability, a `list()` restore scan.
  *
- * `askKey` is a STABLE identity for an ask across restarts: derived by the
- * caller (daemon) from `BOTMUX_SESSION_ID` (unchanged across a daemon restart —
- * it is the CLI process's spawn-time env) + a hash of the questions. The
- * reconnecting hook, being the same CLI process, recomputes the identical key
- * and so re-attaches to its own dormant ask rather than posting a duplicate
- * card.
+ * IDENTITY (codex影响面纠正): `askKey` is supplied by the caller and is derived
+ * from a per-invocation `requestId` (generated once by the hook, reused across
+ * retries) + an `originKind` (hook-ask vs explicit `botmux ask buttons`). This
+ * is a true invocation identity — unlike a questions hash it distinguishes two
+ * concurrent same-question asks and two same-question invocations 24h apart, and
+ * prevents an explicit ask from re-claiming a hook ask's card.
  */
 
-import { createHash } from 'node:crypto';
 import {
   existsSync,
   mkdirSync,
   readFileSync,
   readdirSync,
   unlinkSync,
+  writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
 
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
-import { config } from '../config.js';
 import { logger } from '../utils/logger.js';
-import type { AskQuestion } from './ask-types.js';
+import type { AskQuestion, AskResult } from './ask-types.js';
 
-/** Persisted shape — everything needed to re-hydrate a dormant ask + re-render
- *  its card. Deliberately excludes runtime-only fields (resolve fn, timers). */
+/** Sentinel file marking a directory as a botmux ask store. teardown/reset only
+ *  ever touches a directory that contains this file — a guard against a missing
+ *  temp override accidentally reaping a real data dir. */
+export const ASK_STORE_SENTINEL = '.botmux-ask-store';
+
+/** Persisted shape — everything needed to re-hydrate a dormant ask, re-render or
+ *  re-send its card, and hand off an answer that arrived before the hook
+ *  reconnected. Excludes runtime-only fields (resolve fn, timers). */
 export interface PersistedAsk {
   /** Schema version so a future field change can migrate/skip cleanly. */
-  v: 1;
-  /** Stable cross-restart identity (see module doc). */
+  v: 2;
+  /** Stable cross-restart identity = `${originKind}.${requestId}` (see module doc). */
   askKey: string;
-  /** The random per-process askId assigned when first registered. Retained so a
-   *  restored ask keeps a stable id for logging/snapshots; a re-attach keeps it. */
+  /** Per-invocation id the hook generates once and reuses across retries. */
+  requestId: string;
+  /** Distinguishes a hook AskUserQuestion from an explicit `botmux ask buttons`
+   *  so they can never re-claim each other's card. */
+  originKind: string;
+  /** Random per-process askId assigned at first register; kept stable across
+   *  restore/re-attach for logging + card action values. */
   askId: string;
   nonce: string;
   larkAppId: string;
@@ -62,111 +76,120 @@ export interface PersistedAsk {
   questions: ReadonlyArray<AskQuestion>;
   createdAt: number;
   deadlineAt: number;
-  /** Feishu message id of the posted card, once dispatch landed. Undefined until
-   *  the card send resolves; a restored ask without it can still be re-sent. */
+  /** Feishu message id of the posted card, once dispatch landed. Undefined means
+   *  the card has NOT been confirmed sent — restore/re-attach must (idempotently,
+   *  keyed by requestId) send it so the user always has exactly one live card. */
   cardMessageId?: string;
   /** Accumulated per-question selections (checkbox state), so a restart mid-
    *  multi-select keeps the boxes the user already ticked. */
   selections: ReadonlyArray<ReadonlyArray<string>>;
+  /** Durable handoff (codex P1-1): a terminal answer that arrived while the ask
+   *  was dormant (user clicked before the hook reconnected). The record is NOT
+   *  deleted on settle in that case — it is retained here until the reconnecting
+   *  hook CLAIMS it, then removed. Absent while still awaiting a click. */
+  answeredResult?: AskResult;
 }
 
-/** Compute the stable cross-restart key for an ask. Same session + same
- *  questions → same key, so a reconnecting hook re-attaches deterministically.
- *  The questions hash guards against two concurrent asks from one session
- *  colliding (rare, but possible if a CLI fires two AskUserQuestion in flight).
- */
-export function computeAskKey(sessionId: string, questions: ReadonlyArray<AskQuestion>): string {
-  const shape = JSON.stringify(
-    questions.map((q) => ({
-      p: q.prompt,
-      m: !!q.multiSelect,
-      o: q.options.map((o) => o.key),
-    })),
-  );
-  const h = createHash('sha256').update(shape).digest('hex').slice(0, 16);
-  // sessionId is already filesystem-safe (uuid-ish); keep it readable in the
-  // filename, append the questions hash for collision resistance.
-  return `${sanitizeKeySegment(sessionId)}.${h}`;
+/** Build the stable identity key from the invocation id + origin. */
+export function askKeyFor(originKind: string, requestId: string): string {
+  return `${sanitizeKeySegment(originKind)}.${sanitizeKeySegment(requestId)}`;
 }
 
 /** Keep a key segment safe as a path component (no separators / traversal). */
 function sanitizeKeySegment(s: string): string {
-  return s.replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 80);
+  return String(s).replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 80);
 }
 
-function asksDir(): string {
-  return join(config.session.dataDir, 'asks');
+export interface AskPersistStore {
+  /** Absolute directory this store owns. */
+  readonly dir: string;
+  /** Create-or-update a record. Best-effort durable (atomic rename + fsync). */
+  put(ask: PersistedAsk): void;
+  /** Remove a record by key. Idempotent (missing file is not an error). */
+  remove(askKey: string): void;
+  /** Load all valid, unexpired records (reaps corrupt / wrong-version / expired). */
+  list(now?: number): PersistedAsk[];
 }
 
-function askFilePath(askKey: string): string {
-  return join(asksDir(), `${sanitizeKeySegment(askKey)}.json`);
-}
+/**
+ * Create a store bound to an explicit directory. The directory is created (with
+ * a sentinel) lazily on first write. Nothing here reads global config — the
+ * caller decides the path, which is what makes the broker testable without
+ * touching live data.
+ */
+export function createAskPersistStore(dir: string): AskPersistStore {
+  const filePath = (askKey: string): string => join(dir, `${sanitizeKeySegment(askKey)}.json`);
 
-/** Persist (create or update) a pending ask. Called on register and whenever
- *  cardMessageId / selections change so a restart mid-interaction is faithful.
- *  Best-effort durable: atomic rename + fsync via atomicWriteFileSync. */
-export function persistAsk(ask: PersistedAsk): void {
-  try {
-    mkdirSync(asksDir(), { recursive: true });
-    atomicWriteFileSync(askFilePath(ask.askKey), JSON.stringify(ask), { mode: 0o600, durable: true });
-  } catch (e) {
-    // Persistence is a resilience enhancement, never a correctness gate for the
-    // live path: a failed write just means this ask won't survive a restart.
-    logger.warn?.(
-      `ask-persist: failed to persist ${ask.askKey}: ${e instanceof Error ? e.message : String(e)}`,
-    );
-  }
-}
-
-/** Remove a persisted ask (on settle: answered / timed out / invalidated).
- *  Idempotent — a missing file is not an error. */
-export function removePersistedAsk(askKey: string): void {
-  try {
-    unlinkSync(askFilePath(askKey));
-  } catch (e) {
-    if ((e as NodeJS.ErrnoException).code === 'ENOENT') return;
-    logger.warn?.(
-      `ask-persist: failed to remove ${askKey}: ${e instanceof Error ? e.message : String(e)}`,
-    );
-  }
-}
-
-/** Load all persisted asks for restart recovery. Skips corrupt / wrong-version
- *  / already-expired entries (and reaps the expired files). Never throws — a
- *  bad store must not block daemon boot. */
-export function listPersistedAsks(now: number = Date.now()): PersistedAsk[] {
-  const dir = asksDir();
-  if (!existsSync(dir)) return [];
-  let names: string[];
-  try {
-    names = readdirSync(dir).filter((n) => n.endsWith('.json'));
-  } catch (e) {
-    logger.warn?.(
-      `ask-persist: cannot read ${dir}: ${e instanceof Error ? e.message : String(e)}`,
-    );
-    return [];
-  }
-  const out: PersistedAsk[] = [];
-  for (const name of names) {
-    const fp = join(dir, name);
-    let parsed: PersistedAsk | undefined;
-    try {
-      parsed = JSON.parse(readFileSync(fp, 'utf-8')) as PersistedAsk;
-    } catch {
-      // Corrupt/racing write — drop it so it can't wedge recovery.
-      try { unlinkSync(fp); } catch { /* ignore */ }
-      continue;
+  function ensureDir(): void {
+    mkdirSync(dir, { recursive: true });
+    const sentinel = join(dir, ASK_STORE_SENTINEL);
+    if (!existsSync(sentinel)) {
+      try { writeFileSync(sentinel, 'botmux ask persist store\n', { mode: 0o600 }); } catch { /* best effort */ }
     }
-    if (!parsed || parsed.v !== 1 || !parsed.askKey || !Array.isArray(parsed.questions)) {
-      try { unlinkSync(fp); } catch { /* ignore */ }
-      continue;
-    }
-    if (typeof parsed.deadlineAt === 'number' && parsed.deadlineAt <= now) {
-      // Already past its deadline while the daemon was down — nothing to resume.
-      try { unlinkSync(fp); } catch { /* ignore */ }
-      continue;
-    }
-    out.push(parsed);
   }
-  return out;
+
+  return {
+    dir,
+    put(ask: PersistedAsk): void {
+      try {
+        ensureDir();
+        atomicWriteFileSync(filePath(ask.askKey), JSON.stringify(ask), { mode: 0o600, durable: true });
+      } catch (e) {
+        // Persistence is a resilience enhancement, never a correctness gate for
+        // the live path: a failed write just means this ask won't survive a
+        // restart.
+        logger.warn?.(
+          `ask-persist: failed to persist ${ask.askKey}: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    },
+    remove(askKey: string): void {
+      try {
+        unlinkSync(filePath(askKey));
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code === 'ENOENT') return;
+        logger.warn?.(
+          `ask-persist: failed to remove ${askKey}: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    },
+    list(now: number = Date.now()): PersistedAsk[] {
+      if (!existsSync(dir)) return [];
+      let names: string[];
+      try {
+        names = readdirSync(dir).filter((n) => n.endsWith('.json'));
+      } catch (e) {
+        logger.warn?.(`ask-persist: cannot read ${dir}: ${e instanceof Error ? e.message : String(e)}`);
+        return [];
+      }
+      const out: PersistedAsk[] = [];
+      for (const name of names) {
+        const fp = join(dir, name);
+        let parsed: PersistedAsk | undefined;
+        try {
+          parsed = JSON.parse(readFileSync(fp, 'utf-8')) as PersistedAsk;
+        } catch {
+          try { unlinkSync(fp); } catch { /* ignore */ }
+          continue;
+        }
+        if (!parsed || parsed.v !== 2 || !parsed.askKey || !parsed.requestId || !Array.isArray(parsed.questions)) {
+          try { unlinkSync(fp); } catch { /* ignore */ }
+          continue;
+        }
+        // A record carrying an unclaimed answer is kept even past its deadline —
+        // the answer still needs delivering to the reconnecting hook. Only drop
+        // deadline-expired records that were never answered.
+        if (
+          parsed.answeredResult === undefined &&
+          typeof parsed.deadlineAt === 'number' &&
+          parsed.deadlineAt <= now
+        ) {
+          try { unlinkSync(fp); } catch { /* ignore */ }
+          continue;
+        }
+        out.push(parsed);
+      }
+      return out;
+    },
+  };
 }

--- a/src/core/ask-persist-store.ts
+++ b/src/core/ask-persist-store.ts
@@ -106,6 +106,15 @@ export const HANDOFF_RETENTION_MS = 24 * 60 * 60 * 1000; // 24h
  * the same requestId lands on a DIFFERENT key and can never reclaim another
  * session's ask (codex P1-3). The reattach path additionally verifies the full
  * immutable identity (chat/root/questions) before delivering.
+ *
+ * Canonical + INJECTIVE (codex P1-1): each segment is length-prefixed
+ * (`<len>:<raw>`) and joined with `|`. Length-prefixing means no separator can
+ * be forged from segment content and no two distinct tuples can alias — unlike
+ * the previous delimiter-join-then-truncate, which collapsed production-length
+ * keys (a 36-char app id + uuid session pushed the requestId past the 80-char
+ * cut, so two different requestIds sharing an 80-char prefix produced ONE key).
+ * The full string is retained (never truncated); the filesystem-length problem
+ * is solved separately by hashing for the filename, not by cutting the key.
  */
 export function askKeyFor(
   larkAppId: string,
@@ -113,21 +122,22 @@ export function askKeyFor(
   originKind: string,
   requestId: string,
 ): string {
-  return [larkAppId, sessionId, originKind, requestId].map(sanitizeKeySegment).join('.');
+  return [larkAppId, sessionId, originKind, requestId]
+    .map((seg) => {
+      const raw = String(seg);
+      return `${raw.length}:${raw}`;
+    })
+    .join('|');
 }
 
-/** Feishu IM `uuid` dedupe token: ≤50 chars. A requestId is normally a uuid
- *  (36 chars) so it passes through, but an over-long / unusual caller-supplied
- *  requestId is hashed to a stable ≤50 token so the card send is still
- *  idempotent (codex P1-1). */
-export function dispatchUuidFor(requestId: string): string {
-  if (requestId.length <= 50 && /^[A-Za-z0-9_-]+$/.test(requestId)) return requestId;
-  return `ask-${createHash('sha256').update(requestId).digest('hex').slice(0, 40)}`;
-}
-
-/** Keep a key segment safe as a path component (no separators / traversal). */
-function sanitizeKeySegment(s: string): string {
-  return String(s).replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 80);
+/** Feishu IM `uuid` dedupe token (≤50 chars) derived from the FULL scoped ask
+ *  key — NOT the bare requestId (codex P1-1). Deriving from the scoped key means
+ *  a re-send within the same invocation dedupes server-side (same key → same
+ *  uuid → Feishu returns the original message_id), while a different session
+ *  reusing the same requestId gets a DIFFERENT uuid and so cannot alias the
+ *  first session's card. `ask-` + 40 hex = 44 chars, safely under the cap. */
+export function dispatchUuidForKey(askKey: string): string {
+  return `ask-${createHash('sha256').update(`uuid|${askKey}`).digest('hex').slice(0, 40)}`;
 }
 
 export interface AskPersistStore {
@@ -148,7 +158,14 @@ export interface AskPersistStore {
  * touching live data.
  */
 export function createAskPersistStore(dir: string): AskPersistStore {
-  const filePath = (askKey: string): string => join(dir, `${sanitizeKeySegment(askKey)}.json`);
+  // Filename = SHA-256 of the FULL canonical key (codex P1-1). Hashing (not
+  // truncating) means two production-length keys that share a long prefix but
+  // differ in the requestId tail land on DISTINCT files — the previous
+  // `sanitize(key).slice(0,80)` collapsed them because a 36-char app id + uuid
+  // session pushed the requestId past char 80. Fixed-length hex is also always a
+  // valid path component, so no separate sanitize step is needed.
+  const filePath = (askKey: string): string =>
+    join(dir, `${createHash('sha256').update(askKey).digest('hex')}.json`);
 
   function ensureDir(): void {
     mkdirSync(dir, { recursive: true });

--- a/src/core/ask-persist-store.ts
+++ b/src/core/ask-persist-store.ts
@@ -1,0 +1,172 @@
+/**
+ * ask-persist-store — file-backed pending `botmux ask` state.
+ *
+ * Why this exists: the ask broker's pending registry is an in-memory Map, so a
+ * daemon restart between "card posted" and "user clicked" loses the ask. The
+ * user's later click then hits `stale` ("此 ask 已失效"), and the CLI hook that
+ * was blocking on `/api/asks` has meanwhile dropped its connection and fallen
+ * back to passthrough → the CLI renders its native picker with no way to deliver
+ * the answer. (See the AskUserQuestion picker-desync investigation.)
+ *
+ * This module owns the durable projection of each pending ask under
+ * `<dataDir>/asks/<askKey>.json`. The broker persists on create, removes on
+ * settle, and on boot re-hydrates them as "dormant" asks (card still live in
+ * Feishu, but no waiter yet). When the surviving CLI hook reconnects and
+ * re-POSTs the same ask, the broker matches it by `askKey` and re-attaches a
+ * fresh waiter Promise + timeout to the dormant entry — so the answer flows back
+ * through the normal hook directive, no native picker, no keystroke driving.
+ *
+ * Design mirrors `workflows/v3/gate-wait-store.ts` (also "survive restart"):
+ * atomic writes, fsync durability, a `listPersistedAsks` restore scan. Kept
+ * bot-agnostic and pure file IO so it's testable without the daemon.
+ *
+ * `askKey` is a STABLE identity for an ask across restarts: derived by the
+ * caller (daemon) from `BOTMUX_SESSION_ID` (unchanged across a daemon restart —
+ * it is the CLI process's spawn-time env) + a hash of the questions. The
+ * reconnecting hook, being the same CLI process, recomputes the identical key
+ * and so re-attaches to its own dormant ask rather than posting a duplicate
+ * card.
+ */
+
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  unlinkSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
+import { config } from '../config.js';
+import { logger } from '../utils/logger.js';
+import type { AskQuestion } from './ask-types.js';
+
+/** Persisted shape — everything needed to re-hydrate a dormant ask + re-render
+ *  its card. Deliberately excludes runtime-only fields (resolve fn, timers). */
+export interface PersistedAsk {
+  /** Schema version so a future field change can migrate/skip cleanly. */
+  v: 1;
+  /** Stable cross-restart identity (see module doc). */
+  askKey: string;
+  /** The random per-process askId assigned when first registered. Retained so a
+   *  restored ask keeps a stable id for logging/snapshots; a re-attach keeps it. */
+  askId: string;
+  nonce: string;
+  larkAppId: string;
+  chatId: string;
+  rootMessageId: string | null;
+  sessionId: string;
+  chatType?: 'group' | 'p2p';
+  questions: ReadonlyArray<AskQuestion>;
+  createdAt: number;
+  deadlineAt: number;
+  /** Feishu message id of the posted card, once dispatch landed. Undefined until
+   *  the card send resolves; a restored ask without it can still be re-sent. */
+  cardMessageId?: string;
+  /** Accumulated per-question selections (checkbox state), so a restart mid-
+   *  multi-select keeps the boxes the user already ticked. */
+  selections: ReadonlyArray<ReadonlyArray<string>>;
+}
+
+/** Compute the stable cross-restart key for an ask. Same session + same
+ *  questions → same key, so a reconnecting hook re-attaches deterministically.
+ *  The questions hash guards against two concurrent asks from one session
+ *  colliding (rare, but possible if a CLI fires two AskUserQuestion in flight).
+ */
+export function computeAskKey(sessionId: string, questions: ReadonlyArray<AskQuestion>): string {
+  const shape = JSON.stringify(
+    questions.map((q) => ({
+      p: q.prompt,
+      m: !!q.multiSelect,
+      o: q.options.map((o) => o.key),
+    })),
+  );
+  const h = createHash('sha256').update(shape).digest('hex').slice(0, 16);
+  // sessionId is already filesystem-safe (uuid-ish); keep it readable in the
+  // filename, append the questions hash for collision resistance.
+  return `${sanitizeKeySegment(sessionId)}.${h}`;
+}
+
+/** Keep a key segment safe as a path component (no separators / traversal). */
+function sanitizeKeySegment(s: string): string {
+  return s.replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 80);
+}
+
+function asksDir(): string {
+  return join(config.session.dataDir, 'asks');
+}
+
+function askFilePath(askKey: string): string {
+  return join(asksDir(), `${sanitizeKeySegment(askKey)}.json`);
+}
+
+/** Persist (create or update) a pending ask. Called on register and whenever
+ *  cardMessageId / selections change so a restart mid-interaction is faithful.
+ *  Best-effort durable: atomic rename + fsync via atomicWriteFileSync. */
+export function persistAsk(ask: PersistedAsk): void {
+  try {
+    mkdirSync(asksDir(), { recursive: true });
+    atomicWriteFileSync(askFilePath(ask.askKey), JSON.stringify(ask), { mode: 0o600, durable: true });
+  } catch (e) {
+    // Persistence is a resilience enhancement, never a correctness gate for the
+    // live path: a failed write just means this ask won't survive a restart.
+    logger.warn?.(
+      `ask-persist: failed to persist ${ask.askKey}: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+}
+
+/** Remove a persisted ask (on settle: answered / timed out / invalidated).
+ *  Idempotent — a missing file is not an error. */
+export function removePersistedAsk(askKey: string): void {
+  try {
+    unlinkSync(askFilePath(askKey));
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') return;
+    logger.warn?.(
+      `ask-persist: failed to remove ${askKey}: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+}
+
+/** Load all persisted asks for restart recovery. Skips corrupt / wrong-version
+ *  / already-expired entries (and reaps the expired files). Never throws — a
+ *  bad store must not block daemon boot. */
+export function listPersistedAsks(now: number = Date.now()): PersistedAsk[] {
+  const dir = asksDir();
+  if (!existsSync(dir)) return [];
+  let names: string[];
+  try {
+    names = readdirSync(dir).filter((n) => n.endsWith('.json'));
+  } catch (e) {
+    logger.warn?.(
+      `ask-persist: cannot read ${dir}: ${e instanceof Error ? e.message : String(e)}`,
+    );
+    return [];
+  }
+  const out: PersistedAsk[] = [];
+  for (const name of names) {
+    const fp = join(dir, name);
+    let parsed: PersistedAsk | undefined;
+    try {
+      parsed = JSON.parse(readFileSync(fp, 'utf-8')) as PersistedAsk;
+    } catch {
+      // Corrupt/racing write — drop it so it can't wedge recovery.
+      try { unlinkSync(fp); } catch { /* ignore */ }
+      continue;
+    }
+    if (!parsed || parsed.v !== 1 || !parsed.askKey || !Array.isArray(parsed.questions)) {
+      try { unlinkSync(fp); } catch { /* ignore */ }
+      continue;
+    }
+    if (typeof parsed.deadlineAt === 'number' && parsed.deadlineAt <= now) {
+      // Already past its deadline while the daemon was down — nothing to resume.
+      try { unlinkSync(fp); } catch { /* ignore */ }
+      continue;
+    }
+    out.push(parsed);
+  }
+  return out;
+}

--- a/src/core/ask-persist-store.ts
+++ b/src/core/ask-persist-store.ts
@@ -40,6 +40,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
@@ -88,11 +89,40 @@ export interface PersistedAsk {
    *  deleted on settle in that case — it is retained here until the reconnecting
    *  hook CLAIMS it, then removed. Absent while still awaiting a click. */
   answeredResult?: AskResult;
+  /** epoch ms the answer was stashed. Bounds handoff retention so an answer that
+   *  is never claimed (e.g. the CLI is gone for good) is eventually reaped
+   *  instead of accumulating forever (codex P1-4). */
+  answeredAt?: number;
 }
 
-/** Build the stable identity key from the invocation id + origin. */
-export function askKeyFor(originKind: string, requestId: string): string {
-  return `${sanitizeKeySegment(originKind)}.${sanitizeKeySegment(requestId)}`;
+/** How long an unclaimed answered-handoff record is kept before `list()` reaps
+ *  it. Generous (a reconnecting hook claims within seconds of a restart) but
+ *  bounded so a dead CLI's stash can't live forever. */
+export const HANDOFF_RETENTION_MS = 24 * 60 * 60 * 1000; // 24h
+
+/**
+ * Build the stable identity key. Scoped to `larkAppId + sessionId + originKind +
+ * requestId` so the key is NOT a bearer secret: a different bot/session reusing
+ * the same requestId lands on a DIFFERENT key and can never reclaim another
+ * session's ask (codex P1-3). The reattach path additionally verifies the full
+ * immutable identity (chat/root/questions) before delivering.
+ */
+export function askKeyFor(
+  larkAppId: string,
+  sessionId: string,
+  originKind: string,
+  requestId: string,
+): string {
+  return [larkAppId, sessionId, originKind, requestId].map(sanitizeKeySegment).join('.');
+}
+
+/** Feishu IM `uuid` dedupe token: ≤50 chars. A requestId is normally a uuid
+ *  (36 chars) so it passes through, but an over-long / unusual caller-supplied
+ *  requestId is hashed to a stable ≤50 token so the card send is still
+ *  idempotent (codex P1-1). */
+export function dispatchUuidFor(requestId: string): string {
+  if (requestId.length <= 50 && /^[A-Za-z0-9_-]+$/.test(requestId)) return requestId;
+  return `ask-${createHash('sha256').update(requestId).digest('hex').slice(0, 40)}`;
 }
 
 /** Keep a key segment safe as a path component (no separators / traversal). */
@@ -176,14 +206,18 @@ export function createAskPersistStore(dir: string): AskPersistStore {
           try { unlinkSync(fp); } catch { /* ignore */ }
           continue;
         }
-        // A record carrying an unclaimed answer is kept even past its deadline —
-        // the answer still needs delivering to the reconnecting hook. Only drop
-        // deadline-expired records that were never answered.
-        if (
-          parsed.answeredResult === undefined &&
-          typeof parsed.deadlineAt === 'number' &&
-          parsed.deadlineAt <= now
-        ) {
+        // Reap rules:
+        //  - answered-handoff records are kept until CLAIMED, but bounded by
+        //    HANDOFF_RETENTION_MS from answeredAt so an unclaimed stash (dead
+        //    CLI) can't accumulate forever (codex P1-4).
+        //  - never-answered records are dropped once past their deadline.
+        if (parsed.answeredResult !== undefined) {
+          const stashedAt = typeof parsed.answeredAt === 'number' ? parsed.answeredAt : parsed.createdAt;
+          if (now - stashedAt > HANDOFF_RETENTION_MS) {
+            try { unlinkSync(fp); } catch { /* ignore */ }
+            continue;
+          }
+        } else if (typeof parsed.deadlineAt === 'number' && parsed.deadlineAt <= now) {
           try { unlinkSync(fp); } catch { /* ignore */ }
           continue;
         }

--- a/src/core/ask-types.ts
+++ b/src/core/ask-types.ts
@@ -250,17 +250,22 @@ export function isRetryableAskHttpStatus(status: number): boolean {
  * decision seam). PURE + exported so daemon.ts and its unit test share the SAME
  * predicate rather than asserting against source regex.
  *
- * True iff a NON-trusted caller's session lookup missed AND session restore
- * hasn't finished — the reconnecting hook is racing `restoreActiveSessions`, so
- * a permanent 403 here would drop it to passthrough (stuck native picker). A 503
- * (which `isRetryableAskHttpStatus` marks retryable) keeps the hook blocking
- * until restore binds its session. A trusted-host IPC caller bypasses this (it
- * isn't a session-scoped hook).
+ * True iff an unknown session hits the route while restore is still in flight —
+ * regardless of how the caller authenticated. The earlier `trustedHost` escape
+ * was WRONG (codex P1-2): a normal unsandbox hook IS the trusted-host path
+ * (`postAsk` loads the host secret and calls the HMAC `fetchDaemonIpc` when
+ * there's no relay), so exempting trusted callers let exactly the reconnecting
+ * hook we must protect slip through during the descriptor-published-but-sessions-
+ * not-yet-restored window — it would then register a NEW ask computed as
+ * `backendSurvivesRestart:false` (session unknown) and be lost on the next
+ * restart. Every `POST /api/asks` caller is a session-scoped ask registration
+ * (the desktop/dashboard ANSWER path is a different route), so gating all
+ * unknown sessions here is safe: once `sessionsRestored` flips true the gate
+ * lifts and unknown sessions fall through to normal authorization.
  */
 export function shouldReturnAskStartupNotReady(args: {
   hasSession: boolean;
   sessionsRestored: boolean;
-  trustedHost: boolean;
 }): boolean {
-  return !args.hasSession && !args.sessionsRestored && !args.trustedHost;
+  return !args.hasSession && !args.sessionsRestored;
 }

--- a/src/core/ask-types.ts
+++ b/src/core/ask-types.ts
@@ -103,6 +103,14 @@ export interface CreateAskInput {
    *  'explicit' = `botmux ask buttons`, etc.). Namespaces the identity so an
    *  explicit ask can never re-claim a hook ask's card. Defaults to 'hook'. */
   originKind?: string;
+  /** DAEMON-COMPUTED authoritative persistence gate (codex P1-4): does the
+   *  authenticated issuing session's FROZEN backend survive a daemon restart
+   *  (tmux/herdr/zellij/zmx = yes; pty = no)? The broker persists + resumes ONLY
+   *  when this is true — it must NOT trust the client-supplied `originKind`
+   *  string, since a PTY-session hook could POST `originKind:'hook'` and orphan a
+   *  record that can never be re-claimed. Undefined → treated as false (fail
+   *  closed: don't persist when the backend is unknown). */
+  backendSurvivesRestart?: boolean;
   /** 问题列表，调用方保证每问 `options.length ≥ 2` 且 key 唯一。 */
   questions: ReadonlyArray<AskQuestion>;
   /** Absolute deadline; computed by caller from `--timeout`. Broker won't
@@ -192,4 +200,67 @@ export interface AskCardDispatcher {
     ask: PendingAsk,
     result: AskResult,
   ): void | Promise<void>;
+}
+
+/**
+ * Typed dispatch failure the card dispatcher throws from `send`, so the broker
+ * can decide whether re-sending could help WITHOUT importing IM/HTTP types
+ * (codex P1-3). The IM side owns classification (it alone sees the AxiosError /
+ * Feishu code); the broker owns the bounded retry policy.
+ *
+ *   - `retryable: true`  → transient (5xx / 429 / network / no-response). The
+ *     broker re-sends with the SAME dispatchUuid, so a send that actually landed
+ *     server-side before the socket broke returns the original message_id (one
+ *     logical card) instead of duplicating.
+ *   - `retryable: false` → deterministic (4xx bad request / permission /
+ *     withdrawn / malformed). Retrying can't help; the broker invalidates now.
+ *
+ * A plain (untyped) error thrown from `send` is treated as NOT retryable — fail
+ * closed, since we can't prove a re-send is safe/idempotent.
+ */
+export class AskDispatchError extends Error {
+  readonly retryable: boolean;
+  constructor(message: string, retryable: boolean) {
+    super(message);
+    this.name = 'AskDispatchError';
+    this.retryable = retryable;
+  }
+}
+
+/**
+ * Whether a daemon `/api/asks` HTTP status is worth the hook retrying (codex
+ * P1-3, executable decision seam). PURE + exported so cli.ts's `postAsk` AND its
+ * unit test call the SAME function — the retry contract is exercised by real
+ * calls, not asserted against source text.
+ *
+ * Retryable = the daemon is up but transiently unready: 502/503/504 (e.g. the
+ * startup readiness window returns 503 `startup_not_ready`). Everything else is
+ * deterministic — a 4xx (bad body / capability denied / unsupported chat) fails
+ * identically forever, so the hook should stop retrying and passthrough. The
+ * no-daemon and network-failure legs are classified retryable separately at
+ * their throw sites (there is no HTTP status there).
+ */
+export function isRetryableAskHttpStatus(status: number): boolean {
+  return status === 502 || status === 503 || status === 504;
+}
+
+/**
+ * Whether the daemon's `/api/asks` handler must answer a RETRYABLE 503
+ * `startup_not_ready` instead of proceeding (codex P1-2/P1-4, executable
+ * decision seam). PURE + exported so daemon.ts and its unit test share the SAME
+ * predicate rather than asserting against source regex.
+ *
+ * True iff a NON-trusted caller's session lookup missed AND session restore
+ * hasn't finished — the reconnecting hook is racing `restoreActiveSessions`, so
+ * a permanent 403 here would drop it to passthrough (stuck native picker). A 503
+ * (which `isRetryableAskHttpStatus` marks retryable) keeps the hook blocking
+ * until restore binds its session. A trusted-host IPC caller bypasses this (it
+ * isn't a session-scoped hook).
+ */
+export function shouldReturnAskStartupNotReady(args: {
+  hasSession: boolean;
+  sessionsRestored: boolean;
+  trustedHost: boolean;
+}): boolean {
+  return !args.hasSession && !args.sessionsRestored && !args.trustedHost;
 }

--- a/src/core/ask-types.ts
+++ b/src/core/ask-types.ts
@@ -93,6 +93,16 @@ export interface CreateAskInput {
   rootMessageId: string | null;
   /** Session that issued the ask — used for audit + future replay scoping. */
   sessionId: string;
+  /** Per-invocation identity: the hook generates this once and reuses it across
+   *  reconnect retries, so a re-POST after a daemon restart re-attaches to the
+   *  same ask instead of creating a duplicate. Unlike a questions hash it
+   *  distinguishes concurrent same-question asks. Optional for legacy/explicit
+   *  callers that don't need restart-resume; the broker synthesizes one. */
+  requestId?: string;
+  /** What kind of caller issued this ask ('hook' = AskUserQuestion PreToolUse,
+   *  'explicit' = `botmux ask buttons`, etc.). Namespaces the identity so an
+   *  explicit ask can never re-claim a hook ask's card. Defaults to 'hook'. */
+  originKind?: string;
   /** 问题列表，调用方保证每问 `options.length ≥ 2` 且 key 唯一。 */
   questions: ReadonlyArray<AskQuestion>;
   /** Absolute deadline; computed by caller from `--timeout`. Broker won't

--- a/src/core/ask-types.ts
+++ b/src/core/ask-types.ts
@@ -140,6 +140,11 @@ export interface PendingAsk {
   cardMessageId?: string;
   /** Once true, subsequent click attempts return `already_settled`. */
   settled: boolean;
+  /** Stable Feishu IM dedupe token for the card send (≤50 chars, derived from
+   *  the ask's requestId). The dispatcher passes it as the message `uuid` so a
+   *  re-send after a daemon restart returns the ORIGINAL message_id instead of
+   *  posting a duplicate card. Absent for non-resumable asks. */
+  dispatchUuid?: string;
 }
 
 /** Outcome of a click-resolution attempt. Card click handler maps these to

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -368,6 +368,7 @@ import {
 } from './core/ask-broker.js';
 import { createAskPersistStore } from './core/ask-persist-store.js';
 import { parseAskBody } from './core/ask-api.js';
+import { shouldReturnAskStartupNotReady } from './core/ask-types.js';
 import { computeCocoPickerKeys } from './core/coco-picker-keys.js';
 import { createLarkAskCardDispatcher } from './im/lark/ask-card.js';
 import { normalizeVcMeetingEvents } from './vc-agent/normalizer.js';
@@ -5129,7 +5130,12 @@ ipcRoute('POST', '/api/asks', async (req, res) => {
   // yet, so a reconnecting ask hook's session lookup misses and would otherwise
   // get a permanent 403. Return a RETRYABLE 503 so the hook keeps waiting
   // (blocking Claude, no native picker) until restore finishes and it can bind.
-  if (!askSession && !sessionsRestored && !isTrustedHostIpcRequest(req)) {
+  // Predicate is a shared pure function (unit-tested directly — codex P1-2 seam).
+  if (shouldReturnAskStartupNotReady({
+    hasSession: !!askSession,
+    sessionsRestored,
+    trustedHost: isTrustedHostIpcRequest(req),
+  })) {
     return jsonRes(res, 503, { ok: false, error: 'startup_not_ready' });
   }
   let boundAsk = parsed;
@@ -5219,6 +5225,12 @@ ipcRoute('POST', '/api/asks', async (req, res) => {
     // Invocation identity (from the hook; enables cross-restart re-attach).
     requestId: boundAsk.requestId,
     originKind: boundAsk.originKind,
+    // Authoritative persistence gate (codex P1-4): derive resumability from the
+    // authenticated session's FROZEN backend, not the client's origin string. A
+    // PTY-backed session dies with the daemon, so its ask must NOT persist; only
+    // a restart-surviving mux backend (tmux/herdr/zellij/zmx) is resumable.
+    backendSurvivesRestart:
+      !!askSession && getSessionPersistentBackendType(askSession) !== undefined,
   });
 
   // CoCo 专属：它的 hook 不能用 directive 代答（hook 客户端永远 passthrough，CoCo 会

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -360,11 +360,13 @@ import { botAutoWorktreeEnabled } from './services/default-worktree.js';
 import {
   setCardDispatcher as setAskCardDispatcher,
   setCanTalkChecker as setAskCanTalkChecker,
+  setAskPersistStore as setAskPersistStoreBroker,
   registerAsk as registerAskBroker,
   restorePersistedAsks as restorePersistedAsksBroker,
   findPendingAskByAnchor,
   submitCustomReply,
 } from './core/ask-broker.js';
+import { createAskPersistStore } from './core/ask-persist-store.js';
 import { parseAskBody } from './core/ask-api.js';
 import { computeCocoPickerKeys } from './core/coco-picker-keys.js';
 import { createLarkAskCardDispatcher } from './im/lark/ask-card.js';
@@ -5200,6 +5202,9 @@ ipcRoute('POST', '/api/asks', async (req, res) => {
     questions: boundAsk.questions,
     timeoutMs: boundAsk.timeoutMs,
     chatType: askChatType,
+    // Invocation identity (from the hook; enables cross-restart re-attach).
+    requestId: boundAsk.requestId,
+    originKind: boundAsk.originKind,
   });
 
   // CoCo 专属：它的 hook 不能用 directive 代答（hook 客户端永远 passthrough，CoCo 会
@@ -18736,6 +18741,9 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   // waiter, so the answer flows back through the normal hook directive instead
   // of the CLI falling into a stuck native picker. Scoped to this daemon's bot.
   try {
+    // Bind the durable store to the real data dir (dependency-injected so unit
+    // tests use a temp dir and never touch live data — codex P1-4).
+    setAskPersistStoreBroker(createAskPersistStore(join(config.session.dataDir, 'asks')));
     restorePersistedAsksBroker(Date.now(), cfg.larkAppId);
   } catch (e) {
     logger.warn(`[ask] restorePersistedAsks failed: ${e instanceof Error ? e.message : String(e)}`);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -5131,10 +5131,13 @@ ipcRoute('POST', '/api/asks', async (req, res) => {
   // get a permanent 403. Return a RETRYABLE 503 so the hook keeps waiting
   // (blocking Claude, no native picker) until restore finishes and it can bind.
   // Predicate is a shared pure function (unit-tested directly — codex P1-2 seam).
+  // NOTE: this gate does NOT exempt trusted-host callers — a normal unsandbox
+  // hook IS the trusted-host path (HMAC fetchDaemonIpc), so exempting it would
+  // let the very reconnecting hook we must protect register a lost
+  // non-resumable ask during the restore window.
   if (shouldReturnAskStartupNotReady({
     hasSession: !!askSession,
     sessionsRestored,
-    trustedHost: isTrustedHostIpcRequest(req),
   })) {
     return jsonRes(res, 503, { ok: false, error: 'startup_not_ready' });
   }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -528,6 +528,13 @@ import {
 // ─── State ───────────────────────────────────────────────────────────────────
 
 const activeSessions = new Map<string, DaemonSession>();
+/** False until restoreActiveSessions() finishes. During the startup window the
+ *  IPC server is already listening but activeSessions is empty, so a reconnecting
+ *  ask hook would fail session lookup and get a 403 origin_unproven — which the
+ *  CLI would treat as permanent and passthrough into a stuck native picker
+ *  (codex P1-2). While false, /api/asks returns a retryable 503 for unknown
+ *  sessions instead, so the reconnecting hook keeps waiting through the restore. */
+let sessionsRestored = false;
 const VC_MEETING_DELIVERY_LEASE_MS = 15 * 60_000;
 const VC_MEETING_DELIVERY_LEASE_SCAN_MS = 60_000;
 const VC_MEETING_RUNTIME_EXPIRY_ACK_TIMEOUT_MS = 3_000;
@@ -5118,6 +5125,13 @@ ipcRoute('POST', '/api/asks', async (req, res) => {
   if ('error' in parsed) return jsonRes(res, 400, { ok: false, error: parsed.error });
 
   const askSession = findActiveBySessionId(parsed.sessionId);
+  // Startup window (codex P1-2): IPC is listening but sessions aren't restored
+  // yet, so a reconnecting ask hook's session lookup misses and would otherwise
+  // get a permanent 403. Return a RETRYABLE 503 so the hook keeps waiting
+  // (blocking Claude, no native picker) until restore finishes and it can bind.
+  if (!askSession && !sessionsRestored && !isTrustedHostIpcRequest(req)) {
+    return jsonRes(res, 503, { ok: false, error: 'startup_not_ready' });
+  }
   let boundAsk = parsed;
   if (!isTrustedHostIpcRequest(req)) {
     const body = raw && typeof raw === 'object' && !Array.isArray(raw)
@@ -19281,6 +19295,9 @@ export async function startDaemon(botIndex?: number): Promise<void> {
 
   // Restore active sessions from previous run
   await restoreActiveSessions(activeSessions);
+  // Restore complete → /api/asks may now safely 403 unknown sessions again; a
+  // reconnecting ask hook that raced the restore got retryable 503s until here.
+  sessionsRestored = true;
 
   // Now that activeSessions is populated, release the forward-followup flush
   // barrier. Persisted seeds were loaded into the buffer at dispatcher startup

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -361,6 +361,7 @@ import {
   setCardDispatcher as setAskCardDispatcher,
   setCanTalkChecker as setAskCanTalkChecker,
   registerAsk as registerAskBroker,
+  restorePersistedAsks as restorePersistedAsksBroker,
   findPendingAskByAnchor,
   submitCustomReply,
 } from './core/ask-broker.js';
@@ -18727,6 +18728,18 @@ export async function startDaemon(botIndex?: number): Promise<void> {
   setAskCanTalkChecker((appId, chatId, openId, chatType, actor) =>
     evaluateAskAnswerTalk(appId, chatId, openId, chatType, actor),
   );
+
+  // Resume pending `botmux ask` cards that outlived a daemon restart. Each is
+  // restored as a DORMANT ask (card still live in Feishu, no waiter yet). The
+  // surviving CLI hook — whose /api/asks connection dropped on restart and is
+  // retrying — re-registers the same ask by its stable key and re-attaches a
+  // waiter, so the answer flows back through the normal hook directive instead
+  // of the CLI falling into a stuck native picker. Scoped to this daemon's bot.
+  try {
+    restorePersistedAsksBroker(Date.now(), cfg.larkAppId);
+  } catch (e) {
+    logger.warn(`[ask] restorePersistedAsks failed: ${e instanceof Error ? e.message : String(e)}`);
+  }
 
   writePidFile();
   const memoryDiagnostics = startMemoryDiagnostics();

--- a/src/im/lark/ask-card.ts
+++ b/src/im/lark/ask-card.ts
@@ -4,6 +4,7 @@ import type {
   AskResult,
   PendingAsk,
 } from '../../core/ask-types.js';
+import { AskDispatchError } from '../../core/ask-types.js';
 import { getAskSnapshot, submitAsk, toggleAsk, tryResolveAsk } from '../../core/ask-broker.js';
 import { logger } from '../../utils/logger.js';
 import { t, localeForBot, type Locale } from '../../i18n/index.js';
@@ -54,10 +55,18 @@ export function createLarkAskCardDispatcher(
       // re-send after a daemon restart (restart-resume) dedupes server-side and
       // returns the ORIGINAL message_id instead of posting a second card.
       const uuid = ask.dispatchUuid;
-      const messageId = canReplyToRoot
-        ? await reply(ask.larkAppId, ask.rootMessageId!, cardJson, 'interactive', true, uuid)
-        : await send(ask.larkAppId, ask.chatId, cardJson, 'interactive', uuid);
-      return { messageId };
+      try {
+        const messageId = canReplyToRoot
+          ? await reply(ask.larkAppId, ask.rootMessageId!, cardJson, 'interactive', true, uuid)
+          : await send(ask.larkAppId, ask.chatId, cardJson, 'interactive', uuid);
+        return { messageId };
+      } catch (err) {
+        // Re-throw as a typed AskDispatchError so the broker's bounded retry can
+        // decide transient-vs-deterministic without importing HTTP types
+        // (codex P1-3). The same uuid is reused on retry → server-side dedupe.
+        const { retryable, detail } = classifyAskDispatchError(err);
+        throw new AskDispatchError(detail, retryable);
+      }
     },
     async onSettle(ask, result) {
       if (!ask.cardMessageId) return;
@@ -72,6 +81,53 @@ export function createLarkAskCardDispatcher(
       }
     },
   };
+}
+
+/**
+ * Classify a Feishu card-send failure into "worth retrying" vs "give up now"
+ * (codex P1-3). PURE + exported so the retry decision is unit-tested directly
+ * (executable decision seam) rather than asserted against source text.
+ *
+ * Retryable (transient — a re-send with the same uuid may succeed / dedupe):
+ *   - no HTTP response at all (network reset, DNS, timeout)
+ *   - HTTP 429 (rate limited) or any 5xx (server-side)
+ *   - a 2xx-body business error whose message carries no decisive 4xx status
+ *     BUT names a transient Feishu condition (rate limit / internal) — we stay
+ *     conservative and only mark the well-known transient codes retryable.
+ * Not retryable (deterministic — re-sending repeats the same failure):
+ *   - HTTP 4xx other than 429 (bad request, permission, not found)
+ *   - message withdrawn (target gone)
+ *   - anything we can't positively classify → fail closed (retry is unsafe when
+ *     we can't prove idempotency).
+ *
+ * Extraction mirrors bot-registry.formatLarkError: status at `response.status`
+ * or `.status`; Feishu code at `response.data.code` or `.code`.
+ */
+export function classifyAskDispatchError(err: unknown): { retryable: boolean; detail: string } {
+  const e = err as {
+    isAxiosError?: boolean; name?: string; message?: string;
+    response?: { status?: number; data?: { code?: number; msg?: string } };
+    status?: number; code?: number; config?: unknown;
+  } | null | undefined;
+
+  const detail =
+    (e && (e.response?.data?.msg || e.message)) ||
+    (typeof err === 'string' ? err : 'unknown dispatch error');
+
+  const looksAxios =
+    !!e && (e.isAxiosError === true || e.name === 'AxiosError' || (!!e.config && (!!e.response || e.status != null)));
+
+  if (looksAxios) {
+    const status = e!.response?.status ?? e!.status;
+    if (status === undefined) return { retryable: true, detail: `no-response: ${detail}` }; // network/transport
+    if (status === 429 || (status >= 500 && status <= 599)) return { retryable: true, detail: `http ${status}: ${detail}` };
+    return { retryable: false, detail: `http ${status}: ${detail}` }; // deterministic 4xx
+  }
+
+  // Non-axios (plain Error / string). MessageWithdrawnError and the
+  // `res.code !== 0` 2xx-body throws land here — HTTP already succeeded, so a
+  // re-send repeats the same deterministic outcome. Fail closed.
+  return { retryable: false, detail: `non-transport: ${detail}` };
 }
 
 export function isAskCardAction(action?: string): boolean {

--- a/src/im/lark/ask-card.ts
+++ b/src/im/lark/ask-card.ts
@@ -50,9 +50,13 @@ export function createLarkAskCardDispatcher(
       // 所以这里要按前缀判断是否真的能 reply.
       const canReplyToRoot =
         typeof ask.rootMessageId === 'string' && ask.rootMessageId.startsWith('om_');
+      // Pass the ask's stable dispatchUuid as the Feishu message uuid so a
+      // re-send after a daemon restart (restart-resume) dedupes server-side and
+      // returns the ORIGINAL message_id instead of posting a second card.
+      const uuid = ask.dispatchUuid;
       const messageId = canReplyToRoot
-        ? await reply(ask.larkAppId, ask.rootMessageId!, cardJson, 'interactive', true)
-        : await send(ask.larkAppId, ask.chatId, cardJson, 'interactive');
+        ? await reply(ask.larkAppId, ask.rootMessageId!, cardJson, 'interactive', true, uuid)
+        : await send(ask.larkAppId, ask.chatId, cardJson, 'interactive', uuid);
       return { messageId };
     },
     async onSettle(ask, result) {

--- a/src/im/lark/ask-card.ts
+++ b/src/im/lark/ask-card.ts
@@ -84,16 +84,51 @@ export function createLarkAskCardDispatcher(
 }
 
 /**
+ * Feishu business error codes that mean "the request is transient — retry
+ * later", per the official IM v1 send/reply error table + frequency-control
+ * guide (codex P1-3). These must be retryable EVEN when the HTTP status is a
+ * 4xx (some legacy freq-control surfaces as HTTP 400) or a 2xx-body business
+ * error — otherwise a same-uuid partial-success convergence (the second request
+ * arriving while the first is still "being sent") is wrongly given up on.
+ *
+ *   230049  the message is being sent — official "please retry"
+ *   230020  message API per-chat rate limit
+ *   99991400 generic OpenAPI frequency control (modern = HTTP 429, legacy = 400)
+ *
+ * NOT included: 11232 / 11233 are the old V4 message API; the current im.v1
+ * create/reply path never returns them, so mixing them in would only widen the
+ * whitelist without cause.
+ *
+ * Rate-limit codes (99991400 / HTTP 429) ideally honour `x-ogw-ratelimit-reset`
+ * as the retry delay — the broker's short fixed backoff can't outlast a long
+ * official reset window. Plumbing that through AskDispatchError.retryAfterMs is
+ * a follow-up (see PR notes); 230049/230020 converge within the short backoff.
+ */
+const TRANSIENT_LARK_CODES = new Set([230049, 230020, 99991400]);
+
+/** Extract a Lark business code from either error shape:
+ *  - axios path A: `response.data.code` / top-level `code` (number)
+ *  - 2xx-body path B: a plain Error whose message ends in `(code: NNN)` (the
+ *    `res.code !== 0` throws in client.ts embed the code only in the string). */
+function extractLarkCode(e: {
+  response?: { data?: { code?: number } }; code?: number; message?: string;
+} | null | undefined, rawMessage: string): number | undefined {
+  const structured = e?.response?.data?.code ?? e?.code;
+  if (typeof structured === 'number') return structured;
+  const m = /\(code:\s*(\d+)\)/.exec(rawMessage);
+  return m ? Number(m[1]) : undefined;
+}
+
+/**
  * Classify a Feishu card-send failure into "worth retrying" vs "give up now"
  * (codex P1-3). PURE + exported so the retry decision is unit-tested directly
  * (executable decision seam) rather than asserted against source text.
  *
  * Retryable (transient — a re-send with the same uuid may succeed / dedupe):
+ *   - a well-known transient Lark business code (TRANSIENT_LARK_CODES), checked
+ *     FIRST so it wins even on an HTTP 400 or a 2xx-body business error
  *   - no HTTP response at all (network reset, DNS, timeout)
  *   - HTTP 429 (rate limited) or any 5xx (server-side)
- *   - a 2xx-body business error whose message carries no decisive 4xx status
- *     BUT names a transient Feishu condition (rate limit / internal) — we stay
- *     conservative and only mark the well-known transient codes retryable.
  * Not retryable (deterministic — re-sending repeats the same failure):
  *   - HTTP 4xx other than 429 (bad request, permission, not found)
  *   - message withdrawn (target gone)
@@ -101,7 +136,7 @@ export function createLarkAskCardDispatcher(
  *     we can't prove idempotency).
  *
  * Extraction mirrors bot-registry.formatLarkError: status at `response.status`
- * or `.status`; Feishu code at `response.data.code` or `.code`.
+ * or `.status`; Feishu code at `response.data.code` / `.code` / message tail.
  */
 export function classifyAskDispatchError(err: unknown): { retryable: boolean; detail: string } {
   const e = err as {
@@ -114,6 +149,13 @@ export function classifyAskDispatchError(err: unknown): { retryable: boolean; de
     (e && (e.response?.data?.msg || e.message)) ||
     (typeof err === 'string' ? err : 'unknown dispatch error');
 
+  // A whitelisted transient business code is retryable regardless of HTTP
+  // status / error shape (codex P1-3) — check it before the status branches.
+  const larkCode = extractLarkCode(e, typeof detail === 'string' ? detail : '');
+  if (larkCode !== undefined && TRANSIENT_LARK_CODES.has(larkCode)) {
+    return { retryable: true, detail: `lark code ${larkCode} (transient): ${detail}` };
+  }
+
   const looksAxios =
     !!e && (e.isAxiosError === true || e.name === 'AxiosError' || (!!e.config && (!!e.response || e.status != null)));
 
@@ -124,9 +166,9 @@ export function classifyAskDispatchError(err: unknown): { retryable: boolean; de
     return { retryable: false, detail: `http ${status}: ${detail}` }; // deterministic 4xx
   }
 
-  // Non-axios (plain Error / string). MessageWithdrawnError and the
-  // `res.code !== 0` 2xx-body throws land here — HTTP already succeeded, so a
-  // re-send repeats the same deterministic outcome. Fail closed.
+  // Non-axios (plain Error / string) without a transient code. MessageWithdrawn
+  // and other `res.code !== 0` 2xx-body throws land here — HTTP already
+  // succeeded, so a re-send repeats the same deterministic outcome. Fail closed.
   return { retryable: false, detail: `non-transport: ${detail}` };
 }
 

--- a/test/ask-api.test.ts
+++ b/test/ask-api.test.ts
@@ -138,3 +138,34 @@ describe('parseAskBody — questions[] 多问多选', () => {
     expect('error' in body).toBe(true);
   });
 });
+
+describe('parseAskBody — requestId / originKind (invocation identity)', () => {
+  it('接受并透传合法 requestId + originKind', () => {
+    const out = parseAskBody(validBody({ requestId: 'req-abc', originKind: 'hook' }));
+    expect('error' in out).toBe(false);
+    if (!('error' in out)) {
+      expect(out.requestId).toBe('req-abc');
+      expect(out.originKind).toBe('hook');
+    }
+  });
+
+  it('缺省时 requestId/originKind 为 undefined（旧调用方兼容）', () => {
+    const out = parseAskBody(validBody());
+    if (!('error' in out)) {
+      expect(out.requestId).toBeUndefined();
+      expect(out.originKind).toBeUndefined();
+    }
+  });
+
+  it('非法 requestId（空 / 超 128 / 非字符串）报错', () => {
+    expect('error' in parseAskBody(validBody({ requestId: '' }))).toBe(true);
+    expect('error' in parseAskBody(validBody({ requestId: 'x'.repeat(129) }))).toBe(true);
+    expect('error' in parseAskBody(validBody({ requestId: 123 }))).toBe(true);
+  });
+
+  it('非法 originKind（空 / 超 32 / 非字符串）报错', () => {
+    expect('error' in parseAskBody(validBody({ originKind: '' }))).toBe(true);
+    expect('error' in parseAskBody(validBody({ originKind: 'x'.repeat(33) }))).toBe(true);
+    expect('error' in parseAskBody(validBody({ originKind: {} }))).toBe(true);
+  });
+});

--- a/test/ask-card.test.ts
+++ b/test/ask-card.test.ts
@@ -632,24 +632,25 @@ describe('handleAskCardAction: ask_submit 路径', () => {
 });
 
 describe('createLarkAskCardDispatcher', () => {
-  it('replies into the root thread when rootMessageId exists', async () => {
+  it('replies into the root thread when rootMessageId exists (forwards dispatchUuid)', async () => {
     const reply = vi.fn(async () => 'om_reply');
     const send = vi.fn(async () => 'om_send');
     const dispatcher = createLarkAskCardDispatcher({ replyMessage: reply as any, sendMessage: send as any });
 
-    await expect(dispatcher.send(makePending())).resolves.toEqual({ messageId: 'om_reply' });
-    expect(reply).toHaveBeenCalledWith('cli_ask', 'om_root', expect.any(String), 'interactive', true);
+    await expect(dispatcher.send(makePending({ dispatchUuid: 'req-uuid-1' }))).resolves.toEqual({ messageId: 'om_reply' });
+    // The stable dispatchUuid is forwarded as the Feishu message uuid (idempotent re-send).
+    expect(reply).toHaveBeenCalledWith('cli_ask', 'om_root', expect.any(String), 'interactive', true, 'req-uuid-1');
     expect(send).not.toHaveBeenCalled();
   });
 
-  it('sends to chat when rootMessageId is absent and patches on settle', async () => {
+  it('sends to chat when rootMessageId is absent and patches on settle (forwards dispatchUuid)', async () => {
     const update = vi.fn(async () => undefined);
     const send = vi.fn(async () => 'om_send');
     const dispatcher = createLarkAskCardDispatcher({ sendMessage: send as any, updateMessage: update as any });
-    const ask = makePending({ rootMessageId: null, cardMessageId: 'om_card' });
+    const ask = makePending({ rootMessageId: null, cardMessageId: 'om_card', dispatchUuid: 'req-uuid-2' });
 
     await expect(dispatcher.send(ask)).resolves.toEqual({ messageId: 'om_send' });
-    expect(send).toHaveBeenCalledWith('cli_ask', 'oc_chat', expect.any(String), 'interactive');
+    expect(send).toHaveBeenCalledWith('cli_ask', 'oc_chat', expect.any(String), 'interactive', 'req-uuid-2');
 
     await dispatcher.onSettle?.(ask, {
       kind: 'timedOut',

--- a/test/ask-resume-contract.test.ts
+++ b/test/ask-resume-contract.test.ts
@@ -314,6 +314,38 @@ describe('clause 5 — dispatch partial-success converges (codex P1-3)', () => {
     expect(result.kind).toBe('invalidated');
     expect(attempts).toBe(1);                    // fail closed — no retry when idempotency unproven
   });
+
+  // codex P1-1 (regression the retry-all change introduced): a NON-resumable ask
+  // (explicit `botmux ask buttons`, or a PTY-backed hook) ALSO retries — so it
+  // MUST carry a dedupe uuid, or the retry after a landed-but-reset send posts a
+  // second real card. dispatchUuid is now decoupled from resumability.
+  for (const variant of [
+    { name: 'explicit ask', over: { originKind: 'explicit' as const, requestId: undefined, backendSurvivesRestart: false } },
+    { name: 'PTY-backed hook', over: { backendSurvivesRestart: false } },
+  ]) {
+    it(`${variant.name}: transient retry reuses the SAME uuid → one logical card (not double-send)`, async () => {
+      let attempts = 0;
+      const uuids: (string | undefined)[] = [];
+      const d: AskCardDispatcher & { sendCalls: PendingAsk[] } = {
+        sendCalls: [],
+        async send(ask) {
+          this.sendCalls.push(ask);
+          uuids.push(ask.dispatchUuid);
+          attempts++;
+          if (attempts === 1) throw new AskDispatchError('socket hang up', true);
+          return { messageId: 'om_original' };
+        },
+        onSettle() {},
+      };
+      setCardDispatcher(d);
+      registerAsk(brokerInput(variant.over));
+      await new Promise((r) => setTimeout(r, 900));
+      expect(attempts).toBe(2);
+      expect(uuids[0]).toBeTruthy();      // non-resumable STILL gets a uuid now
+      expect(uuids[1]).toBe(uuids[0]);    // same uuid on retry → server dedupes
+      expect(brokerFiles()).toHaveLength(0); // and it is still NOT persisted (backend gate intact)
+    });
+  }
 });
 
 describe('clause 5 — classifier decision table (executable seam, codex P1-3)', () => {
@@ -335,6 +367,18 @@ describe('clause 5 — classifier decision table (executable seam, codex P1-3)',
     expect(classifyAskDispatchError('nope').retryable).toBe(false);
     expect(classifyAskDispatchError(undefined).retryable).toBe(false);
   });
+  it('transient Lark business codes are retryable EVEN on HTTP 400 / 2xx-body (codex P1-3)', () => {
+    // 230049 "message is being sent" — official retry-later; can appear as the
+    // second same-uuid partial-success request while the first is still landing.
+    expect(classifyAskDispatchError({ isAxiosError: true, response: { status: 400, data: { code: 230049, msg: 'The message is being sent.' } } }).retryable).toBe(true);
+    // 230020 per-chat rate limit; 99991400 generic OpenAPI freq-control (legacy 400).
+    expect(classifyAskDispatchError({ isAxiosError: true, response: { status: 400, data: { code: 230020 } } }).retryable).toBe(true);
+    expect(classifyAskDispatchError({ isAxiosError: true, response: { status: 400, data: { code: 99991400 } } }).retryable).toBe(true);
+    // Same code surfacing via a 2xx-body plain Error (code only in the message).
+    expect(classifyAskDispatchError(new Error('Failed to reply message: being sent (code: 230049)')).retryable).toBe(true);
+    // A NON-whitelisted business code on 400 stays deterministic.
+    expect(classifyAskDispatchError({ isAxiosError: true, response: { status: 400, data: { code: 230011 } } }).retryable).toBe(false);
+  });
 });
 
 describe('clause 4 — only a restart-surviving backend is resumable (codex P1-4)', () => {
@@ -354,19 +398,22 @@ describe('clause 4 — only a restart-surviving backend is resumable (codex P1-4
     registerAsk(brokerInput({ backendSurvivesRestart: false }));
     await new Promise((r) => setTimeout(r, 5));
     expect(brokerFiles()).toHaveLength(0);        // never persisted
-    // And its card carries no dedupe uuid (it never re-sends across a restart).
-    expect(d.sendCalls[0]!.dispatchUuid).toBeUndefined();
+    // But its card STILL carries a dedupe uuid (codex P1-1): the bounded retry
+    // re-sends even a non-resumable card, so it needs server-side dedupe. uuid
+    // gates dispatch idempotency; persistence is gated separately (backend).
+    expect(d.sendCalls[0]!.dispatchUuid).toBeTruthy();
   });
 
-  it('an undefined backend signal fails closed (not persisted)', async () => {
+  it('an undefined backend signal fails closed (not persisted) but still carries a uuid', async () => {
     const d = mockDispatcher();
     setCardDispatcher(d);
     registerAsk(brokerInput({ backendSurvivesRestart: undefined }));
     await new Promise((r) => setTimeout(r, 5));
     expect(brokerFiles()).toHaveLength(0);
+    expect(d.sendCalls[0]!.dispatchUuid).toBeTruthy(); // dedupe uuid decoupled from persistence
   });
 
-  it('a hook on a persistent (tmux) backend IS persisted', async () => {
+  it('a hook on a persistent (tmux) backend IS persisted and carries a uuid', async () => {
     const d = mockDispatcher();
     setCardDispatcher(d);
     registerAsk(brokerInput({ backendSurvivesRestart: true }));

--- a/test/ask-resume-contract.test.ts
+++ b/test/ask-resume-contract.test.ts
@@ -1,0 +1,441 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  createAskPersistStore,
+  askKeyFor,
+  dispatchUuidForKey,
+  ASK_STORE_SENTINEL,
+  type PersistedAsk,
+} from '../src/core/ask-persist-store.js';
+import {
+  registerAsk,
+  tryResolveAsk,
+  restorePersistedAsks,
+  setCardDispatcher,
+  setCanTalkChecker,
+  setAskPersistStore,
+  _pendingCount,
+  _setHandoffRetentionForTest,
+  _resetForTest,
+} from '../src/core/ask-broker.js';
+import type { AskCardDispatcher, AskResult, CreateAskInput, PendingAsk } from '../src/core/ask-types.js';
+import { AskDispatchError } from '../src/core/ask-types.js';
+import { classifyAskDispatchError } from '../src/im/lark/ask-card.js';
+
+/**
+ * FROZEN CONTRACT for restart-resume of `botmux ask` (codex round-3 freeze).
+ * Each `describe` is one of the six clauses agreed before implementation; every
+ * clause leads with a counter-example that FAILS on the pre-fix code and passes
+ * only once the clause holds. Re-review runs this matrix instead of re-reading
+ * the diff.
+ *
+ *   1. canonical identity is unique end-to-end (filename + transport uuid)
+ *   2. same identity is idempotent across ALL states (active/terminal/dormant)
+ *   3. identity mismatch on a shared key FAILS CLOSED (never a silent new ask)
+ *   4. only a persistent (restart-surviving) backend is resumable
+ *   5. card dispatch partial-success converges (bounded retry, same uuid)
+ *   6. handoff has an absolute expiry; memory + disk are cleaned together
+ *
+ * Clauses 2–6 that need the broker live in ask-resume-restart.test.ts and the
+ * clause-specific blocks below; this file owns the pure-identity clause 1 and
+ * the seams that don't need a full broker.
+ */
+
+const OPTIONS = [
+  { key: 'yes', label: '继续' },
+  { key: 'no', label: '回滚' },
+];
+
+let dataDir: string;
+
+function persistedFiles(dir: string): string[] {
+  const d = join(dir, 'asks');
+  if (!existsSync(d)) return [];
+  return readdirSync(d).filter((n) => n.endsWith('.json'));
+}
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), 'botmux-ask-contract-'));
+});
+
+afterEach(() => {
+  const store = join(dataDir, 'asks');
+  if (existsSync(join(store, ASK_STORE_SENTINEL)) || !existsSync(store)) {
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
+function persistedFor(
+  larkAppId: string,
+  sessionId: string,
+  originKind: string,
+  requestId: string,
+): PersistedAsk {
+  return {
+    v: 2,
+    askKey: askKeyFor(larkAppId, sessionId, originKind, requestId),
+    requestId,
+    originKind,
+    askId: requestId,
+    nonce: 'nonce',
+    larkAppId,
+    chatId: 'oc_chat',
+    rootMessageId: null,
+    sessionId,
+    questions: [{ prompt: '继续发版吗？', options: OPTIONS, multiSelect: false }],
+    createdAt: 0,
+    deadlineAt: 10_000_000_000_000,
+    selections: [[]],
+  };
+}
+
+describe('clause 1 — canonical identity is unique end-to-end (codex P1-1)', () => {
+  it('production-length keys with different requestIds get DISTINCT persisted files', () => {
+    // Reproduces the 80-char filename truncation collision: with a real bot id
+    // (cli_ + 32 hex = 36 chars) and a uuid sessionId, the joined key pushes the
+    // requestId past character 80 — the pre-fix filePath truncated the WHOLE key
+    // to 80 chars, so two distinct requestIds sharing an 80-char prefix collapsed
+    // to ONE file (one card silently overwrote the other's durable record).
+    const store = createAskPersistStore(join(dataDir, 'asks'));
+    const app = 'cli_' + 'a'.repeat(32); // 36 chars, like a real Feishu app id
+    const sess = '11111111-1111-1111-1111-111111111111'; // 36-char uuid session
+    store.put(persistedFor(app, sess, 'hook', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'));
+    store.put(persistedFor(app, sess, 'hook', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'));
+    expect(persistedFiles(dataDir)).toHaveLength(2); // pre-fix: 1 (collision)
+  });
+
+  it('two invocations differing ONLY in the tail of a long requestId do not collide', () => {
+    const store = createAskPersistStore(join(dataDir, 'asks'));
+    const app = 'cli_' + 'c'.repeat(32);
+    const sess = '22222222-2222-2222-2222-222222222222';
+    // Long, identical-prefix requestIds — differ only far past char 80.
+    const long = 'req-' + 'x'.repeat(200);
+    store.put(persistedFor(app, sess, 'hook', long + 'A'));
+    store.put(persistedFor(app, sess, 'hook', long + 'B'));
+    expect(persistedFiles(dataDir)).toHaveLength(2);
+  });
+
+  it('askKeyFor is injective for the full tuple (no delimiter aliasing)', () => {
+    // Length-prefixed canonical form must not alias "a|bc" vs "ab|c".
+    expect(askKeyFor('cli', 'a', 'hook', 'bc')).not.toBe(askKeyFor('cli', 'ab', 'hook', 'c'));
+    expect(askKeyFor('cli_app', 'sess-1', 'hook', 'req-1')).toBe(
+      askKeyFor('cli_app', 'sess-1', 'hook', 'req-1'),
+    ); // deterministic
+    expect(askKeyFor('cli_app', 'sess-2', 'hook', 'req-1')).not.toBe(
+      askKeyFor('cli_app', 'sess-1', 'hook', 'req-1'),
+    );
+    expect(askKeyFor('cli_app', 'sess-1', 'explicit', 'req-1')).not.toBe(
+      askKeyFor('cli_app', 'sess-1', 'hook', 'req-1'),
+    );
+  });
+
+  it('dispatch uuid: stable per invocation, distinct across sessions, ≤50 chars', () => {
+    const kA = askKeyFor('cli_app', 'sess-A', 'hook', 'shared-req');
+    const kB = askKeyFor('cli_app', 'sess-B', 'hook', 'shared-req');
+    // Same invocation → same uuid (a restart re-send dedupes server-side).
+    expect(dispatchUuidForKey(kA)).toBe(
+      dispatchUuidForKey(askKeyFor('cli_app', 'sess-A', 'hook', 'shared-req')),
+    );
+    // Same requestId, different session → DIFFERENT uuid (uuid is not a bearer
+    // token that a second session could reuse to alias the first's card).
+    expect(dispatchUuidForKey(kA)).not.toBe(dispatchUuidForKey(kB));
+    // Feishu message uuid hard cap.
+    expect(dispatchUuidForKey(kA).length).toBeLessThanOrEqual(50);
+  });
+});
+
+// --- broker-backed clauses (2 & 3) -------------------------------------------
+
+const BROKER_QS = [{ prompt: '继续发版吗？', options: OPTIONS, multiSelect: false }];
+
+function brokerInput(over: Partial<CreateAskInput> = {}): CreateAskInput {
+  return {
+    larkAppId: 'cli_app',
+    chatId: 'oc_chat',
+    rootMessageId: 'om_root',
+    sessionId: 'sess-1',
+    requestId: 'req-1',
+    originKind: 'hook',
+    backendSurvivesRestart: true, // tmux-backed hook: resumable
+    questions: BROKER_QS,
+    timeoutMs: 60_000,
+    ...over,
+  };
+}
+
+function mockDispatcher(): AskCardDispatcher & { sendCalls: PendingAsk[] } {
+  const sendCalls: PendingAsk[] = [];
+  return {
+    async send(ask) { sendCalls.push(ask); return { messageId: `om_card_${ask.askId}` }; },
+    onSettle() {},
+    sendCalls,
+  };
+}
+
+function brokerFiles(): PersistedAsk[] {
+  const dir = join(dataDir, 'asks');
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((n) => n.endsWith('.json'))
+    .map((n) => JSON.parse(readFileSync(join(dir, n), 'utf-8')) as PersistedAsk);
+}
+
+describe('clause 2 — same identity is idempotent across ALL states (codex P1-1)', () => {
+  beforeEach(() => {
+    _resetForTest();
+    setAskPersistStore(createAskPersistStore(join(dataDir, 'asks')));
+    setCanTalkChecker((_a, _c, openId) => openId === 'ou_owner');
+  });
+  afterEach(() => { _resetForTest(); });
+
+  it('terminal-state replay returns the SAME result (no new card, no re-ask)', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    const p1 = registerAsk(brokerInput());
+    await new Promise((r) => setTimeout(r, 5));
+    const rec = brokerFiles()[0]!;
+    // Answer it → settles, record removed, entry retained briefly for replay.
+    expect(tryResolveAsk({ askId: rec.askId, nonce: rec.nonce, selected: 'yes', by: 'ou_owner' })).toBe('accepted');
+    const r1 = await p1;
+    // Same-identity re-POST in the retention window → identical terminal result,
+    // NOT a fresh ask, NOT a second card.
+    const r2 = await registerAsk(brokerInput());
+    expect(r2).toEqual(r1);
+    expect(d.sendCalls).toHaveLength(1);
+  });
+});
+
+describe('clause 3 — identity mismatch on a shared key FAILS CLOSED (codex P1-2)', () => {
+  beforeEach(() => {
+    _resetForTest();
+    setAskPersistStore(createAskPersistStore(join(dataDir, 'asks')));
+    setCanTalkChecker((_a, _c, openId) => openId === 'ou_owner');
+  });
+  afterEach(() => { _resetForTest(); });
+
+  it('same key + DIFFERENT questions → invalidated (never a silent fall-through new ask)', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    registerAsk(brokerInput()); // active ask with req-1
+    await new Promise((r) => setTimeout(r, 5));
+    expect(d.sendCalls).toHaveLength(1);
+
+    // A second register REUSES the same (app/session/origin/request) key but the
+    // question set differs — a crafted / stale-but-mutated re-POST. Pre-fix this
+    // fell THROUGH to a brand-new ask (a second card, ambiguous which the click
+    // resolves). It must instead fail closed: the caller gets `invalidated`, and
+    // NO second card is posted.
+    const conflicting = brokerInput({
+      questions: [{ prompt: '完全不同的问题', options: OPTIONS, multiSelect: false }],
+    });
+    const result = await registerAsk(conflicting);
+    expect(result.kind).toBe('invalidated');
+    expect(d.sendCalls).toHaveLength(1); // no second card
+  });
+
+  it('questionsShape distinguishes a changed option LABEL (not just keys/prompt)', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    registerAsk(brokerInput());
+    await new Promise((r) => setTimeout(r, 5));
+    // Same prompt, same option keys, but a DIFFERENT visible label → the user
+    // would see a different card, so it must not silently re-attach/replay.
+    const relabelled = brokerInput({
+      questions: [{ prompt: '继续发版吗？', options: [
+        { key: 'yes', label: '完全不同的标签' },
+        { key: 'no', label: '回滚' },
+      ], multiSelect: false }],
+    });
+    const result = await registerAsk(relabelled);
+    expect(result.kind).toBe('invalidated');
+    expect(d.sendCalls).toHaveLength(1);
+  });
+});
+
+describe('clause 5 — dispatch partial-success converges (codex P1-3)', () => {
+  beforeEach(() => {
+    _resetForTest();
+    setAskPersistStore(createAskPersistStore(join(dataDir, 'asks')));
+    setCanTalkChecker((_a, _c, openId) => openId === 'ou_owner');
+  });
+  afterEach(() => { _resetForTest(); });
+
+  it('a transient send failure is retried with the SAME uuid → one logical card, broker stays pending', async () => {
+    // First attempt: send actually LANDS server-side but the client sees a
+    // socket reset (retryable). Second attempt: Feishu dedupes on the same uuid
+    // and returns the ORIGINAL message_id. Net: one card, ask still awaiting a
+    // click (NOT invalidated).
+    let attempts = 0;
+    const uuids: (string | undefined)[] = [];
+    const d: AskCardDispatcher & { sendCalls: PendingAsk[] } = {
+      sendCalls: [],
+      async send(ask) {
+        this.sendCalls.push(ask);
+        uuids.push(ask.dispatchUuid);
+        attempts++;
+        if (attempts === 1) throw new AskDispatchError('socket hang up', true); // transient
+        return { messageId: 'om_original' }; // server-side dedupe returns original
+      },
+      onSettle() {},
+    };
+    setCardDispatcher(d);
+    registerAsk(brokerInput());
+    // Wait past the first backoff (500ms) so the retry runs.
+    await new Promise((r) => setTimeout(r, 900));
+    expect(attempts).toBe(2);                    // retried exactly once
+    expect(uuids[0]).toBe(uuids[1]);             // SAME uuid on retry
+    expect(uuids[0]).toBeTruthy();               // resumable → has a uuid
+    expect(_pendingCount()).toBe(1);             // still awaiting a click, NOT invalidated
+  });
+
+  it('a deterministic 4xx send failure invalidates immediately (no retry)', async () => {
+    let attempts = 0;
+    const d: AskCardDispatcher = {
+      async send() { attempts++; throw new AskDispatchError('http 403: permission denied', false); },
+      onSettle() {},
+    };
+    setCardDispatcher(d);
+    const result = await registerAsk(brokerInput());
+    expect(result.kind).toBe('invalidated');
+    expect(attempts).toBe(1);                    // no retry on deterministic failure
+  });
+
+  it('an UNTYPED throw fails closed (treated as not retryable)', async () => {
+    let attempts = 0;
+    const d: AskCardDispatcher = {
+      async send() { attempts++; throw new Error('plain error'); },
+      onSettle() {},
+    };
+    setCardDispatcher(d);
+    const result = await registerAsk(brokerInput());
+    expect(result.kind).toBe('invalidated');
+    expect(attempts).toBe(1);                    // fail closed — no retry when idempotency unproven
+  });
+});
+
+describe('clause 5 — classifier decision table (executable seam, codex P1-3)', () => {
+  it('network / no-response → retryable', () => {
+    expect(classifyAskDispatchError({ isAxiosError: true, message: 'ECONNRESET' }).retryable).toBe(true);
+  });
+  it('HTTP 429 and 5xx → retryable', () => {
+    expect(classifyAskDispatchError({ isAxiosError: true, response: { status: 429 } }).retryable).toBe(true);
+    expect(classifyAskDispatchError({ isAxiosError: true, response: { status: 500 } }).retryable).toBe(true);
+    expect(classifyAskDispatchError({ isAxiosError: true, response: { status: 503 } }).retryable).toBe(true);
+  });
+  it('HTTP 4xx (except 429) → NOT retryable', () => {
+    expect(classifyAskDispatchError({ isAxiosError: true, response: { status: 400 } }).retryable).toBe(false);
+    expect(classifyAskDispatchError({ isAxiosError: true, response: { status: 403 } }).retryable).toBe(false);
+    expect(classifyAskDispatchError({ isAxiosError: true, response: { status: 404 } }).retryable).toBe(false);
+  });
+  it('plain Error (2xx-body business error / withdrawn) → NOT retryable (fail closed)', () => {
+    expect(classifyAskDispatchError(new Error('Failed to send message: xxx (code: 230011)')).retryable).toBe(false);
+    expect(classifyAskDispatchError('nope').retryable).toBe(false);
+    expect(classifyAskDispatchError(undefined).retryable).toBe(false);
+  });
+});
+
+describe('clause 4 — only a restart-surviving backend is resumable (codex P1-4)', () => {
+  beforeEach(() => {
+    _resetForTest();
+    setAskPersistStore(createAskPersistStore(join(dataDir, 'asks')));
+    setCanTalkChecker((_a, _c, openId) => openId === 'ou_owner');
+  });
+  afterEach(() => { _resetForTest(); });
+
+  it('a hook on a NON-persistent (PTY) backend is NOT persisted (no orphan record)', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    // Same hook origin + requestId, but the daemon reports the backend does NOT
+    // survive a restart (pty). Pre-fix, resumability keyed off originKind alone
+    // → this persisted a record no reconnecting hook could ever exist to claim.
+    registerAsk(brokerInput({ backendSurvivesRestart: false }));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(brokerFiles()).toHaveLength(0);        // never persisted
+    // And its card carries no dedupe uuid (it never re-sends across a restart).
+    expect(d.sendCalls[0]!.dispatchUuid).toBeUndefined();
+  });
+
+  it('an undefined backend signal fails closed (not persisted)', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    registerAsk(brokerInput({ backendSurvivesRestart: undefined }));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(brokerFiles()).toHaveLength(0);
+  });
+
+  it('a hook on a persistent (tmux) backend IS persisted', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    registerAsk(brokerInput({ backendSurvivesRestart: true }));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(brokerFiles()).toHaveLength(1);
+    expect(d.sendCalls[0]!.dispatchUuid).toBeTruthy();
+  });
+});
+
+describe('clause 6 — handoff has absolute expiry; memory + disk cleaned together (codex P1-4)', () => {
+  beforeEach(() => {
+    _resetForTest();
+    setAskPersistStore(createAskPersistStore(join(dataDir, 'asks')));
+    setCanTalkChecker((_a, _c, openId) => openId === 'ou_owner');
+  });
+  afterEach(() => { _resetForTest(); });
+
+  it('an UNCLAIMED stash is reaped from memory AND disk at answeredAt + retention', async () => {
+    _setHandoffRetentionForTest(120); // 120ms window instead of 24h
+    setCardDispatcher(mockDispatcher());
+    registerAsk(brokerInput());
+    await new Promise((r) => setTimeout(r, 5));
+    const rec = brokerFiles()[0]!;
+
+    // Simulate a restart → restore dormant → user answers the dormant card
+    // BEFORE the hook reconnects (stash). Nobody ever claims it.
+    _resetForTest();
+    _setHandoffRetentionForTest(120);
+    setAskPersistStore(createAskPersistStore(join(dataDir, 'asks')));
+    setCanTalkChecker((_a, _c, openId) => openId === 'ou_owner');
+    setCardDispatcher(mockDispatcher());
+    restorePersistedAsks(Date.now(), 'cli_app');
+    expect(tryResolveAsk({ askId: rec.askId, nonce: rec.nonce, selected: 'yes', by: 'ou_owner' })).toBe('accepted');
+    expect(brokerFiles()).toHaveLength(1);   // stashed, awaiting claim
+    expect(_pendingCount()).toBe(0);         // settled (terminal), not awaiting a click
+
+    // Wait past the shrunk retention → the absolute-expiry reaper fires and
+    // clears BOTH memory and disk (not just a boot list() sweep).
+    await new Promise((r) => setTimeout(r, 220));
+    expect(brokerFiles()).toHaveLength(0);   // disk reaped
+    // memory: the entry is gone (no dormant handoff lingering).
+    // (indirect: a fresh restore finds nothing.)
+    restorePersistedAsks(Date.now(), 'cli_app');
+    expect(_pendingCount()).toBe(0);
+  });
+
+  it('a CLAIMED stash cancels the reaper (no double-free, answer delivered once)', async () => {
+    _setHandoffRetentionForTest(120);
+    setCardDispatcher(mockDispatcher());
+    registerAsk(brokerInput());
+    await new Promise((r) => setTimeout(r, 5));
+    const rec = brokerFiles()[0]!;
+
+    _resetForTest();
+    _setHandoffRetentionForTest(120);
+    setAskPersistStore(createAskPersistStore(join(dataDir, 'asks')));
+    setCanTalkChecker((_a, _c, openId) => openId === 'ou_owner');
+    setCardDispatcher(mockDispatcher());
+    restorePersistedAsks(Date.now(), 'cli_app');
+    tryResolveAsk({ askId: rec.askId, nonce: rec.nonce, selected: 'yes', by: 'ou_owner' });
+    // Hook reconnects and CLAIMS the stash before the reaper fires.
+    const result = await registerAsk(brokerInput());
+    expect(result.kind).toBe('answered');
+    expect(brokerFiles()).toHaveLength(0);   // claimed → removed
+
+    // Let the (now-cancelled) reaper's original deadline pass; nothing crashes,
+    // no resurrection.
+    await new Promise((r) => setTimeout(r, 220));
+    expect(brokerFiles()).toHaveLength(0);
+    expect(_pendingCount()).toBe(0);
+  });
+});

--- a/test/ask-resume-restart.test.ts
+++ b/test/ask-resume-restart.test.ts
@@ -12,7 +12,7 @@ import {
   setAskPersistStore,
   _resetForTest,
 } from '../src/core/ask-broker.js';
-import { createAskPersistStore, askKeyFor, dispatchUuidFor, ASK_STORE_SENTINEL, type PersistedAsk } from '../src/core/ask-persist-store.js';
+import { createAskPersistStore, askKeyFor, dispatchUuidForKey, ASK_STORE_SENTINEL, type PersistedAsk } from '../src/core/ask-persist-store.js';
 import type { AskCardDispatcher, AskResult, CreateAskInput, PendingAsk } from '../src/core/ask-types.js';
 
 /**
@@ -37,6 +37,7 @@ function makeInput(over: Partial<CreateAskInput> = {}): CreateAskInput {
     sessionId: 'sess-1',
     requestId: 'req-1',
     originKind: 'hook',
+    backendSurvivesRestart: true, // tmux-backed hook: resumable (daemon-computed)
     questions: [{ prompt: '继续发版吗？', options: OPTIONS, multiSelect: false }],
     timeoutMs: 60_000,
     ...over,
@@ -306,13 +307,13 @@ describe('active same-requestId replay joins one ask (codex P1-1)', () => {
 });
 
 describe('dispatch uuid + non-resumable origins (codex P1-1/P1-4)', () => {
-  it('resumable (hook) card send carries a stable dispatchUuid derived from requestId', async () => {
+  it('resumable (hook) card send carries a stable dispatchUuid derived from the scoped key', async () => {
     let seenUuid: string | undefined = 'UNSET';
     const d = mockDispatcher((ask) => { seenUuid = ask.dispatchUuid; return Promise.resolve({ messageId: 'om_x' }); });
     setCardDispatcher(d);
     registerAsk(makeInput({ requestId: 'req-uuid-1' }));
     await new Promise((r) => setTimeout(r, 5));
-    expect(seenUuid).toBe(dispatchUuidFor('req-uuid-1'));
+    expect(seenUuid).toBe(dispatchUuidForKey(askKeyFor('cli_app', 'sess-1', 'hook', 'req-uuid-1')));
   });
 
   it('explicit origin is NOT persisted and its card carries no dispatchUuid', async () => {

--- a/test/ask-resume-restart.test.ts
+++ b/test/ask-resume-restart.test.ts
@@ -1,31 +1,27 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readdirSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import {
   registerAsk,
   restorePersistedAsks,
-  submitAsk,
   tryResolveAsk,
-  toggleAsk,
   setCardDispatcher,
   setCanTalkChecker,
+  setAskPersistStore,
   _resetForTest,
-  _getPending,
 } from '../src/core/ask-broker.js';
-import { computeAskKey, listPersistedAsks } from '../src/core/ask-persist-store.js';
-import { config } from '../src/config.js';
+import { createAskPersistStore, askKeyFor, ASK_STORE_SENTINEL, type PersistedAsk } from '../src/core/ask-persist-store.js';
 import type { AskCardDispatcher, AskResult, CreateAskInput, PendingAsk } from '../src/core/ask-types.js';
 
 /**
- * Restart-resume for `botmux ask` (the AskUserQuestion picker-desync root fix).
- *
- * A daemon restart between "card posted" and "user clicked" used to lose the
- * in-memory pending ask → the click hit `stale` ("此 ask 已失效") and the CLI
- * hook fell into a stuck native picker. These tests exercise the fix: persist on
- * register, restore as a DORMANT ask on boot, and re-attach a reconnecting hook
- * by stable key so the answer flows back through the normal directive.
+ * Restart-resume for `botmux ask` — the AskUserQuestion picker-desync root fix,
+ * hardened per codex's REQUEST_CHANGES. Covers BOTH restart orderings:
+ *   - reattach → click  (hook reconnects first, then user answers)
+ *   - click → reattach  (user answers the dormant card first — durable handoff)
+ * plus card re-send when the restart lands before cardMessageId was recorded,
+ * request-id/originKind identity, and dependency-injected store isolation.
  */
 
 const OPTIONS = [
@@ -39,150 +35,222 @@ function makeInput(over: Partial<CreateAskInput> = {}): CreateAskInput {
     chatId: 'oc_chat',
     rootMessageId: 'om_root',
     sessionId: 'sess-1',
+    requestId: 'req-1',
+    originKind: 'hook',
     questions: [{ prompt: '继续发版吗？', options: OPTIONS, multiSelect: false }],
     timeoutMs: 60_000,
     ...over,
   };
 }
 
-function mockDispatcher(): AskCardDispatcher & { sendCalls: PendingAsk[] } {
+/** Dispatcher that records sends and lets a test control the returned messageId
+ *  (default: undefined-safe id). Also records onSettle for card-flip assertions. */
+function mockDispatcher(sendImpl?: (ask: PendingAsk) => Promise<{ messageId?: string }>): AskCardDispatcher & {
+  sendCalls: PendingAsk[];
+  settleCalls: AskResult[];
+} {
   const sendCalls: PendingAsk[] = [];
+  const settleCalls: AskResult[] = [];
   return {
-    async send(ask) { sendCalls.push(ask); return { messageId: `om_card_${ask.askId}` }; },
-    onSettle() { /* no-op */ },
+    async send(ask) { sendCalls.push(ask); return sendImpl ? sendImpl(ask) : { messageId: `om_card_${ask.askId}` }; },
+    onSettle(_ask, result) { settleCalls.push(result); },
     sendCalls,
+    settleCalls,
   };
 }
 
 let dataDir: string;
 let prevDataDir: string | undefined;
 
+/** Rebind a fresh injected store on the broker after a simulated restart. */
+function bindStore() {
+  setAskPersistStore(createAskPersistStore(join(dataDir, 'asks')));
+}
+
 beforeEach(() => {
   prevDataDir = process.env.SESSION_DATA_DIR;
   dataDir = mkdtempSync(join(tmpdir(), 'botmux-ask-resume-'));
-  config.session.dataDir = dataDir; // maps onto SESSION_DATA_DIR
-  _resetForTest();
+  _resetForTest();          // detaches store (never deletes)
+  bindStore();
   setCanTalkChecker((_a, _c, openId) => openId === 'ou_owner');
 });
 
 afterEach(() => {
   _resetForTest();
+  // Teardown deletes ONLY this test's own temp dir, and only if it carries the
+  // store sentinel (guard against ever reaping a shared/real dir — codex P1-4).
+  const store = join(dataDir, 'asks');
+  if (existsSync(join(store, ASK_STORE_SENTINEL)) || !existsSync(store)) {
+    rmSync(dataDir, { recursive: true, force: true });
+  }
   if (prevDataDir === undefined) delete process.env.SESSION_DATA_DIR;
   else process.env.SESSION_DATA_DIR = prevDataDir;
-  rmSync(dataDir, { recursive: true, force: true });
 });
 
-describe('ask persistence', () => {
-  it('registerAsk writes a durable record; settle removes it', async () => {
+function persistedFiles(): string[] {
+  const dir = join(dataDir, 'asks');
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter((n) => n.endsWith('.json'));
+}
+
+/** Read the single persisted ask record (fails if not exactly one). */
+function onlyPersisted(): PersistedAsk {
+  const files = persistedFiles();
+  if (files.length !== 1) throw new Error(`expected 1 persisted ask, got ${files.length}`);
+  return JSON.parse(readFileSync(join(dataDir, 'asks', files[0]), 'utf-8')) as PersistedAsk;
+}
+
+describe('ask persistence (injected store)', () => {
+  it('registerAsk writes a durable record; answering removes it', async () => {
     setCardDispatcher(mockDispatcher());
-    const promise = registerAsk(makeInput());
-    // Card dispatch is async; let it land.
+    const p = registerAsk(makeInput());
     await new Promise((r) => setTimeout(r, 5));
-
-    const persisted = listPersistedAsks();
-    expect(persisted).toHaveLength(1);
-    expect(persisted[0].sessionId).toBe('sess-1');
-    expect(persisted[0].cardMessageId).toMatch(/^om_card_/);
-    const askId = persisted[0].askId;
-
-    // Answer it → record removed.
-    expect(tryResolveAsk({ askId, nonce: persisted[0].nonce, selected: 'yes', by: 'ou_owner' })).toBe('accepted');
-    await promise;
-    expect(listPersistedAsks()).toHaveLength(0);
+    expect(persistedFiles()).toHaveLength(1);
+    const rec = onlyPersisted();
+    expect(tryResolveAsk({ askId: rec.askId, nonce: rec.nonce, selected: 'yes', by: 'ou_owner' })).toBe('accepted');
+    await p;
+    expect(persistedFiles()).toHaveLength(0);
   });
 
-  it('multi-select toggle persists accumulated checkbox state', async () => {
-    setCardDispatcher(mockDispatcher());
-    registerAsk(makeInput({ questions: [{ prompt: '多选', options: OPTIONS, multiSelect: true }] }));
-    await new Promise((r) => setTimeout(r, 5));
-    const { askId, nonce } = listPersistedAsks()[0];
-    toggleAsk({ askId, nonce, questionIndex: 0, key: 'yes', by: 'ou_owner' });
-    expect(listPersistedAsks()[0].selections[0]).toEqual(['yes']);
-    toggleAsk({ askId, nonce, questionIndex: 0, key: 'no', by: 'ou_owner' });
-    expect(listPersistedAsks()[0].selections[0]).toEqual(['yes', 'no']);
-  });
-});
-
-describe('restorePersistedAsks (daemon restart recovery)', () => {
-  it('restores a persisted ask as dormant WITHOUT re-posting the card', async () => {
-    // Simulate: a prior daemon posted+persisted an ask, then died.
+  it('does nothing when no store is wired (no global-dir writes)', async () => {
+    setAskPersistStore(null);
     setCardDispatcher(mockDispatcher());
     registerAsk(makeInput());
     await new Promise((r) => setTimeout(r, 5));
-    const before = listPersistedAsks()[0];
+    expect(persistedFiles()).toHaveLength(0); // never touched the dir
+  });
+});
 
-    // New daemon boot: reset in-memory state (disk survives), wire a fresh
-    // dispatcher, restore.
+describe('reattach → click (hook reconnects first)', () => {
+  it('restores dormant (no re-post), hook re-registers, then click resolves', async () => {
+    setCardDispatcher(mockDispatcher());
+    registerAsk(makeInput());
+    await new Promise((r) => setTimeout(r, 5));
+    const orig = onlyPersisted();
+
+    // Simulate restart: reset memory, rebind store (disk survives), restore.
     _resetForTest();
+    bindStore();
     const d2 = mockDispatcher();
     setCardDispatcher(d2);
     setCanTalkChecker((_a, _c, openId) => openId === 'ou_owner');
-    const n = restorePersistedAsks(Date.now(), 'cli_app');
+    expect(restorePersistedAsks(Date.now(), 'cli_app')).toBe(1);
+    expect(d2.sendCalls).toHaveLength(0); // card still live → no re-post
 
-    expect(n).toBe(1);
-    // Dormant restore must NOT re-post a card (the original is still live).
+    // Hook reconnects: same requestId → re-attach (no new card).
+    const reattached = registerAsk(makeInput());
+    await new Promise((r) => setTimeout(r, 5));
     expect(d2.sendCalls).toHaveLength(0);
-    // The dormant ask is queryable and clickable.
-    const snap = _getPending(before.askId);
-    expect(snap?.askId).toBe(before.askId);
-    expect(snap?.cardMessageId).toBe(before.cardMessageId);
-  });
 
-  it('skips restoring asks belonging to a different bot', async () => {
-    setCardDispatcher(mockDispatcher());
-    registerAsk(makeInput({ larkAppId: 'cli_other', sessionId: 'sess-other' }));
-    await new Promise((r) => setTimeout(r, 5));
-    _resetForTest();
-    setCardDispatcher(mockDispatcher());
-    // This daemon serves cli_app, not cli_other → nothing to restore.
-    expect(restorePersistedAsks(Date.now(), 'cli_app')).toBe(0);
-  });
-
-  it('drops persisted asks whose deadline already passed while down', async () => {
-    setCardDispatcher(mockDispatcher());
-    registerAsk(makeInput({ timeoutMs: 1_000 }));
-    await new Promise((r) => setTimeout(r, 5));
-    _resetForTest();
-    setCardDispatcher(mockDispatcher());
-    // now is well past the 1s deadline.
-    expect(restorePersistedAsks(Date.now() + 10_000, 'cli_app')).toBe(0);
-    expect(listPersistedAsks(Date.now() + 10_000)).toHaveLength(0);
+    // Now the user clicks → resolves the re-attached waiter.
+    expect(tryResolveAsk({ askId: orig.askId, nonce: orig.nonce, selected: 'yes', by: 'ou_owner' })).toBe('accepted');
+    const result = await reattached;
+    expect(result.kind).toBe('answered');
+    expect(persistedFiles()).toHaveLength(0);
   });
 });
 
-describe('re-attach: reconnecting hook resolves the restored card', () => {
-  it('registerAsk with the same key re-attaches to the dormant ask (no new card), then a click resolves it', async () => {
-    // Prior daemon: post + persist.
+describe('click → reattach (durable handoff — codex P1-1)', () => {
+  it('user answers dormant card first; hook reconnect delivers the stashed answer, 0 new cards', async () => {
     setCardDispatcher(mockDispatcher());
     registerAsk(makeInput());
     await new Promise((r) => setTimeout(r, 5));
-    const orig = listPersistedAsks()[0];
+    const orig = onlyPersisted();
 
-    // Restart: restore dormant.
+    // Restart → restore dormant.
     _resetForTest();
+    bindStore();
     const d2 = mockDispatcher();
     setCardDispatcher(d2);
     setCanTalkChecker((_a, _c, openId) => openId === 'ou_owner');
     restorePersistedAsks(Date.now(), 'cli_app');
 
-    // The surviving hook reconnects → re-registers the SAME ask (same session +
-    // questions → same key). This must re-attach, NOT post a second card.
-    const reattached = registerAsk(makeInput());
-    await new Promise((r) => setTimeout(r, 5));
-    expect(d2.sendCalls).toHaveLength(0); // no duplicate card
-
-    // A click now resolves the re-attached waiter through the normal path.
+    // User clicks the dormant card BEFORE the hook reconnects.
     expect(tryResolveAsk({ askId: orig.askId, nonce: orig.nonce, selected: 'yes', by: 'ou_owner' })).toBe('accepted');
-    const result: AskResult = await reattached;
+    // Answer is stashed durably (record kept, not deleted) + card flipped.
+    expect(persistedFiles()).toHaveLength(1);
+    expect(d2.settleCalls).toHaveLength(1);
+
+    // Hook reconnects (same requestId) → claims the stashed answer, no new card.
+    const reattached = registerAsk(makeInput());
+    const result = await reattached;
     expect(result.kind).toBe('answered');
-    expect(listPersistedAsks()).toHaveLength(0); // cleaned on settle
+    if (result.kind === 'answered') expect(result.answers).toEqual([['yes']]);
+    expect(d2.sendCalls).toHaveLength(0);           // never posted a second card
+    expect(persistedFiles()).toHaveLength(0);       // claimed → cleaned
   });
 
-  it('computeAskKey is stable for same session+questions and differs otherwise', () => {
-    const qs = makeInput().questions;
-    expect(computeAskKey('sess-1', qs)).toBe(computeAskKey('sess-1', qs));
-    expect(computeAskKey('sess-1', qs)).not.toBe(computeAskKey('sess-2', qs));
-    const qs2 = [{ prompt: 'different?', options: OPTIONS, multiSelect: false }];
-    expect(computeAskKey('sess-1', qs)).not.toBe(computeAskKey('sess-1', qs2));
+  it('stashed answer survives a SECOND restart before the hook claims it', async () => {
+    setCardDispatcher(mockDispatcher());
+    registerAsk(makeInput());
+    await new Promise((r) => setTimeout(r, 5));
+    const orig = onlyPersisted();
+
+    _resetForTest(); bindStore(); setCardDispatcher(mockDispatcher());
+    setCanTalkChecker((_a, _c, openId) => openId === 'ou_owner');
+    restorePersistedAsks(Date.now(), 'cli_app');
+    tryResolveAsk({ askId: orig.askId, nonce: orig.nonce, selected: 'no', by: 'ou_owner' }); // answered while dormant
+    expect(persistedFiles()).toHaveLength(1); // stashed
+
+    // Second restart before claim: the stashed answer must persist.
+    _resetForTest(); bindStore(); setCardDispatcher(mockDispatcher());
+    setCanTalkChecker((_a, _c, openId) => openId === 'ou_owner');
+    restorePersistedAsks(Date.now(), 'cli_app');
+    const result = await registerAsk(makeInput());
+    expect(result.kind).toBe('answered');
+    if (result.kind === 'answered') expect(result.answers).toEqual([['no']]);
+    expect(persistedFiles()).toHaveLength(0);
+  });
+});
+
+describe('card re-send when restart precedes cardMessageId (codex P1-2)', () => {
+  it('a restored ask without cardMessageId re-sends exactly one card on re-attach', async () => {
+    // Dispatcher that never resolves a messageId → simulates restart before the
+    // .then() that records cardMessageId runs.
+    let resolveSend: (v: { messageId?: string }) => void;
+    const slow = mockDispatcher(() => new Promise((res) => { resolveSend = res; }));
+    setCardDispatcher(slow);
+    registerAsk(makeInput());
+    await new Promise((r) => setTimeout(r, 5));
+    // Record persisted WITHOUT cardMessageId (send still pending).
+    const files = readdirSync(join(dataDir, 'asks')).filter(n => n.endsWith('.json'));
+    const orig = onlyPersisted();
+    expect(orig.cardMessageId).toBeUndefined();
+
+    // Restart → restore → hook re-attach: MUST re-send the card exactly once.
+    _resetForTest(); bindStore();
+    const d2 = mockDispatcher();
+    setCardDispatcher(d2);
+    setCanTalkChecker((_a, _c, openId) => openId === 'ou_owner');
+    restorePersistedAsks(Date.now(), 'cli_app');
+    expect(d2.sendCalls).toHaveLength(0);           // restore alone doesn't send
+    registerAsk(makeInput());
+    await new Promise((r) => setTimeout(r, 5));
+    expect(d2.sendCalls).toHaveLength(1);           // re-attach re-sends exactly one
+    void resolveSend!;
+  });
+});
+
+describe('identity + isolation', () => {
+  it('askKeyFor namespaces by originKind so hook vs explicit asks never collide', () => {
+    expect(askKeyFor('hook', 'req-1')).toBe(askKeyFor('hook', 'req-1'));
+    expect(askKeyFor('hook', 'req-1')).not.toBe(askKeyFor('explicit', 'req-1'));
+    expect(askKeyFor('hook', 'req-1')).not.toBe(askKeyFor('hook', 'req-2'));
+  });
+
+  it('two concurrent same-question asks from one session get distinct records (distinct requestId)', async () => {
+    setCardDispatcher(mockDispatcher());
+    registerAsk(makeInput({ requestId: 'req-A' }));
+    registerAsk(makeInput({ requestId: 'req-B' }));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(persistedFiles()).toHaveLength(2); // NOT collapsed by a questions hash
+  });
+
+  it('restore skips a different bot; drops answered-never records past deadline', async () => {
+    setCardDispatcher(mockDispatcher());
+    registerAsk(makeInput({ larkAppId: 'cli_other', requestId: 'req-other' }));
+    await new Promise((r) => setTimeout(r, 5));
+    _resetForTest(); bindStore(); setCardDispatcher(mockDispatcher());
+    expect(restorePersistedAsks(Date.now(), 'cli_app')).toBe(0);      // different bot
   });
 });

--- a/test/ask-resume-restart.test.ts
+++ b/test/ask-resume-restart.test.ts
@@ -316,7 +316,7 @@ describe('dispatch uuid + non-resumable origins (codex P1-1/P1-4)', () => {
     expect(seenUuid).toBe(dispatchUuidForKey(askKeyFor('cli_app', 'sess-1', 'hook', 'req-uuid-1')));
   });
 
-  it('explicit origin is NOT persisted and its card carries no dispatchUuid', async () => {
+  it('explicit origin is NOT persisted but DOES carry a dispatchUuid (codex P1-1)', async () => {
     let seenUuid: string | undefined = 'UNSET';
     const d = mockDispatcher((ask) => { seenUuid = ask.dispatchUuid; return Promise.resolve({ messageId: 'om_x' }); });
     setCardDispatcher(d);
@@ -324,6 +324,9 @@ describe('dispatch uuid + non-resumable origins (codex P1-1/P1-4)', () => {
     registerAsk(makeInput({ originKind: 'explicit', requestId: undefined }));
     await new Promise((r) => setTimeout(r, 5));
     expect(persistedFiles()).toHaveLength(0);   // never persisted → no orphan handoff
-    expect(seenUuid).toBeUndefined();           // no dedupe uuid (never re-sends)
+    // But it STILL carries a dedupe uuid: the bounded retry re-sends even a
+    // non-resumable card, so it needs server-side dedupe. uuid gates dispatch
+    // idempotency (intra-process); resumable gates persistence (cross-restart).
+    expect(seenUuid).toBeTruthy();
   });
 });

--- a/test/ask-resume-restart.test.ts
+++ b/test/ask-resume-restart.test.ts
@@ -12,7 +12,7 @@ import {
   setAskPersistStore,
   _resetForTest,
 } from '../src/core/ask-broker.js';
-import { createAskPersistStore, askKeyFor, ASK_STORE_SENTINEL, type PersistedAsk } from '../src/core/ask-persist-store.js';
+import { createAskPersistStore, askKeyFor, dispatchUuidFor, ASK_STORE_SENTINEL, type PersistedAsk } from '../src/core/ask-persist-store.js';
 import type { AskCardDispatcher, AskResult, CreateAskInput, PendingAsk } from '../src/core/ask-types.js';
 
 /**
@@ -231,11 +231,41 @@ describe('card re-send when restart precedes cardMessageId (codex P1-2)', () => 
   });
 });
 
-describe('identity + isolation', () => {
-  it('askKeyFor namespaces by originKind so hook vs explicit asks never collide', () => {
-    expect(askKeyFor('hook', 'req-1')).toBe(askKeyFor('hook', 'req-1'));
-    expect(askKeyFor('hook', 'req-1')).not.toBe(askKeyFor('explicit', 'req-1'));
-    expect(askKeyFor('hook', 'req-1')).not.toBe(askKeyFor('hook', 'req-2'));
+describe('identity + isolation (codex P1-3)', () => {
+  it('askKeyFor scopes by larkAppId+session+originKind+requestId (not a bearer secret)', () => {
+    const k = askKeyFor('cli_app', 'sess-1', 'hook', 'req-1');
+    expect(k).toBe(askKeyFor('cli_app', 'sess-1', 'hook', 'req-1'));
+    expect(k).not.toBe(askKeyFor('cli_app', 'sess-2', 'hook', 'req-1')); // diff session
+    expect(k).not.toBe(askKeyFor('cli_b', 'sess-1', 'hook', 'req-1'));   // diff bot
+    expect(k).not.toBe(askKeyFor('cli_app', 'sess-1', 'explicit', 'req-1')); // diff origin
+    expect(k).not.toBe(askKeyFor('cli_app', 'sess-1', 'hook', 'req-2')); // diff request
+  });
+
+  it('session B CANNOT reclaim session A dormant ask by reusing the same requestId', async () => {
+    setCardDispatcher(mockDispatcher());
+    registerAsk(makeInput({ sessionId: 'sess-A', requestId: 'shared-req' }));
+    await new Promise((r) => setTimeout(r, 5));
+    const a = onlyPersisted();
+
+    // Restart → restore A's dormant ask.
+    _resetForTest(); bindStore();
+    const d2 = mockDispatcher();
+    setCardDispatcher(d2);
+    setCanTalkChecker((_x, _y, openId) => openId === 'ou_owner');
+    restorePersistedAsks(Date.now(), 'cli_app');
+
+    // Session B re-registers with the SAME requestId but its own session id.
+    // Different scoped key → must NOT re-attach to A; posts B's own new card.
+    const bPromise = registerAsk(makeInput({ sessionId: 'sess-B', requestId: 'shared-req' }));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(d2.sendCalls).toHaveLength(1); // B got its OWN card, did not steal A's
+
+    // Answering A's original card must resolve nobody's B promise.
+    tryResolveAsk({ askId: a.askId, nonce: a.nonce, selected: 'yes', by: 'ou_owner' });
+    let bResolved = false;
+    void bPromise.then(() => { bResolved = true; });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(bResolved).toBe(false); // B never received A's answer
   });
 
   it('two concurrent same-question asks from one session get distinct records (distinct requestId)', async () => {
@@ -246,11 +276,53 @@ describe('identity + isolation', () => {
     expect(persistedFiles()).toHaveLength(2); // NOT collapsed by a questions hash
   });
 
-  it('restore skips a different bot; drops answered-never records past deadline', async () => {
+  it('restore skips a different bot', async () => {
     setCardDispatcher(mockDispatcher());
-    registerAsk(makeInput({ larkAppId: 'cli_other', requestId: 'req-other' }));
+    registerAsk(makeInput({ larkAppId: 'cli_other', sessionId: 'sess-o', requestId: 'req-other' }));
     await new Promise((r) => setTimeout(r, 5));
     _resetForTest(); bindStore(); setCardDispatcher(mockDispatcher());
-    expect(restorePersistedAsks(Date.now(), 'cli_app')).toBe(0);      // different bot
+    expect(restorePersistedAsks(Date.now(), 'cli_app')).toBe(0);
+  });
+});
+
+describe('active same-requestId replay joins one ask (codex P1-1)', () => {
+  it('a second live register with the same identity shares the ONE ask/card and both get the answer', async () => {
+    const d = mockDispatcher();
+    setCardDispatcher(d);
+    const p1 = registerAsk(makeInput());
+    await new Promise((r) => setTimeout(r, 5));
+    // Client reset → re-POST same requestId while still active: joins, no 2nd card.
+    const p2 = registerAsk(makeInput());
+    await new Promise((r) => setTimeout(r, 5));
+    expect(d.sendCalls).toHaveLength(1);        // ONE card
+    expect(persistedFiles()).toHaveLength(1);   // ONE record
+
+    const rec = onlyPersisted();
+    tryResolveAsk({ askId: rec.askId, nonce: rec.nonce, selected: 'yes', by: 'ou_owner' });
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1.kind).toBe('answered');
+    expect(r2).toEqual(r1);                     // both waiters got the SAME result
+  });
+});
+
+describe('dispatch uuid + non-resumable origins (codex P1-1/P1-4)', () => {
+  it('resumable (hook) card send carries a stable dispatchUuid derived from requestId', async () => {
+    let seenUuid: string | undefined = 'UNSET';
+    const d = mockDispatcher((ask) => { seenUuid = ask.dispatchUuid; return Promise.resolve({ messageId: 'om_x' }); });
+    setCardDispatcher(d);
+    registerAsk(makeInput({ requestId: 'req-uuid-1' }));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(seenUuid).toBe(dispatchUuidFor('req-uuid-1'));
+  });
+
+  it('explicit origin is NOT persisted and its card carries no dispatchUuid', async () => {
+    let seenUuid: string | undefined = 'UNSET';
+    const d = mockDispatcher((ask) => { seenUuid = ask.dispatchUuid; return Promise.resolve({ messageId: 'om_x' }); });
+    setCardDispatcher(d);
+    // Explicit ask: originKind='explicit', no requestId → not resumable.
+    registerAsk(makeInput({ originKind: 'explicit', requestId: undefined }));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(persistedFiles()).toHaveLength(0);   // never persisted → no orphan handoff
+    expect(seenUuid).toBeUndefined();           // no dedupe uuid (never re-sends)
   });
 });

--- a/test/ask-resume-restart.test.ts
+++ b/test/ask-resume-restart.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  registerAsk,
+  restorePersistedAsks,
+  submitAsk,
+  tryResolveAsk,
+  toggleAsk,
+  setCardDispatcher,
+  setCanTalkChecker,
+  _resetForTest,
+  _getPending,
+} from '../src/core/ask-broker.js';
+import { computeAskKey, listPersistedAsks } from '../src/core/ask-persist-store.js';
+import { config } from '../src/config.js';
+import type { AskCardDispatcher, AskResult, CreateAskInput, PendingAsk } from '../src/core/ask-types.js';
+
+/**
+ * Restart-resume for `botmux ask` (the AskUserQuestion picker-desync root fix).
+ *
+ * A daemon restart between "card posted" and "user clicked" used to lose the
+ * in-memory pending ask → the click hit `stale` ("此 ask 已失效") and the CLI
+ * hook fell into a stuck native picker. These tests exercise the fix: persist on
+ * register, restore as a DORMANT ask on boot, and re-attach a reconnecting hook
+ * by stable key so the answer flows back through the normal directive.
+ */
+
+const OPTIONS = [
+  { key: 'yes', label: '继续' },
+  { key: 'no', label: '回滚' },
+];
+
+function makeInput(over: Partial<CreateAskInput> = {}): CreateAskInput {
+  return {
+    larkAppId: 'cli_app',
+    chatId: 'oc_chat',
+    rootMessageId: 'om_root',
+    sessionId: 'sess-1',
+    questions: [{ prompt: '继续发版吗？', options: OPTIONS, multiSelect: false }],
+    timeoutMs: 60_000,
+    ...over,
+  };
+}
+
+function mockDispatcher(): AskCardDispatcher & { sendCalls: PendingAsk[] } {
+  const sendCalls: PendingAsk[] = [];
+  return {
+    async send(ask) { sendCalls.push(ask); return { messageId: `om_card_${ask.askId}` }; },
+    onSettle() { /* no-op */ },
+    sendCalls,
+  };
+}
+
+let dataDir: string;
+let prevDataDir: string | undefined;
+
+beforeEach(() => {
+  prevDataDir = process.env.SESSION_DATA_DIR;
+  dataDir = mkdtempSync(join(tmpdir(), 'botmux-ask-resume-'));
+  config.session.dataDir = dataDir; // maps onto SESSION_DATA_DIR
+  _resetForTest();
+  setCanTalkChecker((_a, _c, openId) => openId === 'ou_owner');
+});
+
+afterEach(() => {
+  _resetForTest();
+  if (prevDataDir === undefined) delete process.env.SESSION_DATA_DIR;
+  else process.env.SESSION_DATA_DIR = prevDataDir;
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('ask persistence', () => {
+  it('registerAsk writes a durable record; settle removes it', async () => {
+    setCardDispatcher(mockDispatcher());
+    const promise = registerAsk(makeInput());
+    // Card dispatch is async; let it land.
+    await new Promise((r) => setTimeout(r, 5));
+
+    const persisted = listPersistedAsks();
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].sessionId).toBe('sess-1');
+    expect(persisted[0].cardMessageId).toMatch(/^om_card_/);
+    const askId = persisted[0].askId;
+
+    // Answer it → record removed.
+    expect(tryResolveAsk({ askId, nonce: persisted[0].nonce, selected: 'yes', by: 'ou_owner' })).toBe('accepted');
+    await promise;
+    expect(listPersistedAsks()).toHaveLength(0);
+  });
+
+  it('multi-select toggle persists accumulated checkbox state', async () => {
+    setCardDispatcher(mockDispatcher());
+    registerAsk(makeInput({ questions: [{ prompt: '多选', options: OPTIONS, multiSelect: true }] }));
+    await new Promise((r) => setTimeout(r, 5));
+    const { askId, nonce } = listPersistedAsks()[0];
+    toggleAsk({ askId, nonce, questionIndex: 0, key: 'yes', by: 'ou_owner' });
+    expect(listPersistedAsks()[0].selections[0]).toEqual(['yes']);
+    toggleAsk({ askId, nonce, questionIndex: 0, key: 'no', by: 'ou_owner' });
+    expect(listPersistedAsks()[0].selections[0]).toEqual(['yes', 'no']);
+  });
+});
+
+describe('restorePersistedAsks (daemon restart recovery)', () => {
+  it('restores a persisted ask as dormant WITHOUT re-posting the card', async () => {
+    // Simulate: a prior daemon posted+persisted an ask, then died.
+    setCardDispatcher(mockDispatcher());
+    registerAsk(makeInput());
+    await new Promise((r) => setTimeout(r, 5));
+    const before = listPersistedAsks()[0];
+
+    // New daemon boot: reset in-memory state (disk survives), wire a fresh
+    // dispatcher, restore.
+    _resetForTest();
+    const d2 = mockDispatcher();
+    setCardDispatcher(d2);
+    setCanTalkChecker((_a, _c, openId) => openId === 'ou_owner');
+    const n = restorePersistedAsks(Date.now(), 'cli_app');
+
+    expect(n).toBe(1);
+    // Dormant restore must NOT re-post a card (the original is still live).
+    expect(d2.sendCalls).toHaveLength(0);
+    // The dormant ask is queryable and clickable.
+    const snap = _getPending(before.askId);
+    expect(snap?.askId).toBe(before.askId);
+    expect(snap?.cardMessageId).toBe(before.cardMessageId);
+  });
+
+  it('skips restoring asks belonging to a different bot', async () => {
+    setCardDispatcher(mockDispatcher());
+    registerAsk(makeInput({ larkAppId: 'cli_other', sessionId: 'sess-other' }));
+    await new Promise((r) => setTimeout(r, 5));
+    _resetForTest();
+    setCardDispatcher(mockDispatcher());
+    // This daemon serves cli_app, not cli_other → nothing to restore.
+    expect(restorePersistedAsks(Date.now(), 'cli_app')).toBe(0);
+  });
+
+  it('drops persisted asks whose deadline already passed while down', async () => {
+    setCardDispatcher(mockDispatcher());
+    registerAsk(makeInput({ timeoutMs: 1_000 }));
+    await new Promise((r) => setTimeout(r, 5));
+    _resetForTest();
+    setCardDispatcher(mockDispatcher());
+    // now is well past the 1s deadline.
+    expect(restorePersistedAsks(Date.now() + 10_000, 'cli_app')).toBe(0);
+    expect(listPersistedAsks(Date.now() + 10_000)).toHaveLength(0);
+  });
+});
+
+describe('re-attach: reconnecting hook resolves the restored card', () => {
+  it('registerAsk with the same key re-attaches to the dormant ask (no new card), then a click resolves it', async () => {
+    // Prior daemon: post + persist.
+    setCardDispatcher(mockDispatcher());
+    registerAsk(makeInput());
+    await new Promise((r) => setTimeout(r, 5));
+    const orig = listPersistedAsks()[0];
+
+    // Restart: restore dormant.
+    _resetForTest();
+    const d2 = mockDispatcher();
+    setCardDispatcher(d2);
+    setCanTalkChecker((_a, _c, openId) => openId === 'ou_owner');
+    restorePersistedAsks(Date.now(), 'cli_app');
+
+    // The surviving hook reconnects → re-registers the SAME ask (same session +
+    // questions → same key). This must re-attach, NOT post a second card.
+    const reattached = registerAsk(makeInput());
+    await new Promise((r) => setTimeout(r, 5));
+    expect(d2.sendCalls).toHaveLength(0); // no duplicate card
+
+    // A click now resolves the re-attached waiter through the normal path.
+    expect(tryResolveAsk({ askId: orig.askId, nonce: orig.nonce, selected: 'yes', by: 'ou_owner' })).toBe('accepted');
+    const result: AskResult = await reattached;
+    expect(result.kind).toBe('answered');
+    expect(listPersistedAsks()).toHaveLength(0); // cleaned on settle
+  });
+
+  it('computeAskKey is stable for same session+questions and differs otherwise', () => {
+    const qs = makeInput().questions;
+    expect(computeAskKey('sess-1', qs)).toBe(computeAskKey('sess-1', qs));
+    expect(computeAskKey('sess-1', qs)).not.toBe(computeAskKey('sess-2', qs));
+    const qs2 = [{ prompt: 'different?', options: OPTIONS, multiSelect: false }];
+    expect(computeAskKey('sess-1', qs)).not.toBe(computeAskKey('sess-1', qs2));
+  });
+});

--- a/test/ask-resume-startup-guards.test.ts
+++ b/test/ask-resume-startup-guards.test.ts
@@ -1,58 +1,71 @@
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+
+import {
+  isRetryableAskHttpStatus,
+  shouldReturnAskStartupNotReady,
+} from '../src/core/ask-types.js';
 
 /**
- * Source-guard tests for two ask-resume behaviours that live inside large
- * closures (daemon.ts's `/api/asks` handler; cli.ts's `postAsk`) and can't be
- * unit-tested without booting the whole daemon / doing real daemon discovery.
- * The runtime contract they enforce IS unit-tested elsewhere:
- *   - the retry gate honouring `retryable`     → test/cmd-hook.test.ts
- *   - requestId/originKind parsing             → test/ask-api.test.ts
- *   - persistence / handoff / re-attach        → test/ask-resume-restart.test.ts
- * These assertions pin the two remaining seams so they can't be silently
- * removed (codex P1-2/P1-3 startup-503 + typed classifier).
+ * Executable decision seams for two ask-resume behaviours that used to be
+ * asserted only against source text (codex round-3: source regex can't be the
+ * contract). Both predicates are now PURE functions that the daemon `/api/asks`
+ * handler (shouldReturnAskStartupNotReady) and cli.ts `postAsk`
+ * (isRetryableAskHttpStatus) import and call at runtime — so these tests
+ * exercise the SAME code the production path runs, not a copy.
+ *
+ * The runtime WIRING (that daemon.ts actually calls the guard before the 403,
+ * and postAsk actually gates its retry on the classifier) is covered by
+ * behavioural tests: test/cmd-hook.test.ts drives postAsk's retry loop end to
+ * end against a stub daemon returning 503 vs 4xx.
  */
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const read = (rel: string) => readFileSync(join(__dirname, '..', rel), 'utf-8');
-
-describe('daemon /api/asks startup readiness (codex P1-2)', () => {
-  const daemon = read('src/daemon.ts');
-
-  it('returns a RETRYABLE 503 startup_not_ready for an unknown session before restore completes', () => {
-    // The guard must sit before the 403 origin_unproven authorization so a
-    // reconnecting hook that races restoreActiveSessions gets 503 (retryable),
-    // not a permanent 403 → passthrough → stuck native picker.
-    expect(daemon).toMatch(/!askSession\s*&&\s*!sessionsRestored[\s\S]*?503[\s\S]*?startup_not_ready/);
+describe('postAsk retry classifier (codex P1-3 seam)', () => {
+  it('502/503/504 are retryable (daemon up but transiently unready)', () => {
+    expect(isRetryableAskHttpStatus(502)).toBe(true);
+    expect(isRetryableAskHttpStatus(503)).toBe(true);
+    expect(isRetryableAskHttpStatus(504)).toBe(true);
   });
 
-  it('flips sessionsRestored=true only AFTER restoreActiveSessions()', () => {
-    const restoreIdx = daemon.indexOf('await restoreActiveSessions(activeSessions)');
-    const flipIdx = daemon.indexOf('sessionsRestored = true');
-    expect(restoreIdx).toBeGreaterThan(0);
-    expect(flipIdx).toBeGreaterThan(restoreIdx); // set after, not before
+  it('deterministic 4xx are NOT retryable (fail identically forever → passthrough)', () => {
+    for (const s of [400, 401, 403, 404, 409, 422]) {
+      expect(isRetryableAskHttpStatus(s)).toBe(false);
+    }
+  });
+
+  it('other 5xx that are not the startup/ready band are NOT retryable', () => {
+    // 500/501 are treated as deterministic here: the daemon answered decisively,
+    // not "restarting". Only the 502/503/504 unready band is retried.
+    expect(isRetryableAskHttpStatus(500)).toBe(false);
+    expect(isRetryableAskHttpStatus(501)).toBe(false);
+  });
+
+  it('2xx is never classified retryable (success is not an error to retry)', () => {
+    expect(isRetryableAskHttpStatus(200)).toBe(false);
   });
 });
 
-describe('postAsk error classification (codex P1-3)', () => {
-  const cli = read('src/cli.ts');
-  // Isolate the postAsk function body.
-  const start = cli.indexOf('async function postAsk(');
-  const body = cli.slice(start, start + 3000);
-
-  it('only 502/503/504 HTTP responses are marked retryable (deterministic 4xx are not)', () => {
-    expect(body).toMatch(/res\.status === 502 \|\| res\.status === 503 \|\| res\.status === 504/);
+describe('daemon /api/asks startup readiness guard (codex P1-2 seam)', () => {
+  it('unknown session + restore not finished + untrusted → 503 startup_not_ready', () => {
+    expect(shouldReturnAskStartupNotReady({
+      hasSession: false, sessionsRestored: false, trustedHost: false,
+    })).toBe(true);
   });
 
-  it('non-JSON daemon response is NOT retryable (retry cannot fix a malformed body)', () => {
-    expect(body).toMatch(/返回非 JSON[\s\S]*?false/);
+  it('once restore has finished, a still-unknown session does NOT get 503 (falls through to 403/proceed)', () => {
+    expect(shouldReturnAskStartupNotReady({
+      hasSession: false, sessionsRestored: true, trustedHost: false,
+    })).toBe(false);
   });
 
-  it('no-daemon and transport failures ARE retryable (restart-in-progress)', () => {
-    // Both the "找不到 daemon" and "无法连接 daemon" throws pass retryable=true.
-    expect(body).toMatch(/找不到 daemon[\s\S]*?true/);
-    expect(body).toMatch(/无法连接 daemon[\s\S]*?true/);
+  it('a session that already resolved never hits the startup guard', () => {
+    expect(shouldReturnAskStartupNotReady({
+      hasSession: true, sessionsRestored: false, trustedHost: false,
+    })).toBe(false);
+  });
+
+  it('a trusted-host IPC caller bypasses the startup guard (not a session-scoped hook)', () => {
+    expect(shouldReturnAskStartupNotReady({
+      hasSession: false, sessionsRestored: false, trustedHost: true,
+    })).toBe(false);
   });
 });

--- a/test/ask-resume-startup-guards.test.ts
+++ b/test/ask-resume-startup-guards.test.ts
@@ -45,27 +45,33 @@ describe('postAsk retry classifier (codex P1-3 seam)', () => {
 });
 
 describe('daemon /api/asks startup readiness guard (codex P1-2 seam)', () => {
-  it('unknown session + restore not finished + untrusted → 503 startup_not_ready', () => {
+  it('unknown session + restore not finished → 503 startup_not_ready', () => {
     expect(shouldReturnAskStartupNotReady({
-      hasSession: false, sessionsRestored: false, trustedHost: false,
+      hasSession: false, sessionsRestored: false,
     })).toBe(true);
   });
 
   it('once restore has finished, a still-unknown session does NOT get 503 (falls through to 403/proceed)', () => {
     expect(shouldReturnAskStartupNotReady({
-      hasSession: false, sessionsRestored: true, trustedHost: false,
+      hasSession: false, sessionsRestored: true,
     })).toBe(false);
   });
 
   it('a session that already resolved never hits the startup guard', () => {
     expect(shouldReturnAskStartupNotReady({
-      hasSession: true, sessionsRestored: false, trustedHost: false,
+      hasSession: true, sessionsRestored: false,
     })).toBe(false);
   });
 
-  it('a trusted-host IPC caller bypasses the startup guard (not a session-scoped hook)', () => {
+  it('a reconnecting unsandbox hook (trusted-host transport) is NOT exempted during restore — it is exactly who must 503 (codex P1-2)', () => {
+    // A normal unsandbox tmux hook reaches /api/asks via the HMAC fetchDaemonIpc
+    // (trusted-host) path. The earlier gate exempted trusted callers, letting
+    // this hook slip past 503 during the descriptor-published-but-not-restored
+    // window and register a lost non-resumable ask. The predicate no longer
+    // takes trustedHost at all: an unknown session mid-restore ALWAYS 503s,
+    // regardless of how it authenticated.
     expect(shouldReturnAskStartupNotReady({
-      hasSession: false, sessionsRestored: false, trustedHost: true,
-    })).toBe(false);
+      hasSession: false, sessionsRestored: false,
+    })).toBe(true);
   });
 });

--- a/test/ask-resume-startup-guards.test.ts
+++ b/test/ask-resume-startup-guards.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+/**
+ * Source-guard tests for two ask-resume behaviours that live inside large
+ * closures (daemon.ts's `/api/asks` handler; cli.ts's `postAsk`) and can't be
+ * unit-tested without booting the whole daemon / doing real daemon discovery.
+ * The runtime contract they enforce IS unit-tested elsewhere:
+ *   - the retry gate honouring `retryable`     → test/cmd-hook.test.ts
+ *   - requestId/originKind parsing             → test/ask-api.test.ts
+ *   - persistence / handoff / re-attach        → test/ask-resume-restart.test.ts
+ * These assertions pin the two remaining seams so they can't be silently
+ * removed (codex P1-2/P1-3 startup-503 + typed classifier).
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(join(__dirname, '..', rel), 'utf-8');
+
+describe('daemon /api/asks startup readiness (codex P1-2)', () => {
+  const daemon = read('src/daemon.ts');
+
+  it('returns a RETRYABLE 503 startup_not_ready for an unknown session before restore completes', () => {
+    // The guard must sit before the 403 origin_unproven authorization so a
+    // reconnecting hook that races restoreActiveSessions gets 503 (retryable),
+    // not a permanent 403 → passthrough → stuck native picker.
+    expect(daemon).toMatch(/!askSession\s*&&\s*!sessionsRestored[\s\S]*?503[\s\S]*?startup_not_ready/);
+  });
+
+  it('flips sessionsRestored=true only AFTER restoreActiveSessions()', () => {
+    const restoreIdx = daemon.indexOf('await restoreActiveSessions(activeSessions)');
+    const flipIdx = daemon.indexOf('sessionsRestored = true');
+    expect(restoreIdx).toBeGreaterThan(0);
+    expect(flipIdx).toBeGreaterThan(restoreIdx); // set after, not before
+  });
+});
+
+describe('postAsk error classification (codex P1-3)', () => {
+  const cli = read('src/cli.ts');
+  // Isolate the postAsk function body.
+  const start = cli.indexOf('async function postAsk(');
+  const body = cli.slice(start, start + 3000);
+
+  it('only 502/503/504 HTTP responses are marked retryable (deterministic 4xx are not)', () => {
+    expect(body).toMatch(/res\.status === 502 \|\| res\.status === 503 \|\| res\.status === 504/);
+  });
+
+  it('non-JSON daemon response is NOT retryable (retry cannot fix a malformed body)', () => {
+    expect(body).toMatch(/返回非 JSON[\s\S]*?false/);
+  });
+
+  it('no-daemon and transport failures ARE retryable (restart-in-progress)', () => {
+    // Both the "找不到 daemon" and "无法连接 daemon" throws pass retryable=true.
+    expect(body).toMatch(/找不到 daemon[\s\S]*?true/);
+    expect(body).toMatch(/无法连接 daemon[\s\S]*?true/);
+  });
+});

--- a/test/cmd-hook.test.ts
+++ b/test/cmd-hook.test.ts
@@ -52,10 +52,11 @@ function makeAnsweredStub(answers: string[][]): () => Promise<AskResult> {
   });
 }
 
-// 构造一个抛出错误的 postAskFn stub
-function makeThrowingStub(msg = 'daemon unreachable'): () => Promise<AskResult> {
+// 构造一个抛出错误的 postAskFn stub。exitCode=3（daemon 不可达）会被 runHook
+// 重试；传别的（或不传）用于测"非可重试错误立即 passthrough"。
+function makeThrowingStub(msg = 'boom', exitCode?: number): () => Promise<AskResult> {
   return async () => {
-    throw Object.assign(new Error(msg), { exitCode: 3 });
+    throw Object.assign(new Error(msg), exitCode !== undefined ? { exitCode } : {});
   };
 }
 
@@ -91,8 +92,8 @@ describe('runHook', () => {
   });
 
   describe('(b) postAskFn 抛错 → 输出 passthrough，不抛出', () => {
-    it('任何 postAsk 错误均优雅放行', async () => {
-      const stub = makeThrowingStub('daemon unreachable');
+    it('非可重试错误（无 exitCode 3）立即优雅放行', async () => {
+      const stub = makeThrowingStub('boom');
       // 不应抛出
       let result: Awaited<ReturnType<typeof runHook>>;
       expect(async () => {
@@ -104,6 +105,32 @@ describe('runHook', () => {
       // 回归（Codex P1.1）：放行 = 空 stdout，绝不输出 directive。直接断言空串，
       // 不与实现的 passthrough() 比较，避免实现回退时测试跟着移动。
       expect(result.stdout).toBe('');
+    });
+
+    it('daemon 不可达（exitCode 3）先重试，超过 ask 截止仍失败才 passthrough', async () => {
+      // exitCode 3 = daemon restart-in-progress → runHook 重试而非立即放行,
+      // 避免"卡还在但 hook 退出→原生 picker 卡死"。这里用极短 timeout 让重试
+      // 循环很快撞上截止、回落 passthrough,断言:①最终仍优雅放行 ②确实重试了多次。
+      let calls = 0;
+      const stub = async () => { calls++; throw Object.assign(new Error('daemon unreachable'), { exitCode: 3 }); };
+      const env = { ...FULL_ENV, BOTMUX_ASK_TIMEOUT_MS: '1200' }; // 1.2s window
+      const result = await runHook(claudeAskPayload, env, stub, 'claude-code');
+      expect(result.stdout).toBe('');       // 截止后 passthrough
+      expect(calls).toBeGreaterThan(1);     // 至少重试过一次（非立即放行）
+    });
+
+    it('daemon 恢复后重试拿到 answered → 走正常 directive（不 passthrough）', async () => {
+      // 模拟：前两次 exitCode 3（restart 中），第三次 daemon 回来返 answered。
+      let calls = 0;
+      const stub = async (): Promise<AskResult> => {
+        calls++;
+        if (calls < 3) throw Object.assign(new Error('daemon unreachable'), { exitCode: 3 });
+        return { kind: 'answered', answers: [['继续']], by: 'ou_u', comment: null, timedOut: false };
+      };
+      const result = await runHook(claudeAskPayload, FULL_ENV, stub, 'claude-code');
+      expect(calls).toBe(3);
+      expect(result.stdout).toBeTruthy();
+      expect(JSON.stringify(JSON.parse(result.stdout))).toContain('继续');
     });
   });
 
@@ -259,7 +286,7 @@ describe('runHook', () => {
       expect(capturedBody?.timeoutMs).toBe(7_200_000);
     });
 
-    it('无效值 → 使用默认 3600000', async () => {
+    it('无效值 → 回退到默认（24h，对齐 hook 进程超时上限）', async () => {
       let capturedBody: Record<string, unknown> | undefined;
       const captureStub = async (body: Record<string, unknown>): Promise<AskResult> => {
         capturedBody = body;
@@ -267,7 +294,17 @@ describe('runHook', () => {
       };
       const env = { ...FULL_ENV, BOTMUX_ASK_TIMEOUT_MS: 'not_a_number' };
       await runHook(claudeAskPayload, env, captureStub, 'claude-code');
-      expect(capturedBody?.timeoutMs).toBe(3_600_000);
+      expect(capturedBody?.timeoutMs).toBe(86_400_000);
+    });
+
+    it('未设 BOTMUX_ASK_TIMEOUT_MS → body.timeoutMs 默认 24h', async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      const captureStub = async (body: Record<string, unknown>): Promise<AskResult> => {
+        capturedBody = body;
+        return { kind: 'answered', answers: [['继续']], by: 'ou_u', comment: null, timedOut: false };
+      };
+      await runHook(claudeAskPayload, FULL_ENV, captureStub, 'claude-code');
+      expect(capturedBody?.timeoutMs).toBe(86_400_000);
     });
   });
 

--- a/test/cmd-hook.test.ts
+++ b/test/cmd-hook.test.ts
@@ -107,24 +107,34 @@ describe('runHook', () => {
       expect(result.stdout).toBe('');
     });
 
-    it('daemon 不可达（exitCode 3）先重试，超过 ask 截止仍失败才 passthrough', async () => {
-      // exitCode 3 = daemon restart-in-progress → runHook 重试而非立即放行,
+    it('daemon 不可达（retryable）先重试，超过 ask 截止仍失败才 passthrough', async () => {
+      // retryable=true = daemon restart-in-progress → runHook 重试而非立即放行,
       // 避免"卡还在但 hook 退出→原生 picker 卡死"。这里用极短 timeout 让重试
       // 循环很快撞上截止、回落 passthrough,断言:①最终仍优雅放行 ②确实重试了多次。
       let calls = 0;
-      const stub = async () => { calls++; throw Object.assign(new Error('daemon unreachable'), { exitCode: 3 }); };
+      const stub = async () => { calls++; throw Object.assign(new Error('daemon unreachable'), { exitCode: 3, retryable: true }); };
       const env = { ...FULL_ENV, BOTMUX_ASK_TIMEOUT_MS: '1200' }; // 1.2s window
       const result = await runHook(claudeAskPayload, env, stub, 'claude-code');
       expect(result.stdout).toBe('');       // 截止后 passthrough
       expect(calls).toBeGreaterThan(1);     // 至少重试过一次（非立即放行）
     });
 
+    it('确定性错误（retryable=false，如 4xx / 非 JSON）立即 passthrough,不重试', async () => {
+      // 关键回归（codex P1-3）：postAsk 对确定性 4xx / 非 JSON 给 retryable=false,
+      // runHook 必须立即放行,而不是每 5s 重试到 24h。
+      let calls = 0;
+      const stub = async () => { calls++; throw Object.assign(new Error('HTTP 400 bad body'), { exitCode: 3, retryable: false }); };
+      const result = await runHook(claudeAskPayload, FULL_ENV, stub, 'claude-code');
+      expect(result.stdout).toBe('');
+      expect(calls).toBe(1);                 // 只调一次,不重试
+    });
+
     it('daemon 恢复后重试拿到 answered → 走正常 directive（不 passthrough）', async () => {
-      // 模拟：前两次 exitCode 3（restart 中），第三次 daemon 回来返 answered。
+      // 模拟：前两次 retryable（restart 中），第三次 daemon 回来返 answered。
       let calls = 0;
       const stub = async (): Promise<AskResult> => {
         calls++;
-        if (calls < 3) throw Object.assign(new Error('daemon unreachable'), { exitCode: 3 });
+        if (calls < 3) throw Object.assign(new Error('daemon unreachable'), { exitCode: 3, retryable: true });
         return { kind: 'answered', answers: [['继续']], by: 'ou_u', comment: null, timedOut: false };
       };
       const result = await runHook(claudeAskPayload, FULL_ENV, stub, 'claude-code');


### PR DESCRIPTION
## 问题

`botmux ask`(含 AskUserQuestion hook)的 pending 注册表只在内存。daemon 在「卡片已发」到「用户点击」之间重启时,ask 蒸发:用户点击拿到 `stale`,而阻塞在 `/api/asks` 的 CLI hook 早已断连回落 passthrough → CLI 渲染原生 picker,答案无处投递(卡在原生选择器不消失)。

## 保证(冻结成 6 条契约)

「CLI ask 卡片跨 daemon 重启不丢」这个保证的正确实现面较大。为避免每轮 review 临时扩题,把它冻结成 6 条契约,**每条先落一个失败反例(`test/ask-resume-contract.test.ts`,在旧代码上跑红)再改实现让其转绿**:

1. **canonical identity 全链路唯一** — `askKeyFor` 改长度前缀编码消除分隔符别名与截断碰撞;持久化文件名对完整 key 做 SHA-256(不截断);派发 uuid 从完整 scoped key 派生(非裸 requestId),同 invocation 幂等、跨 session 同 requestId 不互相别名。
2. **同 identity 全状态幂等** — active 合并 waiter / 终态复返 / dormant 重挂,三态都测。
3. **mismatch fail-closed** — 同 key 但不可变身份(问题集/chat)不符 → 明确 `invalidated`,不 fall-through 新建第二张卡;questionsShape 纳入 option label。
4. **仅 restart-surviving 后端可恢复** — resumable 由 daemon 按已认证 session 的 frozen backend 判(`getSessionPersistentBackendType`:tmux/herdr/zellij/zmx=yes,pty=no),不信 client 的 origin 字符串;undefined fail-closed 不落盘(否则 PTY hook 落盘 → 无人认领 → 孤儿)。
5. **派发 partial-success 可收敛** — dispatcher 抛 typed `AskDispatchError{retryable}`,broker 有界重试(4 次线性退避)复用同 uuid → 服务端已成功的投卡在 socket reset 后重试返回原 messageId(一张逻辑卡,broker 保持 pending);确定 4xx/withdrawn/未 typed 裸抛 → 立即 invalidate(fail closed)。
6. **handoff 绝对到期 + map/disk 同步清** — stash 与 restore 都武装 `answeredAt + 24h` 绝对到期 timer,触发即删内存+盘(原先只在 boot 的 `list()` sweep 清盘,long-running daemon 永不触发);二次重启前未认领仍按原 answeredAt 计时;认领时取消 reaper。

另把两处藏在大闭包、原先只能靠源码 regex 断言的判定抽成**纯函数**,由 route/CLI 真调用 + 直接单测(executable decision seam):
- `isRetryableAskHttpStatus(status)` — postAsk 重试分类器(502/503/504 retryable)。
- `shouldReturnAskStartupNotReady({hasSession,sessionsRestored})` — `/api/asks` 启动期 503 门(重启 restore 竞态期给 retryable 503 而非永久 403;不放行 trusted-host,见下方复审收敛第 2 点)。

## 影响面

改动集中在 ask 子系统(broker / persist-store / types / lark card)+ daemon `/api/asks` 接线 + cli `postAsk` 分类器。
- **跨 CLI**:重试仅对 `AskDispatchError`(飞书投卡)生效,不碰其它 CLI 的出站路径;未动 `adapters/cli/` 共用层。
- **跨后端**:`backendSurvivesRestart` 只门控「是否落盘恢复」——PTY 会话的 ask 仍能实时问答,只是不跨重启持久化(与 tmux/herdr/zellij/zmx 的可恢复语义分离)。
- **跨会话类型**:VC meeting receiver ask 仍走既有 `managed_action_required` 拒绝;apiOnly / HTTP 虚拟会话仍 `unsupported` fail-fast。

## 验证

- `test/ask-resume-contract.test.ts` 六条契约 + 复审 3 条 red case(explicit/PTY 双卡、瞬时 Lark code、unsandbox-hook 应 503),每条含 red-on-old 反例。
- 6 个 ask 聚焦文件(`ask-resume-contract` / `ask-resume-restart` / `ask-resume-startup-guards` / `ask-card` / `ask-api` / `cmd-hook`)本地 **120 tests 全绿**;CI 全 ask 聚焦口径 **233/233**。
- `pnpm build` 通过;全量 vitest 通过(唯一飘红 `doc-comment-daemon-concurrency` 与本 PR 无关:未改任何 doc-comment 文件,该用例满载并发下 10s 超时、单独跑 4.7s 稳过)。
- rebase 最新 master(含 #742),重建 + 重跑 ask 全套仍绿。

> codex 已 CODE APPROVED(`afafd6834`,因作者与 reviewer 共用同一 GitHub 身份记为 COMMENTED)。合并前剩 live 手测:发卡 → daemon restart → 点卡 → directive 生效 → 落盘清空。通过后请申晗拍合。


---

## 复审后 3 点收敛(HEAD `afafd6834`,delta `2e0e3b56c..afafd6834`)

1. **dispatchUuid 与 retry 同门**(修一个本 PR retry-all 引入的回归):有界重试对所有 ask 生效,但 uuid 原先只给 resumable → explicit / PTY hook 重试无去重键 → "服务端已投卡后 socket reset" 的重试会真发第二张卡。改为 `snapshot()` 对**所有** ask 派生 `dispatchUuidForKey(scoped askKey)`;`resumable` 只再门控跨重启持久化,不门控进程内派发幂等。补 explicit + PTY 双卡反例。
2. **启动期 503 门不再放行 trusted-host**:普通 unsandbox hook 本身走 HMAC `fetchDaemonIpc`(trusted-host)路径;descriptor 先发布、sessions 后恢复。原门排除 trusted → 这段窗口 unknown-session hook 绕过 503、被算 `backendSurvivesRestart:false`,daemon 若死在首次 register 前则重连新建 non-resumable ask 下次仍丢。改:`shouldReturnAskStartupNotReady` 去掉 `trustedHost` 入参,restore 未完成 + session 未知即 503(所有 `/api/asks` 调用方都是 session-scoped 注册,desktop 作答走另一路由)。
3. **classifier 认瞬时 Lark 业务码**:`230049`(message is being sent,官方 retry-later,尤其出现在同 uuid partial-success 收敛)原被判 permanent。加白名单 `{230049, 230020, 99991400}`,命中即 retryable,无论 HTTP 400 还是 2xx-body plain Error(`response.data.code` + 兜底解析 message 尾 `(code: NNN)`)。`11232/11233` 属旧 V4 不混入。

**Follow-up(不在本轮)**:429 / `99991400` 的 `x-ogw-ratelimit-reset` 尚未接成 `AskDispatchError.retryAfterMs`,当前短退避(0.5/1/1.5s ×4)覆盖不了官方长 reset 窗口 → 留后续;`230049/230020` 在短退避内即可收敛。

复审已通过的反证(retry×三态 settle、mismatch 不碰原 waiter、生产长 key restore/remove 对称、settled+dormant 的 GC/anchor/二次重启)均保留;新增 3 条 red case;6 ask 聚焦文件 **120 tests** 全绿。

