### PR TITLE
feat(dashboard): 提供脱敏运行摘要并加固登录令牌

### DIFF
--- a/docs-site/docs/en/api-task-trigger.md
+++ b/docs-site/docs/en/api-task-trigger.md
@@ -23,13 +23,13 @@ Both modes open a "virtual session" (when no `chatId` is given) that **never ent
 
 ## 2. Authentication
 
-Calls go through the dashboard (default `http://<daemon-host>:7891`). Auth currently uses a short-lived dashboard token:
+Calls go through the dashboard (default `http://<daemon-host>:7891`). Auth currently uses the rotating dashboard token:
 
 - **Programmatic calls MUST send the token as a Cookie header**: `Cookie: botmux_dashboard_token=<TOKEN>`
 - ⚠️ Do NOT use `?t=<TOKEN>` query: that's for browser login; a `POST` carrying it returns a **302 redirect** (set-cookie) and the call fails.
-- Getting a token: run `botmux dashboard` to print the login URL — the part after `?t=` is the token. Each run rotates it (the old token is invalidated).
+- Getting a token: run `botmux dashboard` to get the current login URL — the part after `?t=` is the token. The command creates the first token when absent; use `botmux dashboard rotate` only when you intend to invalidate an existing token.
 
-> The token is short-lived. Long-lived API-key auth (e.g. `X-Botmux-Api-Key`) is planned; this doc will be updated when it lands.
+> The token persists until explicit rotation. Dedicated API-key auth (e.g. `X-Botmux-Api-Key`) is planned; this doc will be updated when it lands.
 
 ---
 

--- a/docs-site/docs/en/cli-commands.md
+++ b/docs-site/docs/en/cli-commands.md
@@ -15,7 +15,7 @@ Manage the daemon and sessions from the terminal.
 | `botmux delete <id>` (aliases `del`/`rm`) | Close the specified session, with ID prefix matching |
 | `botmux delete all` | Close all active sessions |
 | `botmux delete stopped` | Clean up zombie sessions whose processes have exited |
-| `botmux dashboard` | Print a Web Dashboard URL once (refreshes the token each time) |
+| `botmux dashboard [current\|rotate]` | Get the current Dashboard login URL, creating the first token if absent; `rotate` explicitly replaces an existing token |
 
 When the daemon is online, `botmux delete` first asks the owning daemon to run
 the same lifecycle teardown as `/close`: evict the in-memory active session,

--- a/docs-site/docs/en/dashboard.md
+++ b/docs-site/docs/en/dashboard.md
@@ -1,13 +1,15 @@
 # Dashboard Control Panel
 
-The `botmux dashboard` command produces a one-time token URL for unified control across all daemons / bots in the browser.
+The `botmux dashboard` command prints the current rotating login-token URL for unified control across all daemons / bots in the browser.
 
 ```bash
-botmux dashboard
+botmux dashboard          # Get the current URL, creating the first token if absent
+botmux dashboard current  # Explicit form of the same operation
+botmux dashboard rotate   # Rotate the token and print the new URL
 # Output: http://<lan-ip>:7891/?t=<token>
 ```
 
-> This is a **rotating login token**: a URL stays valid until the next time you run `botmux dashboard` (which rotates it and invalidates the old URL); the token is persisted and survives a `botmux restart`. A successful `?t=` visit just writes the same token into a cookie — it does not consume or revoke it, so the same URL logs in repeatedly until rotation. Sharing the URL ≈ sharing the login state, so keep it safe. Default port `7891`, overridable via `BOTMUX_DASHBOARD_PORT`.
+> This is a **rotating login token**: a URL stays valid until `botmux dashboard rotate` replaces it and invalidates the old URL; the token is persisted and survives a `botmux restart`. The bare/current command reuses that token, creating the first one when absent. A successful `?t=` visit just writes the same token into a cookie — it does not consume or revoke it, so the same URL logs in repeatedly until rotation. Sharing the URL ≈ sharing the login state, so keep it safe. Default port `7891`, overridable via `BOTMUX_DASHBOARD_PORT`.
 
 ![Dashboard Groups panel](https://magic-builder.tos-cn-beijing.volces.com/uploads/1780033300739_dash-groups.png)
 <p class="cap">Groups panel: a chat × bot matrix that shows at a glance which bots are in which groups</p>
@@ -24,12 +26,71 @@ botmux dashboard
 
 ## External read-only queries
 
-The Dashboard HTTP service exposes two session read surfaces for the board and external observers:
+The primary external observation surfaces documented here are:
 
+- `GET /api/dashboard/v1/summary`: a versioned, strongly redacted fleet summary.
 - `GET /api/sessions`: the current aggregate of active + closed session rows.
 - `GET /events`: the Dashboard's external SSE stream. For session events, `session.spawned` carries the full values in `body.session`, while `session.update` carries changes in `body.patch`. Each daemon also has a loopback-only `/api/events` endpoint for Dashboard aggregator IPC; it is not the external URL.
 
-The following fields are all **optional**. Consumers must handle older sessions/daemons that omit them:
+### Dashboard Summary API
+
+`GET /api/dashboard/v1/summary` lets an external status page, monitor, or orchestrator treat a regular botmux fleet as a long-running daemon service. It reads live sessions and schedules from the currently online daemons, then returns only positively allow-listed status and counts. It never returns bot or session IDs, titles, group names, working directories, prompts, schedule contents, or diagnostic logs. Its 200, 429, and 503 responses include `Cache-Control: no-store`.
+
+> This is a **Dashboard facade for regular fleet mode**, served by the `botmux-dashboard` process started alongside `botmux start`. `botmux serve --api-only` is a core-only, single-process mode that does not start the Dashboard, so this route does not exist there. See [Core-only API Control](/en/api-core-only) for that mode's health and control endpoints.
+
+A successfully generated snapshot returns HTTP 200. A 200 means that snapshot generation succeeded; `service.status` is still `degraded` when a configured bot is offline:
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-09T02:30:00.000Z",
+  "service": { "status": "healthy" },
+  "bots": { "online": 3 },
+  "sessions": { "active": 7, "attention": 1 },
+  "schedules": {
+    "enabled": 2,
+    "nextRunAt": "2026-08-09T04:00:00.000Z"
+  },
+  "dashboard": { "href": "/" }
+}
+```
+
+| Field | Meaning |
+|------|---------|
+| `schemaVersion` | Response-contract version; currently `1` |
+| `generatedAt` | ISO-8601 time at which the Dashboard generated this live snapshot |
+| `service.status` | `healthy` when the online bot count equals the configured bot count; otherwise `degraded` |
+| `bots.online` | Number of currently online daemons / bots |
+| `sessions.active` | Sessions from online daemons whose status is not `closed` |
+| `sessions.attention` | Active sessions requiring attention, including repository selection, a TUI prompt, agent attention, and the `limited` or `stalled` states |
+| `schedules.enabled` | Enabled schedules from online daemons |
+| `schedules.nextRunAt` | Earliest valid next-run time among enabled schedules (ISO-8601), or `null` when none exists |
+| `dashboard.href` | Relative path to the Dashboard root; resolve it against the current Dashboard origin |
+
+If any live daemon's sessions or schedules snapshot times out, fails, or has a malformed shape, the endpoint returns HTTP 503. Count fields are deliberately omitted rather than presenting missing state as zero:
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-09T02:30:00.000Z",
+  "service": { "status": "degraded" }
+}
+```
+
+Anonymous requests are subject to a rolling, **Dashboard-process-global** limit shared by every anonymous caller: at most 5 requests in any 10-second window. The sixth request returns HTTP 429:
+
+```json
+{
+  "error": "rate_limited",
+  "retryAfterSeconds": 7
+}
+```
+
+The `Retry-After` response header carries the same decimal number of seconds (at least `1`, normally `1`–`10`); wait that long before retrying. Requests authenticated with the current Dashboard token are exempt from the anonymous limit. Authentication uses the existing Dashboard login state: a valid `?t=<token>` first returns a 302, sets the `botmux_dashboard_token` cookie, and redirects to the URL without the query. A pure API client that needs the exemption must retain and return that cookie. `Authorization: Bearer` is not accepted here.
+
+### Session row optional fields
+
+The following fields belong only to the richer `/api/sessions` rows and `/events` session payloads; they are never returned by the summary endpoint. They are all **optional**, so consumers must handle older sessions/daemons that omit them:
 
 | Field | Meaning |
 |------|---------|
@@ -40,10 +101,11 @@ The following fields are all **optional**. Consumers must handle older sessions/
 
 ### `publicReadOnly` and the token boundary
 
-`publicReadOnly` is on by default. While it is enabled, `GET /api/sessions` and `GET /events` are reachable **without a token** on the Dashboard listener, so session names, titles, backends, and the other row metadata must be treated as public to that network.
+`publicReadOnly` is on by default. While it is enabled, allow-listed reads including `GET /api/dashboard/v1/summary`, `GET /api/sessions`, and `GET /events` are reachable **without a token** on the Dashboard listener. The summary contains only the strongly redacted aggregate above; session names, titles, backends, and the other session/event row metadata must be treated as public to that network.
 
 - Every POST / PATCH / DELETE mutation, every GET outside the read-only allow-list, and every raw PTY / diagnostic log still requires the current token issued by `botmux dashboard`. The allow-list is fail-closed: a newly added GET endpoint does not become public merely because public read-only mode is enabled.
-- Each `botmux dashboard` invocation rotates the token and invalidates the previous link. The token is application-layer Dashboard access, not a replacement for host firewall, VPN, or reverse-proxy authentication.
+- When `publicReadOnly` is off, a tokenless summary request returns 401. A request carrying the current token remains available and is exempt from the anonymous rate limit. In public read-only mode, an incorrect or rotated old token is treated as anonymous.
+- `botmux dashboard` and `botmux dashboard current` reuse the current token (creating the first one when absent); `botmux dashboard rotate` explicitly replaces it and invalidates the previous link. The token is application-layer Dashboard access, not a replacement for host firewall, VPN, or reverse-proxy authentication.
 - If tokenless observation is unnecessary, turn off **Public read-only** under Dashboard Settings. You can also start with `BOTMUX_DASHBOARD_PUBLIC_READONLY=false`; once the setting has been saved in the UI, the persisted value in `~/.botmux/config.json` takes precedence over the environment variable.
 
 ## Deployment details

--- a/docs-site/docs/en/pitfalls.md
+++ b/docs-site/docs/en/pitfalls.md
@@ -47,7 +47,7 @@
 
 ## Dashboard / Security
 
-- **Don't post a token-bearing dashboard URL into a group** (it's equivalent to publicly exposing a temporary access credential). For security-sensitive scenarios, bind the host to the local machine: `BOTMUX_DASHBOARD_HOST=127.0.0.1`. The token is single-use; each run of `botmux dashboard` regenerates it and the old link becomes invalid immediately.
+- **Don't post a token-bearing dashboard URL into a group** (it's equivalent to publicly exposing a temporary access credential). For security-sensitive scenarios, bind the host to the local machine: `BOTMUX_DASHBOARD_HOST=127.0.0.1`. The token rotates rather than being consumed: the same URL remains reusable until rotation; only `botmux dashboard rotate` generates a new token and immediately invalidates the old link. The bare command and `botmux dashboard current` do not rotate it.
 - **Dashboard won't open**: First run `curl http://<host>:<port>/__health`; a `{"ok":true}` response means the service is healthy. The problem is usually a browser proxy / wrong host (a Mac's intranet IP can change) / opening a link with an old token.
 
 ## General troubleshooting approach

--- a/docs-site/docs/zh/api-task-trigger.md
+++ b/docs-site/docs/zh/api-task-trigger.md
@@ -23,13 +23,13 @@
 
 ## 2. 鉴权
 
-调用走 dashboard（默认 `http://<daemon-host>:7891`）。当前用 dashboard 短期 token 鉴权：
+调用走 dashboard（默认 `http://<daemon-host>:7891`）。当前用 dashboard 轮换式 token 鉴权：
 
 - **程序化调用必须把 token 放在 Cookie 头**：`Cookie: botmux_dashboard_token=<TOKEN>`
 - ⚠️ 不要用 `?t=<TOKEN>` query：那是给浏览器登录用的，`POST` 带它会返回 **302 重定向**（set-cookie），程序化调用会失败。
-- token 获取：运行 `botmux dashboard` 打印登录 URL，其中 `?t=` 后面那段就是 token。每次运行会 rotate（旧 token 失效）。
+- token 获取：运行 `botmux dashboard` 获取当前登录 URL，其中 `?t=` 后面那段就是 token。尚无 token 时命令会创建第一个；仅在确实要让已有 token 失效时才运行 `botmux dashboard rotate`。
 
-> token 是短期凭证。长期稳定的 API Key 认证（如 `X-Botmux-Api-Key`）在规划中，届时本文更新。
+> token 会一直保留到显式轮换。独立 API Key 认证（如 `X-Botmux-Api-Key`）在规划中，届时本文更新。
 
 ---
 

--- a/docs-site/docs/zh/cli-commands.md
+++ b/docs-site/docs/zh/cli-commands.md
@@ -15,7 +15,7 @@
 | `botmux delete <id>` (别名 `del`/`rm`) | 关闭指定会话，支持 ID 前缀匹配 |
 | `botmux delete all` | 关闭所有活跃会话 |
 | `botmux delete stopped` | 清理进程已退出的僵尸会话 |
-| `botmux dashboard` | 输出一次 Web Dashboard URL（每次刷 token） |
+| `botmux dashboard [current\|rotate]` | 获取当前 Dashboard 登录 URL，尚无 token 时创建第一个；`rotate` 才显式替换已有 token |
 
 daemon 在线时，`botmux delete` 会先请求会话所属 daemon 执行与 `/close`
 一致的生命周期收口：移除内存中的活跃会话、持久化关闭状态，并回收

--- a/docs-site/docs/zh/dashboard.md
+++ b/docs-site/docs/zh/dashboard.md
@@ -1,13 +1,15 @@
 # Dashboard 管控面
 
-命令行 `botmux dashboard` 出一个一次性 token URL，浏览器里跨所有 daemon / 机器人统一管控。
+命令行 `botmux dashboard` 输出当前的轮换式登录 token URL，浏览器里跨所有 daemon / 机器人统一管控。
 
 ```bash
-botmux dashboard
+botmux dashboard          # 获取当前 URL；尚无 token 时创建第一个
+botmux dashboard current  # 同一操作的显式写法
+botmux dashboard rotate   # 轮换 token 并输出新 URL
 # 输出: http://<lan-ip>:7891/?t=<token>
 ```
 
-> 这是**轮换式登录 token**：一条 URL 有效到下次运行 `botmux dashboard`（那时才轮换、让旧 URL 失效）；token 会持久化、`botmux restart` 后仍有效。成功访问 `?t=` 只是把同一 token 写进 cookie，不消费/作废它，轮换前同一 URL 可重复登录——所以分享链接≈分享登录态，注意保管。默认端口 `7891`，可用 `BOTMUX_DASHBOARD_PORT` 改。
+> 这是**轮换式登录 token**：一条 URL 会一直有效，直到 `botmux dashboard rotate` 生成新 token、让旧 URL 失效；token 会持久化、`botmux restart` 后仍有效。裸命令/current 会复用这个 token，尚无 token 时创建第一个。成功访问 `?t=` 只是把同一 token 写进 cookie，不消费/作废它，轮换前同一 URL 可重复登录——所以分享链接≈分享登录态，注意保管。默认端口 `7891`，可用 `BOTMUX_DASHBOARD_PORT` 改。
 
 ![Dashboard Groups 面板](https://magic-builder.tos-cn-beijing.volces.com/uploads/1780033300739_dash-groups.png)
 <p class="cap">Groups 面板：chat × bot 矩阵，一眼看清哪个群里有哪些机器人</p>
@@ -24,12 +26,71 @@ botmux dashboard
 
 ## 对外只读查询
 
-Dashboard HTTP 服务提供两个可供看板或外部观测端消费的会话读接口：
+这里重点说明三个对外观测接口：
 
+- `GET /api/dashboard/v1/summary`：版本化、强脱敏的 fleet 运行摘要。
 - `GET /api/sessions`：当前聚合的 active + closed session rows。
 - `GET /events`：Dashboard 对外 SSE 流，其中 `session.spawned` 的 `body.session` 和 `session.update` 的 `body.patch` 会携带对应的完整值/变更值。每个 daemon 内部还有只绑定 loopback 的 `/api/events`，这是 Dashboard 聚合器的 IPC，不是对外地址。
 
-会话输出中的下列字段都是**可选字段**，消费者必须兼容旧会话/旧 daemon 不返回它们：
+### Dashboard Summary API
+
+`GET /api/dashboard/v1/summary` 用于把普通 botmux fleet 的守护进程作为常驻服务接入外部状态页、监控或编排器。它直接汇总当前在线 daemon 的 live sessions / schedules，只输出正向白名单中的状态和计数；不会返回 bot / session ID、标题、群名、工作目录、提示词、排程内容或诊断日志。它的 200、429、503 响应都带 `Cache-Control: no-store`。
+
+> 这是普通 fleet 模式的 **Dashboard facade**，由 `botmux start` 一同启动的 `botmux-dashboard` 提供。`botmux serve --api-only` 是不启动 Dashboard 的 core-only 单进程模式，因此没有这个路由；该模式的健康检查和控制接口见 [Core-only API 控制](/api-core-only)。
+
+成功生成快照时返回 HTTP 200。200 只表示快照生成成功；fleet 里有已配置但不在线的 bot 时，`service.status` 仍会是 `degraded`：
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-09T02:30:00.000Z",
+  "service": { "status": "healthy" },
+  "bots": { "online": 3 },
+  "sessions": { "active": 7, "attention": 1 },
+  "schedules": {
+    "enabled": 2,
+    "nextRunAt": "2026-08-09T04:00:00.000Z"
+  },
+  "dashboard": { "href": "/" }
+}
+```
+
+| 字段 | 语义 |
+|------|------|
+| `schemaVersion` | 响应契约版本，当前为 `1` |
+| `generatedAt` | Dashboard 生成本次 live 快照的 ISO-8601 时间 |
+| `service.status` | 在线 bot 数等于已配置 bot 数时为 `healthy`，否则为 `degraded` |
+| `bots.online` | 当前在线 daemon / bot 数 |
+| `sessions.active` | 在线 daemon 中状态不是 `closed` 的会话数 |
+| `sessions.attention` | active 会话中需要处理的数量，包括待选仓库、TUI 提示、agent attention，以及 `limited` / `stalled` 状态 |
+| `schedules.enabled` | 在线 daemon 中已启用的排程数 |
+| `schedules.nextRunAt` | 已启用排程里最早的有效下次运行时间（ISO-8601）；没有时为 `null` |
+| `dashboard.href` | Dashboard 根页面的相对路径；消费者应相对当前 Dashboard origin 解析 |
+
+只要任一 live daemon 的 sessions / schedules 快照超时、返回错误或格式不合法，接口就返回 HTTP 503。计数字段会刻意省略，避免把缺失状态伪装成零：
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-09T02:30:00.000Z",
+  "service": { "status": "degraded" }
+}
+```
+
+无当前 token 的匿名请求受 **Dashboard 进程全局**滚动窗口限流：所有匿名调用方共享配额，任意 10 秒内最多 5 次。第 6 次返回 HTTP 429：
+
+```json
+{
+  "error": "rate_limited",
+  "retryAfterSeconds": 7
+}
+```
+
+响应头 `Retry-After` 是同一个十进制秒数（最少为 `1`，通常为 `1`–`10`）；等待该时长后再重试。携带当前 Dashboard token 的已认证请求不计入匿名限流。认证沿用 Dashboard 登录态：正确的 `?t=<token>` 会先返回 302、设置 `botmux_dashboard_token` cookie，再跳转到无 query 的 URL；纯 API 客户端若要使用豁免，需要保存并回传该 cookie。这里不接受 `Authorization: Bearer`。
+
+### 会话 row 可选字段
+
+下列字段只属于信息更丰富的 `/api/sessions` rows 和 `/events` 会话 payload，summary 接口绝不会返回它们。它们都是**可选字段**，消费者必须兼容旧会话/旧 daemon 不返回：
 
 | 字段 | 语义 |
 |------|------|
@@ -40,10 +101,11 @@ Dashboard HTTP 服务提供两个可供看板或外部观测端消费的会话�
 
 ### `publicReadOnly` 与 token 边界
 
-`publicReadOnly` 默认开启。开启时，`GET /api/sessions` 和 `GET /events` 在 Dashboard 监听地址上可以**无 token** 访问，因此会话名称、标题、后端和 row 中的其它元数据都应按可公开信息对待。
+`publicReadOnly` 默认开启。开启时，`GET /api/dashboard/v1/summary`、`GET /api/sessions` 和 `GET /events` 等只读白名单接口在 Dashboard 监听地址上可以**无 token** 访问。summary 只含上述强脱敏聚合；会话名称、标题、后端和 session / event row 中的其它元数据都应按可公开信息对待。
 
 - 全部 POST / PATCH / DELETE 写操作、不在只读白名单中的 GET，以及原始 PTY / 诊断日志，始终需要 `botmux dashboard` 生成的当前 token。白名单是 fail-closed 的：新增 GET 不会因公开只读开启就自动暴露。
-- 每次运行 `botmux dashboard` 都会轮换 token，之前的链接失效。token 只提供 Dashboard 应用层访问权，不代替主机防火墙、VPN 或反向代理鉴权。
+- 关闭 `publicReadOnly` 后，无 token 的 summary 请求会返回 401；持当前 token 的请求仍可访问，且不受上面的匿名限流。错误或已轮换的旧 token 在公开只读开启时按匿名请求处理。
+- `botmux dashboard` 和 `botmux dashboard current` 会复用当前 token（尚无时创建第一个）；`botmux dashboard rotate` 才会显式替换 token、让之前的链接失效。token 只提供 Dashboard 应用层访问权，不代替主机防火墙、VPN 或反向代理鉴权。
 - 不需要无 token 观测时，在 Dashboard 「设置」中关闭「公开只读」。也可先设 `BOTMUX_DASHBOARD_PUBLIC_READONLY=false`；但设置页一旦保存过该开关，`~/.botmux/config.json` 的持久值会优先于环境变量。
 
 ## 部署细节

--- a/docs-site/docs/zh/pitfalls.md
+++ b/docs-site/docs/zh/pitfalls.md
@@ -47,7 +47,7 @@
 
 ## Dashboard / 安全
 
-- **别把带 token 的 dashboard URL 发到群里**（等于公开临时访问凭证）。安全敏感场景把 host 绑本机：`BOTMUX_DASHBOARD_HOST=127.0.0.1`。token 一次性，每跑一次 `botmux dashboard` 重新生成、旧链接立即失效。
+- **别把带 token 的 dashboard URL 发到群里**（等于公开临时访问凭证）。安全敏感场景把 host 绑本机：`BOTMUX_DASHBOARD_HOST=127.0.0.1`。token 是轮换式而非单次消费：轮换前同一 URL 可重复使用；只有 `botmux dashboard rotate` 会生成新 token、让旧链接立即失效，裸命令和 `botmux dashboard current` 都不会轮换。
 - **dashboard 打不开**：先 `curl http://<host>:<port>/__health`，返回 `{"ok":true}` 说明服务正常；问题多在浏览器代理 / host 不对（mac 连内网 IP 会变）/ 打开了旧 token 链接。
 
 ## 排查通用手法

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -114,6 +114,7 @@ import { callDashboard, type DashboardEndpoint, type DashboardResult } from './c
 import {
   DASHBOARD_COMMAND_USAGE,
   executeDashboardCommand,
+  formatDashboardFallbackFailure,
 } from './cli/dashboard-command.js';
 import { globalInstallUpdateLockTargetIn, installLatestBotmuxSync } from './core/maintenance.js';
 import {
@@ -3171,7 +3172,7 @@ async function printDashboardHintWithRetry(): Promise<void> {
   }
   // Soft fallback
   if (last?.reason === 'no-active-token') {
-    console.log('   面板: 运行 `botmux dashboard` 获取链接');
+    console.log('   面板: 运行 `botmux dashboard` 创建登录链接');
   } else if (last?.reason === 'no-secret') {
     console.log('   面板: dashboard 凭证未就绪，启动后可用 `botmux dashboard` 获取链接');
   } else if (last?.reason === 'wrong-service') {
@@ -3181,9 +3182,9 @@ async function printDashboardHintWithRetry(): Promise<void> {
   }
 }
 
-/** Print the current or freshly-rotated dashboard URL. Bare `dashboard` keeps
- * the legacy rotate behavior; help and invalid subcommands never call either
- * credential endpoint. */
+/** Get or create the current dashboard URL, or explicitly rotate it. Bare
+ * `dashboard` is the non-rotating get-or-create form; help and invalid
+ * subcommands never call either credential endpoint. */
 async function cmdDashboard(args: string[]): Promise<void> {
   const execution = await executeDashboardCommand(args, callDashboardEndpoint);
   if (execution.kind === 'help') {
@@ -3223,11 +3224,8 @@ async function cmdDashboard(args: string[]): Promise<void> {
       '运行 `botmux restart` 重启 dashboard 并刷新端口文件。',
     );
     if (r.detail) console.error(`  详情: ${r.detail}`);
-  } else if (r.reason === 'no-active-token' && action === 'current') {
-    console.error('尚无 Dashboard token。运行 `botmux dashboard rotate` 创建一个。');
   } else {
-    // `no-active-token` can't occur on rotate (it always mints); fall through.
-    console.error('Rotation failed:', r.detail ?? r.reason);
+    console.error(formatDashboardFallbackFailure(action, r));
   }
   process.exit(1);
 }
@@ -5787,9 +5785,9 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
   status      查看 daemon 状态
   upgrade     升级到最新版本（别名：update）
   dashboard current
-              打印当前 Web Dashboard 登录 URL（不轮换 token）
+              获取当前 Web Dashboard 登录 URL（裸 \`dashboard\` 同义；没有则创建）
   dashboard rotate
-              轮换 token，并打印新的登录 URL（裸 \`dashboard\` 为兼容别名）
+              显式轮换 token，并打印新的登录 URL
   device enroll|status|logout
               在宿主终端注册、查看或清除 desktop device 凭证（AI CLI 会话内拒绝）
   list        列出活跃会话（交互式选择并连接 tmux）

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -111,6 +111,10 @@ import { resolveDaemonEnv } from './cli/daemon-lifecycle-env.js';
 import { buildPm2SpawnCommand } from './cli/pm2-command.js';
 import { pm2ManagedExitConfig } from './pm2-graceful-exit.js';
 import { callDashboard, type DashboardEndpoint, type DashboardResult } from './cli/dashboard-endpoint.js';
+import {
+  DASHBOARD_COMMAND_USAGE,
+  executeDashboardCommand,
+} from './cli/dashboard-command.js';
 import { globalInstallUpdateLockTargetIn, installLatestBotmuxSync } from './core/maintenance.js';
 import {
   formatGlobalInstallCommand,
@@ -3177,13 +3181,23 @@ async function printDashboardHintWithRetry(): Promise<void> {
   }
 }
 
-/**
- * Print a fresh dashboard URL by HMAC-authing to the dashboard process's
- * loopback rotation endpoint. Each call invalidates the previously-issued
- * token, so sharing a URL is the same as sharing a one-shot session.
- */
-async function cmdDashboard(): Promise<void> {
-  const r = await callDashboardEndpoint('/__cli/rotate');
+/** Print the current or freshly-rotated dashboard URL. Bare `dashboard` keeps
+ * the legacy rotate behavior; help and invalid subcommands never call either
+ * credential endpoint. */
+async function cmdDashboard(args: string[]): Promise<void> {
+  const execution = await executeDashboardCommand(args, callDashboardEndpoint);
+  if (execution.kind === 'help') {
+    console.log(DASHBOARD_COMMAND_USAGE);
+    return;
+  }
+  if (execution.kind === 'invalid') {
+    console.error(`未知 dashboard 子命令: ${execution.argument}`);
+    console.error(DASHBOARD_COMMAND_USAGE);
+    process.exitCode = 2;
+    return;
+  }
+
+  const { action, result: r } = execution;
   if (r.ok) {
     // 首行保持纯 URL（脚本/复制取第一行即可）；走中心化平台时再补一行本地直连兜底。
     console.log(r.url);
@@ -3209,6 +3223,8 @@ async function cmdDashboard(): Promise<void> {
       '运行 `botmux restart` 重启 dashboard 并刷新端口文件。',
     );
     if (r.detail) console.error(`  详情: ${r.detail}`);
+  } else if (r.reason === 'no-active-token' && action === 'current') {
+    console.error('尚无 Dashboard token。运行 `botmux dashboard rotate` 创建一个。');
   } else {
     // `no-active-token` can't occur on rotate (it always mints); fall through.
     console.error('Rotation failed:', r.detail ?? r.reason);
@@ -5770,7 +5786,10 @@ botmux v${getVersion()} — IM ↔ AI 编程 CLI 桥接
   logs        查看 daemon 日志（--lines N, --bot <0-based-index|pm2-name|appId>）
   status      查看 daemon 状态
   upgrade     升级到最新版本（别名：update）
-  dashboard   打印新的 Web Dashboard 一次性登录 URL（旧 token 同时失效）
+  dashboard current
+              打印当前 Web Dashboard 登录 URL（不轮换 token）
+  dashboard rotate
+              轮换 token，并打印新的登录 URL（裸 \`dashboard\` 为兼容别名）
   device enroll|status|logout
               在宿主终端注册、查看或清除 desktop device 凭证（AI CLI 会话内拒绝）
   list        列出活跃会话（交互式选择并连接 tmux）
@@ -11852,7 +11871,7 @@ switch (command) {
   case 'status':  cmdStatus(); break;
   case 'upgrade':
   case 'update':  cmdUpgrade(); break;
-  case 'dashboard': await cmdDashboard(); break;
+  case 'dashboard': await cmdDashboard(process.argv.slice(3)); break;
   case 'bind': {
     // `botmux bind <code>` — 把本机绑定到中心化平台
     const { cmdBind } = await import('./platform/bind.js');

--- a/src/cli/dashboard-command.ts
+++ b/src/cli/dashboard-command.ts
@@ -1,0 +1,33 @@
+import type { DashboardEndpoint, DashboardResult } from './dashboard-endpoint.js';
+
+export const DASHBOARD_COMMAND_USAGE = `用法:
+  botmux dashboard current   打印当前 Dashboard 登录 URL（不轮换 token）
+  botmux dashboard rotate    轮换 token，并打印新的 Dashboard 登录 URL
+  botmux dashboard           rotate 的兼容别名`;
+
+export type DashboardCommandExecution =
+  | { kind: 'help' }
+  | { kind: 'invalid'; argument: string }
+  | { kind: 'endpoint'; action: 'current' | 'rotate'; result: DashboardResult };
+
+/**
+ * Parse and dispatch the dashboard subcommand without touching process-global
+ * output or credentials. Keeping the endpoint call injected makes the safety
+ * property executable in tests: help/invalid invocations cannot accidentally
+ * reach the token-rotation endpoint.
+ */
+export async function executeDashboardCommand(
+  args: readonly string[],
+  callEndpoint: (path: DashboardEndpoint) => Promise<DashboardResult>,
+): Promise<DashboardCommandExecution> {
+  const raw = args[0]?.toLowerCase();
+  if (raw === '--help' || raw === '-h' || raw === 'help') return { kind: 'help' };
+
+  if (raw !== undefined && raw !== 'current' && raw !== 'rotate') {
+    return { kind: 'invalid', argument: args[0] };
+  }
+
+  const action = raw === 'current' ? 'current' : 'rotate';
+  const path: DashboardEndpoint = action === 'current' ? '/__cli/current' : '/__cli/rotate';
+  return { kind: 'endpoint', action, result: await callEndpoint(path) };
+}

--- a/src/cli/dashboard-command.ts
+++ b/src/cli/dashboard-command.ts
@@ -1,14 +1,22 @@
 import type { DashboardEndpoint, DashboardResult } from './dashboard-endpoint.js';
 
 export const DASHBOARD_COMMAND_USAGE = `用法:
-  botmux dashboard current   打印当前 Dashboard 登录 URL（不轮换 token）
-  botmux dashboard rotate    轮换 token，并打印新的 Dashboard 登录 URL
-  botmux dashboard           rotate 的兼容别名`;
+  botmux dashboard           获取当前 Dashboard 登录 URL（没有则创建，不轮换已有 token）
+  botmux dashboard current   获取当前 Dashboard 登录 URL（没有则创建，不轮换已有 token）
+  botmux dashboard rotate    轮换 token，并打印新的 Dashboard 登录 URL`;
 
 export type DashboardCommandExecution =
   | { kind: 'help' }
   | { kind: 'invalid'; argument: string }
   | { kind: 'endpoint'; action: 'current' | 'rotate'; result: DashboardResult };
+
+export function formatDashboardFallbackFailure(
+  action: 'current' | 'rotate',
+  failure: Extract<DashboardResult, { ok: false }>,
+): string {
+  const operation = action === 'current' ? 'Dashboard lookup' : 'Rotation';
+  return `${operation} failed: ${failure.detail ?? failure.reason}`;
+}
 
 /**
  * Parse and dispatch the dashboard subcommand without touching process-global
@@ -20,14 +28,18 @@ export async function executeDashboardCommand(
   args: readonly string[],
   callEndpoint: (path: DashboardEndpoint) => Promise<DashboardResult>,
 ): Promise<DashboardCommandExecution> {
+  if (args.some(arg => ['--help', '-h', 'help'].includes(arg.toLowerCase()))) {
+    return { kind: 'help' };
+  }
+  if (args.length > 1) return { kind: 'invalid', argument: args.join(' ') };
+
   const raw = args[0]?.toLowerCase();
-  if (raw === '--help' || raw === '-h' || raw === 'help') return { kind: 'help' };
 
   if (raw !== undefined && raw !== 'current' && raw !== 'rotate') {
     return { kind: 'invalid', argument: args[0] };
   }
 
-  const action = raw === 'current' ? 'current' : 'rotate';
-  const path: DashboardEndpoint = action === 'current' ? '/__cli/current' : '/__cli/rotate';
+  const action = raw === 'rotate' ? 'rotate' : 'current';
+  const path: DashboardEndpoint = action === 'current' ? '/__cli/ensure' : '/__cli/rotate';
   return { kind: 'endpoint', action, result: await callEndpoint(path) };
 }

--- a/src/cli/dashboard-command.ts
+++ b/src/cli/dashboard-command.ts
@@ -10,6 +10,16 @@ export type DashboardCommandExecution =
   | { kind: 'invalid'; argument: string }
   | { kind: 'endpoint'; action: 'current' | 'rotate'; result: DashboardResult };
 
+const LEGACY_ENSURE_TOKEN_GATE_PREFIX =
+  '401 <h1>Token expired</h1><p>Run <code>botmux dashboard</code>';
+
+function legacyEnsureRouteMissing(result: DashboardResult): boolean {
+  if (result.ok) return false;
+  if (result.reason === 'wrong-service') return true;
+  return result.reason === 'http-error'
+    && result.detail?.startsWith(LEGACY_ENSURE_TOKEN_GATE_PREFIX) === true;
+}
+
 export function formatDashboardFallbackFailure(
   action: 'current' | 'rotate',
   failure: Extract<DashboardResult, { ok: false }>,
@@ -40,6 +50,31 @@ export async function executeDashboardCommand(
   }
 
   const action = raw === 'rotate' ? 'rotate' : 'current';
-  const path: DashboardEndpoint = action === 'current' ? '/__cli/ensure' : '/__cli/rotate';
-  return { kind: 'endpoint', action, result: await callEndpoint(path) };
+  if (action === 'rotate') {
+    return { kind: 'endpoint', action, result: await callEndpoint('/__cli/rotate') };
+  }
+
+  const current = await callEndpoint('/__cli/current');
+  if (current.ok || current.reason !== 'no-active-token') {
+    return { kind: 'endpoint', action, result: current };
+  }
+
+  const ensured = await callEndpoint('/__cli/ensure');
+  // The immediately preceding current probe proved this is a dashboard with no
+  // active token. Older dashboards either 404 an unknown ensure route or pass
+  // it through the browser token gate (the exact 401 HTML above). Only those
+  // version signatures may fall back to legacy rotate; a new endpoint's 500,
+  // auth failure, or transport failure must remain fail-closed.
+  if (legacyEnsureRouteMissing(ensured)) {
+    // A token may have appeared between the first read and the failed legacy
+    // capability probe (or rediscovery may have healed the recorded port).
+    // Re-read before using the mutating compatibility endpoint so a concurrent
+    // valid link is returned instead of invalidated.
+    const legacyCurrent = await callEndpoint('/__cli/current');
+    if (legacyCurrent.ok || legacyCurrent.reason !== 'no-active-token') {
+      return { kind: 'endpoint', action, result: legacyCurrent };
+    }
+    return { kind: 'endpoint', action, result: await callEndpoint('/__cli/rotate') };
+  }
+  return { kind: 'endpoint', action, result: ensured };
 }

--- a/src/cli/dashboard-endpoint.ts
+++ b/src/cli/dashboard-endpoint.ts
@@ -5,7 +5,7 @@ import { cliAuthBind, loadDashboardSecret, signCliAuth } from '../dashboard/auth
 
 /**
  * Loopback HMAC client for the dashboard process's `/__cli/*` endpoints, used by
- * `botmux dashboard` (rotate) and the post-start/restart hint (current).
+ * `botmux dashboard [current|rotate]` and the post-start/restart hint.
  *
  * Two subtleties this module exists to handle correctly:
  *
@@ -29,7 +29,7 @@ import { cliAuthBind, loadDashboardSecret, signCliAuth } from '../dashboard/auth
  *    self-heal `.dashboard-port`.
  */
 
-export type DashboardEndpoint = '/__cli/rotate' | '/__cli/current' | '/__cli/reload-binding';
+export type DashboardEndpoint = '/__cli/rotate' | '/__cli/ensure' | '/__cli/current' | '/__cli/reload-binding';
 
 export type DashboardFailReason =
   | 'no-secret'
@@ -49,7 +49,7 @@ type FetchImpl = typeof fetch;
  * Classify a 404 from a `/__cli/*` request. A genuine "no token yet" only comes
  * from `/__cli/current` carrying `{ error: 'no_active_token' }`; everything else
  * means the port is answering for some other service (daemon IPC, a stray HTTP
- * server, …), not the dashboard rotate/current routes.
+ * server, …), not one of the dashboard CLI routes.
  */
 export function classifyDashboard404(path: DashboardEndpoint, bodyText: string): DashboardResult {
   let body: unknown = null;

--- a/src/config.ts
+++ b/src/config.ts
@@ -233,7 +233,7 @@ export const config = {
      *  schedules, SSE — are reachable WITHOUT a token, so a stale dashboard
      *  link degrades to read-only browsing instead of a dead "link expired"
      *  wall. Write actions (POST/PATCH/DELETE) and the raw PTY log always
-     *  require the rotated token. Opt out with
+     *  require the current token. Opt out with
      *  BOTMUX_DASHBOARD_PUBLIC_READONLY=false.
      *
      *  NOTE: this env value is only the DEFAULT. Once the toggle is changed on

--- a/src/core/terminal-write-auth.ts
+++ b/src/core/terminal-write-auth.ts
@@ -134,6 +134,18 @@ export function readDashboardCookie(cookieHeader: string | string[] | undefined)
   return null;
 }
 
+/** Credential rotation atomically replaces the token file, so a strict
+ * inode-stability read may transiently throw while the rename wins. Auth must
+ * fail closed for that request rather than letting storage errors escape into
+ * the worker HTTP/WebSocket server. */
+function readLiveDashboardToken(getDashboardToken: () => string | null): string | null {
+  try {
+    return getDashboardToken();
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Resolve terminal write for one request: extract the `X-Botmux-Role` header
  * (a duplicated/array header is treated as absent), verify the request came
@@ -141,10 +153,10 @@ export function readDashboardCookie(cookieHeader: string | string[] | undefined)
  * active token), and gate the role's trust on the machine's platform binding.
  *
  * Both `isPlatformBound` and `getDashboardToken` are thunks evaluated on EVERY
- * call — never snapshotted. `botmux bind`/unbind and `botmux dashboard` (token
- * rotation) rewrite state that the dashboard hot-reloads WITHOUT restarting live
- * workers; a cached value would go stale — keep trusting a request after an
- * unbind / token rotation, or deny legitimate platform writes after a bind.
+ * call — never snapshotted. `botmux bind`/unbind and `botmux dashboard rotate`
+ * rewrite state that the dashboard hot-reloads WITHOUT restarting live workers;
+ * a cached value would go stale — keep trusting a request after an unbind / token
+ * rotation, or deny legitimate platform writes after a bind.
  */
 export function resolveTerminalWriteForRequest(
   headers: Record<string, string | string[] | undefined>,
@@ -155,7 +167,7 @@ export function resolveTerminalWriteForRequest(
   const rawRole = headers['x-botmux-role'];
   const role = typeof rawRole === 'string' ? rawRole : undefined;
   const cookieToken = readDashboardCookie(headers['cookie']);
-  const activeToken = getDashboardToken();
+  const activeToken = readLiveDashboardToken(getDashboardToken);
   const platformProxied = !!activeToken && safeTerminalTokenEqual(cookieToken, activeToken);
   return resolveTerminalWrite({ role, tokenMatches, platformBound: isPlatformBound(), platformProxied });
 }
@@ -175,7 +187,7 @@ export function resolveTerminalAccessForRequest(
   const rawRole = headers['x-botmux-role'];
   const role = typeof rawRole === 'string' ? rawRole : undefined;
   const cookieToken = readDashboardCookie(headers['cookie']);
-  const activeToken = getDashboardToken();
+  const activeToken = readLiveDashboardToken(getDashboardToken);
   const platformProxied = !!activeToken && safeTerminalTokenEqual(cookieToken, activeToken);
   return resolveTerminalAccess({
     role,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -171,7 +171,7 @@ import {
   cancelSessionReadyAck,
   waitForSessionReadyAck,
 } from './core/session-ready-handshake.js';
-import { loadOrCreateDashboardSecret } from './dashboard/auth.js';
+import { loadOrCreateDashboardSecret, loadPersistedToken } from './dashboard/auth.js';
 import { daemonIpcAuthHeaders, loadDaemonIpcSecret } from './core/daemon-ipc-auth.js';
 import {
   authorizeSessionScopedIpc,
@@ -19789,9 +19789,8 @@ function dashboardUrlForReport(): { url?: string; localUrl?: string } {
   try {
     const dir = join(homedir(), '.botmux');
     const portFile = join(dir, '.dashboard-port');
-    const tokenFile = join(dir, '.dashboard-token');
     const port = existsSync(portFile) ? readFileSync(portFile, 'utf8').trim() : String(config.dashboard.port);
-    const tok = existsSync(tokenFile) ? readFileSync(tokenFile, 'utf8').trim() : '';
+    const tok = loadPersistedToken(join(dir, '.dashboard-token')) ?? '';
     // buildDashboardUrls swaps in the central-platform machine subdomain when
     // 远程访问 is on and this host is bound, so the restart-report DM links to the
     // platform dashboard instead of an unreachable local host:port. In that case

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -15,8 +15,8 @@ import { gracefulProcessExitCode } from './pm2-graceful-exit.js';
 import { config, isWildcardBindHost } from './config.js';
 import { listenWithProbe } from './utils/listen-with-probe.js';
 import {
-  generateToken, parseCookie, buildSetCookie, verifyHmac, cliAuthBind, decideDashboardAuth,
-  loadPersistedToken, loadOrCreatePersistedToken, persistToken,
+  parseCookie, buildSetCookie, verifyHmac, cliAuthBind, decideDashboardAuth,
+  loadPersistedToken, loadOrCreatePersistedToken, rotatePersistedToken,
   loadDashboardSecret, loadOrCreateDashboardSecret,
 } from './dashboard/auth.js';
 import { DaemonRegistry, botsRosterSignature } from './dashboard/registry.js';
@@ -219,7 +219,11 @@ import { assertPluginBindingTransition, describePluginDependencyError } from './
 import { inspectGatewayEntry } from './core/plugins/mcp/gateway-installer.js';
 import type { InstalledPluginRecord, PluginDashboardEntry } from './core/plugins/types.js';
 import { fetchDaemonIpc } from './core/daemon-ipc-auth.js';
-import { buildDashboardSummary, unavailableDashboardSummary } from './dashboard/dashboard-summary.js';
+import {
+  buildDashboardSummary,
+  parseDashboardSummaryRows,
+} from './dashboard/dashboard-summary.js';
+import { createDashboardSummaryEndpoint } from './dashboard/dashboard-summary-endpoint.js';
 
 const SECRET_PATH = dashboardSecretPath();
 const TOKEN_PATH = join(homedir(), '.botmux', '.dashboard-token');
@@ -230,7 +234,8 @@ const BOTS_JSON_PATH = join(homedir(), '.botmux', 'bots.json');
 const REGISTRY_DIR = join(resolveBotmuxDataDir(), 'dashboard-daemons');
 // The dashboard probes upward if its configured port is busy (e.g. a second
 // botmux instance on this host). The actually-bound port is persisted here so
-// the `botmux dashboard` CLI can reach /__cli/rotate without guessing.
+// the `botmux dashboard` CLI can reach /__cli/current, /__cli/ensure, and
+// /__cli/rotate without guessing.
 const PORT_PATH = join(homedir(), '.botmux', '.dashboard-port');
 
 function loadOrCreateSecret(): string {
@@ -254,16 +259,21 @@ function loadOrCreateSecret(): string {
   }
 }
 
-// The active dashboard token is persisted to disk so a previously-issued
-// dashboard URL survives `botmux restart`. A platform-bound dashboard creates
-// the first token on startup; only `botmux dashboard` (the /__cli/rotate
-// endpoint) replaces it and thereby invalidates the old link.
-// The start/restart hint reads it via the non-rotating /__cli/current endpoint
-// so it can show the live link without invalidating it.
-let activeToken: string | null = loadPersistedToken(TOKEN_PATH);
+// The persisted file is the active-token authority. Reading it at each use
+// keeps multiple dashboard processes coherent: first creation converges under
+// a file lock, and an explicit rotation is observed by every process without a
+// restart. `/__cli/current` remains a strictly read-only probe.
+function currentDashboardToken(): string | null {
+  try {
+    return loadPersistedToken(TOKEN_PATH);
+  } catch (error) {
+    logger.warn(`[dashboard] Failed to read token from ${TOKEN_PATH}: ${(error as Error).message}`);
+    return null;
+  }
+}
 
 // The port we actually bound (may differ from config.dashboard.port after an
-// EADDRINUSE probe). Used for the rotation-URL and persisted for the CLI.
+// EADDRINUSE probe). Used for token-bearing URLs and persisted for the CLI.
 let boundDashboardPort = config.dashboard.port;
 
 const SECRET = loadOrCreateSecret();
@@ -342,7 +352,7 @@ aggregator.on(sessionPresentation.onEvent);
 // 调试终端（owner-only 裸 bash）。默认工作目录取当前所有 session 的工作目录去重，
 // 让 owner 从熟悉的目录起终端复现问题；都没有时模块内退回 homedir。
 const debugTerminalManager = createDebugTerminalManager({
-  getActiveToken: () => activeToken,
+  getActiveToken: currentDashboardToken,
   defaultWorkingDirs: () => {
     const dirs = new Set<string>();
     for (const s of aggregator.getSessions()) {
@@ -1244,9 +1254,9 @@ const groupsActionDeps: GroupsActionDeps = {
 // ─── PR2 C8: Route B internal API (`/__daemon/*`) ───────────────────────────
 // HMAC + loopback + ts ±60s + nonce TTL, signed-request envelope = full
 // (ts, nonce, method, pathWithQuery, sha256(body)). Reuses `.dashboard-secret`
-// for the HMAC key — the same secret `/__cli/rotate` already uses — but the
-// signing material is wider so a `/__cli/rotate` signature cannot be replayed
-// here and vice versa (different protocols, same secret, no cross-replay).
+// for the HMAC key — the same secret the `/__cli/*` protocol uses — but the
+// signing material is wider so a CLI signature cannot be replayed here and
+// vice versa (different protocols, same secret, no cross-replay).
 //
 // SECRET fail-closed: `loadOrCreateSecret()` returns a 32-byte base64url
 // string and never empty; we still guard below at server-startup time.
@@ -1937,7 +1947,11 @@ async function handlePluginManagementApi(
 
 // ─── HTTP routing ────────────────────────────────────────────────────────────
 
-function authedToken(req: IncomingMessage, url: URL): string | undefined {
+function authedToken(
+  req: IncomingMessage,
+  url: URL,
+  activeToken: string | null,
+): string | undefined {
   const q = url.searchParams.get('t');
   if (q && q === activeToken) return q;
   return parseCookie(req.headers.cookie);
@@ -2631,13 +2645,10 @@ async function liveDashboardSummary(): Promise<ReturnType<typeof buildDashboardS
       sessionsResponse.json() as Promise<{ sessions?: unknown }>,
       schedulesResponse.json() as Promise<{ schedules?: unknown }>,
     ]);
-    if (!Array.isArray(sessionsBody.sessions) || !Array.isArray(schedulesBody.schedules)) {
-      throw new Error('daemon_snapshot_malformed');
-    }
-    return {
+    return parseDashboardSummaryRows({
       sessions: sessionsBody.sessions,
       schedules: schedulesBody.schedules,
-    };
+    });
   }));
 
   return buildDashboardSummary({
@@ -2648,6 +2659,13 @@ async function liveDashboardSummary(): Promise<ReturnType<typeof buildDashboardS
     schedules: snapshots.flatMap(snapshot => snapshot.schedules),
   });
 }
+
+const dashboardSummaryEndpoint = createDashboardSummaryEndpoint({
+  load: liveDashboardSummary,
+  onError: error => {
+    logger.warn(`[dashboard-summary] live snapshot unavailable: ${error instanceof Error ? error.message : String(error)}`);
+  },
+});
 
 const server = createServer(async (req, res) => {
   try {
@@ -2670,7 +2688,8 @@ const server = createServer(async (req, res) => {
     // outside the browser auth gate so packaged desktop apps can decide whether
     // this runtime speaks their dashboard protocol before loading the SPA.
     if (req.method === 'GET' && url.pathname === '/__desktop/compat') {
-      const presentedToken = authedToken(req, url);
+      const activeToken = currentDashboardToken();
+      const presentedToken = authedToken(req, url, activeToken);
       const boundMachineId = activeToken && presentedToken === activeToken
         ? readPlatformBinding()?.machineId
         : null;
@@ -2744,29 +2763,48 @@ const server = createServer(async (req, res) => {
       return;
     }
 
-    // CLI rotate (HMAC + loopback only) — for `botmux dashboard`. Mints a fresh
-    // token, invalidating any previously-issued link.
+    // CLI rotate (HMAC + loopback only) — for `botmux dashboard rotate`.
+    // Publish the new token only after a durable write succeeds.
     if (req.method === 'POST' && url.pathname === '/__cli/rotate') {
       const gate = verifyCliRequest(req, url.pathname);
       if (!gate.ok) return jsonRes(res, gate.status, gate.body);
-      activeToken = generateToken();
       try {
-        persistToken(TOKEN_PATH, activeToken);
+        const token = rotatePersistedToken(TOKEN_PATH);
+        return jsonRes(res, 200, dashboardUrlsFor(token));
       } catch (e) {
         logger.warn(`[dashboard] Failed to persist token to ${TOKEN_PATH}: ${(e as Error).message}`);
+        return jsonRes(res, 500, { error: 'token_persist_failed' });
       }
-      return jsonRes(res, 200, dashboardUrlsFor(activeToken));
     }
 
-    // CLI read current URL (HMAC + loopback only) — for the start/restart hint.
-    // Unlike /__cli/rotate this does NOT mint a token, so an already-issued
-    // dashboard link survives restart untouched. 404 → no token has ever been
-    // minted (caller falls back to suggesting `botmux dashboard`).
+    // CLI get-or-create URL (HMAC + loopback only). Existing links survive
+    // untouched; the first caller atomically creates and persists a token.
+    if (req.method === 'POST' && url.pathname === '/__cli/ensure') {
+      const gate = verifyCliRequest(req, url.pathname);
+      if (!gate.ok) return jsonRes(res, gate.status, gate.body);
+      try {
+        const token = loadOrCreatePersistedToken(TOKEN_PATH);
+        return jsonRes(res, 200, dashboardUrlsFor(token));
+      } catch (e) {
+        logger.warn(`[dashboard] Failed to ensure token at ${TOKEN_PATH}: ${(e as Error).message}`);
+        return jsonRes(res, 500, { error: 'token_persist_failed' });
+      }
+    }
+
+    // CLI read current URL (HMAC + loopback only) — for start/restart hints and
+    // safe port discovery. This never mints a token.
     if (req.method === 'POST' && url.pathname === '/__cli/current') {
       const gate = verifyCliRequest(req, url.pathname);
       if (!gate.ok) return jsonRes(res, gate.status, gate.body);
-      if (!activeToken) return jsonRes(res, 404, { error: 'no_active_token' });
-      return jsonRes(res, 200, dashboardUrlsFor(activeToken));
+      let token: string | null;
+      try {
+        token = loadPersistedToken(TOKEN_PATH);
+      } catch (e) {
+        logger.warn(`[dashboard] Failed to read token from ${TOKEN_PATH}: ${(e as Error).message}`);
+        return jsonRes(res, 500, { error: 'token_unavailable' });
+      }
+      if (!token) return jsonRes(res, 404, { error: 'no_active_token' });
+      return jsonRes(res, 200, dashboardUrlsFor(token));
     }
 
     // CLI 通知绑定变化（HMAC + loopback）——`botmux bind` 写完绑定后捅一下，立即重连平台，
@@ -2789,7 +2827,8 @@ const server = createServer(async (req, res) => {
       return jsonRes(res, 200, { ok: true });
     }
 
-    const presentedToken = authedToken(req, url);
+    const activeToken = currentDashboardToken();
+    const presentedToken = authedToken(req, url, activeToken);
     const globalDashboardConfig = readGlobalConfig().dashboard;
     const decision = decideDashboardAuth({
       method: req.method ?? 'GET',
@@ -2930,13 +2969,9 @@ const server = createServer(async (req, res) => {
     // ─── Public API (cookie/token already validated above) ──────────────────
 
     if (req.method === 'GET' && url.pathname === '/api/dashboard/v1/summary') {
-      res.setHeader('cache-control', 'no-store');
-      try {
-        return jsonRes(res, 200, await liveDashboardSummary());
-      } catch (error) {
-        logger.warn(`[dashboard-summary] live snapshot unavailable: ${error instanceof Error ? error.message : String(error)}`);
-        return jsonRes(res, 503, unavailableDashboardSummary(new Date()));
-      }
+      const result = await dashboardSummaryEndpoint.get({ authenticated: authed });
+      for (const [name, value] of Object.entries(result.headers)) res.setHeader(name, value);
+      return jsonRes(res, result.status, result.body);
     }
 
     if (await handleResourceMonitorApi(req, res, url, resourceMonitor)) {
@@ -5702,15 +5737,16 @@ function startPlatformTunnelIfBound(): void {
   try {
     const binding = readPlatformBinding();
     if (!binding) return;
-    if (!activeToken) {
-      activeToken = loadOrCreatePersistedToken(TOKEN_PATH);
+    const existingToken = currentDashboardToken();
+    loadOrCreatePersistedToken(TOKEN_PATH);
+    if (!existingToken) {
       logger.info('[platform-tunnel] 已初始化 dashboard token');
     }
     const version = readBotmuxVersion();
     platformTunnel = startPlatformTunnelClient({
       binding,
       getDashboardPort: () => boundDashboardPort,
-      getDashboardToken: () => activeToken,
+      getDashboardToken: currentDashboardToken,
       getVersion: () => version,
       getBots: () => readPlatformBotsInfo(),
       getTeamSyncRev: () => getPlatformTeamSyncRev(config.session.dataDir),

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -2628,7 +2628,7 @@ function parseTerminalSessionId(pathname: string): string | undefined {
  */
 async function liveDashboardSummary(): Promise<ReturnType<typeof buildDashboardSummary>> {
   const daemons = registry.list();
-  const configuredBotCount = loadBotConfigs().length;
+  const configuredBots = loadBotConfigs();
   const snapshots = await Promise.all(daemons.map(async daemon => {
     const [sessionsResponse, schedulesResponse] = await Promise.all([
       fetchDaemonIpc(daemon.ipcPort, '/api/sessions', {
@@ -2653,8 +2653,8 @@ async function liveDashboardSummary(): Promise<ReturnType<typeof buildDashboardS
 
   return buildDashboardSummary({
     generatedAt: new Date(),
-    configuredBotCount,
-    onlineBotCount: daemons.length,
+    configuredBotAppIds: configuredBots.map(bot => bot.larkAppId),
+    onlineBotAppIds: daemons.map(daemon => daemon.larkAppId),
     sessions: snapshots.flatMap(snapshot => snapshot.sessions),
     schedules: snapshots.flatMap(snapshot => snapshot.schedules),
   });

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -219,6 +219,7 @@ import { assertPluginBindingTransition, describePluginDependencyError } from './
 import { inspectGatewayEntry } from './core/plugins/mcp/gateway-installer.js';
 import type { InstalledPluginRecord, PluginDashboardEntry } from './core/plugins/types.js';
 import { fetchDaemonIpc } from './core/daemon-ipc-auth.js';
+import { buildDashboardSummary, unavailableDashboardSummary } from './dashboard/dashboard-summary.js';
 
 const SECRET_PATH = dashboardSecretPath();
 const TOKEN_PATH = join(homedir(), '.botmux', '.dashboard-token');
@@ -2603,6 +2604,51 @@ function parseTerminalSessionId(pathname: string): string | undefined {
   return seg || undefined;
 }
 
+/**
+ * Read every currently-online daemon directly for the public dashboard
+ * summary. The regular aggregator intentionally retains offline
+ * rows for operator history, so using it here would make an offline bot's old
+ * sessions or schedules look live. A failed or malformed daemon snapshot
+ * rejects the whole projection instead of silently turning missing data into
+ * zeroes.
+ */
+async function liveDashboardSummary(): Promise<ReturnType<typeof buildDashboardSummary>> {
+  const daemons = registry.list();
+  const configuredBotCount = loadBotConfigs().length;
+  const snapshots = await Promise.all(daemons.map(async daemon => {
+    const [sessionsResponse, schedulesResponse] = await Promise.all([
+      fetchDaemonIpc(daemon.ipcPort, '/api/sessions', {
+        signal: AbortSignal.timeout(2_000),
+      }),
+      fetchDaemonIpc(daemon.ipcPort, '/api/schedules', {
+        signal: AbortSignal.timeout(2_000),
+      }),
+    ]);
+    if (!sessionsResponse.ok || !schedulesResponse.ok) {
+      throw new Error('daemon_snapshot_http_error');
+    }
+    const [sessionsBody, schedulesBody] = await Promise.all([
+      sessionsResponse.json() as Promise<{ sessions?: unknown }>,
+      schedulesResponse.json() as Promise<{ schedules?: unknown }>,
+    ]);
+    if (!Array.isArray(sessionsBody.sessions) || !Array.isArray(schedulesBody.schedules)) {
+      throw new Error('daemon_snapshot_malformed');
+    }
+    return {
+      sessions: sessionsBody.sessions,
+      schedules: schedulesBody.schedules,
+    };
+  }));
+
+  return buildDashboardSummary({
+    generatedAt: new Date(),
+    configuredBotCount,
+    onlineBotCount: daemons.length,
+    sessions: snapshots.flatMap(snapshot => snapshot.sessions),
+    schedules: snapshots.flatMap(snapshot => snapshot.schedules),
+  });
+}
+
 const server = createServer(async (req, res) => {
   try {
     const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
@@ -2882,6 +2928,16 @@ const server = createServer(async (req, res) => {
     }
 
     // ─── Public API (cookie/token already validated above) ──────────────────
+
+    if (req.method === 'GET' && url.pathname === '/api/dashboard/v1/summary') {
+      res.setHeader('cache-control', 'no-store');
+      try {
+        return jsonRes(res, 200, await liveDashboardSummary());
+      } catch (error) {
+        logger.warn(`[dashboard-summary] live snapshot unavailable: ${error instanceof Error ? error.message : String(error)}`);
+        return jsonRes(res, 503, unavailableDashboardSummary(new Date()));
+      }
+    }
 
     if (await handleResourceMonitorApi(req, res, url, resourceMonitor)) {
       return;

--- a/src/dashboard/auth.ts
+++ b/src/dashboard/auth.ts
@@ -233,8 +233,9 @@ export type AuthDecision =
  *  workflow tombstone are handled separately in decideDashboardAuth. Full v3
  *  workflow projections stay private because goals, node ids, and run ids can
  *  contain project or personal information.
- *  口径：公开 = 会话板 / 排程(脱敏) / 设置(只读) / 群名册 / 事件流。 */
+ *  口径：公开 = 运行摘要 / 会话板 / 排程(脱敏) / 设置(只读) / 群名册 / 事件流。 */
 const PUBLIC_READ_PATHS: ReadonlySet<string> = new Set([
+  '/api/dashboard/v1/summary', // strongly-redacted dashboard aggregate
   '/api/sessions',    // session board
   '/api/schedules',   // schedules page — task prompt redacted for anon upstream
   '/api/settings',    // read-only settings — only public flags + authed:false

--- a/src/dashboard/auth.ts
+++ b/src/dashboard/auth.ts
@@ -4,6 +4,12 @@ import {
 } from 'node:fs';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { dirname } from 'node:path';
+import {
+  readSecureHostFileSync,
+  secureHostFilePath,
+  writeSecureHostFileSync,
+} from '../platform/secure-host-file.js';
+import { withFileLockSync } from '../utils/file-lock.js';
 
 const NONCE_TTL_MS = 60_000;
 const TS_WINDOW_S = 30;
@@ -18,11 +24,13 @@ export interface HmacAttempt { ts: string; nonce: string; sig: string; }
  * single set of `X-Botmux-Cli-*` headers signed only over `ts:nonce` is valid
  * for ANY `/__cli/*` route on ANY dashboard — which lets a malicious local
  * server, handed a discovery probe, forward the headers to the real dashboard
- * (e.g. a `/__cli/current` probe relayed to `/__cli/rotate` to mint a token).
+ * (e.g. a `/__cli/current` probe relayed to `/__cli/ensure` or `/__cli/rotate`
+ * to mint a token).
  * Binding `method + path + bound-port` makes the credential single-purpose:
  *  - the verifier uses the port IT actually bound (not the attacker-controlled
  *    Host header), so a forward from port X to the dashboard on port Y mismatches;
- *  - a `/__cli/current` capture can't be replayed to `/__cli/rotate` (path differs).
+ *  - a `/__cli/current` capture can't be replayed to either token-writing route
+ *    (path differs).
  */
 export function cliAuthBind(method: string, path: string, port: number | string): string {
   return `${String(method).toUpperCase()} ${path} ${port}`;
@@ -150,35 +158,47 @@ export function loadOrCreateDashboardSecret(secretPath: string): string {
 
 /**
  * Load the persisted active dashboard token from `tokenPath`, or `null` when
- * the file is absent / empty / unreadable.
+ * the file is genuinely absent or empty. Unsafe credential-file shapes fail
+ * closed instead of being treated as a missing token.
  *
  * Persisting the active token lets a previously-issued dashboard URL survive a
- * `botmux restart`: on startup the dashboard hydrates `activeToken` from this
- * file instead of starting blank.  Only `botmux dashboard` rotates the token
- * (via `persistToken` with a fresh value), which is what invalidates the old
- * link.
+ * `botmux restart` and keeps multiple dashboard processes on one authority.
+ * Only `botmux dashboard rotate` replaces the file, which invalidates the old
+ * link for every process on its next request.
  */
 export function loadPersistedToken(tokenPath: string): string | null {
-  try {
-    if (existsSync(tokenPath)) return readFileSync(tokenPath, 'utf8').trim() || null;
-  } catch { /* unreadable token file → behave as if none persisted */ }
-  return null;
+  return readSecureHostFileSync(tokenPath, 256)?.trim() || null;
 }
 
-/** Persist the active dashboard token to `tokenPath` with 0600 perms. */
+/** Durably persist the active dashboard token without following a leaf symlink. */
 export function persistToken(tokenPath: string, token: string): void {
-  mkdirSync(dirname(tokenPath), { recursive: true });
-  atomicWriteFileSync(tokenPath, token, { mode: 0o600 });
-  chmodSync(tokenPath, 0o600);
+  writeSecureHostFileSync(tokenPath, token);
 }
 
-/** Load the active token, creating and persisting the first one when absent. */
+/**
+ * Load the active token, creating and persisting the first one when absent.
+ * The file lock makes get-or-create linearizable across dashboard processes:
+ * every concurrent caller returns the same durable token.
+ */
 export function loadOrCreatePersistedToken(tokenPath: string): string {
-  const existing = loadPersistedToken(tokenPath);
-  if (existing) return existing;
-  const token = generateToken();
-  persistToken(tokenPath, token);
-  return token;
+  const securePath = secureHostFilePath(tokenPath);
+  return withFileLockSync(securePath, () => {
+    const existing = loadPersistedToken(securePath);
+    if (existing) return existing;
+    const token = generateToken();
+    persistToken(securePath, token);
+    return token;
+  });
+}
+
+/** Generate and durably replace the token while serialized with first creation. */
+export function rotatePersistedToken(tokenPath: string): string {
+  const securePath = secureHostFilePath(tokenPath);
+  return withFileLockSync(securePath, () => {
+    const token = generateToken();
+    persistToken(securePath, token);
+    return token;
+  });
 }
 
 /** Extract `botmux_dashboard_token` value from a Cookie header. */
@@ -215,8 +235,10 @@ export function buildSetCookie(token: string): string {
  *   - `GET /api/workflows/*`                   — zero-I/O legacy retirement
  *                                                tombstone (HTTP 410).
  *
- * Anything else (sessions, schedules, dashboard rotate, etc.) requires the active session token, matching the
- * "get_write_link" pattern that the chat web terminal already uses.
+ * Outside those always-public surfaces, the explicit `publicReadOnly`
+ * allow-list controls tokenless observation. Mutations and private reads still
+ * require the active session token, matching the chat web terminal's
+ * capability boundary.
  */
 export type AuthDecision =
   | { kind: 'allow' }

--- a/src/dashboard/dashboard-summary-endpoint.ts
+++ b/src/dashboard/dashboard-summary-endpoint.ts
@@ -1,0 +1,85 @@
+import {
+  unavailableDashboardSummary,
+  type DashboardSummary,
+} from './dashboard-summary.js';
+
+const ANONYMOUS_WINDOW_MS = 10_000;
+const ANONYMOUS_MAX_REQUESTS = 5;
+
+export type DashboardSummaryEndpointResult =
+  | {
+    status: 200;
+    headers: { 'cache-control': 'no-store' };
+    body: DashboardSummary;
+  }
+  | {
+    status: 429;
+    headers: { 'cache-control': 'no-store'; 'retry-after': string };
+    body: { error: 'rate_limited'; retryAfterSeconds: number };
+  }
+  | {
+    status: 503;
+    headers: { 'cache-control': 'no-store' };
+    body: ReturnType<typeof unavailableDashboardSummary>;
+  };
+
+export interface DashboardSummaryEndpoint {
+  get(input: { authenticated: boolean }): Promise<DashboardSummaryEndpointResult>;
+}
+
+/**
+ * Own the public summary request policy behind one small interface. The live
+ * fleet loader is injected so callers and tests cross the same seam.
+ */
+export function createDashboardSummaryEndpoint(options: {
+  load: () => Promise<DashboardSummary>;
+  now?: () => number;
+  onError?: (error: unknown) => void;
+}): DashboardSummaryEndpoint {
+  const now = options.now ?? Date.now;
+  const anonymousAttempts: number[] = [];
+
+  return {
+    async get(input) {
+      if (!input.authenticated) {
+        const requestAt = now();
+        while (
+          anonymousAttempts.length > 0
+          && requestAt - anonymousAttempts[0] >= ANONYMOUS_WINDOW_MS
+        ) {
+          anonymousAttempts.shift();
+        }
+        if (anonymousAttempts.length >= ANONYMOUS_MAX_REQUESTS) {
+          const retryAfterSeconds = Math.max(
+            1,
+            Math.ceil((anonymousAttempts[0] + ANONYMOUS_WINDOW_MS - requestAt) / 1000),
+          );
+          return {
+            status: 429,
+            headers: {
+              'cache-control': 'no-store',
+              'retry-after': String(retryAfterSeconds),
+            },
+            body: { error: 'rate_limited', retryAfterSeconds },
+          };
+        }
+        anonymousAttempts.push(requestAt);
+      }
+
+      try {
+        return {
+          status: 200,
+          headers: { 'cache-control': 'no-store' },
+          body: await options.load(),
+        };
+      } catch (error) {
+        options.onError?.(error);
+        return {
+          status: 503,
+          headers: { 'cache-control': 'no-store' },
+          body: unavailableDashboardSummary(new Date(now())),
+        };
+      }
+    },
+  };
+}

--- a/src/dashboard/dashboard-summary.ts
+++ b/src/dashboard/dashboard-summary.ts
@@ -88,11 +88,13 @@ export function parseDashboardSummaryRows(input: {
  */
 export function buildDashboardSummary(input: {
   generatedAt: Date;
-  configuredBotCount: number;
-  onlineBotCount: number;
+  configuredBotAppIds: readonly string[];
+  onlineBotAppIds: readonly string[];
   sessions: readonly DashboardSummarySessionRow[];
   schedules: readonly DashboardSummaryScheduleRow[];
 }): DashboardSummary {
+  const onlineBotAppIds = new Set(input.onlineBotAppIds);
+  const configuredFleetOnline = input.configuredBotAppIds.every(appId => onlineBotAppIds.has(appId));
   const activeSessions = input.sessions.filter(row => row.status !== 'closed');
   const attentionSessions = activeSessions.filter(row => (
     !!row.agentAttention
@@ -113,9 +115,9 @@ export function buildDashboardSummary(input: {
     schemaVersion: DASHBOARD_SUMMARY_SCHEMA_VERSION,
     generatedAt: input.generatedAt.toISOString(),
     service: {
-      status: input.onlineBotCount === input.configuredBotCount ? 'healthy' : 'degraded',
+      status: configuredFleetOnline ? 'healthy' : 'degraded',
     },
-    bots: { online: input.onlineBotCount },
+    bots: { online: input.onlineBotAppIds.length },
     sessions: {
       active: activeSessions.length,
       attention: attentionSessions.length,

--- a/src/dashboard/dashboard-summary.ts
+++ b/src/dashboard/dashboard-summary.ts
@@ -22,6 +22,64 @@ interface DashboardSummaryScheduleRow {
   nextRunAt?: unknown;
 }
 
+const DASHBOARD_SUMMARY_SESSION_STATUSES = new Set([
+  'working',
+  'idle',
+  'analyzing',
+  'limited',
+  'stalled',
+  'starting',
+  'closed',
+  'dormant',
+]);
+
+function objectRow(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** Validate the minimal daemon row shape consumed by the public projection.
+ * Rejecting malformed live data keeps the endpoint from publishing plausible
+ * but invented operational counts. */
+export function parseDashboardSummaryRows(input: {
+  sessions: unknown;
+  schedules: unknown;
+}): {
+  sessions: readonly DashboardSummarySessionRow[];
+  schedules: readonly DashboardSummaryScheduleRow[];
+} {
+  if (!Array.isArray(input.sessions)) throw new Error('dashboard summary sessions must be an array');
+  if (!Array.isArray(input.schedules)) throw new Error('dashboard summary schedules must be an array');
+  for (const row of input.sessions) {
+    if (!objectRow(row)
+      || typeof row.status !== 'string'
+      || !DASHBOARD_SUMMARY_SESSION_STATUSES.has(row.status)) {
+      throw new Error('dashboard summary session status is invalid');
+    }
+    if (row.pendingRepo !== undefined && typeof row.pendingRepo !== 'boolean') {
+      throw new Error('dashboard summary session pendingRepo must be a boolean');
+    }
+    if (row.tuiPromptActive !== undefined && typeof row.tuiPromptActive !== 'boolean') {
+      throw new Error('dashboard summary session tuiPromptActive must be a boolean');
+    }
+    if (row.agentAttention !== undefined && row.agentAttention !== null && !objectRow(row.agentAttention)) {
+      throw new Error('dashboard summary session agentAttention must be an object or null');
+    }
+  }
+  for (const row of input.schedules) {
+    if (!objectRow(row) || typeof row.enabled !== 'boolean') {
+      throw new Error('dashboard summary schedule enabled must be a boolean');
+    }
+    if (row.nextRunAt !== undefined
+      && (typeof row.nextRunAt !== 'string' || !Number.isFinite(Date.parse(row.nextRunAt)))) {
+      throw new Error('dashboard summary schedule nextRunAt must be a valid timestamp');
+    }
+  }
+  return {
+    sessions: input.sessions as DashboardSummarySessionRow[],
+    schedules: input.schedules as DashboardSummaryScheduleRow[],
+  };
+}
+
 /**
  * Reduce the dashboard's rich internal read model to a deliberately tiny
  * public summary contract. Keep the projection here as a positive allowlist:
@@ -41,6 +99,7 @@ export function buildDashboardSummary(input: {
     || !!row.pendingRepo
     || !!row.tuiPromptActive
     || row.status === 'limited'
+    || row.status === 'stalled'
   ));
   const enabledSchedules = input.schedules.filter(row => row.enabled === true);
   const nextRunMs = enabledSchedules.reduce<number | null>((earliest, row) => {

--- a/src/dashboard/dashboard-summary.ts
+++ b/src/dashboard/dashboard-summary.ts
@@ -1,0 +1,82 @@
+export const DASHBOARD_SUMMARY_SCHEMA_VERSION = 1 as const;
+
+export interface DashboardSummary {
+  schemaVersion: typeof DASHBOARD_SUMMARY_SCHEMA_VERSION;
+  generatedAt: string;
+  service: { status: 'healthy' | 'degraded' };
+  bots: { online: number };
+  sessions: { active: number; attention: number };
+  schedules: { enabled: number; nextRunAt: string | null };
+  dashboard: { href: '/' };
+}
+
+interface DashboardSummarySessionRow {
+  status?: unknown;
+  pendingRepo?: unknown;
+  tuiPromptActive?: unknown;
+  agentAttention?: unknown;
+}
+
+interface DashboardSummaryScheduleRow {
+  enabled?: unknown;
+  nextRunAt?: unknown;
+}
+
+/**
+ * Reduce the dashboard's rich internal read model to a deliberately tiny
+ * public summary contract. Keep the projection here as a positive allowlist:
+ * adding a field to a session, schedule, bot descriptor, or dashboard API can
+ * never make it appear in this response by accident.
+ */
+export function buildDashboardSummary(input: {
+  generatedAt: Date;
+  configuredBotCount: number;
+  onlineBotCount: number;
+  sessions: readonly DashboardSummarySessionRow[];
+  schedules: readonly DashboardSummaryScheduleRow[];
+}): DashboardSummary {
+  const activeSessions = input.sessions.filter(row => row.status !== 'closed');
+  const attentionSessions = activeSessions.filter(row => (
+    !!row.agentAttention
+    || !!row.pendingRepo
+    || !!row.tuiPromptActive
+    || row.status === 'limited'
+  ));
+  const enabledSchedules = input.schedules.filter(row => row.enabled === true);
+  const nextRunMs = enabledSchedules.reduce<number | null>((earliest, row) => {
+    if (typeof row.nextRunAt !== 'string') return earliest;
+    const candidate = Date.parse(row.nextRunAt);
+    if (!Number.isFinite(candidate)) return earliest;
+    return earliest === null || candidate < earliest ? candidate : earliest;
+  }, null);
+
+  return {
+    schemaVersion: DASHBOARD_SUMMARY_SCHEMA_VERSION,
+    generatedAt: input.generatedAt.toISOString(),
+    service: {
+      status: input.onlineBotCount === input.configuredBotCount ? 'healthy' : 'degraded',
+    },
+    bots: { online: input.onlineBotCount },
+    sessions: {
+      active: activeSessions.length,
+      attention: attentionSessions.length,
+    },
+    schedules: {
+      enabled: enabledSchedules.length,
+      nextRunAt: nextRunMs === null ? null : new Date(nextRunMs).toISOString(),
+    },
+    dashboard: { href: '/' },
+  };
+}
+
+/** Minimal, still-whitelisted body for an upstream snapshot failure. Counts
+ * are intentionally absent: returning plausible zeroes would turn missing
+ * daemon state into false operational health. The HTTP handler pairs this with
+ * 503 so consumers can render an unavailable state. */
+export function unavailableDashboardSummary(generatedAt: Date): Pick<DashboardSummary, 'schemaVersion' | 'generatedAt' | 'service'> {
+  return {
+    schemaVersion: DASHBOARD_SUMMARY_SCHEMA_VERSION,
+    generatedAt: generatedAt.toISOString(),
+    service: { status: 'degraded' },
+  };
+}

--- a/src/dashboard/web/i18n.ts
+++ b/src/dashboard/web/i18n.ts
@@ -2153,7 +2153,7 @@ const zh: DashboardMessages = {
   'workflow.v3.cancelPending': '取消请求已持久化；正在等待运行中的节点收敛。',
   'workflow.v3.cancelled': '运行已取消。',
   'workflow.v3.cancelAlreadyTerminal': '运行已先一步进入终态，未再提交取消。',
-  'workflow.v3.cancelAuthRequired': '需要 Dashboard 写权限：请在终端运行 `botmux dashboard` 获取一次性链接后重试。',
+  'workflow.v3.cancelAuthRequired': '需要 Dashboard 写权限：请在终端运行 `botmux dashboard` 获取当前登录链接后重试。',
   'workflow.v3.cancelFailed': '取消失败：{error}',
 };
 
@@ -4307,7 +4307,7 @@ const en: DashboardMessages = {
   'workflow.v3.cancelPending': 'The cancel request is durable; waiting for running nodes to drain.',
   'workflow.v3.cancelled': 'Run cancelled.',
   'workflow.v3.cancelAlreadyTerminal': 'The run reached a terminal state first; no cancel was submitted.',
-  'workflow.v3.cancelAuthRequired': 'Dashboard write access is required. Run `botmux dashboard` in a terminal, open its one-time link, then retry.',
+  'workflow.v3.cancelAuthRequired': 'Dashboard write access is required. Run `botmux dashboard` in a terminal, open its current login link, then retry.',
   'workflow.v3.cancelFailed': 'Cancel failed: {error}',
 };
 

--- a/src/desktop/main/ipc.ts
+++ b/src/desktop/main/ipc.ts
@@ -144,7 +144,7 @@ async function locateDashboard(runtime: RuntimeService): Promise<DashboardLocate
   const result = await runtime.dashboard();
   const url = result.code === 0 ? selectDesktopDashboardUrl(result.stdout) : '';
   if (url) {
-    return validateLocatedDashboard(url, 'rotated');
+    return validateLocatedDashboard(url, 'ensured');
   }
 
   const message = result.stderr.trim() || result.stdout.trim() || `Dashboard lookup failed with exit code ${result.code}`;

--- a/src/desktop/main/runtime-service.ts
+++ b/src/desktop/main/runtime-service.ts
@@ -420,8 +420,8 @@ export function createRuntimeService(deps: RuntimeServiceDeps) {
       const runtime = activeRuntime();
       if (!runtime) return rejectedCliRequired();
       // Desktop embeds the existing authenticated dashboard session by default.
-      // Falling back to rotation is decided by the IPC locator only when the
-      // dashboard explicitly reports that no active token exists yet.
+      // The IPC locator falls back to the get-or-create command only when the
+      // read-only probe reports that no active token exists yet.
       const result = deps.dashboardEndpoint
         ? await deps.dashboardEndpoint('/__cli/current')
         : await callDashboard({

--- a/src/desktop/shared/types.ts
+++ b/src/desktop/shared/types.ts
@@ -63,7 +63,7 @@ export interface LogTail {
 }
 
 export type DashboardLocateResult =
-  | { ok: true; url: string; source: 'current' | 'rotated' }
+  | { ok: true; url: string; source: 'current' | 'ensured' }
   | {
     ok: false;
     reason: 'not_running' | 'no_secret' | 'wrong_service' | 'unreachable' | 'incompatible' | 'unknown';

--- a/test/dashboard-auth.test.ts
+++ b/test/dashboard-auth.test.ts
@@ -3,13 +3,13 @@ import { createHmac } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
 import {
-  mkdirSync, mkdtempSync, rmSync, writeFileSync, existsSync, statSync,
+  mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync, existsSync, statSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   verifyHmac, generateToken, parseCookie, decideDashboardAuth,
-  loadPersistedToken, loadOrCreatePersistedToken, persistToken,
+  loadPersistedToken, loadOrCreatePersistedToken, persistToken, rotatePersistedToken,
   loadDashboardSecret, loadOrCreateDashboardSecret,
 } from '../src/dashboard/auth.js';
 
@@ -64,7 +64,7 @@ describe('generateToken', () => {
   });
 });
 
-describe('token persistence (survives restart, rotates only on `botmux dashboard`)', () => {
+describe('token persistence (survives restart, rotates only on `botmux dashboard rotate`)', () => {
   let dir: string;
   let tokenPath: string;
 
@@ -97,6 +97,54 @@ describe('token persistence (survives restart, rotates only on `botmux dashboard
     expect(loadPersistedToken(tokenPath)).toBe('existing-token');
   });
 
+  it('concurrent processes creating the first token all return the persisted winner', async () => {
+    const goPath = join(dir, 'go');
+    const authModuleUrl = new URL('../src/dashboard/auth.ts', import.meta.url).href;
+    const childSource = `
+      import { existsSync, writeFileSync } from 'node:fs';
+      const [tokenPath, readyPath, goPath] = process.argv.slice(1);
+      const { loadOrCreatePersistedToken } = await import(${JSON.stringify(authModuleUrl)});
+      writeFileSync(readyPath, 'ready');
+      while (!existsSync(goPath)) await new Promise(resolve => setTimeout(resolve, 5));
+      process.stdout.write(loadOrCreatePersistedToken(tokenPath));
+    `;
+    const children = Array.from({ length: 12 }, (_, index) => {
+      const readyPath = join(dir, `token-ready-${index}`);
+      const child = spawn(process.execPath, [
+        '--import', 'tsx', '--input-type=module', '-e', childSource,
+        tokenPath, readyPath, goPath,
+      ], { stdio: ['ignore', 'pipe', 'pipe'] });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', chunk => { stdout += String(chunk); });
+      child.stderr.on('data', chunk => { stderr += String(chunk); });
+      return { child, readyPath, stdout: () => stdout, stderr: () => stderr };
+    });
+
+    try {
+      const deadline = Date.now() + 10_000;
+      while (!children.every(entry => existsSync(entry.readyPath))) {
+        if (Date.now() >= deadline) throw new Error('token children did not reach barrier');
+        await new Promise(resolve => setTimeout(resolve, 10));
+      }
+      writeFileSync(goPath, 'go');
+      const exits = await Promise.all(children.map(async entry => {
+        const [code, signal] = await once(entry.child, 'close');
+        return { code, signal, stdout: entry.stdout(), stderr: entry.stderr() };
+      }));
+      for (const result of exits) {
+        expect(result, result.stderr).toMatchObject({ code: 0, signal: null });
+      }
+      const tokens = exits.map(result => result.stdout);
+      expect(new Set(tokens).size).toBe(1);
+      expect(tokens[0]).toBe(loadPersistedToken(tokenPath));
+    } finally {
+      for (const { child } of children) {
+        if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+      }
+    }
+  }, 20_000);
+
   it('persisted token survives a simulated restart (same file, new process)', () => {
     const tok = generateToken();
     persistToken(tokenPath, tok);
@@ -104,11 +152,10 @@ describe('token persistence (survives restart, rotates only on `botmux dashboard
     expect(loadPersistedToken(tokenPath)).toBe(tok);
   });
 
-  it('re-running `botmux dashboard` overwrites the old token (old link invalidated)', () => {
+  it('running `botmux dashboard rotate` overwrites the old token (old link invalidated)', () => {
     const first = generateToken();
     persistToken(tokenPath, first);
-    const second = generateToken();
-    persistToken(tokenPath, second);
+    const second = rotatePersistedToken(tokenPath);
     expect(second).not.toBe(first);
     expect(loadPersistedToken(tokenPath)).toBe(second);
   });
@@ -118,22 +165,32 @@ describe('token persistence (survives restart, rotates only on `botmux dashboard
     expect(statSync(tokenPath).mode & 0o777).toBe(0o600);
   });
 
+  it('refuses rotation through a token leaf symlink without modifying its target', () => {
+    if (process.platform === 'win32') return;
+    mkdirSync(join(dir, 'nested'));
+    const victim = join(dir, 'victim');
+    writeFileSync(victim, 'keep-me', { mode: 0o600 });
+    symlinkSync(victim, tokenPath);
+
+    expect(() => rotatePersistedToken(tokenPath)).toThrow();
+    expect(readFileSync(victim, 'utf8')).toBe('keep-me');
+  });
+
   it('loadPersistedToken trims surrounding whitespace/newlines', () => {
     const p = join(dir, 'spaced-token');
-    writeFileSync(p, '  tok-with-space\n');
+    writeFileSync(p, '  tok-with-space\n', { mode: 0o600 });
     expect(loadPersistedToken(p)).toBe('tok-with-space');
   });
 
   it('loadPersistedToken returns null for an empty file', () => {
     const p = join(dir, 'empty-token');
-    writeFileSync(p, '   \n');
+    writeFileSync(p, '   \n', { mode: 0o600 });
     expect(loadPersistedToken(p)).toBeNull();
     expect(existsSync(p)).toBe(true);
   });
 
-  it('loadPersistedToken returns null when path is a directory (unreadable)', () => {
-    // dir itself exists but is not a file — read throws, helper swallows.
-    expect(loadPersistedToken(dir)).toBeNull();
+  it('loadPersistedToken fails closed when the credential path is not a regular file', () => {
+    expect(() => loadPersistedToken(dir)).toThrow();
   });
 });
 
@@ -531,7 +588,7 @@ describe('decideDashboardAuth — ?t=<token> cookie set redirect', () => {
     expect(d.kind).toBe('allow');
   });
 
-  it('empty active token never authenticates (server not yet rotated)', () => {
+  it('empty active token never authenticates (server has not created one yet)', () => {
     const d = decideDashboardAuth({
       method: 'POST',
       pathname: '/api/workflows/run-1/cancel',

--- a/test/dashboard-auth.test.ts
+++ b/test/dashboard-auth.test.ts
@@ -586,6 +586,14 @@ describe('decideDashboardAuth — publicReadOnly mode', () => {
     expect(d.kind).toBe('deny401');
   });
 
+  it('publicReadOnly off → tokenless dashboard summary stays private', () => {
+    const d = decideDashboardAuth({
+      method: 'GET', pathname: '/api/dashboard/v1/summary', hasTokenParam: false,
+      presentedToken: undefined, activeToken: TOK, publicReadOnly: false,
+    });
+    expect(d.kind).toBe('deny401');
+  });
+
   it('stale token GET behaves like tokenless read-only (no 401 wall)', () => {
     const d = decideDashboardAuth({
       method: 'GET', pathname: '/api/schedules', hasTokenParam: false,
@@ -626,7 +634,7 @@ describe('decideDashboardAuth — publicReadOnly mode', () => {
   });
 
   it('allow-listed watch-work reads are public in publicReadOnly', () => {
-    for (const pathname of ['/api/sessions', '/api/schedules', '/api/settings', '/api/groups', '/events']) {
+    for (const pathname of ['/api/dashboard/v1/summary', '/api/sessions', '/api/schedules', '/api/settings', '/api/groups', '/events']) {
       const d = decideDashboardAuth({
         method: 'GET', pathname, hasTokenParam: false,
         presentedToken: undefined, activeToken: TOK, publicReadOnly: true,

--- a/test/dashboard-command.test.ts
+++ b/test/dashboard-command.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   executeDashboardCommand,
+  formatDashboardFallbackFailure,
 } from '../src/cli/dashboard-command.js';
 
 describe('executeDashboardCommand', () => {
@@ -10,14 +11,25 @@ describe('executeDashboardCommand', () => {
     expect(callEndpoint).not.toHaveBeenCalled();
   });
 
-  it('current reads the existing URL and never calls rotate', async () => {
+  it.each([
+    { args: ['--help', 'rotate'] },
+    { args: ['rotate', '--help'] },
+    { args: ['current', 'unexpected', '-h'] },
+    { args: ['unexpected', 'help', 'rotate'] },
+  ])('treats help anywhere in $args as non-mutating help', async ({ args }) => {
+    const callEndpoint = vi.fn();
+    expect(await executeDashboardCommand(args, callEndpoint)).toEqual({ kind: 'help' });
+    expect(callEndpoint).not.toHaveBeenCalled();
+  });
+
+  it.each([{ args: [] }, { args: ['current'] }])('$args gets or creates the current URL and never calls rotate', async ({ args }) => {
     const callEndpoint = vi.fn(async () => ({
       ok: true as const,
       url: 'https://dashboard.test/?t=synthetic-current-token',
     }));
-    const result = await executeDashboardCommand(['current'], callEndpoint);
+    const result = await executeDashboardCommand(args, callEndpoint);
     expect(callEndpoint).toHaveBeenCalledTimes(1);
-    expect(callEndpoint).toHaveBeenCalledWith('/__cli/current');
+    expect(callEndpoint).toHaveBeenCalledWith('/__cli/ensure');
     expect(result).toEqual({
       kind: 'endpoint',
       action: 'current',
@@ -25,15 +37,29 @@ describe('executeDashboardCommand', () => {
     });
   });
 
-  it.each([{ args: [] }, { args: ['rotate'] }])('$args preserves explicit and legacy rotation', async ({ args }) => {
+  it('rotates only when explicitly requested', async () => {
     const callEndpoint = vi.fn(async () => ({
       ok: true as const,
       url: 'https://dashboard.test/?t=synthetic-rotated-token',
     }));
-    const result = await executeDashboardCommand(args, callEndpoint);
+    const result = await executeDashboardCommand(['rotate'], callEndpoint);
     expect(callEndpoint).toHaveBeenCalledTimes(1);
     expect(callEndpoint).toHaveBeenCalledWith('/__cli/rotate');
     expect(result).toMatchObject({ kind: 'endpoint', action: 'rotate' });
+  });
+
+  it.each([
+    { args: ['current', 'unexpected'] },
+    { args: ['rotate', 'unexpected'] },
+    { args: ['current', 'rotate'] },
+    { args: ['rotate', 'current'] },
+  ])('rejects extra argv in $args without touching either endpoint', async ({ args }) => {
+    const callEndpoint = vi.fn();
+    expect(await executeDashboardCommand(args, callEndpoint)).toEqual({
+      kind: 'invalid',
+      argument: args.join(' '),
+    });
+    expect(callEndpoint).not.toHaveBeenCalled();
   });
 
   it('rejects unknown subcommands without touching either endpoint', async () => {
@@ -43,5 +69,38 @@ describe('executeDashboardCommand', () => {
       argument: 'wat',
     });
     expect(callEndpoint).not.toHaveBeenCalled();
+  });
+});
+
+describe('formatDashboardFallbackFailure', () => {
+  it.each([
+    {
+      failure: { ok: false as const, reason: 'auth-failed' as const },
+      expected: 'Dashboard lookup failed: auth-failed',
+    },
+    {
+      failure: { ok: false as const, reason: 'http-error' as const, detail: '500 upstream error' },
+      expected: 'Dashboard lookup failed: 500 upstream error',
+    },
+    {
+      failure: {
+        ok: false as const,
+        reason: 'http-error' as const,
+        detail: 'malformed response (no url)',
+      },
+      expected: 'Dashboard lookup failed: malformed response (no url)',
+    },
+  ])('labels current failures as a lookup failure: $failure', ({ failure, expected }) => {
+    const message = formatDashboardFallbackFailure('current', failure);
+    expect(message).toBe(expected);
+    expect(message).not.toContain('Rotation');
+  });
+
+  it('retains the rotation-specific label for rotate failures', () => {
+    expect(formatDashboardFallbackFailure('rotate', {
+      ok: false,
+      reason: 'http-error',
+      detail: '500 upstream error',
+    })).toBe('Rotation failed: 500 upstream error');
   });
 });

--- a/test/dashboard-command.test.ts
+++ b/test/dashboard-command.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  executeDashboardCommand,
+} from '../src/cli/dashboard-command.js';
+
+describe('executeDashboardCommand', () => {
+  it.each([['--help'], ['-h'], ['help']])('%s is non-mutating', async (...args) => {
+    const callEndpoint = vi.fn();
+    expect(await executeDashboardCommand(args, callEndpoint)).toEqual({ kind: 'help' });
+    expect(callEndpoint).not.toHaveBeenCalled();
+  });
+
+  it('current reads the existing URL and never calls rotate', async () => {
+    const callEndpoint = vi.fn(async () => ({
+      ok: true as const,
+      url: 'https://dashboard.test/?t=synthetic-current-token',
+    }));
+    const result = await executeDashboardCommand(['current'], callEndpoint);
+    expect(callEndpoint).toHaveBeenCalledTimes(1);
+    expect(callEndpoint).toHaveBeenCalledWith('/__cli/current');
+    expect(result).toEqual({
+      kind: 'endpoint',
+      action: 'current',
+      result: { ok: true, url: 'https://dashboard.test/?t=synthetic-current-token' },
+    });
+  });
+
+  it.each([{ args: [] }, { args: ['rotate'] }])('$args preserves explicit and legacy rotation', async ({ args }) => {
+    const callEndpoint = vi.fn(async () => ({
+      ok: true as const,
+      url: 'https://dashboard.test/?t=synthetic-rotated-token',
+    }));
+    const result = await executeDashboardCommand(args, callEndpoint);
+    expect(callEndpoint).toHaveBeenCalledTimes(1);
+    expect(callEndpoint).toHaveBeenCalledWith('/__cli/rotate');
+    expect(result).toMatchObject({ kind: 'endpoint', action: 'rotate' });
+  });
+
+  it('rejects unknown subcommands without touching either endpoint', async () => {
+    const callEndpoint = vi.fn();
+    expect(await executeDashboardCommand(['wat'], callEndpoint)).toEqual({
+      kind: 'invalid',
+      argument: 'wat',
+    });
+    expect(callEndpoint).not.toHaveBeenCalled();
+  });
+});

--- a/test/dashboard-command.test.ts
+++ b/test/dashboard-command.test.ts
@@ -3,6 +3,7 @@ import {
   executeDashboardCommand,
   formatDashboardFallbackFailure,
 } from '../src/cli/dashboard-command.js';
+import type { DashboardEndpoint } from '../src/cli/dashboard-endpoint.js';
 
 describe('executeDashboardCommand', () => {
   it.each([['--help'], ['-h'], ['help']])('%s is non-mutating', async (...args) => {
@@ -23,18 +24,164 @@ describe('executeDashboardCommand', () => {
   });
 
   it.each([{ args: [] }, { args: ['current'] }])('$args gets or creates the current URL and never calls rotate', async ({ args }) => {
+    const callEndpoint = vi.fn(async (path: DashboardEndpoint) => path === '/__cli/current'
+      ? { ok: false as const, reason: 'no-active-token' as const }
+      : { ok: true as const, url: 'https://dashboard.test/?t=synthetic-created-token' });
+    const result = await executeDashboardCommand(args, callEndpoint);
+    expect(callEndpoint.mock.calls.map(([path]) => path)).toEqual([
+      '/__cli/current',
+      '/__cli/ensure',
+    ]);
+    expect(result).toEqual({
+      kind: 'endpoint',
+      action: 'current',
+      result: { ok: true, url: 'https://dashboard.test/?t=synthetic-created-token' },
+    });
+  });
+
+  it('returns an existing current URL without touching a token-writing endpoint', async () => {
     const callEndpoint = vi.fn(async () => ({
       ok: true as const,
       url: 'https://dashboard.test/?t=synthetic-current-token',
     }));
-    const result = await executeDashboardCommand(args, callEndpoint);
-    expect(callEndpoint).toHaveBeenCalledTimes(1);
-    expect(callEndpoint).toHaveBeenCalledWith('/__cli/ensure');
-    expect(result).toEqual({
+
+    const result = await executeDashboardCommand(['current'], callEndpoint);
+
+    expect(callEndpoint).toHaveBeenCalledOnce();
+    expect(callEndpoint).toHaveBeenCalledWith('/__cli/current');
+    expect(result).toMatchObject({
       kind: 'endpoint',
       action: 'current',
       result: { ok: true, url: 'https://dashboard.test/?t=synthetic-current-token' },
     });
+  });
+
+  it.each([
+    { ok: false as const, reason: 'unreachable' as const },
+    { ok: false as const, reason: 'auth-failed' as const },
+    { ok: false as const, reason: 'wrong-service' as const },
+  ])('does not touch a token-writing endpoint when current fails with $reason', async (currentFailure) => {
+    const callEndpoint = vi.fn(async () => currentFailure);
+
+    const result = await executeDashboardCommand(['current'], callEndpoint);
+
+    expect(callEndpoint).toHaveBeenCalledOnce();
+    expect(callEndpoint).toHaveBeenCalledWith('/__cli/current');
+    expect(result).toEqual({ kind: 'endpoint', action: 'current', result: currentFailure });
+  });
+
+  it('falls back to legacy rotate only after current confirms a dashboard with no token and ensure is missing', async () => {
+    const callEndpoint = vi.fn(async (path: DashboardEndpoint) => {
+      if (path === '/__cli/current') {
+        return { ok: false as const, reason: 'no-active-token' as const };
+      }
+      if (path === '/__cli/ensure') {
+        return {
+          ok: false as const,
+          reason: 'wrong-service' as const,
+          detail: '404 {"error":"not_found","path":"/__cli/ensure"}',
+        };
+      }
+      if (path === '/__cli/rotate') {
+        return { ok: true as const, url: 'https://dashboard.test/?t=legacy-token' };
+      }
+      throw new Error(`unexpected endpoint: ${path}`);
+    });
+
+    const result = await executeDashboardCommand(['current'], callEndpoint);
+
+    expect(callEndpoint.mock.calls.map(([path]) => path)).toEqual([
+      '/__cli/current',
+      '/__cli/ensure',
+      '/__cli/current',
+      '/__cli/rotate',
+    ]);
+    expect(result).toEqual({
+      kind: 'endpoint',
+      action: 'current',
+      result: { ok: true, url: 'https://dashboard.test/?t=legacy-token' },
+    });
+  });
+
+  it('recognizes the legacy token-gate response for an unsupported ensure route', async () => {
+    const callEndpoint = vi.fn(async (path: DashboardEndpoint) => {
+      if (path === '/__cli/current') {
+        return { ok: false as const, reason: 'no-active-token' as const };
+      }
+      if (path === '/__cli/ensure') {
+        return {
+          ok: false as const,
+          reason: 'http-error' as const,
+          detail: '401 <h1>Token expired</h1><p>Run <code>botmux dashboard</code> to get a fresh URL.</p>',
+        };
+      }
+      if (path === '/__cli/rotate') {
+        return { ok: true as const, url: 'https://dashboard.test/?t=legacy-token' };
+      }
+      throw new Error(`unexpected endpoint: ${path}`);
+    });
+
+    const result = await executeDashboardCommand([], callEndpoint);
+
+    expect(callEndpoint.mock.calls.map(([path]) => path)).toEqual([
+      '/__cli/current',
+      '/__cli/ensure',
+      '/__cli/current',
+      '/__cli/rotate',
+    ]);
+    expect(result).toMatchObject({
+      kind: 'endpoint',
+      action: 'current',
+      result: { ok: true, url: 'https://dashboard.test/?t=legacy-token' },
+    });
+  });
+
+  it('rechecks current before legacy rotation so a concurrently-created token survives', async () => {
+    let currentCalls = 0;
+    const callEndpoint = vi.fn(async (path: DashboardEndpoint) => {
+      if (path === '/__cli/current') {
+        currentCalls += 1;
+        return currentCalls === 1
+          ? { ok: false as const, reason: 'no-active-token' as const }
+          : { ok: true as const, url: 'https://dashboard.test/?t=concurrent-token' };
+      }
+      if (path === '/__cli/ensure') {
+        return { ok: false as const, reason: 'wrong-service' as const };
+      }
+      throw new Error(`unexpected endpoint: ${path}`);
+    });
+
+    const result = await executeDashboardCommand(['current'], callEndpoint);
+
+    expect(callEndpoint.mock.calls.map(([path]) => path)).toEqual([
+      '/__cli/current',
+      '/__cli/ensure',
+      '/__cli/current',
+    ]);
+    expect(result).toMatchObject({
+      kind: 'endpoint',
+      action: 'current',
+      result: { ok: true, url: 'https://dashboard.test/?t=concurrent-token' },
+    });
+  });
+
+  it('does not rotate when the new ensure route fails closed', async () => {
+    const ensureFailure = {
+      ok: false as const,
+      reason: 'http-error' as const,
+      detail: '500 {"error":"token_persist_failed"}',
+    };
+    const callEndpoint = vi.fn(async (path: DashboardEndpoint) => path === '/__cli/current'
+      ? { ok: false as const, reason: 'no-active-token' as const }
+      : ensureFailure);
+
+    const result = await executeDashboardCommand(['current'], callEndpoint);
+
+    expect(callEndpoint.mock.calls.map(([path]) => path)).toEqual([
+      '/__cli/current',
+      '/__cli/ensure',
+    ]);
+    expect(result).toEqual({ kind: 'endpoint', action: 'current', result: ensureFailure });
   });
 
   it('rotates only when explicitly requested', async () => {

--- a/test/dashboard-endpoint.test.ts
+++ b/test/dashboard-endpoint.test.ts
@@ -51,6 +51,10 @@ function makeFetch(ports: Record<number, PortBehaviour>): typeof fetch {
     if (path === '/__cli/rotate') {
       return new Response(JSON.stringify({ url: `http://host:${port}/?t=fresh` }), { status: 200 });
     }
+    if (path === '/__cli/ensure') {
+      const token = b.hasToken ? 'current' : 'created';
+      return new Response(JSON.stringify({ url: `http://host:${port}/?t=${token}` }), { status: 200 });
+    }
     // /__cli/current
     if (!b.hasToken) return new Response(JSON.stringify({ error: 'no_active_token' }), { status: 404 });
     return new Response(JSON.stringify({ url: `http://host:${port}/?t=current` }), { status: 200 });
@@ -125,6 +129,18 @@ describe('callDashboard', () => {
       fetchImpl: makeFetch({ 7891: { kind: 'dashboard', hasToken: false } }),
     });
     expect(r).toEqual({ ok: true, url: 'http://host:7891/?t=fresh' });
+  });
+
+  it.each([
+    { hasToken: false, token: 'created' },
+    { hasToken: true, token: 'current' },
+  ])('ensure gets a usable URL without replacing an existing token: $hasToken', async ({ hasToken, token }) => {
+    setPort(7891);
+    const r = await callDashboard({
+      configDir: dir, defaultPort: 7891, path: '/__cli/ensure',
+      fetchImpl: makeFetch({ 7891: { kind: 'dashboard', hasToken } }),
+    });
+    expect(r).toEqual({ ok: true, url: `http://host:7891/?t=${token}` });
   });
 
   it('surfaces the dashboard-provided localUrl fallback (platform link case)', async () => {
@@ -259,12 +275,16 @@ describe('discovery credential binding (anti-forward)', () => {
     // → escalate to the token-minting route: rejected (path + port differ).
     expect(verifyHmac(SECRET, captured, LOOPBACK,
       cliAuthBind('POST', '/__cli/rotate', REAL_PORT)).ok).toBe(false);
+    expect(verifyHmac(SECRET, captured, LOOPBACK,
+      cliAuthBind('POST', '/__cli/ensure', REAL_PORT)).ok).toBe(false);
   });
 
-  it('a current-route credential cannot be replayed onto the rotate route (same port)', () => {
+  it('a current-route credential cannot be replayed onto a token-writing route (same port)', () => {
     const cur = signCliAuth(SECRET, cliAuthBind('POST', '/__cli/current', REAL_PORT));
     expect(verifyHmac(SECRET, cur, LOOPBACK,
       cliAuthBind('POST', '/__cli/rotate', REAL_PORT)).ok).toBe(false);
+    expect(verifyHmac(SECRET, cur, LOOPBACK,
+      cliAuthBind('POST', '/__cli/ensure', REAL_PORT)).ok).toBe(false);
   });
 
   it('a correctly-addressed request still verifies (positive control)', () => {

--- a/test/dashboard-summary-endpoint.test.ts
+++ b/test/dashboard-summary-endpoint.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createDashboardSummaryEndpoint } from '../src/dashboard/dashboard-summary-endpoint.js';
+import type { DashboardSummary } from '../src/dashboard/dashboard-summary.js';
+
+const SUMMARY: DashboardSummary = {
+  schemaVersion: 1,
+  generatedAt: '2026-08-09T00:00:00.000Z',
+  service: { status: 'healthy' },
+  bots: { online: 1 },
+  sessions: { active: 0, attention: 0 },
+  schedules: { enabled: 0, nextRunAt: null },
+  dashboard: { href: '/' },
+};
+
+describe('dashboard summary endpoint', () => {
+  it('rejects the sixth anonymous request before loading another fleet snapshot', async () => {
+    const load = vi.fn(async () => SUMMARY);
+    const endpoint = createDashboardSummaryEndpoint({ load, now: () => 0 });
+
+    for (let request = 0; request < 5; request += 1) {
+      await expect(endpoint.get({ authenticated: false })).resolves.toEqual({
+        status: 200,
+        headers: { 'cache-control': 'no-store' },
+        body: SUMMARY,
+      });
+    }
+
+    await expect(endpoint.get({ authenticated: false })).resolves.toEqual({
+      status: 429,
+      headers: {
+        'cache-control': 'no-store',
+        'retry-after': '10',
+      },
+      body: { error: 'rate_limited', retryAfterSeconds: 10 },
+    });
+    expect(load).toHaveBeenCalledTimes(5);
+  });
+
+  it('admits a new anonymous request when the oldest attempt leaves the rolling window', async () => {
+    let now = 0;
+    const load = vi.fn(async () => SUMMARY);
+    const endpoint = createDashboardSummaryEndpoint({ load, now: () => now });
+    for (let request = 0; request < 5; request += 1) {
+      await endpoint.get({ authenticated: false });
+    }
+
+    now = 9_999;
+    await expect(endpoint.get({ authenticated: false })).resolves.toMatchObject({
+      status: 429,
+      headers: { 'retry-after': '1' },
+      body: { retryAfterSeconds: 1 },
+    });
+
+    now = 10_000;
+    await expect(endpoint.get({ authenticated: false })).resolves.toMatchObject({
+      status: 200,
+      body: SUMMARY,
+    });
+    expect(load).toHaveBeenCalledTimes(6);
+  });
+
+  it('lets authenticated callers bypass an exhausted anonymous budget', async () => {
+    const load = vi.fn(async () => SUMMARY);
+    const endpoint = createDashboardSummaryEndpoint({ load, now: () => 0 });
+    for (let request = 0; request < 5; request += 1) {
+      await endpoint.get({ authenticated: false });
+    }
+
+    await expect(endpoint.get({ authenticated: true })).resolves.toMatchObject({
+      status: 200,
+      body: SUMMARY,
+    });
+    await expect(endpoint.get({ authenticated: false })).resolves.toMatchObject({ status: 429 });
+    expect(load).toHaveBeenCalledTimes(6);
+  });
+
+  it('returns the unavailable contract and reports a fleet snapshot failure', async () => {
+    const failure = new Error('daemon_snapshot_http_error');
+    const onError = vi.fn();
+    const endpoint = createDashboardSummaryEndpoint({
+      load: vi.fn(async () => { throw failure; }),
+      now: () => Date.parse('2026-08-09T01:02:03.000Z'),
+      onError,
+    });
+
+    await expect(endpoint.get({ authenticated: false })).resolves.toEqual({
+      status: 503,
+      headers: { 'cache-control': 'no-store' },
+      body: {
+        schemaVersion: 1,
+        generatedAt: '2026-08-09T01:02:03.000Z',
+        service: { status: 'degraded' },
+      },
+    });
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError).toHaveBeenCalledWith(failure);
+  });
+});

--- a/test/dashboard-summary.test.ts
+++ b/test/dashboard-summary.test.ts
@@ -9,8 +9,8 @@ describe('buildDashboardSummary', () => {
   it('returns only the redacted aggregate contract', () => {
     const summary = buildDashboardSummary({
       generatedAt: new Date('2026-08-08T09:30:00.000Z'),
-      configuredBotCount: 3,
-      onlineBotCount: 3,
+      configuredBotAppIds: ['cli_a', 'cli_b', 'cli_c'],
+      onlineBotAppIds: ['cli_a', 'cli_b', 'cli_c'],
       sessions: [
         {
           sessionId: 'secret-session',
@@ -49,8 +49,8 @@ describe('buildDashboardSummary', () => {
   it('marks a partial bot fleet degraded and uses null when no enabled task has a valid next run', () => {
     expect(buildDashboardSummary({
       generatedAt: new Date('2026-08-08T09:30:00.000Z'),
-      configuredBotCount: 3,
-      onlineBotCount: 2,
+      configuredBotAppIds: ['cli_a', 'cli_b', 'cli_c'],
+      onlineBotAppIds: ['cli_a', 'cli_b'],
       sessions: [],
       schedules: [{ enabled: false, nextRunAt: '2026-08-09T00:00:00.000Z' }],
     })).toEqual({
@@ -64,11 +64,38 @@ describe('buildDashboardSummary', () => {
     });
   });
 
+  it('marks an equal-sized replacement fleet degraded without exposing bot identities', () => {
+    const summary = buildDashboardSummary({
+      generatedAt: new Date('2026-08-08T09:30:00.000Z'),
+      configuredBotAppIds: ['cli_a', 'cli_c'],
+      onlineBotAppIds: ['cli_a', 'cli_b'],
+      sessions: [],
+      schedules: [],
+    });
+
+    expect(summary.service).toEqual({ status: 'degraded' });
+    expect(summary.bots).toEqual({ online: 2 });
+    expect(JSON.stringify(summary)).not.toMatch(/cli_[abc]/);
+  });
+
+  it('stays healthy when every configured bot is online alongside an extra descriptor', () => {
+    const summary = buildDashboardSummary({
+      generatedAt: new Date('2026-08-08T09:30:00.000Z'),
+      configuredBotAppIds: ['cli_a'],
+      onlineBotAppIds: ['cli_a', 'cli_orphan'],
+      sessions: [],
+      schedules: [],
+    });
+
+    expect(summary.service).toEqual({ status: 'healthy' });
+    expect(summary.bots).toEqual({ online: 2 });
+  });
+
   it('counts a stalled active session as needing attention', () => {
     expect(buildDashboardSummary({
       generatedAt: new Date('2026-08-08T09:30:00.000Z'),
-      configuredBotCount: 1,
-      onlineBotCount: 1,
+      configuredBotAppIds: ['cli_a'],
+      onlineBotAppIds: ['cli_a'],
       sessions: [{ status: 'stalled' }],
       schedules: [],
     }).sessions).toEqual({ active: 1, attention: 1 });

--- a/test/dashboard-summary.test.ts
+++ b/test/dashboard-summary.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDashboardSummary,
+  unavailableDashboardSummary,
+} from '../src/dashboard/dashboard-summary.js';
+
+describe('buildDashboardSummary', () => {
+  it('returns only the redacted aggregate contract', () => {
+    const summary = buildDashboardSummary({
+      generatedAt: new Date('2026-08-08T09:30:00.000Z'),
+      configuredBotCount: 3,
+      onlineBotCount: 3,
+      sessions: [
+        {
+          sessionId: 'secret-session',
+          status: 'working',
+          title: 'private prompt',
+          workingDir: '/private/repo',
+          chatId: 'oc_private',
+          larkAppId: 'cli_private',
+        },
+        { status: 'idle', agentAttention: { reason: 'private reason' } },
+        { status: 'limited' },
+        { status: 'closed', agentAttention: { reason: 'closed is not attention' } },
+      ],
+      schedules: [
+        { enabled: true, nextRunAt: '2026-08-09T08:00:00+08:00', prompt: 'private schedule prompt' },
+        { enabled: true, nextRunAt: '2026-08-08T19:00:00.000Z' },
+        { enabled: false, nextRunAt: '2026-08-08T18:00:00.000Z' },
+        { enabled: true, nextRunAt: 'not-a-date' },
+      ],
+    });
+
+    expect(summary).toEqual({
+      schemaVersion: 1,
+      generatedAt: '2026-08-08T09:30:00.000Z',
+      service: { status: 'healthy' },
+      bots: { online: 3 },
+      sessions: { active: 3, attention: 2 },
+      schedules: { enabled: 3, nextRunAt: '2026-08-08T19:00:00.000Z' },
+      dashboard: { href: '/' },
+    });
+    expect(JSON.stringify(summary)).not.toMatch(
+      /secret-session|private prompt|private\/repo|oc_private|cli_private|private reason|schedule prompt/,
+    );
+  });
+
+  it('marks a partial bot fleet degraded and uses null when no enabled task has a valid next run', () => {
+    expect(buildDashboardSummary({
+      generatedAt: new Date('2026-08-08T09:30:00.000Z'),
+      configuredBotCount: 3,
+      onlineBotCount: 2,
+      sessions: [],
+      schedules: [{ enabled: false, nextRunAt: '2026-08-09T00:00:00.000Z' }],
+    })).toEqual({
+      schemaVersion: 1,
+      generatedAt: '2026-08-08T09:30:00.000Z',
+      service: { status: 'degraded' },
+      bots: { online: 2 },
+      sessions: { active: 0, attention: 0 },
+      schedules: { enabled: 0, nextRunAt: null },
+      dashboard: { href: '/' },
+    });
+  });
+
+  it('does not invent aggregate zeroes when the live snapshot is unavailable', () => {
+    expect(unavailableDashboardSummary(new Date('2026-08-08T09:30:00.000Z'))).toEqual({
+      schemaVersion: 1,
+      generatedAt: '2026-08-08T09:30:00.000Z',
+      service: { status: 'degraded' },
+    });
+  });
+});

--- a/test/dashboard-summary.test.ts
+++ b/test/dashboard-summary.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildDashboardSummary,
+  parseDashboardSummaryRows,
   unavailableDashboardSummary,
 } from '../src/dashboard/dashboard-summary.js';
 
@@ -63,11 +64,62 @@ describe('buildDashboardSummary', () => {
     });
   });
 
+  it('counts a stalled active session as needing attention', () => {
+    expect(buildDashboardSummary({
+      generatedAt: new Date('2026-08-08T09:30:00.000Z'),
+      configuredBotCount: 1,
+      onlineBotCount: 1,
+      sessions: [{ status: 'stalled' }],
+      schedules: [],
+    }).sessions).toEqual({ active: 1, attention: 1 });
+  });
+
   it('does not invent aggregate zeroes when the live snapshot is unavailable', () => {
     expect(unavailableDashboardSummary(new Date('2026-08-08T09:30:00.000Z'))).toEqual({
       schemaVersion: 1,
       generatedAt: '2026-08-08T09:30:00.000Z',
       service: { status: 'degraded' },
     });
+  });
+});
+
+describe('parseDashboardSummaryRows', () => {
+  it('rejects a session row without a status instead of counting it as active', () => {
+    expect(() => parseDashboardSummaryRows({
+      sessions: [{}],
+      schedules: [],
+    })).toThrow(/session status/i);
+  });
+
+  it('rejects a schedule row without an enabled flag instead of silently dropping it', () => {
+    expect(() => parseDashboardSummaryRows({
+      sessions: [],
+      schedules: [{}],
+    })).toThrow(/schedule enabled/i);
+  });
+
+  it.each([
+    ['pendingRepo', { status: 'idle', pendingRepo: 'false' }],
+    ['tuiPromptActive', { status: 'idle', tuiPromptActive: 1 }],
+    ['agentAttention', { status: 'idle', agentAttention: 'blocked' }],
+  ])('rejects a malformed session %s signal', (field, row) => {
+    expect(() => parseDashboardSummaryRows({
+      sessions: [row],
+      schedules: [],
+    })).toThrow(new RegExp(`session ${field}`, 'i'));
+  });
+
+  it('rejects an unknown session status instead of treating it as active', () => {
+    expect(() => parseDashboardSummaryRows({
+      sessions: [{ status: 'unknown-from-malformed-snapshot' }],
+      schedules: [],
+    })).toThrow(/session status/i);
+  });
+
+  it('rejects a malformed next run timestamp instead of publishing a misleading null', () => {
+    expect(() => parseDashboardSummaryRows({
+      sessions: [],
+      schedules: [{ enabled: true, nextRunAt: 'not-a-date' }],
+    })).toThrow(/schedule nextRunAt/i);
   });
 });

--- a/test/desktop/desktop-ipc-runtime-monitor.test.ts
+++ b/test/desktop/desktop-ipc-runtime-monitor.test.ts
@@ -238,7 +238,7 @@ describe('desktop dashboard locate IPC', () => {
     await expect(handlers.get('desktop:get-dashboard-url')?.({} as any)).resolves.toBe('http://10.92.89.226:7891/?t=local-token');
   });
 
-  it('rotates a dashboard URL only when no active dashboard token exists', async () => {
+  it('creates a dashboard URL only when no active dashboard token exists', async () => {
     const { registerDesktopIpc } = await import('../../src/desktop/main/ipc.js');
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,
@@ -271,7 +271,7 @@ describe('desktop dashboard locate IPC', () => {
     await expect(handlers.get('desktop:locate-dashboard')?.({} as any)).resolves.toEqual({
       ok: true,
       url: 'http://127.0.0.1:7891/?t=x',
-      source: 'rotated',
+      source: 'ensured',
     });
     expect(runtime.dashboard).toHaveBeenCalledTimes(1);
   });

--- a/test/terminal-write-auth.test.ts
+++ b/test/terminal-write-auth.test.ts
@@ -184,6 +184,22 @@ describe('resolveTerminalWriteForRequest', () => {
       .toEqual({ hasWrite: false, platformReadonly: false });
   });
 
+  it('fails closed when the live dashboard token cannot be read during rotation', () => {
+    const unreadable = () => { throw new Error('token changed during read'); };
+    expect(() => resolveTerminalWriteForRequest(
+      { 'x-botmux-role': 'owner', ...cookie(TOK) },
+      false,
+      bound,
+      unreadable,
+    )).not.toThrow();
+    expect(resolveTerminalWriteForRequest(
+      { 'x-botmux-role': 'owner', ...cookie(TOK) },
+      false,
+      bound,
+      unreadable,
+    )).toEqual({ hasWrite: false, platformReadonly: false });
+  });
+
   it('ignores the role when unbound even with a matching cookie', () => {
     expect(resolveTerminalWriteForRequest({ 'x-botmux-role': 'owner', ...cookie(TOK) }, false, unbound, token))
       .toEqual({ hasWrite: false, platformReadonly: false });
@@ -246,6 +262,16 @@ describe('resolveTerminalAccessForRequest', () => {
   it('lets an authenticated local dashboard cookie view without platform binding', () => {
     expect(resolveTerminalAccessForRequest(cookie(TOK), false, false, unbound, token))
       .toEqual({ hasRead: true, hasWrite: false, platformReadonly: false });
+  });
+
+  it('denies the request instead of throwing when token rotation races the read', () => {
+    const unreadable = () => { throw new Error('token changed during read'); };
+    expect(() => resolveTerminalAccessForRequest(
+      cookie(TOK), false, false, unbound, unreadable,
+    )).not.toThrow();
+    expect(resolveTerminalAccessForRequest(
+      cookie(TOK), false, false, unbound, unreadable,
+    )).toEqual({ hasRead: false, hasWrite: false, platformReadonly: false });
   });
 
   it('keeps authenticated platform guest read-only and owner writable', () => {


### PR DESCRIPTION
## 改动内容

- 新增 `GET /api/dashboard/v1/summary`，以版本化、正向白名单的结构返回 fleet 健康状态、在线 bot 数、活跃/待关注会话数和排程摘要；任一 live daemon 快照失败或格式异常时返回 503，不用伪造的零值掩盖缺失状态。
- 为匿名 summary 请求增加 Dashboard 进程全局的滚动限流（10 秒 5 次），第 6 次在 fan-out 前返回 429 和 `Retry-After`；携带当前 Dashboard 登录态的请求不受匿名配额影响。
- 修正 `stalled` 会话未计入 attention、daemon snapshot 字段未做最小运行时校验等摘要口径问题，并补齐中英文 API 契约、鉴权边界和 fleet/core-only 模式说明。
- 调整 Dashboard CLI：裸 `botmux dashboard` 与 `dashboard current` 获取或首次创建当前 token，已有 token 时不轮换；只有 `dashboard rotate` 显式替换 token。`--help` 出现在任意位置、未知子命令和多余参数都不会触碰凭证端点。
- 将 token 文件设为多 Dashboard 进程共享的唯一权威源：首次创建和轮换走同一跨进程锁，凭证以 0600 durable 落盘且拒绝叶子 symlink；持久化失败返回 500，不发布未落盘的新 token。Dashboard、worker、tunnel、daemon report 与 Desktop 都按需读取当前值，读取竞态按未认证 fail-closed。

## 改动目的

普通 fleet 模式缺少一个适合外部健康页、监控和编排器消费的稳定摘要接口。直接消费现有 sessions/events 会暴露过多会话细节，也会让匿名高频轮询放大为对每个在线 daemon 的实时 IPC。本次新增的强脱敏 summary 契约用于更安全地把 Botmux 的普通 Dashboard facade 作为常驻服务观测入口，并用前置限流约束 fan-out 成本；它不改变 `botmux serve --api-only` 的 core-only 接口。

原有裸 `botmux dashboard` 会无条件轮换 token，导致 `dashboard rotate --help` 等只读意图也可能让旧链接失效。随着 token 已持久化并跨重启复用，默认“获取可用链接”、显式 `rotate` 才撤销旧链接更符合用户预期；首次尚无 token 时仍会安全创建一个，避免为了取链接再多走一步。持久化和跨进程加固保证返回给用户的链接就是所有本机 Dashboard 进程共同认可的 durable 凭证。

## 影响面

- 涉及 Dashboard HTTP 聚合、CLI 本机 HMAC 端点、Dashboard token 文件、Desktop 定位结果及对应文档。
- summary 只读取现有 daemon sessions/schedules IPC，不修改任何会话、排程或 IM 状态。
- 不修改 CLI adapter、PTY/Tmux/Herdr/Zellij/Zmx 后端或会话类型语义；共享 Node 路径同时适用于 macOS/Linux，凭证文件复用仓库既有 secure-host 与 file-lock 实现。
- 无 Dashboard 页面布局或视觉变更，因此无新增截图。

## 验证

- `pnpm build`：通过（TypeScript、Dashboard bundle、domain/dist audit）。
- `pnpm exec vitest run test/dashboard-auth.test.ts test/dashboard-command.test.ts test/dashboard-endpoint.test.ts test/dashboard-summary.test.ts test/dashboard-summary-endpoint.test.ts test/terminal-write-auth.test.ts test/desktop/desktop-ipc-runtime-monitor.test.ts`：7 files，162/162 通过。
- `pnpm test`：13,994 passed，37 skipped；并行全量运行中 2 个既有重负载用例超时，随后独立重跑：
  - `pnpm exec vitest run test/codex-app-runner.integration.test.ts`：42/42 通过。
  - `pnpm exec vitest run test/cost-calculator-cache.test.ts`：49/49 通过。
- `BOTMUX_DOCS_BASE=/botmux/ BOTMUX_DOCS_ASSET_PREFIX=/botmux/ ./node_modules/.bin/rspress build`（`docs-site/`）：通过，包含页面渲染与死链检查。
- 12 进程并发首次创建 token 回归测试通过；额外隔离的 ensure/rotate 同闸竞争验证收敛到最终已提交凭证。
