### PR TITLE
fix(repo-scan): 仓库扫描加目录数+时长预算护栏（纵深防御，缓解扫 ~ 拖垮 daemon）

### DIFF
--- a/src/core/command-handler.ts
+++ b/src/core/command-handler.ts
@@ -2049,10 +2049,24 @@ export async function handleCommand(
           await sessionReply(rootId, t('cmd.repo.scan_dir_not_exist', { dirs: scanDirs.join(', ') }, loc));
           break;
         }
-        const projects = scanMultipleProjects(validDirs, 3, repoPickerScanOptions());
+        let scanBudgetHit = false;
+        const projects = scanMultipleProjects(validDirs, 3, {
+          ...repoPickerScanOptions(),
+          onBudgetExceeded: () => { scanBudgetHit = true; },
+        });
         if (projects.length === 0) {
-          await sessionReply(rootId, t('cmd.repo.no_git_repos', { dirs: validDirs.join(', ') }, loc));
+          // Distinguish "genuinely no repos here" from "we bailed at the scan
+          // budget before we could find them" — the latter is actionable
+          // (narrow the root / give an explicit path) and must not read as an
+          // empty projects dir.
+          const key = scanBudgetHit ? 'cmd.repo.scan_budget_no_repos' : 'cmd.repo.no_git_repos';
+          await sessionReply(rootId, t(key, { dirs: validDirs.join(', ') }, loc));
           break;
+        }
+        if (scanBudgetHit) {
+          // We have a partial list; show it but warn it may be incomplete so a
+          // missing target repo doesn't look like it simply isn't there.
+          await sessionReply(rootId, t('cmd.repo.scan_budget_partial', undefined, loc));
         }
         if (ds) lastRepoScan.set(ds.chatId, projects);
         const currentCwd = getSessionWorkingDir(ds);

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -320,6 +320,8 @@ export const messages: Record<string, string> = {
   'cmd.repo.scan_dir_not_exist': 'Scan dirs do not exist: {dirs}\nCheck that workingDir in bots.json points to a valid directory.',
   'cmd.repo.working_dir_not_exist': '❌ Configured working directory does not exist or is not a directory: {dirs}\nCheck workingDir / workingDirs in ~/.botmux/bots.json, or run `botmux setup` and choose an existing directory.',
   'cmd.repo.no_git_repos': 'No git repositories found under {dirs}.',
+  'cmd.repo.scan_budget_no_repos': '⚠️ Scanning {dirs} hit too many directories (or was too slow) and stopped at the budget before finding any git repo.\nThis usually means the scan root is too large (e.g. pointed at your home dir `~`). Use `/repo <path-to-repo>` to open one directly, or narrow workingDir / workingDirs in ~/.botmux/bots.json.\nNote: if a directory hangs at the OS level (not just "too many dirs"), this guard cannot interrupt it — narrowing the root is still required.',
+  'cmd.repo.scan_budget_partial': '⚠️ Too many directories (or too slow); the scan stopped at the budget, so the list below may be incomplete.\nIf your repo is missing, use `/repo <path-to-repo>`, or narrow workingDir / workingDirs in ~/.botmux/bots.json.',
   'cmd.repo.worktree_usage': 'Usage: `/repo wt <N|name|path> [new-branch]` — create a worktree off the repo\'s remote default branch and open it; without a branch, Botmux auto-names it from the topic title / first prompt when possible.',
   'cmd.repo.worktree_creating': '🌿 Creating a worktree for `{repo}` (includes a git fetch, may take a few seconds)…',
   'card.repo.riff_worktree_push_failed': '⚠️ Failed to push branch `{branch}` to origin: {error}\nThe riff sandbox will use the default branch (push manually and retry).',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -321,6 +321,8 @@ export const messages: Record<string, string> = {
   'cmd.repo.scan_dir_not_exist': '扫描目录不存在：{dirs}\n请检查 bots.json 中的 workingDir 是否指向有效目录。',
   'cmd.repo.working_dir_not_exist': '❌ 配置的工作目录不存在或不是目录：{dirs}\n请检查 ~/.botmux/bots.json 中的 workingDir / workingDirs，或重新运行 `botmux setup` 修改为已存在的目录。',
   'cmd.repo.no_git_repos': '在 {dirs} 下未找到 git 仓库。',
+  'cmd.repo.scan_budget_no_repos': '⚠️ 扫描 {dirs} 时目录过多或读取过慢，已在到达上限后中止，未发现 git 仓库。\n这通常是根目录设得太大（例如指向了 home 目录 `~`）。请用 `/repo <具体仓库路径>` 直接指定，或收窄 `~/.botmux/bots.json` 里的 workingDir / workingDirs。\n注意：若某个目录在系统层面读取卡死（非目录过多），本护栏无法中断它，仍需收窄根目录。',
+  'cmd.repo.scan_budget_partial': '⚠️ 目录过多或读取过慢，扫描在到达上限后中止，下方仓库列表可能不完整。\n如未看到目标仓库，请用 `/repo <具体仓库路径>` 指定，或收窄 `~/.botmux/bots.json` 里的 workingDir / workingDirs。',
   'cmd.repo.worktree_usage': '用法：`/repo wt <编号|项目名|路径> [新分支名]` — 基于该仓库的远端默认分支新建 worktree 并打开；未指定分支时会优先根据话题标题/首条需求自动命名。',
   'cmd.repo.worktree_creating': '🌿 正在为 `{repo}` 创建 worktree（含 git fetch，可能需要几秒）…',
   'card.repo.riff_worktree_push_failed': '⚠️ 分支 `{branch}` 推送远端失败：{error}\nRiff 沙箱将使用默认分支（可手动 push 后重试）',

--- a/src/services/project-scanner.ts
+++ b/src/services/project-scanner.ts
@@ -34,7 +34,38 @@ export interface ProjectInfo {
 
 export interface ProjectScanOptions {
   includeWorktrees?: boolean;
+  /** Hard cap on directories visited during a single scan. Guards against a
+   *  misconfigured scan root (e.g. `~`) turning the synchronous walk into a
+   *  minutes-long event-loop stall. Defaults to DEFAULT_MAX_SCAN_DIRS. */
+  maxScanDirs?: number;
+  /** Wall-clock budget (ms) for a single scan, checked between filesystem
+   *  calls. A dir-count cap alone doesn't bound a "repo storm" root where
+   *  each repo spawns a slow `git` subprocess; this stops the walk once the
+   *  budget is spent. Defaults to DEFAULT_MAX_SCAN_MS. Note: this cannot
+   *  interrupt a single syscall already blocked in the kernel (e.g. a
+   *  readdir that hangs on a protected/stale directory) — only the space
+   *  between calls. Narrowing the scan root remains the real fix. */
+  maxScanMs?: number;
+  /** Invoked once, after the walk, if either budget (dirs or wall-clock) was
+   *  hit — meaning the returned list may be incomplete. Lets a caller surface a
+   *  "scan root too large / narrow it" hint to the user instead of silently
+   *  showing a partial list or a misleading "no repos found". Not called when
+   *  the scan completes within budget. `reason` says which cap tripped. */
+  onBudgetExceeded?: (info: { reason: 'dirs' | 'time'; dirsVisited: number; baseDir: string }) => void;
 }
+
+/** Upper bound on directories a single `scanProjects` walk will visit before
+ *  bailing out. `scanProjects` is fully synchronous (readdirSync + a `git`
+ *  subprocess per repo), so an unbounded walk over a huge root such as the
+ *  home directory blocks the daemon's event loop — no repo card is ever sent
+ *  and the whole bot appears hung. 4000 dirs comfortably covers a normal
+ *  projects root while capping the worst case. */
+export const DEFAULT_MAX_SCAN_DIRS = 4000;
+
+/** Wall-clock budget for one scan. A normal projects root scans in well under
+ *  a second; anything past a few seconds means the root is misconfigured
+ *  (pointed at `~` or similar). Bailing keeps the daemon responsive. */
+export const DEFAULT_MAX_SCAN_MS = 4000;
 
 /**
  * Describe a single directory as a project: the main worktree basename +
@@ -146,9 +177,22 @@ export function scanProjects(baseDir: string, maxDepth: number = 3, options: Pro
   const projects: ProjectInfo[] = [];
   const seenRepos = new Set<string>();   // by git-common-dir
   const seenPaths = new Set<string>();   // by absolute path
+  const maxScanDirs = options.maxScanDirs ?? DEFAULT_MAX_SCAN_DIRS;
+  const maxScanMs = options.maxScanMs ?? DEFAULT_MAX_SCAN_MS;
+  const deadline = Date.now() + maxScanMs;
+  let dirsVisited = 0;
+  let budgetReason: 'dirs' | 'time' | null = null;
+
+  function overBudget(): boolean {
+    if (dirsVisited >= maxScanDirs) { budgetReason ??= 'dirs'; return true; }
+    if (Date.now() >= deadline) { budgetReason ??= 'time'; return true; }
+    return false;
+  }
 
   function walk(dir: string, depth: number): void {
     if (depth > maxDepth) return;
+    if (overBudget()) return;
+    dirsVisited++;
 
     let entries: string[];
     try {
@@ -173,6 +217,7 @@ export function scanProjects(baseDir: string, maxDepth: number = 3, options: Pro
 
     for (const entry of entries) {
       if (entry.startsWith('.') || entry === 'node_modules' || entry === 'vendor' || entry === 'dist') continue;
+      if (overBudget()) return;
       const fullPath = join(dir, entry);
       try {
         if (statSync(fullPath).isDirectory()) {
@@ -187,7 +232,13 @@ export function scanProjects(baseDir: string, maxDepth: number = 3, options: Pro
   walk(baseDir, 0);
   projects.sort(compareProjects);
 
-  logger.info(`Scanned ${baseDir}: found ${projects.length} project(s)`);
+  if (budgetReason) {
+    const limit = budgetReason === 'dirs' ? `${maxScanDirs}-dir` : `${maxScanMs}ms`;
+    logger.warn(`Scanned ${baseDir}: hit ${limit} budget after ${dirsVisited} dirs, found ${projects.length} project(s) so far — results may be incomplete. Configure a narrower workingDirs to avoid scanning a huge root.`);
+    options.onBudgetExceeded?.({ reason: budgetReason, dirsVisited, baseDir });
+  } else {
+    logger.info(`Scanned ${baseDir}: found ${projects.length} project(s)`);
+  }
   return projects;
 }
 

--- a/test/command-handler.test.ts
+++ b/test/command-handler.test.ts
@@ -2623,8 +2623,69 @@ describe('handleCommand', () => {
       expect(scanMultipleProjects).toHaveBeenCalledWith(
         ['/home/testuser'],
         3,
-        { includeWorktrees: false },
+        expect.objectContaining({
+          includeWorktrees: false,
+          onBudgetExceeded: expect.any(Function),
+        }),
       );
+    });
+
+    // ── Scan-budget prompts (behavioural, not just wiring) ──────────────────
+    // These fire the onBudgetExceeded callback the handler passes in and assert
+    // the USER-VISIBLE consequence. A mutation that keeps the callback wired but
+    // empties its body (`() => {}`) leaves scanBudgetHit false, so both prompts
+    // vanish — and both of these tests must go red. (The `expect.any(Function)`
+    // wiring check above cannot catch that; this is the rev1 false-green lesson.)
+    it('budget hit with zero repos → warns to narrow the root and sends NO card', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      // scan bailed at the budget before finding anything: empty list + callback.
+      vi.mocked(scanMultipleProjects).mockImplementation(((_dirs: any, _depth: any, options: any) => {
+        options?.onBudgetExceeded?.({ reason: 'dirs', dirsVisited: 4000, baseDir: '/home/testuser' });
+        return [];
+      }) as any);
+
+      const ds = makeDaemonSession({ worker: null });
+      const deps = makeDeps(ds);
+
+      await handleCommand('/repo', ROOT_ID, makeLarkMessage('/repo'), deps, LARK_APP_ID);
+
+      // t() returns the resolved zh string here, so assert on stable fragments
+      // that are UNIQUE to each i18n key (avoids brittle full-text matching).
+      // scan_budget_no_repos: "…已在到达上限后中止，未发现 git 仓库。"
+      // no_git_repos:         "在 {dirs} 下未找到 git 仓库。"
+      const replies = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls.map(c => c[1] as string);
+      // Must warn with the budget-specific message (mentions 中止 / 收窄根目录)…
+      expect(replies.some(c => typeof c === 'string' && c.includes('到达上限后中止') && c.includes('未发现 git 仓库'))).toBe(true);
+      // …and must NOT have fallen through to the plain "未找到 git 仓库" empty message.
+      expect(replies.some(c => typeof c === 'string' && c.includes('下未找到 git 仓库'))).toBe(false);
+      // …nor sent an interactive repo-selection card (there are no repos to pick).
+      const sentCard = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls
+        .some(c => c[2] === 'interactive');
+      expect(sentCard).toBe(false);
+    });
+
+    it('budget hit with a partial list → sends the "incomplete" notice BEFORE the card', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      // scan found one repo but tripped the budget: partial list + callback.
+      vi.mocked(scanMultipleProjects).mockImplementation(((_dirs: any, _depth: any, options: any) => {
+        options?.onBudgetExceeded?.({ reason: 'time', dirsVisited: 12, baseDir: '/home/testuser' });
+        return [{ name: 'proj', path: '/home/testuser/proj', branch: 'main' }];
+      }) as any);
+
+      const ds = makeDaemonSession({ worker: null });
+      const deps = makeDeps(ds);
+
+      await handleCommand('/repo', ROOT_ID, makeLarkMessage('/repo'), deps, LARK_APP_ID);
+
+      const calls = (deps.sessionReply as ReturnType<typeof vi.fn>).mock.calls;
+      // scan_budget_partial is the only message containing "列表可能不完整".
+      const partialIdx = calls.findIndex(c => typeof c[1] === 'string' && (c[1] as string).includes('列表可能不完整'));
+      const cardIdx = calls.findIndex(c => c[2] === 'interactive');
+      // Both must happen…
+      expect(partialIdx).toBeGreaterThanOrEqual(0);
+      expect(cardIdx).toBeGreaterThanOrEqual(0);
+      // …and the "may be incomplete" notice must precede the card.
+      expect(partialIdx).toBeLessThan(cardIdx);
     });
 
     it('should resolve a first-level project name and switch repo (mid-session)', async () => {

--- a/test/project-scanner.test.ts
+++ b/test/project-scanner.test.ts
@@ -28,7 +28,7 @@ vi.mock('node:child_process', () => ({
 }));
 
 // Import after mock setup
-import { scanProjects, scanMultipleProjects, type ProjectInfo } from '../src/services/project-scanner.js';
+import { scanProjects, scanMultipleProjects, DEFAULT_MAX_SCAN_DIRS, DEFAULT_MAX_SCAN_MS, type ProjectInfo } from '../src/services/project-scanner.js';
 import { execSync } from 'node:child_process';
 
 const mockedExecSync = vi.mocked(execSync);
@@ -837,5 +837,105 @@ describe('scanMultipleProjects', () => {
   it('should handle empty baseDirs array', () => {
     const results = scanMultipleProjects([]);
     expect(results).toEqual([]);
+  });
+});
+
+// ─── maxScanDirs budget guard ──────────────────────────────────────────────
+// A misconfigured scan root (e.g. `~`) must not turn the synchronous walk into
+// a minutes-long event-loop stall. The guard caps directories visited.
+
+describe('scanProjects — maxScanDirs budget', () => {
+  it('does not discover a repo that sits beyond the directory budget', () => {
+    // Single deterministic chain: tempRoot → a → b → c → d → e → repo.
+    // With maxScanDirs:5 the walk visits tempRoot(1) a(2) b(3) c(4) d(5), trips
+    // the budget at d, and never descends into e/ — so the repo is unreachable.
+    // Order-independent: there's only one path, so this doesn't depend on which
+    // sibling readdir returns first. A weaker `toBeLessThanOrEqual(1)` would pass
+    // even if the whole dir guard were deleted; `toEqual([])` catches that.
+    mkRepo('a/b/c/d/e/repo');
+
+    const results = scanProjects(tempRoot, 10, { maxScanDirs: 5 });
+
+    expect(results).toEqual([]);
+  });
+
+  it('discovers that same repo when the budget is large (positive control)', () => {
+    // Same fixture as above, but a huge budget proves the chain IS fully
+    // scannable — so the empty result above is caused by the budget, not by
+    // an unreachable/mis-built fixture.
+    mkRepo('a/b/c/d/e/repo');
+
+    const results = scanProjects(tempRoot, 10, { maxScanDirs: 999999 });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.name).toBe('repo');
+  });
+
+  it('finds repos normally when the tree fits within budget', () => {
+    mkRepo('a/proj-1');
+    mkRepo('b/proj-2');
+
+    const results = scanProjects(tempRoot, 3, { maxScanDirs: DEFAULT_MAX_SCAN_DIRS });
+
+    expect(results.map(r => r.name).sort()).toEqual(['proj-1', 'proj-2']);
+  });
+
+  it('defaults to DEFAULT_MAX_SCAN_DIRS when no budget is given', () => {
+    mkRepo('proj');
+    const results = scanProjects(tempRoot);
+    expect(results.map(r => r.name)).toEqual(['proj']);
+    expect(DEFAULT_MAX_SCAN_DIRS).toBeGreaterThan(0);
+  });
+
+  it('stops walking once the wall-clock budget is spent', () => {
+    // A deep chain of dirs; a 0ms budget trips on the very first overBudget()
+    // check so almost nothing is traversed. Proves the time guard is wired in
+    // independently of the dir-count cap.
+    mkRepo('a/b/c/d/e/repo');
+    const results = scanProjects(tempRoot, 10, { maxScanMs: 0, maxScanDirs: 999999 });
+    expect(results).toEqual([]);
+    expect(DEFAULT_MAX_SCAN_MS).toBeGreaterThan(0);
+  });
+
+  it('invokes onBudgetExceeded with reason "dirs" when the dir cap trips', () => {
+    // Same single-chain fixture as the false-green test: the repo sits behind
+    // the budget, so the walk bails and the callback must fire so a caller can
+    // warn the user the list is incomplete.
+    mkRepo('a/b/c/d/e/repo');
+    const calls: Array<{ reason: string; dirsVisited: number }> = [];
+    scanProjects(tempRoot, 10, {
+      maxScanDirs: 5,
+      onBudgetExceeded: (info) => calls.push({ reason: info.reason, dirsVisited: info.dirsVisited }),
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.reason).toBe('dirs');
+    expect(calls[0]!.dirsVisited).toBeGreaterThanOrEqual(5);
+  });
+
+  it('invokes onBudgetExceeded with reason "time" when the wall-clock cap trips', () => {
+    mkRepo('a/b/c/d/e/repo');
+    const calls: Array<{ reason: string }> = [];
+    scanProjects(tempRoot, 10, {
+      maxScanMs: 0,
+      maxScanDirs: 999999,
+      onBudgetExceeded: (info) => calls.push({ reason: info.reason }),
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.reason).toBe('time');
+  });
+
+  it('does NOT invoke onBudgetExceeded when the scan completes within budget', () => {
+    // Deleting the guard entirely would still pass this (it never trips), but
+    // paired with the "dirs"/"time" tests above it pins the callback to fire
+    // exactly on budget-hit and never on a clean scan — so a caller never shows
+    // a spurious "incomplete" warning.
+    mkRepo('proj');
+    let called = false;
+    const results = scanProjects(tempRoot, 3, {
+      maxScanDirs: DEFAULT_MAX_SCAN_DIRS,
+      onBudgetExceeded: () => { called = true; },
+    });
+    expect(results.map(r => r.name)).toEqual(['proj']);
+    expect(called).toBe(false);
   });
 });


### PR DESCRIPTION
## 一句话结论

`/repo` 切换仓库时，若某个 bot 的工作目录配成 `~`（家目录），同步的仓库扫描可能**钉死整个 daemon 进程**——不只当前群的选仓库卡片发不出，同一 daemon 管理的所有其它群也一起"已读不回"。本 PR 加**协作式预算护栏（目录数 + 时长）**作为纵深防御，并在命中预算时给群里回卡片提示收窄根目录。

> ⚠️ **本 PR 不是对"扫 `~` 卡死"的确定性修复。** 事故的直接死因是 `readdirSync('~/Downloads')` 单次调用陷入内核不返回；预算护栏只在文件系统调用**之间**检查，打不断已经阻塞在内核态的那一次 readdir。若遍历在预算耗尽前先撞上这种目录，daemon 仍会挂。护栏能挡的是"目录海量 / git 子进程风暴"这类**可协作中断**的慢扫描——是概率性缓解 + 体验改善，不是根治。彻底修复需把扫描移出 daemon、由父进程施硬超时（能 kill 内核挂死的 syscall），列为 follow-up。

- 状态：head `fix/repo-scan-guard`，已明确能力边界、修复护栏回归测试并新增预算命中提示，当前未合并。
- 已验证：project-scanner 单测（含护栏截断、正向对照、回调触发共 47 条）+ command-handler 单测（含预算命中的两条行为测试）；`tsc --noEmit` 通过。
- 未验证：真实 daemon 端到端在 `~` 场景下的恢复（需重启目标 bot 后现场复核，见文末）。

## 如何发现

用户在飞书「Botmux-本地」群连发两次 `/repo` 想切仓库，第二次只弹出"⚠️ 当前会话已在运行中…请在下方卡片中选择新仓库"的警告，但**选仓库的卡片始终不来**。随后用户在另一个群（「Devbox Town」）@ 同一个 bot，也"已读不回"。

定位路径：
1. 查 daemon 日志，锁定那次操作 `13:20:48 [a4017e9e] Command: /repo`。
2. 对比正常流程：正常应有 `Sent repo card with N project(s)`；而这次警告之后 daemon **再无任何输出**，连"扫描完成"日志都没有——说明卡在发卡片之前。实测该次静默持续约 **23 分钟**（13:20:48 → 13:43:45 期间零日志），13:43:45 才复活并对所有 session 喷 `tmux pane probe ETIMEDOUT`——同步扫 `~` 钉死事件循环的现场。
3. 该 bot 的 `defaultWorkingDir = '~'`，第二次 `/repo` 走到 `scanMultipleProjects(['/Users/bytedance'], depth=3)`。
4. 用真实扫描逻辑实测家目录：**2 分钟未扫完**；进一步定位到 `readdirSync('/Users/bytedance/Downloads')` **单次调用稳定挂起不返回**（多次复现，连系统 `ls -f` 也挂）。
5. 交叉核对「Devbox Town」群：它与「Botmux-本地」**同属一个 local bot（`cli_a97771991eb8dccb`）、同一个 daemon 进程**（pm2 id 0）；进程被扫 `~` 占死期间，该 bot 名下所有群都无法处理消息——这解释了"另一个群也不理我"。

## 用户看到什么

| 触发方式 | 旧表现 | 本 PR 后表现 |
| --- | --- | --- |
| 会话运行中再发 `/repo`（bot workingDir=`~`，**慢扫描但可中断**） | 只弹警告，选仓库卡片永不出现 | 命中预算即返回：有部分结果则发卡片 + 追加"列表可能不全，请收窄根目录"提示；无结果则回"根目录过大/请指定路径"提示，不再误报"未找到仓库" |
| 会话运行中再发 `/repo`（**单目录内核挂死，如 Downloads**） | 选仓库卡片永不出现，daemon 静默钉死 | ⚠️ **仍会挂死**（护栏打不断内核态 readdir）；根治见 follow-up，当前须收窄根目录规避 |
| 同一 daemon 下其它群 @ 该 bot | 一起"已读不回" | 仅"可中断慢扫描"场景下恢复正常；"内核挂死"场景仍受牵连 |
| daemon 日志 | 卡片前无任何输出，进程静默钉死 | 命中预算时 `logger.warn` 明确提示收窄 workingDirs |

## 根因

`scanProjects`（`src/services/project-scanner.ts`）是**完全同步**的递归遍历：`readdirSync` + 每个 git 仓库 fork 一次 `git worktree list` 子进程。当扫描根是家目录 `~` 时有两重杀伤：

1. **量级（可协作中断）**：家目录下目录海量、git 仓库众多，同步遍历 + 子进程风暴本身就极慢——但每次 fs 调用会返回，护栏能在调用间截断。
2. **挂起（不可协作中断）**：家目录里存在会让 `readdirSync` 永久阻塞的目录（本机是 `~/Downloads`，单次 readdir 稳定不返回）——这次事故的**直接死因**。护栏无法中断已陷入内核的单次 syscall。

因为扫描同步执行且无任何上限，一旦卡住就钉死 daemon 事件循环。而一个 daemon 进程服务多个群，于是"一次扫 `~` 卡死 → 拖垮该进程下所有会话"。

## 改了什么

**1. `src/services/project-scanner.ts` — 协作式预算护栏**

给 `scanProjects` 增加两道预算，在文件系统调用**之间**检查：

- `maxScanDirs`（默认 `DEFAULT_MAX_SCAN_DIRS = 4000`）：访问目录数上限，挡"海量目录 + git 子进程风暴"。
- `maxScanMs`（默认 `DEFAULT_MAX_SCAN_MS = 4000ms`）：墙钟时长上限，挡目录数不高但每仓库 git 子进程慢的"仓库风暴"。

命中任一预算即停止遍历，返回已找到的部分结果，`logger.warn` 提示收窄，并**回调 `onBudgetExceeded`** 把"结果可能不全"的信号交给调用方。均可通过 `ProjectScanOptions` 覆盖；默认值对正常 projects 根目录（毫秒级扫完）无影响。

> 关于时长承诺的诚实修正：护栏**不保证** "4s 后 daemon 必然恢复"——每发现一个 repo 会跑 ≥2 个各 5s 超时的**同步** git 子进程（`getGitCommonDir` + `worktree list`），期间无预算检查；且 `scanMultipleProjects` 对每个 root 重置预算，K 个 root 累计约 K×4s。净收益仍在（把"无限"降为"有界且可中断"），但不是确定性时限。

**2. `src/core/command-handler.ts` + i18n — 提示卡片**

`/repo` 扫描命中预算时，通过 `onBudgetExceeded` 感知，给群里回明确提示而非静默/误报：

- 命中预算且**无结果** → `cmd.repo.scan_budget_no_repos`："根目录过大或读取过慢，已中止；请用 `/repo <路径>` 指定或收窄 workingDirs"，并注明"若某目录系统级读取卡死，本护栏无法中断"。
- 命中预算但**有部分结果** → 先发 `cmd.repo.scan_budget_partial`："列表可能不完整"，再照常发卡片。

> 诚实边界：此提示卡片只在"可中断慢扫描"场景有用；真·内核挂死时事件循环已停摆，卡片同样发不出去——它也是纵深防御，不是根治。

## 观察到的修复结果

- `test/project-scanner.test.ts`：**47 passed**。其中修复了评审指出的**目录护栏假绿**：旧断言 `toBeLessThanOrEqual(1)` 即使整段删掉目录护栏也仍绿；改用**顺序无关单链 fixture**（`mkRepo('a/b/c/d/e/repo')` + `maxScanDirs:5 → toEqual([])`，再 `maxScanDirs:999999 → toHaveLength(1)` 正向对照）。变异验证：把目录护栏分支改成永不触发后该用例**立即 FAIL**。新增 `onBudgetExceeded` 的 dirs/time 触发 + 预算内不触发共 3 条。
- `test/command-handler.test.ts`：**244 passed**，含 `/repo` 相关路径回归，并**新增两条预算命中的行为测试**：mock 的 `scanMultipleProjects` 主动触发 `onBudgetExceeded` 回调，① 回 `[]` → 断言发 `scan_budget_no_repos` 提示、不误报「未找到仓库」、且**不发选仓库卡**；② 回一个 repo → 断言先发 `scan_budget_partial` 再发卡。变异验证：把回调体清空（`() => {}`）后这两条**同时 FAIL**——补上了「回调在但没干活」这类只测 wiring 抓不到的假绿。
- `tsc --noEmit` 退出 0。
- 全量套件：本 PR 相关的两个文件（scanner + command-handler）共 **291 passed**；仓库既有的 PTY/tmux/CoCo-snapshot 等 e2e 用例存在**与本改动无关的环境性超时失败**（`multi-bot-session.e2e.ts` 等，改动前即失败），见下方"仍未验证"。

## 仍未验证什么

| 剩余检查 | 需要的环境 / 原因 | 影响范围 |
| --- | --- | --- |
| 真实 daemon 在 `~` 场景下重启后恢复响应 | 需重启目标 bot 的 daemon（影响在线会话，需用户授权） | 阻塞发布验收，不阻塞代码合并 |
| 单次 syscall 挂起的彻底兜底（**出口 A**） | 护栏只在调用间检查，无法中断已阻塞在内核态的 `readdir`；根治需把扫描移到带硬超时的 worker/父进程 | 已知边界，列为 follow-up；不阻塞本 PR |
| 全量测试套件 | 既有 PTY/tmux/CoCo e2e 用例在本机环境超时失败，改动前即存在，与本 PR 无关 | 不阻塞合并；需 CI 环境确认这些 e2e 的基线状态 |

## 治本建议（配置层 + 出口 A）

- **配置层（立即可做）**：不要把 bot 的 `workingDir`/`defaultWorkingDir` 配成 `~`，改成具体 projects 根目录（如 `/Users/bytedance/Documents`），从源头避免扫描家目录。
- **出口 A（follow-up）**：把仓库扫描移出 daemon 主进程，由父进程对子进程施**硬超时**（可 `kill` 掉陷在内核态的 syscall），才能对"单目录挂死"确定性兜底。

本 PR 定位为**纵深防御 + 体验改善**，不声称已修复"扫 `~` 挂死"。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
