### PR TITLE
fix(riff-backend): 修复 web 终端 stdout 日志糊成墙(SSE 逐行日志丢尾换行)

### DIFF
--- a/src/adapters/backend/riff-backend.ts
+++ b/src/adapters/backend/riff-backend.ts
@@ -1263,9 +1263,18 @@ export class RiffBackend implements SessionBackend {
           const kind = data['kind'] as string | undefined;
           const group = (data['group'] as string | undefined)
             ?? (data['payload'] as Record<string, unknown> | undefined)?.['group'] as string | undefined;
-          // stdout logs are the real output stream — emit as data regardless of logLevel
+          // stdout logs are the real output stream — emit as data regardless of logLevel.
+          // riff stores each stdout log line BARE (no trailing newline): the runner's
+          // logger persists `message` verbatim (Logger.createRootLog) and the SSE `log`
+          // event carries it as `text` unchanged (taskLog.ts runnerLog*→text: log.message).
+          // For codex_app_server that message is one `JSON.stringify(event)` per line. Since
+          // emitText only NORMALIZES existing newlines and never adds a separator, emitting
+          // the bare text would butt consecutive events together into one unreadable wall.
+          // Re-add the per-line separator here (safe & non-duplicating precisely because the
+          // stored line has no trailing newline). NOTE: the `output`/chunk path stays raw —
+          // those chunks may be partial lines, so they must NOT get a synthetic newline.
           if (group === 'stdout' && text) {
-            this.emitText(text);
+            this.emitText(`${text}\n`);
           } else if (this.config.logLevel === 'verbose' && text) {
             this.emitLine(`[riff:${kind ?? 'log'}] ${text}`);
           }

--- a/test/riff-backend.test.ts
+++ b/test/riff-backend.test.ts
@@ -380,6 +380,47 @@ describe('RiffBackend', () => {
     });
   });
 
+  describe('stdout log line separation (finding: app_server char-wall)', () => {
+    // riff ships each stdout log line BARE (no trailing newline). The relay must
+    // re-add a separator per log event, else consecutive events concatenate into
+    // one unreadable "wall" — the exact symptom seen with codex_app_server, whose
+    // stdout logs are one JSON.stringify(event) per line (thread.started, etc).
+    it('separates consecutive stdout log events instead of concatenating them', () => {
+      const be = makeBackend({ injectStatusLines: false });
+      const lines: string[] = [];
+      be.onData(d => lines.push(d));
+      (be as any).currentTaskId = 'task-1';
+      (be as any).handleSseEvent('event:log\ndata:{"group":"stdout","text":"{\\"type\\":\\"thread.started\\"}"}', 'task-1');
+      (be as any).handleSseEvent('event:log\ndata:{"group":"stdout","text":"{\\"type\\":\\"turn.started\\"}"}', 'task-1');
+      const out = lines.join('');
+      // The two events must not butt together (…}{… would be the wall).
+      expect(out).not.toContain('}{');
+      // Each event renders on its own line (emitText normalizes \n → \r\n).
+      expect(out).toContain('{"type":"thread.started"}\r\n');
+      expect(out).toContain('{"type":"turn.started"}\r\n');
+    });
+
+    it('does not double-space a stdout log (bare line + exactly one separator)', () => {
+      const be = makeBackend({ injectStatusLines: false });
+      const lines: string[] = [];
+      be.onData(d => lines.push(d));
+      (be as any).currentTaskId = 'task-1';
+      (be as any).handleSseEvent('event:log\ndata:{"group":"stdout","text":"hello"}', 'task-1');
+      expect(lines.join('')).toBe('hello\r\n');
+    });
+
+    it('leaves the output/chunk path raw (chunks may be partial lines)', () => {
+      const be = makeBackend({ injectStatusLines: false });
+      const lines: string[] = [];
+      be.onData(d => lines.push(d));
+      (be as any).currentTaskId = 'task-1';
+      (be as any).handleSseEvent('event:output\ndata:{"chunk":"par"}', 'task-1');
+      (be as any).handleSseEvent('event:output\ndata:{"chunk":"tial"}', 'task-1');
+      // No synthetic newline injected between chunks — they join seamlessly.
+      expect(lines.join('')).toBe('partial');
+    });
+  });
+
   describe('task isolation (finding F)', () => {
     it('stale stream events are inert once a newer task is current', () => {
       const be = makeBackend({ injectStatusLines: false });


### PR DESCRIPTION
## 问题

codex_app_server 路径下,飞书 web 终端的日志正文"糊成墙"——多条 stdout 日志首尾相接、零分隔,不可读(申晗截图复现,截图里能看到 `thread.started`/`turn.started`,确认走的是 main 上的 app_server 新路径,不是老 exec)。

## 根因:SSE 逐行日志丢尾换行

riff 端**逐行、无尾换行**地存/发 stdout 日志:

1. `appServer.ts` emitNormalized:`logger.info(JSON.stringify(event), {group:'stdout'})` 存的是**裸行**(带 `\n` 的那份喂给另一个 sink,不进日志流)。codex_app_server 下这条 message 就是一条 `JSON.stringify(event)`(thread.started / turn.started / item.* …)。
2. runner logger 存 `message` 时只做 mask/truncate,**不加换行**。
3. SSE `event: log` 的 `text` = `log.message` **原样**。

到本仓 relay 这端,`emitText` 只把已有 `\r?\n` 归一化(`\n`→`\r\n`),**从不给每条日志补分隔**。于是 `case 'log'` 的 stdout 分支 `emitText(text)` 把逐条裸行首尾相接 → 糊成墙。

## 修法

`src/adapters/backend/riff-backend.ts` 的 `case 'log'`,`group === 'stdout'` 分支:

```diff
- this.emitText(text);
+ this.emitText(`${text}\n`);
```

因 riff 逐行、无尾换行存,补 `\n` **精确不重复**。

### 两个刻意的边界

- **没用 `emitLine`**:`emitLine` 会包 ANSI 色 + 前后 `\r\n` 空行(状态行语义),会把每条 stdout 撑成双倍行距。stdout 原始流只需要"补一个分隔",所以走 `emitText(text+'\n')`。
- **`output`/chunk 路径故意不动**:`event: output` 的 chunk 是**字节流、可能半行**语义,给它补 `\n` 会把一行劈两段。只有 `log` 事件是逐行语义,补换行才安全。

## 影响面

只影响 web 终端**实时日志流**的渲染(把"糊成墙"降为"每行一个规整 JSON 事件"可读)。不改任何数据、不动终报路径、不动 chunk 流。

> 注:补 `\n` 后仍是裸 JSON-per-line,不是人类可读时间线——那是可选的后续打磨(relay 里 parse thread/turn/item 渲成时间线),不在本 PR 范围。

## 测试

新增 3 个回归测试(`test/riff-backend.test.ts`):
- 两条连续 stdout log 分行不糊(断言不含 `}{`,各自 `…\r\n`)
- 单条不双空行(`hello` → `hello\r\n`)
- chunk 路径保持原样(`par`+`tial` → `partial`,无注入换行)

`riff-backend.test.ts` **50/50 绿**,`tsc --noEmit` 对改动文件干净。
