### PR TITLE
fix(worker): 避免冷启动误报消息投递失败

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -7,7 +7,7 @@ import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { readFileSync, readdirSync, mkdirSync, existsSync, realpathSync, unlinkSync } from 'node:fs';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { ensureSkills, ensureAskSkill, ensurePluginSkills, ensureWhiteboardSkill, removeGlobalBotmuxSkills } from '../skills/installer.js';
 import { shouldInstallGlobalSkills } from '../skills/injection-mode.js';
 import { whiteboardEnabled } from '../services/whiteboard-store.js';
@@ -76,6 +76,12 @@ const DAEMON_BOOT_ID = randomUUID();
 const restartCoordinator = new RestartCoordinator();
 const lifecycleRetiringWorkers = new WeakMap<DaemonSession, Set<ChildProcess>>();
 const transferRetiringWorkers = new WeakSet<ChildProcess>();
+
+/** 在完整 Worker 模块加载前接住首条 IPC，避免冷启动耗时被误判为投递失败。 */
+function workerForkExecArgv(): string[] {
+  const preloadPath = join(__dirname, '..', 'worker-ipc-preload.js');
+  return [...process.execArgv, '--import', pathToFileURL(preloadPath).href];
+}
 
 function trackLifecycleRetirement(ds: DaemonSession, worker: ChildProcess): void {
   let workers = lifecycleRetiringWorkers.get(ds);
@@ -4385,6 +4391,7 @@ export function forkWorker(
   const worker = fork(workerPath, [], {
     windowsHide: true,
     stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    execArgv: workerForkExecArgv(),
     cwd,
     env: {
       ...forkEnv,
@@ -7236,6 +7243,7 @@ export function forkAdoptWorker(ds: DaemonSession, opts?: { restoredFromMetadata
   const worker = fork(workerPath, [], {
     windowsHide: true,
     stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+    execArgv: workerForkExecArgv(),
     cwd: adoptCwd,
     env: {
       ...forkEnv,

--- a/src/worker-ipc-preload.ts
+++ b/src/worker-ipc-preload.ts
@@ -1,0 +1,51 @@
+import type { EventEmitter } from 'node:events';
+
+export const WORKER_IPC_HANDLER_READY_EVENT = 'botmux:worker-ipc-handler-ready';
+
+type IpcHost = Pick<EventEmitter, 'emit' | 'prependListener' | 'removeListener' | 'once'> & {
+  send?: (message: unknown) => unknown;
+};
+
+function ordinaryColdStartTurnId(raw: unknown): string | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const message = raw as Record<string, unknown>;
+  if (
+    message.type !== 'init'
+    || message.adoptMode === true
+    || message.dispatchAttempt !== undefined
+    || typeof message.prompt !== 'string'
+    || message.prompt.length === 0
+    || typeof message.turnId !== 'string'
+    || !message.turnId.startsWith('om_')
+  ) {
+    return undefined;
+  }
+  return message.turnId;
+}
+
+/**
+ * 完整 Worker 加载前暂存父进程消息，并为已由当前进程持有的首轮输入回执。
+ * Worker 注册正式处理器后再按原顺序重放，保持后续提交确认语义不变。
+ */
+export function installWorkerIpcPreload(host: IpcHost): void {
+  const bufferedMessages: unknown[] = [];
+  let replaying = false;
+
+  const bufferMessage = (raw: unknown): void => {
+    if (replaying) return;
+    bufferedMessages.push(raw);
+    const turnId = ordinaryColdStartTurnId(raw);
+    if (turnId) host.send?.({ type: 'turn_input_received', turnId });
+  };
+
+  host.prependListener('message', bufferMessage);
+  host.once(WORKER_IPC_HANDLER_READY_EVENT, () => {
+    host.removeListener('message', bufferMessage);
+    replaying = true;
+    for (const message of bufferedMessages) host.emit('message', message);
+    bufferedMessages.length = 0;
+    replaying = false;
+  });
+}
+
+if (typeof process.send === 'function') installWorkerIpcPreload(process);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -133,6 +133,7 @@ import {
 import { buildBotmuxLarkNativeSessionTitle } from './core/session-title.js';
 import { drainCodexRollout, findCodexRolloutBySessionId, findCodexRolloutByPid, findCodexRolloutSetByPid, codexHistorySidIsOwned, splitCodexEventsByCutoff, extractLastCodexTurn, codexSessionIdFromRolloutPath, scanCodexThreadSettings, type CodexBridgeEvent, type CodexDrainResult } from './services/codex-transcript.js';
 import { CodexServiceTierTracker, resolveCodexServiceTierSnapshot } from './services/codex-service-tier.js';
+import { WORKER_IPC_HANDLER_READY_EVENT } from './worker-ipc-preload.js';
 import { drainTraexRollout, findTraexRolloutBySessionId, findTraexRolloutByPid, findTraexRolloutSetByPid, traexHistorySidIsOwned } from './services/traex-transcript.js';
 import { parseTraexUserInputQuestions } from './services/traex-user-input.js';
 import { cocoEventsPathForSession, drainCocoEvents, findCocoSessionByPid } from './services/coco-transcript.js';
@@ -12958,6 +12959,9 @@ process.on('message', async (raw: unknown) => {
     }
   }
 });
+
+// 预加载层会在正式处理器注册前暂存冷启动消息；现在按到达顺序交还。
+process.emit(WORKER_IPC_HANDLER_READY_EVENT);
 
 // ─── Cleanup ─────────────────────────────────────────────────────────────────
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12961,7 +12961,7 @@ process.on('message', async (raw: unknown) => {
 });
 
 // 预加载层会在正式处理器注册前暂存冷启动消息；现在按到达顺序交还。
-process.emit(WORKER_IPC_HANDLER_READY_EVENT);
+(process as NodeJS.EventEmitter).emit(WORKER_IPC_HANDLER_READY_EVENT);
 
 // ─── Cleanup ─────────────────────────────────────────────────────────────────
 

--- a/test/worker-ipc-preload.test.ts
+++ b/test/worker-ipc-preload.test.ts
@@ -1,0 +1,68 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  installWorkerIpcPreload,
+  WORKER_IPC_HANDLER_READY_EVENT,
+} from '../src/worker-ipc-preload.js';
+
+class FakeIpcHost extends EventEmitter {
+  send = vi.fn();
+}
+
+describe('worker IPC preload', () => {
+  it('acknowledges and replays an ordinary cold-start init after the worker handler is ready', () => {
+    const host = new FakeIpcHost();
+    const handled = vi.fn();
+    const init = {
+      type: 'init',
+      prompt: '排查问题',
+      turnId: 'om_cold_start',
+    };
+
+    installWorkerIpcPreload(host);
+    host.emit('message', init);
+    expect(host.send).toHaveBeenCalledWith({
+      type: 'turn_input_received',
+      turnId: 'om_cold_start',
+    });
+
+    host.on('message', handled);
+    host.emit(WORKER_IPC_HANDLER_READY_EVENT);
+    expect(handled).toHaveBeenCalledTimes(1);
+    expect(handled).toHaveBeenCalledWith(init);
+  });
+
+  it('buffers non-ordinary init without forging a delivery receipt', () => {
+    const host = new FakeIpcHost();
+    const handled = vi.fn();
+    const init = {
+      type: 'init',
+      prompt: '接管会话',
+      turnId: 'om_adopt',
+      adoptMode: true,
+    };
+
+    installWorkerIpcPreload(host);
+    host.emit('message', init);
+    host.on('message', handled);
+    host.emit(WORKER_IPC_HANDLER_READY_EVENT);
+
+    expect(host.send).not.toHaveBeenCalled();
+    expect(handled).toHaveBeenCalledWith(init);
+  });
+
+  it('stops intercepting messages after the worker handler is ready', () => {
+    const host = new FakeIpcHost();
+    const handled = vi.fn();
+    installWorkerIpcPreload(host);
+    host.on('message', handled);
+    host.emit(WORKER_IPC_HANDLER_READY_EVENT);
+
+    const followUp = { type: 'message', content: '继续', turnId: 'om_follow_up' };
+    host.emit('message', followUp);
+
+    expect(host.send).not.toHaveBeenCalled();
+    expect(handled).toHaveBeenCalledTimes(1);
+    expect(handled).toHaveBeenCalledWith(followUp);
+  });
+});


### PR DESCRIPTION
## 问题

普通群消息在冷启动 Worker 时立即启动 2 秒回执计时。Worker 模块加载耗时超过两轮计时后，Daemon 会发送“Worker 未能接收”的错误提示，但消息随后仍会进入 CLI，形成用户可见的假失败和重复投递。

## 修改

- 通过 Node `--import` 加载轻量 IPC 预加载层，在完整 Worker 模块加载前持有并确认首轮消息
- 正式 Worker IPC 处理器注册后，按原到达顺序重放暂存消息
- 保留现有 `turn_input_committed` 队列提交确认、重试与失败恢复语义
- 增加预加载回执、非普通会话隔离和就绪后透传的回归测试

## 影响面

- 影响所有 CLI 的 Worker 冷启动首轮普通群消息
- 稳态消息在正式处理器就绪后直接透传，不经过预加载暂存
- adopt、持久后端及各 CLI 输入队列逻辑不变
- 使用文件 URL 注入预加载模块，兼容 macOS、Linux 和 Windows 路径

## 验证

- `pnpm exec vitest run test/worker-ipc-preload.test.ts test/session-lifecycle-start.test.ts test/worker-ordinary-im-receipt-wiring.test.ts`：81 项通过
- `pnpm test`：全量 unit 测试通过
- `pnpm build`：通过
- 真实子进程延迟 3 秒注册处理器：约 124 ms 返回回执，约 3125 ms 后按序交给正式处理器