### PR TITLE
fix(kimi): 修复多行输入未提交

### DIFF
--- a/src/adapters/cli/kimi.ts
+++ b/src/adapters/cli/kimi.ts
@@ -4,6 +4,11 @@ import type { CliAdapter, PtyHandle } from './types.js';
 
 import { delay } from '../../utils/timing.js';
 
+const BRACKETED_PASTE_START = '\x1b[200~';
+const BRACKETED_PASTE_END = '\x1b[201~';
+const KIMI_FIRST_WRITE_SETTLE_MS = 250;
+const kimiFirstWriteSeen = new WeakSet<PtyHandle>();
+
 export function createKimiAdapter(pathOverride?: string): CliAdapter {
   const rawBin = pathOverride ?? 'kimi';
   let cachedBin: string | undefined;
@@ -31,14 +36,23 @@ export function createKimiAdapter(pathOverride?: string): CliAdapter {
     },
 
     async writeInput(pty: PtyHandle, content: string) {
-      if (pty.sendText && pty.sendSpecialKeys) {
-        pty.sendText(content);
-        await delay(200);
-        pty.sendSpecialKeys('Enter');
-      } else {
-        pty.write(content);
-        await delay(1000);
-        pty.write('\r');
+      try {
+        if (!kimiFirstWriteSeen.has(pty)) {
+          kimiFirstWriteSeen.add(pty);
+          await delay(KIMI_FIRST_WRITE_SETTLE_MS);
+        }
+        if (pty.pasteText && pty.sendSpecialKeys) {
+          pty.pasteText(content);
+          await delay(200);
+          pty.sendSpecialKeys('Enter');
+        } else {
+          const pasted = `${BRACKETED_PASTE_START}${content}${BRACKETED_PASTE_END}`;
+          pty.write(pasted);
+          await delay(1000);
+          pty.write('\r');
+        }
+      } catch {
+        return;
       }
     },
 

--- a/test/write-input.test.ts
+++ b/test/write-input.test.ts
@@ -55,6 +55,7 @@ import { createMtrAdapter } from '../src/adapters/cli/mtr.js';
 import { createHermesAdapter } from '../src/adapters/cli/hermes.js';
 import { createMiraAdapter } from '../src/adapters/cli/mira.js';
 import { createPiAdapter } from '../src/adapters/cli/pi.js';
+import { createKimiAdapter } from '../src/adapters/cli/kimi.js';
 import { createGrokAdapter } from '../src/adapters/cli/grok.js';
 import { createKiroCliAdapter } from '../src/adapters/cli/kiro-cli.js';
 import type { CliAdapter, PtyHandle } from '../src/adapters/cli/types.js';
@@ -171,7 +172,6 @@ const PLAIN_ADAPTERS: AdapterEntry[] = [
 ];
 
 const OPENCODE_ADAPTER: AdapterEntry = ['opencode', createOpenCodeAdapter('/bin/opencode')];
-
 /** Node runner adapters use a one-line base64 control protocol so multiline
  *  content cannot be split by terminal Enter semantics. */
 const APP_RUNNER_ADAPTERS: AdapterEntry[] = [
@@ -184,18 +184,19 @@ const HUMAN_TYPING_ADAPTERS: AdapterEntry[] = [
 ];
 
 /** Adapters that use tmux pasteText (load-buffer + paste-buffer -d) with
- *  delayed Enter — CoCo / Trae CLI, Codex, and Pi. See coco.ts for the Trae 0.120.31
- *  burst bug, and codex.ts for the per-line-submit bug bracketed paste fixes
+ *  delayed Enter — CoCo / Trae CLI, Codex, Kimi, and Pi. See coco.ts for the
+ *  Trae 0.120.31 burst bug, and codex.ts for the per-line-submit bug bracketed paste fixes
  *  (Codex 0.134+ handles bracketed paste correctly — the old "Codex exits on
  *  bracketed paste" note was true only for a much earlier build). */
 const PASTE_BUFFER_ADAPTERS: AdapterEntry[] = [
   ['coco', createCocoAdapter('/bin/coco')],
   ['codex', createCodexAdapter('/bin/codex')],
+  ['kimi', createKimiAdapter('/bin/kimi')],
   ['pi', createPiAdapter('/bin/pi')],
 ];
 
 /** Adapters that wrap content in bracketed-paste markers (\x1b[200~ ... \x1b[201~)
- *  in non-tmux mode — claude-code and coco. */
+ *  in non-tmux mode. */
 const BRACKETED_PASTE_FALLBACK_ADAPTERS: AdapterEntry[] = [
   ...HUMAN_TYPING_ADAPTERS,
   ...PASTE_BUFFER_ADAPTERS,
@@ -573,6 +574,7 @@ describe('writeInput: multiline preserves unicode and session IDs', () => {
     expect(pty.pasteText).toHaveBeenCalledWith(followUp);
     expect(pty.sendSpecialKeys).toHaveBeenLastCalledWith('Enter');
   });
+
 });
 
 // =========================================================================
@@ -647,6 +649,120 @@ describe('writeInput: edge cases', () => {
     const pty = makeTmuxPty();
     await adapter.writeInput(pty, '');
     expect(pty.sendSpecialKeys).toHaveBeenCalledWith('Enter');
+  });
+
+  it('kimi: settles only the first write for each backend instance', async () => {
+    vi.useFakeTimers();
+    try {
+      const adapter = createKimiAdapter('/bin/kimi');
+      const pty = makeTmuxPty();
+
+      const first = adapter.writeInput(pty, 'first');
+      expect(pty.pasteText).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(Math.round(250 * TIME_SCALE));
+      expect(pty.pasteText).toHaveBeenCalledOnce();
+      await vi.runAllTimersAsync();
+      await first;
+
+      const second = adapter.writeInput(pty, 'second');
+      expect(pty.pasteText).toHaveBeenCalledTimes(2);
+      await vi.runAllTimersAsync();
+      await second;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('kimi: treats a side-effecting false paste result as assume-issued', async () => {
+    const adapter = createKimiAdapter('/bin/kimi');
+    const pasted: string[] = [];
+    const pty = {
+      write: vi.fn(),
+      pasteText: vi.fn((content: string) => {
+        pasted.push(content);
+        return false;
+      }),
+      sendSpecialKeys: vi.fn(),
+    } satisfies PtyHandle;
+
+    const result = await adapter.writeInput(pty, MULTILINE);
+
+    expect(pasted).toEqual([MULTILINE]);
+    expect(pty.pasteText).toHaveBeenCalledTimes(1);
+    expect(pty.sendSpecialKeys).toHaveBeenCalledTimes(1);
+    expect(result).toBeUndefined();
+  });
+
+  it('kimi: treats a side-effecting false Enter result as assume-issued', async () => {
+    const adapter = createKimiAdapter('/bin/kimi');
+    const submittedKeys: string[] = [];
+    const pty = {
+      write: vi.fn(),
+      pasteText: vi.fn(),
+      sendSpecialKeys: vi.fn((...keys: string[]) => {
+        submittedKeys.push(...keys);
+        return false;
+      }),
+    } satisfies PtyHandle;
+
+    const result = await adapter.writeInput(pty, MULTILINE);
+
+    expect(pty.pasteText).toHaveBeenCalledTimes(1);
+    expect(submittedKeys).toEqual(['Enter']);
+    expect(pty.sendSpecialKeys).toHaveBeenCalledTimes(1);
+    expect(result).toBeUndefined();
+  });
+
+  it('kimi: sends large prompts through pasteText instead of argv-bound sendText', async () => {
+    const adapter = createKimiAdapter('/bin/kimi');
+    const pty = makeTmuxPty();
+    const content = 'routing-context\n' + 'x'.repeat(64 * 1024);
+
+    const result = await adapter.writeInput(pty, content);
+
+    expect(pty.pasteText).toHaveBeenCalledWith(content);
+    expect(pty.sendText).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+
+  it('kimi: does not retry when paste transport throws after a side effect', async () => {
+    const adapter = createKimiAdapter('/bin/kimi');
+    const pasted: string[] = [];
+    const pty = {
+      write: vi.fn(),
+      pasteText: vi.fn((content: string) => {
+        pasted.push(content);
+        throw new Error('confirmation timed out');
+      }),
+      sendSpecialKeys: vi.fn(),
+    } satisfies PtyHandle;
+
+    const result = await adapter.writeInput(pty, MULTILINE);
+
+    expect(pasted).toEqual([MULTILINE]);
+    expect(pty.pasteText).toHaveBeenCalledTimes(1);
+    expect(pty.sendSpecialKeys).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+
+  it('kimi: raw PTY false writes remain assume-issued instead of clean non-submit', async () => {
+    const adapter = createKimiAdapter('/bin/kimi');
+    const writes: string[] = [];
+    const pty = {
+      write: vi.fn((data: string) => {
+        writes.push(data);
+        return false;
+      }),
+    } satisfies PtyHandle;
+
+    const result = await adapter.writeInput(pty, MULTILINE);
+
+    expect(writes).toEqual([
+      `\x1b[200~${MULTILINE}\x1b[201~`,
+      '\r',
+    ]);
+    expect(pty.write).toHaveBeenCalledTimes(2);
+    expect(result).toBeUndefined();
   });
 
   it('claude-code: image path in multiline still types via sendText', async () => {


### PR DESCRIPTION
## 问题

Kimi Code TUI 收到 Botmux 首条消息时，旧适配器通过普通 `sendText` 写入完整 routing prompt。该 prompt 包含多行 XML、技能上下文和用户消息；在生产规模下，Kimi 会把这段快速输入视为仍未结束的 paste burst，随后发送的 Enter 被吸收为换行，内容留在输入框中。冷启动时还存在一个更窄的窗口：TUI 第一次显示 composer 后立即写入，首条消息仍可能被初始化过程丢弃。用户侧表现为消息发出后没有回应、仍显示 `No session yet`。

## 修复

- tmux / Zellij / ZMX 等带 `pasteText` 能力的后端统一走 backend bracketed-paste 传输，再单独发送 Enter。
  - tmux 实际使用 `load-buffer` stdin + `paste-buffer -p`，避免把完整 prompt 放进 `send-keys` argv，同时支持大输入。
  - Zellij / ZMX 继续复用其已有 bracketed-paste 实现。
- raw PTY 保留显式 `\x1b[200~...\x1b[201~` 回退。
- 每个 backend 实例的首次 `writeInput` 在 paste 前等待 250ms，让冷启动 composer 完成初始化；同一 backend 的后续输入不增加该等待。
- 保持旧 adapter 的 assume-issued 返回语义：`false` 或副作用后抛错都不转换为 clean non-submit，避免 queued activation 自动重放造成正文重复或同一 turn 执行两次。
- 补充 64 KiB 大输入、首次写入和歧义传输场景测试。

## 影响面

- 仅修改 `src/adapters/cli/kimi.ts` 与对应输入测试。
- 未修改公共 worker、公共 backend、其它 CLI adapter、IM 路由或会话恢复逻辑。
- Kimi 启动参数、模型选择、native session 恢复保持不变。
- 首写 settle 按 backend 对象身份记录：fresh spawn / backend replacement 各自执行一次，warm follow-up 不重复等待。

## 验证

- `pnpm build`
  - TypeScript、Dashboard bundle、build audit 全部通过。
- `pnpm vitest run --project unit test/write-input.test.ts test/tmux-backend-input.test.ts test/tmux-pipe-backend.test.ts`
  - 3 个文件、185 条测试全部通过。
- blocking review 回归：
  - paste 产生副作用后返回 false：只粘贴一次，返回 `undefined`；
  - Enter 产生副作用后返回 false：只发送一次 Enter，返回 `undefined`；
  - paste 产生副作用后抛异常：不追加正文、不返回 clean non-submit；
  - raw PTY `write()` 返回 false：仍保持 assume-issued，不触发自动重放；
  - 64 KiB prompt 必须走 `pasteText`，`sendText` 调用为 0；
  - 同一 backend 首次写入有 settle，第二次写入不重复 settle。
- Kimi Code CLI `0.34.0` + tmux `2.8` 真实 TUI：
  - 14,439 Bytes 脱敏 production-shaped prompt：修复前无响应，修复后模型响应、`sendTextCalls=0`；
  - 约 30 KiB prompt：通过 `paste-buffer` 正常响应；
  - 冷启动时序矩阵（4,390+ Bytes 脱敏首条 prompt）：ready 后外部等待 250/1000/2000ms 三组均建立 native session 并返回 sentinel；
  - 最终代码验证：外部等待 0ms，仅依赖 adapter 内 250ms 首写 settle，首条即建立 native session 并返回 sentinel。
- `pnpm test`
  - 13,974 条通过，10 条跳过，4 条失败；
  - 2 条 Codex App runner timeout 单独重跑均通过；
  - 另外 2 条为本机 `tmux-backend-env` shell wrapper 与 adopted Pi tmux fixture，已在最新 `origin/master` 独立 worktree、同机同命令稳定复现，与本 PR 两个改动文件无关。

## 实证截图

### 修复前：首轮多行 prompt 留在输入框，仍为 `No session yet`

![Kimi pre-fix prompt stuck](https://raw.githubusercontent.com/acllm/botmux/assets/pr-788-kimi-e2e/pr-assets/788/kimi-old-stuck.png)

### 修复后：同一脱敏 prompt 一次提交，模型返回结果

![Kimi patched prompt submitted](https://raw.githubusercontent.com/acllm/botmux/assets/pr-788-kimi-e2e/pr-assets/788/kimi-new-ok.png)
