### PR TITLE
fix(setup): 自动发版不再重置应用可见范围（原样镜像线上白/黑名单）

### DIFF
--- a/src/services/open-platform-rename.ts
+++ b/src/services/open-platform-rename.ts
@@ -33,6 +33,7 @@ import {
   type OpenPlatformClientResult,
   type StoredCookie,
 } from '../setup/open-platform-automation.js';
+import { parseOnlineVisibility } from '../setup/open-platform-visibility.js';
 import { normalizeBrand, type Brand } from '../im/lark/lark-hosts.js';
 import { logger } from '../utils/logger.js';
 
@@ -67,112 +68,6 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 
 function asRecord(value: unknown): Record<string, unknown> {
   return isPlainRecord(value) ? value : {};
-}
-
-// visible/online 各集合的 id 字段族：console 内部接口的条目形态没有公开契约，
-// members 实测是 { id }，departments / groups 未实测——按开放平台常见命名把
-// 候选 key 都列上，并配合下面的 fail-closed 兜底。
-const MEMBER_ID_KEYS = ['id', 'openId', 'open_id', 'userId', 'user_id', 'memberId', 'member_id'];
-const DEPARTMENT_ID_KEYS = ['id', 'departmentId', 'department_id', 'openDepartmentId', 'open_department_id'];
-const GROUP_ID_KEYS = ['id', 'groupId', 'group_id', 'chatId', 'chat_id', 'openChatId', 'open_chat_id'];
-
-/** 可见范围形态未识别 —— 绝不能发布可能改变可见性的版本，fail closed。 */
-class VisibilityParseError extends Error {
-  constructor(readonly collection: string) {
-    super(`visible/online ${collection} 形态未识别，已中止（避免把线上可见范围发布成空/发漏）`);
-  }
-}
-
-function pickIdByKeys(item: unknown, keys: string[]): string {
-  if (typeof item === 'string') return item;
-  if (typeof item === 'number' && Number.isFinite(item)) return String(item);
-  const rec = asRecord(item);
-  for (const key of keys) {
-    const v = rec[key];
-    if (typeof v === 'string' && v) return v;
-    if (typeof v === 'number' && Number.isFinite(v)) return String(v);
-  }
-  return '';
-}
-
-/**
- * 条目 → id 列表。fail closed：任何一个条目解析不出 id 就抛
- * {@link VisibilityParseError}——部分丢失同样会收窄可见范围，宁可中止
- * 走降级路径，也不发布一个"看起来成功"但少了人的版本。
- */
-function idList(value: unknown, keys: string[], collection: string): string[] {
-  if (!Array.isArray(value)) return [];
-  const ids = value.map((item) => pickIdByKeys(item, keys)).filter(Boolean);
-  if (ids.length < value.length) throw new VisibilityParseError(collection);
-  return ids;
-}
-
-/** 集合键：只有「键不存在」允许当空（仅 legacy 顶层形态的可选 groups 会走到）；
- *  键存在则值必须是数组——null/字符串等一律 fail closed，不得静默变空集合。 */
-function idListStrict(rec: Record<string, unknown>, key: string, keys: string[], label: string): string[] {
-  if (!(key in rec)) return [];
-  const value = rec[key];
-  if (!Array.isArray(value)) throw new VisibilityParseError(`${label}.${key}`);
-  return idList(value, keys, `${label}.${key}`);
-}
-
-type VisibilitySuggest = { departments: string[]; members: string[]; groups: string[]; isAll: number };
-
-const EMPTY_VISIBILITY: VisibilitySuggest = { departments: [], members: [], groups: [], isAll: 0 };
-
-/**
- * visible/online 的白/黑名单块 → 版本 payload 的 visibleSuggest 形态。
- * fail closed：块必须是对象且带齐 requiredKeys（实测线上契约 whiteList/blackList
- * 恒有 departments/groups/members/isAll 四键）——{}、null、缺键的残缺响应一律
- * 中止，绝不默认成「空可见范围」发布出去（那会把应用从所有人面前收走；黑名单
- * 丢失同理会把被拉黑的人放出来）。
- */
-function visibilityBlock(raw: unknown, label: string, requiredKeys: readonly string[]): VisibilitySuggest {
-  if (!isPlainRecord(raw)) throw new VisibilityParseError(label);
-  for (const key of requiredKeys) {
-    if (!(key in raw)) throw new VisibilityParseError(`${label}.${key}(缺失)`);
-  }
-  // isAll 只认 0/1/false/true：'1'、null 等异常值可能把「全员可见」误发布成
-  // 不可见（或反之），一律 fail closed。
-  const isAllRaw = raw.isAll;
-  if (isAllRaw !== 0 && isAllRaw !== 1 && isAllRaw !== false && isAllRaw !== true) {
-    throw new VisibilityParseError(`${label}.isAll`);
-  }
-  return {
-    departments: idListStrict(raw, 'departments', DEPARTMENT_ID_KEYS, label),
-    members: idListStrict(raw, 'members', MEMBER_ID_KEYS, label),
-    groups: idListStrict(raw, 'groups', GROUP_ID_KEYS, label),
-    isAll: isAllRaw === 1 || isAllRaw === true ? 1 : 0,
-  };
-}
-
-/** 现行契约块的必备键（实测所有 app 的 whiteList/blackList 都带齐这四键）。 */
-const BLOCK_REQUIRED_KEYS = ['departments', 'groups', 'members', 'isAll'] as const;
-/** 旧形态（可见范围直接铺在 data 顶层）没有 groups 容器。 */
-const LEGACY_TOP_REQUIRED_KEYS = ['departments', 'members', 'isAll'] as const;
-
-/**
- * 解析 visible/online 响应为 白/黑名单 suggest 对。两种已知形态：
- *   • 现行：data.whiteList + data.blackList 成对出现（成对是契约的一部分——
- *     只认白名单会把 blackList 静默丢成空、把被拉黑的人放出来，fail closed）
- *   • 旧形态兜底：可见范围直接铺在 data 顶层（无 whiteList 容器）；此形态
- *     没有黑名单容器，blackList 缺失按空处理，出现则严格解析
- */
-function parseOnlineVisibility(payload: unknown): { visibleSuggest: VisibilitySuggest; blackVisibleSuggest: VisibilitySuggest } {
-  const data = asRecord(payload).data;
-  if (!isPlainRecord(data)) throw new VisibilityParseError('data');
-  if ('whiteList' in data) {
-    return {
-      visibleSuggest: visibilityBlock(data.whiteList, 'whiteList', BLOCK_REQUIRED_KEYS),
-      blackVisibleSuggest: visibilityBlock(data.blackList, 'blackList', BLOCK_REQUIRED_KEYS),
-    };
-  }
-  return {
-    visibleSuggest: visibilityBlock(data, 'whiteList', LEGACY_TOP_REQUIRED_KEYS),
-    blackVisibleSuggest: data.blackList == null
-      ? { ...EMPTY_VISIBILITY }
-      : visibilityBlock(data.blackList, 'blackList', BLOCK_REQUIRED_KEYS),
-  };
 }
 
 function failureFromError(err: unknown, fallbackReason: OpenPlatformRenameFailureReason = 'api_error'): { reason: OpenPlatformRenameFailureReason; message: string } {

--- a/src/setup/open-platform-automation.ts
+++ b/src/setup/open-platform-automation.ts
@@ -13,6 +13,11 @@ import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import qrcode from 'qrcode-terminal';
 import { VC_MEETING_BOT_EVENTS } from './verify-permissions.js';
+import {
+  parseOnlineVisibility,
+  VisibilityParseError,
+  type VisibilitySuggest,
+} from './open-platform-visibility.js';
 
 /**
  * All non-VC events (application identity) that the botmux dispatcher consumes.
@@ -153,6 +158,7 @@ export type OpenPlatformAutomationResult =
         | 'scope_mapping_failed'
         | 'event_verification_failed'
         | 'version_verification_failed'
+        | 'visibility_unreadable'
         | 'network'
         | 'api_error';
       message: string;
@@ -510,6 +516,14 @@ function extractEventIdsFromDetails(value: unknown): string[] {
  * 那会让版本进入人工审核、发布后应用停在「未上架/未启用」(tenantAppStatus=0),
  * 事件配置进了草稿也无法在企业内生效。visibleSuggest.members 必须含创建者,
  * 否则同样不会自动上架启用。
+ *
+ * ⚠️ **visibleSuggest 是全量覆写语义**：这里给什么,新版本的可见范围就是什么,
+ * 没给的集合会被清空而不是保持原样。因此**只有全新应用的首次发布**能用这个
+ * 默认的空 departments/groups + isAll:0 —— 对已有应用发版,调用方必须先用
+ * {@link parseOnlineVisibility} 读回线上可见范围并整块覆盖 visibleSuggest /
+ * blackVisibleSuggest（见 automateOpenPlatformSetup 与 open-platform-rename）。
+ * 曾经漏掉这一步,导致每次权限自愈自动发版都把「全员可见 / 部门 / 用户组」
+ * 静默清空。
  */
 export function buildAppVersionCreatePayload(appVersion: string, visibleMemberIds: string[] = []) {
   return {
@@ -893,16 +907,42 @@ export async function automateOpenPlatformSetup(
 
   try {
     await postJson(`/developers/v1/safe_setting/update/${options.appId}`, buildSafeSettingPayload(options.appId));
-    const contactRange = await postJson(`/developers/v1/contact_range/${options.appId}`, {});
-    // 镜像应用原有 contact range 作为版本可见范围——绝不注入「当前 Web session
-    // 操作者」:automateOpenPlatformSetup 也被 VC listener 保存 / 权限自愈 / 选择
-    // 已有应用等路径调用,那里操作者不一定是创建者/现有可见成员,注入会悄悄扩大
-    // 已有 bot 的可见范围。新建应用的「上架启用」由 createOpenPlatformAppWithClient
+    // 原样镜像**线上版本**的可见范围（白/黑名单都带）——绝不注入「当前 Web
+    // session 操作者」:automateOpenPlatformSetup 也被 VC listener 保存 / 权限自愈 /
+    // 选择已有应用等路径调用,那里操作者不一定是创建者/现有可见成员,注入会悄悄
+    // 扩大已有 bot 的可见范围。新建应用的「上架启用」由 createOpenPlatformAppWithClient
     // 的首次发布(含创建者可见)完成,与本处无关。
-    const visibleMemberIds = extractContactRangeMemberIds(contactRange);
+    //
+    // ⚠️ 数据来源必须是 visible/online（应用可见范围），不是 contact_range
+    // （通讯录权限范围，是另一个概念）。历史上这里读的是 contact_range 且只取
+    // members、把 departments/groups/isAll 写死空值,于是每次自动发版都把「全员
+    // 可见 / 按部门授权 / 按用户组授权」静默清成「仅少数个人可见」——权限自愈
+    // 一重启就发版,受影响的人第二天集体访问不了应用。
+    //
+    // 解析失败 fail closed：此时还没建版,可见范围零改动,调用方降级为给管理员
+    // 发 DM 手动处理,绝不发布一个可能把人关在门外的版本。
+    let visibility: { visibleSuggest: VisibilitySuggest; blackVisibleSuggest: VisibilitySuggest };
+    try {
+      visibility = parseOnlineVisibility(await postJson(`/developers/v1/visible/online/${options.appId}`, {}));
+    } catch (err: any) {
+      if (!(err instanceof VisibilityParseError)) throw err;
+      return {
+        ok: false,
+        reason: 'visibility_unreadable',
+        message: `无法可靠读取应用现有可见范围（${err.message}），已中止发版以免重置可见范围；请到开放平台手动发布新版本`,
+        sessionFile,
+        subscribedEventCount,
+        eventWarning,
+        missingVcEvents,
+        eventModeReady,
+      };
+    }
     const versionList = await postJson(`/developers/v1/app_version/list/${options.appId}`, {});
     const appVersion = nextAppVersion(versionList);
-    const created = await postJson(`/developers/v1/app_version/create/${options.appId}`, buildAppVersionCreatePayload(appVersion, visibleMemberIds));
+    const versionPayload = buildAppVersionCreatePayload(appVersion) as unknown as Record<string, unknown>;
+    versionPayload.visibleSuggest = visibility.visibleSuggest;
+    versionPayload.blackVisibleSuggest = visibility.blackVisibleSuggest;
+    const created = await postJson(`/developers/v1/app_version/create/${options.appId}`, versionPayload);
     const versionId = extractVersionId(created);
     if (options.requireVerifiedEvents && !versionId) {
       return {
@@ -1748,15 +1788,6 @@ export function nextAppVersion(payload: unknown): string {
     return a;
   });
   return [max[0], max[1], max[2] + 1].join('.');
-}
-
-function extractContactRangeMemberIds(payload: unknown): string[] {
-  const data = asRecord(asRecord(payload).data);
-  const detail = asRecord(data.contactRangeDetail);
-  const members = Array.isArray(detail.members) ? detail.members : [];
-  return uniqueStrings(members
-    .map(item => pickString(asRecord(item), ['id']))
-    .filter((id): id is string => Boolean(id)));
 }
 
 /** 从 app_version/create 响应提取 versionId（多种响应形态兼容）。 */

--- a/src/setup/open-platform-visibility.ts
+++ b/src/setup/open-platform-visibility.ts
@@ -1,0 +1,132 @@
+/**
+ * 应用可见范围（谁能看到 / 使用这个飞书应用）的读取与 fail-closed 解析。
+ *
+ * 为什么单独成模块：**每一次 `app_version/create` 都会整体覆写可见范围**——
+ * payload 里的 `visibleSuggest` 就是新版本的可见范围，漏掉的集合不是"保持不变"
+ * 而是"被清空"。因此任何要发版的链路都必须先把线上可见范围原样读回来再镜像
+ * 过去，且读不准时宁可不发版。
+ *
+ * 这段解析原本只长在 `services/open-platform-rename.ts`（改名/改头像链路）里，
+ * 而 `setup/open-platform-automation.ts` 的自动发版走的是另一套（读 `contact_range`
+ * 只取 members，departments/groups/isAll 写死空值），把「全员可见 / 按部门授权 /
+ * 按用户组授权」在每次自动发版时静默清成「仅少数个人可见」。抽到这里共用，
+ * 保证所有发版链路只有一个可见范围来源。
+ *
+ * 正确的数据来源是 `/developers/v1/visible/online/{clientId}`（线上版本的可见
+ * 范围），**不是** `/developers/v1/contact_range/{clientId}`——后者是「通讯录权限
+ * 范围」（应用能读谁的通讯录），和「应用可见范围」是两个概念。
+ */
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return isPlainRecord(value) ? value : {};
+}
+
+// visible/online 各集合的 id 字段族：console 内部接口的条目形态没有公开契约，
+// members 实测是 { id }，departments / groups 未实测——按开放平台常见命名把
+// 候选 key 都列上，并配合下面的 fail-closed 兜底。
+const MEMBER_ID_KEYS = ['id', 'openId', 'open_id', 'userId', 'user_id', 'memberId', 'member_id'];
+const DEPARTMENT_ID_KEYS = ['id', 'departmentId', 'department_id', 'openDepartmentId', 'open_department_id'];
+const GROUP_ID_KEYS = ['id', 'groupId', 'group_id', 'chatId', 'chat_id', 'openChatId', 'open_chat_id'];
+
+/** 可见范围形态未识别 —— 绝不能发布可能改变可见性的版本，fail closed。 */
+export class VisibilityParseError extends Error {
+  constructor(readonly collection: string) {
+    super(`visible/online ${collection} 形态未识别，已中止（避免把线上可见范围发布成空/发漏）`);
+  }
+}
+
+function pickIdByKeys(item: unknown, keys: string[]): string {
+  if (typeof item === 'string') return item;
+  if (typeof item === 'number' && Number.isFinite(item)) return String(item);
+  const rec = asRecord(item);
+  for (const key of keys) {
+    const v = rec[key];
+    if (typeof v === 'string' && v) return v;
+    if (typeof v === 'number' && Number.isFinite(v)) return String(v);
+  }
+  return '';
+}
+
+/**
+ * 条目 → id 列表。fail closed：任何一个条目解析不出 id 就抛
+ * {@link VisibilityParseError}——部分丢失同样会收窄可见范围，宁可中止
+ * 走降级路径，也不发布一个"看起来成功"但少了人的版本。
+ */
+function idList(value: unknown, keys: string[], collection: string): string[] {
+  if (!Array.isArray(value)) return [];
+  const ids = value.map((item) => pickIdByKeys(item, keys)).filter(Boolean);
+  if (ids.length < value.length) throw new VisibilityParseError(collection);
+  return ids;
+}
+
+/** 集合键：只有「键不存在」允许当空（仅 legacy 顶层形态的可选 groups 会走到）；
+ *  键存在则值必须是数组——null/字符串等一律 fail closed，不得静默变空集合。 */
+function idListStrict(rec: Record<string, unknown>, key: string, keys: string[], label: string): string[] {
+  if (!(key in rec)) return [];
+  const value = rec[key];
+  if (!Array.isArray(value)) throw new VisibilityParseError(`${label}.${key}`);
+  return idList(value, keys, `${label}.${key}`);
+}
+
+export type VisibilitySuggest = { departments: string[]; members: string[]; groups: string[]; isAll: number };
+
+export const EMPTY_VISIBILITY: VisibilitySuggest = { departments: [], members: [], groups: [], isAll: 0 };
+
+/**
+ * visible/online 的白/黑名单块 → 版本 payload 的 visibleSuggest 形态。
+ * fail closed：块必须是对象且带齐 requiredKeys（实测线上契约 whiteList/blackList
+ * 恒有 departments/groups/members/isAll 四键）——{}、null、缺键的残缺响应一律
+ * 中止，绝不默认成「空可见范围」发布出去（那会把应用从所有人面前收走；黑名单
+ * 丢失同理会把被拉黑的人放出来）。
+ */
+function visibilityBlock(raw: unknown, label: string, requiredKeys: readonly string[]): VisibilitySuggest {
+  if (!isPlainRecord(raw)) throw new VisibilityParseError(label);
+  for (const key of requiredKeys) {
+    if (!(key in raw)) throw new VisibilityParseError(`${label}.${key}(缺失)`);
+  }
+  // isAll 只认 0/1/false/true：'1'、null 等异常值可能把「全员可见」误发布成
+  // 不可见（或反之），一律 fail closed。
+  const isAllRaw = raw.isAll;
+  if (isAllRaw !== 0 && isAllRaw !== 1 && isAllRaw !== false && isAllRaw !== true) {
+    throw new VisibilityParseError(`${label}.isAll`);
+  }
+  return {
+    departments: idListStrict(raw, 'departments', DEPARTMENT_ID_KEYS, label),
+    members: idListStrict(raw, 'members', MEMBER_ID_KEYS, label),
+    groups: idListStrict(raw, 'groups', GROUP_ID_KEYS, label),
+    isAll: isAllRaw === 1 || isAllRaw === true ? 1 : 0,
+  };
+}
+
+/** 现行契约块的必备键（实测所有 app 的 whiteList/blackList 都带齐这四键）。 */
+const BLOCK_REQUIRED_KEYS = ['departments', 'groups', 'members', 'isAll'] as const;
+/** 旧形态（可见范围直接铺在 data 顶层）没有 groups 容器。 */
+const LEGACY_TOP_REQUIRED_KEYS = ['departments', 'members', 'isAll'] as const;
+
+/**
+ * 解析 visible/online 响应为 白/黑名单 suggest 对。两种已知形态：
+ *   • 现行：data.whiteList + data.blackList 成对出现（成对是契约的一部分——
+ *     只认白名单会把 blackList 静默丢成空、把被拉黑的人放出来，fail closed）
+ *   • 旧形态兜底：可见范围直接铺在 data 顶层（无 whiteList 容器）；此形态
+ *     没有黑名单容器，blackList 缺失按空处理，出现则严格解析
+ */
+export function parseOnlineVisibility(payload: unknown): { visibleSuggest: VisibilitySuggest; blackVisibleSuggest: VisibilitySuggest } {
+  const data = asRecord(payload).data;
+  if (!isPlainRecord(data)) throw new VisibilityParseError('data');
+  if ('whiteList' in data) {
+    return {
+      visibleSuggest: visibilityBlock(data.whiteList, 'whiteList', BLOCK_REQUIRED_KEYS),
+      blackVisibleSuggest: visibilityBlock(data.blackList, 'blackList', BLOCK_REQUIRED_KEYS),
+    };
+  }
+  return {
+    visibleSuggest: visibilityBlock(data, 'whiteList', LEGACY_TOP_REQUIRED_KEYS),
+    blackVisibleSuggest: data.blackList == null
+      ? { ...EMPTY_VISIBILITY }
+      : visibilityBlock(data.blackList, 'blackList', BLOCK_REQUIRED_KEYS),
+  };
+}

--- a/test/setup-open-platform-automation.test.ts
+++ b/test/setup-open-platform-automation.test.ts
@@ -64,6 +64,8 @@ function openPlatformSubscriptionMock(appId: string, opts: {
   /** event/update 中包含这些事件时整批被拒(逐个重试时对应单个失败)。 */
   rejectEventNames?: string[];
   initial?: { appEvents?: string[]; userEvents?: string[]; callbacks?: string[]; callbackMode?: number; eventMode?: number };
+  /** visible/online 响应体（不给时用「全员可见」的现行契约形态）。 */
+  visibleOnline?: unknown;
 } = {}) {
   const state = {
     eventMode: opts.initial?.eventMode ?? 4,
@@ -111,6 +113,15 @@ function openPlatformSubscriptionMock(appId: string, opts: {
     }
     if (href.endsWith(`/developers/v1/callback/${appId}`)) {
       return Response.json({ code: 0, data: { callbackMode: state.callbackMode, callbacks: [...state.callbacks] } });
+    }
+    if (href.endsWith(`/developers/v1/visible/online/${appId}`)) {
+      return Response.json(opts.visibleOnline ?? {
+        code: 0,
+        data: {
+          whiteList: { departments: [], members: [], groups: [], isAll: 1 },
+          blackList: { departments: [], members: [], groups: [], isAll: 0 },
+        },
+      });
     }
     return null;
   };
@@ -829,7 +840,7 @@ describe('automateOpenPlatformSetup', () => {
       '/developers/v1/callback/update/cli_x',
       '/developers/v1/callback/cli_x',
       '/developers/v1/safe_setting/update/cli_x',
-      '/developers/v1/contact_range/cli_x',
+      '/developers/v1/visible/online/cli_x',
       '/developers/v1/app_version/list/cli_x',
       '/developers/v1/app_version/create/cli_x',
       '/developers/v1/publish/commit/cli_x/v1',
@@ -904,7 +915,7 @@ describe('automateOpenPlatformSetup', () => {
       '/developers/v1/callback/update/cli_x',
       '/developers/v1/callback/cli_x',
       '/developers/v1/safe_setting/update/cli_x',
-      '/developers/v1/contact_range/cli_x',
+      '/developers/v1/visible/online/cli_x',
       '/developers/v1/app_version/list/cli_x',
       '/developers/v1/app_version/create/cli_x',
       '/developers/v1/publish/commit/cli_x/v1',
@@ -1242,5 +1253,111 @@ describe('automateOpenPlatformSetup', () => {
       .toContain('长连接');
     // 走不到订阅阶段的早期失败(missingVcEvents/eventModeReady 均 undefined)保持原 best-effort 语义
     expect(vcListenerEventGateError({})).toBeNull();
+  });
+});
+
+/**
+ * 回归：自动发版必须原样镜像线上可见范围。
+ *
+ * 历史 bug —— 这里读的是 `contact_range`（通讯录权限范围）且只取 members，
+ * `departments` / `groups` / `isAll` 在版本 payload 里写死空值。由于
+ * `app_version/create` 的 visibleSuggest 是**全量覆写**语义，每次权限自愈自动
+ * 发版都把「全员可见 / 按部门授权 / 按用户组授权」静默清成「仅少数个人可见」，
+ * 升级次日大量用户访问不了应用。
+ */
+describe('automateOpenPlatformSetup 版本可见范围', () => {
+  const visibilityFetch = (appId: string, sub: ReturnType<typeof openPlatformSubscriptionMock>, calls: string[]) =>
+    (async (url: string | URL | Request, init?: RequestInit) => {
+      const href = String(url);
+      if (href === 'https://ask.feishu.cn/') return new Response('ask home', { status: 200 });
+      if (href === `https://open.feishu.cn/app/${appId}/auth`) {
+        return new Response('<script>window.csrfToken="csrf_auto"</script>', { status: 200 });
+      }
+      const path = new URL(href).pathname;
+      calls.push(path);
+      if (path.includes('/scope/all/')) {
+        return Response.json({ code: 0, data: { appScopeList: [{ id: 'tenant-1', name: 'im:message' }], userScopeList: [] } });
+      }
+      if (path.includes('/app_version/create/')) return Response.json({ code: 0, data: { versionId: 'v1' } });
+      return sub.handle(href, init) ?? Response.json({ code: 0 });
+    }) as typeof fetch;
+
+  const runWith = async (visibleOnline: unknown) => {
+    const dir = mkdtempSync(join(tmpdir(), 'botmux-visibility-'));
+    const sessionFile = join(dir, 'feishu-session.json');
+    writeStoredCookiesToSessionFile(sessionFile, [cookie()]);
+    const sub = openPlatformSubscriptionMock('cli_x', { visibleOnline });
+    const calls: string[] = [];
+    const bodies: Array<Record<string, unknown>> = [];
+    const inner = visibilityFetch('cli_x', sub, calls);
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      const href = String(url);
+      if (href.includes('/app_version/create/')) bodies.push(JSON.parse(String(init?.body)));
+      return inner(url, init);
+    }) as typeof fetch;
+    const result = await automateOpenPlatformSetup({
+      appId: 'cli_x',
+      sessionFilePath: sessionFile,
+      fetchImpl,
+      scopeManifest: { scopes: { tenant: ['im:message'], user: [] } },
+    });
+    return { result, calls, versionBody: bodies[0] };
+  };
+
+  it('把线上的全员可见 / 部门 / 用户组原样镜像进新版本，而不是清空', async () => {
+    const { result, versionBody } = await runWith({
+      code: 0,
+      data: {
+        whiteList: {
+          departments: [{ id: 'od_sales' }, { id: 'od_eng' }],
+          members: [{ id: 'ou_alice' }],
+          groups: [{ id: 'g_oncall' }],
+          isAll: 1,
+        },
+        blackList: { departments: [], members: [{ id: 'ou_banned' }], groups: [], isAll: 0 },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    // 四个集合一个都不能丢：isAll=1 掉成 0 就是「全员可见」被撤销，
+    // departments/groups 清空就是按部门/用户组授权的人全部失去访问。
+    expect(versionBody.visibleSuggest).toEqual({
+      departments: ['od_sales', 'od_eng'],
+      members: ['ou_alice'],
+      groups: ['g_oncall'],
+      isAll: 1,
+    });
+    // 黑名单同样要镜像：丢了就把被拉黑的人重新放进来。
+    expect(versionBody.blackVisibleSuggest).toEqual({
+      departments: [], members: ['ou_banned'], groups: [], isAll: 0,
+    });
+  });
+
+  it('读的是 visible/online（应用可见范围），不再读 contact_range（通讯录权限范围）', async () => {
+    const { calls } = await runWith(undefined);
+    expect(calls).toContain('/developers/v1/visible/online/cli_x');
+    expect(calls).not.toContain('/developers/v1/contact_range/cli_x');
+  });
+
+  it('可见范围响应形态不认识时 fail closed：不建版、不发布', async () => {
+    // isAll 是字符串 '1' —— 猜错方向就会把全员可见发布成不可见，宁可不发版。
+    const { result, calls } = await runWith({
+      code: 0,
+      data: {
+        whiteList: { departments: [], members: [], groups: [], isAll: '1' },
+        blackList: { departments: [], members: [], groups: [], isAll: 0 },
+      },
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: 'visibility_unreadable' });
+    expect(calls.some(path => path.includes('/app_version/create/'))).toBe(false);
+    expect(calls.some(path => path.includes('/publish/commit/'))).toBe(false);
+  });
+
+  it('可见范围块缺键时同样 fail closed（残缺响应不得当成空可见范围）', async () => {
+    const { result, calls } = await runWith({ code: 0, data: { whiteList: {}, blackList: {} } });
+
+    expect(result).toMatchObject({ ok: false, reason: 'visibility_unreadable' });
+    expect(calls.some(path => path.includes('/app_version/create/'))).toBe(false);
   });
 });


### PR DESCRIPTION
## 问题

`automateOpenPlatformSetup` 建版时读 `contact_range/{clientId}` 只取 `members`，`departments` / `groups` / `isAll` 用的是 `buildAppVersionCreatePayload` 里写死的空值。

而 `app_version/create` 的 `visibleSuggest` 是**全量覆写**语义 —— 没给的集合不是「保持原样」而是「被清空」。于是每次自动发版都把线上的可见范围静默收窄：

| 线上原状态 | 发版后 |
|---|---|
| 全员可见（`isAll=1`） | `isAll=0`，全员可见被撤销 |
| 按部门授权 | `departments` 清空 |
| 按用户组授权 | `groups` 清空 |
| 逐个点名的个人成员 | 幸存（唯一被读到的集合） |

这条链路被 `im/lark/event-dispatcher.ts` 的 `tryAutoFixScopes`（权限自愈）**无人交互地**调用：只要新版本引入了新 scope，每个 bot 一重启就各自触发一次自动发版。

**实际影响**：一次机队升级后多个 bot 的应用同时被自动发版，次日大量用户发现访问不了应用。

数据来源本身也用错了 —— `contact_range` 是**通讯录权限范围**（应用能读谁的通讯录），和**应用可见范围**（谁能用这个应用）是两个概念。

## 关键背景

仓库里**已经有一份正确实现**：`services/open-platform-rename.ts`（改名/改头像链路）读 `visible/online/{clientId}`，把白/黑名单原样镜像，且是 fail-closed 的，注释写着「本链路绝不改变谁能看到这个应用」。

同一个仓库两条发版路径，一条对一条错，而错的那条被权限自愈调用。本 PR 让它们共用同一份实现。

## 改动

- 新增 `setup/open-platform-visibility.ts`：把 rename 链路里已经正确的 `visible/online` fail-closed 解析抽出共用（rename 侧行为零变化，纯 import 替换）
- `automateOpenPlatformSetup` 改读 `visible/online/{clientId}`，`visibleSuggest` 与 `blackVisibleSuggest` 整块原样镜像（黑名单丢了会把被拉黑的人放回来，同样要带）
- 新增 fail-closed 出口 `visibility_unreadable`：解析失败时**尚未建版**，可见范围零改动，调用方降级为给管理员发 DM 手动处理 —— 绝不发布一个可能把人关在门外的版本
- 删除错误来源 `extractContactRangeMemberIds`
- `buildAppVersionCreatePayload` 补文档：`visibleSuggest` 是全量覆写语义，只有全新应用的首次发布能用默认空值

全新应用的「上架启用」首发（`createOpenPlatformAppWithClient`，没有历史可见范围可镜像）**保持不变**。

## 测试

4 条回归，覆盖镜像正确性与 fail-closed：

1. 线上「全员可见 + 2 个部门 + 1 个用户组 + 黑名单 1 人」→ 断言版本 payload 四个集合逐字段一致
2. 断言读的是 `visible/online`，不再出现 `contact_range`
3. `isAll` 是字符串 `'1'` → 断言 `ok:false / visibility_unreadable`，且**根本没发出** `app_version/create` 与 `publish/commit`
4. 白/黑名单块缺键 → 同样中止

**变异验证**（确认测试真的能抓到 bug）：

| 变异 | 结果 |
|---|---|
| 镜像退回「只带 `members`」（复刻原 bug） | 用例 1 红 ✅ |
| fail-closed 改成退化成空可见范围继续发版 | 用例 3、4 红 ✅ |

`pnpm test`：受影响的 3 个文件 68/68 全绿。全量套件在本分支与 `upstream/master` 基线**失败集合一致**（5 文件 / 10 用例，`codex-app-*` 与 `worker-*` 家族，与本改动无关）；满载时偶发多出的 `codex-app-threads` / `worker-argv-reaction-status` 单独跑 14/14 通过，属已知负载相关 flaky。

🤖 Generated with [Claude Code](https://claude.com/claude-code)