### PR TITLE
fix(pi): 启动时传递机器人模型配置

### DIFF
--- a/src/adapters/cli/pi.ts
+++ b/src/adapters/cli/pi.ts
@@ -66,10 +66,11 @@ export function createPiAdapter(pathOverride?: string): CliAdapter {
     authPaths: ['~/.pi/agent/auth.json'],
     resolvedBin: bin,
 
-    buildArgs({ sessionId, initialPrompt }) {
+    buildArgs({ sessionId, initialPrompt, model }) {
       const args = [
         '--session-id', sessionId,
       ];
+      if (model?.trim()) args.push('--model', model.trim());
       // Pi's interactive mode processes positional initial messages after TUI
       // startup, avoiding stdin races while keeping the native TUI visible.
       if (initialPrompt) args.push(initialPrompt);

--- a/test/cli-adapters.test.ts
+++ b/test/cli-adapters.test.ts
@@ -829,6 +829,18 @@ describe('pi buildArgs', () => {
     expect(adapter.maxInitialPromptArgBytes).toBeUndefined();
     expect(adapter.altScreen).toBe(true);
   });
+
+  it('pins the configured model instead of inheriting Pi defaults', () => {
+    const args = adapter.buildArgs({
+      sessionId: 'sess-pi',
+      resume: false,
+      model: 'custom/long-context-model',
+    });
+    expect(args).toEqual([
+      '--session-id', 'sess-pi',
+      '--model', 'custom/long-context-model',
+    ]);
+  });
 });
 
 describe('oh-my-pi buildArgs', () => {


### PR DESCRIPTION
## 改动

- 让 Pi 适配器消费 `BotConfig.model`，启动时显式传入 `--model`
- 未配置模型时保持原行为，继续使用 Pi 自身默认值
- 增加适配器回归测试，防止模型配置再次被静默忽略

## 原因

此前 Pi 的 `buildArgs` 只传递会话 ID 和首条提示词。即使机器人配置了模型，实际启动仍会继承 Pi 的全局默认模型；全局默认值变化后，机器人会在无提示的情况下漂移到其他模型或提供方。

## 影响面

改动仅限 Pi CLI 适配器及其单元测试，不修改公共启动链路，也不影响其他 CLI、后端或会话类型。PTY/Tmux 均复用同一适配器参数；未设置 `model` 的 Pi 配置不受影响。

## 验证

- `vitest run --project unit test/cli-adapters.test.ts test/pi-initial-prompt.test.ts test/initial-prompt-arg-limit.test.ts`：350 tests passed
- `pnpm exec tsc --noEmit --pretty false`：通过
- `pnpm build`：通过
- `git diff --check`：通过
- 使用自定义 provider/model 完成新会话与已有会话恢复验证，transcript 均记录配置模型并正常返回