### PR TITLE
fix(dashboard): 定时任务展示目标群聊

### DIFF
--- a/src/dashboard/web/schedules-page.tsx
+++ b/src/dashboard/web/schedules-page.tsx
@@ -9,6 +9,7 @@ import {
   OverviewListMain,
   OverviewListTail,
 } from './dashboard-components.js';
+import { chatDisplayTitle, loadNameMaps } from './ui.js';
 
 type ScheduleRow = Record<string, any> & { id: string };
 type ScheduleAction = 'run' | 'pause' | 'resume';
@@ -84,6 +85,7 @@ function ScheduleRowCard(props: {
   onDelete(schedule: ScheduleRow): void;
 }) {
   const { schedule: s, scheduleTimeZone, tr } = props;
+  const chatTitle = chatDisplayTitle(s);
   const kind = String(s.parsed?.kind ?? 'unknown');
   const toggleOp: ScheduleAction = s.enabled ? 'pause' : 'resume';
   const toggleKey = `${s.id}:${toggleOp}`;
@@ -104,6 +106,7 @@ function ScheduleRowCard(props: {
         </div>
         <div className="schedule-chip-strip">
           <span>{kind}</span>
+          {s.chatId ? <span title={String(s.chatId)}>{tr('schedules.form.chat')}: {chatTitle ?? s.chatId}</span> : null}
           <span>{tr('schedules.delivery')}: {placementLabel(s, tr)}</span>
           {s.silent ? <span>🔇 {tr('schedules.silent')}</span> : null}
           <span>{tr('schedules.next')}: {fmtScheduleDate(s.nextRunAt, scheduleTimeZone)}</span>
@@ -171,6 +174,7 @@ function SchedulesPage() {
   const [editing, setEditing] = useState<ScheduleRow | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
   const [bots, setBots] = useState<Array<{ larkAppId: string; botName?: string }>>([]);
+  const [, setNameMapsVersion] = useState(0);
 
   useEffect(() => {
     fetch('/api/bots')
@@ -179,6 +183,10 @@ function SchedulesPage() {
         if (Array.isArray(b?.bots)) setBots(b.bots);
       })
       .catch(() => undefined);
+  }, []);
+
+  useEffect(() => {
+    void loadNameMaps().then(() => setNameMapsVersion(version => version + 1));
   }, []);
 
   const rows = useMemo(
@@ -583,9 +591,14 @@ function ScheduleFormModal(props: {
             />
             <small className="schedule-form-help">{tr('schedules.form.promptHelp')}</small>
           </label>
-          {!editing ? (
-            <label className="schedule-form-field">
-              <span className="schedule-form-label">{tr('schedules.form.chat')}</span>
+        {editing ? (
+          <div className="schedule-form-field">
+            <span className="schedule-form-label">{tr('schedules.form.chat')}</span>
+            <code title={chatId}>{chatDisplayTitle(editing) ?? chatId}</code>
+          </div>
+        ) : (
+          <label className="schedule-form-field">
+            <span className="schedule-form-label">{tr('schedules.form.chat')}</span>
               <input
                 type="text"
                 value={chatId}
@@ -594,7 +607,7 @@ function ScheduleFormModal(props: {
                 required
               />
             </label>
-          ) : null}
+          )}
           {localDelivery ? (
             <div className="schedule-form-field">
               <span className="schedule-form-label">{tr('schedules.form.deliver')}</span>

--- a/src/dashboard/web/schedules-page.tsx
+++ b/src/dashboard/web/schedules-page.tsx
@@ -106,7 +106,14 @@ function ScheduleRowCard(props: {
         </div>
         <div className="schedule-chip-strip">
           <span>{kind}</span>
-          {s.chatId ? <span title={String(s.chatId)}>{tr('schedules.form.chat')}: {chatTitle ?? s.chatId}</span> : null}
+          {s.chatId ? (
+            <span
+              className="schedule-chat-chip"
+              title={chatTitle ? `${chatTitle} · ${String(s.chatId)}` : String(s.chatId)}
+            >
+              {tr('schedules.form.chat')}: {chatTitle ?? s.chatId}
+            </span>
+          ) : null}
           <span>{tr('schedules.delivery')}: {placementLabel(s, tr)}</span>
           {s.silent ? <span>🔇 {tr('schedules.silent')}</span> : null}
           <span>{tr('schedules.next')}: {fmtScheduleDate(s.nextRunAt, scheduleTimeZone)}</span>

--- a/src/dashboard/web/style.css
+++ b/src/dashboard/web/style.css
@@ -13640,6 +13640,16 @@ tbody tr[data-chat]:hover {
   white-space: nowrap;
 }
 
+.schedule-chip-strip span.schedule-chat-chip {
+  display: inline-block;
+  max-width: min(320px, 100%);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 22px;
+  text-align: left;
+}
+
 .schedule-chip-strip span.schedule-error-chip {
   border-color: color-mix(in srgb, var(--danger) 35%, var(--border-soft));
   background: color-mix(in srgb, var(--danger) 10%, var(--surface));

--- a/test/dashboard-schedules-ui.test.ts
+++ b/test/dashboard-schedules-ui.test.ts
@@ -49,6 +49,13 @@ describe('dashboard schedules React page helpers', () => {
     expect(page).not.toContain('setDeliver(');
   });
 
+  it('shows the target chat in both the schedule row and edit dialog', () => {
+    const page = readFileSync(new URL('../src/dashboard/web/schedules-page.tsx', import.meta.url), 'utf8');
+    expect(page).toContain("import { chatDisplayTitle, loadNameMaps } from './ui.js';");
+    expect(page).toContain("{s.chatId ? <span title={String(s.chatId)}>{tr('schedules.form.chat')}: {chatTitle ?? s.chatId}</span> : null}");
+    expect(page).toContain("<code title={chatId}>{chatDisplayTitle(editing) ?? chatId}</code>");
+  });
+
   it('offers three execution positions and allows lazy silent fresh topics', () => {
     const page = readFileSync(new URL('../src/dashboard/web/schedules-page.tsx', import.meta.url), 'utf8');
     expect(page).toContain('onChange={e => setSilent(e.target.checked)}');

--- a/test/dashboard-schedules-ui.test.ts
+++ b/test/dashboard-schedules-ui.test.ts
@@ -52,8 +52,27 @@ describe('dashboard schedules React page helpers', () => {
   it('shows the target chat in both the schedule row and edit dialog', () => {
     const page = readFileSync(new URL('../src/dashboard/web/schedules-page.tsx', import.meta.url), 'utf8');
     expect(page).toContain("import { chatDisplayTitle, loadNameMaps } from './ui.js';");
-    expect(page).toContain("{s.chatId ? <span title={String(s.chatId)}>{tr('schedules.form.chat')}: {chatTitle ?? s.chatId}</span> : null}");
+    // Row chip: dedicated class so a long (Chinese) chat name can be width-capped
+    // + ellipsised instead of overrunning into the action buttons.
+    expect(page).toContain('className="schedule-chat-chip"');
+    expect(page).toContain("{tr('schedules.form.chat')}: {chatTitle ?? s.chatId}");
+    // Tooltip keeps the full name AND the raw chatId so truncation loses nothing.
+    expect(page).toContain('title={chatTitle ? `${chatTitle} · ${String(s.chatId)}` : String(s.chatId)}');
     expect(page).toContain("<code title={chatId}>{chatDisplayTitle(editing) ?? chatId}</code>");
+  });
+
+  it('caps the target-chat chip width so a long name cannot overrun the row', () => {
+    const css = readFileSync(new URL('../src/dashboard/web/style.css', import.meta.url), 'utf8');
+    // The chip must have its own bounded rule (base .schedule-chip-strip span is
+    // flex:none + nowrap with no max-width — a long name would push past the
+    // main column into the Run/Edit/Delete actions).
+    expect(css).toMatch(
+      /\.schedule-chip-strip span\.schedule-chat-chip \{[\s\S]*?max-width:[\s\S]*?overflow:\s*hidden[\s\S]*?text-overflow:\s*ellipsis/,
+    );
+    // inline-block (not the base inline-flex) is what actually renders the … glyph.
+    expect(css).toMatch(
+      /\.schedule-chip-strip span\.schedule-chat-chip \{[\s\S]*?display:\s*inline-block/,
+    );
   });
 
   it('offers three execution positions and allows lazy silent fresh topics', () => {


### PR DESCRIPTION
## 改动
- 在定时任务卡片展示目标群聊名称；群名尚未解析时回退显示 chat ID。
- 编辑任务时只读展示目标群聊，避免误以为可修改任务绑定。
- 页面加载后刷新群聊名称映射；超长群名使用省略展示，避免挤压右侧操作按钮。

## 原因
定时任务此前仅显示 Bot AppID 与执行位置，无法在控制台确认任务实际投递到哪个群聊。

## UI 截图
<img width="1280" height="720" alt="clipboard" src="https://github.com/user-attachments/assets/f4a70fc6-17ee-41e5-9312-6d9ed56dcd75" />

## 影响面
仅 Dashboard 定时任务列表和编辑态展示；不改变任务创建、调度、投递或 PATCH 的数据语义。

## 实际验证
- pnpm vitest run --project unit test/dashboard-schedules-ui.test.ts
- pnpm tsc --noEmit
- pnpm dashboard:bundle
- 1280×720 本机 mock 页面：长群名省略展示，右侧“立即运行 / 启用 / 编辑 / 删除”按钮无重叠。