### PR TITLE
fix(worker): 修新建会话首条消息白等 15 秒才投递

### DIFF
--- a/src/utils/idle-detector.ts
+++ b/src/utils/idle-detector.ts
@@ -39,6 +39,25 @@ export class IdleDetector {
     this.busyCallback = cb;
   }
 
+  /**
+   * Seed readyPattern evidence for a prompt that IS on screen but was rendered
+   * before resetReadyEvidence() cleared the flag. A new session (SessionStart
+   * source=startup) never redraws after that boundary, so Strategy 2's
+   * `!readySeen` early return would suppress quiescence detection forever.
+   *
+   * The caller must first confirm the PTY is quiet AND the current rendered
+   * screen matches readyPattern. This only restores readySeen — a full
+   * quiescence check (spinner guard included) still runs on top of it, so no
+   * existing check is bypassed.
+   */
+  seedReadyEvidence(): boolean {
+    if (this.isIdle || this.readySeen) return false;
+    this.readySeen = true;
+    this.clearTimer();
+    this.quiescenceCheck();
+    return true;
+  }
+
   feed(data: string): void {
     // A botmux-owned submit calls reset() before writing input, but adopted
     // panes can also receive local terminal input while we are already idle.

--- a/src/utils/input-gate.ts
+++ b/src/utils/input-gate.ts
@@ -62,6 +62,33 @@ export function shouldWaitForPostSessionStartPromptEvidence(state: {
 }
 
 /**
+ * Whether the "accept a prompt that is ALREADY on screen" fallback
+ * (decidePostHookPromptEvidence) may be armed for THIS SessionStart signal.
+ *
+ * The fallback exists only for `source=startup`: a brand-new session paints its
+ * prompt before the hooks finish and never redraws, so the fresh-evidence fence
+ * would otherwise wait out the full first-prompt timeout. Every OTHER source
+ * (resume/clear/compact) replays or reprints its transcript AFTER the boundary,
+ * so a genuinely fresh ❯ redraw arrives on its own in ~2s — the fence resolves
+ * without help. Arming the fallback there would instead let a >2s pause over a
+ * REPLAYED historical ❯ (still on the viewport during replay) satisfy the quiet
+ * gate and accept a pre-boundary prompt, defeating the very fence resume relies
+ * on. So the fallback is startup-only; the fence itself stays for all sources.
+ *
+ * Fail-safe: an unknown/absent source is NOT startup, so it does not arm — the
+ * signal simply falls back to the existing first-prompt timeout (status quo),
+ * never a new premature-delivery path.
+ */
+export function shouldArmPostHookPromptEvidenceFallback(state: {
+  /** shouldWaitForPostSessionStartPromptEvidence already said we're fencing. */
+  waitingForPostHookPrompt: boolean;
+  /** The SessionStart hook payload's `source` field (Claude: startup/resume/…). */
+  source: string | undefined;
+}): boolean {
+  return state.waitingForPostHookPrompt && state.source === 'startup';
+}
+
+/**
  * How long after the SessionStart boundary the fallback starts polling.
  *
  * The boundary also resets the quiescence baseline (`lastPtyOutputAtMs`), so the

--- a/src/utils/input-gate.ts
+++ b/src/utils/input-gate.ts
@@ -61,8 +61,15 @@ export function shouldWaitForPostSessionStartPromptEvidence(state: {
     && !state.alreadyWaiting;
 }
 
-/** How long after the SessionStart boundary the fallback starts polling. */
-export const POST_HOOK_EVIDENCE_FALLBACK_MS = 3_000;
+/**
+ * How long after the SessionStart boundary the fallback starts polling.
+ *
+ * The boundary also resets the quiescence baseline (`lastPtyOutputAtMs`), so the
+ * quiet window can never be satisfied before `POST_HOOK_EVIDENCE_QUIET_MS` has
+ * passed — polling earlier than that only burns a wakeup. Polling LATER just
+ * adds dead time to every new session, so this tracks the quiet threshold.
+ */
+export const POST_HOOK_EVIDENCE_FALLBACK_MS = 2_000;
 /** PTY must be silent at least this long before the screen is trusted. */
 export const POST_HOOK_EVIDENCE_QUIET_MS = 2_000;
 /** Past this the fallback gives up and hands back to the first-prompt timeout. */
@@ -82,9 +89,14 @@ export const POST_HOOK_EVIDENCE_RETRY_MS = 500;
  * timeout before its first message is forced in.
  *
  * So the wait window gets a second, independent criterion: the screen has been
- * quiet long enough AND the prompt is visible on the CURRENT screen. Together
- * these still exclude a startup selector's look-alike prompt (a selector screen
- * does not go quiet), without depending on a redraw that may never happen.
+ * quiet long enough AND the prompt is visible on the CURRENT screen — no longer
+ * depending on a redraw that may never happen.
+ *
+ * What keeps a startup selector's look-alike ❯ out is NOT the quiet window — a
+ * selector sitting there waiting for a keypress is perfectly quiet. It is the
+ * arming point: the caller only arms this fallback once the SessionStart ready
+ * signal has arrived, and that hook does not fire while the selector is still
+ * up. Outside that window the fallback never runs at all.
  *
  * The caller must read the prompt from the rendered viewport
  * (`renderer.rawSnapshot()`), NOT from the appended PTY log: after ANSI erase

--- a/src/utils/input-gate.ts
+++ b/src/utils/input-gate.ts
@@ -61,6 +61,69 @@ export function shouldWaitForPostSessionStartPromptEvidence(state: {
     && !state.alreadyWaiting;
 }
 
+/** How long after the SessionStart boundary the fallback starts polling. */
+export const POST_HOOK_EVIDENCE_FALLBACK_MS = 3_000;
+/** PTY must be silent at least this long before the screen is trusted. */
+export const POST_HOOK_EVIDENCE_QUIET_MS = 2_000;
+/** Past this the fallback gives up and hands back to the first-prompt timeout. */
+export const POST_HOOK_EVIDENCE_MAX_WAIT_MS = 10_000;
+/** Re-poll delay when the PTY is quiet enough but the prompt isn't on screen yet. */
+export const POST_HOOK_EVIDENCE_RETRY_MS = 500;
+
+/**
+ * SessionStart boundary fallback — accept a prompt that is ALREADY on screen.
+ *
+ * At the boundary `resetReadyEvidence()` drops old evidence and waits for a
+ * freshly rendered ❯. Resume replays its transcript, so it redraws and the real
+ * evidence arrives in ~2s. A `source=startup` session does not redraw at all:
+ * the prompt was painted before the hooks finished and the TUI has no reason to
+ * paint it again. `!readySeen` then suppresses the idle detector's quiescence
+ * strategy permanently and every new topic waits out the full first-prompt
+ * timeout before its first message is forced in.
+ *
+ * So the wait window gets a second, independent criterion: the screen has been
+ * quiet long enough AND the prompt is visible on the CURRENT screen. Together
+ * these still exclude a startup selector's look-alike prompt (a selector screen
+ * does not go quiet), without depending on a redraw that may never happen.
+ *
+ * The caller must read the prompt from the rendered viewport
+ * (`renderer.rawSnapshot()`), NOT from the appended PTY log: after ANSI erase
+ * sequences are stripped, a ❯ the TUI already wiped still matches, which would
+ * accept a prompt that is no longer there.
+ *
+ * Returns the action for the polling timer:
+ *   - `accept` — seed the ready evidence; the idle detector still runs a full
+ *                quiescence check (spinner guard included) on top of it.
+ *   - `retry`  — re-arm after `retryInMs`.
+ *   - `stop`   — real evidence won the race, or the window expired; hand back
+ *                to the existing first-prompt timeout rather than poll forever.
+ */
+export function decidePostHookPromptEvidence(state: {
+  /** The worker is still waiting for post-boundary prompt evidence. */
+  stillWaiting: boolean;
+  /** Milliseconds since the fallback was armed at the SessionStart boundary. */
+  elapsedMs: number;
+  /** Milliseconds since the last PTY byte. */
+  quietMs: number;
+  /** The CURRENT rendered screen matches the adapter's readyPattern. */
+  screenHasReadyPattern: boolean;
+  maxWaitMs?: number;
+  quietThresholdMs?: number;
+}): { action: 'accept' | 'retry' | 'stop'; retryInMs?: number } {
+  const maxWaitMs = state.maxWaitMs ?? POST_HOOK_EVIDENCE_MAX_WAIT_MS;
+  const quietThresholdMs = state.quietThresholdMs ?? POST_HOOK_EVIDENCE_QUIET_MS;
+  // Real evidence arrived — the fallback steps aside.
+  if (!state.stillWaiting) return { action: 'stop' };
+  if (state.elapsedMs >= maxWaitMs) return { action: 'stop' };
+  if (state.quietMs < quietThresholdMs) {
+    // Wait out the remainder of the quiet window, plus a small margin so the
+    // next poll lands after the threshold rather than exactly on it.
+    return { action: 'retry', retryInMs: quietThresholdMs - state.quietMs + 100 };
+  }
+  if (!state.screenHasReadyPattern) return { action: 'retry', retryInMs: POST_HOOK_EVIDENCE_RETRY_MS };
+  return { action: 'accept' };
+}
+
 export function shouldReleaseFirstPromptTimeout(state: {
   /** Adapter wants the soft timeout to wait for a real readyPattern. */
   deferFirstPromptTimeoutUntilReady: boolean;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -43,10 +43,13 @@ import { BridgeTurnQueue, makeFingerprint, normaliseForFingerprint } from './ser
 import { shouldEmitEmptyCompletedBridgeFallback, shouldSuppressBridgeEmit, type BridgeSendMarker } from './services/bridge-fallback-gate.js';
 import {
   decideHardTimeoutAction,
+  decidePostHookPromptEvidence,
   decideSettleMarkReady,
   shouldReleaseFirstPromptTimeout,
   shouldWaitForPostSessionStartPromptEvidence,
   shouldWriteNow,
+  POST_HOOK_EVIDENCE_FALLBACK_MS,
+  POST_HOOK_EVIDENCE_RETRY_MS,
 } from './utils/input-gate.js';
 import {
   decideCodexRunnerFreshness,
@@ -5685,6 +5688,62 @@ function recentTerminalLogTail(): string | undefined {
   return tailChars(plain, CRASH_LOG_TAIL_MAX);
 }
 
+/**
+ * 兜底：SessionStart 边界之后接受「屏幕上已有的」提示符。
+ * 判据本身是 decidePostHookPromptEvidence()（input-gate.ts），这里只负责取数据
+ * 和排定时器。
+ *
+ * 提示符必须从**渲染后的画面**读（renderer.rawSnapshot()），不能用
+ * recentTerminalLogTail() —— 后者是 PTY 追加日志，stripAnsi 之后擦除语义全丢，
+ * 一个早已被 TUI 抹掉的 ❯ 照样匹配得上，会把首条消息灌进还没就绪的界面。
+ * 另外只有 rawSnapshot() 才含 ❯ 行，snapshot() 会把它过滤掉。
+ */
+let postHookEvidenceFallbackTimer: ReturnType<typeof setTimeout> | null = null;
+
+function clearPostHookEvidenceFallback(): void {
+  if (postHookEvidenceFallbackTimer) {
+    clearTimeout(postHookEvidenceFallbackTimer);
+    postHookEvidenceFallbackTimer = null;
+  }
+}
+
+/** 当前渲染画面是否有提示符（renderer 尚未就绪时按「没有」处理，等下一轮）。 */
+function screenShowsReadyPattern(): boolean {
+  const pattern = cliAdapter?.readyPattern;
+  if (!pattern) return false;
+  let screen = '';
+  try { screen = renderer?.rawSnapshot() ?? ''; } catch { return false; }
+  return !!screen && pattern.test(screen);
+}
+
+function armPostHookPromptEvidenceFallback(
+  startedAt: number = Date.now(),
+  delayMs: number = POST_HOOK_EVIDENCE_FALLBACK_MS,
+): void {
+  clearPostHookEvidenceFallback();
+  postHookEvidenceFallbackTimer = setTimeout(() => {
+    postHookEvidenceFallbackTimer = null;
+    const quietMs = Date.now() - lastPtyOutputAtMs;
+    const decision = decidePostHookPromptEvidence({
+      stillWaiting: awaitingPostSessionStartPromptEvidence,
+      elapsedMs: Date.now() - startedAt,
+      quietMs,
+      screenHasReadyPattern: screenShowsReadyPattern(),
+    });
+    if (decision.action === 'stop') return;
+    if (decision.action === 'retry') {
+      armPostHookPromptEvidenceFallback(startedAt, decision.retryInMs ?? POST_HOOK_EVIDENCE_RETRY_MS);
+      return;
+    }
+    // seedReadyEvidence() 只补 readySeen，仍走完整静默判定；随后由既有的
+    // markIdle('screen') → markPromptReadyFromPty() 链路清除等待标记。
+    if (idleDetector?.seedReadyEvidence()) {
+      log(`Post-SessionStart evidence fallback: screen quiet ${quietMs}ms with readyPattern on screen; accepting existing prompt`);
+    }
+  }, delayMs);
+  postHookEvidenceFallbackTimer.unref?.();
+}
+
 function crashDiagnosticPath(): string | undefined {
   const dataDir = process.env.SESSION_DATA_DIR;
   if (!dataDir || !sessionId) return undefined;
@@ -7711,6 +7770,7 @@ function markPromptReady(): void {
       return;
     }
     awaitingPostSessionStartPromptEvidence = false;
+    clearPostHookEvidenceFallback();
     log('Fresh prompt evidence observed after SessionStart hooks');
   }
   if (isSettlingFirstFlush) {
@@ -7767,6 +7827,7 @@ function markPromptReady(): void {
   if (awaitingFirstPrompt) {
     awaitingFirstPrompt = false;
     awaitingPostSessionStartPromptEvidence = false;
+    clearPostHookEvidenceFallback();
     renderer?.markNewTurn();  // exclude history replay from streaming card
   }
   send({ type: 'prompt_ready' });
@@ -11665,6 +11726,7 @@ async function spawnCli(
   promptReadyDetectedDuringSettle = false;
   readyPatternSeenDuringHold = false;
   awaitingPostSessionStartPromptEvidence = false;
+  clearPostHookEvidenceFallback();
   // Reset quiescence baseline so the settle measures silence from THIS spawn.
   lastPtyOutputAtMs = Date.now();
   const readyHookAvailable = effectiveReadyHookInstall
@@ -12025,6 +12087,7 @@ async function spawnCli(
 
     awaitingFirstPrompt = false;
     awaitingPostSessionStartPromptEvidence = false;
+    clearPostHookEvidenceFallback();
     renderer?.markNewTurn();
     log(forced
       ? `WARN First prompt hard timeout — ${cliName()} readyPattern did not arrive; forcing queued message flush`
@@ -12102,6 +12165,7 @@ function killCli(opts: {
   promptReadyDetectedDuringSettle = false;
   readyPatternSeenDuringHold = false;
   awaitingPostSessionStartPromptEvidence = false;
+  clearPostHookEvidenceFallback();
   stopStuckDetector();
   tuiPromptBlocking = false;
   stopScreenUpdates();
@@ -14771,6 +14835,7 @@ process.on('message', async (raw: unknown) => {
         idleDetector?.resetReadyEvidence();
         lastPtyOutputAtMs = Date.now();
         log('SessionStart boundary recorded — waiting for fresh post-hook prompt evidence');
+        armPostHookPromptEvidenceFallback();
       }
       // 先记下 gate 是否已被 45s fallback 释放：ReadyGate.receive() 是一次性
       // 语义，fallback 抢先后 releaseReadyGate 会整块跳过迟到的真信号。

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -45,6 +45,7 @@ import {
   decideHardTimeoutAction,
   decidePostHookPromptEvidence,
   decideSettleMarkReady,
+  shouldArmPostHookPromptEvidenceFallback,
   shouldReleaseFirstPromptTimeout,
   shouldWaitForPostSessionStartPromptEvidence,
   shouldWriteNow,
@@ -14834,6 +14835,16 @@ process.on('message', async (raw: unknown) => {
         isPromptReady,
         alreadyWaiting: awaitingPostSessionStartPromptEvidence,
       });
+      // 「接受屏幕已有提示符」兜底只对全新会话（source=startup）arm：新建会话在
+      // hook 跑完前就画好提示符、之后不再重绘，fence 必须靠兜底才解。resume/clear/
+      // compact 会在边界后自行重绘一个新 ❯（transcript 重放/重印），fence 靠真证据
+      // ~2s 自解；给它们 arm 反而会让回放中残留的历史 ❯ 满足静默门控、提前接受边界
+      // 前的旧提示符，破坏 resume 本就依赖的 fresh-evidence fence。未识别的 source
+      // 按非 startup 处理（fail-safe 不 arm，退回既有 15s 首提示符超时，无新回归）。
+      const armPostHookFallback = shouldArmPostHookPromptEvidenceFallback({
+        waitingForPostHookPrompt: waitForPostHookPrompt,
+        source: msg.source,
+      });
       if (waitForPostHookPrompt) {
         awaitingPostSessionStartPromptEvidence = true;
         promptReadyDetectedDuringSettle = false;
@@ -14841,7 +14852,7 @@ process.on('message', async (raw: unknown) => {
         idleDetector?.resetReadyEvidence();
         lastPtyOutputAtMs = Date.now();
         log('SessionStart boundary recorded — waiting for fresh post-hook prompt evidence');
-        armPostHookPromptEvidenceFallback();
+        if (armPostHookFallback) armPostHookPromptEvidenceFallback();
       }
       // 先记下 gate 是否已被 45s fallback 释放：ReadyGate.receive() 是一次性
       // 语义，fallback 抢先后 releaseReadyGate 会整块跳过迟到的真信号。

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5693,6 +5693,12 @@ function recentTerminalLogTail(): string | undefined {
  * 判据本身是 decidePostHookPromptEvidence()（input-gate.ts），这里只负责取数据
  * 和排定时器。
  *
+ * 挡住启动选择器假提示符的**不是**静默窗口 —— 选择器停在那儿等按键时屏幕是静
+ * 的（这正是它当初骗过 readyPattern 的原因）。真正的保障是 arm 的时机：只在
+ * 收到 SessionStart ready 信号之后才 arm，而该 hook 在选择器还没过去时不会
+ * 触发。窗口之外本兜底根本不运行。adopt / reattach 同理拿不到信号，不会 arm，
+ * 与 shouldArmReadyGate() 的 !adoptMode && !willReattachPersistent 天然一致。
+ *
  * 提示符必须从**渲染后的画面**读（renderer.rawSnapshot()），不能用
  * recentTerminalLogTail() —— 后者是 PTY 追加日志，stripAnsi 之后擦除语义全丢，
  * 一个早已被 TUI 抹掉的 ❯ 照样匹配得上，会把首条消息灌进还没就绪的界面。

--- a/test/first-prompt-timeout-repro.test.ts
+++ b/test/first-prompt-timeout-repro.test.ts
@@ -217,11 +217,20 @@ describe('First prompt timeout: worker 侧兜底接线', () => {
     expect(screenProbe).toContain('catch { return false; }');
   });
 
-  it('兜底只在 SessionStart 边界 arm', () => {
+  it('兜底只在 SessionStart 边界 arm —— 这是挡住启动选择器的唯一保障', () => {
+    // 选择器停在那儿等按键时屏幕是【静的】（这正是它当初骗过 readyPattern 的
+    // 原因），所以静默窗口挡不住它。真正挡住它的是 arm 时机：SessionStart hook
+    // 在选择器还没过去时不触发，兜底也就不会上场。这条断言一旦松掉（比如为了
+    // 修 re-attach 把 arm 提前到收信号之前），选择器就重新暴露在射程内。
     const armCallIdx = source.indexOf('armPostHookPromptEvidenceFallback();');
     const boundaryIdx = source.indexOf('SessionStart boundary recorded');
     expect(armCallIdx).toBeGreaterThan(boundaryIdx);
     expect(armCallIdx - boundaryIdx).toBeLessThan(200);   // 紧挨着边界日志
+
+    // 且这段必须落在 session_ready 消息分支内 —— 收到 ready 信号才 arm。
+    const caseIdx = source.lastIndexOf("case 'session_ready':", armCallIdx);
+    expect(caseIdx).toBeGreaterThan(-1);
+    expect(armCallIdx - caseIdx).toBeLessThan(1_500);
   });
 
   it('每个清除等待标记的位置都必须同时清定时器', () => {

--- a/test/first-prompt-timeout-repro.test.ts
+++ b/test/first-prompt-timeout-repro.test.ts
@@ -230,7 +230,28 @@ describe('First prompt timeout: worker 侧兜底接线', () => {
     // 且这段必须落在 session_ready 消息分支内 —— 收到 ready 信号才 arm。
     const caseIdx = source.lastIndexOf("case 'session_ready':", armCallIdx);
     expect(caseIdx).toBeGreaterThan(-1);
-    expect(armCallIdx - caseIdx).toBeLessThan(1_500);
+    expect(armCallIdx - caseIdx).toBeLessThan(2_000);
+  });
+
+  it('兜底只对 source=startup arm —— resume/clear/compact 不进兜底射程', () => {
+    // 兜底是为「新建会话画完提示符后不再重绘」而生。resume/clear/compact 会在
+    // 边界后自行重绘一个新 ❯，fence 靠真证据自解；给它们 arm 反而会让回放中
+    // 残留的历史 ❯ 满足静默门控、提前接受边界前的旧提示符，破坏 fresh-evidence
+    // fence。所以 arm 调用必须被 startup gate 守着，而不是裸调用。
+    const armLineStart = source.lastIndexOf('\n', source.indexOf('armPostHookPromptEvidenceFallback();'));
+    const armLine = source.slice(armLineStart, source.indexOf('armPostHookPromptEvidenceFallback();') + 'armPostHookPromptEvidenceFallback();'.length);
+    // arm 必须由 startup 判据守卫，不能裸调用（否则 resume 也会 arm）。
+    expect(armLine).toContain('if (armPostHookFallback)');
+
+    // 判据本身走 input-gate 的纯函数，并且喂进去的是 SessionStart 的 msg.source。
+    const caseStart = source.indexOf("case 'session_ready':");
+    const caseBody = source.slice(caseStart, source.indexOf('armPostHookPromptEvidenceFallback();', caseStart));
+    expect(caseBody).toContain('shouldArmPostHookPromptEvidenceFallback({');
+    expect(caseBody).toContain('source: msg.source,');
+
+    // fence 本身（awaitingPostSessionStartPromptEvidence = true）必须对所有 source
+    // 都设 —— resume 依赖它等真证据；只有 arm 才收窄到 startup。
+    expect(caseBody).toContain('awaitingPostSessionStartPromptEvidence = true;');
   });
 
   it('每个清除等待标记的位置都必须同时清定时器', () => {

--- a/test/first-prompt-timeout-repro.test.ts
+++ b/test/first-prompt-timeout-repro.test.ts
@@ -1,0 +1,245 @@
+/**
+ * 复现 "First prompt timeout" 的触发条件。
+ *
+ * 背景：worker.ts 在每次 spawn CLI 时 armed 一个 15s 定时器
+ * (FIRST_PROMPT_TIMEOUT_MS)。若届时 IdleDetector 还没判定空闲，就打
+ * "First prompt timeout — enabling screen updates and flushing queued messages"
+ * 并强行把排队的首条消息灌进 PTY（实测使首条消息延迟从 p50 1s 变成 14s）。
+ *
+ * 这组测试把「什么情况下 15s 内判不出空闲」固化下来。
+ *
+ * Run:  pnpm vitest run test/first-prompt-timeout-repro.test.ts
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { IdleDetector } from '../src/utils/idle-detector.js';
+import type { CliAdapter } from '../src/adapters/cli/types.js';
+
+/** claude-code 适配器的真实 readyPattern（src/adapters/cli/claude-code.ts:1147）。 */
+const CLAUDE_READY = /❯/;
+
+/** idle-detector.ts 内部常量，此处复述用于断言边界。 */
+const QUIESCENCE_MS = 2_000;
+const SPINNER_GUARD_MS = 3_000;
+/** worker.ts:1368 FIRST_PROMPT_TIMEOUT_MS —— 判不出空闲的预算。 */
+const FIRST_PROMPT_TIMEOUT_MS = 15_000;
+
+function makeCli(readyPattern?: RegExp): CliAdapter {
+  return {
+    id: 'test-cli',
+    resolvedBin: '/usr/bin/test-cli',
+    buildArgs: () => [],
+    writeInput: async () => {},
+    readyPattern,
+    systemHints: [],
+    altScreen: false,
+  };
+}
+
+function setup(readyPattern?: RegExp) {
+  const detector = new IdleDetector(makeCli(readyPattern));
+  const cb = vi.fn();
+  detector.onIdle(cb);
+  return { detector, cb };
+}
+
+describe('First prompt timeout: 触发条件', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('重绘间隔 < 2s 时，整个 15s 预算内都判不出空闲（这就是超时的直接成因）', () => {
+    const { detector, cb } = setup(CLAUDE_READY);
+    detector.feed('❯ ');                       // 提示符已经出现
+
+    // Ink TUI 周期性重绘状态栏。每次 feed() 都 clearTimer() 并重排 2000ms，
+    // 所以只要间隔小于 QUIESCENCE_MS，静默窗口永远排不满。
+    let elapsed = 0;
+    while (elapsed < FIRST_PROMPT_TIMEOUT_MS) {
+      vi.advanceTimersByTime(1_500);
+      elapsed += 1_500;
+      detector.feed('\x1b[2Ktokens: 1234  ctx: 45%');
+    }
+
+    expect(cb).not.toHaveBeenCalled();         // → worker 打 First prompt timeout
+    detector.dispose();
+  });
+
+  it('只要出现一次 >2s 的间隙就会判定空闲（同样的总输出量，只是时序不同）', () => {
+    const { detector, cb } = setup(CLAUDE_READY);
+    detector.feed('❯ ');
+    vi.advanceTimersByTime(QUIESCENCE_MS + 100);
+    expect(cb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('提示符出现前的 spinner 会让判定再推迟约 1.2s（max(❯+2.0s, spinner+3.2s)）', () => {
+    const { detector, cb } = setup(CLAUDE_READY);
+
+    detector.feed('⠋ loading plugins');        // lastSpinnerAt = now（readySeen 尚为 false）
+    detector.feed('❯ ');                       // readySeen = true，此后 spinner 不再计时
+
+    vi.advanceTimersByTime(QUIESCENCE_MS);
+    // quiescenceCheck: sinceSpinner ≈ 2000 < SPINNER_GUARD_MS → 重排 (3000-2000+200)
+    expect(cb).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(SPINNER_GUARD_MS - QUIESCENCE_MS + 200);
+    expect(cb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('提示符未出现时，静默判定被完全抑制（静默再久也不算空闲）', () => {
+    const { detector, cb } = setup(CLAUDE_READY);
+
+    detector.feed('Loading MCP servers...');   // 没有 ❯
+    vi.advanceTimersByTime(60_000);
+    expect(cb).not.toHaveBeenCalled();
+
+    detector.feed('❯ ');
+    vi.advanceTimersByTime(QUIESCENCE_MS + 100);
+    expect(cb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('SessionStart 边界丢弃旧提示符证据，必须等一个新的 ❯ —— 这会吃掉 15s 预算', () => {
+    const { detector, cb } = setup(CLAUDE_READY);
+
+    detector.feed('❯ ');                       // hook 触发前就渲染过提示符
+    detector.resetReadyEvidence();             // worker 在 SessionStart 边界调用
+
+    vi.advanceTimersByTime(10_000);            // 旧证据作废，光静默不够
+    expect(cb).not.toHaveBeenCalled();
+
+    detector.feed('❯ ');                       // 新提示符
+    vi.advanceTimersByTime(QUIESCENCE_MS + 100);
+    expect(cb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  // ── 修复：seedReadyEvidence() ──────────────────────────────────────────
+  // 实测 6/6 超时都是 readySeen=false + msSincePty≈3-4s + 屏幕上确有 ❯，
+  // 即「提示符在 resetReadyEvidence() 之前就渲染好了，此后不再重绘」。
+
+  it('修复：补种证据后，被 !readySeen 永久抑制的静默判定得以完成', () => {
+    const { detector, cb } = setup(CLAUDE_READY);
+
+    detector.feed('❯ ');            // 边界之前提示符已渲染
+    detector.resetReadyEvidence();  // SessionStart 边界丢弃证据
+    detector.feed('status bar');    // 之后只有状态栏更新，不含 ❯
+
+    vi.advanceTimersByTime(10_000); // 静默远超 2s，仍判不出（复现原缺陷）
+    expect(cb).not.toHaveBeenCalled();
+
+    // 调用方已自行确认 PTY 静默 + 屏幕含 readyPattern
+    expect(detector.seedReadyEvidence()).toBe(true);
+    expect(cb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('修复不绕过 spinner guard：补种后仍需等满 3.2s', () => {
+    const { detector, cb } = setup(CLAUDE_READY);
+
+    detector.feed('⠋ still loading');  // lastSpinnerAt = now
+    detector.resetReadyEvidence();     // 注意：这会把 lastSpinnerAt 清零
+    detector.feed('⠋ still loading');  // 重新置上 spinner 时刻
+
+    expect(detector.seedReadyEvidence()).toBe(true);
+    expect(cb).not.toHaveBeenCalled();          // spinner guard 拦住
+
+    vi.advanceTimersByTime(SPINNER_GUARD_MS + 200);
+    expect(cb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('已就绪或已空闲时补种是幂等的空操作', () => {
+    const { detector, cb } = setup(CLAUDE_READY);
+    detector.feed('❯ ');                        // readySeen 已为 true
+    expect(detector.seedReadyEvidence()).toBe(false);
+
+    vi.advanceTimersByTime(QUIESCENCE_MS + 100);
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(detector.seedReadyEvidence()).toBe(false);   // 已 idle
+    expect(cb).toHaveBeenCalledTimes(1);
+    detector.dispose();
+  });
+
+  it('边界值：恰好 2s 的间隙足够，1.9s 不够', () => {
+    const a = setup(CLAUDE_READY);
+    a.detector.feed('❯ ');
+    vi.advanceTimersByTime(1_900);
+    expect(a.cb).not.toHaveBeenCalled();
+    a.detector.dispose();
+
+    const b = setup(CLAUDE_READY);
+    b.detector.feed('❯ ');
+    vi.advanceTimersByTime(QUIESCENCE_MS);
+    expect(b.cb).toHaveBeenCalledTimes(1);
+    b.detector.dispose();
+  });
+});
+
+/**
+ * 上面那组只覆盖 IdleDetector 自身。判据逻辑在 input-gate.ts
+ * 的 decidePostHookPromptEvidence()（见 test/input-gate.test.ts），worker 这边
+ * 剩下的是「取什么数据、什么时候清定时器」—— worker.ts 不导出任何符号，按仓库
+ * 既有惯例（worker-pipe-initial-screen-order.test.ts）用源码断言把接线钉住。
+ */
+describe('First prompt timeout: worker 侧兜底接线', () => {
+  const source = readFileSync(join(process.cwd(), 'src/worker.ts'), 'utf8');
+  const fallbackStart = source.indexOf('function armPostHookPromptEvidenceFallback');
+  const fallbackBody = source.slice(fallbackStart, source.indexOf('\n}\n', fallbackStart));
+
+  it('兜底判据走 decidePostHookPromptEvidence，三个动作都接线', () => {
+    expect(fallbackStart).toBeGreaterThan(-1);
+    expect(fallbackBody).toContain('decidePostHookPromptEvidence({');
+    expect(fallbackBody).toContain("if (decision.action === 'stop') return;");
+    expect(fallbackBody).toContain("if (decision.action === 'retry')");
+    // retry 必须用决策返回的延时重排自身，否则轮询节奏与判据脱钩。
+    expect(fallbackBody).toContain('armPostHookPromptEvidenceFallback(startedAt, decision.retryInMs');
+    // accept 只补种证据，仍由 IdleDetector 走完整静默判定。
+    expect(fallbackBody).toContain('idleDetector?.seedReadyEvidence()');
+  });
+
+  it('提示符必须读渲染后的画面，不能读 PTY 追加日志', () => {
+    // recentTerminalLogTail() 是 stripAnsi 后的 scrollback：TUI 擦掉的旧 ❯ 在
+    // 那里照样匹配，会把首条消息灌进还没就绪的界面。必须用 rawSnapshot()；
+    // snapshot() 也不行——它按设计过滤掉 bare prompt 行，恰好把 ❯ 滤没。
+    const screenProbe = source.slice(
+      source.indexOf('function screenShowsReadyPattern'),
+      source.indexOf('function armPostHookPromptEvidenceFallback'),
+    );
+    expect(screenProbe).toContain('renderer?.rawSnapshot()');
+    expect(screenProbe).not.toContain('recentTerminalLogTail');
+    expect(screenProbe).not.toContain('renderer?.snapshot()');
+    expect(fallbackBody).toContain('screenHasReadyPattern: screenShowsReadyPattern()');
+    expect(fallbackBody).not.toContain('recentTerminalLogTail');
+    // renderer 尚未就绪时按「屏幕上没有提示符」处理，继续轮询而不是抛错。
+    expect(screenProbe).toContain('catch { return false; }');
+  });
+
+  it('兜底只在 SessionStart 边界 arm', () => {
+    const armCallIdx = source.indexOf('armPostHookPromptEvidenceFallback();');
+    const boundaryIdx = source.indexOf('SessionStart boundary recorded');
+    expect(armCallIdx).toBeGreaterThan(boundaryIdx);
+    expect(armCallIdx - boundaryIdx).toBeLessThan(200);   // 紧挨着边界日志
+  });
+
+  it('每个清除等待标记的位置都必须同时清定时器', () => {
+    // 否则陈旧回调会活到下一个周期。回调首行的 stillWaiting 检查只是第二道
+    // 防线，不能替代生命周期清理。
+    // 只看赋值，跳过 `let ...= false` 的声明本身。
+    const assignments = [...source.matchAll(/(?<!let )awaitingPostSessionStartPromptEvidence = false;/g)];
+    expect(assignments.length).toBeGreaterThanOrEqual(5);
+    const missing = assignments.filter(m => !/^\s*clearPostHookEvidenceFallback\(\);/.test(
+      source.slice(m.index + m[0].length),
+    ));
+    expect(missing.map(m => source.slice(m.index, m.index + 120))).toEqual([]);
+  });
+
+  it('定时期加的诊断日志不留在上游', () => {
+    expect(source).not.toContain('First-prompt-timeout diagnostic');
+    const detectorSource = readFileSync(join(process.cwd(), 'src/utils/idle-detector.ts'), 'utf8');
+    expect(detectorSource).not.toContain('get readyPatternSeen');
+    expect(detectorSource).not.toContain('get msSinceSpinner');
+  });
+});

--- a/test/input-gate.test.ts
+++ b/test/input-gate.test.ts
@@ -15,10 +15,14 @@
 import { describe, it, expect } from 'vitest';
 import {
   decideHardTimeoutAction,
+  decidePostHookPromptEvidence,
   decideSettleMarkReady,
   shouldReleaseFirstPromptTimeout,
   shouldWaitForPostSessionStartPromptEvidence,
   shouldWriteNow,
+  POST_HOOK_EVIDENCE_MAX_WAIT_MS,
+  POST_HOOK_EVIDENCE_QUIET_MS,
+  POST_HOOK_EVIDENCE_RETRY_MS,
 } from '../src/utils/input-gate.js';
 
 const base = {
@@ -187,6 +191,89 @@ describe('decideSettleMarkReady', () => {
       promptReadyDetectedDuringSettle: true,
       readyPatternSeenDuringHold: true,
     })).toBe(true);
+  });
+});
+
+describe('decidePostHookPromptEvidence', () => {
+  // A prompt that was already on screen before the SessionStart boundary is
+  // legitimate evidence, but ONLY when the caller can prove it is still there.
+  const waiting = {
+    stillWaiting: true,
+    elapsedMs: 3_000,
+    quietMs: POST_HOOK_EVIDENCE_QUIET_MS,
+    screenHasReadyPattern: true,
+  };
+
+  it('accepts once the PTY is quiet and the prompt is on the current screen', () => {
+    expect(decidePostHookPromptEvidence(waiting)).toEqual({ action: 'accept' });
+  });
+
+  it('steps aside the moment real evidence wins the race', () => {
+    // markPromptReadyFromPty() clears the waiting flag. A timer that already
+    // fired must not seed evidence on top of a session that moved on.
+    expect(decidePostHookPromptEvidence({ ...waiting, stillWaiting: false }))
+      .toEqual({ action: 'stop' });
+  });
+
+  it('gives up at the max wait instead of polling forever', () => {
+    // Handing back to the existing first-prompt timeout is the safe default:
+    // the fallback must never become a second, unbounded readiness path.
+    expect(decidePostHookPromptEvidence({ ...waiting, elapsedMs: POST_HOOK_EVIDENCE_MAX_WAIT_MS }))
+      .toEqual({ action: 'stop' });
+    expect(decidePostHookPromptEvidence({ ...waiting, elapsedMs: POST_HOOK_EVIDENCE_MAX_WAIT_MS + 1 }))
+      .toEqual({ action: 'stop' });
+  });
+
+  it('waits out the remainder of the quiet window rather than accepting early', () => {
+    // THE POINT OF THE QUIET GATE: a startup selector keeps painting, so it
+    // never goes quiet. Accepting before the window closes would put the first
+    // message into a selector's look-alike prompt.
+    const decision = decidePostHookPromptEvidence({ ...waiting, quietMs: 500 });
+    expect(decision.action).toBe('retry');
+    expect(decision.retryInMs).toBe(POST_HOOK_EVIDENCE_QUIET_MS - 500 + 100);
+  });
+
+  it('boundary: exactly the quiet threshold is enough, one ms short is not', () => {
+    expect(decidePostHookPromptEvidence({ ...waiting, quietMs: POST_HOOK_EVIDENCE_QUIET_MS }).action)
+      .toBe('accept');
+    expect(decidePostHookPromptEvidence({ ...waiting, quietMs: POST_HOOK_EVIDENCE_QUIET_MS - 1 }).action)
+      .toBe('retry');
+  });
+
+  it('THE SCROLLBACK TRAP: a quiet PTY without the prompt on screen must NOT accept', () => {
+    // The first cut of this fix read recentTerminalLogTail() — the appended PTY
+    // log with ANSI stripped. A ❯ the TUI had already erased still matched
+    // there, so a quiet-but-not-ready screen would have been accepted and the
+    // first message forced into a UI that wasn't listening. The caller now
+    // passes renderer.rawSnapshot(); this case pins the decision it feeds.
+    const decision = decidePostHookPromptEvidence({ ...waiting, screenHasReadyPattern: false });
+    expect(decision).toEqual({ action: 'retry', retryInMs: POST_HOOK_EVIDENCE_RETRY_MS });
+  });
+
+  it('keeps retrying while the prompt is absent, until the window expires', () => {
+    // Absent prompt at 9s → still retry; at 10s the max-wait stop wins.
+    expect(decidePostHookPromptEvidence({ ...waiting, elapsedMs: 9_000, screenHasReadyPattern: false }).action)
+      .toBe('retry');
+    expect(decidePostHookPromptEvidence({ ...waiting, elapsedMs: 10_000, screenHasReadyPattern: false }).action)
+      .toBe('stop');
+  });
+
+  it('stop beats every other condition — an expired window never accepts', () => {
+    expect(decidePostHookPromptEvidence({
+      stillWaiting: false,
+      elapsedMs: 0,
+      quietMs: 60_000,
+      screenHasReadyPattern: true,
+    })).toEqual({ action: 'stop' });
+  });
+
+  it('honours caller-supplied thresholds', () => {
+    expect(decidePostHookPromptEvidence({
+      ...waiting, quietMs: 400, quietThresholdMs: 300,
+    }).action).toBe('accept');
+    expect(decidePostHookPromptEvidence({
+      ...waiting, elapsedMs: 4_000, maxWaitMs: 4_000,
+    }).action).toBe('stop');
   });
 });
 

--- a/test/input-gate.test.ts
+++ b/test/input-gate.test.ts
@@ -17,6 +17,7 @@ import {
   decideHardTimeoutAction,
   decidePostHookPromptEvidence,
   decideSettleMarkReady,
+  shouldArmPostHookPromptEvidenceFallback,
   shouldReleaseFirstPromptTimeout,
   shouldWaitForPostSessionStartPromptEvidence,
   shouldWriteNow,
@@ -192,6 +193,62 @@ describe('decideSettleMarkReady', () => {
       promptReadyDetectedDuringSettle: true,
       readyPatternSeenDuringHold: true,
     })).toBe(true);
+  });
+});
+
+describe('shouldArmPostHookPromptEvidenceFallback', () => {
+  // The fresh-evidence FENCE is set for every source (resume relies on it). This
+  // predicate only decides whether the "accept a prompt already on screen"
+  // FALLBACK is armed on top of it — and that must be startup-only, because only
+  // a brand-new session paints its prompt before hooks finish and never redraws.
+  it('arms for a fresh startup session that is fencing', () => {
+    expect(shouldArmPostHookPromptEvidenceFallback({
+      waitingForPostHookPrompt: true,
+      source: 'startup',
+    })).toBe(true);
+  });
+
+  it('does NOT arm for resume — its transcript replay redraws a fresh prompt on its own', () => {
+    // THE BLOCKING CASE: arming resume let a >2s pause over a REPLAYED historical
+    // ❯ satisfy the quiet gate and accept a pre-boundary prompt, defeating the
+    // fence resume depends on. Resume must keep the fence but never the fallback.
+    expect(shouldArmPostHookPromptEvidenceFallback({
+      waitingForPostHookPrompt: true,
+      source: 'resume',
+    })).toBe(false);
+  });
+
+  it('does NOT arm for clear / compact — both reprint after the boundary', () => {
+    expect(shouldArmPostHookPromptEvidenceFallback({
+      waitingForPostHookPrompt: true,
+      source: 'clear',
+    })).toBe(false);
+    expect(shouldArmPostHookPromptEvidenceFallback({
+      waitingForPostHookPrompt: true,
+      source: 'compact',
+    })).toBe(false);
+  });
+
+  it('fail-safe: an unknown or absent source is not startup, so it never arms', () => {
+    // A future/unrecognised source falls back to the existing first-prompt
+    // timeout (status quo) rather than a new premature-delivery path.
+    expect(shouldArmPostHookPromptEvidenceFallback({
+      waitingForPostHookPrompt: true,
+      source: 'future-mode',
+    })).toBe(false);
+    expect(shouldArmPostHookPromptEvidenceFallback({
+      waitingForPostHookPrompt: true,
+      source: undefined,
+    })).toBe(false);
+  });
+
+  it('never arms when we are not even fencing, regardless of source', () => {
+    // If shouldWaitForPostSessionStartPromptEvidence said no (e.g. already ready,
+    // non-Claude, or a mid-session clear/compact), the fallback has nothing to do.
+    expect(shouldArmPostHookPromptEvidenceFallback({
+      waitingForPostHookPrompt: false,
+      source: 'startup',
+    })).toBe(false);
   });
 });
 

--- a/test/input-gate.test.ts
+++ b/test/input-gate.test.ts
@@ -20,6 +20,7 @@ import {
   shouldReleaseFirstPromptTimeout,
   shouldWaitForPostSessionStartPromptEvidence,
   shouldWriteNow,
+  POST_HOOK_EVIDENCE_FALLBACK_MS,
   POST_HOOK_EVIDENCE_MAX_WAIT_MS,
   POST_HOOK_EVIDENCE_QUIET_MS,
   POST_HOOK_EVIDENCE_RETRY_MS,
@@ -225,12 +226,28 @@ describe('decidePostHookPromptEvidence', () => {
   });
 
   it('waits out the remainder of the quiet window rather than accepting early', () => {
-    // THE POINT OF THE QUIET GATE: a startup selector keeps painting, so it
-    // never goes quiet. Accepting before the window closes would put the first
-    // message into a selector's look-alike prompt.
+    // The quiet window proves the CLI stopped emitting, not that a selector is
+    // gone — a selector waiting for a keypress is perfectly quiet. What keeps
+    // the selector out is the arming point (only after the SessionStart signal,
+    // which does not fire while the selector is up); this gate is about not
+    // trusting a screen that is still being painted.
     const decision = decidePostHookPromptEvidence({ ...waiting, quietMs: 500 });
     expect(decision.action).toBe('retry');
     expect(decision.retryInMs).toBe(POST_HOOK_EVIDENCE_QUIET_MS - 500 + 100);
+  });
+
+  it('first poll is not scheduled before the quiet window can possibly close', () => {
+    // The boundary resets the quiescence baseline, so quietMs cannot exceed the
+    // time since arming. Polling before the quiet threshold can only ever
+    // return retry — and polling later than it adds dead time to every new
+    // session. Keep the two aligned.
+    expect(POST_HOOK_EVIDENCE_FALLBACK_MS).toBe(POST_HOOK_EVIDENCE_QUIET_MS);
+    // At exactly the first poll, a session quiet since the boundary accepts.
+    expect(decidePostHookPromptEvidence({
+      ...waiting,
+      elapsedMs: POST_HOOK_EVIDENCE_FALLBACK_MS,
+      quietMs: POST_HOOK_EVIDENCE_FALLBACK_MS,
+    }).action).toBe('accept');
   });
 
   it('boundary: exactly the quiet threshold is enough, one ms short is not', () => {


### PR DESCRIPTION
**一句话**：新建会话的第一条消息会被扣在 worker 手里约 14 秒才写进 PTY——CLI 早就 ready 了，是就绪判定漏掉了这种情形，只能等满 15 秒硬超时强行灌入。本 PR 补一条独立判据把这段白等消掉。

## 问题

新建会话（SessionStart `source=startup`）的首条消息本该 1 秒送达，实际要等约 14 秒。

worker 在 SessionStart 边界调用 `resetReadyEvidence()` 丢弃旧的 readyPattern 证据，等一个**新渲染**的 ❯。这个设计假设「Claude 要等所有 hook 跑完才渲染真提示符，之后必然重绘」——对 resume 路径成立（transcript 重放天然会重绘，约 2s 就拿到真证据），但**对新建会话不成立**：提示符在 hook 跑完之前就画好了，TUI 没有理由再画一遍。

于是 `idle-detector.ts` 里 Strategy 2 的早退

```ts
if (this.readyPattern && !this.readySeen) return;
```

把静默判定永久抑制住，PTY 再安静也判不出空闲，只能白等满 `FIRST_PROMPT_TIMEOUT_MS`(15s) 才强行灌入排队的首条消息。

### 触发条件不是随机的，几乎是确定的

把一台部署上未修复期间的每一次 SessionStart 边界，按 spawn 命令带不带 `--resume` 分开统计结局（样本限定：`Spawning fresh CLI` 与其后 120s 内的边界配对，边界后 60s 内取第一个终局）：

| spawn 类型 | 样本 | 走满硬超时 | 约 2s 拿到就绪证据 |
|-|-|-|-|
| **新建**（无 `--resume`） | 297 | **296（99.7%）** | 1（0.3%） |
| **恢复**（带 `--resume`） | 211 | 1（0.5%） | **210（99.5%）** |

硬超时那一列的耗时中位数是 14.0s；拿到就绪证据的中位数是 2.00s。

恢复路径要重放 transcript，屏幕必然重绘一次，`readySeen` 因此拿得到；新建路径没有东西可重放，边界之后再无重绘 —— **297 次里只有 1 次侥幸赶上一次真重绘**。所以这不是概率问题：只要是新建会话，首条消息基本必然被扣满 15 秒。

冷启动量本身是结构性的，与消息量无关：每个会话在每个 `suspend all` 周期内都会冷启动一次。

## 改法

在等待窗口内加一条**独立的次级判据**：PTY 已静默 ≥2s **且当前渲染画面上就有提示符**，不再依赖一次未必会发生的重绘。

```
边界后 2s 起轮询
  ├ 要求 PTY 静默 ≥ 2000ms
  ├ 要求当前渲染画面匹配 readyPattern
  ├ 命中 → idleDetector.seedReadyEvidence()
  └ 超过 10s 放手，交回原有的 15s 硬超时，不无限轮询
```

首次轮询与静默门槛对齐：SessionStart 边界会把 `lastPtyOutputAtMs` 重置为当前时刻，所以静默窗口最早也要到边界 + 2000ms 才可能满足 —— 早于它轮询只会白白返回 retry，晚于它则给每个新建会话平白加一段死等。

### 启动选择器为什么进不来

不是靠静默窗口挡的 —— **启动选择器停在那里等按键时屏幕恰恰是静的**，这正是它当初能骗过 `readyPattern` 的原因。

真正的保障是 arm 的时机：本兜底只在收到 SessionStart ready 信号之后才 arm（`case 'session_ready'` 分支内），而该 hook 在选择器尚未越过时不会触发，窗口之外兜底根本不运行。adopt / reattach 拿不到该信号因而也不会 arm，与 `shouldArmReadyGate()` 的 `!adoptMode && !willReattachPersistent` 天然一致。

测试里有断言把「arm 必须落在 `session_ready` 分支内」钉死：日后若为了修 re-attach 把 arm 提前到收信号之前，选择器会重新暴露在射程内，该断言会失败。

### resume 靠的是 source 门控，不是「拿不到信号」

上面那条只覆盖 startup selector 与 adopt / reattach。**resume 是另一回事：它 spawn 的是一个带 `--resume` 的新进程，SessionStart hook 照样 fire、信号照样到、`awaitingFirstPrompt` 照样为 true** —— 光靠「拿不到信号」挡不住它。

而 resume 期间画面停在 transcript 重放出来的**历史 ❯**，若那段 replay 出现 >2s 的停顿，就会同时满足「静默 ≥2s + 屏幕有 ❯」，把边界前的旧提示符当成就绪证据接受，把首条消息投进仍在 replay / 仍在跑 project hook 的会话 —— 恰好击穿 resume 本来依赖的 fresh-evidence 栅栏。

所以 arm 之前还有一道 `shouldArmPostHookPromptEvidenceFallback()`：只有 `source === 'startup'` 才 arm；**未知 / 缺失 source 一律不 arm**（fail-safe 退回既有首提示符超时，不新增任何提前投递路径）。栅栏本身对所有 source 保持不变，只是不再给非 startup 的源叠这层兜底。

`seedReadyEvidence()` **只补 `readySeen`**，随后仍走一次完整的静默判定（含 spinner guard），不绕过任何既有检查；对已 idle / 已 readySeen 是幂等空操作。真证据先到时兜底直接让路。

判据本身抽成 `input-gate.ts` 的纯函数 `decidePostHookPromptEvidence()`（与既有的 `shouldReleaseFirstPromptTimeout` 等同类决策函数放在一起），worker 只负责取数据与排定时器。

### 一个关键细节：提示符必须读渲染后的画面

取数据用 `renderer.rawSnapshot()`，**不能用** `recentTerminalLogTail()`：

- `recentTerminalLogTail()` 读的是 `scrollback`，是 PTY 的**追加日志**，`stripAnsi` 之后擦除序列、光标移动的语义全部丢失。一个早已被 TUI 抹掉的 ❯ 在那里照样匹配得上——那会把首条消息灌进还没就绪的界面，正是 ready gate 本来要防的事。
- `renderer.snapshot()` 也不行：它按设计会过滤掉 bare prompt 行（*drops the bare prompt + input echo lines*），恰好把 ❯ 滤没。

`rawSnapshot()` 是 xterm 渲染后的 viewport，擦除与光标移动都已生效，才是真正的「当前屏幕」。测试里对这条有专门断言钉死。

## 影响面

`idle-detector` 是 20+ 个 CLI 共用的组件，属影响面最大的一档，逐项评估：

| 维度 | 评估 |
|-|-|
| 其它 CLI（20+） | **不受影响**。`idle-detector` 的改动是纯新增方法，既有 `feed()` / `quiescenceCheck()` 逻辑一行未改；唯一调用方只在 claude 家族且有 `readyPattern` 的首提示符等待路径上 arm |
| 恢复会话（`--resume`） | 不受影响。`shouldArmPostHookPromptEvidenceFallback()` 只对 `source === 'startup'` arm，resume 的 fresh-evidence 栅栏原样保留 |
| 群会话 / adopt / reattach | 不受影响。兜底只在等待窗口内生效，窗口外 `decidePostHookPromptEvidence()` 直接返回 `stop`；adopt / reattach 更是拿不到 SessionStart 信号 |
| 回合中途误判 | 已规避。`reset()` 每回合清零 `readySeen`，兜底仅在该窗口内 arm，且 `seedReadyEvidence()` 对已 idle / 已 readySeen 是幂等空操作 |
| 定时器生命周期 | 5 处清除 `awaitingPostSessionStartPromptEvidence` 的位置都同步清理定时器，陈旧回调不会活到下一个周期；定时器本身 `.unref()` |
| 跨平台 | 无平台相关代码（纯定时器 + 屏幕文本匹配），macOS / Linux 一致 |
| PtyBackend / TmuxBackend | 不受影响，读的是 `renderer`，两种后端同源 |

## 验证

在最新 `origin/master`（`4c4e24c0`）基线上：

```
$ npx tsc --noEmit
（无输出，exit 0）

$ npx vitest run --project unit
 Test Files  7 failed | 833 passed | 4 skipped (844)
      Tests  10 failed | 13710 passed | 37 skipped (13757)
```

失败全部来自基线，与本改动无关，已做对照：把本分支 `reset --hard origin/master` 后跑同一组文件，**裸基线自身失败 6 个文件**（`codex-app-runner.integration` / `command-handler` / `daemon-rename-route` / `listener-foreign-bot-owner` / `worker-codex-app-turn-routing.integration` / `worker-ordinary-im-receipt-wiring`）；带本改动跑同一组失败 5 个 —— 比基线还少一个，说明这批集成测试本身不稳定。`cost-calculator-cache.test.ts` 单独跑 49 passed（并发下的 timing flaky）。

针对性用例：

```
$ npx vitest run --project unit test/input-gate.test.ts \
    test/first-prompt-timeout-repro.test.ts test/idle-detector.test.ts
 Test Files  3 passed (3)
      Tests  98 passed (98)
```

新增覆盖：

- **判据分支**（`test/input-gate.test.ts`）：静默门槛边界（恰好 2000ms 够 / 1999ms 不够）、10s 截止放手、真证据抢先时让路、**屏幕上没有提示符时绝不接受**、首次轮询与静默门槛必须对齐、自定义阈值
- **worker 接线**（`test/first-prompt-timeout-repro.test.ts`）：数据源必须是 `rawSnapshot()` 且不得出现 `recentTerminalLogTail` / `snapshot()`、三个动作都接线、**arm 必须落在 `session_ready` 分支内**、每处清标记必须同时清定时器
- **缺陷条件固化**：重绘间隔 <2s 时 15s 内判不出空闲、只要一次 >2s 间隙就能判出、spinner 让判定推迟 1.2s、边界值 2.0s 够 / 1.9s 不够

两条关键断言做过注入回归验证：把数据源改回 `recentTerminalLogTail()`、删掉任意一处定时器清理，对应用例都会立刻失败，恢复后 14/14 通过。

