### PR TITLE
fix(sandbox): 收口 Linux lark-cli keystore 跨 bot 泄漏

### DIFF
--- a/src/adapters/backend/sandbox.ts
+++ b/src/adapters/backend/sandbox.ts
@@ -600,6 +600,14 @@ export function prepareDirectSandbox(opts: {
   trustedBotmuxCommandPaths?: readonly string[];
   /** Worker-owned Unix socket for the credential-bearing MCP Gateway. */
   mcpGatewaySocketPath?: string;
+  /** CANONICAL lark-cli data root (the parent of the frozen keystore dir, i.e.
+   *  `dirname(larkCliLinuxStore)`) the worker resolved + nearest-ancestor-canonicalized.
+   *  Pinned into the child as LARKSUITE_CLI_DATA_DIR so the in-sandbox lark-cli resolves
+   *  the SAME keystore the policy denied/carved-out — NOT the lexical env value, which on a
+   *  symlinked data root resolves to an unbound path inside the sandbox (ENOENT → auth
+   *  breaks) or a namespace the policy never anchored. Absent/empty →
+   *  unset in the child (default store, matching the policy's default resolution). */
+  larkCliDataDir?: string | null;
 }): DirectSandboxSpawn | null {
   if (process.platform !== 'linux') return null;
   if (!ensureSandboxDeps()) return null;
@@ -749,6 +757,20 @@ export function prepareDirectSandbox(opts: {
   }
   args.push('--unsetenv', 'BOTS_CONFIG');
   args.push('--unsetenv', 'BOTMUX_HOST_RELAY_AUTHORIZED');
+  // LARKSUITE_CLI_DATA_DIR relocates the lark-cli keystore dir on Linux to
+  // `<value>/lark-cli`. Pin the child to the CANONICAL data root the worker resolved
+  // (opts.larkCliDataDir = dirname of the frozen keystore dir) so the in-sandbox lark-cli
+  // opens EXACTLY the keystore the policy denied/carved-out — same canonical namespace,
+  // not the lexical env value (which on a symlinked data root resolves to an unbound path
+  // inside the sandbox → ENOENT/auth-break, or a namespace the policy never anchored).
+  // Absent → unset so the child falls back to $HOME/.local/share,
+  // matching the policy's default resolution. Authoritative: applied last, and bwrap has
+  // no --clearenv so this overrides any inherited/rc-injected value.
+  if (opts.larkCliDataDir && opts.larkCliDataDir.startsWith('/')) {
+    args.push('--setenv', 'LARKSUITE_CLI_DATA_DIR', opts.larkCliDataDir);
+  } else {
+    args.push('--unsetenv', 'LARKSUITE_CLI_DATA_DIR');
+  }
   for (const [k, v] of Object.entries(env)) args.push('--setenv', k, v);
   // Canonicalize the CLI binary before execvp: on a symlinked-$HOME host
   // (e.g. /home/u → /data00/home/u shared-drive mount) the worker hands us the

--- a/src/adapters/cli/fs-policy.ts
+++ b/src/adapters/cli/fs-policy.ts
@@ -642,7 +642,7 @@ export function buildFsPolicy(ctx: FsPolicyContext): FsPolicy {
   // BOT_HOME AND p is inside BOT_HOME; a root at/under BOT_HOME keeps restricting.
   const insideAuthority = (p: string): boolean =>
     authorityRoots.some(root =>
-      coversPath(root, p) && !(coversPath(root, ctx.botHome) && coversPath(ctx.botHome, p)));
+      coversPath(root, p) && !(root !== ctx.botHome && coversPath(root, ctx.botHome) && coversPath(ctx.botHome, p)));
   // Dropped caller allow paths are RECORDED so the worker can log the suppression
   // (codex: a silently-dropped grant is a diagnosability hole).
   const suppressedAuthorityPaths: string[] = [];
@@ -851,8 +851,7 @@ export function buildFsPolicy(ctx: FsPolicyContext): FsPolicy {
   // master stay denied (no leak) and this bot's own keys are readable (auth works) — with
   // ZERO dependence on matching lark-cli's char validator. Deduped when equal (common case:
   // no custom LARKSUITE_CLI_DATA_DIR → resolved == default → one store). `deny` tagged
-  // `baseline` to match darwin (store deny lives in darwinBaseline; can't live in
-  // linuxBaseline — that has no homeDir-independent way to know the resolved store path).
+  // `mandatory` (not `baseline` like darwin's): see the rank-collision note in the loop.
   // No-transport denies both stores wholesale via authorityRoots and gets NO carve-out.
   if (ctx.platform === 'linux' && larkTransport) {
     const stores = new Set<string>();
@@ -861,7 +860,12 @@ export function buildFsPolicy(ctx: FsPolicyContext): FsPolicy {
     const dflt = normalizeFsPath(`${ctx.homeDir}/.local/share/lark-cli`);
     if (dflt) stores.add(dflt);
     for (const larkStore of stores) {
-      push([larkStore], 'deny', 'baseline');
+      // `mandatory` (not `baseline`): if a deployment wires the store onto BOT_HOME
+      // itself (store === botHome — e.g. appId 'lark-cli' + LARKSUITE_CLI_DATA_DIR=<botmuxHome>/bots),
+      // the internal BOT_HOME readWrite grant lands on the SAME path and would otherwise
+      // outrank this deny by source rank (internal 2 > baseline 0), re-opening the whole
+      // keystore rw. mandatory (4) keeps the ceiling; the deeper own-key carve-outs still win by depth.
+      push([larkStore], 'deny', 'mandatory');
       push([`${larkStore}/master.key`, `${larkStore}/appsecret_${ctx.currentAppId}.enc`], 'readOnly', 'internal');
     }
   }

--- a/src/adapters/cli/fs-policy.ts
+++ b/src/adapters/cli/fs-policy.ts
@@ -143,6 +143,25 @@ export interface FsPolicyContext {
    *  not silently mask an arbitrary parent dir (`/tmp`, `/etc`, a project root),
    *  which would break the core CLI (codex P1). Absent = default `~/.botmux/bots.json`. */
   loadedBotsConfigPath?: string;
+  /** LINUX ONLY: the CANONICAL lark-cli data store dir that holds EVERY bot's
+   *  `appsecret_<appId>.enc` + the shared `master.key` (the Linux analogue of the
+   *  macOS `~/Library/Application Support/lark-cli` keystore). lark-cli resolves it
+   *  to `${LARKSUITE_CLI_DATA_DIR}/lark-cli` (when that env var is ABSOLUTE) else
+   *  `$HOME/.local/share/lark-cli` — it does NOT consult XDG_DATA_HOME (verified by
+   *  strace on v1.0.76). So it is NOT purely a function of homeDir. The worker
+   *  resolves it from the FROZEN host env (`resolveLarkCliLinuxStoreDir`) and
+   *  canonicalizes it (this fn stays pure — it must never read env). Under the
+   *  baseline `ro(~/.local/share)` grant the whole store is otherwise exposed
+   *  read-only → a sandboxed bot could read its SIBLINGS' ciphertext + the shared
+   *  master key and impersonate them (the pre-refactor cross-bot leak macOS already
+   *  closes). buildFsPolicy DENIES the store and, for a transport-enabled turn,
+   *  re-opens ONLY this bot's own `master.key` + `appsecret_<currentAppId>.enc`
+   *  read-only at a deeper path (longest-prefix-wins), mirroring the darwin carve-out.
+   *  A no-transport turn freezes it as an authority root with NO carve-out. Absent on
+   *  Linux → falls back to the default `${homeDir}/.local/share/lark-cli` (correct
+   *  whenever LARKSUITE_CLI_DATA_DIR is unset/relative — the common case — and still
+   *  protective otherwise). Ignored on darwin. */
+  larkCliLinuxStore?: string;
 }
 
 /** Normalize: require absolute, strip trailing slashes, reject `..` segments.
@@ -408,6 +427,112 @@ export class FsPolicyConfigError extends Error {
 }
 
 /**
+ * The Linux lark-cli keystore dir. lark-cli stores keys at
+ * `${LARKSUITE_CLI_DATA_DIR}/lark-cli` (absolute) else `$HOME/.local/share/lark-cli`.
+ * The worker resolves the real (env-aware, cleaned) path via
+ * resolveLarkCliLinuxStoreDir + a nearest-existing-ancestor canonicalize, passing
+ * it as `override`; when absent this falls back to the default under homeDir. PURE
+ * — never reads env (that would break single-testability). Exported so the worker's
+ * real assembly and the unit matrix share ONE resolver.
+ *
+ * `override` is expected to already be lexically clean (resolveLarkCliLinuxStoreDir
+ * Cleans it); a defensive normalizeFsPath still rejects a `..`-bearing value — but
+ * that must NEVER silently fall back to the default store (the pitfall this guards: the
+ * default gets denied while the real `..`-cleaned store lark-cli reads stays exposed).
+ * So a non-null-but-unnormalizable override returns null → the caller (buildFsPolicy)
+ * emits NO Linux carve-out, and the store stays denied-by-default rather than
+ * mis-anchored. In practice the worker always Cleans first, so this path is defensive.
+ */
+export function larkCliLinuxStorePath(homeDir: string, override?: string): string | null {
+  if (override) return normalizeFsPath(override); // may be null → no carve-out (never silent default fallback)
+  return normalizeFsPath(`${homeDir}/.local/share/lark-cli`);
+}
+
+/**
+ * The CANONICAL lark-cli data root to pin into the sandbox child as
+ * LARKSUITE_CLI_DATA_DIR, given the fully-canonical keystore dir the policy protects
+ * (`canonStore` = worker's larkCliLinuxStore, leaf symlinks already followed). The
+ * in-sandbox lark-cli opens `<pin>/lark-cli`, so the pin must be `dirname(canonStore)`
+ * — but that is same-source with the policy-protected store ONLY when the canonical
+ * store's basename is still `lark-cli` (the common case, incl. a symlink that resolves
+ * to another dir also named `lark-cli`). If the `lark-cli` leaf was a symlink to a
+ * DIFFERENTLY-named dir (basename !== 'lark-cli'), `<dirname>/lark-cli` would NOT equal
+ * canonStore, so pinning it would point the child at an unbound/foreign path. There is
+ * no leak either way (the policy denies the real store, and both candidate stores are
+ * locked), so return null → the worker pins nothing and the child falls back to the
+ * default store (also locked). Pure + total. (handles the symlinked keystore leaf case.)
+ */
+export function larkCliChildDataRoot(canonStore: string | null | undefined): string | null {
+  const s = canonStore ? normalizeFsPath(canonStore) : null;
+  if (!s || s === '/') return null;
+  const lastSlash = s.lastIndexOf('/');
+  const base = s.slice(lastSlash + 1);
+  if (base !== 'lark-cli') return null; // symlinked-leaf to a different name → degrade safely
+  return s.slice(0, lastSlash) || '/';
+}
+
+/**
+ * Lexically clean an ABSOLUTE POSIX path the way Go's `filepath.Clean` does
+ * (resolve `.`/`..` segments, collapse `//`, drop trailing `/`, clamp `..` at root)
+ * — WITHOUT touching the filesystem. Returns null for a non-absolute input or one
+ * containing NUL / control chars (lark-cli's `SafeEnvDirPath` rejects those). This
+ * mirrors lark-cli's own env-path handling so the policy anchors the SAME dir the
+ * in-sandbox CLI will open (a `..`-bearing `LARKSUITE_CLI_DATA_DIR` is
+ * Clean'd by lark-cli to a real store, but an un-cleaned policy path was rejected by
+ * normalizeFsPath and silently fell back to the default — leaving the real store
+ * exposed). Pure + total.
+ */
+export function cleanPosixAbsPath(p: string): string | null {
+  if (!p || typeof p !== 'string' || !p.startsWith('/')) return null;
+  // Reject control chars (0x00–0x1F, 0x7F) — lark-cli's validator treats them as
+  // invalid → falls back to $HOME; matching keeps policy == CLI.
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(p)) return null;
+  const out: string[] = [];
+  for (const seg of p.split('/')) {
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') { out.pop(); continue; } // clamp at root (Go filepath.Clean semantics)
+    out.push(seg);
+  }
+  return '/' + out.join('/');
+}
+
+/**
+ * Resolve the lark-cli Linux store dir BEFORE canonicalization, replicating
+ * lark-cli's OWN resolution (`internal/keychain/keychain_other.go::StorageDir` +
+ * `SafeEnvDirPath`, verified by strace against v1.0.76): the keystore dir is
+ * `<clean(LARKSUITE_CLI_DATA_DIR)>/lark-cli` when `LARKSUITE_CLI_DATA_DIR` is a VALID
+ * ABSOLUTE path (lexically Cleaned — `..`/`.`/`//` resolved, control chars rejected),
+ * else `$HOME/.local/share/lark-cli`. lark-cli does NOT consult `XDG_DATA_HOME` for
+ * the keystore at all (strace: setting it has zero effect), and it IGNORES a relative
+ * / tilde / empty / control-char `LARKSUITE_CLI_DATA_DIR` (spec-invalid → falls back
+ * to $HOME). PURE (exported so the "absolute-cleaned / relative-ignored / unset /
+ * `..`-cleaned / control-char-rejected" matrix is unit-locked against strace).
+ *
+ * CRITICAL: the `..` Clean must happen HERE, lexically, so the returned
+ * path is already normalized (no `..`) — otherwise the worker's realpath throws on a
+ * not-yet-existent store leaf, keeps the raw `..` path, normalizeFsPath rejects it,
+ * and the policy silently anchors the DEFAULT store while lark-cli (which Cleans)
+ * opens the real one → the real store stays exposed.
+ *
+ * The worker passes `process.env.LARKSUITE_CLI_DATA_DIR` + the (lexical) home, then
+ * nearest-existing-ancestor `canonical()`s the result (a full-path realpath would
+ * throw on the nonexistent leaf), and hands it to buildFsPolicy as `larkCliLinuxStore`.
+ * This is the AUTHORITATIVE value the in-sandbox lark-cli reads: bwrap has NO
+ * `--clearenv`, so the sandboxed child INHERITS `LARKSUITE_CLI_DATA_DIR` from the
+ * worker's process env (redactChildEnv doesn't strip it), and the sandbox pins the
+ * child's value to the SAME cleaned resolution (`--setenv`/`--unsetenv` in sandbox.ts)
+ * so policy == CLI by construction.
+ */
+export function resolveLarkCliLinuxStoreDir(rawDataDir: string | undefined, homeDir: string): string {
+  const cleaned = rawDataDir ? cleanPosixAbsPath(rawDataDir) : null;
+  const base = cleaned ?? `${homeDir}/.local/share`;
+  // Strip a trailing slash so a root base ('/') doesn't yield '//lark-cli' (the only
+  // case that produces one — cleanPosixAbsPath returns '/' when all segments pop).
+  return `${base === '/' ? '' : base}/lark-cli`;
+}
+
+/**
  * Compute the frozen Feishu-authority roots for a no-transport turn. PURE +
  * exported so the worker's real path assembly and the unit matrix lock the SAME
  * provenance logic (codex P2: prior tests hand-fed roots and never touched this).
@@ -418,7 +543,10 @@ export class FsPolicyConfigError extends Error {
  *    HMAC + bots.json, so denying only one leaves the sibling-daemon escalation
  *    open (codex P1).
  *  - freezes the lark-cli identity/key stores: bare `~/.lark-cli` (repo marks it
- *    sensitive), `~/.lark-cli-bots`, macOS lark-cli store.
+ *    sensitive), `~/.lark-cli-bots`, macOS lark-cli store, AND the Linux lark-cli
+ *    keystore (`$HOME/.local/share/lark-cli` or `<LARKSUITE_CLI_DATA_DIR>/lark-cli` — every bot's
+ *    appsecret ciphertext + the shared master key; on Linux a no-transport turn
+ *    must get NO carve-out into it, unlike the transport-enabled own-key carve-out).
  *  - the loaded bots-config path: OUTSIDE every root → THROW here (fail-closed);
  *    never mask its parent dir. Being INSIDE a root is necessary but NOT
  *    sufficient — a deeper trusted carve-out (own BOT_HOME / bin / attachments /
@@ -427,10 +555,12 @@ export class FsPolicyConfigError extends Error {
  *    to `deny`, else throws `bots-config-in-carveout` (codex P1).
  */
 export function computeNoTransportAuthorityRoots(input: {
+  platform: 'darwin' | 'linux';
   homeDir: string;
   botmuxHome: string;
   defaultBotmuxHome?: string;
   loadedBotsConfigPath?: string;
+  larkCliLinuxStore?: string;
 }): string[] {
   const roots = [...new Set([
     input.botmuxHome,
@@ -438,6 +568,19 @@ export function computeNoTransportAuthorityRoots(input: {
     `${input.homeDir}/.lark-cli`,
     `${input.homeDir}/.lark-cli-bots`,
     `${input.homeDir}/Library/Application Support/lark-cli`,
+    // Linux keystore — BOTH candidate stores frozen (no own-key carve-out; transport-only).
+    // lark-cli opens either `<resolved>/lark-cli` (custom LARKSUITE_CLI_DATA_DIR accepted) or
+    // the default `$HOME/.local/share/lark-cli` (rejected/unset); a no-transport turn must
+    // deny WHICHEVER, without depending on matching lark-cli's env-value validator.
+    // LINUX-ONLY: macOS lark-cli uses the `Library/Application Support/lark-cli` store above,
+    // NOT `~/.local/share/lark-cli`. Freezing the Linux paths on darwin is NOT a no-op — it
+    // adds an authority root that would change darwin behavior (e.g. a no-transport
+    // workingDir=~/.local/share/lark-cli would newly fail `working-dir-is-authority`). So
+    // gate strictly on platform to keep darwin byte-identical to pre-refactor.
+    ...(input.platform === 'linux' ? [
+      `${input.homeDir}/.local/share/lark-cli`,
+      ...(() => { const s = larkCliLinuxStorePath(input.homeDir, input.larkCliLinuxStore); return s ? [s] : []; })(),
+    ] : []),
   ])].map(normalizeFsPath).filter((r): r is string => !!r);
   const cfg = input.loadedBotsConfigPath ? normalizeFsPath(input.loadedBotsConfigPath) : null;
   if (cfg && !roots.some(root => coversPath(root, cfg))) {
@@ -479,15 +622,27 @@ export function buildFsPolicy(ctx: FsPolicyContext): FsPolicy {
   // computeNoTransportAuthorityRoots freezes BOTH the configured + default botmux
   // roots and THROWS on an external bots-config (fail-closed, never silent-mask).
   const authorityRoots = larkTransport ? [] : computeNoTransportAuthorityRoots({
+    platform: ctx.platform,
     homeDir: ctx.homeDir,
     botmuxHome: ctx.botmuxHome,
     defaultBotmuxHome: ctx.defaultBotmuxHome,
     loadedBotsConfigPath: ctx.loadedBotsConfigPath,
+    larkCliLinuxStore: ctx.larkCliLinuxStore,
   });
-  // A path is authority-restricted when it's inside an authority root but NOT
-  // inside the bot's own BOT_HOME (which is legitimately re-allowed).
+  // A path is authority-restricted when SOME authority root covers it — EXCEPT the
+  // bot's own BOT_HOME carve-out (legitimately re-allowed deeper, minus send-cred).
+  // That exception is scoped PER-ROOT: it fires only for a root that is an ANCESTOR
+  // of BOT_HOME (the botmux root, of which BOT_HOME is a re-allowed subtree). An
+  // authority root NESTED INSIDE BOT_HOME — e.g. the lark-cli keystore when a
+  // deployment sets LARKSUITE_CLI_DATA_DIR into BOT_HOME so the store resolves to
+  // `<BOT_HOME>/lark-cli` — is MORE SPECIFIC than the BOT_HOME carve-out and must
+  // STILL restrict, or a deeper hostile user RW under the nested store escapes
+  // dropAuthority and re-opens `master.key`/sibling appsecrets. So for
+  // each root the BOT_HOME exception applies only when that root is an ancestor of
+  // BOT_HOME AND p is inside BOT_HOME; a root at/under BOT_HOME keeps restricting.
   const insideAuthority = (p: string): boolean =>
-    authorityRoots.some(root => coversPath(root, p)) && !coversPath(ctx.botHome, p);
+    authorityRoots.some(root =>
+      coversPath(root, p) && !(coversPath(root, ctx.botHome) && coversPath(ctx.botHome, p)));
   // Dropped caller allow paths are RECORDED so the worker can log the suppression
   // (codex: a silently-dropped grant is a diagnosability hole).
   const suppressedAuthorityPaths: string[] = [];
@@ -672,12 +827,43 @@ export function buildFsPolicy(ctx: FsPolicyContext): FsPolicy {
   // operation not permitted"). Re-allow ONLY those two, read-only, at a DEEPER
   // path than the deny so longest-prefix-wins. Siblings' `appsecret_*.enc` and
   // user tokens stay denied → the master key alone can't decrypt what it can't
-  // read (verified: sibling ciphertext still DENIED). Linux keeps its keys in the
-  // per-bot `.lark-cli-bots/<self>` dir (already readWrite above), so this is
-  // darwin-only.
+  // read (verified: sibling ciphertext still DENIED).
   if (ctx.platform === 'darwin' && larkTransport) {
     const larkStore = `${ctx.homeDir}/Library/Application Support/lark-cli`;
     push([`${larkStore}/master.key.file`, `${larkStore}/appsecret_${ctx.currentAppId}.enc`], 'readOnly', 'internal');
+  }
+  // LINUX lark-cli key store — SAME cross-bot leak, SAME carve-out (was missing).
+  // lark-cli on Linux writes keys to `<LARKSUITE_CLI_DATA_DIR>/lark-cli` (when that env
+  // var is a valid absolute path) else `$HOME/.local/share/lark-cli` — NOT the per-bot
+  // `.lark-cli-bots/<self>` dir (that only holds config.json; secrets land in the shared
+  // data store — verified on lark-cli 1.0.56/1.0.76). The linuxBaseline `ro(~/.local/share)`
+  // grant exposed EVERY bot's `appsecret_*.enc` + the shared `master.key` read-only to any
+  // sandboxed bot — a cross-bot impersonation hole macOS already closed. Mirror the darwin
+  // fix: DENY the whole store (deeper than `~/.local/share` so longest-prefix wins), then
+  // re-open ONLY this bot's own `master.key` (Linux name — NOT darwin's `master.key.file`)
+  // + `appsecret_<self>.enc` read-only at a deeper path.
+  //
+  // TWO candidate stores, BOTH locked (lark-cli's env-value validator —
+  // control chars / bidi / BOM rejection — is not perfectly replicable, so we do NOT try
+  // to predict WHICH store it picks). lark-cli opens EITHER `<clean(env)>/lark-cli` (value
+  // accepted) OR the default `$HOME/.local/share/lark-cli` (value rejected/unset/relative).
+  // Denying both + carving own keys in both means: whichever lark-cli opens, siblings +
+  // master stay denied (no leak) and this bot's own keys are readable (auth works) — with
+  // ZERO dependence on matching lark-cli's char validator. Deduped when equal (common case:
+  // no custom LARKSUITE_CLI_DATA_DIR → resolved == default → one store). `deny` tagged
+  // `baseline` to match darwin (store deny lives in darwinBaseline; can't live in
+  // linuxBaseline — that has no homeDir-independent way to know the resolved store path).
+  // No-transport denies both stores wholesale via authorityRoots and gets NO carve-out.
+  if (ctx.platform === 'linux' && larkTransport) {
+    const stores = new Set<string>();
+    const resolved = larkCliLinuxStorePath(ctx.homeDir, ctx.larkCliLinuxStore);
+    if (resolved) stores.add(resolved);
+    const dflt = normalizeFsPath(`${ctx.homeDir}/.local/share/lark-cli`);
+    if (dflt) stores.add(dflt);
+    for (const larkStore of stores) {
+      push([larkStore], 'deny', 'baseline');
+      push([`${larkStore}/master.key`, `${larkStore}/appsecret_${ctx.currentAppId}.enc`], 'readOnly', 'internal');
+    }
   }
 
   // User config — highest precedence.

--- a/src/core/per-bot-env.ts
+++ b/src/core/per-bot-env.ts
@@ -65,6 +65,16 @@ const RESERVED_ENV_KEYS = new Set<string>([
   'CLAUDE_PID',
   'CLAUDE_CONFIG_DIR',
   'CODEX_HOME',
+  // lark-cli keystore data root (Linux): `<value>/lark-cli` holds THIS bot's
+  // appsecret + the shared master key. The file sandbox freezes the keystore path
+  // from the worker's OWN process env value and denies the store (carving out only
+  // this bot's keys); a per-bot inject would (a) NOT reach a sandboxed child anyway
+  // (bwrap uses a --setenv allowlist that excludes it + the worker re-pins it), so
+  // it would be silently overridden — confusing — and (b) if it DID take effect on a
+  // non-sandboxed path, relocate the keystore out from under the frozen policy. So a
+  // per-bot `env` must not set it: reserve it (rejected + diagnosable), not silently
+  // accepted-then-ignored. The authoritative value is the worker's env.
+  'LARKSUITE_CLI_DATA_DIR',
   // Grok data root: daemon installs hooks/skills and drains transcripts under
   // the process-level GROK_HOME. A per-bot inject would only reach the child
   // CLI and split-brain path resolution (see grok-paths header).

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -45,7 +45,7 @@ import {
   isolationPanePolicyDigest,
   type IsolationCapability,
 } from './adapters/cli/read-isolation.js';
-import { buildFsPolicy, compileToSeatbelt, migrateLegacySandboxFields, resolveRedirectedAdapterAuthPaths, FsPolicyConfigError } from './adapters/cli/fs-policy.js';
+import { buildFsPolicy, compileToSeatbelt, migrateLegacySandboxFields, resolveRedirectedAdapterAuthPaths, resolveLarkCliLinuxStoreDir, larkCliChildDataRoot, FsPolicyConfigError } from './adapters/cli/fs-policy.js';
 import { buildCloseResultMessage, normalizeDestroyResult, mayRestoreWriteAdmission, interpretAbortOutcome, classifyRestartTeardown, type RestartTeardownOutcome } from './adapters/backend/destroy-result.js';
 import { isRemoteBackendType, killPersistentBackendTarget, killPersistentSession, probePersistentBackendTarget, probePersistentSession, shouldRejectPersistentPostKillProbe, type PersistentBackendType } from './core/persistent-backend.js';
 import { finalizeRawCommandDelivery, writeRawCommandLine } from './core/raw-command-writer.js';
@@ -13726,6 +13726,26 @@ async function spawnCli(
       }
       return out;
     };
+    // Canonicalize a path whose LEAF may not exist yet (e.g. a lark-cli keystore dir
+    // lark-cli will create on first write): realpath the DEEPEST EXISTING ancestor
+    // (resolving any symlinked prefix — symlinked $HOME, a symlinked data root) and
+    // re-append the non-existent tail. A plain full-path realpath THROWS on the
+    // missing leaf and returns the raw lexical value, so a symlinked ancestor would
+    // stay unresolved and the policy could anchor a DIFFERENT namespace than the one
+    // lark-cli opens after IT canonicalizes (a canonicalization TOCTOU). Input must already be
+    // lexically clean (no `..`); resolveLarkCliLinuxStoreDir Cleans it first.
+    const canonicalNearestAncestor = (p: string): string => {
+      if (!p.startsWith('/')) return p;
+      const segs = p.split('/').filter(Boolean);
+      for (let i = segs.length; i >= 0; i--) {
+        const prefix = '/' + segs.slice(0, i).join('/');
+        try {
+          const real = realpathSync(prefix);
+          return i === segs.length ? real : `${real}/${segs.slice(i).join('/')}`;
+        } catch { /* ancestor missing → try a shallower prefix */ }
+      }
+      return p; // not even '/' resolved (impossible) → lexical fallback
+    };
 
     // User three-tier lists: the new sandboxPaths field, or a pre-migration
     // session/config's legacy fields mapped through the SAME lossless mapping
@@ -13996,6 +14016,23 @@ async function spawnCli(
       // arbitrary parent dir (`/tmp`, `/etc`, a project root) and bricking the
       // core CLI (codex P1). Canonicalized so it shares the roots' namespace.
       loadedBotsConfigPath: cfg.loadedBotsConfigPath ? canonical(cfg.loadedBotsConfigPath) : undefined,
+      // Linux lark-cli keystore (holds every bot's appsecret ciphertext + the shared
+      // master key). Resolve it EXACTLY as the in-sandbox lark-cli will:
+      // `<clean(LARKSUITE_CLI_DATA_DIR)>/lark-cli` when that env var is a valid ABSOLUTE
+      // path (lexically Cleaned — `..`/`.`/`//` resolved, control chars rejected), else
+      // `$HOME/.local/share/lark-cli` — lark-cli does NOT read XDG_DATA_HOME (verified by
+      // strace on v1.0.76 + its keychain_other.go::StorageDir / SafeEnvDirPath). The
+      // Clean happens INSIDE resolveLarkCliLinuxStoreDir (a `..`-bearing value
+      // must be normalized here, or realpath throws on the nonexistent leaf, the raw `..`
+      // survives, normalizeFsPath rejects it, and the policy anchors the DEFAULT store
+      // while lark-cli opens the Clean'd real one → leak). canonicalNearestAncestor then
+      // resolves any SYMLINKED ancestor even when the store leaf does not exist yet (a
+      // full-path realpath would throw and skip symlink resolution → policy/CLI namespace
+      // divergence). bwrap has no --clearenv, so the child inherits this bot's
+      // LARKSUITE_CLI_DATA_DIR from the worker's own (frozen, non-agent-controllable)
+      // process.env, and sandbox.ts pins the child to the SAME cleaned resolution
+      // (--setenv/--unsetenv) so policy == CLI by construction. Ignored on darwin.
+      larkCliLinuxStore: canonicalNearestAncestor(resolveLarkCliLinuxStoreDir(process.env.LARKSUITE_CLI_DATA_DIR, lexicalHome)),
       redirectedCliData: willRedirectCliData,
       cliDataPaths: willRedirectCliData ? undefined : keepExisting([
         cliAdapter.claudeDataDir,
@@ -14125,6 +14162,25 @@ async function spawnCli(
         log(`Sandbox REATTACH (${cfg.cliId}): no on-disk sandbox tree — reattaching live pane as-is`);
       }
     } else {
+      // Canonical lark-cli data root pinned into the child so the in-sandbox lark-cli
+      // resolves the SAME physical keystore the policy denied/carved-out (avoiding a
+      // symlinked-data-root namespace split). fsPolicyCtx.larkCliLinuxStore is the FULLY-canonical store dir (leaf
+      // symlinks followed) — the physical location the policy protects. The child opens
+      // `<pin>/lark-cli`, so pin = dirname(store) is same-source ONLY when the canonical
+      // store's basename is still `lark-cli` (the common case, incl. a symlink that
+      // resolves to another `lark-cli` dir). If the `lark-cli` leaf was a symlink to a
+      // DIFFERENTLY-named dir (basename !== 'lark-cli'), dirname(store)+'/lark-cli' would
+      // NOT equal the canonical store → child would open an unbound path (auth breaks) OR
+      // a foreign one. There is no leak either way (the policy still denies the real dir,
+      // and both candidate stores are locked), so degrade SAFELY: pin nothing → child
+      // falls back to the default store (also locked), and log the exotic layout.
+      const canonStore = fsPolicyCtx.larkCliLinuxStore;
+      const childLarkDataRoot = larkCliChildDataRoot(canonStore);
+      if (canonStore && childLarkDataRoot === null) {
+        log(`[sandbox] lark-cli keystore ${canonStore} does not end in 'lark-cli' (symlinked leaf?) — `
+          + `not pinning a custom LARKSUITE_CLI_DATA_DIR into the sandbox; the in-sandbox lark-cli will `
+          + `use the default store. The real keystore is still denied/carve-out'd by policy (no leak).`);
+      }
       const sbx = prepareDirectSandbox({
         sessionId: cfg.sessionId,
         dataDir,
@@ -14135,6 +14191,7 @@ async function spawnCli(
         cliArgs: args,
         trustedBotmuxCommandPaths: [defaultGatewayEntry().command],
         mcpGatewaySocketPath: sessionMcpGatewayHost?.socketPath,
+        larkCliDataDir: childLarkDataRoot,
       });
       if (!sbx) {
         // FAIL-SAFE: never silently run unsandboxed.

--- a/test/api-only-mode-wiring.test.ts
+++ b/test/api-only-mode-wiring.test.ts
@@ -456,7 +456,12 @@ describe('API-only bot mode — no-transport fs-policy authority provenance (wor
   it('worker turns an unconfined no-transport layout into a fail-closed spawn abort', () => {
     // FsPolicyConfigError (external bots-config / workingDir-is-authority) must
     // abort the spawn with a diagnostic, never fall through to an unconfined run.
-    expect(workerSource).toContain('import { buildFsPolicy, compileToSeatbelt, migrateLegacySandboxFields, resolveRedirectedAdapterAuthPaths, FsPolicyConfigError }');
+    // Assert the meaningful imports are present (not a frozen full-literal named-import
+    // list — that list legitimately grows, e.g. resolveLarkCliLinuxStoreDir for the
+    // Linux keystore fix — so match the module + the two symbols this test relies on).
+    const fsPolicyImport = region(workerSource, "import {", "} from './adapters/cli/fs-policy.js';");
+    expect(fsPolicyImport).toContain('buildFsPolicy');
+    expect(fsPolicyImport).toContain('FsPolicyConfigError');
     const block = region(workerSource, 'const policy = (() => {', 'suppressedAuthorityPaths?.length');
     expect(block).toContain('if (err instanceof FsPolicyConfigError) {');
     expect(block).toContain('refusing to start no-transport session');

--- a/test/fs-policy-bwrap.e2e.test.ts
+++ b/test/fs-policy-bwrap.e2e.test.ts
@@ -50,7 +50,7 @@ d('bwrap three-tier enforcement (real bubblewrap)', () => {
   // Build the bwrap argv the SAME way the worker does (deny masks: mode-000
   // empty sources, missing mountpoints pre-created). Returns the created-mask
   // list too so cleanup tests can assert rmdir-if-empty.
-  function build(userPaths: { readWrite?: string[]; readOnly?: string[]; deny?: string[] }) {
+  function build(userPaths: { readWrite?: string[]; readOnly?: string[]; deny?: string[] }, opts: { larkCliLinuxStore?: string; larkTransportEnabled?: boolean; botHome?: string } = {}) {
     const emptiesDir = join(S, 'sbx/empties');
     const emptyDir = join(S, 'sbx/empty');
     mkdirSync(emptiesDir, { recursive: true });
@@ -60,10 +60,12 @@ d('bwrap three-tier enforcement (real bubblewrap)', () => {
       platform: 'linux', homeDir: canonical(homedir()),
       botmuxHome: join(S, 'botmux-home'), sessionDataDir: join(S, 'botmux-home/data'),
       sessionId: 'e2e-session',
-      workingDir: join(S, 'proj'), currentAppId: 'cli_e2e', botHome: join(S, 'botmux-home/bots/cli_e2e'),
+      workingDir: join(S, 'proj'), currentAppId: 'cli_e2e', botHome: opts.botHome ?? join(S, 'botmux-home/bots/cli_e2e'),
       redirectedCliData: true,
       execPaths: [dirname(canonical(process.execPath))],
       userPaths: { readOnly: [join(S, 'ref'), ...(userPaths.readOnly ?? [])], readWrite: userPaths.readWrite, deny: userPaths.deny },
+      larkCliLinuxStore: opts.larkCliLinuxStore,
+      larkTransportEnabled: opts.larkTransportEnabled,
       net: true, writeRegexes: [],
     });
     policy.rules = policy.rules.filter(r => r.access === 'deny' || existsSync(r.path));
@@ -262,5 +264,76 @@ d('bwrap three-tier enforcement (real bubblewrap)', () => {
     expect(r.out).not.toContain('INNERSECRET');
     expect(r.out).toContain('---'); // process actually ran
     rmSync(a, { recursive: true, force: true });
+  });
+
+  it('LINUX lark-cli keystore (KERNEL-level): own key readable, SIBLING ciphertext + master.key hidden, store not writable', () => {
+    // The whole point of the fix, proven at the kernel (not just accessForPath):
+    // the store sits under a read-only parent (production: baseline ro(~/.local/share)),
+    // is DENIED, and ONLY this bot's own master.key + appsecret_<self>.enc are carved
+    // back read-only. A sandboxed bot must NOT be able to read a sibling's appsecret
+    // or the shared master.key — that was the cross-bot impersonation leak. This is a
+    // white-in-black shape (ro parent → deny store → ro own-keys), so it exercises the
+    // tmpfs-mask + deferred --remount-ro carve-out path at the mount level.
+    const xdg = join(S, 'xdg');            // exposed read-only parent (stands in for ~/.local/share)
+    const store = join(xdg, 'lark-cli');
+    mkdirSync(store, { recursive: true });
+    writeFileSync(join(store, 'master.key'), 'MASTERKEY');
+    writeFileSync(join(store, 'appsecret_cli_e2e.enc'), 'OWNSECRET');       // this bot
+    writeFileSync(join(store, 'appsecret_cli_other.enc'), 'SIBLINGSECRET'); // a sibling bot
+    writeFileSync(join(store, 'cli_other_ou_x.enc'), 'SIBLINGTOKEN');       // a sibling user token
+    // parent is user-readOnly (mirrors baseline ro(~/.local/share)); store path is
+    // frozen via larkCliLinuxStore so the policy denies it + carves out own keys.
+    const { args } = build({ readOnly: [xdg] }, { larkCliLinuxStore: store });
+
+    // own appsecret + master.key ARE readable (needed to authenticate)
+    expect(run(args, `cat ${JSON.stringify(join(store, 'appsecret_cli_e2e.enc'))}`).out).toContain('OWNSECRET');
+    expect(run(args, `cat ${JSON.stringify(join(store, 'master.key'))}`).out).toContain('MASTERKEY');
+    // SIBLING ciphertext + token are HIDDEN at the kernel level (the leak)
+    const sib = run(args, `cat ${JSON.stringify(join(store, 'appsecret_cli_other.enc'))}`);
+    expect(sib.status).not.toBe(0);
+    expect(sib.out).not.toContain('SIBLINGSECRET');
+    const tok = run(args, `cat ${JSON.stringify(join(store, 'cli_other_ou_x.enc'))}`);
+    expect(tok.status).not.toBe(0);
+    expect(tok.out).not.toContain('SIBLINGTOKEN');
+    // a directory listing must not surface the sibling files either (the carve-out
+    // exposes ONLY the two own-key files; the rest of the store is a masked tmpfs)
+    const ls = run(args, `ls -A ${JSON.stringify(store)} 2>&1`);
+    expect(ls.out).not.toContain('appsecret_cli_other.enc');
+    expect(ls.out).not.toContain('cli_other_ou_x.enc');
+    // own carve-out files are read-ONLY (the CLI never rewrites the keystore in-sandbox)
+    expect(run(args, `echo x > ${JSON.stringify(join(store, 'master.key'))} && echo WROTE`).out).not.toContain('WROTE');
+    // and the store dir itself is not writable — no planting a fake sibling secret
+    expect(run(args, `echo x > ${JSON.stringify(join(store, 'appsecret_cli_evil.enc'))} && echo WROTE`).out).not.toContain('WROTE');
+    expect(existsSync(join(store, 'appsecret_cli_evil.enc'))).toBe(false);
+    rmSync(xdg, { recursive: true, force: true });
+  });
+
+  it('LINUX keystore NESTED in BOT_HOME + no-transport + hostile user RW (KERNEL-level): master.key/siblings STILL hidden (nested-authority regression)', () => {
+    // The reproduced escape at the kernel level: LARKSUITE_CLI_DATA_DIR=<BOT_HOME> so the
+    // store is <BOT_HOME>/lark-cli, under a no-transport turn, with a hostile user RW
+    // grant directly targeting master.key. Old logic exempted everything under BOT_HOME
+    // → master.key was RW (readable+writable) inside the sandbox. The per-root BOT_HOME
+    // exception must keep it denied — proven by real bubblewrap, not just accessForPath.
+    const botHome = join(S, 'botmux-home/bots/cli_e2e');
+    const store = join(botHome, 'lark-cli');
+    mkdirSync(store, { recursive: true });
+    writeFileSync(join(store, 'master.key'), 'NESTEDMASTER');
+    writeFileSync(join(store, 'appsecret_cli_other.enc'), 'NESTEDSIBLING');
+    const { args } = build(
+      { readWrite: [join(store, 'master.key'), store] },     // hostile user RW straight at the secret
+      { larkCliLinuxStore: store, larkTransportEnabled: false, botHome },
+    );
+    // master.key: real content NOT readable + NOT writable (the reproduced leak, sealed)
+    const rd = run(args, `cat ${JSON.stringify(join(store, 'master.key'))}`);
+    expect(rd.status).not.toBe(0);
+    expect(rd.out).not.toContain('NESTEDMASTER');
+    expect(run(args, `echo x > ${JSON.stringify(join(store, 'master.key'))} && echo WROTE`).out).not.toContain('WROTE');
+    // sibling appsecret also hidden
+    const sib = run(args, `cat ${JSON.stringify(join(store, 'appsecret_cli_other.enc'))}`);
+    expect(sib.status).not.toBe(0);
+    expect(sib.out).not.toContain('NESTEDSIBLING');
+    // BOT_HOME scratch OUTSIDE the nested store is still writable (carve-out intact there)
+    expect(run(args, `echo ok > ${JSON.stringify(join(botHome, 'scratch.txt'))} && echo WROTE`).out).toContain('WROTE');
+    rmSync(store, { recursive: true, force: true });
   });
 });

--- a/test/fs-policy.test.ts
+++ b/test/fs-policy.test.ts
@@ -351,6 +351,25 @@ describe('buildFsPolicy', () => {
     expect(accessForPath(p.rules, `${botHome}/scratch.txt`).access).toBe('readWrite');
   });
 
+  it('LINUX lark-cli key store EXACTLY ON BOT_HOME (store===botHome): store deny outranks the BOT_HOME rw grant — transport', () => {
+    // Equality edge of the nested-authority fix: a deployment can wire the store ONTO
+    // BOT_HOME itself (appId 'lark-cli' — assertSafeAppId is charset-only, no `cli_`
+    // prefix enforcement — plus LARKSUITE_CLI_DATA_DIR=<botmuxHome>/bots). The internal
+    // BOT_HOME readWrite grant then lands on the SAME path as the store deny; the deny
+    // must be tagged `mandatory` (rank 4 > internal 2) or the whole keystore — siblings
+    // included — goes readWrite by same-path source rank. Own-key carve-outs still win by depth.
+    const botHome = '/home/u/.botmux/bots/lark-cli';
+    const p = buildFsPolicy(ctx({
+      platform: 'linux', homeDir: '/home/u', botHome, currentAppId: 'lark-cli',
+      botmuxHome: '/home/u/.botmux', sessionDataDir: '/home/u/.botmux/data', workingDir: '/home/u/proj',
+      larkCliLinuxStore: botHome,
+    }));
+    expect(accessForPath(p.rules, botHome).access).toBe('deny');
+    expect(accessForPath(p.rules, `${botHome}/master.key`).access).toBe('readOnly');
+    expect(accessForPath(p.rules, `${botHome}/appsecret_lark-cli.enc`).access).toBe('readOnly');
+    expect(accessForPath(p.rules, `${botHome}/appsecret_cli_other.enc`).access).toBe('deny');
+  });
+
   it('internal injections: workingDir + BOT_HOME rw, own session store + attachments ro; siblings uncovered', () => {
     const p = buildFsPolicy(ctx());
     expect(accessForPath(p.rules, '/Users/u/proj/src/x.ts').access).toBe('readWrite');
@@ -990,6 +1009,24 @@ describe('no-Lark-transport credential profile (larkTransportEnabled=false)', ()
     expect(accessForPath(p.rules, `${store}/appsecret_cli_other.enc`).access).toBe('deny');
     // model CLI's own auth still works (not a Feishu cred)
     expect(accessForPath(p.rules, '/home/u/.codex/auth.json').access).toBe('readWrite');
+  });
+
+  it('LINUX no-transport: store EXACTLY ON BOT_HOME (store===botHome) — hostile user RW at master.key is STILL dropped', () => {
+    // Equality edge of the per-root BOT_HOME exception: when the store root IS botHome,
+    // the exception must NOT fire (it is meant only for STRICT ancestors like the botmux
+    // root), or a hostile userPaths.readWrite straight at master.key escapes dropAuthority
+    // and wins by depth — the exact escape the nested-root fix closed, re-opened at equality.
+    const botHome = '/home/u/.botmux/bots/lark-cli';
+    const p = buildFsPolicy(ctx({
+      platform: 'linux', larkTransportEnabled: false, homeDir: '/home/u', workingDir: '/home/u/proj',
+      botmuxHome: '/home/u/.botmux', sessionDataDir: '/home/u/.botmux/data',
+      botHome, currentAppId: 'lark-cli', redirectedCliData: false, authPaths: ['/home/u/.codex'],
+      larkCliLinuxStore: botHome,
+      userPaths: { readWrite: [`${botHome}/master.key`, `${botHome}/appsecret_lark-cli.enc`] },
+    }));
+    expect(accessForPath(p.rules, `${botHome}/master.key`).access).toBe('deny');
+    expect(accessForPath(p.rules, `${botHome}/appsecret_lark-cli.enc`).access).toBe('deny');
+    expect(accessForPath(p.rules, `${botHome}/appsecret_cli_other.enc`).access).toBe('deny');
   });
 
   it('LINUX no-transport: BOTH candidate stores frozen when a custom LARKSUITE_CLI_DATA_DIR is set (both-candidate lock)', () => {

--- a/test/fs-policy.test.ts
+++ b/test/fs-policy.test.ts
@@ -14,6 +14,10 @@ import {
   compileToBwrap,
   migrateLegacySandboxFields,
   computeNoTransportAuthorityRoots,
+  larkCliLinuxStorePath,
+  larkCliChildDataRoot,
+  resolveLarkCliLinuxStoreDir,
+  cleanPosixAbsPath,
   FsPolicyConfigError,
   type FsPolicyContext,
   type FsRule,
@@ -229,9 +233,122 @@ describe('buildFsPolicy', () => {
     // siblings' ciphertext + tokens stay denied → master key alone can't decrypt them
     expect(accessForPath(p.rules, `${store}/appsecret_cli_other.enc`).access).toBe('deny');
     expect(accessForPath(p.rules, `${store}/cli_other_ou_x.enc`).access).toBe('deny');
-    // linux keeps lark keys in ~/.lark-cli-bots/<self> → no darwin carve-out there
+    // linux never emits the macOS `Library/…` keystore rule (it has its OWN store
+    // carve-out under ~/.local/share/lark-cli — asserted in the next test)
     const lin = buildFsPolicy(ctx({ platform: 'linux', homeDir: '/home/u', botHome: '/home/u/.botmux/bots/cli_self', botmuxHome: '/home/u/.botmux', sessionDataDir: '/home/u/.botmux/data', workingDir: '/home/u/proj' }));
     expect(lin.rules.some(r => r.path.includes('Library/Application Support/lark-cli'))).toBe(false);
+  });
+
+  it('LINUX lark-cli key store: OWN appsecret + master.key readable, siblings/token/future-file denied, toolchain not clobbered (cross-bot leak fix)', () => {
+    // lark-cli on Linux writes keys to `$HOME/.local/share/lark-cli` (or `<LARKSUITE_CLI_DATA_DIR>/lark-cli`)
+    // (verified live: appsecret_<appId>.enc + master.key, NOT master.key.file), which
+    // the baseline `ro(~/.local/share)` grant otherwise exposed read-only to every
+    // sandboxed bot — the cross-bot impersonation hole macOS already closed. This is
+    // the Linux mirror of the darwin carve-out test above.
+    const linCtx = { platform: 'linux' as const, homeDir: '/home/u', botHome: '/home/u/.botmux/bots/cli_self', botmuxHome: '/home/u/.botmux', sessionDataDir: '/home/u/.botmux/data', workingDir: '/home/u/proj' };
+    const p = buildFsPolicy(ctx(linCtx)); // currentAppId = cli_self, default store
+    const store = '/home/u/.local/share/lark-cli';
+    // own material re-allowed (deeper than the store deny → longest-prefix-wins)
+    expect(accessForPath(p.rules, `${store}/master.key`).access).toBe('readOnly');
+    expect(accessForPath(p.rules, `${store}/appsecret_cli_self.enc`).access).toBe('readOnly');
+    // the store DIR itself is denied — the pre-fix `ro(~/.local/share)` exposure
+    expect(accessForPath(p.rules, store).access).toBe('deny');
+    // siblings' ciphertext + user tokens stay denied → master key can't decrypt them
+    expect(accessForPath(p.rules, `${store}/appsecret_cli_other.enc`).access).toBe('deny');
+    expect(accessForPath(p.rules, `${store}/cli_other_ou_x.enc`).access).toBe('deny');
+    // future files under the store are denied-by-default (deny of the whole dir)
+    expect(accessForPath(p.rules, `${store}/future_new_secret.enc`).access).toBe('deny');
+    // darwin's master.key.file NAME does NOT get a Linux carve-out (Linux uses master.key)
+    expect(accessForPath(p.rules, `${store}/master.key.file`).access).toBe('deny');
+    // the REST of ~/.local/share (toolchains: pipx, bytedcli SSO, etc.) stays readable
+    // — the deny is scoped to the lark-cli subdir, not the whole default data root.
+    expect(accessForPath(p.rules, '/home/u/.local/share/some-toolchain/bin').access).toBe('readOnly');
+    expect(accessForPath(p.rules, '/home/u/.local/share/bytedcli/data/sso.json').access).toBe('readOnly');
+  });
+
+  it('LINUX lark-cli key store: BOTH the custom store AND the default are locked (no dependence on the lark-cli env-value validator); darwin unaffected', () => {
+    // A custom LARKSUITE_CLI_DATA_DIR moves the store OUT of ~/.local/share. lark-cli
+    // opens EITHER the custom store (value accepted) OR the default (value rejected by its
+    // control-char/bidi validator, which we do NOT replicate). So the policy locks BOTH:
+    // deny both dirs + carve own keys in both. Whichever lark-cli picks, siblings + master
+    // stay denied (no leak) and own keys are readable (auth works).
+    const store = '/data00/cli-data/lark-cli';
+    const dflt = '/home/u/.local/share/lark-cli';
+    const p = buildFsPolicy(ctx({
+      platform: 'linux', homeDir: '/home/u', botHome: '/home/u/.botmux/bots/cli_self',
+      botmuxHome: '/home/u/.botmux', sessionDataDir: '/home/u/.botmux/data', workingDir: '/home/u/proj',
+      larkCliLinuxStore: store,
+    }));
+    // custom store: own keys RO, siblings + dir denied
+    expect(accessForPath(p.rules, `${store}/master.key`).access).toBe('readOnly');
+    expect(accessForPath(p.rules, `${store}/appsecret_cli_self.enc`).access).toBe('readOnly');
+    expect(accessForPath(p.rules, `${store}/appsecret_cli_other.enc`).access).toBe('deny');
+    expect(accessForPath(p.rules, store).access).toBe('deny');
+    // DEFAULT store ALSO locked (the fix): own keys RO there too, siblings denied — so if
+    // lark-cli rejected the custom value and fell back here, the shared keystore is NOT
+    // left exposed read-only under baseline ro(~/.local/share).
+    expect(accessForPath(p.rules, dflt).access).toBe('deny');
+    expect(accessForPath(p.rules, `${dflt}/appsecret_cli_other.enc`).access).toBe('deny');
+    expect(accessForPath(p.rules, `${dflt}/master.key`).access).toBe('readOnly');
+    expect(accessForPath(p.rules, `${dflt}/appsecret_cli_self.enc`).access).toBe('readOnly');
+    // darwin never emits a Linux store rule even when larkCliLinuxStore is set
+    const dar = buildFsPolicy(ctx({ larkCliLinuxStore: store }));
+    expect(dar.rules.some(r => r.path === store)).toBe(false);
+  });
+
+  it('LINUX lark-cli key store: default-only case (no custom store) dedupes to ONE store, unchanged behavior', () => {
+    const p = buildFsPolicy(ctx({
+      platform: 'linux', homeDir: '/home/u', botHome: '/home/u/.botmux/bots/cli_self',
+      botmuxHome: '/home/u/.botmux', sessionDataDir: '/home/u/.botmux/data', workingDir: '/home/u/proj',
+      // larkCliLinuxStore omitted → resolver default == /home/u/.local/share/lark-cli
+    }));
+    const dflt = '/home/u/.local/share/lark-cli';
+    expect(accessForPath(p.rules, `${dflt}/master.key`).access).toBe('readOnly');
+    expect(accessForPath(p.rules, `${dflt}/appsecret_cli_other.enc`).access).toBe('deny');
+    // exactly ONE deny rule for the store path (resolved == default, deduped)
+    expect(p.rules.filter(r => r.path === dflt && r.access === 'deny')).toHaveLength(1);
+  });
+
+  it('LINUX symlinked-leaf degrade precondition: when the canonical custom store basename != lark-cli (child falls back to default), BOTH the custom AND default stores are locked (no leak on fallback)', () => {
+    // The symlinked-leaf case: worker resolved larkCliLinuxStore to a canonical dir whose
+    // basename is NOT `lark-cli` (e.g. `data/lark-cli` → `elsewhere/keys`), so
+    // larkCliChildDataRoot returns null and the child degrades to the DEFAULT store. That
+    // degrade is only SAFE if the policy locks BOTH the canonical custom store AND the
+    // default (the safety precondition) — else the store the child actually opens on
+    // fallback would be exposed. Assert both are deny+own-carve, siblings denied in both.
+    const customCanon = '/data00/elsewhere/keys';   // canonical custom (basename 'keys')
+    const dflt = '/home/u/.local/share/lark-cli';
+    const p = buildFsPolicy(ctx({
+      platform: 'linux', homeDir: '/home/u', botHome: '/home/u/.botmux/bots/cli_self',
+      botmuxHome: '/home/u/.botmux', sessionDataDir: '/home/u/.botmux/data', workingDir: '/home/u/proj',
+      larkCliLinuxStore: customCanon,
+    }));
+    for (const s of [customCanon, dflt]) {
+      expect(accessForPath(p.rules, s).access).toBe('deny');
+      expect(accessForPath(p.rules, `${s}/appsecret_cli_other.enc`).access).toBe('deny');     // sibling — no leak
+      expect(accessForPath(p.rules, `${s}/master.key`).access).toBe('readOnly');              // own auth works on either
+      expect(accessForPath(p.rules, `${s}/appsecret_cli_self.enc`).access).toBe('readOnly');
+    }
+  });
+
+  it('LINUX lark-cli key store NESTED INSIDE BOT_HOME (LARKSUITE_CLI_DATA_DIR=<BOT_HOME>): own keys RO, siblings deny — transport', () => {
+    // nested-authority surface: a deployment may set LARKSUITE_CLI_DATA_DIR into BOT_HOME so
+    // the store resolves to `<BOT_HOME>/lark-cli`. The transport carve-out must STILL
+    // isolate — the store deny + own-key carve-out ride on top of the BOT_HOME rw grant
+    // (deeper prefix wins), so siblings/master stay isolated even though the whole
+    // BOT_HOME is otherwise writable.
+    const botHome = '/home/u/.botmux/bots/cli_self';
+    const store = `${botHome}/lark-cli`;
+    const p = buildFsPolicy(ctx({
+      platform: 'linux', homeDir: '/home/u', botHome,
+      botmuxHome: '/home/u/.botmux', sessionDataDir: '/home/u/.botmux/data', workingDir: '/home/u/proj',
+      larkCliLinuxStore: store,
+    }));
+    expect(accessForPath(p.rules, `${store}/master.key`).access).toBe('readOnly');
+    expect(accessForPath(p.rules, `${store}/appsecret_cli_self.enc`).access).toBe('readOnly');
+    expect(accessForPath(p.rules, `${store}/appsecret_cli_other.enc`).access).toBe('deny');
+    // BOT_HOME scratch OUTSIDE the store stays writable (the carve-out is scoped)
+    expect(accessForPath(p.rules, `${botHome}/scratch.txt`).access).toBe('readWrite');
   });
 
   it('internal injections: workingDir + BOT_HOME rw, own session store + attachments ro; siblings uncovered', () => {
@@ -855,6 +972,98 @@ describe('no-Lark-transport credential profile (larkTransportEnabled=false)', ()
     expect(accessForPath(p.rules, '/Users/u/.botmux/bots/sibling/send-cred.json').access).toBe('deny');
   });
 
+  it('LINUX no-transport: the lark-cli keystore is frozen with NO own-key carve-out (unlike transport-enabled)', () => {
+    // A no-transport (apiOnly / HTTP-virtual) turn has no Feishu sender identity, so
+    // it gets NO lark-cli credential at all — not even its OWN master.key. The store
+    // is an authority root: denied wholesale, and the transport-only own-key carve-out
+    // is gated OFF. This closes the no-transport path that previously left the shared
+    // Linux keystore readable. workingDir=~ is worst case.
+    const store = '/home/u/.local/share/lark-cli';
+    const p = buildFsPolicy(ctx({
+      platform: 'linux', larkTransportEnabled: false, homeDir: '/home/u', workingDir: '/home/u',
+      botmuxHome: '/home/u/.botmux', sessionDataDir: '/home/u/.botmux/data',
+      botHome: '/home/u/.botmux/bots/cli_self', redirectedCliData: false, authPaths: ['/home/u/.codex'],
+    }));
+    expect(accessForPath(p.rules, store).access).toBe('deny');
+    expect(accessForPath(p.rules, `${store}/master.key`).access).toBe('deny');        // OWN key too — no carve-out
+    expect(accessForPath(p.rules, `${store}/appsecret_cli_self.enc`).access).toBe('deny');
+    expect(accessForPath(p.rules, `${store}/appsecret_cli_other.enc`).access).toBe('deny');
+    // model CLI's own auth still works (not a Feishu cred)
+    expect(accessForPath(p.rules, '/home/u/.codex/auth.json').access).toBe('readWrite');
+  });
+
+  it('LINUX no-transport: BOTH candidate stores frozen when a custom LARKSUITE_CLI_DATA_DIR is set (both-candidate lock)', () => {
+    // no-transport must deny whichever store lark-cli opens — custom OR default — without
+    // depending on lark-cli's env-value validator. Both are authority roots, zero carve-out.
+    const custom = '/data00/cli-data/lark-cli';
+    const dflt = '/home/u/.local/share/lark-cli';
+    const p = buildFsPolicy(ctx({
+      platform: 'linux', larkTransportEnabled: false, homeDir: '/home/u', workingDir: '/home/u',
+      botmuxHome: '/home/u/.botmux', sessionDataDir: '/home/u/.botmux/data',
+      botHome: '/home/u/.botmux/bots/cli_self', redirectedCliData: false, authPaths: ['/home/u/.codex'],
+      larkCliLinuxStore: custom,
+    }));
+    for (const s of [custom, dflt]) {
+      expect(accessForPath(p.rules, s).access).toBe('deny');
+      expect(accessForPath(p.rules, `${s}/master.key`).access).toBe('deny');            // no carve-out
+      expect(accessForPath(p.rules, `${s}/appsecret_cli_self.enc`).access).toBe('deny');
+      expect(accessForPath(p.rules, `${s}/appsecret_cli_other.enc`).access).toBe('deny');
+    }
+    expect(accessForPath(p.rules, '/home/u/.codex/auth.json').access).toBe('readWrite');
+  });
+
+  it('LINUX no-transport: a HOSTILE deeper user sandboxPaths.readWrite cannot re-open the keystore', () => {
+    // deepest-prefix-wins: dropAuthority must strip a nested user grant that targets
+    // the frozen store BEFORE merge, else it would beat the shallow authority deny.
+    const store = '/home/u/.local/share/lark-cli';
+    const p = buildFsPolicy(ctx({
+      platform: 'linux', larkTransportEnabled: false, homeDir: '/home/u', workingDir: '/home/u',
+      botmuxHome: '/home/u/.botmux', sessionDataDir: '/home/u/.botmux/data',
+      botHome: '/home/u/.botmux/bots/cli_self', redirectedCliData: false, authPaths: ['/home/u/.codex'],
+      userPaths: { readWrite: [`${store}/appsecret_cli_other.enc`, store] },
+    }));
+    expect(accessForPath(p.rules, `${store}/appsecret_cli_other.enc`).access).toBe('deny');
+    expect(accessForPath(p.rules, `${store}/master.key`).access).toBe('deny');
+  });
+
+  it('LINUX no-transport: keystore NESTED INSIDE BOT_HOME still denies — BOT_HOME carve-out must not shadow a nested authority', () => {
+    // The reproduced escape: LARKSUITE_CLI_DATA_DIR=<BOT_HOME> → store=<BOT_HOME>/lark-cli.
+    // The old `insideAuthority = under(anyRoot) && !under(botHome)` exempted EVERYTHING
+    // under BOT_HOME, so a deeper hostile user RW under the nested store escaped
+    // dropAuthority and `master.key` resolved readWrite. The per-root BOT_HOME exception
+    // (only exempts a root that is an ANCESTOR of BOT_HOME) must keep the nested store
+    // restricting. Exercise ALL hostile channels: user RW/RO, readonlyRoots, extraWrite.
+    const botHome = '/home/u/.botmux/bots/cli_self';
+    const store = `${botHome}/lark-cli`;
+    const p = buildFsPolicy(ctx({
+      platform: 'linux', larkTransportEnabled: false, homeDir: '/home/u', workingDir: '/home/u',
+      botmuxHome: '/home/u/.botmux', sessionDataDir: '/home/u/.botmux/data',
+      botHome, redirectedCliData: false, authPaths: ['/home/u/.codex'],
+      larkCliLinuxStore: store,
+      userPaths: {
+        readWrite: [`${store}/master.key`, `${store}/appsecret_cli_other.enc`, store],
+        readOnly: [`${store}/appsecret_cli_sneaky.enc`],
+      },
+      readonlyRoots: [`${store}/via-readonly.enc`],
+      extraWritePaths: [`${store}/via-extrawrite.enc`],
+    }));
+    // NO channel may re-open any keystore file — all must resolve deny
+    expect(accessForPath(p.rules, `${store}/master.key`).access).toBe('deny');            // the reproduced leak
+    expect(accessForPath(p.rules, `${store}/appsecret_cli_other.enc`).access).toBe('deny');
+    expect(accessForPath(p.rules, `${store}/appsecret_cli_sneaky.enc`).access).toBe('deny');
+    expect(accessForPath(p.rules, `${store}/via-readonly.enc`).access).toBe('deny');
+    expect(accessForPath(p.rules, `${store}/via-extrawrite.enc`).access).toBe('deny');
+    expect(accessForPath(p.rules, store).access).toBe('deny');
+    // own appsecret ALSO denied under no-transport (no carve-out at all), and the
+    // dropped hostile paths are recorded for diagnosability.
+    expect(accessForPath(p.rules, `${store}/appsecret_cli_self.enc`).access).toBe('deny');
+    expect(p.suppressedAuthorityPaths?.some(s => s.startsWith(store))).toBe(true);
+    // BOT_HOME scratch OUTSIDE the nested store stays writable (exception still valid there)
+    expect(accessForPath(p.rules, `${botHome}/scratch.txt`).access).toBe('readWrite');
+    // ~/.codex (CLI's own auth, outside every authority root) still works
+    expect(accessForPath(p.rules, '/home/u/.codex/auth.json').access).toBe('readWrite');
+  });
+
   it('KEEPS the model CLI own auth (~/.codex) readWrite under no-transport — core functionality intact', () => {
     // The regression codex caught: authPaths are the CLI's OWN login (not Feishu),
     // so a core-only turn must still authenticate its CLI. ~/.codex stays RW even
@@ -889,6 +1098,28 @@ describe('no-Lark-transport credential profile (larkTransportEnabled=false)', ()
     expect(accessForPath(p.rules, '/Users/u/.codex/auth.json').access).toBe('readWrite');
     expect(accessForPath(p.rules, '/Users/u/Library/Application Support/lark-cli/master.key.file').access).toBe('readOnly');
     // bots.json (sibling secrets) is baseline-denied for normal bots too.
+  });
+
+  it('DARWIN no-transport is byte-identical to pre-refactor: the Linux keystore paths are NOT frozen (cross-platform gate)', () => {
+    // The Linux-store additions to computeNoTransportAuthorityRoots must be platform-gated,
+    // or macOS no-transport behavior changes: a workingDir under ~/.local/share/lark-cli
+    // (a normal macOS dir — macOS lark-cli uses the Library/… store) would newly fail
+    // `working-dir-is-authority`, and that dir would be spuriously denied. Assert neither.
+    // (1) workingDir under ~/.local/share/lark-cli must NOT throw on darwin
+    expect(() => buildFsPolicy(ctx({
+      platform: 'darwin', larkTransportEnabled: false, workingDir: '/Users/u/.local/share/lark-cli',
+      redirectedCliData: false, authPaths: ['/Users/u/.codex'],
+      larkCliLinuxStore: '/Users/u/.local/share/lark-cli',  // worker computes this on darwin too; must be ignored
+    }))).not.toThrow();
+    // (2) ~/.local/share/lark-cli is NOT specially frozen on darwin (workingDir=~ worst case)
+    const p = buildFsPolicy(ctx({
+      platform: 'darwin', larkTransportEnabled: false, workingDir: '/Users/u',
+      redirectedCliData: false, authPaths: ['/Users/u/.codex'],
+      larkCliLinuxStore: '/Users/u/.local/share/lark-cli',
+    }));
+    // the macOS keystore is still frozen (darwin's real store); the Linux path is not.
+    expect(accessForPath(p.rules, '/Users/u/Library/Application Support/lark-cli/master.key.file').access).toBe('deny');
+    expect(p.rules.some(r => r.path === '/Users/u/.local/share/lark-cli')).toBe(false);
   });
 
   it('denies the trusted-host HMAC + port table (escalation vector) even with workingDir=~', () => {
@@ -1065,7 +1296,7 @@ describe('no-Lark-transport credential profile (larkTransportEnabled=false)', ()
   it('computeNoTransportAuthorityRoots dedupes when configured === default and includes lark-cli stores', () => {
     // Pure-helper unit lock: the provenance logic the worker's real assembly uses.
     const roots = computeNoTransportAuthorityRoots({
-      homeDir: '/home/u', botmuxHome: '/home/u/.botmux', defaultBotmuxHome: '/home/u/.botmux',
+      platform: 'linux', homeDir: '/home/u', botmuxHome: '/home/u/.botmux', defaultBotmuxHome: '/home/u/.botmux',
     });
     expect(roots).toEqual(expect.arrayContaining([
       '/home/u/.botmux', '/home/u/.lark-cli', '/home/u/.lark-cli-bots',
@@ -1074,9 +1305,100 @@ describe('no-Lark-transport credential profile (larkTransportEnabled=false)', ()
     expect(roots.filter(r => r === '/home/u/.botmux')).toHaveLength(1);
     // distinct configured root is added too
     const dual = computeNoTransportAuthorityRoots({
-      homeDir: '/home/u', botmuxHome: '/srv/botmux', defaultBotmuxHome: '/home/u/.botmux',
+      platform: 'linux', homeDir: '/home/u', botmuxHome: '/srv/botmux', defaultBotmuxHome: '/home/u/.botmux',
     });
     expect(dual).toEqual(expect.arrayContaining(['/srv/botmux', '/home/u/.botmux']));
+  });
+
+  it('computeNoTransportAuthorityRoots freezes the Linux keystore ONLY on linux (default + custom); darwin gets NEITHER', () => {
+    // linux default: LARKSUITE_CLI_DATA_DIR unset → store under ~/.local/share
+    const def = computeNoTransportAuthorityRoots({ platform: 'linux', homeDir: '/home/u', botmuxHome: '/home/u/.botmux' });
+    expect(def).toEqual(expect.arrayContaining(['/home/u/.local/share/lark-cli']));
+    // linux custom store (worker resolved an absolute LARKSUITE_CLI_DATA_DIR) is frozen too
+    const custom = computeNoTransportAuthorityRoots({
+      platform: 'linux', homeDir: '/home/u', botmuxHome: '/home/u/.botmux', larkCliLinuxStore: '/data00/cli-data/lark-cli',
+    });
+    expect(custom).toEqual(expect.arrayContaining(['/data00/cli-data/lark-cli', '/home/u/.local/share/lark-cli']));
+    // DARWIN: the Linux store paths must NOT be added (macOS uses the Library/… store, which
+    // IS present). Freezing ~/.local/share/lark-cli on darwin would change darwin behavior
+    // (cross-platform regression) — assert it's absent even if larkCliLinuxStore is passed.
+    const dar = computeNoTransportAuthorityRoots({
+      platform: 'darwin', homeDir: '/Users/u', botmuxHome: '/Users/u/.botmux', larkCliLinuxStore: '/Users/u/.local/share/lark-cli',
+    });
+    expect(dar).toEqual(expect.arrayContaining(['/Users/u/Library/Application Support/lark-cli'])); // macOS store still frozen
+    expect(dar).not.toContain('/Users/u/.local/share/lark-cli');   // Linux default NOT added
+    expect(dar.some(r => r === '/Users/u/.local/share/lark-cli')).toBe(false);
+  });
+
+  it('resolveLarkCliLinuxStoreDir mirrors lark-cli SafeEnvDirPath (absolute Cleaned; relative/tilde/empty/control-char → $HOME; XDG ignored)', () => {
+    // strace-verified against lark-cli v1.0.76 keychain_other.go::StorageDir + SafeEnvDirPath:
+    // absolute LARKSUITE_CLI_DATA_DIR → <clean(value)>/lark-cli
+    expect(resolveLarkCliLinuxStoreDir('/data00/cli-data', '/home/u')).toBe('/data00/cli-data/lark-cli');
+    // a `..`-bearing absolute value is CLEANED (lark-cli does filepath.Clean),
+    // NOT rejected+fallback — else policy anchors the default while lark-cli opens the real dir.
+    expect(resolveLarkCliLinuxStoreDir('/srv/review/data/../actual', '/home/u')).toBe('/srv/review/actual/lark-cli');
+    expect(resolveLarkCliLinuxStoreDir('/a/b/../../etc', '/home/u')).toBe('/etc/lark-cli');
+    expect(resolveLarkCliLinuxStoreDir('/srv/review/actual//', '/home/u')).toBe('/srv/review/actual/lark-cli'); // // collapsed
+    expect(resolveLarkCliLinuxStoreDir('/srv/../..', '/home/u')).toBe('/lark-cli');                             // .. clamped at root
+    // unset / empty → $HOME/.local/share/lark-cli
+    expect(resolveLarkCliLinuxStoreDir(undefined, '/home/u')).toBe('/home/u/.local/share/lark-cli');
+    expect(resolveLarkCliLinuxStoreDir('', '/home/u')).toBe('/home/u/.local/share/lark-cli');
+    // RELATIVE / tilde values are spec-invalid → lark-cli IGNORES them, falls back to
+    // $HOME (verified by strace: `relseg/x` and `~/t` both opened ~/.local/share).
+    expect(resolveLarkCliLinuxStoreDir('relseg/x', '/home/u')).toBe('/home/u/.local/share/lark-cli');
+    expect(resolveLarkCliLinuxStoreDir('~/tildetest', '/home/u')).toBe('/home/u/.local/share/lark-cli');
+    expect(resolveLarkCliLinuxStoreDir('.', '/home/u')).toBe('/home/u/.local/share/lark-cli');
+    // CONTROL CHARS are rejected by lark-cli's validator → fallback to $HOME (strace-verified)
+    expect(resolveLarkCliLinuxStoreDir('/srv/\x01bad', '/home/u')).toBe('/home/u/.local/share/lark-cli');
+    expect(resolveLarkCliLinuxStoreDir('/srv/\x00nul', '/home/u')).toBe('/home/u/.local/share/lark-cli');
+  });
+
+  it('cleanPosixAbsPath: Go filepath.Clean semantics + control-char rejection (mirrors lark-cli SafeEnvDirPath)', () => {
+    expect(cleanPosixAbsPath('/a/b/../c')).toBe('/a/c');
+    expect(cleanPosixAbsPath('/a/./b//c/')).toBe('/a/b/c');
+    expect(cleanPosixAbsPath('/a/../../b')).toBe('/b');   // .. clamps at root
+    expect(cleanPosixAbsPath('/')).toBe('/');
+    expect(cleanPosixAbsPath('/srv/../..')).toBe('/');
+    // non-absolute → null
+    expect(cleanPosixAbsPath('rel/x')).toBeNull();
+    expect(cleanPosixAbsPath('~/x')).toBeNull();
+    expect(cleanPosixAbsPath('')).toBeNull();
+    // control chars → null (lark-cli treats as invalid)
+    expect(cleanPosixAbsPath('/a/\x01b')).toBeNull();
+    expect(cleanPosixAbsPath('/a/\x7f')).toBeNull();
+    expect(cleanPosixAbsPath('/a/\nb')).toBeNull();
+  });
+
+  it('larkCliLinuxStorePath: override wins; unnormalizable override → NULL (no carve-out), never silent default fallback', () => {
+    // a clean absolute override is used verbatim
+    expect(larkCliLinuxStorePath('/home/u', '/data00/cli-data/lark-cli')).toBe('/data00/cli-data/lark-cli');
+    // no override → default under homeDir
+    expect(larkCliLinuxStorePath('/home/u')).toBe('/home/u/.local/share/lark-cli');
+    // a `..`-bearing override must NOT silently fall back to the default
+    // store (that leaves the real store exposed). It returns NULL → buildFsPolicy emits
+    // NO Linux carve-out and the store stays denied-by-default. (In practice the worker
+    // Cleans first via resolveLarkCliLinuxStoreDir, so a `..` never reaches here.)
+    expect(larkCliLinuxStorePath('/home/u', '/a/../b')).toBeNull();
+    expect(larkCliLinuxStorePath('/home/u', 'relative')).toBeNull();
+  });
+
+  it('larkCliChildDataRoot: same-source pin when basename is lark-cli; null (safe degrade) for a symlinked leaf to a different name', () => {
+    // common / symlink-to-same-name: canonical store basename is `lark-cli` →
+    // pin = dirname, so child opens <pin>/lark-cli == the policy-protected store.
+    expect(larkCliChildDataRoot('/home/u/.local/share/lark-cli')).toBe('/home/u/.local/share');
+    expect(larkCliChildDataRoot('/data00/cli-data/lark-cli')).toBe('/data00/cli-data');
+    expect(larkCliChildDataRoot('/other/lark-cli')).toBe('/other');       // symlink resolved to another lark-cli dir
+    // symlinked `lark-cli` leaf → canonical basename differs → NULL (worker pins nothing;
+    // child falls back to the default store, which is ALSO locked → no leak, auth degrades).
+    expect(larkCliChildDataRoot('/tmp/elsewhere/keys')).toBeNull();
+    expect(larkCliChildDataRoot('/store')).toBeNull();                    // basename 'store' != lark-cli
+    // unusable inputs
+    expect(larkCliChildDataRoot(null)).toBeNull();
+    expect(larkCliChildDataRoot(undefined)).toBeNull();
+    expect(larkCliChildDataRoot('/')).toBeNull();
+    expect(larkCliChildDataRoot('relative/lark-cli')).toBeNull();         // not absolute
+    // a store directly at root: /lark-cli → pin '/'
+    expect(larkCliChildDataRoot('/lark-cli')).toBe('/');
   });
 
   it('CLI runtime still works under no-transport (.data-dir / bin / bots-info / own session)', () => {

--- a/test/per-bot-env.test.ts
+++ b/test/per-bot-env.test.ts
@@ -54,6 +54,7 @@ describe('sanitizePerBotEnv()', () => {
         CLAUDE_CONFIG_DIR: '/tmp/evil',
         CODEX_HOME: '/tmp/evil-codex',
         GROK_HOME: '/tmp/evil-grok',
+        LARKSUITE_CLI_DATA_DIR: '/tmp/evil-keystore',
         CLAUDE_CODE_RESUME_TOKEN_THRESHOLD: '1',
         CJADK_INTERACTIVE: '1',
         IS_SANDBOX: '1',
@@ -82,7 +83,7 @@ describe('isReservedPerBotEnvKey()', () => {
       'CLAUDECODE', 'CLAUDE_CONFIG_DIR', 'CLAUDE_CODE_RESUME_TOKEN_THRESHOLD',
       'CLAUDE_CODE_CHILD_SESSION', 'CLAUDE_CODE_SESSION_ID',
       'CLAUDE_CODE_ENTRYPOINT', 'CLAUDE_CODE_EXECPATH', 'CLAUDE_PID',
-      'CODEX_HOME', 'GROK_HOME',
+      'CODEX_HOME', 'GROK_HOME', 'LARKSUITE_CLI_DATA_DIR',
       'CJADK_INTERACTIVE', 'IS_SANDBOX', 'SESSION_DATA_DIR', '__OWNER_OPEN_ID',
     ]) {
       expect(isReservedPerBotEnvKey(k), k).toBe(true);


### PR DESCRIPTION
## 背景 / 问题

沙盒白名单模型设计上按「每个 bot 只放行自己那份 lark-cli 密钥」，macOS 早已在 keystore 上闭合，但 **Linux 漏写了这半边**。

lark-cli 在 Linux 把密钥落在**共享** store（`appsecret_<appId>.enc` 每 app 一份 + 共享 `master.key`），而 Linux `fs-policy` 只有一条 baseline `ro(~/.local/share)`、**没有更深的 deny**——于是任何开了 `sandbox`/`readIsolation` 的 bot 在沙盒内都能**只读到所有兄弟 bot 的 `appsecret_*.enc` + 共享 `master.key`**，可改写自身 config 指向兄弟 appId/keyId 从而**冒用兄弟 app 身份**。daemon 实际跑在 Linux，任何 Linux bot 开沙盒即触发。

## keystore 路径的权威来源（strace 实证 lark-cli v1.0.76）

lark-cli 的 Linux keystore 落点由 **`LARKSUITE_CLI_DATA_DIR`** 决定，**不读 `XDG_DATA_HOME`**（`strace -e openat` 三组对照 + 官方 `internal/keychain/keychain_other.go::StorageDir` / `SafeEnvDirPath`）：

- `<clean(LARKSUITE_CLI_DATA_DIR)>/lark-cli`，当该变量是**合法绝对路径**（先 `filepath.Clean` 解析 `..`/`.`/`//`；含控制字符/危险 Unicode 则判无效）
- 否则（相对/空/未设/非法）回退 `$HOME/.local/share/lark-cli`

## 改动

1. **`fs-policy.ts`** — Linux transport 会话镜像 macOS carve-out：`deny(store 根)`（deeper than baseline `ro(~/.local/share)` → longest-prefix 赢）+ 深一层 `ro(master.key)`（**Linux 是 `master.key`，非 macOS 的 `master.key.file`**）+ `ro(appsecret_<self>.enc)`。兄弟密文、用户 token、未来新文件全 deny-by-default。
2. **BOT_HOME 嵌套 authority**：`insideAuthority` 的 BOT_HOME 例外改为**按 root 作用**——只对「作为 BOT_HOME 祖先的 root」豁免；嵌套在 BOT_HOME 内、比它更具体的 authority root（如 `LARKSUITE_CLI_DATA_DIR=<BOT_HOME>` 时的 keystore）仍照常限制，堵住深层 hostile user RW 逃过 `dropAuthority` 把 `master.key` 解析成 readWrite 的逃逸。
3. **no-transport**（apiOnly / HTTP 虚拟会话）：把 keystore 纳入 `computeNoTransportAuthorityRoots`，整个 store 冻结、**零 carve-out**（连自身 key 也不给），并靠 `dropAuthority` 压住敌意 user RW/RO + 宽 workingDir 重开洞。
4. **store 路径解析**：新增纯函数 `cleanPosixAbsPath`（Go `filepath.Clean` 语义 + 控制字符拒绝）+ `resolveLarkCliLinuxStoreDir`（对齐 `SafeEnvDirPath`）。worker 从**冻结宿主环境**取 `process.env.LARKSUITE_CLI_DATA_DIR`，`cleanPosixAbsPath` 后经 `canonicalNearestAncestor`（realpath 最深存在祖先 + 回接不存在尾段，解 symlink 前缀而不在缺失叶子上抛错）规范化，作为显式 `FsPolicyContext.larkCliLinuxStore` 传入；**policy 保持纯函数、绝不读 env**。
5. **双候选 store 全锁**（去除对 lark-cli 字符校验器的 parity 依赖）：lark-cli 对一个 `LARKSUITE_CLI_DATA_DIR` 只可能开两个 store 之一——`<resolved>/lark-cli`（值被接受）或默认 `$HOME/.local/share/lark-cli`（值被拒/未设）。其字符校验规则（接受 TAB/LF/NBSP，拒绝 DEL / U+202E / U+FEFF / U+200B 等）难以逐字符复刻，故**不预测它选哪个**：transport 下两个 store 都 deny + 都 carve 自身 key；no-transport 下两个都进 authority roots 零 carve-out。无论 lark-cli 选哪个，兄弟 + master 都 deny（不泄漏）、自身 key 可读（auth 正常）。常态（无自定义）resolved == 默认 → 去重成一个。
6. **沙盒 child-pin 用 canonical 数据根**：`prepareDirectSandbox` 新增 `larkCliDataDir`，worker 传 `larkCliChildDataRoot(canonStore)`——仅当 canonical store basename 仍是 `lark-cli`（常态，含 symlink 解析到另一个同名 `lark-cli` 目录）才 `--setenv` `dirname(store)` 作 child 的 `LARKSUITE_CLI_DATA_DIR`，使沙盒内 lark-cli 与 policy 落**同一 canonical 命名空间**；若 `lark-cli` leaf 是 symlink 指向别名目录则不钉（child 回退默认 store，默认也已被锁）→ symlink 数据根不再命名空间分叉。
7. **per-bot env**：`LARKSUITE_CLI_DATA_DIR` 纳入 `per-bot-env.ts` 保留键——用户在 `bots.json.env` 配它会被拒 + 可诊断，不再被沙盒 host `--setenv/--unsetenv` 静默覆盖。

## 影响面评估

- **跨平台**：仅 Linux 且开 `sandbox`/`readIsolation` 的会话行为变化（收紧）。darwin 路径**完全不变**——新逻辑均在 `platform === 'linux'` 分支内，darwin 分支与断言未动。
- **跨会话类型**：transport（普通话题/群会话）拿自身 key carve-out；no-transport（apiOnly / HTTP 虚拟）整个 keystore 冻结、零 carve-out。两条路径都覆盖并测试。
- **跨后端**：改的是 policy 规则装配 + 沙盒 env 注入层，`PtyBackend`/`TmuxBackend` 共用同一编译产物，两引擎都按 longest-prefix 语义，无差异。
- **跨 CLI**：动的是共用 `fs-policy.ts` / `sandbox.ts` / `per-bot-env.ts`，不涉及单个 CLI 适配器；所有 CLI 只要开沙盒都受同一（收紧后的）keystore 规则保护。`prepareDirectSandbox` 新增可选入参，旧调用兼容。

## 测试验证

- `pnpm build` ✅
- **fs-policy 单测**：默认 store 自身 RO / 兄弟 + token + 未来文件 deny / 无关工具链（pipx、bytedcli SSO）不误伤；自定义 store rehome；BOT_HOME 嵌套 authority（transport + no-transport）；双候选 store 全锁 + default-only 去重；`cleanPosixAbsPath` 与 `resolveLarkCliLinuxStoreDir` 的「绝对 Clean / 相对忽略 / 控制字符拒绝 / `..` 归一」真值表；`larkCliChildDataRoot` 的同名 / 别名 symlink / root / 不可用输入。
- **bwrap 内核级 e2e**：真 bubblewrap 挂载下——兄弟 `appsecret` + `master.key` 内核级读不到、`ls` 不列兄弟、自身 key 可读、store 不可写；`LARKSUITE_CLI_DATA_DIR=<BOT_HOME>` + no-transport + 敌意 user RW 直指 `master.key` 仍全部拒绝。
- **变异测试**：去掉 store deny / 破坏 no-transport 门 / 碰错 `master.key` 文件名 / 去掉默认 store 锁 / 去掉 child-pin basename 判定，各让对应用例（含内核级）翻红，确认测试有牙、非假绿。
- **live**（真 sandbox + 真 lark-cli）：① 默认 store `lark-cli auth scopes` 出 158 scope、兄弟 `appsecret` 内核级 rc=1 拦；② `LARKSUITE_CLI_DATA_DIR` 指向重定向 store 同样 auth 正常 + 兄弟拦；③ 含 `..` 的 env 走完整 pipeline 后 auth 正常 + 兄弟拦；④ **symlink 数据根** child 钉 canonical → auth 正常 + 兄弟拦；⑤ no-transport 下自身 key 亦被冻结（BLOCKED）。

Refs #701（该文档 PR 保持 docs，阻塞到本代码修复合入后再 rebase 修正 Linux 密钥落点表述 + 首次 init 只能在宿主沙盒外终端执行）。
