### PR TITLE
fix(card): 按 turn 受理时创建状态卡

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -212,7 +212,7 @@ export interface DaemonSession {
   ownerOpenId?: string;          // receives owner-only links and controls write-enabled access
   streamCardId?: string;         // message_id of the streaming card in group (PATCHed with live output)
   streamCardNonce?: string;       // unique nonce for the current streaming card — embedded in button values to distinguish old vs current card
-  streamCardPending?: boolean;    // true when a new turn started, next screen_update creates a new card
+  streamCardPending?: boolean;    // true while the newest turn still needs its own streaming card
   /** Monotonic in-memory generation for accepted user turns. Card POST
    * completions use it to avoid clearing a newer turn's pending state. */
   streamCardTurnGeneration?: number;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -213,6 +213,11 @@ export interface DaemonSession {
   streamCardId?: string;         // message_id of the streaming card in group (PATCHed with live output)
   streamCardNonce?: string;       // unique nonce for the current streaming card — embedded in button values to distinguish old vs current card
   streamCardPending?: boolean;    // true when a new turn started, next screen_update creates a new card
+  /** Monotonic in-memory generation for accepted user turns. Card POST
+   * completions use it to avoid clearing a newer turn's pending state. */
+  streamCardTurnGeneration?: number;
+  /** Exact newest turn awaiting its own streaming card. In-memory only. */
+  streamCardPendingTurnId?: string;
   pendingLocalCliButtonRefresh?: boolean; // true when cli_session_id arrived while the streaming card POST was in flight
   pendingRiffUrlCardRefresh?: boolean; // true when riff_access_url arrived while the streaming card POST was in flight
   /** Set on sessions restored after a daemon restart: suppresses the automatic

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1353,6 +1353,97 @@ export function recallFrozenCards(ds: DaemonSession): void {
 }
 
 /**
+ * Post the current turn's starting card as soon as the daemon accepts the
+ * inbound message. Terminal redraw is deliberately not part of this trigger:
+ * some CLIs consume a turn without emitting another screen_update, which used
+ * to leave streamCardPending stuck and suppress cards for every later turn.
+ *
+ * Only one POST may be in flight per session. If another turn arrives during
+ * the request, the generation check preserves that newer pending state and
+ * immediately follows with its card after the first POST settles.
+ */
+export async function postTurnStartingCard(
+  ds: DaemonSession,
+  sessionReply: (rootId: string, content: string, msgType?: string, larkAppId?: string, turnId?: string) => Promise<string>,
+  turnId: string,
+): Promise<boolean> {
+  if (!ds.streamCardPending || ds.streamCardPendingTurnId !== turnId) return false;
+  if (ds.streamCardId === CARD_POSTING_SENTINEL) return false;
+  if (ds.session.vcMeetingReceiver || streamingCardDisabled(ds, turnId)) return false;
+  if (!workerHasInitialized(ds)) return false;
+  if (!larkTransportEnabled({ chatId: ds.chatId, apiOnly: getBot(ds.larkAppId).config.apiOnly })) return false;
+
+  const generation = ds.streamCardTurnGeneration ?? 0;
+  const botCfg = getBot(ds.larkAppId).config;
+  const effectiveCliId = sessionCliId(ds, botCfg);
+  const previousCardId = ds.streamCardId;
+  const previousNonce = ds.streamCardNonce;
+  // A newer turn may have arrived while the previous turn's POST was still in
+  // flight, so beginNewTurn could not park that sentinel. Park the now-live
+  // predecessor here before replacing its identity.
+  parkStreamCard(ds);
+  const nonce = randomBytes(4).toString('hex');
+  const status = ds.usageLimit ? 'limited' : 'starting';
+  const cardJson = buildStreamingCard(
+    ds.session.sessionId,
+    sessionAnchorId(ds),
+    readableTerminalUrlFor(ds),
+    ds.currentTurnTitle || ds.session.title || sessionCliDisplayName(ds, botCfg),
+    '',
+    status,
+    effectiveCliId,
+    ds.displayMode ?? 'hidden',
+    nonce,
+    undefined,
+    !!ds.adoptedFrom,
+    false,
+    localeForBot(ds.larkAppId),
+    ds.usageLimit,
+    writableTerminalLinkFor(ds),
+    isLocalCliOpenReady(ds, { cliId: effectiveCliId }),
+    getDaemonStreamingCardUsageSnapshot(ds, effectiveCliId),
+    sessionRuntimeDisplayName(ds, botCfg),
+    codexServiceTierBadge(effectiveCliId, ds.codexServiceTier),
+  );
+
+  ds.streamCardNonce = nonce;
+  ds.streamCardId = CARD_POSTING_SENTINEL;
+  try {
+    const messageId = await sessionReply(
+      sessionAnchorId(ds), cardJson, 'interactive', ds.larkAppId, turnId,
+    );
+    ds.streamCardId = messageId;
+    ds.parkedStreamCardNonce = undefined;
+    const superseded = (ds.streamCardTurnGeneration ?? 0) !== generation;
+    if (!superseded) {
+      ds.streamCardPending = false;
+      ds.streamCardPendingTurnId = undefined;
+    }
+    persistStreamCardState(ds);
+    recallFrozenCards(ds);
+    flushPendingLocalCliOpenReadinessPatch(ds);
+    flushPendingRiffUrlPatch(ds);
+    flushPendingActiveRuntimePatch(ds);
+    flushPendingCodexServiceTierPatch(ds);
+    syncUsageRefreshTimer(ds);
+    logger.info(`[${tag(ds)}] Posted starting card for turn ${turnId.substring(0, 12)}`);
+    if (superseded && ds.streamCardPendingTurnId) {
+      void postTurnStartingCard(ds, sessionReply, ds.streamCardPendingTurnId);
+    }
+    return true;
+  } catch (err) {
+    ds.streamCardId = previousCardId;
+    ds.streamCardNonce = previousNonce;
+    persistStreamCardState(ds);
+    logger.warn(`[${tag(ds)}] Failed to post starting card for turn ${turnId.substring(0, 12)}: ${err}`);
+    if ((ds.streamCardTurnGeneration ?? 0) !== generation && ds.streamCardPendingTurnId) {
+      void postTurnStartingCard(ds, sessionReply, ds.streamCardPendingTurnId);
+    }
+    return false;
+  }
+}
+
+/**
  * Force-post a fresh streaming card for `ds`, bypassing the per-bot
  * `disableStreamingCard` opt-out. Backs the `/card` command: a user can
  * manually summon a live card in an otherwise-quiet session. Parks the current
@@ -7220,6 +7311,7 @@ function setupWorkerHandlers(
         // in-flight. In that case CARD_POSTING_SENTINEL is already set — don't
         // POST a second card; the in-flight POST becomes this turn's card.
         if (ds.streamCardId === CARD_POSTING_SENTINEL) break;
+        const postingGeneration = ds.streamCardTurnGeneration ?? 0;
         ds.streamCardId = CARD_POSTING_SENTINEL;
         try {
           ds.streamCardNonce = randomBytes(4).toString('hex');
@@ -7267,7 +7359,11 @@ function setupWorkerHandlers(
           // this "starting" card is orphaned (never entered frozenCards, so
           // recallFrozenCards can't withdraw it). Mirrors the screen_update POST
           // branch which clears the flag after posting.
-          ds.streamCardPending = false;
+          const superseded = (ds.streamCardTurnGeneration ?? 0) !== postingGeneration;
+          if (!superseded) {
+            ds.streamCardPending = false;
+            ds.streamCardPendingTurnId = undefined;
+          }
           ds.parkedStreamCardNonce = undefined;
           persistStreamCardState(ds);
           // Re-sync worker's display mode (it starts fresh in 'hidden')
@@ -7284,6 +7380,9 @@ function setupWorkerHandlers(
           // resume where the CLI kept running), arm here — same authorized arm
           // point as the reuse branch, now that streamCardId is the real id.
           syncUsageRefreshTimer(ds);
+          if (superseded && ds.streamCardPendingTurnId) {
+            void postTurnStartingCard(ds, cb.sessionReply, ds.streamCardPendingTurnId);
+          }
         } catch (err) {
           if (!ownsLifecycleMutation()) break;
           if (err instanceof MessageWithdrawnError) {
@@ -7623,6 +7722,7 @@ function setupWorkerHandlers(
           // New turn — create a fresh card, old card freezes at its last state.
           // Generate new nonce so old card buttons are distinguishable.
           const isNewTurn = !!ds.streamCardPending;
+          const postingGeneration = ds.streamCardTurnGeneration ?? 0;
           ds.streamCardNonce = randomBytes(4).toString('hex');
           // New turn → image_key from previous turn no longer valid
           if (isNewTurn) ds.currentImageKey = undefined;
@@ -7658,6 +7758,8 @@ function setupWorkerHandlers(
                 return;
               }
               ds.streamCardId = msgId;
+              const superseded = (ds.streamCardTurnGeneration ?? 0) !== postingGeneration;
+              if (!superseded) ds.streamCardPendingTurnId = undefined;
               ds.parkedStreamCardNonce = undefined;
               persistStreamCardState(ds);
               // New card live — recall any cards parked by previous turns
@@ -7675,6 +7777,9 @@ function setupWorkerHandlers(
               // periodic usage refresh here (once the real card id exists, not
               // the POSTING sentinel). syncUsageRefreshTimer re-checks state.
               syncUsageRefreshTimer(ds);
+              if (superseded && ds.streamCardPendingTurnId) {
+                void postTurnStartingCard(ds, cb.sessionReply, ds.streamCardPendingTurnId);
+              }
             })
             .catch(async err => {
               if (!ownsLifecycleMutation()) return;
@@ -7688,6 +7793,9 @@ function setupWorkerHandlers(
               ds.pendingActiveRuntimeCardRefresh = undefined;
               ds.pendingCodexTierCardRefresh = undefined;
               persistStreamCardState(ds);
+              if ((ds.streamCardTurnGeneration ?? 0) !== postingGeneration && ds.streamCardPendingTurnId) {
+                void postTurnStartingCard(ds, cb.sessionReply, ds.streamCardPendingTurnId);
+              }
             });
         } else {
           // Same turn — PATCH only on status change. Image PATCHes go through

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1368,6 +1368,7 @@ export async function postTurnStartingCard(
   turnId: string,
 ): Promise<boolean> {
   if (!ds.streamCardPending || ds.streamCardPendingTurnId !== turnId) return false;
+  if (riffRetirementAdmissionPhase(ds)) return false;
   if (ds.streamCardId === CARD_POSTING_SENTINEL) return false;
   if (ds.session.vcMeetingReceiver || streamingCardDisabled(ds, turnId)) return false;
   if (!workerHasInitialized(ds)) return false;
@@ -1412,7 +1413,7 @@ export async function postTurnStartingCard(
 
   ds.streamCardNonce = nonce;
   ds.streamCardId = CARD_POSTING_SENTINEL;
-  const stillOwnsPost = (): boolean =>
+  const ownsPostIdentity = (): boolean =>
     ds.session === sessionAtPost
     && ds.session.status === 'active'
     && ds.larkAppId === larkAppIdAtPost
@@ -1421,12 +1422,22 @@ export async function postTurnStartingCard(
     && ds.streamCardId === CARD_POSTING_SENTINEL
     && ds.streamCardNonce === nonce
     && (!activeSessionsRegistry || activeSessionsRegistry.get(registryKeyAtPost) === ds);
+  const stillOwnsPost = (): boolean =>
+    ownsPostIdentity() && riffRetirementAdmissionPhase(ds) === null;
+  const restorePrePostIdentityForRetirement = (): boolean => {
+    if (riffRetirementAdmissionPhase(ds) === null || !ownsPostIdentity()) return false;
+    ds.streamCardId = previousCardId;
+    ds.streamCardNonce = previousNonce;
+    persistStreamCardState(ds);
+    return true;
+  };
   try {
     const messageId = await sessionReply(
       anchorAtPost, cardJson, 'interactive', larkAppIdAtPost, turnId,
     );
     if (!stillOwnsPost()) {
       void deleteMessage(larkAppIdAtPost, messageId).catch(() => { /* best-effort stale-card cleanup */ });
+      restorePrePostIdentityForRetirement();
       logger.info(`[${tag(ds)}] Discarded stale starting card for turn ${turnId.substring(0, 12)}`);
       return false;
     }
@@ -1451,6 +1462,7 @@ export async function postTurnStartingCard(
     return true;
   } catch (err) {
     if (!stillOwnsPost()) {
+      restorePrePostIdentityForRetirement();
       logger.info(`[${tag(ds)}] Ignored stale starting-card failure for turn ${turnId.substring(0, 12)}`);
       return false;
     }

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1374,6 +1374,10 @@ export async function postTurnStartingCard(
   if (!larkTransportEnabled({ chatId: ds.chatId, apiOnly: getBot(ds.larkAppId).config.apiOnly })) return false;
 
   const generation = ds.streamCardTurnGeneration ?? 0;
+  const sessionAtPost = ds.session;
+  const larkAppIdAtPost = ds.larkAppId;
+  const anchorAtPost = sessionAnchorId(ds);
+  const registryKeyAtPost = sessionKey(anchorAtPost, larkAppIdAtPost);
   const botCfg = getBot(ds.larkAppId).config;
   const effectiveCliId = sessionCliId(ds, botCfg);
   const previousCardId = ds.streamCardId;
@@ -1408,10 +1412,24 @@ export async function postTurnStartingCard(
 
   ds.streamCardNonce = nonce;
   ds.streamCardId = CARD_POSTING_SENTINEL;
+  const stillOwnsPost = (): boolean =>
+    ds.session === sessionAtPost
+    && ds.session.status === 'active'
+    && ds.larkAppId === larkAppIdAtPost
+    && sessionAnchorId(ds) === anchorAtPost
+    && !isSessionTransferring(ds)
+    && ds.streamCardId === CARD_POSTING_SENTINEL
+    && ds.streamCardNonce === nonce
+    && (!activeSessionsRegistry || activeSessionsRegistry.get(registryKeyAtPost) === ds);
   try {
     const messageId = await sessionReply(
-      sessionAnchorId(ds), cardJson, 'interactive', ds.larkAppId, turnId,
+      anchorAtPost, cardJson, 'interactive', larkAppIdAtPost, turnId,
     );
+    if (!stillOwnsPost()) {
+      void deleteMessage(larkAppIdAtPost, messageId).catch(() => { /* best-effort stale-card cleanup */ });
+      logger.info(`[${tag(ds)}] Discarded stale starting card for turn ${turnId.substring(0, 12)}`);
+      return false;
+    }
     ds.streamCardId = messageId;
     ds.parkedStreamCardNonce = undefined;
     const superseded = (ds.streamCardTurnGeneration ?? 0) !== generation;
@@ -1432,6 +1450,10 @@ export async function postTurnStartingCard(
     }
     return true;
   } catch (err) {
+    if (!stillOwnsPost()) {
+      logger.info(`[${tag(ds)}] Ignored stale starting-card failure for turn ${turnId.substring(0, 12)}`);
+      return false;
+    }
     ds.streamCardId = previousCardId;
     ds.streamCardNonce = previousNonce;
     persistStreamCardState(ds);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -167,6 +167,7 @@ import {
   withActiveSessionKeyLock,
   getDaemonBootId,
   getDaemonStreamingCardUsageSnapshot,
+  postTurnStartingCard,
   isSessionTransferring,
   type WorkerSessionReplyOptions,
 } from './core/worker-pool.js';
@@ -4205,7 +4206,7 @@ function getActiveCount(): number {
  * this, passthrough commands silently PATCH the previous card and the user
  * sees no visible response.
  */
-function beginNewTurn(ds: DaemonSession, title: string): void {
+function beginNewTurn(ds: DaemonSession, title: string, turnId: string): void {
   // docCommentTargets 改为 per-turn map（按 turnId 索引），不再需要每轮清空：
   // 非文档轮的 BOTMUX_TURN_ID 不会命中 map，天然不会误投；旧 entry 由
   // deliverFinalOutput / botmux send 成功路径清理。
@@ -4256,9 +4257,12 @@ function beginNewTurn(ds: DaemonSession, title: string): void {
   }
   ds.usageLimit = undefined;
   ds.streamCardPending = true;
+  ds.streamCardPendingTurnId = turnId;
+  ds.streamCardTurnGeneration = (ds.streamCardTurnGeneration ?? 0) + 1;
   ds.currentTurnTitle = title.substring(0, 50);
   ds.currentImageKey = undefined;
   persistStreamCardState(ds);
+  void postTurnStartingCard(ds, sessionReply, turnId);
 }
 
 /**
@@ -4298,7 +4302,7 @@ async function prewarmDocCommentSession(ds: DaemonSession, sub: DocSubscription)
     );
   }
 
-  beginNewTurn(ds, title);
+  beginNewTurn(ds, title, turnId);
   ds.lastMessageAt = Date.now();
   ds.session.lastMessageAt = new Date(ds.lastMessageAt).toISOString();
   if (sub.workingDir && (!ds.worker || ds.worker.killed)) {
@@ -16258,7 +16262,7 @@ function deliverPassthroughToExistingSession(
     // clearing the marker would lose the opening for the next real turn.
     // `/model` on an empty-started session therefore stays literal and the
     // FOLLOWING business message still opens as a new topic.
-    beginNewTurn(ds, commandContent);
+    beginNewTurn(ds, commandContent, turn.messageId);
     sendWorkerSessionInput(ds, {
       type: 'raw_input',
       content: commandContent,
@@ -18952,7 +18956,7 @@ async function handleThreadReplyAdmitted(
           codexAppApplicationContext,
           codexAppMessageContext,
         });
-    beginNewTurn(ds, parsed.content);
+    beginNewTurn(ds, parsed.content, parsed.messageId);
     await noteTurnReceived(ds, parsed.messageId, parsed.content, turnSender, parsed.messageId, substituteTrigger ? SUBSTITUTE_RECEIVED_REACTION_EMOJI_TYPE : undefined);
     // Codex App steer authorization was computed ONCE before the branch split
     // above (R4-B1); reuse the same frozen value here for the live-worker path.
@@ -19001,6 +19005,8 @@ async function handleThreadReplyAdmitted(
     // new Worker card until the next screenshot upload, which makes a fresh
     // @mention appear to resurrect the wrong CLI UI.
     ds.streamCardPending = true;
+    ds.streamCardPendingTurnId = parsed.messageId;
+    ds.streamCardTurnGeneration = (ds.streamCardTurnGeneration ?? 0) + 1;
     ds.currentImageKey = undefined;
     persistStreamCardState(ds);
     // Wrap the user message in the same `<user_message>` / `<session_id>` /
@@ -19587,7 +19593,7 @@ async function handleDocCommentAdmitted(ctx: DocCommentContext): Promise<boolean
           sender,
           mode: 'live',
         });
-        beginNewTurn(ds, text);
+        beginNewTurn(ds, text, turnId);
         (ds.session.docCommentTargets ??= {})[turnId] = docTarget; // per-turn map，不覆盖其他并发轮
         // rememberLastCliInput persists both the exact comment target and the
         // structured sidecar before any worker-visible delivery can occur.
@@ -19613,6 +19619,8 @@ async function handleDocCommentAdmitted(ctx: DocCommentContext): Promise<boolean
       ds.streamCardId = undefined;
       ds.streamCardNonce = undefined;
       ds.streamCardPending = true;
+      ds.streamCardPendingTurnId = turnId;
+      ds.streamCardTurnGeneration = (ds.streamCardTurnGeneration ?? 0) + 1;
       ds.currentImageKey = undefined;
       persistStreamCardState(ds);
       // Skip whiteboard ensure for adopted (bridge) sessions on re-fork — mirrors

--- a/test/cli-runtime-display.test.ts
+++ b/test/cli-runtime-display.test.ts
@@ -66,4 +66,15 @@ describe('CLI runtime display identity', () => {
     expect(body).toContain('sessionConfiguredRuntimeDisplayName(ds.session, dsBotCfg.cliRuntime)');
     expect(body).toMatch(/getDaemonStreamingCardUsageSnapshot[\s\S]*runtimeDisplayName,/);
   });
+
+  it('starts the current turn card at message acceptance instead of waiting for terminal redraw', () => {
+    const source = readFileSync(new URL('../src/daemon.ts', import.meta.url), 'utf8');
+    const begin = source.indexOf('function beginNewTurn(');
+    const end = source.indexOf('\nfunction ', begin + 1);
+    const body = source.slice(begin, end);
+
+    expect(body).toContain('postTurnStartingCard(ds, sessionReply, turnId)');
+    expect(body).toContain('ds.streamCardPendingTurnId = turnId');
+    expect(body).toContain('ds.streamCardTurnGeneration = (ds.streamCardTurnGeneration ?? 0) + 1');
+  });
 });

--- a/test/doc-comment-daemon-concurrency.test.ts
+++ b/test/doc-comment-daemon-concurrency.test.ts
@@ -409,7 +409,7 @@ describe('document-comment routing integration', () => {
     expect(region).toMatch(/const generation = captureRoutingGeneration\(ds\);[\s\S]*await resolveSender[\s\S]*ensureCurrentRoutingGeneration\(generation, 'prewarm:sender'\)/);
     const guard = region.indexOf("ensureCurrentRoutingGeneration(generation, 'prewarm:sender')");
     expect(guard).toBeGreaterThanOrEqual(0);
-    expect(region.indexOf('beginNewTurn(ds, title)')).toBeGreaterThan(guard);
+    expect(region.indexOf('beginNewTurn(ds, title, turnId)')).toBeGreaterThan(guard);
     expect(region.indexOf('sendWorkerInput(ds, cliInput', guard)).toBeGreaterThan(guard);
     expect(region.indexOf('forkWorker(ds, wrappedInput', guard)).toBeGreaterThan(guard);
   });

--- a/test/recall-frozen-cards.test.ts
+++ b/test/recall-frozen-cards.test.ts
@@ -113,6 +113,7 @@ import {
   recallFrozenCards,
   parkStreamCard,
   postFreshStreamingCard,
+  postTurnStartingCard,
   restoreUsageLimitRuntimeState,
   scheduleCardPatch,
   usageRefreshShouldRun,
@@ -443,6 +444,83 @@ describe('receiver streaming card boundary', () => {
     await expect(postFreshStreamingCard(ds, sessionReply)).resolves.toBe(false);
     expect(sessionReply).not.toHaveBeenCalled();
     expect(buildStreamingCard).not.toHaveBeenCalled();
+  });
+});
+
+describe('postTurnStartingCard', () => {
+  it('posts a new-turn card immediately without waiting for screen_update', async () => {
+    const ds = makeDs();
+    ds.workerReady = true;
+    ds.streamCardId = 'om_previous';
+    ds.streamCardNonce = 'nonce_previous';
+    ds.streamCardPending = true;
+    ds.streamCardTurnGeneration = 1;
+    ds.streamCardPendingTurnId = 'om_turn_1';
+    ds.currentTurnTitle = 'first turn';
+    const sessionReply = vi.fn(async () => 'om_turn_card_1');
+
+    await expect(postTurnStartingCard(ds, sessionReply, 'om_turn_1')).resolves.toBe(true);
+
+    expect(sessionReply).toHaveBeenCalledTimes(1);
+    expect(sessionReply.mock.calls[0][4]).toBe('om_turn_1');
+    expect(ds.streamCardId).toBe('om_turn_card_1');
+    expect(ds.streamCardPending).toBe(false);
+    expect(ds.streamCardPendingTurnId).toBeUndefined();
+  });
+
+  it('posts the newest queued turn after an older card POST finishes', async () => {
+    let resolveFirst!: (messageId: string) => void;
+    const sessionReply = vi.fn()
+      .mockImplementationOnce(() => new Promise<string>(resolve => { resolveFirst = resolve; }))
+      .mockResolvedValueOnce('om_turn_card_2');
+    const ds = makeDs();
+    ds.workerReady = true;
+    ds.streamCardId = 'om_previous';
+    ds.streamCardNonce = 'nonce_previous';
+    ds.streamCardPending = true;
+    ds.streamCardTurnGeneration = 1;
+    ds.streamCardPendingTurnId = 'om_turn_1';
+    ds.currentTurnTitle = 'first turn';
+
+    const firstPost = postTurnStartingCard(ds, sessionReply, 'om_turn_1');
+    expect(sessionReply).toHaveBeenCalledTimes(1);
+
+    ds.streamCardTurnGeneration = 2;
+    ds.streamCardPendingTurnId = 'om_turn_2';
+    ds.currentTurnTitle = 'second turn';
+    await expect(postTurnStartingCard(ds, sessionReply, 'om_turn_2')).resolves.toBe(false);
+
+    resolveFirst('om_turn_card_1');
+    await firstPost;
+    await flush();
+    await flush();
+
+    expect(sessionReply).toHaveBeenCalledTimes(2);
+    expect(sessionReply.mock.calls[1][4]).toBe('om_turn_2');
+    expect(ds.streamCardId).toBe('om_turn_card_2');
+    expect(ds.streamCardPending).toBe(false);
+    expect(ds.streamCardPendingTurnId).toBeUndefined();
+    expect(deleteMessageMock).toHaveBeenCalledWith(APP_ID, 'om_turn_card_1');
+  });
+
+  it('restores the previous live card when the starting-card POST fails', async () => {
+    const ds = makeDs();
+    ds.workerReady = true;
+    ds.streamCardId = 'om_previous';
+    ds.streamCardNonce = 'nonce_previous';
+    ds.streamCardPending = true;
+    ds.streamCardTurnGeneration = 1;
+    ds.streamCardPendingTurnId = 'om_turn_1';
+    ds.currentTurnTitle = 'first turn';
+    const sessionReply = vi.fn(async () => { throw new Error('network unavailable'); });
+
+    await expect(postTurnStartingCard(ds, sessionReply, 'om_turn_1')).resolves.toBe(false);
+
+    expect(ds.streamCardId).toBe('om_previous');
+    expect(ds.streamCardNonce).toBe('nonce_previous');
+    expect(ds.streamCardPending).toBe(true);
+    expect(ds.streamCardPendingTurnId).toBe('om_turn_1');
+    expect(deleteMessageMock).not.toHaveBeenCalled();
   });
 });
 

--- a/test/recall-frozen-cards.test.ts
+++ b/test/recall-frozen-cards.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { DaemonSession, FrozenCard } from '../src/core/types.js';
+import { sessionKey } from '../src/core/types.js';
 import { setTerminalProxyPort } from '../src/core/terminal-url.js';
 
 // ─── Mocks ─────────────────────────────────────────────────────────────────
@@ -114,6 +115,7 @@ import {
   parkStreamCard,
   postFreshStreamingCard,
   postTurnStartingCard,
+  setActiveSessionsRegistry,
   restoreUsageLimitRuntimeState,
   scheduleCardPatch,
   usageRefreshShouldRun,
@@ -180,6 +182,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  setActiveSessionsRegistry(undefined as any);
   vi.clearAllTimers();
   vi.useRealTimers();
 });
@@ -448,6 +451,22 @@ describe('receiver streaming card boundary', () => {
 });
 
 describe('postTurnStartingCard', () => {
+  it('does not start a card POST while Riff retirement is already active', async () => {
+    const ds = makeDs();
+    ds.workerReady = true;
+    ds.streamCardPending = true;
+    ds.streamCardTurnGeneration = 1;
+    ds.streamCardPendingTurnId = 'om_turn_1';
+    ds.riffCloseState = { phase: 'preparing', requestId: 'close-before-post' };
+    const sessionReply = vi.fn(async () => 'om_forbidden');
+
+    await expect(postTurnStartingCard(ds, sessionReply, 'om_turn_1')).resolves.toBe(false);
+
+    expect(sessionReply).not.toHaveBeenCalled();
+    expect(ds.streamCardPending).toBe(true);
+    expect(ds.streamCardPendingTurnId).toBe('om_turn_1');
+  });
+
   it('posts a new-turn card immediately without waiting for screen_update', async () => {
     const ds = makeDs();
     ds.workerReady = true;
@@ -633,6 +652,102 @@ describe('postTurnStartingCard', () => {
     expect(ds.streamCardId).toBeUndefined();
     expect(ds.streamCardNonce).toBeUndefined();
     expect(persistStreamCardStateMock).not.toHaveBeenCalled();
+  });
+
+  it('discards an in-flight card when Riff explicit close starts preparing', async () => {
+    let resolvePost!: (messageId: string) => void;
+    const sessionReply = vi.fn(() => new Promise<string>(resolve => { resolvePost = resolve; }));
+    const ds = makeDs();
+    ds.workerReady = true;
+    ds.streamCardId = 'om_previous';
+    ds.streamCardNonce = 'nonce_previous';
+    ds.streamCardPending = true;
+    ds.streamCardTurnGeneration = 1;
+    ds.streamCardPendingTurnId = 'om_turn_1';
+
+    const post = postTurnStartingCard(ds, sessionReply, 'om_turn_1');
+    ds.riffCloseState = { phase: 'preparing', requestId: 'close-1' };
+    resolvePost('om_riff_orphan_card');
+
+    await expect(post).resolves.toBe(false);
+    await flush();
+
+    expect(ds.streamCardId).toBe('om_previous');
+    expect(ds.streamCardNonce).toBe('nonce_previous');
+    expect(ds.streamCardPending).toBe(true);
+    expect(deleteMessageMock).toHaveBeenCalledWith(APP_ID, 'om_riff_orphan_card');
+  });
+
+  it('discards an in-flight card when Riff daemon shutdown starts preparing', async () => {
+    let resolvePost!: (messageId: string) => void;
+    const sessionReply = vi.fn(() => new Promise<string>(resolve => { resolvePost = resolve; }));
+    const ds = makeDs();
+    ds.workerReady = true;
+    ds.streamCardId = 'om_previous';
+    ds.streamCardNonce = 'nonce_previous';
+    ds.streamCardPending = true;
+    ds.streamCardTurnGeneration = 1;
+    ds.streamCardPendingTurnId = 'om_turn_1';
+
+    const post = postTurnStartingCard(ds, sessionReply, 'om_turn_1');
+    ds.riffShutdownState = { phase: 'preparing', requestId: 'shutdown-1' };
+    resolvePost('om_riff_shutdown_orphan_card');
+
+    await expect(post).resolves.toBe(false);
+    await flush();
+
+    expect(ds.streamCardId).toBe('om_previous');
+    expect(ds.streamCardNonce).toBe('nonce_previous');
+    expect(deleteMessageMock).toHaveBeenCalledWith(APP_ID, 'om_riff_shutdown_orphan_card');
+  });
+
+  it('can retry after Riff close preparation aborts without leaving the sentinel stuck', async () => {
+    let resolveFirst!: (messageId: string) => void;
+    const sessionReply = vi.fn()
+      .mockImplementationOnce(() => new Promise<string>(resolve => { resolveFirst = resolve; }))
+      .mockResolvedValueOnce('om_retry_card');
+    const ds = makeDs();
+    ds.workerReady = true;
+    ds.streamCardId = 'om_previous';
+    ds.streamCardNonce = 'nonce_previous';
+    ds.streamCardPending = true;
+    ds.streamCardTurnGeneration = 1;
+    ds.streamCardPendingTurnId = 'om_turn_1';
+
+    const firstPost = postTurnStartingCard(ds, sessionReply, 'om_turn_1');
+    ds.riffCloseState = { phase: 'preparing', requestId: 'close-abort' };
+    resolveFirst('om_aborted_close_orphan_card');
+    await expect(firstPost).resolves.toBe(false);
+
+    ds.riffCloseState = undefined;
+    await expect(postTurnStartingCard(ds, sessionReply, 'om_turn_1')).resolves.toBe(true);
+
+    expect(sessionReply).toHaveBeenCalledTimes(2);
+    expect(ds.streamCardId).toBe('om_retry_card');
+    expect(ds.streamCardPending).toBe(false);
+    expect(deleteMessageMock).toHaveBeenCalledWith(APP_ID, 'om_aborted_close_orphan_card');
+  });
+
+  it('rejects a POST whose active registry key was taken by another session', async () => {
+    let resolvePost!: (messageId: string) => void;
+    const sessionReply = vi.fn(() => new Promise<string>(resolve => { resolvePost = resolve; }));
+    const ds = makeDs();
+    ds.workerReady = true;
+    ds.streamCardPending = true;
+    ds.streamCardTurnGeneration = 1;
+    ds.streamCardPendingTurnId = 'om_turn_1';
+    const registry = new Map([[sessionKey('om_root', APP_ID), ds]]);
+    setActiveSessionsRegistry(registry);
+
+    const post = postTurnStartingCard(ds, sessionReply, 'om_turn_1');
+    registry.set(sessionKey('om_root', APP_ID), makeDs());
+    resolvePost('om_displaced_registry_card');
+
+    await expect(post).resolves.toBe(false);
+    await flush();
+
+    expect(ds.streamCardId).not.toBe('om_displaced_registry_card');
+    expect(deleteMessageMock).toHaveBeenCalledWith(APP_ID, 'om_displaced_registry_card');
   });
 });
 

--- a/test/recall-frozen-cards.test.ts
+++ b/test/recall-frozen-cards.test.ts
@@ -522,6 +522,118 @@ describe('postTurnStartingCard', () => {
     expect(ds.streamCardPendingTurnId).toBe('om_turn_1');
     expect(deleteMessageMock).not.toHaveBeenCalled();
   });
+
+  it('does not let an old POST overwrite a replacement session', async () => {
+    let resolvePost!: (messageId: string) => void;
+    const sessionReply = vi.fn(() => new Promise<string>(resolve => { resolvePost = resolve; }));
+    const ds = makeDs();
+    ds.workerReady = true;
+    ds.streamCardId = 'om_previous';
+    ds.streamCardNonce = 'nonce_previous';
+    ds.streamCardPending = true;
+    ds.streamCardTurnGeneration = 1;
+    ds.streamCardPendingTurnId = 'om_turn_1';
+
+    const post = postTurnStartingCard(ds, sessionReply, 'om_turn_1');
+    ds.session = {
+      ...ds.session,
+      sessionId: 'sess-replacement',
+      rootMessageId: 'om_replacement_root',
+    };
+    ds.streamCardId = undefined;
+    ds.streamCardNonce = undefined;
+    ds.streamCardPending = false;
+    ds.streamCardPendingTurnId = undefined;
+    persistStreamCardStateMock.mockClear();
+
+    resolvePost('om_stale_turn_card');
+    await expect(post).resolves.toBe(false);
+    await flush();
+
+    expect(ds.streamCardId).toBeUndefined();
+    expect(ds.streamCardNonce).toBeUndefined();
+    expect(persistStreamCardStateMock).not.toHaveBeenCalled();
+    expect(deleteMessageMock).toHaveBeenCalledWith(APP_ID, 'om_stale_turn_card');
+  });
+
+  it('deletes an orphan card when the session closes during POST', async () => {
+    let resolvePost!: (messageId: string) => void;
+    const sessionReply = vi.fn(() => new Promise<string>(resolve => { resolvePost = resolve; }));
+    const ds = makeDs();
+    ds.workerReady = true;
+    ds.streamCardPending = true;
+    ds.streamCardTurnGeneration = 1;
+    ds.streamCardPendingTurnId = 'om_turn_1';
+
+    const post = postTurnStartingCard(ds, sessionReply, 'om_turn_1');
+    ds.session.status = 'closed' as any;
+    ds.streamCardId = undefined;
+    ds.streamCardNonce = undefined;
+    persistStreamCardStateMock.mockClear();
+
+    resolvePost('om_orphan_card');
+    await expect(post).resolves.toBe(false);
+    await flush();
+
+    expect(ds.streamCardId).toBeUndefined();
+    expect(ds.streamCardNonce).toBeUndefined();
+    expect(persistStreamCardStateMock).not.toHaveBeenCalled();
+    expect(deleteMessageMock).toHaveBeenCalledWith(APP_ID, 'om_orphan_card');
+  });
+
+  it('does not adopt an old-route card after a completed transfer', async () => {
+    let resolvePost!: (messageId: string) => void;
+    const sessionReply = vi.fn(() => new Promise<string>(resolve => { resolvePost = resolve; }));
+    const ds = makeDs();
+    ds.workerReady = true;
+    ds.streamCardPending = true;
+    ds.streamCardTurnGeneration = 1;
+    ds.streamCardPendingTurnId = 'om_turn_1';
+
+    const post = postTurnStartingCard(ds, sessionReply, 'om_turn_1');
+    ds.session.rootMessageId = 'om_transferred_root';
+    ds.streamCardId = undefined;
+    ds.streamCardNonce = undefined;
+
+    resolvePost('om_old_route_card');
+    await expect(post).resolves.toBe(false);
+    await flush();
+
+    expect(ds.streamCardId).toBeUndefined();
+    expect(ds.streamCardNonce).toBeUndefined();
+    expect(deleteMessageMock).toHaveBeenCalledWith(APP_ID, 'om_old_route_card');
+  });
+
+  it('does not roll an old POST failure back into a replacement session', async () => {
+    let rejectPost!: (error: Error) => void;
+    const sessionReply = vi.fn(() => new Promise<string>((_resolve, reject) => { rejectPost = reject; }));
+    const ds = makeDs();
+    ds.workerReady = true;
+    ds.streamCardId = 'om_previous';
+    ds.streamCardNonce = 'nonce_previous';
+    ds.streamCardPending = true;
+    ds.streamCardTurnGeneration = 1;
+    ds.streamCardPendingTurnId = 'om_turn_1';
+
+    const post = postTurnStartingCard(ds, sessionReply, 'om_turn_1');
+    ds.session = {
+      ...ds.session,
+      sessionId: 'sess-replacement',
+      rootMessageId: 'om_replacement_root',
+    };
+    ds.streamCardId = undefined;
+    ds.streamCardNonce = undefined;
+    ds.streamCardPending = false;
+    ds.streamCardPendingTurnId = undefined;
+    persistStreamCardStateMock.mockClear();
+
+    rejectPost(new Error('old route failed'));
+    await expect(post).resolves.toBe(false);
+
+    expect(ds.streamCardId).toBeUndefined();
+    expect(ds.streamCardNonce).toBeUndefined();
+    expect(persistStreamCardStateMock).not.toHaveBeenCalled();
+  });
 });
 
 // ─── P3 helper: parkStreamCard ─────────────────────────────────────────────

--- a/test/worker-ready-display-mode.test.ts
+++ b/test/worker-ready-display-mode.test.ts
@@ -668,6 +668,42 @@ describe('Worker ready: set_display_mode re-sync', () => {
     expect(ds.streamCardPending).toBe(false);
   });
 
+  it('does not let an older ready POST consume a newer turn pending state', async () => {
+    let resolveFirst!: (messageId: string) => void;
+    sessionReplyMock
+      .mockImplementationOnce(() => new Promise<string>(resolve => { resolveFirst = resolve; }))
+      .mockResolvedValueOnce('om_newer_card');
+    const fakeWorker = makeFakeWorker();
+    const ds = makeDs({
+      streamCardPending: true,
+      streamCardId: undefined,
+      streamCardTurnGeneration: 1,
+      streamCardPendingTurnId: 'om_turn_1',
+      worker: fakeWorker,
+    });
+
+    __testOnly_setupWorkerHandlers(ds, fakeWorker);
+    fakeWorker.emit('message', {
+      type: 'ready', port: 9999, token: 'tok_abc', turnId: 'om_turn_1',
+    });
+    await flush();
+    expect(ds.streamCardId).toBe(CARD_POSTING_SENTINEL);
+
+    ds.streamCardPending = true;
+    ds.streamCardTurnGeneration = 2;
+    ds.streamCardPendingTurnId = 'om_turn_2';
+    ds.currentTurnTitle = 'newer turn';
+    resolveFirst('om_older_card');
+    await flush();
+    await flush();
+
+    expect(sessionReplyMock).toHaveBeenCalledTimes(2);
+    expect(sessionReplyMock.mock.calls[1][4]).toBe('om_turn_2');
+    expect(ds.streamCardId).toBe('om_newer_card');
+    expect(ds.streamCardPending).toBe(false);
+    expect(ds.streamCardPendingTurnId).toBeUndefined();
+  });
+
   it('patches the active card when cli_session_id makes local resume ready', async () => {
     const fakeWorker = makeFakeWorker();
     const ds = makeDs({


### PR DESCRIPTION
## 修复内容

- 在新 turn 受理时立即创建「启动中」状态卡，不再等待下一次 `screen_update`。
- 为状态卡 POST 增加 turn generation。旧请求完成时不会清除更新 turn 的待发状态，并会继续创建最新 turn 的卡片。
- 为异步 POST 增加生命周期归属校验：返回后重新检查 session 对象、active 状态、路由锚点与 app、transfer 状态、registry 所有权、本次 nonce / sentinel，以及 Riff close / shutdown retirement fence。
- 过期 POST 成功时不再把旧卡 ID 写回新会话，并 best-effort 删除孤儿卡；过期 POST 失败时不再把旧状态回滚进 replacement session。
- Riff 进入退休准备后不再开始新 POST；飞行中的 POST 会撤回孤儿卡并恢复发卡前 identity，保留 pending。关闭准备失败后可重试，不会卡死在 sentinel。
- 修正 `beginNewTurn(ds, title, turnId)` 的源码断言，并补充 close、repo replacement、transfer、Riff explicit close、daemon shutdown、abort retry 和 registry occupant replacement 回归。

## 问题原因

原逻辑在收到消息后只设置 `streamCardPending=true`，实际建卡依赖 worker 后续发送 `screen_update`。部分 CLI 已接收并处理消息，但不会再产生满足条件的终端刷新。此时旧卡片 ID 会一直保留，新 turn 没有卡片；后续消息继续复用同一状态，因此单条消息也可能持续不显示处理中卡片。

连续消息还存在另一处竞态：较早 turn 的卡片 POST 完成后会直接清除 `streamCardPending`，可能把较新 turn 的待发状态一起清掉。

审核进一步发现，turn generation 只能识别「更新 turn」，不能识别 `/close`、仓库替换、接力，以及 Riff 已开始 close / shutdown prepare 但 session 仍暂时显示 active 的窗口。旧 POST 在这些生命周期变化后返回，仍可能污染新会话或留下孤儿卡。因此补充了完整的生命周期和 retirement 归属校验。

## 影响范围

- 影响启用状态卡的普通消息和透传命令。
- 不改变卡片 JSON、样式和按钮行为。
- 保留 `disableStreamingCard`、`noCardChats`、substitute turn、文档原生会话和 VC receiver 的原有门禁。
- 不修改版本号。

## 测试

- 状态卡聚焦回归：`103/103` 通过。
- Riff close / shutdown 生命周期回归：`49/49` 通过。
- 构建：`pnpm build` 通过，包含 TypeScript 编译、Dashboard bundle 和 dist audit。
- `git diff --check` 通过。
- 全量单元测试：`14618` 通过、`12` 失败、`37` 跳过。失败仍位于本 PR 未修改的 Codex runner、文档同步、缓存和 worker 时序用例；本 PR 的 152 项聚焦与关联回归未失败。全量门禁尚未全绿，需由维护者判断这些主线现存失败是否阻塞合并。

## 截图

本 PR 不修改卡片视觉样式或字段，仅修改卡片创建时机和并发状态管理，因此没有新增视觉对比截图。
