### PR TITLE
fix(bridge): 已 send 过 + 末行 sentinel 判为收尾抑制,修 narration 被兜底发出

### DIFF
--- a/src/services/bridge-fallback-gate.ts
+++ b/src/services/bridge-fallback-gate.ts
@@ -10,17 +10,21 @@
  * Rules:
  *   - Non-adopt + sentinel terminator: the model ended its final with a
  *     standalone `BOTMUX_NOTHING_TO_SEND` (or the legacy `BOTMUX_NO_REPLY`)
- *     line. Two sub-cases, split by what remains after the sentinel line is
- *     stripped (stripTrailingBridgeSentinelLine):
- *       · NOTHING remains → genuine silence (#554): the model was triggered but
- *         deliberately produced no answer (ambient group chatter, or a message
- *         addressed to another bot). Suppress the whole turn. isBridgeNothingToSendFinal.
- *       · PROSE remains → the model DID produce an answer and merely appended
- *         the sentinel. This is the "did work, forgot to `botmux send`, ended
- *         with the sentinel" ghosting shape. Do NOT drop it: callers strip the
- *         sentinel line and forward the prose through the normal send-marker
- *         gate (so a turn that already sent is still suppressed, but an un-sent
- *         answer is delivered instead of lost).
+ *     line. Sub-cases:
+ *       · NOTHING remains after stripping the sentinel → genuine silence (#554):
+ *         the model was triggered but deliberately produced no answer (ambient
+ *         group chatter, or a message addressed to another bot). Suppress the
+ *         whole turn. isBridgeNothingToSendFinal.
+ *       · PROSE remains AND the model ALREADY sent ≥1 message in-window → the
+ *         trailing prose is narration / thinking the model kept out of chat and
+ *         then ended with the sentinel. SUPPRESS (do not re-post it as a new
+ *         answer — the length heuristic would otherwise mistake longer narration
+ *         for a substantive final). This is the "already sent, then narrated,
+ *         ended with sentinel" leak the send-marker branch guards.
+ *       · PROSE remains AND the model sent NOTHING in-window → the prose is a
+ *         real answer produced but never sent (ghosting). Do NOT drop it: callers
+ *         strip the sentinel line and forward the prose (empty marker set → not
+ *         suppressed).
  *     A token that only appears inline (mid-sentence, or with prose after it) is
  *     a normal answer and is left untouched.
  *   - Adopt mode never suppresses: in /adopt the model in the adopted
@@ -265,6 +269,25 @@ export function shouldSuppressBridgeEmit(
   const lower = turn.markTimeMs;
   const upper = nextBoundaryMs ?? Number.POSITIVE_INFINITY;
   const markersInWindow = markers.filter(m => m.sentAtMs >= lower && m.sentAtMs < upper);
+  // A trailing sentinel line is the model's explicit "I have nothing more to
+  // send" signal. Split the two prose+sentinel cases by whether the model
+  // ALREADY sent this turn:
+  //   · sent ≥1 in-window + trailing sentinel → the trailing prose is narration
+  //     / thinking the model deliberately kept out of chat (it explicitly ended
+  //     with the sentinel after sending). SUPPRESS — do NOT let the length
+  //     heuristic below mistake longer narration for a new substantive answer
+  //     and re-post it. This is the "already sent, then narrated, ended with
+  //     sentinel" leak.
+  //   · zero sends in-window + trailing sentinel → the prose is a real answer
+  //     the model produced but never sent (ghosting). Fall through: the
+  //     stripped prose is forwarded by the length check below (markers empty →
+  //     markerSetCoversFinal=false → not suppressed → caller posts it).
+  // A final WITHOUT a trailing sentinel keeps the pure length-based behavior.
+  if (turn.finalText !== undefined
+      && hasTrailingBridgeSentinelLine(turn.finalText)
+      && markersInWindow.length > 0) {
+    return true;
+  }
   // Compare the SENTINEL-STRIPPED final against send markers: a prose+sentinel
   // final is delivered as the stripped prose (callers strip before send), so the
   // length used for the material-longer check must match what actually posts —

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8462,7 +8462,15 @@ async function handleTrustedCodexAppMarker(
     }
     if (deliverableContent && startedAtMs !== undefined) {
       const suppressMarkers = readSendMarkers();
-      const gateInput = { markTimeMs: startedAtMs, isLocal: false, finalText: deliverableContent };
+      // Pass the RAW finalContent (not the pre-stripped deliverableContent) as
+      // finalText: shouldSuppressBridgeEmit needs to SEE the trailing sentinel to
+      // apply the "already sent this turn + sentinel terminator → suppress
+      // narration" branch. It strips internally for the length comparison, so a
+      // prose+sentinel final is still length-matched on the stripped prose. If we
+      // handed it the already-stripped text, the trailing-sentinel signal would
+      // be invisible and a longer-than-send narration would leak (same class as
+      // the transcript-path bug this fixes).
+      const gateInput = { markTimeMs: startedAtMs, isLocal: false, finalText: finalContent };
       suppressDelivery = suppressDelivery || shouldSuppressBridgeEmit(
         gateInput,
         completedAtMs + 5_001,

--- a/test/bridge-fallback-gate.test.ts
+++ b/test/bridge-fallback-gate.test.ts
@@ -211,6 +211,46 @@ describe('shouldSuppressBridgeEmit', () => {
     )).toBe(true);
   });
 
+  it('non-adopt: trailing sentinel + ANY in-window send suppresses long narration (real-world leak)', () => {
+    // The reported bug: the model `botmux send`s a short message, then writes a
+    // long block of NARRATION/thinking it deliberately keeps out of chat, and
+    // ends the final with the sentinel. The narration is materially LONGER than
+    // the send, so the length heuristic (markerSetCoversFinal) alone judged it a
+    // new substantive answer and RE-POSTED the narration. A trailing sentinel +
+    // any in-window marker now suppresses unconditionally: the sentinel is the
+    // model's explicit "nothing more to send" after it already sent.
+    const shortSend = 'On it.';
+    const longNarration =
+      "The screenshot subagent is running. I'll wait for it to save the file(s), "
+      + 'then send them via botmux send --images and stop the server. No message '
+      + 'needed until I have the files.';
+    expect(longNarration.length).toBeGreaterThan(shortSend.length * 2); // would trip material-longer
+    expect(shouldSuppressBridgeEmit(
+      { ...turn(100), finalText: `${longNarration}\n\n${BRIDGE_NOTHING_TO_SEND_SENTINEL}` },
+      500,
+      [{ sentAtMs: 200, ...buildBridgeSendMarkerContent(shortSend) }],
+      false,
+    )).toBe(true);
+  });
+
+  it('non-adopt: NO trailing sentinel + long final still posts even with a short prior send (unchanged)', () => {
+    // Guard the narrowing: the sentinel is what flips a longer-than-send final to
+    // suppressed. WITHOUT a trailing sentinel, a materially longer final is still
+    // treated as a genuine follow-up answer and posts (preserves the pre-existing
+    // "short progress update then a substantive final" behavior).
+    const shortSend = 'Working on it.';
+    const longFinal = 'Here is the complete, substantive answer that is materially '
+      + 'longer than the short progress note I sent earlier, with real content '
+      + 'that clearly exceeds the material-longer threshold by a wide margin here.';
+    // sanity: this final IS materially longer than the send (would post on its own)
+    expect(shouldSuppressBridgeEmit(
+      { ...turn(100), finalText: longFinal },
+      500,
+      [{ sentAtMs: 200, ...buildBridgeSendMarkerContent(shortSend) }],
+      false,
+    )).toBe(false);
+  });
+
   it('non-adopt: token inline in a prose sentence is not guessed away', () => {
     // Last non-empty line is a full sentence (token mid-line), not a bare
     // sentinel — a normal answer that merely mentions the token.

--- a/test/worker-app-runner-control-wiring.test.ts
+++ b/test/worker-app-runner-control-wiring.test.ts
@@ -352,4 +352,27 @@ describe('worker app-runner control-channel wiring', () => {
     // Both the signed final and the bridge-fallback paths notify — never just one.
     expect((workerSource.match(/notifyExplicitReplyObserved\(/g) ?? []).length).toBeGreaterThanOrEqual(2);
   });
+
+  it('passes RAW finalContent (not the pre-stripped deliverable) to the suppress gate', () => {
+    // Regression guard for the narration-leak fix (#804): shouldSuppressBridgeEmit
+    // gained a branch "trailing sentinel + a send marker in-window → suppress" so
+    // that a model which already `botmux send`-ed and then wrote longer narration
+    // ending in the sentinel does NOT get that narration re-posted. That branch
+    // can only fire if the gate SEES the trailing sentinel — so the codex-app
+    // call site must hand it the RAW finalContent, not deliverableContent (which
+    // has already had the sentinel stripped). The actual send still uses
+    // deliverableContent; the gate strips internally for its length comparison.
+    const markerStart = workerSource.indexOf('async function handleTrustedCodexAppMarker(');
+    const markerEnd = workerSource.indexOf('function handleAppRunnerOscMarker(', markerStart);
+    const marker = workerSource.slice(markerStart, markerEnd);
+    // The deliverable is derived by stripping; the gate input must be the raw text.
+    expect(marker).toContain('const deliverableContent = stripTrailingBridgeSentinelLine(finalContent);');
+    const gateInputIdx = marker.indexOf('finalText: finalContent };');
+    expect(gateInputIdx).toBeGreaterThan(-1);
+    // Guard against reintroducing the bug: the gateInput must NOT be built from
+    // the already-stripped deliverableContent.
+    expect(marker).not.toContain('finalText: deliverableContent');
+    // The send payload still posts the stripped deliverable, not the raw final.
+    expect(marker).toContain('content: (suppressDelivery || isSuperseded) ? \'\' : deliverableContent,');
+  });
 });


### PR DESCRIPTION
## 背景 / 动机

#791 的 strip-and-forward 有个漏洞(飞书实测发现):模型本轮**已经 `botmux send` 过**,随后写了一段 narration / 思考(例如「我等 subagent 出图再发,在此之前无需发消息」),并在 final 末行补 `BOTMUX_NOTHING_TO_SEND` 收尾。

gate 对「prose + 末行 sentinel」的处理是:剥掉 sentinel 后走长度启发式 `markerSetCoversFinal`。这段 narration 比之前的 send **显著长** → 被判「新的实质答复」→ 当作兜底发到飞书。**结果:模型的思考被当答复泄漏到群里。**

## 根因

sentinel 是模型显式的「我没有更多要发的了」信号。旧逻辑在 prose+sentinel 时把它 strip 掉、完全交给长度启发式,让「长度」盖过了这个显式信号。「prose+sentinel」应按**本轮是否已 send** 区分:

| 情况 | 含义 | 应对 |
|------|------|------|
| 已 send ≥1 + 末行 sentinel | 末尾是 narration/思考,模型发完了 | **抑制** |
| 零 send + prose + sentinel | 有答复但忘了 send(#791 要救的 ghosting) | 转发 |
| 纯 sentinel | 正当静默(#554) | 静默 |

## 改动

### 1. gate 新增 A/B 分支(`bridge-fallback-gate.ts`)
`shouldSuppressBridgeEmit`:算出 `markersInWindow` 后,若 final **末行是 sentinel**(`hasTrailingBridgeSentinelLine`)且窗口内**有 ≥1 send marker** → 直接 `return true` 抑制,**不再走长度启发式**;窗口内零 marker 时才落到原 strip-and-forward(保 #791 ghosting)。无 sentinel 的 final 保持原纯长度行为不变。

### 2. codex-app 回投向 gate 传 raw finalContent(`worker.ts`)
`handleTrustedCodexAppMarker` 原先先 `deliverableContent = stripTrailingBridgeSentinelLine(finalContent)`,再以 `finalText: deliverableContent` 调 gate —— gate 已看不到末行 sentinel,上面的新分支对 codex-app **永不命中**,同类 narration 泄漏仍在(复现:raw 228 char → suppress=true;pre-stripped 204 char → suppress=false)。修:gateInput 传 **raw `finalContent`**(gate 内部本就 strip 后做长度比较,零 marker ghosting / 无 sentinel 长 final / 纯 sentinel 三态不变);真正发送仍用 `deliverableContent`。这样 transcript 路径与 codex-app 行为一致。

## 影响面评估

- 改 gate 一个判断分支 + codex-app 回投调用点的 gateInput 传参,多 CLI 共享路径(Claude 家族 / 结构化 bridge / codex-app durable)现在**行为一致**遵守同一张三态真值表。
- 是对 #791 的**收窄**:只在「末行 sentinel + 已 send」精确组合下多抑制一次。不影响 ① 纯 sentinel 静默(#554)② 零 send 的 ghosting 转发(#791)③ 无 sentinel 的长答复跟发(pre-existing「短进度后接实质 final」)。

## 验证(4 文件 +106/−12)

- `pnpm build` ✅
- **`bridge-fallback-gate` 52/52**:新增 real-world narration 泄漏用例(短 send + 长 narration + sentinel → 抑制)+ 收窄守卫(无 sentinel 的长 final + 短 send → 仍跟发,证明是 sentinel 触发收窄而非误伤长答复)。
- **`worker-app-runner-control-wiring`**:新增源断言——codex-app gateInput 必须是 `finalText: finalContent`(raw)、**不得**是 `deliverableContent`;send payload 仍用 `deliverableContent`。锁死 codex-app 调用点回归。
- emit-path 全绿:`codex-app-turn` / `codex-app-turn-controller`、`bridge-final-output-retry`、queue。
- 全量回归结果见下方评论(失败对照 clean master baseline)。