### PR TITLE
fix(desktop): 打磨桌面 shell 顶栏与左下角运行控制 UI

### DIFF
--- a/src/desktop/renderer/app.ts
+++ b/src/desktop/renderer/app.ts
@@ -167,6 +167,7 @@ const messages: Record<DesktopLocale, Record<string, string>> = {
     'dashboard.urlUnavailable': '控制台 URL 暂不可用。',
     'dashboard.openFailed': '打开页面失败：{error}',
     'login.launchAtLogin': '开机启动 App',
+    'login.launchAtLoginOn': '已设为开机启动',
     'login.unavailable': '登录项不可用：{error}',
     'login.updateFailed': '登录项更新失败：{error}',
     'logs.title': '日志',
@@ -249,6 +250,7 @@ const messages: Record<DesktopLocale, Record<string, string>> = {
     'dashboard.urlUnavailable': 'Dashboard URL is not available yet.',
     'dashboard.openFailed': 'Open page failed: {error}',
     'login.launchAtLogin': 'Launch app at login',
+    'login.launchAtLoginOn': 'Launches at login',
     'login.unavailable': 'Login item unavailable: {error}',
     'login.updateFailed': 'Login item update failed: {error}',
     'logs.title': 'Logs',
@@ -280,6 +282,8 @@ const addBotBtn = byId<HTMLButtonElement>('add-bot-btn');
 const logsBtn = byId<HTMLButtonElement>('logs-btn');
 const homeBtn = byId<HTMLButtonElement>('home-btn');
 const loginToggle = byId<HTMLInputElement>('login-toggle');
+const loginRow = byId<HTMLLabelElement>('login-row');
+const loginLabel = byId<HTMLSpanElement>('login-label');
 const versionLine = byId<HTMLDivElement>('version-line');
 const dashboardFrame = byId<DashboardWebviewElement>('dashboard-frame');
 const emptyDashboard = byId<HTMLDivElement>('empty-dashboard');
@@ -360,6 +364,15 @@ function paintChrome(): void {
     button.classList.toggle('active', button.dataset.locale === currentLocale);
     button.setAttribute('aria-pressed', String(button.dataset.locale === currentLocale));
   }
+  paintLoginState();
+}
+
+function paintLoginState(): void {
+  // The label reflects the persisted state, not just the control: enabled gets
+  // distinct copy and brighter text so on/off read differently at a glance.
+  const enabled = loginToggle.checked;
+  loginRow.dataset.enabled = String(enabled);
+  loginLabel.textContent = t(enabled ? 'login.launchAtLoginOn' : 'login.launchAtLogin');
 }
 
 async function initialize(): Promise<void> {
@@ -558,7 +571,13 @@ function paintControls(state: DesktopRuntimeState | null): void {
   const disabled = bridgeUnavailable || actionPending;
   const status = state?.status;
   const unmanagedRuntime = Boolean(state && !state.runtimeManaged);
+  // Show only the actions that fit the current state: stop/restart while the
+  // runtime is up (or on its way up), start otherwise.
+  const runningLike = status === 'running' || status === 'starting' || status === 'degraded';
 
+  startBtn.hidden = runningLike;
+  stopBtn.hidden = !runningLike;
+  restartBtn.hidden = !runningLike;
   startBtn.disabled = disabled || unmanagedRuntime || status === 'running' || status === 'starting';
   stopBtn.disabled =
     disabled || unmanagedRuntime || !status || status === 'not_configured' || status === 'stopped' || status === 'starting';
@@ -844,9 +863,11 @@ async function initializeLoginToggle(api: BotmuxDesktopApi): Promise<void> {
     setRuntimeNotice(t('login.unavailable', { error: formatError(error) }));
   } finally {
     loginToggle.disabled = false;
+    paintLoginState();
   }
 
   loginToggle.addEventListener('change', () => {
+    paintLoginState();
     void updateLoginItem(api, loginToggle.checked);
   });
 }
@@ -862,6 +883,7 @@ async function updateLoginItem(api: BotmuxDesktopApi, enabled: boolean): Promise
     setRuntimeNotice(t('login.updateFailed', { error: formatError(error) }));
   } finally {
     loginToggle.disabled = false;
+    paintLoginState();
   }
 }
 

--- a/src/desktop/renderer/index.html
+++ b/src/desktop/renderer/index.html
@@ -110,9 +110,10 @@
         </div>
 
         <div class="footer-meta-row">
-          <label class="login-row">
-            <input id="login-toggle" type="checkbox" disabled />
-            <span data-i18n="login.launchAtLogin">开机启动 App</span>
+          <label id="login-row" class="login-row">
+            <input id="login-toggle" type="checkbox" role="switch" disabled />
+            <span class="login-switch" aria-hidden="true"></span>
+            <span id="login-label" class="login-label">开机启动 App</span>
           </label>
           <div id="version-line" class="version-line" data-i18n="version.unavailable">版本信息不可用</div>
         </div>

--- a/src/desktop/renderer/index.html
+++ b/src/desktop/renderer/index.html
@@ -89,6 +89,11 @@
             <div id="runtime-status" class="runtime-status" data-i18n="runtime.checking">正在检查运行时</div>
             <div id="runtime-meta" class="runtime-meta" data-i18n="runtime.waitingBridge">等待桌面桥接</div>
           </div>
+          <label id="login-row" class="login-row">
+            <input id="login-toggle" type="checkbox" role="switch" disabled />
+            <span class="login-switch" aria-hidden="true"></span>
+            <span id="login-label" class="login-label">开机启动 App</span>
+          </label>
         </div>
         <div class="runtime-actions runtime-control-group" aria-label="CLI actions">
           <button id="start-btn" class="runtime-action runtime-action-primary" type="button" disabled>
@@ -110,11 +115,6 @@
         </div>
 
         <div class="footer-meta-row">
-          <label id="login-row" class="login-row">
-            <input id="login-toggle" type="checkbox" role="switch" disabled />
-            <span class="login-switch" aria-hidden="true"></span>
-            <span id="login-label" class="login-label">开机启动 App</span>
-          </label>
           <div id="version-line" class="version-line" data-i18n="version.unavailable">版本信息不可用</div>
         </div>
       </div>

--- a/src/desktop/renderer/style.css
+++ b/src/desktop/renderer/style.css
@@ -272,7 +272,9 @@ input:disabled {
   color: var(--text);
   font-size: 13px;
   font-weight: 650;
-  line-height: 1.2;
+  /* Exactly the switch height, so the status line and the launch-at-login
+     row that shares this line have identical vertical centers. */
+  line-height: 16px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -418,10 +420,11 @@ input:disabled {
   margin-top: 0;
   padding: 0;
   color: var(--muted);
-  /* Sits beside the 13px/650 runtime status; match its tone one notch smaller. */
+  /* Sits beside the 13px/650 runtime status; match its tone one notch smaller,
+     on the same exact 16px line box so both text centers coincide. */
   font-size: 12px;
   font-weight: 650;
-  line-height: 1.2;
+  line-height: 16px;
   cursor: pointer;
 }
 

--- a/src/desktop/renderer/style.css
+++ b/src/desktop/renderer/style.css
@@ -52,6 +52,15 @@ body {
   background:
     linear-gradient(180deg, rgba(17, 24, 39, 0.72), rgba(7, 9, 15, 0.98)),
     var(--bg);
+  /* Native app chrome: labels, pills, and buttons are controls, not copyable
+     text. Diagnostic text re-enables selection below. */
+  user-select: none;
+}
+
+.runtime-meta,
+.version-line,
+.log-output {
+  user-select: text;
 }
 
 button,
@@ -273,8 +282,10 @@ input:disabled {
 }
 
 .runtime-actions {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  /* Only state-relevant actions are visible (start vs stop/restart), so the
+     row flexes to share space among whichever buttons are shown. */
+  display: flex;
+  flex-wrap: wrap;
   gap: 4px;
   padding: 4px;
   border: 1px solid var(--border-soft);
@@ -287,6 +298,7 @@ input:disabled {
   align-items: center;
   justify-content: center;
   gap: 4px;
+  flex: 1 1 0;
   min-width: 0;
   height: 28px;
   padding: 0 6px;
@@ -361,7 +373,7 @@ input:disabled {
 }
 
 .runtime-action-takeover {
-  grid-column: 1 / -1;
+  flex: 1 1 100%;
   min-height: 30px;
   justify-content: center;
   padding: 0 10px;
@@ -389,29 +401,83 @@ input:disabled {
 }
 
 .login-row {
-  display: grid;
-  grid-template-columns: 14px minmax(0, auto);
-  gap: 6px;
+  display: flex;
+  gap: 7px;
   align-items: center;
   min-width: 0;
   margin-top: 0;
   padding: 0;
   color: var(--muted);
   font-size: 12px;
+  cursor: pointer;
 }
 
+.login-row:has(input:disabled) {
+  cursor: not-allowed;
+}
+
+/* The real checkbox stays in the tree for the label/a11y wiring; the switch
+   track next to it is the visible control (macOS-style sliding toggle). */
 .login-row input {
-  width: 14px;
-  height: 14px;
+  position: absolute;
+  width: 1px;
+  height: 1px;
   margin: 0;
-  accent-color: var(--accent);
+  opacity: 0;
+  pointer-events: none;
 }
 
-.login-row span {
+.login-switch {
+  flex: 0 0 26px;
+  position: relative;
+  width: 26px;
+  height: 16px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.14);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.09);
+  transition: background 160ms ease, box-shadow 160ms ease;
+}
+
+.login-switch::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+  transition: transform 160ms ease;
+}
+
+.login-row input:checked ~ .login-switch {
+  background: linear-gradient(120deg, var(--accent), var(--info));
+  box-shadow: none;
+}
+
+.login-row input:checked ~ .login-switch::after {
+  transform: translateX(10px);
+}
+
+.login-row input:disabled ~ .login-switch {
+  opacity: 0.55;
+}
+
+.login-row input:focus-visible ~ .login-switch {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.login-label {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.login-row[data-enabled="true"] .login-label {
+  color: var(--text);
 }
 
 .version-line {
@@ -478,27 +544,28 @@ input:disabled {
 }
 
 .topbar-status {
-  justify-content: flex-end;
+  /* Read-only summary lives on the left; interactive actions right-align. */
+  justify-content: flex-start;
 }
 
 .status-pill {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   min-width: 0;
-  height: 32px;
-  padding: 0 10px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  height: 26px;
+  padding: 0 11px;
+  border: 1px solid var(--border-soft);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.045);
+  background: rgba(255, 255, 255, 0.03);
   color: var(--muted);
-  font-size: 12px;
-  font-weight: 700;
+  font-size: 11px;
+  font-weight: 650;
 }
 
 .status-pill strong {
   color: var(--accent-strong);
-  font-size: 15px;
+  font-size: 13px;
 }
 
 .topbar-actions {
@@ -536,10 +603,15 @@ input:disabled {
 .topbar-actions > a,
 .logs-actions button {
   height: 32px;
+  padding: 0 13px;
   border: 1px solid var(--border);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.045);
   color: var(--text);
+  /* Buttons inherit the 16px document size otherwise; the rest of the shell
+     chrome (sidebar nav, pills, locale toggle) sits at 12-13px. */
+  font-size: 12px;
+  font-weight: 650;
 }
 
 .topbar-actions > button:hover:not(:disabled),
@@ -552,7 +624,6 @@ input:disabled {
 .topbar-actions > a {
   display: inline-flex;
   align-items: center;
-  padding: 0 14px;
   text-decoration: none;
 }
 

--- a/src/desktop/renderer/style.css
+++ b/src/desktop/renderer/style.css
@@ -211,8 +211,11 @@ input:disabled {
 }
 
 .sidebar-foot {
-  display: grid;
-  gap: 8px;
+  /* Three rows — status line, action group, version — spaced evenly. */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 9px;
   flex: 0 0 auto;
   margin-top: 10px;
   padding: 10px 6px 0;
@@ -220,10 +223,17 @@ input:disabled {
 }
 
 .runtime-line {
+  /* Status reads left, the launch-at-login switch right-aligns on the same line. */
   display: grid;
-  grid-template-columns: 10px minmax(0, 1fr);
+  grid-template-columns: 10px minmax(0, 1fr) auto;
   gap: 8px;
   align-items: center;
+}
+
+.runtime-line > .login-row {
+  /* Multi-line runtime meta grows the row; keep the switch level with the
+     first (status) line instead of drifting to the vertical middle. */
+  align-self: start;
 }
 
 .status-dot {
@@ -402,13 +412,16 @@ input:disabled {
 
 .login-row {
   display: flex;
-  gap: 7px;
+  gap: 6px;
   align-items: center;
   min-width: 0;
   margin-top: 0;
   padding: 0;
   color: var(--muted);
+  /* Sits beside the 13px/650 runtime status; match its tone one notch smaller. */
   font-size: 12px;
+  font-weight: 650;
+  line-height: 1.2;
   cursor: pointer;
 }
 
@@ -487,7 +500,7 @@ input:disabled {
   color: var(--faint);
   font-size: 10.5px;
   line-height: 1.2;
-  text-align: left;
+  text-align: center;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/desktop/renderer/style.css
+++ b/src/desktop/renderer/style.css
@@ -59,7 +59,8 @@ body {
 
 .runtime-meta,
 .version-line,
-.log-output {
+.log-output,
+.empty-dashboard {
   user-select: text;
 }
 

--- a/test/desktop/desktop-dashboard-webview.test.ts
+++ b/test/desktop/desktop-dashboard-webview.test.ts
@@ -400,13 +400,55 @@ describe('desktop dashboard embed', () => {
     expect(styleSource).toContain('.runtime-action[hidden]');
     expect(styleSource).toContain('.runtime-action svg');
     expect(styleSource).toContain('.runtime-action-takeover');
-    expect(styleSource).toContain('grid-column: 1 / -1');
+    // Visible actions flex to fill the row because state-irrelevant buttons hide.
+    expect(styleSource).toContain('flex-wrap: wrap');
+    expect(styleSource).toContain('flex: 1 1 100%');
     expect(html).toContain('footer-meta-row');
     expect(html).toContain('开机启动 App');
-    expect(styleSource).toContain('grid-template-columns: repeat(3, minmax(0, 1fr))');
     expect(styleSource).toContain('grid-template-columns: minmax(0, 1fr)');
     expect(styleSource).toContain('text-align: left');
     expect(styleSource).toContain('-webkit-line-clamp: 2');
+  });
+
+  it('shows only state-relevant runtime actions', () => {
+    const rendererSource = readFileSync(
+      fileURLToPath(new URL('../../src/desktop/renderer/app.ts', import.meta.url)),
+      'utf-8',
+    );
+
+    // Running-like states offer stop/restart; everything else offers start only.
+    const controlsFunction = /function paintControls[\s\S]*?function paintBridgeUnavailable/.exec(rendererSource)?.[0] ?? '';
+    expect(controlsFunction).toContain("status === 'running' || status === 'starting' || status === 'degraded'");
+    expect(controlsFunction).toContain('startBtn.hidden = runningLike');
+    expect(controlsFunction).toContain('stopBtn.hidden = !runningLike');
+    expect(controlsFunction).toContain('restartBtn.hidden = !runningLike');
+  });
+
+  it('renders launch-at-login as a switch with distinct on/off copy', () => {
+    const html = readFileSync(
+      fileURLToPath(new URL('../../src/desktop/renderer/index.html', import.meta.url)),
+      'utf-8',
+    );
+    const rendererSource = readFileSync(
+      fileURLToPath(new URL('../../src/desktop/renderer/app.ts', import.meta.url)),
+      'utf-8',
+    );
+    const styleSource = readFileSync(
+      fileURLToPath(new URL('../../src/desktop/renderer/style.css', import.meta.url)),
+      'utf-8',
+    );
+
+    // The hidden checkbox keeps label/a11y semantics; the sliding switch next
+    // to it is the visible control, and enabled state changes label copy/color.
+    expect(html).toMatch(/<input id="login-toggle" type="checkbox" role="switch"/);
+    expect(html).toContain('class="login-switch"');
+    expect(html).toContain('id="login-label"');
+    expect(styleSource).toContain('.login-row input:checked ~ .login-switch');
+    expect(styleSource).toContain('.login-row input:focus-visible ~ .login-switch');
+    expect(styleSource).toContain('.login-row[data-enabled="true"] .login-label');
+    expect(rendererSource).toContain('function paintLoginState');
+    expect(rendererSource).toContain("'login.launchAtLoginOn'");
+    expect(rendererSource).toContain("'login.launchAtLoginOn': 'Launches at login'");
   });
 
   it('syncs desktop locale into the embedded dashboard', () => {

--- a/test/desktop/desktop-dashboard-webview.test.ts
+++ b/test/desktop/desktop-dashboard-webview.test.ts
@@ -406,7 +406,9 @@ describe('desktop dashboard embed', () => {
     expect(html).toContain('footer-meta-row');
     expect(html).toContain('开机启动 App');
     expect(styleSource).toContain('grid-template-columns: minmax(0, 1fr)');
-    expect(styleSource).toContain('text-align: left');
+    // The bottom version line centers under evenly spaced footer rows.
+    expect(styleSource).toContain('justify-content: space-between');
+    expect(styleSource).toContain('text-align: center');
     expect(styleSource).toContain('-webkit-line-clamp: 2');
   });
 
@@ -443,6 +445,9 @@ describe('desktop dashboard embed', () => {
     expect(html).toMatch(/<input id="login-toggle" type="checkbox" role="switch"/);
     expect(html).toContain('class="login-switch"');
     expect(html).toContain('id="login-label"');
+    // The switch shares the status row: status reads left, switch right-aligns.
+    expect(html).toMatch(/<div class="runtime-line">[\s\S]*id="login-row"[\s\S]*?<\/div>\n\s*<div class="runtime-actions/);
+    expect(styleSource).toContain('grid-template-columns: 10px minmax(0, 1fr) auto');
     expect(styleSource).toContain('.login-row input:checked ~ .login-switch');
     expect(styleSource).toContain('.login-row input:focus-visible ~ .login-switch');
     expect(styleSource).toContain('.login-row[data-enabled="true"] .login-label');

--- a/test/desktop/desktop-dashboard-webview.test.ts
+++ b/test/desktop/desktop-dashboard-webview.test.ts
@@ -192,9 +192,13 @@ describe('desktop dashboard embed', () => {
     );
   });
 
-  it('renders structured dashboard locate failure reason/message', () => {
+  it('renders selectable structured dashboard locate failure reason/message', () => {
     const rendererSource = readFileSync(
       fileURLToPath(new URL('../../src/desktop/renderer/app.ts', import.meta.url)),
+      'utf-8',
+    );
+    const styleSource = readFileSync(
+      fileURLToPath(new URL('../../src/desktop/renderer/style.css', import.meta.url)),
       'utf-8',
     );
 
@@ -203,6 +207,15 @@ describe('desktop dashboard embed', () => {
     expect(rendererSource).toContain('formatDashboardLocateFailure');
     expect(rendererSource).toContain('locate.reason');
     expect(rendererSource).toContain('locate.message');
+    const selectableDiagnosticText = [
+      ...styleSource.matchAll(/([^{}]+)\{([^{}]*user-select:\s*text;[^{}]*)\}/g),
+    ].some(([, selectors]) =>
+      selectors
+        .split(',')
+        .map(selector => selector.trim())
+        .includes('.empty-dashboard'),
+    );
+    expect(selectableDiagnosticText).toBe(true);
   });
 
   it('switches sidebar routes without re-querying the dashboard URL after load', () => {


### PR DESCRIPTION
## 改了什么

Botmux Desktop 原生 shell（`src/desktop/renderer/`）的 4 处 UI 细节打磨，均为纯样式/展示逻辑，不涉及功能行为变化：

1. **顶栏 action 按钮字号对齐**：「创建会话 / 添加机器人 / 文档 / 日志 / 打开目录」此前继承文档默认 16px 字号，明显大于侧边栏（13px）与胶囊（12px）。补上 `font-size: 12px; font-weight: 650`，并统一左右 padding。
2. **顶栏布局：状态左、操作右**：「在线 Daemon / 需要处理 / 已配置 Bot」是只读摘要，与 action 入口性质不同，改为左对齐；action 入口与中英文切换统一右对齐。样式上同步做出区隔：状态胶囊弱化（26px 高、低对比边框、11px 标签），action 按钮保持 32px 交互样式，整体风格仍统一。
3. **左下角运行控制按状态显隐**：运行中/启动中/需要处理只显示「停止 + 重启」，其余状态（已停止/需要配置/状态不可用）只显示「启动」。此前三个按钮常驻、靠 disabled 区分，运行中还挂着一个灰掉的「启动」。按钮组从固定 3 列 grid 改为 flex 自适应，可见按钮均分整行。
4. **开机启动改为 macOS 风格滑动 switch**：替换原生 checkbox，原生 input 视觉隐藏但保留在 DOM（label 联动、`role="switch"`、focus-visible 描边等 a11y 语义不变）。开启/关闭态做出区隔：开启态轨道用主题渐变色、文案变为「已设为开机启动」且亮色显示；关闭态保持灰色「开机启动 App」。新增 i18n key `login.launchAtLoginOn`（中英文）。
5. **左下角整体改为三行均匀布局**：开机自启 switch 上移至运行状态行右侧（状态左对齐、switch 右对齐，字号字重与状态文案对齐；出现多行运行详情时 switch 钉在首行不下坠）；版本信息行水平居中、保持底部位置；`sidebar-foot` 改为 flex column 均匀排布三行（状态行 / 操作按钮组 / 版本行）。

另按桌面应用惯例，shell chrome（导航、胶囊、按钮、运行状态文案）整体 `user-select: none`；日志输出、版本号、运行时错误详情等诊断文本保留可选中，方便复制反馈。

## 影响面

- 仅桌面 shell 渲染层：`src/desktop/renderer/{index.html,style.css,app.ts}` + 对应源码断言测试 `test/desktop/desktop-dashboard-webview.test.ts`。
- 不涉及 daemon / CLI 适配器 / 飞书链路 / dashboard web（webview 内嵌页面零改动，注入的 `desktopShellInjectedCss` 未动）。
- `paintControls` 仅新增 `hidden` 赋值，原有 disabled 判定逐行保留，`unmanagedRuntime` / 桥接不可用等分支行为不变；takeover 按钮维持常驻隐藏，其兼容样式改为 `flex: 1 1 100%` 等价保留。
- login-row 挪入 `runtime-line`（HTML 结构移动 + grid 加第三列 auto），`footer-meta-row` 仅剩版本行；`aria-live="polite"` 容器范围未变。
- 开关交互链路（`getLoginItem` / `setLoginItem`、失败回滚、legacy autostart title 提示）未改，仅新增状态渲染 `paintLoginState()`，在初始化、切换语言、变更成功/失败后统一重绘。

## 验证

- `pnpm build` ✅
- `pnpm test` 全量单测 ✅（首个 commit 全量 825 文件 / 13267 用例通过；第二个 commit 后复跑，desktop 相关全绿，全量运行中 codex-app-threads / cost-calculator-cache 出现的计时敏感用例失败经单独复跑 60/60 通过，确认为并发负载 flake，与本 PR 改动无交集）
- `test/desktop/` 19 个测试文件 / 144 用例全绿；本 PR 同步更新了按钮组布局与版本行对齐的源码断言，并新增两个用例：运行按钮按状态显隐、开机启动 switch 的结构/同行布局与开启态文案断言
- 浏览器加载构建产物 + mock 桥接数据实测四种状态（运行中/已停止 × 开关开/关）：胶囊左对齐、按钮显隐、switch 同行右对齐与文案切换、版本行居中均符合预期，截图见下

## 演示截图

截图为浏览器加载构建产物 + mock 桥接数据渲染（版本号、计数均为演示值），不含真实环境信息。

### 整体：顶栏状态胶囊左对齐 / action 右对齐 + 字号对齐

| Before | After |
|---|---|
| ![before-running](https://raw.githubusercontent.com/LucasIcarus/botmux/236143023fb56a2de00fa92c90f0be381153d90d/before-running.png) | ![after-running](https://raw.githubusercontent.com/LucasIcarus/botmux/236143023fb56a2de00fa92c90f0be381153d90d/after-running.png) |
| ![before-stopped](https://raw.githubusercontent.com/LucasIcarus/botmux/236143023fb56a2de00fa92c90f0be381153d90d/before-stopped.png) | ![after-stopped](https://raw.githubusercontent.com/LucasIcarus/botmux/236143023fb56a2de00fa92c90f0be381153d90d/after-stopped.png) |

（第一行为运行中，第二行为已停止；整体图统一 2560×1600、特写统一 1000×608 同一裁剪区，便于逐格对比）

### 左下角特写：运行控制显隐 + 开机自启 switch

| 状态 | Before | After |
|---|---|---|
| 运行中 / 自启开 | ![foot-before-running](https://raw.githubusercontent.com/LucasIcarus/botmux/236143023fb56a2de00fa92c90f0be381153d90d/foot-before-running.png) | ![foot-after-running](https://raw.githubusercontent.com/LucasIcarus/botmux/236143023fb56a2de00fa92c90f0be381153d90d/foot-after-running.png) |
| 已停止 / 自启关 | ![foot-before-stopped](https://raw.githubusercontent.com/LucasIcarus/botmux/236143023fb56a2de00fa92c90f0be381153d90d/foot-before-stopped.png) | ![foot-after-stopped](https://raw.githubusercontent.com/LucasIcarus/botmux/236143023fb56a2de00fa92c90f0be381153d90d/foot-after-stopped.png) |
