### PR TITLE
feat(suspend): 会话正在产出回复时延迟挂起而非切断

### DIFF
--- a/docs/design/deferred-suspend.md
+++ b/docs/design/deferred-suspend.md
@@ -100,12 +100,17 @@ drain 并 ACK → daemon 等此前 `final_output` 的**实际投递完成** → 
 
 ### 决策 1：改默认行为，不加开关
 
-有了"延迟兑现"之后默认开启是站得住的 —— 没有会话被漏掉，只是晚几十秒到几分钟。
+有了"延迟兑现"之后默认开启是站得住的 —— **目标会话不会因为 busy 就被跳过**
+（claim 记下来，转 idle 必兑现），只是晚几十秒到几分钟。注意这说的是「挂起请求
+不丢」，不等于「回复不丢」：交付边界仍有一个已知窗口，见 §2。
 
-对凭证轮换而言，**延迟兑现严格优于现在的立即切断**：正在跑的那一轮本来就已经
+对凭证轮换而言，延迟兑现**通常优于**现在的立即切断：正在跑的那一轮本来就已经
 持有旧凭证，切断它并不能让那一轮用上新凭证，只是白白丢掉一次回复。
 两种做法对"该会话何时开始用新凭证"的结果相同（都是下一轮），
 区别只在于当前这一轮是完成还是被丢弃。
+
+**最坏情况下退化为与立即切断相同**：若这一轮的回复正好落进 §2 那个交付窗口，
+它同样会丢 —— 那时两种做法的结果一样，延迟兑现并不更差，但也不再更好。
 
 因此不加 `--defer-busy` 之类的开关，直接改默认。
 
@@ -164,16 +169,23 @@ function runPendingSuspendIfSettled(ds: DaemonSession, ownsGeneration?: () => bo
   const reason = ds.pendingSuspendReason;
   if (!reason) return;
   if (ownsGeneration && !ownsGeneration()) return;
-  const st = ds.lastScreenStatus;
-  if (st !== 'idle' && st !== 'limited') return;
-  // worker 已经没了（崩溃 / 被别的路径挂起）：目标态已达成，清标志即可。
-  if (!ds.worker || ds.worker.killed) {
-    ds.pendingSuspendReason = undefined;
+  // claim 属于排队时那一代；到了更晚的 generation 说明它自己的兑现点没跑到，
+  // 就地消费而不是挂起一个它从未指向过的 worker（兜底，正常由下面两处消费）。
+  if (ds.pendingSuspendGeneration !== undefined
+      && ds.workerGeneration !== undefined
+      && ds.pendingSuspendGeneration !== ds.workerGeneration) {
+    clearPendingSuspendClaim(ds, 'generation changed');
     return;
   }
-  // 只在成功时清标志（见下）。
+  const st = ds.lastScreenStatus;
+  if (st !== 'idle' && st !== 'limited') return;
+  // worker 已经没了（崩溃 / 被别的路径挂起）：目标态已达成，清 claim 即可。
+  if (!ds.worker || ds.worker.killed) {
+    clearPendingSuspendClaim(ds, 'worker already gone');
+    return;
+  }
+  // 成功时 claim 由 suspendWorker 内部的 clearPendingSuspendClaim 消费，这里只补一条可区分的日志。
   if (suspendWorker(ds, reason)) {
-    ds.pendingSuspendReason = undefined;
     logger.info(`[${tag(ds)}] Deferred suspend fulfilled (${reason}) after turn completed`);
     return;
   }
@@ -184,17 +196,21 @@ function runPendingSuspendIfSettled(ds: DaemonSession, ownsGeneration?: () => bo
 
 三个细节都是正确性要求，不是讲究：
 
-**`ownsGeneration` 必须传，否则会挂掉替换上来的新 worker** —— 但原因不是本文早先
-写的那条。它**不是**「旧 worker 的陈旧消息能进入 `screenshot_uploaded`」：message
-handler 的统一 fence（`if (ds.worker !== worker) return`）排在 switch **之前**，
-被替换 worker 的消息一条也进不来。
+**`ownsGeneration` 要传，但它是 defense-in-depth，不是防一个已证实可达的 race。**
+本文先后写过两版「具体 race」的论证，两版都不成立，为免第三次重蹈，把结论记在这里：
 
-真正的窗口是**延迟兑现本身**。调用方必须用 `queueMicrotask` 推迟（理由见下），
-于是 fence 是在**消息到达**时检查的，而挂起在**一个微任务之后**才执行。两条消息
-可以在同一 tick 内都合法通过 fence：第一条的微任务挂起了会话、随后 refork 装上新
-worker，第二条的微任务这时才运行，面对的是一个全新的 worker。没有这道判定就会把
-它挂掉 —— 新 worker 若正在产出，正是原样复现本功能要消灭的截断 bug。
-不属于当前 generation 的 checkpoint **保留标志直接返回**。
+- **不是**「旧 worker 的陈旧消息进入 `screenshot_uploaded`」：message handler 的统一
+  fence（`if (ds.worker !== worker) return`）排在 switch **之前**，被替换 worker 的
+  消息一条也进不来。
+- **也不是**「同一 tick 两条微任务，第一条挂起并 refork、第二条撞上新 worker」：
+  `suspendWorker` 只把 `ds.worker` 置 null，**它不 refork**（refork 由外部输入驱动，
+  属于之后的宏任务），而微任务队列连续 drain 期间宏任务插不进来。所以第二条微任务
+  面对的是 `ds.worker === null`，`ownsGeneration` 判假直接早退 —— 不是一个新 worker。
+
+它真正买到的是：排队的回调**只可能在自己那一代仍持有会话时执行**。消费 claim 是对
+一个存活 worker 的破坏性操作，即便今天没有可达的 race，也值得为将来的调用方、
+enqueue 与 drain 之间新增的同步副作用、以及任何比现在更早开始 refork 的路径留住
+这道门。不属于当前 generation 的 checkpoint **保留标志直接返回**。
 
 （不要改成给 `screenshot_uploaded` 加前置 `ownsLifecycleMutation()` break：那会改掉
 该 case 的既有行为，影响面不明。把判定传进兑现函数是最小且封闭的改法。）
@@ -362,7 +378,7 @@ CLI 本地的 session store 这些判据一个都没有，要按 daemon 拉一�
 | 会话状态为 `undefined` | 不排队，走原有立即挂起路径（`undefined` 不属于 working/analyzing） |
 | daemon 重启 | 排队丢失，下一周期重新排队（决策 4） |
 | 兑现时 bridge 队列还有未发的回复 | **仍可能丢** —— 交付边界是 best-effort，见 §2 的已知残留窗口 |
-| 排队期间会话 refork，旧 worker 的 `screenshot_uploaded(idle)` 晚到 | `ownsGeneration` 判定为假 → **保留标志、不挂新 worker**（§5.2a） |
+| 排队期间会话 refork | claim 绑定在排队那一代，`suspendWorker` 成功或 worker exit 时即被消费；漏网的到下一代由 generation 门控就地消费，**绝不挂新 worker**（§5.1 / §5.2a） |
 | 兑现时 `suspendWorker` 拒绝（routing transfer 中） | 保留标志，并注册 `deferUntilSessionTransferSettled` 重试 —— 不能只靠"下一个 checkpoint"，安静会话可能再也没有（§5.2a） |
 | dry-run 遇到正在 routing transfer 的会话 | **预告不准**：会报"将排队/将挂起"，实际是 409 `session_transferring`。`/api/sessions` 行不暴露该状态，已在代码注释标明（§5.4） |
 
@@ -417,15 +433,19 @@ flush 产物在 daemon 侧被 fence 确定性丢弃，它依然全绿。这是�
 
 ### 生产验证
 
-改动部署后（`pnpm build`；worker 是每次冷启动 fork `dist/worker.js`，所以 §5.5 的
-worker 侧改动 build 完即生效；而 `worker-pool.ts` / `dashboard-ipc-server.ts` 跑在
-daemon 进程里，**必须重启 daemon**）：
+改动部署后（`pnpm build`），本设计只涉及 daemon 侧（`src/worker.ts` 零 diff —— §5.5 的
+worker 侧 flush 已移除），daemon 重启即全部生效。
 
 1. 找一个正在生成回复的会话（`botmux list --plain` 里 status 为 online 且屏幕在动）
 2. `botmux suspend <sid>` → 应输出 `⏳ 已排队`
 3. 等该会话回复完成 → daemon 日志应出现 `Deferred suspend fulfilled`
 4. `botmux list` 确认该会话已变成 dormant
 5. 关键回归：确认那条回复**完整发到了飞书**，没有被截断
+
+> ⚠️ 第 5 步观察到"完整送达"只是**一个样本的观测结果**，并不证明 §2 那个交付边界
+> 窗口消失 —— 那个窗口要求 `final_output` 与 idle 落在同一轮事件循环，日常抽查大
+> 概率碰不上。判断它是否发生，看 daemon 日志里有没有
+> `Bridge final_output abandoned — worker/session ownership changed`。
 
 也可直接观察下一次 6 小时周期的 `suspend all` 输出，排队数应与当时的
 busy 会话数吻合（历史 `p99=4, max=5`）。

--- a/docs/design/deferred-suspend.md
+++ b/docs/design/deferred-suspend.md
@@ -33,7 +33,7 @@
 
 **目标**
 
-- 挂起请求不再切断正在产出的回复
+- 挂起请求不再切断**正在产出中**的回合 —— 等它产完再挂
 - 不漏掉任何会话 —— 语义从"立即挂起"变成"最终挂起"
 - 调用方能看到有多少被排队
 
@@ -43,6 +43,44 @@
 - 不改 `suspend` 之外的挂起路径（`idle-worker-sweeper` / `host_overload_sweep`
   本来就有 busy 守卫，无需改动）
 - 不引入新的配置项或环境变量
+- **不保证「一条回复都不丢」** —— 见下方「交付边界仍是 best-effort」
+
+### ⚠️ 交付边界仍是 best-effort（已知残留窗口）
+
+本设计解决的是「**回合还在产出时被一刀切断**」。它**没有**建立
+「回复交付完成 → 才撤销 worker ownership」这个 happens-before，因此
+idle 与交付的交界处仍有一个窗口会丢回复：
+
+1. worker 在 idle 路径先 drain bridge、依次 `process.send(final_output)`，再发 idle `screen_update`；
+2. daemon 收到 `final_output` 后**并不立即投递** —— `deliverFinalOutput()` 把真正的
+   `sessionReply` 放进 `setTimeout(...)`，同步返回；
+3. daemon 随后收到 idle，排一个 `queueMicrotask` 兑现挂起；
+4. **微任务先于 timer 执行**（JS 事件循环规范）：挂起先跑，同一同步栈里 `ds.worker = null`；
+5. `setTimeout` 的投递这才运行，首行 `isStillOwned()` 已为假 → 放弃投递，
+   日志留下 `Bridge final_output abandoned — worker/session ownership changed`。
+
+即使 worker→daemon 的 IPC 是 FIFO（`final_output` 先于 idle 到达），只要两者落在
+**同一轮事件循环**批量到达，这个顺序就是确定的，不是概率窗口。另外若本轮
+transcript terminal 在 idle 时尚未落盘，`stopBridgeWatcher()` 的 `clearPending()`
+会让答案同样消失。
+
+几点必须说清楚：
+
+- **这不是本设计引入的**。`idle-worker-sweeper` / `host_overload_sweep` 同样按
+  `lastScreenStatus === 'idle'` 挂起，窗口一直存在，只是它们跑在定时器上、有几秒
+  余量遮着。
+- **但本设计放大了它**：排队兑现把挂起时机从「定时器几秒后」拉到了「idle 的那一刻」，
+  正好贴着窗口边界。
+- **影响面**：只涉及靠 bridge 兜底投递的回合（模型自己调了 `botmux send` 的回合，
+  消息在挂起前早已发出，不受影响）。某台生产机器上这个比例约 4.3%
+  （`Bridge fallback suppressed` 3935 次 vs `kind=bridge` 175 次），
+  且该机器至今 `final_output abandoned` **0 次** —— 属于「理论真实、尚未观测」。
+
+彻底解法是做两阶段 barrier：先进 retiring（保留 ownership、禁止 refork）→ worker
+drain 并 ACK → daemon 等此前 `final_output` 的**实际投递完成** → 再 commit suspend、
+清 `ds.worker`；配一条把 `final_output + idle` 同批送入、断言 `sessionReply` 完成
+先于 ownership 撤销的行为测试。**这属于 ownership 生命周期的改动，比本设计大一个
+量级，留作后续单独的改动**，不在本设计范围内。
 
 ## 3. 机制
 
@@ -105,6 +143,12 @@
    *  （见 worker-pool.ts runPendingSuspendIfSettled）。仅存内存：daemon 重启即丢，
    *  下一个 `suspend all` 周期会重新排队，代价只是延后一个周期。 */
   pendingSuspendReason?: string;
+  /** 排队时那一代 worker 的 generation。claim 只针对「当时正在产出的那一代」，
+   *  绝不能活过它：该 generation 一旦被挂起（任何路径）或退出，目标态即达成、
+   *  claim 就地消费。否则兑现 checkpoint 没跑到的场景（worker 崩溃、或 `/cd` /
+   *  读隔离切换先挂起）会让标志活到下一代，在它第一次 idle 时把它平白挂掉。
+   *  见 worker-pool.ts clearPendingSuspendClaim。 */
+  pendingSuspendGeneration?: number;
 ```
 
 ### 5.2 `src/core/worker-pool.ts`
@@ -140,13 +184,17 @@ function runPendingSuspendIfSettled(ds: DaemonSession, ownsGeneration?: () => bo
 
 三个细节都是正确性要求，不是讲究：
 
-**`ownsGeneration` 必须传，否则会挂掉替换上来的新 worker。** `screenshot_uploaded`
-这个 case **没有** `ownsLifecycleMutation()` 守卫（`screen_update` 第一行就有），
-它今天就无门槛地写 `ds.lastScreenStatus`。把「写状态」升级成「杀 worker」之后：
-旧 worker 被 refork 替换 → 它退出前排队的 `screenshot_uploaded(idle)` 晚到 →
-覆写成 idle → 微任务看到 `pendingSuspendReason` 和**新 worker** 还活着 → 把刚起来的
-新 worker 挂了。新 worker 若正在产出，这就是原样复现本功能要消灭的截断 bug。
-陈旧的 checkpoint **保留标志直接返回** —— 只有当前 generation 有资格消费它。
+**`ownsGeneration` 必须传，否则会挂掉替换上来的新 worker** —— 但原因不是本文早先
+写的那条。它**不是**「旧 worker 的陈旧消息能进入 `screenshot_uploaded`」：message
+handler 的统一 fence（`if (ds.worker !== worker) return`）排在 switch **之前**，
+被替换 worker 的消息一条也进不来。
+
+真正的窗口是**延迟兑现本身**。调用方必须用 `queueMicrotask` 推迟（理由见下），
+于是 fence 是在**消息到达**时检查的，而挂起在**一个微任务之后**才执行。两条消息
+可以在同一 tick 内都合法通过 fence：第一条的微任务挂起了会话、随后 refork 装上新
+worker，第二条的微任务这时才运行，面对的是一个全新的 worker。没有这道判定就会把
+它挂掉 —— 新 worker 若正在产出，正是原样复现本功能要消灭的截断 bug。
+不属于当前 generation 的 checkpoint **保留标志直接返回**。
 
 （不要改成给 `screenshot_uploaded` 加前置 `ownsLifecycleMutation()` break：那会改掉
 该 case 的既有行为，影响面不明。把判定传进兑现函数是最小且封闭的改法。）
@@ -283,51 +331,24 @@ CLI 本地的 session store 这些判据一个都没有，要按 daemon 拉一�
 原则不变：dry-run 不该因为某个 daemon 抽风而失败，但也绝不该把"读不到"伪装成
 "已确认"——反过来，把**本来可确定**的结果报成"未知"同样是失职。
 
-### 5.5 `src/worker.ts` + `src/types.ts`：挂起前 flush 输出
+### 5.5 挂起前 flush 输出：**已从本改动移除**
 
-**只改 daemon 侧不够。** `final_output` 由 transcript 驱动（bridge 的 fs.watch + 1s
-poller），而触发挂起的 idle `screen_update` 由屏幕分析器驱动 —— 两个互相独立的生产者，
-没有顺序保证。在 idle 边沿兑现挂起时，这一轮的回复可能还躺在 bridge 队列里，而
-`case 'suspend'` 的自身拆解会把它毁掉两次：`stopBridgeWatcher()` 调 `clearPending()`，
-`process.exit(0)` 又丢掉 `process.send()` 只排队、还没写出的 IPC。
+早先的草案在 `case 'suspend'` 里插入 `await flushBridgeOutputBeforeSuspend()`，
+想在 teardown 前把 bridge 队列里已就绪的回复推出去。**该实现已整体删除**，原因是
+它的产物在 daemon 侧会被确定性丢弃：
 
-这就是本设计要消灭的「回复被切断」换了个入口复现。而且这个洞**现在就存在** ——
-`idle-worker-sweeper` 和 `host_overload_sweep` 同样按 `lastScreenStatus === 'idle'`
-挂起，只是它们跑在定时器上、有几秒余量遮着；兑现函数挂在 idle 边沿、零余量，会放大它。
+`suspendWorker` 发出 `{ type: 'suspend' }` 之后，在**同一同步调用栈内**就把
+`ds.worker = null`；worker 要收到该消息后才开始 flush，等 `final_output` /
+`suspend_ready` 回到 daemon 时，message handler 在 switch **之前**的统一 fence
+（`if (ds.worker !== worker) return`）已经把它们全部丢弃。也就是说那条路径在当前
+接线下**无法成功**，不是「尚未观测到正向场景」。
 
-在 `case 'suspend'` 的 `stopBridgeWatcher()` 与 `destroySession` **之前**插入
-`await flushBridgeOutputBeforeSuspend()`（CLI 还活着时 drain，transcript 才完整）。
-该函数做两件事：
+要让 flush 真正落地，需要在那道 fence 上开一个「正在 suspend 的这一个 worker」的
+定向例外 —— 那道 fence 护着 cards / tokens / readiness / durable turn state，属于
+安全边界，值得单独一个改动连同 daemon 侧行为测试一起做。
 
-1. **drain 两条 transcript 桥**：`bridgeDrainAndMaybeEmit()`（Claude）+
-   `codexBridgeDrainAndMaybeEmit({ signalIdle: false })`（codex/grok/traex/pi/hermes/mtr）。
-   配对方式抄既有的 `drainReliableTerminalBeforeInterrupt`，但**去掉它的
-   `reliableTurnTerminal` 门** —— 这里 drain 只是提前发布下一个 poller tick 本来就会发的
-   东西，对所有 CLI 都安全。两个 drain 各自 try/catch：坏掉的 transcript 不能把会话
-   钉在内存里，挂起本身就是内存回收手段。
-2. **写屏障**：追一条 `suspend_ready` 走 `sendAndFlush`。`process.send` 是 FIFO，
-   它的回调触发就意味着前面的 `final_output` 已经落到管道上。用 `Promise.race`
-   加 500ms 上界，写法对齐 `flushTransferDetachAck`。
+由此带来的残留窗口已在 §2「交付边界仍是 best-effort」如实记录。
 
-**这是尽最大努力，不是保证。** 超时分支被选中时屏障并未成立，后面照常
-teardown + `process.exit(0)`，队列里没写出去的消息仍会丢。窗口比现状（完全不 flush）
-小得多，但不为零 —— 注释、文档、测试都不该声称"保证"。
-
-为什么**不能**去掉这个上界改成无限等：`suspendWorker` 在发出 suspend 消息的同时就
-arm 了 daemon 侧的 kill backstop（`WORKER_SIGTERM_BACKSTOP_MS = 2_000`，
-SIGKILL 7s）。所以无限等根本不是无限等 —— 2 秒后照样被 SIGTERM 打断，区别只在于
-**被打断时 `destroySession()` 和 `cleanup()` 还没跑**，backing tmux session 和 CLI 留在
-那儿，挂起要回收的内存一点没回收。2 秒总预算必须在 flush 和其后的 teardown 之间分，
-500ms 是留够 teardown 余量的切分。
-
-`src/types.ts` 的 `WorkerToDaemon` 相应新增 `{ type: 'suspend_ready'; sessionId: string }`。
-daemon 侧**不需要 handler**：它是写屏障不是命令，daemon 早就决定要挂起了，
-除了 flush 本身不需要它任何东西（worker-pool 的 switch 没有 `default` 分支，未知
-类型天然忽略）。
-
-**残留窗口**：drain 用的是 `drainEmittable({ terminalBoundary: true })`。若这一轮的
-terminal 行在 drain 那一刻还没落到 transcript 里，仍然会漏 —— 窗口从秒级压到微秒级，
-但没有归零。彻底归零需要让挂起等一个显式的 turn-terminal 信号，那是另一个设计。
 
 ## 6. 边界情况
 
@@ -340,7 +361,7 @@ terminal 行在 drain 那一刻还没落到 transcript 里，仍然会漏 ——
 | adopt / 不可挂起 backend | 保持现有守卫，**在排队检查之前** return，不排队 |
 | 会话状态为 `undefined` | 不排队，走原有立即挂起路径（`undefined` 不属于 working/analyzing） |
 | daemon 重启 | 排队丢失，下一周期重新排队（决策 4） |
-| 兑现时 bridge 队列还有未发的回复 | worker 侧 `flushBridgeOutputBeforeSuspend` 先 drain + flush（§5.5） |
+| 兑现时 bridge 队列还有未发的回复 | **仍可能丢** —— 交付边界是 best-effort，见 §2 的已知残留窗口 |
 | 排队期间会话 refork，旧 worker 的 `screenshot_uploaded(idle)` 晚到 | `ownsGeneration` 判定为假 → **保留标志、不挂新 worker**（§5.2a） |
 | 兑现时 `suspendWorker` 拒绝（routing transfer 中） | 保留标志，并注册 `deferUntilSessionTransferSettled` 重试 —— 不能只靠"下一个 checkpoint"，安静会话可能再也没有（§5.2a） |
 | dry-run 遇到正在 routing transfer 的会话 | **预告不准**：会报"将排队/将挂起"，实际是 409 `session_transferring`。`/api/sessions` 行不暴露该状态，已在代码注释标明（§5.4） |
@@ -381,23 +402,18 @@ terminal 行在 drain 那一刻还没落到 transcript 里，仍然会漏 ——
 11. 幂等分支（无 worker）仍返回 `reason:'no_live_worker'`，不被误判为 deferred
 12. `backend_not_suspendable` / `adopt_suspend_unsupported` 两道守卫都排在排队之前
 
-`test/worker-suspend-output-flush.test.ts` — §5.5 的接线。worker.ts 的 IPC handler
-模块级副作用太重、单测里无法独立驱动，这里按仓库既有惯例（见
-`test/worker-pipe-initial-screen-order.test.ts`）用源码断言：
+`test/worker-suspend-output-flush.test.ts` — **已随 §5.5 的实现一并删除。**
+那组用例只对 worker 侧做源码顺序断言，完全没有跨过 daemon 的接收边界，所以即使
+flush 产物在 daemon 侧被 fence 确定性丢弃，它依然全绿。这是个值得记住的教训：
+**跨进程的承诺，必须由跨过那道边界的行为测试来钉，源码断言证明不了任何交付。**
 
-13. `flushBridgeOutputBeforeSuspend()` 排在 `stopBridgeWatcher()` 和 `destroySession` 之前，
-    且**带 `await`**（漏掉 await 会让 `process.exit(0)` 直接越过整个 flush）
-14. 两条 transcript 桥都被 drain，codex 那条精确匹配 `{ signalIdle: false }`
-15. **写屏障的位置在两个 drain 之后**（排在前面就毫无意义）
-16. 屏障等待有界，且预算 `< 2000ms`（必须留在 daemon SIGTERM backstop 之内并给
-    teardown 余量）
-17. **两个 drain 各自独立 try/catch**（单个 `try`+`catch` 同时存在挡不住"第一个 drain
-    抛异常带走第二个"）
+`test/deferred-suspend.test.ts` 另有一组 claim 生命周期用例（真行为断言）：
 
-⚠️ 这个文件是**接线测试而非行为测试**，测试头部已如实注明：它能挡住顺序被改坏、
-参数被改回、兜底被删掉，挡不住 helper 内部逻辑写错但形状没变。要覆盖后者需要把
-flush helper 拆成可注入 `sendAndFlush`/drain/timer 的独立模块 —— 那是一次独立重构，
-为测试改写 worker.ts 的退出路径，风险大于收益。
+13. 任何成功的 `suspendWorker` 都消费 claim —— 不只是兑现 checkpoint，`/cd` /
+    读隔离切换 / idle sweeper 这些不路过 checkpoint 的路径同样算目标态达成
+14. 被拒绝时 claim 与其 generation 一并保留（暂时性拒绝不能吃掉请求）
+15. claim 属于更早的 generation 时**就地消费、绝不挂起新 worker**
+16. 同代时照常兑现（上一条门控不能把正常路径也挡掉）
 
 ### 生产验证
 
@@ -419,9 +435,11 @@ busy 会话数吻合（历史 `p99=4, max=5`）。
 改动集中在六个文件、且互相独立：`dashboard-ipc-server.ts` 的排队分支去掉后即恢复
 原行为，`pendingSuspendReason` 永不被设置，兑现函数自然变成空操作。
 
-§5.5 的 worker 侧 flush 是**独立可回滚**的另一半：它不依赖排队机制，删掉它排队仍然
-工作（只是回到「兑现时可能漏掉一条回复」的窗口）；反过来留着它也独立改善现有的
-`idle-worker-sweeper` / `host_overload_sweep` 两条挂起路径。
+§5.5 的 worker 侧 flush **已在本改动中删除**（原因见该节），所以不存在回滚它的问题；
+它留下的交付边界窗口已在 §2 如实记录为已知项。
+
+generation 绑定（`pendingSuspendGeneration` + `clearPendingSuspendClaim`）同样独立：
+去掉它排队机制仍然工作，只是回到「claim 可能残留到下一代」的行为。
 
 ## 9. 参考：本文结论的数据来源
 

--- a/docs/design/deferred-suspend.md
+++ b/docs/design/deferred-suspend.md
@@ -1,0 +1,421 @@
+# 延迟挂起（Deferred Suspend）
+
+`botmux suspend` 在会话正在产出回复时会直接杀掉 worker，把那一轮回复丢掉。
+本文要求把它改成：**正在忙的会话先排队，等它自己结束后自动挂起。**
+
+## 1. 背景与证据
+
+### 现状
+
+`suspend all` 走的路径（`dashboard-ipc-server.ts` 的 `POST /api/sessions/:sessionId/suspend`）
+只有四道守卫：`session_not_active` / `session_transferring` / `adopt` / `backend_not_suspendable`。
+**没有任何 busy 检查** —— 会话正在生成回复时照杀不误，用户那条消息的回复就此丢失。
+
+对比：同文件里的 `POST /api/host-overload/sweep` 有守卫
+`if (ds.lastScreenStatus !== 'idle') continue;`，说明这个概念在代码库里已经存在，
+只是没用在 suspend 路由上。
+
+### 触发频率
+
+生产机（Mac mini, 24GB）上 `suspend all` 由凭证轮换 cron 驱动，
+`7,37 * * * *` 里 `SUSPEND=1`，实际约每 6 小时执行一次（00:07 / 06:07 / 12:07 / 18:07）。
+
+31 小时探针数据：并发 busy 会话数 `p99=4, max=5`。
+即**每次 `suspend all` 大约打断 0–5 个正在生成的回复，每天 4 次**。
+
+### 为什么现在要改
+
+这台机器的内存余量正在收紧（8月7日峰值 56 会话，距估算上限仅 2–5 个会话），
+候选缓解方案是把清理窗口从 6 小时缩短到 3 小时。但那会让"打断回复"的次数翻倍。
+先修掉这个副作用，缓解方案才可用。
+
+## 2. 目标与非目标
+
+**目标**
+
+- 挂起请求不再切断正在产出的回复
+- 不漏掉任何会话 —— 语义从"立即挂起"变成"最终挂起"
+- 调用方能看到有多少被排队
+
+**非目标**
+
+- 不做持久化（daemon 重启丢失排队状态，见 §4 决策 4）
+- 不改 `suspend` 之外的挂起路径（`idle-worker-sweeper` / `host_overload_sweep`
+  本来就有 busy 守卫，无需改动）
+- 不引入新的配置项或环境变量
+
+## 3. 机制
+
+会话状态类型：`ScreenStatus = 'working' | 'idle' | 'analyzing' | 'limited'`（`src/types.ts`）。
+
+**排队**：IPC suspend 路由收到请求时，若 `ds.lastScreenStatus` 为 `working` 或 `analyzing`，
+不杀 worker，在 `DaemonSession` 上记 `pendingSuspendReason`，返回
+`{ ok: true, suspended: false, reason: 'deferred' }`。
+
+**兑现**：`worker-pool.ts` 处理 `screen_update` 时，状态转入 `idle` 或 `limited` 后，
+若 `pendingSuspendReason` 存在则调用 `suspendWorker(ds, reason)` 并清除标志。
+
+`limited`（被限流）纳入兑现条件：该状态同样没有在产出内容，挂起不切断任何东西，
+而且这类会话正是内存回收最该清理的。
+
+## 4. 设计决策
+
+### 决策 1：改默认行为，不加开关
+
+有了"延迟兑现"之后默认开启是站得住的 —— 没有会话被漏掉，只是晚几十秒到几分钟。
+
+对凭证轮换而言，**延迟兑现严格优于现在的立即切断**：正在跑的那一轮本来就已经
+持有旧凭证，切断它并不能让那一轮用上新凭证，只是白白丢掉一次回复。
+两种做法对"该会话何时开始用新凭证"的结果相同（都是下一轮），
+区别只在于当前这一轮是完成还是被丢弃。
+
+因此不加 `--defer-busy` 之类的开关，直接改默认。
+
+### 决策 2：不设兑现上限
+
+会话长时间卡在 `working` 时，排队的挂起会一直不兑现。**接受这一点**，理由：
+
+- 设 deadline 强制挂起 = 又回到切断回复，把本次改动的收益抵消掉
+- 标志本来就会被下一个 `suspend all` 周期重新设上，不会永久丢失
+- 安全阀是**可见性**而非超时：CLI 必须明确报出排队数（见 §5.4）
+
+### 决策 3：排队期间来了新消息不取消排队
+
+那一轮结束转入 idle 时照常挂起，用户下条消息冷启动续上下文
+（生产实测冷恢复 `source=resume` 约 2.2 秒）。
+
+如果取消排队，会出现"对话频繁的会话永远挂不掉"—— 而那恰恰是内存占用最大、
+最需要回收的一类。
+
+### 决策 4：只存内存，不持久化
+
+`pendingSuspendReason` 存在 daemon 进程内存里，daemon 重启即丢。
+不做持久化，因为下一个 `suspend all` 周期会重新排队，代价只是延后一个周期；
+而持久化需要改 session store 的 schema，不成比例。
+
+## 5. 改动清单
+
+### 5.1 `src/core/types.ts`
+
+`DaemonSession` 接口，紧挨 `lastScreenStatus`（当前在第 202 行附近）新增：
+
+```ts
+  /** 排队中的挂起：请求到达时会话正在产出（working/analyzing），杀 worker 会丢掉
+   *  这一轮回复。改为记下原因，等 screen_update 转入 idle/limited 时再兑现
+   *  （见 worker-pool.ts runPendingSuspendIfSettled）。仅存内存：daemon 重启即丢，
+   *  下一个 `suspend all` 周期会重新排队，代价只是延后一个周期。 */
+  pendingSuspendReason?: string;
+```
+
+### 5.2 `src/core/worker-pool.ts`
+
+**(a) 新增兑现函数**，放在 `suspendWorker`（当前 2229 行 `export function suspendWorker`）附近：
+
+```ts
+/**
+ * 兑现排队中的挂起。会话转入非产出状态（idle/limited）后调用。
+ * working/analyzing 期间是空操作 —— 那正是当初排队的原因。
+ */
+function runPendingSuspendIfSettled(ds: DaemonSession, ownsGeneration?: () => boolean): void {
+  const reason = ds.pendingSuspendReason;
+  if (!reason) return;
+  if (ownsGeneration && !ownsGeneration()) return;
+  const st = ds.lastScreenStatus;
+  if (st !== 'idle' && st !== 'limited') return;
+  // worker 已经没了（崩溃 / 被别的路径挂起）：目标态已达成，清标志即可。
+  if (!ds.worker || ds.worker.killed) {
+    ds.pendingSuspendReason = undefined;
+    return;
+  }
+  // 只在成功时清标志（见下）。
+  if (suspendWorker(ds, reason)) {
+    ds.pendingSuspendReason = undefined;
+    logger.info(`[${tag(ds)}] Deferred suspend fulfilled (${reason}) after turn completed`);
+    return;
+  }
+  // 被进行中的 transfer 拒绝：光保留标志不够，还要有重试触发点（见下）。
+  deferUntilSessionTransferSettled(ds, () => runPendingSuspendIfSettled(ds, ownsGeneration));
+}
+```
+
+三个细节都是正确性要求，不是讲究：
+
+**`ownsGeneration` 必须传，否则会挂掉替换上来的新 worker。** `screenshot_uploaded`
+这个 case **没有** `ownsLifecycleMutation()` 守卫（`screen_update` 第一行就有），
+它今天就无门槛地写 `ds.lastScreenStatus`。把「写状态」升级成「杀 worker」之后：
+旧 worker 被 refork 替换 → 它退出前排队的 `screenshot_uploaded(idle)` 晚到 →
+覆写成 idle → 微任务看到 `pendingSuspendReason` 和**新 worker** 还活着 → 把刚起来的
+新 worker 挂了。新 worker 若正在产出，这就是原样复现本功能要消灭的截断 bug。
+陈旧的 checkpoint **保留标志直接返回** —— 只有当前 generation 有资格消费它。
+
+（不要改成给 `screenshot_uploaded` 加前置 `ownsLifecycleMutation()` break：那会改掉
+该 case 的既有行为，影响面不明。把判定传进兑现函数是最小且封闭的改法。）
+
+**只在 `suspendWorker` 返回 true 时清标志。** 它在 routing transfer 期间会拒绝并
+返回 false —— 那是**暂时**拒绝，先清后调会把这次请求静默吞掉，一直丢到下一个
+`suspend all` 周期才补回来。
+
+**transfer 拒绝后必须显式重试，光保留标志不够。** 传进去的是纯 generation 判定
+`ownsWorkerSession`，**不是 `ownsLifecycleMutation`**（后者把「不在 transfer 中」也
+折了进去）。原因：transfer 是暂时拒绝、不是"这个 generation 不是我们的"，该由
+`suspendWorker` 自己那道守卫来判。若用 `ownsLifecycleMutation`，transfer 期间会被
+当成"不归我们"而直接 return —— 而**会话安静下来后屏幕分析器就不再发 `screen_update`**
+（只在 `changed || status 变化` 时发），于是可能再也没有下一个 checkpoint 来唤醒它，
+标志一直挂到下一个 `suspend all` 周期。所以拒绝后用**已导出的**
+`deferUntilSessionTransferSettled` 注册重试；它在没有进行中的 transfer 时返回 false，
+所以非 transfer 的拒绝（如 pty）不会注册多余回调。
+
+日志用该文件既有的 `logger`（`import { logger } from '../utils/logger.js'`，第 34 行）
+与 `tag(ds)` 前缀 —— 对齐 `suspendWorker` 内部
+`logger.warn(\`[${tag(ds)}] Suspend refused while ...\`)` 的写法。
+
+**(b) 在两处状态赋值后调用它**（`screen_update` 主路径约 5451–5454 行，
+`screenshot_uploaded` 第二条路径约 5658–5660 行）。两处都已经捕获了 `prevStatus`
+并给 `ds.lastScreenStatus` 赋值。
+
+⚠️ **必须用 `queueMicrotask` 推迟一拍，不能同步调**：
+
+```ts
+queueMicrotask(() => runPendingSuspendIfSettled(ds, ownsWorkerSession));
+```
+
+（`ownsWorkerSession` 是这两个 handler 闭包里已有的纯 generation 判定，直接传即可。
+为什么必须传、以及为什么不能传 `ownsLifecycleMutation`，见上面 (a)。）
+
+`suspendWorker` 是同步的，且会把 `ds.worker` 和 `ds.lastScreenStatus` 清空。
+而同一个 handler 在赋值之后还要读这两个字段做**回合收尾**：
+
+- `recordUsageForDaemonSession(ds)` 与 `void finishTurnReactions(ds)`（✋→✅）
+  都门控在 `lastScreenStatus === 'idle' || 'limited'` 上 —— 同步挂起会让它们**整段跳过**
+- `emitSessionStateTransitionHook(ds, prevStatus, ds.lastScreenStatus, ...)`
+  会把新状态报成 `undefined`
+- 末尾 `buildStreamingCard(..., ds.lastScreenStatus, ...)` 拿到 `undefined`
+
+同步调用等于为了不切断回复，反手切掉了这一轮的收尾记账 —— 正是本设计要保护的东西。
+`queueMicrotask` 是这个文件既有的惯用法：同一段里 `queueMicrotask(cb.enforceLiveSessionCap)`
+的注释写的就是「Defer until this screen_update has finished using process state」。
+
+⚠️ 也不要挂到 `emitSessionStateTransitionHook()` 上。那个函数是给外部 hook 事件用的，
+带去重窗口且对 `vcMeetingReceiver` 等提前 return，会漏触发。
+
+### 5.3 `src/core/dashboard-ipc-server.ts`
+
+`POST /api/sessions/:sessionId/suspend` 路由（当前 743 行附近）。
+在现有的 `!ds.worker || ds.worker.killed` 幂等分支**之后**、
+`suspendWorker(...)` 调用**之前**插入：
+
+```ts
+  // 正在产出回复时不杀 worker —— 那会把这一轮丢掉。改为排队，等
+  // screen_update 转入 idle/limited 时由 runPendingSuspendIfSettled 兑现。
+  if (
+    (ds.lastScreenStatus === 'working' || ds.lastScreenStatus === 'analyzing')
+    && isSuspendableBackendType(ds.initConfig?.backendType)
+  ) {
+    ds.pendingSuspendReason = 'manual_suspend';
+    return jsonRes(res, 200, {
+      ok: true, sessionId: params.sessionId, suspended: false, reason: 'deferred',
+    });
+  }
+```
+
+注意顺序：幂等分支在前，这样"worker 早就没了"仍然返回 `reason: 'no_live_worker'`，
+不会被误报成 deferred。
+
+`isSuspendableBackendType` 是**排队条件的一部分，而不是排在它前面的新守卫** ——
+现状是 busy + pty 直接 409（`suspendWorker` 返回 false），把它写成独立的前置 return
+有两个坏处：① busy 的 pty 会话若先排队，就变成「200 deferred，然后到点静默失败」；
+② 独立前置 return 会**改掉非 busy 会话的行为**，因为 `isSuspendableBackendType(undefined)`
+返回 false，而 `test/dashboard-ipc.test.ts` 里那条 mock 掉 `suspendWorker` 的既有用例
+用的 fixture 没有 `initConfig`。写成合取式则不可挂起的 backend 照旧穿透到
+`suspendWorker` 的 409，非 busy 路径一行行为都不变。
+`isSuspendableBackendType` 该文件已导入（第 75 行）。
+
+### 5.4 `src/cli.ts`
+
+`cmdSuspend()`（当前 4504 行）里的结果分类。现有逻辑：
+
+```ts
+if (body.suspended) { console.log(`✓ 已挂起: ${label}`); suspended++; }
+else { console.log(`· 本就无存活 CLI（目标态已达成）: ${label}`); skipped++; }
+```
+
+需要把 `reason === 'deferred'` 单独分出来计数，不要混进 `skipped`：
+
+```ts
+if (body.suspended) { console.log(`✓ 已挂起: ${label}`); suspended++; }
+else if (body.reason === 'deferred') {
+  console.log(`⏳ 已排队（正在回复，完成后自动挂起）: ${label}`); deferred++;
+}
+else { console.log(`· 本就无存活 CLI（目标态已达成）: ${label}`); skipped++; }
+```
+
+结尾汇总行同步加上排队数：
+
+```
+完成：挂起 N 个，排队 M 个，跳过 K 个[，失败 J 个]。
+```
+
+**这个计数是决策 2 的安全阀**，必须实现 —— 排队数持续不降就是会话卡住的信号。
+
+`--dry-run` 分支也要跟上，而且**必须复刻 suspend 路由的完整分类，不能只看忙不忙**。
+只按屏幕状态判断的话，busy 的 pty / adopt 会话会被预告成"将排队"，实际请求拿到的是
+`backend_not_suspendable` / `adopt_suspend_unsupported`；没有存活 worker 的会话会被
+预告成"将挂起"，实际是跳过 —— 一个说得斩钉截铁的错误预告比不预告更坏。
+
+CLI 本地的 session store 这些判据一个都没有，要按 daemon 拉一次 `GET /api/sessions`：
+该路由的 dashboard 行同时带 `status`（即 `lastScreenStatus`，无 worker 时为 `dormant`）、
+`adopt`、`backendType`，**足够完整复刻**路由的分支顺序（adopt → 无 worker →
+不可挂起 backend → busy → 挂起）。每个 daemon 只拉一次。
+
+拉不到时（daemon 不在线 / 非 2xx / 返回非 JSON）预告降级为**"未知"**并在结尾打一行
+warning，不猜一个确定结论 —— dry-run 不该因为某个 daemon 抽风而失败，但也不该
+把"读不到"伪装成"已确认"。
+
+### 5.5 `src/worker.ts` + `src/types.ts`：挂起前 flush 输出
+
+**只改 daemon 侧不够。** `final_output` 由 transcript 驱动（bridge 的 fs.watch + 1s
+poller），而触发挂起的 idle `screen_update` 由屏幕分析器驱动 —— 两个互相独立的生产者，
+没有顺序保证。在 idle 边沿兑现挂起时，这一轮的回复可能还躺在 bridge 队列里，而
+`case 'suspend'` 的自身拆解会把它毁掉两次：`stopBridgeWatcher()` 调 `clearPending()`，
+`process.exit(0)` 又丢掉 `process.send()` 只排队、还没写出的 IPC。
+
+这就是本设计要消灭的「回复被切断」换了个入口复现。而且这个洞**现在就存在** ——
+`idle-worker-sweeper` 和 `host_overload_sweep` 同样按 `lastScreenStatus === 'idle'`
+挂起，只是它们跑在定时器上、有几秒余量遮着；兑现函数挂在 idle 边沿、零余量，会放大它。
+
+在 `case 'suspend'` 的 `stopBridgeWatcher()` 与 `destroySession` **之前**插入
+`await flushBridgeOutputBeforeSuspend()`（CLI 还活着时 drain，transcript 才完整）。
+该函数做两件事：
+
+1. **drain 两条 transcript 桥**：`bridgeDrainAndMaybeEmit()`（Claude）+
+   `codexBridgeDrainAndMaybeEmit({ signalIdle: false })`（codex/grok/traex/pi/hermes/mtr）。
+   配对方式抄既有的 `drainReliableTerminalBeforeInterrupt`，但**去掉它的
+   `reliableTurnTerminal` 门** —— 这里 drain 只是提前发布下一个 poller tick 本来就会发的
+   东西，对所有 CLI 都安全。两个 drain 各自 try/catch：坏掉的 transcript 不能把会话
+   钉在内存里，挂起本身就是内存回收手段。
+2. **写屏障**：追一条 `suspend_ready` 走 `sendAndFlush`。`process.send` 是 FIFO，
+   它的回调触发就意味着前面的 `final_output` 已经落到管道上。用 `Promise.race`
+   加 500ms 上界，写法对齐 `flushTransferDetachAck`。
+
+**这是尽最大努力，不是保证。** 超时分支被选中时屏障并未成立，后面照常
+teardown + `process.exit(0)`，队列里没写出去的消息仍会丢。窗口比现状（完全不 flush）
+小得多，但不为零 —— 注释、文档、测试都不该声称"保证"。
+
+为什么**不能**去掉这个上界改成无限等：`suspendWorker` 在发出 suspend 消息的同时就
+arm 了 daemon 侧的 kill backstop（`WORKER_SIGTERM_BACKSTOP_MS = 2_000`，
+SIGKILL 7s）。所以无限等根本不是无限等 —— 2 秒后照样被 SIGTERM 打断，区别只在于
+**被打断时 `destroySession()` 和 `cleanup()` 还没跑**，backing tmux session 和 CLI 留在
+那儿，挂起要回收的内存一点没回收。2 秒总预算必须在 flush 和其后的 teardown 之间分，
+500ms 是留够 teardown 余量的切分。
+
+`src/types.ts` 的 `WorkerToDaemon` 相应新增 `{ type: 'suspend_ready'; sessionId: string }`。
+daemon 侧**不需要 handler**：它是写屏障不是命令，daemon 早就决定要挂起了，
+除了 flush 本身不需要它任何东西（worker-pool 的 switch 没有 `default` 分支，未知
+类型天然忽略）。
+
+**残留窗口**：drain 用的是 `drainEmittable({ terminalBoundary: true })`。若这一轮的
+terminal 行在 drain 那一刻还没落到 transcript 里，仍然会漏 —— 窗口从秒级压到微秒级，
+但没有归零。彻底归零需要让挂起等一个显式的 turn-terminal 信号，那是另一个设计。
+
+## 6. 边界情况
+
+| 情况 | 期望行为 |
+|---|---|
+| 排队期间 worker 崩溃 | 兑现函数发现 `!ds.worker \|\| killed`，清标志，不报错 |
+| 排队期间会话被 `delete` 关闭 | 会话记录消失，标志随之消失，无副作用 |
+| 排队期间被 `idle-worker-sweeper` 挂起 | 同上：worker 已 killed，兑现函数清标志即可 |
+| 同一会话重复请求挂起 | 幂等 —— 覆写同一个 `pendingSuspendReason` |
+| adopt / 不可挂起 backend | 保持现有守卫，**在排队检查之前** return，不排队 |
+| 会话状态为 `undefined` | 不排队，走原有立即挂起路径（`undefined` 不属于 working/analyzing） |
+| daemon 重启 | 排队丢失，下一周期重新排队（决策 4） |
+| 兑现时 bridge 队列还有未发的回复 | worker 侧 `flushBridgeOutputBeforeSuspend` 先 drain + flush（§5.5） |
+| 排队期间会话 refork，旧 worker 的 `screenshot_uploaded(idle)` 晚到 | `ownsGeneration` 判定为假 → **保留标志、不挂新 worker**（§5.2a） |
+| 兑现时 `suspendWorker` 拒绝（routing transfer 中） | 保留标志，并注册 `deferUntilSessionTransferSettled` 重试 —— 不能只靠"下一个 checkpoint"，安静会话可能再也没有（§5.2a） |
+| dry-run 遇到正在 routing transfer 的会话 | **预告不准**：会报"将排队/将挂起"，实际是 409 `session_transferring`。`/api/sessions` 行不暴露该状态，已在代码注释标明（§5.4） |
+
+## 7. 测试
+
+### 单元测试
+
+仓库用 vitest（`pnpm vitest run --project unit`）。参考既有测试风格。
+
+`runPendingSuspendIfSettled` 是 `worker-pool.ts` 的模块内函数。仿照同文件既有的
+`export const __testOnly_deliverFinalOutput`，导出 `__testOnly_runPendingSuspendIfSettled`
+做**真行为断言**（mock 掉 session-store / dashboard-events / logger，写法照抄
+`test/worker-suspend.test.ts`），比源码断言可靠得多。
+
+`test/deferred-suspend.test.ts` — 兑现半边：
+
+1. 兑现函数在 `working` / `analyzing` 时是空操作，**且标志必须留着**（否则排队被静默吞掉）
+2. 转入 `idle` 和 `limited` 都会兑现
+3. `worker` 已 killed / 缺失时只清标志、不走 `suspendWorker`（它的 no-worker 分支会
+   顺手清 `managedTurnOrigin`/`workerReady`，那是这次排队从未拥有的 generation）
+4. 兑现后标志被清除，第二个 idle tick 不会重复挂起
+5. **reason 真的被透传**（断言被 mock 的 `logger.info` 收到该 reason；只断言"标志被清"
+   是空测试 —— 实现把 reason 写死也会绿）
+6. **`ownsGeneration` 为假时不挂 worker 且保留标志**；为真时正常兑现
+7. **`suspendWorker` 拒绝时保留标志**（routing transfer 的门是模块私有的，用同样
+   「早退且零副作用」的 pty 分支钉这条不变式）
+8. **transfer 拒绝后注册了 `deferUntilSessionTransferSettled` 重试**，且两个 checkpoint
+   传的是 `ownsWorkerSession` 而非 `ownsLifecycleMutation`（transfer 门是模块私有的，
+   这条用源码断言钉）
+
+`test/ipc-suspend-route.test.ts` — 排队半边（起真 IPC server + `vi.spyOn(workerPool, ...)`，
+写法照抄 `test/ipc-close-route.test.ts`）：
+
+8. `working`/`analyzing` 返回 `{suspended:false, reason:'deferred'}` 且**没有**调用 `suspendWorker`
+9. `idle`/`limited` 仍立即挂起
+10. 状态 `undefined` 不排队
+11. 幂等分支（无 worker）仍返回 `reason:'no_live_worker'`，不被误判为 deferred
+12. `backend_not_suspendable` / `adopt_suspend_unsupported` 两道守卫都排在排队之前
+
+`test/worker-suspend-output-flush.test.ts` — §5.5 的接线。worker.ts 的 IPC handler
+模块级副作用太重、单测里无法独立驱动，这里按仓库既有惯例（见
+`test/worker-pipe-initial-screen-order.test.ts`）用源码断言：
+
+13. `flushBridgeOutputBeforeSuspend()` 排在 `stopBridgeWatcher()` 和 `destroySession` 之前，
+    且**带 `await`**（漏掉 await 会让 `process.exit(0)` 直接越过整个 flush）
+14. 两条 transcript 桥都被 drain，codex 那条精确匹配 `{ signalIdle: false }`
+15. **写屏障的位置在两个 drain 之后**（排在前面就毫无意义）
+16. 屏障等待有界，且预算 `< 2000ms`（必须留在 daemon SIGTERM backstop 之内并给
+    teardown 余量）
+17. **两个 drain 各自独立 try/catch**（单个 `try`+`catch` 同时存在挡不住"第一个 drain
+    抛异常带走第二个"）
+
+⚠️ 这个文件是**接线测试而非行为测试**，测试头部已如实注明：它能挡住顺序被改坏、
+参数被改回、兜底被删掉，挡不住 helper 内部逻辑写错但形状没变。要覆盖后者需要把
+flush helper 拆成可注入 `sendAndFlush`/drain/timer 的独立模块 —— 那是一次独立重构，
+为测试改写 worker.ts 的退出路径，风险大于收益。
+
+### 生产验证
+
+改动部署后（`pnpm build`；worker 是每次冷启动 fork `dist/worker.js`，所以 §5.5 的
+worker 侧改动 build 完即生效；而 `worker-pool.ts` / `dashboard-ipc-server.ts` 跑在
+daemon 进程里，**必须重启 daemon**）：
+
+1. 找一个正在生成回复的会话（`botmux list --plain` 里 status 为 online 且屏幕在动）
+2. `botmux suspend <sid>` → 应输出 `⏳ 已排队`
+3. 等该会话回复完成 → daemon 日志应出现 `Deferred suspend fulfilled`
+4. `botmux list` 确认该会话已变成 dormant
+5. 关键回归：确认那条回复**完整发到了飞书**，没有被截断
+
+也可直接观察下一次 6 小时周期的 `suspend all` 输出，排队数应与当时的
+busy 会话数吻合（历史 `p99=4, max=5`）。
+
+## 8. 回滚
+
+改动集中在六个文件、且互相独立：`dashboard-ipc-server.ts` 的排队分支去掉后即恢复
+原行为，`pendingSuspendReason` 永不被设置，兑现函数自然变成空操作。
+
+§5.5 的 worker 侧 flush 是**独立可回滚**的另一半：它不依赖排队机制，删掉它排队仍然
+工作（只是回到「兑现时可能漏掉一条回复」的窗口）；反过来留着它也独立改善现有的
+`idle-worker-sweeper` / `host_overload_sweep` 两条挂起路径。
+
+## 9. 参考：本文结论的数据来源
+
+- 并发 busy 分布 `p99=4 / max=5`：`~/.botmux/probe/` 的 31 小时采样，
+  用 `python3 ~/.botmux/probe/report.py` 复现
+- 冷恢复耗时 2.2 秒：daemon 日志中 `SessionStart ready signal received (source=resume)`
+  到 `Writing to PTY (flush)` 的间隔，n=2
+- `suspend all` 实际频率：`crontab -l` 的 `7,37 * * * *` + `bot-cred-refresh-oauth.sh`
+  中 `SUSPEND=1` 的触发条件（仅在 token 刷新成功后）

--- a/docs/design/deferred-suspend.md
+++ b/docs/design/deferred-suspend.md
@@ -267,9 +267,21 @@ CLI 本地的 session store 这些判据一个都没有，要按 daemon 拉一�
 `adopt`、`backendType`，**足够完整复刻**路由的分支顺序（adopt → 无 worker →
 不可挂起 backend → busy → 挂起）。每个 daemon 只拉一次。
 
-拉不到时（daemon 不在线 / 非 2xx / 返回非 JSON）预告降级为**"未知"**并在结尾打一行
-warning，不猜一个确定结论 —— dry-run 不该因为某个 daemon 抽风而失败，但也不该
-把"读不到"伪装成"已确认"。
+**"读不到"要分成两种，不能混成一个"未知"**（这是 live 验证才暴露出来的 —— 单测和
+两轮 codex 都没看出来，因为它只在真实多 bot 环境里显形）：
+
+- **daemon 不在线**（`findDaemon()` 为空）→ 结果是**确定可知**的：真实循环在发请求
+  之前就会因为同一个条件跳过。预告成"将跳过（daemon 不在线）"。
+  实测本机 516 个目标里有 20 个属于此类（`cli_listener_status` / `cli_listener_run`
+  这两个伪 app id 下的 Message Listener Preview 会话），报"未知"是实打实的信息损失。
+- **daemon 在线但 `/api/sessions` 读失败**（非 2xx / 非 JSON）→ 这才是真未知，
+  预告为"未知"并在结尾打一行 warning。
+
+同理，真实循环里排在 daemon 查找**之前**的那道
+`!s.larkAppId && online.length > 1` 跳过，dry-run 也要照抄，否则这类会被误报。
+
+原则不变：dry-run 不该因为某个 daemon 抽风而失败，但也绝不该把"读不到"伪装成
+"已确认"——反过来，把**本来可确定**的结果报成"未知"同样是失职。
 
 ### 5.5 `src/worker.ts` + `src/types.ts`：挂起前 flush 输出
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5918,10 +5918,61 @@ async function cmdSuspend(): Promise<void> {
   }
 
   const online = listOnlineDaemons();
-  let suspended = 0, skipped = 0, failed = 0;
+  let suspended = 0, deferred = 0, skipped = 0, failed = 0;
+
+  // dry-run 的预告要复刻 suspend 路由的分类，而这些判据（实时屏幕状态、是否还有
+  // 存活 worker、backend、adopt）本地 session store 全都没有。每个 daemon 只拉一次
+  // /api/sessions 拿 dashboard 行；拉不到就退回不带判据的旧预告，dry-run 不该因为
+  // 一个 daemon 抽风而失败。
+  const daemonRows = new Map<number, Map<string, any> | null>();
+  let dryRunDegraded = false;
+  const rowOf = async (sessionId: string, larkAppId?: string): Promise<any | undefined> => {
+    const daemon = findDaemon(larkAppId);
+    if (!daemon) { dryRunDegraded = true; return undefined; }
+    if (!daemonRows.has(daemon.ipcPort)) {
+      try {
+        const res = await fetchDaemonIpc(daemon.ipcPort, '/api/sessions', { method: 'GET' });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const body: any = await res.json();
+        const rows: any[] = Array.isArray(body?.sessions) ? body.sessions : [];
+        daemonRows.set(daemon.ipcPort, new Map(rows.filter(r => r?.sessionId).map(r => [r.sessionId, r])));
+      } catch { daemonRows.set(daemon.ipcPort, null); }
+    }
+    const map = daemonRows.get(daemon.ipcPort);
+    if (!map) { dryRunDegraded = true; return undefined; }
+    return map.get(sessionId);
+  };
+  // 复刻 dashboard-ipc-server 的 suspend 路由分支顺序。行拿不到时返回 undefined
+  // （预告降级为"未知"），绝不猜一个确定的结论。
+  //
+  // ⚠️ 一个分支复刻不了：路由的第一道守卫是 `isSessionTransferring` → 409，而
+  // /api/sessions 的行不暴露 transfer 状态。正在 routing transfer 中的会话会被这里
+  // 预告成 排队/挂起，实际执行拿到 `session_transferring`。transfer 是短暂窗口，
+  // 为一个 dry-run 预告给 SessionRow 加字段不成比例；如果以后行里有了该状态，
+  // 在 adopt 之前补一条分支即可。
+  const SUSPENDABLE_BACKENDS = new Set(['tmux', 'herdr', 'zellij', 'zmx']);
+  const predictSuspend = (row: any): 'defer' | 'suspend' | 'no_worker' | 'refuse' | undefined => {
+    if (!row) return undefined;
+    if (row.adopt) return 'refuse';                          // adopt_suspend_unsupported
+    if (row.status === 'dormant' || row.status === 'closed') return 'no_worker';
+    if (!SUSPENDABLE_BACKENDS.has(row.backendType)) return 'refuse';  // backend_not_suspendable
+    if (row.status === 'working' || row.status === 'analyzing') return 'defer';
+    return 'suspend';
+  };
+
   for (const s of matched) {
     const label = `${s.sessionId.substring(0, 8)}  ${s.title ?? ''}`.trimEnd();
-    if (dryRun) { console.log(`· 将挂起: ${label}`); continue; }
+    if (dryRun) {
+      const predicted = predictSuspend(await rowOf(s.sessionId, s.larkAppId));
+      switch (predicted) {
+        case 'defer': console.log(`· 将排队（正在回复，完成后自动挂起）: ${label}`); deferred++; break;
+        case 'suspend': console.log(`· 将挂起: ${label}`); break;
+        case 'no_worker': console.log(`· 将跳过（本就无存活 CLI）: ${label}`); skipped++; break;
+        case 'refuse': console.log(`· 将拒绝（adopt / 不可挂起 backend）: ${label}`); failed++; break;
+        default: console.log(`? 未知（daemon 状态读不到，无法预告）: ${label}`); break;
+      }
+      continue;
+    }
     // 旧会话缺 larkAppId 时多 daemon 下无法判定归属，跳过而不是误路由。
     if (!s.larkAppId && online.length > 1) {
       console.log(`- 跳过（缺 larkAppId，多 daemon 无法判定归属）: ${label}`);
@@ -5943,6 +5994,10 @@ async function cmdSuspend(): Promise<void> {
       const body: any = await res.json().catch(() => ({}));
       if (res.ok && body?.ok) {
         if (body.suspended) { console.log(`✓ 已挂起: ${label}`); suspended++; }
+        else if (body.reason === 'deferred') {
+          console.log(`⏳ 已排队（正在回复，完成后自动挂起）: ${label}`);
+          deferred++;
+        }
         else { console.log(`· 本就无存活 CLI（目标态已达成）: ${label}`); skipped++; }
       } else {
         console.log(`✗ 失败（${body?.error ?? `HTTP ${res.status}`}）: ${label}`);
@@ -5955,10 +6010,14 @@ async function cmdSuspend(): Promise<void> {
   }
 
   if (dryRun) {
-    console.log(`\nDRY-RUN：共 ${matched.length} 个目标，未执行。`);
+    if (dryRunDegraded) {
+      console.log('\n⚠️  部分会话的 daemon 状态读不到（daemon 不在线或 /api/sessions 失败），这些预告标为「未知」而非猜测。');
+    }
+    console.log(`DRY-RUN：共 ${matched.length} 个目标${deferred ? `（其中 ${deferred} 个正在回复，会排队）` : ''}，未执行。`);
     return;
   }
-  console.log(`\n完成：挂起 ${suspended} 个，跳过 ${skipped} 个${failed ? `，失败 ${failed} 个` : ''}。`);
+  // 排队数必须单列：不设兑现上限的安全阀是可见性——这个数持续不降就是会话卡住的信号。
+  console.log(`\n完成：挂起 ${suspended} 个，排队 ${deferred} 个，跳过 ${skipped} 个${failed ? `，失败 ${failed} 个` : ''}。`);
   console.log('下条消息会冷启动并 --resume 续上下文；读隔离 bot 冷启动时自动同步最新登录凭证。');
   if (failed > 0) process.exitCode = 1;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5926,9 +5926,17 @@ async function cmdSuspend(): Promise<void> {
   // 一个 daemon 抽风而失败。
   const daemonRows = new Map<number, Map<string, any> | null>();
   let dryRunDegraded = false;
-  const rowOf = async (sessionId: string, larkAppId?: string): Promise<any | undefined> => {
+  // daemon 不在线是**确定可知**的结果，不是未知：真实循环在发请求之前就会因
+  // findDaemon() 为空而跳过。只有「daemon 在线但 /api/sessions 读不到」才是真未知。
+  // 早期版本把这两种混成一个 undefined，于是 listener 那类伪 app id（无对应 daemon）
+  // 的会话被报成「未知」——实测 20/516 条这样的信息损失，而它们的真实结果是"跳过"。
+  type Lookup =
+    | { kind: 'row'; row: any | undefined }
+    | { kind: 'no_daemon'; larkAppId?: string }
+    | { kind: 'unreadable' };
+  const lookupRow = async (sessionId: string, larkAppId?: string): Promise<Lookup> => {
     const daemon = findDaemon(larkAppId);
-    if (!daemon) { dryRunDegraded = true; return undefined; }
+    if (!daemon) return { kind: 'no_daemon', larkAppId };
     if (!daemonRows.has(daemon.ipcPort)) {
       try {
         const res = await fetchDaemonIpc(daemon.ipcPort, '/api/sessions', { method: 'GET' });
@@ -5939,8 +5947,8 @@ async function cmdSuspend(): Promise<void> {
       } catch { daemonRows.set(daemon.ipcPort, null); }
     }
     const map = daemonRows.get(daemon.ipcPort);
-    if (!map) { dryRunDegraded = true; return undefined; }
-    return map.get(sessionId);
+    if (!map) { dryRunDegraded = true; return { kind: 'unreadable' }; }
+    return { kind: 'row', row: map.get(sessionId) };
   };
   // 复刻 dashboard-ipc-server 的 suspend 路由分支顺序。行拿不到时返回 undefined
   // （预告降级为"未知"），绝不猜一个确定的结论。
@@ -5951,8 +5959,13 @@ async function cmdSuspend(): Promise<void> {
   // 为一个 dry-run 预告给 SessionRow 加字段不成比例；如果以后行里有了该状态，
   // 在 adopt 之前补一条分支即可。
   const SUSPENDABLE_BACKENDS = new Set(['tmux', 'herdr', 'zellij', 'zmx']);
-  const predictSuspend = (row: any): 'defer' | 'suspend' | 'no_worker' | 'refuse' | undefined => {
-    if (!row) return undefined;
+  type Prediction = 'defer' | 'suspend' | 'no_worker' | 'refuse' | 'skip_no_daemon' | 'unknown';
+  const predictSuspend = (lk: Lookup): Prediction => {
+    if (lk.kind === 'no_daemon') return 'skip_no_daemon';
+    if (lk.kind === 'unreadable') return 'unknown';
+    const row = lk.row;
+    // 会话在本地 store 里是 active，但 daemon 的行里没有它——判不出走哪条分支。
+    if (!row) return 'unknown';
     if (row.adopt) return 'refuse';                          // adopt_suspend_unsupported
     if (row.status === 'dormant' || row.status === 'closed') return 'no_worker';
     if (!SUSPENDABLE_BACKENDS.has(row.backendType)) return 'refuse';  // backend_not_suspendable
@@ -5963,13 +5976,23 @@ async function cmdSuspend(): Promise<void> {
   for (const s of matched) {
     const label = `${s.sessionId.substring(0, 8)}  ${s.title ?? ''}`.trimEnd();
     if (dryRun) {
-      const predicted = predictSuspend(await rowOf(s.sessionId, s.larkAppId));
+      // 真实循环的第一道跳过在发请求之前，dry-run 也要照抄，否则这类会被误报。
+      if (!s.larkAppId && online.length > 1) {
+        console.log(`· 将跳过（缺 larkAppId，多 daemon 无法判定归属）: ${label}`);
+        skipped++;
+        continue;
+      }
+      const predicted = predictSuspend(await lookupRow(s.sessionId, s.larkAppId));
       switch (predicted) {
         case 'defer': console.log(`· 将排队（正在回复，完成后自动挂起）: ${label}`); deferred++; break;
         case 'suspend': console.log(`· 将挂起: ${label}`); break;
         case 'no_worker': console.log(`· 将跳过（本就无存活 CLI）: ${label}`); skipped++; break;
         case 'refuse': console.log(`· 将拒绝（adopt / 不可挂起 backend）: ${label}`); failed++; break;
-        default: console.log(`? 未知（daemon 状态读不到，无法预告）: ${label}`); break;
+        case 'skip_no_daemon':
+          console.log(`· 将跳过（daemon 不在线${s.larkAppId ? `: ${s.larkAppId}` : ''}）: ${label}`);
+          skipped++;
+          break;
+        default: console.log(`? 未知（daemon 在线但状态读不到，无法预告）: ${label}`); break;
       }
       continue;
     }
@@ -6011,7 +6034,7 @@ async function cmdSuspend(): Promise<void> {
 
   if (dryRun) {
     if (dryRunDegraded) {
-      console.log('\n⚠️  部分会话的 daemon 状态读不到（daemon 不在线或 /api/sessions 失败），这些预告标为「未知」而非猜测。');
+      console.log('\n⚠️  部分会话所属 daemon 在线但 /api/sessions 读失败，这些预告标为「未知」而非猜测。');
     }
     console.log(`DRY-RUN：共 ${matched.length} 个目标${deferred ? `（其中 ${deferred} 个正在回复，会排队）` : ''}，未执行。`);
     return;

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -1158,6 +1158,24 @@ ipcRoute('POST', '/api/sessions/:sessionId/suspend', async (_req, res, params) =
     // already reached, so report idempotent success without a live kill.
     return jsonRes(res, 200, { ok: true, sessionId: params.sessionId, suspended: false, reason: 'no_live_worker' });
   }
+  // Producing a reply — killing the worker now would drop this turn. Queue
+  // instead; worker-pool's runPendingSuspendIfSettled cashes it in on the
+  // idle/limited edge. Ordering matters: the idempotent no-worker branch above
+  // must win, so "worker was already gone" never reports as deferred.
+  //
+  // The suspendability check is part of the queueing condition, not a new guard
+  // ahead of it: a non-suspendable (pty) backend must keep falling through to
+  // suspendWorker's existing 409 rather than get a `deferred` that could only
+  // fail silently at fulfillment time.
+  if (
+    (ds.lastScreenStatus === 'working' || ds.lastScreenStatus === 'analyzing')
+    && isSuspendableBackendType(ds.initConfig?.backendType)
+  ) {
+    ds.pendingSuspendReason = 'manual_suspend';
+    return jsonRes(res, 200, {
+      ok: true, sessionId: params.sessionId, suspended: false, reason: 'deferred',
+    });
+  }
   if (!suspendWorker(ds, 'manual_suspend')) {
     // Live worker but a non-suspendable (pty) backend: killing it would drop the
     // in-memory conversation with no persistent pane to resume from lazily.

--- a/src/core/dashboard-ipc-server.ts
+++ b/src/core/dashboard-ipc-server.ts
@@ -1172,6 +1172,9 @@ ipcRoute('POST', '/api/sessions/:sessionId/suspend', async (_req, res, params) =
     && isSuspendableBackendType(ds.initConfig?.backendType)
   ) {
     ds.pendingSuspendReason = 'manual_suspend';
+    // Bind the claim to the generation that is producing right now: it must not
+    // outlive that worker (see clearPendingSuspendClaim).
+    ds.pendingSuspendGeneration = ds.workerGeneration;
     return jsonRes(res, 200, {
       ok: true, sessionId: params.sessionId, suspended: false, reason: 'deferred',
     });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -264,6 +264,14 @@ export interface DaemonSession {
    *  only: lost on daemon restart, and the next `suspend all` cycle re-queues
    *  it — the cost is one cycle of delay, not a missed session. */
   pendingSuspendReason?: string;
+  /** Worker generation that owned the queued suspend above. A claim is only
+   *  ever about the generation that was producing when the request arrived, so
+   *  it must not outlive it: once that worker is suspended (by ANY path) or
+   *  exits, the goal state is reached and the claim is consumed. Without this,
+   *  a claim whose fulfilment checkpoint never ran (worker crashed, or `/cd` /
+   *  read-isolation switch suspended first) survives into the NEXT generation
+   *  and suspends it on its first idle. See clearPendingSuspendClaim. */
+  pendingSuspendGeneration?: number;
   /** Executor-observed Codex settings for this worker/rollout generation. */
   codexServiceTier?: CodexServiceTierSnapshot;
   /** Tier change arrived while a card POST was in-flight. */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -257,6 +257,13 @@ export interface DaemonSession {
   activeReasoningEffort?: string;
   /** Runtime change arrived while a streaming-card POST was in flight. */
   pendingActiveRuntimeCardRefresh?: boolean;
+  /** Queued suspend: the request arrived while the session was producing
+   *  (working/analyzing), where killing the worker would drop that turn's reply.
+   *  Record the reason instead and cash it in once screen_update settles into
+   *  idle/limited (see worker-pool.ts runPendingSuspendIfSettled). In-memory
+   *  only: lost on daemon restart, and the next `suspend all` cycle re-queues
+   *  it — the cost is one cycle of delay, not a missed session. */
+  pendingSuspendReason?: string;
   /** Executor-observed Codex settings for this worker/rollout generation. */
   codexServiceTier?: CodexServiceTierSnapshot;
   /** Tier change arrived while a card POST was in-flight. */

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -2853,12 +2853,20 @@ export function suspendWorker(ds: DaemonSession, reason = 'suspended_idle'): boo
  * this whole feature exists to protect.
  *
  * `ownsGeneration` is the calling handler's generation check (`ownsWorkerSession`)
- * and is REQUIRED for correctness, not a nicety: `screenshot_uploaded` writes
- * `lastScreenStatus` with no ownership check of its own, so a stale `idle` from a
- * replaced worker can land on a session that has since re-forked. Without this
- * check the microtask would then suspend the *replacement* worker — mid-reply —
- * which is the exact truncation bug this feature removes. A stale checkpoint
- * keeps the flag pending; only the owning generation may consume it.
+ * and is REQUIRED for correctness, not a nicety — but NOT for the reason an
+ * earlier draft of this comment gave. It is not about a stale worker's message
+ * reaching `screenshot_uploaded`: the message handler's fence
+ * (`if (ds.worker !== worker) return`) sits BEFORE the switch and already drops
+ * every message from a replaced worker.
+ *
+ * The real window is the deferral itself. Callers hand this to `queueMicrotask`
+ * (they must — see above), so the fence is checked when the MESSAGE arrives while
+ * the suspend runs one microtask later. Two messages can clear the fence in the
+ * same tick; the first one's microtask suspends and the session re-forks, and the
+ * second one's microtask then runs against a brand-new worker. Without this check
+ * it would suspend that replacement — mid-reply — which is the exact truncation
+ * bug this feature removes. A checkpoint from a generation that no longer owns
+ * the session keeps the flag pending; only the owning generation may consume it.
  *
  * Deliberately the generation check ALONE, not `ownsLifecycleMutation` (which
  * also folds in "not transferring"): a routing transfer is a temporary refusal,

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -2736,6 +2736,30 @@ function reclaimParkedCrashDiagnostic(ds: DaemonSession): void {
   try { unlinkSync(join(config.session.dataDir, 'crash-diagnostics', `${ds.session.sessionId}.ansi`)); } catch { /* absent — benign */ }
 }
 
+/**
+ * Consume a queued suspend claim once its goal state is reached.
+ *
+ * A claim only ever means "suspend the generation that is producing right now".
+ * It is therefore consumed the moment that generation stops running, by ANY
+ * route — the deferred checkpoint itself, a `/cd` or read-isolation switch that
+ * suspended first, or an outright crash. Leaving it set is not a harmless
+ * no-op: `runPendingSuspendIfSettled` fires on the NEXT generation's first
+ * screen checkpoint, and its `ownsGeneration` predicate passes there (that
+ * worker legitimately owns the session), so the replacement gets suspended for
+ * a request that was never about it.
+ *
+ * The old code did have a "worker already gone → drop the flag" branch, but it
+ * lived inside the checkpoint — which by definition stops running once the
+ * session goes quiet. The clear needs to hang off the lifecycle events instead.
+ */
+function clearPendingSuspendClaim(ds: DaemonSession, why: string): void {
+  if (ds.pendingSuspendReason === undefined && ds.pendingSuspendGeneration === undefined) return;
+  const reason = ds.pendingSuspendReason;
+  ds.pendingSuspendReason = undefined;
+  ds.pendingSuspendGeneration = undefined;
+  logger.debug(`[${tag(ds)}] Cleared queued suspend claim (${reason ?? 'none'}): ${why}`);
+}
+
 export function suspendWorker(ds: DaemonSession, reason = 'suspended_idle'): boolean {
   if (hasProtectedSessionMutationOwnership(ds)) {
     logger.warn(`[${tag(ds)}] Refused worker suspend (${reason}) while Codex App dispatch ownership is non-empty`);
@@ -2809,6 +2833,10 @@ export function suspendWorker(ds: DaemonSession, reason = 'suspended_idle'): boo
       },
     });
   }
+  // Goal state reached. Whoever queued a suspend for this generation got what
+  // they asked for — including the paths that never touch the deferred
+  // checkpoint (`/cd`, read-isolation switch, sweepIdleWorkers).
+  clearPendingSuspendClaim(ds, `suspended (${reason})`);
   logger.info(`[${tag(ds)}] Worker + CLI suspended (${reason}); session stays active, cold-resumes from transcript on next message`);
   return true;
 }
@@ -2843,6 +2871,19 @@ function runPendingSuspendIfSettled(ds: DaemonSession, ownsGeneration?: () => bo
   const reason = ds.pendingSuspendReason;
   if (!reason) return;
   if (ownsGeneration && !ownsGeneration()) return;
+  // A claim belongs to the generation that was producing when it was queued.
+  // Reaching a LATER generation means its own fulfilment checkpoint never ran
+  // (crash, or another path suspended first) — consume it rather than suspend a
+  // worker the request never asked about. clearPendingSuspendClaim covers the
+  // normal exits; this is the backstop for a claim that slipped past them.
+  if (
+    ds.pendingSuspendGeneration !== undefined
+    && ds.workerGeneration !== undefined
+    && ds.pendingSuspendGeneration !== ds.workerGeneration
+  ) {
+    clearPendingSuspendClaim(ds, 'generation changed');
+    return;
+  }
   const st = ds.lastScreenStatus;
   if (st !== 'idle' && st !== 'limited') return;
   // Worker already gone (crash / suspended by another path): the goal state is
@@ -2850,14 +2891,16 @@ function runPendingSuspendIfSettled(ds: DaemonSession, ownsGeneration?: () => bo
   // no-worker branch and clear managedTurnOrigin/workerReady for a generation
   // this queued request never owned.
   if (!ds.worker || ds.worker.killed) {
-    ds.pendingSuspendReason = undefined;
+    clearPendingSuspendClaim(ds, 'worker already gone');
     return;
   }
   // Clear only on success. suspendWorker refuses mid-routing-transfer (and for a
   // backend that stopped being suspendable), and that refusal is temporary —
   // eating the flag would silently drop the request until the next `suspend all`.
   if (suspendWorker(ds, reason)) {
-    ds.pendingSuspendReason = undefined;
+    // suspendWorker already consumed the claim (goal state reached); logging
+    // here keeps the "fulfilled by the deferred path" signal distinguishable
+    // from a suspend that came from anywhere else.
     logger.info(`[${tag(ds)}] Deferred suspend fulfilled (${reason}) after turn completed`);
     return;
   }
@@ -9058,6 +9101,11 @@ function setupWorkerHandlers(
       ds.worker = null;
       ds.workerReady = false;
       ds.workerPort = null;
+      // A queued suspend for THIS generation is now moot — the worker it was
+      // about is gone. Leaving it set would suspend the replacement on its
+      // first idle (the deferred checkpoint's own "worker gone" branch cannot
+      // help: it only runs on a screen update that will never arrive).
+      clearPendingSuspendClaim(ds, 'worker exited');
       // Dead worker generation — stop the periodic usage refresh immediately
       // instead of waiting a tick for it to self-clear on !workerHasInitialized.
       clearUsageRefreshTimer(ds);

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -2813,6 +2813,63 @@ export function suspendWorker(ds: DaemonSession, reason = 'suspended_idle'): boo
   return true;
 }
 
+/**
+ * Cash in a queued suspend. Called once the session leaves the producing states
+ * it was queued for; a no-op during working/analyzing — that IS why it queued.
+ *
+ * Callers MUST defer this out of the status handler's synchronous body
+ * (queueMicrotask) — suspendWorker clears `ds.worker` and `ds.lastScreenStatus`,
+ * and the rest of that handler still reads both to record the usage delta, flip
+ * the turn reaction ✋→✅, emit the state-transition hook, and render the final
+ * card. Running it inline would skip exactly the turn-completion bookkeeping
+ * this whole feature exists to protect.
+ *
+ * `ownsGeneration` is the calling handler's generation check (`ownsWorkerSession`)
+ * and is REQUIRED for correctness, not a nicety: `screenshot_uploaded` writes
+ * `lastScreenStatus` with no ownership check of its own, so a stale `idle` from a
+ * replaced worker can land on a session that has since re-forked. Without this
+ * check the microtask would then suspend the *replacement* worker — mid-reply —
+ * which is the exact truncation bug this feature removes. A stale checkpoint
+ * keeps the flag pending; only the owning generation may consume it.
+ *
+ * Deliberately the generation check ALONE, not `ownsLifecycleMutation` (which
+ * also folds in "not transferring"): a routing transfer is a temporary refusal,
+ * not a lost claim, and it is suspendWorker's own guard to make. Screen updates
+ * stop once a session sits quiet, so treating transfer as "not ours" would park
+ * the flag with no later checkpoint to revive it — hence the explicit
+ * transfer-settled retry below.
+ */
+function runPendingSuspendIfSettled(ds: DaemonSession, ownsGeneration?: () => boolean): void {
+  const reason = ds.pendingSuspendReason;
+  if (!reason) return;
+  if (ownsGeneration && !ownsGeneration()) return;
+  const st = ds.lastScreenStatus;
+  if (st !== 'idle' && st !== 'limited') return;
+  // Worker already gone (crash / suspended by another path): the goal state is
+  // reached, so drop the flag. Falling through to suspendWorker would take its
+  // no-worker branch and clear managedTurnOrigin/workerReady for a generation
+  // this queued request never owned.
+  if (!ds.worker || ds.worker.killed) {
+    ds.pendingSuspendReason = undefined;
+    return;
+  }
+  // Clear only on success. suspendWorker refuses mid-routing-transfer (and for a
+  // backend that stopped being suspendable), and that refusal is temporary —
+  // eating the flag would silently drop the request until the next `suspend all`.
+  if (suspendWorker(ds, reason)) {
+    ds.pendingSuspendReason = undefined;
+    logger.info(`[${tag(ds)}] Deferred suspend fulfilled (${reason}) after turn completed`);
+    return;
+  }
+  // Refused by an in-flight transfer: keeping the flag is not enough on its own.
+  // A settled session emits no further screen updates, so there may be no next
+  // checkpoint — re-run when the relay gate releases. Returns false when no
+  // transfer is active (a non-transfer refusal, e.g. pty), which needs no retry.
+  deferUntilSessionTransferSettled(ds, () => runPendingSuspendIfSettled(ds, ownsGeneration));
+}
+
+export const __testOnly_runPendingSuspendIfSettled = runPendingSuspendIfSettled;
+
 function armWorkerKillBackstop(w: ChildProcess, label: string, sigtermMs: number = WORKER_SIGTERM_BACKSTOP_MS): void {
   const sigterm = setTimeout(() => {
     if (w.exitCode === null && w.signalCode === null) {
@@ -7519,6 +7576,11 @@ function setupWorkerHandlers(
         updateUsageLimitState(ds, msg.usageLimit);
         ds.lastScreenContent = msg.content;
         ds.lastScreenStatus = (msg.usageLimit ?? ds.usageLimit) ? 'limited' : msg.status;
+        // A suspend that arrived mid-turn parked itself here. Defer until this
+        // screen_update has finished using process state — suspendWorker nulls
+        // `worker` + `lastScreenStatus`, which everything below still reads
+        // (usage ledger, turn reactions, transition hook, final card).
+        queueMicrotask(() => runPendingSuspendIfSettled(ds, ownsWorkerSession));
 
         // State-boundary clear: the moment we leave `working` (→ idle/limited),
         // stop the periodic usage refresh immediately — BEFORE the aux-UI /
@@ -7725,6 +7787,12 @@ function setupWorkerHandlers(
         const prevStatus = ds.lastScreenStatus;
         updateUsageLimitState(ds, msg.usageLimit);
         ds.lastScreenStatus = (msg.usageLimit ?? ds.usageLimit) ? 'limited' : msg.status;
+        // Same deferred-suspend checkpoint as the screen_update branch, and
+        // deferred for the same reason (see runPendingSuspendIfSettled). This
+        // case has NO ownership guard of its own, so passing the predicate is
+        // what stops a stale worker's late `idle` from suspending its
+        // replacement — the assignment above is already unguarded today.
+        queueMicrotask(() => runPendingSuspendIfSettled(ds, ownsWorkerSession));
         emitSessionStateTransitionHook(ds, prevStatus, ds.lastScreenStatus, {
           source: 'screenshot_uploaded',
           imageKey: msg.imageKey,

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -2852,21 +2852,28 @@ export function suspendWorker(ds: DaemonSession, reason = 'suspended_idle'): boo
  * card. Running it inline would skip exactly the turn-completion bookkeeping
  * this whole feature exists to protect.
  *
- * `ownsGeneration` is the calling handler's generation check (`ownsWorkerSession`)
- * and is REQUIRED for correctness, not a nicety — but NOT for the reason an
- * earlier draft of this comment gave. It is not about a stale worker's message
- * reaching `screenshot_uploaded`: the message handler's fence
- * (`if (ds.worker !== worker) return`) sits BEFORE the switch and already drops
- * every message from a replaced worker.
+ * `ownsGeneration` is the calling handler's generation check (`ownsWorkerSession`),
+ * and it is **defense-in-depth** — not a guard against a race anyone has shown to
+ * be reachable today. Two earlier drafts of this comment each claimed a concrete
+ * race; both were wrong, so the reasoning is spelled out here to stop a third:
  *
- * The real window is the deferral itself. Callers hand this to `queueMicrotask`
- * (they must — see above), so the fence is checked when the MESSAGE arrives while
- * the suspend runs one microtask later. Two messages can clear the fence in the
- * same tick; the first one's microtask suspends and the session re-forks, and the
- * second one's microtask then runs against a brand-new worker. Without this check
- * it would suspend that replacement — mid-reply — which is the exact truncation
- * bug this feature removes. A checkpoint from a generation that no longer owns
- * the session keeps the flag pending; only the owning generation may consume it.
+ *   - It is NOT "a stale worker's late `idle` reaches `screenshot_uploaded`":
+ *     the message handler's fence (`if (ds.worker !== worker) return`) sits
+ *     BEFORE the switch and already drops every message from a replaced worker.
+ *   - It is NOT "two microtasks in one tick, the first suspends + re-forks and
+ *     the second meets the replacement": `suspendWorker` only nulls `ds.worker`,
+ *     it never re-forks (a re-fork is driven by external input, i.e. a later
+ *     MACROtask), and the microtask queue drains without letting one in. The
+ *     second microtask therefore sees `ds.worker === null` and this predicate
+ *     early-returns on that — a replacement is not what it meets.
+ *
+ * What it does buy: a queued callback can only ever act while its own generation
+ * still owns the session. That keeps this deferral safe against future callers,
+ * new synchronous side effects between enqueue and drain, and any path that
+ * starts re-forking earlier than today. Consuming the claim is a destructive act
+ * on a live worker, so it is worth gating even without a demonstrated race.
+ * A checkpoint from a generation that no longer owns the session keeps the flag
+ * pending; only the owning generation may consume it.
  *
  * Deliberately the generation check ALONE, not `ownsLifecycleMutation` (which
  * also folds in "not transferring"): a routing transfer is a temporary refusal,
@@ -7839,10 +7846,12 @@ function setupWorkerHandlers(
         updateUsageLimitState(ds, msg.usageLimit);
         ds.lastScreenStatus = (msg.usageLimit ?? ds.usageLimit) ? 'limited' : msg.status;
         // Same deferred-suspend checkpoint as the screen_update branch, and
-        // deferred for the same reason (see runPendingSuspendIfSettled). This
-        // case has NO ownership guard of its own, so passing the predicate is
-        // what stops a stale worker's late `idle` from suspending its
-        // replacement — the assignment above is already unguarded today.
+        // deferred for the same reason (see runPendingSuspendIfSettled).
+        // The predicate is defense-in-depth here: the handler's fence already
+        // dropped every message from a replaced worker before the switch, so a
+        // stale `idle` cannot reach this case at all. Passing it keeps the
+        // deferred callback from acting on a generation that stopped owning the
+        // session between enqueue and drain.
         queueMicrotask(() => runPendingSuspendIfSettled(ds, ownsWorkerSession));
         emitSessionStateTransitionHook(ds, prevStatus, ds.lastScreenStatus, {
           source: 'screenshot_uploaded',

--- a/test/deferred-suspend.test.ts
+++ b/test/deferred-suspend.test.ts
@@ -1,0 +1,189 @@
+// 延迟挂起（deferred suspend）的兑现半边：会话正在产出时 IPC 路由只记
+// `pendingSuspendReason`，真正的 kill 推迟到会话转入 idle/limited 后由
+// runPendingSuspendIfSettled 兑现。这里钉住兑现函数的状态门控与幂等；
+// 排队半边（IPC 路由）见 ipc-suspend-route.test.ts。
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+vi.mock('../src/services/session-store.js', () => ({
+  registerSessionBridgeSendMarkerCleanupFence: vi.fn(),
+  cleanupSessionBridgeSendMarkers: vi.fn(),
+  cleanupSessionBridgeSendMarkersNow: vi.fn(),
+  updateSessionPid: vi.fn(),
+  updateSession: vi.fn(),
+}));
+vi.mock('../src/core/dashboard-events.js', () => ({
+  dashboardEventBus: { publish: vi.fn() },
+}));
+vi.mock('../src/utils/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { __testOnly_runPendingSuspendIfSettled as runPendingSuspendIfSettled } from '../src/core/worker-pool.js';
+import { logger } from '../src/utils/logger.js';
+
+function fakeWorker() {
+  return {
+    killed: false,
+    pid: 12345,
+    send: vi.fn(),
+    once: vi.fn(),
+    kill: vi.fn(),
+    exitCode: null,
+    signalCode: null,
+  } as any;
+}
+
+function busySession(status: string, opts: { pending?: string } = {}) {
+  const worker = fakeWorker();
+  const ds: any = {
+    session: { sessionId: `sid-${status}`, status: 'active' },
+    initConfig: { backendType: 'tmux' },
+    worker,
+    workerPort: 3456,
+    workerToken: 'token',
+    lastScreenStatus: status,
+    exitEventEmitted: false,
+    pendingSuspendReason: 'pending' in opts ? opts.pending : 'manual_suspend',
+  };
+  return { ds, worker };
+}
+
+describe('runPendingSuspendIfSettled', () => {
+  it('is a no-op with no queued suspend', () => {
+    const { ds, worker } = busySession('idle', { pending: undefined });
+
+    runPendingSuspendIfSettled(ds);
+
+    expect(worker.send).not.toHaveBeenCalled();
+    expect(ds.worker).toBe(worker);
+  });
+
+  // 排队的全部理由：这两个状态正在产出，杀 worker 会丢掉这一轮回复。
+  it.each(['working', 'analyzing'])('is a no-op while still producing (%s)', (status) => {
+    const { ds, worker } = busySession(status);
+
+    runPendingSuspendIfSettled(ds);
+
+    expect(worker.send).not.toHaveBeenCalled();
+    expect(ds.worker).toBe(worker);
+    // 标志必须留着 —— 否则这次排队就被静默吞掉，会话永远挂不起来。
+    expect(ds.pendingSuspendReason).toBe('manual_suspend');
+  });
+
+  // limited 同样没有在产出内容，挂起不切断任何东西，而且这类会话正是内存回收最该清理的。
+  it.each(['idle', 'limited'])('fulfills once the turn settles (%s)', (status) => {
+    const { ds, worker } = busySession(status);
+
+    runPendingSuspendIfSettled(ds);
+
+    expect(worker.send).toHaveBeenCalledWith({ type: 'suspend' });
+    expect(ds.worker).toBe(null);
+    expect(ds.session.status).toBe('active');
+    expect(ds.session.suspendedColdResume).toBe(true);
+    expect(ds.pendingSuspendReason).toBeUndefined();
+  });
+
+  it('carries the queued reason through to suspendWorker', () => {
+    const { ds } = busySession('idle');
+    ds.pendingSuspendReason = 'rotation_xyz';
+
+    runPendingSuspendIfSettled(ds);
+
+    // reason 只经由日志可观测——断言它真的被透传，而不是只断言标志被清（那样
+    // 实现把 reason 写死也会绿）。
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('rotation_xyz'));
+  });
+
+  // suspendWorker 会拒绝（返回 false）而不做任何改动：routing transfer 进行中，
+  // 或 backend 不可挂起。拒绝是**暂时**的，吃掉标志会让这次请求一路丢到下一个
+  // `suspend all` 周期才补回来。routing transfer 的门是模块私有的，这里用同样走
+  // 「早退且零副作用」的 pty 分支来钉住「拒绝 ⇒ 标志保留」这条不变式。
+  it('keeps the flag queued when suspendWorker refuses', () => {
+    const { ds, worker } = busySession('idle');
+    ds.initConfig = { backendType: 'pty' };
+
+    runPendingSuspendIfSettled(ds);
+
+    expect(worker.send).not.toHaveBeenCalled();
+    expect(ds.pendingSuspendReason).toBe('manual_suspend');
+  });
+
+  // 只保留标志还不够：会话安静下来后就不再有 screen_update，可能永远等不到下一个
+  // checkpoint。transfer 结算后必须有一个显式的重试触发点。
+  it('re-arms on transfer settle rather than waiting for a checkpoint that may never come', () => {
+    const src = readFileSync(join(process.cwd(), 'src/core/worker-pool.ts'), 'utf8');
+    const fn = src.slice(
+      src.indexOf('function runPendingSuspendIfSettled'),
+      src.indexOf('export const __testOnly_runPendingSuspendIfSettled'),
+    );
+    expect(fn).toContain('deferUntilSessionTransferSettled(ds, () => runPendingSuspendIfSettled(ds, ownsGeneration))');
+    // 传的必须是纯 generation 判定：ownsLifecycleMutation 把「不在 transfer 中」
+    // 也折了进去，用它会让 transfer 期间被当成「不是我们的」而跳过重试注册。
+    expect(src).toContain('runPendingSuspendIfSettled(ds, ownsWorkerSession)');
+    expect(src).not.toContain('runPendingSuspendIfSettled(ds, ownsLifecycleMutation)');
+  });
+
+  // 最危险的一条：`screenshot_uploaded` 自己没有 ownership 守卫，旧 worker 退出前
+  // 排队的 idle 可能晚到并落在已经 refork 过的会话上。放行就会把**刚起来的**
+  // worker 挂掉 —— 正在产出时就是原样复现本功能要消灭的截断 bug。
+  it('refuses to fulfill from a stale worker generation', () => {
+    const { ds, worker } = busySession('idle');
+
+    runPendingSuspendIfSettled(ds, () => false);
+
+    expect(worker.send).not.toHaveBeenCalled();
+    expect(ds.worker).toBe(worker);
+    // 陈旧的 checkpoint 不该消费掉排队 —— 当前 generation 自己 settle 时还要兑现。
+    expect(ds.pendingSuspendReason).toBe('manual_suspend');
+  });
+
+  it('fulfills when the calling generation still owns the session', () => {
+    const { ds, worker } = busySession('idle');
+
+    runPendingSuspendIfSettled(ds, () => true);
+
+    expect(worker.send).toHaveBeenCalledWith({ type: 'suspend' });
+    expect(ds.pendingSuspendReason).toBeUndefined();
+  });
+
+  it('does not re-suspend on a second settled tick', () => {
+    const { ds, worker } = busySession('idle');
+
+    runPendingSuspendIfSettled(ds);
+    worker.send.mockClear();
+    // suspendWorker 会把 lastScreenStatus 清空；模拟随后又来一个 idle 更新。
+    ds.lastScreenStatus = 'idle';
+    runPendingSuspendIfSettled(ds);
+
+    expect(worker.send).not.toHaveBeenCalled();
+  });
+
+  // 排队期间 worker 崩溃 / 被 idle-worker-sweeper 抢先挂起：目标态已达成，清标志即可。
+  it.each([
+    ['missing', null],
+    ['already killed', { killed: true, send: vi.fn() }],
+  ])('clears the flag without suspending when the worker is %s', (_state, worker) => {
+    const ds: any = {
+      session: { sessionId: 'sid-gone', status: 'active' },
+      initConfig: { backendType: 'tmux' },
+      worker,
+      lastScreenStatus: 'idle',
+      pendingSuspendReason: 'manual_suspend',
+    };
+
+    runPendingSuspendIfSettled(ds);
+
+    expect(ds.pendingSuspendReason).toBeUndefined();
+    // suspendWorker 的 no-worker 分支会顺手清 managedTurnOrigin/workerReady；
+    // 兑现函数必须在它之前 return，不产生这些副作用。
+    expect(ds.workerReady).toBeUndefined();
+    if (worker) expect((worker as any).send).not.toHaveBeenCalled();
+  });
+});

--- a/test/deferred-suspend.test.ts
+++ b/test/deferred-suspend.test.ts
@@ -25,7 +25,10 @@ vi.mock('../src/utils/logger.js', () => ({
   },
 }));
 
-import { __testOnly_runPendingSuspendIfSettled as runPendingSuspendIfSettled } from '../src/core/worker-pool.js';
+import {
+  __testOnly_runPendingSuspendIfSettled as runPendingSuspendIfSettled,
+  suspendWorker,
+} from '../src/core/worker-pool.js';
 import { logger } from '../src/utils/logger.js';
 
 function fakeWorker() {
@@ -185,5 +188,78 @@ describe('runPendingSuspendIfSettled', () => {
     // 兑现函数必须在它之前 return，不产生这些副作用。
     expect(ds.workerReady).toBeUndefined();
     if (worker) expect((worker as any).send).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * claim 的生命周期必须止于它自己那一代 worker。
+ *
+ * 原实现只在兑现函数内部清标志，而兑现函数只被 screen_update /
+ * screenshot_uploaded 两个 checkpoint 调用 —— 会话一旦安静下来就再没有
+ * checkpoint。于是「排队之后 worker 崩了，或被 /cd、读隔离切换先挂起」这类路径
+ * 会把标志留到下一代，下一代第一次 idle 时被平白挂一次；而 ownsGeneration 谓词
+ * 挡不住，因为那时传进来的正是新 worker 自己的闭包。
+ */
+describe('queued suspend claim lifecycle', () => {
+  function claimedSession(status = 'idle') {
+    const worker = fakeWorker();
+    const ds: any = {
+      session: { sessionId: 'sid-claim', status: 'active' },
+      initConfig: { backendType: 'tmux' },
+      worker,
+      workerGeneration: 7,
+      lastScreenStatus: status,
+      exitEventEmitted: false,
+      pendingSuspendReason: 'manual_suspend',
+      pendingSuspendGeneration: 7,
+    };
+    return { ds, worker };
+  }
+
+  // /cd、读隔离切换、idle sweeper 都是直接调 suspendWorker，从不路过兑现函数。
+  // 目标态（这一代被挂起）已经达成，claim 必须就地消费掉。
+  it('is consumed by ANY successful suspend, not just the deferred checkpoint', () => {
+    const { ds, worker } = claimedSession('working');   // 注意：还在产出也不影响
+
+    expect(suspendWorker(ds, 'role_switch')).toBe(true);
+
+    expect(worker.send).toHaveBeenCalledWith({ type: 'suspend' });
+    expect(ds.pendingSuspendReason).toBeUndefined();
+    expect(ds.pendingSuspendGeneration).toBeUndefined();
+  });
+
+  // 拒绝是暂时的，claim 不能被吃掉（与既有 pty 用例同一条不变式，这里补上
+  // generation 字段一并保留的断言）。
+  it('survives a refused suspend together with its generation', () => {
+    const { ds } = claimedSession();
+    ds.initConfig = { backendType: 'pty' };
+
+    expect(suspendWorker(ds, 'manual_suspend')).toBe(false);
+
+    expect(ds.pendingSuspendReason).toBe('manual_suspend');
+    expect(ds.pendingSuspendGeneration).toBe(7);
+  });
+
+  // 兜底：claim 万一漏过了上面的消费点，到了下一代也绝不能挂新 worker。
+  it('never suspends a LATER generation — it consumes the stale claim instead', () => {
+    const { ds, worker } = claimedSession();
+    ds.workerGeneration = 8;              // 已经 refork 过，claim 属于第 7 代
+
+    runPendingSuspendIfSettled(ds);
+
+    expect(worker.send).not.toHaveBeenCalled();   // 新 worker 毫发无伤
+    expect(ds.worker).toBe(worker);
+    expect(ds.pendingSuspendReason).toBeUndefined();
+    expect(ds.pendingSuspendGeneration).toBeUndefined();
+  });
+
+  // 同一代则照常兑现 —— 上面那条门控不能把正常路径也一并挡掉。
+  it('still fulfills when the claim belongs to the CURRENT generation', () => {
+    const { ds, worker } = claimedSession();
+
+    runPendingSuspendIfSettled(ds);
+
+    expect(worker.send).toHaveBeenCalledWith({ type: 'suspend' });
+    expect(ds.pendingSuspendReason).toBeUndefined();
   });
 });

--- a/test/deferred-suspend.test.ts
+++ b/test/deferred-suspend.test.ts
@@ -133,9 +133,11 @@ describe('runPendingSuspendIfSettled', () => {
     expect(src).not.toContain('runPendingSuspendIfSettled(ds, ownsLifecycleMutation)');
   });
 
-  // 最危险的一条：`screenshot_uploaded` 自己没有 ownership 守卫，旧 worker 退出前
-  // 排队的 idle 可能晚到并落在已经 refork 过的会话上。放行就会把**刚起来的**
-  // worker 挂掉 —— 正在产出时就是原样复现本功能要消灭的截断 bug。
+  // 钉住 predicate 的防御语义（defense-in-depth）：当传入的 generation 判定为假
+  // —— 排队那一代已不再持有会话 —— 兑现必须早退，且不能吃掉排队，留给真正属主的
+  // 那一代 settle 时再兑现。此前这里写过两版「陈旧 idle 落在 refork 后的会话上」的
+  // 具体 race，均已被推翻为不可达；predicate 为何仍值得保留，见 worker-pool.ts
+  // runPendingSuspendIfSettled 上方注释。
   it('refuses to fulfill from a stale worker generation', () => {
     const { ds, worker } = busySession('idle');
 

--- a/test/ipc-suspend-route.test.ts
+++ b/test/ipc-suspend-route.test.ts
@@ -1,0 +1,118 @@
+// POST /api/sessions/:sessionId/suspend 的排队半边：会话正在产出回复时不杀
+// worker（那会把这一轮丢掉），改为记 pendingSuspendReason 并回 reason:'deferred'，
+// 由 worker-pool 的 runPendingSuspendIfSettled 在 idle/limited 边沿兑现。
+// 兑现半边见 deferred-suspend.test.ts。
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { startIpcServer, type IpcServerHandle } from '../src/core/dashboard-ipc-server.js';
+import * as workerPool from '../src/core/worker-pool.js';
+
+let handle: IpcServerHandle | null = null;
+
+afterEach(async () => {
+  if (handle) await handle.close();
+  handle = null;
+  vi.restoreAllMocks();
+});
+
+async function postSuspend(sessionId: string): Promise<Response> {
+  handle ??= await startIpcServer({ port: 0, host: '127.0.0.1' });
+  return fetch(`http://127.0.0.1:${handle.port}/api/sessions/${sessionId}/suspend`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{}',
+  });
+}
+
+function activeSession(over: Record<string, unknown> = {}) {
+  return {
+    session: { sessionId: 's-susp', status: 'active' },
+    initConfig: { backendType: 'tmux' },
+    worker: { killed: false },
+    ...over,
+  } as any;
+}
+
+describe('POST /api/sessions/:sessionId/suspend — 延迟挂起', () => {
+  it.each(['working', 'analyzing'])('queues instead of killing while %s', async (status) => {
+    const ds = activeSession({ lastScreenStatus: status });
+    vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue(ds);
+    const suspendSpy = vi.spyOn(workerPool, 'suspendWorker');
+
+    const res = await postSuspend('s-susp');
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true, sessionId: 's-susp', suspended: false, reason: 'deferred',
+    });
+    // 关键回归：正在产出的那一轮回复不能被切断。
+    expect(suspendSpy).not.toHaveBeenCalled();
+    expect(ds.pendingSuspendReason).toBe('manual_suspend');
+  });
+
+  it.each(['idle', 'limited'])('suspends immediately when already settled (%s)', async (status) => {
+    const ds = activeSession({ lastScreenStatus: status });
+    vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue(ds);
+    const suspendSpy = vi.spyOn(workerPool, 'suspendWorker').mockReturnValue(true);
+
+    const res = await postSuspend('s-susp');
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, sessionId: 's-susp', suspended: true });
+    expect(suspendSpy).toHaveBeenCalledWith(ds, 'manual_suspend');
+    expect(ds.pendingSuspendReason).toBeUndefined();
+  });
+
+  // 状态未知（worker 还没报过 screen_update）不属于 working/analyzing，走原有立即挂起路径。
+  it('does not queue when the screen status is unknown', async () => {
+    const ds = activeSession({ lastScreenStatus: undefined });
+    vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue(ds);
+    const suspendSpy = vi.spyOn(workerPool, 'suspendWorker').mockReturnValue(true);
+
+    const res = await postSuspend('s-susp');
+
+    expect((await res.json()).suspended).toBe(true);
+    expect(suspendSpy).toHaveBeenCalled();
+    expect(ds.pendingSuspendReason).toBeUndefined();
+  });
+
+  // 幂等分支必须排在排队检查之前：worker 早就没了要如实回 no_live_worker，
+  // 不能被误报成 deferred（否则 CLI 的排队计数——决策 2 的安全阀——会虚高）。
+  it('reports no_live_worker instead of deferred when the worker is already gone', async () => {
+    const ds = activeSession({ lastScreenStatus: 'working', worker: null });
+    vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue(ds);
+
+    const res = await postSuspend('s-susp');
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true, sessionId: 's-susp', suspended: false, reason: 'no_live_worker',
+    });
+    expect(ds.pendingSuspendReason).toBeUndefined();
+  });
+
+  // 不可挂起的 backend 现在（busy 时）就是 409：suspendWorker 会拒。排队不能把它
+  // 变成一个「200 deferred，然后到点静默失败」的谎——守卫必须排在排队检查之前。
+  it('keeps the backend_not_suspendable guard ahead of queueing', async () => {
+    const ds = activeSession({ lastScreenStatus: 'working', initConfig: { backendType: 'pty' } });
+    vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue(ds);
+
+    const res = await postSuspend('s-susp');
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toBe('backend_not_suspendable');
+    expect(ds.pendingSuspendReason).toBeUndefined();
+  });
+
+  // adopt 会话 botmux 从未拥有那个 CLI，挂起会杀掉用户自己的 pane —— 保持现有守卫，
+  // 在排队检查之前 return。
+  it('keeps the adopt guard ahead of queueing', async () => {
+    const ds = activeSession({ lastScreenStatus: 'working', adoptedFrom: 'tmux:user-pane' });
+    vi.spyOn(workerPool, 'findActiveBySessionId').mockReturnValue(ds);
+
+    const res = await postSuspend('s-susp');
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toBe('adopt_suspend_unsupported');
+    expect(ds.pendingSuspendReason).toBeUndefined();
+  });
+});


### PR DESCRIPTION
`botmux suspend` 在会话**正在产出回复**时会直接杀掉 worker，把那一轮回复丢掉。本 PR 把它改成：**正在忙的会话先排队，等它自己结束后自动挂起。**

## 问题

`suspend all` 走的路径（`dashboard-ipc-server.ts` 的 `POST /api/sessions/:sessionId/suspend`）只有四道守卫：`session_not_active` / `session_transferring` / `adopt` / `backend_not_suspendable` —— **没有任何 busy 检查**，会话正在生成回复时照杀不误。

对比：同文件里的 `POST /api/host-overload/sweep` 有守卫 `if (ds.lastScreenStatus !== 'idle') continue;`（注释写着 *never cut an in-flight reply*），`idle-worker-sweeper` 同理。**三条挂起路径里两条有 busy 守卫，唯独手动 `suspend` 这条没有** —— 而凭证轮换 cron 驱动的 `suspend all` 走的正是没守卫的那条。

生产机 31 小时探针：并发 busy 会话 `p99=4 / max=5`，即**每次 `suspend all` 大约打断 0–5 个正在生成的回复，每天 4 次**。

## 改法

**排队**：IPC 路由收到请求时，若 `lastScreenStatus` 为 `working`/`analyzing`，不杀 worker，记 `pendingSuspendReason` + `pendingSuspendGeneration`，返回 `{ ok: true, suspended: false, reason: 'deferred' }`。

**兑现**：`screen_update` / `screenshot_uploaded` 转入 `idle`/`limited` 后，`queueMicrotask` 里调 `runPendingSuspendIfSettled()` 真正挂起。

必须推迟一拍（不能同步调）：`suspendWorker` 会清空 `ds.worker` 与 `ds.lastScreenStatus`，而同一 handler 之后还要用它们做回合收尾 —— usage 记账、✋→✅、状态转移 hook、末尾卡片，同步挂起会让这些**整段踩空**。

**claim 的生命周期绑定 worker generation**：claim 只针对「排队时正在产出的那一代」。该 generation 一旦被挂起（**任何路径** —— 包括 `/cd`、读隔离切换、idle sweeper 这些从不路过兑现 checkpoint 的）或退出，目标态即达成，由 `clearPendingSuspendClaim()` 在 `suspendWorker` 成功与 worker `exit` 两处统一消费；`runPendingSuspendIfSettled` 另有一道 generation 门控兜底。没有这层绑定，兑现 checkpoint 跑不到的场景（worker 崩溃、别的路径先挂起）会让标志活到下一代，在它第一次 idle 时把它平白挂掉。

**暂时性拒绝保留 claim**：routing transfer 期间 `suspendWorker` 返回 false 是**暂时**拒绝，吃掉 claim 会把请求一路丢到下一个 `suspend all` 周期；且安静会话不再发 `screen_update`，光保留还不够，所以拒绝后用 `deferUntilSessionTransferSettled` 注册显式重试。

**CLI 侧**：`botmux suspend` 汇总里新增「排队」计数，`--dry-run` 预告区分「将排队 / 将挂起 / 将跳过 / 将拒绝」，并修掉它此前把「daemon 不在线」和「状态读不到」混为一谈的问题。

## ⚠️ 交付边界是 best-effort，不保证「一条回复都不丢」

本 PR 解决的是「**回合还在产出时被一刀切断**」。它**没有**建立「回复交付完成 → 才撤销 worker ownership」这个 happens-before，所以 idle 与交付的交界处仍有一个窗口：

1. worker 先 drain bridge、`process.send(final_output)`，再发 idle `screen_update`；
2. daemon 收到 `final_output` 后**并不立即投递** —— `deliverFinalOutput()` 把 `sessionReply` 放进 `setTimeout(...)`，同步返回；
3. daemon 随后收到 idle，排一个 `queueMicrotask` 兑现挂起；
4. **微任务先于 timer**：挂起先跑，同一同步栈里 `ds.worker = null`；
5. `setTimeout` 的投递这才运行，首行 `isStillOwned()` 已假 → 放弃投递，日志留下 `Bridge final_output abandoned — worker/session ownership changed`。

只要两者落在同一轮事件循环，这个顺序就是确定的，不是概率窗口。

- **不是本 PR 引入的**：`idle-worker-sweeper` / `host_overload_sweep` 同样按 idle 挂起，窗口一直存在，只是跑定时器有几秒余量遮着。
- **但本 PR 放大了它**：兑现把挂起时机从「定时器几秒后」拉到「idle 的那一刻」，正贴边界。
- **影响面**：只涉及靠 bridge 兜底投递的回合（模型自己调了 `botmux send` 的回合，消息早已发出，不受影响）。一台生产机上该比例约 4.3%，且至今 `final_output abandoned` **0 次**。

彻底解法是两阶段 barrier（retiring → worker drain ACK → daemon 等投递完成 → 才 commit suspend，配一条把 `final_output + idle` 同批送入、断言 `sessionReply` 先于 ownership 撤销的行为测试）。**属于 ownership 生命周期的改动，比本 PR 大一个量级，留作后续单独改动**，设计文档 §2 已如实记录。

## 影响面

| 维度 | 评估 |
|-|-|
| 其它挂起路径 | 不受影响。`idle-worker-sweeper` / `host_overload_sweep` 本就有 busy 守卫，未改动 |
| `src/worker.ts` | **零 diff** —— 本 PR 只动 daemon 侧 |
| adopt / 不可挂起 backend | 守卫顺序不变，仍排在排队检查之前 |
| daemon 重启 | claim 只存内存，重启即丢；下一个 `suspend all` 周期重新排队，代价是延后一个周期 |
| 长时间 busy 的会话 | 不设兑现上限（设 deadline 等于又回到切断回复）。安全阀是可见性：CLI 明确报出排队数 |

## 改动清单

**4 个提交，7 个文件**：

```
239c49d6  feat(suspend): 会话正在产出回复时延迟挂起而非切断
46d80724  fix(cli): suspend --dry-run 区分「daemon 不在线」与「读不到」
4f6a5e53  fix(suspend): 排队的挂起请求绑定 worker generation，不再残留到下一代
3e099151  docs(suspend): 清扫与实现不一致的描述，并把 ownsGeneration 定位为 defense-in-depth
```

```
docs/design/deferred-suspend.md  | 471 +++
src/cli.ts                       |  90 +-
src/core/dashboard-ipc-server.ts |  21 +
src/core/types.ts                |  15 +
src/core/worker-pool.ts          | 133 +
test/deferred-suspend.test.ts    | 265 +++
test/ipc-suspend-route.test.ts   | 118 +++
7 files changed, 1109 insertions(+), 4 deletions(-)
```

## 验证

```
$ npx tsc --noEmit                 # exit 0
$ npx vitest run --project unit test/deferred-suspend.test.ts test/ipc-suspend-route.test.ts
  Test Files  2 passed (2)
       Tests  25 passed (25)
```

**新增 2 个测试文件、25 条用例**，全部是真行为断言（`__testOnly_runPendingSuspendIfSettled` + 直接调 `suspendWorker`），不是源码断言：

- 兑现门控：`working`/`analyzing` 期间空操作、`idle`/`limited` 才挂、reason 透传、被拒绝时 claim 保留、transfer 结算后重试
- claim 生命周期：任何成功的 `suspendWorker` 都消费 claim（覆盖不路过 checkpoint 的路径）、被拒绝时 claim 与 generation 一并保留、claim 属于更早 generation 时就地消费而绝不挂新 worker、同代照常兑现
- IPC 路由：排队分支返回 `deferred`、守卫顺序、幂等 `no_live_worker`

**注入回归验证过**：去掉 `suspendWorker` 里的 claim 消费点、或去掉 generation 门控，对应用例分别失败，恢复后全绿。

全量 unit 做过基线对照（只看失败文件名集合、不看数字）：把分支 `reset --hard origin/master` 跑同一组失败文件得 **20 failed / 305 passed**，带本 PR 跑同一组**同样 20 failed / 305 passed，文件集合一字不差** —— 那批是基线自带的不稳定集成测试。

## 一条留给后来人的教训

本 PR 早先有第二个 commit「挂起前 flush transcript 桥」，已整体删除：它的产物在 daemon 侧会被 message handler 的统一 fence（`if (ds.worker !== worker) return`，排在 switch 之前）**确定性丢弃** —— 因为 `suspendWorker` 在发出 suspend 消息后的**同一同步栈内**就把 `ds.worker = null`，而 worker 要收到消息之后才开始 flush。

它配套的测试 5/5 全绿却发现不了这一点，因为**只对 worker 侧做源码顺序断言、完全没跨过 daemon 的接收边界**。

> 跨进程的承诺，必须由跨过那道边界的行为测试来钉，源码断言证明不了任何交付。

删掉它同时也消掉了它引入的 cold-refork race（`await flush` 把 `destroySession` 推迟最多 500ms，其间新 worker 可能 reattach 同名 pane 再被旧 worker 杀掉）。
