### PR TITLE
feat: support Feishu conversation labels

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -5222,18 +5222,18 @@ const server = createServer(async (req, res) => {
         const newFeedGroupName = typeof parsed.newFeedGroupName === 'string' ? parsed.newFeedGroupName.trim() : '';
         const feedGroupAppId = typeof parsed.feedGroupAppId === 'string' ? parsed.feedGroupAppId.trim() : '';
         if (upstream.ok && upstreamJson.ok && typeof upstreamJson.chatId === 'string' && (existingFeedGroupId || newFeedGroupName)) {
-          const feedBot = loadBotConfigs().find(bot => bot.larkAppId === feedGroupAppId && !bot.apiOnly);
-          if (!feedBot) {
-            upstreamJson.feedGroupError = '读取标签所用的机器人当前不可用。群聊已创建，但未加入标签。';
-          } else {
-            try {
+          try {
+            const feedBot = loadBotConfigs().find(bot => bot.larkAppId === feedGroupAppId && !bot.apiOnly);
+            if (!feedBot) {
+              upstreamJson.feedGroupError = '读取标签所用的机器人当前不可用。群聊已创建，但未加入标签。';
+            } else {
               const targetId = existingFeedGroupId || await createFeedGroup(feedBot, newFeedGroupName);
               await addChatToFeedGroup(feedBot, targetId, upstreamJson.chatId);
               upstreamJson.feedGroupId = targetId;
               upstreamJson.feedGroupName = newFeedGroupName || undefined;
-            } catch (error) {
-              upstreamJson.feedGroupError = error instanceof Error ? error.message : String(error);
             }
+          } catch (error) {
+            upstreamJson.feedGroupError = error instanceof Error ? error.message : String(error);
           }
         }
       }
@@ -5334,16 +5334,16 @@ const server = createServer(async (req, res) => {
       let feedGroupError = '';
       if (existingFeedGroupId || newFeedGroupName) {
         const feedGroupAppId = typeof parsed.feedGroupAppId === 'string' ? parsed.feedGroupAppId.trim() : '';
-        const feedBot = loadBotConfigs().find(bot => bot.larkAppId === feedGroupAppId && !bot.apiOnly);
-        if (!feedBot) {
-          feedGroupError = '读取标签所用的机器人当前不可用。';
-        } else {
-          try {
+        try {
+          const feedBot = loadBotConfigs().find(bot => bot.larkAppId === feedGroupAppId && !bot.apiOnly);
+          if (!feedBot) {
+            feedGroupError = '读取标签所用的机器人当前不可用。';
+          } else {
             feedGroupId = existingFeedGroupId || await createFeedGroup(feedBot, newFeedGroupName);
             await addChatToFeedGroup(feedBot, feedGroupId, chatId);
-          } catch (error) {
-            feedGroupError = error instanceof Error ? error.message : String(error);
           }
+        } catch (error) {
+          feedGroupError = error instanceof Error ? error.message : String(error);
         }
       }
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -153,6 +153,8 @@ import {
 } from './services/skill-registry-store.js';
 import { redactGitUrlCredentials } from './core/skills/sources.js';
 import { effectiveDefaultWorkingDir, getBot, loadBotConfigs, parseBotConfigsFromText, type BotConfig, type VcMeetingAgentConfig } from './bot-registry.js';
+import { addChatToFeedGroup, createFeedGroup, FEED_GROUP_SCOPES, FeedGroupApiError, listFeedGroups } from './dashboard/feed-groups.js';
+import { generateAuthUrl, handleCallbackUrl, isCallbackUrl } from './utils/user-token.js';
 import { findEntryIndex, readRawConfig, requireConfigPath, writeRawConfigAtomic } from './services/config-store.js';
 import {
   emitCodexNotifierOutboxItem,
@@ -205,7 +207,7 @@ import { maybeInstallTraexPluginOnSettingsChange, TRAEX_RECOMMENDED_SOURCE, TRAE
 import { deriveCreateGroupName, selectCreateSessionTargets } from './core/session-create.js';
 import { parseDashboardImageUploads } from './core/dashboard-images.js';
 import { checkLarkCliVersion, MIN_LARK_CLI_VERSION_FOR_VC_BOT } from './vc-agent/polling-source.js';
-import { larkHosts } from './im/lark/lark-hosts.js';
+import { larkHosts, normalizeBrand } from './im/lark/lark-hosts.js';
 import { buildResourceMonitorDaemonSeeds, createResourceMonitorService, handleResourceMonitorApi, toResourceMonitorSessionSeed } from './dashboard/resource-monitor-service.js';
 import { readPluginRegistry } from './services/plugin-registry-store.js';
 import { pluginRuntimeDir, resolvePluginPath } from './core/plugins/paths.js';
@@ -5066,6 +5068,63 @@ const server = createServer(async (req, res) => {
       return;
     }
 
+    // Native Feishu/Lark conversation labels (feed groups). These APIs are
+    // user-token-only, so the frontend pins subsequent create/assign calls to
+    // the same app whose OAuth token produced this list.
+    if (req.method === 'GET' && url.pathname === '/api/feed-groups/auth-url') {
+      const appId = url.searchParams.get('larkAppId') ?? '';
+      let bot: BotConfig | undefined;
+      try { bot = loadBotConfigs().find(item => !item.apiOnly && (!appId || item.larkAppId === appId)); }
+      catch { /* handled below */ }
+      if (!bot) return jsonRes(res, 404, { ok: false, error: 'bot_not_found' });
+      const { authUrl } = generateAuthUrl(bot.larkAppId, bot.larkAppSecret, normalizeBrand(bot.brand), [...FEED_GROUP_SCOPES]);
+      return jsonRes(res, 200, { ok: true, larkAppId: bot.larkAppId, authUrl });
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/feed-groups/oauth-callback') {
+      let body: { callbackUrl?: unknown };
+      try { body = await readJsonBody(req) as { callbackUrl?: unknown }; }
+      catch { return jsonRes(res, 400, { ok: false, error: 'bad_json' }); }
+      const callbackUrl = typeof body.callbackUrl === 'string' ? body.callbackUrl.trim() : '';
+      if (!isCallbackUrl(callbackUrl)) {
+        return jsonRes(res, 400, { ok: false, error: 'invalid_callback_url', message: '请粘贴完整的 127.0.0.1 OAuth 回调 URL。' });
+      }
+      const message = await handleCallbackUrl(callbackUrl);
+      const ok = typeof message === 'string' && message.startsWith('✅');
+      return jsonRes(res, ok ? 200 : 400, { ok, error: ok ? undefined : 'oauth_exchange_failed', message });
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/feed-groups') {
+      const requestedAppId = url.searchParams.get('larkAppId') ?? '';
+      let bots: BotConfig[];
+      try { bots = loadBotConfigs().filter(bot => !bot.apiOnly); }
+      catch { return jsonRes(res, 500, { ok: false, error: 'bot_config_unavailable' }); }
+      const ordered = requestedAppId
+        ? [...bots.filter(bot => bot.larkAppId === requestedAppId), ...bots.filter(bot => bot.larkAppId !== requestedAppId)]
+        : bots;
+      let loginRequired = false;
+      for (const bot of ordered) {
+        try {
+          const groups = await listFeedGroups(bot);
+          return jsonRes(res, 200, { ok: true, larkAppId: bot.larkAppId, groups });
+        } catch (error) {
+          if (error instanceof FeedGroupApiError && error.code === 'user_login_required') {
+            loginRequired = true;
+            continue;
+          }
+          if (requestedAppId && bot.larkAppId === requestedAppId) {
+            const e = error as FeedGroupApiError;
+            return jsonRes(res, e.status ?? 502, { ok: false, error: e.code ?? 'feed_group_list_failed', message: e.message });
+          }
+        }
+      }
+      return jsonRes(res, loginRequired ? 401 : 503, {
+        ok: false,
+        error: loginRequired ? 'user_login_required' : 'feed_group_api_unavailable',
+        message: loginRequired ? '尚未获得飞书标签权限，请点击「立即授权」按钮进行授权。' : '没有可用于读取标签的飞书机器人。',
+      });
+    }
+
     // Create a new chat — pick a creator from the user-selected larkAppIds
     // (Feishu makes the calling bot the implicit first member, so picking
     // anything else would silently add an unwanted bot). Auto-invite the
@@ -5073,7 +5132,7 @@ const server = createServer(async (req, res) => {
     // are app-scoped, so creator daemon and operator open_id come from the
     // SAME bot by construction. See dashboard/operator-selector.ts.
     if (req.method === 'POST' && url.pathname === '/api/groups/create') {
-      let parsed: { name?: unknown; larkAppIds?: unknown; userOpenIds?: unknown; ownerUnionIds?: unknown; bindWorkingDir?: unknown; roleProfileId?: unknown };
+      let parsed: { name?: unknown; larkAppIds?: unknown; userOpenIds?: unknown; ownerUnionIds?: unknown; bindWorkingDir?: unknown; roleProfileId?: unknown; feedGroupId?: unknown; newFeedGroupName?: unknown; feedGroupAppId?: unknown };
       try {
         const chunks: Buffer[] = [];
         for await (const c of req) chunks.push(c as Buffer);
@@ -5159,6 +5218,24 @@ const server = createServer(async (req, res) => {
         } else {
           upstreamJson.autoInvitedOpenId = autoInvited;
         }
+        const existingFeedGroupId = typeof parsed.feedGroupId === 'string' ? parsed.feedGroupId.trim() : '';
+        const newFeedGroupName = typeof parsed.newFeedGroupName === 'string' ? parsed.newFeedGroupName.trim() : '';
+        const feedGroupAppId = typeof parsed.feedGroupAppId === 'string' ? parsed.feedGroupAppId.trim() : '';
+        if (upstream.ok && upstreamJson.ok && typeof upstreamJson.chatId === 'string' && (existingFeedGroupId || newFeedGroupName)) {
+          const feedBot = loadBotConfigs().find(bot => bot.larkAppId === feedGroupAppId && !bot.apiOnly);
+          if (!feedBot) {
+            upstreamJson.feedGroupError = '读取标签所用的机器人当前不可用。群聊已创建，但未加入标签。';
+          } else {
+            try {
+              const targetId = existingFeedGroupId || await createFeedGroup(feedBot, newFeedGroupName);
+              await addChatToFeedGroup(feedBot, targetId, upstreamJson.chatId);
+              upstreamJson.feedGroupId = targetId;
+              upstreamJson.feedGroupName = newFeedGroupName || undefined;
+            } catch (error) {
+              upstreamJson.feedGroupError = error instanceof Error ? error.message : String(error);
+            }
+          }
+        }
       }
       if (upstream.ok && upstreamJson?.ok) groupsMatrixSnapshot.invalidate();
       res.writeHead(upstream.status, { 'content-type': 'application/json' });
@@ -5173,6 +5250,7 @@ const server = createServer(async (req, res) => {
       let parsed: {
         content?: unknown; larkAppIds?: unknown; mode?: unknown; column?: unknown;
         leadLarkAppId?: unknown; name?: unknown; bindWorkingDir?: unknown; images?: unknown;
+        feedGroupId?: unknown; newFeedGroupName?: unknown; feedGroupAppId?: unknown;
       };
       try {
         const chunks: Buffer[] = [];
@@ -5250,12 +5328,30 @@ const server = createServer(async (req, res) => {
       }
       const chatId: string = groupResp.chatId;
       const invalidBotIds: string[] = Array.isArray(groupResp.invalidBotIds) ? groupResp.invalidBotIds : [];
+      const existingFeedGroupId = typeof parsed.feedGroupId === 'string' ? parsed.feedGroupId.trim() : '';
+      const newFeedGroupName = typeof parsed.newFeedGroupName === 'string' ? parsed.newFeedGroupName.trim() : '';
+      let feedGroupId = '';
+      let feedGroupError = '';
+      if (existingFeedGroupId || newFeedGroupName) {
+        const feedGroupAppId = typeof parsed.feedGroupAppId === 'string' ? parsed.feedGroupAppId.trim() : '';
+        const feedBot = loadBotConfigs().find(bot => bot.larkAppId === feedGroupAppId && !bot.apiOnly);
+        if (!feedBot) {
+          feedGroupError = '读取标签所用的机器人当前不可用。';
+        } else {
+          try {
+            feedGroupId = existingFeedGroupId || await createFeedGroup(feedBot, newFeedGroupName);
+            await addChatToFeedGroup(feedBot, feedGroupId, chatId);
+          } catch (error) {
+            feedGroupError = error instanceof Error ? error.message : String(error);
+          }
+        }
+      }
 
       // spawn 目标：lead 模式只有 lead；一起开工是所有成功入群的选中 bot。
       const joinedIds = selectedIds.filter(id => !invalidBotIds.includes(id) && !!registry.getByAppId(id));
       const targets = selectCreateSessionTargets(mode, joinedIds, creatorLarkAppId);
       if (targets.length === 0) {
-        return jsonRes(res, 200, { ok: true, chatId, shareLink: groupResp.shareLink, spawned: [], failed: [], warning: 'no_spawn_target' });
+        return jsonRes(res, 200, { ok: true, chatId, shareLink: groupResp.shareLink, spawned: [], failed: [], warning: 'no_spawn_target', feedGroupId, feedGroupError });
       }
 
       const bots = liveBots();
@@ -5286,7 +5382,7 @@ const server = createServer(async (req, res) => {
       }));
 
       return jsonRes(res, 200, {
-        ok: true, chatId, shareLink: groupResp.shareLink, mode, column, spawned, failed,
+        ok: true, chatId, shareLink: groupResp.shareLink, mode, column, spawned, failed, feedGroupId, feedGroupError,
       });
     }
 
@@ -5341,6 +5437,41 @@ const server = createServer(async (req, res) => {
     logger.error('[dashboard] handler error', err);
     if (!res.headersSent) jsonRes(res, 500, { error: String(err) });
   }
+});
+
+// OAuth loopback callback for browsers running on the same machine as BotMux.
+// Remote-browser deployments cannot reach this loopback listener; their
+// Dashboard keeps the manual callback-URL paste flow as a fallback.
+const oauthCallbackServer = createServer(async (req, res) => {
+  const url = new URL(req.url ?? '/', 'http://127.0.0.1:9768');
+  if (req.method !== 'GET' || url.pathname !== '/callback') {
+    res.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
+    return res.end('Not found');
+  }
+  let ok = false;
+  try {
+    const message = await handleCallbackUrl(url.toString());
+    ok = typeof message === 'string' && message.startsWith('✅');
+  } catch (error) {
+    logger.warn(`[dashboard] OAuth loopback callback failed: ${(error as Error).message}`);
+  }
+  res.writeHead(ok ? 200 : 400, {
+    'content-type': 'text/html; charset=utf-8',
+    'cache-control': 'no-store',
+  });
+  return res.end(`<!doctype html><meta charset="utf-8"><title>${ok ? '授权成功' : '授权失败'}</title><style>body{font-family:system-ui,sans-serif;max-width:560px;margin:80px auto;padding:24px;color:#111827}h1{font-size:28px}</style><h1>${ok ? '授权成功' : '授权失败'}</h1><p>${ok ? 'BotMux 已完成授权。你可以关闭此页面并返回 Dashboard。' : '授权链接无效或已过期。请返回 Dashboard 后重新发起授权。'}</p>`);
+});
+
+oauthCallbackServer.on('error', error => {
+  const code = (error as NodeJS.ErrnoException).code;
+  if (code === 'EADDRINUSE') {
+    logger.warn('[dashboard] OAuth loopback port 127.0.0.1:9768 is already in use; remote/manual callback fallback remains available');
+  } else {
+    logger.warn(`[dashboard] OAuth loopback server error: ${(error as Error).message}`);
+  }
+});
+oauthCallbackServer.listen(9768, '127.0.0.1', () => {
+  logger.info('[dashboard] OAuth loopback callback listening on 127.0.0.1:9768');
 });
 
 // Web terminal WebSocket reverse-proxy: bridge `/s/*` upgrade requests through to
@@ -5654,6 +5785,7 @@ function shutdown(): void {
   resourceMonitor.stop();
   platformTunnel?.stop();
   debugTerminalManager.shutdown();
+  if (oauthCallbackServer.listening) oauthCallbackServer.close();
   server.close(() => process.exit(gracefulProcessExitCode()));
   // Hard-exit fallback after 5s
   setTimeout(() => process.exit(gracefulProcessExitCode()), 5_000).unref();

--- a/src/dashboard/feed-groups.ts
+++ b/src/dashboard/feed-groups.ts
@@ -1,0 +1,106 @@
+import type { BotConfig } from '../bot-registry.js';
+import { larkHosts, normalizeBrand } from '../im/lark/lark-hosts.js';
+import { resolveUserToken } from '../utils/user-token.js';
+
+export const FEED_GROUP_SCOPES = ['im:feed_group_v1:read', 'im:feed_group_v1:write'] as const;
+
+export interface FeedGroup {
+  groupId: string;
+  name: string;
+  type: string;
+}
+
+export class FeedGroupApiError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly status = 502,
+  ) {
+    super(message);
+  }
+}
+
+type ApiEnvelope = {
+  code?: number;
+  msg?: string;
+  data?: Record<string, unknown>;
+};
+
+async function userApi(
+  bot: Pick<BotConfig, 'larkAppId' | 'larkAppSecret' | 'brand'>,
+  path: string,
+  init: RequestInit,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Record<string, unknown>> {
+  const brand = normalizeBrand(bot.brand);
+  const token = await resolveUserToken(bot.larkAppId, bot.larkAppSecret, brand);
+  if (!token) throw new FeedGroupApiError('尚未获得飞书标签权限，请点击「立即授权」按钮进行授权。', 'user_login_required', 401);
+  const response = await fetchImpl(`${larkHosts(brand).openApi}${path}`, {
+    ...init,
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json; charset=utf-8',
+      ...init.headers,
+    },
+  });
+  const envelope = await response.json().catch(() => ({})) as ApiEnvelope;
+  if (!response.ok || (typeof envelope.code === 'number' && envelope.code !== 0)) {
+    const code = envelope.code ? `feishu_${envelope.code}` : `http_${response.status}`;
+    throw new FeedGroupApiError(envelope.msg || `飞书标签接口请求失败（${code}）`, code, response.status || 502);
+  }
+  return (envelope.data ?? envelope) as Record<string, unknown>;
+}
+
+/** List all live native Feishu/Lark conversation labels for the authorized user. */
+export async function listFeedGroups(
+  bot: Pick<BotConfig, 'larkAppId' | 'larkAppSecret' | 'brand'>,
+  fetchImpl: typeof fetch = fetch,
+): Promise<FeedGroup[]> {
+  const groups: FeedGroup[] = [];
+  let pageToken = '';
+  for (let page = 0; page < 20; page++) {
+    const query = new URLSearchParams({ page_size: '50', page_token: pageToken });
+    const data = await userApi(bot, `/open-apis/im/v1/groups?${query}`, { method: 'GET' }, fetchImpl);
+    for (const raw of Array.isArray(data.groups) ? data.groups : []) {
+      if (!raw || typeof raw !== 'object') continue;
+      const item = raw as Record<string, unknown>;
+      if (typeof item.group_id !== 'string' || typeof item.name !== 'string') continue;
+      groups.push({ groupId: item.group_id, name: item.name, type: String(item.type ?? 'normal') });
+    }
+    if (data.has_more !== true || typeof data.page_token !== 'string' || !data.page_token) break;
+    pageToken = data.page_token;
+  }
+  return groups;
+}
+
+export async function createFeedGroup(
+  bot: Pick<BotConfig, 'larkAppId' | 'larkAppSecret' | 'brand'>,
+  name: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<string> {
+  const data = await userApi(bot, '/open-apis/im/v1/groups', {
+    method: 'POST',
+    body: JSON.stringify({ feed_group_creator: { type: 'normal', name } }),
+  }, fetchImpl);
+  if (typeof data.group_id !== 'string' || !data.group_id) {
+    throw new FeedGroupApiError('飞书创建标签成功，但响应中缺少标签 ID。', 'missing_group_id');
+  }
+  return data.group_id;
+}
+
+export async function addChatToFeedGroup(
+  bot: Pick<BotConfig, 'larkAppId' | 'larkAppSecret' | 'brand'>,
+  feedGroupId: string,
+  chatId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  const data = await userApi(bot, `/open-apis/im/v1/groups/${encodeURIComponent(feedGroupId)}/batch_add_item`, {
+    method: 'POST',
+    body: JSON.stringify({ items: [{ feed_id: chatId, feed_type: 'chat' }] }),
+  }, fetchImpl);
+  const failures = Array.isArray(data.failed_items) ? data.failed_items : [];
+  if (failures.length > 0) {
+    const first = failures[0] as Record<string, unknown>;
+    throw new FeedGroupApiError(String(first.error_message ?? '飞书未能把群聊加入标签。'), 'feed_group_add_failed');
+  }
+}

--- a/src/dashboard/web/groups-page.tsx
+++ b/src/dashboard/web/groups-page.tsx
@@ -63,6 +63,7 @@ type DialogState =
   | { type: 'manage'; chat: GroupChat };
 
 type DialogErrorState = { title: string; reason: unknown };
+type FeedGroupOption = { groupId: string; name: string; type: string };
 
 function emptyRoleContext(): RoleProfileContext {
   return {
@@ -304,6 +305,86 @@ function CreateDialog(props: {
   const [success, setSuccess] = useState<any | null>(null);
   const [copied, setCopied] = useState(false);
   const [roleProfileId, setRoleProfileId] = useState('');
+  const [feedGroups, setFeedGroups] = useState<FeedGroupOption[]>([]);
+  const [feedGroupAppId, setFeedGroupAppId] = useState('');
+  const [feedGroupId, setFeedGroupId] = useState('');
+  const [newFeedGroupName, setNewFeedGroupName] = useState('');
+  const [feedGroupsLoading, setFeedGroupsLoading] = useState(true);
+  const [feedGroupsError, setFeedGroupsError] = useState('');
+  const [feedGroupAuthSubmitting, setFeedGroupAuthSubmitting] = useState(false);
+  const [feedGroupAuthUrl, setFeedGroupAuthUrl] = useState('');
+  const [feedGroupCallbackUrl, setFeedGroupCallbackUrl] = useState('');
+
+  useEffect(() => {
+    let alive = true;
+    void fetch('/api/feed-groups')
+      .then(async response => {
+        const body = await response.json().catch(() => ({}));
+        if (!response.ok || !body.ok) throw new Error(body.message ?? body.error ?? `HTTP ${response.status}`);
+        if (!alive) return;
+        setFeedGroups(Array.isArray(body.groups) ? body.groups : []);
+        setFeedGroupAppId(typeof body.larkAppId === 'string' ? body.larkAppId : '');
+      })
+      .catch(error => { if (alive) setFeedGroupsError(error instanceof Error ? error.message : String(error)); })
+      .finally(() => { if (alive) setFeedGroupsLoading(false); });
+    return () => { alive = false; };
+  }, []);
+
+  useEffect(() => {
+    if (!feedGroupAuthUrl) return;
+    let alive = true;
+    const timer = window.setInterval(() => {
+      void fetch('/api/feed-groups')
+        .then(async response => {
+          const body = await response.json().catch(() => ({}));
+          if (!response.ok || !body.ok || !alive) return;
+          setFeedGroups(Array.isArray(body.groups) ? body.groups : []);
+          setFeedGroupAppId(typeof body.larkAppId === 'string' ? body.larkAppId : '');
+          setFeedGroupsError('');
+          setFeedGroupAuthUrl('');
+          setFeedGroupCallbackUrl('');
+        })
+        .catch(() => { /* remote/manual fallback remains visible */ });
+    }, 1_000);
+    return () => { alive = false; window.clearInterval(timer); };
+  }, [feedGroupAuthUrl]);
+
+  async function openFeedGroupLogin(): Promise<void> {
+    const query = feedGroupAppId ? `?larkAppId=${encodeURIComponent(feedGroupAppId)}` : '';
+    const response = await fetch(`/api/feed-groups/auth-url${query}`);
+    const body = await response.json().catch(() => ({}));
+    if (!response.ok || !body.authUrl) {
+      setError({ title: '无法发起标签授权', reason: body.error ?? `HTTP ${response.status}` });
+      return;
+    }
+    setFeedGroupAuthUrl(String(body.authUrl));
+    setFeedGroupCallbackUrl('');
+  }
+
+  async function completeFeedGroupLogin(callbackUrl: string): Promise<void> {
+    setFeedGroupAuthSubmitting(true);
+    try {
+      const response = await fetch('/api/feed-groups/oauth-callback', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ callbackUrl: callbackUrl.trim() }),
+      });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok || !body.ok) throw new Error(body.message ?? body.error ?? `HTTP ${response.status}`);
+      const groupsResponse = await fetch('/api/feed-groups');
+      const groupsBody = await groupsResponse.json().catch(() => ({}));
+      if (!groupsResponse.ok || !groupsBody.ok) throw new Error(groupsBody.message ?? groupsBody.error ?? `HTTP ${groupsResponse.status}`);
+      setFeedGroups(Array.isArray(groupsBody.groups) ? groupsBody.groups : []);
+      setFeedGroupAppId(typeof groupsBody.larkAppId === 'string' ? groupsBody.larkAppId : '');
+      setFeedGroupsError('');
+      setFeedGroupAuthUrl('');
+      setFeedGroupCallbackUrl('');
+    } catch (error) {
+      setError({ title: '标签授权失败', reason: error instanceof Error ? error.message : String(error) });
+    } finally {
+      setFeedGroupAuthSubmitting(false);
+    }
+  }
 
   async function submit(ev: FormEvent<HTMLFormElement>): Promise<void> {
     ev.preventDefault();
@@ -328,6 +409,9 @@ function CreateDialog(props: {
           larkAppIds: ids,
           bindWorkingDir: bindWorkingDir || undefined,
           roleProfileId: roleProfileId || undefined,
+          feedGroupId: feedGroupId || undefined,
+          newFeedGroupName: newFeedGroupName || undefined,
+          feedGroupAppId: (feedGroupId || newFeedGroupName) ? feedGroupAppId : undefined,
         }),
       });
       const respBody = await r.json().catch(() => ({ ok: false, error: `HTTP ${r.status}` }));
@@ -380,6 +464,8 @@ function CreateDialog(props: {
           </button>
         </p>
         <p><b>创建者:</b> <code>{String(success.creator ?? '?')}</code></p>
+        {success.feedGroupId ? <p className="hint-ok">已加入飞书标签{success.feedGroupName ? `「${String(success.feedGroupName)}」` : ''}。</p> : null}
+        {success.feedGroupError ? <p className="hint-warn">群聊已创建，但标签设置失败：{String(success.feedGroupError)}</p> : null}
         <CreateInviteNote resp={success} />
         {binds.length > 0 ? (
           bindFailed.length === 0 ? (
@@ -450,7 +536,66 @@ function CreateDialog(props: {
             />
             <small>{tr('groups.roleProfileHelp')}</small>
           </fieldset>
+          <fieldset className="g-modal-field g-feed-group-field">
+            <legend>飞书标签（可选）</legend>
+            <input type="hidden" name="feedGroupId" value={feedGroupId} />
+            <DropdownMenu
+              className="g-profile-menu"
+              ariaLabel="飞书标签"
+              label={feedGroupId ? (feedGroups.find(group => group.groupId === feedGroupId)?.name ?? feedGroupId) : '点击选择已有标签（可选）'}
+              value={feedGroupId}
+              options={[
+                { value: '', label: '暂不使用标签' },
+                ...feedGroups.map(group => ({ value: group.groupId, label: group.name })),
+              ]}
+              onChange={value => { setFeedGroupId(value); if (value) setNewFeedGroupName(''); }}
+            />
+            <div className="g-feed-group-new">
+              <span>或新建标签</span>
+              <input
+                type="text"
+                name="newFeedGroupName"
+                value={newFeedGroupName}
+                maxLength={60}
+                placeholder="输入新标签名称"
+                disabled={!!feedGroupId || feedGroupsLoading || !!feedGroupsError}
+                onChange={event => setNewFeedGroupName(event.currentTarget.value.trimStart())}
+              />
+            </div>
+            <small>点击上方下拉框可选择已有标签；不选择则不使用标签。</small>
+            {feedGroupsLoading ? <small>正在读取飞书标签…</small> : null}
+            {feedGroupsError ? (
+              <div className="hint-warn-inline">
+                <small>{feedGroupsError}</small>{' '}
+                <button type="button" disabled={feedGroupAuthSubmitting} onClick={() => void openFeedGroupLogin()}>
+                  {feedGroupAuthSubmitting ? '正在完成授权…' : '立即授权'}
+                </button>
+                <small> 授权后会弹窗提示你粘贴回调地址。</small>
+              </div>
+            ) : null}
+            {!feedGroupsLoading && !feedGroupsError && feedGroups.length === 0 ? <small>当前没有标签，可直接创建一个。</small> : null}
+          </fieldset>
         </div>
+
+        {feedGroupAuthUrl ? (
+          <div className="feed-group-auth-overlay">
+            <section className="feed-group-auth-card" role="dialog" aria-modal="true" aria-labelledby="feed-group-auth-title">
+              <h3 id="feed-group-auth-title">授权飞书标签</h3>
+              <p>点击下面的按钮，在飞书页面确认授权。如果 BotMux 与浏览器在同一台电脑，确认后会自动完成授权。如果 BotMux 运行在远程虚拟机上，浏览器会因无法访问本机地址 <code>127.0.0.1:9768</code> 而显示“无法访问”；此时请复制地址栏中的完整链接并粘贴到下方。</p>
+              <button type="button" className="primary feed-group-auth-open" onClick={() => window.open(feedGroupAuthUrl, '_blank', 'noopener')}>跳转飞书授权</button>
+              <label>
+                <span>请把点击授权后的完整链接粘贴在这里</span>
+                <input type="url" value={feedGroupCallbackUrl} placeholder="http://127.0.0.1:9768/callback?code=…&state=…" onChange={event => setFeedGroupCallbackUrl(event.currentTarget.value)} />
+              </label>
+              <div className="actions">
+                <button type="button" onClick={() => { setFeedGroupAuthUrl(''); setFeedGroupCallbackUrl(''); }}>取消</button>
+                <button type="button" className="primary" disabled={!feedGroupCallbackUrl.trim() || feedGroupAuthSubmitting} onClick={() => void completeFeedGroupLogin(feedGroupCallbackUrl)}>
+                  {feedGroupAuthSubmitting ? '正在完成授权…' : '完成授权'}
+                </button>
+              </div>
+            </section>
+          </div>
+        ) : null}
 
         <div className="g-create-status" data-create-status aria-live="polite">{error ? <DialogError {...error} /> : null}</div>
         <div className="actions g-create-actions">

--- a/src/dashboard/web/sessions-page.tsx
+++ b/src/dashboard/web/sessions-page.tsx
@@ -1973,6 +1973,15 @@ function CreateSessionDialog(props: {
   const [botQuery, setBotQuery] = useState('');
   const [keepOpen, setKeepOpen] = useState(() => readStoredCreateKeepOpen(windowStorage()));
   const [keptSuccess, setKeptSuccess] = useState<any>(null);
+  const [feedGroups, setFeedGroups] = useState<Array<{ groupId: string; name: string }>>([]);
+  const [feedGroupAppId, setFeedGroupAppId] = useState('');
+  const [feedGroupId, setFeedGroupId] = useState('');
+  const [newFeedGroupName, setNewFeedGroupName] = useState('');
+  const [feedGroupError, setFeedGroupError] = useState('');
+  const [feedGroupLoading, setFeedGroupLoading] = useState(false);
+  const [feedGroupAuthSubmitting, setFeedGroupAuthSubmitting] = useState(false);
+  const [feedGroupAuthUrl, setFeedGroupAuthUrl] = useState('');
+  const [feedGroupCallbackUrl, setFeedGroupCallbackUrl] = useState('');
   const [mentionTrigger, setMentionTrigger] = useState<MentionTrigger | null>(null);
   const [mentionIndex, setMentionIndex] = useState(0);
   const contentRef = useRef<HTMLTextAreaElement>(null);
@@ -1992,10 +2001,89 @@ function CreateSessionDialog(props: {
     setSubmitting(false);
     setBotQuery('');
     setKeptSuccess(null);
+    setFeedGroupId('');
+    setNewFeedGroupName('');
+    setFeedGroupError('');
+    setFeedGroupAuthUrl('');
+    setFeedGroupCallbackUrl('');
     setMentionTrigger(null);
     setMentionIndex(0);
     nextImageOrdinalRef.current = 1;
   }, [state]);
+
+  useEffect(() => {
+    if (!feedGroupAuthUrl) return;
+    let alive = true;
+    const timer = window.setInterval(() => {
+      void fetch('/api/feed-groups')
+        .then(async response => {
+          const body = await response.json().catch(() => ({}));
+          if (!response.ok || !body.ok || !alive) return;
+          setFeedGroups(Array.isArray(body.groups) ? body.groups : []);
+          setFeedGroupAppId(typeof body.larkAppId === 'string' ? body.larkAppId : '');
+          setFeedGroupError('');
+          setFeedGroupAuthUrl('');
+          setFeedGroupCallbackUrl('');
+        })
+        .catch(() => { /* remote/manual fallback remains visible */ });
+    }, 1_000);
+    return () => { alive = false; window.clearInterval(timer); };
+  }, [feedGroupAuthUrl]);
+
+  useEffect(() => {
+    if (!state || state.loading || state.success) return;
+    let alive = true;
+    setFeedGroupLoading(true);
+    void fetch('/api/feed-groups')
+      .then(async response => {
+        const body = await response.json().catch(() => ({}));
+        if (!response.ok || !body.ok) throw new Error(body.message ?? body.error ?? `HTTP ${response.status}`);
+        if (!alive) return;
+        setFeedGroups(Array.isArray(body.groups) ? body.groups : []);
+        setFeedGroupAppId(typeof body.larkAppId === 'string' ? body.larkAppId : '');
+        setFeedGroupError('');
+      })
+      .catch(error => { if (alive) setFeedGroupError(error instanceof Error ? error.message : String(error)); })
+      .finally(() => { if (alive) setFeedGroupLoading(false); });
+    return () => { alive = false; };
+  }, [state]);
+
+  const openFeedGroupLogin = async (): Promise<void> => {
+    const query = feedGroupAppId ? `?larkAppId=${encodeURIComponent(feedGroupAppId)}` : '';
+    const response = await fetch(`/api/feed-groups/auth-url${query}`);
+    const body = await response.json().catch(() => ({}));
+    if (!response.ok || !body.authUrl) {
+      alert(body.error ?? `HTTP ${response.status}`);
+      return;
+    }
+    setFeedGroupAuthUrl(String(body.authUrl));
+    setFeedGroupCallbackUrl('');
+  };
+
+  const completeFeedGroupLogin = async (callbackUrl: string): Promise<void> => {
+    setFeedGroupAuthSubmitting(true);
+    try {
+      const response = await fetch('/api/feed-groups/oauth-callback', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ callbackUrl: callbackUrl.trim() }),
+      });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok || !body.ok) throw new Error(body.message ?? body.error ?? `HTTP ${response.status}`);
+      const groupsResponse = await fetch('/api/feed-groups');
+      const groupsBody = await groupsResponse.json().catch(() => ({}));
+      if (!groupsResponse.ok || !groupsBody.ok) throw new Error(groupsBody.message ?? groupsBody.error ?? `HTTP ${groupsResponse.status}`);
+      setFeedGroups(Array.isArray(groupsBody.groups) ? groupsBody.groups : []);
+      setFeedGroupAppId(typeof groupsBody.larkAppId === 'string' ? groupsBody.larkAppId : '');
+      setFeedGroupError('');
+      setFeedGroupAuthUrl('');
+      setFeedGroupCallbackUrl('');
+    } catch (error) {
+      alert(error instanceof Error ? error.message : String(error));
+    } finally {
+      setFeedGroupAuthSubmitting(false);
+    }
+  };
 
   if (!state) return null;
   if (state.success) {
@@ -2156,6 +2244,9 @@ function CreateSessionDialog(props: {
           leadLarkAppId: mode === 'lead' ? leadLarkAppId : undefined,
           name: name.trim() || undefined,
           bindWorkingDir: bindWorkingDir.trim() || undefined,
+          feedGroupId: feedGroupId || undefined,
+          newFeedGroupName: newFeedGroupName.trim() || undefined,
+          feedGroupAppId: (feedGroupId || newFeedGroupName.trim()) ? feedGroupAppId : undefined,
           images: images.map(image => ({
             name: image.name,
             mimeType: image.mimeType,
@@ -2317,6 +2408,25 @@ function CreateSessionDialog(props: {
           <label><input type="radio" name="mode" value="all" checked={mode === 'all'} onChange={() => setMode('all')} /> {t('sessions.create.modeAll')}</label>
           <small>{t('sessions.create.modeHelp')}</small>
         </fieldset>
+        {feedGroupAuthUrl ? (
+          <div className="feed-group-auth-overlay">
+            <section className="feed-group-auth-card" role="dialog" aria-modal="true" aria-labelledby="session-feed-group-auth-title">
+              <h3 id="session-feed-group-auth-title">授权飞书标签</h3>
+              <p>点击下面的按钮，在飞书页面确认授权。如果 BotMux 与浏览器在同一台电脑，确认后会自动完成授权。如果 BotMux 运行在远程虚拟机上，浏览器会因无法访问本机地址 <code>127.0.0.1:9768</code> 而显示“无法访问”；此时请复制地址栏中的完整链接并粘贴到下方。</p>
+              <button type="button" className="primary feed-group-auth-open" onClick={() => window.open(feedGroupAuthUrl, '_blank', 'noopener')}>跳转飞书授权</button>
+              <label>
+                <span>请把点击授权后的完整链接粘贴在这里</span>
+                <input type="url" value={feedGroupCallbackUrl} placeholder="http://127.0.0.1:9768/callback?code=…&state=…" onChange={event => setFeedGroupCallbackUrl(event.currentTarget.value)} />
+              </label>
+              <div className="actions">
+                <button type="button" onClick={() => { setFeedGroupAuthUrl(''); setFeedGroupCallbackUrl(''); }}>取消</button>
+                <button type="button" className="primary" disabled={!feedGroupCallbackUrl.trim() || feedGroupAuthSubmitting} onClick={() => void completeFeedGroupLogin(feedGroupCallbackUrl)}>
+                  {feedGroupAuthSubmitting ? '正在完成授权…' : '完成授权'}
+                </button>
+              </div>
+            </section>
+          </div>
+        ) : null}
         <fieldset className="cs-lead-row" hidden={mode !== 'lead'}>
           <legend>{t('sessions.create.lead')}</legend>
           <select name="lead" disabled={leadOptions.length === 0} value={leadOptions.includes(lead) ? lead : ''} onChange={event => setLead(event.currentTarget.value)}>
@@ -2351,6 +2461,36 @@ function CreateSessionDialog(props: {
               <span>{t('sessions.create.groupName')}</span>
               <input className="cs-pill-input" type="text" name="name" maxLength={60} placeholder={t('sessions.create.groupNamePlaceholder')} value={name} onChange={event => setName(event.currentTarget.value)} />
             </label>
+            <fieldset className="cs-feed-group">
+              <legend>飞书标签（可选）</legend>
+              <select
+                value={feedGroupId}
+                disabled={feedGroupLoading || !!feedGroupError}
+                onChange={event => { setFeedGroupId(event.currentTarget.value); if (event.currentTarget.value) setNewFeedGroupName(''); }}
+              >
+                <option value="">点击选择已有标签（可选）</option>
+                {feedGroups.map(group => <option key={group.groupId} value={group.groupId}>{group.name}</option>)}
+              </select>
+              <input
+                type="text"
+                value={newFeedGroupName}
+                maxLength={60}
+                placeholder="或输入新标签名称"
+                disabled={!!feedGroupId || feedGroupLoading || !!feedGroupError}
+                onChange={event => setNewFeedGroupName(event.currentTarget.value.trimStart())}
+              />
+              <small>点击下拉框可选择已有标签，将新建群聊归入该标签；也可以输入名称创建新标签。</small>
+              {feedGroupLoading ? <small>正在读取飞书标签…</small> : null}
+              {feedGroupError ? (
+                <div className="cs-warn">
+                  <small>{feedGroupError}</small>{' '}
+                  <button type="button" disabled={feedGroupAuthSubmitting} onClick={() => void openFeedGroupLogin()}>
+                    {feedGroupAuthSubmitting ? '正在完成授权…' : '立即授权'}
+                  </button>
+                  <small> 授权后会弹窗提示你粘贴回调地址。</small>
+                </div>
+              ) : null}
+            </fieldset>
             <label className="cs-advanced-field">
               <span>{t('sessions.create.workingDir')}</span>
               <input className="cs-pill-input" type="text" name="bindWorkingDir" placeholder="e.g. ~/projects/foo" value={bindWorkingDir} onChange={event => setBindWorkingDir(event.currentTarget.value)} />

--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -4363,6 +4363,18 @@ td code,
   justify-content: flex-start;
 }
 
+#g-drawer.groups-create-modal .g-feed-group-new {
+  display: grid;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+#g-drawer.groups-create-modal .g-feed-group-new > span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
 #g-drawer.groups-create-modal .g-create-status:empty {
   display: none;
 }
@@ -25825,4 +25837,59 @@ button.ui-refresh-button.is-loading .ui-action-icon {
 .schedule-delete-button {
   color: var(--danger, #e5484d) !important;
   border-color: color-mix(in srgb, var(--danger, #e5484d) 48%, var(--border-soft)) !important;
+}
+.feed-group-auth-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  background: rgb(15 23 42 / 62%);
+}
+
+.feed-group-auth-card {
+  width: min(520px, 100%);
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--panel, #fff);
+  color: #111827;
+  box-shadow: 0 24px 70px rgb(0 0 0 / 28%);
+}
+
+.feed-group-auth-card h3 { margin-top: 0; }
+.feed-group-auth-card p,
+.feed-group-auth-card label,
+.feed-group-auth-card label span { color: #111827; }
+.feed-group-auth-card label { display: grid; gap: 8px; margin-top: 18px; }
+.feed-group-auth-card input { width: 100%; box-sizing: border-box; color: #111827; background: #fff; }
+.feed-group-auth-card input::placeholder { color: #4b5563; opacity: 1; }
+.feed-group-auth-card .actions { margin-top: 20px; justify-content: flex-end; }
+.feed-group-auth-open {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  margin-top: 4px;
+  padding: 0 20px;
+  border: 1px solid #2563eb;
+  border-radius: 8px;
+  color: #fff;
+  background: #2563eb;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.feed-group-auth-open:hover { background: #1d4ed8; }
+
+.cs-advanced-fields .cs-feed-group {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.cs-advanced-fields .cs-feed-group > legend {
+  padding: 0;
 }

--- a/src/setup/lark-scopes.json
+++ b/src/setup/lark-scopes.json
@@ -255,6 +255,8 @@
       "im:chat:moderation:write_only",
       "im:chat:read",
       "im:chat:update",
+      "im:feed_group_v1:read",
+      "im:feed_group_v1:write",
       "im:message",
       "im:message.pins:read",
       "im:message.pins:write_only",

--- a/src/setup/verify-permissions.ts
+++ b/src/setup/verify-permissions.ts
@@ -84,6 +84,12 @@ export const BOTMUX_REQUIRED_SCOPES: RequiredScope[] = [
   // 自检 DM 打扰；只有当同时缺别的 critical 项时才顺带在提示里列出。开了功能却缺它 →
   // bot 开的新话题收不到事件、自动开工静默不触发（预期降级，非崩溃）。
   { name: 'im:message.group_msg.include_bot:read', desc: '接收群聊中所有用户和其他机器人发送的消息（「其他机器人开的新话题也自动开工」需要）', critical: false },
+  // Dashboard 建群/创建会话的原生飞书标签功能。标签 API 只接受用户身份，
+  // 这里检测的是应用是否已经声明对应 user scope；真正使用时仍需用户做一次 OAuth。
+  // 标 non-critical：不用标签的部署不应因它阻塞 daemon 启动；有缓存的开放平台
+  // Web session 时，event-dispatcher 会在启动阶段静默补权限并发布新版本。
+  { name: 'im:feed_group_v1:read', desc: '读取飞书会话标签（Dashboard 建群分类）', critical: false },
+  { name: 'im:feed_group_v1:write', desc: '创建飞书会话标签并将新群加入标签', critical: false },
   { name: 'application:application:self_manage', desc: '应用自查 (免审批)', critical: false },
 ];
 

--- a/src/utils/user-token.ts
+++ b/src/utils/user-token.ts
@@ -245,8 +245,6 @@ const DEFAULT_PORT = 9768;
 const DEFAULT_SCOPES = [
   'im:message:readonly',
   'im:resource',
-  'im:feed_group_v1:read',
-  'im:feed_group_v1:write',
   'offline_access',
 ].join(' ');
 

--- a/src/utils/user-token.ts
+++ b/src/utils/user-token.ts
@@ -8,7 +8,7 @@
  * OAuth login via /login command writes to botmux's own token file.
  * Auto-refreshes expired access_token using refresh_token.
  */
-import { readFileSync, mkdirSync, existsSync } from 'node:fs';
+import { readFileSync, mkdirSync, existsSync, unlinkSync, readdirSync } from 'node:fs';
 import { atomicWriteFileSync } from './atomic-write.js';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
@@ -19,6 +19,7 @@ import { type Brand, larkHosts } from '../im/lark/lark-hosts.js';
 // ─── Token paths ──────────────────────────────────────────────────────────────
 
 const TOKEN_DIR = join(homedir(), '.botmux', 'data');
+const PENDING_DIR = join(TOKEN_DIR, 'oauth-pending');
 /** 旧版单文件（升级前都是单 feishu bot）。仅作向后兼容读取，不再写入。 */
 const LEGACY_TOKEN_PATH = join(TOKEN_DIR, 'user-token.json');
 const BUFFER_MS = 60_000; // 60s safety margin before expiry
@@ -72,6 +73,48 @@ interface PendingLogin {
 }
 
 const pendingLogins = new Map<string, PendingLogin>(); // keyed by state
+
+function pendingPath(state: string): string | null {
+  return /^[a-f0-9]{64}$/.test(state) ? join(PENDING_DIR, `${state}.json`) : null;
+}
+
+/** Persist pending OAuth state so Dashboard and daemon processes can finish
+ * each other's authorization flow. Files contain app credentials and are
+ * therefore always mode 0600 and removed immediately after consumption. */
+function savePendingLogin(pending: PendingLogin): void {
+  const path = pendingPath(pending.state);
+  if (!path) return;
+  mkdirSync(PENDING_DIR, { recursive: true, mode: 0o700 });
+  atomicWriteFileSync(path, JSON.stringify(pending), { mode: 0o600 });
+}
+
+function loadPendingLogin(state: string): PendingLogin | null {
+  const path = pendingPath(state);
+  if (!path) return null;
+  try {
+    const pending = JSON.parse(readFileSync(path, 'utf8')) as PendingLogin;
+    if (pending.state !== state || Date.now() - pending.createdAt > 5 * 60_000) return null;
+    return pending;
+  } catch {
+    return null;
+  }
+}
+
+function removePendingLogin(state: string): void {
+  const path = pendingPath(state);
+  if (!path) return;
+  try { unlinkSync(path); } catch { /* already absent */ }
+}
+
+function cleanupPendingLogins(): void {
+  try {
+    for (const name of readdirSync(PENDING_DIR)) {
+      const state = name.endsWith('.json') ? name.slice(0, -5) : '';
+      const pending = loadPendingLogin(state);
+      if (!pending) removePendingLogin(state);
+    }
+  } catch { /* directory absent */ }
+}
 
 // ─── Token I/O ────────────────────────────────────────────────────────────────
 
@@ -202,6 +245,8 @@ const DEFAULT_PORT = 9768;
 const DEFAULT_SCOPES = [
   'im:message:readonly',
   'im:resource',
+  'im:feed_group_v1:read',
+  'im:feed_group_v1:write',
   'offline_access',
 ].join(' ');
 
@@ -252,11 +297,13 @@ export function generateAuthUrl(appId: string, appSecret: string, brand: Brand =
     brand,
     createdAt: Date.now(),
   });
+  savePendingLogin(pendingLogins.get(state)!);
 
   // Clean up stale pending logins
   for (const [s, p] of pendingLogins) {
     if (Date.now() - p.createdAt > 5 * 60_000) pendingLogins.delete(s);
   }
+  cleanupPendingLogins();
 
   return { authUrl, state };
 }
@@ -274,12 +321,13 @@ export async function handleCallbackUrl(url: string): Promise<string | null> {
   const code = decodeURIComponent(match[1]);
   const state = decodeURIComponent(stateMatch[1]);
 
-  const pending = pendingLogins.get(state);
+  const pending = pendingLogins.get(state) ?? loadPendingLogin(state);
   if (!pending) {
     return '❌ 授权失败：state 不匹配或已过期，请重新执行 /login';
   }
 
   pendingLogins.delete(state);
+  removePendingLogin(state);
 
   // Exchange code for token
   try {

--- a/test/dashboard-feed-groups.test.ts
+++ b/test/dashboard-feed-groups.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/utils/user-token.js', () => ({
+  resolveUserToken: vi.fn(async () => 'u-test'),
+}));
+
+import { resolveUserToken } from '../src/utils/user-token.js';
+import { addChatToFeedGroup, createFeedGroup, FeedGroupApiError, listFeedGroups } from '../src/dashboard/feed-groups.js';
+
+const bot = { larkAppId: 'cli_test', larkAppSecret: 'secret', brand: 'feishu' as const };
+
+function response(data: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(data), { status, headers: { 'content-type': 'application/json' } });
+}
+
+describe('dashboard native Feishu feed groups', () => {
+  beforeEach(() => vi.mocked(resolveUserToken).mockResolvedValue('u-test'));
+
+  it('paginates and normalizes live labels', async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(response({ code: 0, data: { groups: [{ group_id: 'ofg_1', name: '工作', type: 'normal' }], has_more: true, page_token: 'next' } }))
+      .mockResolvedValueOnce(response({ code: 0, data: { groups: [{ group_id: 'ofg_2', name: '学习', type: 'normal' }], has_more: false, page_token: '' } }));
+
+    await expect(listFeedGroups(bot, fetcher)).resolves.toEqual([
+      { groupId: 'ofg_1', name: '工作', type: 'normal' },
+      { groupId: 'ofg_2', name: '学习', type: 'normal' },
+    ]);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(String(fetcher.mock.calls[1][0])).toContain('page_token=next');
+  });
+
+  it('creates a normal label then adds a chat', async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(response({ code: 0, data: { group_id: 'ofg_new' } }))
+      .mockResolvedValueOnce(response({ code: 0, data: { failed_items: [] } }));
+
+    const id = await createFeedGroup(bot, '项目', fetcher);
+    await addChatToFeedGroup(bot, id, 'oc_chat', fetcher);
+    expect(id).toBe('ofg_new');
+    expect(String(fetcher.mock.calls[1][0])).toContain('/groups/ofg_new/batch_add_item');
+    expect(JSON.parse(fetcher.mock.calls[1][1].body)).toEqual({ items: [{ feed_id: 'oc_chat', feed_type: 'chat' }] });
+  });
+
+  it('reports login-required without making an API request', async () => {
+    vi.mocked(resolveUserToken).mockResolvedValueOnce(null);
+    const fetcher = vi.fn();
+    await expect(listFeedGroups(bot, fetcher)).rejects.toMatchObject<Partial<FeedGroupApiError>>({ code: 'user_login_required', status: 401 });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('surfaces partial add failures', async () => {
+    const fetcher = vi.fn().mockResolvedValue(response({
+      code: 0,
+      data: { failed_items: [{ error_code: 240001, error_message: 'feed_id is invalid' }] },
+    }));
+    await expect(addChatToFeedGroup(bot, 'ofg_1', 'oc_bad', fetcher)).rejects.toMatchObject({
+      code: 'feed_group_add_failed',
+      message: 'feed_id is invalid',
+    });
+  });
+});

--- a/test/user-token-brand.test.ts
+++ b/test/user-token-brand.test.ts
@@ -27,4 +27,21 @@ describe('generateAuthUrl — brand-aware authorize host', () => {
     expect(authUrl).toContain('accounts.feishu.cn');
     expect(authUrl).not.toContain('larksuite.com');
   });
+
+  it('keeps feed-group scopes out of the generic login URL', () => {
+    const { authUrl } = generateAuthUrl('cli_app', 'secret', 'lark');
+    const scopes = new URL(authUrl).searchParams.get('scope')?.split(' ') ?? [];
+    expect(scopes).not.toContain('im:feed_group_v1:read');
+    expect(scopes).not.toContain('im:feed_group_v1:write');
+  });
+
+  it('includes feed-group scopes when the caller explicitly requests them', () => {
+    const { authUrl } = generateAuthUrl('cli_app', 'secret', 'feishu', [
+      'im:feed_group_v1:read',
+      'im:feed_group_v1:write',
+    ]);
+    const scopes = new URL(authUrl).searchParams.get('scope')?.split(' ') ?? [];
+    expect(scopes).toContain('im:feed_group_v1:read');
+    expect(scopes).toContain('im:feed_group_v1:write');
+  });
 });

--- a/test/user-token-cross-process.test.ts
+++ b/test/user-token-cross-process.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { unlinkSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+describe('user-token pending OAuth state', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    try { unlinkSync(join(homedir(), '.botmux', 'data', 'user-token-cli_cross_process.json')); } catch { /* absent */ }
+  });
+
+  it('can finish a Dashboard-created flow from a fresh daemon module instance', async () => {
+    const first = await import('../src/utils/user-token.js');
+    const { authUrl } = first.generateAuthUrl('cli_cross_process', 'secret', 'feishu', ['im:feed_group_v1:read']);
+    const authorize = new URL(authUrl);
+    const state = authorize.searchParams.get('state');
+    expect(state).toMatch(/^[a-f0-9]{64}$/);
+
+    vi.resetModules();
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      access_token: 'u-cross-process',
+      refresh_token: 'r-cross-process',
+      token_type: 'Bearer',
+      expires_in: 7200,
+      refresh_token_expires_in: 2_592_000,
+      scope: 'im:feed_group_v1:read offline_access',
+    }), { status: 200, headers: { 'content-type': 'application/json' } })));
+
+    const fresh = await import('../src/utils/user-token.js');
+    await expect(fresh.handleCallbackUrl(`http://127.0.0.1:9768/callback?code=test-code&state=${state}`))
+      .resolves.toContain('授权成功');
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- add native Feishu conversation-label listing, creation, and chat assignment
- expose label selection in Dashboard group/session creation, including optional new-label creation
- add user OAuth with automatic local loopback callback and remote-VM paste fallback
- persist OAuth pending state across Dashboard and daemon processes
- add required Feishu scopes and legacy-app permission top-up

## Verification

- `pnpm exec vitest run --project unit test/dashboard-feed-groups.test.ts test/user-token-cross-process.test.ts test/setup-verify-permissions.test.ts`
- `pnpm build`
- manually verified Dashboard authorization and existing/new label flows on a remote Devbox deployment
