### PR TITLE
fix(test): 隔离单元测试持久化目录

### DIFF
--- a/test/unit-data-dir-isolation.test.ts
+++ b/test/unit-data-dir-isolation.test.ts
@@ -1,0 +1,48 @@
+import { existsSync } from 'node:fs';
+import { dirname, isAbsolute, join, relative } from 'node:path';
+import { beforeEach, describe, expect, inject, it } from 'vitest';
+import { config } from '../src/config.js';
+import * as sessionStore from '../src/services/session-store.js';
+
+describe.sequential('unit-test session persistence', () => {
+  const unitRoot = inject('unitSessionDataRoot');
+  let isolatedDataDir: string;
+
+  it('isolates both DATA_DIR and BOTMUX_HOME from the invoking environment', () => {
+    isolatedDataDir = config.session.dataDir;
+    const relativeDataDir = relative(unitRoot, isolatedDataDir);
+    const relativeBotmuxHome = relative(unitRoot, dirname(isolatedDataDir));
+
+    expect(relativeDataDir).not.toBe('');
+    expect(relativeDataDir.startsWith('..') || isAbsolute(relativeDataDir)).toBe(false);
+    expect(relativeBotmuxHome).not.toBe('');
+    expect(relativeBotmuxHome.startsWith('..') || isAbsolute(relativeBotmuxHome)).toBe(false);
+
+    sessionStore.init('unit_isolation_probe');
+    sessionStore.createSession('oc_probe', 'om_probe', 'unit isolation probe');
+
+    expect(existsSync(join(isolatedDataDir, 'sessions-unit_isolation_probe.json'))).toBe(true);
+
+    process.env.SESSION_DATA_DIR = join(unitRoot, 'leaked-test-override');
+  });
+
+  it('repairs a SESSION_DATA_DIR override leaked by the previous test', () => {
+    expect(process.env.SESSION_DATA_DIR).toBe(isolatedDataDir);
+  });
+
+  describe('with an explicit test override', () => {
+    const explicitDataDir = join(unitRoot, 'explicit-test-override');
+
+    beforeEach(() => {
+      process.env.SESSION_DATA_DIR = explicitDataDir;
+    });
+
+    it('preserves the override selected by the test hook', () => {
+      expect(config.session.dataDir).toBe(explicitDataDir);
+    });
+  });
+
+  it('returns to the managed data directory after an explicit override', () => {
+    expect(process.env.SESSION_DATA_DIR).toBe(isolatedDataDir);
+  });
+});

--- a/test/unit-global-setup.ts
+++ b/test/unit-global-setup.ts
@@ -1,0 +1,19 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { TestProject } from 'vitest/node';
+
+declare module 'vitest' {
+  export interface ProvidedContext {
+    unitSessionDataRoot: string;
+  }
+}
+
+export default function setupUnitDataRoot(project: TestProject) {
+  const root = mkdtempSync(join(tmpdir(), 'botmux-unit-'));
+  project.provide('unitSessionDataRoot', root);
+
+  return () => {
+    rmSync(root, { recursive: true, force: true });
+  };
+}

--- a/test/unit-setup.ts
+++ b/test/unit-setup.ts
@@ -1,0 +1,28 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterAll, beforeEach, inject } from 'vitest';
+
+const inheritedDataDir = process.env.SESSION_DATA_DIR;
+const fileRoot = mkdtempSync(join(inject('unitSessionDataRoot'), 'file-'));
+const dataDir = join(fileRoot, 'data');
+mkdirSync(dataDir);
+
+process.env.SESSION_DATA_DIR = dataDir;
+
+// setupFiles runs before the test module. Capture a file-wide temp override made
+// at module scope or in beforeAll once, then repair per-test mutations back to it.
+let fileDataDir = '';
+beforeEach(() => {
+  if (!fileDataDir) {
+    const candidate = process.env.SESSION_DATA_DIR;
+    fileDataDir = candidate && candidate !== inheritedDataDir ? candidate : dataDir;
+  }
+  process.env.SESSION_DATA_DIR = fileDataDir;
+});
+
+afterAll(() => {
+  // Keep leaked async work fenced inside the managed root until the worker exits.
+  // Restoring the invoking environment here could briefly expose live Botmux data.
+  process.env.SESSION_DATA_DIR = dataDir;
+  rmSync(fileRoot, { recursive: true, force: true });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,6 +33,8 @@ export default defineConfig({
           // e2e dir out explicitly so a stray *.test.ts there can't sneak in.
           exclude: ['test/e2e-browser/**', '**/*.e2e.ts', 'node_modules/**'],
           testTimeout: 30_000,
+          globalSetup: ['./test/unit-global-setup.ts'],
+          setupFiles: ['./test/unit-setup.ts'],
         },
       },
       {


### PR DESCRIPTION
## 背景

Botmux daemon/worker 会把真实的 `SESSION_DATA_DIR` 注入 agent 会话。开发者若直接在该会话里运行 unit tests，Vitest 的 unit project 会继承这个路径。

`dashboard-ipc` 的 Message Listener Preview 用例虽然 mock 了 worker fork，仍会经过 `triggerSessionTurn` → `sessionStore.createSession` 的真实持久化路径。因此测试 fixture 曾被写入 `~/.botmux/data`，在 Dashboard 中显示为 `[External] Message Listener Preview` 会话。

测试结束后再清理真实数据并不能可靠解决这个问题：失败或强制终止可能跳过清理，测试运行期间也已经与 live daemon 共享文件；反向删除真实 session 文件还会引入并发误删风险。这里把隔离提前到测试模块 import 之前，使 unit tests 从一开始就看不到调用环境的生产数据目录。

## 修改

- 为 Vitest `unit` project 增加专用 global setup：每轮测试创建一个系统临时根目录，并在 project teardown 统一兜底回收。
- setup file 为每个测试文件创建独立的 `<run-root>/file-*/data`：
  - 隔离 `SESSION_DATA_DIR`；
  - 同时隔离由 `dirname(SESSION_DATA_DIR)` 派生的有效 Botmux home，避免 schedules、transcripts、per-bot state 等在并行文件间共享。
- 每个 test 开始前恢复文件级受管目录，阻断上一条用例遗留的环境变量；同时保留现有测试在 module scope / `beforeAll` / `beforeEach` 中显式选择临时目录的能力。
- file `afterAll` 清理文件根，project teardown 兜底 collect/import failure。teardown 不恢复调用环境的真实目录，避免 worker 退出前的异步窗口重新触碰 live data。
- 新增端到端回归测试，覆盖真实 `sessionStore.createSession` 落盘、data dir 与有效 Botmux home 的路径 containment、跨 test override 修复，以及显式 test override 的兼容性。

## 范围与兼容性

- 仅影响 Vitest `unit` project；不修改 daemon/worker 运行时代码，也不改变 e2e project。
- 使用 Node.js 的 `tmpdir`、`join`、`mkdtempSync`、`mkdirSync`、`rmSync`，不覆盖 `HOME`，兼容 macOS 与 Linux 的临时目录和路径规则。
- `SIGKILL`、掉电等无法执行进程内 teardown 的场景，最多留下系统临时目录，不会再污染生产 Botmux session 数据。

## 验证

- `pnpm build`
- 隔离回归与兼容组：198/198 tests passed；使用非空模拟生产 `SESSION_DATA_DIR`，运行后该目录 0 写入。
- `TMPDIR=/tmp` 的 Linux-shaped 路径验证：4/4 tests passed；模拟生产目录 0 写入，`botmux-unit-*` 临时根 0 残留。
- 全量 unit 并发运行：13,748 passed、37 skipped、8 failed。2 个确定性源码文本断言已在纯 `upstream/master` 原样复现；其余 6 个仅在全量负载下失败的 runner/timeout/临时目录竞态用例，在本分支与纯 upstream 分别单跑均通过。相关真实行为测试另为 4/4 passed。本项不标记为全绿。
- `git diff --check upstream/master...HEAD`
